### PR TITLE
grilo-plugins: backport more updates from master

### DIFF
--- a/multimedia/grilo-plugins/Makefile
+++ b/multimedia/grilo-plugins/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grilo-plugins
 PKG_VERSION:=0.3.11
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPLv2.1

--- a/multimedia/grilo-plugins/patches/040-backport-names.patch
+++ b/multimedia/grilo-plugins/patches/040-backport-names.patch
@@ -1,0 +1,756 @@
+diff --git a/src/dmap/grl-daap-db.c b/src/dmap/grl-daap-db.c
+index 315370e..e9a1713 100644
+--- a/src/dmap/grl-daap-db.c
++++ b/src/dmap/grl-daap-db.c
+@@ -70,7 +70,7 @@
+ /* Media ID's start at max and go down. Container ID's start at 1 and go up. */
+ static guint nextid = G_MAXINT; /* NOTE: this should be G_MAXUINT, but iPhoto can't handle it. */
+ 
+-struct GrlDAAPDbPrivate {
++struct GrlDaapDbPrivate {
+   /* Contains each album container (tracked with albums hash table) */
+   GrlMedia *albums_container;
+ 
+@@ -99,10 +99,10 @@ container_equal (gconstpointer a, gconstpointer b)
+   return g_str_equal (grl_media_get_id (GRL_MEDIA (a)), grl_media_get_id (GRL_MEDIA (b)));
+ }
+ 
+-GrlDAAPDb *
++GrlDaapDb *
+ grl_daap_db_new (void)
+ {
+-  GrlDAAPDb *db = g_object_new (TYPE_GRL_DAAP_DB, NULL);
++  GrlDaapDb *db = g_object_new (TYPE_GRL_DAAP_DB, NULL);
+ 
+   return db;
+ }
+@@ -160,7 +160,7 @@ grl_daap_db_add (DmapDb *_db, DmapRecord *_record, GError **error)
+   g_assert (IS_GRL_DAAP_DB (_db));
+   g_assert (IS_DMAP_AV_RECORD (_record));
+ 
+-  GrlDAAPDb *db = GRL_DAAP_DB (_db);
++  GrlDaapDb *db = GRL_DAAP_DB (_db);
+   DmapAvRecord *record = DMAP_AV_RECORD (_record);
+ 
+   gint   duration = 0;
+@@ -252,7 +252,7 @@ same_media (GrlMedia *a, GrlMedia *b)
+ }
+ 
+ void
+-grl_daap_db_browse (GrlDAAPDb *db,
++grl_daap_db_browse (GrlDaapDb *db,
+                     GrlMedia *container,
+                     GrlSource *source,
+                     guint op_id,
+@@ -311,7 +311,7 @@ done:
+ }
+ 
+ void
+-grl_daap_db_search (GrlDAAPDb *db,
++grl_daap_db_search (GrlDaapDb *db,
+                     GrlSource *source,
+                     guint op_id,
+                     GHRFunc predicate,
+@@ -373,8 +373,8 @@ dmap_db_interface_init (gpointer iface, gpointer data)
+   daap_db->count = grl_daap_db_count;
+ }
+ 
+-G_DEFINE_TYPE_WITH_CODE (GrlDAAPDb, grl_daap_db, G_TYPE_OBJECT,
+-                         G_ADD_PRIVATE (GrlDAAPDb)
++G_DEFINE_TYPE_WITH_CODE (GrlDaapDb, grl_daap_db, G_TYPE_OBJECT,
++                         G_ADD_PRIVATE (GrlDaapDb)
+                          G_IMPLEMENT_INTERFACE (DMAP_TYPE_DB, dmap_db_interface_init))
+ 
+ static GObject*
+@@ -388,7 +388,7 @@ grl_daap_db_constructor (GType type, guint n_construct_params, GObjectConstructP
+ }
+ 
+ static void
+-grl_daap_db_init (GrlDAAPDb *db)
++grl_daap_db_init (GrlDaapDb *db)
+ {
+   db->priv = grl_daap_db_get_instance_private (db);
+ 
+@@ -412,9 +412,9 @@ grl_daap_db_init (GrlDAAPDb *db)
+ static void
+ grl_daap_db_finalize (GObject *object)
+ {
+-  GrlDAAPDb *db = GRL_DAAP_DB (object);
++  GrlDaapDb *db = GRL_DAAP_DB (object);
+ 
+-  GRL_DEBUG ("Finalizing GrlDAAPDb");
++  GRL_DEBUG ("Finalizing GrlDaapDb");
+ 
+   g_object_unref (db->priv->albums_container);
+   g_object_unref (db->priv->artists_container);
+@@ -451,7 +451,7 @@ grl_daap_db_get_property (GObject *object,
+ 
+ 
+ static void
+-grl_daap_db_class_init (GrlDAAPDbClass *klass)
++grl_daap_db_class_init (GrlDaapDbClass *klass)
+ {
+   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+ 
+diff --git a/src/dmap/grl-daap-db.h b/src/dmap/grl-daap-db.h
+index 1a37a3a..ed877e4 100644
+--- a/src/dmap/grl-daap-db.h
++++ b/src/dmap/grl-daap-db.h
+@@ -33,12 +33,12 @@ G_BEGIN_DECLS
+ #define GRL_DAAP_DB(o)                                                         \
+   (G_TYPE_CHECK_INSTANCE_CAST ((o),                                            \
+                                 TYPE_GRL_DAAP_DB,                              \
+-                                GrlDAAPDb))
++                                GrlDaapDb))
+ 
+ #define GRL_DAAP_DB_CLASS(k)                                                   \
+   (G_TYPE_CHECK_CLASS_CAST ((k),                                               \
+                              TYPE_GRL_DAAP_DB,                                 \
+-                             GrlDAAPDbClass))
++                             GrlDaapDbClass))
+ #define IS_GRL_DAAP_DB(o)                                                      \
+   (G_TYPE_CHECK_INSTANCE_TYPE ((o),                                            \
+                                 TYPE_GRL_DAAP_DB))
+@@ -50,25 +50,25 @@ G_BEGIN_DECLS
+ #define GRL_DAAP_DB_GET_CLASS(o)                                               \
+   (G_TYPE_INSTANCE_GET_CLASS ((o),                                             \
+                                TYPE_GRL_DAAP_DB,                               \
+-                               GrlDAAPDbClass))
++                               GrlDaapDbClass))
+ 
+ #define GRL_DAAP_DB_GET_PRIVATE(o)                                             \
+   (G_TYPE_INSTANCE_GET_PRIVATE ((o),                                           \
+                                  TYPE_GRL_DAAP_DB,                             \
+-                                 GrlDAAPDbPrivate))
++                                 GrlDaapDbPrivate))
+ 
+-typedef struct GrlDAAPDbPrivate GrlDAAPDbPrivate;
++typedef struct GrlDaapDbPrivate GrlDaapDbPrivate;
+ 
+ typedef struct {
+   GObject parent;
+-  GrlDAAPDbPrivate *priv;
+-} GrlDAAPDb;
++  GrlDaapDbPrivate *priv;
++} GrlDaapDb;
+ 
+ typedef struct {
+   GObjectClass parent;
+-} GrlDAAPDbClass;
++} GrlDaapDbClass;
+ 
+-void grl_daap_db_browse (GrlDAAPDb *db,
++void grl_daap_db_browse (GrlDaapDb *db,
+                          GrlMedia *container,
+                          GrlSource *source,
+                          guint op_id,
+@@ -77,7 +77,7 @@ void grl_daap_db_browse (GrlDAAPDb *db,
+                          GrlSourceResultCb func,
+                          gpointer user_data);
+ 
+-void grl_daap_db_search (GrlDAAPDb *db,
++void grl_daap_db_search (GrlDaapDb *db,
+                          GrlSource *source,
+                          guint op_id,
+                          GHRFunc predicate,
+@@ -85,7 +85,7 @@ void grl_daap_db_search (GrlDAAPDb *db,
+                          GrlSourceResultCb func,
+                          gpointer user_data);
+ 
+-GrlDAAPDb *grl_daap_db_new (void);
++GrlDaapDb *grl_daap_db_new (void);
+ 
+ GType grl_daap_db_get_type (void);
+ 
+diff --git a/src/dmap/grl-daap-record-factory.c b/src/dmap/grl-daap-record-factory.c
+index d0c590f..f73fe23 100644
+--- a/src/dmap/grl-daap-record-factory.c
++++ b/src/dmap/grl-daap-record-factory.c
+@@ -33,12 +33,12 @@ grl_daap_record_factory_create (DmapRecordFactory *factory, gpointer user_data,
+ }
+ 
+ static void
+-grl_daap_record_factory_init (GrlDAAPRecordFactory *factory)
++grl_daap_record_factory_init (GrlDaapRecordFactory *factory)
+ {
+ }
+ 
+ static void
+-grl_daap_record_factory_class_init (GrlDAAPRecordFactoryClass *klass)
++grl_daap_record_factory_class_init (GrlDaapRecordFactoryClass *klass)
+ {
+ }
+ 
+@@ -52,11 +52,11 @@ grl_daap_record_factory_interface_init (gpointer iface, gpointer data)
+   factory->create = grl_daap_record_factory_create_compat;
+ }
+ 
+-G_DEFINE_TYPE_WITH_CODE (GrlDAAPRecordFactory, grl_daap_record_factory, G_TYPE_OBJECT,
++G_DEFINE_TYPE_WITH_CODE (GrlDaapRecordFactory, grl_daap_record_factory, G_TYPE_OBJECT,
+                          G_IMPLEMENT_INTERFACE (DMAP_TYPE_RECORD_FACTORY,
+                                                grl_daap_record_factory_interface_init))
+ 
+-GrlDAAPRecordFactory *
++GrlDaapRecordFactory *
+ grl_daap_record_factory_new (void)
+ {
+   return SIMPLE_DAAP_RECORD_FACTORY (g_object_new (TYPE_SIMPLE_DAAP_RECORD_FACTORY, NULL));
+diff --git a/src/dmap/grl-daap-record-factory.h b/src/dmap/grl-daap-record-factory.h
+index f114bad..fa6f05b 100644
+--- a/src/dmap/grl-daap-record-factory.h
++++ b/src/dmap/grl-daap-record-factory.h
+@@ -1,5 +1,5 @@
+ /*
+- * GrlDAAPRecord factory class
++ * GrlDaapRecord factory class
+  *
+  * Copyright (C) 2008 W. Michael Petullo <mike@flyn.org>
+  *
+@@ -32,12 +32,12 @@ G_BEGIN_DECLS
+ #define SIMPLE_DAAP_RECORD_FACTORY(o)                                          \
+   (G_TYPE_CHECK_INSTANCE_CAST ((o),                                            \
+                                 TYPE_SIMPLE_DAAP_RECORD_FACTORY,               \
+-                                GrlDAAPRecordFactory))
++                                GrlDaapRecordFactory))
+ 
+ #define SIMPLE_DAAP_RECORD_FACTORY_CLASS(k)                                    \
+   (G_TYPE_CHECK_CLASS_CAST ((k),                                               \
+                              TYPE_SIMPLE_DAAP_RECORD_FACTORY,                  \
+-                             GrlDAAPRecordFactoryClass))
++                             GrlDaapRecordFactoryClass))
+ 
+ #define IS_SIMPLE_DAAP_RECORD_FACTORY(o)                                       \
+   (G_TYPE_CHECK_INSTANCE_TYPE ((o),                                            \
+@@ -50,21 +50,21 @@ G_BEGIN_DECLS
+ #define SIMPLE_DAAP_RECORD_FACTORY_GET_CLASS(o)                                \
+   (G_TYPE_INSTANCE_GET_CLASS ((o),                                             \
+                                TYPE_SIMPLE_DAAP_RECORD_FACTORY,                \
+-                               GrlDAAPRecordFactoryClass))
++                               GrlDaapRecordFactoryClass))
+ 
+-typedef struct GrlDAAPRecordFactoryPrivate GrlDAAPRecordFactoryPrivate;
++typedef struct GrlDaapRecordFactoryPrivate GrlDaapRecordFactoryPrivate;
+ 
+ typedef struct {
+   GObject parent;
+-} GrlDAAPRecordFactory;
++} GrlDaapRecordFactory;
+ 
+ typedef struct {
+   GObjectClass parent;
+-} GrlDAAPRecordFactoryClass;
++} GrlDaapRecordFactoryClass;
+ 
+ GType grl_daap_record_factory_get_type (void);
+ 
+-GrlDAAPRecordFactory *grl_daap_record_factory_new (void);
++GrlDaapRecordFactory *grl_daap_record_factory_new (void);
+ 
+ #endif /* __SIMPLE_DAAP_RECORD_FACTORY */
+ 
+diff --git a/src/dmap/grl-daap-record.c b/src/dmap/grl-daap-record.c
+index 4fa0c54..f54d6b8 100644
+--- a/src/dmap/grl-daap-record.c
++++ b/src/dmap/grl-daap-record.c
+@@ -27,7 +27,7 @@
+ #include "grl-common.h"
+ #include "grl-daap-record.h"
+ 
+-struct GrlDAAPRecordPrivate {
++struct GrlDaapRecordPrivate {
+   guint64 filesize;
+   char *location;
+   char *format;
+@@ -78,7 +78,7 @@ grl_daap_record_set_property (GObject *object,
+                               const GValue *value,
+                               GParamSpec *pspec)
+ {
+-  GrlDAAPRecord *record = SIMPLE_DAAP_RECORD (object);
++  GrlDaapRecord *record = SIMPLE_DAAP_RECORD (object);
+ 
+   switch (prop_id) {
+   case PROP_LOCATION:
+@@ -158,7 +158,7 @@ grl_daap_record_get_property (GObject *object,
+                               GValue *value,
+                               GParamSpec *pspec)
+ {
+-  GrlDAAPRecord *record = SIMPLE_DAAP_RECORD (object);
++  GrlDaapRecord *record = SIMPLE_DAAP_RECORD (object);
+ 
+   switch (prop_id) {
+   case PROP_LOCATION:
+@@ -224,7 +224,7 @@ grl_daap_record_get_property (GObject *object,
+   }
+ }
+ 
+-GrlDAAPRecord *
++GrlDaapRecord *
+ grl_daap_record_new (void)
+ {
+   return SIMPLE_DAAP_RECORD (g_object_new (TYPE_SIMPLE_DAAP_RECORD, NULL));
+@@ -245,7 +245,7 @@ grl_daap_record_read (DmapAvRecord *record, GError **error)
+ }
+ 
+ static void
+-grl_daap_record_init (GrlDAAPRecord *record)
++grl_daap_record_init (GrlDaapRecord *record)
+ {
+   record->priv = SIMPLE_DAAP_RECORD_GET_PRIVATE (record);
+ }
+@@ -253,7 +253,7 @@ grl_daap_record_init (GrlDAAPRecord *record)
+ static void grl_daap_record_finalize (GObject *object);
+ 
+ static void
+-grl_daap_record_class_init (GrlDAAPRecordClass *klass)
++grl_daap_record_class_init (GrlDaapRecordClass *klass)
+ {
+   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+ 
+@@ -301,15 +301,15 @@ grl_daap_record_dmap_iface_init (gpointer iface, gpointer data)
+ }
+ 
+ 
+-G_DEFINE_TYPE_WITH_CODE (GrlDAAPRecord, grl_daap_record, G_TYPE_OBJECT,
+-                         G_ADD_PRIVATE (GrlDAAPRecord)
++G_DEFINE_TYPE_WITH_CODE (GrlDaapRecord, grl_daap_record, G_TYPE_OBJECT,
++                         G_ADD_PRIVATE (GrlDaapRecord)
+                          G_IMPLEMENT_INTERFACE (DMAP_TYPE_AV_RECORD, grl_daap_record_daap_iface_init)
+                          G_IMPLEMENT_INTERFACE (DMAP_TYPE_RECORD, grl_daap_record_dmap_iface_init))
+ 
+ static void
+ grl_daap_record_finalize (GObject *object)
+ {
+-  GrlDAAPRecord *record = SIMPLE_DAAP_RECORD (object);
++  GrlDaapRecord *record = SIMPLE_DAAP_RECORD (object);
+ 
+   g_free (record->priv->location);
+   g_free (record->priv->title);
+diff --git a/src/dmap/grl-daap-record.h b/src/dmap/grl-daap-record.h
+index 42782b1..b6e8c34 100644
+--- a/src/dmap/grl-daap-record.h
++++ b/src/dmap/grl-daap-record.h
+@@ -32,12 +32,12 @@ G_BEGIN_DECLS
+ #define SIMPLE_DAAP_RECORD(o)                                                  \
+   (G_TYPE_CHECK_INSTANCE_CAST ((o),                                            \
+                                 TYPE_SIMPLE_DAAP_RECORD,                       \
+-                                GrlDAAPRecord))
++                                GrlDaapRecord))
+ 
+ #define SIMPLE_DAAP_RECORD_CLASS(k)                                            \
+   (G_TYPE_CHECK_CLASS_CAST ((k),                                               \
+                              TYPE_SIMPLE_DAAP_RECORD,                          \
+-                             GrlDAAPRecordClass))
++                             GrlDaapRecordClass))
+ 
+ #define IS_SIMPLE_DAAP_RECORD(o)                                               \
+   (G_TYPE_CHECK_INSTANCE_TYPE ((o),                                            \
+@@ -50,27 +50,27 @@ G_BEGIN_DECLS
+ #define SIMPLE_DAAP_RECORD_GET_CLASS(o)                                        \
+   (G_TYPE_INSTANCE_GET_CLASS ((o),                                             \
+                                TYPE_SIMPLE_DAAP_RECORD,                        \
+-                               GrlDAAPRecordClass))
++                               GrlDaapRecordClass))
+ 
+ #define SIMPLE_DAAP_RECORD_GET_PRIVATE(o)                                      \
+   (G_TYPE_INSTANCE_GET_PRIVATE ((o),                                           \
+                                  TYPE_SIMPLE_DAAP_RECORD,                      \
+-                                 GrlDAAPRecordPrivate))
++                                 GrlDaapRecordPrivate))
+ 
+-typedef struct GrlDAAPRecordPrivate GrlDAAPRecordPrivate;
++typedef struct GrlDaapRecordPrivate GrlDaapRecordPrivate;
+ 
+ typedef struct {
+   GObject parent;
+-  GrlDAAPRecordPrivate *priv;
+-} GrlDAAPRecord;
++  GrlDaapRecordPrivate *priv;
++} GrlDaapRecord;
+ 
+ typedef struct {
+   GObjectClass parent;
+-} GrlDAAPRecordClass;
++} GrlDaapRecordClass;
+ 
+ GType grl_daap_record_get_type (void);
+ 
+-GrlDAAPRecord *grl_daap_record_new (void);
++GrlDaapRecord *grl_daap_record_new (void);
+ GInputStream *grl_daap_record_read (DmapAvRecord *record, GError **error);
+ gint grl_daap_record_get_id (DmapAvRecord *record);
+ 
+diff --git a/src/dmap/grl-dpap-db.c b/src/dmap/grl-dpap-db.c
+index cd647ee..56be8b0 100644
+--- a/src/dmap/grl-dpap-db.c
++++ b/src/dmap/grl-dpap-db.c
+@@ -42,7 +42,7 @@
+ /* Media IDs start at max and go down. Container IDs start at 1 and go up. */
+ static guint nextid = G_MAXINT; /* NOTE: this should be G_MAXUINT, but iPhoto can't handle it. */
+ 
+-struct GrlDPAPDbPrivate {
++struct GrlDpapDbPrivate {
+   /* Contains each picture container (tracked with photos hash table) */
+   GrlMedia *photos_container;
+ 
+@@ -67,10 +67,10 @@ container_equal (gconstpointer a, gconstpointer b)
+   return g_str_equal (grl_media_get_id (GRL_MEDIA (a)), grl_media_get_id (GRL_MEDIA (b)));
+ }
+ 
+-GrlDPAPDb *
++GrlDpapDb *
+ grl_dpap_db_new (void)
+ {
+-  GrlDPAPDb *db = g_object_new (TYPE_GRL_DPAP_DB, NULL);
++  GrlDpapDb *db = g_object_new (TYPE_GRL_DPAP_DB, NULL);
+ 
+   return db;
+ }
+@@ -128,7 +128,7 @@ grl_dpap_db_add (DmapDb *_db, DmapRecord *_record, GError **error)
+   g_assert (IS_GRL_DPAP_DB (_db));
+   g_assert (IS_DMAP_IMAGE_RECORD (_record));
+ 
+-  GrlDPAPDb *db = GRL_DPAP_DB (_db);
++  GrlDpapDb *db = GRL_DPAP_DB (_db);
+   DmapImageRecord *record = DMAP_IMAGE_RECORD (_record);
+ 
+   gint        height        = 0,
+@@ -198,7 +198,7 @@ same_media (GrlMedia *a, GrlMedia *b)
+ }
+ 
+ void
+-grl_dpap_db_browse (GrlDPAPDb *db,
++grl_dpap_db_browse (GrlDpapDb *db,
+                     GrlMedia *container,
+                     GrlSource *source,
+                     guint op_id,
+@@ -250,7 +250,7 @@ done:
+ }
+ 
+ void
+-grl_dpap_db_search (GrlDPAPDb *db,
++grl_dpap_db_search (GrlDpapDb *db,
+                     GrlSource *source,
+                     guint op_id,
+                     GHRFunc predicate,
+@@ -312,8 +312,8 @@ dmap_db_interface_init (gpointer iface, gpointer data)
+   dpap_db->count = grl_dpap_db_count;
+ }
+ 
+-G_DEFINE_TYPE_WITH_CODE (GrlDPAPDb, grl_dpap_db, G_TYPE_OBJECT,
+-                         G_ADD_PRIVATE (GrlDPAPDb)
++G_DEFINE_TYPE_WITH_CODE (GrlDpapDb, grl_dpap_db, G_TYPE_OBJECT,
++                         G_ADD_PRIVATE (GrlDpapDb)
+                          G_IMPLEMENT_INTERFACE (DMAP_TYPE_DB, dmap_db_interface_init))
+ 
+ static GObject*
+@@ -327,7 +327,7 @@ grl_dpap_db_constructor (GType type, guint n_construct_params, GObjectConstructP
+ }
+ 
+ static void
+-grl_dpap_db_init (GrlDPAPDb *db)
++grl_dpap_db_init (GrlDpapDb *db)
+ {
+   db->priv = grl_dpap_db_get_instance_private (db);
+ 
+@@ -345,9 +345,9 @@ grl_dpap_db_init (GrlDPAPDb *db)
+ static void
+ grl_dpap_db_finalize (GObject *object)
+ {
+-  GrlDPAPDb *db = GRL_DPAP_DB (object);
++  GrlDpapDb *db = GRL_DPAP_DB (object);
+ 
+-  GRL_DEBUG ("Finalizing GrlDPAPDb");
++  GRL_DEBUG ("Finalizing GrlDpapDb");
+ 
+   g_object_unref (db->priv->photos_container);
+ 
+@@ -355,7 +355,7 @@ grl_dpap_db_finalize (GObject *object)
+ }
+ 
+ static void
+-grl_dpap_db_class_init (GrlDPAPDbClass *klass)
++grl_dpap_db_class_init (GrlDpapDbClass *klass)
+ {
+   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+ 
+diff --git a/src/dmap/grl-dpap-db.h b/src/dmap/grl-dpap-db.h
+index a21ad7a..23ae4c1 100644
+--- a/src/dmap/grl-dpap-db.h
++++ b/src/dmap/grl-dpap-db.h
+@@ -33,12 +33,12 @@ G_BEGIN_DECLS
+ #define GRL_DPAP_DB(o)                                                         \
+   (G_TYPE_CHECK_INSTANCE_CAST ((o),                                            \
+                                 TYPE_GRL_DPAP_DB,                              \
+-                                GrlDPAPDb))
++                                GrlDpapDb))
+ 
+ #define GRL_DPAP_DB_CLASS(k)                                                   \
+   (G_TYPE_CHECK_CLASS_CAST ((k),                                               \
+                              TYPE_GRL_DPAP_DB,                                 \
+-                             GrlDPAPDbClass))
++                             GrlDpapDbClass))
+ #define IS_GRL_DPAP_DB(o)                                                      \
+   (G_TYPE_CHECK_INSTANCE_TYPE ((o),                                            \
+                                 TYPE_GRL_DPAP_DB))
+@@ -49,26 +49,26 @@ G_BEGIN_DECLS
+ #define GRL_DPAP_DB_GET_CLASS(o)                                               \
+   (G_TYPE_INSTANCE_GET_CLASS ((o),                                             \
+                                TYPE_GRL_DPAP_DB,                               \
+-                               GrlDPAPDbClass))
++                               GrlDpapDbClass))
+ 
+ #define GRL_DPAP_DB_GET_PRIVATE(o)                                             \
+   (G_TYPE_INSTANCE_GET_PRIVATE ((o),                                           \
+                                  TYPE_GRL_DPAP_DB,                             \
+-                                 GrlDPAPDbPrivate))
++                                 GrlDpapDbPrivate))
+ 
+-typedef struct GrlDPAPDbPrivate GrlDPAPDbPrivate;
++typedef struct GrlDpapDbPrivate GrlDpapDbPrivate;
+ 
+ typedef struct {
+   GObject parent;
+-  GrlDPAPDbPrivate *priv;
+-} GrlDPAPDb;
++  GrlDpapDbPrivate *priv;
++} GrlDpapDb;
+ 
+ typedef struct {
+   GObjectClass parent;
+-} GrlDPAPDbClass;
++} GrlDpapDbClass;
+ 
+-GrlDPAPDb *grl_dpap_db_new (void);
+-void grl_dpap_db_browse (GrlDPAPDb *_db,
++GrlDpapDb *grl_dpap_db_new (void);
++void grl_dpap_db_browse (GrlDpapDb *_db,
+                          GrlMedia *container,
+                          GrlSource *source,
+                          guint op_id,
+@@ -76,7 +76,7 @@ void grl_dpap_db_browse (GrlDPAPDb *_db,
+                          guint count,
+                          GrlSourceResultCb func,
+                          gpointer user_data);
+-void grl_dpap_db_search (GrlDPAPDb *_db,
++void grl_dpap_db_search (GrlDpapDb *_db,
+                          GrlSource *source,
+                          guint op_id,
+                          GHRFunc predicate,
+diff --git a/src/dmap/grl-dpap-record-factory.c b/src/dmap/grl-dpap-record-factory.c
+index 860d957..d106d0f 100644
+--- a/src/dmap/grl-dpap-record-factory.c
++++ b/src/dmap/grl-dpap-record-factory.c
+@@ -35,12 +35,12 @@ grl_dpap_record_factory_create (DmapRecordFactory *factory,
+ }
+ 
+ static void
+-grl_dpap_record_factory_init (GrlDPAPRecordFactory *factory)
++grl_dpap_record_factory_init (GrlDpapRecordFactory *factory)
+ {
+ }
+ 
+ static void
+-grl_dpap_record_factory_class_init (GrlDPAPRecordFactoryClass *klass)
++grl_dpap_record_factory_class_init (GrlDpapRecordFactoryClass *klass)
+ {
+ }
+ 
+@@ -54,11 +54,11 @@ grl_dpap_record_factory_interface_init (gpointer iface, gpointer data)
+   factory->create = grl_dpap_record_factory_create_compat;
+ }
+ 
+-G_DEFINE_TYPE_WITH_CODE (GrlDPAPRecordFactory, grl_dpap_record_factory, G_TYPE_OBJECT,
++G_DEFINE_TYPE_WITH_CODE (GrlDpapRecordFactory, grl_dpap_record_factory, G_TYPE_OBJECT,
+                          G_IMPLEMENT_INTERFACE (DMAP_TYPE_RECORD_FACTORY,
+                                                 grl_dpap_record_factory_interface_init))
+ 
+-GrlDPAPRecordFactory *
++GrlDpapRecordFactory *
+ grl_dpap_record_factory_new (void)
+ {
+   return SIMPLE_DPAP_RECORD_FACTORY (g_object_new (TYPE_SIMPLE_DPAP_RECORD_FACTORY, NULL));
+diff --git a/src/dmap/grl-dpap-record-factory.h b/src/dmap/grl-dpap-record-factory.h
+index 899fd0a..9758aa5 100644
+--- a/src/dmap/grl-dpap-record-factory.h
++++ b/src/dmap/grl-dpap-record-factory.h
+@@ -1,5 +1,5 @@
+ /*
+- * GrlDPAPRecord factory class
++ * GrlDpapRecord factory class
+  *
+  * Copyright (C) 2008 W. Michael Petullo <mike@flyn.org>
+  *
+@@ -32,12 +32,12 @@ G_BEGIN_DECLS
+ #define SIMPLE_DPAP_RECORD_FACTORY(o)                                          \
+   (G_TYPE_CHECK_INSTANCE_CAST ((o),                                            \
+                                 TYPE_SIMPLE_DPAP_RECORD_FACTORY,               \
+-                                GrlDPAPRecordFactory))
++                                GrlDpapRecordFactory))
+ 
+ #define SIMPLE_DPAP_RECORD_FACTORY_CLASS(k)                                    \
+   (G_TYPE_CHECK_CLASS_CAST ((k),                                               \
+                              TYPE_SIMPLE_DPAP_RECORD_FACTORY,                  \
+-                             GrlDPAPRecordFactoryClass))
++                             GrlDpapRecordFactoryClass))
+ 
+ #define IS_SIMPLE_DPAP_RECORD_FACTORY(o)                                       \
+   (G_TYPE_CHECK_INSTANCE_TYPE ((o),                                            \
+@@ -50,21 +50,21 @@ G_BEGIN_DECLS
+ #define SIMPLE_DPAP_RECORD_FACTORY_GET_CLASS(o)                                \
+   (G_TYPE_INSTANCE_GET_CLASS ((o),                                             \
+                              TYPE_SIMPLE_DPAP_RECORD_FACTORY,                  \
+-                             GrlDPAPRecordFactoryClass))
++                             GrlDpapRecordFactoryClass))
+ 
+-typedef struct GrlDPAPRecordFactoryPrivate GrlDPAPRecordFactoryPrivate;
++typedef struct GrlDpapRecordFactoryPrivate GrlDpapRecordFactoryPrivate;
+ 
+ typedef struct {
+   GObject parent;
+-} GrlDPAPRecordFactory;
++} GrlDpapRecordFactory;
+ 
+ typedef struct {
+   GObjectClass parent;
+-} GrlDPAPRecordFactoryClass;
++} GrlDpapRecordFactoryClass;
+ 
+ GType grl_dpap_record_factory_get_type (void);
+ 
+-GrlDPAPRecordFactory *grl_dpap_record_factory_new (void);
++GrlDpapRecordFactory *grl_dpap_record_factory_new (void);
+ 
+ DmapRecord *grl_dpap_record_factory_create (DmapRecordFactory *factory, gpointer user_data, GError **error);
+ 
+diff --git a/src/dmap/grl-dpap-record.c b/src/dmap/grl-dpap-record.c
+index 0afb2b8..423b9ed 100644
+--- a/src/dmap/grl-dpap-record.c
++++ b/src/dmap/grl-dpap-record.c
+@@ -27,7 +27,7 @@
+ #include "grl-common.h"
+ #include "grl-dpap-record.h"
+ 
+-struct GrlDPAPRecordPrivate {
++struct GrlDpapRecordPrivate {
+   char *location;
+   gint largefilesize;
+   gint creationdate;
+@@ -59,8 +59,8 @@ enum {
+ static void grl_dpap_record_dmap_iface_init (gpointer iface, gpointer data);
+ static void grl_dpap_record_dpap_iface_init (gpointer iface, gpointer data);
+ 
+-G_DEFINE_TYPE_WITH_CODE (GrlDPAPRecord, grl_dpap_record, G_TYPE_OBJECT,
+-                         G_ADD_PRIVATE (GrlDPAPRecord)
++G_DEFINE_TYPE_WITH_CODE (GrlDpapRecord, grl_dpap_record, G_TYPE_OBJECT,
++                         G_ADD_PRIVATE (GrlDpapRecord)
+                          G_IMPLEMENT_INTERFACE (DMAP_TYPE_IMAGE_RECORD, grl_dpap_record_dpap_iface_init)
+                          G_IMPLEMENT_INTERFACE (DMAP_TYPE_RECORD, grl_dpap_record_dmap_iface_init))
+ 
+@@ -70,7 +70,7 @@ grl_dpap_record_set_property (GObject *object,
+                               const GValue *value,
+                               GParamSpec *pspec)
+ {
+-  GrlDPAPRecord *record = SIMPLE_DPAP_RECORD (object);
++  GrlDpapRecord *record = SIMPLE_DPAP_RECORD (object);
+ 
+   switch (prop_id) {
+   case PROP_LOCATION:
+@@ -123,7 +123,7 @@ grl_dpap_record_get_property (GObject *object,
+                               GValue *value,
+                               GParamSpec *pspec)
+ {
+-  GrlDPAPRecord *record = SIMPLE_DPAP_RECORD (object);
++  GrlDpapRecord *record = SIMPLE_DPAP_RECORD (object);
+ 
+   switch (prop_id) {
+   case PROP_LOCATION:
+@@ -165,7 +165,7 @@ grl_dpap_record_get_property (GObject *object,
+   }
+ }
+ 
+-GrlDPAPRecord *
++GrlDpapRecord *
+ grl_dpap_record_new (void)
+ {
+   return SIMPLE_DPAP_RECORD (g_object_new (TYPE_SIMPLE_DPAP_RECORD, NULL));
+@@ -186,7 +186,7 @@ grl_dpap_record_read (DmapImageRecord *record, GError **error)
+ }
+ 
+ static void
+-grl_dpap_record_init (GrlDPAPRecord *record)
++grl_dpap_record_init (GrlDpapRecord *record)
+ {
+   record->priv = grl_dpap_record_get_instance_private (record);
+ }
+@@ -194,7 +194,7 @@ grl_dpap_record_init (GrlDPAPRecord *record)
+ static void grl_dpap_record_finalize (GObject *object);
+ 
+ static void
+-grl_dpap_record_class_init (GrlDPAPRecordClass *klass)
++grl_dpap_record_class_init (GrlDpapRecordClass *klass)
+ {
+   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+ 
+@@ -236,7 +236,7 @@ grl_dpap_record_dmap_iface_init (gpointer iface, gpointer data)
+ static void
+ grl_dpap_record_finalize (GObject *object)
+ {
+-  GrlDPAPRecord *record = SIMPLE_DPAP_RECORD (object);
++  GrlDpapRecord *record = SIMPLE_DPAP_RECORD (object);
+ 
+   g_free (record->priv->location);
+   g_free (record->priv->filename);
+diff --git a/src/dmap/grl-dpap-record.h b/src/dmap/grl-dpap-record.h
+index 77eece0..23a7a74 100644
+--- a/src/dmap/grl-dpap-record.h
++++ b/src/dmap/grl-dpap-record.h
+@@ -32,12 +32,12 @@ G_BEGIN_DECLS
+ #define SIMPLE_DPAP_RECORD(o)                                                  \
+   (G_TYPE_CHECK_INSTANCE_CAST ((o),                                            \
+                                 TYPE_SIMPLE_DPAP_RECORD,                       \
+-                                GrlDPAPRecord))
++                                GrlDpapRecord))
+ 
+ #define SIMPLE_DPAP_RECORD_CLASS(k)                                            \
+   (G_TYPE_CHECK_CLASS_CAST ((k),                                               \
+                              TYPE_SIMPLE_DPAP_RECORD,                          \
+-                             GrlDPAPRecordClass))
++                             GrlDpapRecordClass))
+ 
+ #define IS_SIMPLE_DPAP_RECORD(o)                                               \
+   (G_TYPE_CHECK_INSTANCE_TYPE ((o),                                            \
+@@ -50,27 +50,27 @@ G_BEGIN_DECLS
+ #define SIMPLE_DPAP_RECORD_GET_CLASS(o)                                        \
+   (G_TYPE_INSTANCE_GET_CLASS ((o),                                             \
+                               TYPE_SIMPLE_DPAP_RECORD,                         \
+-                              GrlDPAPRecordClass))
++                              GrlDpapRecordClass))
+ 
+ #define SIMPLE_DPAP_RECORD_GET_PRIVATE(o)                                      \
+   (G_TYPE_INSTANCE_GET_PRIVATE ((o),                                           \
+                                 TYPE_SIMPLE_DPAP_RECORD,                       \
+-                                GrlDPAPRecordPrivate))
++                                GrlDpapRecordPrivate))
+ 
+-typedef struct GrlDPAPRecordPrivate GrlDPAPRecordPrivate;
++typedef struct GrlDpapRecordPrivate GrlDpapRecordPrivate;
+ 
+ typedef struct {
+   GObject parent;
+-  GrlDPAPRecordPrivate *priv;
+-} GrlDPAPRecord;
++  GrlDpapRecordPrivate *priv;
++} GrlDpapRecord;
+ 
+ typedef struct {
+   GObjectClass parent;
+-} GrlDPAPRecordClass;
++} GrlDpapRecordClass;
+ 
+ GType grl_dpap_record_get_type (void);
+ 
+-GrlDPAPRecord *grl_dpap_record_new (void);
++GrlDpapRecord *grl_dpap_record_new (void);
+ GInputStream *grl_dpap_record_read (DmapImageRecord *record, GError **error);
+ gint grl_dpap_record_get_id (DmapImageRecord *record);
+ 

--- a/multimedia/grilo-plugins/patches/050-backport-x-is.patch
+++ b/multimedia/grilo-plugins/patches/050-backport-x-is.patch
@@ -1,0 +1,140 @@
+diff --git a/meson.build b/meson.build
+index 8a590b9..f858a20 100644
+--- a/meson.build
++++ b/meson.build
+@@ -62,7 +62,7 @@ gstreamer_dep = dependency('gstreamer-1.0', required: false)
+ gthread_dep = dependency('gthread-2.0', required: false)
+ json_glib_dep = dependency('json-glib-1.0', required: false)
+ libarchive_dep = dependency('libarchive', required: false)
+-libdmapsharing4_dep = dependency('libdmapsharing-4.0', version: '>= 3.9.4', required: false)
++libdmapsharing4_dep = dependency('libdmapsharing-4.0', version: '>= 3.9.9', required: false)
+ if libdmapsharing4_dep.found()
+     libdmapsharing_dep = libdmapsharing4_dep
+ else
+diff --git a/src/dmap/grl-daap-compat.h b/src/dmap/grl-daap-compat.h
+index da9025f..149e6a0 100644
+--- a/src/dmap/grl-daap-compat.h
++++ b/src/dmap/grl-daap-compat.h
+@@ -38,7 +38,7 @@ guint grl_daap_db_add (DMAPDb *_db, DMAPRecord *_record, GError **error);
+ #define DmapAvRecordInterface DAAPRecordIface
+ #define DMAP_AV_RECORD DAAP_RECORD
+ #define DMAP_TYPE_AV_RECORD DAAP_TYPE_RECORD
+-#define IS_DMAP_AV_RECORD IS_DAAP_RECORD
++#define DMAP_IS_AV_RECORD IS_DAAP_RECORD
+ 
+ static inline DmapRecord *
+ grl_daap_record_factory_create_compat (DmapRecordFactory *factory, gpointer user_data)
+diff --git a/src/dmap/grl-daap-db.c b/src/dmap/grl-daap-db.c
+index e9a1713..46f49bf 100644
+--- a/src/dmap/grl-daap-db.c
++++ b/src/dmap/grl-daap-db.c
+@@ -157,8 +157,8 @@ set_insert (GHashTable *category, const char *category_name, char *set_name, Grl
+ guint
+ grl_daap_db_add (DmapDb *_db, DmapRecord *_record, GError **error)
+ {
+-  g_assert (IS_GRL_DAAP_DB (_db));
+-  g_assert (IS_DMAP_AV_RECORD (_record));
++  g_assert (GRL_IS_DAAP_DB (_db));
++  g_assert (DMAP_IS_AV_RECORD (_record));
+ 
+   GrlDaapDb *db = GRL_DAAP_DB (_db);
+   DmapAvRecord *record = DMAP_AV_RECORD (_record);
+@@ -261,7 +261,7 @@ grl_daap_db_browse (GrlDaapDb *db,
+                     GrlSourceResultCb func,
+                     gpointer user_data)
+ {
+-  g_assert (IS_GRL_DAAP_DB (db));
++  g_assert (GRL_IS_DAAP_DB (db));
+ 
+   int i;
+   guint remaining;
+@@ -319,7 +319,7 @@ grl_daap_db_search (GrlDaapDb *db,
+                     GrlSourceResultCb func,
+                     gpointer user_data)
+ {
+-  g_assert (IS_GRL_DAAP_DB (db));
++  g_assert (GRL_IS_DAAP_DB (db));
+ 
+   gint i, j, k;
+   guint remaining = 0;
+diff --git a/src/dmap/grl-daap-db.h b/src/dmap/grl-daap-db.h
+index ed877e4..16edfce 100644
+--- a/src/dmap/grl-daap-db.h
++++ b/src/dmap/grl-daap-db.h
+@@ -39,11 +39,11 @@ G_BEGIN_DECLS
+   (G_TYPE_CHECK_CLASS_CAST ((k),                                               \
+                              TYPE_GRL_DAAP_DB,                                 \
+                              GrlDaapDbClass))
+-#define IS_GRL_DAAP_DB(o)                                                      \
++#define GRL_IS_DAAP_DB(o)                                                      \
+   (G_TYPE_CHECK_INSTANCE_TYPE ((o),                                            \
+                                 TYPE_GRL_DAAP_DB))
+ 
+-#define IS_GRL_DAAP_DB_CLASS(k)                                                \
++#define GRL_IS_DAAP_DB_CLASS(k)                                                \
+   (G_TYPE_CHECK_CLASS_TYPE ((k),                                               \
+                              TYPE_GRL_DAAP_DB_CLASS))
+ 
+diff --git a/src/dmap/grl-dpap-compat.h b/src/dmap/grl-dpap-compat.h
+index b996464..212fab4 100644
+--- a/src/dmap/grl-dpap-compat.h
++++ b/src/dmap/grl-dpap-compat.h
+@@ -38,7 +38,7 @@ guint grl_dpap_db_add (DMAPDb *_db, DMAPRecord *_record, GError **error);
+ #define DmapImageRecordInterface DPAPRecordIface
+ #define DMAP_IMAGE_RECORD DPAP_RECORD
+ #define DMAP_TYPE_IMAGE_RECORD DPAP_TYPE_RECORD
+-#define IS_DMAP_IMAGE_RECORD IS_DPAP_RECORD
++#define DMAP_IS_IMAGE_RECORD IS_DPAP_RECORD
+ 
+ static inline DmapRecord *
+ grl_dpap_record_factory_create_compat (DmapRecordFactory *factory, gpointer user_data)
+diff --git a/src/dmap/grl-dpap-db.c b/src/dmap/grl-dpap-db.c
+index 56be8b0..833f654 100644
+--- a/src/dmap/grl-dpap-db.c
++++ b/src/dmap/grl-dpap-db.c
+@@ -125,8 +125,8 @@ set_insert (GHashTable *category, const char *category_name, char *set_name, Grl
+ guint
+ grl_dpap_db_add (DmapDb *_db, DmapRecord *_record, GError **error)
+ {
+-  g_assert (IS_GRL_DPAP_DB (_db));
+-  g_assert (IS_DMAP_IMAGE_RECORD (_record));
++  g_assert (GRL_IS_DPAP_DB (_db));
++  g_assert (DMAP_IS_IMAGE_RECORD (_record));
+ 
+   GrlDpapDb *db = GRL_DPAP_DB (_db);
+   DmapImageRecord *record = DMAP_IMAGE_RECORD (_record);
+@@ -207,7 +207,7 @@ grl_dpap_db_browse (GrlDpapDb *db,
+                     GrlSourceResultCb func,
+                     gpointer user_data)
+ {
+-  g_assert (IS_GRL_DPAP_DB (db));
++  g_assert (GRL_IS_DPAP_DB (db));
+ 
+   int i;
+   guint remaining;
+@@ -258,7 +258,7 @@ grl_dpap_db_search (GrlDpapDb *db,
+                     GrlSourceResultCb func,
+                     gpointer user_data)
+ {
+-  g_assert (IS_GRL_DPAP_DB (db));
++  g_assert (GRL_IS_DPAP_DB (db));
+ 
+   gint i, j, k;
+   guint remaining = 0;
+diff --git a/src/dmap/grl-dpap-db.h b/src/dmap/grl-dpap-db.h
+index 23ae4c1..1ee78b4 100644
+--- a/src/dmap/grl-dpap-db.h
++++ b/src/dmap/grl-dpap-db.h
+@@ -39,10 +39,10 @@ G_BEGIN_DECLS
+   (G_TYPE_CHECK_CLASS_CAST ((k),                                               \
+                              TYPE_GRL_DPAP_DB,                                 \
+                              GrlDpapDbClass))
+-#define IS_GRL_DPAP_DB(o)                                                      \
++#define GRL_IS_DPAP_DB(o)                                                      \
+   (G_TYPE_CHECK_INSTANCE_TYPE ((o),                                            \
+                                 TYPE_GRL_DPAP_DB))
+-#define IS_GRL_DPAP_DB_CLASS(k)                                                \
++#define GRL_IS_DPAP_DB_CLASS(k)                                                \
+   (G_TYPE_CHECK_CLASS_TYPE ((k),                                               \
+                              TYPE_GRL_DPAP_DB_CLASS))
+ 


### PR DESCRIPTION
This commit updates the backport from grilo-plugins master to include
a symbol name change.

Changes to libdmapsharing modified IS_X_... symbols to read X_IS_....
This was adopted in grilo-plugins master, as there was no official release
of grilo-plugins since adding support for libdmapsharing4 in the first
place. The next release of grilo-plugins will be the first to include
libdmapsharing4 support to include the X_IS_... name change.

Fixes issue mentioned at https://github.com/openwrt/packages/pull/12766.

Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me