### PR TITLE
lighttpd: switch to meson

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -20,16 +20,16 @@ PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:lighttpd:lighttpd
 
-PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_DEPENDS:=meson/host
+PKG_CONFIG_DEPENDS:=CONFIG_LIGHTTPD_SSL $(patsubst %,CONFIG_PACKAGE_lighttpd-mod-%,$(REBUILD_MODULES))
 
 REBUILD_MODULES=authn_gssapi authn_ldap authn_mysql cml magnet mysql_vhost trigger_b4_dl webdav
-
-PKG_CONFIG_DEPENDS:=CONFIG_LIGHTTPD_SSL $(patsubst %,CONFIG_PACKAGE_lighttpd-mod-%,$(REBUILD_MODULES))
 
 include $(INCLUDE_DIR)/package.mk
 # iconv is required for lighttpd's mysql plugin
 include $(INCLUDE_DIR)/nls.mk
+include ../../devel/meson/meson.mk
 
 define Package/lighttpd/Default
   SECTION:=net
@@ -56,102 +56,36 @@ config LIGHTTPD_SSL
 	  lighttpd confguration file.
 endef
 
+MESON_ARGS += \
+	-Dwith_bzip=false \
+	-Dwith_dbi=$(if $(CONFIG_PACKAGE_lighttpd-mod-vhostdb_dbi),true,false) \
+	-Dwith_fam=false \
+	-Dwith_gdbm=$(if $(CONFIG_PACKAGE_lighttpd-mod-trigger_b4_dl),true,false) \
+	-Dwith_geoip=$(if $(CONFIG_PACKAGE_lighttpd-mod-geoip),true,false) \
+	-Dwith_krb5=$(if $(CONFIG_PACKAGE_lighttpd-mod-authn_gssapi),true,false) \
+	-Dwith_ldap=$(if $(CONFIG_PACKAGE_lighttpd-mod-authn_ldap)$(CONFIG_PACKAGE_lighttpd-mod-vhostdb_ldap),true,false) \
+	-Dwith_libev=false \
+	-Dwith_libunwind=false \
+	-Dwith_lua=$(if $(CONFIG_PACKAGE_lighttpd-mod-cml)$(CONFIG_PACKAGE_lighttpd-mod-magnet),true,false) \
+	-Dwith_maxminddb=$(if $(CONFIG_PACKAGE_lighttpd-mod-maxminddb),true,false) \
+	-Dwith_memcached=false \
+	-Dwith_mysql=$(if $(CONFIG_PACKAGE_lighttpd-mod-authn_mysql)$(CONFIG_PACKAGE_lighttpd-mod-mysql_vhost)$(CONFIG_PACKAGE_lighttpd-mod-vhostdb_mysql),true,false) \
+	-Dwith_openssl=$(if $(CONFIG_LIGHTTPD_SSL),true,false) \
+	-Dwith_pam=$(if $(CONFIG_PACKAGE_lighttpd-mod-authn_pam),true,false) \
+	-Dwith_pcre=true \
+	-Dwith_pgsql=$(if $(CONFIG_PACKAGE_lighttpd-mod-vhostdb_pgsql),true,false) \
+	-Dwith_sasl=$(if $(CONFIG_PACKAGE_lighttpd-mod-authn_sasl),true,false) \
+	-Dwith_webdav_locks=$(if $(CONFIG_PACKAGE_lighttpd-mod-webdav),true,false) \
+	-Dwith_webdav_props=$(if $(CONFIG_PACKAGE_lighttpd-mod-webdav),true,false) \
+	-Dwith_wolfssl=false \
+	-Dwith_xattr=false \
+	-Dwith_zlib=$(if $(CONFIG_PACKAGE_lighttpd-mod-compress)$(CONFIG_PACKAGE_lighttpd-mod-deflate),true,false)
+
 BASE_MODULES:=dirlisting indexfile staticfile
 
-CONFIGURE_ARGS+= \
-	--libdir=/usr/lib/lighttpd \
-	--sysconfdir=/etc/lighttpd \
-	--enable-shared \
-	--enable-static \
-	--disable-rpath \
-	--without-attr \
-	--without-bzip2 \
-	--without-fam \
-	--with-pcre \
-	--without-valgrind \
-	 $(call autoconf_bool,CONFIG_IPV6,ipv6)
-
-CONFIGURE_VARS+= \
-	PCRE_LIB="-lpcre" \
-
 ifneq ($(strip $(CONFIG_LIGHTTPD_SSL)),)
-  CONFIGURE_ARGS+= \
-	--with-openssl="$(STAGING_DIR)/usr"
   BASE_MODULES+= openssl
-else
-  CONFIGURE_ARGS+= \
-	--without-openssl
 endif
-
-ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-authn_gssapi),)
-  CONFIGURE_ARGS+= --with-krb5
-else
-  CONFIGURE_ARGS+= --without-krb5
-endif
-
-ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-authn_ldap),)
-  CONFIGURE_ARGS+= --with-ldap
-else
-  CONFIGURE_ARGS+= --without-ldap
-endif
-
-ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-authn_mysql)$(CONFIG_PACKAGE_lighttpd-mod-mysql_vhost),)
-  CONFIGURE_ARGS+= --with-mysql
-else
-  CONFIGURE_ARGS+= --without-mysql
-endif
-
-#ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-geoip),)
-#  CONFIGURE_ARGS+= --with-geoip
-#else
-#  CONFIGURE_ARGS+= --without-geoip
-#endif
-
-ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-cml)$(CONFIG_PACKAGE_lighttpd-mod-magnet),)
-  CONFIGURE_ARGS+= --with-lua
-else
-  CONFIGURE_ARGS+= --without-lua
-endif
-
-#ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-cml)$(CONFIG_PACKAGE_lighttpd-mod-trigger_b4_dl),)
-#  CONFIGURE_ARGS+= --with-memcached
-#else
-#  CONFIGURE_ARGS+= --without-memcached
-#endif
-
-ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-trigger_b4_dl),)
-  CONFIGURE_ARGS+= --with-gdbm
-else
-  CONFIGURE_ARGS+= --without-gdbm
-endif
-
-ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-webdav),)
-  CONFIGURE_ARGS+= \
-	--with-webdav-locks \
-	--with-webdav-props
-  # XXX: needed by sqlite3 to prevent segfaults in mod_webdav.so
-  CONFIGURE_VARS+= \
-	LIBS="-lpthread"
-else
-  CONFIGURE_ARGS+= \
-	--without-webdav-locks \
-	--without-webdav-props
-endif
-
-ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-authn_pam),)
-  CONFIGURE_ARGS+= \
-       --with-pam
-else
-  CONFIGURE_ARGS+= \
-       --without-pam
-endif
-
-define Build/Configure
-$(call Build/Configure/Default)
-	# XXX: override pcre (mis)detection by ./configure when cross-compiling
-	echo "#define HAVE_LIBPCRE 1" >>$(PKG_BUILD_DIR)/config.h
-	echo "#define HAVE_PCRE_H 1" >>$(PKG_BUILD_DIR)/config.h
-endef
 
 define Package/lighttpd/conffiles
 /etc/lighttpd/lighttpd.conf
@@ -218,6 +152,7 @@ $(eval $(call BuildPlugin,authn_gssapi,Kerberos-based authentication,lighttpd-mo
 $(eval $(call BuildPlugin,authn_ldap,LDAP-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_ldap:libopenldap,20))
 $(eval $(call BuildPlugin,authn_mysql,Mysql-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_mysql:libmysqlclient,20))
 $(eval $(call BuildPlugin,authn_pam,PAM-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_pam:libpam,20))
+$(eval $(call BuildPlugin,authn_sasl,SASL-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_sasl:libsasl2,20))
 
 # Finally, everything else.
 $(eval $(call BuildPlugin,access,Access restrictions,,30))
@@ -234,8 +169,9 @@ $(eval $(call BuildPlugin,expire,Expire,,30))
 $(eval $(call BuildPlugin,extforward,Extract client,,30))
 $(eval $(call BuildPlugin,fastcgi,FastCGI,,30))
 $(eval $(call BuildPlugin,flv_streaming,FLV streaming,,30))
-#$(eval $(call BuildPlugin,geoip,Geolocation,+PACKAGE_lighttpd-mod-geoip:libgeoip,30))
+#$(eval $(call BuildPlugin,geoip,Geolocation,+PACKAGE_lighttpd-mod-geoip:libgeoip,30)) #libgeoip is not in OpenWrt
 $(eval $(call BuildPlugin,magnet,Magnet,+PACKAGE_lighttpd-mod-magnet:liblua,30))
+$(eval $(call BuildPlugin,maxminddb,MaxMind DB,+PACKAGE_lighttpd-mod-maxminddb:libmaxminddb,30))
 $(eval $(call BuildPlugin,mysql_vhost,Mysql virtual hosting,+PACKAGE_lighttpd-mod-mysql_vhost:libmysqlclient,30))
 $(eval $(call BuildPlugin,proxy,Proxy,,30))
 $(eval $(call BuildPlugin,rewrite,URL rewriting,+PACKAGE_lighttpd-mod-rewrite:libpcre,30))
@@ -244,11 +180,19 @@ $(eval $(call BuildPlugin,scgi,SCGI,,30))
 $(eval $(call BuildPlugin,secdownload,Secure and fast download,,30))
 $(eval $(call BuildPlugin,setenv,Environment variable setting,,30))
 $(eval $(call BuildPlugin,simple_vhost,Simple virtual hosting,,30))
+$(eval $(call BuildPlugin,sockproxy,sockproxy,,30))
 $(eval $(call BuildPlugin,ssi,SSI,+PACKAGE_lighttpd-mod-ssi:libpcre,30))
+$(eval $(call BuildPlugin,staticfile,staticfile,,30))
 $(eval $(call BuildPlugin,status,Server status display,,30))
 #$(eval $(call BuildPlugin,trigger_b4_dl,Trigger before download,+PACKAGE_lighttpd-mod-trigger_b4_dl:libpcre +PACKAGE_lighttpd-mod-trigger_b4_dl:libgdbm +PACKAGE_lighttpd-mod-trigger_b4_dl:libmemcached,30))
 $(eval $(call BuildPlugin,trigger_b4_dl,Trigger before download,+PACKAGE_lighttpd-mod-trigger_b4_dl:libpcre +PACKAGE_lighttpd-mod-trigger_b4_dl:libgdbm,30))
+$(eval $(call BuildPlugin,uploadprogress,Upload Progress,,30))
 $(eval $(call BuildPlugin,userdir,User directory,,30))
 $(eval $(call BuildPlugin,usertrack,User tracking,,30))
+$(eval $(call BuildPlugin,vhostdb_dbi,Virtual Host Database (DBI),+PACKAGE_lighttpd-mod-vhostdb_dbi:libdbi,30))
+$(eval $(call BuildPlugin,vhostdb_ldap,Virtual Host Database (LDAP),+PACKAGE_lighttpd-mod-vhostdb_ldap:libopenldap,30))
+$(eval $(call BuildPlugin,vhostdb_mysql,Virtual Host Database (MariaDB),+PACKAGE_lighttpd-mod-vhostdb_mysql:libmysqlclient,30))
+$(eval $(call BuildPlugin,vhostdb_pgsql,Virtual Host Database (PostgreSQL),+PACKAGE_lighttpd-mod-vhostdb_pgsql:libpq,30))
+$(eval $(call BuildPlugin,vhostdb,Virtual Host Database,,30))
 $(eval $(call BuildPlugin,webdav,WebDAV,+PACKAGE_lighttpd-mod-webdav:libsqlite3 +PACKAGE_lighttpd-mod-webdav:libuuid +PACKAGE_lighttpd-mod-webdav:libxml2,30))
 $(eval $(call BuildPlugin,wstunnel,Websocket tunneling,,30))

--- a/net/lighttpd/patches/010-mariadb.patch
+++ b/net/lighttpd/patches/010-mariadb.patch
@@ -1,0 +1,29 @@
+From 04a7d98cb91139d79dd14cbdb0522d3d5898dd12 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Fri, 10 Jul 2020 20:40:07 -0700
+Subject: [PATCH] [meson] fix libmariadb dependency
+
+libmariadb is what should be used as only the library portion is used.
+
+Fixes compilation under OpenWrt.
+
+Note that mariadb.pc is a superset that links to libmariadb.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ src/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/meson.build b/src/meson.build
+index 43ef9540..d39cf1c0 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -387,7 +387,7 @@ if get_option('with_mysql')
+ 	# manual search: extend include path with 'mysql/'
+ 	# header: mysql.h
+ 	# function: mysql_real_connect (-lmariadb)
+-	libmysqlclient = [ dependency('mariadb') ]
++	libmysqlclient = [ dependency('libmariadb') ]
+ 	#-# function: mysql_real_connect (-lmysqlclient)
+ 	#-libmysqlclient = [ dependency('mysqlclient') ]
+ 	conf_data.set('HAVE_MYSQL', true)

--- a/net/lighttpd/patches/020-maxminddb.patch
+++ b/net/lighttpd/patches/020-maxminddb.patch
@@ -1,0 +1,35 @@
+From fd2a12d6362aad2013ba558537647e46419d7595 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Fri, 10 Jul 2020 21:20:52 -0700
+Subject: [PATCH] [meson] add missing libmaxminddb section
+
+Fixes the following error when building with -Dwith_maxminddb=true:
+
+meson.build:916:1: ERROR: Unknown variable "libmaxminddb".
+
+A full log can be found at meson-logs/meson-log.txt
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ src/meson.build | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/meson.build b/src/meson.build
+index d39cf1c0..2191c9bc 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -255,6 +255,14 @@ if get_option('with_fam')
+ 	conf_data.set('HAVE_FAM_H', true)
+ endif
+ 
++libmaxminddb = []
++if get_option('with_maxminddb')
++	libmaxminddb = [ compiler.find_library('maxminddb') ]
++	if not(compiler.has_function('MMDB_open', args: defs, dependencies: libmaxminddb, prefix: '#include <maxminddb.h>'))
++		error('Couldn\'t find maxminddb.h or MMDB_open in lib maxminddb')
++	endif
++endif
++
+ libgeoip = []
+ if get_option('with_geoip')
+ 	libgeoip = dependency('geoip', required: false)


### PR DESCRIPTION
Simplifies the Makefile and allows faster compilation with Ninja.

Added patch to fix libmariadb dependency.

Added extra modules.

Speed Before:

time make package/lighttpd/compile -j 12
________________________________________________________
Executed in   47.91 secs   fish           external
   usr time   41.83 secs  384.00 micros   41.83 secs
   sys time   10.79 secs   37.00 micros   10.79 secs

Speed After:

time make package/lighttpd/compile -j 12
________________________________________________________
Executed in   19.67 secs   fish           external
   usr time   42.79 secs  377.00 micros   42.79 secs
   sys time    8.56 secs   37.00 micros    8.56 secs

Tested with fish shell.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @flyn-org 
Compile tested: ath79

ping @BKPepe I know you guys use this in TurrisOS.