### PR TITLE
cache-domains: Improved configure reliability

### DIFF
--- a/utils/cache-domains/Makefile
+++ b/utils/cache-domains/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cache-domains
-PKG_VERSION:=2.0.0
+PKG_VERSION:=2.1.0
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>

--- a/utils/cache-domains/files/30-cache-domains
+++ b/utils/cache-domains/files/30-cache-domains
@@ -1,8 +1,14 @@
 #!/bin/sh
 
-source /lib/functions/network.sh
+. /lib/functions/network.sh
 network_find_wan WAN_IFACE
 
-if [ "${ACTION}" == "ifup" ] && [ "${INTERFACE}" == "${WAN_IFACE}" ] && [ ! -d /var/cache-domains ]; then
-	/usr/bin/cache-domains configure
+if [ "${ACTION}" = "ifup" ] && [ "${INTERFACE}" = "${WAN_IFACE}" ] && [ ! -d /var/cache-domains ]; then
+	for ATTEMPT in $(seq 1 3); do
+		if /usr/bin/cache-domains configure; then
+			break
+		else
+			sleep 30
+		fi
+	done
 fi

--- a/utils/cache-domains/files/cache-domains
+++ b/utils/cache-domains/files/cache-domains
@@ -1,39 +1,42 @@
 #!/bin/sh
 
+set -e
+
 CACHE_DOMAINS_DIR="/var/cache-domains"
 CACHE_DOMAINS_SRC="https://api.github.com/repos/uklans/cache-domains/tarball/master"
 CONFIG_FILE="/etc/cache-domains.json"
 
 configure() {
-	mkdir -p ${CACHE_DOMAINS_DIR}
-	rm -fr ${CACHE_DOMAINS_DIR}/*
+	mkdir -p "${CACHE_DOMAINS_DIR}"
+	rm -fr "${CACHE_DOMAINS_DIR:?}/"*
 
-	if ! wget -qO - ${CACHE_DOMAINS_SRC} | tar -xzC ${CACHE_DOMAINS_DIR}; then
+	if ! wget -qO - "${CACHE_DOMAINS_SRC}" | tar -xzC "${CACHE_DOMAINS_DIR}"; then
+		rm -fr "${CACHE_DOMAINS_DIR}"
 		echo "ERROR: Could not retrieve ${CACHE_DOMAINS_SRC}"
-		return 1
+		exit 1
 	fi
 
 	INITIAL_DIR="$(pwd)"
-	cd ${CACHE_DOMAINS_DIR}/*/scripts/
+	cd "${CACHE_DOMAINS_DIR}/"*"/scripts/"
 
-	if [ ! -f ${CONFIG_FILE} ]; then
-		cp config.example.json ${CONFIG_FILE}
+	if [ ! -f "${CONFIG_FILE}" ]; then
+		cp "config.example.json" "${CONFIG_FILE}"
 		echo "Using example config file ${CONFIG_FILE}"
 	fi
 
-	cp ${CONFIG_FILE} config.json
+	cp "${CONFIG_FILE}" "config.json"
 	./create-dnsmasq.sh
-	cp ./output/dnsmasq/* /var/dnsmasq.d/
+	cp "./output/dnsmasq/"* "/var/dnsmasq.d/"
 
-	cd ${INITIAL_DIR}
+	cd "${INITIAL_DIR}"
 
 	/etc/init.d/dnsmasq restart
 }
 
 cleanup() {
 	# leave dnsmasq in a clean state
-	for FILE in ${CACHE_DOMAINS_DIR}/*/scripts/output/dnsmasq/*; do
-		rm -f /tmp/dnsmasq.d/$(basename ${FILE})
+	for FILE in "${CACHE_DOMAINS_DIR}/"*"/scripts/output/dnsmasq/"*; do
+		rm -f "/tmp/dnsmasq.d/$(basename "${FILE}")"
 	done
 
 	/etc/init.d/dnsmasq restart


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: x86_x64, Hyper-V, OpenWrt Master
Run tested: x86_x64, Hyper-V, OpenWrt Master

Description:
I've noticed that in deployment on some reboots it won't configure, this seems to be due to running before the system/network is ready.

* `cache-domains configure` exits with `1` on failure
* Retrying on failure every 30s for 3 attempts 
* Removing `/var/cache-domains` on failure so subsequent hotplug events can retry