### PR TITLE
openfortivpn: use standard 'peerdns' config option on netifd script

### DIFF
--- a/net/openfortivpn/Makefile
+++ b/net/openfortivpn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openfortivpn
 PKG_VERSION:=1.14.1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/adrienverge/openfortivpn/tar.gz/v$(PKG_VERSION)?

--- a/net/openfortivpn/files/openfortivpn.sh
+++ b/net/openfortivpn/files/openfortivpn.sh
@@ -19,8 +19,6 @@ proto_openfortivpn_init_config() {
         proto_config_add_string "password"
         proto_config_add_string "trusted_cert"
         proto_config_add_string "remote_status_check"	
-        proto_config_add_int "set_dns"
-        proto_config_add_int "pppd_use_peerdns"
         proto_config_add_int "peerdns"
         proto_config_add_int "metric"
         no_device=1
@@ -32,7 +30,7 @@ proto_openfortivpn_setup() {
         local msg
 
         json_get_vars host server port iface_name local_ip username password trusted_cert \
-	              remote_status_check set_dns pppd_use_peerdns metric
+	              remote_status_check peerdns metric
 
         ifname="vpn-$config"
 
@@ -91,11 +89,12 @@ proto_openfortivpn_setup() {
 
 
         [ -n "$port" ] && port=":$port"
+	[ -z "$peerdns" ] && peerdns=1
 
         append_args "$server$port" --pppd-ifname="$ifname" --use-syslog  -c /dev/null
-        append_args "--set-dns=$set_dns"
+        append_args "--set-dns=0"
         append_args "--no-routes"
-        append_args "--pppd-use-peerdns=$pppd_use_peerdns"
+        append_args "--pppd-use-peerdns=$peerdns"
 
         [ -n "$iface_name" ] && {
             append_args "--ifname=$iface_device_name"


### PR DESCRIPTION
Signed-off-by: Aaron Goodman <aaronjg@stanford.edu>

updated to use the standard 'peerdns' config option as @jow- pointed out here

https://github.com/openwrt/luci/pull/4175

Maintainer: @lucize
Compile tested: 19.07.3-ipq806x
Run tested: 19.07.3-ipq806x
