### PR TITLE
[RFC] dockerd: add iptables access control for docker0

### DIFF
--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -43,10 +43,39 @@ process_config() {
 	json_dump > "$DOCKERD_CONF"
 }
 
+process_ac_allowed() {
+	local cfg="$1"
+
+	local iface
+
+	config_get iface "$cfg" iface
+	iptables -A DOCKER-ACCESS-CONTROL -i "$iface" -o docker0 -j RETURN
+
+}
+
+process_ac() {
+	[ -f /etc/config/dockerd ] || {
+		return 0
+	}
+
+	# Add access control
+	iptables -N DOCKER-ACCESS-CONTROL
+
+	config_foreach process_ac_allowed access_control
+
+	iptables -A DOCKER-ACCESS-CONTROL -m conntrack --ctstate ESTABLISHED,RELATED -o docker0 -j RETURN
+	iptables -A DOCKER-ACCESS-CONTROL -m conntrack --ctstate NEW,INVALID -o docker0 -j DROP
+	iptables -A DOCKER-ACCESS-CONTROL -j RETURN
+
+	iptables -N DOCKER-USER
+	iptables -I DOCKER-USER -j DOCKER-ACCESS-CONTROL
+}
+
 start_service() {
 	local nofile=$(cat /proc/sys/fs/nr_open)
 
 	process_config
+	process_ac
 
 	procd_open_instance
 	procd_set_param stderr 1
@@ -76,11 +105,13 @@ ip4tables_remove_filter() {
 	iptables -t filter -F DOCKER-ISOLATION-STAGE-1
 	iptables -t filter -F DOCKER-ISOLATION-STAGE-2
 	iptables -t filter -F DOCKER-USER
+	iptables -t filter -F DOCKER-ACCESS-CONTROL
 
 	iptables -t filter -X DOCKER
 	iptables -t filter -X DOCKER-ISOLATION-STAGE-1
 	iptables -t filter -X DOCKER-ISOLATION-STAGE-2
 	iptables -t filter -X DOCKER-USER
+	iptables -t filter -X DOCKER-ACCESS-CONTROL
 }
 
 ip4tables_remove() {


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503 
Compile tested: only script changes
Run tested: x86_64, APU3, OpenWrt master

Description:

With this change you can determine who is allowed to access the docker0
interface. For this to take effect a new section access_control with the
option iface must be added to the uci dockerd configuration.

config access_control
	option iface "br-lan"

This is now maintained in the [luci-app-dockerman](https://github.com/openwrt/luci/blob/master/applications/luci-app-dockerman/root/etc/init.d/dockerman). To be able to
discard the init script in the LuCI feed the same functionality must be
included and edited in the dockerd init script.

We have already add uci handling to make it luci-app-dockerman easy to change the needed values.
But it is still to be adjusted by removeing the dockerd-config in the init script and update the cbi handling sources of luci-app-dockerman do use /etc/config/dockerd and not /etc/config/dockerman

@lisaac could you also please verify if this works for you?
