### PR TITLE
mwan3: clean up ipv4/ipv6 duplicated code and misc. improvments

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.9
+PKG_VERSION:=2.8.10
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/etc/config/mwan3
+++ b/net/mwan3/files/etc/config/mwan3
@@ -139,7 +139,12 @@ config rule 'https'
 	option proto 'tcp'
 	option use_policy 'balanced'
 
-config rule 'default_rule'
+config rule 'default_rule_v4'
 	option dest_ip '0.0.0.0/0'
 	option use_policy 'balanced'
+	option family 'ipv4'
 
+config rule 'default_rule_v6'
+	option dest_ip '::/0'
+	option use_policy 'balanced'
+	option family 'ipv6'

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -518,6 +518,8 @@ mwan3_create_iface_route()
 		network_get_gateway${V_} via "$1"
 	fi
 
+	( [ -z "$via" ] || [ "$via" = "0.0.0.0" ] || [ "$via" = "::" ] ) && unset via
+
 	network_get_metric metric "$1"
 
 	$IP route flush table "$id"

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -672,7 +672,9 @@ mwan3_track()
 
 	for pid in $(pgrep -f "mwan3track $1 $2"); do
 		kill -TERM "$pid" > /dev/null 2>&1
-		sleep 1
+	done
+	sleep 1
+	for pid in $(pgrep -f "mwan3track $1 $2"); do
 		kill -KILL "$pid" > /dev/null 2>&1
 	done
 	if [ -n "$track_ips" ]; then

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -39,16 +39,17 @@ NO_IPV6=$?
 # otherwise return false
 mwan3_rtmon_ipv4()
 {
-	local tid=1
 	local idx=0
 	local ret=1
 	local tbl=""
+
+	local tid
+
 	mkdir -p /tmp/mwan3rtmon
 	($IP4 route list table main  | grep -v "^default\|linkdown" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv4.main
 	while uci get mwan3.@interface[$idx] >/dev/null 2>&1 ; do
-		idx=$((idx+1))
-		tid=$idx
-		[ "$(uci get mwan3.@interface[$((idx-1))].family)" = "ipv4" ] && {
+		tid=$((idx+1))
+		[ "$(uci get mwan3.@interface[$idx].family)" = "ipv4" ] && {
 			tbl=$($IP4 route list table $tid 2>/dev/null)
 			if echo "$tbl" | grep -q ^default; then
 				(echo "$tbl"  | grep -v "^default\|linkdown" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv4.$tid
@@ -60,9 +61,10 @@ mwan3_rtmon_ipv4()
 				done
 			fi
 		}
-		if [ "$(uci get mwan3.@interface[$((idx-1))].enabled)" = "1" ]; then
+		if [ "$(uci get mwan3.@interface[$idx].enabled)" = "1" ]; then
 			ret=0
 		fi
+		idx=$((idx+1))
 	done
 	rm -f /tmp/mwan3rtmon/ipv4.*
 	return $ret
@@ -72,16 +74,17 @@ mwan3_rtmon_ipv4()
 # otherwise return false
 mwan3_rtmon_ipv6()
 {
-	local tid=1
 	local idx=0
 	local ret=1
 	local tbl=""
+
+	local tid
+
 	mkdir -p /tmp/mwan3rtmon
 	($IP6 route list table main  | grep -v "^default\|^::/0\|^fe80::/64\|^unreachable" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv6.main
 	while uci get mwan3.@interface[$idx] >/dev/null 2>&1 ; do
-		idx=$((idx+1))
-		tid=$idx
-		[ "$(uci get mwan3.@interface[$((idx-1))].family)" = "ipv6" ] && {
+		tid=$((idx+1))
+		[ "$(uci get mwan3.@interface[$idx].family)" = "ipv6" ] && {
 			tbl=$($IP6 route list table $tid 2>/dev/null)
 			if echo "$tbl" | grep -q "^default\|^::/0"; then
 				(echo "$tbl"  | grep -v "^default\|^::/0\|^unreachable" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv6.$tid
@@ -93,9 +96,10 @@ mwan3_rtmon_ipv6()
 				done
 			fi
 		}
-		if [ "$(uci get mwan3.@interface[$((idx-1))].enabled)" = "1" ]; then
+		if [ "$(uci get mwan3.@interface[$idx].enabled)" = "1" ]; then
 			ret=0
 		fi
+		idx=$((idx+1))
 	done
 	rm -f /tmp/mwan3rtmon/ipv6.*
 	return $ret

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -1023,7 +1023,7 @@ mwan3_set_user_iptables_rule()
 				     ${dest_port:+-m} ${dest_port:+multiport} ${dest_port:+--dports} $dest_port \
 				     -m mark --mark 0/$MMX_MASK \
 				     -m comment --comment "$1" \
-				     -j LOG --log-level "$loglevel" --log-prefix "MWAN3($1)" &> /dev/null
+				     -j LOG --log-level "$loglevel" --log-prefix "MWAN3($1)"
 			}
 
 			$IPT -A mwan3_rules \
@@ -1035,7 +1035,7 @@ mwan3_set_user_iptables_rule()
 			     ${src_port:+-m} ${src_port:+multiport} ${src_port:+--sports} $src_port \
 			     ${dest_port:+-m} ${dest_port:+multiport} ${dest_port:+--dports} $dest_port \
 			     -m mark --mark 0/$MMX_MASK \
-			     -j $policy &> /dev/null
+			     -j $policy
 		done
 	fi
 }

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -64,7 +64,7 @@ ifup()
 	status=$(ubus -S call network.interface.$1 status)
 	[ -n "$status" ] && {
 		json_load "$status"
-		json_get_vars up l3_device 
+		json_get_vars up l3_device
 	}
 
 	config_get enabled "$1" enabled 0
@@ -141,13 +141,19 @@ stop()
 
 	for pid in $(pgrep -f "mwan3rtmon"); do
 		kill -TERM "$pid" > /dev/null 2>&1
-		sleep 1
-		kill -KILL "$pid" > /dev/null 2>&1
 	done
 
 	for pid in $(pgrep -f "mwan3track"); do
 		kill -TERM "$pid" > /dev/null 2>&1
-		sleep 1
+	done
+
+	sleep 1
+
+	for pid in $(pgrep -f "mwan3rtmon"); do
+		kill -KILL "$pid" > /dev/null 2>&1
+	done
+
+	for pid in $(pgrep -f "mwan3track"); do
 		kill -KILL "$pid" > /dev/null 2>&1
 	done
 

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -90,6 +90,7 @@ policies()
 	echo "Current ipv4 policies:"
 	mwan3_report_policies_v4
 	echo -e
+	[ $NO_IPV6 -ne 0 ] && return
 	echo "Current ipv6 policies:"
 	mwan3_report_policies_v6
 	echo -e
@@ -100,6 +101,7 @@ connected()
 	echo "Directly connected ipv4 networks:"
 	mwan3_report_connected_v4
 	echo -e
+	[ $NO_IPV6 -ne 0 ] && return
 	echo "Directly connected ipv6 networks:"
 	mwan3_report_connected_v6
 	echo -e
@@ -110,6 +112,7 @@ rules()
 	echo "Active ipv4 user rules:"
 	mwan3_report_rules_v4
 	echo -e
+	[ $NO_IPV6 -ne 0 ] && return
 	echo "Active ipv6 user rules:"
 	mwan3_report_rules_v6
 	echo -e
@@ -161,7 +164,7 @@ stop()
 	config_foreach mwan3_track_clean interface
 
 	for IP in "$IP4" "$IP6"; do
-
+		[ "$IP" = "$IP6" ] && [ $NO_IPV6 -ne 0 ] && continue
 		for route in $(seq 1 $MWAN3_INTERFACE_MAX); do
 			$IP route flush table $route &> /dev/null
 		done
@@ -172,7 +175,7 @@ stop()
 	done
 
 	for IPT in "$IPT4" "$IPT6"; do
-
+		[ "$IPT" = "$IPT6" ] && [ $NO_IPV6 -ne 0 ] && continue
 		$IPT -D PREROUTING -j mwan3_hook &> /dev/null
 		$IPT -D OUTPUT -j mwan3_hook &> /dev/null
 


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: No compile
Run tested: OpenWrt 19.07.3

@feckert - I was about to create a PR for a couple of cleanup commits I made to mwan3, and I then noticed you had also made some cleanup changes. I rebased off of your latest PR and so am putting my PR here. In testing the rebase, I noticed that some of the places you quoted environment variables broke my configuration, so I added a commit to revert a those changes in the necessary places. Let me know if you'd prefer I create a PR based off of the master/branch or create the PR on your branch in the TDT repository instead.

Description:
Some small cleanup of mwan3 scripts:
- Reduce copy/pasted IPv4 IPv6 code
- Don't try to run IPv6 commands when IPv6 is not present
- Consolidate directly connected ipset
- Reduce wait time when restarting the script

Fixes #12838 