### PR TITLE
openzwave: fix pkgconfig libdir paths

### DIFF
--- a/utils/openzwave/Makefile
+++ b/utils/openzwave/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openzwave
 PKG_VERSION:=1.6.1149
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://old.openzwave.com/downloads
@@ -91,6 +91,7 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libopenzwave.pc $(1)/usr/lib/pkgconfig/
 	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/libopenzwave.pc
+	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/libopenzwave.pc
 endef
 
 $(eval $(call BuildPackage,libopenzwave))


### PR DESCRIPTION
It's currently pointing to the host.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dwmw2 
Compile tested: ath79