### PR TITLE
pcre2: switch to CMake

### DIFF
--- a/libs/pcre2/Makefile
+++ b/libs/pcre2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pcre2
 PKG_VERSION:=10.35
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/pcre/$(PKG_NAME)/$(PKG_VERSION)
@@ -20,13 +20,14 @@ PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENCE
 PKG_CPE_ID:=cpe:/a:pcre:pcre
 
-PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-
 PKG_CONFIG_DEPENDS:=\
+	CONFIG_PACKAGE_libpcre2-16 \
+	CONFIG_PACKAGE_libpcre2-32 \
 	CONFIG_PCRE2_JIT_ENABLED
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/libpcre2/default
   SECTION:=libs
@@ -48,37 +49,28 @@ define Package/libpcre2-16
   TITLE:=A Perl Compatible Regular Expression library (16bit support)
 endef
 
-
 define Package/libpcre2-32
   $(call Package/libpcre2/default)
   TITLE:=A Perl Compatible Regular Expression library (32bit support)
 endef
 
-TARGET_CFLAGS += $(FPIC)
-
-CONFIGURE_ARGS += \
-	--enable-pcre2-16 \
-	--enable-pcre2-32 \
-	$(if $(CONFIG_PCRE2_JIT_ENABLED),--enable-jit,--disable-jit)
-
-MAKE_FLAGS += \
-	CFLAGS="$(TARGET_CFLAGS)"
+CMAKE_OPTIONS += \
+	-DBUILD_SHARED_LIBS=ON \
+	-DPCRE2_BUILD_PCRE2_8=ON \
+	-DPCRE2_BUILD_PCRE2_16=O$(if $(CONFIG_PACKAGE_libpcre2-16),N,FF) \
+	-DPCRE2_BUILD_PCRE2_32=O$(if $(CONFIG_PACKAGE_libpcre2-32),N,FF) \
+	-DPCRE2_DEBUG=OFF \
+	-DPCRE2_DISABLE_PERCENT_ZT=ON \
+	-DPCRE2_SUPPORT_JIT=O$(if $(CONFIG_PCRE2_JIT_ENABLED),N,FF) \
+	-DPCRE2_SHOW_REPORT=OFF \
+	-DPCRE2_BUILD_PCRE2GREP=OFF \
+	-DPCRE2_BUILD_TESTS=OFF
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/pcre2-config $(1)/usr/bin/
-
-	$(INSTALL_DIR) $(2)/bin
-	$(LN) $(STAGING_DIR)/usr/bin/pcre2-config $(2)/bin
-
-	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/pcre*.h $(1)/usr/include/
-
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre*.{a,so*} $(1)/usr/lib/
-
-	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpcre*.pc $(1)/usr/lib/pkgconfig/
+	$(call Build/InstallDev/cmake,$(1))
+	$(SED) \
+		's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' \
+		$(1)/usr/bin/pcre2-config
 endef
 
 define Package/libpcre2/install
@@ -95,8 +87,6 @@ define Package/libpcre2-32/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre2-32.so* $(1)/usr/lib/
 endef
-
-
 
 $(eval $(call BuildPackage,libpcre2))
 $(eval $(call BuildPackage,libpcre2-16))


### PR DESCRIPTION
Allows simplifying the Makefile. Faster compilation as well.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @InBetweenNames 
Compile tested: ath79