### PR TITLE
mwan3: IPv4 ping with address can fail

### DIFF
--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -143,6 +143,10 @@ main() {
 						        ADDR=$(ip -6 addr ls dev "$DEVICE" | sed -ne '/\/128/d' -e 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p' | head -n1)
 							[ -z "$ADDR" ] && ADDR=$(ip -6 addr ls dev "$DEVICE" | sed -ne 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p')
 							ping_protocol=6
+						else
+							ADDR=$(ip -4 addr ls dev "$DEVICE" | sed -ne 's/ *inet \([^ \/]*\).* scope global.*/\1/p')
+						fi
+
 						fi
 						if [ $check_quality -eq 0 ]; then
 							$PING -$ping_protocol -I ${ADDR:-$DEVICE} -c $count -W $timeout -s $size -t $max_ttl -q $track_ip &> /dev/null


### PR DESCRIPTION
Maintainer: me / @feckert 
Compile tested: N/A - no compile done for shell scripts
Run tested: Netgear WNDR4300, 19.07.3

Description:
Similar to the way that IPv6 ping can fail when -I is used with an address
instead of an interface name, the same can happen with IPv4.

Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>