### PR TITLE
cros-vboot: Chrome OS verified boot utilities

### DIFF
--- a/utils/cros-vboot/Makefile
+++ b/utils/cros-vboot/Makefile
@@ -1,0 +1,55 @@
+#
+# Copyright 2025 Brian Norris <computersforpeace@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cros-vboot
+PKG_SOURCE_DATE:=2025-01-23
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://chromium.googlesource.com/chromiumos/platform/vboot_reference
+PKG_SOURCE_VERSION:=e3731b76ae14d6779d7e1e60ce1f9c14a826de68
+PKG_MIRROR_HASH:=259d259811383666200fbfcf7ceb3ecb69355b74293d9c5a673414d386d0280f
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILE:=LICENSE
+PKG_MAINTAINER:=Brian Norris <computersforpeace@gmail.com>
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+MAKE_FLAGS += LD="$(TARGET_CC)" ARCH="$(ARCH)" CROSSYSTEM_LOCK_DIR="/var/run" WERROR=
+TARGET_LDFLAGS += $(if $(CONFIG_USE_MUSL),-lfts)
+
+define Package/cros-vboot
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=ChromeOS verified boot utilities
+  URL:=https://chromium.googlesource.com/chromiumos/platform/vboot_reference
+  DEPENDS:=+libflashrom +libuuid +USE_MUSL:musl-fts +libopenssl
+endef
+
+define Package/cros-vboot/install
+	$(INSTALL_DIR) $(1)/usr/bin
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/cgpt $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/crossystem $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/futility $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/tpmc $(1)/usr/bin
+
+	# Developer keys, useful for (re)signing payloads. Not installed by
+	# 'make install'.
+	$(INSTALL_DIR) $(1)/usr/share/vboot/devkeys
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/tests/devkeys/{kernel_data_key.vbprivk,kernel.keyblock} \
+		$(1)/usr/share/vboot/devkeys
+endef
+
+$(eval $(call BuildPackage,cros-vboot))

--- a/utils/cros-vboot/patches/0001-flashrom-Strip-out-incompatible-libflashrom-APIs.patch
+++ b/utils/cros-vboot/patches/0001-flashrom-Strip-out-incompatible-libflashrom-APIs.patch
@@ -1,0 +1,94 @@
+From: Brian Norris <computersforpeace@gmail.com>
+Date: Wed, 16 Aug 2023 22:43:12 -0700
+Subject: [PATCH 1/3] flashrom: Strip out incompatible libflashrom APIs
+
+Signed-off-by: Brian Norris <computersforpeace@gmail.com>
+---
+ host/lib/flashrom_drv.c | 53 +++++++----------------------------------
+ 1 file changed, 9 insertions(+), 44 deletions(-)
+
+--- a/host/lib/flashrom_drv.c
++++ b/host/lib/flashrom_drv.c
+@@ -89,8 +89,6 @@ static int flashrom_read_image_impl(stru
+ 		goto err_probe;
+ 	}
+ 
+-	flashrom_flag_set(flashctx, FLASHROM_FLAG_SKIP_UNREADABLE_REGIONS, true);
+-
+ 	if (regions_len) {
+ 		int i;
+ 		r = flashrom_layout_read_fmap_from_rom(
+@@ -205,9 +203,6 @@ int flashrom_write_image(const struct fi
+ 		}
+ 	}
+ 
+-	/* Must occur before attempting to read FMAP from SPI flash. */
+-	flashrom_flag_set(flashctx, FLASHROM_FLAG_SKIP_UNREADABLE_REGIONS, true);
+-
+ 	if (regions_len) {
+ 		int i;
+ 		r = flashrom_layout_read_fmap_from_buffer(
+@@ -241,7 +236,6 @@ int flashrom_write_image(const struct fi
+ 		goto err_cleanup;
+ 	}
+ 
+-	flashrom_flag_set(flashctx, FLASHROM_FLAG_SKIP_UNWRITABLE_REGIONS, true);
+ 	flashrom_flag_set(flashctx, FLASHROM_FLAG_VERIFY_WHOLE_CHIP, false);
+ 	flashrom_flag_set(flashctx, FLASHROM_FLAG_VERIFY_AFTER_WRITE,
+ 			  do_verify);
+@@ -380,46 +374,17 @@ int flashrom_get_info(const char *prog_w
+ 		      uint32_t *vid, uint32_t *pid,
+ 		      uint32_t *flash_len, int verbosity)
+ {
+-	int r = 0;
+-
+-	g_verbose_screen = (verbosity == -1) ? FLASHROM_MSG_INFO : verbosity;
+-
+-	char *programmer, *params;
+-	char *tmp = flashrom_extract_params(prog_with_params,
+-					    &programmer, &params);
+-
+-	struct flashrom_programmer *prog = NULL;
+-	struct flashrom_flashctx *flashctx = NULL;
+-
+-	flashrom_set_log_callback((flashrom_log_callback *)&flashrom_print_cb);
++	int r;
+ 
+-	if (flashrom_init(1) ||
+-	    flashrom_programmer_init(&prog, programmer, params)) {
+-		r = -1;
+-		goto err_init;
+-	}
+-	if (flashrom_flash_probe(&flashctx, prog, NULL)) {
+-		r = -1;
+-		goto err_probe;
+-	}
+-
+-	struct flashrom_flashchip_info info;
+-	flashrom_flash_getinfo(flashctx, &info);
+-
+-	*vendor = strdup(info.vendor);
+-	*name = strdup(info.name);
+-	*vid = info.manufacture_id;
+-	*pid = info.model_id;
+-	*flash_len = info.total_size * 1024;
+-
+-	flashrom_flash_release(flashctx);
+-
+-err_probe:
+-	r |= flashrom_programmer_shutdown(prog);
++	r = flashrom_get_size(prog_with_params, flash_len, verbosity);
++	if (r)
++		return r;
++	*vendor = strdup("vendor is missing; libflashrom isn't new enough");
++	*name = strdup("name is missing; libflashrom isn't new enough");
++	*vid = 0xdead;
++	*pid = 0xbeef;
+ 
+-err_init:
+-	free(tmp);
+-	return r;
++	return 0;
+ }
+ 
+ int flashrom_get_size(const char *prog_with_params,

--- a/utils/cros-vboot/patches/0002-flashrom-Update-args-to-upstream.patch
+++ b/utils/cros-vboot/patches/0002-flashrom-Update-args-to-upstream.patch
@@ -1,0 +1,27 @@
+From: Brian Norris <computersforpeace@gmail.com>
+Date: Wed, 16 Aug 2023 23:09:30 -0700
+Subject: [PATCH 2/3] flashrom: Update args to upstream
+
+* --fmap: needed; it's not implicit
+* -r /dev/null: we need to have *some* target file for the read; it's
+  not an optional arg
+
+Signed-off-by: Brian Norris <computersforpeace@gmail.com>
+---
+ host/lib/flashrom.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/host/lib/flashrom.c
++++ b/host/lib/flashrom.c
+@@ -122,8 +122,10 @@ vb2_error_t flashrom_read(struct firmwar
+ 		FLASHROM_EXEC_NAME,
+ 		"-p",
+ 		image->programmer,
++		"--fmap",
+ 		"-r",
+-		region ? "-i" : tmpfile,
++		region ? "/dev/null" : tmpfile,
++		region ? "-i" : NULL,
+ 		region ? region_param : NULL,
+ 		NULL,
+ 	};

--- a/utils/cros-vboot/patches/0003-flashrom-Convert-write-support-to-upstream-args.patch
+++ b/utils/cros-vboot/patches/0003-flashrom-Convert-write-support-to-upstream-args.patch
@@ -1,0 +1,88 @@
+From: Brian Norris <computersforpeace@gmail.com>
+Date: Wed, 16 Aug 2023 23:27:48 -0700
+Subject: [PATCH 3/3] flashrom: Convert 'write' support to upstream args
+
+Signed-off-by: Brian Norris <computersforpeace@gmail.com>
+---
+ host/lib/flashrom.c           | 6 ++++--
+ host/lib/include/subprocess.h | 8 ++++++++
+ host/lib/subprocess.c         | 7 +++++++
+ 3 files changed, 19 insertions(+), 2 deletions(-)
+
+--- a/host/lib/flashrom.c
++++ b/host/lib/flashrom.c
+@@ -87,7 +87,7 @@ static vb2_error_t write_temp_file(const
+ 
+ static vb2_error_t run_flashrom(const char *const argv[])
+ {
+-	int status = subprocess_run(argv, &subprocess_null, &subprocess_null,
++	int status = subprocess_run(argv, &subprocess_zero, &subprocess_null,
+ 				    &subprocess_null);
+ 	if (status) {
+ 		fprintf(stderr, "Flashrom invocation failed (exit status %d):",
+@@ -156,8 +156,10 @@ vb2_error_t flashrom_write(struct firmwa
+ 		"-p",
+ 		image->programmer,
+ 		"--noverify-all",
++		"--fmap",
+ 		"-w",
+-		region ? "-i" : tmpfile,
++		region ? "-" : tmpfile,
++		region ? "-i" : NULL,
+ 		region ? region_param : NULL,
+ 		NULL,
+ 	};
+--- a/host/lib/include/subprocess.h
++++ b/host/lib/include/subprocess.h
+@@ -19,6 +19,8 @@
+  *
+  * - TARGET_NULL: /dev/null, no need to describe any other fields.
+  *
++ * - TARGET_ZERO: /dev/zero, no need to describe any other fields.
++ *
+  * - TARGET_FD: file descriptor, put the fd in the fd field.
+  *
+  * - TARGET_FILE: FILE *, put the FILE pointer in the file field.
+@@ -52,6 +54,7 @@
+ struct subprocess_target {
+ 	enum {
+ 		TARGET_NULL,
++		TARGET_ZERO,
+ 		TARGET_FD,
+ 		TARGET_FILE,
+ 		TARGET_BUFFER,
+@@ -88,6 +91,11 @@ struct subprocess_target {
+ extern struct subprocess_target subprocess_null;
+ 
+ /**
++ * A convenience subprocess target which uses TARGET_ZERO.
++ */
++extern struct subprocess_target subprocess_zero;
++
++/**
+  * A convenience subprocess target which uses TARGET_FD to STDIN_FILENO.
+  */
+ extern struct subprocess_target subprocess_stdin;
+--- a/host/lib/subprocess.c
++++ b/host/lib/subprocess.c
+@@ -49,6 +49,9 @@ static int connect_process_target(struct
+ 	case TARGET_NULL:
+ 		target_fd = open("/dev/null", flags_for_fd(fd));
+ 		break;
++	case TARGET_ZERO:
++		target_fd = open("/dev/zero", flags_for_fd(fd));
++		break;
+ 	case TARGET_FD:
+ 		target_fd = target->fd;
+ 		break;
+@@ -275,6 +278,10 @@ struct subprocess_target subprocess_null
+ 	.type = TARGET_NULL,
+ };
+ 
++struct subprocess_target subprocess_zero = {
++	.type = TARGET_ZERO,
++};
++
+ struct subprocess_target subprocess_stdin = {
+ 	.type = TARGET_FD,
+ 	.fd = STDIN_FILENO,


### PR DESCRIPTION
This new package is useful for systems that have Chrome OS bootloaders,
which use Google's vboot_reference stack for signing and verifying
kernel payloads. Such bootloaders also tend to allow booting custom
(non-Google-signed) payloads when in Developer Mode, using published
developer keys or their own, or their own provided keys (if rebuilding
their own bootloader).

There are a variety of other scripts and binaries built within this
repository, but at the moment, we're installing:

 * cgpt: ChromeOS GPT tool, for manipulating partitions, especially
   Chrome OS kernel partitions and their associated partition attributes
 * crossystem: CrOS System tool, for manipulating various system and
   bootloader/NVRAM properties, like making default boot-disk selection,
   retrieving the firmware revision, and querying special system pin
   states. Some functionalities only work when helpers like "mosys"
   (https://chromium.googlesource.com/chromiumos/platform/mosys) are
   present (not packaged here), but there are still a few useful entries
   in here.
 * futility: a mutli-call binary providing several utility functions.
   I'll quote part of its --help output:

     The following commands are built-in:

       create               Create a keypair from an RSA .pem file
       dump_fmap            Display FMAP contents from a firmware image
       dump_kernel_config   Prints the kernel command line
       gbb                  Manipulate the Google Binary Block (GBB)
       gbb_utility          Legacy name for `gbb` command
       help                 Show a bit of help (you're looking at it)
       load_fmap            Replace the contents of specified FMAP areas
       pcr                  Simulate a TPM PCR extension operation
       show                 Display the content of various binary components
       sign                 Sign / resign various binary components
       update               Update system firmware
       validate_rec_mrc     Validates content of Recovery MRC cache
       vbutil_firmware      Verified boot firmware utility
       vbutil_kernel        Creates, signs, and verifies the kernel partition
       vbutil_key           Wraps RSA keys with vboot headers
       vbutil_keyblock      Creates, signs, and verifies a keyblock
       verify               Verify the signatures of various binary components
       version              Show the futility source revision and build date

 * tpmc: small TPM utility

Signed-off-by: Brian Norris <computersforpeace@gmail.com>

Maintainer: me
Compile tested: ARM/ipq4019, OpenWrt master
Run tested: ARM/ipq4019 (Google WiFi), OpenWrt master

NB: I am prepping OpenWRT support for a Chromium OS based AP, and it will need some of these utilities in the base tools. I have the necessary bits slimmed down and partially rewritten for inclusion there, but the full package is still useful for development and debugging on-device.