### PR TITLE
docker-ce: add reload handling

### DIFF
--- a/utils/docker-ce/Makefile
+++ b/utils/docker-ce/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-ce
 PKG_VERSION:=19.03.12
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=components/cli/LICENSE components/engine/LICENSE
 

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -59,6 +59,15 @@ start_service() {
 	procd_close_instance
 }
 
+reload_service() {
+	process_config
+	procd_send_signal dockerd
+}
+
+service_triggers() {
+	procd_add_reload_trigger 'dockerd'
+}
+
 ip4tables_remove_nat() {
 	iptables -t nat -D OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER
 	iptables -t nat -D PREROUTING -m addrtype --dst-type LOCAL -j DOCKER


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503 
Compile tested: only script changes
Run tested: x86_64, APU3, OpenWrt master

Description:

If the uci configuration is changed send dockerd a SIGHUP to reload the
generated daemon.json file with the new configuration.

This is also needed to switch luci-app-dockerman to use the docker-ce uci handling.
We do not want to start on every change the docker daemon. 
So send them a SIGHUP to reload their configuration.
