### PR TITLE
uwsgi: update to version 2.0.19.1

### DIFF
--- a/net/uwsgi/Makefile
+++ b/net/uwsgi/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uwsgi
-PKG_VERSION:=2.0.18
-PKG_RELEASE:=3
+PKG_VERSION:=2.0.19.1
+PKG_RELEASE:=1
 
-PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=4972ac538800fb2d421027f49b4a1869b66048839507ccf0aa2fda792d99f583
+PYPI_NAME:=uWSGI
+PKG_HASH:=faa85e053c0b1be4d5585b0858d3a511d2cd10201802e8676060fd0a109e5869
 PKG_BUILD_DEPENDS:=python3/host
 PYTHON3_PKG_BUILD:=0
 
@@ -18,6 +18,9 @@ include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
 #for LINUX_UNAME_VERSION:
 include $(INCLUDE_DIR)/kernel.mk
+
+#the .tar.gz does not wrap it into a uWSGI dir; do not use "$(1)/..":
+TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 
 define Package/uwsgi
   SECTION:=net


### PR DESCRIPTION
Maintainer: @Ansuel 
Compile tested: x86_64, x86_64 qemu, master
Run tested: x86_64, x86_64 qemu, master, run luci-nginx and etesync-server.

Description: update to newest version.
