### PR TITLE
fping: update to 4.3

### DIFF
--- a/net/fping/Makefile
+++ b/net/fping/Makefile
@@ -8,18 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fping
-PKG_VERSION:=4.2
-PKG_RELEASE:=2
+PKG_VERSION:=4.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://fping.org/dist/
-PKG_HASH:=7d339674b6a95aae1d8ad487ff5056fd95b474c3650938268f6a905c3771b64a
+PKG_HASH:=92040ae842f7b8942d5cf26d8f58702a8d84c40a1fd492b415bd01b622bf372d
 
 PKG_MAINTAINER:=Nikil Mehta <nikil.mehta@gmail.com>
 PKG_LICENSE:=BSD-4-Clause
 PKG_LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -42,7 +43,7 @@ endef
 
 CONFIGURE_ARGS+= \
 	--enable-ipv4 \
-	--enable-ipv6
+	$(if $(CONFIG_IPV6),en,dis)able-ipv6
 
 define Package/fping/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/net/fping/patches/010-ipv6.patch
+++ b/net/fping/patches/010-ipv6.patch
@@ -1,0 +1,38 @@
+From 54e97d9e393e375820e9c6ca0a56c7a4092ea5de Mon Sep 17 00:00:00 2001
+From: Lars Wendler <polynomial-c@gentoo.org>
+Date: Sun, 12 Jul 2020 13:55:44 +0200
+Subject: [PATCH] Fix build with --disable-ipv6
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Otherwise build breaks with:
+
+fping.c:399:14: error: ‘ident6’ undeclared (first use in this function); did you mean ‘ident4’?
+  399 |     ident4 = ident6 = getpid() & 0xFFFF;
+      |              ^~~~~~
+      |              ident4
+
+Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>
+---
+ src/fping.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/fping.c b/src/fping.c
+index 3522123..4304531 100644
+--- a/src/fping.c
++++ b/src/fping.c
+@@ -258,12 +258,12 @@ HOST_ENTRY* ev_last;
+ 
+ char* prog;
+ int ident4 = 0; /* our icmp identity field */
++int ident6 = 0;
+ int socket4 = -1;
+ int using_sock_dgram4 = 0;
+ #ifndef IPV6
+ int hints_ai_family = AF_INET;
+ #else
+-int ident6 = 0;
+ int socket6 = -1;
+ int hints_ai_family = AF_UNSPEC;
+ #endif


### PR DESCRIPTION
Fixes compilation with GCC 10.

Backported upstream patch to fix compilation without IPv6.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nikil 
Compile tested: ath79