### PR TITLE
radsecproxy: fix compilation with GCC10

### DIFF
--- a/net/radsecproxy/Makefile
+++ b/net/radsecproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radsecproxy
 PKG_VERSION:=1.8.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/radsecproxy/radsecproxy/releases/download/$(PKG_VERSION)/

--- a/net/radsecproxy/patches/300-gcc10.patch
+++ b/net/radsecproxy/patches/300-gcc10.patch
@@ -1,0 +1,36 @@
+From 0098fbc45e5068ef20ba26910e281f3955299176 Mon Sep 17 00:00:00 2001
+From: Robert Scheck <robert@fedoraproject.org>
+Date: Sun, 2 Feb 2020 20:37:16 +0100
+Subject: [PATCH] Declare pthread_attr as extern in header (fixes #63)
+
+GCC 10 compatibility as per https://gcc.gnu.org/gcc-10/porting_to.html
+---
+ radsecproxy.c | 1 +
+ radsecproxy.h | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/radsecproxy.c b/radsecproxy.c
+index a4b1211..b281e21 100644
+--- a/radsecproxy.c
++++ b/radsecproxy.c
+@@ -84,6 +84,7 @@ extern int optind;
+ extern char *optarg;
+ #endif
+ static const struct protodefs *protodefs[RAD_PROTOCOUNT];
++pthread_attr_t pthread_attr;
+ 
+ /* minimum required declarations to avoid reordering code */
+ struct realm *adddynamicrealmserver(struct realm *realm, char *id);
+diff --git a/radsecproxy.h b/radsecproxy.h
+index 3082300..0f20f50 100644
+--- a/radsecproxy.h
++++ b/radsecproxy.h
+@@ -262,7 +262,7 @@ int radsrv(struct request *rq);
+ void replyh(struct server *server, unsigned char *buf);
+ struct addrinfo *resolve_hostport_addrinfo(uint8_t type, char *hostport);
+ uint8_t *radattr2ascii(struct tlv *attr); /* TODO: mv this to radmsg? */
+-pthread_attr_t pthread_attr;
++extern pthread_attr_t pthread_attr;
+ 
+ /* Local Variables: */
+ /* c-file-style: "stroustrup" */


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tohojo 
Compile tested: ath79