### PR TITLE
gnupg: fix compilation with GCC10

### DIFF
--- a/utils/gnupg/Makefile
+++ b/utils/gnupg/Makefile
@@ -9,16 +9,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnupg
 PKG_VERSION:=1.4.23
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/gnupg
 PKG_HASH:=c9462f17e651b6507848c08c430c791287cd75491f8b5a8b50c6ed46b12678ba
 
-PKG_LICENSE:=GPL-3.0
+PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -79,10 +80,12 @@ CONFIGURE_ARGS += \
 	--disable-ldap \
 	--disable-finger \
 	--disable-dns-srv \
-	--disable-regex \
+	--disable-regex
 
 MAKE_FLAGS += \
 	SUBDIRS="m4 intl zlib util mpi cipher tools g10 keyserver ${checks}" \
+
+TARGET_CFLAGS += $(if $(CONFIG_GCC_USE_VERSION_10),-DEXTERN_UNLESS_MAIN_MODULE=static)
 
 define Package/gnupg/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
A bit ugly but it works.

Added PKG_BUILD_PARALLEL for faster compilation.

Fix license information.

Minor cleanups.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ath79