### PR TITLE
openfortivpn: add host up test back

### DIFF
--- a/net/openfortivpn/Makefile
+++ b/net/openfortivpn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openfortivpn
 PKG_VERSION:=1.14.1
-PKG_RELEASE:=2
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/adrienverge/openfortivpn/tar.gz/v$(PKG_VERSION)?


### PR DESCRIPTION
Maintainer: @lucize
Compile tested: netifd changes only 
Run tested: 19.07.3-ipq806x

Description:
PR: https://github.com/openwrt/packages/pull/12692 removed some functionality from the package that was critical for my setup. The openfortivpn package used to ping the server to see if it was up before trying to connect, then sleep for a time if it was unavailable. This prevented continually trying to connect to the down server.  I have added it back in. It is off by default with a new 'ping_check' flag to turn the functionality on.

Please be careful resolving merge conflicts with https://github.com/openwrt/packages/pull/12799 when merging.

cc  @qweaszxcdf 
