### PR TITLE
prometheus-node-exporter-lua: Add feature to listen on all local addre…

### DIFF
--- a/utils/prometheus-node-exporter-lua/files/etc/config/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/etc/config/prometheus-node-exporter-lua
@@ -1,4 +1,5 @@
 config prometheus-node-exporter-lua 'main'
+	option listen_all '0'
 	option listen_interface 'loopback'
 	option listen_ipv6 '0'
 	option listen_port '9100'

--- a/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
@@ -11,12 +11,13 @@ _log() {
 start_service() {
 	. /lib/functions/network.sh
 
-	local interface ipv6 port bind
+	local interface ipv6 port bind all
 
 	config_load prometheus-node-exporter-lua.main
 	config_get interface "main" listen_interface "loopback"
 	config_get_bool ipv6 "main" listen_ipv6 0
 	config_get port "main" listen_port 9100
+	config_get_bool all "main" listen_all 0
 
 	if [ "$interface" = "*" ]; then
 		[ "$ipv6" = 1 ] && bind="::" || bind="0.0.0.0"
@@ -38,6 +39,9 @@ start_service() {
 	procd_set_param command /usr/bin/prometheus-node-exporter-lua
 	procd_append_param command --bind ${bind}
 	procd_append_param command --port ${port}
+	if [ "$all" = 1 ]; then
+		procd_append_param command -a
+	fi
 
 	procd_set_param stdout 1
 	procd_set_param stderr 1

--- a/utils/prometheus-node-exporter-lua/files/usr/bin/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/bin/prometheus-node-exporter-lua
@@ -108,12 +108,17 @@ end
 
 -- Main program
 
+local listen_all = false
+
 for k,v in ipairs(arg) do
   if (v == "-p") or (v == "--port") then
     port = arg[k+1]
   end
   if (v == "-b") or (v == "--bind") then
     bind = arg[k+1]
+  end
+  if (v == "-a") or (v == "--listen-all") then
+    listen_all = true
   end
 end
 
@@ -128,7 +133,14 @@ end
 ls_fd:close()
 
 if port then
-  server = assert(socket.bind(bind, port))
+  if listen_all then
+    server = assert(socket.tcp6())
+    assert(server:setoption("ipv6-v6only",false))
+    assert(server:bind("::", port))
+    assert(server:listen())
+  else
+    server = assert(socket.bind(bind, port))
+  end
 
   while 1 do
     client = server:accept()


### PR DESCRIPTION
Description:
This PR introduces a new feature: When the 'listen_all'-option is true, the exporter listens on all local addresses, both IPv4 and IPv6.
The feature uses an TCP6-Socket with IPV6_V6ONLY disabled, therefore also accepting IPv4 connections.
If 'listen_all' is true, 'listen_interface' and 'listen_ipv6' are ignored.

Signed-off-by: Marvin Gaube <dev@marvingaube.de>

Maintainer: @champtar
Compile tested: -
Run tested: x86/64, OpenWrt 19.07-SNAPSHOT r11098+11-9cafcbe0bd, new features working, old behavior with 'listen_all' disabled is stable
