### PR TITLE
zmq: switch to building with CMake

### DIFF
--- a/libs/zmq/Makefile
+++ b/libs/zmq/Makefile
@@ -22,11 +22,11 @@ PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENCE.txt
 PKG_CPE_ID:=cpe:/a:zeromq:libzmq
 
-PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_REMOVE_FILES:=autogen.sh acinclude.m4 aclocal.m4
+CMAKE_BINARY_SUBDIR:=openwrt-build
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/libzmq/default
   TITLE:=ZeroMQ - Message Queue engine
@@ -58,35 +58,43 @@ define Package/libzmq-curve/description
  Includes CurveZMQ security by libsodium.
 endef
 
-# add extra configure flags here
-CONFIGURE_ARGS += \
-	--enable-static \
-	--enable-shared \
-	--with-pic \
-	--with-relaxed \
-	--without-documentation
+CMAKE_OPTIONS += \
+	-DA2X_EXECUTABLE=OFF \
+	-DASCIIDOC_EXECUTABLE=OFF \
+	-DCMAKE_SKIP_INSTALL_RPATH=ON \
+	-DZMQ_HAVE_SOCK_CLOEXEC=ON \
+	-DZMQ_HAVE_SO_KEEPALIVE=ON \
+	-DZMQ_HAVE_TCP_KEEPCNT=ON \
+	-DZMQ_HAVE_TCP_KEEPIDLE=ON \
+	-DZMQ_HAVE_TCP_KEEPINTVL=ON \
+	-DZMQ_HAVE_TCP_KEEPALIVE=ON \
+	-DENABLE_CURVE=ON \
+	-DENABLE_EVENTFD=ON \
+	-DPOLLER=epoll \
+	-DPYTHON_EXECUTABLE=OFF \
+	-DRT_LIBRARY=OFF \
+	-DWITH_OPENPGM=OFF \
+	-DZMQ_BUILD_TESTS=OFF
 
 ifeq ($(BUILD_VARIANT),curve)
-  CONFIGURE_ARGS+= --with-libsodium
+	CMAKE_OPTIONS += -DWITH_LIBSODIUM=ON
 else
-  CONFIGURE_ARGS+= --without-libsodium
+  	CMAKE_OPTIONS += -DWITH_LIBSODIUM=OFF
 endif
-
-TARGET_CXXFLAGS += -Wno-error=cpp
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/zmq.h $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/zmq_utils.h $(1)/usr/include
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libzmq.{a,so*} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libzmq.so* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libzmq.pc $(1)/usr/lib/pkgconfig/
 endef
 
 define Package/libzmq-nc/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libzmq.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libzmq.so $(1)/usr/lib/
 endef
 
 Package/libzmq-curve/install=$(Package/libzmq-nc/install)

--- a/libs/zmq/patches/010-cmake.patch
+++ b/libs/zmq/patches/010-cmake.patch
@@ -1,0 +1,20 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,6 +3,8 @@
+ cmake_minimum_required(VERSION 2.8.11)
+ project(ZeroMQ)
+ 
++include(FindPkgConfig)
++
+ option(WITH_OPENPGM "Build with support for OpenPGM" OFF)
+ 
+ if(APPLE)
+@@ -21,7 +23,7 @@ if (NOT ENABLE_CURVE)
+     message (STATUS "CURVE security is disabled")
+ 
+ elseif (WITH_LIBSODIUM)
+-    find_package (Sodium)
++    pkg_search_module (SODIUM REQUIRED libsodium)
+     if (SODIUM_FOUND)
+         message (STATUS "Using libsodium for CURVE security")
+         include_directories (${SODIUM_INCLUDE_DIRS})


### PR DESCRIPTION
Faster compilation.

Before:

time make package/zmq/compile -j 12
Executed in   24.98 secs   fish           external
   usr time   97.41 secs  263.00 micros   97.40 secs
   sys time   12.51 secs   34.00 micros   12.51 secs

After:

time make package/zmq/compile -j 12
Executed in   18.17 secs   fish           external
   usr time   85.22 secs  248.00 micros   85.22 secs
   sys time    9.23 secs   32.00 micros    9.23 secs

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @srdgame 
Compile tested: ath79