### PR TITLE
liblz4: convert to meson

### DIFF
--- a/libs/liblz4/Makefile
+++ b/libs/liblz4/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=liblz4
 PKG_VERSION:=1.9.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/lz4/lz4/tar.gz/v$(PKG_VERSION)?
@@ -18,12 +18,15 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/lz4-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Darik Horn <dajhorn@vanadac.com>
 
+PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-CMAKE_INSTALL:=1
-CMAKE_SOURCE_SUBDIR:=contrib/cmake_unofficial
+PKG_BUILD_DEPENDS:=meson/host
+PKG_CONFIG_DEPENDS:=CONFIG_PACKAGE_lz4
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/cmake.mk
+include ../../devel/meson/meson.mk
+
+MESON_BUILD_DIR:=$(PKG_BUILD_DIR)/contrib/meson/openwrt-build
 
 define Package/lz4/Default
   SUBMENU:=Compression
@@ -65,16 +68,27 @@ define Package/lz4/description
   This package provides the lz4 binaries.
 endef
 
-CMAKE_OPTIONS += \
-	-DCMAKE_INSTALL_MANDIR=/dev/null \
-	-DLZ4_BUILD_LEGACY_LZ4C=OFF
+MESON_ARGS += \
+	-Ddebug_level=0 \
+	-Dbacktrace=false \
+	-Dbin_programs=$(if $(CONFIG_PACKAGE_lz4),true,false) \
+	-Dbin_tests=false \
+	-Dbin_contrib=false \
+	-Dbin_examples=false \
+	-Db_lto=false
 
 ifeq ($(CONFIG_LZ4_OPTIMIZE_SPEED),y)
 	TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS)) -O3
 endif
 
-TARGET_CFLAGS += $(FPIC) -ffunction-sections -fdata-sections -flto
-TARGET_LDFLAGS += -Wl,--gc-sections
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liblz4.so* $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/liblz4.pc $(1)/usr/lib/pkgconfig
+endef
 
 define Package/liblz4/install
 	$(INSTALL_DIR) $(1)/usr/lib
@@ -83,7 +97,7 @@ endef
 
 define Package/lz4/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/{lz4,lz4cat,unlz4} $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/{lz4,lz4c,lz4cat,unlz4} $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,liblz4))


### PR DESCRIPTION
Faster compilation

Before:

Executed in   13.68 secs   fish           external
   usr time   12.51 secs    0.00 micros   12.51 secs
   sys time    1.78 secs  345.00 micros    1.78 secs

After:

Executed in    9.60 secs   fish           external
   usr time   10.66 secs  281.00 micros   10.66 secs
   sys time    1.39 secs   36.00 micros    1.39 secs

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dajhorn 
Compile tested: i386