### PR TITLE
mwan3: update to version 2.8.11

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.10
+PKG_VERSION:=2.8.11
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -10,17 +10,22 @@ boot() {
 	rc_procd start_service
 }
 
+# FIXME
+# fd 1000 is an inherited lock file descriptor for preventing concurrent
+# init script executions. Close it here to prevent the mwan3 daemon from
+# inheriting it further to avoid holding the lock indefinitely.
+
 reload_service() {
-	/usr/sbin/mwan3 restart
+	/usr/sbin/mwan3 restart 1000>&-
 }
 
 start_service() {
 	[ -n "${mwan3_boot}" ] && return 0
-	/usr/sbin/mwan3 start
+	/usr/sbin/mwan3 start 1000>&-
 }
 
 stop_service() {
-	/usr/sbin/mwan3 stop
+	/usr/sbin/mwan3 stop 1000>&-
 }
 
 service_triggers() {

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -43,13 +43,20 @@ mwan3_rtmon_ipv4()
 	local ret=1
 	local tbl=""
 
-	local tid
+	local tid family enabled
 
 	mkdir -p /tmp/mwan3rtmon
 	($IP4 route list table main  | grep -v "^default\|linkdown" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv4.main
 	while uci get mwan3.@interface[$idx] >/dev/null 2>&1 ; do
 		tid=$((idx+1))
-		[ "$(uci get mwan3.@interface[$idx].family)" = "ipv4" ] && {
+
+		family="$(uci -q get mwan3.@interface[$idx].family)"
+		[ -z "$family" ] && family="ipv4"
+
+		enabled="$(uci -q get mwan3.@interface[$idx].enabled)"
+		[ -z "$enabled" ] && enabled="0"
+
+		[ "$family" = "ipv4" ] && {
 			tbl=$($IP4 route list table $tid 2>/dev/null)
 			if echo "$tbl" | grep -q ^default; then
 				(echo "$tbl"  | grep -v "^default\|linkdown" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv4.$tid
@@ -61,7 +68,7 @@ mwan3_rtmon_ipv4()
 				done
 			fi
 		}
-		if [ "$(uci get mwan3.@interface[$idx].enabled)" = "1" ]; then
+		if [ "$enabled" = "1" ]; then
 			ret=0
 		fi
 		idx=$((idx+1))
@@ -78,13 +85,21 @@ mwan3_rtmon_ipv6()
 	local ret=1
 	local tbl=""
 
-	local tid
+	local tid family enabled
 
 	mkdir -p /tmp/mwan3rtmon
 	($IP6 route list table main  | grep -v "^default\|^::/0\|^fe80::/64\|^unreachable" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv6.main
 	while uci get mwan3.@interface[$idx] >/dev/null 2>&1 ; do
 		tid=$((idx+1))
-		[ "$(uci get mwan3.@interface[$idx].family)" = "ipv6" ] && {
+
+		family="$(uci -q get mwan3.@interface[$idx].family)"
+		# Set default family to ipv4 that is no mistake
+		[ -z "$family" ] && family="ipv4"
+
+		enabled="$(uci -q get mwan3.@interface[$idx].enabled)"
+		[ -z "$enabled" ] && enabled="0"
+
+		[ "$family" = "ipv6" ] && {
 			tbl=$($IP6 route list table $tid 2>/dev/null)
 			if echo "$tbl" | grep -q "^default\|^::/0"; then
 				(echo "$tbl"  | grep -v "^default\|^::/0\|^unreachable" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv6.$tid
@@ -96,7 +111,7 @@ mwan3_rtmon_ipv6()
 				done
 			fi
 		}
-		if [ "$(uci get mwan3.@interface[$idx].enabled)" = "1" ]; then
+		if [ "$enabled" = "1" ]; then
 			ret=0
 		fi
 		idx=$((idx+1))

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -202,6 +202,13 @@ mwan3_unlock() {
 }
 
 mwan3_lock_clean() {
+	for pid in $(pgrep -f "lock /var/run/mwan3.lock"); do
+		kill -TERM "$pid" > /dev/null 2>&1
+	done
+	sleep 1
+	for pid in $(pgrep -f "lock /var/run/mwan3.lock"); do
+		kill -KILL "$pid" > /dev/null 2>&1
+	done
 	rm -rf /var/run/mwan3.lock
 }
 


### PR DESCRIPTION
Maintainer: me
Compile tested: only script changes
Run tested: x86_64, APU3, OpenWrt master

Description:

- [Commit](https://github.com/openwrt/packages/commit/058a2b6f3057d849cbe4f2c4fda258d32d6da2fd) fixes #12807 
- Add online time and uptime to detail output
- Remove pending lock process on mwan3 stop
- [Commit](https://github.com/openwrt/packages/commit/bcd13ba95cd5b96d04e490b576faab54404cbf69) fixes output `uci: Entry not found`