### PR TITLE
redis: update to version 6.0.6

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
-PKG_VERSION:=6.0.5
+PKG_VERSION:=6.0.6
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=42cf86a114d2a451b898fcda96acd4d01062a7dbaaad2801d9164a36f898f596
+PKG_HASH:=12ad49b163af5ef39466e8d2f7d212a58172116e5b441eebecb4e6ca22363d94
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates redis to version 6.0.6. Update urgency is set to MODERATE. Full [changelog](https://raw.githubusercontent.com/redis/redis/6.0/00-RELEASENOTES?_ga=2.214076247.1707543580.1595323660-344270163.1595323660)

Runtested with build in benchmark
