### PR TITLE
tor: update to version 0.4.3.6 (security fix)

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.3.5
-PKG_RELEASE:=2
+PKG_VERSION:=0.4.3.6
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=616a0e4ae688d0e151d46e3e4258565da4d443d1ddbd316db0b90910e2d5d868
+PKG_HASH:=6a2d0637d4e514be2ec574723a05065245cce51da78a21cec1dc831be5ccac62
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION


maintainer: @tripolar 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates to version 0.4.3.6. It fixes CVE-2020- 15572
[Changelog](https://gitweb.torproject.org/tor.git/plain/ChangeLog?h=tor-0.4.3.6)

Runtested with torsocks

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>

