### PR TITLE
[OpenWrt 19.07] tor: update to version 0.4.2.8 (security fix)

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.2.7
+PKG_VERSION:=0.4.2.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=06a1d835ddf382f6bca40a62e8fb40b71b2f73d56f0d53523c8bd5caf9b3026d
+PKG_HASH:=75a8a9cd7faf7ebe67c4bf27acf27e82619a498f5916976d015acab85047dbab
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: Turris Omnia (TOS5) HBL, OpenWrt 19.07
Run tested: Turis Omnia (TOS5) HBL, OpenWrt 19.07

Description:

Fixes
CVE-2020-15572

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>


