### PR TITLE
docker-ce: add default bridge to openwrt uci backend

### DIFF
--- a/utils/docker-ce/Makefile
+++ b/utils/docker-ce/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-ce
 PKG_VERSION:=19.03.12
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=components/cli/LICENSE components/engine/LICENSE
 

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -122,6 +122,9 @@ process_config() {
 	json_add_array "registry-mirrors"
 	config_list_foreach globals registry_mirror json_add_array_string
 	json_close_array
+	json_add_array "hosts"
+	config_list_foreach globals hosts json_add_array_string
+	json_close_array
 
 	mkdir -p /tmp/dockerd
 	json_dump > "$DOCKERD_CONF"

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -3,14 +3,96 @@
 USE_PROCD=1
 START=25
 
+EXTRA_COMMANDS="uciadd ucidel"
+EXTRA_HELP="\
+	uciadd  Add default bridge configuration to network and firewall uci config
+	ucidel  Delete default bridge configuration from network and firewall uci config"
+
 DOCKERD_CONF="/tmp/dockerd/daemon.json"
+
+uci_quiet() {
+	uci -q ${@} >/dev/null
+}
 
 json_add_array_string() {
 	json_add_string "" "$1"
 }
 
+uciupdate() {
+	local net="$1"
+
+	uci -q get network.docker >/dev/null || {
+		logger -t "dockerd-init" -p warn "No network uci config section for docker default bridge (docker0) found"
+		return
+	}
+
+	[ -z "$net" ] && {
+		logger -t "dockerd-init" -p notice "Removing network uci config options for docker default bridge (docker0)"
+		uci_quiet delete network.docker.netmask
+		uci_quiet delete network.docker.ipaddr
+		uci_quiet commit network
+		return
+	}
+
+	eval "$(ipcalc.sh "$net")"
+	logger -t "dockerd-init" -p notice "Updating network uci config option \"$net\" for docker default bridge (docker0)"
+	uci_quiet set network.docker.netmask="$NETMASK"
+	uci_quiet set network.docker.ipaddr="$IP"
+	uci_quiet commit network
+}
+
+uciadd() {
+	/etc/init.d/dockerd running && {
+		echo "Please stop dockerd service first"
+		exit 0
+	}
+
+	# Add network interface
+	if ! uci -q get network.docker >/dev/null; then
+		logger -t "dockerd-init" -p notice "Adding docker default bridge to network uci config (docker0)"
+		uci_quiet add network interface
+		uci_quiet rename network.@interface[-1]="docker"
+		uci_quiet set network.docker.ifname="docker0"
+		uci_quiet set network.docker.proto="static"
+		uci_quiet set network.docker.auto="0"
+		uci_quiet commit network
+	fi
+
+	# Add firewall zone
+	if ! uci -q get firewall.docker >/dev/null; then
+		logger -t "dockerd-init" -p notice "Adding docker default bridge firewall zone (docker0)"
+		uci_quiet add firewall zone
+		uci_quiet rename firewall.@zone[-1]="docker"
+		uci_quiet set firewall.docker.network="docker"
+		uci_quiet set firewall.docker.input="REJECT"
+		uci_quiet set firewall.docker.output="ACCEPT"
+		uci_quiet set firewall.docker.forward="REJECT"
+		uci_quiet set firewall.docker.name="docker"
+		uci_quiet commit firewall
+	fi
+
+	reload_config
+}
+
+ucidel() {
+	/etc/init.d/dockerd running && {
+		echo "Please stop dockerd service first"
+		exit 0
+	}
+
+	logger -t "dockerd-init" -p notice "Deleting docker default bridge network from network uci config (docker0)"
+	uci_quiet delete network.docker
+	uci_quiet commit network
+
+	logger -t "dockerd-init" -p notice "Deleting docker default bridge firewall zone from firewall uci config (docker0)"
+	uci_quiet delete firewall.docker
+	uci_quiet commit firewall
+
+	reload_config
+}
+
 process_config() {
-	local alt_config_file data_root log_level
+	local alt_config_file data_root log_level bip
 
 	rm -f "$DOCKERD_CONF"
 
@@ -30,17 +112,21 @@ process_config() {
 
 	config_get data_root globals data_root "/opt/docker/"
 	config_get log_level globals log_level "warn"
+	config_get bip globals bip ""
 
 	. /usr/share/libubox/jshn.sh
 	json_init
 	json_add_string "data-root" "$data_root"
 	json_add_string "log-level" "$log_level"
+	[ -z "$bip" ] || json_add_string "bip" "$bip"
 	json_add_array "registry-mirrors"
 	config_list_foreach globals registry_mirror json_add_array_string
 	json_close_array
 
 	mkdir -p /tmp/dockerd
 	json_dump > "$DOCKERD_CONF"
+
+	uciupdate "$bip"
 }
 
 start_service() {
@@ -77,19 +163,25 @@ ip4tables_remove_nat() {
 }
 
 ip4tables_remove_filter() {
-	iptables -t filter -D FORWARD -j DOCKER-USER
+	# Chain DOCKER-USER is only present,
+	# if bip option is NOT set, so >/dev/null 2>&1
+	iptables -t filter -D FORWARD -j DOCKER-USER >/dev/null 2>&1
 	iptables -t filter -D FORWARD -j DOCKER-ISOLATION-STAGE-1
 	iptables -t filter -D FORWARD -o docker0 -j DOCKER
 
 	iptables -t filter -F DOCKER
 	iptables -t filter -F DOCKER-ISOLATION-STAGE-1
 	iptables -t filter -F DOCKER-ISOLATION-STAGE-2
-	iptables -t filter -F DOCKER-USER
+	# Chain DOCKER-USER is only present,
+	# if bip option is NOT set, so >/dev/null 2>&1
+	iptables -t filter -F DOCKER-USER >/dev/null 2>&1
 
 	iptables -t filter -X DOCKER
 	iptables -t filter -X DOCKER-ISOLATION-STAGE-1
 	iptables -t filter -X DOCKER-ISOLATION-STAGE-2
-	iptables -t filter -X DOCKER-USER
+	# Chain DOCKER-USER is only present,
+	# if bip option is NOT set, so >/dev/null 2>&1
+	iptables -t filter -X DOCKER-USER >/dev/null 2>&1
 }
 
 ip4tables_remove() {
@@ -98,5 +190,8 @@ ip4tables_remove() {
 }
 
 stop_service() {
-	ip4tables_remove
+	if /etc/init.d/dockerd running; then
+		service_stop "/usr/bin/dockerd"
+		ip4tables_remove
+	fi
 }

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -18,6 +18,11 @@ json_add_array_string() {
 	json_add_string "" "$1"
 }
 
+boot() {
+	uciadd
+	rc_procd start_service
+}
+
 uciupdate() {
 	local net="$1"
 

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -120,7 +120,7 @@ process_config() {
 	json_add_string "log-level" "$log_level"
 	[ -z "$bip" ] || json_add_string "bip" "$bip"
 	json_add_array "registry-mirrors"
-	config_list_foreach globals registry_mirror json_add_array_string
+	config_list_foreach globals registry_mirrors json_add_array_string
 	json_close_array
 	json_add_array "hosts"
 	config_list_foreach globals hosts json_add_array_string

--- a/utils/docker-ce/files/etc/config/dockerd
+++ b/utils/docker-ce/files/etc/config/dockerd
@@ -7,5 +7,5 @@ config globals 'globals'
 	# If the bip option is changed, dockerd must be restarted.
 	# A service reload is not enough.
 	option bip "172.18.01./24"
-#	list registry_mirror "https://<my-docker-mirror-host>"
-#	list registry_mirror "https://hub.docker.com"
+#	list registry_mirrors "https://<my-docker-mirror-host>"
+#	list registry_mirrors "https://hub.docker.com"

--- a/utils/docker-ce/files/etc/config/dockerd
+++ b/utils/docker-ce/files/etc/config/dockerd
@@ -3,5 +3,6 @@ config globals 'globals'
 #	option alt_config_file "/etc/docker/daemon.json"
 	option data_root "/opt/docker/"
 	option log_level "warn"
+	option hosts "unix://var/run/docker.sock"
 #	list registry_mirror "https://<my-docker-mirror-host>"
 #	list registry_mirror "https://hub.docker.com"

--- a/utils/docker-ce/files/etc/config/dockerd
+++ b/utils/docker-ce/files/etc/config/dockerd
@@ -4,5 +4,8 @@ config globals 'globals'
 	option data_root "/opt/docker/"
 	option log_level "warn"
 	option hosts "unix://var/run/docker.sock"
+	# If the bip option is changed, dockerd must be restarted.
+	# A service reload is not enough.
+	option bip "172.18.01./24"
 #	list registry_mirror "https://<my-docker-mirror-host>"
 #	list registry_mirror "https://hub.docker.com"


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503 
Compile tested: only script change
Run tested: x86_64, APU3, OpenWrt master, startup test

Description:

- I have added the **bip** docker option so we could customize the default bridge. This was descriped by @jmarcet in his [comment](https://github.com/openwrt/packages/pull/12556#issuecomment-648866347).
- I just added the default bridge handling, with the new init.d targets uciadd and ucidel.
- I also replaced the SIGHUB on config change with a start and stop of the whole dockerd service, so the new bip config option get applied.
