### PR TITLE
openfortivpn: use a more 'OpenWRT' paradigm throughout the code

### DIFF
--- a/net/openfortivpn/Makefile
+++ b/net/openfortivpn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openfortivpn
 PKG_VERSION:=1.14.1
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/adrienverge/openfortivpn/tar.gz/v$(PKG_VERSION)?

--- a/net/openfortivpn/files/14-openforticlient
+++ b/net/openfortivpn/files/14-openforticlient
@@ -8,6 +8,8 @@ for i in $networks; do
     iface_success=$?
     [ $? -eq 0 ] && [ $INTERFACE == "$iface" ] && {
         logger -t "openfortivpnhotplug" "$ACTION on $INTERFACE to bring up $i"
+	load_on_boot=$(uci get network.${i}.auto 2>/dev/null)
+	[ -n "$load_on_boot" ] && [ "$load_on_boot" -eq 0 ] && continue
         json_load "$(ifstatus $i)"
         json_get_var autostart autostart
 	[ "$autostart" -eq 0 ] && {

--- a/net/openfortivpn/files/14-openforticlient
+++ b/net/openfortivpn/files/14-openforticlient
@@ -1,20 +1,27 @@
 #!/bin/sh
+. /lib/functions.sh
 . /usr/share/libubox/jshn.sh
 [ "$ACTION" != ifup ] && exit
 
-networks=$(uci show network | sed "s/network.\([^.]*\).proto='openfortivpn'/\1/;t;d")
-for i in $networks; do
-    iface=$(uci get "network.${i}.iface_name")
-    iface_success=$?
-    [ $? -eq 0 ] && [ $INTERFACE == "$iface" ] && {
-        logger -t "openfortivpnhotplug" "$ACTION on $INTERFACE to bring up $i"
-	load_on_boot=$(uci get network.${i}.auto 2>/dev/null)
-	[ -n "$load_on_boot" ] && [ "$load_on_boot" -eq 0 ] && continue
-        json_load "$(ifstatus $i)"
+handle_network()
+{
+    config_get iface $1 iface_name
+    [ $INTERFACE != "$iface" ] && return
+    [ $(config_get $1 proto) != "openfortivpn" ] && return
+
+    config_get_bool load_on_boot $1 auto
+    [ -n "$load_on_boot" ] && [ "$load_on_boot" -eq 0 ] && return
+    status="$(ifstatus $1)" || continue
+        json_load "$status"
         json_get_var autostart autostart
+        logger -t "openfortivpnhotplug" "$ACTION on $INTERFACE to bring up $1. Autostart is $autostart"
 	[ "$autostart" -eq 0 ] && {
-            logger -t "openfortivpnhotplug" "auto-start was false. bringing $i up"
-            ubus call network.interface up "{ \"interface\" : \"$i\" }"
+            logger -t "openfortivpnhotplug" "auto-start was false. bringing $1 up"
+            ubus call network.interface up "{ \"interface\" : \"$1\" }"
         }
-    }
-done
+}
+
+
+config_load network
+config_foreach handle_network interface
+exit 0

--- a/net/openfortivpn/files/openfortivpn-wrapper
+++ b/net/openfortivpn/files/openfortivpn-wrapper
@@ -21,7 +21,7 @@ trap_with_arg() {
 }
 
 func_trap() {
-    logger "openfortivpn-wrapper[$$]" "sending signal ${1}"
+    logger "openfortivpn-wrapper[$$]" "$config: sending signal ${1}"
     killed=1
     kill -${1} $child 2>/dev/null
 }

--- a/net/openfortivpn/files/openfortivpn-wrapper
+++ b/net/openfortivpn/files/openfortivpn-wrapper
@@ -4,10 +4,40 @@
 # file from cmd and to daemonize
 
 # $1 password file
-# $2... are passed to openconnect
+# $2 is the config name
+# $3... are passed to openconnect
 
 test -z "$1" && exit 1
 
-pwfile=$1
-shift
-exec /usr/sbin/openfortivpn "$@" < $pwfile
+pwfile=$1; shift
+config=$1; shift
+killed=0
+
+trap_with_arg() {
+    func="$1" ; shift
+    for sig ; do
+        trap "$func $sig" "$sig"
+    done
+}
+
+func_trap() {
+    logger "openfortivpn-wrapper[$$]" "sending signal ${1}"
+    killed=1
+    kill -${1} $child 2>/dev/null
+}
+
+trap_with_arg func_trap INT TERM KILL
+
+
+start_time=$(date '+%s')
+/usr/sbin/openfortivpn "$@" < $pwfile 2>/dev/null &
+child=$!
+wait $child || {
+    [ "$killed" = 1 ] && exit 0
+    current_time=$(date '+%s')
+    elapsed=$(($current_time-$start_time))
+    . /lib/netifd/netifd-proto.sh
+    proto_notify_error "$config" "Failed to connect after $elapsed seconds."
+    proto_block_restart "$config"
+    exit 1
+}

--- a/net/openfortivpn/files/openfortivpn.sh
+++ b/net/openfortivpn/files/openfortivpn.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 . /lib/functions.sh
+. /lib/functions/network.sh
 . ../netifd-proto.sh
 init_proto "$@"
 
@@ -36,17 +37,14 @@ proto_openfortivpn_setup() {
 
 
         [ -n "$iface_name" ] && {
-            json_load "$(ifstatus $iface_name)"
-            json_get_var iface_device_name l3_device
-            json_get_var iface_device_up up
-        }
-
-        [ "$iface_device_up" -eq 1 ] || {
-            msg="$iface_name is not up $iface_device_up"
-            logger -t "openfortivpn" "$config: $msg"
-            proto_notify_error "$config" "$msg"
-            proto_block_restart "$config"
-            exit 1
+	    network_get_device iface_device_name "$iface_name"
+            network_is_up "$iface_name" ] || {
+		msg="$iface_name is not up $iface_device_up"
+		logger -t "openfortivpn" "$config: $msg"
+		proto_notify_error "$config" "$msg"
+		proto_block_restart "$config"
+		exit 1
+	    }
         }
 
         server_ip=$(resolveip -t 10 "$server")

--- a/net/openfortivpn/files/openfortivpn.sh
+++ b/net/openfortivpn/files/openfortivpn.sh
@@ -134,7 +134,6 @@ ip-down-script /lib/netifd/ppp-down
 mru 1354"  > $callfile
         append_args "--pppd-call=openfortivpn/$config"
 
-        proto_export INTERFACE="$ifname"
         logger -p 6 -t openfortivpn "$config: executing 'openfortivpn $cmdline'"
 
         eval "proto_run_command '$config' /usr/sbin/openfortivpn-wrapper '$pwfile' '$config' $cmdline"

--- a/net/openfortivpn/files/openfortivpn.sh
+++ b/net/openfortivpn/files/openfortivpn.sh
@@ -104,7 +104,7 @@ proto_openfortivpn_setup() {
         [ -n "$username" ] && append_args -u "$username"
         [ -n "$password" ] && {
                 umask 077
-                mkdir -p /var/etc
+                mkdir -p '/var/etc/openfortivpn'
                 pwfile="/var/etc/openfortivpn/$config.passwd"
                 echo "$password" > "$pwfile"
         }
@@ -112,7 +112,7 @@ proto_openfortivpn_setup() {
         [ -n "$local_ip" ] || local_ip=192.0.2.1
         [ -e '/etc/ppp/peers' ] || mkdir -p '/etc/ppp/peers'
         [ -e '/etc/ppp/peers/openfortivpn' ] || {
-            ln -s -T '/var/etc/openfortivpn/peers' '/etc/ppp/peers/openfortivpn'
+            ln -s -T '/var/etc/openfortivpn/peers' '/etc/ppp/peers/openfortivpn' 2> /dev/null
             mkdir -p '/var/etc/openfortivpn/peers'
         }
 

--- a/net/openfortivpn/files/openfortivpn.sh
+++ b/net/openfortivpn/files/openfortivpn.sh
@@ -20,18 +20,19 @@ proto_openfortivpn_init_config() {
         proto_config_add_string "password"
         proto_config_add_string "trusted_cert"
         proto_config_add_string "remote_status_check"
-        proto_config_add_int "peerdns"
-        proto_config_add_int "metric"
+	proto_config_add_defaults
         no_device=1
         available=1
 }
 
 proto_openfortivpn_setup() {
-        local config="$1"
-        local msg
+	local config="$1"
 
+	local msg ifname serverip pwfile callfile default_route_arg
+	local host server port iface_name local_ip username password trusted_cert \
+	              remote_status_check defaultroute peerdns metric
         json_get_vars host server port iface_name local_ip username password trusted_cert \
-                      remote_status_check peerdns metric
+	              remote_status_check defaultroute peerdns metric
 
         ifname="vpn-$config"
 
@@ -87,8 +88,8 @@ proto_openfortivpn_setup() {
 
 
         [ -n "$port" ] && port=":$port"
-        [ -z "$peerdns" ] && peerdns=1
-
+	[ -z "$peerdns" ] && peerdns=1
+	[ "$defaultroute" = 1 ] && defaultroute_arg="defaultroute" || defaultroute_arg=nodefaultroute
         append_args "$server$port" --pppd-ifname="$ifname" --use-syslog  -c /dev/null
         append_args "--set-dns=0"
         append_args "--no-routes"
@@ -123,7 +124,7 @@ noauth
 default-asyncmap
 nopcomp
 receive-all
-defaultroute
+$defaultroute_arg
 nodetach
 ipparam $config
 lcp-max-configure 40

--- a/net/openfortivpn/files/openfortivpn.sh
+++ b/net/openfortivpn/files/openfortivpn.sh
@@ -137,7 +137,7 @@ mru 1354"  > $callfile
         proto_export INTERFACE="$ifname"
         logger -p 6 -t openfortivpn "$config: executing 'openfortivpn $cmdline'"
 
-        eval "proto_run_command '$config' /usr/sbin/openfortivpn-wrapper '$pwfile' $cmdline"
+        eval "proto_run_command '$config' /usr/sbin/openfortivpn-wrapper '$pwfile' '$config' $cmdline"
 
 }
 

--- a/net/openfortivpn/files/openfortivpn.sh
+++ b/net/openfortivpn/files/openfortivpn.sh
@@ -20,7 +20,6 @@ proto_openfortivpn_init_config() {
         proto_config_add_string "password"
         proto_config_add_string "trusted_cert"
         proto_config_add_string "remote_status_check"
-	proto_config_add_defaults
         no_device=1
         available=1
 }
@@ -28,12 +27,12 @@ proto_openfortivpn_init_config() {
 proto_openfortivpn_setup() {
 	local config="$1"
 
-	local msg ifname ip server_ip pwfile callfile default_route_arg
+	local msg ifname ip server_ip pwfile callfile
 
 	local host server port iface_name local_ip username password trusted_cert \
-	              remote_status_check defaultroute peerdns metric
+	              remote_status_check
         json_get_vars host server port iface_name local_ip username password trusted_cert \
-	              remote_status_check defaultroute peerdns metric
+	              remote_status_check
 
         ifname="vpn-$config"
 
@@ -89,12 +88,10 @@ proto_openfortivpn_setup() {
 
 
         [ -n "$port" ] && port=":$port"
-	[ -z "$peerdns" ] && peerdns=1
-	[ "$defaultroute" = 1 ] && defaultroute_arg="defaultroute" || defaultroute_arg=nodefaultroute
         append_args "$server$port" --pppd-ifname="$ifname" --use-syslog  -c /dev/null
         append_args "--set-dns=0"
         append_args "--no-routes"
-        append_args "--pppd-use-peerdns=$peerdns"
+        append_args "--pppd-use-peerdns=1"
 
         [ -n "$iface_name" ] && {
             append_args "--ifname=$iface_device_name"
@@ -125,7 +122,6 @@ noauth
 default-asyncmap
 nopcomp
 receive-all
-$defaultroute_arg
 nodetach
 ipparam $config
 lcp-max-configure 40

--- a/net/openfortivpn/files/openfortivpn.sh
+++ b/net/openfortivpn/files/openfortivpn.sh
@@ -18,7 +18,7 @@ proto_openfortivpn_init_config() {
         proto_config_add_string "username"
         proto_config_add_string "password"
         proto_config_add_string "trusted_cert"
-        proto_config_add_string "remote_status_check"	
+        proto_config_add_string "remote_status_check"
         proto_config_add_int "peerdns"
         proto_config_add_int "metric"
         no_device=1
@@ -30,7 +30,7 @@ proto_openfortivpn_setup() {
         local msg
 
         json_get_vars host server port iface_name local_ip username password trusted_cert \
-	              remote_status_check peerdns metric
+                      remote_status_check peerdns metric
 
         ifname="vpn-$config"
 
@@ -89,7 +89,7 @@ proto_openfortivpn_setup() {
 
 
         [ -n "$port" ] && port=":$port"
-	[ -z "$peerdns" ] && peerdns=1
+        [ -z "$peerdns" ] && peerdns=1
 
         append_args "$server$port" --pppd-ifname="$ifname" --use-syslog  -c /dev/null
         append_args "--set-dns=0"


### PR DESCRIPTION
Maintainer: @lucize 
Compile tested: no compiled changes
Run tested: 19.07.3

Description:
In the initial implementation, I had done many things in non-standard and potentially broken ways, such as calling 'uci' to get configuration parameters (which would cause it to operate on uncommitted configuration changes), or 'ifstatus' to get interface status. This PR cleans a lot of that up to use the built in openwrt function libraries where appropriate.

I also enhanced the hotplug script to not try to start interfaces that were set to not autostart.

I improved the wrapper script to block restarting of the interface if authentication fails due to a bad password, which prevents the openwrt from continually trying to login to the fortigate with bad credentials.