### PR TITLE
freeradius3: add missing conffiles to Makefile

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
 PKG_VERSION:=release_3_0_21
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/archive
@@ -52,8 +52,12 @@ endef
 
 define Package/freeradius3/conffiles
 /etc/freeradius3/clients.conf
+/etc/freeradius3/policy.d/accounting
+/etc/freeradius3/policy.d/filter
+/etc/freeradius3/proxy.conf
 /etc/freeradius3/radiusd.conf
-/etc/freeradius3/sites/default
+/etc/freeradius3/sites-available/default
+/etc/freeradius3/sites-enabled/default
 endef
 
 define Package/freeradius3-common


### PR DESCRIPTION
Config files
/etc/freeradius3/policy.d/accounting
/etc/freeradius3/policy.d/filter
/etc/freeradius3/proxy.conf
/etc/freeradius3/sites-available/default
and link
/etc/freeradius3/sites-enabled/default
are in the freeradius3 package and are mentioned in the main config file
/etc/freeradius3/radiusd.conf
Thus, they must be explicitly specified in the Makefile.

File
/etc/freeradius3/sites/default
is not included in the package, is not created during installation,
is not mentioned in the main config file and should therefore be excluded
from the Makefile.

Signed-off-by: Alexey Dobrovolsky <dobrovolskiy.alexey@gmail.com>