### PR TITLE
zerotier: disable pie support

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
 PKG_VERSION:=1.4.6
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
@@ -18,7 +18,9 @@ PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
 PKG_LICENSE:=BSL 1.1
 PKG_LICENSE_FILES:=LICENSE.txt
 
+PKG_ASLR_PIE:=0
 PKG_BUILD_PARALLEL:=1
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/zerotier


### PR DESCRIPTION
The Makefile is already patched for it. But PKG_ASLR_PIE still needs
to be disabled.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mwarning 
Compile tested: ath79

Fixes: https://github.com/openwrt/packages/issues/12482