### PR TITLE
yggdrasil: Ygg-over-ygg bugfix

### DIFF
--- a/net/yggdrasil/Makefile
+++ b/net/yggdrasil/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yggdrasil
 PKG_VERSION:=0.3.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v$(PKG_VERSION)?

--- a/net/yggdrasil/patches/100-drop-log-ygg-over-ygg.patch
+++ b/net/yggdrasil/patches/100-drop-log-ygg-over-ygg.patch
@@ -1,0 +1,33 @@
+diff --git a/src/yggdrasil/tcp.go b/src/yggdrasil/tcp.go
+index 9cca419..45f93a5 100644
+--- a/src/yggdrasil/tcp.go
++++ b/src/yggdrasil/tcp.go
+@@ -25,6 +25,7 @@ import (
+ 
+ 	"golang.org/x/net/proxy"
+ 
++	"github.com/yggdrasil-network/yggdrasil-go/src/address"
+ 	"github.com/yggdrasil-network/yggdrasil-go/src/util"
+ )
+ 
+@@ -386,6 +387,19 @@ func (t *tcp) handler(sock net.Conn, incoming bool, options interface{}, upgrade
+ 		local, _, _ = net.SplitHostPort(sock.LocalAddr().String())
+ 		remote, _, _ = net.SplitHostPort(sock.RemoteAddr().String())
+ 	}
++	localIP := net.ParseIP(local)
++	if localIP = localIP.To16(); localIP != nil {
++		var laddr address.Address
++		var lsubnet address.Subnet
++		copy(laddr[:], localIP)
++		copy(lsubnet[:], localIP)
++		if laddr.IsValid() || lsubnet.IsValid() {
++			// The local address is with the network address/prefix range
++			// This would route ygg over ygg, which we don't want
++			t.link.core.log.Debugln("Dropping ygg-tunneled connection", local, remote)
++			return
++		}
++	}
+ 	force := net.ParseIP(strings.Split(remote, "%")[0]).IsLinkLocalUnicast()
+ 	link, err := t.link.core.link.create(&stream, name, proto, local, remote, incoming, force)
+ 	if err != nil {
+


### PR DESCRIPTION
Maintainer: @wfleurant 
Compile tested: added patch to feeds/packages build from source (trunk) from Jul 8
Run tested: aarch64_cortex-a72 (bcm27xx/bcm2711)

> make package/yggdrasil/{clean,compile} V=99
> Applying ./patches/100-drop-log-ygg-over-ygg.patch using plaintext: 
> patching file src/yggdrasil/tcp.go

Description: don't allow ygg tcp connections to/from a local ygg address 
