### PR TITLE
augeas & python-augeas: add new package

### DIFF
--- a/lang/python/python-augeas/Makefile
+++ b/lang/python/python-augeas/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-augeas
+PKG_VERSION:=1.1.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=python-augeas
+PKG_HASH:=5194a49e86b40ffc57055f73d833f87e39dce6fce934683e7d0d5bbb8eff3b8c
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=COPYING
+
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:=cffi  # cffi>=1.0.0
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-augeas
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Python bindings for Augeas
+  URL:=http://augeas.net
+  DEPENDS:=+python3-light +python3-cffi +augeas
+endef
+
+define Package/python3-augeas/description
+  Pure python bindings for Augeas.
+endef
+
+$(eval $(call Py3Package,python3-augeas))
+$(eval $(call BuildPackage,python3-augeas))
+$(eval $(call BuildPackage,python3-augeas-src))

--- a/lang/python/python-augeas/patches/001-backport-ffi-fix.patch
+++ b/lang/python/python-augeas/patches/001-backport-ffi-fix.patch
@@ -1,0 +1,95 @@
+From 712c2028568df7760bc98d95577e35709078bfea Mon Sep 17 00:00:00 2001
+From: Jeffery To <jeffery.to@gmail.com>
+Date: Sun, 8 Nov 2020 21:51:09 +0800
+Subject: [PATCH] Use CFFI in out-of-line API mode (#49)
+
+Currently, ffi.py is called during setup to generate augeas.py; this
+file would normally be used for out-of-line ABI mode. ffi.py is also
+imported at run-time, instead of the generated augeas.py, and used in
+in-line ABI mode.
+
+This changes usage of CFFI to out-of-line API mode (CFFI's "main mode of
+usage"): ffi.py is called during setup to generate _augeas.abi3.so (a C
+extension module); this generated module is imported at run-time.
+
+With this change, the headers/development files for augeas (i.e.
+libaugeas-dev on Debian, augeas-devel on Fedora, etc.) and the C
+compiler are required for build/setup. (These were not necessary
+previously.)
+
+Closes https://github.com/hercules-team/python-augeas/issues/48.
+---
+ augeas/__init__.py |  2 +-
+ augeas/ffi.py      | 27 ++++++++++++++++++++++-----
+ setup.py           |  1 +
+ 3 files changed, 24 insertions(+), 6 deletions(-)
+
+diff --git a/augeas/__init__.py b/augeas/__init__.py
+index 0fc0d96..4af0200 100644
+--- a/augeas/__init__.py
++++ b/augeas/__init__.py
+@@ -32,7 +32,7 @@
+ 
+ from sys import version_info as _pyver
+ 
+-from augeas.ffi import ffi, lib
++from _augeas import ffi, lib
+ 
+ __author__ = "Nathaniel McCallum <nathaniel@natemccallum.com>"
+ __credits__ = """Jeff Schroeder <jeffschroeder@computer.org>
+diff --git a/augeas/ffi.py b/augeas/ffi.py
+index fdd8d1c..98b3175 100644
+--- a/augeas/ffi.py
++++ b/augeas/ffi.py
+@@ -1,9 +1,28 @@
++import os
++import subprocess
++
+ from cffi import FFI
+ 
++def get_include_dirs():
++    XML2_CONFIG = os.environ.get('XML2_CONFIG', 'xml2-config')
++    PKG_CONFIG = os.environ.get('PKG_CONFIG', 'pkg-config')
++    try:
++        stdout = subprocess.check_output([XML2_CONFIG, '--cflags'])
++    except (OSError, subprocess.CalledProcessError):
++        try:
++            stdout = subprocess.check_output([PKG_CONFIG, '--cflags', 'libxml-2.0'])
++        except (OSError, subprocess.CalledProcessError):
++            stdout = b''
++    cflags = stdout.decode('utf-8').split()
++    return [cflag[2:] for cflag in cflags if cflag.startswith('-I')]
++
+ ffi = FFI()
+-ffi.set_source("augeas",
+-               None,
+-               libraries=['augeas'])
++ffi.set_source("_augeas",
++               """
++               #include <augeas.h>
++               """,
++               libraries=['augeas'],
++               include_dirs=get_include_dirs())
+ 
+ ffi.cdef("""
+ typedef struct augeas augeas;
+@@ -59,7 +78,5 @@
+ void free(void *);
+ """)
+ 
+-lib = ffi.dlopen("augeas")
+-
+ if __name__ == "__main__":
+     ffi.compile(verbose=True)
+diff --git a/setup.py b/setup.py
+index 65026c1..6c4265e 100755
+--- a/setup.py
++++ b/setup.py
+@@ -22,6 +22,7 @@
+       setup_requires=["cffi>=1.0.0"],
+       cffi_modules=["augeas/ffi.py:ffi"],
+       install_requires=["cffi>=1.0.0"],
++      zip_safe=False,
+       url="http://augeas.net/",
+       classifiers=[
+           "Programming Language :: Python :: 2.7",

--- a/utils/augeas/Makefile
+++ b/utils/augeas/Makefile
@@ -1,0 +1,93 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=augeas
+PKG_VERSION:=1.12.0
+PKG_RELEASE=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://download.augeas.net/
+PKG_HASH:=321942c9cc32185e2e9cb72d0a70eea106635b50269075aca6714e3ec282cb87
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/augeas
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=A configuration editing tool
+  URL:=http://augeas.net
+  DEPENDS:=+libxml2 +libreadline +libncurses
+endef
+
+define Package/augeas/description
+  Augeas is a configuration editing tool.
+  It parses configuration files in their
+  native formats and transforms them into a tree.
+  Configuration changes are made by manipulating this
+  tree and saving it back into native config files.
+endef
+
+define Package/augeas-lenses
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Augeas lenses
+  URL:=http://augeas.net
+  DEPENDS:=+augeas
+endef
+
+define Package/augeas-lense/description
+  Set of Augeas lenses.
+endef
+
+define Package/augeas-lenses-tests
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Augeas lenses tests
+  URL:=http://augeas.net
+  DEPENDS:=+augeas
+endef
+
+define Package/augeas-lenses-tests/description
+  Set of tests for official Augeas lenses.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/* $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/augeas/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
+endef
+
+define Package/augeas-lenses/install
+	$(INSTALL_DIR) $(1)/usr/share/augeas/lenses/dist
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/augeas/lenses/dist/* $(1)/usr/share/augeas/lenses/dist/
+endef
+
+define Package/augeas-lenses-tests/install
+	$(INSTALL_DIR) $(1)/usr/share/augeas/lenses/dist/tests
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/augeas/lenses/dist/tests/* $(1)/usr/share/augeas/lenses/dist/tests
+endef
+
+$(eval $(call BuildPackage,augeas))
+$(eval $(call BuildPackage,augeas-lenses))
+$(eval $(call BuildPackage,augeas-lenses-tests))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (OS5), OpenWrt master
Run tested: Turris Omnia(TOS5), OpenWrt master

Description:
This PR adds a new package agueas and python-augeas. It parses configuration files in their native formats and transforms them into a tree. 
The main reason for adding this into OpenWrt is, that it's used by our DNS testing tool deckard (https://gitlab.nic.cz/knot/deckard/-/tree/answer_checker.py) which should be pushed to OpenWrt in future. 
