### PR TITLE
netdata: update to version 1.23.2

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
-PKG_VERSION:=1.22.1
+PKG_VERSION:=1.23.2
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
@@ -18,7 +18,7 @@ PKG_CPE_ID:=cpe:/a:my-netdata:netdata
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netdata/netdata/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6efd785eab82f98892b4b4017cadfa4ce1688985915499bc75f2f888765a3446
+PKG_HASH:=b6dd13292e0b1fb4137b1f7c0dc3d7c5e8a1bf408b82c2b8394f3751800e0eb5
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Maintainer: me and @diizzyy 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
follow-up https://github.com/openwrt/packages/pull/12912
- Update to version [1.23.2](https://github.com/netdata/netdata/releases/tag/v1.23.2).

Proof of run test:
![Screenshot from 2020-07-24 15-42-43](https://user-images.githubusercontent.com/4096468/88397596-7648fb80-cdc4-11ea-88f5-d75c551264c3.png)
