### PR TITLE
spoofer: Update to 1.4.6

### DIFF
--- a/net/spoofer/Makefile
+++ b/net/spoofer/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 The Regents of the University of California
+# Copyright (C) 2018-2020 The Regents of the University of California
 #
 # This is free software, licensed under the GNU General Public License v3.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=spoofer
-PKG_VERSION:=1.4.5
+PKG_VERSION:=1.4.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.caida.org/projects/spoofer/downloads
-PKG_HASH:=5f045be7269d93efb1ee7918e923e7695c9a36d192c3ada932bb6ae7fba8d15e
+PKG_HASH:=fb814d0beaccc48a155e55bb1e7057520d0fe0584dbcc4c0a89f5cee55d0eaf1
 
 PKG_MAINTAINER:=Ken Keys <spoofer-info@caida.org>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -37,7 +37,7 @@ define Package/spoofer/description
 The spoofer client is part of a system to measure the Internet's
 resistance to packets with a spoofed (forged) source IP address.
 
-This package comes bundled with a small certificate file that allows
+This package comes bundled with small certificate files that allow
 secure communication with the spoofer server without depending on
 the large ca-certificates package.  But if the server's private
 certificate ever changes, it will be necessary to either install the
@@ -61,6 +61,7 @@ define Package/spoofer/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openwrt-files/initscript $(1)/etc/init.d/spoofer
 	$(INSTALL_DIR) $(1)/usr/share/spoofer
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/gd_bundle.crt $(1)/usr/share/spoofer
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/letsencrypt_bundle.pem.txt $(1)/usr/share/spoofer
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/openwrt-files/spoofer-lib.sh $(1)/usr/share/spoofer
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86-64, OpenWrt 19.07
Run tested: x86-64, OpenWrt 19.07, ran spoofer

Description: upstream version 1.4.6; includes a new CA file for compatibility with upcoming change to spoofer server SSL cert

Signed-off-by: Ken Keys <kkeys@caida.org>
