### PR TITLE
netwhere: fix compilation with newer libmicrohttpd

### DIFF
--- a/utils/netwhere/Makefile
+++ b/utils/netwhere/Makefile
@@ -2,18 +2,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netwhere
 PKG_VERSION:=0.9
-PKG_RELEASE:=1
-PKG_LICENSE:=MIT
+PKG_RELEASE:=2
 
 PKG_SOURCE:=netwhere-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/benhsmith/netwhere/archive/$(PKG_VERSION)/
 PKG_HASH:=94a672bdcd9d4455b85429dddd81ffc778e0b26fe87af19ad75c27858ec9dbe2
 
-PKG_BUILD_DEPENDS:=boost
-
 PKG_MAINTAINER:=Ben Smith <le.ben.smith@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
 
-CMAKE_INSTALL:=1
+PKG_BUILD_DEPENDS:=boost
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -22,7 +21,7 @@ define Package/netwhere
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Netwhere
-  MAINTAINER:=Ben Smith
+  URL:=https://github.com/benhsmith/netwhere
   DEPENDS:=+libtins +libmicrohttpd
 endef
 

--- a/utils/netwhere/patches/010-libmicrohttpd.patch
+++ b/utils/netwhere/patches/010-libmicrohttpd.patch
@@ -1,0 +1,27 @@
+--- a/webservice.hpp
++++ b/webservice.hpp
+@@ -38,13 +38,13 @@ class WebService {
+   MHD_Daemon* daemon;
+   Functor functor;
+  
+-  static int on_request(void * cls, struct MHD_Connection * connection, const char * url, const char * method, const char * version,
++  static enum MHD_Result on_request(void * cls, struct MHD_Connection * connection, const char * url, const char * method, const char * version,
+ 			    const char * upload_data, size_t * upload_data_size,
+ 			    void ** ptr);
+ };
+ 
+ template <typename Functor>
+-int WebService<Functor>::on_request(void * cls,
++enum MHD_Result WebService<Functor>::on_request(void * cls,
+ 		    struct MHD_Connection * connection,
+ 		    const char * url,
+ 		    const char * method,
+@@ -53,7 +53,7 @@ int WebService<Functor>::on_request(void * cls,
+ 		    size_t * upload_data_size,
+                     void ** ptr) {
+   static int dummy;
+-  int ret;
++  enum MHD_Result ret;
+ 
+   if (std::string("GET") != method)
+     return MHD_NO; /* unexpected method */


### PR DESCRIPTION
API change.

Cleaned up Makefile.

Fixed license information.

Remove pointless CMAKE_INSTALL. This is not needed in InstallDev.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @benhsmith 
Compile tested: arc700