### PR TITLE
log4cplus: apply cmake options to the host

### DIFF
--- a/libs/log4cplus/Makefile
+++ b/libs/log4cplus/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=log4cplus
 PKG_VERSION:=2.0.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
@@ -42,11 +42,14 @@ define Package/log4cplus/description
   configuration. It is modeled after the Java log4j API.
 endef
 
-CMAKE_OPTIONS += \
+OPTIONS:= \
 	-DLOG4CPLUS_BUILD_LOGGINGSERVER:BOOL=OFF \
 	-DLOG4CPLUS_BUILD_TESTING:BOOL=OFF \
 	-DUNICODE:BOOL=OFF \
 	-DWITH_ICONV:BOOL=OFF
+
+CMAKE_HOST_OPTIONS += $(OPTIONS)
+CMAKE_OPTIONS += $(OPTIONS)
 
 TARGET_CFLAGS += -flto
 TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed


### PR DESCRIPTION
loggingserver was getting built with a bad link path. Instead of fixing
it, just disable it as is done on the target.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @rosysong @hbl0307106015
Compile tested: fedora 32