### PR TITLE
openvswitch: don't build for kernel 4.14

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -58,7 +58,7 @@ ifeq ($(if $(call ovs_kmod_is_intree,$(1)),$(ovs_kmod_intree_not_supported)),)
      CATEGORY:=Kernel modules
      SUBMENU:=Network Support
      TITLE:=$(ovs_kmod_$(1)_title)
-     DEPENDS:=$(ovs_kmod_$(1)_depends) $(if $(call ovs_kmod_is_intree,$(1)),@IPV6 @DEVEL)
+     DEPENDS:=$(ovs_kmod_$(1)_depends) !@LINUX_4_14 $(if $(call ovs_kmod_is_intree,$(1)),@IPV6 @DEVEL)
      PROVIDES:=$(call ovs_kmod_package_provides,$(1))
      KCONFIG:=$(ovs_kmod_$(1)_kconfig)
      FILES:=$(ovs_kmod_$(1)_files)


### PR DESCRIPTION
Maintainer: @yousong 
Compile tested: ar71xx-generic
Run tested: 

Description:

Bulding OpenVSwitch currently fails for kernel 4.14. As 4.14 support is
set to be removed in the near future, don't build OpenVSwitch for kernel
4.14.

```
datapath/linux/geneve.c: In function 'geneve_get_v6_dst':
datapath/linux/geneve.c:966:17: error: 'const struct ipv6_stub' has no member named 'ipv6_dst_lookup'; did you mean 'ipv6_dst_lookup_flow'?
  if (ipv6_stub->ipv6_dst_lookup(geneve->net, gs6->sock->sk, &dst, fl6)) {
                 ^~~~~~~~~~~~~~~
                 ipv6_dst_lookup_flow
```