### PR TITLE
openvswitch: adds new UCI section ovs_switch

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -17,7 +17,7 @@ include ./openvswitch.mk
 #
 PKG_NAME:=openvswitch
 PKG_VERSION:=$(ovs_version)
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openvswitch.org/releases/
 PKG_HASH:=dd5f727427e36cab22bdeae61529d8c8fccacc53d968cfa7658f7f935ddda531

--- a/net/openvswitch/README.md
+++ b/net/openvswitch/README.md
@@ -60,3 +60,20 @@ E.g. replace in-tree datapath module with upstream version
 	opkg remove --force-depends kmod-openvswitch-intree
 	opkg install kmod-openvswitch
 	ovs-ctl force-reload-kmod
+
+# UCI configuration options
+
+There are 4 config section types in package openvswitch:
+ovs ovn_northd, ovn_controller & ovs_bridge.
+
+Each of these supports a disabled option, which should be 
+set to 0 to launch the respective daemons.
+
+The ovs_bridge section also supports the options below,
+for initialising a virtual bridge with an OpenFlow controller.
+
+| Name       | Type    | Required | Default                        | Description                                                |
+|------------|---------|----------|--------------------------------|------------------------------------------------------------|
+| disabled   | boolean | no       | 0                              | If set to true, disable initialisation of the named bridge |
+| name       | string  | no       | Inherits UCI config block name | The name of the switch in the OVS daemon                   |
+| controller | string  | no       | (none)                         | The endpoint of an OpenFlow controller for this bridge     |

--- a/net/openvswitch/files/openvswitch.config
+++ b/net/openvswitch/files/openvswitch.config
@@ -6,3 +6,8 @@ config ovn_northd north
 
 config ovn_controller controller
 	option disabled 1
+
+config ovs_bridge
+	option disabled 1
+	option name 'my-bridge'
+	option controller 'tcp:192.168.0.1'

--- a/net/openvswitch/files/openvswitch.init
+++ b/net/openvswitch/files/openvswitch.init
@@ -36,6 +36,8 @@ ovs_action() {
 	for cfgtype in ovs ovn_northd ovn_controller; do
 		config_foreach "ovs_xx" "$cfgtype" "$action" "$cfgtype"
 	done
+
+	config_foreach ovs_bridge_init "ovs_bridge"
 }
 
 ovs_xx() {
@@ -51,7 +53,7 @@ ovs_xx() {
 		status|stop) ;;
 		*)
 			config_get_bool disabled "$cfg" disabled 0
-			[ "$disabled" -le 0 ] || return
+			[ "$disabled" == "0" ] || return
 			;;
 	esac
 
@@ -64,4 +66,22 @@ ovs_xx() {
 			"$ovn_ctl" "${action}_${cfgtype#ovn_}"
 			;;
 	esac
+}
+
+ovs_bridge_init() {
+	local cfg="$1"
+
+	local disabled
+	local name
+	local controller
+
+	config_get_bool disabled "$cfg" disabled 0
+	[ "$disabled" == "0" ] || return
+
+	config_get name "$cfg" name $cfg
+	ovs-vsctl --may-exist add-br "$name"
+
+	config_get controller "$cfg" controller
+	[ -n "$controller" ] && \
+		ovs-vsctl set-controller "$name" "$controller"
 }


### PR DESCRIPTION
This new config section in package openvswitch
supports creating a named bridge, and setting
its' OpenFlow controller end-point.

An example config is included in /rom/etc/config/openvswitch

Signed-off-by: Simon Kinane <skinane@fb.com>

Maintainer: me
Compile tested: (mips, GL-MT300Nv2, OpenWrt 18.06.1)
Run tested: (mips, GL-MT300Nv2, OpenWrt version, add-br name; set controller; set alt-controller; set controller:port)

Description:
