### PR TITLE
v4l-utils: bring back getsubopt patch

### DIFF
--- a/libs/libv4l/Makefile
+++ b/libs/libv4l/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v4l-utils
 PKG_VERSION:=1.20.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.linuxtv.org/downloads/v4l-utils

--- a/libs/libv4l/patches/030-getsubopt.patch
+++ b/libs/libv4l/patches/030-getsubopt.patch
@@ -1,0 +1,28 @@
+--- a/utils/v4l2-ctl/v4l2-ctl-common.cpp
++++ b/utils/v4l2-ctl/v4l2-ctl-common.cpp
+@@ -785,15 +785,17 @@ static bool parse_subset(char *optarg)
+ 
+ static bool parse_next_subopt(char **subs, char **value)
+ {
+-	static char *const subopts[] = {
+-	    NULL
+-	};
+-	int opt = getsubopt(subs, subopts, value);
++	char *p = *subs;
++	*value = *subs;
+ 
+-	if (opt < 0 || *value)
+-		return false;
+-	fprintf(stderr, "Missing suboption value\n");
+-	return true;
++	while (*p && *p != ',')
++		p++;
++
++	if (*p)
++		*p++ = '\0';
++
++	*subs = p;
++	return false;
+ }
+ 
+ void common_cmd(const std::string &media_bus_info, int ch, char *optarg)


### PR DESCRIPTION
During the update to 1.20.0, this patch was mistakenly removed.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: ath79

Fixes: https://github.com/openwrt/packages/issues/12930