### PR TITLE
libbpf: new package

### DIFF
--- a/libs/libbpf/Makefile
+++ b/libs/libbpf/Makefile
@@ -1,0 +1,56 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libbpf
+PKG_VERSION:=0.0.9
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=https://github.com/libbpf/libbpf/archive/
+PKG_SOURCE_URL_FILE:=v$(PKG_VERSION).tar.gz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_URL_FILE)
+PKG_HASH:=c216c13b48f5fbd870a9b10a9cb747e0e6063f547e327c4d5a0688713e26a1a4
+
+PKG_MAINTAINER:=Thomas Hebb <tommyhebb@gmail.com>
+PKG_LICENSE:=LGPL-2.1-only OR BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE.LPGL-2.1 LICENSE.BSD-2-Clause
+
+MAKE_PATH:=src
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libbpf
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Standalone build of libbpf from the Linux kernel
+  URL:=https://github.com/libbpf/libbpf
+  ABI_VERSION:=0
+  DEPENDS:=+libelf +zlib
+endef
+
+define Package/libbpf/description
+  libbpf is a library, developed in the Linux kernel source tree, that contains
+  a large amount of common code needed to load eBPF programs into the kernel
+  and communicate with those programs.
+endef
+
+# "install" uses the host uname to determine where to place libraries (lib or
+# lib64), so we don't use it. We still need to use the upstream set of headers,
+# though, so we do use "install_headers".
+define Build/Install
+	$(call Build/Install/Default,install_headers)
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/src/libbpf.{a,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_BUILD_DIR)/src/libbpf.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libbpf/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/src/libbpf.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libbpf))

--- a/libs/libbpf/patches/0001-check-reallocarray.sh-Use-the-same-compiler-Make-doe.patch
+++ b/libs/libbpf/patches/0001-check-reallocarray.sh-Use-the-same-compiler-Make-doe.patch
@@ -1,0 +1,53 @@
+From e3f7b84b045952d4c47ce18ddcc8f2c9895d0a52 Mon Sep 17 00:00:00 2001
+Message-Id: <e3f7b84b045952d4c47ce18ddcc8f2c9895d0a52.1595836014.git.tommyhebb@gmail.com>
+From: Thomas Hebb <tommyhebb@gmail.com>
+Date: Mon, 27 Jul 2020 00:30:26 -0700
+Subject: [PATCH] check-reallocarray.sh: Use the same compiler Make does
+
+Currently we hardcode "gcc", which means we get a bogus result any time
+a non-default CC is passed to Make. In fact, it's bogus even when CC is
+not explicitly set, since Make's default is "cc", which isn't
+necessarily the same as "gcc".
+
+Fix the issue by passing the compiler to use to check-reallocarray.sh.
+
+Signed-off-by: Thomas Hebb <tommyhebb@gmail.com>
+---
+ scripts/check-reallocarray.sh | 3 ++-
+ src/Makefile                  | 2 +-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/scripts/check-reallocarray.sh b/scripts/check-reallocarray.sh
+index 74b4a75..d3044ad 100755
+--- a/scripts/check-reallocarray.sh
++++ b/scripts/check-reallocarray.sh
+@@ -1,4 +1,5 @@
+ #!/bin/sh
++# Usage: check-reallocarray.sh cc_path [cc_args...]
+ 
+ tfile=$(mktemp /tmp/test_reallocarray_XXXXXXXX.c)
+ ofile=${tfile%.c}.o
+@@ -13,6 +14,6 @@ int main(void)
+ }
+ EOL
+ 
+-gcc $tfile -o $ofile >/dev/null 2>&1
++"$@" $tfile -o $ofile >/dev/null 2>&1
+ if [ $? -ne 0 ]; then echo "FAIL"; fi
+ /bin/rm -f $tfile $ofile
+diff --git a/src/Makefile b/src/Makefile
+index d0308c3..bb70867 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -10,7 +10,7 @@ TOPDIR = ..
+ INCLUDES := -I. -I$(TOPDIR)/include -I$(TOPDIR)/include/uapi
+ ALL_CFLAGS := $(INCLUDES)
+ 
+-FEATURE_REALLOCARRAY := $(shell $(TOPDIR)/scripts/check-reallocarray.sh)
++FEATURE_REALLOCARRAY := $(shell $(TOPDIR)/scripts/check-reallocarray.sh $(CC))
+ ifneq ($(FEATURE_REALLOCARRAY),)
+ 	ALL_CFLAGS += -DCOMPAT_NEED_REALLOCARRAY
+ endif
+-- 
+2.27.0
+


### PR DESCRIPTION
**Maintainer**: me
**Compile tested**: ARMv7, Linksys WRT1900AC v1, OpenWrt r13952-ac9730c495
**Run tested**: ARMv7, Linksys WRT1900AC v1, 19.07.3 r11063-85e04e9f46

**Description**:
Although OpenWrt kernels have eBPF support compiled in, there's currently no easy way to install userspace eBPF tooling. This package starts to change that. libbpf is a library, developed in the Linux kernel source tree, that contains a large amount of common code needed to load eBPF programs into the kernel and communicate with those programs.  Custom loaders for specific eBPF use cases are often linked against it, and so it's useful to have in OpenWrt even though there are not yet any packages that depend on it.

This package uses the out-of-tree mirror of libbpf at https://github.com/libbpf/libbpf for the reasons described in that mirror's README.

**Tests done**:
Did an absolutely horrible hack job on bpftool, which is a user of libbpf also developed in the kernel tree, to get it to cross compile. Tested both statically and dynamically linking it to libbpf built from this package, and verified that I can load eBPF programs and query eBPF maps successfully.