### PR TITLE
mwan3: backport version 2.8.12 to stable branch openwrt-19.07

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.11
+PKG_VERSION:=2.8.12
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.8
+PKG_VERSION:=2.8.9
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.10
+PKG_VERSION:=2.8.11
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.9
+PKG_VERSION:=2.8.10
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/etc/config/mwan3
+++ b/net/mwan3/files/etc/config/mwan3
@@ -139,7 +139,12 @@ config rule 'https'
 	option proto 'tcp'
 	option use_policy 'balanced'
 
-config rule 'default_rule'
+config rule 'default_rule_v4'
 	option dest_ip '0.0.0.0/0'
 	option use_policy 'balanced'
+	option family 'ipv4'
 
+config rule 'default_rule_v6'
+	option dest_ip '::/0'
+	option use_policy 'balanced'
+	option family 'ipv6'

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -9,13 +9,13 @@
 [ -n "$INTERFACE" ] || exit 2
 
 if [ "$ACTION" == "ifup" ]; then
-        [ -n "$DEVICE" ] || exit 3
+	[ -n "$DEVICE" ] || exit 3
 fi
 
 mwan3_lock "$ACTION" "$INTERFACE"
 config_load mwan3
 config_get_bool enabled globals 'enabled' '0'
-[ ${enabled} -gt 0 ] || {
+[ "${enabled}" -gt 0 ] || {
 	mwan3_unlock "$ACTION" "$INTERFACE"
 	exit 0
 }
@@ -24,14 +24,14 @@ mwan3_init
 mwan3_set_connected_iptables
 mwan3_set_custom_ipset
 
-config_get enabled $INTERFACE enabled 0
 config_get initial_state $INTERFACE initial_state "online"
-[ "${enabled}" == "1" ] || {
+config_get_bool enabled $INTERFACE 'enabled' '0'
+[ "${enabled}" -eq 1 ] || {
 	mwan3_unlock "$ACTION" "$INTERFACE"
 	exit 0
 }
 
-if [ "$ACTION" == "ifup" ]; then
+if [ "$ACTION" = "ifup" ]; then
 	config_get family $INTERFACE family ipv4
 	if [ "$family" = "ipv4" ]; then
 		ubus call network.interface.${INTERFACE}_4 status &>/dev/null
@@ -72,7 +72,7 @@ case "$ACTION" in
 		mwan3_create_iface_iptables $INTERFACE $DEVICE
 		mwan3_create_iface_rules $INTERFACE $DEVICE
 		mwan3_create_iface_route $INTERFACE $DEVICE
-		if [ ${running} -eq 1 -a "${status}" = "online" ]; then
+		if [ "${running}" -eq 1 ] && [ "${status}" = "online" ]; then
 			$LOG notice "Starting tracker on interface $INTERFACE (${DEVICE:-unknown})"
 			mwan3_set_iface_hotplug_state $INTERFACE "online"
 			mwan3_track $INTERFACE $DEVICE "online" "$src_ip"

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -12,19 +12,24 @@ if [ "$ACTION" == "ifup" ]; then
         [ -n "$DEVICE" ] || exit 3
 fi
 
+mwan3_lock "$ACTION" "$INTERFACE"
 config_load mwan3
 config_get_bool enabled globals 'enabled' '0'
-[ ${enabled} -gt 0 ] || exit 0
+[ ${enabled} -gt 0 ] || {
+	mwan3_unlock "$ACTION" "$INTERFACE"
+	exit 0
+}
 
-mwan3_lock "$ACTION" "$INTERFACE"
 mwan3_init
 mwan3_set_connected_iptables
 mwan3_set_custom_ipset
-mwan3_unlock "$ACTION" "$INTERFACE"
 
 config_get enabled $INTERFACE enabled 0
 config_get initial_state $INTERFACE initial_state "online"
-[ "$enabled" == "1" ] || exit 0
+[ "${enabled}" == "1" ] || {
+	mwan3_unlock "$ACTION" "$INTERFACE"
+	exit 0
+}
 
 if [ "$ACTION" == "ifup" ]; then
 	config_get family $INTERFACE family ipv4
@@ -58,7 +63,6 @@ else
 	running=1
 fi
 
-mwan3_lock "$ACTION" "$INTERFACE"
 $LOG notice "Execute "$ACTION" event on interface $INTERFACE (${DEVICE:-unknown})"
 
 case "$ACTION" in

--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3
@@ -8,17 +8,17 @@ mwan3_lock "$ACTION" "mwan3rtmon"
 
 config_load mwan3
 config_get_bool enabled globals 'enabled' '0'
-[ ${enabled} -gt 0 ] || {
+[ "${enabled}" -gt 0 ] || {
 	mwan3_unlock "$ACTION" "mwan3rtmon"
 	exit 0
 }
 
-if [ "$ACTION" == "ifup" ]; then
+if [ "$ACTION" = "ifup" ]; then
 	mwan3_rtmon
 fi
 
-config_get enabled $INTERFACE enabled 0
-[ "${enabled}" = "0" ] || {
+config_get_bool enabled "$INTERFACE" 'enabled' '0'
+[ "${enabled}" -eq 0 ] || {
 	mwan3_flush_conntrack "$INTERFACE" "$ACTION"
 }
 

--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3
@@ -4,19 +4,24 @@
 . /lib/functions/network.sh
 . /lib/mwan3/mwan3.sh
 
+mwan3_lock "$ACTION" "mwan3rtmon"
+
 config_load mwan3
 config_get_bool enabled globals 'enabled' '0'
-[ ${enabled} -gt 0 ] || exit 0
+[ ${enabled} -gt 0 ] || {
+	mwan3_unlock "$ACTION" "mwan3rtmon"
+	exit 0
+}
 
 if [ "$ACTION" == "ifup" ]; then
-	mwan3_lock "$ACTION" "mwan3rtmon"
 	mwan3_rtmon
-	mwan3_unlock "$ACTION" "mwan3rtmon"
 fi
 
 config_get enabled $INTERFACE enabled 0
 [ "${enabled}" = "0" ] || {
 	mwan3_flush_conntrack "$INTERFACE" "$ACTION"
 }
+
+mwan3_unlock "$ACTION" "mwan3rtmon"
 
 exit 0

--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
@@ -2,13 +2,25 @@
 
 [ -f "/etc/mwan3.user" ] && {
 	. /lib/functions.sh
+	. /lib/mwan3/mwan3.sh
+
+	mwan3_lock "$ACTION" "user"
 
 	config_load mwan3
 	config_get_bool enabled globals 'enabled' '0'
-	[ ${enabled} -gt 0 ] || exit 0
+	[ ${enabled} -gt 0 ] || {
+		mwan3_unlock "$ACTION" "user"
+		exit 0
+	}
 
 	config_get enabled "$INTERFACE" enabled 0
-	[ "${enabled}" = "1" ] || exit 0
+	[ "${enabled}" = "1" ] || {
+		mwan3_unlock "$ACTION" "user"
+		exit 0
+	}
+
+	mwan3_unlock "$ACTION" "user"
+
 	env -i ACTION="$ACTION" INTERFACE="$INTERFACE" DEVICE="$DEVICE" \
 		/bin/sh /etc/mwan3.user
 }

--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
@@ -8,13 +8,13 @@
 
 	config_load mwan3
 	config_get_bool enabled globals 'enabled' '0'
-	[ ${enabled} -gt 0 ] || {
+	[ "${enabled}" -gt 0 ] || {
 		mwan3_unlock "$ACTION" "user"
 		exit 0
 	}
 
-	config_get enabled "$INTERFACE" enabled 0
-	[ "${enabled}" = "1" ] || {
+	config_get_bool enabled "$INTERFACE" enabled 0
+	[ "${enabled}" -eq 1 ] || {
 		mwan3_unlock "$ACTION" "user"
 		exit 0
 	}

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -10,17 +10,22 @@ boot() {
 	rc_procd start_service
 }
 
+# FIXME
+# fd 1000 is an inherited lock file descriptor for preventing concurrent
+# init script executions. Close it here to prevent the mwan3 daemon from
+# inheriting it further to avoid holding the lock indefinitely.
+
 reload_service() {
-	/usr/sbin/mwan3 restart
+	/usr/sbin/mwan3 restart 1000>&-
 }
 
 start_service() {
 	[ -n "${mwan3_boot}" ] && return 0
-	/usr/sbin/mwan3 start
+	/usr/sbin/mwan3 start 1000>&-
 }
 
 stop_service() {
-	/usr/sbin/mwan3 stop
+	/usr/sbin/mwan3 stop 1000>&-
 }
 
 service_triggers() {

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -518,6 +518,8 @@ mwan3_create_iface_route()
 		network_get_gateway${V_} via "$1"
 	fi
 
+	( [ -z "$via" ] || [ "$via" = "0.0.0.0" ] || [ "$via" = "::" ] ) && unset via
+
 	network_get_metric metric "$1"
 
 	$IP route flush table "$id"

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -672,7 +672,9 @@ mwan3_track()
 
 	for pid in $(pgrep -f "mwan3track $1 $2"); do
 		kill -TERM "$pid" > /dev/null 2>&1
-		sleep 1
+	done
+	sleep 1
+	for pid in $(pgrep -f "mwan3track $1 $2"); do
 		kill -KILL "$pid" > /dev/null 2>&1
 	done
 	if [ -n "$track_ips" ]; then

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -1146,8 +1146,6 @@ mwan3_report_policies_v6()
 
 mwan3_report_connected_v4()
 {
-	local address
-
 	if [ -n "$($IPT4 -S mwan3_connected 2> /dev/null)" ]; then
 		$IPS -o save list mwan3_connected_v4 | grep add | cut -d " " -f 3
 	fi
@@ -1155,8 +1153,6 @@ mwan3_report_connected_v4()
 
 mwan3_report_connected_v6()
 {
-	local address
-
 	if [ -n "$($IPT6 -S mwan3_connected 2> /dev/null)" ]; then
 		$IPS -o save list mwan3_connected_v6 | grep add | cut -d " " -f 3
 	fi

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -192,7 +192,7 @@ mwan3_get_iface_id()
 	mwan3_get_id()
 	{
 		let _iface_count++
-		[ "$1" == "$_iface" ] && _tmp=$_iface_count
+		[ "$1" = "$_iface" ] && _tmp=$_iface_count
 	}
 	config_foreach mwan3_get_id interface
 	export "$1=$_tmp"
@@ -396,7 +396,7 @@ mwan3_create_iface_iptables()
 
 	[ -n "$id" ] || return 0
 
-	if [ "$family" == "ipv4" ]; then
+	if [ "$family" = "ipv4" ]; then
 		$IPS -! create mwan3_connected list:set
 
 		if ! $IPT4 -S mwan3_ifaces_in &> /dev/null; then
@@ -428,7 +428,7 @@ mwan3_create_iface_iptables()
 			-j mwan3_iface_in_$1
 	fi
 
-	if [ "$family" == "ipv6" ]; then
+	if [ "$family" = "ipv6" ]; then
 		$IPS -! create mwan3_connected_v6 hash:net family inet6
 
 		if ! $IPT6 -S mwan3_ifaces_in &> /dev/null; then
@@ -462,7 +462,7 @@ mwan3_delete_iface_iptables()
 {
 	config_get family $1 family ipv4
 
-	if [ "$family" == "ipv4" ]; then
+	if [ "$family" = "ipv4" ]; then
 
 		$IPT4 -D mwan3_ifaces_in \
 			-m mark --mark 0x0/$MMX_MASK \
@@ -471,7 +471,7 @@ mwan3_delete_iface_iptables()
 		$IPT4 -X mwan3_iface_in_$1 &> /dev/null
 	fi
 
-	if [ "$family" == "ipv6" ]; then
+	if [ "$family" = "ipv6" ]; then
 
 		$IPT6 -D mwan3_ifaces_in \
 			-m mark --mark 0x0/$MMX_MASK \
@@ -490,7 +490,7 @@ mwan3_create_iface_route()
 
 	[ -n "$id" ] || return 0
 
-	if [ "$family" == "ipv4" ]; then
+	if [ "$family" = "ipv4" ]; then
 		if ubus call network.interface.${1}_4 status &>/dev/null; then
 			network_get_gateway route_args ${1}_4
 		else
@@ -513,7 +513,7 @@ mwan3_create_iface_route()
 		mwan3_rtmon_ipv4
 	fi
 
-	if [ "$family" == "ipv6" ]; then
+	if [ "$family" = "ipv6" ]; then
 		if ubus call network.interface.${1}_6 status &>/dev/null; then
 			network_get_gateway6 route_args ${1}_6
 		else
@@ -546,11 +546,11 @@ mwan3_delete_iface_route()
 
 	[ -n "$id" ] || return 0
 
-	if [ "$family" == "ipv4" ]; then
+	if [ "$family" = "ipv4" ]; then
 		$IP4 route flush table $id
 	fi
 
-	if [ "$family" == "ipv6" ]; then
+	if [ "$family" = "ipv6" ]; then
 		$IP6 route flush table $id
 	fi
 }
@@ -564,7 +564,7 @@ mwan3_create_iface_rules()
 
 	[ -n "$id" ] || return 0
 
-	if [ "$family" == "ipv4" ]; then
+	if [ "$family" = "ipv4" ]; then
 
 		while [ -n "$($IP4 rule list | awk '$1 == "'$(($id+1000)):'"')" ]; do
 			$IP4 rule del pref $(($id+1000))
@@ -578,7 +578,7 @@ mwan3_create_iface_rules()
 		$IP4 rule add pref $(($id+2000)) fwmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK lookup $id
 	fi
 
-	if [ "$family" == "ipv6" ]; then
+	if [ "$family" = "ipv6" ]; then
 
 		while [ -n "$($IP6 rule list | awk '$1 == "'$(($id+1000)):'"')" ]; do
 			$IP6 rule del pref $(($id+1000))
@@ -602,7 +602,7 @@ mwan3_delete_iface_rules()
 
 	[ -n "$id" ] || return 0
 
-	if [ "$family" == "ipv4" ]; then
+	if [ "$family" = "ipv4" ]; then
 
 		while [ -n "$($IP4 rule list | awk '$1 == "'$(($id+1000)):'"')" ]; do
 			$IP4 rule del pref $(($id+1000))
@@ -613,7 +613,7 @@ mwan3_delete_iface_rules()
 		done
 	fi
 
-	if [ "$family" == "ipv6" ]; then
+	if [ "$family" = "ipv6" ]; then
 
 		while [ -n "$($IP6 rule list | awk '$1 == "'$(($id+1000)):'"')" ]; do
 			$IP6 rule del pref $(($id+1000))
@@ -698,7 +698,7 @@ mwan3_set_policy()
 
 	config_get family $iface family ipv4
 
-	if [ "$family" == "ipv4" ]; then
+	if [ "$family" = "ipv4" ]; then
 
 		if [ "$(mwan3_get_iface_hotplug_state $iface)" = "online" ]; then
 			if [ "$metric" -lt "$lowest_metric_v4" ]; then
@@ -746,7 +746,7 @@ mwan3_set_policy()
 		fi
 	fi
 
-	if [ "$family" == "ipv6" ]; then
+	if [ "$family" = "ipv6" ]; then
 
 		if [ "$(mwan3_get_iface_hotplug_state $iface)" = "online" ]; then
 			if [ "$metric" -lt "$lowest_metric_v6" ]; then
@@ -858,7 +858,7 @@ mwan3_set_sticky_iptables()
 
 	for iface in $($IPT4 -S $policy | cut -s -d'"' -f2 | awk '{print $1}'); do
 
-		if [ "$iface" == "$1" ]; then
+		if [ "$iface" = "$1" ]; then
 
 			mwan3_get_iface_id id $1
 
@@ -929,11 +929,11 @@ mwan3_set_user_iptables_rule()
 	fi
 
 	if [ -n "$use_policy" ]; then
-		if [ "$use_policy" == "default" ]; then
+		if [ "$use_policy" = "default" ]; then
 			policy="MARK --set-xmark $MMX_DEFAULT/$MMX_MASK"
-		elif [ "$use_policy" == "unreachable" ]; then
+		elif [ "$use_policy" = "unreachable" ]; then
 			policy="MARK --set-xmark $MMX_UNREACHABLE/$MMX_MASK"
-		elif [ "$use_policy" == "blackhole" ]; then
+		elif [ "$use_policy" = "blackhole" ]; then
 			policy="MARK --set-xmark $MMX_BLACKHOLE/$MMX_MASK"
 		else
 			if [ "$sticky" -eq 1 ]; then
@@ -989,8 +989,8 @@ mwan3_set_user_iptables_rule()
 			fi
 		fi
 		for IPT in "$IPT4" "$IPT6"; do
-			[ "$family" == "ipv4" ] && [ "$IPT" == "$IPT6" ] && continue
-			[ "$family" == "ipv6" ] && [ "$IPT" == "$IPT4" ] && continue
+			[ "$family" = "ipv4" ] && [ "$IPT" = "$IPT6" ] && continue
+			[ "$family" = "ipv6" ] && [ "$IPT" = "$IPT4" ] && continue
 			[ "$global_logging" = "1" ] && [ "$rule_logging" = "1" ] && {
 				$IPT -A mwan3_rules \
 				     -p $proto \
@@ -1057,12 +1057,12 @@ mwan3_report_iface_status()
 	config_get enabled "$1" enabled 0
 	config_get family "$1" family ipv4
 
-	if [ "$family" == "ipv4" ]; then
+	if [ "$family" = "ipv4" ]; then
 		IP="$IP4"
 		IPT="$IPT4"
 	fi
 
-	if [ "$family" == "ipv6" ]; then
+	if [ "$family" = "ipv6" ]; then
 		IP="$IP6"
 		IPT="$IPT6"
 	fi
@@ -1079,7 +1079,7 @@ mwan3_report_iface_status()
 		[ -n "$($IPT -S mwan3_iface_in_$1 2> /dev/null)" ] || \
 		[ -n "$($IP route list table $id default dev $device 2> /dev/null)" ]; then
 		result="error"
-	elif [ "$enabled" == "1" ]; then
+	elif [ "$enabled" = "1" ]; then
 		result="offline"
 	else
 		result="disabled"

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -43,13 +43,20 @@ mwan3_rtmon_ipv4()
 	local ret=1
 	local tbl=""
 
-	local tid
+	local tid family enabled
 
 	mkdir -p /tmp/mwan3rtmon
 	($IP4 route list table main  | grep -v "^default\|linkdown" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv4.main
 	while uci get mwan3.@interface[$idx] >/dev/null 2>&1 ; do
 		tid=$((idx+1))
-		[ "$(uci get mwan3.@interface[$idx].family)" = "ipv4" ] && {
+
+		family="$(uci -q get mwan3.@interface[$idx].family)"
+		[ -z "$family" ] && family="ipv4"
+
+		enabled="$(uci -q get mwan3.@interface[$idx].enabled)"
+		[ -z "$enabled" ] && enabled="0"
+
+		[ "$family" = "ipv4" ] && {
 			tbl=$($IP4 route list table $tid 2>/dev/null)
 			if echo "$tbl" | grep -q ^default; then
 				(echo "$tbl"  | grep -v "^default\|linkdown" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv4.$tid
@@ -61,7 +68,7 @@ mwan3_rtmon_ipv4()
 				done
 			fi
 		}
-		if [ "$(uci get mwan3.@interface[$idx].enabled)" = "1" ]; then
+		if [ "$enabled" = "1" ]; then
 			ret=0
 		fi
 		idx=$((idx+1))
@@ -78,13 +85,21 @@ mwan3_rtmon_ipv6()
 	local ret=1
 	local tbl=""
 
-	local tid
+	local tid family enabled
 
 	mkdir -p /tmp/mwan3rtmon
 	($IP6 route list table main  | grep -v "^default\|^::/0\|^fe80::/64\|^unreachable" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv6.main
 	while uci get mwan3.@interface[$idx] >/dev/null 2>&1 ; do
 		tid=$((idx+1))
-		[ "$(uci get mwan3.@interface[$idx].family)" = "ipv6" ] && {
+
+		family="$(uci -q get mwan3.@interface[$idx].family)"
+		# Set default family to ipv4 that is no mistake
+		[ -z "$family" ] && family="ipv4"
+
+		enabled="$(uci -q get mwan3.@interface[$idx].enabled)"
+		[ -z "$enabled" ] && enabled="0"
+
+		[ "$family" = "ipv6" ] && {
 			tbl=$($IP6 route list table $tid 2>/dev/null)
 			if echo "$tbl" | grep -q "^default\|^::/0"; then
 				(echo "$tbl"  | grep -v "^default\|^::/0\|^unreachable" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv6.$tid
@@ -96,7 +111,7 @@ mwan3_rtmon_ipv6()
 				done
 			fi
 		}
-		if [ "$(uci get mwan3.@interface[$idx].enabled)" = "1" ]; then
+		if [ "$enabled" = "1" ]; then
 			ret=0
 		fi
 		idx=$((idx+1))

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -204,7 +204,7 @@ mwan3_set_custom_ipset_v4()
 
 	for custom_network_v4 in $($IP4 route list table "$1" | awk '{print $1}' | egrep '[0-9]{1,3}(\.[0-9]{1,3}){3}'); do
 		$LOG notice "Adding network $custom_network_v4 from table $1 to mwan3_custom_v4 ipset"
-		$IPS -! add mwan3_custom_v4_temp $custom_network_v4
+		$IPS -! add mwan3_custom_v4_temp "$custom_network_v4"
 	done
 }
 
@@ -214,7 +214,7 @@ mwan3_set_custom_ipset_v6()
 
 	for custom_network_v6 in $($IP6 route list table "$1" | awk '{print $1}' | egrep "$IPv6_REGEX"); do
 		$LOG notice "Adding network $custom_network_v6 from table $1 to mwan3_custom_v6 ipset"
-		$IPS -! add mwan3_custom_v6_temp $custom_network_v6
+		$IPS -! add mwan3_custom_v6_temp "$custom_network_v6"
 	done
 }
 
@@ -246,11 +246,11 @@ mwan3_set_connected_iptables()
 	$IPS create mwan3_connected_v4_temp hash:net
 
 	for connected_network_v4 in $($IP4 route | awk '{print $1}' | egrep '[0-9]{1,3}(\.[0-9]{1,3}){3}'); do
-		$IPS -! add mwan3_connected_v4_temp $connected_network_v4
+		$IPS -! add mwan3_connected_v4_temp "$connected_network_v4"
 	done
 
 	for connected_network_v4 in $($IP4 route list table 0 | awk '{print $2}' | egrep '[0-9]{1,3}(\.[0-9]{1,3}){3}'); do
-		$IPS -! add mwan3_connected_v4_temp $connected_network_v4
+		$IPS -! add mwan3_connected_v4_temp "$connected_network_v4"
 	done
 
 	$IPS add mwan3_connected_v4_temp 224.0.0.0/3
@@ -262,7 +262,7 @@ mwan3_set_connected_iptables()
 	$IPS create mwan3_connected_v6_temp hash:net family inet6
 
 	for connected_network_v6 in $($IP6 route | awk '{print $1}' | egrep "$IPv6_REGEX"); do
-		$IPS -! add mwan3_connected_v6_temp $connected_network_v6
+		$IPS -! add mwan3_connected_v6_temp "$connected_network_v6"
 	done
 
 	$IPS swap mwan3_connected_v6_temp mwan3_connected_v6
@@ -275,7 +275,7 @@ mwan3_set_connected_iptables()
 	$IPS -! create mwan3_source_v6 hash:net family inet6
 	$IPS create mwan3_source_v6_temp hash:net family inet6
 	for source_network_v6 in $($IP6 addr ls  | sed -ne 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p'); do
-		$IPS -! add mwan3_source_v6_temp $source_network_v6
+		$IPS -! add mwan3_source_v6_temp "$source_network_v6"
 	done
 	$IPS swap mwan3_source_v6_temp mwan3_source_v6
 	$IPS destroy mwan3_source_v6_temp
@@ -360,7 +360,7 @@ mwan3_set_general_iptables()
 
 			fi
 			$IPT -A mwan3_hook \
-				-j CONNMARK --restore-mark --nfmask $MMX_MASK --ctmask $MMX_MASK
+				-j CONNMARK --restore-mark --nfmask "$MMX_MASK" --ctmask "$MMX_MASK"
 			$IPT -A mwan3_hook \
 				-m mark --mark 0x0/$MMX_MASK \
 				-j mwan3_ifaces_in
@@ -371,7 +371,7 @@ mwan3_set_general_iptables()
 				-m mark --mark 0x0/$MMX_MASK \
 				-j mwan3_rules
 			$IPT -A mwan3_hook \
-				-j CONNMARK --save-mark --nfmask $MMX_MASK --ctmask $MMX_MASK
+				-j CONNMARK --save-mark --nfmask "$MMX_MASK" --ctmask "$MMX_MASK"
 			$IPT -A mwan3_hook \
 				-m mark ! --mark $MMX_DEFAULT/$MMX_MASK \
 				-j mwan3_connected
@@ -391,8 +391,8 @@ mwan3_create_iface_iptables()
 {
 	local id family
 
-	config_get family $1 family ipv4
-	mwan3_get_iface_id id $1
+	config_get family "$1" family ipv4
+	mwan3_get_iface_id id "$1"
 
 	[ -n "$id" ] || return 0
 
@@ -403,29 +403,29 @@ mwan3_create_iface_iptables()
 			$IPT4 -N mwan3_ifaces_in
 		fi
 
-		if ! $IPT4 -S mwan3_iface_in_$1 &> /dev/null; then
-			$IPT4 -N mwan3_iface_in_$1
+		if ! $IPT4 -S "mwan3_iface_in_$1" &> /dev/null; then
+			$IPT4 -N "mwan3_iface_in_$1"
 		fi
 
-		$IPT4 -F mwan3_iface_in_$1
-		$IPT4 -A mwan3_iface_in_$1 \
-			-i $2 \
+		$IPT4 -F "mwan3_iface_in_$1"
+		$IPT4 -A "mwan3_iface_in_$1" \
+			-i "$2" \
 			-m set --match-set mwan3_connected src \
 			-m mark --mark 0x0/$MMX_MASK \
 			-m comment --comment "default" \
 			-j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
-		$IPT4 -A mwan3_iface_in_$1 \
-			-i $2 \
+		$IPT4 -A "mwan3_iface_in_$1" \
+			-i "$2" \
 			-m mark --mark 0x0/$MMX_MASK \
 			-m comment --comment "$1" \
 			-j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
 
 		$IPT4 -D mwan3_ifaces_in \
 			-m mark --mark 0x0/$MMX_MASK \
-			-j mwan3_iface_in_$1 &> /dev/null
+			-j "mwan3_iface_in_$1" &> /dev/null
 		$IPT4 -A mwan3_ifaces_in \
 			-m mark --mark 0x0/$MMX_MASK \
-			-j mwan3_iface_in_$1
+			-j "mwan3_iface_in_$1"
 	fi
 
 	if [ "$family" = "ipv6" ]; then
@@ -435,49 +435,49 @@ mwan3_create_iface_iptables()
 			$IPT6 -N mwan3_ifaces_in
 		fi
 
-		if ! $IPT6 -S mwan3_iface_in_$1 &> /dev/null; then
-			$IPT6 -N mwan3_iface_in_$1
+		if ! $IPT6 -S "mwan3_iface_in_$1" &> /dev/null; then
+			$IPT6 -N "mwan3_iface_in_$1"
 		fi
 
-		$IPT6 -F mwan3_iface_in_$1
-		$IPT6 -A mwan3_iface_in_$1 -i $2 \
+		$IPT6 -F "mwan3_iface_in_$1"
+		$IPT6 -A "mwan3_iface_in_$1" -i "$2" \
 			-m set --match-set mwan3_connected_v6 src \
 			-m mark --mark 0x0/$MMX_MASK \
 			-m comment --comment "default" \
 			-j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
-		$IPT6 -A mwan3_iface_in_$1 -i $2 -m mark --mark 0x0/$MMX_MASK \
+		$IPT6 -A "mwan3_iface_in_$1" -i "$2" -m mark --mark 0x0/$MMX_MASK \
 			-m comment --comment "$1" \
 			-j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
 
 		$IPT6 -D mwan3_ifaces_in \
 			-m mark --mark 0x0/$MMX_MASK \
-			-j mwan3_iface_in_$1 &> /dev/null
+			-j "mwan3_iface_in_$1" &> /dev/null
 		$IPT6 -A mwan3_ifaces_in \
 			-m mark --mark 0x0/$MMX_MASK \
-			-j mwan3_iface_in_$1
+			-j "mwan3_iface_in_$1"
 	fi
 }
 
 mwan3_delete_iface_iptables()
 {
-	config_get family $1 family ipv4
+	config_get family "$1" family ipv4
 
 	if [ "$family" = "ipv4" ]; then
 
 		$IPT4 -D mwan3_ifaces_in \
 			-m mark --mark 0x0/$MMX_MASK \
-			-j mwan3_iface_in_$1 &> /dev/null
-		$IPT4 -F mwan3_iface_in_$1 &> /dev/null
-		$IPT4 -X mwan3_iface_in_$1 &> /dev/null
+			-j "mwan3_iface_in_$1" &> /dev/null
+		$IPT4 -F "mwan3_iface_in_$1" &> /dev/null
+		$IPT4 -X "mwan3_iface_in_$1" &> /dev/null
 	fi
 
 	if [ "$family" = "ipv6" ]; then
 
 		$IPT6 -D mwan3_ifaces_in \
 			-m mark --mark 0x0/$MMX_MASK \
-			-j mwan3_iface_in_$1 &> /dev/null
-		$IPT6 -F mwan3_iface_in_$1 &> /dev/null
-		$IPT6 -X mwan3_iface_in_$1 &> /dev/null
+			-j "mwan3_iface_in_$1" &> /dev/null
+		$IPT6 -F "mwan3_iface_in_$1" &> /dev/null
+		$IPT6 -X "mwan3_iface_in_$1" &> /dev/null
 	fi
 }
 
@@ -541,17 +541,17 @@ mwan3_delete_iface_route()
 {
 	local id
 
-	config_get family $1 family ipv4
-	mwan3_get_iface_id id $1
+	config_get family "$1" family ipv4
+	mwan3_get_iface_id id "$1"
 
 	[ -n "$id" ] || return 0
 
 	if [ "$family" = "ipv4" ]; then
-		$IP4 route flush table $id
+		$IP4 route flush table "$id"
 	fi
 
 	if [ "$family" = "ipv6" ]; then
-		$IP6 route flush table $id
+		$IP6 route flush table "$id"
 	fi
 }
 
@@ -559,8 +559,8 @@ mwan3_create_iface_rules()
 {
 	local id family
 
-	config_get family $1 family ipv4
-	mwan3_get_iface_id id $1
+	config_get family "$1" family ipv4
+	mwan3_get_iface_id id "$1"
 
 	[ -n "$id" ] || return 0
 
@@ -574,8 +574,8 @@ mwan3_create_iface_rules()
 			$IP4 rule del pref $(($id+2000))
 		done
 
-		$IP4 rule add pref $(($id+1000)) iif $2 lookup $id
-		$IP4 rule add pref $(($id+2000)) fwmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK lookup $id
+		$IP4 rule add pref $(($id+1000)) iif "$2" lookup "$id"
+		$IP4 rule add pref $(($id+2000)) fwmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK lookup "$id"
 	fi
 
 	if [ "$family" = "ipv6" ]; then
@@ -588,8 +588,8 @@ mwan3_create_iface_rules()
 			$IP6 rule del pref $(($id+2000))
 		done
 
-		$IP6 rule add pref $(($id+1000)) iif $2 lookup $id
-		$IP6 rule add pref $(($id+2000)) fwmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK lookup $id
+		$IP6 rule add pref $(($id+1000)) iif "$2" lookup "$id"
+		$IP6 rule add pref $(($id+2000)) fwmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK lookup "$id"
 	fi
 }
 
@@ -597,8 +597,8 @@ mwan3_delete_iface_rules()
 {
 	local id family
 
-	config_get family $1 family ipv4
-	mwan3_get_iface_id id $1
+	config_get family "$1" family ipv4
+	mwan3_get_iface_id id "$1"
 
 	[ -n "$id" ] || return 0
 
@@ -629,13 +629,13 @@ mwan3_delete_iface_ipset_entries()
 {
 	local id setname entry
 
-	mwan3_get_iface_id id $1
+	mwan3_get_iface_id id "$1"
 
 	[ -n "$id" ] || return 0
 
 	for setname in $(ipset -n list | grep ^mwan3_sticky_); do
-		for entry in $(ipset list $setname | grep "$(echo $(mwan3_id2mask id MMX_MASK) | awk '{ printf "0x%08x", $1; }')" | cut -d ' ' -f 1); do
-			$IPS del $setname $entry
+		for entry in $(ipset list "$setname" | grep "$(echo $(mwan3_id2mask id MMX_MASK) | awk '{ printf "0x%08x", $1; }')" | cut -d ' ' -f 1); do
+			$IPS del "$setname" $entry
 		done
 	done
 }
@@ -658,7 +658,7 @@ mwan3_track()
 	{
 		track_ips="$track_ips $1"
 	}
-	config_list_foreach $1 track_ip mwan3_list_track_ips
+	config_list_foreach "$1" track_ip mwan3_list_track_ips
 
 	for pid in $(pgrep -f "mwan3track $1 $2"); do
 		kill -TERM "$pid" > /dev/null 2>&1
@@ -684,28 +684,28 @@ mwan3_set_policy()
 {
 	local iface_count id iface family metric probability weight device
 
-	config_get iface $1 interface
-	config_get metric $1 metric 1
-	config_get weight $1 weight 1
+	config_get iface "$1" interface
+	config_get metric "$1" metric 1
+	config_get weight "$1" weight 1
 
 	[ -n "$iface" ] || return 0
-	network_get_device device $iface
+	network_get_device device "$iface"
 	[ "$metric" -gt $DEFAULT_LOWEST_METRIC ] && $LOG warn "Member interface $iface has >$DEFAULT_LOWEST_METRIC metric. Not appending to policy" && return 0
 
-	mwan3_get_iface_id id $iface
+	mwan3_get_iface_id id "$iface"
 
 	[ -n "$id" ] || return 0
 
-	config_get family $iface family ipv4
+	config_get family "$iface" family ipv4
 
 	if [ "$family" = "ipv4" ]; then
 
-		if [ "$(mwan3_get_iface_hotplug_state $iface)" = "online" ]; then
+		if [ "$(mwan3_get_iface_hotplug_state "$iface")" = "online" ]; then
 			if [ "$metric" -lt "$lowest_metric_v4" ]; then
 
 				total_weight_v4=$weight
-				$IPT4 -F mwan3_policy_$policy
-				$IPT4 -A mwan3_policy_$policy \
+				$IPT4 -F "mwan3_policy_$policy"
+				$IPT4 -A "mwan3_policy_$policy" \
 					-m mark --mark 0x0/$MMX_MASK \
 					-m comment --comment "$iface $weight $weight" \
 					-j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
@@ -729,16 +729,16 @@ mwan3_set_policy()
 
 				probability="-m statistic --mode random --probability $probability"
 
-				$IPT4 -I mwan3_policy_$policy \
-					-m mark --mark 0x0/$MMX_MASK $probability \
+				$IPT4 -I "mwan3_policy_$policy" \
+					-m mark --mark 0x0/$MMX_MASK "$probability" \
 					-m comment --comment "$iface $weight $total_weight_v4" \
 					-j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
 			fi
 		else
 			[ -n "$device" ] && {
-				$IPT4 -S mwan3_policy_$policy | grep -q '.*--comment ".* [0-9]* [0-9]*"' || \
-					$IPT4 -I mwan3_policy_$policy \
-					-o $device \
+				$IPT4 -S "mwan3_policy_$policy" | grep -q '.*--comment ".* [0-9]* [0-9]*"' || \
+					$IPT4 -I "mwan3_policy_$policy" \
+					-o "$device" \
 					-m mark --mark 0x0/$MMX_MASK \
 					-m comment --comment "out $iface $device" \
 					-j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
@@ -748,12 +748,12 @@ mwan3_set_policy()
 
 	if [ "$family" = "ipv6" ]; then
 
-		if [ "$(mwan3_get_iface_hotplug_state $iface)" = "online" ]; then
+		if [ "$(mwan3_get_iface_hotplug_state "$iface")" = "online" ]; then
 			if [ "$metric" -lt "$lowest_metric_v6" ]; then
 
 				total_weight_v6=$weight
-				$IPT6 -F mwan3_policy_$policy
-				$IPT6 -A mwan3_policy_$policy \
+				$IPT6 -F "mwan3_policy_$policy"
+				$IPT6 -A "mwan3_policy_$policy" \
 					-m mark --mark 0x0/$MMX_MASK \
 					-m comment --comment "$iface $weight $weight" \
 					-j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
@@ -777,17 +777,17 @@ mwan3_set_policy()
 
 				probability="-m statistic --mode random --probability $probability"
 
-				$IPT6 -I mwan3_policy_$policy \
+				$IPT6 -I "mwan3_policy_$policy" \
 					-m mark --mark 0x0/$MMX_MASK \
-					$probability \
+					"$probability" \
 					-m comment --comment "$iface $weight $total_weight_v6" \
 					-j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
 			fi
 		else
 			[ -n "$device" ] && {
-				$IPT6 -S mwan3_policy_$policy | grep -q '.*--comment ".* [0-9]* [0-9]*"' || \
-					$IPT6 -I mwan3_policy_$policy \
-					-o $device \
+				$IPT6 -S "mwan3_policy_$policy" | grep -q '.*--comment ".* [0-9]* [0-9]*"' || \
+					$IPT6 -I "mwan3_policy_$policy" \
+					-o "$device" \
 					-m mark --mark 0x0/$MMX_MASK \
 					-m comment --comment "out $iface $device" \
 					-j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
@@ -802,35 +802,35 @@ mwan3_create_policies_iptables()
 
 	policy="$1"
 
-	config_get last_resort $1 last_resort unreachable
+	config_get last_resort "$1" last_resort unreachable
 
-	if [ "$1" != $(echo "$1" | cut -c1-15) ]; then
+	if [ "$1" != "$(echo "$1" | cut -c1-15)" ]; then
 		$LOG warn "Policy $1 exceeds max of 15 chars. Not setting policy" && return 0
 	fi
 
 	for IPT in "$IPT4" "$IPT6"; do
 
-		if ! $IPT -S mwan3_policy_$1 &> /dev/null; then
-			$IPT -N mwan3_policy_$1
+		if ! $IPT -S "mwan3_policy_$1" &> /dev/null; then
+			$IPT -N "mwan3_policy_$1"
 		fi
 
-		$IPT -F mwan3_policy_$1
+		$IPT -F "mwan3_policy_$1"
 
 		case "$last_resort" in
 			blackhole)
-				$IPT -A mwan3_policy_$1 \
+				$IPT -A "mwan3_policy_$1" \
 					-m mark --mark 0x0/$MMX_MASK \
 					-m comment --comment "blackhole" \
 					-j MARK --set-xmark $MMX_BLACKHOLE/$MMX_MASK
 			;;
 			default)
-				$IPT -A mwan3_policy_$1 \
+				$IPT -A "mwan3_policy_$1" \
 					-m mark --mark 0x0/$MMX_MASK \
 					-m comment --comment "default" \
 					-j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
 			;;
 			*)
-				$IPT -A mwan3_policy_$1 \
+				$IPT -A "mwan3_policy_$1" \
 					-m mark --mark 0x0/$MMX_MASK \
 					-m comment --comment "unreachable" \
 					-j MARK --set-xmark $MMX_UNREACHABLE/$MMX_MASK
@@ -844,7 +844,7 @@ mwan3_create_policies_iptables()
 	lowest_metric_v6=$DEFAULT_LOWEST_METRIC
 	total_weight_v6=0
 
-	config_list_foreach $1 use_member mwan3_set_policy
+	config_list_foreach "$1" use_member mwan3_set_policy
 }
 
 mwan3_set_policies_iptables()
@@ -856,21 +856,21 @@ mwan3_set_sticky_iptables()
 {
 	local id iface
 
-	for iface in $($IPT4 -S $policy | cut -s -d'"' -f2 | awk '{print $1}'); do
+	for iface in $($IPT4 -S "$policy" | cut -s -d'"' -f2 | awk '{print $1}'); do
 
 		if [ "$iface" = "$1" ]; then
 
-			mwan3_get_iface_id id $1
+			mwan3_get_iface_id id "$1"
 
 			[ -n "$id" ] || return 0
 
 			for IPT in "$IPT4" "$IPT6"; do
-				if [ -n "$($IPT -S mwan3_iface_in_$1 2> /dev/null)" ]; then
-					$IPT -I mwan3_rule_$rule \
+				if [ -n "$($IPT -S "mwan3_iface_in_$1" 2> /dev/null)" ]; then
+					$IPT -I "mwan3_rule_$rule" \
 						-m mark --mark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK \
-						-m set ! --match-set mwan3_sticky_$rule src,src \
+						-m set ! --match-set "mwan3_sticky_$rule" src,src \
 						-j MARK --set-xmark 0x0/$MMX_MASK
-					$IPT -I mwan3_rule_$rule \
+					$IPT -I "mwan3_rule_$rule" \
 						-m mark --mark 0/$MMX_MASK \
 						-j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
 				fi
@@ -887,18 +887,18 @@ mwan3_set_user_iptables_rule()
 
 	rule="$1"
 
-	config_get sticky $1 sticky 0
-	config_get timeout $1 timeout 600
-	config_get ipset $1 ipset
-	config_get proto $1 proto all
-	config_get src_ip $1 src_ip
-	config_get src_iface $1 src_iface
-	network_get_device src_dev $src_iface
-	config_get src_port $1 src_port
-	config_get dest_ip $1 dest_ip
-	config_get dest_port $1 dest_port
-	config_get use_policy $1 use_policy
-	config_get family $1 family any
+	config_get sticky "$1" sticky 0
+	config_get timeout "$1" timeout 600
+	config_get ipset "$1" ipset
+	config_get proto "$1" proto all
+	config_get src_ip "$1" src_ip
+	config_get src_iface "$1" src_iface
+	network_get_device src_dev "$src_iface"
+	config_get src_port "$1" src_port
+	config_get dest_ip "$1" dest_ip
+	config_get dest_port "$1" dest_port
+	config_get use_policy "$1" use_policy
+	config_get family "$1" family any
 
 	[ -z "$dest_ip" ] && unset dest_ip
 	[ -z "$src_ip" ] && unset src_ip
@@ -916,11 +916,11 @@ mwan3_set_user_iptables_rule()
 		unset dest_port
 	}
 
-	config_get rule_logging $1 logging 0
+	config_get rule_logging "$1" logging 0
 	config_get global_logging globals logging 0
 	config_get loglevel globals loglevel notice
 
-	if [ "$1" != $(echo "$1" | cut -c1-15) ]; then
+	if [ "$1" != "$(echo "$1" | cut -c1-15)" ]; then
 		$LOG warn "Rule $1 exceeds max of 15 chars. Not setting rule" && return 0
 	fi
 
@@ -941,39 +941,39 @@ mwan3_set_user_iptables_rule()
 				policy="mwan3_policy_$use_policy"
 
 				for IPT in "$IPT4" "$IPT6"; do
-					if ! $IPT -S $policy &> /dev/null; then
-						$IPT -N $policy
+					if ! $IPT -S "$policy" &> /dev/null; then
+						$IPT -N "$policy"
 					fi
 
-					if ! $IPT -S mwan3_rule_$1 &> /dev/null; then
-						$IPT -N mwan3_rule_$1
+					if ! $IPT -S "mwan3_rule_$1" &> /dev/null; then
+						$IPT -N "mwan3_rule_$1"
 					fi
 
-					$IPT -F mwan3_rule_$1
+					$IPT -F "mwan3_rule_$1"
 				done
 
-				$IPS -! create mwan3_sticky_v4_$rule \
-					hash:ip,mark markmask $MMX_MASK \
-					timeout $timeout
-				$IPS -! create mwan3_sticky_v6_$rule \
-					hash:ip,mark markmask $MMX_MASK \
-					timeout $timeout family inet6
-				$IPS -! create mwan3_sticky_$rule list:set
-				$IPS -! add mwan3_sticky_$rule mwan3_sticky_v4_$rule
-				$IPS -! add mwan3_sticky_$rule mwan3_sticky_v6_$rule
+				$IPS -! create "mwan3_sticky_v4_$rule" \
+					hash:ip,mark markmask "$MMX_MASK" \
+					timeout "$timeout"
+				$IPS -! create "mwan3_sticky_v6_$rule" \
+					hash:ip,mark markmask "$MMX_MASK" \
+					timeout "$timeout" family inet6
+				$IPS -! create "mwan3_sticky_$rule" list:set
+				$IPS -! add "mwan3_sticky_$rule" "mwan3_sticky_v4_$rule"
+				$IPS -! add "mwan3_sticky_$rule" "mwan3_sticky_v6_$rule"
 
 				config_foreach mwan3_set_sticky_iptables interface
 
 				for IPT in "$IPT4" "$IPT6"; do
-					$IPT -A mwan3_rule_$1 \
+					$IPT -A "mwan3_rule_$1" \
 						-m mark --mark 0/$MMX_MASK \
-						-j $policy
-					$IPT -A mwan3_rule_$1 \
+						-j "$policy"
+					$IPT -A "mwan3_rule_$1" \
 						-m mark ! --mark 0xfc00/0xfc00 \
-						-j SET --del-set mwan3_sticky_$rule src,src
-					$IPT -A mwan3_rule_$1 \
+						-j SET --del-set "mwan3_sticky_$rule" src,src
+					$IPT -A "mwan3_rule_$1" \
 						-m mark ! --mark 0xfc00/0xfc00 \
-						-j SET --add-set mwan3_sticky_$rule src,src
+						-j SET --add-set "mwan3_sticky_$rule" src,src
 				done
 
 				policy="mwan3_rule_$1"
@@ -981,8 +981,8 @@ mwan3_set_user_iptables_rule()
 				policy="mwan3_policy_$use_policy"
 
 				for IPT in "$IPT4" "$IPT6"; do
-					if ! $IPT -S $policy &> /dev/null; then
-						$IPT -N $policy
+					if ! $IPT -S "$policy" &> /dev/null; then
+						$IPT -N "$policy"
 					fi
 				done
 
@@ -993,10 +993,10 @@ mwan3_set_user_iptables_rule()
 			[ "$family" = "ipv6" ] && [ "$IPT" = "$IPT4" ] && continue
 			[ "$global_logging" = "1" ] && [ "$rule_logging" = "1" ] && {
 				$IPT -A mwan3_rules \
-				     -p $proto \
+				     -p "$proto" \
 				     ${src_ip:+-s} $src_ip \
 				     ${src_dev:+-i} $src_dev \
-				     ${dest_ip:+-d} $dest_ip\
+				     ${dest_ip:+-d} $dest_ip \
 				     $ipset \
 				     ${src_port:+-m} ${src_port:+multiport} ${src_port:+--sports} $src_port \
 				     ${dest_port:+-m} ${dest_port:+multiport} ${dest_port:+--dports} $dest_port \
@@ -1006,10 +1006,10 @@ mwan3_set_user_iptables_rule()
 			}
 
 			$IPT -A mwan3_rules \
-			     -p $proto \
+			     -p "$proto" \
 			     ${src_ip:+-s} $src_ip \
 			     ${src_dev:+-i} $src_dev \
-			     ${dest_ip:+-d} $dest_ip\
+			     ${dest_ip:+-d} $dest_ip \
 			     $ipset \
 			     ${src_port:+-m} ${src_port:+multiport} ${src_port:+--sports} $src_port \
 			     ${dest_port:+-m} ${dest_port:+multiport} ${dest_port:+--dports} $dest_port \
@@ -1039,21 +1039,21 @@ mwan3_set_iface_hotplug_state() {
 	local iface=$1
 	local state=$2
 
-	echo -n $state > $MWAN3_STATUS_DIR/iface_state/$iface
+	echo "$state" > "$MWAN3_STATUS_DIR/iface_state/$iface"
 }
 
 mwan3_get_iface_hotplug_state() {
 	local iface=$1
 
-	cat $MWAN3_STATUS_DIR/iface_state/$iface 2>/dev/null || echo "offline"
+	cat "$MWAN3_STATUS_DIR/iface_state/$iface" 2>/dev/null || echo "offline"
 }
 
 mwan3_report_iface_status()
 {
 	local device result track_ips tracking IP IPT
 
-	mwan3_get_iface_id id $1
-	network_get_device device $1
+	mwan3_get_iface_id id "$1"
+	network_get_device device "$1"
 	config_get enabled "$1" enabled 0
 	config_get family "$1" family ipv4
 
@@ -1089,7 +1089,7 @@ mwan3_report_iface_status()
 	{
 		track_ips="$1 $track_ips"
 	}
-	config_list_foreach $1 track_ip mwan3_list_track_ips
+	config_list_foreach "$1" track_ip mwan3_list_track_ips
 
 	if [ -n "$track_ips" ]; then
 		if [ -n "$(pgrep -f "mwan3track $1 $device")" ]; then
@@ -1111,16 +1111,16 @@ mwan3_report_policies()
 
 	local percent total_weight weight iface
 
-	total_weight=$($ipt -S $policy | grep -v '.*--comment "out .*" .*$' | cut -s -d'"' -f2 | head -1 | awk '{print $3}')
+	total_weight=$($ipt -S "$policy" | grep -v '.*--comment "out .*" .*$' | cut -s -d'"' -f2 | head -1 | awk '{print $3}')
 
 	if [ ! -z "${total_weight##*[!0-9]*}" ]; then
-		for iface in $($ipt -S $policy | grep -v '.*--comment "out .*" .*$' | cut -s -d'"' -f2 | awk '{print $1}'); do
-			weight=$($ipt -S $policy | grep -v '.*--comment "out .*" .*$' | cut -s -d'"' -f2 | awk '$1 == "'$iface'"' | awk '{print $2}')
+		for iface in $($ipt -S "$policy" | grep -v '.*--comment "out .*" .*$' | cut -s -d'"' -f2 | awk '{print $1}'); do
+			weight=$($ipt -S "$policy" | grep -v '.*--comment "out .*" .*$' | cut -s -d'"' -f2 | awk '$1 == "'$iface'"' | awk '{print $2}')
 			percent=$(($weight*100/$total_weight))
 			echo " $iface ($percent%)"
 		done
 	else
-		echo " $($ipt -S $policy | grep -v '.*--comment "out .*" .*$' | sed '/.*--comment \([^ ]*\) .*$/!d;s//\1/;q')"
+		echo " $($ipt -S "$policy" | grep -v '.*--comment "out .*" .*$' | sed '/.*--comment \([^ ]*\) .*$/!d;s//\1/;q')"
 	fi
 }
 

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -46,7 +46,7 @@ mwan3_rtmon_ipv4()
 		idx=$((idx+1))
 		tid=$idx
 		[ "$(uci get mwan3.@interface[$((idx-1))].family)" = "ipv4" ] && {
-			tbl=$($IP4 route list table $tid)
+			tbl=$($IP4 route list table $tid 2>/dev/null)
 			if echo "$tbl" | grep -q ^default; then
 				(echo "$tbl"  | grep -v "^default\|linkdown" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv4.$tid
 				cat /tmp/mwan3rtmon/ipv4.$tid | grep -v -x -F -f /tmp/mwan3rtmon/ipv4.main | while read line; do
@@ -79,7 +79,7 @@ mwan3_rtmon_ipv6()
 		idx=$((idx+1))
 		tid=$idx
 		[ "$(uci get mwan3.@interface[$((idx-1))].family)" = "ipv6" ] && {
-			tbl=$($IP6 route list table $tid)
+			tbl=$($IP6 route list table $tid 2>/dev/null)
 			if echo "$tbl" | grep -q "^default\|^::/0"; then
 				(echo "$tbl"  | grep -v "^default\|^::/0\|^unreachable" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv6.$tid
 				cat /tmp/mwan3rtmon/ipv6.$tid | grep -v -x -F -f /tmp/mwan3rtmon/ipv6.main | while read line; do

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -39,16 +39,17 @@ NO_IPV6=$?
 # otherwise return false
 mwan3_rtmon_ipv4()
 {
-	local tid=1
 	local idx=0
 	local ret=1
 	local tbl=""
+
+	local tid
+
 	mkdir -p /tmp/mwan3rtmon
 	($IP4 route list table main  | grep -v "^default\|linkdown" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv4.main
 	while uci get mwan3.@interface[$idx] >/dev/null 2>&1 ; do
-		idx=$((idx+1))
-		tid=$idx
-		[ "$(uci get mwan3.@interface[$((idx-1))].family)" = "ipv4" ] && {
+		tid=$((idx+1))
+		[ "$(uci get mwan3.@interface[$idx].family)" = "ipv4" ] && {
 			tbl=$($IP4 route list table $tid 2>/dev/null)
 			if echo "$tbl" | grep -q ^default; then
 				(echo "$tbl"  | grep -v "^default\|linkdown" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv4.$tid
@@ -60,9 +61,10 @@ mwan3_rtmon_ipv4()
 				done
 			fi
 		}
-		if [ "$(uci get mwan3.@interface[$((idx-1))].enabled)" = "1" ]; then
+		if [ "$(uci get mwan3.@interface[$idx].enabled)" = "1" ]; then
 			ret=0
 		fi
+		idx=$((idx+1))
 	done
 	rm -f /tmp/mwan3rtmon/ipv4.*
 	return $ret
@@ -72,16 +74,17 @@ mwan3_rtmon_ipv4()
 # otherwise return false
 mwan3_rtmon_ipv6()
 {
-	local tid=1
 	local idx=0
 	local ret=1
 	local tbl=""
+
+	local tid
+
 	mkdir -p /tmp/mwan3rtmon
 	($IP6 route list table main  | grep -v "^default\|^::/0\|^fe80::/64\|^unreachable" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv6.main
 	while uci get mwan3.@interface[$idx] >/dev/null 2>&1 ; do
-		idx=$((idx+1))
-		tid=$idx
-		[ "$(uci get mwan3.@interface[$((idx-1))].family)" = "ipv6" ] && {
+		tid=$((idx+1))
+		[ "$(uci get mwan3.@interface[$idx].family)" = "ipv6" ] && {
 			tbl=$($IP6 route list table $tid 2>/dev/null)
 			if echo "$tbl" | grep -q "^default\|^::/0"; then
 				(echo "$tbl"  | grep -v "^default\|^::/0\|^unreachable" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv6.$tid
@@ -93,9 +96,10 @@ mwan3_rtmon_ipv6()
 				done
 			fi
 		}
-		if [ "$(uci get mwan3.@interface[$((idx-1))].enabled)" = "1" ]; then
+		if [ "$(uci get mwan3.@interface[$idx].enabled)" = "1" ]; then
 			ret=0
 		fi
+		idx=$((idx+1))
 	done
 	rm -f /tmp/mwan3rtmon/ipv6.*
 	return $ret

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -1023,7 +1023,7 @@ mwan3_set_user_iptables_rule()
 				     ${dest_port:+-m} ${dest_port:+multiport} ${dest_port:+--dports} $dest_port \
 				     -m mark --mark 0/$MMX_MASK \
 				     -m comment --comment "$1" \
-				     -j LOG --log-level "$loglevel" --log-prefix "MWAN3($1)" &> /dev/null
+				     -j LOG --log-level "$loglevel" --log-prefix "MWAN3($1)"
 			}
 
 			$IPT -A mwan3_rules \
@@ -1035,7 +1035,7 @@ mwan3_set_user_iptables_rule()
 			     ${src_port:+-m} ${src_port:+multiport} ${src_port:+--sports} $src_port \
 			     ${dest_port:+-m} ${dest_port:+multiport} ${dest_port:+--dports} $dest_port \
 			     -m mark --mark 0/$MMX_MASK \
-			     -j $policy &> /dev/null
+			     -j $policy
 		done
 	fi
 }

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -202,6 +202,13 @@ mwan3_unlock() {
 }
 
 mwan3_lock_clean() {
+	for pid in $(pgrep -f "lock /var/run/mwan3.lock"); do
+		kill -TERM "$pid" > /dev/null 2>&1
+	done
+	sleep 1
+	for pid in $(pgrep -f "lock /var/run/mwan3.lock"); do
+		kill -KILL "$pid" > /dev/null 2>&1
+	done
 	rm -rf /var/run/mwan3.lock
 }
 

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -1067,7 +1067,7 @@ mwan3_report_iface_status()
 		IPT="$IPT6"
 	fi
 
-	if [ -z "$id" -o -z "$device" ]; then
+	if [ -z "$id" ] || [ -z "$device" ]; then
 		result="offline"
 	elif [ -n "$($IP rule | awk '$1 == "'$(($id+1000)):'"')" ] && \
 		[ -n "$($IP rule | awk '$1 == "'$(($id+2000)):'"')" ] && \

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -203,10 +203,6 @@ mwan3_unlock() {
 	lock -u /var/run/mwan3.lock
 }
 
-mwan3_lock_clean() {
-	rm -rf /var/run/mwan3.lock
-}
-
 mwan3_get_iface_id()
 {
 	local _tmp _iface _iface_count

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -204,13 +204,6 @@ mwan3_unlock() {
 }
 
 mwan3_lock_clean() {
-	for pid in $(pgrep -f "lock /var/run/mwan3.lock"); do
-		kill -TERM "$pid" > /dev/null 2>&1
-	done
-	sleep 1
-	for pid in $(pgrep -f "lock /var/run/mwan3.lock"); do
-		kill -KILL "$pid" > /dev/null 2>&1
-	done
 	rm -rf /var/run/mwan3.lock
 }
 

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -64,7 +64,7 @@ ifup()
 	status=$(ubus -S call network.interface.$1 status)
 	[ -n "$status" ] && {
 		json_load "$status"
-		json_get_vars up l3_device 
+		json_get_vars up l3_device
 	}
 
 	config_get enabled "$1" enabled 0
@@ -141,13 +141,19 @@ stop()
 
 	for pid in $(pgrep -f "mwan3rtmon"); do
 		kill -TERM "$pid" > /dev/null 2>&1
-		sleep 1
-		kill -KILL "$pid" > /dev/null 2>&1
 	done
 
 	for pid in $(pgrep -f "mwan3track"); do
 		kill -TERM "$pid" > /dev/null 2>&1
-		sleep 1
+	done
+
+	sleep 1
+
+	for pid in $(pgrep -f "mwan3rtmon"); do
+		kill -KILL "$pid" > /dev/null 2>&1
+	done
+
+	for pid in $(pgrep -f "mwan3track"); do
 		kill -KILL "$pid" > /dev/null 2>&1
 	done
 

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -90,6 +90,7 @@ policies()
 	echo "Current ipv4 policies:"
 	mwan3_report_policies_v4
 	echo -e
+	[ $NO_IPV6 -ne 0 ] && return
 	echo "Current ipv6 policies:"
 	mwan3_report_policies_v6
 	echo -e
@@ -100,6 +101,7 @@ connected()
 	echo "Directly connected ipv4 networks:"
 	mwan3_report_connected_v4
 	echo -e
+	[ $NO_IPV6 -ne 0 ] && return
 	echo "Directly connected ipv6 networks:"
 	mwan3_report_connected_v6
 	echo -e
@@ -110,6 +112,7 @@ rules()
 	echo "Active ipv4 user rules:"
 	mwan3_report_rules_v4
 	echo -e
+	[ $NO_IPV6 -ne 0 ] && return
 	echo "Active ipv6 user rules:"
 	mwan3_report_rules_v6
 	echo -e
@@ -161,7 +164,7 @@ stop()
 	config_foreach mwan3_track_clean interface
 
 	for IP in "$IP4" "$IP6"; do
-
+		[ "$IP" = "$IP6" ] && [ $NO_IPV6 -ne 0 ] && continue
 		for route in $(seq 1 $MWAN3_INTERFACE_MAX); do
 			$IP route flush table $route &> /dev/null
 		done
@@ -172,7 +175,7 @@ stop()
 	done
 
 	for IPT in "$IPT4" "$IPT6"; do
-
+		[ "$IPT" = "$IPT6" ] && [ $NO_IPV6 -ne 0 ] && continue
 		$IPT -D PREROUTING -j mwan3_hook &> /dev/null
 		$IPT -D OUTPUT -j mwan3_hook &> /dev/null
 

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -210,7 +210,6 @@ stop()
 
 	mwan3_unlock "command" "mwan3"
 
-	mwan3_lock_clean
 	rm -rf $MWAN3_STATUS_DIR $MWAN3TRACK_STATUS_DIR
 }
 

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -45,29 +45,38 @@ ifup()
 {
 	local device enabled up l3_device status
 
+	mwan3_lock "command" "mwan3"
+
 	config_load mwan3
 	config_get_bool enabled globals 'enabled' 0
+
 	[ ${enabled} -gt 0 ] || {
 		echo "The service mwan3 is global disabled."
 		echo "Please execute \"/etc/init.d/mwan3 start\" first."
+		mwan3_unlock "command" "mwan3"
 		exit 1
 	}
 
 	if [ -z "$1" ]; then
-		echo "Expecting interface. Usage: mwan3 ifup <interface>" && exit 0
+		echo "Expecting interface. Usage: mwan3 ifup <interface>"
+		mwan3_unlock "command" "mwan3"
+		exit 0
 	fi
 
 	if [ -n "$2" ]; then
-		echo "Too many arguments. Usage: mwan3 ifup <interface>" && exit 0
+		echo "Too many arguments. Usage: mwan3 ifup <interface>"
+		mwan3_unlock "command" "mwan3"
+		exit 0
 	fi
+
+	config_get enabled "$1" enabled 0
+	mwan3_unlock "command" "mwan3"
 
 	status=$(ubus -S call network.interface.$1 status)
 	[ -n "$status" ] && {
 		json_load "$status"
 		json_get_vars up l3_device
 	}
-
-	config_get enabled "$1" enabled 0
 
 	if [ "$up" = "1" ] \
 		&& [ -n "$l3_device" ] \
@@ -130,7 +139,9 @@ start()
 {
 	local enabled
 
+	mwan3_lock "command" "mwan3"
 	uci_toggle_state mwan3 globals enabled "1"
+	mwan3_unlock "command" "mwan3"
 
 	config_load mwan3
 	config_foreach ifup interface
@@ -141,6 +152,7 @@ stop()
 	local ipset route rule table IP IPT pid
 
 	mwan3_lock "command" "mwan3"
+	uci_toggle_state mwan3 globals enabled "0"
 
 	for pid in $(pgrep -f "mwan3rtmon"); do
 		kill -TERM "$pid" > /dev/null 2>&1
@@ -200,8 +212,6 @@ stop()
 
 	mwan3_lock_clean
 	rm -rf $MWAN3_STATUS_DIR $MWAN3TRACK_STATUS_DIR
-
-	uci_toggle_state mwan3 globals enabled "0"
 }
 
 restart() {


### PR DESCRIPTION
Maintainer: me 
Compile tested: only script changes
Run tested: x86_64, APU3, OpenWrt master

Description:
- IPv6 improvements
- Add check if IPv6 is enabled on the system
- Fix some shellcheck warnings
- Fix procd blocking introduced with commit https://github.com/openwrt/packages/commit/f7749c663b4ac4880cbd1ed7217073d8b03ea072#diff-34590d11545c84b961d1992ce3aefdeb

If [P/R ](https://github.com/openwrt/packages/pull/12948) is merged into master, then we should also backport and add the commits to this pull request. The pull request in master fixes the race condition between mwan3 command and hotplug-script execution.
