### PR TITLE
nginx: remove PROVIDES on depending package

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.19.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
@@ -305,7 +305,8 @@ define Package/nginx-mod-luci
   TITLE:=Support file for Nginx
   URL:=http://nginx.org/
   DEPENDS:=+uwsgi +uwsgi-luci-support +nginx
-  PROVIDES:=nginx-mod-luci-ssl
+  # TODO: add PROVIDES when removing nginx-mod-luci-ssl
+  # PROVIDES:=nginx-mod-luci-ssl
 endef
 
 define Package/nginx-mod-luci/description
@@ -547,7 +548,7 @@ $(eval $(call BuildPackage,nginx-mod-luci))
 
 # TODO: remove after a transition period (together with pkg nginx-util):
 # It is for smoothly substituting nginx and nginx-mod-luci-ssl (by nginx-ssl
-# respectively nginx-mod-luci).
+# respectively nginx-mod-luci). Add above commented PROVIDES when removing.
 
 Package/nginx = $(Package/nginx-ssl)
 


### PR DESCRIPTION
Maintainer: @Ansuel and @heil 
Compile tested: I cannot test it right now, but it should be safe.
Run tested: I cannot test it right now, but it should be safe.

Description: Fix recursive dependency for `make menuconfig`, issue #12938.
(The DCO fails as I signed-off the commit by my usual credentials, but I created it with github's online editor.)
