### PR TITLE
modemmanager: avoid requiring autoreconf to build package

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.65.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/2.65
@@ -116,6 +116,11 @@ define Build/InstallDev
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/share/aclocal/*.m4  \
 		$(2)/share/aclocal/
+
+	$(INSTALL_DIR) $(1)/usr/share/glib-2.0
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/share/glib-2.0/codegen \
+		$(1)/usr/share/glib-2.0/
 endef
 
 define Package/glib2/install

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.14.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
@@ -20,10 +20,9 @@ PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
-PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_DEPENDS:=glib2/host libxslt/host
+PKG_BUILD_DEPENDS:=libxslt/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -76,10 +75,6 @@ define Build/Prepare
 	( cd "$(PKG_BUILD_DIR)"; \
 		printf "all:\ninstall:\n" >po/Makefile.in.in; \
 	)
-	$(SED) 's|^\(GLIB_MKENUMS\)=.*|\1=$(STAGING_DIR_HOSTPKG)/bin/glib-mkenums|' \
-		$(PKG_BUILD_DIR)/configure.ac
-	$(SED) 's|^\(GDBUS_CODEGEN\)=.*|\1=$(STAGING_DIR_HOSTPKG)/bin/gdbus-codegen|' \
-		$(PKG_BUILD_DIR)/configure.ac
 endef
 
 define Build/InstallDev


### PR DESCRIPTION
Do not manually overwrite the paths of gdbus-codegen or glib-mkenums
in the ModemManager package build, as modifying the configure.ac ends
up requiring a full autoreconf.

Since MM 1.14, git builds or autoreconf-ed source package builds
require autoconf-archive installed in the build system, and so the
build would fail if this happens.

The update to overwrite the paths was to force using the gdbus-codegen
and glib-mkenums provided by the "host" glib2 package instead of the
"target" glib2 package (see fa8ad6e),
but these tools are really the same in both as they're python
programs, arch independent.

Tested in a local build where the setup detects and uses the correct
glib tool paths from the target:
  /home/user/openwrt/staging_dir/target-mips_24kc_musl/usr/bin/gdbus-codegen
  /home/user/openwrt/staging_dir/target-mips_24kc_musl/usr/bin/glib-mkenums

Fixes https://github.com/openwrt/packages/issues/12958

Signed-off-by: Aleksander Morgado <aleksander@aleksander.es>

Maintainer: @nickberry17 
