### PR TITLE
 fuse3: update to 3.9.2 /  sshfs: update to 3.7.0

### DIFF
--- a/net/sshfs/Makefile
+++ b/net/sshfs/Makefile
@@ -8,48 +8,34 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sshfs
-PKG_VERSION:=2.10
+PKG_VERSION:=3.7.0
 PKG_RELEASE:=1
 
-PKG_LICENSE:=GPL-2.0
-PKG_MAINTAINER:=Zoltan HERPAI <wigyori@uid0.hu>
-
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/libfuse/sshfs/releases/download/$(PKG_NAME)-$(PKG_VERSION)
-PKG_HASH:=70845dde2d70606aa207db5edfe878e266f9c193f1956dd10ba1b7e9a3c8d101
+PKG_HASH:=6e7e86831f3066b356e7f16e22f1b8a8f177fda05146f6a5eb821c2fd0541c34
 
-include $(INCLUDE_DIR)/package.mk
+PKG_MAINTAINER:=Zoltan HERPAI <wigyori@uid0.hu>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+
+PKG_INSTALL:=1
+
 include $(INCLUDE_DIR)/nls.mk
+include $(INCLUDE_DIR)/package.mk
+include ../../devel/meson/meson.mk
 
 define Package/sshfs
   TITLE:=SSHFS
-  DEPENDS:=+libfuse +fuse-utils +glib2 +libpthread
+  DEPENDS:=+fuse3-utils +glib2 +libpthread
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Filesystem
-  URL:=http://fuse.sourceforge.net/
+  URL:=https://github.com/libfuse/sshfs
 endef
 
 define Package/sshfs/description
 	Mount remote system over sftp.
-endef
-
-CONFIGURE_VARS += \
-	SSHFS_CFLAGS=" \
-		-D_FILE_OFFSET_BITS=64 \
-		-I$(STAGING_DIR)/usr/include/glib-2.0 \
-		-I$(STAGING_DIR)/usr/lib/glib-2.0/include \
-		-I$(STAGING_DIR)/usr/include/fuse" \
-	SSHFS_LIBS=" \
-		-lglib-2.0 -liconv $(if $(INTL_FULL),-lintl) -lfuse -pthread -lgthread-2.0 \
-		-L$(STAGING_DIR)/usr/lib"
-
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		ARCH="$(LINUX_KARCH)" \
-		CROSS_COMPILE="$(TARGET_CROSS)" \
-		DESTDIR="$(PKG_INSTALL_DIR)" \
-		all install
 endef
 
 define Package/sshfs/install

--- a/net/sshfs/patches/010-fuse3.patch
+++ b/net/sshfs/patches/010-fuse3.patch
@@ -1,0 +1,11 @@
+--- a/meson.build
++++ b/meson.build
+@@ -51,7 +51,7 @@ sshfs_deps = [ dependency('fuse3', version: '>= 3.1.0'),
+ executable('sshfs', sshfs_sources,
+            include_directories: include_dirs,
+            dependencies: sshfs_deps,
+-           c_args: ['-DFUSE_USE_VERSION=31'],
++           c_args: ['-DFUSE_USE_VERSION=30'],
+            install: true,
+            install_dir: get_option('bindir'))
+ 

--- a/utils/fuse3/Makefile
+++ b/utils/fuse3/Makefile
@@ -8,46 +8,74 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
-PKG_NAME:=libfuse3
-PKG_VERSION:=3.9.1
+PKG_NAME:=fuse3
+PKG_VERSION:=3.9.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=fuse-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/libfuse/libfuse/releases/download/fuse-$(PKG_VERSION)
-PKG_HASH:=1bafcfd6c66ba35b7b0beb822532a9106eb8409ad6cde988888fde85f89be645
+PKG_HASH:=6999b6d48e7c0a79628fa901f6e66def3513cab4ffdd8097821e7dc3cdeae08a
 PKG_BUILD_DIR:=$(BUILD_DIR)/fuse-$(PKG_VERSION)
 
 PKG_MAINTAINER:=
 PKG_CPE_ID:=cpe:/a:fuse_project:fuse
 
 PKG_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=meson/host
 
 include $(INCLUDE_DIR)/package.mk
 include ../../devel/meson/meson.mk
 
+define Package/fuse3/Default
+  TITLE:=FUSE
+  URL:=https://github.com/libfuse/libfuse
+  SUBMENU:=Filesystem
+endef
+
+define Package/fuse3/Default/description
+ fuse3 (Filesystem in UserSpacE)
+endef
+
 define Package/libfuse3
-  TITLE:=FUSE3 library
+$(call Package/fuse3/Default)
+  TITLE+= library
   URL:=https://github.com/libfuse/libfuse
   SECTION:=libs
   CATEGORY:=Libraries
   DEPENDS:=+kmod-fuse +libpthread
-  SUBMENU:=Filesystem
-  ABI_VERSION:=1
+  ABI_VERSION:=3
   LICENSE:=LGPL-2.1-only
   LICENSE_FILES:=LGPL2.txt
 endef
 
 define Package/libfuse3/description
- fuse3 (Filesystem in UserSpacE)
+$(call Package/fuse3/Default/description)
  This package contains the fuse3 shared libraries, needed by other programs.
  - libfuse3
 endef
 
+define Package/fuse3-utils
+$(call Package/fuse3/Default)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libfuse3
+  TITLE+= (utilities)
+  SUBMENU:=Filesystem
+  LICENSE:=GPL-2.0-only
+  LICENSE_FILES:=COPYING
+endef
+
+define Package/fuse3-utils/description
+$(call Package/fuse3/Default/description)
+ This package contains the FUSE utilities.
+ - fusermount3
+ - mount.fuse3
+endef
+
 MESON_ARGS += \
 	-Ddisable-mtab=true \
-	-Dutils=false \
+	-Dudevrulesdir=/dev/null \
+	-Dutils=$(if $(CONFIG_PACKAGE_fuse3-utils),true,false) \
 	-Dexamples=false \
 	-Duseroot=false
 
@@ -65,4 +93,12 @@ define Package/libfuse3/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfuse3.so.* $(1)/usr/lib/
 endef
 
+define Package/fuse3-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/fusermount3 $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/mount.fuse3 $(1)/usr/sbin/
+endef
+
 $(eval $(call BuildPackage,libfuse3))
+$(eval $(call BuildPackage,fuse3-utils))


### PR DESCRIPTION
Added the mount utilities. It turns out that udev is not a requirement.

Renamed package to fuse3 and moved to utils, as with fuse2.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

sshfs: update to 3.7.0

Simplified Makefile as a result of meson transition.

Fixed license information.

Updated URL.

Added patch to fix linking issue.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @wigyori 
Compile tested: arc700