### PR TITLE
openvswitch: fix build with kernel 4.14.187 and handle libunwind dependency

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -156,7 +156,7 @@ ovs_kmod_openvswitch-lisp-intree_depends:= +kmod-openvswitch-intree
 ovs_kmod_openvswitch-lisp-intree_files:= $(ovs_kmod_intree_dir)/vport-lisp.ko
 $(eval $(call OvsKmodPackageTemplate,openvswitch-lisp-intree))
 
-ovs_common_depends:= +libatomic +libunbound +libunwind
+ovs__common_depends:= +libatomic +libunbound +libunwind
 
 # Dependency review
 #

--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -17,7 +17,7 @@ include ./openvswitch.mk
 #
 PKG_NAME:=openvswitch
 PKG_VERSION:=$(ovs_version)
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openvswitch.org/releases/
 PKG_HASH:=dd5f727427e36cab22bdeae61529d8c8fccacc53d968cfa7658f7f935ddda531

--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -17,7 +17,7 @@ include ./openvswitch.mk
 #
 PKG_NAME:=openvswitch
 PKG_VERSION:=$(ovs_version)
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openvswitch.org/releases/
 PKG_HASH:=dd5f727427e36cab22bdeae61529d8c8fccacc53d968cfa7658f7f935ddda531
@@ -156,7 +156,7 @@ ovs_kmod_openvswitch-lisp-intree_depends:= +kmod-openvswitch-intree
 ovs_kmod_openvswitch-lisp-intree_files:= $(ovs_kmod_intree_dir)/vport-lisp.ko
 $(eval $(call OvsKmodPackageTemplate,openvswitch-lisp-intree))
 
-ovs__common_depends:= +libatomic +libunbound +libunwind
+ovs__common_depends:=+libatomic +librt
 
 # Dependency review
 #
@@ -166,42 +166,46 @@ ovs__common_depends:= +libatomic +libunbound +libunwind
 #
 ovs_libopenvswitch_title:=Open vSwitch (libopenvswitch.so)
 ovs_libopenvswitch_hidden:=1
-ovs_libopenvswitch_depends:=+libopenssl +librt
+ovs_libopenvswitch_depends:=+libopenssl +libunbound +!(arc||arceb):libunwind
+ovs_libopenvswitch_depends+=$(ovs__common_depends)
 ovs_libopenvswitch_files:=usr/lib/libopenvswitch*.so*
 $(eval $(call OvsPackageTemplate,libopenvswitch))
 
 
 ovs_libofproto_title:=Open vSwitch (libofproto.so libsflow.so)
 ovs_libofproto_hidden:=1
-ovs_libofproto_depends:=+librt
+ovs_libofproto_depends+=$(ovs__common_depends)
 ovs_libofproto_files:=usr/lib/libofproto*.so* usr/lib/libsflow*.so*
 $(eval $(call OvsPackageTemplate,libofproto))
 
 
 ovs_libovsdb_title:=Open vSwitch (libovsdb.so)
 ovs_libovsdb_hidden:=1
-ovs_libovsdb_depends:=+librt
+ovs_libovsdb_depends+=$(ovs__common_depends)
 ovs_libovsdb_files:=usr/lib/libovsdb*.so*
 $(eval $(call OvsPackageTemplate,libovsdb))
 
 
 ovs_vswitchd_title:=Open vSwitch (ovs-vswitchd)
 ovs_vswitchd_hidden:=1
-ovs_vswitchd_depends:=+librt +openvswitch-libopenvswitch +openvswitch-libofproto
+ovs_vswitchd_depends:=+openvswitch-libopenvswitch +openvswitch-libofproto
+ovs_vswitchd_depends+=$(ovs__common_depends)
 ovs_vswitchd_files:=usr/sbin/ovs-vswitchd
 $(eval $(call OvsPackageTemplate,vswitchd))
 
 
 ovs_ovsdb_title:=Open vSwitch (ovsdb-server)
 ovs_ovsdb_hidden:=1
-ovs_ovsdb_depends:=+librt +openvswitch-libopenvswitch +openvswitch-libovsdb
+ovs_ovsdb_depends:=+openvswitch-libopenvswitch +openvswitch-libovsdb
+ovs_ovsdb_depends+=$(ovs__common_depends)
 ovs_ovsdb_files:=usr/sbin/ovsdb-server
 $(eval $(call OvsPackageTemplate,ovsdb))
 
 
 ovs_common_title:=Open vSwitch (common files)
 ovs_common_hidden:=1
-ovs_common_depends:=+librt +openvswitch-libopenvswitch +openvswitch-libofproto +openvswitch-libovsdb
+ovs_common_depends:=+openvswitch-libopenvswitch +openvswitch-libofproto +openvswitch-libovsdb
+ovs_common_depends+=$(ovs__common_depends)
 ovs_common_files:= \
 	usr/share/openvswitch/scripts/ovs-lib \
 	usr/share/openvswitch/scripts/ovs-ctl \
@@ -231,8 +235,9 @@ $(eval $(call OvsPackageTemplate,common))
 # uuidgen is required for generating system-id
 ovs_openvswitch_title:=Open vSwitch
 ovs_openvswitch_hidden:=
-ovs_openvswitch_depends:=+librt +coreutils +coreutils-sleep +uuidgen \
+ovs_openvswitch_depends:=+coreutils +coreutils-sleep +uuidgen \
 	+openvswitch-common +openvswitch-vswitchd +openvswitch-ovsdb +kmod-openvswitch
+ovs_openvswitch_depends+=$(ovs__common_depends)
 ovs_openvswitch_files:= usr/share/openvswitch/vswitch.ovsschema
 $(eval $(call OvsPackageTemplate,openvswitch))
 

--- a/net/openvswitch/openvswitch.mk
+++ b/net/openvswitch/openvswitch.mk
@@ -10,7 +10,7 @@ ovs_builddir=$(KERNEL_BUILD_DIR)/openvswitch-$(ovs_version)
 
 # Shared vars, macros
 
-ovs_common_depends:=
+ovs__common_depends:=
 ovs_packages:=
 
 ovs_package_name=$(if $(filter openvswitch,$(1)),openvswitch,openvswitch-$(1))
@@ -22,7 +22,7 @@ define OvsPackageTemplate
      URL:=https://www.openvswitch.org
      TITLE:=$(ovs_$(1)_title)
      HIDDEN:=$(ovs_$(1)_hidden)
-     DEPENDS:=$(ovs_$(1)_depends) $(ovs_common_depends)
+     DEPENDS:=$(ovs_$(1)_depends) $(ovs__common_depends)
   endef
 
   define Package/$(call ovs_package_name,$(1))/install

--- a/net/openvswitch/openvswitch.mk
+++ b/net/openvswitch/openvswitch.mk
@@ -10,7 +10,6 @@ ovs_builddir=$(KERNEL_BUILD_DIR)/openvswitch-$(ovs_version)
 
 # Shared vars, macros
 
-ovs__common_depends:=
 ovs_packages:=
 
 ovs_package_name=$(if $(filter openvswitch,$(1)),openvswitch,openvswitch-$(1))
@@ -22,7 +21,7 @@ define OvsPackageTemplate
      URL:=https://www.openvswitch.org
      TITLE:=$(ovs_$(1)_title)
      HIDDEN:=$(ovs_$(1)_hidden)
-     DEPENDS:=$(ovs_$(1)_depends) $(ovs__common_depends)
+     DEPENDS:=$(ovs_$(1)_depends)
   endef
 
   define Package/$(call ovs_package_name,$(1))/install

--- a/net/openvswitch/patches/0007-compat-Fix-ipv6_dst_lookup-build-error.patch
+++ b/net/openvswitch/patches/0007-compat-Fix-ipv6_dst_lookup-build-error.patch
@@ -1,0 +1,98 @@
+From ab78cc673ebf8e13558fdde459d74538e8cf0760 Mon Sep 17 00:00:00 2001
+From: Yi-Hung Wei <yihung.wei@gmail.com>
+Date: Wed, 29 Apr 2020 14:25:50 -0700
+Subject: [PATCH] compat: Fix ipv6_dst_lookup build error
+
+The geneve/vxlan compat code base invokes ipv6_dst_lookup() which is
+recently replaced by ipv6_dst_lookup_flow() in the stable kernel tree.
+
+This causes travis build failure:
+    * https://travis-ci.org/github/openvswitch/ovs/builds/681084038
+
+This patch updates the backport logic to invoke the right function.
+
+Related patch in
+    git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
+
+b9f3e457098e ("net: ipv6_stub: use ip6_dst_lookup_flow instead of
+               ip6_dst_lookup")
+
+Signed-off-by: Yi-Hung Wei <yihung.wei@gmail.com>
+Signed-off-by: William Tu <u9012063@gmail.com>
+---
+ acinclude.m4                   |  3 +++
+ datapath/linux/compat/geneve.c | 11 +++++++----
+ datapath/linux/compat/vxlan.c  | 14 ++++++++------
+ 3 files changed, 18 insertions(+), 10 deletions(-)
+
+diff --git a/acinclude.m4 b/acinclude.m4
+index c1470ccc6..ebe8b43b5 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -569,7 +569,10 @@ AC_DEFUN([OVS_CHECK_LINUX_COMPAT], [
+ 
+   OVS_GREP_IFELSE([$KSRC/include/net/addrconf.h], [ipv6_dst_lookup.*net],
+                   [OVS_DEFINE([HAVE_IPV6_DST_LOOKUP_NET])])
++  OVS_GREP_IFELSE([$KSRC/include/net/addrconf.h], [ipv6_dst_lookup_flow.*net],
++                  [OVS_DEFINE([HAVE_IPV6_DST_LOOKUP_FLOW_NET])])
+   OVS_GREP_IFELSE([$KSRC/include/net/addrconf.h], [ipv6_stub])
++  OVS_GREP_IFELSE([$KSRC/include/net/addrconf.h], [ipv6_dst_lookup_flow])
+ 
+   OVS_GREP_IFELSE([$KSRC/include/linux/err.h], [ERR_CAST])
+   OVS_GREP_IFELSE([$KSRC/include/linux/err.h], [IS_ERR_OR_NULL])
+diff --git a/datapath/linux/compat/geneve.c b/datapath/linux/compat/geneve.c
+index c044b1489..4bdab6836 100644
+--- a/datapath/linux/compat/geneve.c
++++ b/datapath/linux/compat/geneve.c
+@@ -962,14 +962,17 @@ static struct dst_entry *geneve_get_v6_dst(struct sk_buff *skb,
+ 			return dst;
+ 	}
+ 
+-#ifdef HAVE_IPV6_DST_LOOKUP_NET
++#if defined(HAVE_IPV6_DST_LOOKUP_FLOW_NET)
++	if (ipv6_stub->ipv6_dst_lookup_flow(geneve->net, gs6->sock->sk, &dst,
++                                            fl6)) {
++#elif defined(HAVE_IPV6_DST_LOOKUP_FLOW)
++	if (ipv6_stub->ipv6_dst_lookup_flow(gs6->sock->sk, &dst, fl6)) {
++#elif defined(HAVE_IPV6_DST_LOOKUP_NET)
+ 	if (ipv6_stub->ipv6_dst_lookup(geneve->net, gs6->sock->sk, &dst, fl6)) {
+-#else
+-#ifdef HAVE_IPV6_STUB
++#elif defined(HAVE_IPV6_STUB)
+ 	if (ipv6_stub->ipv6_dst_lookup(gs6->sock->sk, &dst, fl6)) {
+ #else
+ 	if (ip6_dst_lookup(gs6->sock->sk, &dst, fl6)) {
+-#endif
+ #endif
+ 		netdev_dbg(dev, "no route to %pI6\n", &fl6->daddr);
+ 		return ERR_PTR(-ENETUNREACH);
+diff --git a/datapath/linux/compat/vxlan.c b/datapath/linux/compat/vxlan.c
+index 23118e8b6..ff10ae6f4 100644
+--- a/datapath/linux/compat/vxlan.c
++++ b/datapath/linux/compat/vxlan.c
+@@ -990,17 +990,19 @@ static struct dst_entry *vxlan6_get_route(struct vxlan_dev *vxlan,
+ 	fl6.fl6_dport = dport;
+ 	fl6.fl6_sport = sport;
+ 
+-#ifdef HAVE_IPV6_DST_LOOKUP_NET
+-	err = ipv6_stub->ipv6_dst_lookup(vxlan->net,
+-					 sock6->sock->sk,
++#if defined(HAVE_IPV6_DST_LOOKUP_FLOW_NET)
++	err = ipv6_stub->ipv6_dst_lookup_flow(vxlan->net, sock6->sock->sk,
++					      &ndst, &fl6);
++#elif defined(HAVE_IPV6_DST_LOOKUP_FLOW)
++	err = ipv6_stub->ipv6_dst_lookup_flow(sock6->sock->sk, &ndst, &fl6);
++#elif defined(HAVE_IPV6_DST_LOOKUP_NET)
++	err = ipv6_stub->ipv6_dst_lookup(vxlan->net, sock6->sock->sk,
+ 					 &ndst, &fl6);
+-#else
+-#ifdef HAVE_IPV6_STUB
++#elif defined(HAVE_IPV6_STUB)
+ 	err = ipv6_stub->ipv6_dst_lookup(vxlan->vn6_sock->sock->sk,
+ 					 &ndst, &fl6);
+ #else
+ 	err = ip6_dst_lookup(vxlan->vn6_sock->sock->sk, &ndst, &fl6);
+-#endif
+ #endif
+ 	if (err < 0)
+ 		return ERR_PTR(err);

--- a/net/openvswitch/patches/0008-compat-Backport-ipv6_stub-change.patch
+++ b/net/openvswitch/patches/0008-compat-Backport-ipv6_stub-change.patch
@@ -1,0 +1,106 @@
+From 28f52edd7f6978fcd97442312122543bae32597d Mon Sep 17 00:00:00 2001
+From: Greg Rose <gvrose8192@gmail.com>
+Date: Thu, 21 May 2020 14:54:03 -0700
+Subject: [PATCH] compat: Backport ipv6_stub change
+
+A patch backported to the Linux stable 4.14 tree and present in the
+latest stable 4.14.181 kernel breaks ipv6_stub usage.
+
+The commit is
+8ab8786f78c3 ("net ipv6_stub: use ip6_dst_lookup_flow instead of ip6_dst_lookup").
+
+Create the compat layer define to check for it and fixup usage in vxlan
+and geneve modules.
+
+Passes Travis here:
+https://travis-ci.org/github/gvrose8192/ovs-experimental/builds/689798733
+
+Signed-off-by: Greg Rose <gvrose8192@gmail.com>
+Signed-off-by: William Tu <u9012063@gmail.com>
+---
+ acinclude.m4                   |  2 ++
+ datapath/linux/compat/geneve.c | 11 ++++++++++-
+ datapath/linux/compat/vxlan.c  | 18 +++++++++++++++++-
+ 3 files changed, 29 insertions(+), 2 deletions(-)
+
+diff --git a/acinclude.m4 b/acinclude.m4
+index ebe8b43b5..c47a77ed6 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -567,6 +567,8 @@ AC_DEFUN([OVS_CHECK_LINUX_COMPAT], [
+   OVS_GREP_IFELSE([$KSRC/include/net/ip6_fib.h], [rt6_get_cookie],
+                   [OVS_DEFINE([HAVE_RT6_GET_COOKIE])])
+ 
++  OVS_FIND_FIELD_IFELSE([$KSRC/include/net/addrconf.h], [ipv6_stub],
++                        [dst_entry])
+   OVS_GREP_IFELSE([$KSRC/include/net/addrconf.h], [ipv6_dst_lookup.*net],
+                   [OVS_DEFINE([HAVE_IPV6_DST_LOOKUP_NET])])
+   OVS_GREP_IFELSE([$KSRC/include/net/addrconf.h], [ipv6_dst_lookup_flow.*net],
+diff --git a/datapath/linux/compat/geneve.c b/datapath/linux/compat/geneve.c
+index 4bdab6836..bf995aa83 100644
+--- a/datapath/linux/compat/geneve.c
++++ b/datapath/linux/compat/geneve.c
+@@ -962,7 +962,16 @@ static struct dst_entry *geneve_get_v6_dst(struct sk_buff *skb,
+ 			return dst;
+ 	}
+ 
+-#if defined(HAVE_IPV6_DST_LOOKUP_FLOW_NET)
++#if defined(HAVE_IPV6_STUB_WITH_DST_ENTRY) && defined(HAVE_IPV6_DST_LOOKUP_FLOW)
++#ifdef HAVE_IPV6_DST_LOOKUP_FLOW_NET
++	dst = ipv6_stub->ipv6_dst_lookup_flow(geneve->net, gs6->sock->sk, fl6,
++					      NULL);
++#else
++	dst = ipv6_stub->ipv6_dst_lookup_flow(gs6->sock->sk, fl6,
++					      NULL);
++#endif
++	if (IS_ERR(dst)) {
++#elif defined(HAVE_IPV6_DST_LOOKUP_FLOW_NET)
+ 	if (ipv6_stub->ipv6_dst_lookup_flow(geneve->net, gs6->sock->sk, &dst,
+                                             fl6)) {
+ #elif defined(HAVE_IPV6_DST_LOOKUP_FLOW)
+diff --git a/datapath/linux/compat/vxlan.c b/datapath/linux/compat/vxlan.c
+index ff10ae6f4..05ccfb928 100644
+--- a/datapath/linux/compat/vxlan.c
++++ b/datapath/linux/compat/vxlan.c
+@@ -967,7 +967,10 @@ static struct dst_entry *vxlan6_get_route(struct vxlan_dev *vxlan,
+ 	bool use_cache = (dst_cache && ip_tunnel_dst_cache_usable(skb, info));
+ 	struct dst_entry *ndst;
+ 	struct flowi6 fl6;
++#if !defined(HAVE_IPV6_STUB_WITH_DST_ENTRY) || \
++    !defined(HAVE_IPV6_DST_LOOKUP_FLOW)
+ 	int err;
++#endif
+ 
+ 	if (!sock6)
+ 		return ERR_PTR(-EIO);
+@@ -990,7 +993,15 @@ static struct dst_entry *vxlan6_get_route(struct vxlan_dev *vxlan,
+ 	fl6.fl6_dport = dport;
+ 	fl6.fl6_sport = sport;
+ 
+-#if defined(HAVE_IPV6_DST_LOOKUP_FLOW_NET)
++#if defined(HAVE_IPV6_STUB_WITH_DST_ENTRY) && defined(HAVE_IPV6_DST_LOOKUP_FLOW)
++#ifdef HAVE_IPV6_DST_LOOKUP_FLOW_NET
++	ndst = ipv6_stub->ipv6_dst_lookup_flow(vxlan->net, sock6->sock->sk,
++					       &fl6, NULL);
++#else
++	ndst = ipv6_stub->ipv6_dst_lookup_flow(sock6->sock->sk, &fl6, NULL);
++#endif
++	if (unlikely(IS_ERR(ndst))) {
++#elif defined(HAVE_IPV6_DST_LOOKUP_FLOW_NET)
+ 	err = ipv6_stub->ipv6_dst_lookup_flow(vxlan->net, sock6->sock->sk,
+ 					      &ndst, &fl6);
+ #elif defined(HAVE_IPV6_DST_LOOKUP_FLOW)
+@@ -1004,8 +1015,13 @@ static struct dst_entry *vxlan6_get_route(struct vxlan_dev *vxlan,
+ #else
+ 	err = ip6_dst_lookup(vxlan->vn6_sock->sock->sk, &ndst, &fl6);
+ #endif
++#if defined(HAVE_IPV6_STUB_WITH_DST_ENTRY) && defined(HAVE_IPV6_DST_LOOKUP_FLOW)
++		return ERR_PTR(-ENETUNREACH);
++	}
++#else
+ 	if (err < 0)
+ 		return ERR_PTR(err);
++#endif
+ 
+ 	*saddr = fl6.saddr;
+ 	if (use_cache)

--- a/net/openvswitch/patches/0009-build-only-link-libopenvswitch-with-libunwind-libunb.patch
+++ b/net/openvswitch/patches/0009-build-only-link-libopenvswitch-with-libunwind-libunb.patch
@@ -1,0 +1,60 @@
+From 6324f0c594e3773c754861e630fff694d1bec15a Mon Sep 17 00:00:00 2001
+From: Yousong Zhou <yszhou4tech@gmail.com>
+Date: Wed, 29 Jul 2020 17:29:14 +0800
+Subject: [PATCH] build: only link libopenvswitch with libunwind, libunbound
+
+Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
+---
+ lib/automake.mk          | 2 ++
+ lib/libopenvswitch.pc.in | 2 +-
+ m4/openvswitch.m4        | 6 ++++--
+ 3 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/lib/automake.mk b/lib/automake.mk
+index 95925b57c..df95bea10 100644
+--- a/lib/automake.mk
++++ b/lib/automake.mk
+@@ -10,6 +10,8 @@ lib_LTLIBRARIES += lib/libopenvswitch.la
+ lib_libopenvswitch_la_LIBADD = $(SSL_LIBS)
+ lib_libopenvswitch_la_LIBADD += $(CAPNG_LDADD)
+ lib_libopenvswitch_la_LIBADD += $(LIBBPF_LDADD)
++lib_libopenvswitch_la_LIBADD += $(LIBUNBOUND_LDADD)
++lib_libopenvswitch_la_LIBADD += $(LIBUNWIND_LDADD)
+ 
+ if WIN32
+ lib_libopenvswitch_la_LIBADD += ${PTHREAD_LIBS}
+diff --git a/lib/libopenvswitch.pc.in b/lib/libopenvswitch.pc.in
+index 2a3f2ca7b..c8d02eb5a 100644
+--- a/lib/libopenvswitch.pc.in
++++ b/lib/libopenvswitch.pc.in
+@@ -7,5 +7,5 @@ Name: libopenvswitch
+ Description: Open vSwitch library
+ Version: @VERSION@
+ Libs: -L${libdir} -lopenvswitch
+-Libs.private: @LIBS@
++Libs.private: @LIBS@ @SSL_LIBS@ @CAPNG_LDADD@ @LIBBPF_LDADD@ @LIBUNBOUND_LDADD@ @LIBUNWIND_LDADD@
+ Cflags: -I${includedir}/openvswitch
+diff --git a/m4/openvswitch.m4 b/m4/openvswitch.m4
+index ada31c491..6165cc7b1 100644
+--- a/m4/openvswitch.m4
++++ b/m4/openvswitch.m4
+@@ -623,7 +623,8 @@ AC_DEFUN([OVS_CHECK_UNBOUND],
+   [AC_CHECK_LIB(unbound, ub_ctx_create, [HAVE_UNBOUND=yes], [HAVE_UNBOUND=no])
+    if test "$HAVE_UNBOUND" = yes; then
+      AC_DEFINE([HAVE_UNBOUND], [1], [Define to 1 if unbound is detected.])
+-     LIBS="$LIBS -lunbound"
++     LIBUNBOUND_LDADD="-lunbound"
++     AC_SUBST(LIBUNBOUND_LDADD)
+    fi
+    AM_CONDITIONAL([HAVE_UNBOUND], [test "$HAVE_UNBOUND" = yes])
+    AC_SUBST([HAVE_UNBOUND])])
+@@ -635,7 +636,8 @@ AC_DEFUN([OVS_CHECK_UNWIND],
+    [HAVE_UNWIND=no])
+    if test "$HAVE_UNWIND" = yes; then
+      AC_DEFINE([HAVE_UNWIND], [1], [Define to 1 if unwind is detected.])
+-     LIBS="$LIBS -lunwind"
++     LIBUNWIND_LDADD="-lunwind"
++     AC_SUBST(LIBUNWIND_LDADD)
+    fi
+    AM_CONDITIONAL([HAVE_UNWIND], [test "$HAVE_UNWIND" = yes])
+    AC_SUBST([HAVE_UNWIND])])

--- a/net/ovn/Makefile
+++ b/net/ovn/Makefile
@@ -33,7 +33,7 @@ PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-host.mk
 
-ovs_common_depends:= +libatomic +libunbound
+ovs__common_depends:= +libatomic +libunbound
 
 ovs_libovn_title:=Open vSwitch (libovn.so)
 ovs_libovn_hidden:=1

--- a/net/ovn/Makefile
+++ b/net/ovn/Makefile
@@ -10,7 +10,7 @@ include ../openvswitch/openvswitch.mk
 
 PKG_NAME:=ovn
 PKG_VERSION:=20.06.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/ovn-org/ovn.git
@@ -33,18 +33,19 @@ PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-host.mk
 
-ovs__common_depends:= +libatomic +libunbound
+ovs__common_depends:=+libatomic +librt
 
 ovs_libovn_title:=Open vSwitch (libovn.so)
 ovs_libovn_hidden:=1
-ovs_libovn_depends:=+librt
+ovs_libovn_depends+=$(ovs__common_depends)
 ovs_libovn_files:=usr/lib/libovn*.so*
 $(eval $(call OvsPackageTemplate,libovn))
 
 
 ovs_ovn-common_title:=Open Virtual Network (common files)
 ovs_ovn-common_hidden:=1
-ovs_ovn-common_depends:=+librt +openvswitch-common +openvswitch-libopenvswitch +openvswitch-libovn +openvswitch-libovsdb
+ovs_ovn-common_depends:=+openvswitch-common +openvswitch-libopenvswitch +openvswitch-libovn +openvswitch-libovsdb
+ovs_ovn-common_depends+=$(ovs__common_depends)
 ovs_ovn-common_files:= \
 	usr/share/ovn/scripts/ovn-ctl \
 	usr/share/ovn/scripts/ovn-lib \
@@ -58,6 +59,7 @@ $(eval $(call OvsPackageTemplate,ovn-common))
 ovs_ovn-north_title:=Open Virtual Network (north package)
 ovs_ovn-north_hidden:=
 ovs_ovn-north_depends:=+openvswitch-ovsdb +openvswitch-ovn-common
+ovs_ovn-north_depends+=$(ovs__common_depends)
 ovs_ovn-north_files:=\
 	usr/share/ovn/ovn-nb.ovsschema \
 	usr/share/ovn/ovn-sb.ovsschema \
@@ -68,6 +70,7 @@ $(eval $(call OvsPackageTemplate,ovn-north))
 ovs_ovn-host_title:=Open Virtual Network (chassis package)
 ovs_ovn-host_hidden:=
 ovs_ovn-host_depends:=+openvswitch +openvswitch-ovn-common
+ovs_ovn-host_depends+=$(ovs__common_depends)
 ovs_ovn-host_files:=usr/bin/ovn-controller
 $(eval $(call OvsPackageTemplate,ovn-host))
 

--- a/net/ovn/patches/0001-build-skip-check-and-use-of-libunbound.patch
+++ b/net/ovn/patches/0001-build-skip-check-and-use-of-libunbound.patch
@@ -1,0 +1,22 @@
+From f3cc8c83993486b9d35557f2bd85038d5bb96bc5 Mon Sep 17 00:00:00 2001
+From: Yousong Zhou <yszhou4tech@gmail.com>
+Date: Wed, 29 Jul 2020 20:09:56 +0800
+Subject: [PATCH] build: skip check and use of libunbound
+
+Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
+---
+ configure.ac | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 2bcd1945b..ad550fff8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -130,7 +130,6 @@ OVS_CHECK_LINUX_HOST
+ OVS_LIBTOOL_VERSIONS
+ OVS_CHECK_CXX
+ AX_FUNC_POSIX_MEMALIGN
+-OVN_CHECK_UNBOUND
+ 
+ OVS_CHECK_INCLUDE_NEXT([stdio.h string.h])
+ AC_CONFIG_FILES([lib/libovn.sym])

--- a/net/ovn/patches/0002-build-skip-tests-and-docs.patch
+++ b/net/ovn/patches/0002-build-skip-tests-and-docs.patch
@@ -1,18 +1,22 @@
-From d048a1e98363197c0d2609f6adb6919bde473df4 Mon Sep 17 00:00:00 2001
+From cea7c74ecc4a0843f29ce1882d7876fff199a721 Mon Sep 17 00:00:00 2001
 From: Yousong Zhou <yszhou4tech@gmail.com>
 Date: Mon, 23 Mar 2020 14:18:30 +0800
-Subject: [PATCH] build: skip building tests
+Subject: [PATCH] build: skip tests and docs
 
 Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
 ---
- Makefile.am | 1 -
- 1 file changed, 1 deletion(-)
+ Makefile.am | 2 --
+ 1 file changed, 2 deletions(-)
 
 diff --git a/Makefile.am b/Makefile.am
-index 04400e184..b2c42d84c 100644
+index 04400e184..c12cfcd11 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -492,7 +492,6 @@ include Documentation/automake.mk
+@@ -488,11 +488,9 @@ dist-docs:
+ 
+ 
+ include automake.mk
+-include Documentation/automake.mk
  include m4/automake.mk
  include lib/automake.mk
  include utilities/automake.mk

--- a/net/ovn/patches/0003-ovn-lib-fix-install_dir.patch
+++ b/net/ovn/patches/0003-ovn-lib-fix-install_dir.patch
@@ -1,4 +1,4 @@
-From ecf232bf32dd433642bb9da2ac0c2de483b8736a Mon Sep 17 00:00:00 2001
+From 7385d1e67dda100853cf748034220cdbed6b3d7c Mon Sep 17 00:00:00 2001
 From: Yousong Zhou <yszhou4tech@gmail.com>
 Date: Mon, 23 Mar 2020 15:54:26 +0800
 Subject: [PATCH] ovn-lib: fix install_dir()


### PR DESCRIPTION
Maintainer: me
Compile tested: x86/64
Run tested: x86/64, qemu, ldd, kconfig, and run check

Description:
