### PR TITLE
runc/containerd/libnetwork: Refactored Makefiles

### DIFF
--- a/utils/containerd/Makefile
+++ b/utils/containerd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=containerd
 PKG_VERSION:=1.2.13
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -51,7 +51,6 @@ GO_PKG_INSTALL_ALL:=1
 MAKE_PATH:=$(GO_PKG_WORK_DIR_NAME)/build/src/$(GO_PKG)
 MAKE_VARS += $(GO_PKG_VARS)
 MAKE_FLAGS += \
-	DESTDIR="$(PKG_INSTALL_DIR)" \
 	VERSION=$(PKG_VERSION) \
 	REVISION=$(PKG_SOURCE_VERSION)
 
@@ -61,16 +60,8 @@ else
 MAKE_FLAGS += BUILDTAGS=''
 endif
 
-define Build/Compile
-	$(call Build/Compile/Default)
-endef
-
-# Avoid installing binaries
-define Build/InstallDev
-	$(call Build/Compile/Default,clean)
-	rm -f $(STAMP_BUILT)
-	$(call GoPackage/Build/InstallDev,$(1))
-endef
+# Reset golang-package.mk overrides so we can use the Makefile
+Build/Compile=$(call Build/Compile/Default)
 
 define Package/containerd/install
 	$(INSTALL_DIR) $(1)/usr/bin/

--- a/utils/libnetwork/Makefile
+++ b/utils/libnetwork/Makefile
@@ -1,14 +1,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnetwork
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
-
-GO_PKG:=github.com/docker/libnetwork
-GO_PKG_BUILD_PKG:= \
-  $(GO_PKG)/cmd/proxy \
-  $(GO_PKG)/cmd/dnet
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://$(GO_PKG)
@@ -20,6 +15,11 @@ PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
+
+GO_PKG:=github.com/docker/libnetwork
+GO_PKG_BUILD_PKG:= \
+  $(GO_PKG)/cmd/proxy \
+  $(GO_PKG)/cmd/dnet
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk

--- a/utils/runc/Makefile
+++ b/utils/runc/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=runc
 PKG_VERSION:=1.0.0-rc10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -15,6 +15,7 @@ PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
 PKG_USE_MIPS16:=0
 
 GO_PKG:=github.com/opencontainers/runc
@@ -50,8 +51,7 @@ endef
 GO_PKG_INSTALL_ALL:=1
 MAKE_PATH:=$(GO_PKG_WORK_DIR_NAME)/build/src/$(GO_PKG)
 MAKE_VARS += $(GO_PKG_VARS)
-MAKE_FLAGS += \
-	COMMIT=$(PKG_SOURCE_VERSION)
+MAKE_FLAGS += COMMIT=$(PKG_SOURCE_VERSION)
 
 ifeq ($(ARCH),mips)
 MAKE_FLAGS += EXTRA_FLAGS='-buildmode=default'
@@ -63,16 +63,8 @@ else
 MAKE_FLAGS += BUILDTAGS=''
 endif
 
-define Build/Compile
-	$(call Build/Compile/Default)
-endef
-
-# Avoid installing binaries
-define Build/InstallDev
-	$(call Build/Compile/Default,clean)
-	rm -f $(STAMP_BUILT)
-	$(call GoPackage/Build/InstallDev,$(1))
-endef
+# Reset golang-package.mk overrides so we can use the Makefile
+Build/Compile=$(call Build/Compile/Default)
 
 define Package/runc/install
 	$(INSTALL_DIR) $(1)/usr/sbin/


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: x86_x64, Hyper-V, OpenWrt Master
Run tested: x86_x64, Hyper-V, OpenWrt Master

Description:
Refactored packages to help address broken workflows mentioned in https://github.com/openwrt/packages/pull/11439, I wasn't able to reproduce their issue per sey, but this simplifies the makefiles regardless.
