### PR TITLE
libqmi: bump libqmi to 1.26.2

### DIFF
--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_VERSION:=1.26.0
+PKG_VERSION:=1.26.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
-PKG_HASH:=7f0429e0ae58792e21512d09ca2412537840ea42696762795af1284a65fd6e40
+PKG_HASH:=133467b2fe0706850eb587c0103ae6e61b97ce6e2c440d66358f2b72b0db7b03
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 


### PR DESCRIPTION
Signed-off-by: Nicholas Smith <nicholas.smith@telcoantennas.com.au>

Maintainer: me
Compile tested: ath79, Telco T1, master
Run tested: ath79, Telco T1, master, ran basic functions

Description:
More information https://lists.freedesktop.org/archives/libqmi-devel/2020-July/003360.html
