### PR TITLE
glib2: add back gettext dependencies

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.65.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/2.65
@@ -22,8 +22,8 @@ PKG_CPE_ID:=cpe:/a:gnome:glib
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/glib-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/glib-$(PKG_VERSION)
-PKG_BUILD_DEPENDS:=meson/host libiconv/host
-HOST_BUILD_DEPENDS:=meson/host libiconv/host libffi/host
+PKG_BUILD_DEPENDS:=meson/host
+HOST_BUILD_DEPENDS:=meson/host gettext-full/host libiconv/host libffi/host
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/host-build.mk
@@ -34,7 +34,7 @@ include ../../devel/meson/meson.mk
 define Package/glib2
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=$(ICONV_DEPENDS) +zlib +libpthread +libffi +libattr
+  DEPENDS:=$(ICONV_DEPENDS) $(INTL_DEPENDS) +zlib +libpthread +libffi +libattr
   TITLE:=glib 2.0
   URL:=http://www.gtk.org/
 endef
@@ -43,11 +43,12 @@ define Package/glib2/description
   The GLib library of C routines
 endef
 
-HOST_LDFLAGS += -liconv -Wl,-rpath=$(STAGING_DIR_HOSTPKG)/lib
+HOST_LDFLAGS += -Wl,-rpath=$(STAGING_DIR_HOSTPKG)/lib
 TARGET_CFLAGS += -ffunction-sections -fdata-sections
-TARGET_LDFLAGS += -Wl,--gc-sections -liconv
+TARGET_LDFLAGS += -Wl,--gc-sections
 
 COMP_ARGS= \
+	-Diconv=external \
 	-Dselinux=disabled \
 	-Dlibmount=disabled \
 	-Dinternal_pcre=true \
@@ -59,8 +60,10 @@ COMP_ARGS= \
 	-Dforce_posix_threads=true \
 	-Dfam=false \
 	-Dinstalled_tests=false \
-	-Dnls=disabled \
-	-Doss_fuzz=disabled
+	-Dnls=$(if $(CONFIG_BUILD_NLS),en,dis)abled \
+	-Doss_fuzz=disabled \
+	-Dglib_assert=false \
+	-Dglib_checks=false
 
 MESON_HOST_ARGS += $(COMP_ARGS) -Dxattr=false
 MESON_ARGS += $(COMP_ARGS) -Dxattr=true -Db_lto=true

--- a/libs/glib2/patches/001-no-libelf.patch
+++ b/libs/glib2/patches/001-no-libelf.patch
@@ -1,6 +1,6 @@
 --- a/gio/meson.build
 +++ b/gio/meson.build
-@@ -870,20 +870,6 @@ endif
+@@ -881,20 +881,6 @@ endif
  
  # Dependencies used by executables below
  have_libelf = false

--- a/libs/glib2/patches/002-no-tests.patch
+++ b/libs/glib2/patches/002-no-tests.patch
@@ -1,6 +1,6 @@
 --- a/meson.build
 +++ b/meson.build
-@@ -84,7 +84,7 @@ installed_tests_template = files('template.test.in')
+@@ -94,7 +94,7 @@ installed_tests_template = files('template.test.in')
  installed_tests_template_tap = files('template-tap.test.in')
  
  # Don’t build the tests unless we can run them (either natively, in an exe wrapper, or by installing them for later use)

--- a/libs/glib2/patches/003-valgrind.h-mips16-fix.patch
+++ b/libs/glib2/patches/003-valgrind.h-mips16-fix.patch
@@ -1,6 +1,6 @@
 --- a/glib/valgrind.h	2019-12-12 14:53:26.000200499 +0100
 +++ b/glib/valgrind.h	2019-12-12 14:49:45.056163300 +0100
-@@ -157,7 +157,7 @@
+@@ -158,7 +158,7 @@
  #  define PLAT_s390x_linux 1
  #elif defined(__linux__) && defined(__mips__) && (__mips==64)
  #  define PLAT_mips64_linux 1

--- a/libs/glib2/patches/005-intl-fix.patch
+++ b/libs/glib2/patches/005-intl-fix.patch
@@ -1,0 +1,11 @@
+--- a/meson.build
++++ b/meson.build
+@@ -1955,7 +1955,7 @@ endif
+ # FIXME: glib-gettext.m4 has much more checks to detect broken/uncompatible
+ # implementations. This could be extended if issues are found in some platforms.
+ libintl_deps = []
+-if cc.has_function('ngettext')
++if false
+   have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset')
+ else
+   # First just find the bare library.


### PR DESCRIPTION
The libintl check is broken in meson.build. Patched it and added back
the gettext build dependencies. Avoids the proxy-intl thing that glib2
likes to use. Also fixes several problems under uClibc-ng.

Updated configure options.

Refreshed patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 
Compile tested: arc700 with irqbalance