### PR TITLE
clamav: update to version 0.102.4 (security fix)

### DIFF
--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=clamav
-PKG_VERSION:=0.102.3
+PKG_VERSION:=0.102.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.clamav.net/downloads/production/
-PKG_HASH:=ed3050c4569989ee7ab54c7b87246b41ed808259632849be0706467442dc0693
+PKG_HASH:=eebd426a68020ecad0d2084b8c763e6898ccfd5febcae833d719640bb3ff391b
 
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr> \
 		Lucian Cristian <lucian.cristian@gmail.com>


### PR DESCRIPTION
Maintainer: @ratkaj @lucize 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates ClamAV to version 0.102.4 
Fixes [CVE-2020-3481](https://nvd.nist.gov/vuln/detail/CVE-2020-3481)

Affected versions  0.102.0 - 0.102.3 

