### PR TITLE
xtables-addons: update for 3.10

### DIFF
--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -9,16 +9,15 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=xtables-addons
-PKG_VERSION:=3.9
-PKG_RELEASE:=3
-PKG_HASH:=064dd68937d98e6cfcbdf51ef459310d9810c17ab31b21285bc7a76cdcef7c49
+PKG_VERSION:=3.10
+PKG_RELEASE:=1
+PKG_HASH:=b783ecbab46ff3534a0aaff2baacc79553f685697b1f034ca61698443b8210dc
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=@SF/xtables-addons
+PKG_SOURCE_URL:=https://inai.de/files/xtables-addons/
 PKG_BUILD_DEPENDS:=iptables
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_CHECK_FORMAT_SECURITY:=0
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=GPL-2.0
@@ -33,7 +32,7 @@ define Package/xtables-addons
   CATEGORY:=Network
   SUBMENU:=Firewall
   TITLE:=Extensions not distributed in the main Xtables
-  URL:=http://xtables-addons.sourceforge.net/
+  URL:=https://inai.de/projects/xtables-addons/
 endef
 
 # uses GNU configure


### PR DESCRIPTION
Maintainer: @jow-
Compile tested: x86_64, generic, HEAD (f206461)
Run tested: x86_64, generic, HEAD (f2064611), copied image to and reinstalled on production firewall

Description:
