### PR TITLE
ksmbd: update to 3.2.4

### DIFF
--- a/kernel/ksmbd/Makefile
+++ b/kernel/ksmbd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd
-PKG_VERSION:=3.2.2
+PKG_VERSION:=3.2.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/cifsd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=16ad304c09d5f04ddbe99d21ca9df8a9a6d8e35b21ff0e205f212f8c545b979b
+PKG_HASH:=a7beeb0e804b361adf2b79dcd98ccf4b92b2c1fa8a65a39dd4fbb63479cdf7cd
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: arm/mvebu (master)
Run tested: arm/mvebu (master)

Description:
upstream changelog:
```
* cifsd: release 3.2.4 version
* cifsd: don't support FSCTL_VALIDATE_NEGOTIATE_INFO if connect dialect is smaller than SMB3.02
* cifsd: initialize server using init_smb2_0_server() instead of init_smb3_11_server()
* cifsd: fix auto negotiation failure when setting min/max protocol is higher than SMB 2.0
* cifsd: sign session setup response on SMB3.0 and SMB3.02
* cifsd: make 8byte context alignment when there is the next context in negotiate contexts
* cifsd: fix null pointer dereferencing error in ->set_sign_rsp()
* cifsd: ignore EOPNOTSUPP error from ksmbd_vfs_alloc_size
* cifsd: fix warning: unused variable small_sz
* cifsd: release 3.2.3 version
* cifsd: set correct status code on ksmbd_vfs_readdir error
* cifsd: fix stuck issue while writing many files with windows client
* cifsd: return only a single entry if SMB2_RETURN_SINGLE_ENTRY is set
```