### PR TITLE
pulseaudio: fix compilation with ICONV_FULL

### DIFF
--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pulseaudio
 PKG_VERSION:=13.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://freedesktop.org/software/pulseaudio/releases
@@ -143,7 +143,7 @@ MESON_ARGS += \
 	-Ddbus=disabled
 endif
 
-TARGET_LDFLAGS += -Wl,--gc-sections -liconv
+TARGET_LDFLAGS += -Wl,--gc-sections $(if $(INTL_FULL),-lintl)
 
 define Build/Prepare
 	$(call Build/Prepare/Default)

--- a/sound/pulseaudio/patches/010-iconv.patch
+++ b/sound/pulseaudio/patches/010-iconv.patch
@@ -1,0 +1,18 @@
+--- a/meson.build
++++ b/meson.build
+@@ -380,12 +380,11 @@ if dl_dep.found()
+ endif
+ 
+ have_iconv = false
+-if cc.has_function('iconv_open')
++iconv_dep = cc.find_library('iconv', required : false)
++have_iconv = iconv_dep.found()
++if not have_iconv and cc.has_function('iconv_open')
+   iconv_dep = dependency('', required : false)
+   have_iconv = true
+-else
+-  iconv_dep = cc.find_library('iconv', required : false)
+-  have_iconv = iconv_dep.found()
+ endif
+ if have_iconv
+   cdata.set('HAVE_ICONV', 1)


### PR DESCRIPTION
Reordered check to check external iconv first.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 
Compile tested: ath79-glibc arc700