### PR TITLE
nginx-util: fix dependency

### DIFF
--- a/net/nginx-util/Makefile
+++ b/net/nginx-util/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx-util
 PKG_VERSION:=1.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Peter Stadler <peter.stadler@student.uibk.ac.at>
 
 include $(INCLUDE_DIR)/package.mk
@@ -21,6 +21,7 @@ define Package/nginx-ssl-util/default
   # TODO: remove after a transition period (together with below and pkg nginx):
   # It actually removes nginx-util (replacing it by a dummy pkg) to avoid
   # conflicts with nginx-ssl-util*
+  DEPENDS+= +nginx-util
   EXTRA_DEPENDS:=nginx-util (>=1.4-2)
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, x86_64 qemu, master
Run tested: x86_64, x86_64 qemu, master, `make` and run with `luci-ssl-nginx`

Description: Add DEPENDS since EXTRA_DEPENDS is not used by `make menuconfig`. Issue [#12938 no. 2](https://github.com/openwrt/packages/issues/12938#issuecomment-664788535).