### PR TITLE
libextractor: update to 1.10

### DIFF
--- a/libs/libextractor/Makefile
+++ b/libs/libextractor/Makefile
@@ -6,22 +6,25 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libextractor
-PKG_VERSION:=1.9
-PKG_RELEASE:=2
+PKG_VERSION:=1.10
+PKG_RELEASE:=1
 
 # ToDo:
 # - package missing optional dependencies: libexiv2, gsf, librpm, smf, tidy
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
-PKG_HASH:=f08f257d26c5e9b503f068d6753c8e55cb76f47f73a81da6ed2bba3de3fee2ff
+PKG_HASH:=9eed11b5ddc7c929ba112c50de8cfaa379f1d99a0c8e064101775837cf432357
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 
 PKG_INSTALL:=1
-PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_PACKAGE_libextractor-plugin-thumbnailffmpeg \
+	CONFIG_PACKAGE_libextractor-plugin-gstreamer
 
 PLUGINS:= \
 	archive:+libarchive-noopenssl \
@@ -55,10 +58,17 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
 CONFIGURE_ARGS += \
-	--enable-ffmpeg \
-	--with-gstreamer \
+	--$(if $(CONFIG_PACKAGE_libextractor-plugin-thumbnailffmpeg),en,dis)able-ffmpeg \
+	--disable-glibtest \
 	--disable-gsf \
-	--disable-rpath
+	--disable-rpath \
+	--with$(if $(CONFIG_PACKAGE_libextractor-plugin-gstreamer),,out)-gstreamer
+
+CONFIGURE_VARS += \
+	ac_cv_lib_jpeg_jpeg_mem_src=yes
+
+TARGET_LDFLAGS += \
+	-liconv
 
 define Package/libextractor
 	SECTION:=libs

--- a/libs/libextractor/patches/010-musl.patch
+++ b/libs/libextractor/patches/010-musl.patch
@@ -1,5 +1,3 @@
-diff --git a/src/common/le_architecture.h b/src/common/le_architecture.h
-index b863ddb..713acdd 100644
 --- a/src/common/le_architecture.h
 +++ b/src/common/le_architecture.h
 @@ -26,6 +26,8 @@

--- a/libs/libextractor/patches/020-jpeg.patch
+++ b/libs/libextractor/patches/020-jpeg.patch
@@ -1,0 +1,100 @@
+--- a/src/plugins/jpeg_extractor.c
++++ b/src/plugins/jpeg_extractor.c
+@@ -31,8 +31,97 @@ typedef int boolean;
+ #define HAVE_BOOLEAN
+ #endif
+ #include <jpeglib.h>
++#include <jerror.h>
+ #include <setjmp.h>
+ 
++#if JPEG_LIB_VERSION < 80 && !defined(MEM_SRCDST_SUPPORTED)
++typedef struct {
++  struct jpeg_source_mgr pub; /* public fields */
++
++  JOCTET eoi_buffer[2]; /* a place to put a dummy EOI */
++} my_source_mgr;
++
++typedef my_source_mgr * my_src_ptr;
++
++static void
++init_source (j_decompress_ptr cinfo)
++{
++  /* No work, since jpeg_mem_src set up the buffer pointer and count.
++   * Indeed, if we want to read multiple JPEG images from one buffer,
++   * this *must* not do anything to the pointer.
++  */
++}
++
++static boolean
++fill_input_buffer (j_decompress_ptr cinfo)
++{
++  my_src_ptr src = (my_src_ptr) cinfo->src;
++
++  WARNMS(cinfo, JWRN_JPEG_EOF);
++
++  /* Create a fake EOI marker */
++  src->eoi_buffer[0] = (JOCTET) 0xFF;
++  src->eoi_buffer[1] = (JOCTET) JPEG_EOI;
++  src->pub.next_input_byte = src->eoi_buffer;
++  src->pub.bytes_in_buffer = 2;
++
++  return TRUE;
++}
++
++static void
++skip_input_data (j_decompress_ptr cinfo, long num_bytes)
++{
++  my_src_ptr src = (my_src_ptr) cinfo->src;
++
++  if (num_bytes > 0) {
++    while (num_bytes > (long) src->pub.bytes_in_buffer) {
++      num_bytes -= (long) src->pub.bytes_in_buffer;
++      (void) fill_input_buffer(cinfo);
++      /* note we assume that fill_input_buffer will never
++       * return FALSE, so suspension need not be handled.
++       */
++    }
++    src->pub.next_input_byte += (size_t) num_bytes;
++    src->pub.bytes_in_buffer -= (size_t) num_bytes;
++  }
++}
++
++static void
++term_source (j_decompress_ptr cinfo)
++{
++  /* no work necessary here */
++}
++
++static void
++jpeg_mem_src (j_decompress_ptr cinfo, unsigned char * buffer,
++        unsigned long bufsize)
++{
++  my_src_ptr src;
++
++  /* The source object is made permanent so that a series of JPEG images
++   * can be read from a single buffer by calling jpeg_mem_src
++   * only before the first one.
++   * This makes it unsafe to use this manager and a different source
++   * manager serially with the same JPEG object. Caveat programmer.
++  */
++  if (cinfo->src == NULL) { /* first time for this JPEG object? */
++    cinfo->src = (struct jpeg_source_mgr *)
++      (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo,
++                                  JPOOL_PERMANENT,
++                                  sizeof(my_source_mgr));
++  }
++
++  src = (my_src_ptr) cinfo->src;
++  src->pub.init_source = init_source;
++  src->pub.fill_input_buffer = fill_input_buffer;
++  src->pub.skip_input_data = skip_input_data;
++  src->pub.resync_to_restart = jpeg_resync_to_restart; /* use default method */
++  src->pub.term_source = term_source;
++
++  src->pub.next_input_byte = buffer;
++  src->pub.bytes_in_buffer = bufsize;
++}
++#endif
+ 
+ /**
+  * Context for custom functions.


### PR DESCRIPTION
Made two compile options dependent on whether or not the plugins are
selected.

Removed autoreconf as autools files are not being patched.

Added PKG_BUILD_PARALLEL for faster compilation.

Added patch to fix compilation with libjpeg-turbo. libjpeg-turbo can be
fixed to include this API, but it's probably better for size reasons to
patch libextractor instead.

Added -liconv since it seems to be needed for some reason.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: ath79