### PR TITLE
libsodium: compile with scalarmult_ed25519_ref10

### DIFF
--- a/libs/libsodium/Makefile
+++ b/libs/libsodium/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsodium
 PKG_VERSION:=1.0.18
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.libsodium.org/libsodium/releases \

--- a/libs/libsodium/patches/001-revert-f5076db5f8ef27.patch
+++ b/libs/libsodium/patches/001-revert-f5076db5f8ef27.patch
@@ -1,0 +1,36 @@
+--- a/src/libsodium/Makefile.am
++++ b/src/libsodium/Makefile.am
+@@ -59,6 +59,7 @@ libsodium_la_SOURCES = \
+ 	crypto_scalarmult/curve25519/ref10/x25519_ref10.h \
+ 	crypto_scalarmult/curve25519/scalarmult_curve25519.c \
+ 	crypto_scalarmult/curve25519/scalarmult_curve25519.h \
++	crypto_scalarmult/ed25519/ref10/scalarmult_ed25519_ref10.c \
+ 	crypto_secretbox/crypto_secretbox.c \
+ 	crypto_secretbox/crypto_secretbox_easy.c \
+ 	crypto_secretbox/xsalsa20poly1305/secretbox_xsalsa20poly1305.c \
+@@ -160,7 +161,6 @@ libsodium_la_SOURCES += \
+ 	crypto_pwhash/scryptsalsa208sha256/pbkdf2-sha256.h \
+ 	crypto_pwhash/scryptsalsa208sha256/pwhash_scryptsalsa208sha256.c \
+ 	crypto_pwhash/scryptsalsa208sha256/nosse/pwhash_scryptsalsa208sha256_nosse.c \
+-	crypto_scalarmult/ed25519/ref10/scalarmult_ed25519_ref10.c \
+ 	crypto_scalarmult/ristretto255/ref10/scalarmult_ristretto255_ref10.c \
+ 	crypto_secretbox/xchacha20poly1305/secretbox_xchacha20poly1305.c \
+ 	crypto_shorthash/siphash24/shorthash_siphashx24.c \
+--- a/src/libsodium/include/sodium.h
++++ b/src/libsodium/include/sodium.h
+@@ -33,6 +33,7 @@
+ #include "sodium/crypto_pwhash_argon2i.h"
+ #include "sodium/crypto_scalarmult.h"
+ #include "sodium/crypto_scalarmult_curve25519.h"
++#include "sodium/crypto_scalarmult_ed25519.h"
+ #include "sodium/crypto_secretbox.h"
+ #include "sodium/crypto_secretbox_xsalsa20poly1305.h"
+ #include "sodium/crypto_secretstream_xchacha20poly1305.h"
+@@ -57,7 +58,6 @@
+ # include "sodium/crypto_box_curve25519xchacha20poly1305.h"
+ # include "sodium/crypto_core_ed25519.h"
+ # include "sodium/crypto_core_ristretto255.h"
+-# include "sodium/crypto_scalarmult_ed25519.h"
+ # include "sodium/crypto_scalarmult_ristretto255.h"
+ # include "sodium/crypto_secretbox_xchacha20poly1305.h"
+ # include "sodium/crypto_pwhash_scryptsalsa208sha256.h"


### PR DESCRIPTION
Maintainer: @damianorenfer 
Compile tested: x86/64
Run tested: x86/64

Description: compile with scalarmult_ed25519_ref10

scalarmult_ed25519_ref10 was excluded from 'minimal' variant (which is
what we are building) by upstream commit f5076db5f8ef27.
Revert that to allow downstream projects to make use of it (eg. gnunet)

Signed-off-by: Daniel Golle <daniel@makrotopia.org>
