### PR TITLE
exfatprogs: update to 1.0.4

### DIFF
--- a/utils/exfatprogs/Makefile
+++ b/utils/exfatprogs/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=exfatprogs
-PKG_VERSION:=1.0.3
+PKG_VERSION:=1.0.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/$(PKG_NAME)/$(PKG_NAME)/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=5cb2c9e65a1633148d498913508977e6073d6f454a7addfa98623f6d065d5589
+PKG_HASH:=3f755d35785a74138348b3a22dfcda5afc8a69e66a6a0c79be48225e6ca321ce
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Faster fsck.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: ath79