### PR TITLE
python: fix host compile in macos

### DIFF
--- a/lang/python/python-host.mk
+++ b/lang/python/python-host.mk
@@ -41,6 +41,11 @@ define HostPython
 	$(HOST_PYTHON_BIN) $(2);
 endef
 
+HOST_LD_ARG_CONNECTOR:==
+ifeq ($(HOST_OS),Darwin)
+HOST_LD_ARG_CONNECTOR:=,
+endif
+
 define host_python_settings
 	ARCH="$(HOST_ARCH)" \
 	CC="$(HOSTCC)" \
@@ -50,7 +55,7 @@ define host_python_settings
 	LDSHARED="$(HOSTCC) -shared" \
 	CFLAGS="$(HOST_CFLAGS)" \
 	CPPFLAGS="$(HOST_CPPFLAGS) -I$(HOST_PYTHON_INC_DIR)" \
-	LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON_VERSION) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib" \
+	LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON_VERSION) -Wl$(comma)-rpath$(HOST_LD_ARG_CONNECTOR)$(STAGING_DIR_HOSTPKG)/lib" \
 	_PYTHON_HOST_PLATFORM=linux2
 endef
 

--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -268,11 +268,15 @@ define PyPackage/python/filespec
 endef
 
 HOST_LDFLAGS += \
-	$$$$(pkg-config --static --libs libcrypto libssl) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib
+	$$$$(pkg-config --static --libs libcrypto libssl) -Wl$(comma)-rpath$(HOST_LD_ARG_CONNECTOR)$(STAGING_DIR_HOSTPKG)/lib
 
 ifeq ($(HOST_OS),Linux)
 HOST_LDFLAGS += \
 	-Wl,--no-as-needed -lrt
+endif
+
+ifeq ($(HOST_OS),Darwin)
+HOST_LDFLAGS += -framework CoreFoundation
 endif
 
 HOST_CONFIGURE_ARGS+= \

--- a/lang/python/python3-host.mk
+++ b/lang/python/python3-host.mk
@@ -41,6 +41,11 @@ define HostPython3
 	$(HOST_PYTHON3_BIN) $(2);
 endef
 
+HOST_LD_ARG_CONNECTOR:==
+ifeq ($(HOST_OS),Darwin)
+HOST_LD_ARG_CONNECTOR:=,
+endif
+
 define host_python3_settings
 	ARCH="$(HOST_ARCH)" \
 	CC="$(HOSTCC)" \
@@ -50,7 +55,7 @@ define host_python3_settings
 	LDSHARED="$(HOSTCC) -shared" \
 	CFLAGS="$(HOST_CFLAGS)" \
 	CPPFLAGS="$(HOST_CPPFLAGS) -I$(HOST_PYTHON3_INC_DIR)" \
-	LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON3_VERSION) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib" \
+	LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON3_VERSION) -Wl$(comma)-rpath$(HOST_LD_ARG_CONNECTOR)$(STAGING_DIR_HOSTPKG)/lib" \
 	_PYTHON_HOST_PLATFORM=linux2
 endef
 

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -264,11 +264,15 @@ define Py3Package/python3/filespec
 endef
 
 HOST_LDFLAGS += \
-	$$$$(pkg-config --static --libs libcrypto libssl) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib
+	$$$$(pkg-config --static --libs libcrypto libssl) -Wl$(comma)-rpath$(HOST_LD_ARG_CONNECTOR)$(STAGING_DIR_HOSTPKG)/lib
 
 ifeq ($(HOST_OS),Linux)
 HOST_LDFLAGS += \
 	-Wl,--no-as-needed -lrt
+endif
+
+ifeq ($(HOST_OS),Darwin)
+HOST_LDFLAGS += -framework CoreFoundation
 endif
 
 HOST_CONFIGURE_ARGS+= \


### PR DESCRIPTION
Just a fix of compile error in macos.

Signed-off-by: Liangbin Lian <jjm2473@gmail.com>

Maintainer: Alexandru Ardelean <ardeleanalex@gmail.com>
Compile tested: Macos 10.15.6, Openwrt 18.06
Run tested: 

Description:
