### PR TITLE
scons: update to 4.0.1

### DIFF
--- a/devel/scons/Makefile
+++ b/devel/scons/Makefile
@@ -8,15 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=scons
-PKG_VERSION:=3.1.2
+PKG_VERSION:=4.0.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-local-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/scons
-PKG_HASH:=642e90860b746fa18fac08c7a22de6bfa86110ae7c56d7f136f7e5fb0d8f4f44
+PKG_HASH:=23c9d37a008b525bdedfe2666a28b9466c4c945d8ba379873cfd0b9006a3d618
 
+PKG_MAINTAINER:=
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=scons-LICENSE
-PKG_MAINTAINER:=
+
+PKG_HOST_ONLY:=1
+HOST_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
@@ -27,7 +31,8 @@ define Package/scons
   SECTION:=devel
   CATEGORY:=Development
   TITLE:=scons
-  HIDDEN:=1
+  URL:=https://scons.org/
+  BUILDONLY:=1
 endef
 
 define Package/scons/description

--- a/devel/scons/patches/001-platform_env.patch
+++ b/devel/scons/patches/001-platform_env.patch
@@ -1,6 +1,6 @@
---- a/scons-local-3.1.2/SCons/Platform/__init__.py
-+++ b/scons-local-3.1.2/SCons/Platform/__init__.py
-@@ -65,6 +65,8 @@ def platform_default():
+--- a/scons-local-4.0.1/SCons/Platform/__init__.py
++++ b/scons-local-4.0.1/SCons/Platform/__init__.py
+@@ -63,6 +63,8 @@ def platform_default():
      care about the machine architecture.
      """
      osname = os.name

--- a/devel/scons/patches/002-fix-import-path.patch
+++ b/devel/scons/patches/002-fix-import-path.patch
@@ -1,0 +1,10 @@
+--- a/scons.py
++++ b/scons.py
+@@ -56,6 +56,7 @@ if script_path in sys.path:
+     sys.path.remove(script_path)
+ 
+ libs = []
++libs = [os.path.join(os.path.dirname(script_dir), 'lib', 'scons')]
+ 
+ if "SCONS_LIB_DIR" in os.environ:
+     libs.append(os.environ["SCONS_LIB_DIR"])


### PR DESCRIPTION
Cleaned up Makefile to standards.

Replaced HIDDEN with BUILDONLY. It's more descriptive.

Added PKG_HOST_ONLY. This is a host only package.

Added HOST_BUILD_PARALLEL.

Added URL for uscan.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @openwrt/package-maintainers 
Compile tested: Fedora32