### PR TITLE
apfree-wifidog: fix bug of cert generating condition and enable misuse

### DIFF
--- a/net/apfree-wifidog/files/wifidogx.init
+++ b/net/apfree-wifidog/files/wifidogx.init
@@ -62,7 +62,7 @@ prepare_mqtt_conf() {
 
 prepare_wifidog_conf() {
 	local cfg=$1
-	local enable
+	local disabled
 	local gateway_id
 	local gateway_interface
 	local auth_server_hostname
@@ -96,8 +96,8 @@ prepare_wifidog_conf() {
 
 	[ -f ${CONFIGFILE} ] && rm -f ${CONFIGFILE}
 
-	config_get enable "${cfg}" "disabled" 0
-	if [ "${enable}" = "0" ]; then
+	config_get disabled "${cfg}" "disabled" 1
+	if [ "${disabled}" = "1" ]; then
 		echo "wifidogx disabled in /etc/config/wifidogx file, please set disabled to 0 to enable it" >&2
 		return
 	fi
@@ -255,11 +255,11 @@ init_config() {
 		exit
 	fi
 
-	if [ -s "${APFREE_CERT}" ] && [ -s "${APFREE_KEY}" ]; then
+	if [ ! -s "${APFREE_CERT}" ] || [ ! -s "${APFREE_KEY}" ]; then
 		generate_keys
 	fi
 
-	if [ -s ${APFREE_KEY} ] && [ -s ${APFREE_CERT} ]; then
+	if [ ! -s ${APFREE_KEY} ] || [ ! -s ${APFREE_CERT} ]; then
 		echo "no cert or key, exit..." >&2
 		exit
 	fi


### PR DESCRIPTION
Signed-off-by: Dengfeng Liu <dfliuc@isoftstone.com>

Maintainer: me / @liudf0716 
Compile tested: centos 7.7.1908
Run tested: 

Description:
fix bug of cert generating condition and enable misuse