### PR TITLE
netatalk: fix compile error in mac os

### DIFF
--- a/net/netatalk/Makefile
+++ b/net/netatalk/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netatalk
 PKG_VERSION:=3.1.12
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/netatalk
@@ -67,6 +67,7 @@ CONFIGURE_ARGS += \
 	--disable-srvloc \
 	--disable-zeroconf \
 	$(if $(CONFIG_SHADOW_PASSWORDS),--with-shadow,--without-shadow) \
+	--without-dtrace \
 	--without-ldap
 
 define Package/netatalk/conffiles


### PR DESCRIPTION
Maintainer: me
Compile tested: n/a
Run tested: n/a

follow-up on https://github.com/openwrt/packages/pull/12989

-------------------------------

fix compile error in mac os when dtrace installed.

Signed-off-by: Liangbin Lian <jjm2473@gmail.com>
