### PR TITLE
modemmanager: Added options

### DIFF
--- a/net/modemmanager/Config.in
+++ b/net/modemmanager/Config.in
@@ -12,4 +12,10 @@ depends on PACKAGE_modemmanager
 		default y
 		help
 		  Compile ModemManager with QMI support
+
+        config MODEMMANAGER_WITH_AT_COMMAND_VIA_DBUS
+                bool "Allow AT commands via DBus"
+                default n
+                help
+                  Compile ModemManager allowing AT commands without debug flag
 endmenu

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -59,6 +59,10 @@ CONFIGURE_ARGS += \
 	--disable-rpath \
 	--disable-gtk-doc
 
+ifeq ($(CONFIG_MODEMMANAGER_WITH_AT_COMMAND_VIA_DBUS),y)
+  CONFIGURE_ARGS += --with-at-command-via-dbus
+endif
+
 ifdef CONFIG_MODEMMANAGER_WITH_MBIM
   CONFIGURE_ARGS += --with-mbim
 else

--- a/net/modemmanager/README.md
+++ b/net/modemmanager/README.md
@@ -23,6 +23,7 @@ Once installed, you can configure the 2G/3G/4G modem connections directly in
         option pincode     '7423'
         option iptype      'ipv4'
         option lowpower    '1'
+        option signalrate  '30'
 
 Only 'device' and 'proto' are mandatory options, the remaining ones are all
 optional.
@@ -34,3 +35,6 @@ allowing all protocols.
 
 The 'iptype' option supports any of these values: 'ipv4', 'ipv6' or 'ipv4v6'.
 It will default to 'ipv4' if not given.
+
+The 'signalrate' option set's the signal refresh rate (in seconds) for the device.
+You can call signal info with command: mmcli -m 0 --signal-get

--- a/net/modemmanager/files/modemmanager.proto
+++ b/net/modemmanager/files/modemmanager.proto
@@ -343,6 +343,7 @@ proto_modemmanager_init_config() {
 	proto_config_add_string	 password
 	proto_config_add_string	 pincode
 	proto_config_add_string	 iptype
+	proto_config_add_int	 signalrate
 	proto_config_add_boolean lowpower
 	proto_config_add_defaults
 }
@@ -354,11 +355,11 @@ proto_modemmanager_setup() {
 	local bearermethod_ipv4 bearermethod_ipv6 auth cliauth
 	local operatorname operatorid registration accesstech signalquality
 
-	local device apn allowedauth username password pincode iptype metric
+	local device apn allowedauth username password pincode iptype metric signalrate
 
 	local address prefix gateway mtu dns1 dns2
 
-	json_get_vars device apn allowedauth username password pincode iptype metric
+	json_get_vars device apn allowedauth username password pincode iptype metric signalrate
 
 	# validate sysfs path given in config
 	[ -n "${device}" ] || {
@@ -402,6 +403,14 @@ proto_modemmanager_setup() {
 		proto_block_restart "${interface}"
 		return 1
 	}
+
+	# check if Signal refresh rate is set
+	if [ -n "${signalrate}" ] && [ "${signalrate}" -eq "${signalrate}" ] 2>/dev/null; then
+		echo "setting signal refresh rate to ${signalrate} seconds"
+		mmcli --modem="${device}" --signal-setup="${signalrate}"
+	else
+		echo "signal refresh rate is not set"
+	fi
 
 	# log additional useful information
 	modemstatus=$(mmcli --modem="${device}" --output-keyvalue)


### PR DESCRIPTION
Maintainer: @valexi7
Compile tested: ar71xx, MikroTik RouterBoard >= 128MB NAND, OpenWrt master
Run tested: Mikrotik rb912uag-5hpnd, OpenWRT master

Description:

Added:
- Signal refresh rate. This options is reset on every ModemManager restart, so we will set it if it's defined on proto setup. You can ask signal info from modem (mmcli -m 0 --signal-get). This is useful for some scripts or other applications.
- Loglevel check. If you enable debugmode (for sending AT commands to modem) it will automatically set loglevel to debug. With this we can change loglevel to ERR before connecting to avoid cluttered logging.

Question:
- Can we add signal info to netifd proto? It would be great to see SINR, RSSI, RSRQ, RSRP info in interface view.
