### PR TITLE
python-pytest-xdist: add new package

### DIFF
--- a/lang/python/python-apipkg/Makefile
+++ b/lang/python/python-apipkg/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-apipkg
+PKG_VERSION:=1.5
+PKG_RELEASE:=1
+
+PYPI_NAME:=apipkg
+PKG_HASH:=37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=0
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:=setuptools-scm
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-apipkg
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:= Controler for exported namespace of a Python package a
+  URL:=https://github.com/pytest-dev/apipkg
+  DEPENDS:= +python3-light
+endef
+
+define Package/python3-apipkg/description
+  apipkg is used to control the exported namespace of a Python package and greatly reduce
+  the number of imports for users.
+endef
+
+$(eval $(call Py3Package,python3-apipkg))
+$(eval $(call BuildPackage,python3-apipkg))
+$(eval $(call BuildPackage,python3-apipkg-src))

--- a/lang/python/python-execnet/Makefile
+++ b/lang/python/python-execnet/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-execnet
+PKG_VERSION:=1.7.1
+PKG_RELEASE:=1
+
+PYPI_NAME:=execnet
+PKG_HASH:=cacb9df31c9680ec5f95553976c4da484d407e85e41c83cb812aa014f0eddc50
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=0
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:=setuptools-scm
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-execnet
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Library for distributed interact mechanism
+  URL:=https://execnet.readthedocs.io
+  DEPENDS:= +python3-light +python3-apipkg
+endef
+
+define Package/python3-execnet/description
+  The execnet provides a share-nothing model with channel-send/receive communication for
+  distributing execution across many Python interpreters across version, platform and network
+  barriers.complex functional testing for applications and libraries.
+endef
+
+$(eval $(call Py3Package,python3-execnet))
+$(eval $(call BuildPackage,python3-execnet))
+$(eval $(call BuildPackage,python3-execnet-src))

--- a/lang/python/python-pytest-forked/Makefile
+++ b/lang/python/python-pytest-forked/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pytest-forked
+PKG_VERSION:=1.3.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=pytest-forked
+PKG_HASH:=6aa9ac7e00ad1a539c41bec6d21011332de671e938c7637378ec9710204e37ca
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=0
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:=setuptools-scm
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-pytest-forked
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Runs tests in isolated forked subprocesses
+  URL:=https://github.com/pytest-dev/pytest-forked
+  DEPENDS:= +python3-light +python3-pytest +python3-py
+endef
+
+define Package/python3-pytest-forked/description
+  Pytest plugin which enables to run tests in isolated forked subprocesses
+endef
+
+$(eval $(call Py3Package,python3-pytest-forked))
+$(eval $(call BuildPackage,python3-pytest-forked))
+$(eval $(call BuildPackage,python3-pytest-forked-src))

--- a/lang/python/python-pytest-xdist/Makefile
+++ b/lang/python/python-pytest-xdist/Makefile
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pytest-xdist
+PKG_VERSION:=1.34.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=pytest-xdist
+PKG_HASH:=340e8e83e2a4c0d861bdd8d05c5d7b7143f6eea0aba902997db15c2a86be04ee
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=0
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:=setuptools-scm
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-pytest-xdist
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Pytest plugin for parallel test running
+  URL:=https://github.com/pytest-dev/pytest-xdist
+  DEPENDS:= \
+	+python3-light \
+	+python3-pytest \
+	+python3-pytest-forked \
+	+python3-execnet \
+	+python3-six
+endef
+
+define Package/python3-pytest-xdist/description
+  The pytest framework makes it easy to write small tests, yet scales to support
+  complex functional testing for applications and libraries.
+endef
+
+$(eval $(call Py3Package,python3-pytest-xdist))
+$(eval $(call BuildPackage,python3-pytest-xdist))
+$(eval $(call BuildPackage,python3-pytest-xdist-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR adds new package **python-pytest-xdist** and its dependencies **python-apipkg** and **python-execnet**
It's python-pytest package wich provides usefull test execution modes

```
The pytest-xdist plugin extends pytest with some unique test execution modes:

    test run parallelization: if you have multiple CPUs or hosts you can use those for a combined test run. This allows to speed up development or to use special resources of remote machines.
    --looponfail: run your tests repeatedly in a subprocess. After each run pytest waits until a file in your project changes and then re-runs the previously failing tests. This is repeated until all tests pass after which again a full run is performed.
    Multi-Platform coverage: you can specify different Python interpreters or different platforms and run tests in parallel on all of them.
```
