### PR TITLE
ttyd: fix debug config option

### DIFF
--- a/utils/ttyd/Makefile
+++ b/utils/ttyd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ttyd
 PKG_VERSION:=1.6.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tsl0922/ttyd/tar.gz/$(PKG_VERSION)?

--- a/utils/ttyd/files/ttyd.init
+++ b/utils/ttyd/files/ttyd.init
@@ -79,7 +79,7 @@ ttyd_instance()
 		${ssl_cert:+-C $ssl_cert} \
 		${ssl_key:+-K $ssl_key} \
 		${ssl_ca:+-A $ssl_ca} \
-		${debug:+-d}
+		${debug:+-d $debug}
 	config_list_foreach "$1" client_option "procd_append_param command -t"
 	procd_append_param command $command
 	procd_set_param stdout 1


### PR DESCRIPTION
Maintainer: @tsl0922  @neheb 
Compile tested: only script changes
Run tested: x86_64, APU3, OpenWrt master

Description:
Add missing debug option value, if debug value is set.