### PR TITLE
docker-ce: improvements / changes

### DIFF
--- a/utils/docker-ce/Makefile
+++ b/utils/docker-ce/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-ce
 PKG_VERSION:=19.03.12
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=components/cli/LICENSE components/engine/LICENSE
 

--- a/utils/docker-ce/Makefile
+++ b/utils/docker-ce/Makefile
@@ -133,4 +133,22 @@ define Package/docker-ce/install
 		$(1)/etc/sysctl.d/12-br-netfilter-ip.conf
 endef
 
+define Package/docker-ce/postinst
+#!/bin/sh
+[ -n "$$IPKG_INSTROOT" ] || {
+	/etc/init.d/dockerd enable
+	/etc/init.d/dockerd uciadd
+	/etc/init.d/dockerd start
+}
+endef
+
+define Package/docker-ce/prerm
+#!/bin/sh
+[ -n "$$IPKG_INSTROOT" ] || {
+	/etc/init.d/dockerd disable
+	/etc/init.d/dockerd stop
+	/etc/init.d/dockerd ucidel
+}
+endef
+
 $(eval $(call BuildPackage,docker-ce))

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -54,7 +54,7 @@ uciadd() {
 
 	# Add network interface
 	if ! uci -q get network.docker >/dev/null; then
-		logger -t "dockerd-init" -p notice "Adding docker default bridge to network uci config (docker0)"
+		logger -t "dockerd-init" -p notice "Adding docker default interface to network uci config (docker)"
 		uci_quiet add network interface
 		uci_quiet rename network.@interface[-1]="docker"
 		uci_quiet set network.docker.ifname="docker0"
@@ -63,9 +63,20 @@ uciadd() {
 		uci_quiet commit network
 	fi
 
+	# Add docker bridge device
+	if ! uci -q get network.docker0 >/dev/null; then
+		logger -t "dockerd-init" -p notice "Adding docker default bridge device to network uci config (docker0)"
+		uci_quiet add network device
+		uci_quiet rename network.@device[-1]="docker0"
+		uci_quiet set network.docker0.type="bridge"
+		uci_quiet set network.docker0.name="docker0"
+		uci_quiet add_list network.docker0.ifname="docker0"
+		uci_quiet commit network
+	fi
+
 	# Add firewall zone
 	if ! uci -q get firewall.docker >/dev/null; then
-		logger -t "dockerd-init" -p notice "Adding docker default bridge firewall zone (docker0)"
+		logger -t "dockerd-init" -p notice "Adding docker default firewall zone to firewall uci config (docker)"
 		uci_quiet add firewall zone
 		uci_quiet rename firewall.@zone[-1]="docker"
 		uci_quiet set firewall.docker.network="docker"
@@ -85,11 +96,15 @@ ucidel() {
 		exit 0
 	}
 
-	logger -t "dockerd-init" -p notice "Deleting docker default bridge network from network uci config (docker0)"
+	logger -t "dockerd-init" -p notice "Deleting docker default bridge device from network uci config (docker0)"
+	uci_quiet delete network.docker0
+	uci_quiet commit network
+
+	logger -t "dockerd-init" -p notice "Deleting docker default interface from network uci config (docker)"
 	uci_quiet delete network.docker
 	uci_quiet commit network
 
-	logger -t "dockerd-init" -p notice "Deleting docker default bridge firewall zone from firewall uci config (docker0)"
+	logger -t "dockerd-init" -p notice "Deleting docker firewall zone from firewall uci config (docker)"
 	uci_quiet delete firewall.docker
 	uci_quiet commit firewall
 

--- a/utils/docker-ce/files/etc/config/dockerd
+++ b/utils/docker-ce/files/etc/config/dockerd
@@ -3,7 +3,7 @@ config globals 'globals'
 #	option alt_config_file "/etc/docker/daemon.json"
 	option data_root "/opt/docker/"
 	option log_level "warn"
-	option hosts "unix://var/run/docker.sock"
+	list hosts "unix:///var/run/docker.sock"
 	# If the bip option is changed, dockerd must be restarted.
 	# A service reload is not enough.
 	option bip "172.18.0.1/24"


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503 
Compile tested: not needed only script changes
Run tested: x86_64, APU3, openwrt master

Description:

- Add the bridge device to the uci network config
- Change uci hosts config parameter type this is not an option this is a list element
- Add postinst script to enable, uciadd and start docker-ce on package installation
- Add prerm script to disable and stop docker-ce on package remove