### PR TITLE
ttyd: add backport patch for ssl issue on firefox

### DIFF
--- a/utils/ttyd/Makefile
+++ b/utils/ttyd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ttyd
 PKG_VERSION:=1.6.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tsl0922/ttyd/tar.gz/$(PKG_VERSION)?

--- a/utils/ttyd/patches/200-protocol-fix-request-path-for-h2.patch
+++ b/utils/ttyd/patches/200-protocol-fix-request-path-for-h2.patch
@@ -1,0 +1,62 @@
+From f7c171ffbe2d7677af4974a235ed3ccb7b3ba8c8 Mon Sep 17 00:00:00 2001
+From: Shuanglei Tao <tsl0922@gmail.com>
+Date: Tue, 28 Jul 2020 22:55:01 +0800
+Subject: [PATCH 2/7] protocol: fix request path for h2
+
+---
+ src/protocol.c | 12 +++++++-----
+ src/server.h   |  1 +
+ 2 files changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/src/protocol.c b/src/protocol.c
+index fa96b6b..1be0a4e 100644
+--- a/src/protocol.c
++++ b/src/protocol.c
+@@ -236,8 +236,12 @@ int callback_tty(struct lws *wsi, enum lws_callback_reasons reason, void *user,
+         lwsl_warn("refuse to serve WS client due to the --max-clients option.\n");
+         return 1;
+       }
+-      if (lws_hdr_copy(wsi, buf, sizeof(buf), WSI_TOKEN_GET_URI) <= 0 ||
+-          strcmp(buf, endpoints.ws) != 0) {
++
++      n = lws_hdr_copy(wsi, pss->path, sizeof(pss->path), WSI_TOKEN_GET_URI);
++#if defined(LWS_ROLE_H2)
++      if (n <= 0) n = lws_hdr_copy(wsi, pss->path, sizeof(pss->path), WSI_TOKEN_HTTP_COLON_PATH);
++#endif
++      if (strncmp(pss->path, endpoints.ws, n) != 0) {
+         lwsl_warn("refuse to serve WS client for illegal ws path: %s\n", buf);
+         return 1;
+       }
+@@ -276,8 +280,6 @@ int callback_tty(struct lws *wsi, enum lws_callback_reasons reason, void *user,
+       LIST_INSERT_HEAD(&server->procs, proc, entry);
+       server->client_count++;
+ 
+-      lws_hdr_copy(wsi, buf, sizeof(buf), WSI_TOKEN_GET_URI);
+-
+ #if LWS_LIBRARY_VERSION_NUMBER >= 2004000
+       lws_get_peer_simple(lws_get_network_wsi(wsi), pss->address, sizeof(pss->address));
+ #else
+@@ -285,7 +287,7 @@ int callback_tty(struct lws *wsi, enum lws_callback_reasons reason, void *user,
+       lws_get_peer_addresses(wsi, lws_get_socket_fd(wsi), name, sizeof(name), pss->address,
+                              sizeof(pss->address));
+ #endif
+-      lwsl_notice("WS   %s - %s, clients: %d\n", buf, pss->address, server->client_count);
++      lwsl_notice("WS   %s - %s, clients: %d\n", pss->path, pss->address, server->client_count);
+       break;
+ 
+     case LWS_CALLBACK_SERVER_WRITEABLE:
+diff --git a/src/server.h b/src/server.h
+index 116d9b9..167ea8b 100644
+--- a/src/server.h
++++ b/src/server.h
+@@ -57,6 +57,7 @@ struct pss_tty {
+   int initial_cmd_index;
+   bool authenticated;
+   char address[50];
++  char path[20];
+ 
+   struct lws *wsi;
+   char *buffer;
+-- 
+2.20.1
+


### PR DESCRIPTION
Maintainer: @tsl0922 @neheb 
Compile tested: 
Run tested: x86_64, APU3, OpenWrt master, ssl test with firefox

Description:

If ttyd is configured to ssl, you will get the following message in the
log `refuse to serve WS client for illegal ws path`. Upstream a [patch](https://github.com/tsl0922/ttyd/commit/f7c171ffbe2d7677af4974a235ed3ccb7b3ba8c8)
has already been applied which fixes this.

Since there is no newer version than 1.6.1, this fix is backported as a
patch. And could be removed if a new version of ttyd is available.
