### PR TITLE
tayga: Added 64:ff9b:1::/48 as well-known prefix for NAT64 (RFC 8215)

### DIFF
--- a/ipv6/tayga/Makefile
+++ b/ipv6/tayga/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tayga
 PKG_VERSION:=0.9.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=tayga-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.litech.org/tayga/

--- a/ipv6/tayga/patches/003-RFC8215.patch
+++ b/ipv6/tayga/patches/003-RFC8215.patch
@@ -1,0 +1,14 @@
+diff -Naur tayga-0.9.2.orig/addrmap.c tayga-0.9.2/addrmap.c
+--- tayga-0.9.2.orig/addrmap.c	2011-05-25 15:11:30.000000000 +0100
++++ tayga-0.9.2/addrmap.c	2020-07-04 16:24:23.397081572 +0100
+@@ -44,7 +44,9 @@
+ int validate_ip6_addr(const struct in6_addr *a)
+ {
+ 	/* Well-known prefix for NAT64 */
+-	if (a->s6_addr32[0] == WKPF && !a->s6_addr32[1] && !a->s6_addr32[2])
++        if (a->s6_addr32[0] == WKPF &&
++	   (!a->s6_addr32[1] || (a->s6_addr16[2] == htonl(0x0001)))
++	    && !a->s6_addr32[2])
+ 		return 0;
+ 
+ 	/* Reserved per RFC 2373 */


### PR DESCRIPTION
Maintainer: Ondrej Caletka <ondrej@caletka.cz>
Compile tested: OpenWrt SNAPSHOT, r13500+17-4e65838

Run tested: OpenWrt SNAPSHOT, r13500+17-4e65838 on ath79/nand on a Netgear WNDR3700v4
Created interfaces for 64fb:ff9b:1:3::/64 an 64ff9b:1:7::/64 via tayga.

Description:

Added 64:ff9b:1::/48 as well-known prefix for NAT64 (RFC 8215)