### PR TITLE
simple-adblock: README and config update

### DIFF
--- a/net/simple-adblock/files/README.md
+++ b/net/simple-adblock/files/README.md
@@ -1,5 +1,7 @@
 # Simple AdBlock
 
+[![HitCount](http://hits.dwyl.com/stangri/openwrt/simple-adblock.svg)](http://hits.dwyl.com/stangri/openwrt/simple-adblock)
+
 A simple DNSMASQ/Unbound-based AdBlocking service for OpenWrt/LEDE Project.
 
 ## Features
@@ -186,7 +188,7 @@ For most of the [DNS Resolution Options](#dns-resolution-option) to work, your l
       - Removing [DHCP Options](https://openwrt.org/docs/guide-user/base-system/dhcp_configuration#dhcp_options) 5 and 6 from your router's ```/etc/config/dhcp``` file.
       - Enabling ```simple-adblock```'s ```force_dns``` setting to override the hardcoded DNS on your device.
   4. By using the DNS-over-TLS, DNS-over-HTTPS or DNSCrypt on your local device or (if supported) by browser on your local device. You can fix this only by:
-      - Stopping/removing/disabling DNS-over-TLS, DNS-over-HTTPS or DNSCrypt on your local device and using the secure DNS on your router instead. There are merits to all three of the options above, I can recommend the ```https_dns_proxy``` and ```luci-app-https_dns_proxy``` packages for enabling DNS-over-HTTPS on your router.
+      - Stopping/removing/disabling DNS-over-TLS, DNS-over-HTTPS or DNSCrypt on your local device and using the secure DNS on your router instead. There are merits to all three of the options above, I can recommend the ```https-dns-proxy``` and ```luci-app-https-dns-proxy``` packages for enabling DNS-over-HTTPS on your router.
   5. If you are running a wireguard "server" on your router and remote clients connect to it, the AdBlocking may not work properly for your remote clients until you add the following to ```/etc/network``` (credit to [dibdot](https://forum.openwrt.org/t/wireguard-and-adblock/49351/6)):
 
       ```sh

--- a/net/simple-adblock/files/simple-adblock.conf
+++ b/net/simple-adblock/files/simple-adblock.conf
@@ -34,7 +34,7 @@ config simple-adblock 'config'
 	list blocked_hosts_url 'https://adaway.org/hosts.txt'
 	
 # File size: 20.0K
-	list blocked_hosts_url 'https://cdn.jsdelivr.net/gh/hoshsadiq/adblock-nocoin-list@master/hosts.txt'
+	list blocked_hosts_url 'https://cdn.jsdelivr.net/gh/hoshsadiq/adblock-nocoin-list/hosts.txt'
 
 # File size: 36.0K
 	list blocked_hosts_url 'https://www.malwaredomainlist.com/hostslist/hosts.txt'
@@ -45,7 +45,7 @@ config simple-adblock 'config'
 # File size: 388.0K
 # block-list may be too big for some routers
 # block-list may block some video-streaming content
-#	list blocked_hosts_url 'https://cdn.jsdelivr.net/gh/jawz101/MobileAdTrackers@master/hosts'
+#	list blocked_hosts_url 'https://cdn.jsdelivr.net/gh/jawz101/MobileAdTrackers/hosts'
 
 # File size: 424.0K
 # block-list may be too big for some routers
@@ -61,7 +61,7 @@ config simple-adblock 'config'
 
 # File size: 1.6M
 # block-list too big for most routers
-#	list blocked_hosts_url 'https://cdn.jsdelivr.net/gh/StevenBlack/hosts@master/hosts'
+#	list blocked_hosts_url 'https://cdn.jsdelivr.net/gh/StevenBlack/hosts/hosts'
 
 # File size: 3.1M
 # block-list too big for most routers


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, WRT3200ACM, 19.07.3
Run tested: mvebu, WRT3200ACM, 18.06.8, start/stop

Description:
* Updated README with the counter and the new package names for https-dns-proxy
* Updated config to exclude master from jsdelivr URLs

Signed-off-by: Stan Grishin <stangri@melmac.net>

