### PR TITLE
erlang: fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/lang/erlang/Makefile
+++ b/lang/erlang/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=erlang
 PKG_VERSION:=23.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=otp_src_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= http://www.erlang.org/download/

--- a/lang/erlang/patches/010-openssl-deprecated.patch
+++ b/lang/erlang/patches/010-openssl-deprecated.patch
@@ -1,0 +1,66 @@
+--- a/lib/crypto/c_src/crypto_callback.c
++++ b/lib/crypto/c_src/crypto_callback.c
+@@ -112,6 +112,7 @@ static ErlNifRWLock** lock_vec = NULL; /* Static locks used by openssl */
+ 
+ #include <openssl/crypto.h>
+ 
++#if OPENSSL_VERSION_NUMBER < PACKED_OPENSSL_VERSION_PLAIN(1,1,0)
+ static INLINE void locking(int mode, ErlNifRWLock* lock)
+ {
+     switch (mode) {
+@@ -132,7 +133,6 @@ static INLINE void locking(int mode, ErlNifRWLock* lock)
+     }
+ }
+ 
+-#if OPENSSL_VERSION_NUMBER < PACKED_OPENSSL_VERSION_PLAIN(1,1,0)
+ static void locking_function(int mode, int n, const char *file, int line)
+ {
+     locking(mode, lock_vec[n]);
+--- a/lib/crypto/c_src/engine.c
++++ b/lib/crypto/c_src/engine.c
+@@ -244,7 +244,7 @@ ERL_NIF_TERM engine_load_dynamic_nif(ErlNifEnv* env, int argc, const ERL_NIF_TER
+ #ifdef HAS_ENGINE_SUPPORT
+     ASSERT(argc == 0);
+ 
+-    ENGINE_load_dynamic();
++    ENGINE_load_builtin_engines();
+     return atom_ok;
+ #else
+     return atom_notsup;
+--- a/lib/crypto/c_src/info.c
++++ b/lib/crypto/c_src/info.c
+@@ -20,6 +20,11 @@
+ 
+ #include "info.h"
+ 
++#if OPENSSL_VERSION_NUMBER < PACKED_OPENSSL_VERSION_PLAIN(1,1,0)
++#define OPENSSL_VERSION	SSLEAY_VERSION
++#define OpenSSL_version	SSLeay_version
++#endif
++
+ #ifdef HAVE_DYNAMIC_CRYPTO_LIB
+ 
+ # if defined(DEBUG)
+@@ -77,7 +82,7 @@ ERL_NIF_TERM info_lib(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+     ASSERT(argc == 0);
+ 
+     name_sz = strlen(libname);
+-    ver = SSLeay_version(SSLEAY_VERSION);
++    ver = OpenSSL_version(OPENSSL_VERSION);
+     ver_sz = strlen(ver);
+     ver_num = OPENSSL_VERSION_NUMBER;
+ 
+--- a/lib/crypto/c_src/otp_test_engine.c
++++ b/lib/crypto/c_src/otp_test_engine.c
+@@ -100,9 +100,11 @@ static int test_init(ENGINE *e) {
+         goto err;
+ #endif /* if defined(FAKE_RSA_IMPL) */
+ 
++#if OPENSSL_VERSION_NUMBER < PACKED_OPENSSL_VERSION_PLAIN(1,1,0)
+     /* Load all digest and cipher algorithms. Needed for password protected private keys */
+     OpenSSL_add_all_ciphers();
+     OpenSSL_add_all_digests();
++#endif
+ 
+     return 111;
+ 


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @cretingame 
Compile tested: ath79