### PR TITLE
freeradius3: fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
 PKG_VERSION:=release_3_0_21
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/archive

--- a/net/freeradius3/patches/010-openssl-deprecated.patch
+++ b/net/freeradius3/patches/010-openssl-deprecated.patch
@@ -1,0 +1,117 @@
+--- a/src/main/threads.c
++++ b/src/main/threads.c
+@@ -298,6 +298,7 @@ static void ssl_locking_function(int mode, int n, UNUSED char const *file, UNUSE
+  */
+ int tls_mutexes_init(void)
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	int i;
+ 
+ 	ssl_mutexes = rad_malloc(CRYPTO_num_locks() * sizeof(pthread_mutex_t));
+@@ -316,6 +317,7 @@ int tls_mutexes_init(void)
+ #ifdef HAVE_CRYPTO_SET_LOCKING_CALLBACK
+ 	CRYPTO_set_locking_callback(ssl_locking_function);
+ #endif
++#endif
+ 
+ 	return 0;
+ }
+--- a/src/main/tls.c
++++ b/src/main/tls.c
+@@ -55,6 +55,7 @@ USES_APPLE_DEPRECATED_API	/* OpenSSL API has been deprecated by Apple */
+ #    include <openssl/evp.h>
+ #  endif
+ #  include <openssl/ssl.h>
++#  include <openssl/dh.h>
+ 
+ #define LOG_PREFIX "tls"
+ 
+@@ -2133,7 +2134,7 @@ int cbtls_verify(int ok, X509_STORE_CTX *ctx)
+ 	int		my_ok = ok;
+ 
+ 	ASN1_INTEGER	*sn = NULL;
+-	ASN1_TIME	*asn_time = NULL;
++	const ASN1_TIME	*asn_time = NULL;
+ 	VALUE_PAIR	**certs;
+ 	char **identity;
+ #ifdef HAVE_OPENSSL_OCSP_H
+@@ -2207,7 +2208,7 @@ int cbtls_verify(int ok, X509_STORE_CTX *ctx)
+ 	 *	Get the Expiration Date
+ 	 */
+ 	buf[0] = '\0';
+-	asn_time = X509_get_notAfter(client_cert);
++	asn_time = X509_get0_notAfter(client_cert);
+ 	if (certs && (lookup <= 1) && asn_time &&
+ 	    (asn_time->length < (int) sizeof(buf))) {
+ 		memcpy(buf, (char*) asn_time->data, asn_time->length);
+@@ -2220,7 +2221,7 @@ int cbtls_verify(int ok, X509_STORE_CTX *ctx)
+ 	 *	Get the Valid Since Date
+ 	 */
+ 	buf[0] = '\0';
+-	asn_time = X509_get_notBefore(client_cert);
++	asn_time = X509_get0_notBefore(client_cert);
+ 	if (certs && (lookup <= 1) && asn_time &&
+ 	    (asn_time->length < (int) sizeof(buf))) {
+ 		memcpy(buf, (char*) asn_time->data, asn_time->length);
+@@ -2690,10 +2691,12 @@ static int set_ecdh_curve(SSL_CTX *ctx, char const *ecdh_curve, bool disable_sin
+  */
+ int tls_global_init(bool spawn_flag, bool check)
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	SSL_load_error_strings();	/* readable error messages (examples show call before library_init) */
+ 	SSL_library_init();		/* initialize library */
+ 	OpenSSL_add_all_algorithms();	/* required for SHA2 in OpenSSL < 0.9.8o and 1.0.0.a */
+ 	CONF_modules_load_file(NULL, NULL, 0);
++#endif
+ 
+ 	/*
+ 	 *	Initialize the index for the certificates.
+@@ -2769,6 +2772,7 @@ int tls_global_version_check(char const *acknowledged)
+  */
+ void tls_global_cleanup(void)
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ #if OPENSSL_VERSION_NUMBER < 0x10000000L
+ 	ERR_remove_state(0);
+ #elif OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+@@ -2781,6 +2785,7 @@ void tls_global_cleanup(void)
+ 	ERR_free_strings();
+ 	EVP_cleanup();
+ 	CRYPTO_cleanup_all_ex_data();
++#endif
+ }
+ 
+ 
+--- a/src/main/version.c
++++ b/src/main/version.c
+@@ -54,7 +54,7 @@ int ssl_check_consistency(void)
+ {
+ 	long ssl_linked;
+ 
+-	ssl_linked = SSLeay();
++	ssl_linked = OpenSSL_version_num();
+ 
+ 	/*
+ 	 *	Major and minor versions mismatch, that's bad.
+@@ -152,7 +152,7 @@ char const *ssl_version_num(void)
+ {
+ 	long ssl_linked;
+ 
+-	ssl_linked = SSLeay();
++	ssl_linked = OpenSSL_version_num();
+ 	return ssl_version_by_num((uint32_t)ssl_linked);
+ }
+ 
+@@ -188,10 +188,10 @@ char const *ssl_version(void)
+ {
+ 	static char buffer[256];
+ 
+-	uint32_t v = SSLeay();
++	uint32_t v = OpenSSL_version_num();
+ 
+ 	snprintf(buffer, sizeof(buffer), "%s 0x%.8x (%s)",
+-		 SSLeay_version(SSLEAY_VERSION),		/* Not all builds include a useful version number */
++		 OpenSSL_version(OPENSSL_VERSION),		/* Not all builds include a useful version number */
+ 		 v,
+ 		 ssl_version_by_num(v));
+ 


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @openwrt/package-maintainers 
Compile tested: ath79