### PR TITLE
[WIP] mwan3:  dualstack and ipv4 or ipv6 single support

### DIFF
--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -17,6 +17,7 @@ fi
 [ "$MWAN3_STARTUP" = 1 ] || mwan3_lock "$ACTION" "$INTERFACE"
 
 config_load mwan3
+mwan3_check_family_needs
 config_get_bool enabled globals 'enabled' '0'
 [ "${enabled}" -gt 0 ] || {
 	[ "$MWAN3_STARTUP" = 1 ] || mwan3_unlock "$ACTION" "$INTERFACE"
@@ -25,10 +26,20 @@ config_get_bool enabled globals 'enabled' '0'
 	exit 0
 }
 
-$IPT4 -S mwan3_hook &>/dev/null || {
-	mwan3_unlock "$ACTION" "$INTERFACE"
-	LOG warn "hotplug called on $INTERFACE before mwan3 has been set up"
-	exit 0
+[ $NEED_IPV4 -ne 0 ] && {
+	$IPT4 -S mwan3_hook &>/dev/null || {
+		mwan3_unlock "$ACTION" "$INTERFACE"
+		LOG warn "hotplug called on $INTERFACE(ipv4) before mwan3 has been set up"
+		exit 0
+	}
+}
+
+[ $NEED_IPV6 -ne 0 ] && {
+	$IPT6 -S mwan3_hook &>/dev/null || {
+		mwan3_unlock "$ACTION" "$INTERFACE"
+		LOG warn "hotplug called on $INTERFACE(ipv6) before mwan3 has been set up"
+		exit 0
+	}
 }
 
 mwan3_init

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -48,57 +48,59 @@ config_get_bool enabled $INTERFACE 'enabled' '0'
 	LOG notice "mwan3 hotplug on $INTERFACE not called because interface disabled"
 	exit 0
 }
+[ "$FAMILY" = "ipv4" ] || [ "$FAMILY" = "ipv6" ] || FAMILY="ipv4 ipv6"
 
-trackpid=$(pgrep -f "mwan3track $INTERFACE ")
+for family in $FAMILY; do
+
+trackpid=$(pgrep -f "mwan3track $family $INTERFACE ")
 
 if [ "$initial_state" = "offline" ]; then
-	status=$(cat $MWAN3TRACK_STATUS_DIR/$INTERFACE/STATUS 2>/dev/null || echo unknown)
+	status=$(cat $MWAN3TRACK_STATUS_DIR/$INTERFACE.$family/STATUS 2>/dev/null || echo unknown)
 else
 	status=online
 fi
 
-[ -z "$TRUE_INTERFACE" ] && mwan3_get_true_iface TRUE_INTERFACE $INTERFACE
-
 binary_status=$status
 [ "$binary_status" = "online" ] || binary_status=offline
 
-LOG notice "Execute "$ACTION" event on interface $INTERFACE (${DEVICE:-unknown})"
+LOG notice "Execute "$ACTION" event on interface $INTERFACE($family) (${DEVICE:-unknown})"
 
 case "$ACTION" in
 	ifup|connected)
-		mwan3_create_iface_iptables $INTERFACE $DEVICE
-		mwan3_create_iface_rules $INTERFACE $DEVICE
-		mwan3_create_iface_route $INTERFACE $DEVICE
-		[ "$MWAN3_STARTUP" != 1 ] && mwan3_add_non_default_iface_route $INTERFACE $DEVICE
-		mwan3_set_iface_hotplug_state $INTERFACE "$binary_status"
+		mwan3_create_iface_iptables $INTERFACE $DEVICE $family
+		mwan3_create_iface_rules $INTERFACE $DEVICE $family
+		mwan3_create_iface_route $INTERFACE $DEVICE $family
+		[ "$MWAN3_STARTUP" != 1 ] && mwan3_add_non_default_iface_route $INTERFACE $DEVICE $family
+		mwan3_set_iface_hotplug_state $INTERFACE "$binary_status" $family
 
-		mwan3_get_src_ip src_ip "$TRUE_INTERFACE"
 		if [ -n "${trackpid}" ]; then
-			device_pid=$(pgrep -f "mwan3track $INTERFACE $DEVICE ")
+			device_pid=$(pgrep -f "mwan3track $family $INTERFACE $DEVICE ")
 			if [ "$device_pid" = "$trackpid" ]; then
 				[ "$ACTION" = ifup ] && kill -USR2 "$trackpid"
 			else
-				mwan3_track $INTERFACE $DEVICE "$binary_status" "$src_ip"
-				LOG notice "Restarted tracker [$!] on interface $INTERFACE (${DEVICE:-unknown})"
+				mwan3_track $INTERFACE $DEVICE "$binary_status" $family
+				LOG notice "Restarted tracker [$!] on interface $INTERFACE($family) (${DEVICE:-unknown})"
 			fi
 		else
-			mwan3_track $INTERFACE $DEVICE "$binary_status" "$src_ip"
-			LOG notice "Started tracker [$!] on interface $INTERFACE (${DEVICE:-unknown})"
+			mwan3_track $INTERFACE $DEVICE "$binary_status" $family
+			LOG notice "Started tracker [$!] on interface $INTERFACE($family) (${DEVICE:-unknown})"
 		fi
-		[ "$MWAN3_STARTUP" != 1 ] && [ "$binary_status" == "online" ] && mwan3_set_policies_iptables
+		[ "$MWAN3_STARTUP" != 1 ] && [ "$binary_status" == "online" ] && mwan3_set_policies_iptables $family
 
 	;;
 	ifdown|disconnected)
-		mwan3_set_iface_hotplug_state $INTERFACE "offline"
-		mwan3_delete_iface_ipset_entries $INTERFACE
-		mwan3_delete_iface_rules $INTERFACE
-		mwan3_delete_iface_route $INTERFACE
-		mwan3_delete_iface_iptables $INTERFACE
+		mwan3_set_iface_hotplug_state $INTERFACE "offline" $family
+		mwan3_delete_iface_ipset_entries $INTERFACE $family
+		mwan3_delete_iface_rules $INTERFACE $family
+		mwan3_delete_iface_route $INTERFACE $family
+		mwan3_delete_iface_iptables $INTERFACE $family
 		if [ "$ACTION" = "ifdown" ]; then
 			[ -n "$trackpid" ] && kill -USR1 "$trackpid"
 		fi
 		mwan3_set_policies_iptables
 	;;
 esac
+
+done
 [ "$MWAN3_STARTUP" = 1 ] || mwan3_unlock "$ACTION" "$INTERFACE"
 exit 0

--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
@@ -7,6 +7,7 @@
 	[ "$MWAN3_STARTUP" = 1 ] || mwan3_lock "$ACTION" "$DEVICE-user"
 
 	config_load mwan3
+	mwan3_check_family_needs
 	config_get_bool enabled globals 'enabled' '0'
 	[ "${enabled}" -gt 0 ] || {
 		[ "$MWAN3_STARTUP" = 1 ] || mwan3_unlock "$ACTION" "$DEVICE-user"

--- a/net/mwan3/files/lib/mwan3/common.sh
+++ b/net/mwan3/files/lib/mwan3/common.sh
@@ -15,3 +15,6 @@ LOG()
 	[ "$facility" = "debug" ] && return
 	logger -t "$SCRIPTNAME[$$]" -p $facility "$*"
 }
+
+MWAN3_STATUS_DIR="/var/run/mwan3"
+MWAN3TRACK_STATUS_DIR="/var/run/mwan3track"

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -5,8 +5,6 @@
 . /usr/share/libubox/jshn.sh
 . /lib/mwan3/common.sh
 
-MWAN3TRACK_STATUS_DIR="/var/run/mwan3track"
-
 IPS="ipset"
 IPT4="iptables -t mangle -w"
 IPT6="ip6tables -t mangle -w"
@@ -70,8 +68,17 @@ report_policies_v6() {
 }
 
 get_mwan3_status() {
+	local ipv
 	local iface="${1}"
 	local iface_select="${2}"
+
+	config_get ipv "$iface" family "any"
+
+	json_add_object "${iface}"
+	for family in "ipv4" "ipv6"; do
+	[ "$ipv" != "any" ] && [ "$ipv" != "$family" ] && continue
+	json_add_object "$family"
+
 	local running="0"
 	local age=0
 	local online=0
@@ -82,24 +89,24 @@ get_mwan3_status() {
 	network_get_device device $1
 
 	if [ "${iface}" = "${iface_select}" ] || [ "${iface_select}" = "" ]; then
-		pid="$(pgrep -f "mwan3track $iface $device")"
+		pid="$(pgrep -f "mwan3track $family $iface $device")"
 		if [ "${pid}" != "" ]; then
 			running="1"
 		fi
 
-		time_p="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/TIME")"
+		time_p="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}.$family/TIME")"
 		[ -z "${time_p}" ] || {
 			time_n="$(get_uptime)"
 			let age=time_n-time_p
 		}
 
-		time_u="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/ONLINE")"
+		time_u="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}.$family/ONLINE")"
 		[ -z "${time_u}" ] || [ "${time_u}" = "0" ] || {
 			time_n="$(get_uptime)"
 			let online=time_n-time_u
 		}
 
-		time_d="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/OFFLINE")"
+		time_d="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}.$family/OFFLINE")"
 		[ -z "${time_d}" ] || [ "${time_d}" = "0" ] || {
 			time_n="$(get_uptime)"
 			let offline=time_n-time_d
@@ -111,39 +118,41 @@ get_mwan3_status() {
 		network_get_uptime uptime "$iface"
 		network_is_up "$iface" && up="1"
 
-		if [ -f "$MWAN3TRACK_STATUS_DIR/${iface}/STATUS" ]; then
-			status="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/STATUS")"
+		if [ -f "$MWAN3TRACK_STATUS_DIR/${iface}.$family/STATUS" ]; then
+			status="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}.$family/STATUS")"
 		else
 			status="unknown"
 		fi
 
-		json_add_object "${iface}"
 		json_add_int age "$age"
 		json_add_int online "${online}"
 		json_add_int offline "${offline}"
 		json_add_int uptime "${uptime}"
-		json_add_int "score" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/SCORE")"
-		json_add_int "lost" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/LOST")"
-		json_add_int "turn" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/TURN")"
+		json_add_int "score" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}.$family/SCORE")"
+		json_add_int "lost" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}.$family/LOST")"
+		json_add_int "turn" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}.$family/TURN")"
 		json_add_string "status" "${status}"
 		json_add_boolean "enabled" "${enabled}"
 		json_add_boolean "running" "${running}"
 		json_add_boolean "up" "${up}"
 		json_add_array "track_ip"
-		for file in $MWAN3TRACK_STATUS_DIR/${iface}/*; do
+		for file in $MWAN3TRACK_STATUS_DIR/${iface}.$family/*; do
 			track="${file#*/TRACK_}"
 			if [ "${track}" != "${file}" ]; then
 				json_add_object
 				json_add_string ip "${track}"
 				json_add_string status "$(cat "${file}")"
-				json_add_int latency "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/LATENCY_${track}")"
-				json_add_int packetloss "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/LOSS_${track}")"
+				json_add_int latency "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}.$family/LATENCY_${track}")"
+				json_add_int packetloss "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}.$family/LOSS_${track}")"
 				json_close_object
 			fi
 		done
 		json_close_array
-		json_close_object
 	fi
+
+	json_close_object
+	done
+	json_close_object
 }
 
 main () {

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -38,8 +38,12 @@ ifdown()
 
 	ACTION=ifdown INTERFACE=$1 /sbin/hotplug-call iface
 
-	kill $(pgrep -f "mwan3track $1 ") &> /dev/null
-	mwan3_track_clean $1
+	for family in "ipv4" "ipv6"; do
+
+	kill $(pgrep -f "mwan3track $family $1 ") &> /dev/null
+	mwan3_track_clean $1 $family
+
+	done
 }
 
 ifup()
@@ -72,7 +76,9 @@ ifup()
 	else
 		enabled=1
 	fi
-	mwan3_get_true_iface true_iface $interface
+	for family in "ipv4" "ipv6"; do
+
+	mwan3_get_true_iface true_iface $interface $family
 	status=$(ubus -S call network.interface.$true_iface status)
 
 	[ -n "$status" ] && {
@@ -81,8 +87,8 @@ ifup()
 	}
 	hotplug_startup()
 	{
-		MWAN3_STARTUP=$MWAN3_STARTUP ACTION=ifup INTERFACE=$interface DEVICE=$l3_device TRUE_INTERFACE=$true_iface sh /etc/hotplug.d/iface/15-mwan3
-		MWAN3_STARTUP=$MWAN3_STARTUP ACTION=ifup INTERFACE=$interface DEVICE=$l3_device TRUE_INTERFACE=$true_iface sh /etc/hotplug.d/iface/16-mwan3-user
+		MWAN3_STARTUP=$MWAN3_STARTUP ACTION=ifup INTERFACE=$interface DEVICE=$l3_device FAMILY=$family sh /etc/hotplug.d/iface/15-mwan3
+		MWAN3_STARTUP=$MWAN3_STARTUP ACTION=ifup INTERFACE=$interface DEVICE=$l3_device FAMILY=$family sh /etc/hotplug.d/iface/16-mwan3-user
 	}
 
 	if [ "$up" != "1" ] || [ -z "$l3_device" ] || [ "$enabled" != "1" ]; then
@@ -96,6 +102,7 @@ ifup()
 		hotplug_startup
 	fi
 
+	done
 }
 
 interfaces()

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -162,6 +162,7 @@ start()
 	mwan3_lock "command" "mwan3"
 	uci_toggle_state mwan3 globals enabled "1"
 	config_load mwan3
+	mwan3_check_family_needs
 
 	mwan3_update_iface_to_table
 	mwan3_set_connected_iptables

--- a/net/mwan3/files/usr/sbin/mwan3rtmon
+++ b/net/mwan3/files/usr/sbin/mwan3rtmon
@@ -54,8 +54,8 @@ mwan3_rtmon_route_handle()
 	}
 	handle_route_cb(){
 		let tid++
-		config_get family "$section" family ipv4
-		[ "$family" != "$route_family" ] && return
+		config_get family "$section" family "any"
+		[ "$family" != "$route_family" ] && [ "$family" != "any" ] && return
 		handle_route
 	}
 

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -125,6 +125,7 @@ main() {
 	trap if_up USR2
 
 	config_load mwan3
+	mwan3_check_family_needs
 	config_get track_method $INTERFACE track_method ping
 	config_get_bool httping_ssl $INTERFACE httping_ssl 0
 	config_get reliability $INTERFACE reliability 1

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 . /lib/functions.sh
+. /lib/mwan3/mwan3.sh
+. /lib/functions/network.sh
 . /lib/mwan3/common.sh
 
 INTERFACE=""
@@ -63,33 +65,33 @@ validate_track_method() {
 }
 
 disconnected() {
-	echo "offline" > /var/run/mwan3track/$INTERFACE/STATUS
-	echo "$(get_uptime)" > /var/run/mwan3track/$INTERFACE/OFFLINE
-	echo "0" > /var/run/mwan3track/$INTERFACE/ONLINE
+	echo "offline" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$FAMILY/STATUS
+	echo "$(get_uptime)" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$FAMILY/OFFLINE
+	echo "0" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$FAMILY/ONLINE
 	score=0
 	[ "$1" == 1 ] && return
-	LOG notice "Interface $INTERFACE ($DEVICE) is offline"
-	env -i ACTION="disconnected" INTERFACE="$INTERFACE" DEVICE="$DEVICE" /sbin/hotplug-call iface
+	LOG notice "Interface $INTERFACE($FAMILY) ($DEVICE) is offline"
+	env -i ACTION="disconnected" INTERFACE="$INTERFACE" DEVICE="$DEVICE" FAMILY="$FAMILY" /sbin/hotplug-call iface
 }
 
 connected() {
-	echo "online" > /var/run/mwan3track/$INTERFACE/STATUS
-	echo "0" > /var/run/mwan3track/$INTERFACE/OFFLINE
-	echo "$(get_uptime)" > /var/run/mwan3track/$INTERFACE/ONLINE
+	echo "online" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$FAMILY/STATUS
+	echo "0" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$FAMILY/OFFLINE
+	echo "$(get_uptime)" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$FAMILY/ONLINE
 	host_up_count=0
 	lost=0
 	turn=0
 	loss=0
 	[ "$1" == 1 ] && return
-	LOG notice "Interface $INTERFACE ($DEVICE) is online"
-	env -i ACTION="connected" INTERFACE="$INTERFACE" DEVICE="$DEVICE" /sbin/hotplug-call iface
+	LOG notice "Interface $INTERFACE($FAMILY) ($DEVICE) is online"
+	env -i ACTION="connected" INTERFACE="$INTERFACE" DEVICE="$DEVICE" FAMILY=$FAMILY /sbin/hotplug-call iface
 }
 
 firstconnect() {
 	if [ "$STATUS" = "offline" ]; then
-		disconnected 1
+		FAMILY=$FAMILY disconnected 1
 	else
-		connected 1
+		FAMILY=$FAMILY connected 1
 	fi
 }
 
@@ -98,10 +100,10 @@ update_status() {
 	track_ip=$1
 	status=$2
 
-	echo "$1" > /var/run/mwan3track/$INTERFACE/TRACK_${track_ip}
+	echo "$1" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$FAMILY/TRACK_${track_ip}
 	[ -z "$3" ] && return
-	echo "$3" > /var/run/mwan3track/$INTERFACE/LATENCY_${track_ip}
-	echo "$4" > /var/run/mwan3track/$INTERFACE/LOSS_${track_ip}
+	echo "$3" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$FAMILY/LATENCY_${track_ip}
+	echo "$4" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$FAMILY/LOSS_${track_ip}
 }
 
 main() {
@@ -113,11 +115,11 @@ main() {
 
 	[ -z "$5" ] && echo "Error: should not be started manually" && exit 0
 
-	INTERFACE=$1
-	DEVICE=$2
-	STATUS=$3
-	SRC_IP=$4
-	mkdir -p /var/run/mwan3track/$INTERFACE
+	family=$1
+	INTERFACE=$2
+	DEVICE=$3
+	STATUS=$4
+	mkdir -p $MWAN3TRACK_STATUS_DIR/$INTERFACE.$family
 	trap clean_up TERM
 	trap if_down USR1
 	trap if_up USR2
@@ -125,15 +127,6 @@ main() {
 	config_load mwan3
 	config_get track_method $INTERFACE track_method ping
 	config_get_bool httping_ssl $INTERFACE httping_ssl 0
-	validate_track_method $track_method $SRC_IP || {
-		track_method=ping
-		if validate_track_method $track_method; then
-			LOG warn "Using ping to track interface $INTERFACE avaliability"
-		else
-			LOG err "No track method avaliable"
-			exit 1
-		fi
-	}
 	config_get reliability $INTERFACE reliability 1
 	config_get count $INTERFACE count 1
 	config_get timeout $INTERFACE timeout 4
@@ -158,8 +151,21 @@ main() {
 	local turn=0
 	local ping_protocol=4
 	local sleep_time result ping_result ping_result_raw  ping_status loss latency
+	local SRC_IP
 
-	firstconnect
+	if [ "$family" = "ipv6" ]; then
+		ping_protocol=6
+		mwan3_get_src_ip6 SRC_IP "$INTERFACE"
+	else
+		ping_protocol=4
+		mwan3_get_src_ip SRC_IP "$INTERFACE"
+	fi
+	validate_track_method $track_method $SRC_IP || {
+		LOG err "track method($track_method) src_ip($SRC_IP) invalid"
+		exit 1
+	}
+
+	FAMILY=$family firstconnect
 	while true; do
 
 		sleep_time=$interval
@@ -171,9 +177,7 @@ main() {
 						# pinging IPv6 hosts with an interface is troublesome
 						# https://bugs.openwrt.org/index.php?do=details&task_id=2897
 						# so get the IP address of the interface and use that instead
-						if [ -z ${track_ip##*:*} ]; then
-							ping_protocol=6
-						else
+						if [ $ping_protocol -eq 4 ]; then
 							unset SRC_IP
 						fi
 						if [ $check_quality -eq 0 ]; then
@@ -220,40 +224,40 @@ main() {
 				if [ $check_quality -eq 0 ]; then
 					if [ $result -eq 0 ]; then
 						let host_up_count++
-						update_status "$track_ip" "up"
+						FAMILY=$family update_status "$track_ip" "up"
 
 						if [ $score -le $up ]; then
-							LOG info "Check ($track_method) success for target \"$track_ip\" on interface $INTERFACE ($DEVICE). Current score: $score"
+							LOG info "Check ($track_method) success for target \"$track_ip\" on interface $INTERFACE($family) ($DEVICE). Current score: $score"
 						fi
 					else
 						let lost++
-						update_status "$track_ip" "down"
+						FAMILY=$family update_status "$track_ip" "down"
 
 						if [ $score -gt $up ]; then
-							LOG info "Check ($track_method) failed for target \"$track_ip\" on interface $INTERFACE ($DEVICE). Current score: $score"
+							LOG info "Check ($track_method) failed for target \"$track_ip\" on interface $INTERFACE($family) ($DEVICE). Current score: $score"
 						fi
 					fi
 				else
 					if [ "$loss" -ge "$failure_loss" -o "$latency" -ge "$failure_latency" ]; then
 						let lost++
-						update_status "$track_ip" "down" $latency $loss
+						FAMILY=$family update_status "$track_ip" "down" $latency $loss
 
 						if [ $score -gt $up ]; then
-							LOG info "Check (${track_method}: latency=${latency}ms loss=${loss}%) failed for target \"$track_ip\" on interface $INTERFACE ($DEVICE). Current score: $score"
+							LOG info "Check (${track_method}: latency=${latency}ms loss=${loss}%) failed for target \"$track_ip\" on interface $INTERFACE($family) ($DEVICE). Current score: $score"
 						fi
 					elif [ "$loss" -le "$recovery_loss" -a "$latency" -le "$recovery_latency" ]; then
 						let host_up_count++
-						update_status "$track_ip" "up" $latency $loss
+						FAMILY=$family update_status "$track_ip" "up" $latency $loss
 
 						if [ $score -le $up ]; then
-							LOG info "Check (${track_method}: latency=${latency}ms loss=${loss}%) success for target \"$track_ip\" on interface $INTERFACE ($DEVICE). Current score: $score"
+							LOG info "Check (${track_method}: latency=${latency}ms loss=${loss}%) success for target \"$track_ip\" on interface $INTERFACE($family) ($DEVICE). Current score: $score"
 						fi
 					else
-						echo "skipped" > /var/run/mwan3track/$INTERFACE/TRACK_${track_ip}
+						echo "skipped" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$family/TRACK_${track_ip}
 					fi
 				fi
 			else
-				echo "skipped" > /var/run/mwan3track/$INTERFACE/TRACK_${track_ip}
+				echo "skipped" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$family/TRACK_${track_ip}
 			fi
 		done
 
@@ -270,48 +274,48 @@ main() {
 			fi
 
 			if [ $score -eq $up ]; then
-				disconnected
+				FAMILY=$family disconnected
 				score=0
 			fi
 		else
 			if [ $score -lt $(($down+$up)) ] && [ $lost -gt 0 ]; then
-				LOG info "Lost $(($lost*$count)) ping(s) on interface $INTERFACE ($DEVICE). Current score: $score"
+				LOG info "Lost $(($lost*$count)) ping(s) on interface $INTERFACE($family) ($DEVICE). Current score: $score"
 			fi
 
 			let score++
 			lost=0
 
 			if [ $score -gt $up ]; then
-				echo "online" > /var/run/mwan3track/$INTERFACE/STATUS
+				echo "online" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$family/STATUS
 				score=$(($down+$up))
 			elif [ $score -le $up ]; then
 				sleep_time=$recovery_interval
 			fi
 
 			if [ $score -eq $up ]; then
-				connected $INTERFACE $DEVICE
+				FAMILY=$family connected $INTERFACE $DEVICE
 			fi
 		fi
 
 		let turn++
-		mkdir -p "/var/run/mwan3track/${1}"
-		echo "${lost}" > /var/run/mwan3track/$INTERFACE/LOST
-		echo "${score}" > /var/run/mwan3track/$INTERFACE/SCORE
-		echo "${turn}" > /var/run/mwan3track/$INTERFACE/TURN
-		echo "$(get_uptime)" > /var/run/mwan3track/$INTERFACE/TIME
+		mkdir -p "$MWAN3TRACK_STATUS_DIR/$INTERFACE.$family"
+		echo "${lost}" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$family/LOST
+		echo "${score}" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$family/SCORE
+		echo "${turn}" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$family/TURN
+		echo "$(get_uptime)" > $MWAN3TRACK_STATUS_DIR/$INTERFACE.$family/TIME
 
 		host_up_count=0
 		sleep "${sleep_time}" &
 		wait
 
 		if [ "${IFDOWN_EVENT}" -eq 1 ]; then
-			LOG debug "Register ifdown event on interface ${INTERFACE} (${DEVICE})"
-			disconnected 1
+			LOG debug "Register ifdown event on interface ${INTERFACE}($family) (${DEVICE})"
+			FAMILY=$family disconnected 1
 			IFDOWN_EVENT=0
 		fi
 		if [ "${IFUP_EVENT}" -eq 1 ]; then
-			LOG debug "Register ifup event on interface ${INTERFACE} (${DEVICE})"
-			firstconnect
+			LOG debug "Register ifup event on interface ${INTERFACE}($family) (${DEVICE})"
+			FAMILY=$family firstconnect
 			IFUP_EVENT=0
 		fi
 	done


### PR DESCRIPTION
Maintainer: me / @feckert 
Compile tested: ipq40xx
Run tested: ipq40xx

Description:

When the ipv4 interface or ipv6 interface does not exist, we do not set ipv4 or ipv6 rules
what if not, if we setup mwan3 for ipv4 only, ipv6 would be blocked, which is not expected.

Suppose we have two wans, we set up mwan3 ipv4 load balancing, and ipv4 works as expected. At this time, ipv6 did not do any mwan3 settings. We expected it (ipv6) to be able to connect to the Internet at least, but the result did not. Because mwan3 sets ip rule and others, ipv6 is blocked.

Also I make `mwan3track` work with `gateway` as `track_ip`, so we could set `gateway` as tracking ip
