### PR TITLE
net/miniupnpd: check by /etc/init.d/miniupnpd running

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.1.20200510
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/miniupnpd/files/miniupnpd.hotplug
+++ b/net/miniupnpd/files/miniupnpd.hotplug
@@ -7,9 +7,7 @@
 # - check only on ifup (otherwise lease updates etc would cause
 #   miniupnpd state loss)
 
-. /lib/functions/procd.sh
-
-[ "$ACTION" != "ifup" ] && procd_running "miniupnpd" "*" && exit 0
+[ "$ACTION" != "ifup" ] && /etc/init.d/miniupnpd running && exit 0
 
 tmpconf="/var/etc/miniupnpd.conf"
 external_iface=$(uci -q get upnpd.config.external_iface)


### PR DESCRIPTION

use `/etc/init.d/miniupnpd running` API