### PR TITLE
netperf: fix compilation with GCC10

### DIFF
--- a/net/netperf/Makefile
+++ b/net/netperf/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netperf
 PKG_VERSION:=2.7.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Custom
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/net/netperf/patches/010-gcc10_multiple_definition_fix.patch
+++ b/net/netperf/patches/010-gcc10_multiple_definition_fix.patch
@@ -1,0 +1,19 @@
+--- a/src/nettest_omni.c
++++ b/src/nettest_omni.c
+@@ -454,16 +454,6 @@ static  int remote_cpu_method;
+ static int client_port_min = 5000;
+ static int client_port_max = 65535;
+ 
+- /* different options for the sockets				*/
+-
+-int
+-  loc_nodelay,		/* don't/do use NODELAY	locally		*/
+-  rem_nodelay,		/* don't/do use NODELAY remotely	*/
+-  loc_sndavoid,		/* avoid send copies locally		*/
+-  loc_rcvavoid,		/* avoid recv copies locally		*/
+-  rem_sndavoid,		/* avoid send copies remotely		*/
+-  rem_rcvavoid; 	/* avoid recv_copies remotely		*/
+-
+ extern int
+   loc_tcpcork,
+   rem_tcpcork,


### PR DESCRIPTION
**Maintainer:** @tohojo 
**Compile tested:** malta/mips32-be on master branch
**Run tested:**  malta/mips32-be on master branch, tested under QEMU using a speedtest

**Description:**
GCC10 defaults to -fno-common, which breaks compilation when there are
multiple definitions of implicit "extern" variables. Remove extra definitions.

Thanks!