### PR TITLE
treewide: replace `which` with `command -v`

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.8
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=21
+PKG_RELEASE:=22
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=

--- a/net/ddns-scripts/files/ddns.defaults
+++ b/net/ddns-scripts/files/ddns.defaults
@@ -33,7 +33,7 @@ timer2dhms() {
 
 # using function to not confuse function calls with existing ones inside /lib/functions.sh
 update_config() {
-	uc_uci="$(which uci) -q"	# ignore errors
+	uc_uci="$(command -v uci) -q"	# ignore errors
 	uc_cfg=""
 	uc_name=""
 	uc_var=""

--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -73,23 +73,23 @@ DNS_CHARSET="[@a-zA-Z0-9._-]"
 LUCI_HELPER=$(printf %s "$MYPROG" | grep -i "luci")
 
 # Name Server Lookup Programs
-BIND_HOST=$(which host)
-KNOT_HOST=$(which khost)
-DRILL=$(which drill)
-HOSTIP=$(which hostip)
-NSLOOKUP=$(which nslookup)
+BIND_HOST=$(command -v host)
+KNOT_HOST=$(command -v khost)
+DRILL=$(command -v drill)
+HOSTIP=$(command -v hostip)
+NSLOOKUP=$(command -v nslookup)
 
 # Transfer Programs
-WGET=$(which wget)
-WGET_SSL=$(which wget-ssl)
+WGET=$(command -v wget)
+WGET_SSL=$(command -v wget-ssl)
 
-CURL=$(which curl)
+CURL=$(command -v curl)
 # CURL_SSL not empty then SSL support available
 CURL_SSL=$($CURL -V 2>/dev/null | grep -F "https")
 # CURL_PROXY not empty then Proxy support available
 CURL_PROXY=$(find /lib /usr/lib -name libcurl.so* -exec strings {} 2>/dev/null \; | grep -im1 "all_proxy")
 
-UCLIENT_FETCH=$(which uclient-fetch)
+UCLIENT_FETCH=$(command -v uclient-fetch)
 
 # Global configuration settings
 # allow NON-public IP's
@@ -491,8 +491,8 @@ sanitize_variable() {
 verify_host_port() {
 	local __HOST=$1
 	local __PORT=$2
-	local __NC=$(which nc)
-	local __NCEXT=$($(which nc) --help 2>&1 | grep "\-w" 2>/dev/null)	# busybox nc compiled with extensions
+	local __NC=$(command -v nc)
+	local __NCEXT=$($(command -v nc) --help 2>&1 | grep "\-w" 2>/dev/null)	# busybox nc compiled with extensions
 	local __IP __IPV4 __IPV6 __RUNPROG __PROG __ERR
 	# return codes
 	# 1	system specific error
@@ -921,7 +921,7 @@ get_local_ip () {
 			[ -n "$__DATA" ] && write_log 7 "Local IP '$__DATA' detected on network '$ip_network'"
 		elif [ -n "$ip_interface" -a "$ip_source" = "interface" ]; then
 			local __DATA4=""; local __DATA6=""
-			if [ -n "$(which ip)" ]; then		# ip program installed
+			if [ -n "$(command -v ip)" ]; then		# ip program installed
 				write_log 7 "#> ip -o addr show dev $ip_interface scope global >$DATFILE 2>$ERRFILE"
 				ip -o addr show dev $ip_interface scope global >$DATFILE 2>$ERRFILE
 				__ERR=$?
@@ -1124,7 +1124,7 @@ get_registered_ip() {
 		__RUNPROG="$__PROG $lookup_host >$DATFILE 2>$ERRFILE"
 		__PROG="hostip"
 	elif [ -n "$NSLOOKUP" ]; then	# last use BusyBox nslookup
-		NSLOOKUP_MUSL=$($(which nslookup) localhost 2>&1 | grep -F "(null)")	# not empty busybox compiled with musl
+		NSLOOKUP_MUSL=$($(command -v nslookup) localhost 2>&1 | grep -F "(null)")	# not empty busybox compiled with musl
 		[ $force_dnstcp -ne 0 ] && \
 			write_log 14 "Busybox nslookup - no support for 'DNS over TCP'"
 		[ -n "$NSLOOKUP_MUSL" -a -n "$dns_server" ] && \

--- a/net/ddns-scripts/files/update_freedns_42_pl.sh
+++ b/net/ddns-scripts/files/update_freedns_42_pl.sh
@@ -5,7 +5,7 @@ local __URL="https://freedns.42.pl/xmlrpc.php"
 [ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'"
 [ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'"
 [ $ip_dynamic -eq 1 ] && __IP='\&lt;dynamic\&gt;'
-PROG="$(which curl) -sk"
+PROG="$(command -v curl) -sk"
 write_log 7 "sending update to freedns.42.pl with ip $__IP"
 XMLDATA="<?xml version='1.0'?><methodCall><methodName>xname.updateArecord</methodName><params><param><value><struct><member><name>name</name><value><string>[RECORDNAME]</string></value></member><member><name>zone</name><value><string>[ZONENAME]</string></value></member><member><name>oldaddress</name><value><string>*</string></value></member><member><name>updatereverse</name><value><string>0</string></value></member><member><name>user</name><value><string>[USERNAME]</string></value></member><member><name>ttl</name><value><string>600</string></value></member><member><name>newaddress</name><value><string>[IP]</string></value></member><member><name>password</name><value><string>[PASSWORD]</string></value></member></struct></value></param></params></methodCall>"
 XMLDATA=$(echo $XMLDATA | sed -e "s#\[USERNAME\]#$URL_USER#g" -e "s#\[PASSWORD\]#$URL_PASS#g" \

--- a/net/ddns-scripts/files/update_nsupdate.sh
+++ b/net/ddns-scripts/files/update_nsupdate.sh
@@ -17,8 +17,8 @@
 #
 local __TTL=600		#.preset DNS TTL (in seconds)
 local __RRTYPE __PW __TCP
-local __PROG=$(which nsupdate)			# BIND nsupdate ?
-[ -z "$__PROG" ] && __PROG=$(which knsupdate)	# Knot nsupdate ?
+local __PROG=$(command -v nsupdate)			# BIND nsupdate ?
+[ -z "$__PROG" ] && __PROG=$(command -v knsupdate)	# Knot nsupdate ?
 
 [ -z "$__PROG" ]     && write_log 14 "'nsupdate' or 'knsupdate' not installed !"
 [ -z "$username" ]   && write_log 14 "Service section not configured correctly! Missing 'username'"

--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.8.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0
 

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -23,19 +23,19 @@ if_down() {
 validate_track_method() {
 	case "$1" in
 		ping)
-			which ping 1>/dev/null 2>&1 || {
+			command -v ping 1>/dev/null 2>&1 || {
 				$LOG warn "Missing ping. Please install iputils-ping package or enable ping util and recompile busybox."
 				return 1
 			}
 			;;
 		arping)
-			which arping 1>/dev/null 2>&1 || {
+			command -v arping 1>/dev/null 2>&1 || {
 				$LOG warn "Missing arping. Please install iputils-arping package."
 				return 1
 			}
 			;;
 		httping)
-			which httping 1>/dev/null 2>&1 || {
+			command -v httping 1>/dev/null 2>&1 || {
 				$LOG warn "Missing httping. Please install httping package."
 				return 1
 			}
@@ -45,7 +45,7 @@ validate_track_method() {
 			}
 			;;
 		nping-*)
-			which nping 1>/dev/null 2>&1 || {
+			command -v nping 1>/dev/null 2>&1 || {
 				$LOG warn "Missing nping. Please install nping package."
 				return 1
 			}

--- a/net/trafficshaper/Makefile
+++ b/net/trafficshaper/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=trafficshaper
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/trafficshaper/files/trafficshaper.init
+++ b/net/trafficshaper/files/trafficshaper.init
@@ -64,11 +64,11 @@ requires() {
 			die 2 "cannot load $module. Please install kmod-$module"
 	done
 	for cmd in $REQ_CMDS; do
-		which $cmd &>/dev/null ||
+		command -v $cmd &>/dev/null ||
 			die 2 "cannot find command $cmd. Please install $cmd"
 	done
 
-	if ! which ip6tables &>/dev/null; then
+	if ! command -v ip6tables &>/dev/null; then
 		v "Disabling IPv6 as ip6tables was not found"
 		IP6T=true
 	fi

--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=4.0.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/

--- a/utils/lxc/patches/020-lxc-checkconfig.patch
+++ b/utils/lxc/patches/020-lxc-checkconfig.patch
@@ -7,7 +7,7 @@
 +: ${ZGREP:=zgrep}
 +: ${GUNZIP:=gunzip}
 +
-+if [ -z $(which $ZGREP) ] && ! [ -z $(which $GUNZIP) ] && [ -x $(which $GUNZIP) ] &&  [ -f $CONFIG ] && [ "$CONFIG" == "/proc/config.gz" ] ; then
++if [ -z $(command -v $ZGREP) ] && ! [ -z $(command -v $GUNZIP) ] && [ -x $(command -v $GUNZIP) ] &&  [ -f $CONFIG ] && [ "$CONFIG" == "/proc/config.gz" ] ; then
 +
 +	CONFIG_NEW="/tmp/config-$(uname -r)"
 +	$GUNZIP -c $CONFIG > $CONFIG_NEW


### PR DESCRIPTION
Fix shellcheck SC2230
> which is non-standard. Use builtin 'command -v' instead.

Once applied to everything concerning OpenWrt we can disable the busybox
feature `which` and save 3.8kB.

Signed-off-by: Paul Spooren <mail@aparcar.org>