### PR TITLE
docker-ce: Enabled cgroups v1 by default

### DIFF
--- a/utils/docker-ce/Config.in
+++ b/utils/docker-ce/Config.in
@@ -1,15 +1,16 @@
 config DOCKER_KERNEL_OPTIONS
 	bool "Enable Basic kernel support for Docker"
 	depends on PACKAGE_docker-ce
-	default n
+	default y
 	select KERNEL_CGROUPS
 	select KERNEL_CGROUP_CPUACCT
+	select KERNEL_CGROUP_DEVICE
+	select KERNEL_CGROUP_FREEZER
 	select KERNEL_CGROUP_SCHED
 	select KERNEL_NAMESPACES
 	select KERNEL_CPUSETS
 	select KERNEL_MEMCG
 	select KERNEL_KEYS
-	select KERNEL_DEVPTS_MULTIPLE_INSTANCES
 	select KERNEL_POSIX_MQUEUE
 	help
 	  Select needed kernel options for Docker. Options include
@@ -35,7 +36,10 @@ config DOCKER_RES_SHAPE
 	select KERNEL_BLK_DEV_THROTTLING
 	select KERNEL_CFQ_GROUP_IOSCHED
 	select KERNEL_CGROUP_PERF
+	select KERNEL_CGROUP_HUGETLB
 	select KERNEL_FAIR_GROUP_SCHED
+	select KERNEL_NET_CLS_CGROUP
+	select KERNEL_CGROUP_NET_PRIO
 	select KERNEL_CFS_BANDWIDTH
 	select KERNEL_RT_GROUP_SCHED
 

--- a/utils/docker-ce/Makefile
+++ b/utils/docker-ce/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-ce
 PKG_VERSION:=19.03.12
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=components/cli/LICENSE components/engine/LICENSE
 


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: x86_x64, Hyper-V, OpenWrt Master
Run tested: x86_x64, Hyper-V, OpenWrt Master

Description:
* Added kernel options required to run docker by default since https://github.com/openwrt/openwrt/commit/d1a8217d87bffa33fd7d4562b3ed2f797c14beaf
* Added now available kernel options requested by https://github.com/docker/docker-ce/blob/master/components/engine/contrib/check-config.sh
* Related to findings in https://github.com/openwrt/packages/issues/13052