### PR TITLE
sendmail: fix compilation without sys/cdefs

### DIFF
--- a/mail/sendmail/Makefile
+++ b/mail/sendmail/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sendmail
 PKG_VERSION:=8.15.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://artfiles.org/sendmail.org/pub/sendmail/ \

--- a/mail/sendmail/patches/210-cdefs.patch
+++ b/mail/sendmail/patches/210-cdefs.patch
@@ -1,0 +1,10 @@
+--- a/include/sm/os/sm_os_linux.h
++++ b/include/sm/os/sm_os_linux.h
+@@ -33,7 +33,6 @@
+ # endif /* LINUX_VERSION_CODE */
+ #endif /* SM_CONF_SHM */
+ 
+-#define SM_CONF_SYS_CDEFS_H	1
+ #ifndef SM_CONF_SEM
+ # define SM_CONF_SEM	2
+ #endif /* SM_CONF_SEM */


### PR DESCRIPTION
sys/cdefs is deprecated. It's also not included with musl.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @val-kulkov 
Compile tested: ath79