### PR TITLE
linknx: fix compilation without sys/cdefs

### DIFF
--- a/net/linknx/Makefile
+++ b/net/linknx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linknx
 PKG_VERSION:=0.0.1.38
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-${PKG_VERSION}.tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/linknx/linknx/tar.gz/$(PKG_VERSION)?

--- a/net/linknx/patches/010-cdefs.patch
+++ b/net/linknx/patches/010-cdefs.patch
@@ -1,0 +1,26 @@
+--- a/include/eibclient.h
++++ b/include/eibclient.h
+@@ -27,11 +27,12 @@
+ #ifndef EIBCLIENT_H
+ #define EIBCLIENT_H
+ 
+-#include "sys/cdefs.h"
+ #include "stdint.h"
+ #include <pthsem.h>
+ 
+-__BEGIN_DECLS;
++#ifdef __cplusplus
++extern "C" {
++#endif
+ 
+ #include "eibloadresult.h"
+ 
+@@ -705,5 +706,7 @@ BCU_LOAD_RESULT EIB_LoadImage (EIBConnection * con, const uint8_t * image,
+  */
+ int EIB_LoadImage_async (EIBConnection * con, const uint8_t * image, int len);
+ 
+-__END_DECLS
++#ifdef __cplusplus
++}
++#endif
+ #endif


### PR DESCRIPTION
sys/cdefs.h is not included with musl. It's also deprecated.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tru7 
Compile tested: ath79