### PR TITLE
knxd: fix compilation without sys/cdefs

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -12,7 +12,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
 PKG_VERSION:=0.14.39
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/knxd/knxd/tar.gz/$(PKG_VERSION)?

--- a/net/knxd/patches/020-cdefs.patch
+++ b/net/knxd/patches/020-cdefs.patch
@@ -1,0 +1,25 @@
+--- a/src/include/eibclient.h
++++ b/src/include/eibclient.h
+@@ -27,10 +27,11 @@
+ #ifndef EIBCLIENT_H
+ #define EIBCLIENT_H
+ 
+-#include <sys/cdefs.h>
+ #include <stdint.h>
+ 
+-__BEGIN_DECLS;
++#ifdef __cplusplus
++extern "C" {
++#endif
+ 
+ #include "eibloadresult.h"
+ 
+@@ -935,5 +936,7 @@ int EIB_Cache_LastUpdates2_async (EIBConnection * con, uint32_t start,
+                                   uint32_t * end);
+ 
+ 
+-__END_DECLS
++#ifdef __cplusplus
++}
++#endif
+ #endif


### PR DESCRIPTION
sys/cdefs.h does not come with musl. It's also deprecated.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tru7 
Compile tested: ath79