### PR TITLE
hfsprogs: fix compilation without sys/cdefs

### DIFF
--- a/utils/hfsprogs/Makefile
+++ b/utils/hfsprogs/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hfsprogs
 PKG_VERSION:=332.25
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.gz
 PKG_SOURCE_URL:=http://archive.ubuntu.com/ubuntu/pool/universe/h/$(PKG_NAME)

--- a/utils/hfsprogs/patches/030-no-cdefs.patch
+++ b/utils/hfsprogs/patches/030-no-cdefs.patch
@@ -1,0 +1,199 @@
+--- a/disklib/dump.h
++++ b/disklib/dump.h
+@@ -110,9 +110,7 @@ extern long	dev_bsize;	/* block size of underlying disk device */
+ extern int	dev_bshift;	/* log2(dev_bsize) */
+ extern int	tp_bshift;	/* log2(TP_BSIZE) */
+ 
+-#ifndef __P
+-#include <sys/cdefs.h>
+-#endif
++#define __P(x)	x
+ 
+ /* operator interface functions */
+ void	broadcast __P((char *message));
+--- a/dump.tproj/unctime.c
++++ b/dump.tproj/unctime.c
+@@ -64,9 +64,7 @@
+ #include <string.h>
+ #endif
+ 
+-#ifndef __P
+-#include <sys/cdefs.h>
+-#endif
++#define __P(x)	x
+ 
+ /*
+  * Convert a ctime(3) format string into a system format date.
+--- a/fdisk.tproj/getrawpartition.c
++++ b/fdisk.tproj/getrawpartition.c
+@@ -59,7 +59,6 @@
+  * POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <sys/cdefs.h>
+ #if defined(LIBC_SCCS) && !defined(lint)
+ __RCSID("$NetBSD: getrawpartition.c,v 1.4 1999/07/02 15:49:12 simonb Exp $");
+ #endif
+--- a/fdisk.tproj/util.h
++++ b/fdisk.tproj/util.h
+@@ -59,9 +59,10 @@
+ #ifndef _UTIL_H_
+ #define _UTIL_H_
+ 
+-#include <sys/cdefs.h>
+ #include <sys/types.h>
+ 
++#define __P(x)	x
++
+ /*
+  * fparseln() specific operation flags.
+  */
+--- a/fsck_hfs.tproj/fsck_hfs.h
++++ b/fsck_hfs.tproj/fsck_hfs.h
+@@ -24,7 +24,7 @@
+ 
+ #include "cache.h"
+ 
+-#include <sys/cdefs.h>
++#define __P(x)	x
+ 
+ const extern char	*cdevname;		/* name of device being checked */
+ extern char	*progname;
+--- a/fsck_msdos.tproj/boot.c
++++ b/fsck_msdos.tproj/boot.c
+@@ -54,8 +54,6 @@
+  */
+ 
+ 
+-#include <sys/cdefs.h>
+-
+ #include <stdlib.h>
+ #include <string.h>
+ #include <ctype.h>
+--- a/fsck_msdos.tproj/check.c
++++ b/fsck_msdos.tproj/check.c
+@@ -54,8 +54,6 @@
+  */
+ 
+ 
+-#include <sys/cdefs.h>
+-
+ #include <stdlib.h>
+ #include <string.h>
+ #include <ctype.h>
+--- a/fsck_msdos.tproj/dir.c
++++ b/fsck_msdos.tproj/dir.c
+@@ -56,8 +56,6 @@
+  */
+ 
+ 
+-#include <sys/cdefs.h>
+-
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+@@ -109,6 +107,7 @@
+ #define DD_YEAR_MASK		0xFE00	/* year - 1980 */
+ #define DD_YEAR_SHIFT		9
+ 
++#define __P(x)	x
+ 
+ /* dir.c */
+ static struct dosDirEntry *newDosDirEntry __P((void));
+--- a/fsck_msdos.tproj/fat.c
++++ b/fsck_msdos.tproj/fat.c
+@@ -54,8 +54,6 @@
+  */
+ 
+ 
+-#include <sys/cdefs.h>
+-
+ #include <stdlib.h>
+ #include <string.h>
+ #include <ctype.h>
+@@ -67,6 +65,8 @@
+ #include "ext.h"
+ #include "fsutil.h"
+ 
++#define __P(x)	x
++
+ /*
+  * The following value should be a multiple of the sector size in bytes.  The
+  * Microsoft supported sector sizes are 512, 1024, 2048, and 4096, which means
+--- a/fsck_msdos.tproj/fsutil.c
++++ b/fsck_msdos.tproj/fsutil.c
+@@ -54,8 +54,6 @@
+  * SUCH DAMAGE.
+  */
+ 
+-#include <sys/cdefs.h>
+-
+ #include <stdio.h>
+ #include <string.h>
+ #include <stdlib.h>
+@@ -74,6 +72,8 @@
+ #include "ext.h"
+ #include "fsutil.h"
+ 
++#define __P(x)	x
++
+ static const char *dev = NULL;
+ static int hot = 0;
+ /*static int preen = 0;*/
+--- a/fsck_msdos.tproj/main.c
++++ b/fsck_msdos.tproj/main.c
+@@ -54,8 +54,6 @@
+  */
+ 
+ 
+-#include <sys/cdefs.h>
+-
+ #include <stdlib.h>
+ #include <string.h>
+ #include <ctype.h>
+@@ -68,6 +66,8 @@
+ #include <varargs.h>
+ #endif
+ 
++#define __P(x)	x
++
+ #include "fsutil.h"
+ #include "ext.h"
+ 
+--- a/newfs_hfs.tproj/makehfs.c
++++ b/newfs_hfs.tproj/makehfs.c
+@@ -28,7 +28,6 @@
+ 
+ */
+ 
+-#include <sys/cdefs.h>
+ #include <sys/param.h>
+ #include <sys/types.h>
+ #include <sys/time.h>
+@@ -80,6 +79,7 @@ extern Boolean _CFStringGetFileSystemRepresentation(CFStringRef string, UInt8 *b
+ 
+ #define kJournalFileType	0x6a726e6c	/* 'jrnl' */
+ 
++#define __P(x)	x
+ 
+ typedef HFSMasterDirectoryBlock HFS_MDB;
+ 
+--- a/newfs_hfs.tproj/newfs_hfs.c
++++ b/newfs_hfs.tproj/newfs_hfs.c
+@@ -34,7 +34,6 @@
+ #include <syslog.h>
+ #include <unistd.h>
+ 
+-#include <sys/cdefs.h>
+ #include <sys/ioctl.h>
+ #include <sys/mount.h>
+ #include <sys/param.h>
+@@ -62,6 +61,8 @@
+ 
+ #define ROUNDUP(x,y) (((x)+(y)-1)/(y)*(y))
+ 
++#define __P(x)	x
++
+ static void getnodeopts __P((char* optlist));
+ static void getclumpopts __P((char* optlist));
+ static gid_t a_gid __P((char *));


### PR DESCRIPTION
sys/cdefs.h does not come with musl. It's also deprecated.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @openwrt/package-maintainers 
Compile tested: ath79