### PR TITLE
chaosvpn: fix compilation without sys/cdefs

### DIFF
--- a/net/chaosvpn/Makefile
+++ b/net/chaosvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=chaosvpn
 
 PKG_VERSION:=2.19
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ryd/chaosvpn/tar.gz/v$(PKG_VERSION)?

--- a/net/chaosvpn/patches/020-cdefs.patch
+++ b/net/chaosvpn/patches/020-cdefs.patch
@@ -1,0 +1,32 @@
+--- a/ar.h
++++ b/ar.h
+@@ -20,8 +20,6 @@
+ #ifndef _AR_H
+ #define _AR_H 1
+ 
+-#include <sys/cdefs.h>
+-
+ /* Archive files start with the ARMAG identifying string.  Then follows a
+    `struct ar_hdr', and as many bytes of member file data as its `ar_size'
+    member indicates, for each member file.  */
+@@ -31,7 +29,9 @@
+ 
+ #define ARFMAG	"`\n"		/* String in ar_fmag at end of each header.  */
+ 
+-__BEGIN_DECLS
++#ifdef __cplusplus
++extern "C" {
++#endif
+ 
+ struct ar_hdr
+   {
+@@ -43,6 +43,8 @@ struct ar_hdr
+     char ar_fmag[2];		/* Always contains ARFMAG.  */
+   };
+ 
+-__END_DECLS
++#ifdef __cplusplus
++}
++#endif
+ 
+ #endif /* ar.h */


### PR DESCRIPTION
sys/cdefs.h does not come included with musl. It's also deprecated.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @TuxCoder 
Compile tested: ath79