### PR TITLE
fdm: fix compilation without sys/cdefs

### DIFF
--- a/mail/fdm/Makefile
+++ b/mail/fdm/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fdm
 PKG_VERSION:=2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/nicm/fdm/releases/download/$(PKG_VERSION)

--- a/mail/fdm/patches/030-cdefs.patch
+++ b/mail/fdm/patches/030-cdefs.patch
@@ -1,0 +1,32 @@
+From 3232e537ccaba4417b25d9d70264e4a5533042da Mon Sep 17 00:00:00 2001
+From: Nicholas Marriott <nicholas.marriott@gmail.com>
+Date: Mon, 18 Mar 2019 13:04:00 +0000
+Subject: [PATCH] Fix bas64 declarations, from makepost at firemail dot cc.
+
+---
+ fdm.h | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/fdm.h b/fdm.h
+index 41eaa37..511a7b1 100644
+--- a/fdm.h
++++ b/fdm.h
+@@ -20,7 +20,6 @@
+ #define FDM_H
+ 
+ #include <sys/param.h>
+-#include <sys/cdefs.h>
+ #include <sys/stat.h>
+ 
+ #ifdef HAVE_QUEUE_H
+@@ -725,8 +724,8 @@ size_t		 strlcat(char *, const char *, size_t);
+ 
+ #ifndef HAVE_B64_NTOP
+ /* base64.c */
+-int b64_ntop(src, srclength, target, targsize);
+-int b64_pton(src, target, targsize);
++int b64_ntop(u_char const *, size_t, char *, size_t);
++int b64_pton(char const *, u_char *, size_t);
+ #endif
+ 
+ /* shm.c */


### PR DESCRIPTION
It seems this is completely unused.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @pfzim 
Compile tested: ath79