### PR TITLE
micropython: fix compilation without sys/cdefs

### DIFF
--- a/lang/python/micropython/Makefile
+++ b/lang/python/micropython/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=micropython
 PKG_VERSION:=1.9.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/micropython/micropython/releases/download/v$(PKG_VERSION)

--- a/lang/python/micropython/patches/010-cdefs.patch
+++ b/lang/python/micropython/patches/010-cdefs.patch
@@ -1,0 +1,64 @@
+--- a/lib/berkeley-db-1.xx/PORT/bsd.4.4/include/db.h
++++ b/lib/berkeley-db-1.xx/PORT/bsd.4.4/include/db.h
+@@ -37,7 +37,7 @@
+ #define	_DB_H_
+ 
+ #include <sys/types.h>
+-#include <sys/cdefs.h>
++#include "cdefs.h"
+ 
+ #include <limits.h>
+ 
+--- a/lib/berkeley-db-1.xx/PORT/clib/memmove.c
++++ b/lib/berkeley-db-1.xx/PORT/clib/memmove.c
+@@ -38,7 +38,7 @@
+ static char sccsid[] = "@(#)bcopy.c	8.1 (Berkeley) 6/4/93";
+ #endif /* LIBC_SCCS and not lint */
+ 
+-#include <sys/cdefs.h>
++#include "cdefs.h"
+ #include <string.h>
+ 
+ /*
+--- a/lib/berkeley-db-1.xx/PORT/clib/snprintf.c
++++ b/lib/berkeley-db-1.xx/PORT/clib/snprintf.c
+@@ -1,5 +1,5 @@
+ #include <sys/types.h>
+-#include <sys/cdefs.h>
++#include "cdefs.h"
+ 
+ #include <compat.h>
+ 
+--- a/lib/berkeley-db-1.xx/PORT/hpux.9.01/local/hp_siglist.c
++++ b/lib/berkeley-db-1.xx/PORT/hpux.9.01/local/hp_siglist.c
+@@ -2,7 +2,7 @@
+  * Derived from:
+  * static char sccsid[] = "@(#)siglist.c	8.1 (Berkeley) 6/4/93";
+  */
+-#include <sys/cdefs.h>
++#include "cdefs.h"
+ 
+ #include <signal.h>
+ 
+--- a/lib/berkeley-db-1.xx/PORT/ultrix.4.2/include/db.h
++++ b/lib/berkeley-db-1.xx/PORT/ultrix.4.2/include/db.h
+@@ -37,7 +37,7 @@
+ #define	_DB_H_
+ 
+ #include <sys/types.h>
+-#include <sys/cdefs.h>
++#include "cdefs.h"
+ 
+ #include <limits.h>
+ 
+--- a/lib/berkeley-db-1.xx/include/db.h
++++ b/lib/berkeley-db-1.xx/include/db.h
+@@ -37,7 +37,7 @@
+ #define	_DB_H_
+ 
+ #include <sys/types.h>
+-#include <sys/cdefs.h>
++#include "cdefs.h"
+ 
+ #include <limits.h>
+ 


### PR DESCRIPTION
sys/cdefs.h is not provided by musl. micropython also includes its own
copy.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @roger- 
Compile tested: ath79