### PR TITLE
quota: fix compilation without sys/cdefs

### DIFF
--- a/utils/quota/Makefile
+++ b/utils/quota/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=quota
 PKG_VERSION:=4.05
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/linuxquota

--- a/utils/quota/patches/010-cdefs.patch
+++ b/utils/quota/patches/010-cdefs.patch
@@ -1,0 +1,18 @@
+--- a/quota.h
++++ b/quota.h
+@@ -1,7 +1,6 @@
+ #ifndef GUARD_QUOTA_H
+ #define GUARD_QUOTA_H
+ 
+-#include <sys/cdefs.h>
+ #include <sys/types.h>
+ #include <stdint.h>
+ 
+@@ -182,6 +181,6 @@ enum {
+ 	#endif
+ #endif
+ 
+-long quotactl __P((int, const char *, qid_t, caddr_t));
++long quotactl (int, const char *, qid_t, caddr_t);
+ 
+ #endif /* _QUOTA_ */


### PR DESCRIPTION
sys/cdefs.h does not come included with musl. It's also deprecated.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @flyn-org 
Compile tested: ath79