### PR TITLE
open-iscsi: fix compilation with musl 1.2.0

### DIFF
--- a/net/open-iscsi/Makefile
+++ b/net/open-iscsi/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=open-iscsi
 PKG_VERSION:=2.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/open-iscsi/open-iscsi/tar.gz/$(PKG_VERSION)?

--- a/net/open-iscsi/patches/0004-idbw_rec_write-pick-tpgt-from-existing-record.patch
+++ b/net/open-iscsi/patches/0004-idbw_rec_write-pick-tpgt-from-existing-record.patch
@@ -23,7 +23,18 @@ index b6193e7..2208c4a 100644
  #include <sys/stat.h>
  #include <sys/file.h>
  #include <inttypes.h>
-@@ -202,6 +203,8 @@ static struct int_list_tbl {
+@@ -44,6 +45,10 @@
+ #include "fw_context.h"
+ #include "iscsi_err.h"
+ 
++#ifndef GLOB_ONLYDIR
++#define GLOB_ONLYDIR	0x100
++#endif
++
+ #define IDBM_HIDE	0    /* Hide parameter when print. */
+ #define IDBM_SHOW	1    /* Show parameter when print. */
+ #define IDBM_MASKED	2    /* Show "stars" instead of real value when print */
+@@ -202,6 +207,8 @@ static struct int_list_tbl {
  	{ "SHA3-256", AUTH_CHAP_ALG_SHA3_256 },
  };
  
@@ -32,7 +43,7 @@ index b6193e7..2208c4a 100644
  static void
  idbm_recinfo_discovery(discovery_rec_t *r, recinfo_t *ri)
  {
-@@ -2206,12 +2209,49 @@ static int idbm_rec_write_old(node_rec_t *rec)
+@@ -2206,12 +2213,49 @@ static int idbm_rec_write_old(node_rec_t *rec)
  	FILE *f;
  	char *portal;
  	int rc = 0;
@@ -82,6 +93,4 @@ index b6193e7..2208c4a 100644
  	snprintf(portal, PATH_MAX, "%s/%s/%s,%d", NODE_CONFIG_DIR,
  		 rec->name, rec->conn[0].address, rec->conn[0].port);
  
--- 
-2.21.1
 


### PR DESCRIPTION
GLOB_ONLYDIR is not defined.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: ath79