### PR TITLE
pulseaudio: fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pulseaudio
 PKG_VERSION:=13.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://freedesktop.org/software/pulseaudio/releases

--- a/sound/pulseaudio/patches/020-openssl-deprecated.patch
+++ b/sound/pulseaudio/patches/020-openssl-deprecated.patch
@@ -1,0 +1,10 @@
+--- a/src/modules/raop/raop-crypto.c
++++ b/src/modules/raop/raop-crypto.c
+@@ -30,6 +30,7 @@
+ #include <openssl/err.h>
+ #include <openssl/aes.h>
+ #include <openssl/rsa.h>
++#include <openssl/bn.h>
+ 
+ #include <pulse/xmalloc.h>
+ 


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 
Compile tested: ath79