### PR TITLE
minidlna: fix GCC 10 multiple def compilation error

### DIFF
--- a/multimedia/minidlna/Makefile
+++ b/multimedia/minidlna/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=minidlna
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://git.code.sf.net/p/minidlna/git

--- a/multimedia/minidlna/patches/999-05-fix-setjmp-buffer-multiple-def.patch
+++ b/multimedia/minidlna/patches/999-05-fix-setjmp-buffer-multiple-def.patch
@@ -1,0 +1,22 @@
+--- a/image_utils.c
++++ b/image_utils.c
+@@ -190,7 +190,7 @@ jpeg_memory_src(j_decompress_ptr cinfo,
+ 	src->pub.bytes_in_buffer = bufsize;
+ }
+ 
+-jmp_buf setjmp_buffer;
++static jmp_buf setjmp_buffer;
+ /* Don't exit on error like libjpeg likes to do */
+ static void
+ libjpeg_error_handler(j_common_ptr cinfo)
+--- a/metadata.c
++++ b/metadata.c
+@@ -502,7 +502,7 @@ GetAudioMetadata(const char *path, const
+ }
+ 
+ /* For libjpeg error handling */
+-jmp_buf setjmp_buffer;
++static jmp_buf setjmp_buffer;
+ static void
+ libjpeg_error_handler(j_common_ptr cinfo)
+ {


### PR DESCRIPTION
Diffrent file use its own setjmp_buffer, thus
we have two global variables called setjmp_buffer

I am not sure if we should use only one instance of it.

The patch sent upstream uses a similar approach.

https://sourceforge.net/p/minidlna/bugs/327/

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>

Maintainer: @openwrt/package-maintainers 
Compile tested: ath79

ping @wongsyrone 