### PR TITLE
rsync: update to 3.2.3

### DIFF
--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsync
-PKG_VERSION:=3.2.2
+PKG_VERSION:=3.2.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.samba.org/pub/rsync/src
-PKG_HASH:=644bd3841779507665211fd7db8359c8a10670c57e305b4aab61b4e40037afa8
+PKG_HASH:=becc3c504ceea499f4167a260040ccf4d9f2ef9499ad5683c179a697146ce50e
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
Signed-off-by: Maxim Storchak <m.storchak@gmail.com>

Maintainer: me
Compile tested: ath97, WNDR3800, r14128+4-a5a0b3f1d0
Run tested: ath97, WNDR3800, r11651+3-487e0631d0, basic local and remote file transfer works

Description:
