### PR TITLE
libmaxminddb: update to version 1.4.3

### DIFF
--- a/libs/libmaxminddb/Makefile
+++ b/libs/libmaxminddb/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 CZ.NIC z.s.p.o. (http://www.nic.cz/)
+# Copyright (C) 2019-2020 CZ.NIC z.s.p.o. (http://www.nic.cz/)
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmaxminddb
-PKG_VERSION:=1.4.2
+PKG_VERSION:=1.4.3
 PKG_RELEASE=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/maxmind/libmaxminddb/releases/download/$(PKG_VERSION)/
-PKG_HASH:=dd582aa971be23dee960ec33c67fb5fd38affba508e6f00ea75959dbd5aad156
+PKG_HASH:=a5fdf6c7b4880fdc7620f8ace5bd5cbe9f65650c9493034b5b9fc7d83551a439
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates libmaxminddb to version 1.4.3 [Changelog](https://github.com/maxmind/libmaxminddb/releases/tag/1.4.3) Mainly it fixes the use of uninitialized memory.
