### PR TITLE
lvm2: fix CE in mac

### DIFF
--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -61,10 +61,15 @@ CONFIGURE_ARGS += \
 	--with-default-run-dir=/var/run/lvm \
 	--with-default-locking-dir=/var/lock/lvm
 
+ifneq ($(shell /bin/sh -c "echo -n 'X'"),X)
+MAKE_SHELL = SHELL=/bin/bash
+endif
+
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS) $(FPIC)" \
 		DESTDIR="$(PKG_INSTALL_DIR)" \
+		$(MAKE_SHELL) \
 		install
 endef
 


### PR DESCRIPTION
command-count.h generated by makefile was wrong when using default shell in mac, set shell to bash to fix it.

Signed-off-by: Liangbin Lian <jjm2473@gmail.com>

Maintainer: Daniel Golle <daniel@makrotopia.org>
Compile tested: Mac OS 10.15.6 , OpenWRT 18.06
Run tested: 

Description:
