### PR TITLE
nss: update to version 3.55 (security fix)

### DIFF
--- a/libs/nspr/Makefile
+++ b/libs/nspr/Makefile
@@ -7,8 +7,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nspr
-PKG_VERSION:=4.25
-PKG_RELEASE:=3
+PKG_VERSION:=4.27
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENCE:=MPL-2.0
 
@@ -16,7 +16,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
     https://download.cdn.mozilla.net/pub/$(PKG_NAME)/releases/v$(PKG_VERSION)/src/ \
     https://archive.mozilla.org/pub/$(PKG_NAME)/releases/v$(PKG_VERSION)/src/
-PKG_HASH:=0bc309be21f91da4474c56df90415101c7f0c7c7cab2943cd943cd7896985256
+PKG_HASH:=6d495192b6ab00a3c28db053492cf794329f7c0351a5728db198111a1816e89b
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1

--- a/libs/nss/Makefile
+++ b/libs/nss/Makefile
@@ -7,14 +7,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nss
-PKG_VERSION:=3.53
+PKG_VERSION:=3.55
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
     https://download.cdn.mozilla.net/pub/security/$(PKG_NAME)/releases/NSS_$(subst .,_,$(PKG_VERSION))_RTM/src \
     https://archive.mozilla.org/pub/security/$(PKG_NAME)/releases/NSS_$(subst .,_,$(PKG_VERSION))_RTM/src
-PKG_HASH:=08d36dc1a56325f02e626626d4eeab9c4d126dbd99dfaf419b91d0a696f58917
+PKG_HASH:=fc692e3db45a082ee6328cd989e795c171a00df9c518df090937f7604f850004
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENCE:=MPL-2.0


### PR DESCRIPTION
Maintainer: @lucize 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates nss to version 3.55 It fixes multiple security issues

[Changelog](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_3.55_release_notes)

Fixes
CVE-2020-12403
CVE-2020-12401
CVE-2020-6829
CVE-2020-12400

This should be also cherrypicked to 19.07 where nss version is 3.48

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>
