### PR TITLE
mpack: update URLs

### DIFF
--- a/utils/mpack/Makefile
+++ b/utils/mpack/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=1
 PKG_LICENSE:=NLPL
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://ftp.andrew.cmu.edu/pub/mpack/
+PKG_SOURCE_URL:=https://fossies.org/linux/misc/old
 PKG_HASH:=274108bb3a39982a4efc14fb3a65298e66c8e71367c3dabf49338162d207a94c
 
 PKG_INSTALL:=1
@@ -24,7 +24,7 @@ define Package/mpack
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=mpack/munpack MIME format mail messages
-  URL:=http://ftp.andrew.cmu.edu/pub/mpack/
+  URL:=https://gitlab.com/osdp/mpack
   MAINTAINER:=Dmitry V. Zimin <pfzim@mail.ru>
 endef
 


### PR DESCRIPTION
Upstream sort of moved to GitLab.

Use fossies mirror since the original site went down.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @pfzim 