### PR TITLE
coreutils: don't use non-portable path to bash

### DIFF
--- a/utils/coreutils/Makefile
+++ b/utils/coreutils/Makefile
@@ -134,7 +134,7 @@ CONFIGURE_ARGS += \
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		DESTDIR="$(PKG_INSTALL_DIR)" \
-		SHELL="/bin/bash" \
+		SHELL="/bin/sh" \
 		all install
 endef
 


### PR DESCRIPTION
As /bin/bash is not guaranteed to exist, use the less non-portable /bin/sh.
I thought of replacing it with `env bash`, but apparently, sh works here too.
Build-tested on FreeBSD.