### PR TITLE
netsniff-ng: add missing header

### DIFF
--- a/net/netsniff-ng/Makefile
+++ b/net/netsniff-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netsniff-ng
 PKG_VERSION:=0.6.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netsniff-ng/netsniff-ng/tar.gz/v$(PKG_VERSION)?

--- a/net/netsniff-ng/patches/010-uclibc.patch
+++ b/net/netsniff-ng/patches/010-uclibc.patch
@@ -1,0 +1,10 @@
+--- a/cookie.c
++++ b/cookie.c
+@@ -2,6 +2,7 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <syslog.h>
++#include <sys/types.h>
+ 
+ #include "cookie.h"
+ 


### PR DESCRIPTION
Needed for ssize_t.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lnslbrty
Compile tested: ath79