### PR TITLE
u2pnpd: remove index API usage

### DIFF
--- a/net/u2pnpd/Makefile
+++ b/net/u2pnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=u2pnpd
 PKG_VERSION:=0.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/mhei/u2pnpd/releases/download/v$(PKG_VERSION)

--- a/net/u2pnpd/patches/010-index.patch
+++ b/net/u2pnpd/patches/010-index.patch
@@ -1,0 +1,20 @@
+--- a/device_info.c
++++ b/device_info.c
+@@ -42,7 +42,7 @@ int deviceinfo_from_cpuinfo(char **dest, const char *key)
+ 			continue;
+ 
+ 		/* search ':' */
+-		start = index(line, ':');
++		start = strchr(line, ':');
+ 		if (!start)
+ 			continue;
+ 		start++;
+@@ -79,7 +79,7 @@ static int line_get_value(char **dest, char *line)
+ 	char quote = 0;
+ 	int c, q;
+ 
+-	s = index(line, '=');
++	s = strchr(line, '=');
+ 	if (!s)
+ 		return -1;
+ 


### PR DESCRIPTION
(r)index is deprecated and replaced with str(r)chr.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mhei 
Compile tested: ath79