### PR TITLE
tgt: remove bzero usage

### DIFF
--- a/net/tgt/Makefile
+++ b/net/tgt/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tgt
 PKG_VERSION:=1.0.79
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fujita/tgt/tar.gz/v$(PKG_VERSION)?

--- a/net/tgt/patches/110-bzero.patch
+++ b/net/tgt/patches/110-bzero.patch
@@ -1,0 +1,11 @@
+--- a/usr/iscsi/target.c
++++ b/usr/iscsi/target.c
+@@ -224,7 +224,7 @@ get_redirect_address(char *callback, char *buffer, int buflen,
+ {
+ 	char *p, *addr, *port;
+ 
+-	bzero(buffer, buflen);
++	memset(buffer, 0, buflen);
+ 	if (call_program(callback, NULL, NULL, buffer, buflen, 0))
+ 		return -1;
+ 


### PR DESCRIPTION
bzero is deprecated and replaced by memset.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mstorchak 
Compile tested: ath79