### PR TITLE
open-isns: fix compilation without deprecated signal API

### DIFF
--- a/net/open-isns/Makefile
+++ b/net/open-isns/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=open-isns
 PKG_VERSION:=0.100
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/open-iscsi/open-isns/tar.gz/v$(PKG_VERSION)?

--- a/net/open-isns/patches/20-signals.patch
+++ b/net/open-isns/patches/20-signals.patch
@@ -1,0 +1,41 @@
+From e7dac76ce61039fefa58985c955afccb60dabe87 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Wed, 29 Apr 2020 15:55:55 -0700
+Subject: [PATCH] libisns: remove sighold and sigrelse
+
+The man page says that these are deprecated. Use sugprocmask as a replacement.
+---
+ include/libisns/util.h | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/include/libisns/util.h b/include/libisns/util.h
+index e5ed037..f1b97f0 100644
+--- a/include/libisns/util.h
++++ b/include/libisns/util.h
+@@ -41,14 +41,22 @@ char *		print_size(unsigned long);
+  */
+ static inline void signals_hold(void)
+ {
+-	sighold(SIGTERM);
+-	sighold(SIGINT);
++	sigset_t s;
++
++	sigemptyset(&s);
++	sigaddset(&s, SIGTERM);
++	sigaddset(&s, SIGINT);
++	sigprocmask(SIG_BLOCK, &s, 0);
+ }
+ 
+ static inline void signals_release(void)
+ {
+-	sigrelse(SIGTERM);
+-	sigrelse(SIGINT);
++	sigset_t s;
++
++	sigemptyset(&s);
++	sigaddset(&s, SIGTERM);
++	sigaddset(&s, SIGINT);
++	sigprocmask(SIG_UNBLOCK, &s, 0);
+ }
+ 
+ /*


### PR DESCRIPTION
Upstream backport.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: ath79