### PR TITLE
net-snmp: fix compilation without sigblock

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp

--- a/net/net-snmp/patches/910-no-sigblock.patch
+++ b/net/net-snmp/patches/910-no-sigblock.patch
@@ -1,0 +1,20 @@
+--- a/apps/snmpnetstat/if.c
++++ b/apps/snmpnetstat/if.c
+@@ -916,12 +916,13 @@ timerPause(void)
+         sigpause(SIGALRM);
+     }
+ #else
+-    int             oldmask;
+-    oldmask = sigblock(sigmask(SIGALRM));
++    sigset_t mask;
++    sigemptyset(&mask);
++    sigaddset(&mask, SIGALRM);
++    sigprocmask(SIG_BLOCK, &mask, 0);
+     if (!signalled) {
+-        sigpause(0);
++        sigsuspend(&mask);
+     }
+-    sigsetmask(oldmask);
+ #endif
+ }
+ 


### PR DESCRIPTION
sigblock is deprecated. Use newer APIs.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @stintel 
Compile tested: ath79