### PR TITLE
moreutils: fix compilation with uClibc-ng

### DIFF
--- a/utils/moreutils/Makefile
+++ b/utils/moreutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=moreutils
 PKG_VERSION:=0.63
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.kitenet.net/index.cgi/moreutils.git/snapshot

--- a/utils/moreutils/patches/010-uclibc.patch
+++ b/utils/moreutils/patches/010-uclibc.patch
@@ -1,0 +1,11 @@
+--- a/parallel.c
++++ b/parallel.c
+@@ -241,7 +241,7 @@ pid_t create_pipe_child(int *fd, int orig_fd)
+ 	return pipe_child(fds[0], orig_fd);
+ }
+ 
+-#if defined(__CYGWIN__)
++#if defined(__CYGWIN__) || defined(__UCLIBC__)
+ int getloadavg(double loadavg[], int nelem) {
+ 	int fd, n, elem;
+ 	char buf[128];


### PR DESCRIPTION
getloadavg is missing not just under cygwin.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nikil 
Compile tested: ath79