### PR TITLE
klish: fix compilation with uClibc-ng

### DIFF
--- a/utils/klish/Makefile
+++ b/utils/klish/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=klish
 PKG_VERSION:=2.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://libcode.org/attachments/download/77/
@@ -53,8 +53,6 @@ define Package/klish/description
 endef
 
 CONFIGURE_ARGS += --with-libxml2
-
-TARGET_CFLAGS += -D_XOPEN_SOURCE=500
 
 define Package/klish/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/utils/klish/patches/010-shell_execute_fix.patch
+++ b/utils/klish/patches/010-shell_execute_fix.patch
@@ -1,16 +1,19 @@
 --- a/clish/shell/shell_execute.c
 +++ b/clish/shell/shell_execute.c
-@@ -19,13 +19,6 @@
+@@ -19,12 +19,14 @@
  #include <signal.h>
  #include <fcntl.h>
  
--/* Empty signal handler to ignore signal but don't use SIG_IGN. */
++#if defined(__UCLIBC__) && !defined(__UCLIBC_HAS_OBSOLETE_BSD_SIGNAL__)
+ /* Empty signal handler to ignore signal but don't use SIG_IGN. */
 -static void sigignore(int signo)
--{
--	signo = signo; /* Happy compiler */
++static int sigignore(int signo)
+ {
+ 	signo = signo; /* Happy compiler */
 -	return;
--}
--
++	return 0;
+ }
++#endif
+ 
  /*-------------------------------------------------------- */
  static int clish_shell_lock(const char *lock_path)
- {


### PR DESCRIPTION
sigignore is missing from libc.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @t-umeno 
Compile tested: ath79