### PR TITLE
libcgroup: don't build tests

### DIFF
--- a/libs/libcgroup/Makefile
+++ b/libs/libcgroup/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libcgroup
 PKG_VERSION:=0.41
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/libcg
@@ -12,6 +12,7 @@ PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 

--- a/libs/libcgroup/patches/020-tests.patch
+++ b/libs/libcgroup/patches/020-tests.patch
@@ -1,0 +1,9 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,5 +1,5 @@
+ AUTOMAKE_OPTIONS = foreign
+-SUBDIRS = dist doc include samples scripts src tests
++SUBDIRS = dist include samples scripts src
+ 
+ EXTRA_DIST = README_daemon libcgroup.doxyfile README_systemd
+ 


### PR DESCRIPTION
Speeds up compile.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dddaniel
Compile tested: ath79