### PR TITLE
adblock: refresh blocklist sources

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
 PKG_VERSION:=4.0.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -15,7 +15,6 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 | anudeep             |         | M    | compilation      | [Link](https://github.com/anudeepND/blacklist)                                    |
 | bitcoin             |         | S    | mining           | [Link](https://github.com/hoshsadiq/adblock-nocoin-list)                          |
 | disconnect          | x       | S    | general          | [Link](https://disconnect.me)                                                     |
-| dshield             |         | XL   | general          | [Link](https://dshield.org)                                                       |
 | energized_blugo     |         | XL   | compilation      | [Link](https://energized.pro)                                                     |
 | energized_blu       |         | XL   | compilation      | [Link](https://energized.pro)                                                     |
 | energized_porn      |         | XXL  | compilation+porn | [Link](https://energized.pro)                                                     |
@@ -34,28 +33,28 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 | reg_fi              |         | S    | reg_finland      | [Link](https://github.com/finnish-easylist-addition)                              |
 | reg_fr              |         | S    | reg_france       | [Link](https://forums.lanik.us/viewforum.php?f=91)                                |
 | reg_id              |         | M    | reg_indonesia    | [Link](https://easylist.to)                                                       |
-| reg_kr              |         | M    | reg_korea        | [Link](https://list-kr.github.io)                                                 |
+| reg_kr              |         | S    | reg_korea        | [Link](https://list-kr.github.io)                                                 |
 | reg_nl              |         | M    | reg_netherlands  | [Link](https://easylist.to)                                                       |
-| reg_pl              |         | M    | reg_poland       | [Link](https://kadantiscam.netlify.com)                                           |
+| reg_pl1             |         | S    | reg_poland       | [Link](https://kadantiscam.netlify.com)                                           |
+| reg_pl2             |         | S    | reg_poland       | [Link](https://www.certyficate.it)                                                |
 | reg_ro              |         | M    | reg_romania      | [Link](https://easylist.to)                                                       |
 | reg_ru              |         | M    | reg_russia       | [Link](https://easylist.to)                                                       |
-| reg_vn              |         | M    | reg_vietnam      | [Link](https://bigdargon.github.io/hostsVN)                                       |
-| shallalist          |         | L    | general          | [Link](http://www.shallalist.de)                                                  |
-| shallalist_porn     |         | XXL  | general+porn     | [Link](http://www.shallalist.de)                                                  |
+| reg_vn              |         | S    | reg_vietnam      | [Link](https://bigdargon.github.io/hostsVN)                                       |
+| shallalist          |         | L    | general          | [Link](https://www.shallalist.de)                                                 |
+| shallalist_porn     |         | XXL  | general+porn     | [Link](https://www.shallalist.de)                                                 |
 | smarttv             |         | S    | smarttv          | [Link](https://github.com/Perflyst/PiHoleBlocklist)                               |
 | spam404             |         | S    | general          | [Link](https://github.com/Dawsey21)                                               |
 | stevenblack         |         | L    | compilation      | [Link](https://github.com/StevenBlack/hosts)                                      |
 | stevenblack_porn    |         | L    | compilation+porn | [Link](https://github.com/StevenBlack/hosts)                                      |
 | stopforumspam       |         | S    | spam             | [Link](https://www.stopforumspam.com)                                             |
-| sysctl              |         | M    | general          | [Link](http://sysctl.org/cameleon)                                                |
 | utcapitole          |         | L    | general          | [Link](https://dsi.ut-capitole.fr/blacklists/index_en.php)                        |
 | utcapitole_porn     |         | XXL  | general+porn     | [Link](https://dsi.ut-capitole.fr/blacklists/index_en.php)                        |
 | wally3k             |         | S    | compilation      | [Link](https://firebog.net/about)                                                 |
 | whocares            |         | M    | general          | [Link](https://someonewhocares.org)                                               |
-| winhelp             |         | S    | general          | [Link](http://winhelp2002.mvps.org)                                               |
+| winhelp             |         | S    | general          | [Link](https://winhelp2002.mvps.org)                                              |
 | winspy              |         | S    | win_telemetry    | [Link](https://github.com/crazy-max/WindowsSpyBlocker)                            |
 | youtube             |         | M    | youtube          | [Link](https://github.com/kboghdady/youTube_ads_4_pi-hole)                        |
-| yoyo                | x       | S    | general          | [Link](http://pgl.yoyo.org/adservers)                                             |
+| yoyo                | x       | S    | general          | [Link](https://pgl.yoyo.org/adservers)                                            |
 
 * List of supported and fully pre-configured adblock sources, already active sources are pre-selected.  
   <b><em>To avoid OOM errors, please do not select too many lists!</em></b>  

--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -48,13 +48,6 @@
 		"focus": "general",
 		"descurl": "https://disconnect.me"
 	},
-	"dshield": {
-		"url": "https://www.dshield.org/feeds/suspiciousdomains_Low.txt",
-		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
-		"size": "XL",
-		"focus": "general",
-		"descurl": "https://www.dshield.org"
-	},
 	"energized_blugo": {
 		"url": "https://block.energized.pro/bluGo/formats/domains.txt",
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
@@ -91,7 +84,7 @@
 		"descurl": "https://energized.pro"
 	},
 	"malwaredomains": {
-		"url": "http://mirror.espoch.edu.ec/malwaredomains/justdomains",
+		"url": "https://mirror1.malwaredomains.com/files/justdomains",
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
 		"size": "M",
 		"focus": "malware",
@@ -195,12 +188,19 @@
 		"focus": "reg_netherlands",
 		"descurl": "https://easylist.to"
 	},
-	"reg_pl": {
+	"reg_pl1": {
 		"url": "https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADhosts_without_controversies.txt",
 		"rule": "/^0\\.0\\.0\\.0[[:space:]]+([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($2)}",
 		"size": "S",
 		"focus": "reg_poland",
 		"descurl": "https://kadantiscam.netlify.com"
+	},
+	"reg_pl2": {
+		"url": "https://raw.githubusercontent.com/MajkiIT/polish-ads-filter/master/polish-pihole-filters/hostfile.txt",
+		"rule": "/^0\\.0\\.0\\.0[[:space:]]+([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($2)}",
+		"size": "S",
+		"focus": "reg_poland",
+		"descurl": "https://www.certyficate.it"
 	},
 	"reg_ro": {
 		"url": "https://easylist-downloads.adblockplus.org/rolist+easylist.txt",
@@ -224,24 +224,24 @@
 		"descurl": "https://bigdargon.github.io/hostsVN"
 	},
 	"shallalist": {
-		"url": "http://www.shallalist.de/Downloads/shallalist.tar.gz",
+		"url": "https://www.shallalist.de/Downloads/shallalist.tar.gz",
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
 		"categories": [
 				"adv", "costtraps", "spyware", "tracker", "warez"
 		],
 		"size": "L",
 		"focus": "general",
-		"descurl": "http://www.shallalist.de"
+		"descurl": "https://www.shallalist.de"
 	},
 	"shallalist_porn": {
-		"url": "http://www.shallalist.de/Downloads/shallalist.tar.gz",
+		"url": "https://www.shallalist.de/Downloads/shallalist.tar.gz",
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
 		"categories": [
 				"adv", "costtraps", "porn", "spyware", "tracker", "warez"
 		],
 		"size": "XXL",
 		"focus": "general+porn",
-		"descurl": "http://www.shallalist.de"
+		"descurl": "https://www.shallalist.de"
 	},
 	"smarttv": {
 		"url": "https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/SmartTV.txt",
@@ -278,13 +278,6 @@
 		"focus": "spam",
 		"descurl": "https://www.stopforumspam.com"
 	},
-	"sysctl": {
-		"url": "http://sysctl.org/cameleon/hosts",
-		"rule": "/^127\\.0\\.0\\.1[[:space:]]+([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($2)}",
-		"size": "M",
-		"focus": "general",
-		"descurl": "http://sysctl.org/cameleon"
-	},
 	"utcapitole": {
 		"url": "https://dsi.ut-capitole.fr/blacklists/download/blacklists.tar.gz",
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
@@ -320,11 +313,11 @@
 		"descurl": "https://someonewhocares.org"
 	},
 	"winhelp": {
-		"url": "http://winhelp2002.mvps.org/hosts.txt",
+		"url": "https://winhelp2002.mvps.org/hosts.txt",
 		"rule": "/^0\\.0\\.0\\.0[[:space:]]+([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($2)}",
 		"size": "S",
 		"focus": "general",
-		"descurl": "http://winhelp2002.mvps.org"
+		"descurl": "https://winhelp2002.mvps.org"
 	},
 	"winspy": {
 		"url": "https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/spy.txt",


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: n/a
Run tested: Ubiquiti EdgeRouter X, OpenWrt SNAPSHOT r13888-d5a148f5c8

Description:
* remove 'dshield' and 'sysctl' (discontinued)
* switch 'malwaredomains', 'shallalist' and 'winhelp' to https
* add a second regional list for poland (provided by @matx1002)
* update readme

Signed-off-by: Dirk Brenken <dev@brenken.org>

