### PR TITLE
mpg123: update to 1.26.3

### DIFF
--- a/sound/mpg123/Makefile
+++ b/sound/mpg123/Makefile
@@ -8,21 +8,22 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpg123
-PKG_VERSION:=1.25.13
-PKG_RELEASE:=3
+PKG_VERSION:=1.26.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/mpg123
-PKG_HASH:=90306848359c793fd43b9906e52201df18775742dc3c81c06ab67a806509890a
+PKG_HASH:=30c998785a898f2846deefc4d17d6e4683a5a550b7eacf6ea506e30a7a736c6e
 
 PKG_MAINTAINER:=Zoltan HERPAI <wigyori@uid0.hu>
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:mpg123:mpg123
 
-PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+CMAKE_SOURCE_SUBDIR:=ports/cmake
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/mpg123/Default
   URL:=http://www.mpg123.de
@@ -46,36 +47,43 @@ define Package/libout123
   DEPENDS:=+libltdl
 endef
 
+define Package/libsyn123
+  $(call Package/mpg123/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Library for signal generation and format conversion
+  LICENSE:=LGPL-2.1-or-later
+  DEPENDS:=+libltdl
+endef
+
 define Package/mpg123
   $(call Package/mpg123/Default)
   SECTION:=sound
   CATEGORY:=Sound
   TITLE:=fast console mpeg audio player
   LICENSE:=GPL-2.0-or-later
-  DEPENDS+=+libmpg123 +alsa-lib +libout123
+  DEPENDS+=+libmpg123 +alsa-lib +libout123 +libsyn123
 endef
 
-TARGET_CFLAGS += -D_GNU_SOURCE
-
-CONFIGURE_ARGS+= \
-	--enable-shared \
-	--enable-static \
-	--with-audio=alsa \
-	--with-default-audio=alsa \
+CMAKE_OPTIONS += \
+	-DBUILD_SHARED_LIBS=ON \
+	-DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+	-DNO_FEATURE_REPORT=ON \
+	-DNO_LFS_ALIAS=ON
 
 ifeq ($(CONFIG_SOFT_FLOAT),y)
-	CONFIGURE_ARGS+= \
-		--with-cpu=generic_nofpu \
-		--enable-int-quality=yes
+	CMAKE_OPTIONS += \
+		-DPLATFORM_DEFINITIONS="OPT_GENERIC" \
+		-DACCURATE_ROUNDING=OFF
 else ifneq ($(findstring neon,$(CONFIG_CPU_TYPE)),)
-	CONFIGURE_ARGS+= \
-		--with-cpu=arm_fpu
+	CMAKE_OPTIONS += \
+		-DPLATFORM_DEFINITIONS="OPT_MULTI OPT_GENERIC OPT_GENERIC_DITHER OPT_NEON"
 else ifneq ($(findstring aarch64,$(CONFIG_ARCH)),)
-	CONFIGURE_ARGS+= \
-		--with-cpu=aarch64
+	CMAKE_OPTIONS += \
+		-DPLATFORM_DEFINITIONS="OPT_MULTI OPT_GENERIC OPT_GENERIC_DITHER OPT_NEON64"
 else
-	CONFIGURE_ARGS+= \
-		--with-cpu=generic_fpu
+	CMAKE_OPTIONS += \
+		-DPLATFORM_DEFINITIONS="OPT_GENERIC"
 endif
 
 define Build/InstallDev
@@ -83,25 +91,41 @@ define Build/InstallDev
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/include/mpg123.h \
 		$(PKG_INSTALL_DIR)/usr/include/out123.h \
-		$(PKG_INSTALL_DIR)/usr/include/fmt123.h \
+		$(PKG_INSTALL_DIR)/usr/include/syn123.h \
 		$(1)/usr/include/
 
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/libmpg123.{la,a,so*} \
-		$(PKG_INSTALL_DIR)/usr/lib/libout123.{la,a,so*} \
+		$(PKG_INSTALL_DIR)/usr/lib/libmpg123.so \
+		$(PKG_INSTALL_DIR)/usr/lib/libout123.so \
+		$(PKG_INSTALL_DIR)/usr/lib/libsyn123.so \
 		$(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/cmake/mpg123
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/cmake/mpg123/mpg123-config.cmake \
+		$(PKG_INSTALL_DIR)/usr/lib/cmake/mpg123/mpg123-config-version.cmake \
+		$(PKG_INSTALL_DIR)/usr/lib/cmake/mpg123/targets.cmake \
+		$(PKG_INSTALL_DIR)/usr/lib/cmake/mpg123/targets-release.cmake \
+		$(1)/usr/lib/cmake/mpg123
 
 	$(INSTALL_DIR) $(1)/usr/lib/mpg123
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/mpg123/* \
+		$(PKG_INSTALL_DIR)/usr/lib/mpg123/output_alsa.so \
 		$(1)/usr/lib/mpg123
 
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libmpg123.pc \
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libout123.pc \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libsyn123.pc \
 		$(1)/usr/lib/pkgconfig
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/libmpg123.pc
+	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/libmpg123.pc
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/libout123.pc
+	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/libout123.pc
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/libsyn123.pc
+	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/libsyn123.pc
 endef
 
 define Package/libmpg123/install
@@ -115,6 +139,13 @@ define Package/libout123/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/libout123.so* \
+		$(1)/usr/lib/
+endef
+
+define Package/libsyn123/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/libsyn123.so* \
 		$(1)/usr/lib/
 endef
 
@@ -133,4 +164,5 @@ endef
 
 $(eval $(call BuildPackage,libmpg123))
 $(eval $(call BuildPackage,libout123))
+$(eval $(call BuildPackage,libsyn123))
 $(eval $(call BuildPackage,mpg123))

--- a/sound/mpg123/patches/010-no-pulse.patch
+++ b/sound/mpg123/patches/010-no-pulse.patch
@@ -1,0 +1,11 @@
+--- a/ports/cmake/src/CMakeLists.txt
++++ b/ports/cmake/src/CMakeLists.txt
+@@ -199,7 +199,7 @@ if(NOT CHECK_MODULES OR NOT COREAUDIO_REQUIRED EQUAL -1)
+     endif()
+ endif()
+ 
+-find_package(PkgConfig)
++#find_package(PkgConfig)
+ if(PKG_CONFIG_FOUND)
+     if(NOT CHECK_MODULES OR NOT PULSE_REQUIRED EQUAL -1)
+         pkg_search_module(PULSE libpulse-simple)


### PR DESCRIPTION
Switched to CMake. CMake compiles faster.

Added libsyn123 library as it's needed since version 1.26.

Before:

time make package/mpg123/compile -j 12
Executed in   16.05 secs   fish           external
   usr time   26.65 secs    0.00 micros   26.65 secs
   sys time    4.82 secs  833.00 micros    4.81 secs

After:

time make package/mpg123/compile -j 12
Executed in   12.12 secs   fish           external
   usr time   19.35 secs    0.00 micros   19.35 secs
   sys time    3.22 secs  752.00 micros    3.22 secs

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @wigyori 
Compile tested: ath79

Setting as draft since other platforms probably need to be tested.

@jefferyto optimized defaults are available for several platforms. Do you think there's any point in applying those or just keep them generic as is? Currently only NEON, Aarch64, and x86 generates optimized code. There's also code for PPC(with/out-FPU) and ARM(with/out FPU).