### PR TITLE
python3: Add config PYTHON3_HOST_PIP_CACHE_WORLD_READABLE

### DIFF
--- a/lang/python/python3-host.mk
+++ b/lang/python/python3-host.mk
@@ -49,15 +49,21 @@ endef
 # Note: I shamelessly copied this from Yousong's logic (from python-packages);
 HOST_PYTHON3_PIP:=$(STAGING_DIR_HOSTPKG)/bin/pip$(PYTHON3_VERSION)
 
+HOST_PYTHON3_PIP_CACHE_DIR:=$(DL_DIR)/pip-cache
+
 # $(1) => packages to install
 define HostPython3/PipInstall
 	$(HOST_PYTHON3_VARS) \
 	$(HOST_PYTHON3_PIP) \
 		--disable-pip-version-check \
-		--cache-dir "$(DL_DIR)/pip-cache" \
+		--cache-dir "$(HOST_PYTHON3_PIP_CACHE_DIR)" \
 		install \
 		--no-binary :all: \
 		$(1)
+  ifdef CONFIG_PYTHON3_HOST_PIP_CACHE_WORLD_READABLE
+	$(FIND) $(HOST_PYTHON3_PIP_CACHE_DIR) -not -type d -exec chmod go+r  '{}' \;
+	$(FIND) $(HOST_PYTHON3_PIP_CACHE_DIR)      -type d -exec chmod go+rx '{}' \;
+  endif
 endef
 
 # $(1) => build subdir

--- a/lang/python/python3/Config-python3-light.in
+++ b/lang/python/python3/Config-python3-light.in
@@ -4,4 +4,8 @@ config PYTHON3_BLUETOOTH_SUPPORT
 	bool "Enable Bluetooth support"
 	default n
 
+config PYTHON3_HOST_PIP_CACHE_WORLD_READABLE
+	bool "Ensure host pip cache is world-readable"
+	default n
+
 endmenu


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-32, 2020-08-11 snapshot sdk
Run tested: none

Description:
This adds a config option `PYTHON3_HOST_PIP_CACHE_WORLD_READABLE`; if enabled, chmod will be run after pip install to make all files/directories in the host pip cache world-readable.

Supersedes https://github.com/openwrt/packages/pull/13012.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>