### PR TITLE
openfortivpn: fix routes passed to netifd

### DIFF
--- a/net/openfortivpn/Makefile
+++ b/net/openfortivpn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openfortivpn
 PKG_VERSION:=1.14.1
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/adrienverge/openfortivpn/tar.gz/v$(PKG_VERSION)?
@@ -60,6 +60,7 @@ define Package/openfortivpn/install
 	$(INSTALL_BIN) ./files/openfortivpn-wrapper $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/openfortivpn.sh $(1)/lib/netifd/proto/
 	$(INSTALL_BIN) ./files/14-openforticlient $(1)/etc/hotplug.d/iface/
+	$(INSTALL_BIN) ./files/openfortivpn-ppp-up $(1)/lib/netifd/openfortivpn-ppp-up
 endef
 
 $(eval $(call BuildPackage,openfortivpn))

--- a/net/openfortivpn/files/openfortivpn-ppp-up
+++ b/net/openfortivpn/files/openfortivpn-ppp-up
@@ -1,0 +1,20 @@
+#!/bin/sh
+PPP_IPPARAM="$6"
+
+. /lib/netifd/netifd-proto.sh
+proto_init_update "$IFNAME" 1 1
+proto_set_keep 1
+[ -n "$PPP_IPPARAM" ] && {
+	[ -n "$IPLOCAL" ] && proto_add_ipv4_address "$IPLOCAL" 32 "" "$IPREMOTE"
+	[ -n "$IPREMOTE" ] && proto_add_ipv4_route 0.0.0.0 0 "" "$IPLOCAL"
+	[ -n "$DNS1" ] && proto_add_dns_server "$DNS1"
+	[ -n "$DNS2" -a "$DNS1" != "$DNS2" ] && proto_add_dns_server "$DNS2"
+}
+proto_send_update "$PPP_IPPARAM"
+
+[ -d /etc/ppp/ip-up.d ] && {
+	for SCRIPT in /etc/ppp/ip-up.d/*
+	do
+		[ -x "$SCRIPT" ] && "$SCRIPT" "$@"
+	done
+}

--- a/net/openfortivpn/files/openfortivpn.sh
+++ b/net/openfortivpn/files/openfortivpn.sh
@@ -125,7 +125,7 @@ receive-all
 nodetach
 ipparam $config
 lcp-max-configure 40
-ip-up-script /lib/netifd/ppp-up
+ip-up-script /lib/netifd/openfortivpn-ppp-up
 ip-down-script /lib/netifd/ppp-down
 mru 1354"  > $callfile
         append_args "--pppd-call=openfortivpn/$config"


### PR DESCRIPTION
Maintainer: @lucize 
Compile tested: openwrt-sdk-19.07.3-ipq806x-generic_gcc-7.5.0_musl_eabi.Linux-x86_64
Run tested: 19.07.3

Description:

The openfortivpn routes are a bit different than the standard ppp
routes so we need to handle them with a custom ppp-up script.

Gateway should not be set, and src should be set to the PPP local ip
address.
