### PR TITLE
ddns-scripts: Add moniker.com DDNS service

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.8
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=22
+PKG_RELEASE:=23
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -124,6 +124,8 @@
 
 "loopia.se"		"http://[USERNAME]:[PASSWORD]@dns.loopia.se/XDynDNSServer/XDynDNS.php?system=custom&hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
+"moniker.com"		"https://dynamicdns.key-systems.net/update.php?hostname=[DOMAIN]&password=[PASSWORD]&ip=[IP]"	"success"
+
 "mydns.jp"		"http://www.mydns.jp/directip.html?MID=[USERNAME]&PWD=[PASSWORD]&IPV4ADDR=[IP]"
 
 "myip.co.ua"		"http://[USERNAME]:[PASSWORD]@myip.co.ua/update?hostname=[DOMAIN]&myip=[IP]"	"good"


### PR DESCRIPTION
Signed-off-by: Mateusz Stępień <mateusz@argc.pl>

Maintainer: me / Community
Compile tested: Ubiquiti Edgerouter X, OpenWrt 19.07.3 r11063-85e04e9f46 
Run tested: Ubiquiti Edgerouter X, OpenWrt 19.07.3 r11063-85e04e9f46, IP updated fine

Description: Add moniker.com DDNS service
