### PR TITLE
python-pytest-xdist: update to version 2.0.0

### DIFF
--- a/lang/python/python-psutil/Makefile
+++ b/lang/python/python-psutil/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-psutil
+PKG_VERSION:=5.7.2
+PKG_RELEASE:=1
+
+PYPI_NAME:=psutil
+PKG_HASH:=90990af1c3c67195c44c9a889184f84f5b2320dce3ee3acbd054e3ba0b4a7beb
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=BSD 3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=0
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:=setuptools-scm
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-psutil
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=psutil (process and system utilities)
+  URL:=https://github.com/giampaolo/psutil
+  DEPENDS:=+python3-light
+endef
+
+define Package/python3-psutil/description
+  psutil is a cross-platform library for retrieving information
+  on running processes and system utilization.
+endef
+
+$(eval $(call Py3Package,python3-psutil))
+$(eval $(call BuildPackage,python3-psutil))
+$(eval $(call BuildPackage,python3-psutil-src))

--- a/lang/python/python-pytest-xdist/Makefile
+++ b/lang/python/python-pytest-xdist/Makefile
@@ -8,11 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pytest-xdist
-PKG_VERSION:=1.34.0
+PKG_VERSION:=2.0.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=pytest-xdist
-PKG_HASH:=340e8e83e2a4c0d861bdd8d05c5d7b7143f6eea0aba902997db15c2a86be04ee
+PKG_HASH:=3217b1f40290570bf27b1f82714fc4ed44c3260ba9b2f6cde0372378fc707ad3
+
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT
@@ -36,7 +37,8 @@ define Package/python3-pytest-xdist
 	+python3-pytest \
 	+python3-pytest-forked \
 	+python3-execnet \
-	+python3-six
+	+python3-six \
+	+python3-psutil
 endef
 
 define Package/python3-pytest-xdist/description


### PR DESCRIPTION
maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates pytest-xdist to version 2.0.0 It adds new dependecy on psutil and requires pytest version 6.x

Blocked by https://github.com/openwrt/packages/pull/12480


