### PR TITLE
glib2: update to 2.65.1

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
-PKG_VERSION:=2.65.0
-PKG_RELEASE:=5
+PKG_VERSION:=2.65.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/2.65
-PKG_HASH:=b041e63cd0ac1fccb486374022ade040d907aad29b278e27d9e43e9294a6e7a3
+PKG_HASH:=bc63bf6c32713e0ee1dddc28e03f23b4a20c78bcb9a2c5b0f4eea41e46fb9cee
 
 PKG_MAINTAINER:=Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/libs/glib2/patches/001-no-libelf.patch
+++ b/libs/glib2/patches/001-no-libelf.patch
@@ -1,6 +1,6 @@
 --- a/gio/meson.build
 +++ b/gio/meson.build
-@@ -881,20 +881,6 @@ endif
+@@ -874,20 +874,6 @@ endif
  
  # Dependencies used by executables below
  have_libelf = false

--- a/libs/glib2/patches/004-no-distutils.patch
+++ b/libs/glib2/patches/004-no-distutils.patch
@@ -1,6 +1,6 @@
 --- a/meson.build
 +++ b/meson.build
-@@ -2137,16 +2137,10 @@ endif
+@@ -2168,16 +2168,10 @@ endif
  
  glib_conf.set('HAVE_PROC_SELF_CMDLINE', have_proc_self_cmdline)
  

--- a/libs/glib2/patches/005-uclibc.patch
+++ b/libs/glib2/patches/005-uclibc.patch
@@ -1,0 +1,13 @@
+--- a/meson.build
++++ b/meson.build
+@@ -1986,8 +1986,8 @@ endif
+ # FIXME: glib-gettext.m4 has much more checks to detect broken/uncompatible
+ # implementations. This could be extended if issues are found in some platforms.
+ libintl_deps = []
+-if cc.has_function('ngettext')
+-  have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset')
++if true
++  have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset', prefix :'#include <libintl.h>')
+ else
+   # First just find the bare library.
+   libintl = cc.find_library('intl', required : false)


### PR DESCRIPTION
Add a small hack to glib2 to avoid using proxy-intl and break
compilation under uClibc-ng.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 
Compile tested: ath79 both musl and uClibc-ng