### PR TITLE
boost: Package Version Update (1.74.0)

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -11,13 +11,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=boost
-PKG_VERSION:=1.73.0
-PKG_SOURCE_VERSION:=1_73_0
+PKG_VERSION:=1.74.0
+PKG_SOURCE_VERSION:=1_74_0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://dl.bintray.com/boostorg/release/$(PKG_VERSION)/source/
-PKG_HASH:=4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402
+PKG_HASH:=83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1
 
 PKG_MAINTAINER:=Carlos M. Ferreira <carlosmf.pt@gmail.com>
 PKG_LICENSE:=BSL-1.0
@@ -43,7 +43,7 @@ define Package/boost/Default
 endef
 
 define Package/boost/description
-This package provides the Boost v1.73.0 libraries.
+This package provides the Boost v1.74.0 libraries.
 Boost is a set of free, peer-reviewed, portable C++ source libraries.
 
 This package provides the following run-time libraries:
@@ -76,7 +76,7 @@ This package provides the following run-time libraries:
  - wave
 
 There are many more header-only libraries supported by Boost.
-See more at http://www.boost.org/doc/libs/1_72_0/
+See more at http://www.boost.org/doc/libs/1_74_0/
 endef
 
 PKG_BUILD_DEPENDS:=boost/host PACKAGE_python3:python3
@@ -372,7 +372,7 @@ TARGET_LDFLAGS += -pthread -lrt
 TARGET_CFLAGS += \
 	$(if $(CONFIG_SOFT_FLOAT),-DBOOST_NO_FENV_H) -fPIC
 
-EXTRA_CXXFLAGS += $(if $(CONFIG_GCC_USE_VERSION_5),-std=gnu++14,-std=gnu++17)
+EXTRA_CXXFLAGS += $(if $(GCC_USE_VERSION_10),$(if $(CONFIG_GCC_USE_VERSION_5),-std=gnu++14,-std=gnu++17),-std=gnu++20)
 
 ifneq ($(findstring mips,$(ARCH)),)
     BOOST_ABI = o32


### PR DESCRIPTION

Maintainer: me / @ClaymorePT 
Compile tested: RaspberryPi4
Run tested: N/A
Description:

This commit updates Boost to version 1.74.0
In this release, there is one new libraries
 - STLInterfaces [2]:
   A library of CRTP bases to ease the writing of STL views,
   iterators, and sequence containers, from Zach Laine.

This update also provides support to build boost with C++20 when using
GCC 10.x

More info about Boost 1.74.0 can be found at the usual place [1].

[1]: https://www.boost.org/users/history/version_1_74_0.html
[2]: https://www.boost.org/libs/stl_interfaces/

Signed-off-by: Carlos Miguel Ferreira <carlosmf.pt@gmail.com>
