### PR TITLE
stress: replace usleep with nanosleep

### DIFF
--- a/utils/stress/Makefile
+++ b/utils/stress/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress
 PKG_VERSION:=1.0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://fossies.org/linux/privat

--- a/utils/stress/patches/010-usleep.patch
+++ b/utils/stress/patches/010-usleep.patch
@@ -1,0 +1,46 @@
+--- a/src/stress.c
++++ b/src/stress.c
+@@ -262,6 +262,7 @@ main (int argc, char **argv)
+ 
+       /* Calculate the backoff value so we get good fork throughput.  */
+       backoff = do_backoff * forks;
++      struct timespec b = {backoff / 1000000, (backoff % 1000000) * 1000};
+       dbg (stdout, "using backoff sleep of %llius\n", backoff);
+ 
+       /* If we are supposed to respect a timeout, calculate it.  */
+@@ -296,7 +297,7 @@ main (int argc, char **argv)
+             {
+             case 0:            /* child */
+               alarm (timeout);
+-              usleep (backoff);
++              nanosleep(&b, NULL);
+               if (do_dryrun)
+                 exit (0);
+               exit (hogcpu ());
+@@ -317,7 +318,7 @@ main (int argc, char **argv)
+             {
+             case 0:            /* child */
+               alarm (timeout);
+-              usleep (backoff);
++              nanosleep(&b,&b);
+               if (do_dryrun)
+                 exit (0);
+               exit (hogio ());
+@@ -337,7 +338,7 @@ main (int argc, char **argv)
+             {
+             case 0:            /* child */
+               alarm (timeout);
+-              usleep (backoff);
++              nanosleep(&b, &b);
+               if (do_dryrun)
+                 exit (0);
+               exit (hogvm
+@@ -358,7 +359,7 @@ main (int argc, char **argv)
+             {
+             case 0:            /* child */
+               alarm (timeout);
+-              usleep (backoff);
++              nanosleep(&b, &b);
+               if (do_dryrun)
+                 exit (0);
+               exit (hoghdd (do_hdd_bytes));


### PR DESCRIPTION
The former is deprecated.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @commodo 
Compile tested: ath79