### PR TITLE
tcp_wrappers: fix compilation without cdefs

### DIFF
--- a/libs/tcp_wrappers/Makefile
+++ b/libs/tcp_wrappers/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tcp_wrappers
 PKG_VERSION:=7.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://ftp.porcupine.org/pub/security

--- a/libs/tcp_wrappers/patches/001-debian_subset.patch
+++ b/libs/tcp_wrappers/patches/001-debian_subset.patch
@@ -38,7 +38,7 @@
  	return (STR_NE(eval_hostaddr(host), unknown) && HOSTNAME_KNOWN(name));
 --- a/tcpd.h
 +++ b/tcpd.h
-@@ -4,6 +4,25 @@
+@@ -4,6 +4,27 @@
    * Author: Wietse Venema, Eindhoven University of Technology, The Netherlands.
    */
  
@@ -59,12 +59,14 @@
 +#include <netinet/in.h>
 +#include <stdio.h>
 +
-+__BEGIN_DECLS
++#ifdef __cplusplus
++extern "C" {
++#endif
 +
  /* Structure to describe one communications endpoint. */
  
  #define STRING_LENGTH	128		/* hosts, users, processes */
-@@ -25,10 +44,10 @@ struct request_info {
+@@ -25,10 +46,10 @@ struct request_info {
      char    pid[10];			/* access via eval_pid(request) */
      struct host_info client[1];		/* client endpoint info */
      struct host_info server[1];		/* server endpoint info */
@@ -79,7 +81,7 @@
      struct netconfig *config;		/* netdir handle */
  };
  
-@@ -61,25 +80,30 @@ extern char paranoid[];
+@@ -61,25 +82,30 @@ extern char paranoid[];
  /* Global functions. */
  
  #if defined(TLI) || defined(PTX) || defined(TLI_SEQUENT)
@@ -120,7 +122,7 @@
  extern char *hosts_allow_table;		/* for verification mode redirection */
  extern char *hosts_deny_table;		/* for verification mode redirection */
  extern int hosts_access_verbose;	/* for verbose matching mode */
-@@ -92,9 +116,14 @@ extern int resident;			/* > 0 if residen
+@@ -92,9 +118,14 @@ extern int resident;			/* > 0 if resident process */
    */
  
  #ifdef __STDC__
@@ -135,7 +137,7 @@
  extern struct request_info *request_init();	/* initialize request */
  extern struct request_info *request_set();	/* update request structure */
  #endif
-@@ -117,27 +146,31 @@ extern struct request_info *request_set(
+@@ -117,27 +148,31 @@ extern struct request_info *request_set();	/* update request structure */
    * host_info structures serve as caches for the lookup results.
    */
  
@@ -177,7 +179,7 @@
  #endif
  
   /*
-@@ -178,7 +211,7 @@ extern struct tcpd_context tcpd_context;
+@@ -178,7 +213,7 @@ extern struct tcpd_context tcpd_context;
    * behavior.
    */
  
@@ -186,12 +188,14 @@
  extern int dry_run;			/* verification flag */
  
  /* Bug workarounds. */
-@@ -217,3 +250,7 @@ extern char *fix_strtok();
+@@ -217,3 +252,9 @@ extern char *fix_strtok();
  #define strtok	my_strtok
  extern char *my_strtok();
  #endif
 +
-+__END_DECLS
++#ifdef __cplusplus
++}
++#endif
 +
 +#endif /* tcpd.h */
 --- a/Makefile


### PR DESCRIPTION
__DECLS are glibc specific.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 
Compile tested: ath79 + musl 1.2.1 update.