### PR TITLE
boost: Package Revision - Fix C++ standard flag

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.74.0
 PKG_SOURCE_VERSION:=1_74_0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://dl.bintray.com/boostorg/release/$(PKG_VERSION)/source/
@@ -372,7 +372,7 @@ TARGET_LDFLAGS += -pthread -lrt
 TARGET_CFLAGS += \
 	$(if $(CONFIG_SOFT_FLOAT),-DBOOST_NO_FENV_H) -fPIC
 
-EXTRA_CXXFLAGS += $(if $(GCC_USE_VERSION_10),$(if $(CONFIG_GCC_USE_VERSION_5),-std=gnu++14,-std=gnu++17),-std=gnu++20)
+EXTRA_CXXFLAGS += $(if $(CONFIG_GCC_USE_VERSION_10),-std=gnu++20,$(if $(CONFIG_GCC_USE_VERSION_5),-std=gnu++14,-std=gnu++17))
 
 ifneq ($(findstring mips,$(ARCH)),)
     BOOST_ABI = o32


### PR DESCRIPTION
Maintainer: me / @ClaymorePT 
Compile tested: Raspberry Pi 4B
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
This commit fixes the use of the C++20 standard when GCC 10.x is used.

Signed-off-by: Carlos Miguel Ferreira <carlosmf.pt@gmail.com>