### PR TITLE
bandwidthd: don't build in parallel

### DIFF
--- a/utils/bandwidthd/Makefile
+++ b/utils/bandwidthd/Makefile
@@ -19,7 +19,7 @@ PKG_MAINTAINER:=Jean-Michel Lacroix <lacroix@lepine-lacroix.info>
 PKG_LICENSE:=GPL-2.0-or-later
 
 PKG_FIXUP:=autoreconf
-PKG_BUILD_PARALLEL:=1
+PKG_BUILD_PARALLEL:=0
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
There are intermittent build failures on the buildbots because of this.
I see the same build failures locally as well.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @padre-lacroix 
Compile tested: ath79

https://downloads.openwrt.org/snapshots/faillogs/mips_mips32/packages/bandwidthd/