### PR TITLE
gstreamer1: enable build options necessary for most applications

### DIFF
--- a/multimedia/gstreamer1/Makefile
+++ b/multimedia/gstreamer1/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gstreamer1
 PKG_VERSION:=1.17.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=gstreamer-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://gstreamer.freedesktop.org/src/gstreamer
@@ -118,11 +118,11 @@ GST_VERSION:=1.0
 MESON_ARGS += \
 	-Dgst_debug=false \
 	-Dgst_parse=true \
-	-Dregistry=false \
+	-Dregistry=true \
 	-Dtracer_hooks=false \
 	-Dptp-helper-setuid-user=none \
 	-Dptp-helper-setuid-group=none \
-	-Doption-parsing=false \
+	-Doption-parsing=true \
 	-Dpoisoning=false \
 	-Dmemory-alignment=malloc \
 	-Dcheck=enabled \


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64 master
Run tested: x86_64 master

Description:
Commit cb058bf changed gstreamer1's build options, and this broke some applications.
    
First, -Doption-parsing=false is intended for very specific embedded applications rather general packages. Please see:
    
    https://github.com/openwrt/packages/pull/8847
    https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/388
    
Second, -Dregistry=false seems to break plugin discovery. Symptoms of this include broken applications and gst-inspect-1.0 listing zero plugins.

Fixes #13180.