### PR TITLE
[18.06] simple-adblock: bugfix: update config; use command -v

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.8.3
-PKG_RELEASE:=13
+PKG_RELEASE:=15
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/simple-adblock.conf
+++ b/net/simple-adblock/files/simple-adblock.conf
@@ -18,7 +18,7 @@ config simple-adblock 'config'
 	list blocked_domains_url 'https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt'
 
 # File size: 12.0K
-	list blocked_domains_url 'https://ssl.bblck.me/blacklists/domain-list.txt'
+	list blocked_domains_url 'https://cdn.jsdelivr.net/gh/paulgb/BarbBlock/blacklists/domain-list.txt'
 
 # File size: 44.0K
 	list blocked_domains_url 'https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt'

--- a/net/simple-adblock/files/simple-adblock.conf.update
+++ b/net/simple-adblock/files/simple-adblock.conf.update
@@ -3,6 +3,7 @@ s|whitelist_domain|allowed_domain|g
 s|blacklist_hosts_url|blocked_hosts_url|g
 s|blacklist_domains_url|blocked_domains_url|g
 s|blacklist_domain|blocked_domain|g
+s|ssl.bblck.me|cdn.jsdelivr.net/gh/paulgb/BarbBlock|g
 s|dbl.oisd.nl|hosts.oisd.nl|g
 s|raw.githubusercontent.com/StevenBlack/hosts/|cdn.jsdelivr.net/gh/StevenBlack/hosts@|g
 s|raw.githubusercontent.com/hoshsadiq/adblock-nocoin-list/|cdn.jsdelivr.net/gh/hoshsadiq/adblock-nocoin-list@|g

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -247,10 +247,10 @@ load_package_config() {
 	. /lib/functions/network.sh
 	. /usr/share/libubox/jshn.sh
 	# Prefer curl because it supports the file:// scheme.
-	if [ -x /usr/bin/curl ]; then
+	if command -v curl >/dev/null 2>&1; then
 		dl_command="curl --insecure --retry $curlRetry --connect-timeout $dlTimeout --silent"
 		dl_flag="-o"
-	elif wget --version 2>/dev/null | grep -q "+https"; then
+	elif command -v wget >/dev/null 2>&1 && wget --version 2>/dev/null | grep -q "+https"; then
 		dl_command="wget --no-check-certificate --timeout $dlTimeout -q"
 		dl_flag="-O"
 	else


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, WRT3200ACM, 19.07.3
Run tested: mvebu, WRT3200ACM, 18.06.8, start/dl

This contains 2 fixes:
1. Bugfix: update config (and config-update) for the new location of BarbBlock
2. Use command -v instead of fixed locations when checking for curl/wget

I don't have merge access to packages, please merge.

Signed-off-by: Stan Grishin <stangri@melmac.net>
