### PR TITLE
libmraa: support node.js v12

### DIFF
--- a/libs/libmraa/Makefile
+++ b/libs/libmraa/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmraa
 PKG_VERSION:=2.1.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eclipse/mraa/tar.gz/v$(PKG_VERSION)?
@@ -30,8 +30,7 @@ include $(INCLUDE_DIR)/cmake.mk
 include ../../lang/python/python3-package.mk
 
 CMAKE_OPTIONS=-DENABLEEXAMPLES=0 \
-	-DFIRMATA=ON \
-	-DBUILDSWIG=OFF
+	-DFIRMATA=ON
 
 TARGET_CFLAGS+=-I$(STAGING_DIR)/usr/include/node
 
@@ -78,7 +77,7 @@ endef
 define Package/libmraa-python3
   $(call Package/libmraa/Default)
   TITLE:=Eclipse MRAA lowlevel IO Python3 library
-  DEPENDS:=+libmraa +python3-light @BROKEN
+  DEPENDS:=+libmraa +python3-light
 endef
 
 define Package/libmraa-python3/description

--- a/libs/libmraa/patches/020-support_v12.patch
+++ b/libs/libmraa/patches/020-support_v12.patch
@@ -1,0 +1,14 @@
+--- a/api/mraa/gpio.hpp
++++ b/api/mraa/gpio.hpp
+@@ -175,7 +175,11 @@
+         v8::Local<v8::Value> argv[] = { SWIGV8_INTEGER_NEW(-1) };
+ #if NODE_MODULE_VERSION >= 0x000D
+         v8::Local<v8::Function> f = v8::Local<v8::Function>::New(v8::Isolate::GetCurrent(), This->m_v8isr);
++#if NODE_MODULE_VERSION >= 72
++        f->Call(SWIGV8_CURRENT_CONTEXT(), SWIGV8_CURRENT_CONTEXT()->Global(), argc, argv);
++#else
+         f->Call(SWIGV8_CURRENT_CONTEXT()->Global(), argc, argv);
++#endif
+ #else
+         This->m_v8isr->Call(SWIGV8_CURRENT_CONTEXT()->Global(), argc, argv);
+ #endif


### PR DESCRIPTION
Maintainer: @blogic me
Compile tested: head r14241-ba2ddba, x86_64
Run tested: x86_64 (VirtualBox)

Description:
Addressed the build failure with node.js version 12.
Re-enable swig.

https://github.com/openwrt/packages/issues/11977
https://github.com/openwrt/packages/pull/12225

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
