### PR TITLE
libupm: support node.js v12

### DIFF
--- a/libs/libupm/Makefile
+++ b/libs/libupm/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libupm
 PKG_VERSION:=2.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/intel-iot-devkit/upm/tar.gz/v$(PKG_VERSION)?

--- a/libs/libupm/patches/005-support_v12.patch
+++ b/libs/libupm/patches/005-support_v12.patch
@@ -1,0 +1,11 @@
+--- a/src/carrays_uint32_t.i
++++ b/src/carrays_uint32_t.i
+@@ -24,7 +24,7 @@
+ %typemap(in) uint32_t {
+   int ecode2 = 0 ;
+   if (($input)->IsInt32())
+-    $1 = ($input)->Uint32Value();
++    $1 = ($input)->Uint32Value(SWIGV8_CURRENT_CONTEXT()).FromJust();
+   else
+     SWIG_exception_fail(SWIG_ArgError(ecode2), "failed to convert uint32");
+ }


### PR DESCRIPTION
Maintainer: @blogic me
Compile tested: head r14241-ba2ddba, x86_64
Run tested: x86_64 (VirtualBox)

Description:
Addressed the build failure with node.js version 12.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
