### PR TITLE
checksec: add new package

### DIFF
--- a/utils/checksec/Makefile
+++ b/utils/checksec/Makefile
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2020 CZ.NIC z.s.p.o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=checksec.sh
+PKG_VERSION:=2.2.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/slimm609/checksec.sh/archive/$(PKG_VERSION)
+PKG_HASH:=d93c8ddd8bc1c3cbfbc28e34b3b3233f82f79d6800d55ae27dbea3d8b9933435
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE_FILES:=LICENSE.txt
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/checksec/default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  URL:=https://github.com/slimm609/checksec.sh
+endef
+
+define Package/checksec
+  $(call Package/checksec/default)
+  TITLE:=Utility to check PIE, RELRO, ASLR etc.
+  DEPENDS:=+bash +file +binutils +procps-ng +procps-ng-sysctl +openssl-util +coreutils +coreutils-stat
+endef
+
+define Package/checksec_automator
+  $(call Package/checksec/default)
+  TITLE:=Utility to use checksec for dirs
+  DEPENDS:=+checksec +coreutils-tee +findutils-find +grep
+endef
+
+define Package/checksec/description
+  Checksec is a bash script to check the properties
+  of executables (like PIE, RELRO, PaX, Canaries, ASLR, Fortify Source).
+endef
+
+define Package/checksec_automator/description
+  Script for checksec directory scan.
+endef
+
+Build/Compile:=:
+Build/Install:=:
+
+define Package/checksec/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/checksec $(1)/usr/bin/
+endef
+
+define Package/checksec_automator/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/checksec_automator.sh $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,checksec))
+$(eval $(call BuildPackage,checksec_automator))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master, RPI3, OpenWrt 19.07
Run tested: Turris Omnia (TOS5), OpenWrt master, RPI3, OpenWrt 19.07

Description:
This PR adds a new package checksec.sh utility. It helps with checking properties of executables (like PIE, RELRO, PaX, Canaries, ASLR, Fortify Source).
The main reason why to make it as the package is the number of non-busybos utilities which it uses.


It could be useful in case of similar studies like this https://www.fkie.fraunhofer.de/content/dam/fkie/de/documents/HomeRouter/HomeRouterSecurity_2020_Bericht.pdf (section 3.3  Exploit Mitigation )