### PR TITLE
curl: add package (previously in base)

### DIFF
--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -1,0 +1,160 @@
+if PACKAGE_libcurl
+
+comment "SSL support"
+
+choice
+	prompt "Selected SSL library"
+	default LIBCURL_MBEDTLS
+
+	config LIBCURL_MBEDTLS
+		bool "mbed TLS"
+
+	config LIBCURL_WOLFSSL
+		bool "wolfSSL"
+
+	config LIBCURL_OPENSSL
+		bool "OpenSSL"
+
+	config LIBCURL_GNUTLS
+		bool "GNUTLS"
+
+	config LIBCURL_NOSSL
+		bool "No SSL support"
+
+endchoice
+
+comment "Supported protocols"
+
+config LIBCURL_DICT
+	bool "DICT protocol"
+	default n
+
+config LIBCURL_FILE
+	bool "FILE protocol"
+	default y
+
+config LIBCURL_FTP
+	bool "FTP / FTPS protocol"
+	default y
+
+config LIBCURL_GOPHER
+	bool "Gopher protocol"
+	default n
+
+config LIBCURL_HTTP
+	bool "HTTP / HTTPS protocol"
+	default y
+
+config LIBCURL_COOKIES
+	bool "Enable Cookies support"
+	depends on LIBCURL_HTTP
+	default y
+
+config LIBCURL_IMAP
+	bool "IMAP / IMAPS protocol"
+	default n
+
+config LIBCURL_LDAP
+	bool "LDAP protocol"
+	default n
+
+config LIBCURL_LDAPS
+	bool "Enable LDAPS support"
+	depends on LIBCURL_LDAP && !LIBCURL_NOSSL
+	default y
+
+config LIBCURL_POP3
+	bool "POP3 / POP3S protocol"
+	default n
+
+config LIBCURL_RTSP
+	bool "RTSP protocol"
+	depends on LIBCURL_HTTP
+	default n
+config LIBCURL_NO_RTSP
+	string "RTSP require HTTP protocol"
+	depends on !LIBCURL_HTTP
+	default "!"
+
+config LIBCURL_SSH2
+	bool "SCP / SFTP protocol"
+	default n
+
+config LIBCURL_SMB
+	bool "SMB protocol (CIFS)"
+	depends on LIBCURL_CRYPTO_AUTH && (LIBCURL_GNUTLS || LIBCURL_OPENSSL)
+	default n
+config LIBCURL_NO_SMB
+	string "SMB require 'cryptographic authentication' and either 'GnuTLS' or 'OpenSSL'"
+	depends on !LIBCURL_CRYPTO_AUTH || (!LIBCURL_GNUTLS && !LIBCURL_OPENSSL)
+	default "!"
+
+config LIBCURL_SMTP
+	bool "SMTP / SMTPS protocol"
+	default n
+
+config LIBCURL_TELNET
+	bool "TELNET protocol"
+	default n
+
+config LIBCURL_TFTP
+	bool "TFTP protocol"
+	default n
+
+config LIBCURL_NGHTTP2
+	bool "HTTP2 protocol"
+	default n
+
+comment "Miscellaneous"
+
+config LIBCURL_PROXY
+	bool "Enable proxy support"
+	default y
+
+config LIBCURL_CRYPTO_AUTH
+	bool "Enable cryptographic authentication"
+	default n
+
+config LIBCURL_TLS_SRP
+	bool "Enable TLS-SRP authentication"
+	default n
+
+config LIBCURL_LIBIDN2
+	bool "Enable IDN2 support"
+	default n
+
+config LIBCURL_THREADED_RESOLVER
+	bool "Enable threaded DNS resolver"
+	default n
+	help
+		Enable POSIX threaded asynchronous DNS resolution
+
+config LIBCURL_ZLIB
+	bool "Enable zlib support"
+	default n
+
+config LIBCURL_UNIX_SOCKETS
+	bool "Enable unix domain socket support"
+	default n
+	help
+		Enable HTTP over unix domain sockets.
+		To use this with the curl command line, you specify the socket path to the new --unix-domain option.
+		This feature is actually not limited to HTTP, you can do all the TCP-based protocols 
+		except FTP over the unix domain socket, but it is only HTTP that is regularly used this way. 
+		The reason FTP isn't supported is of course its use of two connections 
+		which would be even weirder to do like this.
+
+config LIBCURL_LIBCURL_OPTION
+	bool "Enable generation of C code"
+	default n
+
+config LIBCURL_VERBOSE
+	bool "Enable verbose error strings"
+	default n
+
+config LIBCURL_NTLM
+	bool "Enable NTLM support"
+	depends on LIBCURL_CRYPTO_AUTH && !LIBCURL_NOSSL
+	default n
+
+endif

--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -4,7 +4,7 @@ comment "SSL support"
 
 choice
 	prompt "Selected SSL library"
-	default LIBCURL_MBEDTLS
+	default LIBCURL_WOLFSSL
 
 	config LIBCURL_MBEDTLS
 		bool "mbed TLS"

--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -133,6 +133,10 @@ config LIBCURL_ZLIB
 	bool "Enable zlib support"
 	default n
 
+config LIBCURL_ZSTD
+	bool "Enable zstd support"
+	default n
+
 config LIBCURL_UNIX_SOCKETS
 	bool "Enable unix domain socket support"
 	default n

--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -1,0 +1,189 @@
+#
+# Copyright (C) 2007-2020 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=curl
+PKG_VERSION:=7.72.0
+PKG_RELEASE:=2
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://dl.uxnr.de/mirror/curl/ \
+	https://curl.mirror.anstey.ca/ \
+	https://curl.askapache.com/download/ \
+	https://curl.haxx.se/download/
+PKG_HASH:=0ded0808c4d85f2ee0db86980ae610cc9d165e9ca9da466196cc73c346513713
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:haxx:libcurl
+
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+
+PKG_CONFIG_DEPENDS:= \
+  CONFIG_IPV6 \
+  \
+  CONFIG_LIBCURL_WOLFSSL \
+  CONFIG_LIBCURL_GNUTLS \
+  CONFIG_LIBCURL_OPENSSL \
+  CONFIG_LIBCURL_MBEDTLS \
+  CONFIG_LIBCURL_NOSSL \
+  \
+  CONFIG_LIBCURL_LIBIDN2 \
+  CONFIG_LIBCURL_SSH2 \
+  CONFIG_LIBCURL_ZLIB \
+  \
+  CONFIG_LIBCURL_DICT \
+  CONFIG_LIBCURL_FILE \
+  CONFIG_LIBCURL_FTP \
+  CONFIG_LIBCURL_GOPHER \
+  CONFIG_LIBCURL_HTTP \
+  CONFIG_LIBCURL_IMAP \
+  CONFIG_LIBCURL_LDAP \
+  CONFIG_LIBCURL_LDAPS \
+  CONFIG_LIBCURL_POP3 \
+  CONFIG_LIBCURL_RTSP \
+  CONFIG_LIBCURL_NO_RTSP \
+  CONFIG_LIBCURL_SMB \
+  CONFIG_LIBCURL_NO_SMB \
+  CONFIG_LIBCURL_SMTP \
+  CONFIG_LIBCURL_TELNET \
+  CONFIG_LIBCURL_TFTP \
+  CONFIG_LIBCURL_NGHTTP2 \
+  \
+  CONFIG_LIBCURL_COOKIES \
+  CONFIG_LIBCURL_CRYPTO_AUTH \
+  CONFIG_LIBCURL_LIBCURL_OPTION \
+  CONFIG_LIBCURL_PROXY \
+  CONFIG_LIBCURL_THREADED_RESOLVER \
+  CONFIG_LIBCURL_TLS_SRP \
+  CONFIG_LIBCURL_UNIX_SOCKETS \
+  CONFIG_LIBCURL_VERBOSE \
+  CONFIG_LIBCURL_NTLM \
+  $(if $(CONFIG_LIBCURL_OPENSSL), \
+	CONFIG_OPENSSL_ENGINE \
+	CONFIG_OPENSSL_WITH_COMPRESSION \
+	CONFIG_OPENSSL_WITH_NPN)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/curl/Default
+  SECTION:=net
+  CATEGORY:=Network
+  URL:=http://curl.haxx.se/
+  MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>
+endef
+
+define Package/curl
+  $(call Package/curl/Default)
+  SUBMENU:=File Transfer
+  DEPENDS:=+libcurl
+  TITLE:=A client-side URL transfer utility
+endef
+
+define Package/libcurl
+  $(call Package/curl/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:= +LIBCURL_WOLFSSL:libwolfssl +LIBCURL_OPENSSL:libopenssl +LIBCURL_GNUTLS:libgnutls +LIBCURL_MBEDTLS:libmbedtls
+  DEPENDS += +LIBCURL_ZLIB:zlib +LIBCURL_THREADED_RESOLVER:libpthread +LIBCURL_LDAP:libopenldap +LIBCURL_LIBIDN2:libidn2
+  DEPENDS += +LIBCURL_SSH2:libssh2 +LIBCURL_NGHTTP2:libnghttp2 +ca-bundle
+  TITLE:=A client-side URL transfer library
+  MENU:=1
+  ABI_VERSION:=4
+endef
+
+define Package/libcurl/config
+  source "$(SOURCE)/Config.in"
+endef
+
+TARGET_CFLAGS += $(FPIC) -ffunction-sections -fdata-sections
+TARGET_CPPFLAGS += $(if $(CONFIG_LIBCURL_NTLM),,-DCURL_DISABLE_NTLM)
+TARGET_LDFLAGS += -Wl,--gc-sections
+
+CONFIGURE_ARGS += \
+	--disable-debug \
+	--disable-ares \
+	--enable-shared \
+	--enable-static \
+	--disable-manual \
+	--without-nss \
+	--without-libmetalink \
+	--without-librtmp \
+	--without-libidn \
+	--without-ca-path \
+	--without-libpsl \
+	--without-zstd \
+	--with-ca-bundle=/etc/ssl/certs/ca-certificates.crt \
+	\
+	$(call autoconf_bool,CONFIG_IPV6,ipv6) \
+	\
+	$(if $(CONFIG_LIBCURL_WOLFSSL),--with-wolfssl="$(STAGING_DIR)/usr",--without-wolfssl) \
+	$(if $(CONFIG_LIBCURL_GNUTLS),--with-gnutls="$(STAGING_DIR)/usr",--without-gnutls) \
+	$(if $(CONFIG_LIBCURL_OPENSSL),--with-ssl="$(STAGING_DIR)/usr",--without-ssl) \
+	$(if $(CONFIG_LIBCURL_MBEDTLS),--with-mbedtls="$(STAGING_DIR)/usr",--without-mbedtls) \
+	\
+	$(if $(CONFIG_LIBCURL_LIBIDN2),--with-libidn2="$(STAGING_DIR)/usr",--without-libidn2) \
+	$(if $(CONFIG_LIBCURL_SSH2),--with-libssh2="$(STAGING_DIR)/usr",--without-libssh2) \
+	$(if $(CONFIG_LIBCURL_ZLIB),--with-zlib="$(STAGING_DIR)/usr",--without-zlib) \
+	$(if $(CONFIG_LIBCURL_NGHTTP2),--with-nghttp2="$(STAGING_DIR)/usr",--without-nghttp2) \
+	\
+	$(call autoconf_bool,CONFIG_LIBCURL_DICT,dict) \
+	$(call autoconf_bool,CONFIG_LIBCURL_FILE,file) \
+	$(call autoconf_bool,CONFIG_LIBCURL_FTP,ftp) \
+	$(call autoconf_bool,CONFIG_LIBCURL_GOPHER,gopher) \
+	$(call autoconf_bool,CONFIG_LIBCURL_HTTP,http) \
+	$(call autoconf_bool,CONFIG_LIBCURL_IMAP,imap) \
+	$(call autoconf_bool,CONFIG_LIBCURL_LDAP,ldap) \
+	$(call autoconf_bool,CONFIG_LIBCURL_LDAPS,ldaps) \
+	$(call autoconf_bool,CONFIG_LIBCURL_POP3,pop3) \
+	$(call autoconf_bool,CONFIG_LIBCURL_RTSP,rtsp) \
+	$(call autoconf_bool,CONFIG_LIBCURL_SMB,smb) \
+	$(call autoconf_bool,CONFIG_LIBCURL_SMTP,smtp) \
+	$(call autoconf_bool,CONFIG_LIBCURL_TELNET,telnet) \
+	$(call autoconf_bool,CONFIG_LIBCURL_TFTP,tftp) \
+	\
+	$(call autoconf_bool,CONFIG_LIBCURL_COOKIES,cookies) \
+	$(call autoconf_bool,CONFIG_LIBCURL_CRYPTO_AUTH,crypto-auth) \
+	$(call autoconf_bool,CONFIG_LIBCURL_LIBCURL_OPTION,libcurl-option) \
+	$(call autoconf_bool,CONFIG_LIBCURL_PROXY,proxy) \
+	$(call autoconf_bool,CONFIG_LIBCURL_THREADED_RESOLVER,threaded-resolver) \
+	$(call autoconf_bool,CONFIG_LIBCURL_TLS_SRP,tls-srp) \
+	$(call autoconf_bool,CONFIG_LIBCURL_UNIX_SOCKETS,unix-sockets) \
+	$(call autoconf_bool,CONFIG_LIBCURL_VERBOSE,verbose) \
+
+define Build/Compile
+	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		CC="$(TARGET_CC)" \
+		install
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(2)/bin $(1)/usr/bin $(1)/usr/include $(1)/usr/lib $(1)/usr/lib/pkgconfig
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/curl-config $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/curl $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcurl.{a,so*} $(1)/usr/lib/
+	$(CP) $(PKG_BUILD_DIR)/libcurl.pc $(1)/usr/lib/pkgconfig/
+	$(SED) 's,-L$$$${exec_prefix}/lib,,g' $(1)/usr/bin/curl-config
+	[ -n "$(TARGET_LDFLAGS)" ] && $(SED) 's#$(TARGET_LDFLAGS)##g' $(1)/usr/lib/pkgconfig/libcurl.pc || true
+	$(LN) $(STAGING_DIR)/usr/bin/curl-config $(2)/bin/
+endef
+
+define Package/curl/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/curl $(1)/usr/bin/
+endef
+
+define Package/libcurl/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcurl.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,curl))
+$(eval $(call BuildPackage,libcurl))

--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -37,6 +37,7 @@ PKG_CONFIG_DEPENDS:= \
   CONFIG_LIBCURL_LIBIDN2 \
   CONFIG_LIBCURL_SSH2 \
   CONFIG_LIBCURL_ZLIB \
+  CONFIG_LIBCURL_ZSTD \
   \
   CONFIG_LIBCURL_DICT \
   CONFIG_LIBCURL_FILE \
@@ -91,8 +92,8 @@ define Package/libcurl
   SECTION:=libs
   CATEGORY:=Libraries
   DEPENDS:= +LIBCURL_WOLFSSL:libwolfssl +LIBCURL_OPENSSL:libopenssl +LIBCURL_GNUTLS:libgnutls +LIBCURL_MBEDTLS:libmbedtls
-  DEPENDS += +LIBCURL_ZLIB:zlib +LIBCURL_THREADED_RESOLVER:libpthread +LIBCURL_LDAP:libopenldap +LIBCURL_LIBIDN2:libidn2
-  DEPENDS += +LIBCURL_SSH2:libssh2 +LIBCURL_NGHTTP2:libnghttp2 +ca-bundle
+  DEPENDS += +LIBCURL_ZLIB:zlib +LIBCURL_ZSTD:libzstd +LIBCURL_THREADED_RESOLVER:libpthread +LIBCURL_LDAP:libopenldap
+  DEPENDS += +LIBCURL_LIBIDN2:libidn2 +LIBCURL_SSH2:libssh2 +LIBCURL_NGHTTP2:libnghttp2 +ca-bundle
   TITLE:=A client-side URL transfer library
   MENU:=1
   ABI_VERSION:=4
@@ -131,6 +132,7 @@ CONFIGURE_ARGS += \
 	$(if $(CONFIG_LIBCURL_LIBIDN2),--with-libidn2="$(STAGING_DIR)/usr",--without-libidn2) \
 	$(if $(CONFIG_LIBCURL_SSH2),--with-libssh2="$(STAGING_DIR)/usr",--without-libssh2) \
 	$(if $(CONFIG_LIBCURL_ZLIB),--with-zlib="$(STAGING_DIR)/usr",--without-zlib) \
+	$(if $(CONFIG_LIBCURL_ZSTD),--with-zstd="$(STAGING_DIR)/usr",--without-zstd) \
 	$(if $(CONFIG_LIBCURL_NGHTTP2),--with-nghttp2="$(STAGING_DIR)/usr",--without-nghttp2) \
 	\
 	$(call autoconf_bool,CONFIG_LIBCURL_DICT,dict) \

--- a/net/curl/patches/100-configure-fix-pkg-config-detecting-wolfssl.patch
+++ b/net/curl/patches/100-configure-fix-pkg-config-detecting-wolfssl.patch
@@ -1,0 +1,31 @@
+From 510d98157f21dee5793c4e975fde3317b6139267 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 24 Aug 2020 16:28:34 +0200
+Subject: [PATCH] configure: fix pkg-config detecting wolfssl
+
+When amending the include path with "/wolfssl", this now properly strips
+off all whitespace from the path variable! Previously this would lead to
+pkg-config builds creating bad command lines.
+
+Closes #5848
+---
+ configure.ac | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -2474,8 +2474,12 @@ if test -z "$ssl_backends" -o "x$OPT_WOL
+             AC_DEFINE(HAVE_WOLFSSL_DES_ECB_ENCRYPT, 1,
+                       [if you have wolfSSL_DES_ecb_encrypt])
+             if test -n "$addcflags"; then
+-              CPPFLAGS="$addcflags/wolfssl $CPPFLAGS"
+-              AC_MSG_NOTICE([Add $addcflags/wolfssl to CPPFLAGS])
++              dnl use a for loop to strip off whitespace
++              for f in $addcflags; do
++                CPPFLAGS="$f/wolfssl $CPPFLAGS"
++                AC_MSG_NOTICE([Add $f/wolfssl to CPPFLAGS])
++                break
++              done
+             else
+               dnl user didn't give a path, so guess/hope they installed wolfssl
+               dnl headers to system default location

--- a/net/curl/patches/200-no_docs_tests.patch
+++ b/net/curl/patches/200-no_docs_tests.patch
@@ -1,0 +1,22 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -192,7 +192,7 @@ CLEANFILES = $(VC6_LIBDSP) $(VC6_SRCDSP)
+ bin_SCRIPTS = curl-config
+ 
+ SUBDIRS = lib src
+-DIST_SUBDIRS = $(SUBDIRS) tests packages scripts include docs
++DIST_SUBDIRS = $(SUBDIRS) packages include
+ 
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = libcurl.pc
+@@ -303,8 +303,8 @@ cygwinbin:
+ # We extend the standard install with a custom hook:
+ install-data-hook:
+ 	(cd include && $(MAKE) install)
+-	(cd docs && $(MAKE) install)
+-	(cd docs/libcurl && $(MAKE) install)
++	#(cd docs && $(MAKE) install)
++	#(cd docs/libcurl && $(MAKE) install)
+ 
+ # We extend the standard uninstall with a custom hook:
+ uninstall-hook:


### PR DESCRIPTION
Move package over from openwrt.git based on the Hamburg 2019 decision
that non essential packages should be maintained in packages.git

Signed-off-by: Paul Spooren <mail@aparcar.org>

Maintainer @kaloz 
Compile tested armvirt/armv8