### PR TITLE
openfortivpn: use more standard config option names

### DIFF
--- a/net/openfortivpn/Makefile
+++ b/net/openfortivpn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openfortivpn
 PKG_VERSION:=1.14.1
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/adrienverge/openfortivpn/tar.gz/v$(PKG_VERSION)?


### PR DESCRIPTION
@lucize - I found a few more inconsistencies with how other tunneling packages name variables.  6in4, 6rd, dslite, gre, vxlan, ipip, xfrm, and vti all use 'tunlink' for the interface that the tunnel is established through and 'peeraddr' for the remote peer.

Breaking changes like this are not ideal, but the netifd version of openfortivpn has never been in a stable release, so I'd like to make breaking changes to the config now before the netifd version of openfortivpn has made it to a stable release.


Maintainer: @lucize 

