### PR TITLE
openconnect: allow disable dtls with bool option no_dtls

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=8.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://ftp.infradead.org/pub/openconnect/

--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -15,6 +15,7 @@ proto_openconnect_init_config() {
 	proto_config_add_int "port"
 	proto_config_add_int "mtu"
 	proto_config_add_int "juniper"
+	proto_config_add_boolean "no_dtls"
 	proto_config_add_string "interface"
 	proto_config_add_string "username"
 	proto_config_add_string "serverhash"
@@ -46,6 +47,7 @@ proto_openconnect_setup() {
 		interface \
 		juniper \
 		mtu \
+		no_dtls \
 		os \
 		password \
 		password2 \
@@ -72,6 +74,7 @@ proto_openconnect_setup() {
 	[ -n "$port" ] && port=":$port"
 
 	append_args "$server$port" -i "$ifname" --non-inter --syslog --script /lib/netifd/vpnc-script
+	[ "$no_dtls" = 1 ] && append_args --no-dtls
 	[ -n "$mtu" ] && append_args --mtu "$mtu"
 
 	# migrate to standard config files

--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -39,7 +39,24 @@ proto_openconnect_add_form_entry() {
 proto_openconnect_setup() {
 	local config="$1"
 
-	json_get_vars server port interface username serverhash authgroup usergroup password password2 token_mode token_secret token_script os csd_wrapper mtu juniper form_entry
+	json_get_vars \
+		authgroup \
+		csd_wrapper \
+		form_entry \
+		interface \
+		juniper \
+		mtu \
+		os \
+		password \
+		password2 \
+		port \
+		server \
+		serverhash \
+		token_mode \
+		token_script \
+		token_secret \
+		usergroup \
+		username \
 
 	grep -q tun /proc/modules || insmod tun
 	ifname="vpn-$config"


### PR DESCRIPTION
Maintainer: @nmav 
Compile tested: x86/64, openwrt master
Run tested: x86/64 on qemu, openwrt master

Tests done: Observe openconnect command line arguments and syslog lines under the following condition combinations

 - On/off the `no_dtls`
 - Enable/disable dtls udp traffic with iptables rule
