### PR TITLE
glib2: update to 2.65.2

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
-PKG_VERSION:=2.65.1
+PKG_VERSION:=2.65.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/2.65
-PKG_HASH:=bc63bf6c32713e0ee1dddc28e03f23b4a20c78bcb9a2c5b0f4eea41e46fb9cee
+PKG_HASH:=445b1951eaa82d7a8af46bdff5dcc8030406db1ceeb0f0c3a88983f70152c555
 
 PKG_MAINTAINER:=Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/libs/glib2/patches/004-no-distutils.patch
+++ b/libs/glib2/patches/004-no-distutils.patch
@@ -1,6 +1,6 @@
 --- a/meson.build
 +++ b/meson.build
-@@ -2168,16 +2168,10 @@ endif
+@@ -2185,16 +2185,10 @@ endif
  
  glib_conf.set('HAVE_PROC_SELF_CMDLINE', have_proc_self_cmdline)
  

--- a/libs/glib2/patches/005-uclibc.patch
+++ b/libs/glib2/patches/005-uclibc.patch
@@ -1,6 +1,6 @@
 --- a/meson.build
 +++ b/meson.build
-@@ -1986,8 +1986,8 @@ endif
+@@ -2003,8 +2003,8 @@ endif
  # FIXME: glib-gettext.m4 has much more checks to detect broken/uncompatible
  # implementations. This could be extended if issues are found in some platforms.
  libintl_deps = []


### PR DESCRIPTION
Refreshed patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 
Compile tested: ath79