### PR TITLE
autossh: switch to procd

### DIFF
--- a/net/autossh/Makefile
+++ b/net/autossh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=autossh
 PKG_VERSION:=1.4g
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://www.harding.motd.ca/autossh/

--- a/net/autossh/files/autossh.init
+++ b/net/autossh/files/autossh.init
@@ -1,6 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2007-2011 OpenWrt.org
 
+USE_PROCD=1
 START=80
 
 start_instance() {
@@ -14,20 +15,15 @@ start_instance() {
 
 	[ "$enabled" = 1 ] || exit 0
 
-	export AUTOSSH_GATETIME="${gatetime:-30}"
-	export AUTOSSH_POLL="${poll:-600}"
-	service_start /usr/sbin/autossh -M ${monitorport:-20000} -f ${ssh}
+	procd_open_instance
+	procd_set_param command /usr/sbin/autossh -M ${monitorport:-20000} ${ssh}
+	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+	procd_set_param env AUTOSSH_GATETIME="${gatetime:-30}"
+	procd_set_param env AUTOSSH_POLL="${poll:-600}"
+	procd_close_instance
 }
 
-boot() {
-	return
-}
-
-start() {
+start_service() {
 	config_load 'autossh'
 	config_foreach start_instance 'autossh'
-}
-
-stop() {
-	service_stop /usr/sbin/autossh
 }


### PR DESCRIPTION
Maintainer: @bk138 
Compile tested: Turris Omnia (TOS5), OpenWrt master, OpenWrt 19.07
Run tested: Turris Omnia (TOS5), OpenWrt 19.07

Description:
This PR changes autossh init script to procd.

