### PR TITLE
[18.06] simple-adblock: add config auto-update feature

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -5,8 +5,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
-PKG_VERSION:=1.8.3
-PKG_RELEASE:=15
+PKG_VERSION:=1.8.4
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/README.md
+++ b/net/simple-adblock/files/README.md
@@ -135,6 +135,7 @@ In the Web UI the ```simple-adblock``` settings are split into ```basic``` and `
 |Web UI Section|Parameter|Type|Default|Description|
 | --- | --- | --- | --- | --- |
 |Basic|enabled|boolean|0|Enable/disable the ```simple-adblock``` service.|
+|Basic|config_update_enabled|boolean|0|Enable/disable the ```simple-adblock``` config update. Oftentimes, the URLs to the blocked hosts/domains files become obsolete/outdated, resulting in the error during lists download stage. ```simple-adblock``` already updates users' config files during install/reinstall, if you enable this variable it will also attempt to fetch and use the most recent config update file before downloading allow/block-lists.|
 |Basic|verbosity|integer|2|Can be set to 0, 1 or 2 to control the console and system log output verbosity of the ```simple-adblock``` service.|
 |Basic|force_dns|boolean|1|Force router's DNS to local devices which may have different/hardcoded DNS server settings. If enabled, creates a firewall rule to intercept DNS requests from local devices to external DNS servers and redirect them to router.|
 |Basic|led|string|none|Use one of the router LEDs to indicate the AdBlocking status.|

--- a/net/simple-adblock/files/simple-adblock.conf
+++ b/net/simple-adblock/files/simple-adblock.conf
@@ -1,5 +1,6 @@
 config simple-adblock 'config'
 	option enabled '0'
+	option config_update_enabled '0'
 	option dns 'dnsmasq.servers'
 	option dns_instance '0'
 	option verbosity '2'

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -10,7 +10,7 @@ USE_PROCD=1
 LC_ALL=C
 
 # shellcheck disable=SC2034
-EXTRA_COMMANDS='check dl killcache sizes show'
+EXTRA_COMMANDS='check dl killcache sizes show enable disable'
 # shellcheck disable=SC2034
 EXTRA_HELP='	check	Checks if specified domain is found in current block-list
 	dl	Force-downloads all enabled block-list
@@ -53,6 +53,10 @@ readonly _FAIL_='\033[0;31m\xe2\x9c\x97\033[0m'
 readonly __OK__='\033[0;32m[\xe2\x9c\x93]\033[0m'
 readonly __FAIL__='\033[0;31m[\xe2\x9c\x97]\033[0m'
 readonly _ERROR_='\033[0;31mERROR\033[0m'
+readonly configUpdateURL='https://cdn.jsdelivr.net/gh/openwrt/packages/net/simple-adblock/files/simple-adblock.conf.update'
+
+enable() { uci set "$packageName.config.enabled=1"; uci commit "$packageName"; }
+disable() { uci set "$packageName.config.enabled=0"; uci commit "$packageName"; }
 
 getStatusText() {
 	local _ret
@@ -89,8 +93,10 @@ getErrorText() {
 		errorOhSnap) _ret="failed to create block-list or restart DNS resolver";;
 		errorStopping) _ret="failed to stop $serviceName";;
 		errorDNSReload) _ret="failed to reload/restart DNS resolver";;
+		errorDownloadingConfigUpdate) _ret="failed to download Config Update file";;
 		errorDownloadingList) _ret="failed to download";;
 		errorParsingList) _ret="failed to parse";;
+		errorParsingConfigUpdate) _ret="failed to parse Config Update file";;
 	esac
 	printf "%b" "$_ret"
 }
@@ -139,6 +145,7 @@ parallelDL=1
 debug=0
 compressedCache=0
 ipv6Enabled=0
+configUpdateEnabled=0
 bootDelay=120
 dlTimeout=20
 curlRetry=3
@@ -169,6 +176,7 @@ load_package_config() {
 	config_get_bool debug                 'config' 'debug' 0
 	config_get_bool compressedCache       'config' 'compressed_cache' 0
 	config_get_bool ipv6Enabled           'config' 'ipv6_enabled' 0
+	config_get_bool configUpdateEnabled   'config' 'config_update_enabled' 0
 	config_get bootDelay                  'config' 'boot_delay' '120'
 	config_get dlTimeout                  'config' 'download_timeout' '20'
 	config_get curlRetry                  'config' 'curl_retry' '3'
@@ -722,6 +730,31 @@ process_url() {
 	return 0
 }
 
+process_config_update() {
+	local label R_TMP
+	[ "$configUpdateEnabled" -eq 0 ] && return 0
+	label="${1##*//}"; label="${label%%/*}";
+	while [ -z "$R_TMP" ] || [ -e "$R_TMP" ]; do
+		R_TMP="$(mktemp -u -q -t ${packageName}_tmp.XXXXXXXX)"
+	done
+	if ! $dl_command "$1" $dl_flag "$R_TMP" 2>/dev/null || [ ! -s "$R_TMP" ]; then
+		output 1 "$_FAIL_"
+		output 2 "[DL] Config  Update:  $label $__FAIL__\\n"
+		tmpfs add error "errorDownloadingConfigUpdate"
+	else
+		if ! sed -f "$R_TMP" -i /etc/config/simple-adblock; then
+			output 1 "$_FAIL_"
+			output 2 "[DL] Config  Update:  $label $__FAIL__\\n"
+			tmpfs add error "errorParsingConfigUpdate"
+		else
+			output 1 "$_OK_"
+			output 2 "[DL] Config  Update:  $label $__OK__\\n"
+		fi
+	fi
+	rm -f "$R_TMP"
+	return 0
+}
+
 download_lists() {
 	local hf w_filter j=0 R_TMP
 
@@ -739,6 +772,7 @@ download_lists() {
 	fi
 	touch $A_TMP; touch $B_TMP;
 	output 1 'Downloading lists '
+	process_config_update "$configUpdateURL"
 	rm -f "$sharedMemoryError"
 	if [ -n "$blocked_hosts_urls" ]; then
 		for hf in ${blocked_hosts_urls}; do


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, WRT3200ACM, 19.07.3
Run tested: mvebu, WRT3200ACM, 19.07.3, start/config auto-update

Description: 
This update contains following:
* Adds an option (disabled by default) to perform user's config auto-update before downloading allow/block-lists. Config auto-update is a simple sed-control file to update/remove obsolete and outdated URLs to block-lists in the config file.
* Updated README.
* Added `version` parameter to the init-script to simplify corresponding luci app ACL.

Please merge, as I don't have merge access to packages.

I also request a merge access to packages as I will need to update most of my other apps with the `version` parameter for init-script.

Signed-off-by: Stan Grishin <stangri@melmac.net>
