### PR TITLE
lcd4linux: drop dependencies on ar71xx/rb532

### DIFF
--- a/utils/lcd4linux/Config.in
+++ b/utils/lcd4linux/Config.in
@@ -274,12 +274,6 @@ config LCD4LINUX_CUSTOM_DRIVER_TeakLCM
 	bool
 	prompt "TeakLCM"
 
-config LCD4LINUX_CUSTOM_DRIVER_TEW673GRU
-	bool
-	select LCD4LINUX_CUSTOM_NEEDS_libgd
-	depends on TARGET_ar71xx
-	default TARGET_ar71xx
-
 config LCD4LINUX_CUSTOM_DRIVER_Trefon
 	bool
 	prompt "Trefon"

--- a/utils/lcd4linux/Config.in
+++ b/utils/lcd4linux/Config.in
@@ -233,11 +233,6 @@ config LCD4LINUX_CUSTOM_DRIVER_PPM
 	prompt "PPM"
 	select LCD4LINUX_CUSTOM_NEEDS_libgd
 
-config LCD4LINUX_CUSTOM_DRIVER_RouterBoard
-	bool
-	prompt "RouterBoard"
-	depends on TARGET_rb532
-
 config LCD4LINUX_CUSTOM_DRIVER_SamsungSPF
 	bool
 	prompt "SamsungSPF"

--- a/utils/lcd4linux/Makefile
+++ b/utils/lcd4linux/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lcd4linux
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/feckert/lcd4linux
@@ -67,7 +67,6 @@ LCD4LINUX_DRIVERS:= \
 	picoLCDGraphic \
 	PNG \
 	PPM \
-	$(if $(CONFIG_TARGET_rb532),RouterBoard) \
 	$(if $(CONFIG_BROKEN),SamsungSPF) \
 	ShuttleVFD \
 	SimpleLCD \

--- a/utils/lcd4linux/Makefile
+++ b/utils/lcd4linux/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lcd4linux
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/feckert/lcd4linux
@@ -74,7 +74,6 @@ LCD4LINUX_DRIVERS:= \
 	st2205 \
 	T6963 \
 	TeakLCM \
-	$(if $(CONFIG_TARGET_ar71xx),TEW673GRU) \
 	Trefon \
 	USBHUB \
 	USBLCD \


### PR DESCRIPTION
The ar71xx target has finally been removed in master, so drop the
dependencies in this package.

Maintainer: @feckert @neheb
Compile tested: no
Run tested: no