### PR TITLE
python-cryptography: fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/lang/python/python-cryptography/patches/010-Add-new-ASN1_STRING_get0_data-API.patch
+++ b/lang/python/python-cryptography/patches/010-Add-new-ASN1_STRING_get0_data-API.patch
@@ -1,0 +1,37 @@
+From 1d97b931bf4701fbd3478d2b788ec4310d9eb8e1 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Fri, 7 Jun 2019 18:18:46 -0700
+Subject: [PATCH] Add new ASN1_STRING_get0_data API
+
+Introduced with OpenSSL 1.1
+---
+ src/_cffi_src/openssl/asn1.py | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/_cffi_src/openssl/asn1.py b/src/_cffi_src/openssl/asn1.py
+index da55b670..85cd58bd 100644
+--- a/src/_cffi_src/openssl/asn1.py
++++ b/src/_cffi_src/openssl/asn1.py
+@@ -45,6 +45,7 @@ void ASN1_OBJECT_free(ASN1_OBJECT *);
+ 
+ /*  ASN1 STRING */
+ unsigned char *ASN1_STRING_data(ASN1_STRING *);
++const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *);
+ int ASN1_STRING_set(ASN1_STRING *, const void *, int);
+ 
+ /*  ASN1 OCTET STRING */
+@@ -105,4 +106,11 @@ ASN1_NULL *ASN1_NULL_new(void);
+ """
+ 
+ CUSTOMIZATIONS = """
++#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110 && !CRYPTOGRAPHY_LIBRESSL_27_OR_GREATER
++#define ASN1_STRING_get0_data ASN1_STRING_data
++#endif
++
++#if (OPENSSL_API_COMPAT >= 0x10100000L) && !CRYPTOGRAPHY_IS_LIBRESSL
++#define ASN1_STRING_data ASN1_STRING_get0_data
++#endif
+ """
+-- 
+2.26.2
+

--- a/lang/python/python-cryptography/patches/020-Add-compatibility-for-X509_STORE_set_get_issuer.patch
+++ b/lang/python/python-cryptography/patches/020-Add-compatibility-for-X509_STORE_set_get_issuer.patch
@@ -1,0 +1,63 @@
+From a30684980e8f1f7472d885487880b405608f4122 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Fri, 7 Jun 2019 20:42:04 -0700
+Subject: [PATCH] Add compatibility for X509_STORE_set_get_issuer
+
+Deprecated under OpenSSL 1.1.
+---
+ src/_cffi_src/openssl/x509_vfy.py                        | 8 ++++++++
+ src/cryptography/hazmat/bindings/openssl/_conditional.py | 9 +++++++++
+ 2 files changed, 17 insertions(+)
+
+diff --git a/src/_cffi_src/openssl/x509_vfy.py b/src/_cffi_src/openssl/x509_vfy.py
+index d2bc5f4e..a1730738 100644
+--- a/src/_cffi_src/openssl/x509_vfy.py
++++ b/src/_cffi_src/openssl/x509_vfy.py
+@@ -22,6 +22,7 @@ TYPES = """
+ static const long Cryptography_HAS_102_VERIFICATION;
+ static const long Cryptography_HAS_110_VERIFICATION_PARAMS;
+ static const long Cryptography_HAS_X509_STORE_CTX_GET_ISSUER;
++static const long Cryptography_HAS_X509_CB_ISSUER_CHECK;
+ 
+ typedef ... Cryptography_STACK_OF_ASN1_OBJECT;
+ typedef ... Cryptography_STACK_OF_X509_OBJECT;
+@@ -274,4 +275,11 @@ void (*X509_STORE_set_get_issuer)(X509_STORE *,
+ #else
+ static const long Cryptography_HAS_X509_STORE_CTX_GET_ISSUER = 1;
+ #endif
++
++#ifndef X509_V_FLAG_CB_ISSUER_CHECK
++static const long Cryptography_HAS_X509_CB_ISSUER_CHECK = 0;
++#define X509_V_FLAG_CB_ISSUER_CHECK	0x0
++#else
++static const long Cryptography_HAS_X509_CB_ISSUER_CHECK = 1;
++#endif
+ """
+diff --git a/src/cryptography/hazmat/bindings/openssl/_conditional.py b/src/cryptography/hazmat/bindings/openssl/_conditional.py
+index 9cf489ac..23dc38a4 100644
+--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
++++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
+@@ -287,6 +287,12 @@ def cryptography_has_srtp():
+     ]
+ 
+ 
++def cryptography_has_x509_cb_issuer_check():
++    return [
++        "X509_V_FLAG_CB_ISSUER_CHECK",
++    ]
++
++
+ # This is a mapping of
+ # {condition: function-returning-names-dependent-on-that-condition} so we can
+ # loop over them and delete unsupported names at runtime. It will be removed
+@@ -338,4 +344,7 @@ CONDITIONAL_NAMES = {
+     "Cryptography_HAS_ENGINE": cryptography_has_engine,
+     "Cryptography_HAS_VERIFIED_CHAIN": cryptography_has_verified_chain,
+     "Cryptography_HAS_SRTP": cryptography_has_srtp,
++    "Cryptography_HAS_X509_CB_ISSUER_CHECK": (
++        cryptography_has_x509_cb_issuer_check
++    ),
+ }
+-- 
+2.26.2
+

--- a/lang/python/python-cryptography/patches/030-Add-compatibility-for-deprecated-TLS-methods.patch
+++ b/lang/python/python-cryptography/patches/030-Add-compatibility-for-deprecated-TLS-methods.patch
@@ -1,0 +1,137 @@
+From 3f3b85a59d3c2cb021174ad92ad3a43d9eb73e62 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Fri, 7 Jun 2019 21:00:46 -0700
+Subject: [PATCH] Add compatibility for deprecated TLS methods
+
+---
+ src/_cffi_src/openssl/ssl.py                  | 45 +++++++++++++++++--
+ .../hazmat/bindings/openssl/_conditional.py   | 36 +++++++++++++++
+ 2 files changed, 77 insertions(+), 4 deletions(-)
+
+diff --git a/src/_cffi_src/openssl/ssl.py b/src/_cffi_src/openssl/ssl.py
+index c38e309a..e726417d 100644
+--- a/src/_cffi_src/openssl/ssl.py
++++ b/src/_cffi_src/openssl/ssl.py
+@@ -15,8 +15,9 @@ static const long Cryptography_HAS_SSL_ST;
+ static const long Cryptography_HAS_TLS_ST;
+ static const long Cryptography_HAS_SSL2;
+ static const long Cryptography_HAS_SSL3_METHOD;
+-static const long Cryptography_HAS_TLSv1_1;
+-static const long Cryptography_HAS_TLSv1_2;
++static const long Cryptography_HAS_TLS1_METHOD;
++static const long Cryptography_HAS_TLS1_1_METHOD;
++static const long Cryptography_HAS_TLS1_2_METHOD;
+ static const long Cryptography_HAS_TLSv1_3;
+ static const long Cryptography_HAS_SECURE_RENEGOTIATION;
+ static const long Cryptography_HAS_TLSEXT_STATUS_REQ_CB;
+@@ -24,6 +25,7 @@ static const long Cryptography_HAS_STATUS_REQ_OCSP_RESP;
+ static const long Cryptography_HAS_TLSEXT_STATUS_REQ_TYPE;
+ static const long Cryptography_HAS_SSL_CTX_CLEAR_OPTIONS;
+ static const long Cryptography_HAS_DTLS;
++static const long Cryptography_HAS_DTLS1_METHOD;
+ static const long Cryptography_HAS_SIGALGS;
+ static const long Cryptography_HAS_PSK;
+ static const long Cryptography_HAS_CIPHER_DETAILS;
+@@ -596,8 +598,43 @@ static const long Cryptography_HAS_STATUS_REQ_OCSP_RESP = 1;
+ static const long Cryptography_HAS_TLSEXT_STATUS_REQ_TYPE = 1;
+ static const long Cryptography_HAS_RELEASE_BUFFERS = 1;
+ static const long Cryptography_HAS_OP_NO_COMPRESSION = 1;
+-static const long Cryptography_HAS_TLSv1_1 = 1;
+-static const long Cryptography_HAS_TLSv1_2 = 1;
++
++#if (OPENSSL_API_COMPAT >= 0x10100000L) && !CRYPTOGRAPHY_IS_LIBRESSL
++static const long Cryptography_HAS_TLS1_METHOD = 0;
++const SSL_METHOD* (*TLSv1_method)(void) = NULL;
++const SSL_METHOD* (*TLSv1_server_method)(void) = NULL;
++const SSL_METHOD* (*TLSv1_client_method)(void) = NULL;
++#else
++static const long Cryptography_HAS_TLS1_METHOD = 1;
++#endif
++
++#if (OPENSSL_API_COMPAT >= 0x10100000L) && !CRYPTOGRAPHY_IS_LIBRESSL
++static const long Cryptography_HAS_TLS1_1_METHOD = 0;
++const SSL_METHOD* (*TLSv1_1_method)(void) = NULL;
++const SSL_METHOD* (*TLSv1_1_server_method)(void) = NULL;
++const SSL_METHOD* (*TLSv1_1_client_method)(void) = NULL;
++#else
++static const long Cryptography_HAS_TLS1_1_METHOD = 1;
++#endif
++
++#if (OPENSSL_API_COMPAT >= 0x10100000L) && !CRYPTOGRAPHY_IS_LIBRESSL
++static const long Cryptography_HAS_TLS1_2_METHOD = 0;
++const SSL_METHOD* (*TLSv1_2_method)(void) = NULL;
++const SSL_METHOD* (*TLSv1_2_server_method)(void) = NULL;
++const SSL_METHOD* (*TLSv1_2_client_method)(void) = NULL;
++#else
++static const long Cryptography_HAS_TLS1_2_METHOD = 1;
++#endif
++
++#if (OPENSSL_API_COMPAT >= 0x10100000L) && !CRYPTOGRAPHY_IS_LIBRESSL
++static const long Cryptography_HAS_DTLS1_METHOD = 0;
++const SSL_METHOD* (*DTLSv1_method)(void) = NULL;
++const SSL_METHOD* (*DTLSv1_server_method)(void) = NULL;
++const SSL_METHOD* (*DTLSv1_client_method)(void) = NULL;
++#else
++static const long Cryptography_HAS_DTLS1_METHOD = 1;
++#endif
++
+ static const long Cryptography_HAS_SSL_OP_MSIE_SSLV2_RSA_PADDING = 1;
+ static const long Cryptography_HAS_SSL_OP_NO_TICKET = 1;
+ static const long Cryptography_HAS_SSL_SET_SSL_CTX = 1;
+diff --git a/src/cryptography/hazmat/bindings/openssl/_conditional.py b/src/cryptography/hazmat/bindings/openssl/_conditional.py
+index 23dc38a4..c0dca00a 100644
+--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
++++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
+@@ -33,6 +33,38 @@ def cryptography_has_ssl3_method():
+     ]
+ 
+ 
++def cryptography_has_tls1_method():
++    return [
++        "TLSv1_method",
++        "TLSv1_client_method",
++        "TLSv1_server_method",
++    ]
++
++
++def cryptography_has_tls1_1_method():
++    return [
++        "TLSv1_1_method",
++        "TLSv1_1_client_method",
++        "TLSv1_1_server_method",
++    ]
++
++
++def cryptography_has_tls1_2_method():
++    return [
++        "TLSv1_2_method",
++        "TLSv1_2_client_method",
++        "TLSv1_2_server_method",
++    ]
++
++
++def cryptography_has_dtls1_method():
++    return [
++        "DTLSv1_method",
++        "DTLSv1_client_method",
++        "DTLSv1_server_method",
++    ]
++
++
+ def cryptography_has_102_verification():
+     return [
+         "X509_V_ERR_SUITE_B_INVALID_VERSION",
+@@ -303,6 +335,10 @@ CONDITIONAL_NAMES = {
+     "Cryptography_HAS_RSA_OAEP_MD": cryptography_has_rsa_oaep_md,
+     "Cryptography_HAS_RSA_OAEP_LABEL": cryptography_has_rsa_oaep_label,
+     "Cryptography_HAS_SSL3_METHOD": cryptography_has_ssl3_method,
++    "Cryptography_HAS_TLS1_METHOD": cryptography_has_tls1_method,
++    "Cryptography_HAS_TLS1_1_METHOD": cryptography_has_tls1_1_method,
++    "Cryptography_HAS_TLS1_2_METHOD": cryptography_has_tls1_2_method,
++    "Cryptography_HAS_DTLS1_METHOD": cryptography_has_dtls1_method,
+     "Cryptography_HAS_102_VERIFICATION": cryptography_has_102_verification,
+     "Cryptography_HAS_110_VERIFICATION_PARAMS": (
+         cryptography_has_110_verification_params
+-- 
+2.26.2
+

--- a/lang/python/python-cryptography/patches/040-Replace-EVP_CIPHER_CTX_cleanup-with-EVP_CIPHER_CTX_r.patch
+++ b/lang/python/python-cryptography/patches/040-Replace-EVP_CIPHER_CTX_cleanup-with-EVP_CIPHER_CTX_r.patch
@@ -1,0 +1,53 @@
+From 50c1e937342c8b13c8a80c3bb55ce245aecdcdfe Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sat, 15 Jun 2019 17:49:25 -0700
+Subject: [PATCH] Replace EVP_CIPHER_CTX_cleanup with EVP_CIPHER_CTX_reset
+
+Deprecated in OpenSSL 1.1
+---
+ src/_cffi_src/openssl/evp.py                        | 10 ++++++++++
+ src/cryptography/hazmat/backends/openssl/ciphers.py |  2 +-
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/src/_cffi_src/openssl/evp.py b/src/_cffi_src/openssl/evp.py
+index d7ac93e6..0b3e067d 100644
+--- a/src/_cffi_src/openssl/evp.py
++++ b/src/_cffi_src/openssl/evp.py
+@@ -48,6 +48,7 @@ int EVP_CipherUpdate(EVP_CIPHER_CTX *, unsigned char *, int *,
+                      const unsigned char *, int);
+ int EVP_CipherFinal_ex(EVP_CIPHER_CTX *, unsigned char *, int *);
+ int EVP_CIPHER_CTX_cleanup(EVP_CIPHER_CTX *);
++int EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX *);
+ EVP_CIPHER_CTX *EVP_CIPHER_CTX_new(void);
+ void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *);
+ int EVP_CIPHER_CTX_set_key_length(EVP_CIPHER_CTX *, int);
+@@ -273,4 +274,13 @@ static const long Cryptography_HAS_EVP_DIGESTFINAL_XOF = 1;
+ #ifndef EVP_PKEY_POLY1305
+ #define EVP_PKEY_POLY1305 NID_poly1305
+ #endif
++
++#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110 && !CRYPTOGRAPHY_LIBRESSL_27_OR_GREATER
++#define EVP_CIPHER_CTX_reset EVP_CIPHER_CTX_cleanup
++#endif
++
++#if (OPENSSL_API_COMPAT >= 0x10100000L) && !CRYPTOGRAPHY_IS_LIBRESSL
++#define EVP_CIPHER_CTX_cleanup EVP_CIPHER_CTX_reset
++#define OpenSSL_add_all_algorithms() do {} while(0)
++#endif
+ """
+diff --git a/src/cryptography/hazmat/backends/openssl/ciphers.py b/src/cryptography/hazmat/backends/openssl/ciphers.py
+index 171605a6..4c0504ca 100644
+--- a/src/cryptography/hazmat/backends/openssl/ciphers.py
++++ b/src/cryptography/hazmat/backends/openssl/ciphers.py
+@@ -199,7 +199,7 @@ class _CipherContext(object):
+             self._backend.openssl_assert(res != 0)
+             self._tag = self._backend._ffi.buffer(tag_buf)[:]
+ 
+-        res = self._backend._lib.EVP_CIPHER_CTX_cleanup(self._ctx)
++        res = self._backend._lib.EVP_CIPHER_CTX_reset(self._ctx)
+         self._backend.openssl_assert(res == 1)
+         return self._backend._ffi.buffer(buf)[: outlen[0]]
+ 
+-- 
+2.26.2
+

--- a/lang/python/python-cryptography/patches/050-Switch-get_-Update-APIs-to-get0.patch
+++ b/lang/python/python-cryptography/patches/050-Switch-get_-Update-APIs-to-get0.patch
@@ -1,0 +1,135 @@
+From 645c30f76bce250772ce4e0b878e7228bd104277 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sat, 15 Jun 2019 18:47:46 -0700
+Subject: [PATCH] Switch get_*Update APIs to get0
+
+Deprecated in 1.1
+---
+ src/_cffi_src/openssl/x509.py                 | 34 ++++++++++++++++---
+ .../hazmat/backends/openssl/backend.py        |  4 +--
+ .../hazmat/backends/openssl/x509.py           |  8 ++---
+ 3 files changed, 36 insertions(+), 10 deletions(-)
+
+diff --git a/src/_cffi_src/openssl/x509.py b/src/_cffi_src/openssl/x509.py
+index b88daa1f..54cd66c9 100644
+--- a/src/_cffi_src/openssl/x509.py
++++ b/src/_cffi_src/openssl/x509.py
+@@ -202,8 +202,10 @@ long X509_get_version(X509 *);
+ 
+ ASN1_TIME *X509_get_notBefore(X509 *);
+ ASN1_TIME *X509_get_notAfter(X509 *);
+-ASN1_TIME *X509_getm_notBefore(X509 *);
+-ASN1_TIME *X509_getm_notAfter(X509 *);
++ASN1_TIME *X509_getm_notBefore(const X509 *);
++ASN1_TIME *X509_getm_notAfter(const X509 *);
++const ASN1_TIME *X509_get0_notBefore(const X509 *);
++const ASN1_TIME *X509_get0_notAfter(const X509 *);
+ 
+ long X509_REQ_get_version(X509_REQ *);
+ X509_NAME *X509_REQ_get_subject_name(X509_REQ *);
+@@ -235,6 +237,8 @@ X509_CRL *sk_X509_CRL_value(Cryptography_STACK_OF_X509_CRL *, int);
+ long X509_CRL_get_version(X509_CRL *);
+ ASN1_TIME *X509_CRL_get_lastUpdate(X509_CRL *);
+ ASN1_TIME *X509_CRL_get_nextUpdate(X509_CRL *);
++const ASN1_TIME *X509_CRL_get0_lastUpdate(const X509_CRL *);
++const ASN1_TIME *X509_CRL_get0_nextUpdate(const X509_CRL *);
+ X509_NAME *X509_CRL_get_issuer(X509_CRL *);
+ Cryptography_STACK_OF_X509_REVOKED *X509_CRL_get_REVOKED(X509_CRL *);
+ 
+@@ -243,8 +247,11 @@ int X509_CRL_set_lastUpdate(X509_CRL *, ASN1_TIME *);
+ int X509_CRL_set_nextUpdate(X509_CRL *, ASN1_TIME *);
+ int X509_set_notBefore(X509 *, ASN1_TIME *);
+ int X509_set_notAfter(X509 *, ASN1_TIME *);
+-int X509_set1_notBefore(X509 *, ASN1_TIME *);
+-int X509_set1_notAfter(X509 *, ASN1_TIME *);
++
++int X509_CRL_set1_lastUpdate(X509_CRL *, const ASN1_TIME *);
++int X509_CRL_set1_nextUpdate(X509_CRL *, const ASN1_TIME *);
++int X509_set1_notBefore(X509 *, const ASN1_TIME *);
++int X509_set1_notAfter(X509 *, const ASN1_TIME *);
+ 
+ EC_KEY *d2i_EC_PUBKEY_bio(BIO *, EC_KEY **);
+ int i2d_EC_PUBKEY_bio(BIO *, EC_KEY *);
+@@ -339,6 +346,25 @@ const ASN1_INTEGER *X509_REVOKED_get0_serialNumber(const X509_REVOKED *x)
+ #define X509_set1_notAfter X509_set_notAfter
+ #define X509_getm_notAfter X509_get_notAfter
+ #define X509_getm_notBefore X509_get_notBefore
++#define X509_get0_notAfter X509_get_notAfter
++#define X509_get0_notBefore X509_get_notBefore
++
++#define X509_CRL_set1_lastUpdate X509_CRL_set_lastUpdate
++#define X509_CRL_set1_nextUpdate X509_CRL_set_nextUpdate
++#define X509_CRL_get0_lastUpdate X509_CRL_get_lastUpdate
++#define X509_CRL_get0_nextUpdate X509_CRL_get_nextUpdate
++#endif
+ #endif
++
++#if (OPENSSL_API_COMPAT >= 0x10100000L) && !CRYPTOGRAPHY_IS_LIBRESSL
++#define X509_set_notBefore X509_set1_notBefore
++#define X509_set_notAfter X509_set1_notAfter
++#define X509_get_notAfter X509_get0_notAfter
++#define X509_get_notBefore X509_get0_notBefore
++
++#define X509_CRL_get_lastUpdate X509_CRL_get0_lastUpdate
++#define X509_CRL_get_nextUpdate X509_CRL_get0_nextUpdate
++#define X509_CRL_set_lastUpdate X509_CRL_set1_lastUpdate
++#define X509_CRL_set_nextUpdate X509_CRL_set1_nextUpdate
+ #endif
+ """
+diff --git a/src/cryptography/hazmat/backends/openssl/backend.py b/src/cryptography/hazmat/backends/openssl/backend.py
+index 97c7fd05..891d6309 100644
+--- a/src/cryptography/hazmat/backends/openssl/backend.py
++++ b/src/cryptography/hazmat/backends/openssl/backend.py
+@@ -1129,12 +1129,12 @@ class Backend(object):
+ 
+         # Set the last update time.
+         last_update = self._create_asn1_time(builder._last_update)
+-        res = self._lib.X509_CRL_set_lastUpdate(x509_crl, last_update)
++        res = self._lib.X509_CRL_set1_lastUpdate(x509_crl, last_update)
+         self.openssl_assert(res == 1)
+ 
+         # Set the next update time.
+         next_update = self._create_asn1_time(builder._next_update)
+-        res = self._lib.X509_CRL_set_nextUpdate(x509_crl, next_update)
++        res = self._lib.X509_CRL_set1_nextUpdate(x509_crl, next_update)
+         self.openssl_assert(res == 1)
+ 
+         # Add extensions.
+diff --git a/src/cryptography/hazmat/backends/openssl/x509.py b/src/cryptography/hazmat/backends/openssl/x509.py
+index 4d0dac76..074211e6 100644
+--- a/src/cryptography/hazmat/backends/openssl/x509.py
++++ b/src/cryptography/hazmat/backends/openssl/x509.py
+@@ -86,12 +86,12 @@ class _Certificate(object):
+ 
+     @property
+     def not_valid_before(self):
+-        asn1_time = self._backend._lib.X509_getm_notBefore(self._x509)
++        asn1_time = self._backend._lib.X509_get0_notBefore(self._x509)
+         return _parse_asn1_time(self._backend, asn1_time)
+ 
+     @property
+     def not_valid_after(self):
+-        asn1_time = self._backend._lib.X509_getm_notAfter(self._x509)
++        asn1_time = self._backend._lib.X509_get0_notAfter(self._x509)
+         return _parse_asn1_time(self._backend, asn1_time)
+ 
+     @property
+@@ -277,13 +277,13 @@ class _CertificateRevocationList(object):
+ 
+     @property
+     def next_update(self):
+-        nu = self._backend._lib.X509_CRL_get_nextUpdate(self._x509_crl)
++        nu = self._backend._lib.X509_CRL_get0_nextUpdate(self._x509_crl)
+         self._backend.openssl_assert(nu != self._backend._ffi.NULL)
+         return _parse_asn1_time(self._backend, nu)
+ 
+     @property
+     def last_update(self):
+-        lu = self._backend._lib.X509_CRL_get_lastUpdate(self._x509_crl)
++        lu = self._backend._lib.X509_CRL_get0_lastUpdate(self._x509_crl)
+         self._backend.openssl_assert(lu != self._backend._ffi.NULL)
+         return _parse_asn1_time(self._backend, lu)
+ 
+-- 
+2.26.2
+

--- a/lang/python/python-cryptography/patches/060-Add-X509_STORE_CTX_trusted_stack-compatibility-macro.patch
+++ b/lang/python/python-cryptography/patches/060-Add-X509_STORE_CTX_trusted_stack-compatibility-macro.patch
@@ -1,0 +1,49 @@
+From 07fb50eecc3a3a50ac543f53f98c285eb1ceeb1e Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Mon, 25 Nov 2019 12:06:16 -0800
+Subject: [PATCH] Add X509_STORE_CTX_trusted_stack compatibility macro
+
+Deprecated in 1.1
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ src/_cffi_src/openssl/x509_vfy.py | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/src/_cffi_src/openssl/x509_vfy.py b/src/_cffi_src/openssl/x509_vfy.py
+index a1730738..cd143ea0 100644
+--- a/src/_cffi_src/openssl/x509_vfy.py
++++ b/src/_cffi_src/openssl/x509_vfy.py
+@@ -157,8 +157,12 @@ int X509_STORE_CTX_init(X509_STORE_CTX *, X509_STORE *, X509 *,
+                         Cryptography_STACK_OF_X509 *);
+ void X509_STORE_CTX_trusted_stack(X509_STORE_CTX *,
+                                   Cryptography_STACK_OF_X509 *);
++void X509_STORE_CTX_set0_trusted_stack(X509_STORE_CTX *,
++                                  Cryptography_STACK_OF_X509 *);
+ void X509_STORE_CTX_set_cert(X509_STORE_CTX *, X509 *);
+-void X509_STORE_CTX_set_chain(X509_STORE_CTX *,Cryptography_STACK_OF_X509 *);
++void X509_STORE_CTX_set_chain(X509_STORE_CTX *, Cryptography_STACK_OF_X509 *);
++void X509_STORE_CTX_set0_untrusted(X509_STORE_CTX *,
++                                  Cryptography_STACK_OF_X509 *);
+ X509_VERIFY_PARAM *X509_STORE_CTX_get0_param(X509_STORE_CTX *);
+ void X509_STORE_CTX_set0_param(X509_STORE_CTX *, X509_VERIFY_PARAM *);
+ int X509_STORE_CTX_set_default(X509_STORE_CTX *, const char *);
+@@ -282,4 +286,15 @@ static const long Cryptography_HAS_X509_CB_ISSUER_CHECK = 0;
+ #else
+ static const long Cryptography_HAS_X509_CB_ISSUER_CHECK = 1;
+ #endif
++
++#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110 && !CRYPTOGRAPHY_IS_LIBRESSL
++#define X509_STORE_CTX_set0_trusted_stack X509_STORE_CTX_trusted_stack
++#define X509_STORE_CTX_set0_untrusted X509_STORE_CTX_set_chain
++#endif
++
++#if (OPENSSL_API_COMPAT >= 0x10100000L) && !CRYPTOGRAPHY_IS_LIBRESSL
++#define X509_STORE_CTX_trusted_stack X509_STORE_CTX_set0_trusted_stack
++#define X509_STORE_CTX_set_chain X509_STORE_CTX_set0_untrusted
++#define X509_STORE_CTX_get_chain X509_STORE_CTX_get1_chain
++#endif
+ """
+-- 
+2.26.2
+

--- a/lang/python/python-cryptography/patches/070-Add-defines-for-totally-deprecated-functions.patch
+++ b/lang/python/python-cryptography/patches/070-Add-defines-for-totally-deprecated-functions.patch
@@ -1,0 +1,54 @@
+From 93317e7835acf40a9b8b0f7af417240b57ab690a Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Thu, 5 Dec 2019 12:52:13 -0800
+Subject: [PATCH] Add defines for totally deprecated functions
+
+---
+ src/_cffi_src/openssl/conf.py   | 4 ++++
+ src/_cffi_src/openssl/crypto.py | 4 ++++
+ src/_cffi_src/openssl/ssl.py    | 5 +++++
+ 3 files changed, 13 insertions(+)
+
+diff --git a/src/_cffi_src/openssl/conf.py b/src/_cffi_src/openssl/conf.py
+index 9db0162a..6b474d42 100644
+--- a/src/_cffi_src/openssl/conf.py
++++ b/src/_cffi_src/openssl/conf.py
+@@ -18,4 +18,8 @@ void OPENSSL_no_config(void);
+ """
+ 
+ CUSTOMIZATIONS = """
++#if (OPENSSL_API_COMPAT >= 0x10100000L) && !CRYPTOGRAPHY_IS_LIBRESSL
++#define OPENSSL_config(x) 0
++#define OPENSSL_no_config() 0
++#endif
+ """
+diff --git a/src/_cffi_src/openssl/crypto.py b/src/_cffi_src/openssl/crypto.py
+index f3623b21..85541b31 100644
+--- a/src/_cffi_src/openssl/crypto.py
++++ b/src/_cffi_src/openssl/crypto.py
+@@ -124,4 +124,8 @@ void *Cryptography_realloc_wrapper(void *ptr, size_t size, const char *path,
+ void Cryptography_free_wrapper(void *ptr, const char *path, int line) {
+     free(ptr);
+ }
++
++#if (OPENSSL_API_COMPAT >= 0x10100000L) && !CRYPTOGRAPHY_IS_LIBRESSL
++#define CRYPTO_get_locking_callback() 0
++#endif
+ """
+diff --git a/src/_cffi_src/openssl/ssl.py b/src/_cffi_src/openssl/ssl.py
+index e726417d..68c42160 100644
+--- a/src/_cffi_src/openssl/ssl.py
++++ b/src/_cffi_src/openssl/ssl.py
+@@ -792,4 +792,9 @@ int (*SSL_CTX_set_max_early_data)(SSL_CTX *, uint32_t) = NULL;
+ #else
+ static const long Cryptography_HAS_TLSv1_3 = 1;
+ #endif
++
++#if (OPENSSL_API_COMPAT >= 0x10100000L) && !CRYPTOGRAPHY_IS_LIBRESSL
++#define SSL_library_init() 1
++#define SSL_load_error_strings() 0
++#endif
+ """
+-- 
+2.26.2
+


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jefferyto @commodo 
Compile tested: ath79

https://github.com/pyca/cryptography/pull/4920