### PR TITLE
mstpd: fix compilation with uClibc-ng

### DIFF
--- a/net/mstpd/Makefile
+++ b/net/mstpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mstpd
 PKG_VERSION:=0.0.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mstpd/mstpd/tar.gz/$(PKG_VERSION)?

--- a/net/mstpd/patches/010-bsd.patch
+++ b/net/mstpd/patches/010-bsd.patch
@@ -1,0 +1,17 @@
+--- a/hmac_md5.c
++++ b/hmac_md5.c
+@@ -356,10 +356,10 @@ caddr_t         digest;     /* caller digest to be filled in */
+      */
+ 
+     /* start out by storing key in pads */
+-    bzero(k_ipad, sizeof k_ipad);
+-    bzero(k_opad, sizeof k_opad);
+-    bcopy(key, k_ipad, key_len);
+-    bcopy( key, k_opad, key_len);
++    memset(k_ipad, 0, sizeof k_ipad);
++    memset(k_opad, 0, sizeof k_opad);
++    memcpy(k_ipad, key, key_len);
++    memcpy(k_opad, key, key_len);
+ 
+     /* XOR key with ipad and opad values */
+     for(i = 0; i < 64; ++i)


### PR DESCRIPTION
bcopy/bzero are no longer available.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @commodo 
Compile tested: ath79