### PR TITLE
sqm-scripts: depend directly on kmod-sched-cake again

### DIFF
--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=sqm-scripts
 PKG_SOURCE_VERSION:=ab763cba8b1516b3afa99760e0ca884f8b8d93b8
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/tohojo/sqm-scripts
@@ -26,7 +26,7 @@ define Package/sqm-scripts
   CATEGORY:=Base system
   DEPENDS:=+tc +kmod-sched-core +kmod-ifb +iptables \
 	+iptables-mod-ipopt +iptables-mod-conntrack-extra \
-	+kmod-sched-cake-virtual
+	+kmod-sched-cake
   TITLE:=SQM Scripts (QoS)
   PKGARCH:=all
 endef


### PR DESCRIPTION
**I plan to remove support for 4.14 kernel later this week, and will remove kmod-sched-cake-virtual as well then.**
**This PR is meant to discuss the necessary changes here, so we can just merge them when I remove 4.14 in master.**

Since support for kernel 4.14 has been removed, kmod-sched-cake-oot
is gone, and the kmod-sched-cake-virtual package is not needed
anymore.

This effectively reverts 9114244fbd1b ("sqm-scripts: Switch sch_cake
dependency to new virtual package")

Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>

Maintainer: @tohojo @hnyman 
Compile tested: no
Run tested: no