### PR TITLE
python-more-itertools: update to version 8.5.0

### DIFF
--- a/lang/python/python-more-itertools/Makefile
+++ b/lang/python/python-more-itertools/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-more-itertools
-PKG_VERSION:=8.4.0
+PKG_VERSION:=8.5.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=more-itertools
-PKG_HASH:=68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5
+PKG_HASH:=6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates package more-itertools to version 8.5.0. [Changelog](https://github.com/more-itertools/more-itertools/blob/b0b56acc0669ba77f64a93602355aed50532566a/docs/versions.rst)

Run tested with internal unit tests
```
Ran 505 tests in 4.494s

OK 
```
