### PR TITLE
erlang: fix host build when pcre/host is installed

### DIFF
--- a/lang/erlang/Makefile
+++ b/lang/erlang/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=erlang
 PKG_VERSION:=23.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=otp_src_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= http://www.erlang.org/download/

--- a/lang/erlang/patches/020-erts-emulator-reorder-inclued-headers-paths.patch
+++ b/lang/erlang/patches/020-erts-emulator-reorder-inclued-headers-paths.patch
@@ -1,0 +1,46 @@
+From 85a3e5b4f65e5284e59dcdd90e92ea7d50ef6907 Mon Sep 17 00:00:00 2001
+From: Romain Naour <romain.naour@openwide.fr>
+Date: Sun, 8 Feb 2015 17:23:13 +0100
+Subject: [PATCH] erts/emulator: reorder inclued headers paths
+
+If the Perl Compatible Regular Expressions is installed on the
+host and the path to the headers is added to the CFLAGS, the
+pcre.h from the host is used instead of the one provided by
+erlang.
+
+Erlang use an old version of this file which is incompatible
+with the upstream one.
+
+Move INCLUDES before CFLAGS to use pcre.h from erlang.
+
+http://autobuild.buildroot.net/results/cbd/cbd8b54eef535f19d7d400fd269af1b3571d6143/build-end.log
+
+Signed-off-by: Romain Naour <romain.naour@openwide.fr>
+[Bernd: rebased for erlang-21.0]
+Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
+---
+ erts/emulator/Makefile.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/erts/emulator/Makefile.in b/erts/emulator/Makefile.in
+index 7145824..d079487 100644
+--- a/erts/emulator/Makefile.in
++++ b/erts/emulator/Makefile.in
+@@ -712,7 +712,7 @@
+ # Usually the same as the default rule, but certain platforms (e.g. win32) mix
+ # different compilers
+ $(OBJDIR)/beam_emu.o: beam/beam_emu.c
+-	$(V_EMU_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
++	$(V_EMU_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
+ 
+ $(OBJDIR)/beam_emu.S: beam/beam_emu.c
+ 	$(V_EMU_CC) -S -fverbose-asm $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
+@@ -765,7 +765,7 @@
+ # General targets
+ #
+ $(OBJDIR)/%.o: beam/%.c
+-	$(V_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
++	$(V_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
+ 
+ $(OBJDIR)/%.o: $(TARGET)/%.c
+ 	$(V_CC) $(CFLAGS) $(INCLUDES) -Idrivers/common -c $< -o $@


### PR DESCRIPTION
OpenWrt added pcre/host recently. When it is available (installed)
erlang finds staging_dir/hostpkg/include/pcre.h before it finds its own
copy and the build fails.

 CC	obj/x86_64-pc-linux-gnu/opt/smp/erl_bif_chksum.o
 CC	obj/x86_64-pc-linux-gnu/opt/smp/erl_bif_re.o
beam/erl_bif_re.c: In function 'erts_init_bif_re':
beam/erl_bif_re.c:96:5: error: 'erts_pcre_malloc' undeclared (first use in this function)
     erts_pcre_malloc = &erts_erts_pcre_malloc;
     ^~~~~~~~~~~~~~~~
beam/erl_bif_re.c:96:5: note: each undeclared identifier is reported only once for each function it appears in
beam/erl_bif_re.c:97:5: error: 'erts_pcre_free' undeclared (first use in this function)
     erts_pcre_free = &erts_erts_pcre_free;
     ^~~~~~~~~~~~~~

This adds a patch from Romain Naour and Bernd Kuhls to prevent that.
Patch snatched from buildroot [1].

[1] https://github.com/buildroot/buildroot/blob/master/package/erlang/0002-erts-emulator-reorder-inclued-headers-paths.patch

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @cretingame 
Compile tested: x86_64
Run tested: x86_64 build machine, escript works fine (allows target package to build)

Description:
Fix build fail