### PR TITLE
libuhttpd: fix compilation with uClibc-ng

### DIFF
--- a/libs/libuhttpd/Makefile
+++ b/libs/libuhttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuhttpd
 PKG_VERSION:=3.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://github.com/zhaojh329/libuhttpd/releases/download/v$(PKG_VERSION)

--- a/libs/libuhttpd/patches/010-offset.patch
+++ b/libs/libuhttpd/patches/010-offset.patch
@@ -1,0 +1,10 @@
+--- a/src/file.c
++++ b/src/file.c
+@@ -24,6 +24,7 @@
+ 
+ #define _DEFAULT_SOURCE
+ #define _XOPEN_SOURCE
++#define _FILE_OFFSET_BITS 64
+ 
+ #include <stdio.h>
+ #include <stdlib.h>


### PR DESCRIPTION
Upstream backport.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @zhaojh329 
Compile tested: ath79