### PR TITLE
libreswan: drop support for kernel 4.14

### DIFF
--- a/net/libreswan/Makefile
+++ b/net/libreswan/Makefile
@@ -86,10 +86,6 @@ MAKE_FLAGS+= \
     MODPROBEARGS="-q" \
     ARCH="$(LINUX_KARCH)" \
 
-ifdef CONFIG_LINUX_4_14
-	MAKE_FLAGS+= USE_XFRM_INTERFACE_IFLA_HEADER=true
-endif
-
 define Build/Prepare
 	$(call Build/Prepare/Default)
 	$(SED) 's,include $$$$(top_srcdir)/mk/manpages.mk,,g' \


### PR DESCRIPTION
Support for kernel 4.14 has been dropped in main repo, so remove it
here as well.

Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>

Maintainer: @lucize 
Compile tested: none
Run tested: none