### PR TITLE
adblock: Added remaining Perflyst lists

### DIFF
--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -13,6 +13,20 @@
 		"focus": "general",
 		"descurl": "https://adguard.com"
 	},
+	"amazonfiretv_tracking": {
+		"url": "https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/AmazonFireTV.txt",
+		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
+		"size": "S",
+		"focus": "AmazonFire TV tracking",
+		"descurl": "https://github.com/Perflyst/PiHoleBlocklist"
+	},
+	"android_tracking": {
+		"url": "https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/android-tracking.txt",
+		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
+		"size": "S",
+		"focus": "Android tracking",
+		"descurl": "https://github.com/Perflyst/PiHoleBlocklist"
+	},
 	"andryou": {
 		"url": "https://gitlab.com/andryou/block/raw/master/kouhai-compressed-domains",
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",


### PR DESCRIPTION
Added the AmazonTV and Android Tracking lists published by Perflyst (https://github.com/Perflyst/PiHoleBlocklist). Perflyst's SmartTV list is already in the adblock.sources list.

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (Turris Omnia, TurrisOS 5.1.0)
Run tested: (Turris Omnia, TurrisOS 5.1.0, tests done)

Description:
