### PR TITLE
freeradius3: enable radtest utility and adapt it to OpenWrt

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
 PKG_VERSION:=release_3_0_21
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/archive
@@ -732,7 +732,7 @@ endef
 
 define Package/freeradius3-utils/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	for f in radclient radeapclient radwho; do \
+	for f in radclient radeapclient radtest radwho; do \
 		$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/$$$${f} $(1)/usr/bin/ ; \
 	done
 endef

--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
 PKG_VERSION:=release_3_0_21
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/archive

--- a/net/freeradius3/patches/004-get-hostname-from-proc-in-radtest.patch
+++ b/net/freeradius3/patches/004-get-hostname-from-proc-in-radtest.patch
@@ -1,0 +1,12 @@
+--- a/src/main/radtest.in
++++ b/src/main/radtest.in
+@@ -112,7 +112,7 @@ if [ "$7" ]
+ then
+ 	nas=$7
+ else
+-	nas=`hostname`
++	nas=$(cat /proc/sys/kernel/hostname)
+ fi
+ 
+ (
+


### PR DESCRIPTION
Compile tested: x86_64 trunk
Run tested: x86_64 trunk. radtest ran successfully with all authentication methods.

Description:
freeradius3: enable radtest utility and adapt it to OpenWrt.