### PR TITLE
redis: update to version 6.0.7

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
-PKG_VERSION:=6.0.6
+PKG_VERSION:=6.0.7
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=12ad49b163af5ef39466e8d2f7d212a58172116e5b441eebecb4e6ca22363d94
+PKG_HASH:=c2aaa1a4c7e72c70adedf976fdd5e1d34d395989283dab9d7840e0a304bb2393
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates redis to version 6.0.7 update urgency is set to **MODERATE** ( Program an upgrade of the server, but it's not urgent.)

[Changelog](https://raw.githubusercontent.com/redis/redis/6.0/00-RELEASENOTES)

Run tested with a benchmark utility.