### PR TITLE
python3-texttable: update to version 1.6.3

### DIFF
--- a/lang/python/python-texttable/Makefile
+++ b/lang/python/python-texttable/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-texttable
-PKG_VERSION:=1.6.2
-PKG_RELEASE:=2
+PKG_VERSION:=1.6.3
+PKG_RELEASE:=1
 
 PYPI_NAME:=texttable
-PKG_HASH:=eff3703781fbc7750125f50e10f001195174f13825a92a45e9403037d539b4f4
+PKG_HASH:=ce0faf21aa77d806bbff22b107cc22cce68dc9438f97a2df32c93e9afa4ce436
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86-64
Run tested: master x86-64

Description:
Just bug fixes, does not seem to break anything.