### PR TITLE
ninja: use for CMake

### DIFF
--- a/devel/ninja/Makefile
+++ b/devel/ninja/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ninja
 PKG_VERSION:=1.10.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ninja-build/ninja/tar.gz/v$(PKG_VERSION)?

--- a/devel/ninja/ninja-cmake.mk
+++ b/devel/ninja/ninja-cmake.mk
@@ -1,0 +1,25 @@
+include $(INCLUDE_DIR)/cmake.mk
+include ../../devel/ninja/ninja.mk
+
+CMAKE_HOST_OPTIONS += -DCMAKE_GENERATOR="Ninja"
+CMAKE_OPTIONS += -DCMAKE_GENERATOR="Ninja"
+
+define Host/Compile/Default
+	$(call Ninja,-C $(HOST_BUILD_DIR)/$(CMAKE_BINARY_SUBDIR),)
+endef
+
+define Host/Install/Default
+	$(call Ninja,-C $(HOST_BUILD_DIR)/$(CMAKE_BINARY_SUBDIR) install,DESTDIR="$(HOST_INSTALL_DIR)")
+endef
+
+define Host/Uninstall/Default
+	-$(call Ninja,-C $(HOST_BUILD_DIR)/$(CMAKE_BINARY_SUBDIR) uninstall,)
+endef
+
+define Build/Compile/Default
+	$(call Ninja,-C $(PKG_BUILD_DIR)/$(CMAKE_BINARY_SUBDIR),)
+endef
+
+define Build/Install/Default
+	$(call Ninja,-C $(PKG_BUILD_DIR)/$(CMAKE_BINARY_SUBDIR) install,DESTDIR="$(PKG_INSTALL_DIR)")
+endef

--- a/devel/ninja/ninja.mk
+++ b/devel/ninja/ninja.mk
@@ -6,6 +6,9 @@
 #   $(call Ninja,-C $(MY_NINJA_BUILD_DIR),$(MY_NINJA_ENV_VARS))
 # endef
 
+HOST_BUILD_DEPENDS += ninka/host
+PKG_BUILD_DEPENDS += ninja/host
+
 NINJA_ARGS:=$(filter -j%,$(filter-out -j,$(MAKEFLAGS)))
 ifneq ($(findstring c,$(OPENWRT_VERBOSE)),)
   NINJA_ARGS+=-v


### PR DESCRIPTION
CMake supports Ninja for faster compilation and less bugginess when it
comes to parallel compilation. That is, some CMake packages currently
have PKG_BUILD_PARALLEL set where it is not needed with ninja.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dhewg 
Compile tested: ath79

I'm unsure how to properly implement this. I initially tried to get this in base by modifying cmake.mk but was rejected.

The idea currently is to include ninja.mk after cmake.mk.