### PR TITLE
CI: fix compilation of all packages

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -31,22 +31,23 @@ jobs:
 
       - name: Determine changed packages
         run: |
+          # only detect packages with changed Makefiles
           PACKAGES="$(git diff --diff-filter=d --name-only origin/master \
             | grep 'Makefile$' | grep -Ev '/files/|/src/' \
             | awk -F/ '{ print $(NF-1) }' | tr '\n' ' ')"
 
-          echo "Building $PACKAGES"
+          # fallback to test packages if nothing explicitly changes this is
+          # should run if other mechanics in packages.git changed
+          PACKAGES="${PACKAGES:-vim tmux bmon}"
 
+          echo "Building $PACKAGES"
           echo "::set-env name=PACKAGES::$PACKAGES"
 
       - name: Build
         uses: openwrt/gh-action-sdk@v1
         env:
           ARCH: ${{ matrix.arch }}
-          BUILD_LOG: 1
           FEEDNAME: packages_ci
-          IGNORE_ERRORS: ""
-          V: s
 
       - name: Store packages
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
By using `feeds install -d y` the CI tries to install e.g. `libcxx`
which fails, unrelated to the tested packages. Now follow the approach
of the current CircleCI implementation.

Signed-off-by: Paul Spooren <mail@aparcar.org>