### PR TITLE
dovecot: update to version 2.3.11.3 (security fix)

### DIFF
--- a/mail/dovecot/Makefile
+++ b/mail/dovecot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dovecot
-PKG_VERSION:=2.3.10.1
+PKG_VERSION:=2.3.11.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dovecot.org/releases/2.3
-PKG_HASH:=6642e62f23b1b23cfac235007ca6e21cb67460cca834689fad450724456eb10c
+PKG_HASH:=d3d9ea9010277f57eb5b9f4166a5d2ba539b172bd6d5a2b2529a6db524baafdc
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENSE:=LGPL-2.1-only MIT BSD-3-Clause


### PR DESCRIPTION
maintainer: @lucize 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates dovecot to version 2.3.11.3 . Version 2.3.11 should fix multiple security issues from version 2.3.10

[Changelog](https://github.com/dovecot/core/blob/2.3.11.3/NEWS)

Fixes:
[CVE-2020-12100](https://nvd.nist.gov/vuln/detail/CVE-2020-12100)
[CVE-2020-12673](https://nvd.nist.gov/vuln/detail/CVE-2020-12673)
[CVE-2020-12674](https://nvd.nist.gov/vuln/detail/CVE-2020-12674)


I did just the basic run test. 

