### PR TITLE
safe-search: duckduckgo.com new ip address

### DIFF
--- a/net/safe-search/Makefile
+++ b/net/safe-search/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=safe-search
 PKG_VERSION:=1.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=MIT
 PKG_MAINTAINER:=Gregory L. Dietsche <Gregory.Dietsche@cuw.edu>
 

--- a/net/safe-search/files/hosts/duckduckgo.default
+++ b/net/safe-search/files/hosts/duckduckgo.default
@@ -7,10 +7,6 @@
 # IMPORTANT: if this file is not working, make sure that dnsmasq is able to READ it!
 #
 
-#50.16.250.179 safe.duckduckgo.com
-#54.208.102.2 safe.duckduckgo.com
-#52.204.96.252 safe.duckduckgo.com
+#40.89.244.237 safe.duckduckgo.com
 
-50.16.250.179 duckduckgo.com
-54.208.102.2 duckduckgo.com
-52.204.96.252 duckduckgo.com
+40.89.244.237 duckduckgo.com


### PR DESCRIPTION
Maintainer: me 
Compile tested: x86
Run tested: x86 / 19.07.3

Description:
Update to 40.89.244.237 which is the new IP address that duckduckgo.com is using for safe-search.

Signed-off-by: Gregory L. Dietsche <gregory.dietsche@cuw.edu>