### PR TITLE
stress-ng: bump to version 0.11.20

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.11.18
-PKG_RELEASE:=2
+PKG_VERSION:=0.11.20
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://kernel.ubuntu.com/~cking/tarballs/stress-ng
-PKG_HASH:=07c82a5c89538b5b696a79192faa70d0232352004c9e532946f7f3613d0adf23
+PKG_HASH:=145210ec692382e447579ec5c1651f89aa9cb4f6531bab9c0e54ded82c8ac338
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested:  x86 https://github.com/openwrt/openwrt/commit/d8104c83535634906a4f3bd92f2e59c7fa7ceefd
Run tested: x86 https://github.com/openwrt/openwrt/commit/d8104c83535634906a4f3bd92f2e59c7fa7ceefd

--------------------------------

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>
