### PR TITLE
[WIP] acme: use micrond as default cron

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -25,7 +25,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/acme
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+wget-ssl +ca-bundle +openssl-util +socat
+  DEPENDS:=+wget-ssl +ca-bundle +openssl-util +socat +micrond
   TITLE:=ACME (Letsencrypt) client
   URL:=https://acme.sh
   PKGARCH:=all
@@ -59,7 +59,12 @@ endef
 
 define Package/acme/prerm
 #!/bin/sh
-sed -i '/\/etc\/init\.d\/acme start/d' /etc/crontabs/root
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	[ -f "/usr/lib/micron.d/acme" ] && {
+		rm -rf "/usr/lib/micron.d/acme
+		/etc/init.d/micrond restart
+	}
+fi
 endef
 
 define Package/acme-dnsapi

--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -21,14 +21,15 @@ NGINX_WEBSERVER=0
 UPDATE_NGINX=0
 UPDATE_UHTTPD=0
 USER_CLEANUP=
+MICROND_FILE="/usr/lib/micron.d/acme"
 
 . /lib/functions.sh
 
 check_cron()
 {
-	[ -f "/etc/crontabs/root" ] && grep -q '/etc/init.d/acme' /etc/crontabs/root && return
-	echo "0 0 * * * /etc/init.d/acme start" >> /etc/crontabs/root
-	/etc/init.d/cron start
+	[ -f "$MICROND_FILE" ] && return
+	echo "0 0 * * * /etc/init.d/acme start" > "$MICROND_FILE"
+	/etc/init.d/micrond restart
 }
 
 log()


### PR DESCRIPTION
Maintainer: @tohojo
Compile tested: not neede only script changes
Run tested: x86_64, APU3, check if micrond file was added 

Description:
The advantage of micrond is that it does not pollute the crontab of the
user root. This cron job was not created by the user. It was created by
acme. This is a system cron job and therefore it should not appear in
the crontab of the user root.
