### PR TITLE
cache-domains: Fixed upstream changes + wolfssl

### DIFF
--- a/utils/cache-domains/Makefile
+++ b/utils/cache-domains/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cache-domains
-PKG_VERSION:=2.1.0
+PKG_VERSION:=2.2.0
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
@@ -46,10 +46,20 @@ define Package/cache-domains-mbedtls
   TITLE += (mbedtls)
   DEPENDS += +libustream-mbedtls
   VARIANT:=mbedtls
-  DEFAULT_VARIANT:=1
 endef
 Package/cache-domains-mbedtls/description = $(Package/cache-domains/description/default)
 Package/cache-domains-mbedtls/install = $(Package/cache-domains/install/default)
 
+define Package/cache-domains-wolfssl
+  $(Package/cache-domains/default)
+  TITLE += (wolfssl)
+  DEPENDS += +libustream-wolfssl
+  VARIANT:=wolfssl
+  DEFAULT_VARIANT:=1
+endef
+Package/cache-domains-wolfssl/description = $(Package/cache-domains/description/default)
+Package/cache-domains-wolfssl/install = $(Package/cache-domains/install/default)
+
 $(eval $(call BuildPackage,cache-domains-openssl))
 $(eval $(call BuildPackage,cache-domains-mbedtls))
+$(eval $(call BuildPackage,cache-domains-wolfssl))

--- a/utils/cache-domains/README.md
+++ b/utils/cache-domains/README.md
@@ -3,7 +3,7 @@
 hotplug script to dynamically configure the local DNS (dnsmasq) to redirect game content servers to a LAN cache. Definitive list dynamically obtained from https://github.com/uklans/cache-domains.
 
 ## Configuration
-Configuration file follows the same [syntax as the upsteam file](https://github.com/uklans/cache-domains/blob/master/scripts/config.example.json). The key for each `cache_domain` member matches the name of one of the `.txt` files in the [upstream root directory](https://github.com/uklans/cache-domains/blob/master/), except for the `default` key which matches the all the unreferenced `.txt` files. The value of each `cache_domain` member maps to one of the keys of the `ips` members, Thus mapping a cached domain to a list of IP addresses/LAN cache server.
+The configuration file (`/etc/cache-domains.json`) follows the same [syntax as the upsteam file](https://github.com/uklans/cache-domains/blob/master/scripts/config.example.json). The key for each `cache_domains` member matches the name of one of the `.txt` files in the [upstream root directory](https://github.com/uklans/cache-domains/blob/master/), except for the `default` key which matches the all the unreferenced `.txt` files. The value of each `cache_domains` member maps to one of the keys of the `ips` members, Thus mapping a cached domain to a list of IP addresses/LAN cache server.
 
 ```json
 {
@@ -13,10 +13,10 @@ Configuration file follows the same [syntax as the upsteam file](https://github.
 		"server3":	"10.10.3.13"
 	},
 	"cache_domains": {
-		"default":	"server2",
+		"default":	"server1",
 		"blizzard":	"server1",
 		"origin":	"server1",
-		"steam":	"server1",
+		"steam":	"server2",
 		"wsus":		"server3",
 		"xboxlive":	"server3"
 	}
@@ -27,4 +27,4 @@ Configuration file follows the same [syntax as the upsteam file](https://github.
 `/usr/bin/cache-domains configure` will configure the local DNS (dnsmasq) to redirect the configured cache domains. `/usr/bin/cache-domains cleanup` will cleanup redirection. The hotplug script calls `/usr/bin/cache-domains configure` when the WAN interface is brought up.
 
 ## Testing
-With the above configuration set and the service running `nslookup swcdn.apple.com` would return `10.10.3.12`
+After configuring with the above example configuration, running `nslookup lancache.steamcontent.com` would return `10.10.3.12`

--- a/utils/cache-domains/files/cache-domains
+++ b/utils/cache-domains/files/cache-domains
@@ -1,12 +1,26 @@
 #!/bin/sh
 
+. /lib/config/uci.sh
+
 set -e
 
-CACHE_DOMAINS_DIR="/var/cache-domains"
 CACHE_DOMAINS_SRC="https://api.github.com/repos/uklans/cache-domains/tarball/master"
+CACHE_DOMAINS_DIR="/var/cache-domains"
+CACHE_DOMAINS_HOSTS_DIR="${CACHE_DOMAINS_DIR}/scripts/output/dnsmasq"
 CONFIG_FILE="/etc/cache-domains.json"
 
+uci_changes() {
+	local PACKAGE="$1"
+	local STATE="$2"
+
+	CHANGES=$(/sbin/uci ${UCI_CONFIG_DIR:+-c ${UCI_CONFIG_DIR}} ${STATE:+-P ${STATE}} -q changes "${PACKAGE}" | wc -l)
+	return "${CHANGES}"
+}
+
 configure() {
+	local INITIAL_DIR
+	local I=0
+
 	mkdir -p "${CACHE_DOMAINS_DIR}"
 	rm -fr "${CACHE_DOMAINS_DIR:?}/"*
 
@@ -16,30 +30,53 @@ configure() {
 		exit 1
 	fi
 
-	INITIAL_DIR="$(pwd)"
-	cd "${CACHE_DOMAINS_DIR}/"*"/scripts/"
+	# move files out of versioned directory
+	mv "${CACHE_DOMAINS_DIR}/"*"/"* "${CACHE_DOMAINS_DIR}/"
 
 	if [ ! -f "${CONFIG_FILE}" ]; then
-		cp "config.example.json" "${CONFIG_FILE}"
+		cp "${CACHE_DOMAINS_DIR}/scripts/config.example.json" "${CONFIG_FILE}"
 		echo "Using example config file ${CONFIG_FILE}"
 	fi
 
+	INITIAL_DIR="$(pwd)"
+	cd "${CACHE_DOMAINS_DIR}/scripts/"
 	cp "${CONFIG_FILE}" "config.json"
 	./create-dnsmasq.sh
-	cp "./output/dnsmasq/"* "/var/dnsmasq.d/"
-
+	rm "config.json" "${CACHE_DOMAINS_HOSTS_DIR}/lancache.conf"
 	cd "${INITIAL_DIR}"
 
-	/etc/init.d/dnsmasq restart
+	while uci_get "dhcp" "@dnsmasq[${I}]" > /dev/null; do
+		if uci_changes "dhcp"; then
+			uci_remove_list	"dhcp" "@dnsmasq[${I}]" "addnhosts" "${CACHE_DOMAINS_HOSTS_DIR}"
+			uci_add_list	"dhcp" "@dnsmasq[${I}]" "addnhosts" "${CACHE_DOMAINS_HOSTS_DIR}"
+			uci_commit		"dhcp"
+		else
+			echo "ERROR: Unexpected changes in the dhcp configuration, commit changes and try again"
+			exit 1
+		fi
+
+		I=$((${I} + 1))
+	done
+
+	/etc/init.d/dnsmasq "restart"
 }
 
 cleanup() {
-	# leave dnsmasq in a clean state
-	for FILE in "${CACHE_DOMAINS_DIR}/"*"/scripts/output/dnsmasq/"*; do
-		rm -f "/tmp/dnsmasq.d/$(basename "${FILE}")"
+	local I=0
+
+	while uci_get "dhcp" "@dnsmasq[${I}]" > /dev/null; do
+		if uci_changes "dhcp"; then
+			uci_remove_list	"dhcp" "@dnsmasq[${I}]" "addnhosts" "${CACHE_DOMAINS_HOSTS_DIR}"
+			uci_commit		"dhcp"
+		else
+			echo "ERROR: Unexpected changes in the dhcp configuration, commit changes and try again"
+			exit 1
+		fi
+
+		I=$((${I} + 1))
 	done
 
-	/etc/init.d/dnsmasq restart
+	/etc/init.d/dnsmasq "restart"
 }
 
 case ${1} in


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: x86_x64, Hyper-V, OpenWrt Master
Run tested: x86_x64, Hyper-V, OpenWrt Master

Description:
* The upstream script changed to use `.hosts` files from `.conf` files,
so changes were required to make dnsmasq use the new file format.
* Added a default wolfssl variant.
* As a bonus, after the config is loaded, changes in `CACHE_DOMAINS_HOSTS_DIR` can be loaded with `service dnsmasq reload`