### PR TITLE
CI: add super-linter for pull requests

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,22 @@
+name: Lint Pull Request
+
+# Documentation:
+# https://github.com/github/super-linter
+ 
+on:
+  pull_request:
+    branches: [master]
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Lint Code Base
+        uses: github/super-linter@v3
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit adds a linter which checks most common filetypes, including
Shell and Lua. Ideally this improves the quality of especially `init`
scripts written in Shell.
