### PR TITLE
pigeonhole: update to 0.5.11

### DIFF
--- a/mail/pigeonhole/Makefile
+++ b/mail/pigeonhole/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dovecot-pigeonhole
-PKG_VERSION_PLUGIN:=0.5.9
+PKG_VERSION_PLUGIN:=0.5.11
 PKG_VERSION_DOVECOT:=$(shell make --no-print-directory -C ../dovecot/ val.PKG_VERSION V=s)
 PKG_VERSION:=$(PKG_VERSION_DOVECOT)-$(PKG_VERSION_PLUGIN)
 PKG_RELEASE:=1
@@ -17,7 +17,7 @@ DOVECOT_VERSION:=2.3
 
 PKG_SOURCE:=dovecot-$(DOVECOT_VERSION)-pigeonhole-$(PKG_VERSION_PLUGIN).tar.gz
 PKG_SOURCE_URL:=https://pigeonhole.dovecot.org/releases/$(DOVECOT_VERSION)
-PKG_HASH:=36da68aae5157b83e21383f711b8977e5b6f5477f369f71e7e22e76a738bbd05
+PKG_HASH:=0b972a441f680545ddfacd2f41fb2a705fb03249d46ed5ce7e01fe68b6cfb5f0
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
This fixes an error in the previous package when building against recent
OpenWrt releases:

In file included from /builder/shared-workdir/build/sdk/staging_dir/target-x86_64_musl/usr/include/dovecot/lib.h:50,
                 from ext-variables-common.c:4:
ext-variables-common.c: In function 'ext_variables_load':
ext-variables-common.c:91:14: error: expected ')' before 'PRIuSIZE_T'
       "(>= %"PRIuSIZE_T" bytes)",

Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64 master

Description:
