### PR TITLE
acme: update to 2.8.7

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme
-PKG_VERSION:=2.8.6
-PKG_RELEASE:=5
+PKG_VERSION:=2.8.7
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/acmesh-official/acme.sh/archive/$(PKG_VERSION).tar.gz
-PKG_HASH:=fd36cb749466296ded521ceacda3fc841ec76be620900d1116e0492d171c1d9f
+PKG_SOURCE_URL:=https://codeload.github.com/acmesh-official/acme.sh/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=774010429730882f6bbfcd3756ff0fa755846106664841092af828a814159861
 PKG_BUILD_DIR:=$(BUILD_DIR)/acme.sh-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>


### PR DESCRIPTION
Change URL to codeload. It redirects to it anyway. I was getting a 404
error with the original. I couldn't figure it out.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tohojo 
Compile tested: ath79