### PR TITLE
apache: use fakeroot instead of postinst script

### DIFF
--- a/net/apache/Makefile
+++ b/net/apache/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apache
 PKG_VERSION:=2.4.46
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE_NAME:=httpd
 
 PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.bz2
@@ -138,6 +138,11 @@ define Package/apache-suexec
 $(call Package/apache/Default)
   TITLE:=Apache suEXEC
   DEPENDS:=apache
+  # Directory "/usr/lib/apache2/suexec_dir" is installed with mode 0750
+  # and is only accessible by root and the group apache. This way apache
+  # can access the SUID binary "suexec" contained within while others
+  # cannot.
+  FILE_MODES:=/usr/lib/apache2/suexec_dir:root:apache:0750
 endef
 
 define Package/apache-suexec/description
@@ -327,7 +332,7 @@ define Package/apache-icons/install
 endef
 
 define Package/apache-suexec/install
-	$(INSTALL_DIR) -m0750 $(1)/usr/lib/apache2/suexec_dir
+	$(INSTALL_DIR) $(1)/usr/lib/apache2/suexec_dir
 	$(INSTALL_SUID) $(PKG_INSTALL_DIR)/usr/sbin/suexec \
 			$(1)/usr/lib/apache2/suexec_dir
 endef
@@ -337,22 +342,6 @@ define Package/apache-utils/install
 	$(INSTALL_BIN) \
 		$(PKG_INSTALL_DIR)/usr/sbin/{checkgid,envvars*,htcacheclean,rotatelogs} \
 									$(1)/usr/sbin
-endef
-
-# Directory "suexec_dir" is installed with '-m0750' above and contains
-# SUID binary "suexec". Below post-install script changes the group of
-# "suexec_dir" to apache, so user apache can access the folder (and the
-# SUID binary). The script only changes the group if the directory is
-# currently owned by "root:root".
-define Package/apache-suexec/postinst
-#!/bin/sh
-if [ -z "$${IPKG_INSTROOT}" ]; then
-  dir="/usr/lib/apache2/suexec_dir"
-  if ! [ -L "$$dir" ] && [ -d "$$dir" ] && [ -O "$$dir" ] && [ -G "$$dir" ]; then
-    chown :apache "$$dir"
-  fi
-fi
-exit 0
 endef
 
 define Package/apache/Module


### PR DESCRIPTION
fakeroot support was recently added to OpenWrt. Let's make use of it.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @heil 
Compile tested: master ath79
Run tested: ath79 master, installed package to device, checked that permissions are as expected

Description:
This drops postinst script in favor of using fakeroot.

Kind regards,
Seb