### PR TITLE
syslog-ng: tweak shell code of network_localhost little bit

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=3.29.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later

--- a/admin/syslog-ng/files/scl/network_localhost/detect.sh
+++ b/admin/syslog-ng/files/scl/network_localhost/detect.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if [ "$(sysctl net.ipv6.conf.lo.disable_ipv6 | cut -d' ' -f 3)" = "0" ]; then
+if [ "$(sysctl -n net.ipv6.conf.lo.disable_ipv6)" = "0" ]; then
 	echo 'network(ip("::1") port(514) transport(udp) ip-protocol(6) )'
 else
 	echo 'network(ip("127.0.0.1") port(514) transport(udp) ip-protocol(4) )'


### PR DESCRIPTION
We can get rid of pipe with -n flag to sysctl.

Maintainer: @BKPepe 
Compile tested:
Run tested: Turris Omnia, OpenWrt 19.07

Description:
It is just simple shell code tweak. It simplifies code. It is not necessary but refactor is always good.