### PR TITLE
redis: update to version 6.0.8

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
-PKG_VERSION:=6.0.7
+PKG_VERSION:=6.0.8
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=c2aaa1a4c7e72c70adedf976fdd5e1d34d395989283dab9d7840e0a304bb2393
+PKG_HASH:=04fa1fddc39bd1aecb6739dd5dd73858a3515b427acd1e2947a66dadce868d68
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates redis to version 6.0.8. Update urgency is HIGH (There is a critical bug that may affect a subset of users)
[Changelog](https://raw.githubusercontent.com/redis/redis/6.0/00-RELEASENOTES) 

Run tested with redis benchmark
