### PR TITLE
python-pytest: update to version 6.0.2

### DIFF
--- a/lang/python/python-pytest/Makefile
+++ b/lang/python/python-pytest/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pytest
-PKG_VERSION:=6.0.1
-PKG_RELEASE:=2
+PKG_VERSION:=6.0.2
+PKG_RELEASE:=1
 
 PYPI_NAME:=pytest
-PKG_HASH:=85228d75db9f45e06e57ef9bf4429267f81ac7c0d742cc9ed63d09886a9fe6f4
+PKG_HASH:=c8f57c2a30983f469bf03e68cdfa74dc474ce56b8f280ddcb080dfd91df01043
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt maser

Description:
This PR updates pytest to version 6.0.2 which fixes multiple smaller issues. see [Changelog](https://github.com/pytest-dev/pytest/releases/tag/6.0.2)

Run tested with internal tests:
```
collected 2521 items / 5 errors / 2516 selected   
```

cc @jefferyto @commodo 