### PR TITLE
CI: shellcheck ignore OpenWrt unrelated warnings

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Lint Code Base
         uses: github/super-linter@v3
         env:
+          SHELLCHECK_OPTS: "-e SC1091 -e SC2039"
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@aaronjg found the following unrelated shellcheck warnings which do not
apply to OpenWrt:

* It is unable to find sourced scripts (SC1091), which causes unused
  variable warnigs (SC2039)

* It doesn't seem to understand how variables are assigned using
  config_get, causing many unused variable warnings (SC2039)

* It does not understand the capabilities of busybox ash causing many
  SC2039 warnings

Add a workflow env variable to ignore them.

Signed-off-by: Paul Spooren <mail@aparcar.org>