### PR TITLE
zmq: update to version 4.3.3 (security fix)

### DIFF
--- a/libs/zmq/Makefile
+++ b/libs/zmq/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zeromq
-PKG_VERSION:=4.3.2
-PKG_RELEASE:=3
+PKG_VERSION:=4.3.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/zeromq/libzmq/releases/download/v$(PKG_VERSION)
-PKG_HASH:=ebd7b5c830d6428956b67a0454a7f8cbed1de74b3b01e5c33c5378e22740f763
+PKG_HASH:=9d9285db37ae942ed0780c016da87060497877af45094ff9e1a1ca736e3875a2
 
 PKG_MAINTAINER:=Dirk Chang <dirk@kooiot.com>
 PKG_LICENSE:=GPL-3.0-or-later

--- a/libs/zmq/patches/010-uclibcxx.patch
+++ b/libs/zmq/patches/010-uclibcxx.patch
@@ -8,13 +8,13 @@
 -#if __cplusplus >= 201103L
 +#include <ios>
 +#if __cplusplus >= 201103L && !defined(__UCLIBCXX_MAJOR__)
- 
+
  #include "radix_tree.hpp"
  #include "trie.hpp"
 --- a/src/atomic_counter.hpp
 +++ b/src/atomic_counter.hpp
 @@ -35,7 +35,7 @@
- 
+
  #if defined ZMQ_FORCE_MUTEXES
  #define ZMQ_ATOMIC_COUNTER_MUTEX
 -#elif (defined __cplusplus && __cplusplus >= 201103L)                          \
@@ -25,7 +25,7 @@
 --- a/src/atomic_ptr.hpp
 +++ b/src/atomic_ptr.hpp
 @@ -34,7 +34,7 @@
- 
+
  #if defined ZMQ_FORCE_MUTEXES
  #define ZMQ_ATOMIC_PTR_MUTEX
 -#elif (defined __cplusplus && __cplusplus >= 201103L)                          \
@@ -38,34 +38,23 @@
 @@ -38,7 +38,7 @@
  #include <algorithm>
  #include <ios>
- 
+
 -#if __cplusplus >= 201103L || defined(_MSC_VER) && _MSC_VER > 1700
 +#if __cplusplus >= 201103L && !defined(__UCLIBCXX_MAJOR__) || defined(_MSC_VER) && _MSC_VER > 1700
  #define ZMQ_HAS_MOVE_SEMANTICS
  #define ZMQ_MAP_INSERT_OR_EMPLACE(k, v) emplace (k, v)
  #define ZMQ_PUSH_OR_EMPLACE_BACK emplace_back
---- a/src/ctx.cpp
-+++ b/src/ctx.cpp
-@@ -544,7 +544,7 @@ void zmq::ctx_t::unregister_endpoints (socket_base_t *socket_)
-                                end = _endpoints.end ();
-          it != end;) {
-         if (it->second.socket == socket_)
--#if __cplusplus >= 201103L
-+#if __cplusplus >= 201103L && !defined(__UCLIBCXX_MAJOR__)
-             it = _endpoints.erase (it);
- #else
-             _endpoints.erase (it++);
 --- a/src/msg.hpp
 +++ b/src/msg.hpp
 @@ -30,8 +30,8 @@
  #ifndef __ZMQ_MSG_HPP_INCLUDE__
  #define __ZMQ_MSG_HPP_INCLUDE__
- 
+
 -#include <stddef.h>
 -#include <stdio.h>
 +#include <cstddef>
 +#include <cstdio>
- 
+
  #include "config.hpp"
  #include "err.hpp"
 --- a/src/options.hpp
@@ -79,14 +68,25 @@
      static_assert (std::is_trivially_copyable<T>::value,
                     "invalid use of do_getsockopt");
  #endif
+--- a/src/ctx.cpp
++++ b/src/ctx.cpp
+@@ -725,7 +725,7 @@ void zmq::ctx_t::unregister_endpoints (c
+                                end = _endpoints.end ();
+          it != end;) {
+         if (it->second.socket == socket_)
+-#if __cplusplus >= 201103L || (defined _MSC_VER && _MSC_VER >= 1700)
++#if (__cplusplus >= 201103L || (defined _MSC_VER && _MSC_VER >= 1700)) && !defined(__UCLIBCXX_MAJOR__)
+             it = _endpoints.erase (it);
+ #else
+             _endpoints.erase (it++);
 --- a/src/radio.cpp
 +++ b/src/radio.cpp
-@@ -126,7 +126,7 @@ void zmq::radio_t::xpipe_terminated (pipe_t *pipe_)
+@@ -126,7 +126,7 @@ void zmq::radio_t::xpipe_terminated (pip
                                     end = _subscriptions.end ();
           it != end;) {
          if (it->second == pipe_) {
--#if __cplusplus >= 201103L
-+#if __cplusplus >= 201103L && !defined(__UCLIBCXX_MAJOR__)
+-#if __cplusplus >= 201103L || (defined _MSC_VER && _MSC_VER >= 1700)
++#if (__cplusplus >= 201103L || (defined _MSC_VER && _MSC_VER >= 1700)) && !defined(__UCLIBCXX_MAJOR__)
              it = _subscriptions.erase (it);
  #else
              _subscriptions.erase (it++);


### PR DESCRIPTION
maintainer: @srdgame 
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates zmq to version 4.3.3. It fixes [CVE-2020-15166](https://nvd.nist.gov/vuln/detail/CVE-2020-15166) and multiple other issues see [Changelog](https://github.com/zeromq/libzmq/releases/tag/v4.3.3)

Run tested with internal tests (https://github.com/zeromq/libzmq/tree/master/tests) 

This should be also backported to **OpenWrt 19.07**

