### PR TITLE
youtube-dl: update to version 2020.9.14

### DIFF
--- a/multimedia/youtube-dl/Makefile
+++ b/multimedia/youtube-dl/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=youtube-dl
-PKG_VERSION:=2020.9.6
+PKG_VERSION:=2020.9.14
 PKG_RELEASE:=1
 
 PYPI_NAME:=youtube_dl
-PKG_HASH:=eced5195e3264c36d2d62610bf235f75b592d5bb2f8ac424fd8da54ee426cd75
+PKG_HASH:=fdd7e328c6f23e83f331490293dc8fb4d4ca07eaf22b895d51021541abcc4236
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Unlicense


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
- update to version [2020.9.14](https://github.com/ytdl-org/youtube-dl/releases/tag/2020.09.14)