### PR TITLE
kea: update package to 1.8.0

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kea
-PKG_VERSION:=1.6.2
+PKG_VERSION:=1.8.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.isc.org/isc/kea/$(PKG_VERSION)
-PKG_HASH:=2af7336027143c3e98d8d1d44165b2c2cbb0252a92bd88f6dd4d2c6adb69d7b5
+PKG_HASH:=3d91106fba3698194fb80da4149af709c7b2e89881311522816e561fca0ec0ea
 
 PKG_MAINTAINER:=BangLang Huang<banglang.huang@foxmail.com>, Rosy Song<rosysong@rosinson.com>
 PKG_LICENSE:=MPL-2.0
@@ -144,11 +144,21 @@ DHCPv4 and DHCPv6 server performance.
 endef
 
 ###### *************************************************************************
+define Package/kea-shell
+	$(call Package/kea/Default)
+	TITLE+=shell
+	DEPENDS:=+kea-libs
+endef
+define Package/kea-shell/description
+     This simple text client uses the REST interface to connect to the Kea
+Control Agent.
+endef
+
+###### *************************************************************************
 HOST_CONFIGURE_ARGS += \
 	--with-boost-include="$(STAGING_DIR_HOSTPKG)" \
 	--with-log4cplus="$(STAGING_DIR_HOSTPKG)" \
 	--with-openssl="$(STAGING_DIR_HOST)" \
-	--enable-boost-headers-only \
 	--enable-generate-messages
 
 HOST_LDFLAGS += \
@@ -159,7 +169,8 @@ CONFIGURE_ARGS += \
 	--with-log4cplus="$(STAGING_DIR)/usr" \
 	--with-openssl="$(STAGING_DIR)/usr" \
 	--without-pic \
-	$(if $(CONFIG_PACKAGE_kea-perfdhcp),--enable-perfdhcp,)
+	$(if $(CONFIG_PACKAGE_kea-perfdhcp),--enable-perfdhcp,) \
+	$(if $(CONFIG_PACKAGE_kea-shell),--enable-shell,)
 
 CONFIGURE_VARS += \
 	cross_compiling="yes"
@@ -241,6 +252,11 @@ define Package/kea-perfdhcp/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/perfdhcp $(1)/usr/sbin/perfdhcp
 endef
 
+define Package/kea-shell/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/kea-shell $(1)/usr/sbin/kea-shell
+endef
+
 $(eval $(call HostBuild))
 $(eval $(call BuildPackage,kea-libs))
 $(eval $(call BuildPackage,kea-ctrl))
@@ -250,3 +266,4 @@ $(eval $(call BuildPackage,kea-dhcp-ddns))
 $(eval $(call BuildPackage,kea-admin))
 $(eval $(call BuildPackage,kea-lfc))
 $(eval $(call BuildPackage,kea-perfdhcp))
+$(eval $(call BuildPackage,kea-shell))

--- a/net/kea/patches/003-no-test-compile.patch
+++ b/net/kea/patches/003-no-test-compile.patch
@@ -81,8 +81,8 @@
 --- a/src/hooks/dhcp/high_availability/Makefile.am
 +++ b/src/hooks/dhcp/high_availability/Makefile.am
 @@ -1,4 +1,4 @@
--SUBDIRS = . tests
-+SUBDIRS = .
+-SUBDIRS = . libloadtests tests
++SUBDIRS = . libloadtests
 
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
@@ -303,19 +303,11 @@
 @@ -1,6 +1,6 @@
  AUTOMAKE_OPTIONS = subdir-objects
 
--SUBDIRS = . io unittests tests python threads
-+SUBDIRS = . io python threads
+-SUBDIRS = . io unittests tests python
++SUBDIRS = . io unittests python
 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
---- a/src/lib/util/threads/Makefile.am
-+++ b/src/lib/util/threads/Makefile.am
-@@ -1,4 +1,4 @@
--SUBDIRS = . tests
-+SUBDIRS = .
- AM_CXXFLAGS = $(KEA_CXXFLAGS)
-
- AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
 --- a/src/lib/yang/Makefile.am
 +++ b/src/lib/yang/Makefile.am
 @@ -1,4 +1,4 @@

--- a/net/kea/patches/004-replace-rev-with-awk.patch
+++ b/net/kea/patches/004-replace-rev-with-awk.patch
@@ -1,0 +1,11 @@
+--- a/src/bin/keactrl/keactrl.in
++++ b/src/bin/keactrl/keactrl.in
+@@ -98,7 +98,7 @@ get_pid_from_file() {
+     # Extract the name portion (from last slash to last dot) of the config file name
+     # File name and extension are documented in src/lib/util/filename.h
+     local conf_name
+-    conf_name=$(basename -- "${kea_config_file}" | rev | cut -f2- -d'.' | rev)
++    conf_name=$(basename -- "${kea_config_file}" | awk '{for(i=length($0); i>0;i--) printf (substr($0,i,1));}' | cut -f2- -d'.' | awk '{for(i=length($0); i>0;i--) printf (substr($0,i,1));}')
+
+     # Default the directory to --localstatedir / run
+     local pid_file_dir


### PR DESCRIPTION
Maintainer:BangLang Huang<banglang.huang@foxmail.com>, Rosy Song<rosysong@rosinson.com>
Compile tested: Latest OpenWRT master ARM
Run tested: Latest OpenWRT master ARM

Description:

Update kea to the latest stable version (1.8.0) and add kea-shell 
package.
Signed-off-by: Tiago Gaspar <tiagogaspar8@gmail.com>

PS: For some reason after boot this appeared in the syslog, but everything is working fine.

```
Tue Sep 15 23:12:39 2020 daemon.notice procd: /etc/rc.d/S95done: /usr/sbin/keactrl: line 101: rev: not found
Tue Sep 15 23:12:39 2020 daemon.notice procd: /etc/rc.d/S95done: /usr/sbin/keactrl: line 101: rev: not found
Tue Sep 15 23:12:39 2020 daemon.notice procd: /etc/rc.d/S95done: INFO/keactrl: Starting /usr/sbin/kea-dhcp4 -c /etc/kea/kea-dhcp4.conf
Tue Sep 15 23:12:39 2020 daemon.notice procd: /etc/rc.d/S95done: /usr/sbin/keactrl: line 101: rev: not found
Tue Sep 15 23:12:39 2020 daemon.notice procd: /etc/rc.d/S95done: /usr/sbin/keactrl: line 101: rev: not found
Tue Sep 15 23:12:39 2020 daemon.notice procd: /etc/rc.d/S95done: INFO/keactrl: Starting /usr/sbin/kea-dhcp6 -c /etc/kea/kea-dhcp6.conf
Tue Sep 15 23:12:39 2020 daemon.notice procd: /etc/rc.d/S95done: /usr/sbin/keactrl: line 101: rev: not found
Tue Sep 15 23:12:39 2020 daemon.notice procd: /etc/rc.d/S95done: /usr/sbin/keactrl: line 101: rev: not found
Tue Sep 15 23:12:39 2020 daemon.notice procd: /etc/rc.d/S95done: INFO/keactrl: Starting /usr/sbin/kea-dhcp-ddns -c /etc/kea/kea-dhcp-ddns.conf
```
UPDATE 1: This proved to be deadly, I'll try to pind out where these errors came from, as soon as I find it I'll give an update. If anyone has any Idea please enlighten me.

UPDATE 2: I have no idea what's wrong, maybe a missing dependency? this is an output example of the error:
```
root@OpenWrt:~# keactrl status
/usr/sbin/keactrl: line 101: rev: not found
/usr/sbin/keactrl: line 101: rev: not found
DHCPv4 server: inactive
/usr/sbin/keactrl: line 101: rev: not found
/usr/sbin/keactrl: line 101: rev: not found
DHCPv6 server: inactive
/usr/sbin/keactrl: line 101: rev: not found
/usr/sbin/keactrl: line 101: rev: not found
DHCP DDNS: inactive
/usr/sbin/keactrl: line 101: rev: not found
/usr/sbin/keactrl: line 101: rev: not found
Control Agent: inactive
```