### PR TITLE
node: update to v12.18.4

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v12.18.3
+PKG_VERSION:=v12.18.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=71158026579487422fd13cc2553b34cddb76519098aa6030faab52f88c6e0d0e
+PKG_HASH:=25f03cb18e53b6d0959d0c219e701a85eb4693f526bdda7c72bc6199b364f609
 
 PKG_MAINTAINER:=John Crispin <blogic@openwrt.org>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/999-localhost-no-addrconfig.patch
+++ b/lang/node/patches/999-localhost-no-addrconfig.patch
@@ -1,0 +1,29 @@
+Description: do not use dns.ADDRCONFIG for localhost
+ it fails on IPv6-only systems. Setting it with libc fails on linux.
+ https://github.com/nodejs/node/issues/33279
+Author: Jérémy Lal <kapouer@melix.org>
+Last-Update: 2020-06-11
+Bug-Debian: https://bugs.debian.org/962318
+Forwarded: https://github.com/nodejs/node/issues/33816
+--- a/lib/net.js
++++ b/lib/net.js
+@@ -1,4 +1,5 @@
+ // Copyright Joyent, Inc. and other Node contributors.
++
+ //
+ // Permission is hereby granted, free of charge, to any person obtaining a
+ // copy of this software and associated documentation files (the
+@@ -1028,13 +1029,6 @@
+     hints: options.hints || 0
+   };
+ 
+-  if (!isWindows &&
+-      dnsopts.family !== 4 &&
+-      dnsopts.family !== 6 &&
+-      dnsopts.hints === 0) {
+-    dnsopts.hints = dns.ADDRCONFIG;
+-  }
+-
+   debug('connect: find host', host);
+   debug('connect: dns options', dnsopts);
+   self._host = host;

--- a/lang/node/patches/999-mips-fix.patch
+++ b/lang/node/patches/999-mips-fix.patch
@@ -1,0 +1,210 @@
+Description: upstream mips fix
+Origin: https://github.com/nodejs/node/issues/31118
+Last-Update: 2020-05-30
+
+--- a/deps/v8/AUTHORS
++++ b/deps/v8/AUTHORS
+@@ -106,6 +106,7 @@
+ James M Snell <jasnell@gmail.com>
+ Jianghua Yang <jianghua.yjh@alibaba-inc.com>
+ Jiawen Geng <technicalcute@gmail.com>
++Jiaxun Yang <jiaxun.yang@flygoat.com>
+ Joel Stanley <joel@jms.id.au>
+ Johan Bergström <johan@bergstroem.nu>
+ Jonathan Liu <net147@gmail.com>
+--- a/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-aix.cc
++++ b/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-aix.cc
+@@ -94,10 +94,6 @@
+ 
+ void PlatformEmbeddedFileWriterAIX::DeclareFunctionEnd(const char* name) {}
+ 
+-int PlatformEmbeddedFileWriterAIX::HexLiteral(uint64_t value) {
+-  return fprintf(fp_, "0x%" PRIx64, value);
+-}
+-
+ void PlatformEmbeddedFileWriterAIX::FilePrologue() {}
+ 
+ void PlatformEmbeddedFileWriterAIX::DeclareExternalFilename(
+@@ -120,12 +116,6 @@
+   return kLong;
+ }
+ 
+-int PlatformEmbeddedFileWriterAIX::WriteByteChunk(const uint8_t* data) {
+-  DCHECK_EQ(ByteChunkDataDirective(), kLong);
+-  const uint32_t* long_ptr = reinterpret_cast<const uint32_t*>(data);
+-  return HexLiteral(*long_ptr);
+-}
+-
+ #undef SYMBOL_PREFIX
+ 
+ }  // namespace internal
+--- a/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-aix.h
++++ b/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-aix.h
+@@ -37,8 +37,6 @@
+   void DeclareFunctionBegin(const char* name) override;
+   void DeclareFunctionEnd(const char* name) override;
+ 
+-  int HexLiteral(uint64_t value) override;
+-
+   void Comment(const char* string) override;
+ 
+   void FilePrologue() override;
+@@ -48,7 +46,6 @@
+   int IndentedDataDirective(DataDirective directive) override;
+ 
+   DataDirective ByteChunkDataDirective() const override;
+-  int WriteByteChunk(const uint8_t* data) override;
+ 
+  private:
+   void DeclareSymbolGlobal(const char* name);
+--- a/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-base.cc
++++ b/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-base.cc
+@@ -24,6 +24,10 @@
+   }
+ }
+ 
++int PlatformEmbeddedFileWriterBase::HexLiteral(uint64_t value) {
++  return fprintf(fp_, "0x%" PRIx64, value);
++}
++
+ int DataDirectiveSize(DataDirective directive) {
+   switch (directive) {
+     case kByte:
+@@ -39,24 +43,37 @@
+ }
+ 
+ int PlatformEmbeddedFileWriterBase::WriteByteChunk(const uint8_t* data) {
+-  DCHECK_EQ(ByteChunkDataDirective(), kOcta);
+-
+-  static constexpr size_t kSize = kInt64Size;
+-
+-  uint64_t part1, part2;
+-  // Use memcpy for the reads since {data} is not guaranteed to be aligned.
++  size_t kSize = DataDirectiveSize(ByteChunkDataDirective());
++  size_t kHalfSize = kSize / 2;
++  uint64_t high = 0, low = 0;
++
++  switch (kSize) {
++    case 1:
++      low = *data;
++      break;
++    case 4:
++      low = *reinterpret_cast<const uint32_t*>(data);
++      break;
++    case 8:
++      low = *reinterpret_cast<const uint64_t*>(data);
++      break;
++    case 16:
+ #ifdef V8_TARGET_BIG_ENDIAN
+-  memcpy(&part1, data, kSize);
+-  memcpy(&part2, data + kSize, kSize);
++      memcpy(&high, data, kHalfSize);
++      memcpy(&low, data + kHalfSize, kHalfSize);
+ #else
+-  memcpy(&part1, data + kSize, kSize);
+-  memcpy(&part2, data, kSize);
++      memcpy(&high, data + kHalfSize, kHalfSize);
++      memcpy(&low, data, kHalfSize);
+ #endif  // V8_TARGET_BIG_ENDIAN
++      break;
++    default:
++      UNREACHABLE();
++  }
+ 
+-  if (part1 != 0) {
+-    return fprintf(fp(), "0x%" PRIx64 "%016" PRIx64, part1, part2);
++  if (high != 0) {
++    return fprintf(fp(), "0x%" PRIx64 "%016" PRIx64, high, low);
+   } else {
+-    return fprintf(fp(), "0x%" PRIx64, part2);
++    return fprintf(fp(), "0x%" PRIx64, low);
+   }
+ }
+ 
+--- a/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-base.h
++++ b/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-base.h
+@@ -67,7 +67,7 @@
+   virtual void DeclareFunctionEnd(const char* name) = 0;
+ 
+   // Returns the number of printed characters.
+-  virtual int HexLiteral(uint64_t value) = 0;
++  virtual int HexLiteral(uint64_t value);
+ 
+   virtual void Comment(const char* string) = 0;
+   virtual void Newline() { fprintf(fp_, "\n"); }
+--- a/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-generic.cc
++++ b/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-generic.cc
+@@ -112,10 +112,6 @@
+ 
+ void PlatformEmbeddedFileWriterGeneric::DeclareFunctionEnd(const char* name) {}
+ 
+-int PlatformEmbeddedFileWriterGeneric::HexLiteral(uint64_t value) {
+-  return fprintf(fp_, "0x%" PRIx64, value);
+-}
+-
+ void PlatformEmbeddedFileWriterGeneric::FilePrologue() {}
+ 
+ void PlatformEmbeddedFileWriterGeneric::DeclareExternalFilename(
+@@ -142,6 +138,18 @@
+   return fprintf(fp_, "  %s ", DirectiveAsString(directive));
+ }
+ 
++DataDirective PlatformEmbeddedFileWriterGeneric::ByteChunkDataDirective()
++    const {
++#if defined(V8_TARGET_ARCH_MIPS) || defined(V8_TARGET_ARCH_MIPS64)
++  // MIPS uses a fixed 4 byte instruction set, using .long
++  // to prevent any unnecessary padding.
++  return kLong;
++#else
++  // Other ISAs just listen to the base
++  return PlatformEmbeddedFileWriterBase::ByteChunkDataDirective();
++#endif
++}
++
+ #undef SYMBOL_PREFIX
+ 
+ }  // namespace internal
+--- a/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-generic.h
++++ b/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-generic.h
+@@ -39,8 +39,6 @@
+   void DeclareFunctionBegin(const char* name) override;
+   void DeclareFunctionEnd(const char* name) override;
+ 
+-  int HexLiteral(uint64_t value) override;
+-
+   void Comment(const char* string) override;
+ 
+   void FilePrologue() override;
+@@ -49,6 +47,8 @@
+ 
+   int IndentedDataDirective(DataDirective directive) override;
+ 
++  DataDirective ByteChunkDataDirective() const override;
++
+  private:
+   void DeclareSymbolGlobal(const char* name);
+ 
+--- a/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-mac.cc
++++ b/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-mac.cc
+@@ -87,10 +87,6 @@
+ 
+ void PlatformEmbeddedFileWriterMac::DeclareFunctionEnd(const char* name) {}
+ 
+-int PlatformEmbeddedFileWriterMac::HexLiteral(uint64_t value) {
+-  return fprintf(fp_, "0x%" PRIx64, value);
+-}
+-
+ void PlatformEmbeddedFileWriterMac::FilePrologue() {}
+ 
+ void PlatformEmbeddedFileWriterMac::DeclareExternalFilename(
+--- a/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-mac.h
++++ b/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-mac.h
+@@ -37,8 +37,6 @@
+   void DeclareFunctionBegin(const char* name) override;
+   void DeclareFunctionEnd(const char* name) override;
+ 
+-  int HexLiteral(uint64_t value) override;
+-
+   void Comment(const char* string) override;
+ 
+   void FilePrologue() override;

--- a/lang/node/patches/999-mips-less-memory.patch
+++ b/lang/node/patches/999-mips-less-memory.patch
@@ -1,0 +1,26 @@
+Description: mksnapshot uses too much memory on 32-bit mipsel
+Author: Jérémy Lal <kapouer@melix.org>
+Last-Update: 2020-06-03
+Forwarded: https://bugs.chromium.org/p/v8/issues/detail?id=10586
+--- a/deps/v8/src/common/globals.h
++++ b/deps/v8/src/common/globals.h
+@@ -206,7 +206,7 @@
+ constexpr size_t kMinExpectedOSPageSize = 64 * KB;  // OS page on PPC Linux
+ #elif V8_TARGET_ARCH_MIPS
+ constexpr bool kRequiresCodeRange = false;
+-constexpr size_t kMaximalCodeRangeSize = 2048LL * MB;
++constexpr size_t kMaximalCodeRangeSize = 512 * MB;
+ constexpr size_t kMinimumCodeRangeSize = 0 * MB;
+ constexpr size_t kMinExpectedOSPageSize = 4 * KB;  // OS page.
+ #else
+--- a/deps/v8/src/codegen/mips/constants-mips.h
++++ b/deps/v8/src/codegen/mips/constants-mips.h
+@@ -137,7 +137,7 @@
+ namespace v8 {
+ namespace internal {
+ 
+-constexpr size_t kMaxPCRelativeCodeRangeInMB = 4096;
++constexpr size_t kMaxPCRelativeCodeRangeInMB = 1024;
+ 
+ // -----------------------------------------------------------------------------
+ // Registers and FPURegisters.

--- a/lang/node/patches/999-v8_this_build_method_will_be_deprecated.patch
+++ b/lang/node/patches/999-v8_this_build_method_will_be_deprecated.patch
@@ -1,7 +1,7 @@
 diff -urN a/configure.py b/configure.py
 --- a/configure.py	2019-09-05 00:36:21.000000000 +0900
 +++ b/configure.py	2019-09-27 11:49:55.445800884 +0900
-@@ -1276,6 +1276,23 @@
+@@ -1276,6 +1276,15 @@
      options.build_v8_with_gn = FetchDeps(v8_path)
    o['variables']['build_v8_with_gn'] = b(options.build_v8_with_gn)
  
@@ -14,14 +14,6 @@ diff -urN a/configure.py b/configure.py
 +
 +  if target_arch in ('mips', 'mips64'):
 +    o['variables']['v8_use_snapshot'] = 'false'
-+  elif target_arch in ('mipsel', 'mips64el'):
-+    o['variables']['v8_enable_embedded_builtins'] = 0
-+  elif target_arch == 'x64':
-+    if options.with_intl not in (None, 'none'):
-+      o['variables']['v8_enable_embedded_builtins'] = 0
-+  elif target_arch == 'ia32':
-+    if options.with_intl in (None, 'none'):
-+      o['variables']['v8_use_snapshot'] = 'false'
  
  def configure_openssl(o):
    variables = o['variables']


### PR DESCRIPTION
Maintainer: @blogic @ianchi 
Compile tested: head r14475-4a32306, aarch64, arm, i386, mips, mips64, mips64el, mipsel, x86_64 
Run tested: (qemu 5.1.0) aarch64, arm, i386, mips, mips64, mips64el, mipsel, x86_64

Description:
 Vulnerabilities fixed:
* CVE-2020-8201: HTTP Request Smuggling due to CR-to-Hyphen conversion (High).
* CVE-2020-8252: fs.realpath.native on may cause buffer overflow (Medium).

Imported patches from the debian package.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
