### PR TITLE
zmq: enable libbsd by default

### DIFF
--- a/libs/zmq/Makefile
+++ b/libs/zmq/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zeromq
 PKG_VERSION:=4.3.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/zeromq/libzmq/releases/download/v$(PKG_VERSION)
@@ -33,7 +33,7 @@ define Package/libzmq/default
   URL:=http://www.zeromq.org/
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libuuid +libpthread +librt +libstdcpp
+  DEPENDS:=+libuuid +libpthread +librt +libstdcpp +libbsd
   PROVIDES:=libzmq
 endef
 
@@ -71,6 +71,7 @@ CMAKE_OPTIONS += \
 	-DZMQ_HAVE_TCP_KEEPALIVE=ON \
 	-DENABLE_CURVE=ON \
 	-DENABLE_EVENTFD=ON \
+	-DWITH_LIBBSD=ON \
 	-DPOLLER=epoll \
 	-DPYTHON_EXECUTABLE=OFF \
 	-DRT_LIBRARY=OFF \


### PR DESCRIPTION
maintainer: @srdgame 
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR enables libbsd and adds it to dependency.  This suppresses libbsd autodetection.

Related to https://github.com/openwrt/packages/pull/13398
