### PR TITLE
prometheus: add runtime test

### DIFF
--- a/utils/prometheus/test.sh
+++ b/utils/prometheus/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+prometheus --version 2>&1 | grep "${2%%-*}"


### PR DESCRIPTION
Maintainer: me
Compile tested: CI
Run tested: CI

Description:
Run trivial check if the compiled binary works on the architecture. Do
so by comparing the printed version by the binary with the Makefile
version. The release is OpenWrt specific, so cut it off.

Signed-off-by: Paul Spooren <mail@aparcar.org>