### PR TITLE
CI: simplify runtime test version check

### DIFF
--- a/.github/workflows/entrypoint.sh
+++ b/.github/workflows/entrypoint.sh
@@ -6,8 +6,10 @@ opkg update
 
 for PKG in /ci/*.ipk; do
 	tar -xzOf "$PKG" ./control.tar.gz | tar xzf - ./control 
+	# package name including variant
 	PKG_NAME=$(sed -ne 's#^Package: \(.*\)$#\1#p' ./control)
-	PKG_VERSION=$(sed -ne 's#^Version: \(.*\)$#\1#p' ./control)
+	# package version without release
+	PKG_VERSION=$(sed -ne 's#^Version: \(.*\)-[0-9]*$#\1#p' ./control)
 
 	echo "Testing package $PKG_NAME ($PKG_VERSION)"
 

--- a/utils/prometheus/test.sh
+++ b/utils/prometheus/test.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-prometheus --version 2>&1 | grep "${2%%-*}"
+prometheus --version 2>&1 | grep "$2"

--- a/utils/syncthing/test.sh
+++ b/utils/syncthing/test.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-syncthing --version | grep "${2%%-*}"
+syncthing --version | grep "$2"


### PR DESCRIPTION
The version check is the most simple runtime check possible. By adding a `grep` after the version output it is possible to check that the compiled binary actually changed and loaded up correctly.