### PR TITLE
atftp: add init script and config file for atftpd

### DIFF
--- a/net/atftp/Makefile
+++ b/net/atftp/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=atftp
 PKG_VERSION:=0.7.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
@@ -53,6 +53,11 @@ endef
 
 define Package/atftpd/install
 	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/atftpd.init $(1)/etc/init.d/atftpd
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_BIN) ./files/atftpd.conf $(1)/etc/config/atftpd
+	$(INSTALL_DIR) $(1)/srv/tftp
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)//usr/sbin/atftpd $(1)/usr/sbin/
 endef

--- a/net/atftp/files/atftpd.conf
+++ b/net/atftp/files/atftpd.conf
@@ -1,0 +1,3 @@
+
+config service 'service'
+	option path '/srv/tftp'

--- a/net/atftp/files/atftpd.init
+++ b/net/atftp/files/atftpd.init
@@ -1,0 +1,17 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2020 OpenWrt.org
+
+START=95
+PIDFILE=/tmp/run/atftpd.pid
+
+start() {
+	config_load atftpd
+	config_get SRV service path "/srv/tftp"
+	config_get PORT service port 69
+
+	atftpd --pidfile $PIDFILE --user root.root --port $PORT --daemon $SRV
+}
+
+stop() {
+	kill $(cat $PIDFILE)
+}

--- a/net/atftp/test.sh
+++ b/net/atftp/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+"$1" --version 2>&1 | grep "$2"


### PR DESCRIPTION
Signed-off-by: Russell Senior <russell@personaltelco.net>

Maintainer: Daniel Danzberger / @dddaniel
Compile tested: ramips, Ubiquiti EdgeRouter X, reboot-14485-g4a46f36f99
Run tested: ramips, Ubiquiti EdgeRouter X, reboot-14485-g4a46f36f99, checked that it starts

Description: the server package, atftpd, currently lacks an init script. Added one, along with a config file. atftpd likes to run as a daemon and complained when attempting to run in foreground, so my initial efforts to implement a procd-style init script failed.
