### PR TITLE
ttyd: fix compilation under glibc

### DIFF
--- a/utils/ttyd/Makefile
+++ b/utils/ttyd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ttyd
 PKG_VERSION:=1.6.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tsl0922/ttyd/tar.gz/$(PKG_VERSION)?
@@ -40,6 +40,8 @@ endef
 define Package/ttyd/conffiles
 /etc/config/ttyd
 endef
+
+TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-ldl)
 
 define Package/ttyd/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tsl0922 

Continuation of : https://github.com/openwrt/packages/pull/12222

I'll try to compile this when I can.

@tsl0922 do you know why the original user tried building against libdl? I don't see any dl function usage in the codebase.