### PR TITLE
perl-parse-yapp: fix compilation under the CI

### DIFF
--- a/.github/workflows/entrypoint.sh
+++ b/.github/workflows/entrypoint.sh
@@ -28,5 +28,5 @@ for PKG in /ci/*.ipk; do
 		echo "No test.sh script available"
 	fi
 
-	opkg remove "$PKG_NAME"
+	opkg remove "$PKG_NAME" --force-removal-of-dependent-packages --force-remove
 done

--- a/lang/perl-parse-yapp/Makefile
+++ b/lang/perl-parse-yapp/Makefile
@@ -24,7 +24,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/perl/Parse-Yapp-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
-include $(TOPDIR)/feeds/packages/lang/perl/perlmod.mk
+include ../perl/perlmod.mk
 
 define Package/perl-parse-yapp
   SUBMENU:=Perl


### PR DESCRIPTION
Wrong path to perlmod.mk. Use what everything else uses.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Andy2244 

```
git grep perlmod.mk
perl-authen-sasl-xs/Makefile:include ../perl/perlmod.mk
perl-authen-sasl/Makefile:include ../perl/perlmod.mk
perl-cgi/Makefile:include ../perl/perlmod.mk
perl-compress-bzip2/Makefile:include ../perl/perlmod.mk
perl-dbi/Makefile:include ../perl/perlmod.mk
perl-device-serialport/Makefile:include ../perl/perlmod.mk
perl-device-usb/Makefile:include ../perl/perlmod.mk
perl-encode-locale/Makefile:include ../perl/perlmod.mk
perl-file-listing/Makefile:include ../perl/perlmod.mk
perl-file-rsyncp/Makefile:include ../perl/perlmod.mk
perl-file-sharedir-install/Makefile:include ../perl/perlmod.mk
perl-html-form/Makefile:include ../perl/perlmod.mk
perl-html-parser/Makefile:include ../perl/perlmod.mk
perl-html-tagset/Makefile:include ../perl/perlmod.mk
perl-html-tree/Makefile:include ../perl/perlmod.mk
perl-http-cookies/Makefile:include ../perl/perlmod.mk
perl-http-daemon/Makefile:include ../perl/perlmod.mk
perl-http-date/Makefile:include ../perl/perlmod.mk
perl-http-message/Makefile:include ../perl/perlmod.mk
perl-http-negotiate/Makefile:include ../perl/perlmod.mk
perl-http-server-simple/Makefile:include ../perl/perlmod.mk
perl-inline-c/Makefile:include ../perl/perlmod.mk
perl-inline/Makefile:include ../perl/perlmod.mk
perl-io-html/Makefile:include ../perl/perlmod.mk
perl-lockfile-simple/Makefile:include ../perl/perlmod.mk
perl-lwp-mediatypes/Makefile:include ../perl/perlmod.mk
perl-net-cidr-lite/Makefile:include ../perl/perlmod.mk
perl-net-http/Makefile:include ../perl/perlmod.mk
perl-net-telnet/Makefile:include ../perl/perlmod.mk
perl-parse-recdescent/Makefile:include ../perl/perlmod.mk
perl-parse-yapp/Makefile:include $(TOPDIR)/feeds/packages/lang/perl/perlmod.mk
perl-sub-uplevel/Makefile:include ../perl/perlmod.mk
perl-test-harness/Makefile:include ../perl/perlmod.mk
perl-test-warn/Makefile:include ../perl/perlmod.mk
perl-text-csv_xs/Makefile:include ../perl/perlmod.mk
perl-uri/Makefile:include ../perl/perlmod.mk
perl-www-curl/Makefile:include ../perl/perlmod.mk
perl-www-mechanize/Makefile:include ../perl/perlmod.mk
perl-www-robotrules/Makefile:include ../perl/perlmod.mk
perl-www/Makefile:include ../perl/perlmod.mk
perl-xml-parser/Makefile:include ../perl/perlmod.mk
perl/Makefile:include perlmod.mk
```

```
2020-09-18T21:17:17.4521588Z ERROR: please fix feeds/packages_ci/lang/perl-parse-yapp/Makefile - see logs/feeds/packages_ci/lang/perl-parse-yapp/dump.txt for details
```

```
Build-Depends/host: perl/host
Build-Types: host

Package: perl-parse-yapp
Submenu: Perl
Version: 1.21-1
Depends: +libc +USE_GLIBC:librt +USE_GLIBC:libpthread perl +perlbase-essential +perlbase-test
Conflicts: 
Menu-Depends: 
Provides: 
Section: lang
Category: Languages
Repository: base
Title: Yet Another Parser Parser For Perl
Maintainer: Andy Walsh <andy.walsh44+github@gmail.com>
Source: Parse-Yapp-1.21.tar.gz
License: GPL-1.0-or-later Artistic-1.0-Perl
Type: ipkg
Description: Yet Another Parser Parser For Perl
http://search.cpan.org/dist/Parse-Yapp/
Andy Walsh <andy.walsh44+github@gmail.com>
@@

Makefile:27: /home/build/openwrt/feeds/packages/lang/perl/perlmod.mk: No such file or directory
make[1]: *** No rule to make target '/home/build/openwrt/feeds/packages/lang/perl/perlmod.mk'.  Stop.
```