### PR TITLE
imagemagick: do not use flto under GCC10

### DIFF
--- a/multimedia/imagemagick/Makefile
+++ b/multimedia/imagemagick/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=imagemagick
 PKG_VERSION:=7.0.9
 PKG_REVISION:=5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Val Kulkov <val.kulkov@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_REVISION).tar.gz
@@ -109,7 +109,7 @@ CONFIGURE_ARGS += \
 	--with-png \
 	--with-tiff
 
-TARGET_CFLAGS += -flto
+TARGET_CFLAGS += $(if $(CONFIG_GCC_USE_VERSION_10),,-flto)
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
Causes compilation failure.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @val-kulkov 
Compile tested: ath79

Fixes: https://github.com/openwrt/packages/issues/12805