### PR TITLE
gateway-go: add default config and gateway-go.int for background service

### DIFF
--- a/net/gateway-go/Makefile
+++ b/net/gateway-go/Makefile
@@ -40,5 +40,16 @@ define Package/gateway-go/description
   gateway-go is GateWay Client for OpenIoTHub.
 endef
 
+define Package/gateway-go/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gateway-go $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/gateway-go/
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/gateway-go.yaml $(1)/etc/gateway-go/
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/gateway-go.init $(1)/etc/init.d/gateway-go
+endef
+
 $(eval $(call GoBinPackage,gateway-go))
 $(eval $(call BuildPackage,gateway-go))

--- a/net/gateway-go/files/gateway-go.init
+++ b/net/gateway-go/files/gateway-go.init
@@ -1,0 +1,19 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+
+CFGFILE=/etc/gateway-go/gateway-go.yaml
+
+APP=gateway-go
+
+start() {
+	service_start /usr/bin/$APP -c $CFGFILE
+}
+
+stop() {
+	service_stop /usr/bin/$APP
+}
+
+reload() {
+	service_reload /usr/bin/$APP
+}


### PR DESCRIPTION
Signed-off-by: Yu Fang <newfarry@126.com>

Maintainer: me
Compile tested: x86-64, OpenWrt master
Run tested: x86-64, OpenWrt master

Description:
add default config and gateway-go.int for background service