### PR TITLE
ratched: add new package

### DIFF
--- a/net/ratched/Makefile
+++ b/net/ratched/Makefile
@@ -1,0 +1,37 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ratched
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Toni Uhlig <matzeton@googlemail.com>
+PKG_LICENSE:=GPL-3.0-only
+
+PKG_SOURCE_URL:=https://github.com/johndoe31415/ratched.git
+PKG_SOURCE_VERSION:=091d000ba91c5ebc41148cb9b511a4b527c1ea44
+PKG_SOURCE_PROTO:=git
+PKG_MIRROR_HASH:=67c8ff1a54af34181d8467803e18c709d06fd20929b6fdbba68700af88de71aa
+
+include $(INCLUDE_DIR)/package.mk
+
+MAKE_FLAGS+=CFLAGS='$(TARGET_CFLAGS) -DBUILD_TIMESTAMP_UTC="\"unknown\"" -DBUILD_REVISION="\"$(PKG_VERSION)-$(PKG_RELEASE)\""'
+MAKE_FLAGS+=LDFLAGS='$(TARGET_LDFLAGS) -lssl -lcrypto $(if $(CONFIG_USE_GLIBC),-lpthread)'
+
+define Package/ratched
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=ratched
+  URL:=https://github.com/johndoe31415/ratched
+  DEPENDS:=+libopenssl +libpthread
+endef
+
+define Package/ratched/description
+  Ratched is a transparent Man-in-the-Middle TLS proxy intended for penetration testing.
+endef
+
+define Package/ratched/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ratched $(1)/usr/bin/ratched
+endef
+
+$(eval $(call BuildPackage,ratched))

--- a/net/ratched/patches/0001-Disable-non-IANA-TLS-extensions.patch
+++ b/net/ratched/patches/0001-Disable-non-IANA-TLS-extensions.patch
@@ -1,0 +1,27 @@
+From 70cef63e0c0ec15016cf7c52d5183ed864cc50c4 Mon Sep 17 00:00:00 2001
+From: Toni Uhlig <matzeton@googlemail.com>
+Date: Sun, 20 Sep 2020 13:58:05 +0200
+Subject: [PATCH] Disable non IANA TLS extensions.
+
+Signed-off-by: Toni Uhlig <matzeton@googlemail.com>
+---
+ openssl_clienthello.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/openssl_clienthello.c b/openssl_clienthello.c
+index 559db56..6ecabcb 100644
+--- a/openssl_clienthello.c
++++ b/openssl_clienthello.c
+@@ -93,7 +93,9 @@ static struct lookup_table_element_t known_extensions[] = {
+ 	ELEMENT(TLSEXT_TYPE_certificate_authorities),
+ #endif
+ 	ELEMENT(TLSEXT_TYPE_renegotiate),
++#ifndef OPENSSL_NO_NEXTPROTONEG
+ 	ELEMENT(TLSEXT_TYPE_next_proto_neg),
++#endif
+ 	{ 0 }
+ };
+ 
+-- 
+2.20.1
+

--- a/net/ratched/patches/0002-openssl-fix-compilation-without-deprecated-APIs.patch
+++ b/net/ratched/patches/0002-openssl-fix-compilation-without-deprecated-APIs.patch
@@ -1,0 +1,95 @@
+From fa8f6fcd33e829cbe3ef3e4a92fa34cba3f20c91 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sun, 20 Sep 2020 20:18:18 -0700
+Subject: [PATCH] openssl: fix compilation without deprecated APIs
+
+Added missing headers, removed initialization, and fixed APIs.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ openssl.c       | 8 ++------
+ openssl_certs.c | 9 +++++----
+ openssl_tls.c   | 5 -----
+ 3 files changed, 7 insertions(+), 15 deletions(-)
+
+diff --git a/openssl.c b/openssl.c
+index ba097a5..76c817b 100644
+--- a/openssl.c
++++ b/openssl.c
+@@ -22,21 +22,17 @@
+ **/
+ 
+ #include <openssl/ssl.h>
++#include <openssl/bn.h>
++#include <openssl/rsa.h>
+ #include <openssl/err.h>
+ 
+ #include "openssl.h"
+ #include "errstack.h"
+ 
+ void openssl_init(void) {
+-	SSL_load_error_strings();
+-    OpenSSL_add_ssl_algorithms();
+ }
+ 
+ void openssl_deinit(void) {
+-	EVP_cleanup();
+-	CRYPTO_cleanup_all_ex_data();
+-	SSL_COMP_free_compression_methods();
+-	ERR_free_strings();
+ }
+ 
+ static void errstack_free_X509(struct errstack_element_t *element) {
+diff --git a/openssl_certs.c b/openssl_certs.c
+index 021b573..a062a24 100644
+--- a/openssl_certs.c
++++ b/openssl_certs.c
+@@ -27,6 +27,7 @@
+ #include <openssl/ssl.h>
+ #include <openssl/err.h>
+ #include <openssl/bn.h>
++#include <openssl/rsa.h>
+ #include <openssl/x509v3.h>
+ 
+ #include "ipfwd.h"
+@@ -280,8 +281,8 @@ X509* openssl_create_certificate(const struct certificatespec_t *spec) {
+ 	BN_free(serial);
+ 
+ 	/* Set lifetime */
+-	X509_gmtime_adj(X509_get_notBefore(cert), -spec->validity_predate_seconds);
+-	X509_gmtime_adj(X509_get_notAfter(cert), spec->validity_seconds);
++	X509_gmtime_adj(X509_getm_notBefore(cert), -spec->validity_predate_seconds);
++	X509_gmtime_adj(X509_getm_notAfter(cert), spec->validity_seconds);
+ 
+ 	/* Set public key */
+ 	X509_set_pubkey(cert, spec->subject_pubkey);
+@@ -357,8 +358,8 @@ X509* openssl_create_certificate(const struct certificatespec_t *spec) {
+ 	return cert;
+ }
+ 
+-static bool is_certificate_expired(X509 *cert) {
+-	return X509_cmp_current_time(X509_get_notAfter(cert)) <= 0;
++static bool is_certificate_expired(const X509 *cert) {
++	return X509_cmp_current_time(X509_get0_notAfter(cert)) <= 0;
+ }
+ 
+ X509* openssl_load_stored_certificate(const struct certificatespec_t *certspec, const char *filename, bool recreate_when_expired, bool recreate_when_key_mismatch) {
+diff --git a/openssl_tls.c b/openssl_tls.c
+index 4ba19a3..96a12ec 100644
+--- a/openssl_tls.c
++++ b/openssl_tls.c
+@@ -146,11 +146,6 @@ struct tls_connection_t openssl_tls_connect(const struct tls_connection_request_
+ 		SSL_CTX_set_verify(sslctx, SSL_VERIFY_PEER, NULL);
+ 		SSL_CTX_set_cert_verify_callback(sslctx, cert_verify_callback, &result);
+ 	}
+-	if (!SSL_CTX_set_ecdh_auto(sslctx, 1)) {
+-		logmsgext(LLVL_ERROR, FLAG_OPENSSL_ERROR, "openssl_tls %s: SSL_CTX_set_ecdh_auto() failed.", request->is_server ? "server" : "client");
+-		SSL_CTX_free(sslctx);
+-		return result;
+-	}
+ 
+ 	if (request->config && request->config->cert) {
+ 		if (SSL_CTX_use_certificate(sslctx, request->config->cert) != 1) {
+-- 
+2.20.1
+


### PR DESCRIPTION
Signed-off-by: Toni Uhlig <matzeton@googlemail.com>

Maintainer: me
Compile tested: x86_64, debian-stable
Run tested: mvebu, OpenWrt SNAPSHOT, r13575+9-d64d5ed142

Description: Ratched is a transparent Man-in-the-Middle TLS proxy intended for penetration testing.