### PR TITLE
gateway-go: add default config and gateway-go.init for background service

### DIFF
--- a/net/gateway-go/Makefile
+++ b/net/gateway-go/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gateway-go
 PKG_VERSION:=0.1.92
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/OpenIoTHub/gateway-go/tar.gz/v${PKG_VERSION}?
@@ -38,6 +38,21 @@ endef
 
 define Package/gateway-go/description
   gateway-go is GateWay Client for OpenIoTHub.
+endef
+
+define Package/gateway-go/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gateway-go $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/gateway-go/
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/gateway-go.yaml $(1)/etc/gateway-go/
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/gateway-go.init $(1)/etc/init.d/gateway-go
+endef
+
+define Package/gateway-go/conffiles
+/etc/gateway-go/gateway-go.yaml
 endef
 
 $(eval $(call GoBinPackage,gateway-go))

--- a/net/gateway-go/files/gateway-go.init
+++ b/net/gateway-go/files/gateway-go.init
@@ -1,0 +1,17 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=10
+USE_PROCD=1
+
+PROG="/usr/bin/gateway-go"
+CONF="/etc/gateway-go/gateway-go.yaml"
+
+start_service() {
+    procd_open_instance
+    procd_set_param command $PROG -c $CONF
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_set_param respawn
+    procd_close_instance
+}


### PR DESCRIPTION
Signed-off-by: Yu Fang <newfarry@126.com>

Maintainer: me
Compile tested: x86-64, openwrtorg/rootfs docker image container
Run tested: x86-64, openwrtorg/rootfs docker image container

Description:
gateway-go: add default config and gateway-go.init for background service