### PR TITLE
tor: update to version 0.4.4.5

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.3.6
+PKG_VERSION:=0.4.4.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=6a2d0637d4e514be2ec574723a05065245cce51da78a21cec1dc831be5ccac62
+PKG_HASH:=a45ca00afe765e3baa839767c9dd6ac9a46dd01720a3a8ff4d86558c12359926
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE
@@ -104,13 +104,14 @@ CONFIGURE_ARGS += \
 	--disable-zstd \
 	--with-tor-user=tor \
 	--with-tor-group=tor \
-	--with-pic
+	--enable-pic
 
 TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
 TARGET_LDFLAGS += -Wl,--gc-sections -flto
 
 CONFIGURE_VARS += \
-	CROSS_COMPILE="yes"
+	CROSS_COMPILE="yes" \
+	ac_cv_func_mallinfo=no
 
 define Package/tor/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
maintainer: @tripolar 
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates tor to version 0.4.4.5  Series 0.4.x should be supported till June 2021

[Changes](https://blog.torproject.org/node/1921)

Run tested with torsocks