### PR TITLE
ctop: fix install phase

### DIFF
--- a/utils/ctop/Makefile
+++ b/utils/ctop/Makefile
@@ -46,7 +46,7 @@ MAKE_FLAGS += \
 
 define Package/ctop/install
 	$(INSTALL_DIR) $(1)/usr/sbin/
-	$(INSTALL_BIN) $(GO_PKG_BUILD_DIR)/bin/ctop $(1)/usr/sbin/
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/ctop $(1)/usr/sbin/
 endef
 
 $(eval $(call BuildPackage,ctop))


### PR DESCRIPTION
Fix install phase for this package: use variable GO_PKG_BUILD_BIN_DIR
instead of GO_PKG_BUILD_DIR.

Signed-off-by: Marek Behún <kabel@blackhole.sk>

Compile tested: mvebu
