### PR TITLE
ola: fix compilation of this package

### DIFF
--- a/net/ola/Makefile
+++ b/net/ola/Makefile
@@ -55,7 +55,6 @@ CONFIGURE_ARGS += \
 
 HOST_CONFIGURE_ARGS += \
 	--disable-all-plugins \
-	--disable-slp \
 	--disable-osc \
 	--disable-uart \
 	--disable-libusb \
@@ -67,9 +66,6 @@ HOST_CONFIGURE_ARGS += \
 
 HOST_CPPFLAGS += \
 	-std=gnu++11
-
-CONFIGURE_VARS += \
-	require_gnu_plus_plus_11=yes
 
 HOST_LDFLAGS += -Wl,-rpath$(comma)$(STAGING_DIR_HOSTPKG)/lib
 TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-lm)

--- a/net/ola/patches/200-configure-acx-pthread.patch
+++ b/net/ola/patches/200-configure-acx-pthread.patch
@@ -1,0 +1,12 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -400,8 +400,7 @@ ACX_PTHREAD([
+              LIBS="$PTHREAD_LIBS $LIBS"
+              CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+              CXXFLAGS="$CXXFLAGS $PTHREAD_CXXFLAGS"
+-             CC="$PTHREAD_CC"
+-             CXX="$PTHREAD_CXX"],
++             CC="$PTHREAD_CC"],
+             [AC_MSG_ERROR([Missing pthread, please install it])])
+ 
+ # pthread_setname_np can take either 1 or 2 arguments.

--- a/net/ola/patches/201-automake-fix.patch
+++ b/net/ola/patches/201-automake-fix.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -12,8 +12,6 @@ AUX_DIST                = $(auxdir)/inst
+ ACLOCAL         = aclocal -I $(auxdir)
+ ACLOCAL_AMFLAGS = -I config
+ 
+-include aminclude.am
+-
+ # When running distcheck we want to enable the Python modules.
+ AM_DISTCHECK_CONFIGURE_FLAGS = --enable-python-libs
+ 

--- a/net/ola/patches/202-gnu++11.patch
+++ b/net/ola/patches/202-gnu++11.patch
@@ -1,0 +1,19 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -66,14 +66,14 @@ AM_CONDITIONAL([SUPPORTS_GNU_PLUS_PLUS_1
+ 
+ # force us into gnu++98 mode if necessary
+ # If gnu++11 and gnu++98 then
+-#   If no unit tests, force to gnu++98
++#   If no unit tests, force to gnu++11
+ #   If unittests and cppunit < 1.14.0, force to gnu++98
+ #   Else turn off deprecation messages for std::auto_ptr and run gnu++11
+ require_gnu_plus_plus_11="no"
+ AS_IF([test "x$ac_cv_gnu_plus_plus_11" = xyes],
+       [AS_IF([test "x$ac_cv_gnu_plus_plus_98" = xyes],
+              [AS_IF([test "x$enable_unittests" = xno],
+-                    [CXXFLAGS="$CXXFLAGS -std=gnu++98"],
++                    [require_gnu_plus_plus_11="yes"],
+                     [PKG_CHECK_MODULES([CPPUNIT1], [cppunit < 1.14.0],
+                                        [CXXFLAGS="$CXXFLAGS -std=gnu++98"],
+                                        [PKG_CHECK_MODULES([CPPUNIT2], [cppunit >= 1.14.0],

--- a/net/ola/patches/203-fix-HttpServer.cpp.patch
+++ b/net/ola/patches/203-fix-HttpServer.cpp.patch
@@ -1,0 +1,47 @@
+--- a/common/http/HTTPServer.cpp
++++ b/common/http/HTTPServer.cpp
+@@ -88,7 +88,7 @@ const char HTTPServer::CONTENT_TYPE_OCT[
+  * @param key the header name
+  * @param value the header value
+  */
+-static int AddHeaders(void *cls, OLA_UNUSED enum MHD_ValueKind kind,
++static MHD_Result AddHeaders(void *cls, OLA_UNUSED enum MHD_ValueKind kind,
+                       const char *key, const char *value) {
+   HTTPRequest *request = static_cast<HTTPRequest*>(cls);
+   string key_string = key;
+@@ -110,7 +110,7 @@ static int AddHeaders(void *cls, OLA_UNU
+  * @param off the offset of the data
+  * @param size the number of bytes available
+  */
+-int IteratePost(void *request_cls, OLA_UNUSED enum MHD_ValueKind kind,
++MHD_Result IteratePost(void *request_cls, OLA_UNUSED enum MHD_ValueKind kind,
+                 const char *key, OLA_UNUSED const char *filename,
+                 OLA_UNUSED const char *content_type,
+                 OLA_UNUSED const char *transfer_encoding, const char *data,
+@@ -129,7 +129,7 @@ int IteratePost(void *request_cls, OLA_U
+  * This sets up HTTPRequest & HTTPResponse objects and then calls
+  * DispatchRequest.
+  */
+-static int HandleRequest(void *http_server_ptr,
++static MHD_Result HandleRequest(void *http_server_ptr,
+                          struct MHD_Connection *connection,
+                          const char *url,
+                          const char *method,
+@@ -163,7 +163,7 @@ static int HandleRequest(void *http_serv
+   if (request->Method() == MHD_HTTP_METHOD_GET) {
+     HTTPResponse *response = new HTTPResponse(connection);
+     request->SetInFlight();
+-    return http_server->DispatchRequest(request, response);
++    return MHD_Result(http_server->DispatchRequest(request, response));
+ 
+   } else if (request->Method() == MHD_HTTP_METHOD_POST) {
+     if (*upload_data_size != 0) {
+@@ -173,7 +173,7 @@ static int HandleRequest(void *http_serv
+     }
+     request->SetInFlight();
+     HTTPResponse *response = new HTTPResponse(connection);
+-    return http_server->DispatchRequest(request, response);
++    return MHD_Result(http_server->DispatchRequest(request, response));
+   }
+   return MHD_NO;
+ }


### PR DESCRIPTION
This package does not currently compile.

This is needed to do so that it compiles:
- fix emptying CXX variable in configure script
- fix automake not generating Makefile (remove doxygen definitions)
- force gnu++11
Also because of changed API in libmicrohttpd:
- build with -fpermissive
- fix return values of callbacks in HttpServer

Moreover this package does not support --disable-slp configure option
anymore, remove it.

Signed-off-by: Marek Behún <kabel@blackhole.sk>

Compile tested: mvebu
