### PR TITLE
libuv: update to 1.39.0

### DIFF
--- a/libs/libuv/Makefile
+++ b/libs/libuv/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuv
-PKG_VERSION:=1.34.2
+PKG_VERSION:=1.39.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://dist.libuv.org/dist/v$(PKG_VERSION)/
-PKG_HASH:=65d93b4504ef5f3ec784c0c186f4ba8abd1031292c7f15dda8111d7e319adf46
+PKG_HASH:=5c52de5bdcfb322dbe10f98feb56e45162e668ad08bc28ab4b914d4f79911697
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>


### PR DESCRIPTION
Maintainer: @ratkaj
Compile tested: head r14552-d20007c, aarch64
 Run tested: aarch64 (qemu 5.1.0)

Description:
update to 1.39.0

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
