### PR TITLE
xinetd: fix xinetd reload problem

### DIFF
--- a/net/xinetd/Makefile
+++ b/net/xinetd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xinetd
 PKG_VERSION:=2.3.15
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/xinetd-org/xinetd/archive

--- a/net/xinetd/files/xinetd.init
+++ b/net/xinetd/files/xinetd.init
@@ -114,6 +114,11 @@ start_service() {
 	procd_close_instance
 }
 
+reload_service() {
+	procd_send_signal xinetd "*" QUIT
+	start
+}
+
 service_triggers() {
 	procd_add_reload_trigger "xinetd"
 }


### PR DESCRIPTION
This patch fixes the problem with xinetd not restarting on uci changes.
xinetd must be explicitly killed with SIGQUIT if running with the `-dontfork` option.
The option is required to keep xinetd in foreground to be handled by procd.