### PR TITLE
nlohmannjson: update to 3.9.1

### DIFF
--- a/libs/nlohmannjson/Makefile
+++ b/libs/nlohmannjson/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nlohmannjson
-PKG_VERSION:=3.8.0
-PKG_RELEASE:=2
+PKG_VERSION:=3.9.1
+PKG_RELEASE:=1
 
-PKG_SOURCE:=json-$(PKG_VERSION).zip
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
 PKG_SOURCE_URL:=https://codeload.github.com/nlohmann/json/zip/v$(PKG_VERSION)?
-PKG_HASH:=83947cb78d50990b4b931b8dbc8632781bc601baa45b75ece0899c7b98d86c0b
+PKG_HASH:=a88449d68aab8d027c5beefe911ba217f5ffcc0686ae1793d37f3d20698b37c6
 PKG_BUILD_DIR:=$(BUILD_DIR)/json-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Leonid Esman <leonid.esman@gmail.com>


### PR DESCRIPTION
Rename PKG_SOURCE. No point in matching with BUILD_DIR.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @LLE8 
Compile tested: ath79