### PR TITLE
ruby: do not check for -diag-disable compiler flag

### DIFF
--- a/lang/ruby/patches/101-dont-check-compiler-flag-diag-disable.patch
+++ b/lang/ruby/patches/101-dont-check-compiler-flag-diag-disable.patch
@@ -1,0 +1,10 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -530,7 +530,6 @@ AS_CASE(["$GCC:${warnflags+set}:${extra_
+ 		 -Wsuggest-attribute=format \
+ 		 -Wsuggest-attribute=noreturn \
+ 		 -Wunused-variable \
+-		 -diag-disable=175,188,2259 \
+ 		 $extra_warnflags \
+ 		 ; do
+ 	AS_IF([test "$particular_werror_flags" != yes], [


### PR DESCRIPTION
This is an ICC flag which is not supported on GCC and with combination
with ccache the configure script may cause problems on some setups.

Signed-off-by: Marek Behún <kabel@blackhole.sk>

Compile tested: mvebu

Description:
Without this compilation of ruby fails with strange warning on some setups.
The configure script checks whether -diag-disable is a valid compiler flag, for some ccache reason the check suceeds, so the configure script then uses this flag, but many other configure checks using the compiler fail, resulting in weird state of macro definitions in config.h (for example the PRI_LL_PREFIX macro is not defined, and thereafter compilation fails).