### PR TITLE
CI: test build with Full Lanaguage Support

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Test ${{ matrix.arch }}
+    name: Test ${{ matrix.arch }} ${{ matrix.config }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -30,6 +30,9 @@ jobs:
             runtime_test: true
           - arch: x86_64
             runtime_test: true
+          - arch: x86-64
+            config: nls
+            container: aparcar/openwrt-sdk-nls
 
     steps:
       - uses: actions/checkout@v2
@@ -55,6 +58,7 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
           FEEDNAME: packages_ci
+          CONTAINER: ${{ matrix.container }}
 
       - name: Move created packages to project dir
         run: cp bin/packages/${{ matrix.arch }}/packages_ci/*.ipk . || true

--- a/multimedia/gphoto2/Makefile
+++ b/multimedia/gphoto2/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gphoto2
 PKG_VERSION:=2.5.23
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Leonardo Medici <leonardo_medici@me.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2


### PR DESCRIPTION
The added SDK is build with `CONFIG_BUILD_NLS` which enabled full language support. According to @dangowrt this is a common problem in packages, so we could add this test as well.

Containers are created by another CI job and official and also the labelling is still wip (x86-64 instead of x86_64).

Signed-off-by: Paul Spooren <mail@aparcar.org>
