### PR TITLE
muninlite: Fixes xinetd service not launching (since v2.0.1)

### DIFF
--- a/admin/muninlite/Makefile
+++ b/admin/muninlite/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=muninlite
 PKG_VERSION:=2.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/munin-monitoring/$(PKG_NAME)/releases/download/$(PKG_VERSION)/

--- a/admin/muninlite/files/etc/xinetd.d/muninlite
+++ b/admin/muninlite/files/etc/xinetd.d/muninlite
@@ -1,4 +1,4 @@
-service muninlite
+service munin
 {
 	socket_type	= stream
 	protocol	= tcp


### PR DESCRIPTION
Maintainer: @jmccrohan
Compile tested: Not compiled (no need)
Run tested: MT7621 , Xiaomi Redmi AC2100, SNAPSHOT r14465-04d3b517dc / LuCI Master git-20.244.43974-4b8d4ba

-------
Service name was wrongly changed from 'munin' to 'muninlite' in the latest commit.
Launching xinetd don't start munin, See syslog:

```
xinetd[2802]: Reading included configuration file: /etc/xinetd.d/muninlite [file=/var/run/xinetd.conf] [line=9]
xinetd[2802]: Port not specified and can't find service: muninlite with getservbyname
xinetd[2802]: xinetd Version 2.3.15 started with loadavg options compiled in.
xinetd[2802]: Started working: 0 available services
```
Reverting service name from 'muninlite' , back to 'munin' fixes the issue.

HTH

