### PR TITLE
gphoto2: fix compilation with full NLS

### DIFF
--- a/multimedia/gphoto2/Makefile
+++ b/multimedia/gphoto2/Makefile
@@ -10,19 +10,22 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gphoto2
 PKG_VERSION:=2.5.23
-PKG_RELEASE:=1
-PKG_MAINTAINER:=Leonardo Medici <leonardo_medici@me.com>
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/gphoto
 PKG_HASH:=df87092100e7766c9d0a4323217c91908a9c891c0d3670ebf40b76903be458d1
+
+PKG_MAINTAINER:=Leonardo Medici <leonardo_medici@me.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/gphoto2
   SECTION:=multimedia
@@ -37,9 +40,7 @@ define Package/gphoto2/description
 endef
 
 CONFIGURE_ARGS += \
-	--without-aalib \
-	--without-libiconv-prefix \
-	--without-libintl-prefix \
+	--without-aalib
 
 CONFIGURE_VARS += \
 	LIBGPHOTO2_CFLAGS="$$$$CFLAGS -I$(STAGING_DIR)/usr/include/gphoto2 $$$$CPPFLAGS" \

--- a/multimedia/gphoto2/patches/001-automake-compat.patch
+++ b/multimedia/gphoto2/patches/001-automake-compat.patch
@@ -30,7 +30,7 @@
  
  dnl We cannot use AC_DEFINE_UNQUOTED() for these definitions, as
  dnl we require make to do insert the proper $(datadir) value
-@@ -407,7 +404,6 @@ AC_SUBST([AM_LDFLAGS])
+@@ -406,7 +403,6 @@ AC_SUBST([AM_LDFLAGS])
  # Create output files
  # ---------------------------------------------------------------------------
  AC_CONFIG_FILES([

--- a/multimedia/gphoto2/patches/002-no-docs-test.patch
+++ b/multimedia/gphoto2/patches/002-no-docs-test.patch
@@ -19,7 +19,7 @@
  all: config.h
 --- a/configure.ac
 +++ b/configure.ac
-@@ -407,16 +407,10 @@ AC_CONFIG_FILES([
+@@ -406,16 +406,10 @@ AC_CONFIG_FILES([
  Makefile
  gphoto2/Makefile
  gphoto-m4/Makefile


### PR DESCRIPTION
Reorganized Makefile a little bit for consistency.

Added PKG_BUILD_PARALLEL for faster compilation.

Refreshed patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @DocLM 
Compile tested: ath79