### PR TITLE
 openssh: update to 8.4p1

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
-PKG_VERSION:=8.3p1
-PKG_RELEASE:=2
+PKG_VERSION:=8.4p1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
 		https://ftp.spline.de/pub/OpenBSD/OpenSSH/portable/
-PKG_HASH:=f2befbe0472fe7eb75d23340eb17531cb6b3aac24075e2066b41f814e12387b2
+PKG_HASH:=5a01d22e407eb1c05ba8a8f7c654d388a13e9f226e4ed33bd38748dafa1d2b24
 
 PKG_LICENSE:=BSD ISC
 PKG_LICENSE_FILES:=LICENCE


### PR DESCRIPTION
update openssh to 8.4p1

Maintainer: @neheb 
Compile tested: rockchip-aarch64, nanopi-r2s, https://github.com/openwrt/openwrt/commit/3fab4ace570740a90f96c55c2c6ce85c48bc0bdc
Run tested: rockchip-aarch64, nanopi-r2s, https://github.com/openwrt/openwrt/commit/3fab4ace570740a90f96c55c2c6ce85c48bc0bdc

Signed-off-by: Yuan Tao <ty@wevs.org>