### PR TITLE
CI: get rid of the arc_archs buildbot

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         arch:
           - arc_arc700
-          - arc_archs
           - arm_cortex-a9_neon
           - arm_cortex-a9_vfpv3-d16
           - mips_24kc


### PR DESCRIPTION
Both ARC platforms are not useful. One is enough for uClibc-ng.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

ping @aparcar 