### PR TITLE
bwping: update to version 2.1

### DIFF
--- a/net/bwping/Makefile
+++ b/net/bwping/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bwping
-PKG_VERSION:=2.0
+PKG_VERSION:=2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/bwping
-PKG_HASH:=70c20c9667c41e67a8a91e1222c40dfecaf6aee0832df5d43e12480aa508a358
+PKG_HASH:=09bf0f369f19e2ea85aab4812ad89b7a20edb9cc242ec98931f5fd0646bb1d74
 
 PKG_MAINTAINER:=Oleg Derevenetz <oleg.derevenetz@gmail.com>
 PKG_LICENSE:=BSD-2-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: MIPS 74K, ASUS RT-N16, snapshot from master branch
Run tested: MIPS 74K, ASUS RT-N16, snapshot from master branch

Description:
This PR updates bwping to version 2.1.

Signed-off-by: Oleg Derevenetz <oleg-derevenetz@yandex.ru>
