### PR TITLE
libuv: update to 1.40.0

### DIFF
--- a/libs/libuv/Makefile
+++ b/libs/libuv/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuv
-PKG_VERSION:=1.39.0
+PKG_VERSION:=1.40.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://dist.libuv.org/dist/v$(PKG_VERSION)/
-PKG_HASH:=5c52de5bdcfb322dbe10f98feb56e45162e668ad08bc28ab4b914d4f79911697
+PKG_HASH:=61a90db95bac00adec1cc5ddc767ebbcaabc70242bd1134a7a6b1fb1d498a194
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>


### PR DESCRIPTION
Maintainer: @ratkaj
Compile tested: head r14615-624298d, mipsel 
Run tested: mipsel (qemu 5.1.0)

Description:
update to 1.40.0

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
