### PR TITLE
python-zeroconf: update to version 0.28.5

### DIFF
--- a/lang/python/python-zeroconf/Makefile
+++ b/lang/python/python-zeroconf/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-zeroconf
-PKG_VERSION:=0.28.0
+PKG_VERSION:=0.28.5
 PKG_RELEASE:=1
 
 PYPI_NAME:=zeroconf
-PKG_HASH:=881da2ed3d7c8e0ab59fb1cc8b02b53134351941c4d8d3f3553a96700f257a03
+PKG_HASH:=c08dbb90c116626cb6c5f19ebd14cd4846cffe7151f338c19215e6938d334980
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
This time, simple test:
```
>>> from zeroconf import ZeroconfServiceTypes
>>> print('\n'.join(ZeroconfServiceTypes.find()))
_afpovertcp._tcp.local.
_http._tcp.local.
_sftp-ssh._tcp.local.
_ssh._tcp.local.
_wd-2go._tcp.local.
>>> 
```

Description:

Update to version 0.28.5
Changelog: https://github.com/jstasiak/python-zeroconf/blob/master/README.rst#0285