### PR TITLE
nnn: update to version 3.4

### DIFF
--- a/utils/nnn/Makefile
+++ b/utils/nnn/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nnn
-PKG_VERSION:=3.0
+PKG_VERSION:=3.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jarun/nnn/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=04db6d6710ce1232c779bf70137a86557e486614e20327717122bb63f36348f7
+PKG_HASH:=7803ae6e974aeb4008507d9d1afbcca8d084a435f36ff636b459ca50414930a1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=BSD-2-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
**Copying, removing files works.**

Description:
- Update to version 3.4
Changelog: https://github.com/jarun/nnn/blob/master/CHANGELOG#L1