### PR TITLE
freeradius3: add meta-package for default modules

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
 PKG_VERSION:=release_3_0_21
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/archive
@@ -96,6 +96,11 @@ define Package/freeradius3-default
 +freeradius3-mod-realm \
 +freeradius3-mod-unix
   TITLE:=Modules needed for Radius default configuration
+endef
+
+define Package/freeradius3-default/description
+ This meta-package contains only dependencies for modules needed in
+ FreeRADIUS default configuration.
 endef
 
 define Package/freeradius3-democerts
@@ -719,6 +724,10 @@ define Package/freeradius3/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/radiusd $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/radiusd.init $(1)/etc/init.d/radiusd
+endef
+
+define Package/freeradius3-default/install
+	true
 endef
 
 define Package/freeradius3-democerts/install


### PR DESCRIPTION
This meta-package contains only dependencies for modules needed in
FreeRADIUS default configuration.

This commit adds missing description and install sections.

Compile tested: x86_64, OpenWrt trunk
Run tested: x86_64, OpenWrt trunk
