### PR TITLE
ddns-scripts: add ipv6 capability for no-ip.com

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
-PKG_VERSION:=2.8.1
+PKG_VERSION:=2.8.2
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0

--- a/net/ddns-scripts/files/usr/lib/ddns/update_no-ip_com.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_no-ip_com.sh
@@ -10,8 +10,8 @@
 # so we send a dummy (localhost) and a seconds later we send the correct IP addr
 #
 local __DUMMY
-local __UPDURL6="http://[USERNAME]:[PASSWORD]@dynupdate6.no-ip.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
-local __UPDURL="http://[USERNAME]:[PASSWORD]@dynupdate.no-ip.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
+local __UPDURL6="http://[USERNAME]:[PASSWORD]@dynupdate6.noip.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
+local __UPDURL="http://[USERNAME]:[PASSWORD]@dynupdate.noip.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
 # inside url we need username and password
 [ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'"
 [ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'"

--- a/net/ddns-scripts/files/usr/lib/ddns/update_no-ip_com.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_no-ip_com.sh
@@ -10,6 +10,7 @@
 # so we send a dummy (localhost) and a seconds later we send the correct IP addr
 #
 local __DUMMY
+local __UPDURL6="http://[USERNAME]:[PASSWORD]@dynupdate6.no-ip.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
 local __UPDURL="http://[USERNAME]:[PASSWORD]@dynupdate.no-ip.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
 # inside url we need username and password
 [ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'"
@@ -17,6 +18,7 @@ local __UPDURL="http://[USERNAME]:[PASSWORD]@dynupdate.no-ip.com/nic/update?host
 
 # set IP version dependend dummy (localhost)
 [ $use_ipv6 -eq 0 ] && __DUMMY="127.0.0.1" || __DUMMY="::1"
+[ $use_ipv6 -eq 0 ] && __UPDURL=$__UPDURL || __UPDURL=$__UPDURL6
 
 # lets do DUMMY transfer
 write_log 7 "sending dummy IP to 'no-ip.com'"

--- a/net/ddns-scripts/files/usr/share/ddns/default/no-ip.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/no-ip.com.json
@@ -2,6 +2,9 @@
 	"name": "no-ip.com",
 	"ipv4": {
 		"url": "update_no-ip_com.sh"
+	},
+	"ipv6": {
+		"url": "update_no-ip_com.sh"
 	}
 }
 


### PR DESCRIPTION
Maintainer: me / @feckert (find it by checking history of the package Makefile)
Compile tested: BCM27xx Raspberry Pi 4B openwrt - snapshot
Run tested: BCM27xx Raspberry Pi 4B openwrt - snapshot

Description: Add in the ability to select no-ip.com as an IPV6 ddns provider. Tested in my home with snapshot build on Raspberry Pi 4B.
