### PR TITLE
rsync: disable option for bundled zlib, add option for zstd

### DIFF
--- a/net/rsync/Config.in
+++ b/net/rsync/Config.in
@@ -12,4 +12,9 @@ if PACKAGE_rsync
 		default y if USE_FS_ACL_ATTR
 		default n
 
+	config RSYNC_zstd
+		bool
+		prompt "Enable zstd stream compression"
+		default n
+
 endif

--- a/net/rsync/Config.in
+++ b/net/rsync/Config.in
@@ -12,16 +12,4 @@ if PACKAGE_rsync
 		default y if USE_FS_ACL_ATTR
 		default n
 
-	config RSYNC_zlib
-		bool
-		prompt "Enable system zlib"
-		help 
-			Use the system's zlib library instead of rsync's internal copy. Enabling
-			this may create compatibility errors when using compression  with older
-			clients, or those using the current default of the bundled zlib.
-
-			rsync's upstream default is to use their bundled zlib. OpenWrt uses the
-			system zlib for space reasons. The system zlib will eventually become 
-			default for upstream as well.
-		default y
 endif

--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -30,7 +30,7 @@ define Package/rsync
   CATEGORY:=Network
   SUBMENU:=File Transfer
   TITLE:=Fast remote file copy program (like rcp)
-  DEPENDS:=+libpopt +RSYNC_xattr:libattr +RSYNC_acl:libacl +RSYNC_zlib:zlib
+  DEPENDS:=+libpopt +zlib +RSYNC_xattr:libattr +RSYNC_acl:libacl
   URL:=https://rsync.samba.org/
   MENU:=1
 endef
@@ -43,6 +43,7 @@ TARGET_CFLAGS += $(if $(CONFIG_IPV6),-DINET6,)
 
 CONFIGURE_ARGS += \
 	--without-included-popt \
+	--without-included-zlib \
 	--disable-debug \
 	--disable-asm \
 	--disable-iconv \
@@ -56,7 +57,6 @@ CONFIGURE_ARGS += \
 	--disable-zstd \
 	--$(if $(CONFIG_RSYNC_xattr),en,dis)able-xattr-support \
 	--$(if $(CONFIG_RSYNC_acl),en,dis)able-acl-support \
-	--with$(if $(CONFIG_RSYNC_zlib),,out)-included-zlib \
 	$(if $(CONFIG_IPV6),,--disable-ipv6)
 
 define Package/rsyncd

--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsync
 PKG_VERSION:=3.2.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.samba.org/pub/rsync/src
@@ -30,7 +30,7 @@ define Package/rsync
   CATEGORY:=Network
   SUBMENU:=File Transfer
   TITLE:=Fast remote file copy program (like rcp)
-  DEPENDS:=+libpopt +zlib +RSYNC_xattr:libattr +RSYNC_acl:libacl
+  DEPENDS:=+libpopt +zlib +RSYNC_xattr:libattr +RSYNC_acl:libacl +RSYNC_zstd:libzstd
   URL:=https://rsync.samba.org/
   MENU:=1
 endef
@@ -54,7 +54,7 @@ CONFIGURE_ARGS += \
 	--disable-openssl \
 	--disable-simd \
 	--disable-xxhash \
-	--disable-zstd \
+	--$(if $(CONFIG_RSYNC_zstd),en,dis)able-zstd \
 	--$(if $(CONFIG_RSYNC_xattr),en,dis)able-xattr-support \
 	--$(if $(CONFIG_RSYNC_acl),en,dis)able-acl-support \
 	$(if $(CONFIG_IPV6),,--disable-ipv6)


### PR DESCRIPTION
Maintainer: @mstorchak 
Compile tested: arm/mvebu, openwrt HEAD as of 2020-10-02
Run tested: arm/mvebu with openwrt acting as server transferring to local clients, and as client retrieving from remote servers.

Description:

This removes the option to use rsync's bundled zlib. I added it ~6 years ago to give compatibility with even older versions of rsync. Said old versions should hopefully no longer be in use, so remove the option.

This adds the option to use zstd for transfer compression.