### PR TITLE
travelmate: update 2.0.2

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=2.0.1
-PKG_RELEASE:=2
+PKG_VERSION:=2.0.2
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 
@@ -17,7 +17,7 @@ define Package/travelmate
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=A wlan connection manager for travel router
-	DEPENDS:=+iwinfo +jshn +jsonfilter +curl +ca-bundle +dnsmasq
+	DEPENDS:=+iwinfo +jshn +jsonfilter +curl +ca-bundle
 	PKGARCH:=all
 endef
 

--- a/net/travelmate/files/chs-hotel.login
+++ b/net/travelmate/files/chs-hotel.login
@@ -3,26 +3,32 @@
 # Copyright (c) 2020 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
-domain="hotspot.internet-for-guests.com"
-cmd="$(command -v curl)"
+# set (s)hellcheck exceptions
+# shellcheck disable=1091,2016,2039,2059,2086,2143,2181,2188
 
-# curl check
-#
-if [ ! -x "${cmd}" ]
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+set -o pipefail
+
+if [ "$(uci_get 2>/dev/null; printf "%u" "${?}")" = "127" ]
 then
-	exit 1
+	. "/lib/functions.sh"
 fi
+
+trm_domain="hotspot.internet-for-guests.com"
+trm_useragent="$(uci_get travelmate global trm_useragent "Mozilla/5.0 (Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0")"
+trm_maxwait="$(uci_get travelmate global trm_maxwait "30")"
+trm_fetch="$(command -v curl)"
 
 # initial get request to receive & extract valid security tokens
 #
-"${cmd}" "https://${domain}/logon/cgi/index.cgi" -c "/tmp/${domain}.cookie" -s -o /dev/null
-
-if [ -r "/tmp/${domain}.cookie" ]
+"${trm_fetch}" --user-agent "${trm_useragent}" --referer "http://www.example.com" --silent --connect-timeout $((trm_maxwait/6)) --cookie-jar "/tmp/${trm_domain}.cookie" --output /dev/null "https://${trm_domain}/logon/cgi/index.cgi"
+if [ -r "/tmp/${trm_domain}.cookie" ]
 then
-	lg_id="$(awk '/LGNSID/{print $7}' "/tmp/${domain}.cookie")"
-	ta_id="$(awk '/ta_id/{print $7}' "/tmp/${domain}.cookie")"
-	cl_id="$(awk '/cl_id/{print $7}' "/tmp/${domain}.cookie")"
-	rm -f "/tmp/${domain}.cookie"
+	lg_id="$(awk '/LGNSID/{print $7}' "/tmp/${trm_domain}.cookie")"
+	ta_id="$(awk '/ta_id/{print $7}' "/tmp/${trm_domain}.cookie")"
+	cl_id="$(awk '/cl_id/{print $7}' "/tmp/${trm_domain}.cookie")"
+	rm -f "/tmp/${trm_domain}.cookie"
 else
 	exit 2
 fi
@@ -31,7 +37,7 @@ fi
 #
 if [ -n "${lg_id}" ] && [ -n "${ta_id}" ] && [ -n "${cl_id}" ]
 then
-	"${cmd}" "https://${domain}/logon/cgi/index.cgi" -H "Referer: https://${domain}/logon/cgi/index.cgi" -H "Cookie: LGNSID=${lg_id}; lang=en_US; use_mobile_interface=0; ta_id=${ta_id}; cl_id=${cl_id}" -H 'Connection: keep-alive' --data 'accept_termsofuse=&freeperperiod=1&device_infos=1125:2048:1152:2048' -s -o /dev/null
+	"${trm_fetch}" --user-agent "${trm_useragent}" --referer "https://${trm_domain}/logon/cgi/index.cgi" --silent --connect-timeout $((trm_maxwait/6)) --header "Cookie: LGNSID=${lg_id}; lang=en_US; use_mobile_interface=0; ta_id=${ta_id}; cl_id=${cl_id}" --data "accept_termsofuse=&freeperperiod=1&device_infos=1125:2048:1152:2048" --output /dev/null "https://${trm_domain}/logon/cgi/index.cgi"
 else
 	exit 3
 fi

--- a/net/travelmate/files/db-bahn.login
+++ b/net/travelmate/files/db-bahn.login
@@ -3,6 +3,18 @@
 # Copyright (c) 2020 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
+# set (s)hellcheck exceptions
+# shellcheck disable=1091,2016,2039,2059,2086,2143,2181,2188
+
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+set -o pipefail
+
+if [ "$(uci_get 2>/dev/null; printf "%u" "${?}")" = "127" ]
+then
+	. "/lib/functions.sh"
+fi
+
 trm_domain="wifi.bahn.de"
 trm_useragent="$(uci_get travelmate global trm_useragent "Mozilla/5.0 (Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0")"
 trm_maxwait="$(uci_get travelmate global trm_maxwait "30")"
@@ -16,7 +28,7 @@ trm_fetch="$(command -v curl)"
 #
 if [ -s "/tmp/${trm_domain}.cookie" ]
 then
-	php_token="$(awk 'BEGIN{FS="[ ;]"}/^Set-Cookie:/{print $2}' "/tmp/${trm_domain}.cookie")"
+	sec_token="$(awk 'BEGIN{FS="[ ;]"}/^Set-Cookie:/{print $2}' "/tmp/${trm_domain}.cookie")"
 	location="$(awk '/^Location:/{print $2}' "/tmp/${trm_domain}.cookie")"
 	rm -f "/tmp/${trm_domain}.cookie"
 else
@@ -25,9 +37,9 @@ fi
 
 # post request to subscribe to the portal API
 #
-if [ -n "${php_token}" ] && [ -n "${location}" ]
+if [ -n "${sec_token}" ] && [ -n "${location}" ]
 then
-	"${trm_fetch}" --user-agent "${trm_useragent}" --referer "${location}" --silent  --connect-timeout $((trm_maxwait/6)) --include --cookie-jar "/tmp/${trm_domain}.cookie" --header "Cookie: ${php_token}" --data "action=subscribe&type=one&connect_policy_accept=false&user_login=&user_password=&user_password_confirm=&email_address=&prefix=&phone=&policy_accept=false&gender=&interests=" --output /dev/null "https://${trm_domain}/portal_api.php"
+	"${trm_fetch}" --user-agent "${trm_useragent}" --referer "${location}" --silent  --connect-timeout $((trm_maxwait/6)) --include --cookie-jar "/tmp/${trm_domain}.cookie" --header "Cookie: ${sec_token}" --data "action=subscribe&type=one&connect_policy_accept=false&user_login=&user_password=&user_password_confirm=&email_address=&prefix=&phone=&policy_accept=false&gender=&interests=" --output /dev/null "https://${trm_domain}/portal_api.php"
 else
 	exit 3
 fi
@@ -47,7 +59,7 @@ fi
 #
 if [ -n "${login}" ] && [ -n "${password}" ]
 then
-	"${trm_fetch}" --user-agent "${trm_useragent}" --referer "${location}" --silent --connect-timeout $((trm_maxwait/6)) --header "Cookie: ${php_token}" --data "action=authenticate&login=${login}&password=${password}&policy_accept=false&from_ajax=true&wispr_mode=false" "https://${trm_domain}/portal_api.php"
+	"${trm_fetch}" --user-agent "${trm_useragent}" --referer "${location}" --silent --connect-timeout $((trm_maxwait/6)) --header "Cookie: ${sec_token}" --data "action=authenticate&login=${login}&password=${password}&policy_accept=false&from_ajax=true&wispr_mode=false" "https://${trm_domain}/portal_api.php"
 else
 	exit 5
 fi

--- a/net/travelmate/files/generic-user-pass.login
+++ b/net/travelmate/files/generic-user-pass.login
@@ -1,18 +1,33 @@
 #!/bin/sh
+# captive portal auto-login script template with credentials as parameters
+# Copyright (c) 2020 Dirk Brenken (dev@brenken.org)
+# This is free software, licensed under the GNU General Public License v3.
 
-cmd="$(command -v curl)"
-url="http://example.com/"
-success_string="Thank you!"
+# set (s)hellcheck exceptions
+# shellcheck disable=1091,2016,2039,2059,2086,2143,2181,2188
 
-if [ ! -x "${cmd}" ]
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+set -o pipefail
+
+if [ "$(uci_get 2>/dev/null; printf "%u" "${?}")" = "127" ]
 then
-	exit 1
+	. "/lib/functions.sh"
 fi
 
-response="$("${cmd}" $url -d "username=${1}&password=${2}" \
-	--header "Content-Type:application/x-www-form-urlencoded" -s)"
+trm_domain="example.com"
+trm_useragent="$(uci_get travelmate global trm_useragent "Mozilla/5.0 (Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0")"
+trm_maxwait="$(uci_get travelmate global trm_maxwait "30")"
+trm_fetch="$(command -v curl)"
 
-if [ -n "$(printf "%s" "${response}" | grep "${success_string}")" ]
+user="${1}"
+password="${2}"
+success="Thank you!"
+
+# login with credentials
+#
+response="$("${trm_fetch}" --user-agent "${trm_useragent}" --referer "http://www.example.com" --silent --connect-timeout $((trm_maxwait/6)) --data "username=${user}&password=${password}" --header "Content-Type:application/x-www-form-urlencoded" "http://${trm_domain}")"
+if [ -n "$(printf "%s" "${response}" | grep "${success}")" ]
 then
 	exit 0
 else

--- a/net/travelmate/files/h-hotels.login
+++ b/net/travelmate/files/h-hotels.login
@@ -3,26 +3,32 @@
 # Copyright (c) 2020 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
-domain="hotspot.t-mobile.net"
-cmd="$(command -v curl)"
+# set (s)hellcheck exceptions
+# shellcheck disable=1091,2016,2039,2059,2086,2143,2181,2188
 
-# curl check
-#
-if [ ! -x "${cmd}" ]
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+set -o pipefail
+
+if [ "$(uci_get 2>/dev/null; printf "%u" "${?}")" = "127" ]
 then
-	exit 1
+	. "/lib/functions.sh"
 fi
+
+trm_domain="hotspot.t-mobile.net"
+trm_useragent="$(uci_get travelmate global trm_useragent "Mozilla/5.0 (Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0")"
+trm_maxwait="$(uci_get travelmate global trm_maxwait "30")"
+trm_fetch="$(command -v curl)"
 
 # initial get request to receive & extract valid security tokens
 #
-"${cmd}" "https://${domain}/wlan/rest/freeLogin" -c "/tmp/${domain}.cookie" -s -o /dev/null
-
-if [ -r "/tmp/${domain}.cookie" ]
+"${trm_fetch}" --user-agent "${trm_useragent}" --referer "http://www.example.com" --silent --connect-timeout $((trm_maxwait/6)) --cookie-jar "/tmp/${trm_domain}.cookie" --output /dev/null "https://${trm_domain}/wlan/rest/freeLogin"
+if [ -r "/tmp/${trm_domain}.cookie" ]
 then
-	ses_id="$(awk '/JSESSIONID/{print $7}' "/tmp/${domain}.cookie")"
-	sec_id="$(awk '/DT_H/{print $7}' "/tmp/${domain}.cookie")"
+	ses_id="$(awk '/JSESSIONID/{print $7}' "/tmp/${trm_domain}.cookie")"
+	sec_id="$(awk '/DT_H/{print $7}' "/tmp/${trm_domain}.cookie")"
 	dev_id="$(sha256sum /etc/config/wireless | awk '{printf "%s",substr($1,1,13)}')"
-	rm -f "/tmp/${domain}.cookie"
+	rm -f "/tmp/${trm_domain}.cookie"
 else
 	exit 2
 fi
@@ -31,7 +37,7 @@ fi
 #
 if [ -n "${ses_id}" ] && [ -n "${sec_id}" ] && [ -n "${dev_id}" ]
 then
-	"${cmd}" "https://${domain}/wlan/rest/freeLogin" -H "Referer: https://${domain}/TD/hotspot/H_Hotels/en_GB/index.html" -H "Cookie: JSESSIONID=${ses_id}; DT_DEV_ID=${dev_id}; DT_H=${sec_id}" -H 'Connection: keep-alive' --data "rememberMe=true" -s -o /dev/null
+	"${trm_fetch}" --user-agent "${trm_useragent}" --referer "https://${trm_domain}/TD/hotspot/H_Hotels/en_GB/index.html" --silent --connect-timeout $((trm_maxwait/6)) --header "Cookie: JSESSIONID=${ses_id}; DT_DEV_ID=${dev_id}; DT_H=${sec_id}" --data "rememberMe=true" --output /dev/null "https://${trm_domain}/wlan/rest/freeLogin"
 else
 	exit 3
 fi

--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 
 # set (s)hellcheck exceptions
-# shellcheck disable=1091,2016,2039,2059,2086,2143,2181,2188
+# shellcheck disable=1091,2016,2034,2039,2059,2086,2143,2181,2188
 
 START=25
 USE_PROCD=1
@@ -25,7 +25,7 @@ boot()
 
 start_service()
 {
-	if [ "$("${trm_init}" enabled; printf "%u" ${?})" -eq "0" ]
+	if [ "$("${trm_init}" enabled; printf "%u" ${?})" = "0" ]
 	then
 		procd_open_instance "travelmate"
 		procd_set_param command "${trm_script}" "${@}"
@@ -69,7 +69,7 @@ status_service()
 	rtfile="$(uci_get travelmate global trm_rtfile "/tmp/trm_runtime.json")"
 	json_load_file "${rtfile}" >/dev/null 2>&1
 	json_select data >/dev/null 2>&1
-	if [ ${?} -eq 0 ]
+	if [ "${?}" = "0" ]
 	then
 		printf "%s\n" "::: travelmate runtime information"
 		json_get_keys keylist

--- a/net/travelmate/files/travelmate.mail
+++ b/net/travelmate/files/travelmate.mail
@@ -8,10 +8,15 @@
 
 # Please note: you have to setup the package 'msmtp' before using this script
 
-LC_ALL=C
-PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+set -o pipefail
 
-. "/lib/functions.sh"
+if [ "$(uci_get 2>/dev/null; printf "%u" "${?}")" = "127" ]
+then
+	. "/lib/functions.sh"
+fi
+
 trm_debug="$(uci_get travelmate global trm_debug "0")"
 trm_mailreceiver="$(uci_get travelmate global trm_mailreceiver)"
 trm_mailprofile="$(uci_get travelmate global trm_mailprofile "trm_notify")"
@@ -38,7 +43,7 @@ then
 	exit 1
 fi
 
-if [ "${trm_debug}" -eq "1" ]
+if [ "${trm_debug}" = "1" ]
 then
 	debug="--debug"
 fi

--- a/net/travelmate/files/travelmate.vpn
+++ b/net/travelmate/files/travelmate.vpn
@@ -8,10 +8,15 @@
 
 # Please note: you have to setup the package 'wireguard' or 'openvpn' before using this script
 
-LC_ALL=C
-PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+set -o pipefail
 
-. "/lib/functions.sh"
+if [ "$(uci_get 2>/dev/null; printf "%u" "${?}")" = "127" ]
+then
+	. "/lib/functions.sh"
+fi
+
 vpn_action="${1}"
 trm_vpnservice="$(uci_get travelmate global trm_vpnservice)"
 trm_vpniface="$(uci_get travelmate global trm_vpniface)"
@@ -60,7 +65,8 @@ then
 	vpn_status="$(ubus -S call network.interface."${trm_vpniface}" status 2>/dev/null | jsonfilter -l1 -e '@.up')"
 	if [ "${vpn_action}" = "disable" ] && [ "${vpn_status}" = "true" ]
 	then
-		if [ -n "$("${trm_iptables}" "-w $((trm_maxwait/6))" -C ${trm_iptrule_drop} 2>&1)" ]
+		if [ -n "$("${trm_iptables}" "-w $((trm_maxwait/6))" -C ${trm_iptrule_drop} 2>&1)" ] && \
+			[ -n "$("${trm_iptables}" "-w $((trm_maxwait/6))" -C ${trm_iptrule_accept} 2>&1)" ]
 		then
 			"${trm_iptables}" "-w $((trm_maxwait/6))" -I ${trm_iptrule_drop} 2>&1
 			f_log "info" "lan forward blocked for device '${trm_landevice}'"
@@ -68,7 +74,8 @@ then
 	fi
 	if [ "${vpn_action}" = "disable" ] && [ "${status%% (net cp *}" = "connected" ]
 	then
-		if [ -n "$("${trm_iptables}" "-w $((trm_maxwait/6))" -C ${trm_iptrule_accept} 2>&1)" ]
+		if [ -n "$("${trm_iptables}" "-w $((trm_maxwait/6))" -C ${trm_iptrule_accept} 2>&1)" ] && \
+			[ -z "$("${trm_iptables}" "-w $((trm_maxwait/6))" -C ${trm_iptrule_drop} 2>&1)" ]
 		then
 			"${trm_iptables}" "-w $((trm_maxwait/6))" -I ${trm_iptrule_accept} 2>&1
 			f_log "info" "lan forward on ports 80/443 freed for device '${trm_landevice}'"

--- a/net/travelmate/files/travelmate_ntp.hotplug
+++ b/net/travelmate/files/travelmate_ntp.hotplug
@@ -23,7 +23,7 @@ f_log()
 }
 
 if [ "${ACTION}" = "stratum" ] && [ ! -f "${trm_ntpfile}" ] && \
-	[ "$("${trm_init}" enabled; printf "%u" ${?})" -eq "0" ]
+	[ "$("${trm_init}" enabled; printf "%u" ${?})" = "0" ]
 then
 	> "${trm_ntpfile}"
 	f_log "info" "get ntp time sync"

--- a/net/travelmate/files/wifionice.login
+++ b/net/travelmate/files/wifionice.login
@@ -3,6 +3,18 @@
 # Copyright (c) 2020 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
+# set (s)hellcheck exceptions
+# shellcheck disable=1091,2016,2039,2059,2086,2143,2181,2188
+
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+set -o pipefail
+
+if [ "$(uci_get 2>/dev/null; printf "%u" "${?}")" = "127" ]
+then
+	. "/lib/functions.sh"
+fi
+
 trm_domain="www.wifionice.de"
 trm_useragent="$(uci_get travelmate global trm_useragent "Mozilla/5.0 (Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0")"
 trm_maxwait="$(uci_get travelmate global trm_maxwait "30")"


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: n/a
Run tested: TP-Link RE650 v1, OpenWrt SNAPSHOT r14627-d6a9a92e32

Description:
* fix a vpn/iptables race condition
* remove needless dnsmasq dependency
* synchronize code-base of all auto-login scripts, due to
  COVID-19 restrictions all of them are still untested/WIP
* various small cleanups

Signed-off-by: Dirk Brenken <dev@brenken.org>
