### PR TITLE
php7: update to 7.4.11

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=7.4.10
+PKG_VERSION:=7.4.11
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=c2d90b00b14284588a787b100dee54c2400e7db995b457864d66f00ad64fb010
+PKG_HASH:=5d31675a9b9c21b5bd03389418218c30b26558246870caba8eb54f5856e2d6ce
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0

--- a/lang/php7/patches/0050-remove-build-timestamps.patch
+++ b/lang/php7/patches/0050-remove-build-timestamps.patch
@@ -9,9 +9,9 @@
 -		PHP_MD5Update(&context, __DATE__, sizeof(__DATE__)-1);
 -		PHP_MD5Update(&context, __TIME__, sizeof(__TIME__)-1);
 -	}
- 	PHP_MD5Final(digest, &context);
- 	php_hash_bin2hex(accel_system_id, digest, sizeof digest);
- }
+ 	/* Modules may have changed after restart which can cause dangling pointers from
+      * custom opcode handlers in the second-level cache files
+      */
 --- a/sapi/litespeed/lsapi_main.c
 +++ b/sapi/litespeed/lsapi_main.c
 @@ -1284,9 +1284,9 @@ static int cli_main( int argc, char * ar


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs

Description:

This fixes:
  - CVE-2020-7069
  - CVE-2020-7070

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
