### PR TITLE
banip: Added optional packet logging feature. Resolved all shellcheck warnings.

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
-PKG_VERSION:=0.3.11
+PKG_VERSION:=0.3.12
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
-PKG_VERSION:=0.3.12
+PKG_VERSION:=0.3.11
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/banip/files/README.md
+++ b/net/banip/files/README.md
@@ -27,6 +27,7 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 * output comprehensive runtime information via LuCI or via 'status' init command
 * strong LuCI support
 * optional: add new banIP sources on your own
+* optional: log banned inbound and/or outbound IP to syslog.
 
 ## Prerequisites
 * [OpenWrt](https://openwrt.org), tested with the stable release series (19.07) and with the latest snapshot
@@ -45,28 +46,52 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 ## banIP config options
 * usually the pre-configured banIP setup works quite well and no manual overrides are needed
 * the following options apply to the 'global' config section:
-    * ban\_enabled => main switch to enable/disable banIP service (bool/default: '0', disabled)
-    * ban\_automatic => determine the L2/L3 WAN network device automatically (bool/default: '1', enabled)
-    * ban\_iface => space separated list of WAN network interface(s)/device(s) used by banIP (default: not set, automatically detected)
-    * ban\_realtime => a small log/banIP background monitor to block SSH/LuCI brute force attacks in realtime (bool/default: 'false', disabled)
+  * ban\_enabled => main switch to enable/disable banIP service (bool/default: '0', disabled)
+  * ban\_automatic => determine the L2/L3 WAN network device automatically (bool/default: '1', enabled)
+  * ban\_iface => space separated list of WAN network interface(s)/device(s) used by banIP (default: not set, automatically detected)
+  * ban\_realtime => a small log/banIP background monitor to block SSH/LuCI brute force attacks in realtime (bool/default: 'false', disabled)
+  * ban\_target\_src => action to perform when banning inbound IPv4 packets ('DROP'/'REJECT', default: 'DROP')
+  * ban\_target\_src\_6 => action to perform when banning inbound IPv6 packets ('DROP'/'REJECT', default: 'DROP')
+  * ban\_target\_dst => action to perform when banning outbound IPv4 packets ('DROP'/'REJECT', default: 'REJECT')
+  * ban\_target\_dst\_6 => action to perform when banning outbound IPv6 packets ('DROP'/'REJECT', default: 'REJECT')
+  * ban\_log\_src => switch to enable/disable logging of banned inbound IPv4 packets (bool/default: '0', disabled)
+  * ban\_log\_dst => switch to enable/disable logging of banned outbound IPv4 packets (bool/default: '0', disabled)
 
 * the following options apply to the 'extra' config section:
-    * ban\_debug => enable/disable banIP debug output (bool/default: '0', disabled)
-    * ban\_nice => set the nice level of the banIP process and all sub-processes (int/default: '0', standard priority)
-    * ban\_triggerdelay => additional trigger delay in seconds before banIP processing begins (int/default: '2')
-    * ban\_backupdir => target directory for banIP backups (default: '/tmp')
-    * ban\_sshdaemon => select the SSH daemon for logfile parsing, 'dropbear' or 'sshd' (default: 'dropbear')
-    * ban\_starttype => select the used start type during boot, 'start', 'refresh' or 'reload' (default: 'start')
-    * ban\_maxqueue => size of the download queue to handle downloads & IPSet processing in parallel (int/default: '4')
-    * ban\_fetchutil => name of the used download utility: 'uclient-fetch', 'wget', 'curl', 'aria2c' (default: not set, automatically detected)
-    * ban\_fetchparm => special config options for the download utility (default: not set)
-    * ban\_autoblacklist => store auto-addons temporary in ipset and permanently in local blacklist as well (bool/default: '1', enabled)
-    * ban\_autowhitelist => store auto-addons temporary in ipset and permanently in local whitelist as well (bool/default: '1', enabled)
+  * ban\_debug => enable/disable banIP debug output (bool/default: '0', disabled)
+  * ban\_nice => set the nice level of the banIP process and all sub-processes (int/default: '0', standard priority)
+  * ban\_triggerdelay => additional trigger delay in seconds before banIP processing begins (int/default: '2')
+  * ban\_backupdir => target directory for banIP backups (default: '/tmp')
+  * ban\_sshdaemon => select the SSH daemon for logfile parsing, 'dropbear' or 'sshd' (default: 'dropbear')
+  * ban\_starttype => select the used start type during boot, 'start', 'refresh' or 'reload' (default: 'start')
+  * ban\_maxqueue => size of the download queue to handle downloads & IPSet processing in parallel (int/default: '4')
+  * ban\_fetchutil => name of the used download utility: 'uclient-fetch', 'wget', 'curl', 'aria2c' (default: not set, automatically detected)
+  * ban\_fetchparm => special config options for the download utility (default: not set)
+  * ban\_autoblacklist => store auto-addons temporary in ipset and permanently in local blacklist as well (bool/default: '1', enabled)
+  * ban\_autowhitelist => store auto-addons temporary in ipset and permanently in local whitelist as well (bool/default: '1', enabled)
+
+## Logging of banned packets
+* by setting ban\_log\_src=1 / ban\_log\_dst=1 in the config options, banIP will log banned inbound / outbound packets to syslog.
+* example of a logged inbound (dst) and outbound (src) packet:
+<pre><code>
+Oct  2 12:49:14 gateway kernel: [434134.855130] REJECT(dst banIP) IN=br-lan OUT=br-wan MAC=xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx SRC=x.x.x.x DST=x.x.x.x LEN=100 TOS=0x00 PREC=0x00 TTL=63 ID=7938 PROTO=UDP SPT=16393 DPT=16393 LEN=80
+
+Oct  3 14:11:13 gateway kernel: [11290.429712] DROP(src banIP) IN=br-wan OUT= MAC=xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx SRC=x.x.x.x DST=x.x.x.x LEN=40 TOS=0x00 PREC=0x00 TTL=235 ID=63275 PROTO=TCP SPT=48246 DPT=37860 WINDOW=1024 RES=0x00 SYN URGP=0
+</code></pre>
+* to change the default logging behavior, the following options can be added to the 'global' config section:
+  * ban\_log\_src\_opts => IPv4 iptables LOG options for banned inbound packets (default: '-m limit --limit 10/sec')
+  * ban\_log\_src\_opts\_6 => IPv6 iptables LOG options for banned inbound packets (default: '-m limit --limit 10/sec')
+  * ban\_log\_src\_prefix (default: '<ban\_target\_src>(src banIP) ', typically 'DROP(src banIP) ')
+  * ban\_log\_src\_prefix\_6 (default: '<ban\_target\_src\_6>(src banIP) ', typically 'DROP('src banIP)' )
+  * ban\_log\_dst\_opts => IPv4 iptables LOG options for banned outbound packets (default: '-m limit --limit 10/sec')
+  * ban\_log\_dst\_opts\_6 => IPv6 iptables LOG options for banned outbound packets (default: '-m limit --limit 10/sec')
+  * ban\_log\_dst\_prefix (default: '<ban\_target\_dst>(dst banIP) ', typically 'REJECT(dst banIP) ')
+  * ban\_log\_dst\_prefix\_6 (default: '<ban\_target\_dst\_6>(dst banIP) ', typically 'REJECT('dst banIP)' )
 
 ## Examples
 **receive banIP runtime information:**
 
-<pre><code>
+```
 /etc/init.d/banip status
 ::: banIP runtime information
   + status     : enabled
@@ -76,14 +101,14 @@ IP address blocking is commonly used to protect against brute force attacks, pre
   + backup_dir : /tmp
   + last_run   : 03.10.2019 19:15:25
   + system     : UBNT-ERX, OpenWrt SNAPSHOT r11102-ced4c0e635
-</code></pre>
-  
+```
+
 **cronjob for a regular IPSet blocklist update (/etc/crontabs/root):**
 
-<pre><code>
-0 06 * * *    /etc/init.d/banip reload
-</code></pre>
-  
+```
+# Every day at 06:00, update the IPSets of banIP
+00 06 * * *    /etc/init.d/banip reload
+```
 
 ## Support
 Please join the banIP discussion in this [forum thread](https://forum.openwrt.org/t/banip-support-thread/16985) or contact me by mail <dev@brenken.org>  

--- a/net/banip/files/README.md
+++ b/net/banip/files/README.md
@@ -27,7 +27,6 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 * output comprehensive runtime information via LuCI or via 'status' init command
 * strong LuCI support
 * optional: add new banIP sources on your own
-* optional: log banned inbound and/or outbound IP to syslog.
 
 ## Prerequisites
 * [OpenWrt](https://openwrt.org), tested with the stable release series (19.07) and with the latest snapshot
@@ -46,52 +45,28 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 ## banIP config options
 * usually the pre-configured banIP setup works quite well and no manual overrides are needed
 * the following options apply to the 'global' config section:
-  * ban\_enabled => main switch to enable/disable banIP service (bool/default: '0', disabled)
-  * ban\_automatic => determine the L2/L3 WAN network device automatically (bool/default: '1', enabled)
-  * ban\_iface => space separated list of WAN network interface(s)/device(s) used by banIP (default: not set, automatically detected)
-  * ban\_realtime => a small log/banIP background monitor to block SSH/LuCI brute force attacks in realtime (bool/default: 'false', disabled)
-  * ban\_target\_src => action to perform when banning inbound IPv4 packets ('DROP'/'REJECT', default: 'DROP')
-  * ban\_target\_src\_6 => action to perform when banning inbound IPv6 packets ('DROP'/'REJECT', default: 'DROP')
-  * ban\_target\_dst => action to perform when banning outbound IPv4 packets ('DROP'/'REJECT', default: 'REJECT')
-  * ban\_target\_dst\_6 => action to perform when banning outbound IPv6 packets ('DROP'/'REJECT', default: 'REJECT')
-  * ban\_log\_src => switch to enable/disable logging of banned inbound IPv4 packets (bool/default: '0', disabled)
-  * ban\_log\_dst => switch to enable/disable logging of banned outbound IPv4 packets (bool/default: '0', disabled)
+    * ban\_enabled => main switch to enable/disable banIP service (bool/default: '0', disabled)
+    * ban\_automatic => determine the L2/L3 WAN network device automatically (bool/default: '1', enabled)
+    * ban\_iface => space separated list of WAN network interface(s)/device(s) used by banIP (default: not set, automatically detected)
+    * ban\_realtime => a small log/banIP background monitor to block SSH/LuCI brute force attacks in realtime (bool/default: 'false', disabled)
 
 * the following options apply to the 'extra' config section:
-  * ban\_debug => enable/disable banIP debug output (bool/default: '0', disabled)
-  * ban\_nice => set the nice level of the banIP process and all sub-processes (int/default: '0', standard priority)
-  * ban\_triggerdelay => additional trigger delay in seconds before banIP processing begins (int/default: '2')
-  * ban\_backupdir => target directory for banIP backups (default: '/tmp')
-  * ban\_sshdaemon => select the SSH daemon for logfile parsing, 'dropbear' or 'sshd' (default: 'dropbear')
-  * ban\_starttype => select the used start type during boot, 'start', 'refresh' or 'reload' (default: 'start')
-  * ban\_maxqueue => size of the download queue to handle downloads & IPSet processing in parallel (int/default: '4')
-  * ban\_fetchutil => name of the used download utility: 'uclient-fetch', 'wget', 'curl', 'aria2c' (default: not set, automatically detected)
-  * ban\_fetchparm => special config options for the download utility (default: not set)
-  * ban\_autoblacklist => store auto-addons temporary in ipset and permanently in local blacklist as well (bool/default: '1', enabled)
-  * ban\_autowhitelist => store auto-addons temporary in ipset and permanently in local whitelist as well (bool/default: '1', enabled)
-
-## Logging of banned packets
-* by setting ban\_log\_src=1 / ban\_log\_dst=1 in the config options, banIP will log banned inbound / outbound packets to syslog.
-* example of a logged inbound (dst) and outbound (src) packet:
-<pre><code>
-Oct  2 12:49:14 gateway kernel: [434134.855130] REJECT(dst banIP) IN=br-lan OUT=br-wan MAC=xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx SRC=x.x.x.x DST=x.x.x.x LEN=100 TOS=0x00 PREC=0x00 TTL=63 ID=7938 PROTO=UDP SPT=16393 DPT=16393 LEN=80
-
-Oct  3 14:11:13 gateway kernel: [11290.429712] DROP(src banIP) IN=br-wan OUT= MAC=xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx SRC=x.x.x.x DST=x.x.x.x LEN=40 TOS=0x00 PREC=0x00 TTL=235 ID=63275 PROTO=TCP SPT=48246 DPT=37860 WINDOW=1024 RES=0x00 SYN URGP=0
-</code></pre>
-* to change the default logging behavior, the following options can be added to the 'global' config section:
-  * ban\_log\_src\_opts => IPv4 iptables LOG options for banned inbound packets (default: '-m limit --limit 10/sec')
-  * ban\_log\_src\_opts\_6 => IPv6 iptables LOG options for banned inbound packets (default: '-m limit --limit 10/sec')
-  * ban\_log\_src\_prefix (default: '<ban\_target\_src>(src banIP) ', typically 'DROP(src banIP) ')
-  * ban\_log\_src\_prefix\_6 (default: '<ban\_target\_src\_6>(src banIP) ', typically 'DROP('src banIP)' )
-  * ban\_log\_dst\_opts => IPv4 iptables LOG options for banned outbound packets (default: '-m limit --limit 10/sec')
-  * ban\_log\_dst\_opts\_6 => IPv6 iptables LOG options for banned outbound packets (default: '-m limit --limit 10/sec')
-  * ban\_log\_dst\_prefix (default: '<ban\_target\_dst>(dst banIP) ', typically 'REJECT(dst banIP) ')
-  * ban\_log\_dst\_prefix\_6 (default: '<ban\_target\_dst\_6>(dst banIP) ', typically 'REJECT('dst banIP)' )
+    * ban\_debug => enable/disable banIP debug output (bool/default: '0', disabled)
+    * ban\_nice => set the nice level of the banIP process and all sub-processes (int/default: '0', standard priority)
+    * ban\_triggerdelay => additional trigger delay in seconds before banIP processing begins (int/default: '2')
+    * ban\_backupdir => target directory for banIP backups (default: '/tmp')
+    * ban\_sshdaemon => select the SSH daemon for logfile parsing, 'dropbear' or 'sshd' (default: 'dropbear')
+    * ban\_starttype => select the used start type during boot, 'start', 'refresh' or 'reload' (default: 'start')
+    * ban\_maxqueue => size of the download queue to handle downloads & IPSet processing in parallel (int/default: '4')
+    * ban\_fetchutil => name of the used download utility: 'uclient-fetch', 'wget', 'curl', 'aria2c' (default: not set, automatically detected)
+    * ban\_fetchparm => special config options for the download utility (default: not set)
+    * ban\_autoblacklist => store auto-addons temporary in ipset and permanently in local blacklist as well (bool/default: '1', enabled)
+    * ban\_autowhitelist => store auto-addons temporary in ipset and permanently in local whitelist as well (bool/default: '1', enabled)
 
 ## Examples
 **receive banIP runtime information:**
 
-```
+<pre><code>
 /etc/init.d/banip status
 ::: banIP runtime information
   + status     : enabled
@@ -101,14 +76,14 @@ Oct  3 14:11:13 gateway kernel: [11290.429712] DROP(src banIP) IN=br-wan OUT= MA
   + backup_dir : /tmp
   + last_run   : 03.10.2019 19:15:25
   + system     : UBNT-ERX, OpenWrt SNAPSHOT r11102-ced4c0e635
-```
-
+</code></pre>
+  
 **cronjob for a regular IPSet blocklist update (/etc/crontabs/root):**
 
-```
-# Every day at 06:00, update the IPSets of banIP
-00 06 * * *    /etc/init.d/banip reload
-```
+<pre><code>
+0 06 * * *    /etc/init.d/banip reload
+</code></pre>
+  
 
 ## Support
 Please join the banIP discussion in this [forum thread](https://forum.openwrt.org/t/banip-support-thread/16985) or contact me by mail <dev@brenken.org>  

--- a/net/banip/files/banip.conf
+++ b/net/banip/files/banip.conf
@@ -4,6 +4,8 @@ config banip 'global'
 	option ban_basever '0.3'
 	option ban_automatic '1'
 	option ban_realtime 'false'
+	option ban_log_src '0'
+	option ban_log_dst '0'
 
 config banip 'extra'
 	option ban_debug '0'

--- a/net/banip/files/banip.conf
+++ b/net/banip/files/banip.conf
@@ -4,8 +4,6 @@ config banip 'global'
 	option ban_basever '0.3'
 	option ban_automatic '1'
 	option ban_realtime 'false'
-	option ban_log_src '0'
-	option ban_log_dst '0'
 
 config banip 'extra'
 	option ban_debug '0'

--- a/net/banip/files/banip.init
+++ b/net/banip/files/banip.init
@@ -4,9 +4,8 @@
 START=30
 USE_PROCD=1
 
-EXTRA_COMMANDS="refresh status"
-EXTRA_HELP="	refresh	Refresh ipsets without new list downloads
-	status  Show banIP status"
+EXTRA_COMMANDS="refresh"
+EXTRA_HELP="	refresh	Refresh ipsets without new list downloads"
 
 ban_init="/etc/init.d/banip"
 ban_script="/usr/bin/banip.sh"
@@ -81,11 +80,6 @@ status_service()
 	else
 		printf "%s\\n" "::: no banIP runtime information available"
 	fi
-}
-
-status()
-{
-	status_service
 }
 
 service_triggers()

--- a/net/banip/files/banip.init
+++ b/net/banip/files/banip.init
@@ -4,8 +4,9 @@
 START=30
 USE_PROCD=1
 
-EXTRA_COMMANDS="refresh"
-EXTRA_HELP="	refresh	Refresh ipsets without new list downloads"
+EXTRA_COMMANDS="refresh status"
+EXTRA_HELP="	refresh	Refresh ipsets without new list downloads
+	status  Show banIP status"
 
 ban_init="/etc/init.d/banip"
 ban_script="/usr/bin/banip.sh"
@@ -80,6 +81,11 @@ status_service()
 	else
 		printf "%s\\n" "::: no banIP runtime information available"
 	fi
+}
+
+status()
+{
+	status_service
 }
 
 service_triggers()

--- a/net/banip/files/banip.sh
+++ b/net/banip/files/banip.sh
@@ -7,13 +7,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 # (s)hellcheck exceptions
-# shellcheck disable=1091,2039,2086,2140,2143,2181,2188
+# shellcheck disable=1091 disable=2039 disable=2143 disable=2181 disable=2188
 
 # set initial defaults
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-ban_ver="0.3.12"
+ban_ver="0.3.11"
 ban_basever=""
 ban_enabled=0
 ban_automatic="1"
@@ -42,8 +42,6 @@ ban_logservice="/etc/banip/banip.service"
 ban_sshdaemon=""
 ban_setcnt=0
 ban_cnt=0
-ban_log_src=0
-ban_log_dst=0
 
 # load environment
 #
@@ -98,28 +96,6 @@ f_envload()
 	#
 	config_load banip
 	config_foreach parse_config source
-
-	# setup logging
-	#
-	ban_log_chain_src="${ban_log_chain_src:-"${ban_chain}_log_src"}"
-	if [ "${ban_log_src}" -eq 1 ]
-	then
-		log_target_src="${ban_target_src:-"DROP"}"
-		ban_target_src="${ban_log_chain_src}"
-
-		log_target_src_6="${ban_target_src_6:-"DROP"}"
-		ban_target_src_6="${ban_log_chain_src}"
-	fi
-
-	ban_log_chain_dst="${ban_log_chain_dst:-"${ban_chain}_log_dst"}"
-	if [ "${ban_log_dst}" -eq 1 ]
-	then
-		log_target_dst="${ban_target_dst:-"REJECT"}"
-		ban_target_dst="${ban_log_chain_dst}"
-
-		log_target_dst_6="${ban_target_dst_6:-"REJECT"}"
-		ban_target_dst_6="${ban_log_chain_dst}"
-	fi
 
 	# log daemon check
 	#
@@ -283,7 +259,7 @@ f_envcheck()
 	fi
 	case "${util}" in
 		"aria2c")
-			ban_fetchparm="${ban_fetchparm:-"--timeout=20 --allow-overwrite=true --auto-file-renaming=false --check-certificate=true --dir=/ -o"}"
+			ban_fetchparm="${ban_fetchparm:-"--timeout=20 --allow-overwrite=true --auto-file-renaming=false --check-certificate=true --dir=" " -o"}"
 		;;
 		"curl")
 			ban_fetchparm="${ban_fetchparm:-"--connect-timeout 20 -o"}"
@@ -416,13 +392,15 @@ f_iptadd()
 	then
 		if [ "${src_ruletype}" != "dst" ]
 		then
-			f_iptrule "-I" "${wan_input} -j ${ban_chain}"
-			f_iptrule "-I" "${wan_forward} -j ${ban_chain}"
-			if [ "${src_name##*_}" != "6" ]
+			if [ "${src_name##*_}" = "6" ]
 			then
-				# special IPv4 rules
-				f_iptrule "-A" "${ban_chain} -p udp --dport 67:68 --sport 67:68 -j RETURN"
+				# dummy, special IPv6 rules
+				/bin/true
+			else
+				f_iptrule "-I" "${wan_input} -p udp --dport 67:68 --sport 67:68 -j RETURN"
 			fi
+			f_iptrule "-A" "${wan_input} -j ${ban_chain}"
+			f_iptrule "-A" "${wan_forward} -j ${ban_chain}"
 			for dev in ${ban_dev}
 			do
 				f_iptrule "${action:-"-A"}" "${ban_chain} -i ${dev} -m conntrack --ctstate NEW -m set --match-set ${src_name} src -j ${target_src}"
@@ -430,13 +408,15 @@ f_iptadd()
 		fi
 		if [ "${src_ruletype}" != "src" ]
 		then
-			f_iptrule "-I" "${lan_input} -j ${ban_chain}"
-			f_iptrule "-I" "${lan_forward} -j ${ban_chain}"
-			if [ "${src_name##*_}" != "6" ]
+			if [ "${src_name##*_}" = "6" ]
 			then
-				# special IPv4 rules
-				f_iptrule "-A" "${ban_chain} -p udp --dport 67:68 --sport 67:68 -j RETURN"
+				# dummy, special IPv6 rules
+				/bin/true
+			else
+				f_iptrule "-I" "${lan_input} -p udp --dport 67:68 --sport 67:68 -j RETURN"
 			fi
+			f_iptrule "-A" "${lan_input} -j ${ban_chain}"
+			f_iptrule "-A" "${lan_forward} -j ${ban_chain}"
 			for dev in ${ban_dev}
 			do
 				f_iptrule "${action:-"-A"}" "${ban_chain} -o ${dev} -m conntrack --ctstate NEW -m set --match-set ${src_name} dst -j ${target_dst}"
@@ -454,7 +434,7 @@ f_iptadd()
 #
 f_ipset()
 {
-	local out_rc source action ruleset rule cnt=0 cnt_ip=0 cnt_cidr=0 timeout="-w 5" mode="${1}" in_rc="${src_rc:-0}"
+	local out_rc source action ruleset ruleset_6 rule cnt=0 cnt_ip=0 cnt_cidr=0 timeout="-w 5" mode="${1}" in_rc="${src_rc:-0}"
 
 	if [ "${src_name%_6*}" = "whitelist" ]
 	then
@@ -491,81 +471,34 @@ f_ipset()
 			return "${out_rc}"
 		;;
 		"initial")
-			local ipt log_src_target log_src_opts log_src_prefix log_dst_target log_dst_opts log_dst_prefix
-			for src_name in "ruleset" "ruleset_6"
-			do
-				if [ "${src_name##*_}" = "6" ]
-				then
-					ipt="${ban_ipt6}"
-					ruleset="${ban_wan_input_chain_6:-"input_wan_rule"} ${ban_wan_forward_chain_6:-"forwarding_wan_rule"} ${ban_lan_input_chain_6:-"input_lan_rule"} ${ban_lan_forward_chain_6:-"forwarding_lan_rule"}"
-					log_src_target="${log_target_src_6}"
-					log_src_opts="${ban_log_src_opts_6:-"-m limit --limit 10/sec"}"
-					log_src_prefix="${ban_log_src_prefix_6:-"${log_target_src_6}(src banIP) "}"
-					log_dst_target="${log_target_dst_6}"
-					log_dst_opts="${ban_log_dst_opts_6:-"-m limit --limit 10/sec"}"
-					log_dst_prefix="${ban_log_dst_prefix_6:-"${log_target_dst_6}(dst banIP) "}"
-				else
-					ipt="${ban_ipt}"
-					ruleset="${ban_wan_input_chain:-"input_wan_rule"} ${ban_wan_forward_chain:-"forwarding_wan_rule"} ${ban_lan_input_chain:-"input_lan_rule"} ${ban_lan_forward_chain:-"forwarding_lan_rule"}"
-					log_src_target="${log_target_src}"
-					log_src_opts="${ban_log_src_opts:-"-m limit --limit 10/sec"}"
-					log_src_prefix="${ban_log_src_prefix:-"${log_target_src}(src banIP) "}"
-					log_dst_target="${log_target_dst}"
-					log_dst_opts="${ban_log_dst_opts:-"-m limit --limit 10/sec"}"
-					log_dst_prefix="${ban_log_dst_prefix:-"${log_target_dst}(dst banIP) "}"
-				fi
-
-				if [ -x "${ipt}" ]
-				then
-					if [ -z "$("${ipt}" "${timeout}" -nL "${ban_chain}" 2>/dev/null)" ]
-					then
-						"${ipt}" "${timeout}" -N "${ban_chain}" 2>/dev/null
-						out_rc="${?}"
-					else
-						out_rc=0
-						for rule in ${ruleset}
-						do
-							f_iptrule "-D" "${rule} -j ${ban_chain}"
-						done
-					fi
-					f_log "debug" "f_ipset ::: name: -, mode: ${mode:-"-"}, chain: ${ban_chain:-"-"}, $src_name: ${ruleset:-"-"}, out_rc: ${out_rc}"
-
-					if [ "${ban_log_src}" -eq 1 ] && [ "${out_rc}" -eq 0 ]
-					then
-						if [ -z "$("${ipt}" "${timeout}" -nL "${ban_log_chain_src}" 2>/dev/null)" ]
-						then
-							"${ipt}" "${timeout}" -N "${ban_log_chain_src}" 2>/dev/null
-							out_rc="${?}"
-							if [ "${out_rc}" -eq 0 ]
-							then
-								"${ipt}" "${timeout}" -A "${ban_log_chain_src}" -j LOG ${log_src_opts} --log-prefix "${log_src_prefix}" && \
-									"${ipt}" "${timeout}" -A "${ban_log_chain_src}" -j "${log_src_target}"
-								out_rc="${?}"
-							fi
-						fi
-						f_log "debug" "f_ipset ::: name: -, mode: ${mode:-"-"}, chain: ${ban_log_chain_src:-"-"}, out_rc: ${out_rc}"
-					fi
-
-					if [ "${ban_log_dst}" -eq 1 ] && [ "${out_rc}" -eq 0 ]
-					then
-						if [ -z "$("${ipt}" "${timeout}" -nL "${ban_log_chain_dst}" 2>/dev/null)" ]
-						then
-							"${ipt}" "${timeout}" -N "${ban_log_chain_dst}" 2>/dev/null
-							out_rc="${?}"
-							if [ "${out_rc}" -eq 0 ]
-							then
-								"${ipt}" "${timeout}" -A "${ban_log_chain_dst}" -j LOG ${log_dst_opts} --log-prefix "${log_dst_prefix}" && \
-									"${ipt}" "${timeout}" -A "${ban_log_chain_dst}" -j "${log_dst_target}"
-								out_rc="${?}"
-							fi
-						fi
-						f_log "debug" "f_ipset ::: name: -, mode: ${mode:-"-"}, chain: ${ban_log_chain_dst:-"-"}, out_rc: ${out_rc}"
-					fi
-				fi
-			done
-
+			if [ -x "${ban_ipt}" ] && [ -z "$("${ban_ipt}" "${timeout}" -nL "${ban_chain}" 2>/dev/null)" ]
+			then
+				"${ban_ipt}" "${timeout}" -N "${ban_chain}" 2>/dev/null
+				out_rc="${?}"
+			elif [ -x "${ban_ipt}" ]
+			then
+				src_name="ruleset"
+				ruleset="${ban_wan_input_chain:-"input_wan_rule"} ${ban_wan_forward_chain:-"forwarding_wan_rule"} ${ban_lan_input_chain:-"input_lan_rule"} ${ban_lan_forward_chain:-"forwarding_lan_rule"}"
+				for rule in ${ruleset}
+				do
+					f_iptrule "-D" "${rule} -j ${ban_chain}"
+				done
+			fi
+			if [ -x "${ban_ipt6}" ] && [ -z "$("${ban_ipt6}" "${timeout}" -nL "${ban_chain}" 2>/dev/null)" ]
+			then
+				"${ban_ipt6}" "${timeout}" -N "${ban_chain}" 2>/dev/null
+				out_rc="${?}"
+			elif [ -x "${ban_ipt6}" ]
+			then
+				src_name="ruleset_6"
+				ruleset_6="${ban_wan_input_chain_6:-"input_wan_rule"} ${ban_wan_forward_chain_6:-"forwarding_wan_rule"} ${ban_lan_input_chain_6:-"input_lan_rule"} ${ban_lan_forward_chain_6:-"forwarding_lan_rule"}"
+				for rule in ${ruleset_6}
+				do
+					f_iptrule "-D" "${rule} -j ${ban_chain}"
+				done
+			fi
 			out_rc="${out_rc:-"${in_rc}"}"
-			f_log "debug" "f_ipset ::: name: -, mode: ${mode:-"-"}, out_rc: ${out_rc}"
+			f_log "debug" "f_ipset ::: name: -, mode: ${mode:-"-"}, chain: ${ban_chain:-"-"}, ruleset: ${ruleset:-"-"}, ruleset_6: ${ruleset_6:-"-"}, out_rc: ${out_rc}"
 			return "${out_rc}"
 		;;
 		"create")
@@ -629,23 +562,20 @@ f_ipset()
 			f_log "debug" "f_ipset ::: name: ${src_name:-"-"}, mode: ${mode:-"-"}"
 		;;
 		"destroy")
-			for chain in ${ban_log_chain_src} ${ban_log_chain_dst} ${ban_chain}
-			do
-				if [ -x "${ban_ipt}" ] && [ -x "${ban_ipt_save}" ] && [ -x "${ban_ipt_restore}" ] && \
-					[ -n "$("${ban_ipt}" "${timeout}" -nL "${chain}" 2>/dev/null)" ]
-				then
-					"${ban_ipt_save}" | grep -v -- "-j ${chain}" | "${ban_ipt_restore}"
-					"${ban_ipt}" "${timeout}" -F "${chain}" 2>/dev/null
-					"${ban_ipt}" "${timeout}" -X "${chain}" 2>/dev/null
-				fi
-				if [ -x "${ban_ipt6}" ] && [ -x "${ban_ipt6_save}" ] && [ -x "${ban_ipt6_restore}" ] && \
-					[ -n "$("${ban_ipt6}" "${timeout}" -nL "${chain}" 2>/dev/null)" ]
-				then
-					"${ban_ipt6_save}" | grep -v -- "-j ${chain}" | "${ban_ipt6_restore}"
-					"${ban_ipt6}" "${timeout}" -F "${chain}" 2>/dev/null
-					"${ban_ipt6}" "${timeout}" -X "${chain}" 2>/dev/null
-				fi
-			done
+			if [ -x "${ban_ipt}" ] && [ -x "${ban_ipt_save}" ] && [ -x "${ban_ipt_restore}" ] && \
+				[ -n "$("${ban_ipt}" "${timeout}" -nL "${ban_chain}" 2>/dev/null)" ]
+			then
+				"${ban_ipt_save}" | grep -v -- "-j ${ban_chain}" | "${ban_ipt_restore}"
+				"${ban_ipt}" "${timeout}" -F "${ban_chain}" 2>/dev/null
+				"${ban_ipt}" "${timeout}" -X "${ban_chain}" 2>/dev/null
+			fi
+			if [ -x "${ban_ipt6}" ] && [ -x "${ban_ipt6_save}" ] && [ -x "${ban_ipt6_restore}" ] && \
+				[ -n "$("${ban_ipt6}" "${timeout}" -nL "${ban_chain}" 2>/dev/null)" ]
+			then
+				"${ban_ipt6_save}" | grep -v -- "-j ${ban_chain}" | "${ban_ipt6_restore}"
+				"${ban_ipt6}" "${timeout}" -F "${ban_chain}" 2>/dev/null
+				"${ban_ipt6}" "${timeout}" -X "${ban_chain}" 2>/dev/null
+			fi
 			for source in ${ban_sources}
 			do
 				if [ -x "${ban_ipset}" ] && [ -n "$("${ban_ipset}" -q -n list "${source}")" ]
@@ -965,15 +895,14 @@ f_main()
 
 	if [ -z "$(ls "${ban_tmpfile}".*.err 2>/dev/null)" ]
 	then
-                for cnt_file in "${ban_tmpfile}".*.cnt
-                do
-			if [ -f "$cnt_file" ]
-			then
-				read -r cnt < "$cnt_file"
-				ban_cnt="$((ban_cnt+cnt))"
-				ban_setcnt="$((ban_setcnt+1))"
-			fi
-                done
+		for cnt in $(cat "${ban_tmpfile}".*.cnt 2>/dev/null)
+		do
+			ban_cnt="$((ban_cnt+cnt))"
+		done
+		if [ "${ban_cnt}" -gt 0 ]
+		then
+			ban_setcnt="$(ls "${ban_tmpfile}".*.cnt 2>/dev/null | wc -l)"
+		fi
 		f_log "info" "${ban_setcnt} IPSets with overall ${ban_cnt} IPs/Prefixes loaded successfully (${ban_sysver})"
 		f_bgserv "start"
 		f_jsnup

--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=2.0.1
-PKG_RELEASE:=2
+PKG_VERSION:=2.0.2
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 
@@ -17,7 +17,7 @@ define Package/travelmate
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=A wlan connection manager for travel router
-	DEPENDS:=+iwinfo +jshn +jsonfilter +curl +ca-bundle +dnsmasq
+	DEPENDS:=+iwinfo +jshn +jsonfilter +curl +ca-bundle
 	PKGARCH:=all
 endef
 

--- a/net/travelmate/files/chs-hotel.login
+++ b/net/travelmate/files/chs-hotel.login
@@ -3,26 +3,32 @@
 # Copyright (c) 2020 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
-domain="hotspot.internet-for-guests.com"
-cmd="$(command -v curl)"
+# set (s)hellcheck exceptions
+# shellcheck disable=1091,2016,2039,2059,2086,2143,2181,2188
 
-# curl check
-#
-if [ ! -x "${cmd}" ]
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+set -o pipefail
+
+if [ "$(uci_get 2>/dev/null; printf "%u" "${?}")" = "127" ]
 then
-	exit 1
+	. "/lib/functions.sh"
 fi
+
+trm_domain="hotspot.internet-for-guests.com"
+trm_useragent="$(uci_get travelmate global trm_useragent "Mozilla/5.0 (Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0")"
+trm_maxwait="$(uci_get travelmate global trm_maxwait "30")"
+trm_fetch="$(command -v curl)"
 
 # initial get request to receive & extract valid security tokens
 #
-"${cmd}" "https://${domain}/logon/cgi/index.cgi" -c "/tmp/${domain}.cookie" -s -o /dev/null
-
-if [ -r "/tmp/${domain}.cookie" ]
+"${trm_fetch}" --user-agent "${trm_useragent}" --referer "http://www.example.com" --silent --connect-timeout $((trm_maxwait/6)) --cookie-jar "/tmp/${trm_domain}.cookie" --output /dev/null "https://${trm_domain}/logon/cgi/index.cgi"
+if [ -r "/tmp/${trm_domain}.cookie" ]
 then
-	lg_id="$(awk '/LGNSID/{print $7}' "/tmp/${domain}.cookie")"
-	ta_id="$(awk '/ta_id/{print $7}' "/tmp/${domain}.cookie")"
-	cl_id="$(awk '/cl_id/{print $7}' "/tmp/${domain}.cookie")"
-	rm -f "/tmp/${domain}.cookie"
+	lg_id="$(awk '/LGNSID/{print $7}' "/tmp/${trm_domain}.cookie")"
+	ta_id="$(awk '/ta_id/{print $7}' "/tmp/${trm_domain}.cookie")"
+	cl_id="$(awk '/cl_id/{print $7}' "/tmp/${trm_domain}.cookie")"
+	rm -f "/tmp/${trm_domain}.cookie"
 else
 	exit 2
 fi
@@ -31,7 +37,7 @@ fi
 #
 if [ -n "${lg_id}" ] && [ -n "${ta_id}" ] && [ -n "${cl_id}" ]
 then
-	"${cmd}" "https://${domain}/logon/cgi/index.cgi" -H "Referer: https://${domain}/logon/cgi/index.cgi" -H "Cookie: LGNSID=${lg_id}; lang=en_US; use_mobile_interface=0; ta_id=${ta_id}; cl_id=${cl_id}" -H 'Connection: keep-alive' --data 'accept_termsofuse=&freeperperiod=1&device_infos=1125:2048:1152:2048' -s -o /dev/null
+	"${trm_fetch}" --user-agent "${trm_useragent}" --referer "https://${trm_domain}/logon/cgi/index.cgi" --silent --connect-timeout $((trm_maxwait/6)) --header "Cookie: LGNSID=${lg_id}; lang=en_US; use_mobile_interface=0; ta_id=${ta_id}; cl_id=${cl_id}" --data "accept_termsofuse=&freeperperiod=1&device_infos=1125:2048:1152:2048" --output /dev/null "https://${trm_domain}/logon/cgi/index.cgi"
 else
 	exit 3
 fi

--- a/net/travelmate/files/db-bahn.login
+++ b/net/travelmate/files/db-bahn.login
@@ -3,6 +3,18 @@
 # Copyright (c) 2020 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
+# set (s)hellcheck exceptions
+# shellcheck disable=1091,2016,2039,2059,2086,2143,2181,2188
+
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+set -o pipefail
+
+if [ "$(uci_get 2>/dev/null; printf "%u" "${?}")" = "127" ]
+then
+	. "/lib/functions.sh"
+fi
+
 trm_domain="wifi.bahn.de"
 trm_useragent="$(uci_get travelmate global trm_useragent "Mozilla/5.0 (Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0")"
 trm_maxwait="$(uci_get travelmate global trm_maxwait "30")"
@@ -16,7 +28,7 @@ trm_fetch="$(command -v curl)"
 #
 if [ -s "/tmp/${trm_domain}.cookie" ]
 then
-	php_token="$(awk 'BEGIN{FS="[ ;]"}/^Set-Cookie:/{print $2}' "/tmp/${trm_domain}.cookie")"
+	sec_token="$(awk 'BEGIN{FS="[ ;]"}/^Set-Cookie:/{print $2}' "/tmp/${trm_domain}.cookie")"
 	location="$(awk '/^Location:/{print $2}' "/tmp/${trm_domain}.cookie")"
 	rm -f "/tmp/${trm_domain}.cookie"
 else
@@ -25,9 +37,9 @@ fi
 
 # post request to subscribe to the portal API
 #
-if [ -n "${php_token}" ] && [ -n "${location}" ]
+if [ -n "${sec_token}" ] && [ -n "${location}" ]
 then
-	"${trm_fetch}" --user-agent "${trm_useragent}" --referer "${location}" --silent  --connect-timeout $((trm_maxwait/6)) --include --cookie-jar "/tmp/${trm_domain}.cookie" --header "Cookie: ${php_token}" --data "action=subscribe&type=one&connect_policy_accept=false&user_login=&user_password=&user_password_confirm=&email_address=&prefix=&phone=&policy_accept=false&gender=&interests=" --output /dev/null "https://${trm_domain}/portal_api.php"
+	"${trm_fetch}" --user-agent "${trm_useragent}" --referer "${location}" --silent  --connect-timeout $((trm_maxwait/6)) --include --cookie-jar "/tmp/${trm_domain}.cookie" --header "Cookie: ${sec_token}" --data "action=subscribe&type=one&connect_policy_accept=false&user_login=&user_password=&user_password_confirm=&email_address=&prefix=&phone=&policy_accept=false&gender=&interests=" --output /dev/null "https://${trm_domain}/portal_api.php"
 else
 	exit 3
 fi
@@ -47,7 +59,7 @@ fi
 #
 if [ -n "${login}" ] && [ -n "${password}" ]
 then
-	"${trm_fetch}" --user-agent "${trm_useragent}" --referer "${location}" --silent --connect-timeout $((trm_maxwait/6)) --header "Cookie: ${php_token}" --data "action=authenticate&login=${login}&password=${password}&policy_accept=false&from_ajax=true&wispr_mode=false" "https://${trm_domain}/portal_api.php"
+	"${trm_fetch}" --user-agent "${trm_useragent}" --referer "${location}" --silent --connect-timeout $((trm_maxwait/6)) --header "Cookie: ${sec_token}" --data "action=authenticate&login=${login}&password=${password}&policy_accept=false&from_ajax=true&wispr_mode=false" "https://${trm_domain}/portal_api.php"
 else
 	exit 5
 fi

--- a/net/travelmate/files/generic-user-pass.login
+++ b/net/travelmate/files/generic-user-pass.login
@@ -1,18 +1,33 @@
 #!/bin/sh
+# captive portal auto-login script template with credentials as parameters
+# Copyright (c) 2020 Dirk Brenken (dev@brenken.org)
+# This is free software, licensed under the GNU General Public License v3.
 
-cmd="$(command -v curl)"
-url="http://example.com/"
-success_string="Thank you!"
+# set (s)hellcheck exceptions
+# shellcheck disable=1091,2016,2039,2059,2086,2143,2181,2188
 
-if [ ! -x "${cmd}" ]
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+set -o pipefail
+
+if [ "$(uci_get 2>/dev/null; printf "%u" "${?}")" = "127" ]
 then
-	exit 1
+	. "/lib/functions.sh"
 fi
 
-response="$("${cmd}" $url -d "username=${1}&password=${2}" \
-	--header "Content-Type:application/x-www-form-urlencoded" -s)"
+trm_domain="example.com"
+trm_useragent="$(uci_get travelmate global trm_useragent "Mozilla/5.0 (Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0")"
+trm_maxwait="$(uci_get travelmate global trm_maxwait "30")"
+trm_fetch="$(command -v curl)"
 
-if [ -n "$(printf "%s" "${response}" | grep "${success_string}")" ]
+user="${1}"
+password="${2}"
+success="Thank you!"
+
+# login with credentials
+#
+response="$("${trm_fetch}" --user-agent "${trm_useragent}" --referer "http://www.example.com" --silent --connect-timeout $((trm_maxwait/6)) --data "username=${user}&password=${password}" --header "Content-Type:application/x-www-form-urlencoded" "http://${trm_domain}")"
+if [ -n "$(printf "%s" "${response}" | grep "${success}")" ]
 then
 	exit 0
 else

--- a/net/travelmate/files/h-hotels.login
+++ b/net/travelmate/files/h-hotels.login
@@ -3,26 +3,32 @@
 # Copyright (c) 2020 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
-domain="hotspot.t-mobile.net"
-cmd="$(command -v curl)"
+# set (s)hellcheck exceptions
+# shellcheck disable=1091,2016,2039,2059,2086,2143,2181,2188
 
-# curl check
-#
-if [ ! -x "${cmd}" ]
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+set -o pipefail
+
+if [ "$(uci_get 2>/dev/null; printf "%u" "${?}")" = "127" ]
 then
-	exit 1
+	. "/lib/functions.sh"
 fi
+
+trm_domain="hotspot.t-mobile.net"
+trm_useragent="$(uci_get travelmate global trm_useragent "Mozilla/5.0 (Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0")"
+trm_maxwait="$(uci_get travelmate global trm_maxwait "30")"
+trm_fetch="$(command -v curl)"
 
 # initial get request to receive & extract valid security tokens
 #
-"${cmd}" "https://${domain}/wlan/rest/freeLogin" -c "/tmp/${domain}.cookie" -s -o /dev/null
-
-if [ -r "/tmp/${domain}.cookie" ]
+"${trm_fetch}" --user-agent "${trm_useragent}" --referer "http://www.example.com" --silent --connect-timeout $((trm_maxwait/6)) --cookie-jar "/tmp/${trm_domain}.cookie" --output /dev/null "https://${trm_domain}/wlan/rest/freeLogin"
+if [ -r "/tmp/${trm_domain}.cookie" ]
 then
-	ses_id="$(awk '/JSESSIONID/{print $7}' "/tmp/${domain}.cookie")"
-	sec_id="$(awk '/DT_H/{print $7}' "/tmp/${domain}.cookie")"
+	ses_id="$(awk '/JSESSIONID/{print $7}' "/tmp/${trm_domain}.cookie")"
+	sec_id="$(awk '/DT_H/{print $7}' "/tmp/${trm_domain}.cookie")"
 	dev_id="$(sha256sum /etc/config/wireless | awk '{printf "%s",substr($1,1,13)}')"
-	rm -f "/tmp/${domain}.cookie"
+	rm -f "/tmp/${trm_domain}.cookie"
 else
 	exit 2
 fi
@@ -31,7 +37,7 @@ fi
 #
 if [ -n "${ses_id}" ] && [ -n "${sec_id}" ] && [ -n "${dev_id}" ]
 then
-	"${cmd}" "https://${domain}/wlan/rest/freeLogin" -H "Referer: https://${domain}/TD/hotspot/H_Hotels/en_GB/index.html" -H "Cookie: JSESSIONID=${ses_id}; DT_DEV_ID=${dev_id}; DT_H=${sec_id}" -H 'Connection: keep-alive' --data "rememberMe=true" -s -o /dev/null
+	"${trm_fetch}" --user-agent "${trm_useragent}" --referer "https://${trm_domain}/TD/hotspot/H_Hotels/en_GB/index.html" --silent --connect-timeout $((trm_maxwait/6)) --header "Cookie: JSESSIONID=${ses_id}; DT_DEV_ID=${dev_id}; DT_H=${sec_id}" --data "rememberMe=true" --output /dev/null "https://${trm_domain}/wlan/rest/freeLogin"
 else
 	exit 3
 fi

--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 
 # set (s)hellcheck exceptions
-# shellcheck disable=1091,2016,2039,2059,2086,2143,2181,2188
+# shellcheck disable=1091,2016,2034,2039,2059,2086,2143,2181,2188
 
 START=25
 USE_PROCD=1
@@ -25,7 +25,7 @@ boot()
 
 start_service()
 {
-	if [ "$("${trm_init}" enabled; printf "%u" ${?})" -eq "0" ]
+	if [ "$("${trm_init}" enabled; printf "%u" ${?})" = "0" ]
 	then
 		procd_open_instance "travelmate"
 		procd_set_param command "${trm_script}" "${@}"
@@ -69,7 +69,7 @@ status_service()
 	rtfile="$(uci_get travelmate global trm_rtfile "/tmp/trm_runtime.json")"
 	json_load_file "${rtfile}" >/dev/null 2>&1
 	json_select data >/dev/null 2>&1
-	if [ ${?} -eq 0 ]
+	if [ "${?}" = "0" ]
 	then
 		printf "%s\n" "::: travelmate runtime information"
 		json_get_keys keylist

--- a/net/travelmate/files/travelmate.mail
+++ b/net/travelmate/files/travelmate.mail
@@ -8,10 +8,15 @@
 
 # Please note: you have to setup the package 'msmtp' before using this script
 
-LC_ALL=C
-PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+set -o pipefail
 
-. "/lib/functions.sh"
+if [ "$(uci_get 2>/dev/null; printf "%u" "${?}")" = "127" ]
+then
+	. "/lib/functions.sh"
+fi
+
 trm_debug="$(uci_get travelmate global trm_debug "0")"
 trm_mailreceiver="$(uci_get travelmate global trm_mailreceiver)"
 trm_mailprofile="$(uci_get travelmate global trm_mailprofile "trm_notify")"
@@ -38,7 +43,7 @@ then
 	exit 1
 fi
 
-if [ "${trm_debug}" -eq "1" ]
+if [ "${trm_debug}" = "1" ]
 then
 	debug="--debug"
 fi

--- a/net/travelmate/files/travelmate.vpn
+++ b/net/travelmate/files/travelmate.vpn
@@ -8,10 +8,15 @@
 
 # Please note: you have to setup the package 'wireguard' or 'openvpn' before using this script
 
-LC_ALL=C
-PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+set -o pipefail
 
-. "/lib/functions.sh"
+if [ "$(uci_get 2>/dev/null; printf "%u" "${?}")" = "127" ]
+then
+	. "/lib/functions.sh"
+fi
+
 vpn_action="${1}"
 trm_vpnservice="$(uci_get travelmate global trm_vpnservice)"
 trm_vpniface="$(uci_get travelmate global trm_vpniface)"
@@ -60,7 +65,8 @@ then
 	vpn_status="$(ubus -S call network.interface."${trm_vpniface}" status 2>/dev/null | jsonfilter -l1 -e '@.up')"
 	if [ "${vpn_action}" = "disable" ] && [ "${vpn_status}" = "true" ]
 	then
-		if [ -n "$("${trm_iptables}" "-w $((trm_maxwait/6))" -C ${trm_iptrule_drop} 2>&1)" ]
+		if [ -n "$("${trm_iptables}" "-w $((trm_maxwait/6))" -C ${trm_iptrule_drop} 2>&1)" ] && \
+			[ -n "$("${trm_iptables}" "-w $((trm_maxwait/6))" -C ${trm_iptrule_accept} 2>&1)" ]
 		then
 			"${trm_iptables}" "-w $((trm_maxwait/6))" -I ${trm_iptrule_drop} 2>&1
 			f_log "info" "lan forward blocked for device '${trm_landevice}'"
@@ -68,7 +74,8 @@ then
 	fi
 	if [ "${vpn_action}" = "disable" ] && [ "${status%% (net cp *}" = "connected" ]
 	then
-		if [ -n "$("${trm_iptables}" "-w $((trm_maxwait/6))" -C ${trm_iptrule_accept} 2>&1)" ]
+		if [ -n "$("${trm_iptables}" "-w $((trm_maxwait/6))" -C ${trm_iptrule_accept} 2>&1)" ] && \
+			[ -z "$("${trm_iptables}" "-w $((trm_maxwait/6))" -C ${trm_iptrule_drop} 2>&1)" ]
 		then
 			"${trm_iptables}" "-w $((trm_maxwait/6))" -I ${trm_iptrule_accept} 2>&1
 			f_log "info" "lan forward on ports 80/443 freed for device '${trm_landevice}'"

--- a/net/travelmate/files/travelmate_ntp.hotplug
+++ b/net/travelmate/files/travelmate_ntp.hotplug
@@ -23,7 +23,7 @@ f_log()
 }
 
 if [ "${ACTION}" = "stratum" ] && [ ! -f "${trm_ntpfile}" ] && \
-	[ "$("${trm_init}" enabled; printf "%u" ${?})" -eq "0" ]
+	[ "$("${trm_init}" enabled; printf "%u" ${?})" = "0" ]
 then
 	> "${trm_ntpfile}"
 	f_log "info" "get ntp time sync"

--- a/net/travelmate/files/wifionice.login
+++ b/net/travelmate/files/wifionice.login
@@ -3,6 +3,18 @@
 # Copyright (c) 2020 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
+# set (s)hellcheck exceptions
+# shellcheck disable=1091,2016,2039,2059,2086,2143,2181,2188
+
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+set -o pipefail
+
+if [ "$(uci_get 2>/dev/null; printf "%u" "${?}")" = "127" ]
+then
+	. "/lib/functions.sh"
+fi
+
 trm_domain="www.wifionice.de"
 trm_useragent="$(uci_get travelmate global trm_useragent "Mozilla/5.0 (Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0")"
 trm_maxwait="$(uci_get travelmate global trm_maxwait "30")"


### PR DESCRIPTION
Maintainer: @dibdot 
Compile tested: n/a
Run tested: ipq806x, Netgear R7800, OpenWRT 19.7.04.

Description:
Added ability to log IP packets being blocked via banIP by creating additional src (inbound) and/or dst (outbound) logging chains.

Logging can be enabled using the `config banip 'global'` options:

```
        option ban_log_src '1'
        option ban_log_dst '1'
```

Possible customizations, showing default values:

```
ban_log_chain_src       ${ban_chain}_log_src
ban_log_chain_dst       ${ban_chain}_log_dst
ban_log_src_opts_6      -m limit --limit 10/sec
ban_log_src_prefix_6    ${ban_target_src_6}(src banIP)
ban_log_dst_opts_6      -m limit --limit 10/sec
ban_log_dst_prefix_6    ${ban_target_dst_6}(dst banIP)
ban_log_src_opts        -m limit --limit 10/sec
ban_log_src_prefix      ${ban_target_src}(src banIP)
ban_log_dst_opts        -m limit --limit 10/sec
ban_log_dst_prefix      ${ban_target_dst}(dst banIP)
```

Example of logged packets:
```
Oct  2 12:49:14 gateway kernel: [434134.855130] REJECT(dst banIP) IN=br-lan OUT=br-wan MAC=xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx SRC=x.x.x.x DST=x.x.x.x LEN=100 TOS=0x00 PREC=0x00 TTL=63 ID=7938 PROTO=UDP SPT=16393 DPT=16393 LEN=80

Oct  3 14:11:13 gateway kernel: [11290.429712] DROP(src banIP) IN=br-wan OUT= MAC=xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx SRC=x.x.x.x DST=x.x.x.x LEN=40 TOS=0x00 PREC=0x00 TTL=235 ID=63275 PROTO=TCP SPT=48246 DPT=37860 WINDOW=1024 RES=0x00 SYN URGP=0
```
