### PR TITLE
ddns-scripts: re-add no-ip.com to list of supported providers

### DIFF
--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -49,6 +49,7 @@ myonlineportal.net
 mythic-beasts.com
 namecheap.com
 nettica.com
+no-ip.com
 no-ip.pl
 now-dns.com
 nsupdate.info


### PR DESCRIPTION
@feckert I'm not sure if this list is purely descriptive or if it's parsed by e.g. the LuCI frontend, but No-IP.com got dropped from that list in the overhaul. This adds it back.