### PR TITLE
dnstap: update to version 0.2.2

### DIFF
--- a/net/dnstap/Makefile
+++ b/net/dnstap/Makefile
@@ -8,19 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnstap
-PKG_VERSION:=0.2.1
+PKG_VERSION:=0.2.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=golang-dnstap-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/dnstap/golang-dnstap/archive/v$(PKG_VERSION)/
-PKG_HASH:=2b0b7bf32ceb2cdbc4d3956a7bd437ef332c615443a4dee808d9c1129ffd7f30
+PKG_HASH:=c7eb42f1f0ca7247b22b774dd78d9874b9db776fa9072f92a5f3a945000b7a60
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/golang-dnstap-$(PKG_VERSION)
-PKG_BUILD_DEPENDS:=golang/host 
+PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
@@ -32,7 +32,7 @@ include ../../lang/golang/golang-package.mk
 define Package/dnstap
   SECTION:=net
   CATEGORY:=Network
-  TITLE:=dnstap command-line tool 
+  TITLE:=dnstap command-line tool
   URL:=https://dnstap.info
   DEPENDS:=$(GO_ARCH_DEPENDS)
 endef


### PR DESCRIPTION
maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates dnstap to version 0.2.2 It removes non-blocking channel write from output.



