### PR TITLE
libshout: update to 2.4.4

### DIFF
--- a/libs/libshout/Makefile
+++ b/libs/libshout/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libshout
-PKG_VERSION:=2.4.3
-PKG_RELEASE:=2
+PKG_VERSION:=2.4.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.us.xiph.org/releases/libshout/
-PKG_HASH:=0d8af55d1141bf90710bcd41a768c9cc5adb251502a0af1dd22c8da215d40dfe
+PKG_HASH:=8ce90c5d05e7ad1da4c12f185837e8a867c22df2d557b0125afaba4b1438e6c3
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/libs/libshout/patches/130-usleep.patch
+++ b/libs/libshout/patches/130-usleep.patch
@@ -1,6 +1,14 @@
 --- a/examples/nonblocking.c
 +++ b/examples/nonblocking.c
-@@ -70,8 +70,10 @@ int main()
+@@ -6,6 +6,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <time.h>
+ #include <unistd.h>
+ 
+ #include <shout/shout.h>
+@@ -70,8 +71,10 @@ int main()
      if (ret == SHOUTERR_BUSY)
          printf("Connection pending...\n");
  


### PR DESCRIPTION
Small fix to nanosleep patch.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: ath79