### PR TITLE
[lighttpd] Pull in mod-authn_file with mod-auth

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.55
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x
@@ -146,8 +146,8 @@ $(eval $(call BuildPackage,lighttpd))
 $(eval $(call BuildPlugin,redirect,URL redirection,+PACKAGE_lighttpd-mod-redirect:libpcre,10))
 
 # Next, permit authentication.
-$(eval $(call BuildPlugin,auth,Authentication,,20))
-$(eval $(call BuildPlugin,authn_file,File-based authentication,lighttpd-mod-auth,20))
+$(eval $(call BuildPlugin,auth,Authentication,+PACKAGE_lighttpd-mod-auth:lighttpd-mod-authn_file,20))
+$(eval $(call BuildPlugin,authn_file,File-based authentication,,20))
 $(eval $(call BuildPlugin,authn_gssapi,Kerberos-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_gssapi:krb5-libs,20))
 $(eval $(call BuildPlugin,authn_ldap,LDAP-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_ldap:libopenldap,20))
 $(eval $(call BuildPlugin,authn_mysql,Mysql-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_mysql:libmysqlclient,20))


### PR DESCRIPTION
If lighttpd loads mod-auth, it also automatically tries to load
mod-authn_file, and fails if it's not available. That is a compatibility
feature of lighttpd after the funtionality was split into modules.

Signed-off-by: Jan Kardell <jan.kardell@telliq.com>

Maintainer: @flyn-org
Compile tested: (omap, 19.07)
Run tested: (omap, 19.07)

Description:
