### PR TITLE
debootstrap: update to version 1.0.123

### DIFF
--- a/admin/debootstrap/Makefile
+++ b/admin/debootstrap/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=debootstrap
-PKG_VERSION:=1.0.119~bpo10+1
+PKG_VERSION:=1.0.123
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-udeb_$(PKG_VERSION)_all.udeb
 PKG_SOURCE_URL:=http://ftp.debian.org/debian/pool/main/d/debootstrap
-PKG_HASH:=b48aeb76533f233ac45c8b5ddd452550b3998e67e32dba4137f320a1a7b3519e
+PKG_HASH:=df537297f212a7ffab3bb033065a466887e552a579d4f7115f2d042a86ba811f
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=Unique


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:

- Update to version [1.0.123](https://metadata.ftp-master.debian.org/changelogs//main/d/debootstrap/debootstrap_1.0.123_changelog)