### PR TITLE
gst1-plugins-bad: add back mpegtsdemux & mpegtsmux

### DIFF
--- a/multimedia/gst1-plugins-bad/Makefile
+++ b/multimedia/gst1-plugins-bad/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-bad
 PKG_VERSION:=1.18.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=gst-plugins-bad-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gst-plugins-bad/
@@ -308,6 +308,8 @@ $(eval $(call GstBuildLibrary,adaptivedemux,adaptivedemux,app uridownloader,))
 $(eval $(call GstBuildLibrary,photography,photography,,))
 $(eval $(call GstBuildLibrary,basecamerabinsrc,basecamerabinsrc,app,))
 $(eval $(call GstBuildLibrary,uridownloader,uridownloader,,))
+$(eval $(call GstBuildLibrary,codecparsers,codecparsers,,))
+$(eval $(call GstBuildLibrary,mpegts,mpegts,,))
 
 # 1: short name
 # 2: description
@@ -380,8 +382,8 @@ $(eval $(call GstBuildPlugin,legacyrawparse,rawparse support,audio video,,))
 $(eval $(call GstBuildPlugin,midi,midi support,audio,,))
 $(eval $(call GstBuildPlugin,mpegpsdemux,mpegpsdemux support,pbutils,,))
 $(eval $(call GstBuildPlugin,mpegpsmux,mpegpsmux support,,,))
-#$(eval $(call GstBuildPlugin,mpegtsdemux,mpegtsdemux support,mpegts pbutils,,))
-#$(eval $(call GstBuildPlugin,mpegtsmux,mpegtsmux support,video,,))
+$(eval $(call GstBuildPlugin,mpegtsdemux,mpegtsdemux support,codecparsers mpegts pbutils,,))
+$(eval $(call GstBuildPlugin,mpegtsmux,mpegtsmux support,mpegts video,,))
 $(eval $(call GstBuildPlugin,mxf,mxf support,audio video,,))
 $(eval $(call GstBuildPlugin,netsim,netsim support,,,))
 $(eval $(call GstBuildPlugin,pcapparse,pcapparse support,,,))


### PR DESCRIPTION
These plugins were disabled in commit e35d46b. Add them back. The
required libs are added, too.

Closes #13545

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @flyn-org @thess 
Compile tested: ath79 master
Run tested: nope, not bored enough for that :)

Description:
Had a bit of time on my hands and thought I may give #13545 a try. I had initially thought this would be more involved, but the Makefile actually makes it very easy to add libs and plugins. :)

Kind regards,
Seb
