### PR TITLE
[19.07] libuv: update to 1.40.0

### DIFF
--- a/libs/libuv/Makefile
+++ b/libs/libuv/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuv
-PKG_VERSION:=1.34.2
+PKG_VERSION:=1.40.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://dist.libuv.org/dist/v$(PKG_VERSION)/
-PKG_HASH:=65d93b4504ef5f3ec784c0c186f4ba8abd1031292c7f15dda8111d7e319adf46
+PKG_HASH:=61a90db95bac00adec1cc5ddc767ebbcaabc70242bd1134a7a6b1fb1d498a194
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>


### PR DESCRIPTION
Maintainer: @ratkaj
Compile tested: 19.07 r11216-8910229, mips
 Run tested: mips (qemu 5.1.0)

Description:
update to 1.40.0
FIX CVE-2020-8252

https://www.cybersecurity-help.cz/vdb/SB2020091824

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
