### PR TITLE
ctop: match ARCH with docker-ce

### DIFF
--- a/utils/ctop/Makefile
+++ b/utils/ctop/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ctop
 PKG_VERSION:=0.7.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/bcicen/ctop/archive
@@ -25,7 +25,7 @@ define Package/ctop
   CATEGORY:=Utilities
   TITLE:=Top-like interface for container metrics
   URL:=https://ctop.sh/
-  DEPENDS:=$(GO_ARCH_DEPENDS) @!mips @!mipsel
+  DEPENDS:=$(GO_ARCH_DEPENDS) @(aarch64||arm||x86_64)
 endef
 
 define Package/ctop/description


### PR DESCRIPTION
Only makes sense as ctop uses docker-ce.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jmarcet 