### PR TITLE
libmbim: update libmbim to 1.24.4

### DIFF
--- a/libs/libmbim/Makefile
+++ b/libs/libmbim/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmbim
-PKG_VERSION:=1.24.0
+PKG_VERSION:=1.24.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libmbim
-PKG_HASH:=3d495cec3becfd02731ceac67a5ad7e0f1b328395137024d7cb91d31f00e1196
+PKG_HASH:=dd488ee6176243a6adb27a5872897336272ea7bea33a3ad501ba268e5a58b285
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 


### PR DESCRIPTION
Signed-off-by: Nicholas Smith <nicholas.smith@telcoantennas.com.au>

Maintainer: me 
Compile tested: ath79, Telco T1
Run tested: ath79, Telco T1, tested basic functionality

Description:
Overview of changes in libmbim 1.24.4
----------------------------------------

 * libmbim-glib,device:
   ** Added new mbim_device_get_transaction_id() to retrieve the transaction id currently being used.

 * libmbim-glib,proxy:
   ** Fixed the transaction id used in fragments of the same request.
   ** Avoid creating device context when it's already being untracked.
   ** Fixed double GError free.

 * mbimcli:
   ** Fixed missing EOL in error string when closing device.
