### PR TITLE
wget: rename wget to wget-ssl

### DIFF
--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -29,7 +29,7 @@ define Package/wget/Default
   SUBMENU:=File Transfer
   TITLE:=Non-interactive network downloader
   URL:=https://www.gnu.org/software/wget/index.html
-  PROVIDES:=gnu-wget
+  PROVIDES:=gnu-wget wget
 endef
 
 define Package/wget/Default/description
@@ -41,12 +41,11 @@ define Package/wget/Default/description
  archives and home pages or to travel the Web like a WWW robot.
 endef
 
-define Package/wget
+define Package/wget-ssl
 $(call Package/wget/Default)
   DEPENDS+= +libopenssl +librt
   TITLE+= (with SSL support)
   VARIANT:=ssl
-  PROVIDES+=wget-ssl
   ALTERNATIVES:=300:/usr/bin/wget:/usr/libexec/wget-ssl
 endef
 
@@ -59,7 +58,6 @@ define Package/wget-nossl
 $(call Package/wget/Default)
   TITLE+= (without SSL support)
   VARIANT:=nossl
-  PROVIDES+=wget
   ALTERNATIVES:=300:/usr/bin/wget:/usr/libexec/wget-nossl
 endef
 
@@ -104,5 +102,5 @@ define Package/wget-nossl/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/wget $(1)/usr/libexec/wget-nossl
 endef
 
-$(eval $(call BuildPackage,wget))
+$(eval $(call BuildPackage,wget-ssl))
 $(eval $(call BuildPackage,wget-nossl))


### PR DESCRIPTION

Maintainer: @tripolar 
Compile tested:
Run tested:

Description:
The idea behind this is to prevent confusion between "virtual" package
wget and real one. Wget is provided by not just wget packages but also
by uclient-fetch so technically it is better to threat wget as virtual
package.

In reality I need to cover this case: https://forum.turris.cz/t/wget-busybox-vs-package-wget/2547. Turris Updater-ng minimizes amount of installed packages (compared to opkg that does nothing like that) and that makes confusion between users. `opkg instrall wget` installs real wget package. Updater has then request to install `wget` and `uclient-fetch` (because of `opkg` package). Because `uclient-fetch` provides `wget` it removes `wget` package as that is already satisfied by `uclient-fetch`. It is hard to explain users that they have to install virtual package `gnu-wget` to get real wget as "virtual" packages are not reported by opkg and thus by LuCI. This makes it so listing of existing packages lists `wget-ssl` that is unique name of that package that can be satisfied by only installing real wget.

And yeh the reason why it is this way right now is partially my fault thanks to commit 75f2be7d509e802f2d946d732e7a7539c2b27d2e.