### PR TITLE
vim: run test.sh only for vim{-full,-fuller}

### DIFF
--- a/utils/vim/test.sh
+++ b/utils/vim/test.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-vim --version | grep "$2"
+case "$1" in
+	vim|vim-full|vim-fuller)
+		vim --version | grep "$2"
+		;;
+esac


### PR DESCRIPTION
Previously the test.sh script would also run for the `vim-help` package
which isn't a binary package but just a tar archive.

Signed-off-by: Paul Spooren <mail@aparcar.org>