### PR TITLE
actions: remove arm_cortex-a9_neon

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         arch:
           - arc_arc700
-          - arm_cortex-a9_neon
           - arm_cortex-a9_vfpv3-d16
           - mips_24kc
           - powerpc_464fp


### PR DESCRIPTION
This is the second ARM NEON target that is tested. It's unlikely that
one will fail and the other succeed.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @aparcar 
