### PR TITLE
nextdns: mark /etc/config/nextdns as configuration file

### DIFF
--- a/net/nextdns/Makefile
+++ b/net/nextdns/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nextdns
 PKG_VERSION:=1.8.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
@@ -37,6 +37,10 @@ define Package/nextdns
   TITLE:=NextDNS DNS over HTTPS Proxy
   URL:=https://github.com/nextdns/nextdns
   DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+endef
+
+define Package/nextdns/conffiles
+/etc/config/nextdns
 endef
 
 define Package/nextdns/install


### PR DESCRIPTION
Maintainer: @rs
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07.4

### Description:

Conffile was set for OpenWrt master, but it is not present in OpenWrt
19.07. When /etc/config/nextdns is not set as conffile, it gets
overwritten by each update of nextdns and the user needs to set up it again.

This can be simply reproduced by these steps:
opkg update
opkg install nextdns
edit or add smth to /etc/config/nextdns, save it
then do: opkg install nextdns --force-reinstall

Reported here: https://www.reddit.com/r/Turris/comments/j7ia6x/installing_updates_for_turris_omnia_erases/

#### Run tested:  Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07.4

However, this is a little bit complicated. Config file will get overwritten/erased once again from nextdns 1.8.5-1 to 1.8.5-2, but it will be persistent from nextdns 1.8.5-2 to any new release. And after doing --force-reinstall, you will get:

- Not deleting modified conffile /etc/config/nextdns.
- Existing conffile /etc/config/nextdns is different from the conffile in the new package. The new conffile will be placed at /etc/config/nextdns-opkg.

And this is why I was asking if your automatic submitted PRs are compile and run tested.