### PR TITLE
[19.07] chrony: update to 3.5.1

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
-PKG_VERSION:=3.5
+PKG_VERSION:=3.5.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.tuxfamily.org/chrony/
-PKG_HASH:=4e02795b1260a4ec51e6ace84149036305cc9fc340e65edb9f8452aa611339b5
+PKG_HASH:=1ba82f70db85d414cd7420c39858e3ceca4b9eb8b028cbe869512c3a14a2dca7
 
 PKG_MAINTAINER:=Miroslav Lichvar <mlichvar0@gmail.com>
 PKG_LICENSE:=GPL-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: mips, Archer C2 v3, OpenWrt 19.07
Run tested: mips, Archer C2 v3, OpenWrt 19.07, tested basic client functionality

Description: Fixes CVE-2020-14367.
