### PR TITLE
golang: make golang compilable on aarch64 host

### DIFF
--- a/lang/golang/golang/Makefile
+++ b/lang/golang/golang/Makefile
@@ -76,7 +76,7 @@ BOOTSTRAP_GO_VALID_OS_ARCH:= \
   darwin_386     darwin_amd64 \
   dragonfly_386  dragonfly_amd64 \
   freebsd_386    freebsd_amd64    freebsd_arm \
-  linux_386      linux_amd64      linux_arm \
+  linux_386      linux_amd64      linux_arm    linux_arm64\
   netbsd_386     netbsd_amd64     netbsd_arm \
   openbsd_386    openbsd_amd64 \
   plan9_386      plan9_amd64 \
@@ -169,6 +169,7 @@ BOOTSTRAP_ROOT_DIR:=$(call qstrip,$(CONFIG_GOLANG_EXTERNAL_BOOTSTRAP_ROOT))
 
 ifeq ($(BOOTSTRAP_ROOT_DIR),)
   BOOTSTRAP_ROOT_DIR:=$(BOOTSTRAP_BUILD_DIR)
+  BOOTSTRAP_PATCH_DIR:=./bootstrap-patches
 
   define Download/golang-bootstrap
     FILE:=$(BOOTSTRAP_SOURCE)
@@ -180,6 +181,7 @@ ifeq ($(BOOTSTRAP_ROOT_DIR),)
   define Bootstrap/Prepare
 	mkdir -p "$(BOOTSTRAP_BUILD_DIR)"
 	$(BOOTSTRAP_UNPACK)
+	$(call HostPatchDir,$(BOOTSTRAP_BUILD_DIR),$(BOOTSTRAP_PATCH_DIR),)
   endef
   Hooks/HostPrepare/Post+=Bootstrap/Prepare
 

--- a/lang/golang/golang/bootstrap-patches/001-force-arm-for-aarch64.patch
+++ b/lang/golang/golang/bootstrap-patches/001-force-arm-for-aarch64.patch
@@ -1,0 +1,11 @@
+--- a/src/cmd/dist/unix.c
++++ b/src/cmd/dist/unix.c
+@@ -706,7 +706,7 @@ main(int argc, char **argv)
+ 			gohostarch = "amd64";
+ 		else if(hassuffix(u.machine, "86"))
+ 			gohostarch = "386";
+-		else if(contains(u.machine, "arm"))
++		else if(contains(u.machine, "arm") || contains(u.machine, "aarch64"))
+ 			gohostarch = "arm";
+ 		else
+ 			fatal("unknown architecture: %s", u.machine);


### PR DESCRIPTION
Maintainer: @jefferyto 
Compile tested: host-aarch64 (RPi4)
Run tested: host-aarch64 (RPi4)

Description:
Initially I couldn't compile dnscrypt-proxy2 on RPi4. Little investigation and found out the issue is Go bootstrap (1.4) that does not support arm64. It supports arm(32) so I tried forcing it as it should be backwards compatible on arm64 and it worked.
Bootstrap (1.4) is the last version that it written in C++ and it used only to compile the result version of golang in the host arch (arm64 in my case).

OT: Later I found out that golang does not support powerpc, the arch of device I targeted :(
