### PR TITLE
geth: update to 1.9.22

### DIFF
--- a/net/geth/Makefile
+++ b/net/geth/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=go-ethereum
-PKG_VERSION:=1.9.14
+PKG_VERSION:=1.9.22
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ethereum/go-ethereum/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=2bb8dda5dcfceebb31d1e1def1bdc6bf999ac8883a7235b4b242f55e930bcb3c
+PKG_HASH:=cda67de8e76afaad28b8bb4d3e5a95d01f88f69ab2c25964bc8ee2d368794d8c
 
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
 PKG_LICENSE:=GPL-3.0-or-later LGPL-3.0-or-later
@@ -27,6 +27,7 @@ GO_PKG:=github.com/ethereum/go-ethereum
 GO_PKG_BUILD_PKG:=github.com/ethereum/go-ethereum/cmd/geth
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 include ../../lang/golang/golang-package.mk
 
 define Package/geth
@@ -35,7 +36,6 @@ define Package/geth
   TITLE:=Ethereum Go client
   URL:=https://geth.ethereum.org/
   DEPENDS:=$(GO_ARCH_DEPENDS)
-  PKGARCH:=all
 endef
 
 define Package/geth/description
@@ -43,6 +43,8 @@ Ethereum is a decentralized platform that runs smart contracts, applications
 that run exactly as programmed without possibility of downtime, censorship,
 fraud or third party interference.
 endef
+
+TARGET_LDFLAGS += -liconv
 
 define Package/geth/install
 	$(call GoPackage/Package/Install/Bin,$(1))


### PR DESCRIPTION
Removed bogus PKGARCH.

Added nls.mk to fix compilation with uClibc-ng.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mislavn
Compile tested: ath79