### PR TITLE
mariadb: fix compilation when selinux is present

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
 PKG_VERSION:=10.4.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := \

--- a/utils/mariadb/patches/200-no-selinux.patch
+++ b/utils/mariadb/patches/200-no-selinux.patch
@@ -1,0 +1,11 @@
+--- a/support-files/CMakeLists.txt
++++ b/support-files/CMakeLists.txt
+@@ -61,7 +61,7 @@ IF(UNIX)
+     INSTALL(FILES magic DESTINATION ${inst_location} COMPONENT SupportFiles)
+     INSTALL(DIRECTORY policy DESTINATION ${inst_location} COMPONENT SupportFiles)
+     FIND_PROGRAM(CHECKMODULE checkmodule)
+-    FIND_PROGRAM(SEMODULE_PACKAGE semodule_package)
++#    FIND_PROGRAM(SEMODULE_PACKAGE semodule_package)
+     MARK_AS_ADVANCED(CHECKMODULE SEMODULE_PACKAGE)
+ 
+     # Build pp files in policy/selinux


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @miska 
Compile tested: ath79