### PR TITLE
docker-ce: disable docker iptables changes

### DIFF
--- a/utils/docker-ce/Makefile
+++ b/utils/docker-ce/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-ce
 PKG_VERSION:=19.03.13
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=components/cli/LICENSE components/engine/LICENSE
 

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -137,7 +137,7 @@ ucidel() {
 }
 
 process_config() {
-	local alt_config_file data_root log_level bip
+	local alt_config_file data_root log_level iptables bip
 
 	[ -f /etc/config/dockerd ] || {
 		# Use the daemon default configuration
@@ -150,9 +150,6 @@ process_config() {
 	mkdir -p "${DOCKER_CONF_DIR}"
 
 	config_load 'dockerd'
-
-	config_list_foreach firewall blocked_interfaces add_docker_firewall_rules
-
 	config_get alt_config_file globals alt_config_file
 	[ -n "${alt_config_file}" ] && [ -f "${alt_config_file}" ] && {
 		ln -s "${alt_config_file}" "${DOCKERD_CONF}"
@@ -161,6 +158,7 @@ process_config() {
 
 	config_get data_root globals data_root "/opt/docker/"
 	config_get log_level globals log_level "warn"
+	config_get_bool iptables globals iptables "1"
 	config_get bip globals bip ""
 
 	. /usr/share/libubox/jshn.sh
@@ -174,6 +172,9 @@ process_config() {
 	json_add_array "hosts"
 	config_list_foreach globals hosts json_add_array_string
 	json_close_array
+
+	json_add_boolean iptables "${iptables}"
+	[ "${iptables}" -ne "0" ] && config_foreach iptables_add_blocking_rule firewall
 
 	json_dump > "${DOCKERD_CONF}"
 

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -181,16 +181,39 @@ service_triggers() {
 	procd_add_reload_trigger 'dockerd'
 }
 
-add_docker_firewall_rules() {
-	. /lib/functions/network.sh
-	local device interface="${1}"
+iptables_add_blocking_rule() {
+	local cfg="$1"
 
-	# Ignore errors as it might already be present
-	iptables --table filter --new DOCKER-USER 2>/dev/null
-	network_get_physdev device "${interface}"
-	if ! iptables --table filter --check DOCKER-USER --in-interface "${device}" --out-interface docker0 --jump DROP 2>/dev/null; then
-		iptables --table filter --insert DOCKER-USER --in-interface "${device}" --out-interface docker0 --jump DROP
-	fi
+	local device=""
+
+	handle_iptables_rule() {
+		local interface="$1"
+		local outbound="$2"
+
+		local inbound=""
+
+		. /lib/functions/network.sh
+		network_get_physdev inbound "${interface}"
+
+		[ -z "$inbound" ] && {
+			logger -t "dockerd-init" -p notice "Unable to get physical device for interface ${interface}"
+			return
+		}
+
+		if ! iptables --table filter --check DOCKER-USER --in-interface "${inbound}" --out-interface "${outbound}" --jump DROP 2>/dev/null; then
+			logger -t "dockerd-init" -p notice "Drop traffic from ${inbound} to ${outbound}"
+			iptables --table filter --insert DOCKER-USER --in-interface "${inbound}" --out-interface "${outbound}" --jump DROP
+		fi
+	}
+
+	config_get device "$cfg" device
+
+	[ -z "$device" ] && {
+		logger -t "dockerd-init" -p notice "No device configured for ${cfg}"
+		return
+	}
+
+	config_list_foreach "$cfg" blocked_interfaces handle_iptables_rule "$device"
 }
 
 ip4tables_remove_nat() {

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -3,8 +3,8 @@
 USE_PROCD=1
 START=25
 
-extra_command "uciadd" "Add default bridge configuration to network and firewall uci config"
-extra_command "ucidel" "Delete default bridge configuration from network and firewall uci config"
+extra_command "uciadd" "<interface> <device> <zone> Add docker bridge configuration to network and firewall uci config"
+extra_command "ucidel" "<interface> <device> <zone> Delete docker bridge configuration from network and firewall uci config"
 
 DOCKER_CONF_DIR="/tmp/dockerd"
 DOCKERD_CONF="${DOCKER_CONF_DIR}/daemon.json"
@@ -46,43 +46,53 @@ uciupdate() {
 }
 
 uciadd() {
+	local iface="$1"
+	local device="$2"
+	local zone="$3"
+
+	[ -z "$iface" ] && {
+		iface="docker"
+		device="docker0"
+		zone="docker"
+	}
+
 	/etc/init.d/dockerd running && {
 		echo "Please stop dockerd service first"
 		exit 0
 	}
 
 	# Add network interface
-	if ! uci_quiet get network.docker; then
-		logger -t "dockerd-init" -p notice "Adding docker default interface to network uci config (docker)"
+	if ! uci_quiet get network.${iface}; then
+		logger -t "dockerd-init" -p notice "Adding docker default interface to network uci config (${iface})"
 		uci_quiet add network interface
-		uci_quiet rename network.@interface[-1]="docker"
-		uci_quiet set network.docker.ifname="docker0"
-		uci_quiet set network.docker.proto="static"
-		uci_quiet set network.docker.auto="0"
+		uci_quiet rename network.@interface[-1]="${iface}"
+		uci_quiet set network.@interface[-1].ifname="${device}"
+		uci_quiet set network.@interface[-1].proto="static"
+		uci_quiet set network.@interface[-1].auto="0"
 		uci_quiet commit network
 	fi
 
 	# Add docker bridge device
-	if ! uci_quiet get network.docker0; then
-		logger -t "dockerd-init" -p notice "Adding docker default bridge device to network uci config (docker0)"
+	if ! uci_quiet get network.${device}; then
+		logger -t "dockerd-init" -p notice "Adding docker default bridge device to network uci config (${device})"
 		uci_quiet add network device
-		uci_quiet rename network.@device[-1]="docker0"
-		uci_quiet set network.docker0.type="bridge"
-		uci_quiet set network.docker0.name="docker0"
-		uci_quiet add_list network.docker0.ifname="docker0"
+		uci_quiet rename network.@device[-1]="${device}"
+		uci_quiet set network.@device[-1].type="bridge"
+		uci_quiet set network.@device[-1].name="${device}"
+		uci_quiet add_list network.@device[-1].ifname="${device}"
 		uci_quiet commit network
 	fi
 
 	# Add firewall zone
-	if ! uci_quiet get firewall.docker; then
-		logger -t "dockerd-init" -p notice "Adding docker default firewall zone to firewall uci config (docker)"
+	if ! uci_quiet get firewall.${zone}; then
+		logger -t "dockerd-init" -p notice "Adding docker default firewall zone to firewall uci config (${zone})"
 		uci_quiet add firewall zone
-		uci_quiet rename firewall.@zone[-1]="docker"
-		uci_quiet set firewall.docker.network="docker"
-		uci_quiet set firewall.docker.input="REJECT"
-		uci_quiet set firewall.docker.output="ACCEPT"
-		uci_quiet set firewall.docker.forward="REJECT"
-		uci_quiet set firewall.docker.name="docker"
+		uci_quiet rename firewall.@zone[-1]="${zone}"
+		uci_quiet set firewall.@zone[-1].network="${iface}"
+		uci_quiet set firewall.@zone[-1].input="REJECT"
+		uci_quiet set firewall.@zone[-1].output="ACCEPT"
+		uci_quiet set firewall.@zone[-1].forward="REJECT"
+		uci_quiet set firewall.@zone[-1].name="${zone}"
 		uci_quiet commit firewall
 	fi
 
@@ -90,22 +100,38 @@ uciadd() {
 }
 
 ucidel() {
+	local iface="$1"
+	local device="$2"
+	local zone="$3"
+
+	[ -z "$iface" ] && {
+		iface="docker"
+		device="docker0"
+		zone="docker"
+	}
+
 	/etc/init.d/dockerd running && {
 		echo "Please stop dockerd service first"
 		exit 0
 	}
 
-	logger -t "dockerd-init" -p notice "Deleting docker default bridge device from network uci config (docker0)"
-	uci_quiet delete network.docker0
-	uci_quiet commit network
+	if uci_quiet get network.${device}; then
+		logger -t "dockerd-init" -p notice "Deleting docker default bridge device from network uci config (${device})"
+		uci_quiet delete network.${device}
+		uci_quiet commit network
+	fi
 
-	logger -t "dockerd-init" -p notice "Deleting docker default interface from network uci config (docker)"
-	uci_quiet delete network.docker
-	uci_quiet commit network
+	if uci_quiet get network.${iface}; then
+		logger -t "dockerd-init" -p notice "Deleting docker default interface from network uci config (${iface})"
+		uci_quiet delete network.${iface}
+		uci_quiet commit network
+	fi
 
-	logger -t "dockerd-init" -p notice "Deleting docker firewall zone from firewall uci config (docker)"
-	uci_quiet delete firewall.docker
-	uci_quiet commit firewall
+	if uci_quiet get firewall.${zone}; then
+		logger -t "dockerd-init" -p notice "Deleting docker firewall zone from firewall uci config (${zone})"
+		uci_quiet delete firewall.${zone}
+		uci_quiet commit firewall
+	fi
 
 	reload_config
 }

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -67,7 +67,7 @@ uciadd() {
 		uci_quiet add network interface
 		uci_quiet rename network.@interface[-1]="${iface}"
 		uci_quiet set network.@interface[-1].ifname="${device}"
-		uci_quiet set network.@interface[-1].proto="static"
+		uci_quiet set network.@interface[-1].proto="none"
 		uci_quiet set network.@interface[-1].auto="0"
 		uci_quiet commit network
 	fi

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -22,29 +22,6 @@ boot() {
 	rc_procd start_service
 }
 
-uciupdate() {
-	local net="${1}"
-
-	uci_quiet get network.docker || {
-		logger -t "dockerd-init" -p warn "No network uci config section for docker default bridge (docker0) found"
-		return
-	}
-
-	[ -z "${net}" ] && {
-		logger -t "dockerd-init" -p notice "Removing network uci config options for docker default bridge (docker0)"
-		uci_quiet delete network.docker.netmask
-		uci_quiet delete network.docker.ipaddr
-		uci_quiet commit network
-		return
-	}
-
-	eval "$(ipcalc.sh "${net}")"
-	logger -t "dockerd-init" -p notice "Updating network uci config option \"${net}\" for docker default bridge (docker0)"
-	uci_quiet set network.docker.netmask="${NETMASK}"
-	uci_quiet set network.docker.ipaddr="${IP}"
-	uci_quiet commit network
-}
-
 uciadd() {
 	local iface="$1"
 	local device="$2"
@@ -177,8 +154,6 @@ process_config() {
 	[ "${iptables}" -ne "0" ] && config_foreach iptables_add_blocking_rule firewall
 
 	json_dump > "${DOCKERD_CONF}"
-
-	uciupdate "${bip}"
 }
 
 start_service() {

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -216,41 +216,8 @@ iptables_add_blocking_rule() {
 	config_list_foreach "$cfg" blocked_interfaces handle_iptables_rule "$device"
 }
 
-ip4tables_remove_nat() {
-	iptables --table nat --delete OUTPUT ! --destination 127.0.0.0/8 --match addrtype --dst-type LOCAL --jump DOCKER
-	iptables --table nat --delete PREROUTING --match addrtype --dst-type LOCAL --jump DOCKER
-
-	iptables --table nat --flush DOCKER
-	iptables --table nat --delete-chain DOCKER
-}
-
-ip4tables_remove_filter() {
-	iptables --table filter --delete FORWARD --jump DOCKER-USER
-	iptables --table filter --delete FORWARD --jump DOCKER-ISOLATION-STAGE-1
-	iptables --table filter --delete FORWARD --out-interface docker0 --jump DOCKER
-	iptables --table filter --delete FORWARD --out-interface docker0 --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT
-	iptables --table filter --delete FORWARD --in-interface docker0 --out-interface docker0 --jump ACCEPT
-	iptables --table filter --delete FORWARD --in-interface docker0 ! --out-interface docker0 --jump ACCEPT
-
-	iptables --table filter --flush DOCKER
-	iptables --table filter --flush DOCKER-ISOLATION-STAGE-1
-	iptables --table filter --flush DOCKER-ISOLATION-STAGE-2
-	iptables --table filter --flush DOCKER-USER
-
-	iptables --table filter --delete-chain DOCKER
-	iptables --table filter --delete-chain DOCKER-ISOLATION-STAGE-1
-	iptables --table filter --delete-chain DOCKER-ISOLATION-STAGE-2
-	iptables --table filter --delete-chain DOCKER-USER
-}
-
-ip4tables_remove() {
-	ip4tables_remove_nat
-	ip4tables_remove_filter
-}
-
 stop_service() {
 	if /etc/init.d/dockerd running; then
 		service_stop "/usr/bin/dockerd"
-		ip4tables_remove
 	fi
 }

--- a/utils/docker-ce/files/etc/config/dockerd
+++ b/utils/docker-ce/files/etc/config/dockerd
@@ -16,4 +16,5 @@ config globals 'globals'
 # Docker ignores fw3 rules and by default all external source IPs are allowed
 # to connect to the Docker host. See https://docs.docker.com/network/iptables/
 config firewall 'firewall'
+	option device 'docker0'
 	list blocked_interfaces 'wan'

--- a/utils/docker-ce/files/etc/config/dockerd
+++ b/utils/docker-ce/files/etc/config/dockerd
@@ -9,6 +9,7 @@ config globals 'globals'
 	option log_level "warn"
 	list hosts "unix:///var/run/docker.sock"
 	option bip "172.18.0.1/24"
+#	option iptables "0"
 #	list registry_mirrors "https://<my-docker-mirror-host>"
 #	list registry_mirrors "https://hub.docker.com"
 


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503 
Compile tested: x86_64, APU3, OpenWrt master)
Run tested: x86_64, APU3, OpenWrt master

Description:
Openwrt has a own firewall service called fw3, that supports firewall zones. Docker can bypass the handling of the zone rules in openwrt via custom tables. These are "always" processed before the openwrt firewall. Which is prone to errors!

Since not everyone is aware that the firewall of openwrt will not be passed. And this is a security problem because a mapped port is visible on all interfaces and so also on the WAN side. If the firewall handling in docker is switched off, then the port in fw3 must be explicitly released and it cannot happen that the port is accidentally exported to the outside world via the interfaces on the WAN zone.

So all rules for the containers should and so must be made in fw3.

Edit:
This describes the problem https://fralef.me/docker-and-iptables.html And since we are on a router that has several interfaces. Is that a security problem, the way docker does it