### PR TITLE
zoneinfo: Updated to the latest release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2020a
+PKG_VERSION:=2020b
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=547161eca24d344e0b5f96aff6a76b454da295dc14ed4ca50c2355043fb899a2
+PKG_HASH:=9b053f951d245ce89d850b96ee4711d82d833559b1fc96ba19f90bc4d745e809
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=7d2af7120ee03df71fbca24031ccaf42404752e639196fe93c79a41b38a6d669
+   HASH:=47eff8944de4a64f7629b851e4a32338ab12c9b73edd62063795167ff1fe43da
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT/LEDE master
Run tested: n/a

Description:

Briefly:

     Revised predictions for Morocco's changes starting in 2023.
     Canada's Yukon changes to -07 on 2020-11-01, not 2020-03-08.
     Macquarie Island has stayed in sync with Tasmania since 2011.
     Casey, Antarctica is at +08 in winter and +11 in summer.
     zic no longer supports -y, nor the TYPE field of Rules.

   Changes to future timestamps

     Morocco's spring-forward after Ramadan is now predicted to occur
     no sooner than two days after Ramadan, instead of one day.
     (Thanks to Milamber.)  The first altered prediction is for 2023,
     now predicted to spring-forward on April 30 instead of April 23.

   Changes to past and future timestamps

    Casey Station, Antarctica has been using +08 in winter and +11 in
    summer since 2018.  The most recent transition from +08 to +11 was
    2020-10-04 00:01.  Also, Macquarie Island has been staying in
    sync with Tasmania since 2011.  (Thanks to Steffen Thorsen.)

   Changes to past and future time zone abbreviations and DST flags

     Canada's Yukon, represented by America/Whitehorse and
     America/Dawson, changes its time zone rules from -08/-07 to
     permanent -07 on 2020-11-01, not on 2020-03-08 as 2020a had it.
     This change affects only the time zone abbreviation (MST vs PDT)
     and daylight saving flag for the period between the two dates.
     (Thanks to Andrew G. Smith.)

   Changes to past timestamps

     Correct several transitions for Hungary for 1918/1983.
     For example, the 1983-09-25 fall-back was at 01:00, not 03:00.
     (Thanks to G?za Ny?ry.)  Also, the 1890 transition to standard
     time was on 11-01, not 10-01 (thanks to Michael Deckers).

     The 1891 French transition was on March 16, not March 15.  The
     1911-03-11 French transition was at midnight, not a minute later.
     Monaco's transitions were on 1892-06-01 and 1911-03-29, not
     1891-03-15 and 1911-03-11.  (Thanks to Michael Deckers.)

   Changes to code

     Support for zic's long-obsolete '-y YEARISTYPE' option has been
     removed and, with it, so has support for the TYPE field in Rule
     lines, which is now reserved for compatibility with earlier zic.
     These features were previously deprecated in release 2015f.
     (Thanks to Tim Parenti.)

     zic now defaults to '-b slim' instead of to '-b fat'.

     zic's new '-l -' and '-p -' options uninstall any existing
     localtime and posixrules files, respectively.

     The undocumented and ineffective tzsetwall function has been
     removed.

   Changes to build procedure

     The Makefile now defaults POSIXRULES to '-', so the posixrules
     feature (obsolete as of 2019b) is no longer installed by default.

   Changes to documentation and commentary

     The long-obsolete files pacificnew, systemv, and yearistype.sh have
     been removed from the distribution.  (Thanks to Tim Parenti.)
