### PR TITLE
Update libqmi to 1.26.6 and make QMI-over-MBIM support optional

### DIFF
--- a/libs/libqmi/Config.in
+++ b/libs/libqmi/Config.in
@@ -1,0 +1,9 @@
+menu "Configuration"
+depends on PACKAGE_libqmi
+
+	config LIBQMI_WITH_MBIM_QMUX
+		bool "Include MBIM QMUX service support"
+		default y
+		help
+		  Compile libqmi with QMI-over-MBIM support
+endmenu

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
 PKG_VERSION:=1.26.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
@@ -23,10 +23,16 @@ PKG_BUILD_PARALLEL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
+define Package/libqmi/config
+  source "$(SOURCE)/Config.in"
+endef
+
 define Package/libqmi
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libmbim
+  DEPENDS:= \
+    +glib2 \
+    +LIBQMI_WITH_MBIM_QMUX:libmbim
   TITLE:=Helper library to talk to QMI enabled modems
   URL:=https://www.freedesktop.org/wiki/Software/libqmi
   LICENSE:=LGPL-2.0-or-later
@@ -59,7 +65,7 @@ CONFIGURE_ARGS += \
 	--disable-gtk-doc-pdf \
 	--disable-silent-rules \
 	--enable-firmware-update \
-	--enable-mbim-qmux \
+	--$(if $(LIBQMI_WITH_MBIM_QMUX),en,dis)able-mbim-qmux \
 	--enable-more-warnings=yes \
 	--without-udev \
 	--without-udev-base-dir

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_VERSION:=1.26.4
+PKG_VERSION:=1.26.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
-PKG_HASH:=c0adcb84ba452e3e13edeb3f94f7b003ea927b354bc187629e05efb333ce270b
+PKG_HASH:=a71963bb1097a42665287e40a9a36f95b8f9d6d6a4b7a5de22d660328af97cb9
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_VERSION:=1.26.2
+PKG_VERSION:=1.26.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
-PKG_HASH:=133467b2fe0706850eb587c0103ae6e61b97ce6e2c440d66358f2b72b0db7b03
+PKG_HASH:=c0adcb84ba452e3e13edeb3f94f7b003ea927b354bc187629e05efb333ce270b
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 


### PR DESCRIPTION
Maintainer: @nickberry17 

Description: Upgrade library version to 1.26.6 and also add a new CONFIG_LIBQMI_WITH_MBIM_QMUX that allows disabling the libmbim dependency altogether (i.e. for systems running with modems in QMI mode explicitly).  
