### PR TITLE
seafile-server: Update to 7.1.5

### DIFF
--- a/net/seafile-ccnet/Makefile
+++ b/net/seafile-ccnet/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-ccnet
-PKG_VERSION:=7.1.4
+PKG_VERSION:=7.1.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/haiwen/ccnet-server/tar.gz/v$(PKG_VERSION)-server?
-PKG_HASH:=b46508a686e7fe8eb9e1515e5384c7d9aca25cf596ef4b8383646e587f1032eb
+PKG_HASH:=11e5281c239474756ed606bffe8f24c1089a3a9eb2502cfac7815d25ebc4585a
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=AGPL-3.0-only

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-seahub
-PKG_VERSION:=7.1.4
-PKG_RELEASE:=3
+PKG_VERSION:=7.1.5
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/haiwen/seahub/tar.gz/v$(PKG_VERSION)-server?
-PKG_HASH:=921ef4373311c06c1192975a294d7d38c12ac34381a7df19542391fc1d810baf
+PKG_HASH:=cc7f5a1642d203b2390ae3c30c8a5546d1e829d9d1a5ddf686e558292746ce5c
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/net/seafile-seahub/patches/030-uci-conf.patch
+++ b/net/seafile-seahub/patches/030-uci-conf.patch
@@ -9,7 +9,7 @@
              os.path.join(PROJECT_ROOT, 'seahub/templates'),
          ],
          'APP_DIRS': True,
-@@ -633,7 +633,7 @@ CAPTCHA_IMAGE_SIZE = (90, 42)
+@@ -646,7 +646,7 @@ CAPTCHA_IMAGE_SIZE = (90, 42)
  ENABLE_THUMBNAIL = True
  
  # Absolute filesystem path to the directory that will hold thumbnail files.
@@ -18,7 +18,7 @@
  if os.path.exists(SEAHUB_DATA_ROOT):
      THUMBNAIL_ROOT = os.path.join(SEAHUB_DATA_ROOT, 'thumbnail')
  else:
-@@ -829,7 +829,7 @@ except ImportError:
+@@ -842,7 +842,7 @@ except ImportError:
      pass
  else:
      # In server release, sqlite3 db file is <topdir>/seahub.db

--- a/net/seafile-server/Makefile
+++ b/net/seafile-server/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-server
-PKG_VERSION:=7.1.4
-PKG_RELEASE:=2
+PKG_VERSION:=7.1.5
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/haiwen/seafile-server/tar.gz/v$(PKG_VERSION)-server?
-PKG_HASH:=cc5aaf76044f907758a75a43e321fef499482d7b57d9e61d0297a4bba66dcce4
+PKG_HASH:=407a6243f754e366ce6754a2aa643574aa7742d4e81b7cc350dea348f3063707
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=AGPL-3.0-only

--- a/net/seafile-server/patches/020-installpath.patch
+++ b/net/seafile-server/patches/020-installpath.patch
@@ -1,6 +1,6 @@
 --- a/controller/seafile-controller.c
 +++ b/controller/seafile-controller.c
-@@ -257,7 +257,7 @@ init_seafile_path ()
+@@ -288,7 +288,7 @@ init_seafile_path ()
      bin_dir = g_path_get_dirname (binary);
  
      tmp = g_path_get_dirname (bin_dir);

--- a/net/seafile-server/patches/022-uci-conf.patch
+++ b/net/seafile-server/patches/022-uci-conf.patch
@@ -1,6 +1,6 @@
 --- a/common/seaf-utils.c
 +++ b/common/seaf-utils.c
-@@ -236,7 +236,12 @@ create_ccnet_rpc_client ()
+@@ -238,7 +238,12 @@ create_ccnet_rpc_client ()
      SearpcNamedPipeClient *transport = NULL;
      char *pipe_path = NULL;
  
@@ -16,7 +16,7 @@
      if (!transport)
 --- a/controller/seafile-controller.c
 +++ b/controller/seafile-controller.c
-@@ -480,7 +480,10 @@ stop_services ()
+@@ -511,7 +511,10 @@ stop_services ()
  static void
  init_pidfile_path (SeafileController *ctl)
  {
@@ -28,7 +28,7 @@
      if (!g_file_test(pid_dir, G_FILE_TEST_EXISTS)) {
          if (g_mkdir(pid_dir, 0777) < 0) {
              seaf_warning("failed to create pid dir %s: %s", pid_dir, strerror(errno));
-@@ -492,6 +495,8 @@ init_pidfile_path (SeafileController *ct
+@@ -523,6 +526,8 @@ init_pidfile_path (SeafileController *ct
      ctl->pidfile[PID_SERVER] = g_build_filename (pid_dir, "seaf-server.pid", NULL);
      ctl->pidfile[PID_SEAFDAV] = g_build_filename (pid_dir, "seafdav.pid", NULL);
      ctl->pidfile[PID_SEAFEVENTS] = g_build_filename (pid_dir, "seafevents.pid", NULL);
@@ -37,7 +37,7 @@
  }
  
  static int
-@@ -514,7 +519,10 @@ seaf_controller_init (SeafileController
+@@ -545,7 +550,10 @@ seaf_controller_init (SeafileController
  
      if (logdir == NULL) {
          char *topdir = g_path_get_dirname(config_dir);
@@ -49,7 +49,7 @@
          if (checkdir_with_mkdir(logdir) < 0) {
              fprintf (stderr, "failed to create log folder \"%s\": %s\n",
                       logdir, strerror(errno));
-@@ -523,10 +531,15 @@ seaf_controller_init (SeafileController
+@@ -554,10 +562,15 @@ seaf_controller_init (SeafileController
          g_free (topdir);
      }
  

--- a/net/seafile-server/patches/030-controller-pid-dir-permissions.patch
+++ b/net/seafile-server/patches/030-controller-pid-dir-permissions.patch
@@ -1,6 +1,6 @@
 --- a/controller/seafile-controller.c
 +++ b/controller/seafile-controller.c
-@@ -485,7 +485,7 @@ init_pidfile_path (SeafileController *ct
+@@ -516,7 +516,7 @@ init_pidfile_path (SeafileController *ct
          pid_dir = g_build_filename (topdir, "pids", NULL);
      }
      if (!g_file_test(pid_dir, G_FILE_TEST_EXISTS)) {

--- a/net/seafile-server/patches/120-recent-libevhtp.patch
+++ b/net/seafile-server/patches/120-recent-libevhtp.patch
@@ -9,7 +9,7 @@ Forwarded: no
 
 --- a/server/access-file.c
 +++ b/server/access-file.c
-@@ -661,7 +661,7 @@ do_file(evhtp_request_t *req, SeafRepo *
+@@ -665,7 +665,7 @@ do_file(evhtp_request_t *req, SeafRepo *
      /* Block any new request from this connection before finish
       * handling this request.
       */
@@ -18,7 +18,7 @@ Forwarded: no
  
      /* Kick start data transfer by sending out http headers. */
      evhtp_send_reply_start(req, EVHTP_RES_OK);
-@@ -1021,7 +1021,7 @@ do_file_range (evhtp_request_t *req, Sea
+@@ -1030,7 +1030,7 @@ do_file_range (evhtp_request_t *req, Sea
      /* Block any new request from this connection before finish
       * handling this request.
       */
@@ -27,7 +27,7 @@ Forwarded: no
  
      /* Kick start data transfer by sending out http headers. */
      evhtp_send_reply_start(req, EVHTP_RES_PARTIAL);
-@@ -1091,7 +1091,7 @@ start_download_zip_file (evhtp_request_t
+@@ -1100,7 +1100,7 @@ start_download_zip_file (evhtp_request_t
      /* Block any new request from this connection before finish
       * handling this request.
       */
@@ -36,7 +36,7 @@ Forwarded: no
  
      /* Kick start data transfer by sending out http headers. */
      evhtp_send_reply_start(req, EVHTP_RES_OK);
-@@ -1435,7 +1435,7 @@ do_block(evhtp_request_t *req, SeafRepo
+@@ -1444,7 +1444,7 @@ do_block(evhtp_request_t *req, SeafRepo
      /* Block any new request from this connection before finish
       * handling this request.
       */


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-32, 2020-10-11 snapshot sdk
Run tested: armvirt-32 (qemu), 2020-10-11 snapshot

Description:
This updates the Seafile packages (seafile-ccnet, seafile-seahub, seafile-server) to 7.1.5.