### PR TITLE
picocom: remove usleep

### DIFF
--- a/utils/picocom/Makefile
+++ b/utils/picocom/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=picocom
 PKG_VERSION:=3.1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/npat-efault/picocom/tar.gz/$(PKG_VERSION)?

--- a/utils/picocom/patches/030-usleep.patch
+++ b/utils/picocom/patches/030-usleep.patch
@@ -1,0 +1,65 @@
+From 84fdd943aee9fdf199f6668145246d3021527c29 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sun, 11 Oct 2020 22:10:45 -0700
+Subject: [PATCH] remove usleep
+
+usleep is removed in POSIX 2008.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ term.c | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/term.c b/term.c
+index b45ab3d..23afd4f 100644
+--- a/term.c
++++ b/term.c
+@@ -33,6 +33,7 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <errno.h>
++#include <time.h>
+ #include <unistd.h>
+ #include <termios.h>
+ #ifdef USE_FLOCK
+@@ -1588,6 +1589,8 @@ term_drain(int fd)
+ 
+     rval = 0;
+ 
++    struct timespec s;
++
+     do { /* dummy */
+ 
+         r = term_find(fd);
+@@ -1614,7 +1617,10 @@ term_drain(int fd)
+            the port is immediately reconfigured, even after a
+            drain. (I guess, drain does not wait for everything to
+            actually be transitted on the wire). */
+-        if ( DRAIN_DELAY ) usleep(DRAIN_DELAY);
++        if ( DRAIN_DELAY ) {
++            struct timespec d = {0, DRAIN_DELAY * 1000};
++            nanosleep(&d, &s);
++        }
+ 
+     } while (0);
+ 
+@@ -1627,6 +1633,7 @@ int
+ term_fake_flush(int fd)
+ {
+     struct termios tio;
++    struct timespec s;
+     int rval, i, r;
+ 
+     rval = 0;
+@@ -1666,7 +1673,10 @@ term_fake_flush(int fd)
+             break;
+         }
+         /* see comment in term_drain */
+-        if ( DRAIN_DELAY ) usleep(DRAIN_DELAY);
++        if ( DRAIN_DELAY ) {
++            struct timespec d = {0, DRAIN_DELAY * 1000};
++            nanosleep(&d, &s);
++        }
+         /* Reset flow-control to original setting. */
+         r = tcsetattr(fd, TCSANOW, &term.currtermios[i]);
+         if ( r < 0 ) {


### PR DESCRIPTION
usleep is removed in POSIX 2008.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ath79