### PR TITLE
znc: Add support for many configurable listeners for znc

### DIFF
--- a/net/znc/Makefile
+++ b/net/znc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=znc
 PKG_VERSION:=1.7.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://znc.in/releases \

--- a/net/znc/files/znc.conf
+++ b/net/znc/files/znc.conf
@@ -1,7 +1,5 @@
 config znc
-	# where to listen for connections
-	list listener	'192.168.1.1 1234'
-	# If using SSL sockets, use the following certifcate:
+	# If using SSL sockets, use the following certificate:
 	# option znc_ssl_cert '/etc/znc.cert'
 
 	# load global modules (You need to install them first):
@@ -9,6 +7,16 @@ config znc
 
 	# remove this to enable the service
 	option disabled 1
+
+config listener 'sampleListener'
+	option allowirc 'true'
+	option allowweb 'false'
+	option host '192.168.1.1'
+	option port '1234'
+	option ipv4 'true'
+	option ipv6 'false'
+	# you must set option_ssl_cert in znc section before change
+	option ssl 'false'
 
 config user 'sampleUser'
 	# Use either a plain text password or use the full sha256#... line.

--- a/net/znc/files/znc.init
+++ b/net/znc/files/znc.init
@@ -71,7 +71,7 @@ znc_global() {
 		mkdir -p $ZNC_CONFIG_PATH/configs/
 		[ ! -f "$ZNC_CONFIG" ] || rm "$ZNC_CONFIG"
 
-		add_param "Version" "1.0"
+		add_param "Version" "1.6"
 
 		config_get anoniplimit "$znc" anoniplimit
 		config_get maxbuffersize "$znc" maxbuffersize
@@ -91,6 +91,37 @@ znc_global() {
 		config_list_foreach "$znc" listener "add_param Listener"
 		config_list_foreach "$znc" module "add_param LoadModule"
 	fi
+}
+
+add_listener() {
+       local listener="$1"
+       local host
+       local port
+       local allowirc
+       local allowweb
+       local ipv4
+       local ipv6
+       local ssl
+
+       config_get host "$listener" host
+       config_get port "$listener" port
+       config_get allowirc "$listener" allowirc
+       config_get allowweb "$listener" allowweb
+       config_get ipv4 "$listener" ipv4
+       config_get ipv6 "$listener" ipv6
+       config_get ssl "$listener" ssl
+
+       echo "<Listener $listener>" >> $ZNC_CONFIG
+
+       [ -z "$host" ] || add_param "  Host" "$host"
+       [ -z "$port" ] || add_param "  Port" "$port"
+       [ -z "$allowirc" ] || add_param "  AllowIRC" "$allowirc"
+       [ -z "$allowweb" ] || add_param "  AllowWeb" "$allowweb"
+       [ -z "$ipv4" ] || add_param "  IPv4" "$ipv4"
+       [ -z "$ipv6" ] || add_param "  IPv6" "$ipv6"
+       [ -z "$ssl" ] || add_param "  SSL" "$ssl"
+
+       echo "</Listener>" >> $ZNC_CONFIG
 }
 
 add_user() {


### PR DESCRIPTION
Function add_listener called from /etc/init.d/znc, but not implemented

Signed-off-by: Pavel Demkovich <finn@finnix.servebeer.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
