### PR TITLE
transmission: fix mbedtls search

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=3.00
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master
@@ -137,9 +137,6 @@ CONFIGURE_ARGS += \
 
 ifeq ($(BUILD_VARIANT),mbedtls)
   CONFIGURE_ARGS += --with-crypto=polarssl
-  CONFIGURE_VARS += \
-	MBEDTLS_CFLAGS="-I$(STAGING_DIR)/usr/include/mbedtls" \
-	MBEDTLS_LIBS="-lmbedtls -lmbedcrypto"
 else
   CONFIGURE_ARGS += --with-crypto=openssl
 endif

--- a/net/transmission/patches/020-mbedcrypto.patch
+++ b/net/transmission/patches/020-mbedcrypto.patch
@@ -1,0 +1,13 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -152,8 +152,8 @@ AS_IF([test "x$want_crypto" = "xauto" -o "x$want_crypto" = "xcyassl"], [
+     )
+ ])
+ AS_IF([test "x$want_crypto" = "xauto" -o "x$want_crypto" = "xpolarssl"], [
+-    PKG_CHECK_MODULES(MBEDTLS, [mbedtls >= $POLARSSL_MINIMUM],
+-        [want_crypto="polarssl"; CRYPTO_PKG="polarssl"; CRYPTO_CFLAGS="$MBEDTLS_CFLAGS"; CRYPTO_LIBS="$MBEDTLS_LIBS"; POLARSSL_IS_MBEDTLS=yes],
++    AC_CHECK_LIB(mbedcrypto, mbedtls_strerror,
++        [want_crypto="polarssl"; CRYPTO_PKG="polarssl"; CRYPTO_LIBS="-lmbedcrypto"; POLARSSL_IS_MBEDTLS=yes],
+         [AC_CHECK_HEADER([polarssl/version.h],
+             [AC_EGREP_CPP([version_ok], [#include <polarssl/version.h>
+                                          #if defined (POLARSSL_VERSION_NUMBER) && POLARSSL_VERSION_NUMBER >= $POLARSSL_MINIMUM


### PR DESCRIPTION
mbedcrypto should be searched, not mbedtls. Also, there is no pkgconfig
file with mbedtls. Fixed that as well. Removed Makefile hacks.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me
Compile tested: ath79

@ja-pa this should help with https://github.com/openwrt/packages/pull/13609