### PR TITLE
modemmanager: bump to 1.14.6

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
-PKG_VERSION:=1.14.2
+PKG_VERSION:=1.14.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
-PKG_HASH:=5fb5553aecd6eb9d6d8ecd130a24f3461e5f93c5f91a0e4ae0508b5228e8b0be
+PKG_HASH:=783d5da925b2ca69f6233fcead691dd0f5cba06aa479d71495efdc07053fc0fd
 PKG_BUILD_DIR:=$(BUILD_DIR)/ModemManager-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>


### PR DESCRIPTION
Signed-off-by: Nicholas Smith <nicholas.smith@telcoantennas.com.au>

Maintainer: me
Compile tested: ath79/Telco T1
Run tested: ath79/Telco T1 ran basic tests

Description:

* QMI:
   ** Fix missing GError initialization.

* plugins:
   ** xmm: fix missing GError initialization.
   ** cinterion: fix missing GError initialization.
   ** simtech: fix missing GError initialization.
* Location interface:
   ** Allow cell ID only updates.

* Messaging interface:
   ** Fixed memory leak when SMS parts being processed but device goes away.
   ** Fixed CDMA SMS UTF-8 translation.
   ** Allow sending UTF-16 as if it were UCS-2.

* QMI:
   ** Increased port probing timeout to 25s.
   ** Return error in facility locks loading if PIN status check fails.
   ** Return FIXED_DIALING lock status when checking PIN2.

* MBIM:
   ** Don't fail IPv4 connection if IPv4v6 was requested.

* Plugins:
   ** telit: new ID_MM_TELIT_PORT_DELAY tag to flag devices that require extended AT probing.
   ** telit: added FN980 and LM9x0 MBIM compositions rules.
   ** telit: fixed LM9x0 udev rules.
   ** cinterion: configure the PLAS9 to correctly send URCs.
   ** simtech: add SIM7070/SIM7080/SIM7090 port type hints

* i18n:
   ** Updated Swedish and Slovak translations.
   ** Updated package bugreport to use the gitlab issues URL.

* Several other minor improvements and fixes.