### PR TITLE
boost: improve package compilation

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.74.0
 PKG_SOURCE_VERSION:=1_74_0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://dl.bintray.com/boostorg/release/$(PKG_VERSION)/source/
@@ -80,7 +80,7 @@ There are many more header-only libraries supported by Boost.
 See more at http://www.boost.org/doc/libs/1_74_0/
 endef
 
-PKG_BUILD_DEPENDS:=boost/host PACKAGE_boost-python3:python3
+PKG_BUILD_DEPENDS:=boost/host
 
 include ../../lang/python/python3-version.mk
 BOOST_PYTHON3_VER=$(PYTHON3_VERSION)
@@ -302,12 +302,17 @@ endef
 define Build/Configure
 endef
 
+define Package/boost/Default/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/lib/libboost_$(2)*.so* $(1)/usr/lib/
+endef
+
 # 1: short name
 # 2: dependencies on other boost libraries (short name)
 # 3: dependencies on other packages
 # 4: conditional/inward dependencies
+# 5: dependencies compiled only when this package has been selected
 define DefineBoostLibrary
-
   BOOST_DEPENDS+= +$(if $(4),$(4):boost-$(1),boost-$(1))
   PKG_CONFIG_DEPENDS+= CONFIG_PACKAGE_boost-$(1)
 
@@ -316,12 +321,16 @@ define DefineBoostLibrary
   define Package/boost-$(1)
     $(call Package/boost/Default)
     TITLE+= ($(1))
-    DEPENDS+= $$(foreach lib,$(2),+boost-$$(lib)) $(3) $(if $(4),@$(4),) $(patsubst %,+PACKAGE_boost-$(1):%,$(5))
+    DEPENDS+= $(foreach lib,$(2),+boost-$(lib)) $(3) $(if $(4),@$(4),) $(patsubst %,+PACKAGE_boost-$(1):%,$(5))
     HIDDEN:=1
   endef
 
   define Package/boost-$(1)/description
    This package contains the Boost $(1) library.
+  endef
+
+  define Package/boost-$(1)/install
+    $(if $(CONFIG_boost-static-libs),true,$(call Package/boost/Default/install,$$(1),$(1)))
   endef
 endef
 
@@ -343,7 +352,7 @@ $(eval $(call DefineBoostLibrary,math))
 #$(eval $(call DefineBoostLibrary,mpi,,)) # OpenMPI does no exist in OpenWRT at this time.
 $(eval $(call DefineBoostLibrary,nowide))
 $(eval $(call DefineBoostLibrary,program_options))
-$(eval $(call DefineBoostLibrary,python3))
+$(eval $(call DefineBoostLibrary,python3,,,,python3-base))
 $(eval $(call DefineBoostLibrary,random,system))
 $(eval $(call DefineBoostLibrary,regex))
 $(eval $(call DefineBoostLibrary,serialization))
@@ -368,10 +377,10 @@ define Host/Compile
 endef
 
 CONFIGURE_PREFIX:=$(PKG_INSTALL_DIR)
-TARGET_LDFLAGS += -pthread -lrt
+TARGET_LDFLAGS += -pthread -lrt -lstdc++ -Wl,--gc-sections,--as-needed,--print-gc-sections
 
 TARGET_CFLAGS += \
-	$(if $(CONFIG_SOFT_FLOAT),-DBOOST_NO_FENV_H) -fPIC
+	$(if $(CONFIG_SOFT_FLOAT),-DBOOST_NO_FENV_H) -fPIC -ffunction-sections -fdata-sections -flto
 
 EXTRA_CXXFLAGS += $(if $(CONFIG_GCC_USE_VERSION_10),-std=gnu++20,$(if $(CONFIG_GCC_USE_VERSION_5),-std=gnu++14,-std=gnu++17))
 
@@ -481,28 +490,16 @@ define Host/Install
 	$(CP) $(HOST_BUILD_DIR)/tools/build/src/engine/b2 $(STAGING_DIR_HOSTPKG)/bin/
 endef
 
-define Package/boost/Default/install
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/lib/libboost_$(2)*.so* $(1)/usr/lib/
-endef
-
 define Package/boost-test/install
+	$(if $(CONFIG_boost-static-libs),true,
 		$(INSTALL_DIR) $(1)/usr/lib
-		$(CP) $(PKG_INSTALL_DIR)/lib/libboost_unit_test_framework*.so* $(1)/usr/lib/
-		$(CP) $(PKG_INSTALL_DIR)/lib/libboost_prg_exec_monitor*.so* $(1)/usr/lib/
-endef
-
-define BuildBoostLibrary
-  define Package/boost-$(1)/install
-    $(call Package/boost/Default/install,$$(1),$(1))
-  endef
-
-  $$(eval $$(call BuildPackage,boost-$(1)))
+		$(CP) $(PKG_INSTALL_DIR)/lib/libboost_{unit_test_framework,prg_exec_monitor}*.so* $(1)/usr/lib/
+	)
 endef
 
 $(eval $(call HostBuild))
 
-$(foreach lib,$(BOOST_LIBS),$(eval $(call BuildBoostLibrary,$(lib))))
+$(foreach lib,$(BOOST_LIBS),$(eval $(call BuildPackage,boost-$(lib))))
 $(eval $(call BuildPackage,boost-test))
 $(eval $(call BuildPackage,boost-libs))
 $(eval $(call BuildPackage,boost))


### PR DESCRIPTION
Maintainer: @ClaymorePT @neheb
Environment: x86_64

Description:
* Add `-lstdc++` to `LDFLAGS`, and close #13652
* Add `-Wl,--gc-sections,--as-needed` to  `LDFLAGS` and `-ffunction-sections -fdata-sections -flto` to `CFLAGS` which will reduce the size by 10% ~ 13%
* Only a virtual package will be created if only static libs are built, which will avoid compiliation failures
* Add python3-base to boost-python3's dependences according to [python.jam](https://github.com/boostorg/build/blob/develop/src/tools/python.jam#L1010~#L1014)

Signed-off-by: Van Waholtz <vanwaholtz@gmail.com>