### PR TITLE
fwknop: Use sensible defaults.

### DIFF
--- a/net/fwknop/Makefile
+++ b/net/fwknop/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fwknop
 PKG_VERSION:=2.6.10
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.cipherdyne.org/fwknop/download

--- a/net/fwknop/files/fwknopd
+++ b/net/fwknop/files/fwknopd
@@ -8,10 +8,18 @@ config network
 
 config access
 	option SOURCE 'ANY'
-	option HMAC_KEY 'CHANGEME'
-	option KEY 'CHANGEME'
+	option HMAC_KEY '__CHANGEME__'
+	option KEY '__CHANGEME__'
 
 config config
 	# Alternative direct physical interface definition, but untracked - you
 	# are on your own to correctly start/stop the service when needed
 #	option PCAP_INTF 'eth0'
+
+	# Allow SPA clients to request access to services through an iptables
+	# firewall instead of just to it (i.e. access through the FWKNOP_FORWARD
+	# chain instead of the INPUT chain
+	option ENABLE_IPT_FORWARDING 'Y'
+
+	# Allow fwknopd to resolve hostnames in NAT access messages
+	option ENABLE_NAT_DNS 'Y'


### PR DESCRIPTION
Maintainer: @jp-bennett
Compile tested: ath79, TP-Link Archer C7 v4, OpenWrt master
Run tested: ath79, TP-Link Archer C7 v4, OpenWrt master

Description:

 * Change KEY/HMAC_KEY to \_\_CHANGEME__, which is rejected by fwknopd    during start-up. The value CHANGEME is used only by LuCI package luci-app-fwknopd - pull request for generating keys directly from LuCI has been created already (see openwrt/luci#4490.
 * Add sensible defaults for ENABLE_IPT_FORWARDING and ENABLE_NAT_DNS, which both are/were set by luci-app-fwknopd. Move the defaults here.
