### PR TITLE
[19.07] freeradius3: backport latest changes to 19.07

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -8,10 +8,10 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
-PKG_VERSION:=release_3_0_21
-PKG_RELEASE:=6
+PKG_VERSION:=3_0_21
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_VERSION).tar.gz
+PKG_SOURCE:=release_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/archive
 PKG_HASH:=b2014372948a92f86cfe2cf43c58ef47921c03af05666eb9d6416bdc6eeaedc2
 
@@ -20,7 +20,7 @@ PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYRIGHT LICENSE
 PKG_CPE_ID:=cpe:/a:freeradius:freeradius
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/freeradius-server-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/freeradius-server-release_$(PKG_VERSION)
 PKG_FIXUP:=autoreconf
 
 PKG_CONFIG_DEPENDS := \

--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
 PKG_VERSION:=release_3_0_21
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/archive
@@ -96,6 +96,11 @@ define Package/freeradius3-default
 +freeradius3-mod-realm \
 +freeradius3-mod-unix
   TITLE:=Modules needed for Radius default configuration
+endef
+
+define Package/freeradius3-default/description
+ This meta-package contains only dependencies for modules needed in
+ FreeRADIUS default configuration.
 endef
 
 define Package/freeradius3-democerts
@@ -741,6 +746,10 @@ define Package/freeradius3/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/radiusd $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/radiusd.init $(1)/etc/init.d/radiusd
+endef
+
+define Package/freeradius3-default/install
+	true
 endef
 
 define Package/freeradius3-democerts/install


### PR DESCRIPTION
This PR contains backports of the latest freeradius3 changes from master to 19.07:
7737abf   add meta-package for default modules
11aa0b9   move "release_" from PKG_VERSION

Compile tested: x86_64, OpenWrt 19.07
Run tested: x86_64, OpenWrt 19.07