### PR TITLE
netdata: update to version 1.26.0

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
-PKG_VERSION:=1.23.2
+PKG_VERSION:=1.26.0
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
@@ -18,7 +18,7 @@ PKG_CPE_ID:=cpe:/a:my-netdata:netdata
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netdata/netdata/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=b6dd13292e0b1fb4137b1f7c0dc3d7c5e8a1bf408b82c2b8394f3751800e0eb5
+PKG_HASH:=be32d49381da39196574011653ea863f2064a2168bc9b61a1354171b27ce370b
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
@@ -52,6 +52,7 @@ CONFIGURE_ARGS += \
 	--with-math \
 	--disable-x86-sse \
 	--enable-lto \
+	--disable-ebpf \
 	--without-libcap \
 	--disable-https \
 	--disable-dbengine \

--- a/admin/netdata/patches/007-dont-check-for-ebpf-dependencies-when-it-is-disabled.patch
+++ b/admin/netdata/patches/007-dont-check-for-ebpf-dependencies-when-it-is-disabled.patch
@@ -1,0 +1,79 @@
+From bb405e3c274ca8860c974a720071d346b16c8462 Mon Sep 17 00:00:00 2001
+From: Tomas Kopal <Tomas.Kopal@eccam.com>
+Date: Tue, 6 Oct 2020 13:38:08 +0200
+Subject: [PATCH] Don't check for ebpf dependencies if ebpf is disabled.
+
+---
+ configure.ac | 56 +++++++++++++++++++++++++++-------------------------
+ 1 file changed, 29 insertions(+), 27 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 57f6c0b1cb3a..5f13b4feb0d1 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -989,36 +989,38 @@ AM_CONDITIONAL([ENABLE_PLUGIN_PERF], [test "${enable_plugin_perf}" = "yes"])
+ # -----------------------------------------------------------------------------
+ # ebpf.plugin
+ 
+-PKG_CHECK_MODULES(
+-    [LIBELF],
+-    [libelf],
+-    [have_libelf=yes],
+-    [have_libelf=no]
+-)
++if test "${build_target}" = "linux" -a "${enable_ebpf}" != "no"; then
++    PKG_CHECK_MODULES(
++        [LIBELF],
++        [libelf],
++        [have_libelf=yes],
++        [have_libelf=no]
++    )
+ 
+-AC_CHECK_TYPE(
+-    [struct bpf_prog_info],
+-    [have_bpf=yes],
+-    [have_bpf=no],
+-    [#include <linux/bpf.h>]
+-)
++    AC_CHECK_TYPE(
++        [struct bpf_prog_info],
++        [have_bpf=yes],
++        [have_bpf=no],
++        [#include <linux/bpf.h>]
++    )
+ 
+-AC_CHECK_FILE(
+-    externaldeps/libbpf/libbpf.a,
+-    [have_libbpf=yes],
+-    [have_libbpf=no]
+-)
++    AC_CHECK_FILE(
++        externaldeps/libbpf/libbpf.a,
++        [have_libbpf=yes],
++        [have_libbpf=no]
++    )
+ 
+-AC_MSG_CHECKING([if ebpf.plugin should be enabled])
+-if test "${build_target}" = "linux" -a \
+-        "${enable_ebpf}" != "no" -a \
+-        "${have_libelf}" = "yes" -a \
+-        "${have_bpf}" = "yes" -a \
+-        "${have_libbpf}" = "yes"; then
+-    OPTIONAL_BPF_CFLAGS="${LIBELF_CFLAGS} -I externaldeps/libbpf/include"
+-    OPTIONAL_BPF_LIBS="externaldeps/libbpf/libbpf.a ${LIBELF_LIBS}"
+-    AC_DEFINE([HAVE_LIBBPF], [1], [libbpf usability])
+-    enable_ebpf="yes"
++    AC_MSG_CHECKING([if ebpf.plugin should be enabled])
++    if test "${have_libelf}" = "yes" -a \
++            "${have_bpf}" = "yes" -a \
++            "${have_libbpf}" = "yes"; then
++        OPTIONAL_BPF_CFLAGS="${LIBELF_CFLAGS} -I externaldeps/libbpf/include"
++        OPTIONAL_BPF_LIBS="externaldeps/libbpf/libbpf.a ${LIBELF_LIBS}"
++        AC_DEFINE([HAVE_LIBBPF], [1], [libbpf usability])
++        enable_ebpf="yes"
++    else
++        enable_ebpf="no"
++    fi
+ else
+     enable_ebpf="no"
+ fi

--- a/admin/netdata/test.sh
+++ b/admin/netdata/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+netdata -version 2>&1 | grep "$2"


### PR DESCRIPTION
Maintainer: me and @diizzyy 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07.4
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07.4

Description:

- Update to version 1.26.0.
Changelog: https://github.com/netdata/netdata/releases/tag/v1.26.0

Disable ebpf plugin as in OpenWrt there is no package libbpf.
- With that, I need to introduce patch, which is not merged into netdata,
yet. (https://github.com/netdata/netdata/pull/10034)

Without it, I still got during cross-compilation this error:
checking for externaldeps/libbpf/libbpf.a... configure: error: cannot check for file existence when cross compiling

- And yes, the flag was there.

Fixes: https://github.com/openwrt/packages/issues/13616