### PR TITLE
CI: fix grammar typo when test is succesful

### DIFF
--- a/.github/workflows/entrypoint.sh
+++ b/.github/workflows/entrypoint.sh
@@ -26,7 +26,7 @@ for PKG in /ci/*.ipk; do
 	if [ -f "$TEST_SCRIPT" ]; then
 		echo "Use package specific test.sh"
 		if sh "$TEST_SCRIPT" "$PKG_NAME" "$PKG_VERSION"; then
-			echo "Test successfull"
+			echo "Test succesful"
 		else
 			echo "Test failed"
 			exit 1

--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -46,7 +46,7 @@ jobs:
           PACKAGES="${PACKAGES:-vim tmux bmon}"
 
           echo "Building $PACKAGES"
-          echo "::set-env name=PACKAGES::$PACKAGES"
+          echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
 
       - name: Build
         uses: openwrt/gh-action-sdk@v1


### PR DESCRIPTION
Maintainer: @aparcar

While adding test.sh to one of my packages, which I maintain, I noticed in the output, that there is typo. It's nitpick, but hopefully you don't mind that.