### PR TITLE
[19.07] travelmate: bugfix single radio mode

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=1.5.4
-PKG_RELEASE:=3
+PKG_VERSION:=1.5.5
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-trm_ver="1.5.4"
+trm_ver="1.5.5"
 trm_enabled=0
 trm_debug=0
 trm_iface="trm_wwan"
@@ -245,7 +245,7 @@ f_check()
 {
 	local IFS ifname radio dev_status result uci_section login_command login_command_args wait_time=1 mode="${1}" status="${2:-"false"}" cp_domain="${3:-"false"}"
 
-	if [ "${mode}" != "initial" ] && [ "${mode}" != "dev" ] && [ "${status}" = "false" ]
+	if [ "${mode}" != "initial" ] && [ "${status}" = "false" ]
 	then
 		"${trm_wifi}" "${trm_wificmd}"
 		sleep $((trm_maxwait/6))


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: n/a
Run tested: GL-MT300Nv2, ZBT 826

Description:
* fix the re-connection handling in single radio mode,
  see https://forum.openwrt.org/t/travelmate-support-thread/5155/470 for details

Signed-off-by: Dirk Brenken <dev@brenken.org>

