### PR TITLE
acme: Allow custom ACME server directory URL

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme
 PKG_VERSION:=2.8.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/acmesh-official/acme.sh/tar.gz/$(PKG_VERSION)?

--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -210,6 +210,7 @@ issue_cert()
 	local user_cleanup
 	local ret
 	local domain_dir
+	local acme_server
 
 	config_get_bool enabled "$section" enabled 0
 	config_get_bool use_staging "$section" use_staging
@@ -223,6 +224,7 @@ issue_cert()
 	config_get dns "$section" dns
 	config_get user_setup "$section" user_setup
 	config_get user_cleanup "$section" user_cleanup
+	config_get acme_server "$section" acme_server
 
 	UPDATE_NGINX=$update_nginx
 	UPDATE_UHTTPD=$update_uhttpd
@@ -276,6 +278,11 @@ issue_cert()
 	acme_args="$acme_args --keylength $keylength"
 	[ -n "$ACCOUNT_EMAIL" ] && acme_args="$acme_args --accountemail $ACCOUNT_EMAIL"
 	[ "$use_staging" -eq "1" ] && acme_args="$acme_args --staging"
+
+	if [ -n $acme_server ]; then
+		log "Using custom ACME server URL"
+		acme_args="$acme_args --server $acme_server"
+	fi
 
 	if [ -n "$dns" ]; then
 		log "Using dns mode"


### PR DESCRIPTION
The underlying `acme.sh` allows custom ACME server URLs (using `--server`). Adding the necessary fields to specify a custom ACME server URL from UCI.

Maintainer: @tohojo 
Compile tested: ipq40xx
Run tested: ipq40xx (tested issuance of a certificate from a custom ACME compatible CA)

Signed-off-by: Jannis Pinter <jannis+openwrt@pinterjann.is>