### PR TITLE
logrotate: add runtime test and bump to 3.17.0

### DIFF
--- a/utils/logrotate/Makefile
+++ b/utils/logrotate/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=logrotate
-PKG_VERSION:=3.16.0
-PKG_RELEASE:=2
+PKG_VERSION:=3.17.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/logrotate/logrotate/releases/download/$(PKG_VERSION)
-PKG_HASH:=442f6fdf61c349eeae5f76799878b88fe45a11c8863a38b618bac6988f4a7ce5
+PKG_HASH:=58cc2178ff57faa3c0490181cce041345aeca6cff18dba1c5cd1398bf1c19294
 
 PKG_MAINTAINER:=Christian Beier <cb@shoutrlabs.com>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/utils/logrotate/test.sh
+++ b/utils/logrotate/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+logrotate --version 2>&1 | grep "$2"


### PR DESCRIPTION
Maintainer: @bk138
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07.4
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07.4

Description:
- Update to version [3.17.0](https://github.com/logrotate/logrotate/releases/tag/3.17.0)
