### PR TITLE
python-babel: add new package

### DIFF
--- a/lang/python/python-babel/Makefile
+++ b/lang/python/python-babel/Makefile
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2019-2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-babel
+PKG_VERSION:=2.8.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=Babel
+PKG_HASH:=1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38
+
+PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-babel
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Internationalization utilities
+  URL:=https://babel.pocoo.org/en/latest/
+  DEPENDS:= \
+    +python3-cgi \
+    +python3-decimal \
+    +python3-distutils \
+    +python3-email \
+    +python3-light \
+    +python3-pytz \
+    +python3-urllib
+endef
+
+define Package/python3-babel/description
+  Babel is an integrated collection of utilities that assist in
+  internationalizing and localizing Python applications
+  with an emphasis on web-based applications.
+endef
+
+$(eval $(call Py3Package,python3-babel))
+$(eval $(call BuildPackage,python3-babel))
+$(eval $(call BuildPackage,python3-babel-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
- Add [Babel](http://babel.pocoo.org/en/latest/)

Dependency pytz is also required:
`AttributeError: module 'pytz' has no attribute 'UnknownTimeZoneError`
while trying to run tested it with:
`from babel.dates import format_date, format_datetime, format_time`

@jefferyto and @commodo can you please review it? :)