### PR TITLE
Flask: Babel, SeaSurf, Session - add packages

### DIFF
--- a/lang/python/python-flask-babel/Makefile
+++ b/lang/python/python-flask-babel/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2019-2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-flask-babel
+PKG_VERSION:=2.0.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=Flask-Babel
+PKG_HASH:=f9faf45cdb2e1a32ea2ec14403587d4295108f35017a7821a2b1acb8cfd9257d
+
+PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-flask-babel
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Flask Babel
+  URL:=https://github.com/python-babel/flask-babel
+  DEPENDS:= \
+    +python3-light \
+    +python3-flask \
+    +python3-babel \
+    +python3-jinja2 \
+    +python3-pytz
+endef
+
+define Package/python3-flask-babel/description
+  Implements i18n and l10n support for Flask.
+endef
+
+$(eval $(call Py3Package,python3-flask-babel))
+$(eval $(call BuildPackage,python3-flask-babel))
+$(eval $(call BuildPackage,python3-flask-babel-src))

--- a/lang/python/python-flask-seasurf/Makefile
+++ b/lang/python/python-flask-seasurf/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2019-2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-flask-seasurf
+PKG_VERSION:=0.2.2
+PKG_RELEASE:=1
+
+PYPI_NAME:=Flask-SeaSurf
+PKG_HASH:=c57918c17e9afd988bdc30d8dcb7bfb833741dee38b06c1bbd17821d6fa2b6cf
+
+PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-flask-seasurf
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Flask SeaSurf
+  URL:=https://flask-seasurf.readthedocs.io/en/latest/
+  DEPENDS:= \
+    +python3-flask \
+    +python3-light \
+    +python3-urllib
+endef
+
+define Package/python3-flask-seasurf/description
+  SeaSurf is a Flask extension for preventing cross-site request forgery (CSRF).
+endef
+
+$(eval $(call Py3Package,python3-flask-seasurf))
+$(eval $(call BuildPackage,python3-flask-seasurf))
+$(eval $(call BuildPackage,python3-flask-seasurf-src))

--- a/lang/python/python-flask-session/Makefile
+++ b/lang/python/python-flask-session/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2019-2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-flask-session
+PKG_VERSION:=0.3.2
+PKG_RELEASE:=1
+
+PYPI_NAME:=Flask-Session
+PKG_HASH:=0768e2bbf06f963ec1aa711bde7aa32dc39ff70f89b495d6db687d899eae4423
+
+PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-flask-session
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Flask Session
+  URL:=https://github.com/fengsp/flask-session
+  DEPENDS:= \
+    +python3-cachelib \
+    +python3-flask \
+    +python3-light
+endef
+
+define Package/python3-flask-session/description
+  Adds server-side session support to your Flask application.
+endef
+
+$(eval $(call Py3Package,python3-flask-session))
+$(eval $(call BuildPackage,python3-flask-session))
+$(eval $(call BuildPackage,python3-flask-session-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
In this pull request, I added 3 packages, which depends on Flask. In this case stdlib shows dependencies just for Flask Seasurf. Rest were taking from setup.py.

@jefferyto and @commodo , if you have time, would you please check it?