### PR TITLE
etesync-server: use relative path for static_url

### DIFF
--- a/net/etesync-server/Makefile
+++ b/net/etesync-server/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=etesync-server
 PKG_VERSION:=0.3.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=etesync-server-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/etesync/server/archive/v$(PKG_VERSION)
@@ -88,7 +88,7 @@ Py3Package/etesync-server/filespec:=
 define Package/etesync-server/postrm
 #!/bin/sh
 [ -n "$${IPKG_INSTROOT}" ] && exit 0
-rmdir /usr/share/etesync-server/etesync_server
+rmdir --ignore-fail-on-non-empty /usr/share/etesync-server/etesync_server
 [ "$${PKG_UPGRADE}" = "1" ] && exit 0
 rm -r /www/etesync/static
 rmdir /www/etesync

--- a/net/etesync-server/files/81_setup-etesync-server
+++ b/net/etesync-server/files/81_setup-etesync-server
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-[ "${PKG_UPGRADE}" = "1" ] && /etc/init.d/etesync-server stop
-
 cd /usr/share/etesync-server || exit 1
 
 python3 manage.pyc migrate --noinput || exit 1

--- a/net/etesync-server/files/uci.cfg
+++ b/net/etesync-server/files/uci.cfg
@@ -1,6 +1,6 @@
 
 config django 'global'
-	option static_url '/etesync/static/' # TODO for django 3.1: "static/"
+	option static_url 'static/'
 	option debug 'false'
 
 config django 'allowed_hosts'


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, x86_64 qemu, master
Run tested: x86_64, x86_64 qemu, master, run it and log into admin interface

Description: Django 3.1 supports relative paths for `static_url`. Use it to make it more flexible.
Made also minor fixes for upgrade:
* add `--ignore-fail-on-non-empty` to `rmdir /usr/share/etesync-server/etesync_server`
* do not stop service (it is stopped already and init file is removed)
