### PR TITLE
adblock: update 4.0.7

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=4.0.6
-PKG_RELEASE:=3
+PKG_VERSION:=4.0.7
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable -->
+
 # DNS based ad/abuse domain blocking
 
 ## Description
@@ -36,6 +38,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 | reg_fi              |         | S    | reg_finland      | [Link](https://github.com/finnish-easylist-addition)                              |
 | reg_fr              |         | S    | reg_france       | [Link](https://forums.lanik.us/viewforum.php?f=91)                                |
 | reg_id              |         | M    | reg_indonesia    | [Link](https://easylist.to)                                                       |
+| reg_it              |         | M    | reg_italy        | [Link](https://easylist.to)                                                       |
 | reg_kr              |         | S    | reg_korea        | [Link](https://list-kr.github.io)                                                 |
 | reg_nl              |         | M    | reg_netherlands  | [Link](https://easylist.to)                                                       |
 | reg_pl1             |         | S    | reg_poland       | [Link](https://kadantiscam.netlify.com)                                           |

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -2,16 +2,20 @@
 # Copyright (c) 2015-2020 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
+# set (s)hellcheck exceptions
+# shellcheck disable=1091,2010,2016,2034,2039,2059,2086,2091,2129,2143,2154,2181,2183,2188
+
 START=30
 USE_PROCD=1
 
-EXTRA_COMMANDS="suspend resume query report list timer status_service"
+EXTRA_COMMANDS="suspend resume query report list timer status_service version"
 EXTRA_HELP="	suspend	Suspend adblock processing
 	resume	Resume adblock processing
 	query	<domain> Query active blocklists and backups for a specific domain
 	report	[<search>] Print DNS statistics with an optional search parameter
 	list	[[<add>|<remove>] [source(s)]] List available adblock sources or add/remove them from config
-	timer	<action> <hour> [<minute>] [<weekday>] Set a cron based update interval"
+	timer	<action> <hour> [<minute>] [<weekday>] Set a cron based update interval
+	version	print version information"
 
 adb_init="/etc/init.d/adblock"
 adb_script="/usr/bin/adblock.sh"
@@ -24,6 +28,11 @@ if [ -s "${adb_pidfile}" ] && { [ "${action}" = "start" ] || [ "${action}" = "st
 then
 	exit 0
 fi
+
+version()
+{
+	rc_procd "${adb_script}" version
+}
 
 boot()
 {

--- a/net/adblock/files/adblock.mail
+++ b/net/adblock/files/adblock.mail
@@ -5,6 +5,9 @@
 
 # Please note: you have to manually install and configure the package 'msmtp' before using this script
 
+# set (s)hellcheck exceptions
+# shellcheck disable=1091,2010,2016,2034,2039,2059,2086,2091,2129,2143,2154,2181,2183,2188
+
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
 

--- a/net/adblock/files/adblock.monitor
+++ b/net/adblock/files/adblock.monitor
@@ -3,6 +3,9 @@
 # Copyright (c) 2015-2020 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
+# set (s)hellcheck exceptions
+# shellcheck disable=1091,2010,2016,2034,2039,2059,2086,2091,2129,2143,2154,2181,2183,2188
+
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
 

--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -195,6 +195,13 @@
 		"focus": "reg_indonesia",
 		"descurl": "https://easylist.to"
 	},
+	"reg_it": {
+		"url": "https://easylist-downloads.adblockplus.org/easylistitaly+easylist.txt",
+		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
+		"size": "M",
+		"focus": "reg_italy",
+		"descurl": "https://easylist.to"
+	},
 	"reg_kr": {
 		"url": "https://raw.githubusercontent.com/List-KR/List-KR/master/filter.txt",
 		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",

--- a/net/adblock/test.sh
+++ b/net/adblock/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/etc/init.d/"${1}" version 2>/dev/null | grep "${2}"


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: PC Engines apu4, OpenWrt SNAPSHOT r14692-0830ae3a2f

Description:
* fix aria2c download options
* fix report engine with empty domains
* fix safesearch ips of safe.duckduckgo.com (get ips dynamically)
* fix safesearch ips of safesearch.pixabay.com (get ips dynamically)
* add regional blocklist for italy
* shellcheck adjustments

Signed-off-by: Dirk Brenken <dev@brenken.org>
