### PR TITLE
prometheus: bump to 2.22.0

### DIFF
--- a/utils/prometheus/Makefile
+++ b/utils/prometheus/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus
-PKG_VERSION:=2.21.0
+PKG_VERSION:=2.22.0
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/prometheus/prometheus/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=afafed1be631a53ada60e2b2f12cfdb51dcaee5e539fb65e9983f3276c99f5af
+PKG_HASH:=9390cbd338d253956184d0f0a6719d21cb5719f0319fc48ee08d5bd48fc87cc2
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
As announced in the 2.21.0 release notes, the experimental gRPC API v2
has been removed.

[CHANGE] web: Remove APIv2. #7935
[ENHANCEMENT] React UI: Implement missing TSDB head stats section. #7876
[ENHANCEMENT] UI: Add Collapse all button to targets page. #6957
[ENHANCEMENT] UI: Clarify alert state toggle via checkbox icon. #7936
[ENHANCEMENT] Add rule_group_last_evaluation_samples and
	prometheus_tsdb_data_replay_duration_seconds metrics. #7737 #7977
[ENHANCEMENT] Gracefully handle unknown WAL record types. #8004
[ENHANCEMENT] Issue a warning for 64 bit systems running 32 bit
	binaries. #8012
[BUGFIX] Adjust scrape timestamps to align them to the intended
	schedule, effectively reducing block size. Workaround for a regression
	in go1.14+. #7976
[BUGFIX] promtool: Ensure alert rules are marked as restored in unit
	tests. #7661
[BUGFIX] Eureka: Fix service discovery when compiled in 32-bit. #7964
[BUGFIX] Don't do literal regex matching optimisation when case
	insensitive. #8013
[BUGFIX] Fix classic UI sometimes running queries for instant query when
	in range query mode. #7984