### PR TITLE
adblock: update 4.0.7-2

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
 PKG_VERSION:=4.0.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: TP-Link RE650 v1, OpenWrt SNAPSHOT r14723-7f5f738466

Description:
* switch all safesearch providers to dynamic ips (derived from cname)
* made the new safesearch approach compatible with bind-nslookup
* removed 3.x config compatibility code

Signed-off-by: Dirk Brenken <dev@brenken.org>

