### PR TITLE
python-msgpack: add new package

### DIFF
--- a/lang/python/python-msgpack/Makefile
+++ b/lang/python/python-msgpack/Makefile
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2017-2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-msgpack
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=msgpack
+PKG_HASH:=9534d5cc480d4aff720233411a1f765be90885750b07df772380b34c10ecb5c0
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=COPYING
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-msgpack
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=MessagePack (de)serializer
+  URL:=https://msgpack.org/
+  DEPENDS:=+python3-light +libstdcpp
+endef
+
+define Package/python3-msgpack/description
+  MessagePack is an efficient binary serialization format.
+  It lets you exchange data among multiple languages like JSON.
+endef
+
+$(eval $(call Py3Package,python3-msgpack))
+$(eval $(call BuildPackage,python3-msgpack))
+$(eval $(call BuildPackage,python3-msgpack-src))


### PR DESCRIPTION
maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR adds a new python library for efficient binary serialization. 

It's related to https://github.com/openwrt/packages/pull/13740 (dependeny for python-influxdb)

Run tested with internal unit tests:
```
1 failed, 114 passed in 1.43s
```


