### PR TITLE
zoneinfo: Updated to the latest release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2019 OpenWrt.org
+# Copyright (C) 2007-2020 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2020a
+PKG_VERSION:=2020c
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=547161eca24d344e0b5f96aff6a76b454da295dc14ed4ca50c2355043fb899a2
+PKG_HASH:=7890ac105f1aa4a5d15c5be2409580af401ee2f3fffe2a1e4748af589e194bd9
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=7d2af7120ee03df71fbca24031ccaf42404752e639196fe93c79a41b38a6d669
+   HASH:=9aa97f40f7b5d90c76c1af80295194daef9c427302f50c278d10ca31c3ccbfe4
 endef
 
 $(eval $(call Download,tzcode))
@@ -127,7 +127,7 @@ define Build/Compile
 		$(HOST_CONFIGURE_OPTS) \
 		CC="$(HOSTCC)" \
 		LD="\$$$$(CC)" \
-		CPPFLAGS="$(HOST_CPPFLAGS) -DHAVE_SNPRINTF=1" \
+		CPPFLAGS="$(HOST_CPPFLAGS) -DHAVE_SNPRINTF=1 -DZIC_BLOAT_DEFAULT='\"fat\"'" \
 		LDFLAGS="$(HOST_LDFLAGS)" \
 		TOPDIR="$(PKG_INSTALL_DIR)" \
 		TZDIR="$(PKG_INSTALL_DIR)/zoneinfo" \


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT/LEDE master
Run tested: n/a

Notes:

    I've updated build parameters to build in TZif "fat" format. 
    If musl will implement support for TZif "slim" format we should switch to default compile options. 
    "Slim" format significantly reduces size of zoneinfo packages.

Description:

   Briefly:

     Fiji starts DST later than usual, on 2020-12-20.

   Changes to future timestamps

     Fiji will start DST on 2020-12-20, instead of 2020-11-08 as
     previously predicted.  DST will still end on 2021-01-17.
     (Thanks to Raymond Kumar and Alan Mintz.)  Assume for now that
     the later-than-usual start date is a one-time departure from the
     recent pattern.

   Changes to build procedure

     Rearguard tarballs now contain an empty file pacificnew.
     Some older downstream software expects this file to exist.
     (Problem reported by Mike Cullinan.)