### PR TITLE
transmission: remove variants and use libcurl's TLS library

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=3.00
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master
@@ -23,6 +23,12 @@ PKG_CPE_ID:=cpe:/a:transmissionbt:transmission
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_LIBCURL_GNUTLS \
+	CONFIG_LIBCURL_MBEDTLS \
+	CONFIG_LIBCURL_OPENSSL \
+	CONFIG_LIBCURL_WOLFSSL \
+	CONFIG_LIBCURL_NOSSL
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/package-seccomp.mk
@@ -34,93 +40,53 @@ define Package/transmission/template
   CATEGORY:=Network
   TITLE:=BitTorrent client
   URL:=https://www.transmissionbt.com
-  DEPENDS:=+libcurl +libevent2 +libminiupnpc +libnatpmp +libpthread +librt +zlib $(ICONV_DEPENDS)
+  DEPENDS:=+libcurl +libevent2 +libminiupnpc +libnatpmp +libpthread +librt +zlib +LIBCURL_NOSSL:libmbedtls +LIBCURL_GNUTLS:libmbedtls $(ICONV_DEPENDS)
 endef
 
-define Package/transmission-daemon/Default
+define Package/transmission-daemon
   $(call Package/transmission/template)
   USERID:=transmission=224:transmission=224
 endef
 
-define Package/transmission-daemon-openssl
-  $(call Package/transmission-daemon/Default)
-  TITLE+= (with OpenSSL)
-  DEPENDS+=+libopenssl
-  VARIANT:=openssl
-endef
-
-define Package/transmission-daemon-mbedtls
-  $(call Package/transmission-daemon/Default)
-  TITLE+= (with mbed TLS)
-  DEPENDS+=+libmbedtls
-  VARIANT:=mbedtls
-endef
-
-define Package/transmission-cli-openssl
+define Package/transmission-cli
   $(call Package/transmission/template)
-  TITLE+= (with OpenSSL)
-  DEPENDS+=+libopenssl
-  VARIANT:=openssl
+  TITLE+= (utilities)
 endef
 
-define Package/transmission-cli-mbedtls
+define Package/transmission-remote
   $(call Package/transmission/template)
-  TITLE+= (with mbed TLS)
-  DEPENDS+=+libmbedtls
-  VARIANT:=mbedtls
-endef
-
-define Package/transmission-remote-openssl
-  $(call Package/transmission/template)
-  TITLE+= (with OpenSSL)
-  DEPENDS+=+libopenssl
-  VARIANT:=openssl
-endef
-
-define Package/transmission-remote-mbedtls
-  $(call Package/transmission/template)
-  TITLE+= (with mbed TLS)
-  DEPENDS+=+libmbedtls
-  VARIANT:=mbedtls
+  TITLE+= (remote)
 endef
 
 define Package/transmission-web
   $(call Package/transmission/template)
   TITLE+= (webinterface)
-  DEPENDS:=@(PACKAGE_transmission-daemon-openssl||PACKAGE_transmission-daemon-mbedtls)
+  DEPENDS:=+transmission-daemon
   PKGARCH:=all
 endef
 
-
-define Package/transmission-daemon/Default/description
+define Package/transmission-daemon/description
  Transmission is a simple BitTorrent client.
  It features a very simple, intuitive interface
  on top on an efficient, cross-platform back-end.
  This package contains the daemon itself.
 endef
-Package/transmission-daemon-openssl/description = $(Package/transmission-daemon/Default/description)
-Package/transmission-daemon-mbedtls/description = $(Package/transmission-daemon/Default/description)
 
-define Package/transmission-cli/Default/description
+define Package/transmission-cli/description
  CLI utilities for transmission.
 endef
-Package/transmission-cli-openssl/description = $(Package/transmission-cli/Default/description)
-Package/transmission-cli-mbedtls/description = $(Package/transmission-cli/Default/description)
 
-define Package/transmission-remote/Default/description
+define Package/transmission-remote/description
  CLI remote interface for transmission.
 endef
-Package/transmission-remote-openssl/description = $(Package/transmission-remote/Default/description)
-Package/transmission-remote-mbedtls/description = $(Package/transmission-remote/Default/description)
 
 define Package/transmission-web/description
  Webinterface resources for transmission.
 endef
 
-define Package/transmission-daemon-openssl/conffiles
+define Package/transmission-daemon/conffiles
 /etc/config/transmission
 endef
-Package/transmission-daemon-mbedtls/conffiles = $(Package/transmission-daemon-openssl/conffiles)
 
 TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
 TARGET_LDFLAGS += -Wl,--gc-sections -Wl,--as-needed -liconv
@@ -133,15 +99,14 @@ CONFIGURE_ARGS += \
 	--enable-lightweight \
 	--without-gtk \
 	--without-kqueue \
-	--without-systemd-daemon
+	--without-systemd-daemon \
+	$(if $(CONFIG_LIBCURL_NOSSL),--with-crypto=polarssl) \
+	$(if $(CONFIG_LIBCURL_GNUTLS),--with-crypto=polarssl) \
+	$(if $(CONFIG_LIBCURL_MBEDTLS),--with-crypto=polarssl) \
+	$(if $(CONFIG_LIBCURL_OPENSSL),--with-crypto=openssl) \
+	$(if $(CONFIG_LIBCURL_WOLFSSL),--with-crypto=cyassl)
 
-ifeq ($(BUILD_VARIANT),mbedtls)
-  CONFIGURE_ARGS += --with-crypto=polarssl
-else
-  CONFIGURE_ARGS += --with-crypto=openssl
-endif
-
-define Package/transmission-daemon-openssl/install
+define Package/transmission-daemon/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/transmission-daemon $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/etc/init.d/
@@ -152,9 +117,8 @@ define Package/transmission-daemon-openssl/install
 	$(INSTALL_CONF) files/transmission.sysctl $(1)/etc/sysctl.d/20-transmission.conf
 	$(call InstallSeccomp,$(1),./files/transmission-daemon.json)
 endef
-Package/transmission-daemon-mbedtls/install = $(Package/transmission-daemon-openssl/install)
 
-define Package/transmission-cli-openssl/install
+define Package/transmission-cli/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/transmission-cli \
 			$(PKG_INSTALL_DIR)/usr/bin/transmission-create \
@@ -162,23 +126,18 @@ define Package/transmission-cli-openssl/install
 			$(PKG_INSTALL_DIR)/usr/bin/transmission-show \
 			$(1)/usr/bin/
 endef
-Package/transmission-cli-mbedtls/install = $(Package/transmission-cli-openssl/install)
 
-define Package/transmission-remote-openssl/install
+define Package/transmission-remote/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/transmission-remote $(1)/usr/bin/
 endef
-Package/transmission-remote-mbedtls/install = $(Package/transmission-remote-openssl/install)
 
 define Package/transmission-web/install
 	$(INSTALL_DIR) $(1)/usr/share/transmission
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/transmission/web $(1)/usr/share/transmission/
 endef
 
-$(eval $(call BuildPackage,transmission-daemon-openssl))
-$(eval $(call BuildPackage,transmission-daemon-mbedtls))
-$(eval $(call BuildPackage,transmission-cli-openssl))
-$(eval $(call BuildPackage,transmission-cli-mbedtls))
-$(eval $(call BuildPackage,transmission-remote-openssl))
-$(eval $(call BuildPackage,transmission-remote-mbedtls))
+$(eval $(call BuildPackage,transmission-daemon))
+$(eval $(call BuildPackage,transmission-cli))
+$(eval $(call BuildPackage,transmission-remote))
 $(eval $(call BuildPackage,transmission-web))


### PR DESCRIPTION
Allows the Makefile to be cleaned up and to have fewer dependencies.
There's no need for multiple TLS libraries to be installed.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me
Compile tested: powerpc

Alternative to https://github.com/openwrt/packages/pull/13609

@ja-pa please review.