### PR TITLE
modemmanager: include all init commands in the procd instance

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.14.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager

--- a/net/modemmanager/files/modemmanager.init
+++ b/net/modemmanager/files/modemmanager.init
@@ -12,21 +12,24 @@ stop_service() {
 }
 
 start_service() {
-	# Load common utils
-	. /usr/share/ModemManager/modemmanager.common
-
-	# Always make sure the rundir exists
-	mkdir -m 0755 -p "${MODEMMANAGER_RUNDIR}"
-
-	# Initially set all configured interfaces as unavailable
-	mm_cleanup_interfaces
-
-	# Report cached events (will wait for MM to be launched)
-	( mm_report_events_from_cache ) >/dev/null 2>&1 &
-
 	# Setup ModemManager service
+	#
+	# We will make sure that the rundir always exists, and we initially cleanup
+	# all interfaces flagging them as unavailable.
+	#
+	# The cached events processing will wait for MM to be available in DBus
+	# and will make sure all ports are re-notified to ModemManager every time
+	# it starts.
+	#
+	# All these commands need to be executed on every MM start, even after
+	# procd-triggered respawns, which is why they're all included as instance command
+	#
 	procd_open_instance
-	procd_set_param command /usr/sbin/ModemManager
+	procd_set_param command sh -c ". /usr/share/ModemManager/modemmanager.common;    \
+	                               mkdir -m 0755 -p ${MODEMMANAGER_RUNDIR};          \
+	                               mm_cleanup_interfaces;                            \
+	                               ( mm_report_events_from_cache ) >/dev/null 2>&1 & \
+	                               /usr/sbin/ModemManager"
 	procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 	procd_set_param pidfile "${MODEMMANAGER_PID_FILE}"
 	procd_close_instance


### PR DESCRIPTION
If procd relaunches the ModemManager daemon after e.g. a crash, we
also want it to notify all cached hotplug events, or otherwise we
would end up leaving the daemon running without the full initial
processing done.

This change modifies the init script to include all the required init
commands as part of the procd instance command, so that procd launches
all of them on every respawn.

Maintainer: @nickberry17 
