### PR TITLE
libndpi: Update to 3.4

### DIFF
--- a/libs/libndpi/Makefile
+++ b/libs/libndpi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libndpi
-PKG_VERSION:=3.2
+PKG_VERSION:=3.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ntop/nDPI/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=6808c8c4495343e67863f4d30bb261c1e2daec5628ae0be257ba2a2dea7ec70a
+PKG_HASH:=dc9b291c7fde94edb45fb0f222e0d93c93f8d6d37f4efba20ebd9c655bfcedf9
 PKG_BUILD_DIR:=$(BUILD_DIR)/nDPI-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Banglang Huang <banglang.huang@foxmail.com>, Toni Uhlig <matzeton@googlemail.com>
@@ -28,12 +28,16 @@ PKG_BUILD_PARALLEL:=1
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 
+ifeq ($(CONFIG_LIBNDPI_GCRYPT),)
+CONFIGURE_ARGS += --disable-gcrypt
+endif
+
 define Package/libndpi
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Library for deep-packet inspection
   URL:=https://github.com/ntop/nDPI
-  DEPENDS:=$(CXX_DEPENDS) +libpcap +libjson-c
+  DEPENDS:=$(CXX_DEPENDS) +LIBNDPI_GCRYPT:libgcrypt +libpcap +libjson-c
 endef
 
 define Package/libndpi/description
@@ -41,14 +45,25 @@ define Package/libndpi/description
   Based on OpenDPI it includes ntop extensions.
 endef
 
+define Package/libndpi/config
+config LIBNDPI_GCRYPT
+	bool "GCrypt support"
+	depends on PACKAGE_libndpi
+	default n
+	help
+	  This option enables QUIC client hello decryption.
+	  Disabled by default.
+endef
+
 define Build/Prepare
 	$(PKG_UNPACK)
 	$(Build/Patch)
 	mv $(PKG_BUILD_DIR)/configure.seed $(PKG_BUILD_DIR)/configure.ac
 	$(SED) "s/@NDPI_MAJOR@/3/g" \
-		-e "s/@NDPI_MINOR@/2/g" \
+		-e "s/@NDPI_MINOR@/4/g" \
 		-e "s/@NDPI_PATCH@/0/g" \
-		-e "s/@NDPI_VERSION_SHORT@/3.2.0/g" \
+		-e "s/@NDPI_VERSION_SHORT@/3.4.0/g" \
+		-e "s/@FUZZY@/dnl> /g" \
 		$(PKG_BUILD_DIR)/configure.ac
 endef
 


### PR DESCRIPTION
Signed-off-by: Toni Uhlig <matzeton@googlemail.com>

Maintainer: me
Compile tested: x86_64, debian-stable
Run tested: mvebu, OpenWrt SNAPSHOT, r14664+9-156b72b9aa

Description: Added config option to toggle GCrypt based decryption support for QUIC client hellos.