### PR TITLE
 udpxy: fix error 'enable verbose' command flag in init script

### DIFF
--- a/net/udpxy/Makefile
+++ b/net/udpxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=udpxy
 PKG_VERSION:=1.0-24.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/pcherenkov/udpxy/tar.gz/$(PKG_VERSION)?

--- a/net/udpxy/files/udpxy.init
+++ b/net/udpxy/files/udpxy.init
@@ -38,7 +38,7 @@ start_instance() {
 	procd_set_param command /usr/bin/udpxy
 	procd_append_param command "-T"
 
-	append_bool "$cfg" verbose "-V"
+	append_bool "$cfg" verbose "-v"
 	append_bool "$cfg" status "-S"
 	append_arg "$cfg" bind "-a"
 	append_arg "$cfg" port "-p"


### PR DESCRIPTION
Maintainer: @Noltari
Compile tested: ramips, mt7621-xiaomi_mir3g, Openwrt master
Run tested: ramips, mt7621-xiaomi_mir3g, Openwrt master

Description:
The udpxy command flag for "enable verbose output" should be "-v" not "-V".
Otherwise, if enable verbose output in config file, procd will crash with " procd: Instance udpxy::instance1 s in a crash loop 9 crashes, 0 seconds since last crash" message.
