### PR TITLE
Python influxdb 5.3.0

### DIFF
--- a/lang/python/python-influxdb/Makefile
+++ b/lang/python/python-influxdb/Makefile
@@ -5,12 +5,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-influxdb
-PKG_VERSION:=5.2.2
-PKG_RELEASE:=2
+PKG_VERSION:=5.3.0
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
 
 PYPI_NAME:=influxdb
-PKG_HASH:=afeff28953a91b4ea1aebf9b5b8258a4488d0e49e2471db15ea43fd2c8533143
+PKG_HASH:=9bcaafd57ac152b9824ab12ed19f204206ef5df8af68404770554c5b55b475f6
+
 PKG_LICENSE:=MIT
 
 include ../pypi.mk
@@ -23,7 +24,12 @@ define Package/python3-influxdb
   SUBMENU:=Python
   URL:=https://github.com/influxdb/influxdb-python
   TITLE:=python3-influxdb
-  DEPENDS:=+python3-requests +python3-pytz +python3-six +python3-dateutil
+  DEPENDS:=\
+    +python3-requests \
+    +python3-pytz \
+    +python3-six \
+    +python3-dateutil \
+    +python3-msgpack
 endef
 
 define Package/python3-influxdb/description


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (master)
Run tested: Turris Omnia (master)

Description:
Update to latest version of python-influxdb. It needs new dependency python-msgpack so it requires https://github.com/openwrt/packages/pull/13713