### PR TITLE
python-intelhex: add patch to fix Python 3.9 compatibility

### DIFF
--- a/lang/python/python-intelhex/Makefile
+++ b/lang/python/python-intelhex/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-intelhex
 PKG_VERSION:=2.2.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=IntelHex
 PYPI_SOURCE_NAME:=intelhex

--- a/lang/python/python-intelhex/patches/001-Fix-Python-3.9-compatibility-issue-with-array-module.patch
+++ b/lang/python/python-intelhex/patches/001-Fix-Python-3.9-compatibility-issue-with-array-module.patch
@@ -1,0 +1,26 @@
+From 4125dce5b174401d38cc0fcf9d2e1aad07997f5e Mon Sep 17 00:00:00 2001
+From: fernandez85 <fernandez2005@gmail.com>
+Date: Sun, 11 Oct 2020 12:39:06 +0200
+Subject: [PATCH] Fix Python 3.9 compatibility issue with 'array' module
+
+---
+ intelhex/compat.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/intelhex/compat.py b/intelhex/compat.py
+index 194cd5d..2a6bee6 100644
+--- a/intelhex/compat.py
++++ b/intelhex/compat.py
+@@ -57,7 +57,8 @@ if sys.version_info[0] >= 3:
+             return s
+         return s.decode('latin1')
+ 
+-    array_tobytes = getattr(array.array, "tobytes", array.array.tostring)
++    # for python >= 3.2 use 'tobytes', otherwise 'tostring'
++    array_tobytes = array.array.tobytes if sys.version_info[1] >= 2 else array.array.tostring
+ 
+     IntTypes = (int,)
+     StrType = str
+-- 
+2.28.0
+


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (master)
Run tested: Turris Omnia (master)

Description:
This fixes this library on Python 3.9.