### PR TITLE
nginx: adapt to changed ubus.sock path

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.19.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/

--- a/net/nginx/files-luci-support/60_nginx-luci-support
+++ b/net/nginx/files-luci-support/60_nginx-luci-support
@@ -6,12 +6,15 @@ if nginx -V 2>&1 | grep -q ubus; then
 
 location /ubus {
         ubus_interpreter;
-        ubus_socket_path /var/run/ubus.sock;
+        ubus_socket_path /var/run/ubus/ubus.sock;
         ubus_parallel_req 2;
 }
 EOT
 	fi
 fi
+
+grep -q /var/run/ubus.sock /etc/nginx/conf.d/luci.locations &&
+	sed -i 's#/var/run/ubus.sock#/var/run/ubus/ubus.sock#' /etc/nginx/conf.d/luci.locations
 
 if [ -x /etc/init.d/uhttpd ]; then
         /etc/init.d/uhttpd disable


### PR DESCRIPTION
Signed-off-by: Daniel Golle <daniel@makrotopia.org>

Maintainer: @heil @Ansuel 
Compile tested: --
Run tested: --

Description:
ubus socket was moved from /var/run/ubus.sock to /var/run/ubus/ubus.sock upstream.
Reflect that change in nginx and migrate existing configurations.