### PR TITLE
acme: Add option for days until renewal

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme
 PKG_VERSION:=2.8.7
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/acmesh-official/acme.sh/tar.gz/$(PKG_VERSION)?

--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -211,6 +211,7 @@ issue_cert()
 	local ret
 	local domain_dir
 	local acme_server
+	local days
 
 	config_get_bool enabled "$section" enabled 0
 	config_get_bool use_staging "$section" use_staging
@@ -225,6 +226,7 @@ issue_cert()
 	config_get user_setup "$section" user_setup
 	config_get user_cleanup "$section" user_cleanup
 	config_get acme_server "$section" acme_server
+	config_get days "$section" days
 
 	UPDATE_NGINX=$update_nginx
 	UPDATE_UHTTPD=$update_uhttpd
@@ -282,6 +284,11 @@ issue_cert()
 	if [ -n "$acme_server" ]; then
 		log "Using custom ACME server URL"
 		acme_args="$acme_args --server $acme_server"
+	fi
+
+	if [ -n "$days" ]; then
+		log "Renewing after $days days"
+		acme_args="$acme_args --days $days"
 	fi
 
 	if [ -n "$dns" ]; then


### PR DESCRIPTION
Signed-off-by: Jannis Pinter <jannis+openwrt@pinterjann.is>

Maintainer: @tohojo 
Compile tested: ipq40xx
Run tested: ipq40xx, issued a certificate and set renewal period to 20 days

Description: This change allows to set the `--days` option to specify a custom renewal period for certificates. When left unset, the default setting from `acme.sh` will be used.
