### PR TITLE
banip: Added packet logging feature. Resolved shellcheck warnings.

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
-PKG_VERSION:=0.3.11
+PKG_VERSION:=0.3.12
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/banip/files/banip.conf
+++ b/net/banip/files/banip.conf
@@ -4,6 +4,8 @@ config banip 'global'
 	option ban_basever '0.3'
 	option ban_automatic '1'
 	option ban_realtime 'false'
+	option ban_log_src '0'
+	option ban_log_dst '0'
 
 config banip 'extra'
 	option ban_debug '0'


### PR DESCRIPTION
Signed-off-by: Richard Gering <rg4github@dutchies.us>

Maintainer: @dibdot 
Compile tested: n/a
Run tested: ipq806x, Netgear R7800, OpenWRT 19.7.04.

Description:
Added ability to log IP packets that banIP blocks by creating additional src (inbound) and/or dst (outbound) logging chains.

Logging can be enabled using the `config banip 'global'` options:

```
        option ban_log_src '1'
        option ban_log_dst '1'
```

Possible customizations, showing default values:

```
ban_log_chain_src       ${ban_chain}_log_src
ban_log_chain_dst       ${ban_chain}_log_dst
ban_log_src_opts_6      -m limit --limit 10/sec
ban_log_src_prefix_6    ${ban_target_src_6}(src banIP)
ban_log_dst_opts_6      -m limit --limit 10/sec
ban_log_dst_prefix_6    ${ban_target_dst_6}(dst banIP)
ban_log_src_opts        -m limit --limit 10/sec
ban_log_src_prefix      ${ban_target_src}(src banIP)
ban_log_dst_opts        -m limit --limit 10/sec
ban_log_dst_prefix      ${ban_target_dst}(dst banIP)
```

Example of logged packets:
```
Oct  2 12:49:14 gateway kernel: [434134.855130] REJECT(dst banIP) IN=br-lan OUT=br-wan MAC=xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx SRC=x.x.x.x DST=x.x.x.x LEN=100 TOS=0x00 PREC=0x00 TTL=63 ID=7938 PROTO=UDP SPT=16393 DPT=16393 LEN=80

Oct  3 14:11:13 gateway kernel: [11290.429712] DROP(src banIP) IN=br-wan OUT= MAC=xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx SRC=x.x.x.x DST=x.x.x.x LEN=40 TOS=0x00 PREC=0x00 TTL=235 ID=63275 PROTO=TCP SPT=48246 DPT=37860 WINDOW=1024 RES=0x00 SYN URGP=0
```
