### PR TITLE
knot: update to version 3.0.1

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=2.9.6
+PKG_VERSION:=3.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=bf742883c6825b54f19f2dadca2c94fec1ff8bdcf0a52388e2e167937594b2e7
+PKG_HASH:=97af6724b04308f691392c80d75564ff8b246871f2f59c4f03cede3c4dd401bb
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8
@@ -157,7 +157,7 @@ CONFIGURE_ARGS += 			\
 	--with-configdir=/etc/knot	\
 	--with-conf-mapsize=20
 
-TARGET_CFLAGS += -DPSELECT_COMPAT -DNDEBUG
+TARGET_CFLAGS += -DNDEBUG
 
 define Package/knot/conffiles
 /etc/knot/knot.conf


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 5.2 (hbl)
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 5.1.2 (hbk), all tests successful (1 skipped)

Description:
- definition of PSELECT_COMPAT could be removed many years ago, is no longer needed (see  https://gitlab.nic.cz/knot/knot-dns/-/commit/c03c51cf02d745993f03d997bc99768fab87676b)

Signed-off-by: Jan Hak <jan.hak@nic.cz>