### PR TITLE
docker-compose: move to Utilities in menuconfig

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -18,9 +18,8 @@ include ../../lang/python/python3-package.mk
 PYTHON3_PKG_SETUP_ARGS:=
 
 define Package/docker-compose
-  SECTION:=lang
-  CATEGORY:=Languages
-  SUBMENU:=Python
+  SECTION:=utils
+  CATEGORY:=Utilities
   TITLE:=Docker Compose
   URL:=https://github.com/docker/compose
   DEPENDS+=+docker-ce \


### PR DESCRIPTION
it makes no sense to show docker-compose sit in Languages -> Python
submenu in menuconfig, it is a tool and not a library.
Move it to Utilities section like docker-ce also is.

Signed-off-by: Alberto Bursi <bobafetthotmaiil@gmail.com>

Maintainer: @jmarcet 