### PR TITLE
gunicorn: move to webserver category in menuconfig

### DIFF
--- a/lang/python/gunicorn/Makefile
+++ b/lang/python/gunicorn/Makefile
@@ -23,9 +23,9 @@ include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
 define Package/gunicorn/Default
-  SUBMENU:=Python
-  SECTION:=lang
-  CATEGORY:=Languages
+  SUBMENU:=Web Servers/Proxies
+  SECTION:=net
+  CATEGORY:=Network
   TITLE:=WSGI HTTP Server for UNIX
   URL:=https://gunicorn.org
 endef


### PR DESCRIPTION
this is a webserver and not a python library, so it makes
sense to have it in the same category other webservers
also are placed in the menuconfig interface

Signed-off-by: Alberto Bursi <bobafetthotmail@gmail.com>

Maintainer: @commodo 