### PR TITLE
telldus-core: replace iconv with standard C++

### DIFF
--- a/utils/telldus-core/Makefile
+++ b/utils/telldus-core/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telldus-core
 PKG_VERSION:=2.1.2
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.telldus.com/TellStick/Software/telldus-core/
@@ -22,7 +22,6 @@ PKG_BUILD_PARALLEL:=0
 PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/cmake.mk
 
 define Package/telldus-core
@@ -30,7 +29,7 @@ define Package/telldus-core
 	CATEGORY:=Utilities
 	TITLE:=Telldus TellStick USB interface
 	URL:=https://telldus.com
-	DEPENDS:=+confuse +libftdi +libstdcpp $(ICONV_DEPENDS)
+	DEPENDS:=+confuse +libftdi +libstdcpp
 endef
 
 define Package/telldus-core/description
@@ -45,8 +44,7 @@ endef
 CMAKE_OPTIONS += \
 	-DBUILD_LIBTELLDUS-CORE=1 \
 	-DBUILD_TDTOOL=1 \
-	-DGENERATE_MAN=0 \
-	-DICONV_LIBRARY=-liconv
+	-DGENERATE_MAN=0
 
 define Package/telldus-core/install
 	$(INSTALL_DIR)  $(1)/usr/bin

--- a/utils/telldus-core/patches/200-no-iconv.patch
+++ b/utils/telldus-core/patches/200-no-iconv.patch
@@ -1,0 +1,72 @@
+--- a/common/Strings.cpp
++++ b/common/Strings.cpp
+@@ -12,7 +12,8 @@
+ #ifdef _WINDOWS
+ #include <windows.h>
+ #else
+-#include <iconv.h>
++#include <locale>
++#include <codecvt>
+ #endif
+ #include <algorithm>
+ #include <sstream>
+@@ -50,35 +51,8 @@ std::wstring TelldusCore::charToWstring(const char *value) {
+ 	return retval;
+ 
+ #else
+-	size_t utf8Length = strlen(value);
+-	size_t outbytesLeft = utf8Length*sizeof(wchar_t);
+-
+-	// Copy the instring
+-	char *inString = new char[utf8Length+1];
+-	snprintf(inString, utf8Length+1, "%s", value);
+-
+-	// Create buffer for output
+-	char *outString = reinterpret_cast<char*>(new wchar_t[utf8Length+1]);
+-	memset(outString, 0, sizeof(wchar_t)*(utf8Length+1));
+-
+-#ifdef _FREEBSD
+-	const char *inPointer = inString;
+-#else
+-	char *inPointer = inString;
+-#endif
+-	char *outPointer = outString;
+-
+-	iconv_t convDesc = iconv_open(WCHAR_T_ENCODING, "UTF-8");
+-	iconv(convDesc, &inPointer, &utf8Length, &outPointer, &outbytesLeft);
+-	iconv_close(convDesc);
+-
+-	std::wstring retval( reinterpret_cast<wchar_t *>(outString) );
+-
+-	// Cleanup
+-	delete[] inString;
+-	delete[] outString;
+-
+-	return retval;
++	std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
++	return converter.from_bytes(value);
+ #endif
+ }
+ 
+@@ -211,19 +185,8 @@ std::string TelldusCore::wideToString(const std::wstring &input) {
+ #else
+ 	char *inPointer = inString;
+ #endif
+-	char *outPointer = outString;
+-
+-	iconv_t convDesc = iconv_open("UTF-8", WCHAR_T_ENCODING);
+-	iconv(convDesc, &inPointer, &wideSize, &outPointer, &outbytesLeft);
+-	iconv_close(convDesc);
+-
+-	std::string retval(outString);
+-
+-	// Cleanup
+-	delete[] inString;
+-	delete[] outString;
+-
+-	return retval;
++	std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
++	return converter.to_bytes(input);
+ #endif
+ }
+ 

--- a/utils/telldus-core/patches/900-openwrt_fixes_cmake.patch
+++ b/utils/telldus-core/patches/900-openwrt_fixes_cmake.patch
@@ -24,25 +24,6 @@ Adopted to OpenWrt target. Most likely these changes go elsewhere when done righ
  	)
  ENDIF (WIN32)
  
---- a/common/CMakeLists.txt
-+++ b/common/CMakeLists.txt
-@@ -66,12 +66,16 @@ ELSEIF (CMAKE_SYSTEM_NAME MATCHES "FreeB
- 	)
- ELSE (APPLE)
- 	#### Linux ####
-+	#FIND_LIBRARY(ICONV_LIBRARY iconv) Does not work
- 	ADD_DEFINITIONS( -D_LINUX )
- 	LIST(APPEND  telldus-common_SRCS
- 		Event_unix.cpp
- 		EventHandler_unix.cpp
- 		Socket_unix.cpp
- 	)
-+	LIST(APPEND telldus-common_LIBRARIES
-+		${ICONV_LIBRARY}
-+	)
- ENDIF (APPLE)
- 
- 
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -62,7 +62,7 @@ IF(DOXYGEN_FOUND)


### PR DESCRIPTION
Avoids iconv dependency.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @PeterFromSweden 
Compile tested: powerpc