### PR TITLE
SSHTunnel: Proxycommand support

### DIFF
--- a/net/mac-telnet/Makefile
+++ b/net/mac-telnet/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mac-telnet
 PKG_VERSION:=2015-09-02
-PKG_RELEASE=$(PKG_SOURCE_VERSION)
+PKG_RELEASE=$(PKG_SOURCE_VERSION).r2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/jow-/MAC-Telnet.git

--- a/net/mac-telnet/Makefile
+++ b/net/mac-telnet/Makefile
@@ -65,6 +65,7 @@ define Package/mac-telnet-server/install-extra
 	$(INSTALL_DATA) ./files/mactelnet.config $$(1)/etc/config/mactelnet
 endef
 
+
 $(eval $(call BuildPlugin,server,mactelnetd))
 $(eval $(call BuildPlugin,client,mactelnet))
 $(eval $(call BuildPlugin,ping,macping))

--- a/net/mac-telnet/Makefile
+++ b/net/mac-telnet/Makefile
@@ -65,7 +65,6 @@ define Package/mac-telnet-server/install-extra
 	$(INSTALL_DATA) ./files/mactelnet.config $$(1)/etc/config/mactelnet
 endef
 
-
 $(eval $(call BuildPlugin,server,mactelnetd))
 $(eval $(call BuildPlugin,client,mactelnet))
 $(eval $(call BuildPlugin,ping,macping))

--- a/net/mac-telnet/patches/010-openwrt-name.patch
+++ b/net/mac-telnet/patches/010-openwrt-name.patch
@@ -1,0 +1,11 @@
+--- a/config.h
++++ b/config.h
+@@ -42,7 +42,7 @@
+ #define PLATFORM_NAME "BSD/OS"
+
+ #elif defined(linux) || defined(__linux__)
+-#define PLATFORM_NAME "Linux"
++#define PLATFORM_NAME "OpenWRT"
+
+ #elif defined(sun)
+ #define PLATFORM_NAME "Solaris"

--- a/net/mac-telnet/patches/010-openwrt-name.patch
+++ b/net/mac-telnet/patches/010-openwrt-name.patch
@@ -5,7 +5,7 @@
 
  #elif defined(linux) || defined(__linux__)
 -#define PLATFORM_NAME "Linux"
-+#define PLATFORM_NAME "OpenWRT"
++#define PLATFORM_NAME "OpenWrt"
 
  #elif defined(sun)
  #define PLATFORM_NAME "Solaris"


### PR DESCRIPTION
Maintainer: @nunojpg
Compile tested: mips
Run tested: TP-Link Archer C2 v3, OpenWrt 19.07.2

Description:

A simple update to support the ProxyCommand parameter. Installing the OpenSSH client and NCat tool it's possible to stablish the SSH tunnel over an authenticated HTTP proxy or over a SOCKS4/5 proxy.
 