### PR TITLE
sshtunnel: Add support for "ProxyCommand" [v2]

### DIFF
--- a/net/sshtunnel/Makefile
+++ b/net/sshtunnel/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sshtunnel
 PKG_VERSION:=4
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_LICENSE:=GPL-2.0-or-later
 
 PKG_MAINTAINER:=Nuno Goncalves <nunojpg@gmail.com>

--- a/net/sshtunnel/files/sshtunnel.init
+++ b/net/sshtunnel/files/sshtunnel.init
@@ -52,7 +52,8 @@ validate_server_section() {
 		'ServerAliveInterval:min(0)' \
 		'StrictHostKeyChecking:or("yes", "no", "accept-new")' \
 		'TCPKeepAlive:or("yes", "no")' \
-		'VerifyHostKeyDNS:or("yes", "no")'
+		'VerifyHostKeyDNS:or("yes", "no")' \
+		'ProxyCommand:string(1)'
 }
 
 validate_tunnelR_section() {
@@ -179,6 +180,11 @@ load_server() {
 		StrictHostKeyChecking TCPKeepAlive VerifyHostKeyDNS
 
 	ARGS="$ARGS_options -o ExitOnForwardFailure=yes -o BatchMode=yes -nN $ARGS_tunnels -p $port $user@$hostname"
+
+	if [ ! -z "$ProxyCommand" ]; then
+		ARGS="$ARGS -o \"ProxyCommand ${ProxyCommand}\""
+	fi
+	#_log "sshtunnel params: $ARGS"
 
 	procd_open_instance "$server"
 	procd_set_param command "$PROG" $ARGS

--- a/net/sshtunnel/files/uci_sshtunnel
+++ b/net/sshtunnel/files/uci_sshtunnel
@@ -21,6 +21,7 @@
 #	option StrictHostKeyChecking	accept-new
 #	option TCPKeepAlive		yes
 #	option VerifyHostKeyDNS		yes
+#	option ProxyCommand		'ncat --proxy-type http --proxy-auth user:pass --proxy proxy:port %h %p'
 
 # tunnelR(emote) - when the connection will be initiated to the R(emote) endpoint at
 # remoteaddress:remoteport and then forwarded to localaddress:localport


### PR DESCRIPTION
Maintainer: @nunojpg
Compile tested: mips
Run tested: TP-Link Archer C2 v3, OpenWrt 19.07.2

Description:

A simple update to support the ProxyCommand parameter. Installing the OpenSSH client and NCat tool it's possible to stablish the SSH tunnel over an authenticated HTTP proxy or over a SOCKS4/5 proxy.

This replaces #13787 
