### PR TITLE
docker-ce: Added blocked_interfaces config option

### DIFF
--- a/utils/docker-ce/Makefile
+++ b/utils/docker-ce/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-ce
 PKG_VERSION:=19.03.13
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=components/cli/LICENSE components/engine/LICENSE
 

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -25,7 +25,7 @@ boot() {
 uciupdate() {
 	local net="${1}"
 
-	uci -q get network.docker >/dev/null || {
+	uci_quiet get network.docker || {
 		logger -t "dockerd-init" -p warn "No network uci config section for docker default bridge (docker0) found"
 		return
 	}
@@ -52,7 +52,7 @@ uciadd() {
 	}
 
 	# Add network interface
-	if ! uci -q get network.docker >/dev/null; then
+	if ! uci_quiet get network.docker; then
 		logger -t "dockerd-init" -p notice "Adding docker default interface to network uci config (docker)"
 		uci_quiet add network interface
 		uci_quiet rename network.@interface[-1]="docker"
@@ -63,7 +63,7 @@ uciadd() {
 	fi
 
 	# Add docker bridge device
-	if ! uci -q get network.docker0 >/dev/null; then
+	if ! uci_quiet get network.docker0; then
 		logger -t "dockerd-init" -p notice "Adding docker default bridge device to network uci config (docker0)"
 		uci_quiet add network device
 		uci_quiet rename network.@device[-1]="docker0"
@@ -74,7 +74,7 @@ uciadd() {
 	fi
 
 	# Add firewall zone
-	if ! uci -q get firewall.docker >/dev/null; then
+	if ! uci_quiet get firewall.docker; then
 		logger -t "dockerd-init" -p notice "Adding docker default firewall zone to firewall uci config (docker)"
 		uci_quiet add firewall zone
 		uci_quiet rename firewall.@zone[-1]="docker"
@@ -178,33 +178,33 @@ service_triggers() {
 }
 
 ip4tables_remove_nat() {
-	iptables -t nat -D OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER
-	iptables -t nat -D PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
+	iptables --table nat --delete OUTPUT ! --destination 127.0.0.0/8 --match addrtype --dst-type LOCAL --jump DOCKER
+	iptables --table nat --delete PREROUTING --match addrtype --dst-type LOCAL --jump DOCKER
 
-	iptables -t nat -F DOCKER
-	iptables -t nat -X DOCKER
+	iptables --table nat --flush DOCKER
+	iptables --table nat --delete-chain DOCKER
 }
 
 ip4tables_remove_filter() {
 	# Chain DOCKER-USER is only present,
 	# if bip option is NOT set, so >/dev/null 2>&1
-	iptables -t filter -D FORWARD -j DOCKER-USER >/dev/null 2>&1
-	iptables -t filter -D FORWARD -j DOCKER-ISOLATION-STAGE-1
-	iptables -t filter -D FORWARD -o docker0 -j DOCKER
+	iptables --table filter --delete FORWARD --jump DOCKER-USER >/dev/null 2>&1
+	iptables --table filter --delete FORWARD --jump DOCKER-ISOLATION-STAGE-1
+	iptables --table filter --delete FORWARD --out-interface docker0 --jump DOCKER
 
-	iptables -t filter -F DOCKER
-	iptables -t filter -F DOCKER-ISOLATION-STAGE-1
-	iptables -t filter -F DOCKER-ISOLATION-STAGE-2
+	iptables --table filter --flush DOCKER
+	iptables --table filter --flush DOCKER-ISOLATION-STAGE-1
+	iptables --table filter --flush DOCKER-ISOLATION-STAGE-2
 	# Chain DOCKER-USER is only present,
 	# if bip option is NOT set, so >/dev/null 2>&1
-	iptables -t filter -F DOCKER-USER >/dev/null 2>&1
+	iptables --table filter --flush DOCKER-USER >/dev/null 2>&1
 
-	iptables -t filter -X DOCKER
-	iptables -t filter -X DOCKER-ISOLATION-STAGE-1
-	iptables -t filter -X DOCKER-ISOLATION-STAGE-2
+	iptables --table filter --delete-chain DOCKER
+	iptables --table filter --delete-chain DOCKER-ISOLATION-STAGE-1
+	iptables --table filter --delete-chain DOCKER-ISOLATION-STAGE-2
 	# Chain DOCKER-USER is only present,
 	# if bip option is NOT set, so >/dev/null 2>&1
-	iptables -t filter -X DOCKER-USER >/dev/null 2>&1
+	iptables --table filter --delete-chain DOCKER-USER >/dev/null 2>&1
 }
 
 ip4tables_remove() {

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -6,7 +6,8 @@ START=25
 extra_command "uciadd" "Add default bridge configuration to network and firewall uci config"
 extra_command "ucidel" "Delete default bridge configuration from network and firewall uci config"
 
-DOCKERD_CONF="/tmp/dockerd/daemon.json"
+DOCKER_CONF_DIR="/tmp/dockerd"
+DOCKERD_CONF="${DOCKER_CONF_DIR}/daemon.json"
 
 uci_quiet() {
 	uci -q "${@}" >/dev/null
@@ -112,13 +113,15 @@ ucidel() {
 process_config() {
 	local alt_config_file data_root log_level bip
 
-	rm -f "${DOCKERD_CONF}"
-
 	[ -f /etc/config/dockerd ] || {
 		# Use the daemon default configuration
 		DOCKERD_CONF=""
 		return 0
 	}
+
+	# reset configuration
+	rm -fr "${DOCKER_CONF_DIR}"
+	mkdir -p "${DOCKER_CONF_DIR}"
 
 	config_load 'dockerd'
 
@@ -144,7 +147,6 @@ process_config() {
 	config_list_foreach globals hosts json_add_array_string
 	json_close_array
 
-	mkdir -p /tmp/dockerd
 	json_dump > "${DOCKERD_CONF}"
 
 	uciupdate "${bip}"

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -9,11 +9,11 @@ extra_command "ucidel" "Delete default bridge configuration from network and fir
 DOCKERD_CONF="/tmp/dockerd/daemon.json"
 
 uci_quiet() {
-	uci -q ${@} >/dev/null
+	uci -q "${@}" >/dev/null
 }
 
 json_add_array_string() {
-	json_add_string "" "$1"
+	json_add_string "" "${1}"
 }
 
 boot() {
@@ -22,14 +22,14 @@ boot() {
 }
 
 uciupdate() {
-	local net="$1"
+	local net="${1}"
 
 	uci -q get network.docker >/dev/null || {
 		logger -t "dockerd-init" -p warn "No network uci config section for docker default bridge (docker0) found"
 		return
 	}
 
-	[ -z "$net" ] && {
+	[ -z "${net}" ] && {
 		logger -t "dockerd-init" -p notice "Removing network uci config options for docker default bridge (docker0)"
 		uci_quiet delete network.docker.netmask
 		uci_quiet delete network.docker.ipaddr
@@ -37,10 +37,10 @@ uciupdate() {
 		return
 	}
 
-	eval "$(ipcalc.sh "$net")"
-	logger -t "dockerd-init" -p notice "Updating network uci config option \"$net\" for docker default bridge (docker0)"
-	uci_quiet set network.docker.netmask="$NETMASK"
-	uci_quiet set network.docker.ipaddr="$IP"
+	eval "$(ipcalc.sh "${net}")"
+	logger -t "dockerd-init" -p notice "Updating network uci config option \"${net}\" for docker default bridge (docker0)"
+	uci_quiet set network.docker.netmask="${NETMASK}"
+	uci_quiet set network.docker.ipaddr="${IP}"
 	uci_quiet commit network
 }
 
@@ -112,7 +112,7 @@ ucidel() {
 process_config() {
 	local alt_config_file data_root log_level bip
 
-	rm -f "$DOCKERD_CONF"
+	rm -f "${DOCKERD_CONF}"
 
 	[ -f /etc/config/dockerd ] || {
 		# Use the daemon default configuration
@@ -123,8 +123,8 @@ process_config() {
 	config_load 'dockerd'
 
 	config_get alt_config_file globals alt_config_file
-	[ -n "$alt_config_file" ] && [ -f "$alt_config_file" ] && {
-		ln -s "$alt_config_file" "$DOCKERD_CONF"
+	[ -n "${alt_config_file}" ] && [ -f "${alt_config_file}" ] && {
+		ln -s "${alt_config_file}" "${DOCKERD_CONF}"
 		return 0
 	}
 
@@ -134,9 +134,9 @@ process_config() {
 
 	. /usr/share/libubox/jshn.sh
 	json_init
-	json_add_string "data-root" "$data_root"
-	json_add_string "log-level" "$log_level"
-	[ -z "$bip" ] || json_add_string "bip" "$bip"
+	json_add_string "data-root" "${data_root}"
+	json_add_string "log-level" "${log_level}"
+	[ -z "${bip}" ] || json_add_string "bip" "${bip}"
 	json_add_array "registry-mirrors"
 	config_list_foreach globals registry_mirrors json_add_array_string
 	json_close_array
@@ -145,9 +145,9 @@ process_config() {
 	json_close_array
 
 	mkdir -p /tmp/dockerd
-	json_dump > "$DOCKERD_CONF"
+	json_dump > "${DOCKERD_CONF}"
 
-	uciupdate "$bip"
+	uciupdate "${bip}"
 }
 
 start_service() {
@@ -157,10 +157,10 @@ start_service() {
 
 	procd_open_instance
 	procd_set_param stderr 1
-	if [ -z "$DOCKERD_CONF" ]; then
+	if [ -z "${DOCKERD_CONF}" ]; then
 		procd_set_param command /usr/bin/dockerd
 	else
-		procd_set_param command /usr/bin/dockerd --config-file="$DOCKERD_CONF"
+		procd_set_param command /usr/bin/dockerd --config-file="${DOCKERD_CONF}"
 	fi
 	procd_set_param limits nofile="${nofile} ${nofile}"
 	procd_close_instance

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -125,6 +125,8 @@ process_config() {
 
 	config_load 'dockerd'
 
+	config_list_foreach firewall blocked_interfaces add_docker_firewall_rules
+
 	config_get alt_config_file globals alt_config_file
 	[ -n "${alt_config_file}" ] && [ -f "${alt_config_file}" ] && {
 		ln -s "${alt_config_file}" "${DOCKERD_CONF}"
@@ -177,6 +179,18 @@ service_triggers() {
 	procd_add_reload_trigger 'dockerd'
 }
 
+add_docker_firewall_rules() {
+	. /lib/functions/network.sh
+	local device interface="${1}"
+
+	# Ignore errors as it might already be present
+	iptables --table filter --new DOCKER-USER 2>/dev/null
+	network_get_physdev device "${interface}"
+	if ! iptables --table filter --check DOCKER-USER --in-interface "${device}" --out-interface docker0 --jump DROP 2>/dev/null; then
+		iptables --table filter --insert DOCKER-USER --in-interface "${device}" --out-interface docker0 --jump DROP
+	fi
+}
+
 ip4tables_remove_nat() {
 	iptables --table nat --delete OUTPUT ! --destination 127.0.0.0/8 --match addrtype --dst-type LOCAL --jump DOCKER
 	iptables --table nat --delete PREROUTING --match addrtype --dst-type LOCAL --jump DOCKER
@@ -186,25 +200,22 @@ ip4tables_remove_nat() {
 }
 
 ip4tables_remove_filter() {
-	# Chain DOCKER-USER is only present,
-	# if bip option is NOT set, so >/dev/null 2>&1
-	iptables --table filter --delete FORWARD --jump DOCKER-USER >/dev/null 2>&1
+	iptables --table filter --delete FORWARD --jump DOCKER-USER
 	iptables --table filter --delete FORWARD --jump DOCKER-ISOLATION-STAGE-1
 	iptables --table filter --delete FORWARD --out-interface docker0 --jump DOCKER
+	iptables --table filter --delete FORWARD --out-interface docker0 --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT
+	iptables --table filter --delete FORWARD --in-interface docker0 --out-interface docker0 --jump ACCEPT
+	iptables --table filter --delete FORWARD --in-interface docker0 ! --out-interface docker0 --jump ACCEPT
 
 	iptables --table filter --flush DOCKER
 	iptables --table filter --flush DOCKER-ISOLATION-STAGE-1
 	iptables --table filter --flush DOCKER-ISOLATION-STAGE-2
-	# Chain DOCKER-USER is only present,
-	# if bip option is NOT set, so >/dev/null 2>&1
-	iptables --table filter --flush DOCKER-USER >/dev/null 2>&1
+	iptables --table filter --flush DOCKER-USER
 
 	iptables --table filter --delete-chain DOCKER
 	iptables --table filter --delete-chain DOCKER-ISOLATION-STAGE-1
 	iptables --table filter --delete-chain DOCKER-ISOLATION-STAGE-2
-	# Chain DOCKER-USER is only present,
-	# if bip option is NOT set, so >/dev/null 2>&1
-	iptables --table filter --delete-chain DOCKER-USER >/dev/null 2>&1
+	iptables --table filter --delete-chain DOCKER-USER
 }
 
 ip4tables_remove() {

--- a/utils/docker-ce/files/etc/config/dockerd
+++ b/utils/docker-ce/files/etc/config/dockerd
@@ -1,11 +1,18 @@
+# The following settings require a restart to take full effect, A reload will
+# only have partial or no effect:
+# option bip
+# list blocked_interfaces
 
 config globals 'globals'
 #	option alt_config_file "/etc/docker/daemon.json"
 	option data_root "/opt/docker/"
 	option log_level "warn"
 	list hosts "unix:///var/run/docker.sock"
-	# If the bip option is changed, dockerd must be restarted.
-	# A service reload is not enough.
 	option bip "172.18.0.1/24"
 #	list registry_mirrors "https://<my-docker-mirror-host>"
 #	list registry_mirrors "https://hub.docker.com"
+
+# Docker ignores fw3 rules and by default all external source IPs are allowed
+# to connect to the Docker host. See https://docs.docker.com/network/iptables/
+config firewall 'firewall'
+	list blocked_interfaces 'wan'


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: x86_x64, Hyper-V, OpenWrt Master
Run tested: x86_x64, Hyper-V, OpenWrt Master

Description:
* blocked_interfaces blocks all packets to docker0 from the given
  interface since the iptables commands docker adds all operate before
  any of the fw3 generated rules.
* Made shellcheck recommendations
* Fixed issue where `/tmp/dockerd/` didn't exist for `alt_config_file`


