### PR TITLE
at: bump to version 3.2.1

### DIFF
--- a/utils/at/Makefile
+++ b/utils/at/Makefile
@@ -8,12 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=at
-PKG_VERSION:=3.1.23
-PKG_RELEASE:=3
+PKG_VERSION:=3.2.1
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.gz
-PKG_SOURCE_URL:=http://ftp.debian.org/debian/pool/main/a/at
-PKG_HASH:=97450aa954aaa8a70218cc8e61a33df9fee9f86527e9f861de302fb7a3c81710
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://salsa.debian.org/debian/at.git
+PKG_SOURCE_VERSION:=release/3.2.1
+PKG_MIRROR_HASH=c37feb425e7d310f29b4c8dffd846b8a3b410ff6e88a6563f0ecaa636fb22cc2
 
 PKG_MAINTAINER:=Phil Eichinger <phil@zankapfel.net>
 PKG_LICENSE:=GPL-2.0-or-later GPL-3.0-or-later ISC


### PR DESCRIPTION
Change upstream to official repository at
https://salsa.debian.org/debian/at

Signed-off-by: Phil Eichinger <phil@zankapfel.net>

Maintainer: me
Compile tested: (ar71xx, TL-WDR4300, 19.07)
Run tested: (ar71xx, TL-WDR4300, 19.07)