### PR TITLE
uw-imap: install c-client/linkage.c to staging

### DIFF
--- a/libs/uw-imap/Makefile
+++ b/libs/uw-imap/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uw-imap
 PKG_VERSION:=2007f
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=imap-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -57,7 +57,7 @@ define Build/InstallDev
 			$(1)/usr/include/c-client
 	$(CP) $(PKG_BUILD_DIR)/c-client/libc-client.so.$(PKG_VERSION) $(1)/usr/lib/
 	$(LN) libc-client.so.$(PKG_VERSION) $(1)/usr/lib/libc-client.so
-	$(CP) $(PKG_BUILD_DIR)/c-client/linkage.h $(1)/usr/include/c-client/
+	$(CP) $(PKG_BUILD_DIR)/c-client/linkage.{c,h} $(1)/usr/include/c-client/
 	$(CP) $(PKG_BUILD_DIR)/src/c-client/*.h $(1)/usr/include/c-client/
 	$(CP) $(PKG_BUILD_DIR)/src/osdep/unix/*.h $(1)/usr/include/c-client/
 	$(LN) os_slx.h $(1)/usr/include/c-client/osdep.h


### PR DESCRIPTION
linkage.c can be included by other programs as described in
docs/internal.txt (quote: "By using linkage.c instead of explicit
mail_link() calls, you are guaranteed that you will have a consistant
linkage among all software built on this system").

This commit adds linkage.c to staging.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @lucize 
Compile tested: ath79 master
Run tested: N/A, no runtime change

Description:
Hello Lucian,

Would be good if this file can be added. Asterisk 18 is using it, so then we could use it, too.

Kind regards,
Seb