### PR TITLE
stunnel: update version to 5.57

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.56
+PKG_VERSION:=5.57
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0-or-later
@@ -23,7 +23,7 @@ PKG_SOURCE_URL:= \
 	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=7384bfb356b9a89ddfee70b5ca494d187605bb516b4fff597e167f97e2236b22
+PKG_HASH:=af5ab973dde11807c38735b87bdd87563a47d2fa1c72a07929fcfce80a600fe1
 
 PKG_FIXUP:=autoreconf
 PKG_FIXUP:=patch-libtool


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, APU3, openwrt master latest
Run tested: x86_64, APU3, opnewrt master latest, execute `stunnel`
Description:
Update to version 5.57
```
[ ] Initializing inetd mode configuration
[ ] Clients allowed=500
[.] stunnel 5.57 on x86_64-openwrt-linux-gnu platform
[.] Compiled/running with OpenSSL 1.1.1h  22 Sep 2020
[.] Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,FIPS,OCSP,PSK,SNI
[ ] errno: (*__errno_location())
[ ] Initializing inetd mode configuration
[.] Reading configuration from file /etc/stunnel/stunnel.conf
[.] UTF-8 byte order mark not detected
[.] FIPS mode disabled
[ ] Compression disabled
[ ] No PRNG seeding was required
[ ] Initializing service [dummy]
[ ] stunnel default security level set: 2
[ ] Ciphers: HIGH:!aNULL:!SSLv2:!DH:!kDHEPSK
[ ] TLSv1.3 ciphersuites: TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256
[ ] TLS options: 0x02100004 (+0x00000000, -0x00000000)
[ ] No certificate or private key specified
[:] Service [dummy] needs authentication to prevent MITM attacks
[ ] DH initialization skipped: client section
[ ] ECDH initialization
[ ] ECDH initialized with curves X25519:P-256:X448:P-521:P-384
[.] Configuration successful
[ ] Deallocating deployed section defaults
[ ] Binding service [dummy]
[ ] Listening file descriptor created (FD=9)
[ ] Setting accept socket options (FD=9)
[ ] Option SO_REUSEADDR set on accept socket
[.] Binding service [dummy] to ::1:6000: Address in use (98)
[ ] Listening file descriptor created (FD=9)
[ ] Setting accept socket options (FD=9)
[ ] Option SO_REUSEADDR set on accept socket
[.] Binding service [dummy] to 127.0.0.1:6000: Address in use (98)
[!] Binding service [dummy] failed
[ ] Unbinding service [dummy]
[ ] Service [dummy] closed
[ ] Deallocating deployed section defaults
[ ] Deallocating section [dummy]
[ ] Initializing inetd mode configuration
```
