### PR TITLE
prometheus-node-exporter-lua: fix hostapd exporter

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2020.10.10
+PKG_VERSION:=2020.10.29
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/hostapd_ubus_stations.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/hostapd_ubus_stations.lua
@@ -1,5 +1,5 @@
 local ubus = require "ubus"
-local bit = require "bit32"
+local bit = require "bit"
 
 local function get_wifi_interfaces() -- based on hostapd_stations.lua
   local u = ubus.connect()


### PR DESCRIPTION
Fix "hostapd_ubus_stations.lua". The bit-lib that is imported and the one specified as the dependency do not match. Use luabitop.

Maintainer: @champtar
Compile tested: `35b66c25b8f4607a79cb75fb1db4b0bb101a85cf`
Run tested: `r14793+2-9f1927173ac6`