### PR TITLE
umurmur: Specify config file location at startup

### DIFF
--- a/net/umurmur/patches/020-specify-conffile-path.patch
+++ b/net/umurmur/patches/020-specify-conffile-path.patch
@@ -1,0 +1,13 @@
+diff --git a/openwrt/files/umurmur.init b/openwrt/files/umurmur.init
+index 392cd69..7223d03 100644
+--- a/openwrt/files/umurmur.init
++++ b/openwrt/files/umurmur.init
+@@ -7,7 +7,7 @@ PIDFILE="/var/run/umurmurd.pid"
+ 
+ start() {
+         stop
+-        /usr/bin/umurmurd -p $PIDFILE
++        /usr/bin/umurmurd -p $PIDFILE -c /etc/umurmur.conf
+ }
+ 
+ stop() {


### PR DESCRIPTION
...to workaround issue where default location is set to '/usr/etc/...'

Maintainer: me 
Compile tested: On Ubuntu WSL. Target arm-cortex-a15 (Netgear Nighthawk R7800), OpenWrt r14728-21cf17bb4c
Run tested: On same as above. Verified startup OK)

Refer to issue https://github.com/openwrt/packages/issues/13735#issue-726463731
