### PR TITLE
modemmanager: increase initial timeout for event reporting

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.14.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager

--- a/net/modemmanager/files/modemmanager.common
+++ b/net/modemmanager/files/modemmanager.common
@@ -301,7 +301,7 @@ mm_report_events_from_cache() {
 	# Remove the sysfs cache
 	rm -f "${MODEMMANAGER_SYSFS_CACHE}"
 
-	local n=10
+	local n=60
 	local step=1
 	local mmrunning=0
 


### PR DESCRIPTION
When the ModemManager daemon is started by the init script, we're
explicitly calling mm_report_events_from_cache() so that all the
hotplug events that happened before that moment are properly notified
to the newly launched daemon.

This initial reporting of events does a wait for the ModemManager
process to be available in DBus, and if the daemon isn't registered in
the bus in a given time, the process is considered failed:

  Sun Sep  6 16:20:02 2020 ModemManager: hotplug: checking if ModemManager is available...
  Sun Sep  6 16:20:02 2020 ModemManager: hotplug: ModemManager not yet available
  Sun Sep  6 16:20:03 2020 [2180]: <info>  ModemManager (version 1.14.6) starting in system bus...
  Sun Sep  6 16:20:03 2020 ModemManager: hotplug: checking if ModemManager is available...
  Sun Sep  6 16:20:04 2020 ModemManager: hotplug: ModemManager not yet available
  Sun Sep  6 16:20:05 2020 ModemManager: hotplug: checking if ModemManager is available...
  Sun Sep  6 16:20:05 2020 ModemManager: hotplug: ModemManager not yet available
  Sun Sep  6 16:20:06 2020 ModemManager: hotplug: checking if ModemManager is available...
  Sun Sep  6 16:20:06 2020 ModemManager: hotplug: ModemManager not yet available
  Sun Sep  6 16:20:07 2020 ModemManager: hotplug: checking if ModemManager is available...
  Sun Sep  6 16:20:07 2020 ModemManager: hotplug: ModemManager not yet available
  Sun Sep  6 16:20:08 2020 ModemManager: hotplug: checking if ModemManager is available...
  Sun Sep  6 16:20:08 2020 ModemManager: hotplug: ModemManager not yet available
  Sun Sep  6 16:20:09 2020 ModemManager: hotplug: checking if ModemManager is available...
  Sun Sep  6 16:20:09 2020 ModemManager: hotplug: ModemManager not yet available
  Sun Sep  6 16:20:10 2020 ModemManager: hotplug: checking if ModemManager is available...
  Sun Sep  6 16:20:10 2020 ModemManager: hotplug: ModemManager not yet available
  Sun Sep  6 16:20:11 2020 ModemManager: hotplug: checking if ModemManager is available...
  Sun Sep  6 16:20:11 2020 ModemManager: hotplug: ModemManager not yet available
  Sun Sep  6 16:20:12 2020 ModemManager: hotplug: checking if ModemManager is available...
  Sun Sep  6 16:20:12 2020 ModemManager: hotplug: ModemManager not yet available
  Sun Sep  6 16:20:12 2020 ModemManager: hotplug: error: couldn't report initial kernel events: ModemManager not running

Update the default wait time for this initial event notification from
10s to 60s, because there are cases where the daemon is slower to
boot, e.g. during the first boot after a sysupgrade.

Signed-off-by: Aleksander Morgado <aleksander@aleksander.es>

Maintainer: @nickberry17 
