### PR TITLE
mariadb: fix compilation with libcxx

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
 PKG_VERSION:=10.4.14
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := \

--- a/utils/mariadb/patches/100-fix_hostname.patch
+++ b/utils/mariadb/patches/100-fix_hostname.patch
@@ -1,6 +1,6 @@
 --- a/scripts/mysql_install_db.sh
 +++ b/scripts/mysql_install_db.sh
-@@ -419,7 +419,7 @@ fi
+@@ -418,7 +418,7 @@ fi
  
  
  # Try to determine the hostname

--- a/utils/mariadb/patches/130-c11_atomics.patch
+++ b/utils/mariadb/patches/130-c11_atomics.patch
@@ -9,7 +9,7 @@ Date:   Fri Dec 21 19:14:04 2018 +0200
 
 --- a/configure.cmake
 +++ b/configure.cmake
-@@ -866,7 +866,25 @@ int main()
+@@ -864,7 +864,25 @@ int main()
    long long int *ptr= &var;
    return (int)__atomic_load_n(ptr, __ATOMIC_SEQ_CST);
  }"
@@ -38,7 +38,7 @@ Date:   Fri Dec 21 19:14:04 2018 +0200
    SET(HAVE_valgrind 1)
 --- a/mysys/CMakeLists.txt
 +++ b/mysys/CMakeLists.txt
-@@ -79,6 +79,10 @@ TARGET_LINK_LIBRARIES(mysys dbug strings
+@@ -78,6 +78,10 @@ TARGET_LINK_LIBRARIES(mysys dbug strings
   ${LIBNSL} ${LIBM} ${LIBRT} ${LIBDL} ${LIBSOCKET} ${LIBEXECINFO} ${CRC32_LIBRARY})
  DTRACE_INSTRUMENT(mysys)
  
@@ -51,7 +51,7 @@ Date:   Fri Dec 21 19:14:04 2018 +0200
  ENDIF(HAVE_BFD_H)
 --- a/sql/CMakeLists.txt
 +++ b/sql/CMakeLists.txt
-@@ -190,6 +190,10 @@ ELSE()
+@@ -191,6 +191,10 @@ ELSE()
    SET(MYSQLD_SOURCE main.cc ${DTRACE_PROBES_ALL})
  ENDIF()
  

--- a/utils/mariadb/patches/170-ppc-remove-glibc-dep.patch
+++ b/utils/mariadb/patches/170-ppc-remove-glibc-dep.patch
@@ -23,7 +23,7 @@
  /* High priority */
  #define HMT_high() asm volatile("or 3,3,3")
  #else
-@@ -72,7 +71,7 @@ static inline void MY_RELAX_CPU(void)
+@@ -79,7 +78,7 @@ static inline void MY_RELAX_CPU(void)
    __asm__ __volatile__ ("pause");
  #endif
  #elif defined(_ARCH_PWR8)

--- a/utils/mariadb/patches/180-relax-mysql_install-db-wrt-pam-tool.patch
+++ b/utils/mariadb/patches/180-relax-mysql_install-db-wrt-pam-tool.patch
@@ -1,6 +1,6 @@
 --- a/scripts/mysql_install_db.sh
 +++ b/scripts/mysql_install_db.sh
-@@ -359,6 +359,14 @@ then
+@@ -358,6 +358,14 @@ then
      exit 1
    fi
    plugindir=`find_in_dirs --dir auth_pam.so $basedir/lib*/plugin $basedir/lib*/mysql/plugin $basedir/lib/*/mariadb19/plugin`
@@ -15,7 +15,7 @@
    pamtooldir=$plugindir
  # relative from where the script was run for a relocatable install
  elif test -n "$dirname0" -a -x "$rel_mysqld" -a ! "$rel_mysqld" -ef "@sbindir@/mysqld"
-@@ -478,7 +486,9 @@ do
+@@ -477,7 +485,9 @@ do
    fi
  done
  
@@ -26,7 +26,7 @@
  then
    if test -z "$srcdir" -a "$in_rpm" -eq 0
    then
-@@ -499,6 +509,10 @@ then
+@@ -498,6 +508,10 @@ then
          echo
      fi
    fi

--- a/utils/mariadb/patches/190-replace-hostname-in-mysqld_safe.patch
+++ b/utils/mariadb/patches/190-replace-hostname-in-mysqld_safe.patch
@@ -1,6 +1,6 @@
 --- a/scripts/mysqld_safe.sh
 +++ b/scripts/mysqld_safe.sh
-@@ -242,7 +242,7 @@ wsrep_recover_position() {
+@@ -244,7 +244,7 @@ wsrep_recover_position() {
      return 1
    fi
  
@@ -9,7 +9,7 @@
  
    local wr_options="--disable-log-error  --pid-file='$wr_pidfile'"
  
-@@ -673,7 +673,7 @@ then
+@@ -680,7 +680,7 @@ then
          * ) err_log="$DATADIR/$err_log" ;;
        esac
      else
@@ -18,7 +18,7 @@
      fi
    fi
  
-@@ -752,7 +752,7 @@ fi
+@@ -759,7 +759,7 @@ fi
  
  if test -z "$pid_file"
  then

--- a/utils/mariadb/patches/210-libcxx.patch
+++ b/utils/mariadb/patches/210-libcxx.patch
@@ -1,0 +1,22 @@
+--- a/storage/innobase/handler/ha_innodb.cc
++++ b/storage/innobase/handler/ha_innodb.cc
+@@ -14862,7 +14862,7 @@ ha_innobase::update_table_comment(
+ 
+ 	m_prebuilt->trx->op_info = "returning table comment";
+ 
+-#define SSTR( x ) reinterpret_cast< std::ostringstream & >(		\
++#define SSTR( x ) (		\
+         ( std::ostringstream() << std::dec << x ) ).str()
+ 
+ 	if (m_prebuilt->table->space) {
+--- a/wsrep-lib/include/wsrep/gtid.hpp
++++ b/wsrep-lib/include/wsrep/gtid.hpp
+@@ -26,6 +26,8 @@
+ 
+ #include <iosfwd>
+ 
++#include <sys/types.h>
++
+ /**
+  * Minimum number of bytes guaratneed to store GTID string representation,
+  * terminating '\0' not included (36 + 1 + 20).


### PR DESCRIPTION
Missing header and pointless cast.

Refresh all patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @miska 
Compile tested: powerpc 