### PR TITLE
kea: fix compilation with libcxx

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kea
 PKG_VERSION:=1.8.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.isc.org/isc/kea/$(PKG_VERSION)
@@ -178,7 +178,8 @@ CONFIGURE_VARS += \
 TARGET_CXXFLAGS += \
 	$(FPIC) \
 	-fdata-sections \
-	-ffunction-sections
+	-ffunction-sections \
+	-std=c++17
 
 TARGET_LDFLAGS += \
 	-Wl,--gc-sections,--as-needed

--- a/net/kea/patches/001-fix-cross-compile.patch
+++ b/net/kea/patches/001-fix-cross-compile.patch
@@ -1,6 +1,8 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -542,8 +542,8 @@ AC_TRY_COMPILE([
+@@ -580,10 +580,10 @@ AC_TRY_COMPILE([
+ 
+ usable_regex=
  AC_MSG_CHECKING(for usuable C++11 regex)
 -AC_TRY_RUN([
 +AC_TRY_COMPILE([

--- a/net/kea/patches/002-fix-host-compile.patch
+++ b/net/kea/patches/002-fix-host-compile.patch
@@ -1,6 +1,6 @@
 --- a/m4macros/ax_crypto.m4
 +++ b/m4macros/ax_crypto.m4
-@@ -454,7 +454,7 @@ EOF
+@@ -330,7 +330,7 @@ EOF
      dnl Check availability of SHA-2
      AC_MSG_CHECKING([support of SHA-2])
      LIBS_SAVED=${LIBS}

--- a/net/kea/patches/003-no-test-compile.patch
+++ b/net/kea/patches/003-no-test-compile.patch
@@ -3,7 +3,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  # Install kea-admin in sbin.
  sbin_SCRIPTS  = kea-admin
 --- a/src/bin/agent/Makefile.am
@@ -11,7 +11,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
 --- a/src/bin/d2/Makefile.am
@@ -19,7 +19,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
 --- a/src/bin/dhcp4/Makefile.am
@@ -27,7 +27,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
 --- a/src/bin/dhcp6/Makefile.am
@@ -35,7 +35,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
 --- a/src/bin/keactrl/Makefile.am
@@ -43,7 +43,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  # Install keactrl in sbin and the keactrl.conf required by the keactrl
  # in etc. keactrl will look for its configuration file in the etc folder.
 --- a/src/bin/lfc/Makefile.am
@@ -51,7 +51,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
 --- a/src/bin/netconf/Makefile.am
@@ -59,7 +59,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
 --- a/src/bin/perfdhcp/Makefile.am
@@ -67,7 +67,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
 --- a/src/bin/shell/Makefile.am
@@ -75,15 +75,15 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  pkgpython_PYTHON = kea_conn.py kea_connector2.py kea_connector3.py
-
+ 
 --- a/src/hooks/dhcp/high_availability/Makefile.am
 +++ b/src/hooks/dhcp/high_availability/Makefile.am
 @@ -1,4 +1,4 @@
 -SUBDIRS = . libloadtests tests
 +SUBDIRS = . libloadtests
-
+ 
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/hooks/dhcp/lease_cmds/Makefile.am
@@ -91,7 +91,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/hooks/dhcp/stat_cmds/Makefile.am
@@ -99,7 +99,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/hooks/dhcp/user_chk/Makefile.am
@@ -107,7 +107,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/asiodns/Makefile.am
@@ -115,7 +115,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/asiolink/Makefile.am
@@ -123,7 +123,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . testutils tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/cc/Makefile.am
@@ -131,7 +131,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/cfgrpt/Makefile.am
@@ -139,7 +139,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CXXFLAGS  = $(KEA_CXXFLAGS)
 --- a/src/lib/config/Makefile.am
@@ -147,7 +147,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/config_backend/Makefile.am
@@ -155,7 +155,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/cql/Makefile.am
@@ -163,7 +163,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . testutils tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES) $(CQL_CPPFLAGS)
 --- a/src/lib/cryptolink/Makefile.am
@@ -171,7 +171,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES) $(CRYPTO_CFLAGS) $(CRYPTO_INCLUDES)
 --- a/src/lib/database/Makefile.am
@@ -179,7 +179,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . testutils tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/dhcp/Makefile.am
@@ -187,7 +187,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/dhcp_ddns/Makefile.am
@@ -195,27 +195,27 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/dhcpsrv/Makefile.am
 +++ b/src/lib/dhcpsrv/Makefile.am
 @@ -1,6 +1,6 @@
  AUTOMAKE_OPTIONS = subdir-objects
-
+ 
 -SUBDIRS = . testutils tests benchmarks
 +SUBDIRS = . benchmarks
-
- dhcp_data_dir = @localstatedir@/@PACKAGE@
- kea_lfc_location = @prefix@/sbin/kea-lfc
+ 
+ # DATA_DIR is the directory where to put default CSV files and the DHCPv6
+ # server ID file (i.e. the file where the server finds its DUID at startup).
 --- a/src/lib/dns/Makefile.am
 +++ b/src/lib/dns/Makefile.am
 @@ -1,6 +1,6 @@
  AUTOMAKE_OPTIONS = subdir-objects
-
+ 
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/eval/Makefile.am
@@ -223,7 +223,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/exceptions/Makefile.am
@@ -231,7 +231,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CXXFLAGS=$(KEA_CXXFLAGS)
 --- a/src/lib/hooks/Makefile.am
@@ -239,7 +239,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/http/Makefile.am
@@ -247,7 +247,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/log/Makefile.am
@@ -255,7 +255,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = interprocess . compiler tests
 +SUBDIRS = interprocess . compiler
-
+ 
  AM_CPPFLAGS = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/log/interprocess/Makefile.am
@@ -263,7 +263,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -DLOCKFILE_DIR=\"$(localstatedir)/run/$(PACKAGE_NAME)\"
 --- a/src/lib/mysql/Makefile.am
@@ -271,7 +271,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . testutils tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES) $(MYSQL_CPPFLAGS)
 --- a/src/lib/pgsql/Makefile.am
@@ -279,7 +279,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . testutils tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES) $(PGSQL_CPPFLAGS)
 --- a/src/lib/process/Makefile.am
@@ -295,17 +295,17 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/util/Makefile.am
 +++ b/src/lib/util/Makefile.am
 @@ -1,6 +1,6 @@
  AUTOMAKE_OPTIONS = subdir-objects
-
+ 
 -SUBDIRS = . io unittests tests python
 +SUBDIRS = . io unittests python
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/yang/Makefile.am
@@ -313,6 +313,6 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . testutils pretests tests
 +SUBDIRS = .
-
+ 
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES) $(SYSREPO_CPPFLAGS)

--- a/net/kea/patches/004-replace-rev-with-awk.patch
+++ b/net/kea/patches/004-replace-rev-with-awk.patch
@@ -6,6 +6,6 @@
      local conf_name
 -    conf_name=$(basename -- "${kea_config_file}" | rev | cut -f2- -d'.' | rev)
 +    conf_name=$(basename -- "${kea_config_file}" | awk '{for(i=length($0); i>0;i--) printf (substr($0,i,1));}' | cut -f2- -d'.' | awk '{for(i=length($0); i>0;i--) printf (substr($0,i,1));}')
-
+ 
      # Default the directory to --localstatedir / run
      local pid_file_dir


### PR DESCRIPTION
Boost headers try to include experimental/string_view when std is less
than c++17. This does not work ith libcxx where this header is not
present.

Refreshed patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @rosysong @hbl0307106015
Compile tested: powerpc