### PR TITLE
ksmbd: update to 3.2.5

### DIFF
--- a/kernel/ksmbd/Makefile
+++ b/kernel/ksmbd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd
-PKG_VERSION:=3.2.4
+PKG_VERSION:=3.2.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/cifsd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=a7beeb0e804b361adf2b79dcd98ccf4b92b2c1fa8a65a39dd4fbb63479cdf7cd
+PKG_HASH:=b93a068f6dc2b2040c8cebcb67f6d8c3a1c5c7c5032269a48579ccba996e6be7
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: @Andy2244 
Compile tested: mips, lantiq
Run tested: lantiq BT Home Hub 5A

Description:
fixes a bunch of problems with SMB1 clients and a few crashes

upstream changes:
* cifsd: release 3.2.5 version
* cifsd: fix unassigned pointer access in smb_fileinfo_rename()
* cifsd: remove unneeded ksmbd_fd_put() in find_next()
* cifsd: always zero-initialize ksmbd_dir_info in smb1pdu
* cifsd: make spnego depend on the "extended security" bit in flags2
* cifsd: add support for weird clients with off-by-one buffer size issues
* cifsd: allow SMB_COM_ECHO without valid user session
* cifsd: fix potential null pointer dereferencing error of tfm in alloc_shash_desc()
* cifsd: fix potential overflow issue in ___server_conf_set()
* cifsd: add xfstests cases in travis-CI