### PR TITLE
bind: update to version 9.16.8

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.16.7
+PKG_VERSION:=9.16.8
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=9f7d1812ebbd26a699f62b6fa8522d5dec57e4bf43af0042a0d60d39ed8314d1
+PKG_HASH:=9e9b9c563692be86ec41f670f6b70e26c14e72445c742d7b5eb4db7d2b5e8d31
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/patches/002-fix-cross-compilation.patch
+++ b/net/bind/patches/002-fix-cross-compilation.patch
@@ -1,0 +1,84 @@
+From 12a10bcfb1999d07961206587d79ce27c432c6ce Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20K=C4=99pie=C5=84?= <michal@isc.org>
+Date: Tue, 27 Oct 2020 12:40:45 +0100
+Subject: [PATCH] Fix cross-compilation
+
+Using AC_RUN_IFELSE() in configure.ac breaks cross-compilation:
+
+    configure: error: cannot run test program while cross compiling
+
+Commit 978c7b2e89aa37a7ddfe2f6b6ba12ce73dd04528 caused AC_RUN_IFELSE()
+to be used instead of AC_LINK_IFELSE() because the latter had seemingly
+been causing the check for --wrap support in the linker to not work as
+expected.  However, it later turned out that the problem lied elsewhere:
+a minus sign ('-') was missing from the LDFLAGS variable used in the
+relevant check [1].
+
+Revert to using AC_LINK_IFELSE() for checking whether the linker
+supports the --wrap option in order to make cross-compilation possible
+again.
+
+Fixes: https://gitlab.isc.org/isc-projects/bind9/-/issues/2237
+
+[1] see commit cfa4ea64bc06685f210a4187dcc05cc0aac84851
+---
+ configure    | 16 ++++------------
+ configure.ac |  2 +-
+ 2 files changed, 5 insertions(+), 13 deletions(-)
+
+diff --git a/configure b/configure
+index a408f0dcf6..7694a18c0b 100755
+--- a/configure
++++ b/configure
+@@ -22047,13 +22047,7 @@ $as_echo_n "checking for linker support for --wrap option... " >&6; }
+
+
+ LDFLAGS="-Wl,--wrap,exit"
+-if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
+-else
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <stdlib.h>
+ 		       void __real_exit (int status);
+@@ -22067,7 +22061,7 @@ exit (1);
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_c_try_run "$LINENO"; then :
++if ac_fn_c_try_link "$LINENO"; then :
+   LD_WRAP_TESTS=true
+
+ $as_echo "#define LD_WRAP 1" >>confdefs.h
+@@ -22078,10 +22072,8 @@ else
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ $as_echo "no" >&6; }
+ fi
+-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+-  conftest.$ac_objext conftest.beam conftest.$ac_ext
+-fi
+-
++rm -f core conftest.err conftest.$ac_objext \
++    conftest$ac_exeext conftest.$ac_ext
+
+   CCASFLAGS=$CCASFLAGS_wrap_ax_save_flags
+
+diff --git a/configure.ac b/configure.ac
+index 1201b5e2a7..9648d9727a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2247,7 +2247,7 @@ LD_WRAP_TESTS=false
+ AC_MSG_CHECKING([for linker support for --wrap option])
+ AX_SAVE_FLAGS([wrap])
+ LDFLAGS="-Wl,--wrap,exit"
+-AC_RUN_IFELSE(
++AC_LINK_IFELSE(
+     [AC_LANG_PROGRAM([[#include <stdlib.h>
+ 		       void __real_exit (int status);
+ 		       void __wrap_exit (int status) { __real_exit (0); }
+--
+GitLab


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master - Dig works, DNS resolving via named works, too.

Description:
Changelog 9.16.8: https://downloads.isc.org/isc/bind9/9.16.8/doc/arm/html/notes.html#notes-for-bind-9-16-8

- DNS Flag Day 2020
(default EDNS buffer size changed from 4096 to 1232 bytes)

-- Added patch, which should be part of the next release
It fixes an issue while cross-compilation (I linked it in the commit
message with [issue link](https://gitlab.isc.org/isc-projects/bind9/-/issues/2237))

