### PR TITLE
docker-ce: Move creation of /tmp/docker above first use

### DIFF
--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -124,6 +124,7 @@ process_config() {
 
 	config_load 'dockerd'
 
+	mkdir -p /tmp/dockerd
 	config_get alt_config_file globals alt_config_file
 	[ -n "$alt_config_file" ] && [ -f "$alt_config_file" ] && {
 		ln -s "$alt_config_file" "$DOCKERD_CONF"
@@ -146,7 +147,6 @@ process_config() {
 	config_list_foreach globals hosts json_add_array_string
 	json_close_array
 
-	mkdir -p /tmp/dockerd
 	json_dump > "$DOCKERD_CONF"
 
 	uciupdate "$bip"


### PR DESCRIPTION
Signed-off-by: Adam Baxter <github@voltagex.org>
Maintainer: @feckert (find it by checking history of the package Makefile)
Compile tested: N/A
Run tested: N/A

Description: If you've got alt_config_file defined, the init script will try to create a symlink as /tmp/dockerd/daemon.json before /tmp/dockerd exists. Moving the mkdir call prevents the init script from failing here.
