### PR TITLE
php7: update to 7.4.12

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=7.4.11
+PKG_VERSION:=7.4.12
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=5d31675a9b9c21b5bd03389418218c30b26558246870caba8eb54f5856e2d6ce
+PKG_HASH:=e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
Maintainer:me
Compile tested: mxs
Run tested: mxs

Description: update php to 7.4.12

Signed-off-by: Michael Heimpold <mhei@heimpold.de>