### PR TITLE
python-cached-property: update to v1.5.2

### DIFF
--- a/lang/python/python-cached-property/Makefile
+++ b/lang/python/python-cached-property/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cached-property
-PKG_VERSION:=1.5.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.5.2
+PKG_RELEASE:=1
 
 PYPI_NAME:=cached-property
-PKG_HASH:=9217a59f14a5682da7c4b8829deadbfc194ac22e9908ccf7c8820234e80a1504
+PKG_HASH:=9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
Stable update with formal support for python 3.8