### PR TITLE
cgroupfs-mount: fix symbolic link name

### DIFF
--- a/utils/cgroupfs-mount/Makefile
+++ b/utils/cgroupfs-mount/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgroupfs-mount
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/tianon/$(PKG_NAME)

--- a/utils/cgroupfs-mount/files/cgroupfs-mount.init
+++ b/utils/cgroupfs-mount/files/cgroupfs-mount.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 
-START=1
+START=01
 
 boot() {
 	# Procd mounts non-hierarchical cgroupfs so unmount first before cgroupfs-mount


### PR DESCRIPTION
Fix the symbolic link name to /etc/rc.d/S01cgroupfs-mount.

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
The created symbolic link S1cgroupfs-mount will be executed after S10fstab.
Fix the START setting to ensure that cgroupfs-mount is executed at S01.