### PR TITLE
redis: update to version 6.0.9

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
-PKG_VERSION:=6.0.8
+PKG_VERSION:=6.0.9
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=04fa1fddc39bd1aecb6739dd5dd73858a3515b427acd1e2947a66dadce868d68
+PKG_HASH:=dc2bdcf81c620e9f09cfd12e85d3bc631c897b2db7a55218fd8a65eaa37f86dd
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause

--- a/libs/redis/patches/020-fix-atomicvar.patch
+++ b/libs/redis/patches/020-fix-atomicvar.patch
@@ -1,22 +1,20 @@
-Index: redis-5.0.0/src/atomicvar.h
-===================================================================
---- redis-5.0.0.orig/src/atomicvar.h
-+++ redis-5.0.0/src/atomicvar.h
+--- a/src/atomicvar.h
++++ b/src/atomicvar.h
 @@ -68,7 +68,7 @@
   * is reported. */
  // #define __ATOMIC_VAR_FORCE_SYNC_MACROS
-
+ 
 -#if !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && defined(__ATOMIC_RELAXED) && !defined(__sun) && (!defined(__clang__) || !defined(__APPLE__) || __apple_build_version__ > 4210057)
 +#if defined(CONFIG_EDAC_ATOMIC_SCRUB) &&  !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && defined(__ATOMIC_RELAXED) && !defined(__sun) && (!defined(__clang__) || !defined(__APPLE__) || __apple_build_version__ > 4210057)
  /* Implementation using __atomic macros. */
-
+ 
  #define atomicIncr(var,count) __atomic_add_fetch(&var,(count),__ATOMIC_RELAXED)
 @@ -82,7 +82,7 @@
  #define atomicSet(var,value) __atomic_store_n(&var,value,__ATOMIC_RELAXED)
  #define REDIS_ATOMIC_API "atomic-builtin"
-
+ 
 -#elif defined(HAVE_ATOMIC)
 +#elif defined(CONFIG_EDAC_ATOMIC_SCRUB) && defined(HAVE_ATOMIC)
  /* Implementation using __sync macros. */
-
+ 
  #define atomicIncr(var,count) __sync_add_and_fetch(&var,(count))

--- a/libs/redis/patches/030-fix-uclibc-compilation.patch
+++ b/libs/redis/patches/030-fix-uclibc-compilation.patch
@@ -3,7 +3,7 @@
 @@ -30,6 +30,10 @@
  #ifndef __CONFIG_H
  #define __CONFIG_H
-
+ 
 +#if defined(__unix) || defined(__linux__)
 +#include <features.h>
 +#endif
@@ -11,15 +11,15 @@
  #ifdef __APPLE__
  #include <AvailabilityMacros.h>
  #endif
-@@ -62,9 +66,9 @@
+@@ -63,9 +67,9 @@
  #endif
-
+ 
  /* Test for backtrace() */
 -#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__)) || \
 +#if (defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__)) || \
-     defined(__FreeBSD__) || (defined(__OpenBSD__) && defined(USE_BACKTRACE))\
+     defined(__FreeBSD__) || ((defined(__OpenBSD__) || defined(__NetBSD__)) && defined(USE_BACKTRACE))\
 - || defined(__DragonFly__)
 + || defined(__DragonFly__)) && !defined(__UCLIBC__)
  #define HAVE_BACKTRACE 1
  #endif
-
+ 


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia(TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates redis to version 6.0.9. This is a security release and it fixes potential heap overflow issue [Changelog](https://raw.githubusercontent.com/redis/redis/6.0/00-RELEASENOTES)

Run tested with an internal benchmark.

