### PR TITLE
utils: stress-ng: bump to version 0.11.23

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.11.20
+PKG_VERSION:=0.11.23
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://kernel.ubuntu.com/~cking/tarballs/stress-ng
-PKG_HASH:=145210ec692382e447579ec5c1651f89aa9cb4f6531bab9c0e54ded82c8ac338
+PKG_HASH:=c0a76147a02f4c31af1fb4b9b7e0b90ac8bbd8590ccb54264d5cbe046c769cd2
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/4b7165722cb0e2ba62ab68e8b90d4d4b0909744c
Run tested: x86 https://github.com/openwrt/openwrt/commit/4b7165722cb0e2ba62ab68e8b90d4d4b0909744c

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>