### PR TITLE
python-tornado: update to version 6.1

### DIFF
--- a/lang/python/python-tornado/Makefile
+++ b/lang/python/python-tornado/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-tornado
-PKG_VERSION:=6.0.4
+PKG_VERSION:=6.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=tornado
-PKG_HASH:=0fe2d45ba43b00a41cd73f8be321a44936dc1aba233dee979f17a042b83eb6dc
+PKG_HASH:=33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:

- Update to version [6.1](https://github.com/tornadoweb/tornado/releases/tag/v6.1.0)