### PR TITLE
python-urllib3: update to version 1.25.11

### DIFF
--- a/lang/python/python-urllib3/Makefile
+++ b/lang/python/python-urllib3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-urllib3
-PKG_VERSION:=1.25.10
+PKG_VERSION:=1.25.11
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
@@ -17,7 +17,7 @@ PKG_LICENSE_FILES:=LICENSE.txt
 PKG_CPE_ID:=cpe:/a:urllib3_project:urllib3
 
 PYPI_NAME:=urllib3
-PKG_HASH:=91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a
+PKG_HASH:=8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
- update to version [1.25.11](https://github.com/urllib3/urllib3/releases/tag/1.25.11)