### PR TITLE
python-more-itertools: update to version 8.6.0

### DIFF
--- a/lang/python/python-more-itertools/Makefile
+++ b/lang/python/python-more-itertools/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-more-itertools
-PKG_VERSION:=8.5.0
+PKG_VERSION:=8.6.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=more-itertools
-PKG_HASH:=6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20
+PKG_HASH:=b3a9005928e5bed54076e6e549c792b306fddfe72b2d1d22dd63d42d5d3899cf
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
maintainer: me
Compile tested: Turris Omnia (TS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt maser

Description:
This PR updates python-more-itertools package to version 8.6.0. It adds support for python 3.9 [Changelog](https://github.com/more-itertools/more-itertools/blob/4d2e1db8eced66fa797832b2b2d720b4f6ae6483/docs/versions.rst#860)

Run tested with internal unit tests.
```
Ran 525 tests in 4.584s

OK
```
