### PR TITLE
travelmate: adapt openwrt rc.common changes

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
 PKG_VERSION:=2.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -6,9 +6,8 @@
 START=25
 USE_PROCD=1
 
-EXTRA_COMMANDS="scan setup"
-EXTRA_HELP="	scan	<radio> Scan for available nearby uplinks
-	setup	[<iface>] [<zone>] [<metric>] Setup the travelmate uplink interface, by default 'trm_wwan' with firewall zone 'wan' and metric '100'"
+extra_command "scan" "<radio> Scan for available nearby uplinks"
+extra_command "setup" "[<iface>] [<zone>] [<metric>] Setup the travelmate uplink interface, by default 'trm_wwan' with firewall zone 'wan' and metric '100'"
 
 trm_init="/etc/init.d/travelmate"
 trm_script="/usr/bin/travelmate.sh"


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: OpenWrt SNAPSHOT, r14851-08d90a75f9

Description:
* since openwrt master has merged the depending P/R, the old
extra_help/extra_commands syntax is no longer working, see #13798 for
reference

Signed-off-by: Dirk Brenken <dev@brenken.org>
