### PR TITLE
banip: adapt openwrt rc.common changes

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
 PKG_VERSION:=0.3.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 
@@ -17,7 +17,7 @@ define Package/banip
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=Ban incoming and/or outgoing ip adresses via ipsets
-	DEPENDS:=+jshn +jsonfilter +ip +ipset +iptables +ca-bundle +logd
+	DEPENDS:=+jshn +jsonfilter +ip +ipset +iptables +ca-bundle
 	PKGARCH:=all
 endef
 

--- a/net/banip/files/banip.init
+++ b/net/banip/files/banip.init
@@ -4,8 +4,7 @@
 START=30
 USE_PROCD=1
 
-EXTRA_COMMANDS="refresh"
-EXTRA_HELP="	refresh	Refresh ipsets without new list downloads"
+extra_command "refresh" "Refresh ipsets without new list downloads"
 
 ban_init="/etc/init.d/banip"
 ban_script="/usr/bin/banip.sh"


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: OpenWrt SNAPSHOT, r14851-08d90a75f9

Description:
* since openwrt master has merged the depending P/R, the old
extra_help/extra_commands syntax is no longer working, see #13798 for
reference
* removed logd dependency, see #13820 for reference

Signed-off-by: Dirk Brenken <dev@brenken.org>
