### PR TITLE
adblock: adapt openwrt rc.common changes

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
 PKG_VERSION:=4.0.7
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -8,14 +8,13 @@
 START=30
 USE_PROCD=1
 
-EXTRA_COMMANDS="suspend resume query report list timer status_service version"
-EXTRA_HELP="	suspend	Suspend adblock processing
-	resume	Resume adblock processing
-	query	<domain> Query active blocklists and backups for a specific domain
-	report	[<search>] Print DNS statistics with an optional search parameter
-	list	[[<add>|<remove>] [source(s)]] List available adblock sources or add/remove them from config
-	timer	<action> <hour> [<minute>] [<weekday>] Set a cron based update interval
-	version	print version information"
+extra_command "suspend" "Suspend adblock processing"
+extra_command "resume" "Resume adblock processing"
+extra_command "query" "<domain> Query active blocklists and backups for a specific domain"
+extra_command "report" "[<search>] Print DNS statistics with an optional search parameter"
+extra_command "list" "[[<add>|<remove>] [source(s)]] List available adblock sources or add/remove them from config"
+extra_command "timer" "<action> <hour> [<minute>] [<weekday>] Set a cron based update interval"
+extra_command "version" "Print version information"
 
 adb_init="/etc/init.d/adblock"
 adb_script="/usr/bin/adblock.sh"

--- a/net/adblock/test.sh
+++ b/net/adblock/test.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-/etc/init.d/"${1}" version 2>/dev/null | grep "${2}"


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: OpenWrt SNAPSHOT, r14851-08d90a75f9

Description:
* since openwrt master has merged the depending P/R, the old
extra_help/extra_commands syntax is no longer working, see #13798 for
reference
* removed test.sh script from package

Signed-off-by: Dirk Brenken <dev@brenken.org>

