### PR TITLE
unbound: change edns buffer size to 1232

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.11.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound

--- a/net/unbound/files/unbound.sh
+++ b/net/unbound/files/unbound.sh
@@ -1327,7 +1327,7 @@ unbound_uci() {
 
   config_get UB_IP_DNS64    "$cfg" dns64_prefix "64:ff9b::/96"
 
-  config_get UB_N_EDNS_SIZE "$cfg" edns_size 1280
+  config_get UB_N_EDNS_SIZE "$cfg" edns_size 1232
   config_get UB_N_RX_PORT   "$cfg" listen_port 53
   config_get UB_N_ROOT_AGE  "$cfg" root_age 9
   config_get UB_N_THREADS   "$cfg" num_threads 1

--- a/net/unbound/files/unbound.uci
+++ b/net/unbound/files/unbound.uci
@@ -8,7 +8,7 @@ config unbound
 	option dns64_prefix '64:ff9b::/96'
 	option domain 'lan'
 	option domain_type 'static'
-	option edns_size '1280'
+	option edns_size '1232'
 	option extended_stats '0'
 	option hide_binddata '1'
 	option interface_auto '1'


### PR DESCRIPTION
Maintainer: @EricLuehrsen 
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR changes default edns buffer size to value 1232. It is related to the change proposed by  **DNS Flag Day 2020**. https://dnsflagday.net/2020/#dns-flag-day-2020 


