### PR TITLE
mwan3: reload unreachable/blackhole rules on hotplug, fix mwan3track bugs, resolve deadlock

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.10.1
+PKG_VERSION:=2.10.2
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -75,6 +75,7 @@ case "$ACTION" in
 		mwan3_set_iface_hotplug_state $INTERFACE "$status"
 		if [ "$MWAN3_STARTUP" != 1 ]; then
 			mwan3_create_iface_route $INTERFACE $DEVICE
+	                mwan3_set_general_rules
 			[ "$status" = "online" ] && mwan3_set_policies_iptables
 		fi
 		[ "$ACTION" = ifup ] && procd_running mwan3 "track_$INTERFACE" && procd_send_signal mwan3 "track_$INTERFACE" USR2

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -6,6 +6,10 @@
 . /usr/share/libubox/jshn.sh
 . /lib/mwan3/common.sh
 
+initscript=/etc/init.d/mwan3
+. /lib/functions/procd.sh
+
+
 SCRIPTNAME="mwan3-hotplug"
 [ "$ACTION" = "ifup" ] || [ "$ACTION" = "ifdown" ] || [ "$ACTION" = "connected" ] || [ "$ACTION" = "disconnected" ] || exit 1
 [ -n "$INTERFACE" ] || exit 2
@@ -16,18 +20,17 @@ if { [ "$ACTION" = "ifup" ] || [ "$ACTION" = "connected" ] ; } && [ -z "$DEVICE"
 	exit 3
 fi
 
-[ "$MWAN3_STARTUP" = 1 ] || mwan3_lock "$ACTION" "$INTERFACE"
+[ "$MWAN3_STARTUP" = 1 ] || procd_lock
 
 config_load mwan3
 /etc/init.d/mwan3 running || {
-	[ "$MWAN3_STARTUP" = 1 ] || mwan3_unlock "$ACTION" "$INTERFACE"
+	[ "$MWAN3_STARTUP" = 1 ] || procd_lock
 	LOG notice "mwan3 hotplug $ACTION on $INTERFACE not called because globally disabled"
 	mwan3_flush_conntrack "$INTERFACE" "$ACTION"
 	exit 0
 }
 
 $IPT4 -S mwan3_hook &>/dev/null || {
-	mwan3_unlock "$ACTION" "$INTERFACE"
 	LOG warn "hotplug called on $INTERFACE before mwan3 has been set up"
 	exit 0
 }
@@ -44,7 +47,6 @@ fi
 
 config_get_bool enabled $INTERFACE 'enabled' '0'
 [ "${enabled}" -eq 1 ] || {
-	[ "$MWAN3_STARTUP" = 1 ] || mwan3_unlock "$ACTION" "$INTERFACE"
 	LOG notice "mwan3 hotplug on $INTERFACE not called because interface disabled"
 	exit 0
 }
@@ -55,11 +57,6 @@ if [ "$initial_state" = "offline" ]; then
 	[ "$status" = "online" ] || status=offline
 else
 	status=online
-fi
-
-if [ "$ACTION" = ifup ] || [ "$ACTION" = ifdown ]; then
-	initscript=/etc/init.d/mwan3
-	. /lib/functions/procd.sh
 fi
 
 LOG notice "Execute $ACTION event on interface $INTERFACE (${DEVICE:-unknown})"
@@ -94,5 +91,4 @@ case "$ACTION" in
 		mwan3_set_policies_iptables
 	;;
 esac
-[ "$MWAN3_STARTUP" = 1 ] || mwan3_unlock "$ACTION" "$INTERFACE"
 exit 0

--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
@@ -3,11 +3,12 @@
 [ -f "/etc/mwan3.user" ] && {
 	. /lib/functions.sh
 	. /lib/mwan3/mwan3.sh
+        initscript=/etc/init.d/mwan3
+	. /lib/functions/procd.sh
 
-	[ "$MWAN3_SHUTDOWN" != 1 ] && mwan3_lock "$ACTION" "$DEVICE-user"
+	[ "$MWAN3_SHUTDOWN" != 1 ] && procd_lock
 
 	[ "$MWAN3_SHUTDOWN" != 1 ] && ! /etc/init.d/mwan3 running && {
-		mwan3_unlock "$ACTION" "$DEVICE-user"
 		exit 0
 	}
 
@@ -18,8 +19,6 @@
 		[ "$MWAN3_SHUTDOWN" != 1 ] && mwan3_unlock "$ACTION" "$DEVICE-user"
 		exit 0
 	}
-
-	[ "$MWAN3_SHUTDOWN" != 1 ] && mwan3_unlock "$ACTION" "$DEVICE-user"
 
 	env -i ACTION="$ACTION" INTERFACE="$INTERFACE" DEVICE="$DEVICE" \
 		/bin/sh /etc/mwan3.user

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -31,8 +31,6 @@ start_service() {
 	mwan3_init
 	config_foreach start_tracker interface
 
-	mwan3_lock "command" "mwan3"
-
 	mwan3_update_iface_to_table
 	mwan3_set_connected_ipset
 	mwan3_set_custom_ipset
@@ -42,8 +40,6 @@ start_service() {
 	wait $hotplug_pids
 	mwan3_set_policies_iptables
 	mwan3_set_user_rules
-
-	mwan3_unlock "command" "mwan3"
 
 	procd_open_instance rtmon_ipv4
 	procd_set_param command /usr/sbin/mwan3rtmon ipv4
@@ -60,8 +56,6 @@ start_service() {
 
 stop_service() {
 	local ipset rule IP IPTR IPT family table tid
-
-	mwan3_lock "command" "mwan3"
 
 	config_load mwan3
 	mwan3_init
@@ -108,7 +102,6 @@ stop_service() {
 
 	rm -rf $MWAN3_STATUS_DIR $MWAN3TRACK_STATUS_DIR
 
-	mwan3_unlock "command" "mwan3"
 }
 
 reload_service() {

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -103,16 +103,6 @@ mwan3_count_one_bits()
 	echo $count
 }
 
-mwan3_lock() {
-	lock /var/run/mwan3.lock
-	#LOG debug "$1 $2 (lock)"
-}
-
-mwan3_unlock() {
-	#LOG debug "$1 $2 (unlock)"
-	lock -u /var/run/mwan3.lock
-}
-
 mwan3_get_iface_id()
 {
 	local _tmp

--- a/net/mwan3/files/usr/sbin/mwan3rtmon
+++ b/net/mwan3/files/usr/sbin/mwan3rtmon
@@ -159,16 +159,13 @@ main()
 		IP="$IP4"
 	fi
 	mwan3_init
-	mwan3_lock "mwan3rtmon" "start"
 	sh -c "echo \$\$; exec $IP monitor route" | {
 		read -r monitor_pid
 		trap_with_arg func_trap "$monitor_pid" SIGINT SIGTERM SIGKILL
 		while IFS='' read -r line; do
 			[ -z "${line##*table*}" ] && continue
 			LOG debug "handling route update $family '$line'"
-			mwan3_lock "service" "mwan3rtmon"
 			mwan3_rtmon_route_handle "$line" "$family"
-			mwan3_unlock "service" "mwan3rtmon"
 		done
 	} &
 	child=$!
@@ -176,7 +173,6 @@ main()
 	trap_with_arg func_trap "$child" SIGINT SIGTERM SIGKILL
 	mwan3_set_connected_${family}
 	mwan3_add_all_routes ${family}
-	mwan3_unlock "mwan3rtmon" "start"
 	kill -SIGCONT $child
 	wait $!
 }

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -9,7 +9,6 @@ DEVICE=""
 
 IFDOWN_EVENT=0
 IFUP_EVENT=0
-TRACK_OUTPUT=$MWAN3TRACK_STATUS_DIR/$INTERFACE/TRACK_OUTPUT
 
 mwan3_init
 
@@ -169,6 +168,7 @@ main() {
 	INTERFACE=$1
 	STATUS=""
 	STARTED=0
+	TRACK_OUTPUT=$MWAN3TRACK_STATUS_DIR/$INTERFACE/TRACK_OUTPUT
 	mkdir -p $MWAN3TRACK_STATUS_DIR/$INTERFACE
 
 	trap clean_up TERM
@@ -345,7 +345,7 @@ main() {
 		get_uptime > $MWAN3TRACK_STATUS_DIR/$INTERFACE/TIME
 
 		host_up_count=0
-		if [ "${IFDOWN_EVENT}" -ne 0 ] && [ "${IFUP_EVENT}" -ne 0 ]; then
+		if [ "${IFDOWN_EVENT}" -eq 0 ] && [ "${IFUP_EVENT}" -eq 0 ]; then
 			sleep "${sleep_time}" &
 			SLEEP_PID=$!
 			wait


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: Scripts Only
Run tested: Snapshot

Description:
when the network procd service restarts, it flushes the ip rules. We
need to add these rules back. Since hotplug events are triggered when
the networks come back online, adding this call to the hotplug script
is the most convenient place to refresh the rules.

Signed-off-by: Aaron Goodman <aaronjg@stanford.edu>