### PR TITLE
xinetd: do not restart service after config change if it is not running

### DIFF
--- a/net/xinetd/Makefile
+++ b/net/xinetd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xinetd
 PKG_VERSION:=2.3.15
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/xinetd-org/xinetd/archive

--- a/net/xinetd/files/xinetd.init
+++ b/net/xinetd/files/xinetd.init
@@ -1,6 +1,8 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2006-2011 OpenWrt.org
 
+. /lib/functions.sh
+
 START=50
 STOP=10
 
@@ -119,8 +121,10 @@ start_service() {
 }
 
 reload_service() {
-	procd_send_signal xinetd "*" QUIT
-	start
+	procd_running xinetd "instance1" && {
+		procd_send_signal xinetd "*" QUIT
+		start
+	}
 }
 
 service_triggers() {


### PR DESCRIPTION
This patch prevents (re)starting xinetd after triggering `reload_service()` if xinetd is not running.
It fixes the problem that xinetd will be started although it is stopped at the moment.
