### PR TITLE
transmission-web-control: remove Transmission SSL variants

### DIFF
--- a/net/transmission-web-control/Makefile
+++ b/net/transmission-web-control/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission-web-control
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/ronggang/transmission-web-control
@@ -19,7 +19,7 @@ define Package/transmission-web-control
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=BitTorrent
-  DEPENDS:=@(PACKAGE_transmission-daemon-openssl||PACKAGE_transmission-daemon-mbedtls)
+  DEPENDS:=+transmission-daemon
   CONFLICTS:=transmission-web
   TITLE:=Transmission Web Control
   URL:=https://github.com/ronggang/transmission-web-control


### PR DESCRIPTION
Maintainer: @ysc3839 
Compile tested: N/A
Run tested: N/A

Description:
In recent commits, there were removed Transmission SSL variants and
there is just used one variant of transmission-daemon. (https://github.com/openwrt/packages/pull/13723).

Let's adjust it here as well.
