### PR TITLE
banip: removed logd check since logd dep has been dropped

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
 PKG_VERSION:=0.3.12
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/banip/files/banip.sh
+++ b/net/banip/files/banip.sh
@@ -121,16 +121,6 @@ f_envload()
 		ban_target_dst_6="${ban_log_chain_dst}"
 	fi
 
-	# log daemon check
-	#
-	if [ "$(/etc/init.d/log running; printf "%u" "${?}")" -eq 1 ]
-	then
-		unset ban_logger
-		f_log "info" "your log daemon 'logd' is not running, please enable 'logd' to use this service"
-		f_rmtemp
-		exit 1
-	fi
-
 	# version check
 	#
 	if [ -z "${ban_basever}" ] || [ "${ban_ver%.*}" != "${ban_basever}" ]


### PR DESCRIPTION
Maintainer: Dirk Brenken <dev@brenken.org>
Compile tested: x86_64 master
Run tested: x86_64 master

Description:
#13848 dropped the logd dependency in commit 14a69715899accff66009d45a4a13ab7cb5a38b7 trying to fix #13820 

I say trying because **banip.sh** checks whether **/etc/init.d/log** is running at runtime, failing when syslog-ng is used.
 