### PR TITLE
NetStinky IDS for detecting IoCs on your network

### DIFF
--- a/net/netstinky/Makefile
+++ b/net/netstinky/Makefile
@@ -1,0 +1,62 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=netstinky
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=nsids-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/wanduow/netstinky-ids/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=143e8d7a9ee7f58893d92b065aed7eca35798f5807b07d9a78f404ea8614e216
+PKG_BUILD_DIR:=$(BUILD_DIR)/nsids-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Andrew Mackintosh <amackint@waikato.ac.nz>
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/netstinky
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libpcap +libuv +libopenssl +umdns
+  TITLE:=NetStinky IDS for detecting IoCs on an active network
+  URL:=https://netstinky.wand.net.nz/
+endef
+
+define Package/netstinky/description
+  The NetStinky IDS is a component of the NetStinky suite of tools. It
+  monitors the traffic on the LAN interfaces of your router for Indications
+  of Compromise (IoCs), drawn from an auto-updating list of definitions.
+  IoCs are subsequently reported to the NetStinky smartphone applications.
+endef
+
+CONFIGURE_ARGS += \
+	--enable-mdns=no \
+	--enable-updates
+
+define Package/netstinky/conffiles
+/etc/config/netstinky
+endef
+
+define Package/netstinky/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) \
+		$(PKG_INSTALL_DIR)/usr/bin/nsids \
+		$(1)/usr/bin
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) \
+		./files/nsids.init \
+		$(1)/etc/init.d/nsids
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) \
+		./files/nsids.conf \
+		$(1)/etc/config/netstinky
+endef
+
+$(eval $(call BuildPackage,netstinky))
+

--- a/net/netstinky/files/nsids.conf
+++ b/net/netstinky/files/nsids.conf
@@ -1,0 +1,8 @@
+
+config netstinky 'ids'
+    option interface 'lan'
+    option port '8089'
+    option updatehost 'netstinky-api.wand.net.nz'
+    option updateport '15000'
+    option sslnoverify 'false'
+

--- a/net/netstinky/files/nsids.init
+++ b/net/netstinky/files/nsids.init
@@ -1,0 +1,64 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+START=95
+STOP=01
+
+CONFIGURATION=netstinky
+
+validate_ids_section()
+{
+    uci_load_validate netstinky netstinky "$1" "$2" \
+            'interface:string:lan' \
+            'port:uinteger:8089' \
+            'updatehost:string' \
+            'updateport:uinteger' \
+            'sslnoverify:bool:false'
+}
+
+netstinky_instance()
+{
+    [ "$2" = 0 ] || {
+        echo "validation failed"
+        return 1
+    }
+
+    procd_open_instance
+    procd_set_param command /usr/bin/nsids
+
+    if [ -n "${interface}" ]; then
+        local iface
+        network_get_device iface "${interface}"
+        procd_append_param command -i "${iface}"
+    fi
+    procd_append_param command -p "${port}"
+    [ -n "${updatehost}" ] && procd_append_param command --update-host "${updatehost}"
+    [ -n "${updateport}" ] && procd_append_param command --update-port "${updateport}"
+    [ "${sslnoverify}" -eq 1 ] && procd_append_param command --ssl-no-verify
+
+    procd_set_param stderr 1
+    procd_set_param stdout 1
+
+    procd_add_mdns "netstinky" "tcp" "$port"
+
+    procd_close_instance
+}
+
+start_service()
+{
+    . /lib/functions/network.sh
+
+    config_load "${CONFIGURATION}"
+    config_foreach validate_ids_section netstinky netstinky_instance
+}
+
+service_triggers()
+{
+    procd_add_config_trigger "config.change" "netstinky" /etc/init.d/nsids reload
+
+    config_load "${CONFIGURATION}"
+
+    procd_add_validation validate_ids_section
+}
+


### PR DESCRIPTION
Signed-off-by: Andrew Mackintosh <amackint@waikato.ac.nz>

Maintainer: me / @null-cipher
Compile tested: Raspberry Pi 3 / brcm2708-bcm2710, OpenWrt 19.07.4
                Hyper-V VM / x86_64, OpenWrt 19.07.4
Run tested: Raspberry Pi 3 / brcm2708-bcm2710, OpenWrt 19.07.4
            Hyper-V VM / x86_64, OpenWrt 19.07.4

Description:
The NetStinky IDS is a component of the NetStinky suite of tools. It
monitors the traffic on the LAN interfaces of your router for
Indications of Compromise (IoCs), drawn from an auto-updating list of
definitions.  IoCs are subsequently reported to the NetStinky smartphone
applications.