### PR TITLE
php7: fix for icu 68.1

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=7.4.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=PHP-3.01

--- a/lang/php7/patches/1005-support_for_icu4c_68_1.patch
+++ b/lang/php7/patches/1005-support_for_icu4c_68_1.patch
@@ -1,0 +1,13 @@
+--- a/build/php.m4	2020-10-28 00:01:52.000000000 +0900
++++ b/build/php.m4	2020-11-13 08:57:27.939303216 +0900
+@@ -1907,6 +1907,10 @@
+   if test "$PKG_CONFIG icu-io --atleast-version=60"; then
+     ICU_CFLAGS="$ICU_CFLAGS -DU_HIDE_OBSOLETE_UTF_OLD_H=1"
+   fi
++
++  if test "$PKG_CONFIG icu-io --atleast-version=68"; then
++    ICU_CFLAGS="$ICU_CFLAGS -DU_DEFINE_FALSE_AND_TRUE=1"
++  fi
+ ])
+ 
+ dnl


### PR DESCRIPTION
Maintainer: @mhei 
Compile tested: aarch64
 Run tested: none

Description:
fix for icu 68.1

https://github.com/openwrt/packages/pull/13883
https://github.com/php/php-src/commit/975735c02751d9409c4a4757e7b70d217f0f54fe

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
