### PR TITLE
libexif: update to 0.6.22

### DIFF
--- a/libs/libexif/Makefile
+++ b/libs/libexif/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libexif
-PKG_VERSION:=0.6.21
+PKG_VERSION:=0.6.22
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=@SF/libexif
-PKG_HASH:=16cdaeb62eb3e6dfab2435f7d7bccd2f37438d21c5218ec4e58efa9157d4d41a
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/$(PKG_NAME)-0_6_22-release/
+PKG_HASH:=5048f1c8fc509cc636c2f97f4b40c293338b6041a5652082d5ee2cf54b530c56
 
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING
@@ -28,7 +28,7 @@ define Package/libexif
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=library for jpeg files with exif tags
-  URL:=http://libexif.sourceforge.net/
+  URL:=https://libexif.github.io/
   MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 endef
 

--- a/libs/libexif/patches/100-no_doc.patch
+++ b/libs/libexif/patches/100-no_doc.patch
@@ -1,12 +1,12 @@
-diff -u --recursive libexif-0.6.21-vanilla/Makefile.in libexif-0.6.21/Makefile.in
---- libexif-0.6.21-vanilla/Makefile.in	2014-07-17 22:17:52.439423287 -0400
-+++ libexif-0.6.21/Makefile.in	2014-07-17 22:18:28.125359945 -0400
-@@ -289,7 +289,7 @@
+diff -u --recursive libexif-0.6.22-vanilla/Makefile.in libexif-0.6.22/Makefile.in
+--- libexif-0.6.22-vanilla/Makefile.in	2020-05-18 14:51:57.000000000 -0500
++++ libexif-0.6.22/Makefile.in	2020-11-10 14:02:49.736268440 -0600
+@@ -393,7 +393,7 @@
  top_build_prefix = @top_build_prefix@
  top_builddir = @top_builddir@
  top_srcdir = @top_srcdir@
--SUBDIRS = m4m po libexif test doc binary contrib
-+SUBDIRS = m4m po libexif test binary contrib
+-SUBDIRS = m4m po libexif test doc binary-dist contrib
++SUBDIRS = m4m po libexif test binary-dist contrib
  EXTRA_DIST = @PACKAGE_TARNAME@.spec README-Win32.txt libexif.pc.in \
- 	libexif-uninstalled.pc.in
+ 	libexif-uninstalled.pc.in SECURITY.md
  pkgconfigdir = $(libdir)/pkgconfig


### PR DESCRIPTION
Aside from updating the package, this modifies the Makefile to pull the
sources from GitHub rather than SourceForge. The exif project recently
moved to GitHub.

Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_66
