### PR TITLE
libupm: Allow to build only python modules

### DIFF
--- a/libs/libupm/Makefile
+++ b/libs/libupm/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libupm
 PKG_VERSION:=2.0.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/intel-iot-devkit/upm/tar.gz/v$(PKG_VERSION)?
@@ -52,6 +52,8 @@ UPM_MODULES:= \
 	vcap t3311 hwxpxx h803x ozw curieimu
 # (require libbacnet) tb7300 t8100 e50hx bacnetmstp
 # (require libtinyb) 2jciebu01_ble 2jciebu01_usb
+
+CMAKE_OPTIONS=-DBUILDSWIGNODE=$(if $(CONFIG_PACKAGE_libmraa-node),ON,OFF)
 
 define Package/libupm/Default
   SECTION:=libs
@@ -345,7 +347,7 @@ define Package/libupm-$(1)-node
   $(call Package/libupm/Default)
   $(call UpmPackage/depends,$(1))
   TITLE:=$(1) Node.js library
-  DEPENDS+=+libupm-$(1) +libmraa-node +node
+  DEPENDS+=+libupm-$(1) +libmraa-node
 endef
 
 define Package/libupm-$(1)-node/description


### PR DESCRIPTION
Maintainer: @blogic me
Compile tested: head r14887-a472791, aarch64
Run tested: aarch64 (qemu-5.1.0)

Description:
Allow to build only python modules.
The change was made because node.js no longer supports most of the MIPS.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
