### PR TITLE
mwan3: remove dependency on rpcd & fix iputils-ping check

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.10.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -45,7 +45,7 @@ endef
 
 define Package/mwan3/postinst
 #!/bin/sh
-if [ -z "$${IPKG_INSTROOT}" ]; then
+if [ -z "$${IPKG_INSTROOT}" ] && [ -x /etc/init.d/rpcd ]; then
 	/etc/init.d/rpcd restart
 fi
 exit 0
@@ -53,7 +53,7 @@ endef
 
 define Package/mwan3/postrm
 #!/bin/sh
-if [ -z "$${IPKG_INSTROOT}" ]; then
+if [ -z "$${IPKG_INSTROOT}" ] && [ -x /etc/init.d/rpcd ]; then
 	/etc/init.d/rpcd restart
 fi
 exit 0

--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -10,7 +10,8 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=mwan3
 PKG_VERSION:=2.10.3
 PKG_RELEASE:=2
-PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
+PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
+		Aaron Goodman <aaronjg@alumni.stanford.edu>
 PKG_LICENSE:=GPL-2.0
 PKG_CONFIG_DEPENDS:=CONFIG_IPV6
 

--- a/net/mwan3/files/lib/mwan3/common.sh
+++ b/net/mwan3/files/lib/mwan3/common.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-get_uptime() {
-	local uptime=$(cat /proc/uptime)
-	echo "${uptime%%.*}"
-}
-
 IP4="ip -4"
 IP6="ip -6"
 SCRIPTNAME="$(basename "$0")"
@@ -179,4 +174,19 @@ mwan3_count_one_bits()
 		count=$((count+1))
 	done
 	echo $count
+}
+
+get_uptime() {
+	local uptime=$(cat /proc/uptime)
+	echo "${uptime%%.*}"
+}
+
+get_online_time() {
+	local time_n time_u iface
+	iface="$1"
+	time_u="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/ONLINE" 2>/dev/null)"
+	[ -z "${time_u}" ] || [ "${time_u}" = "0" ] || {
+		time_n="$(get_uptime)"
+		echo $((time_n-time_u))
+	}
 }

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -1053,15 +1053,8 @@ mwan3_report_iface_status()
 	if [ "$result" = "offline" ]; then
 		:
 	elif [ $error -eq 0 ]; then
-		json_init
-		json_add_string section interfaces
-		json_add_string interface "$1"
-		json_load "$(ubus call mwan3 status "$(json_dump)")"
-		json_select "interfaces"
-		json_select "$1"
-		json_get_vars online uptime
-		json_select ..
-		json_select ..
+		online=$(get_online_time "$1")
+		network_get_uptime uptime "$1"
 		online="$(printf '%02dh:%02dm:%02ds\n' $((online/3600)) $((online%3600/60)) $((online%60)))"
 		uptime="$(printf '%02dh:%02dm:%02ds\n' $((uptime/3600)) $((uptime%3600/60)) $((uptime%60)))"
 		result="$(mwan3_get_iface_hotplug_state $1) $online, uptime $uptime"

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -69,6 +69,26 @@ report_policies_v6() {
 	done
 }
 
+get_age() {
+	local time_p time_u
+	iface="$1"
+	time_p="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/TIME")"
+	[ -z "${time_p}" ] || {
+		time_n="$(get_uptime)"
+		echo $((time_n-time_p))
+	}
+}
+
+get_offline_time() {
+	local time_n time_d iface
+	iface="$1"
+	time_d="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/OFFLINE")"
+	[ -z "${time_d}" ] || [ "${time_d}" = "0" ] || {
+		time_n="$(get_uptime)"
+		echo $((time_n-time_d))
+	}
+}
+
 get_mwan3_status() {
 	local iface="${1}"
 	local iface_select="${2}"
@@ -85,23 +105,9 @@ get_mwan3_status() {
 
 	track_status="$(mwan3_get_mwan3track_status "$1")"
 	[ "$track_status" = "active" ] && running="1"
-	time_p="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/TIME")"
-	[ -z "${time_p}" ] || {
-		time_n="$(get_uptime)"
-		let age=time_n-time_p
-	}
-
-	time_u="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/ONLINE")"
-	[ -z "${time_u}" ] || [ "${time_u}" = "0" ] || {
-		time_n="$(get_uptime)"
-		let online=time_n-time_u
-	}
-
-	time_d="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/OFFLINE")"
-	[ -z "${time_d}" ] || [ "${time_d}" = "0" ] || {
-		time_n="$(get_uptime)"
-		let offline=time_n-time_d
-	}
+	age=$(get_age "$iface")
+	online=$(get_online_time "$iface")
+	offline=$(get_offline_time "$iface")
 
 	local uptime="0"
 

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -40,19 +40,35 @@ if_up() {
 	stop_subprocs
 }
 
+ping_test_host() {
+	if [ "$FAMILY" = "ipv6" ]; then
+		echo "::1"
+	else
+		echo "127.0.0.1"
+	fi
+}
+
+get_ping_command() {
+	if [ -x "/usr/bin/ping" ] && /usr/bin/ping -${FAMILY#ipv} -c1 -q $(ping_test_host) &>/dev/null; then
+		# -4 option added in iputils c3e68ac6 so need to check if we can use it
+		# or if we must use ping and ping6
+		echo "/usr/bin/ping -${FAMILY#ipv}"
+	elif [ "$FAMILY" = "ipv6" ] && [ -x "/usr/bin/ping6" ]; then
+		echo "/usr/bin/ping6"
+	elif [ "$FAMILY" = "ipv4" ] && [ -x "/usr/bin/ping" ]; then
+		echo "/usr/bin/ping"
+	elif [ -x "/bin/ping" ]; then
+		echo "/bin/ping -${FAMILY#ipv}"
+	else
+		return 1
+	fi
+}
+
 validate_track_method() {
 	case "$1" in
 		ping)
-			if [ -x "/usr/bin/ping" ] && [ "$(/usr/bin/ping -V | grep -o '[0-9]*$')" -gt 20150519 ]; then
-				# -4 option added in iputils c3e68ac6
-				PING="/usr/bin/ping -${FAMILY#ipv}"
-			elif [ "$FAMILY" = "ipv6" ] && [ -x "/usr/bin/ping6" ]; then
-				PING="/usr/bin/ping6"
-			elif [ "$FAMILY" = "ipv4" ] && [ -x "/usr/bin/ping" ]; then
-				PING="/usr/bin/ping"
-			elif [ -x "/bin/ping" ]; then
-				PING="/bin/ping -${FAMILY#ipv}"
-			else
+			PING=$(get_ping_command)
+			if [ $? -ne 0 ]; then
 				LOG warn "Missing ping. Please enable BUSYBOX_DEFAULT_PING and recompile busybox or install iputils-ping package."
 				return 1
 			fi


### PR DESCRIPTION
Maintainer @feckert 

Allow `mwan3 interfaces` to get uptime via an internal function and
thus remove the dependency on rpcd for `mwan3 interface` calls.

Do not install the rpcd script if an image is built without rpcd. rpcd
is included in the standard images, so this will only impact custom images.

Fixes: #13896

Signed-off-by: Aaron Goodman <aaronjg@stanford.edu>

