### PR TITLE
libudev-zero: fix installation of so files.

### DIFF
--- a/libs/libudev-zero/Makefile
+++ b/libs/libudev-zero/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libudev-zero
 PKG_VERSION:=0.4.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/illiliti/libudev-zero/tar.gz/$(PKG_VERSION)?
@@ -45,7 +45,7 @@ endef
 
 define Package/libudev-zero/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libudev.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libudev.so* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libudev-zero))


### PR DESCRIPTION
Maintainer: @neheb 
Compile tested: x86_64, latest master
Run tested: x86_64, latest master

Description:
This fixes the installation of the file `/usr/lib/libudev.so`.