### PR TITLE
stm32flash: Added patch to lock serial device

### DIFF
--- a/utils/stm32flash/Makefile
+++ b/utils/stm32flash/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stm32flash
 PKG_VERSION:=0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://sourceforge.net/projects/stm32flash/files

--- a/utils/stm32flash/patches/0001-Serial-POSIX-Check-if-tty-is-already-opened-by-anoth.patch
+++ b/utils/stm32flash/patches/0001-Serial-POSIX-Check-if-tty-is-already-opened-by-anoth.patch
@@ -1,0 +1,47 @@
+From 1f10b4e3364de54f108bc42e4f789893afd44c9a Mon Sep 17 00:00:00 2001
+From: Mickael GARDET <m.gardet@overkiz.com>
+Date: Thu, 1 Sep 2016 17:12:03 +0200
+Subject: [PATCH] Serial POSIX: Check if tty is already opened by another
+ stm32flash
+
+---
+ serial_posix.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/serial_posix.c b/serial_posix.c
+index 46b8a94..020e796 100644
+--- a/serial_posix.c
++++ b/serial_posix.c
+@@ -25,6 +25,7 @@
+ #include <termios.h>
+ #include <unistd.h>
+ #include <sys/ioctl.h>
++#include <sys/file.h>
+ 
+ #include "serial.h"
+ #include "port.h"
+@@ -45,6 +46,13 @@ static serial_t *serial_open(const char *device)
+ 		free(h);
+ 		return NULL;
+ 	}
++
++	if(lockf(h->fd,F_TLOCK,0) != 0)
++	{
++		fprintf(stderr, "Error: %s is already open\n", device);
++		free(h);
++		return NULL;
++	}
+ 	fcntl(h->fd, F_SETFL, 0);
+ 
+ 	tcgetattr(h->fd, &h->oldtio);
+@@ -62,6 +70,7 @@ static void serial_close(serial_t *h)
+ {
+ 	serial_flush(h);
+ 	tcsetattr(h->fd, TCSANOW, &h->oldtio);
++	lockf(h->fd, F_ULOCK, 0);
+ 	close(h->fd);
+ 	free(h);
+ }
+-- 
+2.17.1
+


### PR DESCRIPTION
Patch backported from upstream master

Tested:
```
stm32flash 0.4

http://stm32flash.googlecode.com/

Error: /dev/ttyS1 is already open
Error probing interface "serial_posix"
Cannot handle device "/dev/ttyS1"
Failed to open port: /dev/ttyS1
```