### PR TITLE
knot: fix compilation with musl 1.2.0

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
 PKG_VERSION:=3.0.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/

--- a/net/knot/patches/010-musl120.patch
+++ b/net/knot/patches/010-musl120.patch
@@ -1,0 +1,35 @@
+--- a/src/libknot/xdp/eth.c
++++ b/src/libknot/xdp/eth.c
+@@ -20,6 +20,7 @@
+ #include <linux/if.h>
+ #include <linux/sockios.h>
+ #include <sys/ioctl.h>
++#include <string.h>
+ #include <unistd.h>
+ 
+ #include "contrib/openbsd/strlcpy.h"
+--- a/src/libknot/xdp/xdp.c
++++ b/src/libknot/xdp/xdp.c
+@@ -16,10 +16,6 @@
+ 
+ #include <assert.h>
+ #include <errno.h>
+-#include <linux/if_ether.h>
+-#include <linux/ip.h>
+-#include <linux/ipv6.h>
+-#include <linux/udp.h>
+ #include <stddef.h>
+ #include <stdlib.h>
+ #include <string.h>
+@@ -32,6 +28,11 @@
+ #include "libknot/xdp/xdp.h"
+ #include "contrib/macros.h"
+ 
++#include <linux/if_ether.h>
++#include <linux/ip.h>
++#include <linux/ipv6.h>
++#include <linux/udp.h>
++
+ /* Don't fragment flag. */
+ #define	IP_DF 0x4000
+ 

--- a/net/knot/patches/01_zscanner_tests.patch
+++ b/net/knot/patches/01_zscanner_tests.patch
@@ -1,5 +1,3 @@
-diff --git a/tests/libzscanner/test_zscanner.in b/tests/libzscanner/test_zscanner.in
-index 2c0c27526..72b2124c7 100644
 --- a/tests/libzscanner/test_zscanner.in
 +++ b/tests/libzscanner/test_zscanner.in
 @@ -1,15 +1,14 @@

--- a/net/knot/patches/02_knot.conf.patch
+++ b/net/knot/patches/02_knot.conf.patch
@@ -1,8 +1,6 @@
-diff --git a/samples/knot.sample.conf.in b/samples/knot.sample.conf.in
-index 10302f958..75082f537 100644
 --- a/samples/knot.sample.conf.in
 +++ b/samples/knot.sample.conf.in
-@@ -30,6 +30,8 @@ template:
+@@ -33,6 +33,8 @@ template:
    - id: default
      storage: "@storage_dir@"
      file: "%s.zone"


### PR DESCRIPTION
Missing header for strlcpy.

Moved linux defines down as they conflict with netinet/in.h , which
must be include first.

Refreshed patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @salzmdan 
Compile tested: powerpc

This does not compile with full NLS. I tried adding nls.mk to fix, but then I get this error:

```
powerpc-openwrt-linux-musl-gcc: error: none: No such file or directory
powerpc-openwrt-linux-musl-gcc: error: required: No such file or **directory**
```

No idea how to fix.