### PR TITLE
tor: update to version 0.4.4.6 (security fix)

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.4.5
-PKG_RELEASE:=2
+PKG_VERSION:=0.4.4.6
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=a45ca00afe765e3baa839767c9dd6ac9a46dd01720a3a8ff4d86558c12359926
+PKG_HASH:=5f154c155803adf5c89e87cab53017b6908c5ebe50c65839e8cf4fbd2abe1fdc
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: Turris Omnia (TOS6), OpenWrt maser
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates Tor to version 0.4.4.6. It fixes security bug [TROVE-2020- 005](https://gitlab.torproject.org/tpo/core/tor/-/issues/40080) and a few minor issues.

[Changelog](https://blog.torproject.org/node/1952)

Run tested with torsocks
