### PR TITLE
ooniprobe: update to version 3.0.10

### DIFF
--- a/net/ooniprobe/Makefile
+++ b/net/ooniprobe/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ooniprobe
-PKG_VERSION:=3.0.9
+PKG_VERSION:=3.0.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=probe-cli-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ooni/probe-cli/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=1910d8042bf92528ba233ef874e128e2960ab2e3e9b7081367529e7ca421f055
+PKG_HASH:=2724199105b4708b82af456e882011bf1766849a1d72efb117343643230b8766
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates ooniprobe to version 3.0.10. This version updates the  engine probe to v0.20.0  It adds support for http3, riseupvpn measurement.


[Ooniprobe changelog](https://github.com/ooni/probe-cli/releases/tag/v3.0.10)
[Engine probe changelog](https://github.com/ooni/probe-engine/releases/tag/v0.20.0)

