### PR TITLE
git-lfs: add new package

### DIFF
--- a/net/git-lfs/Makefile
+++ b/net/git-lfs/Makefile
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2020-2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=git-lfs
+PKG_VERSION:=2.13.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/git-lfs/git-lfs/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=782e6275df9ca370730945112e16a0b8c64b9819f0b61fae52ba1ebbc8dce2d5
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.md
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/git-lfs/git-lfs
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/git-lfs
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Git Large File Storage
+  URL:=https://git-lfs.github.com
+  DEPENDS:=$(GO_ARCH_DEPENDS) +git
+endef
+
+define Package/git-lfs/description
+  Git Large File Storage (LFS) replaces large files such as audio samples,
+  videos, datasets, and graphics with text pointers inside Git, while storing
+  the file contents on a remote server like GitHub.com or GitHub Enterprise.
+endef
+
+$(eval $(call GoBinPackage,git-lfs))
+$(eval $(call BuildPackage,git-lfs))

--- a/net/git-lfs/test.sh
+++ b/net/git-lfs/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+git-lfs --version|grep "$2"


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR adds new package git-lfs. It helps to store large file inside git. 

This is related to PR https://github.com/openwrt/packages/pull/13919. It is one of the required packages from GitLab to run custom executor https://docs.gitlab.com/runner/executors/custom.html#prerequisite-software-for-running-a-job 
