### PR TITLE
mariadb: Update to 10.4.17

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
-PKG_VERSION:=10.4.14
-PKG_RELEASE:=2
+PKG_VERSION:=10.4.17
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := \
@@ -18,7 +18,7 @@ PKG_SOURCE_URL := \
 	https://ftp.yz.yamagata-u.ac.jp/pub/dbms/mariadb/$(PKG_NAME)-$(PKG_VERSION)/source \
 	https://downloads.mariadb.org/interstitial/$(PKG_NAME)-$(PKG_VERSION)/source
 
-PKG_HASH:=f92fcd59e0122461482f28c67c5ea01c7cf6979494a571db68074396864c86fc
+PKG_HASH:=a7b104e264311cd46524ae546ff0c5107978373e4a01cf7fd8a241454548d16e
 PKG_MAINTAINER:=Michal Hrusecky <Michal@Hrusecky.net>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING THIRDPARTY

--- a/utils/mariadb/patches/170-ppc-remove-glibc-dep.patch
+++ b/utils/mariadb/patches/170-ppc-remove-glibc-dep.patch
@@ -1,5 +1,7 @@
---- a/include/my_cpu.h
-+++ b/include/my_cpu.h
+Index: mariadb-10.4.17/include/my_cpu.h
+===================================================================
+--- mariadb-10.4.17.orig/include/my_cpu.h
++++ mariadb-10.4.17/include/my_cpu.h
 @@ -24,17 +24,16 @@
  */
  
@@ -23,17 +25,19 @@
  /* High priority */
  #define HMT_high() asm volatile("or 3,3,3")
  #else
-@@ -72,7 +71,7 @@ static inline void MY_RELAX_CPU(void)
+@@ -80,7 +79,7 @@ static inline void MY_RELAX_CPU(void)
    __asm__ __volatile__ ("pause");
  #endif
  #elif defined(_ARCH_PWR8)
 -  __ppc_get_timebase();
 +  __builtin_ppc_get_timebase();
- #else
-   int32 var, oldval = 0;
-   my_atomic_cas32_strong_explicit(&var, &oldval, 1, MY_MEMORY_ORDER_RELAXED,
---- a/storage/tokudb/PerconaFT/portability/toku_time.h
-+++ b/storage/tokudb/PerconaFT/portability/toku_time.h
+ #elif defined __GNUC__ && (defined __arm__ || defined __aarch64__)
+   /* Mainly, prevent the compiler from optimizing away delay loops */
+   __asm__ __volatile__ ("":::"memory");
+Index: mariadb-10.4.17/storage/tokudb/PerconaFT/portability/toku_time.h
+===================================================================
+--- mariadb-10.4.17.orig/storage/tokudb/PerconaFT/portability/toku_time.h
++++ mariadb-10.4.17/storage/tokudb/PerconaFT/portability/toku_time.h
 @@ -124,7 +124,7 @@ static inline tokutime_t toku_time_now(v
      __asm __volatile__ ("mrs %[rt], cntvct_el0" : [rt] "=r" (result));
      return result;


### PR DESCRIPTION
Update to the latest version from 10.4 series

Signed-off-by: Michal Hrusecky <michal.hrusecky@turris.com>

Maintainer: me
Compile tested: mvebu, Turris Omnia, Turris OS 5.2 ~ OpenWrt 19.07
Run tested: mvebu, Turris Omnia, Turris OS 5.2 ~ OpenWrt 19.07, runs
