### PR TITLE
mwan3: add mwan3 reload if firewall gets restarted

### DIFF
--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -108,6 +108,30 @@ reload_service() {
 	start
 }
 
+extra_command "firewall" "Reload all mwan3 firewall rules"
+firewall() {
+	handle_reload() {
+		local iface="$1"
+		local device
+
+		[ "$(mwan3_get_iface_hotplug_state "$iface")" = "online" ] && {
+			network_get_device device $iface
+			mwan3_create_iface_iptables $iface $device
+		}
+	}
+
+	mwan3_init
+	mwan3_set_general_iptables
+
+	config_load mwan3
+	config_foreach handle_reload interface
+
+	mwan3_set_policies_iptables
+
+	LOG notice "Re-apply firewall rules"
+}
+
 service_triggers() {
+	procd_add_restart_service_trigger "firewall" /etc/init.d/mwan3 firewall
 	procd_add_reload_trigger 'mwan3'
 }


### PR DESCRIPTION
Signed-off-by: Florian Eckert <fe@dev.tdt.de>

Maintainer: me / @aaronjg 
Compile tested: not needed only script changes
Run tested: x86_64, APU3, openwrt master

Description:

If firewall is restarted, then the mwan3 rules are purged and not
reinstalled. To fix this add a hotplug script to restart mwan3 on
firewall restart.

Depends on procd change:
This is still pending https://patchwork.ozlabs.org/project/openwrt/list/?series=218099

