### PR TITLE
adblock: modify StevenBlack blocklist sources

### DIFF
--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -292,8 +292,8 @@
 		"focus": "compilation",
 		"descurl": "https://github.com/StevenBlack/hosts"
 	},
-	"stevenblack_porn": {
-		"url": "https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-gambling-porn-social/hosts",
+	"stevenblack_fakenews-gambling-porn": {
+		"url": "https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-gambling-porn/hosts",
 		"rule": "/^0\\.0\\.0\\.0[[:space:]]+([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($2)}",
 		"size": "L",
 		"focus": "compilation",


### PR DESCRIPTION
Maintainer: @dibdot
Compile tested: -
Run tested: TurrisOS 5.1.3

Description:
* replace fakenews-gambling-porn-social with fakenews-gambling-porn
* modify title accordingly

Comment:
  The current title for this blocklist is stevenblack_porn although
  it also contains other extensions. Particularly, it contains the social
  extension which block legitimate websites the like ofTwitter, Reddit etc.
  I replaced the list with the fakenew-gambling-porn list which I believe is
  more adequat.

Signed-off-by: Alexandre Mercier <alex@cyberflamingo.net>