### PR TITLE
c-ares: fix CVE-2020-8277

### DIFF
--- a/libs/c-ares/Makefile
+++ b/libs/c-ares/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=c-ares
 PKG_VERSION:=1.16.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://c-ares.haxx.se/download

--- a/libs/c-ares/patches/CVE-2020-8277.patch
+++ b/libs/c-ares/patches/CVE-2020-8277.patch
@@ -1,0 +1,50 @@
+From 0d252eb3b2147179296a3bdb4ef97883c97c54d3 Mon Sep 17 00:00:00 2001
+From: bradh352 <brad@brad-house.com>
+Date: Thu, 12 Nov 2020 10:24:40 -0500
+Subject: [PATCH] ares_parse_{a,aaaa}_reply could return larger *naddrttls than
+ passed in
+
+If there are more ttls returned than the maximum provided by the requestor, then
+the *naddrttls response would be larger than the actual number of elements in
+the addrttls array.
+
+This bug could lead to invalid memory accesses in applications using c-ares.
+
+This behavior appeared to break with PR #257
+
+Fixes: #371
+Reported By: Momtchil Momtchev (@mmomtchev)
+Fix By: Brad House (@bradh352)
+---
+ src/lib/ares_parse_a_reply.c    | 3 ++-
+ src/lib/ares_parse_aaaa_reply.c | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/ares_parse_a_reply.c b/ares_parse_a_reply.c
+index d8a9e9b5..e71c993f 100644
+--- a/ares_parse_a_reply.c
++++ b/ares_parse_a_reply.c
+@@ -197,7 +197,8 @@ int ares_parse_a_reply(const unsigned char *abuf, int alen,
+ 
+   if (naddrttls)
+     {
+-      *naddrttls = naddrs;
++      /* Truncated to at most *naddrttls entries */
++      *naddrttls = (naddrs > *naddrttls)?*naddrttls:naddrs;
+     }
+ 
+   ares__freeaddrinfo_cnames(ai.cnames);
+diff --git a/ares_parse_aaaa_reply.c b/ares_parse_aaaa_reply.c
+index 0d39bfa8..346d4307 100644
+--- a/ares_parse_aaaa_reply.c
++++ b/ares_parse_aaaa_reply.c
+@@ -200,7 +200,8 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
+ 
+   if (naddrttls)
+     {
+-      *naddrttls = naddrs;
++      /* Truncated to at most *naddrttls entries */
++      *naddrttls = (naddrs > *naddrttls)?*naddrttls:naddrs;
+     }
+ 
+   ares__freeaddrinfo_cnames(ai.cnames);


### PR DESCRIPTION
Maintainer: @karlp
Compile tested: HEAD r14954-aafbfc6, aarch64
Run tested: aarch64 (qemu 5.1.0)

Description:
Fix CVE-2020-8277 : Denial of Service through DNS request

https://github.com/c-ares/c-ares/issues/371
https://github.com/c-ares/c-ares/commit/0d252eb3b2147179296a3bdb4ef97883c97c54d3
https://github.com/nodejs/node/commit/a81aa37944a6b3efad49c15bbb62cbd1522631f4

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
