### PR TITLE
travelmate: remove wrong f_net call in source

### DIFF
--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -610,7 +610,6 @@ f_check()
 				ifname="$(printf "%s" "${dev_status}" | jsonfilter -l1 -e '@.*.interfaces[@.config.mode="sta"].ifname')"
 				if [ -n "${ifname}" ] && [ "${enabled}" = "1" ]
 				then
-					result="$(f_net)"
 					trm_ifquality="$(${trm_iwinfo} "${ifname}" info 2>/dev/null | awk -F '[ ]' '/Link Quality:/{split($NF,var0,"/");printf "%i\n",(var0[1]*100/var0[2])}')"
 					if [ "${trm_ifquality}" -ge "${trm_minquality}" ]
 					then


### PR DESCRIPTION
Maintainer: @dibdot 
Compile tested: only script changes
Run tested: x86_64, APU3, openwrt master

Description:
The call to f_net on this point in the source makes no sense.