### PR TITLE
vim: fix host compile with clang 12.0.0

### DIFF
--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vim
 PKG_VERSION:=8.1
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 VIMVER:=81
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/utils/vim/patches/004-clang.patch
+++ b/utils/vim/patches/004-clang.patch
@@ -1,0 +1,24 @@
+--- a/src/auto/configure
++++ b/src/auto/configure
+@@ -13922,6 +13922,9 @@ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#if STDC_HEADERS
++# include <stdlib.h>
++#endif
+ #ifdef HAVE_STDINT_H
+ # include <stdint.h>
+ #endif
+--- a/src/configure.ac
++++ b/src/configure.ac
+@@ -4064,6 +4064,9 @@ AC_DEFINE_UNQUOTED(VIM_SIZEOF_LONG, [$ac
+ dnl Make sure that uint32_t is really 32 bits unsigned.
+ AC_MSG_CHECKING([uint32_t is 32 bits])
+ AC_TRY_RUN([
++#if STDC_HEADERS
++# include <stdlib.h>
++#endif
+ #ifdef HAVE_STDINT_H
+ # include <stdint.h>
+ #endif


### PR DESCRIPTION
fix autoconf script using 'exit' without including 'stdlib.h'

Signed-off-by: Liangbin Lian <jjm2473@gmail.com>

Maintainer: Marko Ratkaj <marko.ratkaj@sartura.hr>
Compile tested: MacOS clang 12.0.0
Run tested: MacOS