### PR TITLE
runc: enable seccomp support by default

### DIFF
--- a/utils/runc/Makefile
+++ b/utils/runc/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=runc
 PKG_VERSION:=1.0.0-rc10
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -26,9 +26,9 @@ include ../../lang/golang/golang-package.mk
 define Package/runc/config
 config RUNC_SECCOMP
 	depends on PACKAGE_runc
+	depends on KERNEL_SECCOMP
 	bool "Enable support for seccomp in runc"
-	default DOCKER_SECCOMP
-	select KERNEL_SECCOMP
+	default y
 	select PACKAGE_libseccomp
 	help
 	  Build runc with support for seccomp filters.


### PR DESCRIPTION
It's nice to have seccomp support which is enabled in OpenWrt on
supported platforms on targets which are not marked as SMALL_FLASH.
(and it's kinda obvious that you wouldn't want to install runc on a
SMALL_FLASH target to begin with)
So let's enable seccomp by default.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>
Maintainer: @G-M0N3Y-2503