### PR TITLE
Added chain rule to filter table so udp stun incoming connections rul…

### DIFF
--- a/net/miniupnpd/files/firewall.include
+++ b/net/miniupnpd/files/firewall.include
@@ -31,13 +31,15 @@ add_extzone_rules() {
     [ -z "$ext_zone" ] && return
 
     # IPv4 - due to NAT, need to add both to nat and filter table
-    # need to insert as penultimate rule for forward & postrouting since final rule might be a fw3 REJECT
+    # need to insert as penultimate rule for input & forward & postrouting since final rule might be a fw3 REJECT
+    iptables_prepend_rule "$IPTABLES" filter "zone_${ext_zone}_input" MINIUPNPD
     iptables_prepend_rule "$IPTABLES" filter "zone_${ext_zone}_forward" MINIUPNPD
     $IPTABLES -t nat -A "zone_${ext_zone}_prerouting"  -j MINIUPNPD
     iptables_prepend_rule "$IPTABLES" nat "zone_${ext_zone}_postrouting" MINIUPNPD-POSTROUTING
 
     # IPv6 if available - filter only
     [ -x $IP6TABLES ] && {
+	iptables_prepend_rule "$IP6TABLES" filter "zone_${ext_zone}_input" MINIUPNPD
 	iptables_prepend_rule "$IP6TABLES" filter "zone_${ext_zone}_forward" MINIUPNPD
     }
     ADDED=$(($ADDED + 1))


### PR DESCRIPTION
Maintainer: @neheb @ptpt52 
Compile tested: (ath79, tplink_tl-wr941-v2, openwrt-19.07)
Run tested: (ath79, tplink_tl-wr941-v2, openwrt-19.07)
Added to /etc/config/upnpd 
option use_stun '1'
option stun_host 'stun.stunprotocol.org'
option stun_port '3478'

Make sure that no UDP rule exists on the firewall to accept all connections and check miniupnpd system logs to see it was successful.

Description:

Fix this issue https://forum.openwrt.org/t/miniupnpd-in-trunk-stun-setup/18688

For the miniupnpd stun protocol to work correctly to find out the external IP address dynamically, it opens rules in the table 'filter' to receive incoming UDP connections for the router IP but there was no chain rule on the zone input referencing the MINIUPNPD table and so it couldn't receive the expected connections.
The fix was to add a chain rule in the zone input to check the MINIUPNPD table before rejecting all connections.
Should I make another pull request for the master branch? I will not be able to test this on the new version.
