### PR TITLE
meson: update to 0.56.0

### DIFF
--- a/devel/meson/Makefile
+++ b/devel/meson/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=meson
-PKG_VERSION:=0.55.3
+PKG_VERSION:=0.56.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=meson
-PKG_HASH:=6bed2a25a128bbabe97cf40f63165ebe800e4fcb46db8ab7ef5c2b5789f092a5
+PKG_HASH:=291dd38ff1cd55fcfca8fc985181dd39be0d3e5826e5f0013bf867be40117213
 
 PKG_MAINTAINER:=Andre Heider <a.heider@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/devel/meson/meson.mk
+++ b/devel/meson/meson.mk
@@ -76,7 +76,6 @@ define Meson/CreateCrossFile
 		-e "s|@AR@|$(TARGET_AR)|" \
 		-e "s|@STRIP@|$(TARGET_CROSS)strip|" \
 		-e "s|@NM@|$(TARGET_NM)|" \
-		-e "s|@LD@|$(TARGET_CROSS)ld|" \
 		-e "s|@PKGCONFIG@|$(PKG_CONFIG)|" \
 		-e "s|@CFLAGS@|$(foreach FLAG,$(TARGET_CFLAGS) $(EXTRA_CFLAGS) $(TARGET_CPPFLAGS) $(EXTRA_CPPFLAGS),'$(FLAG)',)|" \
 		-e "s|@CXXFLAGS@|$(foreach FLAG,$(TARGET_CXXFLAGS) $(EXTRA_CXXFLAGS) $(TARGET_CPPFLAGS) $(EXTRA_CPPFLAGS),'$(FLAG)',)|" \

--- a/devel/meson/src/openwrt-cross.txt.in
+++ b/devel/meson/src/openwrt-cross.txt.in
@@ -4,15 +4,13 @@ cpp = [@CXX@]
 ar = '@AR@'
 strip = '@STRIP@'
 nm = '@NM@'
-ld = '@LD@'
 pkgconfig = '@PKGCONFIG@'
 
-[properties]
+[built-in options]
 c_args = [@CFLAGS@]
 c_link_args = [@LDFLAGS@]
 cpp_args = [@CXXFLAGS@]
 cpp_link_args = [@LDFLAGS@]
-needs_exe_wrapper = true
 
 [host_machine]
 system = 'linux'
@@ -20,6 +18,8 @@ cpu_family = '@ARCH@'
 cpu = '@CPU@'
 endian = '@ENDIAN@'
 
+[properties]
+needs_exe_wrapper = true
+
 [paths]
 prefix = '/usr'
-libdir = 'lib'

--- a/devel/meson/src/openwrt-native.txt.in
+++ b/devel/meson/src/openwrt-native.txt.in
@@ -3,7 +3,7 @@ c = [@CC@]
 cpp = [@CXX@]
 pkgconfig = '@PKGCONFIG@'
 
-[properties]
+[built-in options]
 c_args = [@CFLAGS@]
 c_link_args = [@LDFLAGS@]
 cpp_args = [@CXXFLAGS@]


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dhewg 
Compile tested: ath79

I think this will be the last version where OS python can be relied upon. Next release is Python 3.6 and above.