### PR TITLE
Provide both libdaq 2.2.2 and 3.0.0-beta1 to satisfy Snort 2 and 3.

### DIFF
--- a/libs/libdaq/Makefile
+++ b/libs/libdaq/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdaq
-PKG_VERSION:=3.0.0-beta1
+PKG_VERSION:=2.2.2
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://www.snort.org/downloads/snortplus/
 PKG_SOURCE:=daq-$(PKG_VERSION).tar.gz
-PKG_HASH:=ef74aa1c30a6ee93eacbe7967d1c85d7df3214cf3783d4eabbb6b64305fd273e
+PKG_HASH:=7cd818cabb1ad35360e83076e54775f07165ee71407dc672d147e27d3cd37f7b
 PKG_BUILD_DIR:=$(BUILD_DIR)/daq-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-2.0
@@ -29,7 +29,7 @@ define Package/libdaq
   CATEGORY:=Libraries
   TITLE:=DAQ library
   URL:=$(PKG_SOURCE_URL)
-  DEPENDS:=+libdnet +libpcap +libstdcpp
+  DEPENDS:=+libdnet +libpcap
 endef
 
 define Package/libdaq/description
@@ -52,7 +52,7 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib/daq
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/daq/* $(STAGING_DIR)/usr/lib/daq/
 	$(INSTALL_DIR) $(STAGING_DIR)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(STAGING_DIR)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/daq-modules-config $(STAGING_DIR)/usr/bin/
 endef
 
 define Package/libdaq/install
@@ -61,7 +61,7 @@ define Package/libdaq/install
 	$(INSTALL_DIR) $(1)/usr/lib/daq
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/daq/*.so* $(1)/usr/lib/daq/
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/daq-modules-config $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,libdaq))

--- a/libs/libdaq/patches/001-compile.patch
+++ b/libs/libdaq/patches/001-compile.patch
@@ -1,0 +1,19 @@
+diff -u --recursive daq-2.2.2-vanilla/configure daq-2.2.2/configure
+--- daq-2.2.2-vanilla/configure	2017-07-05 15:58:03.000000000 -0400
++++ daq-2.2.2/configure	2018-09-01 17:18:56.774898034 -0400
+@@ -13244,10 +13244,11 @@
+ else
+ 
+     if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
++#  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++#$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++#as_fn_error $? "cannot run test program while cross compiling
++#See \`config.log' for more details" "$LINENO" 5; }
++        echo "    No cross compiling test."
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */

--- a/libs/libdaq/patches/100-musl-compat.patch
+++ b/libs/libdaq/patches/100-musl-compat.patch
@@ -1,0 +1,45 @@
+diff -u --recursive daq-2.2.2-vanilla/os-daq-modules/daq_ipfw.c daq-2.2.2/os-daq-modules/daq_ipfw.c
+--- daq-2.2.2-vanilla/os-daq-modules/daq_ipfw.c	2017-02-08 17:04:18.000000000 -0500
++++ daq-2.2.2/os-daq-modules/daq_ipfw.c	2018-09-01 17:21:10.608181841 -0400
+@@ -23,10 +23,10 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <stdio.h>
++#include <unistd.h>
+ 
+ #include <sys/types.h>
+ #include <sys/time.h>
+-#include <sys/unistd.h>
+ 
+ #include <netinet/in.h>
+ #include <sys/socket.h>
+diff -u --recursive daq-2.2.2-vanilla/os-daq-modules/daq_ipq.c daq-2.2.2/os-daq-modules/daq_ipq.c
+--- daq-2.2.2-vanilla/os-daq-modules/daq_ipq.c	2017-02-08 17:04:18.000000000 -0500
++++ daq-2.2.2/os-daq-modules/daq_ipq.c	2018-09-01 17:21:23.162208457 -0400
+@@ -24,10 +24,10 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ #include <sys/types.h>
+ #include <sys/time.h>
+-#include <sys/unistd.h>
+ 
+ #include <netinet/ip.h>
+ 
+diff -u --recursive daq-2.2.2-vanilla/os-daq-modules/daq_nfq.c daq-2.2.2/os-daq-modules/daq_nfq.c
+--- daq-2.2.2-vanilla/os-daq-modules/daq_nfq.c	2017-02-08 17:04:18.000000000 -0500
++++ daq-2.2.2/os-daq-modules/daq_nfq.c	2018-09-01 17:21:35.202233988 -0400
+@@ -24,10 +24,10 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ #include <sys/types.h>
+ #include <sys/time.h>
+-#include <sys/unistd.h>
+ 
+ #include <netinet/ip.h>
+ 

--- a/libs/libdaq3/Makefile
+++ b/libs/libdaq3/Makefile
@@ -1,0 +1,67 @@
+#
+# Copyright (C) 2012-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libdaq3
+PKG_VERSION:=3.0.0-beta1
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=https://www.snort.org/downloads/snortplus/
+PKG_SOURCE:=daq-$(PKG_VERSION).tar.gz
+PKG_HASH:=ef74aa1c30a6ee93eacbe7967d1c85d7df3214cf3783d4eabbb6b64305fd273e
+PKG_BUILD_DIR:=$(BUILD_DIR)/daq-$(PKG_VERSION)
+
+PKG_LICENSE:=GPL-2.0-only
+PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libdaq3
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=DAQ library
+  URL:=$(PKG_SOURCE_URL)
+  DEPENDS:=+libdnet +libpcap +libstdcpp
+endef
+
+define Package/libdaq3/description
+ Data Acquisition library for packet I/O.
+endef
+
+CONFIGURE_ARGS+= \
+	--disable-static \
+	--disable-nfq-module \
+	--with-dnet-includes="$(STAGING_DIR)/usr/include" \
+	--with-dnet-libraries="$(STAGING_DIR)/usr/lib" \
+	--with-libpcap-includes="$(STAGING_DIR)/usr/include" \
+	--with-libpcap-libraries="$(STAGING_DIR)/usr/lib" \
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(STAGING_DIR)/usr/include/
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib* $(STAGING_DIR)/usr/lib/
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib/daq
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/daq/* $(STAGING_DIR)/usr/lib/daq/
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(STAGING_DIR)/usr/bin/
+endef
+
+define Package/libdaq3/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/daq
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/daq/*.so* $(1)/usr/lib/daq/
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,libdaq3))

--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -28,7 +28,7 @@ define Package/snort3
   SUBMENU:=Firewall
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libstdcpp +libdaq +libdnet +libopenssl +libpcap +libpcre +libpthread +libuuid +zlib +libhwloc +libtirpc +luajit
+  DEPENDS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre +libpthread +libuuid +zlib +libhwloc +libtirpc +luajit
   TITLE:=Lightweight Network Intrusion Detection System
   URL:=http://www.snort.org/
   MENU:=1
@@ -51,6 +51,7 @@ CMAKE_OPTIONS += \
 	-DMAKE_HTML_DOC:BOOL=NO \
 	-DMAKE_PDF_DOC:BOOL=NO \
 	-DMAKE_TEXT_DOC:BOOL=NO \
+	-DHAVE_LIBUNWIND=OFF \
 	-DHAVE_LZMA=OFF
 
 TARGET_CFLAGS  += -I$(STAGING_DIR)/usr/include/tirpc


### PR DESCRIPTION
Maintainer: me
Compile tested: mips_24kc master

Description:
Earlier bump of libdaq left Snort 2 unable to compile. This provides both libdaq and libdaq3 packages so that both Snort 3 and 3 compile.