### PR TITLE
hwinfo: update to version 21.71

### DIFF
--- a/utils/hwinfo/Makefile
+++ b/utils/hwinfo/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hwinfo
-PKG_VERSION:=21.70
-PKG_RELEASE:=2
+PKG_VERSION:=21.71
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/openSUSE/hwinfo/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=bc3c4a4498e4abc32a54497ced715bbae5dfd19dd999da294bca6d69fea2db52
+PKG_HASH:=c4c573eb15cbc10103f5044b485d7e4ff941500ed559743a1c98e6a6deb0ebda
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_MAINTAINER:=Alberto Bursi <bobafetthotmail@gmail.com>


### PR DESCRIPTION
update to upstream version 21.71

Signed-off-by: Alberto Bursi <bobafetthotmail@gmail.com>

Maintainer: me 

compile-tested and run-tested on x86_64 target