### PR TITLE
libseccomp: update to 2.5.1

### DIFF
--- a/libs/libseccomp/Makefile
+++ b/libs/libseccomp/Makefile
@@ -8,18 +8,22 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libseccomp
-PKG_VERSION:=2.4.3
+PKG_VERSION:=2.5.1
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/seccomp/libseccomp/releases/download/v$(PKG_VERSION)/
-PKG_HASH:=cf15d1421997fac45b936515af61d209c4fd788af11005d212b3d0fd71e7991d
+PKG_HASH:=ee307e383c77aa7995abc5ada544d51c9723ae399768a97667d4cdb3c3a30d55
+
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <nmav@gnutls.org>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:libseccomp_project:libseccomp
 
-PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DEPENDS:=gperf/host
 PKG_LIBTOOL_PATHS:=. lib
 
 PKG_CONFIG_DEPENDS:= \


### PR DESCRIPTION
Add license information.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nmav 
Compile tested: ath79