### PR TITLE
libcap-ng: update to 0.8.1

### DIFF
--- a/libs/libcap-ng/Makefile
+++ b/libs/libcap-ng/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libcap-ng
-PKG_VERSION:=0.8
+PKG_VERSION:=0.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://people.redhat.com/sgrubb/libcap-ng
-PKG_HASH:=f14d23b60ae1465b032e4e8cbd4112006572c69a6017d55d5d3c6aad622a9e21
+PKG_HASH:=f06b17aaca029e245c9a26c698c6cc8a1cf42b58483d93e94ee02b478bdc1055
 
 PKG_MAINTAINER:=Lucian CRISTIAN <lucian.cristian@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.1-or-later


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: ath79