### PR TITLE
avahi: incorrectly requires IFF_MULTICAST on point-to-point (tunnel) …

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=avahi
 PKG_VERSION:=0.8
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lathiat/avahi/releases/download/v$(PKG_VERSION) \

--- a/libs/avahi/patches/100-p2p-no-iff_multicast-required.patch
+++ b/libs/avahi/patches/100-p2p-no-iff_multicast-required.patch
@@ -1,0 +1,49 @@
+commit 2b6bccca5d9d8ab7f11219a639707b325910a0b1
+Author: Philip Prindeville <philipp@redfish-solutions.com>
+Date:   Thu Sep 17 00:27:55 2020 +0000
+
+    Logic for p2p on tunnels incorrectly requires IFF_MULTICAST (#305)
+    
+    Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
+
+diff --git a/avahi-core/iface-linux.c b/avahi-core/iface-linux.c
+index e116c7b..75089c4 100644
+--- a/avahi-core/iface-linux.c
++++ b/avahi-core/iface-linux.c
+@@ -105,8 +105,8 @@ static void netlink_callback(AvahiNetlink *nl, struct nlmsghdr *n, void* userdat
+             (ifinfomsg->ifi_flags & IFF_UP) &&
+             (!m->server->config.use_iff_running || (ifinfomsg->ifi_flags & IFF_RUNNING)) &&
+             ((ifinfomsg->ifi_flags & IFF_LOOPBACK) ||
+-             (ifinfomsg->ifi_flags & IFF_MULTICAST)) &&
+-            (m->server->config.allow_point_to_point || !(ifinfomsg->ifi_flags & IFF_POINTOPOINT));
++             (ifinfomsg->ifi_flags & IFF_MULTICAST) ||
++             ((ifinfomsg->ifi_flags & IFF_POINTOPOINT) && m->server->config.allow_point_to_point));
+ 
+         /* Handle interface attributes */
+         l = NLMSG_PAYLOAD(n, sizeof(struct ifinfomsg));
+diff --git a/avahi-core/iface-pfroute.c b/avahi-core/iface-pfroute.c
+index 45fd970..4eafce0 100644
+--- a/avahi-core/iface-pfroute.c
++++ b/avahi-core/iface-pfroute.c
+@@ -81,8 +81,8 @@ static void rtm_info(struct rt_msghdr *rtm, AvahiInterfaceMonitor *m)
+     (ifm->ifm_flags & IFF_UP) &&
+     (!m->server->config.use_iff_running || (ifm->ifm_flags & IFF_RUNNING)) &&
+     ((ifm->ifm_flags & IFF_LOOPBACK) ||
+-     (ifm->ifm_flags & IFF_MULTICAST)) &&
+-    (m->server->config.allow_point_to_point || !(ifm->ifm_flags & IFF_POINTOPOINT));
++     (ifm->ifm_flags & IFF_MULTICAST) ||
++      ((ifm->ifm_flags & IFF_POINTOPOINT) && m->server->config.allow_point_to_point));
+ 
+   avahi_free(hw->name);
+   hw->name = avahi_strndup(sdl->sdl_data, sdl->sdl_nlen);
+@@ -428,8 +428,8 @@ static void if_add_interface(struct lifreq *lifreq, AvahiInterfaceMonitor *m, in
+             (flags & IFF_UP) &&
+             (!m->server->config.use_iff_running || (flags & IFF_RUNNING)) &&
+             ((flags & IFF_LOOPBACK) ||
+-            (flags & IFF_MULTICAST)) &&
+-            (m->server->config.allow_point_to_point || !(flags & IFF_POINTOPOINT));
++             (flags & IFF_MULTICAST) ||
++              ((flags & IFF_POINTOPOINT) && m->server->config.allow_point_to_point));
+         hw->name = avahi_strdup(lifreq->lifr_name);
+         hw->mtu = mtu;
+         /* TODO get mac address */


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: x86_64, generic, 359a4b46b
Run tested: ditto, built and installed on production routers

Description:

The notion of "multicast" is meaningless on a point-to-point (P2P) connection because there's only ever going to be a single recipient at the other end.

This issue has been submitted upstream as: https://github.com/lathiat/avahi/issues/305 and a fix as PR: https://github.com/lathiat/avahi/pull/306.
