### PR TITLE
hdparm: update to 9.60

### DIFF
--- a/utils/hdparm/Makefile
+++ b/utils/hdparm/Makefile
@@ -8,16 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hdparm
-PKG_VERSION:=9.58
-PKG_RELEASE:=2
+PKG_VERSION:=9.60
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
-PKG_HASH:=9ae78e883f3ce071d32ee0f1b9a2845a634fc4dd94a434e653fdbef551c5e10f
+PKG_HASH:=8397739c73e44d5ab96c4aef28fa9c0147276d53a1b5657ce04c4565cf6635cc
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=BSD-Style Open Source License
 PKG_LICENSE_FILES:=LICENSE.TXT
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -35,7 +38,7 @@ endef
 
 define Package/hdparm/install
 	$(INSTALL_DIR) $(1)/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(PKG_NAME) $(1)/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/sbin/hdparm $(1)/sbin
 endef
 
 $(eval $(call BuildPackage,hdparm))

--- a/utils/hdparm/patches/010-cflags.patch
+++ b/utils/hdparm/patches/010-cflags.patch
@@ -1,13 +1,11 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -13,9 +13,8 @@ oldmandir = $(manprefix)/man
+@@ -13,7 +13,7 @@ oldmandir = $(manprefix)/man
  CC ?= gcc
  STRIP ?= strip
  
 -CFLAGS := -O2 -W -Wall -Wbad-function-cast -Wcast-align -Wpointer-arith -Wcast-qual -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -fkeep-inline-functions -Wwrite-strings -Waggregate-return -Wnested-externs -Wtrigraphs $(CFLAGS)
 +CFLAGS ?= -O2 -W -Wall -Wbad-function-cast -Wcast-align -Wpointer-arith -Wcast-qual -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -fkeep-inline-functions -Wwrite-strings -Waggregate-return -Wnested-externs -Wtrigraphs $(CFLAGS)
  
--LDFLAGS = -s
- #LDFLAGS = -s -static
  INSTALL = install
  INSTALL_DATA = $(INSTALL) -m 644


### PR DESCRIPTION
Use PKG_INSTALL and PKG_BUILD_PARALLEL for consistency.

Rebase patch.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ath79