### PR TITLE
adguardhome: upstream upgrade to v0.104.3

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
-PKG_VERSION:=0.104.1
+PKG_VERSION:=0.104.3
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://github.com/AdguardTeam/AdGuardHome
-PKG_MIRROR_HASH:=3abbbf0531fd991a96dc2ea32aaaa9ab65dee5f40bb71e5939ddd068bbb17f7c
+PKG_SOURCE_VERSION:=62a8fe0b73d16b9f71234f6b4efbba560ba470e2
 
 PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILES:=LICENSE.txt
@@ -23,7 +23,7 @@ PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
 GO_PKG:=github.com/AdguardTeam/AdGuardHome
-GO_PKG_EXCLUDES:=dhcpd/standalone
+GO_PKG_EXCLUDES:=internal/dhcpd/standalone
 GO_PKG_LDFLAGS_X:=main.version=$(PKG_VERSION) main.channel=release main.goarm=$(GO_ARM)
 
 include $(INCLUDE_DIR)/package.mk
@@ -50,7 +50,7 @@ define Build/Compile
 		pushd $(PKG_BUILD_DIR) ; \
 		npm --prefix client ci ; \
 		npm --prefix client run build-prod ; \
-		packr -z -v -i internal ; \
+		packr -z -v -i internal/home ; \
 		popd ; \
 		$(call GoPackage/Build/Compile) ; \
 	)


### PR DESCRIPTION
adguardhome: upstream upgrade to v0.104.3

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
