### PR TITLE
gst1-plugins-base: fix build with no module

### DIFF
--- a/multimedia/gst1-plugins-base/Makefile
+++ b/multimedia/gst1-plugins-base/Makefile
@@ -182,11 +182,14 @@ define Build/InstallDev
 		./usr/lib/libgst*-$(GST_VERSION).so* \
 		$(1)/usr/lib/ \
 	)
-	$(INSTALL_DIR) $(1)/usr/lib/gstreamer-$(GST_VERSION)
-	( cd $(PKG_INSTALL_DIR); $(CP) \
-		./usr/lib/gstreamer-$(GST_VERSION)/libgst*.so \
-		$(1)/usr/lib/gstreamer-$(GST_VERSION)/ \
-	)
+	if [ -d $(PKG_INSTALL_DIR)/usr/lib/gstreamer-$(GST_VERSION)/ ]; then \
+		$(INSTALL_DIR) $(1)/usr/lib/gstreamer-$(GST_VERSION); \
+		( cd $(PKG_INSTALL_DIR); $(FIND) \
+			./usr/lib/gstreamer-$(GST_VERSION)/ -name libgst*.so -print0 | \
+			xargs --null --no-run-if-empty $(CP) \
+			--target-directory=$(1)/usr/lib/gstreamer-$(GST_VERSION)/ \
+		) \
+	fi
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	( cd $(PKG_INSTALL_DIR); $(CP) \
 		./usr/lib/pkgconfig/gstreamer*-$(GST_VERSION).pc \


### PR DESCRIPTION
gst1-plugins-base might be required only for its libraries, not modules.
However, InstallDev tries to copy them unconditionally, failing when
no modules are selected/compiled.

Fixes #13973

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: @flyn-org @thess
Compile tested: arc_generic,armvirt_64,ath79_generic,powerpc,ramips_mt7620,x86_64,x86_generic
Run tested: not needed (Makefile fix)

Description:

It deals with missing or empty $(PKG_INSTALL_DIR)/usr/lib/gstreamer-$(GST_VERSION)

I left other $(CP) cases intact as I don't know if those source files could be missing without being an error.