### PR TITLE
net/miniupnpd: ext_ip_reserved_ignore support

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -62,6 +62,7 @@ upnpd() {
 	local use_stun stun_host stun_port uuid notify_interval presentation_url
 	local upnp_lease_file clean_ruleset_threshold clean_ruleset_interval
 	local ipv6_disable
+	local ext_ip_reserved_ignore
 
 	local enabled
 	config_get_bool enabled config enabled 1
@@ -89,6 +90,7 @@ upnpd() {
 	config_get clean_ruleset_threshold config clean_ruleset_threshold
 	config_get clean_ruleset_interval config clean_ruleset_interval
 	config_get ipv6_disable config ipv6_disable 0
+	config_get ext_ip_reserved_ignore config ext_ip_reserved_ignore 0
 
 	local conf ifname ifname6
 
@@ -142,6 +144,7 @@ upnpd() {
 		upnpd_write_bool igdv1 0 force_igd_desc_v1
 		upnpd_write_bool use_stun 0 ext_perform_stun
 		upnpd_write_bool ipv6_disable $ipv6_disable
+		upnpd_write_bool ext_ip_reserved_ignore $ext_ip_reserved_ignore
 
 		[ "$use_stun" -eq 0 ] || {
 			[ -n "$stun_host" ] && echo "ext_stun_host=$stun_host"

--- a/net/miniupnpd/files/upnpd.config
+++ b/net/miniupnpd/files/upnpd.config
@@ -12,6 +12,7 @@ config upnpd config
 	option port		5000
 	option upnp_lease_file	/var/run/miniupnpd.leases
 	option igdv1		1
+	option ext_ip_reserved_ignore '1'
 
 config perm_rule
 	option action		allow

--- a/net/miniupnpd/patches/301-ext_ip_reserved_ignore.patch
+++ b/net/miniupnpd/patches/301-ext_ip_reserved_ignore.patch
@@ -1,0 +1,126 @@
+commit cb046cfef1d6b954d3fc09f09a1fc3a7ffeb7593
+Author: Chen Minqiang <ptpt52@gmail.com>
+Date:   Sun Jul 5 10:42:52 2020 +0800
+
+    options: ext_ip_reserved_ignore support
+    
+    This make the port forwarding force to work even
+    when the router is behind NAT
+    
+    Signed-off-by: Chen Minqiang <ptpt52@gmail.com>
+
+diff --git a/getifaddr.c b/getifaddr.c
+index 7c09064..46cae8c 100644
+--- a/getifaddr.c
++++ b/getifaddr.c
+@@ -25,6 +25,7 @@
+ #if defined(USE_GETIFADDRS) || defined(ENABLE_IPV6) || defined(ENABLE_PCP)
+ #include <ifaddrs.h>
+ #endif
++#include "upnpglobalvars.h"
+ 
+ int
+ getifaddr(const char * ifname, char * buf, int len,
+@@ -295,6 +296,11 @@ addr_is_reserved(struct in_addr * addr)
+ 	uint32_t address = ntohl(addr->s_addr);
+ 	size_t i;
+ 
++	if(GETFLAG(EXTIPRESERVEDIGNOREMASK)) {
++		syslog(LOG_NOTICE, "private/reserved address checking is ignore");
++		return 0;
++	}
++
+ 	for (i = 0; i < sizeof(reserved)/sizeof(reserved[0]); ++i) {
+ 		if ((address >> reserved[i].rmask) == (reserved[i].address >> reserved[i].rmask))
+ 			return 1;
+diff --git a/miniupnpd.c b/miniupnpd.c
+index e9f9f61..86b4200 100644
+--- a/miniupnpd.c
++++ b/miniupnpd.c
+@@ -1225,6 +1225,10 @@ init(int argc, char * * argv, struct runtime_vars * v)
+ 			case UPNPEXT_IP:
+ 				use_ext_ip_addr = ary_options[i].value;
+ 				break;
++			case UPNPEXT_IP_RESERVED_IGNORE:
++				if(strcmp(ary_options[i].value, "yes") == 0)
++					SETFLAG(EXTIPRESERVEDIGNOREMASK);
++				break;
+ 			case UPNPEXT_PERFORM_STUN:
+ 				if(strcmp(ary_options[i].value, "yes") == 0)
+ 					SETFLAG(PERFORMSTUNMASK);
+diff --git a/miniupnpd.conf b/miniupnpd.conf
+index 6274f67..c614192 100644
+--- a/miniupnpd.conf
++++ b/miniupnpd.conf
+@@ -9,6 +9,8 @@
+ # Setting ext_ip is also useful in double NAT setup, you can declare here
+ # the public IP address.
+ #ext_ip=
++#ignore even if ext_ip is reserved: default is no
++#ext_ip_reserved_ignore=yes
+ # WAN interface must have public IP address. Otherwise it is behind NAT
+ # and port forwarding is impossible. In some cases WAN interface can be
+ # behind unrestricted NAT 1:1 when all incoming traffic is NAT-ed and
+diff --git a/options.c b/options.c
+index 05fa317..3711094 100644
+--- a/options.c
++++ b/options.c
+@@ -34,6 +34,7 @@ static const struct {
+ 	{ UPNPEXT_IFNAME6, "ext_ifname6" },
+ #endif
+ 	{ UPNPEXT_IP,	"ext_ip" },
++	{ UPNPEXT_IP_RESERVED_IGNORE, "ext_ip_reserved_ignore" },
+ 	{ UPNPEXT_PERFORM_STUN, "ext_perform_stun" },
+ 	{ UPNPEXT_STUN_HOST, "ext_stun_host" },
+ 	{ UPNPEXT_STUN_PORT, "ext_stun_port" },
+diff --git a/options.h b/options.h
+index 96cdbbf..34c698f 100644
+--- a/options.h
++++ b/options.h
+@@ -21,6 +21,7 @@ enum upnpconfigoptions {
+ 	UPNPEXT_IFNAME6,		/* ext_ifname6 */
+ #endif
+ 	UPNPEXT_IP,				/* ext_ip */
++	UPNPEXT_IP_RESERVED_IGNORE, /* ignore if ext_ip is reserved */
+ 	UPNPEXT_PERFORM_STUN,		/* ext_perform_stun */
+ 	UPNPEXT_STUN_HOST,		/* ext_stun_host */
+ 	UPNPEXT_STUN_PORT,		/* ext_stun_port */
+diff --git a/testgetifaddr.c b/testgetifaddr.c
+index 8045b89..b5cdbb4 100644
+--- a/testgetifaddr.c
++++ b/testgetifaddr.c
+@@ -13,6 +13,8 @@
+ #include "config.h"
+ #include "getifaddr.h"
+ 
++int runtime_flags = 0;
++
+ #if defined(__sun)
+ /* solaris 10 does not define LOG_PERROR */
+ #define LOG_PERROR 0
+diff --git a/testportinuse.c b/testportinuse.c
+index 98574c6..507f830 100644
+--- a/testportinuse.c
++++ b/testportinuse.c
+@@ -14,6 +14,8 @@
+ #include "config.h"
+ #include "portinuse.h"
+ 
++int runtime_flags = 0;
++
+ int main(int argc, char * * argv)
+ {
+ #ifndef CHECK_PORTINUSE
+diff --git a/upnpglobalvars.h b/upnpglobalvars.h
+index a474353..4f5bbdd 100644
+--- a/upnpglobalvars.h
++++ b/upnpglobalvars.h
+@@ -84,6 +84,8 @@ extern int runtime_flags;
+ 
+ #define PERFORMSTUNMASK    0x1000
+ 
++#define EXTIPRESERVEDIGNOREMASK 0x2000
++
+ #define SETFLAG(mask)	runtime_flags |= mask
+ #define GETFLAG(mask)	(runtime_flags & mask)
+ #define CLEARFLAG(mask)	runtime_flags &= ~mask


### PR DESCRIPTION
This add an option to ignore ext_ip reserved
Enable this option in config by default.

Fixes: #13773 
Patche is upstream pending https://github.com/miniupnp/miniupnp/pull/511