### PR TITLE
fix ntpd-4.2.8p15 building error

### DIFF
--- a/net/ntpd/Makefile
+++ b/net/ntpd/Makefile
@@ -148,7 +148,7 @@ define Package/ntp-utils/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ntpdc/ntpdc $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ntpq/ntpq $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/util/ntptime $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/sntp/sntp $(1)/usr/sbin/
+	$(if $(CONFIG_PACKAGE_ntp-utils), $(INSTALL_BIN) $(PKG_BUILD_DIR)/sntp/sntp $(1)/usr/sbin/)
 endef
 
 define Package/ntp-keygen/install

--- a/net/ntpd/patches/001-fix-fstack-protector-build-error.patch
+++ b/net/ntpd/patches/001-fix-fstack-protector-build-error.patch
@@ -1,0 +1,40 @@
+Index: ntp-4.2.8p15/sntp/harden/linux
+===================================================================
+--- ntp-4.2.8p15.orig/sntp/harden/linux
++++ ntp-4.2.8p15/sntp/harden/linux
+@@ -1,4 +1,4 @@
+ # generic linux hardening flags
+-NTP_HARD_CFLAGS="-fPIE -fPIC -fstack-protector-all -O1"
++NTP_HARD_CFLAGS="-fPIE -fPIC -O1"
+ NTP_HARD_CPPFLAGS="-D_FORTIFY_SOURCE=2"
+ NTP_HARD_LDFLAGS="-pie -Wl,-z,relro -Wl,-z,now"
+Index: ntp-4.2.8p15/sntp/libevent/configure
+===================================================================
+--- ntp-4.2.8p15.orig/sntp/libevent/configure
++++ ntp-4.2.8p15/sntp/libevent/configure
+@@ -5047,9 +5047,8 @@ fi
+ # Check whether --enable-gcc-hardening was given.
+ if test "${enable_gcc_hardening+set}" = set; then :
+   enableval=$enable_gcc_hardening; if test x$enableval = xyes; then
+-    CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=2 -fstack-protector-all"
++    CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=2"
+     CFLAGS="$CFLAGS -fwrapv -fPIE -Wstack-protector"
+-    CFLAGS="$CFLAGS --param ssp-buffer-size=1"
+ fi
+ fi
+ 
+Index: ntp-4.2.8p15/sntp/libevent/configure.ac
+===================================================================
+--- ntp-4.2.8p15.orig/sntp/libevent/configure.ac
++++ ntp-4.2.8p15/sntp/libevent/configure.ac
+@@ -89,9 +89,8 @@ AC_ARG_ENABLE(gcc-warnings,
+ AC_ARG_ENABLE(gcc-hardening,
+      AS_HELP_STRING(--enable-gcc-hardening, enable compiler security checks),
+ [if test x$enableval = xyes; then
+-    CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=2 -fstack-protector-all"
++    CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=2 "
+     CFLAGS="$CFLAGS -fwrapv -fPIE -Wstack-protector"
+-    CFLAGS="$CFLAGS --param ssp-buffer-size=1"
+ fi])
+ 
+ AC_ARG_ENABLE(thread-support,


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
1. ntpd build error when ntp-utils option not selected.
2. if not select libssp , ntpd will build error "x86_64-openwrt-linux-uclibc/bin/ld: cannot find -lssp"