### PR TITLE
libroxml: import from base

### DIFF
--- a/libs/libroxml/Makefile
+++ b/libs/libroxml/Makefile
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libroxml
+PKG_VERSION:=3.0.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://download.libroxml.net/pool/v3.x
+PKG_HASH:=ed6d68d1bceabf98e5e76907411e2e4d93b2dbd48479ab41dede851f59dad6a3
+PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+PKG_LICENSE:=LGPL-2.1+
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libroxml
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Minimum, easy-to-use, C implementation for xml file parsing
+  URL:=http://www.libroxml.net/
+  ABI_VERSION:=3.0.2
+endef
+
+CONFIGURE_ARGS += \
+	--enable-shared \
+	--enable-static \
+	--disable-roxml
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)
+	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
+endef
+
+define Package/libroxml/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libroxml.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libroxml))

--- a/libs/libroxml/Makefile
+++ b/libs/libroxml/Makefile
@@ -9,36 +9,36 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libroxml
 PKG_VERSION:=3.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.libroxml.net/pool/v3.x
 PKG_HASH:=ed6d68d1bceabf98e5e76907411e2e4d93b2dbd48479ab41dede851f59dad6a3
-PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 
-PKG_INSTALL:=1
+PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=License.txt
+
+CMAKE_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_LICENSE:=LGPL-2.1+
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/libroxml
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Minimum, easy-to-use, C implementation for xml file parsing
   URL:=http://www.libroxml.net/
-  ABI_VERSION:=3.0.2
+  ABI_VERSION:=2
 endef
 
-CONFIGURE_ARGS += \
-	--enable-shared \
-	--enable-static \
-	--disable-roxml
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)
-	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
-endef
+CMAKE_OPTIONS += \
+	-DBUILD_TESTING=OFF \
+	-DCONFIG_XML_FILE=OFF \
+	-DCONFIG_XML_EDIT=OFF \
+	-DCONFIG_XML_COMMIT=OFF \
+	-DCONFIG_XML_XPATH=OFF
 
 define Package/libroxml/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/libs/libroxml/patches/010-gcc10.patch
+++ b/libs/libroxml/patches/010-gcc10.patch
@@ -1,0 +1,11 @@
+--- a/src/roxml_mem.h
++++ b/src/roxml_mem.h
+@@ -14,7 +14,7 @@
+ 
+ #include "roxml_internal.h"
+ 
+-memory_cell_t head_cell;
++extern memory_cell_t head_cell;
+ 
+ /** \brief alloc memory function
+  *


### PR DESCRIPTION
libroxml: import from base
libroxml: switch to CMake

Added patch to fix compilation with gcc10.

Fixed license information.

Fix ABI_VERSION.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nbd168 
Compile tested: ath79