### PR TITLE
coremark: allow to build with multithrading support

### DIFF
--- a/utils/coremark/Makefile
+++ b/utils/coremark/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=coremark
 PKG_SOURCE_DATE:=2020-09-16
 PKG_SOURCE_VERSION:=41537ea30b0104438b4ff993e7d349af26900acf
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_DATE).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eembc/coremark/tar.gz/$(PKG_SOURCE_VERSION)?
@@ -45,6 +45,20 @@ define Package/coremark/config
 		default y
 		help
 			This enables additional optmizations using the -O3 compilation flag.
+
+	config COREMARK_ENABLE_MULTITHREADING
+		bool "Enable multithreading support"
+		depends on PACKAGE_coremark
+		default n
+		help
+			This enables multithreading support
+
+	config COREMARK_NUMBER_OF_THREADS
+		int "Number of threads"
+		depends on COREMARK_ENABLE_MULTITHREADING
+		default 2
+		help
+			Number of threads to run in parallel
 endef
 
 TARGET_CFLAGS += -flto
@@ -53,12 +67,16 @@ ifeq ($(CONFIG_COREMARK_OPTIMIZE_O3),y)
 	TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS)) -O3
 endif
 
+ifeq ($(CONFIG_COREMARK_ENABLE_MULTITHREADING),y)
+	EXTRA_CFLAGS := -DMULTITHREAD=$(CONFIG_COREMARK_NUMBER_OF_THREADS) -DUSE_PTHREAD
+endif
+
 define Build/Compile
 	$(SED) 's|EXE = .exe|EXE =|' $(PKG_BUILD_DIR)/$(DIR_ARCH)/core_portme.mak
 	mkdir $(PKG_BUILD_DIR)/$(ARCH)
 	$(CP) -r $(PKG_BUILD_DIR)/$(DIR_ARCH)/* $(PKG_BUILD_DIR)/$(ARCH)
 	$(MAKE) -C $(PKG_BUILD_DIR) PORT_DIR=$(ARCH) $(MAKE_FLAGS) \
-		PORT_CFLAGS="$(TARGET_CFLAGS)" compile
+		PORT_CFLAGS="$(TARGET_CFLAGS)" XCFLAGS="$(EXTRA_CFLAGS)" compile
 endef
 
 define Package/coremark/install


### PR DESCRIPTION
Maintainer: @gwlim
Compile tested: (lantiq/xrx200, BT Home Hub 5A, snapshot)
Run tested: (lantiq/xrx200, BT Home Hub 5A, snapshot)

Description: This patch allows to build coremark with multithreading support.

Signed-off-by: Aleksander Jan Bajkowski <A.Bajkowski@stud.elka.pw.edu.pl>
