### PR TITLE
strongswan: add wolfssl plugin

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -89,6 +89,7 @@ PKG_MOD_AVAILABLE:= \
 	updown \
 	vici \
 	whitelist \
+	wolfssl \
 	x509 \
 	xauth-eap \
 	xauth-generic \
@@ -211,6 +212,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-updown \
 	+strongswan-mod-vici \
 	+strongswan-mod-whitelist \
+	+strongswan-mod-wolfssl \
 	+strongswan-mod-x509 \
 	+strongswan-mod-xauth-eap \
 	+strongswan-mod-xauth-generic \
@@ -692,6 +694,7 @@ $(eval $(call BuildPlugin,unity,Cisco Unity extension,))
 $(eval $(call BuildPlugin,updown,updown firewall,))
 $(eval $(call BuildPlugin,vici,Versatile IKE Configuration Interface,))
 $(eval $(call BuildPlugin,whitelist,peer identity whitelisting,))
+$(eval $(call BuildPlugin,wolfssl,WolfSSL crypto,+PACKAGE_strongswan-mod-wolfssl:libwolfssl))
 $(eval $(call BuildPlugin,x509,x509 certificate,))
 $(eval $(call BuildPlugin,xauth-eap,EAP XAuth backend,))
 $(eval $(call BuildPlugin,xauth-generic,generic XAuth backend,))


### PR DESCRIPTION
Maintainer: @stintel 
Compile tested: With gcc 7.5.0 on v19.07 x86_64-glibc and musl
Run tested: v19.07 x86_64 musl, gcc 7.5.0

Description: Adds WolfSSL module to strongswan

Verification:

```
root@OpenWrt:/# ipsec statusall
Status of IKE charon daemon (strongSwan 5.8.2, Linux 4.14.195, x86_64):
  uptime: 54 seconds, since Nov 27 21:31:04 2020
  worker threads: 11 of 16 idle, 5/0/0/0 working, job queue: 0/0/0/0, scheduled: 0
  loaded plugins: charon aes des rc2 sha2 sha1 md5 random nonce x509 revocation constraints pubkey pkcs1 pgp dnskey sshkey pem wolfssl fips-prf gmp xcbc hmac a
ttr kernel-netlink resolve socket-default connmark stroke updown xauth-generic
Listening IP addresses:
  192.168.1.1
  fdee:4407:1377::1
Connections:
Security Associations (0 up, 0 connecting):
  none
root@OpenWrt:/# ipsec listalgs

List of registered IKE algorithms:

  encryption: AES_CBC[aes] AES_ECB[aes] 3DES_CBC[des] DES_CBC[des] DES_ECB[des] RC2_CBC[rc2] AES_CTR[wolfssl]
              NULL[wolfssl]
  integrity:  HMAC_MD5_96[wolfssl] HMAC_MD5_128[wolfssl] HMAC_SHA1_96[wolfssl] HMAC_SHA1_128[wolfssl]
              HMAC_SHA1_160[wolfssl] HMAC_SHA2_256_128[wolfssl] HMAC_SHA2_256_256[wolfssl] HMAC_SHA2_384_192[wolfssl]
              HMAC_SHA2_384_384[wolfssl] HMAC_SHA2_512_256[wolfssl] HMAC_SHA2_512_512[wolfssl] AES_XCBC_96[xcbc]
  aead:       AES_GCM_16[wolfssl] AES_GCM_12[wolfssl] AES_CCM_16[wolfssl] AES_CCM_12[wolfssl] AES_CCM_8[wolfssl]
              CHACHA20_POLY1305[wolfssl]
  hasher:     HASH_SHA1[sha1] HASH_SHA2_224[sha2] HASH_SHA2_256[sha2] HASH_SHA2_384[sha2] HASH_SHA2_512[sha2]
              HASH_MD5[md5]
  prf:        PRF_KEYED_SHA1[sha1] PRF_HMAC_MD5[wolfssl] PRF_HMAC_SHA1[wolfssl] PRF_HMAC_SHA2_256[wolfssl]
              PRF_HMAC_SHA2_384[wolfssl] PRF_HMAC_SHA2_512[wolfssl] PRF_FIPS_SHA1_160[fips-prf] PRF_AES128_XCBC[xcbc]
  xof:       
  drbg:      
  dh-group:   ECP_256[wolfssl] ECP_384[wolfssl] ECP_521[wolfssl] ECP_224[wolfssl] ECP_192[wolfssl] MODP_3072[wolfssl]
              MODP_4096[wolfssl] MODP_2048[wolfssl] MODP_2048_224[wolfssl] MODP_2048_256[wolfssl] MODP_1536[wolfssl]
              MODP_1024[wolfssl] MODP_1024_160[wolfssl] MODP_768[wolfssl] MODP_CUSTOM[wolfssl] MODP_6144[gmp]
              MODP_8192[gmp]
  random-gen: RNG_WEAK[wolfssl] RNG_STRONG[random] RNG_TRUE[random]
  nonce-gen:  [nonce]
```