### PR TITLE
libusb-compat: fix libusb-config

### DIFF
--- a/libs/libusb-compat/Makefile
+++ b/libs/libusb-compat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libusb-compat
 PKG_VERSION:=0.1.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/libusb/libusb-compat-0.1/releases/download/v$(PKG_VERSION)
@@ -41,8 +41,13 @@ endef
 TARGET_CFLAGS += $(FPIC)
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(2)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/libusb-config $(2)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/libusb-config $(1)/usr/bin/
+	$(SED) \
+		's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' \
+		$(1)/usr/bin/libusb-config
+	$(INSTALL_DIR) $(2)/bin
+	$(LN) ../../usr/bin/libusb-config $(2)/bin/
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/usb.h $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
Turns out, some packages like serdisplib actually use libusb-config.
Fix the paths in it so that they can work properly. Method taken from
libpng.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nbd168 
Compile tested: ath79