### PR TITLE
update utils/jupp and utils/mksh to their current versions

### DIFF
--- a/utils/jupp/Makefile
+++ b/utils/jupp/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=jupp
-PKG_VERSION:=3.1.39
+PKG_VERSION:=3.1.40
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-1.0
 PKG_LICENSE_FILES:=COPYING
@@ -17,7 +17,7 @@ PKG_CONFIG_DEPENDS:=CONFIG_PACKAGE_libncurses
 PKG_SOURCE:=joe-$(basename ${PKG_VERSION})jupp$(subst .,,$(suffix ${PKG_VERSION})).tgz
 PKG_SOURCE_URL:=http://www.mirbsd.org/MirOS/dist/jupp/ \
 		http://pub.allbsd.org/MirOS/dist/jupp/
-PKG_HASH:=0d5d5b3c8e3db7b64410779fd4ccf962174ebac0c7e717674c780edf44d2fe91
+PKG_HASH:=4bed439cde7f2be294e96e49ef3e913ea90fbe5e914db888403e3a27e8035b1a
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/utils/mksh/Makefile
+++ b/utils/mksh/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mksh
-PKG_VERSION:=56c
+PKG_VERSION:=59c
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Thorsten Glaser <tg@mirbsd.org>, \
@@ -19,7 +19,7 @@ PKG_LICENSE:=MirOS
 PKG_SOURCE:=$(PKG_NAME)-R$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=http://www.mirbsd.org/MirOS/dist/mir/mksh \
 		http://pub.allbsd.org/MirOS/dist/mir/mksh
-PKG_HASH:=dd86ebc421215a7b44095dc13b056921ba81e61b9f6f4cdab08ca135d02afb77
+PKG_HASH:=77ae1665a337f1c48c61d6b961db3e52119b38e58884d1c89684af31f87bc506
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -42,7 +42,7 @@ derivate currently being actively developed.  It includes bug
 fixes and feature improvements, in order to produce a modern,
 robust shell good for interactive and especially script use.
 mksh has UTF-8 support (in substring operations and the Emacs
-editing mode) and - while R50 corresponds to OpenBSD 5.5-cur-
+editing mode) and - while R59 corresponds to OpenBSD 5.7-cur-
 rent ksh (without GNU bash-like PS1 and fancy character clas-
 ses) - adheres to SUSv4 and is much more robust. The code has
 been cleaned up and simplified, bugs fixed, standards compli-
@@ -65,11 +65,11 @@ define Build/Compile
 		CC="$(TARGET_CC)" \
 		TARGET_OS="$(shell uname -s)" \
 		CFLAGS="$(TARGET_CFLAGS)" \
-		CPPFLAGS="-DMKSH_SMALL=1 -DMKSH_ASSUME_UTF8=0 -DMKSH_BINSHPOSIX -DMKSHRC_PATH=\\\"/etc/mkshrc\\\"" \
+		CPPFLAGS="$(TARGET_CPPFLAGS) -DMKSH_SMALL=1 -DMKSH_ASSUME_UTF8=0 -DMKSH_BINSHPOSIX -DMKSHRC_PATH=\\\"/etc/mkshrc\\\"" \
 		HAVE_CAN_FSTACKPROTECTORALL=0 \
 		HAVE_CAN_FSTACKPROTECTORSTRONG=0 \
 		LDFLAGS="$(TARGET_LDFLAGS)" \
-			$(BASH) Build.sh -Q -r -c lto
+			$(BASH) Build.sh -Q -r
 endef
 
 define Package/mksh/postinst

--- a/utils/mksh/patches/100-dot_mkshrc
+++ b/utils/mksh/patches/100-dot_mkshrc
@@ -32,17 +32,16 @@ Signed-off-by: Alif M. A. <alive4ever at live.com>
 
 --- a/dot.mkshrc
 +++ b/dot.mkshrc
-@@ -63,10 +63,9 @@
+@@ -64,9 +64,9 @@
  	EDITOR=
  done
  
 -\\builtin alias ls=ls l='ls -F' la='l -a' ll='l -l' lo='l -alo'
--\: "${HOSTNAME:=$(\\builtin ulimit -c 0; \\builtin print -r -- $(hostname \
--    2>/dev/null))}${EDITOR:=/bin/ed}${TERM:=vt100}${USER:=$(\\builtin ulimit \
--    -c 0; id -un 2>/dev/null)}${USER:=?}"
+-\: "${EDITOR:=/bin/ed}${TERM:=vt100}${USER:=$(\\builtin ulimit -c 0; id -un \
+-    2>/dev/null)}${HOSTNAME:=$(\\builtin ulimit -c 0; hostname 2>/dev/null)}"
 +\\builtin alias ls=ls l='ls -F' la='l -a' ll='l -l' lo='l -al'
-+\: "${HOSTNAME:=$(</proc/sys/kernel/hostname)}${EDITOR:=/bin/vi}${TERM:=vt100}\
-+	${USER:=$(\\builtin ulimit -c 0; id -un 2>/dev/null)}${USER:=?}"
++\: "${EDITOR:=/bin/vi}${TERM:=vt100}${USER:=$(\\builtin ulimit -c 0; id -un \
++    2>/dev/null)}${HOSTNAME:=$(</proc/sys/kernel/hostname)}"
  [[ $HOSTNAME = ?(?(ip6-)localhost?(6)) ]] && HOSTNAME=nil; \\builtin unalias ls
- \\builtin export EDITOR HOSTNAME TERM USER
+ \\builtin export EDITOR HOSTNAME TERM USER="${USER:-?}"
  


### PR DESCRIPTION
Maintainer: me
Compile tested: MIPS malta, git head
Run tested: MIPS malta, git head

Description:

update utils/jupp and utils/mksh to their current versions

in mksh, also
- update description
- drop `-c lto`, this option is gone from `Build.sh`
- add missing `$(TARGET_CPPFLAGS)`