### PR TITLE
netdata: fix log spam caused by procfile

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
 PKG_VERSION:=1.29.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
 PKG_LICENSE:=GPL-3.0-or-later

--- a/admin/netdata/files/netdata.conf
+++ b/admin/netdata/files/netdata.conf
@@ -27,3 +27,6 @@
 
 [health]
 	enabled = no
+
+[plugin:proc:ipc]
+	shared memory totals = no


### PR DESCRIPTION
Maintainer: Josef Schlehofer <pepe.schlehofer@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
Compile tested: WRT3200ACM on latest trunk
Run tested: WRT3200ACM on latest trunk

Description:

Fix log spam:
daemon.err netdata[2090]: PROCFILE: Cannot open file '/proc/sysvipc/shm'
That's caused by a non existant /proc/sysvipc/shm