### PR TITLE
ddns-scripts: cloudflare: Add Authorization: Bearer header to allow authentication using API tokens

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
@@ -131,6 +131,7 @@ if [ "$username" = "Bearer" ]; then
 else
   __PRGBASE="$__PRGBASE --header 'X-Auth-Email: $username' "
   __PRGBASE="$__PRGBASE --header 'X-Auth-Key: $password' "
+  __PRGBASE="$__PRGBASE --header 'Authorization: Bearer $password' "
 fi
 __PRGBASE="$__PRGBASE --header 'Content-Type: application/json' "
 


### PR DESCRIPTION
Signed-off-by: gareth <gareth>

Parameters:
Lookup Hostname: <dyn-record>.<your-domain>
Domain: <dyn-record>@<your-domain>
Username: <email address of cloudflare account>
Password:The Global API Key / API Token