### PR TITLE
docker-ce: Added firewall.extra_iptables_args

### DIFF
--- a/utils/docker-ce/Makefile
+++ b/utils/docker-ce/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-ce
 PKG_VERSION:=19.03.13
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=components/cli/LICENSE components/engine/LICENSE
 

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -185,10 +185,12 @@ iptables_add_blocking_rule() {
 	local cfg="${1}"
 
 	local device=""
+	local extra_iptables_args=""
 
 	handle_iptables_rule() {
 		local interface="${1}"
 		local outbound="${2}"
+		local extra_iptables_args="${3}"
 
 		local inbound=""
 
@@ -200,9 +202,11 @@ iptables_add_blocking_rule() {
 			return
 		}
 
-		if ! iptables --table filter --check DOCKER-USER --in-interface "${inbound}" --out-interface "${outbound}" --jump DROP 2>/dev/null; then
+		# Ignore errors as it might already be present
+		iptables --table filter --new DOCKER-USER 2>/dev/null
+		if ! iptables --table filter --check DOCKER-USER --in-interface "${inbound}" --out-interface "${outbound}" ${extra_iptables_args} --jump DROP 2>/dev/null; then
 			logger -t "dockerd-init" -p notice "Drop traffic from ${inbound} to ${outbound}"
-			iptables --table filter --insert DOCKER-USER --in-interface "${inbound}" --out-interface "${outbound}" --jump DROP
+			iptables --table filter --insert DOCKER-USER --in-interface "${inbound}" --out-interface "${outbound}" ${extra_iptables_args} --jump DROP
 		fi
 	}
 
@@ -213,7 +217,8 @@ iptables_add_blocking_rule() {
 		return
 	}
 
-	config_list_foreach "${cfg}" blocked_interfaces handle_iptables_rule "${device}"
+	config_get extra_iptables_args "${cfg}" extra_iptables_args
+	config_list_foreach "${cfg}" blocked_interfaces handle_iptables_rule "${device}" "${extra_iptables_args}"
 }
 
 stop_service() {

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -23,11 +23,11 @@ boot() {
 }
 
 uciadd() {
-	local iface="$1"
-	local device="$2"
-	local zone="$3"
+	local iface="${1}"
+	local device="${2}"
+	local zone="${3}"
 
-	[ -z "$iface" ] && {
+	[ -z "${iface}" ] && {
 		iface="docker"
 		device="docker0"
 		zone="docker"
@@ -77,11 +77,11 @@ uciadd() {
 }
 
 ucidel() {
-	local iface="$1"
-	local device="$2"
-	local zone="$3"
+	local iface="${1}"
+	local device="${2}"
+	local zone="${3}"
 
-	[ -z "$iface" ] && {
+	[ -z "${iface}" ] && {
 		iface="docker"
 		device="docker0"
 		zone="docker"
@@ -182,20 +182,20 @@ service_triggers() {
 }
 
 iptables_add_blocking_rule() {
-	local cfg="$1"
+	local cfg="${1}"
 
 	local device=""
 
 	handle_iptables_rule() {
-		local interface="$1"
-		local outbound="$2"
+		local interface="${1}"
+		local outbound="${2}"
 
 		local inbound=""
 
 		. /lib/functions/network.sh
 		network_get_physdev inbound "${interface}"
 
-		[ -z "$inbound" ] && {
+		[ -z "${inbound}" ] && {
 			logger -t "dockerd-init" -p notice "Unable to get physical device for interface ${interface}"
 			return
 		}
@@ -206,14 +206,14 @@ iptables_add_blocking_rule() {
 		fi
 	}
 
-	config_get device "$cfg" device
+	config_get device "${cfg}" device
 
-	[ -z "$device" ] && {
+	[ -z "${device}" ] && {
 		logger -t "dockerd-init" -p notice "No device configured for ${cfg}"
 		return
 	}
 
-	config_list_foreach "$cfg" blocked_interfaces handle_iptables_rule "$device"
+	config_list_foreach "${cfg}" blocked_interfaces handle_iptables_rule "${device}"
 }
 
 stop_service() {

--- a/utils/docker-ce/files/etc/config/dockerd
+++ b/utils/docker-ce/files/etc/config/dockerd
@@ -1,7 +1,8 @@
-# The following settings require a restart to take full effect, A reload will
-# only have partial or no effect:
-# option bip
-# list blocked_interfaces
+# The following settings require a restart of docker to take full effect, A reload will only have partial or no effect:
+# bip
+# blocked_interfaces
+# extra_iptables_args
+# device
 
 config globals 'globals'
 #	option alt_config_file "/etc/docker/daemon.json"
@@ -13,8 +14,11 @@ config globals 'globals'
 #	list registry_mirrors "https://<my-docker-mirror-host>"
 #	list registry_mirrors "https://hub.docker.com"
 
-# Docker ignores fw3 rules and by default all external source IPs are allowed
-# to connect to the Docker host. See https://docs.docker.com/network/iptables/
+# Docker ignores fw3 rules and by default all external source IPs are allowed to connect to the Docker host.
+# See https://docs.docker.com/network/iptables/ for more details.
+# firewall config changes are only additive i.e firewall will need to be restarted first to clear old changes,
+# then docker restarted to load in new changes.
 config firewall 'firewall'
 	option device 'docker0'
 	list blocked_interfaces 'wan'
+#	option extra_iptables_args '--match conntrack ! --ctstate RELATED,ESTABLISHED' # allow outbound connections


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: x86_x64, Hyper-V, OpenWrt Master
Run tested: x86_x64, Hyper-V, OpenWrt Master

Description:
Added dockerd.firewall.extra_iptables_args

This is a convenience argument to primarily facilitate outbound wan
connections from a docker container. However, all docker containers still can't
bidirectionally communicate with the internet by default.

