### PR TITLE
ariang: add title and shortcut icons

### DIFF
--- a/net/ariang/Makefile
+++ b/net/ariang/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ariang
 PKG_VERSION:=1.1.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mayswind/AriaNg-DailyBuild/tar.gz/$(PKG_VERSION)?
@@ -55,7 +55,8 @@ define Package/ariang/install
 		$(PKG_BUILD_DIR)/index.html \
 		$(PKG_BUILD_DIR)/index.manifest \
 		$(PKG_BUILD_DIR)/LICENSE \
-		$(PKG_BUILD_DIR)/favicon.ico \
+		$(PKG_BUILD_DIR)/{favicon.*,*.png} \
+		$(PKG_BUILD_DIR)/robots.txt \
 		$(1)/www/ariang
 endef
 


### PR DESCRIPTION
Maintainer: @Ansuel @neheb
Compile tested: x86
Run tested: x86 with the Chrome browser

Description:

Before:
The shortcut icon for Chrome
![1](https://user-images.githubusercontent.com/30111323/100537122-bdf2fe80-3260-11eb-930d-31cda9c0e4f5.PNG)


There is no title icon for Chrome
![2](https://user-images.githubusercontent.com/30111323/100537200-54272480-3261-11eb-9cec-f325bfdf3c12.PNG)


After:
The shortcut icon for Chrome
![1-1](https://user-images.githubusercontent.com/30111323/100537113-afa4e280-3260-11eb-9932-b1e1be313600.PNG)

The title icon for Chrome
![2-1](https://user-images.githubusercontent.com/30111323/100537114-b16ea600-3260-11eb-8769-6b74b587ca37.PNG)

Signed-off-by: Van Waholtz <vanwaholtz@gmail.com>
