### PR TITLE
openssh: fix compilation

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
 PKG_VERSION:=8.4p1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
@@ -178,7 +178,7 @@ endif
 CONFIGURE_VARS += LD="$(TARGET_CC)"
 
 ifeq ($(BUILD_VARIANT),with-pam)
-TARGET_LDFLAGS += -lpthread
+TARGET_LDFLAGS += -L$(STAGING_DIR)/usr/lib -L$(STAGING_DIR)/lib -lpthread
 endif
 
 define Build/Compile


### PR DESCRIPTION
e52d0487e88c3c8c57e1310d1a02b18eae0d142e upstream removes a bunch of
needed LDFLAGS. Add them back.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 
Compile tested: powerpc