### PR TITLE
google-authenticator-libpam: fix compilation

### DIFF
--- a/libs/google-authenticator-libpam/Makefile
+++ b/libs/google-authenticator-libpam/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=google-authenticator-libpam
 PKG_VERSION:=1.09
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/google/google-authenticator-libpam/tar.gz/$(PKG_VERSION)?
@@ -36,8 +36,8 @@ define Package/google-authenticator-libpam/description
 endef
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/lib/security
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/security/* $(1)/lib/security/
+	$(INSTALL_DIR) $(1)/usr/lib/security
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/security/* $(1)/usr/lib/security/
 endef
 
 define Package/google-authenticator-libpam/install


### PR DESCRIPTION
e52d0487e88c3c8c57e1310d1a02b18eae0d142e upstream no longer add these
needed LDFLAGS. Add them back.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: powerpc