### PR TITLE
hplip: use libusb-compat

### DIFF
--- a/utils/hplip/Makefile
+++ b/utils/hplip/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hplip
 PKG_VERSION:=3.20.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/hplip
@@ -40,7 +40,7 @@ endef
 define Package/hplip-common
 $(call Package/hplip/Default)
   TITLE+= (common files)
-  DEPENDS+=+libusb-1.0
+  DEPENDS+=+libusb-compat
 endef
 
 define Package/hplip-common/description
@@ -72,7 +72,8 @@ CONFIGURE_ARGS += \
 	--disable-hpcups-install \
 	--disable-hpps-install \
 	--disable-cups-drv-install \
-	--enable-lite-build
+	--enable-lite-build \
+	--enable-libusb01_build
 
 define Build/Install
 	mkdir -p $(PKG_INSTALL_DIR)/usr/share/sane


### PR DESCRIPTION
Some change to base broke compilation. From looking at the CFLAGS,
hplip tries to use the host libusb.

libusb-compat seems to work properly. So use that.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @luizluca 
Compile tested: powerpc