### PR TITLE
hplip: move back to compiling with libusb

### DIFF
--- a/utils/hplip/Makefile
+++ b/utils/hplip/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hplip
 PKG_VERSION:=3.20.9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/hplip
@@ -40,7 +40,7 @@ endef
 define Package/hplip-common
 $(call Package/hplip/Default)
   TITLE+= (common files)
-  DEPENDS+=+libusb-compat
+  DEPENDS+=+libusb-1.0
 endef
 
 define Package/hplip-common/description
@@ -72,8 +72,7 @@ CONFIGURE_ARGS += \
 	--disable-hpcups-install \
 	--disable-hpps-install \
 	--disable-cups-drv-install \
-	--enable-lite-build \
-	--enable-libusb01_build
+	--enable-lite-build
 
 define Build/Install
 	mkdir -p $(PKG_INSTALL_DIR)/usr/share/sane

--- a/utils/hplip/patches/010-libusb_fix.patch
+++ b/utils/hplip/patches/010-libusb_fix.patch
@@ -1,3 +1,23 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -110,7 +110,7 @@ libhpmud_la_SOURCES += io/hpmud/musb_lib
+ libhpmud_la_LDFLAGS += -lusb
+ else
+ libhpmud_la_SOURCES += io/hpmud/musb.c 
+-libhpmud_la_CFLAGS  += -I/usr/include/libusb-1.0
++libhpmud_la_CFLAGS  += ${LIBUSB_1_0_CFLAGS}
+ libhpmud_la_LDFLAGS += -lusb-1.0
+ endif
+ 
+@@ -363,7 +363,7 @@ hpmudext_la_CFLAGS += -Iprotocol/discove
+ endif
+ 
+ if !LIBUSB01_BUILD
+-hpmudext_la_CFLAGS +=-I/usr/include/libusb-1.0 
++hpmudext_la_CFLAGS += ${LIBUSB_1_0_CFLAGS}
+ endif
+ endif #!HPLIP_CLASS_DRIVER
+ # ui (qt3)
 --- a/configure.in
 +++ b/configure.in
 @@ -601,6 +601,10 @@ if test "$class_driver" = "no" && test "

--- a/utils/hplip/patches/020-remove_cups_dep_on_scan.patch
+++ b/utils/hplip/patches/020-remove_cups_dep_on_scan.patch
@@ -1,7 +1,5 @@
-Index: hplip-3.20.9/Makefile.am
-===================================================================
---- hplip-3.20.9.orig/Makefile.am
-+++ hplip-3.20.9/Makefile.am
+--- a/Makefile.am
++++ b/Makefile.am
 @@ -71,7 +71,7 @@ else
  libsane_hpaio_la_LDFLAGS = -version-info 1:0:0
  endif
@@ -11,10 +9,8 @@ Index: hplip-3.20.9/Makefile.am
  #libsane_hpaio_la_CFLAGS = -DWITH_NONAMESPACES -DSOAP_DEBUG
  libsane_hpaio_la_CFLAGS = $(DBUS_CFLAGS) -Iprotocol
  
-Index: hplip-3.20.9/scan/sane/hpaio.c
-===================================================================
---- hplip-3.20.9.orig/scan/sane/hpaio.c
-+++ hplip-3.20.9/scan/sane/hpaio.c
+--- a/scan/sane/hpaio.c
++++ b/scan/sane/hpaio.c
 @@ -34,9 +34,7 @@
  #include <stdio.h>
  #include <stdlib.h>

--- a/utils/hplip/patches/030-replace_unsafe_memcpy_with_memmove.patch
+++ b/utils/hplip/patches/030-replace_unsafe_memcpy_with_memmove.patch
@@ -4,7 +4,7 @@ memcpy should never be used with overlapping memory regions
 
 --- a/io/hpmud/musb.c
 +++ b/io/hpmud/musb.c
-@@ -775,7 +775,7 @@ static int device_id(int fd, unsigned char *buffer, int size)
+@@ -775,7 +775,7 @@ static int device_id(int fd, unsigned ch
          len = size-1;   /* leave byte for zero termination */
      if (len > 2)
          len -= 2;

--- a/utils/hplip/patches/050-fix-glibcisms.patch
+++ b/utils/hplip/patches/050-fix-glibcisms.patch
@@ -1,5 +1,3 @@
-diff --git a/scan/sane/OrbliteScan/LinuxCommon.h b/scan/sane/OrbliteScan/LinuxCommon.h
-index 6605dd9..55c7110 100644
 --- a/scan/sane/OrbliteScan/LinuxCommon.h
 +++ b/scan/sane/OrbliteScan/LinuxCommon.h
 @@ -18,10 +18,8 @@ typedef u_int32_t			UInt32;


### PR DESCRIPTION
Some change in base broke compilation with libusb and this package.
From looking at it more carefully, it turns out that the libusb patch
needs to be updated so that host paths are not used.

libusb-compat also depends on libusb, which increases the overall
installed size.

Refreshed patches with make package/hplip/refresh .

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @luizluca 
Compile tested: ath79
