### PR TITLE
gphoto2: update to 2.5.26

### DIFF
--- a/multimedia/gphoto2/Makefile
+++ b/multimedia/gphoto2/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gphoto2
-PKG_VERSION:=2.5.23
-PKG_RELEASE:=2
+PKG_VERSION:=2.5.26
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/gphoto
-PKG_HASH:=df87092100e7766c9d0a4323217c91908a9c891c0d3670ebf40b76903be458d1
+PKG_HASH:=7653213b05329c1dc2779efea3eff00504e12011436587aedc9aaa1e8665ab2f
 
 PKG_MAINTAINER:=Leonardo Medici <leonardo_medici@me.com>
 PKG_LICENSE:=GPL-2.0
@@ -43,12 +43,8 @@ CONFIGURE_ARGS += \
 	--without-aalib
 
 CONFIGURE_VARS += \
-	LIBGPHOTO2_CFLAGS="$$$$CFLAGS -I$(STAGING_DIR)/usr/include/gphoto2 $$$$CPPFLAGS" \
-	LIBGPHOTO2_LIBS="$$$$LDFLAGS -lgphoto2 -lgphoto2_port -lltdl" \
-	LIBEXIF_CFLAGS="$$$$CFLAGS $$$$CPPFLAGS" \
-	LIBEXIF_LIBS="$$$$LDFLAGS -lexif" \
-	POPT_CFLAGS="$$$$CFLAGS $$$$CPPFLAGS" \
-	POPT_LIBS="$$$$LDFLAGS -lpopt" \
+	POPT_CFLAGS="-I$(STAGING_DIR)/usr/include" \
+	POPT_LIBS="-L$(STAGING_DIR)/usr/lib -lpopt"
 
 define Package/gphoto2/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/multimedia/gphoto2/patches/001-automake-compat.patch
+++ b/multimedia/gphoto2/patches/001-automake-compat.patch
@@ -19,7 +19,7 @@
  all: config.h
 --- a/configure.ac
 +++ b/configure.ac
-@@ -58,10 +58,7 @@ dnl ---------------------------------------------------------------------------
+@@ -58,10 +58,7 @@ dnl ------------------------------------
  GP_GETTEXT_HACK([],[Lutz Müller and others],[${MAIL_GPHOTO_TRANSLATION}])
  ALL_LINGUAS="az cs da de en_GB es eu fi fr hu id is it ja nl pa pl pt_BR ro ru rw sk sr sv uk vi zh_CN zh_TW"
  AM_GNU_GETTEXT_VERSION([0.14.1])


### PR DESCRIPTION
Remove several unneeded configure hacks.

Replace the POPT ones with more sensible ones.

Refresh patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @DocLM 
Compile tested: ath79