### PR TITLE
modemmanager: bump to 1.14.8

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
-PKG_VERSION:=1.14.6
-PKG_RELEASE:=3
+PKG_VERSION:=1.14.8
+PKG_RELEASE:=1
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
-PKG_HASH:=783d5da925b2ca69f6233fcead691dd0f5cba06aa479d71495efdc07053fc0fd
+PKG_HASH:=fe1a26ba51b4bda7abd09ad4dadedd87d8b8154809fc9d88e94f75fdfff19295
 PKG_BUILD_DIR:=$(BUILD_DIR)/ModemManager-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
@@ -22,7 +22,6 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_DEPENDS:=libxslt/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk


### PR DESCRIPTION
Signed-off-by: Nicholas Smith <nicholas.smith@telcoantennas.com.au>

Maintainer: me
Compile tested: ath79 Telco T1
Run tested: ath79 Telco T1 ran basic tests

Description: 
```
Overview of changes in ModemManager 1.14.8
-------------------------------------------

 * Build:
   ** Fixed distcheck with new gtk-doc releases.
   ** ModemManager-names.h was being included in the dist tarball, but then
      removed on the 'clean' target. Fix that, by only removing it on the
      'maintainer-clean' target. Therefore, 'xsltproc' is now only needed in
      git builds, not needed when building from a dist tarball.

 * QMI:
   ** Fix daemon crash when the device is removed during the initialization
      sequence.

 * Several other minor improvements and fixes.
```

https://lists.freedesktop.org/archives/modemmanager-devel/2020-November/008279.html