### PR TITLE
libpam: update to 1.5.1

### DIFF
--- a/libs/libpam/Makefile
+++ b/libs/libpam/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpam
-PKG_VERSION:=1.5.0
+PKG_VERSION:=1.5.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=Linux-PAM-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/linux-pam/linux-pam/releases/download/v$(PKG_VERSION)
-PKG_HASH:=02d39854b508fae9dc713f7733bbcdadbe17b50de965aedddd65bcb6cc7852c8
+PKG_HASH:=201d40730b1135b1b3cdea09f2c28ac634d73181ccd0172ceddee3649c5792fc
 PKG_BUILD_DIR:=$(BUILD_DIR)/Linux-PAM-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
@@ -22,8 +22,8 @@ PKG_LICENSE_FILES:=COPYING Copyright
 PKG_CPE_ID:=cpe:/a:kernel:linux-pam
 
 PKG_FIXUP:=autoreconf
-PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -60,21 +60,21 @@ CONFIGURE_ARGS += \
 	--without-xauth
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/lib
 	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/lib/* $(1)/lib/
+	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
 endef
 
 define Package/libpam/install
-	$(INSTALL_DIR) $(1)/lib $(1)/lib/security $(1)/lib/security/pam_filter
 	$(INSTALL_DIR) $(1)/etc $(1)/etc/pam.d
+	$(INSTALL_DIR) $(1)/usr/lib $(1)/usr/lib/security $(1)/usr/lib/security/pam_filter
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(CP) $(PKG_INSTALL_DIR)/lib/*.so* $(1)/lib/
-	$(CP) $(PKG_INSTALL_DIR)/lib/security/*.so* $(1)/lib/security/
-	$(CP) $(PKG_INSTALL_DIR)/lib/security/pam_filter/* $(1)/lib/security/pam_filter/
 	$(CP) $(PKG_INSTALL_DIR)/etc/* $(1)/etc/
 	$(CP) ./files/* $(1)/etc/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/security/*.so* $(1)/usr/lib/security/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/security/pam_filter/* $(1)/usr/lib/security/pam_filter/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/* $(1)/usr/sbin/
 endef
 

--- a/libs/libpam/patches/0001-build-always-use-lib-instead-of-lib64.patch
+++ b/libs/libpam/patches/0001-build-always-use-lib-instead-of-lib64.patch
@@ -1,36 +1,11 @@
-From 1948dd03d69c1a50e92d7e8868b7d6eabd4873c1 Mon Sep 17 00:00:00 2001
-From: Yousong Zhou <yszhou4tech@gmail.com>
-Date: Wed, 17 Jun 2015 16:11:31 +0800
-Subject: [PATCH 1/7] build: always use /lib instead of /lib64.
-
-* configure.ac: OpenWrt does not use /lib64.
-
-Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
----
- configure.ac |   10 +---------
- 1 file changed, 1 insertion(+), 9 deletions(-)
-
-diff --git a/configure.ac b/configure.ac
-index fd0e310..306b6e2 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -25,15 +25,7 @@ dnl If we use /usr as prefix, use /etc for config files
+@@ -25,7 +25,7 @@ dnl If we use /usr as prefix, use /etc f
          then
                  sysconfdir="/etc"
          fi
 -	if test ${libdir} = '${exec_prefix}/lib'
--	then
--		case "$host_cpu" in
--		    x86_64|ppc64|s390x|sparc64)
--			libdir="/lib64" ;;
--		    *)
--			libdir="/lib" ;;
--		esac
--	fi
-+	libdir="/lib"
- 	if test ${sbindir} = '${exec_prefix}/sbin'
-         then
-                 sbindir="/sbin"
--- 
-1.7.10.4
-
++	if false
+ 	then
+ 		case "$host_cpu" in
+ 		    x86_64|ppc64|s390x|sparc64)


### PR DESCRIPTION
Fix installed paths. After e52d0487e88c3c8c57e1310d1a02b18eae0d142e
upstream, this bug was exposed.

Instead of working around it, fix the patch.

After this, everything consistently gets installed to ipkg-install/usr.

Minor Makefile reorganization.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nmav 
Compile tested: ath79