### PR TITLE
uvcdynctrl: remove libwebcam

### DIFF
--- a/utils/uvcdynctrl/Makefile
+++ b/utils/uvcdynctrl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uvcdynctrl
 PKG_VERSION:=0.2.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=libwebcam-src-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/libwebcam
@@ -17,7 +17,9 @@ PKG_HASH:=3ca5199c7b8398b655a7c38e3ad4191bb053b1486503287f20d30d141bda9d41
 PKG_BUILD_DIR:=$(BUILD_DIR)/libwebcam-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
-CMAKE_INSTALL:=1
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=uvcdynctrl/COPYING
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -26,10 +28,8 @@ include $(INCLUDE_DIR)/nls.mk
 define Package/uvcdynctrl
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libwebcam
+  DEPENDS:=+libxml2 $(ICONV_DEPENDS)
   TITLE:=Manage dynamic controls in uvcvideo
-  LICENSE:=GPL-3.0-or-later
-  LICENSE_FILES:=uvcdynctrl/COPYING
   URL:=https://sourceforge.net/projects/libwebcam/
   MENU:=1
 endef
@@ -40,30 +40,10 @@ define Package/uvcdynctrl/description
   - uvcdynctrl: Manage dynamic controls in uvcvideo (GPL)
 endef
 
-define Package/libwebcam
-  SECTION:=libs
-  CATEGORY:=Libraries
-  DEPENDS:=+libxml2 $(ICONV_DEPENDS)
-  TITLE:=Webcam library
-  LICENSE:=LGPL-3.0-or-later
-  LICENSE_FILES:=libwebcam/COPYING.LESSER
-  URL:=https://sourceforge.net/projects/libwebcam/
-endef
-
-define Package/libwebcam/description
-  $(call Package/uvcdynctrl/description)
-endef
-
 define Package/uvcdynctrl/install
 	$(INSTALL_DIR) $(1)/usr/{bin,share}
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/uvcdynctrl* $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/uvcdynctrl/ $(1)/usr/share/
 endef
 
-define Package/libwebcam/install
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libwebcam.so* $(1)/usr/lib/
-endef
-
 $(eval $(call BuildPackage,uvcdynctrl))
-$(eval $(call BuildPackage,libwebcam))

--- a/utils/uvcdynctrl/patches/020-static.patch
+++ b/utils/uvcdynctrl/patches/020-static.patch
@@ -1,0 +1,11 @@
+--- a/uvcdynctrl/CMakeLists.txt
++++ b/uvcdynctrl/CMakeLists.txt
+@@ -77,7 +77,7 @@ include_directories (../common/include)
+ include_directories (${CMAKE_CURRENT_BINARY_DIR})
+ link_directories (${LIBWEBCAM_BINARY_DIR}/webcam)
+ 
+-target_link_libraries (uvcdynctrl webcam iconv)
++target_link_libraries (uvcdynctrl webcam_static iconv)
+ 
+ # Compiler flags
+ set_target_properties (uvcdynctrl PROPERTIES


### PR DESCRIPTION
It's useless and it's only used by this package. Just link it
statically.

Remove CMAKE_INSTALL as InstallDev section is gone.

Add PKG_BUILD_PARALLEL for faster compilation.

Put license information up as there are no longer 2 packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @roger- 
Compile tested: powerpc