### PR TITLE
gpsd: fix compilation under some setups

### DIFF
--- a/utils/gpsd/Makefile
+++ b/utils/gpsd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gpsd
 PKG_VERSION:=3.21
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SAVANNAH/$(PKG_NAME)
@@ -104,6 +104,7 @@ SCONS_OPTIONS += \
 	implicit_link=no \
 	chrpath=no \
 	manbuild=no \
+	sysroot="$(STAGING_DIR)" \
 	target="$(TARGET_CROSS:-=)"
 
 define Build/InstallDev


### PR DESCRIPTION
Some commit in base broke compilation. Adding sysroot fixes it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @psidhu 
Compile tested: ath79