### PR TITLE
crelay: backport patch for use gpio >255

### DIFF
--- a/utils/crelay/Makefile
+++ b/utils/crelay/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crelay
 PKG_VERSION:=0.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ondrej1024/crelay/tar.gz/V$(PKG_VERSION)?

--- a/utils/crelay/patches/011-support-gpio-with-number-bigger-than-255.patch
+++ b/utils/crelay/patches/011-support-gpio-with-number-bigger-than-255.patch
@@ -1,0 +1,92 @@
+From 30a2323bc0a95cda4eca818fe1d523a2e5c031f3 Mon Sep 17 00:00:00 2001
+From: Pawel Dembicki <paweldembicki@gmail.com>
+Date: Mon, 2 Nov 2020 14:50:34 +0100
+Subject: [PATCH] support gpio with number bigger than 255
+
+Change 8-bit gpio value to 16-bit, which allow to use gpio >255.
+
+Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
+---
+ src/data_types.h     | 16 ++++++++--------
+ src/relay_drv_gpio.c | 10 +++++-----
+ 2 files changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/src/data_types.h b/src/data_types.h
+index f13baeb..d4dc7b1 100644
+--- a/src/data_types.h
++++ b/src/data_types.h
+@@ -56,14 +56,14 @@ typedef struct
+     /* [GPIO drv] */
+     uint8_t gpio_num_relays;
+     uint8_t gpio_active_value;
+-    uint8_t relay1_gpio_pin;
+-    uint8_t relay2_gpio_pin;
+-    uint8_t relay3_gpio_pin;
+-    uint8_t relay4_gpio_pin;
+-    uint8_t relay5_gpio_pin;
+-    uint8_t relay6_gpio_pin;
+-    uint8_t relay7_gpio_pin;
+-    uint8_t relay8_gpio_pin;
++    uint16_t relay1_gpio_pin;
++    uint16_t relay2_gpio_pin;
++    uint16_t relay3_gpio_pin;
++    uint16_t relay4_gpio_pin;
++    uint16_t relay5_gpio_pin;
++    uint16_t relay6_gpio_pin;
++    uint16_t relay7_gpio_pin;
++    uint16_t relay8_gpio_pin;
+     
+     /* [Sainsmart drv] */
+     uint8_t sainsmart_num_relays;
+diff --git a/src/relay_drv_gpio.c b/src/relay_drv_gpio.c
+index 705c157..28464be 100644
+--- a/src/relay_drv_gpio.c
++++ b/src/relay_drv_gpio.c
+@@ -53,7 +53,7 @@
+ #define GPIO_BASE_FILE GPIO_BASE_DIR"gpio"
+ 
+ 
+-static uint8_t pins[] =
++static uint16_t pins[] =
+ {
+   0, // dummy
+   0, // pin 1
+@@ -85,7 +85,7 @@ int set_relay_generic_gpio(char* portname, uint8_t relay, relay_state_t relay_st
+  *         -1 - fail
+  *         -2 - already exported
+  *********************************************************/
+-static int do_export(uint8_t pin)
++static int do_export(uint16_t pin)
+ {
+    int fd;
+    char b[64];
+@@ -151,7 +151,7 @@ static int do_export(uint8_t pin)
+  * Return:  0 - success
+  *         -1 - fail
+  *********************************************************/
+-static int do_unexport(uint8_t pin)
++static int do_unexport(uint16_t pin)
+ {
+    int fd;
+    char b[64];
+@@ -261,7 +261,7 @@ int get_relay_generic_gpio(char* portname, uint8_t relay, relay_state_t* relay_s
+    int fd;
+    char b[64];
+    char d[1];
+-   uint8_t pin;
++   uint16_t pin;
+ 
+    if (relay<FIRST_RELAY || relay>(FIRST_RELAY+g_num_relays-1))
+    {
+@@ -324,7 +324,7 @@ int set_relay_generic_gpio(char* portname, uint8_t relay, relay_state_t relay_st
+    int fd;
+    char b[64];
+    char d[1];
+-   uint8_t pin;
++   uint16_t pin;
+    
+    if (relay<FIRST_RELAY || relay>(FIRST_RELAY+g_num_relays-1))
+    {
+-- 
+2.17.1
+


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: Layerscape LS1012A-RDB
Run tested: Layerscape LS1012A-RDB 

I sent patch upstream and was accepted. It allows to use gpio with number bigger than 255.
