### PR TITLE
syslog-ng: update to version 3.30.1

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
-PKG_VERSION:=3.29.1
-PKG_RELEASE:=3
+PKG_VERSION:=3.30.1
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later
@@ -11,7 +11,7 @@ PKG_CPE_ID:=cpe:/a:balabit:syslog-ng
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syslog-ng/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
-PKG_HASH:=5cd6b65466671ec5b793fc703a515e07e0da39b79190b2a3c89af176d07e89fd
+PKG_HASH:=44e54a6186af14d01affa06bf7391cfe8fc2460bd4ba211aab5469d8b1ca5b4b
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1

--- a/admin/syslog-ng/files/syslog-ng.conf
+++ b/admin/syslog-ng/files/syslog-ng.conf
@@ -4,7 +4,7 @@
 # More details about these settings can be found here:
 # https://www.syslog-ng.com/technical-documents/list/syslog-ng-open-source-edition
 
-@version: 3.29
+@version: 3.30
 @include "scl.conf"
 
 options {


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris 1.x, powerpc 8540, OpenWrt 19.07
Run tested: Turris 1.x, powerpc 8540, OpenWrt 19.07

Description:
- update to version [3.30.1](https://github.com/syslog-ng/syslog-ng/releases/tag/syslog-ng-3.30.1)