### PR TITLE
ksmbd and ksmbd-tools 3.3.1

### DIFF
--- a/kernel/ksmbd/Makefile
+++ b/kernel/ksmbd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd
-PKG_VERSION:=3.2.5
+PKG_VERSION:=3.3.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/cifsd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=b93a068f6dc2b2040c8cebcb67f6d8c3a1c5c7c5032269a48579ccba996e6be7
+PKG_HASH:=bfee16468ef8c0ed35c07ed5c507826fdb33d4b934c0ec706ade439711f0985a
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -37,7 +37,8 @@ define KernelPackage/fs-ksmbd
 		+kmod-crypto-sha512 \
 		+kmod-crypto-aead \
 		+kmod-crypto-ccm \
-		+kmod-crypto-gcm
+		+kmod-crypto-gcm \
+		+kmod-lib-crc32c
 endef
 
 define KernelPackage/fs-ksmbd/description

--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
-PKG_VERSION:=3.2.6
+PKG_VERSION:=3.3.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/ksmbd-tools/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=595029adb899fd8b4c49bea75bce4e3c3466811ef7089b2a55960174e720d919
+PKG_HASH:=0831677c5ccb91ba38c764ad22577830650a78300a676c2e7bb1baecadbdf725
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: @Andy2244
Compile tested: mips, lantiq
Run tested: lantiq BT Home Hub 5A

Description:
Updates ksmbd and ksmbd-tools to the latest upstream version, which is 3.3.1 (for both packages)
Upstream changelogs are included in the commit for each package