### PR TITLE
lighttpd: meson.build linker fix for TLS modules

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.56
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 # release candidate ~rcX testing; remove for release
 #PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-1.4.56
 

--- a/net/lighttpd/patches/040-meson-tls.patch
+++ b/net/lighttpd/patches/040-meson-tls.patch
@@ -1,0 +1,89 @@
+From 233a218ab3cf449a0667438cf0b1830eeb33471b Mon Sep 17 00:00:00 2001
+From: Glenn Strauss <gstrauss@gluelogic.com>
+Date: Thu, 3 Dec 2020 17:16:52 -0500
+Subject: [PATCH] [build] fix meson.build when building all TLS mods
+
+x-ref:
+  "[lighttpd] -mod-openssl fails"
+  https://github.com/openwrt/packages/issues/14121
+  "[lighttpd] -mod-wolfssl fails"
+  https://github.com/openwrt/packages/issues/14122
+
+Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
+---
+ src/meson.build | 20 +++++++++++++-------
+ 1 file changed, 13 insertions(+), 7 deletions(-)
+
+diff --git a/src/meson.build b/src/meson.build
+index 71e4ec90..2d6ee2df 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -432,15 +432,20 @@ if get_option('with_mysql')
+ endif
+ 
+ libssl = []
+-libx509 = []
+ libcrypto = []
++libsslcrypto = []
+ libgnutls = []
++libmbedtls = []
++libmbedcrypto = []
++libmbedx509 = []
++libwolfssl = []
+ if get_option('with_openssl')
+ 	# manual search:
+ 	# header: openssl/ssl.h
+ 	# function: SSL_new (-lssl)
+ 	# function: BIO_f_base64 (-lcrypto)
+ 	libssl = [ dependency('libssl') ]
++	libsslcrypto = [ dependency('libcrypto') ]
+ 	libcrypto = [ dependency('libcrypto') ]
+ 	conf_data.set('HAVE_OPENSSL_SSL_H', true)
+ 	conf_data.set('HAVE_LIBSSL', true)
+@@ -449,7 +454,7 @@ if get_option('with_wolfssl')
+ 	# manual search:
+ 	# header: wolfssl/ssl.h
+ 	# function: wolfSSL_Init (-lwolfssl)
+-	libssl = [ dependency('wolfssl') ]
++	libwolfssl = [ dependency('wolfssl') ]
+ 	libcrypto = [ dependency('wolfssl') ]
+ 	conf_data.set('HAVE_WOLFSSL_SSL_H', true)
+ endif
+@@ -459,8 +464,9 @@ if get_option('with_mbedtls')
+ 	# function: mbedtls_cipher_info_from_type (-lmbedtls)
+ 	# function: mbedtls_x509_get_name (-lmbedx509)
+ 	# function: mbedtls_base64_encode (-lmbedcrypto)
+-	libssl = [ compiler.find_library('mbedtls') ]
+-	libx509 = [ compiler.find_library('mbedx509') ]
++	libmbedtls = [ compiler.find_library('mbedtls') ]
++	libmbedx509 = [ compiler.find_library('mbedx509') ]
++	libmbedcrypto = [ compiler.find_library('mbedcrypto') ]
+ 	libcrypto = [ compiler.find_library('mbedcrypto') ]
+ 	conf_data.set('HAVE_LIBMBEDCRYPTO', true)
+ endif
+@@ -1070,19 +1076,19 @@ endif
+ 
+ if get_option('with_openssl')
+ 	modules += [
+-		[ 'mod_openssl', [ 'mod_openssl.c' ], libssl + libcrypto ],
++		[ 'mod_openssl', [ 'mod_openssl.c' ], libssl + libsslcrypto ],
+ 	]
+ endif
+ 
+ if get_option('with_wolfssl')
+ 	modules += [
+-		[ 'mod_wolfssl', [ 'mod_wolfssl.c' ], libcrypto ],
++		[ 'mod_wolfssl', [ 'mod_wolfssl.c' ], libwolfssl ],
+ 	]
+ endif
+ 
+ if get_option('with_mbedtls')
+ 	modules += [
+-		[ 'mod_mbedtls', [ 'mod_mbedtls.c' ], libssl + libx509 + libcrypto ],
++		[ 'mod_mbedtls', [ 'mod_mbedtls.c' ], libmbedtls + libmbedx509 + libmbedcrypto ],
+ 	]
+ endif
+ 
+-- 
+2.28.0
+


### PR DESCRIPTION
Maintainer: W. Michael Petullo mike@flyn.org
Compile tested: x86-64 OpenWrt master branch (v19.07.4)

Description:
lighttpd: meson.build linker fix for TLS modules

Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>

Fixes #14121 and #14122 