### PR TITLE
Add support to darkstat to allow multiple local networks to be specified for montioring

### DIFF
--- a/net/darkstat/Makefile
+++ b/net/darkstat/Makefile
@@ -1,7 +1,7 @@
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
-#
+# 
 
 include $(TOPDIR)/rules.mk
 

--- a/net/darkstat/Makefile
+++ b/net/darkstat/Makefile
@@ -1,13 +1,13 @@
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
-# 
+#
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=darkstat
 PKG_VERSION:=3.0.719
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_MAINTAINER:=Jean-Michel Lacroix <lacroix@lepine-lacroix.info>
 

--- a/net/darkstat/patches/101-allow-multiple-local-interfaces.patch
+++ b/net/darkstat/patches/101-allow-multiple-local-interfaces.patch
@@ -1,0 +1,70 @@
+--- a/acct.c
++++ b/acct.c
+@@ -37,8 +37,9 @@
+ 
+ uint64_t acct_total_packets = 0, acct_total_bytes = 0;
+ 
++#define LOCAL_NET_MAX 10
+ static int using_localnet4 = 0, using_localnet6 = 0;
+-static struct addr localnet4, localmask4, localnet6, localmask6;
++static struct addr localnet4[LOCAL_NET_MAX], localmask4[LOCAL_NET_MAX], localnet6[LOCAL_NET_MAX], localmask6[LOCAL_NET_MAX];
+ 
+ /* Parse the net/mask specification into two IPs or die trying. */
+ void
+@@ -120,13 +121,19 @@ acct_init_localnet(const char *spec)
+    /* Register the correct netmask and calculate the correct net.  */
+    addr_mask(&localnet, &localmask);
+    if (localnet.family == IPv6) {
+-      using_localnet6 = 1;
+-      localnet6 = localnet;
+-      localmask6 = localmask;
++      if(using_localnet6 >= LOCAL_NET_MAX){
++	errx(1, "Exceeded maximum IPv6 local networks");
++      }
++      localnet6[using_localnet6] = localnet;
++      localmask6[using_localnet6] = localmask;
++      using_localnet6++;
+    } else {
+-      using_localnet4 = 1;
+-      localnet4 = localnet;
+-      localmask4 = localmask;
++      if(using_localnet4 >= LOCAL_NET_MAX){
++	errx(1, "Exceeded maximum IPv4 local networks");
++      }
++      localnet4[using_localnet4] = localnet;
++      localmask4[using_localnet4] = localmask;
++      using_localnet4++;
+    }
+ 
+    verbosef("local network address: %s", addr_to_str(&localnet));
+@@ -138,11 +145,15 @@ static int addr_is_local(const struct addr * const a,
+    if (is_localip(a, local_ips))
+       return 1;
+    if (a->family == IPv4 && using_localnet4) {
+-      if (addr_inside(a, &localnet4, &localmask4))
+-         return 1;
++      for (int i=0; i < using_localnet4; i++){	   
++        if (addr_inside(a, &localnet4[i], &localmask4[i]))
++           return 1;
++      }
+    } else if (a->family == IPv6 && using_localnet6) {
+-      if (addr_inside(a, &localnet6, &localmask6))
+-         return 1;
++      for (int i=0; i < using_localnet6; i++){	   
++        if (addr_inside(a, &localnet6[i], &localmask6[i]))
++           return 1;
++      }
+    }
+    return 0;
+ }
+--- a/darkstat.c
++++ b/darkstat.c
+@@ -193,7 +193,7 @@ static struct cmdline_arg cmdline_args[] = {
+    {"-r",             "capfile",         cb_capfile,      0},
+    {"-p",             "port",            cb_port,         0},
+    {"-b",             "bindaddr",        cb_bindaddr,    -1},
+-   {"-l",             "network/netmask", cb_local,        0},
++   {"-l",             "network/netmask", cb_local,       -1},
+    {"--base",         "path",            cb_base,         0},
+    {"--local-only",   NULL,              cb_local_only,   0},
+    {"--snaplen",      "bytes",           cb_snaplen,      0},


### PR DESCRIPTION
specified for montioring

eg allows ipv4 and ipv6 forwarded traffic to be monitored from both main network and dmz in single graph

Maintainer: @padre-lacroix  (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
Add support to darkstat to allow multiple local networks to be specified for montioring

eg allows ipv4 and ipv6 forwarded traffic to be monitored from both main network and dmz in single graph

patched provided to package developer and acknowledged, but no schedule give for when they might be able to to add it to the base package

addresses: https://github.com/openwrt/packages/issues/14113