### PR TITLE
lighttpd: wolfssl TLS compat module detection

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.56
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 # release candidate ~rcX testing; remove for release
 #PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-1.4.56
 

--- a/net/lighttpd/patches/050-wolfssl-compat.patch
+++ b/net/lighttpd/patches/050-wolfssl-compat.patch
@@ -1,0 +1,32 @@
+From a27e55b2dd0887f462c36ff788dde5c5de20a154 Mon Sep 17 00:00:00 2001
+From: Glenn Strauss <gstrauss@gluelogic.com>
+Date: Sat, 5 Dec 2020 11:19:03 -0500
+Subject: [PATCH] [core] add missing mod_wolfssl to ssl compat list
+
+add missing mod_wolfssl to ssl compat module list
+
+x-ref:
+  "[lighttpd] -mod-wolfssl fails (requires dependency on -mod-openssl?)"
+  https://github.com/openwrt/packages/issues/14139
+
+Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
+---
+ src/configfile.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/configfile.c b/src/configfile.c
+index da444154..c7739c4f 100644
+--- a/src/configfile.c
++++ b/src/configfile.c
+@@ -345,6 +345,8 @@ static void config_compat_module_load (server *srv) {
+             append_mod_openssl = 0;
+         else if (buffer_eq_slen(m, CONST_STR_LEN("mod_openssl")))
+             append_mod_openssl = 0;
++        else if (buffer_eq_slen(m, CONST_STR_LEN("mod_wolfssl")))
++            append_mod_openssl = 0;
+         else if (buffer_eq_slen(m, CONST_STR_LEN("mod_authn_file")))
+             append_mod_authn_file = 0;
+         else if (buffer_eq_slen(m, CONST_STR_LEN("mod_authn_ldap")))
+-- 
+2.28.0
+


### PR DESCRIPTION
Maintainer: W. Michael Petullo mike@flyn.org
Compile tested: x86-64 OpenWrt master branch

Description:
lighttpd: wolfssl TLS compat module detection

x-ref:
  "[lighttpd] -mod-wolfssl fails (requires dependency on -mod-openssl?)"
  https://github.com/openwrt/packages/issues/14139

github: closes #14139