### PR TITLE
sumo: fix compilation with ccache

### DIFF
--- a/utils/sumo/Makefile
+++ b/utils/sumo/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sumo
 PKG_VERSION:=1.7.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-src-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/sumo

--- a/utils/sumo/patches/010-ccache.patch
+++ b/utils/sumo/patches/010-ccache.patch
@@ -1,0 +1,15 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -29,12 +29,6 @@ project(SUMO)
+ set(PACKAGE_VERSION "1.7.0")
+ cmake_minimum_required(VERSION 3.1)
+ 
+-find_program(CCACHE_FOUND "ccache")
+-if (CCACHE_FOUND AND CCACHE_SUPPORT)
+-  message(STATUS "Enabling ccache")
+-  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "ccache")
+-endif()
+-
+ set(CMAKE_COLOR_MAKEFILE ON)
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/build/cmake_modules/")
+ 


### PR DESCRIPTION
sumo's builtin support for ccache doesn't work well with the one in
base. Remove it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Noltari 
Compile tested: ath79