### PR TITLE
miniupnpd: Don't override ipv6_listening_ip

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.2.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -131,9 +131,8 @@ upnpd() {
 
 		local iface
 		for iface in ${internal_iface:-lan}; do
-			local device addr6
+			local device
 			network_get_device device "$iface" && echo "listening_ip=$device"
-			network_get_ipaddr6 addr6 "$iface" && echo "ipv6_listening_ip=$addr6"
 		done
 
 		config_load "upnpd"


### PR DESCRIPTION
Fixes: https://github.com/openwrt/packages/issues/14145
Signed-off-by: Jitao Lu <dianlujitao@gmail.com>

Maintainer: @neheb