### PR TITLE
zerotier: add patch to avoid including sys/auxv.h

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
 PKG_VERSION:=1.6.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?

--- a/net/zerotier/patches/0001-find-miniupnpc.h-in-staging-directory.patch
+++ b/net/zerotier/patches/0001-find-miniupnpc.h-in-staging-directory.patch
@@ -7,8 +7,6 @@ Subject: [PATCH 1/8] find miniupnpc.h in staging directory
  make-linux.mk | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/make-linux.mk b/make-linux.mk
-index 03cce517..cae8459a 100644
 --- a/make-linux.mk
 +++ b/make-linux.mk
 @@ -25,8 +25,8 @@ TIMESTAMP=$(shell date +"%Y%m%d%H%M")
@@ -22,6 +20,3 @@ index 03cce517..cae8459a 100644
  ifeq ($(MINIUPNPC_IS_NEW_ENOUGH),1)
  	override DEFS+=-DZT_USE_SYSTEM_MINIUPNPC
  	LDLIBS+=-lminiupnpc
--- 
-2.29.2
-

--- a/net/zerotier/patches/0002-remove-pie.patch
+++ b/net/zerotier/patches/0002-remove-pie.patch
@@ -9,8 +9,6 @@ when making a shared object; recompile with -fPIC" error
  make-linux.mk | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
-diff --git a/make-linux.mk b/make-linux.mk
-index cae8459a..bd05e6b5 100644
 --- a/make-linux.mk
 +++ b/make-linux.mk
 @@ -73,11 +73,11 @@ ifeq ($(ZT_DEBUG),1)
@@ -28,6 +26,3 @@ index cae8459a..bd05e6b5 100644
  	STRIP?=strip
  	STRIP+=--strip-all
  endif
--- 
-2.29.2
-

--- a/net/zerotier/patches/0003-remove-arm32-conservative-CFLAGS.patch
+++ b/net/zerotier/patches/0003-remove-arm32-conservative-CFLAGS.patch
@@ -7,8 +7,6 @@ Subject: [PATCH 3/8] remove arm32 conservative CFLAGS
  make-linux.mk | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/make-linux.mk b/make-linux.mk
-index bd05e6b5..b1bb638e 100644
 --- a/make-linux.mk
 +++ b/make-linux.mk
 @@ -276,7 +276,7 @@ ifeq ($(ZT_CONTROLLER),1)
@@ -20,6 +18,3 @@ index bd05e6b5..b1bb638e 100644
  	ifeq ($(shell if [ -e /usr/bin/dpkg ]; then dpkg --print-architecture; fi),armel)
  		override CFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
  		override CXXFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
--- 
-2.29.2
-

--- a/net/zerotier/patches/0004-accept-external-linker-flags.patch
+++ b/net/zerotier/patches/0004-accept-external-linker-flags.patch
@@ -7,8 +7,6 @@ Subject: [PATCH 4/8] accept external linker flags
  make-linux.mk | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/make-linux.mk b/make-linux.mk
-index b1bb638e..d358ecfb 100644
 --- a/make-linux.mk
 +++ b/make-linux.mk
 @@ -77,7 +77,7 @@ else
@@ -20,6 +18,3 @@ index b1bb638e..d358ecfb 100644
  	STRIP?=strip
  	STRIP+=--strip-all
  endif
--- 
-2.29.2
-

--- a/net/zerotier/patches/0005-link-natpmp.patch
+++ b/net/zerotier/patches/0005-link-natpmp.patch
@@ -7,8 +7,6 @@ Subject: [PATCH 5/8] link natpmp
  make-linux.mk | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/make-linux.mk b/make-linux.mk
-index d358ecfb..cbee51c3 100644
 --- a/make-linux.mk
 +++ b/make-linux.mk
 @@ -34,7 +34,7 @@ else
@@ -20,6 +18,3 @@ index d358ecfb..cbee51c3 100644
  	ONE_OBJS+=ext/libnatpmp/natpmp.o ext/libnatpmp/getgateway.o
  else
  	LDLIBS+=-lnatpmp
--- 
-2.29.2
-

--- a/net/zerotier/patches/0006-gcc10.patch
+++ b/net/zerotier/patches/0006-gcc10.patch
@@ -7,8 +7,6 @@ Subject: [PATCH 6/8] gcc10
  osdep/Binder.hpp | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
-diff --git a/osdep/Binder.hpp b/osdep/Binder.hpp
-index c52f303b..8a38ab04 100644
 --- a/osdep/Binder.hpp
 +++ b/osdep/Binder.hpp
 @@ -396,9 +396,9 @@ public:
@@ -24,6 +22,3 @@ index c52f303b..8a38ab04 100644
  						phy.setIfName(udps,(char*)ii->second.c_str(),(int)ii->second.length());
  						++_bindingCount;
  					}
--- 
-2.29.2
-

--- a/net/zerotier/patches/0007-add-cerrno-header-for-str-errno.patch
+++ b/net/zerotier/patches/0007-add-cerrno-header-for-str-errno.patch
@@ -10,8 +10,6 @@ Signed-off-by: Rosen Penev <rosenp@gmail.com>
  osdep/LinuxNetLink.cpp | 2 ++
  1 file changed, 2 insertions(+)
 
-diff --git a/osdep/LinuxNetLink.cpp b/osdep/LinuxNetLink.cpp
-index 421da1f6..b7c13edf 100644
 --- a/osdep/LinuxNetLink.cpp
 +++ b/osdep/LinuxNetLink.cpp
 @@ -22,6 +22,8 @@
@@ -23,6 +21,3 @@ index 421da1f6..b7c13edf 100644
  #ifndef IFNAMSIZ
  #define IFNAMSIZ 16
  #endif
--- 
-2.29.2
-

--- a/net/zerotier/patches/0008-fix-compilation-for-arm_cortex-a7-neon.patch
+++ b/net/zerotier/patches/0008-fix-compilation-for-arm_cortex-a7-neon.patch
@@ -10,8 +10,6 @@ Signed-off-by: Rosen Penev <rosenp@gmail.com>
  node/Constants.hpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/node/Constants.hpp b/node/Constants.hpp
-index 400976c1..eccc3a31 100644
 --- a/node/Constants.hpp
 +++ b/node/Constants.hpp
 @@ -109,7 +109,7 @@
@@ -23,6 +21,3 @@ index 400976c1..eccc3a31 100644
  #if (defined(__APPLE__) && !defined(__LP64__)) || (defined(__ANDROID__) && defined(__arm__))
  #ifdef ZT_ARCH_ARM_HAS_NEON
  #undef ZT_ARCH_ARM_HAS_NEON
--- 
-2.29.2
-

--- a/net/zerotier/patches/010-auxv.patch
+++ b/net/zerotier/patches/010-auxv.patch
@@ -1,0 +1,11 @@
+--- a/node/Utils.cpp
++++ b/node/Utils.cpp
+@@ -28,7 +28,7 @@
+ #include <sys/stat.h>
+ #include <sys/uio.h>
+ #include <dirent.h>
+-#ifdef __LINUX__
++#if 0
+ #include <sys/auxv.h>
+ #endif
+ #endif


### PR DESCRIPTION
It seems it's not needed and not supported under uClibc-ng.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mwarning 
Compile tested: arc700

Refreshed all patches.