### PR TITLE
stress-ng: bump to version 0.12.00

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.11.23
+PKG_VERSION:=0.12.00
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://kernel.ubuntu.com/~cking/tarballs/stress-ng
-PKG_HASH:=c0a76147a02f4c31af1fb4b9b7e0b90ac8bbd8590ccb54264d5cbe046c769cd2
+PKG_HASH:=b2b738f574671926654b1623103a7aa58ee6911894ac78760ee188c4bfa96fe2
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/f276395cda79996d395209700a51bb94a0e25abd
Run tested: x86 https://github.com/openwrt/openwrt/commit/f276395cda79996d395209700a51bb94a0e25abd

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>