### PR TITLE
prometheus-node-exporter-lua: add snmp6 exporter

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2020.10.29
+PKG_VERSION:=2020.12.07
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
@@ -199,6 +199,17 @@ define Package/prometheus-node-exporter-lua-wifi_stations/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/wifi_stations.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
+define Package/prometheus-node-exporter-lua-snmp6
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (snmp6 collector)
+  DEPENDS:=prometheus-node-exporter-lua +libubus-lua
+endef
+
+define Package/prometheus-node-exporter-lua-snmp6/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/snmp6.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
 $(eval $(call BuildPackage,prometheus-node-exporter-lua))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx6))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx7))
@@ -213,3 +224,4 @@ $(eval $(call BuildPackage,prometheus-node-exporter-lua-textfile))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-uci_dhcp_host))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi_stations))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-snmp6))

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/snmp6.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/snmp6.lua
@@ -1,0 +1,39 @@
+local ubus = require "ubus"
+
+local function get_devices() -- based on hostapd_stations.lua
+    local u = ubus.connect()
+    local status = u:call("network.device", "status", {})
+    local devices = {}
+
+    for dev, dev_table in pairs(status) do
+        table.insert(devices, dev)
+    end
+    return devices
+end
+
+local function get_metric(device)
+    local label = {
+        device = device
+      }
+      
+    if device == "all" then
+        for e in io.lines("/proc/net/snmp6") do
+            local snmp6 = space_split(e)
+            metric("snmp6_" .. snmp6[1], "counter", label, tonumber(snmp6[2]))
+        end
+    else
+        for e in io.lines("/proc/net/dev_snmp6/" .. device) do
+            local snmp6 = space_split(e)
+            metric("snmp6_" .. snmp6[1], "counter", label, tonumber(snmp6[2]))
+        end
+    end
+end
+
+local function scrape()
+    get_metric("all")
+    for _, devicename in ipairs(get_devices()) do
+        get_metric(devicename)
+    end
+end
+
+return { scrape = scrape }


### PR DESCRIPTION
If you want statistics about IPv6 you can use snmpv6 exporter. Currently, the "/proc/net/snmp6" and "/proc/net/dev_snmp6/" is existing but all values are just "0".

To use this plugin you have to set
  CONFIG_PROC_STRIPPED=n

I will find a way to enable the important ipv6 statistics by default.

Maintainer: @champtar
Compile tested: trunk
Run tested: WDR4300 Trunk
