### PR TITLE
htop: update to 3.0.3-1

### DIFF
--- a/admin/htop/Makefile
+++ b/admin/htop/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=htop
-PKG_VERSION:=3.0.2
+PKG_VERSION:=3.0.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/htop-dev/htop/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=b4744a3bea279f2a3725ed8e5e35ffd9cb10d66673bf07c8fe21feb3c4661305
+PKG_HASH:=725103929c925a7252b4dedeb29b3a1da86a2f74e96c50eb9ea6c8fec1942cd2
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Build-tested: x86/64
Run-tested: ipq806x (R7800)

Signed-off-by: John Audia <graysky@archlinux.us>

Maintainer: @neheb @hnyman @champtar
Description: new upstream release