### PR TITLE
rpcd-mod-lxc: add postinst to reload rpcd on update/installation

### DIFF
--- a/utils/rpcd-mod-lxc/Makefile
+++ b/utils/rpcd-mod-lxc/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rpcd-mod-lxc
-PKG_RELEASE=20171206
+PKG_RELEASE=20201208
 
 PKG_LICENSE:=ISC
 
@@ -32,6 +32,11 @@ endef
 define Package/rpcd-mod-lxc/install
 	$(INSTALL_DIR) $(1)/usr/lib/rpcd
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/lxc.so $(1)/usr/lib/rpcd/
+endef
+
+define Package/rpcd-mod-lxc/postinst
+#!/bin/sh
+[ -n "$$IPKG_INSTROOT" ] || /etc/init.d/rpcd reload
 endef
 
 $(eval $(call BuildPackage,rpcd-mod-lxc))


### PR DESCRIPTION
Maintainer: @lperkov 
Compile tested: 
Run tested: 

Description:
This is dependency of luci-app-lxc and when users install that package
it is no way clear that they have to reload rpcd to get it working
correctly. Without it container listing does not work.
In general this reload should be in this package simply because other
rpcd-mod-* packages reload rpcd as well.