### PR TITLE
neon: install neon-config to host path

### DIFF
--- a/libs/neon/Makefile
+++ b/libs/neon/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=neon
 PKG_VERSION:=0.31.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://notroj.github.io/neon
@@ -65,8 +65,9 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libneon.{a,so*} $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/neon.pc $(1)/usr/lib/pkgconfig/
-	$(SED) 's,-I$$$${includedir}/,-I$(STAGING_DIR)/usr/include/,g' $(1)/usr/bin/neon-config
-	$(SED) 's,-L$$$${libdir},,g' $(1)/usr/bin/neon-config
+	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' $(1)/usr/bin/neon-config
+	$(INSTALL_DIR) $(2)/bin
+	$(LN) ../../usr/bin/neon-config $(2)/bin/neon-config
 endef
 
 define Package/libneon/install


### PR DESCRIPTION
Helps old packages that do not use pkgconfig.

Fixed paths.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @fededim 
Compile tested: ath79

Interestingly enough with this change, davfs2 does not need to specify neon manually.