### PR TITLE
taglib: install taglib-config to host path

### DIFF
--- a/libs/taglib/Makefile
+++ b/libs/taglib/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=taglib
 PKG_VERSION:=1.12-beta-1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/taglib/taglib/tar.gz/v$(PKG_VERSION)?
@@ -52,6 +52,8 @@ define Build/InstallDev
 	$(SED) '/^prefix=\|^exec_prefix=/s|/usr|$(STAGING_DIR)/usr|' $(1)/usr/bin/taglib-config
 	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/taglib.pc
 	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/taglib.pc
+	$(INSTALL_DIR) $(2)/bin
+	$(LN) ../../usr/bin/taglib-config $(2)/bin/taglib-config
 endef
 
 $(eval $(call BuildPackage,taglib))


### PR DESCRIPTION
Helps old packages that do not use pkgconfig.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ath79