### PR TITLE
samba4: update to 4.13.2

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.12.7
+PKG_VERSION:=4.13.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -13,7 +13,7 @@ PKG_SOURCE_URL:= \
 		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
-PKG_HASH:=30556a0dd2f9ab3b251eb9db6132ffd4379c159f574366fc2f2eabbc018c6fd2
+PKG_HASH:=276464396a05d88b775bda01ac2eb1e5a636ccf7010b0fd28efc3d85583af2b4
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/samba4/files/samba.init
+++ b/net/samba4/files/samba.init
@@ -60,8 +60,6 @@ smb_header() {
 			printf "\tmin receivefile size = 131072\n" # allows zero-copy writes via fs
 			printf "\tfake oplocks = Yes\n" # may corrupt files for simultanous writes to the same files by multiple clients, but might also see big speed boost
 			printf "\tuse sendfile = Yes\n" # enable sendfile, not sure whats with the 2019 bug https://bugzilla.samba.org/show_bug.cgi?id=14095
-			# Removed in 4.12.x in favor of VFS io_uring ; this is per file, so may increase memory useage on many simultanous oplocked files!
-			printf "\twrite cache size = 262144\n" # adds a write cache buffer per file for oplocked files, flushes if size is exhausted
 		fi
 
 		if [ "$DISABLE_NETBIOS" -eq 1 ] || [ ! -x /usr/sbin/nmbd ]; then


### PR DESCRIPTION
Maintainer: me
Compile tested: arm/mvebu (master)
Run tested: arm/mvebu (master)

Description:
* update to 4.13.2
* remove outdated option "write cache size"