### PR TITLE
Fix version in hwinfo and a few cosmetic stuff

### DIFF
--- a/utils/hwinfo/Makefile
+++ b/utils/hwinfo/Makefile
@@ -9,6 +9,7 @@ PKG_SOURCE_URL:=https://codeload.github.com/openSUSE/hwinfo/tar.gz/$(PKG_VERSION
 PKG_HASH:=c4c573eb15cbc10103f5044b485d7e4ff941500ed559743a1c98e6a6deb0ebda
 
 PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Alberto Bursi <bobafetthotmail@gmail.com>
 
 PKG_BUILD_DEPENDS:= hwinfo/host

--- a/utils/hwinfo/Makefile
+++ b/utils/hwinfo/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hwinfo
 PKG_VERSION:=21.71
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/openSUSE/hwinfo/tar.gz/$(PKG_VERSION)?

--- a/utils/hwinfo/patches/0-hardcoding-version
+++ b/utils/hwinfo/patches/0-hardcoding-version
@@ -13,7 +13,7 @@ with hwinfo version changes when updating the package
 -VERSION := $(shell $(GIT2LOG) --version VERSION ; cat VERSION)
 -endif
 +BRANCH  := master
-+VERSION := $(shell echo 21.7 > VERSION; cat VERSION)
++VERSION := $(shell echo 21.71 > VERSION; cat VERSION)
  PREFIX  := hwinfo-$(VERSION)
  
  include Makefile.common

--- a/utils/hwinfo/patches/1-remove_libx8emu_dependency
+++ b/utils/hwinfo/patches/1-remove_libx8emu_dependency
@@ -5,9 +5,9 @@ to compile this package with this dependency in OpenWrt due to
 host builds and whatnot, we simply remove it and disable this 
 functionality in hwinfo.
 This also saves some space.
---- a/Makefile	
-+++ b/Makefile	
-@@ -25,13 +25,14 @@
+--- a/Makefile
++++ b/Makefile
+@@ -25,13 +25,14 @@ LIBDIR		?= /usr/lib
  endif
  ULIBDIR		= $(LIBDIR)
  
@@ -28,10 +28,9 @@ This also saves some space.
  
  SHARED_FLAGS	=
  OBJS_NO_TINY	= names.o parallel.o modem.o
-
 --- a/src/hd/bios.c
 +++ b/src/hd/bios.c
-@@ -447,9 +447,10 @@
+@@ -447,9 +447,10 @@ void hd_scan_bios(hd_data_t *hd_data)
        }
      }
  
@@ -45,7 +44,6 @@ This also saves some space.
  
      if(vbe->ok) {
        bt->vbe_ver = vbe->version;
-
 --- a/src/hd/bios.h
 +++ b/src/hd/bios.h
 @@ -5,4 +5,5 @@
@@ -55,7 +53,6 @@ This also saves some space.
 -void get_vbe_info(hd_data_t *hd_data, vbe_info_t *vbe);
 +//disabled as we removed the lib needed by this function
 +//void get_vbe_info(hd_data_t *hd_data, vbe_info_t *vbe);
-
 --- a/src/hd/mdt.c
 +++ b/src/hd/mdt.c
 @@ -1,4 +1,6 @@

--- a/utils/hwinfo/patches/2-enable-hw-ids-and-disable-generation-of-tiny-hwinfo-headers
+++ b/utils/hwinfo/patches/2-enable-hw-ids-and-disable-generation-of-tiny-hwinfo-headers
@@ -6,7 +6,7 @@ on my OpenSUSE system, so I guess that it is just legacy stuff that bitrotted.
 
 --- a/src/ids/Makefile
 +++ b/src/ids/Makefile
-@@ -17,47 +17,47 @@
+@@ -17,47 +17,47 @@ IDFILES	+= src/bus src/class src/extra s
  	  src/usb src/usb2 src/isapnp src/monitor src/camera src/tv2 src/tv src/dvb2 src/dvb \
  	  src/chipcard src/modem src/pcmcia src/s390 src/sdio
  

--- a/utils/hwinfo/patches/3-assorted-Makefile-butchery
+++ b/utils/hwinfo/patches/3-assorted-Makefile-butchery
@@ -4,8 +4,8 @@ Some makefile modifications to:
 >>disable the install functionality as we take the files we need with OpenWrt build system
 >>changes to all makefiles to respect the compile flags
 
---- a/Makefile	
-+++ b/Makefile	
+--- a/Makefile
++++ b/Makefile
 @@ -1,6 +1,6 @@
  TOPDIR		= $(CURDIR)
  SUBDIRS		= src
@@ -14,7 +14,7 @@ Some makefile modifications to:
  CLEANFILES	= hwinfo hwinfo.pc hwinfo.static hwscan hwscan.static hwscand hwscanqueue doc/libhd doc/*~
  LIBS		= -lhd
  SLIBS		= -lhd -luuid
-@@ -18,11 +18,11 @@
+@@ -18,11 +18,11 @@ PREFIX  := hwinfo-$(VERSION)
  
  include Makefile.common
  
@@ -30,7 +30,7 @@ Some makefile modifications to:
  ULIBDIR		= $(LIBDIR)
  
  # this library has been removed from the code, disabling it here too
-@@ -39,13 +39,13 @@
+@@ -39,13 +39,13 @@ OBJS_NO_TINY	= names.o parallel.o modem.
  
  .PHONY:	fullstatic static shared tiny doc diet tinydiet uc tinyuc
  
@@ -49,7 +49,7 @@ Some makefile modifications to:
  
  hwscan: hwscan.o $(LIBHD)
  	$(CC) hwscan.o $(LDFLAGS) $(CFLAGS) $(LIBS) -o $@
-@@ -99,28 +99,29 @@
+@@ -99,28 +99,29 @@ doc:
  	@cd doc ; doxygen libhd.doxy
  
  install:
@@ -101,7 +101,6 @@ Some makefile modifications to:
  
  archive: changelog
  	@if [ ! -d .git ] ; then echo no git repo ; false ; fi
-
 --- a/Makefile.common
 +++ b/Makefile.common
 @@ -1,28 +1,26 @@
@@ -147,7 +146,7 @@ Some makefile modifications to:
  SHARED_FLAGS	= -fPIC
  
  LDFLAGS	+= -Lsrc
-@@ -36,7 +34,7 @@
+@@ -36,7 +34,7 @@ LIBHD_NAME	= $(LIBHD_BASE).so.$(LIBHD_VE
  LIBHD_SO	= $(TOPDIR)/src/$(LIBHD_NAME)
  LIBHD_D		= $(TOPDIR)/src/.lib
  
@@ -156,10 +155,9 @@ Some makefile modifications to:
  
  .PHONY: all distclean clean install subdirs
  
-
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -12,7 +12,7 @@
+@@ -12,7 +12,7 @@ include $(TOPDIR)/Makefile.common
  #endif
  
  $(LIBHD): $(OBJS)
@@ -170,16 +168,15 @@ Some makefile modifications to:
  ifdef SHARED_FLAGS
 --- a/src/hd/Makefile
 +++ b/src/hd/Makefile
-@@ -12,4 +12,4 @@
- 	@perl -pi -e "s/define\s+HD_MINOR_VERSION\s+\d+/define HD_MINOR_VERSION\t$(LIBHD_MINOR_VERSION)/" $@
+@@ -8,4 +8,4 @@ version.h: $(TOPDIR)/VERSION
+ 	@echo "#define HD_VERSION_STRING \"`cat $(TOPDIR)/VERSION`\"" >$@
  
  $(LIBHD_D): $(OBJS)
 -	ar r $(LIBHD) $?
 +	$(AR) r $(LIBHD) $?
- 
 --- a/src/isdn/Makefile
 +++ b/src/isdn/Makefile
-@@ -5,5 +5,5 @@
+@@ -5,5 +5,5 @@ SUBDIRS = cdb
  include $(TOPDIR)/Makefile.common
  
  $(LIBHD_D): $(OBJS)
@@ -188,10 +185,9 @@ Some makefile modifications to:
  
 --- a/src/smp/Makefile
 +++ b/src/smp/Makefile
-@@ -4,4 +4,4 @@
+@@ -4,4 +4,4 @@ TARGETS	= $(LIBHD_D)
  include $(TOPDIR)/Makefile.common
  
  $(LIBHD_D): $(OBJS)
 -	ar r $(LIBHD) $?
 +	$(AR) r $(LIBHD) $?
-


### PR DESCRIPTION
Maintainer: @bobafetthotmail
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07 (backported from master branch)
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07 (backported from master branch)

Description:

- Fixes version in hwinfo

Before:
```
root@omnia:~# opkg list-installed | grep hwinfo
hwinfo - 21.71-1
root@omnia:~# hwinfo --version
21.7
```

After:

```
root@omnia:~# opkg list-installed | grep hwinfo
hwinfo - 21.71-2
root@omnia:~# hwinfo --version
21.71
```

- Add PKG_LICENSE_FILES and refresh patches to avoid fuzz