### PR TITLE
github: test i386_pentium-mmx instead of pentium4

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -24,7 +24,7 @@ jobs:
             runtime_test: true
           - arch: arm_cortex-a15_neon-vfpv4
             runtime_test: true
-          - arch: i386_pentium4
+          - arch: i386_pentium-mmx
             runtime_test: true
           - arch: x86_64
             runtime_test: true


### PR DESCRIPTION
It seems the former causes more compilation failures due to not having
SSE.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @aparcar 

See: https://downloads.openwrt.org/snapshots/faillogs/i386_pentium-mmx/packages/i2pd/compile.txt