### PR TITLE
python3: add python3-webbrowser package from python3-light

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 include ../python3-version.mk
 
 PKG_NAME:=python3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_VERSION:=$(PYTHON3_VERSION).$(PYTHON3_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -262,7 +262,6 @@ define Py3Package/python3-light/filespec
 -|/usr/lib/python$(PYTHON3_VERSION)/lib-dynload/readline*.so
 -|/usr/lib/python$(PYTHON3_VERSION)/pdb.doc
 -|/usr/lib/python$(PYTHON3_VERSION)/test
--|/usr/lib/python$(PYTHON3_VERSION)/webbrowser.py
 -|/usr/lib/python$(PYTHON3_VERSION)/*/test
 -|/usr/lib/python$(PYTHON3_VERSION)/*/tests
 -|/usr/lib/python$(PYTHON3_VERSION)/_osx_support.py

--- a/lang/python/python3/files/python3-package-webbrowser.mk
+++ b/lang/python/python3/files/python3-package-webbrowser.mk
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2020 Josef Schlehofer <pepe.schlehofer@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Package/python3-webbrowser
+$(call Package/python3/Default)
+  TITLE:=Python $(PYTHON3_VERSION) Web-browser controller
+  DEPENDS:=+python3-light
+endef
+
+$(eval $(call Py3BasePackage,python3-webbrowser, \
+	/usr/lib/python$(PYTHON3_VERSION)/webbrowser.py \
+))


### PR DESCRIPTION
Maintainers: @jefferyto , @commodo 
Compile and run tested on Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07.5
I didn't test it so far on OpenWrt master, but I can do it based on request.

According to the documentation of webbrowser [1], it should allow displaying
Web-based documents to users.

Most likely, there is no much usage as there is not any browser
available for OpenWrt AFAIK.

However, somebody is using it because of Microsoft Authentication Library
which uses webbrowser module. This was requested on the Turris forum [2]
and it was confirmed that it works.

[1] https://docs.python.org/3/library/webbrowser.html
[2] https://forum.turris.cz/t/missing-webbrowser-module-in-python3-standard-distribution-on-turris-5-x/14407?u=pepe
