### PR TITLE
glib2: use normal format functions

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.66.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/2.66

--- a/libs/glib2/patches/002-no-tests.patch
+++ b/libs/glib2/patches/002-no-tests.patch
@@ -1,6 +1,6 @@
 --- a/meson.build
 +++ b/meson.build
-@@ -94,7 +94,7 @@ installed_tests_template = files('template.test.in')
+@@ -94,7 +94,7 @@ installed_tests_template = files('templa
  installed_tests_template_tap = files('template-tap.test.in')
  
  # Don’t build the tests unless we can run them (either natively, in an exe wrapper, or by installing them for later use)

--- a/libs/glib2/patches/003-valgrind.h-mips16-fix.patch
+++ b/libs/glib2/patches/003-valgrind.h-mips16-fix.patch
@@ -1,5 +1,5 @@
---- a/glib/valgrind.h	2019-12-12 14:53:26.000200499 +0100
-+++ b/glib/valgrind.h	2019-12-12 14:49:45.056163300 +0100
+--- a/glib/valgrind.h
++++ b/glib/valgrind.h
 @@ -158,7 +158,7 @@
  #  define PLAT_s390x_linux 1
  #elif defined(__linux__) && defined(__mips__) && (__mips==64)

--- a/libs/glib2/patches/006-c99.patch
+++ b/libs/glib2/patches/006-c99.patch
@@ -1,0 +1,11 @@
+--- a/meson.build
++++ b/meson.build
+@@ -923,7 +923,7 @@ if host_system == 'windows' and (cc.get_
+   glib_conf.set('HAVE_C99_SNPRINTF', false)
+   glib_conf.set('HAVE_C99_VSNPRINTF', false)
+   glib_conf.set('HAVE_UNIX98_PRINTF', false)
+-elif not cc_can_run and host_system in ['ios', 'darwin']
++elif true
+   # All these are true when compiling natively on macOS, so we should use good
+   # defaults when building for iOS and tvOS.
+   glib_conf.set('HAVE_C99_SNPRINTF', true)


### PR DESCRIPTION
These meson checks rely on being able to run binaries. Just force them
on. Reduces compiled size.

Refreshed patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 
Compile tested: ath79