### PR TITLE
[18.06] simple-adblock: bugfix - config update

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.8.4
-PKG_RELEASE:=2
+PKG_RELEASE:=4
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 PKG_LICENSE:=GPL-3.0-or-later
 
@@ -31,12 +31,6 @@ define Package/simple-adblock/conffiles
 /etc/config/simple-adblock
 endef
 
-define Build/Prepare
-	mkdir -p $(PKG_BUILD_DIR)/files/
-	$(CP) ./files/simple-adblock.init $(PKG_BUILD_DIR)/files/simple-adblock.init
-	sed -i "s|^\(PKG_VERSION\).*|\1='$(PKG_VERSION)-$(PKG_RELEASE)'|" $(PKG_BUILD_DIR)/files/simple-adblock.init
-endef
-
 define Build/Configure
 endef
 
@@ -45,7 +39,8 @@ endef
 
 define Package/simple-adblock/install
 	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/simple-adblock.init $(1)/etc/init.d/simple-adblock
+	$(INSTALL_BIN) ./files/simple-adblock.init $(1)/etc/init.d/simple-adblock
+	sed -i "s|^\(PKG_VERSION\).*|\1='$(PKG_VERSION)-$(PKG_RELEASE)'|" $(1)/etc/init.d/simple-adblock
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/simple-adblock.conf $(1)/etc/config/simple-adblock
 	$(INSTALL_DIR) $(1)/tmp

--- a/net/simple-adblock/files/simple-adblock.conf
+++ b/net/simple-adblock/files/simple-adblock.conf
@@ -38,9 +38,6 @@ config simple-adblock 'config'
 # File size: 20.0K
 	list blocked_hosts_url 'https://cdn.jsdelivr.net/gh/hoshsadiq/adblock-nocoin-list/hosts.txt'
 
-# File size: 36.0K
-	list blocked_hosts_url 'https://www.malwaredomainlist.com/hostslist/hosts.txt'
-
 # File size: 80.0K
 	list blocked_hosts_url 'https://pgl.yoyo.org/as/serverlist.php?hostformat=hosts&showintro=1&mimetype=plaintext'
 

--- a/net/simple-adblock/files/simple-adblock.conf.update
+++ b/net/simple-adblock/files/simple-adblock.conf.update
@@ -9,4 +9,5 @@ s|raw.githubusercontent.com/StevenBlack/hosts/|cdn.jsdelivr.net/gh/StevenBlack/h
 s|raw.githubusercontent.com/hoshsadiq/adblock-nocoin-list/|cdn.jsdelivr.net/gh/hoshsadiq/adblock-nocoin-list@|g
 s|raw.githubusercontent.com/jawz101/MobileAdTrackers/|cdn.jsdelivr.net/gh/jawz101/MobileAdTrackers@|g
 s|http://winhelp2002.mvps.org/hosts.txt|https://winhelp2002.mvps.org/hosts.txt|g
-/dshield.org/d
+\|dshield.org|d
+\|www.malwaredomainlist.com/hostslist/hosts.txt|d

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -9,13 +9,21 @@ START=94
 USE_PROCD=1
 LC_ALL=C
 
+if type extra_command 1>/dev/null 2>&1; then
+	extra_command 'check' 'Checks if specified domain is found in current block-list'
+	extra_command 'dl' 'Force-downloads all enabled block-list'
+	extra_command 'sizes' 'Displays the file-sizes of enabled block-listo'
+	extra_command 'show' 'Shows the service last-run status'
+	extra_command 'version' 'Show version information'
+else
 # shellcheck disable=SC2034
-EXTRA_COMMANDS='check dl killcache sizes show version'
+	EXTRA_COMMANDS='check dl killcache sizes show version'
 # shellcheck disable=SC2034
-EXTRA_HELP='	check	Checks if specified domain is found in current block-list
+	EXTRA_HELP='	check	Checks if specified domain is found in current block-list
 	dl	Force-downloads all enabled block-list
 	sizes	Displays the file-sizes of enabled block-lists
 	show	Shows the service last-run status'
+fi
 
 readonly packageName='simple-adblock'
 readonly serviceName="$packageName $PKG_VERSION"
@@ -742,13 +750,13 @@ process_config_update() {
 		output 2 "[DL] Config  Update:  $label $__FAIL__\\n"
 		tmpfs add error "errorDownloadingConfigUpdate"
 	else
-		if ! sed -f "$R_TMP" -i /etc/config/simple-adblock; then
+		if [ -s "$R_TMP" ] && sed -f "$R_TMP" -i /etc/config/simple-adblock; then
+			output 1 "$_OK_"
+			output 2 "[DL] Config  Update:  $label $__OK__\\n"
+		else
 			output 1 "$_FAIL_"
 			output 2 "[DL] Config  Update:  $label $__FAIL__\\n"
 			tmpfs add error "errorParsingConfigUpdate"
-		else
-			output 1 "$_OK_"
-			output 2 "[DL] Config  Update:  $label $__OK__\\n"
 		fi
 	fi
 	rm -f "$R_TMP"
@@ -1214,7 +1222,7 @@ stop_service() {
 }
 
 service_triggers() {
-	procd_add_reload_trigger 'simple-adblock'
+	procd_add_config_trigger "config.change" "$packageName" /etc/init.d/$packageName reload
 }
 
 check() {


### PR DESCRIPTION
Maintainer: me
Compile tested: ramips, ER-X, 19.07.5
Run tested: ramips, ER-X, 19.07.5, start/download blocklists

Description:
This is a bugfix to update the default config and config update files, otherwise new installs will be producing errors for no longer active https://www.malwaredomainlist.com/hostslist/hosts.txt list.
This also includes bugfix to use `extra_command` only on supported systems and small Makefile improvement.

Signed-off-by: Stan Grishin <stangri@melmac.net>
