### PR TITLE
libpng: disable building of executables

### DIFF
--- a/libs/libpng/Makefile
+++ b/libs/libpng/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpng
 PKG_VERSION:=1.6.37
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/libpng
@@ -38,13 +38,12 @@ CMAKE_OPTIONS += \
 	-DPNG_BUILD_ZLIB=ON \
 	-DPNG_SHARED=ON \
 	-DPNG_STATIC=ON \
+	-DPNG_EXECUTABLES=OFF \
 	-DPNG_TESTS=OFF \
 	-DPNG_FRAMEWORK=OFF \
 	-DPNG_DEBUG=OFF \
 	-DPNG_HARDWARE_OPTIMIZATIONS=O$(if $(findstring powerpc,$(CONFIG_ARCH))$(findstring mipsel,$(CONFIG_ARCH)),FF,N) \
 	-Dld-version-script=OFF
-
-TARGET_LDFLAGS += -lz
 
 define Build/InstallDev
 	$(call Build/InstallDev/cmake,$(1))

--- a/libs/libpng/patches/010-png-exec.patch
+++ b/libs/libpng/patches/010-png-exec.patch
@@ -1,0 +1,38 @@
+From 28c0f8895e4ac270b56b5c7e8089dd2417bc4e3c Mon Sep 17 00:00:00 2001
+From: Alex Gaynor <alex.gaynor@gmail.com>
+Date: Sun, 20 May 2018 18:46:32 -0400
+Subject: [PATCH] cmake: Add an option to enable/disable building of
+ executables
+
+Add the CMake option PNG_EXECUTABLES (on by default) in order to
+allow or disallow the building of non-essential executable programs
+associated with libpng.
+
+Contributed-by: Alex Gaynor <alex.gaynor@gmail.com>
+Contributed-by: Cosmin Truta <ctruta@gmail.com>
+Signed-off-by: Cosmin Truta <ctruta@gmail.com>
+---
+ CMakeLists.txt | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -53,7 +53,8 @@ endif()
+ # COMMAND LINE OPTIONS
+ option(PNG_SHARED "Build shared lib" ON)
+ option(PNG_STATIC "Build static lib" ON)
+-option(PNG_TESTS  "Build libpng tests" ON)
++option(PNG_EXECUTABLES "Build libpng executables" ON)
++option(PNG_TESTS "Build libpng tests" ON)
+ 
+ # Many more configuration options could be added here
+ option(PNG_FRAMEWORK "Build OS X framework" OFF)
+@@ -747,7 +748,7 @@ if(PNG_TESTS AND PNG_SHARED)
+   png_add_test(NAME pngimage-full COMMAND pngimage OPTIONS --exhaustive --list-combos --log FILES ${PNGSUITE_PNGS})
+ endif()
+ 
+-if(PNG_SHARED)
++if(PNG_SHARED AND PNG_EXECUTABLES)
+   add_executable(pngfix ${pngfix_sources})
+   target_link_libraries(pngfix png)
+   set(PNG_BIN_TARGETS pngfix)

--- a/libs/libpng/patches/200-ccache.patch
+++ b/libs/libpng/patches/200-ccache.patch
@@ -8,7 +8,7 @@
  set(CMAKE_C_FLAGS @CMAKE_C_FLAGS@)
  set(INCDIR "@CMAKE_CURRENT_BINARY_DIR@")
  set(PNG_PREFIX "@PNG_PREFIX@")
-@@ -58,7 +59,7 @@ if ("${INPUTEXT}" STREQUAL ".c" AND "${OUTPUTEXT}" STREQUAL ".out")
+@@ -58,7 +59,7 @@ if ("${INPUTEXT}" STREQUAL ".c" AND "${O
      set(PNG_PREFIX_DEF "-DPNG_PREFIX=${PNG_PREFIX}")
    endif()
  


### PR DESCRIPTION
They are not packaged here. Upstream backport.

Speeds up compilation and avoids a zlib hack.

Refreshed patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jow- 
Compile tested: ath79