### PR TITLE
fwknop: gpgme: fix build of fwknop with gpg enabled

### DIFF
--- a/libs/gpgme/Makefile
+++ b/libs/gpgme/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gpgme
 PKG_VERSION:=1.15.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
@@ -83,6 +83,15 @@ define Build/InstallDev
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/lib/cmake/Gpgmepp/*.cmake \
 		$(1)/usr/lib/cmake/Gpgmepp
+
+	$(INSTALL_DIR) $(2)/bin $(1)/usr/bin
+	$(INSTALL_BIN) \
+		$(PKG_INSTALL_DIR)/usr/bin/gpgme-config \
+		$(2)/bin/
+	$(SED) \
+		's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' \
+		$(2)/bin/gpgme-config
+	$(LN) -sf $(STAGING_DIR)/host/bin/gpgme-config $(1)/usr/bin/gpgme-config
 endef
 
 define Package/libgpgme/install

--- a/net/fwknop/Config.in
+++ b/net/fwknop/Config.in
@@ -1,6 +1,6 @@
 #fwknop config
 menu "Configuration"
-	depends on PACKAGE_fwknopd
+	depends on PACKAGE_fwknopd || PACKAGE_fwknop
 
 config FWKNOPD_GPG
 	bool "Enable GPG support"
@@ -11,6 +11,5 @@ config FWKNOPD_NFQ_CAPTURE
 	bool "Enable netfilter_queue capture support (disables libpcap support)"
 	select PACKAGE_iptables-mod-nfqueue
 	default n
-
 
 endmenu

--- a/net/fwknop/Makefile
+++ b/net/fwknop/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fwknop
 PKG_VERSION:=2.6.10
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.cipherdyne.org/fwknop/download
@@ -47,8 +47,9 @@ define Package/fwknopd
   CATEGORY:=Network
   SUBMENU:=Firewall
   TITLE+= Daemon
-  DEPENDS:=+iptables +libfko +!FWKNOPD_NFQ_CAPTURE:libpcap +FWKNOPD_NFQ_CAPTURE:iptables-mod-nfqueue +FWKNOP_GPG:gnupg \
-	+FWKNOPD_NFQ_CAPTURE:libnetfilter-queue +FWKNOPD_NFQ_CAPTURE:libnfnetlink
+  DEPENDS:=+iptables +libfko +!FWKNOPD_NFQ_CAPTURE:libpcap +FWKNOPD_NFQ_CAPTURE:iptables-mod-nfqueue \
+	+FWKNOPD_NFQ_CAPTURE:libnetfilter-queue +FWKNOPD_NFQ_CAPTURE:libnfnetlink \
+	+FWKNOP_GPG:gnupg +FWKNOP_GPG:libgpgme
 endef
 
 define Package/fwknopd/description
@@ -72,7 +73,7 @@ define Package/fwknop
   CATEGORY:=Network
   SUBMENU:=Firewall
   TITLE+= Client
-  DEPENDS:=+libfko
+  DEPENDS:=+libfko +FWKNOPD_GPG:gnupg +FWKNOPD_GPG:libgpgme
 endef
 
 define Package/fwknop/description
@@ -86,6 +87,7 @@ define Package/libfko
   CATEGORY:=Libraries
   SUBMENU:=Firewall
   TITLE+= Library
+  DEPENDS:=+FWKNOPD_GPG:gnupg +FWKNOPD_GPG:libgpgme
 endef
 
 define Package/libfko/description


### PR DESCRIPTION
Maintainer: @dangowrt @jp-bennett 
Compile tested: x86_64, 19.07.5. Tested both with and without gpg enabled.
Run tested: x86_64, 19.07.5. Authenticated with fwknopd running on OpenWrt from a remote client both with and without gpg.

Description:
Building fwknop(d) with gpg enabled failed as it requires gpgme-config during ./configure which wasn't installed by gpgme. This addresses that by making the gpgme package install gpgme-config to host bin.

With gpgme-config in place, the fwknop build still failed due to libfko missing a dependency on libgpgme. This adds that dependency.

Finally, the fwknop and fwknopd packages can be selected independently, but the menuconfig submenu only appeared if fwknopd was selected. Now this submenu appears and allows enabling gpg support even if fwknopd isn't selected.

Note: this is two commits as the gpgme one seemed self-contained, but I can squash them if needed.