### PR TITLE
keyutils: update to 1.6.3 and improve packaging

### DIFF
--- a/libs/keyutils/Makefile
+++ b/libs/keyutils/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keyutils
-PKG_VERSION:=1.6.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.6.3
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=https://people.redhat.com/dhowells/keyutils/
-PKG_HASH:=c8b15722ae51d95b9ad76cc6d49a4c2cc19b0c60f72f61fb9bf43eea7cbd64ce
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git/snapshot/
+PKG_HASH:=a61d5706136ae4c05bd48f86186bcfdbd88dd8bd5107e3e195c924cfc1b39bb4
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
@@ -33,6 +33,16 @@ define Package/keyctl
   CATEGORY:=Utilities
   SUBMENU:=Encryption
   TITLE:=keyctl
+  DEPENDS:=+libkeyutils
+  LICENSE:=GPL-2.0-or-later
+  LICENSE_FILES:=LICENSE.GPL
+endef
+
+define Package/keyutils
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Encryption
+  TITLE:=keyutils (request-key and key.dns_resolver)
   DEPENDS:=+libkeyutils
   LICENSE:=GPL-2.0-or-later
   LICENSE_FILES:=LICENSE.GPL
@@ -61,10 +71,18 @@ define Package/libkeyutils/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libkeyutils.so.$(ABI_VERSION)* $(1)/usr/lib/
 endef
 
+define Package/keyutils/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/keyutils $(1)/etc/request-key.d
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/request-key $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/key.dns_resolver $(1)/usr/sbin/
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/request-key.conf $(1)/etc/
+endef
+
 define Package/keyctl/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/keyctl $(1)/usr/bin
 endef
 
 $(eval $(call BuildPackage,libkeyutils))
+$(eval $(call BuildPackage,keyutils))
 $(eval $(call BuildPackage,keyctl))

--- a/libs/keyutils/patches/010-reproducible-build.patch
+++ b/libs/keyutils/patches/010-reproducible-build.patch
@@ -1,6 +1,6 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -108,7 +108,7 @@ all: keyctl request-key key.dns_resolver
+@@ -109,7 +109,7 @@ all: keyctl request-key key.dns_resolver
  ###############################################################################
  #RPATH = -Wl,-rpath,$(LIBDIR)
  

--- a/libs/keyutils/patches/020-rindex.patch
+++ b/libs/keyutils/patches/020-rindex.patch
@@ -1,6 +1,6 @@
 --- a/key.dns_resolver.c
 +++ b/key.dns_resolver.c
-@@ -529,12 +529,12 @@ int main(int argc, char *argv[])
+@@ -717,12 +717,12 @@ int main(int argc, char *argv[])
  	keyend = buf + ktlen + 1;
  
  	/* the actual key description follows the last semicolon */


### PR DESCRIPTION
Maintainer: @flyn-org (?)
Compile tested: x86/64
Run tested: x86/64

Description:
 * switch to kernel.org upstream (most recent versions seem to be available only there)
 * package request-key, key.dns_resolver and their config file into new package 'keyutils'
 * refresh patches

Signed-off-by: Daniel Golle <daniel@makrotopia.org>