### PR TITLE
CI: test aarch64_cortex-a53 instead of _generic

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -20,7 +20,7 @@ jobs:
           - powerpc_8540
         runtime_test: [false]
         include:
-          - arch: aarch64_generic
+          - arch: aarch64_cortex-a53
             runtime_test: true
           - arch: arm_cortex-a15_neon-vfpv4
             runtime_test: true


### PR DESCRIPTION
The aarch64_cortex-a53 architecture is used by more targets and should
therefore be tested rather than the relatively rare _generic one.

Signed-off-by: Paul Spooren <mail@aparcar.org>