### PR TITLE
p11-kit: update to 0.23.22

### DIFF
--- a/libs/p11-kit/Makefile
+++ b/libs/p11-kit/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=p11-kit
-PKG_VERSION:=0.23.21
+PKG_VERSION:=0.23.22
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/p11-glue/p11-kit/releases/download/$(PKG_VERSION)
-PKG_HASH:=f1baa493f05ca0d867f06bcb54cbb5cdb28c756db07207b6e18de18a87b10627
+PKG_HASH:=8a8f40153dd5a3f8e7c03e641f8db400133fb2a6a9ab2aee1b6d0cb0495ec6b6
 
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/libs/p11-kit/patches/010-stdint.patch
+++ b/libs/p11-kit/patches/010-stdint.patch
@@ -1,0 +1,24 @@
+From 507c394cfcf4edffc5e4450c5d737e545c26b857 Mon Sep 17 00:00:00 2001
+From: Daniel Engberg <daniel.engberg.lists@pyret.net>
+Date: Sat, 12 Dec 2020 18:56:38 +0100
+Subject: [PATCH] p11-kit/lists.c: Add stdint.h to fix compilation
+
+Add stdint.h otherwise compilation fails on FreeBSD 13-CURRENT with "use of undeclared identifier 'SIZE_MAX'"
+
+Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>
+---
+ p11-kit/lists.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/p11-kit/lists.c b/p11-kit/lists.c
+index 365a6d89..1d9062be 100644
+--- a/p11-kit/lists.c
++++ b/p11-kit/lists.c
+@@ -39,6 +39,7 @@
+ 
+ #include <assert.h>
+ #include <ctype.h>
++#include <stdint.h>
+ #include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>


### PR DESCRIPTION
Backport upstream patch that fixes compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nmav 
Compile tested: ath79