### PR TITLE
mwan3: linkdown fix

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.10.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -72,7 +72,7 @@ stop_service() {
 			IP="$IP6"
 		fi
 
-		for tid in $(ip route list table all | sed -ne 's/.*table \([0-9]\+\).*/\1/p' | sort -u); do
+		for tid in $($IP route list table all | sed -ne 's/.*table \([0-9]\+\).*/\1/p' | sort -u); do
 			[ $tid -gt $MWAN3_INTERFACE_MAX ] && continue
 			$IP route flush table $tid &> /dev/null
 		done

--- a/net/mwan3/files/lib/mwan3/common.sh
+++ b/net/mwan3/files/lib/mwan3/common.sh
@@ -129,6 +129,9 @@ mwan3_init()
 		LOG debug "Max interface count is ${MWAN3_INTERFACE_MAX}"
 	fi
 
+	# remove "linkdown", expiry and source based routing modifiers from route lines
+	MWAN3_ROUTE_LINE_EXP="s/linkdown //; s/expires [0-9]\+sec//;s/error [0-9]\+//; ${source_routing:+s/default\(.*\) from [^ ]*/default\1/;} p"
+
 	# mark mask constants
 	bitcnt=$(mwan3_count_one_bits MMX_MASK)
 	mmdefault=$(((1<<bitcnt)-1))

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -413,7 +413,7 @@ mwan3_get_routes()
 	local source_routing
 	config_get_bool source_routing globals source_routing 0
 	[ $source_routing -eq 0 ] && unset source_routing
-	$IP route list table main | sed -ne "/^linkdown/T; s/expires \([0-9]\+\)sec//;s/error [0-9]\+//; ${source_routing:+s/default\(.*\) from [^ ]*/default\1/;} p" | uniq
+	$IP route list table main | sed -ne "$MWAN3_ROUTE_LINE_EXP" | uniq
 }
 
 mwan3_create_iface_route()

--- a/net/mwan3/files/usr/sbin/mwan3rtmon
+++ b/net/mwan3/files/usr/sbin/mwan3rtmon
@@ -22,7 +22,7 @@ func_trap()
 
 mwan3_add_all_routes()
 {
-	local tid IP IPT route_line family active_tbls tid initial_state
+	local tid IP IPT route_line family active_tbls tid initial_state error
 	local ipv=$1
 
 	add_active_tbls()
@@ -40,8 +40,8 @@ mwan3_add_all_routes()
 	{
 		let tid++
 		[ -n "${active_tbls##* $tid *}" ] && return
-		$IP route add table $tid $route_line ||
-			LOG warn "failed to add $route_line to table $tid"
+		error=$($IP route add table $tid $route_line 2>&1) ||
+			LOG warn "failed to add $route_line to table $tid - error: $error"
 	}
 
 	mwan3_update_dev_to_table
@@ -100,6 +100,7 @@ mwan3_rtmon_route_handle()
 	route_line=$(echo "$route_line" | sed -ne "$MWAN3_ROUTE_LINE_EXP")
 
 	handle_route() {
+		local error
 		local iface=$1
 		tbl=$($IP route list table $tid 2>/dev/null)$'\n'
 
@@ -117,8 +118,8 @@ mwan3_rtmon_route_handle()
 
 		network_get_device device "$iface"
 		LOG debug "adjusting route $device: '$IP route $action table $tid $route_line'"
-		$IP route "$action" table $tid $route_line ||
-			LOG warn "failed: '$IP route $action table $tid $route_line'"
+		error=$($IP route "$action" table $tid $route_line 2>&1)||
+			LOG warn "failed: '$IP route $action table $tid $route_line' - error: $error"
 	}
 	handle_route_cb(){
 		local iface=$1

--- a/net/mwan3/files/usr/sbin/mwan3rtmon
+++ b/net/mwan3/files/usr/sbin/mwan3rtmon
@@ -158,6 +158,7 @@ main()
 	sh -c "echo \$\$; exec $IP monitor route" | {
 		read -r monitor_pid
 		trap_with_arg func_trap "$monitor_pid" SIGINT SIGTERM SIGKILL
+		KILL -SIGSTOP $$
 		while IFS='' read -r line; do
 			[ -z "${line##*table*}" ] && continue
 			LOG debug "handling route update $family '$line'"
@@ -165,11 +166,10 @@ main()
 		done
 	} &
 	child=$!
-	kill -SIGSTOP $child
 	trap_with_arg func_trap "$child" SIGINT SIGTERM SIGKILL
 	mwan3_set_connected_${family}
 	mwan3_add_all_routes ${family}
 	kill -SIGCONT $child
-	wait $!
+	wait $child
 }
 main "$@"

--- a/net/mwan3/files/usr/sbin/mwan3rtmon
+++ b/net/mwan3/files/usr/sbin/mwan3rtmon
@@ -69,7 +69,7 @@ mwan3_add_all_routes()
 
 mwan3_rtmon_route_handle()
 {
-	local action route_line family tbl device line route_line_exp tid source_routing
+	local action route_line family tbl device line tid source_routing
 
 	route_line=${1##"Deleted "}
 	route_family=$2
@@ -79,29 +79,25 @@ mwan3_rtmon_route_handle()
 
 	if [ "$route_line" = "$1" ]; then
 		action="replace"
-		route_line_exp="s/expires \([0-9]\+\)sec//;s/error [0-9]\+//; ${source_routing:+s/default\(.*\) from [^ ]*/default\1/}"
 		$IPS -! add mwan3_connected_${route_family##ip} ${route_line%% *}
 	else
 		action="del"
-		route_line_exp="s/expires [0-9]\+sec//;s/error [0-9]\+//; ${source_routing:+s/default\(.*\) from [^ ]*/default\1/}"
 		mwan3_set_connected_${route_family}
+	fi
+
+	if [ -z "${route_line##*linkdown*}" ]; then
+		LOG debug "attempting to add link on down interface - $route_line"
 	fi
 
 	if [ "$route_family" = "ipv4" ]; then
 		IP="$IP4"
 	elif [ "$route_family" = "ipv6" ] && [ $NO_IPV6 -eq 0 ]; then
 		IP="$IP6"
-		route_line=$(echo "$route_line" | sed "$route_line_exp")
 	else
 		LOG warn "route update called with invalid family - $route_family"
 		return
 	fi
-
-	# don't try to add routes when link has gone down
-	if [ -z "${route_line##linkdown*}" ]; then
-		LOG debug "not adding route due to linkdown - skipping $route_line"
-		return
-	fi
+	route_line=$(echo "$route_line" | sed -ne "$MWAN3_ROUTE_LINE_EXP")
 
 	handle_route() {
 		local iface=$1


### PR DESCRIPTION
Maintainer: @feckert 

fix issue on router startup where routes are marked 'linkdown' before interfaces come on line. These routes must be added to the mwan3 routing tables. I have been unable to reproduce, but @feckert has tested and confirmed that it fixes the bug.

fixes: #14003
fixes: #14123