### PR TITLE
bind: start named early enough to be present when isc-dhcp starts

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.16.8
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -183,6 +183,9 @@ define Package/bind-server/install
 		./files/bind/db.root \
 		./files/bind/bind.keys \
 		$(1)/etc/bind/
+	sed -e '1s/ broadcast / empty rfc1918 /' \
+		< ./files/bind/db.0 \
+		> $(1)/etc/bind/db.empty
 	$(CP) ./files/bind/named.conf.example $(1)/etc/bind/named.conf
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/named.init $(1)/etc/init.d/named

--- a/net/bind/files/bind/named.conf.example
+++ b/net/bind/files/bind/named.conf.example
@@ -17,6 +17,8 @@ options {
 
 include "/etc/bind/named-rndc.conf";
 
+include "/tmp/bind/named.conf.local";
+
 // prime the server with knowledge of the root servers
 zone "." {
 	type hint;

--- a/net/bind/files/named.init
+++ b/net/bind/files/named.init
@@ -5,7 +5,7 @@
 
 USE_PROCD=1
 
-START=50
+START=22
 
 config_file=/etc/bind/named.conf
 config_dir=$(dirname $config_file)
@@ -17,9 +17,13 @@ rndc_temp=$(mktemp /tmp/rndc-confgen.XXXXXX)
 logdir=/var/log/named/
 cachedir=/var/cache/bind
 libdir=/var/lib/bind
+dyndir=/tmp/bind
+
+conf_local_file=$dyndir/named.conf.local
+
 
 fix_perms() {
-    for dir in $libdir $logdir $cachedir; do
+    for dir in $libdir $logdir $cachedir $dyndir; do
 	test -e "$dir" || {
             mkdir -p "$dir"
             chgrp bind "$dir"
@@ -29,7 +33,7 @@ fix_perms() {
 }
 
 reload_service() {
-    rndc reload
+    rndc -q reload
 }
 
 start_service() {
@@ -55,11 +59,14 @@ start_service() {
 
     rm -f $rndc_temp
 
+    touch $conf_local_file
+
     procd_open_instance
     procd_set_param command /usr/sbin/named -u bind -f -c $config_file
     procd_set_param file $config_file \
 			 $config_dir/bind.keys \
 			 $named_options_file \
+			 $conf_local_file \
 			 $config_dir/db.*
     procd_set_param respawn
     procd_close_instance


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: x86_64, generic, HEAD (b0cb305236)
Run tested: same, built ipk's and reinstalled on production dhcp/bind server in network

Description:

Start named before dhcpd so that dhcpd can prime the local zones at startup.

Restore the empty domain zone for rfc1918 addresses that previously existed.

Create an additional subsidiary named.conf.local file (initially empty) in /tmp/bind/ that can be seeded with dynamic zones and primed with rndc reload, and add it to the watched list of config files for procd.