### PR TITLE
ksmbd: update to 3.3.2

### DIFF
--- a/kernel/ksmbd/Makefile
+++ b/kernel/ksmbd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd
-PKG_VERSION:=3.3.1
+PKG_VERSION:=3.3.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/cifsd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=bfee16468ef8c0ed35c07ed5c507826fdb33d4b934c0ec706ade439711f0985a
+PKG_HASH:=51f4b8a5c469872fa9bb2661534f51b9a288d2f3af07f0e86cf0d7aa031ccc02
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
The major changes are:

    Fix some of xfstests tests failures when actimeo=0 mount option
    is not used in local.config of xfstests.
    WSL reparse tags support for special files.
    Fix several permission issues.
    Set O_PATH and O_NONBLOCK flags to open_flags.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Andy2244 
Compile tested: ath79