### PR TITLE
nss: update to 3.60

### DIFF
--- a/libs/nss/Makefile
+++ b/libs/nss/Makefile
@@ -7,14 +7,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nss
-PKG_VERSION:=3.58
+PKG_VERSION:=3.60
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
     https://download.cdn.mozilla.net/pub/security/$(PKG_NAME)/releases/NSS_$(subst .,_,$(PKG_VERSION))_RTM/src \
     https://archive.mozilla.org/pub/security/$(PKG_NAME)/releases/NSS_$(subst .,_,$(PKG_VERSION))_RTM/src
-PKG_HASH:=9f73cf789b5f109b978e5239551b609b0cafa88d18f0bc8ce3f976cb629353c0
+PKG_HASH:=84abd5575ab874c53ae511bd461e5d0868d1a1b384ee40753154cdd1d590fe3d
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENCE:=MPL-2.0
@@ -108,6 +108,8 @@ endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) \
+	 $(2)/bin \
+	 $(1)/usr/bin \
 	 $(1)/usr/include/nss \
 	 $(1)/usr/lib \
 	 $(1)/usr/lib/pkgconfig
@@ -119,6 +121,12 @@ define Build/InstallDev
 	  $(1)/usr/lib/
 	$(CP) $(PKG_BUILD_DIR)/nss/config/*.pc \
 	  $(1)/usr/lib/pkgconfig/
+	$(CP) $(PKG_BUILD_DIR)/nss/config/nss-config \
+	  $(1)/usr/bin/
+	$(SED) 's,^\(prefix\)=.*,\1=$(STAGING_DIR)/usr,g' \
+	  $(1)/usr/bin/nss-config
+	$(LN) ../../usr/bin/nss-config \
+	  $(2)/bin/
 endef
 
 define Package/nss-utils/install

--- a/libs/nss/patches/001-nss_standalone.patch
+++ b/libs/nss/patches/001-nss_standalone.patch
@@ -10,9 +10,8 @@ Description:             Adds auto-generated nss.pc and nss-config script, and
                          For 3.48, Requires: updated to nspr >= 4.24.
                          For 3.51.1, Requires: updated to nspr >= 4.25.
 
-diff -Naurp nss-3.28-orig/nss/Makefile nss-3.28/nss/Makefile
---- nss-3.28-orig/nss/Makefile	2016-12-21 05:56:27.000000000 -0600
-+++ nss-3.28/nss/Makefile	2016-12-26 22:24:52.695146032 -0600
+--- a/nss/Makefile
++++ b/nss/Makefile
 @@ -48,7 +48,6 @@ include $(CORE_DEPTH)/coreconf/rules.mk
  #######################################################################
  
@@ -21,9 +20,8 @@ diff -Naurp nss-3.28-orig/nss/Makefile nss-3.28/nss/Makefile
  	$(MAKE) all
  	$(MAKE) latest
  
-diff -Naurp nss-3.28-orig/nss/config/Makefile nss-3.28/nss/config/Makefile
---- nss-3.28-orig/nss/config/Makefile	1969-12-31 18:00:00.000000000 -0600
-+++ nss-3.28/nss/config/Makefile	2016-12-26 22:20:40.008205774 -0600
+--- /dev/null
++++ b/nss/config/Makefile
 @@ -0,0 +1,40 @@
 +CORE_DEPTH = ..
 +DEPTH      = ..
@@ -65,9 +63,8 @@ diff -Naurp nss-3.28-orig/nss/config/Makefile nss-3.28/nss/config/Makefile
 +
 +dummy: all export libs
 +
-diff -Naurp nss-3.28-orig/nss/config/nss-config.in nss-3.28/nss/config/nss-config.in
---- nss-3.28-orig/nss/config/nss-config.in	1969-12-31 18:00:00.000000000 -0600
-+++ nss-3.28/nss/config/nss-config.in	2016-12-26 22:20:40.008205774 -0600
+--- /dev/null
++++ b/nss/config/nss-config.in
 @@ -0,0 +1,153 @@
 +#!/bin/sh
 +
@@ -222,9 +219,8 @@ diff -Naurp nss-3.28-orig/nss/config/nss-config.in nss-3.28/nss/config/nss-confi
 +      echo $libdirs
 +fi      
 +
-diff -Naurp nss-3.28-orig/nss/config/nss.pc.in nss-3.28/nss/config/nss.pc.in
---- nss-3.28-orig/nss/config/nss.pc.in	1969-12-31 18:00:00.000000000 -0600
-+++ nss-3.28/nss/config/nss.pc.in	2016-12-26 22:22:53.300694346 -0600
+--- /dev/null
++++ b/nss/config/nss.pc.in
 @@ -0,0 +1,12 @@
 +prefix=@prefix@
 +exec_prefix=@exec_prefix@
@@ -238,9 +234,8 @@ diff -Naurp nss-3.28-orig/nss/config/nss.pc.in nss-3.28/nss/config/nss.pc.in
 +Libs: -L@libdir@ -lnss@NSS_MAJOR_VERSION@ -lnssutil@NSS_MAJOR_VERSION@ -lsmime@NSS_MAJOR_VERSION@ -lssl@NSS_MAJOR_VERSION@ -lsoftokn@NSS_MAJOR_VERSION@
 +Cflags: -I${includedir}
 +
-diff -Naurp nss-3.28-orig/nss/manifest.mn nss-3.28/nss/manifest.mn
---- nss-3.28-orig/nss/manifest.mn	2016-12-21 05:56:27.000000000 -0600
-+++ nss-3.28/nss/manifest.mn	2016-12-26 22:24:12.278991843 -0600
+--- a/nss/manifest.mn
++++ b/nss/manifest.mn
 @@ -10,7 +10,7 @@ IMPORTS =	nspr20/v4.8 \
  
  RELEASE = nss
@@ -248,6 +243,5 @@ diff -Naurp nss-3.28-orig/nss/manifest.mn nss-3.28/nss/manifest.mn
 -DIRS = coreconf lib cmd cpputil gtests
 +DIRS = coreconf lib cmd cpputil config
  
- lib: coreconf
- cmd: lib
+ HAVE_ALL_TARGET := 1
  

--- a/libs/nss/patches/002-os_test.patch
+++ b/libs/nss/patches/002-os_test.patch
@@ -1,5 +1,5 @@
---- a/nss/coreconf/arch.mk	2019-04-01 22:20:32.470080052 +0300
-+++ b/nss/coreconf/arch.mk	2019-04-01 22:21:01.730987548 +0300
+--- a/nss/coreconf/arch.mk
++++ b/nss/coreconf/arch.mk
 @@ -20,13 +20,13 @@
  # Macros for getting the OS architecture
  #

--- a/libs/nss/patches/003-openwrt_fix.patch
+++ b/libs/nss/patches/003-openwrt_fix.patch
@@ -1,5 +1,5 @@
---- a/nss/lib/dbm/src/dirent.h	2017-10-19 17:15:14.797053528 +0300
-+++ b/nss/lib/dbm/src/dirent.h	2017-10-19 17:15:26.156310432 +0300
+--- a/nss/lib/dbm/src/dirent.h
++++ b/nss/lib/dbm/src/dirent.h
 @@ -30,7 +30,7 @@
  #define MAXNAMLEN FILENAME_MAX
  
@@ -9,9 +9,9 @@
  #endif
  #endif
  
---- a/nss/coreconf/rules.mk	2019-03-31 22:39:06.741609534 +0300
-+++ b/nss/coreconf/rules.mk	2019-03-31 22:36:13.260356949 +0300
-@@ -261,7 +261,7 @@
+--- a/nss/coreconf/rules.mk
++++ b/nss/coreconf/rules.mk
+@@ -176,7 +176,7 @@ $(LIBRARY): $(OBJS) | $$(@D)/d
  ifeq (,$(filter-out _WIN%,$(NS_USE_GCC)_$(OS_TARGET)))
  	$(AR) $(subst /,\\,$(OBJS))
  else
@@ -20,9 +20,9 @@
  endif
  	$(RANLIB) $@
  
---- a/nss/coreconf/arch.mk	2019-03-31 23:38:34.374931416 +0300
-+++ b/nss/coreconf/arch.mk	2019-03-31 23:38:44.667236102 +0300
-@@ -334,7 +334,7 @@
+--- a/nss/coreconf/arch.mk
++++ b/nss/coreconf/arch.mk
+@@ -306,7 +306,7 @@ else
      OBJDIR_NAME_COMPILER = $(COMPILER_TAG)
  endif
  OBJDIR_NAME_BASE = $(OS_TARGET)$(OS_RELEASE)$(CPU_TAG)$(OBJDIR_NAME_COMPILER)$(LIBC_TAG)$(IMPL_STRATEGY)$(OBJDIR_TAG)
@@ -31,29 +31,9 @@
  
  
  ifeq (,$(filter-out WIN%,$(OS_TARGET)))
---- a/nss/coreconf/Linux.mk	2019-04-01 10:08:59.129269177 +0300
-+++ b/nss/coreconf/Linux.mk	2019-04-01 10:09:15.557782574 +0300
-@@ -144,7 +144,8 @@
- 	DEFINES		+= -D_REENTRANT
- endif
- 
-+ifndef USE_NATIVE
--DSO_CFLAGS		= -fPIC
-+DSO_CFLAGS		= $(fpic)
- DSO_LDOPTS		= -shared $(ARCHFLAG) -Wl,--gc-sections
- # The linker on Red Hat Linux 7.2 and RHEL 2.1 (GNU ld version 2.11.90.0.8)
- # incorrectly reports undefined references in the libraries we link with, so
-@@ -154,6 +155,7 @@
- ZDEFS_FLAG		= -Wl,-z,defs
- DSO_LDOPTS		+= $(if $(findstring 2.11.90.0.8,$(shell ld -v)),,$(ZDEFS_FLAG))
- LDFLAGS			+= $(ARCHFLAG) -z noexecstack
-+endif
- 
- # On Maemo, we need to use the -rpath-link flag for even the standard system
- # library directories.
---- a/nss/coreconf/Linux.mk	2019-04-06 20:25:36.431663894 +0300
-+++ b/nss/coreconf/Linux.mk	2019-04-06 20:26:23.397129525 +0300
-@@ -108,11 +108,6 @@
+--- a/nss/coreconf/Linux.mk
++++ b/nss/coreconf/Linux.mk
+@@ -108,11 +108,6 @@ LIBC_TAG		= _glibc
  endif
  
  ifdef BUILD_OPT
@@ -65,18 +45,36 @@
  ifdef MOZ_DEBUG_SYMBOLS
  	ifdef MOZ_DEBUG_FLAGS
  		OPTIMIZER += $(MOZ_DEBUG_FLAGS)
-@@ -192,7 +192,7 @@
+@@ -144,7 +139,8 @@ ifdef USE_PTHREADS
+ 	DEFINES		+= -D_REENTRANT
+ endif
+ 
+-DSO_CFLAGS		= -fPIC
++ifndef USE_NATIVE
++DSO_CFLAGS		= $(fpic)
+ DSO_LDOPTS		= -shared $(ARCHFLAG) -Wl,--gc-sections
+ # The linker on Red Hat Linux 7.2 and RHEL 2.1 (GNU ld version 2.11.90.0.8)
+ # incorrectly reports undefined references in the libraries we link with, so
+@@ -154,6 +150,7 @@ DSO_LDOPTS		= -shared $(ARCHFLAG) -Wl,--
+ ZDEFS_FLAG		= -Wl,-z,defs
+ DSO_LDOPTS		+= $(if $(findstring 2.11.90.0.8,$(shell ld -v)),,$(ZDEFS_FLAG))
+ LDFLAGS			+= $(ARCHFLAG) -z noexecstack
++endif
+ 
+ # On Maemo, we need to use the -rpath-link flag for even the standard system
+ # library directories.
+@@ -195,7 +192,7 @@ RPATH = -Wl,-rpath,'$$ORIGIN:/opt/sun/pr
  endif
  endif
-
+ 
 -MKSHLIB         = $(CC) $(DSO_LDOPTS) -Wl,-soname -Wl,$(@:$(OBJDIR)/%.so=%.so) $(RPATH)
 +MKSHLIB         = $(CC) $(DSO_LDOPTS) -Wl,-soname -Wl,$(@:$(OBJDIR)/%.so=%.so) $(RPATH) $(fpic) -Wl,--gc-sections,--as-needed
-
+ 
  ifdef MAPFILE
  	MKSHLIB += -Wl,--version-script,$(MAPFILE)
---- a/nss/coreconf/UNIX.mk	2019-04-06 20:34:24.284157646 +0300
-+++ b/nss/coreconf/UNIX.mk	2019-04-06 20:34:34.760485327 +0300
-@@ -10,7 +10,6 @@
+--- a/nss/coreconf/UNIX.mk
++++ b/nss/coreconf/UNIX.mk
+@@ -10,7 +10,6 @@ AR          = ar cr $@
  LDOPTS     += -L$(SOURCE_LIB_DIR)
  
  ifdef BUILD_OPT

--- a/libs/nss/patches/010-nanosleep.patch
+++ b/libs/nss/patches/010-nanosleep.patch
@@ -12,7 +12,7 @@
  
 --- a/nss/lib/sqlite/sqlite3.c
 +++ b/nss/lib/sqlite/sqlite3.c
-@@ -39626,7 +39626,8 @@ static int proxyConchLock(unixFile *pFile, uuid_t myHostID, int lockType){
+@@ -39626,7 +39626,8 @@ static int proxyConchLock(unixFile *pFil
        
        if( nTries==1 ){
          conchModTime = buf.st_mtimespec;
@@ -22,7 +22,7 @@
          continue;  
        }
  
-@@ -39652,7 +39653,7 @@ static int proxyConchLock(unixFile *pFile, uuid_t myHostID, int lockType){
+@@ -39652,7 +39653,7 @@ static int proxyConchLock(unixFile *pFil
            /* don't break the lock on short read or a version mismatch */
            return SQLITE_BUSY;
          }

--- a/libs/nss/patches/020-getopt.patch
+++ b/libs/nss/patches/020-getopt.patch
@@ -1,0 +1,12 @@
+--- a/nss/coreconf/nsinstall/nsinstall.c
++++ b/nss/coreconf/nsinstall/nsinstall.c
+@@ -36,8 +36,8 @@ typedef unsigned int mode_t;
+ #undef HAVE_FCHMOD
+ #endif
+ 
+-#ifdef LINUX
+ #include <getopt.h>
++#ifdef LINUX
+ #endif
+ 
+ #if defined(SCO) || defined(UNIXWARE) || defined(SNI) || defined(NCR) || defined(NEC)


### PR DESCRIPTION
Added patch to fix compilation with musl 1.2.x.

Refreshed others.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: ath79

@lucize what's with the first patch? It's creating files that were apparently present before but no longer are.

edit: NVM I see now.