### PR TITLE
knot: update to version 3.0.3

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.0.2
+PKG_VERSION:=3.0.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=f813a5e53263ef51d0415508e1f7d33cfbb75a139ccb10a344ae5a91689933fb
+PKG_HASH:=fbc51897ef0ed0639ebad59b988a91382b9544288a2db8254f0b1de433140e38
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 5.2 (hbl)
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 5.1.2 (hbk), all tests successful (1 skipped)

Description:
- Release patch
