### PR TITLE
[19.07] samba4: update to 4.11.17

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.11.12
+PKG_VERSION:=4.11.17
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -13,7 +13,7 @@ PKG_SOURCE_URL:= \
 		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
-PKG_HASH:=cff839c06f9b0ea2d84eb45e62b25d2917acc5fb3c5b033c6c4ed5e0899badb2
+PKG_HASH:=15167da19922c7be210ecf8149b73abcb7c2be051de05b756f7f24e7ec9e5b04
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: arm/mvebu
Run tested: qemu/arm

Description:
* update to 4.11.17
* fix CVE-2020-1472, CVE-2020-14318, CVE-2020-14323, CVE-2020-14383