### PR TITLE
treewide: move binaries of alternatives to /usr/libexec

### DIFF
--- a/devel/diffutils/Makefile
+++ b/devel/diffutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=diffutils
 PKG_VERSION:=3.7
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/diffutils
@@ -31,9 +31,8 @@ define Package/diffutils
   TITLE:=diffutils
   URL:=http://www.gnu.org/software/diffutils/
   ALTERNATIVES:=\
-    200:/usr/bin/cmp:/usr/bin/gnu-cmp \
-    200:/usr/bin/diff:/usr/bin/gnu-diff \
-
+    200:/usr/bin/cmp:/usr/libexec/cmp-gnu \
+    200:/usr/bin/diff:/usr/libexec/diff-gnu
 endef
 
 define Package/diffutils/description
@@ -48,8 +47,9 @@ CONFIGURE_VARS += \
 define Package/diffutils/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/{sdiff,diff3} $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/diff $(1)/usr/bin/gnu-diff
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/cmp $(1)/usr/bin/gnu-cmp
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/diff $(1)/usr/libexec/diff-gnu
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/cmp $(1)/usr/libexec/cmp-gnu
 endef
 
 $(eval $(call BuildPackage,diffutils))

--- a/net/bridge-utils/Makefile
+++ b/net/bridge-utils/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=bridge-utils
 PKG_VERSION:=1.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/shemminger/bridge-utils
@@ -31,7 +31,7 @@ define Package/bridge
   CATEGORY:=Base system
   TITLE:=Ethernet bridging configuration utility
   URL:=http://www.linuxfromscratch.org/blfs/view/svn/basicnet/bridge-utils.html
-  ALTERNATIVES:=300:/usr/sbin/brctl:/usr/libexec/bridge-utils-brctl
+  ALTERNATIVES:=300:/usr/sbin/brctl:/usr/libexec/brctl-bridge-utils
 endef
 
 define Package/bridge/description
@@ -44,7 +44,7 @@ CONFIGURE_ARGS += \
 
 define Package/bridge/install
 	$(INSTALL_DIR) $(1)/usr/libexec
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/brctl $(1)/usr/libexec/bridge-utils-brctl
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/brctl $(1)/usr/libexec/brctl-bridge-utils
 endef
 
 $(eval $(call BuildPackage,bridge))

--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
 PKG_VERSION:=8.4p1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
@@ -49,9 +49,8 @@ define Package/openssh-client
 	$(call Package/openssh/Default)
 	TITLE+= client
 	ALTERNATIVES:=\
-		200:/usr/bin/ssh:/usr/bin/openssh-ssh \
-		200:/usr/bin/scp:/usr/bin/openssh-scp \
-
+		200:/usr/bin/ssh:/usr/libexec/ssh-openssh \
+		200:/usr/bin/scp:/usr/libexec/scp-openssh
 endef
 
 define Package/openssh-client/description
@@ -197,9 +196,9 @@ define Package/openssh-client/install
 	$(INSTALL_DIR) $(1)/etc/ssh
 	chmod 0700 $(1)/etc/ssh
 	$(CP) $(PKG_INSTALL_DIR)/etc/ssh/ssh_config $(1)/etc/ssh/
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ssh $(1)/usr/bin/openssh-ssh
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/scp $(1)/usr/bin/openssh-scp
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ssh $(1)/usr/libexec/ssh-openssh
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/scp $(1)/usr/libexec/scp-openssh
 endef
 
 define Package/openssh-client-utils/install

--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wget
 PKG_VERSION:=1.20.3
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -47,7 +47,7 @@ $(call Package/wget/Default)
   TITLE+= (with SSL support)
   VARIANT:=ssl
   PROVIDES+=wget-ssl
-  ALTERNATIVES:=300:/usr/bin/wget:/usr/bin/wget-ssl
+  ALTERNATIVES:=300:/usr/bin/wget:/usr/libexec/wget-ssl
 endef
 
 define Package/wget/description
@@ -60,7 +60,7 @@ $(call Package/wget/Default)
   TITLE+= (without SSL support)
   VARIANT:=nossl
   PROVIDES+=wget
-  ALTERNATIVES:=300:/usr/bin/wget:/usr/bin/wget-nossl
+  ALTERNATIVES:=300:/usr/bin/wget:/usr/libexec/wget-nossl
 endef
 
 define Package/wget-nossl/description
@@ -95,13 +95,13 @@ ifeq ($(BUILD_VARIANT),nossl)
 endif
 
 define Package/wget/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/wget $(1)/usr/bin/wget-ssl
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/wget $(1)/usr/libexec/wget-ssl
 endef
 
 define Package/wget-nossl/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/wget $(1)/usr/bin/wget-nossl
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/wget $(1)/usr/libexec/wget-nossl
 endef
 
 $(eval $(call BuildPackage,wget))

--- a/utils/coreutils/Makefile
+++ b/utils/coreutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coreutils
 PKG_VERSION:=8.32
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/coreutils
@@ -56,9 +56,9 @@ DIR_OTHERS := \
 	base32 b2sum basenc csplit dir dircolors fmt join numfmt pathchk pinky	\
 	pr ptx sha224sum sha384sum stdbuf tsort vdir
 
-$(eval $(foreach a,$(DIR_BIN),ALTS_$(a):=300:/bin/$(a):/usr/bin/gnu-$(a)$(newline)))
-$(eval $(foreach a,$(DIR_USR_BIN),ALTS_$(a):=300:/usr/bin/$(a):/usr/bin/gnu-$(a)$(newline)))
-$(eval $(foreach a,$(DIR_USR_SBIN),ALTS_$(a):=300:/usr/sbin/$(a):/usr/bin/gnu-$(a)$(newline)))
+$(eval $(foreach a,$(DIR_BIN),ALTS_$(a):=300:/bin/$(a):/usr/libexec/$(a)-coreutils$(newline)))
+$(eval $(foreach a,$(DIR_USR_BIN),ALTS_$(a):=300:/usr/bin/$(a):/usr/libexec/$(a)-coreutils$(newline)))
+$(eval $(foreach a,$(DIR_USR_SBIN),ALTS_$(a):=300:/usr/sbin/$(a):/usr/libexec/$(a)-coreutils$(newline)))
 
 DEPENDS_sort = +libpthread
 DEPENDS_timeout = +librt
@@ -137,8 +137,8 @@ endef
 
 define BuildPlugin
   define Package/$(1)/install
-	$(INSTALL_DIR) $$(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/$(2) $$(1)/usr/bin/$(if $(ALTS_$(2)),gnu-$(2),$(2))
+	$(INSTALL_DIR) $$(1)/usr/$(if $(ALTS_$(2)),libexec,bin)
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/$(2) $$(1)/usr/$(if $(ALTS_$(2)),libexec/$(2)-coreutils,bin/$(2))
 	$(foreach f,$(FILES_$(2)),
 		$(INSTALL_DIR) $$(1)/$(dir $(f))
 		$(INSTALL_BIN) $(PKG_INSTALL_DIR)/$(f) $$(1)/$(f)

--- a/utils/findutils/Makefile
+++ b/utils/findutils/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=findutils
 PKG_VERSION:=4.7.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -49,13 +49,13 @@ endef
 define Package/findutils-find
 	$(call Package/findutils/Default)
 	TITLE+= - find utility
-	ALTERNATIVES:=300:/usr/bin/find:/usr/libexec/findutils-find
+	ALTERNATIVES:=300:/usr/bin/find:/usr/libexec/find-findutils
 endef
 
 define Package/findutils-xargs
 	$(call Package/findutils/Default)
 	TITLE+= - xargs utility
-	ALTERNATIVES:=300:/usr/bin/xargs:/usr/libexec/findutils-xargs
+	ALTERNATIVES:=300:/usr/bin/xargs:/usr/libexec/xargs-findutils
 endef
 
 define Package/findutils-locate
@@ -74,12 +74,12 @@ endef
 
 define Package/findutils-find/install
 	$(INSTALL_DIR) $(1)/usr/libexec
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/find $(1)/usr/libexec/findutils-find
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/find $(1)/usr/libexec/find-findutils
 endef
 
 define Package/findutils-xargs/install
 	$(INSTALL_DIR) $(1)/usr/libexec
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/xargs $(1)/usr/libexec/findutils-xargs
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/xargs $(1)/usr/libexec/xargs-findutils
 endef
 
 define Package/findutils-locate/install

--- a/utils/xz/Makefile
+++ b/utils/xz/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xz
 PKG_VERSION:=5.2.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/lzmautils
@@ -56,7 +56,7 @@ define BuildSubPackage
   $(call Package/xz/Default)
     DEPENDS:=xz-utils $(2)
     TITLE:=$(1) utility from XZ Utils
-    $(if $(3),ALTERNATIVES:=$(foreach f,$(1) $(3),300:/usr/bin/$(f):/usr/bin/lzmautils-$(1)))
+    $(if $(3),ALTERNATIVES:=$(foreach f,$(1) $(3),300:/usr/bin/$(f):/usr/libexec/$(1)-lzmautils))
   endef
 
   define Package/$(1)/description
@@ -64,8 +64,8 @@ define BuildSubPackage
   endef
 
   define Package/$(1)/install
-	$(INSTALL_DIR) $$(1)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/$(1) $$(1)/usr/bin/$(if $(3),lzmautils-$(1))
+	$(INSTALL_DIR) $$(1)$(if $(3),/usr/libexec,/usr/bin)
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/$(1) $$(1)$(if $(3),/usr/libexec/$(1)-lzmautils,/usr/bin/$(1))
   endef
 
   $$(eval $$(call BuildPackage,$(1)))


### PR DESCRIPTION
Maintainer: 
    coreutils: @neheb 
    binutils: @neheb @yousong 
    bridge-utils: @neheb 
    openssh: @tripolar @neheb 
    wget: @tripolar @yousong 
    findutils: @neheb 
    xz: @dangowrt @neheb 
Compile tested: ath79/nand
Run tested: ath79/nand

Description:
Move binaries of alternatives to /usr/libexec, rename as suggested in https://github.com/openwrt/packages/pull/12281#issuecomment-634015071.
