### PR TITLE
kadnode: link binary relative

### DIFF
--- a/net/kadnode/Makefile
+++ b/net/kadnode/Makefile
@@ -3,15 +3,15 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kadnode
 PKG_VERSION:=2.3.0
-PKG_RELEASE:=2
-
-PKG_LICENSE:=MIT
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://codeload.github.com/mwarning/KadNode/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=kadnode-$(PKG_VERSION).tar.gz
 PKG_HASH:=abb2ca66fb525fab53157d5486bbb43e3a522a4bdc9280a3dcb8cb403ee08583
 PKG_BUILD_DIR:=$(BUILD_DIR)/KadNode-$(PKG_VERSION)
 
+PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
+PKG_LICENSE:=MIT
 
 PKG_BUILD_PARALLEL:=1
 
@@ -25,7 +25,6 @@ define Package/kadnode
 	URL:=https://github.com/mwarning/KadNode
 	MENU:=1
 	DEPENDS:=+KADNODE_ENABLE_BOB:libmbedtls +KADNODE_ENABLE_TLS:libmbedtls +KADNODE_ENABLE_UPNP:libminiupnpc +KADNODE_ENABLE_NATPMP:libnatpmp
-	MAINTAINER:=Moritz Warning <moritzwarning@web.de>
 endef
 
 define Package/kadnode/description
@@ -84,7 +83,7 @@ define Package/kadnode/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/kadnode $(1)/usr/bin/
 ifeq ($(CONFIG_KADNODE_ENABLE_CMD),y)
-	$(LN) /usr/bin/kadnode $(1)/usr/bin/kadnode-ctl
+	$(LN) kadnode $(1)/usr/bin/kadnode-ctl
 endif
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) files/kadnode.init $(1)/etc/init.d/kadnode


### PR DESCRIPTION
Fixes dead symlink in InstallDev

Clean up Makefile for consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mwarning 
Compile tested: ath79