### PR TITLE
protobuf: fix bad CFLAGS in pkgconfig

### DIFF
--- a/libs/protobuf/Makefile
+++ b/libs/protobuf/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=protobuf
 PKG_VERSION:=3.14.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-cpp-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/google/protobuf/releases/download/v$(PKG_VERSION)

--- a/libs/protobuf/patches/010-rpath.patch
+++ b/libs/protobuf/patches/010-rpath.patch
@@ -1,7 +1,5 @@
-Index: protobuf-3.13.0/cmake/install.cmake
-===================================================================
---- protobuf-3.13.0.orig/cmake/install.cmake
-+++ protobuf-3.13.0/cmake/install.cmake
+--- a/cmake/install.cmake
++++ b/cmake/install.cmake
 @@ -16,8 +16,8 @@ foreach(_library ${_protobuf_libraries})
      $<BUILD_INTERFACE:${protobuf_source_dir}/src>
      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)

--- a/libs/protobuf/patches/020-threads.patch
+++ b/libs/protobuf/patches/020-threads.patch
@@ -1,0 +1,33 @@
+From db2c4f357432ee18975a69af71f50ed415584829 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Thu, 17 Dec 2020 20:54:48 -0800
+Subject: [PATCH] remove CMAKE_THREAD_LIBS_INIT from pkgconfig CFLAGS
+
+This is a linker flag and does not belong in CFLAGS.
+
+Fixes an issue with ola and protobuf.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ cmake/protobuf-lite.pc.cmake | 2 +-
+ cmake/protobuf.pc.cmake      | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+--- a/cmake/protobuf-lite.pc.cmake
++++ b/cmake/protobuf-lite.pc.cmake
+@@ -7,5 +7,5 @@ Name: Protocol Buffers
+ Description: Google's Data Interchange Format
+ Version: @protobuf_VERSION@
+ Libs: -L${libdir} -lprotobuf-lite @CMAKE_THREAD_LIBS_INIT@
+-Cflags: -I${includedir} @CMAKE_THREAD_LIBS_INIT@
++Cflags: -I${includedir}
+ Conflicts: protobuf
+--- a/cmake/protobuf.pc.cmake
++++ b/cmake/protobuf.pc.cmake
+@@ -7,5 +7,5 @@ Name: Protocol Buffers
+ Description: Google's Data Interchange Format
+ Version: @protobuf_VERSION@
+ Libs: -L${libdir} -lprotobuf @CMAKE_THREAD_LIBS_INIT@
+-Cflags: -I${includedir} @CMAKE_THREAD_LIBS_INIT@
++Cflags: -I${includedir}
+ Conflicts: protobuf-lite

--- a/net/ola/Makefile
+++ b/net/ola/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ola
 PKG_VERSION:=0.10.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/OpenLightingProject/ola/tar.gz/$(PKG_VERSION)?

--- a/net/ola/patches/010-no-werror.patch
+++ b/net/ola/patches/010-no-werror.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -61,7 +61,7 @@ COMMON_TESTING_PROTOBUF_FLAGS = $(COMMON
+ 
+ # The generated protobuf files don't compile with -Werror on win32 so we
+ # disable fatal warnings on WIN32.
+-if ! USING_WIN32
++if USING_WIN32
+ if FATAL_WARNINGS
+   COMMON_CXXFLAGS += -Werror
+   COMMON_PROTOBUF_CXXFLAGS += -Werror -Wno-error=unused-parameter \


### PR DESCRIPTION
Issue shows itself when using clang.

Refreshed other patch.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @kenkeys @bk138 
Compile tested: ath79
