### PR TITLE
pcscd: default /var/run path instead of /run

### DIFF
--- a/utils/pcsc-lite/Makefile
+++ b/utils/pcsc-lite/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pcsc-lite
 PKG_VERSION:=1.9.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://pcsclite.apdu.fr/files/
@@ -71,6 +71,7 @@ CONFIGURE_ARGS += \
 	--disable-libsystemd \
 	--enable-libusb \
 	--enable-static \
+	--enable-ipcdir=/var/run/pcscd \
 	--enable-usbdropdir=/usr/lib/pcsc/drivers
 
 define Build/InstallDev


### PR DESCRIPTION
Fix start error:
  00001221 [2012634380] pcscdaemon.c:624:main() cannot create /run/pcscd: No such file or directory

Signed-off-by: Vincent JARDIN <vjardin@free.fr>
