### PR TITLE
[19.07] simple-adblock: config update

### DIFF
--- a/net/simple-adblock/files/simple-adblock.conf
+++ b/net/simple-adblock/files/simple-adblock.conf
@@ -28,10 +28,6 @@ config simple-adblock 'config'
 # File size: 44.0K
 	list blocked_domains_url 'https://s3.amazonaws.com/lists.disconnect.me/simple_malvertising.txt'
 
-# File size: 584.0K
-# block-list too big for most routers
-#	list blocked_domains_url 'https://mirror1.malwaredomains.com/files/justdomains'
-
 # File size: 16.0K
 	list blocked_hosts_url 'https://adaway.org/hosts.txt'
 	

--- a/net/simple-adblock/files/simple-adblock.conf.update
+++ b/net/simple-adblock/files/simple-adblock.conf.update
@@ -11,3 +11,4 @@ s|raw.githubusercontent.com/jawz101/MobileAdTrackers/|cdn.jsdelivr.net/gh/jawz10
 s|http://winhelp2002.mvps.org/hosts.txt|https://winhelp2002.mvps.org/hosts.txt|g
 \|dshield.org|d
 \|www.malwaredomainlist.com/hostslist/hosts.txt|d
+\|https://mirror1.malwaredomains.com/files/justdomains|d


### PR DESCRIPTION
Maintainer: me
Compile tested: rampis, er-x, 19.07.5
Run tested: rampis, er-x, 19.07.5, start/dl/stop

Description: malwaredomains.com is gone, this update removes it from the config file.

Signed-off-by: Stan Grishin
