### PR TITLE
adblock: update 4.0.8

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=4.0.7
-PKG_RELEASE:=4
+PKG_VERSION:=4.0.8
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -24,9 +24,9 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 | energized_ultimate  |         | XXL  | compilation      | [Link](https://energized.pro)                                                     |
 | energized_unified   |         | XXL  | compilation      | [Link](https://energized.pro)                                                     |
 | firetv_tracking     |         | S    | tracking         | [Link](https://github.com/Perflyst/PiHoleBlocklist)                               |
+| games_tracking      |         | S    | tracking         | [Link](https://www.gameindustry.eu)                                               |
 | gaming              |         | S    | gaming           | [Link](https://github.com/abyssin/pihole-blocklist)                               |
 | malwaredomains      |         | M    | malware          | [Link](https://malwaredomains.com)                                                |
-| malwarelist         |         | S    | malware          | [Link](https://www.malwaredomainlist.com)                                         |
 | notracking          |         | XL   | tracking         | [Link](https://github.com/notracking/hosts-blocklists)                            |
 | oisd_nl             |         | XXL  | general          | [Link](https://oisd.nl)                                                           |
 | openphish           |         | S    | phishing         | [Link](https://openphish.com)                                                     |
@@ -59,7 +59,6 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 | whocares            |         | M    | general          | [Link](https://someonewhocares.org)                                               |
 | winhelp             |         | S    | general          | [Link](https://winhelp2002.mvps.org)                                              |
 | winspy              |         | S    | win_telemetry    | [Link](https://github.com/crazy-max/WindowsSpyBlocker)                            |
-| youtube             |         | M    | youtube          | [Link](https://github.com/kboghdady/youTube_ads_4_pi-hole)                        |
 | yoyo                | x       | S    | general          | [Link](https://pgl.yoyo.org/adservers)                                            |
 
 * List of supported and fully pre-configured adblock sources, already active sources are pre-selected.  

--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -11,7 +11,7 @@
 export LC_ALL=C
 export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
 set -o pipefail
-adb_ver="4.0.7"
+adb_ver="4.0.8"
 adb_enabled=0
 adb_debug=0
 adb_forcedns=0
@@ -50,7 +50,8 @@ adb_loggercmd="$(command -v logger)"
 adb_dumpcmd="$(command -v tcpdump)"
 adb_lookupcmd="$(command -v nslookup)"
 adb_fetchutil=""
-adb_portlist="53 853 5353"
+adb_zonelist=""
+adb_portlist=""
 adb_repiface=""
 adb_replisten="53"
 adb_repchunkcnt="5"
@@ -148,6 +149,12 @@ f_conf()
 			elif [ "${option}" = "adb_safesearchlist" ]
 			then
 				eval "${option}=\"$(printf "%s" "${adb_safesearchlist}") ${value}\""
+			elif [ "${option}" = "adb_zonelist" ]
+			then
+				eval "${option}=\"$(printf "%s" "${adb_zonelist}") ${value}\""
+			elif [ "${option}" = "adb_portlist" ]
+			then
+				eval "${option}=\"$(printf "%s" "${adb_portlist}") ${value}\""
 			fi
 		}
 	}
@@ -553,7 +560,7 @@ f_count()
 #
 f_extconf()
 {
-	local config config_dir config_file port fwcfg
+	local config config_dir config_file section zone port fwcfg
 
 	case "${adb_dns}" in
 		"dnsmasq")
@@ -579,33 +586,37 @@ f_extconf()
 	f_uci "${config}"
 
 	config="firewall"
-	fwcfg="$(uci -qNX show "${config}")"
+	fwcfg="$(uci -qNX show "${config}" | "${adb_awk}" 'BEGIN{FS="[.=]"};/adblock_/{if(zone==$2){next}else{ORS=" ";zone=$2;print zone}}')"
 	if [ "${adb_enabled}" -eq 1 ] && [ "${adb_forcedns}" -eq 1 ] && \
 		[ "$(/etc/init.d/firewall enabled; printf "%u" ${?})" -eq 0 ]
 	then
-		for port in ${adb_portlist}
+		for zone in ${adb_zonelist}
 		do
-			if [ -z "$(printf "%s" "${fwcfg}" | grep -Fo -m1 "adblock_dns_${port}")" ]
-			then
-				uci -q batch <<-EOC
-					set firewall."adblock_dns_${port}"="redirect"
-					set firewall."adblock_dns_${port}".name="Adblock DNS, port ${port}"
-					set firewall."adblock_dns_${port}".src="lan"
-					set firewall."adblock_dns_${port}".proto="tcp udp"
-					set firewall."adblock_dns_${port}".src_dport="${port}"
-					set firewall."adblock_dns_${port}".dest_port="${port}"
-					set firewall."adblock_dns_${port}".target="DNAT"
-				EOC
-			fi
+			for port in ${adb_portlist}
+			do
+				if [ -z "$(printf "%s" "${fwcfg}" | grep -o -m1 "adblock_${zone}${port}[ |\$]")" ]
+				then
+					uci -q batch <<-EOC
+						set firewall."adblock_${zone}${port}"="redirect"
+						set firewall."adblock_${zone}${port}".name="Adblock DNS (${zone}, ${port})"
+						set firewall."adblock_${zone}${port}".src="${zone}"
+						set firewall."adblock_${zone}${port}".proto="tcp udp"
+						set firewall."adblock_${zone}${port}".src_dport="${port}"
+						set firewall."adblock_${zone}${port}".dest_port="${port}"
+						set firewall."adblock_${zone}${port}".target="DNAT"
+					EOC
+				fi
+				fwcfg="${fwcfg/adblock_${zone}${port}[ |\$]/}"
+			done
 		done
-	elif [ "${adb_enabled}" -eq 0 ] || [ "${adb_forcedns}" -eq 0 ]
+		fwcfg="${fwcfg#"${fwcfg%%[![:space:]]*}"}"
+		fwcfg="${fwcfg%"${fwcfg##*[![:space:]]}"}"
+	fi
+	if [ "${adb_enabled}" -eq 0 ] || [ "${adb_forcedns}" -eq 0 ] || [ -n "${fwcfg}" ]
 	then
-		for port in ${adb_portlist}
+		for section in ${fwcfg}
 		do
-			if [ -n "$(printf "%s" "${fwcfg}" | grep -Fo -m1 "adblock_dns_${port}")" ]
-			then
-				uci_remove firewall "adblock_dns_${port}"
-			fi
+			uci_remove firewall "${section}"
 		done
 	fi
 	f_uci "${config}"
@@ -671,7 +682,7 @@ f_list()
 				rset="/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower(\$1)}"
 				"${adb_awk}" "${rset}" "${adb_blacklist}" | \
 				"${adb_awk}" 'BEGIN{FS="."}{for(f=NF;f>1;f--)printf "%s.",$f;print $1}' > "${adb_tmpdir}/tmp.raw.${src_name}"
-				sort ${adb_srtopts} -u "${adb_tmpdir}/tmp.raw.${src_name}" 2>/dev/null > "${adb_tmpfile}.${src_name}"
+				"${adb_sort}" ${adb_srtopts} -u "${adb_tmpdir}/tmp.raw.${src_name}" 2>/dev/null > "${adb_tmpfile}.${src_name}"
 				out_rc="${?}"
 				rm -f "${adb_tmpdir}/tmp.raw.${src_name}"
 			elif [ "${src_name}" = "whitelist" ] && [ -s "${adb_whitelist}" ]
@@ -887,7 +898,7 @@ f_list()
 				find "${adb_backupdir}" ${ffiles} -print0 2>/dev/null | xargs -0 rm 2>/dev/null
 			fi
 			unset src_name
-			sort ${adb_srtopts} -mu "${adb_tmpfile}".* 2>/dev/null > "${adb_tmpdir}/${adb_dnsfile}"
+			"${adb_sort}" ${adb_srtopts} -mu "${adb_tmpfile}".* 2>/dev/null > "${adb_tmpdir}/${adb_dnsfile}"
 			out_rc="${?}"
 			rm -f "${adb_tmpfile}".*
 		;;
@@ -1297,7 +1308,7 @@ f_main()
 						"${adb_awk}" 'BEGIN{FS="."}{for(f=NF;f>1;f--)printf "%s.",$f;print $1}' > "${src_tmpsort}"
 					fi
 					rm -f "${src_tmpload}"
-					sort ${adb_srtopts} -u "${src_tmpsort}" 2>/dev/null > "${src_tmpfile}"
+					"${adb_sort}" ${adb_srtopts} -u "${src_tmpsort}" 2>/dev/null > "${src_tmpfile}"
 					src_rc="${?}"
 					rm -f "${src_tmpsort}"
 					if [ "${src_rc}" -eq 0 ] && [ -s "${src_tmpfile}" ]
@@ -1335,7 +1346,7 @@ f_main()
 						"${adb_awk}" 'BEGIN{FS="."}{for(f=NF;f>1;f--)printf "%s.",$f;print $1}' > "${src_tmpsort}"
 					fi
 					rm -f "${src_tmpload}"
-					sort ${adb_srtopts} -u "${src_tmpsort}" 2>/dev/null > "${src_tmpfile}"
+					"${adb_sort}" ${adb_srtopts} -u "${src_tmpsort}" 2>/dev/null > "${src_tmpfile}"
 					src_rc="${?}"
 					rm -f "${src_tmpsort}"
 					if [ "${src_rc}" -eq 0 ] && [ -s "${src_tmpfile}" ]
@@ -1499,9 +1510,9 @@ f_report()
 			wait
 			if [ -s "${adb_reportdir}/adb_report.raw" ]
 			then
-				sort ${adb_srtopts} -k1 -k3 -k4 -k5 -k1 -ur "${adb_reportdir}/adb_report.raw" | \
+				"${adb_sort}" ${adb_srtopts} -k1 -k3 -k4 -k5 -k1 -ur "${adb_reportdir}/adb_report.raw" | \
 					"${adb_awk}" '{currA=($1+0);currB=$1;currC=substr($1,length($1),1);if(reqA==currB){reqA=0;printf "%s\t%s\n",d,$2}else if(currC=="+"){reqA=currA;d=$3"\t"$4"\t"$5"\t"$2}}' | \
-					sort ${adb_srtopts} -k1 -k2 -k3 -k4 -ur > "${adb_reportdir}/adb_report.srt"
+					"${adb_sort}" ${adb_srtopts} -k1 -k2 -k3 -k4 -ur > "${adb_reportdir}/adb_report.srt"
 				rm -f "${adb_reportdir}/adb_report.raw"
 			fi
 
@@ -1528,16 +1539,16 @@ f_report()
 					printf "%s" " \"${top}\": [ " >> "${adb_reportdir}/adb_report.json"
 					case "${top}" in
 						"top_clients")
-							"${adb_awk}" '{print $3}' "${adb_reportdir}/adb_report.srt" | sort ${adb_srtopts} | uniq -c | \
-								sort ${adb_srtopts} -nr | "${adb_awk}" '{ORS=" ";if(NR==1)printf "{ \"count\": \"%s\", \"address\": \"%s\" }",$1,$2; else if(NR<10)printf ", { \"count\": \"%s\", \"address\": \"%s\" }",$1,$2}' >> "${adb_reportdir}/adb_report.json"
+							"${adb_awk}" '{print $3}' "${adb_reportdir}/adb_report.srt" | "${adb_sort}" ${adb_srtopts} | uniq -c | \
+								"${adb_sort}" ${adb_srtopts} -nr | "${adb_awk}" '{ORS=" ";if(NR==1)printf "{ \"count\": \"%s\", \"address\": \"%s\" }",$1,$2; else if(NR<10)printf ", { \"count\": \"%s\", \"address\": \"%s\" }",$1,$2}' >> "${adb_reportdir}/adb_report.json"
 						;;
 						"top_domains")
-							"${adb_awk}" '{if($5!="NX")print $4}' "${adb_reportdir}/adb_report.srt" | sort ${adb_srtopts} | uniq -c | \
-								sort ${adb_srtopts} -nr | "${adb_awk}" '{ORS=" ";if(NR==1)printf "{ \"count\": \"%s\", \"address\": \"%s\" }",$1,$2; else if(NR<10)printf ", { \"count\": \"%s\", \"address\": \"%s\" }",$1,$2}' >> "${adb_reportdir}/adb_report.json"
+							"${adb_awk}" '{if($5!="NX")print $4}' "${adb_reportdir}/adb_report.srt" | "${adb_sort}" ${adb_srtopts} | uniq -c | \
+								"${adb_sort}" ${adb_srtopts} -nr | "${adb_awk}" '{ORS=" ";if(NR==1)printf "{ \"count\": \"%s\", \"address\": \"%s\" }",$1,$2; else if(NR<10)printf ", { \"count\": \"%s\", \"address\": \"%s\" }",$1,$2}' >> "${adb_reportdir}/adb_report.json"
 						;;
 						"top_blocked")
-							"${adb_awk}" '{if($5=="NX")print $4}' "${adb_reportdir}/adb_report.srt" | sort ${adb_srtopts} | uniq -c | \
-								sort ${adb_srtopts} -nr | "${adb_awk}" '{ORS=" ";if(NR==1)printf "{ \"count\": \"%s\", \"address\": \"%s\" }",$1,$2; else if(NR<10)printf ", { \"count\": \"%s\", \"address\": \"%s\" }",$1,$2}' >> "${adb_reportdir}/adb_report.json"
+							"${adb_awk}" '{if($5=="NX")print $4}' "${adb_reportdir}/adb_report.srt" | "${adb_sort}" ${adb_srtopts} | uniq -c | \
+								"${adb_sort}" ${adb_srtopts} -nr | "${adb_awk}" '{ORS=" ";if(NR==1)printf "{ \"count\": \"%s\", \"address\": \"%s\" }",$1,$2; else if(NR<10)printf ", { \"count\": \"%s\", \"address\": \"%s\" }",$1,$2}' >> "${adb_reportdir}/adb_report.json"
 						;;
 					esac
 					printf "%s" " ], " >> "${adb_reportdir}/adb_report.json"
@@ -1614,14 +1625,6 @@ f_report()
 	f_log "debug" "f_report ::: action: ${adb_action}, report: ${adb_report}, search: ${1}, count: ${2}, process: ${3}, print: ${4}, dump_util: ${adb_dumpcmd}, repdir: ${adb_reportdir}, repiface: ${adb_repiface:-"-"}, replisten: ${adb_replisten}, repchunksize: ${adb_repchunksize}, repchunkcnt: ${adb_repchunkcnt}, bg_pid: ${bg_pid}"
 }
 
-# awk selection
-#
-adb_awk="$(command -v gawk)"
-if [ -z "${adb_awk}" ]
-then
-	adb_awk="$(command -v awk)"
-fi
-
 # source required system libraries
 #
 if [ -r "/lib/functions.sh" ] && [ -r "/lib/functions/network.sh" ] && [ -r "/usr/share/libubox/jshn.sh" ]
@@ -1631,6 +1634,26 @@ then
 	. "/usr/share/libubox/jshn.sh"
 else
 	f_log "err" "system libraries not found"
+fi
+
+# awk selection
+#
+adb_awk="$(command -v gawk)"
+if [ -z "${adb_awk}" ]
+then
+	adb_awk="$(command -v awk)"
+	if [ -z "${adb_awk}" ]
+	then
+		f_log "err" "awk not found"
+	fi
+fi
+
+# sort selection
+#
+adb_sort="$(command -v gnu-sort)"
+if [ -z "${adb_sort}" ]
+then
+	f_log "err" "gnu-sort not found"
 fi
 
 # version information

--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -97,6 +97,13 @@
 		"focus": "tracking",
 		"descurl": "https://github.com/Perflyst/PiHoleBlocklist"
 	},
+	"games_tracking": {
+		"url": "https://raw.githubusercontent.com/KodoPengin/GameIndustry-hosts-Template/master/Main%20template/hosts",
+		"rule": "/^0\\.0\\.0\\.0[[:space:]]+([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($2)}",
+		"size": "S",
+		"focus": "tracking",
+		"descurl": "https://www.gameindustry.eu"
+	},
 	"gaming": {
 		"url": "https://raw.githubusercontent.com/stopgaming/pihole-blocklist/master/game.txt",
 		"rule": "/^0\\.0\\.0\\.0[[:space:]]+([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($2)}",
@@ -105,18 +112,11 @@
 		"descurl": "https://github.com/abyssin/pihole-blocklist"
 	},
 	"malwaredomains": {
-		"url": "https://mirror1.malwaredomains.com/files/justdomains",
+		"url": "https://mirror.cedia.org.ec/malwaredomains/justdomains",
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
 		"size": "M",
 		"focus": "malware",
 		"descurl": "https://www.malwaredomains.com"
-	},
-	"malwarelist": {
-		"url": "https://www.malwaredomainlist.com/hostslist/hosts.txt",
-		"rule": "/^127\\.0\\.0\\.1[[:space:]]+([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($2)}",
-		"size": "S",
-		"focus": "malware",
-		"descurl": "https://www.malwaredomainlist.com"
 	},
 	"notracking": {
 		"url": "https://raw.githubusercontent.com/notracking/hosts-blocklists/master/dnscrypt-proxy/dnscrypt-proxy.blacklist.txt",
@@ -353,13 +353,6 @@
 		"size": "S",
 		"focus": "win_telemetry",
 		"descurl": "https://github.com/crazy-max/WindowsSpyBlocker"
-	},
-	"youtube": {
-		"url": "https://raw.githubusercontent.com/kboghdady/youTube_ads_4_pi-hole/master/black.list",
-		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
-		"size": "M",
-		"focus": "youtube",
-		"descurl": "https://github.com/kboghdady/youTube_ads_4_pi-hole"
 	},
 	"yoyo": {
 		"url": "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=nohtml&showintro=0&mimetype=plaintext",


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: Raspberry Pi 4 Model B Rev 1.2, OpenWrt SNAPSHOT r15237-fca0eb2d92
Run tested: Raspberry Pi 4 Model B Rev 1.2, OpenWrt SNAPSHOT r15237-fca0eb2d92

Description:
* source changes:
  - add new source 'games_tracking' (https://www.gameindustry.eu)
  - change malwaredomains source mirror
  - remove malwarelist source (source is empty)
  - remove youtube source (does not work at all)
* support multiple firewall zones for dns redirects
* add firewall zone/port housekeeping
* fix dns backend detection in TurrisOS (LuCI change)
* add check for gnu-sort

Signed-off-by: Dirk Brenken <dev@brenken.org>
