### PR TITLE
lvm2: pass CC explicitly

### DIFF
--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=LVM2
 PKG_VERSION:=2.03.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://sourceware.org/pub/lvm2
@@ -67,6 +67,7 @@ endif
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \
+		CC="$(TARGET_CC)" \
 		CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS) $(FPIC)" \
 		DESTDIR="$(PKG_INSTALL_DIR)" \
 		$(MAKE_SHELL) \

--- a/utils/lvm2/patches/002-const-stdio.patch
+++ b/utils/lvm2/patches/002-const-stdio.patch
@@ -1,6 +1,6 @@
 --- a/lib/commands/toolcontext.c
 +++ b/lib/commands/toolcontext.c
-@@ -1599,7 +1599,7 @@ struct cmd_context *create_toolcontext(unsigned is_clvmd,
+@@ -1605,7 +1605,7 @@ struct cmd_context *create_toolcontext(u
  	/* FIXME Make this configurable? */
  	reset_lvm_errno(1);
  
@@ -9,7 +9,7 @@
  	/* Set in/out stream buffering before glibc */
  	if (set_buffering
  #ifdef SYS_gettid
-@@ -1980,7 +1980,7 @@ void destroy_toolcontext(struct cmd_context *cmd)
+@@ -1986,7 +1986,7 @@ void destroy_toolcontext(struct cmd_cont
  
  	if (cmd->pending_delete_mem)
  		dm_pool_destroy(cmd->pending_delete_mem);
@@ -20,7 +20,7 @@
  		if (is_valid_fd(STDIN_FILENO) &&
 --- a/tools/lvmcmdline.c
 +++ b/tools/lvmcmdline.c
-@@ -3230,6 +3230,7 @@ int lvm_split(char *str, int *argc, char **argv, int max)
+@@ -3241,6 +3241,7 @@ int lvm_split(char *str, int *argc, char
  /* Make sure we have always valid filedescriptors 0,1,2 */
  static int _check_standard_fds(void)
  {
@@ -28,7 +28,7 @@
  	int err = is_valid_fd(STDERR_FILENO);
  
  	if (!is_valid_fd(STDIN_FILENO) &&
-@@ -3256,6 +3257,12 @@ static int _check_standard_fds(void)
+@@ -3267,6 +3268,12 @@ static int _check_standard_fds(void)
  		       strerror(errno));
  		return 0;
  	}

--- a/utils/lvm2/patches/003-no-mallinfo.patch
+++ b/utils/lvm2/patches/003-no-mallinfo.patch
@@ -29,7 +29,7 @@
  
  		if (area == max_areas && missing > 0) {
  			/* Too bad. Warn the user and proceed, as things are
-@@ -521,8 +527,13 @@ static void _lock_mem(struct cmd_context *cmd)
+@@ -521,8 +527,13 @@ static void _lock_mem(struct cmd_context
  	 * will not block memory locked thread
  	 * Note: assuming _memlock_count_daemon is updated before _memlock_count
  	 */

--- a/utils/lvm2/patches/004-device-include-goto-lable-as-well.patch
+++ b/utils/lvm2/patches/004-device-include-goto-lable-as-well.patch
@@ -15,7 +15,7 @@ on standard C libraries without O_DIRECT_SUPPORT.
 
 --- a/lib/device/dev-io.c
 +++ b/lib/device/dev-io.c
-@@ -374,7 +374,7 @@ int dev_open_flags(struct device *dev, int flags, int direct, int quiet)
+@@ -379,7 +379,7 @@ int dev_open_flags(struct device *dev, i
  		return 0;
  	}
  


### PR DESCRIPTION
It seems that in some situations, the host CC gets picked up. Just pass
the target one explicitly.

Refreshed patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: ath79