### PR TITLE
uacme: Update to 1.6

### DIFF
--- a/net/uacme/Makefile
+++ b/net/uacme/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uacme
-PKG_VERSION:=1.2.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.6
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ndilieto/uacme/tar.gz/upstream/$(PKG_VERSION)?
-PKG_HASH:=ccd6001e96ec2eb22a1d557bf8dcc4152a567782afc9a1e017a93d7de3b49833
+PKG_HASH:=baeb1621e4b5d3cbf339531aa8c0df29ccffbb9c996379265349976d2c09c259
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
Maintainer: @lucize 
Compile tested: mips_24kc, lantiq/xrx200, master
Run tested: mips_24kc, lantiq/xrx200, master

Description:
Update uacme from version 1.2.1 to 1.6. Includes number of changes: https://github.com/ndilieto/uacme/blob/v1.6/ChangeLog#L1-L58