### PR TITLE
ttyd: temporarily req login to mitigate non-luci lan access

### DIFF
--- a/utils/ttyd/files/ttyd.config
+++ b/utils/ttyd/files/ttyd.config
@@ -1,5 +1,5 @@
 
 config ttyd
 	option interface '@lan'
-	option command '/usr/libexec/login.sh'
+	option command '/bin/login'
 


### PR DESCRIPTION
ttyd via luci-app is authenticated. The underlying server is not, which means anyone with a port scanner on the lan has unauthenticated root level access to the device.

Require authentication in the interim ( within luci also )... until a more elegant fix can be implemented by package maintainers.

Signed-off-by: Imran Khan <gururug@gmail.com>