### PR TITLE
mwan3: Use shebang in /etc/mwan3.user

### DIFF
--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
@@ -20,8 +20,7 @@
 		exit 0
 	}
 
-	env -i ACTION="$ACTION" INTERFACE="$INTERFACE" DEVICE="$DEVICE" \
-		/bin/sh /etc/mwan3.user
+	ACTION="$ACTION" INTERFACE="$INTERFACE" DEVICE="$DEVICE" /etc/mwan3.user
 }
 
 exit 0

--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
@@ -20,7 +20,7 @@
 		exit 0
 	}
 
-	ACTION="$ACTION" INTERFACE="$INTERFACE" DEVICE="$DEVICE" /etc/mwan3.user
+	env -i ACTION="$ACTION" INTERFACE="$INTERFACE" DEVICE="$DEVICE" /etc/mwan3.user
 }
 
 exit 0


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: x86, 19.07.3
Run tested: x86, 19.07.3, restarted mwan3

Description:
To allow the script to define what it should be run with using shebang.

This let's the user use bash if it's available, or python, or perl, etc.

This will also require that /etc/mwan3.user be set as executable.

Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>