### PR TITLE
nft-qos: silence buildsystem errors

### DIFF
--- a/net/nft-qos/files/nft-qos.init
+++ b/net/nft-qos/files/nft-qos.init
@@ -3,12 +3,12 @@
 # Copyright (C) 2018 rosysong@rosinson.com
 #
 
-. /lib/nft-qos/core.sh
-. /lib/nft-qos/monitor.sh
-. /lib/nft-qos/dynamic.sh
-. /lib/nft-qos/static.sh
-. /lib/nft-qos/mac.sh
-. /lib/nft-qos/priority.sh
+. "${IPKG_INSTROOT}/lib/nft-qos/core.sh"
+. "${IPKG_INSTROOT}/lib/nft-qos/monitor.sh"
+. "${IPKG_INSTROOT}/lib/nft-qos/dynamic.sh"
+. "${IPKG_INSTROOT}/lib/nft-qos/static.sh"
+. "${IPKG_INSTROOT}/lib/nft-qos/mac.sh"
+. "${IPKG_INSTROOT}/lib/nft-qos/priority.sh"
 
 START=99
 USE_PROCD=1


### PR DESCRIPTION
Maintainer: @rosysong 

add IPKG_INSTROOT to init script to
silence build system errors

Signed-off-by: Imran Khan <gururug@gmail.com>
