### PR TITLE
bind: add nsupdate and nslookup to tools subpackage

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.16.8
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -214,6 +214,8 @@ endef
 define Package/bind-tools/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/delv $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nsupdate $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nslookup $(1)/usr/bin/
 endef
 
 define Package/bind-rndc/install


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: x86_64, generic, HEAD (b0cb305236)
Run tested: same, built and installed bind-tools... using it for scripting tests to handle CNAME, MX, and SRV records

Description:

Adding support for `domain` (`A`/`PTR`), `srvhost` (`SRV`), `mxhost` (`MX`), `cname` (`CNAME`) `config` record types.