### PR TITLE
gnutls: update to 3.7.0

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
-PKG_VERSION:=3.6.15
+PKG_VERSION:=3.7.0
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6
-PKG_HASH:=0ea8c3283de8d8335d7ae338ef27c53a916f15f382753b174c18b45ffd481558
-#PKG_FIXUP:=autoreconf gettext-version
+PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7
+PKG_HASH:=49e2a22691d252c9f24a9829b293a8f359095bc5a818351f05f1c0a5188a1df8
+PKG_FIXUP:=autoreconf gettext-version
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <nmav@gnutls.org>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_CPE_ID:=cpe:/a:gnu:gnutls

--- a/libs/gnutls/patches/010-m4.patch
+++ b/libs/gnutls/patches/010-m4.patch
@@ -1,0 +1,73 @@
+--- a/m4/stdint.m4
++++ b/m4/stdint.m4
+@@ -15,7 +15,7 @@ AC_DEFUN_ONCE([gl_STDINT_H],
+   AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
+ 
+   AC_REQUIRE([gl_LIMITS_H])
+-  AC_REQUIRE([gt_TYPE_WINT_T])
++  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
+ 
+   dnl For backward compatibility. Some packages may still be testing these
+   dnl macros.
+--- a/m4/vasnprintf.m4
++++ b/m4/vasnprintf.m4
+@@ -33,7 +33,7 @@ AC_DEFUN([gl_REPLACE_VASNPRINTF],
+ AC_DEFUN([gl_PREREQ_PRINTF_ARGS],
+ [
+   AC_REQUIRE([gt_TYPE_WCHAR_T])
+-  AC_REQUIRE([gt_TYPE_WINT_T])
++  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
+ ])
+ 
+ # Prerequisites of lib/printf-parse.h, lib/printf-parse.c.
+@@ -41,7 +41,7 @@ AC_DEFUN([gl_PREREQ_PRINTF_PARSE],
+ [
+   AC_REQUIRE([gl_FEATURES_H])
+   AC_REQUIRE([gt_TYPE_WCHAR_T])
+-  AC_REQUIRE([gt_TYPE_WINT_T])
++  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
+   AC_REQUIRE([AC_TYPE_SIZE_T])
+   AC_CHECK_TYPE([ptrdiff_t], ,
+     [AC_DEFINE([ptrdiff_t], [long],
+@@ -55,7 +55,7 @@ AC_DEFUN_ONCE([gl_PREREQ_VASNPRINTF],
+ [
+   AC_REQUIRE([AC_FUNC_ALLOCA])
+   AC_REQUIRE([gt_TYPE_WCHAR_T])
+-  AC_REQUIRE([gt_TYPE_WINT_T])
++  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
+   AC_CHECK_FUNCS([snprintf strnlen wcslen wcsnlen mbrtowc wcrtomb])
+   dnl Use the _snprintf function only if it is declared (because on NetBSD it
+   dnl is defined as a weak alias of snprintf; we prefer to use the latter).
+--- a/m4/wchar_t.m4
++++ b/m4/wchar_t.m4
+@@ -8,7 +8,7 @@ dnl From Bruno Haible.
+ dnl Test whether <stddef.h> has the 'wchar_t' type.
+ dnl Prerequisite: AC_PROG_CC
+ 
+-AC_DEFUN([gt_TYPE_WCHAR_T],
++AC_DEFUN([gt_TYPE_WCHAR_T_GNUTLS],
+ [
+   AC_CACHE_CHECK([for wchar_t], [gt_cv_c_wchar_t],
+     [AC_COMPILE_IFELSE(
+--- a/m4/wint_t.m4
++++ b/m4/wint_t.m4
+@@ -9,7 +9,7 @@ dnl Test whether <wchar.h> has the 'wint
+ dnl <wchar.h> or <wctype.h> would, if present, override 'wint_t'.
+ dnl Prerequisite: AC_PROG_CC
+ 
+-AC_DEFUN([gt_TYPE_WINT_T],
++AC_DEFUN([gt_TYPE_WINT_T_GNUTLS],
+ [
+   AC_CACHE_CHECK([for wint_t], [gt_cv_c_wint_t],
+     [AC_COMPILE_IFELSE(
+--- a/src/gl/m4/gnulib-comp.m4
++++ b/src/gl/m4/gnulib-comp.m4
+@@ -1061,7 +1061,7 @@ changequote([, ])dnl
+   gl_UNISTD_MODULE_INDICATOR([sleep])
+   AC_CHECK_DECLS_ONCE([alarm])
+   AC_REQUIRE([gt_TYPE_WCHAR_T])
+-  AC_REQUIRE([gt_TYPE_WINT_T])
++  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
+   gl_FUNC_STRERROR_R
+   if test $HAVE_DECL_STRERROR_R = 0 || test $REPLACE_STRERROR_R = 1; then
+     AC_LIBOBJ([strerror_r])


### PR DESCRIPTION
Added autoreconf to fix bad linking under Arch Linux.

Added patch to fix compilation with autoreconf.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nmav 
Compile tested: ath79