### PR TITLE
adblock: fix when PROCD_RELOAD_DELAY is set

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
 PKG_VERSION:=4.0.8
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -246,10 +246,10 @@ service_triggers()
 {
 	local trigger delay type
 
-	PROCD_RELOAD_DELAY=$((delay*1000))
 	trigger="$(uci_get adblock global adb_trigger)"
 	delay="$(uci_get adblock global adb_triggerdelay "2")"
 	type="$(uci_get adblock global adb_starttype "start")"
+	PROCD_RELOAD_DELAY=$((delay*1000))
 	if [ -n "${trigger}" ]
 	then
 		procd_add_interface_trigger "interface.*.up" "${trigger}" "${adb_init}" "${type}"


### PR DESCRIPTION
Maintainer: @dibdot 
Run tested: (ar71xx, WZR-600DHP, OpenWrt 19.07.5)

Description:

PROCD_RELOAD_DELAY was being set before "delay", so the "adb_triggedelay" option was having no effect.