### PR TITLE
zoneinfo: Updated to the latest release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2020d
+PKG_VERSION:=2020e
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=8d813957de363387696f05af8a8889afa282ab5016a764c701a20758d39cbaf3
+PKG_HASH:=0be1ba329eae29ae1b54057c3547b3e672f73b3ae7643aa87dac85122bec037e
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=6cf050ba28e8053029d3f32d71341d11a794c6b5dd51a77fc769d6dae364fad5
+   HASH:=3e10308976b09305d15cb4a32ff75483421f2063bfa24a9be366a027e7cd2902
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT/LEDE master
Run tested: n/a

Description:

   Briefly:

     Volgograd switches to Moscow time on 2020-12-27 at 02:00.

   Changes to future timestamps

     Volgograd changes time zone from +04 to +03 on 2020-12-27 at 02:00.
     (Thanks to Alexander Krivenyshev and Stepan Golosunov.)

   Changes to past timestamps

     Correct many pre-1986 transitions, fixing entries originally
     derived from Shanks.  The fixes include:
       - Australia: several 1917 through 1971 transitions
       - Bahamas: several 1941 through 1945 transitions
       - Bermuda: several 1917 through 1956 transitions
       - Belize: several 1942 through 1968 transitions
       - Ghana: several 1915 through 1956 transitions
       - Israel and Palestine: several 1940 through 1985 transitions
       - Kenya and adjacent: several 1908 through 1960 transitions
       - Nigeria and adjacent: correcting LMT in Lagos, and several 1905
         through 1919 transitions
       - Seychelles: the introduction of standard time in 1907, not 1906
       - Vanuatu: DST in 1973-1974, and a corrected 1984 transition
     (Thanks to P Chan.)

     Because of the Australia change, Australia/Currie (King Island) is
     no longer needed, as it is identical to Australia/Hobart for all
     timestamps since 1970 and was therefore created by mistake.
     Australia/Currie has been moved to the 'backward' file and its
     corrected data moved to the 'backzone' file.

   Changes to past time zone abbreviations and DST flags

     To better match legislation in Turks and Caicos, the 2015 shift to
     year-round observance of -04 is now modeled as AST throughout before
     returning to Eastern Time with US DST in 2018, rather than as
     maintaining EDT until 2015-11-01.  (Thanks to P Chan.)

   Changes to documentation

     The zic man page now documents zic's coalescing of transitions
     when a zone falls back just before DST springs forward.

