### PR TITLE
add SpamAssassin packages

### DIFF
--- a/lang/perl-html-parser/Makefile
+++ b/lang/perl-html-parser/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-html-parser
 PKG_VERSION:=3.72
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=http://www.cpan.org/authors/id/G/GA/GAAS/
 PKG_SOURCE:=HTML-Parser-$(PKG_VERSION).tar.gz
@@ -20,8 +20,10 @@ PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>
 PKG_CPE_ID:=cpe:/a:derrick_oswald:html-parser
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/perl/HTML-Parser-$(PKG_VERSION)
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/perl/HTML-Parser-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../perl/perlmod.mk
 
 define Package/perl-html-parser
@@ -45,5 +47,17 @@ define Package/perl-html-parser/install
 	$(call perlmod/Install,$(1),HTML auto/HTML)
 endef
 
+define Host/Configure
+	$(call perlmod/host/Configure,,,)
+endef
+
+define Host/Compile
+	$(call perlmod/host/Compile,,)
+endef
+
+define Host/Install
+	$(call perlmod/host/Install,$(1),)
+endef
 
 $(eval $(call BuildPackage,perl-html-parser))
+$(eval $(call HostBuild))

--- a/lang/perl-mail-spamassassin/Makefile
+++ b/lang/perl-mail-spamassassin/Makefile
@@ -1,0 +1,101 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-mail-spamassassin
+PKG_RELEASE:=1
+PKG_VERSION:=3.4.4
+PKG_HASH:=8ea27a165b81e3ce8c84ae85c3ecba1f2edfa04ef4a86f07fe28ab612fc8ff60
+
+PKG_SOURCE_NAME:=Mail-SpamAssassin
+PKG_SOURCE_URL:=@APACHE/spamassassin/source
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:apache:spamassassin
+
+PKG_BUILD_DEPENDS:=perl-dbi/host perl-html-parser/host perl-net-dns/host perl-netaddr-ip/host
+PKG_INSTALL:=1
+PKG_SOURCE_VERSION:=$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+CONFIGURE_PATH:=spamc
+
+define Package/spamassassin
+  SECTION:=mail
+  CATEGORY:=Mail
+  TITLE:=SpamAssassin
+  URL:=https://spamassassin.apache.org/
+  DEPENDS:=+perl +perlbase-autoloader +perlbase-config +perlbase-data +perlbase-digest \
+           +perlbase-encode +perlbase-essential +perlbase-file +perlbase-getopt \
+           +perlbase-hash +perlbase-mime +perlbase-net +perlbase-socket \
+           +perl-dbi +perl-html-parser +perl-net-dns +perl-netaddr-ip
+  VARIANT:=ssl
+endef
+
+define Package/spamc/Default
+  SECTION:=mail
+  CATEGORY:=Mail
+  TITLE:=SpamAssassin client binary
+  URL:=https://spamassassin.apache.org/
+  DEPENDS:=+zlib
+endef
+
+define Package/spamc
+  $(call Package/spamc/Default)
+  VARIANT:=nossl
+endef
+
+define Package/spamc-ssl
+  $(call Package/spamc/Default)
+  TITLE+= (with SSL)
+  DEPENDS+=+libopenssl
+  VARIANT:=ssl
+endef
+
+ifeq ($(BUILD_VARIANT),ssl)
+TARGET_CFLAGS += -DSPAMC_SSL
+CONFIGURE_ARGS += --enable-ssl
+endif
+
+define Package/spamassassin/conffiles
+/etc/mail/spamassassin
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+	$(call Build/Configure/Default)
+	( cd "$(PKG_BUILD_DIR)/$(CONFIGURE_PATH)" && ./version.h.pl --with-version=$(PKG_SOURCE_VERSION) )
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+	$(call Build/Compile/Default,,,spamc)
+endef
+
+define Package/spamassassin/install
+	$(call perlmod/Install,$(1),Mail/SpamAssassin auto/Mail/SpamAssassin)
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sa-awl $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sa-learn $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sa-compile $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/spamassassin $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sa-update $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/spamd $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sa-check_spamd $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/etc/mail/spamassassin
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/mail/spamassassin/* $(1)/etc/mail/spamassassin
+endef
+
+define Package/spamc/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/spamc $(1)/usr/bin
+endef
+
+Package/spamc-ssl/install = $(Package/spamc/install)
+
+$(eval $(call BuildPackage,spamassassin))
+$(eval $(call BuildPackage,spamc))
+$(eval $(call BuildPackage,spamc-ssl))

--- a/lang/perl-net-dns/Makefile
+++ b/lang/perl-net-dns/Makefile
@@ -1,0 +1,55 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-net-dns
+PKG_VERSION:=1.29
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=Net-DNS
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://www.net-dns.org/download
+PKG_HASH:=852d6ee87e8f0d014223026581cbb56924ba8cddd3ceb29c6191dbb6122d43c5
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=MIT
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include ../perl/perlmod.mk
+
+define Package/perl-net-dns
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Net::DNS DNS resolver implemented in Perl
+  URL:=https://www.net-dns.org/
+  DEPENDS:=perl +perlbase-essential +perlbase-io
+endef
+
+define Build/Configure
+        $(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+        $(call perlmod/Compile,,)
+endef
+
+define Package/perl-net-dns/install
+        $(call perlmod/Install,$(1),Net auto/Net)
+endef
+
+define Host/Configure
+        $(call perlmod/host/Configure,,,)
+endef
+
+define Host/Compile
+        $(call perlmod/host/Compile,,)
+endef
+
+define Host/Install
+        $(call perlmod/host/Install,$(1),)
+endef
+
+$(eval $(call BuildPackage,perl-net-dns))
+$(eval $(call HostBuild))

--- a/lang/perl-netaddr-ip/Makefile
+++ b/lang/perl-netaddr-ip/Makefile
@@ -1,0 +1,62 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-netaddr-ip
+PKG_VERSION:=4.079
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=NetAddr-IP
+PKG_SOURCE_URL:=https://www.cpan.org/authors/id/M/MI/MIKER/
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=ec5a82dfb7028bcd28bb3d569f95d87dd4166cc19867f2184ed3a59f6d6ca0e7
+
+PKG_LICENSE:=GPL-2.0-or-later Artistic-1.0-Perl
+PKG_LICENSE_FILES:=Copying
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/perl/NetAddr-IP-$(PKG_VERSION)
+HOST_BUILD_DEPENDS:=perl/host
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/NetAddr-IP-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include ../perl/perlmod.mk
+
+define Package/perl-netaddr-ip
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=NetAddr::IP - Manages IPv4 and IPv6 addresses and subnets
+  URL:=http://search.cpan.org/dist/NetAddr::IP/
+  DEPENDS:=perl +perlbase-essential +perlbase-test
+endef
+
+define Host/Configure
+	$(call perlmod/host/Configure,-noxs,,)
+	$(call Host/Configure/Default,,,Lite/Util)
+endef
+
+define Host/Compile
+	$(call Host/Compile/Default,,,Lite/Util)
+	$(call perlmod/host/Compile,,)
+endef
+
+define Host/Install
+	$(call perlmod/host/Install,$(1),)
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,-noxs,)
+	$(call Build/Configure/Default,,,Lite/Util)
+endef
+
+define Build/Compile
+	$(call Build/Compile/Default,,,Lite/Util)
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-netaddr-ip/install
+	$(call perlmod/Install,$(1),NetAddr auto/NetAddr)
+endef
+
+$(eval $(call BuildPackage,perl-netaddr-ip))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: me / @Naoir
Compile tested: x86_64
Run tested: x86_64 (spamc only)

Description:
Add SpamAssassin packages.
Mostly in order to have spamc available, but also as a first step towards actually running fully-featured SpamAssassin on OpenWrt one day (for that still many more Perl packages would need to be added).