### PR TITLE
exim: add package

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
 PKG_VERSION:=3.7.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -37,6 +37,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_GNUTLS_SRP \
 	CONFIG_GNUTLS_TPM \
 	CONFIG_LIBNETTLE_MINI \
+	CONFIG_PACKAGE_libgnutls-dane \
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -80,7 +81,7 @@ $(call Package/gnutls/Default)
   CATEGORY:=Utilities
   SUBMENU:=Encryption
   TITLE+= (utilities)
-  DEPENDS+= +libgnutls
+  DEPENDS+= +libgnutls +PACKAGE_libgnutls-dane:libgnutls-dane
 endef
 
 define Package/gnutls-utils/description
@@ -97,6 +98,12 @@ define Package/libgnutls
 $(call Package/gnutls/Default)
   TITLE+= (library)
   DEPENDS+= +libnettle +!LIBNETTLE_MINI:libgmp +GNUTLS_EXT_LIBTASN1:libtasn1 +GNUTLS_PKCS11:p11-kit +GNUTLS_CRYPTODEV:kmod-cryptodev +libatomic
+endef
+
+define Package/libgnutls-dane
+$(call Package/gnutls/Default)
+  TITLE+= (libgnutls-dane library)
+  DEPENDS:= +libgnutls +libunbound
 endef
 
 define Package/libgnutls/description
@@ -118,8 +125,6 @@ CONFIGURE_ARGS+= \
 	--disable-seccomp-tests \
 	--disable-tests \
 	--disable-valgrind-tests \
-	\
-	--disable-libdane \
 	--disable-ssl2-support \
 	--disable-ssl3-support \
 	--enable-local-libopts \
@@ -178,16 +183,20 @@ ifeq ($(CONFIG_GNUTLS_CRYPTODEV),y)
 CONFIGURE_ARGS += --enable-cryptodev
 endif
 
+ifeq ($(CONFIG_PACKAGE_libgnutls-dane),)
+CONFIGURE_ARGS += --disable-libdane
+endif
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib/pkgconfig
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/libgnutls.so* \
+		$(PKG_INSTALL_DIR)/usr/lib/*.so* \
 		$(1)/usr/lib/
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/include/gnutls \
 		$(1)/usr/include/
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/gnutls.pc \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc \
 		$(1)/usr/lib/pkgconfig/
 endef
 
@@ -244,7 +253,13 @@ define Package/libgnutls/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgnutls.so.* $(1)/usr/lib/
 endef
 
+define Package/libgnutls-dane/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgnutls-dane.so.* $(1)/usr/lib/
+endef
+
 
 $(eval $(call BuildPackage,certtool))
 $(eval $(call BuildPackage,gnutls-utils))
 $(eval $(call BuildPackage,libgnutls))
+$(eval $(call BuildPackage,libgnutls-dane))

--- a/mail/exim/Makefile
+++ b/mail/exim/Makefile
@@ -1,0 +1,288 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=exim
+PKG_VERSION:=4.94
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://ftp.exim.org/pub/exim/exim4/
+PKG_HASH:=f77ee8faf04f5db793243c3ae81c1f4e452cd6ad7dd515a80edf755c4b144bdb
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=LICENSE NOTICE
+PKG_CPE_ID:=cpe:/a:exim:exim
+
+PKG_CONFIG_DEPENDS:=\
+	CONFIG_BUILD_NLS \
+	CONFIG_PACKAGE_exim \
+	CONFIG_PACKAGE_exim-gnutls \
+	CONFIG_EXIM_GNUTLS_DANE \
+	CONFIG_PACKAGE_exim-openssl \
+	CONFIG_PACKAGE_exim-ldap \
+	CONFIG_PACKAGE_exim-lookup-mysql \
+	CONFIG_PACKAGE_exim-lookup-pgsql \
+	CONFIG_PACKAGE_exim-lookup-redis \
+	CONFIG_PACKAGE_exim-lookup-sqlite
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/nls.mk
+
+LOOKUPS:= \
+	cdb \
+	dbmdb \
+	dnsdb \
+	json%+PACKAGE_exim-lookup-json:jansson \
+	mysql%+PACKAGE_exim-lookup-mysql:libmariadb \
+	passwd \
+	pgsql%+PACKAGE_exim-lookup-pgsql:libpq \
+	redis%+PACKAGE_exim-lookup-redis:libhiredis \
+	sqlite%+PACKAGE_exim-lookup-sqlite:libsqlite3
+
+define Package/exim/Default
+  SECTION:=mail
+  CATEGORY:=Mail
+  DEPENDS:=+libdb47 +libpcre $(ICONV_DEPENDS) +BUILD_NLS:libidn2 +BUILD_NLS:libidn
+  TITLE:=Exim message transfer agent
+  URL:=http://www.exim.org/
+  USERID:=mail=42:mail=42
+endef
+
+define Package/exim
+  $(call Package/exim/Default)
+  VARIANT:=nossl
+  CONFLICTS:=exim-openssl exim-gnutls exim-ldap
+endef
+
+define Package/exim-gnutls
+  $(call Package/exim/Default)
+  TITLE+=(with GnuTLS)
+  VARIANT:=gnutls
+  DEPENDS+=+PACKAGE_exim-gnutls:libgnutls +EXIM_GNUTLS_DANE:libgnutls-dane
+  PROVIDES:=exim
+  CONFLICTS:=exim-openssl exim-ldap
+endef
+define Package/exim-openssl
+  $(call Package/exim/Default)
+  TITLE+=(with OpenSSL)
+  VARIANT:=openssl
+  DEPENDS+=+PACKAGE_exim-openssl:libopenssl
+  PROVIDES:=exim
+  CONFLICTS:=exim-ldap
+endef
+
+define Package/exim-ldap
+  $(call Package/exim/Default)
+  TITLE+=(with OpenSSL and OpenLDAP)
+  VARIANT:=ldap
+  DEPENDS+=+PACKAGE_exim-ldap:libopenssl +PACKAGE_exim-ldap:libsasl2 +PACKAGE_exim-ldap:libopenldap
+  PROVIDES:=exim
+endef
+
+define Package/exim/Default/description
+Exim is a message transfer agent (MTA) developed at the University of
+Cambridge for use on Unix systems connected to the Internet.
+endef
+
+define Package/exim/description
+$(call Package/exim/Default/description)
+
+This package provides Exim without TLS support.
+endef
+
+define Package/exim-gnutls/description
+$(call Package/exim/Default/description)
+
+This package provides Exim built with GnuTLS.
+endef
+
+define Package/exim-gnutls/config
+  	config EXIM_GNUTLS_DANE
+  		bool "exim-gnutls DANE support"
+  			depends on PACKAGE_exim-gnutls
+  			default n
+  			help
+  				Build exim-gnutls against libgnutls-dane for DANE support.
+  				libgnutls-dane depends on libunbound which depends on libopenssl.
+endef
+
+define Package/exim-openssl/description
+$(call Package/exim/Default/description)
+
+This package provides Exim built with OpenSSL.
+endef
+
+define Package/exim-ldap/description
+$(call Package/exim/Default/description)
+
+This package provides Exim built with OpenSSL, OpenLDAP and Cyrus SASL.
+endef
+
+define LookupGen
+define Package/exim-lookup-$(subst _,-,$(firstword $(subst %, ,$(1))))
+  SECTION:=mail
+  CATEGORY:=Mail
+  TITLE:=Exim lookup module $(firstword $(subst %, ,$(1)))
+  URL:=http://www.exim.org/
+  DEPENDS:=exim $(wordlist 2,$(words $(subst %, ,$(1))),$(subst %, ,$(1)))
+endef
+endef
+
+$(foreach file,$(LOOKUPS),$(eval $(call LookupGen,$(file))))
+
+define Package/exim/conffiles
+/etc/exim/exim.conf
+endef
+
+TARGET_CFLAGS += $(FPIC) -DNO_IP_OPTIONS -D_FILE_OFFSET_BITS=64
+
+MAKE_VARS += build=Linux-$$(ARCH)
+MAKE_FLAGS += AR="$$(TARGET_AR) r"
+HOST_MAKE_VARS += build=Linux-$$(ARCH)
+
+define Build/Configure
+	$(CP) $(PKG_BUILD_DIR)/src/EDITME $(PKG_BUILD_DIR)/Local/Makefile
+	echo "PID_FILE_PATH=/var/run/exim.pid" >> $(PKG_BUILD_DIR)/Local/Makefile
+	echo "BIN_DIRECTORY=/usr/sbin" >> $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%CONFIGURE_FILE=/usr/exim/configure%CONFIGURE_FILE=/etc/exim/exim.conf%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# EXIM_GROUP=%EXIM_GROUP=42%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# EXIM_USER=exim%EXIM_USER=42%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# INCLUDE=.*%INCLUDE=-I$(STAGING_DIR)/usr/include -I$(STAGING_DIR)/usr/include%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# HAVE_IPV6=YES%HAVE_IPV6=YES%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# WITH_CONTENT_SCAN=yes%WITH_CONTENT_SCAN=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# SUPPORT_MAILDIR=yes%SUPPORT_MAILDIR=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# SUPPORT_MAILSTORE=yes%SUPPORT_MAILSTORE=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# SUPPORT_MBX=yes%SUPPORT_MBX=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+# enable lookup modules
+	$(SED) 's%# LOOKUP_DSEARCH=yes%LOOKUP_DSEARCH=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+ifdef CONFIG_PACKAGE_exim-lookup-dbmdb
+	$(SED) 's%LOOKUP_DBM=yes%LOOKUP_DBM=2%' $(PKG_BUILD_DIR)/Local/Makefile
+else
+	$(SED) 's%LOOKUP_DBM=yes%# LOOKUP_DBM=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+endif
+ifdef CONFIG_PACKAGE_exim-lookup-dnsdb
+	$(SED) 's%LOOKUP_DNSDB=yes%LOOKUP_DNSDB=2%' $(PKG_BUILD_DIR)/Local/Makefile
+else
+	$(SED) 's%LOOKUP_DNSDB=yes%# LOOKUP_DNSDB=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+endif
+ifdef CONFIG_PACKAGE_exim-lookup-passwd
+	$(SED) 's%# LOOKUP_PASSWD=yes%LOOKUP_PASSWD=2%' $(PKG_BUILD_DIR)/Local/Makefile
+endif
+ifdef CONFIG_PACKAGE_exim-lookup-cdb
+	$(SED) 's%# LOOKUP_CDB=yes%LOOKUP_CDB=2%' $(PKG_BUILD_DIR)/Local/Makefile
+endif
+ifdef CONFIG_PACKAGE_exim-lookup-json
+	$(SED) 's%# LOOKUP_JSON=yes%LOOKUP_JSON=2\
+		\nLOOKUP_JSON_INCLUDE=-I$(STAGING_DIR)/usr/include\
+		\nLOOKUP_JSON_LIBS=-Wl,--no-as-needed -ljansson%' $(PKG_BUILD_DIR)/Local/Makefile
+endif
+ifdef CONFIG_PACKAGE_exim-lookup-pgsql
+	$(SED) 's%# LOOKUP_PGSQL=yes%LOOKUP_PGSQL=2\
+		\nLOOKUP_PGSQL_LIBS=-Wl,--no-as-needed -lpq%' $(PKG_BUILD_DIR)/Local/Makefile
+endif
+ifdef CONFIG_PACKAGE_exim-lookup-sqlite
+	$(SED) 's%# LOOKUP_SQLITE=yes%LOOKUP_SQLITE=2\
+		\nLOOKUP_SQLITE_LIBS=-Wl,--no-as-needed -lsqlite3%' $(PKG_BUILD_DIR)/Local/Makefile
+endif
+ifdef CONFIG_PACKAGE_exim-lookup-mysql
+	$(SED) 's%# LOOKUP_MYSQL=yes%LOOKUP_MYSQL=2\
+		\nLOOKUP_MYSQL_INCLUDE=-I$(STAGING_DIR)/usr/include/mysql\
+		\nLOOKUP_MYSQL_LIBS=-Wl,--no-as-needed -lmysqlclient%' $(PKG_BUILD_DIR)/Local/Makefile
+endif
+ifdef CONFIG_PACKAGE_exim-lookup-redis
+	$(SED) 's%# LOOKUP_REDIS=yes%LOOKUP_REDIS=2\
+		\nLOOKUP_REDIS_INCLUDE=-I$(STAGING_DIR)/usr/include/hiredis\
+		\nLOOKUP_REDIS_LIBS=-Wl,--no-as-needed -lhiredis%' $(PKG_BUILD_DIR)/Local/Makefile
+endif
+
+ifeq ($(CONFIG_BUILD_NLS),y)
+	$(SED) 's%# HAVE_ICONV=yes%HAVE_ICONV=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# CFLAGS=-O -I/usr/local/include%CFLAGS=$(TARGET_CFLAGS) $(ICONV_CPPFLAGS)%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# EXTRALIBS_EXIM=-L/usr/local/lib -liconv%EXTRALIBS_EXIM=-export-dynamic -rdynamic $(ICONV_LDFLAGS) -liconv -ldl%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# SUPPORT_I18N_2008=yes%SUPPORT_I18N_2008=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# LDFLAGS += -lidn -lidn2%LDFLAGS += -lidn -lidn2%' $(PKG_BUILD_DIR)/Local/Makefile
+else
+	$(SED) 's%# HAVE_ICONV=yes%HAVE_ICONV=no%' $(PKG_BUILD_DIR)/Local/Makefile
+endif
+
+	$(SED) 's%# AUTH_CRAM_MD5=yes%AUTH_CRAM_MD5=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# AUTH_DOVECOT=yes%AUTH_DOVECOT=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# AUTH_EXTERNAL=yes%AUTH_EXTERNAL=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# AUTH_PLAINTEXT=yes%AUTH_PLAINTEXT=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# AUTH_SPA=yes%AUTH_SPA=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+
+ifeq ($(BUILD_VARIANT),gnutls)
+	$(SED) 's%# USE_GNUTLS=yes%USE_GNUTLS=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# TLS_INCLUDE=-I/usr/local/.*%TLS_INCLUDE=-I$(STAGING_DIR)/usr/include%' $(PKG_BUILD_DIR)/Local/Makefile
+ifeq ($(CONFIG_EXIM_GNUTLS_DANE),y)
+	$(SED) 's%# TLS_LIBS=-lgnutls -lgnutls-dane%TLS_LIBS=-L$(STAGING_DIR)/usr/lib -lgnutls -lgnutls-dane%' $(PKG_BUILD_DIR)/Local/Makefile
+else
+	$(SED) 's%SUPPORT_DANE=yes%# SUPPORT_DANE=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# TLS_LIBS=-lgnutls -lgnutls-dane%TLS_LIBS=-L$(STAGING_DIR)/usr/lib -lgnutls%' $(PKG_BUILD_DIR)/Local/Makefile
+endif
+	$(SED) 's%# AUTH_TLS=yes%AUTH_TLS=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+endif
+ifneq ($(filter ldap openssl, $(BUILD_VARIANT)),)
+	$(SED) 's%# USE_OPENSSL=yes%USE_OPENSSL=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# TLS_INCLUDE=-I/usr/local/.*%TLS_INCLUDE=-I$(STAGING_DIR)/usr/include%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# TLS_LIBS=-lssl -lcrypto%TLS_LIBS=-L$(STAGING_DIR)/usr/lib -lssl -lcrypto%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# AUTH_TLS=yes%AUTH_TLS=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+endif
+ifeq ($(BUILD_VARIANT),ldap)
+	$(SED) 's%# LOOKUP_LDAP=yes%LOOKUP_LDAP=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# LDAP_LIB_TYPE=OPENLDAP2%LDAP_LIB_TYPE=OPENLDAP2%' $(PKG_BUILD_DIR)/Local/Makefile
+	echo "LOOKUP_LIBS+=-lldap -llber" >> $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# AUTH_CYRUS_SASL=yes%AUTH_CYRUS_SASL=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# AUTH_LIBS=-lsasl2%AUTH_LIBS=-lsasl2%' $(PKG_BUILD_DIR)/Local/Makefile
+endif
+ifeq ($(BUILD_VARIANT),nossl)
+	$(SED) 's%# DISABLE_TLS=yes%DISABLE_TLS=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%SUPPORT_DANE=yes%# SUPPORT_DANE=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+endif
+	$(SED) 's%# CFLAGS_DYNAMIC=-shared -rdynamic -fPIC%CFLAGS_DYNAMIC=-shared -rdynamic $(FPIC)%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# LOOKUP_MODULE_DIR=/usr/lib/exim/lookups/%LOOKUP_MODULE_DIR=/usr/lib/exim/lookups/%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%#DLOPEN_LOCAL_SCAN=yes%DLOPEN_LOCAL_SCAN=yes%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(call Build/Compile/Default,makefile)
+	$(CP) $(PKG_BUILD_DIR)/OS/os.h-Linux $(PKG_BUILD_DIR)/build-Linux-$(ARCH)/os.h
+	# overwrite types for cross-compile
+	# (is all the below true for glibc as well?)
+	echo '#include <inttypes.h>' >> $(PKG_BUILD_DIR)/build-Linux-$(ARCH)/os.h
+	echo '#define ip_options ip_opts' >> $(PKG_BUILD_DIR)/build-Linux-$(ARCH)/os.h
+	echo '#undef OFF_T_FMT' >> $(PKG_BUILD_DIR)/build-Linux-$(ARCH)/os.h
+	echo '#define OFF_T_FMT "%" PRId64' >> $(PKG_BUILD_DIR)/build-Linux-$(ARCH)/os.h
+	echo '#undef LONGLONG_T' >> $(PKG_BUILD_DIR)/build-Linux-$(ARCH)/os.h
+	echo '#define LONGLONG_T int64_t' >> $(PKG_BUILD_DIR)/build-Linux-$(ARCH)/os.h
+	echo '#ifndef NS_MAXMSG' >> $(PKG_BUILD_DIR)/build-Linux-$(ARCH)/os.h
+	echo '#define NS_MAXMSG 65535' >> $(PKG_BUILD_DIR)/build-Linux-$(ARCH)/os.h
+	echo '#endif' >> $(PKG_BUILD_DIR)/build-Linux-$(ARCH)/os.h
+	$(HOST_MAKE_VARS) $(MAKE) $(HOST_MAKE_FLAGS) $(HOST_MAKE_VARS) -C $(PKG_BUILD_DIR)/build-Linux-$(ARCH) macro_predef
+endef
+
+define Package/exim/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build-Linux-$(ARCH)/exim $(1)/usr/sbin
+endef
+
+Package/exim-gnutls/install = $(Package/exim/install)
+Package/exim-openssl/install = $(Package/exim/install)
+Package/exim-ldap/install = $(Package/exim/install)
+
+define LookupInstall
+define Package/exim-lookup-$(subst _,-,$(firstword $(subst %, ,$(1))))/install
+	$(INSTALL_DIR) $$(1)/usr/lib/exim/lookups
+	$(INSTALL_BIN) \
+		$(PKG_BUILD_DIR)/build-Linux-$(ARCH)/lookups/$(firstword $(subst %, ,$(1))).so \
+		$$(1)/usr/lib/exim/lookups
+endef
+endef
+
+$(foreach file,$(LOOKUPS),$(eval $(call LookupInstall,$(file))))
+
+$(eval $(call BuildPackage,exim))
+$(eval $(call BuildPackage,exim-gnutls))
+$(eval $(call BuildPackage,exim-openssl))
+$(eval $(call BuildPackage,exim-ldap))
+$(foreach file,$(LOOKUPS),$(eval $(call BuildPackage,exim-lookup-$(subst _,-,$(firstword $(subst %, ,$(file)))))))

--- a/mail/exim/patches/010-allow-json-dynamic-lookup.patch
+++ b/mail/exim/patches/010-allow-json-dynamic-lookup.patch
@@ -1,0 +1,11 @@
+--- a/src/drtables.c
++++ b/src/drtables.c
+@@ -662,7 +662,7 @@ addlookupmodule(NULL, &ibase_lookup_modu
+ addlookupmodule(NULL, &ldap_lookup_module_info);
+ #endif
+ 
+-#ifdef LOOKUP_JSON
++#if defined(LOOKUP_JSON) && LOOKUP_JSON!=2
+ addlookupmodule(NULL, &json_lookup_module_info);
+ #endif
+ 

--- a/mail/exim/patches/020-use-correct-printf-format-for-size-t.patch
+++ b/mail/exim/patches/020-use-correct-printf-format-for-size-t.patch
@@ -1,0 +1,22 @@
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sun, 27 Dec 2020 15:03:22 +0000
+Subject: [PATCH] use correct printf format for size_t
+
+pdkim.c: In function 'check_bare_ed25519_pubkey':
+pdkim.c:1355:60: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'size_t' {aka 'unsigned int'} [-Wformat=]
+   DEBUG(D_acl) debug_printf("DKIM: unexpected pubkey len %lu\n", p->key.len);
+                                                             ~~^     ~~~~~~~~~~
+                                                                                                                       %u
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+--- a/src/pdkim/pdkim.c
++++ b/src/pdkim/pdkim.c
+@@ -1352,7 +1352,7 @@ check_bare_ed25519_pubkey(pdkim_pubkey *
+ int excess = p->key.len - 32;
+ if (excess > 0)
+   {
+-  DEBUG(D_acl) debug_printf("DKIM: unexpected pubkey len %lu\n", p->key.len);
++  DEBUG(D_acl) debug_printf("DKIM: unexpected pubkey len %zu\n", p->key.len);
+   p->key.data += excess; p->key.len = 32;
+   }
+ }

--- a/mail/exim/patches/100-localscan_dlopen.patch
+++ b/mail/exim/patches/100-localscan_dlopen.patch
@@ -1,0 +1,258 @@
+--- a/src/config.h.defaults
++++ b/src/config.h.defaults
+@@ -33,6 +33,8 @@ Do not put spaces between # and the 'def
+ 
+ #define AUTH_VARS                     3
+ 
++#define DLOPEN_LOCAL_SCAN
++
+ #define BIN_DIRECTORY
+ 
+ #define CONFIGURE_FILE
+--- a/src/EDITME
++++ b/src/EDITME
+@@ -877,6 +877,24 @@ HEADERS_CHARSET="ISO-8859-1"
+ 
+ 
+ #------------------------------------------------------------------------------
++# On systems which support dynamic loading of shared libraries, Exim can
++# load a local_scan function specified in its config file instead of having
++# to be recompiled with the desired local_scan function. For a full
++# description of the API to this function, see the Exim specification.
++
++#DLOPEN_LOCAL_SCAN=yes
++
++# If you set DLOPEN_LOCAL_SCAN, then you need to include -rdynamic in the
++# linker flags.  Without it, the loaded .so won't be able to access any
++# functions from exim.
++
++LFLAGS = -rdynamic
++ifeq ($(OSTYPE),Linux)
++LFLAGS += -ldl
++endif
++
++
++#------------------------------------------------------------------------------
+ # The default distribution of Exim contains only the plain text form of the
+ # documentation. Other forms are available separately. If you want to install
+ # the documentation in "info" format, first fetch the Texinfo documentation
+--- a/src/globals.c
++++ b/src/globals.c
+@@ -42,6 +42,10 @@ int     optionlist_auths_size = nelem(op
+ 
+ uschar *no_aliases             = NULL;
+ 
++#ifdef DLOPEN_LOCAL_SCAN
++uschar *local_scan_path        = NULL;
++#endif
++
+ 
+ /* For comments on these variables, see globals.h. I'm too idle to
+ duplicate them here... */
+--- a/src/globals.h
++++ b/src/globals.h
+@@ -162,6 +162,9 @@ extern int (*receive_feof)(void);
+ extern int (*receive_ferror)(void);
+ extern BOOL (*receive_smtp_buffered)(void);
+ 
++#ifdef DLOPEN_LOCAL_SCAN
++extern uschar *local_scan_path;        /* Path to local_scan() library */
++#endif
+ 
+ /* For clearing, saving, restoring address expansion variables. We have to have
+ the size of this vector set explicitly, because it is referenced from more than
+--- a/src/local_scan.c
++++ b/src/local_scan.c
+@@ -5,61 +5,133 @@
+ /* Copyright (c) University of Cambridge 1995 - 2009 */
+ /* See the file NOTICE for conditions of use and distribution. */
+ 
+-
+-/******************************************************************************
+-This file contains a template local_scan() function that just returns ACCEPT.
+-If you want to implement your own version, you should copy this file to, say
+-Local/local_scan.c, and edit the copy. To use your version instead of the
+-default, you must set
+-
+-HAVE_LOCAL_SCAN=yes
+-LOCAL_SCAN_SOURCE=Local/local_scan.c
+-
+-in your Local/Makefile. This makes it easy to copy your version for use with
+-subsequent Exim releases.
+-
+-For a full description of the API to this function, see the Exim specification.
+-******************************************************************************/
+-
+-
+-/* This is the only Exim header that you should include. The effect of
+-including any other Exim header is not defined, and may change from release to
+-release. Use only the documented interface! */
+-
+ #include "local_scan.h"
+ 
+-
+-/* This is a "do-nothing" version of a local_scan() function. The arguments
+-are:
+-
+-  fd             The file descriptor of the open -D file, which contains the
+-                   body of the message. The file is open for reading and
+-                   writing, but modifying it is dangerous and not recommended.
+-
+-  return_text    A pointer to an unsigned char* variable which you can set in
+-                   order to return a text string. It is initialized to NULL.
+-
+-The return values of this function are:
+-
+-  LOCAL_SCAN_ACCEPT
+-                 The message is to be accepted. The return_text argument is
+-                   saved in $local_scan_data.
+-
+-  LOCAL_SCAN_REJECT
+-                 The message is to be rejected. The returned text is used
+-                   in the rejection message.
+-
+-  LOCAL_SCAN_TEMPREJECT
+-                 This specifies a temporary rejection. The returned text
+-                   is used in the rejection message.
+-*/
++#ifdef DLOPEN_LOCAL_SCAN
++#include <stdlib.h>
++#include <dlfcn.h>
++static int (*local_scan_fn)(int fd, uschar **return_text) = NULL;
++static int load_local_scan_library(void);
++extern uschar *local_scan_path;        /* Path to local_scan() library */
++#endif
+ 
+ int
+ local_scan(int fd, uschar **return_text)
+ {
+ fd = fd;                      /* Keep picky compilers happy */
+ return_text = return_text;
+-return LOCAL_SCAN_ACCEPT;
++#ifdef DLOPEN_LOCAL_SCAN
++/* local_scan_path is defined AND not the empty string */
++if (local_scan_path && *local_scan_path)
++  {
++  if (!local_scan_fn)
++    {
++    if (!load_local_scan_library())
++      {
++        char *base_msg , *error_msg , *final_msg ;
++        int final_length = -1 ;
++
++        base_msg=US"Local configuration error - local_scan() library failure\n";
++        error_msg = dlerror() ;
++
++        final_length = strlen(base_msg) + strlen(error_msg) + 1 ;
++        final_msg = (char*)malloc( final_length*sizeof(char) ) ;
++        *final_msg = '\0' ;
++
++        strcat( final_msg , base_msg ) ;
++        strcat( final_msg , error_msg ) ;
++
++        *return_text = final_msg ;
++      return LOCAL_SCAN_TEMPREJECT;
++      }
++    }
++    return local_scan_fn(fd, return_text);
++  }
++else
++#endif
++  return LOCAL_SCAN_ACCEPT;
+ }
+ 
++#ifdef DLOPEN_LOCAL_SCAN
++
++static int load_local_scan_library(void)
++{
++/* No point in keeping local_scan_lib since we'll never dlclose() anyway */
++void *local_scan_lib = NULL;
++int (*local_scan_version_fn)(void);
++int vers_maj;
++int vers_min;
++
++local_scan_lib = dlopen(local_scan_path, RTLD_NOW);
++if (!local_scan_lib)
++  {
++  log_write(0, LOG_MAIN|LOG_REJECT, "local_scan() library open failed - "
++    "message temporarily rejected");
++  return FALSE;
++  }
++
++local_scan_version_fn = dlsym(local_scan_lib, "local_scan_version_major");
++if (!local_scan_version_fn)
++  {
++  dlclose(local_scan_lib);
++  log_write(0, LOG_MAIN|LOG_REJECT, "local_scan() library doesn't contain "
++    "local_scan_version_major() function - message temporarily rejected");
++  return FALSE;
++  }
++
++/* The major number is increased when the ABI is changed in a non
++   backward compatible way. */
++vers_maj = local_scan_version_fn();
++
++local_scan_version_fn = dlsym(local_scan_lib, "local_scan_version_minor");
++if (!local_scan_version_fn)
++  {
++  dlclose(local_scan_lib);
++  log_write(0, LOG_MAIN|LOG_REJECT, "local_scan() library doesn't contain "
++    "local_scan_version_minor() function - message temporarily rejected");
++  return FALSE;
++  }
++
++/* The minor number is increased each time a new feature is added (in a
++   way that doesn't break backward compatibility) -- Marc */
++vers_min = local_scan_version_fn();
++
++
++if (vers_maj != LOCAL_SCAN_ABI_VERSION_MAJOR)
++  {
++  dlclose(local_scan_lib);
++  local_scan_lib = NULL;
++  log_write(0, LOG_MAIN|LOG_REJECT, "local_scan() has an incompatible major"
++    "version number, you need to recompile your module for this version"
++    "of exim (The module was compiled for version %d.%d and this exim provides"
++    "ABI version %d.%d)", vers_maj, vers_min, LOCAL_SCAN_ABI_VERSION_MAJOR,
++    LOCAL_SCAN_ABI_VERSION_MINOR);
++  return FALSE;
++  }
++else if (vers_min > LOCAL_SCAN_ABI_VERSION_MINOR)
++  {
++  dlclose(local_scan_lib);
++  local_scan_lib = NULL;
++  log_write(0, LOG_MAIN|LOG_REJECT, "local_scan() has an incompatible minor"
++    "version number, you need to recompile your module for this version"
++    "of exim (The module was compiled for version %d.%d and this exim provides"
++    "ABI version %d.%d)", vers_maj, vers_min, LOCAL_SCAN_ABI_VERSION_MAJOR,
++    LOCAL_SCAN_ABI_VERSION_MINOR);
++  return FALSE;
++  }
++
++local_scan_fn = dlsym(local_scan_lib, "local_scan");
++if (!local_scan_fn)
++  {
++  dlclose(local_scan_lib);
++  log_write(0, LOG_MAIN|LOG_REJECT, "local_scan() library doesn't contain "
++    "local_scan() function - message temporarily rejected");
++  return FALSE;
++  }
++
++return TRUE;
++}
++
++#endif /* DLOPEN_LOCAL_SCAN */
++
+ /* End of local_scan.c */
+--- a/src/readconf.c
++++ b/src/readconf.c
+@@ -205,6 +205,9 @@ static optionlist optionlist_config[] =
+   { "local_from_prefix",        opt_stringptr,   {&local_from_prefix} },
+   { "local_from_suffix",        opt_stringptr,   {&local_from_suffix} },
+   { "local_interfaces",         opt_stringptr,   {&local_interfaces} },
++#ifdef DLOPEN_LOCAL_SCAN
++  { "local_scan_path",          opt_stringptr,   {&local_scan_path} },
++#endif
+ #ifdef HAVE_LOCAL_SCAN
+   { "local_scan_timeout",       opt_time,        {&local_scan_timeout} },
+ #endif


### PR DESCRIPTION
Add Exim MTA variants:
 * `exim`
   plain variant without any TLS library which hence comes without TLS, DANE and DKIM.
 * `exim-openssl`
   linked against libopenssl
 * `exim-gnutls`
   linked against libgnutls
 * `exim-ldap`
   linked against libopenssl, libopenldap and libsasl2

Provide packages for lookup modules
 * `cdb`
 * `dbmdb`
 * `dnsdb`
 * `json` (depends on `jansson`)
 * `mysql` (depends on `libmariadb`)
 * `passwd`
 * `pgsql` (depends on `libpq`)
 * `redis` (depends on `libhiredis`)
 * `sqlite` (depends on `libsqlite3`)


Note:

As uClibc doesn't provide RES_USE_DNSSEC and hence lacks support for using DNSSec, DANE is disabled when building against uClibc.

As gnutls requires libunbound which depends on libopenssl to provide libgnutls-dane, also disable DANE by default when building with gnutls.

--

Cross-compiling Exim is a hell.