### PR TITLE
transmission: do not use wolfSSL

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=3.00
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master
@@ -40,7 +40,7 @@ define Package/transmission/template
   CATEGORY:=Network
   TITLE:=BitTorrent client
   URL:=https://www.transmissionbt.com
-  DEPENDS:=+libcurl +libevent2 +libminiupnpc +libnatpmp +libpthread +librt +zlib +LIBCURL_NOSSL:libmbedtls +LIBCURL_GNUTLS:libmbedtls $(ICONV_DEPENDS)
+  DEPENDS:=+libcurl +libevent2 +libminiupnpc +libnatpmp +libpthread +librt +zlib +LIBCURL_NOSSL:libmbedtls +LIBCURL_GNUTLS:libmbedtls +LIBCURL_WOLFSSL:libmbedtls $(ICONV_DEPENDS)
 endef
 
 define Package/transmission-daemon
@@ -104,7 +104,7 @@ CONFIGURE_ARGS += \
 	$(if $(CONFIG_LIBCURL_GNUTLS),--with-crypto=polarssl) \
 	$(if $(CONFIG_LIBCURL_MBEDTLS),--with-crypto=polarssl) \
 	$(if $(CONFIG_LIBCURL_OPENSSL),--with-crypto=openssl) \
-	$(if $(CONFIG_LIBCURL_WOLFSSL),--with-crypto=cyassl)
+	$(if $(CONFIG_LIBCURL_WOLFSSL),--with-crypto=polarssl)
 
 define Package/transmission-daemon/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/net/transmission/patches/010-no-intltool.patch
+++ b/net/transmission/patches/010-no-intltool.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -555,9 +555,6 @@ dnl it should be safe to re-edit 0.40 back down to 0.23
+@@ -555,9 +555,6 @@ dnl it should be safe to re-edit 0.40 ba
  use_nls=no
  if test "x$enable_nls" = "xyes" ; then
      use_nls=yes

--- a/net/transmission/patches/020-mbedcrypto.patch
+++ b/net/transmission/patches/020-mbedcrypto.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -152,8 +152,8 @@ AS_IF([test "x$want_crypto" = "xauto" -o "x$want_crypto" = "xcyassl"], [
+@@ -152,8 +152,8 @@ AS_IF([test "x$want_crypto" = "xauto" -o
      )
  ])
  AS_IF([test "x$want_crypto" = "xauto" -o "x$want_crypto" = "xpolarssl"], [

--- a/net/transmission/patches/080-disable-webseeding.patch
+++ b/net/transmission/patches/080-disable-webseeding.patch
@@ -1,6 +1,6 @@
 --- a/libtransmission/webseed.c
 +++ b/libtransmission/webseed.c
-@@ -510,8 +510,6 @@ static void webseed_timer_func(evutil_socket_t foo UNUSED, short bar UNUSED, voi
+@@ -510,8 +510,6 @@ static void webseed_timer_func(evutil_so
          ++w->retry_tickcount;
      }
  


### PR DESCRIPTION
wolfSSL is broken at runtime. It seems to be some error with the random
number generator. It's not currently known what the reason is.

Upstream issue: transmission/transmission#1537

Maintainer: me