### PR TITLE
CI: test x86/64 19.07.5 SDK

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -28,6 +28,8 @@ jobs:
             runtime_test: true
           - arch: x86_64
             runtime_test: true
+          - arch: x86_64-19.07.5
+            runtime_test: true
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Not only use snapshot SDKs for building but also stable releases.

Signed-off-by: Paul Spooren <mail@aparcar.org>