### PR TITLE
lighttpd: update to lighttpd 1.4.58 release hash

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
-PKG_VERSION:=1.4.57
+PKG_VERSION:=1.4.58
 PKG_RELEASE:=1
 # release candidate ~rcX testing; remove for release
-#PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-1.4.57
+#PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-1.4.58
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x
-PKG_HASH:=52ca961b89c12f7ecbb2e4e0c5a9e79b2863c64e33c42832a165e7f894d6217f
+PKG_HASH:=267feffda13a190ebdce7b15172d8be16da98008457f30fddecd72832d126d0e
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: W. Michael Petullo mike@flyn.org
Compile tested: x86 OpenWrt master branch

Description:
lighttpd 1.4.58