### PR TITLE
prometheus-node-exporter-lua: Disk space metric

### DIFF
--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/disk.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/disk.lua
@@ -1,0 +1,17 @@
+require "nixio.fs"
+
+local function scrape()
+  for line in io.lines("/proc/self/mounts")
+  do
+    local fs = space_split(line)
+    local labels = {
+      fstype = fs[3],
+      mountpoint = fs[2]
+    }
+    local stat = nixio.fs.statvfs(fs[2])
+    metric("node_filesystem_avail_bytes", "gauge", labels, stat["bavail"]*stat["frsize"])
+    metric("node_filesystem_size_bytes", "gauge", labels, stat["blocks"]*stat["frsize"])
+  end
+end
+
+return { scrape = scrape }


### PR DESCRIPTION
Gather mounted filesystems stats

Maintainer: @champtar
Compile tested: mips, OpenWrt 18.06.1, r7258-5eb055306f
Run tested: mips, OpenWrt 18.06.1, r7258-5eb055306f

Description:
Script to gather mounted filesystems stats to be exported to prometheus.

Tested with a promtheus/grafana environment