### PR TITLE
bash: import upstream patches for 5.1

### DIFF
--- a/utils/bash/Makefile
+++ b/utils/bash/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bash
 PKG_VERSION:=5.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/bash

--- a/utils/bash/patches/101-bash51-001.patch
+++ b/utils/bash/patches/101-bash51-001.patch
@@ -1,0 +1,64 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.1
+Patch-ID:	bash51-001
+
+Bug-Reported-by:	Fazal Majid <fazal@majid.org>
+Bug-Reference-ID:	<DEAB7D2C-C626-450C-B2E5-281AFF2D26D4@majid.org>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2020-12/msg00000.html
+
+Bug-Description:
+
+There is a missing dependency on a constructed file, which can cause highly
+parellel builds to fail.
+
+Patch (apply with `patch -p0'):
+
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -1315,6 +1315,7 @@ bashline.o: trap.h flags.h assoc.h $(BAS
+ bashline.o: $(DEFSRC)/common.h $(GLOB_LIBSRC)/glob.h alias.h
+ bashline.o: pcomplete.h ${BASHINCDIR}/chartypes.h input.h
+ bashline.o: ${BASHINCDIR}/shmbutil.h ${BASHINCDIR}/shmbchar.h
++bashline.o: ${DEFDIR}/builtext.h
+ bracecomp.o: config.h bashansi.h ${BASHINCDIR}/ansi_stdlib.h
+ bracecomp.o: shell.h syntax.h config.h bashjmp.h ${BASHINCDIR}/posixjmp.h
+ bracecomp.o: command.h ${BASHINCDIR}/stdc.h error.h
+@@ -1435,6 +1436,7 @@ builtins/evalstring.o: quit.h unwind_pro
+ builtins/evalstring.o: dispose_cmd.h make_cmd.h subst.h externs.h 
+ builtins/evalstring.o: jobs.h builtins.h flags.h input.h execute_cmd.h
+ builtins/evalstring.o: bashhist.h $(DEFSRC)/common.h pathnames.h
++builtins/evalstring.o: ${DEFDIR}/builtext.h
+ builtins/getopt.o: config.h ${BASHINCDIR}/memalloc.h
+ builtins/getopt.o: shell.h syntax.h bashjmp.h command.h general.h xmalloc.h error.h
+ builtins/getopt.o: variables.h arrayfunc.h conftypes.h quit.h ${BASHINCDIR}/maxpath.h unwind_prot.h dispose_cmd.h
+--- a/builtins/Makefile.in
++++ b/builtins/Makefile.in
+@@ -361,7 +361,7 @@ evalstring.o: $(topdir)/dispose_cmd.h $(
+ evalstring.o: $(topdir)/externs.h $(topdir)/jobs.h $(topdir)/builtins.h
+ evalstring.o: $(topdir)/flags.h $(topdir)/input.h $(topdir)/execute_cmd.h
+ evalstring.o: $(topdir)/bashhist.h $(srcdir)/common.h
+-evalstring.o: $(topdir)/trap.h $(topdir)/redir.h ../pathnames.h
++evalstring.o: $(topdir)/trap.h $(topdir)/redir.h ../pathnames.h ./builtext.h
+ #evalstring.o: $(topdir)/y.tab.h
+ getopt.o: ../config.h $(BASHINCDIR)/memalloc.h
+ getopt.o: $(topdir)/shell.h $(topdir)/syntax.h $(topdir)/bashjmp.h $(topdir)/command.h
+--- a/patchlevel.h
++++ b/patchlevel.h
+@@ -1,6 +1,6 @@
+ /* patchlevel.h -- current bash patch level */
+ 
+-/* Copyright (C) 2001-2016 Free Software Foundation, Inc.
++/* Copyright (C) 2001-2020 Free Software Foundation, Inc.
+ 
+    This file is part of GNU Bash, the Bourne Again SHell.
+ 
+@@ -25,6 +25,6 @@
+    regexp `^#define[ 	]*PATCHLEVEL', since that's what support/mkversion.sh
+    looks for to find the patch level (for the sccs version string). */
+ 
+-#define PATCHLEVEL 0
++#define PATCHLEVEL 1
+ 
+ #endif /* _PATCHLEVEL_H_ */

--- a/utils/bash/patches/102-bash51-002.patch
+++ b/utils/bash/patches/102-bash51-002.patch
@@ -1,0 +1,45 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.1
+Patch-ID:	bash51-002
+
+Bug-Reported-by:	oguzismailuysal@gmail.com
+Bug-Reference-ID:	<CAH7i3LoHFUa4aSF5-AD2r80HG-p-YzD_9ZxomarZkhP8NMq63g@mail.gmail.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2020-12/msg00037.html
+
+Bug-Description:
+
+If there are no jobs, and the `-n' and `-p' options are both supplied to
+`wait', bash can assign a value to the variable name specified with `-p'
+instead of leaving it unset.
+
+Patch (apply with `patch -p0'):
+
+--- a/builtins/wait.def
++++ b/builtins/wait.def
+@@ -213,11 +213,11 @@ wait_builtin (list)
+ 	}
+ 
+       status = wait_for_any_job (wflags, &pstat);
+-      if (status < 0)
+-	status = 127;
+-
+       if (vname && status >= 0)
+ 	bind_var_to_int (vname, pstat.pid);
++
++      if (status < 0)
++	status = 127;
+       if (list)
+ 	unset_waitlist ();
+       WAIT_RETURN (status);
+--- a/patchlevel.h
++++ b/patchlevel.h
+@@ -25,6 +25,6 @@
+    regexp `^#define[ 	]*PATCHLEVEL', since that's what support/mkversion.sh
+    looks for to find the patch level (for the sccs version string). */
+ 
+-#define PATCHLEVEL 1
++#define PATCHLEVEL 2
+ 
+ #endif /* _PATCHLEVEL_H_ */

--- a/utils/bash/patches/103-bash51-003.patch
+++ b/utils/bash/patches/103-bash51-003.patch
@@ -1,0 +1,43 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.1
+Patch-ID:	bash51-003
+
+Bug-Reported-by:	oguzismailuysal@gmail.com
+Bug-Reference-ID:	<CAH7i3LpG91BnNcDtaTUm2Ph7a+PnJkuh6nAc87cVL7_38tOaMQ@mail.gmail.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2020-12/msg00050.html
+
+Bug-Description:
+
+Bash does not put a command substitution process that is started to perform an
+expansion in a child process into the right process group where it can receive
+keyboard-generated signals.
+
+Patch (apply with `patch -p0'):
+
+--- a/subst.c
++++ b/subst.c
+@@ -6356,8 +6356,10 @@ command_substitute (string, quoted, flag
+ 
+ #if defined (JOB_CONTROL)
+   old_pipeline_pgrp = pipeline_pgrp;
+-  /* Don't reset the pipeline pgrp if we're already a subshell in a pipeline. */
+-  if ((subshell_environment & SUBSHELL_PIPE) == 0)
++  /* Don't reset the pipeline pgrp if we're already a subshell in a pipeline or
++     we've already forked to run a disk command (and are expanding redirections,
++     for example). */
++  if ((subshell_environment & (SUBSHELL_FORK|SUBSHELL_PIPE)) == 0)
+     pipeline_pgrp = shell_pgrp;
+   cleanup_the_pipeline ();
+ #endif /* JOB_CONTROL */
+--- a/patchlevel.h
++++ b/patchlevel.h
+@@ -25,6 +25,6 @@
+    regexp `^#define[ 	]*PATCHLEVEL', since that's what support/mkversion.sh
+    looks for to find the patch level (for the sccs version string). */
+ 
+-#define PATCHLEVEL 2
++#define PATCHLEVEL 3
+ 
+ #endif /* _PATCHLEVEL_H_ */

--- a/utils/bash/patches/104-bash51-004.patch
+++ b/utils/bash/patches/104-bash51-004.patch
@@ -1,0 +1,114 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.1
+Patch-ID:	bash51-004
+
+Bug-Reported-by:	oguzismailuysal@gmail.com
+Bug-Reference-ID:	<CAH7i3LoHGmwaghDpCWRUfcY04gQmeDTH3RiG=bf2b=KbU=gyhw@mail.gmail.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2020-12/msg00039.html
+
+Bug-Description:
+
+If a key-value compound array assignment to an associative array is supplied
+as an assignment statement argument to the `declare' command that declares the
+array, the assignment doesn't perform the correct word expansions.
+
+This patch makes key-value assignment and subscript assignment perform the
+same expansions when they're supplied as an argument to `declare'.
+
+Patch (apply with `patch -p0'):
+
+--- a/arrayfunc.c
++++ b/arrayfunc.c
+@@ -597,6 +597,27 @@ assign_assoc_from_kvlist (var, nlist, h,
+ 	free (aval);
+     }
+ }
++
++/* Return non-zero if L appears to be a key-value pair associative array
++   compound assignment. */ 
++int
++kvpair_assignment_p (l)
++     WORD_LIST *l;
++{
++  return (l && (l->word->flags & W_ASSIGNMENT) == 0 && l->word->word[0] != '[');	/*]*/
++}
++
++char *
++expand_and_quote_kvpair_word (w)
++     char *w;
++{
++  char *t, *r;
++
++  t = w ? expand_assignment_string_to_string (w, 0) : 0;
++  r = sh_single_quote (t ? t : "");
++  free (t);
++  return r;
++}
+ #endif
+      
+ /* Callers ensure that VAR is not NULL. Associative array assignments have not
+@@ -640,7 +661,7 @@ assign_compound_array_list (var, nlist,
+   last_ind = (a && (flags & ASS_APPEND)) ? array_max_index (a) + 1 : 0;
+ 
+ #if ASSOC_KVPAIR_ASSIGNMENT
+-  if (assoc_p (var) && nlist && (nlist->word->flags & W_ASSIGNMENT) == 0 && nlist->word->word[0] != '[')	/*]*/
++  if (assoc_p (var) && kvpair_assignment_p (nlist))
+     {
+       iflags = flags & ~ASS_APPEND;
+       assign_assoc_from_kvlist (var, nlist, nhash, iflags);
+--- a/arrayfunc.h
++++ b/arrayfunc.h
+@@ -67,6 +67,9 @@ extern SHELL_VAR *assign_array_var_from_
+ extern char *expand_and_quote_assoc_word PARAMS((char *, int));
+ extern void quote_compound_array_list PARAMS((WORD_LIST *, int));
+ 
++extern int kvpair_assignment_p PARAMS((WORD_LIST *));
++extern char *expand_and_quote_kvpair_word PARAMS((char *));
++
+ extern int unbind_array_element PARAMS((SHELL_VAR *, char *, int));
+ extern int skipsubscript PARAMS((const char *, int, int));
+ 
+--- a/subst.c
++++ b/subst.c
+@@ -11604,6 +11604,7 @@ expand_oneword (value, flags)
+ {
+   WORD_LIST *l, *nl;
+   char *t;
++  int kvpair;
+   
+   if (flags == 0)
+     {
+@@ -11618,11 +11619,21 @@ expand_oneword (value, flags)
+     {
+       /* Associative array */
+       l = parse_string_to_word_list (value, 1, "array assign");
++#if ASSOC_KVPAIR_ASSIGNMENT
++      kvpair = kvpair_assignment_p (l);
++#endif
++
+       /* For associative arrays, with their arbitrary subscripts, we have to
+ 	 expand and quote in one step so we don't have to search for the
+ 	 closing right bracket more than once. */
+       for (nl = l; nl; nl = nl->next)
+ 	{
++#if ASSOC_KVPAIR_ASSIGNMENT
++	  if (kvpair)
++	    /* keys and values undergo the same set of expansions */
++	    t = expand_and_quote_kvpair_word (nl->word->word);
++	  else
++#endif
+ 	  if ((nl->word->flags & W_ASSIGNMENT) == 0)
+ 	    t = sh_single_quote (nl->word->word ? nl->word->word : "");
+ 	  else
+--- a/patchlevel.h
++++ b/patchlevel.h
+@@ -25,6 +25,6 @@
+    regexp `^#define[ 	]*PATCHLEVEL', since that's what support/mkversion.sh
+    looks for to find the patch level (for the sccs version string). */
+ 
+-#define PATCHLEVEL 3
++#define PATCHLEVEL 4
+ 
+ #endif /* _PATCHLEVEL_H_ */


### PR DESCRIPTION
Source:
https://ftp.gnu.org/gnu/bash/bash-5.1-patches/bash51-001
https://ftp.gnu.org/gnu/bash/bash-5.1-patches/bash51-002
https://ftp.gnu.org/gnu/bash/bash-5.1-patches/bash51-003
https://ftp.gnu.org/gnu/bash/bash-5.1-patches/bash51-004

Maintainer: @jefferyto @neheb 
Compile tested: ath79/nand
Run tested: ath79/nand
