### PR TITLE
lvm2: provide selinux and non-selinux build variants

### DIFF
--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -15,7 +15,7 @@ PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://sourceware.org/pub/lvm2
 PKG_HASH:=5ad1645a480440892e35f31616682acba0dc204ed049635d2df3e5a5929d0ed0
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME).$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/lvm2-$(BUILD_VARIANT)/$(PKG_NAME).$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0 LGPL-2.1
@@ -26,40 +26,82 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/libdevmapper
+define Package/libdevmapper/Default
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=The Linux Kernel Device Mapper userspace library
   URL:=https://sourceware.org/dm/
-  DEPENDS:=+kmod-dm +libpthread +libuuid +librt +libblkid +libselinux
+  DEPENDS:=+kmod-dm +libpthread +libuuid +librt +libblkid
 endef
 
-define Package/libdevmapper/description
+
+define Package/libdevmapper-normal
+  $(call Package/libdevmapper/Default)
+  VARIANT := normal
+  PROVIDES := libdevmapper
+endef
+
+define Package/libdevmapper-selinux
+  $(call Package/libdevmapper/Default)
+  VARIANT := selinux
+  DEPENDS += +libselinux
+  PROVIDES := libdevmapper
+endef
+
+define Package/libdevmapper-normal/description
  The device-mapper is a component of the 2.6 linux kernel that supports logical
  volume management. It is required by LVM2 and EVMS.
 endef
 
-define Package/lvm2
+define Package/libdevmapper-selinux/description
+$(call Package/libdevmapper-normal/description)
+ This variant supports SELinux
+
+endef
+
+define Package/lvm2/default
   SECTION:=utils
   CATEGORY:=Utilities
   SUBMENU:=Disc
   TITLE:=The Linux Logical Volume Manager
   URL:=https://sourceware.org/lvm2/
-  DEPENDS:=+libdevmapper +libreadline +libncurses +libaio
+  DEPENDS:=+libreadline +libncurses +libaio
 endef
 
-define Package/lvm2/description
+define Package/lvm2-normal
+  $(call Package/lvm2/default)
+  VARIANT := normal
+  DEPENDS += +libdevmapper-normal
+  PROVIDES := lvm2
+endef
+
+define Package/lvm2-selinux
+  $(call Package/lvm2/default)
+  VARIANT := selinux
+  DEPENDS += +libdevmapper-selinux
+  PROVIDES := lvm2
+endef
+
+define Package/lvm2-normal/description
  LVM2 refers to a new userspace toolset that provide logical volume management
  facilities on linux. It is reasonably backwards-compatible with the original
  LVM toolset.
 endef
+
+define Package/lvm2-selinux/description
+$(call Package/lvm2-normal/description)
+ This variant supports SELinux
+
+endef
+
 
 CONFIGURE_ARGS += \
 	--disable-o_direct \
 	--with-default-pid-dir=/var/run \
 	--with-default-dm-run-dir=/var/run \
 	--with-default-run-dir=/var/run/lvm \
-	--with-default-locking-dir=/var/lock/lvm
+	--with-default-locking-dir=/var/lock/lvm \
+	--$(if $(findstring selinux,$(BUILD_VARIANT)),en,dis)able-selinux
 
 ifneq ($(shell /bin/sh -c "echo -n 'X'"),X)
 MAKE_SHELL = SHELL=/bin/bash
@@ -83,12 +125,14 @@ define Build/InstallDev
 	$(CP) $(PKG_BUILD_DIR)/libdm/libdevmapper.pc $(1)/usr/lib/pkgconfig
 endef
 
-define Package/libdevmapper/install
+define Package/libdevmapper-normal/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdevmapper.so.* $(1)/usr/lib
 endef
 
-define Package/lvm2/install
+Package/libdevmapper-selinux/install = $(Package/libdevmapper-normal/install)
+
+define Package/lvm2-normal/install
 	$(INSTALL_DIR) $(1)/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/lvm $(1)/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/dmsetup $(1)/sbin
@@ -105,9 +149,15 @@ define Package/lvm2/install
 	$(FIND) $(PKG_INSTALL_DIR)/usr/sbin/ -type l -exec $(CP) -a {} $(1)/sbin/ \;
 endef
 
-define Package/lvm2/conffiles
+Package/lvm2-selinux/install = $(Package/lvm2-normal/install)
+
+define Package/lvm2-normal/conffiles
 /etc/lvm/lvm.conf
 endef
 
-$(eval $(call BuildPackage,libdevmapper))
-$(eval $(call BuildPackage,lvm2))
+Package/lvm2-selinux/conffiles = $(Package/lvm2/conffiles)
+
+$(eval $(call BuildPackage,libdevmapper-normal))
+$(eval $(call BuildPackage,libdevmapper-selinux))
+$(eval $(call BuildPackage,lvm2-normal))
+$(eval $(call BuildPackage,lvm2-selinux))


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: ath97, WNDR3800, r15339+6-bc99b56d7e. Compiles with and without SELinux support depending on the global SELinux switch.
Run tested: ath97, WNDR3800, r15339+6-bc99b56d7e. Runs fine with SELinux disabled, SELinux libs are not required

Description:
This change breaks the assumption that LVM can be used only on systems with a lot of storage. Usually, LVM helps to manage external storage, while the built-in one can still be quite limited. In my case, I have only 16M of NOR FLASH, but a 3TB drive attached.

```
$ grep CONFIG_SELINUX .config
CONFIG_SELINUX=y
# CONFIG_SELINUXTYPE_targeted is not set
CONFIG_SELINUXTYPE_dssp=y
# CONFIG_BUSYBOX_CONFIG_SELINUX is not set

$ ./staging_dir/toolchain-mips_24kc_gcc-8.4.0_musl/bin/mips-openwrt-linux-musl-readelf -d build_dir/target-mips_24kc_musl/LVM2.2.03.10/ipkg-mips_24kc/libdevmapper/usr/lib/libdevmapper.so.1.02 | grep NEEDED
 0x00000001 (NEEDED)                     Shared library: [libselinux.so.1]
 0x00000001 (NEEDED)                     Shared library: [libsepol.so.1]
 0x00000001 (NEEDED)                     Shared library: [libblkid.so.1]
 0x00000001 (NEEDED)                     Shared library: [libgcc_s.so.1]
 0x00000001 (NEEDED)                     Shared library: [libc.so]

$ ./staging_dir/toolchain-mips_24kc_gcc-8.4.0_musl/bin/mips-openwrt-linux-musl-readelf -d build_dir/target-mips_24kc_musl/LVM2.2.03.10/ipkg-mips_24kc/lvm2/sbin/lvm | grep NEEDED
 0x00000001 (NEEDED)                     Shared library: [libreadline.so.8]
 0x00000001 (NEEDED)                     Shared library: [libdevmapper.so.1.02]
 0x00000001 (NEEDED)                     Shared library: [libselinux.so.1]
 0x00000001 (NEEDED)                     Shared library: [libsepol.so.1]
 0x00000001 (NEEDED)                     Shared library: [libblkid.so.1]
 0x00000001 (NEEDED)                     Shared library: [libaio.so.1]
 0x00000001 (NEEDED)                     Shared library: [libgcc_s.so.1]
 0x00000001 (NEEDED)                     Shared library: [libc.so]
```

```
$ grep CONFIG_SELINUX .config
# CONFIG_SELINUX is not set
# CONFIG_BUSYBOX_CONFIG_SELINUX is not set

$ ./staging_dir/toolchain-mips_24kc_gcc-8.4.0_musl/bin/mips-openwrt-linux-musl-readelf -d build_dir/target-mips_24kc_musl/LVM2.2.03.10/ipkg-mips_24kc/libdevmapper/usr/lib/libdevmapper.so.1.02 | grep NEEDED
 0x00000001 (NEEDED)                     Shared library: [libblkid.so.1]
 0x00000001 (NEEDED)                     Shared library: [libgcc_s.so.1]
 0x00000001 (NEEDED)                     Shared library: [libc.so]

$ ./staging_dir/toolchain-mips_24kc_gcc-8.4.0_musl/bin/mips-openwrt-linux-musl-readelf -d build_dir/target-mips_24kc_musl/LVM2.2.03.10/ipkg-mips_24kc/lvm2/sbin/lvm | grep NEEDED
 0x00000001 (NEEDED)                     Shared library: [libreadline.so.8]
 0x00000001 (NEEDED)                     Shared library: [libdevmapper.so.1.02]
 0x00000001 (NEEDED)                     Shared library: [libblkid.so.1]
 0x00000001 (NEEDED)                     Shared library: [libaio.so.1]
 0x00000001 (NEEDED)                     Shared library: [libgcc_s.so.1]
 0x00000001 (NEEDED)                     Shared library: [libc.so]
```