### PR TITLE
CI: switch back to ARCHS

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - arc_arc700
+          - arc_archs
           - arm_cortex-a9_vfpv3-d16
           - mips_24kc
           - powerpc_464fp


### PR DESCRIPTION
Upstream wants to remove ARC700. That and currently, ARC700 is not
compiling with glibc.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @aparcar 