### PR TITLE
bonnie++: fix compilation with glibc

### DIFF
--- a/utils/bonnie++/Makefile
+++ b/utils/bonnie++/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bonnie++
 PKG_VERSION:=1.98
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://www.coker.com.au/bonnie++/

--- a/utils/bonnie++/patches/010-openwrt-fixes.patch
+++ b/utils/bonnie++/patches/010-openwrt-fixes.patch
@@ -18,11 +18,11 @@
  
  bonnie++: $(BONOBJS)
 -	$(LINK) -o bonnie++ $(BONOBJS) $(THREAD_LFLAGS)
-+	$(CXX) $(CXXFLAGS) -o bonnie++ $(BONOBJS)
++	$(CXX) $(CXXFLAGS) -o bonnie++ $(BONOBJS) @thread_ldflags@
  
  zcav: $(ZCAVOBJS)
 -	$(LINK) -o zcav $(ZCAVOBJS) $(THREAD_LFLAGS)
-+	$(CXX) $(CXXFLAGS) -o zcav $(ZCAVOBJS)
++	$(CXX) $(CXXFLAGS) -o zcav $(ZCAVOBJS) @thread_ldflags@
  
  getc_putc: $(GETCOBJS) getc_putc_helper
 -	$(LINK) -o getc_putc $(GETCOBJS) $(THREAD_LFLAGS)


### PR DESCRIPTION
link to pthreads was missing

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: arc700