### PR TITLE
auc: link to libdl when needed

### DIFF
--- a/utils/auc/Makefile
+++ b/utils/auc/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=auc
 PKG_VERSION:=0.1.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-3.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/utils/auc/src/CMakeLists.txt
+++ b/utils/auc/src/CMakeLists.txt
@@ -8,5 +8,5 @@ SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 find_library(json NAMES json-c json)
 
 ADD_EXECUTABLE(auc auc.c)
-TARGET_LINK_LIBRARIES(auc uci ubox ubus uclient blobmsg_json ${json})
+TARGET_LINK_LIBRARIES(auc uci ubox ubus uclient blobmsg_json ${json} ${CMAKE_DL_LIBS})
 INSTALL(TARGETS auc RUNTIME DESTINATION sbin)


### PR DESCRIPTION
Fixes compilation under glibc.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: arc700

https://downloads.openwrt.org/snapshots/faillogs/arc_archs/packages/auc/compile.txt