### PR TITLE
unrar: update to 6.0.3

### DIFF
--- a/utils/unrar/Makefile
+++ b/utils/unrar/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unrar
-PKG_VERSION:=6.0.2
+PKG_VERSION:=6.0.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=unrarsrc-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.rarlab.com/rar
-PKG_HASH:=81bf188333f89c976780a477af27f651f54aa7da9312303d8d1a804696d3edd3
+PKG_HASH:=1def53392d879f9e304aa6eac1339cf41f9bce1111a2f5845071665738c4aca0
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)-$(BUILD_VARIANT)/unrar
 
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>, \
@@ -30,7 +30,7 @@ ifeq ($(CONFIG_USE_UCLIBCXX),y)
 TARGET_LDFLAGS +=-nodefaultlibs
 endif
 TARGET_CXXFLAGS +=-fno-rtti -flto
-TARGET_LDFLAGS +=$(FPIC) -Wl,--gc-sections
+TARGET_LDFLAGS +=$(FPIC) -Wl,--gc-sections $(if $(CONFIG_USE_GLIBC),-lpthread)
 
 define Package/unrar/Default
   TITLE:=UnRAR


### PR DESCRIPTION
Fix compilation with glibc by adding pthread linker flag.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess @Noltari 
Compile tested: arc700