### PR TITLE
hfsprogs: fix compilation under glibc

### DIFF
--- a/utils/hfsprogs/Makefile
+++ b/utils/hfsprogs/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hfsprogs
 PKG_VERSION:=332.25
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.gz
 PKG_SOURCE_URL:=http://archive.ubuntu.com/ubuntu/pool/universe/h/$(PKG_NAME)

--- a/utils/hfsprogs/patches/0001-Create-short-Makefiles-for-Debian.patch
+++ b/utils/hfsprogs/patches/0001-Create-short-Makefiles-for-Debian.patch
@@ -16,9 +16,6 @@ utilities.
  create mode 100644 fsck_hfs.tproj/dfalib/Makefile.lnx
  create mode 100644 newfs_hfs.tproj/Makefile.lnx
 
-diff --git a/Makefile.lnx b/Makefile.lnx
-new file mode 100644
-index 0000000..687d1e7
 --- /dev/null
 +++ b/Makefile.lnx
 @@ -0,0 +1,8 @@
@@ -30,9 +27,6 @@ index 0000000..687d1e7
 +	for d in $(SUBDIRS); do $(MAKE) -C $$d -f Makefile.lnx $@; done
 +
 +export CC CFLAGS
-diff --git a/fsck_hfs.tproj/Makefile.lnx b/fsck_hfs.tproj/Makefile.lnx
-new file mode 100644
-index 0000000..977d7e8
 --- /dev/null
 +++ b/fsck_hfs.tproj/Makefile.lnx
 @@ -0,0 +1,16 @@
@@ -52,9 +46,6 @@ index 0000000..977d7e8
 +	$(MAKE) -C dfalib -f Makefile.lnx clean
 +
 +.PHONY : FORCE clean
-diff --git a/fsck_hfs.tproj/dfalib/Makefile.lnx b/fsck_hfs.tproj/dfalib/Makefile.lnx
-new file mode 100644
-index 0000000..8c07196
 --- /dev/null
 +++ b/fsck_hfs.tproj/dfalib/Makefile.lnx
 @@ -0,0 +1,15 @@
@@ -73,9 +64,6 @@ index 0000000..8c07196
 +
 +clean:
 +	$(RM) $(OFILES) libdfa.a
-diff --git a/newfs_hfs.tproj/Makefile.lnx b/newfs_hfs.tproj/Makefile.lnx
-new file mode 100644
-index 0000000..58e6700
 --- /dev/null
 +++ b/newfs_hfs.tproj/Makefile.lnx
 @@ -0,0 +1,12 @@

--- a/utils/hfsprogs/patches/0002-Add-exclude-Darwin-specific-code.patch
+++ b/utils/hfsprogs/patches/0002-Add-exclude-Darwin-specific-code.patch
@@ -29,8 +29,6 @@ Apple owned frameworks in a Debian system (and possibly others).
  21 files changed, 429 insertions(+), 85 deletions(-)
  create mode 100644 include/missing.h
 
-diff --git a/fsck_hfs.tproj/cache.c b/fsck_hfs.tproj/cache.c
-index be46195..527088a 100644
 --- a/fsck_hfs.tproj/cache.c
 +++ b/fsck_hfs.tproj/cache.c
 @@ -26,7 +26,11 @@
@@ -45,11 +43,9 @@ index be46195..527088a 100644
  #include <sys/uio.h>
  #include <unistd.h>
  #include <string.h>
-diff --git a/fsck_hfs.tproj/dfalib/BTree.c b/fsck_hfs.tproj/dfalib/BTree.c
-index edd8301..7ad9fe0 100644
 --- a/fsck_hfs.tproj/dfalib/BTree.c
 +++ b/fsck_hfs.tproj/dfalib/BTree.c
-@@ -1705,7 +1705,9 @@ OSStatus	BTGetInformation	(SFCB					*filePtr,
+@@ -1705,7 +1705,9 @@ OSStatus	BTGetInformation	(SFCB					*fil
  								 UInt16					 version,
  								 BTreeInfoRec			*info )
  {
@@ -59,8 +55,6 @@ index edd8301..7ad9fe0 100644
  
  	BTreeControlBlockPtr	btreePtr;
  
-diff --git a/fsck_hfs.tproj/dfalib/BlockCache.c b/fsck_hfs.tproj/dfalib/BlockCache.c
-index 1bb952f..e3a28a2 100644
 --- a/fsck_hfs.tproj/dfalib/BlockCache.c
 +++ b/fsck_hfs.tproj/dfalib/BlockCache.c
 @@ -20,6 +20,9 @@
@@ -73,8 +67,6 @@ index 1bb952f..e3a28a2 100644
  #include "SRuntime.h"
  #include "Scavenger.h"
  #include "../cache.h"
-diff --git a/fsck_hfs.tproj/dfalib/SBTree.c b/fsck_hfs.tproj/dfalib/SBTree.c
-index 2fbcd1d..cd81b13 100644
 --- a/fsck_hfs.tproj/dfalib/SBTree.c
 +++ b/fsck_hfs.tproj/dfalib/SBTree.c
 @@ -322,7 +322,9 @@ ErrorExit:
@@ -87,8 +79,6 @@ index 2fbcd1d..cd81b13 100644
  
  	OSStatus	result;
  	UInt32		actualSectorsAdded;
-diff --git a/fsck_hfs.tproj/dfalib/SDevice.c b/fsck_hfs.tproj/dfalib/SDevice.c
-index bf6f61c..9a46023 100644
 --- a/fsck_hfs.tproj/dfalib/SDevice.c
 +++ b/fsck_hfs.tproj/dfalib/SDevice.c
 @@ -2,7 +2,7 @@
@@ -195,7 +185,7 @@ index bf6f61c..9a46023 100644
  
  	if (devBlockSize != 512) {
  		*numBlocks = (devBlockCount * (UInt64)devBlockSize) / 512;
-@@ -70,24 +108,24 @@ OSErr GetDeviceSize(int driveRefNum, UInt64 *numBlocks, UInt32 *blockSize)
+@@ -70,24 +108,24 @@ OSErr GetDeviceSize(int driveRefNum, UIn
  	{
  		/* return format list status code */
  		kFmtLstCode = 6,
@@ -225,7 +215,7 @@ index bf6f61c..9a46023 100644
  	ParamBlockRec	pb;
  	FormatListRec	formatListRecords[kMaxFormatListRecs];
  	DrvSts			status;
-@@ -95,22 +133,22 @@ OSErr GetDeviceSize(int driveRefNum, UInt64 *numBlocks, UInt32 *blockSize)
+@@ -95,22 +133,22 @@ OSErr GetDeviceSize(int driveRefNum, UIn
  	OSErr			result;
  	unsigned long	blocks			= 0;
  
@@ -253,7 +243,7 @@ index bf6f61c..9a46023 100644
  		/* Get the current disk's size. */
  		for( formatListRecIndex = 0;
  			 formatListRecIndex < pb.cntrlParam.csParam[0];
-@@ -131,7 +169,7 @@ OSErr GetDeviceSize(int driveRefNum, UInt64 *numBlocks, UInt32 *blockSize)
+@@ -131,7 +169,7 @@ OSErr GetDeviceSize(int driveRefNum, UIn
  	else if ( driveQElementPtr->dQRefNum == (short)kSonyRefNum )
  	{
  		/* The drive is a non-SuperDrive floppy which only supports 400K and 800K disks */
@@ -262,7 +252,7 @@ index bf6f61c..9a46023 100644
  		result = DriveStatus(driveQElementPtr->dQDrive, &status);
  		if ( result == noErr )
  		{
-@@ -140,11 +178,11 @@ OSErr GetDeviceSize(int driveRefNum, UInt64 *numBlocks, UInt32 *blockSize)
+@@ -140,11 +178,11 @@ OSErr GetDeviceSize(int driveRefNum, UIn
  				case kSingleSided:
  					blocks = kSingleSidedSize;
  					break;
@@ -276,7 +266,7 @@ index bf6f61c..9a46023 100644
  				default:		//	This should never happen
  					result = paramErr;
  					break;
-@@ -155,20 +193,20 @@ OSErr GetDeviceSize(int driveRefNum, UInt64 *numBlocks, UInt32 *blockSize)
+@@ -155,20 +193,20 @@ OSErr GetDeviceSize(int driveRefNum, UIn
  	{
  		/* The drive is not a floppy and it doesn't support ReturnFormatList */
  		/* so use the dQDrvSz field(s) */
@@ -301,7 +291,7 @@ index bf6f61c..9a46023 100644
  			default:		//	This should never happen
  				result = paramErr;
  				break;
-@@ -177,7 +215,7 @@ OSErr GetDeviceSize(int driveRefNum, UInt64 *numBlocks, UInt32 *blockSize)
+@@ -177,7 +215,7 @@ OSErr GetDeviceSize(int driveRefNum, UIn
  
  	*numBlocks = blocks;
  	*blockSize = 512;
@@ -310,7 +300,7 @@ index bf6f61c..9a46023 100644
  	return( result );
  #endif
  }
-@@ -188,7 +226,7 @@ OSErr DeviceRead(int device, int drive, void* buffer, SInt64 offset, UInt32 reqB
+@@ -188,7 +226,7 @@ OSErr DeviceRead(int device, int drive,
  #if BSD
  	off_t seek_off;
  	ssize_t	nbytes;
@@ -319,11 +309,9 @@ index bf6f61c..9a46023 100644
  	*actBytes = 0;
  
  	seek_off = lseek(device, offset, SEEK_SET);
-diff --git a/fsck_hfs.tproj/dfalib/SKeyCompare.c b/fsck_hfs.tproj/dfalib/SKeyCompare.c
-index 46e145f..18d99c5 100644
 --- a/fsck_hfs.tproj/dfalib/SKeyCompare.c
 +++ b/fsck_hfs.tproj/dfalib/SKeyCompare.c
-@@ -454,7 +454,9 @@ SInt32 CompareExtentKeysPlus( const HFSPlusExtentKey *searchKey, const HFSPlusEx
+@@ -454,7 +454,9 @@ SInt32 CompareExtentKeysPlus( const HFSP
   * The name portion of the key is compared using a 16-bit binary comparison. 
   * This is called from the b-tree code.
   */
@@ -333,8 +321,6 @@ index 46e145f..18d99c5 100644
  SInt32
  CompareAttributeKeys(const AttributeKey *searchKey, const AttributeKey *trialKey)
  {
-diff --git a/fsck_hfs.tproj/dfalib/SRepair.c b/fsck_hfs.tproj/dfalib/SRepair.c
-index 01c1a10..8eb759c 100644
 --- a/fsck_hfs.tproj/dfalib/SRepair.c
 +++ b/fsck_hfs.tproj/dfalib/SRepair.c
 @@ -1617,7 +1617,9 @@ Output:
@@ -347,8 +333,6 @@ index 01c1a10..8eb759c 100644
  
  	OSErr						err;
  	HFSMasterDirectoryBlock		*mdb;
-diff --git a/fsck_hfs.tproj/dfalib/SRuntime.h b/fsck_hfs.tproj/dfalib/SRuntime.h
-index 646917b..770e3ef 100644
 --- a/fsck_hfs.tproj/dfalib/SRuntime.h
 +++ b/fsck_hfs.tproj/dfalib/SRuntime.h
 @@ -27,8 +27,11 @@
@@ -364,7 +348,7 @@ index 646917b..770e3ef 100644
  #include <stdlib.h>
  #include <string.h>
  #include <stdio.h>
-@@ -91,10 +94,12 @@ typedef const unsigned char *	ConstStr255Param;
+@@ -91,10 +94,12 @@ typedef const unsigned char *	ConstStr25
  
  typedef u_int32_t	HFSCatalogNodeID;
  
@@ -377,11 +361,9 @@ index 646917b..770e3ef 100644
  
  /* OS error codes */
  enum {
-diff --git a/fsck_hfs.tproj/dfalib/SUtils.c b/fsck_hfs.tproj/dfalib/SUtils.c
-index 72035f0..6e9253e 100644
 --- a/fsck_hfs.tproj/dfalib/SUtils.c
 +++ b/fsck_hfs.tproj/dfalib/SUtils.c
-@@ -380,7 +380,8 @@ void	InvalidateCalculatedVolumeBitMap( SGlobPtr GPtr )
+@@ -380,7 +380,8 @@ void	InvalidateCalculatedVolumeBitMap( S
  //				GPtr->realVCB			Real in-memory vcb
  //------------------------------------------------------------------------------
  
@@ -400,8 +382,6 @@ index 72035f0..6e9253e 100644
  
  
  /*-------------------------------------------------------------------------------
-diff --git a/fsck_hfs.tproj/dfalib/SVerify2.c b/fsck_hfs.tproj/dfalib/SVerify2.c
-index 6a47935..c68f3d8 100644
 --- a/fsck_hfs.tproj/dfalib/SVerify2.c
 +++ b/fsck_hfs.tproj/dfalib/SVerify2.c
 @@ -32,7 +32,9 @@
@@ -414,7 +394,7 @@ index 6a47935..c68f3d8 100644
  
  #include "BTree.h"
  #include "BTreePrivate.h"
-@@ -1354,8 +1356,13 @@ OSErr CompareVolumeHeader( SGlobPtr GPtr, HFSPlusVolumeHeader *volumeHeader )
+@@ -1354,8 +1356,13 @@ OSErr CompareVolumeHeader( SGlobPtr GPtr
  	 * clump size for read-only media is irrelevant we skip the clump size 
  	 * check to avoid non useful warnings. 
  	 */
@@ -428,8 +408,6 @@ index 6a47935..c68f3d8 100644
  	if ( isWriteable != 0 && 
  		 volumeHeader->catalogFile.clumpSize != vcb->vcbCatalogFile->fcbClumpSize ) {
  		PrintError(GPtr, E_InvalidClumpSize, 0);
-diff --git a/fsck_hfs.tproj/dfalib/Scavenger.h b/fsck_hfs.tproj/dfalib/Scavenger.h
-index cf53970..edb3a80 100644
 --- a/fsck_hfs.tproj/dfalib/Scavenger.h
 +++ b/fsck_hfs.tproj/dfalib/Scavenger.h
 @@ -37,11 +37,16 @@
@@ -450,7 +428,7 @@ index cf53970..edb3a80 100644
  
  #ifdef __cplusplus
  extern	"C" {
-@@ -1465,4 +1470,8 @@ extern int 	AllocateContigBitmapBits (SVCB *vcb, UInt32 numBlocks, UInt32 *actua
+@@ -1465,4 +1470,8 @@ extern int 	AllocateContigBitmapBits (SV
  };
  #endif
  
@@ -459,8 +437,6 @@ index cf53970..edb3a80 100644
 +#endif */
 +
  #endif /* __SCAVENGER__ */
-diff --git a/fsck_hfs.tproj/dfalib/hfs_endian.c b/fsck_hfs.tproj/dfalib/hfs_endian.c
-index 7fa5385..69500c1 100755
 --- a/fsck_hfs.tproj/dfalib/hfs_endian.c
 +++ b/fsck_hfs.tproj/dfalib/hfs_endian.c
 @@ -31,7 +31,11 @@
@@ -475,8 +451,6 @@ index 7fa5385..69500c1 100755
  #include <hfs/hfs_format.h>
  
  #include "Scavenger.h"
-diff --git a/fsck_hfs.tproj/dfalib/hfs_endian.h b/fsck_hfs.tproj/dfalib/hfs_endian.h
-index 52d0c3a..0763d9d 100755
 --- a/fsck_hfs.tproj/dfalib/hfs_endian.h
 +++ b/fsck_hfs.tproj/dfalib/hfs_endian.h
 @@ -27,9 +27,14 @@
@@ -495,8 +469,6 @@ index 52d0c3a..0763d9d 100755
  #include "SRuntime.h"
  
  /*********************/
-diff --git a/fsck_hfs.tproj/fsck_hfs.c b/fsck_hfs.tproj/fsck_hfs.c
-index 90532fd..f1a18bd 100644
 --- a/fsck_hfs.tproj/fsck_hfs.c
 +++ b/fsck_hfs.tproj/fsck_hfs.c
 @@ -24,10 +24,14 @@
@@ -644,7 +616,7 @@ index 90532fd..f1a18bd 100644
  ExitThisRoutine:
  	if (lflag) {
  	    fcntl(fs_fd, F_THAW_FS, NULL);
-@@ -401,16 +423,18 @@ setup( char *dev, int *blockDevice_fdPtr, int *canWritePtr )
+@@ -401,16 +423,18 @@ setup( char *dev, int *blockDevice_fdPtr
  	fswritefd = -1;
  	*blockDevice_fdPtr = -1;
  	*canWritePtr = 0;
@@ -664,7 +636,7 @@ index 90532fd..f1a18bd 100644
  	if ((fsreadfd = open(dev, O_RDONLY)) < 0) {
  		printf("Can't open %s: %s\n", dev, strerror(errno));
  		return (0);
-@@ -419,7 +443,7 @@ setup( char *dev, int *blockDevice_fdPtr, int *canWritePtr )
+@@ -419,7 +443,7 @@ setup( char *dev, int *blockDevice_fdPtr
  	/* attempt to get write access to the block device and if not check if volume is */
  	/* mounted read-only.  */
  	getWriteAccess( dev, blockDevice_fdPtr, canWritePtr );
@@ -673,7 +645,7 @@ index 90532fd..f1a18bd 100644
  	if (preen == 0 && !guiControl)
  		printf("** %s", dev);
  	if (nflag || (fswritefd = open(dev, O_WRONLY)) < 0) {
-@@ -433,10 +457,14 @@ setup( char *dev, int *blockDevice_fdPtr, int *canWritePtr )
+@@ -433,10 +457,14 @@ setup( char *dev, int *blockDevice_fdPtr
  		printf("\n");
  
  	/* Get device block size to initialize cache */
@@ -688,7 +660,7 @@ index 90532fd..f1a18bd 100644
  
  	 /* calculate the cache block size and total blocks */
  	if (CalculateCacheSize(userCacheSize, &cacheBlockSize, &cacheTotalBlocks, debug) != 0) {
-@@ -463,11 +491,15 @@ setup( char *dev, int *blockDevice_fdPtr, int *canWritePtr )
+@@ -463,11 +491,15 @@ setup( char *dev, int *blockDevice_fdPtr
  
  static void getWriteAccess( char *dev, int *blockDevice_fdPtr, int *canWritePtr )
  {
@@ -704,7 +676,7 @@ index 90532fd..f1a18bd 100644
  	void *				myNamePtr;
  
  	myPtr = NULL;
-@@ -490,6 +522,9 @@ static void getWriteAccess( char *dev, int *blockDevice_fdPtr, int *canWritePtr
+@@ -490,6 +522,9 @@ static void getWriteAccess( char *dev, i
  	}
  	
  	// get count of mounts then get the info for each 
@@ -714,7 +686,7 @@ index 90532fd..f1a18bd 100644
  	myMountsCount = getfsstat( NULL, 0, MNT_NOWAIT );
  	if ( myMountsCount < 0 )
  		goto ExitThisRoutine;
-@@ -513,8 +548,8 @@ static void getWriteAccess( char *dev, int *blockDevice_fdPtr, int *canWritePtr
+@@ -513,8 +548,8 @@ static void getWriteAccess( char *dev, i
  		}
  		myBufPtr++;
  	}
@@ -725,8 +697,6 @@ index 90532fd..f1a18bd 100644
  ExitThisRoutine:
  	if ( myPtr != NULL )
  		free( myPtr );
-diff --git a/fsck_hfs.tproj/utilities.c b/fsck_hfs.tproj/utilities.c
-index ee41bef..8e1cd77 100644
 --- a/fsck_hfs.tproj/utilities.c
 +++ b/fsck_hfs.tproj/utilities.c
 @@ -183,12 +183,14 @@ retry:
@@ -757,9 +727,6 @@ index ee41bef..8e1cd77 100644
  	(void)strcat(rawbuf, &dp[1]);
  
  	return (rawbuf);
-diff --git a/include/missing.h b/include/missing.h
-new file mode 100644
-index 0000000..0a859c4
 --- /dev/null
 +++ b/include/missing.h
 @@ -0,0 +1,114 @@
@@ -877,8 +844,6 @@ index 0000000..0a859c4
 +#define KAUTH_FILESEC_XATTR "com.apple.system.Security"
 +
 +#endif
-diff --git a/newfs_hfs.tproj/hfs_endian.c b/newfs_hfs.tproj/hfs_endian.c
-index 117b7f8..fdf7353 100644
 --- a/newfs_hfs.tproj/hfs_endian.c
 +++ b/newfs_hfs.tproj/hfs_endian.c
 @@ -30,7 +30,12 @@
@@ -894,8 +859,6 @@ index 117b7f8..fdf7353 100644
  #include <hfs/hfs_format.h>
  
  #include "hfs_endian.h"
-diff --git a/newfs_hfs.tproj/hfs_endian.h b/newfs_hfs.tproj/hfs_endian.h
-index 8d9d01d..5c7ff57 100644
 --- a/newfs_hfs.tproj/hfs_endian.h
 +++ b/newfs_hfs.tproj/hfs_endian.h
 @@ -29,7 +29,12 @@
@@ -911,8 +874,6 @@ index 8d9d01d..5c7ff57 100644
  
  /*********************/
  /* BIG ENDIAN Macros */
-diff --git a/newfs_hfs.tproj/makehfs.c b/newfs_hfs.tproj/makehfs.c
-index 085222f..7609779 100644
 --- a/newfs_hfs.tproj/makehfs.c
 +++ b/newfs_hfs.tproj/makehfs.c
 @@ -31,10 +31,16 @@
@@ -948,7 +909,7 @@ index 085222f..7609779 100644
  
  #include <hfs/hfs_format.h>
  #include <hfs/hfs_mount.h>
-@@ -129,7 +136,9 @@ static UInt32 Largest __P((UInt32 a, UInt32 b, UInt32 c, UInt32 d ));
+@@ -129,7 +136,9 @@ static UInt32 Largest __P((UInt32 a, UIn
  static void MarkBitInAllocationBuffer __P((HFSPlusVolumeHeader *header,
  		UInt32 allocationBlock, void* sectorBuffer, UInt32 *sector));
  
@@ -958,7 +919,7 @@ index 085222f..7609779 100644
  
  static UInt32 UTCToLocal __P((UInt32 utcTime));
  
-@@ -158,11 +167,14 @@ void SETOFFSET (void *buffer, UInt16 btNodeSize, SInt16 recOffset, SInt16 vecOff
+@@ -158,11 +167,14 @@ void SETOFFSET (void *buffer, UInt16 btN
  
  #define ROUNDUP(x, u)	(((x) % (u) == 0) ? (x) : ((x)/(u) + 1) * (u))
  
@@ -975,7 +936,7 @@ index 085222f..7609779 100644
  /*
   * make_hfs
   *	
-@@ -528,6 +540,7 @@ InitMDB(hfsparams_t *defaults, UInt32 driveBlocks, HFS_MDB *mdbp)
+@@ -528,6 +540,7 @@ InitMDB(hfsparams_t *defaults, UInt32 dr
  	 * Map UTF-8 input into a Mac encoding.
  	 * On conversion errors "untitled" is used as a fallback.
  	 */
@@ -983,7 +944,7 @@ index 085222f..7609779 100644
  	{
  		UniChar unibuf[kHFSMaxVolumeNameChars];
  		CFStringRef cfstr;
-@@ -553,7 +566,11 @@ InitMDB(hfsparams_t *defaults, UInt32 driveBlocks, HFS_MDB *mdbp)
+@@ -553,7 +566,11 @@ InitMDB(hfsparams_t *defaults, UInt32 dr
  		bcopy(&mdbp->drVN[1], defaults->volumeName, mdbp->drVN[0]);
  		defaults->volumeName[mdbp->drVN[0]] = '\0';
  	}
@@ -995,7 +956,7 @@ index 085222f..7609779 100644
  	mdbp->drFndrInfo[4] = SET_HFS_TEXT_ENCODING(defaults->encodingHint);
  
  	mdbp->drWrCnt = kWriteSeqNum;
-@@ -1100,9 +1117,11 @@ InitCatalogRoot_HFSPlus(const hfsparams_t *dp, const HFSPlusVolumeHeader *header
+@@ -1100,9 +1117,11 @@ InitCatalogRoot_HFSPlus(const hfsparams_
  	UInt16					nodeSize;
  	SInt16					offset;
  	UInt32					unicodeBytes;
@@ -1007,7 +968,7 @@ index 085222f..7609779 100644
  	int index = 0;
  
  	nodeSize = dp->catalogNodeSize;
-@@ -1122,7 +1141,9 @@ InitCatalogRoot_HFSPlus(const hfsparams_t *dp, const HFSPlusVolumeHeader *header
+@@ -1122,7 +1141,9 @@ InitCatalogRoot_HFSPlus(const hfsparams_
  	 * First record is always the root directory...
  	 */
  	ckp = (HFSPlusCatalogKey *)((UInt8 *)buffer + offset);
@@ -1018,7 +979,7 @@ index 085222f..7609779 100644
  	/* Use CFString functions to get a HFSPlus Canonical name */
  	cfstr = CFStringCreateWithCString(kCFAllocatorDefault, (char *)dp->volumeName, kCFStringEncodingUTF8);
  	cfOK = _CFStringGetFileSystemRepresentation(cfstr, canonicalName, sizeof(canonicalName));
-@@ -1139,6 +1160,7 @@ InitCatalogRoot_HFSPlus(const hfsparams_t *dp, const HFSPlusVolumeHeader *header
+@@ -1139,6 +1160,7 @@ InitCatalogRoot_HFSPlus(const hfsparams_
  		      dp->volumeName, kDefaultVolumeNameStr);
  	}
  	CFRelease(cfstr);
@@ -1026,7 +987,7 @@ index 085222f..7609779 100644
  	ckp->nodeName.length = SWAP_BE16 (ckp->nodeName.length);
  
  	unicodeBytes = sizeof(UniChar) * SWAP_BE16 (ckp->nodeName.length);
-@@ -1821,15 +1843,15 @@ WriteBuffer(const DriveInfo *driveInfo, UInt64 startingSector, UInt32 byteCount,
+@@ -1821,15 +1843,15 @@ WriteBuffer(const DriveInfo *driveInfo,
  	off_t sector;
  
  	if ((byteCount % driveInfo->sectorSize) != 0)
@@ -1045,7 +1006,7 @@ index 085222f..7609779 100644
  }
  
  
-@@ -1913,7 +1935,7 @@ DivideAndRoundUp(UInt32 numerator, UInt32 denominator)
+@@ -1913,7 +1935,7 @@ DivideAndRoundUp(UInt32 numerator, UInt3
  	return quotient;
  }
  
@@ -1063,7 +1024,7 @@ index 085222f..7609779 100644
  
  static int
  ConvertUTF8toUnicode(const UInt8* source, UInt32 bufsize, UniChar* unibuf,
-@@ -2006,6 +2028,9 @@ ConvertUTF8toUnicode(const UInt8* source, UInt32 bufsize, UniChar* unibuf,
+@@ -2006,6 +2028,9 @@ ConvertUTF8toUnicode(const UInt8* source
  static int
  getencodinghint(unsigned char *name)
  {
@@ -1083,7 +1044,7 @@ index 085222f..7609779 100644
  }
  
  
-@@ -2034,12 +2060,14 @@ void GenerateVolumeUUID(VolumeUUID *newVolumeID) {
+@@ -2034,12 +2060,14 @@ void GenerateVolumeUUID(VolumeUUID *newV
  	unsigned char digest[20];
  	time_t now;
  	clock_t uptime;
@@ -1101,7 +1062,7 @@ index 085222f..7609779 100644
  	
  	do {
  		/* Initialize the SHA-1 context for processing: */
-@@ -2052,52 +2080,58 @@ void GenerateVolumeUUID(VolumeUUID *newVolumeID) {
+@@ -2052,52 +2080,58 @@ void GenerateVolumeUUID(VolumeUUID *newV
  		SHA1_Update(&context, &uptime, sizeof(uptime));
  		
  		/* The kernel's boot time: */
@@ -1166,8 +1127,6 @@ index 085222f..7609779 100644
  		/* The current GMT (26 ASCII characters): */
  		time(&now);
  		strncpy(randomInputBuffer, asctime(gmtime(&now)), 26);	/* "Mon Mar 27 13:46:26 2000" */
-diff --git a/newfs_hfs.tproj/newfs_hfs.c b/newfs_hfs.tproj/newfs_hfs.c
-index c4176a9..bf2ed21 100644
 --- a/newfs_hfs.tproj/newfs_hfs.c
 +++ b/newfs_hfs.tproj/newfs_hfs.c
 @@ -38,8 +38,13 @@
@@ -1273,7 +1232,7 @@ index c4176a9..bf2ed21 100644
  	}
  
  	exit(0);
-@@ -506,7 +527,9 @@ hfs_newfs(char *device, int forceHFS, int isRaw)
+@@ -506,7 +527,9 @@ hfs_newfs(char *device, int forceHFS, in
  	int fso = 0;
  	int retval = 0;
  	hfsparams_t defaults = {0};
@@ -1283,7 +1242,7 @@ index c4176a9..bf2ed21 100644
  
  	if (gPartitionSize) {
  			dip.sectorSize = kBytesPerSector;
-@@ -526,6 +549,34 @@ hfs_newfs(char *device, int forceHFS, int isRaw)
+@@ -526,6 +549,34 @@ hfs_newfs(char *device, int forceHFS, in
  	
  		if (fstat( fso, &stbuf) < 0)
  			fatal("%s: %s", device, strerror(errno));
@@ -1318,7 +1277,7 @@ index c4176a9..bf2ed21 100644
  	
  		if (ioctl(fso, DKIOCGETBLOCKCOUNT, &dip.totalSectors) < 0)
  			fatal("%s: %s", device, strerror(errno));
-@@ -537,11 +588,14 @@ hfs_newfs(char *device, int forceHFS, int isRaw)
+@@ -537,11 +588,14 @@ hfs_newfs(char *device, int forceHFS, in
  			dip.sectorsPerIO = (128 * 1024) / dip.sectorSize;  /* use 128K as default */
  		else
  			dip.sectorsPerIO = MIN(maxSectorsPerIO, (1024 * 1024) / dip.sectorSize);
@@ -1333,7 +1292,7 @@ index c4176a9..bf2ed21 100644
  		if (dip.sectorSize != kBytesPerSector) {
  			if (isRaw) {
  				close(fso);
-@@ -556,7 +610,9 @@ hfs_newfs(char *device, int forceHFS, int isRaw)
+@@ -556,7 +610,9 @@ hfs_newfs(char *device, int forceHFS, in
  				dip.sectorSize = kBytesPerSector;
  			}
  		}
@@ -1343,8 +1302,6 @@ index c4176a9..bf2ed21 100644
  	dip.sectorOffset = 0;
  	time(&createtime);
  
-diff --git a/newfs_hfs.tproj/newfs_hfs.h b/newfs_hfs.tproj/newfs_hfs.h
-index 968ff10..5680a34 100644
 --- a/newfs_hfs.tproj/newfs_hfs.h
 +++ b/newfs_hfs.tproj/newfs_hfs.h
 @@ -19,8 +19,12 @@

--- a/utils/hfsprogs/patches/0003-Add-helper-include-files-absent-from-the-upstream-pa.patch
+++ b/utils/hfsprogs/patches/0003-Add-helper-include-files-absent-from-the-upstream-pa.patch
@@ -15,9 +15,6 @@ the data structures used by the programs that manipulate the filesystems.
  create mode 100644 include/hfs/hfs_mount.h
  create mode 100644 include/sys/appleapiopts.h
 
-diff --git a/include/bitstring.h b/include/bitstring.h
-new file mode 100644
-index 0000000..fbecfbe
 --- /dev/null
 +++ b/include/bitstring.h
 @@ -0,0 +1,164 @@
@@ -185,9 +182,6 @@ index 0000000..fbecfbe
 +}
 +
 +#endif /* !_BITSTRING_H_ */
-diff --git a/include/hfs/hfs_format.h b/include/hfs/hfs_format.h
-new file mode 100644
-index 0000000..d820329
 --- /dev/null
 +++ b/include/hfs/hfs_format.h
 @@ -0,0 +1,689 @@
@@ -880,9 +874,6 @@ index 0000000..d820329
 +#endif
 +
 +#endif /* __HFS_FORMAT__ */
-diff --git a/include/hfs/hfs_mount.h b/include/hfs/hfs_mount.h
-new file mode 100644
-index 0000000..ad729f2
 --- /dev/null
 +++ b/include/hfs/hfs_mount.h
 @@ -0,0 +1,78 @@
@@ -964,9 +955,6 @@ index 0000000..ad729f2
 +#endif /* __APPLE_API_UNSTABLE */
 +
 +#endif /* ! _HFS_MOUNT_H_ */
-diff --git a/include/sys/appleapiopts.h b/include/sys/appleapiopts.h
-new file mode 100644
-index 0000000..4d2061f
 --- /dev/null
 +++ b/include/sys/appleapiopts.h
 @@ -0,0 +1,52 @@

--- a/utils/hfsprogs/patches/0004-Fix-compilation-on-64-bit-arches.patch
+++ b/utils/hfsprogs/patches/0004-Fix-compilation-on-64-bit-arches.patch
@@ -9,8 +9,6 @@ Subject: Fix compilation on 64-bit arches
  fsck_hfs.tproj/dfalib/hfs_endian.c   |  2 +-
  4 files changed, 16 insertions(+), 13 deletions(-)
 
-diff --git a/fsck_hfs.tproj/dfalib/BTreePrivate.h b/fsck_hfs.tproj/dfalib/BTreePrivate.h
-index 058c75b..2fc2f28 100644
 --- a/fsck_hfs.tproj/dfalib/BTreePrivate.h
 +++ b/fsck_hfs.tproj/dfalib/BTreePrivate.h
 @@ -104,6 +104,9 @@ typedef enum {
@@ -23,7 +21,7 @@ index 058c75b..2fc2f28 100644
  typedef struct BTreeControlBlock {					// fields specific to BTree CBs
  
  	UInt8		keyCompareType;   /* Key string Comparison Type */
-@@ -144,7 +147,7 @@ typedef struct BTreeControlBlock {					// fields specific to BTree CBs
+@@ -144,7 +147,7 @@ typedef struct BTreeControlBlock {					/
  	UInt32						 numPossibleHints;	// Looks like a formated hint
  	UInt32						 numValidHints;		// Hint used to find correct record.
  	
@@ -32,8 +30,6 @@ index 058c75b..2fc2f28 100644
  	SFCB						*fcbPtr;		// fcb of btree file
  	
  } BTreeControlBlock, *BTreeControlBlockPtr;
-diff --git a/fsck_hfs.tproj/dfalib/SControl.c b/fsck_hfs.tproj/dfalib/SControl.c
-index 37eb242..4ce9e16 100644
 --- a/fsck_hfs.tproj/dfalib/SControl.c
 +++ b/fsck_hfs.tproj/dfalib/SControl.c
 @@ -1034,7 +1034,7 @@ static int ScavTerm( SGlobPtr GPtr )
@@ -70,11 +66,9 @@ index 37eb242..4ce9e16 100644
  			}
  		}
  	}
-diff --git a/fsck_hfs.tproj/dfalib/SVerify1.c b/fsck_hfs.tproj/dfalib/SVerify1.c
-index c272d4d..a273bf3 100644
 --- a/fsck_hfs.tproj/dfalib/SVerify1.c
 +++ b/fsck_hfs.tproj/dfalib/SVerify1.c
-@@ -789,8 +789,8 @@ OSErr	CreateExtentsBTreeControlBlock( SGlobPtr GPtr )
+@@ -789,8 +789,8 @@ OSErr	CreateExtentsBTreeControlBlock( SG
  	//
  	//	set up our DFA extended BTCB area.  Will we have enough memory on all HFS+ volumes.
  	//
@@ -85,7 +79,7 @@ index c272d4d..a273bf3 100644
  		err = R_NoMem;
  		goto exit;
  	}
-@@ -1144,8 +1144,8 @@ OSErr	CreateCatalogBTreeControlBlock( SGlobPtr GPtr )
+@@ -1144,8 +1144,8 @@ OSErr	CreateCatalogBTreeControlBlock( SG
  	//	set up our DFA extended BTCB area.  Will we have enough memory on all HFS+ volumes.
  	//
  
@@ -96,7 +90,7 @@ index c272d4d..a273bf3 100644
  		err = R_NoMem;
  		goto exit;
  	}
-@@ -1779,8 +1779,8 @@ OSErr	CreateAttributesBTreeControlBlock( SGlobPtr GPtr )
+@@ -1779,8 +1779,8 @@ OSErr	CreateAttributesBTreeControlBlock(
  	//
  	//	set up our DFA extended BTCB area.  Will we have enough memory on all HFS+ volumes.
  	//
@@ -107,7 +101,7 @@ index c272d4d..a273bf3 100644
  		err = R_NoMem;
  		goto exit;
  	}
-@@ -1793,7 +1793,7 @@ OSErr	CreateAttributesBTreeControlBlock( SGlobPtr GPtr )
+@@ -1793,7 +1793,7 @@ OSErr	CreateAttributesBTreeControlBlock(
  	}
  	else
  	{
@@ -116,8 +110,6 @@ index c272d4d..a273bf3 100644
  			err = R_NoMem;
  			goto exit;
  		}
-diff --git a/fsck_hfs.tproj/dfalib/hfs_endian.c b/fsck_hfs.tproj/dfalib/hfs_endian.c
-index 69500c1..3cc9eb4 100755
 --- a/fsck_hfs.tproj/dfalib/hfs_endian.c
 +++ b/fsck_hfs.tproj/dfalib/hfs_endian.c
 @@ -437,7 +437,7 @@ hfs_swap_HFSPlusBTInternalNode (

--- a/utils/hfsprogs/patches/0005-Remove-Apple-specific-p-from-strings.patch
+++ b/utils/hfsprogs/patches/0005-Remove-Apple-specific-p-from-strings.patch
@@ -9,11 +9,9 @@ character of them.
  fsck_hfs.tproj/dfalib/SBTree.c       | 14 +++++------
  2 files changed, 31 insertions(+), 31 deletions(-)
 
-diff --git a/fsck_hfs.tproj/dfalib/BTreeTreeOps.c b/fsck_hfs.tproj/dfalib/BTreeTreeOps.c
-index b812b14..37fb170 100644
 --- a/fsck_hfs.tproj/dfalib/BTreeTreeOps.c
 +++ b/fsck_hfs.tproj/dfalib/BTreeTreeOps.c
-@@ -223,7 +223,7 @@ OSStatus	SearchTree	(BTreeControlBlockPtr	 btreePtr,
+@@ -223,7 +223,7 @@ OSStatus	SearchTree	(BTreeControlBlockPt
          //
          if (curNodeNum == 0)
          {
@@ -22,7 +20,7 @@ index b812b14..37fb170 100644
              err = fsBTInvalidNodeErr;
              goto ErrorExit;
          }
-@@ -433,7 +433,7 @@ OSStatus	InsertLevel (BTreeControlBlockPtr		 btreePtr,
+@@ -433,7 +433,7 @@ OSStatus	InsertLevel (BTreeControlBlockP
  		M_ExitOnError (err);
  		
  		if ( DEBUG_BUILD && updateParent && newRoot )
@@ -31,7 +29,7 @@ index b812b14..37fb170 100644
  	}
  
  	//////////////////////// Update Parent(s) ///////////////////////////////
-@@ -448,7 +448,7 @@ OSStatus	InsertLevel (BTreeControlBlockPtr		 btreePtr,
+@@ -448,7 +448,7 @@ OSStatus	InsertLevel (BTreeControlBlockP
  		
  		secondaryKey = nil;
  		
@@ -40,7 +38,7 @@ index b812b14..37fb170 100644
  
  		++level;
  
-@@ -456,7 +456,7 @@ OSStatus	InsertLevel (BTreeControlBlockPtr		 btreePtr,
+@@ -456,7 +456,7 @@ OSStatus	InsertLevel (BTreeControlBlockP
  		index = treePathTable [level].index;
  		parentNodeNum = treePathTable [level].node;
  
@@ -49,7 +47,7 @@ index b812b14..37fb170 100644
  
  		err = GetNode (btreePtr, parentNodeNum, &parentNode);	// released as target node in next level up
  		M_ExitOnError (err);
-@@ -470,7 +470,7 @@ OSStatus	InsertLevel (BTreeControlBlockPtr		 btreePtr,
+@@ -470,7 +470,7 @@ OSStatus	InsertLevel (BTreeControlBlockP
  		{
  			//¥¥Êdebug: check if ptr == targetNodeNum
  			GetRecordByIndex (btreePtr, parentNode.buffer, index, &keyPtr, &recPtr, &recSize);
@@ -67,7 +65,7 @@ index b812b14..37fb170 100644
  
  	return	err;
  
-@@ -566,7 +566,7 @@ static OSErr	InsertNode	(BTreeControlBlockPtr	 btreePtr,
+@@ -566,7 +566,7 @@ static OSErr	InsertNode	(BTreeControlBlo
  
  	*rootSplit = false;
  	
@@ -76,7 +74,7 @@ index b812b14..37fb170 100644
  	
  	leftNodeNum = ((NodeDescPtr) targetNode->buffer)->bLink;
  	rightNodeNum = ((NodeDescPtr) targetNode->buffer)->fLink;
-@@ -606,7 +606,7 @@ static OSErr	InsertNode	(BTreeControlBlockPtr	 btreePtr,
+@@ -606,7 +606,7 @@ static OSErr	InsertNode	(BTreeControlBlo
  	
  	if ( leftNodeNum > 0 )
  	{
@@ -85,7 +83,7 @@ index b812b14..37fb170 100644
  
  		if ( siblingNode->buffer == nil )
  		{
-@@ -614,7 +614,7 @@ static OSErr	InsertNode	(BTreeControlBlockPtr	 btreePtr,
+@@ -614,7 +614,7 @@ static OSErr	InsertNode	(BTreeControlBlo
  			M_ExitOnError (err);
  		}
  
@@ -94,7 +92,7 @@ index b812b14..37fb170 100644
  
  		if ( !key->skipRotate )		// are rotates allowed?
  		{
-@@ -703,7 +703,7 @@ OSStatus	DeleteTree			(BTreeControlBlockPtr		 btreePtr,
+@@ -703,7 +703,7 @@ OSStatus	DeleteTree			(BTreeControlBlock
  
  	targetNodeNum = treePathTable[level].node;
  	targetNodePtr = targetNode->buffer;
@@ -103,7 +101,7 @@ index b812b14..37fb170 100644
  
  	DeleteRecord (btreePtr, targetNodePtr, index);
  		
-@@ -797,7 +797,7 @@ OSStatus	DeleteTree			(BTreeControlBlockPtr		 btreePtr,
+@@ -797,7 +797,7 @@ OSStatus	DeleteTree			(BTreeControlBlock
  			 
  			//¥¥Êdebug: check if ptr == targetNodeNum
  			GetRecordByIndex (btreePtr, parentNode.buffer, index, &keyPtr, &recPtr, &recSize);
@@ -112,7 +110,7 @@ index b812b14..37fb170 100644
  			
  			// need to delete and re-insert this parent key/ptr
  			DeleteRecord (btreePtr, parentNode.buffer, index);
-@@ -1018,7 +1018,7 @@ static OSStatus	RotateLeft		(BTreeControlBlockPtr		 btreePtr,
+@@ -1018,7 +1018,7 @@ static OSStatus	RotateLeft		(BTreeContro
  										keyPtr, keyLength, recPtr, recSize);
  			if ( !didItFit )
  			{
@@ -121,7 +119,7 @@ index b812b14..37fb170 100644
  				err = fsBTBadRotateErr;
  				goto ErrorExit;
  			}
-@@ -1031,7 +1031,7 @@ static OSStatus	RotateLeft		(BTreeControlBlockPtr		 btreePtr,
+@@ -1031,7 +1031,7 @@ static OSStatus	RotateLeft		(BTreeContro
  			didItFit = RotateRecordLeft (btreePtr, leftNode, rightNode);
  			if ( !didItFit )
  			{
@@ -130,7 +128,7 @@ index b812b14..37fb170 100644
  				err = fsBTBadRotateErr;
  				goto ErrorExit;
  			}
-@@ -1048,7 +1048,7 @@ static OSStatus	RotateLeft		(BTreeControlBlockPtr		 btreePtr,
+@@ -1048,7 +1048,7 @@ static OSStatus	RotateLeft		(BTreeContro
  									keyPtr, keyLength, recPtr, recSize);
  		if ( !didItFit )
  		{
@@ -139,7 +137,7 @@ index b812b14..37fb170 100644
  			err = fsBTBadRotateErr;
  			goto ErrorExit;
  		}
-@@ -1117,7 +1117,7 @@ static OSStatus	SplitLeft		(BTreeControlBlockPtr		 btreePtr,
+@@ -1117,7 +1117,7 @@ static OSStatus	SplitLeft		(BTreeControl
  	right = rightNode->buffer;
  	left  = leftNode->buffer;
  	
@@ -148,7 +146,7 @@ index b812b14..37fb170 100644
  	
  	//¥¥ type should be kLeafNode or kIndexNode
  	
-@@ -1240,8 +1240,8 @@ static OSStatus	AddNewRootNode	(BTreeControlBlockPtr	 btreePtr,
+@@ -1240,8 +1240,8 @@ static OSStatus	AddNewRootNode	(BTreeCon
  	Boolean				didItFit;
  	UInt16				keyLength;	
  	
@@ -159,7 +157,7 @@ index b812b14..37fb170 100644
  	
  	
  	/////////////////////// Initialize New Root Node ////////////////////////////
-@@ -1264,7 +1264,7 @@ static OSStatus	AddNewRootNode	(BTreeControlBlockPtr	 btreePtr,
+@@ -1264,7 +1264,7 @@ static OSStatus	AddNewRootNode	(BTreeCon
  	didItFit = InsertKeyRecord ( btreePtr, rootNode.buffer, 0, keyPtr, keyLength,
  								 (UInt8 *) &rightNode->bLink, 4 );
  
@@ -168,7 +166,7 @@ index b812b14..37fb170 100644
  
  
  	//////////////////// Insert Right Node Index Record /////////////////////////
-@@ -1275,7 +1275,7 @@ static OSStatus	AddNewRootNode	(BTreeControlBlockPtr	 btreePtr,
+@@ -1275,7 +1275,7 @@ static OSStatus	AddNewRootNode	(BTreeCon
  	didItFit = InsertKeyRecord ( btreePtr, rootNode.buffer, 1, keyPtr, keyLength,
  								 (UInt8 *) &leftNode->fLink, 4 );
  
@@ -177,7 +175,7 @@ index b812b14..37fb170 100644
  
  
  #if DEBUG_TREEOPS
-@@ -1355,7 +1355,7 @@ static OSStatus	SplitRight		(BTreeControlBlockPtr		 btreePtr,
+@@ -1355,7 +1355,7 @@ static OSStatus	SplitRight		(BTreeContro
  	}
  	rightPtr = rightNodePtr->buffer;
  	
@@ -186,7 +184,7 @@ index b812b14..37fb170 100644
  	
  	//¥¥ type should be kLeafNode or kIndexNode
  	
-@@ -1557,7 +1557,7 @@ static OSStatus	RotateRight		(BTreeControlBlockPtr		 btreePtr,
+@@ -1557,7 +1557,7 @@ static OSStatus	RotateRight		(BTreeContr
  									keyPtr, keyLength, recPtr, recSize);
  		if ( !didItFit )
  		{
@@ -195,7 +193,7 @@ index b812b14..37fb170 100644
  			err = fsBTBadRotateErr;
  			goto ErrorExit;
  		}
-@@ -1572,7 +1572,7 @@ static OSStatus	RotateRight		(BTreeControlBlockPtr		 btreePtr,
+@@ -1572,7 +1572,7 @@ static OSStatus	RotateRight		(BTreeContr
  		didItFit = RotateRecordRight( btreePtr, leftNodePtr, rightNodePtr );
  		if ( !didItFit )
  		{
@@ -204,7 +202,7 @@ index b812b14..37fb170 100644
  			err = fsBTBadRotateErr;
  			goto ErrorExit;
  		}
-@@ -1583,7 +1583,7 @@ static OSStatus	RotateRight		(BTreeControlBlockPtr		 btreePtr,
+@@ -1583,7 +1583,7 @@ static OSStatus	RotateRight		(BTreeContr
  										keyPtr, keyLength, recPtr, recSize);
  			if ( !didItFit )
  			{
@@ -213,7 +211,7 @@ index b812b14..37fb170 100644
  				err = fsBTBadRotateErr;
  				goto ErrorExit;
  			}
-@@ -1607,7 +1607,7 @@ static OSStatus	RotateRight		(BTreeControlBlockPtr		 btreePtr,
+@@ -1607,7 +1607,7 @@ static OSStatus	RotateRight		(BTreeContr
  									keyPtr, keyLength, recPtr, recSize);
  		if ( !didItFit )
  		{
@@ -222,11 +220,9 @@ index b812b14..37fb170 100644
  			err = fsBTBadRotateErr;
  			goto ErrorExit;
  		}
-diff --git a/fsck_hfs.tproj/dfalib/SBTree.c b/fsck_hfs.tproj/dfalib/SBTree.c
-index cd81b13..eeb4e8c 100644
 --- a/fsck_hfs.tproj/dfalib/SBTree.c
 +++ b/fsck_hfs.tproj/dfalib/SBTree.c
-@@ -103,7 +103,7 @@ OSErr SearchBTreeRecord(SFCB *fcb, const void* key, UInt32 hint, void* foundKey,
+@@ -103,7 +103,7 @@ OSErr SearchBTreeRecord(SFCB *fcb, const
  			CopyMemory(&resultIterator->key, foundKey, CalcKeySize(btcb, &resultIterator->key));	//¥¥ warning, this could overflow user's buffer!!!
  
  		if ( DEBUG_BUILD && !ValidHFSRecord(data, btcb, *dataSize) )
@@ -235,7 +231,7 @@ index cd81b13..eeb4e8c 100644
  	}
  
  ErrorExit:
-@@ -211,7 +211,7 @@ OSErr GetBTreeRecord(SFCB *fcb, SInt16 selectionIndex, void* key, void* data, UI
+@@ -211,7 +211,7 @@ OSErr GetBTreeRecord(SFCB *fcb, SInt16 s
  		CopyMemory(&iterator->key, key, CalcKeySize(btcb, &iterator->key));	//¥¥ warning, this could overflow user's buffer!!!
  		
  		if ( DEBUG_BUILD && !ValidHFSRecord(data, btcb, *dataSize) )
@@ -244,7 +240,7 @@ index cd81b13..eeb4e8c 100644
  
  	}
  	
-@@ -243,7 +243,7 @@ OSErr InsertBTreeRecord(SFCB *fcb, const void* key, const void* data, UInt16 dat
+@@ -243,7 +243,7 @@ OSErr InsertBTreeRecord(SFCB *fcb, const
  	CopyMemory(key, &iterator.key, CalcKeySize(btcb, (BTreeKey *) key));	//¥¥ should we range check against maxkeylen?
  
  	if ( DEBUG_BUILD && !ValidHFSRecord(data, btcb, dataSize) )
@@ -253,7 +249,7 @@ index cd81b13..eeb4e8c 100644
  
  	result = BTInsertRecord( fcb, &iterator, &btRecord, dataSize );
  
-@@ -305,7 +305,7 @@ OSErr ReplaceBTreeRecord(SFCB *fcb, const void* key, UInt32 hint, void *newData,
+@@ -305,7 +305,7 @@ OSErr ReplaceBTreeRecord(SFCB *fcb, cons
  	CopyMemory(key, &iterator.key, CalcKeySize(btcb, (BTreeKey *) key));		//¥¥ should we range check against maxkeylen?
  
  	if ( DEBUG_BUILD && !ValidHFSRecord(newData, btcb, dataSize) )
@@ -262,7 +258,7 @@ index cd81b13..eeb4e8c 100644
  
  	result = BTReplaceRecord( fcb, &iterator, &btRecord, dataSize );
  
-@@ -344,7 +344,7 @@ SetEndOfForkProc ( SFCB *filePtr, FSSize minEOF, FSSize maxEOF )
+@@ -344,7 +344,7 @@ SetEndOfForkProc ( SFCB *filePtr, FSSize
  	else
  	{
  		if ( DEBUG_BUILD )
@@ -271,7 +267,7 @@ index cd81b13..eeb4e8c 100644
  		return -1;
  	}
  
-@@ -370,7 +370,7 @@ SetEndOfForkProc ( SFCB *filePtr, FSSize minEOF, FSSize maxEOF )
+@@ -370,7 +370,7 @@ SetEndOfForkProc ( SFCB *filePtr, FSSize
  	//	Make sure we got at least as much space as we needed
  	//
  	if (filePtr->fcbLogicalSize < minEOF) {
@@ -280,7 +276,7 @@ index cd81b13..eeb4e8c 100644
  		return dskFulErr;
  	}
  	
-@@ -442,7 +442,7 @@ static OSErr CheckBTreeKey(const BTreeKey *key, const BTreeControlBlock *btcb)
+@@ -442,7 +442,7 @@ static OSErr CheckBTreeKey(const BTreeKe
  	if ( (keyLen < 6) || (keyLen > btcb->maxKeyLength) )
  	{
  		if ( DEBUG_BUILD )

--- a/utils/hfsprogs/patches/0006-Adjust-types-for-printing.patch
+++ b/utils/hfsprogs/patches/0006-Adjust-types-for-printing.patch
@@ -9,8 +9,6 @@ in 32 and 64-bit architectures.
  fsck_hfs.tproj/dfalib/hfs_endian.c | 2 +-
  2 files changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/fsck_hfs.tproj/dfalib/SControl.c b/fsck_hfs.tproj/dfalib/SControl.c
-index 4ce9e16..8b03ece 100644
 --- a/fsck_hfs.tproj/dfalib/SControl.c
 +++ b/fsck_hfs.tproj/dfalib/SControl.c
 @@ -776,7 +776,7 @@ static int ScavSetUp( SGlob *GPtr)
@@ -22,8 +20,6 @@ index 4ce9e16..8b03ece 100644
  					R_NoMem, sizeof(ScavStaticStructures) );
  			}
  			return( R_NoMem );
-diff --git a/fsck_hfs.tproj/dfalib/hfs_endian.c b/fsck_hfs.tproj/dfalib/hfs_endian.c
-index 3cc9eb4..6ca2ac1 100755
 --- a/fsck_hfs.tproj/dfalib/hfs_endian.c
 +++ b/fsck_hfs.tproj/dfalib/hfs_endian.c
 @@ -563,7 +563,7 @@ hfs_swap_HFSPlusBTInternalNode (

--- a/utils/hfsprogs/patches/0007-Fix-path-for-HFS-wrapper-block.patch
+++ b/utils/hfsprogs/patches/0007-Fix-path-for-HFS-wrapper-block.patch
@@ -8,11 +8,9 @@ systems (since it is arch independent).
  newfs_hfs.tproj/makehfs.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/newfs_hfs.tproj/makehfs.c b/newfs_hfs.tproj/makehfs.c
-index 7609779..2233ef7 100644
 --- a/newfs_hfs.tproj/makehfs.c
 +++ b/newfs_hfs.tproj/makehfs.c
-@@ -70,7 +70,7 @@ extern Boolean _CFStringGetFileSystemRepresentation(CFStringRef string, UInt8 *b
+@@ -70,7 +70,7 @@ extern Boolean _CFStringGetFileSystemRep
  #include "readme.h"
  
  

--- a/utils/hfsprogs/patches/0008-Provide-command-line-option-a.patch
+++ b/utils/hfsprogs/patches/0008-Provide-command-line-option-a.patch
@@ -8,8 +8,6 @@ behavior that the -p option has, for greater compatibility with other tools.
  fsck_hfs.tproj/fsck_hfs.c | 5 +++--
  1 file changed, 3 insertions(+), 2 deletions(-)
 
-diff --git a/fsck_hfs.tproj/fsck_hfs.c b/fsck_hfs.tproj/fsck_hfs.c
-index f1a18bd..6117698 100644
 --- a/fsck_hfs.tproj/fsck_hfs.c
 +++ b/fsck_hfs.tproj/fsck_hfs.c
 @@ -104,7 +104,7 @@ main(argc, argv)

--- a/utils/hfsprogs/patches/0009-Rename-dprintf-to-dbg_printf.patch
+++ b/utils/hfsprogs/patches/0009-Rename-dprintf-to-dbg_printf.patch
@@ -9,11 +9,9 @@ Subject: Rename dprintf to dbg_printf
  fsck_hfs.tproj/fsck_debug.h      | 10 +++++-----
  4 files changed, 22 insertions(+), 22 deletions(-)
 
-diff --git a/fsck_hfs.tproj/dfalib/SRepair.c b/fsck_hfs.tproj/dfalib/SRepair.c
-index 8eb759c..89c12d6 100644
 --- a/fsck_hfs.tproj/dfalib/SRepair.c
 +++ b/fsck_hfs.tproj/dfalib/SRepair.c
-@@ -1825,13 +1825,13 @@ static OSErr FixAttrSize(SGlobPtr GPtr, RepairOrderPtr p)
+@@ -1825,13 +1825,13 @@ static OSErr FixAttrSize(SGlobPtr GPtr,
  	result = BTSearchRecord(GPtr->calculatedAttributesFCB, &iterator, 
  				kInvalidMRUCacheKey, &btRecord, &recSize, &iterator);
  	if (result) {
@@ -29,7 +27,7 @@ index 8eb759c..89c12d6 100644
  		result = btNotFound;
  		goto out;
  	}
-@@ -1862,7 +1862,7 @@ static OSErr FixAttrSize(SGlobPtr GPtr, RepairOrderPtr p)
+@@ -1862,7 +1862,7 @@ static OSErr FixAttrSize(SGlobPtr GPtr,
  		result = BTReplaceRecord(GPtr->calculatedAttributesFCB, &iterator,
  					&btRecord, recSize);
  		if (result) {
@@ -47,7 +45,7 @@ index 8eb759c..89c12d6 100644
  		if (err) {
  			goto create_symlink;
  		}
-@@ -3227,12 +3227,12 @@ static OSErr MoveExtent(SGlobPtr GPtr, ExtentInfo *extentInfo)
+@@ -3227,12 +3227,12 @@ static OSErr MoveExtent(SGlobPtr GPtr, E
  											  &extentData, &recordSize, &foundExtentIndex);
  				foundLocation = extentsBTree;
  				if (err != noErr) {
@@ -62,7 +60,7 @@ index 8eb759c..89c12d6 100644
  				goto out;
  			}
  		}
-@@ -3241,7 +3241,7 @@ static OSErr MoveExtent(SGlobPtr GPtr, ExtentInfo *extentInfo)
+@@ -3241,7 +3241,7 @@ static OSErr MoveExtent(SGlobPtr GPtr, E
  	err = CopyDiskBlocks(GPtr, extentInfo->startBlock, extentInfo->blockCount, 
  						 extentInfo->newStartBlock);
  	if (err != noErr) {
@@ -71,7 +69,7 @@ index 8eb759c..89c12d6 100644
  		goto out;
  	}
  	
-@@ -3260,7 +3260,7 @@ static OSErr MoveExtent(SGlobPtr GPtr, ExtentInfo *extentInfo)
+@@ -3260,7 +3260,7 @@ static OSErr MoveExtent(SGlobPtr GPtr, E
  
  	}
  	if (err != noErr) {
@@ -80,7 +78,7 @@ index 8eb759c..89c12d6 100644
  		goto out;
  	}
  
-@@ -3491,7 +3491,7 @@ static OSErr SearchExtentInAttributeBT(SGlobPtr GPtr, ExtentInfo *extentInfo,
+@@ -3491,7 +3491,7 @@ static OSErr SearchExtentInAttributeBT(S
  	result = BTSearchRecord(GPtr->calculatedAttributesFCB, &iterator, 
  				kInvalidMRUCacheKey, &btRecord, recordSize, &iterator);
  	if (result) {
@@ -89,11 +87,9 @@ index 8eb759c..89c12d6 100644
  		goto out;	
  	}
  	
-diff --git a/fsck_hfs.tproj/dfalib/SVerify1.c b/fsck_hfs.tproj/dfalib/SVerify1.c
-index a273bf3..39bda5c 100644
 --- a/fsck_hfs.tproj/dfalib/SVerify1.c
 +++ b/fsck_hfs.tproj/dfalib/SVerify1.c
-@@ -2157,9 +2157,9 @@ CheckAttributeRecord(SGlobPtr GPtr, const HFSPlusAttrKey *key, const HFSPlusAttr
+@@ -2157,9 +2157,9 @@ CheckAttributeRecord(SGlobPtr GPtr, cons
  	
  	if (doDelete == true) {
  		result = DeleteBTreeRecord(GPtr->calculatedAttributesFCB, key);
@@ -105,7 +101,7 @@ index a273bf3..39bda5c 100644
  		}
  		
  		/* Set flags to mark header and map dirty */
-@@ -3034,7 +3034,7 @@ OSErr	CheckFileExtents( SGlobPtr GPtr, UInt32 fileNumber, UInt8 forkType,
+@@ -3034,7 +3034,7 @@ OSErr	CheckFileExtents( SGlobPtr GPtr, U
  		//	checkout the extent record first
  		err = ChkExtRec( GPtr, extents, &lastExtentIndex );
  		if (err != noErr) {
@@ -114,8 +110,6 @@ index a273bf3..39bda5c 100644
  
  			/* Stop verification if bad extent is found for system file or EA */
  			if ((fileNumber < kHFSFirstUserCatalogNodeID) ||
-diff --git a/fsck_hfs.tproj/fsck_debug.c b/fsck_hfs.tproj/fsck_debug.c
-index 1be3fc5..77e8e51 100644
 --- a/fsck_hfs.tproj/fsck_debug.c
 +++ b/fsck_hfs.tproj/fsck_debug.c
 @@ -25,18 +25,18 @@
@@ -150,8 +144,6 @@ index 1be3fc5..77e8e51 100644
  {
  	if (cur_debug_level & type) {
  		va_list ap;
-diff --git a/fsck_hfs.tproj/fsck_debug.h b/fsck_hfs.tproj/fsck_debug.h
-index 81e3932..cb1b9be 100644
 --- a/fsck_hfs.tproj/fsck_debug.h
 +++ b/fsck_hfs.tproj/fsck_debug.h
 @@ -36,18 +36,18 @@ enum debug_message_type {

--- a/utils/hfsprogs/patches/0010-Rename-custom-macro-nil-with-NULL.patch
+++ b/utils/hfsprogs/patches/0010-Rename-custom-macro-nil-with-NULL.patch
@@ -15,11 +15,9 @@ Subject: Rename custom macro nil with NULL
  fsck_hfs.tproj/dfalib/SVerify2.c      |   4 +-
  10 files changed, 177 insertions(+), 177 deletions(-)
 
-diff --git a/fsck_hfs.tproj/dfalib/BTree.c b/fsck_hfs.tproj/dfalib/BTree.c
-index 7ad9fe0..c0c8744 100644
 --- a/fsck_hfs.tproj/dfalib/BTree.c
 +++ b/fsck_hfs.tproj/dfalib/BTree.c
-@@ -163,21 +163,21 @@ OSStatus	BTInitialize		(FCB					*filePtr,
+@@ -163,21 +163,21 @@ OSStatus	BTInitialize		(FCB					*filePtr
  
  	////////////////////// Preliminary Error Checking ///////////////////////////
  
@@ -48,7 +46,7 @@ index 7ad9fe0..c0c8744 100644
  
  	if ((maxKeyLength == 0) ||
  		(maxKeyLength >  kMaxKeyLength))					return	fsBTInvalidKeyLengthErr;
-@@ -209,7 +209,7 @@ OSStatus	BTInitialize		(FCB					*filePtr,
+@@ -209,7 +209,7 @@ OSStatus	BTInitialize		(FCB					*filePtr
  	//////////////////////// Allocate Control Block /////////////////////////////
  
  	M_RESIDENT_ALLOCATE_FIXED_CLEAR( &btreePtr, sizeof( BTreeControlBlock ), kFSBTreeControlBlockType );
@@ -57,7 +55,7 @@ index 7ad9fe0..c0c8744 100644
  	{
  		err = memFullErr;
  		goto ErrorExit;
-@@ -220,7 +220,7 @@ OSStatus	BTInitialize		(FCB					*filePtr,
+@@ -220,7 +220,7 @@ OSStatus	BTInitialize		(FCB					*filePtr
  	btreePtr->flags				= 0;
  	btreePtr->attributes		= 0;
  	btreePtr->forkPtr			= forkPtr;
@@ -66,7 +64,7 @@ index 7ad9fe0..c0c8744 100644
  	btreePtr->keyDescPtr		= keyDescPtr;
  	btreePtr->btreeType			= btreeType;
  	btreePtr->treeDepth			= 0;
-@@ -282,7 +282,7 @@ OSStatus	BTInitialize		(FCB					*filePtr,
+@@ -282,7 +282,7 @@ OSStatus	BTInitialize		(FCB					*filePtr
  
  	///////////////////// Copy Key Descriptor To Header /////////////////////////
  #if SupportsKeyDescriptors
@@ -75,7 +73,7 @@ index 7ad9fe0..c0c8744 100644
  	{
  		err = CheckKeyDescriptor (keyDescPtr, maxKeyLength);
  		M_ExitOnError (err);
-@@ -309,7 +309,7 @@ OSStatus	BTInitialize		(FCB					*filePtr,
+@@ -309,7 +309,7 @@ OSStatus	BTInitialize		(FCB					*filePtr
  	err = UpdateHeader (btreePtr);
  	M_ExitOnError (err);
  
@@ -84,7 +82,7 @@ index 7ad9fe0..c0c8744 100644
  	M_RESIDENT_DEALLOCATE_FIXED( btreePtr, sizeof( BTreeControlBlock ), kFSBTreeControlBlockType );
  
  	return	noErr;
-@@ -320,7 +320,7 @@ OSStatus	BTInitialize		(FCB					*filePtr,
+@@ -320,7 +320,7 @@ OSStatus	BTInitialize		(FCB					*filePtr
  ErrorExit:
  
  	(void) ReleaseNode (btreePtr, &headerNode);
@@ -93,7 +91,7 @@ index 7ad9fe0..c0c8744 100644
  		M_RESIDENT_DEALLOCATE_FIXED( btreePtr, sizeof( BTreeControlBlock ), kFSBTreeControlBlockType );
  
  	return	err;
-@@ -342,7 +342,7 @@ Input:		filePtr				- pointer to file to open as a B-tree
+@@ -342,7 +342,7 @@ Input:		filePtr				- pointer to file to
  			setEndOfForkProc	- pointer to client's SetEOF function
  
  Result:		noErr				- success
@@ -102,7 +100,7 @@ index 7ad9fe0..c0c8744 100644
  			fsBTInvalidFileErr				-
  			memFullErr			-
  			!= noErr			- failure
-@@ -364,16 +364,16 @@ OSStatus	BTOpenPath			(SFCB					*filePtr,
+@@ -364,16 +364,16 @@ OSStatus	BTOpenPath			(SFCB					*filePtr
  
  	////////////////////// Preliminary Error Checking ///////////////////////////
  
@@ -125,7 +123,7 @@ index 7ad9fe0..c0c8744 100644
  		return noErr;
  
  												// is file large enough to contain header node?
-@@ -384,7 +384,7 @@ OSStatus	BTOpenPath			(SFCB					*filePtr,
+@@ -384,7 +384,7 @@ OSStatus	BTOpenPath			(SFCB					*filePtr
  	//////////////////////// Allocate Control Block /////////////////////////////
  
  	btreePtr = (BTreeControlBlock*) AllocateClearMemory( sizeof( BTreeControlBlock ) );
@@ -134,7 +132,7 @@ index 7ad9fe0..c0c8744 100644
  	{
  		Panic ("\pBTOpen: no memory for btreePtr.");
  		return	memFullErr;
-@@ -397,7 +397,7 @@ OSStatus	BTOpenPath			(SFCB					*filePtr,
+@@ -397,7 +397,7 @@ OSStatus	BTOpenPath			(SFCB					*filePtr
  
  	/////////////////////////// Read Header Node ////////////////////////////////
  
@@ -143,7 +141,7 @@ index 7ad9fe0..c0c8744 100644
  	
  	btreePtr->fcbPtr			= filePtr;
  	filePtr->fcbBtree			= (void *) btreePtr;	// attach btree cb to file
-@@ -487,7 +487,7 @@ OSStatus	BTOpenPath			(SFCB					*filePtr,
+@@ -487,7 +487,7 @@ OSStatus	BTOpenPath			(SFCB					*filePtr
  
  	////////////////////////// Get Key Descriptor ///////////////////////////////
  #if SupportsKeyDescriptors
@@ -152,7 +150,7 @@ index 7ad9fe0..c0c8744 100644
  	{
  		err = GetKeyDescriptor (btreePtr, nodeRec.buffer);	//¥¥ it should check amount of memory allocated...
  		M_ExitOnError (err);
-@@ -499,7 +499,7 @@ OSStatus	BTOpenPath			(SFCB					*filePtr,
+@@ -499,7 +499,7 @@ OSStatus	BTOpenPath			(SFCB					*filePtr
  	else
  #endif
  	{
@@ -161,7 +159,7 @@ index 7ad9fe0..c0c8744 100644
  	}
  
  	err = ReleaseNode (btreePtr, &nodeRec);
-@@ -528,7 +528,7 @@ OSStatus	BTOpenPath			(SFCB					*filePtr,
+@@ -528,7 +528,7 @@ OSStatus	BTOpenPath			(SFCB					*filePtr
  
  ErrorExit:
  
@@ -170,7 +168,7 @@ index 7ad9fe0..c0c8744 100644
  	(void) ReleaseNode (btreePtr, &nodeRec);
  	DisposeMemory( btreePtr );
  
-@@ -567,7 +567,7 @@ OSStatus	BTClosePath			(SFCB					*filePtr)
+@@ -567,7 +567,7 @@ OSStatus	BTClosePath			(SFCB					*filePt
  
  	btreePtr = (BTreeControlBlockPtr) filePtr->fcbBtree;
  
@@ -179,7 +177,7 @@ index 7ad9fe0..c0c8744 100644
  		return fsBTInvalidFileErr;
  
  	////////////////////// Check for other BTree Paths //////////////////////////
-@@ -603,14 +603,14 @@ OSStatus	BTClosePath			(SFCB					*filePtr)
+@@ -603,14 +603,14 @@ OSStatus	BTClosePath			(SFCB					*filePt
  	M_ExitOnError (err);
  
  #if SupportsKeyDescriptors
@@ -196,7 +194,7 @@ index 7ad9fe0..c0c8744 100644
  
  //	LogEndTime(kTraceCloseBTree, noErr);
  
-@@ -643,7 +643,7 @@ Function:	Search for position in B*Tree indicated by searchKey. If a valid node
+@@ -643,7 +643,7 @@ Function:	Search for position in B*Tree
  
  Input:		pathPtr			- pointer to path for BTree file.
  			searchKey		- pointer to search key to match.
@@ -205,7 +203,7 @@ index 7ad9fe0..c0c8744 100644
  
  Output:		record			- pointer to BufferDescriptor containing record
  			recordLen		- length of data at recordPtr
-@@ -678,14 +678,14 @@ OSStatus	BTSearchRecord		(SFCB						*filePtr,
+@@ -678,14 +678,14 @@ OSStatus	BTSearchRecord		(SFCB						*fil
  
  //	LogStartTime(kTraceSearchBTree);
  
@@ -224,7 +222,7 @@ index 7ad9fe0..c0c8744 100644
  	{
  		err = CheckKey (&searchIterator->key, btreePtr->keyDescPtr, btreePtr->maxKeyLength);
  		M_ExitOnError (err);
-@@ -775,9 +775,9 @@ OSStatus	BTSearchRecord		(SFCB						*filePtr,
+@@ -775,9 +775,9 @@ OSStatus	BTSearchRecord		(SFCB						*fil
  		//¥¥ Should check for errors! Or BlockMove could choke on recordPtr!!!
  		GetRecordByIndex (btreePtr, node.buffer, index, &keyPtr, &recordPtr, &len);
  
@@ -236,7 +234,7 @@ index 7ad9fe0..c0c8744 100644
  		{
  			ByteCount recordSize;
  
-@@ -794,7 +794,7 @@ OSStatus	BTSearchRecord		(SFCB						*filePtr,
+@@ -794,7 +794,7 @@ OSStatus	BTSearchRecord		(SFCB						*fil
  
  	/////////////////////// Success - Update Iterator ///////////////////////////
  
@@ -245,7 +243,7 @@ index 7ad9fe0..c0c8744 100644
  	{
  		resultIterator->hint.writeCount	= btreePtr->writeCount;
  		resultIterator->hint.nodeNum	= nodeNum;
-@@ -825,10 +825,10 @@ OSStatus	BTSearchRecord		(SFCB						*filePtr,
+@@ -825,10 +825,10 @@ OSStatus	BTSearchRecord		(SFCB						*fil
  
  ErrorExit:
  
@@ -258,7 +256,7 @@ index 7ad9fe0..c0c8744 100644
  	{
  		resultIterator->hint.writeCount	= 0;
  		resultIterator->hint.nodeNum	= 0;
-@@ -892,18 +892,18 @@ OSStatus	BTIterateRecord		(SFCB						*filePtr,
+@@ -892,18 +892,18 @@ OSStatus	BTIterateRecord		(SFCB						*fi
  
  	////////////////////////// Priliminary Checks ///////////////////////////////
  
@@ -282,7 +280,7 @@ index 7ad9fe0..c0c8744 100644
  	{
  		return	fsBTInvalidFileErr;			//¥¥ handle properly
  	}
-@@ -968,7 +968,7 @@ OSStatus	BTIterateRecord		(SFCB						*filePtr,
+@@ -968,7 +968,7 @@ OSStatus	BTIterateRecord		(SFCB						*fi
  		}
  		else
  		{
@@ -291,7 +289,7 @@ index 7ad9fe0..c0c8744 100644
  			{
  				nodeNum = ((NodeDescPtr) node.buffer)->bLink;
  				if ( nodeNum > 0)
-@@ -981,13 +981,13 @@ OSStatus	BTIterateRecord		(SFCB						*filePtr,
+@@ -981,13 +981,13 @@ OSStatus	BTIterateRecord		(SFCB						*fi
  				}
  			}
  			//	Before we stomp on "right", we'd better release it if needed
@@ -307,7 +305,7 @@ index 7ad9fe0..c0c8744 100644
  			index 		= ((NodeDescPtr) node.buffer)->numRecords -1;
  		}
  	}
-@@ -1012,7 +1012,7 @@ OSStatus	BTIterateRecord		(SFCB						*filePtr,
+@@ -1012,7 +1012,7 @@ OSStatus	BTIterateRecord		(SFCB						*fi
  		}
  		else
  		{
@@ -316,7 +314,7 @@ index 7ad9fe0..c0c8744 100644
  			{
  				nodeNum = ((NodeDescPtr) node.buffer)->fLink;
  				if ( nodeNum > 0)
-@@ -1025,13 +1025,13 @@ OSStatus	BTIterateRecord		(SFCB						*filePtr,
+@@ -1025,13 +1025,13 @@ OSStatus	BTIterateRecord		(SFCB						*fi
  				}
  			}
  			//	Before we stomp on "left", we'd better release it if needed
@@ -382,7 +380,7 @@ index 7ad9fe0..c0c8744 100644
  	{
  		iterator->hint.writeCount	= 0;
  		iterator->hint.nodeNum		= 0;
-@@ -1157,7 +1157,7 @@ OSStatus	BTInsertRecord		(SFCB						*filePtr,
+@@ -1157,7 +1157,7 @@ OSStatus	BTInsertRecord		(SFCB						*fil
  
  	////////////////////////// Priliminary Checks ///////////////////////////////
  
@@ -391,7 +389,7 @@ index 7ad9fe0..c0c8744 100644
  
  	err = CheckInsertParams (filePtr, iterator, record, recordLen);
  	if (err != noErr)
-@@ -1317,7 +1317,7 @@ OSStatus	BTSetRecord			(SFCB						*filePtr,
+@@ -1317,7 +1317,7 @@ OSStatus	BTSetRecord			(SFCB						*fileP
  
  	////////////////////////// Priliminary Checks ///////////////////////////////
  
@@ -400,7 +398,7 @@ index 7ad9fe0..c0c8744 100644
  
  	err = CheckInsertParams (filePtr, iterator, record, recordLen);
  	if (err != noErr)
-@@ -1506,7 +1506,7 @@ OSStatus	BTReplaceRecord		(SFCB						*filePtr,
+@@ -1506,7 +1506,7 @@ OSStatus	BTReplaceRecord		(SFCB						*fi
  
  	////////////////////////// Priliminary Checks ///////////////////////////////
  
@@ -409,7 +407,7 @@ index 7ad9fe0..c0c8744 100644
  
  	err = CheckInsertParams (filePtr, iterator, record, recordLen);
  	if (err != noErr)
-@@ -1645,20 +1645,20 @@ OSStatus	BTDeleteRecord		(SFCB						*filePtr,
+@@ -1645,20 +1645,20 @@ OSStatus	BTDeleteRecord		(SFCB						*fil
  
  	////////////////////////// Priliminary Checks ///////////////////////////////
  
@@ -435,7 +433,7 @@ index 7ad9fe0..c0c8744 100644
  	{
  		err = CheckKey (&iterator->key, btreePtr->keyDescPtr, btreePtr->maxKeyLength);
  		M_ExitOnError (err);
-@@ -1712,12 +1712,12 @@ OSStatus	BTGetInformation	(SFCB					*filePtr,
+@@ -1712,12 +1712,12 @@ OSStatus	BTGetInformation	(SFCB					*fil
  	BTreeControlBlockPtr	btreePtr;
  
  
@@ -451,7 +449,7 @@ index 7ad9fe0..c0c8744 100644
  
  	//¥¥ check version?
  
-@@ -1730,7 +1730,7 @@ OSStatus	BTGetInformation	(SFCB					*filePtr,
+@@ -1730,7 +1730,7 @@ OSStatus	BTGetInformation	(SFCB					*fil
  	info->keyDescriptor	= btreePtr->keyDescPtr;	//¥¥ this won't do at all...
  	info->reserved		= 0;
  
@@ -460,7 +458,7 @@ index 7ad9fe0..c0c8744 100644
  		info->keyDescLength	= 0;
  	else
  		info->keyDescLength	= (UInt32) btreePtr->keyDescPtr->length;
-@@ -1762,11 +1762,11 @@ OSStatus	BTFlushPath				(SFCB					*filePtr)
+@@ -1762,11 +1762,11 @@ OSStatus	BTFlushPath				(SFCB					*fileP
  
  //	LogStartTime(kTraceFlushBTree);
  
@@ -474,7 +472,7 @@ index 7ad9fe0..c0c8744 100644
  
  	err = UpdateHeader (btreePtr);
  
-@@ -1788,13 +1788,13 @@ Input:		iterator	- pointer to BTreeIterator
+@@ -1788,13 +1788,13 @@ Input:		iterator	- pointer to BTreeItera
  Output:		iterator	- iterator with the hint.nodeNum cleared
  
  Result:		noErr			- success
@@ -490,11 +488,9 @@ index 7ad9fe0..c0c8744 100644
  		return	paramErr;
  
  	iterator->hint.nodeNum = 0;
-diff --git a/fsck_hfs.tproj/dfalib/BTreeAllocate.c b/fsck_hfs.tproj/dfalib/BTreeAllocate.c
-index 485d867..02bdd8d 100644
 --- a/fsck_hfs.tproj/dfalib/BTreeAllocate.c
 +++ b/fsck_hfs.tproj/dfalib/BTreeAllocate.c
-@@ -83,7 +83,7 @@ OSStatus	AllocateNode (BTreeControlBlockPtr		btreePtr, UInt32	*nodeNum)
+@@ -83,7 +83,7 @@ OSStatus	AllocateNode (BTreeControlBlock
  	
  	
  	nodeNumber		= 0;				// first node number of header map record
@@ -503,7 +499,7 @@ index 485d867..02bdd8d 100644
  										//	- and for ErrorExit
  	
  	while (true)
-@@ -192,7 +192,7 @@ OSStatus	FreeNode (BTreeControlBlockPtr		btreePtr, UInt32	nodeNum)
+@@ -192,7 +192,7 @@ OSStatus	FreeNode (BTreeControlBlockPtr
  
  	//////////////////////////// Find Map Record ////////////////////////////////
  	nodeIndex			= 0;				// first node number of header map record
@@ -512,7 +508,7 @@ index 485d867..02bdd8d 100644
  	
  	while (nodeNum >= nodeIndex)
  	{
-@@ -278,8 +278,8 @@ OSStatus	ExtendBTree	(BTreeControlBlockPtr	btreePtr,
+@@ -278,8 +278,8 @@ OSStatus	ExtendBTree	(BTreeControlBlockP
  	nodeSize			= btreePtr->nodeSize;
  	filePtr				= btreePtr->fcbPtr;
  	
@@ -532,7 +528,7 @@ index 485d867..02bdd8d 100644
  			node is retrieved.
  
  
-@@ -474,7 +474,7 @@ OSStatus	GetMapNode (BTreeControlBlockPtr	  btreePtr,
+@@ -474,7 +474,7 @@ OSStatus	GetMapNode (BTreeControlBlockPt
  	UInt16		mapIndex;
  	UInt32		nextNodeNum;
  	
@@ -550,11 +546,9 @@ index 485d867..02bdd8d 100644
  	*mapSize	= 0;
  	
  	return	err;
-diff --git a/fsck_hfs.tproj/dfalib/BTreeMiscOps.c b/fsck_hfs.tproj/dfalib/BTreeMiscOps.c
-index 7c9edca..997f34b 100644
 --- a/fsck_hfs.tproj/dfalib/BTreeMiscOps.c
 +++ b/fsck_hfs.tproj/dfalib/BTreeMiscOps.c
-@@ -236,13 +236,13 @@ OSStatus	FindIteratorPosition	(BTreeControlBlockPtr	 btreePtr,
+@@ -236,13 +236,13 @@ OSStatus	FindIteratorPosition	(BTreeCont
  	// assume index points to UInt16
  	// assume foundRecord points to Boolean
  	
@@ -572,7 +566,7 @@ index 7c9edca..997f34b 100644
  	{
  		err = fsBTInvalidIteratorErr;
  		goto ErrorExit;
-@@ -250,7 +250,7 @@ OSStatus	FindIteratorPosition	(BTreeControlBlockPtr	 btreePtr,
+@@ -250,7 +250,7 @@ OSStatus	FindIteratorPosition	(BTreeCont
  
  #if SupportsKeyDescriptors
  	//¥¥ verify iterator key (change CheckKey to take btreePtr instead of keyDescPtr?)
@@ -581,7 +575,7 @@ index 7c9edca..997f34b 100644
  	{
  		err = CheckKey (&iterator->key, btreePtr->keyDescPtr, btreePtr->maxKeyLength );
  		M_ExitOnError (err);
-@@ -309,7 +309,7 @@ OSStatus	FindIteratorPosition	(BTreeControlBlockPtr	 btreePtr,
+@@ -309,7 +309,7 @@ OSStatus	FindIteratorPosition	(BTreeCont
  		{
  			*right			= *middle;
  			*middle			= *left;
@@ -590,7 +584,7 @@ index 7c9edca..997f34b 100644
  			index			= leftIndex;
  			
  			goto SuccessfulExit;
-@@ -330,7 +330,7 @@ OSStatus	FindIteratorPosition	(BTreeControlBlockPtr	 btreePtr,
+@@ -330,7 +330,7 @@ OSStatus	FindIteratorPosition	(BTreeCont
  		{
  			*right			= *middle;
  			*middle			= *left;
@@ -599,7 +593,7 @@ index 7c9edca..997f34b 100644
  			index			= leftIndex;
  			
  			goto SuccessfulExit;
-@@ -363,7 +363,7 @@ OSStatus	FindIteratorPosition	(BTreeControlBlockPtr	 btreePtr,
+@@ -363,7 +363,7 @@ OSStatus	FindIteratorPosition	(BTreeCont
  		{
  			*left			= *middle;
  			*middle			= *right;
@@ -608,7 +602,7 @@ index 7c9edca..997f34b 100644
  			index			= rightIndex;
  			
  			goto SuccessfulExit;
-@@ -427,15 +427,15 @@ OSStatus	CheckInsertParams		(SFCB						*filePtr,
+@@ -427,15 +427,15 @@ OSStatus	CheckInsertParams		(SFCB						*
  {
  	BTreeControlBlockPtr	btreePtr;
  	
@@ -629,11 +623,9 @@ index 7c9edca..997f34b 100644
  	{
  		OSStatus	err;
  
-diff --git a/fsck_hfs.tproj/dfalib/BTreeNodeOps.c b/fsck_hfs.tproj/dfalib/BTreeNodeOps.c
-index da07cc7..ef2bd7b 100644
 --- a/fsck_hfs.tproj/dfalib/BTreeNodeOps.c
 +++ b/fsck_hfs.tproj/dfalib/BTreeNodeOps.c
-@@ -105,7 +105,7 @@ Function:	Gets an existing BTree node from FS Agent and verifies it.
+@@ -105,7 +105,7 @@ Function:	Gets an existing BTree node fr
  Input:		btreePtr	- pointer to BTree control block
  			nodeNum		- number of node to request
  			
@@ -642,7 +634,7 @@ index da07cc7..ef2bd7b 100644
  			
  Result:
  			noErr		- success
-@@ -139,7 +139,7 @@ OSStatus	GetNode		(BTreeControlBlockPtr	 btreePtr,
+@@ -139,7 +139,7 @@ OSStatus	GetNode		(BTreeControlBlockPtr
  	if (err != noErr)
  	{
  		Panic ("\pGetNode: getNodeProc returned error.");
@@ -651,7 +643,7 @@ index da07cc7..ef2bd7b 100644
  		goto ErrorExit;
  	}
  	++btreePtr->numGetNodes;
-@@ -156,8 +156,8 @@ OSStatus	GetNode		(BTreeControlBlockPtr	 btreePtr,
+@@ -156,8 +156,8 @@ OSStatus	GetNode		(BTreeControlBlockPtr
  	return noErr;
  
  ErrorExit:
@@ -662,7 +654,7 @@ index da07cc7..ef2bd7b 100644
  	
  //	LogEndTime(kTraceGetNode, err);
  
-@@ -176,7 +176,7 @@ Function:	Gets a new BTree node from FS Agent and initializes it to an empty
+@@ -176,7 +176,7 @@ Function:	Gets a new BTree node from FS
  Input:		btreePtr		- pointer to BTree control block
  			nodeNum			- number of node to request
  			
@@ -671,7 +663,7 @@ index da07cc7..ef2bd7b 100644
  			
  Result:		noErr		- success
  			!= noErr	- failure
-@@ -203,7 +203,7 @@ OSStatus	GetNewNode	(BTreeControlBlockPtr	 btreePtr,
+@@ -203,7 +203,7 @@ OSStatus	GetNewNode	(BTreeControlBlockPt
  	if (err != noErr)
  	{
  		Panic ("\pGetNewNode: getNodeProc returned error.");
@@ -680,7 +672,7 @@ index da07cc7..ef2bd7b 100644
  		return err;
  	}
  	++btreePtr->numGetNewNodes;
-@@ -248,7 +248,7 @@ OSStatus	ReleaseNode	(BTreeControlBlockPtr	 btreePtr,
+@@ -248,7 +248,7 @@ OSStatus	ReleaseNode	(BTreeControlBlockP
  
  	err = noErr;
  	
@@ -689,7 +681,7 @@ index da07cc7..ef2bd7b 100644
  	{
  		/*
  		 * The nodes must remain in the cache as big endian!
-@@ -267,8 +267,8 @@ OSStatus	ReleaseNode	(BTreeControlBlockPtr	 btreePtr,
+@@ -267,8 +267,8 @@ OSStatus	ReleaseNode	(BTreeControlBlockP
  		++btreePtr->numReleaseNodes;
  	}
  	
@@ -700,7 +692,7 @@ index da07cc7..ef2bd7b 100644
  	
  //	LogEndTime(kTraceReleaseNode, err);
  
-@@ -299,7 +299,7 @@ OSStatus	TrashNode	(BTreeControlBlockPtr	 btreePtr,
+@@ -299,7 +299,7 @@ OSStatus	TrashNode	(BTreeControlBlockPtr
  
  	err = noErr;
  	
@@ -709,7 +701,7 @@ index da07cc7..ef2bd7b 100644
  	{
  		releaseNodeProc = btreePtr->releaseBlockProc;
  		err = releaseNodeProc (btreePtr->fcbPtr,
-@@ -309,8 +309,8 @@ OSStatus	TrashNode	(BTreeControlBlockPtr	 btreePtr,
+@@ -309,8 +309,8 @@ OSStatus	TrashNode	(BTreeControlBlockPtr
  		++btreePtr->numReleaseNodes;
  	}
  
@@ -720,7 +712,7 @@ index da07cc7..ef2bd7b 100644
  	
  	return err;
  }
-@@ -338,7 +338,7 @@ OSStatus	UpdateNode	(BTreeControlBlockPtr	 btreePtr,
+@@ -338,7 +338,7 @@ OSStatus	UpdateNode	(BTreeControlBlockPt
  	
  	err = noErr;
  		
@@ -729,7 +721,7 @@ index da07cc7..ef2bd7b 100644
  	{
  	//	LogStartTime(kTraceReleaseNode);
  		err = hfs_swap_BTNode(nodePtr, btreePtr->fcbPtr, kSwapBTNodeHostToBig);
-@@ -358,8 +358,8 @@ OSStatus	UpdateNode	(BTreeControlBlockPtr	 btreePtr,
+@@ -358,8 +358,8 @@ OSStatus	UpdateNode	(BTreeControlBlockPt
  		++btreePtr->numUpdateNodes;
  	}
  	
@@ -740,11 +732,9 @@ index da07cc7..ef2bd7b 100644
  
  	return	noErr;
  
-diff --git a/fsck_hfs.tproj/dfalib/BTreeTreeOps.c b/fsck_hfs.tproj/dfalib/BTreeTreeOps.c
-index 37fb170..73e1fda 100644
 --- a/fsck_hfs.tproj/dfalib/BTreeTreeOps.c
 +++ b/fsck_hfs.tproj/dfalib/BTreeTreeOps.c
-@@ -177,7 +177,7 @@ Output:		nodeNum			- number of the node containing the key position
+@@ -177,7 +177,7 @@ Output:		nodeNum			- number of the node
  			
  Result:		noErr			- key found, index is record index
  			fsBTRecordNotFoundErr	- key not found, index is insert index
@@ -764,7 +754,7 @@ index 37fb170..73e1fda 100644
  	*returnIndex				= 0;
  
  	return	err;
-@@ -354,7 +354,7 @@ OSStatus	InsertTree ( BTreeControlBlockPtr		 btreePtr,
+@@ -354,7 +354,7 @@ OSStatus	InsertTree ( BTreeControlBlockP
  	primaryKey.replacingKey	= replacingKey;
  	primaryKey.skipRotate	= false;
  
@@ -773,7 +763,7 @@ index 37fb170..73e1fda 100644
  					   targetNode, index, level, insertNode );
  						
  	return err;
-@@ -385,7 +385,7 @@ OSStatus	InsertLevel (BTreeControlBlockPtr		 btreePtr,
+@@ -385,7 +385,7 @@ OSStatus	InsertLevel (BTreeControlBlockP
  #if defined(applec) && !defined(__SC__)
  	PanicIf ((level == 1) && (((NodeDescPtr)targetNode->buffer)->kind != kBTLeafNode), "\P InsertLevel: non-leaf at level 1! ");
  #endif
@@ -782,7 +772,7 @@ index 37fb170..73e1fda 100644
  	targetNodeNum = treePathTable [level].node;
  
  	insertParent = false;
-@@ -420,7 +420,7 @@ OSStatus	InsertLevel (BTreeControlBlockPtr		 btreePtr,
+@@ -420,7 +420,7 @@ OSStatus	InsertLevel (BTreeControlBlockP
  	
  	////// process second insert (if any) //////
  
@@ -791,7 +781,7 @@ index 37fb170..73e1fda 100644
  	{
  		Boolean				temp;
  
-@@ -446,7 +446,7 @@ OSStatus	InsertLevel (BTreeControlBlockPtr		 btreePtr,
+@@ -446,7 +446,7 @@ OSStatus	InsertLevel (BTreeControlBlockP
  		UInt8 *				recPtr;
  		UInt16				recSize;
  		
@@ -800,7 +790,7 @@ index 37fb170..73e1fda 100644
  		
  		PanicIf ( (level == btreePtr->treeDepth), "InsertLevel: unfinished insert!?");
  
-@@ -606,9 +606,9 @@ static OSErr	InsertNode	(BTreeControlBlockPtr	 btreePtr,
+@@ -606,9 +606,9 @@ static OSErr	InsertNode	(BTreeControlBlo
  	
  	if ( leftNodeNum > 0 )
  	{
@@ -812,7 +802,7 @@ index 37fb170..73e1fda 100644
  		{
  			err = GetNode (btreePtr, leftNodeNum, siblingNode);	// will be released by caller or a split below
  			M_ExitOnError (err);
-@@ -703,7 +703,7 @@ OSStatus	DeleteTree			(BTreeControlBlockPtr		 btreePtr,
+@@ -703,7 +703,7 @@ OSStatus	DeleteTree			(BTreeControlBlock
  
  	targetNodeNum = treePathTable[level].node;
  	targetNodePtr = targetNode->buffer;
@@ -821,7 +811,7 @@ index 37fb170..73e1fda 100644
  
  	DeleteRecord (btreePtr, targetNodePtr, index);
  		
-@@ -766,7 +766,7 @@ OSStatus	DeleteTree			(BTreeControlBlockPtr		 btreePtr,
+@@ -766,7 +766,7 @@ OSStatus	DeleteTree			(BTreeControlBlock
  		deleteRequired = false;
  		updateRequired = false;
  		
@@ -830,7 +820,7 @@ index 37fb170..73e1fda 100644
  		{
  			btreePtr->rootNode  = 0;
  			btreePtr->treeDepth = 0;
-@@ -1124,7 +1124,7 @@ static OSStatus	SplitLeft		(BTreeControlBlockPtr		 btreePtr,
+@@ -1124,7 +1124,7 @@ static OSStatus	SplitLeft		(BTreeControl
  	if ( (right->height == 1) && (right->kind != kBTLeafNode) )
  		return	fsBTInvalidNodeErr;
  	
@@ -839,7 +829,7 @@ index 37fb170..73e1fda 100644
  	{
  		if ( left->fLink != rightNodeNum )
  			return fsBTInvalidNodeErr;										//¥¥ E_BadSibling ?
-@@ -1145,7 +1145,7 @@ static OSStatus	SplitLeft		(BTreeControlBlockPtr		 btreePtr,
+@@ -1145,7 +1145,7 @@ static OSStatus	SplitLeft		(BTreeControl
  
  	/////////////// Update Forward Link In Original Left Node ///////////////////
  
@@ -848,7 +838,7 @@ index 37fb170..73e1fda 100644
  	{
  		left->fLink	= newNodeNum;
  		err = UpdateNode (btreePtr, leftNode);
-@@ -1240,8 +1240,8 @@ static OSStatus	AddNewRootNode	(BTreeControlBlockPtr	 btreePtr,
+@@ -1240,8 +1240,8 @@ static OSStatus	AddNewRootNode	(BTreeCon
  	Boolean				didItFit;
  	UInt16				keyLength;	
  	
@@ -859,7 +849,7 @@ index 37fb170..73e1fda 100644
  	
  	
  	/////////////////////// Initialize New Root Node ////////////////////////////
-@@ -1362,7 +1362,7 @@ static OSStatus	SplitRight		(BTreeControlBlockPtr		 btreePtr,
+@@ -1362,7 +1362,7 @@ static OSStatus	SplitRight		(BTreeContro
  	if ( (leftPtr->height == 1) && (leftPtr->kind != kBTLeafNode) )
  		return	fsBTInvalidNodeErr;
  	
@@ -868,7 +858,7 @@ index 37fb170..73e1fda 100644
  	{
  		if ( rightPtr->bLink != nodeNum )
  			return fsBTInvalidNodeErr;										//¥¥ E_BadSibling ?
-@@ -1382,7 +1382,7 @@ static OSStatus	SplitRight		(BTreeControlBlockPtr		 btreePtr,
+@@ -1382,7 +1382,7 @@ static OSStatus	SplitRight		(BTreeContro
  
  	/////////////// Update backward Link In Original Right Node ///////////////////
  
@@ -877,7 +867,7 @@ index 37fb170..73e1fda 100644
  	{
  		rightPtr->bLink	= newNodeNum;
  		err = UpdateNode (btreePtr, rightNodePtr);
-@@ -1739,7 +1739,7 @@ static int DoKeyCheck( NodeDescPtr nodeP, BTreeControlBlock *btcb )
+@@ -1739,7 +1739,7 @@ static int DoKeyCheck( NodeDescPtr nodeP
  	UInt16				keyLength;
  	KeyPtr 				keyPtr;
  	UInt8				*dataPtr;
@@ -886,7 +876,7 @@ index 37fb170..73e1fda 100644
  
  
  	if ( nodeP->numRecords == 0 )
-@@ -1766,7 +1766,7 @@ static int DoKeyCheck( NodeDescPtr nodeP, BTreeControlBlock *btcb )
+@@ -1766,7 +1766,7 @@ static int DoKeyCheck( NodeDescPtr nodeP
  				return( -1 );
  			}
  	
@@ -895,11 +885,9 @@ index 37fb170..73e1fda 100644
  			{
  				if ( CompareKeys( (BTreeControlBlockPtr)btcb, prevkeyP, keyPtr ) >= 0 )
  				{
-diff --git a/fsck_hfs.tproj/dfalib/SControl.c b/fsck_hfs.tproj/dfalib/SControl.c
-index 8b03ece..d3145e0 100644
 --- a/fsck_hfs.tproj/dfalib/SControl.c
 +++ b/fsck_hfs.tproj/dfalib/SControl.c
-@@ -82,7 +82,7 @@ CheckHFS( 	int fsReadRef, int fsWriteRef, int checkLevel, int repairLevel,
+@@ -82,7 +82,7 @@ CheckHFS( 	int fsReadRef, int fsWriteRef
  {
  	SGlob				dataArea;	// Allocate the scav globals
  	short				temp; 	
@@ -1056,7 +1044,7 @@ index 8b03ece..d3145e0 100644
  
  	return( noErr );
  }
-@@ -1113,7 +1113,7 @@ Boolean IsBlueBoxSharedDrive ( DrvQElPtr dqPtr )
+@@ -1113,7 +1113,7 @@ Boolean IsBlueBoxSharedDrive ( DrvQElPtr
  	// Now look at the name of the Driver name. If it is .BlueBoxShared keep it out of the list of available disks.
  	driverDCtlHandle = GetDCtlEntry(dqPtr->dQRefNum);
  	driverDCtlPtr = *driverDCtlHandle;
@@ -1065,7 +1053,7 @@ index 8b03ece..d3145e0 100644
  	{
  		if (((driverDCtlPtr->dCtlFlags) & Is_Ram_Based_Mask) == 0)
  		{
-@@ -1127,19 +1127,19 @@ Boolean IsBlueBoxSharedDrive ( DrvQElPtr dqPtr )
+@@ -1127,19 +1127,19 @@ Boolean IsBlueBoxSharedDrive ( DrvQElPtr
  			
  		}
  		driverName = (StringPtr)&(drvrHeaderPtr->drvrName);
@@ -1089,7 +1077,7 @@ index 8b03ece..d3145e0 100644
  			paramBlock.ioVRefNum	= dqPtr->dQDrive;
  			paramBlock.ioCRefNum	= dqPtr->dQRefNum;
  			paramBlock.csCode		= kDriveIcon;						// return physical icon
-@@ -1152,7 +1152,7 @@ Boolean IsBlueBoxSharedDrive ( DrvQElPtr dqPtr )
+@@ -1152,7 +1152,7 @@ Boolean IsBlueBoxSharedDrive ( DrvQElPtr
  				
  				iconAndStringRecPtr = * (IconAndStringRecPtr*) & paramBlock.csParam;
  				whereStringPtr = (StringPtr) & iconAndStringRecPtr->string;
@@ -1098,11 +1086,9 @@ index 8b03ece..d3145e0 100644
  				{
  					return( true );
  				}
-diff --git a/fsck_hfs.tproj/dfalib/SRepair.c b/fsck_hfs.tproj/dfalib/SRepair.c
-index 89c12d6..b261c37 100644
 --- a/fsck_hfs.tproj/dfalib/SRepair.c
 +++ b/fsck_hfs.tproj/dfalib/SRepair.c
-@@ -844,7 +844,7 @@ static	int	DelFThd( SGlobPtr GPtr, UInt32 fid )				//	the file ID
+@@ -844,7 +844,7 @@ static	int	DelFThd( SGlobPtr GPtr, UInt3
  
  	isHFSPlus = VolumeObjectIsHFSPlus( );
  	
@@ -1111,7 +1097,7 @@ index 89c12d6..b261c37 100644
  	result = SearchBTreeRecord( GPtr->calculatedCatalogFCB, &key, kNoHint, &foundKey, &record, &recSize, &hint );
  	
  	if ( result )	return ( IntError( GPtr, result ) );
-@@ -910,7 +910,7 @@ static	OSErr	FixDirThread( SGlobPtr GPtr, UInt32 did )	//	the dir ID
+@@ -910,7 +910,7 @@ static	OSErr	FixDirThread( SGlobPtr GPtr
  
  	isHFSPlus = VolumeObjectIsHFSPlus( );
  
@@ -1120,7 +1106,7 @@ index 89c12d6..b261c37 100644
  	result = SearchBTreeRecord( GPtr->calculatedCatalogFCB, &key, kNoHint, &foundKey, &record, &recSize, &hint );
  	
  	if ( result )
-@@ -2171,7 +2171,7 @@ static	OSErr	FixOrphanedFiles ( SGlobPtr GPtr )
+@@ -2171,7 +2171,7 @@ static	OSErr	FixOrphanedFiles ( SGlobPtr
  				}
  
  				//-- Build the key for the file thread
@@ -1129,8 +1115,6 @@ index 89c12d6..b261c37 100644
  
  				err = SearchBTreeRecord( GPtr->calculatedCatalogFCB, &key, kNoHint, 
  										 &tempKey, &threadRecord, &recordSize, &hint2 );
-diff --git a/fsck_hfs.tproj/dfalib/SUtils.c b/fsck_hfs.tproj/dfalib/SUtils.c
-index 6e9253e..491afbf 100644
 --- a/fsck_hfs.tproj/dfalib/SUtils.c
 +++ b/fsck_hfs.tproj/dfalib/SUtils.c
 @@ -395,11 +395,11 @@ OSErr GetVolumeFeatures( SGlobPtr GPtr )
@@ -1147,7 +1131,7 @@ index 6e9253e..491afbf 100644
  		pb.ioParam.ioVRefNum	= GPtr->realVCB->vcbVRefNum;
  		pb.ioParam.ioBuffer		= (Ptr) &buffer;
  		pb.ioParam.ioReqCount	= sizeof( buffer );
-@@ -2282,7 +2282,7 @@ void print_prime_buckets(PrimeBuckets *cur);
+@@ -2282,7 +2282,7 @@ void print_prime_buckets(PrimeBuckets *c
   *     	   	4. btreetye - can be kHFSPlusCatalogRecord or kHFSPlusAttributeRecord
   *                            indicates which btree prime number bucket should be incremented
   *
@@ -1156,11 +1140,9 @@ index 6e9253e..491afbf 100644
   */
  void RecordXAttrBits(SGlobPtr GPtr, UInt16 flags, HFSCatalogNodeID fileid, UInt16 btreetype) 
  {
-diff --git a/fsck_hfs.tproj/dfalib/SVerify1.c b/fsck_hfs.tproj/dfalib/SVerify1.c
-index 39bda5c..c33155f 100644
 --- a/fsck_hfs.tproj/dfalib/SVerify1.c
 +++ b/fsck_hfs.tproj/dfalib/SVerify1.c
-@@ -790,13 +790,13 @@ OSErr	CreateExtentsBTreeControlBlock( SGlobPtr GPtr )
+@@ -790,13 +790,13 @@ OSErr	CreateExtentsBTreeControlBlock( SG
  	//	set up our DFA extended BTCB area.  Will we have enough memory on all HFS+ volumes.
  	//
  	btcb->refCon = AllocateClearMemory( sizeof(BTreeExtensionsRec) );			// allocate space for our BTCB extensions
@@ -1176,7 +1158,7 @@ index 39bda5c..c33155f 100644
  	{
  		err = R_NoMem;
  		goto exit;
-@@ -1145,13 +1145,13 @@ OSErr	CreateCatalogBTreeControlBlock( SGlobPtr GPtr )
+@@ -1145,13 +1145,13 @@ OSErr	CreateCatalogBTreeControlBlock( SG
  	//
  
  	btcb->refCon = AllocateClearMemory( sizeof(BTreeExtensionsRec) );			// allocate space for our BTCB extensions
@@ -1210,7 +1192,7 @@ index 39bda5c..c33155f 100644
  				result = SearchBTreeRecord( GPtr->calculatedCatalogFCB, &key, kNoHint, &foundKey, &threadRecord, &recSize, &hint );
  				if ( result != noErr ) {
  					char idStr[16];
-@@ -1780,26 +1780,26 @@ OSErr	CreateAttributesBTreeControlBlock( SGlobPtr GPtr )
+@@ -1780,26 +1780,26 @@ OSErr	CreateAttributesBTreeControlBlock(
  	//	set up our DFA extended BTCB area.  Will we have enough memory on all HFS+ volumes.
  	//
  	btcb->refCon = AllocateClearMemory( sizeof(BTreeExtensionsRec) );			// allocate space for our BTCB extensions
@@ -1241,7 +1223,7 @@ index 39bda5c..c33155f 100644
  		{
  			err = R_NoMem;
  			goto exit;
-@@ -2358,7 +2358,7 @@ static	OSErr	RcdMDBEmbededVolDescriptionErr( SGlobPtr GPtr, OSErr type, HFSMaste
+@@ -2358,7 +2358,7 @@ static	OSErr	RcdMDBEmbededVolDescription
  	RcdError( GPtr, type );												//	first, record the error
  	
  	p = AllocMinorRepairOrder( GPtr, sizeof(EmbededVolDescription) );	//	get the node
@@ -1250,7 +1232,7 @@ index 39bda5c..c33155f 100644
  	
  	p->type							=  type;							//	save error info
  	desc							=  (EmbededVolDescription *) &(p->name);
-@@ -2397,7 +2397,7 @@ static	OSErr	RcdInvalidWrapperExtents( SGlobPtr GPtr, OSErr type )
+@@ -2397,7 +2397,7 @@ static	OSErr	RcdInvalidWrapperExtents( S
  	RcdError( GPtr, type );												//	first, record the error
  	
  	p = AllocMinorRepairOrder( GPtr, 0 );	//	get the node
@@ -1259,7 +1241,7 @@ index 39bda5c..c33155f 100644
  	
  	p->type							=  type;							//	save error info
  	
-@@ -3029,7 +3029,7 @@ OSErr	CheckFileExtents( SGlobPtr GPtr, UInt32 fileNumber, UInt8 forkType,
+@@ -3029,7 +3029,7 @@ OSErr	CheckFileExtents( SGlobPtr GPtr, U
  	foundBadExtent = false;
  	lastExtentIndex = GPtr->numExtents;
  	
@@ -1268,7 +1250,7 @@ index 39bda5c..c33155f 100644
  	{	
  		//	checkout the extent record first
  		err = ChkExtRec( GPtr, extents, &lastExtentIndex );
-@@ -3105,7 +3105,7 @@ OSErr	CheckFileExtents( SGlobPtr GPtr, UInt32 fileNumber, UInt8 forkType,
+@@ -3105,7 +3105,7 @@ OSErr	CheckFileExtents( SGlobPtr GPtr, U
  			if ( err == btNotFound )
  			{
  				err = noErr;								//	 no more extent records
@@ -1277,7 +1259,7 @@ index 39bda5c..c33155f 100644
  				break;
  			}
  			else if ( err != noErr )
-@@ -3121,7 +3121,7 @@ OSErr	CheckFileExtents( SGlobPtr GPtr, UInt32 fileNumber, UInt8 forkType,
+@@ -3121,7 +3121,7 @@ OSErr	CheckFileExtents( SGlobPtr GPtr, U
  			if ( err == btNotFound )
  			{
  				err = noErr;								//	 no more extent records
@@ -1286,7 +1268,7 @@ index 39bda5c..c33155f 100644
  				break;
  			}
  			else if ( err != noErr )
-@@ -3205,7 +3205,7 @@ static OSErr	AddExtentToOverlapList( SGlobPtr GPtr, HFSCatalogNodeID fileNumber,
+@@ -3205,7 +3205,7 @@ static OSErr	AddExtentToOverlapList( SGl
  	}
  	
  	//	If it's uninitialized
@@ -1295,11 +1277,9 @@ index 39bda5c..c33155f 100644
  	{
  		GPtr->overlappedExtents	= (ExtentsTable **) NewHandleClear( sizeof(ExtentsTable) );
  		extentsTableH	= GPtr->overlappedExtents;
-diff --git a/fsck_hfs.tproj/dfalib/SVerify2.c b/fsck_hfs.tproj/dfalib/SVerify2.c
-index c68f3d8..da1a982 100644
 --- a/fsck_hfs.tproj/dfalib/SVerify2.c
 +++ b/fsck_hfs.tproj/dfalib/SVerify2.c
-@@ -1013,7 +1013,7 @@ static int BTKeyChk( SGlobPtr GPtr, NodeDescPtr nodeP, BTreeControlBlock *btcb )
+@@ -1013,7 +1013,7 @@ static int BTKeyChk( SGlobPtr GPtr, Node
  	UInt16				keyLength;
  	KeyPtr 				keyPtr;
  	UInt8				*dataPtr;
@@ -1308,7 +1288,7 @@ index c68f3d8..da1a982 100644
  
  
  	if ( nodeP->numRecords == 0 )
-@@ -1044,7 +1044,7 @@ static int BTKeyChk( SGlobPtr GPtr, NodeDescPtr nodeP, BTreeControlBlock *btcb )
+@@ -1044,7 +1044,7 @@ static int BTKeyChk( SGlobPtr GPtr, Node
  				return( E_KeyLen );
  			}
  	

--- a/utils/hfsprogs/patches/0011-Fix-types.patch
+++ b/utils/hfsprogs/patches/0011-Fix-types.patch
@@ -6,11 +6,9 @@ Subject: Fix types
  fsck_hfs.tproj/cache.c | 30 ++++++++++++++++--------------
  1 file changed, 16 insertions(+), 14 deletions(-)
 
-diff --git a/fsck_hfs.tproj/cache.c b/fsck_hfs.tproj/cache.c
-index 527088a..540fa0b 100644
 --- a/fsck_hfs.tproj/cache.c
 +++ b/fsck_hfs.tproj/cache.c
-@@ -961,20 +961,21 @@ int CacheLookup (Cache_t *cache, uint64_t off, Tag_t **tag)
+@@ -961,20 +961,21 @@ int CacheLookup (Cache_t *cache, uint64_
   */
  int CacheRawRead (Cache_t *cache, uint64_t off, uint32_t len, void *buf)
  {
@@ -39,7 +37,7 @@ index 527088a..540fa0b 100644
  
  	/* Update counters */
  	cache->DiskRead++;
-@@ -989,21 +990,22 @@ int CacheRawRead (Cache_t *cache, uint64_t off, uint32_t len, void *buf)
+@@ -989,21 +990,22 @@ int CacheRawRead (Cache_t *cache, uint64
   */
  int CacheRawWrite (Cache_t *cache, uint64_t off, uint32_t len, void *buf)
  {

--- a/utils/hfsprogs/patches/0012-Fix-mkfs-not-creating-UUIDs-for-new-filesystems.patch
+++ b/utils/hfsprogs/patches/0012-Fix-mkfs-not-creating-UUIDs-for-new-filesystems.patch
@@ -15,11 +15,9 @@ This closes LP: #737002.
  include/missing.h | 8 +++++++-
  1 file changed, 7 insertions(+), 1 deletion(-)
 
-diff --git a/include/missing.h b/include/missing.h
-index 0a859c4..f50e8fb 100644
 --- a/include/missing.h
 +++ b/include/missing.h
-@@ -72,7 +72,7 @@
+@@ -71,7 +71,7 @@
  #define NAME_MAX	255
  
  /* Byteswap stuff */
@@ -28,7 +26,7 @@ index 0a859c4..f50e8fb 100644
  #define NXSwapBigShortToHost(x) 	be16_to_cpu(x)
  #define OSSwapBigToHostInt16(x)		be16_to_cpu(x)
  #define NXSwapBigLongToHost(x)		be32_to_cpu(x)
-@@ -88,6 +88,9 @@
+@@ -87,6 +87,9 @@
  #ifndef be32_to_cpu
  #define be32_to_cpu(x) bswap_32(x)
  #endif
@@ -38,7 +36,7 @@ index 0a859c4..f50e8fb 100644
  #ifndef be64_to_cpu
  #define be64_to_cpu(x) bswap_64(x)
  #endif
-@@ -102,6 +105,9 @@
+@@ -101,6 +104,9 @@
  #ifndef be32_to_cpu
  #define be32_to_cpu(x)	(x)
  #endif

--- a/utils/hfsprogs/patches/0013-Fix-manpages.patch
+++ b/utils/hfsprogs/patches/0013-Fix-manpages.patch
@@ -20,8 +20,6 @@ Reviewed-by: Rogério Theodoro de Brito <rbrito@ime.usp.br>
  newfs_hfs.tproj/newfs_hfs.8 | 23 ++++++++---------------
  2 files changed, 15 insertions(+), 26 deletions(-)
 
-diff --git a/fsck_hfs.tproj/fsck_hfs.8 b/fsck_hfs.tproj/fsck_hfs.8
-index aec9949..0bc804d 100644
 --- a/fsck_hfs.tproj/fsck_hfs.8
 +++ b/fsck_hfs.tproj/fsck_hfs.8
 @@ -19,18 +19,18 @@
@@ -58,7 +56,7 @@ index aec9949..0bc804d 100644
  When preening file systems,
  .Nm
  will fix common inconsistencies for file systems that were not
-@@ -105,9 +103,9 @@ to check and repair journaled HFS+ file systems.
+@@ -105,9 +103,9 @@ to check and repair journaled HFS+ file
  .It Fl g
  Causes
  .Nm
@@ -70,7 +68,7 @@ index aec9949..0bc804d 100644
  .Nm
  tool.
  .It Fl l
-@@ -144,8 +142,6 @@ specified file system for a new catalog file and if there is no damage
+@@ -144,8 +142,6 @@ specified file system for a new catalog
  to the leaf nodes in the existing catalog file.
  .El
  .Pp
@@ -79,8 +77,6 @@ index aec9949..0bc804d 100644
  .Sh SEE ALSO
  .Xr fsck 8
  .Sh BUGS
-diff --git a/newfs_hfs.tproj/newfs_hfs.8 b/newfs_hfs.tproj/newfs_hfs.8
-index d002cc9..fe91962 100644
 --- a/newfs_hfs.tproj/newfs_hfs.8
 +++ b/newfs_hfs.tproj/newfs_hfs.8
 @@ -19,10 +19,10 @@
@@ -118,7 +114,7 @@ index d002cc9..fe91962 100644
  has several options to allow the defaults to be selectively overridden.
  The options are as follows:
  .Bl -tag -width Fl
-@@ -66,7 +60,7 @@ Set the group of the file system's root directory to
+@@ -66,7 +60,7 @@ Set the group of the file system's root
  Specify the access permissions mask for the file system's root directory.
  .It Fl h
  Creates a legacy HFS format filesystem. This option
@@ -145,7 +141,7 @@ index d002cc9..fe91962 100644
  .Bl -tag -width Fl
  .It Em a=bytes
  Set the attribute b-tree node size.
-@@ -139,8 +133,7 @@ Set the extent overflow b-tree node size.
+@@ -139,8 +133,7 @@ Set the extent overflow b-tree node size
  Volume name (file system name) in ascii or UTF-8 format.
  .El
  .Sh SEE ALSO

--- a/utils/hfsprogs/patches/0014-uClibc_no_loadavg.patch
+++ b/utils/hfsprogs/patches/0014-uClibc_no_loadavg.patch
@@ -1,6 +1,6 @@
---- diskdev_cmds-332.25/newfs_hfs.tproj/makehfs.c	2015-03-27 21:58:04.163171675 -0700
-+++ hfsprogs-332.25/newfs_hfs.tproj/makehfs.c	2015-03-27 21:56:03.687175020 -0700
-@@ -2119,10 +2119,12 @@
+--- a/newfs_hfs.tproj/makehfs.c
++++ b/newfs_hfs.tproj/makehfs.c
+@@ -2119,10 +2119,12 @@ void GenerateVolumeUUID(VolumeUUID *newV
  		sysctl(mib, 2, sysctlstring, &datalen, NULL, 0);
  		SHA1_Update(&context, sysctlstring, datalen);
  #endif

--- a/utils/hfsprogs/patches/0015-sysctl-only-on-glibc.patch
+++ b/utils/hfsprogs/patches/0015-sysctl-only-on-glibc.patch
@@ -4,7 +4,7 @@
  #endif
  #include <sys/errno.h>
  #include <sys/stat.h>
-+#ifdef __GLIBC__
++#if 0
  #include <sys/sysctl.h>
 +#endif
  #if !LINUX

--- a/utils/hfsprogs/patches/0016-Fix-fsckhfs-wide-literal.patch
+++ b/utils/hfsprogs/patches/0016-Fix-fsckhfs-wide-literal.patch
@@ -1,7 +1,5 @@
-Index: diskdev_cmds-332.25/fsck_hfs.tproj/dfalib/SVerify1.c
-===================================================================
---- diskdev_cmds-332.25.orig/fsck_hfs.tproj/dfalib/SVerify1.c
-+++ diskdev_cmds-332.25/fsck_hfs.tproj/dfalib/SVerify1.c
+--- a/fsck_hfs.tproj/dfalib/SVerify1.c
++++ b/fsck_hfs.tproj/dfalib/SVerify1.c
 @@ -2848,7 +2848,7 @@ OSErr	VLockedChk( SGlobPtr GPtr )
  	}
  	else		//	Because we don't have the unicode converters, just fill it with a dummy name.

--- a/utils/hfsprogs/patches/010-valloc-to-memalign.patch
+++ b/utils/hfsprogs/patches/010-valloc-to-memalign.patch
@@ -1,6 +1,6 @@
 --- a/newfs_hfs.tproj/makehfs.c
 +++ b/newfs_hfs.tproj/makehfs.c
-@@ -376,7 +376,7 @@ make_hfsplus(const DriveInfo *driveInfo, hfsparams_t *defaults)
+@@ -376,7 +376,7 @@ make_hfsplus(const DriveInfo *driveInfo,
  	if ( (temp & 0x01FF) != 0 )
  		temp = (temp + kBytesPerSector) & 0xFFFFFE00;
  	
@@ -9,7 +9,7 @@
  	if (nodeBuffer == NULL)
  		err(1, NULL);
  
-@@ -1814,7 +1814,7 @@ ClearDisk(const DriveInfo *driveInfo, UInt64 startingSector, UInt32 numberOfSect
+@@ -1814,7 +1814,7 @@ ClearDisk(const DriveInfo *driveInfo, UI
  
  	bufferSize = bufferSizeInSectors << kLog2SectorSize;
  

--- a/utils/hfsprogs/patches/030-no-cdefs.patch
+++ b/utils/hfsprogs/patches/030-no-cdefs.patch
@@ -1,6 +1,6 @@
 --- a/disklib/dump.h
 +++ b/disklib/dump.h
-@@ -110,9 +110,7 @@ extern long	dev_bsize;	/* block size of underlying disk device */
+@@ -110,9 +110,7 @@ extern long	dev_bsize;	/* block size of
  extern int	dev_bshift;	/* log2(dev_bsize) */
  extern int	tp_bshift;	/* log2(TP_BSIZE) */
  
@@ -170,7 +170,7 @@
  #include <sys/param.h>
  #include <sys/types.h>
  #include <sys/time.h>
-@@ -80,6 +79,7 @@ extern Boolean _CFStringGetFileSystemRepresentation(CFStringRef string, UInt8 *b
+@@ -80,6 +79,7 @@ extern Boolean _CFStringGetFileSystemRep
  
  #define kJournalFileType	0x6a726e6c	/* 'jrnl' */
  


### PR DESCRIPTION
Seems sys/sysctl.h was removed.

Refresh patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: arc700