### PR TITLE
freeradius3: add missing libbsd dependency to glibc

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
 PKG_VERSION:=3_0_21
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=release_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/archive
@@ -63,7 +63,7 @@ endef
 define Package/freeradius3-common
   $(call Package/freeradius3/Default)
   TITLE:=common files
-  DEPENDS:=+USE_GLIBC:libpthread +FREERADIUS3_OPENSSL:libopenssl +libcap +libpcap +libncurses +libpcre +libreadline +libtalloc +libatomic
+  DEPENDS:=+USE_GLIBC:libpthread +USE_GLIBC:libbsd +FREERADIUS3_OPENSSL:libopenssl +libcap +libpcap +libncurses +libpcre +libreadline +libtalloc +libatomic
 endef
 
 define Package/freeradius3-default


### PR DESCRIPTION
Fixes packages generation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: arc700