### PR TITLE
cjson: fix wrong pkgconfig paths

### DIFF
--- a/libs/cjson/Makefile
+++ b/libs/cjson/Makefile
@@ -4,17 +4,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cJSON
 PKG_VERSION:=1.7.14
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/DaveGamble/cJSON/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=fb50a663eefdc76bafa80c82bc045af13b1363e8f45cec8b442007aef6a41343
 
+PKG_MAINTAINER:=Karl Palsson <karlp@etactica.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:cjson_project:cjson
 
-CMAKE_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -25,7 +25,6 @@ define Package/cJSON
   CATEGORY:=Libraries
   TITLE:=Ultralightweight JSON parser in ANSI C
   URL:=https://github.com/DaveGamble/cJSON
-  MAINTAINER:=Karl Palsson <karlp@etactica.com>
 endef
 
 define Package/cJSON/description
@@ -37,12 +36,13 @@ endef
 CMAKE_OPTIONS += -DENABLE_CJSON_TEST=OFF
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libcjson.pc $(1)/usr/lib/pkgconfig
 	$(INSTALL_DIR) $(1)/usr/include/cjson
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/cjson/cJSON.h $(1)/usr/include/cjson
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcjson.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libcjson.pc $(1)/usr/lib/pkgconfig
+	$(SED) 's,/usr,$(STAGING_DIR)/usr,g' $(1)/usr/lib/pkgconfig/libcjson.pc
 endef
 
 define Package/cJSON/install


### PR DESCRIPTION
The .pc file points to OS paths instead of target ones.

Remove CMAKE_INSTALL as InstallDev is explicit.

Move MAINTAINER to PKG_MAINTAINER for consistency.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @karlp 
Compile tested: arc700