### PR TITLE
erlang: disable PGO on host

### DIFF
--- a/lang/erlang/Makefile
+++ b/lang/erlang/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=erlang
 PKG_VERSION:=23.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=otp_src_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= http://www.erlang.org/download/
@@ -314,19 +314,9 @@ endef
 
 HOST_CONFIGURE_ARGS += \
 	--disable-hipe \
+	--disable-pgo \
 	--disable-smp-support \
 	--without-javac
-
-HOST_CFLAGS += -D_GNU_SOURCE
-
-define Host/Compile
-	$(MAKE) -C $(HOST_BUILD_DIR) all
-endef
-
-define Host/Install
-	$(MAKE) -C $(HOST_BUILD_DIR) install
-endef
-
 
 # Target
 


### PR DESCRIPTION
Fixes compilation with clang. The make system misidentifies clang as
GCC for some reason.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @cretingame 
Compile tested: CentOS 7