### PR TITLE
openconnect: Fix secondary password script overwriting primary

### DIFF
--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -115,7 +115,7 @@ proto_openconnect_setup() {
 			[ -n "$password2" ] && echo "$password2" >> "$pwfile"
 		}
 		[ "$token_mode" = "script" ] && {
-			$token_script > "$pwfile" 2> /dev/null || {
+			$token_script >> "$pwfile" 2> /dev/null || {
 				logger -t openconenct "Cannot get password from script '$token_script'"
 				proto_setup_failed "$config"
 			}


### PR DESCRIPTION
Maintainer: @nmav 
Compile tested: OpenWrt 19.07.5 x86_64
Run tested: OpenWrt 19.07.5 x86_64 / tested connecting to VPN with a secondary password

Description:
When specifying a secondary password script, the output should be appended to the temporary password file and shouldn't overwrite it. If you refer to the case where there is a static secondary password, you can see that the secondary password is appended. Without this fix, *only* the secondary password is passed to the `openconnect` session.

This pull request fixes #14287.

Signed-off-by: Frederick Morlock <FrederickGeek8@gmail.com>