### PR TITLE
net/miniupnpc: update to 2.2.1

### DIFF
--- a/net/miniupnpc/Makefile
+++ b/net/miniupnpc/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpc
-PKG_VERSION:=2.2.0
-PKG_RELEASE:=2
+PKG_VERSION:=2.2.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
-PKG_HASH:=ff56bec3e5a3aec41f4decb43cb0b925231d6ab4cdfd7a74caa5c7c1043c4ef0
+PKG_HASH:=3a3167e57727bf1d2a7b4861f7c7b57a663f58b9cf68227762ed2fc64e8ea11f
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Signed-off-by: Syrone Wong <wong.syrone@gmail.com>

Maintainer: None
Compile tested: x64 openwrt master
Run tested: x64

Description: update to the latest version
