### PR TITLE
perl-www: add dependency on perl-try-tiny

### DIFF
--- a/lang/perl-try-tiny/Makefile
+++ b/lang/perl-try-tiny/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-try-tiny
+PKG_VERSION:=0.30
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/E/ET/ETHER/
+PKG_SOURCE:=Try-Tiny-$(PKG_VERSION).tar.gz
+PKG_HASH:=da5bd0d5c903519bbf10bb9ba0cb7bcac0563882bcfe4503aee3fb143eddef6b
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/Try-Tiny-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Matt Merhar <mattmerhar@protonmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include $(TOPDIR)/feeds/packages/lang/perl/perlmod.mk
+
+define Package/perl-try-tiny
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Minimal try/catch with proper preservation of $$$$@
+  URL:=https://metacpan.org/pod/Try::Tiny
+  DEPENDS:=perl +perlbase-essential
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-try-tiny/install
+	$(call perlmod/Install,$(1),Try auto/Try)
+endef
+
+$(eval $(call BuildPackage,perl-try-tiny))

--- a/lang/perl-www/Makefile
+++ b/lang/perl-www/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-www
 PKG_VERSION:=6.43
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/O/OA/OALDERS
 PKG_SOURCE:=libwww-perl-$(PKG_VERSION).tar.gz
@@ -30,7 +30,7 @@ define Package/perl-www
   CATEGORY:=Languages
   TITLE:=WWW client/server library for Perl (aka LWP)
   URL:=https://search.cpan.org/dist/libwww-perl/
-  DEPENDS:=perl +perl-encode-locale +perl-file-listing +perl-html-parser +perl-http-cookies +perl-http-daemon +perl-http-date +perl-http-message +perl-http-negotiate +perl-lwp-mediatypes +perl-net-http +perl-uri +perl-www-robotrules +perlbase-base +perlbase-digest +perlbase-encode +perlbase-essential +perlbase-io +perlbase-mime +perlbase-net
+  DEPENDS:=perl +perl-encode-locale +perl-file-listing +perl-html-parser +perl-http-cookies +perl-http-daemon +perl-http-date +perl-http-message +perl-http-negotiate +perl-lwp-mediatypes +perl-net-http +perl-try-tiny +perl-uri +perl-www-robotrules +perlbase-base +perlbase-digest +perlbase-encode +perlbase-essential +perlbase-io +perlbase-mime +perlbase-net
 endef
 
 define Build/Configure


### PR DESCRIPTION
Maintainer: me / @Naoir
Compile tested: x86_64, 19.07.5
Run tested: x86_64, 19.07.5

Description:

The perl-www bump from 6.15 -> 6.39 per https://github.com/openwrt/packages/commit/a9ad795 missed a new dependency on Try::Tiny (introduced in 6.17) which doesn't exist in packages.git. This adds a new package, perl-try-tiny, and changes the perl-www Makefile to depend on it.

