### PR TITLE
Keepalived won't start without enable_script_security option

### DIFF
--- a/net/keepalived/files/keepalived.init
+++ b/net/keepalived/files/keepalived.init
@@ -111,7 +111,8 @@ globals() {
 		router_id \
 		vrrp_mcast_group4 \
 		vrrp_mcast_group6 \
-		vrrp_startup_delay
+		vrrp_startup_delay \
+		enable_script_security
 }
 
 print_ipaddress_indent() {


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
