### PR TITLE
mwan3: fix regression in ipv6 routing tables

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.10.5
+PKG_VERSION:=2.10.6
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -21,7 +21,8 @@ fi
 
 [ "$MWAN3_STARTUP" = "init" ] || procd_lock
 
-config_load mwan3
+mwan3_init
+
 /etc/init.d/mwan3 running || {
 	[ "$MWAN3_STARTUP" = "init" ] || procd_lock
 	LOG notice "mwan3 hotplug $ACTION on $INTERFACE not called because globally disabled"
@@ -33,8 +34,6 @@ $IPT4 -S mwan3_hook &>/dev/null || {
 	LOG warn "hotplug called on $INTERFACE before mwan3 has been set up"
 	exit 0
 }
-
-mwan3_init
 
 if [ "$MWAN3_STARTUP" != "init" ] && [ "$ACTION" = "ifup" ]; then
 	mwan3_set_user_iface_rules $INTERFACE $DEVICE

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -27,7 +27,6 @@ start_tracker() {
 start_service() {
 	local enabled hotplug_pids
 
-	config_load mwan3
 	mwan3_init
 	config_foreach start_tracker interface
 
@@ -57,7 +56,6 @@ start_service() {
 stop_service() {
 	local ipset rule IP IPTR IPT family table tid
 
-	config_load mwan3
 	mwan3_init
 	config_foreach mwan3_interface_shutdown interface
 

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -410,9 +410,6 @@ mwan3_delete_iface_iptables()
 
 mwan3_get_routes()
 {
-	local source_routing
-	config_get_bool source_routing globals source_routing 0
-	[ $source_routing -eq 0 ] && unset source_routing
 	$IP route list table main | sed -ne "$MWAN3_ROUTE_LINE_EXP" | uniq
 }
 

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -129,7 +129,6 @@ use() {
 
 	local interface device src_ip family
 	mwan3_init
-	config_load mwan3
 
 	interface=$1 ; shift
 	[ -z "$*" ] && echo "no command specified for mwan3 use" && return

--- a/net/mwan3/files/usr/sbin/mwan3rtmon
+++ b/net/mwan3/files/usr/sbin/mwan3rtmon
@@ -69,13 +69,10 @@ mwan3_add_all_routes()
 
 mwan3_rtmon_route_handle()
 {
-	local action route_line family tbl device line tid source_routing
+	local action route_line family tbl device line tid
 
 	route_line=${1##"Deleted "}
 	route_family=$2
-
-	config_get_bool source_routing globals source_routing 0
-	[ $source_routing -eq 0 ] && unset source_routing
 
 	if [ "$route_line" = "$1" ]; then
 		action="replace"
@@ -143,7 +140,8 @@ main()
 {
 	local IP family
 
-	config_load mwan3
+	mwan3_init
+
 	family=$1
 	[ -z $family ] && family=ipv4
 	if [ "$family" = "ipv6" ]; then
@@ -155,7 +153,6 @@ main()
 	else
 		IP="$IP4"
 	fi
-	mwan3_init
 	sh -c "echo \$\$; exec $IP monitor route" | {
 		read -r monitor_pid
 		trap_with_arg func_trap "$monitor_pid" SIGINT SIGTERM SIGKILL

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -192,7 +192,6 @@ main() {
 	trap if_down USR1
 	trap if_up USR2
 
-	config_load mwan3
 	config_get FAMILY $INTERFACE family ipv4
 	config_get track_method $INTERFACE track_method ping
 	config_get_bool httping_ssl $INTERFACE httping_ssl 0


### PR DESCRIPTION
Signed-off-by: Aaron Goodman <aaronjg@stanford.edu>

Maintainer: me, @feckert 
Compile tested: 19.07.5/ openwrt/openwrt@55e23f2c
Run tested: 19.07.5/ openwrt/openwrt@55e23f2c

Description: 
Introduced a bug when consolidating the route handling SED line, where it did not check config variable and broke default routes for IPv6 setups. This commit fixes that bug.
