### PR TITLE
openssh: Add FIDO2 hardware token support

### DIFF
--- a/libs/libcbor/Makefile
+++ b/libs/libcbor/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2020 Linos Giannopoulos
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libcbor
+PKG_VERSION:=0.8.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/PJK/libcbor/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=618097166ea4a54499646998ccaa949a5816e6a665cf1d6df383690895217c8b
+
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Linos Giannopoulos <linosgian00+openwrt@gmail.com>
+
+CMAKE_OPTIONS += \
+        -DBUILD_SHARED_LIBS=ON
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/libcbor
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=libcbor
+  URL:=https://github.com/PJK/libcbor
+  ABI_VERSION:=0
+endef
+
+define Package/libcbor/description
+ libcbor is a C library for parsing and generating CBOR, the general-purpose schema-less binary data format.
+endef
+
+
+define Package/libcbor/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcbor.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libcbor))

--- a/libs/libfido2/Makefile
+++ b/libs/libfido2/Makefile
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2020 Linos Giannopoulos
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libfido2
+PKG_VERSION:=1.6.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/Yubico/libfido2/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=6aed47aafd22be49c38f9281fb88ccd08c98678d9b8c39cdc87d1bb3ea2c63e4
+
+PKG_FORTIFY_SOURCE:=0
+CMAKE_INSTALL:=1
+
+TARGET_CFLAGS += -Wno-error=overflow -Wno-error=sign-conversion
+
+PKG_MAINTAINER:=Linos Giannopoulos <linosgian00+openwrt@gmail.com>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/libfido2
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=FIDO2 Library
+  URL:=https://github.com/Yubico/libfido2
+  ABI_VERSION:=1
+  DEPENDS += +libcbor +libopenssl +libudev
+endef
+
+define Package/libfido2/description
+ libfido2 provides library functionality and command-line tools to communicate with a FIDO device over USB, and to verify attestation and assertion signatures.
+
+ libfido2 supports the FIDO U2F (CTAP 1) and FIDO 2.0 (CTAP 2) protocols.
+endef
+
+
+define Package/libfido2/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfido2.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libfido2))

--- a/net/openssh/Config.in
+++ b/net/openssh/Config.in
@@ -1,0 +1,12 @@
+if PACKAGE_openssh-server
+
+config OPENSSH_LIBFIDO2
+	bool
+	default y
+	prompt "Include libfido2 support in openssh-server"
+	help
+		OpenSSH version 8.2 added two new ssh authentication methods,
+		namely `ecdsa_sk` and `ed25519_sk`. These two methods make use
+		of hardware keys that implement the FIDO and FIDO2 protocols.
+		In order to use these two types, libfido2 is required.
+endif

--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
 PKG_VERSION:=8.4p1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
@@ -21,6 +21,10 @@ PKG_LICENSE_FILES:=LICENCE
 PKG_CPE_ID:=cpe:/a:openssh:openssh
 
 PKG_REMOVE_FILES:=
+PKG_CONFIG_DEPENDS := \
+	CONFIG_OPENSSH_LIBFIDO2
+
+PKG_BUILD_DEPENDS += OPENSSH_LIBFIDO2:libfido2
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -82,9 +86,13 @@ endef
 
 define Package/openssh-server
 	$(call Package/openssh/Default)
-	DEPENDS+= +openssh-keygen
+	DEPENDS+= +openssh-keygen +OPENSSH_LIBFIDO2:libfido2
 	TITLE+= server
 	USERID:=sshd=22:sshd=22
+endef
+
+define Package/openssh-server/config
+	source "$(SOURCE)/Config.in"
 endef
 
 define Package/openssh-server/description
@@ -164,8 +172,9 @@ CONFIGURE_ARGS += \
 	--without-bsd-auth \
 	--without-kerberos5 \
 	--with-stackprotect \
-	--with$(if $(CONFIG_OPENSSL_ENGINE),,out)-ssl-engine
-
+	--with$(if $(CONFIG_OPENSSL_ENGINE),,out)-ssl-engine \
+	--with$(if $(CONFIG_OPENSSH_LIBFIDO2),,out)-security-key-builtin
+	
 ifeq ($(BUILD_VARIANT),with-pam)
 CONFIGURE_ARGS += \
 	--with-pam


### PR DESCRIPTION
Maintainer: me
Compile tested: x86-64/generic/snapshot(c5d033a34d)
Run tested: x86-64/generic/snapshot(c5d033a34d) - Tested this end-to-end with a hardware token for the `ecdsa-sk` type

Description:

Version [8.2](https://lwn.net/Articles/812537/)  added support for two new key types: "ecdsa-sk" and
"ed25519-sk". These two types enable the usage of hardware tokens that
implement the FIDO (or FIDO2) standard, as an authentication method for
SSH.

Since we're already on version 8.4 all we need to do is to explicitly enable
the support for hardware keys when compiling OpenSSH and add all the
missing dependencies OpenSSH requires.

OpenSSH depends on [libfido2](https://github.com/Yubico/libfido2), to communicate with the FIDO devices
over USB. In turn, libfido2 depends on libcbor, a C implementation of
the [CBOR protocol](tools.ietf.org/html/rfc7049) and OpenSSL.

I've also compiled openssh-server for 19.07.04 (ramips/mt7621) and I've been using the new `ecdsa-sk` type for a while now.