### PR TITLE
usbutils: add usbreset

### DIFF
--- a/utils/usbutils/Makefile
+++ b/utils/usbutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=usbutils
 PKG_VERSION:=013
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/usb/usbutils
@@ -39,6 +39,7 @@ CONFIGURE_ARGS += \
 define Package/usbutils/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/lsusb $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/usbreset $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,usbutils))


### PR DESCRIPTION
Add `usbreset` here to reflect the removal of `usbreset` package.

Signed-off-by: Kuan-Yi Li <kyli@abysm.org>

Maintainer: @nbd168
CC: @aparcar
Compile tested: aarch64, Raspberry Pi 4 Model B Rev 1.1, OpenWrt SNAPSHOT r15418-acdf07cd3e, `usbutils` installed
Run tested: as above

Description:
Package `usbreset` is removed in commit openwrt/openwrt@6cda95431984312d15032f6466b3b7238936185b. Add `usbreset` here so we can still use it.
