### PR TITLE
[WIP] modemmanager: add experimental support for SIM swtiching

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.14.8
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager

--- a/net/modemmanager/files/modemmanager.proto
+++ b/net/modemmanager/files/modemmanager.proto
@@ -344,6 +344,7 @@ proto_modemmanager_init_config() {
 	proto_config_add_string	 pincode
 	proto_config_add_string	 iptype
 	proto_config_add_int	 signalrate
+	proto_config_add_int	 simslot
 	proto_config_add_boolean lowpower
 	proto_config_add_defaults
 }
@@ -355,11 +356,11 @@ proto_modemmanager_setup() {
 	local bearermethod_ipv4 bearermethod_ipv6 auth cliauth
 	local operatorname operatorid registration accesstech signalquality
 
-	local device apn allowedauth username password pincode iptype metric signalrate
+	local device apn allowedauth username password pincode iptype metric signalrate simslot
 
 	local address prefix gateway mtu dns1 dns2
 
-	json_get_vars device apn allowedauth username password pincode iptype metric signalrate
+	json_get_vars device apn allowedauth username password pincode iptype metric signalrate simslot
 
 	# validate sysfs path given in config
 	[ -n "${device}" ] || {
@@ -387,6 +388,15 @@ proto_modemmanager_setup() {
 
 	# always cleanup before attempting a new connection, just in case
 	modemmanager_cleanup_connection "${modemstatus}"
+
+	# set to the selected SIM
+	if [ -f /usr/bin/qmicli ]; then
+		qmicli -p -d /dev/"$(modemmanager_get_field "${modemstatus}" "modem.generic.primary-port")" --uim-switch-slot=$simslot
+		sleep 2
+	else
+		proto_notify_error "${interface}" UIM_SWITCH_QMICLI_MISSING
+		echo "Error: qmicli not installed.  Cannot switch SIM slots."
+	fi
 
 	# if allowedauth list given, build option string
 	for auth in $allowedauth; do


### PR DESCRIPTION
Signed-off-by: Nicholas Smith <nicholas@nbembedded.com>

WIP/RFC, not ready to merge yet. 

Maintainer: me
Compile tested: ipq40xx/Telco X1 Pro, git master
Run tested: ipq40xx/Telco X1 Pro

Description:
Adds ability to specify SIM slot in UCI.  Modem will switch to that slot before starting the connection, during the setup phase.

Caveat:
Requires qmi-utils installed to work.  Checking with @aleksander0m to see if it can be done without `qmicli`.

Example (add to a modemmanager interface)
`	option simslot '2'`