### PR TITLE
ddns-scripts: Get 'l3 device' (for pppoe connection) for bind_network using curl

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -755,7 +755,7 @@ do_transfer() {
 		# force network/interface-device to use for communication
 		if [ -n "$bind_network" ]; then
 			local __DEVICE
-			network_get_physdev __DEVICE $bind_network || \
+			network_get_device __DEVICE $bind_network || \
 				write_log 13 "Can not detect local device using 'network_get_physdev $bind_network' - Error: '$?'"
 			write_log 7 "Force communication via device '$__DEVICE'"
 			__PROG="$__PROG --interface $__DEVICE"


### PR DESCRIPTION
Maintainer: none
Compile tested: mips_24kc
Run tested: mips_24kc, REVISION 'r15449-936220186d'

Description:
ddns is not working for ipv4, if pppoe is used for wan access. script set 'eth1'
as interface for curl in my case. The correct interface is 'pppoe-wan'.
script uses 'network_get_physdev' function to get real device for bind_network.. So this pull request change function to 'network_get_device'. In case if we don't use pppoe connection - 'l3 device' is equal to real device.
in my case:
root@OpenWrt:~# ifstatus wan
{
	"up": true,
	"pending": false,
	"available": true,
	"autostart": true,
	"dynamic": false,
	"uptime": 8914,
	"l3_device": "pppoe-wan",
	"proto": "pppoe",
	"device": "eth1",
......  

Signed-off-by: Pavel Bukhatkin welder_pb@bk.ru