### PR TITLE
samba4: update to 4.13.3, enbale io_uring

### DIFF
--- a/net/samba4/Config.in
+++ b/net/samba4/Config.in
@@ -33,7 +33,7 @@ config SAMBA4_SERVER_VFSX
 	depends on PACKAGE_samba4-server
 	help
 		installs:
-			modules: vfs_virusfilter vfs_shell_snap vfs_commit vfs_worm vfs_xattr_tdb vfs_aio_fork vfs_aio_pthread (vfs_linux_xfs_sgid) vfs_netatalk vfs_dirsort vfs_fileid
+			modules: vfs_virusfilter vfs_shell_snap vfs_commit vfs_worm vfs_xattr_tdb (vfs_linux_xfs_sgid) vfs_netatalk vfs_dirsort vfs_fileid
 
 		Additional VFS modules that aren't commonly used, vfs_linux_xfs_sgid requires kmod-fs-xfs to be selected separately
 	default n

--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.13.2
+PKG_VERSION:=4.13.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -13,7 +13,7 @@ PKG_SOURCE_URL:= \
 		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
-PKG_HASH:=276464396a05d88b775bda01ac2eb1e5a636ccf7010b0fd28efc3d85583af2b4
+PKG_HASH:=c10585d43f33656fe4e1f9ff8bf40ea57d8d5b653521c1cc198fbf4922756541
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only
@@ -31,7 +31,8 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_SAMBA4_SERVER_VFSX \
 	CONFIG_SAMBA4_SERVER_AD_DC \
 	CONFIG_PACKAGE_kmod-fs-btrfs \
-	CONFIG_PACKAGE_kmod-fs-xfs
+	CONFIG_PACKAGE_kmod-fs-xfs \
+	CONFIG_KERNEL_IO_URING
 
 PYTHON3_PKG_BUILD:=0
 
@@ -61,10 +62,9 @@ endef
 define Package/samba4-libs
   $(call Package/samba4/Default)
   TITLE+= libs
-  DEPENDS:= +libtirpc +libreadline +libpopt +libcap +zlib +libgnutls +libtasn1 +libuuid +libopenssl +libpthread \
+  DEPENDS:= +libtirpc +libreadline +libpopt +libcap +zlib +libgnutls +libtasn1 +libuuid +libopenssl +libpthread +KERNEL_IO_URING:liburing \
 	+PACKAGE_libpam:libpam \
 	+SAMBA4_SERVER_VFS:attr \
-	+SAMBA4_SERVER_VFSX:libaio \
 	+SAMBA4_SERVER_AVAHI:libavahi-client \
 	+SAMBA4_SERVER_AD_DC:python3-cryptodome +SAMBA4_SERVER_AD_DC:libopenldap +SAMBA4_SERVER_AD_DC:jansson +SAMBA4_SERVER_AD_DC:libarchive +SAMBA4_SERVER_AD_DC:acl +SAMBA4_SERVER_AD_DC:attr
 endef
@@ -255,6 +255,10 @@ SAMBA4_PDB_MODULES :=pdb_smbpasswd,pdb_tdbsam,
 SAMBA4_AUTH_MODULES :=auth_builtin,auth_sam,auth_unix,
 SAMBA4_VFS_MODULES :=vfs_default,
 SAMBA4_VFS_MODULES_SHARED :=auth_script,
+# always build if kernel supports io_uring
+ifdef CONFIG_KERNEL_IO_URING
+	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_io_uring,
+endif
 ifeq ($(CONFIG_SAMBA4_SERVER_VFS),y)
 	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_fruit,vfs_shadow_copy2,vfs_recycle,vfs_fake_perms,vfs_readonly,vfs_cap,vfs_offline,vfs_crossrename,vfs_catia,vfs_streams_xattr,vfs_xattr_tdb,vfs_default_quota,
 ifdef CONFIG_PACKAGE_kmod-fs-btrfs
@@ -262,7 +266,7 @@ ifdef CONFIG_PACKAGE_kmod-fs-btrfs
 endif
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_VFSX),y)
-	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_virusfilter,vfs_shell_snap,vfs_commit,vfs_worm,vfs_aio_fork,vfs_aio_pthread,vfs_netatalk,vfs_dirsort,vfs_fileid,
+	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_virusfilter,vfs_shell_snap,vfs_commit,vfs_worm,vfs_netatalk,vfs_dirsort,vfs_fileid,
 ifdef CONFIG_PACKAGE_kmod-fs-xfs
 	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_linux_xfs_sgid,
 endif
@@ -291,15 +295,19 @@ HOST_CONFIGURE_ARGS += \
 PY_VER:=$(PYTHON3_VERSION_MAJOR)$(PYTHON3_VERSION_MINOR)
 # NOTE: bundle + make private, we want to avoid version configuration (build, link) conflicts
 HOST_CONFIGURE_ARGS += --builtin-libraries=replace --nonshared-binary=asn1_compile,compile_et
-SYSTEM_BUNDLED_LIBS:=talloc,tevent,tevent-util,texpect,tdb,ldb,tdr,cmocka,replace,com_err
+SYSTEM_PRIVATE_BUNDLED_LIBS:=talloc,tevent,tevent-util,texpect,tdb,ldb,tdr,cmocka,replace,com_err
+SYSTEM_BUNDLED_LIBS:=
 PYTHON_BUNDLED_LIBS:=pytalloc-util.cpython-$(PY_VER),pyldb-util.cpython-$(PY_VER)
 # CONFIGURE_ARGS += --builtin-libraries=talloc,tevent,tevent-util,texpect,tdb,ldb,tdr,cmocka,com_err
-ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
-	CONFIGURE_ARGS += --bundled-libraries=NONE,$(SYSTEM_BUNDLED_LIBS),$(PYTHON_BUNDLED_LIBS)
-else
-	CONFIGURE_ARGS += --bundled-libraries=NONE,$(SYSTEM_BUNDLED_LIBS)
+ifdef CONFIG_KERNEL_IO_URING
+	SYSTEM_BUNDLED_LIBS:=,uring
 endif
-CONFIGURE_ARGS += --private-libraries=$(SYSTEM_BUNDLED_LIBS)
+ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
+	CONFIGURE_ARGS += --bundled-libraries=NONE,$(SYSTEM_PRIVATE_BUNDLED_LIBS)$(SYSTEM_BUNDLED_LIBS),$(PYTHON_BUNDLED_LIBS)
+else
+	CONFIGURE_ARGS += --bundled-libraries=NONE,$(SYSTEM_PRIVATE_BUNDLED_LIBS)$(SYSTEM_BUNDLED_LIBS)
+endif
+CONFIGURE_ARGS += --private-libraries=$(SYSTEM_PRIVATE_BUNDLED_LIBS)
 
 export COMPILE_ET=$(STAGING_DIR_HOSTPKG)/bin/compile_et_samba
 export ASN1_COMPILE=$(STAGING_DIR_HOSTPKG)/bin/asn1_compile_samba

--- a/net/samba4/files/samba.init
+++ b/net/samba4/files/samba.init
@@ -5,39 +5,39 @@ USE_PROCD=1
 
 SAMBA_IFACE=""
 
+config_get_sane() {
+	config_get "$@"
+	set -- "$(echo "$1" | tr -d '<>[]{};%?=#\n')"
+}
+
 smb_header() {
-	config_get SAMBA_IFACE $1 interface "lan"
+	config_get_sane SAMBA_IFACE "$1" interface "lan"
 
 	# resolve interfaces
-	local interfaces
 	interfaces=$(
 		. /lib/functions/network.sh
 
-		local net
 		for net in $SAMBA_IFACE; do
-			local device
-			network_is_up $net || continue
+			network_is_up "$net" || continue
 			network_get_device device "$net"
 			printf "%s " "${device:-$net}"
 		done
 	)
 
-	local workgroup description charset
 	# we dont use netbios anymore as default and wsd/avahi is dns based
-	local hostname
-	hostname="$(cat /proc/sys/kernel/hostname)"
+	hostname="$(cat /proc/sys/kernel/hostname | tr -d '{};%?=#\n')"
 
-	config_get workgroup $1 workgroup "WORKGROUP"
-	config_get description $1 description "Samba on OpenWrt"
-	config_get charset $1 charset "UTF-8"
+	config_get_sane workgroup "$1" workgroup "WORKGROUP"
+	config_get_sane description "$1" description "Samba on OpenWrt"
+	config_get_sane charset "$1" charset "UTF-8"
 
-	config_get_bool MACOS $1 macos 0
-	config_get_bool DISABLE_NETBIOS $1 disable_netbios 0
-	config_get_bool DISABLE_AD_DC $1 disable_ad_dc 0
-	config_get_bool DISABLE_WINBIND $1 disable_winbind 0
-	config_get_bool DISABLE_ASYNC_IO $1 disable_async_io 0
-	config_get_bool ALLOW_LEGACY_PROTOCOLS $1 allow_legacy_protocols 0
-	config_get_bool ENABLE_EXTRA_TUNING $1 enable_extra_tuning 0
+	config_get_bool MACOS "$1" macos 0
+	config_get_bool DISABLE_NETBIOS "$1" disable_netbios 0
+	config_get_bool DISABLE_AD_DC "$1" disable_ad_dc 0
+	config_get_bool DISABLE_WINBIND "$1" disable_winbind 0
+	config_get_bool DISABLE_ASYNC_IO "$1" disable_async_io 0
+	config_get_bool ALLOW_LEGACY_PROTOCOLS "$1" allow_legacy_protocols 0
+	config_get_bool ENABLE_EXTRA_TUNING "$1" enable_extra_tuning 0
 
 	mkdir -p /var/etc
 	sed -e "s#|NAME|#$hostname#g" \
@@ -52,14 +52,13 @@ smb_header() {
 
 		# extra tuning options by community feedback (kinda try&error)
 		if [ "$ENABLE_EXTRA_TUNING" -eq 1 ]; then
-			local socket_opt
 			socket_opt="$(grep -i 'socket options' /etc/samba/smb.conf.template | awk -F'=' '{print $2}' | tr -d '\n')"
 			[ -n "$socket_opt" ] && printf "\tsocket options =%s SO_KEEPALIVE\n" "$socket_opt" # add keepalive, maybe larger buffer? SO_RCVBUF=65536 SO_SNDBUF=65536
 
 			printf "\tmax xmit = 131072\n" # increase smb1 transmit size
 			printf "\tmin receivefile size = 131072\n" # allows zero-copy writes via fs
 			printf "\tfake oplocks = Yes\n" # may corrupt files for simultanous writes to the same files by multiple clients, but might also see big speed boost
-			printf "\tuse sendfile = Yes\n" # enable sendfile, not sure whats with the 2019 bug https://bugzilla.samba.org/show_bug.cgi?id=14095
+			printf "\tuse sendfile = Yes\n" # enable sendfile?
 		fi
 
 		if [ "$DISABLE_NETBIOS" -eq 1 ] || [ ! -x /usr/sbin/nmbd ]; then
@@ -71,8 +70,6 @@ smb_header() {
 		if [ "$DISABLE_ASYNC_IO" -eq 1 ]; then
 			printf "\taio read size = 0\n"
 			printf "\taio write size = 0\n"
-			# sendfile bug: https://bugzilla.samba.org/show_bug.cgi?id=14095
-			printf "\tuse sendfile = no\n"
 		fi
 
 		if [ "$ALLOW_LEGACY_PROTOCOLS" -eq 1 ]; then
@@ -88,46 +85,27 @@ smb_header() {
 	if [ ! -L /etc/samba/smb.conf ]; then
 		logger -p daemon.warn -t 'samba4-server' "Local custom /etc/samba/smb.conf file detected, all luci/config settings are ignored!"
 	fi
-
 }
 
 smb_add_share() {
-	local name
-	local path
-	local users
-	local create_mask
-	local dir_mask
-	local browseable
-	local read_only
-	local writeable
-	local guest_ok
-	local guest_only
-	local inherit_owner
-	local vfs_objects
-	local timemachine
-	local timemachine_maxsize
-	local force_root
-	local write_list
-	local read_list
-
-	config_get name $1 name
-	config_get path $1 path
-	config_get users $1 users
-	config_get create_mask $1 create_mask
-	config_get dir_mask $1 dir_mask
-	config_get browseable $1 browseable
-	config_get read_only $1 read_only
-	config_get writeable $1 writeable
-	config_get guest_ok $1 guest_ok
-	config_get guest_only $1 guest_only
-	config_get inherit_owner $1 inherit_owner
-	config_get vfs_objects $1 vfs_objects
-	config_get_bool timemachine	$1 timemachine	0
-	config_get timemachine_maxsize $1 timemachine_maxsize
-	config_get_bool force_root	$1 force_root	0
-	config_get write_list $1 write_list
-	config_get read_list $1 read_list
-
+	config_get_sane name "$1" name
+	config_get_sane path "$1" path
+	config_get_sane users "$1" users
+	config_get_sane create_mask "$1" create_mask
+	config_get_sane dir_mask "$1" dir_mask
+	config_get_sane browseable "$1" browseable
+	config_get_sane read_only "$1" read_only
+	config_get_sane writeable "$1" writeable
+	config_get_sane guest_ok "$1" guest_ok
+	config_get_sane guest_only "$1" guest_only
+	config_get_sane inherit_owner "$1" inherit_owner
+	config_get_sane vfs_objects "$1" vfs_objects
+	config_get_bool timemachine "$1" timemachine 0
+	config_get_sane timemachine_maxsize "$1" timemachine_maxsize
+	config_get_bool force_root "$1" force_root 0
+	config_get_sane write_list "$1" write_list
+	config_get_sane read_list "$1" read_list
+	
 	[ -z "$name" ] || [ -z "$path" ] && return
 
 	{
@@ -164,6 +142,12 @@ smb_add_share() {
 				[ -n "$timemachine_maxsize" ] && printf "\tfruit:time machine max size = %sG\n" "${timemachine_maxsize}"
 			fi
 		fi
+		
+		# always enable io_uring if we can
+		if [ "$DISABLE_ASYNC_IO" -ne 1 ] && [ -e /usr/lib/samba/vfs/io_uring.so ]; then
+			# make sure its last in list
+			vfs_objects="$vfs_objects io_uring"
+		fi
 
 		[ -n "$vfs_objects" ] && printf "\tvfs objects = %s\n" "$vfs_objects"
 	} >> /var/etc/smb.conf
@@ -190,9 +174,8 @@ service_triggers() {
 
 	procd_add_reload_trigger "dhcp" "system" "samba4"
 
-	local i
 	for i in $SAMBA_IFACE; do
-		procd_add_reload_interface_trigger $i
+		procd_add_reload_interface_trigger "$i"
 	done
 }
 
@@ -204,14 +187,13 @@ start_service() {
 		exit 1
 	fi
 
-	local nice_value
-	config_get nice_value extra samba_nice 0
+	config_get_sane nice_value extra samba_nice 0
 
 	# start main AD-DC daemon, will spawn (smbd,nmbd,winbindd) as needed/configured.
 	if [ "$DISABLE_AD_DC" -ne 1 ] && [ -x /usr/sbin/samba ]; then
 		procd_open_instance
 		procd_set_param command /usr/sbin/samba -F
-		procd_set_param nice $nice_value
+		procd_set_param nice "$nice_value"
 		procd_set_param respawn
 		procd_set_param file /etc/samba/smb.conf
 		procd_set_param limits nofile=16384
@@ -220,7 +202,7 @@ start_service() {
 		# start fileserver daemon
 		procd_open_instance
 		procd_set_param command /usr/sbin/smbd -F
-		procd_set_param nice $nice_value
+		procd_set_param nice "$nice_value"
 		procd_set_param respawn
 		procd_set_param file /etc/samba/smb.conf
 		procd_set_param limits nofile=16384
@@ -230,7 +212,7 @@ start_service() {
 		if [ "$DISABLE_NETBIOS" -ne 1 ] && [ -x /usr/sbin/nmbd ]; then
 			procd_open_instance
 			procd_set_param command /usr/sbin/nmbd -F
-			procd_set_param nice $nice_value
+			procd_set_param nice "$nice_value"
 			procd_set_param respawn
 			procd_set_param file /etc/samba/smb.conf
 			procd_close_instance
@@ -239,7 +221,7 @@ start_service() {
 		if [ "$DISABLE_WINBIND" -ne 1 ] && [ -x /usr/sbin/winbindd ]; then
 			procd_open_instance
 			procd_set_param command /usr/sbin/winbindd -F
-			procd_set_param nice $nice_value
+			procd_set_param nice "$nice_value"
 			procd_set_param respawn
 			procd_set_param file /etc/samba/smb.conf
 			procd_close_instance


### PR DESCRIPTION
Maintainer: me
Compile tested: arm/mvebu (master)
Run tested: arm/qemu (master)

Description:
* update to 4.13.3
* enable vfs io_uring module by default, if kernel supports it
* fix for possible exploit openwrt/packages#13758
* sanetize all external template/config inputs
* fix some shellcheck warnings
* remove old aio modules/deps