### PR TITLE
db47: don't depend on libxml2 at run-time

### DIFF
--- a/libs/db47/Makefile
+++ b/libs/db47/Makefile
@@ -12,7 +12,7 @@ BASE_VERSION:=4.7.25
 
 PKG_NAME:=db47
 PKG_VERSION:=$(BASE_VERSION).4.NC
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/db-$(BASE_VERSION).NC
 PKG_SOURCE:=db-$(BASE_VERSION).NC.tar.gz
@@ -23,6 +23,7 @@ PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>
 PKG_LICENSE:=Sleepycat
 PKG_LICENSE_FILES:=LICENSE
 
+PKG_BUILD_DEPENDS:=libxml2
 PKG_FIXUP:=autoreconf
 PKG_LIBTOOL_PATHS:=. build_unix
 PKG_BUILD_PARALLEL:=1
@@ -32,7 +33,6 @@ include $(INCLUDE_DIR)/package.mk
 define Package/libdb47
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libxml2
   TITLE:=Berkeley DB library (4.7)
   URL:=http://www.oracle.com/us/products/database/berkeley-db
   PROVIDES:=libdb47-full


### PR DESCRIPTION
Maintainer: @Naoir
Compile tested: x86/64
Run tested: x86/64

Description:
libxml2 seems to be required only during build, hence no need to depend on it in run-time.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>
