### PR TITLE
tcpreplay: add libdnet support

### DIFF
--- a/net/tcpreplay/Makefile
+++ b/net/tcpreplay/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tcpreplay
 PKG_VERSION:=4.3.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/appneta/tcpreplay/releases/download/v$(PKG_VERSION)
@@ -20,6 +20,7 @@ PKG_LICENSE_FILES:=docs/LICENSE
 PKG_CPE_ID:=cpe:/a:appneta:tcpreplay
 
 PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -34,7 +35,7 @@ define Package/tcpreplay/default
   CATEGORY:=Network
   URL:=http://tcpreplay.appneta.com/
   MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
-  DEPENDS:=+librt +libpcap
+  DEPENDS:=+librt +libpcap +libdnet
 endef
 
 define Package/tcpbridge
@@ -135,6 +136,7 @@ CONFIGURE_VARS += \
 CONFIGURE_ARGS += \
 	--enable-force-pf \
 	--enable-dynamic-link \
+	--with-libdnet="$(STAGING_DIR)/usr" \
 	--with-libpcap="$(STAGING_DIR)/usr"
 
 define tcpreplayTemplate


### PR DESCRIPTION
On Arch Linux, tcpreplay is picking up the host dnet-config and adding
OS paths, thereby breaking compilation. The easiest solution is to add
libdnet support as the previous commit fixes dnet-config on OpenWrt.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @commodo 
Compile tested: ath79 Arch Linux