### PR TITLE
node: update to v14.15.4

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v14.15.3
+PKG_VERSION:=v14.15.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=32cfb19be9bd15cfdfaf842b29c80cc1c1c4b841a3b8ce05de74e1aca1cbf4fe
+PKG_HASH:=adb7ecf66c74b52a14a08cc22bb0f9aedc157cac1ac93240f7f455e8c8edec9c
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: head r15468-0f8fd1d, aarch64 
Run tested: (qemu 5.2.0) aarch64

Description:
Update to v14.15.4

January 2021 Security Releases:
use-after-free in TLSWrap (High) (CVE-2020-8265)
HTTP Request Smuggling in nodejs (Low) (CVE-2020-8287)

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
