### PR TITLE
python-msgpack: update to version 1.0.2

### DIFF
--- a/lang/python/python-msgpack/Makefile
+++ b/lang/python/python-msgpack/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-msgpack
-PKG_VERSION:=1.0.0
+PKG_VERSION:=1.0.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=msgpack
-PKG_HASH:=9534d5cc480d4aff720233411a1f765be90885750b07df772380b34c10ecb5c0
+PKG_HASH:=fae04496f5bc150eefad4e9571d1a76c55d021325dcd484ce45065ebbdd00984
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia(TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates python-msgpack to version 1.0.2. It adds support for python 3.9 and fixes multiple bugs [Changelog](https://github.com/msgpack/msgpack-python/blob/master/ChangeLog.rst#102)
