### PR TITLE
libuhttpd: Update to 3.8.0

### DIFF
--- a/libs/libuhttpd/Makefile
+++ b/libs/libuhttpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuhttpd
-PKG_VERSION:=3.7.0
+PKG_VERSION:=3.8.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://github.com/zhaojh329/libuhttpd/releases/download/v$(PKG_VERSION)
-PKG_HASH:=d59987098e8ee46c150b3d8268555a9ec3b17b9feee5c4cb140d33148e886899
+PKG_HASH:=cdf97020be8ef73e74f12e0703e0f871ebd26c641ce2cb31f67c90a79483c372
 
 PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Signed-off-by: Jianhui Zhao zhaojh329@gmail.com

Maintainer: me
Compile tested: (x86, , master)
Run tested: (x86, , master, tests done)

Description:
Release notes for 3.8.0: https://github.com/zhaojh329/libuhttpd/releases/tag/v3.8.0