### PR TITLE
samba4: add proper io_uring kernel detection

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
 PKG_VERSION:=4.13.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \

--- a/net/samba4/files/samba.init
+++ b/net/samba4/files/samba.init
@@ -144,9 +144,14 @@ smb_add_share() {
 		fi
 		
 		# always enable io_uring if we can
-		if [ "$DISABLE_ASYNC_IO" -ne 1 ] && [ -e /usr/lib/samba/vfs/io_uring.so ]; then
+		if [ "$DISABLE_ASYNC_IO" -ne 1 ] && [ -e /usr/lib/samba/vfs/io_uring.so ] && grep "io_uring_setup" /proc/kallsyms >>2 ; then
+			logger -p daemon.info -t 'samba4-server' "io_uring support found in kernel, enabling VFS io_uring."
 			# make sure its last in list
-			vfs_objects="$vfs_objects io_uring"
+			if [ -n "$vfs_objects" ]; then
+				vfs_objects="$vfs_objects io_uring"
+			else
+				vfs_objects="io_uring"
+			fi
 		fi
 
 		[ -n "$vfs_objects" ] && printf "\tvfs objects = %s\n" "$vfs_objects"


### PR DESCRIPTION
Maintainer: me
Compile tested: n/a
Run tested: arm/mvebu (SNAPSHOT r15171-6d4382711a)

Description:
* add proper io_uring kernel detection