### PR TITLE
exim: fix compilation with CentOS 7

### DIFF
--- a/mail/exim/Makefile
+++ b/mail/exim/Makefile
@@ -137,6 +137,7 @@ define Package/exim/conffiles
 /etc/exim/exim.conf
 endef
 
+HOST_CFLAGS += -std=c99
 TARGET_CFLAGS += $(FPIC) -DNO_IP_OPTIONS -D_FILE_OFFSET_BITS=64
 
 MAKE_VARS += build=Linux-$$(ARCH)


### PR DESCRIPTION
CentOS 7 has an old GCC that does not default to c11.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: CentOS 7