### PR TITLE
ooniprobe: update to version 3.1.0

### DIFF
--- a/net/ooniprobe/Makefile
+++ b/net/ooniprobe/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ooniprobe
-PKG_VERSION:=3.0.11
+PKG_VERSION:=3.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=probe-cli-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ooni/probe-cli/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=870b8e2d801a5ae96a27fe0f7898f70ff2839ea12c9872e272b78f175e07deb2
+PKG_HASH:=daa3878737df32565192ea2010151183a45125ee1efced1bfeef21be1e9a54c9
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates ooniprobe to version 3.1.0. It adds a new option to test a custom website. [Changelog](https://github.com/ooni/probe-cli/releases/tag/v3.1.0)

