### PR TITLE
zabbix: update to 5.0.7

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=5.0.1
-PKG_RELEASE:=2
+PKG_VERSION:=5.0.7
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/5.0/
-PKG_HASH:=20a19e5cf2354ffcbbe24521b04becfc9875e57289c00da71999de60c4a853b6
+PKG_HASH:=d762f8a9aa9e8717d2e85d2a82d27316ea5c2b214eb00aff41b6e9b06107916a
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=GPL-2.0
@@ -74,7 +74,7 @@ define Package/zabbix/Default
   TITLE:=Zabbix
   URL:=https://www.zabbix.com/
   USERID:=zabbix=53:zabbix=53
-  DEPENDS += $(ICONV_DEPENDS) +libpcre +zlib +ZABBIX_GNUTLS:libgnutls +ZABBIX_OPENSSL:libopenssl @!USE_UCLIBC
+  DEPENDS += $(ICONV_DEPENDS) +libpcre +zlib +ZABBIX_GNUTLS:libgnutls +ZABBIX_OPENSSL:libopenssl
 endef
 
 define Package/zabbix-agentd

--- a/admin/zabbix/patches/010-change-agentd-config.patch
+++ b/admin/zabbix/patches/010-change-agentd-config.patch
@@ -27,7 +27,7 @@
  ### Option: LogFileSize
  #	Maximum size of log file in MB.
  #	0 - disable automatic log rotation.
-@@ -138,6 +135,7 @@ Server=127.0.0.1
+@@ -136,6 +133,7 @@ Server=127.0.0.1
  # Range: 0-100
  # Default:
  # StartAgents=3
@@ -35,7 +35,7 @@
  
  ##### Active checks related
  
-@@ -153,8 +151,6 @@ Server=127.0.0.1
+@@ -151,8 +149,6 @@ Server=127.0.0.1
  # Default:
  # ServerActive=
  
@@ -44,7 +44,7 @@
  ### Option: Hostname
  #	Unique, case sensitive hostname.
  #	Required for active checks and must match hostname as configured on the server.
-@@ -164,8 +160,6 @@ ServerActive=127.0.0.1
+@@ -162,8 +158,6 @@ ServerActive=127.0.0.1
  # Default:
  # Hostname=
  
@@ -53,7 +53,7 @@
  ### Option: HostnameItem
  #	Item used for generating Hostname if it is undefined. Ignored if Hostname is defined.
  #	Does not support UserParameters or aliases.
-@@ -305,8 +299,8 @@ Hostname=Zabbix server
+@@ -303,8 +297,8 @@ Hostname=Zabbix server
  # Include=
  
  # Include=/usr/local/etc/zabbix_agentd.userparams.conf


### PR DESCRIPTION
Remove pointless uClibc-ng dependency as it's gone now.

Refreshed patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @champtar 
Compile tested: ath79