### PR TITLE
openwisp-config: update to version 0.5.0

### DIFF
--- a/admin/openwisp-config/Makefile
+++ b/admin/openwisp-config/Makefile
@@ -5,16 +5,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openwisp-config
-PKG_VERSION:=0.4.5
-PKG_RELEASE:=2
+PKG_SOURCE_VERSION:=0.5.0
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/openwisp/openwisp-config.git
-PKG_SOURCE_VERSION:=0.4.5
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_SOURCE_VERSION)
-PKG_MIRROR_HASH:=017a8ed35ebfda2805426e7da02559d5cc2845ee9ded60fdae8e848d377424fb
-PKG_LICENSE:=GPL-3.0
+PKG_MIRROR_HASH:=337a3a9542a0898da9f951256b0d19b6bc87ced98f4ec6dc9646172b551880ef
+PKG_MAINTAINER:=Federico Capoano <f.capoano@openwisp.io>
+PKG_LICENSE:=GPL3.0-or-later
 PKGARCH:=all
 
 include $(INCLUDE_DIR)/package.mk
@@ -24,15 +22,15 @@ define Package/openwisp-config/default
 	CATEGORY:=Administration
 	SECTION:=admin
 	SUBMENU:=openwisp
-	DEPENDS:=+curl +lua +libuci-lua +luafilesystem $(3)
+	DEPENDS:=+curl +lua +libuci-lua +luafilesystem +luci-lib-nixio $(3)
 	VARIANT:=$(1)
-	MAINTAINER:=Federico Capoano <f.capoano@cineca.it>
+	PKGARCH:=all
 	URL:=http://openwisp.org
 endef
 
 Package/openwisp-config-openssl=$(call Package/openwisp-config/default,openssl,OpenSSL,+ca-certificates +libopenssl)
 Package/openwisp-config-mbedtls=$(call Package/openwisp-config/default,mbedtls,mbedTLS,+ca-certificates +libmbedtls)
-Package/openwisp-config-cyassl=$(call Package/openwisp-config/default,cyassl,CyaSSL,+ca-certificates +libcyassl)
+Package/openwisp-config-wolfssl=$(call Package/openwisp-config/default,wolfssl,WolfSSL,+ca-certificates +libwolfssl)
 Package/openwisp-config-nossl=$(call Package/openwisp-config/default,nossl,No SSL)
 
 define Build/Compile
@@ -42,19 +40,11 @@ define Package/openwisp-config-$(BUILD_VARIANT)/conffiles
 /etc/config/openwisp
 endef
 
-ifeq ($(BUILD_VARIANT),openssl)
 CONFIG_OPENWISP_UCI:=ssl
-endif
-ifeq ($(BUILD_VARIANT),mbedtls)
-CONFIG_OPENWISP_UCI:=ssl
-endif
-ifeq ($(BUILD_VARIANT),cyassl)
-CONFIG_OPENWISP_UCI:=ssl
-endif
-ifeq ($(BUILD_VARIANT),nossl)
-CONFIG_OPENWISP_UCI:=nossl
-endif
 
+ifeq ($(BUILD_VARIANT),nossl)
+    CONFIG_OPENWISP_UCI:=nossl
+endif
 
 define Package/openwisp-config-$(BUILD_VARIANT)/install
 	$(INSTALL_DIR) \
@@ -84,6 +74,10 @@ define Package/openwisp-config-$(BUILD_VARIANT)/install
 		$(1)/usr/lib/lua/openwisp/utils.lua
 
 	$(INSTALL_BIN) \
+		$(PKG_BUILD_DIR)/openwisp-config/files/lib/openwisp/net.lua \
+		$(1)/usr/lib/lua/openwisp/net.lua
+
+	$(INSTALL_BIN) \
 		$(PKG_BUILD_DIR)/openwisp-config/files/sbin/openwisp-store-unmanaged.lua \
 		$(1)/usr/sbin/openwisp-store-unmanaged
 
@@ -103,10 +97,14 @@ define Package/openwisp-config-$(BUILD_VARIANT)/install
 		$(PKG_BUILD_DIR)/openwisp-config/files/sbin/openwisp-update-config.lua \
 		$(1)/usr/sbin/openwisp-update-config
 
+	$(INSTALL_BIN) \
+		$(PKG_BUILD_DIR)/openwisp-config/files/sbin/openwisp-get-address.lua \
+		$(1)/usr/sbin/openwisp-get-address
+
 	$(CP) $(PKG_BUILD_DIR)/VERSION $(1)/etc/openwisp/
 endef
 
 $(eval $(call BuildPackage,openwisp-config-openssl))
 $(eval $(call BuildPackage,openwisp-config-mbedtls))
-$(eval $(call BuildPackage,openwisp-config-cyassl))
+$(eval $(call BuildPackage,openwisp-config-wolfssl))
 $(eval $(call BuildPackage,openwisp-config-nossl))


### PR DESCRIPTION
Full changelog available at https://github.com/openwisp/openwisp-config/releases/tag/0.5.0

Signed-off-by: Federico Capoano <f.capoano@openwisp.io>
(cherry picked from commit 9f7b8088c374a5c8533c61baf56ae57343f6fb67)

Follow up of https://github.com/openwrt/packages/pull/14283 to enable the new package in the next 19.07 build.