### PR TITLE
perl-html-parser: update to 3.75

### DIFF
--- a/lang/perl-html-parser/Makefile
+++ b/lang/perl-html-parser/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-html-parser
-PKG_VERSION:=3.72
-PKG_RELEASE:=3
+PKG_VERSION:=3.75
+PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=http://www.cpan.org/authors/id/G/GA/GAAS/
 PKG_SOURCE:=HTML-Parser-$(PKG_VERSION).tar.gz
-PKG_HASH:=ec28c7e1d9e67c45eca197077f7cdc41ead1bb4c538c7f02a3296a4bb92f608b
+PKG_SOURCE_URL:=http://www.cpan.org/authors/id/C/CA/CAPOEIRAB
+PKG_HASH:=ac6b5e25a8df7af54885201e91c45fb9ab6744c08cedc1a38fcc7d95d21193a9
 
 PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
 PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>
@@ -21,6 +21,7 @@ PKG_CPE_ID:=cpe:/a:derrick_oswald:html-parser
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/perl/HTML-Parser-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/perl/HTML-Parser-$(PKG_VERSION)
+HOST_BUILD_DEPENDS:=perl/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk


### PR DESCRIPTION
Upstream changed slightly. Adjusted.

Add missing host build dependency. perl/host is needed.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Naoir 