### PR TITLE
python-openpyxl,evdev: bump versions

### DIFF
--- a/lang/python/openpyxl/Makefile
+++ b/lang/python/openpyxl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-openpyxl
-PKG_VERSION:=3.0.5
+PKG_VERSION:=3.0.6
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
@@ -16,7 +16,7 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENCE.rst
 
 PYPI_NAME:=openpyxl
-PKG_HASH:=18e11f9a650128a12580a58e3daba14e00a11d9e907c554a17ea016bf1a2c71b
+PKG_HASH:=b229112b46e158b910a5d1b270b212c42773d39cab24e8db527f775b82afc041
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk

--- a/lang/python/python-evdev/Makefile
+++ b/lang/python/python-evdev/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=python-evdev
-PKG_VERSION:=1.3.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.4.0
+PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_MAINTAINER:=Paulo Costa <me@paulo.costa.nom.br>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
 PYPI_NAME:=evdev
-PKG_HASH:=b1c649b4fed7252711011da235782b2c260b32e004058d62473471e5cd30634d
+PKG_HASH:=8782740eb1a86b187334c07feb5127d3faa0b236e113206dfe3ae8f77fb1aaf1
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: me, @paulo-raca (for python-evdev)
Compile tested: x86 https://github.com/openwrt/openwrt/commit/6773bee10753ae181257b544371101646822e80e
Run tested: x86 https://github.com/openwrt/openwrt/commit/6773bee10753ae181257b544371101646822e80e

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>