### PR TITLE
netopeer2: merge-config: listen on ipv6 and ipv4

### DIFF
--- a/net/netopeer2/Makefile
+++ b/net/netopeer2/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netopeer2
 PKG_VERSION:=1.1.39
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_MAINTAINER:=Jakov Smolic <jakov.smolic@sartura.hr>

--- a/net/netopeer2/files/netopeer2-server-merge-config.default
+++ b/net/netopeer2/files/netopeer2-server-merge-config.default
@@ -17,7 +17,7 @@ CONFIG="<netconf-server xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-server\
             <name>default-ssh</name>
             <ssh>
                 <tcp-server-parameters>
-                    <local-address>0.0.0.0</local-address>
+                    <local-address>::</local-address>
                     <keepalives>
                         <idle-time>1</idle-time>
                         <max-probes>10</max-probes>


### PR DESCRIPTION
* The default local-adress makes Netopeer2-server listen on ipv4 only.
We change it to :: in order to listen on ipv6 as well as ipv4.

Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>

Maintainer: me 
