### PR TITLE
docker-compose: update to v1.28.0

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-compose
-PKG_VERSION:=1.27.4
-PKG_RELEASE:=2
+PKG_VERSION:=1.28.0
+PKG_RELEASE:=1
 
 PYPI_NAME:=docker-compose
-PKG_HASH:=5a5690f24c27d4b43dcbe6b3fae91ba680713208e99ee863352b3bae37bcaa83
+PKG_HASH:=947888fe9377b48c260d59b6511ba205655c6beb45a4b70fbce28f753aacf75a
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream version released this morning. Seems to work all right.

Features:
 - Support for Nvidia GPUs via device requests
 - Support for service profiles
 - Change the SSH connection approach to the Docker CLI's via shellout to the local SSH client (old behaviour enabled by setting COMPOSE_PARAMIKO_SSH environment variable)
 - Add flag to disable log prefix
 - Add flag for ansi output control

Bugs:
 - Make parallel_pull=True by default
 - Bring back warning for configs in non-swarm mode
 - Take --file in account when defining project_dir
 - On compose up, attach only to services we read logs from
