### PR TITLE
atop: update to 2.6.0

### DIFF
--- a/admin/atop/Makefile
+++ b/admin/atop/Makefile
@@ -7,13 +7,15 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=atop
 PKG_RELEASE:=1
-PKG_VERSION:=2.5.0
-PKG_LICENSE:=GPL-2.0-or-later
-PKG_SOURCE_URL:=https://www.atoptool.nl/download/
-PKG_HASH:=4b911057ce50463b6e8b3016c5963d48535c0cddeebc6eda817e292b22f93f33
+PKG_VERSION:=2.6.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://www.atoptool.nl/download/
+PKG_HASH:=9ec2ca3a571692f7efaa095f99a5106432bcb71cc22cd6c49597ef0481058f72
+
 PKG_MAINTAINER:=Toni Uhlig <matzeton@googlemail.com>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -23,7 +25,6 @@ define Package/atop
   TITLE:=System and process monitor for Linux
   DEPENDS:=+zlib +libncurses
   URL:=https://www.atoptool.nl/
-  MAINTAINER:=Toni Uhlig <matzeton@googlemail.com>
 endef
 
 define Package/atop/description

--- a/admin/atop/patches/010-makefile-missing-cflags.patch
+++ b/admin/atop/patches/010-makefile-missing-cflags.patch
@@ -1,22 +1,11 @@
-diff --git a/Makefile b/Makefile
-index 3bf5929..e065577 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -32,7 +32,7 @@ VERS     = $(shell ./atop -V 2>/dev/null| sed -e 's/^[^ ]* //' -e 's/ .*//')
- all: 		atop atopsar atopacctd atopconvert
+@@ -33,7 +33,7 @@ VERS     = $(shell ./atop -V 2>/dev/null
+ all: 		atop atopsar atopacctd atopconvert atopcat
  
  atop:		atop.o    $(ALLMODS) Makefile
--		$(CC) -c version.c
-+		$(CC) $(CFLAGS) -c version.c
- 		$(CC) atop.o $(ALLMODS) -o atop -lncurses -lz -lm -lrt $(LDFLAGS)
+-		$(CC) atop.o $(ALLMODS) -o atop -lncursesw -lz -lm -lrt $(LDFLAGS)
++		$(CC) $(CFLAGS) atop.o $(ALLMODS) -o atop -lncursesw -lz -lm -lrt $(LDFLAGS)
  
  atopsar:	atop
-@@ -45,7 +45,7 @@ atopconvert:	atopconvert.o
- 		$(CC) atopconvert.o -o atopconvert -lz $(LDFLAGS)
- 
- netlink.o:	netlink.c
--		$(CC) -I. -Wall -c netlink.c
-+		$(CC) $(CFLAGS) -I. -Wall -c netlink.c
- 
- clean:
- 		rm -f *.o atop atopacctd atopconvert
+ 		ln -sf atop atopsar

--- a/admin/atop/patches/020-limits.patch
+++ b/admin/atop/patches/020-limits.patch
@@ -1,0 +1,10 @@
+--- a/photosyst.c
++++ b/photosyst.c
+@@ -149,6 +149,7 @@
+ **
+ */
+ 
++#include <limits.h>
+ #include <sys/types.h>
+ #include <stdio.h>
+ #include <string.h>


### PR DESCRIPTION
Reordered some stuff in the Makefile for consistency between packages.

Refreshed patches.

Added a musl fix.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lnslbrty
Compile tested: ath79