### PR TITLE
gitlab-runner: update to 13.9.0

### DIFF
--- a/devel/gitlab-runner/Makefile
+++ b/devel/gitlab-runner/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gitlab-runner
-PKG_VERSION:=13.5.0
+PKG_VERSION:=13.9.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v$(PKG_VERSION)
-PKG_HASH:=765c1556ed9dd4c1b36f9946224c62f068b171e2c1581eeb8f71055327d8a274
+PKG_HASH:=35e128eba8cae5269ba5e17d8a5610b39493cc030f110a2a331bbe642c878191
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT
@@ -33,9 +33,7 @@ define Package/gitlab-runner
   CATEGORY:=Development
   TITLE:=Runner for CI/CD
   URL:=https://docs.gitlab.com/runner
-  DEPENDS:= \
-    $(GO_ARCH_DEPENDS) \
-    @!(mips||mipsel) # Disabled because of docker engine error https://gitlab.com/gitlab-org/gitlab-runner/-/issues/27234
+  DEPENDS:=$(GO_ARCH_DEPENDS)
 endef
 
 define Package/gitlab-runner/description

--- a/devel/gitlab-runner/patches/010-test.patch
+++ b/devel/gitlab-runner/patches/010-test.patch
@@ -1,0 +1,11 @@
+--- a/common/buildtest/masking.go
++++ b/common/buildtest/masking.go
+@@ -39,7 +39,7 @@ func RunBuildWithMasking(t *testing.T, c
+ 
+ 	buf.Finish()
+ 
+-	contents, err := buf.Bytes(0, math.MaxInt64)
++	contents, err := buf.Bytes(0, math.MaxInt32)
+ 	assert.NoError(t, err)
+ 
+ 	assert.NotContains(t, string(contents), "MASKED_KEY=MASKED_VALUE")


### PR DESCRIPTION
Backport patches that fix compilation under MIPS.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ja-pa 
Compile tested: mips64

The backported patch seems like it will not be included under 13.8.0 final. Unfortunate if true.