### PR TITLE
btrfs-progs: update to 5.10

### DIFF
--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btrfs-progs
-PKG_VERSION:=5.7
+PKG_VERSION:=5.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/kdave/btrfs-progs
-PKG_HASH:=5c2f048b8c814852614b0b262ab2d468ea02774ef01124ebc0ab708df262de5c
+PKG_HASH:=e71a0d6dd504f3a5d957fce9a30281eb61ecf991c8af315fe0061a1b97a1d021
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Karel Kočí <karel.koci@nic.cz>
@@ -33,6 +33,7 @@ define Package/btrfs-progs
   DEPENDS:= \
     +libattr \
     +libuuid \
+    +libmount \
     +zlib \
     +libblkid \
     +liblzo \


### PR DESCRIPTION
Added libmount dependency as it's needed now.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Cynerd 
Compile tested: mips64/32

Requires: https://patchwork.ozlabs.org/project/openwrt/list/?series=225321