### PR TITLE
knot: update to version 3.0.4

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.0.3
+PKG_VERSION:=3.0.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=fbc51897ef0ed0639ebad59b988a91382b9544288a2db8254f0b1de433140e38
+PKG_HASH:=451d8913a769b7e4bcb3e250a3181b448e28a82cfc58cea6f2509475d7327983
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 5.2 (hbl)
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 5.1.2 (hbk), all tests successful (1 skipped)

Description:

- Release patch