### PR TITLE
dnscrypt-proxy2: don't enable blacklist by default

### DIFF
--- a/net/dnscrypt-proxy2/Makefile
+++ b/net/dnscrypt-proxy2/Makefile
@@ -52,7 +52,6 @@ define Package/dnscrypt-proxy2/install
 	$(INSTALL_BIN) ./files/dnscrypt-proxy.init $(1)/etc/init.d/dnscrypt-proxy
 
 	sed -i "s/^listen_addresses = .*/listen_addresses = ['127.0.0.53:53']/" $(1)/etc/dnscrypt-proxy2/dnscrypt-proxy.toml
-	sed -i "s/^  # blacklist_file = 'blacklist.txt'/blacklist_file = 'blacklist.txt'/" $(1)/etc/dnscrypt-proxy2/dnscrypt-proxy.toml
 endef
 
 define Package/dnscrypt-proxy2/description


### PR DESCRIPTION
Maintainer: @BKPepe 
Compile tested: no
Run tested: no

Description: the default blacklist.txt contains many very questionable entries that break sites, and is enabled by default. Some examples of questionable entries: `*.local`, `*.invalid`, `*.lan`, `stats.*`, `tracker.*`, `*.10.in-addr.arpa`.

It's better to have the blacklist disabled by default. The contents of the file should probably be looked at too (IMO just don't include it at all or include the dnscrypt-proxy2 example file instead, titled as such) but I don't want to do that.