### PR TITLE
iperf: import iperf3 and iperf from base

### DIFF
--- a/net/iperf/Makefile
+++ b/net/iperf/Makefile
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2007-2010 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=iperf
+PKG_VERSION:=2.0.13
+PKG_RELEASE:=2
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=c88adec966096a81136dda91b4bd19c27aae06df4d45a7f547a8e50d723778ad
+PKG_SOURCE_URL:=@SF/iperf2
+
+PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
+PKG_LICENSE:=BSD-3-Clause
+
+PKG_BUILD_PARALLEL:=1
+
+PKG_CONFIG_DEPENDS:=CONFIG_IPERF_ENABLE_MULTICAST
+
+include $(INCLUDE_DIR)/uclibc++.mk
+include $(INCLUDE_DIR)/package.mk
+
+define Package/iperf
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:= $(CXX_DEPENDS) +libpthread
+  TITLE:=Internet Protocol bandwidth measuring tool
+  URL:=http://sourceforge.net/projects/iperf2/
+endef
+
+define Package/iperf/description
+ Iperf is a modern alternative for measuring TCP and UDP bandwidth
+ performance, allowing the tuning of various parameters and
+ characteristics.
+endef
+
+define Package/iperf/config
+	config IPERF_ENABLE_MULTICAST
+		depends on PACKAGE_iperf
+		bool "Enable multicast support"
+endef
+
+
+TARGET_CFLAGS += -D_GNU_SOURCE
+ifeq ($(CONFIG_IPERF_ENABLE_MULTICAST),y)
+CONFIGURE_ARGS += --enable-multicast
+else
+CONFIGURE_ARGS += --disable-multicast
+endif
+
+ifeq ($(CONFIG_IPV6),)
+	CONFIGURE_ARGS += --disable-ipv6
+endif
+
+CONFIGURE_VARS += CXXFLAGS="$$$$CXXFLAGS -fno-rtti"
+CONFIGURE_VARS += LIBS="-lpthread -lm"
+
+define Package/iperf/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/iperf $(1)/usr/bin/iperf
+endef
+
+$(eval $(call BuildPackage,iperf))

--- a/net/iperf/patches/0003-fix-non-ipv6-builds.patch
+++ b/net/iperf/patches/0003-fix-non-ipv6-builds.patch
@@ -1,0 +1,20 @@
+--- a/src/Listener.cpp
++++ b/src/Listener.cpp
+@@ -723,6 +723,7 @@ int Listener::L2_setup (void) {
+ 
+     // Now optimize packet flow up the raw socket
+     // Establish the flow BPF to forward up only "connected" packets to this raw socket
++#ifdef HAVE_IPV6
+     if (l->sa_family == AF_INET6) {
+ #ifdef HAVE_IPV6
+ 	struct in6_addr *v6peer = SockAddr_get_in6_addr(&server->peer);
+@@ -740,6 +741,9 @@ int Listener::L2_setup (void) {
+ 	return -1;
+ #endif /* HAVE_IPV6 */
+     } else {
++#else
++    {
++#endif
+ 	rc = SockAddr_v4_Connect_BPF(server->mSock, ((struct sockaddr_in *)(l))->sin_addr.s_addr, ((struct sockaddr_in *)(p))->sin_addr.s_addr, ((struct sockaddr_in *)(l))->sin_port, ((struct sockaddr_in *)(p))->sin_port);
+ 	WARN_errno( rc == SOCKET_ERROR, "l2 connect ip bpf");
+     }

--- a/net/iperf/patches/010-libcxx.patch
+++ b/net/iperf/patches/010-libcxx.patch
@@ -1,0 +1,12 @@
+--- a/config.h.in
++++ b/config.h.in
+@@ -360,7 +360,9 @@
+ #undef _REENTRANT
+ 
+ /* */
++#ifndef __cplusplus
+ #undef bool
++#endif
+ 
+ /* Define to empty if `const' does not conform to ANSI C. */
+ #undef const

--- a/net/iperf3/Makefile
+++ b/net/iperf3/Makefile
@@ -1,0 +1,83 @@
+#
+# Copyright (C) 2007-2010 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=iperf
+PKG_VERSION:=3.9
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://downloads.es.net/pub/iperf
+PKG_HASH:=24b63a26382325f759f11d421779a937b63ca1bc17c44587d2fcfedab60ac038
+
+PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
+PKG_LICENSE:=BSD-3-Clause
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+
+DISABLE_NLS:=
+
+define Package/iperf3/default
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Internet Protocol bandwidth measuring tool
+  URL:=https://github.com/esnet/iperf
+endef
+
+define Package/iperf3
+$(call Package/iperf3/default)
+  VARIANT:=nossl
+endef
+
+define Package/iperf3-ssl
+$(call Package/iperf3/default)
+  TITLE+= with iperf_auth support
+  VARIANT:=ssl
+  DEPENDS:= +libopenssl
+endef
+
+TARGET_CFLAGS += -D_GNU_SOURCE
+CONFIGURE_ARGS += --disable-shared
+
+ifeq ($(BUILD_VARIANT),ssl)
+	CONFIGURE_ARGS += --with-openssl="$(STAGING_DIR)/usr"
+else
+	CONFIGURE_ARGS += --without-openssl
+endif
+
+MAKE_FLAGS += noinst_PROGRAMS=
+
+define Package/iperf3/description
+ Iperf is a modern alternative for measuring TCP and UDP bandwidth
+ performance, allowing the tuning of various parameters and
+ characteristics.
+endef
+
+# autoreconf fails if the README file isn't present
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	touch $(PKG_BUILD_DIR)/README
+endef
+
+define Package/iperf3/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/iperf3 $(1)/usr/bin/
+endef
+
+define Package/iperf3-ssl/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/iperf3 $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,iperf3))
+$(eval $(call BuildPackage,iperf3-ssl))


### PR DESCRIPTION
Maintainer: @aparcar  @pprindeville 
Compile tested: x87_64, APU3, OpenWrt master
Run tested: no

Description:
Import iperf and iperf3 package from openwrt base.
https://github.com/openwrt/openwrt/pull/3807