### PR TITLE
owipcalc: fix contains not respect default route

### DIFF
--- a/net/owipcalc/Makefile
+++ b/net/owipcalc/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=owipcalc
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_LICENSE:=Apache-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/net/owipcalc/src/owipcalc.c
+++ b/net/owipcalc/src/owipcalc.c
@@ -227,7 +227,7 @@ static bool cidr_contains4(struct cidr *a, struct cidr *b)
 	if (printed)
 		qprintf(" ");
 
-	if ((b->prefix >= a->prefix) && (net1 == net2))
+	if ((a->prefix == 0) || ((b->prefix >= a->prefix) && (net1 == net2)))
 	{
 		qprintf("1");
 		return true;
@@ -529,7 +529,7 @@ static bool cidr_contains6(struct cidr *a, struct cidr *b)
 {
 	struct in6_addr *x = &a->addr.v6;
 	struct in6_addr *y = &b->addr.v6;
-	uint8_t i = (128 - a->prefix) / 8;
+	uint8_t i = ((128 - a->prefix) / 8) % 16;
 	uint8_t m = ~((1 << ((128 - a->prefix) % 8)) - 1);
 	uint8_t net1 = x->s6_addr[15-i] & m;
 	uint8_t net2 = y->s6_addr[15-i] & m;
@@ -537,8 +537,9 @@ static bool cidr_contains6(struct cidr *a, struct cidr *b)
 	if (printed)
 		qprintf(" ");
 
-	if ((b->prefix >= a->prefix) && (net1 == net2) &&
-	    ((i == 15) || !memcmp(&x->s6_addr, &y->s6_addr, 15-i)))
+	if ((a->prefix == 0) ||
+	    ((b->prefix >= a->prefix) && (net1 == net2) &&
+	    ((i == 15) || !memcmp(&x->s6_addr, &y->s6_addr, 15-i))))
 	{
 		qprintf("1");
 		return true;


### PR DESCRIPTION
In IPv4 the default route can be written as
 0.0.0.0/0

In IPv6 the default route can be written as
 ::/0

If u try
  owipcalc 0.0.0.0/0 contains 1.1.1.1
or
  owipcalc ::/0 contains ::1
owipcalc will respond with 0 meaning that the "default prefixes" do not
contain the routes.

That is why we check now for 0 prefix.

Maintainer: @jow- 
Compile tested: Trunk
Run tested: TP-Link TL-WDR4300 v1 (Trunk)

Moved from: https://github.com/openwrt/openwrt/pull/3793/commits