### PR TITLE
sipcalc: use autorelease feature

### DIFF
--- a/utils/sipcalc/Makefile
+++ b/utils/sipcalc/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sipcalc
 PKG_SOURCE_DATE:=2014-10-24
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/sii/sipcalc


### PR DESCRIPTION
Package version is automatically increased as described here:
https://github.com/openwrt/packages/issues/14537