### PR TITLE
libuwifi: use autorelease feature

### DIFF
--- a/libs/libuwifi/Makefile
+++ b/libs/libuwifi/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuwifi
 PKG_VERSION:=2020-03-10
-PKG_RELEASE:=4
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/br101/libuwifi.git


### PR DESCRIPTION
Package version is automatically increased as described here:
https://github.com/openwrt/packages/issues/14537
