### PR TITLE
libradiotap: use autorelease feature

### DIFF
--- a/libs/libradiotap/Makefile
+++ b/libs/libradiotap/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libradiotap
 PKG_VERSION:=2020-06-22
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/radiotap/radiotap-library.git


### PR DESCRIPTION
Package version is automatically increased as described here:
https://github.com/openwrt/packages/issues/14537