### PR TITLE
generate-ipv6-address: use autorelease feature

### DIFF
--- a/ipv6/generate-ipv6-address/Makefile
+++ b/ipv6/generate-ipv6-address/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=generate-ipv6-address
 PKG_VERSION:=0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=generate-ipv6-address-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.irif.fr/~jch/software/files/


### PR DESCRIPTION
Package version is automatically increased as described here:
https://github.com/openwrt/packages/issues/14537