### PR TITLE
yq: Update to v4.4.1

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.2.1
+PKG_VERSION:=4.4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=83d0bc17078552084eeeebd7c505add331baa89ffde2253119340d22f3b80685
+PKG_HASH:=bdd078847a74245e4c09af3dc31cdb482588398f342a8db4c019115a8495ebad
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@project-openwrt.eu.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, rockchip
Run tested: rockchip nanopi-r2s

Description:
Latest changelog: https://github.com/mikefarah/yq/releases/tag/v4.4.1