### PR TITLE
nebula: initial commit

### DIFF
--- a/net/nebula/Makefile
+++ b/net/nebula/Makefile
@@ -1,0 +1,74 @@
+# Copyright 2021 Stan Grishin (stangri@melmac.net)
+# This is free software, licensed under the MIT License.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nebula
+PKG_VERSION:=1.3.0
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
+
+PKG_SOURCE:=v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/slackhq/nebula/archive/
+PKG_HASH:=b94fba0251a4a436e25b127d0b9bc0181b991631f1dc8e344b1c8e895b55375d
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+GO_PKG:=github.com/slackhq/nebula
+GO_PKG_LDFLAGS_X:=main.Build=$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/nebula
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=nebula
+  URL:=https://github.com/slackhq/nebula
+  DEPENDS:=$(GO_ARCH_DEPENDS) +kmod-tun
+endef
+
+define Package/nebula-cert
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=nebula-cert
+  URL:=https://github.com/slackhq/nebula
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/nebula/description
+  Nebula is a scalable overlay networking tool with a focus on performance, simplicity
+  and security. It lets you seamlessly connect computers anywhere in the world.
+endef
+
+define Package/nebula-cert/description
+$(call Package/nebula/description)
+  This package contains only nebula-cert binary.
+endef
+
+define Package/nebula/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+	$(INSTALL_DIR) $(1)/etc/init.d $(1)/usr/sbin $(1)/usr/share/doc/nebula $(1)/lib/upgrade/keep.d 
+	$(INSTALL_BIN) ./files/nebula.init $(1)/etc/init.d/nebula
+	$(SED) "s|^\(PKG_VERSION\).*|\1='$(PKG_VERSION)-$(PKG_RELEASE)'|" $(1)/etc/init.d/nebula
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nebula $(1)/usr/sbin/nebula
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/LICENSE $(1)/usr/share/doc/nebula/LICENSE
+	$(INSTALL_DATA) ./files/nebula.upgrade $(1)/lib/upgrade/keep.d/nebula
+endef
+
+define Package/nebula-cert/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/usr/share/doc/nebula-cert $(1)/lib/upgrade/keep.d
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nebula-cert $(1)/usr/sbin/nebula-cert
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/LICENSE $(1)/usr/share/doc/nebula-cert/LICENSE
+	$(INSTALL_DATA) ./files/nebula.upgrade $(1)/lib/upgrade/keep.d/nebula-cert
+endef
+
+$(eval $(call GoBinPackage,nebula))
+$(eval $(call BuildPackage,nebula))
+
+$(eval $(call GoBinPackage,nebula-cert))
+$(eval $(call BuildPackage,nebula-cert))

--- a/net/nebula/files/nebula.init
+++ b/net/nebula/files/nebula.init
@@ -1,0 +1,53 @@
+#!/bin/sh /etc/rc.common
+# Copyright 2021 Stan Grishin (stangri@melmac.net)
+# shellcheck disable=SC2039
+PKG_VERSION='dev-test'
+
+# shellcheck disable=SC2034
+START=80
+# shellcheck disable=SC2034
+USE_PROCD=1
+
+if type extra_command 1>/dev/null 2>&1; then
+	extra_command 'version' 'Show version information'
+else
+# shellcheck disable=SC2034
+	EXTRA_COMMANDS='version'
+fi
+
+readonly PROG=/usr/sbin/nebula
+
+version() { echo "Version: $PKG_VERSION"; }
+
+start_instance() {
+	local cfg="$1" port name="${1##*/}"
+	port="$(grep -A2 "^listen:" "$cfg" | grep "port: " | awk '{print $2}')"
+	procd_open_instance
+	procd_set_param command ${PROG} -config "${cfg}"
+	procd_set_param stderr 1
+	procd_set_param stdout 1
+	procd_set_param respawn
+	procd_open_data
+	json_add_array firewall
+		json_add_object ''
+		json_add_string type 'rule'
+		json_add_string name "Allow-$name"
+		json_add_string src 'wan'
+		json_add_string dest_port "$port"
+		json_add_string proto 'udp'
+		json_add_string target 'ACCEPT'
+		json_close_object
+	json_close_array
+	procd_close_data
+	procd_close_instance
+}
+
+start_service() {
+	local f
+	for f in /etc/nebula/*.yml; do
+		[ -s "$f" ] && start_instance "$f"
+	done
+}
+
+service_started() { procd_set_config_changed firewall; }
+service_stopped() { procd_set_config_changed firewall; }

--- a/net/nebula/files/nebula.upgrade
+++ b/net/nebula/files/nebula.upgrade
@@ -1,0 +1,1 @@
+/etc/nebula/

--- a/net/nebula/test.sh
+++ b/net/nebula/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# shellcheck disable=SC2039
+
+"/usr/sbin/${1//-full}" -version 2>&1 | grep "$2"


### PR DESCRIPTION
Maintainer: me
Compile tested: ramips, er-x, 19.07.6
Run tested: ramips, er-x, 19.07.6, start/connect to nebula IP from LAN/stop

Description:
This PR brings [SlackHQ's Nebula](https://github.com/slackhq/nebula) package to OpenWrt. The init script searches for `*.yml` files in `/etc/nebula/` and starts a nebula instance for each discovered `.yml`-file. Given the size of the binaries and the fact that `nebula-cert` is very unlikely to be used on the router, I've split it into variants.

THIS IS READY TO BE MERGED.

PS. SlackHQ confirmed I need to include the LICENSE file: https://github.com/slackhq/nebula/issues/371.

Signed-off-by: Stan Grishin <stangri@melmac.net>
