### PR TITLE
Fix ddns provider

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/ddns.com.br.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/ddns.com.br.json
@@ -1,6 +1,0 @@
-{
-	"name": "ddns.com.br",
-	"ipv4": {
-		"url": "http://[DOMAIN]:[PASSWORD]@members.ddns.com.br/nic/update?hostname=[DOMAIN]&myip=[IP]"
-	}
-}

--- a/net/ddns-scripts/files/usr/share/ddns/default/dyns.net.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/dyns.net.json
@@ -1,7 +1,0 @@
-{
-	"name": "dyns.net",
-	"ipv4": {
-		"url": "http://www.dyns.net/postscript011.php?username=[USERNAME]&password=[PASSWORD]&host=[DOMAIN]&ip=[IP]",
-		"answer": "200"
-	}
-}

--- a/net/ddns-scripts/files/usr/share/ddns/default/myonlineportal.net.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/myonlineportal.net.json
@@ -1,11 +1,11 @@
 {
 	"name": "myonlineportal.net",
 	"ipv4": {
-		"url": "http://[USERNAME]:[PASSWORD]@myonlineportal.net/updateddns?hostname=[DOMAIN]&ip=[IP]",
+		"url": "http://myonlineportal.net/updateddns?hostname=[DOMAIN]&ip=[IP]&username=[USERNAME]&password=[PASSWORD]",
 		"answer": "good|nochg"
 	},
 	"ipv6": {
-		"url": "http://[USERNAME]:[PASSWORD]@myonlineportal.net/updateddns?hostname=[DOMAIN]&ip6=[IP]",
+		"url": "http://myonlineportal.net/updateddns?hostname=[DOMAIN]&ip6=[IP]&username=[USERNAME]&password=[PASSWORD]",
 		"answer": "good|nochg"
 	}
 }

--- a/net/ddns-scripts/files/usr/share/ddns/default/nubem.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/nubem.com.json
@@ -1,6 +1,0 @@
-{
-	"name": "nubem.com",
-	"ipv4": {
-		"url": "http://[USERNAME]:[PASSWORD]@nubem.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
-	}
-}

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -7,7 +7,6 @@ afraid.org-v2-token
 all-inkl.com
 changeip.com
 core-networks.de
-ddns.com.br
 ddnss.de
 ddo.jp
 desec.io
@@ -31,7 +30,6 @@ dyndns.it
 dyndns.org
 dyndnss.net
 dynsip.org
-dyns.net
 dynu.com
 dynv6.com
 easydns.com
@@ -52,7 +50,6 @@ nettica.com
 no-ip.pl
 now-dns.com
 nsupdate.info
-nubem.com
 opendns.com
 oray.com
 ovh.com


### PR DESCRIPTION
Maintainer: none
Compile tested: x86 openwrt-19.07.5
Run tested: VirtualBox

Description:
* Change parameter for myonlineportal
    As the default uclient-fetch doesn't support authentication header
    and the ddns provider myonlineportal.net support also username and
    passwort as url parameter this can be changed.
* Remove not working ddns provider
    I checked the hostname for existing DNS A and AAAA entries and these
    ones didn't have an entry.