### PR TITLE
c-icap-server: Add new package for ICAP service

### DIFF
--- a/net/c-icap-server/Makefile
+++ b/net/c-icap-server/Makefile
@@ -1,0 +1,113 @@
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=c-icap-server
+PKG_SOURCE_NAME:=C_ICAP
+PKG_VERSION:=0.5.7
+PKG_RELEASE:=1
+
+PKG_PROTO:=git
+PKG_SOURCE:=$(PKG_SOURCE_NAME)_$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/c-icap/c-icap-server/tar.gz/$(PKG_SOURCE_NAME)_$(PKG_VERSION)?
+PKG_HASH:=79a228a1145ada3a96dfe0abdbfca2103f0d52f5c75117d71998a07433a9c5d7
+
+PKG_LICENSE:=LGPL-2.1
+PKG_MAINTAINER:=Nishant Sharma <nishant@hopbox.in>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_NAME)_$(PKG_VERSION)
+
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libicapapi/Default
+	URL:=http://c-icap.sourceforge.net/
+	DEPENDS:=+libc +libpcre +libpthread +librt +zlib +libbz2 +libopenssl +libdb47 +libopenldap
+	MAINTAINER:=Nishant Sharma <nishant@hopbox.in>
+endef
+
+define Package/libicapapi
+	$(call Package/libicapapi/Default)
+	SECTION:=libs
+	CATEGORY:=Libraries
+	TITLE:=A library to simplify ICAP programming
+endef
+
+define Package/libicapapi/description
+	The goal of libicapapi is to simplify ICAP programming.
+endef
+
+define Package/$(PKG_NAME)
+	$(call Package/libicapapi/Default)
+	SUBMENU:=Web Servers/Proxies
+	SECTION:=net
+	CATEGORY:=Network
+	DEPENDS+=+libicapapi
+	TITLE:=An ICAP server
+endef
+
+define Package/$(PKG_NAME)/description
+	c-icap is an implementation of an ICAP server. It can be
+	used with HTTP proxies that support the ICAP protocol to
+	implement content adaptation and filtering services.
+endef
+
+CONFIGURE_VARS += \
+	ac_cv_10031b_ipc_sem=yes \
+	ac_cv_fcntl=yes
+
+CONFIGURE_ARGS += \
+	--config-cache \
+	--sysconfdir=/etc/c-icap 
+	
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	echo $(PKG_VERSION) > $(PKG_BUILD_DIR)/VERSION.m4
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(2)/bin $(1)/usr/bin $(1)/usr/lib $(1)/usr/include
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/c-icap-config $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/c-icap-libicapapi-config $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/c_icap $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libicapapi.{la,so*} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/c_icap $(1)/usr/include
+	$(SED) 's,^INCDIR=/usr/include,INCDIR=$(STAGING_DIR)/usr/include,g' $(1)/usr/bin/c-icap-config
+	$(SED) 's,^INCDIR2=/usr/include/c_icap,INCDIR2=$(STAGING_DIR)/usr/include/c_icap,g' $(1)/usr/bin/c-icap-config
+	$(SED) 's,^INCDIR=/usr/include,INCDIR=$(STAGING_DIR)/usr/include,g' $(1)/usr/bin/c-icap-libicapapi-config
+	$(SED) 's,^INCDIR2=/usr/include/c_icap,INCDIR2=$(STAGING_DIR)/usr/include/c_icap,g' $(1)/usr/bin/c-icap-libicapapi-config
+	ln -sf $(STAGING_DIR)/usr/bin/c-icap-config $(2)/bin/
+	ln -sf $(STAGING_DIR)/usr/bin/c-icap-libicapapi-config $(2)/bin/
+endef
+
+define Package/libicapapi/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libicapapi.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/c_icap
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/c_icap/* $(1)/usr/lib/c_icap
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/etc/c-icap
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/c-icap.conf $(1)/etc/c-icap
+
+	$(INSTALL_DIR) $(1)/etc/c-icap
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/c-icap.magic $(1)/etc/c-icap
+
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/c-icap.init $(1)/etc/init.d/c-icap
+endef
+
+$(eval $(call BuildPackage,libicapapi))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/net/c-icap-server/files/c-icap.conf
+++ b/net/c-icap-server/files/c-icap.conf
@@ -1,0 +1,863 @@
+#
+# This file contains the default settings for c-icap
+#
+#
+
+
+# TAG: PidFile
+# Format: PidFile pid_file
+# Description:
+#	The file to store the pid of the main process of the c-icap server.
+# Default:
+#	PidFile /var/run/c-icap/c-icap.pid
+PidFile /var/run/c-icap.pid
+
+# TAG: CommandsSocket
+# Format: CommandsSocket socket_file
+# Description:
+#	The path of file to use as control socket for c-icap
+# Default:
+#	CommandsSocket /var/run/c-icap/c-icap.ctl
+CommandsSocket /var/run/c-icap/c-icap.ctl
+
+# TAG: Timeout
+# Format: Timeout seconds
+# Description:
+#	The time in seconds after which a connection without activity
+#	can be cancelled.
+# Default:
+#	Timeout 300
+Timeout 300
+
+# TAG: MaxKeepAliveRequests
+# Format: MaxKeepAliveRequests number
+# Description:
+#	The maximum number of requests can be served by one connection
+#	Set it to -1 for no limit
+# Default:
+#	MaxKeepAliveRequests 100
+MaxKeepAliveRequests 100
+
+# TAG: KeepAliveTimeout
+# Format: KeepAliveTimeout seconds
+# Description:
+#	The maximum time in seconds waiting for a new requests before a
+#	connection will be closed.
+#	If the value is set to -1, there is no timeout.
+# Default:
+#	KeepAliveTimeout 600
+KeepAliveTimeout 600
+
+# TAG: StartServers
+# Format: StartServers number
+# Description:
+#	The initial number of server processes. Each server process
+#	generates a number of threads, which serve the requests.
+# Default:
+#	StartServers 3
+StartServers 5
+
+# TAG: MaxServers
+# Format: MaxServers number
+# Description:
+#	The maximum allowed number of server processes.
+# Default:
+#	MaxServers 10
+MaxServers 20
+
+# TAG: MinSpareThreads
+# Format: MinSpareThreads number
+# Description:
+#	If the number of the available threads is less than number,
+#	the c-icap server starts a new child.
+# Default:
+#	MinSpareThreads     10
+MinSpareThreads     10
+
+# TAG: MaxSpareThreads
+# Format: MaxSpareThreads number
+# Description:
+#	If the number of the available threads is more than number then
+#	the c-icap server kills a child.
+# Default:
+#	MaxSpareThreads     20
+MaxSpareThreads     20
+
+# TAG: ThreadsPerChild
+# Format:  ThreadsPerChild number
+# Description:
+#	The number of threads per child process.
+# Default:
+#	ThreadsPerChild     10
+ThreadsPerChild     10
+
+# TAG: MaxRequestsPerChild
+# Format: MaxRequestsPerChild number
+# Description:
+#	The maximum number of requests that a child process can serve.
+#	After this number has been reached, process dies. The goal of this
+#	parameter is to minimize the risk of memory leaks and increase the
+#	stability of c-icap. It can be disabled by setting its value to 0.
+# Default:
+#	MaxRequestsPerChild  0
+MaxRequestsPerChild 100 
+
+# TAG: InterProcessSharedMemScheme
+# Format: InterProcessSharedMemScheme posix | mmap | sysv
+# Description:
+#	The interprocess shared mem scheme to use. Available schemes:
+#	posix Use posix shared memory (shm_open interface)
+#	mmap  Use anonymous mmaped files as shared memory
+#	sysv  use the sysv ipc shared memory
+# Default:
+#	InterProcessSharedMemScheme posix
+
+# TAG: InterProcessLockingScheme
+# Format: InterProcessSharedMemScheme file | sysv | posix
+# Description:
+#	The interprocess locking scheme to use. Available schemes:
+#       file  Use lock file
+#       sysv  Use the sysv ipc semaphores
+#	posix Use posix semaphores: Use it with caution you may experienced
+#             locking problems if one or more processes crashed.
+# Default:
+#	InterProcessLockingScheme file
+
+# TAG: Port
+# Format: Port [address:]port
+# Description:
+#	The port number that the c-icap server uses to listen to requests.
+# Default:
+#	None
+Port 1344
+
+# TAG: TlsPort
+# Format: TlsPort [address:]port [tls-method=method] [cert=path_to_pem_cert] [key=path_to_pem_key] [client_ca=path_to_pem_file] [ciphers=ciph1:ciph2...] [tls_options=[!]Opt1|[!]Opt2|...]
+# Description:
+#       The port number that the c-icap server uses to listen for TLS/SSL
+#	requests. Options:
+#	tls-method
+#		Set the SSL method to use. Available methods are:
+#		  SSLv23 TLSv1_2 TLSv1_1 TLSv1 SSLv3 SSLv2
+#	cert
+#		Set the certificate to use by the icap server. The certificate
+#		should be in pem format.
+#	key
+#		The key of the configured certificate in pem format. If none
+#		set then the c-icap searches for the key inside cert file.
+#	client_ca
+#		File containing all CA that we accept client certs from. If it
+#		is set then c-icap enables client certificates verification.
+#	cafile
+#		PEM file containing CA certificates to use when verifying client
+#		certificates. If not configured the root.pem file will be used.
+#	capath
+#		Directory containing additional CA certificates to use when
+#		verifying client certificates.
+#	ciphers
+#		Collon separated lists of the ciphers to accept. Please check
+#		openSSL manual for supported ciphers.
+#	tls-options
+#		Sets various options:
+#		SSL_OP_NO_SSLv2  disable the use of SSLv2
+#		SSL_OP_NO_SSLv3  disable the use of SSLv3
+#		SSL_OP_NO_TLSv1  disable the use of TLSv1
+#		SSL_OP_NO_TLSv1_2 disable the use of TLSv1.2
+#		SSL_OP_NO_TLSv1_1 disable the use of TLSv1.1
+#		SSL_OP_NO_TICKET  disable the use of RFC5077 session tickets
+#		SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION
+#		   When performing renegotiation as a server, always start a
+#		   new session.
+#		SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION
+#		   Allow legacy insecure renegotiation between OpenSSL and
+#		   unpatched clients or servers.
+#		
+#		For more options please see the SSL_set_options documentation.
+#		
+#		By default the SSL_OP_ALL flag is set which enables all of the
+#		important bug workarrounds. To reset this flag use the
+#		"!SSL_OP_ALL" as first flag:
+#			tls-options=!SSL_OP_ALL:SSL_OP_NO_TICKET
+#		
+# Default:
+#       None
+
+# TAG: TlsPassphrase
+# Format: TlsPassphrase /path/to/script
+# Description:
+#	Path to the script to run to get the passphrases of TLS certificates
+#	keys. The c-icap will pass as arguments the IP address and port number
+#	to the script.
+# Default:
+#	No value
+# Example:
+#	TlsPassphrase /use/local/c-icap/scripts/cert-passphrase.sh
+
+# TAG: User
+# Format: User username
+# Description:
+#	The user owning c-icap's processes. By default, the owner is the
+#	user who runs the program.
+# Default:
+#	No value
+# Example:
+#	User wwwrun
+
+# TAG: Group
+# Format: Group groupname
+# Description:
+#	The group of users owning c-icap's processes, which, by default
+#	is the group of the current user.
+# Default:
+#	No value
+# Example:
+#	Group nogroup
+
+# TAG: ServerAdmin
+# Format: ServerAdmin admin_mail
+# Description:
+#	The Administrator of this server. Used when displaying information
+#	about this server (logs, info service, etc)
+# Default:
+#	No value
+ServerAdmin support@hopbox.in
+
+# TAG: ServerName
+# Format: ServerName aServerName
+# Description:
+#	A name for this server. Used when displaying information about this
+#	server (logs, info service, etc)
+# Default:
+#	No value
+ServerName Hopbox C-ICAP Server
+
+# TAG: TmpDir
+# Format: TmpDir dir
+# Description:
+#	dir is the location of temporary files.
+# Default:
+#	TmpDir /var/tmp
+TmpDir /var/tmp
+
+# TAG: MaxMemObject
+# Format: MaxMemObject bytes
+# Description:
+#	The maximum memory size in bytes taken by an object which
+#	is processed by c-icap . If the size of an object's body is
+#	larger than the maximum size a temporary file is used.
+# Default:
+#	MaxMemObject 131072
+MaxMemObject 131072
+
+# TAG: DebugLevel
+# Format: DebugLevel level
+# Description:
+#	The level of debugging information to be logged.
+#	The acceptable range of levels is between 0 and 10.
+# Default:
+#	DebugLevel 1
+DebugLevel 1
+
+# TAG: Pipelining
+# Format: Pipelining on|off
+# Description:
+#	Enable or disable ICAP requests pipelining
+# Default:
+#	Pipelining on
+Pipelining on
+
+# TAG: SupportBuggyClients
+# FORMAT: SupportBuggyClients on|off
+# Description:
+#	Try to handle requests from buggy clients, for example ICAP requests
+#	missing "\r\n" sequences
+# Default:
+# SupportBuggyClients off
+SupportBuggyClients off
+
+# TAG: Allow204As200okZeroEncaps
+# Format: Allow204As200okZeroEncaps
+# Description:
+#	When used the c-icap instead of allow 204 return "200 OK" responses
+#	with zero encapsulated entities.
+# Default:
+#	No set
+
+# TAG: FakeAllow204
+# Format: FakeAllow204 on|off
+# Description:
+#	Support 204 responses from services preview handler to the clients
+#	which does not support preview. Requires early responses support
+#	from clients.
+#	If disabled the c-icap will return 500 response in these cases
+# Default:
+# FakeAllow204 on
+
+# TAG: ModulesDir
+# Format: ModulesDir dir
+# Description:
+#	The location of modules
+# Default:
+#	ModulesDir /usr/lib/c_icap
+ModulesDir /usr/lib/c_icap
+
+# TAG: ServicesDir
+# Format: ServicesDir dir
+# Description:
+#	The location of services
+# Default:
+#	ServicesDir /usr/lib/c_icap
+ServicesDir /usr/lib/c_icap
+
+# TAG: TemplateDir
+# Format: TemplateDir dir
+# Description:
+#	The location of the text templates used by c-icap and its services,
+#	categorized by language and services/modules
+# Default:
+#	No value
+# Example:
+TemplateDir /usr/share/c_icap/templates/
+
+# TAG: TemplateDefaultLanguage
+# Format: TemplateDefaultLanguage lang
+# Description:
+#	Sets the default language to use for text templates
+# Default:
+#	TemplateDefaultLanguage en
+TemplateDefaultLanguage en
+
+#TemplateReloadTime 360
+#TemplateCacheSize 20
+#TemplateMemBufSize 8192
+
+# TAG: LoadMagicFile
+# Format: LoadMagicFile path
+# Description:
+#	Load a c-icap magic file. A magic file contains various
+#	data type definitions. Look inside default c-icap.magic file
+#	for more informations.
+#	It can be used more than once to use multiple magic files.
+# Default:
+#	LoadMagicFile /etc/c-icap.magic
+LoadMagicFile /etc/c-icap.magic
+
+# TAG: RemoteProxyUsers
+# Format: RemoteProxyUsers onoff
+# Description:
+#	Set it to on if you want to use username provided by the proxy server.
+#	This is the recomended way to use users in c-icap.
+#	If the RemoteProxyUsers is off and c-icap configured to use users or
+#	groups the internal authentication mechanism will be used.
+# Default:
+#	RemoteProxyUsers off
+RemoteProxyUsers off
+
+# TAG: RemoteProxyUserHeader
+# Format: RemoteProxyUserHeader Header
+# Description:
+#	Used to specify the icap header used by the proxy server to send
+#	the authenticated client username to c-icap server
+# Default:
+#	RemoteProxyUserHeader X-Authenticated-User
+RemoteProxyUserHeader X-Authenticated-User
+
+# TAG: RemoteProxyUserHeaderEncoded
+# Format: RemoteProxyUserHeaderEncoded onoff
+# Description:
+#	Set it to off if the RemoteProxyUserHeader is not base64 encoded
+# Default:
+#	RemoteProxyUserHeaderEncoded on
+RemoteProxyUserHeaderEncoded on
+
+# TAG: AuthMethod
+# Format: AuthMethod Method Authenticator
+# Description:
+#	Used to define the internal authentication mechanism to use. This
+#	feature is not well tested and may cause problems. It is better to use
+#	RemoteProxyUser configuration.
+#	Method is the authentication method to use (basic, digest, etc).
+#	Currently only basic authentication method is implemented as build in
+#	module
+#	Authenticator currently can only be "basic_simple_db"
+#	It can be considered as a user/password store and can be
+#	implemented as external module. The basic_simple_db is implemented as
+#	build it module
+# Default:
+#	No set
+# Example:
+#	AuthMethod basic basic_simple_db
+
+# TAG: basic.Realm
+# Format: basic.Realm ARealm
+# Description:
+#	Specify the basic method realm
+# Default:
+#	basic.Realm "Basic authentication"
+# Example:
+#	basic.Realm "c-icap server authentication"
+
+# TAG: basic_simple_db.UsersDB
+# Format: basic_simple_db.UsersDB LookupTable
+# Description:
+#	Specify the lookup table where the usernames/passwords pairs
+#	are stored. The paswords must be unencrypted
+#	For more information about c-icap lookup tables read c-icap server
+#	manual page
+# Default:
+#	No value
+# Example:
+#	basic_simple_db.UsersDB hash:/usr/local/c-icap/etc/c-icap-users.txt
+
+# TAG: GroupSourceByGroup
+# Format: GroupSourceByGroup LookupTable
+# Description:
+#	Defines a lookup table where the groups of users are stored indexed
+#	by group. It can be used more than once.
+#	For more information about c-icap lookup tables read c-icap server
+#	manual page
+# Default:
+#	No set
+# Example:
+#	GroupSourceByGroup hash:/usr/local/c-icap/etc/c-icap-groups.txt
+
+# TAG: GroupSourceByUser
+# Format: GroupSourceByUser LookupTable
+# Description:
+#	Defines a lookup table where the groups of users are stored indexed
+#	by user. It can be used more than once.
+#	For more information about c-icap lookup tables read c-icap server
+#	manual page
+# Default:
+#	No set
+# Example:
+#	GroupSourceByUser hash:/usr/local/c-icap/etc/c-icap-user-groups.txt
+
+# TAG: acl
+# Format: acl name type[{param}] value1 [value2] [...]
+# Description:
+#	Supported acl types are:
+#		acl aclname service service1 ...
+#		     The servicename
+#		acl aclname type OPTIONS|RESPMOD|REQMOD ...
+#		     The icap method
+#		acl aclname port port1 ...
+#		     The icap server port
+#		acl aclname src ip1/netmask1 ...
+#		     The client ip address
+#		acl aclname srvip ip1/netmask1 ...
+#		     The c-icap server ip address
+#		acl aclname icap_header{HeaderName} value1 ...
+#		     Matches the icap header HeaderName with value1 ...
+#		     The values are in regex form: /avalue/flags
+#		acl aclname icap_resp_header{HeaderName} value1 ...
+#		     The icap response header
+#		     The values are in regex form: /avalue/flags
+#		acl aclname http_req_header{HeaderName} value1 ...
+#		     The http request header
+#		     The values are in regex form: /avalue/flags
+#		acl aclname http_resp_header{HeaderName} value1 ...
+#		     The http response header
+#		     The values are in regex form: /avalue/flags
+#		acl aclname data_type type1 ...
+#		     The data type as recognized by the internal data type
+#		     recognizer. The types are defined in c-icap.magic file
+#		acl aclname auth username|* ...
+#		     The authenticated users. Using * instead of username means
+#		     all users.
+#		acl aclname group group1 ...
+#		     if the user of request belongs to given groups
+#		acl content_length{>|<|=} value1 ...
+#		     The content length of body data if the related information
+#		     included in http headers.
+#		     The parameter can take the value <, > or = to specify that
+#		     the acl will match if content length is less, greater or
+#		     equal to acl values.
+#		acl time value1 ....
+#		     It checks agains current time. The values format is:
+#		     [DAY[,DAY,[..]]][/][HH:MM-HH:MM]
+#		     The DAY can be one of the following:
+#			S - Sunday
+#			M - Monday
+#			T - Tuesday
+#			W - Wednesday
+#			H - Thursday
+#			F - Friday
+#			A - Saturday
+#		acl http_client_ip ip1[/netmask1] ...
+#		     The HTTP client ip address, if it is available.
+#		acl http_req_line value1 ...
+#		     The first line of HTTP request
+#		     The values are in regex form: /avalue/flags
+#		acl http_resp_line value1 ...
+#		     The first line of HTTP response
+#		     The values are in regex form: /avalue/flags
+#		acl http_req_url value1 ...
+#		     The HTTP request url without GET request arguments
+#		     The values are in regex form: /avalue/flags
+#		acl http_req_method value1 ...
+#		     The HTTP request method
+
+# Default:
+#	None set
+# Examples:
+#	acl OPTIONS type OPTIONS
+#	acl RESPMOD type RESPMOD
+#	acl REQMOD  type REQMOD
+#	acl ALLREQUESTS type OPTIONS RESPMOD REQMOD
+#	acl XHEAD icap_header{X-Test}  /value/
+#	acl ECHO service echo
+#	acl localnet src 192.168.1.0/255.255.255.0
+#	acl localhost src 127.0.0.1/255.255.255.255
+#	acl all src 0.0.0.0/0.0.0.0
+#	acl BigObjects content_length{>} 5000000
+#	acl WorkingHours time M,T,W,H,F/8:00-18:00
+#	acl FreeHour time Sunday,Saturday/8:00-23:59 M,T,W,H,F/18:01-23:59 M,T,W,H,F/0:00-7.59
+
+# TAG: icap_access
+# Format: icap_access allow|deny [!]acl1 ...
+# Description:
+#	Allowing or denying ICAP access based on defined access lists
+# Default:
+#	None set
+# Example:
+#	icap_access deny XHEAD
+#	#Allow OPTIONS method for all:
+#	icap_access allow localnet OPTIONS
+#	#Require authentication for all users from local network:
+#	icap_access allow AUTH localnet
+#	icap_access deny all
+
+# TAG: client_access
+# Format: client_access allow|deny acl1 [acl2] [...]
+# Description:
+#	Allowing or denying connections on c-icap based on
+#	defined access lists. Only the acl types src, srvip and port
+#	can be used.
+# Default:
+#	None set
+# Example:
+#	client_access allow all
+
+# TAG: LogFormat
+# Format: LogFormat Name Format
+# Description:
+#	Name is a name for this log format.
+#	Format is a string with embedded % format codes. % format codes
+#	has the following form:
+#	    % [-] [width] [{argument}] formatcode
+#	    if - is specified then the output is left aligned
+#	    if width specified then the field is exactly width size
+#	    some formatcodes support arguments given as {argument}
+#	
+#	Format codes:
+#	       %a:  Remote IP-Address
+#	       %la: Local IP Address
+#	       %lp: Local port
+#	       %>a: Http Client IP Address. Only supported if the proxy
+#	       	    client supports the "X-Client-IP" header
+#	       %<A: Http Server IP Address. Only supported if the proxy
+#	       	    client supports the "X-Server-IP" header
+#	       %ts: Seconds since epoch
+#	       %tl: Local time. Supports optional strftime format argument
+#	       %tg: GMT time. Supports optional strftime format argument
+#	       %>ho: Modified Http request header. Supports header name
+#	       	     as argument. If no argument given the first line returned
+#	       %huo: Modified Http request url
+#	       %<ho: Modified Http reply header. Supports header name
+#	       	     as argument. If no argument given the first line returned
+#	       %iu: Icap request url
+#	       %im: Icap method
+#	       %is: Icap status code
+#	       %>ih: Icap request header. Supports header name
+#	       	     as argument. If no argument given the first line returned
+#	       %<ih: Icap response header. Supports header name
+#	       	     as argument. If no argument given the first line returned
+#	       %Ih: Http bytes received
+#	       %Oh: Http bytes sent
+#	       %Ib: Http body bytes received
+#	       %Ob: Http body bytes sent
+#	       %I: Bytes received
+#	       %O: Bytes sent
+#	       %bph: The first 5 bytes of the body preview data. Non
+#	       	     printable characters printed in hex form.
+#	       	     Supports the number of bytes to output as argument.
+#	       %un: Username
+#	       %Sl: Service log string
+#              %Sa: Attribute value set by service. The attribute name must
+#                   given as argument.
+# Default:
+#	None set
+# Example:
+#	LogFormat myFormat "%tl, %a %im %iu %is %I %O %Ib %Ob %{10}bph"
+
+# TAG: ServerLog
+# Format: ServerLog LogFile
+# Description:
+#	the file used by the build-in logger file_logger to
+#	store debugging information, errors and other
+#	information about the c-icap server.
+# Default:
+#	ServerLog /usr/var/log/server.log
+ServerLog /var/log/server.log
+
+# TAG: AccessLog
+# Format: AccessLog LogFile [LogFormat] [[!]acl1] [[!]acl2] [...]
+# Description:
+#	LogFile is a file where to log access information.
+#	LogFormat is the log format to use. If ommited c-icap uses:
+#	 	"%tl, %la %a %im %iu %is"
+#	Also acls can be used to select certain requests to be logged.
+#	This directive can be used more than once to specify more than
+#	one access log files
+# Default:
+#	AccessLog /usr/var/log/access.log
+# Example:
+#	AccessLog /usr/var/log/access.log MyFormat all
+AccessLog /var/log/access.log
+
+# TAG: Logger
+# Format: Logger LoggerName
+# Description:
+#	Specify wich logger to use. By default uses the build in "file_logger" which
+#	uses files for access and server logging.
+# Default:
+#	Logger file_logger
+# Example:
+#	Logger sys_logger
+
+# TAG: Module
+# Format: Module Type ModuleFile [forceUnload=off]
+# Description:
+#	Load an external module/plugin to c-icap.
+#	ModuleFile is the filename of the module. If no full path given then
+#	the c-icap uses the path defined by the ModulesDir configuration
+#	parameter.
+#	Type is the type of the external module and can be one of the following:
+#		"logger" for modules implement a logger
+#		"common" for general purpose modules
+#	forceUnload=off
+#		Forces c-icap to not unload services/modules loaded as external
+#		dynamic libraries on shutdown or reconfigure.
+#		This option may required when the services/modules are using
+#		c++, or they are linked with c++ libraries.
+# Default:
+#	
+# Example:
+#	Module logger sys_logger.so
+
+# TAG: Service
+# Format: Service aName ServiceFile [forceUnload=off]
+# Description:
+#	It loads the service ServiceFile. The argument aName used
+#	as alias name for the service
+#	forceUnload=off
+#		Forces c-icap to not unload services/modules loaded as external
+#		dynamic libraries on shutdown or reconfigure.
+#		This option may required when the services/modules are using
+#		c++, or they are linked with c++ libraries.
+
+# Default:
+#	
+# Example:
+#	Service echo_service srv_echo.so
+
+# TAG: ServiceAlias
+# Format: ServiceAlias AliasName ServiceName[?param1=value1&param2=value2...]
+# Description:
+#	Used to define an alias name for a service.
+# Default:
+#	
+# Example:
+#	ServiceAlias avscan srv_clamav?allow204=on&sizelimit=off&mode=simple
+
+
+#
+# TAG: General configuration parameters for all services
+# Description:
+#	PreviewSize: The preview data size to advertise to the icap client
+#	MaxConnections: The client should not use more than MaxConnections
+#		for this service.
+#	TransferPreview: The list of file extensions, seperated by commas,
+#		for which the client should send preview data.
+#	TransferIgnore: The list of file extensions that should not be sent
+#		to the icap server
+#	TransferComplete: The list of file extensions that should be sent
+#		in their entirety, without preview, to the icap server
+#	OptionsTTL: The options ttl for the service. The "sec[s]", "min" or
+#		"hour[s]" can be used to secify that the time is in seconds
+#		minutes or hours respectively. If no time-units given
+#		seconds are assumed.
+#	Allow206 on|off: Enable/disable advertise of 206 responses.
+#
+# Example:
+#	echo.PreviewSize 512
+#	echo.TransferIgnore gif, jpeg
+#	echo.OptionsTTL 3 min
+
+
+######################################################
+# External modules comming with core c-icap server
+#
+# Module: echo
+# Description:
+#	Simple test service
+# Example:
+#	Service echo srv_echo.so
+Service echo srv_echo.so
+
+# Module: sys_logger
+# Description:
+#	Add support for logging access and server events to syslog server
+#	Use "Module" configuration parameter to load this module and "Logger"
+#	to make it default logger for the c-icap.
+# Example:
+Module logger sys_logger.so
+Logger sys_logger
+
+
+# TAG: sys_logger.Prefix
+# Format: sys_logger.Prefix string
+# Description:
+#	 string is be presented in every syslog message.
+# Default:
+sys_logger.Prefix "C-ICAP:"
+
+# TAG: sys_logger.Facility
+# Format: sys_logger.Facility daemon|user|local1|local2|local3|local4|local5|local6|local7
+# Description:
+#	specifies the facility type of syslog.
+# Default:
+sys_logger.Facility daemon
+
+# TAG: sys_logger.access_priority
+# Format: sys_logger.access_priority alert|crit|debug|emerg|err|info|notice|warning
+# Description:
+#	determines  the  importance  of the access log message
+# Default:
+sys_logger.access_priority info
+
+# TAG: sys_logger.server_priority
+# Format: sys_logger.server_priority alert|crit|debug|emerg|err|info|notice|warning
+# Description:
+#	determines  the  importance  of the server log message
+# Default:
+sys_logger.server_priority crit
+
+# TAG: sys_logger.LogFormat
+# Format: sys_logger.LogFormat LOGFORMAT
+# Description:
+#	The log format to use. If no log format defined then
+#	the following will be used:
+#	    "%la %a %im %iu %is"
+# Default:
+#	None set
+# Example:
+#	Logformat BasicFormat "%la %a %im %iu %is"
+#	sys_logger.LogFormat BasicFormat
+
+# TAG: sys_logger.access
+# Format: sys_logger.access [!]acl1 ...
+# Description:
+#	Allow selecting ICAP requests to be logged using acls.
+#	By default all requests will be logged.
+# Default:
+#	None set
+# Example:
+#	sys_logger.access all
+
+# End module: sys_logger
+
+# Module: bdb_tables
+# Description:
+#	Add support for Berkeley DB based lookup tables. The format for
+#	bdb path of the lookup table is:
+#		bdb:/path/to/bdb[{param1=val, ...}]
+#	bdb table parameters can be one or more of the followings:
+#	    cache-size=Size[K|M]
+#               The cache size to use. Default is the berkeleyDB default value.
+#	    cache-num=num
+#	        The number of caches to create. The cache will be split across
+#	        num separate regions, where the region size is equal to the
+#	        initial cache size divided by ncache.
+#	Use the c-icap-mkbdb utility to build Berkeley DB c-icap lookup tables
+# Example:
+#	Module common bdb_tables.so
+
+# End module: bdb_tables
+
+# Module: dnsbl_tables
+# Description:
+#	Add support for dns lookup tables. Can be used to access
+#	dns block lists. The dnsbl lookup table path definition is:
+#	    dnsbl:domainname[{param1=val, ...}]
+#       dnsbl table parameters can be one or more of the followings:
+#            cache=no|cache_type
+#               The cache type to use or 'no' for no cache.
+#            cache-size=Size[K|M]
+#               The cache size in RAM
+#            cache-ttl=ttl
+#               The cache ttl to use
+#	
+#	For example the lookup table  for accessing the black.uribl.com
+#	dns black list is:
+#	    dnsbl:black.uribl.com
+# Example:
+#	Module common dnsbl_tables.so
+
+# End module: dnsbl_tables
+
+# Module: ldap_module
+# Description:
+#	Add LDAP support to c-icap. The user can use LDAP based lookup tables
+#	using the following lookup table paths:
+#	      ldap://[username:password@]ldapserver?base?attr1,attr2?filter[{[param=value, ...]}]
+#	      ldaps://...
+#	      ldapi://...
+#	The filter can contain the "%s" formating code which will be replaced by
+#	the search key.
+#	ldap table parameters can be one or more of the followings:
+#	     name=aName
+#		A unique name to use for this table
+#	     cache=no|cache_type
+#		The cache type to use or no for no cache.
+#	     cache-size=Size[K|M]
+#		The cache size in RAM
+#	     cache-ttl=ttl
+#		The cache ttl to use
+#	     cache-item-size=ItemSize[K|M]
+#		The maximum item size
+#	
+#	Examples of supported ldap urls:
+#	     ldap://ldap.chtsanti.net?o=chtsanti?cn,uid?uid=%s{cache=memcached}
+#	     ldap://cn=Directory Manager:Apassword@ldap.chtsanti.net?o=chtsanti?mermberUid?(&(objectClass=posixGroup)(cn=%s))
+#	
+#	WARNING: is not enough tested it may contain bugs!
+# Example:
+#	Module common ldap_module.so
+
+# End module: ldap_module
+
+# Module: memcached
+# Description:
+#       Add support for memcached c-icap cache.
+# Example:
+#       Module common memcached.so
+
+# TAG: memcached.servers
+# Format: memcached.servers hostname1 hostname2 ...
+# Description:
+#	Set the memcached servers to use
+# Default:
+#	memcached.servers 127.0.0.1
+
+# TAG: memcached.use_md5_keys
+# Format: memcached.use_md5_keys on|off
+# Description:
+#	Whether to use or not md5 hash as key when the key exceeds the
+#	MEMCACHED_MAX_KEY (normaly 251 bytes)
+# Default:
+#	memcached.use_md5_keys on
+
+# End module: memcached
+Service squidclamav squidclamav.so

--- a/net/c-icap-server/files/c-icap.init
+++ b/net/c-icap-server/files/c-icap.init
@@ -1,0 +1,18 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2013 OpenWrt.org
+
+START=20
+USE_PROCD=1
+
+start_service()
+{
+        procd_open_instance
+        procd_set_param command "/usr/bin/c-icap" -N 
+        procd_close_instance
+}
+
+stop_service()
+{
+        kill `cat /var/run/c-icap.pid`
+}
+

--- a/net/c-icap-server/patches/001_local_page.patch
+++ b/net/c-icap-server/patches/001_local_page.patch
@@ -1,0 +1,31 @@
+--- a/utils/c-icap-mkbdb.c	2020-10-25 15:53:25.000000000 +0530
++++ b/utils/c-icap-mkbdb.c	2021-01-09 12:35:01.765242597 +0530
+@@ -23,7 +23,7 @@
+ int DUMP_MODE = 0;
+ int VERSION_MODE = 0;
+ int USE_DBTREE = 0;
+-long int PAGE_SIZE;
++long int LOCAL_PAGE_SIZE;
+ 
+ ci_mem_allocator_t *allocator = NULL;
+ int cfg_set_type(const char *directive, const char **argv, void *setdata);
+@@ -52,7 +52,7 @@
+         "The type of values"
+     },
+     {
+-        "-p", "page_size", &PAGE_SIZE, ci_cfg_size_long,
++        "-p", "page_size", &LOCAL_PAGE_SIZE, ci_cfg_size_long,
+         "The page size to use for the database"
+     },
+     {
+@@ -107,8 +107,8 @@
+         return 0;
+     }
+ 
+-    if (PAGE_SIZE > 512 && PAGE_SIZE <= 64*1024)
+-        db->set_pagesize(db, (uint32_t)PAGE_SIZE);
++    if (LOCAL_PAGE_SIZE > 512 && LOCAL_PAGE_SIZE <= 64*1024)
++        db->set_pagesize(db, (uint32_t)LOCAL_PAGE_SIZE);
+ 
+     if ((ret = db->open(db, NULL, path, NULL,
+                         (USE_DBTREE ? DB_BTREE : DB_HASH),

--- a/net/squidclamav/Makefile
+++ b/net/squidclamav/Makefile
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=squidclamav
+PKG_VERSION:=7.1
+PKG_RELEASE:=1
+
+#PKG_SOURCE_PROTO:=git
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/darold/$(PKG_NAME)/tar.gz/v$(PKG_VERSION)?
+#PKG_SOURCE_URL:=https://github.com/darold/squidclamav.git
+#PKG_SOURCE_VERSION:=ecc17ea8e035b609cb3db2abaf276a2d89a4c3c0
+#PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_HASH:=skip
+
+PKG_LICENSE:=GPLv2+
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Nishant Sharma <nishant@hopbox.in>
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+  SUBMENU:=Web Servers/Proxies
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS+=+c-icap-server +squid +clamav
+  TITLE:=Clamav ICAP service and redirector for Squid
+endef
+
+define Package/$(PKG_NAME)/description
+	SquidClamav is an antivirus for Squid proxy based on the Awards winning ClamAv anti-virus toolkit.
+	Using it will help you securing your home or enterprise network web traffic. SquidClamav is the
+	most efficient Squid Redirector and ICAP service antivirus tool for HTTP traffic available for free,
+	it is written in C and can handle thousand of connections.
+endef
+
+CONFIGURE_VARS += \
+	ac_cv_10031b_ipc_sem=yes \
+	ac_cv_fcntl=yes
+
+CONFIGURE_ARGS += \
+	--with-c-icap=$(STAGING_DIR)/usr
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	echo $(PKG_VERSION) > $(PKG_BUILD_DIR)/VERSION.m4
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/usr/lib/c_icap
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/c_icap/* $(1)/usr/lib/c_icap
+	$(INSTALL_DIR) $(1)/usr/lib/squidclamav
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/squidclamav/* $(1)/usr/lib/squidclamav
+	$(INSTALL_DIR) $(1)/etc/c-icap 
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/etc/squidclamav.conf $(1)/etc/c-icap
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/net/squidclamav/files/squidclamav.conf
+++ b/net/squidclamav/files/squidclamav.conf
@@ -1,0 +1,81 @@
+#-----------------------------------------------------------------------------
+# SquidClamav default configuration file
+#
+# To know to customize your configuration file, see squidclamav manpage
+# or go to http://squidclamav.darold.net/
+#
+#-----------------------------------------------------------------------------
+#
+# Global configuration
+#
+
+# Maximum size of a file that may be scanned. Any file bigger that this value
+# will not be scanned.
+maxsize 5000000
+
+# When a virus is found then redirect the user to this URL. If this directive
+# is disabled squidclamav will use c-icap error templates to report issues.
+redirect http://proxy.domain.dom/cgi-bin/clwarn.cgi
+
+# Path to the squiGuard binary if you want URL filtering, note that you'd better
+# use the squid configuration directive 'url_rewrite_program' instead.
+#squidguard /usr/local/squidGuard/bin/squidGuard
+
+# Path to the clamd socket, use clamd_local if you use Unix socket or if clamd
+# is listening on an Inet socket, comment clamd_local and set the clamd_ip and
+# clamd_port to the corresponding value.
+clamd_local /var/run/clamav/clamd.sock
+#clamd_ip 10.27.0.1
+#clamd_port 3310
+
+# Set the timeout for clamd connection. Default is 1 second, this is a good
+# value but if you have slow service you can increase up to 3.
+timeout 1
+
+# Force SquidClamav to log all virus detection or squiguard block redirection
+# to the c-icap log file.
+logredir 0
+
+# Enable / disable DNS lookup of client ip address. Default is enabled '1' to
+# preserve backward compatibility but you must desactivate this feature if you
+# don't use trustclient with hostname in the regexp or if you don't have a DNS
+# on your network. Disabling it will also speed up squidclamav.
+dnslookup 0
+
+# Enable / Disable Clamav Safe Browsing feature. You mus have enabled the
+# corresponding behavior in clamd by enabling SafeBrowsing into freshclam.conf
+# Enabling it will first make a safe browsing request to clamd and then the
+# virus scan request. 
+safebrowsing 1
+
+#
+# Here is some defaut regex pattern to have a high speed proxy on system
+# with low resources.
+#
+
+# Do not scan images
+abort ^.*\.(ico|gif|png|jpg)$
+abortcontent ^image\/.*$
+
+# Do not scan text files
+#abort ^.*\.(css|xml|xsl|js|html|jsp)$
+#abortcontent ^text\/.*$
+#abortcontent ^application\/x-javascript$
+
+# Do not scan streamed videos
+abortcontent ^video\/x-flv$
+abortcontent ^video\/mp4$
+
+# Do not scan flash files
+abort ^.*\.swf$
+abortcontent ^application\/x-shockwave-flash$
+
+# Do not scan sequence of framed Microsoft Media Server (MMS) data packets
+#abortcontent ^.*application\/x-mms-framed.*$
+
+# White list some sites
+whitelist .*\.clamav.net
+whitelist 10\.0\.*
+
+# See also 'trustuser' and 'trustclient' configuration directives
+


### PR DESCRIPTION

Maintainer: me 
Compile tested: x86_64, master, 19.07.6
Run tested: x86_64, master, 19.07.6

Description:
c-icap-server to provides ICAP implementation for proxies like Squid for content adaptation and filtering. squidclamav package is required for virus scanning of the web traffic through Squid proxy.

Signed-off-by: Nishant Sharma <nishant@hopbox.in>