### PR TITLE
php7: Fix prepare target incorrectly referencing 'configure.in' instead of 'configure.ac'

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -561,7 +561,7 @@ endef
 
 define Build/Prepare
 	$(call Build/Prepare/Default)
-	( cd $(PKG_BUILD_DIR); touch configure.in; ./buildconf --force )
+	( cd $(PKG_BUILD_DIR); touch configure.ac; ./buildconf --force )
 endef
 
 define Build/InstallDev


### PR DESCRIPTION
Package release version unchanged as it does not impact the build result in any way.

This was already fixed in master during PHP 7.4 upgrade in 0f10c8c84135eb222b26f0c6dfe561c0b4cefb94

Maintainer: @mhei 
