### PR TITLE
squidclamav: Add new package - malware scanning of web traffic with ClamAV

### DIFF
--- a/net/squidclamav/Makefile
+++ b/net/squidclamav/Makefile
@@ -1,0 +1,66 @@
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=squidclamav
+PKG_VERSION:=7.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/darold/$(PKG_NAME)/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=08121d7db383093d9966798783798d1364d10c91d6cd38392813bdefc0b58de8
+
+PKG_LICENSE:=GPLv2+
+PKG_LICENSE_FILES:=COPYING
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+PKG_MAINTAINER:=Nishant Sharma <nishant@hopbox.in>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+  SUBMENU:=Web Servers/Proxies
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS+=+c-icap-server +squid +clamav
+  TITLE:=Clamav ICAP service and redirector for Squid
+endef
+
+define Package/$(PKG_NAME)/description
+	SquidClamav is an antivirus for Squid proxy based on the Awards winning ClamAv anti-virus toolkit.
+	Using it will help you securing your home or enterprise network web traffic. SquidClamav is the
+	most efficient Squid Redirector and ICAP service antivirus tool for HTTP traffic available for free,
+	it is written in C and can handle thousand of connections.
+endef
+
+CONFIGURE_VARS += \
+	ac_cv_10031b_ipc_sem=yes \
+	ac_cv_fcntl=yes
+
+CONFIGURE_ARGS += \
+	--with-c-icap=$(STAGING_DIR)/usr
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	echo $(PKG_VERSION) > $(PKG_BUILD_DIR)/VERSION.m4
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/usr/lib/c_icap
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/c_icap/* $(1)/usr/lib/c_icap
+	$(INSTALL_DIR) $(1)/usr/lib/squidclamav
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/squidclamav/* $(1)/usr/lib/squidclamav
+	$(INSTALL_DIR) $(1)/etc/c-icap 
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/etc/squidclamav.conf $(1)/etc/c-icap
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/net/squidclamav/files/squidclamav.conf
+++ b/net/squidclamav/files/squidclamav.conf
@@ -1,0 +1,81 @@
+#-----------------------------------------------------------------------------
+# SquidClamav default configuration file
+#
+# To know to customize your configuration file, see squidclamav manpage
+# or go to http://squidclamav.darold.net/
+#
+#-----------------------------------------------------------------------------
+#
+# Global configuration
+#
+
+# Maximum size of a file that may be scanned. Any file bigger that this value
+# will not be scanned.
+maxsize 5000000
+
+# When a virus is found then redirect the user to this URL. If this directive
+# is disabled squidclamav will use c-icap error templates to report issues.
+redirect http://proxy.domain.dom/cgi-bin/clwarn.cgi
+
+# Path to the squiGuard binary if you want URL filtering, note that you'd better
+# use the squid configuration directive 'url_rewrite_program' instead.
+#squidguard /usr/local/squidGuard/bin/squidGuard
+
+# Path to the clamd socket, use clamd_local if you use Unix socket or if clamd
+# is listening on an Inet socket, comment clamd_local and set the clamd_ip and
+# clamd_port to the corresponding value.
+clamd_local /var/run/clamav/clamd.sock
+#clamd_ip 10.27.0.1
+#clamd_port 3310
+
+# Set the timeout for clamd connection. Default is 1 second, this is a good
+# value but if you have slow service you can increase up to 3.
+timeout 1
+
+# Force SquidClamav to log all virus detection or squiguard block redirection
+# to the c-icap log file.
+logredir 0
+
+# Enable / disable DNS lookup of client ip address. Default is enabled '1' to
+# preserve backward compatibility but you must desactivate this feature if you
+# don't use trustclient with hostname in the regexp or if you don't have a DNS
+# on your network. Disabling it will also speed up squidclamav.
+dnslookup 0
+
+# Enable / Disable Clamav Safe Browsing feature. You mus have enabled the
+# corresponding behavior in clamd by enabling SafeBrowsing into freshclam.conf
+# Enabling it will first make a safe browsing request to clamd and then the
+# virus scan request. 
+safebrowsing 1
+
+#
+# Here is some defaut regex pattern to have a high speed proxy on system
+# with low resources.
+#
+
+# Do not scan images
+abort ^.*\.(ico|gif|png|jpg)$
+abortcontent ^image\/.*$
+
+# Do not scan text files
+#abort ^.*\.(css|xml|xsl|js|html|jsp)$
+#abortcontent ^text\/.*$
+#abortcontent ^application\/x-javascript$
+
+# Do not scan streamed videos
+abortcontent ^video\/x-flv$
+abortcontent ^video\/mp4$
+
+# Do not scan flash files
+abort ^.*\.swf$
+abortcontent ^application\/x-shockwave-flash$
+
+# Do not scan sequence of framed Microsoft Media Server (MMS) data packets
+#abortcontent ^.*application\/x-mms-framed.*$
+
+# White list some sites
+whitelist .*\.clamav.net
+whitelist 10\.0\.*
+
+# See also 'trustuser' and 'trustclient' configuration directives
+


### PR DESCRIPTION
Maintainer: @codemarauder 
Compile tested: x86_64, PCEngines APU, master/19.07.6/18.06.2
Run tested: x86_64, PCEngines APU, master/19.07.6/18.06.2

Description: squidclamav is a module for c-icap-server to implement
anti-virus scanning of the web traffic by ClamAV.

Signed-off-by: Nishant Sharma <codemarauder@gmail.com>

