### PR TITLE
collectd: refactor snmp6

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.12.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \

--- a/utils/collectd/patches/931-snmp6-add-ipv6-statistics.patch
+++ b/utils/collectd/patches/931-snmp6-add-ipv6-statistics.patch
@@ -155,7 +155,7 @@ Signed-off-by: Nick Hainke <vincent@systemli.org>
 +int snmp_read(char *ifname) {
 +  FILE *fh;
 +  char buffer[1024];
-+  char *fields[16];
++  char *fields[2];
 +  int numfields;
 +  int currline = 0;
 +  derive_t data[76];
@@ -178,17 +178,17 @@ Signed-off-by: Nick Hainke <vincent@systemli.org>
 +  }
 +
 +  while (fgets(buffer, 1024, fh) != NULL) {
-+    numfields = strsplit(buffer, fields, 16);
++    numfields = strsplit(buffer, fields, 2);
 +
 +    if (numfields < 2)
-+      continue;
++      return -1;
 +
 +    data[currline++] = atoll(fields[1]);
 +  }
 +
 +  fclose(fh);
 +
-+  if (currline < 25) {
++  if (currline < 28) {
 +    return -1;
 +  }
 +

--- a/utils/collectd/patches/931-snmp6-add-ipv6-statistics.patch
+++ b/utils/collectd/patches/931-snmp6-add-ipv6-statistics.patch
@@ -90,7 +90,7 @@ Signed-off-by: Nick Hainke <vincent@systemli.org>
  #  Port "8125"
 --- /dev/null
 +++ b/src/snmp6.c
-@@ -0,0 +1,133 @@
+@@ -0,0 +1,135 @@
 +/*
 +  This Plugin is based opn the interface.c Plugin.
 +*/
@@ -202,19 +202,21 @@ Signed-off-by: Nick Hainke <vincent@systemli.org>
 +#ifndef HAVE_IFADDRS_H
 +  return -1;
 +#else
-+  struct ifaddrs *addrs,*tmp;
 +
-+  getifaddrs(&addrs);
-+  tmp = addrs;
++  // getifaddrs is not working all the time (e.g. wireguard interfaces)
++  // instead we use if_nameindex() syscall as suggested in:
++  // https://stackoverflow.com/a/45796495/8474618
++  struct if_nameindex *if_nidxs, *intf;
 +
-+  while (tmp)
-+  {
-+    if (tmp->ifa_addr && tmp->ifa_addr->sa_family == AF_PACKET)
-+      snmp_read(tmp->ifa_name);
-+    tmp = tmp->ifa_next;
++  if_nidxs = if_nameindex();
++
++  if (if_nidxs != NULL) {
++    for (intf = if_nidxs; intf->if_index != 0 || intf->if_name != NULL; intf++) {
++      snmp_read(intf->if_name);
++    }
++    if_freenameindex(if_nidxs);
 +  }
 +
-+  freeifaddrs(addrs);
 +  snmp_read("all");
 +  return 0;
 +#endif


### PR DESCRIPTION
Getifaddrs() is not working all the time (e.g. wireguard interfaces).
Instead we use if_nameindex() syscall as suggested in:
 https://stackoverflow.com/a/45796495/8474618

Maintainer: @hnyman 
Compile tested: trunk
Run tested: wdr4300 (trunk)