### PR TITLE
python-pytest: update to version 6.2.2

### DIFF
--- a/lang/python/python-pytest/Makefile
+++ b/lang/python/python-pytest/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+# Copyright (C) 2020-2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pytest
-PKG_VERSION:=6.1.2
+PKG_VERSION:=6.2.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=pytest
-PKG_HASH:=c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e
+PKG_HASH:=9d1edf9e7d0b84d72ea3dbcdfd22b35fb543a5e8f2a60092dd578936bf63d7f9
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia(TOS6), OpenWrt master

Description:
This PR updates pytest to version 6.2.2 [Changelog](https://github.com/pytest-dev/pytest/releases)

Tested with internal test
```
platform linux -- Python 3.9.1, pytest-6.2.2, py-1.9.0, pluggy-0.13.1
rootdir: /testdir/pytest, configfile: pyproject.toml
collected 2830 items / 2 errors / 2828 selected  
```
(errors are because of missing hypothesis and xmlschema)