### PR TITLE
Fix typo in cmakeconfig.h.in files

### DIFF
--- a/libs/getdns/patches/030-typo-cmake-fix-stubby.patch
+++ b/libs/getdns/patches/030-typo-cmake-fix-stubby.patch
@@ -1,0 +1,13 @@
+--- a/cmake/include/cmakeconfig.h.in
++++ b/cmake/include/cmakeconfig.h.in
+@@ -91,8 +91,8 @@
+ #cmakedefine HAVE_OPENSSL_VERSION	1
+ 
+ #cmakedefine HAVE_SSL_CTX_DANE_ENABLE	1
+-#cmakedefine HAVE_SSL_CTX_SET_CIPHERSUITS	1
+-#cmakedefine HAVE_SSL_SET_CIPHERSUITS	1
++#cmakedefine HAVE_SSL_CTX_SET_CIPHERSUITES	1
++#cmakedefine HAVE_SSL_SET_CIPHERSUITES	1
+ 
+ #cmakedefine HAVE_OPENSSL_INIT_CRYPTO	1
+ 


### PR DESCRIPTION
Description : 
Fix typo in CMAKE getdns included files, so Stubby can use TLS v1.3 with chipersuites options ON.

This solve issue that's written in here :
https://github.com/getdnsapi/stubby/issues/240
https://github.com/getdnsapi/stubby/issues/257

Signed-off-by: Harris K Kusuma <igharris.kk@gmail.com>