### PR TITLE
ddns-scripts: make WGET_SSL executable

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -85,8 +85,7 @@ NSLOOKUP=$(command -v nslookup)
 
 # Transfer Programs
 WGET=$(command -v wget)
-# SSL support is available if WGET_SSL is not empty
-WGET_SSL=$("$WGET" -V 2>/dev/null | grep -F +https)
+$WGET -V 2>/dev/null | grep -F -q +https && WGET_SSL=$WGET
 
 CURL=$(command -v curl)
 # CURL_SSL not empty then SSL support available


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: x86, master
Run tested: x86, master

Description: 
In 9eab8cc, WGET_SSL has been changed to something like `-cares +digest -gpgme +https +ipv6 -iri +large-file -metalink -nls`, and it breaks some thirdparty ddns scripts. So I change it back to a valid path. 
