### PR TITLE
python-psutil: update to version 5.8.0

### DIFF
--- a/lang/python/python-psutil/Makefile
+++ b/lang/python/python-psutil/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+# Copyright (C) 2020-2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-psutil
-PKG_VERSION:=5.7.3
+PKG_VERSION:=5.8.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=psutil
-PKG_HASH:=af73f7bcebdc538eda9cc81d19db1db7bf26f103f91081d780bbacfcb620dee2
+PKG_HASH:=0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD 3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates psutil to version 5.8.0 [Changelog](https://github.com/giampaolo/psutil/blob/master/HISTORY.rst#580)


