### PR TITLE
socat: allow more complex command line options

### DIFF
--- a/net/socat/Makefile
+++ b/net/socat/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=socat
 PKG_VERSION:=1.7.3.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.dest-unreach.org/socat/download

--- a/net/socat/files/socat.init
+++ b/net/socat/files/socat.init
@@ -12,11 +12,18 @@ validate_section_socat()
 {
 	uci_load_validate socat socat "$1" "$2" \
 		'enable:bool:1' \
-		'SocatOptions:string'
+		'SocatOptions:or(string, list(string))'
+}
+
+append_param_command()
+{
+	procd_append_param command "$1"
 }
 
 socat_instance()
 {
+	local is_list
+
 	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
@@ -26,7 +33,14 @@ socat_instance()
 
 	procd_open_instance
 	procd_set_param command "$PROG"
-	procd_append_param command $SocatOptions
+	config_get is_list "$1" SocatOptions_LENGTH
+	if [ -z "$is_list" ]; then
+		procd_append_param command $SocatOptions
+	else
+		config_list_foreach "$1" SocatOptions append_param_command
+	fi
+	procd_set_param stdout 1
+	procd_set_param stderr 1
 	procd_close_instance
 }
 


### PR DESCRIPTION
Current implementation of socat's init service doesn't allow to run more
complex configurations. As an example there's no possibility to execute
following command:

  socat TCP-LISTEN:8080,fork,reuseaddr,bind=192.168.1.1 \
    EXEC:"/sbin/ip netns exec somenetns socat STDIO TCP:10.0.0.1:80"

In such command the first line is argv[1] and the second line is
argv[2]. SocatOptions config option is a string. As as a consequence of
this each word will be passed as a separate argv element. Socat won't be
able to parse arguments correctly.

In order to mitigate this issue, we can also accept SocatOptions as a
list of strings. Following config file will work correctly:

config socat 'tunnel_8080_into_somenetns'
	option enable '1'
	list SocatOptions 'TCP-LISTEN:8080,fork,reuseaddr,bind=192.168.1.1'
	list SocatOptions 'EXEC:"/sbin/ip netns exec somenetns socat STDIO TCP:10.0.0.1:80"'

While we're at it, pass stdout and stderr into logread.

Signed-off-by: Dobroslaw Kijowski <dobo90@gmail.com>

Maintainer: @thess Ted Hess <thess@kitschensync.net>
Compile tested: aarch64_generic, NanoPi R2S, OpenWrt SNAPSHOT r15603-23be333401
Run tested: aarch64_generic, NanoPi R2S, OpenWrt SNAPSHOT r15603-23be333401
