### PR TITLE
udpspeeded: add missing libatomic dependency

### DIFF
--- a/net/udpspeeder/Makefile
+++ b/net/udpspeeder/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=UDPspeeder
 PKG_VERSION:=20210116.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/wangyu-/$(PKG_NAME)/tar.gz/$(PKG_VERSION)?
@@ -28,7 +28,7 @@ define Package/UDPspeeder
 	CATEGORY:=Network
 	TITLE:=UDP Network Speed-Up Tool
 	URL:=https://github.com/wangyu-/UDPspeeder
-	DEPENDS:= +libstdcpp +librt
+	DEPENDS:= +libstdcpp +librt +libatomic
 endef
 
 define Package/UDPspeeder/description


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @codemarauder 

https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/udpspeeder/compile.txt