### PR TITLE
xray-core: add new package

### DIFF
--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -1,0 +1,107 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=xray-core
+PKG_VERSION:=1.2.4
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/XTLS/xray-core/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=25f6c9edec0ac1f98328943cd2bb760ac7b69107582f9d27e43559da39dc01ed
+
+PKG_MAINTAINER:=Tianling Shen <cnsztl@project-openwrt.eu.org>
+PKG_LICENSE:=MPL-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/Xray-core-$(PKG_VERSION)
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/xtls/xray-core
+GO_PKG_BUILD_PKG:=github.com/xtls/xray-core/main
+GO_PKG_LDFLAGS:=-s -w
+GO_PKG_LDFLAGS_X:= \
+	$(GO_PKG)/core.version=$(PKG_VERSION) \
+	$(GO_PKG)/core.codename=OpenWrt
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/xray/template
+  TITLE:=A platform for building proxies to bypass network restrictions
+  SECTION:=net
+  CATEGORY:=Network
+  URL:=https://xtls.github.io
+endef
+
+define Package/xray-core
+  $(call Package/xray/template)
+  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+  PROVIDES:=v2ray-core
+endef
+
+define Package/xray-geodata
+  $(call Package/xray/template)
+  TITLE+= (geodata files)
+  DEPENDS:=xray-core
+endef
+
+define Package/xray/description
+  Xray, Penetrates Everything. Also the best v2ray-core, with XTLS support. Fully compatible configuration.
+  It secures your network connections and thus protects your privacy.
+endef
+
+define Package/xray-core/description
+  $(call Package/xray/description)
+endef
+
+define Package/xray-geodata/description
+  $(call Package/xray/description)
+
+  This includes GEO datas used for xray-core.
+endef
+
+GEOIP_VER:=202101280019
+GEOIP_FILE:=geoip.dat.$(GEOIP_VER)
+
+define Download/geoip
+  URL:=https://github.com/v2fly/geoip/releases/download/$(GEOIP_VER)/
+  URL_FILE:=geoip.dat
+  FILE:=$(GEOIP_FILE)
+  HASH:=69bb1f820f416e4591a7b76bfabf9fde9cce6550cddcc1a99b2ccafeb2a8ebd3
+endef
+
+GEOSITE_VER:=20210130061540
+GEOSITE_FILE:=dlc.dat.$(GEOSITE_VER)
+
+define Download/geosite
+  URL:=https://github.com/v2fly/domain-list-community/releases/download/$(GEOSITE_VER)/
+  URL_FILE:=dlc.dat
+  FILE:=$(GEOSITE_FILE)
+  HASH:=bc9748c95b0545376356174b005fccfbc21d647df46293d5197853ee06a9c0a2
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+ifneq ($(CONFIG_PACKAGE_xray-geodata),)
+	$(call Download,geoip)
+	$(call Download,geosite)
+endif
+endef
+
+define Package/xray-core/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/main $(1)/usr/bin/xray
+	$(LN) xray $(1)/usr/bin/v2ray
+endef
+
+define Package/xray-geodata/install
+	$(INSTALL_DIR) $(1)/usr/share/xray/
+	$(INSTALL_DATA) $(DL_DIR)/$(GEOIP_FILE) $(1)/usr/share/xray/geoip.dat
+	$(INSTALL_DATA) $(DL_DIR)/$(GEOSITE_FILE) $(1)/usr/share/xray/geosite.dat
+endef
+
+$(eval $(call BuildPackage,xray-core))
+$(eval $(call BuildPackage,xray-geodata))


### PR DESCRIPTION
Maintainer: me
Compile tested: i386, ipq40xx, ipq806x, ramips, rockchip, x86_64
Run tested: ipq40xx, rockchip, x86_64

Description:
v2ray-core is a platform for building proxies to bypass network restrictions,
and it secures your network connections and thus protects your privacy.

It supports most popular proxies protocols like Shadowsocks, Trojan, VMESS and VLESS,
as well as port forwarding, NAT traversal, DNS resolving etc.
More information can be found here: https://www.v2fly.org/en_US / https://xtls.github.io/config/

Xray is the superset of V2Ray, with extra XTLS support and higher performance, and fully
compatible with configuration of V2Ray, so it's fine to use Xray to provide V2Ray.