### PR TITLE
prometheus-node-exporter-lua: update netstat

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
 PKG_VERSION:=2020.12.07
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/netstat.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/netstat.lua
@@ -10,8 +10,6 @@ local netsubstat = {
 }
 
 local function scrape()
-  -- NOTE: Both of these are missing in OpenWRT kernels.
-  --       See: https://dev.openwrt.org/ticket/15781
   local netstat = get_contents("/proc/net/netstat") .. get_contents("/proc/net/snmp")
 
   -- all devices


### PR DESCRIPTION
The snmp and netstat interface are enabled by default
See: 4943bc5cff47a482c3010033e04c6d489a4b733c

Maintainer: @champtar
Compile tested: tbd
Run tested: tbd