### PR TITLE
libgpg-error: fix build error on macOS

### DIFF
--- a/libs/libgpg-error/Makefile
+++ b/libs/libgpg-error/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgpg-error
 PKG_VERSION:=1.39
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://mirrors.dotsrc.org/gcrypt/libgpg-error \

--- a/libs/libgpg-error/patches/010-add-arc-support.patch
+++ b/libs/libgpg-error/patches/010-add-arc-support.patch
@@ -26,8 +26,6 @@ Signed-off-by: Alexey Brodkin <abrodkin at synopsys.com>
  2 files changed, 24 insertions(+)
  create mode 100644 src/syscfg/lock-obj-pub.arc-unknown-linux-gnu.h
 
-diff --git a/src/Makefile.am b/src/Makefile.am
-index 380ea7c09c04..bd00961c2f27 100644
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
 @@ -48,6 +48,7 @@ lock_obj_pub = \
@@ -38,9 +36,6 @@ index 380ea7c09c04..bd00961c2f27 100644
          syscfg/lock-obj-pub.arm-unknown-linux-androideabi.h \
          syscfg/lock-obj-pub.arm-unknown-linux-gnueabi.h     \
  	syscfg/lock-obj-pub.arm-apple-darwin.h              \
-diff --git a/src/syscfg/lock-obj-pub.arc-unknown-linux-gnu.h b/src/syscfg/lock-obj-pub.arc-unknown-linux-gnu.h
-new file mode 100644
-index 000000000000..3b1a8fadf8a7
 --- /dev/null
 +++ b/src/syscfg/lock-obj-pub.arc-unknown-linux-gnu.h
 @@ -0,0 +1,23 @@
@@ -67,5 +62,3 @@ index 000000000000..3b1a8fadf8a7
 +## buffer-read-only: t
 +## End:
 +##
--- 
-2.17.1

--- a/libs/libgpg-error/patches/011-macos-compile-fix.patch
+++ b/libs/libgpg-error/patches/011-macos-compile-fix.patch
@@ -1,0 +1,24 @@
+--- a/src/gen-lock-obj.sh
++++ b/src/gen-lock-obj.sh
+@@ -84,17 +84,16 @@ EOF
+ #     USE_LONG_DOUBLE_FOR_ALIGNMENT
+ #
+ 
+-echo -n "#define GPGRT_LOCK_INITIALIZER {$LOCK_ABI_VERSION,{{"
++printf "#define GPGRT_LOCK_INITIALIZER {$LOCK_ABI_VERSION,{{"
+ 
+ i=0
+ while test "$i" -lt $ac_mtx_size; do
+     if test "$i" -ne 0 -a "$(( $i % 8 ))" -eq 0; then
+-        echo ' \'
+-        echo -n "                                    "
++        printf " %s\n                                    " "\\"
+     fi
+-    echo -n '0'
++    printf '0'
+     if test "$i" -lt $(($ac_mtx_size - 1)); then
+-        echo -n ','
++        printf ','
+     fi
+     i=$(( i + 1 ))
+ done


### PR DESCRIPTION
libgpg-error 1.39 does not compile on macOS, because src/gen-lock-obj.sh runs in /bin/sh, which does not support echo -n, and generates garbage. Since /bin/sh is an absolute path on a read-only file-system, it is not possible to replace the binary or adjust the PATH. Resolved by switching to /bin/dash.

Maintainer: @flyn-org
Compile tested: macOS 11.1, Ubuntu 20.04 LTS
Run tested: arm9 mvebu, WRT3200ACM, OpenWrt SNAPSHOT r14965+644-3f1109bf2a
