### PR TITLE
hwdata 0.343: fix build error on macOS

### DIFF
--- a/utils/hwdata/Makefile
+++ b/utils/hwdata/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hwdata
 PKG_VERSION:=0.343
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/vcrhonek/hwdata/tar.gz/v$(PKG_VERSION)?
@@ -16,9 +16,6 @@ PKG_HASH:=ccb4d21337b3773cc02654b360e91feb44c9258728d2f027b72013bd5628113b
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0-or-later  XFree86-1.0
 PKG_LICENSE_FILES:=LICENSE
-
-PKG_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -38,12 +35,12 @@ endef
 
 define Package/pciids/install
 	$(INSTALL_DIR) $(1)/usr/share/hwdata
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/hwdata/pci.ids $(1)/usr/share/hwdata
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/pci.ids $(1)/usr/share/hwdata
 endef
 
 define Package/usbids/install
 	$(INSTALL_DIR) $(1)/usr/share/hwdata
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/hwdata/usb.ids $(1)/usr/share/hwdata
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/usb.ids $(1)/usr/share/hwdata
 endef
 
 $(eval $(call BuildPackage,pciids))


### PR DESCRIPTION
The install command on macOS does not support the -T flag.
Resolved by omitting the -T flag  when building on macOS.

Maintainer: @vcrhonek, @zpc0
Compile tested: macOS 11.1, Ubuntu 20.04 LTS
Run tested: arm9 mvebu, WRT3200ACM, OpenWrt SNAPSHOT r14965+644-3f1109bf2a
