### PR TITLE
mini_snmpd: Fix minor nit in the init script

### DIFF
--- a/net/mini_snmpd/Makefile
+++ b/net/mini_snmpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mini_snmpd
 PKG_VERSION:=1.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Marcin Jurkowski <marcin1j@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING

--- a/net/mini_snmpd/files/mini_snmpd.init
+++ b/net/mini_snmpd/files/mini_snmpd.init
@@ -77,7 +77,7 @@ append_interface() {
 	[ -z $netdev_count ] && netdev_count=0
 	# for the purposes of snmp monitoring it doesn't need to be up, it just needs to exist in /proc/net/dev
 	network_get_device netdev "$name"
-	if [ -n "$netdev" ] && grep -qF "$netdev" /proc/net/dev ]; then
+	if [ -n "$netdev" ] && grep -qF "$netdev" /proc/net/dev; then
 		[ $netdev_count -ge 8 ] && {
 			_err "$cfg: too many network interfaces configured, ignoring $name"
 			return


### PR DESCRIPTION
Maintainer: @marcin1j
Compile tested: none (shell script)
Run tested: "/etc/init.d/mini_snmpd restart" on an OpenWRT 19.07.6 device

Description:
This removes extra ] from grep invocation in append_interface().