### PR TITLE
snort3: fix alert_syslog

### DIFF
--- a/libs/libdaq3/Makefile
+++ b/libs/libdaq3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdaq3
-PKG_VERSION:=3.0.0
-PKG_RELEASE:=2
+PKG_VERSION:=3.0.3
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=libdaq-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.snort.org/downloads/snortplus/
-PKG_HASH:=4de807ab8c622e9ef8e0cfaa8dbd9231ece17d14dc9ebaa63add800475347b99
+PKG_HASH:=920344f5c98ac68b401d1bc92ebaed78b0d15779b0480c213db279d0a60acc32
 PKG_BUILD_DIR:=$(BUILD_DIR)/libdaq-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-2.0-only

--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
-PKG_VERSION:=3.1.0.0
-PKG_RELEASE:=2
+PKG_VERSION:=3.1.4.0
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.snort.org/downloads/snortplus/
-PKG_HASH:=c4e2e78e3afa879d7e35e482afe42a6c4b96ed26198a9979edf7953b5151ccbf
+PKG_HASH:=a68af8ea46a038dfb0ad489e8d11dee62a3e63cb4a639f6bb4fac4ded955fe11
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64
Run tested: x86_64

Description:
Snort 3.1.0.0 contains a bug that causes snort to crash when loading the syslog alert module. This adds a patch that fixes this bug. The package maintainer submitted the patch to the upstream snort project.