### PR TITLE
antfs: patch for linux >= 5.8.0

### DIFF
--- a/kernel/antfs/Makefile
+++ b/kernel/antfs/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=antfs
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://github.com/klukonin/antfs.git
 PKG_SOURCE_PROTO:=git

--- a/kernel/antfs/patches/0001-file.c-Patch-for-Linux-v5.8.patch
+++ b/kernel/antfs/patches/0001-file.c-Patch-for-Linux-v5.8.patch
@@ -1,0 +1,47 @@
+diff --git a/file.c b/file.c
+index 105e41c..98d5204 100644
+--- a/file.c
++++ b/file.c
+@@ -625,6 +625,9 @@ static int antfs_readpages(struct file *file, struct address_space *mapping,
+ 		unsigned page_idx = nr_pages;
+ 		pgoff_t page_idx_to_init;
+ 		bool do_init_page = false;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
++		DEFINE_READAHEAD(rac, file, mapping, 0);
++#endif
+ 
+ 		if (page_offs & (buffer_len - 1)) {
+ 			/* If initialized size is not on buffer boundary, walk
+@@ -660,8 +663,13 @@ static int antfs_readpages(struct file *file, struct address_space *mapping,
+ 			}
+ 		}
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
++		mpage_readahead(&rac, antfs_get_block);
++		err = 0;
++#else
+ 		err = mpage_readpages(mapping, pages, nr_pages,
+ 				antfs_get_block);
++#endif
+ 		if (!err && do_init_page) {
+ 			/* Initialize stuff past initialized_size with zero. */
+ 			page = grab_cache_page(mapping, page_idx_to_init);
+diff --git a/libntfs-3g/misc.c b/libntfs-3g/misc.c
+index b3ec53a..c5a94de 100644
+--- a/libntfs-3g/misc.c
++++ b/libntfs-3g/misc.c
+@@ -38,7 +38,11 @@ void *ntfs_malloc(size_t size)
+ 		return kmalloc(size, GFP_KERNEL);
+ 	}
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
++	return __vmalloc(size, GFP_KERNEL);
++#else
+ 	return __vmalloc(size, GFP_KERNEL, PAGE_KERNEL);
++#endif
+ }
+ 
+ /**
+-- 
+2.30.0
+


### PR DESCRIPTION
Signed-off-by: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>

Maintainer: @neheb @dengqf6 
Compile tested: mt7621, linux 5.10