### PR TITLE
lighttpd: update to lighttpd 1.4.59 release hash

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
-PKG_VERSION:=1.4.58
+PKG_VERSION:=1.4.59
 PKG_RELEASE:=1
 # release candidate ~rcX testing; remove for release
-#PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-1.4.58
+#PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-1.4.59
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x
-PKG_HASH:=267feffda13a190ebdce7b15172d8be16da98008457f30fddecd72832d126d0e
+PKG_HASH:=fb953db273daef08edb6e202556cae8a3d07eed6081c96bd9903db957d1084d5
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=BSD-3-Clause
@@ -104,7 +104,8 @@ MESON_ARGS += \
 	-Dwith_webdav_props=$(if $(CONFIG_PACKAGE_lighttpd-mod-webdav),true,false) \
 	-Dwith_wolfssl=$(if $(CONFIG_PACKAGE_lighttpd-mod-wolfssl),true,false) \
 	-Dwith_xattr=false \
-	-Dwith_zlib=$(if $(CONFIG_PACKAGE_lighttpd-mod-deflate),true,false)
+	-Dwith_zlib=$(if $(CONFIG_PACKAGE_lighttpd-mod-deflate),true,false) \
+	-Dwith_zstd=false
 
 BASE_MODULES:=dirlisting indexfile staticfile
 
@@ -184,6 +185,7 @@ $(eval $(call BuildPlugin,authn_sasl,SASL-based authentication,lighttpd-mod-auth
 # Finally, everything else.
 $(eval $(call BuildPlugin,access,Access restrictions,,30))
 $(eval $(call BuildPlugin,accesslog,Access logging,,30))
+$(eval $(call BuildPlugin,ajp13,AJP13 Tomcat connector,,30))
 $(eval $(call BuildPlugin,alias,Directory alias,,30))
 $(eval $(call BuildPlugin,cgi,CGI,,30))
 $(eval $(call BuildPlugin,cml,Cache Meta Language,+PACKAGE_lighttpd-mod-cml:liblua +PACKAGE_lighttpd-mod-cml:libnettle,30))

--- a/net/lighttpd/patches/020-meson-zstd.patch
+++ b/net/lighttpd/patches/020-meson-zstd.patch
@@ -1,0 +1,29 @@
+From a737572aa4b7a50fd9ac3f54245e40fd5cd2609d Mon Sep 17 00:00:00 2001
+From: Glenn Strauss <gstrauss@gluelogic.com>
+Date: Wed, 3 Feb 2021 00:35:34 -0500
+Subject: [PATCH] [meson] add with_zstd to meson_options.txt
+
+Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
+---
+ meson_options.txt | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/meson_options.txt b/meson_options.txt
+index 51bea44d..f6687159 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -148,6 +148,11 @@ option('with_zlib',
+ 	value: true,
+ 	description: 'with deflate-support for mod_deflate [default: on]',
+ )
++option('with_zstd',
++	type: 'boolean',
++	value: false,
++	description: 'with zstd-support for mod_deflate [default: off]',
++)
+ 
+ option('build_extra_warnings',
+ 	type: 'boolean',
+-- 
+2.29.2
+


### PR DESCRIPTION
Maintainer: W. Michael Petullo mike@flyn.org
Compile tested: i386 OpenWrt master

Description:
update to lighttpd 1.4.59 release hash
add new base module mod_ajp13

Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>