### PR TITLE
stress-ng: bump to version 0.12.02

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.12.01
-PKG_RELEASE:=2
+PKG_VERSION:=0.12.02
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://kernel.ubuntu.com/~cking/tarballs/stress-ng
-PKG_HASH:=d354bbbb1500cfe043c761014dc9c3f62779747fafea8a19af94402327f6d3fc
+PKG_HASH:=f847be115f60d3ad7d37c806fd1bfb1412aa3c631fca581d6dc233322f50d6a5
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/84fa59b5a80f8522239755d75d7ae51855c47fd2
Run tested: x86 https://github.com/openwrt/openwrt/commit/84fa59b5a80f8522239755d75d7ae51855c47fd2


Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>
