### PR TITLE
iputils: bump to 20210202 and fix version reporting

### DIFF
--- a/net/iputils/Makefile
+++ b/net/iputils/Makefile
@@ -9,13 +9,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iputils
-PKG_VERSION:=20200821
+PKG_VERSION:=20210202
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/iputils/iputils/tar.gz/s$(PKG_VERSION)?
-PKG_HASH:=f265da0d02dd2259efd8c57a9c2e0c8bb3361abb14639fcffb26707be5783a5b
-PKG_BUILD_DIR:=$(BUILD_DIR)/iputils-s$(PKG_VERSION)
+PKG_SOURCE_URL:=https://codeload.github.com/iputils/iputils/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=3f557ecfd2ace873801231d2c1f42de73ced9fbc1ef3a438d847688b5fb0e8ab
+PKG_BUILD_DIR:=$(BUILD_DIR)/iputils-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
 PKG_LICENSE:=BSD-3-Clause
@@ -141,8 +141,8 @@ define Package/iputils-tftpd/description
 endef
 
 define Package/iputils-tftpd/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin//tftpd $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/tftpd $(1)/usr/sbin/
 endef
 
 $(eval $(call BuildPackage,iputils-ping))

--- a/net/iputils/patches/001_version_fix.patch
+++ b/net/iputils/patches/001_version_fix.patch
@@ -1,0 +1,24 @@
+Description: set a static version string rather than discern it from git
+--- a/meson.build
++++ b/meson.build
+@@ -17,6 +17,7 @@ add_project_arguments(
+ 
+ conf = configuration_data()
+ conf.set_quoted('PACKAGE_NAME', meson.project_name())
++conf.set('VCS_TAG', meson.project_version())
+ conf.set('_GNU_SOURCE', 1, description : 'Enable GNU extensions on systems that have them.')
+ 
+ build_arping = get_option('BUILD_ARPING')
+@@ -207,10 +208,10 @@ foreach h : [
+ 	endif
+ endforeach
+ 
+-git_version_h = vcs_tag(
++git_version_h = configure_file(
+ 	input : 'git-version.h.meson',
+ 	output : 'git-version.h',
+-	fallback : meson.project_version()
++	configuration: conf
+ )
+ 
+ config_h = configure_file(


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu x86_64
Run tested: mvebu

Description:
Updates to the latest upstream release.
Move `tftpd` binary from /usr/bin to /usr/sbin per upstream change.

Fix `-V` (version) output issue described in #13920 

ping -V would previously report funny versions, e.g.
```
root@gw:/# ping -V
ping from iputils reboot-15620-g7b63d89b52
```
With this fix, it reports the correct value:
```
root@gw:/# ping -V
ping from iputils 20210202
```