### PR TITLE
xray-core: add example configs and init script

### DIFF
--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -40,10 +40,18 @@ define Package/xray-core
   PROVIDES:=v2ray-core
 endef
 
+define Package/xray-example
+  $(call Package/xray/template)
+  TITLE+= (example configs)
+  DEPENDS:=xray-core
+  PKGARCH:=all
+endef
+
 define Package/xray-geodata
   $(call Package/xray/template)
   TITLE+= (geodata files)
   DEPENDS:=xray-core
+  PKGARCH:=all
 endef
 
 define Package/xray/description
@@ -53,6 +61,12 @@ endef
 
 define Package/xray-core/description
   $(call Package/xray/description)
+endef
+
+define Package/xray-example/description
+  $(call Package/xray/description)
+
+  This includes example configuration files for xray-core.
 endef
 
 define Package/xray-geodata/description
@@ -97,6 +111,12 @@ define Package/xray-core/install
 	$(LN) xray $(1)/usr/bin/v2ray
 endef
 
+define Package/xray-example/install
+	$(INSTALL_DIR) $(1)/etc/xray/
+	$(INSTALL_CONF) $(CURDIR)/files/vpoint_socks_vmess.json $(1)/etc/xray/
+	$(INSTALL_CONF) $(CURDIR)/files/vpoint_vmess_freedom.json $(1)/etc/xray/
+endef
+
 define Package/xray-geodata/install
 	$(INSTALL_DIR) $(1)/usr/share/xray/
 	$(INSTALL_DATA) $(DL_DIR)/$(GEOIP_FILE) $(1)/usr/share/xray/geoip.dat
@@ -104,4 +124,5 @@ define Package/xray-geodata/install
 endef
 
 $(eval $(call BuildPackage,xray-core))
+$(eval $(call BuildPackage,xray-example))
 $(eval $(call BuildPackage,xray-geodata))

--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -75,6 +75,11 @@ define Package/xray-geodata/description
   This includes GEO datas used for xray-core.
 endef
 
+define Package/xray-core/conffiles
+/etc/xray/
+/etc/config/xray
+endef
+
 GEOIP_VER:=202101280019
 GEOIP_FILE:=geoip.dat.$(GEOIP_VER)
 
@@ -105,10 +110,20 @@ endef
 
 define Package/xray-core/install
 	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
-
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/main $(1)/usr/bin/xray
 	$(LN) xray $(1)/usr/bin/v2ray
+
+	$(INSTALL_DIR) $(1)/etc/xray/
+	$(INSTALL_CONF) $(CURDIR)/files/config.json.example $(1)/etc/xray/
+
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_CONF) $(CURDIR)/files/xray.conf $(1)/etc/config/xray
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) $(CURDIR)/files/xray.init $(1)/etc/init.d/xray
+
+	$(INSTALL_DIR) $(1)/etc/capabilities/
+	$(INSTALL_DATA) $(CURDIR)/files/xray.capabilities $(1)/etc/capabilities/xray.json
 endef
 
 define Package/xray-example/install

--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -2,10 +2,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-core
 PKG_VERSION:=1.2.4
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/XTLS/xray-core/tar.gz/v$(PKG_VERSION)?
+PKG_SOURCE_URL:=https://codeload.github.com/XTLS/Xray-core/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=25f6c9edec0ac1f98328943cd2bb760ac7b69107582f9d27e43559da39dc01ed
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@project-openwrt.eu.org>
@@ -31,7 +31,7 @@ define Package/xray/template
   TITLE:=A platform for building proxies to bypass network restrictions
   SECTION:=net
   CATEGORY:=Network
-  URL:=https://xtls.github.io
+  URL:=https://xray.sh
 endef
 
 define Package/xray-core

--- a/net/xray-core/files/config.json.example
+++ b/net/xray-core/files/config.json.example
@@ -1,0 +1,144 @@
+// Config file of Xray. This file follows standard JSON format, with comments support.
+// Uncomment entries below to satisfy your needs. Also read our manual for more detail at
+// https://www.v2fly.org/en_US/config/overview.html and https://xray.sh/en/config/
+{
+  "log": {
+    // By default, Xray writes access log to stdout.
+    // "access": "/path/to/access/log/file",
+
+    // By default, Xray write error log to stdout.
+    // "error": "/path/to/error/log/file",
+
+    // Log level, one of "debug", "info", "warning", "error", "none"
+    "loglevel": "warning"
+  },
+  // List of inbound proxy configurations.
+  "inbounds": [{
+    // Port to listen on. You may need root access if the value is less than 1024.
+    "port": 1080,
+
+    // IP address to listen on. Change to "0.0.0.0" to listen on all network interfaces.
+    "listen": "127.0.0.1",
+
+    // Tag of the inbound proxy. May be used for routing.
+    "tag": "socks-inbound",
+
+    // Protocol name of inbound proxy.
+    "protocol": "socks",
+
+    // Settings of the protocol. Varies based on protocol.
+    "settings": {
+      "auth": "noauth",
+      "udp": false,
+      "ip": "127.0.0.1"
+    },
+
+    // Enable sniffing on TCP connection.
+    "sniffing": {
+      "enabled": true,
+      // Target domain will be overriden to the one carried by the connection, if the connection is HTTP or HTTPS.
+      "destOverride": ["http", "tls"]
+    }
+  }],
+  // List of outbound proxy configurations.
+  "outbounds": [{
+    // Protocol name of the outbound proxy.
+    "protocol": "freedom",
+
+    // Settings of the protocol. Varies based on protocol.
+    "settings": {},
+
+    // Tag of the outbound. May be used for routing.
+    "tag": "direct"
+  },{
+    "protocol": "blackhole",
+    "settings": {},
+    "tag": "blocked"
+  }],
+
+  // Transport is for global transport settings. If you have multiple transports with same settings
+  // (say mKCP), you may put it here, instead of in each individual inbound/outbounds.
+  //"transport": {},
+
+  // Routing controls how traffic from inbounds are sent to outbounds.
+  "routing": {
+    "domainStrategy": "IPOnDemand",
+    "rules":[
+      {
+        // Blocks access to private IPs. Remove this if you want to access your router.
+        "type": "field",
+        "ip": ["geoip:private"],
+        "outboundTag": "blocked"
+      },
+      {
+        // Blocks major ads.
+        "type": "field",
+        "domain": ["geosite:category-ads"],
+        "outboundTag": "blocked"
+      }
+    ]
+  },
+
+  // Dns settings for domain resolution.
+  "dns": {
+    // Static hosts, similar to hosts file.
+    "hosts": {
+      // Match v2ray.com to another domain on CloudFlare. This domain will be used when querying IPs for v2ray.com.
+      "domain:v2ray.com": "www.vicemc.net",
+
+      // The following settings help to eliminate DNS poisoning in mainland China.
+      // It is safe to comment these out if this is not the case for you.
+      "domain:github.io": "pages.github.com",
+      "domain:wikipedia.org": "www.wikimedia.org",
+      "domain:shadowsocks.org": "electronicsrealm.com"
+    },
+    "servers": [
+      "1.1.1.1",
+      {
+        "address": "114.114.114.114",
+        "port": 53,
+        // List of domains that use this DNS first.
+        "domains": [
+          "geosite:cn"
+        ]
+      },
+      "8.8.8.8",
+      "localhost"
+    ]
+  },
+
+  // Policy controls some internal behavior of how Xray handles connections.
+  // It may be on connection level by user levels in 'levels', or global settings in 'system.'
+  "policy": {
+    // Connection policys by user levels
+    "levels": {
+      "0": {
+        "uplinkOnly": 0,
+        "downlinkOnly": 0
+      }
+    },
+    "system": {
+      "statsInboundUplink": false,
+      "statsInboundDownlink": false,
+      "statsOutboundUplink": false,
+      "statsOutboundDownlink": false
+    }
+  },
+
+  // Stats enables internal stats counter.
+  // This setting can be used together with Policy and Api.
+  //"stats":{},
+
+  // Api enables gRPC APIs for external programs to communicate with Xray instance.
+  //"api": {
+    //"tag": "api",
+    //"services": [
+    //  "HandlerService",
+    //  "LoggerService",
+    //  "StatsService"
+    //]
+  //},
+
+  // You may add other entries to the configuration, but they will not be recognized by Xray.
+  "other": {}
+}

--- a/net/xray-core/files/vpoint_socks_vmess.json
+++ b/net/xray-core/files/vpoint_socks_vmess.json
@@ -1,0 +1,25 @@
+{
+  "log": {
+    "loglevel": "warning"
+  },
+  "inbounds": [{
+    "port": 1080,
+    "listen": "127.0.0.1",
+    "protocol": "socks",
+    "settings": {
+      "auth": "noauth",
+      "udp": false,
+      "ip": "127.0.0.1"
+    }
+  }],
+  "outbounds": [{
+    "protocol": "freedom",
+    "settings": {},
+    "tag": "direct"
+  }],
+  "policy": {
+    "levels": {
+      "0": {"uplinkOnly": 0}
+    }
+  }
+}

--- a/net/xray-core/files/vpoint_vmess_freedom.json
+++ b/net/xray-core/files/vpoint_vmess_freedom.json
@@ -1,0 +1,32 @@
+{
+  "inbounds": [{
+    "port": 10086,
+    "protocol": "vmess",
+    "settings": {
+      "clients": [
+        {
+          "id": "23ad6b10-8d1a-40f7-8ad0-e3e35cd38297",
+          "level": 1,
+          "alterId": 64
+        }
+      ]
+    }
+  }],
+  "outbounds": [{
+    "protocol": "freedom",
+    "settings": {}
+  },{
+    "protocol": "blackhole",
+    "settings": {},
+    "tag": "blocked"
+  }],
+  "routing": {
+    "rules": [
+      {
+        "type": "field",
+        "ip": ["geoip:private"],
+        "outboundTag": "blocked"
+      }
+    ]
+  }
+}

--- a/net/xray-core/files/xray.capabilities
+++ b/net/xray-core/files/xray.capabilities
@@ -1,0 +1,10 @@
+{
+	"ambient": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_BIND_SERVICE"
+	],
+	"bounding": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_BIND_SERVICE"
+	]
+}

--- a/net/xray-core/files/xray.conf
+++ b/net/xray-core/files/xray.conf
@@ -1,0 +1,10 @@
+
+config xray 'enabled'
+	option enabled '0'
+
+config xray 'config'
+	option confdir '/etc/xray'
+	list conffiles '/etc/xray/config.json'
+	option datadir '/usr/share/xray'
+	option format 'json'
+

--- a/net/xray-core/files/xray.init
+++ b/net/xray-core/files/xray.init
@@ -1,0 +1,51 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=99
+
+CONF="xray"
+PROG="/usr/bin/xray"
+CAPA_FILE="/etc/capabilities/xray.json"
+
+start_instance() {
+	config_load "$CONF"
+
+	local enabled
+	config_get enabled "enabled" "enabled" "0"
+	[ "$enabled" -eq "0" ] && exit 1
+
+	local confdir
+	local conffiles
+	local datadir
+	local format
+
+	config_get confdir "config" "confdir"
+	config_get conffiles "config" "conffiles"
+	config_get datadir "config" "datadir" "/usr/share/xray"
+	config_get format "config" "format" "json"
+
+	procd_open_instance
+	procd_set_param command "$PROG" run
+	[ -n "$confdir" ] && procd_append_param command -confdir "$confdir"
+	[ -n "$conffiles" ] && {
+		for i in $conffiles
+		do
+			procd_append_param command -config "$i"
+		done
+	}
+	procd_append_param command -format "$format"
+	procd_set_param env XRAY_LOCATION_ASSET="$datadir"
+	procd_set_param file $conffiles
+
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn
+
+	[ -x "/sbin/ujail" -a -e "$CAPA_FILE" ] && {
+		procd_add_jail xray
+		procd_set_param capabilities "$CAPA_FILE"
+		procd_set_param user nobody
+		procd_set_param no_new_privs 1
+	}
+	procd_close_instance
+}


### PR DESCRIPTION
Maintainer: me

Description:
1. Add example conffiles from v2fly/v2ray-core wikis.
2. Add init script so the users could run it with their configs quickly.