### PR TITLE
prometheus-node-exporter-lua: fix wifi

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2021.01.27
+PKG_VERSION:=2021.02.15
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/hostapd_stations.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/hostapd_stations.lua
@@ -6,9 +6,9 @@ local function get_wifi_interfaces()
   local status = u:call("network.wireless", "status", {})
   local interfaces = {}
 
-  for dev, dev_table in pairs(status) do
+  for _, dev_table in pairs(status) do
     for _, intf in ipairs(dev_table['interfaces']) do
-      table.insert(interfaces, intf['config']['ifname'])
+      table.insert(interfaces, intf['ifname'])
     end
   end
 


### PR DESCRIPTION
The "get_wifi_interfaces" function is not returning the wifi interface names. This causes the bug #14625.

Fix the "get_wifi_interfaces" function.
