### PR TITLE
xray-core: fix service start / reload

### DIFF
--- a/net/xray-core/files/xray.init
+++ b/net/xray-core/files/xray.init
@@ -7,7 +7,7 @@ CONF="xray"
 PROG="/usr/bin/xray"
 CAPA_FILE="/etc/capabilities/xray.json"
 
-start_instance() {
+start_service() {
 	config_load "$CONF"
 
 	local enabled
@@ -24,7 +24,7 @@ start_instance() {
 	config_get datadir "config" "datadir" "/usr/share/xray"
 	config_get format "config" "format" "json"
 
-	procd_open_instance
+	procd_open_instance "$CONF"
 	procd_set_param command "$PROG" run
 	[ -n "$confdir" ] && procd_append_param command -confdir "$confdir"
 	[ -n "$conffiles" ] && {
@@ -42,10 +42,19 @@ start_instance() {
 	procd_set_param respawn
 
 	[ -x "/sbin/ujail" -a -e "$CAPA_FILE" ] && {
-		procd_add_jail xray
+		procd_add_jail "$CONF"
 		procd_set_param capabilities "$CAPA_FILE"
 		procd_set_param user nobody
 		procd_set_param no_new_privs 1
 	}
 	procd_close_instance
+}
+
+reload_service() {
+	stop
+	start
+}
+
+service_triggers() {
+	procd_add_reload_trigger "$CONF"
 }


### PR DESCRIPTION
Maintainer: me

Description:

Fix starting problem:
Starting function should be named 'start_service' instead of 'start_instance'.

Fix reloading problem:
Register reload tigger for uci config itself.
And, xray does not support reload currently, so use legacy restart as reload.

Fixes: 6c9b96352fb5e7d6acdf8f14ea4f9251cd09926b ("xray-core: add init script")