### PR TITLE
lang/php7: Don't run phpize7 with QUILT

### DIFF
--- a/lang/php7/pecl.mk
+++ b/lang/php7/pecl.mk
@@ -13,7 +13,7 @@ endef
 
 define Build/Prepare
 	$(Build/Prepare/Default)
-	( cd $(PKG_BUILD_DIR); $(STAGING_DIR)/usr/bin/phpize7 )
+	$(if $(QUILT),,( cd $(PKG_BUILD_DIR); $(STAGING_DIR)/usr/bin/phpize7 ))
 endef
 
 CONFIGURE_VARS+= \


### PR DESCRIPTION
Allows targets such as prepare, refresh, or update to be run without
building dependencies for easier patch maintenance.

Signed-off-by: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>

Maintainer: @mhei 

