### PR TITLE
svox: Don't move files with QUILT

### DIFF
--- a/sound/svox/Makefile
+++ b/sound/svox/Makefile
@@ -46,7 +46,9 @@ endef
 
 define Build/Prepare
 	$(call Build/Prepare/Default)
+ifeq ($(QUILT),)
 	mv $(PKG_BUILD_DIR)/pico/* $(PKG_BUILD_DIR)
+endif
 endef
 
 define Package/svox/install


### PR DESCRIPTION
Allows targets such as prepare, refresh, or update to be run without
building dependencies for easier patch maintenance.

Signed-off-by: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>

Maintainer: @neheb 