### PR TITLE
miniupnpd: introduce IGDv1 variant

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -26,7 +26,7 @@ PKG_BUILD_PARALLEL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/version.mk
 
-define Package/miniupnpd
+define Package/miniupnpd/Default
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=+iptables +libip4tc +IPV6:libip6tc +IPV6:ip6tables +libuuid +libcap-ng
@@ -35,9 +35,25 @@ define Package/miniupnpd
   URL:=https://miniupnp.tuxfamily.org/
 endef
 
+define Package/miniupnpd
+  $(call Package/miniupnpd/Default)
+  TITLE+= (IGDv2)
+  CONFLICTS:=miniupnpd-igdv1
+  VARIANT:=igdv2
+endef
+
+define Package/miniupnpd-igdv1
+  $(call Package/miniupnpd/Default)
+  TITLE+= (IGDv1)
+  PROVIDES:=miniupnpd
+  VARIANT:=igdv1
+endef
+
 define Package/miniupnpd/conffiles
 /etc/config/upnpd
 endef
+
+Package/miniupnpd-igdv1/conffiles = $(Package/miniupnpd/conffiles)
 
 define Build/Prepare
 	$(call Build/Prepare/Default)
@@ -46,11 +62,14 @@ endef
 
 CONFIGURE_ARGS = \
 	$(if $(CONFIG_IPV6),--ipv6) \
-	--igd2 \
 	--leasefile \
 	--portinuse \
 	--firewall=iptables \
 	--disable-fork
+
+ifeq ($(BUILD_VARIANT),igdv2)
+	CONFIGURE_ARGS += --igd2
+endif
 
 TARGET_CFLAGS += $(FPIC) -flto
 TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
@@ -71,4 +90,7 @@ define Package/miniupnpd/install
 	$(INSTALL_DATA) ./files/firewall.include $(1)/usr/share/miniupnpd/firewall.include
 endef
 
+Package/miniupnpd-igdv1/install = $(Package/miniupnpd/install)
+
 $(eval $(call BuildPackage,miniupnpd))
+$(eval $(call BuildPackage,miniupnpd-igdv1))


### PR DESCRIPTION
Microsoft Windows, Xbox and possibly other operating systems do not
support IGDv2. With IGDv2 enabled, they send a HTTP GET request for
rootDesc.xml and WANIPCn.xml, and then nothing happens. The Microsoft
implementation probably doesn't like the WANIPCn.xml response and
decides UPnP is not available. When miniupnpd is built without IGDv2
support, after the 2 HTTP GET requests, there is a HTTP POST request to
/ctl/IPConn, and miniupnpd configures the port forward as expected.

The runtime option force_igd_desc_v1=yes (UCI: igvd1) does not solve
this problem. It's possible this was enough in earlier miniupnpd
versions, but it does not fix the problem the current version.

Since we are a modern distro, we want to support the latest and
greatest, so we should default to IGDv2 enabled. Introducing a
menuconfig option to disable IGDv2 would only help people who build
their own images, so offer a separate package variant for IGDv1.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>

Maintainer: NA
Compile tested: x86/64, apu2, master r15679-43ff6e641e
Run tested: x86/64, apu2, master r15679-43ff6e641e, tested UPnP with xbox series x
