### PR TITLE
php8: fix cross-compiling for x86_64

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -466,6 +466,9 @@ CONFIGURE_VARS+= \
 	ac_cv_u8t_decompose=yes \
 	ac_cv_have_pcre2_jit=no
 
+MAKE_VARS+= \
+	HOSTCC="$(HOSTCC)"
+
 define Package/php8/conffiles
 /etc/php.ini
 /etc/php8/

--- a/lang/php8/patches/1010-Fix-opcache-jit-minilua-compiling.patch
+++ b/lang/php8/patches/1010-Fix-opcache-jit-minilua-compiling.patch
@@ -1,0 +1,25 @@
+From 73ea1d44c1e6b063bfa02e12919ec8a9de3709d8 Mon Sep 17 00:00:00 2001
+From: Michael Heimpold <mhei@heimpold.de>
+Date: Wed, 3 Feb 2021 22:51:34 +0100
+Subject: [PATCH] Fix opcache jit minilua compiling
+
+Signed-off-by: Michael Heimpold <mhei@heimpold.de>
+---
+ ext/opcache/jit/Makefile.frag | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ext/opcache/jit/Makefile.frag b/ext/opcache/jit/Makefile.frag
+index d4f97de..7421897 100644
+--- a/ext/opcache/jit/Makefile.frag
++++ b/ext/opcache/jit/Makefile.frag
+@@ -1,6 +1,6 @@
+ 
+ $(builddir)/minilua: $(srcdir)/jit/dynasm/minilua.c
+-	$(CC) $(srcdir)/jit/dynasm/minilua.c -lm -o $@
++	$(HOSTCC) $(srcdir)/jit/dynasm/minilua.c -lm -o $@
+ 
+ $(builddir)/jit/zend_jit_x86.c: $(srcdir)/jit/zend_jit_x86.dasc $(srcdir)/jit/dynasm/*.lua $(builddir)/minilua
+ 	$(builddir)/minilua $(srcdir)/jit/dynasm/dynasm.lua  $(DASM_FLAGS) -o $@ $(srcdir)/jit/zend_jit_x86.dasc
+-- 
+2.17.1
+


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs, x86_64
Run tested: x86_64

Description:

The build process uses a minilua helper for code generation
which must not be compiled with target cross-compiler but
the host compiler.

This error was spotted by buildbots:
ext/opcache/minilua /builder/shared-workdir/build/sdk/build_dir/
 target-x86_64_musl/php-8.0.1/ext/opcache/jit/dynasm/dynasm.lua
 -D X64=1 -o ext/opcache/jit/zend_jit_x86.c /builder/shared-workdir
 /build/sdk/build_dir/target-x86_64_musl/php-8.0.1/ext/opcache/jit/zend_jit_x86.dasc
/bin/bash: ext/opcache/minilua: No such file or directory
Makefile:406: recipe for target 'ext/opcache/jit/zend_jit_x86.c' failed
make[4]: *** [ext/opcache/jit/zend_jit_x86.c] Error 127

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
