### PR TITLE
keepalived: backport fixes

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.0.18
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software

--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.0.18
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software

--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.0.18
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software
@@ -86,7 +86,8 @@ endef
 
 CONFIGURE_ARGS+= \
 	--with-init=SYSV \
-	--disable-nftables
+	--disable-nftables \
+	--with-run-dir="/var/run"
 
 ifeq ($(CONFIG_KEEPALIVED_VRRP),)
 CONFIGURE_ARGS += \

--- a/net/keepalived/files/keepalived.init
+++ b/net/keepalived/files/keepalived.init
@@ -104,6 +104,9 @@ global_defs() {
 	config_get_bool linkbeat_use_polling "$1" linkbeat_use_polling 0
 	[ "$linkbeat_use_polling" -gt 0 ] && printf 'linkbeat_use_polling\n\n' >> "$KEEPALIVED_CONF"
 
+	printf '%bscript_user root\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
+	printf '%benabled_script_security\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
+
 	config_get notification_email "$1" notification_email
 	print_list_indent notification_email
 

--- a/net/keepalived/files/keepalived.init
+++ b/net/keepalived/files/keepalived.init
@@ -105,7 +105,7 @@ global_defs() {
 	[ "$linkbeat_use_polling" -gt 0 ] && printf 'linkbeat_use_polling\n\n' >> "$KEEPALIVED_CONF"
 
 	printf '%bscript_user root\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
-	printf '%benabled_script_security\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
+	printf '%benable_script_security\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
 
 	config_get notification_email "$1" notification_email
 	print_list_indent notification_email


### PR DESCRIPTION
Maintainer: me 
Compile tested: no
Run tested: x86_64, APU3, Service started -> warning disappears.

Description:
@pgaufillet Thank you for pointing this out. That the changes that you suggest to backport to the stable branch openwrt-19.07. The commit https://github.com/openwrt/packages/commit/d41a0b75aac67da9267386bde61c898d37fb3f17 must be checked. It applies proper but due a config change, I think this is not correct. I do not like to backport the uci config also. So please test this and give me a feedback if it works or not and tell me what needs to be changed.

I do not have a running setup on openwrt-19.07 stable branch with keepalived.

Closes #14648

Edit:
I have now tested the configuration change. What I didn't do is recompile the package because I don't have a setup. I assume that this is correct, since the [compile option](https://github.com/openwrt/packages/pull/14661/commits/dee2e818b9b2c6bc6e82b8e040095b908fa49e49) is also set in the master and there is no problem there.