### PR TITLE
zerotier: update to 1.6.3

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
-PKG_VERSION:=1.6.2
-PKG_RELEASE:=2
+PKG_VERSION:=1.6.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=c8087b26c1191d36fda004b42cdfed31042cafd8586e49015586eef786f2c9a5
+PKG_HASH:=437d51a396e65f45822b0e5ee3761e3dfaf3507d9cc8f9b01e09c5541395d7b2
 PKG_BUILD_DIR:=$(BUILD_DIR)/ZeroTierOne-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>


### PR DESCRIPTION
Signed-off-by: Moritz Warning <moritzwarning@web.de>

Maintainer: me
Compile tested: ramips/mt7620, Nexx wt3020, OpenWrt master 
Run tested: Runs and connects to public network.