### PR TITLE
strongswan: avoid duplicate logging

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/ipsec.init
+++ b/net/strongswan/files/ipsec.init
@@ -326,9 +326,6 @@ config_ipsec() {
 	swan_xappend "    daemon {"
 	swan_xappend "      default = $debug"
 	swan_xappend "    }"
-	swan_xappend "    auth {"
-	swan_xappend "      default = $debug"
-	swan_xappend "    }"
 	swan_xappend "  }"
 	swan_xappend "}"
 }


### PR DESCRIPTION
Maintainer: @stintel 
Compile tested: x86_64, generic, head (7d12f29ae1)
Run tested: same, been running this on a production VPN concentrator for months

Description:

Seeing the same logging twice when creating new sessions or authenticating them is confusing.  Authentication is already logged by default, it doesn't need duplication.
