### PR TITLE
strongswan: create /etc/swanctl/conf.d directory

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/
@@ -524,7 +524,7 @@ define Package/strongswan-swanctl/conffiles
 endef
 
 define Package/strongswan-swanctl/install
-	$(INSTALL_DIR) $(1)/etc/swanctl/{bliss,ecdsa,pkcs{12,8},private,pubkey,rsa}
+	$(INSTALL_DIR) $(1)/etc/swanctl/{bliss,conf.d,ecdsa,pkcs{12,8},private,pubkey,rsa}
 	$(INSTALL_DIR) $(1)/etc/swanctl/x509{,aa,ac,ca,crl,ocsp}
 	$(CP) $(PKG_INSTALL_DIR)/etc/swanctl/swanctl.conf $(1)/etc/swanctl/
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
Maintainer: @stintel 
Compile tested: x86_64, generic, head (7d12f29ae1)
Run tested: same, been running this on a production VPN concentrator for months

Description:

`/etc/swanctl/conf.d/` gets read by `swanctl` when invoked with `-q` (or `-c`) but we aren't creating it as part of the packaging.

The last 2 lines of `swanctl.conf` are:

```
# Include config snippets
include conf.d/*.conf
```