### PR TITLE
php8: Don't run phpize8 with QUILT

### DIFF
--- a/lang/php8/pecl.mk
+++ b/lang/php8/pecl.mk
@@ -13,7 +13,7 @@ endef
 
 define Build/Prepare
 	$(Build/Prepare/Default)
-	( cd $(PKG_BUILD_DIR); $(STAGING_DIR)/usr/bin/phpize8 )
+	$(if $(QUILT),,( cd $(PKG_BUILD_DIR); $(STAGING_DIR)/usr/bin/phpize8 ))
 endef
 
 CONFIGURE_VARS+= \


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: -

Description:

Allows targets such as prepare, refresh, or update to be run without
building dependencies for easier patch maintenance.

This is d741a64b7 applied to php8.

Signed-off-by: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
Signed-off-by: Michael Heimpold <mhei@heimpold.de>
