### PR TITLE
perl: fix build errors on macOS

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -11,7 +11,7 @@ include perlver.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=$(PERL_VERSION)
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_URL:=\
 		https://cpan.metacpan.org/src/5.0 \

--- a/lang/perl/patches/001-macos_11_support.patch
+++ b/lang/perl/patches/001-macos_11_support.patch
@@ -1,0 +1,29 @@
+--- a/hints/darwin.sh
++++ b/hints/darwin.sh
+@@ -301,7 +301,7 @@ case "$osvers" in  # Note: osvers is the
+    # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
+    # capturing its value and adding it to the flags.
+     case "$MACOSX_DEPLOYMENT_TARGET" in
+-    10.*)
++    [1-9][0-9].*)
+       add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
+       add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
+       ;;
+@@ -313,7 +313,7 @@ case "$osvers" in  # Note: osvers is the
+ 
+ *** Unexpected MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET
+ ***
+-*** Please either set it to 10.something, or to empty.
++*** Please either set it to a valid macOS version number (e.g., 10.15) or to empty.
+ 
+ EOM
+       exit 1
+@@ -327,7 +327,7 @@ EOM
+     # "ProductVersion:    10.11"     "10.11"
+         prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
+     case "$prodvers" in
+-    10.*)
++    [1-9][0-9].*)
+       add_macosx_version_min ccflags $prodvers
+       add_macosx_version_min ldflags $prodvers
+       ;;

--- a/lang/perl/patches/002-add-Internals-getcwd.patch
+++ b/lang/perl/patches/002-add-Internals-getcwd.patch
@@ -1,0 +1,85 @@
+From 15f67d146cf1f32504e8a11de3faa2abc0f467cd Mon Sep 17 00:00:00 2001
+From: Tony Cook <tony@develop-help.com>
+Date: Mon, 25 Mar 2019 16:48:40 +1100
+Subject: [PATCH] (perl #133951) add Internals::getcwd
+
+---
+ MANIFEST      |  1 +
+ t/io/getcwd.t | 22 ++++++++++++++++++++++
+ universal.c   | 22 ++++++++++++++++++++++
+ 3 files changed, 45 insertions(+)
+ create mode 100644 t/io/getcwd.t
+
+--- a/MANIFEST
++++ b/MANIFEST
+@@ -5456,6 +5456,7 @@ t/io/errno.t			See if $! is correctly se
+ t/io/errnosig.t			Test case for restoration $! when leaving signal handlers
+ t/io/fflush.t			See if auto-flush on fork/exec/system/qx works
+ t/io/fs.t			See if directory manipulations work
++t/io/getcwd.t			See if Internals::getcwd is sane
+ t/io/inplace.t			See if inplace editing works
+ t/io/iofile.t			See if we can load IO::File on demand
+ t/io/iprefix.t			See if inplace editing works with prefixes
+--- /dev/null
++++ b/t/io/getcwd.t
+@@ -0,0 +1,22 @@
++#!./perl -w
++
++BEGIN {
++    chdir 't' if -d 't';
++    require "./test.pl";
++    set_up_inc('../lib');
++}
++
++use Config;
++
++$Config{d_getcwd}
++  or plan skip_all => "no getcwd";
++
++my $cwd = Internals::getcwd();
++ok(!defined $cwd || $cwd ne "",
++   "Internals::getcwd() returned a reasonable result");
++
++if (defined $cwd) {
++    ok(-d $cwd, "check a success result is a directory");
++}
++
++done_testing();
+--- a/universal.c
++++ b/universal.c
+@@ -986,6 +986,25 @@ XS(XS_re_regexp_pattern)
+     NOT_REACHED; /* NOTREACHED */
+ }
+ 
++#ifdef HAS_GETCWD
++
++XS(XS_Internals_getcwd)
++{
++    dXSARGS;
++    SV *sv = sv_newmortal();
++
++    if (items != 0)
++        croak_xs_usage(cv, "");
++
++    (void)getcwd_sv(sv);
++
++    SvTAINTED_on(sv);
++    PUSHs(sv);
++    XSRETURN(1);
++}
++
++#endif
++
+ #include "vutil.h"
+ #include "vxs.inc"
+ 
+@@ -1020,6 +1039,9 @@ static const struct xsub_details details
+     {"re::regnames", XS_re_regnames, ";$"},
+     {"re::regnames_count", XS_re_regnames_count, ""},
+     {"re::regexp_pattern", XS_re_regexp_pattern, "$"},
++#ifdef HAS_GETCWD
++    {"Internals::getcwd", XS_Internals_getcwd, ""},
++#endif
+ };
+ 
+ STATIC OP*

--- a/lang/perl/patches/003-fallback-to-the-built-in-getcwd-if-we-ca.patch
+++ b/lang/perl/patches/003-fallback-to-the-built-in-getcwd-if-we-ca.patch
@@ -1,0 +1,40 @@
+--- a/dist/PathTools/Cwd.pm
++++ b/dist/PathTools/Cwd.pm
+@@ -659,6 +659,10 @@ if (exists $METHOD_MAP{$^O}) {
+   }
+ }
+ 
++# built-in from 5.30
++*getcwd = \&Internals::getcwd
++  if !defined &getcwd && defined &Internals::getcwd;
++
+ # In case the XS version doesn't load.
+ *abs_path = \&_perl_abs_path unless defined &abs_path;
+ *getcwd = \&_perl_getcwd unless defined &getcwd;
+--- a/dist/PathTools/t/cwd.t
++++ b/dist/PathTools/t/cwd.t
+@@ -10,6 +10,7 @@ chdir 't';
+ use Config;
+ use File::Spec;
+ use File::Path;
++use Errno qw(EACCES);
+ 
+ use lib File::Spec->catdir('t', 'lib');
+ use Test::More;
+@@ -208,7 +209,15 @@ SKIP: {
+ 
+     like($abs_path,      qr|$want$|i, "Cwd::abs_path produced $abs_path");
+     like($fast_abs_path, qr|$want$|i, "Cwd::fast_abs_path produced $fast_abs_path");
+-    like($pas,           qr|$want$|i, "Cwd::_perl_abs_path produced $pas") if $EXTRA_ABSPATH_TESTS;
++    if ($EXTRA_ABSPATH_TESTS) {
++        # _perl_abs_path() can fail if some ancestor directory isn't readable
++        if (defined $pas) {
++            like($pas,           qr|$want$|i, "Cwd::_perl_abs_path produced $pas");
++        }
++        else {
++            is($!+0, EACCES, "check we got the expected error on failure");
++        }
++    }
+ 
+     rmtree($test_dirs[0], 0, 0);
+     1 while unlink $file;

--- a/lang/perl/patches/998-Errno_errno.h_path.patch
+++ b/lang/perl/patches/998-Errno_errno.h_path.patch
@@ -1,6 +1,6 @@
 --- a/ext/Errno/Errno_pm.PL
 +++ b/ext/Errno/Errno_pm.PL
-@@ -133,7 +133,7 @@
+@@ -133,7 +133,7 @@ sub get_files {
  	# Some Linuxes have weird errno.hs which generate
  	# no #file or #line directives
  	my ($linux_errno_h) = grep { -e $_ } map { "$_/errno.h" }

--- a/lang/perl/patches/999-fix-build-failure-against-gcc-10.patch
+++ b/lang/perl/patches/999-fix-build-failure-against-gcc-10.patch
@@ -20,11 +20,9 @@ patch fixes all of them I found.
  cflags.SH |  2 +-
  2 files changed, 8 insertions(+), 8 deletions(-)
 
-diff --git a/Configure b/Configure
-index fad1c9f2b1..706c0b64ed 100755
 --- a/Configure
 +++ b/Configure
-@@ -4701,7 +4701,7 @@ else
+@@ -4689,7 +4689,7 @@ else
  fi
  $rm -f try try.*
  case "$gccversion" in
@@ -33,7 +31,7 @@ index fad1c9f2b1..706c0b64ed 100755
  esac
  case "$gccversion" in
  '') gccosandvers='' ;;
-@@ -4741,7 +4741,7 @@ esac
+@@ -4729,7 +4729,7 @@ esac
  # gcc 3.* complain about adding -Idirectories that they already know about,
  # so we will take those off from locincpth.
  case "$gccversion" in
@@ -42,7 +40,7 @@ index fad1c9f2b1..706c0b64ed 100755
      echo "main(){}">try.c
      for incdir in $locincpth; do
         warn=`$cc $ccflags -I$incdir -c try.c 2>&1 | \
-@@ -5467,13 +5467,13 @@ fi
+@@ -5455,13 +5455,13 @@ fi
  case "$hint" in
  default|recommended)
  	case "$gccversion" in
@@ -58,7 +56,7 @@ index fad1c9f2b1..706c0b64ed 100755
  			$contains _POSIX_VERSION $usrinc/sys/unistd.h >/dev/null 2>&1
  		then
  			# Interactive Systems (ISC) POSIX mode.
-@@ -5482,7 +5482,7 @@ default|recommended)
+@@ -5470,7 +5470,7 @@ default|recommended)
  		;;
  	esac
  	case "$gccversion" in
@@ -67,7 +65,7 @@ index fad1c9f2b1..706c0b64ed 100755
  	2.[0-8]*) ;;
  	?*)	set strict-aliasing -fno-strict-aliasing
  		eval $checkccflag
-@@ -5600,7 +5600,7 @@ case "$cppflags" in
+@@ -5588,7 +5588,7 @@ case "$cppflags" in
      ;;
  esac
  case "$gccversion" in
@@ -76,7 +74,7 @@ index fad1c9f2b1..706c0b64ed 100755
  esac
  case "$mips_type" in
  '');;
-@@ -23103,7 +23103,7 @@ fi
+@@ -22957,7 +22957,7 @@ fi
  
  : add -D_FORTIFY_SOURCE if feasible and not already there
  case "$gccversion" in
@@ -85,8 +83,6 @@ index fad1c9f2b1..706c0b64ed 100755
  	*-O*)	case "$ccflags$cppsymbols" in
  		*_FORTIFY_SOURCE=*) # Don't add it again.
  			echo "You seem to have -D_FORTIFY_SOURCE already, not adding it." >&4
-diff --git a/cflags.SH b/cflags.SH
-index e60742fed1..f1bcd6c38e 100755
 --- a/cflags.SH
 +++ b/cflags.SH
 @@ -156,7 +156,7 @@ esac
@@ -98,6 +94,3 @@ index e60742fed1..f1bcd6c38e 100755
  Intel*) ;; # # Is that you, Intel C++?
  #
  # NOTE 1: the -std=c89 without -pedantic is a bit pointless.
--- 
-2.17.1
-


### PR DESCRIPTION
- The current version of perl 5.28.1 cannot be compiled on macOS 11, because hints/darwin.sh checks only for version 10, and fails on 11:

`*** Unexpected product version 11.2.`
Resolved by adding a check for macOS 11 and newer.

- When multithreaded build is used on macOS 11, a race condition results in failing to locate the current directory (cwd), and producers one of the following errors:

```
Can't locate Errno.pm in @INC
/miniperl not found
```

Resolved by adding Internals::getcwd, and then fallback to the built-in getcwd.


Maintainer: @pprindeville, @Naoir, @neheb
Compile tested: macOS 11.2
Run tested: (mvebu, Linksys WRT3200ACM, OpenWrt 17fa01bb79be12a08f8f7a0beb7f0d73618a6193)
