### PR TITLE
ttyd: force enable authentication for login

### DIFF
--- a/utils/ttyd/Makefile
+++ b/utils/ttyd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ttyd
 PKG_VERSION:=1.6.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tsl0922/ttyd/tar.gz/$(PKG_VERSION)?

--- a/utils/ttyd/files/ttyd.config
+++ b/utils/ttyd/files/ttyd.config
@@ -1,5 +1,5 @@
 
 config ttyd
 	option interface '@lan'
-	option command '/usr/libexec/login.sh'
+	option command '/bin/login'
 


### PR DESCRIPTION
Maintainer: @tsl0922
Compile tested: ipq40xx, rockchip, x86_64
Run tested: ipq40xx, rockchip, x86_64

Description:
```
Currently, we called `/usr/libexec/login.sh` as login command, but unfortunately the auth
is disabled by default in it[1], and this is really serious as it could be a free "backdoor"
for any spoiler who has conntectd to the router via LAN or wireless.

In my option, it shouldn't be exposed to anyone without auth, so I set the default login
command to `/bin/login`. And for those who really want that, they can do it themselves.

1. `login.sh` adjusts whether use authentication or not from system config named ttylogin,
which is set to disabled by default. See package/base-files/files/bin/config_generate#L243.
```