### PR TITLE
wg-installer: add babeld hotplug.d script

### DIFF
--- a/net/wg-installer/Makefile
+++ b/net/wg-installer/Makefile
@@ -21,6 +21,7 @@ endef
 define Package/wg-installer-server
 	$(call Package/wg-installer/Default)
 	TITLE+= (server)
+	MENU:=1
 	DEPENDS:=+rpcd +uhttpd +uhttpd-mod-ubus +owipcalc
 endef
 
@@ -47,6 +48,16 @@ define Package/wg-installer-server/postinst
 	fi
 endef
 
+define Package/wg-installer-server-hotplug-babeld
+	$(call Package/wg-installer-server)
+	DEPENDS:=wg-installer-server
+endef
+
+define Package/wg-installer-server-hotplug-babeld/install
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/net/
+	$(INSTALL_BIN) ./wg-server/hotplug.d/99-mesh-babeld $(1)/etc/hotplug.d/net/99-mesh-babeld
+endef
+
 define Package/wg-installer-client
 	$(call Package/wg-installer/Default)
 	TITLE+= (client)
@@ -66,4 +77,5 @@ define Package/wg-installer-client/install
 endef
 
 $(eval $(call BuildPackage,wg-installer-server))
+$(eval $(call BuildPackage,wg-installer-server-hotplug-babeld))
 $(eval $(call BuildPackage,wg-installer-client))

--- a/net/wg-installer/README.md
+++ b/net/wg-installer/README.md
@@ -24,3 +24,7 @@ Get Usage Statistics
 Register Tunnel Interface
 
     wg-client-installer register --ip 127.0.0.1 --user wginstaller --password wginstaller --bandwidth 10
+
+## Hotplugs
+
+- wg-installer-server-hotplug-babeld: mesh automatically via wireguard with babeld

--- a/net/wg-installer/wg-server/hotplug.d/99-mesh-babeld
+++ b/net/wg-installer/wg-server/hotplug.d/99-mesh-babeld
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# check if wireguard
+if [ "${DEVTYPE}" != "wireguard" ]; then
+	exit 0
+fi
+
+# check if correct naming
+slicedint=$(echo $INTERFACE | cut -c1-3)
+if [ "${slicedint}" != "wg_" ]; then
+	exit 0
+fi
+
+if [ "${ACTION}" == "add" ]; then
+	uci add babeld interface
+	uci set babeld.@interface[-1].ifname="${INTERFACE}"
+	uci commit
+	/etc/init.d/babeld reload
+fi
+
+if [ "${ACTION}" == "remove" ]; then
+	i=0
+	while uci get babeld.@interface[$i] &> /dev/null ; do
+		if [ "$(uci get babeld.@interface[$i].ifname)" == "${INTERFACE}" ]; then
+			uci delete babeld.@interface[$i]
+		fi
+		i=$((i+1));
+	done
+	uci commit
+	/etc/init.d/babeld reload
+fi


### PR DESCRIPTION
Add a hotplug.d-extension that automatically configures babeld for meshing via wireguard interfaces.

It checks for "add" and "remove" of a wireguard interface with name "wg_*". Depending on the action, it removes it from the babeld config or adds the interface and reloads babeld.

Maintainer: me
Compile tested: trunk
Run tested: trunk