### PR TITLE
ruby: update to 3.0.0

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=2.7.2
+PKG_VERSION:=3.0.0
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=1b95ab193cc8f5b5e59d2686cb3d5dcf1ddf2a86cb6950e0b4bdaae5040ec0d6
+PKG_HASH:=68bfaeef027b6ccd0032504a68ae69721a70e97d921ff328c0c8836c798f6cb1
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING
@@ -70,6 +70,13 @@ CONFIGURE_ARGS += \
 	--with-bundled-sha2 \
 
 endif
+
+# JIT requires a local cc installed and it is currently pointing to a wrong
+# compiler (ccache) used during build, without a way to set it without a patch.
+# Disabling it saves dozens of kbytes in libruby
+CONFIGURE_ARGS += --disable-jit-support
+# Host JIT does work but it is not worth it
+HOST_CONFIGURE_ARGS += --disable-jit-support
 
 TARGET_LDFLAGS += -L$(PKG_BUILD_DIR)
 
@@ -217,6 +224,18 @@ define Package/ruby-stdlib/install
 	/bin/true
 endef
 
+define Package/ruby-abbrev/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/abbrev.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/abbrev-*/
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/abbrev-*.gemspec
+endef
+
+define Package/ruby-base64/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/base64.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/base64-*/
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/base64-*.gemspec
+endef
+
 define Package/ruby-benchmark/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/benchmark.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/benchmark/
@@ -237,6 +256,20 @@ define Package/ruby-bundler/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/bundler-*/
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/bundler-*.gemspec
 endef
+define Package/ruby-bundler/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/bundler-*/doc
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/bundler-*/test
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/bundler-*/sample
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/bundler-*/man
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/bundler-*/*.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/bundler-*/*.txt
+endef
+define Package/ruby-bundler/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/bundle $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/bundler $(1)/usr/bin/
+	$(call RubyBuildPackage/install,bundler,$(1))
+endef
 
 define Package/ruby-cgi/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/cgi.rb
@@ -244,6 +277,15 @@ define Package/ruby-cgi/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/cgi-*/
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/cgi-*.gemspec
 /usr/lib/ruby/$(PKG_ABI_VERSION)/*/cgi/escape.so
+endef
+
+define Package/ruby-coverage/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/coverage.rb
+/usr/lib/ruby/$(PKG_ABI_VERSION)/*/coverage.so
+endef
+
+define Package/ruby-continuation/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/*/continuation.so
 endef
 
 define Package/ruby-csv/files
@@ -268,9 +310,9 @@ define Package/ruby-dbm/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/dbm-*.gemspec
 endef
 
-define Package/ruby-debuglib/files
+define Package/ruby-debug/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/debug.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/*/objspace.so
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/debug-*.gemspec
 endef
 
 define Package/ruby-delegate/files
@@ -310,11 +352,13 @@ define Package/ruby-digest/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/digest.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/*/digest.so
 /usr/lib/ruby/$(PKG_ABI_VERSION)/*/digest/*
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/digest-*.gemspec
 endef
 
 define Package/ruby-drb/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/drb.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/drb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/drb-*.gemspec
 endef
 
 define Package/ruby-enc/files
@@ -331,9 +375,20 @@ define Package/ruby-enc-extra/files-excluded
 $(call Package/ruby-enc/files)
 endef
 
+define Package/ruby-english/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/English.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/english-*.gemspec
+endef
+
 define Package/ruby-erb/files
-/usr/bin/erb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/erb.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/erb-*
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/erb-*.gemspec
+endef
+define Package/ruby-erb/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/erb $(1)/usr/bin/
+	$(call RubyBuildPackage/install,erb,$(1))
 endef
 
 define Package/ruby-etc/files
@@ -341,9 +396,17 @@ define Package/ruby-etc/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/etc-*.gemspec
 endef
 
+define Package/ruby-expect/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/expect.rb
+endef
+
 define Package/ruby-fcntl/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/*/fcntl.so
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/fcntl-*.gemspec
+endef
+
+define Package/ruby-fiber/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/*/fiber.so
 endef
 
 define Package/ruby-fiddle/files
@@ -353,18 +416,15 @@ define Package/ruby-fiddle/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/fiddle-*.gemspec
 endef
 
-define Package/ruby-filelib/files
-/usr/lib/ruby/$(PKG_ABI_VERSION)/tmpdir.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/tempfile.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/pathname.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/*/pathname.so
-/usr/lib/ruby/$(PKG_ABI_VERSION)/find.rb
-endef
-
 define Package/ruby-fileutils/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/fileutils.rb
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/fileutils-*/
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/fileutils-*.gemspec
+endef
+
+define Package/ruby-find/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/find.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/find-*.gemspec
 endef
 
 define Package/ruby-forwardable/files
@@ -412,6 +472,16 @@ define Package/ruby-io-console/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/io-console-*.gemspec
 endef
 
+define Package/ruby-io-nonblock/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/*/io/nonblock.so
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/io-nonblock-*.gemspec
+endef
+
+define Package/ruby-io-wait/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/*/io/wait.so
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/io-wait-*.gemspec
+endef
+
 define Package/ruby-ipaddr/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/ipaddr.rb
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/ipaddr-*.gemspec
@@ -442,8 +512,6 @@ endef
 define Package/ruby-logger/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/logger.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/logger/
-/usr/lib/ruby/$(PKG_ABI_VERSION)/syslog/logger.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/*/syslog.so
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/logger-*.gemspec
 endef
 
@@ -463,33 +531,13 @@ define Package/ruby-minitest/files-excluded
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/minitest-*/*.txt
 endef
 
-define Package/ruby-misc/files
-/usr/lib/ruby/$(PKG_ABI_VERSION)/English.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/abbrev.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/base64.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/coverage.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/expect.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/securerandom.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/set.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/shellwords.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/tsort.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/weakref.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/*/continuation.so
-/usr/lib/ruby/$(PKG_ABI_VERSION)/*/coverage.so
-/usr/lib/ruby/$(PKG_ABI_VERSION)/*/fiber.so
-/usr/lib/ruby/$(PKG_ABI_VERSION)/*/pty.so
-endef
-
 define Package/ruby-mkmf/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/mkmf.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/un.rb
 endef
 
-define Package/ruby-multithread/files
+define Package/ruby-monitor/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/monitor.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/*/monitor.so
-/usr/lib/ruby/$(PKG_ABI_VERSION)/*/io/wait.so
-/usr/lib/ruby/$(PKG_ABI_VERSION)/*/io/nonblock.so
 endef
 
 define Package/ruby-mutex_m/files
@@ -497,15 +545,34 @@ define Package/ruby-mutex_m/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/mutex_m-*.gemspec
 endef
 
-define Package/ruby-net/files
-/usr/lib/ruby/$(PKG_ABI_VERSION)/open-uri.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/net/*
+define Package/ruby-net-ftp/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/net/ftp.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/net-ftp-*.gemspec
 endef
-define Package/ruby-net/files-excluded
+
+define Package/ruby-net-http/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/net/http.rb
+/usr/lib/ruby/$(PKG_ABI_VERSION)/net/https.rb
+/usr/lib/ruby/$(PKG_ABI_VERSION)/net/http/
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-http-*/
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/net-http-*.gemspec
+endef
+
+define Package/ruby-net-imap/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/net/imap.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/net-imap-*.gemspec
+endef
+
+define Package/ruby-net-pop/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/net/pop.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/net/pop/*
-/usr/lib/ruby/$(PKG_ABI_VERSION)/net/smtp.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/net/smtp/*
+/usr/lib/ruby/$(PKG_ABI_VERSION)/net/pop/
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-pop-*/
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/net-pop-*.gemspec
+endef
+
+define Package/ruby-net-protocol/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/net/protocol.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/net-protocol-*.gemspec
 endef
 
 define Package/ruby-net-pop/files
@@ -522,19 +589,15 @@ define Package/ruby-net-smtp/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/net-smtp-*.gemspec
 endef
 
-define Package/ruby-net-telnet/files
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/net-telnet-*.gemspec
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-telnet-*/
-endef
-define Package/ruby-net-telnet/files-excluded
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-telnet-*/*.md
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-telnet-*/*.txt
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-telnet-*/.travis.yml
-endef
-
 define Package/ruby-nkf/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/kconv.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/*/nkf.so
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/nkf-*.gemspec
+endef
+
+define Package/ruby-objspace/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/objspace.rb
+/usr/lib/ruby/$(PKG_ABI_VERSION)/*/objspace.so
 endef
 
 define Package/ruby-observer/files
@@ -542,6 +605,11 @@ define Package/ruby-observer/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/observer/
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/observer-*/
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/observer-*.gemspec
+endef
+
+define Package/ruby-open-uri/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/open-uri.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/open-uri-*.gemspec
 endef
 
 define Package/ruby-open3/files
@@ -562,12 +630,19 @@ define Package/ruby-optparse/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/optparse.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/optionparser.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/optparse
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/optparse-*.gemspec
 endef
 
 define Package/ruby-ostruct/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/ostruct.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/ostruct/
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/ostruct-*.gemspec
+endef
+
+define Package/ruby-pathname/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/pathname.rb
+/usr/lib/ruby/$(PKG_ABI_VERSION)/*/pathname.so
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/pathname-*.gemspec
 endef
 
 define Package/ruby-powerassert/files
@@ -579,9 +654,14 @@ define Package/ruby-powerassert/files-excluded
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/power_assert-*/.travis.yml
 endef
 
-define Package/ruby-prettyprint/files
+define Package/ruby-pp/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/pp.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/pp-*.gemspec
+endef
+
+define Package/ruby-prettyprint/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/prettyprint.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/prettyprint-*.gemspec
 endef
 
 define Package/ruby-prime/files
@@ -603,6 +683,10 @@ define Package/ruby-psych/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/psych-*.gemspec
 endef
 
+define Package/ruby-pty/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/*/pty.so
+endef
+
 define Package/ruby-racc/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/racc.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/racc
@@ -613,8 +697,6 @@ endef
 define Package/ruby-racc/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/racc $(1)/usr/bin/;
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/racc2y $(1)/usr/bin/;
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/y2racc $(1)/usr/bin/;
 	$(call RubyBuildPackage/install,racc,$(1))
 endef
 
@@ -635,6 +717,22 @@ endef
 define Package/ruby-rbconfig/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/*/rbconfig.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/*/rbconfig/*.so
+endef
+
+define Package/ruby-rbs/files
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rbs-*
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/rbs-*.gemspec
+endef
+define Package/ruby-rbs/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rbs-*/docs
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rbs-*/test
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rbs-*/sample
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rbs-*/*.md
+endef
+define Package/ruby-rbs/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/rbs $(1)/usr/bin/
+	$(call RubyBuildPackage/install,rbs,$(1))
 endef
 
 define Package/ruby-rdoc/files
@@ -669,13 +767,35 @@ define Package/ruby-reline/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/reline-*.gemspec
 endef
 
+define Package/ruby-resolv/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/resolv.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/resolv-*.gemspec
+endef
+define Package/ruby-resolv/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/resolv-replace*.gemspec
+endef
+
+define Package/ruby-resolv-replace/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/resolv-replace.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/resolv-replace*.gemspec
+endef
+
 define Package/ruby-rexml/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/rexml
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/rexml-*.gemspec
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rexml-*
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/rexml-*.gemspec
+endef
+define Package/ruby-rexml/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rexml-*/doc
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rexml-*/test
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rexml-*/sample
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rexml-*/*.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rexml-*/.travis.yml
 endef
 
 define Package/ruby-rinda/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/rinda
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/rinda-*.gemspec
 endef
 
 define Package/ruby-ripper/files
@@ -687,12 +807,31 @@ endef
 define Package/ruby-rss/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/rss
 /usr/lib/ruby/$(PKG_ABI_VERSION)/rss.rb
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/rss-*.gemspec
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rss-*
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/rss-*.gemspec
+endef
+define Package/ruby-rss/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rss-*/doc
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rss-*/test
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rss-*/sample
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rss-*/*.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rss-*/*.txt
 endef
 
-define Package/ruby-sdbm/files
-/usr/lib/ruby/$(PKG_ABI_VERSION)/*/sdbm.so
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/sdbm-*.gemspec
+define Package/ruby-securerandom/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/securerandom.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/securerandom-*.gemspec
+endef
+
+define Package/ruby-set/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/set.rb
+/usr/lib/ruby/$(PKG_ABI_VERSION)/set/*.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/set-*.gemspec
+endef
+
+define Package/ruby-shellwords/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/shellwords.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/shellwords-*.gemspec
 endef
 
 define Package/ruby-singleton/files
@@ -703,8 +842,6 @@ define Package/ruby-singleton/files
 endef
 
 define Package/ruby-socket/files
-/usr/lib/ruby/$(PKG_ABI_VERSION)/resolv-replace.rb
-/usr/lib/ruby/$(PKG_ABI_VERSION)/resolv.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/socket.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/*/socket.so
 endef
@@ -717,6 +854,12 @@ endef
 define Package/ruby-strscan/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/*/strscan.so
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/strscan-*.gemspec
+endef
+
+define Package/ruby-syslog/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/*/syslog.so
+/usr/lib/ruby/$(PKG_ABI_VERSION)/syslog/logger.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/syslog-*.gemspec
 endef
 
 define Package/ruby-testunit/files
@@ -732,6 +875,7 @@ endef
 
 define Package/ruby-time/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/time.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/time-*.gemspec
 endef
 
 define Package/ruby-timeout/files
@@ -741,10 +885,48 @@ define Package/ruby-timeout/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/timeout-*.gemspec
 endef
 
+define Package/ruby-tempfile/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/tempfile.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/tempfile-*.gemspec
+endef
+
+define Package/ruby-tmpdir/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/tmpdir.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/tmpdir-*.gemspec
+endef
+
 define Package/ruby-tracer/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/tracer.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/tracer/
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/tracer-*.gemspec
+endef
+
+define Package/ruby-tsort/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/tsort.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/tsort-*.gemspec
+endef
+
+define Package/ruby-typeprof/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/typeprof.rb
+/usr/lib/ruby/$(PKG_ABI_VERSION)/typeprof
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/typeprof-*/
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/typeprof-*.gemspec
+endef
+define Package/ruby-typeprof/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/typeprof-*/doc
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/typeprof-*/test
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/typeprof-*/sample
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/typeprof-*/*.md
+endef
+define Package/ruby-typeprof/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/typeprof $(1)/usr/bin/
+	$(call RubyBuildPackage/install,typeprof,$(1))
+endef
+
+define Package/ruby-un/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/un.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/un-*.gemspec
 endef
 
 define Package/ruby-unicodenormalize/files
@@ -758,20 +940,9 @@ define Package/ruby-uri/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/uri-*.gemspec
 endef
 
-define Package/ruby-webrick/files
-/usr/lib/ruby/$(PKG_ABI_VERSION)/webrick
-/usr/lib/ruby/$(PKG_ABI_VERSION)/webrick.rb
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/webrick-*.gemspec
-endef
-
-define Package/ruby-xmlrpc/files
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/xmlrpc-*
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/xmlrpc-*.gemspec
-endef
-define Package/ruby-xmlrpc/files-excluded
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/xmlrpc-*/*.md
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/xmlrpc-*/*.txt
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/xmlrpc-*/.travis.yml
+define Package/ruby-weakref/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/weakref.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/weakref-*.gemspec
 endef
 
 define Package/ruby-yaml/files
@@ -857,80 +1028,105 @@ endef
 $(eval $(call BuildPackage,libruby))
 $(eval $(call BuildPackage,ruby))
 $(eval $(call BuildPackage,ruby-dev))
+$(eval $(call RubyBuildPackage,abbrev,Calculates the set of unambiguous abbreviations for a given set of strings,))
+$(eval $(call RubyBuildPackage,base64,Encode and decode base64,))
 $(eval $(call RubyBuildPackage,benchmark,Performance benchmarking library,))
 $(eval $(call RubyBuildPackage,bigdecimal,Arbitrary-precision decimal floating-point library,))
-$(eval $(call RubyBuildPackage,bundler,Manage dependencies,+ruby-irb +ruby-openssl +ruby-readline))
-$(eval $(call RubyBuildPackage,cgi,CGI support toolkit,+ruby-filelib +ruby-pstore +ruby-stringio))
-$(eval $(call RubyBuildPackage,csv,CSV Reading and Writing,+ruby-date +ruby-forwardable +ruby-misc +ruby-stringio +ruby-strscan))
+$(eval $(call RubyBuildPackage,bundler,Manage dependencies,+ruby-erb +ruby-irb +ruby-open-uri +ruby-readline))
+$(eval $(call RubyBuildPackage,cgi,CGI support toolkit,+ruby-pstore +ruby-securerandom +ruby-shellwords +ruby-tempfile))
+$(eval $(call RubyBuildPackage,continuation,Similar to C setjmp/longjmp with extra states,))
+$(eval $(call RubyBuildPackage,coverage,Coverage measurement,))
+$(eval $(call RubyBuildPackage,csv,CSV Reading and Writing,+ruby-date +ruby-english +ruby-forwardable +ruby-stringio +ruby-strscan))
 $(eval $(call RubyBuildPackage,date,Comparable module for handling dates,))
 $(eval $(call RubyBuildPackage,dbm,Wrapper for the UNIX-style Database Manager Library,+libdb47))
-$(eval $(call RubyBuildPackage,debuglib,debug library,+ruby-filelib +ruby-prettyprint +ruby-tracer))
+$(eval $(call RubyBuildPackage,debug,generic command line interface for ruby-debug,+ruby-continuation +ruby-pp +ruby-readline +ruby-tracer))
 $(eval $(call RubyBuildPackage,delegate,lib to delegate method calls to an object,))
-$(eval $(call RubyBuildPackage,did-you-mean,did you mean? experience,+ruby-misc))
+$(eval $(call RubyBuildPackage,did-you-mean,did you mean? experience,))
 $(eval $(call RubyBuildPackage,digest,Digest Library,+RUBY_DIGEST_USE_OPENSSL:libopenssl))
-$(eval $(call RubyBuildPackage,drb,distributed object system,+ruby-filelib +ruby-ipaddr +ruby-observer +ruby-singleton))
+$(eval $(call RubyBuildPackage,drb,distributed object system,+ruby-ipaddr +ruby-monitor +ruby-observer +ruby-singleton +ruby-tmpdir))
 $(eval $(call RubyBuildPackage,enc,character re-coding library charset (small subset),))
 $(eval $(call RubyBuildPackage,enc-extra,character re-coding library charset (extra subset),+ruby-enc))
-$(eval $(call RubyBuildPackage,erb,(embedded interpreter),+ruby-cgi +ruby-strscan))
+$(eval $(call RubyBuildPackage,english,Reference some global vars as english variables,))
+$(eval $(call RubyBuildPackage,erb,(embedded interpreter),+ruby-gems))
 $(eval $(call RubyBuildPackage,etc,Access info typically stored in /etc,))
+$(eval $(call RubyBuildPackage,expect,Expect-like for IO,))
 $(eval $(call RubyBuildPackage,fcntl,Loads constants defined in the OS fcntl.h C header file,))
+$(eval $(call RubyBuildPackage,fiber,Light weight cooperative concurrency,))
 $(eval $(call RubyBuildPackage,fiddle,Libffi wrapper for Ruby,+libffi))
-$(eval $(call RubyBuildPackage,filelib,file utils library,+ruby-fileutils))
 $(eval $(call RubyBuildPackage,fileutils,File utility methods for copying moving removing etc,+ruby-enc +ruby-etc +ruby-rbconfig +ruby-socket))
+$(eval $(call RubyBuildPackage,find,top-down traversal of a set of file paths,+ruby-enc))
 $(eval $(call RubyBuildPackage,forwardable,delegation of methods to a object,))
 $(eval $(call RubyBuildPackage,gdbm,Ruby extension for GNU dbm,+libgdbm))
-$(eval $(call RubyBuildPackage,gems,gems packet management,+ruby-net +ruby-open3 +ruby-rdoc))
+$(eval $(call RubyBuildPackage,gems,gems packet management,+ruby-base64 +ruby-cgi +ruby-json +ruby-net-http +ruby-open3 +ruby-pathname +ruby-pp +ruby-rake +ruby-resolv +ruby-yaml))
 $(eval $(call RubyBuildPackage,getoptlong,implementation of getoptLong,))
 $(eval $(call RubyBuildPackage,io-console,Console interface,))
+$(eval $(call RubyBuildPackage,io-nonblock,Non-blocking mode with IO class,))
+$(eval $(call RubyBuildPackage,io-wait,Waits until IO is readable or writable without blocking,))
 $(eval $(call RubyBuildPackage,ipaddr,Set of methods to manipulate an IP address,+ruby-socket))
-$(eval $(call RubyBuildPackage,irb,(interactive shell),+ruby-gems +ruby-reline +ruby-tracer))
+$(eval $(call RubyBuildPackage,irb,(interactive shell),+ruby-gems +ruby-reline +ruby-ripper +ruby-tracer))
 $(eval $(call RubyBuildPackage,json,JSON Implementation for Ruby,+ruby-date +ruby-ostruct))
-$(eval $(call RubyBuildPackage,logger,logger and syslog library,+ruby-multithread))
+$(eval $(call RubyBuildPackage,logger,logger and syslog library,+ruby-monitor))
 $(eval $(call RubyBuildPackage,matrix,implementation of Matrix and Vector classes,))
 $(eval $(call RubyBuildPackage,minitest,Gem minitest,+ruby-gems +ruby-mutex_m))
-$(eval $(call RubyBuildPackage,misc,standard libraries subset (miscellaneous files),+ruby-delegate))
-$(eval $(call RubyBuildPackage,mkmf,makefile library,+ruby-filelib +ruby-optparse))
-$(eval $(call RubyBuildPackage,multithread,multithread library,))
+$(eval $(call RubyBuildPackage,mkmf,makefile library,+ruby-shellwords +ruby-tmpdir))
+$(eval $(call RubyBuildPackage,monitor,Object or module methods are executed with mutual exclusion,))
 $(eval $(call RubyBuildPackage,mutex_m,extend objects to be handled like a Mutex,))
-$(eval $(call RubyBuildPackage,net,Network Protocols Library,+ruby-time +ruby-digest +ruby-filelib +ruby-stringio +ruby-strscan +ruby-uri))
-$(eval $(call RubyBuildPackage,net-pop,POP3 lib,+ruby-net +ruby-openssl))
-$(eval $(call RubyBuildPackage,net-smtp,SMTP lib,+ruby-net +ruby-openssl))
-$(eval $(call RubyBuildPackage,net-telnet,telnet client,+ruby-net))
+$(eval $(call RubyBuildPackage,net-ftp,FTP lib,+ruby-monitor +ruby-net-protocol +ruby-openssl +ruby-time))
+$(eval $(call RubyBuildPackage,net-http,HTTP lib,+ruby-net-protocol +ruby-securerandom +ruby-tempfile +ruby-uri +ruby-zlib))
+$(eval $(call RubyBuildPackage,net-imap,IMAP lib,+ruby-monitor +ruby-net-protocol +ruby-openssl +ruby-strscan))
+$(eval $(call RubyBuildPackage,net-pop,POP3 lib,+ruby-net-protocol +ruby-openssl))
+$(eval $(call RubyBuildPackage,net-protocol,Abstract for net-* clients,+ruby-socket +ruby-timeout))
+$(eval $(call RubyBuildPackage,net-smtp,SMTP lib,+ruby-net-protocol +ruby-openssl))
 $(eval $(call RubyBuildPackage,nkf,Network Kanji Filter,+ruby-enc))
+$(eval $(call RubyBuildPackage,objspace,Routines to interact with the garbage collection facility,+ruby-tempfile))
 $(eval $(call RubyBuildPackage,observer,Observer design pattern,))
+$(eval $(call RubyBuildPackage,open-uri,Wrapper for Net::HTTP Net::HTTPS and Net::,+ruby-net-ftp +ruby-net-http))
 $(eval $(call RubyBuildPackage,open3,popen with stderr,))
-$(eval $(call RubyBuildPackage,openssl,SSL TLS and general purpose cryptography,+ruby-digest +ruby-enc +ruby-ipaddr +ruby-stringio +libopenssl))
+$(eval $(call RubyBuildPackage,openssl,SSL TLS and general purpose cryptography,+ruby-digest +ruby-enc +ruby-io-nonblock +ruby-ipaddr +ruby-stringio +libopenssl))
+$(eval $(call RubyBuildPackage,optparse,command-line option analysis,+ruby-shellwords +ruby-time))
 $(eval $(call RubyBuildPackage,ostruct,build custom data structures,))
-$(eval $(call RubyBuildPackage,optparse,command-line option analysis,+ruby-misc +ruby-time))
-$(eval $(call RubyBuildPackage,powerassert,Gem power_assert,+ruby-prettyprint +ruby-ripper))
-$(eval $(call RubyBuildPackage,prettyprint,PrettyPrint library,+ruby-etc))
+$(eval $(call RubyBuildPackage,pathname,Pathname lib,+ruby-fileutils +ruby-find))
+$(eval $(call RubyBuildPackage,powerassert,Gem power_assert,+ruby-pp +ruby-ripper))
+$(eval $(call RubyBuildPackage,pp,Pretty print objects,+ruby-etc +ruby-prettyprint))
+$(eval $(call RubyBuildPackage,prettyprint,PrettyPrint library,))
 $(eval $(call RubyBuildPackage,prime,Prime numbers and factorization library,+ruby-forwardable +ruby-singleton))
 $(eval $(call RubyBuildPackage,pstore,file based persistence,+ruby-digest +ruby-enc))
-$(eval $(call RubyBuildPackage,psych,YAML parser and emitter,+ruby-bigdecimal +ruby-date +ruby-enc +ruby-stringio +ruby-strscan +libyaml))
-$(eval $(call RubyBuildPackage,racc,LALR parser generator,+ruby-forwardable +ruby-optparse +ruby-rbconfig +ruby-stringio +ruby-strscan))
-$(eval $(call RubyBuildPackage,rake,Rake (make replacement),+ruby-fileutils +ruby-optparse +ruby-ostruct +ruby-singleton))
+$(eval $(call RubyBuildPackage,psych,YAML parser and emitter,+ruby-bigdecimal +ruby-date +ruby-enc +ruby-forwardable +ruby-stringio +ruby-strscan +libyaml))
+$(eval $(call RubyBuildPackage,pty,Creates and manages pseudo terminals,))
+$(eval $(call RubyBuildPackage,racc,LALR parser generator,+ruby-forwardable +ruby-optparse +ruby-rbconfig +ruby-stringio))
+$(eval $(call RubyBuildPackage,rake,Rake (make replacement),+ruby-fileutils +ruby-monitor +ruby-optparse +ruby-ostruct +ruby-set +ruby-singleton))
 $(eval $(call RubyBuildPackage,rbconfig,RbConfig,))
-$(eval $(call RubyBuildPackage,rdoc,RDoc produces HTML and command-line documentation for Ruby projects,+ruby-did-you-mean +ruby-erb +ruby-json +ruby-prettyprint +ruby-racc +ruby-rake +ruby-ripper +ruby-yaml +ruby-zlib))
-$(eval $(call RubyBuildPackage,readline,loads readline-ext(native) or reline(ruby),+ruby-reline))
+$(eval $(call RubyBuildPackage,rbs,RBS provides syntax and semantics definition for the Ruby Signature language,+ruby-gems +ruby-logger +ruby-racc +ruby-ripper))
+$(eval $(call RubyBuildPackage,rdoc,RDoc produces HTML and command-line documentation for Ruby projects,+ruby-abbrev +ruby-did-you-mean +ruby-erb +ruby-racc +ruby-ripper))
 $(eval $(call RubyBuildPackage,readline-ext,support for native GNU readline,+libncurses +libreadline))
-$(eval $(call RubyBuildPackage,reline,alternative to readline-ext in pure ruby,+ruby-fiddle +ruby-filelib +ruby-forwardable +ruby-io-console))
-$(eval $(call RubyBuildPackage,rexml,XML toolkit,+ruby-enc +ruby-forwardable +ruby-misc +ruby-prettyprint +ruby-stringio +ruby-strscan))
+$(eval $(call RubyBuildPackage,readline,loads readline-ext(native) or reline(ruby),+ruby-reline))
+$(eval $(call RubyBuildPackage,reline,alternative to readline-ext in pure ruby,+ruby-fiddle +ruby-forwardable +ruby-io-console +ruby-tempfile +ruby-timeout))
+$(eval $(call RubyBuildPackage,resolv,DNS resolver library,+ruby-securerandom +ruby-timeout))
+$(eval $(call RubyBuildPackage,resolv-replace,Replace Socket DNS with Resolv,+ruby-resolv))
+$(eval $(call RubyBuildPackage,rexml,XML toolkit,+ruby-enc +ruby-forwardable +ruby-pp +ruby-set +ruby-stringio +ruby-strscan))
 $(eval $(call RubyBuildPackage,rinda,Linda paradigm implementation,+ruby-drb +ruby-forwardable))
 $(eval $(call RubyBuildPackage,ripper,script parser,))
-$(eval $(call RubyBuildPackage,rss,RSS toolkit,+ruby-net +ruby-nkf +ruby-rexml))
-$(eval $(call RubyBuildPackage,sdbm,simple file-based key-value dbm implementation,))
+$(eval $(call RubyBuildPackage,rss,RSS toolkit,+ruby-english +ruby-nkf +ruby-open-uri +ruby-rexml))
+$(eval $(call RubyBuildPackage,securerandom,Secure random number generators,+ruby-openssl))
+$(eval $(call RubyBuildPackage,set,Set collection,+ruby-tsort))
+$(eval $(call RubyBuildPackage,shellwords,Manipulate strings as Bourne Shell,))
 $(eval $(call RubyBuildPackage,singleton,Singleton pattern,))
-$(eval $(call RubyBuildPackage,socket,socket support,+ruby-misc +ruby-multithread +ruby-timeout))
+$(eval $(call RubyBuildPackage,socket,socket support,+ruby-io-wait))
 $(eval $(call RubyBuildPackage,stringio,Pseudo `IO` class from/to `String`,))
 $(eval $(call RubyBuildPackage,strscan,Lexical scanning operations on a String,))
-$(eval $(call RubyBuildPackage,testunit,Gem test-unit,+ruby-csv +ruby-erb +ruby-optparse +ruby-powerassert +ruby-rexml +ruby-yaml))
+$(eval $(call RubyBuildPackage,syslog,Syslog Lib,+ruby-logger))
+$(eval $(call RubyBuildPackage,tempfile,Manages temporary files,+ruby-delegate +ruby-tmpdir))
+$(eval $(call RubyBuildPackage,testunit,Gem test-unit,+ruby-csv +ruby-erb +ruby-powerassert +ruby-rexml))
 $(eval $(call RubyBuildPackage,time,Extends Time with additional methods for parsing and converting Times,+ruby-date))
 $(eval $(call RubyBuildPackage,timeout,Auto-terminate potentially long-running operations,))
+$(eval $(call RubyBuildPackage,tmpdir,Get temp dir path,+ruby-fileutils))
 $(eval $(call RubyBuildPackage,tracer,Outputs a source level execution trace of a Ruby program,))
+$(eval $(call RubyBuildPackage,tsort,Topological sorting using Tarjan s algorithm,))
+$(eval $(call RubyBuildPackage,typeprof,A type analysis tool for Ruby code based on abstract interpretation,+ruby-coverage +ruby-rbs))
 $(eval $(call RubyBuildPackage,unicodenormalize,String additions for Unicode normalization,+ruby-enc +ruby-enc-extra))
+$(eval $(call RubyBuildPackage,un,Utilities to replace common UNIX commands in Makefiles,+ruby-mkmf +ruby-optparse))
 $(eval $(call RubyBuildPackage,uri,library to handle URI,+ruby-enc))
-$(eval $(call RubyBuildPackage,webrick,HTTP server toolkit,+ruby-erb +ruby-net +ruby-singleton))
-$(eval $(call RubyBuildPackage,xmlrpc,XML-RPC toolkit,+ruby-rexml +ruby-webrick))
+$(eval $(call RubyBuildPackage,weakref,Weak reference to be garbage collected,+ruby-delegate))
 $(eval $(call RubyBuildPackage,yaml,YAML toolkit,+ruby-dbm +ruby-pstore +ruby-psych))
 $(eval $(call RubyBuildPackage,zlib,compression/decompression library interface,))
 $(eval $(call BuildPackage,ruby-stdlib))

--- a/lang/ruby/patches/100-musl.patch
+++ b/lang/ruby/patches/100-musl.patch
@@ -1,19 +1,12 @@
---- a/coroutine/copy/Context.h
-+++ b/coroutine/copy/Context.h
-@@ -13,6 +13,7 @@
- #include <string.h>
- #include <stdlib.h>
- #include <alloca.h>
-+#include <sys/types.h>
- 
- #define COROUTINE __attribute__((noreturn)) void
- 
+Rebased on https://patch-diff.githubusercontent.com/raw/ruby/ruby/pull/2995.patch
+which was originally based on this file.
+
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2347,7 +2347,10 @@ AS_CASE([$rb_cv_coroutine], [yes|''], [
+@@ -2441,7 +2441,10 @@ AS_CASE([$rb_cv_coroutine], [yes|''], [
              rb_cv_coroutine=copy
          ],
-         [*], [
+         [
 -            rb_cv_coroutine=ucontext
 +            AC_CHECK_FUNCS([getcontext swapcontext makecontext],
 +                [rb_cv_coroutine=ucontext],

--- a/lang/ruby/ruby_find_pkgsdeps
+++ b/lang/ruby/ruby_find_pkgsdeps
@@ -9,6 +9,10 @@
 RUBY_SIMPLE_VERSION = RUBY_VERSION.split(".")[0..1].join(".")
 failed = false
 
+puts "Loading all installed gems (unstable after external gems are instaled/update)"
+require 'rubygems'
+Gem::Specification.collect{ |g| g.name.downcase }.uniq.each {|g| gem g }
+
 puts "Looking for installed ruby packages..."
 packages=`opkg list-installed '*ruby*' | cut -d' ' -f 1`.split("\n")
 
@@ -27,7 +31,7 @@ require_ignore=%w{foo rubygems/defaults/operating_system win32console java Win32
                   xmlscan/parser xmlscan/scanner xmltreebuilder xml/parser xmlparser xml/encoding-ja xmlencoding-ja
                   iconv uconv win32ole gettext/po_parser gettext/mo libxml psych.jar psych_jars jar-dependencies thread minitest/proveit
 		bundler pry bcrypt net/http/pipeline capistrano/version rubygems/builder rubygems/format diff/lcs graphviz
-		win32api racc/cparse-jruby.jar profile profiler
+		win32api racc/cparse-jruby.jar profile profiler sorted_set jruby coverage/helpers stackprof webrick/https webrick
 	}
 
 builtin_enc=[
@@ -142,21 +146,17 @@ weak_dependency.merge!({
 "ruby-debuglib"=>["ruby-readline"],				#debug.rb
 "ruby-drb"=>["ruby-openssl"],				 	#drb/ssl.rb
 "ruby-irb"=>["ruby-rdoc", "ruby-readline"],		 	#irb/cmd/help.rb
-"ruby-gems"=>["ruby-openssl","ruby-io-console","ruby-webrick",  #rubygems/commands/cert_command.rb rubygems/user_interaction.rb rubygems/server.rb
-		"ruby-bundler"],				#rubygems.rb
-"ruby-mkmf"=>["ruby-webrick"], 					#un.rb
+"ruby-gems"=>["ruby-openssl","ruby-io-console",  		#rubygems/commands/cert_command.rb rubygems/user_interaction.rb
+		"ruby-bundler", "ruby-erb", "ruby-rdoc"],	#rubygems.rb rubygems/server.rb
 "ruby-net"=>["ruby-openssl","ruby-io-console","ruby-zlib"], 	#net/*.rb
 "ruby-optparse"=>["ruby-uri","ruby-datetime"],			#optparse/date.rb optparse/uri.rb
 "ruby-racc"=>["ruby-gems"],					#/usr/bin/racc*
 "ruby-rake"=>["ruby-net","ruby-gems"],				#rake/contrib/ftptools.rb /usr/bin/rake
-"ruby-rdoc"=>["ruby-gems","ruby-readline","ruby-webrick",	#/usr/bin/rdoc and others
+"ruby-rdoc"=>["ruby-gems","ruby-readline",			#/usr/bin/rdoc and others
 	       "ruby-io-console"],				#rdoc/stats/normal.rb
-"ruby-webrick"=>["ruby-openssl"],				#webrick/ssl.rb
 "ruby-testunit"=>["ruby-io-console"],			 	#gems/test-unit-3.1.5/lib/test/unit/ui/console/testrunner.rb
+"ruby-net-http"=>["ruby-open-uri"]				#net/http/status.rb
 })
-
-puts "Preloading gems..."
-Gem::Specification.all.each{ |x| gem x.name }
 
 puts "Looking for package dependencies..."
 package_provides = {}


### PR DESCRIPTION
This release goal is performance, concurrency, and typing. See details
in https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

New subpackages (reflect of mostly complete upstream ruby gemification)
- ruby-abbrev (from ruby-misc)
- ruby-base64 (from ruby-misc)
- ruby-coverage (from ruby-misc)
- ruby-continuation (from ruby-misc)
- ruby-debug (from ruby-debuglib)
- ruby-english (from ruby-misc)
- ruby-expect (from ruby-misc)
- ruby-fiber (from ruby-misc)
- ruby-find (from ruby-filelib)
- ruby-io-nonblock (from ruby-multithread)
- ruby-io-wait (from ruby-multithread)
- ruby-monitor (from ruby-multithread)
- ruby-net-ftp (from ruby-net)
- ruby-net-http (from ruby-net)
- ruby-net-imap (from ruby-net)
- ruby-net-pop (from ruby-net)
- ruby-net-protocol (from ruby-net)
- ruby-objspace (from ruby-debuglib)
- ruby-open-uri (from ruby-net)
- ruby-pathname (from ruby-filelib)
- ruby-pp (from ruby-prettyprint)
- ruby-pty (from ruby-misc)
- ruby-rbs (NEW)
- ruby-resolv (from ruby-socket)
- ruby-resolv-replace (from ruby-socket)
- ruby-securerandom (from ruby-misc)
- ruby-set (from ruby-misc)
- ruby-shellwords (from ruby-misc)
- ruby-syslog (from ruby-logger)
- ruby-tempfile (from ruby-filelib)
- ruby-tmpdir (from ruby-filelib)
- ruby-tsort (from ruby-misc)
- ruby-typeprof (NEW)
- ruby-un (from ruby-mkmf)
- ruby-weakref (from ruby-misc)

Removed subpackages
- ruby-debuglib (split into ruby-debug,ruby-objspace)
- ruby-filelib (split into ruby-find,ruby-pathname,ruby-tempfile,ruby-tmpdir)
- ruby-misc (split into ruby-abbrev,ruby-base64,ruby-continuation,
    ruby-coverage,ruby-english,ruby-expect,ruby-fiber,ruby-securerandom,
    ruby-set,ruby-shellwords,ruby-tsort,ruby-weakref)
- ruby-multithread (split into ruby-io-nonblock,ruby-io-wait,ruby-monitor)
- ruby-net (split into ruby-net-ftp,ruby-net-http,ruby-net-imap,ruby-net-pop,
    ruby-net-protocol,ruby-open-uri)
- ruby-net-telnet (removed upstream)
- ruby-sdbm (removed upstream)
- ruby-webrick (removed upstream)
- ruby-xmlrpc (removed upstream)

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: me
Compile tested: master on arc_generic,armvirt_64,ath79_generic,mvebu_cortexa9,powerpc,ramips_mt7620,x86_64,x86_generic
Run tested: x86_64, ath79_generic (in malta), mvebu_cortexa9 running "gem update" and ruby_find_pkgsdeps

Description:
