### PR TITLE
netdata: update to version 1.29.0

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
-PKG_VERSION:=1.28.0
+PKG_VERSION:=1.29.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
@@ -18,7 +18,7 @@ PKG_CPE_ID:=cpe:/a:my-netdata:netdata
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netdata/netdata/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=35f681abddfc307ffa8f026dbded4eadf3752a7cbb3078501a64d4f9b605491e
+PKG_HASH:=d5029b466e801966b7fb483905d61a290cec7c19ec95f96ae2fbff14c723ee37
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Maintainer: me and @diizzyy
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07.6
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07.6

Description:
- update to version [1.29.0](https://github.com/netdata/netdata/releases/tag/v1.29.0)