### PR TITLE
libxslt: allow access to iconv

### DIFF
--- a/libs/libxslt/Makefile
+++ b/libs/libxslt/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxslt
 PKG_VERSION:=1.1.34
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -29,11 +29,12 @@ HOST_BUILD_DEPENDS:=libxml2/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/libxslt
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libxml2
+  DEPENDS:=+libxml2 $(ICONV_DEPENDS)
   TITLE:=Gnome XSLT library
   URL:=http://xmlsoft.org/XSLT/
 endef


### PR DESCRIPTION
Since commit d18692c libxml2 is linked against iconv. Now libxslt needs
access to iconv as well. Without it the build fails.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @jslachta 
Compile tested: ath79 master
Run tested: N/A

Description:
Hi Jiri :)

Kind regards,
Seb