### PR TITLE
icecast: allow access to iconv

### DIFF
--- a/multimedia/icecast/Makefile
+++ b/multimedia/icecast/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=icecast
 PKG_VERSION:=2.4.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.xiph.org/releases/icecast/
@@ -24,11 +24,12 @@ PKG_FIXUP:=autoreconf
 PKG_INSTALL:= 1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/icecast
   SECTION:=multimedia
   CATEGORY:=Multimedia
-  DEPENDS:=+libcurl +libxml2 +libxslt +libogg +libvorbisidec
+  DEPENDS:=+libcurl +libxml2 +libxslt +libogg +libvorbisidec $(ICONV_DEPENDS)
   TITLE:=A streaming media server for Ogg/Vorbis and MP3 audio streams
   USERID:=icecast=87:icecast=87
   URL:=https://icecast.org/


### PR DESCRIPTION
Since commit d18692c libxml2 (and by extension libxslt) is linked against
iconv. Now icecast needs access to iconv as well. Without it the build fails.

xslt.c: In function 'xsltSaveResultToString':
xslt.c:72:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
     if (result->children == NULL)
     ^~
xslt.c:75:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
  buf = xmlAllocOutputBuffer(NULL);
  ^~~
xslt.c:81:27: error: dereferencing pointer to incomplete type 'xmlBuf' {aka 'struct _xmlBuf'}
   *doc_txt_len = buf->conv->use;
                           ^~
make[6]: *** [Makefile:545: xslt.o] Error 1
make[6]: Leaving directory '/openwrt/build_dir/target-mips_24kc_musl/icecast-2.4.4/src'

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @andrenarchy @thess 
Compile tested: ath79 master
Run tested: N/A
Description: build fix
