### PR TITLE
ices: allow access to iconv

### DIFF
--- a/multimedia/ices/Makefile
+++ b/multimedia/ices/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ices
 PKG_VERSION:=2.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://downloads.xiph.org/releases/ices/
@@ -22,13 +22,14 @@ PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/ices
   SECTION:=sound
   CATEGORY:=Sound
   TITLE:=ices client for Icecast media streaming servers
   URL:=http://www.icecast.org/ices/
-  DEPENDS:=+libshout +libxml2 +zlib +libogg +libvorbis +alsa-lib
+  DEPENDS:=+libshout +libxml2 +zlib +libogg +libvorbis +alsa-lib $(ICONV_DEPENDS)
 endef
 
 define Package/ices/description


### PR DESCRIPTION
Since commit d18692c libxml2 is linked against iconv. Now ices needs
access to iconv as well. Without it the build fails.

checking for ftime... yes
checking for XML configuration
checking for xml2-config... /builder/shared-workdir/build/sdk/staging_dir/target-aarch64_generic_musl/host/bin/xml2-config
checking for xmlParseFile... no
configure: error: Unable to link with libxml

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @nicolas-thill @thess 
Compile tested: ath79 master
Run tested: N/A

Description: build fix
