### PR TITLE
libiio: allow access to iconv

### DIFF
--- a/libs/libiio/Makefile
+++ b/libs/libiio/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libiio
 PKG_VERSION:=0.21
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/analogdevicesinc/libiio/tar.gz/v$(PKG_VERSION)?
@@ -34,6 +34,7 @@ PKG_CONFIG_DEPENDS:= \
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
+include $(INCLUDE_DIR)/nls.mk
 
 CMAKE_OPTIONS += -DWITH_DOC=OFF
 CMAKE_OPTIONS += -DENABLE_IPV6=$(if $(CONFIG_IPV6),ON,OFF)
@@ -55,7 +56,8 @@ define Package/libiio
            +zlib \
            +LIBIIO_USB_BACKEND:libusb-1.0 \
            +LIBIIO_NETWORK_BACKEND:libavahi-client \
-           +LIBIIO_XML_BACKEND:libxml2
+           +LIBIIO_XML_BACKEND:libxml2 \
+           $(ICONV_DEPENDS)
   MENU:=1
 endef
 


### PR DESCRIPTION
Since commit d18692c libxml2 is linked against iconv. Now ices needs
access to iconv as well. Without it the build fails.

[ 32%] Building C object CMakeFiles/iio.dir/lock.c.o
[ 34%] Building C object CMakeFiles/iio.dir/iiod-client.c.o
[ 37%] Linking C shared library libiio.so
/builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_generic_gcc-8.4.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/8.4.0/../../../../aarch64-openwrt-linux-musl/bin/ld: cannot find -liconv
collect2: error: ld returned 1 exit status

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @mhei 
Compile tested: ath79 master
Run tested: N/A

Description: build fix
