### PR TITLE
https-dns-proxy: support for force DNS/DNS hijacking

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2021-01-17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy
@@ -41,7 +41,7 @@ define Package/https-dns-proxy/install
 	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/init.d ${1}/etc/config
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/https_dns_proxy $(1)/usr/sbin/https-dns-proxy
 	$(INSTALL_BIN) ./files/https-dns-proxy.init $(1)/etc/init.d/https-dns-proxy
-	sed -i "s|^\(PKG_VERSION\).*|\1='$(PKG_VERSION)-$(PKG_RELEASE)'|" $(1)/etc/init.d/https-dns-proxy
+	$(SED) "s|^\(PKG_VERSION\).*|\1='$(PKG_VERSION)-$(PKG_RELEASE)'|" $(1)/etc/init.d/https-dns-proxy
 	$(INSTALL_CONF) ./files/https-dns-proxy.config $(1)/etc/config/https-dns-proxy
 endef
 

--- a/net/https-dns-proxy/files/https-dns-proxy.config
+++ b/net/https-dns-proxy/files/https-dns-proxy.config
@@ -1,18 +1,19 @@
 config main 'config'
 	option update_dnsmasq_config '*'
-
-config https-dns-proxy
-	option bootstrap_dns '8.8.8.8,8.8.4.4'
-	option resolver_url 'https://dns.google/dns-query'
-	option listen_addr '127.0.0.1'
-	option listen_port '5053'
-	option user 'nobody'
-	option group 'nogroup'
+	option force_dns '1'
 
 config https-dns-proxy
 	option bootstrap_dns '1.1.1.1,1.0.0.1'
 	option resolver_url 'https://cloudflare-dns.com/dns-query'
 	option listen_addr '127.0.0.1'
 	option listen_port '5054'
+	option user 'nobody'
+	option group 'nogroup'
+
+config https-dns-proxy
+	option bootstrap_dns '8.8.8.8,8.8.4.4'
+	option resolver_url 'https://dns.google/dns-query'
+	option listen_addr '127.0.0.1'
+	option listen_port '5053'
 	option user 'nobody'
 	option group 'nogroup'

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -17,6 +17,7 @@ fi
 
 readonly PROG=/usr/sbin/https-dns-proxy
 dnsmasqConfig=''
+forceDNS='1'
 
 version() { echo "$PKG_VERSION"; }
 
@@ -91,13 +92,37 @@ start_instance() {
 	p="$((p+1))"
 }
 
+is_force_dns_active() { iptables-save | grep -q -w -- '--dport 53'; }
+
 start_service() {
 	local p=5053
 	config_load 'https-dns-proxy'
 	config_get dnsmasqConfig	'config' 'update_dnsmasq_config' '*'
+	config_get_bool forceDNS	'config' 'force_dns' '1'
 	dhcp_backup 'create'
 	config_load 'https-dns-proxy'
 	config_foreach start_instance 'https-dns-proxy'
+	if [ "$forceDNS" -ne 0 ]; then
+		procd_open_instance 'main'
+		procd_set_param command /bin/true
+		procd_set_param stdout 1
+		procd_set_param stderr 1
+		procd_open_data
+		json_add_array firewall
+		json_add_object ''
+		json_add_string type redirect
+		json_add_string name https_dns_proxy_dns_redirect
+		json_add_string target DNAT
+		json_add_string src lan
+		json_add_string proto tcpudp
+		json_add_string src_dport 53
+		json_add_string dest_port 53
+		json_add_string reflection 0
+		json_close_object
+		json_close_array
+		procd_close_data
+		procd_close_instance
+	fi
 	if [ -n "$(uci -q changes dhcp)" ]; then
 		uci -q commit dhcp
 		[ -x /etc/init.d/dnsmasq ] && /etc/init.d/dnsmasq restart >/dev/null 2>&1
@@ -117,6 +142,9 @@ stop_service() {
 service_triggers() {
 	procd_add_config_trigger "config.change" "https-dns-proxy" /etc/init.d/https-dns-proxy reload
 }
+
+service_started() { procd_set_config_changed firewall; }
+service_stopped() { procd_set_config_changed firewall; }
 
 dnsmasq_add_doh_server() {
 	local cfg="$1" address="$2" port="$3"


### PR DESCRIPTION
Maintainer: me
Compile tested: ramips, er-x, 19.07.6
Run tested:  ramips, er-x, 19.07.6, start/stop/dns hijack

Description: This introduces support for DNS Hijacking. 

Signed-off-by: Stan Grishin <stangri@melmac.net>

PS. Please grant merge rights.