### PR TITLE
[19.07] ttyd: force enable authentication for login

### DIFF
--- a/utils/ttyd/Makefile
+++ b/utils/ttyd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ttyd
 PKG_VERSION:=1.5.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tsl0922/ttyd/tar.gz/$(PKG_VERSION)?

--- a/utils/ttyd/files/ttyd.config
+++ b/utils/ttyd/files/ttyd.config
@@ -1,5 +1,5 @@
 
 config ttyd
 	option interface '@lan'
-	option command '/usr/libexec/login.sh'
+	option command '/bin/login'
 


### PR DESCRIPTION
Maintainer: @tsl0922
Compile tested: ramips, x86_64
Run tested: ramips newifi-d2

Description:
Backported from f45bb2981d41e1005a2658661da2475518835db8 #14683 