### PR TITLE
libgpiod: update to 1.6.3

### DIFF
--- a/libs/libgpiod/Makefile
+++ b/libs/libgpiod/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgpiod
-PKG_VERSION:=1.4.4
+PKG_VERSION:=1.6.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/libs/libgpiod/
-PKG_HASH:=f1cda2789e6a13a92aefc012a76e5a7cc57a1b402d66f71df8719ee314b67699
+PKG_HASH:=841be9d788f00bab08ef22c4be5c39866f0e46cb100a3ae49ed816ac9c5dddc7
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
