### PR TITLE
adguardhome: bump to 0.105.1

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -6,25 +6,30 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
-PKG_VERSION:=0.104.3
+PKG_VERSION:=0.105.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://github.com/AdguardTeam/AdGuardHome
-PKG_MIRROR_HASH:=9051c08ebefccd918cad9b487d2d3b2c4b276ac71f16706c2ae8ee2a37ba9d03
+PKG_MIRROR_HASH:=745024632c9bd462f962abf6828b971fec6fc9f6154a7a05f6ed1eaa81882c66
 
 PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_MAINTAINER:=Dobroslaw Kijowski <dobo90@gmail.com>
 
-PKG_BUILD_DEPENDS:=golang/host node/host packr/host
+PKG_BUILD_DEPENDS:=golang/host node/host node-yarn/host packr/host
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
 GO_PKG:=github.com/AdguardTeam/AdGuardHome
-GO_PKG_EXCLUDES:=dhcpd/standalone
-GO_PKG_LDFLAGS_X:=main.version=$(PKG_VERSION) main.channel=release main.goarm=$(GO_ARM)
+GO_PKG_BUILD_PKG:=github.com/AdguardTeam/AdGuardHome
+
+AGH_VERSION_PKG:=github.com/AdguardTeam/AdGuardHome/internal/version
+GO_PKG_LDFLAGS_X:=$(AGH_VERSION_PKG).channel=release \
+	$(AGH_VERSION_PKG).version=$(PKG_SOURCE_VERSION) \
+	$(AGH_VERSION_PKG).goarm=$(GO_ARM) \
+	$(AGH_VERSION_PKG).gomips=$(GO_MIPS)
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
@@ -48,8 +53,7 @@ endef
 define Build/Compile
 	( \
 		pushd $(PKG_BUILD_DIR) ; \
-		npm --prefix client ci ; \
-		npm --prefix client run build-prod ; \
+		make js-deps js-build ; \
 		packr -z -v -i internal ; \
 		popd ; \
 		$(call GoPackage/Build/Compile) ; \


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_generic, NanoPi R2S, OpenWrt SNAPSHOT r15730
Run tested: aarch64_generic, NanoPi R2S, OpenWrt SNAPSHOT r15730

* Full changelog available at:
  * https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.105.0
  * https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.105.1
* Add node-yarn/host dependency as it is needed since [1].
* Adjust LDFLAGS to the new ones introduced in [2].
* Invoke targets from make instead of manually running npm and yarn.
* Replace GO_PKG_EXCLUDES with GO_PKG_BUILD_PKG as our intention is to
  build only one specific package (a cosmetic change).

[1]: https://github.com/AdguardTeam/AdGuardHome/commit/5e20ac7ed5de861ea5c945d1775f75312d62b69f#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R140
[2]: https://github.com/AdguardTeam/AdGuardHome/commit/0d67aa251d18f8ab47cfd90072e9d0387dff4224#diff-82ef468ec5547f1ed424776755a7f87dfec4eba9838d2c2ac02c9881bb67d737R60