### PR TITLE
sysrepo-plugind : option -v is correct

### DIFF
--- a/net/sysrepo/files/sysrepo.init
+++ b/net/sysrepo/files/sysrepo.init
@@ -9,7 +9,7 @@ PROG_PLUGIN=/usr/bin/sysrepo-plugind
 start_service() {
     procd_open_instance
     procd_set_param command ${PROG_PLUGIN}
-    procd_append_param command -d -l 0
+    procd_append_param command -d -v 0
     procd_set_param respawn
     procd_close_instance
 }


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
sysrepo-plugind : option -v is correct, -l is not correct 