### PR TITLE
xray-core: Update to 1.3.0

### DIFF
--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-core
-PKG_VERSION:=1.2.4
+PKG_VERSION:=1.3.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/XTLS/Xray-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=25f6c9edec0ac1f98328943cd2bb760ac7b69107582f9d27e43559da39dc01ed
+PKG_HASH:=1125af4411655abf47913af14a22fd7e2b13371e3566cc03676207519b0fe407
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@project-openwrt.eu.org>
 PKG_LICENSE:=MPL-2.0

--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -21,8 +21,8 @@ GO_PKG:=github.com/xtls/xray-core
 GO_PKG_BUILD_PKG:=github.com/xtls/xray-core/main
 GO_PKG_LDFLAGS:=-s -w
 GO_PKG_LDFLAGS_X:= \
-	$(GO_PKG)/core.version=$(PKG_VERSION) \
-	$(GO_PKG)/core.codename=OpenWrt
+	$(GO_PKG)/core.build=OpenWrt \
+	$(GO_PKG)/core.version=$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
@@ -80,24 +80,24 @@ define Package/xray-core/conffiles
 /etc/config/xray
 endef
 
-GEOIP_VER:=202101280019
+GEOIP_VER:=202102110014
 GEOIP_FILE:=geoip.dat.$(GEOIP_VER)
 
 define Download/geoip
   URL:=https://github.com/v2fly/geoip/releases/download/$(GEOIP_VER)/
   URL_FILE:=geoip.dat
   FILE:=$(GEOIP_FILE)
-  HASH:=69bb1f820f416e4591a7b76bfabf9fde9cce6550cddcc1a99b2ccafeb2a8ebd3
+  HASH:=c80e61b251fd76b09df5624b12cc84d7e1d9a0492b9acb43e21f0a244b1f9fc3
 endef
 
-GEOSITE_VER:=20210130061540
+GEOSITE_VER:=20210211141342
 GEOSITE_FILE:=dlc.dat.$(GEOSITE_VER)
 
 define Download/geosite
   URL:=https://github.com/v2fly/domain-list-community/releases/download/$(GEOSITE_VER)/
   URL_FILE:=dlc.dat
   FILE:=$(GEOSITE_FILE)
-  HASH:=bc9748c95b0545376356174b005fccfbc21d647df46293d5197853ee06a9c0a2
+  HASH:=e71b4acf2918851dd56e7cda714abb4758deb57b91d716911f33c453b909e796
 endef
 
 define Build/Prepare

--- a/net/xray-core/files/xray.conf
+++ b/net/xray-core/files/xray.conf
@@ -1,6 +1,7 @@
 
 config xray 'enabled'
 	option enabled '0'
+	option fullcone '1'
 
 config xray 'config'
 	option confdir '/etc/xray'

--- a/net/xray-core/files/xray.init
+++ b/net/xray-core/files/xray.init
@@ -18,11 +18,13 @@ start_service() {
 	local conffiles
 	local datadir
 	local format
+	local fullcone
 
 	config_get confdir "config" "confdir"
 	config_get conffiles "config" "conffiles"
 	config_get datadir "config" "datadir" "/usr/share/xray"
 	config_get format "config" "format" "json"
+	config_get fullcone "enabled" "fullcone" "0"
 
 	procd_open_instance "$CONF"
 	procd_set_param command "$PROG" run
@@ -34,6 +36,7 @@ start_service() {
 		done
 	}
 	procd_append_param command -format "$format"
+	[ "$fullcone" -eq "0" ] && procd_set_param env XRAY_CONE_DISABLED="true"
 	procd_set_param env XRAY_LOCATION_ASSET="$datadir"
 	procd_set_param file $conffiles
 

--- a/net/xray-core/test.sh
+++ b/net/xray-core/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+case "$1" in
+	"xray-core")
+		xray version 2>&1 | grep "${2#*v}"
+		;;
+esac


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip, x86_64
Run tested: rockchip nanopi-r2s

Description:
xray-geodata:
\* bump to latest version

xray-core:
\* adjust LDFLAGS
\* init: add option to control fullcone nat setting
\* add test script for action checking
\* bump to 1.3.0