### PR TITLE
[RFC] boost: build context under MIPS64

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.75.0
 PKG_SOURCE_VERSION:=1_75_0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://dl.bintray.com/boostorg/release/$(PKG_VERSION)/source/
@@ -117,7 +117,7 @@ define Package/boost/config
 	# Invisible config dependency
 	config boost-context-exclude
 		bool
-		default y if (TARGET_arc770 || TARGET_archs38 || TARGET_octeon || TARGET_octeontx)
+		default y if (TARGET_arc770 || TARGET_archs38)
 		default n
 
 	config boost-coroutine-exclude
@@ -387,7 +387,7 @@ EXTRA_CXXFLAGS += $(if $(CONFIG_GCC_USE_VERSION_10),-std=gnu++20,$(if $(CONFIG_G
 ifneq ($(findstring mips,$(ARCH)),)
     BOOST_ABI = o32
     ifneq ($(findstring 64,$(ARCH)),)
-        BOOST_ABI = o64
+        BOOST_ABI = n64
     endif
 else ifneq ($(findstring arm,$(ARCH)),)
     BOOST_ABI = aapcs

--- a/libs/boost/patches/010-mips64.patch
+++ b/libs/boost/patches/010-mips64.patch
@@ -1,0 +1,70 @@
+--- a/libs/context/src/asm/jump_mips64_n64_elf_gas.S
++++ b/libs/context/src/asm/jump_mips64_n64_elf_gas.S
+@@ -67,7 +67,7 @@ jump_fcontext:
+     sd  $ra, 144($sp) # save RA
+     sd  $ra, 152($sp) # save RA as PC
+ 
+-
++#if defined(__mips_hard_float)
+     s.d  $f24, 0($sp)   # save F24
+     s.d  $f25, 8($sp)   # save F25
+     s.d  $f26, 16($sp)  # save F26
+@@ -76,6 +76,7 @@ jump_fcontext:
+     s.d  $f29, 40($sp)  # save F29
+     s.d  $f30, 48($sp)  # save F30
+     s.d  $f31, 56($sp)  # save F31
++#endif
+ 
+     # store SP (pointing to old context-data) in v0 as return
+     move  $v0, $sp
+@@ -83,6 +84,7 @@ jump_fcontext:
+     # get SP (pointing to new context-data) from a0 param
+     move  $sp, $a0
+ 
++#if defined(__mips_hard_float)
+     l.d  $f24, 0($sp)   # restore F24
+     l.d  $f25, 8($sp)   # restore F25
+     l.d  $f26, 16($sp)  # restore F26
+@@ -91,6 +93,7 @@ jump_fcontext:
+     l.d  $f29, 40($sp)  # restore F29
+     l.d  $f30, 48($sp)  # restore F30
+     l.d  $f31, 56($sp)  # restore F31
++#endif
+ 
+     ld  $s0, 64($sp)  # restore S0
+     ld  $s1, 72($sp)  # restore S1
+--- a/libs/context/src/asm/ontop_mips64_n64_elf_gas.S
++++ b/libs/context/src/asm/ontop_mips64_n64_elf_gas.S
+@@ -67,7 +67,7 @@ ontop_fcontext:
+     sd  $ra, 144($sp) # save RA
+     sd  $ra, 152($sp) # save RA as PC
+ 
+-
++#if defined(__mips_hard_float)
+     s.d  $f24, 0($sp)   # save F24
+     s.d  $f25, 8($sp)   # save F25
+     s.d  $f26, 16($sp)  # save F26
+@@ -76,6 +76,7 @@ ontop_fcontext:
+     s.d  $f29, 40($sp)  # save F29
+     s.d  $f30, 48($sp)  # save F30
+     s.d  $f31, 56($sp)  # save F31
++#endif
+ 
+     # store SP (pointing to context-data) in t0
+     move  $t0, $sp
+@@ -83,6 +84,7 @@ ontop_fcontext:
+     # restore SP (pointing to context-data) from a0
+     move  $sp, $a0
+ 
++#if defined(__mips_hard_float)
+     l.d  $f24, 0($sp)   # restore F24
+     l.d  $f25, 8($sp)   # restore F25
+     l.d  $f26, 16($sp)  # restore F26
+@@ -91,6 +93,7 @@ ontop_fcontext:
+     l.d  $f29, 40($sp)  # restore F29
+     l.d  $f30, 48($sp)  # restore F30
+     l.d  $f31, 56($sp)  # restore F31
++#endif
+ 
+     ld  $s0, 64($sp)  # restore S0
+     ld  $s1, 72($sp)  # restore S1

--- a/libs/boost/patches/020-mips64-fiber.patch
+++ b/libs/boost/patches/020-mips64-fiber.patch
@@ -1,0 +1,11 @@
+--- a/boost/fiber/detail/cpu_relax.hpp
++++ b/boost/fiber/detail/cpu_relax.hpp
+@@ -47,7 +47,7 @@ namespace detail {
+ # else
+ #  define cpu_relax() asm volatile ("nop" ::: "memory");
+ # endif
+-#elif BOOST_ARCH_MIPS && (__mips_isa_rev > 1)
++#elif BOOST_ARCH_MIPS && (__mips_isa_rev > 1) && !defined(_MIPS_ARCH_OCTEONP)
+ # define cpu_relax() asm volatile ("pause" ::: "memory");
+ #elif BOOST_ARCH_PPC
+ // http://code.metager.de/source/xref/gnu/glibc/sysdeps/powerpc/sys/platform/ppc.h


### PR DESCRIPTION
Maintainer: @ClaymorePT 

This is a test PR.

I noticed the MIPS64 ABI parameter is wrong. Octeon platform uses N64 ABI by default.