### PR TITLE
openpgm: Add Pragmatic General Multicast library

### DIFF
--- a/libs/openpgm/Makefile
+++ b/libs/openpgm/Makefile
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=openpgm
+PKG_VERSION:=5.3.128
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL_FILE:=release-5-3-128
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_URL_FILE).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/steve-o/openpgm/tar.gz
+PKG_HASH:=8d707ef8dda45f4a7bc91016d7f2fed6a418637185d76c7ab30b306499c6d393
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_URL_FILE)
+
+PKG_FIXUP:=autoreconf
+MAKE_PATH:=openpgm/pgm
+PKG_AUTOMAKE_PATHS:=$(MAKE_PATH)
+
+PKG_MAINTAINER:=Ye Holmes <yeholmes@outlook.com>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=$(MAKE_PATH)/LICENSE
+PKG_CPE_ID:=cpe:/a:openpgm:openpgm
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/openpgm
+  TITLE:=OpenPGM, an implementation of the PGM protocol
+  URL:=http://openpgm.googlecode.com/
+  SECTION:=libs
+  CATEGORY:=Libraries
+endef
+
+define Package/openpgm/description
+  OpenPGM is a library implementing the PGM reliable multicast
+  network protocol. For more information about OpenPGM, see:
+  http://openpgm.googlecode.com/
+endef
+
+CONFIGURE_VARS += ac_cv_file__proc_cpuinfo=yes \
+    ac_cv_file__dev_rtc=no ac_cv_file__dev_hpet=no
+CONFIGURE_ARGS += --enable-static=no --enable-shared=yes
+
+define Build/Configure
+	$(call Build/Configure/Default,,,$(MAKE_PATH))
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/pgm
+	$(CP) $(PKG_BUILD_DIR)/$(MAKE_PATH)/include/pgm/* $(1)/usr/include/pgm/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_BUILD_DIR)/$(MAKE_PATH)/.libs/libpgm*.so* $(1)/usr/lib/
+	$(CP) $(PKG_BUILD_DIR)/$(MAKE_PATH)/openpgm-5.3.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/openpgm/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/$(MAKE_PATH)/.libs/libpgm*.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,openpgm))

--- a/libs/openpgm/patches/0001-Rename-openpgm-5.2.pc.in.patch
+++ b/libs/openpgm/patches/0001-Rename-openpgm-5.2.pc.in.patch
@@ -1,0 +1,45 @@
+From 240634b1afb968a051f8c68696eae2a582a02450 Mon Sep 17 00:00:00 2001
+From: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+Date: Mon, 31 Aug 2020 20:16:25 +0200
+Subject: [PATCH 1/2] Rename openpgm-5.2.pc.in
+
+This will fix the following build failure:
+
+config.status: error: cannot find input file: `openpgm-5.3.pc.in'
+
+Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+---
+ openpgm/pgm/{openpgm-5.2.pc.in => openpgm-5.3.pc.in} | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+ rename openpgm/pgm/{openpgm-5.2.pc.in => openpgm-5.3.pc.in} (100%)
+
+--- a/openpgm/pgm/openpgm-5.2.pc.in
++++ /dev/null
+@@ -1,12 +0,0 @@
+-prefix=@prefix@
+-exec_prefix=@exec_prefix@
+-libdir=@libdir@
+-includedir=@includedir@
+-
+-Name: OpenPGM
+-Description: PGM Protocol Library.
+-Version: @PACKAGE_VERSION@
+-# packagers may wish to move @LIBS@ to Libs.private for platforms with
+-# versions of pkg-config that support static linking.
+-Libs: -L${libdir} -lpgm @LIBS@
+-Cflags: -I${includedir}/pgm-@VERSION_MAJOR@.@VERSION_MINOR@
+--- /dev/null
++++ b/openpgm/pgm/openpgm-5.3.pc.in
+@@ -0,0 +1,12 @@
++prefix=@prefix@
++exec_prefix=@exec_prefix@
++libdir=@libdir@
++includedir=@includedir@
++
++Name: OpenPGM
++Description: PGM Protocol Library.
++Version: @PACKAGE_VERSION@
++# packagers may wish to move @LIBS@ to Libs.private for platforms with
++# versions of pkg-config that support static linking.
++Libs: -L${libdir} -lpgm @LIBS@
++Cflags: -I${includedir}/pgm-@VERSION_MAJOR@.@VERSION_MINOR@

--- a/libs/openpgm/patches/0002-openpgm-pgm-checksum.c-fix-build-with-32-bits-MMX.patch
+++ b/libs/openpgm/patches/0002-openpgm-pgm-checksum.c-fix-build-with-32-bits-MMX.patch
@@ -1,0 +1,33 @@
+From b7fa865fa6b06d97d424c500fd1c4bc44c096359 Mon Sep 17 00:00:00 2001
+From: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+Date: Sun, 1 Nov 2020 22:46:18 +0100
+Subject: [PATCH 2/2] openpgm/pgm/checksum.c: fix build with 32 bits MMX
+
+Build with i386-pentium-mmx or i686 is broken since version 5-3-128 and
+https://github.com/steve-o/openpgm/commit/b276dc15be5d4e6e1143b9de25d09f63f9c85135
+because _mm_cvtm64_si64 is undefined resulting in the following build
+failure for example on zeromq:
+
+/srv/storage/autobuild/run/instance-3/output-1/host/opt/ext-toolchain/bin/../lib/gcc/i586-buildroot-linux-musl/8.3.0/../../../../i586-buildroot-linux-musl/bin/ld: /srv/storage/autobuild/run/instance-3/output-1/host/i586-buildroot-linux-musl/sysroot/usr/lib32/libpgm-5.3.so.0: undefined reference to `_mm_cvtm64_si64'
+
+So use the fallback if __x86_64__ is not defined
+
+Fixes:
+ - http://autobuild.buildroot.org/results/01d9be37e8a743307128f53f41785654c9971e1a
+
+Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+---
+ openpgm/pgm/checksum.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/openpgm/pgm/checksum.c
++++ b/openpgm/pgm/checksum.c
+@@ -948,7 +948,7 @@ do_csumcpy_mmx (
+ 
+ 		sum = _mm_add_pi32 (sum, lo);
+ 		sum = _mm_add_pi32 (sum, hi);
+-#if 1
++#if defined(__x86_64__)
+ 		*(int64_t*)dst = _mm_cvtm64_si64 (tmp);
+ #else		
+ 		((int*)dst)[1] = _mm_cvtsi64_si32 (tmp);


### PR DESCRIPTION
OpenPGM is a library implementing the PGM reliable multicast
network protocol; The famous messaging library ZMQ has an
optional dependency on OpenPGM, with OpenPGM enabled, we can
foster the development of multicast network applications.

Signed-off-by: Ye Holmes <yeholmes@outlook.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
The PR is intended to add new package under libs directory, OpenPGM.
The downloaded source tarball is named as openpgm-release-5-3-128.tar.gz.
Two more patches since the release tarball are also included.