### PR TITLE
Nebula: downloading tarball with name and its version instead of just version and cosmetic polishing of Makefile

### DIFF
--- a/net/nebula/Makefile
+++ b/net/nebula/Makefile
@@ -6,11 +6,12 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=nebula
 PKG_VERSION:=1.3.0
 PKG_RELEASE:=1
-PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/slackhq/nebula/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=b94fba0251a4a436e25b127d0b9bc0181b991631f1dc8e344b1c8e895b55375d
+
+PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 

--- a/net/nebula/Makefile
+++ b/net/nebula/Makefile
@@ -8,8 +8,8 @@ PKG_VERSION:=1.3.0
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 
-PKG_SOURCE:=v$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/slackhq/nebula/archive/
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/slackhq/nebula/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=b94fba0251a4a436e25b127d0b9bc0181b991631f1dc8e344b1c8e895b55375d
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @stangri 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: not needed and also bumping of PKG_RELEASE should not be necessary.

Description:
Previous code was downloading file **v1.3.0, which is wrong,** because in
the dl folder there might be some tarballs with that naming and they are
wrong as well.

This could lead to some issues like this:
Hash of the local file v1.3.0.tar.gz does not match (file: `87cf846b02dde6328b84832287d8725d91f12f41366eecb4d59eeda1d6c7efdf, requested: b94fba0251a4a436e25b127d0b9bc0181b991631f1dc8e344b1c8e895b55375d) - deleting download.`

Even though, if you tried it on SDK or minimal build when there is a
small number of packages, you most likely don't encounter it.

The correct solution is to download files with their name and version.
**E.g. nebula-version.tar.gz as it is in PKG_SOURCE variable now.**

____

**This can be verified by command: make package/nebula/{clean,download} V=s**
and then checking dl folder.