### PR TITLE
geth: add libiconv-full dependency if build with NLS

### DIFF
--- a/net/geth/Makefile
+++ b/net/geth/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=go-ethereum
 PKG_VERSION:=1.9.22
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ethereum/go-ethereum/tar.gz/v${PKG_VERSION}?
@@ -35,7 +35,7 @@ define Package/geth
   CATEGORY:=Network
   TITLE:=Ethereum Go client
   URL:=https://geth.ethereum.org/
-  DEPENDS:=$(GO_ARCH_DEPENDS)
+  DEPENDS:=$(GO_ARCH_DEPENDS) $(ICONV_DEPENDS)
 endef
 
 define Package/geth/description

--- a/net/geth/Makefile
+++ b/net/geth/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=go-ethereum
-PKG_VERSION:=1.9.22
-PKG_RELEASE:=2
+PKG_VERSION:=1.9.25
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ethereum/go-ethereum/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=cda67de8e76afaad28b8bb4d3e5a95d01f88f69ab2c25964bc8ee2d368794d8c
+PKG_HASH:=d7b733aeef4eba97f5351ba435001fa7365f55adabffdfdda909700335e98b0e
 
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
 PKG_LICENSE:=GPL-3.0-or-later LGPL-3.0-or-later


### PR DESCRIPTION
Maintainer: @mislavn
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
Variable ICONV_DEPENDS is specified in nls.sk which can be found in
OpenWrt main repository.

This fixes issue:
/foo/build/staging_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-8.4.0_musl_eabi/lib/gcc/arm-openwrt-linux-muslgnueabi/8.4.0/../../../../arm-openwrt-linux-muslgnueabi/bin/ld: cannot find -liconv

Fixes:  https://github.com/openwrt/packages/issues/14731