### PR TITLE
ddns-scripts: add * to DNS_CHARSET list

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -71,7 +71,7 @@ IPV6_REGEX="\(\([0-9A-Fa-f]\{1,4\}:\)\{1,\}\)\(\([0-9A-Fa-f]\{1,4\}\)\{0,1\}\)\(
 SHELL_ESCAPE="[\"\'\`\$\!();><{}?|\[\]\*\\\\]"
 
 # dns character set
-DNS_CHARSET="[@a-zA-Z0-9._-]"
+DNS_CHARSET="[@a-zA-Z0-9._-*]"
 
 # detect if called by ddns-lucihelper.sh script, disable retrys (empty variable == false)
 LUCI_HELPER=$(printf %s "$MYPROG" | grep -i "luci")


### PR DESCRIPTION
Compile tested: none - just edited the SH in my local FS
Run tested:
Model：PC Engines apu2
Architecture：AMD GX-412TC SOC
Firmware Version：OpenWrt SNAPSHOT r14528-7190fb2da4



Description:
add wildcard domain support to ddns scripts.
nothing more is needed to get this to work with * in domain names