### PR TITLE
openconnect: fix dependencies to iconv/intl (fixes #14734)

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=8.10
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://ftp.infradead.org/pub/openconnect/
@@ -26,6 +26,7 @@ PKG_CONFIG_DEPENDS:= \
 PKG_USE_MIPS16:=0
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/openconnect/config
 	source "$(SOURCE)/Config.in"
@@ -34,7 +35,7 @@ endef
 define Package/openconnect
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libxml2 +kmod-tun +resolveip +vpnc-scripts +OPENCONNECT_OPENSSL:libopenssl +OPENCONNECT_OPENSSL:p11-kit +OPENCONNECT_OPENSSL:libp11 +OPENCONNECT_GNUTLS:libgnutls +OPENCONNECT_GNUTLS:libtasn1 +OPENCONNECT_STOKEN:libstoken
+  DEPENDS:=+libxml2 +kmod-tun +resolveip +vpnc-scripts +OPENCONNECT_OPENSSL:libopenssl +OPENCONNECT_OPENSSL:p11-kit +OPENCONNECT_OPENSSL:libp11 +OPENCONNECT_GNUTLS:libgnutls +OPENCONNECT_GNUTLS:libtasn1 +OPENCONNECT_STOKEN:libstoken $(ICONV_DEPENDS) $(INTL_DEPENDS)
   TITLE:=OpenConnect VPN client (Cisco AnyConnect and Juniper/Pulse compatible)
   MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
   URL:=https://www.infradead.org/openconnect/
@@ -55,6 +56,8 @@ endef
 
 CONFIGURE_ARGS += \
 	--disable-shared \
+	--with-libiconv-prefix=$(ICONV_PREFIX) \
+	--with-libintl-prefix=$(INTL_PREFIX) \
 	--with-vpnc-script=/lib/netifd/vpnc-script \
 	--without-libpcsclite \
 	--without-stoken \


### PR DESCRIPTION
Maintainer: @nmav
Compile tested: mxs
Run tested: -

Description:

This fixes the issue raised after d18692c (libxml2: allow building with iconv support).

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
