### PR TITLE
open-vm-tools: update to 11.2.5

### DIFF
--- a/utils/open-vm-tools/Makefile
+++ b/utils/open-vm-tools/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=open-vm-tools
-PKG_VERSION:=11.2.0
+PKG_VERSION:=11.2.5
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-16938113.tar.gz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-17337674.tar.gz
 PKG_SOURCE_URL:=https://github.com/vmware/open-vm-tools/releases/download/stable-$(PKG_VERSION)
-PKG_HASH:=df16b78bb919e85fe2b9190148f4987ea4942f9f9667836bf1311dfc2eb839db
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)-16938113
+PKG_HASH:=d01c9e036536b569ee561e33302e9dad1c2ac27c04f762ebdc3f81791cb44566
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)-17337674
 
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=LICENSE
@@ -79,6 +79,13 @@ CONFIGURE_ARGS+= \
 	--enable-resolutionkms=no
 
 TARGET_LDFLAGS += -liconv
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+ifeq ($(QUILT),)
+	mv $(PKG_BUILD_DIR)/lib/include/poll.h $(PKG_BUILD_DIR)/lib/include/vm_poll.h
+endif
+endef
 
 define Package/open-vm-tools/install
 	$(INSTALL_DIR) $(1)/etc/init.d/

--- a/utils/open-vm-tools/patches/0008-Rename-poll.h-to-vm_poll.h.patch
+++ b/utils/open-vm-tools/patches/0008-Rename-poll.h-to-vm_poll.h.patch
@@ -42,10 +42,6 @@
  #include "vm_basic_asm.h"
  
  #if defined(__cplusplus)
-diff --git a/lib/include/poll.h b/lib/include/vm_poll.h
-rename from lib/include/poll.h
-rename to lib/include/vm_poll.h
-diff --git a/lib/rpcIn/rpcin.c b/lib/rpcIn/rpcin.c
 --- a/lib/rpcIn/rpcin.c
 +++ b/lib/rpcIn/rpcin.c
 @@ -57,7 +57,7 @@


### PR DESCRIPTION
Work around a quilt bug where instead of showing a rename, it removes
and duplicates the file.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @srchack 
Compile tested: i386