### PR TITLE
python-requests: split up patches into two files

### DIFF
--- a/lang/python/python-requests/patches/0001-idna-dependency-bump.patch
+++ b/lang/python/python-requests/patches/0001-idna-dependency-bump.patch
@@ -12,43 +12,14 @@ https://github.com/psf/requests/pull/5711
  setup.py | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/setup.py b/setup.py
-index 7ba4b2a25f..f265384236 100755
 --- a/setup.py
 +++ b/setup.py
-@@ -43,7 +43,7 @@ def run_tests(self):
-
+@@ -43,7 +43,7 @@ packages = ['requests']
+ 
  requires = [
      'chardet>=3.0.2,<5',
 -    'idna>=2.5,<3',
 +    'idna>=2.5,<4',
      'urllib3>=1.21.1,<1.27',
      'certifi>=2017.4.17'
-
-
-From d3e00a4958af046879f24de365d5589d861ea6ef Mon Sep 17 00:00:00 2001
-From: Naor Livne <naorlivne@gmail.com>
-Date: Tue, 5 Jan 2021 16:31:15 +0200
-Subject: [PATCH 2/2] Update setup.py
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-Content-Transfer-Encoding: 8bit
-
-Co-authored-by: Mickaël Schoentgen <contact@tiger-222.fr>
----
- setup.py | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
-
-diff --git a/setup.py b/setup.py
-index f265384236..5ce59e621d 100755
---- a/setup.py
-+++ b/setup.py
-@@ -43,7 +43,8 @@ def run_tests(self):
-
- requires = [
-     'chardet>=3.0.2,<5',
--    'idna>=2.5,<4',
-+    'idna>=2.5,<3 ; python_version < "3"',
-+    'idna>=2.5,<4 ; python_version >= "3"',
-     'urllib3>=1.21.1,<1.27',
-     'certifi>=2017.4.17'
+ 

--- a/lang/python/python-requests/patches/0002-idna-dependency-bump.patch
+++ b/lang/python/python-requests/patches/0002-idna-dependency-bump.patch
@@ -1,0 +1,25 @@
+From d3e00a4958af046879f24de365d5589d861ea6ef Mon Sep 17 00:00:00 2001
+From: Naor Livne <naorlivne@gmail.com>
+Date: Tue, 5 Jan 2021 16:31:15 +0200
+Subject: [PATCH 2/2] Update setup.py
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Co-authored-by: Mickaël Schoentgen <contact@tiger-222.fr>
+---
+ setup.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/setup.py
++++ b/setup.py
+@@ -43,7 +43,8 @@ packages = ['requests']
+ 
+ requires = [
+     'chardet>=3.0.2,<5',
+-    'idna>=2.5,<4',
++    'idna>=2.5,<3 ; python_version < "3"',
++    'idna>=2.5,<4 ; python_version >= "3"',
+     'urllib3>=1.21.1,<1.27',
+     'certifi>=2017.4.17'
+ 


### PR DESCRIPTION
quilt cannot handle two patches in one file. It ends up merging them
and removing the description from the second. To avoid this, split into
two.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @BKPepe 

No PKG_RELEASE bump as this is mostly cosmetic.