### PR TITLE
rpcbind: clean up patches using quilt

### DIFF
--- a/net/rpcbind/patches/001-CVE-2017-8779-dos-via-memory-consumption.patch
+++ b/net/rpcbind/patches/001-CVE-2017-8779-dos-via-memory-consumption.patch
@@ -6,8 +6,6 @@ Origin: Guido Vranken
 Description: Fixes CVE-2017-8779 (DOS by remote attackers - memory consumption
 without subsequent free).
 
-diff --git a/src/rpcb_svc_com.c b/src/rpcb_svc_com.c
-index 5862c26..e11f61b 100644
 --- a/src/rpcb_svc_com.c
 +++ b/src/rpcb_svc_com.c
 @@ -48,6 +48,7 @@
@@ -18,7 +16,7 @@ index 5862c26..e11f61b 100644
  #include <netconfig.h>
  #include <errno.h>
  #include <syslog.h>
-@@ -432,7 +433,7 @@ rpcbproc_taddr2uaddr_com(void *arg, struct svc_req *rqstp /*__unused*/,
+@@ -432,7 +433,7 @@ rpcbproc_taddr2uaddr_com(void *arg, stru
  static bool_t
  xdr_encap_parms(XDR *xdrs, struct encap_parms *epp)
  {

--- a/net/rpcbind/patches/002-fix_stack_buffer_overflow.patch
+++ b/net/rpcbind/patches/002-fix_stack_buffer_overflow.patch
@@ -1,9 +1,9 @@
 From 0bc1c0ae7ce61a7ac8a8e9a9b2086268f011abf0 Mon Sep 17 00:00:00 2001
 From: Steve Dickson <steved@redhat.com>
 Date: Tue, 9 Oct 2018 09:19:50 -0400
-Subject: [PATCH 1/1] rpcinfo: Fix stack buffer overflow
+Subject: [PATCH] rpcinfo: Fix stack buffer overflow
 
-*** buffer overflow detected ***: rpcinfo terminated
+buffer overflow detected: rpcinfo terminated
 ======= Backtrace: =========
 /lib64/libc.so.6(+0x721af)[0x7ff24c4451af]
 /lib64/libc.so.6(__fortify_fail+0x37)[0x7ff24c4ccdc7]
@@ -23,8 +23,6 @@ Signed-off-by: Steve Dickson <steved@redhat.com>
  src/rpcinfo.c | 23 +++++++++++++++++------
  1 file changed, 17 insertions(+), 6 deletions(-)
 
-diff --git a/src/rpcinfo.c b/src/rpcinfo.c
-index 9b46864..cfdba88 100644
 --- a/src/rpcinfo.c
 +++ b/src/rpcinfo.c
 @@ -973,6 +973,7 @@ rpcbdump (dumptype, netid, argc, argv)
@@ -64,6 +62,3 @@ index 9b46864..cfdba88 100644
  	  printf ("%-32s", buf);
  	  rpc = getrpcbynumber (rs->prog);
  	  if (rpc)
--- 
-1.8.3.1
-


### PR DESCRIPTION
The second one was manually modified as quilt gets confused by the ***
and ends up removing the commit description.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Andy2244 