### PR TITLE
klish: add include for nls when BUILD_NLS is enabled

### DIFF
--- a/utils/klish/Makefile
+++ b/utils/klish/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=klish
 PKG_VERSION:=2.2.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://libcode.org/attachments/download/77/
@@ -24,6 +24,7 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/klish/default
   SECTION:=utils


### PR DESCRIPTION
Maintainer: @t-umeno
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master and enabled hardening, NLS
Run tested: N/A

Description:
In recent commit for libxml2 [1], there was enabled support for iconv,
but it relieves issue with klish that it does not compile as it fails with
following output:

checking for xmlNewDoc in -lxml2... no
configure: error: cannot find libxml2 library
make[2]: *** [Makefile:73: /foo/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/klish-2.2.0/.configured_68b329da9893e34099c7d8ad5cb9c940] Error 1
make[2]: Leaving directory '/foo/build/feeds/packages/utils/klish'

[1] https://github.com/openwrt/packages/commit/d18692c92638cdc1e643554699cb21e893abf2e9


