### PR TITLE
strongswan: fix local_gateway discovery

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/ipsec.init
+++ b/net/strongswan/files/ipsec.init
@@ -249,7 +249,7 @@ config_remote() {
 		local ipdest
 
 		[ "$remote_gateway" = "%any" ] && ipdest="1.1.1.1" || ipdest="$remote_gateway"
-		local_gateway=`ip route get $ipdest | awk -F"src" '/src/{gsub(/ /,"");print $2}'`
+		local_gateway=$(ip -o route get "$ipdest" | awk '/ src / { print gensub(/^.* src ([^ ]*) .*$/, "\\1", "g"); }')
 	}
 
 	[ -n "$local_identifier" ] && secret_xappend -n "$local_identifier " || secret_xappend -n "$local_gateway "


### PR DESCRIPTION
Maintainer: @stintel
Compile tested: x86_64, generic, head (7d12f29ae1)
Run tested: same, running on a production router

Description:

This has been observed by myself and @luizluca: `ip route get` is appending `uid0` to the output, as seen from:

```
root@OpenWrt2:~# ip route get 1.1.1.1
1.1.1.1 via 174.27.160.1 dev eth3 src 174.27.182.184 uid 0 
    cache 
root@OpenWrt2:~#
```

so the fix is an anchored match, discarding all else.  Also, using `ip -o` means never having to do multiline matches...