### PR TITLE
python3: Fix target python-config when building on macOS

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 include ../python3-version.mk
 
 PKG_NAME:=python3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=$(PYTHON3_VERSION).$(PYTHON3_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -299,6 +299,8 @@ endif
 ifeq ($(HOST_OS),Darwin)
 HOST_CONFIGURE_VARS += \
 	ac_cv_header_libintl_h=no
+HOST_MAKE_VARS += \
+	USE_PYTHON_CONFIG_PY=1
 endif
 
 HOST_CONFIGURE_ARGS+= \
@@ -315,8 +317,8 @@ define Host/Configure
 endef
 
 define Host/Compile
-	+$(HOST_MAKE_VARS) $(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR) python
-	+$(HOST_MAKE_VARS) $(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR) sharedmods
+	$(call Host/Compile/Default,python)
+	$(call Host/Compile/Default,sharedmods)
 endef
 
 define Host/Install
@@ -336,7 +338,7 @@ define Host/Install
 			$(HOST_PYTHON3_PKG_DIR)/.pip-patched* \
 			$(HOST_PYTHON3_PKG_DIR)/.pip_installed_*
 	)
-	$(MAKE) -C $(HOST_BUILD_DIR) install
+	$(call Host/Install/Default)
 	$(if $(wildcard $(HOST_PYTHON3_PKG_DIR)/.setuptools_installed_$(PYTHON3_SETUPTOOLS_VERSION)-$(PYTHON3_SETUPTOOLS_PKG_RELEASE)),,
 		$(call HostPatchDir,$(HOST_PYTHON3_PKG_DIR),./patches-setuptools,)
 		touch $(HOST_PYTHON3_PKG_DIR)/.setuptools_installed_$(PYTHON3_SETUPTOOLS_VERSION)-$(PYTHON3_SETUPTOOLS_PKG_RELEASE)

--- a/lang/python/python3/patches/025-choose-python-config-version.patch
+++ b/lang/python/python3/patches/025-choose-python-config-version.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -1586,7 +1586,7 @@ python-config: $(srcdir)/Misc/python-con
+ 	@ # On Darwin, always use the python version of the script, the shell
+ 	@ # version doesn't use the compiler customizations that are provided
+ 	@ # in python (_osx_support.py).
+-	@if test `uname -s` = Darwin; then \
++	@if test "$(USE_PYTHON_CONFIG_PY)" = 1; then \
+ 		cp python-config.py python-config; \
+ 	fi
+ 


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-32, 2020-02-14 snapshot sdk (Ubuntu 20.10); ramips (mt76x8), OpenWrt master (a45953c) (macOS Catalina 10.15.7)
Run tested: N/A

Description:
The Python version of python-config is installed when building on macOS, rather than the shell script version when building on Linux. When run on macOS, the Python version of python-config will return values with Mac-specific customizations.

This patches the python-config install recipe so that which version is installed can be controlled by the package makefile. When building on macOS, this installs the Python version for host Python and the shell script version for target Python.

This also updates `Host/Compile` and `Host/Install` to use the default host build recipes, so that the various `HOST_*` variables are taken into account automatically.

Fixes https://github.com/openwrt/packages/issues/14652

Signed-off-by: Jeffery To <jeffery.to@gmail.com>