### PR TITLE
node: make hostpkg icu-enabled

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
 PKG_VERSION:=v14.15.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
@@ -127,7 +127,7 @@ HOST_CONFIGURE_VARS:=
 
 HOST_CONFIGURE_ARGS:= \
 	--dest-os=$(if $(findstring Darwin,$(HOST_OS)),mac,linux) \
-	--with-intl=none \
+	--with-intl=small-icu \
 	--prefix=$(STAGING_DIR_HOSTPKG)
 
 define Build/InstallDev


### PR DESCRIPTION
Maintainer: me @ianchi
 Compile tested: head r15827-0e43f62, arm
 Run tested: (qemu 5.2.0) arm

Description:
make hostpkg icu-enabled

Made the necessary changes to build the latest version of adguardhome.
See this thread : https://github.com/openwrt/packages/pull/14717

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
