### PR TITLE
zmq: add optional dependency on openpgm

### DIFF
--- a/libs/zmq/Makefile
+++ b/libs/zmq/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zeromq
 PKG_VERSION:=4.3.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/zeromq/libzmq/releases/download/v$(PKG_VERSION)
@@ -37,16 +37,24 @@ define Package/libzmq/default
   PROVIDES:=libzmq
 endef
 
+define Package/libzmq/default-config
+config LIBZMQ_$(2)_WITH_OPENPGM
+	depends on PACKAGE_libzmq-$(1)
+	bool "enable openpgm support for libzmq-$(1)"
+	default n
+endef
+
 define Package/libzmq-nc
   $(call Package/libzmq/default)
   VARIANT:=nc
+  DEPENDS+=+LIBZMQ_NC_WITH_OPENPGM:openpgm
 endef
 
 define Package/libzmq-curve
   $(call Package/libzmq/default)
   VARIANT:=curve
   TITLE+= (CurveZMQ)
-  DEPENDS+=+libsodium
+  DEPENDS+=+libsodium +LIBZMQ_CURVE_WITH_OPENPGM:openpgm
 endef
 
 define Package/libzmq-nc/description
@@ -56,6 +64,14 @@ endef
 define Package/libzmq-curve/description
  $(call Package/libzmq-nc/description)
  Includes CurveZMQ security by libsodium.
+endef
+
+define Package/libzmq-nc/config
+	$(call Package/libzmq/default-config,nc,NC)
+endef
+
+define Package/libzmq-curve/config
+	$(call Package/libzmq/default-config,curve,CURVE)
 endef
 
 CMAKE_OPTIONS += \
@@ -73,7 +89,6 @@ CMAKE_OPTIONS += \
 	-DENABLE_EVENTFD=ON \
 	-DPOLLER=epoll \
 	-DRT_LIBRARY=OFF \
-	-DWITH_OPENPGM=OFF \
 	-DZMQ_BUILD_TESTS=OFF \
 	-DWITH_LIBBSD=O$(if $(CONFIG_USE_GLIBC),N,FF)
 
@@ -81,6 +96,14 @@ ifeq ($(BUILD_VARIANT),curve)
 	CMAKE_OPTIONS += -DWITH_LIBSODIUM=ON
 else
   	CMAKE_OPTIONS += -DWITH_LIBSODIUM=OFF
+endif
+
+ifeq ($(CONFIG_LIBZMQ_NC_WITH_OPENPGM),y)
+	CMAKE_OPTIONS += -DWITH_OPENPGM=ON
+else ifeq ($(CONFIG_LIBZMQ_CURVE_WITH_OPENPGM),y)
+	CMAKE_OPTIONS += -DWITH_OPENPGM=ON
+else
+	CMAKE_OPTIONS += -DWITH_OPENPGM=OFF
 endif
 
 define Build/InstallDev

--- a/libs/zmq/patches/0001-fix-openpgm-linking-for-zeromq.patch
+++ b/libs/zmq/patches/0001-fix-openpgm-linking-for-zeromq.patch
@@ -1,0 +1,40 @@
+From 68546793d3ead9fef78f4b6670b4bee92ae99bc8 Mon Sep 17 00:00:00 2001
+From: Ye Holmes <yeholmes@outlook.com>
+Date: Wed, 17 Feb 2021 19:26:52 +0800
+Subject: [PATCH] fix-openpgm-linking-for-zeromq
+
+---
+ CMakeLists.txt | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -793,7 +793,7 @@ else()
+     # message(FATAL_ERROR "WITH_OPENPGM not implemented")
+ 
+     if(NOT OPENPGM_PKGCONFIG_NAME)
+-      set(OPENPGM_PKGCONFIG_NAME "openpgm-5.2")
++      set(OPENPGM_PKGCONFIG_NAME "openpgm-5.3")
+     endif()
+ 
+     set(OPENPGM_PKGCONFIG_NAME
+@@ -804,6 +804,8 @@ else()
+ 
+     if(OPENPGM_FOUND)
+       message(STATUS ${OPENPGM_PKGCONFIG_NAME}" found")
++      find_library(OPENPGM_LIBRARIES NAMES libpgm pgm)
++      set(pkg_config_libs_private "${pkg_config_libs_private} -lpgm")
+       set(pkg_config_names_private "${pkg_config_names_private} ${OPENPGM_PKGCONFIG_NAME}")
+     else()
+       message(
+@@ -1447,6 +1449,10 @@ if(BUILD_SHARED)
+     endif()
+   endif()
+ 
++  if(OPENPGM_FOUND)
++   target_link_libraries(libzmq ${OPENPGM_LIBRARIES})
++  endif()
++
+   if(HAVE_WS2_32)
+     target_link_libraries(libzmq ws2_32)
+   elseif(HAVE_WS2)


### PR DESCRIPTION
And add a patch for CMakeList.txt to configure
correctly with openpgm enabled.

Signed-off-by: Ye Holmes <yeholmes@outlook.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
Add an optional dependency on openpgm, for libzmq-curve/libzmq-nc.
The menuconfig shown as below:

<\*> libzmq-curve.................... ZeroMQ - Message Queue engine (CurveZMQ)
[   ]   enable openpgm support for libzmq-curve (NEW)
<\*> libzmq-nc.................................. ZeroMQ - Message Queue engine
[   ]   enable openpgm support for libzmq-nc  (NEW)