### PR TITLE
pingcheck: Remove unnecessary PKG_SOURCE and _SUBDIR

### DIFF
--- a/net/pingcheck/Makefile
+++ b/net/pingcheck/Makefile
@@ -9,14 +9,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pingcheck
 PKG_VERSION:=2020-02-12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_MIRROR_HASH:=3890cd39add7e523ab7418faf6a7ae1a1f71d2739982e6e09aa33cc6defac8be
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://github.com/br101/pingcheck
 PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/br101/pingcheck
 PKG_SOURCE_VERSION:=520718f9377eab49888a3e38ece59f9ad94d978e
+PKG_MIRROR_HASH:=3890cd39add7e523ab7418faf6a7ae1a1f71d2739982e6e09aa33cc6defac8be
 
 PKG_MAINTAINER:=Bruno Randolf <br1@einfach.org>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Adressing issue #14773

Signed-off-by: Bruno Randolf <br1@einfach.org>

Maintainer: me
Compile tested: ar71xx, Rambutan
Run tested: not necessary

Description: addressing issue #14773 removing unneeded directives
