### PR TITLE
ksmbd: remove kmod-crypto-arc4 dependency

### DIFF
--- a/kernel/ksmbd/Makefile
+++ b/kernel/ksmbd/Makefile
@@ -29,7 +29,6 @@ define KernelPackage/fs-ksmbd
 		+kmod-crypto-md4 \
 		+kmod-crypto-md5 \
 		+kmod-crypto-hmac \
-		+kmod-crypto-arc4 \
 		+kmod-crypto-ecb \
 		+kmod-crypto-des \
 		+kmod-crypto-sha256 \


### PR DESCRIPTION
Maintainer: @neheb and @Andy2244 
Compile tested: N/A
Run tested: N/A

Description:
Fixes: https://github.com/openwrt/packages/issues/14771

Run test and compile test will follow.