### PR TITLE
banip: update to 0.7.2

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
-PKG_VERSION:=0.7.1
-PKG_RELEASE:=2
+PKG_VERSION:=0.7.2
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/banip/files/README.md
+++ b/net/banip/files/README.md
@@ -8,34 +8,35 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 ## Main Features
 * Support of the following fully pre-configured domain blocklist sources (free for private usage, for commercial use please check their individual licenses)
 
-| Source              | Focus                        | Information                                                                       |
-| :------------------ | :--------------------------: | :-------------------------------------------------------------------------------- |
-| asn                 | ASN block                    | [Link](https://asn.ipinfo.app)                                                    |
-| bogon               | Bogon prefixes               | [Link](https://team-cymru.com)                                                    |
-| country             | Country blocks               | [Link](https://www.ipdeny.com/ipblocks)                                           |
-| darklist            | Attacker IP blacklist        | [Link](https://darklist.de)                                                       |
-| debl                | Fail2ban IP blacklist        | [Link](https://www.blocklist.de)                                                  |
-| doh                 | Public DoH-Provider          | [Link](https://github.com/dibdot/DoH-IP-blocklists)                               |
-| drop                | Spamhaus drop compilation    | [Link](https://www.spamhaus.org)                                                  |
-| dshield             | Dshield IP blocklist         | [Link](https://www.dshield.org)                                                   |
-| edrop               | Spamhaus edrop compilation   | [Link](https://www.spamhaus.org)                                                  |
-| feodo               | Feodo Tracker                | [Link](https://feodotracker.abuse.ch)                                             |
-| firehol1            | Firehol Level 1 compilation  | [Link](https://iplists.firehol.org/?ipset=firehol_level1)                         |
-| firehol2            | Firehol Level 2 compilation  | [Link](https://iplists.firehol.org/?ipset=firehol_level2)                         |
-| firehol3            | Firehol Level 3 compilation  | [Link](https://iplists.firehol.org/?ipset=firehol_level3)                         |
-| firehol4            | Firehol Level 4 compilation  | [Link](https://iplists.firehol.org/?ipset=firehol_level4)                         |
-| iblockads           | Advertising blocklist        | [Link](https://www.iblocklist.com)                                                |
-| iblockspy           | Malicious spyware blocklist  | [Link](https://www.iblocklist.com)                                                |
-| myip                | Myip Live IP blacklist       | [Link](https://myip.ms)                                                           |
-| nixspam             | iX spam protection           | [Link](http://www.nixspam.org)                                                    |
-| proxy               | Firehol list of open proxies | [Link](https://iplists.firehol.org/?ipset=proxylists)                             |
-| ssbl                | SSL botnet IP blacklist      | [Link](https://sslbl.abuse.ch)                                                    |
-| threat              | Emerging Threats             | [Link](https://rules.emergingthreats.net)                                         |
-| tor                 | Tor exit nodes               | [Link](https://fissionrelays.net/lists)                                           |
-| uceprotect1         | Spam protection level 1      | [Link](http://www.uceprotect.net/en/index.php)                                    |
-| uceprotect2         | Spam protection level 2      | [Link](http://www.uceprotect.net/en/index.php)                                    |
-| voip                | VoIP fraud blocklist         | [Link](http://www.voipbl.org)                                                     |
-| yoyo                | Ad protection blacklist      | [Link](https://pgl.yoyo.org/adservers/)                                           |
+| Source              | Focus                          | Information                                                                       |
+| :------------------ | :----------------------------: | :-------------------------------------------------------------------------------- |
+| asn                 | ASN block                      | [Link](https://asn.ipinfo.app)                                                    |
+| bogon               | Bogon prefixes                 | [Link](https://team-cymru.com)                                                    |
+| country             | Country blocks                 | [Link](https://www.ipdeny.com/ipblocks)                                           |
+| darklist            | blocks suspicious attacker IPs | [Link](https://darklist.de)                                                       |
+| debl                | Fail2ban IP blacklist          | [Link](https://www.blocklist.de)                                                  |
+| doh                 | Public DoH-Provider            | [Link](https://github.com/dibdot/DoH-IP-blocklists)                               |
+| drop                | Spamhaus drop compilation      | [Link](https://www.spamhaus.org)                                                  |
+| dshield             | Dshield IP blocklist           | [Link](https://www.dshield.org)                                                   |
+| edrop               | Spamhaus edrop compilation     | [Link](https://www.spamhaus.org)                                                  |
+| feodo               | Feodo Tracker                  | [Link](https://feodotracker.abuse.ch)                                             |
+| firehol1            | Firehol Level 1 compilation    | [Link](https://iplists.firehol.org/?ipset=firehol_level1)                         |
+| firehol2            | Firehol Level 2 compilation    | [Link](https://iplists.firehol.org/?ipset=firehol_level2)                         |
+| firehol3            | Firehol Level 3 compilation    | [Link](https://iplists.firehol.org/?ipset=firehol_level3)                         |
+| firehol4            | Firehol Level 4 compilation    | [Link](https://iplists.firehol.org/?ipset=firehol_level4)                         |
+| greensnow           | blocks suspicious server IPs   | [Link](https://greensnow.co)                                                      |
+| iblockads           | Advertising blocklist          | [Link](https://www.iblocklist.com)                                                |
+| iblockspy           | Malicious spyware blocklist    | [Link](https://www.iblocklist.com)                                                |
+| myip                | Myip Live IP blacklist         | [Link](https://myip.ms)                                                           |
+| nixspam             | iX spam protection             | [Link](http://www.nixspam.org)                                                    |
+| proxy               | Firehol list of open proxies   | [Link](https://iplists.firehol.org/?ipset=proxylists)                             |
+| ssbl                | SSL botnet IP blacklist        | [Link](https://sslbl.abuse.ch)                                                    |
+| threat              | Emerging Threats               | [Link](https://rules.emergingthreats.net)                                         |
+| tor                 | Tor exit nodes                 | [Link](https://fissionrelays.net/lists)                                           |
+| uceprotect1         | Spam protection level 1        | [Link](http://www.uceprotect.net/en/index.php)                                    |
+| uceprotect2         | Spam protection level 2        | [Link](http://www.uceprotect.net/en/index.php)                                    |
+| voip                | VoIP fraud blocklist           | [Link](http://www.voipbl.org)                                                     |
+| yoyo                | Ad protection blacklist        | [Link](https://pgl.yoyo.org/adservers/)                                           |
 
 * zero-conf like automatic installation & setup, usually no manual changes needed
 * automatically selects one of the following download utilities: aria2c, curl, uclient-fetch, wget
@@ -150,6 +151,11 @@ Available commands:
 | ban_maclist_timeout     | option | -                             | individual maclist IPSet timeout                                                      |
 | ban_whitelist_timeout   | option | -                             | individual whitelist IPSet timeout                                                    |
 | ban_blacklist_timeout   | option | -                             | individual blacklist IPSet timeout                                                    |
+| ban_logterms            | list   | dropbear, sshd, luci, nginx   | limit the log monitor to certain log terms                                            |
+| ban_loglimit            | option | 100                           | parse only the last stated number of log entries for suspicious events                |
+| ban_ssh_logcount        | option | 3                             | number of the failed ssh login repetitions of the same ip in the log before banning   |
+| ban_luci_logcount       | option | 3                             | number of the failed luci login repetitions of the same ip in the log before banning  |
+| ban_nginx_logcount      | option | 5                             | number of the failed nginx requests of the same ip in the log before banning          |
   
 ## Examples
 **list/edit banIP sources:**

--- a/net/banip/files/banip.init
+++ b/net/banip/files/banip.init
@@ -339,7 +339,6 @@ service_triggers()
 	fi
 	if [ -n "${iface}" ]
 	then
-		
 		procd_add_interface_trigger "interface.*.up" "${iface}" "${ban_init}" "start"
 	fi
 	procd_add_reload_trigger "banip"

--- a/net/banip/files/banip.service
+++ b/net/banip/files/banip.service
@@ -30,7 +30,7 @@ f_log()
 if [ -x "${ban_logread}" ]
 then
 	f_log "info" "log/banIP service started"
-	"${ban_logread}" -f | { grep -q "${ban_search}"; [ "${?}" = "0" ] && /etc/init.d/banip refresh; }
+	"${ban_logread}" -f | { grep -qE "${ban_search}"; [ "${?}" = "0" ] && { /etc/init.d/banip refresh; exit 0; }; }
 else
 	f_log "err" "can't start log/banIP service"
 fi

--- a/net/banip/files/banip.sources
+++ b/net/banip/files/banip.sources
@@ -26,7 +26,7 @@
 	"darklist": {
 		"url_4": "https://darklist.de/raw.php",
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)([[:space:]]|$)/{print \"add darklist_4 \"$1}",
-		"focus": "Attacker IP blacklist",
+		"focus": "Blocks suspicious attacker IPs",
 		"descurl": "https://darklist.de"
 	},
 	"debl": {
@@ -94,6 +94,12 @@
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)([[:space:]]|$)/{print \"add firehol4_4 \"$1}",
 		"focus": "Firehol Level 4 compilation",
 		"descurl": "https://iplists.firehol.org/?ipset=firehol_level4"
+	},
+	"greensnow": {
+		"url_4": "https://blocklist.greensnow.co/greensnow.txt",
+		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)([[:space:]]|$)/{print \"add greensnow_4 \"$1}",
+		"focus": "Blocks suspicious server IPs",
+		"descurl": "https://greensnow.co"
 	},
 	"iblockads": {
 		"url_4": "https://list.iblocklist.com/?list=dgxtneitpuvgqqcpfulq&fileformat=cidr&archiveformat=gz",


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: OpenWrt SNAPSHOT, r15743-048131ba3a

Description:
* add scanning for suspicious nginx events
* add a log counter to track the number of the failed requests
  or login repetitions of the same ip in the log before banning,
  defaults are: ssh (3), luci (3), nginx (5)
* optimize the background service handling
* add 'greensnow' as a new source
* update readme and LuCI frontend regarding the new log count options

Signed-off-by: Dirk Brenken <dev@brenken.org>
