### PR TITLE
libnetfilter-queue: re-add PKG_FIXUP to fix build

### DIFF
--- a/libs/libnetfilter-queue/Makefile
+++ b/libs/libnetfilter-queue/Makefile
@@ -9,12 +9,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnetfilter_queue
 PKG_VERSION:=1.0.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.netfilter.org/projects/libnetfilter_queue/files
 PKG_HASH:=f9ff3c11305d6e03d81405957bdc11aea18e0d315c3e3f48da53a24ba251b9f5
 
+PKG_FIXUP:=autoreconf
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 


### PR DESCRIPTION
Currently when trying to build this package a build error is produced:

WARNING: 'automake-1.16' is missing on your system.
         You should only need it if you modified 'Makefile.am' or
         'configure.ac' or m4 files included by 'configure.ac'.
         The 'automake' program is part of the GNU Automake package:
         <https://www.gnu.org/software/automake>
         It also requires GNU Autoconf, GNU m4 and Perl in order to run:
         <https://www.gnu.org/software/autoconf>
         <https://www.gnu.org/software/m4/>
         <https://www.perl.org/>

This error is due to an attempt to use the native host tools instead of
the OpenWrt build system generated ones. By re-adding PKG_FIXUP it is
ensured that the correct version of the host tools are used.

Signed-off-by: Etan Kissling <etan_kissling@apple.com>