### PR TITLE
bcm27xx-eeprom: update to latest version

### DIFF
--- a/utils/bcm27xx-eeprom/Makefile
+++ b/utils/bcm27xx-eeprom/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcm27xx-eeprom
-PKG_VERSION:=fd2ea72b2677504f41298c9137647aa057f67f47
+PKG_VERSION:=3129546271da09dde04da5c9715db909b8e1e417
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/raspberrypi/rpi-eeprom/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=3a4e1db25db8188535ad0ad12a6e40e2ff927b20cd21b1b5ff783c2fde966308
+PKG_HASH:=8ae34dd286d777484e670284883c91831ca8bdd15cc90a069009fdf1016de40b
 
 PKG_LICENSE:=BSD-3-Clause Custom
 PKG_LICENSE_FILES:=LICENSE
@@ -21,7 +21,7 @@ TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 define Package/bcm27xx-eeprom
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=bcm27xx-userland +blkid +pciutils +python3-light
+  DEPENDS:=bcm27xx-userland +blkid +coreutils +coreutils-od +pciutils +python3-light
   TITLE:=BCM27xx EEPROM tools
 endef
 

--- a/utils/bcm27xx-eeprom/patches/0001-rpi-eeprom-update-OpenWrt-defaults.patch
+++ b/utils/bcm27xx-eeprom/patches/0001-rpi-eeprom-update-OpenWrt-defaults.patch
@@ -14,24 +14,23 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 
 --- a/rpi-eeprom-update
 +++ b/rpi-eeprom-update
-@@ -24,14 +24,14 @@ else
+@@ -24,13 +24,13 @@ else
  fi
  
- # May be used to select beta or stable releases instead of the default critical updates.
--FIRMWARE_RELEASE_STATUS=${FIRMWARE_RELEASE_STATUS:-critical}
+ # Selects the release sub-directory
+-FIRMWARE_RELEASE_STATUS=${FIRMWARE_RELEASE_STATUS:-default}
 +FIRMWARE_RELEASE_STATUS=${FIRMWARE_RELEASE_STATUS:-stable}
  FIRMWARE_IMAGE_DIR=${FIRMWARE_IMAGE_DIR:-${FIRMWARE_ROOT}/${FIRMWARE_RELEASE_STATUS}}
 -FIRMWARE_BACKUP_DIR=${FIRMWARE_BACKUP_DIR:-/var/lib/raspberrypi/bootloader/backup}
 +FIRMWARE_BACKUP_DIR=${FIRMWARE_BACKUP_DIR:-${FIRMWARE_ROOT}/backup}
  ENABLE_VL805_UPDATES=${ENABLE_VL805_UPDATES:-1}
- USE_FLASHROM=${USE_FLASHROM:-0}
  RECOVERY_BIN=${RECOVERY_BIN:-${FIRMWARE_ROOT}/${FIRMWARE_RELEASE_STATUS}/recovery.bin}
  BOOTFS=${BOOTFS:-/boot}
 -VCMAILBOX=${VCMAILBOX:-/opt/vc/bin/vcmailbox}
 +VCMAILBOX=${VCMAILBOX:-/usr/bin/vcmailbox}
+ CM4_ENABLE_RPI_EEPROM_UPDATE=${CM4_ENABLE_RPI_EEPROM_UPDATE:-0}
+ RPI_EEPROM_UPDATE_CONFIG_TOOL="${RPI_EEPROM_UPDATE_CONFIG_TOOL:-raspi-config}"
  
- EXIT_SUCCESS=0
- EXIT_UPDATE_REQUIRED=1
 --- a/rpi-eeprom-update-default
 +++ b/rpi-eeprom-update-default
 @@ -1,8 +1,9 @@
@@ -45,4 +44,4 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  BOOTFS=/boot
  USE_FLASHROM=0
  EEPROM_CONFIG_HOOK=
-+VCMAILBOX=/usr/bin/vcmailbox
++VCMAILBOX=/usr/bin/vcmailbo

--- a/utils/bcm27xx-eeprom/patches/0002-rpi-eeprom-config-switch-to-Python-3.patch
+++ b/utils/bcm27xx-eeprom/patches/0002-rpi-eeprom-config-switch-to-Python-3.patch
@@ -14,8 +14,8 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 --- a/rpi-eeprom-config
 +++ b/rpi-eeprom-config
 @@ -1,4 +1,4 @@
--#!/usr/bin/python
-+#!/usr/bin/python3
+-#!/usr/bin/env python
++#!/usr/bin/env python3
  
- # rpi-eeprom-config
- # Utility for reading and writing the configuration file in the
+ """
+ rpi-eeprom-config

--- a/utils/bcm27xx-eeprom/patches/0003-rpi-eeprom-update-change-default-include-path.patch
+++ b/utils/bcm27xx-eeprom/patches/0003-rpi-eeprom-update-change-default-include-path.patch
@@ -24,7 +24,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  fi
  
  LOCAL_MODE=0
-@@ -346,7 +346,7 @@ The system should then boot normally.
+@@ -386,7 +386,7 @@ The system should then boot normally.
  
  If /boot does not correspond to the boot partition and this
  is not a NOOBS system, then the mount point for BOOTFS should be defined
@@ -33,7 +33,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  
  A backup of the current EEPROM config file is written to ${FIRMWARE_BACKUP_DIR}
  before applying the update.
-@@ -368,7 +368,7 @@ Options:
+@@ -415,7 +415,7 @@ Options:
     -u Install the specified VL805 (USB EEPROM) image file.
  
  Environment:

--- a/utils/bcm27xx-eeprom/patches/0004-rpi-eeprom-update-chmod-silent-f-is-not-supported.patch
+++ b/utils/bcm27xx-eeprom/patches/0004-rpi-eeprom-update-chmod-silent-f-is-not-supported.patch
@@ -1,0 +1,33 @@
+From 8376ac74390af0ad736c88615e128b82a75eebc0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
+Date: Fri, 19 Feb 2021 10:54:23 +0100
+Subject: [PATCH] rpi-eeprom-update: chmod silent (-f) is not supported
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+---
+ rpi-eeprom-update | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/rpi-eeprom-update
++++ b/rpi-eeprom-update
+@@ -212,7 +212,7 @@ applyRecoveryUpdate()
+                 || die "Failed to copy ${TMP_EEPROM_IMAGE} to ${BOOTFS}"
+ 
+         # For NFS mounts ensure that the files are readable to the TFTP user
+-        chmod -f go+r "${BOOTFS}/pieeprom.upd" "${BOOTFS}/pieeprom.sig" \
++        chmod go+r "${BOOTFS}/pieeprom.upd" "${BOOTFS}/pieeprom.sig" \
+                 || die "Failed to set permissions on eeprom update files"
+    fi
+ 
+@@ -224,7 +224,7 @@ applyRecoveryUpdate()
+                 || die "Failed to copy ${VL805_UPDATE_IMAGE} to ${BOOTFS}/vl805.bin"
+ 
+         # For NFS mounts ensure that the files are readable to the TFTP user
+-        chmod -f go+r "${BOOTFS}/vl805.bin" "${BOOTFS}/vl805.sig" \
++        chmod go+r "${BOOTFS}/vl805.bin" "${BOOTFS}/vl805.sig" \
+                 || die "Failed to set permissions on eeprom update files"
+    fi
+ 


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm27xx/bcm2711
Run tested: RPi 4B

Description:
New eeprom firmwares support recently added devices (RPi 400 and CM4).

This should also be cherry-picked for openwrt-21.02.