### PR TITLE
tor: update to version 0.4.5.6

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.4.6
+PKG_VERSION:=0.4.5.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=5f154c155803adf5c89e87cab53017b6908c5ebe50c65839e8cf4fbd2abe1fdc
+PKG_HASH:=22cba3794fedd5fa87afc1e512c6ce2c21bc20b4e1c6f8079d832dc1e545e733
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates tor to version 0.4.5.6 this version improves IPv6 implementation. [Changelog](https://blog.torproject.org/node/2000)
