### PR TITLE
libnetfilter-queue: add pkt_buff function for ICMP

### DIFF
--- a/libs/libnetfilter-queue/Makefile
+++ b/libs/libnetfilter-queue/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnetfilter_queue
 PKG_VERSION:=1.0.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.netfilter.org/projects/libnetfilter_queue/files

--- a/libs/libnetfilter-queue/patches/0001-src-add-pkt_buff-function-for-ICMP.patch
+++ b/libs/libnetfilter-queue/patches/0001-src-add-pkt_buff-function-for-ICMP.patch
@@ -1,0 +1,100 @@
+From 662c8f44d53492d2e0ebd430dadef12d580ec330 Mon Sep 17 00:00:00 2001
+From: Etan Kissling <etan_kissling@apple.com>
+Date: Tue, 19 Jan 2021 16:05:39 +0100
+Subject: [PATCH] src: add pkt_buff function for ICMP
+
+Add support for processing ICMP packets using pkt_buff, similar to
+existing library support for TCP and UDP.
+
+Signed-off-by: Etan Kissling <etan_kissling@apple.com>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ include/libnetfilter_queue/Makefile.am        |  1 +
+ .../libnetfilter_queue_icmp.h                 |  8 ++++
+ src/Makefile.am                               |  1 +
+ src/extra/icmp.c                              | 48 +++++++++++++++++++
+ 4 files changed, 58 insertions(+)
+ create mode 100644 include/libnetfilter_queue/libnetfilter_queue_icmp.h
+ create mode 100644 src/extra/icmp.c
+
+--- a/include/libnetfilter_queue/Makefile.am
++++ b/include/libnetfilter_queue/Makefile.am
+@@ -1,5 +1,6 @@
+ pkginclude_HEADERS = libnetfilter_queue.h	\
+ 		     linux_nfnetlink_queue.h	\
++		     libnetfilter_queue_icmp.h	\
+ 		     libnetfilter_queue_ipv4.h	\
+ 		     libnetfilter_queue_ipv6.h	\
+ 		     libnetfilter_queue_tcp.h	\
+--- /dev/null
++++ b/include/libnetfilter_queue/libnetfilter_queue_icmp.h
+@@ -0,0 +1,8 @@
++#ifndef _LIBNFQUEUE_ICMP_H_
++#define _LIBNFQUEUE_ICMP_H_
++
++struct pkt_buff;
++
++struct icmphdr *nfq_icmp_get_hdr(struct pkt_buff *pktb);
++
++#endif
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -31,6 +31,7 @@ libnetfilter_queue_la_LDFLAGS = -Wc,-nos
+ libnetfilter_queue_la_SOURCES = libnetfilter_queue.c	\
+ 				nlmsg.c			\
+ 				extra/checksum.c	\
++				extra/icmp.c		\
+ 				extra/ipv6.c		\
+ 				extra/tcp.c		\
+ 				extra/ipv4.c		\
+--- /dev/null
++++ b/src/extra/icmp.c
+@@ -0,0 +1,48 @@
++/*
++ * (C) 2012 by Pablo Neira Ayuso <pablo@netfilter.org>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This code has been sponsored by Vyatta Inc. <http://www.vyatta.com>
++ */
++
++#include <stdio.h>
++#define _GNU_SOURCE
++#include <netinet/ip_icmp.h>
++
++#include <libnetfilter_queue/libnetfilter_queue_icmp.h>
++
++#include "internal.h"
++
++/**
++ * \defgroup icmp ICMP helper functions
++ * @{
++ */
++
++/**
++ * nfq_icmp_get_hdr - get the ICMP header.
++ * \param pktb: pointer to user-space network packet buffer
++ * \returns validated pointer to the ICMP header or NULL if the ICMP header was
++ * not set or if a minimal length check fails.
++ * \note You have to call nfq_ip_set_transport_header() or
++ * nfq_ip6_set_transport_header() first to set the ICMP header.
++ */
++EXPORT_SYMBOL
++struct icmphdr *nfq_icmp_get_hdr(struct pkt_buff *pktb)
++{
++	if (pktb->transport_header == NULL)
++		return NULL;
++
++	/* No room for the ICMP header. */
++	if (pktb_tail(pktb) - pktb->transport_header < sizeof(struct icmphdr))
++		return NULL;
++
++	return (struct icmphdr *)pktb->transport_header;
++}
++
++/**
++ * @}
++ */


### PR DESCRIPTION
Import 662c8f44d53492d2e0ebd430dadef12d580ec330 from upstream.

Signed-off-by: Etan Kissling <etan_kissling@apple.com>
