### PR TITLE
ooniprobe: update to version 3.5.2

### DIFF
--- a/net/ooniprobe/Makefile
+++ b/net/ooniprobe/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ooniprobe
-PKG_VERSION:=3.5.1
+PKG_VERSION:=3.5.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=probe-cli-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ooni/probe-cli/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8278f9318ef939c46169dc44e89bbc03915c660912e66be9c4b20d18d00816fe
+PKG_HASH:=56e419033715e1b2b61a82661f724148bab8fec4a28b2566a10e0a3051b3bade
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt maser
Run testd: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates ooniprobe to version 3.5.2 [Changelog](https://github.com/ooni/probe-cli/releases/tag/v3.5.2)
