### PR TITLE
rng-tools: start as early as possible

### DIFF
--- a/utils/rng-tools/Makefile
+++ b/utils/rng-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rng-tools
 PKG_VERSION:=6.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/nhorman/rng-tools

--- a/utils/rng-tools/files/rngd.init
+++ b/utils/rng-tools/files/rngd.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2011-2014 OpenWrt.org
 
-START=25
+START=0
 
 USE_PROCD=1
 PROG=/sbin/rngd


### PR DESCRIPTION
Maintainer: @hnyman @nwf @pprindeville 
Compile tested: bcm27xx/bcm2708
Run tested: bcm27xx/bcm2708 (Raspberry Pi B+)

Description:
Raspberry Pi devices (bcm2708) need this to get from:
[  102.310494] random: crng init done
to:
[   12.539744] random: crng init done