### PR TITLE
reptyr: Don't build for mipsel

### DIFF
--- a/utils/reptyr/Makefile
+++ b/utils/reptyr/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=reptyr
 PKG_VERSION:=0.8.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/nelhage/reptyr/archive/
@@ -23,7 +23,7 @@ define Package/reptyr
   CATEGORY:=Utilities
   TITLE:=Tool for reparenting running programs
   URL:=https://github.com/nelhage/reptyr
-  DEPENDS:=@!(arc||mips)
+  DEPENDS:=@!(arc||mips||mipsel)
 endef
 
 define Package/reptyr/description


### PR DESCRIPTION
Maintainer: @BKPepe 
Compile tested: ramips, mipsel_74kc
Run tested: N/A

Description:
The package does not support any mips archs, including mipsel.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---
Fixes current build errors like:
https://downloads.openwrt.org/releases/faillogs-21.02/mipsel_74kc/packages/reptyr/compile.txt
As can be seen above, I intend to cherry-pick it to 21.02 as well.