### PR TITLE
banip: update to 0.7.3

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
-PKG_VERSION:=0.7.2
+PKG_VERSION:=0.7.3
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/banip/files/README.md
+++ b/net/banip/files/README.md
@@ -31,6 +31,7 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 | nixspam             | iX spam protection             | [Link](http://www.nixspam.org)                                                    |
 | proxy               | Firehol list of open proxies   | [Link](https://iplists.firehol.org/?ipset=proxylists)                             |
 | ssbl                | SSL botnet IP blacklist        | [Link](https://sslbl.abuse.ch)                                                    |
+| talos               | Cisco Talos IP Blacklist       | [Link](https://talosintelligence.com/reputation_center)                           |
 | threat              | Emerging Threats               | [Link](https://rules.emergingthreats.net)                                         |
 | tor                 | Tor exit nodes                 | [Link](https://fissionrelays.net/lists)                                           |
 | uceprotect1         | Spam protection level 1        | [Link](http://www.uceprotect.net/en/index.php)                                    |
@@ -68,6 +69,7 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 * [OpenWrt](https://openwrt.org), tested with the stable release series (19.07.x) and with the latest rolling snapshot releases. On turris devices it has been successfully tested with TurrisOS 5.2.x  
   <b>Please note:</b> Older OpenWrt releases like 18.06.x or 17.01.x are _not_ supported!  
   <b>Please note:</b> Devices with less than 128 MByte RAM are _not_ supported!  
+  <b>Please note:</b> If you're updating from former banIP 0.3x please manually remove your config (/etc/config/banip) before you start!  
 * A download utility with SSL support: 'wget', 'uclient-fetch' with one of the 'libustream-*' ssl libraries, 'aria2c' or 'curl' is required
 * A certificate store like 'ca-bundle', as banIP checks the validity of the SSL certificates of all download sites by default
 * Optional E-Mail notification support: for E-Mail notifications you need to install the additional 'msmtp' package

--- a/net/banip/files/banip.sources
+++ b/net/banip/files/banip.sources
@@ -142,6 +142,12 @@
 		"focus": "SSL botnet IP blacklist",
 		"descurl": "https://sslbl.abuse.ch"
 	},
+	"talos": {
+		"url_4": "https://www.talosintelligence.com/documents/ip-blacklist",
+		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)([[:space:]]|$)/{print \"add talos_4 \"$1}",
+		"focus": "Cisco Talos IP Blacklist",
+		"descurl": "https://talosintelligence.com/reputation_center"
+	},
 	"threat": {
 		"url_4": "https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt",
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)([[:space:]]|$)/{print \"add threat_4 \"$1}",


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: PC Engines apu4, OpenWrt SNAPSHOT r15871-bb817bb4b8

Description:
* fix search string/pipe preparation for the background service
* fix IPSet maxelem limitation, made it more flexible
* fix potential error during resume action
* add Cisco Talos IP blacklist
* update readme

Signed-off-by: Dirk Brenken <dev@brenken.org>
