### PR TITLE
ksmbd and ksmbd-tools 3.3.5

### DIFF
--- a/kernel/ksmbd/Makefile
+++ b/kernel/ksmbd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd
-PKG_VERSION:=3.3.4
+PKG_VERSION:=3.3.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/cifsd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=4f8b7610ba084f6813cbb85bb6c07af50ba542e928c370e79022039fa027bc9a
+PKG_HASH:=d34c73d1fe1d6d2136472e37cf54bb819a59fc7e79b4f95772ce9da1eff7fff9
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
-PKG_VERSION:=3.3.4
+PKG_VERSION:=3.3.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/ksmbd-tools/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=f7065da4008292bcaf43b15190715b4f224919f7d60f18b79b836eab6ee6d43b
+PKG_HASH:=e1080c2254c418bc5d9e955b626603c166775972607eca930342aee413a38473
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: @Andy2244
Compile tested: mips, lantiq
Run tested: lantiq BT Home Hub 5A

Description:
Updates ksmbd and ksmbd-tools to the latest upstream version, which is 3.3.5 (for both packages)
Upstream changelogs are included in the commit for each package

The main change for me is that it fixes a crash, possibly the one fixed in cifsd-team/cifsd@d877f11fbd5aab09e73a09fdb93d1bae4efae46e
Possibly this should be backported to 21.02 for that reason