### PR TITLE
unbound: fix cross compile in macOS

### DIFF
--- a/net/unbound/patches/001-macos-host.patch
+++ b/net/unbound/patches/001-macos-host.patch
@@ -1,0 +1,28 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -1209,23 +1209,13 @@ esac
+ 
+ AC_ARG_ENABLE(tfo-client, AS_HELP_STRING([--enable-tfo-client],[Enable TCP Fast Open for client mode]))
+ case "$enable_tfo_client" in
+-	yes)
+-		case `uname` in
+-			Linux) AC_CHECK_DECL([MSG_FASTOPEN], [AC_MSG_WARN([Check the platform specific TFO kernel parameters are correctly configured to support client mode TFO])],
++	yes) AC_CHECK_DECL([MSG_FASTOPEN], [AC_MSG_WARN([Check the platform specific TFO kernel parameters are correctly configured to support client mode TFO])],
+ 			                     [AC_MSG_ERROR([TCP Fast Open is not available for client mode: please rerun without --enable-tfo-client])], 
+ 			                     [AC_INCLUDES_DEFAULT 
+ #include <netinet/tcp.h>
+ ])
+ 					AC_DEFINE_UNQUOTED([USE_MSG_FASTOPEN], [1], [Define this to enable client TCP Fast Open.])
+-			  ;;
+-			Darwin) AC_CHECK_DECL([CONNECT_RESUME_ON_READ_WRITE], [AC_MSG_WARN([Check the platform specific TFO kernel parameters are correctly configured to support client mode TFO])], 
+-			                      [AC_MSG_ERROR([TCP Fast Open is not available for client mode: please rerun without --enable-tfo-client])], 
+-			                      [AC_INCLUDES_DEFAULT
+-#include <sys/socket.h>
+-])
+-					AC_DEFINE_UNQUOTED([USE_OSX_MSG_FASTOPEN], [1], [Define this to enable client TCP Fast Open.])
+-			  ;;
+-		esac
++
+ 	;;
+ 	no|*)
+ 		;;


### PR DESCRIPTION
don't use `uname` when cross compile,
uname should always be 'linux' in openwrt target.

Signed-off-by: Liangbin Lian <jjm2473@gmail.com>

Maintainer: Eric Luehrsen <ericluehrsen@gmail.com>
Compile tested: macOS 10.15.7
Run tested: Not tested

Description:
