### PR TITLE
stunnel: update to 5.58

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.57
+PKG_VERSION:=5.58
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
-PKG_LICENSE_FILES:=COPYING COPYRIGHT.GPL
+PKG_LICENSE_FILES:=COPYING.md COPYRIGHT.md
 PKG_CPE_ID:=cpe:/a:stunnel:stunnel
 
 PKG_SOURCE_URL:= \
@@ -23,7 +23,7 @@ PKG_SOURCE_URL:= \
 	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=af5ab973dde11807c38735b87bdd87563a47d2fa1c72a07929fcfce80a600fe1
+PKG_HASH:=d4c14cc096577edca3f6a2a59c2f51869e35350b3988018ddf808c88e5973b79
 
 PKG_FIXUP:=autoreconf
 PKG_FIXUP:=patch-libtool


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, APU3, OpenWrt master
Run tested: x86_64, APU3, OpenWrt master, tests done

```
root@router / # stunnel -help
Description:Initializing inetd mode configuration
stunnel 5.58 on x86_64-openwrt-linux-gnu platform
Compiled with OpenSSL 1.1.1j  16 Feb 2021
Running  with OpenSSL 1.1.1i  8 Dec 2020
Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,OCSP,PSK,SNI

Global options:
chroot                 = directory to chroot stunnel process
compression            = compression type
EGD                    = path to Entropy Gathering Daemon socket
engine                 = auto|engine_id
engineCtrl             = cmd[:arg]
engineDefault          = TASK_LIST
foreground             = yes|quiet|no foreground mode (don't fork, log to stderr)
log                    = append|overwrite log file
output                 = file to append log messages
pid                    = pid file
RNDbytes               = bytes to read from random seed files
RNDfile                = path to file with random seed data
RNDoverwrite           = yes|no overwrite seed datafiles with new random data
syslog                 = yes|no send logging messages to syslog

Service-level options:
accept                 = [host:]port accept connections on specified host:port
CApath                 = CA certificate directory for 'verify' option
CAfile                 = CA certificate file for 'verify' option
cert                   = certificate chain
checkEmail             = peer certificate email address
checkHost              = peer certificate host name pattern
checkIP                = peer certificate IP address
ciphers                = permitted ciphers for TLS 1.2 or older
ciphersuites           = permitted ciphersuites for TLS 1.3
client                 = yes|no client mode (remote service uses TLS)
config                 = command[:parameter] to execute
connect                = [host:]port to connect
CRLpath                = CRL directory
CRLfile                = CRL file
curves                 = ECDH curve names
debug                  = [facility].level (e.g. daemon.info)
delay                  = yes|no delay DNS lookup for 'connect' option
engineId               = ID of engine to read the key from
engineNum              = number of engine to read the key from
exec                   = file execute local inetd-type program
execArgs               = arguments for 'exec' (including $0)
failover               = rr|prio failover strategy
ident                  = username for IDENT (RFC 1413) checking
include                = directory with configuration file snippets
key                    = certificate private key
local                  = IP address to be used as source for remote connections
logId                  = connection identifier type
OCSP                   = OCSP responder URL
OCSPaia                = yes|no check the AIA responders from certificates
OCSPflag               = OCSP responder flags
OCSPnonce              = yes|no send and verify the OCSP nonce extension
options                = TLS option to set/reset
protocol               = protocol to negotiate before TLS initialization
                         currently supported: cifs, connect, imap,
                             nntp, pgsql, pop3, proxy, smtp, sock
protocolAuthentication = authentication type for protocol negotiations
protocolDomain         = domain for protocol negotiations
protocolHeader         = custom header for protocol negotiations
protocolHost           = host:port for protocol negotiations
protocolPassword       = password for protocol negotiations
protocolUsername       = username for protocol negotiations
PSKidentity            = identity for PSK authentication
PSKsecrets             = secrets for PSK authentication
pty                    = yes|no allocate pseudo terminal for 'exec' option
redirect               = [host:]port to redirect on authentication failures
renegotiation          = yes|no support renegotiation
requireCert            = yes|no require client certificate
reset                  = yes|no send TCP RST on error
retry                  = yes|no retry connect+exec section
securityLevel          = set the security level
service                = service name
setgid                 = groupname for setgid()
setuid                 = username for setuid()
sessionCacheSize       = session cache size
sessionCacheTimeout    = session cache timeout (in seconds)
sessiond               = [host:]port use sessiond at host:port
sni                    = master_service:host_name for an SNI virtual service
socket                 = a|l|r:option=value[:value]
                         set an option on accept/local/remote socket
sslVersion             = all|SSLv3|TLSv1|TLSv1.1|TLSv1.2|TLSv1.3 TLS version
sslVersionMax          = all|SSLv3|TLSv1|TLSv1.1|TLSv1.2|TLSv1.3 TLS version
sslVersionMin          = all|SSLv3|TLSv1|TLSv1.1|TLSv1.2|TLSv1.3 TLS version
stack                  = thread stack size (in bytes)
ticketKeySecret        = secret key for encryption/decryption TLSv1.3 tickets
ticketMacSecret        = key for HMAC operations on TLSv1.3 tickets
TIMEOUTbusy            = seconds to wait for expected data
TIMEOUTclose           = seconds to wait for close_notify
TIMEOUTconnect         = seconds to connect remote host
TIMEOUTidle            = seconds to keep an idle connection
transparent            = none|source|destination|both transparent proxy mode
verify                 = level of peer certificate verification
verifyChain            = yes|no verify certificate chain
verifyPeer             = yes|no verify peer certificate
```

