### PR TITLE
python-packaging: update to version 20.9

### DIFF
--- a/lang/python/python-packaging/Makefile
+++ b/lang/python/python-packaging/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+# Copyright (C) 2020-2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-packaging
-PKG_VERSION:=20.4
+PKG_VERSION:=20.9
 PKG_RELEASE:=1
 
 PYPI_NAME:=packaging
-PKG_HASH:=4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8
+PKG_HASH:=5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=Apache-2.0 BSD-2-Clause
@@ -27,7 +27,7 @@ define Package/python3-packaging
   SUBMENU:=Python
   TITLE:=Core utilities for Python packages
   URL:=https://github.com/pypa/packaging
-  DEPENDS:=+python3-light +python3-pyparsing +python3-six +python3-logging +python3-distutils
+  DEPENDS:=+python3-light +python3-pyparsing +python3-six +python3-logging +python3-distutils +python3-urllib
 endef
 
 define Package/python3-packaging/description


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates python-packaging to version 20.9 and adds dependency for python-urllib. [Changelog](https://github.com/pypa/packaging/blob/main/CHANGELOG.rst)


Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>
