### PR TITLE
mini_snmpd: fix spurious version bump to 1.6

### DIFF
--- a/net/mini_snmpd/Makefile
+++ b/net/mini_snmpd/Makefile
@@ -9,17 +9,15 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mini_snmpd
 PKG_VERSION:=1.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Marcin Jurkowski <marcin1j@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/troglobit/mini-snmpd.git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=203d92e60ed09466d6676c6ad20ad6cb2ce08a5d
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MIRROR_HASH:=f3a19ea0a24ddf57b90e122acdb765f8a2323b1f63ca82a5b56a919ccca16d70
+PKG_SOURCE:=mini-snmpd-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/troglobit/mini-snmpd/tar.gz/v$(PKG_VERSION)?
+PKG_BUILD_DIR:=$(BUILD_DIR)/mini-snmpd-$(PKG_VERSION)
+PKG_HASH:=de00c475a3c70c56f3ee97cd683cb71009d3521d60b1f589c5a91b4671ede9f3
 
 PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1
@@ -51,8 +49,8 @@ CONFIGURE_ARGS+= \
 #	--disable-demo - Upstream Github Issue #4 Fixed 20160707
 
 define Package/mini_snmpd/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mini_snmpd $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/mini-snmpd $(1)/usr/sbin
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/mini_snmpd.config $(1)/etc/config/mini_snmpd
 	$(INSTALL_DIR) $(1)/etc/init.d

--- a/net/mini_snmpd/files/mini_snmpd.init
+++ b/net/mini_snmpd/files/mini_snmpd.init
@@ -5,7 +5,7 @@
 
 START=98
 USE_PROCD=1
-PROG=/usr/bin/mini_snmpd
+PROG=/usr/sbin/mini-snmpd
 NAME=mini_snmpd
 
 global_respawn_threshold=


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79, TP-Link TL-WR842ND v1, OpenWRT r15880
Run tested: ath79, TP-Link TL-WR842ND v1, OpenWRT r15880

Description:
Fixes spurious version bump done in 5c8fb42 and reported in #14815 and
switches source proto from git to codeload.

Upstream has changed daemon binary name to `/usr/sbin/mini-snmpd`.
Package and config/init script name stays unchanged.
