### PR TITLE
netdata: update to version 1.29.2

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
-PKG_VERSION:=1.29.1
+PKG_VERSION:=1.29.2
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
@@ -18,7 +18,7 @@ PKG_CPE_ID:=cpe:/a:my-netdata:netdata
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netdata/netdata/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=d5029b466e801966b7fb483905d61a290cec7c19ec95f96ae2fbff14c723ee37
+PKG_HASH:=def61f78b03b92ff95d0511681f125afb0338961b7e6a7d7ea91f7463dc7d11e
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Maintainers: me and @diizzyy
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07.7
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07.7

Description:
![Screenshot from 2021-02-22 19-06-56](https://user-images.githubusercontent.com/4096468/108750356-37894880-7541-11eb-95c3-be1bcbb56166.png)

Release notes:
https://github.com/netdata/netdata/releases/tag/v1.29.2

