### PR TITLE
hplip: bump to 3.21.2

### DIFF
--- a/utils/hplip/Makefile
+++ b/utils/hplip/Makefile
@@ -1,7 +1,4 @@
 #
-# Copyright (C) 2006-2011 OpenWrt.org
-# Copyright (C) 2017-2018 Luiz Angelo Daros de Luca <luizluca@gmail.com>
-#
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
@@ -9,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hplip
-PKG_VERSION:=3.20.9
-PKG_RELEASE:=3
+PKG_VERSION:=3.21.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/hplip
-PKG_HASH:=36251189aa9cc349f6a3eacbb7ac3c4fd26fc9f087c9f75cee051010c85d2ddf
+PKG_HASH:=410421a13e62205d41bacd3215993c89e513fb4d7fab07e23e2720465aea7c41
 
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=GPL-2.0 GPL-2.0-or-later

--- a/utils/hplip/patches/010-libusb_fix.patch
+++ b/utils/hplip/patches/010-libusb_fix.patch
@@ -20,7 +20,7 @@
  # ui (qt3)
 --- a/configure.in
 +++ b/configure.in
-@@ -601,6 +601,10 @@ if test "$class_driver" = "no" && test "
+@@ -611,6 +611,10 @@ if test "$class_driver" = "no" && test "
     else
        AC_CHECK_LIB([usb-1.0], [libusb_init], [LIBS="$LIBS"], [AC_MSG_ERROR([cannot find libusb 1.0 support], 2)])
        AC_CHECK_HEADERS(libusb-1.0/libusb.h, ,[AC_MSG_ERROR([cannot find libusb-1.0-devel support], 11)])

--- a/utils/hplip/patches/020-remove_cups_dep_on_scan.patch
+++ b/utils/hplip/patches/020-remove_cups_dep_on_scan.patch
@@ -11,17 +11,15 @@
  
 --- a/scan/sane/hpaio.c
 +++ b/scan/sane/hpaio.c
-@@ -34,9 +34,7 @@
+@@ -34,7 +34,6 @@
  #include <stdio.h>
  #include <stdlib.h>
  #include <string.h>
 -#include <cups/cups.h>
  #include "hpmud.h"
--#include "avahiDiscovery.h"
- #include "hp_ipp.h"
- #include "soap.h"
- #include "soapht.h"
-@@ -146,98 +144,6 @@ static int GetUriLine(char *buf, char *u
+ 
+ #ifdef HAVE_LIBAVAHI
+@@ -150,98 +149,6 @@ static int GetUriLine(char *buf, char *u
     return i;
  }
  
@@ -120,7 +118,7 @@
  static int AddDevice(char *uri)
  {
      struct hpmud_model_attributes ma;
-@@ -290,7 +196,6 @@ static int DevDiscovery(int localOnly)
+@@ -294,7 +201,6 @@ static int DevDiscovery(int localOnly)
      char uri[HPMUD_LINE_SIZE];
      char *tail = message;
      int i, scan_type, cnt=0, total=0, bytes_read;
@@ -128,10 +126,10 @@
      char* token = NULL;
      enum HPMUD_RESULT stat;
  
-@@ -305,39 +210,6 @@ static int DevDiscovery(int localOnly)
+@@ -308,38 +214,6 @@ static int DevDiscovery(int localOnly)
+         GetUriLine(tail, uri, &tail);
          total += AddDevice(uri);
      }
-     //memset(message, 0, sizeof(message));
 -    /* Look for Network Scan devices if localonly flag if FALSE. */
 -    if (!localOnly)
 -    {   
@@ -144,9 +142,8 @@
 -        }
 -        if (cups_printer)
 -            free(cups_printer);
--#ifdef HAVE_LIBNETSNMP
+-#ifdef HAVE_LIBAVAHI
 -        /* Discover NW scanners using Bonjour*/
--        //bytes_read = avahi_probe_nw_scanners();
 -        if( (avahi_probe_nw_scanners() == AVAHI_STATUS_OK) && (aUriBuf != NULL) )
 -        {           
 -          token = strtok(aUriBuf, ";");

--- a/utils/hplip/patches/060-fix-glibc.patch
+++ b/utils/hplip/patches/060-fix-glibc.patch
@@ -1,5 +1,5 @@
 Fix missing definition of uint64_t while compiling
-under uclibc
+under uclibc or glibc
 
 https://bugs.launchpad.net/hplip/+bug/1826965
 


### PR DESCRIPTION
Patches refreshed:
* 010-libusb_fix.patch and
* 020-remove_cups_dep_on_scan.patch.
Patches dropped:
* 060-fix-uclibc.patch as uclibc support is gone in OpenWrt

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: me
Compile tested: armvirt_64,ath79_generic,mvebu_cortexa9,powerpc,ramips_mt7620,x86_64,x86_generic
Run tested: scanned using a TP-Link archer C7v5

Description:
