### PR TITLE
dovecot: update to 2.3.13

### DIFF
--- a/mail/dovecot/Makefile
+++ b/mail/dovecot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dovecot
-PKG_VERSION:=2.3.11.3
-PKG_RELEASE:=2
+PKG_VERSION:=2.3.13
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dovecot.org/releases/2.3
-PKG_HASH:=d3d9ea9010277f57eb5b9f4166a5d2ba539b172bd6d5a2b2529a6db524baafdc
+PKG_HASH:=a3f875b80ec11a452480690108660030978c94fa8e796ad6d943a874b496f1c4
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENSE:=LGPL-2.1-only MIT BSD-3-Clause

--- a/mail/dovecot/patches/100-openssl-deprecated.patch
+++ b/mail/dovecot/patches/100-openssl-deprecated.patch
@@ -1,13 +1,3 @@
---- a/src/lib-dcrypt/dcrypt-openssl.c
-+++ b/src/lib-dcrypt/dcrypt-openssl.c
-@@ -23,6 +23,7 @@
- #include <openssl/engine.h>
- #include <openssl/hmac.h>
- #include <openssl/objects.h>
-+#include <openssl/bn.h>
- #include "dcrypt.h"
- #include "dcrypt-private.h"
- 
 --- a/src/lib-ssl-iostream/dovecot-openssl-common.c
 +++ b/src/lib-ssl-iostream/dovecot-openssl-common.c
 @@ -63,9 +63,11 @@ void dovecot_openssl_common_global_ref(v
@@ -40,17 +30,7 @@
  
 --- a/src/lib-ssl-iostream/iostream-openssl-context.c
 +++ b/src/lib-ssl-iostream/iostream-openssl-context.c
-@@ -6,6 +6,9 @@
- #include "dovecot-openssl-common.h"
- 
- #include <openssl/crypto.h>
-+#include <openssl/rsa.h>
-+#include <openssl/dh.h>
-+#include <openssl/bn.h>
- #include <openssl/x509.h>
- #include <openssl/pem.h>
- #include <openssl/ssl.h>
-@@ -555,8 +558,10 @@ ssl_proxy_ctx_set_crypto_params(SSL_CTX
+@@ -558,8 +558,10 @@ ssl_proxy_ctx_set_crypto_params(SSL_CTX
  	int nid;
  	const char *curve_name;
  #endif

--- a/mail/dovecot/patches/110-openssl-engine.patch
+++ b/mail/dovecot/patches/110-openssl-engine.patch
@@ -14,7 +14,7 @@
  #include "dcrypt.h"
  #include "dcrypt-private.h"
  
-@@ -235,11 +237,13 @@ dcrypt_openssl_padding_mode(enum dcrypt_
+@@ -236,11 +238,13 @@ dcrypt_openssl_padding_mode(enum dcrypt_
  static bool dcrypt_openssl_initialize(const struct dcrypt_settings *set,
  				      const char **error_r)
  {


### PR DESCRIPTION
Fixed and refreshed patches.

Switched to AUTORELEASE for simplicity.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: ath79