### PR TITLE
Update libqmi, ModemManager and add libqrtr-glib

### DIFF
--- a/libs/libqmi/Config.in
+++ b/libs/libqmi/Config.in
@@ -1,9 +1,16 @@
 menu "Configuration"
-depends on PACKAGE_libqmi
+	depends on PACKAGE_libqmi
 
-	config LIBQMI_WITH_MBIM_QMUX
-		bool "Include MBIM QMUX service support"
-		default y
-		help
-		  Compile libqmi with QMI-over-MBIM support
+config LIBQMI_WITH_MBIM_QMUX
+	bool "Include MBIM QMUX service support"
+	default y
+	help
+	  Compile libqmi with QMI-over-MBIM support
+
+config LIBQMI_WITH_QRTR_GLIB
+	bool "Include QRTR support"
+	default y
+	help
+	  Compile libqmi with QRTR support
+
 endmenu

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_VERSION:=1.26.8
+PKG_VERSION:=1.28.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
-PKG_HASH:=ef76dc95ab0a06321a1bd25e875489cba12c9f6611974ca0135cf067bb20c960
+PKG_HASH:=e235f63aa375da322e32ad135671757c5a93b0df59e60dcc17703762b32e9a94
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 
@@ -32,7 +32,8 @@ define Package/libqmi
   CATEGORY:=Libraries
   DEPENDS:= \
     +glib2 \
-    +LIBQMI_WITH_MBIM_QMUX:libmbim
+    +LIBQMI_WITH_MBIM_QMUX:libmbim \
+    +LIBQMI_WITH_QRTR_GLIB:libqrtr-glib
   TITLE:=Helper library to talk to QMI enabled modems
   URL:=https://www.freedesktop.org/wiki/Software/libqmi
   LICENSE:=LGPL-2.0-or-later
@@ -66,6 +67,7 @@ CONFIGURE_ARGS += \
 	--disable-silent-rules \
 	--enable-firmware-update \
 	--$(if $(LIBQMI_WITH_MBIM_QMUX),en,dis)able-mbim-qmux \
+	--$(if $(LIBQMI_WITH_QRTR_GLIB),en,dis)able-qrtr \
 	--enable-more-warnings=yes \
 	--without-udev \
 	--without-udev-base-dir

--- a/libs/libqrtr-glib/Makefile
+++ b/libs/libqrtr-glib/Makefile
@@ -1,0 +1,71 @@
+#
+# Copyright (C) 2016 Velocloud Inc.
+# Copyright (C) 2016 Aleksander Morgado <aleksander@aleksander.es>
+#
+# This is free software, licensed under the GNU General Public License v2.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libqrtr-glib
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi/
+PKG_HASH:=30d879b2ade6f8f461def3a677755db5c0238babf688d5c83c03b3e6abe35cee
+
+PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/libqrtr-glib
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+glib2
+  TITLE:=Helper library to talk to QRTR enabled modems
+  URL:=https://gitlab.freedesktop.org/mobile-broadband/libqrtr-glib
+  LICENSE:=LGPL-2.0-or-later
+  LICENSE_FILES:=COPYING.LIB
+endef
+
+define Package/libqrtr-glib/description
+  Helper library talk to QRTR enabled modems.
+endef
+
+CONFIGURE_ARGS += \
+	--disable-static \
+	--disable-gtk-doc \
+	--disable-gtk-doc-html \
+	--disable-gtk-doc-pdf \
+	--disable-silent-rules
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/include/libqrtr-glib \
+		$(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/libqrtr-glib*.so* \
+		$(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/qrtr-glib.pc \
+		$(1)/usr/lib/pkgconfig
+endef
+
+define Package/libqrtr-glib/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/libqrtr-glib*.so.* \
+		$(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libqrtr-glib))

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
-PKG_VERSION:=1.14.10
+PKG_VERSION:=1.16.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
-PKG_HASH:=4ea60b375a761e17e7bb095bca894579ed0e8e33b273dc698b5cbe03947f357f
+PKG_HASH:=11a4de3df1d686c1c6d7e3977e783be490e856e1499fb311991b0d47a752ae35
 PKG_BUILD_DIR:=$(BUILD_DIR)/ModemManager-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79 Telco T1
Run tested: ath79 Telco T1 OpenWrt master. Compiled and tested basic functionality
Description: Updates the libqmi and ModemManager packages.  `libqrtr-glib` has now been separated from `libqmi` and is its an optional dependency for `libqmi`.  In Menuconfig the `libqrtr-glib` package is selected if libqmi is built with QRTR support, which is selected by default.

More information:
https://lists.freedesktop.org/archives/libqmi-devel/2021-February/003550.html
https://lists.freedesktop.org/archives/libqmi-devel/2021-February/003552.html
https://lists.freedesktop.org/archives/modemmanager-devel/2021-February/008437.html