### PR TITLE
gost_engine: remove OPENSSL_WITH_GOST restraint

### DIFF
--- a/libs/gost_engine/Makefile
+++ b/libs/gost_engine/Makefile
@@ -35,7 +35,7 @@ define Package/libopenssl-gost_engine
     SUBMENU:=SSL
     TITLE+= (library)
     URL:=https://github.com/gost-engine/engine/
-    DEPENDS:=libopenssl @OPENSSL_ENGINE @OPENSSL_WITH_GOST +libopenssl-conf
+    DEPENDS:=libopenssl @OPENSSL_ENGINE +libopenssl-conf
 endef
 
 define Package/libopenssl-gost_engine/description


### PR DESCRIPTION
Maintainer: @6ec123321 
Compile tested: N/A - only changes menuconfig
Run tested: N/A

Description:
OpenSSL now is always built with GOST support, and OPENSSL_WITH_GOST
symbol was removed.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---
This is simple and necessary.  Right now the engine is never shown.