### PR TITLE
django: bump to version 3.1.7

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=3.1.6
+PKG_VERSION:=3.1.7
 PKG_RELEASE:=1
 
 PYPI_NAME:=Django
-PKG_HASH:=c6c0462b8b361f8691171af1fb87eceb4442da28477e12200c40420176206ba7
+PKG_HASH:=32ce792ee9b6a0cbbec340123e229ac9f765dff8c2a4ae9247a14b2ba3a365a7
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Peter Stadler <peter.stadler@student.uibk.ac.at>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me, @peter-stadler  
Compile tested:  x86 https://github.com/openwrt/openwrt/commit/36e35b8d813c259e08974e758fe3509921f1d767
Run tested: x86 https://github.com/openwrt/openwrt/commit/36e35b8d813c259e08974e758fe3509921f1d767

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmai.com>