### PR TITLE
treewide, affected packages: fix build with golang 1.16

### DIFF
--- a/net/restic-rest-server/Makefile
+++ b/net/restic-rest-server/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=restic-rest-server
 PKG_VERSION:=0.9.7
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/rest-server-$(PKG_VERSION)
 PKG_SOURCE:=rest-server-$(PKG_VERSION).tar.gz
@@ -42,6 +42,8 @@ Rest Server is a high performance HTTP server that implements restic's REST back
 API. It provides secure and efficient way to backup data remotely, using restic
 backup client via the rest: URL.
 endef
+
+GO_PKG_BUILD_VARS += GO111MODULE=auto
 
 define Package/restic-rest-server/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/net/tor-fw-helper/Makefile
+++ b/net/tor-fw-helper/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor-fw-helper
 PKG_VERSION:=0.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://git.torproject.org/tor-fw-helper.git
@@ -68,6 +68,8 @@ $(call Package/tor-fw-helper/Default/description)
 
 This package provides the source files for the helper program.
 endef
+
+GO_PKG_BUILD_VARS += GO111MODULE=auto
 
 $(eval $(call GoBinPackage,tor-fw-helper))
 $(eval $(call BuildPackage,tor-fw-helper))

--- a/utils/cni/Makefile
+++ b/utils/cni/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cni
 PKG_VERSION:=0.8.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -23,6 +23,7 @@ include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
 PKG_USE_MIPS16:=0
+GO_PKG_BUILD_VARS += GO111MODULE=auto
 
 define Package/cni
   SECTION:=utils

--- a/utils/containerd/Makefile
+++ b/utils/containerd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=containerd
 PKG_VERSION:=1.4.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -36,6 +36,7 @@ define Package/containerd/description
 An industry-standard container runtime with an emphasis on simplicity, robustness and portability
 endef
 
+GO_PKG_BUILD_VARS += GO111MODULE=auto
 GO_PKG_INSTALL_ALL:=1
 MAKE_PATH:=$(GO_PKG_WORK_DIR_NAME)/build/src/$(GO_PKG)
 MAKE_VARS += $(GO_PKG_VARS)

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker
 PKG_VERSION:=20.10.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -34,6 +34,7 @@ define Package/docker/description
 The CLI used in the Docker CE and Docker EE products.
 endef
 
+GO_PKG_BUILD_VARS += GO111MODULE=auto
 TAR_OPTIONS:=--strip-components 1 $(TAR_OPTIONS)
 TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
 PKG_VERSION:=20.10.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -46,6 +46,7 @@ define Package/dockerd/description
 The Docker CE Engine.
 endef
 
+GO_PKG_BUILD_VARS += GO111MODULE=auto
 TAR_OPTIONS:=--strip-components 1 $(TAR_OPTIONS)
 TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 

--- a/utils/libnetwork/Makefile
+++ b/utils/libnetwork/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnetwork
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -37,6 +37,8 @@ define Package/libnetwork/description
 Libnetwork provides a native Go implementation for connecting containers.
 The goal of libnetwork is to deliver a robust Container Network Model that provides a consistent programming interface and the required network abstractions for applications.
 endef
+
+GO_PKG_BUILD_VARS += GO111MODULE=auto
 
 define Package/libnetwork/install
 	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))

--- a/utils/oci-runtime-tools/Makefile
+++ b/utils/oci-runtime-tools/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=oci-runtime-tools
 PKG_VERSION:=1.0.0-pre20210122
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -53,6 +53,8 @@ define Package/oci-runtime-tests/description
   Best used in combination with a TAP consumer like 'node-tap',
   installable via npm.
 endef
+
+GO_PKG_BUILD_VARS += GO111MODULE=auto
 
 define Build/Compile
 	$(call GoPackage/Build/Compile)


### PR DESCRIPTION
Maintainers: @gekmihesg @jefferyto @dangowrt @aparcar @G-M0N3Y-2503
Compile tested: mvebu, arm_cortex-a9+vfpv3-d16, openwrt master
Run tested: none
Description: 
Golang 1.16 changed the default package build mode to "module-aware" mode.  The intention is to drop GOPATH mode (opposite of module-aware) in go 1.17. See https://blog.golang.org/go116-module-changes

To enable GOPATH mode, this PR adds `GO111MODULE=auto` to `GO_PKG_BUILD_VARS`.  Affected packages are

- restic-rest-server
- tor-fw-helper
- cni
- containerd
- docker
- dockerd
- libnetwork
- oci-runtime-tools

#### Sample error messages

```
Finding targets
no required module provides package github.com/containernetworking/cni/cnitool: working directory is not part of a module

Building targets
go: cannot find main module; see 'go help modules'
```
```
go: cannot find main module, but found vendor.conf in /builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/containerd-1.4.3/.go_work/build/src/github.com/containerd/containerd
	to create a module there, run:
	go mod init
Makefile:193: recipe for target 'bin/ctr' failed
```

Fixes #14879 