### PR TITLE
[19.07] vpn-policy-routing: custom user scripts improvements

### DIFF
--- a/net/vpn-policy-routing/Makefile
+++ b/net/vpn-policy-routing/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vpn-policy-routing
 PKG_VERSION:=0.3.2
-PKG_RELEASE:=12
+PKG_RELEASE:=14
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 

--- a/net/vpn-policy-routing/files/vpn-policy-routing.aws.user
+++ b/net/vpn-policy-routing/files/vpn-policy-routing.aws.user
@@ -4,8 +4,16 @@
 TARGET_IPSET='wan'
 
 TARGET_URL="https://ip-ranges.amazonaws.com/ip-ranges.json"
-TARGET_FNAME="/var/tmp_aws_ip_ranges"
+TARGET_FNAME="/var/vpn-policy-routing_tmp_aws_ip_ranges"
 
-curl "$TARGET_URL" 2>/dev/null | grep "ip_prefix" | sed 's/^.*\"ip_prefix\": \"//; s/\",//' > "$TARGET_FNAME"
-awk -v ipset="$TARGET_IPSET" '{print "add " ipset " " $1}' "$TARGET_FNAME" | ipset restore -!
+_ret=1
+
+if [ ! -s "$TARGET_FNAME" ]; then
+	curl "$TARGET_URL" 2>/dev/null | grep "ip_prefix" | sed 's/^.*\"ip_prefix\": \"//; s/\",//' > "$TARGET_FNAME"
+fi
+if [ -s "$TARGET_FNAME" ]; then
+	awk -v ipset="$TARGET_IPSET" '{print "add " ipset " " $1}' "$TARGET_FNAME" | ipset restore -! && _ret=0
+fi
 rm -f "$TARGET_FNAME"
+
+return $_ret

--- a/net/vpn-policy-routing/files/vpn-policy-routing.netflix.user
+++ b/net/vpn-policy-routing/files/vpn-policy-routing.netflix.user
@@ -5,28 +5,31 @@
 
 TARGET_IPSET='wan'
 TARGET_ASN='2906'
-TARGET_FNAME="/var/tmp_AS${TARGET_ASN}"
+TARGET_FNAME="/var/vpn-policy-routing_tmp_AS${TARGET_ASN}"
 #DB_SOURCE='ipinfo.io'
 #DB_SOURCE='api.hackertarget.com'
 DB_SOURCE='api.bgpview.io'
 
 _ret=1
-if [ "$DB_SOURCE" = "ipinfo.io" ]; then
-	TARGET_URL="https://ipinfo.io/AS${TARGET_ASN}"
-	curl "$TARGET_URL" 2>/dev/null | grep -E "a href.*${TARGET_ASN}\/" | grep -v ":" | sed "s/^.*<a href=\"\/AS${TARGET_ASN}\///; s/\" >//" > "$TARGET_FNAME"
-fi
 
-if [ "$DB_SOURCE" = "api.hackertarget.com" ]; then
-	TARGET_URL="https://api.hackertarget.com/aslookup/?q=AS${TARGET_ASN}"
-	curl "$TARGET_URL" 2>/dev/null | sed '1d' > "$TARGET_FNAME"
-fi
+if [ ! -s "$TARGET_FNAME" ]; then
+	if [ "$DB_SOURCE" = "ipinfo.io" ]; then
+		TARGET_URL="https://ipinfo.io/AS${TARGET_ASN}"
+		curl "$TARGET_URL" 2>/dev/null | grep -E "a href.*${TARGET_ASN}\/" | grep -v ":" | sed "s/^.*<a href=\"\/AS${TARGET_ASN}\///; s/\" >//" > "$TARGET_FNAME"
+	fi
 
-if [ "$DB_SOURCE" = "api.bgpview.io" ]; then
-	TARGET_URL="https://api.bgpview.io/asn/${TARGET_ASN}/prefixes"
-	if command -v jq >/dev/null 2>&1; then
-		curl -s "$TARGET_URL" 2>/dev/null | jq -r '.data.ipv4_prefixes[].prefix' > "$TARGET_FNAME"
-	else
-		curl -s "$TARGET_URL" 2>/dev/null | sed -ne 's/.*"ipv4_prefixes":\(.*\),"ipv6_prefixes":.*/\1\n/g; s/\}\},/&\n/g; s/"parent":{"prefix":/"parent":{"parent_prefix":/gp' | sed -ne 's/.*"prefix":"\(.\{0,20\}\)",".*/\1/g; s/\\//gp' > "$TARGET_FNAME"
+	if [ "$DB_SOURCE" = "api.hackertarget.com" ]; then
+		TARGET_URL="https://api.hackertarget.com/aslookup/?q=AS${TARGET_ASN}"
+		curl "$TARGET_URL" 2>/dev/null | sed '1d' > "$TARGET_FNAME"
+	fi
+
+	if [ "$DB_SOURCE" = "api.bgpview.io" ]; then
+		TARGET_URL="https://api.bgpview.io/asn/${TARGET_ASN}/prefixes"
+		if command -v jq >/dev/null 2>&1; then
+			curl -s "$TARGET_URL" 2>/dev/null | jq -r '.data.ipv4_prefixes[].prefix' > "$TARGET_FNAME"
+		else
+			curl -s "$TARGET_URL" 2>/dev/null | sed -ne 's/.*"ipv4_prefixes":\(.*\),"ipv6_prefixes":.*/\1\n/g; s/\}\},/&\n/g; s/"parent":{"prefix":/"parent":{"parent_prefix":/gp' | sed -ne 's/.*"prefix":"\(.\{0,20\}\)",".*/\1/g; s/\\//gp' > "$TARGET_FNAME"
+		fi
 	fi
 fi
 


### PR DESCRIPTION
Maintainer: me
Compile tested: ramips, er-x, 19.07.7
Run tested: ramips, er-x, 19.07.7, start/stop

Description: Based on [user request](https://github.com/stangri/source.openwrt.melmac.net/issues/128) I've made minor changes to only redownload the IP ranges within the custom user scripts if the target file doesn't exist or empty, making it a bit easier for users to control the expiry/redownload options for these.

Signed-off-by: Stan Grishin <stangri@melmac.net>
