### PR TITLE
snort[3],libdaq[3]: install/use libdaq 2&3 in their own dir

### DIFF
--- a/libs/libdaq/Makefile
+++ b/libs/libdaq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdaq
 PKG_VERSION:=2.2.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://www.snort.org/downloads/snortplus/
 PKG_SOURCE:=daq-$(PKG_VERSION).tar.gz
@@ -45,12 +45,12 @@ CONFIGURE_ARGS+= \
 	--with-libpcap-libraries="$(STAGING_DIR)/usr/lib" \
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(STAGING_DIR)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(STAGING_DIR)/usr/include/
-	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib* $(STAGING_DIR)/usr/lib/
-	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib/daq
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/daq/* $(STAGING_DIR)/usr/lib/daq/
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/include/daq2
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(STAGING_DIR)/usr/include/daq2/
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib/daq2
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib* $(STAGING_DIR)/usr/lib/daq2/
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib/daq2/daq
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/daq/* $(STAGING_DIR)/usr/lib/daq2/daq/
 	$(INSTALL_DIR) $(STAGING_DIR)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/daq-modules-config $(STAGING_DIR)/usr/bin/
 	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' $(STAGING_DIR)/usr/bin/daq-modules-config

--- a/libs/libdaq3/Makefile
+++ b/libs/libdaq3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdaq3
 PKG_VERSION:=3.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=libdaq-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.snort.org/downloads/snortplus/
@@ -46,14 +46,12 @@ CONFIGURE_ARGS+= \
 	--with-libpcap-libraries="$(STAGING_DIR)/usr/lib" \
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(STAGING_DIR)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(STAGING_DIR)/usr/include/
-	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib* $(STAGING_DIR)/usr/lib/
-	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib/daq
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/daq/* $(STAGING_DIR)/usr/lib/daq/
-	$(INSTALL_DIR) $(STAGING_DIR)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(STAGING_DIR)/usr/bin/
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/include/daq3
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/. $(STAGING_DIR)/usr/include/daq3/
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib/daq3
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib* $(STAGING_DIR)/usr/lib/daq3/
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib/daq3/daq
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/daq/* $(STAGING_DIR)/usr/lib/daq3/daq/
 endef
 
 define Package/libdaq3/install

--- a/net/snort/Makefile
+++ b/net/snort/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort
 PKG_VERSION:=2.9.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -58,8 +58,8 @@ CONFIGURE_ARGS += \
 	--with-libpcap-libraries="$(STAGING_DIR)/usr/lib" \
 	--with-libpcre-includes="$(STAGING_DIR)/usr/include" \
 	--with-libpcre-libraries="$(STAGING_DIR)/usr/lib" \
-	--with-daq-includes="$(STAGING_DIR)/usr/include" \
-	--with-daq-libraries="$(STAGING_DIR)/usr/lib" \
+	--with-daq-includes="$(STAGING_DIR)/usr/include/daq2" \
+	--with-daq-libraries="$(STAGING_DIR)/usr/lib/daq2" \
 	--disable-static-daq
 
 ifeq ($(CONFIG_SNORT_LZMA),)

--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.1.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.snort.org/downloads/snortplus/
@@ -45,6 +45,8 @@ endef
 CMAKE_OPTIONS += \
 	-DUSE_TIRPC:BOOL=YES \
 	-DENABLE_STATIC_DAQ:BOOL=NO \
+	-DDAQ_INCLUDE_DIR=$(STAGING_DIR)/usr/include/daq3 \
+	-DDAQ_LIBRARIES_DIR_HINT:PATH=$(STAGING_DIR)/usr/lib/daq3 \
 	-DENABLE_COREFILES:BOOL=NO \
 	-DENABLE_GDB:BOOL=NO \
 	-DMAKE_DOC:BOOL=NO \
@@ -54,8 +56,8 @@ CMAKE_OPTIONS += \
 	-DHAVE_LIBUNWIND=OFF \
 	-DHAVE_LZMA=OFF
 
-TARGET_CFLAGS  += -I$(STAGING_DIR)/usr/include/tirpc
-TARGET_LDFLAGS += -ltirpc
+TARGET_CFLAGS  += -I$(STAGING_DIR)/usr/include/daq3 -I$(STAGING_DIR)/usr/include/tirpc
+TARGET_LDFLAGS += -L$(STAGING_DIR)/usr/lib/daq3 -ltirpc
 
 define Package/snort3/conffiles
 /etc/config/snort


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: arm-cortex-a9+vfp3-d16, mipsel_74kc,mipsel_mips32
Run tested: none

Description:
libdaq 2 & 3 install some files to the same place, so whichever is compile last overwrite the first one's files.
This series saves libdaq2 and libdaq3 into separate include & lib directories, and adapt snort 2 & 3 to reach the new locations.

I'm doing libdaq2 & snort2 together in the same commit (and likewise for version 3) to avoid a failing commit.  libdaq is only used by snort, so this should not be a big deal, I hope.  I can always split them on request.

Fixes compilation errors like:
```
checking for daq_load_modules in -ldaq... no

   ERROR!  daq library not found, go get it from
   http://www.snort.org/.
Makefile:158: recipe for target '/builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/snort/snort-2.9.17/.configured_68b329da9893e34099c7d8ad5cb9c940' failed
make[3]: *** [/builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/snort/snort-2.9.17/.configured_68b329da9893e34099c7d8ad5cb9c940] Error 1
```