### PR TITLE
setools: Avoid using host libraries

### DIFF
--- a/utils/setools/Makefile
+++ b/utils/setools/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=setools
 PKG_VERSION:=4.3.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/SELinuxProject/setools/releases/download/4.3.0

--- a/utils/setools/patches/030-remove-host-paths.patch
+++ b/utils/setools/patches/030-remove-host-paths.patch
@@ -1,0 +1,12 @@
+--- a/setup.py
++++ b/setup.py
+@@ -79,7 +79,8 @@ class QtHelpCommand(Command):
+ 
+ 
+ # Library linkage
+-lib_dirs = ['.', '/usr/lib64', '/usr/lib', '/usr/local/lib']
++owrt_staging_dir = os.environ["STAGING_DIR"]
++lib_dirs = ['.', owrt_staging_dir + '/usr/lib64', owrt_staging_dir + '/usr/lib', owrt_staging_dir + '/usr/local/lib' ]
+ include_dirs = []
+ 
+ with suppress(KeyError):


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: arm_cortex-a9+vfpv3-d16, openwrt master
Run tested: none

Description:
This adds $STAGING_DIR to library search paths in setup.py, to avoid
picking up host libraries when linking.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>