### PR TITLE
php7: adjust build with QUILT

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=7.4.15
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=PHP-3.01
@@ -530,7 +530,12 @@ endef
 
 define Build/Prepare
 	$(call Build/Prepare/Default)
-	( cd $(PKG_BUILD_DIR); touch configure.ac; ./buildconf --force )
+	$(if $(QUILT),,( cd $(PKG_BUILD_DIR); touch configure.ac; ./buildconf --force ))
+endef
+
+define Build/Configure
+	$(if $(QUILT),( cd $(PKG_BUILD_DIR); touch configure.ac; ./buildconf --force ))
+	$(call Build/Configure/Default)
 endef
 
 define Build/InstallDev

--- a/lang/php7/pecl.mk
+++ b/lang/php7/pecl.mk
@@ -16,6 +16,11 @@ define Build/Prepare
 	$(if $(QUILT),,( cd $(PKG_BUILD_DIR); $(STAGING_DIR)/usr/bin/phpize7 ))
 endef
 
+define Build/Configure
+	$(if $(QUILT),( cd $(PKG_BUILD_DIR); $(STAGING_DIR)/usr/bin/phpize7 ))
+	$(Build/Configure/Default)
+endef
+
 CONFIGURE_VARS+= \
 	ac_cv_c_bigendian_php=$(if $(CONFIG_BIG_ENDIAN),yes,no)
 


### PR DESCRIPTION
#### php7:
Maintainer: @mhei
Compile tested: arm_cortex-a9+vfpv3-d16, openwrt master
Run tested: none

Description:
Commit d741a64 ("lang/php7: Don't run phpize7 with QUILT") changed
pecl.mk to not run phpize7 during Package/prepare if QUILT is set.  The
intention was to allow prepare, refresh and update targets to run
without building dependencies.

As a side-effect, Package/configure and Package/compile fail when QUILT
is defined because they can't find ./configure or a Makefile.  It also
impacts the github tests run with pull requests, because QUILT is
defined there.

To avoid that failure and still keep the prepare, refresh, and update
speedup, call phpize7 before Package/Configure if QUILT is defined.

A similar fix is needed for php7 itself.  run buildconf in Build/Prepare only when QUILT is
off, and do it in Build/Configure otherwise.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---
~This single PR is handling two packages because the change in php7 affects compilation of pecl packages, including php7-pecl-imagik.~

---
#### ~php7-pecl-imagik~

~Maintainer: @flyn-org ~
~Compile tested: arm_cortex-a9+vfpv3-d16, openwrt master~
~Run tested: none~

~Description:~
~This patch avoids looking for Wand-config, or MagickWand-config under~
~/usr, and /opt directories.~

~Otherwise, the host-installed program is used, and compilation fails.~

~Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>~
