### PR TITLE
tor: fix building without OpenSSL engine support

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -139,7 +139,10 @@ ifeq ($(BUILD_VARIANT),basic)
   CONFIGURE_ARGS += --disable-module-relay
 endif
 
-TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
+
+TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto \
+	$(if $(CONFIG_OPENSSL_ENGINE),,-DDISABLE_ENGINES)
+
 TARGET_LDFLAGS += -Wl,--gc-sections -flto
 
 CONFIGURE_VARS += \


### PR DESCRIPTION
Fixes  #14827.

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>