### PR TITLE
lxc: fix build without seccomp if libseccomp built

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=4.0.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/

--- a/utils/lxc/patches/030-commands-fix-check-for-seccomp-notify-support.patch
+++ b/utils/lxc/patches/030-commands-fix-check-for-seccomp-notify-support.patch
@@ -1,0 +1,34 @@
+From a342b11fedb3010630de4909ca707ebdc0862060 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cotequeiroz@gmail.com>
+Date: Fri, 25 Dec 2020 13:54:14 -0300
+Subject: [PATCH 1/2] commands: fix check for seccomp notify support
+
+Use HAVE_SECCOMP_NOTIFY instead of HAVE_DECL_SECCOMP_NOTIFY_FD.
+Currently the latter will be true if the declaration is found by
+configure, even if 'configure --disable-seccomp' is used.
+
+HAVE_SECCOMP_NOTIFY is defined in lxcseccomp.h if both HAVE_SECCOMP and
+HAVE_DECL_SECCOMP_NOTIFY_FD are true, which is the correct behavior.
+
+Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
+
+--- a/src/lxc/commands.c
++++ b/src/lxc/commands.c
+@@ -498,7 +498,7 @@ static int lxc_cmd_get_devpts_fd_callbac
+ 
+ int lxc_cmd_get_seccomp_notify_fd(const char *name, const char *lxcpath)
+ {
+-#if HAVE_DECL_SECCOMP_NOTIFY_FD
++#ifdef HAVE_SECCOMP_NOTIFY
+ 	int ret, stopped;
+ 	struct lxc_cmd_rr cmd = {
+ 		.req = {
+@@ -523,7 +523,7 @@ static int lxc_cmd_get_seccomp_notify_fd
+ 						  struct lxc_handler *handler,
+ 						  struct lxc_epoll_descr *descr)
+ {
+-#if HAVE_DECL_SECCOMP_NOTIFY_FD
++#ifdef HAVE_SECCOMP_NOTIFY
+ 	struct lxc_cmd_rsp rsp = {
+ 		.ret = 0,
+ 	};

--- a/utils/lxc/patches/035-configure-skip-libseccomp-tests-if-it-is-disabled.patch
+++ b/utils/lxc/patches/035-configure-skip-libseccomp-tests-if-it-is-disabled.patch
@@ -1,0 +1,43 @@
+From 67cd8bde2d46983df8fa9f647e9fc0b96370ec29 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cotequeiroz@gmail.com>
+Date: Sat, 16 Jan 2021 13:54:07 -0300
+Subject: [PATCH 2/2] configure: skip libseccomp tests if it is disabled
+
+Move the block checking for libseccomp api compatibility inside
+AM_COND_IF([ENABLE_SECCOMP] ... ).
+
+Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -284,6 +284,14 @@ AM_COND_IF([ENABLE_SECCOMP],
+ 		AC_CHECK_LIB([seccomp], [seccomp_init],[],[AC_MSG_ERROR([You must install the seccomp development package in order to compile lxc])])
+ 		AC_SUBST([SECCOMP_LIBS], [-lseccomp])
+ 		])
++	# HAVE_SCMP_FILTER_CTX=1 will tell us we have libseccomp api >= 1.0.0
++	OLD_CFLAGS="$CFLAGS"
++	CFLAGS="$CFLAGS $SECCOMP_CFLAGS"
++	AC_CHECK_TYPES([scmp_filter_ctx], [], [], [[#include <seccomp.h>]])
++	AC_CHECK_DECLS([seccomp_notify_fd], [], [], [[#include <seccomp.h>]])
++	AC_CHECK_TYPES([struct seccomp_notif_sizes], [], [], [[#include <seccomp.h>]])
++	AC_CHECK_DECLS([seccomp_syscall_resolve_name_arch], [], [], [[#include <seccomp.h>]])
++	CFLAGS="$OLD_CFLAGS"
+ 	])
+ 
+ AC_MSG_CHECKING(for static libcap)
+@@ -331,15 +339,6 @@ AM_COND_IF([ENABLE_CAP],
+         AC_CHECK_LIB(cap,cap_get_file, AC_DEFINE(LIBCAP_SUPPORTS_FILE_CAPABILITIES,1,[Have cap_get_file]),[],[])
+         AC_SUBST([CAP_LIBS], [-lcap])])
+ 
+-# HAVE_SCMP_FILTER_CTX=1 will tell us we have libseccomp api >= 1.0.0
+-OLD_CFLAGS="$CFLAGS"
+-CFLAGS="$CFLAGS $SECCOMP_CFLAGS"
+-AC_CHECK_TYPES([scmp_filter_ctx], [], [], [[#include <seccomp.h>]])
+-AC_CHECK_DECLS([seccomp_notify_fd], [], [], [[#include <seccomp.h>]])
+-AC_CHECK_TYPES([struct seccomp_notif_sizes], [], [], [[#include <seccomp.h>]])
+-AC_CHECK_DECLS([seccomp_syscall_resolve_name_arch], [], [], [[#include <seccomp.h>]])
+-CFLAGS="$OLD_CFLAGS"
+-
+ AC_CHECK_HEADERS([linux/bpf.h], [
+ 	AC_CHECK_TYPES([struct bpf_cgroup_dev_ctx], [], [], [[#include <linux/bpf.h>]])
+ ], [], [])


### PR DESCRIPTION
Maintainer: @ratkaj 
Compile tested: arm_cortex-a9+vfp-d16, mipsel_74kc with openwrt master
Run tested: none

Description:
This fixes compiling lxc without seccomp support if libseccomp is
already installed to the staging dir.  Patches were applied upstream.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

Fixes errors like this, if libseccomp is present, but `CONFIG_LXC_SECCOMP` is not set:
```
commands.c: In function 'lxc_cmd_get_seccomp_notify_fd_callback':
commands.c:532:46: error: 'struct lxc_seccomp' has no member named 'notifier'
  if (!handler->conf || handler->conf->seccomp.notifier.notify_fd < 0)
                                              ^
commands.c:534:62: error: 'struct lxc_seccomp' has no member named 'notifier'
  ret = lxc_abstract_unix_send_fds(fd, &handler->conf->seccomp.notifier.notify_fd, 1, &rsp, sizeof(rsp));
                                                              ^
make[6]: *** [Makefile:3958: liblxc_la-commands.lo] Error 1
```
