### PR TITLE
vim: fix compile with BUILD_NLS

### DIFF
--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vim
 PKG_VERSION:=8.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 VIMVER:=82
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/utils/vim/patches/010-no-msgfmt.patch
+++ b/utils/vim/patches/010-no-msgfmt.patch
@@ -1,0 +1,11 @@
+--- a/src/po/Makefile
++++ b/src/po/Makefile
+@@ -32,7 +32,7 @@ MSGMERGE = OLD_PO_FILE_INPUT=yes OLD_PO_
+ 	$(VIM) -u NONE -e -X -S check.vim -c "if error == 0 | q | endif" -c cq $<
+ 	touch $@
+ 
+-all: $(MOFILES) $(MOCONVERTED) $(MSGFMT_DESKTOP)
++all: $(MOFILES) $(MOCONVERTED)
+ 
+ check: $(CHECKFILES)
+ 


### PR DESCRIPTION
Avoids having to use msgfmt, which happens to be broken with gettext-full.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ratkaj 
Compile tested: ath79

ping @BKPepe 