### PR TITLE
node: bump to v14.16.0

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v14.15.5
-PKG_RELEASE:=2
+PKG_VERSION:=v14.16.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=e19b1d40e958fe30c224f5a67af4ee4081e7f9d6fb586fb4bbc8d94aab39655b
+PKG_HASH:=4e7648a617f79b459d583f7dbdd31fbbac5b846d41598f3b54331a5b6115dfa6
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: head r15963-512229c, aarch64, arm, i386, x86_64, mipsel (pistachio)
Run tested: (qemu 5.2.0) aarch64, arm, i386, x86_64

Description:
Update to v14.16.0

February 2021 Security Releases
- HTTP2 'unknownProtocol' cause Denial of Service by resource exhaustion (Critical) (CVE-2021-22883)
- DNS rebinding in --inspect (CVE-2021-22884)
- OpenSSL - Integer overflow in CipherUpdate (CVE-2021-23840)

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
