### PR TITLE
libuhttpd: Update to 3.10.0

### DIFF
--- a/libs/libuhttpd/Makefile
+++ b/libs/libuhttpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuhttpd
-PKG_VERSION:=3.9.0
+PKG_VERSION:=3.10.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://github.com/zhaojh329/libuhttpd/releases/download/v$(PKG_VERSION)
-PKG_HASH:=9939cd5f9aaad2c118bc04417fb2d21994fb1cdca7fff475a0930a1374635af0
+PKG_HASH:=78b1c670e4f259346a1e49e57d158c619eace23f0b72821b0ff2ba991f7dcc51
 
 PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Signed-off-by: Jianhui Zhao zhaojh329@gmail.com

Maintainer: me
Compile tested: (x86, , master)
Run tested: (x86, , master, tests done)

Description:
Release notes for 3.10.0: https://github.com/zhaojh329/libuhttpd/releases/tag/v3.10.0