### PR TITLE
php7-pecl-imagick, imagemagick: save & use MagickWand-config

### DIFF
--- a/lang/php7-pecl-imagick/Makefile
+++ b/lang/php7-pecl-imagick/Makefile
@@ -9,7 +9,7 @@ PECL_NAME:=imagick
 PECL_LONGNAME:=Image Processing (ImageMagick binding)
 
 PKG_VERSION:=3.4.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_HASH:=8dd5aa16465c218651fc8993e1faecd982e6a597870fd4b937e9ece02d567077
 
 PKG_NAME:=php7-pecl-imagick
@@ -28,6 +28,8 @@ PKG_BUILD_PARALLEL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 include ../php7/pecl.mk
+
+CONFIGURE_ARGS+= --with-imagick="$(STAGING_DIR)/usr"
 
 $(eval $(call PHP7PECLPackage,imagick,$(PECL_LONGNAME),+imagemagick,30))
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/multimedia/imagemagick/Makefile
+++ b/multimedia/imagemagick/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=imagemagick
 PKG_VERSION:=7.0.9
 PKG_REVISION:=5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Val Kulkov <val.kulkov@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_REVISION).tar.gz
@@ -126,6 +126,13 @@ define Build/InstallDev
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/* \
 		$(1)/usr/lib/pkgconfig/
+
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) \
+		$(PKG_INSTALL_DIR)/usr/bin/*-config \
+		$(1)/usr/bin/
+	$(SED) 's|prefix=/usr|prefix=$(STAGING_DIR)/usr|' \
+		$(1)/usr/bin/*-config
 endef
 
 IMlibdir:=usr/lib/ImageMagick-$(PKG_VERSION)


### PR DESCRIPTION
Maintainers: @flyn-org  , @val-kulkov 
Compile tested: arm_cortex-a9+vfpv3-d16, openwrt master
Run tested: none

Description:
If ImageMagick is installed in the host machine, when php7-pecl-imagick is compiled, the host MagickWand-config is used, and the package fails to build.

#### make package/php7-pecl/imagick/configure

One can see the host `/usr/bin/MagickWand-config` being used here:
```
checking for pkg-config... /home/equeiroz/src/openwrt/staging_dir/host/bin/pkg-config
checking ImageMagick MagickWand API configuration program... checking Testing /usr/local/bin/MagickWand-config... Doesn't exist
checking Testing /usr/bin/MagickWand-config... It exists
found in /usr/bin/MagickWand-config
checking if ImageMagick version is at least 6.2.4... found version 7.0.10 Q16
checking for MagickWand.h or magick-wand.h header... /usr/include/ImageMagick-7/MagickWand/MagickWand.h
Package MagickWand-7.Q16 was not found in the pkg-config search path.
Perhaps you should add the directory containing `MagickWand-7.Q16.pc'
to the PKG_CONFIG_PATH environment variable
No package 'MagickWand-7.Q16' found
Package MagickWand-7.Q16 was not found in the pkg-config search path.
Perhaps you should add the directory containing `MagickWand-7.Q16.pc'
to the PKG_CONFIG_PATH environment variable
No package 'MagickWand-7.Q16' found
checking PHP version is at least 5.3.2... yes. found 7.4.15
libs



checking for MagickGetVersion... no
checking for __MagickGetVersion... no
```

#### make package/php7-pecl/imagick/compile
Then compilation fails:
```
arm-openwrt-linux-muslgnueabi-gcc -I. -I/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/pecl-php7/imagick-3.4.4 -DPHP_ATOM_INC -I/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/pecl-php7/imagick-3.4.4/include -I/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/pecl-php7/imagick-3.4.4/main -I/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/pecl-php7/imagick-3.4.4 -I/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/include/php7 -I/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/include/php7/main -I/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/include/php7/TSRM -I/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/include/php7/Zend -I/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/include/php7/ext -I/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/include/php7/ext/date/lib -I/home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-8.4.0_musl_eabi/usr/include -I/home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-8.4.0_musl_eabi/include/fortify -I/home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-8.4.0_musl_eabi/include -I/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/lib/libiconv-stub/include -I/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/lib/libintl-stub/include -DHAVE_CONFIG_H -Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -mfloat-abi=hard -fmacro-prefix-map=/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/pecl-php7/imagick-3.4.4=imagick-3.4.4 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -I/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/lib/libiconv-stub/include -I/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/lib/libintl-stub/include -c /home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/pecl-php7/imagick-3.4.4/imagick_file.c  -fPIC -DPIC -o .libs/imagick_file.o
In file included from /home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/pecl-php7/imagick-3.4.4/php_imagick_file.h:24,
                 from /home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/pecl-php7/imagick-3.4.4/imagick_file.c:22:
/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/pecl-php7/imagick-3.4.4/php_imagick_defs.h:25:12: fatal error: MagickWand/MagickWand.h: No such file or directory
 #  include <MagickWand/MagickWand.h>
            ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[3]: *** [Makefile:192: imagick_file.lo] Error 1
```
I first attempted to fix this with a patch in #14894, but I turned that PR into just fixing php7 itself.  It turns out that by saving MagickWand-config to the staging dir, when imagemagick is built, then I don't need to patch php7-pecl-imagick, I just need to tell it where to find MagickWand-config. 

```
checking for pkg-config... /home/equeiroz/src/openwrt/staging_dir/host/bin/pkg-config
checking ImageMagick MagickWand API configuration program... checking Testing /home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/bin/MagickWand-config... It exists
found in /home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/bin/MagickWand-config
checking if ImageMagick version is at least 6.2.4... found version 7.0.9 Q8
```
If I don't edit the generated MagicWand-config to change `prefix=/usr` to `prefix=$(STAGING_DIR)/usr`, then it would still look for the header below under `/usr/include`, since it uses `MagicWand-config --prefix` for this.
```
checking for MagickWand.h or magick-wand.h header... /home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/include/ImageMagick-7/MagickWand/MagickWand.h
checking PHP version is at least 5.3.2... yes. found 7.4.15
libs
-L/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/lib -lMagickWand-7.Q8 -lMagickCore-7.Q8


checking for MagickGetVersion... yes
```