### PR TITLE
safe-search: fix typos in package scripting

### DIFF
--- a/net/safe-search/Makefile
+++ b/net/safe-search/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=safe-search
 PKG_VERSION:=2.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=MIT
 PKG_MAINTAINER:=Gregory L. Dietsche <Gregory.Dietsche@cuw.edu>
 
@@ -53,7 +53,7 @@ endef
 
 define Package/safe-search/postinst
 #!/bin/sh
-if [ -z "$${IPGK_INSTROOT}" ]; then
+if [ -z "$${IPKG_INSTROOT}" ]; then
   echo "0 * * * * /bin/nice /usr/sbin/safe-search-maintenance>/dev/null 2>&1">>/etc/crontabs/root
   /etc/init.d/cron restart
 fi
@@ -62,7 +62,7 @@ endef
 
 define Package/safe-search/prerm
 #!/bin/sh
-if [ -z "$${IPGK_INSTROOT}" ]; then
+if [ -z "$${IPKG_INSTROOT}" ]; then
 	uci del_list dhcp.@dnsmasq[0].addnhosts=/etc/safe-search/enabled
 	uci commit dhcp
 	/etc/init.d/dnsmasq reload
@@ -73,7 +73,7 @@ endef
 
 define Package/safe-search/postrm
 #!/bin/sh
-if [ -z "$${IPGK_INSTROOT}" ]; then
+if [ -z "$${IPKG_INSTROOT}" ]; then
 	rm -rf /etc/safe-search/enabled
 	rmdir /etc/safe-search/available
 	rmdir /etc/safe-search/


### PR DESCRIPTION
Maintainer: @farmergreg
Compile tested: x86_64, generic, head (2ff9686040)
Run tested: same, not installed (I don't use safe-search)

Description:
