### PR TITLE
[21.02] vpn-policy-routing: bugfix: netflix user file missing redirect

### DIFF
--- a/net/vpn-policy-routing/Makefile
+++ b/net/vpn-policy-routing/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vpn-policy-routing
 PKG_VERSION:=0.3.2
-PKG_RELEASE:=14
+PKG_RELEASE:=16
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 

--- a/net/vpn-policy-routing/files/vpn-policy-routing.netflix.user
+++ b/net/vpn-policy-routing/files/vpn-policy-routing.netflix.user
@@ -25,7 +25,7 @@ if [ ! -s "$TARGET_FNAME" ]; then
 
 	if [ "$DB_SOURCE" = "api.bgpview.io" ]; then
 		TARGET_URL="https://api.bgpview.io/asn/${TARGET_ASN}/prefixes"
-		curl -s "$TARGET_URL" 2>/dev/null | jsonfilter -e '@.data.ipv4_prefixes[*].prefix'
+		curl -s "$TARGET_URL" 2>/dev/null | jsonfilter -e '@.data.ipv4_prefixes[*].prefix' > "$TARGET_FNAME"
 	fi
 fi
 


### PR DESCRIPTION
Maintainer: me
Compile tested: ramips, er-x, 19.07.7
Run tested: ramips, er-x, 19.07.7, run script and verify ipset has been appended

Description: This fixes the bug with not saving downloaded IP ranges for netflix and hence not populating the ipset with reuired IPs as per https://github.com/openwrt/packages/pull/14902#issuecomment-786507228. Also bumps the PKG_RELEASE as suggested here: https://github.com/openwrt/packages/pull/14902#issuecomment-786445413. 

Signed-off-by: Stan Grishin <stangri@melmac.net>
