### PR TITLE
openvpn: update to 2.5.1

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,16 +9,16 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.5.0
-PKG_RELEASE:=2
+PKG_VERSION:=2.5.1
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=029a426e44d656cb4e1189319c95fe6fc9864247724f5599d99df9c4c3478fbd
+PKG_HASH:=40930489c837c05f6153f38e1ebaec244431ef1a034e4846ff732d71d59ff194
 
-PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
+PKG_MAINTAINER:=Magnus Kroken <mkroken@gmail.com>
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Set myself as maintainer.

Signed-off-by: Magnus Kroken <mkroken@gmail.com>

Maintainer: me 
Compile tested: mips_24kc (WDR4300v1), powerpc (WDR4900v1), arm_cortex-a9 (Turris Omnia), x86_64
Run tested: arm_cortex-a9 as server, x86_64 as client connecting together

Description: Contains bugfixes and improvements, no security fixes in this release.

I would like to request commit access to openwrt/packages.
