### PR TITLE
libdrm: install all headers

### DIFF
--- a/libs/libdrm/Makefile
+++ b/libs/libdrm/Makefile
@@ -64,7 +64,7 @@ MESON_ARGS += \
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.so* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig


### PR DESCRIPTION
include/libdrm/drm.h and others headers are needed to build libva.

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>

Maintainer: @lucize 
Compile tested: x86_64