### PR TITLE
Pulseaudio: avahi-variant: Restore Bluez functionality

### DIFF
--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -111,7 +111,6 @@ MESON_ARGS += \
 	-Datomic-arm-memory-barrier=false \
 	-Dalsa=enabled \
 	-Dasyncns=disabled \
-	-Dbluez5=false \
 	-Dbluez5-native-headset=false \
 	-Dbluez5-ofono-headset=false \
 	-Dfftw=disabled \
@@ -137,12 +136,14 @@ MESON_ARGS += \
 ifeq ($(BUILD_VARIANT),avahi)
 MESON_ARGS += \
 	-Davahi=enabled \
+	-Dbluez5=true \
 	-Ddbus=enabled
 endif
 
 ifeq ($(BUILD_VARIANT),noavahi)
 MESON_ARGS += \
 	-Davahi=disabled \
+	-Dbluez5=false \
 	-Ddbus=disabled
 endif
 


### PR DESCRIPTION
Signed-off-by: Johnny Vogels <35307256+jmv2009@users.noreply.github.com>

Maintainer: @tripolar

Compile tested: x64
Run tested: x64

Description:
Bluez had actually been disabled since Pulseaudio 13.0 update

Similar to https://github.com/openwrt/packages/pull/14960 on main branch