### PR TITLE
mwan3: disable DNS lookups for ping checks

### DIFF
--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -242,12 +242,12 @@ main() {
 				case "$track_method" in
 					ping)
 						if [ $check_quality -eq 0 ]; then
-							WRAP $PING -c $count -W $timeout -s $size -t $max_ttl -q $track_ip &> /dev/null &
+							WRAP $PING -n -c $count -W $timeout -s $size -t $max_ttl -q $track_ip &> /dev/null &
 							TRACK_PID=$!
 							wait $TRACK_PID
 							result=$?
 						else
-							WRAP $PING -c $count -W $timeout -s $size -t $max_ttl -q $track_ip 2>/dev/null > $TRACK_OUTPUT &
+							WRAP $PING -n -c $count -W $timeout -s $size -t $max_ttl -q $track_ip 2>/dev/null > $TRACK_OUTPUT &
 							TRACK_PID=$!
 							wait $TRACK_PID
 							ping_status=$?


### PR DESCRIPTION
by default, ping does a reverse DNS of the IP that you are pinging.
When you have a network issue (such as when a link has just gone down
and you haven't yet marked it down), this lookup can cause failures on
tests for links that are still good

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
