### PR TITLE
spi-tools: update to 0.8.7

### DIFF
--- a/utils/spi-tools/Makefile
+++ b/utils/spi-tools/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=spi-tools
-PKG_VERSION:=0.8.6
-PKG_RELEASE:=1
+PKG_VERSION:=0.8.7
+PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE_URL:=https://codeload.github.com/cpb-/spi-tools/tar.gz/$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=319ad6ab296111109ea4a820e216cef392429295de7e10e76f7146677337cf09
+PKG_SOURCE_URL:=https://codeload.github.com/cpb-/spi-tools/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=550f505cc5c34a50d5cd36c49c69b2709fca3f0be4f0777e3f96a45c1ffdbd79
 
 PKG_MAINTAINER:=John Crispin <blogic@openwrt.org>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Switch to AUTORELEASE for simplicity.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @blogic 
Compile tested: ath79