### PR TITLE
rsync: fix compilation for undefined reference ot makedev

### DIFF
--- a/net/rsync/patches/001-fix-makedev-issue.patch
+++ b/net/rsync/patches/001-fix-makedev-issue.patch
@@ -1,0 +1,10 @@
+--- a/rsync.h
++++ b/rsync.h
+@@ -307,6 +307,7 @@ enum delret {
+ #include <stdio.h>
+ #ifdef HAVE_SYS_TYPES_H
+ # include <sys/types.h>
++# include <sys/sysmacros.h>
+ #endif
+ #ifdef HAVE_SYS_STAT_H
+ # include <sys/stat.h>


### PR DESCRIPTION
Maintainer: @mstorchak
Compile tested: x86_64, APU3, OpenWrt [master](https://github.com/openwrt/openwrt/commit/ebcb4f1d0a091d1fa87d6aa04ecae355ef23ef22)
Run tested: no

Description:

This change fixes the following compilation error for rsync
`
generator.c:(.text+0x4872): undefined reference to `makedev'
`
Glibc removes sys/sysmacros.h which defines makedev from sys/types.h
since v2.28.
