### PR TITLE
redis: update to version 6.2.0

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
-PKG_VERSION:=6.0.10
+PKG_VERSION:=6.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=79bbb894f9dceb33ca699ee3ca4a4e1228be7fb5547aeb2f99d921e86c1285bd
+PKG_HASH:=67d624c25d962bd68aff8812a135df85bad07556b8825f3bcd5b522a9932dbca
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause

--- a/libs/redis/patches/020-fix-atomicvar.patch
+++ b/libs/redis/patches/020-fix-atomicvar.patch
@@ -1,16 +1,16 @@
 --- a/src/atomicvar.h
 +++ b/src/atomicvar.h
-@@ -68,7 +68,7 @@
-  * is reported. */
- // #define __ATOMIC_VAR_FORCE_SYNC_MACROS
+@@ -81,7 +81,7 @@
+ #define ANNOTATE_HAPPENS_AFTER(v)  ((void) v)
+ #endif
  
--#if !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && defined(__ATOMIC_RELAXED) && !defined(__sun) && (!defined(__clang__) || !defined(__APPLE__) || __apple_build_version__ > 4210057)
-+#if defined(CONFIG_EDAC_ATOMIC_SCRUB) &&  !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && defined(__ATOMIC_RELAXED) && !defined(__sun) && (!defined(__clang__) || !defined(__APPLE__) || __apple_build_version__ > 4210057)
- /* Implementation using __atomic macros. */
- 
- #define atomicIncr(var,count) __atomic_add_fetch(&var,(count),__ATOMIC_RELAXED)
-@@ -82,7 +82,7 @@
- #define atomicSet(var,value) __atomic_store_n(&var,value,__ATOMIC_RELAXED)
+-#if !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && defined(__STDC_VERSION__) && \
++#if defined(CONFIG_EDAC_ATOMIC_SCRUB) && !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && defined(__STDC_VERSION__) && \
+     (__STDC_VERSION__ >= 201112L) && !defined(__STDC_NO_ATOMICS__)
+ /* Use '_Atomic' keyword if the compiler supports. */
+ #undef  redisAtomic
+@@ -126,7 +126,7 @@
+     __atomic_store_n(&var,value,__ATOMIC_SEQ_CST)
  #define REDIS_ATOMIC_API "atomic-builtin"
  
 -#elif defined(HAVE_ATOMIC)

--- a/libs/redis/patches/030-fix-size_t-zmalloc.patch
+++ b/libs/redis/patches/030-fix-size_t-zmalloc.patch
@@ -1,0 +1,43 @@
+From dd885780d67f18f356a5652ab6d4f947ee035305 Mon Sep 17 00:00:00 2001
+From: Yossi Gottlieb <yossigo@gmail.com>
+Date: Tue, 23 Feb 2021 17:08:49 +0200
+Subject: [PATCH] Fix compile errors with no HAVE_MALLOC_SIZE. (#8533)
+
+Also adds a new daily CI test, relying on the fact that we don't use malloc_size() on alpine libmusl.
+
+Fixes #8531
+---
+ .github/workflows/daily.yml | 22 +++++++++++++++++++++-
+ src/zmalloc.c               |  7 ++-----
+ 2 files changed, 23 insertions(+), 6 deletions(-)
+
+--- a/src/zmalloc.c
++++ b/src/zmalloc.c
+@@ -32,6 +32,7 @@
+ #include <stdlib.h>
+ #include <stdint.h>
+ #include <unistd.h>
++#include <assert.h>
+ 
+ /* This function provide us access to the original libc free(). This is useful
+  * for instance to free results obtained by backtrace_symbols(). We need
+@@ -49,18 +50,14 @@ void zlibc_free(void *ptr) {
+ 
+ #ifdef HAVE_MALLOC_SIZE
+ #define PREFIX_SIZE (0)
++#define ASSERT_NO_SIZE_OVERFLOW(sz)
+ #else
+ #if defined(__sun) || defined(__sparc) || defined(__sparc__)
+ #define PREFIX_SIZE (sizeof(long long))
+ #else
+ #define PREFIX_SIZE (sizeof(size_t))
+ #endif
+-#endif
+-
+-#if PREFIX_SIZE > 0
+ #define ASSERT_NO_SIZE_OVERFLOW(sz) assert((sz) + PREFIX_SIZE > (sz))
+-#else
+-#define ASSERT_NO_SIZE_OVERFLOW(sz)
+ #endif
+ 
+ /* Explicitly override malloc/free etc when using tcmalloc. */


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates redis to version 6.2.0. It fixes [CVE-2021-21309](https://nvd.nist.gov/vuln/detail/CVE-2021-21309).

Upgrade urgency:
SECURITY if you use 32bit build of redis
MODERATE if you used earlier versions of Redis 6.2
LOW otherwise.

[Changelog](https://github.com/redis/redis/blob/6.2.0/00-RELEASENOTES)

Run tested with redis benchmark utils.