### PR TITLE
yq: Update to 4.6.1

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.6.0
+PKG_VERSION:=4.6.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=67c2c4d832da46e3f2d2f364f8b85af5468c9dc1800d5cf066bd25ff5beb9a66
+PKG_HASH:=a843b90e4e86efa310284823ab6f1249e4ae3c6aa5df4d61c10b0fdc543b267d
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: N/A
Compile tested: rockchip, x86_64
Run tested: rockchip nanopi-r2s

Description:
Fixed performance issue.