### PR TITLE
python-aiohttp: update to version 3.7.4 (security fix)

### DIFF
--- a/lang/python/python-aiohttp/Makefile
+++ b/lang/python/python-aiohttp/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019-2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+# Copyright (C) 2019-2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aiohttp
-PKG_VERSION:=3.7.1
+PKG_VERSION:=3.7.4
 PKG_RELEASE:=1
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=04f9d70f6c4d089be5068d7df6281e638f6820d4f1b1ec3dc012b0b43fa997d2
+PKG_HASH:=5d84ecc73141d0a0d61ece0742bb7ff5751b0657dab8405f899d3ceb104cc7de
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -39,7 +39,8 @@ define Package/python3-aiohttp
 	+python3-logging \
 	+python3-codecs \
 	+python3-cgi \
-	+python3-openssl
+	+python3-openssl \
+	+python3-typing-extensions
 endef
 
 define Package/python3-aiohttp/description

--- a/lang/python/python-typing-extensions/Makefile
+++ b/lang/python/python-typing-extensions/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-typing-extensions
+PKG_VERSION:=3.7.4.3
+PKG_RELEASE:=1
+
+PYPI_NAME:=typing-extensions
+PYPI_SOURCE_NAME:=typing_extensions
+PKG_HASH:=99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=PSF-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-typing-extensions
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Module with type hints for Python
+  URL:=https://github.com/python/typing
+  DEPENDS:= \
+	+python3-light
+endef
+
+define Package/python3-typing-extensions/description
+  Backported and Experimental Type Hints for Python.
+endef
+
+$(eval $(call Py3Package,python3-typing-extensions))
+$(eval $(call BuildPackage,python3-typing-extensions))
+$(eval $(call BuildPackage,python3-typing-extensions-src))


### PR DESCRIPTION
Maintainer: @BKPepe 
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR  updates python-aiohttp to version 3.7.4. It fixes [CVE-2021-21330](https://nvd.nist.gov/vuln/detail/CVE-2021-21330) and adds new package python-typing-extensions which is new aiohttp dependency.

[Changelog](https://github.com/aio-libs/aiohttp/blob/master/CHANGES.rst#374-2021-02-25)

Run tested with simple aiohttp example 