### PR TITLE
mwan3: add connecting and disconnecting event to mwan3track

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.10.7
+PKG_VERSION:=2.10.8
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -128,6 +128,24 @@ connected() {
 	env -i FIRSTCONNECT=$1 ACTION="connected" INTERFACE="$INTERFACE" DEVICE="$DEVICE" /sbin/hotplug-call iface
 }
 
+disconnecting() {
+	if [ "$STATUS" != "disconnecting" ] ; then
+		STATUS="disconnecting"
+		echo "disconnecting" > $MWAN3TRACK_STATUS_DIR/$INTERFACE/STATUS
+		LOG notice "Interface $INTERFACE ($DEVICE) is disconnecting"
+		env -i ACTION="disconnecting" INTERFACE="$INTERFACE" DEVICE="$DEVICE" /sbin/hotplug-call iface
+	fi
+}
+
+connecting() {
+	if [ "$STATUS" != "connecting" ] ; then
+		STATUS="connecting"
+		echo "connecting" > $MWAN3TRACK_STATUS_DIR/$INTERFACE/STATUS
+		LOG notice "Interface $INTERFACE ($DEVICE) is connecting"
+		env -i ACTION="connecting" INTERFACE="$INTERFACE" DEVICE="$DEVICE" /sbin/hotplug-call iface
+	fi
+}
+
 disabled() {
 	STATUS='disabled'
 	echo "disabled" > $MWAN3TRACK_STATUS_DIR/$INTERFACE/STATUS
@@ -326,6 +344,7 @@ main() {
 				score=0
 				[ ${keep_failure_interval} -eq 1 ] && sleep_time=$failure_interval
 			else
+				disconnecting
 				sleep_time=$failure_interval
 			fi
 
@@ -335,6 +354,7 @@ main() {
 			fi
 		else
 			if [ $score -lt $((down+up)) ] && [ $lost -gt 0 ]; then
+				connecting
 				LOG info "Lost $((lost*count)) ping(s) on interface $INTERFACE ($DEVICE). Current score: $score"
 			fi
 
@@ -345,6 +365,7 @@ main() {
 				echo "online" > $MWAN3TRACK_STATUS_DIR/$INTERFACE/STATUS
 				score=$((down+up))
 			elif [ $score -le $up ]; then
+				connecting
 				sleep_time=$recovery_interval
 			fi
 


### PR DESCRIPTION
Maintainer: me / @aaronjg 
Compile tested: not needed only script changes
Run tested: x86_64, APU3, OpenWrt master, mwan3track check if event is generated

Description:
If the interface goes into failure state (is disconnecting)
then with this change one hotplug.d event is generated.

The same is true for the recovery state (is connecting), when the interface
comes back from a failure state.

In both cases, a hotplug.d event for the iface is triggered. Once
with the $ACTION=disconnecting and once for the $ACTION=connecting.
