### PR TITLE
hs20: fix linking with full language support enabled

### DIFF
--- a/net/hs20/Makefile
+++ b/net/hs20/Makefile
@@ -40,6 +40,7 @@ ifdef CONFIG_USE_GLIBC
 endif
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/hs20-common
   SECTION:=net


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: mxs
Run tested: -

Description:
After d18692c, we need to include nls.mk to setup correct
environment variables so that linking succeeds.

Reported-by: Josef Schlehofer <pepe.schlehofer@gmail.com>
Signed-off-by: Michael Heimpold <mhei@heimpold.de>