### PR TITLE
openssh: update to 8.5p1

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
-PKG_VERSION:=8.4p1
-PKG_RELEASE:=4
+PKG_VERSION:=8.5p1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
 		https://ftp.spline.de/pub/OpenBSD/OpenSSH/portable/
-PKG_HASH:=5a01d22e407eb1c05ba8a8f7c654d388a13e9f226e4ed33bd38748dafa1d2b24
+PKG_HASH:=f52f3f41d429aa9918e38cf200af225ccdd8e66f052da572870c89737646ec25
 
 PKG_LICENSE:=BSD ISC
 PKG_LICENSE_FILES:=LICENCE


### PR DESCRIPTION
Signed-off-by: Sibren Vasse <github@sibrenvasse.nl>

Maintainer: @tripolar
Compile tested: tp-link archer c7 v2 / ath79 / master
Run tested: tp-link archer c7 v2 / ath79 / master
- Server running and accepting connections
- Client connecting to servers

Description:
Version bump to 8.5p1