### PR TITLE
bash: fixing missing PARAMS() macro in strtod.c

### DIFF
--- a/utils/bash/Makefile
+++ b/utils/bash/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bash
 PKG_VERSION:=5.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/bash

--- a/utils/bash/patches/902-missing-params.patch
+++ b/utils/bash/patches/902-missing-params.patch
@@ -1,0 +1,11 @@
+--- a/lib/sh/strtod.c
++++ b/lib/sh/strtod.c
+@@ -41,6 +41,8 @@ extern int errno;
+ 
+ #include <bashansi.h>
+ 
++#include <stdc.h>
++
+ #ifndef NULL
+ #  define NULL 0
+ #endif


### PR DESCRIPTION
Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>

Maintainer: @Naoir 
Compile tested: x86_64, generic, head (ebcb4f1d0a)
Run tested: same, copied to test VM, installed, seems to run fine

Description:

Fix to the following prior failure:

```
make[4]: Entering directory '/home/philipp/lede/build_dir/target-x86_64_musl/bash-5.1/lib/sh'
x86_64-openwrt-linux-musl-gcc -c   -I. -I../.. -I../.. -I../../lib -I../../include -I.  -DHAVE_CONFIG_H -DSHELL  -Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -fmacro-prefix-map=/home/philipp/lede/build_dir/target-x86_64_musl/bash-5.1=bash-5.1 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro   -I/home/philipp/lede/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/usr/include -I/home/philipp/lede/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/include/fortify -I/home/philipp/lede/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/include   strtod.c
strtod.c:53:28: error: expected '=', ',', ';', 'asm' or '__attribute__' before 'PARAMS'
 extern int locale_decpoint PARAMS((void));
                            ^~~~~~
strtod.c: In function 'strtod':
strtod.c:93:15: warning: implicit declaration of function 'locale_decpoint' [-Wimplicit-function-declaration]
   radixchar = locale_decpoint ();
               ^~~~~~~~~~~~~~~
strtod.c:105:4: warning: floating constant exceeds range of 'double' [-Woverflow]
    if (num > DBL_MAX * 0.1)
    ^~
strtod.c:180:7: warning: floating constant exceeds range of 'double' [-Woverflow]
       if (num > DBL_MAX * pow (10.0, (double) -exponent))
       ^~
make[4]: *** [Makefile:78: strtod.o] Error 1
make[4]: Leaving directory '/home/philipp/lede/build_dir/target-x86_64_musl/bash-5.1/lib/sh'
make[3]: *** [Makefile:692: lib/sh/libsh.a] Error 1
make[3]: Leaving directory '/home/philipp/lede/build_dir/target-x86_64_musl/bash-5.1'
make[2]: *** [Makefile:103: /home/philipp/lede/build_dir/target-x86_64_musl/bash-5.1/.built] Error 2
make[2]: Leaving directory '/home/philipp/lede/feeds/packages/utils/bash'
time: package/feeds/packages/bash/compile#0.55#0.33#0.79
    ERROR: package/feeds/packages/bash failed to build.
```