### PR TITLE
pigeonhole: bump to 0.5.14

### DIFF
--- a/mail/pigeonhole/Makefile
+++ b/mail/pigeonhole/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dovecot-pigeonhole
-PKG_VERSION_PLUGIN:=0.5.13
+PKG_VERSION_PLUGIN:=0.5.14
 PKG_VERSION_DOVECOT:=$(shell make --no-print-directory -C ../dovecot/ val.PKG_VERSION V=s)
 PKG_VERSION:=$(PKG_VERSION_DOVECOT)-$(PKG_VERSION_PLUGIN)
 PKG_RELEASE:=$(AUTORELEASE)
@@ -17,7 +17,7 @@ DOVECOT_VERSION:=2.3
 
 PKG_SOURCE:=dovecot-$(DOVECOT_VERSION)-pigeonhole-$(PKG_VERSION_PLUGIN).tar.gz
 PKG_SOURCE_URL:=https://pigeonhole.dovecot.org/releases/$(DOVECOT_VERSION)
-PKG_HASH:=911fe566da5b638eab1b11105314300bc9049cc3832d4bd2aed44c265013bf17
+PKG_HASH:=68ca0f78a3caa6b090a469f45c395c44cf16da8fcb3345755b1ca436c9ffb2d2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: @flyn-org CC: @neheb 
Compile tested: arm-cortex-a15-neon-vfp4, openwrt-21.02
Run tested: none

Description:
ChangeLog:
 - IMAP FILTER command: cmd-filter-sieve - Do not allow NIL as script
   name argument.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---
There are 5 changed files from 0.5.13, one change in actual code, and the rest is rather cosmetic:
 - A one-liner change in code from 0.5.13, really, to check for the NIL script.  
- A version correction in configure.ac because it was not updated in 0.5.13, having version 0.6-devel and dovecot 2.4 instead. 
- The rest are all formatting changes and typos.

Therefore I opted to review the code instead of run-testing this (I would need to do a lot of setup to actually run it).