### PR TITLE
bind: fix linking with full language support enabled

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -40,6 +40,7 @@ PKG_CONFIG_DEPENDS := \
 PKG_BUILD_DEPENDS += BIND_LIBXML2:libxml2 BIND_LIBJSON:libjson-c
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/bind/Default
   SECTION:=net


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: mxs
Run tested: -

Description:

After d18692c, we need to include nls.mk to setup correct
environment variables so that linking succeeds.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>