### PR TITLE
CI: migrate formal checks from CircleCI to GitHub

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -1,0 +1,65 @@
+name: Test Formalities
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Test Formalities
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Determine branch name
+        run: |
+          BRANCH="${GITHUB_BASE_REF#refs/heads/}"
+          echo "Building for $BRANCH"
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+      - name: Test formalities
+        run: |
+          # remove GitHubs merge commit
+          git rebase "origin/$BRANCH"
+
+          source .github/workflows/ci_helpers.sh
+
+          RET=0
+          for commit in $(git rev-list HEAD ^origin/$BRANCH); do
+            info "=== Checking commit '$commit'"
+            if git show --format='%P' -s $commit | grep -qF ' '; then
+              err "Pull request should not include merge commits"
+              RET=1
+            fi
+
+            author="$(git show -s --format=%aN $commit)"
+            if echo $author | grep -q '\S\+\s\+\S\+'; then
+              success "Author name ($author) seems ok"
+            else
+              err "Author name ($author) need to be your real name 'firstname lastname'"
+              RET=1
+            fi
+
+            subject="$(git show -s --format=%s $commit)"
+            if echo "$subject" | grep -q -e '^[0-9A-Za-z,+/_-]\+: ' -e '^Revert '; then
+              success "Commit subject line seems ok ($subject)"
+            else
+              err "Commit subject line MUST start with '<package name>: ' ($subject)"
+              RET=1
+            fi
+
+            body="$(git show -s --format=%b $commit)"
+            sob="$(git show -s --format='Signed-off-by: %aN <%aE>' $commit)"
+            if echo "$body" | grep -qF "$sob"; then
+              success "Signed-off-by match author"
+            else
+              err "Signed-off-by is missing or doesn't match author (should be '$sob')"
+              RET=1
+            fi
+          done
+
+          exit $RET


### PR DESCRIPTION
Run the formal checks like SoB message via the GitHub CI.

Signed-off-by: Paul Spooren <mail@aparcar.org>