### PR TITLE
python3-libselinux: fix musl 1.2.x compilation.

### DIFF
--- a/lang/python/python3-libselinux/Makefile
+++ b/lang/python/python3-libselinux/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 SRC_NAME:=libselinux
 PKG_NAME:=python3-$(SRC_NAME)
 PKG_VERSION:=3.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/python-libselinux/$(SRC_NAME)-$(PKG_VERSION)
 PKG_SOURCE:=$(SRC_NAME)-$(PKG_VERSION).tar.gz

--- a/lang/python/python3-libselinux/patches/030-musl12x.patch
+++ b/lang/python/python3-libselinux/patches/030-musl12x.patch
@@ -1,0 +1,66 @@
+From 398d2ceef92cb1baac18e6b34a1a8e1bf41296cd Mon Sep 17 00:00:00 2001
+From: Nicolas Iooss <nicolas.iooss@m4x.org>
+Date: Tue, 16 Feb 2021 22:13:28 +0100
+Subject: [PATCH] libselinux: rename gettid() to something which never
+ conflicts with the libc
+
+Musl recently added a wrapper for gettid() syscall. There is no way to
+detect this new version in a reliable way, so rename our gettid()
+wrapper to a non-conflicting name.
+
+Introduce a new function which, when using a libc known to provide a
+wrapper for gettid(), calls it, and which, otherwise, performs the
+syscall directly.
+
+Anyway this function is only used on systems where /proc/thread-self
+does not exist, which are therefore running Linux<3.17.
+
+Fixes: https://github.com/SELinuxProject/selinux/issues/282
+Signed-off-by: Nicolas Iooss <nicolas.iooss@m4x.org>
+Acked-by: Petr Lautrbach <plautrba@redhat.com>
+---
+ src/procattr.c | 18 ++++++++++--------
+ 1 file changed, 10 insertions(+), 8 deletions(-)
+
+--- a/src/procattr.c
++++ b/src/procattr.c
+@@ -25,21 +25,23 @@ static __thread char destructor_initiali
+ /* Bionic and glibc >= 2.30 declare gettid() system call wrapper in unistd.h and
+  * has a definition for it */
+ #ifdef __BIONIC__
+-  #define OVERRIDE_GETTID 0
++  #define HAVE_GETTID 1
+ #elif !defined(__GLIBC_PREREQ)
+-  #define OVERRIDE_GETTID 1
++  #define HAVE_GETTID 0
+ #elif !__GLIBC_PREREQ(2,30)
+-  #define OVERRIDE_GETTID 1
++  #define HAVE_GETTID 0
+ #else
+-  #define OVERRIDE_GETTID 0
++  #define HAVE_GETTID 1
+ #endif
+ 
+-#if OVERRIDE_GETTID
+-static pid_t gettid(void)
++static pid_t selinux_gettid(void)
+ {
++#if HAVE_GETTID
++	return gettid();
++#else
+ 	return syscall(__NR_gettid);
+-}
+ #endif
++}
+ 
+ static void procattr_thread_destructor(void __attribute__((unused)) *unused)
+ {
+@@ -94,7 +96,7 @@ static int openattr(pid_t pid, const cha
+ 		if (fd >= 0 || errno != ENOENT)
+ 			goto out;
+ 		free(path);
+-		tid = gettid();
++		tid = selinux_gettid();
+ 		rc = asprintf(&path, "/proc/self/task/%d/attr/%s", tid, attr);
+ 	} else {
+ 		errno = EINVAL;


### PR DESCRIPTION
Backported upstream patch.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tpetazzoni 
Compile tested: ppc