### PR TITLE
stoken: fix compilation with BUILD_NLS

### DIFF
--- a/utils/stoken/Makefile
+++ b/utils/stoken/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stoken
 PKG_VERSION:=0.92
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/stoken
@@ -22,6 +22,7 @@ PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/stoken/Default
   TITLE:=tokencode generator compatible with RSA SecurID 128-bit (AES)


### PR DESCRIPTION
Fixes linking issue as libxml2 uses iconv.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ppc