### PR TITLE
freetype: switch to meson

### DIFF
--- a/libs/freetype/Makefile
+++ b/libs/freetype/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freetype
 PKG_VERSION:=2.10.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/freetype
@@ -20,12 +20,10 @@ PKG_LICENSE:=FTL GPL-2.0-only MIT ZLIB GPL-3.0-or-later
 PKG_LICENSE_FILES:=docs/LICENSE.TXT docs/FTL.TXT docs/GPLv2.TXT src/bdf/README src/pcf/README src/gzip/zlib.h builds/unix/config.sub builds/unix/config.guess builds/unix/libtool 
 PKG_CPE_ID:=cpe:/a:freetype:freetype2
 
-CMAKE_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
-CMAKE_BINARY_SUBDIR:=build
+PKG_BUILD_DEPENDS:=meson/host
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/cmake.mk
+include ../../devel/meson/meson.mk
 
 define Package/libfreetype
   SECTION:=libs
@@ -42,14 +40,22 @@ define Package/libfreetype/description
  efficient and ubiquitous products.
 endef
 
-CMAKE_OPTIONS += \
-	-DBUILD_SHARED_LIBS=ON \
-	-DCMAKE_DISABLE_FIND_PACKAGE_BZip2=ON \
-	-DFT_WITH_ZLIB=ON \
-	-DFT_WITH_BZIP2=OFF \
-	-DFT_WITH_PNG=ON \
-	-DFT_WITH_HARFBUZZ=OFF \
-	-DFT_WITH_BROTLI=OFF
+MESON_ARGS += \
+	-Dzlib=system \
+	-Dbzip2=disabled \
+	-Dpng=enabled \
+	-Dharfbuzz=disabled \
+	-Dbrotli=disabled \
+	-Dmmap=enabled
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/freetype2
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/freetype2/* $(1)/usr/include/freetype2/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfreetype.{a,so}* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/freetype2.pc $(1)/usr/lib/pkgconfig/freetype2.pc
+endef
 
 define Package/libfreetype/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/libs/freetype/patches/010-meson.patch
+++ b/libs/freetype/patches/010-meson.patch
@@ -1,0 +1,37 @@
+From 40c5681ab92e7db1298273ccf3c816e6a1498260 Mon Sep 17 00:00:00 2001
+From: Werner Lemberg <wl@gnu.org>
+Date: Mon, 26 Oct 2020 18:09:56 +0100
+Subject: [PATCH] * meson.build: Fix 'harfbuzz' and 'brotli' build options
+ (#59347).
+
+Without this patch, 'harfbuzz' and 'brotli' are always required.
+
+Patch submitted anonymously in Savannah bug report.
+---
+ meson.build | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+--- a/meson.build
++++ b/meson.build
+@@ -267,13 +267,17 @@ ft2_deps += [libpng_dep]
+ harfbuzz_dep = dependency('harfbuzz',
+                  version: '>= 1.8.0',
+                  required: get_option('harfbuzz'))
+-ftoption_command += ['--enable=FT_CONFIG_OPTION_USE_HARFBUZZ']
+-ft2_deps += [harfbuzz_dep]
++if harfbuzz_dep.found()
++  ftoption_command += ['--enable=FT_CONFIG_OPTION_USE_HARFBUZZ']
++  ft2_deps += [harfbuzz_dep]
++endif
+ 
+ # Brotli decompression support
+ brotli_dep = dependency('libbrotlidec', required: get_option('brotli'))
+-ftoption_command += ['--enable=FT_CONFIG_OPTION_USE_BROTLI']
+-ft2_deps += [brotli_dep]
++if brotli_dep.found()
++  ftoption_command += ['--enable=FT_CONFIG_OPTION_USE_BROTLI']
++  ft2_deps += [brotli_dep]
++endif
+ 
+ # We can now generate `ftoption.h`.
+ ftoption_h = custom_target('ftoption.h',

--- a/libs/freetype/patches/020-distutils.patch
+++ b/libs/freetype/patches/020-distutils.patch
@@ -1,0 +1,11 @@
+--- a/meson.build
++++ b/meson.build
+@@ -26,7 +26,7 @@ project('freetype2', 'c',
+ # running an external command is required.
+ 
+ python = import('python')
+-python_exe = python.find_installation(required: true)
++python_exe = 'python3'
+ 
+ ft2_version = run_command(python_exe,
+   files('builds/meson/extract_freetype_version.py'),


### PR DESCRIPTION
Meson configures and builds faster. It's also simpler.

Backport upstream patch fixing compilation without harfbuzz and brotli.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @val-kulkov 
Compile tested: ath79
