### PR TITLE
CI: checkout HEAD commit rather than merge commit

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Determine branch name
@@ -23,9 +24,6 @@ jobs:
 
       - name: Test formalities
         run: |
-          # remove GitHubs merge commit
-          git rebase "origin/$BRANCH"
-
           source .github/workflows/ci_helpers.sh
 
           RET=0


### PR DESCRIPTION
GitHub CI actions/checkout uses a merge commit which isn't compatible
with our formality checks. Instead checkout the pull request HEAD.

Signed-off-by: Paul Spooren <mail@aparcar.org>