### PR TITLE
conmon: update to 2.0.26

### DIFF
--- a/utils/conmon/Makefile
+++ b/utils/conmon/Makefile
@@ -1,25 +1,22 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=conmon
-PKG_VERSION:=2.0.24
+PKG_VERSION:=2.0.26
 PKG_RELEASE:=1
-PKG_LICENSE:=Apache-2.0
-PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containers/$(PKG_NAME)/archive/v$(PKG_VERSION)
-PKG_HASH:=e00bc44a8bd783fd417a5c90d3b8c15035ddc69b18350a31258e7f79aec8c697
+PKG_HASH:=845744c3323bbf9adab4444d70fd7de0ceb12a578c9cf2fd2366c6bed0ac7970
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DEPENDS:=golang/host
-PKG_BUILD_PARALLEL:=1
-PKG_INSTALL:=1
+PKG_BUILD_DEPENDS:=golang/host meson/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
-
-MAKE_VARS += PREFIX=/usr
+include ../../devel/meson/meson.mk
 
 define Package/conmon
   SECTION:=utils
@@ -30,12 +27,12 @@ define Package/conmon
 endef
 
 define Package/conmon/description
-  Podman: A tool for managing OCI containers and pods 
+  Podman: A tool for managing OCI containers and pods
 endef
 
 define Package/conmon/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/conmon $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/libexec/podman/conmon $(1)/usr/bin
 endef
 
 $(eval $(call BuildPackage,conmon))


### PR DESCRIPTION
Switched to building with meson as it works better in a parallel
context.

Small Makefile adjustments for consistency.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: ath79