### PR TITLE
python-flask-socketio: add new package 

### DIFF
--- a/lang/python/python-bidict/Makefile
+++ b/lang/python/python-bidict/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-bidict
+PKG_VERSION:=0.21.2
+PKG_RELEASE:=1
+
+PYPI_NAME:=bidict
+PKG_HASH:=4fa46f7ff96dc244abfc437383d987404ae861df797e2fd5b190e233c302be09
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MPL-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:=setuptools-scm
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-bidict
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=The bidirectional mapping library
+  URL:=https://github.com/jab/bidict
+  DEPENDS:= \
+	+python3-light
+endef
+
+define Package/python3-bidict/description
+  The bidirectional mapping library for Python.
+endef
+
+$(eval $(call Py3Package,python3-bidict))
+$(eval $(call BuildPackage,python3-bidict))
+$(eval $(call BuildPackage,python3-bidict-src))

--- a/lang/python/python-engineio/Makefile
+++ b/lang/python/python-engineio/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-engineio
+PKG_VERSION:=4.0.1
+PKG_RELEASE:=1
+
+PYPI_NAME:=python-engineio
+PKG_HASH:=bb575c1a3512b4b5d4706f3071d5cc36e592459e99a47d9a4b7faabeba941377
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-engineio
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Engine.IO server
+  URL:=https://github.com/miguelgrinberg/python-engineio
+  DEPENDS:= \
+	+python3-light \
+	+python3-asyncio \
+	+python3-logging \
+	+python3-openssl \
+	+python3-urllib
+endef
+
+define Package/python3-engineio/description
+  Python implementation of the Engine.IO realtime client and server.
+endef
+
+$(eval $(call Py3Package,python3-engineio))
+$(eval $(call BuildPackage,python3-engineio))
+$(eval $(call BuildPackage,python3-engineio-src))

--- a/lang/python/python-flask-socketio/Makefile
+++ b/lang/python/python-flask-socketio/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-flask-socketio
+PKG_VERSION:=5.0.1
+PKG_RELEASE:=1
+
+PYPI_NAME:=Flask-SocketIO
+PKG_HASH:=5c4319f5214ada20807857dc8fdf3dc7d2afe8d6dd38f5c516c72e2be47d2227
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-flask-socketio
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Socket.IO integration for Flask
+  URL:=https://github.com/miguelgrinberg/Flask-SocketIO/
+  DEPENDS:= \
+	+python3-light \
+	+python3-flask \
+	+python3-socketio
+endef
+
+define Package/python3-flask-socketio/description
+  Flask-SocketIO gives Flask applications access to low latency
+  bi-directional communications between the clients and the server.
+endef
+
+$(eval $(call Py3Package,python3-flask-socketio))
+$(eval $(call BuildPackage,python3-flask-socketio))
+$(eval $(call BuildPackage,python3-flask-socketio-src))

--- a/lang/python/python-socketio/Makefile
+++ b/lang/python/python-socketio/Makefile
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-socketio
+PKG_VERSION:=5.1.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=python-socketio
+PKG_HASH:=338cc29abb6f3ca14c88f1f8d05ed27c690df4648f62062b299f92625bbf7093
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-socketio
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Socket.IO server and client
+  URL:=https://github.com/miguelgrinberg/python-socketio
+  DEPENDS:= \
+	+python3-light \
+	+python3-bidict \
+	+python3-engineio \
+	+python3-asyncio \
+	+python3-logging \
+	+python3-urllib
+endef
+
+define Package/python3-socketio/description
+  Python implementation of the Socket.IO realtime client and server.
+endef
+
+$(eval $(call Py3Package,python3-socketio))
+$(eval $(call BuildPackage,python3-socketio))
+$(eval $(call BuildPackage,python3-socketio-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR adds a new package python-flask-socketio and its dependencies. 

Flask-socketio enables flask application to use Socket.IO for real-time bi-direction communication.

[Official documentation](https://flask-socketio.readthedocs.io/en/latest/)

New packages:
- python-flask-socketio
- python-socketio
- python-engineio
- python-bidict


