### PR TITLE
wg-installer: add link-local to client interface

### DIFF
--- a/net/wg-installer/wg-client/wg-client-installer.sh
+++ b/net/wg-installer/wg-client/wg-client-installer.sh
@@ -84,6 +84,7 @@ register_client_interface () {
 	ip link add dev $ifname type wireguard
 
 	ip -6 a a dev $ifname $client_ip
+	ip -6 a a dev $ifname fe80::2/64
 	wg set $ifname listen-port $port private-key $gw_key peer $pubkey allowed-ips ::/0 endpoint "${endpoint}:${gw_port}"
 	ip link set up dev $ifname
 	ip link set mtu $mtu_client dev $ifname # configure mtu here!


### PR DESCRIPTION
Wireguard has no link-local address on an interface automatically. Add a link-local to the interface. The server has fe80::1/64 and the client fe80::2/64.
