### PR TITLE
libmraa: fix compilation with GCC10

### DIFF
--- a/libs/libmraa/Makefile
+++ b/libs/libmraa/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmraa
 PKG_VERSION:=2.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eclipse/mraa/tar.gz/v$(PKG_VERSION)?

--- a/libs/libmraa/patches/030-gcc10.patch
+++ b/libs/libmraa/patches/030-gcc10.patch
@@ -1,0 +1,13 @@
+--- a/include/version.h
++++ b/include/version.h
+@@ -11,8 +11,8 @@
+ extern "C" {
+ #endif
+ 
+-const char* gVERSION;
+-const char* gVERSION_SHORT;
++extern const char* gVERSION;
++extern const char* gVERSION_SHORT;
+ 
+ #ifdef __cplusplus
+ }


### PR DESCRIPTION
Taken from an upstream issue.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nxhack 
Compile tested: ath79