### PR TITLE
nginx: fix compilation with BUILD_NLS

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.19.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
@@ -74,6 +74,7 @@ PKG_CONFIG_DEPENDS := \
 	CONFIG_OPENSSL_WITH_NPN
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/nginx/default
   SECTION:=net


### PR DESCRIPTION
Requires nls.mk because of libxml2.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Ansuel @peter-stadler 
Compile tested: ath79