### PR TITLE
sed: use gnu-sed binary name

### DIFF
--- a/utils/sed/Makefile
+++ b/utils/sed/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sed
 PKG_VERSION:=4.8
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/sed
@@ -48,7 +48,7 @@ CONFIGURE_ARGS += \
 
 define Package/sed/install
 	$(INSTALL_DIR) $(1)/usr/libexec
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sed $(1)/usr/libexec/sed-gnu
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sed $(1)/usr/libexec/gnu-sed
 endef
 
 $(eval $(call BuildPackage,sed))


### PR DESCRIPTION
Maintainer: Russel Senior <russell@personaltelco.net>

Description: The other GNU packages on OpenWrt use the `gnu-binary` (like `gnu-sort`, `gnu-stat`, `gnu-timeout`) names, hence the `gnu-sed` name for binary is better. The package home page (https://www.gnu.org/software/sed/) also reads: GNU sed.

@zhanhb @neheb -- please review and merge.

Please cherry-pick this for 21.02 or LMK if I should create a separate PR for 21.02.

Signed-off-by: Stan Grishin <stangri@melmac.net>
