### PR TITLE
modemmanager and libqmi: bump version

### DIFF
--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_VERSION:=1.28.0
+PKG_VERSION:=1.28.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
-PKG_HASH:=e235f63aa375da322e32ad135671757c5a93b0df59e60dcc17703762b32e9a94
+PKG_HASH:=8c8c3ee719874d2529bce9b35b028fe435b36f003979a360d3ad0938449db783
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
-PKG_VERSION:=1.16.0
+PKG_VERSION:=1.16.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
-PKG_HASH:=11a4de3df1d686c1c6d7e3977e783be490e856e1499fb311991b0d47a752ae35
+PKG_HASH:=efa9a963499e0885f3f163096d433334143c4937545134ecd682e0157fa591e3
 PKG_BUILD_DIR:=$(BUILD_DIR)/ModemManager-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>


### PR DESCRIPTION
Signed-off-by: Nicholas Smith <nicholas@nbembedded.com>

Maintainer: me
Compile tested: ath79/Telco T1
Run tested: ath79/Telco T1, checked basic functionality

Description:
Bump libqmi to 1.28.2
Bump ModemManager to 1.16.2
https://lists.freedesktop.org/archives/libqmi-devel/2021-March/003554.html
https://lists.freedesktop.org/archives/modemmanager-devel/2021-March/008460.html