### PR TITLE
libstrophe: fix build with full language support enabled

### DIFF
--- a/libs/libstrophe/Makefile
+++ b/libs/libstrophe/Makefile
@@ -28,6 +28,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_libstrophe-expat
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/libstrophe
 	SECTION:=libs


### PR DESCRIPTION
Maintainer: @changeway 
Compile tested: mxs
Run tested: -

Description:

After d18692c, we need to include nls.mk to setup correct
environment variables so that linking succeeds.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>