### PR TITLE
fish: update to 3.2.0

### DIFF
--- a/utils/fish/Makefile
+++ b/utils/fish/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fish
-PKG_VERSION:=3.1.2
+PKG_VERSION:=3.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/fish-shell/fish-shell/releases/download/$(PKG_VERSION)
-PKG_HASH:=d5b927203b5ca95da16f514969e2a91a537b2f75bec9b21a584c4cd1c7aa74ed
+PKG_HASH:=4f0293ed9f6a6b77e47d41efabe62f3319e86efc8bf83cc58733044fbc6f9211
 
 PKG_MAINTAINER:=Curtis Jiang <jqqqqqqqqqq@gmail.com>, Hao Dong <halbertdong@gmail.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Signed-off-by: Curtis Jiang <jqqqqqqqqqq@gmail.com>

Maintainer: me / @jqqqqqqqqqq 
Compile tested: x86_64
Run tested: x86-64, 19.07.2

Description:
Update fish to 3.2.0
