### PR TITLE
stress-ng: bump to version 0.12.04

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.12.02
+PKG_VERSION:=0.12.04
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://kernel.ubuntu.com/~cking/tarballs/stress-ng
-PKG_HASH:=f847be115f60d3ad7d37c806fd1bfb1412aa3c631fca581d6dc233322f50d6a5
+PKG_HASH:=b4e34bda8db4ed37e33b7a861bc06ad77cbbd234d63236da2cb58f02e3f3218e
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only

--- a/utils/stress-ng/patches/010-soft-float.patch
+++ b/utils/stress-ng/patches/010-soft-float.patch
@@ -1,6 +1,6 @@
 --- a/stress-fp-error.c
 +++ b/stress-fp-error.c
-@@ -115,42 +115,43 @@ static int stress_fp_error(const stress_
+@@ -117,42 +117,43 @@ static int stress_fp_error(const stress_
  	do {
  		volatile double d1, d2;
  
@@ -50,7 +50,7 @@
  		/*
  		 * Use volatiles to force compiler to generate code
  		 * to perform run time computation of 1.0 / M_PI
-@@ -171,14 +172,15 @@ static int stress_fp_error(const stress_
+@@ -173,14 +174,15 @@ static int stress_fp_error(const stress_
  		stress_fp_check(args, "DBL_MAX + DBL_MAX / 2.0",
  			DBL_MAX + DBL_MAX / 2.0, INFINITY,
  			false, true, 0, FE_OVERFLOW | FE_INEXACT);


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/d54072587146dd0db9bb52b513234d944edabda3
Run tested: x86 https://github.com/openwrt/openwrt/commit/d54072587146dd0db9bb52b513234d944edabda3

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>