### PR TITLE
atheepmgr: bugfix missing libpciaccess dependency

### DIFF
--- a/utils/atheepmgr/Makefile
+++ b/utils/atheepmgr/Makefile
@@ -25,6 +25,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/atheepmgr
   SECTION:=utils
   CATEGORY:=Utilities
+  DEPENDS:=+libpciaccess
   TITLE:=EEPROM/boarddata management utility for Atheros WLAN chips
   MENU:=1
 endef


### PR DESCRIPTION
Maintainer: @rsa9000  
Compile tested: x86-64 VM 19.07.7-SNAPSHOT
Run tested: x86-64 VM 19.07.7-SNAPSHOT