### PR TITLE
igmpproxy: move package from openwrt repo

### DIFF
--- a/net/igmpproxy/Makefile
+++ b/net/igmpproxy/Makefile
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2006-2011 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=igmpproxy
+PKG_VERSION:=0.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/pali/igmpproxy/releases/download/${PKG_VERSION}/
+PKG_HASH:=d1fc244cb2fbbf99f720bda3e841fe59ece9b6919073790b4b892739b1b844eb
+PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
+
+include $(INCLUDE_DIR)/package.mk
+
+PKG_FIXUP:=autoreconf
+PKG_LICENSE:=GPL-2.0+
+
+define Package/igmpproxy
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  DEPENDS:=+USE_GLIBC:librt
+  TITLE:=Multicast Routing Daemon
+  URL:=http://sourceforge.net/projects/igmpproxy
+endef
+
+define Package/igmpproxy/description
+	IGMPproxy is a simple dynamic Multicast Routing Daemon using
+	only IGMP signalling (Internet Group Management Protocol).
+endef
+
+define Package/igmpproxy/conffiles
+/etc/config/igmpproxy
+endef
+
+define Package/igmpproxy/install
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/igmpproxy.config $(1)/etc/config/igmpproxy
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/igmpproxy.init $(1)/etc/init.d/igmpproxy
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/igmpproxy $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,igmpproxy))

--- a/net/igmpproxy/files/igmpproxy.config
+++ b/net/igmpproxy/files/igmpproxy.config
@@ -1,0 +1,14 @@
+config igmpproxy
+	option quickleave 1
+#	option verbose [0-3](none, minimal[default], more, maximum)
+
+config phyint
+	option network wan
+	option zone wan
+	option direction upstream
+	list altnet 192.168.1.0/24
+
+config phyint
+	option network lan
+	option zone lan
+	option direction downstream

--- a/net/igmpproxy/files/igmpproxy.init
+++ b/net/igmpproxy/files/igmpproxy.init
@@ -1,0 +1,156 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2010-2014 OpenWrt.org
+
+START=99
+USE_PROCD=1
+PROG=/usr/sbin/igmpproxy
+CONFIGFILE=/var/etc/igmpproxy.conf
+
+igmp_header() {
+	local quickleave verbose
+	config_get_bool quickleave "$1" quickleave 0
+	config_get verbose "$1" verbose 1
+
+	[ $verbose = "0" ] && logopts="-d"
+	[ $verbose = "2" ] && logopts="-v"
+	[ $verbose = "3" ] && logopts="-v -v"
+
+	mkdir -p /var/etc
+	rm -f /var/etc/igmpproxy.conf
+	[ $quickleave -gt 0 ] && echo "quickleave" >> /var/etc/igmpproxy.conf
+
+	[ -L /etc/igmpproxy.conf ] || ln -nsf /var/etc/igmpproxy.conf /etc/igmpproxy.conf
+}
+
+igmp_add_phyint() {
+	local network direction altnets device up
+
+	config_get network $1 network
+	config_get direction $1 direction
+	config_get altnets $1 altnet
+
+	local status="$(ubus -S call "network.interface.$network" status)"
+	[ -n "$status" ] || return
+
+	json_load "$status"
+	json_get_var device l3_device
+	json_get_var up up
+
+	[ -n "$device" -a "$up" = "1" ] || {
+		procd_append_param error "$network is not up"
+		return;
+	}
+
+	append netdevs "$device"
+
+	[ "$direction" = "upstream" ] && has_upstream=1
+
+	echo -e "\nphyint $device $direction ratelimit 0 threshold 1" >> /var/etc/igmpproxy.conf
+
+	if [ -n "$altnets" ]; then
+		local altnet
+		for altnet in $altnets; do
+			echo -e "\taltnet $altnet" >> /var/etc/igmpproxy.conf
+		done
+	fi
+}
+
+igmp_add_network() {
+	local network
+
+	config_get network $1 network
+	procd_add_interface_trigger "interface.*" $network /etc/init.d/igmpproxy reload
+}
+
+igmp_add_firewall_routing() {
+	config_get direction $1 direction
+	config_get zone $1 zone
+
+	if [ "$direction" != "downstream" ] || [ -z "$zone" ]; then
+		return 0
+	fi
+
+# First drop SSDP packets then accept all other multicast
+
+	json_add_object ""
+	json_add_string type rule
+	json_add_string src "$upstream"
+	json_add_string dest "$zone"
+	json_add_string family ipv4
+	json_add_string proto udp
+	json_add_string dest_ip "239.255.255.250"
+	json_add_string target DROP
+	json_close_object
+
+	json_add_object ""
+	json_add_string type rule
+	json_add_string src "$upstream"
+	json_add_string dest "$zone"
+	json_add_string family ipv4
+	json_add_string proto udp
+	json_add_string dest_ip "224.0.0.0/4"
+	json_add_string target ACCEPT
+	json_close_object
+}
+
+igmp_add_firewall_network() {
+	config_get direction $1 direction
+	config_get zone $1 zone
+
+	[ ! -z "$zone" ] || return
+
+	json_add_object ""
+	json_add_string type rule
+	json_add_string src "$zone"
+	json_add_string family ipv4
+	json_add_string proto igmp
+	json_add_string target ACCEPT
+	json_close_object
+
+	[ "$direction" = "upstream" ] && {
+		upstream="$zone"
+		config_foreach igmp_add_firewall_routing phyint
+	}
+}
+
+service_triggers() {
+	procd_add_reload_trigger "igmpproxy"
+	config_foreach igmp_add_network phyint
+}
+
+start_service() {
+	has_upstream=
+	netdevs=
+	logopts=
+	config_load igmpproxy
+
+	config_foreach igmp_header igmpproxy
+	config_foreach igmp_add_phyint phyint
+	[ -n "$has_upstream" ] || return
+
+	procd_open_instance
+	procd_set_param command $PROG '-n'
+	[ -n "$logopts" ] && procd_append_param command $logopts
+	procd_append_param command $CONFIGFILE
+	procd_set_param file $CONFIGFILE
+	procd_set_param netdev $netdevs
+	procd_set_param respawn
+
+	procd_open_data
+
+	json_add_array firewall
+	config_foreach igmp_add_firewall_network phyint
+	json_close_array
+
+	procd_close_data
+
+	procd_close_instance
+}
+
+service_started() {
+	procd_set_config_changed firewall
+}
+
+stop_service() {
+	procd_set_config_changed firewall
+}


### PR DESCRIPTION
Maintainer: Felix Fietkau <nbd@nbd.name>
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR moves igmpproxy package from openwrt repo to packages repo.
The proposal for this change was raised in https://github.com/openwrt/openwrt/pull/3819

Related MR for openwrt repo https://github.com/openwrt/openwrt/pull/3976

cc  @bobafetthotmail @rsalvaterra  
