### PR TITLE
[21.02] php8: backport fixes and update from master

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.0.2
+PKG_VERSION:=8.0.3
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=84dd6e36f48c3a71ff5dceba375c1f6b34b71d4fa9e06b720780127176468ccc
+PKG_HASH:=c9816aa9745a9695672951eaff3a35ca5eddcb9cacf87a4f04b9fb1169010251
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0

--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -529,7 +529,12 @@ endef
 
 define Build/Prepare
 	$(call Build/Prepare/Default)
-	( cd $(PKG_BUILD_DIR); touch configure.ac; ./buildconf --force )
+	$(if $(QUILT),,( cd $(PKG_BUILD_DIR); touch configure.ac; ./buildconf --force ))
+endef
+
+define Build/Configure
+	$(if $(QUILT),( cd $(PKG_BUILD_DIR); touch configure.ac; ./buildconf --force ))
+	$(call Build/Configure/Default)
 endef
 
 define Build/InstallDev

--- a/lang/php8/patches/1001-ext-opcache-fix-detection-of-shm-mmap.patch
+++ b/lang/php8/patches/1001-ext-opcache-fix-detection-of-shm-mmap.patch
@@ -44,3 +44,17 @@ Signed-off-by: Michael Heimpold <mhei@heimpold.de>
    AC_MSG_RESULT([$have_shm_mmap_anon=yes])
  
    PHP_CHECK_FUNC_LIB(shm_open, rt, root)
+@@ -294,8 +300,11 @@ int main() {
+     PHP_CHECK_LIBRARY(rt, shm_unlink, [PHP_ADD_LIBRARY(rt,1,OPCACHE_SHARED_LIBADD)])
+   ],[
+     AC_MSG_RESULT([no])
+-  ],[
+-    AC_MSG_RESULT([no])
++  ],[dnl
++    AC_DEFINE(HAVE_SHM_MMAP_POSIX, 1, [Define if you have POSIX mmap() SHM support])
++    AC_MSG_RESULT([yes])
++    have_shm_mmap_posix=yes
++    PHP_CHECK_LIBRARY(rt, shm_unlink, [PHP_ADD_LIBRARY(rt,1,OPCACHE_SHARED_LIBADD)])
+   ])
+ 
+   PHP_NEW_EXTENSION(opcache,

--- a/lang/php8/pecl.mk
+++ b/lang/php8/pecl.mk
@@ -16,6 +16,11 @@ define Build/Prepare
 	$(if $(QUILT),,( cd $(PKG_BUILD_DIR); $(STAGING_DIR)/usr/bin/phpize8 ))
 endef
 
+define Build/Configure
+	$(if $(QUILT),( cd $(PKG_BUILD_DIR); $(STAGING_DIR)/usr/bin/phpize8 ))
+	$(Build/Configure/Default)
+endef
+
 CONFIGURE_VARS+= \
 	ac_cv_c_bigendian_php=$(if $(CONFIG_BIG_ENDIAN),yes,no)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs

Description:

This cherry-picks several fixes and update to 8.0.3 from master.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>