### PR TITLE
ninja: fix cmake host install

### DIFF
--- a/devel/ninja/Makefile
+++ b/devel/ninja/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ninja
 PKG_VERSION:=1.10.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ninja-build/ninja/tar.gz/v$(PKG_VERSION)?

--- a/devel/ninja/ninja-cmake.mk
+++ b/devel/ninja/ninja-cmake.mk
@@ -9,7 +9,7 @@ define Host/Compile/Default
 endef
 
 define Host/Install/Default
-	$(call Ninja,-C $(HOST_BUILD_DIR)/$(CMAKE_BINARY_SUBDIR) install,DESTDIR="$(HOST_INSTALL_DIR)")
+	$(call Ninja,-C $(HOST_BUILD_DIR)/$(CMAKE_BINARY_SUBDIR) install,)
 endef
 
 define Host/Uninstall/Default


### PR DESCRIPTION
Passing DESTDIR is not needed with cmake packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dhewg 
Compile tested: ath79
