### PR TITLE
stubby: Update README.md

### DIFF
--- a/net/stubby/files/README.md
+++ b/net/stubby/files/README.md
@@ -153,10 +153,10 @@ require that the `dnsmasq` package on the OpenWRT device is replaced with the
 #### DNSSEC by stubby
 
 Configuring stubby to perform DNSSEC validation requires setting the stubby
-configuration option `dnssec_return_status` to `'1'` in `/etc/config/stubby`,
+configuration option `dnssec_return_status` to `'GETDNS_EXTENSION_TRUE'` in `/etc/config/stubby`,
 which can be done by editing the file directly or by executing the commands:
 
-    uci set stubby.global.dnssec_return_status=1
+    uci set stubby.global.dnssec_return_status=GETDNS_EXTENSION_TRUE
     uci commit && reload_config
     
 With stubby performing DNSSEC validation, dnsmasq needs to be configured to


### PR DESCRIPTION
Update to correct dnssec configuration value

Description:
Hey team, just a little update to the readme for configuring stubby with DNSSEC. I tried with `1` as per the original readme, but it appears to actually need to be `GETDNS_EXTENSION_TRUE` as per the stubby documentation: https://dnsprivacy.org/wiki/display/DP/Configuring+Stubby#ConfiguringStubby-DNSSEC