### PR TITLE
safe-search: check for changed IP addresses weekly

### DIFF
--- a/net/safe-search/Makefile
+++ b/net/safe-search/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=safe-search
 PKG_VERSION:=2.0.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=MIT
 PKG_MAINTAINER:=Gregory L. Dietsche <Gregory.Dietsche@cuw.edu>
 
@@ -54,7 +54,7 @@ endef
 define Package/safe-search/postinst
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
-  echo "0 * * * * /bin/nice /usr/sbin/safe-search-maintenance>/dev/null 2>&1">>/etc/crontabs/root
+  echo "1 1 * * 1 /bin/nice /usr/sbin/safe-search-maintenance>/dev/null 2>&1">>/etc/crontabs/root
   /etc/init.d/cron restart
 fi
 exit 0


### PR DESCRIPTION
Maintainer: me
Compile tested: 19.07.6
Run tested: x86, archer-c7

Description:
The current default of hourly is too fast. Some services such as
DuckDuckGo return IPs from a pool based on the user's location instead
of a fixed IP address. This change prevents unnecessary writes to the
flash memory by only updating once per week.

Signed-off-by: Gregory L. Dietsche <gregory.dietsche@cuw.edu>