### PR TITLE
zstd: update to version 1.4.9 (security issue)

### DIFF
--- a/utils/zstd/Makefile
+++ b/utils/zstd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zstd
-PKG_VERSION:=1.4.8
+PKG_VERSION:=1.4.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.zst
 PKG_SOURCE_URL:=https://github.com/facebook/zstd/releases/download/v$(PKG_VERSION)
-PKG_HASH:=c7ea10e20dd61b457220455e3cf553069987b968b7c63d1b9d46acbdb45623eb
+PKG_HASH:=61dce0e9a5036d7fb9b5709ee6567c2c8a1b4ba48a8e43afe9ae355cc37bb494
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0-or-later

--- a/utils/zstd/patches/001-fix-meson.patch
+++ b/utils/zstd/patches/001-fix-meson.patch
@@ -1,0 +1,11 @@
+Fixes build issue https://github.com/facebook/zstd/issues/2519
+--- a/build/meson/lib/meson.build
++++ b/build/meson/lib/meson.build
+@@ -22,6 +22,7 @@ libzstd_sources = [join_paths(zstd_rootd
+   join_paths(zstd_rootdir, 'lib/common/threading.c'),
+   join_paths(zstd_rootdir, 'lib/common/pool.c'),
+   join_paths(zstd_rootdir, 'lib/common/zstd_common.c'),
++  join_paths(zstd_rootdir, 'lib/common/zstd_trace.c'),
+   join_paths(zstd_rootdir, 'lib/common/error_private.c'),
+   join_paths(zstd_rootdir, 'lib/common/xxhash.c'),
+   join_paths(zstd_rootdir, 'lib/compress/hist.c'),


### PR DESCRIPTION
Maintainer: N/A
Compile tested: Turis Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates zstd to version 1.4.9. It fixes [CVE-2021-24032](https://nvd.nist.gov/vuln/detail/CVE-2021-24032) it fixes incomplete fix for CVE-2021-24031.


