### PR TITLE
pdns-recursor: don't search for boost libs in host

### DIFF
--- a/net/pdns-recursor/patches/300-boost-dont-search-host-dirs.patch
+++ b/net/pdns-recursor/patches/300-boost-dont-search-host-dirs.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cotequeiroz@gmail.com>
+Date: Tue, 9 Mar 2021 16:56:13 -0300
+Subject: Openwrt: don't search for boost libs in host dirs
+
+While searching for the boost_system library in boost.m4, configure
+tries to find boost_system-mt before boost_system.  The presence of
+boost_system-mt in the staging dir depends on
+CONFIG_boost-use-name-tags.  If it is not defined (default), and there
+is a boost_system-mt library in the host system, it will be used, and
+the build will fail.
+
+This patch removes the host paths from the search loop, preserving the
+rest of the detection logic.
+
+Alternatively, boost_cv_lib_context_LIBS could be used to avoid library
+detection code entirely, but then the mt- variant would never be used.
+
+Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
+
+--- a/m4/boost.m4
++++ b/m4/boost.m4
+@@ -467,8 +467,7 @@ for boost_rtopt_ in $boost_rtopt '' -d;
+     boost_tmp_lib=$with_boost
+     test x"$with_boost" = x && boost_tmp_lib=${boost_cv_inc_path%/include}
+     for boost_ldpath in "$boost_tmp_lib/lib" '' \
+-             /opt/local/lib* /usr/local/lib* /opt/lib* /usr/lib* \
+-             "$with_boost" C:/Boost/lib /lib*
++             "$with_boost"
+     do
+       # Don't waste time with directories that don't exist.
+       if test x"$boost_ldpath" != x && test ! -e "$boost_ldpath"; then


### PR DESCRIPTION
Maintainer: @James-TR 
Compile tested: x86_64, openwrt-21.02
Run tested: none (waiting for arrival of APU2)

Description:
While searching for the boost_system library in boost.m4, configure
tries to find boost_system-mt before boost_system.  The presence of
boost_system-mt in the staging dir depends on
CONFIG_boost-use-name-tags.  If it is not defined (default), and there
is a boost_system-mt library in the host system, it will be used, and
the build will fail.

This adds a patch to remove the host paths from the search loop,
preserving the rest of the detection logic.

Alternatively, `boost_cv_lib_context_LIBS` could be used to avoid library
detection code entirely, but then the `mt-` variant would never be used.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---
Here's the part of `config.log` showing the host library being picked up:
```
configure:17070: re-using the existing conftest.o
configure:17076: x86_64-openwrt-linux-musl-g++ -o conftest -std=c++11 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -g -O2 -O2 -pipe -march=btver2 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -fmacro-prefix-map=/home/equeiroz/src/openwrt/build_dir/target-x86_64_musl/pdns-recursor-4.4.2=pdns-recursor-4.4.2 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro  -I/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/usr/include -I/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/include/fortify -I/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/include   -L/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/usr/lib -L/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/lib -znow -zrelro  -L/usr/lib64 conftest.o -lboost_system-mt  >&5
/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/lib/gcc/x86_64-openwrt-linux-musl/8.4.0/../../../../x86_64-openwrt-linux-musl/bin/ld: warning: librt.so.1, needed by /usr/lib64/libboost_system-mt.so, not found (try using -rpath or -rpath-link)
configure:17085: $? = 0
configure:17131: re-using the existing conftest.o
configure:17137: x86_64-openwrt-linux-musl-g++ -o conftest -std=c++11 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -g -O2 -O2 -pipe -march=btver2 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -fmacro-prefix-map=/home/equeiroz/src/openwrt/build_dir/target-x86_64_musl/pdns-recursor-4.4.2=pdns-recursor-4.4.2 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro  -I/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/usr/include -I/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/include/fortify -I/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/include   -L/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/usr/lib -L/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/lib -znow -zrelro  -L/usr/lib64 -Wl,-R,/usr/lib64 conftest.o -lboost_system-mt  >&5
/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/lib/gcc/x86_64-openwrt-linux-musl/8.4.0/../../../../x86_64-openwrt-linux-musl/bin/ld: warning: librt.so.1, needed by /usr/lib64/libboost_system-mt.so, not found (try using -rpath or -rpath-link)
configure:17146: $? = 0
configure:17197: result: yes
```
Here are some build log bits:
```
OpenWrt-libtool: link: x86_64-openwrt-linux-musl-g++ -DSYSCONFDIR=\"/etc/powerdns\" -DPKGLIBDIR=\"/usr/lib/pdns-recursor\" -DLOCALSTATEDIR=\"/var/run\" -fPIE -DPIE --param ssp-buffer-size=4 -fstack-protector -std=c++11 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -g -O2 -O2 -pipe -march=btver2 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -fmacro-prefix-map=/home/equeiroz/src/openwrt/build_dir/target-x86_64_musl/pdns-recursor-4.4.2=pdns-recursor-4.4.2 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z -Wl,now -Wl,-z -Wl,relro -pie -pthread -Wl,-R -Wl,/usr/lib64 -Wl,-z -Wl,relro -Wl,-z -Wl,now -znow -zrelro -o pdns_recursor arguments.o base32.o base64.o capabilities.o dns.o dns_random.o dnslabeltext.o dnsname.o dnsparser.o dnsrecords.o dnssecinfra.o dnswriter.o ednsoptions.o ednssubnet.o filterpo.o fstrm_logger.o gettime.o gss_context.o iputils.o ixfr.o json.o logger.o lua-base4.o lua-recursor4.o lwres.o misc.o mtasker_context.o negcache.o nsecrecords.o opensslsigners.o pdns_recursor.o pollmplexer.o protobuf.o proxy-protocol.o pubsuffix.o pubsuffixloader.o qtype.o query-local-address.o rcpgenerator.o rec-carbon.o rec-lua-conf.o rec-protobuf.o rec-snmp.o rec_channel.o rec_channel_rec.o recpacketcache.o recursor_cache.o reczones.o remote_logger.o resolver.o axfr-retriever.o responsestats.o rpzloader.o secpoll-recursor.o secpoll.o shuffle.o sillyrecords.o snmp-agent.o sortlist.o syncres.o threadname.o tsigverifier.o unix_utility.o uuid-utils.o validate.o validate-recursor.o version.o webserver.o ws-api.o ws-recursor.o xpf.o zoneparser-tng.o epollmplexer.o dnstap.o dnsmessage.pb.o dnstap.pb.o  -L/home/equeiroz/src/openwrt/staging_dir/target-x86_64_musl/usr/lib -L/usr/lib64 -L/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/usr/lib -L/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/lib ./ext/yahttp/yahttp/.libs/libyahttp.a ./ext/json11/.libs/libjson11.a -lcrypto -lboost_context -lboost_system-mt ./ext/probds/.libs/libprobds.a /home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/lib/libstdc++.so -llua -lm -lprotobuf -lfstrm -pthread -Wl,-rpath -Wl,/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/lib -Wl,-rpath -Wl,/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/lib
/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/lib/gcc/x86_64-openwrt-linux-musl/8.4.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/x86_64-openwrt-linux-musl/bin/../../../toolchain-x86_64_gcc-8.4.0_musl/lib64/libc.so: warning: the use of `tmpnam' is dangerous, better use `mkstemp'
/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/lib/gcc/x86_64-openwrt-linux-musl/8.4.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/x86_64-openwrt-linux-musl/bin/../../../toolchain-x86_64_gcc-8.4.0_musl/lib64/libc.so: warning: the use of `mktemp' is dangerous, better use `mkstemp' or `mkdtemp'
/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/lib/gcc/x86_64-openwrt-linux-musl/8.4.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/x86_64-openwrt-linux-musl/bin/../../../toolchain-x86_64_gcc-8.4.0_musl/lib64/libc.so: warning: the `gets' function is dangerous and should not be used.
/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/lib/gcc/x86_64-openwrt-linux-musl/8.4.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/x86_64-openwrt-linux-musl/bin/../../../toolchain-x86_64_gcc-8.4.0_musl/lib64/libc.so: warning: the use of `tempnam' is dangerous, better use `mkstemp'
/home/equeiroz/src/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/lib/gcc/x86_64-openwrt-linux-musl/8.4.0/../../../../x86_64-openwrt-linux-musl/bin/ld: warning: librt.so.1, needed by /usr/lib64/libboost_system-mt.so, not found (try using -rpath or -rpath-link)
```
```
Package pdns-recursor is missing dependencies for the following libraries:
libboost_system.so.1.74.0
libc.so.6
libm.so.6
libpthread.so.0
```
