### PR TITLE
[21.02] pigeonhole: cherry-pick bumps to 0.5.14 from master

### DIFF
--- a/mail/pigeonhole/Makefile
+++ b/mail/pigeonhole/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dovecot-pigeonhole
-PKG_VERSION_PLUGIN:=0.5.13
+PKG_VERSION_PLUGIN:=0.5.14
 PKG_VERSION_DOVECOT:=$(shell make --no-print-directory -C ../dovecot/ val.PKG_VERSION V=s)
 PKG_VERSION:=$(PKG_VERSION_DOVECOT)-$(PKG_VERSION_PLUGIN)
 PKG_RELEASE:=$(AUTORELEASE)
@@ -17,7 +17,7 @@ DOVECOT_VERSION:=2.3
 
 PKG_SOURCE:=dovecot-$(DOVECOT_VERSION)-pigeonhole-$(PKG_VERSION_PLUGIN).tar.gz
 PKG_SOURCE_URL:=https://pigeonhole.dovecot.org/releases/$(DOVECOT_VERSION)
-PKG_HASH:=911fe566da5b638eab1b11105314300bc9049cc3832d4bd2aed44c265013bf17
+PKG_HASH:=68ca0f78a3caa6b090a469f45c395c44cf16da8fcb3345755b1ca436c9ffb2d2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/mail/pigeonhole/Makefile
+++ b/mail/pigeonhole/Makefile
@@ -8,16 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dovecot-pigeonhole
-PKG_VERSION_PLUGIN:=0.5.11
+PKG_VERSION_PLUGIN:=0.5.13
 PKG_VERSION_DOVECOT:=$(shell make --no-print-directory -C ../dovecot/ val.PKG_VERSION V=s)
 PKG_VERSION:=$(PKG_VERSION_DOVECOT)-$(PKG_VERSION_PLUGIN)
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 DOVECOT_VERSION:=2.3
 
 PKG_SOURCE:=dovecot-$(DOVECOT_VERSION)-pigeonhole-$(PKG_VERSION_PLUGIN).tar.gz
 PKG_SOURCE_URL:=https://pigeonhole.dovecot.org/releases/$(DOVECOT_VERSION)
-PKG_HASH:=0b972a441f680545ddfacd2f41fb2a705fb03249d46ed5ce7e01fe68b6cfb5f0
+PKG_HASH:=911fe566da5b638eab1b11105314300bc9049cc3832d4bd2aed44c265013bf17
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: arm-cortex-a9+vfpv3-d16,arm_cortex-a15+neon-vfpv4,x86_64, openwrt-21.02
Run tested: tested by @flyn-org in master, in preparation to go into 21.02 (see #15007)

Description:
This cherry-picks two commits from master bumping pigeonhole to version 0.5.14.  Version 0.5.11, currently installed, fails to build with dovecot 2.3.13 because of API changes.