### PR TITLE
overture: update to 1.7

### DIFF
--- a/net/overture/Makefile
+++ b/net/overture/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=overture
-PKG_VERSION:=1.6.1
+PKG_VERSION:=1.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/shawn1m/overture/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=916ddbc4e8ee3cd008e281ba768c1502ad7b3ad71073f5e587b187e371eedd2b
+PKG_HASH:=d3912fe53d2f6a60d20767a8dc5041333f8b5386b7d23d959b4de872d12b5024
 
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 PKG_LICENSE:=MIT
@@ -46,8 +46,8 @@ define Package/overture/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/main $(1)/usr/bin/overture
 	$(INSTALL_DIR) $(1)/etc/overture
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/config.sample.json $(1)/etc/overture/config.json
-	$(SED) 's@"\.\(/[^"]\{1,\}_sample\)"@"/etc/overture\1"@g;s/":53"/"127.0.0.3:53"/' $(1)/etc/overture/config.json
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/config.sample.yml $(1)/etc/overture/config.yml
+	$(SED) 's@\.\(/[^[:space:]]\{1,\}_sample\)@/etc/overture\1@g;s/^\(bindAddress:[[:space:]]\{0,\}\)[^[:space:]]\{0,\}$$$$/\1127.0.0.3:53/' $(1)/etc/overture/config.yml
 	$(INSTALL_DATA) ./files/*_sample $(1)/etc/overture
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/overture.init $(1)/etc/init.d/overture

--- a/net/overture/files/overture.init
+++ b/net/overture/files/overture.init
@@ -5,7 +5,7 @@ USE_PROCD=1
 
 start_service() {
 	procd_open_instance
-	procd_set_param command /usr/bin/overture -c /etc/overture/config.json
+	procd_set_param command /usr/bin/overture -c /etc/overture/config.yml
 	procd_set_param file /etc/overture/config.json
 	procd_set_param stdout 1
 	procd_set_param stderr 1

--- a/net/overture/patches/001-fix-go-sum.patch
+++ b/net/overture/patches/001-fix-go-sum.patch
@@ -1,0 +1,10 @@
+--- a/go.sum
++++ b/go.sum
+@@ -91,6 +91,7 @@ github.com/cncf/udpa/go v0.0.0-201912090
+ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
+ github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+ github.com/coredns/caddy v1.1.0/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
++github.com/coredns/coredns v1.8.0 h1:U6Z6Ljuy5D8VKDquF1dUotUtFeoNt0PVCwSfIVYFC6s=
+ github.com/coredns/coredns v1.8.0/go.mod h1:R/TQ2yPVKdafwpVXOh6NFN13ikgto21kOMPvOeFPS8o=
+ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+ github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=


### PR DESCRIPTION
Maintainer: @ysc3839 
Compile tested: ath79/nand
Run tested: ath79/nand

Description:
ChangeLog:
- Improve search performance with sorted ip ranges @zhanhb
- Auto reload config @F-TD5X
- Add pprof for debug use
- Fix hosts: When hosts exist but query type do not match, an empty result should be returned @wzv5
- Fix suffix tree: When insert abc.com and 1.abc.com, abc.com will not be matched @wzv5
- Fix the domain matching method of the mix-list matcher. (https://github.com/shawn1m/overture/pull/246) @LEXUGE
- Add feature: dns over http server
- Add redis cache support for cache sharing and persistence
- Add yaml support as default for the config file
- Fix nil pointer dereference for empty edns conifg