### PR TITLE
tor-hs: change rpc service name

### DIFF
--- a/net/tor-hs/Makefile
+++ b/net/tor-hs/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor-hs
 PKG_VERSION:=0.0.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -58,7 +58,7 @@ define Package/tor-hs/install
 	$(INSTALL_DIR) $(1)/etc/tor/
 	$(INSTALL_BIN) ./files/nextcloud-update.sh $(1)/etc/tor/
 	$(INSTALL_DIR) $(1)/usr/libexec/rpcd
-	$(INSTALL_BIN) ./files/tor_rpcd.sh $(1)/usr/libexec/rpcd/
+	$(INSTALL_BIN) ./files/tor_rpcd.sh $(1)/usr/libexec/rpcd/tor-hs-rpc
 endef
 
 $(eval $(call BuildPackage,tor-hs))

--- a/net/tor-hs/README.md
+++ b/net/tor-hs/README.md
@@ -85,7 +85,7 @@ After that you should also restart rpcd daemon, so you can use tor-hs RPCD servi
 
 RPCD servis helps users to access basic informations about hidden services on router. After running HS it contains onion url for given hidden service in hostname value.
 ```
-root@turris:/# ubus call tor_rpcd.sh list-hs '{}'
+root@turris:/# ubus call tor-hs-rpc list-hs '{}'
 {
 	"hs-list": [
 		{


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR changes RPC service name from **tor_rpcd.sh** to **tor-hs-rpc**. Related to https://github.com/openwrt/luci/pull/4805#discussion_r574661486
