### PR TITLE
freetype: meson.build: Fix .pc file generation

### DIFF
--- a/libs/freetype/patches/030-meson-pkgconfig.patch
+++ b/libs/freetype/patches/030-meson-pkgconfig.patch
@@ -1,0 +1,56 @@
+From 26e2a89598d69c7aba76c83f6a1fcf1db17574ab Mon Sep 17 00:00:00 2001
+From: Werner Lemberg <wl@gnu.org>
+Date: Wed, 4 Nov 2020 21:00:22 +0100
+Subject: [PATCH] * meson.build: Fix .pc file generation.
+
+For backwards compatibility we need the libtool version, not the .so
+number.
+
+Reported by Nikolaus.
+
+Downloaded from upstream commit:
+https://gitlab.freedesktop.org/freetype/freetype/-/commit/26e2a89598d69c7aba76c83f6a1fcf1db17574ab
+
+Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
+---
+ ChangeLog   |  9 +++++++++
+ meson.build | 10 +++++++---
+ 2 files changed, 16 insertions(+), 3 deletions(-)
+
+--- a/meson.build
++++ b/meson.build
+@@ -32,11 +32,15 @@ ft2_version = run_command(python_exe,
+   files('builds/meson/extract_freetype_version.py'),
+   files('include/freetype/freetype.h')).stdout().strip()
+ 
+-ft2_libtool_version = run_command(python_exe,
++ft2_so_version = run_command(python_exe,
+   files('builds/meson/extract_libtool_version.py'),
+   '--soversion',
+   files('builds/unix/configure.raw')).stdout().strip()
+ 
++ft2_libtool_version = run_command(python_exe,
++  files('builds/meson/extract_libtool_version.py'),
++  files('builds/unix/configure.raw')).stdout().strip()
++
+ ft2_includes = include_directories('include')
+ 
+ 
+@@ -320,7 +324,7 @@ ft2_lib = library('freetype',
+   include_directories: ft2_includes,
+   dependencies: ft2_deps,
+   install: true,
+-  version: ft2_libtool_version,
++  version: ft2_so_version,
+ )
+ 
+ 
+@@ -328,7 +332,7 @@ ft2_lib = library('freetype',
+ freetype2_dep = declare_dependency(
+   include_directories: ft2_includes,
+   link_with: ft2_lib,
+-  version: ft2_libtool_version)
++  version: ft2_so_version)
+ 
+ 
+ # NOTE: Using both `install_dir` and `subdir` doesn't seem to work below,


### PR DESCRIPTION
Fixes error when building fontconfig after switch to meson (https://github.com/openwrt/packages/pull/15018):
```
checking for FREETYPE... no
configure: error: Package requirements (freetype2 >= 21.0.15) were not met:

Package dependency requirement 'freetype2 >= 21.0.15' could not be satisfied.
Package 'freetype2' has version '6.17.4', required version is '>= 21.0.15'
```
Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>

Maintainer: @val-kulkov 
Compile tested: x86_64
