### PR TITLE
docker,dockerd: Updated to 20.10.5

### DIFF
--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker
-PKG_VERSION:=20.10.4
+PKG_VERSION:=20.10.5
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/docker/cli
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=2757ce724b80289d834618f338faa49c512240f3006d18119677f63ec12f0631
-PKG_GIT_SHORT_COMMIT:=d3cb89e # SHA1 used within the docker executables
+PKG_HASH:=4ba845f8c7e2e0a2ca1ec6589847159ca8d0d37b609f0e6f78def7a893b9b342
+PKG_GIT_SHORT_COMMIT:=55c4c88 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=20.10.4
+PKG_VERSION:=20.10.5
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,7 +10,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=97e8861fe68427bf695846d9cca7ff15101f4f393547660fac2fee2e99eba07d
+PKG_HASH:=bcf651d75e5c80421e8cd3b0d47f3425e01047cf67aef0eda83b68776905a583
 PKG_GIT_SHORT_COMMIT:=363e9a8 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>


### PR DESCRIPTION
Maintainer: me @G-M0N3Y-2503 
Compile tested: x86_x64, VirtualBox, `openwrt-21.20`
Run tested: x86_x64, VirtualBox, `openwrt-21.20`

Description:
Updated to 20.10.5

FYI, Looks like this update was just reverting on a commit so the SHA for `dockerd` didn't update, I assume this is expected.