### PR TITLE
wg-installer: fix get_usage function

### DIFF
--- a/net/wg-installer/wg-server/lib/wg_functions.sh
+++ b/net/wg-installer/wg-server/lib/wg_functions.sh
@@ -2,7 +2,7 @@
 . /usr/share/wginstaller/wg.sh
 
 wg_get_usage () {
-	num_interfaces = $(wg show interfaces | wc -w)
+	num_interfaces=$(wg show interfaces | wc -w)
 	json_init
 	json_add_int "num_interfaces" $num_interfaces
 	echo $(json_dump)


### PR DESCRIPTION
The get_usage function always returns 0. The shell syntax was wrong.

Maintainer: me
Compile tested: Trunk
Run tested: Ubiquiti EdgeRouter 4
