### PR TITLE
banip: bump to 0.7.5

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
-PKG_VERSION:=0.7.3
+PKG_VERSION:=0.7.5
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
@@ -55,6 +55,7 @@ define Package/banip/install
 	$(INSTALL_CONF) ./files/banip.conf $(1)/etc/config/banip
 
 	$(INSTALL_DIR) $(1)/etc/banip
+	$(INSTALL_BIN) ./files/banip.dns $(1)/etc/banip
 	$(INSTALL_BIN) ./files/banip.mail $(1)/etc/banip
 	$(INSTALL_BIN) ./files/banip.service $(1)/etc/banip
 	$(INSTALL_CONF) ./files/banip.maclist $(1)/etc/banip

--- a/net/banip/files/banip.dns
+++ b/net/banip/files/banip.dns
@@ -1,0 +1,79 @@
+#!/bin/sh
+# helper script to resolve domains for adding to banIP-related IPSets
+# written by Dirk Brenken (dev@brenken.org)
+#
+# This is free software, licensed under the GNU General Public License v3.
+#
+# (s)hellcheck exceptions
+# shellcheck disable=1091,2030,2031,2034,2039,2086,2129,2140,2143,2154,2181,2183,2188
+
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+set -o pipefail
+
+if [ -r "/lib/functions.sh" ]
+then
+	. "/lib/functions.sh"
+	ban_debug="$(uci_get banip global ban_debug "0")"
+fi
+ban_ver="${1}"
+ban_src_name="${2}"
+ban_src_file="${3}"
+ban_ipset_cmd="$(command -v ipset)"
+ban_lookup_cmd="$(command -v nslookup)"
+ban_logger_cmd="$(command -v logger)"
+ban_rc=1
+
+f_log()
+{
+	local class="${1}" log_msg="${2}"
+
+	if [ -n "${log_msg}" ] && { [ "${class}" != "debug" ] || [ "${ban_debug}" = "1" ]; }
+	then
+		if [ -x "${ban_logger_cmd}" ]
+		then
+			"${ban_logger_cmd}" -p "${class}" -t "banIP-${ban_ver%-*}[${$}]" "${log_msg}"
+		else
+			printf "%s %s %s\n" "${class}" "banIP-${ban_ver%-*}[${$}]" "${log_msg}"
+		fi
+	fi
+}
+
+while read -r domain
+do
+	update_ips=""
+	result="$("${ban_lookup_cmd}" "${domain}" 2>/dev/null; printf "%s" "${?}")"
+	if [ "$(printf "%s" "${result}" | tail -1)" = "0" ]
+	then
+		ips="$(printf "%s" "${result}" | awk '/^Address[ 0-9]*: /{ORS=" ";print $NF}')"
+		for ip in ${ips}
+		do
+			for proto in "4" "6"
+			do
+				if { [ "${proto}" = "4" ] && [ -n "$("${ban_ipset_cmd}" -q -n list "${ban_src_name}_${proto}")" ] && [ -n "$(printf "%s" "${ip}" | awk '/^(([0-9]{1,3}\.){3}[0-9]{1,3}(\/[0-9]{1,2})?)([[:space:]]|$)/{print $1}')" ]; } || \
+					{ [ "${proto}" = "6" ] && [ -n "$("${ban_ipset_cmd}" -q -n list "${ban_src_name}_${proto}")" ] && [ -z "$(printf "%s" "${ip}" | awk '/^(([0-9]{1,3}\.){3}[0-9]{1,3}(\/[0-9]{1,2})?)([[:space:]]|$)/{print $1}')" ]; }
+				then
+					"${ban_ipset_cmd}" add "${ban_src_name}_${proto}" "${ip}" 2>/dev/null
+					if [ "${?}" = "0" ]
+					then
+						if [ -z "${update_ips}" ]
+						then
+							update_ips="${ip}"
+						else
+							update_ips="${update_ips}, ${ip}"
+						fi
+					fi
+					break
+				fi
+			done
+		done
+		if [ -n "${update_ips}" ]
+		then
+			ban_rc=0
+			f_log "debug" "dns_imp ::: source '${ban_src_name}' supplemented by '${domain}' (${update_ips})"
+		fi
+	fi
+done < "${ban_src_file}"
+rm -f "${ban_src_file}"
+f_log "info" "banIP domain import for source '${ban_src_name}' has been finished with rc '${ban_rc}'"
+exit ${ban_rc}

--- a/net/banip/files/banip.sh
+++ b/net/banip/files/banip.sh
@@ -12,7 +12,7 @@
 export LC_ALL=C
 export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
 set -o pipefail
-ban_ver="0.7.3"
+ban_ver="0.7.5"
 ban_enabled="0"
 ban_mail_enabled="0"
 ban_proto4_enabled="0"
@@ -44,7 +44,7 @@ ban_ipt6_savecmd="$(command -v ip6tables-save)"
 ban_ipt6_restorecmd="$(command -v ip6tables-restore)"
 ban_ipset_cmd="$(command -v ipset)"
 ban_logger_cmd="$(command -v logger)"
-ban_logread="$(command -v logread)"
+ban_logread_cmd="$(command -v logread)"
 ban_allsources=""
 ban_sources=""
 ban_asns=""
@@ -68,6 +68,7 @@ ban_srcfile="${ban_tmpbase}/ban_sources.json"
 ban_reportdir="${ban_tmpbase}/banIP-Report"
 ban_backupdir="${ban_tmpbase}/banIP-Backup"
 ban_srcarc="/etc/banip/banip.sources.gz"
+ban_dnsservice="/etc/banip/banip.dns"
 ban_mailservice="/etc/banip/banip.mail"
 ban_logservice="/etc/banip/banip.service"
 ban_maclist="/etc/banip/banip.maclist"
@@ -921,7 +922,7 @@ f_bgsrv()
 {
 	local bg_pid action="${1}"
 
-	bg_pid="$(pgrep -f "^/bin/sh ${ban_logservice}|${ban_logread}|^grep -qE Exit before auth|^grep -qE error: maximum|^grep -qE luci: failed|^grep -qE nginx" | awk '{ORS=" "; print $1}')"
+	bg_pid="$(pgrep -f "^/bin/sh ${ban_logservice}|${ban_logread_cmd}|^grep -qE Exit before auth|^grep -qE error: maximum|^grep -qE luci: failed|^grep -qE nginx" | awk '{ORS=" "; print $1}')"
 	if [ "${action}" = "start" ] && [ -x "${ban_logservice}" ] && [ "${ban_monitor_enabled}" = "1" ]
 	then
 		if [ -n "${bg_pid}" ]
@@ -1004,6 +1005,20 @@ f_down()
 			if [ "${src_rc}" = "0" ]
 			then
 				f_ipset "create"
+				src_name="${src_name%_*}"
+				tmp_dns="${ban_tmpbase}/${src_name}.dns"
+				if [ ! -f "${tmp_dns}" ] && [ "${proto}" = "4" ]
+				then
+					src_rule="/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower(\$1)}"
+					awk "${src_rule}" "${src_url}" > "${tmp_dns}"
+					src_rc="${?}"
+					if [ "${src_rc}" = "0" ] && [ -s "${tmp_dns}" ]
+					then
+						( "${ban_dnsservice}" "${ban_ver}" "${src_name}" "${tmp_dns}" & )
+					else
+						rm -f "${tmp_dns}"
+					fi
+				fi
 			else
 				f_log "debug" "f_down  ::: name: ${src_name}, url: ${src_url}, rule: ${src_rule}, rc: ${src_rc}"
 			fi
@@ -1160,7 +1175,7 @@ f_main()
 	#
 	if [ "${ban_autoblacklist}" = "1" ] || [ "${ban_monitor_enabled}" = "1" ]
 	then
-		log_raw="$(${ban_logread} -l "${ban_loglimit}")"
+		log_raw="$(${ban_logread_cmd} -l "${ban_loglimit}")"
 		if [ -n "$(printf "%s\n" "${ban_logterms}" | grep -F "dropbear")" ]
 		then
 			log_ips="$(printf "%s\n" "${log_raw}" | grep -E "Exit before auth from" | \


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: PC Engines apu4, OpenWrt SNAPSHOT r16174-9530b9bb78

Description:
* black- and whitelist now supporting domain names as well - the
corresponding IPs (IPv4 & IPv6) will be resolved in a detached
background process and added to the IPsets

Signed-off-by: Dirk Brenken <dev@brenken.org>
