### PR TITLE
wg-installer: delete old interfaces

### DIFF
--- a/net/wg-installer/wg-server/config/wgserver.conf
+++ b/net/wg-installer/wg-server/config/wgserver.conf
@@ -4,3 +4,4 @@ config server
     option base_prefix '2002::/64'
     option wg_key '/root/wg.key'
     option wg_pub '/root/wg.pub'
+    option timeout_handshake '600'

--- a/net/wg-installer/wg-server/lib/wg_functions.sh
+++ b/net/wg-installer/wg-server/lib/wg_functions.sh
@@ -1,6 +1,33 @@
 . /usr/share/libubox/jshn.sh
 . /usr/share/wginstaller/wg.sh
 
+wg_timeout () {
+	local int=$1
+
+	handshake=$(wg show $int latest-handshakes | awk '{print $2}')
+	timeout=$(uci get wgserver.@server[0].timeout_handshake)
+
+	if [ $handshake -ge $timeout ]; then
+		echo "1"
+	else
+		echo "0"
+	fi
+}
+
+wg_check_interface () {
+	local int=$1
+	if [ $(wg_timeout $int) -eq "1" ]; then
+		ip link del dev $int
+	fi
+}
+
+wg_check_interfaces () {
+	wg_interfaces=$(wg show interfaces)
+	for interface in $wg_interfaces; do
+		wg_check_interface $interface
+	done
+}
+
 wg_get_usage () {
 	num_interfaces=$(wg show interfaces | wc -w)
 	json_init


### PR DESCRIPTION
Add "wg_check_interfaces" and specify a timeout in the config file.
This allows to delete not used wireguard-interfaces automatically.

For example a cronjob can be installed that calls:

    . /usr/share/wginstaller/wg_functions.sh && wg_check_interfaces

Maintainer: me
Compile tested: trunk
Run tested: edge router 4