### PR TITLE
libx264: enable parallel build

### DIFF
--- a/libs/libx264/Makefile
+++ b/libs/libx264/Makefile
@@ -20,6 +20,7 @@ PKG_MAINTAINER:=Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>

Maintainer: @ianchi 
Compile tested: x86_64