### PR TITLE
openvpn: fix hotplug parameters

### DIFF
--- a/net/openvpn/files/etc/hotplug.d/openvpn/01-user
+++ b/net/openvpn/files/etc/hotplug.d/openvpn/01-user
@@ -3,7 +3,8 @@
 . /lib/functions/openvpn.sh
 
 [ -e "/etc/openvpn.user" ] && {
-	env -i ACTION="$ACTION" INSTANCE="$INSTANCE" \
+	env -i ACTION="$ACTION" INSTANCE="$INSTANCE" INTERFACE=$INTERFACE MTU=$MTU LINK_MTU=$LINK_MTU \
+		   IP_ADDRESS=$IP_ADDRESS NETMASK=$NETMASK COMMAND=$COMMAND \
 		/bin/sh \
 		/etc/openvpn.user \
 		$*
@@ -12,9 +13,8 @@
 # Wrap user defined scripts on up/down events
 case "$ACTION" in
 	up|down)
-		if get_openvpn_option "$config" command "$ACTION"; then
-			shift
-			exec /bin/sh -c "$command $*"
+		if command=$(uci get "openvpn.${INSTANCE}.${ACTION}"); then
+			exec /bin/sh -c "$command $INTERFACE $MTU $LINK_MTU $IP_ADDRESS $NETMASK $COMMAND"
 		fi
 	;;
 esac

--- a/net/openvpn/files/etc/openvpn.user
+++ b/net/openvpn/files/etc/openvpn.user
@@ -8,4 +8,9 @@
 #      <down>    down action is generated after the TUN/TAP device is closed
 #      <up>      up action is generated after the TUN/TAP device is opened
 # $INSTANCE  Name of the openvpn instance which went up or down
-
+# $INTERFACE  VPN interface name
+# $MTU        VPN tunnel MTU
+# $LINK_MTU   VPN tunnel link MTU
+# $IP_ADDRESS VPN interface IP Address
+# $NETMASK    VPN interface netmask
+# $COMMAND    Command to execute (in general this is "init")

--- a/net/openvpn/files/usr/libexec/openvpn-hotplug
+++ b/net/openvpn/files/usr/libexec/openvpn-hotplug
@@ -4,7 +4,25 @@ ACTION=$1
 shift
 INSTANCE=$1
 shift
+INTERFACE=$1
+shift
+MTU=$1
+shift
+LINK_MTU=$1
+shift
+IP_ADDRESS=$1
+shift
+NETMASK=$1
+shift
+COMMAND=$1
+shift
 
 export ACTION=$ACTION
 export INSTANCE=$INSTANCE
+export INTERFACE=$INTERFACE
+export MTU=$MTU
+export LINK_MTU=$LINK_MTU
+export IP_ADDRESS=$IP_ADDRESS
+export NETMASK=$NETMASK
+export COMMAND=$COMMAND
 exec /sbin/hotplug-call openvpn "$@"


### PR DESCRIPTION
Maintainer: me / @\<Felix Fietkau> (find it by checking history of the package Makefile)
Compile tested: (lantiq, mvebu BT HH5, WRT1200 , OpenWrt 21.02)
Run tested: (lantiq, mvebu BT HH5, WRT1200 , OpenWrt 21.02, tests done)

Description: add missing parameters to openvpn hotplug scripts for backwards compatibility with openvpn up/down configuration
