### PR TITLE
mwan3: remove mwan3 ubus call on mwan3 iface hotplug ACTION

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.15
+PKG_VERSION:=2.8.16
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -53,14 +53,10 @@ if [ "$ACTION" = "ifup" ]; then
 fi
 
 if [ "$initial_state" = "offline" ]; then
-	json_load "$(ubus call mwan3 status '{"section":"interfaces"}')"
-	json_select "interfaces"
-	json_select "${INTERFACE}"
-	json_get_var running running
-	json_get_var status status
+	status=$(cat $MWAN3TRACK_STATUS_DIR/$INTERFACE/STATUS 2>/dev/null || echo unknown)
+	[ "$status" = "online" ] || status=offline
 else
 	status=online
-	running=1
 fi
 
 $LOG notice "Execute "$ACTION" event on interface $INTERFACE (${DEVICE:-unknown})"
@@ -72,7 +68,7 @@ case "$ACTION" in
 		mwan3_create_iface_iptables $INTERFACE $DEVICE
 		mwan3_create_iface_rules $INTERFACE $DEVICE
 		mwan3_create_iface_route $INTERFACE $DEVICE
-		if [ "${running}" -eq 1 ] && [ "${status}" = "online" ]; then
+		if [ "${status}" = "online" ]; then
 			$LOG notice "Starting tracker on interface $INTERFACE (${DEVICE:-unknown})"
 			mwan3_set_iface_hotplug_state $INTERFACE "online"
 			mwan3_track $INTERFACE $DEVICE "online" "$src_ip"


### PR DESCRIPTION
Maintainer: me / @aaronjg 
Run tested: x86_64, APU3, OpenWrt openwrt-19.07, tests done)

Description:
With this change, the interface status is no longer read from the mwan3 ubus.
The status of the interface is read directly from the status directory.

I had a strange behavior on my system. It turned out that for reasons unknown to me, the rpcd could no longer find the mwan3 ubus object. But since the status is checked via the mwan3 ubus object, the router was in a loop and always restarted the interface. To prevent this from happening again, remove tha call do ubus and so read the status information from status directory.
This was already implemented in the master with other change in commit c07f5230be128669f7b6731415de26f8176fbf5b.
