### PR TITLE
banip: update to 0.7.5-2

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
 PKG_VERSION:=0.7.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/banip/files/banip.dns
+++ b/net/banip/files/banip.dns
@@ -15,10 +15,17 @@ if [ -r "/lib/functions.sh" ]
 then
 	. "/lib/functions.sh"
 	ban_debug="$(uci_get banip global ban_debug "0")"
+	ban_tmpbase="$(uci_get banip global ban_tmpbase "/tmp")"
+	ban_backupdir="$(uci_get banip global ban_backupdir "${ban_tmpbase}/banIP-Backup")"
+	ban_proto4_enabled="$(uci_get banip global ban_proto4_enabled "0")"
+	ban_proto6_enabled="$(uci_get banip global ban_proto6_enabled "0")"
+else
+	exit 1
 fi
 ban_ver="${1}"
-ban_src_name="${2}"
-ban_src_file="${3}"
+ban_action="${2}"
+ban_src_name="${3}"
+ban_src_file="${4}"
 ban_ipset_cmd="$(command -v ipset)"
 ban_lookup_cmd="$(command -v nslookup)"
 ban_logger_cmd="$(command -v logger)"
@@ -39,23 +46,47 @@ f_log()
 	fi
 }
 
-while read -r domain
-do
-	update_ips=""
-	result="$("${ban_lookup_cmd}" "${domain}" 2>/dev/null; printf "%s" "${?}")"
-	if [ "$(printf "%s" "${result}" | tail -1)" = "0" ]
-	then
-		ips="$(printf "%s" "${result}" | awk '/^Address[ 0-9]*: /{ORS=" ";print $NF}')"
-		for ip in ${ips}
-		do
-			for proto in "4" "6"
+if [ "${ban_action}" = "start" ] || [ "${ban_action}" = "refresh" ]
+then
+	for proto in "4" "6"
+	do
+		if [ -s "${ban_backupdir}/banIP.${ban_src_name}_addon_${proto}.gz" ]
+		then
+			gzip -df "${ban_backupdir}/banIP.${ban_src_name}_addon_${proto}.gz"
+			if [ "${?}" = "0" ]
+			then
+				ban_rc=0
+			else
+				ban_rc=1
+				break
+			fi
+		fi
+	done
+fi
+
+if [ "${ban_rc}" = "1" ]
+then
+	> "${ban_backupdir}/banIP.${ban_src_name}_addon_4"
+	> "${ban_backupdir}/banIP.${ban_src_name}_addon_6"
+	while read -r domain
+	do
+		update_ips=""
+		result="$("${ban_lookup_cmd}" "${domain}" 2>/dev/null; printf "%s" "${?}")"
+		if [ "$(printf "%s" "${result}" | tail -1)" = "0" ]
+		then
+			ips="$(printf "%s" "${result}" | awk '/^Address[ 0-9]*: /{ORS=" ";print $NF}')"
+			for ip in ${ips}
 			do
-				if { [ "${proto}" = "4" ] && [ -n "$("${ban_ipset_cmd}" -q -n list "${ban_src_name}_${proto}")" ] && [ -n "$(printf "%s" "${ip}" | awk '/^(([0-9]{1,3}\.){3}[0-9]{1,3}(\/[0-9]{1,2})?)([[:space:]]|$)/{print $1}')" ]; } || \
-					{ [ "${proto}" = "6" ] && [ -n "$("${ban_ipset_cmd}" -q -n list "${ban_src_name}_${proto}")" ] && [ -z "$(printf "%s" "${ip}" | awk '/^(([0-9]{1,3}\.){3}[0-9]{1,3}(\/[0-9]{1,2})?)([[:space:]]|$)/{print $1}')" ]; }
-				then
-					"${ban_ipset_cmd}" add "${ban_src_name}_${proto}" "${ip}" 2>/dev/null
-					if [ "${?}" = "0" ]
+				for proto in "4" "6"
+				do
+					if { [ "${proto}" = "4" ] && [ "${ban_proto4_enabled}" = "1" ] && \
+						[ -n "$("${ban_ipset_cmd}" -q -n list "${ban_src_name}_${proto}")" ] && \
+						[ -n "$(printf "%s" "${ip}" | awk '/^(([0-9]{1,3}\.){3}[0-9]{1,3}(\/[0-9]{1,2})?)([[:space:]]|$)/{print $1}')" ]; } || \
+						{ [ "${proto}" = "6" ] && [ "${ban_proto6_enabled}" = "1" ] && \
+						[ -n "$("${ban_ipset_cmd}" -q -n list "${ban_src_name}_${proto}")" ] && \
+						[ -z "$(printf "%s" "${ip}" | awk '/^(([0-9]{1,3}\.){3}[0-9]{1,3}(\/[0-9]{1,2})?)([[:space:]]|$)/{print $1}')" ]; }
 					then
+						printf "%s\n" "add ${ban_src_name}_${proto} ${ip}" >> "${ban_backupdir}/banIP.${ban_src_name}_addon_${proto}"
 						if [ -z "${update_ips}" ]
 						then
 							update_ips="${ip}"
@@ -63,17 +94,29 @@ do
 							update_ips="${update_ips}, ${ip}"
 						fi
 					fi
-					break
-				fi
+				done
 			done
-		done
-		if [ -n "${update_ips}" ]
-		then
-			ban_rc=0
-			f_log "debug" "dns_imp ::: source '${ban_src_name}' supplemented by '${domain}' (${update_ips})"
+			if [ -n "${update_ips}" ]
+			then
+				ban_rc=0
+				f_log "debug" "dns_imp ::: source '${ban_src_name}' supplemented by '${domain}' (${update_ips})"
+			fi
 		fi
-	fi
-done < "${ban_src_file}"
-rm -f "${ban_src_file}"
+	done < "${ban_src_file}"
+fi
+
+if [ "${ban_rc}" = "0" ]
+then
+	for proto in "4" "6"
+	do
+		if [ -n "$("${ban_ipset_cmd}" -q -n list "${ban_src_name}_${proto}")" ] && [ -s "${ban_backupdir}/banIP.${ban_src_name}_addon_${proto}" ]
+		then
+			"${ban_ipset_cmd}" -q -! restore < "${ban_backupdir}/banIP.${ban_src_name}_addon_${proto}"
+			gzip -f "${ban_backupdir}/banIP.${ban_src_name}_addon_${proto}"
+		fi
+		rm -f "${ban_backupdir}/banIP.${ban_src_name}_addon_${proto}"
+	done
+fi
 f_log "info" "banIP domain import for source '${ban_src_name}' has been finished with rc '${ban_rc}'"
-exit ${ban_rc}
+rm -f "${ban_src_file}"
+exit "${ban_rc}"


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: OpenWrt SNAPSHOT, r16186-bf4aa0c6a2

Description:
* refine the new dns resolving process
* add a backup/caching mechanism for the resolved IPs. The detached name
  lookup takes place only during 'restart' or 'reload' action, 'start'
  and 'refresh' actions are using an auto-generated backup instead.
* update the readme

Signed-off-by: Dirk Brenken <dev@brenken.org>
