### PR TITLE
tor: update to version 0.4.5.7 (security fix)

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.5.6
+PKG_VERSION:=0.4.5.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=22cba3794fedd5fa87afc1e512c6ce2c21bc20b4e1c6f8079d832dc1e545e733
+PKG_HASH:=447fcaaa133e2ef22427e98098a60a9c495edf9ff3e0dd13f484b9ad0185f074
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: TurrisOmnia (TOS6), OpenWrt master

Description:
This PR updates tor package to version  0.4.5.7. It fixes two denial-of-service bugs tracked as CVE-2021-28089 and CVE-2021-28090

[Changelog](https://gitweb.torproject.org/tor.git/tree/ChangeLog?h=tor-0.4.5.7)

[Blog info](https://blog.torproject.org/node/2009)

Run tested with torsocks and curl
