### PR TITLE
mwan3: reload interface parameters on ifupdate event

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.10.8
+PKG_VERSION:=2.10.9
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -10,11 +10,11 @@ initscript=/etc/init.d/mwan3
 
 
 SCRIPTNAME="mwan3-hotplug"
-[ "$ACTION" = "ifup" ] || [ "$ACTION" = "ifdown" ] || [ "$ACTION" = "connected" ] || [ "$ACTION" = "disconnected" ] || exit 1
+[ "$ACTION" = "ifupdate" ] || [ "$ACTION" = "ifup" ] || [ "$ACTION" = "ifdown" ] || [ "$ACTION" = "connected" ] || [ "$ACTION" = "disconnected" ] || exit 1
 [ -n "$INTERFACE" ] || exit 2
 [ "$FIRSTCONNECT" = "1" ] || [ "$MWAN3_SHUTDOWN" = "1" ] && exit 0
 
-if { [ "$ACTION" = "ifup" ] || [ "$ACTION" = "connected" ] ; } && [ -z "$DEVICE" ]; then
+if { [ "$ACTION" = "ifup" ] || [ "$ACTION" = "ifupdate" ] || [ "$ACTION" = "connected" ] ; } && [ -z "$DEVICE" ]; then
 	LOG notice "$ACTION called on $INTERFACE with no device set"
 	exit 3
 fi
@@ -35,7 +35,7 @@ $IPT4 -S mwan3_hook &>/dev/null || {
 	exit 0
 }
 
-if [ "$MWAN3_STARTUP" != "init" ] && [ "$ACTION" = "ifup" ]; then
+if [ "$MWAN3_STARTUP" != "init" ] && { [ "$ACTION" = "ifup" ] || [ "$ACTION" = "ifupdate" ] ; }; then
 	mwan3_set_user_iface_rules $INTERFACE $DEVICE
 fi
 
@@ -66,10 +66,13 @@ case "$ACTION" in
 		mwan3_set_iface_hotplug_state $INTERFACE "$status"
 		if [ "$MWAN3_STARTUP" != "init" ]; then
 			mwan3_create_iface_route $INTERFACE $DEVICE
-	                mwan3_set_general_rules
+			mwan3_set_general_rules
 			[ "$status" = "online" ] && mwan3_set_policies_iptables
 		fi
-		[ "$ACTION" = ifup ] && procd_running mwan3 "track_$INTERFACE" && procd_send_signal mwan3 "track_$INTERFACE" USR2
+		procd_running mwan3 "track_$INTERFACE" && procd_send_signal mwan3 "track_$INTERFACE" USR2
+		;;
+	ifupdate)
+		procd_running mwan3 "track_$INTERFACE" && procd_send_signal mwan3 "track_$INTERFACE" USR2
 		;;
 	disconnected)
 		mwan3_set_iface_hotplug_state $INTERFACE "offline"

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -396,7 +396,7 @@ main() {
 			IFDOWN_EVENT=0
 		fi
 		if [ "${IFUP_EVENT}" -eq 1 ]; then
-			LOG debug "Register ifup event on interface ${INTERFACE} (${DEVICE})"
+			LOG debug "Register ifup/ifupdate event on interface ${INTERFACE} (${DEVICE})"
 			firstconnect
 			IFUP_EVENT=0
 		fi


### PR DESCRIPTION
Maintainer: me, @feckert 
Compile tested: none needed
Run tested: @wackejohn , openwrt 20.x

mwan3track was failing if an interface changed IP address on DHCP renew. I was not able to recreate it, but a user was able to test this fix and confirmed that it resolved the issue.


