### PR TITLE
[openwrt 19.07] tor: update to version 0.4.4.8 (security fix)

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.4.5
+PKG_VERSION:=0.4.4.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=a45ca00afe765e3baa839767c9dd6ac9a46dd01720a3a8ff4d86558c12359926
+PKG_HASH:=4cad1638d22d47f4877da44f85d655205a069464a02d2f2a2d20f08756cb7547
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @tripolar
Compile tested: Turris Omnia (TOS5.2), OpenWrt 19.07
Run tested: Turris Omnia (TOS5.2), OpenWrt 19.07

Description:
This PR updates tor package to version 0.4.4.8. It fixes two denial-of-service bugs tracked as CVE-2021-28089 and CVE-2021-28090
[Changelog](https://gitweb.torproject.org/tor.git/tree/ChangeLog?h=tor-0.4.4.8)

Similar to #15144