### PR TITLE
restic-rest-server: fix configuration option names

### DIFF
--- a/net/restic-rest-server/Makefile
+++ b/net/restic-rest-server/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=restic-rest-server
 PKG_VERSION:=0.9.7
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/rest-server-$(PKG_VERSION)
 PKG_SOURCE:=rest-server-$(PKG_VERSION).tar.gz

--- a/net/restic-rest-server/files/etc/config/restic-rest-server
+++ b/net/restic-rest-server/files/etc/config/restic-rest-server
@@ -1,13 +1,13 @@
 config rest-server
 	option enabled '0'
 	option path '/mnt/backup'			# data directory (default "/tmp/restic")
-	#option append-only '1'				# enable append only mode
+	#option append_only '1'				# enable append only mode
 	#option cpuprofile '/mnt/backup/cpuprofile'	# write CPU profile to file
 	#option debug '1'				# output debug messages
 	#option listen ':8000'				# listen address (default ":8000")
 	#option log '/mnt/backup/http.log'		# log HTTP requests in the combined log format
-	#option private-repos '1'			# users can only access their private repo
+	#option private_repos '1'			# users can only access their private repo
 	#option prometheus '1'				# enable Prometheus metrics
 	#option tls '1'					# turn on TLS support
-	#option tls-cert '/mnt/backup/public_key'	# TLS certificate path
-	#option tls-key '/mnt/backup/private_key'	# TLS key path
+	#option tls_cert '/mnt/backup/public_key'	# TLS certificate path
+	#option tls_key '/mnt/backup/private_key'	# TLS key path


### PR DESCRIPTION
Signed-off-by: Anton Ryzhov <anton@ryzhov.me>

Maintainer: @gekmihesg
Compile tested: no bin sources were changed
Run tested: OpenWrt SNAPSHOT, r15366-dbb542f194

Description: UCI doesn't allow dashes in option names, [init script](https://github.com/openwrt/packages/blob/4cdbe799b1722443f8aeeb3de32d00c964c6a2a9/net/restic-rest-server/files/etc/init.d/restic-rest-server#L18-L25) already expects names with underscores and rewrites them
