### PR TITLE
CI: use new `openwrt` Docker username

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH=x86-64
-FROM openwrtorg/rootfs:$ARCH
+FROM openwrt/rootfs:$ARCH
 
 ADD entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
We now own `openwrtorg` and `openwrt`, where the latter replaces the
former. Slowly migrate over.

Signed-off-by: Paul Spooren <mail@aparcar.org>