### PR TITLE
adblock: add option to disable dhcp config updates

### DIFF
--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -41,6 +41,7 @@ adb_whitelist="/etc/adblock/adblock.whitelist"
 adb_mailservice="/etc/adblock/adblock.mail"
 adb_dnsfile="${adb_dnsprefix}.overall"
 adb_dnsjail="${adb_dnsprefix}.jail"
+adb_updatedhcpconfig=1
 adb_srcarc="/etc/adblock/adblock.sources.gz"
 adb_srcfile="${adb_tmpbase}/adb_sources.json"
 adb_rtfile="${adb_tmpbase}/adb_runtime.json"
@@ -575,7 +576,7 @@ f_extconf()
 		"dnsmasq")
 			config="dhcp"
 			config_dir="$(uci_get dhcp "@dnsmasq[${adb_dnsinstance}]" confdir | grep -Fo "${adb_dnsdir}")"
-			if [ "${adb_enabled}" = "1" ] && [ -z "${config_dir}" ]
+			if [ "${adb_enabled}" = "1" ] && [ "${adb_updatedhcpconfig}" -eq "1" ] && [ -z "${config_dir}" ]
 			then
 				uci_set dhcp "@dnsmasq[${adb_dnsinstance}]" confdir "${adb_dnsdir}" 2>/dev/null
 			fi


### PR DESCRIPTION
Maintainer: @dibdot
Compile tested: N/A
Run tested: (arch arm_cortex-a9_vfpv3-d16, Turris Omnia 2GB, TurrisOS 5.1.10 a5672f6, refreshed adblock lists)

Description:

this change makes adblock 'jail mode' usable with dnsmasq.

currently, setting `option serversfile` does not have the desired behavior, presumably because `servers-file` are only [expected](https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html) to contain `server` lines.

pointing dnsmasq at a conf-dir with no other file but the jail list does work, however, each invocation of `adblock.sh` overwrites any customization of `option confdir` in /etc/config/dhcp.

with this PR, "whitelist only" jail mode can be enabled by following these instructions:

1. add `option adb_updatedhcpconfig '0'` to /etc/config/adblock
2. add `option adb_jail '1'` to /etc/config/adblock
3. add `option adb_jaildir '/tmp/dnsmasq.jail.d'` to /etc/config/adblock
4. add `option adb_dns 'dnsmasq'` to /etc/config/adblock
5. add `option confdir '/tmp/dnsmasq.jail.d'` to the relevant dnsmasq in /etc/config/dhcp
6. execute `/etc/init.d/adblock restart`
7. execute `/etc/init.d/dnsmasq restart`