### PR TITLE
treewide: fix places where $(FPIC) is unquoted

### DIFF
--- a/libs/libredblack/Makefile
+++ b/libs/libredblack/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libredblack
 PKG_VERSION:=1.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/libredblack
@@ -38,7 +38,7 @@ define Package/libredblack/description
 endef
 
 CONFIGURE_ARGS += --without-rbgen
-CONFIGURE_VARS += lt_cv_prog_cc_pic=$(FPIC)
+CONFIGURE_VARS += lt_cv_prog_cc_pic="$(FPIC)"
 MAKE_FLAGS += CFLAGS="$(TARGET_CFLAGS)"
 
 define Build/InstallDev

--- a/sound/madplay/Makefile
+++ b/sound/madplay/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=madplay
 PKG_VERSION:=0.15.2b
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/mad \
@@ -51,7 +51,7 @@ CONFIGURE_ARGS += \
 	--with-alsa
 
 CONFIGURE_VARS += \
-	lt_prog_compiler_pic=$(FPIC)
+	lt_prog_compiler_pic="$(FPIC)"
 
 MAKE_FLAGS += CFLAGS="$(TARGET_CFLAGS)"
 


### PR DESCRIPTION
Maintainer: various
Compile tested: x86_64, generic, head (85fa8ad8af)
Run tested: same, installed via sysupgrade on test VM

Description:

It's incorrect to assume that `$(FPIC)` only contains a single token and doesn't need to be protected in expansion with quotes (such as would be necessary if it contained spaces).