### PR TITLE
mwan3: check if the shell is in interactive mode for 'use' command

### DIFF
--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -141,7 +141,7 @@ use() {
 	config_get family $interface family
 	[ -z "$family" ] && echo "could not find family for $interface. Using ipv4." && family='ipv4'
 
-	echo "Running '$*' with DEVICE=$device SRCIP=$src_ip FWMARK=$MMX_DEFAULT FAMILY=$family"
+	[ -t 1 ] && echo "Running '$*' with DEVICE=$device SRCIP=$src_ip FWMARK=$MMX_DEFAULT FAMILY=$family"
 	# shellcheck disable=SC2048
 	FAMILY=$family DEVICE=$device SRCIP=$src_ip FWMARK=$MMX_DEFAULT LD_PRELOAD=/lib/mwan3/libwrap_mwan3_sockopt.so.1.0 $*
 


### PR DESCRIPTION

Maintainer: @aaronjg @feckert
Run tested: mipsel_24kc, redmi ac2100, OpenWrt snapshot/21.02-snapshot, tested on a test version of [this script of mine](https://github.com/kopijahe/wifiid-openwrt/blob/master/scripts/kopijahe)

Description:
fixes #15103

Signed-off-by: Abdul Aziz Amar <abdulaziz.amar@gmail.com>
