### PR TITLE
libtorrent-rasterbar: update to 2.0.2

### DIFF
--- a/libs/libtorrent-rasterbar/Makefile
+++ b/libs/libtorrent-rasterbar/Makefile
@@ -1,22 +1,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtorrent-rasterbar
-PKG_VERSION:=2.0.1
-PKG_RELEASE:=1
+PKG_VERSION:=2.0.2
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/arvidn/libtorrent/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=cf906167e0b332681f6304a9bb740404a53bb0efed39897e1d2bd0f6f0d9e9cd
+PKG_HASH:=d5960e8c9f80f62126d723c6cc0522e7900c9c323f28994027eae3325fe03a3f
 
 PKG_MAINTAINER:=David Yang <mmyangfl@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
 
-PKG_BUILD_PARALLEL:=1
-PKG_INSTALL:=1
-
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/cmake.mk
+include ../../devel/ninja/ninja-cmake.mk
 
 define Package/libtorrent-rasterbar/Default
 	TITLE:=Rasterbar BitTorrent library
@@ -27,7 +24,7 @@ define Package/libtorrent-rasterbar
 	$(call Package/libtorrent-rasterbar/Default)
 	SECTION:=libs
 	CATEGORY:=Libraries
-	DEPENDS:=+boost-system +libopenssl
+	DEPENDS:=+boost-system +libopenssl +libatomic
 endef
 
 #define Package/python3-libtorrent
@@ -50,11 +47,11 @@ endef
 #endef
 
 define Download/try_signal
-	VERSION:=2a99893f92b29a5948569cba1e16fd259dbc2016
+	VERSION:=334fd139e2bb387017b42d36753a03935e3bca75
 	SUBDIR:=deps/try_signal
 	FILE:=$(PKG_NAME)-try_signal-$$(VERSION).tar.xz
 	URL:=https://github.com/arvidn/try_signal.git
-	MIRROR_HASH:=4dee408897de3475e6f7eca9c4e4617c3e746351d01cec3cccac38b9b4d38302
+	MIRROR_HASH:=c85d65352c20713cb6cfb005942b46ab7579dc7eef3b876666bff9347149d47f
 	PROTO:=git
 endef
 $(eval $(call Download,try_signal))


### PR DESCRIPTION
Switch to AUTORELEASE for simplicity.

Switch to building with Ninja for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @yangfl 
Compile tested: mips64el
