### PR TITLE
log4cplus: update to 2.0.6

### DIFF
--- a/libs/log4cplus/Makefile
+++ b/libs/log4cplus/Makefile
@@ -9,24 +9,22 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=log4cplus
-PKG_VERSION:=2.0.5
-PKG_RELEASE:=2
+PKG_VERSION:=2.0.6
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
-PKG_HASH:=6046f0867ce4734f298418c7b7db0d35c27403090bb751d98e6e76aa4935f1af
+PKG_HASH:=73519a5e47c40cf375aa6cd28a703b01908b5dcd3f4cb4290db2fef237c8180c
 
 PKG_MAINTAINER:=BangLang Huang <banglang.huang@foxmail.com>, Rosy Song <rosysong@rosinson.com>
 PKG_LICENSE:=BSD-2-Clause Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-HOST_BUILD_PARALLEL:=1
-PKG_BUILD_PARALLEL:=1
 CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
-include $(INCLUDE_DIR)/cmake.mk
+include ../../devel/ninja/ninja-cmake.mk
 
 define Package/log4cplus
   SECTION:=libs


### PR DESCRIPTION
Switch to AUTORELEASE for simplicity.

Switch to building with Ninja for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @rosysong @hbl0307106015
Compile tested: mips64el