### PR TITLE
mbusd: update to 0.5.0

### DIFF
--- a/net/mbusd/Makefile
+++ b/net/mbusd/Makefile
@@ -1,23 +1,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbusd
-PKG_VERSION:=0.4.0
-PKG_RELEASE:=1
+PKG_VERSION:=0.5.0
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_URL:=https://codeload.github.com/3cky/mbusd/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=8458afc455a28c8f798cadd3982f9e03496a494a2269e31e8255a6ca273a6898
+PKG_HASH:=a41fc1254972d41d184d47e82b13c83577f22023f7a540d02062b704bce5c710
 
+PKG_MAINTAINER:=Marcin Jurkowski <marcin1j@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_MAINTAINER:=Marcin Jurkowski <marcin1j@gmail.com>
-
-PKG_BUILD_PARALLEL:=1
-PKG_INSTALL:=1
-
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/cmake.mk
+include ../../devel/ninja/ninja-cmake.mk
 
 define Package/mbusd
 	SECTION:=net


### PR DESCRIPTION
Switch to AUTORELEASE for simplicity.

Switch to building with Ninja for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @marcin1j 
Compile tested: mips64el