### PR TITLE
bind: update to 9.17.11

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.17.10
-PKG_RELEASE:=1
+PKG_VERSION:=9.17.11
+PKG_RELEASE:=$(AUTORELEASE)
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=26a90d28ad694029e480fadcdf60b6219e8128a02d3dd594f6c1a83d002890fd
+PKG_HASH:=00de7bad9291121f3b93e70a6959b540b002f742774823c358c7a416c2e2ed4b
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/patches/010-openssl-deprecated.patch
+++ b/net/bind/patches/010-openssl-deprecated.patch
@@ -1,0 +1,45 @@
+From a9f883cbc28b865d312918368772627cf9610a2f Mon Sep 17 00:00:00 2001
+From: Mark Andrews <marka@isc.org>
+Date: Tue, 16 Mar 2021 21:58:55 +0000
+Subject: [PATCH] Stop using deprecated calls in lib/isc/tls.c
+
+from Rosen Penev @neheb
+---
+ lib/isc/tls.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+--- a/lib/isc/tls.c
++++ b/lib/isc/tls.c
+@@ -12,10 +12,12 @@
+ #include <inttypes.h>
+ #include <nghttp2/nghttp2.h>
+ 
++#include <openssl/bn.h>
+ #include <openssl/conf.h>
+ #include <openssl/err.h>
+ #include <openssl/opensslv.h>
+ #include <openssl/rand.h>
++#include <openssl/rsa.h>
+ 
+ #include <isc/atomic.h>
+ #include <isc/log.h>
+@@ -274,11 +276,19 @@ isc_tlsctx_createserver(const char *keyf
+ 		rsa = NULL;
+ 		ASN1_INTEGER_set(X509_get_serialNumber(cert), 1);
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10101000L
+ 		X509_gmtime_adj(X509_get_notBefore(cert), 0);
++#else
++		X509_gmtime_adj(X509_getm_notBefore(cert), 0);
++#endif
+ 		/*
+ 		 * We set the vailidy for 10 years.
+ 		 */
++#if OPENSSL_VERSION_NUMBER < 0x10101000L
+ 		X509_gmtime_adj(X509_get_notAfter(cert), 3650 * 24 * 3600);
++#else
++		X509_gmtime_adj(X509_getm_notAfter(cert), 3650 * 24 * 3600);
++#endif
+ 
+ 		X509_set_pubkey(cert, pkey);
+ 


### PR DESCRIPTION
Backport upstream OpenSSL deprecated API patch.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nmeyerhans 
Compile tested: mips64el