### PR TITLE
netstinky: fix no deprecated OpenSSL

### DIFF
--- a/net/netstinky/Makefile
+++ b/net/netstinky/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netstinky
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=nsids-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/wanduow/netstinky-ids/releases/download/v$(PKG_VERSION)/

--- a/net/netstinky/patches/010-openssl-deprecated.patch
+++ b/net/netstinky/patches/010-openssl-deprecated.patch
@@ -1,0 +1,16 @@
+--- a/updates/ids_tls_update.c
++++ b/updates/ids_tls_update.c
+@@ -68,11 +68,13 @@ setup_context(const char *hostname, int
+     int rc;
+     unsigned long ssl_err = 0;
+ 
++#if OPENSSL_API_COMPAT < 0x10100000L
+     SSL_load_error_strings();
+     SSL_library_init();
+     OpenSSL_add_all_algorithms();
+     ERR_load_BIO_strings();
+     ERR_load_crypto_strings();
++#endif
+ 
+ #ifdef HAVE_TLS_METHOD
+     method = TLS_method();


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @null-cipher
Compile tested: mips64el