### PR TITLE
tinc: fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/tinc/Makefile
+++ b/net/tinc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tinc
 PKG_VERSION:=1.1-git
-PKG_RELEASE=$(PKG_SOURCE_VERSION)-1
+PKG_RELEASE=$(PKG_SOURCE_VERSION)-2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=http://tinc-vpn.org/git/tinc

--- a/net/tinc/patches/010-openssl-deprecated.patch
+++ b/net/tinc/patches/010-openssl-deprecated.patch
@@ -1,0 +1,35 @@
+--- a/src/openssl/crypto.c
++++ b/src/openssl/crypto.c
+@@ -96,9 +96,10 @@ void crypto_init(void) {
+ 
+ 	ENGINE_load_builtin_engines();
+ 	ENGINE_register_all_complete();
+-
++#if OPENSSL_API_COMPAT < 0x10100000L
+ 	ERR_load_crypto_strings();
+ 	OpenSSL_add_all_algorithms();
++#endif
+ 
+ 	if(!RAND_status()) {
+ 		fprintf(stderr, "Not enough entropy for the PRNG!\n");
+@@ -107,8 +108,10 @@ void crypto_init(void) {
+ }
+ 
+ void crypto_exit(void) {
++#if OPENSSL_API_COMPAT < 0x10100000L
+ 	EVP_cleanup();
+ 	ERR_free_strings();
+ 	ENGINE_cleanup();
++#endif
+ 	random_exit();
+ }
+--- a/src/openssl/rsa.c
++++ b/src/openssl/rsa.c
+@@ -21,6 +21,7 @@
+ 
+ #include <openssl/pem.h>
+ #include <openssl/err.h>
++#include <openssl/rsa.h>
+ 
+ #define TINC_RSA_INTERNAL
+ typedef RSA rsa_t;


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ErwanMAS 
Compile tested: mips64el
