### PR TITLE
perl-mail-spamassassin: fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/lang/perl-mail-spamassassin/Makefile
+++ b/lang/perl-mail-spamassassin/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-mail-spamassassin
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_VERSION:=3.4.4
 PKG_HASH:=8ea27a165b81e3ce8c84ae85c3ecba1f2edfa04ef4a86f07fe28ab612fc8ff60
 

--- a/lang/perl-mail-spamassassin/patches/010-openssl-deprecated.patch
+++ b/lang/perl-mail-spamassassin/patches/010-openssl-deprecated.patch
@@ -1,0 +1,28 @@
+--- a/spamc/libspamc.c
++++ b/spamc/libspamc.c
+@@ -1213,9 +1213,11 @@ int message_filter(struct transport *tp,
+ 
+     if (flags & SPAMC_USE_SSL) {
+ #ifdef SPAMC_SSL
++#if 0
+ 	SSLeay_add_ssl_algorithms();
+-	meth = SSLv23_client_method();
+ 	SSL_load_error_strings();
++#endif
++	meth = SSLv23_client_method();
+ 	ctx = SSL_CTX_new(meth);
+ #else
+ 	UNUSED_VARIABLE(ssl);
+@@ -1600,9 +1602,11 @@ int message_tell(struct transport *tp, c
+ 
+     if (flags & SPAMC_USE_SSL) {
+ #ifdef SPAMC_SSL
++#if 0
+ 	SSLeay_add_ssl_algorithms();
+-	meth = SSLv23_client_method();
+ 	SSL_load_error_strings();
++#endif
++	meth = SSLv23_client_method();
+ 	ctx = SSL_CTX_new(meth);
+ #else
+ 	UNUSED_VARIABLE(ssl);


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: mips64el