### PR TITLE
umurmur: fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/umurmur/Makefile
+++ b/net/umurmur/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=umurmur
 PKG_VERSION:=0.2.19
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/umurmur/umurmur/tar.gz/$(PKG_VERSION)?

--- a/net/umurmur/patches/010-openssl-deprecated.patch
+++ b/net/umurmur/patches/010-openssl-deprecated.patch
@@ -1,0 +1,10 @@
+--- a/src/ssli_openssl.c
++++ b/src/ssli_openssl.c
+@@ -46,6 +46,7 @@
+ #include <openssl/pem.h>
+ #include <openssl/bn.h>
+ #include <openssl/err.h>
++#include <openssl/rsa.h>
+ #include <openssl/safestack.h>
+ #include <openssl/opensslv.h>
+ #ifndef OPENSSL_NO_EC


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @fatbob313 
Compile tested: mips64el