### PR TITLE
znc: fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/znc/patches/120-openssl-deprecated.patch
+++ b/net/znc/patches/120-openssl-deprecated.patch
@@ -1,0 +1,56 @@
+--- a/third_party/Csocket/Csocket.cc
++++ b/third_party/Csocket/Csocket.cc
+@@ -47,10 +47,16 @@
+ #include <stdio.h>
+ #include <openssl/ssl.h>
+ #include <openssl/conf.h>
+-#include <openssl/engine.h>
++#include <openssl/bn.h>
++#include <openssl/dh.h>
++#include <openssl/dsa.h>
++#include <openssl/rsa.h>
+ #ifndef OPENSSL_NO_COMP
+ #include <openssl/comp.h>
+ #endif
++#ifndef OPENSSL_NO_ENGINE
++#include <openssl/engine.h>
++#endif
+ #define HAVE_ERR_REMOVE_STATE
+ #ifdef OPENSSL_VERSION_NUMBER
+ # if OPENSSL_VERSION_NUMBER >= 0x10000000
+@@ -588,15 +594,17 @@ void ShutdownCsocket()
+ #elif defined( HAVE_ERR_REMOVE_STATE )
+ 	ERR_remove_state( 0 );
+ #endif
+-#ifndef OPENSSL_NO_ENGINE
+-	ENGINE_cleanup();
+-#endif
+ #ifndef OPENSSL_IS_BORINGSSL
+ 	CONF_modules_unload( 1 );
+ #endif
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#ifndef OPENSSL_NO_ENGINE
++	ENGINE_cleanup();
++#endif
+ 	ERR_free_strings();
+ 	EVP_cleanup();
+ 	CRYPTO_cleanup_all_ex_data();
++#endif
+ #endif /* HAVE_LIBSSL */
+ #ifdef HAVE_C_ARES
+ #if ARES_VERSION >= CREATE_ARES_VER( 1, 6, 1 )
+@@ -611,12 +619,14 @@ void ShutdownCsocket()
+ #ifdef HAVE_LIBSSL
+ bool InitSSL( ECompType eCompressionType )
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	SSL_load_error_strings();
+ 	if( SSL_library_init() != 1 )
+ 	{
+ 		CS_DEBUG( "SSL_library_init() failed!" );
+ 		return( false );
+ 	}
++#endif
+ 
+ #ifndef _WIN32
+ 	if( access( "/dev/urandom", R_OK ) == 0 )


### PR DESCRIPTION
Patch was wrongly removed.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @KanjiMonster 
Compile tested: mips64el
