### PR TITLE
exim: fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/mail/exim/Makefile
+++ b/mail/exim/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=exim
 PKG_VERSION:=4.94
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ftp.exim.org/pub/exim/exim4/

--- a/mail/exim/patches/030-openssl-deprecated.patch
+++ b/mail/exim/patches/030-openssl-deprecated.patch
@@ -1,0 +1,85 @@
+--- a/src/dane-openssl.c
++++ b/src/dane-openssl.c
+@@ -1098,8 +1098,8 @@ if (dane->selectors[DANESSL_USAGE_DANE_T
+      * Check that setting the untrusted chain updates the expected
+      * structure member at the expected offset.
+      */
+-    X509_STORE_CTX_trusted_stack(ctx, dane->roots);
+-    X509_STORE_CTX_set_chain(ctx, dane->chain);
++    X509_STORE_CTX_set0_trusted_stack(ctx, dane->roots);
++    X509_STORE_CTX_set0_untrusted(ctx, dane->chain);
+     OPENSSL_assert(dane->chain == X509_STORE_CTX_get0_untrusted(ctx));
+     }
+   }
+--- a/src/pdkim/signing.c
++++ b/src/pdkim/signing.c
+@@ -699,7 +699,6 @@ return NULL;
+ void
+ exim_dkim_init(void)
+ {
+-ERR_load_crypto_strings();
+ }
+ 
+ 
+--- a/src/tls-openssl.c
++++ b/src/tls-openssl.c
+@@ -22,7 +22,10 @@ functions from the OpenSSL library. */
+ #include <openssl/lhash.h>
+ #include <openssl/ssl.h>
+ #include <openssl/err.h>
++#include <openssl/bn.h>
++#include <openssl/dh.h>
+ #include <openssl/rand.h>
++#include <openssl/rsa.h>
+ #ifndef OPENSSL_NO_ECDH
+ # include <openssl/ec.h>
+ #endif
+@@ -1462,8 +1465,8 @@ if (!EVP_PKEY_assign_RSA(pkey, rsa))
+ 
+ X509_set_version(x509, 2);				/* N+1 - version 3 */
+ ASN1_INTEGER_set(X509_get_serialNumber(x509), 1);
+-X509_gmtime_adj(X509_get_notBefore(x509), 0);
+-X509_gmtime_adj(X509_get_notAfter(x509), (long)60 * 60);	/* 1 hour */
++X509_gmtime_adj(X509_getm_notBefore(x509), 0);
++X509_gmtime_adj(X509_getm_notAfter(x509), (long)60 * 60);	/* 1 hour */
+ X509_set_pubkey(x509, pkey);
+ 
+ name = X509_get_subject_name(x509);
+@@ -3900,8 +3903,8 @@ fprintf(f, "Library version: OpenSSL: Co
+            "                          Runtime: %s\n"
+            "                                 : %s\n",
+            OPENSSL_VERSION_TEXT,
+-           SSLeay_version(SSLEAY_VERSION),
+-           SSLeay_version(SSLEAY_BUILT_ON));
++           OpenSSL_version(OPENSSL_VERSION),
++           OpenSSL_version(OPENSSL_BUILT_ON));
+ /* third line is 38 characters for the %s and the line is 73 chars long;
+ the OpenSSL output includes a "built on: " prefix already. */
+ }
+@@ -3943,8 +3946,6 @@ if (pidnow != pidlast)
+   is unique for each thread", this doesn't apparently apply across processes,
+   so our own warning from vaguely_random_number_fallback() applies here too.
+   Fix per PostgreSQL. */
+-  if (pidlast != 0)
+-    RAND_cleanup();
+   pidlast = pidnow;
+   }
+ 
+--- a/src/tlscert-openssl.c
++++ b/src/tlscert-openssl.c
+@@ -217,13 +217,13 @@ return mod ? tls_field_from_dn(cp, mod)
+ uschar *
+ tls_cert_not_before(void * cert, uschar * mod)
+ {
+-return asn1_time_copy(X509_get_notBefore((X509 *)cert), mod);
++return asn1_time_copy(X509_getm_notBefore((X509 *)cert), mod);
+ }
+ 
+ uschar *
+ tls_cert_not_after(void * cert, uschar * mod)
+ {
+-return asn1_time_copy(X509_get_notAfter((X509 *)cert), mod);
++return asn1_time_copy(X509_getm_notAfter((X509 *)cert), mod);
+ }
+ 
+ uschar *


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: mips64el