### PR TITLE
mandoc: fix compilation with GCC10

### DIFF
--- a/utils/mandoc/patches/020-gcc10.patch
+++ b/utils/mandoc/patches/020-gcc10.patch
@@ -1,0 +1,11 @@
+--- a/compat_getline.c
++++ b/compat_getline.c
+@@ -2,7 +2,7 @@
+ 
+ #if HAVE_GETLINE
+ 
+-int dummy;
++extern int dummy;
+ 
+ #else
+ 


### PR DESCRIPTION
This is probably fixed in CVS. Unfortunately, I have no idea how to
import such a patch.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @flyn-org 
Compile tested: mips64el