### PR TITLE
libmariadb: update to 3.1.12

### DIFF
--- a/libs/libmariadb/Makefile
+++ b/libs/libmariadb/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmariadb
-PKG_VERSION:=3.1.10
-PKG_RELEASE:=2
+PKG_VERSION:=3.1.12
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=mariadb-connector-c-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL := \
@@ -17,16 +17,13 @@ PKG_SOURCE_URL := \
 	https://mirror.lstn.net/mariadb/connector-c-$(PKG_VERSION) \
 	https://ftp.yz.yamagata-u.ac.jp/pub/dbms/mariadb/connector-c-$(PKG_VERSION) \
 	https://downloads.mariadb.org/interstitial/connector-c-$(PKG_VERSION)
-PKG_HASH:=af3e5613cb9e811f70db85a8a704c7140dc3e35f7c39912d0509511638f9658f
+PKG_HASH:=2f5ae14708b4813e4ff6857d152c22e6fc0e551c9fa743c1ef81a68e3254fe63
 PKG_BUILD_DIR:=$(BUILD_DIR)/mariadb-connector-c-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Michal Hrusecky <Michal@Hrusecky.net>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING.LIB
 PKG_CPE_ID:=cpe:/a:mariadb:mariadb
-
-CMAKE_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
 
 MARIADB_CONF_DIR:=/etc/mysql
 MARIADB_PLUGIN_DIR:=/usr/lib/mariadb/plugin
@@ -46,8 +43,8 @@ plugin-auth_gssapi_client       := CLIENT_PLUGIN_AUTH_GSSAPI_CLIENT
 plugin-remote_io                := CLIENT_PLUGIN_REMOTE_IO
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/cmake.mk
 include $(INCLUDE_DIR)/nls.mk
+include ../../devel/ninja/ninja-cmake.mk
 
 # Pass CPPFLAGS in the CFLAGS as otherwise the build system will
 # ignore them.


### PR DESCRIPTION
Switch to AUTORELEASE for simplicity.

Switch to building with Ninja for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @miska 
Compile tested: mips64el