### PR TITLE
libnetconf2: update to 1.1.43

### DIFF
--- a/libs/libnetconf2/Makefile
+++ b/libs/libnetconf2/Makefile
@@ -8,22 +8,21 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnetconf2
-PKG_VERSION:=1.1.36
-PKG_RELEASE:=1
+PKG_VERSION:=1.1.43
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/CESNET/libnetconf2/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=17aa551380ffcccc3bfd928edbcc170cbe85b0f336b361d5f03ede8f3e5f6348
+PKG_HASH:=66139fc9e68aa89c82235f4135dba9e44f5db663541279c14c74131e22b7f571
 
 PKG_MAINTAINER:=Jakov Smolic <jakov.smolic@sartura.hr>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
 CMAKE_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/cmake.mk
+include ../../devel/ninja/ninja-cmake.mk
 
 define Package/libnetconf2
   SECTION:=libs


### PR DESCRIPTION
Switch to AUTORELEASE for simplicity.

Switch to building with Ninja for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jsmolic 
Compile tested: mips64el