### PR TITLE
openvpn: add OpenVPN option server-poll-timeout

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.5.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/openvpn.options
+++ b/net/openvpn/files/openvpn.options
@@ -107,6 +107,7 @@ secret
 server
 server_bridge
 server_ipv6
+server_poll_timeout
 setenv
 shaper
 sndbuf


### PR DESCRIPTION
See https://www.mankier.com/8/openvpn#--server-poll-timeout

Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>

Maintainer: @mkrkn
Compile tested: Netgear R9000, OpenWrt SNAPSHOT r16275-7cb210e2b3
Run tested: Netgear R9000, OpenWrt SNAPSHOT r16275-7cb210e2b3

Description:

Adds support for --server-poll-timeout OpenVPN configuration.


```
root@OpenWrt:~# uci show openvpn | grep poll
openvpn.***.server_poll_timeout='10'

root@OpenWrt:~# cat /tmp/etc/openvpn-***.conf  | grep poll
server-poll-timeout 10
```