### PR TITLE
netifyd: support filter parameter

### DIFF
--- a/net/netifyd/Makefile
+++ b/net/netifyd/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifyd
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Darryl Sokoloski <darryl@egloo.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/netifyd/files/netifyd.config
+++ b/net/netifyd/files/netifyd.config
@@ -3,3 +3,4 @@ config netifyd
 	option autoconfig 1
 #	option internal_if 'eth0'
 #	option external_if 'eth1'
+#	option filter 'not (udp and dst 239.255.255.250 and dst port 1900 and src 192.168.1.5)'

--- a/net/netifyd/files/netifyd.init
+++ b/net/netifyd/files/netifyd.init
@@ -21,6 +21,7 @@ start_netifyd() {
 	[ ! -d /var/run/netifyd ] && mkdir -p /var/run/netifyd
 
 	config_get_bool autoconfig "$instance" autoconfig 1
+	config_get filter "$instance" filter
 
 	if [ "$autoconfig" -gt 0 ] ; then
 		source /usr/share/netifyd/functions.sh
@@ -33,8 +34,10 @@ start_netifyd() {
 		NETIFYD_OPTS="-E $external_if -I $internal_if"
 	fi
 
+
 	procd_open_instance
 	procd_set_param command $PROG -R $NETIFYD_OPTS
+	[ -n "$filter" ] && procd_append_param command -F "$filter"
 	procd_set_param file /etc/netifyd.conf
 	procd_set_param respawn
 	procd_close_instance


### PR DESCRIPTION
netifyd supports a '-F' filter option in 'bpf' notation to filter
packets from its consideration.

Add support for a uci 'filter' option. eg. filter to exclude SSDP
multicasts from a particularly noisy device:

option filter 'not (udp and dst 239.255.255.250 and dst port 1900 and src 192.168.1.5)'

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>

Maintainer: @dsokoloski 