### PR TITLE
acl: update to 2.3.1

### DIFF
--- a/utils/acl/Makefile
+++ b/utils/acl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acl
-PKG_VERSION:=2.2.53
-PKG_RELEASE:=1
+PKG_VERSION:=2.3.1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.savannah.nongnu.org/cgit/acl.git/snapshot
-PKG_HASH:=9e905397ac10d06768c63edd0579c34b8431555f2ea8e8f2cee337b31f856805
+PKG_HASH:=8cad1182cc5703c3e8bf7a220fc267f146246f088d1ba5dd72d8b02736deedcc
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 
 PKG_LICENSE:=LGPL-2.1 GPL-2.0

--- a/utils/acl/patches/100-no-gettext_configure.patch
+++ b/utils/acl/patches/100-no-gettext_configure.patch
@@ -10,7 +10,7 @@
  AC_ARG_ENABLE([debug],
  	[AS_HELP_STRING([--enable-debug], [Enable extra debugging])])
  AS_IF([test "x$enable_debug" = "xyes"],
-@@ -62,6 +59,5 @@ AC_CONFIG_COMMANDS([include/sys],
+@@ -67,6 +64,5 @@ AC_CONFIG_COMMANDS([include/sys],
  AC_CONFIG_FILES([
  	libacl.pc
  	Makefile


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79, r16206+5-bb95be9265
Run tested: ath79, r15339+6-bc99b56d7e. {get,set}facl work.

Description:
- update to 2.3.1
- refresh patches
- switch to AUTORELEASE