### PR TITLE
bind: update to version 9.16.13

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.16.12
+PKG_VERSION:=9.16.13
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=9914af9311fd349cab441097898d94fb28d0bfd9bf6ed04fe1f97f042644da7f
+PKG_HASH:=a54cc793fa5b69b35f610f2095760f8238dff5cfd52419f7ee1c9c227da4cc08
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile tested: Turris MOX, mvebu/cortexa53, OpenWrt 19.07.7
Run tested: Turris MOX, mvebu/cortexa53, OpenWrt 19.07.7
Tests: dig works, DNS resolving via named works, too.

Description:
- update to version [9.16.13](https://downloads.isc.org/isc/bind9/9.16.13/doc/arm/html/notes.html#notes-for-bind-9-16-13)