### PR TITLE
python-aiohttp: backport fix for CVE-2021-21330

### DIFF
--- a/lang/python/python-aiohttp/Makefile
+++ b/lang/python/python-aiohttp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aiohttp
 PKG_VERSION:=3.5.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=aiohttp-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/a/aiohttp/

--- a/lang/python/python-aiohttp/patches/010-CVE-2021-21330.patch
+++ b/lang/python/python-aiohttp/patches/010-CVE-2021-21330.patch
@@ -1,0 +1,25 @@
+From 5d19ea5e28ae9a55ef1f33ea820f813bf26a7e57 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jelmer=20Vernoo=C4=B3?= <jelmer@jelmer.uk>
+Date: Wed, 10 Feb 2021 04:33:11 +0000
+Subject: [PATCH] Prevent open redirects from normalize_path_middleware.
+
+---
+ CHANGES/openredirects.bugfix |  1 +
+ aiohttp/web_middlewares.py   |  4 ++--
+ 2 files changed, 7 insertions(+), 8 deletions(-)
+ create mode 100644 CHANGES/openredirects.bugfix
+
+--- /dev/null
++++ b/CHANGES/openredirects.bugfix
+@@ -0,0 +1 @@
++Prevent open redirects from normalize_path_middleware.
+--- a/aiohttp/web_middlewares.py
++++ b/aiohttp/web_middlewares.py
+@@ -101,6 +101,7 @@ def normalize_path_middleware(
+                 paths_to_check.append(merged_slashes[:-1])
+ 
+             for path in paths_to_check:
++                path = re.sub("^//+", "/", path) # SECURITY: GHSA-v6wp-4m6f-gcjg
+                 resolves, request = await _check_request_resolves(
+                     request, path)
+                 if resolves:


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris MOX, mvebu/cortexa53, OpenWrt 19.07.7
Run tested: N/A

Description:

- Backport fix for [CVE-2021-21330](https://github.com/aio-libs/aiohttp/commit/2545222a3853e31ace15d87ae0e2effb7da0c96b)

More details:
https://github.com/aio-libs/aiohttp/security/advisories/GHSA-v6wp-4m6f-gcjg
