### PR TITLE
sshpass: update to version 1.0.9

### DIFF
--- a/utils/sshpass/Makefile
+++ b/utils/sshpass/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sshpass
-PKG_VERSION:=1.06
+PKG_VERSION:=1.09
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/sshpass
-PKG_HASH:=c6324fcee608b99a58f9870157dfa754837f8c48be3df0f5e2f3accf145dee60
+PKG_HASH:=71746e5e057ffe9b00b44ac40453bf47091930cba96bbea8dc48717dedc49fb7
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris MOX, mvebu/cortexa53, OpenWrt master

**Changelog [1]:**

Version 1.09
	* Explicitly set the controlling TTY

Version 1.08
	* Report when IP key has changed
	* Scrub the environment variable for -e

Version 1.07
	* Pass signals that should terminate to ssh
	* Fix race around signal handling
	* Report IPC errors to stderr
	* Report if can't open -f password file

[1] https://sourceforge.net/p/sshpass/code/76/tree/trunk/ChangeLog