### PR TITLE
nnn: update to version 3.6

### DIFF
--- a/utils/nnn/Makefile
+++ b/utils/nnn/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nnn
-PKG_VERSION:=3.4
+PKG_VERSION:=3.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jarun/nnn/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=7803ae6e974aeb4008507d9d1afbcca8d084a435f36ff636b459ca50414930a1
+PKG_HASH:=875094caebcc22ecf53b3722d139b127d25e1d5563a954342f32ded8980978b5
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=BSD-2-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris MOX, mvebu/cortexa53, OpenWrt master
Run tested: Turris MOX, mvebu/cortexa53, OpenWrt master

Description:
- changelog [3.5](https://github.com/jarun/nnn/releases/tag/v3.5), [3.6](https://github.com/jarun/nnn/releases/tag/v3.6)