### PR TITLE
[19.07] https-dns-proxy: support for additional Force DNS ports

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2021-01-17
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy

--- a/net/https-dns-proxy/files/https-dns-proxy.config
+++ b/net/https-dns-proxy/files/https-dns-proxy.config
@@ -1,6 +1,16 @@
 config main 'config'
 	option update_dnsmasq_config '*'
 	option force_dns '1'
+	list force_dns_port '53'
+	list force_dns_port '853'
+# ports listed below are used by some
+# of the dnscrypt-proxy v1 resolvers
+#	list force_dns_port '553'
+#	list force_dns_port '1443'
+#	list force_dns_port '4343'
+#	list force_dns_port '4434'
+#	list force_dns_port '5443'
+#	list force_dns_port '8443'
 
 config https-dns-proxy
 	option bootstrap_dns '1.1.1.1,1.0.0.1'

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -16,8 +16,7 @@ else
 fi
 
 readonly PROG=/usr/sbin/https-dns-proxy
-dnsmasqConfig=''
-forceDNS='1'
+dnsmasqConfig=''; forceDNS=''; forceDNSPorts='';
 
 version() { echo "$PKG_VERSION"; }
 
@@ -95,10 +94,11 @@ start_instance() {
 is_force_dns_active() { iptables-save | grep -q -w -- '--dport 53'; }
 
 start_service() {
-	local p=5053
+	local p=5053 c
 	config_load 'https-dns-proxy'
 	config_get dnsmasqConfig	'config' 'update_dnsmasq_config' '*'
 	config_get_bool forceDNS	'config' 'force_dns' '1'
+	config_get forceDNSPorts	'config' 'force_dns_port' '53 853'
 	dhcp_backup 'create'
 	config_load 'https-dns-proxy'
 	config_foreach start_instance 'https-dns-proxy'
@@ -109,16 +109,28 @@ start_service() {
 		procd_set_param stderr 1
 		procd_open_data
 		json_add_array firewall
-		json_add_object ''
-		json_add_string type redirect
-		json_add_string name https_dns_proxy_dns_redirect
-		json_add_string target DNAT
-		json_add_string src lan
-		json_add_string proto tcpudp
-		json_add_string src_dport 53
-		json_add_string dest_port 53
-		json_add_string reflection 0
-		json_close_object
+		for c in $forceDNSPorts; do
+			if netstat -tuln | grep LISTEN | grep ":${c}" >/dev/null 2>&1; then
+				json_add_object ''
+				json_add_string type 'redirect'
+				json_add_string target 'DNAT'
+				json_add_string src 'lan'
+				json_add_string proto 'tcp udp'
+				json_add_string src_dport "$c"
+				json_add_string dest_port "$c"
+				json_add_string reflection '0'
+				json_close_object
+			else
+				json_add_object ''
+				json_add_string type 'rule'
+				json_add_string src 'lan'
+				json_add_string dest '*'
+				json_add_string proto 'tcp udp'
+				json_add_string dest_port "$c"
+				json_add_string target 'REJECT'
+				json_close_object
+			fi
+		done
 		json_close_array
 		procd_close_data
 		procd_close_instance


### PR DESCRIPTION
Maintainer: me
Compile tested: x86-64, Sophos SG-105, 21.02-SNAPSHOT
Run tested: x86-64, Sophos SG-105, 21.02-SNAPSHOT, start/stop, test dns resolution, iptables rules

Description: Previous version only supported ForceDNS for port 53, this update supports inserting either redirct (if port is open on the router) or reject rules for additional ports with the goal to make the LAN devices configured to use DoT or v1 dnscrypt-proxy either redirect to the service running on the router or fail and fall back to unsecure DNS/port 53 on router.

Signed-off-by: Stan Grishin <stangri@melmac.net>
