### PR TITLE
nss: quote $(PIC) usage and fix compilation with QUILT

### DIFF
--- a/libs/nss/Makefile
+++ b/libs/nss/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nss
 PKG_VERSION:=3.61
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -80,7 +80,7 @@ MAKE_FLAGS += \
 	NSS_USE_SYSTEM_SQLITE=1 \
 	OS_ARCH=Linux \
 	OS_TEST=$(ARCH) \
-	fpic=$(FPIC) \
+	fpic="$(FPIC)" \
 	NSPR_INCLUDE_DIR=$(STAGING_DIR)/usr/include/nspr \
 	SEED_ONLY_DEV_URANDOM=1 \
 	NS_USE_GCC=1 \

--- a/libs/nss/Makefile
+++ b/libs/nss/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nss
 PKG_VERSION:=3.61
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -91,13 +91,10 @@ MAKE_FLAGS += \
 	OS_REL_CFLAGS="$(TARGET_CFLAGS)"
 
 #native compile nsinstall
-define Build/Prepare
-	$(call Build/Prepare/Default)
-ifeq ($(QUILT),)
+define Build/Configure
 	USE_NATIVE=1 OS_REL_CFLAGS="$(HOST_CFLAGS)" LDFLAGS="$(HOST_LDFLAGS)" \
 	CC="$(HOSTCC)" CPU_ARCH="$(HOST_ARCH)" \
 	    $(MAKE) -C $(PKG_BUILD_DIR)/nss/coreconf/nsinstall
-endif
 endef
 
 define Build/Compile


### PR DESCRIPTION
Maintainer: @lucize 
Compile tested: x86_64, openwrt-21.2
Run tested: none

Description:
openwrt/openwrt#4006 intends to add `-DPIC` to the global definition of `FPIC`.  Then it becomes mandatory to quote it when assigning it to a variable or a parameter in a shell context.

While looking at the previous issue, I found out that the package was not compiling with `QUILT=1` because of 657574f45 (#14644).  To allow building with quilt, and still keep #14644's goal, I've moved it from `Build/Prepare` to `Build/Configure`.  Since the nss package does not have a `configure` step, I've skipped calling `Build/Configure/Default`.