### PR TITLE
[21.02] Cherry-picks from PRs dealing with $(FPIC) quoting

### DIFF
--- a/libs/libredblack/Makefile
+++ b/libs/libredblack/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libredblack
 PKG_VERSION:=1.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/libredblack
@@ -38,7 +38,7 @@ define Package/libredblack/description
 endef
 
 CONFIGURE_ARGS += --without-rbgen
-CONFIGURE_VARS += lt_cv_prog_cc_pic=$(FPIC)
+CONFIGURE_VARS += lt_cv_prog_cc_pic="$(FPIC)"
 MAKE_FLAGS += CFLAGS="$(TARGET_CFLAGS)"
 
 define Build/InstallDev

--- a/libs/nss/Makefile
+++ b/libs/nss/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nss
 PKG_VERSION:=3.61
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -80,7 +80,7 @@ MAKE_FLAGS += \
 	NSS_USE_SYSTEM_SQLITE=1 \
 	OS_ARCH=Linux \
 	OS_TEST=$(ARCH) \
-	fpic=$(FPIC) \
+	fpic="$(FPIC)" \
 	NSPR_INCLUDE_DIR=$(STAGING_DIR)/usr/include/nspr \
 	SEED_ONLY_DEV_URANDOM=1 \
 	NS_USE_GCC=1 \

--- a/libs/nss/Makefile
+++ b/libs/nss/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nss
 PKG_VERSION:=3.61
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -91,13 +91,10 @@ MAKE_FLAGS += \
 	OS_REL_CFLAGS="$(TARGET_CFLAGS)"
 
 #native compile nsinstall
-define Build/Prepare
-	$(call Build/Prepare/Default)
-ifeq ($(QUILT),)
+define Build/Configure
 	USE_NATIVE=1 OS_REL_CFLAGS="$(HOST_CFLAGS)" LDFLAGS="$(HOST_LDFLAGS)" \
 	CC="$(HOSTCC)" CPU_ARCH="$(HOST_ARCH)" \
 	    $(MAKE) -C $(PKG_BUILD_DIR)/nss/coreconf/nsinstall
-endif
 endef
 
 define Build/Compile

--- a/sound/madplay/Makefile
+++ b/sound/madplay/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=madplay
 PKG_VERSION:=0.15.2b
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/mad \
@@ -51,7 +51,7 @@ CONFIGURE_ARGS += \
 	--with-alsa
 
 CONFIGURE_VARS += \
-	lt_prog_compiler_pic=$(FPIC)
+	lt_prog_compiler_pic="$(FPIC)"
 
 MAKE_FLAGS += CFLAGS="$(TARGET_CFLAGS)"
 


### PR DESCRIPTION
Maintainers: @mislavn, @probonopd,  @lucize 
Compile tested: openwrt-21.02, x86_64
Run tested: none

Description:
The commits are cherry-picks from #15169 & #15222, dealing with quoting `$(FPIC)` usage, and fixing nss build with QUILT.  They should be pretty harmless, and were compile-tested successfully with openwrt-21.02.