### PR TITLE
uMurmur: Update to 0.2.20. Fix build against OpenSSL without deprecat…

### DIFF
--- a/net/umurmur/Makefile
+++ b/net/umurmur/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=umurmur
-PKG_VERSION:=0.2.19
+PKG_VERSION:=0.2.20
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/umurmur/umurmur/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=338053160bc48e48850061cdfc19cf1b2bb66e56877c04cd6de7831b468646b6
+PKG_HASH:=b7b2978c3197aef0a6531f1cf0ee1aebb32a55ad8bda43064ce3a944edbcac83
 
 PKG_MAINTAINER:=Martin Johansson <martin@fatbob.nu>
 PKG_LICENSE:=BSD-3-Clause
@@ -19,7 +19,7 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/cmake.mk
+include ../../devel/ninja/ninja-cmake.mk
 
 define Package/umurmur/Default
   SECTION:=net


### PR DESCRIPTION
…ed API enabled.

Signed-off-by: Martin Johansson <martin@fatbob.nu>

Maintainer: me 
Compile tested: (Ubuntu WSL, OpenWrt 21.02)
Run tested: (arm_cortex-a15_neon-vfpv4 (Netgear R7800),  OpenWrt 21.02, working as expected)

Description:
