### PR TITLE
 forked-daapd: update to 27.4

### DIFF
--- a/sound/forked-daapd/Makefile
+++ b/sound/forked-daapd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=forked-daapd
-PKG_VERSION:=27.2
+PKG_VERSION:=27.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/ejurgensen/$(PKG_NAME)/releases/download/$(PKG_VERSION)/
-PKG_HASH:=27294a893253d232161f4521fc42147e65324ce5a13fcf550b537100375277bb
+PKG_HASH:=00f71c687df268a3c4db77cecf37972e76832a99e34f09750d07a92934a0bfa8
 
 PKG_FIXUP:=autoreconf
 PKG_USE_MIPS16:=0
@@ -49,7 +49,6 @@ define Package/forked-daapd/conffiles
 endef
 
 CONFIGURE_ARGS += \
-	--enable-itunes \
 	--enable-lastfm \
 	--enable-mpd \
 	--enable-chromecast \


### PR DESCRIPTION
Maintainer: me
Compile tested: Atheros ATH79, trunk
Run tested: no

Description:
Update to version 27.4. Incl remove "--enable-itunes" compile option (no longer exists).

Signed-off-by: Espen Jürgensen <espenjurgensen+openwrt@gmail.com>