### PR TITLE
collectd: add bad blocks percent calculation for ubi plugin

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.12.0
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \

--- a/utils/collectd/patches/934-ubi-prepare-read-for-percent.patch
+++ b/utils/collectd/patches/934-ubi-prepare-read-for-percent.patch
@@ -1,0 +1,66 @@
+--- a/src/ubi.c
++++ b/src/ubi.c
+@@ -84,9 +84,8 @@ static void ubi_submit(const char *dev_n
+   plugin_dispatch_values(&vl);
+ } /* void ubi_submit */
+ 
+-static int ubi_read_dev_attr(const char *dev_name, const char *attr) {
++static int ubi_read_dev_attr(const char *dev_name, const char *attr, int *value) {
+   FILE *f;
+-  int val;
+   char
+       str[sizeof(SYS_PATH) + strlen(dev_name) + sizeof("/") + strlen(attr) + 1];
+   int n;
+@@ -98,7 +97,7 @@ static int ubi_read_dev_attr(const char
+     return -1;
+   }
+ 
+-  n = fscanf(f, "%d", &val);
++  n = fscanf(f, "%d", value);
+   fclose(f);
+ 
+   if (n != 1) {
+@@ -106,17 +105,39 @@ static int ubi_read_dev_attr(const char
+     return -1;
+   }
+ 
+-  ubi_submit(dev_name, attr, (gauge_t)val);
+-
+   return 0;
+ } /* int ubi_read_dev_attr */
+ 
+ static inline int ubi_read_dev_bad_count(const char *dev_name) {
+-  return ubi_read_dev_attr(dev_name, DEV_BAD_COUNT);
++  int ret;
++  int value;
++
++  ret = ubi_read_dev_attr(dev_name, DEV_BAD_COUNT, &value);
++
++  if (ret != 0) {
++    ERROR(PLUGIN_NAME " : Unable to read bat_peb_count");
++    return -1;
++  }
++
++  ubi_submit(dev_name, DEV_BAD_COUNT, (gauge_t)value);
++
++  return 0;
+ } /* int ubi_read_dev_bad_count */
+ 
+ static inline int ubi_read_max_ec(const char *dev_name) {
+-  return ubi_read_dev_attr(dev_name, MAXIMUM_ERASE);
++  int ret;
++  int value;
++
++  ret = ubi_read_dev_attr(dev_name, MAXIMUM_ERASE, &value);
++
++  if (ret != 0) {
++    ERROR(PLUGIN_NAME " : Unable to read max_ec");
++    return -1;
++  }
++
++  ubi_submit(dev_name, MAXIMUM_ERASE, (gauge_t)value);
++
++  return 0;
+ } /* int ubi_read_max_ec */
+ 
+ static int ubi_read(void) {

--- a/utils/collectd/patches/935-ubi-add-percent.patch
+++ b/utils/collectd/patches/935-ubi-add-percent.patch
@@ -1,0 +1,56 @@
+--- a/src/ubi.c
++++ b/src/ubi.c
+@@ -35,6 +35,9 @@
+ #define DEV_BAD_COUNT                                                          \
+   "bad_peb_count" // Count of bad physical eraseblocks on the underlying MTD
+                   // device.
++// Value reserved for bad block
++#define DEV_RESERVED_BAD_BLOCK "reserved_for_bad"
++
+ #define MAXIMUM_ERASE "max_ec" // Current maximum erase counter value
+ 
+ /*
+@@ -140,6 +143,35 @@ static inline int ubi_read_max_ec(const
+   return 0;
+ } /* int ubi_read_max_ec */
+ 
++static inline int ubi_read_percent(const char *dev_name) {
++  int ret;
++  int bcount;
++  int bblock;
++
++  ret = ubi_read_dev_attr(dev_name, DEV_BAD_COUNT, &bcount);
++
++  if (ret != 0) {
++    ERROR(PLUGIN_NAME " : Unable to read bad_peb_count");
++    return -1;
++  }
++
++  ret = ubi_read_dev_attr(dev_name, DEV_RESERVED_BAD_BLOCK, &bblock);
++
++  if (ret != 0) {
++    ERROR(PLUGIN_NAME " : Unable to read reserved_for_bad");
++    return -1;
++  }
++
++  if (bblock == 0) {
++    ERROR(PLUGIN_NAME " : Percentage value cannot be determined (reserved_for_bad = 0)");
++    return -2;
++  }
++
++  ubi_submit(dev_name, "percent", (gauge_t)((float_t)bcount / (float_t)bblock * 100.0));
++
++  return 0;
++} /* int ubi_read_percent */
++
+ static int ubi_read(void) {
+   DIR *dir;
+   struct dirent *dirent;
+@@ -155,6 +187,7 @@ static int ubi_read(void) {
+ 
+     ubi_read_dev_bad_count(dirent->d_name);
+     ubi_read_max_ec(dirent->d_name);
++    ubi_read_percent(dirent->d_name);
+   }
+ 
+   closedir(dir);


### PR DESCRIPTION
Maintainer: @hnyman 
Compile tested: lantiq_xrx200, latest OpenWrt master
Run tested: lantiq_xrx200, latest OpenWrt master

Description:

So far the plugin contains the evaluation of the maximum erase count
from `/sys/class/ubi/ubi<x>/max_ec` and the evaluation of bad physical
erase block count from `/sys/class/ubi/ubi<x>/bad_peb_count`.

For each ubi device, the reserved physical erase blocks are also displayed.
The value is shown in `/sys/class/ubi/ubi<x>/reserved_for_bad`.

If the defect erase blocks are now used with the reserved erase blocks,
we can calculate who many percent of the flash is defect.

I have already pushed this upstream https://github.com/collectd/collectd/pull/3864

```
root@VR2-106149 /tmp/rrd/VR2-106149/ubi # ls -la
drwxr-xr-x    2 root     root           100 Mar 17 10:35 .
drwxr-xr-x    9 root     root           180 Mar 17 10:35 ..
-rw-r--r--    1 root     root          7096 Mar 23 10:25 bad_peb_count-ubi0.rrd
-rw-r--r--    1 root     root          7096 Mar 23 10:25 max_ec-ubi0.rrd
-rw-r--r--    1 root     root          7096 Mar 23 10:25 percent-ubi0.rrd
```

