### PR TITLE
ratechecker: update to 2020-01-30

### DIFF
--- a/net/ratechecker/Makefile
+++ b/net/ratechecker/Makefile
@@ -8,24 +8,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ratechecker
-PKG_VERSION:=0.0.20170609
-PKG_RELEASE:=2
-PKG_REV:=4cd4e3c70d9832336af5ba157f2a272f9c0098dc
-PKG_MIRROR_HASH:=c6f02b273536738bbcf4b16e3859f733a02ada88b4078fc8a5b0ad8d1d184370
+PKG_RELEASE:=$(AUTORELEASE)
 
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://bitbucket.org/comnets/ratechecker.git
+PKG_SOURCE_DATE:=2020-01-30
+PKG_SOURCE_VERSION:=a2b8b958548bacdb69ffac3aa033f519093415f7
+PKG_MIRROR_HASH:=ff89ca080cb5e557f47738078d5f0a70030f597e04c239426898ec7fc1e658ab
+
+PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=$(PKG_REV)
-PKG_SOURCE_URL:=https://bitbucket.org/comnets/ratechecker.git
-PKG_SOURCE_PROTO:=git
-
-PKG_BUILD_PARALLEL:=1
-
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/cmake.mk
+include ../../devel/ninja/ninja-cmake.mk
 
 define Package/ratechecker
   SECTION:=net
@@ -33,7 +29,6 @@ define Package/ratechecker
   TITLE:=IEEE 802.11 bitrate analysis tool
   URL:=https://bitbucket.org/comnets/ratechecker/
   DEPENDS:=+libevent2
-  MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 endef
 
 define Package/ratechecker/install


### PR DESCRIPTION
Reorganize Makefile for consistency between packages.

Switch to AUTORELEASE for simplicity.

Switch to building with Ninja for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ecsv ???
Compile tested: ath79