### PR TITLE
cshark: update to 2020-07-22

### DIFF
--- a/net/cshark/Makefile
+++ b/net/cshark/Makefile
@@ -8,21 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cshark
-PKG_SOURCE_DATE:=2018-08-20
-PKG_SOURCE_VERSION:=7a7cf7f35074b85c6fb0c52067e640d2433ef73b
-PKG_RELEASE:=1
+PKG_SOURCE_DATE:=2020-07-22
+PKG_SOURCE_VERSION:=c0d32fb6df3cd095fecac8aefe8d188170246403
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/cloudshark/cshark.git
-PKG_MIRROR_HASH:=b09822e93d7de7f4aa9fa018c304ebc52dd3419de3dd2eff463986d3a3b8ca71
+PKG_MIRROR_HASH:=35fd177653725e64c330fca62e674c1106d5893c8a33bad29b8e6dac4a4d4dcc
 
 PKG_MAINTAINER:=Luka Perkov <luka@openwrt.org>
 PKG_LICENSE:=BSD-2-Clause
 
-PKG_BUILD_PARALLEL:=1
-
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/cmake.mk
+include ../../devel/ninja/ninja-cmake.mk
 
 define Package/cshark
   SECTION:=net
@@ -32,7 +30,7 @@ define Package/cshark
   DEPENDS:=+libjson-c +libpcap +libuci +libubox +libuclient +libustream-mbedtls
 endef
 
-CMAKE_OPTIONS = \
+CMAKE_OPTIONS += \
 	-DWITH_DEBUG=OFF
 
 define Package/cshark/conffiles
@@ -49,11 +47,6 @@ define Package/cshark/install
 	$(INSTALL_CONF) \
 		$(PKG_BUILD_DIR)/config/cshark \
 		$(1)/etc/config/
-
-	$(INSTALL_DIR) $(1)/etc/ssl/certs
-	$(INSTALL_CONF) \
-		$(PKG_BUILD_DIR)/config/ca-the_usertrust_network.pem \
-		$(1)/etc/ssl/certs/
 endef
 
 


### PR DESCRIPTION
Switch to AUTORELEASE for simplicity.

Switch to building with Ninja for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lperkov 
Compile tested: ath79
