### PR TITLE
gost_engine: fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/libs/gost_engine/Makefile
+++ b/libs/gost_engine/Makefile
@@ -12,7 +12,7 @@ PKG_MAINTAINER:=Artur Petrov <github@phpchain.ru>
 PKG_LICENSE:=OpenSSL
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/cmake.mk
+include ../../devel/ninja/ninja-cmake.mk
 
 PKG_UNPACK:=$(HOST_TAR) -C "$(PKG_BUILD_DIR)" --strip-components=1 -xzf "$(DL_DIR)/$(PKG_SOURCE)"
 PKG_INSTALL:=

--- a/libs/gost_engine/patches/010-openssl-deprecated.patch
+++ b/libs/gost_engine/patches/010-openssl-deprecated.patch
@@ -1,0 +1,11 @@
+--- a/gost_pmeth.c
++++ b/gost_pmeth.c
+@@ -608,7 +608,7 @@ static int pkey_gost_mac_ctrl_str(EVP_PK
+     if (strcmp(type, hexkey_ctrl_string) == 0) {
+         long keylen;
+         int ret;
+-        unsigned char *keybuf = string_to_hex(value, &keylen);
++        unsigned char *keybuf = OPENSSL_hexstr2buf(value, &keylen);
+         if (!keybuf || keylen != 32) {
+             GOSTerr(GOST_F_PKEY_GOST_MAC_CTRL_STR,
+                     GOST_R_INVALID_MAC_KEY_LENGTH);


### PR DESCRIPTION
Build with Ninja for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @6ec123321 
Compile tested: ath79