### PR TITLE
boost: fixup mips64 fiber patch

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.75.0
 PKG_SOURCE_VERSION:=1_75_0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://dl.bintray.com/boostorg/release/$(PKG_VERSION)/source/

--- a/libs/boost/patches/020-mips64-fiber.patch
+++ b/libs/boost/patches/020-mips64-fiber.patch
@@ -5,7 +5,7 @@
  #  define cpu_relax() asm volatile ("nop" ::: "memory");
  # endif
 -#elif BOOST_ARCH_MIPS && (__mips_isa_rev > 1)
-+#elif BOOST_ARCH_MIPS && (__mips_isa_rev > 1) && !defined(_MIPS_ARCH_OCTEONP)
++#elif BOOST_ARCH_MIPS && (((__mips_isa_rev > 1) && defined(__mips32)) || ((__mips_isa_rev > 2)  && defined(__mips64)))
  # define cpu_relax() asm volatile ("pause" ::: "memory");
  #elif BOOST_ARCH_PPC
  // http://code.metager.de/source/xref/gnu/glibc/sysdeps/powerpc/sys/platform/ppc.h


### PR DESCRIPTION
It turns out that this is also broken on mips64el. Further testing
reveals that

-mips32r2 -mtune=mips32r2 -mabi=32

compiles the PAUSE instruction just fine whereas

-mips64r2 -mtune=mips64r2 -mabi=64

does not. The PAUSE instruction was introduced in version 2.6 of the
MIPS ISA and GCC for some reason does not allow usage of it with MIPS64.
Modify the macro to fix the situation instead of just matching on
octeon, which is not quite correct.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ClaymorePT 
Compile tested: mips64el