### PR TITLE
travelmate: fix for captive portal handling

### DIFF
--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -228,12 +228,18 @@ f_net()
 {
 	local IFS raw result
 
-	raw="$(${trm_fetch} --timeout=$((trm_maxwait/6)) "${trm_captiveurl}" -O /dev/null 2>&1 | tail -n 1)"
+	raw="$(${trm_fetch} --timeout=$((trm_maxwait/6)) "${trm_captiveurl}" -O /dev/null 2>&1)"
+	if [ $(printf "%s" "${raw}" | grep Redirected | wc -l) -gt "0" ] 
+	then
+		raw="$(printf "%s" "${raw}" | grep Redirected)"
+	else
+		raw="$(printf "%s" "${raw}" | tail -n1)"
+	fi
 	raw="$(printf "%s" "${raw//[\?\$\%\&\+\|\'\"\:\*\=\/]/ }")"
 	result="$(printf "%s" "${raw}" | awk '/^Failed to redirect|^Redirected/{printf "%s","net cp";exit}/^Download completed/{printf "%s","net ok";exit}/^Failed|Connection error/{printf "%s","net nok";exit}')"
 	if [ "${result}" = "net cp" ]
 	then
-		result="$(printf "%s" "${raw//*on /}" | awk 'match($0,/^([[:alnum:]_-]+\.)+[[:alpha:]]+/){printf "%s","net cp \047"substr(tolower($0),RSTART,RLENGTH)"\047"}')"
+		result="$(printf "%s" "net cp : ${raw//*on /}")"
 	fi
 	printf "%s" "${result}"
 	f_log "debug" "f_net     ::: fetch: ${trm_fetch}, timeout: $((trm_maxwait/6)), url: ${trm_captiveurl}, result: ${result}"


### PR DESCRIPTION
Maintainer: @dibdot 
Compile tested: xRX200 rev 1.2, AVM FRITZ!Box 7362 SL, OpenWrt 19.07.7 r11306-c4a6851c72 
Run tested: same as compile tested

Description:
This fixes #12867. It resolves problems I experienced with a Mikrotik captive portal detection. See bug ticket for details

