### PR TITLE
travelmate: added login script for mikrotik captive portal

### DIFF
--- a/net/travelmate/files/mikrotik.login
+++ b/net/travelmate/files/mikrotik.login
@@ -4,11 +4,40 @@
 #    username - user name for login
 #    password - password for login
 
-set -eu
+# check arguments
+if [ "$#" -ne 2 ]; then
+    echo "Error: Invalid number of arguments."
+    echo "usage: mikrotik.login <username> <password>"
+    exit 1
+fi
+
+cmd="$(command -v curl)"
+# curl check
+if [ ! -x "${cmd}" ]
+then
+	echo "Error: this script depends on curl. Please install this first."
+    exit 2
+fi
+
 username=$1
 password=$2
+login_success="You are logged in"
+
+# Get login domain from redirection information
 domain=$(curl -I -s -X GET connectivity-check.ubuntu.com | grep Location | grep -o 'http://[^/]*')
+if [ "${domain}" = "" ] 
+then
+    echo "Error getting captive portal domain. Are you already logged in?"
+    exit 3
+fi
 
 # Login via username/password
-echo "Logging in via username/password."
-response=$(curl -s -X POST -d "username=${username}&password=${password}&dst=&popup=true" ${domain}/login)
+response=$(${cmd} -s -X POST -d "username=${username}&password=${password}&dst=&popup=true" ${domain}/login)
+if [ -n "$(printf "%s" "${response}" | grep "${login_success}")" ]
+then
+    echo "Login successful."
+	exit 0
+else
+    echo "Error: login failed."
+	exit 4
+fi

--- a/net/travelmate/files/mikrotik.login
+++ b/net/travelmate/files/mikrotik.login
@@ -1,0 +1,14 @@
+#!/bin/sh
+# This script will login to Mikrotik captive portals
+# Arguments:
+#    username - user name for login
+#    password - password for login
+
+set -eu
+username=$1
+password=$2
+domain=$(curl -I -s -X GET connectivity-check.ubuntu.com | grep Location | grep -o 'http://[^/]*')
+
+# Login via username/password
+echo "Logging in via username/password."
+response=$(curl -s -X POST -d "username=${username}&password=${password}&dst=&popup=true" ${domain}/login)


### PR DESCRIPTION
Maintainer: @dibdot
Compile tested: xRX200 rev 1.2, AVM FRITZ!Box 7362 SL, OpenWrt 19.07.7 r11306-c4a6851c72
Run tested: same as compile tested

Description:
Added handling of Mikrotik captive portals
