### PR TITLE
gnutls: update to version 3.7.1

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
-PKG_VERSION:=3.7.0
-PKG_RELEASE:=2
+PKG_VERSION:=3.7.1
+PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7
-PKG_HASH:=49e2a22691d252c9f24a9829b293a8f359095bc5a818351f05f1c0a5188a1df8
+PKG_HASH:=3777d7963eca5e06eb315686163b7b3f5045e2baac5e54e038ace9835e5cac6f
 PKG_FIXUP:=autoreconf gettext-version
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <nmav@gnutls.org>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/libs/gnutls/patches/010-m4.patch
+++ b/libs/gnutls/patches/010-m4.patch
@@ -62,7 +62,7 @@
      [AC_COMPILE_IFELSE(
 --- a/src/gl/m4/gnulib-comp.m4
 +++ b/src/gl/m4/gnulib-comp.m4
-@@ -1061,7 +1061,7 @@ changequote([, ])dnl
+@@ -1064,7 +1064,7 @@ changequote([, ])dnl
    gl_UNISTD_MODULE_INDICATOR([sleep])
    AC_CHECK_DECLS_ONCE([alarm])
    AC_REQUIRE([gt_TYPE_WCHAR_T])


### PR DESCRIPTION
Maintainer: @nmav 
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates gnutls to version 3.7.1. It fixes security issues [CVE-2021-20231](https://nvd.nist.gov/vuln/detail/CVE-2021-20231) and [CVE-2021-20232](https://nvd.nist.gov/vuln/detail/CVE-2021-20232).

[Changelog](https://lists.gnupg.org/pipermail/gnutls-help/2021-March/004698.html)
Upstream issue https://gitlab.com/gnutls/gnutls/-/issues/1151

