### PR TITLE
[OpenWrt 19.07] gnutls: patch security issue

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
 PKG_VERSION:=3.6.15
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz

--- a/libs/gnutls/patches/001-CVE-2021-20231-CVE-2021-20232.patch
+++ b/libs/gnutls/patches/001-CVE-2021-20231-CVE-2021-20232.patch
@@ -1,0 +1,253 @@
+From b02c4a7209f6423e908d8e84b4767e5a0abea804 Mon Sep 17 00:00:00 2001
+From: Daiki Ueno <ueno@gnu.org>
+Date: Tue, 9 Mar 2021 13:07:26 +0100
+Subject: [PATCH 1/4] gnutls_buffer_append_data: remove duplicated code
+
+The function shared the same logic as in _gnutls_buffer_resize.
+
+Signed-off-by: Daiki Ueno <ueno@gnu.org>
+---
+ lib/str.c | 24 ++++--------------------
+ 1 file changed, 4 insertions(+), 20 deletions(-)
+
+diff --git a/lib/str.c b/lib/str.c
+index e31449937d..2247fc322b 100644
+--- a/lib/str.c
++++ b/lib/str.c
+@@ -113,7 +113,7 @@ gnutls_buffer_append_data(gnutls_buffer_t dest, const void *data,
+ 			   size_t data_size)
+ {
+ 	size_t const tot_len = data_size + dest->length;
+-	size_t const unused = MEMSUB(dest->data, dest->allocd);
++	int ret;
+ 
+ 	if (unlikely(dest->data != NULL && dest->allocd == NULL))
+ 		return gnutls_assert_val(GNUTLS_E_INVALID_REQUEST);
+@@ -126,25 +126,9 @@ gnutls_buffer_append_data(gnutls_buffer_t dest, const void *data,
+ 		return gnutls_assert_val(GNUTLS_E_MEMORY_ERROR);
+ 	}
+ 
+-	if (dest->max_length >= tot_len) {
+-
+-		if (dest->max_length - unused <= tot_len) {
+-			align_allocd_with_data(dest);
+-		}
+-	} else {
+-		size_t const new_len =
+-		    MAX(data_size, MIN_CHUNK) + MAX(dest->max_length,
+-						    MIN_CHUNK);
+-
+-		dest->allocd = gnutls_realloc_fast(dest->allocd, new_len);
+-		if (dest->allocd == NULL) {
+-			gnutls_assert();
+-			return GNUTLS_E_MEMORY_ERROR;
+-		}
+-		dest->max_length = new_len;
+-		dest->data = dest->allocd + unused;
+-
+-		align_allocd_with_data(dest);
++	ret = _gnutls_buffer_resize(dest, tot_len);
++	if (ret < 0) {
++		return ret;
+ 	}
+ 	assert(dest->data != NULL);
+ 
+-- 
+GitLab
+
+
+From 11ab01ae35d5c4fe93d117fd12f561a69c3b810f Mon Sep 17 00:00:00 2001
+From: Daiki Ueno <ueno@gnu.org>
+Date: Tue, 9 Mar 2021 13:41:59 +0100
+Subject: [PATCH 2/4] _gnutls_buffer_resize: add option to use allocation
+ simpler logic
+
+This helps detect common mistakes[1] in realloc usage with valgrind,
+where the caller assumes that the original ptr is always returned.
+
+1. https://bugzilla.mozilla.org/show_bug.cgi?id=1377618
+
+Signed-off-by: Daiki Ueno <ueno@gnu.org>
+Co-authored-by: Alexander Sosedkin <asosedkin@redhat.com>
+---
+ .gitlab-ci.yml | 27 +++++++++++++++++++++++++++
+ lib/str.c      | 32 ++++++++++++++++++++++++++++++++
+ 2 files changed, 59 insertions(+)
+
+diff --git a/lib/str.c b/lib/str.c
+index 2247fc322b..506fe17210 100644
+--- a/lib/str.c
++++ b/lib/str.c
+@@ -138,6 +138,36 @@ gnutls_buffer_append_data(gnutls_buffer_t dest, const void *data,
+ 	return 0;
+ }
+ 
++#ifdef AGGRESSIVE_REALLOC
++
++/* Use a simpler logic for reallocation; i.e., always call
++ * gnutls_realloc_fast() and do not reclaim the no-longer-used
++ * area which has been removed from the beginning of buffer
++ * with _gnutls_buffer_pop_datum().  This helps hit more
++ * issues when running under valgrind.
++ */
++int _gnutls_buffer_resize(gnutls_buffer_st * dest, size_t new_size)
++{
++	size_t unused;
++
++	if (unlikely(dest->data != NULL && dest->allocd == NULL))
++		return gnutls_assert_val(GNUTLS_E_INVALID_REQUEST);
++
++	unused = MEMSUB(dest->data, dest->allocd);
++	dest->allocd =
++	    gnutls_realloc_fast(dest->allocd, new_size);
++	if (dest->allocd == NULL) {
++		gnutls_assert();
++		return GNUTLS_E_MEMORY_ERROR;
++	}
++	dest->max_length = new_size;
++	dest->data = dest->allocd + unused;
++
++	return 0;
++}
++
++#else
++
+ int _gnutls_buffer_resize(gnutls_buffer_st * dest, size_t new_size)
+ {
+ 	if (unlikely(dest->data != NULL && dest->allocd == NULL))
+@@ -171,6 +201,8 @@ int _gnutls_buffer_resize(gnutls_buffer_st * dest, size_t new_size)
+ 	}
+ }
+ 
++#endif
++
+ /* Appends the provided string. The null termination byte is appended
+  * but not included in length.
+  */
+-- 
+GitLab
+
+
+From 15beb4b193b2714d88107e7dffca781798684e7e Mon Sep 17 00:00:00 2001
+From: Daiki Ueno <ueno@gnu.org>
+Date: Fri, 29 Jan 2021 14:06:32 +0100
+Subject: [PATCH 3/4] key_share: avoid use-after-free around realloc
+
+Signed-off-by: Daiki Ueno <ueno@gnu.org>
+---
+ lib/ext/key_share.c | 12 +++++-------
+ 1 file changed, 5 insertions(+), 7 deletions(-)
+
+diff --git a/lib/ext/key_share.c b/lib/ext/key_share.c
+index ab8abf8fe6..a8c4bb5cff 100644
+--- a/lib/ext/key_share.c
++++ b/lib/ext/key_share.c
+@@ -664,14 +664,14 @@ key_share_send_params(gnutls_session_t session,
+ {
+ 	unsigned i;
+ 	int ret;
+-	unsigned char *lengthp;
+-	unsigned int cur_length;
+ 	unsigned int generated = 0;
+ 	const gnutls_group_entry_st *group;
+ 	const version_entry_st *ver;
+ 
+ 	/* this extension is only being sent on client side */
+ 	if (session->security_parameters.entity == GNUTLS_CLIENT) {
++		unsigned int length_pos;
++
+ 		ver = _gnutls_version_max(session);
+ 		if (unlikely(ver == NULL || ver->key_shares == 0))
+ 			return 0;
+@@ -679,16 +679,13 @@ key_share_send_params(gnutls_session_t session,
+ 		if (!have_creds_for_tls13(session))
+ 			return 0;
+ 
+-		/* write the total length later */
+-		lengthp = &extdata->data[extdata->length];
++		length_pos = extdata->length;
+ 
+ 		ret =
+ 		    _gnutls_buffer_append_prefix(extdata, 16, 0);
+ 		if (ret < 0)
+ 			return gnutls_assert_val(ret);
+ 
+-		cur_length = extdata->length;
+-
+ 		if (session->internals.hsk_flags & HSK_HRR_RECEIVED) { /* we know the group */
+ 			group = get_group(session);
+ 			if (unlikely(group == NULL))
+@@ -736,7 +733,8 @@ key_share_send_params(gnutls_session_t session,
+ 		}
+ 
+ 		/* copy actual length */
+-		_gnutls_write_uint16(extdata->length - cur_length, lengthp);
++		_gnutls_write_uint16(extdata->length - length_pos - 2,
++				     &extdata->data[length_pos]);
+ 
+ 	} else { /* server */
+ 		ver = get_version(session);
+-- 
+GitLab
+
+
+From 75a937d97f4fefc6f9b08e3791f151445f551cb3 Mon Sep 17 00:00:00 2001
+From: Daiki Ueno <ueno@gnu.org>
+Date: Fri, 29 Jan 2021 14:06:50 +0100
+Subject: [PATCH 4/4] pre_shared_key: avoid use-after-free around realloc
+
+Signed-off-by: Daiki Ueno <ueno@gnu.org>
+---
+ lib/ext/pre_shared_key.c | 15 ++++++++++++---
+ 1 file changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/lib/ext/pre_shared_key.c b/lib/ext/pre_shared_key.c
+index a042c6488e..380bf39ed5 100644
+--- a/lib/ext/pre_shared_key.c
++++ b/lib/ext/pre_shared_key.c
+@@ -267,7 +267,7 @@ client_send_params(gnutls_session_t session,
+ 	size_t spos;
+ 	gnutls_datum_t username = {NULL, 0};
+ 	gnutls_datum_t user_key = {NULL, 0}, rkey = {NULL, 0};
+-	gnutls_datum_t client_hello;
++	unsigned client_hello_len;
+ 	unsigned next_idx;
+ 	const mac_entry_st *prf_res = NULL;
+ 	const mac_entry_st *prf_psk = NULL;
+@@ -428,8 +428,7 @@ client_send_params(gnutls_session_t session,
+ 	assert(extdata->length >= sizeof(mbuffer_st));
+ 	assert(ext_offset >= (ssize_t)sizeof(mbuffer_st));
+ 	ext_offset -= sizeof(mbuffer_st);
+-	client_hello.data = extdata->data+sizeof(mbuffer_st);
+-	client_hello.size = extdata->length-sizeof(mbuffer_st);
++	client_hello_len = extdata->length-sizeof(mbuffer_st);
+ 
+ 	next_idx = 0;
+ 
+@@ -440,6 +439,11 @@ client_send_params(gnutls_session_t session,
+ 	}
+ 
+ 	if (prf_res && rkey.size > 0) {
++		gnutls_datum_t client_hello;
++
++		client_hello.data = extdata->data+sizeof(mbuffer_st);
++		client_hello.size = client_hello_len;
++
+ 		ret = compute_psk_binder(session, prf_res,
+ 					 binders_len, binders_pos,
+ 					 ext_offset, &rkey, &client_hello, 1,
+@@ -474,6 +478,11 @@ client_send_params(gnutls_session_t session,
+ 	}
+ 
+ 	if (prf_psk && user_key.size > 0 && info) {
++		gnutls_datum_t client_hello;
++
++		client_hello.data = extdata->data+sizeof(mbuffer_st);
++		client_hello.size = client_hello_len;
++
+ 		ret = compute_psk_binder(session, prf_psk,
+ 					 binders_len, binders_pos,
+ 					 ext_offset, &user_key, &client_hello, 0,
+-- 
+GitLab
+


### PR DESCRIPTION
Maintainer: @nmav 
Compile tested: Turris Omnia (TOS5), OpenWrt 19.07
Run tested: Turris Omnia (TOS5), OpenWrt 19.07

Description:
This PR backports upstream fixes for gnutls security issues [CVE-2021-20231](https://nvd.nist.gov/vuln/detail/CVE-2021-20231) and [CVE-2021-20232](https://nvd.nist.gov/vuln/detail/CVE-2021-20232)
Upstream issue https://gitlab.com/gnutls/gnutls/-/issues/1151
