### PR TITLE
Fixed mosquitto cannot be started when system boot

### DIFF
--- a/net/mosquitto/files/etc/init.d/mosquitto
+++ b/net/mosquitto/files/etc/init.d/mosquitto
@@ -3,7 +3,7 @@
 # April 2012, OpenWrt.org
 # Provides support for the luci-app-mosquitto package, if installed
 
-START=80
+START=81
 USE_PROCD=1
 TCONF=/tmp/mosquitto.generated.conf
 CONF_WATCH=/etc/config/mosquitto
@@ -244,6 +244,7 @@ start_service_real() {
 	# Makes /etc/init.d/mosquitto reload work if you edit the final file.
 	procd_set_param file $CONF_WATCH
 	[ "$write_pid" -eq 1 ] && procd_set_param pidfile /var/run/mosquitto.pid
+	procd_set_param respawn
 	procd_close_instance
 }
 


### PR DESCRIPTION
I have included this package in my own SUNXI (H3) board build, but it failed to be started when system booted.  Either change the start seq to 81 or set the correct respawn flag cloud fix this.

So I have changed the start sequence and added respawn flag, to make sure the mosquitto service could be started when system booting

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: SUNXI A7 Openwrt SNAPSHOT
Run tested:  SUNXI A7 Openwrt SNAPSHOT

Description:
