### PR TITLE
[OpenWrt 19.07] mariadb: update to version 10.2.37

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
-PKG_VERSION:=10.2.33
+PKG_VERSION:=10.2.37
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -18,7 +18,7 @@ PKG_SOURCE_URL := \
 	https://ftp.yz.yamagata-u.ac.jp/pub/dbms/mariadb/$(PKG_NAME)-$(PKG_VERSION)/source \
 	https://downloads.mariadb.org/interstitial/$(PKG_NAME)-$(PKG_VERSION)/source
 
-PKG_HASH:=f6b2fa588d296eec38c11d794a48713c237ad5b6eb27c6669673ccbe46906445
+PKG_HASH:=38c630485e3a5ed438e43257b9693f005f572d05e240ff25244d2fa7682250f5
 PKG_MAINTAINER:=Michal Hrusecky <michal@hrusecky.net>
 PKG_LICENSE:=GPL-2.0 LGPL-2.1
 PKG_LICENSE_FILES:=COPYING THIRDPARTY libmariadb/COPYING.LIB


### PR DESCRIPTION
Maintainer: @miska 
Compile tested: Turris Omnia (TOS5), OpenWrt 19.07
Run tested: Turris Omnia(TOS5), OpenWrt 19.07

Description:
This PR updates mariadb to version 10.2.37 to fix [CVE-2021-27928](https://nvd.nist.gov/vuln/detail/CVE-2021-27928).

[Release notes](https://mariadb.com/kb/en/mariadb-10237-release-notes/)




