### PR TITLE
[19.07] libftdi1: Improve build binary reproducibility

### DIFF
--- a/libs/libftdi1/Makefile
+++ b/libs/libftdi1/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libftdi1
 PKG_VERSION:=1.4
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.intra2net.com/en/developer/libftdi/download/

--- a/libs/libftdi1/patches/102-remove-snapshot-git.patch
+++ b/libs/libftdi1/patches/102-remove-snapshot-git.patch
@@ -1,0 +1,10 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -11,7 +11,6 @@ execute_process(COMMAND git describe
+                 OUTPUT_STRIP_TRAILING_WHITESPACE
+                 )
+ if(${GIT_DESCRIBE_RESULT} STREQUAL 0)
+-  set(SNAPSHOT_VERSION ${GIT_DESCRIBE_OUTPUT})
+ endif ()
+ message(STATUS "Detected git snapshot version: ${SNAPSHOT_VERSION}")
+ 


### PR DESCRIPTION
The library embeds the result of "git describe" inside the source code, making the binary result dependent of the particular commit being used in the build root when building inside a git working copy.

As this is unnecessary information, remove this option and fallback to the default "unknown", which is also the value compiled by tools that do not clone but export the openwrt base tree.
