### PR TITLE
[21.02] https-dns-proxy: bugfix: correct PROCD firewall object

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2021-01-17
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy
@@ -14,7 +14,7 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/cmake.mk
+include ../../devel/ninja/ninja-cmake.mk
 
 CMAKE_OPTIONS += -DCLANG_TIDY_EXE=
 

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -111,23 +111,23 @@ start_service() {
 		json_add_array firewall
 		for c in $forceDNSPorts; do
 			if netstat -tuln | grep LISTEN | grep ":${c}" >/dev/null 2>&1; then
-				json_add_object ''
-				json_add_string type 'redirect'
-				json_add_string target 'DNAT'
-				json_add_string src 'lan'
-				json_add_string proto 'tcp udp'
+				json_add_object ""
+				json_add_string type redirect
+				json_add_string target DNAT
+				json_add_string src lan
+				json_add_string proto "tcp udp"
 				json_add_string src_dport "$c"
 				json_add_string dest_port "$c"
-				json_add_string reflection '0'
+				json_add_boolean reflection 0
 				json_close_object
 			else
-				json_add_object ''
-				json_add_string type 'rule'
-				json_add_string src 'lan'
-				json_add_string dest '*'
-				json_add_string proto 'tcp udp'
+				json_add_object ""
+				json_add_string type rule
+				json_add_string src lan
+				json_add_string dest "*"
+				json_add_string proto "tcp udp"
 				json_add_string dest_port "$c"
-				json_add_string target 'REJECT'
+				json_add_string target REJECT
 				json_close_object
 			fi
 		done

--- a/net/https-dns-proxy/patches/010-ninja.patch
+++ b/net/https-dns-proxy/patches/010-ninja.patch
@@ -1,0 +1,33 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,7 +5,6 @@ set(CMAKE_BUILD_TYPE "Debug")
+ #set(CMAKE_BUILD_TYPE "Release")
+ 
+ #set(CMAKE_C_FLAGS "-Wall -Wextra --pedantic -Wno-strict-aliasing")
+-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$(notdir $<)\"'")
+ set(CMAKE_C_FLAGS_DEBUG "-g")
+ set(CMAKE_C_FLAGS_RELEASE "-O2")
+ 
+--- a/src/logging.h
++++ b/src/logging.h
+@@ -34,6 +34,20 @@ enum _LogSeverity {
+   LOG_FATAL = 4,
+ };
+ 
++#define STRIPPATH(s)\
++    (sizeof(s) > 2 && (s)[sizeof(s)-2] == '/' ? (s) + sizeof(s) - 1 : \
++    sizeof(s) > 3 && (s)[sizeof(s)-3] == '/' ? (s) + sizeof(s) - 2 : \
++    sizeof(s) > 4 && (s)[sizeof(s)-4] == '/' ? (s) + sizeof(s) - 3 : \
++    sizeof(s) > 5 && (s)[sizeof(s)-5] == '/' ? (s) + sizeof(s) - 4 : \
++    sizeof(s) > 6 && (s)[sizeof(s)-6] == '/' ? (s) + sizeof(s) - 5 : \
++    sizeof(s) > 7 && (s)[sizeof(s)-7] == '/' ? (s) + sizeof(s) - 6 : \
++    sizeof(s) > 8 && (s)[sizeof(s)-8] == '/' ? (s) + sizeof(s) - 7 : \
++    sizeof(s) > 9 && (s)[sizeof(s)-9] == '/' ? (s) + sizeof(s) - 8 : \
++    sizeof(s) > 10 && (s)[sizeof(s)-10] == '/' ? (s) + sizeof(s) - 9 : \
++    sizeof(s) > 11 && (s)[sizeof(s)-11] == '/' ? (s) + sizeof(s) - 10 : (s))
++
++#define __FILENAME__ STRIPPATH(__FILE__)
++
+ // Debug, Info, Warning, Error logging.
+ #define DLOG(...) _log(__FILENAME__, __LINE__, LOG_DEBUG, __VA_ARGS__)
+ #define ILOG(...) _log(__FILENAME__, __LINE__, LOG_INFO, __VA_ARGS__)


### PR DESCRIPTION
Maintainer: me
Compile tested: x86-64, Sophos SG-105, 21.02-SNAPSHOT r15926
Run tested: x86-64, Sophos SG-105, 21.02-SNAPSHOT r15926, start/stop/resolution/test iptables presence

Description: This includes bugfix for the PROCD firewall object and use of ninja-cmake instead of cmake.

Signed-off-by: Stan Grishin <stangri@melmac.net>
