### PR TITLE
prometheus: Update default tsdb path

### DIFF
--- a/utils/prometheus/Makefile
+++ b/utils/prometheus/Makefile
@@ -47,6 +47,9 @@ Prometheus, a Cloud Native Computing Foundation project, is a systems and
 service monitoring system. It collects metrics from configured targets at given
 intervals, evaluates rule expressions, displays the results, and can trigger
 alerts if some condition is observed to be true.
+
+Default tsdb path is /srv/prometheus, you might want to edit /etc/config/prometheus
+in order to place it on USB storage or external SD card.
 endef
 
 define Package/prometheus/install

--- a/utils/prometheus/files/etc/init.d/prometheus
+++ b/utils/prometheus/files/etc/init.d/prometheus
@@ -12,8 +12,14 @@ start_service() {
 	local web_listen_address
 	config_load "prometheus"
 	config_get config_file prometheus config_file "$CONFFILE"
-	config_get storage_tsdb_path prometheus storage_tsdb_path "/data"
+	config_get storage_tsdb_path prometheus storage_tsdb_path "/srv/prometheus"
 	config_get web_listen_address prometheus web_listen_address "127.0.0.1:9090"
+	
+	# Create tsdb dir & permissions if needed
+	if [ ! -d "$storage_tsdb_path" ]; then
+		mkdir "$storage_tsdb_path"
+		chown prometheus:prometheus "$storage_tsdb_path"
+	fi;
 
 	procd_open_instance
 	procd_set_param command "$PROG"

--- a/utils/prometheus/files/etc/uci-defaults/prometheus-defaults
+++ b/utils/prometheus/files/etc/uci-defaults/prometheus-defaults
@@ -6,7 +6,7 @@ uci -q get prometheus.prometheus || {
 	uci -q batch <<EOF
 	set prometheus.prometheus=prometheus
 	set prometheus.prometheus.config_file='/etc/prometheus.yml'
-	set prometheus.prometheus.storage_tsdb_path='/data'
+	set prometheus.prometheus.storage_tsdb_path='/srv/prometheus'
 	set prometheus.prometheus.web_listen_address='127.0.0.1:9090'
 	commit prometheus
 EOF


### PR DESCRIPTION
Use /var/prometheus-data instead of /data, because user `prometheus` doesn't have permissions to create directory in root filesystem, while it's totally fine to be in /var

Maintainer: @aparcar
Compile tested: -
Run tested: linux/arm64, RaspberryPI4 model B, snapshot - by editing /etc/config/prometheus manually

Description: Use /var/prometheus-data instead of /data, because user prometheus doesn't have permissions to create directory in root filesystem, while it's totally fine to be in /var

related: #15236