### PR TITLE
docker-compose: Update to version 1.28.6

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-compose
-PKG_VERSION:=1.28.4
+PKG_VERSION:=1.28.6
 PKG_RELEASE:=1
 
 PYPI_NAME:=docker-compose
-PKG_HASH:=681aca74e70e238ae43c810a62f471b645942f0ce97b6a0ca375fcb64f3aca85
+PKG_HASH:=1d44906f7ab738ba2d1785130ed31b16111eee6dc5a1dbd7252091dae48c5281
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
Two upstream updates in a row, I missed the interim one.

Mostly bug fixes, interesting `compose.yml` and `compose.yaml` are now valid names.