### PR TITLE
poco: update to 1.10.1

### DIFF
--- a/libs/poco/Makefile
+++ b/libs/poco/Makefile
@@ -9,24 +9,26 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=poco
-PKG_RELEASE:=2
-PKG_VERSION:=1.9.0
+PKG_VERSION:=1.10.1
+PKG_RELEASE:=$(AUTORELEASE)
 
 ifeq ($(BUILD_VARIANT),all)
 _PKG_VERSION:=${PKG_VERSION}-all
-PKG_HASH:=b6e33898588e74337efec4e8d8b9b277bb653b08318a79215f9aa4a3ff1ea9fd
+PKG_HASH:=2cde4b50778013ab3b7a522aa59bccaa7e85a8ccfc654a354c4d9611b6ce1758
 else
 _PKG_VERSION:=${PKG_VERSION}
-PKG_HASH:=a0a5a03d87c585f1a43def33bfc52c0c34a528e43a7b13bc83841a7c00adde39
+PKG_HASH:=cdab379d7d0394a763821d058eee1e7d4d8214a3caec05c775b60962b2f20762
 endif
 
 PKG_SOURCE:=$(PKG_NAME)-$(_PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://pocoproject.org/releases/$(PKG_NAME)-$(PKG_VERSION)
 
+PKG_MAINTAINER:=Jean-Michel Julien <jean-michel.julien@trilliantinc.com>
 PKG_LICENSE:=BSL-1.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:pocoproject:poco
 
+PKG_BUILD_DEPENDS:=postgresql
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(_PKG_VERSION)
@@ -39,7 +41,6 @@ define Package/poco
   TITLE:=Poco C++ libraries
   URL:=https://www.pocoproject.org/
   DEPENDS:=+libstdcpp +libpthread +librt @!arc
-  MAINTAINER:=Jean-Michel Julien <jean-michel.julien@trilliantinc.com>
   VARIANT:=minimal
 endef
 

--- a/libs/poco/patches/200-strerror.patch
+++ b/libs/poco/patches/200-strerror.patch
@@ -1,6 +1,6 @@
 --- a/Foundation/src/Error.cpp
 +++ b/Foundation/src/Error.cpp
-@@ -70,7 +70,7 @@ namespace Poco {
+@@ -64,7 +64,7 @@ namespace Poco {
  
  #if (_XOPEN_SOURCE >= 600) || POCO_OS == POCO_OS_ANDROID || __APPLE__
  			setMessage(strerror_r(err, _buffer, sizeof(_buffer)));


### PR DESCRIPTION
Switch to AUTORELEASE for simplicity.

Move MAINTAINER line up for consistency.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @padre-lacroix 
Compile tested: mips64el