### PR TITLE
mpd: remove libavfilter support

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpd
 PKG_VERSION:=0.22.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.musicpd.org/download/mpd/0.22/
@@ -48,7 +48,7 @@ define Package/mpd-full
 $(call Package/mpd/Default)
   TITLE+= (full)
   DEPENDS+= +AUDIO_SUPPORT:pulseaudio-daemon +libvorbis +libmms +libupnp +libshout +yajl \
-            +BUILD_PATENTED:libffmpeg +!BUILD_PATENTED:libmad
+            +libffmpeg +!BUILD_PATENTED:libmad
   PROVIDES:=mpd
   VARIANT:=full
 endef

--- a/sound/mpd/patches/030-no-avfilter.patch
+++ b/sound/mpd/patches/030-no-avfilter.patch
@@ -1,0 +1,14 @@
+--- a/src/lib/ffmpeg/meson.build
++++ b/src/lib/ffmpeg/meson.build
+@@ -6,11 +6,7 @@ conf.set('HAVE_LIBAVUTIL', libavutil_dep
+ enable_ffmpeg = libavformat_dep.found() and libavcodec_dep.found() and libavutil_dep.found()
+ conf.set('ENABLE_FFMPEG', enable_ffmpeg)
+ 
+-if enable_ffmpeg
+-  libavfilter_dep = dependency('libavfilter', required: false)
+-else
+   libavfilter_dep = dependency('', required: false)
+-endif
+ conf.set('HAVE_LIBAVFILTER', libavfilter_dep.found())
+ 
+ if not enable_ffmpeg


### PR DESCRIPTION
The ffmpeg package in OpenWrt is customizable and that can cause issues
with a dirty InstallDev. Just remove libavfilter support.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: mips64el