### PR TITLE
mosquitto: update boot sequence and add respawn

### DIFF
--- a/net/mosquitto/files/etc/init.d/mosquitto
+++ b/net/mosquitto/files/etc/init.d/mosquitto
@@ -3,7 +3,7 @@
 # April 2012, OpenWrt.org
 # Provides support for the luci-app-mosquitto package, if installed
 
-START=80
+START=81
 USE_PROCD=1
 TCONF=/tmp/mosquitto.generated.conf
 CONF_WATCH=/etc/config/mosquitto
@@ -244,6 +244,7 @@ start_service_real() {
 	# Makes /etc/init.d/mosquitto reload work if you edit the final file.
 	procd_set_param file $CONF_WATCH
 	[ "$write_pid" -eq 1 ] && procd_set_param pidfile /var/run/mosquitto.pid
+	procd_set_param respawn
 	procd_close_instance
 }
 


### PR DESCRIPTION
Maintainer:  Karl Palsson <karlp@etactica.com>
Compile tested: sunxi h3 board
Run tested: SNAPSHOT

Description:
Mosquitto cannot be booted at the *FIRST* boot of device.

By added system("ifconfig -a > /tmp/mosq.log"), it says there is no any IP in all interfaces in *FIRST* boot

I think this is caused by relayd service is not started, thus there is not IP been set on lo? and br-lan not created?

So by change the service boot sequence to 81, this will fixed the *FIRST* boot issue.

And added respawn flag in case it crashed and cloud be rebooted.






