### PR TITLE
CI: revert adding of *depending* packages

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -82,16 +82,6 @@ jobs:
           echo "Building $PACKAGES"
           echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
 
-      - name: Determine depended packages
-        run: |
-          DEPENDS=$(docker run --rm \
-            "openwrt/imagebuilder:${{ matrix.target }}-$BRANCH" \
-            make whatdepends PACKAGE="$PACKAGES" | grep $'\t' | \
-            grep -v luci-i18n | awk '{ print $1 }' | tr '\n' ' ')
-
-          echo "Building $DEPENDS"
-          echo "PACKAGES=$PACKAGES $DEPENDS" >> $GITHUB_ENV
-
       - name: Build
         uses: openwrt/gh-action-sdk@v1
         env:


### PR DESCRIPTION
While the idea may make sense the current implementation is faulty.
Problem is that OpenWrt uses the folder name of packages within the
build system while `opkg` spits out the actual packages names.

An example, compiling the packages of folder `vim` (`make
package/vim/compile`) creates a package called `xxd`, where `make
package/xxd/compile` would fail.

The current implementation uses `opkg` to figure out dependent packages,
but the resulting names do not match the above mentioned folders.

Revert this for now until we come up with a better implementation to
avoid false positive CI failures.

Signed-off-by: Paul Spooren <mail@aparcar.org>