### PR TITLE
forked-daapd: add missing dependency (libuuid)

### DIFF
--- a/sound/forked-daapd/Makefile
+++ b/sound/forked-daapd/Makefile
@@ -34,7 +34,8 @@ URL:=https://github.com/ejurgensen/forked-daapd
 DEPENDS:=+libgpg-error +libgcrypt +libgdbm +zlib +libexpat +libunistring \
 	+libevent2 +libdaemon +libantlr3c +confuse +alsa-lib +libffmpeg-full \
 	+mxml +libavahi-client +sqlite3-cli +libplist +libcurl +libjson-c \
-	+libprotobuf-c +libgnutls +libsodium +libwebsockets $(ICONV_DEPENDS)
+	+libprotobuf-c +libgnutls +libsodium +libwebsockets $(ICONV_DEPENDS) \
+	+libuuid
 endef
 
 define Package/forked-daapd/description


### PR DESCRIPTION
Maintainer: me
Compile tested: Atheros ATH79, trunk
Run tested: No

Description:
Fix build error after PR #15230 due to missing libuuid dependency, see: https://downloads.openwrt.org/snapshots/faillogs/i386_pentium4/packages/forked-daapd/compile.txt

Signed-off-by: Espen Jürgensen <espenjurgensen+openwrt@gmail.com>