### PR TITLE
acme: Get listener name from /proc/PID/exe instead of netstat output

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme
 PKG_VERSION:=2.8.7
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/acmesh-official/acme.sh/tar.gz/$(PKG_VERSION)?

--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -73,7 +73,7 @@ pre_checks()
 
 	for listener in $(get_listeners); do
 		pid="${listener%/*}"
-		cmd="${listener#*/}"
+		cmd="$(basename $(readlink /proc/$pid/exe))"
 
 		case "$cmd" in
 			uhttpd)
@@ -100,7 +100,7 @@ pre_checks()
 					return 1
 				fi
 				;;
-			nginx*)
+			nginx)
 				if [ "$NGINX_WEBSERVER" -eq "1" ]; then
 					debug "Already handled nginx; skipping"
 					continue


### PR DESCRIPTION
It seems the command name output from netstat can be truncated in weird
ways, so let's get the binary name from /proc instead and use that for
matching which listener we have.

Fixes #15071.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>

Maintainer: me

Posting this as a draft so @majkrzak can test it :)