### PR TITLE
banip: update to 0.7.6

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
-PKG_VERSION:=0.7.5
-PKG_RELEASE:=4
+PKG_VERSION:=0.7.6
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: PC Engines apu4, OpenWrt SNAPSHOT r16345-d71424a085

Description:
* rework the central iptables function to significantly
  reduce the code complexity and the overall number of iptables calls
* check early and only once in the chain for ctstate NEW and
  return otherwise (thanks @ldir-EDB0)
* made the whitelist ordering within the chain more flexible

Signed-off-by: Dirk Brenken <dev@brenken.org>
