### PR TITLE
mpd-full: enable lame and vorbis encoders

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpd
 PKG_VERSION:=0.22.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.musicpd.org/download/mpd/0.22/
@@ -48,7 +48,7 @@ define Package/mpd-full
 $(call Package/mpd/Default)
   TITLE+= (full)
   DEPENDS+= +AUDIO_SUPPORT:pulseaudio-daemon +libvorbis +libmms +libupnp +libshout +yajl \
-            +libffmpeg +!BUILD_PATENTED:libmad
+            +libffmpeg +lame-lib +!BUILD_PATENTED:libmad
   PROVIDES:=mpd
   VARIANT:=full
 endef
@@ -188,7 +188,9 @@ ifeq ($(BUILD_VARIANT),full)
 	-Dpulse=$(if $(CONFIG_AUDIO_SUPPORT),en,dis)abled \
 	-Drecorder=true \
 	-Dshout=enabled \
-	-Dyajl=enabled
+	-Dyajl=enabled \
+	-Dvorbisenc=enabled \
+	-Dlame=enabled
 
 ifeq ($(CONFIG_AUDIO_SUPPORT),y)
 	TARGET_LDFLAGS += -Wl,-rpath-link=$(STAGING_DIR)/usr/lib/pulseaudio


### PR DESCRIPTION
Enable Vorbis encoder for OGG format and lame for MP3.
This enables mpd to stream OGG and MP3 to e.g. Icecast2.

Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>

Maintainer: @neheb
Compile tested: Netgear R9000, OpenWrt SNAPSHOT r16368-9f31c417a2
Run tested: Netgear R9000, OpenWrt SNAPSHOT r16368-9f31c417a2

```
root@OpenWrt:~# mpd -V
Music Player Daemon 0.22.6 (reboot-16368-g9f31c417a2)

Encoder plugins:
 null vorbis opus lame wave flac
```

Example config:
```
audio_output {
        type            "shout"
        encoder         "lame"
        name            "my music"
        host            "192.168.1.1"
        port            "8000"
        mount           "/mpd"
        user            "source"
        password        "secret"
        bitrate         "64000"
        format          "48000:16:2"
}

# Need this so that mpd still works if icecast is not running
audio_output {
        type    "null"
        name    "fake out"
}
```
