### PR TITLE
yggdrasil: bump to 0.3.16

### DIFF
--- a/net/yggdrasil/Makefile
+++ b/net/yggdrasil/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yggdrasil
-PKG_VERSION:=0.3.15
+PKG_VERSION:=0.3.16
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=25ea85399a142aa7a3d6f6886fd4e0d215116c4c8c33453de43999787d735565
+PKG_HASH:=e03595b78906b171155aaa11c922be3418bd056f8547e4d9f5123b6047316eac
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-go-$(PKG_VERSION)
 
 PKG_MAINTAINER:=William Fleurant <meshnet@protonmail.com>


### PR DESCRIPTION
Signed-off-by: George Iv <zhoreeq@users.noreply.github.com>

Maintainer: @wfleurant 
Compile tested: none
Run tested: none
Description: bump version