### PR TITLE
mpd: run mpd as a non-root user

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpd
 PKG_VERSION:=0.22.6
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.musicpd.org/download/mpd/0.22/
@@ -35,6 +35,7 @@ define Package/mpd/Default
   URL:=https://www.musicpd.org/
   DEPENDS:= +zlib +libcurl +libpthread +libmpdclient +boost $(ICONV_DEPENDS) \
             +AUDIO_SUPPORT:alsa-lib +libexpat +libflac +libid3tag +libfaad2 +libopus
+  USERID:=mpd:mpd
 endef
 
 define Package/mpd/Default/description
@@ -220,7 +221,7 @@ define Package/mpd/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mpd $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/etc
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/doc/mpdconf.example $(1)/etc/mpd.conf
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/doc/mpdconf.example $(1)/etc/mpd.conf
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/mpd.init $(1)/etc/init.d/mpd
 endef

--- a/sound/mpd/files/mpd.init
+++ b/sound/mpd/files/mpd.init
@@ -9,6 +9,9 @@ PROG=/usr/bin/mpd
 CONFIGFILE=/etc/mpd.conf
 NICEPRIO=-10
 
+USER="mpd"
+GROUP="mpd"
+
 #TODO: Add uci config - nice, config
 
 start_service() {
@@ -16,7 +19,10 @@ start_service() {
 
 	#create mpd directories from config
 	pld=$(grep ^playlist_directory "$CONFIGFILE" | cut -d "\"" -f 2 | sed "s/~/\/root/g")
-	[ -d "$pld" ] || mkdir -m 0755 -p "$pld"
+	if [ ! -d "$pld" ]; then
+		mkdir -m 0755 -p "$pld"
+		chown $USER:$GROUP $pld
+	fi
 
 	lport=$(grep ^port "$CONFIGFILE" | cut -d "\"" -f 2)
 	[ -z "$lport" ] && lport=6600
@@ -24,6 +30,8 @@ start_service() {
 	procd_open_instance
 	procd_add_mdns "mpd" "tcp" "$lport"
 	procd_set_param command "$PROG" --no-daemon "$CONFIGFILE"
+	procd_set_param user "$USER"
+	procd_set_param group "$GROUP"
 	procd_set_param stderr 1
 	# Give MPD some real-time priority
 	procd_set_param nice "$NICEPRIO"


### PR DESCRIPTION
Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>

Maintainer: @neheb
Compile tested: Netgear R9000, OpenWrt SNAPSHOT r16368-9f31c417a2 
Run tested: Netgear R9000, OpenWrt SNAPSHOT r16368-9f31c417a2 

```
root@OpenWrt:~# ps aux | grep mpd
mpd      17800  4.7  1.3  36296 13436 ?        S<l  06:50   0:23 /usr/bin/mpd --no-daemon /etc/mpd.conf
```

```
root@OpenWrt:~# ls -l /mnt/sda1/openwrt/mpd/
-rw-r--r--    1 mpd      mpd          76892 Mar 29 06:50 database
drwxr-xr-x    1 mpd      mpd              0 Mar 29 06:50 playlists
```

Example config:
```
root@OpenWrt:~# cat /etc/mpd.conf
bind_to_address "192.168.1.1"

music_directory "/mnt/sda1/music/"
playlist_directory "/mnt/sda1/openwrt/mpd/playlists"
db_file "/mnt/sda1/openwrt/mpd/database"

audio_output {
        type            "shout"
        encoder         "lame"
        name            "my music"
        host            "192.168.1.1"
        port            "8000"
        mount           "/mpd"
        user            "source"
        password        "secret"
        bitrate         "64000"
        format          "48000:16:2"
}

# Need this so that mpd still works if icecast is not running
audio_output {
        type    "null"
        name    "fake out"
}
```