### PR TITLE
git-lfs: update to version 2.13.3

### DIFF
--- a/net/git-lfs/Makefile
+++ b/net/git-lfs/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=git-lfs
-PKG_VERSION:=2.13.2
+PKG_VERSION:=2.13.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/git-lfs/git-lfs/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=782e6275df9ca370730945112e16a0b8c64b9819f0b61fae52ba1ebbc8dce2d5
+PKG_HASH:=f8bd7a06e61e47417eb54c3a0db809ea864a9322629b5544b78661edab17b950
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: Turis Omna (TOS6), OpenWrt maser
Run tested: Turris Omnia(TOS6), OpenWrt master

Description:
This PR updates git-lfs to version 2.13.3. It is a bugfix release. [Changelog](https://github.com/git-lfs/git-lfs/releases/tag/v2.13.3)

