### PR TITLE
tmate-ssh-server: add package

### DIFF
--- a/net/tmate-ssh-server/Makefile
+++ b/net/tmate-ssh-server/Makefile
@@ -1,0 +1,51 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tmate-ssh-server
+PKG_VERSION:=511fd2bd852464e76824279609a34ee93fe148a4
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/tmate-io/tmate-ssh-server/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=68602496ca6a17ea80f5be53eba047897ac714c7cdfcb3bcdc12c56b8f3c3b45
+
+PKG_LICENSE:=ISC
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/tmate-ssh-server
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Instant Terminal Sharing Server
+  URL:=https://tmate.io
+  DEPENDS:=+libevent2 +libncurses +libpthread +libssh +msgpack-c +terminfo +openssh-keygen
+endef
+
+define Package/tmate-ssh-server/description
+  tmate-ssh-server is the server side part of tmate.io.
+endef
+
+CONFIGURE_VARS+= \
+	LIBSSH_CFLAGS="-I$(STAGING_DIR)/usr/include" \
+	LIBSSH_LIBS="-lssh"
+
+TARGET_CFLAGS+= \
+	-D_GNU_SOURCE \
+
+define Package/tmate-ssh-server/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/tmate-ssh-server $(1)/usr/bin/tmate-ssh-server
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/tmate-ssh-server.init $(1)/etc/init.d/tmate-ssh-server
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/tmate-ssh-server.config $(1)/etc/config/tmate-ssh-server
+endef
+
+$(eval $(call BuildPackage,tmate-ssh-server))

--- a/net/tmate-ssh-server/files/tmate-ssh-server.config
+++ b/net/tmate-ssh-server/files/tmate-ssh-server.config
@@ -1,0 +1,6 @@
+config tmate-ssh-server 'main'
+	option listen_port 2222
+	option keys_dir '/etc/tmate-ssh-server/keys/'
+	# option ip '0.0.0.0'
+	# option hostname 'OpenWrt'
+	# option ssh_port_advertized 2222

--- a/net/tmate-ssh-server/files/tmate-ssh-server.init
+++ b/net/tmate-ssh-server/files/tmate-ssh-server.init
@@ -1,0 +1,65 @@
+#!/bin/sh /etc/rc.common
+
+START=90
+STOP=10
+
+USE_PROCD=1
+PROG=/usr/bin/tmate-ssh-server
+
+generate_keys() {
+	mkdir -p "$1"
+	echo "Generating fresh keys"
+	ssh-keygen -t "rsa" -f "$1/ssh_host_rsa_key" -N '' > /dev/null
+	ssh-keygen -t "ed25519" -f "$1/ssh_host_ed25519_key" -N '' > /dev/null
+}
+
+start_service() {
+	local ip hostname keys_dir listen_port ssh_port_advertized
+	config_load "tmate-http-server"
+
+	procd_open_instance
+	procd_set_param command $PROG
+
+	config_get ip main ip
+	if [ ! -z "$ip" ]; then
+		procd_append_param command -b "$ip"
+	fi
+
+	config_get hostname main hostname "$HOSTNAME"
+	procd_append_param command -h "$hostname"
+
+	config_get keys_dir main keys_dir "/etc/tmate-ssh-server/keys/"
+	if [ ! -f "$keys_dir/ssh_host_rsa_key" ] && \
+			[ ! -f "ssh_host_ed25519_key" ]; then
+		generate_keys "$keys_dir"
+	fi
+
+	procd_append_param command -k "$keys_dir"
+
+	config_get listen_port main listen_port "2222"
+	procd_append_param command -p "$listen_port"
+
+	config_get ssh_port_advertized main ssh_port_advertized "$listen_port"
+	procd_append_param command -q "$ssh_port_advertized"
+
+	echo "You may use the following settings this in your .tmate.conf:"
+	echo ""
+	echo "set -g tmate-server-host $hostname"
+	echo "set -g tmate-server-port $ssh_port_advertized"
+	printf "set -g tmate-server-rsa-fingerprint "
+	ssh-keygen -l -E SHA256 -f "$keys_dir/ssh_host_rsa_key.pub" | \
+		cut -d ' ' -f 2
+	printf "set -g tmate-server-ed25519-fingerprint "
+	ssh-keygen -l -E SHA256 -f "$keys_dir/ssh_host_ed25519_key.pub" | \
+		cut -d ' ' -f 2
+
+	procd_set_param respawn
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+
+	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger "tmate-ssh-server"
+}


### PR DESCRIPTION
The `tmate` tool is a fork of `tmux` which allows remote access to a
device without setting up any port forwarding. This commits adds the
backend server which handles connections.

Signed-off-by: Paul Spooren <mail@aparcar.org>