### PR TITLE
Fix null socket connections list

### DIFF
--- a/utils/conmon/Makefile
+++ b/utils/conmon/Makefile
@@ -28,6 +28,7 @@ endef
 
 define Package/conmon/description
   Podman: A tool for managing OCI containers and pods
+  Conmon is necessary part of podman.
 endef
 
 define Package/conmon/install

--- a/utils/conmon/Makefile
+++ b/utils/conmon/Makefile
@@ -21,7 +21,7 @@ include ../../devel/meson/meson.mk
 define Package/conmon
   SECTION:=utils
   CATEGORY:=Utilities
-  TITLE:=Podmon conmon
+  TITLE:=Podman conmon
   URL:=https://podman.io
   DEPENDS:=+glib2 $(INTL_DEPENDS) $(ICONV_DEPENDS)
 endef

--- a/utils/conmon/patches/100-fix-null-socket-connection-list.patch
+++ b/utils/conmon/patches/100-fix-null-socket-connection-list.patch
@@ -1,5 +1,5 @@
---- a/src/conn_sock.c.orig	2021-03-29 14:44:23.235796360 +0300
-+++ b/src/conn_sock.c	2021-03-29 14:45:43.115728169 +0300
+--- a/src/conn_sock.c
++++ b/src/conn_sock.c
 @@ -465,6 +465,9 @@
  
  static void close_sock(gpointer data, G_GNUC_UNUSED gpointer user_data)

--- a/utils/conmon/patches/100-fix-null-socket-connection-list.patch
+++ b/utils/conmon/patches/100-fix-null-socket-connection-list.patch
@@ -1,0 +1,22 @@
+--- a/src/conn_sock.c.orig	2021-03-29 14:44:23.235796360 +0300
++++ b/src/conn_sock.c	2021-03-29 14:45:43.115728169 +0300
+@@ -465,6 +465,9 @@
+ 
+ static void close_sock(gpointer data, G_GNUC_UNUSED gpointer user_data)
+ {
++	if (data == NULL)
++		return;
++
+ 	struct remote_sock_s *sock = (struct remote_sock_s *)data;
+ 
+ 	close(sock->fd);
+@@ -473,5 +476,9 @@
+ 
+ void close_all_readers()
+ {
++
++	if (local_mainfd_stdin.readers == NULL)
++		return;
++
+ 	g_ptr_array_foreach(local_mainfd_stdin.readers, close_sock, NULL);
+ }


### PR DESCRIPTION
Maintainer: Daniel Golle / @dangowrt
Compile tested: x86_64, xeon powered server, OpenWRT snapshot (recent)
Run tested: x86_64, xeon powered server, OpenWRT snapshot (recent), tests: issue fixed, no more segfault

Description:
When podman stops a container, conmon segfaults.
This is output of podman when stopping a container:
`
error stopping container 0c1488f14bf30b16ad4f70a752400038d50fde4a63305d24d8543e3ce310ecab: timed out waiting for file /run/libpod/exits/0c1488f14bf30b16ad4f70a752400038d50fde4a63305d24d8543e3ce310ecab: internal libpod error
`

And this is output of system log:
`
Mon Mar 29 12:37:14 2021 kern.info kernel: [44090.269813] conmon[32066]: segfault at 8 ip 00007fa70ca8d549 sp 00007fff6bcaac50 error 4 in libglib-2.0.so.0.6600.7[7fa70ca23000+6f000]
Mon Mar 29 12:37:14 2021 kern.info kernel: [44090.271638] Code: eb d2 31 c0 5b 5d 41 5c 41 5d 41 5e c3 48 89 d1 31 d2 e9 9b ff ff ff 90 41 55 49 89 d5 41 54 49 89 f4 55 48 89 fd 53 31 db 51 <39> 5d 08 76 14 48 8b 45 00 89 da 4c 89 ee ff c3 48 8b 3c d0 41 ff
`

When conmon stops a container, it closes all currently active connections to container's socket, but segfault occurs when list of sockets is NULL, I also added a second check for NULL data just to be sure. These are minor changes that won't hurt anyone and this patch fixes the issue.

I also reported and provided a patch to conmon's maintainers, but it's not that sure if it ever gets there since this seems to be openwrt only issue, same issue for example does not occur in Alpine Linux which is very much similar to OpenWRT as it uses musl and does not need gigabytes......
