### PR TITLE
stress-ng: bump to version 0.12.06

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.12.04
+PKG_VERSION:=0.12.06
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://kernel.ubuntu.com/~cking/tarballs/stress-ng
-PKG_HASH:=b4e34bda8db4ed37e33b7a861bc06ad77cbbd234d63236da2cb58f02e3f3218e
+PKG_HASH:=75eb340266b1bbae944d8f9281af978bd5bc2c8085df97a098d5500d6f177296
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me,
Compile tested: x86 https://github.com/openwrt/openwrt/commit/571aedbc6cbb7a9bfc96bcad543a39d158925cbc
Run tested: x86 https://github.com/openwrt/openwrt/commit/571aedbc6cbb7a9bfc96bcad543a39d158925cbc


Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>