### PR TITLE
podman: several improvements and add selinux variant

### DIFF
--- a/utils/podman/Makefile
+++ b/utils/podman/Makefile
@@ -10,7 +10,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 
 PKG_BUILD_DEPENDS:=golang/host protobuf/host
 PKG_BUILD_PARALLEL:=1
@@ -18,8 +18,6 @@ PKG_USE_MIPS16:=0
 
 GO_PKG:=github.com/containers/podman/
 GO_PKG_BUILD_PKG:=github.com/containers/podman/v2/cmd/podman/
-
-GO_PKG_TAGS=seccomp,exclude_graphdriver_devicemapper
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
@@ -38,21 +36,53 @@ define Download/default-policy
   HASH:=cddfaa8e6a7e5497b67cc0dd8e8517058d0c97de91bf46fff867528415f2d946
 endef
 
-define Package/podman
+define Package/podman/Default
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Podman
+  DEPENDS:=$(GO_ARCH_DEPENDS) +conmon +cni +cni-plugins +btrfs-progs +glib2 +gnupg2 +iptables +libgpg-error +libseccomp +libgpgme +nsenter +zoneinfo-simple +kmod-veth
   URL:=https://podman.io
-  DEPENDS:=$(GO_ARCH_DEPENDS) +conmon +cni +cni-plugins +btrfs-progs +glib2 +gnupg2 +iptables +libgpg-error +libseccomp +libgpgme +nsenter +zoneinfo-simple
+endef
+
+define Package/podman
+  $(call Package/podman/Default)
+  CONFLICTS:=podman-selinux
+  VARIANT:=default
+  PROVIDES:=podman
+endef
+
+define Package/podman-selinux
+  $(call Package/podman/Default)
+  TITLE+= with SELinux support
+  DEPENDS+= libselinux
+  VARIANT:=selinux
+  PROVIDES:=podman
 endef
 
 define Package/podman/description
   Podman: A tool for managing OCI containers and pods
 endef
 
-define Package/podman/conffiles
-/etc/containers
+define Package/podman-selinux/description
+  Podman: A tool for managing OCI containers and pods
+  SELinux enabled.
 endef
+
+define Package/podman/conffiles
+  /etc/containers/policy.json
+  /etc/containers/storage.conf
+  /etc/containers/registries.conf
+  /etc/containers/containers.conf
+  /etc/cni/net.d/87-podman-bridge.conflist
+endef
+
+Package/podman-selinux/conffiles = $(Package/podman/conffiles)
+
+ifeq ($(BUILD_VARIANT),selinux)
+  GO_PKG_TAGS=seccomp,exclude_graphdriver_devicemapper,selinux
+else
+  GO_PKG_TAGS=seccomp,exclude_graphdriver_devicemapper
+endif
 
 define Build/Prepare
 	$(call Build/Prepare/Default)
@@ -69,7 +99,14 @@ define Package/podman/install
 	$(INSTALL_CONF) ./files/containers.conf $(1)/etc/containers/containers.conf
 	$(INSTALL_DIR) $(1)/etc/cni/net.d
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/cni/87-podman-bridge.conflist $(1)/etc/cni/net.d/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/podman.init $(1)/etc/init.d/podman
+	$(SED) 's/driver = \"\"/driver = \"overlay\"/g' $(1)/etc/containers/storage.conf
 endef
+
+Package/podman-selinux/install = $(Package/podman/install)
 
 $(eval $(call GoBinPackage,podman))
 $(eval $(call BuildPackage,podman))
+$(eval $(call GoBinPackage,podman-selinux))
+$(eval $(call BuildPackage,podman-selinux))

--- a/utils/podman/files/containers.conf
+++ b/utils/podman/files/containers.conf
@@ -7,19 +7,19 @@ network_config_dir="/etc/cni/net.d/"
 default_network="podman"
 
 [engine]
-runtime="/usr/sbin/crun"
+runtime="/usr/bin/crun"
 # runtime="/usr/sbin/runc"
 # runtime="/sbin/uxc"
 # runtime_supports_nocgroups = ["crun", "uxc"]
 # runtime_supports_json = ["crun", "runc", "kata", "uxc"]
 
 [engine.runtimes]
-runc = [
-        "/usr/sbin/runc",
+crun = [
+	"/usr/bin/crun",
 ]
 
-crun = [
-        "/usr/bin/crun",
+runc = [
+        "/usr/sbin/runc",
 ]
 
 uxc = [

--- a/utils/podman/files/podman.init
+++ b/utils/podman/files/podman.init
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+USE_PROCD=1
+NAME=podman
+PROG=/usr/bin/podman
+
+start_service() {
+	[ -d /run/podman ] || mkdir -p /run/podman
+	procd_open_instance "podman"
+	procd_set_param command "$PROG" system service --time=0
+	procd_append_param command $command
+	procd_close_instance
+}


### PR DESCRIPTION
Maintainer: Daniel Golle / @dangowrt
Compile tested: x86_64, xeon powered server, OpenWRT snapshot (recent)
Run tested: x86_64, xeon powered server, OpenWRT snapshot (recent)

Description:

- Added selinux support as a variant
- Init script for socket
- Updated containers.conf
- preselected overlay as storage driver
- changed maintainer from Daniel to me as per request.
- Changes requested by Daniel Golle

Source code has remained same and no patches provided this time.
Replaces pull request #15310

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>