### PR TITLE
atlas-sw-probe: add new package

### DIFF
--- a/net/atlas-probe/Makefile
+++ b/net/atlas-probe/Makefile
@@ -1,0 +1,70 @@
+#
+# Copyright (C) 2019-2021 CZ.NIC z.s.p.o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=atlas-probe
+PKG_VERSION:=2.2.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=ripe-atlas-probe-busybox-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/RIPE-NCC/ripe-atlas-probe-busybox/archive/v$(PKG_VERSION)
+PKG_HASH:=c5a3aca026cd1a3b93a77b159b36cd7a1098eb6d90e9ae4a69872cd7a419a87b
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/ripe-atlas-probe-busybox-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/atlas-probe
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=RIPE Atlas probe measurement
+  DEPENDS:=+librt +libopenssl +openssh-client +sudo
+  USERID:=atlas=444:atlas=444
+  URL:=https://atlas.ripe.net/
+endef
+
+define Package/atlas-probe/description
+  RIPE Atlas is a global, open, distributed Internet measurement platform,
+  consisting of thousands of measurement devices that measure Internet
+  connectivity in real time.
+endef
+
+TARGET_CFLAGS += $(FPIC)
+
+CONFIGURE_ARGS += \
+	--disable-shared \
+	--enable-static
+
+CONFIGURE_PATH = libevent-2.1.11-stable
+
+TARGET_LDFLAGS = -L$(PKG_BUILD_DIR)/$(CONFIGURE_PATH)/.libs
+
+define Build/Compile
+	+$(MAKE_VARS) \
+	$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/$(CONFIGURE_PATH) \
+		$(MAKE_FLAGS)
+	+$(MAKE_VARS) \
+	$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+		$(MAKE_FLAGS)
+endef
+
+define Package/atlas-probe/install
+	+$(MAKE_VARS) \
+	$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+		$(MAKE_FLAGS) CONFIG_PREFIX=$(1)/usr/libexec/atlas-probe install
+	$(INSTALL_DIR) $(1)/usr/libexec/atlas-probe/state
+	echo $(PKG_VERSION) > $(1)/usr/libexec/atlas-probe/state/VERSION
+endef
+
+$(eval $(call BuildPackage,atlas-probe))

--- a/net/atlas-probe/patches/001-fix-stime-glibc-remove.patch
+++ b/net/atlas-probe/patches/001-fix-stime-glibc-remove.patch
@@ -1,0 +1,178 @@
+From 402150eed057fc9fa52c8471ae645e23913a2805 Mon Sep 17 00:00:00 2001
+From: Philip Homburg <phomburg@ripe.net>
+Date: Tue, 23 Jun 2020 12:25:08 -0400
+Subject: [PATCH] replace stime with clock_settime
+
+---
+ coreutils/date.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/coreutils/date.c
++++ b/coreutils/date.c
+@@ -246,6 +246,9 @@ int date_main(int argc UNUSED_PARAM, cha
+ 	if (*argv)
+ 		bb_show_usage();
+ 
++    /* Clear ts.tv_nsec, in case we need to set the time later */
++  	ts.tv_nsec= 0;
++
+ 	/* Now we have parsed all the information except the date format
+ 	 * which depends on whether the clock is being set or read */
+ 
+@@ -310,7 +313,7 @@ int date_main(int argc UNUSED_PARAM, cha
+ 		}
+ 
+ 		/* if setting time, set it */
+-		if ((opt & OPT_SET) && stime(&ts.tv_sec) < 0) {
++		if ((opt & OPT_SET) && clock_settime(CLOCK_REALTIME, &ts) < 0) {
+ 			bb_perror_msg("can't set date");
+ 		}
+ 	}
+--- a/util-linux/rdate.c
++++ b/util-linux/rdate.c
+@@ -65,27 +65,27 @@ static time_t askremotedate(const char *
+ int rdate_main(int argc, char **argv) MAIN_EXTERNALLY_VISIBLE;
+ int rdate_main(int argc UNUSED_PARAM, char **argv)
+ {
+-	time_t remote_time;
++	struct timespec remote_time;
+ 	unsigned flags;
+ 
+ 	opt_complementary = "-1";
+ 	flags = getopt32(argv, "sp");
+ 
+-	remote_time = askremotedate(argv[optind]);
++	remote_time.tv_sec = askremotedate(argv[optind]);
+ 
+ 	if (!(flags & 2)) { /* no -p (-s may be present) */
+ 		time_t current_time;
+ 
+ 		time(&current_time);
+-		if (current_time == remote_time)
++		if (current_time == remote_time.tv_sec)
+ 			bb_error_msg("current time matches remote time");
+ 		else
+-			if (stime(&remote_time) < 0)
++			if (clock_settime(CLOCK_REALTIME,&remote_time) < 0)
+ 				bb_perror_msg_and_die("can't set time of day");
+ 	}
+ 
+ 	if (flags != 1) /* not lone -s */
+-		printf("%s", ctime(&remote_time));
++		printf("%s", ctime(&remote_time.tv_sec));
+ 
+ 	return EXIT_SUCCESS;
+ }
+--- a/networking/httpget.c
++++ b/networking/httpget.c
+@@ -947,8 +947,9 @@ static int eat_headers(FILE *tcp_file, i
+ 		if (time_tolerance && strncmp(line, "Date: ", 6) == 0)
+ 		{
+ 			/* Try to set time from server */
+-			time_t now, tim, tolerance;
++			time_t now, tolerance;
+ 			struct tm tm;
++			struct timespec tim;
+ 
+ 			tolerance= strtoul(time_tolerance, &cp, 10);
+ 			if (cp[0] != '\0')
+@@ -966,16 +967,16 @@ static int eat_headers(FILE *tcp_file, i
+ 						line+6);
+ 				}
+ 			}
+-			tim= timegm(&tm);
++			tim.tv_sec= timegm(&tm);
+ 			now= time(NULL);
+-			if (now < tim-tolerance || now > tim+tolerance)
++			if (now < tim.tv_sec-tolerance || now > tim.tv_sec+tolerance)
+ 			{
+ 				if (debug)
+ 				{	fprintf(stderr,
+ 				"setting time, time difference is %d\n",
+-						(int)(tim-now));
++						(int)(tim.tv_sec-now));
+ 				}
+-				stime(&tim);
++				clock_settime(CLOCK_REALTIME,&tim);
+ 			}
+ 		}
+ 
+--- a/networking/httppost.c
++++ b/networking/httppost.c
+@@ -92,13 +92,14 @@ int httppost_main(int argc, char *argv[]
+ 	char *time_tolerance, *rebased_fn= NULL;
+ 	char *fn_new, *fn;
+ 	FILE *tcp_file, *out_file, *fh;
+-	time_t server_time, tolerance;
++	time_t tolerance;
++	struct timespec server_time;
+ 	struct stat sbF, sbH, sbS;
+ 	off_t cLength, dir_length, maxpostsize;
+ 	struct sigaction sa;
+ 
+-	post_dir= NULL; 
+-	post_file= NULL; 
++	post_dir= NULL;
++	post_file= NULL;
+ 	post_footer=NULL;
+ 	post_header=NULL;
+ 	atlas_id= NULL;
+@@ -470,12 +471,12 @@ int httppost_main(int argc, char *argv[]
+ 	if (!check_result(tcp_file))
+ 		goto err;
+ 	fprintf(stderr, "httppost: getting reply headers \n");
+-	server_time= 0;
++	server_time.tv_sec = 0;
+ 	content_length= -1;
+-	if (!eat_headers(tcp_file, &chunked, &content_length, &server_time))
++	if (!eat_headers(tcp_file, &chunked, &content_length, &server_time.tv_sec))
+ 		goto err;
+ 
+-	if (tolerance && server_time > 0)
++	if (tolerance && server_time.tv_sec > 0)
+ 	{
+ 		/* Try to set time from server */
+ 		int need_set_time;
+@@ -486,35 +487,35 @@ int httppost_main(int argc, char *argv[]
+ 		rtt= now.tv_sec-start_time.tv_sec;
+ 		rtt += (now.tv_usec-start_time.tv_usec)/1e6;
+ 		if (rtt < 0) rtt= 0;
+-		need_set_time= (now.tv_sec < server_time-tolerance-rtt ||
+-			now.tv_sec > server_time+tolerance+rtt);
++		need_set_time= (now.tv_sec < server_time.tv_sec-tolerance-rtt ||
++			now.tv_sec > server_time.tv_sec+tolerance+rtt);
+ 		if (need_set_time && getenv("HTTPPOST_ALLOW_STIME"))
+ 		{
+ 			fprintf(stderr,
+ 				"setting time, time difference is %ld\n",
+-				(long)server_time-now.tv_sec);
+-			stime(&server_time);
++				(long)server_time.tv_sec-now.tv_sec);
++			clock_settime(CLOCK_REALTIME,&server_time);
+ 			if (atlas_id)
+ 			{
+ 				printf(
+ 	"RESULT %s ongoing %ld httppost setting time, local %ld, remote %ld\n",
+ 					atlas_id, (long)time(NULL),
+ 					(long)now.tv_sec,
+-					(long)server_time);
++					(long)server_time.tv_sec);
+ 			}
+ 		}
+ 		else if (need_set_time)
+ 		{
+ 			fprintf(stderr,
+ 				"not setting time, time difference is %ld\n",
+-				(long)server_time-now.tv_sec);
++				(long)server_time.tv_sec-now.tv_sec);
+ 			if (atlas_id)
+ 			{
+ 				printf(
+ 	"RESULT %s ongoing %ld httppost not in sync, local %ld, remote %ld\n",
+ 					atlas_id, (long)time(NULL),
+ 					(long)now.tv_sec,
+-					(long)server_time);
++					(long)server_time.tv_sec);
+ 			}
+ 		}
+ 		else if (rtt <= 1)

--- a/net/atlas-sw-probe/Makefile
+++ b/net/atlas-sw-probe/Makefile
@@ -1,0 +1,127 @@
+#
+# Copyright (C) 2019-2021 CZ.NIC z.s.p.o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=atlas-sw-probe
+PKG_VERSION:=5020
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/RIPE-NCC/ripe-atlas-software-probe.git
+PKG_SOURCE:=ripe-atlas-software-probe-$(PKG_VERSION).tar.gz
+
+PKG_MIRROR_HASH:=846aa20ff4bc938c07526a9893dcae4ac7dfa41982a5b2bcfe2dd53c974ecdc9
+PKG_SOURCE_VERSION:=edee49c942b726a1d8865d91c8d7f32843bc8ad1
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/atlas-sw-probe
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=RIPE Atlas software probe
+  URL:=https://atlas.ripe.net/about/probes/
+  DEPENDS:=+atlas-probe
+endef
+
+define Package/atlas-sw-probe/description
+  RIPE Atlas SW probe is software variant of RIPE Atlas Probe.
+  It contains utilities which helps actively measure
+  Internet connectivity through ping, traceroute, DNS, SSL/TLS, NTP, and HTTP.
+  Data are then collected, aggregated and published by the RIPE NCC.
+endef
+
+define Package/atlas-sw-probe-rpc
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=RPC service
+  URL:=https://atlas.ripe.net/about/probes/
+  DEPENDS:=+atlas-probe +bind-dig +rpcd
+endef
+
+define Package/atlas-sw-probe-rpc/description
+  Provides ubus calls for probe.
+endef
+
+Build/Compile:=:
+Build/Install:=:
+
+define Package/atlas-sw-probe-rpc/postinst
+#!/bin/sh
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/rpcd restart
+exit 0
+endef
+
+define Package/atlas-sw-probe-rpc/postrm
+#!/bin/sh
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/rpcd restart
+exit 0
+endef
+
+define Package/atlas-sw-probe/conffiles
+/etc/config/atlas
+/usr/libexec/atlas-probe-scripts/state/config.txt
+endef
+
+TMP_BASE_DIR:=/tmp/ripe_atlas_probe
+SCRIPTS_DIR:=/usr/libexec/atlas-probe-scripts
+
+define Package/atlas-sw-probe/install
+	$(INSTALL_DIR) $(1)/$(SCRIPTS_DIR)
+	$(INSTALL_DIR) $(1)/$(SCRIPTS_DIR)/{etc,state,bin/arch,bin/bin}
+
+	# Copy config
+	$(CP) $(PKG_BUILD_DIR)/atlas-config/etc/* $(1)/$(SCRIPTS_DIR)/etc/
+
+	# Copy firmware version
+	$(CP) $(PKG_BUILD_DIR)/atlas-config/state/FIRMWARE_APPS_VERSION $(1)/$(SCRIPTS_DIR)/state/
+
+	# Set probe mode
+	echo "prod" > $(1)/$(SCRIPTS_DIR)/state/mode
+
+	# Copy scripts
+	$(CP) $(PKG_BUILD_DIR)/bin/{ATLAS,common-pre.sh,common.sh,reginit.sh,resolvconf} $(1)/$(SCRIPTS_DIR)/bin/
+	$(CP) $(PKG_BUILD_DIR)/bin/arch/{linux,openwrt-sw-probe} $(1)/$(SCRIPTS_DIR)/bin/arch/
+
+	# Create config info
+	echo "DEVICE_NAME=openwrt-sw-probe" > $(1)/$(SCRIPTS_DIR)/bin/config.sh
+	echo "ATLAS_BASE=$(SCRIPTS_DIR)" >> $(1)/$(SCRIPTS_DIR)/bin/config.sh
+	echo "ATLAS_STATIC=$(SCRIPTS_DIR)" >> $(1)/$(SCRIPTS_DIR)/bin/config.sh
+	echo "SUB_ARCH=openwrt-$(ARCH)-$(PKG_VERSION)-$(PKG_RELEASE)" >> $(1)/$(SCRIPTS_DIR)/bin/bin/config.sh
+
+	# Enable sending interface traffic statistics as Atlas measurement results
+	echo "RXTXRPT=yes" > $(1)/$(SCRIPTS_DIR)/state/config.txt
+
+	# Fix permision
+	chmod 755 $(1)/$(SCRIPTS_DIR)/bin
+
+	# Create softlinks for writable dirs
+	$(LN) $(TMP_BASE_DIR)/crons $(1)/$(SCRIPTS_DIR)/crons
+	$(LN) $(TMP_BASE_DIR)/data $(1)/$(SCRIPTS_DIR)/data
+	$(LN) $(TMP_BASE_DIR)/run $(1)/$(SCRIPTS_DIR)/run
+	$(LN) $(TMP_BASE_DIR)/status $(1)/$(SCRIPTS_DIR)/status
+
+	# Copy init and config
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/atlas.init $(1)/etc/init.d/atlas
+
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_CONF) ./files/atlas.conf $(1)/etc/config/atlas
+endef
+
+define Package/atlas-sw-probe-rpc/install
+	$(INSTALL_DIR) $(1)/usr/libexec/rpcd
+	$(INSTALL_BIN) ./files/atlas_rpcd.sh $(1)/usr/libexec/rpcd/atlas
+endef
+
+$(eval $(call BuildPackage,atlas-sw-probe))
+$(eval $(call BuildPackage,atlas-sw-probe-rpc))

--- a/net/atlas-sw-probe/files/atlas.conf
+++ b/net/atlas-sw-probe/files/atlas.conf
@@ -1,0 +1,4 @@
+config atlas 'common'
+	option log_stderr '1'
+	option log_stdout '0'
+	option rxtxrpt '1'

--- a/net/atlas-sw-probe/files/atlas.init
+++ b/net/atlas-sw-probe/files/atlas.init
@@ -1,0 +1,178 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=30
+EXTRA_COMMANDS="get_key probeid log create_backup load_backup"
+EXTRA_HELP="	get_key	print probe public key (used for probe registration)
+	probeid	print probe id
+	log	print probe status log
+	create_backup 	backup ssh key to tar.gz
+	load_backup 'backup.tar.gz' 	load backup ssh key from tar.gz
+"
+
+SCRIPTS_DIR="/usr/libexec/atlas-probe-scripts"
+TMP_BASE_DIR="/tmp/ripe_atlas_probe"
+PUB_KEY_FILE="$SCRIPTS_DIR/etc/probe_key.pub"
+PRIV_KEY_FILE="$SCRIPTS_DIR/etc/probe_key"
+PROBE_ID_FILE="$TMP_BASE_DIR/status/reg_init_reply.txt"
+LOG_FILE="/tmp/log/ripe_sw_probe"
+STATE_CONFIG="$SCRIPTS_DIR/state/config.txt"
+
+load_backup() {
+	local backup_arch
+	local tmp_dir
+
+	backup_arch="$1"
+	tmp_dir="$(mktemp -u -p /var/run/atlas)"
+	if [ -f "$backup_arch" ]; then
+		safe_mkdir "$tmp_dir"
+		tar -xzf "$backup_arch" -C "$tmp_dir/"
+		if [ -f "$tmp_dir/probe_key.pub" ] && [ -f "$tmp_dir/probe_key" ]; then
+			mv "$tmp_dir/probe_key.pub" "$PUB_KEY_FILE"
+			mv "$tmp_dir/probe_key" "$PRIV_KEY_FILE"
+			rm -rf "$tmp_dir"
+			print_msg "Info: public and private key loaded from backup"
+		else
+			print_msg "Error: Could not extract probe_key or probe_key form backup archive"
+			rm -rf "$tmp_dir"
+			exit 1
+		fi
+	else
+		print_msg "Error: Provided backup file $backup_arch does not exists"
+		exit 1
+	fi
+}
+
+create_backup() {
+	local back_dir
+
+	back_dir="$(pwd)"
+
+	if [ -f "$PUB_KEY_FILE" -a -f "$PRIV_KEY_FILE" ]; then
+		print_msg "Info: Creating backup arch in $back_dir"
+		tar -czf "$back_dir/atlas-key-backup.tar.gz" -C "$SCRIPTS_DIR/etc" probe_key probe_key.pub
+	else
+		print_msg "Error: private or public key does not exists."
+		exit 1
+	fi
+}
+
+log() {
+	if [ -f "$LOG_FILE" ];then
+		tail "$LOG_FILE"
+	else
+		print_msg "Error. No log file found. Probe isn't probably running"
+		exit 1
+	fi
+}
+
+get_key() {
+	if [ -f "$PUB_KEY_FILE" ]; then
+		echo "Probe public key (use for registration)"
+		echo "URL with registration form https://atlas.ripe.net/apply/swprobe/"
+		echo "=========================================="
+		cat "$PUB_KEY_FILE"
+	else
+		print_msg "Error! Pub. key not found"
+		exit 1
+	fi
+}
+
+probeid() {
+	local probe_id
+
+	if [ -f "$PROBE_ID_FILE" ]; then
+		probe_id="$(awk '/PROBE_ID/ {print $2}' "$PROBE_ID_FILE")"
+		if [ -z "$probe_id" ]; then
+			print_msg "Probe ID not found SW probe isn't probably registered yet"
+			exit 1
+		else
+			print_msg "Probe ID is $probe_id"
+		fi
+	else
+		print_msg "Probe ID not found. SW probe is not running or probe_key isn't registered yet"
+		exit 1
+	fi
+}
+
+print_msg() {
+	echo "$1" >&2
+	logger -t atlas-sw-probe "$1"
+}
+
+stop_service() {
+	local atlas_pid
+	local tunnel_pid
+	local pid_file
+
+	print_msg "Stopping atlas sw probe"
+	print_msg "Kill all atlas processes"
+
+	for pid_file in "$SCRIPTS_DIR/run/"*.vol; do
+		[ -f "$pid_file" ] || continue
+		# test if proccess is still running
+		atlas_pid="$(cat "$pid_file")"
+		if kill -0 "$atlas_pid" 2>/dev/null; then
+			kill "$atlas_pid"
+		fi
+	done
+
+	if [ -f "$SCRIPTS_DIR/status/con_keep_pid.vol" ]; then
+		print_msg "Kill ssh tunnel"
+		tunnel_pid="$(cat "$SCRIPTS_DIR/status/con_keep_pid.vol")"
+		if kill -0 "$tunnel_pid" 2>/dev/null; then
+			kill "$tunnel_pid"
+		fi
+	fi
+}
+
+safe_mkdir() {
+    local dir="$1"
+    if [ -e "$dir" ] && [ ! -d "$dir" -o -L "$dir" ]; then
+        rm -rf "$dir"
+    fi
+    mkdir -p "$dir"
+    chmod 700 "$dir"
+    chown root:root "$dir"
+}
+
+create_tmp_dirs() {
+	local dirs
+
+	chown -R atlas:atlas "$SCRIPTS_DIR/bin"
+	chmod 755 "$SCRIPTS_DIR/bin"
+	dirs='crons data run status'
+
+	safe_mkdir "$TMP_BASE_DIR"
+	for i in $dirs;	do
+		safe_mkdir "$TMP_BASE_DIR/$i"
+	done
+}
+
+start_service() {
+	local log_stderr
+	local log_stdout
+	local rxtxrpt
+	local test_setting
+
+	create_tmp_dirs
+
+	config_load atlas
+	config_get_bool log_stderr "common" log_stderr "0"
+	config_get_bool log_stdout "common" log_stdout "0"
+	config_get_bool rxtxrpt "common" rxtxrpt "1"
+	test_setting=$(grep "^[ 	]*RXTXRPT=yes" "$STATE_CONFIG")
+
+	# Decide if we should write to permanent storage
+	if [ "$rxtxrpt" == "1" ] &&  [ -z "$test_setting" ]; then
+		echo "RXTXRPT=yes">$STATE_CONFIG
+	elif [ "$rxtxrpt" == "0" ] &&  [ ! -z "$test_setting" ]; then
+		echo "RXTXRPT=no">$STATE_CONFIG
+	fi
+
+	procd_open_instance
+	procd_set_param command "$SCRIPTS_DIR/bin/ATLAS"
+	procd_set_param stdout "$log_stdout"
+	procd_set_param stderr "$log_stderr"
+	procd_close_instance
+}

--- a/net/atlas-sw-probe/files/atlas_rpcd.sh
+++ b/net/atlas-sw-probe/files/atlas_rpcd.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+SCRIPTS_DIR="/usr/libexec/atlas-probe-scripts"
+TMP_BASE_DIR="/tmp/ripe_atlas_probe"
+PUB_KEY_FILE="$SCRIPTS_DIR/etc/probe_key.pub"
+PRIV_KEY_FILE="$SCRIPTS_DIR/etc/probe_key"
+PROBE_ID_FILE="$TMP_BASE_DIR/status/reg_init_reply.txt"
+
+get_atlas_public_key() {
+	local pub_key
+
+	if [ -f "$PUB_KEY_FILE" ]; then
+		pub_key=$(cat "$PUB_KEY_FILE")
+	fi
+
+	echo "{"
+	echo \"pub-key\":\"$pub_key\"
+	echo "}"
+}
+
+get_atlas_probeid() {
+	local probe_id
+
+	if /etc/init.d/atlas probeid 2>/dev/null; then
+		probe_id="$(awk '/PROBE_ID/ {print $2}' "$PROBE_ID_FILE")"
+	fi
+
+	echo "{"
+	echo \"probe-id\":\"$probe_id\"
+	echo "}"
+}
+
+get_reg_info() {
+	local pub_ip
+	local asn
+	local asn_org
+
+	if [ -z "$pub_ip" ]; then
+		pub_ip="$(dig -4 TXT +short o-o.myaddr.l.google.com @ns1.google.com|tr -d '"')"
+	fi
+
+	echo "{"
+	echo \"public-ipv4\":\"$pub_ip\"
+	echo "}"
+}
+
+get_status() {
+	local status
+
+	status="$(/etc/init.d/atlas status)"
+	echo "{"
+	echo \"status\":\"$status\"
+	echo "}"
+}
+
+case "$1" in
+	list)
+		echo '{'
+		echo ' "pub-key": {},'
+		echo ' "probe-id": {},'
+		echo ' "reg-info": {}'
+		echo ' "status": {}'
+		echo '}'
+	;;
+	call)
+		case "$2" in
+			pub-key)
+				get_atlas_public_key
+			;;
+			probe-id)
+				get_atlas_probeid
+			;;
+			reg-info)
+				get_reg_info
+			;;
+			get-status)
+				get_status
+			;;
+		esac
+	;;
+esac

--- a/net/atlas-sw-probe/patches/001-fix-config-path.patch
+++ b/net/atlas-sw-probe/patches/001-fix-config-path.patch
@@ -1,0 +1,14 @@
+--- a/bin/ATLAS
++++ b/bin/ATLAS
+@@ -7,9 +7,9 @@
+ #exec >/tmp/ATLAS.out 2>/tmp/ATLAS.err
+ #set -x
+ 
+-if [ -f bin/config.sh ]
++if [ -f /usr/libexec/atlas-probe-scripts/bin/config.sh ]
+ then
+-	. bin/config.sh
++	. /usr/libexec/atlas-probe-scripts/bin/config.sh
+ 	export DEVICE_NAME SUB_ARCH ATLAS_STATIC
+ else
+ 	echo no 'bin/config.sh' >&2


### PR DESCRIPTION
Maintaier: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt maser

Description:
This PR adds new package atlas-sw-probe and its dependency atlas-probe.  

> RIPE Atlas employs a global network of probes that measure Internet connectivity and reachability, providing an unprecedented understanding of the state of the Internet in real time.

 https://labs.ripe.net/Members/alun_davies/ripe-atlas-software-probes