### PR TITLE
xray-core: Update to 1.4.2

### DIFF
--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-core
-PKG_VERSION:=1.4.1
+PKG_VERSION:=1.4.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/XTLS/Xray-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=0dfedb6e133f431e9588a84b7a36112e058bf09ced2d10ffe603ab0db6610430
+PKG_HASH:=565255d8c67b254f403d498b9152fa7bc097d649c50cb318d278c2be644e92cc
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MPL-2.0
@@ -80,24 +80,24 @@ define Package/xray-core/conffiles
 /etc/config/xray
 endef
 
-GEOIP_VER:=202103250007
+GEOIP_VER:=202104010913
 GEOIP_FILE:=geoip.dat.$(GEOIP_VER)
 
 define Download/geoip
   URL:=https://github.com/v2fly/geoip/releases/download/$(GEOIP_VER)/
   URL_FILE:=geoip.dat
   FILE:=$(GEOIP_FILE)
-  HASH:=eca0b25e528167dbdec6c130b6a5240284ce20b28158d1448f8dbeddace2e8cf
+  HASH:=f94e464f7f37e6f3c88c2aa5454ab02a4b840bc44c75c5001719a618916906cf
 endef
 
-GEOSITE_VER:=20210330120529
+GEOSITE_VER:=20210401091829
 GEOSITE_FILE:=dlc.dat.$(GEOSITE_VER)
 
 define Download/geosite
   URL:=https://github.com/v2fly/domain-list-community/releases/download/$(GEOSITE_VER)/
   URL_FILE:=dlc.dat
   FILE:=$(GEOSITE_FILE)
-  HASH:=e7f41feadae73854a2e2103aa5e09f3e8d6ed924391e3963d3b1a67ef61d6ad2
+  HASH:=ee9778dc00b703905ca1f400ad13dd462eae52c5aee6465f0a7543b0232c9d08
 endef
 
 define Build/Prepare

--- a/net/xray-core/files/xray.conf
+++ b/net/xray-core/files/xray.conf
@@ -7,5 +7,6 @@ config xray 'config'
 	option confdir '/etc/xray'
 	list conffiles '/etc/xray/config.json'
 	option datadir '/usr/share/xray'
+	option dialer ''
 	option format 'json'
 

--- a/net/xray-core/files/xray.init
+++ b/net/xray-core/files/xray.init
@@ -17,12 +17,14 @@ start_service() {
 	local confdir
 	local conffiles
 	local datadir
+	local dialer
 	local format
 	local fullcone
 
 	config_get confdir "config" "confdir"
 	config_get conffiles "config" "conffiles"
 	config_get datadir "config" "datadir" "/usr/share/xray"
+	config_get dialer "config" "dialer"
 	config_get format "config" "format" "json"
 	config_get fullcone "enabled" "fullcone" "0"
 
@@ -35,7 +37,8 @@ start_service() {
 			procd_append_param command -config "$i"
 		done
 	}
-	procd_append_param command -format "$format"
+	[ -n "$format" ] && procd_append_param command -format "$format"
+	[ -n "$dialer" ] && procd_set_param env XRAY_BROWSER_DIALER="$dialer"
 	[ "$fullcone" -eq "0" ] && procd_set_param env XRAY_CONE_DISABLED="true"
 	procd_set_param env XRAY_LOCATION_ASSET="$datadir"
 	procd_set_param file $conffiles


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip, x86_64
Run tested: rockchip nanopi-r2s

Description:
- Updated core to 1.4.2, which includes a hotfix for uTLS (uTLS fingerprints disguising doesn't work).
- Updated geodata to latest version.
- Added `WSS Browser Dialer` support in init:
Since v1.4.1, Xray has introduced a new feature to transfer data via browsers, which can disguise itself as a normal browser to cheat network censorship.
For more details, see XTLS/Xray-core#421.
