### PR TITLE
mosh: Fix for building mosh by adding libprotobuf-c to the dependency list

### DIFF
--- a/net/mosh/Makefile
+++ b/net/mosh/Makefile
@@ -29,7 +29,7 @@ define Package/mosh/Default
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Mosh mobile shell
-  DEPENDS:=+libncursesw +libopenssl +protobuf
+  DEPENDS:=+libncursesw +libopenssl +protobuf +libprotobuf-c
   URL:=https://mosh.org/
 endef
 


### PR DESCRIPTION
Signed-off-by: Arne Zachlod <arne@nerdkeller.org>

Maintainer:@neheb 
Compile tested: ramips, erx, master

Description:
mosh doesn't build and fails with libprotobuf not found without this patch.