### PR TITLE
lualanes: build with CMake

### DIFF
--- a/lang/lualanes/Makefile
+++ b/lang/lualanes/Makefile
@@ -9,19 +9,21 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lualanes
 PKG_VERSION:=3.13.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/LuaLanes/lanes/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=53a17d7ee11f17ca0543ae5aa640208dcb62d37862a0d0ea450455fae12c8ff1
 PKG_BUILD_DIR:=$(BUILD_DIR)/lanes-$(PKG_VERSION)
 
-PKG_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
+PKG_MAINTAINER:=Vladimir Malyutin <first-leon@yandex.ru>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=COPYRIGHT
 
 PKG_BUILD_DEPENDS:=lua/host
 
 include $(INCLUDE_DIR)/package.mk
+include ../../devel/ninja/ninja-cmake.mk
 
 define Package/lualanes
 	SUBMENU:=Lua
@@ -30,7 +32,6 @@ define Package/lualanes
 	TITLE:=LuaLanes
 	URL:=http://lualanes.github.io/lanes/
 	DEPENDS:=+lua +luac +liblua +libpthread
-	MAINTAINER:=Vladimir Malyutin <first-leon@yandex.ru>
 endef
 
 define Package/lualanes/description
@@ -46,21 +47,11 @@ extension modules should work seamlessly together with the multiple lanes.
 Lanes supports Lua 5.1, 5.2 and 5.3
 endef
 
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) all \
-        CC="$(TARGET_CC)" \
-        LUA="$(STAGING_DIR_HOSTPKG)/bin/lua" \
-        LUAC="$(STAGING_DIR_HOSTPKG)/bin/luac" \
-	LUA_FLAGS= \
-	LUA_LIBS=-llua \
-        OPT_FLAGS="$(TARGET_CFLAGS) -Dpthread_yield=sched_yield"
-endef
-
 define Package/lualanes/install
 	$(INSTALL_DIR) $(1)/usr/lib/lua
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/lanes.lua $(1)/usr/lib/lua/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/lua/lmod/lanes.lua $(1)/usr/lib/lua/
 	$(INSTALL_DIR) $(1)/usr/lib/lua/lanes
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/src/lanes/core.so $(1)/usr/lib/lua/lanes/core.so
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/lua/cmod/core.so $(1)/usr/lib/lua/lanes/core.so
 endef
 
 $(eval $(call BuildPackage,lualanes))

--- a/lang/lualanes/patches/100-musl-compat.patch
+++ b/lang/lualanes/patches/100-musl-compat.patch
@@ -5,7 +5,7 @@
    #include <pthread.h>
  
 -  #ifdef PLATFORM_LINUX
-+  #if defined(PLATFORM_LINUX) && defined(__UCLIBC__)
++  #if defined(PLATFORM_LINUX) && defined(__GLIBC__)
    # define _MUTEX_RECURSIVE PTHREAD_MUTEX_RECURSIVE_NP
    #else
      /* OS X, ... */


### PR DESCRIPTION
Faster to compile.

Add license information.

Several cleanups for consistency between packages.

Small patch fix now that uClibc-ng is gone.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @first-leon 
Compile tested: mips64el