### PR TITLE
xinetd: honor ${IPKG_INSTROOT} when sourcing /lib/functions.sh

### DIFF
--- a/net/xinetd/Makefile
+++ b/net/xinetd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xinetd
 PKG_VERSION:=2.3.15
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/xinetd-org/xinetd/archive

--- a/net/xinetd/files/xinetd.init
+++ b/net/xinetd/files/xinetd.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2006-2011 OpenWrt.org
 
-. /lib/functions.sh
+. ${IPKG_INSTROOT}/lib/functions.sh
 
 START=50
 STOP=10


### PR DESCRIPTION
Maintainer: @feckert 

Avoid "file not found"-error when embedding via Imagebuilder.
