### PR TITLE
nut: fix typo in nutshutdown script

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=21
+PKG_RELEASE:=22
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/

--- a/net/nut/files/nutshutdown
+++ b/net/nut/files/nutshutdown
@@ -24,7 +24,7 @@ do_fsd() {
 		mount -o remount,ro /overlay /overlay
 		mount -o remount,ro / /
 
-		. ${IPKG_INSTOOT}/lib/functions.sh
+		. ${IPKG_INSTROOT}/lib/functions.sh
 
 		if [ -f /etc/config/nut_server ]; then
 			config_load nut_server


### PR DESCRIPTION
Maintainer: @neheb, @micmac1 

Description: Even it's only cosmetic and should not affect the function of regular system, fix the name of the IPKG_INSTROOT variable.