### PR TITLE
strongswan: remove synthesized ipsec conf files

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.1
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/ipsec.init
+++ b/net/strongswan/files/ipsec.init
@@ -331,6 +331,12 @@ reload_service() {
 	start
 }
 
+stop_service() {
+	ipsec_reset
+	swan_reset
+	secret_reset
+}
+
 check_ipsec_interface() {
 	local intf
 


### PR DESCRIPTION
Maintainer: me, @Thermi
Compile tested: x86_64, generic, head (85fa8ad8af)
Run tested: same, installed on a VM

Description:

When stopping the `ipsec` service, clear (set to empty) the files `/var/ipsec/ipsec.secrets`, `/var/ipsec/ipsec.conf`, and `/var/ipsec/strongswan.conf` so that Charon doesn't load them when the `swanctl` service is started.