### PR TITLE
python-dotenv: update to v0.17.0

### DIFF
--- a/lang/python/python-dotenv/Makefile
+++ b/lang/python/python-dotenv/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dotenv
-PKG_VERSION:=0.15.0
+PKG_VERSION:=0.17.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=python-dotenv
-PKG_HASH:=587825ed60b1711daea4832cf37524dfd404325b7db5e25ebe88c495c9f807a0
+PKG_HASH:=471b782da0af10da1a80341e8438fca5fadeba2881c54360d5fd8d03d03a4f4a
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
Small upstream update.