### PR TITLE
udp-broadcast-relay-redux: Add package

### DIFF
--- a/net/udp-broadcast-relay-redux-openwrt/Makefile
+++ b/net/udp-broadcast-relay-redux-openwrt/Makefile
@@ -1,0 +1,49 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=udp-broadcast-relay-redux
+PKG_RELEASE:=$(AUTORELEASE)
+PKG_LICENSE:=GPL-2.0
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/udp-redux/udp-broadcast-relay-redux
+PKG_SOURCE_DATE:=2021-04-05
+PKG_SOURCE_VERSION:=671372938b55a186625a80516f86e8b9948c977a
+PKG_MIRROR_HASH:=11cf8728f2b8e966f4f57032d817a889f680ed8e61afff35b52ca9c6789a03c6
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/udp-broadcast-relay-redux
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  TITLE:=listens for packets on a specified UDP broadcast port and replays them
+  URL:=https://github.com/udp-redux/udp-broadcast-relay-redux
+endef
+
+define Package/udp-broadcast-relay-redux/description
+	This program listens for packets on a specified UDP broadcast port.
+	When a packet is received, it sends that packet to all specified interfaces but
+	the one it came from as though it originated from the original sender.
+	The primary purpose of this is to allow games on machines on separated
+	local networks (Ethernet, WLAN) that use udp broadcasts to find each other to do so.
+	It also works on ppp links, so you can log in from windows boxes (e.g. using pptp)
+	and play LAN-based games together. Currently, you have to care about upcoming or
+	downgoing interfaces yourself.
+endef
+
+define Package/udp-broadcast-relay-redux/conffiles
+/etc/config/udp_broadcast_relay_redux
+endef
+
+define Build/Compile
+	$(TARGET_CC) $(TARGET_CFLAGS) $(PKG_BUILD_DIR)/main.c -o $(PKG_BUILD_DIR)/$(PKG_NAME)
+endef
+
+define Package/udp-broadcast-relay-redux/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/config $(1)/etc/init.d
+	$(CP) $(PKG_BUILD_DIR)/$(PKG_NAME) $(1)/usr/sbin/
+	$(INSTALL_CONF) ./files/udp_broadcast_relay_redux.config $(1)/etc/config/udp_broadcast_relay_redux
+	$(INSTALL_BIN) ./files/udp-broadcast-relay-redux.init $(1)/etc/init.d/udp-broadcast-relay-redux
+endef
+
+$(eval $(call BuildPackage,udp-broadcast-relay-redux))

--- a/net/udp-broadcast-relay-redux-openwrt/files/udp-broadcast-relay-redux.init
+++ b/net/udp-broadcast-relay-redux-openwrt/files/udp-broadcast-relay-redux.init
@@ -1,0 +1,76 @@
+#!/bin/sh /etc/rc.common
+
+START=90
+STOP=10
+
+USE_PROCD=1
+PROG=/usr/sbin/udp-broadcast-relay-redux
+NAME=udp-broadcast-relay-redux
+PIDCOUNT=0
+
+validate_section_udp_broadcast_relay_redux()
+{
+    uci_validate_section udp_broadcast_relay_redux udp_broadcast_relay_redux "${1}" \
+	'id:uinteger' \
+	'port:port' \
+	'network:list(string)' \
+	'src_override:ip4addr' \
+	'dest_override:ip4addr'
+
+    [ -z "$id" ] && return 1
+
+    [ -z "$network" ] && return 1
+
+    [ -z "$port" ] && return 1
+
+    return 0
+}
+
+udp_broadcast_relay_redux_instance() {
+    local net network ifname id port src_override dest_override
+
+    validate_section_udp_broadcast_relay_redux "${1}" || {
+	echo "Validation failed"
+	return 1
+    }
+
+    PIDCOUNT="$((PIDCOUNT + 1))"
+
+    procd_open_instance
+    procd_set_param command "$PROG" "--id" "${id}" "--port" "${port}"
+
+    for net in $network; do
+	network_get_device ifname "$net"
+	if [ -z "$ifname" ]; then
+	    network_get_physdev ifname "$net"
+	fi
+	if [ -n "$ifname" ]; then
+	    procd_append_param command "--dev" "$ifname"
+	    procd_append_param netdev "$ifname"
+	fi
+    done
+
+    if [ -n "$src_override" ] ; then
+        procd_append_param command "-s" "$src_override"
+    fi
+
+    if [ -n "$dest_override" ] ; then
+        procd_append_param command "-t" "$dest_override"
+    fi
+
+    procd_add_jail ubr-${PIDCOUNT}
+    procd_close_instance
+}
+
+start_service() {
+    . /lib/functions.sh
+    . /lib/functions/network.sh
+
+    config_load udp_broadcast_relay_redux
+    config_foreach udp_broadcast_relay_redux_instance udp_broadcast_relay_redux
+}
+
+service_triggers() {
+    procd_add_reload_trigger "udp_broadcast_relay_redux"
+    procd_add_validation validate_section_udp_broadcast_relay_redux
+}

--- a/net/udp-broadcast-relay-redux-openwrt/files/udp_broadcast_relay_redux.config
+++ b/net/udp-broadcast-relay-redux-openwrt/files/udp_broadcast_relay_redux.config
@@ -1,0 +1,6 @@
+#config udp_broadcast_relay_redux
+#       option id 1
+#       option port 47624
+#       list network lan
+#       list network vpnsrv
+#       option dest_override 10.66.2.13


### PR DESCRIPTION
Add package for udp-broadcast-relay-redux (https://github.com/udp-redux/udp-broadcast-relay-redux). 

Description: This program listens for packets on a specified UDP broadcast port.  When a packet is received, it sends that packet to all specified interfaces but the one it came from as though it originated from the original sender. The primary purpose of this is to allow games on machines on separated local networks (Ethernet, WLAN) that use udp broadcasts to find each other to do so.
It also works on ppp links, so you can log in from windows boxes (e.g. using pptp) and play LAN-based games together. Currently, you have to care about upcoming or downgoing interfaces yourself.

My interest: I found this simple utility to be pretty helpful in forwarding UDP broadcast traffic across two networks joined by tun-based VPN (tun does not support broadcast packets so use --target override on src and dest).

Other info: This commit is largely based on the work from Daniel Dickinson in PR #2096 which was never merged. I tweaked it in a number of ways. All bugs with this package are mine, not his ;-)

Maintainer: me
Compile tested: mvebu, Linksys wrt1200ac, bleeding edge
Compile tested: mvebu, Linksys wrt1200ac, 19.07.7
Run tested: mvebu, Linksys wrt1200ac, bleeding edge, verified binary at least launches
Run tested: mvebu, Linksys wrt1200ac, 19.07.7, verified traffic forwarding works in my home network config

Signed-off-by: Aaron Curley <accwebs@gmail.com>


Caution:  Noob PR. I don't quite know what I'm doing to apologies in advance for clueless questions.  :-) 
Also, I listed myself as maintainer above but didn't put myself in the Makefile.  I can *try* to act as maintainer from this point forward but I don't entirely know what I'm doing.