### PR TITLE
minisatip: add libdvbcsa support

### DIFF
--- a/multimedia/minisatip/Makefile
+++ b/multimedia/minisatip/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=minisatip
 PKG_VERSION:=1.0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/catalinii/minisatip/tar.gz/$(PKG_VERSION)?
@@ -17,6 +17,10 @@ PKG_MAINTAINER:=Daniel Kucera <github@danman.eu>
 PKG_LICENSE:=GPL-2.0-or-later
 
 PKG_BUILD_PARALLEL:=1
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_BUILD_PATENTED \
+	CONFIG_MINISATIP_AES \
+	CONFIG_MINISATIP_CLIENT
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -25,7 +29,7 @@ define Package/minisatip
   URL:=https://github.com/catalinii/minisatip
   SECTION:=multimedia
   CATEGORY:=Multimedia
-  DEPENDS:=+MINISATIP_AES:libopenssl
+  DEPENDS:=+MINISATIP_AES:libopenssl +BUILD_PATENTED:libdvbcsa
 endef
 
 define Package/minisatip/config
@@ -42,13 +46,10 @@ define Package/minisatip/config
 	endif
 endef
 
-ifeq ($(CONFIG_MINISATIP_AES),)
-	CONFIGURE_ARGS += --disable-dvbaes
-endif
-
-ifeq ($(CONFIG_MINISATIP_CLIENT),)
-	CONFIGURE_ARGS += --disable-satipc
-endif
+CONFIGURE_ARGS += \
+	--$(if $(CONFIG_BUILD_PATENTED),en,dis)able-dvbcsa \
+	--$(if $(CONFIG_MINISATIP_AES),en,dis)able-dvbaes \
+	--$(if $(CONFIG_MINISATIP_CLIENT),en,dis)able-satipc
 
 define Package/minisatip/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Unconditionally enable with BUILD_PATENTED.

Simplify configure args.

Add missing PKG_CONFIG_DEPENDS

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @danielkucera 
Compile tested: ath79