### PR TITLE
ksmbd-tools: Add a mDNS TXT record for the ksmbd service

### DIFF
--- a/net/ksmbd-tools/files/ksmbd.init
+++ b/net/ksmbd-tools/files/ksmbd.init
@@ -160,7 +160,7 @@ start_service()
 
 	logger -p daemon.notice -t 'ksmbd' "Starting Ksmbd userspace service."
 	procd_open_instance
-	procd_add_mdns "smb" "tcp" "445"
+	procd_add_mdns "smb" "tcp" "445" "daemon=ksmbd"
 	procd_set_param command /usr/sbin/ksmbd.mountd --n
 	procd_set_param file /etc/ksmbd/smb.conf
 	procd_set_param limits nofile=16384


### PR DESCRIPTION
MacOS ignores Bonjour services for which TXT records are not returned. This changes forces umdns service to return a TXT record (`daemon=ksmbd`) for the ksmbd service. The exact content is unimportant and to the best of my knowledge nothing reads the `daemon` tag.

Symptoms of the problem (which are also debugging steps):
* Finder refuses to open the OpenWRT "computer" in the Network list.
* Discovery.app (Bonjour Browser) lists the _ssh._tcp service, but the submenu for it doesn't unfold and no address is shown.
* `dns-sd -L OpenWrt _smb._tcp` doesn't return any address.

Maintainer: @neheb 
Compile tested: not compiled
Run tested: tl-wr902ac-v3 (mips), OpenWRT 19.07.7, pushed to init.d/ksmbd and ran the tests above on MacOS 11.1