### PR TITLE
haproxy: Update HAProxy to v2.2.13

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=2.2.11
+PKG_VERSION:=2.2.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/2.2/src
-PKG_HASH:=173a98506472bb1ba5a4a7f3a281125163f78bab5793bf6ba1f1d50853eb5f23
+PKG_HASH:=9e3e51441c70bedfb494fc9d4b4d3389a71be9a3c915ba3d6f7e8fd9a57ce160
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Christian Lachner <gladiac@gmail.com>

--- a/net/haproxy/get-latest-patches.sh
+++ b/net/haproxy/get-latest-patches.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CLONEURL=https://git.haproxy.org/git/haproxy-2.2.git
-BASE_TAG=v2.2.11
+BASE_TAG=v2.2.13
 TMP_REPODIR=tmprepo
 PATCHESDIR=patches
 


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Christian Lachner <gladiac@gmail.com>
Compile tested: mips, ipq806x, x86, arc700
Run tested: ipq806x (r7800)

Description: Update HAProxy to v2.2.13
- Update haproxy download URL and hash