### PR TITLE
knot-resolver: update to version 5.3.1

### DIFF
--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -10,12 +10,12 @@ PKG_RELRO_FULL:=0
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot-resolver
-PKG_VERSION:=5.3.0
+PKG_VERSION:=5.3.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-resolver
-PKG_HASH:=fb6cb2c03f4fffbdd8a0098127383d03b14cf7d6abf3a0cd229fb13ff68ee33e
+PKG_HASH:=9d4d6b7bcdf114acc948e5ee68c83fcbb3944f48a13b9751dbbbc190cdd729c9
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=GPL-3.0-later


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates knot-resolve to version 5.3.1. It is bufix release [Changelog](https://www.knot-resolver.cz/2021-03-31-knot-resolver-5.3.1.html)