### PR TITLE
ooniprobe: update to version 3.9.0

### DIFF
--- a/net/ooniprobe/Makefile
+++ b/net/ooniprobe/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ooniprobe
-PKG_VERSION:=3.8.0
+PKG_VERSION:=3.9.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=probe-cli-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ooni/probe-cli/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=65bc4e592cadb99530be713798308d6950f67240bff6d90f2760fde11d750a83
+PKG_HASH:=92dc714472c473352d750d558962734a42894d67407e755f94fed8d099cc8504
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause
@@ -41,11 +41,6 @@ endef
 define Package/ooniprobe/description
   The next generation of  OONI(Open Observatory of Network Interference)
   Probe Command Line Interface.
-endef
-
-define Build/Configure
-	$(call GoPackage/Build/Configure)
-	cd $(PKG_BUILD_DIR) && $(STAGING_DIR_HOSTPKG)/bin/go run $(PKG_BUILD_DIR)/internal/cmd/getresources/getresources.go
 endef
 
 $(eval $(call GoBinPackage,ooniprobe))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates ooniprobe to version 3.9.0 and removes the call for getrecources which is no longer required.
[Changes](https://github.com/ooni/probe-cli/releases/tag/v3.9.0)