### PR TITLE
python-pytest: update to version 6.2.3

### DIFF
--- a/lang/python/python-pytest/Makefile
+++ b/lang/python/python-pytest/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pytest
-PKG_VERSION:=6.2.2
+PKG_VERSION:=6.2.3
 PKG_RELEASE:=1
 
 PYPI_NAME:=pytest
-PKG_HASH:=9d1edf9e7d0b84d72ea3dbcdfd22b35fb543a5e8f2a60092dd578936bf63d7f9
+PKG_HASH:=671238a46e4df0f3498d1c3270e5deb9b32d25134c99b7d75370a68cfbe9b634
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS6), OpenWrt master
Run tested: Turris Omnia (TOS6), OpenWrt master

Description:
This PR updates pytest to version 6.2.3 It fixes issue https://github.com/pytest-dev/pytest/issues/8414 pytest used to create directories under /tmp with world-readable permissions.
