### PR TITLE
netdata: update to version 1.30.0

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
-PKG_VERSION:=1.29.3
-PKG_RELEASE:=2
+PKG_VERSION:=1.30.1
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -18,7 +18,7 @@ PKG_CPE_ID:=cpe:/a:my-netdata:netdata
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netdata/netdata/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8e045ea153db99317a95232d1d7a76711bee46f4bc2666d22e268ff03011aa43
+PKG_HASH:=e05f8b59d283fb2844280455b9481a2f9104730fd77f535312ff2fec40a6bc11
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Maintainers: me, @diizzyy
Compile tested: Turris MOX, mvebu/cortexa53, OpenWrt 19.07.7
Run tested: Turris MOX, mvebu/cortexa53, OpenWrt 19.07.7

Description:
- update to version [1.30.0](https://github.com/netdata/netdata/releases/tag/v1.30.0)

![Screenshot from 2021-04-06 22-38-49](https://user-images.githubusercontent.com/4096468/113775660-5c203500-9729-11eb-9c72-3327bebb1b3c.png)
