### PR TITLE
suricata-update: Initial commit

### DIFF
--- a/net/suricata-update/Makefile
+++ b/net/suricata-update/Makefile
@@ -1,0 +1,48 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=suricata-update
+PKG_VERSION:=1.1.2
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Build/Prepare
+	true
+endef
+
+define Build/Configure
+	true
+endef
+
+define Build/Compile
+	true
+endef
+
+define Package/suricata-update
+    SUBMENU:=Firewall
+    SECTION:=net
+    CATEGORY:=Network
+    DEPENDS:=+suricata6 +python3-pip +python3-yaml
+    TITLE:=OISF Suricata IDS Update Utility
+    URL:=https://www.openinfosecfoundation.org/
+endef
+
+define Package/suricata-update/description
+ Suricata-Update provides updated ruleset lists for the Suricata IDS/IPS/NMS
+endef
+
+define Package/suricata-update/conffiles
+/etc/config/suricata-update
+endef
+
+define Package/suricata-update/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/etc/init.d/suricata-update $(1)/etc/init.d/suricata-update
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/etc/config/suricata-update $(1)/etc/config/suricata-update
+endef
+
+$(eval $(call BuildPackage,suricata-update))
+

--- a/net/suricata-update/files/etc/config/suricata-update
+++ b/net/suricata-update/files/etc/config/suricata-update
@@ -1,0 +1,23 @@
+config suricata-update 'update'
+        option defaultpath '/var/lib/suricata'
+        #option rulespath '/var/lib/rules'
+        option reload 1
+        option enable_sources_on_startup 1
+	option testupdate 0
+        list sources 'et/open'
+        list sources 'oisf/trafficid'
+        list sources 'ptresearch/attackdetection'
+        list sources 'sslbl/ssl-fp-blacklist'
+        list sources 'sslbl/ja3-fingerprints'
+        list sources 'etnetera/aggressive'
+        list sources 'tgreen/hunting'
+
+config source
+        option name 'et/open'
+        option secret 'ashkan'
+
+config source
+        option name 'scwx/security'
+        option secret 'jjjj'
+
+

--- a/net/suricata-update/files/etc/init.d/suricata-update
+++ b/net/suricata-update/files/etc/init.d/suricata-update
@@ -1,0 +1,74 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=10
+
+USE_PROCD=1
+PROG=/usr/bin/suricata-update
+
+validate_suricata_update_section() {
+        uci_load_validate suricata-update suricata-update "$1" "$2" \
+                'rulespath:string' \
+                'defaultpath:string:/var/lib/suricata' \
+                'reload:bool' \
+                'enable_sources_on_startup:bool' \
+		'test_update:bool' \
+                'sources:list(string)'
+
+        # If suricata-update doesn't exist, install it.
+        [ ! -f $PROG ] && \
+            /usr/bin/pip3 install suricata-update && \
+            echo "Suricata-Update is now installed to $PROG" && \
+            echo "Please Restart the suricata-update service" && \
+            exit
+}
+
+enable_list() {
+    suricata-update enable-source $1 -D $defaultpath
+}
+enable_source() {
+    local config="$1"
+    config_get source_name $config name
+    config_get secret $config secret
+}
+
+
+start_suricata_update() {
+        [ "$2" = 0 ] || {
+                echo "validation failed"
+                return 1
+        }
+
+	[ $enable_sources_on_startup -eq "1" ] && {
+	        suricata-update update-sources -D $defaultpath
+	        config_list_foreach update sources enable_list
+	        config_foreach enable_source source
+	}
+	procd_open_instance
+	procd_set_param command $PROG -v
+	[ $defaultpath ] && procd_append_param command -D $defaultpath
+	[ $rulespath ] && procd_append_param command -o $rulespath
+	[ $test_update -eq 0 ] && procd_append_param command --no-test
+	[ $reload -eq 1 ] && procd_append_param command --reload-command "/etc/init.d/suricata restart"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+stop_service()
+{
+        service_stop ${PROG}
+}
+start_service() {
+config_load "suricata"
+validate_suricata_update_section update start_suricata_update
+
+}
+
+service_triggers()
+{
+        procd_add_reload_trigger "suricata-update"
+        procd_add_validation validate_suricata_update_section
+}
+
+


### PR DESCRIPTION
Provide the framework for Suricata-update

Signed-off-by: Donald Hoskins <grommish@gmail.com>

Maintainer: me 
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:

Suricata-update framework, uci config and init.d service entry.

Requires [Suricata6](https://github.com/openwrt/packages/pull/13924)