### PR TITLE
python3-readline: add package

### DIFF
--- a/lang/python/python3-readline/Makefile
+++ b/lang/python/python3-readline/Makefile
@@ -1,0 +1,34 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-readline
+PKG_VERSION:=8.0.0
+PKG_RELEASE:=$(AUTORELEASE)
+
+PYPI_NAME:=gnureadline
+PKG_HASH:=61eef72ed02dad415ede49752e972a1d2bd8c35c1e4464565d7effd806c99476
+
+PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-readline
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Python GNU readline module
+  URL:=https://github.com/ludwigschwardt/python-gnureadline
+  DEPENDS:=+python3 +libreadline +libncurses
+endef
+
+define Package/python3-readline/description
+  The standard Python readline extension linked against the GNU
+  readline library.
+endef
+
+$(eval $(call Py3Package,python3-readline))
+$(eval $(call BuildPackage,python3-readline))
+$(eval $(call BuildPackage,python3-readline-src))

--- a/lang/python/python3-readline/patches/010-link-with-system-libs.patch
+++ b/lang/python/python3-readline/patches/010-link-with-system-libs.patch
@@ -1,0 +1,78 @@
+Links dynamically to system's libreadline/libhistory.
+--- a/setup.py
++++ b/setup.py
+@@ -7,11 +7,6 @@ import subprocess
+ 
+ from setuptools import setup, Extension
+ 
+-if sys.platform == 'win32':
+-    sys.exit('Error: this module is not meant to work on Windows (try pyreadline instead)')
+-elif sys.platform == 'cygwin':
+-    sys.exit('Error: this module is not needed for Cygwin (and probably does not compile anyway)')
+-
+ here = os.path.abspath(os.path.dirname(__file__))
+ README = open(os.path.join(here, 'README.rst')).read()
+ NEWS = open(os.path.join(here, 'NEWS.rst')).read()
+@@ -47,7 +42,6 @@ DEFINE_MACROS = [
+     ('HAVE_RL_RESIZE_TERMINAL', None),
+ ]
+ 
+-
+ def which_shell():
+     valid_paths = ["/bin/bash", "/usr/local/bin/bash", "/bin/sh"]
+     for path in valid_paths:
+@@ -55,33 +49,18 @@ def which_shell():
+             return path
+     raise IOError("No Shell Found")
+ 
+-
+ # Check if any of the distutils commands involves building the module,
+ # and check for quiet vs. verbose option
+ building = False
+ verbose = True
+ for s in sys.argv[1:]:
+-    if s.startswith('bdist') or s.startswith('build') or s.startswith('install'):
+-        building = True
++#    if s.startswith('bdist') or s.startswith('build') or s.startswith('install'):
++#        building = True
+     if s in ['--quiet', '-q']:
+         verbose = False
+     if s in ['--verbose', '-v']:
+         verbose = True
+ 
+-# Build readline first, if it is not there and we are building the module
+-if building and not os.path.exists('readline/libreadline.a'):
+-    shell_path = which_shell()
+-    if verbose:
+-        print("\n============ Building the readline library ============\n")
+-        os.system('cd rl && %s ./build.sh' % shell_path)
+-        print("\n============ Building the readline extension module ============\n")
+-    else:
+-        os.system('cd rl && %s ./build.sh > /dev/null 2>&1' % shell_path)
+-    # Add symlink that simplifies include and link paths to real library
+-    if not (os.path.exists('readline') or os.path.islink('readline')):
+-        os.symlink(os.path.join('rl', 'readline-lib'), 'readline')
+-
+-
+ # Workaround for OS X 10.9.2 and Xcode 5.1+
+ # The latest clang treats unrecognized command-line options as errors and the
+ # Python CFLAGS variable contains unrecognized ones (e.g. -mno-fused-madd).
+@@ -104,7 +83,6 @@ class build_ext_subclass(build_ext):
+                     ext.extra_compile_args += ['-Wno-error=unused-command-line-argument-hard-error-in-future']
+         build_ext.build_extensions(self)
+ 
+-
+ # First try version-specific readline.c, otherwise fall back to major-only version
+ source = os.path.join('Modules', '%d.%d' % sys.version_info[:2], 'readline.c')
+ if not os.path.exists(source):
+@@ -127,8 +105,8 @@ setup(
+                   sources=[source],
+                   include_dirs=['.'],
+                   define_macros=DEFINE_MACROS,
+-                  extra_objects=['readline/libreadline.a', 'readline/libhistory.a'],
+-                  libraries=['ncurses']
++                  extra_objects=[],
++                  libraries=['ncurses', 'readline', 'history']
+                   ),
+     ],
+     zip_safe=False,


### PR DESCRIPTION
Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>

Maintainer: Oskari Rauta / @oskarirauta
Compile tested: x86_64, xeon powered server, recent OpenWRT snapshot
Run tested: x86_64, xeon powered server, recent OpenWRT snapshot

Description:
Python wrapper to libreadline

Includes patch that allows it to compile without issues and instead of static link, links dynamically against system's libreadline- although, author never said or claimed that there would be any static linking anywhere..