### PR TITLE
[21.02] safe-search: check for changed IP addresses weekly

### DIFF
--- a/net/safe-search/Makefile
+++ b/net/safe-search/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=safe-search
 PKG_VERSION:=2.0.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=MIT
 PKG_MAINTAINER:=Gregory L. Dietsche <Gregory.Dietsche@cuw.edu>
 
@@ -54,7 +54,7 @@ endef
 define Package/safe-search/postinst
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
-  echo "0 * * * * /bin/nice /usr/sbin/safe-search-maintenance>/dev/null 2>&1">>/etc/crontabs/root
+  echo "1 1 * * 1 /bin/nice /usr/sbin/safe-search-maintenance>/dev/null 2>&1">>/etc/crontabs/root
   /etc/init.d/cron restart
 fi
 exit 0


### PR DESCRIPTION
I am the maintainer of this package.
I'd like to get this fix into 21.02:

cherry-pick 7164ccf1553a990d8823bc545d970334fa0cd32e into the openwrt-21.02 release branch.

Thanks!
Greg