### PR TITLE
python3-dbus: add package

### DIFF
--- a/lang/python/python3-dbus/Makefile
+++ b/lang/python/python3-dbus/Makefile
@@ -30,7 +30,7 @@ define Package/python3-dbus/description
   the reference implementation of the D-Bus protocol.
 endef
 
-PYTHON3_PKG_SETUP_ARGS=
+PYTHON3_PKG_SETUP_ARGS:=
 
 CONFIGURE_VARS += \
 	PYTHON_LIBS="-L$(PYTHON3_LIB_DIR) -L$(STAGING_DIR)/usr/lib -lpython$(PYTHON3_VERSION)" \

--- a/lang/python/python3-dbus/Makefile
+++ b/lang/python/python3-dbus/Makefile
@@ -1,0 +1,51 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-dbus
+PKG_VERSION:=1.2.16
+PKG_RELEASE:=$(AUTORELEASE)
+
+PYPI_NAME:=dbus-python
+PKG_HASH:=11238f1d86c995d8aed2e22f04a1e3779f0d70e587caffeab4857f3c662ed5a4
+
+PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_FIXUP:=patch-libtool
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/python3-dbus
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Python bindings for libdbus
+  DEPENDS:=$(INTL_DEPENDS) +libdbus +glib2 +python3
+endef
+
+define Package/python3-dbus/description
+  dbus-python is the original Python binding for dbus,
+  the reference implementation of the D-Bus protocol.
+endef
+
+PYTHON3_PKG_SETUP_ARGS=
+
+CONFIGURE_VARS += \
+	PYTHON_LIBS="-L$(PYTHON3_LIB_DIR) -L$(STAGING_DIR)/usr/lib -lpython$(PYTHON3_VERSION)" \
+	PYTHON_INCLUDES="-I$(PYTHON3_INC_DIR)"
+
+CONFIGURE_ARGS += \
+	--disable-installed-tests
+
+define Py3Build/Compile
+	$(call Py3Build/Compile/Default)
+	$(MAKE_VARS) $(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) $(MAKE_FLAGS) \
+		DESTDIR="$(PKG_INSTALL_DIR)" install
+	$(RM) $(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON3_VERSION)/site-packages/*.la
+endef
+
+$(eval $(call Py3Package,python3-dbus))
+$(eval $(call BuildPackage,python3-dbus))
+$(eval $(call BuildPackage,python3-dbus-src))

--- a/lang/python/python3-dbus/patches/010-keep-config.patch
+++ b/lang/python/python3-dbus/patches/010-keep-config.patch
@@ -1,0 +1,47 @@
+--- a/setup.py
++++ b/setup.py
+@@ -25,10 +25,10 @@
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ # DEALINGS IN THE SOFTWARE.
+ 
+-from distutils.dir_util import copy_tree, mkpath
+-from distutils.file_util import copy_file
+ from setuptools.dist import Distribution
+ from setuptools import setup, Extension
++from distutils.dir_util import copy_tree, mkpath
++from distutils.file_util import copy_file
+ import os
+ import subprocess
+ import sys
+@@ -47,27 +47,16 @@ class Build(Distribution().get_command_c
+     def run(self):
+         srcdir = os.getcwd()
+         builddir = os.path.join(srcdir, self.build_temp)
+-        configure = os.path.join(srcdir, 'configure')
+         mkpath(builddir)
+ 
+-        if not os.path.exists(configure):
+-            configure = os.path.join(srcdir, 'autogen.sh')
+-
+-        subprocess.check_call([
+-                configure,
+-                '--disable-maintainer-mode',
+-                'PYTHON=' + sys.executable,
+-                # Put the documentation, etc. out of the way: we only want
+-                # the Python code and extensions
+-                '--prefix=' + os.path.join(builddir, 'prefix'),
+-            ],
+-            cwd=builddir)
+         make_args = [
+             'pythondir=' + os.path.join(srcdir, self.build_lib),
+             'pyexecdir=' + os.path.join(srcdir, self.build_lib),
++            'DESTDIR=' + os.path.join(srcdir, 'ipkg-install'),
+         ]
+-        subprocess.check_call(['make', '-C', builddir] + make_args)
+-        subprocess.check_call(['make', '-C', builddir, 'install'] + make_args)
++
++        subprocess.check_call(['make', '-C', srcdir] + make_args)
++        #subprocess.check_call(['make', '-C', srcdir, 'install'] + make_args)
+ 
+ class BuildExt(Distribution().get_command_class('build_ext')):
+     def run(self):


### PR DESCRIPTION
Signed-off-by: Oskari Rauta oskari.rauta@gmail.com

Maintainer: Oskari Rauta / @oskarirauta
Compile tested: x86_64, xeon powered server, recent OpenWRT snapshot
Run tested: x86_64, xeon powered server, recent OpenWRT snapshot

Description:
libdbus1 bindings for python
Replaces #15365

Package python3-notify2, #15374 needs this.