### PR TITLE
safe-search: prevent duplicate cron job installation

### DIFF
--- a/net/safe-search/Makefile
+++ b/net/safe-search/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=safe-search
-PKG_VERSION:=2.0.0
-PKG_RELEASE:=3
+PKG_VERSION:=2.0.1
+PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=MIT
 PKG_MAINTAINER:=Gregory L. Dietsche <Gregory.Dietsche@cuw.edu>
 
@@ -54,6 +54,7 @@ endef
 define Package/safe-search/postinst
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
+  crontab -l | grep -v "safe-search-maintenance" | sort | uniq | crontab -
   echo "1 1 * * 1 /bin/nice /usr/sbin/safe-search-maintenance>/dev/null 2>&1">>/etc/crontabs/root
   /etc/init.d/cron restart
 fi


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79, x86
Run tested: latest openwrt snapshot ( r16450-d92a9c97bf  )

Description:
This patch prevents multiple cron jobs from being created to run the
safe-search-maintenance script.

To reproduce this bug, perform the following:
  - Install safe-search
  - Perform an OpenWRT firmware upgrade (choose to preserve user settings so that the crontab stays intact)
  - Install safe-search again

Signed-off-by: Gregory L. Dietsche <gregory.dietsche@cuw.edu>


