### PR TITLE
ocserv：libseccomp doesn't build

### DIFF
--- a/net/ocserv/Makefile
+++ b/net/ocserv/Makefile
@@ -39,7 +39,7 @@ define Package/ocserv
   TITLE:=OpenConnect VPN server
   URL:=http://www.infradead.org/ocserv/
   MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
-  DEPENDS:= +OCSERV_RADIUS:libradcli +OCSERV_HTTP_PARSER:libhttp-parser +OCSERV_SECCOMP:libseccomp +libgnutls +certtool +libncurses +libreadline +OCSERV_PAM:libpam +OCSERV_PROTOBUF:libprotobuf-c +libev +kmod-tun
+  DEPENDS:= +OCSERV_RADIUS:libradcli +OCSERV_HTTP_PARSER:libhttp-parser +(!arc&&OCSERV_SECCOMP):libseccomp +libgnutls +certtool +libncurses +libreadline +OCSERV_PAM:libpam +OCSERV_PROTOBUF:libprotobuf-c +libev +kmod-tun
   USERID:=ocserv=72:ocserv=72
 endef
 


### PR DESCRIPTION
Maintainer: zxlhhyccc zxlhhy@gmail.com
Compile tested: x86_64, xeon powered server, recent OpenWRT snapshot
Run tested: x86_64, xeon powered server, recent OpenWRT snapshot

Description:
Upstream use of libseccomp cannot be built on ARC, causing OCSERV to compile circular references under other architectures. For ARC that relies on OCSERV, do not use libseccomp.

https://github.com/openwrt/packages/issues/15313
