### PR TITLE
strongswan: fix dependency in strongswan-libnttfft

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -377,7 +377,7 @@ endef
 define Package/strongswan-libnttfft
 $(call Package/strongswan/Default)
   TITLE+= nttfft library
-  DEPENDS:= +strongswan
+  DEPENDS:= strongswan
 endef
 
 define Package/strongswan-libnttfft/description


### PR DESCRIPTION
Maintainer: zxlhhyccc zxlhhy@gmail.com
Compile tested: x86_64, xeon powered server, recent OpenWRT snapshot
Run tested: x86_64, xeon powered server, recent OpenWRT snapshot

Description:
Looping applications due to dependency issues
https://github.com/openwrt/packages/issues/15376