### PR TITLE
bonding: accept list of slaves in uci list notation

### DIFF
--- a/net/bonding/Makefile
+++ b/net/bonding/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=proto-bonding
-PKG_VERSION:=2020-03-30
+PKG_VERSION:=2021-04-09
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0


### PR DESCRIPTION
Maintainer: @he-ma 
Compile tested: -
Run tested: -

Description:

Rework the bonding.sh protocol handler to accept slave interface names
encoded in uci list notation. Also replace ifconfig up/down with ip
link calls while we're at it.

Fixes: #11455
Fixes: https://github.com/openwrt/luci/issues/4473
Signed-off-by: Jo-Philipp Wich <jo@mein.io>