### PR TITLE
strongswan: libnttft must not select strongswan

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/
@@ -377,7 +377,7 @@ endef
 define Package/strongswan-libnttfft
 $(call Package/strongswan/Default)
   TITLE+= nttfft library
-  DEPENDS:= +strongswan
+  DEPENDS:= strongswan
 endef
 
 define Package/strongswan-libnttfft/description


### PR DESCRIPTION
Maintainer: @pprindeville, @thermi
Compile tested: none - should not be needed, menuconfig-tested only
Run tested: none

Description:

The strongswan-libnttfft package should not select the strongswan
package, but should depend on it instead.  Otherwise a circular
dependency is created.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>