### PR TITLE
Transfer of boinc 7.16.16 from 21.02 to 19.07

### DIFF
--- a/net/boinc/Makefile
+++ b/net/boinc/Makefile
@@ -1,0 +1,83 @@
+# Copyright 2020 by Christian Dreihsig and Steffen Möller
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=boinc
+PKG_VERSION:=7.16.16
+PKG_VERSION_SHORT:=$(shell echo $(PKG_VERSION)| cut -f1,2 -d.)
+PKG_RELEASE:=1
+
+PKG_SOURCE_DATE:=2020-02-25
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/BOINC/boinc/tar.gz/client_release/$(PKG_VERSION_SHORT)/$(PKG_VERSION)?
+PKG_HASH:=0d5656a9f8ed1048936a5764270848b892d63f27bdb863d0ace447f1eaae6002
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-client_release-$(PKG_VERSION_SHORT)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Christian Dreihsig <christian.dreihsig@t-online.de>, Steffen Moeller <moeller@debian.org>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:boinc_project:boinc
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=0
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/target.mk
+
+define Package/boinc
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=BOINC client
+  DEPENDS:=+curl +bzip2 +libstdcpp +libopenssl +zlib
+  USERID:=boinc:boinc
+  URL:=https://github.com/BOINC/boinc/
+endef
+
+define Package/boinc/description
+  The Berkeley Open Infrastructure for Network Computing (BOINC) is a
+  software platform for distributed computing: several initiatives of
+  various scientific disciplines all compete for the idle time of
+  desktop computers. The developers' web site at the University of
+  Berkeley serves as a common portal to the otherwise independently run
+  projects.
+ 
+  This package provides the BOINC core client program that is
+  required to participate in any project that uses BOINC to control what
+  projects to join and to determine constraints for the computation
+  like the percentage of CPU time. OpenWrt does not
+  provide the graphical BOINC Manager, but you can connect to this
+  machine from the BOINC Manager of your desktop computer.
+endef
+
+CONFIGURE_ARGS += \
+	--disable-server --disable-manager --enable-client --enable-libraries \
+	--disable-boinczip --enable-install-headers --enable-dynamic-client-linkage \
+	--with-boinc-platform=$(REAL_GNU_TARGET_NAME) \
+	--with-boinc-alt-platform=$(ARCH)-$(BOARD)-$(DEVICE_TYPE)-openwrt-$(TARGET_SUFFIX)
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/boinc
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/boinc/* $(1)/usr/include/boinc/
+	$(CP) $(PKG_BUILD_DIR)/*.h $(1)/usr/include/boinc/ # project_specific_defines.h, config.h, version.h, svn_version.h
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.a $(1)/usr/lib/
+endef
+
+define Package/boinc/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.{la,so}* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/boinc-client.init $(1)/etc/init.d/boinc-client
+	$(INSTALL_DIR) $(1)/opt/boinc
+	$(INSTALL_DIR) $(1)/usr/share/boinc
+	$(CP) ./files/global_prefs_override.xml $(1)/usr/share/boinc/global_prefs_override.xml
+	$(CP) ./files/remote_hosts.cfg $(1)/usr/share/boinc/remote_hosts.cfg
+endef
+
+$(eval $(call BuildPackage,boinc))

--- a/net/boinc/files/boinc-client.init
+++ b/net/boinc/files/boinc-client.init
@@ -1,0 +1,53 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+USE_PROCD=1
+
+BOINCEXE_NAME=boinc_client
+BOINCDIR=/opt/boinc/
+PRESETDIR=/usr/share/boinc
+BOINCUSR=boinc
+BOINCEXE_OPTS="--check_all_logins --redirectio --dir $BOINCDIR"
+PID_FILE="/var/run/$BOINCEXE_NAME.pid"
+
+start_service() {
+   # First check that BOINCDIR exists
+   if ! [ -d "$BOINCDIR" ]; then
+      if ! mkdir -p $BOINCDIR 2>/dev/null ; then
+         echo "ERROR: $BOINCDIR doesn't exist and couldn't be created"
+         return 1
+      fi
+   fi
+
+   # adjust some presettings if necessary
+   for f in global_prefs_override.xml remote_hosts.cfg; do
+      if ! [ -f $BOINCDIR/$f ]; then
+         cp $PRESETDIR/$f $BOINCDIR
+      fi
+   done
+
+   # and ensure it is accessible by boinc
+   BOINCDIR_OWNER="$(ls -ld $BOINCDIR | awk '{print $3}')"
+   if [ "$BOINCUSR" != "$BOINCDIR_OWNER" ] ; then
+      chown -R $BOINCUSR:$BOINCUSR $BOINCDIR
+      BOINCDIR_OWNER="$(ls -ld $BOINCDIR | awk '{print $3}')"
+
+      if [ "$BOINCUSR" != "$BOINCDIR_OWNER" ] ; then
+         echo "User boinc can't access $BOINC_DIR"
+         return 3
+      fi
+   fi
+
+   # now use procd to start boinc
+   procd_open_instance $BOINCEXE_NAME
+
+   procd_set_param command $BOINCEXE_NAME
+   procd_append_param command $BOINCEXE_OPTS
+   procd_set_param user $BOINCUSR
+   procd_set_param limits core="unlimited"
+   procd_set_param stdout 1
+   procd_set_param stderr 1
+   procd_set_param pidfile $PID_FILE
+
+   procd_close_instance
+}

--- a/net/boinc/files/global_prefs_override.xml
+++ b/net/boinc/files/global_prefs_override.xml
@@ -1,0 +1,4 @@
+<global_preferences>
+   <max_ncpus_pct>50.000000</max_ncpus_pct>
+   <disk_interval>21600.000000</disk_interval>
+<global_preferences>

--- a/net/boinc/files/remote_hosts.cfg
+++ b/net/boinc/files/remote_hosts.cfg
@@ -1,0 +1,8 @@
+# This file contains a list of hostnames or IP addresses (one per line)
+# of remote hosts, that are allowed to connect and to control the local
+# BOINC core client via GUI RPCs.
+# Lines beginning with a # or a ; are treated like comments and will be
+# ignored.
+#
+#host.example.com
+#192.168.0.180

--- a/net/boinc/patches/001-avoidExtraDependencies
+++ b/net/boinc/patches/001-avoidExtraDependencies
@@ -1,0 +1,13 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -502,8 +502,10 @@ SAH_CHECK_LIB([dl], [dlopen],
+     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
+ SAH_CHECK_LIB([nsl], [gethostbyname],
+     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
++if test "${enable_manager}" = yes ; then
+ SAH_CHECK_LIB([freetype], [fopen],
+     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
++fi
+ SAH_CHECK_LIB([socket], [bind],
+     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
+ SAH_CHECK_LIB([z], [gzopen],

--- a/net/boinc/patches/002-hosttypeRespected
+++ b/net/boinc/patches/002-hosttypeRespected
@@ -1,0 +1,49 @@
+--- a/client/cs_platforms.cpp
++++ b/client/cs_platforms.cpp
+@@ -76,6 +76,21 @@ void CLIENT_STATE::add_platform(const ch
+ //
+ void CLIENT_STATE::detect_platforms() {
+ 
++// if specified - use it
++#ifdef HOSTTYPE
++    add_platform(HOSTTYPE);
++#endif
++
++// if specified - use it
++#ifdef HOSTTYPEALT
++    add_platform(HOSTTYPEALT);
++#endif
++
++// if both the hosttype and its alternative are specified,
++// there is no need to look further and one should go directly
++// to the inspection of the cc_config.xml data
++#if !defined(HOSTTYPE) || !defined(HOSTTYPEALT)
++
+ #if defined(_WIN32) && !defined(__CYGWIN32__)
+ #if defined(_WIN64) && defined(_M_X64)
+     add_platform("windows_x86_64");
+@@ -210,15 +225,6 @@ void CLIENT_STATE::detect_platforms() {
+         add_platform("i686-pc-linux-gnu");
+     }
+ 
+-    if (!(support64 || support32)) {
+-        // Something went wrong. Assume HOSTTYPE and HOSTTYPEALT
+-        // are correct
+-        add_platform(HOSTTYPE);
+-#ifdef HOSTTYPEALT
+-        add_platform(HOSTTYPEALT);
+-#endif
+-    }
+-
+ #elif defined(sun)
+     // Check if we can run 64-bit binaries...
+     // this assumes there isn't a 64-bit only solaris.  (Every 64-bit solaris can run 32 bit binaries)
+@@ -294,6 +300,8 @@ void CLIENT_STATE::detect_platforms() {
+ #endif
+ 
+ #endif
++
++#endif
+ 
+     if (cc_config.no_alt_platform) {
+         PLATFORM p = platforms[0];


### PR DESCRIPTION
Intentionally unchanged from 43d21e650d4409b45ccc2c70fe507a29f783dda3,
i.e. the pull request #14862 from neheb/boi

Maintainer: @smoe 
Compile tested:
 - openwrt-sdk-19.07.7-ipq806x-generic_gcc-7.5.0_musl_eabi.Linux-x86_64
 - openwrt-sdk-19.07.7-mvebu-cortexa9_gcc-7.5.0_musl_eabi.Linux-x86_64

Run tested: ipq806x/arm_cortex-a15_neon-vfpv4 19.07 as shipping with Gluon 2020.2.2 on 10-Apr-2021 17:17:04 .

Description:

This is my attempt to follow the kind instructions of https://github.com/openwrt/packages/issues/12248 to bring BOINC to the masses of OpenWrt. The package itself is just fine, left everything unchanged from what already works on the snapshot (which is how Debian requests it for its backports). I found that for my Freifunk Community a few packages were not installable (like kmod-usb-storage). I prepared https://github.com/freifunk-gluon/gluon/issues/2198, since uncertain about where this problem should be fixed.

Signed-off-by: Steffen Moeller <moeller@debian.org>