### PR TITLE
simple-adblock: update to 1.8.7-3

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.8.7
-PKG_RELEASE:=1
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 PKG_LICENSE:=GPL-3.0-or-later
 
@@ -17,7 +17,7 @@ define Package/simple-adblock
 	CATEGORY:=Network
 	TITLE:=Simple AdBlock Service
 	URL:=https://docs.openwrt.melmac.net/simple-adblock/
-	DEPENDS:=+jshn
+	DEPENDS:=+jshn +wget
 	PKGARCH:=all
 endef
 
@@ -42,7 +42,7 @@ define Package/simple-adblock/install
 	$(INSTALL_BIN) ./files/simple-adblock.init $(1)/etc/init.d/simple-adblock
 	$(SED) "s|^\(PKG_VERSION\).*|\1='$(PKG_VERSION)-$(PKG_RELEASE)'|" $(1)/etc/init.d/simple-adblock
 	$(INSTALL_CONF) ./files/simple-adblock.conf $(1)/etc/config/simple-adblock
-	$(INSTALL_CONF) ./files/simple-adblock.conf.update $(1)/tmp/simple-adblock.conf.update
+	$(INSTALL_DATA) ./files/simple-adblock.conf.update $(1)/tmp/simple-adblock.conf.update
 endef
 
 define Package/simple-adblock/postinst

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -247,6 +247,9 @@ load_package_config() {
 	if is_present 'curl'; then
 		dl_command="curl --insecure --retry $curlRetry --connect-timeout $dlTimeout --silent"
 		dl_flag="-o"
+	elif is_present '/usr/libexec/wget-ssl'; then
+		dl_command="/usr/libexec/wget-ssl --no-check-certificate --timeout $dlTimeout -q"
+		dl_flag="-O"
 	elif is_present wget && wget --version 2>/dev/null | grep -q "+https"; then
 		dl_command="wget --no-check-certificate --timeout $dlTimeout -q"
 		dl_flag="-O"
@@ -882,41 +885,41 @@ start_service() {
 	if [ "$forceDNS" -ne 0 ]; then
 		for c in $forceDNSPorts; do
 			if netstat -tuln | grep LISTEN | grep ":${c}" >/dev/null 2>&1; then
-				json_add_object ''
-				json_add_string type 'redirect'
-				json_add_string target 'DNAT'
-				json_add_string src 'lan'
-				json_add_string proto 'tcp udp'
+				json_add_object ""
+				json_add_string type redirect
+				json_add_string target DNAT
+				json_add_string src lan
+				json_add_string proto "tcp udp"
 				json_add_string src_dport "$c"
 				json_add_string dest_port "$c"
-				json_add_string reflection '0'
+				json_add_boolean reflection 0
 				json_close_object
 			else
-				json_add_object ''
-				json_add_string type 'rule'
-				json_add_string src 'lan'
-				json_add_string dest '*'
-				json_add_string proto 'tcp udp'
+				json_add_object ""
+				json_add_string type rule
+				json_add_string src lan
+				json_add_string dest "*"
+				json_add_string proto "tcp udp"
 				json_add_string dest_port "$c"
-				json_add_string target 'REJECT'
+				json_add_string target REJECT
 				json_close_object
 			fi
 		done
 	fi
 	if [ "$targetDNS" = 'dnsmasq.ipset' ]; then
-		json_add_object ''
-		json_add_string type 'ipset'
-		json_add_string name 'adb'
-		json_add_string match 'dest_net'
-		json_add_string storage 'hash'
+		json_add_object ""
+		json_add_string type ipset
+		json_add_string name adb
+		json_add_string match dest_net
+		json_add_string storage hash
 		json_close_object
-		json_add_object ''
-		json_add_string type 'rule'
-		json_add_string ipset 'adb'
-		json_add_string src 'lan'
-		json_add_string dest '*'
-		json_add_string proto 'tcp udp'
-		json_add_string target 'REJECT'
+		json_add_object ""
+		json_add_string type rule
+		json_add_string ipset adb
+		json_add_string src lan
+		json_add_string dest "*"
+		json_add_string proto "tcp udp"
+		json_add_string target REJECT
 		json_close_object
 	fi
 	json_close_array
@@ -994,11 +997,11 @@ start_service() {
 
 service_started() { procd_set_config_changed firewall; }
 service_stopped() { procd_set_config_changed firewall; }
+
 restart_service() { rc_procd start_service 'restart'; }
-reload_service() { restart_service; }
-restart() { restart_service; }
-reload() { restart_service; }
+reload_service() { rc_procd start_service 'restart'; }
 dl() { rc_procd start_service 'download'; }
+
 killcache() {
 	rm -f "$addnhostsCache" "$addnhostsGzip"
 	rm -f "$dnsmasqCache" "$dnsmasqGzip"


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-105, 21.02-SNAPSHOT r15926
Run tested: x86_64, Sophos SG-105, 21.02-SNAPSHOT r15926, start/stop/dl

Description: This includes:
* detect and use wget-ssl if installed
* depend on `wget` package
* use $(INSTALL_DATA) command instead of $(INSTALL_CONF) for config update file
* proper PROCD firewall data

Signed-off-by: Stan Grishin <stangri@melmac.net>
