### PR TITLE
[21.02] https-dns-proxy: bugfix: race condition with dnsmasq

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2021-01-17
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -110,7 +110,7 @@ start_service() {
 		procd_open_data
 		json_add_array firewall
 		for c in $forceDNSPorts; do
-			if netstat -tuln | grep LISTEN | grep ":${c}" >/dev/null 2>&1; then
+			if netstat -tuln | grep 'LISTEN' | grep ":${c}" >/dev/null 2>&1 || [ "$c" = "53" ]; then
 				json_add_object ""
 				json_add_string type redirect
 				json_add_string target DNAT


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-105, 21.02-SNAPSHOT r15926
Run tested: x86_64, Sophos SG-105, 21.02-SNAPSHOT r15926, start/stop, ensure port 53 requests redirected when dnsmasq is stopped.

Description: This fixes the race condition with dnsmasq (https://github.com/openwrt/packages/issues/15322). If dnsmasq doesn't start before https-dns-proxy, the latter blocks requests to port 53 instead of hijacking them. This fix ensures that requests to port 53 are always hijacked and not blocked. Reported by @rhester72.

Signed-off-by: Stan Grishin <stangri@melmac.net>
