### PR TITLE
node: #14983 NODEJS_ICU_SMALL is default

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
 PKG_VERSION:=v14.16.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
@@ -71,7 +71,7 @@ define Package/node/config
 	if PACKAGE_node
 	choice
 		prompt "i18n features"
-		default NODEJS_ICU_NONE
+		default NODEJS_ICU_SMALL
 		help
 		 Select i18n features
 


### PR DESCRIPTION
Signed-off-by: Robin Rainton <robin@rainton.com>

Maintainer: @nxhack
Compile tested: aarch64, OpenWrt SNAPSHOT r16076-5a3562cd1d
Run tested: aarch64, OpenWrt SNAPSHOT r16076-5a3562cd1d, runs ioBroker just fine

Description:

Re-created due to issues with PR #15005. Apologies.