### PR TITLE
uacme: add use_auto_staging

### DIFF
--- a/net/uacme/files/run.sh
+++ b/net/uacme/files/run.sh
@@ -28,7 +28,7 @@ export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 export NO_TIMESTAMP=1
 
 UHTTPD_LISTEN_HTTP=
-STATE_DIR='/etc/acme'
+PRODUCTION_STATE_DIR='/etc/acme'
 STAGING_STATE_DIR='/etc/acme/staging'
 
 ACCOUNT_EMAIL=
@@ -219,6 +219,8 @@ issue_cert()
     local staging=
     local HOOK=
 
+    # reload uci values, as the value of use_staging may have changed
+    config_load acme
     config_get_bool enabled "$section" enabled 0
     config_get_bool use_staging "$section" use_staging
     config_get_bool update_uhttpd "$section" update_uhttpd
@@ -243,7 +245,13 @@ issue_cert()
     elif [ "$APP" = "acme" ]; then
 	[ "$DEBUG" -eq "1" ] && acme_args="$acme_args --debug"
     fi
-    [ "$use_staging" -eq "1" ] && STATE_DIR="$STAGING_STATE_DIR" && staging="--staging"
+    if [ "$use_staging" -eq "1" ]; then
+	STATE_DIR="$STAGING_STATE_DIR";
+	staging="--staging";
+    else
+	STATE_DIR="$PRODUCTION_STATE_DIR";
+	staging="";
+    fi
 
     set -- $domains
     main_domain=$1
@@ -443,8 +451,8 @@ load_vars()
 {
     local section="$1"
 
-    STATE_DIR=$(config_get "$section" state_dir)
-    STAGING_STATE_DIR=$STATE_DIR/staging
+    PRODUCTION_STATE_DIR=$(config_get "$section" state_dir)
+    STAGING_STATE_DIR=$PRODUCTION_STATE_DIR/staging
     ACCOUNT_EMAIL=$(config_get "$section" account_email)
     DEBUG=$(config_get "$section" debug)
 }
@@ -458,12 +466,12 @@ fi
 config_load acme
 config_foreach load_vars acme
 
-if [ -z "$STATE_DIR" ] || [ -z "$ACCOUNT_EMAIL" ]; then
+if [ -z "$PRODUCTION_STATE_DIR" ] || [ -z "$ACCOUNT_EMAIL" ]; then
     err "state_dir and account_email must be set"
     exit 1
 fi
 
-[ -d "$STATE_DIR" ] || mkdir -p "$STATE_DIR"
+[ -d "$PRODUCTION_STATE_DIR" ] || mkdir -p "$PRODUCTION_STATE_DIR"
 [ -d "$STAGING_STATE_DIR" ] || mkdir -p "$STAGING_STATE_DIR"
 
 trap err_out HUP TERM


### PR DESCRIPTION
Maintainer: @lucize
Compile tested: tested: x86-64, openwrt master (https://github.com/openwrt/openwrt/commit/9397b22df1473f315552578b58322db7f7750361)
Run tested: tested: x86-64, openwrt master (https://github.com/openwrt/openwrt/commit/9397b22df1473f315552578b58322db7f7750361)

Description:

Staging certificates have the advantage that their retry limits are loose.
Therefore they can be obtained quickly when automatic retries are used.
Unfortunately they can not be used for deployments because their CA is not
accepted by clients. Production certificates do not have this limitation, but
their retry limits are strict. For production certificates, automatic retries
can only be performed a few times per hour. This makes automatic obtainment of
certificates tenacious.

With use_auto_staging=1, the advantages of the two certificate types are
combined. Uacme will first obtain a staging certificate. When the staging
certificate is successfully obtained, uacme will switch and obtain a production
certificate. Since the staging certificate has already been successfully
obtained, we can ensure that the production certificate is successfully
obtained in the first attempt. This means that "retries" are performed on the
staging certificate and the production certificate is obtained in the first
attempt.

In summary, this feature enables fast obtaining of production certificates when
automatic retries are used.

By default, this feature is set to use_auto_staging=0, which means that
uacme will behave as before by default.
