### PR TITLE
libseccomp,crun: Fix circular deps

### DIFF
--- a/libs/libseccomp/Makefile
+++ b/libs/libseccomp/Makefile
@@ -56,7 +56,6 @@ endef
 define Package/libseccomp
 $(call Package/libseccomp/Default)
   TITLE+= (library)
-  DEPENDS+= @!arc
 endef
 
 define Package/scmp_sys_resolver

--- a/utils/crun/Makefile
+++ b/utils/crun/Makefile
@@ -26,7 +26,7 @@ define Package/crun
   CATEGORY:=Utilities
   TITLE:=crun
   URL:=https://github.com/containers/crun
-  DEPENDS:=+libseccomp +libcap
+  DEPENDS:=@!arc +libseccomp +libcap
 endef
 
 define Package/crun/description


### PR DESCRIPTION
Maintainer: @oskarirauta, @nmav  
Compile tested: 
Run tested: Tested with `make menuconfig`, on arc, and on mvebu

Description:
There are two commits here.  One reverts b29e609701987072fbd991a9ffc203103f99b943.  Ping @dangowrt 
The other commit fixes the issue in crun that the first one tried to resolve: crun selects package libseccomp, but libseccomp does not build for ARC.  Therefore, crun must also not be build for ARC.

The first commit added a constraint to libseccomp to not build on arc.  However, simply adding `DEPENDS+=@!arc`, as done in the commit being reverted, will cause a circular dependency because some packages select libseccomp based on a build option.

Commit e29483d7e ("libseccomp: workaround a recursive dependency") added a workaround that was not properly documented, so I'll explain here.

The problem arises when libseccomp is selected depending on some config option:
```
define Pakcage/foo
  DEPENDS=+FOO_SECCOMP:libseccomp
```
Even if the condition is correctly defined, excluding arc, such as:
```
define Package/foo/config
  config FOO_SECCOMP
    depends on !arc
```
the config generator will parse libseccomp's `DEPENDS` variable and generate menuconfig statements like these:
```
    config PACKAGE_foo
       select PACKAGE_libseccomp if FOO_SECCOMP
       depends on !FOO_SECCOMP || !arc
```
The last condition is always true because `FOO_SECCOMP` will always be be false when arc is true.  The config generator is not able to simplify/optimize the condition.

The circular dependecy occurs because `FOO_SECCOMP` depends on `PACKAGE_foo`, and the redundant, always true line will make `PACKAGE_foo` depend on `FOO_SECCOMP`.

As a workaround, we can add the `depends on !arc` line to `Package/libseccomp/config`, outside of the `DEPENDS` variable, so that the redundant depends line line does not get generated.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

Ping @neheb