### PR TITLE
node: bump to v14.16.1

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v14.16.0
-PKG_RELEASE:=2
+PKG_VERSION:=v14.16.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=4e7648a617f79b459d583f7dbdd31fbbac5b846d41598f3b54331a5b6115dfa6
+PKG_HASH:=e44adbbed6756c2c1a01258383e9f00df30c147b36e438f6369b5ef1069abac3
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi
 Compile tested: aarch64, arm, i386, x86_64, mipsel (pistachio)
Run tested: (qemu 5.2.0) aarch64, arm, i386, x86_64

Description:
April 2021 Security Releases
- OpenSSL - CA certificate check bypass with X509_V_FLAG_X509_STRICT (High) (CVE-2021-3450)
- OpenSSL - NULL pointer deref in signature_algorithms processing (High) (CVE-2021-3449)
- npm upgrade - Update y18n to fix Prototype-Pollution (High) (CVE-2020-7774)

OpenSSL-related vulnerabilities do not affect the OpenWrt package. Because OpenWrt's OpenSSL shared library has been updated.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
