### PR TITLE
python-greenlet: support MIPS architecture

### DIFF
--- a/lang/python/python-greenlet/Makefile
+++ b/lang/python/python-greenlet/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-greenlet
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=greenlet
 PKG_HASH:=719e169c79255816cdcf6dccd9ed2d089a72a9f6c42273aae12d55e8d35bdcf8
@@ -17,6 +17,8 @@ PKG_HASH:=719e169c79255816cdcf6dccd9ed2d089a72a9f6c42273aae12d55e8d35bdcf8
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
+# FIXME: remove when GCC10 is the oldest supported compiler, or the issue goes away
+PKG_USE_MIPS16:=0
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -31,13 +33,20 @@ define Package/python3-greenlet
   DEPENDS:= \
 	+python3-light \
 	+libstdcpp \
-	@!(arc||mips)
+	@!arc
 endef
 
 define Package/python3-greenlet/description
   The greenlet package is a spin-off of Stackless
   a version of CPython that supports micro-threads called tasklets.
 endef
+
+# FIXME: remove when GCC10 is the oldest supported compiler, or the issue goes away
+# This is required in addition to PKG_USE_MIPS16:=0 because otherwise MIPS16
+# flags are inherited from the Python base package (via sysconfig module)
+ifdef CONFIG_USE_MIPS16
+TARGET_CFLAGS += -mno-mips16 -mno-interlink-mips16
+endif
 
 $(eval $(call Py3Package,python3-greenlet))
 $(eval $(call BuildPackage,python3-greenlet))


### PR DESCRIPTION
Maintainer: @ja-pa 
Compile tested: mips_24kc https://github.com/openwrt/openwrt/commit/d92a9c97bf3700e90af1d3c9157502af660365c0
Run tested: n/a

----------------------------------------------------------

Fixes: https://github.com/openwrt/packages/issues/15370

This is inspired from:
   https://github.com/wlanslovenija/firmware-packages-opkg/blob/330bc94dccd16a3e92ac2fdde08c81a598e12f94/lang/python-greenlet/Makefile

The `PKG_USE_MIPS16:=0` is not taken into consideration when building
Python modules. That's because the sysconfig is used.

This is only an issue with greenlet (on MIPS) so far.

One option is to do `PKG_USE_MIPS16:=0` in the core Python package.
But, since we know that the `wlanslovenija` group has successfully used
greenlet on MIPS with this construct, we might as well adopt it until GCC10
becomes the main compiler.

As noted here:
  https://github.com/openwrt/packages/issues/15370#issuecomment-817015484
GCC10 doesn't have this problem.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>