### PR TITLE
django: bump to version 3.2

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=3.1.7
+PKG_VERSION:=3.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=Django
-PKG_HASH:=32ce792ee9b6a0cbbec340123e229ac9f765dff8c2a4ae9247a14b2ba3a365a7
+PKG_HASH:=21f0f9643722675976004eb683c55d33c05486f94506672df3d6a141546f389d
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Peter Stadler <peter.stadler@student.uibk.ac.at>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me, @peter-stadler 
Compile tested: x86 https://github.com/openwrt/openwrt/commit/d92a9c97bf3700e90af1d3c9157502af660365c0
Run tested: x86 https://github.com/openwrt/openwrt/commit/d92a9c97bf3700e90af1d3c9157502af660365c0


Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>