### PR TITLE
yubico-pam: update to 2.27

### DIFF
--- a/libs/yubico-pam/Makefile
+++ b/libs/yubico-pam/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yubico-pam
-PKG_VERSION:=2.26
-PKG_RELEASE:=3
+PKG_VERSION:=2.27
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=pam_yubico-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://developers.yubico.com/yubico-pam/Releases
-PKG_HASH:=2de96495963fefd72b98243952ca5d5ec513e702c596e54bc667ef6b5e252966
+PKG_HASH:=63d02788852644d871746e1a7a1d16c272c583c226f62576f5ad232a6a44e18c
 PKG_BUILD_DIR:=$(BUILD_DIR)/pam_yubico-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Stuart B. Wilkins <stuwilkins@mac.com>


### PR DESCRIPTION
Switch to AUTORELEASE for simplicity.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @stuwilkins 
Compile tested: mips64el