### PR TITLE
[19.07] ruby: update to 2.6.7

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=2.6.6
+PKG_VERSION:=2.6.7
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=5db187882b7ac34016cd48d7032e197f07e4968f406b0690e20193b9b424841f
+PKG_HASH:=f43ead5626202d5432d2050eeab606e547f0554299cc1e5cf573d45670e59611
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Fixes two CVEs:

CVE-2020-25613: Potential HTTP Request Smuggling Vulnerability in WEBrick
CVE-2021-28965: XML round-trip vulnerability in REXML

After this release, ruby 2.6 is now in security maintenance phase.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: me
Compile tested: arc_generic, armvirt_64, ath79_generic, mediatek_mt7622, mvebu_cortexa9, powerpc, ramips_mt7620, x86_64, x86_generic
Run tested: x86_64 running "gem update"

Description:
