### PR TITLE
[18.06] ruby: update to 2.5.9

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=2.5.8
+PKG_VERSION:=2.5.9
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=0391b2ffad3133e274469f9953ebfd0c9f7c186238968cbdeeb0651aa02a4d6d
+PKG_HASH:=a87f2fa901408cc77652c1a55ff976695bbe54830ff240e370039eca14b358f0
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Fixes two CVEs:

CVE-2020-25613: Potential HTTP Request Smuggling Vulnerability in WEBrick
CVE-2021-28965: XML round-trip vulnerability in REXML

After this release, Ruby 2.5 reaches EOL.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: me
Compile tested: x86_generic,armvirt_64
Run tested: x86_generic running "gem update"

Description:
