### PR TITLE
fdm: don't use host headers

### DIFF
--- a/mail/fdm/Makefile
+++ b/mail/fdm/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fdm
 PKG_VERSION:=2.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/nicm/fdm/releases/download/$(PKG_VERSION)

--- a/mail/fdm/patches/040-remove_host_includes.patch
+++ b/mail/fdm/patches/040-remove_host_includes.patch
@@ -1,0 +1,12 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -11,9 +11,6 @@ AC_CANONICAL_HOST
+ 
+ : ${CFLAGS=""}
+ 
+-CPPFLAGS="$CPPFLAGS -I/usr/local/include"
+-LDFLAGS="$LDFLAGS -L/usr/local/lib"
+-
+ AC_PROG_CC
+ AM_PROG_CC_C_O
+ AC_PROG_INSTALL


### PR DESCRIPTION
Maintainer: @neheb, @pfzim.
Compile tested: Clean Debian 10 host, Entware repo ([commit](https://github.com/Entware/entware-packages/commit/2ab44922cb72f612a12a92f4f0964c1e32931c9e)).
Run tested: Entware, mipsel feed

Description: remove `-I/usr/local/include` and ` -L/usr/local/lib` from compilation flags.