### PR TITLE
strongswan: add deprecation warning to ipsec script

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/ipsec.init
+++ b/net/strongswan/files/ipsec.init
@@ -354,6 +354,8 @@ service_triggers() {
 start_service() {
 	prepare_env
 
+	warning "Strongswan is deprecating the ipsec CLI; please migrate to swanctl."
+
 	[ $WAIT_FOR_INTF -eq 1 ] && return
 
 	procd_open_instance


### PR DESCRIPTION
Maintainer: me, @Thermi
Compile tested: x86_64, generic, head (cb3fb45ed1)
Run tested: same, installed on test VM

Description:

```
root@OpenWrt-test:~# /etc/init.d/ipsec start
WARNING: Strongswan is deprecating the ipsec CLI; please migrate to swanctl.
root@OpenWrt-test:~# 
```