### PR TITLE
clamav: add libiconv dependencies when build with NLS

### DIFF
--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=clamav
 PKG_VERSION:=0.103.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.clamav.net/downloads/production/
@@ -29,7 +29,7 @@ include ../../devel/ninja/ninja-cmake.mk
 
 define Package/clamav/Default
   SECTION:=net
-  DEPENDS:=+libstdcpp +libpthread +zlib +libbz2 +libxml2 +libcurl +libjson-c +libmilter-sendmail +libopenssl +libltdl +libpcre2
+  DEPENDS:=+libstdcpp +libpthread +zlib +libbz2 +libxml2 +libcurl +libjson-c +libmilter-sendmail +libopenssl +libltdl +libpcre2 $(ICONV_DEPENDS)
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
   TITLE:=ClamAV


### PR DESCRIPTION
Maintainer: @lucize 
Compile tested: Turris Omnia, mvebu (cortex-a9), pre-OpenWrt 21.02
Run tested: N/A

**Description:**

NLS means Native Language Support and when you have it enabled (it is
not default), clamav can not be compiled as it shows following error:

Package clamav is missing dependencies for the following libraries:
libiconv.so.2

Also, it is required that package libiconv-full is compiled first/before
than clamav and then try to compile clamav.
