### PR TITLE
adblock: update to 4.1.1

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=4.1.0
-PKG_RELEASE:=4
+PKG_VERSION:=4.1.1
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -68,6 +68,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 * Supports five different DNS backend formats: dnsmasq, unbound, named (bind), kresd or raw (e.g. used by dnscrypt-proxy)
 * Supports four different SSL-enabled download utilities: uclient-fetch, wget, curl or aria2c
 * Supports SafeSearch for google, bing, duckduckgo, yandex, youtube and pixabay
+* Supports RPZ-trigger 'RPZ-CLIENT-IP' to always allow/deny certain DNS clients based on their IP address (currently only supported by bind dns backend)
 * Fast downloads & list processing as they are handled in parallel running background jobs with multicore support
 * Supports a wide range of router modes, even AP modes are supported
 * Full IPv4 and IPv6 support
@@ -159,7 +160,7 @@ Available commands:
 | adb_dnsinstance    | 0, first instance                  | set to the relevant dns backend instance used by adblock (dnsmasq only)                        |
 | adb_dnsflush       | 0, disabled                        | set to 1 to flush the DNS Cache before & after adblock processing                              |
 | adb_dnsinotify     | -, not set                         | set to 1 to prevent adblock triggered restarts for DNS backends with autoload functions        |
-| adb_dnsallow       | -, not set                         | set to 1 to disable selective DNS whitelisting (RPZ pass through)                              |
+| adb_dnsallow       | -, not set                         | set to 1 to disable selective DNS whitelisting (RPZ-PASSTHRU)                                  |
 | adb_lookupdomain   | example.com                        | external domain to check for a successful DNS backend restart or 'false' to disable this check |
 | adb_portlist       | 53 853 5353                        | space separated list of firewall ports which should be redirected locally                      |
 | adb_report         | 0, disabled                        | set to 1 to enable the background tcpdump gathering process for reporting                      |
@@ -189,7 +190,6 @@ No further configuration is needed, adblock deposits the final blocklist 'adb_li
 
 **Change the DNS backend to 'named' (bind):**  
 Adblock deposits the final blocklist 'adb_list.overall' in '/var/lib/bind'.  
-To preserve the DNS cache after adblock processing you need to install & configure 'bind-rdnc'.  
 To use the blocklist please modify '/etc/bind/named.conf':
 <pre><code>
 in the 'options' namespace add:
@@ -209,7 +209,7 @@ Adblock deposits the final blocklist 'adb_list.overall' in '/etc/kresd', no furt
 <b>Please note:</b> The knot-resolver (kresd) is only available on Turris devices and does not support the SafeSearch functionality yet.
 
 **Use restrictive jail modes:**  
-You can enable a restrictive 'adb_list.jail' to block access to all domains except those listed in the whitelist file. Usually this list will be generated as an additional list for guest or kidsafe configurations (for a separate dns server instance). If the jail directory points to your primary dns directory, adblock enables the restrice jail mode (jail mode only).
+You can enable a restrictive 'adb_list.jail' to block access to all domains except those listed in the whitelist file. Usually this list will be generated as an additional list for guest or kidsafe configurations (for a separate dns server instance). If the jail directory points to your primary dns directory, adblock enables the restrictive jail mode automatically (jail mode only).
 
 **Enable E-Mail notification via 'msmtp':**  
 To use the email notification you have to install & configure the package 'msmtp'.  

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -13,7 +13,7 @@ then
 	extra_command "suspend" "Suspend adblock processing"
 	extra_command "resume" "Resume adblock processing"
 	extra_command "query" "<domain> Query active blocklists and backups for a specific domain"
-	extra_command "report" "[<search>] Print DNS statistics with an optional search parameter"
+	extra_command "report" "[[<cli>|<mail>|<gen>|<json>] [<count>] [<search>]] Print DNS statistics with an optional search parameter"
 	extra_command "list" "[<add>|<add_sha>|<add_utc>|<add_eng>|<add_stb>|<remove>|<remove_sha>|<remove_utc>|<remove_eng>|<remove_stb>] <source(s)> List/Edit available sources"
 	extra_command "timer" "[<add> <tasks> <hour> [<minute>] [<weekday>]]|[<remove> <line no.>] List/Edit cron update intervals"
 	extra_command "version" "Print version information"
@@ -23,7 +23,7 @@ else
 	suspend	Suspend adblock processing
 	resume	Resume adblock processing
 	query	<domain> Query active blocklists and backups for a specific domain
-	report	[<search>] Print DNS statistics with an optional search parameter
+	report	[[<cli>|<mail>|<gen>|<json>] [<count>] [<search>]] Print DNS statistics with an optional search parameter
 	list	[<add>|<add_sha>|<add_utc>|<add_eng>|<add_stb>|<remove>|<remove_sha>|<remove_utc>|<remove_eng>|<remove_stb>] <source(s)> List/Edit available sources
 	timer	[<add> <tasks> <hour> [<minute>] [<weekday>]]|[<remove> <line no.>] List/Edit cron update intervals
 	version	Print version information"
@@ -105,7 +105,7 @@ query()
 
 report()
 {
-	rc_procd "${adb_script}" report "${1:-"+"}" "${2:-"50"}" "${3:-"true"}" "${4:-"cli"}"
+	rc_procd "${adb_script}" report "${1:-"cli"}" "${2}" "${3}"
 }
 
 list()

--- a/net/adblock/files/adblock.mail
+++ b/net/adblock/files/adblock.mail
@@ -34,7 +34,7 @@ f_log()
 	then
 		"${adb_logger}" -p "${class}" -t "adblock-${adb_ver}[${$}]" "${log_msg}"
 	else
-		printf "%s %s %s\\n" "${class}" "adblock-${adb_ver}[${$}]" "${log_msg}"
+		printf "%s %s %s\n" "${class}" "adblock-${adb_ver}[${$}]" "${log_msg}"
 	fi
 }
 
@@ -44,17 +44,18 @@ then
 	exit ${adb_rc}
 fi
 
-if [ "${adb_debug}" -eq 1 ]
+if [ "${adb_debug}" = "1" ]
 then
 	debug="--debug"
 fi
 
-adb_mailhead="From: ${adb_mailsender}\\nTo: ${adb_mailreceiver}\\nSubject: ${adb_mailtopic}\\nReply-to: ${adb_mailsender}\\nMime-Version: 1.0\\nContent-Type: text/html\\nContent-Disposition: inline\\n\\n"
+adb_mailhead="From: ${adb_mailsender}\nTo: ${adb_mailreceiver}\nSubject: ${adb_mailtopic}\nReply-to: ${adb_mailsender}\nMime-Version: 1.0\nContent-Type: text/html;charset=utf-8\nContent-Disposition: inline\n\n"
 
 # info preparation
 #
 sys_info="$(strings /etc/banner 2>/dev/null; ubus call system board | sed -e 's/\"release\": {//' | sed -e 's/^[ \t]*//' | sed -e 's/[{}\",]//g' | sed -e 's/[ ]/  \t/' | sed '/^$/d' 2>/dev/null)"
 adb_info="$(/etc/init.d/adblock status 2>/dev/null)"
+rep_info="${2}"
 if [ -x "${adb_logread}" ]
 then
 	log_info="$("${adb_logread}" -l 100 -e "adblock-" | awk '{NR=1;max=120;if(length($0)>max+1)while($0){if(NR==1){print substr($0,1,max)}else{print substr($0,1,max)}{$0=substr($0,max+1);NR=NR+1}}else print}')"
@@ -63,9 +64,13 @@ fi
 # mail body
 #
 adb_mailtext="<html><body><pre style='display:block;font-family:monospace;font-size:1rem;padding:20;background-color:#f3eee5;white-space:pre'>"
-adb_mailtext="${adb_mailtext}\\n<strong>++\\n++ System Information ++\\n++</strong>\\n${sys_info}"
-adb_mailtext="${adb_mailtext}\\n\\n<strong>++\\n++ Adblock Information ++\\n++</strong>\\n${adb_info}"
-adb_mailtext="${adb_mailtext}\\n\\n<strong>++\\n++ Logfile Information ++\\n++</strong>\\n${log_info}"
+adb_mailtext="${adb_mailtext}\n<strong>++\n++ System Information ++\n++</strong>\n${sys_info}"
+adb_mailtext="${adb_mailtext}\n\n<strong>++\n++ Adblock Information ++\n++</strong>\n${adb_info}"
+if [ -n "${rep_info}" ]
+then
+	adb_mailtext="${adb_mailtext}\n\n<strong>++\n++ Report Information ++\n++</strong>\n${rep_info}"
+fi
+adb_mailtext="${adb_mailtext}\n\n<strong>++\n++ Logfile Information ++\n++</strong>\n${log_info}"
 adb_mailtext="${adb_mailtext}</pre></body></html>"
 
 # send mail


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: PC Engines apu4, OpenWrt SNAPSHOT r16484-dc61c32fdc

Description:
* support the RPZ trigger 'RPZ-CLIENT-IP' to always allow/block certain
  clients based on their IP (currently only supported by bind!)
* avoid promiscuous mode in tcpdump setup for adblock reporting
* speed up dns report preparation
* support dns report mailing (/etc/init.d/adblock report mail)
* fix bind autodetection
* update LuCI-frontend (separate PR)
* update readme

Signed-off-by: Dirk Brenken <dev@brenken.org>
