### PR TITLE
dbus: fix new cmake build

### DIFF
--- a/utils/dbus/Makefile
+++ b/utils/dbus/Makefile
@@ -72,6 +72,9 @@ $(call Package/dbus/Default/description)
 endef
 
 CMAKE_OPTIONS += \
+	-DDBUS_SYSTEM_SOCKET=/var/run/dbus/system_bus_socket \
+	-DDBUS_SESSION_SOCKET_DIR=/tmp \
+	-DDBUS_SYSTEM_PID_FILE=/var/run/dbus.pid \
 	-DDBUS_BUILD_TESTS=OFF \
 	-DDBUS_LINUX=ON \
 	-DDBUS_DISABLE_ASSERT=ON \
@@ -84,6 +87,8 @@ CMAKE_OPTIONS += \
 	-DDBUS_ENABLE_VERBOSE_MODE=OFF \
 	-DDBUS_DISABLE_CHECKS=ON \
 	-DDBUS_BUILD_X11=OFF \
+	-DDBUS_ENABLE_DOXYGEN_DOCS=OFF \
+	-DENABLE_QT_HELP=OFF
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include

--- a/utils/dbus/patches/010-cmake-paths.patch
+++ b/utils/dbus/patches/010-cmake-paths.patch
@@ -1,0 +1,16 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -510,11 +510,11 @@ if(WIN32)
+ else(WIN32)
+     set(DBUS_SESSION_BUS_LISTEN_ADDRESS "unix:tmpdir=${DBUS_SESSION_SOCKET_DIR}" CACHE STRING "session bus default listening address")
+     set(DBUS_SESSION_BUS_CONNECT_ADDRESS "autolaunch:" CACHE STRING "session bus fallback address for clients")
+-    set(sysconfdir "")
++    set(sysconfdir "/usr/share")
+     set(configdir ${sysconfdir}/dbus-1 )
+     set(DBUS_SYSTEM_CONFIG_FILE  ${configdir}/system.conf)
+     set(DBUS_SESSION_CONFIG_FILE ${configdir}/session.conf)
+-    set(DBUS_USER "messagebus")
++    set(DBUS_USER "root")
+     set(DBUS_TEST_USER "nobody")
+   # For best security, assume that all non-Windows platforms can do
+   # credentials-passing.


### PR DESCRIPTION
CMake was using the wrong paths. Fix them up.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ath79

ping @DazzyWalkman