### PR TITLE
libtalloc: add Python3/host dependency

### DIFF
--- a/libs/libtalloc/Makefile
+++ b/libs/libtalloc/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=talloc
 PKG_VERSION:=2.3.1
 MAJOR_VERSION:=2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.samba.org/ftp/talloc
@@ -18,6 +18,7 @@ PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=LGPL-3.0-or-later
 
 PKG_BUILD_PARALLEL:=0
+PKG_BUILD_DEPENDS:=python3/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/kernel.mk


### PR DESCRIPTION
Maintainer: @thess, @jefferyto.
Compile tested: Clean Debian 10 host, Entware repo ([commit](https://github.com/Entware/entware-packages/commit/99c05d4192787cf4824e6f873a1c99fb476dc543)).
Run tested: Entware, mipsel feed

Description: bring back `Python3/host` dependency to prevent following error:
```
make package/libtalloc/compile V=s
…
The distutils module is unusable: install "python-devel"?
(complete log in /build/me/E.mipsel/build_dir/target-mipsel_mips32r2_glibc-2.27/talloc-2.3.1/bin/config.log)
make[2]: *** [Makefile:93: /build/me/E.mipsel/build_dir/target-mipsel_mips32r2_glibc-2.27/talloc-2.3.1/.configured_68b329da9893e34099c7d8ad5cb9c940] Error 1
make[2]: Leaving directory '/build/me/E.mipsel/feeds/packages/libs/libtalloc'
```