### PR TITLE
mutt: don't use host mailpath definition

### DIFF
--- a/mail/mutt/Makefile
+++ b/mail/mutt/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mutt
 PKG_VERSION:=1.14.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://bitbucket.org/mutt/mutt/downloads/ \
 		http://ftp.mutt.org/pub/mutt/
@@ -45,6 +45,7 @@ CONFIGURE_ARGS += \
 	--oldincludedir=$(PKG_BUILD_DIR)/. \
 	--enable-pop \
 	--enable-imap \
+	--with-mailpath=/var/mail \
 	--with-ssl \
 	--without-idn \
 	--disable-doc


### PR DESCRIPTION
Maintainer: @philenotfound 
Compile tested: mvebu, WRT3200ACM, master
Run tested: same

Description:
Use configure --with-mailpath=/var/mail instead of letting it guess the
value base on the host path.  If configure can't find it, the package
will fail to build.  The path was taken from the current bot build.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

I hit a build failure when building in a box without any mail infrastructure.
```
checking where new mail is stored... no
configure: error: "Could not determine where new mail is stored."
```

Here's the code behind it:
```
        AC_ARG_WITH(mailpath, AS_HELP_STRING([--with-mailpath=DIR],[Directory where spool mailboxes are located]),
                [mutt_cv_mailpath=$withval],
                [ AC_CACHE_CHECK(where new mail is stored, mutt_cv_mailpath,
                        [mutt_cv_mailpath=no
                        if test -d /var/mail; then
                                mutt_cv_mailpath=/var/mail
                        elif test -d /var/spool/mail; then
                                mutt_cv_mailpath=/var/spool/mail
                        elif test -d /usr/spool/mail; then
                                mutt_cv_mailpath=/usr/spool/mail
                        elif test -d /usr/mail; then
                                mutt_cv_mailpath=/usr/mail
                        fi])
                ])
```
Well, I needed to find a good path.  Anything under `/var` would be problematic, I thought.  I've tried to see where it could actually be used in openwrt, since the path from the host may not be a good one.

The mutt package installed from the official distribution uses `/var/mail`, which would be wiped with a reboot.  Then, I've installed postfix to check what it does.  The path it stores mail is `/usr/var/mail`, and it did not install a symlink to it in `/var`.  Does this have to be done manually, or is the package only ever used with remote mail?

If I were to choose, it'd be `/usr/mail`, but I did not feel brave enough to do it, and left it untouched.

The problem exists in 21.02, and probably 19.07 as well (I haven't tested in 19.07 to see if the `--maildir` option exists).  We should cherry pick this at least to 21.02.