### PR TITLE
stunnel: update to 5.59

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.58
+PKG_VERSION:=5.59
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0-or-later
@@ -23,7 +23,7 @@ PKG_SOURCE_URL:= \
 	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=d4c14cc096577edca3f6a2a59c2f51869e35350b3988018ddf808c88e5973b79
+PKG_HASH:=137776df6be8f1701f1cd590b7779932e123479fb91e5192171c16798815ce9f
 
 PKG_FIXUP:=autoreconf
 PKG_FIXUP:=patch-libtool


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, APU3, latest OpenWrt master
Run tested: x86_64, APU3, latest OpenWrt master

Description:
Update to the latest upstream version.
This should be also backported to openwrt-21.02 if this is merged.

```
root@st-dev-07 ~ # stunnel
[ ] Initializing inetd mode configuration
[ ] Clients allowed=500
[.] stunnel 5.59 on x86_64-openwrt-linux-gnu platform
[.] Compiled/running with OpenSSL 1.1.1k  25 Mar 2021
[.] Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,OCSP,PSK,SNI
[ ] errno: (*__errno_location())
[ ] Initializing inetd mode configuration
[.] Reading configuration from file /etc/stunnel/stunnel.conf
[.] UTF-8 byte order mark not detected
[.] FIPS mode disabled
[ ] Compression enabled: 0 methods
[ ] No PRNG seeding was required
[ ] Initializing service [dummy]
[ ] stunnel default security level set: 2
[ ] Ciphers: HIGH:!aNULL:!SSLv2:!DH:!kDHEPSK
[ ] TLSv1.3 ciphersuites: TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256
[ ] TLS options: 0x02100004 (+0x00000000, -0x00000000)
[ ] No certificate or private key specified
[:] Service [dummy] needs authentication to prevent MITM attacks
[ ] DH initialization skipped: client section
[ ] ECDH initialization
[ ] ECDH initialized with curves X25519:P-256:X448:P-521:P-384
[.] Configuration successful
[ ] Deallocating deployed section defaults
[ ] Binding service [dummy]
[ ] Listening file descriptor created (FD=9)
[ ] Setting accept socket options (FD=9)
[ ] Option SO_REUSEADDR set on accept socket
[.] Binding service [dummy] to ::1:6000: Address in use (98)
[ ] Listening file descriptor created (FD=9)
[ ] Setting accept socket options (FD=9)
[ ] Option SO_REUSEADDR set on accept socket
[.] Binding service [dummy] to 127.0.0.1:6000: Address in use (98)
[!] Binding service [dummy] failed
[ ] Unbinding service [dummy]
[ ] Service [dummy] closed
[ ] Deallocating deployed section defaults
[ ] Deallocating section [dummy]
[ ] Initializing inetd mode configuration
```