### PR TITLE
fwknop: Remove unnecessary get_bool() function

### DIFF
--- a/net/fwknop/Makefile
+++ b/net/fwknop/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fwknop
 PKG_VERSION:=2.6.10
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.cipherdyne.org/fwknop/download

--- a/net/fwknop/files/fwknopd.init
+++ b/net/fwknop/files/fwknopd.init
@@ -44,17 +44,6 @@ service_triggers()
 	fi
 }
 
-get_bool()
-{
-	local _tmp="${1}"
-	case "${_tmp}" in
-		1|on|true|yes|enabled) _tmp=1;;
-		0|off|false|no|disabled) _tmp=0;;
-		*) _tmp="${2}";;
-	esac
-	echo -n "${_tmp}"
-}
-
 generate_configuration()
 {
 	[ -f /tmp/access.conf.tmp ] && rm /tmp/access.conf.tmp


### PR DESCRIPTION
Maintainer: @jp-bennett
Compile tested: mips_24kc/ath79, TP-Link Archer C7 v4, OpenWrt Git master
Run tested: mips_24kc/ath79, TP-Link Archer C7 v4, OpenWrt Git master, tested running of fwknop

Description:

The `get_bool()` functionality was already merged to `lib/functions.sh` (https://github.com/openwrt/openwrt/commit/49d678f0d29405883e0789297a476154eef18ec5, part of 21.02 version), so it is redundant in the init script. Remove it.
