### PR TITLE
conntrack-tools: add a patch to fix endianness issue

### DIFF
--- a/net/conntrack-tools/Makefile
+++ b/net/conntrack-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=conntrack-tools
 PKG_VERSION:=1.4.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.netfilter.org/projects/conntrack-tools/files

--- a/net/conntrack-tools/patches/001-endianness_fix.patch
+++ b/net/conntrack-tools/patches/001-endianness_fix.patch
@@ -1,0 +1,101 @@
+--- a/src/build.c
++++ b/src/build.c
+@@ -66,7 +66,14 @@ ct_build_u32(const struct nf_conntrack *
+ }
+ 
+ static inline void
+-ct_build_u128(const struct nf_conntrack *ct, int a, struct nethdr *n, int b)
++ct_build_be32(const struct nf_conntrack *ct, int a, struct nethdr *n, int b)
++{
++	uint32_t data = nfct_get_attr_u32(ct, a);
++	addattr(n, b, &data, sizeof(uint32_t));
++}
++
++static inline void
++ct_build_be128(const struct nf_conntrack *ct, int a, struct nethdr *n, int b)
+ {
+ 	const char *data = nfct_get_attr(ct, a);
+ 	addattr(n, b, data, sizeof(uint32_t) * 4);
+@@ -279,18 +286,18 @@ void ct2msg(const struct nf_conntrack *c
+ 	switch (nfct_get_attr_u8(ct, ATTR_ORIG_L3PROTO)) {
+ 	case AF_INET:
+ 		if (nfct_getobjopt(ct, NFCT_GOPT_IS_SNAT))
+-			ct_build_u32(ct, ATTR_REPL_IPV4_DST, n, NTA_SNAT_IPV4);
++			ct_build_be32(ct, ATTR_REPL_IPV4_DST, n, NTA_SNAT_IPV4);
+ 		if (nfct_getobjopt(ct, NFCT_GOPT_IS_DNAT))
+-			ct_build_u32(ct, ATTR_REPL_IPV4_SRC, n, NTA_DNAT_IPV4);
++			ct_build_be32(ct, ATTR_REPL_IPV4_SRC, n, NTA_DNAT_IPV4);
+ 		break;
+ 	case AF_INET6:
+ 		if (nfct_getobjopt(ct, NFCT_GOPT_IS_SNAT)) {
+-			ct_build_u128(ct, ATTR_REPL_IPV6_DST, n,
+-				      NTA_SNAT_IPV6);
++			ct_build_be128(ct, ATTR_REPL_IPV6_DST, n,
++				       NTA_SNAT_IPV6);
+ 		}
+ 		if (nfct_getobjopt(ct, NFCT_GOPT_IS_DNAT)) {
+-			ct_build_u128(ct, ATTR_REPL_IPV6_SRC, n,
+-				      NTA_DNAT_IPV6);
++			ct_build_be128(ct, ATTR_REPL_IPV6_SRC, n,
++				       NTA_DNAT_IPV6);
+ 		}
+ 		break;
+ 	default:
+--- a/src/parse.c
++++ b/src/parse.c
+@@ -29,7 +29,8 @@
+ static void ct_parse_u8(struct nf_conntrack *ct, int attr, void *data);
+ static void ct_parse_u16(struct nf_conntrack *ct, int attr, void *data);
+ static void ct_parse_u32(struct nf_conntrack *ct, int attr, void *data);
+-static void ct_parse_u128(struct nf_conntrack *ct, int attr, void *data);
++static void ct_parse_be32(struct nf_conntrack *ct, int attr, void *data);
++static void ct_parse_be128(struct nf_conntrack *ct, int attr, void *data);
+ static void ct_parse_str(struct nf_conntrack *ct,
+ 			 const struct netattr *, void *data);
+ static void ct_parse_group(struct nf_conntrack *ct, int attr, void *data);
+@@ -108,12 +109,12 @@ static struct ct_parser h[NTA_MAX] = {
+ 		.size	= NTA_SIZE(sizeof(struct nfct_attr_grp_port)),
+ 	},
+ 	[NTA_SNAT_IPV4]	= {
+-		.parse	= ct_parse_u32,
++		.parse	= ct_parse_be32,
+ 		.attr	= ATTR_SNAT_IPV4,
+ 		.size	= NTA_SIZE(sizeof(uint32_t)),
+ 	},
+ 	[NTA_DNAT_IPV4] = {
+-		.parse	= ct_parse_u32,
++		.parse	= ct_parse_be32,
+ 		.attr	= ATTR_DNAT_IPV4,
+ 		.size	= NTA_SIZE(sizeof(uint32_t)),
+ 	},
+@@ -192,12 +193,12 @@ static struct ct_parser h[NTA_MAX] = {
+ 		.max_size = NTA_SIZE(NTA_LABELS_MAX_SIZE),
+ 	},
+ 	[NTA_SNAT_IPV6]	= {
+-		.parse	= ct_parse_u128,
++		.parse	= ct_parse_be128,
+ 		.attr	= ATTR_SNAT_IPV6,
+ 		.size	= NTA_SIZE(sizeof(uint32_t) * 4),
+ 	},
+ 	[NTA_DNAT_IPV6] = {
+-		.parse	= ct_parse_u128,
++		.parse	= ct_parse_be128,
+ 		.attr	= ATTR_DNAT_IPV6,
+ 		.size	= NTA_SIZE(sizeof(uint32_t) * 4),
+ 	},
+@@ -229,7 +230,14 @@ ct_parse_u32(struct nf_conntrack *ct, in
+ }
+ 
+ static void
+-ct_parse_u128(struct nf_conntrack *ct, int attr, void *data)
++ct_parse_be32(struct nf_conntrack *ct, int attr, void *data)
++{
++	uint32_t *value = (uint32_t *) data;
++	nfct_set_attr_u32(ct, h[attr].attr, *value);
++}
++
++static void
++ct_parse_be128(struct nf_conntrack *ct, int attr, void *data)
+ {
+ 	nfct_set_attr(ct, h[attr].attr, data);
+ }


### PR DESCRIPTION
Maintainer: me / jo@mein.io

Compile tested: 
x86_64 kvm, QEMU, OpenWrt 19.07.3, and
Atheros AR7161 rev 2, Netgear WNDR3800, OpenWrt 19.07.5

Run tested: 
Mixed endianness firewall failover successful

Description:
There's a endianness bug in conntrack-tools causing SNAT/DNAT IP address being inverted in a mixed-endianness failover. (In my case, a little endian firewall fails-over to a big endian firewall). This patch is a backport of https://marc.info/?l=netfilter&m=161891034013669&w=2 to solve this issue.
