### PR TITLE
node: Resolve ICU conflict

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
 PKG_VERSION:=v14.16.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)

--- a/lang/node/patches/999-fix_icu_conflict.patch
+++ b/lang/node/patches/999-fix_icu_conflict.patch
@@ -1,0 +1,74 @@
+--- a/tools/icu/icu-generic.gyp
++++ b/tools/icu/icu-generic.gyp
+@@ -181,6 +181,7 @@
+               '<(icu_path)/source/i18n/uspoof_wsconf.h',
+             ]}],
+             ],
++          'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+           'include_dirs': [
+             '<(icu_path)/source/i18n',
+           ],
+@@ -189,6 +190,7 @@
+           ],
+           'dependencies': [ 'icuucx', 'icu_implementation', 'icu_uconfig', 'icu_uconfig_target' ],
+           'direct_dependent_settings': {
++            'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+             'include_dirs': [
+               '<(icu_path)/source/i18n',
+             ],
+@@ -275,6 +277,7 @@
+               # full data - no trim needed
+               'sources': [ '<(SHARED_INTERMEDIATE_DIR)/icudt<(icu_ver_major)_dat.<(icu_asm_ext)' ],
+               'dependencies': [ 'genccode#host', 'icupkg#host', 'icu_implementation#host', 'icu_uconfig' ],
++              'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+               'include_dirs': [
+                 '<(icu_path)/source/common',
+               ],
+@@ -359,6 +362,7 @@
+               # This file contains the small ICU data
+               'sources': [ '<(SHARED_INTERMEDIATE_DIR)/icusmdt<(icu_ver_major)_dat.<(icu_asm_ext)' ],
+               # for umachine.h
++              'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+               'include_dirs': [
+                 '<(icu_path)/source/common',
+               ],
+@@ -375,6 +379,7 @@
+       'sources': [
+         '<@(icu_src_stubdata)'
+       ],
++      'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+       'include_dirs': [
+         '<(icu_path)/source/common',
+       ],
+@@ -443,6 +448,7 @@
+           '_XOPEN_SOURCE_EXTENDED=0',
+         ]}],
+       ],
++      'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+       'include_dirs': [
+         '<(icu_path)/source/common',
+       ],
+@@ -452,6 +458,7 @@
+       'cflags_c': ['-std=c99'],
+       'export_dependent_settings': [ 'icu_uconfig', 'icu_uconfig_target' ],
+       'direct_dependent_settings': {
++        'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+         'include_dirs': [
+           '<(icu_path)/source/common',
+         ],
+@@ -482,6 +489,7 @@
+         '<(icu_path)/source/tools/toolutil/dbgutil.cpp',
+         '<(icu_path)/source/tools/toolutil/dbgutil.h',
+       ],
++      'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+       'include_dirs': [
+         '<(icu_path)/source/common',
+         '<(icu_path)/source/i18n',
+@@ -501,6 +509,7 @@
+         }]
+       ],
+       'direct_dependent_settings': {
++        'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+         'include_dirs': [
+           '<(icu_path)/source/common',
+           '<(icu_path)/source/i18n',


### PR DESCRIPTION
Maintainer: @blogic @ianchi 
Compile tested: head r16575-4dcdc8249c, aarch64, arm, i386, x86_64, mipsel (pistachio)
 Run tested: (qemu 5.2.0) aarch64, arm, i386, x86_64

Description:
Resolve conflicts between OpenWrt's ICU package and the ICU shipped with node.js.

https://github.com/openwrt/packages/issues/15437

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
