### PR TITLE
tmux: update to 3.2

### DIFF
--- a/utils/tmux/Makefile
+++ b/utils/tmux/Makefile
@@ -2,12 +2,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tmux
-PKG_VERSION:=3.1c
-PKG_RELEASE:=1
+PKG_VERSION:=3.2
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tmux/tmux/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=b9617dd4d1c541ebc21b6b5760d58102fc039a593786aab273b5dd95dd514bea
+PKG_HASH:=290a2f25a2f26c649f7ec7f2880586b8d3f43e24d7cb42c691f430941edb4fcf
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 
 PKG_LICENSE:=ISC
@@ -25,7 +25,7 @@ define Package/tmux
   CATEGORY:=Utilities
   SUBMENU:=Terminal
   TITLE:=Terminal multiplexer
-  DEPENDS:=+libncurses +libevent2 +libpthread +librt
+  DEPENDS:=+libncurses +libevent2-core +libpthread +librt
   URL:=http://tmux.github.io/
 endef
 

--- a/utils/tmux/patches/100-add-crosscompiling-fallbacks.patch
+++ b/utils/tmux/patches/100-add-crosscompiling-fallbacks.patch
@@ -1,0 +1,24 @@
+commit bb6242675ad0c7447daef148fffced882e5b4a61
+Author: Nicholas Marriott <nicholas.marriott@gmail.com>
+Date:   Thu Apr 15 06:45:19 2021 +0100
+
+    Add crosscompiling fallbacks, from Hasso Tepper.
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -163,6 +163,7 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM(
+ 		[return (reallocarray(NULL, 1, 1) == NULL);]
+ 	)],
+ 	AC_MSG_RESULT(yes),
++	[AC_LIBOBJ(reallocarray) AC_MSG_RESULT([no])],
+ 	[AC_LIBOBJ(reallocarray) AC_MSG_RESULT([no])]
+ )
+ AC_MSG_CHECKING([for working recallocarray])
+@@ -171,6 +172,7 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM(
+ 		[return (recallocarray(NULL, 1, 1, 1) == NULL);]
+ 	)],
+ 	AC_MSG_RESULT(yes),
++	[AC_LIBOBJ(recallocarray) AC_MSG_RESULT([no])],
+ 	[AC_LIBOBJ(recallocarray) AC_MSG_RESULT([no])]
+ )
+ 


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79, r16582+5-3326b5e75c
Run tested: ath79, r15339+6-bc99b56d7e. run-tested on /tmp by supplying the required libevent through LD_LIBRARY_PATH=/tmp:
```
$ ls -la /tmp/libevent_core-2.1.so.7* /tmp/tmux
-rw-r--r--    1 root     users        91144 Apr 22 00:01 /tmp/libevent_core-2.1.so.7
-rw-r--r--    1 root     users        91144 Apr 22 00:01 /tmp/libevent_core-2.1.so.7.0.1
-rwxr-xr-x    1 root     users       446549 Apr 22 00:01 /tmp/tmux

$ LD_LIBRARY_PATH=/tmp /tmp/tmux -V
tmux 3.2
```

Description:
- switch to $(AUTORELEASE)
- change dependency from libevent2 to libevent2-core
- fix cross-compilation