### PR TITLE
coremark: bump to 2021-03-12

### DIFF
--- a/utils/coremark/Makefile
+++ b/utils/coremark/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coremark
-PKG_SOURCE_DATE:=2020-12-17
-PKG_SOURCE_VERSION:=5e0f662ce709f1af8d272bd8d3960034603d3850
+PKG_SOURCE_DATE:=2021-03-12
+PKG_SOURCE_VERSION:=1541482bf3e6ef7f5c69f5be76b14537b60833d0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_DATE).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eembc/coremark/tar.gz/$(PKG_SOURCE_VERSION)?
-PKG_HASH:=fb0a2ee2113322eb976fa521d0ac033a997e0097185c2c2325d84ca94a7f5a6d
+PKG_HASH:=ad32cb10ba491f5c897f1022e97bca691cc88fdbb02ded48a0766c10344abc4f
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
 
 PKG_MAINTAINER:=Lim Guo Wei <limguowei@gmail.com>
@@ -35,8 +35,6 @@ endef
 define Package/coremark/description
   Embedded Microprocessor Benchmark
 endef
-
-DIR_ARCH:=linux$(if $(CONFIG_ARCH_64BIT),64)
 
 define Package/coremark/config
 	config COREMARK_OPTIMIZE_O3
@@ -72,9 +70,9 @@ ifeq ($(CONFIG_COREMARK_ENABLE_MULTITHREADING),y)
 endif
 
 define Build/Compile
-	$(SED) 's|EXE = .exe|EXE =|' $(PKG_BUILD_DIR)/$(DIR_ARCH)/core_portme.mak
+	$(SED) 's|EXE = .exe|EXE =|' $(PKG_BUILD_DIR)/posix/core_portme.mak
 	mkdir $(PKG_BUILD_DIR)/$(ARCH)
-	$(CP) -r $(PKG_BUILD_DIR)/$(DIR_ARCH)/* $(PKG_BUILD_DIR)/$(ARCH)
+	$(CP) -r $(PKG_BUILD_DIR)/linux/* $(PKG_BUILD_DIR)/$(ARCH)
 	$(MAKE) -C $(PKG_BUILD_DIR) PORT_DIR=$(ARCH) $(MAKE_FLAGS) \
 		PORT_CFLAGS="$(TARGET_CFLAGS)" XCFLAGS="$(EXTRA_CFLAGS)" compile
 endef


### PR DESCRIPTION
Maintainer: @gwlim
Compile tested: (sunxi, Orange PI PC2/Orange PI ONE, snapshot)
Run tested: (sunxi, Orange PI PC2/Orange PI ONE, snapshot)

Description: update to the latest version.