### PR TITLE
[21.02] openvpn: update to 2.5.2

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.5.1
-PKG_RELEASE:=3
+PKG_VERSION:=2.5.2
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=40930489c837c05f6153f38e1ebaec244431ef1a034e4846ff732d71d59ff194
+PKG_HASH:=b12743836901f365efaf82ab2493967e1b21c21eb43ce9a8da1002a17c9c1dc8
 
 PKG_MAINTAINER:=Magnus Kroken <mkroken@gmail.com>
 

--- a/net/openvpn/patches/100-mbedtls-disable-runtime-version-check.patch
+++ b/net/openvpn/patches/100-mbedtls-disable-runtime-version-check.patch
@@ -1,6 +1,6 @@
 --- a/src/openvpn/ssl_mbedtls.c
 +++ b/src/openvpn/ssl_mbedtls.c
-@@ -1520,7 +1520,7 @@ const char *
+@@ -1535,7 +1535,7 @@ const char *
  get_ssl_library_version(void)
  {
      static char mbedtls_version[30];

--- a/net/openvpn/patches/115-fix-mbedtls-without-renegotiation.patch
+++ b/net/openvpn/patches/115-fix-mbedtls-without-renegotiation.patch
@@ -1,0 +1,42 @@
+From e4bd17c86e01aaf6f809d9ea355419c86c4defdc Mon Sep 17 00:00:00 2001
+From: Max Fillinger <maximilian.fillinger@foxcrypto.com>
+Date: Mon, 12 Apr 2021 19:46:17 +0200
+Subject: [PATCH] Fix build with mbedtls w/o SSL renegotiation support
+
+In mbedtls, support for SSL renegotiation can be disabled at
+compile-time. However, OpenVPN cannot be built with such a library
+because it calls mbedtls_ssl_conf_renegotiation() to disable this
+feature at runtime. This function doesn't exist when mbedtls was built
+without support for SSL renegotiation.
+
+This commit fixes the build by ifdef'ing out the function call when
+mbedtls was built without support for SSL renegotiation.
+
+Signed-off-by: Max Fillinger <maximilian.fillinger@foxcrypto.com>
+Acked-by: Antonio Quartulli <antonio@openvpn.net>
+Message-Id: <E1lW0eX-00012w-9n@sfs-ml-1.v29.lw.sourceforge.com>
+URL: https://www.mail-archive.com/search?l=mid&q=E1lW0eX-00012w-9n@sfs-ml-1.v29.lw.sourceforge.com
+Signed-off-by: Gert Doering <gert@greenie.muc.de>
+---
+ src/openvpn/ssl_mbedtls.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+--- a/src/openvpn/ssl_mbedtls.c
++++ b/src/openvpn/ssl_mbedtls.c
+@@ -1098,10 +1098,13 @@ key_state_ssl_init(struct key_state_ssl
+     {
+         mbedtls_ssl_conf_curves(ks_ssl->ssl_config, ssl_ctx->groups);
+     }
+-    /* Disable TLS renegotiations. OpenVPN's renegotiation creates new SSL
+-     * session and does not depend on this feature. And TLS renegotiations have
+-     * been problematic in the past */
++
++    /* Disable TLS renegotiations if the mbedtls library supports that feature.
++     * OpenVPN's renegotiation creates new SSL sessions and does not depend on
++     * this feature and TLS renegotiations have been problematic in the past. */
++#if defined(MBEDTLS_SSL_RENEGOTIATION)
+     mbedtls_ssl_conf_renegotiation(ks_ssl->ssl_config, MBEDTLS_SSL_RENEGOTIATION_DISABLED);
++#endif /* MBEDTLS_SSL_RENEGOTIATION */
+ 
+     /* Disable record splitting (for now).  OpenVPN assumes records are sent
+      * unfragmented, and changing that will require thorough review and

--- a/net/openvpn/test.sh
+++ b/net/openvpn/test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+case "$1" in
+	"openvpn-mbedtls")
+		openvpn --version | grep "$2.*SSL (mbed TLS)"
+		;;
+	"openvpn-openssl")
+		openvpn --version | grep "$2.*SSL (OpenSSL)"
+		;;
+esac


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, 21.02 (r16051-15cd9a5d5c)
Run tested: x86_64, 21.02 (r16051-15cd9a5d5c), tested openvpn-mbedtls as client against OpenWrt master 2.5.2 server

Description: Fixes two related security vulnerabilities (CVE-2020-15078) which
under very specific circumstances allow tricking a server using delayed
authentication (plugin or management) into returning a PUSH_REPLY before
the AUTH_FAILED message, which can possibly be used to gather
information about a VPN setup. In combination with "--auth-gen-token" or
a user-specific token auth solution it can be possible to get access to
a VPN with an otherwise-invalid account.

OpenVPN 2.5.2 also includes other bug fixes and improvements.