### PR TITLE
[openwrt-19.07][cherry-pick] squid: Enable dynamic SSL certificate generation

### DIFF
--- a/net/squid/Config.in
+++ b/net/squid/Config.in
@@ -25,7 +25,7 @@ if PACKAGE_squid
 	config SQUID_enable-ssl-crtd
 		bool "Enable dynamic SSL certificate generation "
 		depends on !SQUID_use-gnutls
-		default n
+		default y
 
 	config SQUID_auth-basic
 		bool "Enable the Basic authentication scheme"

--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squid
 PKG_VERSION:=4.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www3.us.squid-cache.org/Versions/v4/ \


### PR DESCRIPTION
Maintainer: @neheb / @BKPepe / @zhanhb
Compile tested: ipq806x, generic, netgear_r7800, master
Run tested: ipq806x, generic, netgear_r7800, openwrt-19.07

Description:

Squid now only support HTTPS proxy in TCP tunnel mode (e.g. `ssl_bump splice all`):

    https_port 3128 ssl-bump tls-cert=/etc/squid/squid.pem generate-host-certificates=on
    ssl_bump splice all

In order to operate in SSL Bump mode, we need to compile with `--enable-ssl-crtd` for following configuration:

    https_port 3128 ssl-bump tls-cert=/etc/squid/squid.pem generate-host-certificates=on
    sslcrtd_program /usr/lib/squid/security_file_certgen -s /car/cache/squid/ssl_db -M 4MB
    ssl_bump stare all
    ssl_bump bump all

This PR switch the `SQUID_enable-ssl-crtd` into `default y`, therefore default enable SSL Bump mode.

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
