### PR TITLE
h2o: remove useless ruby dependency

### DIFF
--- a/libs/h2o/Makefile
+++ b/libs/h2o/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=h2o
 PKG_VERSION:=2.2.6
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE_URL:=https://codeload.github.com/h2o/h2o/tar.gz/v${PKG_VERSION}?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -47,12 +47,12 @@ endef
 
 define Package/libh2o-evloop/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libh2o-evloop.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libh2o-evloop.so* $(1)/usr/lib/
 endef
 
 define Package/libh2o/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libh2o.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libh2o.so* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libh2o-evloop))

--- a/libs/h2o/Makefile
+++ b/libs/h2o/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=h2o
 PKG_VERSION:=2.2.6
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE_URL:=https://codeload.github.com/h2o/h2o/tar.gz/v${PKG_VERSION}?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -15,7 +15,7 @@ PKG_LICENSE_FILES:=LICENSE
 include $(INCLUDE_DIR)/package.mk
 include ../../devel/ninja/ninja-cmake.mk
 
-PKG_BUILD_DEPENDS:=ruby/host libwslay
+PKG_BUILD_DEPENDS:=libwslay
 
 CMAKE_OPTIONS += \
 	-DBUILD_SHARED_LIBS=ON \
@@ -26,7 +26,7 @@ define Package/libh2o-evloop
   CATEGORY:=Libraries
   TITLE:=H2O Library compiled with its own event loop
   URL:=https://h2o.examp1e.net/
-  DEPENDS:=+libopenssl +zlib +libyaml +ruby
+  DEPENDS:=+libopenssl +zlib +libyaml
 endef
 
 define Package/libh2o
@@ -34,7 +34,7 @@ define Package/libh2o
   CATEGORY:=Libraries
   TITLE:=H2O Library compiled with libuv
   URL:=https://h2o.examp1e.net/
-  DEPENDS:=+libuv +libopenssl +zlib +libyaml +ruby
+  DEPENDS:=+libuv +libopenssl +zlib +libyaml
 endef
 
 define Build/InstallDev


### PR DESCRIPTION
Maintainer: @neheb @James-TR 
Compile tested: x86_64, OpenWRT master
Run tested: in the Docker hub image `openwrt/rootfs`, I installed dnsdist and this h2o build, and it could still serve DoH fine.

Description: h2o is the library dnsdist uses to offer DNS over HTTPS to clients. dnsdist is the only user of h2o in this tree.

While h2o can depend on Ruby (to build mruby support), this is disabled in the OpenWRT build of h2o. Hence, the Ruby dependency is unnecessary, and removing it saves a few megabytes of disk space.

Additionally, I noticed that the package contained 3 identical copies of the lib:
```
root@52170cbc2408:/# ls -ali /usr/lib/libh2o*
 162653 -rwxr-xr-x    1 root     root        348857 Apr 25 11:50 /usr/lib/libh2o-evloop.so
 162660 -rwxr-xr-x    1 root     root        348857 Apr 25 11:50 /usr/lib/libh2o-evloop.so.0.13
 162661 -rwxr-xr-x    1 root     root        348857 Apr 25 11:50 /usr/lib/libh2o-evloop.so.0.13.6
```

so this PR fixes that too:
```
root@472ad3a8404e:/# ls -ali /usr/lib/libh2o*
 289858 lrwxrwxrwx    1 root     root            21 Apr 25 12:43 /usr/lib/libh2o-evloop.so -> libh2o-evloop.so.0.13
 289859 lrwxrwxrwx    1 root     root            23 Apr 25 12:43 /usr/lib/libh2o-evloop.so.0.13 -> libh2o-evloop.so.0.13.6
 289860 -rw-r--r--    1 root     root        348857 Apr 25 12:41 /usr/lib/libh2o-evloop.so.0.13.6
```