### PR TITLE
unbound: fix typo in assist name of https-dns-proxy

### DIFF
--- a/net/unbound/files/unbound.sh
+++ b/net/unbound/files/unbound.sh
@@ -473,7 +473,7 @@ unbound_zone() {
     fi
     ;;
 
-  htpps-dns-proxy)
+  htpps-dns-proxy | https-dns-proxy)
     if [ -x /usr/sbin/https-dns-proxy ] \
     && [ -x /etc/init.d/https-dns-proxy ] ; then
       if /etc/init.d/https-dns-proxy ; then


### PR DESCRIPTION
Signed-off-by: Peter van Dijk <peter.van.dijk@powerdns.com>

Maintainer: @EricLuehrsen 
Compile tested: no
Run tested: also no, I don't use unbound. I ran into this typo while helping a user on #openwrt-devel with a different problem.

Description:
The name of `https-dns-proxy` is misspelled. I added the right spelling, leaving the old spelling in, to not break existing configurations.