### PR TITLE
redis: update to version 6.2.2

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
-PKG_VERSION:=6.2.1
+PKG_VERSION:=6.2.2
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=cd222505012cce20b25682fca931ec93bd21ae92cb4abfe742cf7b76aa907520
+PKG_HASH:=7a260bb74860f1b88c3d5942bf8ba60ca59f121c6dce42d3017bed6add0b9535
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS7), OpenWrt master
Run tested: Turris Omnia (TOS7), OpenWrt master

Description:
https://github.com/redis/redis/releases/tag/6.2.2


This PR updates redis to version 6.2.2. It fixes multiple bugs some of them related to ACL [Changelog](https://raw.githubusercontent.com/redis/redis/6.2/00-RELEASENOTES)

Upgrade urgency level is HIGH
(HIGH:  There is a critical bug that may affect a subset of users. Upgrade!)