### PR TITLE
python-engineio & python-socketio: package update

### DIFF
--- a/lang/python/python-engineio/Makefile
+++ b/lang/python/python-engineio/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-engineio
-PKG_VERSION:=4.0.1
+PKG_VERSION:=4.1.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=python-engineio
-PKG_HASH:=bb575c1a3512b4b5d4706f3071d5cc36e592459e99a47d9a4b7faabeba941377
+PKG_HASH:=21e1bcc62f5573a4bb1c805e69915c5a4c5aa953005dde6c2f707c24554c1020
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT

--- a/lang/python/python-socketio/Makefile
+++ b/lang/python/python-socketio/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-socketio
-PKG_VERSION:=5.1.0
+PKG_VERSION:=5.2.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=python-socketio
-PKG_HASH:=338cc29abb6f3ca14c88f1f8d05ed27c690df4648f62062b299f92625bbf7093
+PKG_HASH:=356a8a480fa316295b439d63a5f35a7a59fe65cee1ae35dee28e87d00e5aead6
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS7), OpenWrt master
Run tested: Turris Omnia (TOS7), OpenWrt master

Description:
This PR updates python-engineio to version 4.1.0 and python-socketio to version 5.2.1. New version of python-egineio is required for socketio 5.2.1.

