### PR TITLE
yq: Update to 4.7.1

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.7.0
+PKG_VERSION:=4.7.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=d4984f8f8ac5151797c8cf9c6ab8b705958802721c4405ef8a99206dcd00dcb5
+PKG_HASH:=19a7c43aaac678065f436ddfdf8b0a75dd3883984f4b9548cabdf53eb09932f9
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip, x86_64
Run tested: rockchip nanopi-r2s

Description:
Fixed "del operator does not work"
Releaselog: https://github.com/mikefarah/yq/releases/tag/v4.7.1