### PR TITLE
zerotier: update to 1.6.5

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
-PKG_VERSION:=1.6.4
+PKG_VERSION:=1.6.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=0f45a4050cdfea1018634c88b6c302cbbfcc3f7f93cb94bed840a15e3ffa55ba
+PKG_HASH:=a437ec9e8a4987ed48c0e5af3895a057dcc0307ab38af90dd7729a131097f222
 PKG_BUILD_DIR:=$(BUILD_DIR)/ZeroTierOne-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>

--- a/net/zerotier/patches/0002-remove-pie.patch
+++ b/net/zerotier/patches/0002-remove-pie.patch
@@ -11,7 +11,7 @@ when making a shared object; recompile with -fPIC" error
 
 --- a/make-linux.mk
 +++ b/make-linux.mk
-@@ -73,11 +73,11 @@ ifeq ($(ZT_DEBUG),1)
+@@ -69,11 +69,11 @@ ifeq ($(ZT_DEBUG),1)
  	# C25519 in particular is almost UNUSABLE in -O0 even on a 3ghz box!
  node/Salsa20.o node/SHA512.o node/C25519.o node/Poly1305.o: CXXFLAGS=-Wall -O2 -g -pthread $(INCLUDES) $(DEFS)
  else

--- a/net/zerotier/patches/0003-remove-arm32-conservative-CFLAGS.patch
+++ b/net/zerotier/patches/0003-remove-arm32-conservative-CFLAGS.patch
@@ -9,7 +9,7 @@ Subject: [PATCH 3/8] remove arm32 conservative CFLAGS
 
 --- a/make-linux.mk
 +++ b/make-linux.mk
-@@ -276,7 +276,7 @@ ifeq ($(ZT_CONTROLLER),1)
+@@ -272,7 +272,7 @@ ifeq ($(ZT_CONTROLLER),1)
  endif
  
  # ARM32 hell -- use conservative CFLAGS

--- a/net/zerotier/patches/0004-accept-external-linker-flags.patch
+++ b/net/zerotier/patches/0004-accept-external-linker-flags.patch
@@ -9,7 +9,7 @@ Subject: [PATCH 4/8] accept external linker flags
 
 --- a/make-linux.mk
 +++ b/make-linux.mk
-@@ -77,7 +77,7 @@ else
+@@ -73,7 +73,7 @@ else
  	override CFLAGS+=-Wall -Wno-deprecated -pthread $(INCLUDES) -DNDEBUG $(DEFS)
  	CXXFLAGS?=-O3 -fstack-protector
  	override CXXFLAGS+=-Wall -Wno-deprecated -std=c++11 -pthread $(INCLUDES) -DNDEBUG $(DEFS)


### PR DESCRIPTION
Maintainer: me
Compile tested: OpenWrt master, ath79/generic, Carambola2
Run tested: not tested

Minor ZeroTier update. Refreshed patches