### PR TITLE
libmraa: Disable node.js support

### DIFF
--- a/libs/libmraa/Makefile
+++ b/libs/libmraa/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmraa
 PKG_VERSION:=2.2.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eclipse/mraa/tar.gz/v$(PKG_VERSION)?
@@ -20,7 +20,7 @@ PKG_MAINTAINER:=John Crispin <blogic@openwrt.org>, Hirokazu MORIKAWA <morikw2@gm
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
 
-PKG_BUILD_DEPENDS:=swig/host node/host PACKAGE_node:node
+PKG_BUILD_DEPENDS:=swig/host
 CMAKE_INSTALL:=1
 PKG_USE_MIPS16:=0
 PYTHON3_PKG_BUILD:=0
@@ -31,7 +31,7 @@ include ../../lang/python/python3-package.mk
 
 CMAKE_OPTIONS += \
 	-DENABLEEXAMPLES=0 \
-	-DBUILDSWIGNODE=$(if $(CONFIG_PACKAGE_libmraa-node),ON,OFF) \
+	-DBUILDSWIGNODE=OFF \
 	-DFIRMATA=ON
 
 define Package/libmraa/Default
@@ -62,18 +62,6 @@ $(call Package/libmraa/Default/description)
 This package contains the C/C++ libraries.
 endef
 
-define Package/libmraa-node
-  $(call Package/libmraa/Default)
-  TITLE:=Eclipse MRAA lowlevel IO Node.js library
-  DEPENDS:=+libmraa @PACKAGE_node
-endef
-
-define Package/libmraa-node/description
-$(call Package/libmraa/Default/description)
-
-This package contains the Node.js libraries.
-endef
-
 define Package/libmraa-python3
   $(call Package/libmraa/Default)
   TITLE:=Eclipse MRAA lowlevel IO Python3 library
@@ -93,11 +81,6 @@ define Package/libmraa/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mraa-* $(1)/usr/bin/
 endef
 
-define Package/libmraa-node/install
-	$(INSTALL_DIR) $(1)/usr/lib/node/mraa
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/mraa/* $(1)/usr/lib/node/mraa/
-endef
-
 define Package/libmraa-python3/install
 	$(INSTALL_DIR) $(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON3_VERSION)/site-packages/* \
@@ -105,5 +88,4 @@ define Package/libmraa-python3/install
 endef
 
 $(eval $(call BuildPackage,libmraa))
-$(eval $(call BuildPackage,libmraa-node))
 $(eval $(call BuildPackage,libmraa-python3))


### PR DESCRIPTION
Maintainer: @blogic, me 
Compile tested: head, arm 
Run tested: (qemu-5.2.0) arm

Description:
 Disable node.js support.

Library for node.js will be disabled temporarily due to difficulty in supporting the latest node.js.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>

