### PR TITLE
libedit: update to version 20210419-3.1

### DIFF
--- a/libs/libedit/Makefile
+++ b/libs/libedit/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libedit
-PKG_VERSION:=20210216-3.1
+PKG_VERSION:=20210419-3.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
@@ -16,7 +16,7 @@ PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://thrysoee.dk/editline/
-PKG_HASH:=2283f741d2aab935c8c52c04b57bf952d02c2c02e651172f8ac811f77b1fc77a
+PKG_HASH:=571ebe44b74860823e24a08cf04086ff104fd7dfa1020abf26c52543134f5602
 
 PKG_INSTALL:=1
 


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan

Description:

- update of the library on which knot depends on
