### PR TITLE
xray-core: remove PROVIDES

### DIFF
--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -113,7 +113,7 @@ define Package/xray-core/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/main $(1)/usr/bin/xray
 
 	$(INSTALL_DIR) $(1)/etc/xray/
-	$(INSTALL_CONF) $(CURDIR)/files/config.json.example $(1)/etc/xray/
+	$(INSTALL_DATA) $(CURDIR)/files/config.json.example $(1)/etc/xray/
 
 	$(INSTALL_DIR) $(1)/etc/config/
 	$(INSTALL_CONF) $(CURDIR)/files/xray.conf $(1)/etc/config/xray
@@ -126,8 +126,8 @@ endef
 
 define Package/xray-example/install
 	$(INSTALL_DIR) $(1)/etc/xray/
-	$(INSTALL_CONF) $(CURDIR)/files/vpoint_socks_vmess.json $(1)/etc/xray/
-	$(INSTALL_CONF) $(CURDIR)/files/vpoint_vmess_freedom.json $(1)/etc/xray/
+	$(INSTALL_DATA) $(CURDIR)/files/vpoint_socks_vmess.json $(1)/etc/xray/
+	$(INSTALL_DATA) $(CURDIR)/files/vpoint_vmess_freedom.json $(1)/etc/xray/
 endef
 
 define Package/xray-geodata/install

--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -37,7 +37,6 @@ endef
 define Package/xray-core
   $(call Package/xray/template)
   DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
-  PROVIDES:=v2ray-core
 endef
 
 define Package/xray-example
@@ -55,7 +54,7 @@ define Package/xray-geodata
 endef
 
 define Package/xray/description
-  Xray, Penetrates Everything. Also the best v2ray-core, with XTLS support. Fully compatible configuration.
+  Xray, Penetrates Everything. It helps you to build your own computer network.
   It secures your network connections and thus protects your privacy.
 endef
 
@@ -112,7 +111,6 @@ define Package/xray-core/install
 	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/main $(1)/usr/bin/xray
-	$(LN) xray $(1)/usr/bin/v2ray
 
 	$(INSTALL_DIR) $(1)/etc/xray/
 	$(INSTALL_CONF) $(CURDIR)/files/config.json.example $(1)/etc/xray/

--- a/net/xray-core/files/config.json.example
+++ b/net/xray-core/files/config.json.example
@@ -1,6 +1,6 @@
 // Config file of Xray. This file follows standard JSON format, with comments support.
 // Uncomment entries below to satisfy your needs. Also read our manual for more detail at
-// https://www.v2fly.org/en_US/config/overview.html and https://xray.sh/en/config/
+// https://xtls.github.io/en/config/
 {
   "log": {
     // By default, Xray writes access log to stdout.


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip
Run tested: rockchip nanopi-r2s

Description:
92efcc295: remove PROVIDES
```
Xray now is no longer planning to keep compatibility with original
v2ray. Remove PROVIDES before it is totally broken.
```

bbc6c62c2: use `$(INSTALL_DATA)` to install configuration files
```
Using `$(INSTALL_CONF)` will cause the program has no access to
configurations file when someone enabled the selinux support.
```