### PR TITLE
knxd: bump to new upstream version 0.14.51

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -11,12 +11,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
-PKG_VERSION:=0.14.50
+PKG_VERSION:=0.14.51
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/knxd/knxd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=c9189dc0b05b208b06be311d2792ce11092aee8d51d04083568ae49bd10b7cd8
+PKG_HASH:=c8378bc6f671a5ab75edb51b23e839ee1adcdd00b372314ca9d2bdcd37fb70fb
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/knxd/patches/0100-version.patch
+++ b/net/knxd/patches/0100-version.patch
@@ -1,9 +1,10 @@
 --- a/tools/version.sh
 +++ b/tools/version.sh
-@@ -1,5 +1,3 @@
- #!/bin/sh
- 
+@@ -7,6 +7,4 @@
+     exit
+ fi
+
 -test -d .git || exit
 -# git describe --tags
 -git log --format=format:%D | perl -ne 'next unless s#.*tag: ##; s#,.*##; next if m#/#; print; exit;'
-+echo -n "0.14.50"
++echo -n "0.14.51"


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>

Maintainer: me
Compile tested: mpc85xx, tl-wdr4900-v1, trunk
Compile tested: ath79, tplink_archer-c7-v4, trunk
Compile tested: ramips, mt7620a, trunk
Run tested: ath79, tp-link Archer C7 v4, trunk

Description:
new upstream release 0.14.51
