### PR TITLE
adguardhome: bump to 0.106.0

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
-PKG_VERSION:=0.105.2
+PKG_VERSION:=0.106.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://github.com/AdguardTeam/AdGuardHome
-PKG_MIRROR_HASH:=c2ca02ef4d91250772567994e4a59962dc4ec559f44771cefba2b0663668fba1
+PKG_MIRROR_HASH:=5e3fb3bb93ad8d7ac3351503e7b01353dc409bc30a719a6ed7b967e8a462434c
 
 PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILES:=LICENSE.txt
@@ -25,9 +25,11 @@ PKG_USE_MIPS16:=0
 GO_PKG:=github.com/AdguardTeam/AdGuardHome
 GO_PKG_BUILD_PKG:=github.com/AdguardTeam/AdGuardHome
 
+AGH_BUILD_TIME:=$(shell date -d @$(SOURCE_DATE_EPOCH) +%FT%TZ%z)
 AGH_VERSION_PKG:=github.com/AdguardTeam/AdGuardHome/internal/version
 GO_PKG_LDFLAGS_X:=$(AGH_VERSION_PKG).channel=release \
 	$(AGH_VERSION_PKG).version=$(PKG_SOURCE_VERSION) \
+	$(AGH_VERSION_PKG).buildtime=$(AGH_BUILD_TIME) \
 	$(AGH_VERSION_PKG).goarm=$(GO_ARM) \
 	$(AGH_VERSION_PKG).gomips=$(GO_MIPS)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_generic, NanoPi R2S, OpenWrt SNAPSHOT r15730
Run tested: aarch64_generic, NanoPi R2S, OpenWrt SNAPSHOT r15730

* Full changelog available at:
  * https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.106.0
* Add build time LDFLAG introduced in commit [1].

[1]: https://github.com/AdguardTeam/AdGuardHome/commit/1d07afb30ee9ff00de72182200b7e1c6d1606d77#diff-82ef468ec5547f1ed424776755a7f87dfec4eba9838d2c2ac02c9881bb67d737R67

Signed-off-by: Dobroslaw Kijowski <dobo90@gmail.com>
