### PR TITLE
mwan3: allow interfaces with no tracking IPs

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.10.8
+PKG_VERSION:=2.10.9
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -17,6 +17,7 @@ start_tracker() {
 	interface=$1
 	config_get_bool enabled $interface 'enabled' '0'
 	[ $enabled -eq 0 ] && return
+	[ -z "$(config_get $interface track_ip)" ] && return
 
 	procd_open_instance "track_${1}"
 	procd_set_param command /usr/sbin/mwan3track $interface


### PR DESCRIPTION
Maintainer: me, @feckert 
Compile tested: Not needed
Run tested: 19.07.7


In the procd refactor, support for interfaces with no tracking IPs was
inadvertentiy removed. This commit restores the previous behavior

fixes #15391

