### PR TITLE
tailscale: add new package

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -1,0 +1,77 @@
+#
+# Copyright (C) 2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tailscale
+PKG_VERSION:=1.6.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=tailscale-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=4591c6f6d3d1f9d5aecaa63dd580c389067edeb7287cd587b108ea6a0aa811e7
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/tailscale-$(PKG_VERSION)
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=\
+	tailscale.com/cmd/tailscale \
+	tailscale.com/cmd/tailscaled
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/tailscale/Default
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=VPN
+  TITLE:=Zero config VPN
+  URL:=https://tailscale.com
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/tailscaled
+  $(call Package/tailscale/Default)
+  TITLE+= (daemon)
+  DEPENDS+= +ca-bundle +kmod-tun
+endef
+
+define Package/tailscale
+  $(call Package/tailscale/Default)
+  TITLE+= (utility)
+  DEPENDS+= +tailscaled
+endef
+
+define Package/tailscale/description
+  It creates a secure network between your servers, computers,
+  and cloud instances. Even when separated by firewalls or subnets.
+endef
+
+Package/tailscaled/description:=$(Package/tailscale/description)
+
+define Package/tailscale/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/tailscale $(1)/usr/sbin
+endef
+
+define Package/tailscaled/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/tailscaled $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files//tailscale.init $(1)/etc/init.d/tailscale
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_DATA) ./files//tailscale.conf $(1)/etc/config/tailscale
+endef
+
+$(eval $(call BuildPackage,tailscale))
+$(eval $(call BuildPackage,tailscaled))

--- a/net/tailscale/files/tailscale.conf
+++ b/net/tailscale/files/tailscale.conf
@@ -1,0 +1,5 @@
+config settings 'settings'
+	option log_stderr '1'
+	option log_stdout '1'
+	option port '41641'
+	option state_file '/etc/tailscale/tailscaled.state'

--- a/net/tailscale/files/tailscale.init
+++ b/net/tailscale/files/tailscale.init
@@ -1,0 +1,42 @@
+#!/bin/sh /etc/rc.common
+
+# Copyright 2020 Google LLC.
+# Copyright (C) 2021 CZ.NIC z.s.p.o. (https://www.nic.cz/)
+# SPDX-License-Identifier: Apache-2.0
+
+USE_PROCD=1
+START=80
+
+start_service() {
+  local state_file
+  local port
+  local std_err std_out
+
+  config_load tailscale
+  config_get_bool std_out "settings" log_stdout 1
+  config_get_bool std_err "settings" log_stderr 1
+  config_get port "settings" port 41641
+  config_get state_file "settings" state_file /etc/tailscale/tailscaled.state
+
+  /usr/sbin/tailscaled --cleanup
+
+  procd_open_instance
+  procd_set_param command /usr/sbin/tailscaled
+
+  # Set the port to listen on for incoming VPN packets.
+  # Remote nodes will automatically be informed about the new port number,
+  # but you might want to configure this in order to set external firewall
+  # settings.
+  procd_append_param command --port "$port"
+  procd_append_param command --state "$state_file"
+
+  procd_set_param respawn
+  procd_set_param stdout "$std_out"
+  procd_set_param stderr "$std_err"
+
+  procd_close_instance
+}
+
+stop_service() {
+  /usr/sbin/tailscaled --cleanup
+}


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS7), OpenWrt master
Run tested: Turris Omnia (TOS7), OpenWrt master

Description:
This PR adds new package tailscale. Tailscale is zero config VPN based on WireGuard protocol. For more info see https://tailscale.com .

This is inspired by blog post https://willangley.org/how-i-set-up-tailscale-on-my-wifi-router/ cc @willangley

Fixes https://github.com/tailscale/tailscale/issues/724