### PR TITLE
php8: update to 8.0.5

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.0.3
+PKG_VERSION:=8.0.5
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=c9816aa9745a9695672951eaff3a35ca5eddcb9cacf87a4f04b9fb1169010251
+PKG_HASH:=5dd358b35ecd5890a4f09fb68035a72fe6b45d3ead6999ea95981a107fd1f2ab
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0

--- a/lang/php8/patches/1001-ext-opcache-fix-detection-of-shm-mmap.patch
+++ b/lang/php8/patches/1001-ext-opcache-fix-detection-of-shm-mmap.patch
@@ -41,7 +41,7 @@ Signed-off-by: Michael Heimpold <mhei@heimpold.de>
 +    AC_CHECK_FUNC(mmap,[dnl
 +        AC_DEFINE(HAVE_SHM_MMAP_ANON, 1, [Define if you have mmap(MAP_ANON) SHM support])
 +        have_shm_mmap_anon=yes],[have_shm_mmap_anon=no])])
-   AC_MSG_RESULT([$have_shm_mmap_anon=yes])
+   AC_MSG_RESULT([$have_shm_mmap_anon])
  
    PHP_CHECK_FUNC_LIB(shm_open, rt, root)
 @@ -294,8 +300,11 @@ int main() {


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs

Description:

Also update opcache makefile patch.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>