### PR TITLE
bind: bump to 9.16.15 in openwrt-19.07

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.16.13
+PKG_VERSION:=9.16.15
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=a54cc793fa5b69b35f610f2095760f8238dff5cfd52419f7ee1c9c227da4cc08
+PKG_HASH:=98b6f432d878a7bf8f57eb7b3c28be27278cf6b9989154bfe6c81104b38e7839
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Fixes the following security issues in the openwrt-19.07 branch:

* CVE-2021-25216 - A specially crafted GSS-TSIG query could cause a buffer
                   overflow in the ISC implementation of SPNEGO.
* CVE-2021-25215 - named crashed when a DNAME record placed in the ANSWER
                   section during DNAME chasing turned out to be the final
                   answer to a client query.
* CVE-2021-25214 - Insufficient IXFR checks could result in named serving a
                   zone without an SOA record at the apex, leading to a
                   RUNTIME_CHECK assertion failure when the zone was
                   subsequently refreshed. This has been fixed by adding an
                   owner name check for all SOA records which are included
                   in a zone transfer.

Signed-off-by: Noah Meyerhans <frodo@morgul.net>

Maintainer: me
Compile tested: x86
Run tested: x86
