### PR TITLE
adblock: update to 4.1.2

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=4.1.1
+PKG_VERSION:=4.1.2
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -186,10 +186,12 @@ Available commands:
 
 ## Examples
 **Change the DNS backend to 'unbound':**  
-No further configuration is needed, adblock deposits the final blocklist 'adb_list.overall' in '/var/lib/unbound' by default.
+No further configuration is needed, adblock deposits the final blocklist 'adb_list.overall' in '/var/lib/unbound' by default.  
+To preserve the DNS cache after adblock processing please install the additional package 'unbound-control'.
 
-**Change the DNS backend to 'named' (bind):**  
-Adblock deposits the final blocklist 'adb_list.overall' in '/var/lib/bind'.  
+**Change the DNS backend to 'bind':**  
+Adblock deposits the final blocklist 'adb_list.overall' in '/var/lib/bind' by default.  
+To preserve the DNS cache after adblock processing please install the additional package 'bind-rdnc'.
 To use the blocklist please modify '/etc/bind/named.conf':
 <pre><code>
 in the 'options' namespace add:

--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -98,7 +98,7 @@
 		"descurl": "https://github.com/notracking/hosts-blocklists"
 	},
 	"oisd_basic": {
-		"url": "https://dbl.oisd.nl/basic",
+		"url": "https://dbl.oisd.nl/basic/",
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
 		"size": "L",
 		"focus": "general",
@@ -312,6 +312,6 @@
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
 		"size": "S",
 		"focus": "general",
-		"descurl": "https://pgl.yoyo.org"
+		"descurl": "https://pgl.yoyo.org/as"
 	}
 }


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: PC Engines apu4, OpenWrt SNAPSHOT r16589-210916c9e6

Description:
* preserve DNS cache after adblock processing (unbound & bind)
* fix redirect issue with oisd basic url
* cosmetics

Signed-off-by: Dirk Brenken <dev@brenken.org>
