### PR TITLE
[21.02] icu: add ABI_VERSION

### DIFF
--- a/libs/icu/Makefile
+++ b/libs/icu/Makefile
@@ -11,7 +11,7 @@ PKG_NAME:=icu4c
 MAJOR_VERSION:=68
 MINOR_VERSION:=2
 PKG_VERSION:=$(MAJOR_VERSION).$(MINOR_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(MAJOR_VERSION)_$(MINOR_VERSION)-src.tgz
 PKG_SOURCE_URL:=https://github.com/unicode-org/icu/releases/download/release-$(MAJOR_VERSION)-$(MINOR_VERSION)
@@ -41,6 +41,7 @@ define Package/icu
   TITLE:=International Components for Unicode
   URL:=http://icu-project.org
   DEPENDS:=+libstdcpp +libpthread
+  ABI_VERSION:=$(MAJOR_VERSION)
 endef
 
 define Package/icu/description
@@ -54,6 +55,7 @@ define Package/icu-full-data
   TITLE:=Full ICU Data
   URL:=http://icu-project.org
   DEPENDS:=+icu
+  ABI_VERSION:=$(MAJOR_VERSION)
 endef
 
 define Package/icu-full-data/description


### PR DESCRIPTION
Maintainer: me 
Compile tested: 21.02, aarch64
Run tested: (qemu-5.2.0) aarch64

Description: 
Add ABI_VERSION
To prevent inconsistencies in the coming version (69.1).

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
