### PR TITLE
mwan3: update ubus status for no tracked interfaces

### DIFF
--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -66,7 +66,7 @@ case "$ACTION" in
 		mwan3_set_iface_hotplug_state $INTERFACE "$status"
 		if [ "$MWAN3_STARTUP" != "init" ]; then
 			mwan3_create_iface_route $INTERFACE $DEVICE
-	                mwan3_set_general_rules
+			mwan3_set_general_rules
 			[ "$status" = "online" ] && mwan3_set_policies_iptables
 		fi
 		[ "$ACTION" = ifup ] && procd_running mwan3 "track_$INTERFACE" && procd_send_signal mwan3 "track_$INTERFACE" USR2

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -96,8 +96,7 @@ get_mwan3_status() {
 	local age=0
 	local online=0
 	local offline=0
-	local up="0"
-	local enabled time_p time_n time_u time_d status track_status
+	local enabled time_p time_n time_u time_d status track_status up uptime
 
 	if [ "${iface}" != "${iface_select}" ] && [ "${iface_select}" != "" ]; then
 		return
@@ -109,15 +108,19 @@ get_mwan3_status() {
 	online=$(get_online_time "$iface")
 	offline=$(get_offline_time "$iface")
 
-	local uptime="0"
-
 	config_get enabled "$iface" enabled 0
-	network_get_uptime uptime "$iface"
-	network_is_up "$iface" && up="1"
 
-	if [ -f "$MWAN3TRACK_STATUS_DIR/${iface}/STATUS" ]; then
-		status="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/STATUS")"
+	if [ -d "${MWAN3_STATUS_DIR}" ]; then
+		network_get_uptime uptime "$iface"
+		network_is_up "$iface" && up="1"
+		if [ -f "$MWAN3TRACK_STATUS_DIR/${iface}/STATUS" ]; then
+			status="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/STATUS")"
+		else
+			status="notracking"
+		fi
 	else
+		uptime=0
+		up=0
 		status="unknown"
 	fi
 


### PR DESCRIPTION
Maintainer: me / @aaronjg 
Compile tested: only script changes
Run tested: x86_64, APU3

Description:
In the old mwan3 there was the option of not interface tracking.
This is made possible again by this [pullrequest](https://github.com/openwrt/packages/pull/15537).
In order for the ubus status to be displayed correctly, it must be adjusted with changes

