### PR TITLE
libmaxminddb: update to version 1.6.0

### DIFF
--- a/libs/libmaxminddb/Makefile
+++ b/libs/libmaxminddb/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmaxminddb
-PKG_VERSION:=1.5.2
-PKG_RELEASE=2
+PKG_VERSION:=1.6.0
+PKG_RELEASE=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/maxmind/libmaxminddb/releases/download/$(PKG_VERSION)/
-PKG_HASH:=5237076d250a5f7c297e331c35a433eeaaf0dc205e070e4db353c9ba10f340a2
+PKG_HASH:=7620ac187c591ce21bcd7bf352376a3c56a933e684558a1f6bef4bd4f3f98267
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (OS7), OpenWrt master
Run tested: Turris Omnia (TOS7), OpenWrt master

Description:
This PR updates libmaxminddb to version 1.6.0 [Changelog](https://github.com/maxmind/libmaxminddb/blob/main/Changes.md)
