### PR TITLE
hwdata: update to version 0.347

### DIFF
--- a/utils/hwdata/Makefile
+++ b/utils/hwdata/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hwdata
-PKG_VERSION:=0.345
+PKG_VERSION:=0.347
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/vcrhonek/hwdata/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=fafcc97421ba766e08a2714ccc3eebb0daabc99e67d53c2d682721dd01ccf7a7
+PKG_HASH:=1574e39b5ebd0763beb1fe986cd1a2d17ec81ba0a2f1a61cf27d9b3c62a5a8fa
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0-or-later  XFree86-1.0


### PR DESCRIPTION
Maintainer: none
Compile tested: Turris MOX, mvebu/cortexa53, OpenWrt master
Run tested: N/A, package contents verified and its updated

Description:
- update to [0.347](https://github.com/vcrhonek/hwdata/releases/tag/v0.347)
