### PR TITLE
stress-ng: bump to version 0.12.07

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.12.06
+PKG_VERSION:=0.12.07
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://kernel.ubuntu.com/~cking/tarballs/stress-ng
-PKG_HASH:=75eb340266b1bbae944d8f9281af978bd5bc2c8085df97a098d5500d6f177296
+PKG_HASH:=cf73e3a4c7d95afa46aa27fb9283a8a988f3971de4ce6ffe9f651ca341731ead
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only

--- a/utils/stress-ng/patches/010-soft-float.patch
+++ b/utils/stress-ng/patches/010-soft-float.patch
@@ -1,6 +1,6 @@
 --- a/stress-fp-error.c
 +++ b/stress-fp-error.c
-@@ -117,42 +117,43 @@ static int stress_fp_error(const stress_
+@@ -119,42 +119,43 @@ static int stress_fp_error(const stress_
  	do {
  		volatile double d1, d2;
  
@@ -50,7 +50,7 @@
  		/*
  		 * Use volatiles to force compiler to generate code
  		 * to perform run time computation of 1.0 / M_PI
-@@ -173,14 +174,15 @@ static int stress_fp_error(const stress_
+@@ -175,14 +176,15 @@ static int stress_fp_error(const stress_
  		stress_fp_check(args, "DBL_MAX + DBL_MAX / 2.0",
  			DBL_MAX + DBL_MAX / 2.0, INFINITY,
  			false, true, 0, FE_OVERFLOW | FE_INEXACT);


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/6f77ce77248d6458414efafd64c72d653fc70bb8
Run tested:  x86 https://github.com/openwrt/openwrt/commit/6f77ce77248d6458414efafd64c72d653fc70bb8

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>