### PR TITLE
samba4: update to 4.13.8

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.13.4
+PKG_VERSION:=4.13.8
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -13,7 +13,7 @@ PKG_SOURCE_URL:= \
 		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
-PKG_HASH:=a1b34c63f7100cc8626902d80f335c7cb0b45d4707dd3c4b010f7a28ed615c78
+PKG_HASH:=3347c0c62cc5b1df1fc92d802282e809c354bfb4941a33c91a7fda3795efbf7f
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/samba4/files/samba.init
+++ b/net/samba4/files/samba.init
@@ -143,9 +143,9 @@ smb_add_share() {
 			fi
 		fi
 		
-		# always enable io_uring if we can
-		if [ "$DISABLE_ASYNC_IO" -ne 1 ] && [ -e /usr/lib/samba/vfs/io_uring.so ] && grep "io_uring_setup" /proc/kallsyms >>2 ; then
-			logger -p daemon.info -t 'samba4-server' "io_uring support found in kernel, enabling VFS io_uring."
+		# always enable io_uring if we can ("should" fail silently via samba module load if no kernel support)
+		if [ "$DISABLE_ASYNC_IO" -ne 1 ] && [ -e /usr/lib/samba/vfs/io_uring.so ] ; then
+			logger -p daemon.info -t 'samba4-server' "io_uring module found, enabling VFS io_uring. (also needs Kernel 5.4+ Support)"
 			# make sure its last in list
 			if [ -n "$vfs_objects" ]; then
 				vfs_objects="$vfs_objects io_uring"


### PR DESCRIPTION
Maintainer: me
Compile tested: arm/master
Run tested: arm/mvebu/master 

Description:
* update to 4.13.8
* remove faulty io_uring kernel detection
* fixes CVE's: CVE-2020-27840, CVE-2021-20277, CVE-2020-27840, CVE-2021-20277, CVE-2020-27840, CVE-2021-20277, CVE-2021-20254
* resolves #15512