### PR TITLE
tailscale: update to version 1.8.1

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.6.0
+PKG_VERSION:=1.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=tailscale-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=4591c6f6d3d1f9d5aecaa63dd580c389067edeb7287cd587b108ea6a0aa811e7
+PKG_HASH:=5d08e9c4cbb51da94951281003f3911933962dad0a85003e4b1852ac7b023bcd
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/tailscale/README.md
+++ b/net/tailscale/README.md
@@ -1,0 +1,28 @@
+# Tailscale
+This readme should help you with tailscale client setup.
+
+## Install
+There are two packages related to tailscale. Tailscaled (daemon which has to run every time you want to be connected to VPN) and tailscale (package with a utility which is necessary for registering device).
+
+To install them run
+```
+opkg install tailscale tailscaled
+```
+
+## First setup
+
+First, enable and run daemon
+
+```
+/etc/init.d/tailscale enable
+/etc/init.d/tailscale start
+```
+
+Then you should use tailscale utility to get a login link for your device.
+
+Run command and finish device registration with the given URL.
+```
+tailscale up
+```
+
+After that, you should see your router in tailscale admin page.


### PR DESCRIPTION
maintainer: me
Compile tested: Turris Omnia (TS7), OpenWrt master
Run tested: Turris Omnia (TOS7), OpenWrt master

Description:
This PR updates tailscale to version 1.8.1 and adds basic README file. [Changelog](https://github.com/tailscale/tailscale/releases/tag/v1.8.1)
