### PR TITLE
redis: update to version 6.2.3

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
-PKG_VERSION:=6.2.2
+PKG_VERSION:=6.2.3
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=7a260bb74860f1b88c3d5942bf8ba60ca59f121c6dce42d3017bed6add0b9535
+PKG_HASH:=98ed7d532b5e9671f5df0825bb71f0f37483a16546364049384c63db8764512b
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS7), OpenWrt master
Run tested: Turris Omnia (TOS7), OpenWrt master

Description:
This PR updates redis to version 6.2.3. Upgrade urgency is SECURITY because of [CVE-2021-29477](https://nvd.nist.gov/vuln/detail/CVE-2021-29477)

[Changelog](https://raw.githubusercontent.com/redis/redis/6.2/00-RELEASENOTES)

Runtested with benchmark utils.