### PR TITLE
knot-resolver: update to version 5.3.2

### DIFF
--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -10,12 +10,12 @@ PKG_RELRO_FULL:=0
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot-resolver
-PKG_VERSION:=5.3.1
+PKG_VERSION:=5.3.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-resolver
-PKG_HASH:=9d4d6b7bcdf114acc948e5ee68c83fcbb3944f48a13b9751dbbbc190cdd729c9
+PKG_HASH:=8b6f447d5fe93422d4c129a2d4004a977369c3aa6e55258ead1cbd488bc01436
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=GPL-3.0-later


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS7), OpenWrt master
Run tested: Turris Omnia (TOS7), OpenWrt master

Description:
This PR udpates knot-resolver to version 5.3.2. It fixes security issue in NSEC3 and adds few improvements.

[Changelog](https://www.knot-resolver.cz/2021-05-05-knot-resolver-5.3.2.html)
