### PR TITLE
docker-compose: Update to version 1.29.2

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-compose
-PKG_VERSION:=1.29.1
+PKG_VERSION:=1.29.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=docker-compose
-PKG_HASH:=d2064934f5084db8a0c4805e226447bf1fd0c928419be95afb6bd1866838c1f1
+PKG_HASH:=4c8cd9d21d237412793d18bd33110049ee9af8dab3fe2c213bbd0733959b09b7
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
Small upstream update.

Miscellaneous:
- Remove prompt to use docker compose in the up command
- Bump py to 1.10.0 in requirements-indirect.txt
