### PR TITLE
rsync: Add rrsync script

### DIFF
--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -69,6 +69,15 @@ define Package/rsyncd
   URL:=https://rsync.samba.org/
 endef
 
+define Package/rrsync
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=File Transfer
+  TITLE:=Restricted rsync script
+  DEPENDS:=+rsync +perlbase-file +perl @(PACKAGE_openssh-server||PACKAGE_openssh-server-pam)
+  URL:=https://www.samba.org/ftp/unpacked/rsync/support/rrsync
+endef
+
 define Package/rsync/description
  rsync is a program that allows files to be copied to and from remote machines
  in much the same way as rcp. It has many more options than rcp, and uses the
@@ -100,5 +109,17 @@ define Package/rsyncd/install
 	$(INSTALL_BIN) ./files/rsyncd.init $(1)/etc/init.d/rsyncd
 endef
 
+define Package/rrsync/description
+  rrsync is a script which wraps around rsync to restrict its permission to a
+  particular subdirectory via ~/.ssh/authorized_keys and/or to read-only
+  or write-only mode
+endef
+
+define Package/rrsync/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/support/rrsync $(1)/usr/bin
+endef
+
 $(eval $(call BuildPackage,rsync))
 $(eval $(call BuildPackage,rsyncd))
+$(eval $(call BuildPackage,rrsync))


### PR DESCRIPTION
Signed-off-by: Matt Reeve <matt@mreeve.com>

Maintainer: Maxim Storchak <m.storchak@gmail.com>
Compile tested: Qualcomm Atheros IPQ806X, NETGEAR Nighthawk X4S R7800
Run tested: Qualcomm Atheros IPQ806X, NETGEAR Nighthawk X4S R7800)

mkdir /tmp/xxx
echo hello >> /tmp/xxx/abc

Add to ~/.ssh/authorized_keys:

command="/usr/bin/rrsync -ro /tmp/xxx" ssh-rsa public key here

From another machine:

rsync -av root@router:/ /tmp/yyy

File "abc" transfers successfully.

touch /tmp/yyy/def

rsync -av /tmp/yyy root@router:/

Transfer fails as expected (-ro in authorized_keys)

On router, change ~/.ssh/authorized_keys:

command="/usr/bin/rrsync /tmp/xxx" ssh-rsa public key here

On other machine:

rsync -av /tmp/yyy root@router:/

File def now transfers successfully.



Description:

Rrsync allows selective access to subdirectories in either read-only, write-only or read-write, depending on settings in authorized_keys. This allows for safe, restrictive access. It's particularly useful for automated backup purposes.