### PR TITLE
libgpg-error: patch to fix cross-compile

### DIFF
--- a/libs/libgpg-error/patches/020-build-fix-generation.patch
+++ b/libs/libgpg-error/patches/020-build-fix-generation.patch
@@ -1,0 +1,27 @@
+From 33593864cd54143db594c4237bba41e14179061c Mon Sep 17 00:00:00 2001
+From: David Michael <fedora.dm0@gmail.com>
+Date: Fri, 26 Mar 2021 16:06:50 +0900
+Subject: [PATCH 1/2] build: Fix generation of lock-obj-pub.native.h for cross
+ build.
+
+* src/gen-lock-obj.sh: Capture echo output with quotes.
+
+--
+
+Fixes-commit: 99ae862a96a569724f49a604ebb7d3f6d2c2d374
+Signed-off-by: David Michael <fedora.dm0@gmail.com>
+---
+ src/gen-lock-obj.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/gen-lock-obj.sh
++++ b/src/gen-lock-obj.sh
+@@ -38,7 +38,7 @@
+ #     AWK=gawk ./gen-lock-obj.sh
+ #
+ 
+-if test -n `echo -n`; then
++if test -n "`echo -n`"; then
+     ECHO_C='\c'
+     ECHO_N=''
+ else


### PR DESCRIPTION
Paul Blazejowski discovered that the recent update to this package broke
cross-compiling for some OpenWrt platforms. This backports commit 33593864
(March 26, 2021) from the upstream libgpg-error project to fix this 
problem.

Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64 master

Description:
