### PR TITLE
libassuan: remove gpgrt-config workaround

### DIFF
--- a/libs/libassuan/Makefile
+++ b/libs/libassuan/Makefile
@@ -32,9 +32,6 @@ protocol. This protocol is used for IPC between most newer GnuPG
 components. Both, server and client side functions are provided. 
 endef
 
-CONFIGURE_VARS += \
-		ac_cv_path_GPGRT_CONFIG="no"
-
 define Build/InstallDev
 	$(INSTALL_DIR) $(2)/bin $(1)/usr/bin
 	$(INSTALL_BIN) \


### PR DESCRIPTION
After the recent libgpg-error update, the workaround for gpgrt-config
is no more necessary.

Reverts 63481e619 ("libassuan: fix linking of host's libgpg-error").

Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>

Maintainer: @dangowrt 
Compile tested:  OpenWrt SNAPSHOT r16736-ccf1cc43df, Netgear XR700
Run tested: OpenWrt SNAPSHOT r16736-ccf1cc43df, Netgear XR700
