### PR TITLE
node: bump to v14.17.0

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v14.16.1
-PKG_RELEASE:=2
+PKG_VERSION:=v14.17.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=e44adbbed6756c2c1a01258383e9f00df30c147b36e438f6369b5ef1069abac3
+PKG_HASH:=56e05bff9331039317db417f772e635e0cd1c55f733f7b1b079d71ab5842c9ed
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,6 +1,6 @@
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1179,7 +1179,8 @@ Module._initPaths = function() {
+@@ -1184,7 +1184,8 @@ Module._initPaths = function() {
      path.resolve(process.execPath, '..') :
      path.resolve(process.execPath, '..', '..');
  

--- a/lang/node/patches/004-musl_support.patch
+++ b/lang/node/patches/004-musl_support.patch
@@ -20,7 +20,7 @@
    result = clock_gettime(CLOCK_MONOTONIC, &ts);
 --- a/deps/v8/src/base/platform/platform-posix.cc
 +++ b/deps/v8/src/base/platform/platform-posix.cc
-@@ -823,7 +823,7 @@ bool Thread::Start() {
+@@ -839,7 +839,7 @@ bool Thread::Start() {
  #if V8_OS_MACOSX
      // Default on Mac OS X is 512kB -- bump up to 1MB
      stack_size = 1 * 1024 * 1024;

--- a/lang/node/patches/999-delete_unnecessary_libraries_for_host_execute.patch
+++ b/lang/node/patches/999-delete_unnecessary_libraries_for_host_execute.patch
@@ -1,6 +1,6 @@
 --- a/tools/icu/icu-generic.gyp
 +++ b/tools/icu/icu-generic.gyp
-@@ -522,6 +522,7 @@
+@@ -419,6 +419,7 @@
        'target_name': 'genrb',
        'type': 'executable',
        'toolsets': [ 'host' ],
@@ -8,7 +8,7 @@
        'dependencies': [ 'icutools' ],
        'sources': [
          '<@(icu_src_genrb)'
-@@ -538,6 +539,7 @@
+@@ -435,6 +436,7 @@
        'target_name': 'iculslocs',
        'toolsets': [ 'host' ],
        'type': 'executable',
@@ -16,7 +16,7 @@
        'dependencies': [ 'icutools' ],
        'sources': [
          'iculslocs.cc',
-@@ -550,6 +552,7 @@
+@@ -447,6 +449,7 @@
        'target_name': 'icupkg',
        'toolsets': [ 'host' ],
        'type': 'executable',
@@ -24,7 +24,7 @@
        'dependencies': [ 'icutools' ],
        'sources': [
          '<@(icu_src_icupkg)',
-@@ -561,6 +564,7 @@
+@@ -458,6 +461,7 @@
        'target_name': 'genccode',
        'toolsets': [ 'host' ],
        'type': 'executable',

--- a/lang/node/patches/999-fix_icu_conflict.patch
+++ b/lang/node/patches/999-fix_icu_conflict.patch
@@ -1,14 +1,14 @@
 --- a/tools/icu/icu-generic.gyp
 +++ b/tools/icu/icu-generic.gyp
-@@ -181,6 +181,7 @@
-               '<(icu_path)/source/i18n/uspoof_wsconf.h',
-             ]}],
-             ],
+@@ -107,6 +107,7 @@
+           'sources': [
+             '<@(icu_src_i18n)'
+           ],
 +          'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
            'include_dirs': [
              '<(icu_path)/source/i18n',
            ],
-@@ -189,6 +190,7 @@
+@@ -115,6 +116,7 @@
            ],
            'dependencies': [ 'icuucx', 'icu_implementation', 'icu_uconfig', 'icu_uconfig_target' ],
            'direct_dependent_settings': {
@@ -16,7 +16,7 @@
              'include_dirs': [
                '<(icu_path)/source/i18n',
              ],
-@@ -275,6 +277,7 @@
+@@ -201,6 +203,7 @@
                # full data - no trim needed
                'sources': [ '<(SHARED_INTERMEDIATE_DIR)/icudt<(icu_ver_major)_dat.<(icu_asm_ext)' ],
                'dependencies': [ 'genccode#host', 'icupkg#host', 'icu_implementation#host', 'icu_uconfig' ],
@@ -24,7 +24,7 @@
                'include_dirs': [
                  '<(icu_path)/source/common',
                ],
-@@ -359,6 +362,7 @@
+@@ -285,6 +288,7 @@
                # This file contains the small ICU data
                'sources': [ '<(SHARED_INTERMEDIATE_DIR)/icusmdt<(icu_ver_major)_dat.<(icu_asm_ext)' ],
                # for umachine.h
@@ -32,7 +32,7 @@
                'include_dirs': [
                  '<(icu_path)/source/common',
                ],
-@@ -375,6 +379,7 @@
+@@ -301,6 +305,7 @@
        'sources': [
          '<@(icu_src_stubdata)'
        ],
@@ -40,7 +40,7 @@
        'include_dirs': [
          '<(icu_path)/source/common',
        ],
-@@ -443,6 +448,7 @@
+@@ -340,6 +345,7 @@
            '_XOPEN_SOURCE_EXTENDED=0',
          ]}],
        ],
@@ -48,7 +48,7 @@
        'include_dirs': [
          '<(icu_path)/source/common',
        ],
-@@ -452,6 +458,7 @@
+@@ -349,6 +355,7 @@
        'cflags_c': ['-std=c99'],
        'export_dependent_settings': [ 'icu_uconfig', 'icu_uconfig_target' ],
        'direct_dependent_settings': {
@@ -56,7 +56,7 @@
          'include_dirs': [
            '<(icu_path)/source/common',
          ],
-@@ -482,6 +489,7 @@
+@@ -379,6 +386,7 @@
          '<(icu_path)/source/tools/toolutil/dbgutil.cpp',
          '<(icu_path)/source/tools/toolutil/dbgutil.h',
        ],
@@ -64,7 +64,7 @@
        'include_dirs': [
          '<(icu_path)/source/common',
          '<(icu_path)/source/i18n',
-@@ -501,6 +509,7 @@
+@@ -398,6 +406,7 @@
          }]
        ],
        'direct_dependent_settings': {


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: aarch64, arm, i386, x86_64, mipsel (pistachio)
Run tested: (qemu 5.2.0) aarch64, arm, i386, x86_64

Description:
Update to v14.17.0

Notable Changes:
Diagnostics channel (experimental module)
UUID support in the crypto module
Experimental support for AbortController and AbortSignal

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
