### PR TITLE
tinc: Add possibility to populate more config variables via uci

### DIFF
--- a/net/tinc/Makefile
+++ b/net/tinc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tinc
 PKG_VERSION:=1.1-git
-PKG_RELEASE=$(PKG_SOURCE_VERSION)-1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=http://tinc-vpn.org/git/tinc

--- a/net/tinc/files/tinc.init
+++ b/net/tinc/files/tinc.init
@@ -88,26 +88,41 @@ prepare_host() {
 		[ "$2" != "$n" ] && return 1
 	fi
 
+	HOST_CONF_FILE="$TMP_TINC/$n/hosts/$s"
+	MANDATORY_PARAM_IN_UCI=0
+	[ ! -f "/etc/tinc/$n/hosts/$s" ] && {
+	        config_get pk "$s" "PublicKey"
+		config_get na "$s" "Name"
+		if [ -n "$pk" -a -n "$na" ] ; then
+		        HOST_CONF_FILE="$TMP_TINC/$n/hosts/$na"
+		        MANDATORY_PARAM_IN_UCI=1
+		fi
+	}
+
 	# host disabled?
 	section_enabled "$s" || {
-		[ -f "$TMP_TINC/$n/hosts/$s" ] && rm "$TMP_TINC/$n/hosts/$s"
+		[ -f "$HOST_CONF_FILE" ] && rm "$HOST_CONF_FILE"
 		return 1
 	}
 
 	[ ! -f "/etc/tinc/$n/hosts/$s" ] && {
-		echo -n "tinc: Warning, public key for $s for network $n "
-		echo -n "missing in /etc/tinc/$n/hosts/$s, "
-		echo "skipping configuration of $s"
-		return 1
+		if [ "$MANDATORY_PARAM_IN_UCI" -eq 1 ] ; then
+			touch "$HOST_CONF_FILE" ;
+		else
+			echo -n "tinc: Warning, public key for $s for network $n "
+			echo -n "missing in /etc/tinc/$n/hosts/$s, "
+			echo "skipping configuration of $s"
+			return 1
+		fi
 	}
 
 	# append flags
-	append_conf_bools "$s" "$TMP_TINC/$n/hosts/$s" \
+	append_conf_bools "$s" "$HOST_CONF_FILE" \
 		ClampMSS IndirectData PMTUDiscovery TCPOnly
 
 	# append params
-	append_conf_params "$s" "$TMP_TINC/$n/hosts/$s" \
-		Address Cipher Compression Digest MACLength PMTU \
+	append_conf_params "$s" "$HOST_CONF_FILE" \
+		Address Cipher Compression Digest Ed25519PublicKey MACLength Name PMTU \
 		Port PublicKey PublicKeyFile Subnet
 }
 


### PR DESCRIPTION
Signed-off-by: Erwan MAS <erwan@mas.nom.fr>

Maintainer: @ErwanMAS 
Compile tested: sdk-ramips-mt7621 , snapshot  
Run tested: ramips/ mt7621 / MT1300  snapshot

Description:
  - add Name,Ed25519PublicKey parameter to UCI configuration
  - alter logic to allow full configuration of a Host in UCI 

Can you grant access to openwrt/packages repository ?
