### PR TITLE
bluld: add new package

### DIFF
--- a/utils/bluld/Makefile
+++ b/utils/bluld/Makefile
@@ -1,0 +1,47 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bluld
+PKG_VERSION:=1.1.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/ktgeek/$(PKG_NAME)/releases/download/v$(PKG_VERSION)
+PKG_HASH:=995474bca662cfd8a693a3ab48bdddb2e09c258183a9c29aeddfa341a5082d0e
+
+PKG_MAINTAINER:=Keith T. Garner <kgarner@kgarner.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+EXTRA_CXXFLAGS = -I$(LINUX_DIR)/include
+EXTRA_CFLAGS = -I$(LINUX_DIR)/include
+
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/bluld
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Blinkstick User space LED Daemon
+  DEPENDS:=+kmod-usb-hid +kmod-leds-uleds +libstdcpp +hidapi
+endef
+
+define Package/bluld/description
+  A daemon to expose a Blinkstick to the Linux kernel LED class via /dev/uleds. (Kernel 4.10+ required.)
+endef
+
+define Package/bluld/conffiles
+/etc/config/bluld
+endef
+
+define Package/bluld/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/bluld $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/bluld.conf $(1)/etc/config/bluld
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/bluld.init $(1)/etc/init.d/bluld
+endef
+
+$(eval $(call BuildPackage,bluld))

--- a/utils/bluld/files/bluld.conf
+++ b/utils/bluld/files/bluld.conf
@@ -1,0 +1,3 @@
+config bluld uleds
+	option led_count 1
+	list colors 'green'

--- a/utils/bluld/files/bluld.init
+++ b/utils/bluld/files/bluld.init
@@ -1,0 +1,39 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2021 Keith T. Garner
+
+START=90
+
+USE_PROCD=1
+
+PROG=/usr/sbin/bluld
+
+start_service() {
+    config_load bluld
+
+    local led_count
+    local colors
+
+    config_get led_count uleds led_count
+    config_get colors uleds colors
+
+    procd_open_instance
+    procd_set_param command $PROG $led_count $colors
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_set_param nice 20
+    procd_close_instance
+}
+
+service_triggers() {
+    procd_add_reload_trigger "bluld"
+}
+
+reload_service() {
+    stop
+    start
+    /etc/init.d/led restart
+}
+
+restart() {
+    reload_service
+}


### PR DESCRIPTION
Signed-off-by: Keith T. Garner <kgarner@kgarner.com>

Maintainer: me
Compile tested: x86-64, 19.07.7, 21.02-rc1 
Run tested: x86-64, 19.07.7, tested by running for a year+, tested by running without a config, memory profiling

Description: A small daemon using the user-space LED driver to expose Blinkstick LEDs in /sys/class/leds