### PR TITLE
sudo: bump to version 1.9.7

### DIFF
--- a/admin/sudo/Makefile
+++ b/admin/sudo/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sudo
-PKG_VERSION:=1.9.6p1
+PKG_VERSION:=1.9.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.sudo.ws/dist
-PKG_HASH:=a9e9cdc058fafeb9cd3ebfb864c81755e524d98aa022152763f25bce8ca3ca90
+PKG_HASH:=2bbe7c2d6699b84d950ef9a43f09d4d967b8bc244b73bc095c4202068ddbe549
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 
@@ -53,6 +53,7 @@ CONFIGURE_ARGS += \
 	--with-editor=/bin/vi \
 	--without-lecture \
 	--disable-zlib \
+	--disable-openssl \
 	--with-rundir=/var/lib/sudo \
 	--with-vardir=/var/lib/sudo
 

--- a/admin/sudo/patches/010-cross-compile-fixes.patch
+++ b/admin/sudo/patches/010-cross-compile-fixes.patch
@@ -1,6 +1,6 @@
 --- a/lib/util/Makefile.in
 +++ b/lib/util/Makefile.in
-@@ -219,10 +219,10 @@ libsudo_util.la: $(LTOBJS) @LT_LDDEP@
+@@ -221,10 +221,10 @@ libsudo_util.la: $(LTOBJS) @LT_LDDEP@
  	esac
  
  siglist.c: mksiglist

--- a/admin/sudo/patches/020-no-owner-change.patch
+++ b/admin/sudo/patches/020-no-owner-change.patch
@@ -3,7 +3,7 @@
 @@ -73,7 +73,7 @@ SHELL = @SHELL@
  SED = @SED@
  
- INSTALL = $(SHELL) $(top_srcdir)/install-sh -c
+ INSTALL = $(SHELL) $(scriptdir)/install-sh -c
 -INSTALL_OWNER = -o $(install_uid) -g $(install_gid)
 +INSTALL_OWNER =
  


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/97e820c6d61d174da1091a692546e979a5a45e42
Run tested: x86 https://github.com/openwrt/openwrt/commit/97e820c6d61d174da1091a692546e979a5a45e42

--------------------------------------------------------

Refresh  patch 010-cross-compile-fixes.patch
Re-apply patch 020-no-owner-change.patch

Also we need to explicitly disable OpenSSL support.
We may enable it later if needed/requested.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>