### PR TITLE
ADBLOCK: Removed trailing commas; some JSON readers broke

### DIFF
--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -242,7 +242,7 @@
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
 		"size": "VAR",
 		"focus": "general",
-		"descurl": "https://www.shallalist.de",
+		"descurl": "https://www.shallalist.de"
 	},
 	"smarttv_tracking": {
 		"url": "https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/SmartTV.txt",
@@ -277,7 +277,7 @@
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
 		"size": "VAR",
 		"focus": "general",
-		"descurl": "https://dsi.ut-capitole.fr/blacklists/index_en.php",
+		"descurl": "https://dsi.ut-capitole.fr/blacklists/index_en.php"
 	},
 	"wally3k": {
 		"url": "https://v.firebog.net/hosts/static/w3kbl.txt",


### PR DESCRIPTION
Simple fix to help some JSON readers like JQ.