### PR TITLE
[21.02] php7: backports updates and fixes

### DIFF
--- a/lang/php7-pecl-imagick/Makefile
+++ b/lang/php7-pecl-imagick/Makefile
@@ -9,7 +9,7 @@ PECL_NAME:=imagick
 PECL_LONGNAME:=Image Processing (ImageMagick binding)
 
 PKG_VERSION:=3.4.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_HASH:=8dd5aa16465c218651fc8993e1faecd982e6a597870fd4b937e9ece02d567077
 
 PKG_NAME:=php7-pecl-imagick
@@ -28,6 +28,8 @@ PKG_BUILD_PARALLEL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 include ../php7/pecl.mk
+
+CONFIGURE_ARGS+= --with-imagick="$(STAGING_DIR)/usr"
 
 $(eval $(call PHP7PECLPackage,imagick,$(PECL_LONGNAME),+imagemagick,30))
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=7.4.16
+PKG_VERSION:=7.4.18
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=1c16cefaf88ded4c92eed6a8a41eb682bb2ef42429deb55f1c4ba159053fb98b
+PKG_HASH:=ab97f22b128d21dcbc009b50a37aaea0051b2721cbcd122d9e00e6ffc3c4b7e1
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0

--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=7.4.18
+PKG_VERSION:=7.4.19
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=ab97f22b128d21dcbc009b50a37aaea0051b2721cbcd122d9e00e6ffc3c4b7e1
+PKG_HASH:=6c17172c4a411ccb694d9752de899bb63c72a0a3ebe5089116bc13658a1467b2
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs

Description:

Update php7 to latest release.
While at, also backport fix for php7-pecl-imagick.
