### PR TITLE
[21.02] rsync: Add rrsync script

### DIFF
--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -69,6 +69,15 @@ define Package/rsyncd
   URL:=https://rsync.samba.org/
 endef
 
+define Package/rrsync
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=File Transfer
+  TITLE:=Restricted rsync script
+  DEPENDS:=+rsync +perlbase-file +perl @(PACKAGE_openssh-server||PACKAGE_openssh-server-pam)
+  URL:=https://www.samba.org/ftp/unpacked/rsync/support/rrsync
+endef
+
 define Package/rsync/description
  rsync is a program that allows files to be copied to and from remote machines
  in much the same way as rcp. It has many more options than rcp, and uses the
@@ -100,5 +109,17 @@ define Package/rsyncd/install
 	$(INSTALL_BIN) ./files/rsyncd.init $(1)/etc/init.d/rsyncd
 endef
 
+define Package/rrsync/description
+  rrsync is a script which wraps around rsync to restrict its permission to a
+  particular subdirectory via ~/.ssh/authorized_keys and/or to read-only
+  or write-only mode
+endef
+
+define Package/rrsync/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/support/rrsync $(1)/usr/bin
+endef
+
 $(eval $(call BuildPackage,rsync))
 $(eval $(call BuildPackage,rsyncd))
+$(eval $(call BuildPackage,rrsync))


### PR DESCRIPTION
Maintainer: Maxim Storchak <m.storchak@gmail.com>
Compile tested: Qualcomm Atheros IPQ806X, NETGEAR Nighthawk X4S R7800
Run tested: Qualcomm Atheros IPQ806X, NETGEAR Nighthawk X4S R7800

Description:

Rrsync is a perl script that is supplied as an extra with the rsync program.
It must be used in conjunction with openssh-server or openssh-server-pam
as it requires ~/.ssh/authorized_keys which is not supported by dropbear.

Rrsync allows selective access to subdirectories in either read-only, write-only or read-write mode,
depending on settings in authorized_keys. This allows for safer, restrictive access.
It's particularly useful for automated backup purposes.

An example usage would be this entry:

command="/usr/bin/rrsync -ro /home" <public key here>

This would allow a system connecting with this public key to be able to rsync FROM the
/home directory tree only. It could not write to this directory, nor read from any other directory.

Signed-off-by: Matt Reeve <matt@mreeve.com>
(cherry picked from commit 081229aa09e28435d3d8802ce053a5d4eee8978a)


