### PR TITLE
nginx-util: do not use fallthrough attribute

### DIFF
--- a/net/nginx-util/Makefile
+++ b/net/nginx-util/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx-util
-PKG_VERSION:=1.5
+PKG_VERSION:=1.6
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Peter Stadler <peter.stadler@student.uibk.ac.at>
 

--- a/net/nginx-util/src/nginx-ssl-util.hpp
+++ b/net/nginx-util/src/nginx-ssl-util.hpp
@@ -166,9 +166,14 @@ static constexpr auto _escape = _Line{
         std::string ret{};
         for (char c : strptr) {
             switch (c) {
-                case '^': ret += '\\'; [[fallthrough]];
-                case '_': [[fallthrough]];
-                case '-': ret += c; break;
+                case '^':
+                    ret += '\\';
+                    ret += c;
+                    break;
+                case '_':
+                case '-':
+                    ret += c;
+                    break;
                 default:
                     if ((isalpha(c) != 0) || (isdigit(c) != 0)) {
                         ret += c;


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, x86_64 qemu, master
Run tested: x86_64, x86_64 qemu, master, run tests

Description: fix compile warning/error (issue #15653)
