### PR TITLE
[19-07] ddns-scripts: standardize required params declaration

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.8
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=13
+PKG_RELEASE:=14
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=

--- a/net/ddns-scripts/files/update_route53_v1.sh
+++ b/net/ddns-scripts/files/update_route53_v1.sh
@@ -3,10 +3,10 @@
 # based on Yuval Adam's route53.sh found at https://github.com/yuvadm/route53-ddns/blob/master/route53.sh
 # 2017 Max Berger <max at berger dot name>
 
-[ -z "${CURL_SSL}" ] && write_log 14 "Amazon AWS Route53 communication require cURL with SSL support. Please install"
-[ -z "{$username}" ] && write_log 14 "Service section not configured correctly! Missing key as 'username'"
-[ -z "${password}" ] && write_log 14 "Service section not configured correctly! Missing secret as 'password'"
-[ -z "${domain}" ] && write_log 14 "Service section not configured correctly! Missing zone id as 'domain'"
+[ -z "$CURL_SSL" ] && write_log 14 "Amazon AWS Route53 communication require cURL with SSL support. Please install"
+[ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing key as 'username'"
+[ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing secret as 'password'"
+[ -z "$domain" ] && write_log 14 "Service section not configured correctly! Missing zone id as 'domain'"
 
 ENDPOINT="route53.amazonaws.com"
 RECORD_TTL=300
@@ -17,8 +17,8 @@ RECORD_VALUE="${LOCAL_IP}"
 HOSTED_ZONE_ID="${domain}"
 API_PATH="/2013-04-01/hostedzone/${HOSTED_ZONE_ID}/rrset/"
 
-AWS_ACCESS_KEY_ID="${username}"
-AWS_SECRET_ACCESS_KEY="${password}"
+AWS_ACCESS_KEY_ID="$username"
+AWS_SECRET_ACCESS_KEY="$password"
 AWS_REGION='us-east-1'
 AWS_SERVICE='route53'
 


### PR DESCRIPTION
The luci app scan the script and search for params in the form of $required_params.
This script use the form "${required_params}" and cause confusion with the luci app by hiding needed values. Fix this by using the standard way to declare required params following other ddns scripts.

Fixes: #14477

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
