### PR TITLE
ddns-scripts: Fix for domains with dash

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -70,11 +70,11 @@ IPV6_REGEX="\(\([0-9A-Fa-f]\{1,4\}:\)\{1,\}\)\(\([0-9A-Fa-f]\{1,4\}\)\{0,1\}\)\(
 # characters that are dangerous to pass to a shell command line
 SHELL_ESCAPE="[\"\'\`\$\!();><{}?|\[\]\*\\\\]"
 
-# dns character set
+# dns character set. "-" must be the last character
 DNS_CHARSET="[@a-zA-Z0-9._-]"
 
-# domains can have * for wildcard
-DNS_CHARSET_DOMAIN="[@a-zA-Z0-9._-*]"
+# domains can have * for wildcard. "-" must be the last character
+DNS_CHARSET_DOMAIN="[@a-zA-Z0-9._*-]"
 
 # detect if called by ddns-lucihelper.sh script, disable retrys (empty variable == false)
 LUCI_HELPER=$(printf %s "$MYPROG" | grep -i "luci")


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: mvebu, master
Run tested: mvebu, master: Tested with cloudflare wildcard subdomain, it works

Description:

Fixes ddns-scripts so it will be able to update a domain with dash

It looks like "-" must be the last character, so I have also added a comment. http://mywiki.wooledge.org/glob#globasciiranges_.28since_bash_4.3-alpha.29