### PR TITLE
xr_usb_serial_common: fix compilation for newer linux kernels

### DIFF
--- a/libs/xr_usb_serial_common/patches/0001-xr_usb_serial_common-move-fix-compile-warning-for-ne.patch
+++ b/libs/xr_usb_serial_common/patches/0001-xr_usb_serial_common-move-fix-compile-warning-for-ne.patch
@@ -1,0 +1,98 @@
+From e27f270e005aacdd8dce748c66cb22dba998dc69 Mon Sep 17 00:00:00 2001
+From: Florian Eckert <fe@dev.tdt.de>
+Date: Thu, 20 May 2021 13:18:33 +0200
+Subject: [PATCH 1/3] xr_usb_serial_common: move fix compile warning for newer
+ kernels
+
+On newer kernel a compilation warning is triggerd, that die variable is
+not used. To fix this move the defintions into the precompiler path.
+
+Signed-off-by: Florian Eckert <fe@dev.tdt.de>
+---
+ .../xr_usb_serial_common.c                    | 22 +++++++++----------
+ 1 file changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/xr_usb_serial_common-1a/xr_usb_serial_common.c b/xr_usb_serial_common-1a/xr_usb_serial_common.c
+index 972a9e7..201fbd3 100644
+--- a/xr_usb_serial_common-1a/xr_usb_serial_common.c
++++ b/xr_usb_serial_common-1a/xr_usb_serial_common.c
+@@ -258,7 +258,6 @@ static void xr_usb_serial_ctrl_irq(struct urb *urb)
+ {
+ 	struct xr_usb_serial *xr_usb_serial = urb->context;
+ 	struct usb_cdc_notification *dr = urb->transfer_buffer;
+-	struct tty_struct *tty;
+ 	unsigned char *data;
+ 	int newctrl;
+ 	int retval;
+@@ -307,9 +306,10 @@ static void xr_usb_serial_ctrl_irq(struct urb *urb)
+ 					__func__);
+ 			tty_port_tty_hangup(&xr_usb_serial->port, false);
+ 		}
+-#else		
++#else
++		struct tty_struct *tty;
+ 		tty = tty_port_tty_get(&xr_usb_serial->port);
+-        newctrl = get_unaligned_le16(data);
++		newctrl = get_unaligned_le16(data);
+ 		if (tty)
+ 		{
+ 			if (!xr_usb_serial->clocal &&
+@@ -390,7 +390,6 @@ static int xr_usb_serial_submit_read_urbs(struct xr_usb_serial *xr_usb_serial, g
+ }
+ static void xr_usb_serial_process_read_urb(struct xr_usb_serial *xr_usb_serial, struct urb *urb)
+ {
+-    struct tty_struct *tty;
+ 	if (!urb->actual_length)
+ 		return;
+ #if LINUX_VERSION_CODE > KERNEL_VERSION(3, 9, 0)    
+@@ -398,7 +397,8 @@ static void xr_usb_serial_process_read_urb(struct xr_usb_serial *xr_usb_serial,
+ 			urb->actual_length);
+ 	tty_flip_buffer_push(&xr_usb_serial->port);
+ #else
+-    tty = tty_port_tty_get(&xr_usb_serial->port);
++	struct tty_struct *tty;
++	tty = tty_port_tty_get(&xr_usb_serial->port);
+ 	if (!tty)
+ 		return;
+ 	tty_insert_flip_string(tty, urb->transfer_buffer, urb->actual_length);
+@@ -465,18 +465,18 @@ static void xr_usb_serial_write_bulk(struct urb *urb)
+ static void xr_usb_serial_softint(struct work_struct *work)
+ {
+ 	struct xr_usb_serial *xr_usb_serial = container_of(work, struct xr_usb_serial, work);
+-    struct tty_struct *tty;
+-	
++
+ 	dev_vdbg(&xr_usb_serial->data->dev, "%s\n", __func__);
+ #if LINUX_VERSION_CODE > KERNEL_VERSION(3, 9, 0)
+ 	tty_port_tty_wakeup(&xr_usb_serial->port);
+-#else	
++#else
++	struct tty_struct *tty;
+ 	tty = tty_port_tty_get(&xr_usb_serial->port);
+ 	if (!tty)
+ 		return;
+ 	tty_wakeup(tty);
+ 	tty_kref_put(tty);
+-#endif	
++#endif
+ }
+ 
+ /*
+@@ -1622,12 +1622,12 @@ err_out:
+ static int xr_usb_serial_reset_resume(struct usb_interface *intf)
+ {
+ 	struct xr_usb_serial *xr_usb_serial = usb_get_intfdata(intf);
+-    struct tty_struct *tty;
+ 	if (test_bit(ASYNCB_INITIALIZED, &xr_usb_serial->port.flags)){
+ #if LINUX_VERSION_CODE > KERNEL_VERSION(3, 9, 0)	
+ 	tty_port_tty_hangup(&xr_usb_serial->port, false);
+ #else
+- 	tty = tty_port_tty_get(&xr_usb_serial->port);
++	struct tty_struct *tty;
++	tty = tty_port_tty_get(&xr_usb_serial->port);
+ 	if (tty) {
+ 		tty_hangup(tty);
+ 		tty_kref_put(tty);
+-- 
+2.20.1
+

--- a/libs/xr_usb_serial_common/patches/0002-xr_usb_serial_common-fix-compiler-misleading-indenta.patch
+++ b/libs/xr_usb_serial_common/patches/0002-xr_usb_serial_common-fix-compiler-misleading-indenta.patch
@@ -1,0 +1,158 @@
+From c257743f25bb0a6fe812138e2a00d222504e17e8 Mon Sep 17 00:00:00 2001
+From: Florian Eckert <fe@dev.tdt.de>
+Date: Thu, 20 May 2021 13:28:35 +0200
+Subject: [PATCH 2/3] xr_usb_serial_common: fix compiler misleading-indentation
+ warning
+
+The source code is not formatted correctly. The compiler gives a
+`misleading-indentation` warning. To fix this, the code was reformatted
+from spaces to tabs, as in the rest of the source file.
+
+Signed-off-by: Florian Eckert <fe@dev.tdt.de>
+---
+ .../xr_usb_serial_common.c                    | 119 ++++++++----------
+ 1 file changed, 52 insertions(+), 67 deletions(-)
+
+diff --git a/xr_usb_serial_common-1a/xr_usb_serial_common.c b/xr_usb_serial_common-1a/xr_usb_serial_common.c
+index 201fbd3..01424b6 100644
+--- a/xr_usb_serial_common-1a/xr_usb_serial_common.c
++++ b/xr_usb_serial_common-1a/xr_usb_serial_common.c
+@@ -825,9 +825,9 @@ static int xr_usb_serial_tty_ioctl(struct tty_struct *tty,
+ {
+ 	struct xr_usb_serial *xr_usb_serial = tty->driver_data;
+ 	int rv = -ENOIOCTLCMD;
+-    unsigned int  channel, reg, val;
++	unsigned int channel, reg, val;
++	short *data;
+ 
+-    short	*data;
+ 	switch (cmd) {
+ 	case TIOCGSERIAL: /* gets serial port data */
+ 		rv = get_serial_info(xr_usb_serial, (struct serial_struct __user *) arg);
+@@ -835,73 +835,58 @@ static int xr_usb_serial_tty_ioctl(struct tty_struct *tty,
+ 	case TIOCSSERIAL:
+ 		rv = set_serial_info(xr_usb_serial, (struct serial_struct __user *) arg);
+ 		break;
+-    case XR_USB_SERIAL_GET_REG:
+-                if (get_user(channel, (int __user *)arg))
+-                        return -EFAULT;
+-                if (get_user(reg, (int __user *)(arg + sizeof(int))))
+-                        return -EFAULT;
+-
+-                data = kmalloc(2, GFP_KERNEL);
+-                if (data == NULL) {
+-                        dev_err(&xr_usb_serial->control->dev, "%s - Cannot allocate USB buffer.\n", __func__);
+-                        return -ENOMEM;
++	case XR_USB_SERIAL_GET_REG:
++		if (get_user(channel, (int __user *)arg))
++			return -EFAULT;
++		if (get_user(reg, (int __user *)(arg + sizeof(int))))
++			return -EFAULT;
++		data = kmalloc(2, GFP_KERNEL);
++		if (data == NULL) {
++			dev_err(&xr_usb_serial->control->dev, "%s - Cannot allocate USB buffer.\n", __func__);
++			return -ENOMEM;
+ 		}
+-        			
+-		        if (channel == -1)
+-		        {
+-		          rv = xr_usb_serial_get_reg(xr_usb_serial,reg, data);
+-		        }
+-				else
+-				{
+-			  	  rv = xr_usb_serial_get_reg_ext(xr_usb_serial,channel,reg, data);
+-				}
+-                if (rv != 1) {
+-                        dev_err(&xr_usb_serial->control->dev, "Cannot get register (%d)\n", rv);
+-                        kfree(data);
+-                        return -EFAULT;
+-                }
+-				if (put_user(le16_to_cpu(*data), (int __user *)(arg + 2 * sizeof(int))))
+-              	{
+-                   dev_err(&xr_usb_serial->control->dev, "Cannot put user result\n");
+-                   kfree(data);
+-                   return -EFAULT;
+-                }
+-                rv = 0;
+-                kfree(data);
+-                break;
+-
+-      case XR_USB_SERIAL_SET_REG:
+-                if (get_user(channel, (int __user *)arg))
+-                        return -EFAULT;
+-                if (get_user(reg, (int __user *)(arg + sizeof(int))))
+-                        return -EFAULT;
+-                if (get_user(val, (int __user *)(arg + 2 * sizeof(int))))
+-                        return -EFAULT;
+-
+-			if (channel == -1)
+-			{
+-				rv = xr_usb_serial_set_reg(xr_usb_serial,reg, val);
+-			}
+-			else
+-			{
+-			 	rv = xr_usb_serial_set_reg_ext(xr_usb_serial,channel,reg, val);
+-				
+-			}
+-		    if (rv < 0)
+-               return -EFAULT;  
+-			rv = 0;
+-            break;
++		if (channel == -1)
++			rv = xr_usb_serial_get_reg(xr_usb_serial,reg, data);
++		else
++			rv = xr_usb_serial_get_reg_ext(xr_usb_serial,channel,reg, data);
++		if (rv != 1) {
++			dev_err(&xr_usb_serial->control->dev, "Cannot get register (%d)\n", rv);
++			kfree(data);
++			return -EFAULT;
++		}
++		if (put_user(le16_to_cpu(*data), (int __user *)(arg + 2 * sizeof(int)))) {
++			dev_err(&xr_usb_serial->control->dev, "Cannot put user result\n");
++			kfree(data);
++			return -EFAULT;
++		}
++		rv = 0;
++		kfree(data);
++		break;
++	case XR_USB_SERIAL_SET_REG:
++		if (get_user(channel, (int __user *)arg))
++			return -EFAULT;
++		if (get_user(reg, (int __user *)(arg + sizeof(int))))
++			return -EFAULT;
++		if (get_user(val, (int __user *)(arg + 2 * sizeof(int))))
++			return -EFAULT;
++		if (channel == -1)
++			rv = xr_usb_serial_set_reg(xr_usb_serial,reg, val);
++		else
++			rv = xr_usb_serial_set_reg_ext(xr_usb_serial,channel,reg, val);
++		if (rv < 0)
++			return -EFAULT;
++		rv = 0;
++		break;
+ 	case XR_USB_SERIAL_LOOPBACK:
+-		     if (get_user(channel, (int __user *)arg))
+-                        return -EFAULT;
+-		     if (channel == -1)
+-			   channel = xr_usb_serial->channel;
+-			 rv = xr_usb_serial_set_loopback(xr_usb_serial,channel);
+-			 if (rv < 0)
+-               return -EFAULT;
+-			 rv = 0;
+-		     break;
+-		
++		if (get_user(channel, (int __user *)arg))
++			return -EFAULT;
++		if (channel == -1)
++			channel = xr_usb_serial->channel;
++		rv = xr_usb_serial_set_loopback(xr_usb_serial,channel);
++		if (rv < 0)
++			return -EFAULT;
++		rv = 0;
++		break;
+ 	}
+ 
+ 	return rv;
+-- 
+2.20.1
+

--- a/libs/xr_usb_serial_common/patches/0003-xr_usb_serial_common-fix-compiler-error-for-undefine.patch
+++ b/libs/xr_usb_serial_common/patches/0003-xr_usb_serial_common-fix-compiler-error-for-undefine.patch
@@ -1,0 +1,48 @@
+From f9bbfd4bd71d7c1b65e338b89f558a463dcac286 Mon Sep 17 00:00:00 2001
+From: Florian Eckert <fe@dev.tdt.de>
+Date: Thu, 20 May 2021 13:35:52 +0200
+Subject: [PATCH 3/3] xr_usb_serial_common: fix compiler error for undefined
+ value
+
+The used precompiler defintion ASYNCB_INITIALIZED is not useable for new
+kernel versions. This fix this use the new API to query this state.
+
+Signed-off-by: Florian Eckert <fe@dev.tdt.de>
+---
+ xr_usb_serial_common-1a/xr_usb_serial_common.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/xr_usb_serial_common-1a/xr_usb_serial_common.c b/xr_usb_serial_common-1a/xr_usb_serial_common.c
+index 01424b6..d0c2513 100644
+--- a/xr_usb_serial_common-1a/xr_usb_serial_common.c
++++ b/xr_usb_serial_common-1a/xr_usb_serial_common.c
+@@ -1556,7 +1556,7 @@ static int xr_usb_serial_suspend(struct usb_interface *intf, pm_message_t messag
+ 	if (cnt)
+ 		return 0;
+ 
+-	if (test_bit(ASYNCB_INITIALIZED, &xr_usb_serial->port.flags))
++	if (tty_port_initialized(&xr_usb_serial->port))
+ 		stop_data_traffic(xr_usb_serial);
+ 
+ 	return 0;
+@@ -1577,7 +1577,7 @@ static int xr_usb_serial_resume(struct usb_interface *intf)
+ 	if (cnt)
+ 		return 0;
+ 
+-	if (test_bit(ASYNCB_INITIALIZED, &xr_usb_serial->port.flags)) {
++	if (tty_port_initialized(&xr_usb_serial->port)) {
+ 		rv = usb_submit_urb(xr_usb_serial->ctrlurb, GFP_NOIO);
+ 
+ 		spin_lock_irq(&xr_usb_serial->write_lock);
+@@ -1607,7 +1607,7 @@ err_out:
+ static int xr_usb_serial_reset_resume(struct usb_interface *intf)
+ {
+ 	struct xr_usb_serial *xr_usb_serial = usb_get_intfdata(intf);
+-	if (test_bit(ASYNCB_INITIALIZED, &xr_usb_serial->port.flags)){
++	if (tty_port_initialized(&xr_usb_serial->port)) {
+ #if LINUX_VERSION_CODE > KERNEL_VERSION(3, 9, 0)	
+ 	tty_port_tty_hangup(&xr_usb_serial->port, false);
+ #else
+-- 
+2.20.1
+


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: x86_64, APU3, latest openwrt-21.02
Run tested: no

Description:
Due to the update of the [kernel](https://github.com/openwrt/openwrt/commit/9d21eccc6b763a1e2f0a0ed0bcb4561ea0ed68ff) in openwrt-21.02 this external serial driver can not be built anymore, the API in the kernel has changed.
So that this builds again, the noted compiler errors and warnings were fixed with this patchset.

Since I don't have this hardware available, I can't do an integration test.
The build however now builds without warnings and errors.

Currently only openwrt-21.02 branch fails because of the kernel change in the tty subsystem by kernel commit https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v5.4.120&id=932d67b84b4fb949c6bae8dca95d17f4ecbdc275 I think it is a matter of time until the master kernel 5.10 also experiences this change and this package also fails in the master,


