### PR TITLE
micrond: store cronjobs in /usr/share/micron.d

### DIFF
--- a/utils/micrond/Makefile
+++ b/utils/micrond/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=micrond
 PKG_VERSION:=1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=BSD-2-clause
 
 include $(INCLUDE_DIR)/package.mk

--- a/utils/micrond/files/etc/init.d/micrond
+++ b/utils/micrond/files/etc/init.d/micrond
@@ -3,7 +3,7 @@
 START=50
 USE_PROCD=1
 
-CRONDIR=/usr/lib/micron.d
+CRONDIR=/usr/share/micron.d
 
 start_service() {
 	procd_open_instance


### PR DESCRIPTION
Maintainer: @NeoRaider @feckert @adschm 

Description:
Use the /usr/share/micron.d folder to store the cronjob files. The /usr/lib
folder is commonly used for libraries and internal binaries only. The job
file do not belong to this category.
