### PR TITLE
openvpn: added tun_ipv6 config option

### DIFF
--- a/net/openvpn/files/openvpn.options
+++ b/net/openvpn/files/openvpn.options
@@ -190,6 +190,7 @@ test_crypto
 tls_client
 tls_exit
 tls_server
+tun_ipv6
 up_delay
 up_restart
 username_as_common_name


### PR DESCRIPTION
Signed-off-by: Lucien Weller <lucien@wellernet.ch>

Maintainer: @mkrkn 
Compile tested: Netgear WNDR3700v4, 19.07.07
Run tested: Netgear WNDR3700v4, 19.07.07

Description: Added config option tun_ipv6 required for advanced IPv6 routing setup's (see https://community.openvpn.net/openvpn/wiki/IPv6)