### PR TITLE
netifyd: update to 3.07

### DIFF
--- a/net/netifyd/Makefile
+++ b/net/netifyd/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifyd
-PKG_RELEASE:=3
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Darryl Sokoloski <darryl@egloo.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 
@@ -16,10 +16,10 @@ PKG_INSTALL:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.com/netify.ai/public/netify-agent.git
-PKG_SOURCE_DATE:=2020-09-15
-PKG_SOURCE_VERSION:=v3.05
-#PKG_SOURCE_VERSION:=09fa5fb202ba95ee2d73a4eb0fefe9265d15c780
-PKG_MIRROR_HASH:=2bcaa54f1660a30070f0c79a79259e96f169a9c7a0fe4a1195bb74f7de184204
+PKG_SOURCE_DATE:=2021-05-19
+PKG_SOURCE_VERSION:=v3.07
+#PKG_SOURCE_VERSION:=a22c66b9d916347b34f6d26de2a95c94f446401b
+PKG_MIRROR_HASH:=de6c4ce7bb00ec72478a7eeaa44b1a30d2ef64202f8524a000bce6015441a5ca
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -80,6 +80,13 @@ endef
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/netifyd
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/netifyd/*.h $(1)/usr/include/netifyd
+	$(INSTALL_DIR) $(1)/usr/include/netifyd/pcap-compat
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/netifyd/pcap-compat/*.h $(1)/usr/include/netifyd/pcap-compat
+	$(INSTALL_DIR) $(1)/usr/include/netifyd/nlohmann
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/netifyd/nlohmann/*.hpp $(1)/usr/include/netifyd/nlohmann
+	$(INSTALL_DIR) $(1)/usr/include/libndpi-2.9.0
+	$(INSTALL_DIR) $(1)/usr/include/libndpi-2.9.0/libndpi
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libndpi-2.9.0/libndpi/*.h $(1)/usr/include/libndpi-2.9.0/libndpi
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetifyd.{a,so*} $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig

--- a/net/netifyd/files/netifyd.config
+++ b/net/netifyd/files/netifyd.config
@@ -1,6 +1,6 @@
 config netifyd
 	option enabled 1
 	option autoconfig 1
+#	option options '-t'
 #	option internal_if 'eth0'
 #	option external_if 'eth1'
-#	option filter 'not (udp and dst 239.255.255.250 and dst port 1900 and src 192.168.1.5)'

--- a/net/netifyd/files/netifyd.init
+++ b/net/netifyd/files/netifyd.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 #
-# Copyright (C) 2016-2019 eGloo, Incorporated
+# Copyright (C) 2016-2021 eGloo, Incorporated
 #
 # This is free software, licensed under the GNU General Public License v2.
 
@@ -11,39 +11,45 @@ USE_PROCD=1
 PROG=/usr/sbin/netifyd
 
 start_netifyd() {
-	local instance enabled autoconfig internal_if external_if
+    local autoconfig enabled external_if instance interfaces internal_if options
 
-	instance="$1"
+    instance="$1"
 
-	config_get_bool enabled "$instance" enabled 0
-	[ "$enabled" -eq 0 ] && return 0
+    source /usr/share/netifyd/functions.sh
+    load_modules
 
-	[ ! -d /var/run/netifyd ] && mkdir -p /var/run/netifyd
+    config_get_bool enabled "$instance" enabled 0
+    [ "$enabled" -eq 0 ] && return 0
 
-	config_get_bool autoconfig "$instance" autoconfig 1
-	config_get filter "$instance" filter
+    [ ! -d /var/run/netifyd ] && mkdir -p /var/run/netifyd
 
-	if [ "$autoconfig" -gt 0 ] ; then
-		source /usr/share/netifyd/functions.sh
-		load_modules
-		NETIFYD_AUTODETECT=yes
-		NETIFYD_OPTS=$(auto_detect_options)
-	else
-		config_get internal_if "$instance" internal_if "eth0"
-		config_get external_if "$instance" external_if "eth1"
-		NETIFYD_OPTS="-E $external_if -I $internal_if"
-	fi
+    config_get_bool autoconfig "$instance" autoconfig 1
 
+    if [ "$autoconfig" -gt 0 ]; then
+        NETIFYD_AUTODETECT=yes
+        interfaces="$(auto_detect_options)"
+    else
+        config_get internal_if "$instance" internal_if ""
+        for ifn in $internal_if; do
+            interfaces="${interfaces} -I ${ifn}"
+        done
+        config_get external_if "$instance" external_if ""
+        for ifn in $external_if; do
+            interfaces="${interfaces} -E ${ifn}"
+        done
+    fi
 
-	procd_open_instance
-	procd_set_param command $PROG -R $NETIFYD_OPTS
-	[ -n "$filter" ] && procd_append_param command -F "$filter"
-	procd_set_param file /etc/netifyd.conf
-	procd_set_param respawn
-	procd_close_instance
+    config_get_bool options "$instance" options ""
+
+    procd_open_instance
+    procd_set_param command $PROG -R $options $interfaces
+    procd_set_param file /etc/netifyd.conf
+    procd_set_param term_timeout 20
+    procd_set_param respawn
+    procd_close_instance
 }
 
 start_service() {
-	config_load netifyd
-	config_foreach start_netifyd netifyd
+    config_load netifyd
+    config_foreach start_netifyd netifyd
 }


### PR DESCRIPTION
Signed-off-by: Darryl Sokoloski darryl@sokoloski.ca

Maintainer: Darryl Sokoloski / @dsokoloski
Compile tested: arm_cortex-a15_neon-vfpv4, TP-Link Archer C2600, master
Run tested: TP-Link Archer C2600

Description:

[FIX] Process queued packets on termination instead of discarding.
[FIX] Force detection of all remaining undetected flows before terminating.
[FIX] Fixed packet queue memory leak.
[FIX] Increased TLS SNI buffer size from 64 to RFC 4366 size of 256 bytes.

[IMP] Sanitize MDNS answers of non-printable characters.
[IMP] Added support for plugin reloading on SIGHUP.
[IMP] Added support for new detection plugin types.
[IMP] Removed Git hash and build date/time from usage text.
[IMP] Reordered application detection logic.
[IMP] Added fully configurable multi-core DPI processing.
[IMP] Added GTP tunnel decapsulation support.
[IMP] Added new flow message type for sockets: flow_purge
[IMP] Completely refactored flow purge logic (moved to main thread).
[IMP] Removed lower/upper MACs from lower hash calculation. To be added back as an option.
[IMP] Added TCP seq order checking.
[IMP] Skype: always set application to skype when protocol was detected as Skype.
[IMP] FreeBSD: Various compilation fixes.
[IMP] OpenWrt: Added support for multiple manual interface configuration options.
[IMP] OpenWrt: Extended shutdown time from 5 to 20 seconds.