### PR TITLE
xr_usb_serial_common: fix kernel 5.10 builds

### DIFF
--- a/libs/xr_usb_serial_common/Makefile
+++ b/libs/xr_usb_serial_common/Makefile
@@ -4,7 +4,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=usb-serial-xr_usb_serial_common
 PKG_SOURCE_DATE:=2017-08-01
 PKG_SOURCE_VERSION:=b8dad8cf15de160afbd9989f880dc74b921a857b
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/kasbert/epsolar-tracer

--- a/libs/xr_usb_serial_common/patches/0001-common.c-fix-kernel-5.10-builds-with-CONFIG_PM-enabl.patch
+++ b/libs/xr_usb_serial_common/patches/0001-common.c-fix-kernel-5.10-builds-with-CONFIG_PM-enabl.patch
@@ -1,0 +1,48 @@
+From e4d127ddc83c5fbd93b9c8e2e4fe63b820ac28b6 Mon Sep 17 00:00:00 2001
+From: David Bauer <mail@david-bauer.net>
+Date: Sat, 22 May 2021 10:37:06 +0200
+Subject: [PATCH] common.c: fix kernel 5.10 builds with CONFIG_PM enabled
+
+Building the xr_usb_serial module fails for Kenel 5.10 with CONFIG_PM
+enabled:
+
+xr_usb_serial_common.c:1574:15: error: 'ASYNCB_INITIALIZED' undeclared
+(first use in this function); did you mean 'RCU_INITIALIZER'?
+
+Use tty_port_initialized in order to determine the status of the TTY
+port. This is compatible with Kernel 5.10 and at least Kernel 5.4.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+---
+ xr_usb_serial_common-1a/xr_usb_serial_common.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/xr_usb_serial_common-1a/xr_usb_serial_common.c
++++ b/xr_usb_serial_common-1a/xr_usb_serial_common.c
+@@ -1571,7 +1571,7 @@ static int xr_usb_serial_suspend(struct
+ 	if (cnt)
+ 		return 0;
+ 
+-	if (test_bit(ASYNCB_INITIALIZED, &xr_usb_serial->port.flags))
++	if (tty_port_initialized(&xr_usb_serial->port))
+ 		stop_data_traffic(xr_usb_serial);
+ 
+ 	return 0;
+@@ -1592,7 +1592,7 @@ static int xr_usb_serial_resume(struct u
+ 	if (cnt)
+ 		return 0;
+ 
+-	if (test_bit(ASYNCB_INITIALIZED, &xr_usb_serial->port.flags)) {
++	if (tty_port_initialized(&xr_usb_serial->port)) {
+ 		rv = usb_submit_urb(xr_usb_serial->ctrlurb, GFP_NOIO);
+ 
+ 		spin_lock_irq(&xr_usb_serial->write_lock);
+@@ -1623,7 +1623,7 @@ static int xr_usb_serial_reset_resume(st
+ {
+ 	struct xr_usb_serial *xr_usb_serial = usb_get_intfdata(intf);
+     struct tty_struct *tty;
+-	if (test_bit(ASYNCB_INITIALIZED, &xr_usb_serial->port.flags)){
++	if (tty_port_initialized(&xr_usb_serial->port)){
+ #if LINUX_VERSION_CODE > KERNEL_VERSION(3, 9, 0)	
+ 	tty_port_tty_hangup(&xr_usb_serial->port, false);
+ #else


### PR DESCRIPTION
Maintainer: @dangowrt 

Build-tested: mt7622 / x86
Run-tested: - / Lacking required HW

Building the xr_usb_serial module fails for Kenel 5.10 with CONFIG_PM
enabled:

xr_usb_serial_common.c:1574:15: error: 'ASYNCB_INITIALIZED' undeclared
(first use in this function); did you mean 'RCU_INITIALIZER'?

Use tty_port_initialized in order to determine the status of the TTY
port. This is compatible with Kernel 5.10 and at least Kernel 5.4.
