### PR TITLE
curl: update to version 7.77.0 (security fix)

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=curl
-PKG_VERSION:=7.76.0
+PKG_VERSION:=7.77.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=https://dl.uxnr.de/mirror/curl/ \
 	https://curl.mirror.anstey.ca/ \
 	https://curl.askapache.com/download/ \
 	https://curl.haxx.se/download/
-PKG_HASH:=6302e2d75c59cdc6b35ce3fbe716481dd4301841bbb5fd71854653652a014fc8
+PKG_HASH:=0f64582c54282f31c0de9f0a1a596b182776bd4df9a4c4a2a41bbeb54f62594b
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION


Maintainer: @kaloz
Compile tested: Turris Omnia (TOS7), OpenWrt master
Run tested: Turris Omnia (TOS7), OpenWrt master

Description:
This PR updates curl to version 7.77.0. It fixes 3 security issues.

[Changelog](https://curl.se/changes.html#7_77_0)
[Release video :-)](https://youtu.be/Mmq8kb6GcAw)

Fixes:
[CVE-2021-22897](https://curl.se/docs/CVE-2021-22897.html)
[CVE-2021-22898](https://curl.se/docs/CVE-2021-22898.html)
[CVE-2021-22901](https://curl.se/docs/CVE-2021-22901.html)

Note:
This should be also cherry-picked to 21.02
