### PR TITLE
dnsdist: update to 1.6.0 and make some features optional

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -62,6 +62,12 @@ menu "Configuration"
 		help
 			"Enabled DNS over TLS Support for dnsdist"
 		default y
+
+	config DNSDIST_NET_SNMP
+		bool "Net-SNMP support"
+		help
+			"Enable Net-SNMP support for dnsdist"
+		default y
 endmenu
 endef
 
@@ -74,11 +80,11 @@ define Package/dnsdist
 	  +DNSDIST_DNS_OVER_HTTPS:libh2o-evloop \
 	  +DNSDIST_GNUTLS:libgnutls \
 	  +DNSDIST_OPENSSL:libopenssl \
+	  +DNSDIST_NET_SNMP:libnetsnmp \
 	  +libatomic \
 	  +libcap \
 	  +libedit \
 	  +libfstrm \
-	  +libnetsnmp \
 	  +libsodium \
 	  +lmdb \
 	  +re2 \
@@ -110,7 +116,7 @@ CONFIGURE_ARGS+= \
 	--with-pic \
 	--with-re2 \
 	--with-lua=lua \
-	--with-net-snmp \
+	$(if $(CONFIG_DNSDIST_NET_SNMP),--with,--without)-net-snmp \
 	$(if $(CONFIG_DNSDIST_GNUTLS),--with,--without)-gnutls \
 	$(if $(CONFIG_DNSDIST_OPENSSL),--with,--without)-libssl \
 	$(if $(CONFIG_DNSDIST_DNS_OVER_TLS),--enable-dns-over-tls,) \

--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -80,6 +80,12 @@ menu "Configuration"
 		help
 			"Enable DNSTAP support for dnsdist"
 		default y
+
+	config DNSDIST_SODIUM
+		bool "Build with libsodium
+		help
+			"Build with libsodium - for encrypted console connections, and DNSCrypt"
+		default y
 endmenu
 endef
 
@@ -95,10 +101,10 @@ define Package/dnsdist
 	  +DNSDIST_NET_SNMP:libnetsnmp \
 	  +DNSDIST_RE2:re2 \
 	  +DNSDIST_DNSTAP:libfstrm \
+	  +DNSDIST_SODIUM:libsodium \
 	  +libatomic \
 	  +libcap \
 	  +libedit \
-	  +libsodium \
 	  +libstdcpp \
 	  +lmdb \
 	  +liblua \
@@ -130,10 +136,9 @@ TARGET_CXX+=-std=c++17
 
 CONFIGURE_ARGS+= \
 	--enable-option-checking=fatal \
-	--enable-dnscrypt \
-	--with-libsodium \
 	--with-pic \
 	--with-lua=lua \
+	$(if $(CONFIG_DNSDIST_SODIUM),--enable-dnscrypt --with-libsodium,--disable-dnscrypt --without-libsodium) \
 	$(if $(CONFIG_DNSDIST_DNSTAP),--enable-dnstap=yes,--enable-dnstap=no) \
 	$(if $(CONFIG_DNSDIST_RE2),--with,--without)-re2 \
 	$(if $(CONFIG_DNSDIST_NET_SNMP),--with,--without)-net-snmp \

--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -74,6 +74,12 @@ menu "Configuration"
 		help
 			"Enable RE2 support for dnsdist"
 		default y
+
+	config DNSDIST_DNSTAP
+		bool "DNSTAP support"
+		help
+			"Enable DNSTAP support for dnsdist"
+		default y
 endmenu
 endef
 
@@ -88,10 +94,10 @@ define Package/dnsdist
 	  +DNSDIST_OPENSSL:libopenssl \
 	  +DNSDIST_NET_SNMP:libnetsnmp \
 	  +DNSDIST_RE2:re2 \
+	  +DNSDIST_DNSTAP:libfstrm \
 	  +libatomic \
 	  +libcap \
 	  +libedit \
-	  +libfstrm \
 	  +libsodium \
 	  +libstdcpp \
 	  +lmdb \
@@ -125,10 +131,10 @@ TARGET_CXX+=-std=c++17
 CONFIGURE_ARGS+= \
 	--enable-option-checking=fatal \
 	--enable-dnscrypt \
-	--enable-dnstap \
 	--with-libsodium \
 	--with-pic \
 	--with-lua=lua \
+	$(if $(CONFIG_DNSDIST_DNSTAP),--enable-dnstap=yes,--enable-dnstap=no) \
 	$(if $(CONFIG_DNSDIST_RE2),--with,--without)-re2 \
 	$(if $(CONFIG_DNSDIST_NET_SNMP),--with,--without)-net-snmp \
 	$(if $(CONFIG_DNSDIST_GNUTLS),--with,--without)-gnutls \

--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -68,6 +68,12 @@ menu "Configuration"
 		help
 			"Enable Net-SNMP support for dnsdist"
 		default y
+
+	config DNSDIST_RE2
+		bool "RE2 support"
+		help
+			"Enable RE2 support for dnsdist"
+		default y
 endmenu
 endef
 
@@ -81,13 +87,14 @@ define Package/dnsdist
 	  +DNSDIST_GNUTLS:libgnutls \
 	  +DNSDIST_OPENSSL:libopenssl \
 	  +DNSDIST_NET_SNMP:libnetsnmp \
+	  +DNSDIST_RE2:re2 \
 	  +libatomic \
 	  +libcap \
 	  +libedit \
 	  +libfstrm \
 	  +libsodium \
+	  +libstdcpp \
 	  +lmdb \
-	  +re2 \
 	  +liblua \
 	  +tinycdb
   URL:=https://dnsdist.org/
@@ -108,14 +115,21 @@ endef
 # not everything groks --disable-nls
 DISABLE_NLS:=
 
+# OpenWRT's setting of CXX destroys dnsdist's -std=c++17
+# --with-re2 compensates for that because it compensates for a bug in re2.pc that also destroys it
+# so this addition is for the --without-re2 case
+#
+# none of this is pretty
+TARGET_CXX+=-std=c++17
+
 CONFIGURE_ARGS+= \
 	--enable-option-checking=fatal \
 	--enable-dnscrypt \
 	--enable-dnstap \
 	--with-libsodium \
 	--with-pic \
-	--with-re2 \
 	--with-lua=lua \
+	$(if $(CONFIG_DNSDIST_RE2),--with,--without)-re2 \
 	$(if $(CONFIG_DNSDIST_NET_SNMP),--with,--without)-net-snmp \
 	$(if $(CONFIG_DNSDIST_GNUTLS),--with,--without)-gnutls \
 	$(if $(CONFIG_DNSDIST_OPENSSL),--with,--without)-libssl \

--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsdist
-PKG_VERSION:=1.5.1
-PKG_RELEASE:=1
+PKG_VERSION:=1.6.0
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=cae759729a87703f4d09b0ed4227cb224aaaa252fa92f2432fd7116f560afbf1
+PKG_HASH:=a7783a04d8d4ad2b0168ffaaf85ef95d5f557057b0462280684dd799d0cdd292
 
 PKG_MAINTAINER:=James Taylor <james@jtaylor.id.au>
 PKG_LICENSE:=GPL-2.0-only
@@ -17,7 +17,7 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 PKG_ASLR_PIE:=0
-PKG_BUILD_DEPENDS:=protobuf/host
+PKG_BUILD_DEPENDS:=boost
 
 PKG_CONFIG_DEPENDS:= \
   CONFIG_DNSDIST_GNUTLS \
@@ -74,7 +74,6 @@ define Package/dnsdist
 	  +DNSDIST_DNS_OVER_HTTPS:libh2o-evloop \
 	  +DNSDIST_GNUTLS:libgnutls \
 	  +DNSDIST_OPENSSL:libopenssl \
-	  +boost \
 	  +libatomic \
 	  +libcap \
 	  +libedit \
@@ -82,9 +81,8 @@ define Package/dnsdist
 	  +libnetsnmp \
 	  +libsodium \
 	  +lmdb \
-	  +lua \
-	  +protobuf \
 	  +re2 \
+	  +liblua \
 	  +tinycdb
   URL:=https://dnsdist.org/
 endef
@@ -101,12 +99,15 @@ define Package/dnsdist/conffiles
 /etc/init.d/dnsdist
 endef
 
+# not everything groks --disable-nls
+DISABLE_NLS:=
+
 CONFIGURE_ARGS+= \
+	--enable-option-checking=fatal \
 	--enable-dnscrypt \
 	--enable-dnstap \
 	--with-libsodium \
 	--with-pic \
-	--with-protobuf \
 	--with-re2 \
 	--with-lua=lua \
 	--with-net-snmp \

--- a/net/dnsdist/patches/010-time_t-check.patch
+++ b/net/dnsdist/patches/010-time_t-check.patch
@@ -1,0 +1,12 @@
+--- a/configure
++++ b/configure
+@@ -5044,9 +5044,6 @@ cat >>confdefs.h <<_ACEOF
+ _ACEOF
+ 
+ 
+-if test $ac_size -lt 8; then :
+-  as_fn_error $? "size of time_t is $ac_size, which is not large enough to fix the y2k38 bug" "$LINENO" 5
+-fi
+ 
+  typename=`echo time_t | sed "s/[^a-zA-Z0-9_]/_/g"`
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether time_t is signed" >&5


### PR DESCRIPTION
Maintainer: @James-TR but I'm happy to take ownership
Compile tested: compiled on amd64 inside an openwrt git master tree, for the target below
Run tested:  OpenWrt SNAPSHOT, r16595-f4473baf6e, on TP-Link Archer C7/AC1750. Tested forwarding of UDP, DoT and DoH DNS queries.


Description:
this PR updates dnsdist 1.6.0 and updates dependencies accordingly. The additional commits make some dnsdist features optional at build time, which can make the package smaller.

dnsdist (and other PowerDNS products) recently got a configure-time check for the size of `time_t`, because this simplifies reasoning about timestamps. This PR patches that check out because many OpenWRT targets are still 32 bits.