### PR TITLE
bind: bump to 9.17.13

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.17.12
+PKG_VERSION:=9.17.13
 PKG_RELEASE:=$(AUTORELEASE)
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=e77951eaa4aaa92b30e6f3ff6c915081a21c8cc70000e7f25a7a285eed0acbe7
+PKG_HASH:=bf485ac49715d43fa65c2c6e33271aab965bcd1b461fe2ac9f439754a210e6c7
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Signed-off-by: Noah Meyerhans <frodo@morgul.net>

Maintainer: me
Compile tested: master (x86_64, mvebu)
Run tested: master/mvebu. validated recursive service, DNSSEC validation, AXFR/IXFR

Description:
Update to latest upstream version.