### PR TITLE
ack: add new packages

### DIFF
--- a/lang/perl-ack/Makefile
+++ b/lang/perl-ack/Makefile
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# Copyright (C) 2021 ImmortalWrt.org
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-ack
+PKG_VERSION:=3.5.0
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE_URL:=http://www.cpan.org/authors/id/P/PE/PETDANCE/
+PKG_SOURCE:=ack-v$(PKG_VERSION).tar.gz
+PKG_HASH:=66053e884e803387a02ddee0d68abf2a10239fab654364dab33287309a725521
+
+PKG_LICENSE:=Artistic-2.0
+PKG_LICENSE_FILE:=LICENSE.md
+PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/ack-v$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/ack
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=A grep-like source code search tool
+  URL:=https://beyondgrep.com
+  DEPENDS:=+perl +perl-ack
+  PROVIDES:=ack-grep
+endef
+
+define Package/perl-ack
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=grep-like text finder
+  URL:=http://search.cpan.org/dist/ack/
+  DEPENDS:=perl +perl-file-next +perlbase-filetest +perlbase-if \
+    +perlbase-list +perlbase-pod +perlbase-test +perlbase-text \
+    +perlbase-term
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/ack/install
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ack $(1)/usr/bin/
+	$(SED) "1"'!'"b;s,^#"'!'".*perl.*,#"'!'"/usr/bin/perl," -i --follow-symlinks $(1)/usr/bin/ack
+endef
+
+define Package/perl-ack/install
+	$(call perlmod/Install,$(1),App auto/ack)
+endef
+
+$(eval $(call BuildPackage,ack))
+$(eval $(call BuildPackage,perl-ack))

--- a/lang/perl-ack/test.sh
+++ b/lang/perl-ack/test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+case "$1" in
+	"ack")
+		ack --version | grep "$PKG_VERSION"
+		;;
+esac

--- a/lang/perl-file-next/Makefile
+++ b/lang/perl-file-next/Makefile
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# Copyright (C) 2021 ImmortalWrt.org
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-file-next
+PKG_VERSION:=1.18
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE_URL:=http://www.cpan.org/authors/id/P/PE/PETDANCE/
+PKG_SOURCE:=File-Next-$(PKG_VERSION).tar.gz
+PKG_HASH:=f900cb39505eb6e168a9ca51a10b73f1bbde1914b923a09ecd72d9c02e6ec2ef
+
+PKG_LICENSE:=Artistic-2.0
+PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/File-Next-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-file-next
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=File finding module
+  URL:=http://search.cpan.org/dist/File-Next/
+  DEPENDS:=perl +perlbase-file
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-file-next/install
+	$(call perlmod/Install,$(1),File auto/File)
+endef
+
+$(eval $(call BuildPackage,perl-file-next))


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm27xx, rockchip, x86_64
Run tested: bcm2710 raspberrypi-3b

Description:
ack is a grep-like source code search tool.
Designed for programmers with large heterogeneous trees of source code,
ack is written in portable Perl 5 and takes advantage of the power of
Perl's regular expressions.

Official website: https://beyondgrep.com