### PR TITLE
i2pd: Update to 2.38.0

### DIFF
--- a/net/i2pd/Makefile
+++ b/net/i2pd/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=i2pd
-PKG_VERSION:=2.36.0
+PKG_VERSION:=2.38.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/PurpleI2P/i2pd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=17b7309cbee41b991cf9480334495c5a049f709beb1b31fbfcb47de19c8462a3
+PKG_HASH:=8452f5323795a1846d554096c08fffe5ac35897867b93a5079605df8f80a3089
 
 PKG_MAINTAINER:=David Yang <mmyangfl@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -55,7 +55,6 @@ define Build/Prepare
 endef
 
 TARGET_LDFLAGS+=-latomic
-MAKE_FLAGS+=USE_AESNI=no USE_AVX=no
 
 define Package/i2pd/install
 	$(INSTALL_DIR) $(1)/usr/sbin

--- a/net/i2pd/patches/010-config.patch
+++ b/net/i2pd/patches/010-config.patch
@@ -15,7 +15,7 @@
  
  ## Where to write pidfile (default: i2pd.pid, not used in Windows)
  # pidfile = /run/i2pd.pid
-@@ -25,12 +25,12 @@
+@@ -26,12 +26,12 @@
  ##  * stdout - print log entries to stdout
  ##  * file - log entries to a file
  ##  * syslog - use syslog, see man 3 syslog
@@ -30,16 +30,7 @@
  ## Write full CLF-formatted date and time to log (default: write only time)
  # logclftime = true
  
-@@ -61,7 +61,7 @@ ipv6 = false
- # ifname6 = 
- 
- ## Enable NTCP transport (default = true)
--# ntcp = true
-+ntcp = false
- ## If you run i2pd behind a proxy server, you can only use NTCP transport with ntcpproxy option 
- ## Should be http://address:port or socks://address:port
- # ntcpproxy = http://127.0.0.1:8118
-@@ -81,7 +81,7 @@ ipv6 = false
+@@ -84,7 +84,7 @@ ipv6 = false
  
  ## Router will not accept transit tunnels, disabling transit traffic completely
  ## (default = false)
@@ -47,8 +38,8 @@
 +notransit = true
  
  ## Router will be floodfill
- # floodfill = true
-@@ -91,8 +91,10 @@ ipv6 = false
+ ## Note: that mode uses much more network connections and CPU!
+@@ -95,8 +95,10 @@ ipv6 = false
  ## Uncomment and set to 'false' to disable Web Console
  # enabled = true
  ## Address and port service will listen on
@@ -59,8 +50,8 @@
 +# strictheaders = false
  ## Path to web console, default "/"
  # webroot = /
- ## Uncomment following lines to enable Web Console authentication 
-@@ -104,7 +106,7 @@ port = 7070
+ ## Uncomment following lines to enable Web Console authentication
+@@ -108,7 +110,7 @@ port = 7070
  ## Uncomment and set to 'false' to disable HTTP Proxy
  # enabled = true
  ## Address and port service will listen on
@@ -69,7 +60,7 @@
  port = 4444
  ## Optional keys file for proxy local destination
  # keys = http-proxy-keys.dat
-@@ -118,7 +120,7 @@ port = 4444
+@@ -122,7 +124,7 @@ port = 4444
  ## Uncomment and set to 'false' to disable SOCKS Proxy
  # enabled = true
  ## Address and port service will listen on
@@ -78,12 +69,14 @@
  port = 4447
  ## Optional keys file for proxy local destination
  # keys = socks-proxy-keys.dat
-@@ -228,7 +230,8 @@ verify = true
+@@ -237,9 +239,9 @@ verify = true
  
  [persist]
  ## Save peer profiles on disk (default: true)
 -# profiles = true
 +profiles = false
+ ## Save full addresses on disk (default: true)
+-# addressbook = true
 +addressbook = false
  
  [cpuext]


### PR DESCRIPTION
Maintainer: @yangfl
Compile tested: ramips, MT7621
Run tested: ramips, MT7621, 19.07.7

Description:
Updated i2pd to 2.38.0. Removed make flags, because AVX and AESNI correctly detected at runtime and compilation.

<strike>If run testing is required, than I'll build package with custom openwrt source where my router is present.</strike>
Tested on 19.07.7.