### PR TITLE
acme: don't log regular messages as error

### DIFF
--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -33,7 +33,7 @@ check_cron()
 
 log()
 {
-	logger -t acme -s -p daemon.info -- "$@"
+	logger -t acme -p daemon.info -- "$@"
 }
 
 err()


### PR DESCRIPTION
Maintainer: @tohojo
Compile tested: N/A, shell only
Run tested: mvebu, recent snapshot

Description:
Don't duplicate regular log messages to stderr via logger, since when
run via init script the stderr gets captured and erroneously logged as
error messages, duplicating the info message.

Fixes #15706 15706