### PR TITLE
rtty: update to 7.4.1

### DIFF
--- a/utils/rtty/Makefile
+++ b/utils/rtty/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtty
-PKG_VERSION:=7.4.0
+PKG_VERSION:=7.4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://github.com/zhaojh329/rtty/releases/download/v$(PKG_VERSION)
-PKG_HASH:=9bc5d30dfa9bd664a62711b6229f47505b83adb364907f24e3a404aad52a4802
+PKG_HASH:=997e5a3f0b1ce5e06d8505691ea0a9a3fd8af972f6d1b4b04f42dd03f392649f
 
 PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
 PKG_LICENSE:=MIT
@@ -47,13 +47,13 @@ Package/rtty-mbedtls/conffiles = $(Package/rtty-openssl/conffiles)
 Package/rtty-nossl/conffiles = $(Package/rtty-openssl/conffiles)
 
 ifeq ($(BUILD_VARIANT),openssl)
-  CMAKE_OPTIONS += -DRTTY_USE_OPENSSL=ON
+  CMAKE_OPTIONS += -DUSE_OPENSSL=ON
 else ifeq ($(BUILD_VARIANT),wolfssl)
-  CMAKE_OPTIONS += -DRTTY_USE_WOLFSSL=ON
+  CMAKE_OPTIONS += -DUSE_WOLFSSL=ON
 else ifeq ($(BUILD_VARIANT),mbedtls)
-  CMAKE_OPTIONS += -DRTTY_USE_MBEDTLS=ON
+  CMAKE_OPTIONS += -DUSE_MBEDTLS=ON
 else
-  CMAKE_OPTIONS += -DRTTY_SSL_SUPPORT=OFF
+  CMAKE_OPTIONS += -DSSL_SUPPORT=OFF
 endif
 
 define Package/rtty-$(BUILD_VARIANT)/install


### PR DESCRIPTION
Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>

Maintainer: me
Compile tested: (ath79, GL-AR750S, master)
Run tested: (ath79, GL-AR750S, master, tests done)

Description:
Release notes for 7.4.1: https://github.com/zhaojh329/rtty/releases/tag/v7.4.1