### PR TITLE
dnsdist: fix missing quote

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -82,7 +82,7 @@ menu "Configuration"
 		default y
 
 	config DNSDIST_SODIUM
-		bool "Build with libsodium
+		bool "Build with libsodium"
 		help
 			"Build with libsodium - for encrypted console connections, and DNSCrypt"
 		default y


### PR DESCRIPTION
Maintainer: @James-TR
Compile tested: x86_64, generic, HEAD (5072577)
Run tested: same

Description:

Seeing the following error when running 'make defconfig':

...
tmp/.config-package.in:69874:warning: multi-line strings not supported
...