### PR TITLE
strongswan: start charon directly from swanctl

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.2
-PKG_RELEASE:=7
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -4,7 +4,7 @@ START=90
 STOP=10
 
 USE_PROCD=1
-PROG=/usr/lib/ipsec/starter
+PROG=/usr/lib/ipsec/charon
 
 . $IPKG_INSTROOT/lib/functions.sh
 . $IPKG_INSTROOT/lib/functions/network.sh
@@ -614,7 +614,7 @@ start_service() {
 
 	procd_open_instance
 
-	procd_set_param command $PROG --daemon charon --nofork
+	procd_set_param command $PROG
 
 	procd_set_param file $SWANCTL_CONF_FILE
 	procd_append_param file /etc/swanctl/conf.d/*.conf


### PR DESCRIPTION
Maintainer: me, @Thermi
Compile tested: x86_64, generic, HEAD (cb3fb45ed1)
Run tested: same, installed on production satellite router

Description:

Don't use `/usr/lib/ipsec/starter` to start `charon` when we can start it directly more easily.