### PR TITLE
miniupnpd: disable ext_ip_reserved_ignore by default; fix grammar

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.2.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/miniupnpd/files/upnpd.config
+++ b/net/miniupnpd/files/upnpd.config
@@ -12,7 +12,6 @@ config upnpd config
 	option port		5000
 	option upnp_lease_file	/var/run/miniupnpd.leases
 	option igdv1		1
-	option ext_ip_reserved_ignore '1'
 
 config perm_rule
 	option action		allow

--- a/net/miniupnpd/patches/301-ext_ip_reserved_ignore.patch
+++ b/net/miniupnpd/patches/301-ext_ip_reserved_ignore.patch
@@ -24,7 +24,7 @@ Date:   Sun Jul 5 10:42:52 2020 +0800
  	size_t i;
  
 +	if(GETFLAG(EXTIPRESERVEDIGNOREMASK)) {
-+		syslog(LOG_NOTICE, "private/reserved address checking is ignore");
++		syslog(LOG_NOTICE, "private/reserved address checking is ignored");
 +		return 0;
 +	}
 +


### PR DESCRIPTION
Maintainer: ??? @neheb @feckert @ptpt52 

Description:
This fixes issues mentioned in the comments of https://github.com/openwrt/packages/pull/14031 that on a lot of systems, having `ext_ip_reserved_ignore` set to 1 in config by default causes extra log entries with poor grammar.

I didn't compile/test it, does it need to be done for a small change like this?

Signed-off-by: Stan Grishin <stangri@melmac.net>
