### PR TITLE
[master] iperf3: Update to version 3.10.1

### DIFF
--- a/net/iperf3/Makefile
+++ b/net/iperf3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
-PKG_VERSION:=3.9
+PKG_VERSION:=3.10.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.es.net/pub/iperf
-PKG_HASH:=24b63a26382325f759f11d421779a937b63ca1bc17c44587d2fcfedab60ac038
+PKG_HASH:=03bc9760cc54a245191d46bfc8edaf8a4750f0e87abca6764486972044d6715a
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Signed-off-by: James White <james@jmwhite.co.uk>

Maintainer: @nbd168

Description:

Resolves #15762. Updates iperf3 to 3.10.1.
