### PR TITLE
[19.07] libnet-1.2.x: Export `libnet-config` in development environments

### DIFF
--- a/libs/libnet-1.2.x/Makefile
+++ b/libs/libnet-1.2.x/Makefile
@@ -56,6 +56,10 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(STAGING_DIR)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/libnet.h $(STAGING_DIR)/usr/include
 
+	$(INSTALL_DIR) $(STAGING_DIR)
+	$(CP) $(PKG_BUILD_DIR)/libnet-config $(STAGING_DIR)/usr
+	chmod a+x $(STAGING_DIR)/usr/libnet-config
+
 	$(INSTALL_DIR) $(STAGING_DIR)/usr/include/libnet
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/libnet/libnet-*.h $(STAGING_DIR)/usr/include/libnet
 


### PR DESCRIPTION
Maintainer: me / @lperkov
Compile tested: mipsle/WiFi Pineapple Mark 7/19.07
Run tested: mipsle/WiFi Pineapple Mark 7/19.07 Verified libnet-config is left in $(STAGING_DIR)/usr/libnet-config

Description:
Only change is copying and chmod a+x'ing libnet-config build artifact.

Fixes #15767