### PR TITLE
boost: Fixes Boost.regex header-only (v5) include

### DIFF
--- a/libs/boost/patches/020-regex.patch
+++ b/libs/boost/patches/020-regex.patch
@@ -1,0 +1,29 @@
+--- a/boost/regex/v5/mem_block_cache.hpp
++++ b/boost/regex/v5/mem_block_cache.hpp
+@@ -85,10 +85,10 @@ struct mem_block_node
+ struct mem_block_cache
+ {
+    // this member has to be statically initialsed:
+-   mem_block_node* next;
+-   unsigned cached_blocks;
++   mem_block_node* next { nullptr };
++   unsigned cached_blocks { 0 };
+ #ifdef BOOST_HAS_THREADS
+-   boost::static_mutex mut;
++   std::mutex mut;
+ #endif
+ 
+    ~mem_block_cache()
+@@ -133,11 +133,7 @@ struct mem_block_cache
+    }
+    static mem_block_cache& instance()
+    {
+-#ifdef BOOST_HAS_THREADS
+-      static mem_block_cache block_cache = { 0, 0, BOOST_STATIC_MUTEX_INIT, };
+-#else
+-      static mem_block_cache block_cache = { 0, 0, };
+-#endif
++      static mem_block_cache block_cache;
+       return block_cache;
+    }
+ };


### PR DESCRIPTION
**Maintainer:** @ClaymorePT 
**Compile tested:** Target `Freescale i.MX23/i.MX28` - Profile `I2SE Duckbill boards`
**Run tested:** N/A

# Description:
In v1.76.0 Boost.Regex became a header-only library.
With this update, there are now two different versions:
- v4 for C++03 (deprecated)
- v5 header-only

This commit fixes an issue which was preventing Boost.Regex
from being built for old ArmV5 targets

Signed-off-by: Carlos Miguel Ferreira <carlosmf.pt@gmail.com>