### PR TITLE
xray-core: bump geodata to latest version

### DIFF
--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -79,24 +79,24 @@ define Package/xray-core/conffiles
 /etc/config/xray
 endef
 
-GEOIP_VER:=202104010913
+GEOIP_VER:=202106030115
 GEOIP_FILE:=geoip.dat.$(GEOIP_VER)
 
 define Download/geoip
   URL:=https://github.com/v2fly/geoip/releases/download/$(GEOIP_VER)/
   URL_FILE:=geoip.dat
   FILE:=$(GEOIP_FILE)
-  HASH:=f94e464f7f37e6f3c88c2aa5454ab02a4b840bc44c75c5001719a618916906cf
+  HASH:=acf231d7c6461d088ae479fe0c1cb143b5ee3cf7048a897c5a9b7807ab7005df
 endef
 
-GEOSITE_VER:=20210401091829
+GEOSITE_VER:=20210531212831
 GEOSITE_FILE:=dlc.dat.$(GEOSITE_VER)
 
 define Download/geosite
   URL:=https://github.com/v2fly/domain-list-community/releases/download/$(GEOSITE_VER)/
   URL_FILE:=dlc.dat
   FILE:=$(GEOSITE_FILE)
-  HASH:=ee9778dc00b703905ca1f400ad13dd462eae52c5aee6465f0a7543b0232c9d08
+  HASH:=332bbe53af49582dbf89bda04ee5e60e474f9293fc368ab55b517fdcd4a78ed2
 endef
 
 define Build/Prepare

--- a/net/xray-core/files/xray.conf
+++ b/net/xray-core/files/xray.conf
@@ -1,7 +1,6 @@
 
 config xray 'enabled'
 	option enabled '0'
-	option fullcone '1'
 
 config xray 'config'
 	option confdir '/etc/xray'

--- a/net/xray-core/files/xray.init
+++ b/net/xray-core/files/xray.init
@@ -19,14 +19,12 @@ start_service() {
 	local datadir
 	local dialer
 	local format
-	local fullcone
 
 	config_get confdir "config" "confdir"
 	config_get conffiles "config" "conffiles"
 	config_get datadir "config" "datadir" "/usr/share/xray"
 	config_get dialer "config" "dialer"
 	config_get format "config" "format" "json"
-	config_get fullcone "enabled" "fullcone" "0"
 
 	procd_open_instance "$CONF"
 	procd_set_param command "$PROG" run
@@ -39,7 +37,6 @@ start_service() {
 	}
 	[ -n "$format" ] && procd_append_param command -format "$format"
 	[ -n "$dialer" ] && procd_set_param env XRAY_BROWSER_DIALER="$dialer"
-	[ "$fullcone" -eq "0" ] && procd_set_param env XRAY_CONE_DISABLED="true"
 	procd_set_param env XRAY_LOCATION_ASSET="$datadir"
 	procd_set_param file $conffiles
 


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip
Run tested: rockchip nanopi-r2s

Description:
- Bump geodata to latest version
- Removed `fullcone` option as this is outdated