### PR TITLE
Update ModemManager and dependencies

### DIFF
--- a/libs/libmbim/Makefile
+++ b/libs/libmbim/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmbim
-PKG_VERSION:=1.24.6
+PKG_VERSION:=1.24.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libmbim
-PKG_HASH:=760465caaa1ccd699c14290e9791da456d5300dd11ebf4c1486151033e875dfd
+PKG_HASH:=02590736163fff10e5732191fccc1b9920969616ddc59613a003052a116a3c25
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_VERSION:=1.28.2
+PKG_VERSION:=1.28.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
-PKG_HASH:=8c8c3ee719874d2529bce9b35b028fe435b36f003979a360d3ad0938449db783
+PKG_HASH:=cbb890893de1dee06ea5ebdac2d22f0469314a6f93f15f61f2f1206a1c9ae5fd
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
-PKG_VERSION:=1.16.2
+PKG_VERSION:=1.16.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
-PKG_HASH:=efa9a963499e0885f3f163096d433334143c4937545134ecd682e0157fa591e3
+PKG_HASH:=2a90b6260f66d3135609d62667ada73416694d717e7fd9b73223e3703a499617
 PKG_BUILD_DIR:=$(BUILD_DIR)/ModemManager-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79, Telco T1, master
Run tested: ath79, Telco T1, master, confirmed basic functionality

Description:
Updates libqmi, libmbim and ModemManager

Overview of changes in libqmi 1.28.6
----------------------------------------

  * New request/responses:
    ** dms: implement "Foxconn Set FCC authentication" request/response.

  * libqmi-glib:
    ** Fix transport detection in the 'wwan' subsystem.

  * build:
    ** Fix build with GCC 11 and -Wincompatible-pointer-types.

  * Several other minor improvements and fixes.


Overview of changes in libmbim 1.24.8
----------------------------------------

  * libmbim-glib,message:
    ** Fix read overflow on malformed MBIM messages.

  * build:
    ** Fix build with GCC 11 and -Wincompatible-pointer-types.

  * Several other minor improvements and fixes.
 

ModemManager 1.16.6
-------------------------------------------

  * Build:
    ** Require libqmi >= 1.28.6 (for the optional QMI support).
    ** Fix error with GCC 11 and -Wincompatible-pointer-types.
    ** Fix warning with GCC 11 and -Wmaybe-uninitialized.

  * QMI:
    ** Increased device open timeout to 45s.
    ** Added support to handle transfer-route messages.

  * Base manager:
    ** Added support for Qualcomm based PCI devices in the new WWAN subsystem in
       kernel 5.13.
    ** Fix segfault on rare conditions when ports reported don't have a proper
       subsystem or name.
    ** Fix segfault when trying to create device id after device is already gone.

  * plugins:
    ** foxconn: added support for the T99W175 module.
    ** foxconn: fix segfault when attempting to use parent location support.
    ** quectel: ignore QLWURC URCs.

  * Several other minor improvements and fixes.
