### PR TITLE
cni: update to 0.8.1

### DIFF
--- a/utils/cni/Makefile
+++ b/utils/cni/Makefile
@@ -1,16 +1,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cni
-PKG_VERSION:=0.8.0
-PKG_RELEASE:=3
+PKG_VERSION:=0.8.1
+PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containernetworking/$(PKG_NAME)/archive/v$(PKG_VERSION)
-PKG_HASH:=df8afe3eeae3296ba33ca267041c42f13135c3a067bf2d932761bb02998247a6
+PKG_HASH:=6242e7905b5f8f7561a21f595209b569998727927380a8cdf5ab58e7fd5ac2d5
 
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>, Paul Spooren <mail@aparcar.org>
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>, Paul Spooren <mail@aparcar.org>, Oskari Rauta <oskari.rauta@gmail.com>
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>

Maintainer: Daniel Golle / @dangowrt 
Compile tested: x86_64, recent git
Run tested: x86_64, recent git

Description:
update version to 0.8.1

This is a security release that fixes a single bug:
 - tighten up plugin-finding logic (issue 811 of cni)

Users of libcni are strongly encouraged to update.

Also added myself to the list of maintainers per request.