### PR TITLE
kea: update to 1.8.2

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kea
-PKG_VERSION:=1.8.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.8.2
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.isc.org/isc/kea/$(PKG_VERSION)
-PKG_HASH:=3d91106fba3698194fb80da4149af709c7b2e89881311522816e561fca0ec0ea
+PKG_HASH:=486ca7abedb9d6fdf8e4344ad8688d1171f2ef0f5506d118988aadeae80a1d39
 
 PKG_MAINTAINER:=BangLang Huang<banglang.huang@foxmail.com>, Rosy Song<rosysong@rosinson.com>
 PKG_LICENSE:=MPL-2.0

--- a/net/kea/patches/020-shared_ptr.patch
+++ b/net/kea/patches/020-shared_ptr.patch
@@ -1,0 +1,24 @@
+From d505f7a7d6fac1c00a4467dfcf1e84f2db508bc6 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 26 Feb 2021 23:14:20 -0800
+Subject: [PATCH] ax_cpp11.m4: Include <memory> header
+
+This is needed for std::shared_ptr
+GCC-11 throws errors if header is not included
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ m4macros/ax_cpp11.m4 | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/m4macros/ax_cpp11.m4
++++ b/m4macros/ax_cpp11.m4
+@@ -182,6 +182,7 @@ for retry in "none" "--std=c++11" "--std
+ 	AC_COMPILE_IFELSE(
+ 		[AC_LANG_PROGRAM(
+ 			[#include <thread>
++			 #include <memory>
+ 			 std::shared_ptr<std::thread> th;],
+ 			[th.reset(new std::thread([[]]() { return; }));
+ 			 th->join();])],


### PR DESCRIPTION
Backport upstream patch fixing host compilation with GCC11.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @rosysong @hbl0307106015
Compile tested: fedora 34