### PR TITLE
[21.02] samplicator: add samplicator

### DIFF
--- a/net/samplicator/Makefile
+++ b/net/samplicator/Makefile
@@ -1,0 +1,42 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=samplicator
+PKG_VERSION:=1.3.6
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/sleinen/samplicator/releases/download/v$(PKG_VERSION)
+PKG_HASH:=3c4358b4b0992a77251f2b9e2221d4ae945781160732c73504eb126e69d72d40
+
+PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/samplicator
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=UDP Samplicator
+  URL:=https://github.com/sleinen/samplicator
+endef
+
+define Package/samplicator/description
+  Send copies of (UDP) datagrams to multiple receivers,
+  with optional sampling and spoofing.
+endef
+
+define Package/samplicator/conffiles
+/etc/samplicator.conf
+endef
+
+define Package/samplicator/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/samplicate $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/samplicator.init $(1)/etc/init.d/samplicator
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_DATA) ./files/samplicator.conf $(1)/etc/
+endef
+
+$(eval $(call BuildPackage,samplicator))

--- a/net/samplicator/files/samplicator.conf
+++ b/net/samplicator/files/samplicator.conf
@@ -1,0 +1,18 @@
+# Samplicator Config File
+#
+# Format:
+# a.b.c.d[/e.f.g.h]: destination
+# a.b.c.d   is the sender's IP address
+# e.f.g.h   is a mask to apply to the sender (default 255.255.255.255)
+# 
+# Destination Format:
+# <addr>[/<port>[/<interval>[,ttl]]]
+# <addr>    IP address of the receiver
+# <port>    port UDP number of the receiver (default 2000)
+# <freq>    number of received datagrams between successive
+#           copied datagrams for this receiver.
+# <ttl>     The TTL (IPv4) or hop-limit (IPv6) for
+#           outgoing datagrams.
+#
+# Example:
+# 10.0.0.1/255.255.255.0: 10.0.0.42/1025

--- a/net/samplicator/files/samplicator.init
+++ b/net/samplicator/files/samplicator.init
@@ -1,0 +1,18 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=70
+
+SAMPLICATOR_BIN="/usr/sbin/samplicate"
+SAMPLICATOR_CONF="/etc/samplicator.conf"
+
+start_service() {
+    mkdir -p /var/run
+    procd_open_instance
+    procd_set_param command $SAMPLICATOR_BIN -c $SAMPLICATOR_CONF
+    procd_set_param file "$SAMPLICATOR_CONF"
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_set_param respawn
+    procd_close_instance
+}


### PR DESCRIPTION
Samplicator receives UDP datagrams on a given port and resends those
datagrams to a specified set of receivers.

Use Cases:
- replicate Flow Samples to multiple receivers
- use with conntrackd to synchronize via unicast to multiple targets

(cherry picked from commit 41534e5a19dc8350c1aa27ec926b34f779914ac4)

Maintainer: me