### PR TITLE
adblock: update 4.1.3

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=4.1.2
+PKG_VERSION:=4.1.3
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -148,7 +148,8 @@ Available commands:
 | adb_srcfile        | -, /tmp/adb_sources.json           | full path to the used adblock source file, which has a higher precedence than the archive file |
 | adb_dns            | -, auto-detected                   | 'dnsmasq', 'unbound', 'named', 'kresd' or 'raw'                                                |
 | adb_fetchutil      | -, auto-detected                   | 'uclient-fetch', 'wget', 'curl' or 'aria2c'                                                    |
-| adb_fetchparm      | -, auto-detected                   | config options for the selected download utility, e.g. to disable the certificate check        |
+| adb_fetchparm      | -, auto-detected                   | manually override the config options for the selected download utility                         |
+| adb_fetchinsecure  | 0, disabled                        | don't check SSL server certificates during download                                            |
 | adb_trigger        | -, not set                         | trigger network interface or 'not set' to use a time-based startup                             |
 | adb_triggerdelay   | 2                                  | additional trigger delay in seconds before adblock processing begins                           |
 | adb_debug          | 0, disabled                        | set to 1 to enable the debug output                                                            |
@@ -212,6 +213,15 @@ Adblock deposits the final blocklist 'adb_list.overall' in '/etc/kresd', no furt
 
 **Use restrictive jail modes:**  
 You can enable a restrictive 'adb_list.jail' to block access to all domains except those listed in the whitelist file. Usually this list will be generated as an additional list for guest or kidsafe configurations (for a separate dns server instance). If the jail directory points to your primary dns directory, adblock enables the restrictive jail mode automatically (jail mode only).
+
+**Manually override the download options:**  
+By default adblock uses the following pre-configured download options:  
+* aria2c: <code>--timeout=20 --allow-overwrite=true --auto-file-renaming=false --log-level=warn --dir=/ -o</code>
+* curl: <code>--connect-timeout 20 --silent --show-error --location -o</code>
+* uclient-fetch: <code>--timeout=20 -O</code>
+* wget: <code>--no-cache --no-cookies --max-redirect=0 --timeout=20 -O</code>
+
+To override the default set 'adb_fetchparm' manually to your needs.
 
 **Enable E-Mail notification via 'msmtp':**  
 To use the email notification you have to install & configure the package 'msmtp'.  

--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -11,7 +11,7 @@
 export LC_ALL=C
 export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
 set -o pipefail
-adb_ver="4.1.2"
+adb_ver="4.1.3"
 adb_enabled=0
 adb_debug=0
 adb_forcedns=0
@@ -459,7 +459,7 @@ f_dns()
 #
 f_fetch()
 {
-	local util utils cnt=0
+	local util utils insecure cnt=0
 
 	if [ -z "${adb_fetchutil}" ]
 	then
@@ -485,16 +485,32 @@ f_fetch()
 	fi
 	case "${adb_fetchutil}" in
 		"aria2c")
-			adb_fetchparm="${adb_fetchparm:-"--timeout=20 --allow-overwrite=true --auto-file-renaming=false --check-certificate=true --log-level=warn --dir=/ -o"}"
+			if [ "${adb_fetchinsecure}" = "1" ]
+			then
+				insecure="--check-certificate=false"
+			fi
+			adb_fetchparm="${adb_fetchparm:-"${insecure} --timeout=20 --allow-overwrite=true --auto-file-renaming=false --log-level=warn --dir=/ -o"}"
 		;;
 		"curl")
-			adb_fetchparm="${adb_fetchparm:-"--connect-timeout 20 --silent --show-error --location -o"}"
+			if [ "${adb_fetchinsecure}" = "1" ]
+			then
+				insecure="--insecure"
+			fi
+			adb_fetchparm="${adb_fetchparm:-"${insecure} --connect-timeout 20 --silent --show-error --location -o"}"
 		;;
 		"uclient-fetch")
-			adb_fetchparm="${adb_fetchparm:-"--timeout=20 -O"}"
+			if [ "${adb_fetchinsecure}" = "1" ]
+			then
+				insecure="--no-check-certificate"
+			fi
+			adb_fetchparm="${adb_fetchparm:-"${insecure} --timeout=20 -O"}"
 		;;
 		"wget")
-			adb_fetchparm="${adb_fetchparm:-"--no-cache --no-cookies --max-redirect=0 --timeout=20 -O"}"
+			if [ "${adb_fetchinsecure}" = "1" ]
+			then
+				insecure="--no-check-certificate"
+			fi
+			adb_fetchparm="${adb_fetchparm:-"${insecure} --no-cache --no-cookies --max-redirect=0 --timeout=20 -O"}"
 		;;
 	esac
 	if [ -n "${adb_fetchutil}" ] && [ -n "${adb_fetchparm}" ]

--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -161,9 +161,9 @@
 		"descurl": "https://github.com/finnish-easylist-addition"
 	},
 	"reg_fr": {
-		"url": "https://easylist-downloads.adblockplus.org/liste_fr.txt",
+		"url": "https://easylist-downloads.adblockplus.org/liste_fr+easylist.txt",
 		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
-		"size": "S",
+		"size": "M",
 		"focus": "reg_france",
 		"descurl": "https://forums.lanik.us/viewforum.php?f=91"
 	},
@@ -242,7 +242,7 @@
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
 		"size": "VAR",
 		"focus": "general",
-		"descurl": "https://www.shallalist.de",
+		"descurl": "https://www.shallalist.de"
 	},
 	"smarttv_tracking": {
 		"url": "https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/SmartTV.txt",
@@ -277,7 +277,7 @@
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
 		"size": "VAR",
 		"focus": "general",
-		"descurl": "https://dsi.ut-capitole.fr/blacklists/index_en.php",
+		"descurl": "https://dsi.ut-capitole.fr/blacklists/index_en.php"
 	},
 	"wally3k": {
 		"url": "https://v.firebog.net/hosts/static/w3kbl.txt",


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: PC Engines apu1, OpenWrt SNAPSHOT r16925-b721579842

Description:
* fix a small json syntax issue in adblock.sources
* add easylist addon to reg_fr source
* add switch 'adb_fetchinsecure' to allow insecure downloads
  without certificate check (disabled by default)
* better explain 'adb_fetchparm' in readme

Signed-off-by: Dirk Brenken <dev@brenken.org>
