### PR TITLE
banip: update 0.7.9

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
-PKG_VERSION:=0.7.8
+PKG_VERSION:=0.7.9
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/banip/files/README.md
+++ b/net/banip/files/README.md
@@ -146,6 +146,9 @@ Available commands:
 | ban_wan_inputchains_6   | list   | input_wan_rule                | list option to add IPv6 wan input chains                                              |
 | ban_wan_forwardchains_4 | list   | forwarding_wan_rule           | list option to add IPv4 wan forward chains                                            |
 | ban_wan_forwardchains_6 | list   | forwarding_wan_rule           | list option to add IPv6 wan forward chains                                            |
+| ban_fetchutil           | option | -, auto-detected              | 'uclient-fetch', 'wget', 'curl' or 'aria2c'                                           |
+| ban_fetchparm           | option | -, auto-detected              | manually override the config options for the selected download utility                |
+| ban_fetchinsecure       | option | 0, disabled                   | don't check SSL server certificates during download                                   |
 | ban_mailreceiver        | option | -                             | receiver address for banIP related notification E-Mails                               |
 | ban_mailsender          | option | no-reply@banIP                | sender address for banIP related notification E-Mails                                 |
 | ban_mailtopic           | option | banIP notification            | topic for banIP related notification E-Mails                                          |
@@ -228,6 +231,15 @@ Last but not least, both lists also accept domain names as input to allow IP fil
   
 **whitelist-only mode:**  
 banIP supports a "whitelist only" mode. This option allows to restrict the internet access from/to a small number of secure websites/IPs, and block access from/to the rest of the internet. All IPs and Domains which are _not_ listed in the whitelist are blocked. Please note: suspend/resume does not work in this mode.
+  
+**Manually override the download options:**  
+By default banIP uses the following pre-configured download options:  
+* aria2c: <code>--timeout=20 --allow-overwrite=true --auto-file-renaming=false --log-level=warn --dir=/ -o</code>
+* curl: <code>--connect-timeout 20 --silent --show-error --location -o</code>
+* uclient-fetch: <code>--timeout=20 -O</code>
+* wget: <code>--no-cache --no-cookies --max-redirect=0 --timeout=20 -O</code>
+
+To override the default set 'ban_fetchparm' manually to your needs.
   
 **generate an IPSet report:**  
 <pre><code>

--- a/net/banip/files/banip.sh
+++ b/net/banip/files/banip.sh
@@ -12,7 +12,7 @@
 export LC_ALL=C
 export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
 set -o pipefail
-ban_ver="0.7.8"
+ban_ver="0.7.9"
 ban_enabled="0"
 ban_mail_enabled="0"
 ban_proto4_enabled="0"
@@ -251,7 +251,7 @@ f_conf()
 #
 f_env()
 {
-	local util utils packages iface tmp cnt="0" cnt_max="10"
+	local util utils packages iface insecure tmp cnt="0" cnt_max="10"
 
 	ban_starttime="$(date "+%s")"
 	f_jsnup "running"
@@ -402,16 +402,32 @@ f_env()
 	fi
 	case "${ban_fetchutil}" in
 		"aria2c")
-			ban_fetchparm="${ban_fetchparm:-"--timeout=20 --allow-overwrite=true --auto-file-renaming=false --check-certificate=true --log-level=warn --dir=/ -o"}"
+			if [ "${ban_fetchinsecure}" = "1" ]
+			then
+				insecure="--check-certificate=false"
+			fi
+			ban_fetchparm="${ban_fetchparm:-"${insecure} --timeout=20 --allow-overwrite=true --auto-file-renaming=false --log-level=warn --dir=/ -o"}"
 		;;
 		"curl")
-			ban_fetchparm="${ban_fetchparm:-"--connect-timeout 20 --silent --show-error --location -o"}"
+			if [ "${ban_fetchinsecure}" = "1" ]
+			then
+				insecure="--insecure"
+			fi
+			ban_fetchparm="${ban_fetchparm:-"${insecure} --connect-timeout 20 --silent --show-error --location -o"}"
 		;;
 		"uclient-fetch")
-			ban_fetchparm="${ban_fetchparm:-"--timeout=20 -O"}"
+			if [ "${ban_fetchinsecure}" = "1" ]
+			then
+				insecure="--no-check-certificate"
+			fi
+			ban_fetchparm="${ban_fetchparm:-"${insecure} --timeout=20 -O"}"
 		;;
 		"wget")
-			ban_fetchparm="${ban_fetchparm:-"--no-cache --no-cookies --max-redirect=0 --timeout=20 -O"}"
+			if [ "${ban_fetchinsecure}" = "1" ]
+			then
+				insecure="--no-check-certificate"
+			fi
+			ban_fetchparm="${ban_fetchparm:-"${insecure} --no-cache --no-cookies --max-redirect=0 --timeout=20 -O"}"
 		;;
 	esac
 	if [ -n "${ban_fetchutil}" ] && [ -n "${ban_fetchparm}" ]


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: PC Engines apu1, OpenWrt SNAPSHOT r16925-b721579842

Description:
* add switch 'ban_fetchinsecure' to allow insecure downloads
  without certificate check (disabled by default)
* better explain 'ban_fetchparm' in readme

Signed-off-by: Dirk Brenken <dev@brenken.org>

