### PR TITLE
[stubby,getdns]: Remove maintainer from stubby and getdns packages

### DIFF
--- a/libs/getdns/Makefile
+++ b/libs/getdns/Makefile
@@ -10,7 +10,7 @@ PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Jonathan Underwood <jonathan.underwood@gmail.com>
+PKG_MAINTAINER:=
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://getdnsapi.net/dist/

--- a/net/stubby/Makefile
+++ b/net/stubby/Makefile
@@ -13,7 +13,7 @@ PKG_SOURCE_URL:=https://github.com/getdnsapi/$(PKG_NAME)
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_MIRROR_HASH:=bc5f604da1b70287a6c3d89eac2e13ce8bca52840e7b72ab098a3deeb9935082
 
-PKG_MAINTAINER:=Jonathan Underwood <jonathan.underwood@gmail.com>
+PKG_MAINTAINER:=
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
 


### PR DESCRIPTION
Maintainer: me
Compile tested: N/A
Run tested: N/A

Description:
@neheb persists in merging PRs without package maintainer notification and approval. I have raised this previously, but this behaviour persists. A recent PR was merged which lacks the relevant documentation updates, and with problems that should have been addressed during review, and I am not prepared to pick up the mess and continue to maintain packages when a key maintainer does not follow process.