### PR TITLE
yggdrasil: allow HTTPS connections

### DIFF
--- a/net/yggdrasil/Makefile
+++ b/net/yggdrasil/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yggdrasil
 PKG_VERSION:=0.3.16
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v$(PKG_VERSION)?

--- a/net/yggdrasil/files/yggdrasil.defaults
+++ b/net/yggdrasil/files/yggdrasil.defaults
@@ -89,6 +89,17 @@ EOF
     set firewall.@rule[-1].target=ACCEPT
 EOF
 
+  # allow LuCI access with SSL from yggdrasil zone, needs to be explicitly enabled
+  uci -q batch <<-EOF >/dev/null
+    add firewall rule
+    set firewall.@rule[-1].enabled=0
+    set firewall.@rule[-1].name='Allow-HTTPS-yggdrasil'
+    set firewall.@rule[-1].src=yggdrasil
+    set firewall.@rule[-1].proto=tcp
+    set firewall.@rule[-1].dest_port=443
+    set firewall.@rule[-1].target=ACCEPT
+EOF
+
   uci commit firewall
   uci commit network
 


### PR DESCRIPTION
Signed-off-by: James Vorderbruggen <jamesvorder@gmail.com>

Maintainer: @wfleurant 
Compile tested: none
Run tested: rpi4

Description:
Adds a firewall run (disabled by default) to allow HTTPS connections via Yggdrasil. Tested on a raspberry pi 4b.