### PR TITLE
python3: Add readline to dependency finder script

### DIFF
--- a/lang/python/python3-find-stdlib-depends.sh
+++ b/lang/python/python3-find-stdlib-depends.sh
@@ -25,6 +25,7 @@ python3-multiprocessing: multiprocessing
 python3-ncurses: ncurses
 python3-openssl: ssl
 python3-pydoc: doctest pydoc
+python3-readline: readline
 python3-sqlite3: sqlite3
 python3-unittest: unittest
 python3-urllib: urllib


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-32, 2021-06-07 snapshot sdk (see note below)
Run tested: N/A

Description:
I run-tested this on a regular Python package (that does not use readline) and there was no error. The only package I know that uses readline is apparmor but the package has an [invalid include](https://github.com/openwrt/packages/blob/d6b10350df2331ddd750131543af16d997b27637/utils/apparmor/Makefile#L24) which prevents me from compiling (or configuring) it.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>