### PR TITLE
[openwrt-21.02] python3: add python3-readline subpackage

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 include ../python3-version.mk
 
 PKG_NAME:=python3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=$(PYTHON3_VERSION).$(PYTHON3_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -270,7 +270,6 @@ define Py3Package/python3-light/filespec
 -|/usr/lib/python$(PYTHON3_VERSION)/tkinter
 -|/usr/lib/python$(PYTHON3_VERSION)/turtledemo
 -|/usr/lib/python$(PYTHON3_VERSION)/lib-dynload/_test*.so
--|/usr/lib/python$(PYTHON3_VERSION)/lib-dynload/readline*.so
 -|/usr/lib/python$(PYTHON3_VERSION)/pdb.doc
 -|/usr/lib/python$(PYTHON3_VERSION)/test
 -|/usr/lib/python$(PYTHON3_VERSION)/webbrowser.py

--- a/lang/python/python3/files/python3-package-ncurses.mk
+++ b/lang/python/python3/files/python3-package-ncurses.mk
@@ -8,7 +8,7 @@
 define Package/python3-ncurses
 $(call Package/python3/Default)
   TITLE:=Python $(PYTHON3_VERSION) ncurses module
-  DEPENDS:=+python3-light +libncurses
+  DEPENDS:=+python3-light +libncursesw
 endef
 
 $(eval $(call Py3BasePackage,python3-ncurses, \

--- a/lang/python/python3/files/python3-package-readline.mk
+++ b/lang/python/python3/files/python3-package-readline.mk
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2021 Alexandru Ardelean <ardeleanalex@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Package/python3-readline
+$(call Package/python3/Default)
+  TITLE:=Python $(PYTHON3_VERSION) readline module
+  DEPENDS:=+python3-light +libreadline +libncursesw
+endef
+
+$(eval $(call Py3BasePackage,python3-readline, \
+	/usr/lib/python$(PYTHON3_VERSION)/lib-dynload/readline.$(PYTHON3_SO_SUFFIX) \
+))


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: none (cherry picked from #15659)
Run tested: none

Description:
Python3 comes with a built-in readline module. It wasn't included up until
now; mostly because it wasn't considered.

This change introduces it as a sub-package of the main Python3 package.
readline support is included in Python.

libreadline pulls libncursesw as a package, so python3-ncurses was
updated to pull libncursesw as well.
It should be the same package; mostly done for consistency.

Resolves the issue reported here:
  https://forum.openwrt.org/t/python3-repl-missing-readline/90039

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>
(cherry picked from commit 49faf5d7cacf91aeb0c72447f0f5a069c891c3a9)
Signed-off-by: Jeffery To <jeffery.to@gmail.com>