### PR TITLE
[openwrt-21.02] python3: Add readline to dependency finder script

### DIFF
--- a/lang/python/python3-find-stdlib-depends.sh
+++ b/lang/python/python3-find-stdlib-depends.sh
@@ -25,6 +25,7 @@ python3-multiprocessing: multiprocessing
 python3-ncurses: ncurses
 python3-openssl: ssl
 python3-pydoc: doctest pydoc
+python3-readline: readline
 python3-sqlite3: sqlite3
 python3-unittest: unittest
 python3-urllib: urllib


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: none (cherry picked from #15856)
Run tested: N/A

Description:
Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 1eeeba60d8cffc2f655c1ecbb277ca6734ac46b7)