### PR TITLE
sudo: bump to version 1.9.7p1

### DIFF
--- a/admin/sudo/Makefile
+++ b/admin/sudo/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sudo
-PKG_VERSION:=1.9.7
+PKG_VERSION:=1.9.7p1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.sudo.ws/dist
-PKG_HASH:=2bbe7c2d6699b84d950ef9a43f09d4d967b8bc244b73bc095c4202068ddbe549
+PKG_HASH:=391431f454e55121b60c6ded0fcf30ddb80d623d7d16a6d1907cfa6a0b91d8cf
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 


### PR DESCRIPTION
Maintainer: me
Compile tested:  x86  https://github.com/openwrt/openwrt/commit/2cd1a108290f48fd35373f91056c05277c289687 
Run tested:  x86  https://github.com/openwrt/openwrt/commit/2cd1a108290f48fd35373f91056c05277c289687

----------------------------------------------------------------

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>