### PR TITLE
pdns-recursor: update to 4.5.2

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
-PKG_VERSION:=4.4.2
+PKG_VERSION:=4.5.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=b0b97f49848a1758b64bc0b99a596c1583ea525477193f3c01905f5163a4f5cf
+PKG_HASH:=b1283d5354f1cbb3d15791f96af3ab3e08a13453431e94fe87b8dbe9f78f0184
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>
 PKG_LICENCE:=GPL-2.0-only
@@ -16,7 +16,6 @@ PKG_CPE_ID:=cpe:/a:powerdns:recursor
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_DEPENDS:=protobuf/host
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -26,7 +25,7 @@ define Package/pdns-recursor
   SUBMENU:=IP Addresses and Names
   USERID:=pdns:pdns
   TITLE:=PowerDNS Recursor
-  DEPENDS:=+boost +boost-context +boost-filesystem +libatomic +liblua +libopenssl +protobuf +libfstrm
+  DEPENDS:=+boost +boost-context +boost-filesystem +libatomic +liblua +libopenssl +libfstrm
   URL:=https://www.powerdns.com/recursor.html
 endef
 
@@ -40,19 +39,18 @@ define Package/pdns-recursor/conffiles
 /etc/init.d/pdns-recursor
 endef
 
+# not everything groks --disable-nls
+DISABLE_NLS:=
+
 CONFIGURE_ARGS += \
+	--enable-option-checking=fatal \
 	--sysconfdir=/etc/powerdns \
 	--with-lua=lua \
 	--without-libcap \
 	--without-libsodium \
-	--with-protobuf \
 	--without-net-snmp \
 	--enable-reproducible \
 	--disable-silent-rules
-
-CONFIGURE_VARS += \
-	boost_cv_lib_context=yes \
-	boost_cv_lib_context_LIBS=-lboost_context
 
 define Package/pdns-recursor/install
 	$(INSTALL_DIR) $(1)/etc/powerdns

--- a/net/pdns-recursor/patches/010-time_t-check.patch
+++ b/net/pdns-recursor/patches/010-time_t-check.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -25,8 +25,6 @@ AC_PROG_CC
+ AC_PROG_CXX
+ AC_LANG([C++])
+ 
+-PDNS_CHECK_TIME_T
+-
+ AC_DEFINE([RECURSOR], [1],
+   [This is the PowerDNS Recursor]
+ )

--- a/net/pdns-recursor/patches/100-disable-recursor.conf-dist.patch
+++ b/net/pdns-recursor/patches/100-disable-recursor.conf-dist.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -452,12 +452,6 @@ $(srcdir)/effective_tld_names.dat:
+@@ -433,12 +433,6 @@ $(srcdir)/effective_tld_names.dat:
  pubsuffix.cc: $(srcdir)/effective_tld_names.dat
  	$(AM_V_GEN)./mkpubsuffixcc
  


### PR DESCRIPTION
Signed-off-by: Peter van Dijk <peter.van.dijk@powerdns.com>

Maintainer: me
Compile tested: built for mips_24kc_musl on Debian 10 x86_64
Run tested: Run tested: OpenWrt SNAPSHOT, r16595-f4473baf6e, on TP-Link Archer C7/AC1750. Tested resolving of a few names.

Description:
this PR updates pdns-recursor to 4.5.2 and removes the protobuf dependency accordingly.

pdns-recursor (and other PowerDNS products) recently got a configure-time check for the size of time_t, because this simplifies reasoning about timestamps. This PR patches that check out because many OpenWrt targets are still 32 bits.