### PR TITLE
tmux: update to 3.2a

### DIFF
--- a/utils/tmux/Makefile
+++ b/utils/tmux/Makefile
@@ -2,12 +2,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tmux
-PKG_VERSION:=3.2
+PKG_VERSION:=3.2a
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tmux/tmux/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=290a2f25a2f26c649f7ec7f2880586b8d3f43e24d7cb42c691f430941edb4fcf
+PKG_HASH:=497bc4ee16f10b53b161bf0253b6f9e20cd0f86c5d0104f149212cb0778ae13a
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 
 PKG_LICENSE:=ISC

--- a/utils/tmux/patches/100-add-crosscompiling-fallbacks.patch
+++ b/utils/tmux/patches/100-add-crosscompiling-fallbacks.patch
@@ -1,24 +1,10 @@
-commit bb6242675ad0c7447daef148fffced882e5b4a61
-Author: Nicholas Marriott <nicholas.marriott@gmail.com>
-Date:   Thu Apr 15 06:45:19 2021 +0100
-
-    Add crosscompiling fallbacks, from Hasso Tepper.
-
 --- a/configure.ac
 +++ b/configure.ac
-@@ -163,6 +163,7 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM(
- 		[return (reallocarray(NULL, 1, 1) == NULL);]
- 	)],
- 	AC_MSG_RESULT(yes),
-+	[AC_LIBOBJ(reallocarray) AC_MSG_RESULT([no])],
- 	[AC_LIBOBJ(reallocarray) AC_MSG_RESULT([no])]
- )
- AC_MSG_CHECKING([for working recallocarray])
-@@ -171,6 +172,7 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM(
- 		[return (recallocarray(NULL, 1, 1, 1) == NULL);]
- 	)],
- 	AC_MSG_RESULT(yes),
-+	[AC_LIBOBJ(recallocarray) AC_MSG_RESULT([no])],
- 	[AC_LIBOBJ(recallocarray) AC_MSG_RESULT([no])]
+@@ -160,6 +160,7 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM(
+          [return (strtonum("0", 0, 1, NULL) == 0 ? 0 : 1);]
+ 	 )],
+ 	 [AC_DEFINE(HAVE_STRTONUM) AC_MSG_RESULT(yes)],
++	 [AC_LIBOBJ(strtonum) AC_MSG_RESULT(no)],
+ 	 [AC_LIBOBJ(strtonum) AC_MSG_RESULT(no)]
  )
  


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79, r16955+5-946019637e
Run tested: ath79, WNDR3800, r15339+6-bc99b56d7e, with libevent_core-2.1.so.7* in /tmp and running as  LD_LIBRARY_PATH=/tmp /tmp/tmux

Description:
- update to 3.2a
