### PR TITLE
linknx: adopt new libesmtp version

### DIFF
--- a/net/linknx/patches/020-configure.ac.patch
+++ b/net/linknx/patches/020-configure.ac.patch
@@ -1,0 +1,36 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -90,8 +90,24 @@ if test x"$enable_smtp" != xno ; then
+ 	)
+ fi
+ 
+-AC_MSG_CHECKING(whether to use libesmtp)
++AC_MSG_CHECKING(whether to use libesmtp >= v1.1.x)
+ if test x"$enable_smtp" != xno ; then
++	PKG_CHECK_MODULES(ESMTP, libesmtp-1.0 >= 1.1.0, [
++		AC_DEFINE([HAVE_LIBESMTP], [1], [Build with libesmtp email support.])
++		AC_SUBST(ESMTP_CFLAGS)
++		AC_SUBST(ESMTP_LIBS)
++		if test x"`echo $ESMTP_LIBS | grep pthread`" != x ; then
++			AC_MSG_WARN([libesmtp is compiled with pthread support. This can conflict with pth. If you observe segmentation faults at startup, try to recompile with libesmtp support disabled])
++			AC_DEFINE([HAVE_LIBESMTP_PTHREAD], [1], [libesmtp is compiled with pthread support.])
++		fi
++		found_esmtp=yes
++	],[
++		AC_MSG_RESULT([no])
++	])
++fi
++if test x"$found_esmtp" = x ; then
++AC_MSG_CHECKING(whether to use libesmtp v1.0.x)
++if test x"$enable_smtp" != xno && test x`which libesmtp-config` != x ; then
+ 	ESMTP_CFLAGS="`libesmtp-config --cflags`"
+ 	ESMTP_LIBS="`libesmtp-config --libs`"
+ 	if test x"`libesmtp-config --libs | grep pthread`" != x ; then
+@@ -110,6 +126,7 @@ if test x"$enable_smtp" != xno ; then
+ else
+ 	AC_MSG_RESULT([no])
+ fi
++fi
+ AM_CONDITIONAL([USE_B64], [test x"$enable_smtp" != xno])
+ 
+ 


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>

Maintainer: me
Compile tested: mpc85xx, tl-wdr4900-v1, trunk
Compile tested: ath79, tplink_archer-c7-v4, trunk
Compile tested: ramips, mt7620a, trunk
Run tested: ath79, tp-link Archer C7 v4, trunk

Description:
add patch to adopt new libesmtp version

