### PR TITLE
strongswan: fix PSK config generation

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.2
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -486,12 +486,14 @@ config_remote() {
 		swanctl_xappend0 "secrets {"
 		swanctl_xappend1 "ike {"
 		swanctl_xappend2 "secret = $pre_shared_key"
-		if [ -z "$local_id" ]; then
+		if [ -n "$local_id" ]; then
 			swanctl_xappend2 "id1 = $local_id"
-			if [ -z "$remote_id" ]; then
+			if [ -n "$remote_id" ]; then
 				swanctl_xappend2 "id2 = $remote_id"
 			fi
 		fi
+		swanctl_xappend1 "}"
+		swanctl_xappend0 "}"
 	else
 		fatal "AuthenticationMode $auth_mode not supported"
 	fi


### PR DESCRIPTION
Maintainer: @pprindeville @thermi
Compile tested: Yes (ath79)
Run tested: Yes (ath79)

Description:
There were closing curly braces missing and it was checking for empty strings
while it should have been checking for non-empty strings.
