### PR TITLE
knot-resolver: change scheduling priority

### DIFF
--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot-resolver
 PKG_VERSION:=5.3.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-resolver

--- a/net/knot-resolver/files/kresd.init
+++ b/net/knot-resolver/files/kresd.init
@@ -65,6 +65,7 @@ start_service() {
 	procd_append_param command -c "$CONFIGFILE"
 	procd_append_param command -a "0.0.0.0#53"
 	procd_append_param command -a "::0#53"
+	procd_set_param nice '-5'
 	procd_close_instance
 }
 


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS7), OpenWrt master
Run tested: Turris Omnia (TOS7), OpenWrt master

Description:
This PR changes running priority for knot-resolver due to occasional problems with resolving


