### PR TITLE
fuse-overlayfs: add new package

### DIFF
--- a/utils/fuse-overlayfs/Makefile
+++ b/utils/fuse-overlayfs/Makefile
@@ -1,0 +1,39 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=fuse-overlayfs
+PKG_VERSION:=1.5.0
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
+
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/containers/fuse-overlayfs/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=6c81b65b71067b303aaa9871f512c2cabc23e2b793f19c6c854d01a492b5a923
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/fuse-overlayfs
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libfuse3
+  TITLE:=fuse-overlayfs
+  URL:=https://github.com/containers/fuse-overlayfs
+endef
+
+define Package/fuse-overlayfs/description
+  FUSE overlay+shiftfs implementation for rootless containers
+endef
+
+define Package/fuse-overlayfs/install
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fuse-overlayfs $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,fuse-overlayfs))


### PR DESCRIPTION
This is part of an attempt to get rootless podman to work on OpenWrt.
See https://github.com/openwrt/packages/issues/15096.

Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64 master
Run tested: x86_64 master

Description:
