### PR TITLE
strongswan: use correct directory for CA's

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.2
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/gencerts.sh
+++ b/net/strongswan/files/gencerts.sh
@@ -72,7 +72,7 @@ genca()
 
 	pki --self --ca --lifetime "$CADAYS" --in "$SWANCTL_DIR/private/$SHORT_DOMAIN.key" --type "$keytype" \
 		--dn "$ROOTDN" --outform pem > "$SWANCTL_DIR/x509ca/$SHORT_DOMAIN.crt"
-	chmod 0444 "$SWANCTL_DIR/cacerts/$SHORT_DOMAIN.crt"
+	chmod 0444 "$SWANCTL_DIR/x509ca/$SHORT_DOMAIN.crt"
 }
 
 genclientkey()


### PR DESCRIPTION
Maintainer: me, @Thermi
Compile tested: x86_64, generic, HEAD (507257778c)
Run tested: same, installed on production firewall

Description:

Was previously trying to write backing CA's to `/etc/swanctl/cacerts/` which should be `/etc/swanctl/x509ca/` instead.
