### PR TITLE
[21.02] node: bump to 14.17.1

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v14.17.0
-PKG_RELEASE:=2
+PKG_VERSION:=v14.17.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=56e05bff9331039317db417f772e635e0cd1c55f733f7b1b079d71ab5842c9ed
+PKG_HASH:=ddf1d2d56ddf35ecd98c5ea5ddcd690b245899f289559b4330c921255f5a247f
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,6 +1,6 @@
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1184,7 +1184,8 @@ Module._initPaths = function() {
+@@ -1202,7 +1202,8 @@ Module._initPaths = function() {
      path.resolve(process.execPath, '..') :
      path.resolve(process.execPath, '..', '..');
  
@@ -9,4 +9,4 @@
 +               path.resolve(prefixDir, 'lib', 'node_modules')];
  
    if (homeDir) {
-     paths.unshift(path.resolve(homeDir, '.node_libraries'));
+     ArrayPrototypeUnshift(paths, path.resolve(homeDir, '.node_libraries'));

--- a/lang/node/patches/999-localhost-no-addrconfig.patch
+++ b/lang/node/patches/999-localhost-no-addrconfig.patch
@@ -13,7 +13,7 @@ Forwarded: https://github.com/nodejs/node/issues/33816
  //
  // Permission is hereby granted, free of charge, to any person obtaining a
  // copy of this software and associated documentation files (the
-@@ -1026,13 +1027,6 @@ function lookupAndConnect(self, options)
+@@ -1028,13 +1029,6 @@ function lookupAndConnect(self, options)
      hints: options.hints || 0
    };
  


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: 21.02 aarch64, arm, i386, x86_64, mipsel (pistachio)
Run tested: (qemu 5.2.0) aarch64, arm, i386, x86_64

Description:
deps: update ICU to 69.1 (Michaël Zasso)
errors: align source-map stacks with spec (Benjamin Coe)

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
