### PR TITLE
[openwrt-21.02] yq: Update to 4.9.6

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.9.3
+PKG_VERSION:=4.9.6
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=b66b9b4182f8fd23d974c3d35e0552f5fdd5280162cec31102f69c3119ed1694
+PKG_HASH:=40f549d801826b4a7bdad0b2a924f10b354da1d518759b2974e82dda7563f7ee
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm27xx
Run tested: bcm2710 raspberrypi-3b

Description:
Including bugs fixes.
Changelog: https://github.com/mikefarah/yq/releases/tag/v4.9.6