### PR TITLE
chrony: fix uci NTP access configuration

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
 PKG_VERSION:=4.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.tuxfamily.org/chrony/

--- a/net/chrony/files/chrony.hotplug
+++ b/net/chrony/files/chrony.hotplug
@@ -17,6 +17,7 @@ fi
 [ "$ACTION" = ifup ] || exit 0
 
 . /lib/functions.sh
+. /lib/functions/network.sh
 . /etc/init.d/chronyd
 
 config_load chrony


### PR DESCRIPTION
Maintainer: me
Compile tested: ramips, mir4ag, 21.02-rc2
Run tested: ramips, mir4ag, 21.02-rc2

Description:
The chrony interface hotplug script reuses the handle_allow function
from the init script to allow NTP access on interfaces specified in uci.
The function requires /lib/functions/network.sh. Include the file in the
hotplug script to make the function work as expected.
