### PR TITLE
sumo: fix compilation when gtest is present

### DIFF
--- a/utils/sumo/patches/010-gtest.patch
+++ b/utils/sumo/patches/010-gtest.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -339,7 +339,6 @@ if (SUMO_LIBRARIES AND WIN32)
+     file(GLOB TEXTTEST_EXECUTABLE "${SUMO_LIBRARIES}/TextTest-*/texttest.exe")
+ else ()
+     # for Linux and Mac only
+-    find_package(GTest)
+ endif ()
+ 
+ find_package(XercesC REQUIRED)


### PR DESCRIPTION
Removes cmake check for gtest.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Noltari 
Compile tested: ath79