### PR TITLE
libmraa: don't build tests

### DIFF
--- a/libs/libmraa/Makefile
+++ b/libs/libmraa/Makefile
@@ -32,6 +32,7 @@ include ../../lang/python/python3-package.mk
 CMAKE_OPTIONS += \
 	-DENABLEEXAMPLES=0 \
 	-DBUILDSWIGNODE=OFF \
+	-DBUILDTESTS=OFF \
 	-DFIRMATA=ON
 
 define Package/libmraa/Default


### PR DESCRIPTION
Fixes compilation when gtest is present.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nxhack 
Compile tested: ath79