### PR TITLE
knot: update to version 3.0.7

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.0.6
+PKG_VERSION:=3.0.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=63756ac5a00c3e4a066ed231a287faef5963a9183d77326e30bf0644cdf74f86
+PKG_HASH:=2bad8be0be95c8f54a26d1e16299e65f31ae1b34bd6ad3819aa50e7b40521484
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 6.0 (hbd)
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 5.1.10 (hbs), all tests successful (1 skipped)

Description:

- Release patch