### PR TITLE
libmariadb: fix compilation cmake issue

### DIFF
--- a/libs/libmariadb/patches/0001-libmariadb-fix-cmake.patch
+++ b/libs/libmariadb/patches/0001-libmariadb-fix-cmake.patch
@@ -1,0 +1,11 @@
+--- a/cmake/ConnectorName.cmake
++++ b/cmake/ConnectorName.cmake
+@@ -22,7 +22,7 @@ IF(CMAKE_SYSTEM_NAME MATCHES "Windows")
+     SET(MACHINE_NAME "x64")
+   ELSE()
+     SET(MACHINE_NAME "32")
+-  END()
++  ENDIF()
+ ENDIF()
+ 
+ SET(product_name "mysql-connector-c-${CPACK_PACKAGE_VERSION}-${PLATFORM_NAME}${CONCAT_SIGN}${MACHINE_NAME}")


### PR DESCRIPTION
Maintainer: @miska @neheb @pprindeville
Compile tested: mips_24kc, lantiq_xrx200, latest OpenWrt master)
Run tested: only compilation fix

Description:
This patch fixes the compilation issue of the upstream Cmake file.
If this patch is not applied we get the following compilation error output for this package.
```
CMake Error at cmake/ConnectorName.cmake:30 (ENDMACRO):
  Flow control statements are not properly nested.
Call Stack (most recent call first):
  CMakeLists.txt:423 (INCLUDE)
```

The blamed cmake/ConnectorName.cmake file gets fixed with this patch.
