### PR TITLE
spdlog: fix compilation with fmtlib 8

### DIFF
--- a/libs/spdlog/patches/010-fmt8.patch
+++ b/libs/spdlog/patches/010-fmt8.patch
@@ -1,0 +1,11 @@
+--- a/include/spdlog/common-inl.h
++++ b/include/spdlog/common-inl.h
+@@ -60,7 +60,7 @@ SPDLOG_INLINE spdlog_ex::spdlog_ex(std::
+ SPDLOG_INLINE spdlog_ex::spdlog_ex(const std::string &msg, int last_errno)
+ {
+     memory_buf_t outbuf;
+-    fmt::format_system_error(outbuf, last_errno, msg);
++    fmt::format_system_error(outbuf, last_errno, msg.data());
+     msg_ = fmt::to_string(outbuf);
+ }
+ 


### PR DESCRIPTION
Small API change.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: 
Compile tested: ath79