### PR TITLE
tvheadend: fix compilation with GCC 9 and 10

### DIFF
--- a/multimedia/tvheadend/Makefile
+++ b/multimedia/tvheadend/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tvheadend
 PKG_VERSION:=4.0.10
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tvheadend/tvheadend/tar.gz/v$(PKG_VERSION)?

--- a/multimedia/tvheadend/patches/040-fortify.patch
+++ b/multimedia/tvheadend/patches/040-fortify.patch
@@ -1,0 +1,9 @@
+--- a/src/intlconv.c
++++ b/src/intlconv.c
+@@ -1,3 +1,6 @@
++#ifndef _GNU_SOURCE
++#define _GNU_SOURCE
++#endif
+ #include <iconv.h>
+ #include "tvheadend.h"
+ #include "intlconv.h"


### PR DESCRIPTION
Without this, compilation fails because of a fortify-source header.
There's something defining and undefining _GNU_SOURCE somewhere.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @sairon 
Compile tested: ath79