### PR TITLE
mariadb: fix cmake issue

### DIFF
--- a/utils/mariadb/patches/210-libmariadb-fix-cmake.patch
+++ b/utils/mariadb/patches/210-libmariadb-fix-cmake.patch
@@ -1,0 +1,11 @@
+--- a/libmariadb/cmake/ConnectorName.cmake
++++ b/libmariadb/cmake/ConnectorName.cmake
+@@ -22,7 +22,7 @@ IF(CMAKE_SYSTEM_NAME MATCHES "Windows")
+     SET(MACHINE_NAME "x64")
+   ELSE()
+     SET(MACHINE_NAME "32")
+-  END()
++  ENDIF()
+ ENDIF()
+ 
+ SET(product_name "mysql-connector-c-${CPACK_PACKAGE_VERSION}-${PLATFORM_NAME}${CONCAT_SIGN}${MACHINE_NAME}")


### PR DESCRIPTION
Same fix that went into libmariadb package with commit fd13c12.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @miska 
Compile tested: ath79 master
Run tested: N/A

Description:
Same as #15937 for mariadb.