### PR TITLE
ffmpeg: update to 4.4

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
-PKG_VERSION:=4.3.2
+PKG_VERSION:=4.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
-PKG_HASH:=46e4e64f1dd0233cbc0934b9f1c0da676008cad34725113fb7f802cfa84ccddb
+PKG_HASH:=06b10a183ce5371f915c6bb15b7b1fffbe046e8275099c96affc29e17645d909
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Ian Leonard <antonlacon@gmail.com>
 

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
-PKG_VERSION:=4.4
+PKG_VERSION:=4.4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
-PKG_HASH:=06b10a183ce5371f915c6bb15b7b1fffbe046e8275099c96affc29e17645d909
+PKG_HASH:=eadbad9e9ab30b25f5520fbfde99fae4a92a1ae3c0257a8d68569a4651e30e02
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Ian Leonard <antonlacon@gmail.com>
 

--- a/multimedia/ffmpeg/patches/030-h264-mips.patch
+++ b/multimedia/ffmpeg/patches/030-h264-mips.patch
@@ -1,7 +1,7 @@
 --- a/libavcodec/mips/cabac.h
 +++ b/libavcodec/mips/cabac.h
 @@ -28,6 +28,7 @@
- #include "libavutil/mips/mmiutils.h"
+ #include "libavutil/mips/asmdefs.h"
  #include "config.h"
  
 +#ifndef __mips16


### PR DESCRIPTION
Maintainer: me & @thess 
Compile tested: arm/mvebu/master HEAD as of 24.06.2021
Run tested: arm/mvebu/master HEAD as of 24.06.2021

Description:
Tested libffmpeg-full/cli via audio conversion flac -> opus.
Tested libffmpeg-full via minidlna media detection.