### PR TITLE
libzip: fix pkgconfig paths (fixes #15943)

### DIFF
--- a/libs/libzip/Makefile
+++ b/libs/libzip/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libzip
 PKG_VERSION:=1.8.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://libzip.org/download/

--- a/libs/libzip/patches/0001-Try-having-relative-paths-in-pkg-config-file.patch
+++ b/libs/libzip/patches/0001-Try-having-relative-paths-in-pkg-config-file.patch
@@ -1,0 +1,52 @@
+From c4af9182efd9cbb127bb43486b55d9ddf4a521ca Mon Sep 17 00:00:00 2001
+From: Thomas Klausner <tk@giga.or.at>
+Date: Mon, 28 Jun 2021 11:52:15 +0200
+Subject: [PATCH] Try having relative paths in pkg-config file.
+
+Addresses #248
+---
+ CMakeLists.txt | 11 ++++++-----
+ libzip.pc.in   |  7 +++----
+ 2 files changed, 9 insertions(+), 9 deletions(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -281,11 +281,12 @@ endif()
+ 
+ 
+ # pkgconfig file
+-set(prefix ${CMAKE_INSTALL_PREFIX})
+-set(exec_prefix \${prefix})
+-SET(bindir ${CMAKE_INSTALL_FULL_BINDIR})
+-SET(libdir ${CMAKE_INSTALL_FULL_LIBDIR})
+-SET(includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
++file(RELATIVE_PATH pc_relative_bindir ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_FULL_BINDIR})
++set(bindir "\${prefix}/${pc_relative_bindir}")
++file(RELATIVE_PATH pc_relative_libdir ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_FULL_LIBDIR})
++set(libdir "\${prefix)/${pc_relative_libdir}")
++file(RELATIVE_PATH pc_relative_includedir ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_FULL_INCLUDEDIR})
++set(includedir "\${prefix}/${pc_relative_includedir}")
+ if(CMAKE_SYSTEM_NAME MATCHES BSD)
+   set(PKG_CONFIG_RPATH "-Wl,-R\${libdir}")
+ endif(CMAKE_SYSTEM_NAME MATCHES BSD)
+--- a/libzip.pc.in
++++ b/libzip.pc.in
+@@ -1,10 +1,10 @@
+-prefix=@prefix@
+-exec_prefix=@exec_prefix@
++prefix=@CMAKE_INSTALL_PREFIX@
++exec_prefix=${prefix}
+ bindir=@bindir@
+ libdir=@libdir@
+ includedir=@includedir@
+ 
+-zipcmp=@bindir@/zipcmp
++zipcmp=${bindir}/zipcmp
+ 
+ Name: libzip
+ Description: library for handling zip archives
+@@ -12,4 +12,3 @@ Version: @PROJECT_VERSION@
+ Libs: @PKG_CONFIG_RPATH@ -L${libdir} -lzip
+ Libs.private: @LIBS@
+ Cflags: -I${includedir}
+-


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs

Description:

We should use upstream patch here, which can be removed later,
instead of maintaining our own one.

Reported-by: Rosen Penev <rosenp@gmail.com>
Signed-off-by: Michael Heimpold <mhei@heimpold.de>

