### PR TITLE
Adds stalkerware blocklist by astryzia to config file

### DIFF
--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -258,6 +258,13 @@
 		"focus": "general",
 		"descurl": "https://github.com/Dawsey21"
 	},
+        "stalkerware": {
+                "url": "https://raw.githubusercontent.com/astryzia/stalkerware-urls/main/stalkerware_urls.txt",
+                "rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
+                "size": "S",
+                "focus": "general",
+                "descurl": "https://github.com/astryzia/stalkerware-urls"
+        },
 	"stevenblack": {
 		"url": "https://raw.githubusercontent.com/StevenBlack/hosts/master/",
 		"rule": "/^0\\.0\\.0\\.0[[:space:]]+([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($2)}",


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested:
Model	PC Engines apu2
Architecture	AMD GX-412TC SOC
Firmware Version	OpenWrt 19.07.6 r11278-8055e38794 / LuCI openwrt-19.07 branch git-21.160.68865-15ca915
Kernel Version	4.14.215

Description: This addition to the config file adds a blocklist for Stalker ware used for surveillance of users. 
