### PR TITLE
[19.07] python-dateutil: disable setuptools-scm for build

### DIFF
--- a/lang/python/python-dateutil/Makefile
+++ b/lang/python/python-dateutil/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dateutil
 PKG_VERSION:=2.8.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=BSD-2-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/lang/python/python-dateutil/patches/0001-disable-setuptools-scm.patch
+++ b/lang/python/python-dateutil/patches/0001-disable-setuptools-scm.patch
@@ -1,0 +1,32 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -2,8 +2,7 @@
+ requires = [
+     "setuptools; python_version != '3.3'",
+     "setuptools<40.0; python_version == '3.3'",
+-    "wheel",
+-    "setuptools_scm"
++    "wheel"
+ ]
+ build-backend = "setuptools.build_meta"
+ 
+--- a/setup.py
++++ b/setup.py
+@@ -49,9 +49,6 @@ README = README()  # NOQA
+ 
+ 
+ setup(name="python-dateutil",
+-      use_scm_version={
+-          'write_to': 'dateutil/_version.py',
+-      },
+       description="Extensions to the standard Python datetime module",
+       author="Gustavo Niemeyer",
+       author_email="gustavo@niemeyer.net",
+@@ -65,7 +62,6 @@ setup(name="python-dateutil",
+       python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*",
+       package_data={"dateutil.zoneinfo": ["dateutil-zoneinfo.tar.gz"]},
+       zip_safe=True,
+-      setup_requires=['setuptools_scm'],
+       install_requires=["six >=1.5"],
+       classifiers=[
+           'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79  openwrt-19.07  https://github.com/openwrt/openwrt/commit/71fa524e1bef2b266d9ed3ee94c2b7ff9d8e59b0
Run tested: n/a

-------------------------------------------------------------

Fixes https://github.com/openwrt/packages/issues/15988

It seems that the newer setuptools-scm package (6.0.1) has some
Python3-only syntax.
For the 19.07 release, where Python2 is still around this causes the
python-dateutil package to fail to build.

See https://github.com/pypa/setuptools_scm/issues/541

However, removing 'setuptools-scm' from the build also works.
This change does that.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>


Description:
