### PR TITLE
dnsdist, pdns-recursor: remove --enable-option-checking=fatal

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -135,7 +135,6 @@ DISABLE_NLS:=
 TARGET_CXX+=-std=c++17
 
 CONFIGURE_ARGS+= \
-	--enable-option-checking=fatal \
 	--with-pic \
 	--with-lua=lua \
 	$(if $(CONFIG_DNSDIST_SODIUM),--enable-dnscrypt --with-libsodium,--disable-dnscrypt --without-libsodium) \

--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -43,7 +43,6 @@ endef
 DISABLE_NLS:=
 
 CONFIGURE_ARGS += \
-	--enable-option-checking=fatal \
 	--sysconfdir=/etc/powerdns \
 	--with-lua=lua \
 	--without-libcap \


### PR DESCRIPTION
Maintainer: me
Compile tested: built for mips_24kc_musl on Debian 10 x86_64
Run tested: OpenWrt SNAPSHOT, r16595-f4473baf6e, on TP-Link Archer C7/AC1750. recursor: Tested resolving of a few names. dnsdist: Tested forwarding of UDP, DoT and DoH DNS queries.

Description:
A user reported that his build that passed `--disable-ipv6` to everything failed, because I previously enabled fatal option checking. It looks like these are the only two packages in OpenWRT packages that are that strict, so this PR reverts that strictness.