### PR TITLE
udhcpsnoop: import package from TIP

### DIFF
--- a/net/udhcpsnoop/Makefile
+++ b/net/udhcpsnoop/Makefile
@@ -1,0 +1,31 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=udhcpsnoop
+PKG_RELEASE:=1
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_MAINTAINER:=John Crispin <john@phrozen.org>
+
+PKG_SOURCE_URL=https://github.com/blogic/udhcpsnoop.git
+PKG_MIRROR_HASH:=64d9d2cb93bd67d55aa08328ef6aa1412e6c1a827e3eccec784a3ba65be2596f
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2021-05-30
+PKG_SOURCE_VERSION:=b86639904147a40be32ac43cd89c21109ffc3543
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/udhcpsnoop
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=DHCP Snooping Daemon
+  DEPENDS:=+libubox +libubus +libuci
+endef
+
+define Package/udhcpsnoop/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/udhcpsnoop $(1)/usr/sbin/
+	$(CP) ./files/* $(1)
+endef
+
+$(eval $(call BuildPackage,udhcpsnoop))

--- a/net/udhcpsnoop/files/etc/config/dhcpsnoop
+++ b/net/udhcpsnoop/files/etc/config/dhcpsnoop
@@ -1,0 +1,4 @@
+config snooping
+	option enable 0
+	#list network lan
+	#list network wan

--- a/net/udhcpsnoop/files/etc/init.d/dhcpsnoop
+++ b/net/udhcpsnoop/files/etc/init.d/dhcpsnoop
@@ -1,0 +1,22 @@
+#!/bin/sh /etc/rc.common
+
+START=80
+
+USE_PROCD=1
+PROG=/usr/sbin/udhcpsnoop
+
+service_triggers() {
+	procd_add_reload_trigger dhcpsnoop
+}
+
+start_service() {
+	[ "$(uci get dhcpsnoop.@snooping[-1].enable)" -eq 1 ] || return
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_set_param respawn
+	procd_close_instance
+}
+
+reload_service() {
+	restart
+}


### PR DESCRIPTION
```
Import the udhcpsnoop package from the TIP feed.

The original Makefile in TIP repo spcifies GPL-2.0 as the PKG_LICENSE.
However this is a mistake, as the SPDX headers of the repos source files
all specify BSD-3-Clause as their license.

See https://github.com/Telecominfraproject/wlan-ap/blob/uCentral-trunk/feeds/ucentral/udhcpsnoop/Makefile

Signed-off-by: David Bauer <mail@david-bauer.net>
```

Maintainer: @blogic (?)
Compile tested: ipq40xx-generic
Run tested: gl-b1300

Description: dhcp snooping daemon that relays dhcp packets as ubus events
