### PR TITLE
arp-scan: install database files and add MAC codes

### DIFF
--- a/net/arp-scan/Makefile
+++ b/net/arp-scan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=arp-scan
 PKG_VERSION:=1.9-40-g69b2f70
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-3.0
 PKG_MAINTAINER:=Sergey Urushkin <urusha.v1.0@gmail.com>
 
@@ -41,8 +41,11 @@ define Package/arp-scan/description
 endef
 
 define Package/arp-scan/install
-	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/share/arp-scan
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/arp-scan $(1)/usr/bin/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/ieee-iab.txt $(1)/usr/share/arp-scan/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/ieee-oui.txt $(1)/usr/share/arp-scan/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/mac-vendor.txt $(1)/usr/share/arp-scan/
 endef
 
 $(eval $(call BuildPackage,arp-scan))

--- a/net/arp-scan/patches/010-mac-vendor.patch
+++ b/net/arp-scan/patches/010-mac-vendor.patch
@@ -1,0 +1,51 @@
+--- a/mac-vendor.txt
++++ b/mac-vendor.txt
+@@ -37,6 +37,48 @@
+ # http://www.nta-monitor.com/wiki
+ #
+ 
++# From Transacom
++00D861	Micro-Star Intl Co., Ltd.
++10E7C6	Hewlett Packard
++38AF29	Zhejiang Dahua Technology Co., Ltd.
++3C846A	TP-Link Technologies Co., Ltd.
++3C2AF4	Brother Industries, Ltd.
++449160	Murata Manufacturing Co., Ltd.
++484BAA	Apple, Inc.
++48A6B8	Sonos, Inc.
++4CCC6A	Micro-Star INTL CO., LTD.
++509A4C	Dell Inc.
++58EF68	Belkin International Inc.
++6032B1	TP-Link Technologies Co., Ltd.
++701F53	Cisco Systems, Inc
++704F57	TP-Link Technologies Co., Ltd.
++706BB9	Cisco Systems, Inc
++7085C2	ASRock Incorporation
++70AF24	TP Vision Belgium NV
++7828ca	Sonos, Inc.
++78DDD9	Guangzhou Shiyuan Electronics Co., Ltd.
++70EF00	Apple, Inc.
++805EC0	Yealink(XIAMEN) Network Technology Co.,Ltd.
++847BEB	Dell Inc.
++84A93E	Hewlett Packard
++84D81B	TP-Link Technologies Co., Ltd.
++94C691	EliteGroup Computer Systems Co., Ltd
++9C1463	Zhejiang Dahua Technology Co., Ltd.
++A0BD1D	Zhejiang Dahua Technology Co., Ltd.
++A4AE11	Hon Hai Precision Ind. Co., Ltd.
++A860B6	Apple, Inc.
++B04E26	TP-Link Technologies Co., Ltd.
++B40016	Ingenico Terminals SAS
++B8ECA3	Zyxel Communications Corporation
++C83C85	Apple, Inc.
++CC6EA4	Samsung Electronics Co., Ltd.
++D807B6	TP-Link Technologies Co., Ltd.
++D80D17	TP-Link Technologies Co., Ltd.
++D89EF3	Dell Inc.
++DC56E7	Apple, Inc.
++E454E8	Dell Inc.
++E8D8D1	HP Inc.
++
+ # From nmap Debian bug report #369681 dated 31 May 2006
+ 525400	QEMU
+ B0C420	Bochs


### PR DESCRIPTION
Maintainer: Sergey Urushkin <urusha.v1.0@gmail.com>
Compile tested: x86_64 OverTheBox v3.10 v0.6.32 OpenWRT 18.06
Run tested: x86_64 OverTheBox v3.10 v0.6.32 OpenWRT 18.06

Description:
Install database files for arp-scan so that it can run correctly
Add additional MAC vendor codes