### PR TITLE
adblock: update 4.1.3-2

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
 PKG_VERSION:=4.1.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -47,6 +47,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 | shallalist          |         | VAR  | general          | [Link](https://www.shallalist.de)                                                 |
 | smarttv_tracking    |         | S    | tracking         | [Link](https://github.com/Perflyst/PiHoleBlocklist)                               |
 | spam404             |         | S    | general          | [Link](https://github.com/Dawsey21)                                               |
+| stalkerware         |         | S    | tracking         | [Link](https://github.com/astryzia/stalkerware-urls)                              |
 | stevenblack         |         | VAR  | compilation      | [Link](https://github.com/StevenBlack/hosts)                                      |
 | stopforumspam       |         | S    | spam             | [Link](https://www.stopforumspam.com)                                             |
 | utcapitole          |         | VAR  | general          | [Link](https://dsi.ut-capitole.fr/blacklists/index_en.php)                        |
@@ -170,6 +171,7 @@ Available commands:
 | adb_replisten      | 53                                 | space separated list of reporting port(s) used by tcpdump                                      |
 | adb_repchunkcnt    | 5                                  | report chunk count used by tcpdump                                                             |
 | adb_repchunksize   | 1                                  | report chunk size used by tcpdump in MB                                                        |
+| adb_represolve     | 0, disabled                        | resolve reporting IP addresses using reverse DNS (PTR) lookups                                 |
 | adb_backup         | 1, enabled                         | set to 0 to disable the backup function                                                        |
 | adb_backupdir      | /tmp                               | path for adblock backups                                                                       |
 | adb_tmpbase        | /tmp                               | path for all adblock related runtime operations, e.g. downloading, sorting, merging etc.       |

--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -54,6 +54,7 @@ adb_repiface=""
 adb_replisten="53"
 adb_repchunkcnt="5"
 adb_repchunksize="1"
+adb_represolve="0"
 adb_lookupdomain="example.com"
 adb_action="${1:-"start"}"
 adb_packages=""
@@ -1653,7 +1654,7 @@ f_main()
 #
 f_report()
 {
-	local report_raw report_json report_txt content status total start end blocked percent top_list top array item index hold ports value key key_list cnt=0 action="${1}" count="${2:-"50"}" search="${3:-"+"}"
+	local report_raw report_json report_txt content status total start end blocked percent top_list top array item index hold ports value key key_list cnt=0 resolve="-nn" action="${1}" count="${2:-"50"}" search="${3:-"+"}"
 
 	report_raw="${adb_reportdir}/adb_report.raw"
 	report_srt="${adb_reportdir}/adb_report.srt"
@@ -1668,10 +1669,14 @@ f_report()
 		> "${report_srt}"
 		> "${report_txt}"
 		> "${report_jsn}"
+		if [ "${adb_represolve}" = "1" ]
+		then
+			resolve=""
+		fi
 		for file in "${adb_reportdir}/adb_report.pcap"*
 		do
 			(
-				"${adb_dumpcmd}" -nn -tttt -r "${file}" 2>/dev/null | \
+				"${adb_dumpcmd}" "${resolve}" -tttt -r "${file}" 2>/dev/null | \
 					"${adb_awk}" -v cnt="${cnt}" '!/\.lan\. |PTR\? | SOA\? /&&/ A[\? ]+|NXDomain|0\.0\.0\.0/{a=$1;b=substr($2,0,8);c=$4;sub(/\.[0-9]+$/,"",c);gsub(/[^[:alnum:]\.:-]/,"",c);d=cnt $7;sub(/\*$/,"",d);
 					e=$(NF-1);sub(/[0-9]\/[0-9]\/[0-9]|0\.0\.0\.0/,"NX",e);sub(/\.$/,"",e);sub(/([0-9]{1,3}\.){3}[0-9]{1,3}/,"OK",e);gsub(/[^[:alnum:]\.-]/,"",e);if(e==""){e="err"};printf "%s\t%s\t%s\t%s\t%s\n",d,e,a,b,c}' >> "${report_raw}"
 			)&
@@ -1810,7 +1815,7 @@ f_report()
 		( "${adb_mailservice}" "${adb_ver}" "${content}" >/dev/null 2>&1 )&
 		bg_pid="${!}"
 	fi
-	f_log "debug" "f_report ::: action: ${action}, count: ${count}, search: ${search}, dump_util: ${adb_dumpcmd}, rep_dir: ${adb_reportdir}, rep_iface: ${adb_repiface:-"-"}, rep_listen: ${adb_replisten}, rep_chunksize: ${adb_repchunksize}, rep_chunkcnt: ${adb_repchunkcnt}"
+	f_log "debug" "f_report ::: action: ${action}, count: ${count}, search: ${search}, dump_util: ${adb_dumpcmd}, rep_dir: ${adb_reportdir}, rep_iface: ${adb_repiface:-"-"}, rep_listen: ${adb_replisten}, rep_chunksize: ${adb_repchunksize}, rep_chunkcnt: ${adb_repchunkcnt}, rep_resolve: ${adb_represolve}"
 }
 
 # source required system libraries

--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -258,6 +258,13 @@
 		"focus": "general",
 		"descurl": "https://github.com/Dawsey21"
 	},
+	"stalkerware": {
+		"url": "https://raw.githubusercontent.com/astryzia/stalkerware-urls/main/stalkerware_urls.txt",
+		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
+		"size": "S",
+		"focus": "tracking",
+		"descurl": "https://github.com/astryzia/stalkerware-urls"
+	},
 	"stevenblack": {
 		"url": "https://raw.githubusercontent.com/StevenBlack/hosts/master/",
 		"rule": "/^0\\.0\\.0\\.0[[:space:]]+([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($2)}",


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: TP-Link RE650 v1, OpenWrt SNAPSHOT r17073-8bb4437c01

Description:
* add a tcpdump option to resolve IPs in adblock reporting,
  set 'adb_represolve' accordingly (disabled by default). If enabled
  tcpdump will perform a reverse DNS (PTR) lookup for each IP address
* add 'stalkerware' source (provided by @astryzia/@rahlquist)
* update readme

Signed-off-by: Dirk Brenken <dev@brenken.org>
