### PR TITLE
miniupnpd: add force_forwarding option support

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.2.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -62,7 +62,7 @@ upnpd() {
 	local use_stun stun_host stun_port uuid notify_interval presentation_url
 	local upnp_lease_file clean_ruleset_threshold clean_ruleset_interval
 	local ipv6_disable
-	local ext_ip_reserved_ignore
+	local force_forwarding
 
 	local enabled
 	config_get_bool enabled config enabled 1
@@ -90,7 +90,7 @@ upnpd() {
 	config_get clean_ruleset_threshold config clean_ruleset_threshold
 	config_get clean_ruleset_interval config clean_ruleset_interval
 	config_get ipv6_disable config ipv6_disable 0
-	config_get ext_ip_reserved_ignore config ext_ip_reserved_ignore 0
+	config_get force_forwarding config force_forwarding 0
 
 	local conf ifname ifname6
 
@@ -143,7 +143,7 @@ upnpd() {
 		upnpd_write_bool igdv1 0 force_igd_desc_v1
 		upnpd_write_bool use_stun 0 ext_perform_stun
 		upnpd_write_bool ipv6_disable $ipv6_disable
-		upnpd_write_bool ext_ip_reserved_ignore $ext_ip_reserved_ignore
+		upnpd_write_bool force_forwarding $force_forwarding
 
 		[ "$use_stun" -eq 0 ] || {
 			[ -n "$stun_host" ] && echo "ext_stun_host=$stun_host"

--- a/net/miniupnpd/files/upnpd.config
+++ b/net/miniupnpd/files/upnpd.config
@@ -2,6 +2,7 @@ config upnpd config
 	option enabled		0
 	option enable_natpmp	1
 	option enable_upnp	1
+	option force_forwarding 1
 	option secure_mode	1
 	option log_output	0
 	option download		1024

--- a/net/miniupnpd/patches/301-options-force_forwarding-support.patch
+++ b/net/miniupnpd/patches/301-options-force_forwarding-support.patch
@@ -1,45 +1,32 @@
-commit cb046cfef1d6b954d3fc09f09a1fc3a7ffeb7593
-Author: Chen Minqiang <ptpt52@gmail.com>
-Date:   Sun Jul 5 10:42:52 2020 +0800
+From 1037e70c96c546b3f4d27efe7830d9c09092b97e Mon Sep 17 00:00:00 2001
+From: Chen Minqiang <ptpt52@gmail.com>
+Date: Sun, 5 Jul 2020 10:42:52 +0800
+Subject: [PATCH] options: force_forwarding support
 
-    options: ext_ip_reserved_ignore support
-    
-    This make the port forwarding force to work even
-    when the router is behind NAT
-    
-    Signed-off-by: Chen Minqiang <ptpt52@gmail.com>
+This make the port forwarding force to work even
+when the router is behind NAT
 
---- a/getifaddr.c
-+++ b/getifaddr.c
-@@ -25,6 +25,7 @@
- #if defined(USE_GETIFADDRS) || defined(ENABLE_IPV6) || defined(ENABLE_PCP)
- #include <ifaddrs.h>
- #endif
-+#include "upnpglobalvars.h"
- 
- int
- getifaddr(const char * ifname, char * buf, int len,
-@@ -295,6 +296,11 @@ addr_is_reserved(struct in_addr * addr)
- 	uint32_t address = ntohl(addr->s_addr);
- 	size_t i;
- 
-+	if(GETFLAG(EXTIPRESERVEDIGNOREMASK)) {
-+		syslog(LOG_NOTICE, "private/reserved address checking is ignored");
-+		return 0;
-+	}
-+
- 	for (i = 0; i < sizeof(reserved)/sizeof(reserved[0]); ++i) {
- 		if ((address >> reserved[i].rmask) == (reserved[i].address >> reserved[i].rmask))
- 			return 1;
+Signed-off-by: Chen Minqiang <ptpt52@gmail.com>
+---
+ miniupnpd/miniupnpd.c      | 4 ++++
+ miniupnpd/miniupnpd.conf   | 2 ++
+ miniupnpd/options.c        | 1 +
+ miniupnpd/options.h        | 1 +
+ miniupnpd/testgetifaddr.c  | 2 ++
+ miniupnpd/testportinuse.c  | 2 ++
+ miniupnpd/upnpglobalvars.h | 2 ++
+ miniupnpd/upnpredirect.c   | 2 +-
+ 8 files changed, 15 insertions(+), 1 deletion(-)
+
 --- a/miniupnpd.c
 +++ b/miniupnpd.c
 @@ -1241,6 +1241,10 @@ init(int argc, char * * argv, struct run
  			case UPNPEXT_IP:
  				use_ext_ip_addr = ary_options[i].value;
  				break;
-+			case UPNPEXT_IP_RESERVED_IGNORE:
++			case UPNP_FORCE_FORWARDING:
 +				if(strcmp(ary_options[i].value, "yes") == 0)
-+					SETFLAG(EXTIPRESERVEDIGNOREMASK);
++					SETFLAG(FORCEFORWARDINGMASK);
 +				break;
  			case UPNPEXT_PERFORM_STUN:
  				if(strcmp(ary_options[i].value, "yes") == 0)
@@ -50,8 +37,8 @@ Date:   Sun Jul 5 10:42:52 2020 +0800
  # Setting ext_ip is also useful in double NAT setup, you can declare here
  # the public IP address.
  #ext_ip=
-+#ignore even if ext_ip is reserved: default is no
-+#ext_ip_reserved_ignore=yes
++#force forwarding enable for upnp: default is no
++#force_forwarding=yes
  # WAN interface must have public IP address. Otherwise it is behind NAT
  # and port forwarding is impossible. In some cases WAN interface can be
  # behind unrestricted full-cone NAT 1:1 when all incoming traffic is NAT-ed and
@@ -61,7 +48,7 @@ Date:   Sun Jul 5 10:42:52 2020 +0800
  	{ UPNPEXT_IFNAME6, "ext_ifname6" },
  #endif
  	{ UPNPEXT_IP,	"ext_ip" },
-+	{ UPNPEXT_IP_RESERVED_IGNORE, "ext_ip_reserved_ignore" },
++	{ UPNP_FORCE_FORWARDING, "force_forwarding" },
  	{ UPNPEXT_PERFORM_STUN, "ext_perform_stun" },
  	{ UPNPEXT_STUN_HOST, "ext_stun_host" },
  	{ UPNPEXT_STUN_PORT, "ext_stun_port" },
@@ -71,7 +58,7 @@ Date:   Sun Jul 5 10:42:52 2020 +0800
  	UPNPEXT_IFNAME6,		/* ext_ifname6 */
  #endif
  	UPNPEXT_IP,				/* ext_ip */
-+	UPNPEXT_IP_RESERVED_IGNORE, /* ignore if ext_ip is reserved */
++	UPNP_FORCE_FORWARDING, /* force forwarding enable for upnp */
  	UPNPEXT_PERFORM_STUN,		/* ext_perform_stun */
  	UPNPEXT_STUN_HOST,		/* ext_stun_host */
  	UPNPEXT_STUN_PORT,		/* ext_stun_port */
@@ -103,8 +90,19 @@ Date:   Sun Jul 5 10:42:52 2020 +0800
  
  #define PERFORMSTUNMASK    0x1000
  
-+#define EXTIPRESERVEDIGNOREMASK 0x2000
++#define FORCEFORWARDINGMASK 0x2000
 +
  #define SETFLAG(mask)	runtime_flags |= mask
  #define GETFLAG(mask)	(runtime_flags & mask)
  #define CLEARFLAG(mask)	runtime_flags &= ~mask
+--- a/upnpredirect.c
++++ b/upnpredirect.c
+@@ -444,7 +444,7 @@ upnp_redirect_internal(const char * rhos
+ {
+ 	/*syslog(LOG_INFO, "redirecting port %hu to %s:%hu protocol %s for: %s",
+ 		eport, iaddr, iport, protocol, desc);			*/
+-	if(disable_port_forwarding)
++	if(disable_port_forwarding && !GETFLAG(FORCEFORWARDINGMASK))
+ 		return -1;
+ 	if(add_redirect_rule2(ext_if_name, rhost, eport, iaddr, iport, proto,
+ 	                      desc, timestamp) < 0) {


### PR DESCRIPTION
This option replace the 'ext_ip_reserved_ignore', and replace the
patch with new one

as addr_is_reserved() behavior should not be changed, so drop the
ext_ip_reserved_ignore

use a force_forwarding option to make the port forwarding force to
work when the router is behind NAT


Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
