### PR TITLE
[21.02] python-dateutil: add setuptools-scm build dep

### DIFF
--- a/lang/python/host-pip-requirements/setuptools-scm.txt
+++ b/lang/python/host-pip-requirements/setuptools-scm.txt
@@ -1,1 +1,1 @@
-setuptools-scm==4.1.2 --hash=sha256:a8994582e716ec690f33fec70cca0f85bd23ec974e3f783233e4879090a7faa8
+setuptools-scm==6.0.1 --hash=sha256:d1925a69cb07e9b29416a275b9fadb009a23c148ace905b2fb220649a6c18e92

--- a/lang/python/python-dateutil/Makefile
+++ b/lang/python/python-dateutil/Makefile
@@ -9,12 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dateutil
 PKG_VERSION:=2.8.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=BSD-2-Clause
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:=setuptools-scm
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: me
Compile tested: n/a
Run tested: n/a

--------------------------------------------------------------------

Following:
  https://github.com/openwrt/packages/pull/16004
  https://github.com/openwrt/packages/pull/15995
  https://github.com/openwrt/packages/issues/15988

It seems that dateutil requires setuptools-scm to be installed.
As such, this is being added as a dependency.

Also, bump setuptools-scm to version 6.0.1

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>
(cherry picked from commit e2026346cceeb54216090a75c83d527f8c51f321)