### PR TITLE
qemu: update to 6.1.0, add usb passthrough option

### DIFF
--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qemu
-PKG_VERSION:=5.0.0
-PKG_RELEASE:=5
+PKG_VERSION:=6.1.0
+PKG_RELEASE:=$(AUTORELEASE)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=2f13a92a0fa5c8b69ff0796b59b86b080bbb92ebad5d301a7724dd06b5e78cb6
+PKG_HASH:=eebc089db3414bbeedf1e464beda0a7515aad30f73261abc246c9b27503a3c96
 PKG_SOURCE_URL:=http://download.qemu.org/
-PKG_LICENSE:=GPL-2.0
+PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=LICENSE tcg/LICENSE
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 PKG_CPE_ID:=cpe:/a:qemu:qemu
@@ -23,7 +23,7 @@ PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 PKG_USE_MIPS16:=0
 
-PKG_BUILD_DEPENDS+=spice-protocol
+PKG_BUILD_DEPENDS+=spice-protocol meson/host
 
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/package.mk
@@ -96,7 +96,7 @@ endef
 
 define Package/qemu-img/install
 	$(INSTALL_DIR) $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/qemu-img $(1)/usr/bin/qemu-img
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/qemu-img $(1)/usr/bin/qemu-img
 endef
 
 
@@ -111,7 +111,7 @@ endef
 
 define Package/qemu-nbd/install
 	$(INSTALL_DIR) $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/qemu-nbd $(1)/usr/sbin/qemu-nbd
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/qemu-nbd $(1)/usr/sbin/qemu-nbd
 endef
 
 
@@ -190,12 +190,13 @@ define qemu-target
     SUBMENU:=Virtualization
     TITLE:=QEMU target $(1)
     URL:=http://www.qemu.org
-    DEPENDS:= +glib2 +libpthread +zlib $(QEMU_DEPS_IN_HOST) $(qemu-target-$(1)-deps) \
+    DEPENDS:= +glib2 +libpthread +zlib +libbpf $(QEMU_DEPS_IN_HOST) $(qemu-target-$(1)-deps) \
 	+QEMU_UI_VNC:qemu-keymaps \
 	+QEMU_UI_VNC_JPEG:libjpeg \
 	+QEMU_UI_VNC_PNG:libpng \
 	+QEMU_UI_VNC_SASL:libsasl2 \
 	+QEMU_UI_SPICE:libspice-server \
+	+QEMU_DEV_USB:libusb-1.0 \
 	$(if $(filter %-softmmu,$(1)),+libncurses +libfdt +pixman +qemu-firmware-efi $(ICONV_DEPENDS))
   endef
 
@@ -257,6 +258,9 @@ config QEMU_UI_VNC_SASL
 config QEMU_UI_SPICE
 	bool "QEMU SPICE ui support"
 
+config QEMU_DEV_USB
+	bool "QEMU USB passthrough support"
+
 endif
 endef
 
@@ -266,6 +270,7 @@ PKG_CONFIG_DEPENDS += \
 	CONFIG_QEMU_UI_VNC_PNG \
 	CONFIG_QEMU_UI_VNC_SASL \
 	CONFIG_QEMU_UI_SPICE \
+	CONFIG_QEMU_DEV_USB \
 
 
 # QEMU configure script does not recognize these options
@@ -299,7 +304,9 @@ CONFIGURE_ARGS +=			\
 	--enable-vhost-scsi		\
 	--enable-vhost-user		\
 	--enable-vhost-user-fs		\
+	--enable-vhost-user-blk-server	\
 	--enable-vhost-vsock		\
+	--enable-vhost-vdpa		\
 
 # Image formats support
 CONFIGURE_ARGS +=			\
@@ -351,6 +358,8 @@ CONFIGURE_ARGS +=			\
 	--enable-live-block-migration	\
 	--enable-membarrier		\
 	--enable-replication		\
+	--enable-lto			\
+	--enable-tools			\
 
 # Review configure options not explicitly specified here
 #
@@ -375,7 +384,7 @@ CONFIGURE_ARGS +=			\
 	--disable-debug-tcg		\
 	--disable-docs			\
 	--disable-gcrypt		\
-	--disable-git-update		\
+	--with-git-submodules=ignore	\
 	--disable-glusterfs		\
 	--disable-gnutls		\
 	--disable-guest-agent-msi	\
@@ -385,7 +394,7 @@ CONFIGURE_ARGS +=			\
 	--disable-libpmem		\
 	--disable-libssh		\
 	--disable-libudev		\
-	--disable-libusb		\
+	--$(if $(CONFIG_QEMU_DEV_USB),enable,disable)-libusb		\
 	--disable-libxml2		\
 	--disable-linux-aio		\
 	--disable-linux-io-uring	\
@@ -405,19 +414,16 @@ CONFIGURE_ARGS +=			\
 	--disable-rdma			\
 	--disable-sanitizers		\
 	--disable-seccomp		\
-	--disable-sheepdog		\
 	--disable-smartcard		\
 	--disable-snappy		\
 	--disable-sparse		\
 	--disable-strip			\
 	--disable-tcg-interpreter	\
 	--disable-tcmalloc		\
-	--disable-tools			\
 	--disable-tpm			\
 	--disable-usb-redir		\
 	--disable-vde			\
 	--disable-virtfs		\
-	--disable-vxhs			\
 	--disable-werror		\
 	--disable-xen-pci-passthrough	\
 	--disable-xkbcommon		\
@@ -434,17 +440,6 @@ MAKE_VARS += V=1
 MAKE_FLAGS:=$(filter-out	\
 	ARCH=%			\
 	,$(MAKE_FLAGS))
-
-QEMU_MAKE_TARGETS := \
-	$(if $(CONFIG_PACKAGE_qemu-ga),qemu-ga) \
-	$(if $(CONFIG_PACKAGE_qemu-bridge-helper),qemu-bridge-helper) \
-	$(if $(CONFIG_PACKAGE_qemu-img),qemu-img) \
-	$(if $(CONFIG_PACKAGE_qemu-nbd),qemu-nbd) \
-	$(foreach target,$(qemu-target-list),$(if $(CONFIG_PACKAGE_qemu-$(target)),$(target)/all)) \
-
-define Build/Compile
-	$(if $(strip $(QEMU_MAKE_TARGETS)),$(call Build/Compile/Default,$(QEMU_MAKE_TARGETS)))
-endef
 
 $(eval $(call BuildPackage,virtio-console-helper))
 $(eval $(call BuildPackage,qemu-ga))

--- a/utils/qemu/patches/0001-configure-allow-disable-fortify_source.patch
+++ b/utils/qemu/patches/0001-configure-allow-disable-fortify_source.patch
@@ -11,9 +11,9 @@ OpenWrt base build system decide flavor of fortify_source to use
 
 --- a/configure
 +++ b/configure
-@@ -1601,6 +1601,8 @@ for opt do
+@@ -1581,6 +1581,8 @@ for opt do
    ;;
-   --gdb=*) gdb_bin="$optarg"
+   --disable-slirp-smbd) slirp_smbd=no
    ;;
 +  --disable-fortify-source) fortify_source="no"
 +  ;;

--- a/utils/qemu/patches/0002-configure-allow-enabling-disabling-libudev-from-comm.patch
+++ b/utils/qemu/patches/0002-configure-allow-enabling-disabling-libudev-from-comm.patch
@@ -9,9 +9,9 @@ Subject: [PATCH] configure: allow enabling/disabling libudev from command line
 
 --- a/configure
 +++ b/configure
-@@ -1601,6 +1601,10 @@ for opt do
+@@ -1581,6 +1581,10 @@ for opt do
    ;;
-   --gdb=*) gdb_bin="$optarg"
+   --disable-slirp-smbd) slirp_smbd=no
    ;;
 +  --enable-libudev) libudev=yes
 +  ;;

--- a/utils/qemu/patches/0003-configure-enable-guest_agent-no-matter-whether-softm.patch
+++ b/utils/qemu/patches/0003-configure-enable-guest_agent-no-matter-whether-softm.patch
@@ -14,7 +14,7 @@ Fixes a512590 ("configure: qemu-ga is only needed with softmmu targets")
 
 --- a/configure
 +++ b/configure
-@@ -6414,7 +6414,7 @@ fi
+@@ -4375,7 +4375,7 @@ fi
  # Probe for guest agent support/options
  
  if [ "$guest_agent" != "no" ]; then
@@ -22,4 +22,4 @@ Fixes a512590 ("configure: qemu-ga is only needed with softmmu targets")
 +  if [ "$guest_agent" = "" -a "$want_tools" = no ] ; then
        guest_agent=no
    elif [ "$linux" = "yes" -o "$bsd" = "yes" -o "$solaris" = "yes" -o "$mingw32" = "yes" ] ; then
-       tools="qemu-ga\$(EXESUF) $tools"
+       guest_agent=yes

--- a/utils/qemu/patches/0005-pc-bios-fix-compilation-when-AS-is-actually-gcc-driv.patch
+++ b/utils/qemu/patches/0005-pc-bios-fix-compilation-when-AS-is-actually-gcc-driv.patch
@@ -9,21 +9,21 @@ Subject: [PATCH] pc-bios: fix compilation when $(AS) is actually gcc driver
 
 --- a/pc-bios/optionrom/Makefile
 +++ b/pc-bios/optionrom/Makefile
-@@ -34,7 +34,7 @@ endif
- QEMU_INCLUDES += -I$(SRC_PATH)
+@@ -36,7 +36,7 @@ override CFLAGS += -m32 -include $(SRC_D
+ endif
  
  Wa = -Wa,
--ASFLAGS += -32
-+ASFLAGS += $(Wa)-32
- QEMU_CFLAGS += $(call cc-c-option, $(QEMU_CFLAGS), $(Wa)-32)
+-override ASFLAGS += -32
++override ASFLAGS += $(Wa)-32
+ override CFLAGS += $(call cc-option, $(Wa)-32)
  
- build-all: multiboot.bin linuxboot.bin linuxboot_dma.bin kvmvapic.bin pvh.bin
-@@ -44,7 +44,7 @@ build-all: multiboot.bin linuxboot.bin l
- 
+ LD_I386_EMULATION ?= elf_i386
+@@ -47,7 +47,7 @@ all: multiboot.bin linuxboot.bin linuxbo
+ pvh.img: pvh.o pvh_main.o
  
  %.o: %.S
--	$(call quiet-command,$(CPP) $(QEMU_INCLUDES) $(QEMU_DGFLAGS) -c -o - $< | $(AS) $(ASFLAGS) -o $@,"AS","$(TARGET_DIR)$@")
-+	$(call quiet-command,$(CPP) $(QEMU_INCLUDES) $(QEMU_DGFLAGS) -c -o - $< | $(AS) $(ASFLAGS) -o $@ -x assembler -,"AS","$(TARGET_DIR)$@")
+-	$(call quiet-command,$(CPP) $(CPPFLAGS) -c -o - $< | $(AS) $(ASFLAGS) -o $@,"AS","$@")
++	$(call quiet-command,$(CPP) $(CPPFLAGS) -c -o - $< | $(AS) $(ASFLAGS) -o $@ -x assembler -,"AS","$@")
  
- pvh.img: pvh.o pvh_main.o
- 	$(call quiet-command,$(LD) $(LDFLAGS_NOPIE) -m $(LD_I386_EMULATION) -T $(SRC_PATH)/pc-bios/optionrom/flat.lds -s -o $@ $^,"BUILD","$(TARGET_DIR)$@")
+ %.o: %.c
+ 	$(call quiet-command,$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@,"CC","$@")

--- a/utils/qemu/patches/0006-util-mmap-alloc-fix-missing-MAP_SYNC.patch
+++ b/utils/qemu/patches/0006-util-mmap-alloc-fix-missing-MAP_SYNC.patch
@@ -32,7 +32,7 @@ Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
  #endif /* CONFIG_LINUX */
  
  #include "qemu/osdep.h"
-@@ -27,6 +24,13 @@
+@@ -29,6 +26,13 @@
  #include <sys/vfs.h>
  #endif
  

--- a/utils/qemu/patches/0007-qga-invoke-separate-applets-for-guest-shutdown-modes.patch
+++ b/utils/qemu/patches/0007-qga-invoke-separate-applets-for-guest-shutdown-modes.patch
@@ -38,7 +38,7 @@ https://gitlab.alpinelinux.org/alpine/aports/commit/76b81b486480fd9c3294cd420bcf
 @@ -111,6 +115,7 @@ void qmp_guest_shutdown(bool has_mode, c
  
          execle("/sbin/shutdown", "shutdown", "-h", shutdown_flag, "+0",
-                "hypervisor initiated shutdown", (char*)NULL, environ);
+                "hypervisor initiated shutdown", (char *)NULL, environ);
 +        execle(fallback_cmd, fallback_cmd, (char*)NULL, environ);
          _exit(EXIT_FAILURE);
      } else if (pid < 0) {


### PR DESCRIPTION
Signed-off-by: Vladimir Ermakov <vooon341@gmail.com>

Maintainer: @yousong
Compile tested: x86_64, OpenWrt master (https://github.com/openwrt/openwrt/commit/90e167abaae80a59c8780d3305f8e1260d9f1339), GCC 10.3
Run tested: x86_64 host, KVM for qemu-x86_64-softmmu + UEFI VM (homeassistant ova).

Description:
- Version updated to 6.1.0
- I had have compile problems with gcc 10 on 5.x
- Added option to enable USB pass-through (used it before with 5.x)
- Some changes in build system do not allow to use `make x86_64-softmmu` or `make qemu-img`, current workaround - build all