### PR TITLE
mwan3: use default routes from additional tables

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.10.9
+PKG_VERSION:=2.10.10
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -408,9 +408,17 @@ mwan3_delete_iface_iptables()
 
 }
 
+mwan3_extra_tables_routes()
+{
+	$IP route list table "$1"
+}
+
 mwan3_get_routes()
 {
-	$IP route list table main | sed -ne "$MWAN3_ROUTE_LINE_EXP" | uniq
+	{
+		$IP route list table main
+		config_list_foreach "globals" "rt_table_lookup" mwan3_extra_tables_routes
+	} | sed -ne "$MWAN3_ROUTE_LINE_EXP" | sort -u
 }
 
 mwan3_create_iface_route()


### PR DESCRIPTION
Maintainer: @feckert @aaronjg
Compile tested: x86/64
Run tested: x86/64 (PCEngines APU3)

Description:
Until now the additional tables listed in gobal `rt_table_lookup` were not considered for interfaces.
In order to be able to also use interface-defined routes from tables other than main, consider also tables listed in `rt_table_lookup`.
