### PR TITLE
Revert "openvpn: disable LZO support by default"

### DIFF
--- a/net/openvpn/Config-mbedtls.in
+++ b/net/openvpn/Config-mbedtls.in
@@ -2,7 +2,7 @@ if PACKAGE_openvpn-mbedtls
 
 config OPENVPN_mbedtls_ENABLE_LZO
 	bool "Enable LZO compression support"
-	default n
+	default y
 
 config OPENVPN_mbedtls_ENABLE_LZ4
 	bool "Enable LZ4 compression support"

--- a/net/openvpn/Config-openssl.in
+++ b/net/openvpn/Config-openssl.in
@@ -2,7 +2,7 @@ if PACKAGE_openvpn-openssl
 
 config OPENVPN_openssl_ENABLE_LZO
 	bool "Enable LZO compression support"
-	default n
+	default y
 
 config OPENVPN_openssl_ENABLE_LZ4
 	bool "Enable LZ4 compression support"

--- a/net/openvpn/files/openvpn.config
+++ b/net/openvpn/files/openvpn.config
@@ -300,7 +300,9 @@ config openvpn sample_server
 	#
 	# LZ4 requires OpenVPN 2.4+ client and server
 #	option compress lz4
-	
+	# LZO is compatible with most OpenVPN versions
+	# (set "compress lzo" on 2.4+ clients, and "comp-lzo yes" on older clients)
+#	option compress lzo
 	# Control how OpenVPN handles peers using compression
 	#
 	# Do not allow any connections using compression
@@ -492,6 +494,8 @@ config openvpn sample_client
 	#
 	# LZ4 requires OpenVPN 2.4+ on server and client
 #	option compress lz4
+	# LZO is compatible with most OpenVPN versions
+#	option compress lzo
 
 	# Set log file verbosity.
 	option verb 3


### PR DESCRIPTION
Maintainer: @mkrkn 

Description:

This reverts commit e4376793b4e093089543cb1bad64eef34ed25eca.

Many OpenVPN users are not in the position to disable LZO support on the
server side. Official OpenVPN packages should still support it to
retain broad compatibility with existing deployments.

Just because upstream does not recommend using compression, we should
not remove the ability to negotiate compressed connections, otherwise
we break existing deployments.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>
