### PR TITLE
openvpn: enable LZO support by default for OpenSSL variant

### DIFF
--- a/net/openvpn/Config-openssl.in
+++ b/net/openvpn/Config-openssl.in
@@ -2,7 +2,7 @@ if PACKAGE_openvpn-openssl
 
 config OPENVPN_openssl_ENABLE_LZO
 	bool "Enable LZO compression support"
-	default n
+	default y
 
 config OPENVPN_openssl_ENABLE_LZ4
 	bool "Enable LZ4 compression support"

--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.5.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/openvpn.config
+++ b/net/openvpn/files/openvpn.config
@@ -300,6 +300,9 @@ config openvpn sample_server
 	#
 	# LZ4 requires OpenVPN 2.4+ client and server
 #	option compress lz4
+	# LZO is available by default only in openvpn-openssl variant
+	# LZO is compatible with most OpenVPN versions
+#	option compress lzo
 	
 	# Control how OpenVPN handles peers using compression
 	#
@@ -492,6 +495,9 @@ config openvpn sample_client
 	#
 	# LZ4 requires OpenVPN 2.4+ on server and client
 #	option compress lz4
+	# LZO is available by default only in openvpn-openssl variant
+	# LZO is compatible with most OpenVPN versions
+#	option compress lzo
 
 	# Set log file verbosity.
 	option verb 3


### PR DESCRIPTION
Maintainer: @mkrkn or none
Compile tested: no
Run tested: no
Description:
User that don't control both OpenVPN client and server
might still need LZO support, so keep it enable by default for at least
OpenSSL variant.