### PR TITLE
nginx: add PROVIDES nginx-ssl to nginx-all-module 

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.17.7
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
@@ -116,7 +116,7 @@ define Package/nginx-all-module
   DEPENDS:=+libpcre +libopenssl +zlib +liblua +libpthread +libxml2 \
    +libubus +libblobmsg-json +libjson-c
   VARIANT:=all-module
-  PROVIDES:=nginx
+  PROVIDES:=nginx nginx-ssl
 endef
 
 Package/nginx-all-module/description = $(Package/nginx/description) \


### PR DESCRIPTION
Maintainer: @Ansuel and @heil
Compile tested: not done (the PROVIDES variable should not influence compilation)
Run tested: not done (I know only a laborious way for testing it and would do it on request; it is a small change and should be OK)

Description: fix issue #15859 when installing luci-ssl-nginx after nginx-all-module, which has SSL support but lacks nginx-ssl in its PROVIDES variable.
