### PR TITLE
php8: update to 8.0.8

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.0.7
+PKG_VERSION:=8.0.8
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=d5fc2e4fc780a32404d88c360e3e0009bc725d936459668e9c2ac992f2d83654
+PKG_HASH:=dc1668d324232dec1d05175ec752dade92d29bb3004275118bc3f7fc7cbfbb1c
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0

--- a/lang/php8/patches/0025-php-5.4.9-fixheader.patch
+++ b/lang/php8/patches/0025-php-5.4.9-fixheader.patch
@@ -9,7 +9,7 @@ Make generated php_config.h constant across rebuilds.
 
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1278,7 +1278,7 @@ PHP_REMOVE_USR_LIB(LDFLAGS)
+@@ -1289,7 +1289,7 @@ PHP_REMOVE_USR_LIB(LDFLAGS)
  EXTRA_LDFLAGS="$EXTRA_LDFLAGS $PHP_LDFLAGS"
  EXTRA_LDFLAGS_PROGRAM="$EXTRA_LDFLAGS_PROGRAM $PHP_LDFLAGS"
  

--- a/lang/php8/patches/0041-Add-patch-to-remove-build-timestamps-from-generated-.patch
+++ b/lang/php8/patches/0041-Add-patch-to-remove-build-timestamps-from-generated-.patch
@@ -6,7 +6,7 @@ Subject: Add patch to remove build timestamps from generated binaries.
 
 --- a/ext/standard/info.c
 +++ b/ext/standard/info.c
-@@ -791,7 +791,6 @@ PHPAPI ZEND_COLD void php_print_info(int
+@@ -792,7 +792,6 @@ PHPAPI ZEND_COLD void php_print_info(int
  		php_info_print_box_end();
  		php_info_print_table_start();
  		php_info_print_table_row(2, "System", ZSTR_VAL(php_uname));

--- a/lang/php8/patches/1004-disable-phar-command.patch
+++ b/lang/php8/patches/1004-disable-phar-command.patch
@@ -11,7 +11,7 @@
  
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1423,13 +1423,13 @@ CFLAGS_CLEAN="$CFLAGS \$(PROF_FLAGS)"
+@@ -1434,13 +1434,13 @@ CFLAGS_CLEAN="$CFLAGS \$(PROF_FLAGS)"
  CFLAGS="\$(CFLAGS_CLEAN) $standard_libtool_flag"
  CXXFLAGS="$CXXFLAGS $standard_libtool_flag \$(PROF_FLAGS)"
  


### PR DESCRIPTION
This fixes:
  - CVE-2021-21704
  - CVE-2021-21705

Signed-off-by: Michael Heimpold <mhei@heimpold.de>

Maintainer: me
Compile tested: mxs
Run tested: mxs