### PR TITLE
php7: update to 7.4.21

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=7.4.20
+PKG_VERSION:=7.4.21
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=1fa46ca6790d780bf2cb48961df65f0ca3640c4533f0bca743cd61b71cb66335
+PKG_HASH:=cf43384a7806241bc2ff22022619baa4abb9710f12ec1656d0173de992e32a90
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0

--- a/lang/php7/patches/0041-Add-patch-to-remove-build-timestamps-from-generated-.patch
+++ b/lang/php7/patches/0041-Add-patch-to-remove-build-timestamps-from-generated-.patch
@@ -13,7 +13,7 @@ Subject: Add patch to remove build timestamps from generated binaries.
 
 --- a/ext/standard/info.c
 +++ b/ext/standard/info.c
-@@ -802,7 +802,6 @@ PHPAPI ZEND_COLD void php_print_info(int
+@@ -803,7 +803,6 @@ PHPAPI ZEND_COLD void php_print_info(int
  		php_info_print_box_end();
  		php_info_print_table_start();
  		php_info_print_table_row(2, "System", ZSTR_VAL(php_uname));


### PR DESCRIPTION
This fixes:
    - CVE-2021-21704
    - CVE-2021-21705

Signed-off-by: Michael Heimpold <mhei@heimpold.de>

Maintainer: me
Compile tested: mxs
Run tested: mxs