### PR TITLE
django: bump to version 3.2.5

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=3.2.4
+PKG_VERSION:=3.2.5
 PKG_RELEASE:=1
 
 PYPI_NAME:=Django
-PKG_HASH:=66c9d8db8cc6fe938a28b7887c1596e42d522e27618562517cc8929eb7e7f296
+PKG_HASH:=3da05fea54fdec2315b54a563d5b59f3b4e2b1e69c3a5841dda35019c01855cd
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Peter Stadler <peter.stadler@student.uibk.ac.at>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me, @peter-stadler 
Compile tested:x86 https://github.com/openwrt/openwrt/commit/6c148116f778bfd2db88476cee4753b32538eafe
Run tested: x86 https://github.com/openwrt/openwrt/commit/6c148116f778bfd2db88476cee4753b32538eafe

---------------------------------------------------

Several bug-fixes.
Fix CVE-2021-35042

Release notes:
  https://docs.djangoproject.com/en/3.2/releases/3.2.5/

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>