### PR TITLE
postgresql: prevent addition of ARM target flag

### DIFF
--- a/libs/postgresql/patches/700-no-arm-crc-march-change.patch
+++ b/libs/postgresql/patches/700-no-arm-crc-march-change.patch
@@ -1,0 +1,15 @@
+--- a/configure.in
++++ b/configure.in
+@@ -2019,9 +2019,9 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [
+ # flags. If not, check if adding -march=armv8-a+crc flag helps.
+ # CFLAGS_ARMV8_CRC32C is set if the extra flag is required.
+ PGAC_ARMV8_CRC32C_INTRINSICS([])
+-if test x"$pgac_armv8_crc32c_intrinsics" != x"yes"; then
+-  PGAC_ARMV8_CRC32C_INTRINSICS([-march=armv8-a+crc])
+-fi
++#if test x"$pgac_armv8_crc32c_intrinsics" != x"yes"; then
++#  PGAC_ARMV8_CRC32C_INTRINSICS([-march=armv8-a+crc])
++#fi
+ AC_SUBST(CFLAGS_ARMV8_CRC32C)
+ 
+ # Select CRC-32C implementation.


### PR DESCRIPTION
configure.in checks for "ARMv8 CRC32C intrinsics" and goes as far as
adding "-march=armv8-a+crc" to the target flags if the compiler allows
it. This can clash with the OpenWrt target flags in
CONFIG_TARGET_OPTIMIZATION. If for example the latter is set to
"-mcpu=cortex-a9" the following warning is issued:

  cc1: warning: switch '-mcpu=cortex-a9' conflicts with '-march=armv5t' switch

This commit prevents configure.in from adding the mentioned flag. The
addition is unwanted when cross-compiling.

An issue was raised for this recently, see [1].

[1] https://github.com/openwrt/packages/issues/16034

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @dangowrt 
Compile tested: mvebu cortexa9 for wrt3200acm 
Run tested: N/A
Description: Please see above

Closes #16034