### PR TITLE
syncthing: update to v1.18.0

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.17.0
+PKG_VERSION:=1.18.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=625412991717e0d442e24beac88e4b7a16545fbc8c0afffeebbe95dbeae3be33
+PKG_HASH:=169d3579b74083d4115b4d324620a7f0888e4b1a3ad3dac71d46d76d51322900
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 


### PR DESCRIPTION
See upstream release notes for changes:
https://github.com/syncthing/syncthing/releases/tag/v1.18.0

Signed-off-by: Paul Spooren <mail@aparcar.org>