### PR TITLE
libupm: Workaround for errors with GCC11

### DIFF
--- a/libs/libupm/Makefile
+++ b/libs/libupm/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libupm
 PKG_VERSION:=2.0.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/intel-iot-devkit/upm/tar.gz/v$(PKG_VERSION)?
@@ -54,6 +54,7 @@ UPM_MODULES:= \
 
 CMAKE_OPTIONS += \
 	-DBUILDSWIGNODE=OFF \
+	-DWERROR=OFF \
 	-DPYTHON2LIBS_FOUND=FALSE \
 	-DPYTHON2INTERP_FOUND=FALSE \
 


### PR DESCRIPTION
Maintainer: @blogic, me 
Compile tested: head (with gcc11 commit), arm 
Run tested: (qemu-5.2.0) arm

Description: 
Workaround for errors with GCC11
https://github.com/openwrt/packages/issues/16060

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
