### PR TITLE
dnsdist: fix compilation with GCC11

### DIFF
--- a/net/dnsdist/patches/020-gcc11.patch
+++ b/net/dnsdist/patches/020-gcc11.patch
@@ -1,0 +1,10 @@
+--- a/lock.hh
++++ b/lock.hh
+@@ -20,6 +20,7 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+  */
+ #pragma once
++#include <mutex>
+ #include <shared_mutex>
+ 
+ class ReadWriteLock


### PR DESCRIPTION
Missing header.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Habbie 
Compile tested: ath79