### PR TITLE
kea: fix compilation with GCC11

### DIFF
--- a/net/kea/patches/030-gcc11.patch
+++ b/net/kea/patches/030-gcc11.patch
@@ -1,0 +1,21 @@
+--- a/src/lib/database/backend_selector.cc
++++ b/src/lib/database/backend_selector.cc
+@@ -6,7 +6,7 @@
+ 
+ #include <database/backend_selector.h>
+ #include <exceptions/exceptions.h>
+-#include <climits>
++#include <limits>
+ #include <sstream>
+ 
+ using namespace isc::data;
+--- a/src/lib/dhcpsrv/subnet_id.h
++++ b/src/lib/dhcpsrv/subnet_id.h
+@@ -10,6 +10,7 @@
+ #include <exceptions/exceptions.h>
+ #include <stdint.h>
+ #include <typeinfo>
++#include <limits>
+ 
+ namespace isc {
+ namespace dhcp {


### PR DESCRIPTION
Missing header.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @rosysong @hbl0307106015
Compile tested: ath79