### PR TITLE
emailrelay: fix compilation with GCC11

### DIFF
--- a/mail/emailrelay/patches/010-gcc11.patch
+++ b/mail/emailrelay/patches/010-gcc11.patch
@@ -1,0 +1,20 @@
+--- a/src/gnet/gsocket.h
++++ b/src/gnet/gsocket.h
+@@ -27,6 +27,7 @@
+ #include "gevent.h"
+ #include "gdescriptor.h"
+ #include "greadwrite.h"
++#include <memory>
+ #include <string>
+ #include <new>
+ 
+--- a/src/gssl/gssl.h
++++ b/src/gssl/gssl.h
+@@ -26,6 +26,7 @@
+ #include "gdef.h"
+ #include "gstrings.h"
+ #include "greadwrite.h"
++#include <memory>
+ #include <string>
+ #include <utility>
+ 


### PR DESCRIPTION
Missing header.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @fededim 
Compile tested: ath79