### PR TITLE
squid: update to 4.16

### DIFF
--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -8,14 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squid
-PKG_VERSION:=4.14
+PKG_VERSION:=4.16
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://www3.us.squid-cache.org/Versions/v4/ \
-	http://www2.pl.squid-cache.org/Versions/v4/ \
+PKG_SOURCE_URL:=http://www2.pl.squid-cache.org/Versions/v4/ \
 	http://www.squid-cache.org/Versions/v4/
-PKG_HASH:=f1097daa6434897c159bc100978b51347c0339041610845d0afa128151729ffc
+PKG_HASH:=7e00e891757c1c02dae546c9898f440c6031b684d8c243d6edab529076e3ba63
 
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Fixes compilation with GCC11.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ratkaj 
Compile tested: ath79