### PR TITLE
hashdeep: fix compilation with GCC11

### DIFF
--- a/utils/hashdeep/Makefile
+++ b/utils/hashdeep/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hashdeep
 PKG_VERSION:=4.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jessek/hashdeep/tar.gz/v$(PKG_VERSION)?

--- a/utils/hashdeep/patches/010-gcc11.patch
+++ b/utils/hashdeep/patches/010-gcc11.patch
@@ -1,0 +1,27 @@
+From 6ef69a26126ee4e69a25392fd456b8a66c51dffd Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 15 Nov 2016 02:46:55 +0000
+Subject: [PATCH] Fix errors found by clang
+
+Fixes errors like
+
+../../git/src/hash.cpp:282:19: error: ordered comparison between pointer and zero ('const unsigned char *' and 'int')
+            if(fdht->base>0){
+               ~~~~~~~~~~^~
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/hash.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/hash.cpp
++++ b/src/hash.cpp
+@@ -279,7 +279,7 @@ void file_data_hasher_t::hash()
+ 		MAP_FILE|
+ #endif
+ 		MAP_SHARED,fd,0);
+-	    if(fdht->base>0){		
++	    if(fdht->base != (void *) -1){
+ 		/* mmap is successful, so set the bounds.
+ 		 * if it is not successful, we default to reading the fd
+ 		 */


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @trldp
Compile tested: ath79