### PR TITLE
lxc: add patch to switch GPG server

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=2.1.1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_LICENSE:=LGPL-2.1-or-later BSD-2-Clause GPL-2.0
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>

--- a/utils/lxc/patches/031-lxc-download-Switch-GPG-server.patch
+++ b/utils/lxc/patches/031-lxc-download-Switch-GPG-server.patch
@@ -1,0 +1,47 @@
+From a08242fc033b39be7e782ad6455973ec07f62b61 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?St=C3=A9phane=20Graber?= <stgraber@ubuntu.com>
+Date: Sun, 27 Jun 2021 23:42:52 -0400
+Subject: [PATCH] lxc-download: Switch GPG server
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+A few days ago, sks-keyservers.net pool announced that their service is
+deprecated and no longer maintained.
+
+References:
+Reddit.com [1]
+sks-keyservers.net [2] with invalid SSL certificate
+
+[1] https://www.reddit.com/r/crypto/comments/o7oh4w/skskeyserversnet_pool_dns_records_disabled/
+[2] https://sks-keyservers.net/
+
+Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>
+(cherry picked from commit f2a5d95d00a55bed27ef9920d67617cc75fecad8)
+Signed-off-by: Josef Schlehofer <pepe.schlehofer@gmail.com>
+[added commit message]
+---
+ templates/lxc-download.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/templates/lxc-download.in b/templates/lxc-download.in
+index 490552138..d6761e0cd 100644
+--- a/templates/lxc-download.in
++++ b/templates/lxc-download.in
+@@ -54,11 +54,11 @@ LXC_PATH=
+ LXC_ROOTFS=
+ 
+ if [ -z "${DOWNLOAD_KEYSERVER:-}" ]; then
+-	DOWNLOAD_KEYSERVER="hkp://pool.sks-keyservers.net"
++	DOWNLOAD_KEYSERVER="hkp://keyserver.ubuntu.com"
+ 
+ 	# Deal with GPG over http proxy
+ 	if [ -n "${http_proxy:-}" ]; then
+-	    DOWNLOAD_KEYSERVER="hkp://p80.pool.sks-keyservers.net:80"
++	    DOWNLOAD_KEYSERVER="hkp://keyserver.ubuntu.com:80"
+ 	fi
+ fi
+ 
+-- 
+2.30.2
+


### PR DESCRIPTION
Maintainer: @ratkaj
Compile tested: openwrt-sdk-19.07.7-mvebu-cortexa9_gcc-7.5.0_musl_eabi.Linux-x86_64
Run tested: OpenWrt 19.07.7 on Turris 1.1, powerpc8540 router with [this patch](https://gitlab.nic.cz/turris/os/build/-/commit/0bf44b2f1c273d5bf36e6a04d3c746cb837317be) verified that downloading LXC containers works.

Description:
- By default, there was used sks-keyservers.net pool, which has invalid
SSL certificate and they also announced that their service is deprecate
and no longer maintained.

Use the same GPG server as LXC is using by default in the newer
releases.

- Fixes issue described here:
https://forum.turris.cz/t/lxc-create-error-unable-to-fetch-gpg-key-from-keyserver/15636/2



