### PR TITLE
lxc: add patch to switch GPG server

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=4.0.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/

--- a/utils/lxc/patches/040-gpg.patch
+++ b/utils/lxc/patches/040-gpg.patch
@@ -1,0 +1,29 @@
+From 3efa0cf3455cbe330b4e79a647a57ad8e9cf3476 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?St=C3=A9phane=20Graber?= <stgraber@ubuntu.com>
+Date: Sun, 27 Jun 2021 23:42:52 -0400
+Subject: [PATCH] lxc-download: Switch GPG server
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>
+---
+ templates/lxc-download.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/templates/lxc-download.in
++++ b/templates/lxc-download.in
+@@ -55,11 +55,11 @@ LXC_PATH=
+ LXC_ROOTFS=
+ 
+ if [ -z "${DOWNLOAD_KEYSERVER:-}" ]; then
+-  DOWNLOAD_KEYSERVER="hkp://pool.sks-keyservers.net"
++  DOWNLOAD_KEYSERVER="hkp://keyserver.ubuntu.com"
+ 
+   # Deal with GPG over http proxy
+   if [ -n "${http_proxy:-}" ]; then
+-    DOWNLOAD_KEYSERVER="hkp://p80.pool.sks-keyservers.net:80"
++    DOWNLOAD_KEYSERVER="hkp://keyserver.ubuntu.com:80"
+     DOWNLOAD_GPG_PROXY="--keyserver-options http-proxy=\"${http_proxy}\""
+   fi
+ fi


### PR DESCRIPTION
Maintainer: @ratkaj
Compile tested: N/A; done for 21.02 in https://github.com/openwrt/packages/pull/16088
Run tested: OpenWrt 19.07.7 on Turris 1.1, powerpc8540 router with [this patch](https://gitlab.nic.cz/turris/os/build/-/commit/0bf44b2f1c273d5bf36e6a04d3c746cb837317be) verified that downloading LXC containers works.

Description:
- By default, there was used sks-keyservers.net pool, which has invalid
SSL certificate and they also announced that their service is deprecate
and no longer maintained.

Use the same GPG server as LXC is using by default in the newer
releases.

- Fixes issue described here:
https://forum.turris.cz/t/lxc-create-error-unable-to-fetch-gpg-key-from-keyserver/15636/2

__

The patch is present in stable-4.0 branch in LXC repository already, so it can be removed in the future bumps.
