### PR TITLE
[21.02] libtirpc: update to 1.3.2

### DIFF
--- a/libs/libtirpc/Makefile
+++ b/libs/libtirpc/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtirpc
-PKG_VERSION:=1.3.1
-PKG_RELEASE:=1
+PKG_VERSION:=1.3.2
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_URL:=@SF/libtirpc
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_HASH:=245895caf066bec5e3d4375942c8cb4366adad184c29c618d97f724ea309ee17
+PKG_HASH:=e24eb88b8ce7db3b7ca6eb80115dd1284abc5ec32a8deccfed2224fc2532b9fd
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: arm
Run tested:

Description:
* update to 1.3.2