### PR TITLE
bind: update to version 9.16.18

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.16.15
+PKG_VERSION:=9.16.18
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=98b6f432d878a7bf8f57eb7b3c28be27278cf6b9989154bfe6c81104b38e7839
+PKG_HASH:=3c6263a4364eb5dce233f9f22b90acfa1ec2488d534f91d21663d0ac25ce5e65
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile tested: Turris 1.1, powerpc_8540, OpenWrt 19.07.7
Run tested: Turris 1.1, powerpc_8540, OpenWrt 19.07.7

Description:

- update to version [9.16.18](https://downloads.isc.org/isc/bind9/9.16.18/doc/arm/html/notes.html#notes-for-bind-9-16-18
)