### PR TITLE
whois: remove nls.mk

### DIFF
--- a/utils/whois/Makefile
+++ b/utils/whois/Makefile
@@ -19,7 +19,6 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/nls.mk
 
 define Package/whois
   SECTION:=utils


### PR DESCRIPTION
whois as implemented in the OpenWrt package does not use gettext. Fixes
compilation issue with glibc.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @aparcar 
Compile tested: ath79