### PR TITLE
qt5base: add package

### DIFF
--- a/libs/qt5base/Config.in
+++ b/libs/qt5base/Config.in
@@ -1,0 +1,37 @@
+choice
+	prompt "Build Variant"
+	default QT_BUILD_RELEASE
+	help
+		Choose which Qt variant should be built:
+		-> Release: Build Qt with debugging turned off.
+		-> Debug: Build Qt with debugging turned on.
+
+	config QT_BUILD_RELEASE
+		bool "Release"
+
+	config QT_BUILD_DEBUG
+		bool "Debug"
+endchoice
+
+config QT_OPTIMIZE_SIZE
+	depends on QT_BUILD_RELEASE
+	bool "Optimize Size"
+	default n
+	help
+		Optimize release builds for size instead of speed.
+		(Not available in debug variant)
+
+config QT_OPTIMIZE_DEBUG
+	depends on QT_BUILD_DEBUG
+	bool "Optimize Debug"
+	default n
+	help
+		Enable debug-friendly optimizations in debug builds.
+		(Not available in release variant)
+
+config QT_OPTIMIZE_TOOLS
+	depends on QT_BUILD_DEBUG
+	bool "Optimized Tools"
+	default n
+	help
+		Build optimized host tools even in debug build.

--- a/libs/qt5base/Makefile
+++ b/libs/qt5base/Makefile
@@ -1,0 +1,364 @@
+#
+# ported from
+#
+#
+# https://github.com/KryptonLee/qBittorrent-openwrt-package/blob/master/qt5/Makefile
+#
+# Copyright (C) 2020 Krypton Lee <jun.k.lee199410@outlook.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+#
+# https://github.com/pawelkn/qt5-openwrt-package/blob/master/Makefile
+#
+# Copyright (C) 2013 Riccardo Ferrazzo <f.riccardo87@gmail.com>
+# Copyright (C) 2017 Paweł Knioła <pawel.kn@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+#
+# https://github.com/Entware/rtndev/blob/master/qt5/Makefile
+#
+# Copyright (C) 2017-2021 Entware
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+#
+# https://github.com/coolsnowwolf/lede/blob/master/package/lean/qtbase/Makefile
+#
+# Copyright (C) 2020 Openwrt.org
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+#
+# https://github.com/openwrt/video/blob/master/frameworks/qt5base/Makefile
+#
+# Copyright (C) 2020 OpenWrt.org
+# Author: Mirko Vogt <mirko-openwrt@nanl.de>
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+PKG_NAME:=qt5base
+QT_NAME:=qtbase
+PKG_HASH:=909fad2591ee367993a75d7e2ea50ad4db332f05e1c38dd7a5a274e156a4e0f8
+
+include qtlib.mk
+
+PKG_MAINTAINER:=David Yang <mmyangfl@gmail.com>
+PKG_CPE_ID:=cpe:/a:qt:qt
+
+# Yes, the host build depends on the target build. This is not a mistake!
+# The target build provides the (target specific) qmake.mk file which
+# is also used for host builds.
+# Host projects depend on qt5base/host which however don't build
+# if qt5base didn't install the qmake.mk file before.
+# Benefit of the target build providing qmake.mk instead of the host build
+# is that the host build really only needs to be built, if there're targets
+# which actually depend on it. At the time of this writing, only qt5tools
+# makes use of the host build.
+HOST_BUILD_DEPENDS:=qt5base
+
+define Package/qt5base
+	$(call Package/qt5/Default)
+	TITLE:=Qt Base Module
+endef
+
+define Package/qt5base/description
+$(call Package/qt5/Default/description)
+
+The Qt Base module offers classes for embedded Linux devices. The Base
+module is based on Qt and builds the foundation for all other modules of
+Qt Extended. This means that all other modules rely on this module.
+endef
+
+define Package/qt5base/config
+	source "$(SOURCE)/Config.in"
+
+	menu "Select Qtbase Modules"
+		depends on PACKAGE_qt5base
+
+		$(foreach lib,$(QT5BASE_LIBS),
+			config PACKAGE_qt5base-$(lib)
+				bool "Qt $(lib) Library"
+				default y
+		)
+
+	endmenu
+
+endef
+
+PKG_CONFIG_DEPENDS+= \
+	QT_BUILD_RELEASE QT_BUILD_DEBUG \
+	QT_OPTIMIZE_SIZE QT_OPTIMIZE_DEBUG QT_OPTIMIZE_TOOLS
+
+ifndef CONFIG_USE_GLIBC
+  # Do not use sstrip for QT5. When sstrip is used the QT5 plugin loading does
+  # not work, because of QT''s internal elf parser, see
+  # https://bugreports.qt.io/browse/QTBUG-52567
+  # Use the code from the gcc package to use strip instaed.
+  ifneq ($(CONFIG_USE_SSTRIP),)
+    STRIP:=$(TARGET_CROSS)strip $(call qstrip,$(CONFIG_STRIP_ARGS))
+    RSTRIP:= \
+      export CROSS="$(TARGET_CROSS)" \
+        $(if $(CONFIG_KERNEL_KALLSYMS),NO_RENAME=1) \
+        $(if $(CONFIG_KERNEL_PROFILING),KEEP_SYMBOLS=1); \
+      NM="$(TARGET_CROSS)nm" \
+      STRIP="$(STRIP)" \
+      STRIP_KMOD="$(SCRIPT_DIR)/strip-kmod.sh" \
+      $(SCRIPT_DIR)/rstrip.sh
+  endif
+endif
+
+include $(INCLUDE_DIR)/host-build.mk
+include qmake.mk
+
+BASE_CONFIGURE_ARGSBASE= \
+	--gcc-sysroot=no \
+	--verbose=yes \
+	--opensource \
+	--confirm-license \
+	--release=$(if $(CONFIG_QT_BUILD_RELEASE),yes,no) \
+	$(if $(CONFIG_QT_BUILD_DEBUG),--debug,) \
+	--optimized-tools=$(if $(CONFIG_QT_OPTIMIZE_TOOLS),yes,no) \
+	--optimize-size=$(if $(CONFIG_QT_OPTIMIZE_SIZE),yes,no) \
+	--optimize-debug=$(if $(CONFIG_QT_OPTIMIZE_DEBUG),yes,no) \
+	--strip=no \
+	--shared=yes \
+	--framework=no \
+	--reduce-exports=no \
+	--reduce-relocations=no \
+	--pch=no \
+	--ltcg=no \
+	--use-gold-linker=no \
+	--warnings-are-errors=no \
+	--pkg-config=yes \
+
+# ICU is preferred over iconv by, moreover, you should have enough space to hold Qt programs.
+CONFIGURE_ARGS=$(BASE_CONFIGURE_ARGSBASE) \
+	--prefix=$(QT_INSTALL_PREFIX) \
+	--extprefix=$(QT_EXTPREFIX) \
+	--hostprefix=$(QT_HOST_PREFIX) \
+	--bindir=$(QT_INSTALL_BINS) \
+	--headerdir=$(QT_INSTALL_HEADERS) \
+	--libdir=$(QT_INSTALL_LIBS) \
+	--archdatadir=$(QT_INSTALL_ARCHDATA) \
+	--plugindir=$(QT_INSTALL_PLUGINS) \
+	--libexecdir=$(QT_INSTALL_LIBEXECS) \
+	--importdir=$(QT_INSTALL_IMPORTS) \
+	--qmldir=$(QT_INSTALL_QML) \
+	--datadir=$(QT_INSTALL_DATA) \
+	--docdir=$(QT_INSTALL_DOCS) \
+	--translationdir=$(QT_INSTALL_TRANSLATIONS) \
+	--sysconfdir=$(QT_INSTALL_CONFIGURATION) \
+	--examplesdir=$(QT_INSTALL_EXAMPLES) \
+	--testsdir=$(QT_INSTALL_TESTS) \
+	--hostbindir=$(QT_HOST_BINS) \
+	--hostlibdir=$(QT_HOST_LIBS) \
+	--hostdatadir=$(QT_HOST_DATA) \
+	--xplatform=linux-openwrt-g++ \
+	--compile-examples=$(if $(CONFIG_PACKAGE_qt5base-examples),yes,no) \
+	$(if $(CONFIG_PACKAGE_qt5base-examples),,--nomake=examples) \
+	--gui=$(if $(CONFIG_PACKAGE_qt5base-gui),yes,no) \
+	--widgets=$(if $(CONFIG_PACKAGE_qt5base-widgets),yes,no) \
+	--dbus=no \
+	--accessibility=yes \
+	--doubleconversion=system \
+	--glib=no \
+	--eventfd=no \
+	--inotify=no \
+	--iconv=no \
+	--icu=yes \
+	--pcre=system \
+	--zlib=system \
+	--journald=no \
+	--syslog=no \
+	--ssl=$(if $(CONFIG_PACKAGE_qt5base-network),yes,no) \
+	--openssl-linked$(if $(CONFIG_PACKAGE_qt5base-network),,=no) \
+	--libproxy=no \
+	--system-proxies=yes \
+	--cups=no \
+	--fontconfig=no \
+	--freetype=no \
+	--harfbuzz=no \
+	--gtk=no \
+	--opengl=no \
+	--opengles3=no \
+	--egl=no \
+	--xcb-xlib=no \
+	--qpa=$(if $(CONFIG_PACKAGE_qt5base-plugin-platforms-linuxfb),linuxfb,no) \
+	--directfb=no \
+	--eglfs=no \
+	--gbm=no \
+	--linuxfb=$(if $(CONFIG_PACKAGE_qt5base-plugin-platforms-linuxfb),yes,no) \
+	--xcb=no \
+	\
+	--libudev=no \
+	--evdev=no \
+	--libinput=$(if $(CONFIG_PACKAGE_qt5base-plugin-input-libinput),yes,no) \
+	--mtdev=no \
+	--tslib=no \
+	--bundled-xcb-xinput=no \
+	--xkbcommon=no \
+	--gif=$(if $(CONFIG_PACKAGE_qt5base-gui),yes,no) \
+	--ico=$(if $(CONFIG_PACKAGE_qt5base-plugin-imageformats-ico),yes,no) \
+	--libjpeg=$(if $(CONFIG_PACKAGE_qt5base-plugin-imageformats-jpeg),system,no) \
+	--libpng=no \
+	--sql-db2=no \
+	--sql-ibase=no \
+	--sql-mysql=no \
+	--sql-oci=no \
+	--sql-odbc=no \
+	--sql-psql=no \
+	--sql-sqlite=no \
+	--sql-sqlite2=no \
+	--sql-tds=no \
+	--sqlite=no \
+
+CONFIGURE_ARGS+= \
+	$(if $(CONFIG_PACKAGE_qt5base-bluetooth),,$(if $(CONFIG_PACKAGE_qt5base-nfc),,--skip connectivity)) \
+	$(if $(CONFIG_PACKAGE_qt5base-bodymovin),,--skip lottie) \
+	$(if $(CONFIG_PACKAGE_qt5base-charts),,--skip charts) \
+	$(if $(CONFIG_PACKAGE_qt5base-gamepad),,--skip gamepad) \
+	$(if $(CONFIG_PACKAGE_qt5base-multimedia),,--skip multimedia) \
+	$(if $(CONFIG_PACKAGE_qt5base-networkauth),,--skip networkauth) \
+	$(if $(CONFIG_PACKAGE_qt5base-positioning),,--skip location) \
+	$(if $(CONFIG_PACKAGE_qt5base-purchasing),,--skip purchasing) \
+	$(if $(CONFIG_PACKAGE_qt5base-qml),,--skip declarative) \
+	$(if $(CONFIG_PACKAGE_qt5base-quicktemplates2),,--skip quickcontrols2 --skip graphicaleffects) \
+	$(if $(CONFIG_PACKAGE_qt5base-remoteobjects),,--skip remoteobjects) \
+	$(if $(CONFIG_PACKAGE_qt5base-script),,--skip script) \
+	$(if $(CONFIG_PACKAGE_qt5base-scxml),,--skip scxml) \
+	$(if $(CONFIG_PACKAGE_qt5base-sensors),,--skip sensors) \
+	$(if $(CONFIG_PACKAGE_qt5base-serialbus),,--skip serialbus) \
+	$(if $(CONFIG_PACKAGE_qt5base-serialport),,--skip serialport) \
+	$(if $(CONFIG_PACKAGE_qt5base-svg),,--skip svg) \
+	$(if $(CONFIG_PACKAGE_qt5base-texttospeech),,--skip speech) \
+	$(if $(CONFIG_PACKAGE_qt5base-virtualkeyboard),,--skip virtualkeyboard) \
+	$(if $(CONFIG_PACKAGE_qt5base-webchannel),,--skip webchannel) \
+	$(if $(CONFIG_PACKAGE_qt5base-websockets),,--skip websockets) \
+	$(if $(CONFIG_PACKAGE_qt5base-webview),,--skip webview) \
+	$(if $(CONFIG_PACKAGE_qt5base-xmloatterns),,--skip xmlpatterns) \
+
+define Build/Configure
+	# CROSS/TARGET_* need to be passed to configure, in order to use cross-compiling tools to check for requirements.
+	# Usually used variables such as CC/CXX/CFLAGS/CXXFLAGS/LDFLAGS would be used for compilation of host tools (qmake, moc, etc.),
+	# hence we use the TARGET_* nomenclature.
+	cd $(PKG_BUILD_DIR) ; \
+		TARGET_CROSS="$(TARGET_CROSS)" \
+		TARGET_CFLAGS="$(TARGET_CFLAGS)" \
+		TARGET_CXXFLAGS="$(TARGET_CFLAGS) $(TARGET_CXXFLAGS)" \
+		TARGET_LDFLAGS="$(TARGET_LDFLAGS)" \
+		PKG_CONFIG_SYSROOT_DIR="$(STAGING_DIR)" \
+		./configure $(CONFIGURE_ARGS)
+endef
+
+HOST_CONFIGURE_ARGS=$(BASE_CONFIGURE_ARGSBASE) \
+	--prefix=$(STAGING_DIR_HOST) \
+	--hostprefix=$(STAGING_DIR_HOST) \
+	--hostdatadir=$(STAGING_DIR_HOST)/share \
+	--datadir=$(STAGING_DIR_HOST)/share \
+	--archdatadir=$(STAGING_DIR_HOST)/lib \
+	--compile-examples=no \
+	--make=libs \
+	--nomake=tools \
+	--nomake=examples \
+	--gui=yes \
+	--widgets=no \
+	--dbus=no \
+	--accessibility=no \
+	--doubleconversion=qt \
+	--glib=no \
+	--eventfd=no \
+	--inotify=no \
+	--iconv=no \
+	--icu=no \
+	--pcre=qt \
+	--zlib=qt \
+	--journald=no \
+	--syslog=no \
+	--ssl=no \
+	--libproxy=no \
+	--system-proxies=no \
+	--cups=no \
+	--fontconfig=no \
+	--freetype=no \
+	--harfbuzz=no \
+	--gtk=no \
+	--opengl=no \
+	--opengles3=no \
+	--egl=no \
+	--xcb-xlib=no \
+	--directfb=no \
+	--eglfs=no \
+	--gbm=no \
+	--linuxfb=no \
+	--xcb=no \
+	\
+	--libudev=no \
+	--evdev=no \
+	--libinput=no \
+	--mtdev=no \
+	--tslib=no \
+	--bundled-xcb-xinput=no \
+	--xkbcommon=yes \
+	--gif=no \
+	--ico=no \
+	--libjpeg=no \
+	--libpng=no \
+	--sql-db2=no \
+	--sql-ibase=no \
+	--sql-mysql=no \
+	--sql-oci=no \
+	--sql-odbc=no \
+	--sql-psql=no \
+	--sql-sqlite=no \
+	--sql-sqlite2=no \
+	--sql-tds=no \
+	--sqlite=no \
+
+define Host/Configure
+	# CROSS/TARGET_* need to be passed to configure, in order to use cross-compiling tools to check for requirements.
+	# Usually used variables such as CC/CXX/CFLAGS/CXXFLAGS/LDFLAGS would be used for compilation of host tools (qmake, moc, etc.),
+	# hence we use the TARGET_* nomenclature.
+	cd $(HOST_BUILD_DIR) ; \
+		TARGET_CFLAGS="$(HOST_CFLAGS)" \
+		TARGET_CXXFLAGS="$(HOST_CFLAGS) $(HOST_CXXFLAGS)" \
+		TARGET_LDFLAGS="$(HOST_LDFLAGS)" \
+		./configure $(HOST_CONFIGURE_ARGS)
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(STAGING_DIR)/host/mk
+	$(CP) ./qmake.mk $(STAGING_DIR)/host/mk/
+
+	$(call Build/Install/Headers,$(1))
+	$(call Build/Install/Libdevs,$(1))
+endef
+
+define Host/Install
+	$(call Host/Install/Default)
+
+	$(INSTALL_DIR) $(STAGING_DIR_HOST)
+	$(CP) $(HOST_INSTALL_DIR)/lib $(STAGING_DIR_HOST)
+	$(CP) $(HOST_INSTALL_DIR)/include $(STAGING_DIR_HOST)
+	$(CP) $(HOST_INSTALL_DIR)/share $(STAGING_DIR_HOST)
+	$(CP) $(HOST_INSTALL_DIR)/bin $(STAGING_DIR_HOST)
+endef
+
+define DefineQt5baseLibrary
+  PKG_CONFIG_DEPENDS+=CONFIG_PACKAGE_qt5base-$(1)
+  QT5BASE_LIBS+=$(1)
+  $(eval $(call DefineQt5Library,$(1),$(2),$(3)))
+endef
+
+$(eval $(call DefineQt5baseLibrary,core,,+libatomic +libpthread +zlib +libzstd +libpcre2-16 +libstdcpp +librt +libdouble-conversion +icu))
+$(eval $(call DefineQt5baseLibrary,network,core,+libopenssl))
+$(eval $(call DefineQt5baseLibrary,xml,core,))
+
+$(foreach lib,$(QT5BASE_LIBS),$(eval $(call BuildPackage,qt5base-$(lib))))
+$(eval $(call BuildPackage,qt5base))
+$(eval $(call HostBuild))

--- a/libs/qt5base/qmake.mk
+++ b/libs/qt5base/qmake.mk
@@ -1,0 +1,171 @@
+#
+# Copyright (C) 2020 OpenWrt.org
+# Author: Mirko Vogt <mirko-openwrt@nanl.de>
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+# qmake - oh my.. qmake is supposed to generate Makefiles suitable for cross-compiling
+# however fails itself hard being used in a cross compiling toolchain in any sane way.
+#
+# There are the QT_INSTALL_* variables - which get set via Qt's configure options,
+# containing paths which become hardcoded into the qmake binary.
+# Those paths are supposed to refer to the target system, however are also used for
+# include and linker paths.
+# Hence, setting QT_INSTALL_PREFIX=/usr would result in -I/usr/include,
+# -L/usr/lib, etc., referencing the host headers and libraries.
+# The QT_SYSROOT variable looks most promising for distinguishing between
+# host and target specific paths, however it fails hard and is totally undocumented.
+# The extprefix variable tries to cover the situation, however actually just prepends
+# its path to the QT_INSTALL_* variables - basically cosmetics.
+#
+# The QT_HOST_* variables are used for host tools, libraries, mkspecs and its data.
+#
+# As a consequence we set QT_INSTALL_* and QT_HOST_* to absolute paths, which
+# inevitably results in the following issues:
+#
+#  - 'make install' results in paths like:
+#    /tmp/install_root/home/cross/openwrt/staging_dir/target-*/usr.
+#    This is workarounded by overriding the PKG_INSTALL_DIR, so the Makefiles don't
+#    have to care about that.
+#  - Once compiled, qmake's location and its requirements (mkspecs, etc.) are fixed,
+#    since its absolute paths were hardcoded. No moving around of the toolchain.
+#  - Those variables might be used for target binaries for some weird reason, so
+#    paths to the host staging_dir would make it to the target, logically leading to
+#    errors.
+#  - Paths might make it into target binaries, thus referencing non-existing
+#    objects on the target platform. Tihs behaviour wasn't observed so far, however
+#    one might use the QT_INSTALL_* variables for some weird reason during runtime.
+
+# for target builds (STAGING_DIR)
+QT_EXTPREFIX:=$(STAGING_DIR)/$(CONFIGURE_PREFIX)
+QT_SYSROOT:=
+QT_INSTALL_CONFIGURATION:=/etc/qt5
+QT_INSTALL_PREFIX:=$(CONFIGURE_PREFIX)
+QT_INSTALL_LIBS:=$(QT_INSTALL_PREFIX)/lib
+QT_INSTALL_DATA:=$(QT_INSTALL_PREFIX)/share/qt5
+QT_INSTALL_HEADERS:=$(QT_INSTALL_PREFIX)/include
+QT_INSTALL_BINS:=$(QT_INSTALL_PREFIX)/bin
+QT_INSTALL_DOCS:=$(QT_INSTALL_DATA)/doc
+QT_INSTALL_TRANSLATIONS:=$(QT_INSTALL_DATA)/translations
+QT_INSTALL_ARCHDATA:=$(QT_INSTALL_LIBS)/qt5
+QT_INSTALL_LIBEXECS:=$(QT_INSTALL_ARCHDATA)
+QT_INSTALL_TESTS:=$(QT_INSTALL_ARCHDATA)/tests
+QT_INSTALL_PLUGINS:=$(QT_INSTALL_ARCHDATA)/plugins
+QT_INSTALL_IMPORTS:=$(QT_INSTALL_ARCHDATA)/imports
+QT_INSTALL_QML:=$(QT_INSTALL_ARCHDATA)/qml
+QT_INSTALL_EXAMPLES:=$(QT_INSTALL_ARCHDATA)/examples
+QT_INSTALL_DEMOS:=$(QT_INSTALL_EXAMPLES)
+# for host builds defined in target project files (STAGING_DIR)/host
+QT_HOST_EXTPREFIX:=$(STAGING_DIR)/host
+QT_HOST_PREFIX:=$(QT_HOST_EXTPREFIX)
+QT_HOST_DATA:=$(QT_HOST_PREFIX)/share
+QT_HOST_BINS:=$(QT_HOST_PREFIX)/bin
+QT_HOST_LIBS:=$(QT_HOST_PREFIX)/lib
+
+QMAKE_SPEC:=linux-g++
+QMAKE_XSPEC:=linux-openwrt-g++
+
+PKG_INSTALL_DIR_ROOT:=$(PKG_INSTALL_DIR)
+PKG_INSTALL_DIR:=$(PKG_INSTALL_DIR_ROOT)/$(STAGING_DIR)
+
+# for target independant host builds (STAGING_DIR_HOST)
+HOST_INSTALL_DIR_ROOT:=$(HOST_INSTALL_DIR)
+HOST_INSTALL_DIR:=$(HOST_INSTALL_DIR_ROOT)/$(STAGING_DIR_HOST)
+#HOST_INSTALL_DIR:=$(HOST_INSTALL_DIR_ROOT)/$(STAGING_DIR)
+
+QMAKE_TARGET=$(STAGING_DIR)/host/bin/qmake
+QMAKE_HOST=$(STAGING_DIR_HOST)/bin/qmake
+
+define Build/Configure/Default
+	TARGET_CROSS="$(TARGET_CROSS)" \
+	TARGET_CFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS)" \
+	TARGET_CXXFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CXXFLAGS)" \
+	TARGET_LDFLAGS="$(TARGET_LDFLAGS)" \
+	$(QMAKE_TARGET) \
+		-o $(PKG_BUILD_DIR)/$(MAKE_PATH)/Makefile \
+		$(PKG_BUILD_DIR)/$(MAKE_PATH)/$(if $(1),$(1).pro,)
+endef
+
+define Host/Configure/Default
+	$(QMAKE_HOST) \
+		-o $(HOST_BUILD_DIR)/$(MAKE_PATH)/Makefile \
+		$(HOST_BUILD_DIR)/$(MAKE_PATH)/$(if $(1),$(1).pro,)
+endef
+
+# We need to pass all qmake (TARGET_*) related variables to $(MAKE) as well, as
+# (generated) Makefiles may invoke qmake once again for creating further Makefiles.
+# Actually we'd also like to pass all other vars (defined in $MAKE_VARS and
+# $MAKE_FLAGS) to also make ordinary non-qmake generated Makefiles calling tool-
+# chain executables like $CC/$CXX/$AR.. work, however this would interfere with
+# qmake generated Makefiles, since they expect variables being set differently.
+# For example qmake generated Makefiles expect $AR to also contain ar's arguments,
+# while ordinary Makefiles don't.
+# Until we find a way to disginguish both kinds of Makefiles, we will neglect
+# ordinary Makefiles calling toolchain executables, however as they might take
+# $CFLAGS/CXXFLAGS into account (e.g. flags as -D*), we pass at least those
+# hoping to not interfere / break something.
+# Mixing qmake generated and ordinary Makfiles - both calling toolchain execut-
+# ables - is probably a very rare case anyway.
+define Build/Compile/Default
+	+TARGET_CROSS="$(TARGET_CROSS)" \
+	TARGET_CFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS)" \
+	TARGET_CXXFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CXXFLAGS)" \
+	TARGET_LDFLAGS="$(TARGET_LDFLAGS)" \
+	CFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS)" \
+	CXXFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CXXFLAGS)" \
+	LDFLAGS="$(TARGET_LDFLAGS)" \
+	$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/$(MAKE_PATH) $(1)
+endef
+
+define Host/Compile/Default
+	$(MAKE) $(PKG_JOBS) -C $(HOST_BUILD_DIR)/$(MAKE_PATH) $(1)
+endef
+
+define Build/Install/Default
+	INSTALL_ROOT="$(PKG_INSTALL_DIR_ROOT)" \
+	$(MAKE) -C $(PKG_BUILD_DIR)/$(MAKE_PATH) $(1) install
+endef
+
+define Host/Install/Default
+	INSTALL_ROOT="$(HOST_INSTALL_DIR_ROOT)" \
+	$(MAKE) -C $(HOST_BUILD_DIR)/$(MAKE_PATH) $(1) install
+endef
+
+define Build/Install/HostFiles
+	$(INSTALL_DIR) $(1)/host
+	$(CP) $(PKG_BUILD_DIR)/host/* $(1)/host/
+endef
+
+define Build/Install/Headers
+	$(INSTALL_DIR) $(1)/$(QT_INSTALL_HEADERS)
+	$(CP) $(PKG_BUILD_DIR)/include/* $(1)/$(QT_INSTALL_HEADERS)/
+endef
+
+define Build/Install/Libs
+	$(INSTALL_DIR) $(1)/$(QT_INSTALL_LIBS)
+	$(FIND) $(PKG_BUILD_DIR)/lib -iname libQt5$(2).so.* -exec $(CP) {} $(1)/$(QT_INSTALL_LIBS)/ \;
+endef
+
+define Build/Install/Libdevs
+	$(INSTALL_DIR) $(1)/$(QT_INSTALL_LIBS)
+	$(CP) $(PKG_BUILD_DIR)/lib/lib*.so* $(1)/$(QT_INSTALL_LIBS)/
+endef
+
+define Build/Install/Translations
+	$(INSTALL_DIR) $(1)/$(QT_INSTALL_TRANSLATIONS)
+	$(CP) $(PKG_BUILD_DIR)/translations/$(2).qm $(1)/$(QT_INSTALL_TRANSLATIONS)/
+endef
+
+define Build/Install/Plugins
+	$(INSTALL_DIR) $(1)/$(QT_INSTALL_PLUGINS)/$(2)
+	$(CP) $(PKG_BUILD_DIR)/plugins/$(2)/lib$(3).so* $(1)/$(QT_INSTALL_PLUGINS)/$(2)/
+endef
+
+define Build/Install/Examples
+	$(INSTALL_DIR) $(1)/$(QT_INSTALL_EXAMPLES)
+	$(CP) $(PKG_BUILD_DIR)/examples/* $(1)/$(QT_INSTALL_EXAMPLES)/
+	$(FIND) $(1)/$(QT_INSTALL_EXAMPLES) \
+		-type f \( -name '*.cpp' -o -name '*.h' -o -name '*.pro' -o -name '*.pri' \) \
+		-exec $(RM) {} \;
+endef

--- a/libs/qt5base/qt.mk
+++ b/libs/qt5base/qt.mk
@@ -1,0 +1,42 @@
+include $(TOPDIR)/rules.mk
+
+#PKG_NAME:=
+PKG_VERSION_API:=5.15
+PKG_VERSION_REV:=2
+PKG_VERSION:=$(PKG_VERSION_API).$(PKG_VERSION_REV)
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SYS_NAME:=$(QT_NAME)-everywhere-src-$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_SYS_NAME).tar.xz
+PKG_SOURCE_URL:=http://download.qt.io/archive/qt/$(PKG_VERSION_API)/$(PKG_VERSION)/submodules
+#PKG_HASH:=
+
+#PKG_MAINTAINER:=
+PKG_LICENSE:=LGPL-2.1
+PKG_LICENSE_FILES:=COPYING
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SYS_NAME)
+HOST_BUILD_DIR=$(BUILD_DIR)/host/$(PKG_SYS_NAME)
+
+HOST_BUILD_PARALLEL:=1
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/qt5/Default
+	SECTION:=libs
+	CATEGORY:=Libraries
+	# TITLE:=
+	SUBMENU:=Qt
+	URL:=http://qt-project.org
+endef
+
+define Package/qt5/Default/description
+Qt is a cross-platform C++ application framework. Qt's primary feature
+is its rich set of widgets that provide standard GUI functionality.
+endef
+
+# define Package/qt5/Default/config
+# 	source "$(SOURCE)/Config.in"
+# endef

--- a/libs/qt5base/qtlib.mk
+++ b/libs/qt5base/qtlib.mk
@@ -1,0 +1,35 @@
+include qt.mk
+
+define DefineQt5Library
+  define Package/qt5base-$(1)
+    $(call Package/qt5/Default)
+    TITLE:=Qt $(1) Library
+    DEPENDS+=$(foreach lib,$(2),+qt5base-$(lib)) $(3)
+    HIDDEN:=1
+  endef
+
+  define Package/qt5base-$(1)/description
+    This package contains the Qt $(1) library.
+  endef
+
+  define Package/qt5base-$(1)/install
+    $(call Build/Install/Libs,$$(1),$(1))
+  endef
+endef
+
+define DefineQt5Plugin
+  define Package/qt5base-plugin-$(1)
+    $(call Package/qt5/Default)
+    TITLE:=Qt $(5) Plugin
+    DEPENDS+=$(foreach lib,$(2),+qt5base-$(lib)) $(3)
+    HIDDEN:=1
+  endef
+
+  define Package/qt5base-plugin-$(1)/description
+    This package contains the Qt $(5) Plugin.
+  endef
+
+  define Package/qt5base-plugin-$(1)/install
+    $(call Build/Install/Plugins,$$(1),$(4))
+  endef
+endef

--- a/libs/qt5base/src/mkspecs/linux-openwrt-g++/qmake.conf
+++ b/libs/qt5base/src/mkspecs/linux-openwrt-g++/qmake.conf
@@ -1,0 +1,34 @@
+#
+# qmake configuration for building with linux-openwrt-g++
+#
+
+MAKEFILE_GENERATOR      = UNIX
+CONFIG                 += incremental
+QMAKE_INCREMENTAL_STYLE = sublib
+
+include(../common/linux.conf)
+include(../common/gcc-base-unix.conf)
+include(../common/g++-unix.conf)
+
+
+# modifications to gcc-base.conf (included by gcc-base-unix.conf)
+QMAKE_CFLAGS           += $$(TARGET_CFLAGS)
+QMAKE_CXXFLAGS         += $$(TARGET_CXXFLAGS)
+QMAKE_LFLAGS           += $$(TARGET_LDFLAGS)
+
+# modifications to g++.conf
+QMAKE_CC                = $$(TARGET_CROSS)gcc
+QMAKE_CXX               = $$(TARGET_CROSS)g++
+
+QMAKE_LINK_C            = $$QMAKE_CC
+QMAKE_LINK_C_SHLIB      = $$QMAKE_CC
+QMAKE_LINK              = $$QMAKE_CXX
+QMAKE_LINK_SHLIB        = $$QMAKE_CXX
+
+# modifications to linux.conf
+QMAKE_AR                = $$(TARGET_CROSS)ar cqs
+QMAKE_OBJCOPY           = $$(TARGET_CROSS)objcopy
+QMAKE_NM                = $$(TARGET_CROSS)nm -P # whole qt5 project doesn't use $QMAKE_NM - wonder why it's defined in linux.conf at all. However better set it to ours than keep it being set to the host's version, just in case...
+QMAKE_STRIP             = # not used, since --strip=no is passed. Let's OpenWrt do the stripping
+
+load(qt_config)

--- a/libs/qt5base/src/mkspecs/linux-openwrt-g++/qplatformdefs.h
+++ b/libs/qt5base/src/mkspecs/linux-openwrt-g++/qplatformdefs.h
@@ -1,0 +1,9 @@
+#include "../linux-g++/qplatformdefs.h"
+
+#undef QT_SOCKLEN_T
+
+#if defined(__GLIBC__) && (__GLIBC__ < 2)
+#define QT_SOCKLEN_T            int
+#else
+#define QT_SOCKLEN_T            socklen_t
+#endif


### PR DESCRIPTION
Maintainer: me / @mirko 
Compile tested: 19.07.7 ramips

Description:

This package is mainly stolen from the same package from video feed, but
without any GUI functionalities, to enable building for other packages
that depend on Qt core library.