### PR TITLE
muninlite: update to new upstream release (2.1.2)

### DIFF
--- a/admin/muninlite/Makefile
+++ b/admin/muninlite/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=muninlite
-PKG_VERSION:=2.1.1
+PKG_VERSION:=2.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/munin-monitoring/$(PKG_NAME)/releases/download/$(PKG_VERSION)/
-PKG_HASH:=427295fe29ac9a7d99d31aa98f3d5dfd382b7e131d0e1193899d54487ca589af
+PKG_HASH:=5a49da30944f3b85a0030b661a27e84c06c7f640050802e799304b11cc635ffc
 
 PKG_MAINTAINER:=Jonathan McCrohan <jmccrohan@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Signed-off-by: Lars Kruse <devel@sumpfralle.de>

Maintainer: @jmccrohan

Description: new upstream relase with trivial fixes
