### PR TITLE
[openwrt-21.02] addrwatch: Various fixes

### DIFF
--- a/net/addrwatch/Makefile
+++ b/net/addrwatch/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=addrwatch
 PKG_VERSION:=1.0.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/fln/addrwatch/releases/download/v$(PKG_VERSION)
@@ -21,34 +21,102 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_DEPENDS:=USE_UCLIBC:argp-standalone USE_MUSL:argp-standalone
+PKG_BUILD_DEPENDS:=USE_MUSL:argp-standalone
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/addrwatch
+define Package/addrwatch/Default
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libpcap +libevent2
   TITLE:=IPv4/IPv6 and ethernet address pairing tool
   URL:=https://github.com/fln/addrwatch
 endef
 
-define Package/addrwatch/description
+define Package/addrwatch/Default/description
   This is a tool similar to arpwatch. It main purpose is to monitor network and
   log discovered ethernet/ip pairings. Addrwatch is extremely useful in networks
   with IPv6 autoconfiguration (RFC4862) enabled. It allows to track IPv6
   addresses of hosts using IPv6 privacy extensions (RFC4941).
 endef
 
+define Package/addrwatch
+$(call Package/addrwatch/Default)
+  DEPENDS:=+libpcap +libevent2
+endef
+
+define Package/addrwatch/description
+$(call Package/addrwatch/Default/description)
+
+  This contains the main addrwatch program.
+endef
+
+define Package/addrwatch-mysql
+$(call Package/addrwatch/Default)
+  TITLE+= (MySQL output module)
+  DEPENDS:=+addrwatch +libmariadb
+endef
+
+define Package/addrwatch-mysql/description
+$(call Package/addrwatch/Default/description)
+
+  This contains the MySQL output module.
+endef
+
+define Package/addrwatch-stdout
+$(call Package/addrwatch/Default)
+  TITLE+= (stdout output module)
+  DEPENDS:=+addrwatch
+endef
+
+define Package/addrwatch-stdout/description
+$(call Package/addrwatch/Default/description)
+
+  This contains the stdout output module.
+endef
+
+define Package/addrwatch-syslog
+$(call Package/addrwatch/Default)
+  TITLE+= (syslog output module)
+  DEPENDS:=+addrwatch
+endef
+
+define Package/addrwatch-syslog/description
+$(call Package/addrwatch/Default/description)
+
+  This contains the syslog output module.
+endef
+
 define Package/addrwatch/conffiles
 /etc/config/addrwatch
 endef
 
+CONFIGURE_ARGS+= \
+	--enable-mysql
+
 define Package/addrwatch/install
-	$(INSTALL_DIR) $(1)/usr/bin $(1)/etc/config $(1)/etc/init.d
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/addrwatch $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/config $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/addrwatch $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/addrwatch.init $(1)/etc/init.d/addrwatch
 	$(INSTALL_CONF) ./files/addrwatch.config $(1)/etc/config/addrwatch
 endef
 
+define Package/addrwatch-mysql/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/addrwatch_mysql $(1)/usr/sbin/
+endef
+
+define Package/addrwatch-stdout/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/addrwatch_stdout $(1)/usr/sbin/
+endef
+
+define Package/addrwatch-syslog/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/addrwatch_syslog $(1)/usr/sbin/
+endef
+
 $(eval $(call BuildPackage,addrwatch))
+$(eval $(call BuildPackage,addrwatch-mysql))
+$(eval $(call BuildPackage,addrwatch-stdout))
+$(eval $(call BuildPackage,addrwatch-syslog))

--- a/net/addrwatch/files/addrwatch.config
+++ b/net/addrwatch/files/addrwatch.config
@@ -1,12 +1,12 @@
 
 config addrwatch
-	option disabled '0'
+	option enabled '0'
 	list interface 'lan'
 	#list interface 'wan'
-	#option syslog '1'
+	#option syslog '0'
 	#option verbose '0'
 	#option output '/var/log/addrwatch'
 	#list blacklist '192.168.1.1'
 	#option hashsize '1'
-	#option ratelimit '-1'
+	#option ratelimit '0'
 

--- a/net/addrwatch/files/addrwatch.init
+++ b/net/addrwatch/files/addrwatch.init
@@ -6,17 +6,16 @@ USE_PROCD=1
 
 validate_section_addrwatch() {
 	uci_load_validate addrwatch addrwatch "$1" "$2" \
-		'disabled:bool:0' \
+		'enabled:bool:0' \
 		'interface:list(string):lan' \
-		'syslog:bool:1' \
+		'syslog:bool:0' \
 		'output:string' \
-		'quiet:bool:0' \
 		'verbose:bool:0' \
 		'ipv4only:bool:0' \
 		'ipv6only:bool:0' \
 		'blacklist:list(or(ip4addr,ip6addr))' \
-		'hashsize:range(1,65536):1024'\
-		'ratelimit:integer:3600'
+		'hashsize:range(1,65536):1'\
+		'ratelimit:integer:0'
 }
 
 start_instance() {
@@ -27,7 +26,7 @@ start_instance() {
 		echo "validation of config $cfg failed"
 		return 1
 	}
-	[ $disabled -ne 0 ] && return 1
+	[ $enabled -eq 1 ] || return 1
 
 	for iface in $interface; do
 		local netdev
@@ -36,15 +35,13 @@ start_instance() {
 	done
 
 	procd_open_instance
-	procd_set_param command /usr/sbin/addrwatch
-	[ "$syslog" -eq 1 ] && procd_append_param command --syslog
-	[ -n "$output" ] && procd_append_param command --output "$output"
-	[ "$quiet" -eq 1 ] && procd_append_param command --quiet
-	[ "$verbose" -eq 1 ] && procd_append_param command --verbose
-	[ "$ipv4only" -eq 1 ] && procd_append_param command --ipv4only
-	[ "$ipv6only" -eq 1 ] && procd_append_param command --ipv6only
-	[ -n "$hashsize" ] && procd_append_param command --hashsize "$hashsize"
-	[ -n "$ratelimit" ] && procd_append_param command --ratelimit "$ratelimit"
+	procd_set_param command /usr/sbin/addrwatch --quiet
+	[ -n "$output" ] && procd_append_param command "--output=$output"
+	[ "$verbose" -eq 1 ] && procd_append_param command "--verbose"
+	[ "$ipv4only" -eq 1 ] && procd_append_param command "--ipv4-only"
+	[ "$ipv6only" -eq 1 ] && procd_append_param command "--ipv6-only"
+	[ -n "$hashsize" ] && procd_append_param command "--hashsize=$hashsize"
+	[ -n "$ratelimit" ] && procd_append_param command "--ratelimit=$ratelimit"
 	for blitem in $blacklist; do
 		procd_append_param command "--blacklist=$blitem"
 	done
@@ -57,6 +54,18 @@ start_instance() {
 	done
 	procd_close_trigger
 	procd_close_instance
+
+	[ "$syslog" -eq 1 ] && {
+		if [ -x /usr/sbin/addrwatch_syslog ]; then
+			procd_open_instance
+			procd_set_param command /usr/sbin/addrwatch_syslog
+			procd_set_param respawn
+			procd_close_instance
+		else
+			echo "Cannot find /usr/sbin/addrwatch_syslog" >&2
+			echo "Install the addrwatch-syslog package to enable syslog output" >&2
+		fi
+	}
 }
 
 start_service() {

--- a/net/addrwatch/patches/003-add-space-for-null-byte.patch
+++ b/net/addrwatch/patches/003-add-space-for-null-byte.patch
@@ -1,0 +1,20 @@
+From 374cfd2cabe4db9882d8a210adff430cc579f859 Mon Sep 17 00:00:00 2001
+From: Julius Kriukas <julius@kriukas.lt>
+Date: Sun, 8 Mar 2020 12:46:55 +0200
+Subject: [PATCH] Use HOST_NAME_MAX+1 to add space for null byte
+
+---
+ src/addrwatch.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/addrwatch.c
++++ b/src/addrwatch.c
+@@ -501,7 +501,7 @@ int main(int argc, char *argv[])
+ 	argp_parse(&argp, argc, argv, 0, &optind, 0);
+ 
+ 	if (!cfg.hostname) {
+-		cfg.hostname_len = HOST_NAME_MAX;
++		cfg.hostname_len = HOST_NAME_MAX + 1;
+ 		cfg.hostname = (char *)calloc(cfg.hostname_len, sizeof(char));
+ 		gethostname(cfg.hostname, cfg.hostname_len);
+ 	}

--- a/net/addrwatch/patches/004-more-specific-library-linking.patch
+++ b/net/addrwatch/patches/004-more-specific-library-linking.patch
@@ -1,0 +1,46 @@
+From 1988f6228225e10bccc50941798f1e1b4ca1ff62 Mon Sep 17 00:00:00 2001
+From: Jeffery To <jeffery.to@gmail.com>
+Date: Fri, 18 Jun 2021 15:46:47 +0800
+Subject: [PATCH] More specific library linking
+
+Currently, the main binary and all output modules are linked to the same
+set of libraries. This changes the linking so that only the main binary
+is linked to pcap, and only addrwatch_mysql is linked to mysqlclient.
+
+This allows the main binary and output modules to be packaged separately
+with fewer dependencies for each individual package.
+---
+ configure.ac    | 4 ++--
+ src/Makefile.am | 3 ++-
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -12,7 +12,7 @@ optional_modules=""
+ AC_SUBST([optional_modules])
+ 
+ # Checks for libraries.
+-AC_CHECK_LIB([pcap], [pcap_open_live])
++AC_CHECK_LIB([pcap], [pcap_open_live], :)
+ AC_CHECK_LIB([rt], [shm_open])
+ 
+ PKG_CHECK_MODULES(LIBEVENT, [libevent >= 1.4], , [
+@@ -46,7 +46,7 @@ AC_ARG_ENABLE([sqlite3],
+ )
+ AC_ARG_ENABLE([mysql],
+     AS_HELP_STRING([--enable-mysql], [Enable MySQL database output]),
+-    AC_CHECK_LIB([mysqlclient], [mysql_real_connect], , [
++    AC_CHECK_LIB([mysqlclient], [mysql_real_connect], :, [
+     	AC_MSG_ERROR([Unable to find libmysqlclient.])
+     ])
+     optional_modules="${optional_modules} addrwatch_mysql"
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -9,5 +9,6 @@ addrwatch_stdout_SOURCES = addrwatch_std
+ addrwatch_syslog_SOURCES = addrwatch_syslog.c shm_client.c shm_client.h
+ addrwatch_mysql_SOURCES = addrwatch_mysql.c shm_client.c shm_client.h util.c util.h
+ 
+-addrwatch_LDADD = @LIBEVENT_LIBS@
++addrwatch_LDADD = @LIBEVENT_LIBS@ -lpcap
++addrwatch_mysql_LDADD = -lmysqlclient
+ 

--- a/net/addrwatch/patches/005-use-c99-format-macro-constants.patch
+++ b/net/addrwatch/patches/005-use-c99-format-macro-constants.patch
@@ -1,0 +1,175 @@
+From 11f224baeede709a181a9ccb01558ff39432a994 Mon Sep 17 00:00:00 2001
+From: Jeffery To <jeffery.to@gmail.com>
+Date: Mon, 5 Jul 2021 04:23:19 +0800
+Subject: [PATCH] Use C99 format macro constants for timestamp and vlan_tag
+
+Since timestamp and vlan_tag in the shm_log_entry struct are C99 fixed
+width integer types (uint64_t and uint16_t), the cross-platform way to
+print these values is to use the corresponding format macro
+constants[1], PRIu64 and PRIu16.
+
+This also adjusts the places where the time_t timestamp value is
+printed, casting it to uint64_t, for consistency.
+
+Fixes https://github.com/fln/addrwatch/issues/25
+Fixes https://github.com/fln/addrwatch/issues/26
+
+[1]: https://en.cppreference.com/w/c/types/integer#Format_macro_constants
+---
+ configure.ac           | 2 +-
+ src/addrwatch.c        | 2 +-
+ src/addrwatch_stdout.c | 2 +-
+ src/addrwatch_syslog.c | 2 +-
+ src/base64.h           | 2 +-
+ src/common.h           | 2 +-
+ src/mcache.h           | 2 +-
+ src/output_flatfile.c  | 4 ++--
+ src/parse.c            | 2 +-
+ src/shm.h              | 2 +-
+ src/shm_client.c       | 2 +-
+ src/storage.c          | 2 +-
+ src/util.h             | 2 +-
+ 13 files changed, 14 insertions(+), 14 deletions(-)
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -53,7 +53,7 @@ AC_ARG_ENABLE([mysql],
+ )
+ 
+ # Checks for header files.
+-AC_CHECK_HEADERS([arpa/inet.h netinet/in.h stdint.h stdlib.h syslog.h unistd.h])
++AC_CHECK_HEADERS([arpa/inet.h netinet/in.h inttypes.h stdlib.h syslog.h unistd.h])
+ 
+ # Checks for typedefs, structures, and compiler characteristics.
+ AC_C_INLINE
+--- a/src/addrwatch.c
++++ b/src/addrwatch.c
+@@ -3,7 +3,7 @@
+ #include <limits.h>
+ #include <pwd.h>
+ #include <signal.h>
+-#include <stdint.h>
++#include <inttypes.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+--- a/src/addrwatch_stdout.c
++++ b/src/addrwatch_stdout.c
+@@ -16,7 +16,7 @@ void process_entry(struct shm_log_entry
+ 		ip4_ntoa(e->ip_address, ip_str);
+ 	}
+ 
+-	printf("%lu %s %u %s %s %s\n", e->timestamp, e->interface, e->vlan_tag,
++	printf("%" PRIu64 " %s %" PRIu16 " %s %s %s\n", e->timestamp, e->interface, e->vlan_tag,
+ 		mac_str, ip_str, pkt_origin_str[e->origin]);
+ }
+ 
+--- a/src/addrwatch_syslog.c
++++ b/src/addrwatch_syslog.c
+@@ -18,7 +18,7 @@ void process_entry(struct shm_log_entry
+ 		ip4_ntoa(e->ip_address, ip_str);
+ 	}
+ 
+-	syslog(LOG_INFO, "%lu %s %u %s %s %s", e->timestamp, e->interface,
++	syslog(LOG_INFO, "%" PRIu64 " %s %" PRIu16 " %s %s %s", e->timestamp, e->interface,
+ 		e->vlan_tag, mac_str, ip_str, pkt_origin_str[e->origin]);
+ }
+ 
+--- a/src/base64.h
++++ b/src/base64.h
+@@ -2,7 +2,7 @@
+ #define BASE64_H
+ 
+ #include "addrwatch.h"
+-#include <stdint.h>
++#include <inttypes.h>
+ 
+ void base64_encode(const uint8_t *src, char *dst, int ssize, int dsize);
+ char *base64_encode_packet(struct pkt *p);
+--- a/src/common.h
++++ b/src/common.h
+@@ -2,7 +2,7 @@
+ #define COMMON_H
+ 
+ #include <arpa/inet.h>
+-#include <stdint.h>
++#include <inttypes.h>
+ #include <stdio.h>
+ #include <sys/socket.h>
+ 
+--- a/src/mcache.h
++++ b/src/mcache.h
+@@ -6,7 +6,7 @@
+ 
+ #include <sys/types.h>
+ #include <netinet/if_ether.h>
+-#include <stdint.h>
++#include <inttypes.h>
+ 
+ struct mcache_node {
+ 	uint8_t l2_addr[ETHER_ADDR_LEN];
+--- a/src/output_flatfile.c
++++ b/src/output_flatfile.c
+@@ -22,8 +22,8 @@ void output_flatfile_reload()
+ void output_flatfile_save(struct pkt *p, char *mac_str, char *ip_str)
+ {
+ 	if (cfg.data_fd) {
+-		fprintf(cfg.data_fd, "%lu %s %u %s %s %s\n",
+-			p->pcap_header->ts.tv_sec, p->ifc->name, p->vlan_tag,
++		fprintf(cfg.data_fd, "%" PRIu64 " %s %" PRIu16 " %s %s %s\n",
++			(uint64_t)p->pcap_header->ts.tv_sec, p->ifc->name, p->vlan_tag,
+ 			mac_str, ip_str, pkt_origin_str[p->origin]);
+ 		fflush(cfg.data_fd);
+ 	}
+--- a/src/parse.c
++++ b/src/parse.c
+@@ -1,4 +1,4 @@
+-//#include <stdint.h>
++//#include <inttypes.h>
+ //#include <stdio.h>
+ //#include <stdlib.h>
+ 
+--- a/src/shm.h
++++ b/src/shm.h
+@@ -4,7 +4,7 @@
+ #include <net/if.h>
+ #include <netinet/in.h>
+ #include <netinet/if_ether.h>
+-#include <stdint.h>
++#include <inttypes.h>
+ #include <sys/socket.h>
+ 
+ #define DEFAULT_SHM_LOG_NAME "/addrwatch-shm-log"
+--- a/src/shm_client.c
++++ b/src/shm_client.c
+@@ -2,7 +2,7 @@
+ 
+ #include <fcntl.h>
+ #include <net/if.h>
+-#include <stdint.h>
++#include <inttypes.h>
+ #include <stdlib.h>
+ #include <sys/mman.h>
+ #include <sys/stat.h>
+--- a/src/storage.c
++++ b/src/storage.c
+@@ -129,7 +129,7 @@ void save_pairing(struct pkt *p)
+ 
+ 	output_shm_save(p, mac_str, ip_str);
+ 	if (!cfg.quiet) {
+-		printf("%lu %s %u %s %s %s\n", tstamp, p->ifc->name,
++		printf("%" PRIu64 " %s %" PRIu16 " %s %s %s\n", (uint64_t)tstamp, p->ifc->name,
+ 			p->vlan_tag, mac_str, ip_str, pkt_origin_str[p->origin]);
+ 		fflush(stdout);
+ 	}
+--- a/src/util.h
++++ b/src/util.h
+@@ -5,7 +5,7 @@
+ #include "config.h"
+ #endif
+ 
+-#include <stdint.h>
++#include <inttypes.h>
+ #include <stdio.h>
+ 
+ #include <syslog.h>


### PR DESCRIPTION
Maintainer: @oskar456 
Compile tested: none (cherry picked from #15899)
Run tested: none

Description:
Makefile changes include:

* Remove `USE_UCLIBC`, as uclibc is no longer supported

* Package output modules

* Move main binary (back) to /usr/sbin, as it is system administration related and requires superuser privileges

New patches:

* 003-add-space-for-null-byte.patch - from https://github.com/fln/addrwatch/commit/374cfd2cabe4db9882d8a210adff430cc579f859

* 004-more-specific-library-linking.patch - from https://github.com/fln/addrwatch/commit/27b57d9da322fc16c6904d8e35aae4557a3e517b

* 005-use-c99-format-macro-constants.patch - from https://github.com/fln/addrwatch/pull/28

Init script changes include:

* Change from explicit disable to explicit enable, so that the service is disabled by default and on first install

* Set config option default values to default values of the main binary

* Fix command-line option names and format (from https://forum.openwrt.org/t/cant-start-addrwatch-service/60499/3)

* Always use the `--quiet` command-line option, as the procd instance is not configured to capture stdout/stderr

* Change the syslog config option to start the syslog output module

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 31ae85bca963ce240c9e1b8df55294587b079161)