### PR TITLE
openvpn: add OpenVPN option push-peer-info

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.5.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/openvpn.options
+++ b/net/openvpn/files/openvpn.options
@@ -177,6 +177,7 @@ persist_remote_ip
 persist_tun
 ping_timer_rem
 pull
+push_peer_info
 push_reset
 remote_random
 rmtun


### PR DESCRIPTION
This will allow the server to know more info about the client like
HWADDR, very useful for managing IoT devices.

See: https://www.mankier.com/8/openvpn#--push-peer-info

Signed-off-by: Nguyen Quang Minh <minhnq31@fpt.com.vn>

Maintainer: Magnus Kroken <mkroken@gmail.com>
Compile tested: EA8300, ARM, master branch
Run tested: EA8300, ARM, master branch, server now receive HWADDR containing the client's gateway MAC address when connected

Description:
This option could be backported to OpenWrt-19.07, which seems to be supported at least way back in 2014.