### PR TITLE
[openwrt-21.02] yq: Update to 4.9.8

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.9.7
+PKG_VERSION:=4.9.8
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=1247e7f0de1f66367b1082c62ecf25e704994a34acc7d2280dac3a30052e2348
+PKG_HASH:=a7b68382ea04da47c1ef0486140f093ee4578525a89f33c3ba457d424e316cc2
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm27xx
Run tested: bcm2710 raspberrypi-3b

Description:
Including a hotfix.