### PR TITLE
dnsproxy: add new package

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# Copyright (C) 2021 ImmortalWrt.org
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dnsproxy
+PKG_VERSION:=0.38.2
+PKG_RELEASE:=$(AUTORELESE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=cc240be1e6975cc782155427f45a3753beb647d0de44f2e9f734486fc19db379
+
+PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/AdguardTeam/dnsproxy
+GO_PKG_LDFLAGS:=-s -w
+GO_PKG_LDFLAGS_X:=main.VersionString=v$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/dnsproxy
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=IP Addresses and Names
+  TITLE:=Simple DNS proxy with DoH, DoT, DoQ and DNSCrypt support
+  URL:=https://github.com/AdguardTeam/dnsproxy
+  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+endef
+
+define Package/dnsproxy/description
+  A simple DNS proxy server that supports all existing DNS protocols including
+  DNS-over-TLS, DNS-over-HTTPS, DNSCrypt, and DNS-over-QUIC.Moreover, it can
+  work as a DNS-over-HTTPS, DNS-over-TLS or DNS-over-QUIC server.
+endef
+
+$(eval $(call GoBinPackage,dnsproxy))
+$(eval $(call BuildPackage,dnsproxy))

--- a/net/dnsproxy/test.sh
+++ b/net/dnsproxy/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+dnsproxy --version | grep "$PKG_VERSION"


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip, x86
Run tested: rockchip nanopi-r2s

Description:
A simple DNS proxy server that supports all existing DNS protocols including DNS-over-TLS, DNS-over-HTTPS, DNSCrypt, and DNS-over-QUIC. Moreover, it can work as a DNS-over-HTTPS, DNS-over-TLS or DNS-over-QUIC server.

For documents, see https://github.com/AdguardTeam/dnsproxy.