### PR TITLE
ruby: update to 3.0.2

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=3.0.1
+PKG_VERSION:=3.0.2
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=d06bccd382d03724b69f674bc46cd6957ba08ed07522694ce44b9e8ffc9c48e2
+PKG_HASH:=570e7773100f625599575f363831166d91d49a1ab97d3ab6495af44774155c40
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING

--- a/lang/ruby/patches/100-musl.patch
+++ b/lang/ruby/patches/100-musl.patch
@@ -3,7 +3,7 @@ which was originally based on this file.
 
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2441,7 +2441,10 @@ AS_CASE([$rb_cv_coroutine], [yes|''], [
+@@ -2471,7 +2471,10 @@ AS_CASE([$rb_cv_coroutine], [yes|''], [
              rb_cv_coroutine=copy
          ],
          [


### PR DESCRIPTION
This release fixes some bugs and these vulnerabilities:

* CVE-2021-31810: Trusting FTP PASV responses vulnerability in Net::FTP
* CVE-2021-32066: A StartTLS stripping vulnerability in Net::IMAP
* CVE-2021-31799: A command injection vulnerability in RDoc

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: me
Compile tested: x64 master
Run tested: x64 master running "gem update"
