### PR TITLE
ddns-scripts: use https for google ipv6 ddns url

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/google.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/google.com.json
@@ -5,7 +5,7 @@
 		"answer": "good|nochg"
 	},
 	"ipv6": {
-		"url": "http://[USERNAME]:[PASSWORD]@domains.google.com/nic/update?hostname=[DOMAIN]&myip=[IP]",
+		"url": "https://[USERNAME]:[PASSWORD]@domains.google.com/nic/update?hostname=[DOMAIN]&myip=[IP]",
 		"answer": "good|nochg"
 	}
 }


### PR DESCRIPTION
Maintainer: unsure; Makefile last touched by `Florian Eckert <fe@dev.tdt.de>`

Compile tested: no, trivial

Run tested: manually tested by copying into a `custom` subdir on 21.02.0-rc3

Description:

This matches an ipv4 change in 21f5cdd2fa and has the same rationale.
Google requires https for both ipv6 and ipv6.