### PR TITLE
ruby: update to 2.6.8

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=2.6.7
+PKG_VERSION:=2.6.8
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=f43ead5626202d5432d2050eeab606e547f0554299cc1e5cf573d45670e59611
+PKG_HASH:=8262e4663169c85787fdc9bfbd04d9eb86eb2a4b56d7f98373a8fcaa18e593eb
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING

--- a/lang/ruby/patches/001_fix_isnan_isinf_finite_with_uclibc.patch
+++ b/lang/ruby/patches/001_fix_isnan_isinf_finite_with_uclibc.patch
@@ -25,7 +25,7 @@ git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/trunk@67036 b2dd03c8-39d4-4d8f-98ff-
  m4_include([tool/m4/ruby_setjmp_type.m4])
 --- a/configure.ac
 +++ b/configure.ac
-@@ -946,9 +946,6 @@ main()
+@@ -958,9 +958,6 @@ main()
  		ac_cv_func_fsync=yes
  		ac_cv_func_seekdir=yes
  		ac_cv_func_telldir=yes
@@ -35,7 +35,7 @@ git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/trunk@67036 b2dd03c8-39d4-4d8f-98ff-
  		ac_cv_func_lchown=yes
  		ac_cv_func_link=yes
  		ac_cv_func_readlink=yes
-@@ -999,9 +996,6 @@ main()
+@@ -1011,9 +1008,6 @@ main()
  [netbsd*], [	LIBS="-lm $LIBS"
  		],
  [dragonfly*], [	LIBS="-lm $LIBS"
@@ -45,7 +45,7 @@ git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/trunk@67036 b2dd03c8-39d4-4d8f-98ff-
  		],
  [aix*],[	LIBS="-lm $LIBS"
  		ac_cv_func_round=no
-@@ -1724,11 +1718,8 @@ AC_REPLACE_FUNCS(dup2)
+@@ -1736,11 +1730,8 @@ AC_REPLACE_FUNCS(dup2)
  AC_REPLACE_FUNCS(erf)
  AC_REPLACE_FUNCS(explicit_bzero)
  AC_REPLACE_FUNCS(ffs)
@@ -57,7 +57,7 @@ git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/trunk@67036 b2dd03c8-39d4-4d8f-98ff-
  AC_REPLACE_FUNCS(lgamma_r)
  AC_REPLACE_FUNCS(memmove)
  AC_REPLACE_FUNCS(nan)
-@@ -1741,6 +1732,10 @@ AC_REPLACE_FUNCS(strlcpy)
+@@ -1753,6 +1744,10 @@ AC_REPLACE_FUNCS(strlcpy)
  AC_REPLACE_FUNCS(strstr)
  AC_REPLACE_FUNCS(tgamma)
  


### PR DESCRIPTION
This release includes security fixes like:

CVE-2021-31810: Trusting FTP PASV responses vulnerability in Net::FTP
CVE-2021-32066: A StartTLS stripping vulnerability in Net::IMAP
CVE-2021-31799: A command injection vulnerability in RDoc

We ordinally do not fix Ruby 2.6 except security fixes, but this release
also includes some regressed bugs and build problem fixes.

Ruby 2.6 is now under the state of the security maintenance phase, until
the end of March of 2022. After that date, maintenance of Ruby 2.6 will
be ended.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: me
Compile tested: arc_generic,armvirt_64,ath79_generic,mediatek_mt7622,mvebu_cortexa9,powerpc,ramips_mt7620,x86_64,x86_generic
Run tested: not done

Description:
