### PR TITLE
tor: bump to 0.4.6.6 stable

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.5.8
+PKG_VERSION:=0.4.6.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=57ded091e8bcdcebb0013fe7ef4a4439827cb169358c7874fd05fa00d813e227
+PKG_HASH:=3423189ba455372021ed44e0be576d181f2908cbd9bdef202d9c11c950882e12
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @hauke, @tripolar

Run tested (tor-basic):
ath79/generic, master
mvebu/cortexa9, master
ramips/mt7621, master