### PR TITLE
yq: Update to 4.11.0

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.9.8
+PKG_VERSION:=4.11.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=a7b68382ea04da47c1ef0486140f093ee4578525a89f33c3ba457d424e316cc2
+PKG_HASH:=0201719fcdce5e98f7620e854825fb3e81d16abf6108df424dcb00de33b26c21
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip, x86_64
Run tested: rk3328 nanopi-r2s

Description:
- Added new RegEx operators
- Supports yaml front matter files
- Other bug fixes

For details, please see release note:
 https://github.com/mikefarah/yq/releases/tag/v4.10.0
 https://github.com/mikefarah/yq/releases/tag/v4.11.0