### PR TITLE
openvswitch: allow complex port configurations

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -17,7 +17,7 @@ include ./openvswitch.mk
 #
 PKG_NAME:=openvswitch
 PKG_VERSION:=$(ovs_version)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openvswitch.org/releases/
 PKG_HASH:=7d5797f2bf2449c6a266149e88f72123540f7fe7f31ad52902057ae8d8f88c38

--- a/net/openvswitch/README.md
+++ b/net/openvswitch/README.md
@@ -63,7 +63,7 @@ E.g. replace in-tree datapath module with upstream version
 
 # UCI configuration options
 
-There are 4 config section types in package openvswitch:
+There are 5 config section types in package openvswitch:
 ovs ovn_northd, ovn_controller & ovs_bridge.
 
 Each of these supports a disabled option, which should be 
@@ -77,3 +77,14 @@ for initialising a virtual bridge with an OpenFlow controller.
 | disabled   | boolean | no       | 0                              | If set to true, disable initialisation of the named bridge |
 | name       | string  | no       | Inherits UCI config block name | The name of the switch in the OVS daemon                   |
 | controller | string  | no       | (none)                         | The endpoint of an OpenFlow controller for this bridge     |
+
+The ovs_port section can be used to add ports to a bridge. It supports the options below.
+
+| Name     | Type    | Required | Default | Description
+| ---------|---------|----------|---------|------------------------------------------------|
+| disabled | boolean | no       | 0       | If set to 1, do not add the port to the bridge |
+| bridge   | string  | yes      | (none)  | Name of the bridge to add the port to          |
+| port     | string  | yes      | (none)  | Name of the port to add to the bridge          |
+| ofport   | integer | no       | (none)  | OpenFlow port number to be used by the port    |
+| tag      | integer | no       | (none)  | 802.1Q VLAN tag to set on the port             |
+| type     | string  | no       | (none)  | Port type, e.g. internal, erspan, type, ...    |

--- a/net/openvswitch/files/openvswitch.config
+++ b/net/openvswitch/files/openvswitch.config
@@ -11,3 +11,11 @@ config ovs_bridge
 	option disabled 1
 	option name 'my-bridge'
 	option controller 'tcp:192.168.0.1'
+
+config ovs_port
+	option disabled 1
+	option bridge 'my-bridge'
+	option port 'ovs-port1'
+	option ofport '1'
+	option tag '123'
+	option type 'internal'

--- a/net/openvswitch/files/openvswitch.init
+++ b/net/openvswitch/files/openvswitch.init
@@ -59,7 +59,12 @@ ovs_action() {
 		config_foreach "ovs_xx" "$cfgtype" "$action" "$cfgtype"
 	done
 
-	config_foreach ovs_bridge_init "ovs_bridge"
+	case "$action" in
+		restart|start)
+			config_foreach ovs_bridge_init "ovs_bridge"
+			;;
+	esac
+
 }
 
 ovs_xx() {

--- a/net/openvswitch/files/openvswitch.init
+++ b/net/openvswitch/files/openvswitch.init
@@ -121,6 +121,47 @@ ovs_bridge_port_add() {
 	__port_list="$__port_list ${port} "
 }
 
+ovs_bridge_port_add_complex() {
+	local cfg="$1"
+	local cur_bridge="$2"
+
+	local bridge disabled ofport port tag type
+	local cur_tag cur_type del_port
+
+	config_get_bool disabled "$cfg" disabled 0
+	[ "$disabled" = "0" ] || return
+
+	config_get bridge "$cfg" bridge
+	[ "$bridge" = "$cur_bridge" ] || return
+	ovs-vsctl br-exists "$bridge" || return
+
+	config_get port "$cfg" port
+	[ -n "$port" ] || return
+
+	config_get ofport "$cfg" ofport
+
+	config_get tag "$cfg" tag
+	if [ -n "$tag" ]; then
+		if cur_tag="$(ovs-vsctl get port "$port" tag 2>/dev/null)"; then
+			[ "$tag" = "$cur_tag" ] || del_port=1
+		fi
+	fi
+
+	config_get type "$cfg" type
+	if [ -n "$type" ]; then
+		if cur_type="$(ovs-vsctl get interface "$port" type 2>/dev/null)"; then
+			[ "$type" = "$cur_type" ] || del_port=1
+		fi
+	fi
+
+	[ "${del_port:-0}" -eq 1 ] && ovs-vsctl --if-exists del-port "$bridge" "$port"
+
+	ovs-vsctl --may-exist add-port "$bridge" "$port" ${tag:+tag="$tag"} \
+		${ofport:+ -- set interface "$port" ofport_request="$ofport"} \
+		${type:+ -- set interface "$port" type="$type"}
+	__port_list="$__port_list ${port} "
+}
+
 ovs_bridge_port_cleanup() {
 	for port in `ovs-vsctl list-ports "$name"`; do
 		case "$__port_list" in
@@ -144,6 +185,7 @@ ovs_bridge_init() {
 	ovs-vsctl --may-exist add-br "$name"
 
 	config_list_foreach "$cfg" "ports" ovs_bridge_port_add
+	config_foreach ovs_bridge_port_add_complex ovs_port "$name"
 	config_get_bool drop "$cfg" "drop_unknown_ports" 0
 	[ "$drop" == 1 ] && ovs_bridge_port_cleanup
 

--- a/net/openvswitch/patches/0002-python-separate-host-target-python-for-cross-compile.patch
+++ b/net/openvswitch/patches/0002-python-separate-host-target-python-for-cross-compile.patch
@@ -22,7 +22,7 @@ Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
  BUILT_SOURCES =
 --- a/m4/openvswitch.m4
 +++ b/m4/openvswitch.m4
-@@ -383,6 +383,8 @@ else:
+@@ -372,6 +372,8 @@ else:
       AC_MSG_ERROR([Python 3.4 or later is required but not found in $PATH, please install it or set $PYTHON3 to point to it])
     fi
     AC_ARG_VAR([PYTHON3])

--- a/net/openvswitch/patches/0004-build-trim-build.patch
+++ b/net/openvswitch/patches/0004-build-trim-build.patch
@@ -10,7 +10,7 @@ Signed-off-by: Yousong Zhou <zhouyousong@yunionyun.com>
 
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -475,12 +475,10 @@ dist-docs:
+@@ -477,12 +477,10 @@ dist-docs:
  	VERSION=$(VERSION) MAKE='$(MAKE)' $(srcdir)/build-aux/dist-docs $(srcdir) $(docs)
  .PHONY: dist-docs
  

--- a/net/openvswitch/patches/0007-build-only-link-libopenvswitch-with-libunwind-libunb.patch
+++ b/net/openvswitch/patches/0007-build-only-link-libopenvswitch-with-libunwind-libunb.patch
@@ -32,7 +32,7 @@ Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
  Cflags: -I${includedir}/openvswitch
 --- a/m4/openvswitch.m4
 +++ b/m4/openvswitch.m4
-@@ -657,7 +657,8 @@ AC_DEFUN([OVS_CHECK_UNBOUND],
+@@ -646,7 +646,8 @@ AC_DEFUN([OVS_CHECK_UNBOUND],
    [AC_CHECK_LIB(unbound, ub_ctx_create, [HAVE_UNBOUND=yes], [HAVE_UNBOUND=no])
     if test "$HAVE_UNBOUND" = yes; then
       AC_DEFINE([HAVE_UNBOUND], [1], [Define to 1 if unbound is detected.])
@@ -42,7 +42,7 @@ Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
     fi
     AM_CONDITIONAL([HAVE_UNBOUND], [test "$HAVE_UNBOUND" = yes])
     AC_SUBST([HAVE_UNBOUND])])
-@@ -669,7 +670,8 @@ AC_DEFUN([OVS_CHECK_UNWIND],
+@@ -658,7 +659,8 @@ AC_DEFUN([OVS_CHECK_UNWIND],
     [HAVE_UNWIND=no])
     if test "$HAVE_UNWIND" = yes; then
       AC_DEFINE([HAVE_UNWIND], [1], [Define to 1 if unwind is detected.])


### PR DESCRIPTION
Maintainer: @yousong /cc @nbd168 @blogic 
Compile tested: NA
Run tested: OpenWrt master r17170-86a61e716e on x86/64

Since the the feature that allows adding ports to bridges was only very recently added, I have not foreseen a mechanism to migrate existing configs. If this is desired, please let me know.

For setting the OpenFlow port number, we should also check if there are no more than 1 port with the same ID in a single bridge. This is slightly different from the feature to drop unknown ports. I still have to come up with a way to do this, so if anyone has any ideas, please do tell.