### PR TITLE
canutils: uipdate to 2021.06.0

### DIFF
--- a/utils/canutils/Makefile
+++ b/utils/canutils/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=canutils
-PKG_VERSION:=2020.12.0
-PKG_RELEASE:=1
+PKG_VERSION:=2021.06.0
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/linux-can/can-utils/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c5c22a00ce2ea7578d7617ac0affef8f47a349be58e708780d703b979f324a2b
+PKG_HASH:=f7874457224c89f8b2eb55ab741935ddb7f1c9bc52de2642330b0799f89d1040
 PKG_BUILD_DIR:=$(BUILD_DIR)/can-utils-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Anton Glukhov <anton.a.glukhov@gmail.com>


### PR DESCRIPTION
Switch to AUTORELEASE for simplicity.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @toxxin 
Compile tested: ath79