### PR TITLE
dnsproxy: Update to 0.39.0 and add init script

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.38.2
+PKG_VERSION:=0.39.0
 PKG_RELEASE:=$(AUTORELESE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=cc240be1e6975cc782155427f45a3753beb647d0de44f2e9f734486fc19db379
+PKG_HASH:=00cf9978670e51be14cab262638735321afa917c3b4f46c0c5a189731ee124bf
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0

--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -34,12 +34,22 @@ define Package/dnsproxy
   TITLE:=Simple DNS proxy with DoH, DoT, DoQ and DNSCrypt support
   URL:=https://github.com/AdguardTeam/dnsproxy
   DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+  USERID:=dnsproxy=411:dnsproxy=411
 endef
 
 define Package/dnsproxy/description
   A simple DNS proxy server that supports all existing DNS protocols including
   DNS-over-TLS, DNS-over-HTTPS, DNSCrypt, and DNS-over-QUIC.Moreover, it can
   work as a DNS-over-HTTPS, DNS-over-TLS or DNS-over-QUIC server.
+endef
+
+define Package/dnsproxy/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_CONF) $(CURDIR)/files/dnsproxy.config $(1)/etc/config/dnsproxy
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) $(CURDIR)/files/dnsproxy.init $(1)/etc/init.d/dnsproxy
 endef
 
 $(eval $(call GoBinPackage,dnsproxy))

--- a/net/dnsproxy/files/dnsproxy.config
+++ b/net/dnsproxy/files/dnsproxy.config
@@ -1,0 +1,41 @@
+
+# For documents, please see https://github.com/AdguardTeam/dnsproxy#usage
+
+config dnsproxy 'global'
+	option enabled '0'
+	option listen_addr '127.0.0.1'
+	option listen_port '5353'
+	option log_file ''
+	option all_servers '0'
+	option fastest_addr '0'
+	option insecure '0'
+	option ipv6_disabled '0'
+	option max_go_routines ''
+	option rate_limit ''
+	option refuse_any '0'
+	option udp_buf_size ''
+	option verbose '0'
+
+config dnsproxy 'bogus_nxdomain'
+	list ip_addr ''
+
+config dnsproxy 'cache'
+	option enabled '0'
+	option cache_optimistic '0'
+	option size '65535'
+	option min_ttl ''
+	option max_ttl ''
+
+config dnsproxy 'dns64'
+	option enabled '0'
+	option dns64_prefix '64:ff9b::'
+
+config dnsproxy 'edns'
+	option enabled '0'
+	option edns_addr ''
+
+config dnsproxy 'servers'
+	list bootstrap 'tls://8.8.8.8'
+	list fallback 'tls://9.9.9.9'
+	list upstream 'tls://1.1.1.1'
+

--- a/net/dnsproxy/files/dnsproxy.init
+++ b/net/dnsproxy/files/dnsproxy.init
@@ -1,0 +1,115 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2021 Tianling Shen <cnsztl@immortalwrt.org>
+
+USE_PROCD=1
+START=90
+
+CONF="dnsproxy"
+PROG="/usr/bin/dnsproxy"
+
+is_enabled() {
+	local enabled
+	config_get enabled "$1" "$2" "0"
+	if [ "$enabled" -eq "1" ]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+is_empty() {
+	local empty
+	config_get empty "$1" "$2" $3
+	if [ -z "$empty" ]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+append_param() {
+	procd_append_param command "$1" $2
+}
+
+append_param_arg() {
+	local value
+	config_get value "$1" "$2" $4
+	[ -n "$value" ] && append_param "$3" "$value"
+}
+
+append_param_bool() {
+	is_enabled "$1" "$2" && append_param "--${2//_/-}"
+}
+
+load_config_arg() {
+	append_param_bool "$1" "all_servers"
+	append_param_bool "$1" "fastest_addr"
+	append_param_bool "$1" "insecure"
+	append_param_bool "$1" "ipv6_disabled"
+	append_param_bool "$1" "refuse_any"
+	append_param_bool "$1" "verbose"
+}
+
+load_config_list() {
+	is_empty "bogus_nxdomain" "ip_addr" || config_list_foreach "bogus_nxdomain" "ip_addr" "append_param '--bogus-nxdomain'"
+
+	for i in "bootstrap" "fallback" "upstream"; do
+		is_empty "servers" "$i" || config_list_foreach "servers" "$i" "append_param '--$i'"
+	done
+}
+
+load_config_param() {
+	append_param_arg "global" "listen_addr" "--listen" "127.0.0.1"
+	append_param_arg "global" "listen_port" "--port" "5353"
+	append_param_arg "global" "log_file" "--output"
+	append_param_arg "global" "max_go_routines" "--max-go-routines"
+	append_param_arg "global" "rate_limit" "--ratelimit"
+	append_param_arg "global" "udp_buf_size" "--udp-buf-size"
+
+	is_enabled "cache" "enabled" && {
+		append_param "--cache"
+		append_param_bool "cache" "cache_optimistic"
+		append_param_arg "cache" "size" "--cache-size"
+		append_param_arg "cache" "min_ttl" "--cache-min-ttl"
+		append_param_arg "cache" "max_ttl" "--cache-max-ttl"
+	}
+
+	is_enabled "dns64" "enabled" && {
+		append_param "--dns64"
+		append_param_arg "dns64" "dns64_prefix" "--dns64-prefix"
+	}
+
+	is_enabled "edns" "enabled" && {
+		append_param "--edns"
+		append_param_arg "edns" "edns_addr" "--edns-addr"
+	}
+}
+
+start_service() {
+	config_load "$CONF"
+
+	is_enabled "global" "enabled" || exit 1
+
+	procd_open_instance "$CONF"
+	procd_set_param command "$PROG"
+
+	load_config_arg "global"
+	load_config_list
+	load_config_param
+
+	procd_set_param respawn
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param user dnsproxy
+
+	procd_close_instance
+}
+
+reload_service() {
+	stop
+	start
+}
+
+service_triggers() {
+	procd_add_reload_trigger "$CONF"
+}


### PR DESCRIPTION
Maintainer: me
Compile tested: ipq807x, rockchip
Run tested: rk3328 nanopi-r2s

Description:
- Updated to latest 0.39.0 release
- Added basic init script