### PR TITLE
librouteros: don't build docs

### DIFF
--- a/libs/librouteros/Makefile
+++ b/libs/librouteros/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=librouteros
 PKG_SOURCE_DATE:=2018-07-19
 PKG_SOURCE_VERSION:=c485c777ffbbbd87c3d72d843af36ba016803cae
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Sven Roederer <devel-sven@geroedel.de>
 PKG_LICENSE:=ISC

--- a/libs/librouteros/patches/010-no-doc.patch
+++ b/libs/librouteros/patches/010-no-doc.patch
@@ -1,0 +1,7 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,3 +1,3 @@
+-SUBDIRS = src doc
++SUBDIRS = src
+ 
+ README:	README.md


### PR DESCRIPTION
Fixes compilation without host pod2man.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @SvenRoederer 
Compile tested: ath79