### PR TITLE
alsa-lib: install also /usr/share/alsa/ctl or alsa-mixer fails with:

### DIFF
--- a/libs/alsa-lib/Makefile
+++ b/libs/alsa-lib/Makefile
@@ -100,10 +100,13 @@ define Package/alsa-lib/install
 		$(PKG_INSTALL_DIR)/usr/lib/libatopology.so.* \
 		$(1)/usr/lib/
 
-	$(INSTALL_DIR) $(1)/usr/share/alsa/{cards,pcm}
+	$(INSTALL_DIR) $(1)/usr/share/alsa/{cards,ctl,pcm}
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/share/alsa/alsa.conf \
 		$(1)/usr/share/alsa/
+	$(INSTALL_DATA) \
+		$(PKG_INSTALL_DIR)/usr/share/alsa/ctl/* \
+		$(1)/usr/share/alsa/ctl/
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/share/alsa/pcm/* \
 		$(1)/usr/share/alsa/pcm/


### PR DESCRIPTION
Maintainer: Ted Hess <thess@kitschensync.net>, Peter Wagner <tripolar@gmx.at>
Compile tested: master x86_64
Run tested: master x86_64

Description:
Last alsa-lib update broke alsamixer, current master fails with:

```
❯ alsamixer
ALSA lib conf.c:827:(get_char_skip_comments) Cannot access file /usr/share/alsa/ctl/default.conf
ALSA lib conf.c:1994:(_snd_config_load_with_include) _toplevel_:61:26:No such file or directory
ALSA lib conf.c:4040:(config_file_open) /usr/share/alsa/cards/aliases.conf may be old or corrupted: consider to remove or fix it
ALSA lib conf.c:3962:(snd_config_hooks_call) function snd_config_hook_load returned error: No such file or directory
ALSA lib control.c:1481:(snd_ctl_open_noupdate) Invalid CTL cards.ctl.default
cannot open mixer: No such file or directory
```
