### PR TITLE
cryptsetup: update to version 2.3.6

### DIFF
--- a/utils/cryptsetup/Makefile
+++ b/utils/cryptsetup/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cryptsetup
-PKG_VERSION:=2.3.5
+PKG_VERSION:=2.3.6
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/cryptsetup/v2.3
-PKG_HASH:=ced9946f444d132536daf92fc8aca4277638a3c2d96e20540b2bae4d36fd70c1
+PKG_HASH:=b296b7a21ea576c2b180611ccb19d06aec8dddaedf7c704b0c6a81210c25635f
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: Daniel Golle <daniel@makrotopia.org>
Compile tested: master x86_64
Run tested: master x86_64

Description:
Small upstream update.