### PR TITLE
nginx: add scgi_params if CONFIG_NGINX_HTTP_SCGI=y

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -197,6 +197,8 @@ ifneq ($(BUILD_VARIANT),all-module)
   endif
   ifneq ($(CONFIG_NGINX_HTTP_SCGI),y)
     ADDITIONAL_MODULES += --without-http_scgi_module
+  else
+    config_files += scgi_params
   endif
   ifneq ($(CONFIG_NGINX_HTTP_MEMCACHED),y)
     ADDITIONAL_MODULES += --without-http_memcached_module


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Ansuel Smith <ansuelsmth@gmail.com>
Compile tested: master x86_64
Run tested: master x86_64

Description:
We do not include `scgi_params` when `CONFIG_NGINX_HTTP_SCGI=y` like we do with `uwsgi_params` when `CONFIG_NGINX_HTTP_UWSGI=y` or `fastcgi_params` when `CONFIG_NGINX_HTTP_FASTCGI=y`.

So, to be coherent, include `scgi_params` too.