### PR TITLE
minidlna: add patch to be compatible with Android DLNA Channels

### DIFF
--- a/multimedia/minidlna/patches/999-force-compatibility-android_channels.patch
+++ b/multimedia/minidlna/patches/999-force-compatibility-android_channels.patch
@@ -1,0 +1,19 @@
+--- ./minissdp.c-orig	2020-11-24 19:53:50.000000000 +0100
++++ ./minissdp.c	2021-07-06 11:05:37.422070969 +0200
+@@ -650,11 +650,11 @@ ProcessSSDPRequest(struct event *ev)
+ 			DPRINTF(E_INFO, L_SSDP, "WARNING: Ignoring invalid SSDP M-SEARCH from %s [bad source port %d]\n",
+ 				inet_ntoa(sendername.sin_addr), ntohs(sendername.sin_port));
+ 		}
+-		else if (!man || (strncmp(man, "\"ssdp:discover\"", 15) != 0))
+-		{
+-			DPRINTF(E_INFO, L_SSDP, "WARNING: Ignoring invalid SSDP M-SEARCH from %s [bad %s header '%.*s']\n",
+-				inet_ntoa(sendername.sin_addr), "MAN", man_len, man);
+-		}
++//		else if (!man || (strncmp(man, "\"ssdp:discover\"", 15) != 0))
++//		{
++//			DPRINTF(E_INFO, L_SSDP, "WARNING: Ignoring invalid SSDP M-SEARCH from %s [bad %s header '%.*s']\n",
++//				inet_ntoa(sendername.sin_addr), "MAN", man_len, man);
++//		}
+ 		else if (!mx || mx == mx_end || mx_val < 0)
+ 		{
+ 			DPRINTF(E_INFO, L_SSDP, "WARNING: Ignoring invalid SSDP M-SEARCH from %s [bad %s header '%.*s']\n",


### PR DESCRIPTION
Maintainer: No one
Compile tested: master x86_64
Run tested: master x86_64

Description:
As is, minidlna does not work with [Android DLNA Channels](https://play.google.com/store/apps/details?id=at.nullptr.dlnachannels), a nice little app for Android TV which shows DLNA folders as content in the Android TV Home screen. Seemingly the error should only be a warning but in practice they cannot be used together.

With the attached patch, they not just work together, minidlna is by far the best backend I've tried it with.