### PR TITLE
openvswitch: make libunbound optional

### DIFF
--- a/net/openvswitch/Config.in
+++ b/net/openvswitch/Config.in
@@ -1,0 +1,8 @@
+menu "Configuration"
+	depends on PACKAGE_openvswitch
+
+	config	OPENVSWITCH_WITH_LIBUNBOUND
+		bool
+		default y
+		prompt "Build with libunbound library."
+endmenu

--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -17,7 +17,7 @@ include ./openvswitch.mk
 #
 PKG_NAME:=openvswitch
 PKG_VERSION:=$(ovs_version)
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openvswitch.org/releases/
 PKG_HASH:=7d5797f2bf2449c6a266149e88f72123540f7fe7f31ad52902057ae8d8f88c38
@@ -40,6 +40,9 @@ include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-host.mk
 include ../../lang/python/python3-package.mk
 
+define Package/openvswitch/config
+source "$(SOURCE)/Config.in"
+endef
 
 ovs_kmod_packages:=
 ovs_kmod_intree_kernel_patchver_min:=3.10
@@ -150,8 +153,11 @@ $(eval $(call OvsKmodPackageTemplate,openvswitch-lisp-intree))
 #
 ovs_libopenvswitch_title:=Open vSwitch (libopenvswitch.so)
 ovs_libopenvswitch_hidden:=1
-ovs_libopenvswitch_depends:=+libopenssl +libunbound +!(arc||arceb):libunwind
+ovs_libopenvswitch_depends:=+libopenssl +!(arc||arceb):libunwind
 ovs_libopenvswitch_depends+=+libatomic
+ifeq ($(CONFIG_KEEPALIVED_ROUTES),y)
+ovs_libopenvswitch_depends+=+libunbound
+endif
 ovs_libopenvswitch_files:=usr/lib/libopenvswitch*.so*
 $(eval $(call OvsPackageTemplate,libopenvswitch))
 
@@ -243,6 +249,7 @@ CONFIGURE_ARGS+= \
 	--disable-silent-rules \
 
 CONFIGURE_VARS += \
+	$(if $(CONFIG_OPENVSWITCH_WITH_UNBOUND),,ac_cv_lib_unbound_ub_ctx_create=no) \
 	ovs_cv_flake8=no \
 	ovs_cv_python3=$(PYTHON3) \
 	ovs_cv_python3_host=$(HOST_PYTHON3_BIN) \


### PR DESCRIPTION
Maintainer: @yousong 
Compile tested: OpenWrt master r17184-3cb22b277a on x86/64
Run tested: OpenWrt master r17184-3cb22b277a on x86/64

Description:
Installing openvswitch on an x86/64 snapshot image pulls in a bunch of
dependencies, good for a total size of 3648406 byte. Disabling
libunbound reduces that with 559941 byte, for a total of 3088465 byte.
This is quite a big reduction for a small tradeoff: without libunbound,
hostnames can not be used to specify OpenFlow managers or controllers.