### PR TITLE
prometheus-node-exporter-lua: fix bss identifier in hostapd_stations

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2021.07.04
+PKG_VERSION:=2021.07.24
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>


### PR DESCRIPTION
Maintainer: @champtar @blocktrron 
Compile tested: ath79
Run tested: unifi, unifiac-lite, unifiac-mesh

Description:

We previously did not identify the correct BSS from the output of
`hostapd_cli -i <phy> status`, because when asked for a vif it will
always respond with information relevant to the whole phy.

The per vif settings will use an iterator and we now try to detect
the correct BSS from that output.

Signed-off-by: Martin Weinelt <hexa@darmstadt.ccc.de>