### PR TITLE
net: socat: add option user

### DIFF
--- a/net/socat/Makefile
+++ b/net/socat/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=socat
 PKG_VERSION:=1.7.3.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.dest-unreach.org/socat/download

--- a/net/socat/files/socat.config
+++ b/net/socat/files/socat.config
@@ -3,3 +3,4 @@
 config socat 'http'
 	option enable '0'
 	option SocatOptions '-d -d TCP6-LISTEN:8000,fork TCP4:192.168.1.20:80'
+	option user 'nobody'

--- a/net/socat/files/socat.init
+++ b/net/socat/files/socat.init
@@ -12,7 +12,8 @@ validate_section_socat()
 {
 	uci_load_validate socat socat "$1" "$2" \
 		'enable:bool:1' \
-		'SocatOptions:or(string, list(string))'
+		'SocatOptions:or(string, list(string))' \
+		'user:string:root'
 }
 
 append_param_command()
@@ -23,6 +24,7 @@ append_param_command()
 socat_instance()
 {
 	local is_list
+	local user
 
 	[ "$2" = 0 ] || {
 		echo "validation failed"
@@ -38,6 +40,10 @@ socat_instance()
 		procd_append_param command $SocatOptions
 	else
 		config_list_foreach "$1" SocatOptions append_param_command
+	fi
+	config_get user "$1" user
+	if [ -n "$user" ]; then
+		procd_set_param user $user
 	fi
 	procd_set_param stdout 1
 	procd_set_param stderr 1


### PR DESCRIPTION
Allow UCI configuration to specify username to run this service as.
Defaults to root.

Signed-off-by: Paul Fertser <fercerpav@gmail.com>

Maintainer: @neheb 
Compile tested: 21.02-rc3
Run tested: 21.02-rc3

Description:
