### PR TITLE
adblock: bugfix 4.1.3-3

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
 PKG_VERSION:=4.1.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -916,7 +916,7 @@ f_list()
 		"safesearch")
 			case "${src_name}" in
 				"google")
-					rset="/^(\\.[[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{printf \"%s\n%s\n\",tolower(\"www\"\$1),tolower(substr(\$1,2,length(\$1)))}"
+					rset="/^\\.([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{printf \"%s\n%s\n\",tolower(\"www\"\$1),tolower(substr(\$1,2,length(\$1)))}"
 					safe_url="https://www.google.com/supported_domains"
 					safe_cname="forcesafesearch.google.com"
 					safe_domains="${adb_tmpdir}/tmp.load.safesearch.${src_name}"


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: TP-Link RE650 v1, OpenWrt SNAPSHOT r17216-8c2509dc5f

Description:
* fix regex to prepare google safesearch domains

Signed-off-by: Dirk Brenken <dev@brenken.org>


