### PR TITLE
openvswitch: support setting OpenFlow datapath ID

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -17,7 +17,7 @@ include ./openvswitch.mk
 #
 PKG_NAME:=openvswitch
 PKG_VERSION:=$(ovs_version)
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openvswitch.org/releases/
 PKG_HASH:=7d5797f2bf2449c6a266149e88f72123540f7fe7f31ad52902057ae8d8f88c38

--- a/net/openvswitch/README.md
+++ b/net/openvswitch/README.md
@@ -72,11 +72,12 @@ set to 0 to launch the respective daemons.
 The ovs_bridge section also supports the options below,
 for initialising a virtual bridge with an OpenFlow controller.
 
-| Name       | Type    | Required | Default                        | Description                                                |
-|------------|---------|----------|--------------------------------|------------------------------------------------------------|
-| disabled   | boolean | no       | 0                              | If set to true, disable initialisation of the named bridge |
-| name       | string  | no       | Inherits UCI config block name | The name of the switch in the OVS daemon                   |
-| controller | string  | no       | (none)                         | The endpoint of an OpenFlow controller for this bridge     |
+| Name        | Type    | Required | Default                        | Description                                                |
+|-------------|---------|----------|--------------------------------|------------------------------------------------------------|
+| disabled    | boolean | no       | 0                              | If set to true, disable initialisation of the named bridge |
+| name        | string  | no       | Inherits UCI config block name | The name of the switch in the OVS daemon                   |
+| controller  | string  | no       | (none)                         | The endpoint of an OpenFlow controller for this bridge     |
+| datapath_id | string  | no       | (none)                         | The OpenFlow datapath ID for this bridge                   |
 
 The ovs_port section can be used to add ports to a bridge. It supports the options below.
 

--- a/net/openvswitch/files/openvswitch.config
+++ b/net/openvswitch/files/openvswitch.config
@@ -11,6 +11,7 @@ config ovs_bridge
 	option disabled 1
 	option name 'my-bridge'
 	option controller 'tcp:192.168.0.1'
+	option datapath_id ''
 
 config ovs_port
 	option disabled 1

--- a/net/openvswitch/files/openvswitch.init
+++ b/net/openvswitch/files/openvswitch.init
@@ -171,18 +171,39 @@ ovs_bridge_port_cleanup() {
 	done
 }
 
+ovs_bridge_validate_datapath_id() {
+	local dpid="$1"
+
+	if expr "$dpid" : '[[:xdigit:]]\{16\}$' > /dev/null; then
+		return 0
+	elif expr "$dpid" : '0x[[:xdigit:]]\{1,16\}$' > /dev/null; then
+		return 0
+	else
+		logger -t openvswitch "invalid datapath_id: $dpid"
+		return 1
+	fi
+}
+
 ovs_bridge_init() {
 	local cfg="$1"
 
 	local disabled
 	local name
 	local controller
+	local datapath_id
 
 	config_get_bool disabled "$cfg" disabled 0
 	[ "$disabled" == "0" ] || return
 
 	config_get name "$cfg" name $cfg
 	ovs-vsctl --may-exist add-br "$name"
+
+	config_get datapath_id "$cfg" datapath_id
+	[ -n "$datapath_id" ] && {
+		ovs_bridge_validate_datapath_id "$datapath_id" && {
+			ovs-vsctl --if-exists set bridge "$name" other-config:datapath-id="$datapath_id"
+		}
+	}
 
 	config_list_foreach "$cfg" "ports" ovs_bridge_port_add
 	config_foreach ovs_bridge_port_add_complex ovs_port "$name"


### PR DESCRIPTION
Maintainer: me / @yousong 
Compile tested: NA
Run tested: OpenWrt master r17170-86a61e716e on x86/64

Description:
By default, Open vSwitch will generate the OpenFlow datapath ID of a
bridge based on the MAC address of one of its ports. Due to this, it's
possible that the datapath ID changes when new ports are added. When the
datapath ID changes, Open vSwitch disconnects from the controller, as
there is no way to notify the controller that the datapath ID has
changed.

Add an option to set the datapath ID so that the above situation can be
avoided. The option either takes 16 hex characters, or when prefixed
with @, the name of a UCI interface section. In the latter case, it will
lookup the MAC address of the interface, and prefix it with 6f77, which
is hex for "ow".