### PR TITLE
transmission: apply DSCP to UDP sockets too

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,13 +9,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=3.00
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master
 PKG_HASH:=9144652fe742f7f7dd6657716e378da60b751aaeda8bef8344b3eefc4db255f2
 
-PKG_MAINTAINER:=Rosen Penev <rosenp@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:transmissionbt:transmission

--- a/net/transmission/patches/001-apply-dscp-to-udp-sockets.patch
+++ b/net/transmission/patches/001-apply-dscp-to-udp-sockets.patch
@@ -1,0 +1,68 @@
+From 98da2afa58b7bdf5350de16fd99905ddb04e1b0d Mon Sep 17 00:00:00 2001
+From: Dan Walters <dan@walters.io>
+Date: Sun, 13 Oct 2019 10:08:36 -0500
+Subject: [PATCH] Apply the configured peer socket TOS to UDP sockets, not just
+ TCP.
+
+---
+ libtransmission/session.c |  2 ++
+ libtransmission/tr-udp.c  | 20 ++++++++++++++++++++
+ libtransmission/tr-udp.h  |  1 +
+ 3 files changed, 23 insertions(+)
+
+--- a/libtransmission/session.c
++++ b/libtransmission/session.c
+@@ -2274,6 +2274,8 @@ static void toggle_utp(void* data)
+ 
+     tr_udpSetSocketBuffers(session);
+ 
++    tr_udpSetSocketTOS(session);
++
+     /* But don't call tr_utpClose -- see reset_timer in tr-utp.c for an
+        explanation. */
+ }
+--- a/libtransmission/tr-udp.c
++++ b/libtransmission/tr-udp.c
+@@ -125,6 +125,24 @@ void tr_udpSetSocketBuffers(tr_session*
+     }
+ }
+ 
++void tr_udpSetSocketTOS(tr_session* session)
++{
++    if (session->peerSocketTOS == 0)
++    {
++        return;
++    }
++
++    if (session->udp_socket != TR_BAD_SOCKET)
++    {
++        tr_netSetTOS(session->udp_socket, session->peerSocketTOS, TR_AF_INET);
++    }
++
++    if (session->udp6_socket != TR_BAD_SOCKET)
++    {
++        tr_netSetTOS(session->udp6_socket, session->peerSocketTOS, TR_AF_INET6);
++    }
++}
++
+ /* BEP-32 has a rather nice explanation of why we need to bind to one
+    IPv6 address, if I may say so myself. */
+ 
+@@ -363,6 +381,8 @@ ipv6:
+ 
+     tr_udpSetSocketBuffers(ss);
+ 
++    tr_udpSetSocketTOS(ss);
++
+     if (ss->isDHTEnabled)
+     {
+         tr_dhtInit(ss);
+--- a/libtransmission/tr-udp.h
++++ b/libtransmission/tr-udp.h
+@@ -30,5 +30,6 @@ THE SOFTWARE.
+ void tr_udpInit(tr_session*);
+ void tr_udpUninit(tr_session*);
+ void tr_udpSetSocketBuffers(tr_session*);
++void tr_udpSetSocketTOS(tr_session*);
+ 
+ bool tau_handle_message(tr_session* session, uint8_t const* msg, size_t msglen);


### PR DESCRIPTION
Maintainer: @dangowrt (?)
Compile tested: mvebu/cortexa9 (Turris Omnia)

Backport a pending patch in order to DSCP-mark UDP traffic. This allows for
correct binning of traffic in diffserv-capable routers.

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>