### PR TITLE
openvswitch: add SSL support

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -17,7 +17,7 @@ include ./openvswitch.mk
 #
 PKG_NAME:=openvswitch
 PKG_VERSION:=$(ovs_version)
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openvswitch.org/releases/
 PKG_HASH:=7d5797f2bf2449c6a266149e88f72123540f7fe7f31ad52902057ae8d8f88c38

--- a/net/openvswitch/README.md
+++ b/net/openvswitch/README.md
@@ -69,6 +69,19 @@ ovs ovn_northd, ovn_controller & ovs_bridge.
 Each of these supports a disabled option, which should be 
 set to 0 to launch the respective daemons.
 
+The ovs section section also supports the options below, to configure a set of
+SSL CA, certificate and private key. After adding these to Open vSwitch, you
+may specify ssl: connection methods for e.g. the OpenFlow controller. Note that
+Open vSwitch only reads these files during startup, so it needs to be restarted
+after adding or changing these options.
+
+| Name     | Type    | Required | Default | Description                       |
+|----------|---------|----------|---------|-----------------------------------|
+| disabled | boolean | no       | 0       | If set to 1, do not configure SSL |
+| ca       | string  | no       | (none)  | Path to CA certificate            |
+| cert     | string  | no       | (none)  | Path to certificate               |
+| key      | string  | no       | (none)  | Path to private key               |
+
 The ovs_bridge section also supports the options below,
 for initialising a virtual bridge with an OpenFlow controller.
 

--- a/net/openvswitch/files/openvswitch.config
+++ b/net/openvswitch/files/openvswitch.config
@@ -1,5 +1,8 @@
 config ovs ovs
 	option disabled 1
+	option ca '/etc/openvswitch/example_ca.crt'
+	option cert '/etc/openvswitch/example_cert.crt'
+	option key '/etc/openvswitch/example_key.crt'
 
 config ovn_northd north
 	option disabled 1

--- a/net/openvswitch/files/openvswitch.init
+++ b/net/openvswitch/files/openvswitch.init
@@ -90,6 +90,7 @@ ovs_xx() {
 		ovs)
 			"$ovs_ctl" "$action" \
 				--system-id=random 1000>&-
+			ovs_set_ssl
 			;;
 		ovn_*)
 			"$ovn_ctl" "${action}_${cfgtype#ovn_}"
@@ -215,4 +216,15 @@ ovs_bridge_init() {
 	config_get controller "$cfg" controller
 	[ -n "$controller" ] && \
 		ovs-vsctl set-controller "$name" "$controller"
+}
+
+ovs_set_ssl() {
+	local ca="$(uci -q get openvswitch.ovs.ca)"
+	[ -f "$ca" ] || return
+	local cert="$(uci get openvswitch.ovs.cert)"
+	[ -f "$cert" ] || return
+	local key="$(uci get openvswitch.ovs.key)"
+	[ -f "$key" ] || return
+
+	ovs-vsctl set-ssl "$key" "$cert" "$ca"
 }

--- a/net/openvswitch/files/openvswitch.init
+++ b/net/openvswitch/files/openvswitch.init
@@ -7,6 +7,8 @@
 . /lib/functions/procd.sh
 START=15
 
+basescript=$(readlink "$initscript")
+
 ovs_ctl="/usr/share/openvswitch/scripts/ovs-ctl"; [ -x "$ovs_ctl" ] || ovs_ctl=:
 ovn_ctl="/usr/share/ovn/scripts/ovn-ctl"; [ -x "$ovn_ctl" ] || ovn_ctl=:
 


### PR DESCRIPTION
Maintainer: @yousong
Compile tested: NA
Run tested: OpenWrt master r17184-3cb22b277a on x86/64

Description:
Open vSwitch supports SSL to connect to an OpenFlow controller. This is
recommended for security. Expand the UCI ovs config section to allow
configuring SSL CA, certificate and private key.