### PR TITLE
php8: update to 8.0.9/add runtime test

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.0.8
+PKG_VERSION:=8.0.9
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=dc1668d324232dec1d05175ec752dade92d29bb3004275118bc3f7fc7cbfbb1c
+PKG_HASH:=71a01b2b56544e20e28696ad5b366e431a0984eaa39aa5e35426a4843e172010
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0

--- a/lang/php8/test.sh
+++ b/lang/php8/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+case "$1" in
+	php8-cgi)
+		php8-cgi -v | grep "$2"
+		;;
+	php8-cli)
+		php8-cli -v | grep "$2"
+		;;
+	php8-fpm)
+		php8-fpm -v | grep "$2"
+		;;
+	php8-mod-*)
+		PHP_MOD="${1#php8-mod-}"
+		PHP_MOD="${PHP_MOD//-/_}"
+
+		opkg install php8-cli
+
+		php8-cli -m | grep -i "$PHP_MOD"
+		;;
+	*)
+		;;
+esac


### PR DESCRIPTION
Signed-off-by: Michael Heimpold <mhei@heimpold.de>

Maintainer: me
Compile tested: mxs
Run tested: mxs