### PR TITLE
[21.02] https-dns-proxy: update to 2021-07-29-1

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -1,20 +1,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
-PKG_VERSION:=2021-06-03
+PKG_VERSION:=2021-07-29
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy
-PKG_SOURCE_DATE:=2021-06-03
-PKG_SOURCE_VERSION:=5651b984f770a8bcecb14aeffc224703f8f82586
-PKG_MIRROR_HASH:=b65161936269aa3117debad0fcfce157024726b78d7e7da77c226f7aa8da5b4d
+PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/
+PKG_SOURCE_DATE:=2021-07-29
+PKG_SOURCE_VERSION:=750c4dbdfe3d3c65edcd57349df181ffd1f6ceeb
+PKG_MIRROR_HASH:=88f487d80f8f20b83d1f9940c30ad1d5b6a4eda6be48fbaea196c69e90c5429e
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
-include ../../devel/ninja/ninja-cmake.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 CMAKE_OPTIONS += -DCLANG_TIDY_EXE=
 
@@ -38,11 +38,12 @@ define Package/https-dns-proxy/conffiles
 endef
 
 define Package/https-dns-proxy/install
-	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/init.d ${1}/etc/config
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/init.d ${1}/etc/config $(1)/etc/hotplug.d/iface
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/https_dns_proxy $(1)/usr/sbin/https-dns-proxy
 	$(INSTALL_BIN) ./files/https-dns-proxy.init $(1)/etc/init.d/https-dns-proxy
 	$(SED) "s|^\(PKG_VERSION\).*|\1='$(PKG_VERSION)-$(PKG_RELEASE)'|" $(1)/etc/init.d/https-dns-proxy
 	$(INSTALL_CONF) ./files/https-dns-proxy.config $(1)/etc/config/https-dns-proxy
+	$(INSTALL_DATA) ./files/https-dns-proxy.hotplug.iface $(1)/etc/hotplug.d/iface/90-https-dns-proxy
 endef
 
 $(eval $(call BuildPackage,https-dns-proxy))

--- a/net/https-dns-proxy/files/https-dns-proxy.hotplug.iface
+++ b/net/https-dns-proxy/files/https-dns-proxy.hotplug.iface
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ "$ACTION" = 'ifup' ] && [ "$INTERFACE" = 'wan' ]; then
+	logger -t "https-dns-proxy" "Reloading https-dns-proxy due to $ACTION of $INTERFACE"
+	/etc/init.d/https-dns-proxy reload
+fi

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -16,7 +16,13 @@ else
 fi
 
 readonly PROG=/usr/sbin/https-dns-proxy
+readonly DEFAULT_BOOTSTRAP='1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844'
 dnsmasqConfig=''; forceDNS=''; forceDNSPorts='';
+
+str_contains() { [ -n "$2" ] && [ "${1//$2}" != "$1" ]; }
+is_mac_address() { expr "$1" : '[0-9A-F][0-9A-F]:[0-9A-F][0-9A-F]:[0-9A-F][0-9A-F]:[0-9A-F][0-9A-F]:[0-9A-F][0-9A-F]:[0-9A-F][0-9A-F]$' >/dev/null; }
+is_ipv4() { expr "$1" : '[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; }
+is_ipv6() { ! is_mac_address "$1" && str_contains "$1" ":"; }
 
 version() { echo "$PKG_VERSION"; }
 
@@ -26,11 +32,10 @@ append_bool() {
 	local section="$1"
 	local option="$2"
 	local value="$3"
-	local default="$4"
+	local default="${4:-0}"
 	local _loctmp
-	[ -z "$default" ] && default="0"
 	config_get_bool _loctmp "$section" "$option" "$default"
-	[ "$_loctmp" != "0" ] && xappend "$value"
+	[ "$_loctmp" -ne 0 ] && xappend "$value"
 }
 
 append_parm() {
@@ -40,41 +45,94 @@ append_parm() {
 	local default="$4"
 	local _loctmp
 	config_get _loctmp "$section" "$option" "$default"
+	[ -n "$_loctmp" ] && xappend "$switch $_loctmp"
+}
+
+append_counter() {
+	local section="$1"
+	local option="$2"
+	local switch="$3"
+	local default="${4:-0}"
+	local _loctmp i
+	config_get _loctmp "$section" "$option" "$default"
+# shellcheck disable=SC2086,SC2154
+	for i in $(seq 1 $_loctmp); do
+		xappend '-v'
+	done
+}
+
+append_bootstrap() {
+	local section="$1"
+	local option="$2"
+	local switch="$3"
+	local default="$4"
+	local _old_ifs="$IFS"
+	local _loctmp _newtmp i
+	config_get _loctmp "$section" "$option" "$default"
 	[ -z "$_loctmp" ] && return 0
-	xappend "$switch $_loctmp"
+	IFS=" ,"
+	for i in $_loctmp; do
+		if { [ "$ipv6_resolvers_only" -eq 0 ] && is_ipv4 "$i"; } || \
+			{ [ "$ipv6_resolvers_only" -ne 0 ] && is_ipv6 "$i"; }; then
+			[ -z "$_newtmp" ] && _newtmp="$i" || _newtmp="${_newtmp},${i}"
+		fi
+	done
+	IFS="$_old_ifs"
+	[ -n "$_newtmp" ] && xappend "$switch $_newtmp"
+	[ "$ipv6_resolvers_only" -eq 0 ] && xappend '-4'
 }
 
 start_instance() {
-	local cfg="$1" param listen_addr listen_port i
+	local cfg="$1" param listen_addr listen_port i ipv6_resolvers_only
+	config_get_bool ipv6_resolvers_only "$cfg" 'use_ipv6_resolvers_only' '0'
 	append_parm "$cfg" 'resolver_url' '-r'
 	append_parm "$cfg" 'polling_interval' '-i'
 	append_parm "$cfg" 'listen_addr' '-a' '127.0.0.1'
 	append_parm "$cfg" 'listen_port' '-p' "$p"
 	append_parm "$cfg" 'dscp_codepoint' '-c'
-	append_parm "$cfg" 'bootstrap_dns' '-b'
+	append_bootstrap "$cfg" 'bootstrap_dns' '-b' "$DEFAULT_BOOTSTRAP"
 	append_parm "$cfg" 'user' '-u' 'nobody'
 	append_parm "$cfg" 'group' '-g' 'nogroup'
 	append_parm "$cfg" 'proxy_server' '-t'
 	append_parm "$cfg" 'logfile' '-l'
 	append_bool "$cfg" 'use_http1' '-x'
-	config_get_bool ipv6_resolvers_only "$cfg" 'use_ipv6_resolvers_only' '0'
-	config_get verbosity "$cfg" 'verbosity' '0'
-
-# shellcheck disable=SC2086,SC2154
-	for i in $(seq 1 $verbosity); do
-		xappend '-v'
-	done
-# shellcheck disable=SC2154
-	if [ "$ipv6_resolvers_only" = 0 ]; then
-		xappend '-4'
-	fi
+	append_counter "$cfg" 'verbosity' '-v' '0'
 
 	procd_open_instance
 # shellcheck disable=SC2086
-	procd_set_param command ${PROG} ${param}
+	procd_set_param command $PROG $param
 	procd_set_param stderr 1
 	procd_set_param stdout 1
 	procd_set_param respawn
+	if [ "$forceDNS" -ne 0 ]; then
+		procd_open_data
+		json_add_array firewall
+		for c in $forceDNSPorts; do
+			if netstat -tuln | grep 'LISTEN' | grep ":${c}" >/dev/null 2>&1 || [ "$c" = "53" ]; then
+				json_add_object ""
+				json_add_string type redirect
+				json_add_string target DNAT
+				json_add_string src lan
+				json_add_string proto "tcp udp"
+				json_add_string src_dport "$c"
+				json_add_string dest_port "$c"
+				json_add_boolean reflection 0
+				json_close_object
+			else
+				json_add_object ""
+				json_add_string type rule
+				json_add_string src lan
+				json_add_string dest "*"
+				json_add_string proto "tcp udp"
+				json_add_string dest_port "$c"
+				json_add_string target REJECT
+				json_close_object
+			fi
+		done
+		json_close_array
+		procd_close_data
+		forceDNS='0'
+	fi
 	procd_close_instance
 
 	config_get listen_addr "$cfg" 'listen_addr' '127.0.0.1'
@@ -102,39 +160,6 @@ start_service() {
 	dhcp_backup 'create'
 	config_load 'https-dns-proxy'
 	config_foreach start_instance 'https-dns-proxy'
-	if [ "$forceDNS" -ne 0 ]; then
-		procd_open_instance 'main'
-		procd_set_param command /bin/true
-		procd_set_param stdout 1
-		procd_set_param stderr 1
-		procd_open_data
-		json_add_array firewall
-		for c in $forceDNSPorts; do
-			if netstat -tuln | grep 'LISTEN' | grep ":${c}" >/dev/null 2>&1 || [ "$c" = "53" ]; then
-				json_add_object ""
-				json_add_string type redirect
-				json_add_string target DNAT
-				json_add_string src lan
-				json_add_string proto "tcp udp"
-				json_add_string src_dport "$c"
-				json_add_string dest_port "$c"
-				json_add_boolean reflection 0
-				json_close_object
-			else
-				json_add_object ""
-				json_add_string type rule
-				json_add_string src lan
-				json_add_string dest "*"
-				json_add_string proto "tcp udp"
-				json_add_string dest_port "$c"
-				json_add_string target REJECT
-				json_close_object
-			fi
-		done
-		json_close_array
-		procd_close_data
-		procd_close_instance
-	fi
 	if [ -n "$(uci -q changes dhcp)" ]; then
 		uci -q commit dhcp
 		[ -x /etc/init.d/dnsmasq ] && /etc/init.d/dnsmasq restart >/dev/null 2>&1


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-105, OpenWrt 21.02.0-rc3
Run tested: x86_64, Sophos SG-105, OpenWrt 21.02.0-rc3, start/stop/name resolution/log output

Description:
* update binary to the latest commit (2021-07-29) to fix #16222 and #16239
* add hotplug.d/iface file and update Makefile to install it
* use Cloudflare's and Google's bootstrap DNS if bootstrap DNS is missing
* minor improvements in append_bool function
* add append_counter function for verbosity setting
* add append_bootstrap function (and supporting functions) to parse/sanitize bootstrap setting
* move firewall array from 'main' instance to the first proxy instance
* delete useless 'main' instace

Signed-off-by: Stan Grishin <stangri@melmac.net>
