### PR TITLE
curl: enable HTTP/2 support by default

### DIFF
--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -103,7 +103,7 @@ config LIBCURL_TFTP
 
 config LIBCURL_NGHTTP2
 	bool "HTTP2 protocol"
-	default n
+	default y
 
 comment "Miscellaneous"
 


### PR DESCRIPTION
Maintainer: @kaloz 

Description: Lack of support of HTTP/2 by default starts to hurt, for example with `https-dns-proxy` package, some DoH resolvers (like mullvad) no longer support HTTP/1 and are not usable.

Can we just enable HTTP/2 support by default (which would bring ~68Kb libnghttp) or would it require a variant? If a variant would be preferred way forward, should the default libcurl include HTTP/2 support (so the variant would be libcurl-nonghttp) or should the default stay as is (and the variant be libcurl-nghttp)?

Signed-off-by: Stan Grishin <stangri@melmac.net>

