### PR TITLE
[21.02] curl: enable HTTP/2 support by default

### DIFF
--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -103,7 +103,7 @@ config LIBCURL_TFTP
 
 config LIBCURL_NGHTTP2
 	bool "HTTP2 protocol"
-	default n
+	default y
 
 comment "Miscellaneous"
 


### PR DESCRIPTION
Maintainer: @kaloz 

Description: Lack of support of HTTP/2 by default starts to hurt,
for example with https-dns-proxy package, some DoH resolvers (like mullvad)
no longer support HTTP/1 and are not usable.

This enables HTTP/2 support by default (which would bring ~68Kb libnghttp).

Signed-off-by: Stan Grishin <stangri@melmac.net>

PS. This is a sister PR to #16255 
