### PR TITLE
strongswan: Add dependency to virtual package strongswan-mod-socket

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -346,7 +346,7 @@ endef
 define Package/strongswan-charon
 $(call Package/strongswan/Default)
   TITLE+= IKEv1/IKEv2 keying daemon
-  DEPENDS:= strongswan
+  DEPENDS:= strongswan strongswan-mod-socket
 endef
 
 define Package/strongswan-charon/description
@@ -441,6 +441,28 @@ define Package/strongswan-libtls/description
 $(call Package/strongswan/description/Default)
  This package contains libtls for strongSwan plugins eap-tls, eap-ttls,
  eap-peap, tnc-tnccs
+endef
+
+
+define BuildPluginModSocketVirt
+  define Package/strongswan-mod-$(1)
+    $$(call Package/strongswan/Default)
+    TITLE:= StrongSwan $(2) plugin
+    DEPENDS:= strongswan $(3)
+    PROVIDES:= strongswan-mod-socket
+  endef
+
+  define Package/strongswan-mod-$(1)/install
+	$(INSTALL_DIR) $$(1)/etc/strongswan.d/charon
+	if [ -f $(PKG_INSTALL_DIR)/etc/strongswan.d/charon/$(1).conf ]; then \
+		$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/strongswan.d/charon/$(1).conf $$(1)/etc/strongswan.d/charon/; fi
+	$(INSTALL_DIR) $$(1)/usr/lib/ipsec/plugins
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ipsec/plugins/libstrongswan-$(1).so \
+		$$(1)/usr/lib/ipsec/plugins/
+	$(call Plugin/$(1)/install,$$(1))
+  endef
+
+  $$(eval $$(call BuildPackage,strongswan-mod-$(1)))
 endef
 
 define BuildPlugin
@@ -730,8 +752,8 @@ $(eval $(call BuildPlugin,sha1,SHA1 crypto,))
 $(eval $(call BuildPlugin,sha2,SHA2 crypto,))
 $(eval $(call BuildPlugin,sha3,SHA3 and SHAKE crypto,))
 $(eval $(call BuildPlugin,smp,SMP configuration and control interface,+PACKAGE_strongswan-mod-smp:libxml2))
-$(eval $(call BuildPlugin,socket-default,default socket implementation for charon,))
-$(eval $(call BuildPlugin,socket-dynamic,dynamic socket implementation for charon,))
+$(eval $(call BuildPluginModSocketVirt,socket-default,default socket implementation for charon,))
+$(eval $(call BuildPluginModSocketVirt,socket-dynamic,dynamic socket implementation for charon,))
 $(eval $(call BuildPlugin,sql,SQL database interface,))
 $(eval $(call BuildPlugin,sqlite,SQLite database interface,+strongswan-mod-sql +PACKAGE_strongswan-mod-sqlite:libsqlite3))
 $(eval $(call BuildPlugin,sshkey,SSH key decoding,))

--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -215,7 +215,6 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-sha2 \
 	+strongswan-mod-sha3 \
 	+strongswan-mod-smp \
-	+strongswan-mod-socket-default \
 	+strongswan-mod-sql \
 	+strongswan-mod-sqlite \
 	+strongswan-mod-sshkey \
@@ -273,7 +272,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-revocation \
 	+strongswan-mod-sha1 \
 	+strongswan-mod-sha2 \
-	+strongswan-mod-socket-default \
+	+@(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic) \
 	+strongswan-mod-sshkey \
 	+strongswan-mod-updown \
 	+strongswan-mod-x509 \
@@ -304,7 +303,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-pubkey \
 	+strongswan-mod-random \
 	+strongswan-mod-sha1 \
-	+strongswan-mod-socket-default \
+	++@(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic) \
 	+strongswan-mod-stroke \
 	+strongswan-mod-uci \
 	+strongswan-mod-updown
@@ -331,7 +330,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-pubkey \
 	+strongswan-mod-random \
 	+strongswan-mod-sha1 \
-	+strongswan-mod-socket-default \
+	++@(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic) \
 	+strongswan-mod-stroke \
 	+strongswan-mod-updown \
 	+strongswan-mod-x509 \
@@ -346,7 +345,7 @@ endef
 define Package/strongswan-charon
 $(call Package/strongswan/Default)
   TITLE+= IKEv1/IKEv2 keying daemon
-  DEPENDS:= strongswan strongswan-mod-socket
+  DEPENDS:= strongswan +@(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic)
 endef
 
 define Package/strongswan-charon/description
@@ -441,28 +440,6 @@ define Package/strongswan-libtls/description
 $(call Package/strongswan/description/Default)
  This package contains libtls for strongSwan plugins eap-tls, eap-ttls,
  eap-peap, tnc-tnccs
-endef
-
-
-define BuildPluginModSocketVirt
-  define Package/strongswan-mod-$(1)
-    $$(call Package/strongswan/Default)
-    TITLE:= StrongSwan $(2) plugin
-    DEPENDS:= strongswan $(3)
-    PROVIDES:= strongswan-mod-socket
-  endef
-
-  define Package/strongswan-mod-$(1)/install
-	$(INSTALL_DIR) $$(1)/etc/strongswan.d/charon
-	if [ -f $(PKG_INSTALL_DIR)/etc/strongswan.d/charon/$(1).conf ]; then \
-		$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/strongswan.d/charon/$(1).conf $$(1)/etc/strongswan.d/charon/; fi
-	$(INSTALL_DIR) $$(1)/usr/lib/ipsec/plugins
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ipsec/plugins/libstrongswan-$(1).so \
-		$$(1)/usr/lib/ipsec/plugins/
-	$(call Plugin/$(1)/install,$$(1))
-  endef
-
-  $$(eval $$(call BuildPackage,strongswan-mod-$(1)))
 endef
 
 define BuildPlugin
@@ -752,8 +729,8 @@ $(eval $(call BuildPlugin,sha1,SHA1 crypto,))
 $(eval $(call BuildPlugin,sha2,SHA2 crypto,))
 $(eval $(call BuildPlugin,sha3,SHA3 and SHAKE crypto,))
 $(eval $(call BuildPlugin,smp,SMP configuration and control interface,+PACKAGE_strongswan-mod-smp:libxml2))
-$(eval $(call BuildPluginModSocketVirt,socket-default,default socket implementation for charon,))
-$(eval $(call BuildPluginModSocketVirt,socket-dynamic,dynamic socket implementation for charon,))
+$(eval $(call BuildPlugin,socket-default,default socket implementation for charon,))
+$(eval $(call BuildPlugin,socket-dynamic,dynamic socket implementation for charon,))
 $(eval $(call BuildPlugin,sql,SQL database interface,))
 $(eval $(call BuildPlugin,sqlite,SQLite database interface,+strongswan-mod-sql +PACKAGE_strongswan-mod-sqlite:libsqlite3))
 $(eval $(call BuildPlugin,sshkey,SSH key decoding,))

--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -303,7 +303,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-pubkey \
 	+strongswan-mod-random \
 	+strongswan-mod-sha1 \
-	++@(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic) \
+	+@(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic) \
 	+strongswan-mod-stroke \
 	+strongswan-mod-uci \
 	+strongswan-mod-updown
@@ -330,7 +330,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-pubkey \
 	+strongswan-mod-random \
 	+strongswan-mod-sha1 \
-	++@(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic) \
+	+@(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic) \
 	+strongswan-mod-stroke \
 	+strongswan-mod-updown \
 	+strongswan-mod-x509 \
@@ -345,7 +345,7 @@ endef
 define Package/strongswan-charon
 $(call Package/strongswan/Default)
   TITLE+= IKEv1/IKEv2 keying daemon
-  DEPENDS:= strongswan +@(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic)
+  DEPENDS:= strongswan @(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic)
 endef
 
 define Package/strongswan-charon/description

--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -272,7 +272,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-revocation \
 	+strongswan-mod-sha1 \
 	+strongswan-mod-sha2 \
-	+@(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic) \
+	@(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic) \
 	+strongswan-mod-sshkey \
 	+strongswan-mod-updown \
 	+strongswan-mod-x509 \
@@ -303,7 +303,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-pubkey \
 	+strongswan-mod-random \
 	+strongswan-mod-sha1 \
-	+@(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic) \
+	@(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic) \
 	+strongswan-mod-stroke \
 	+strongswan-mod-uci \
 	+strongswan-mod-updown
@@ -330,7 +330,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-pubkey \
 	+strongswan-mod-random \
 	+strongswan-mod-sha1 \
-	+@(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic) \
+	@(PACKAGE_strongswan-mod-socket-default||PACKAGE_strongswan-mod-socket-dynamic) \
 	+strongswan-mod-stroke \
 	+strongswan-mod-updown \
 	+strongswan-mod-x509 \


### PR DESCRIPTION
Required to model the dependency of the charon daemon onto one of the two socket abstractions
Otherwise none will be installed and the daemon is not usable

Closes #16261

Signed-off-by: Noel Kuntze <noel.kuntze@thermi.consulting>

Maintainer: me / @pprindeville 
Compile tested: x86_64, trunk
Run tested: Not yet

Description: