### PR TITLE
[21.02] php8 update to 8.0.9

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.0.3
+PKG_VERSION:=8.0.9
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=c9816aa9745a9695672951eaff3a35ca5eddcb9cacf87a4f04b9fb1169010251
+PKG_HASH:=71a01b2b56544e20e28696ad5b366e431a0984eaa39aa5e35426a4843e172010
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0

--- a/lang/php8/patches/0025-php-5.4.9-fixheader.patch
+++ b/lang/php8/patches/0025-php-5.4.9-fixheader.patch
@@ -9,7 +9,7 @@ Make generated php_config.h constant across rebuilds.
 
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1278,7 +1278,7 @@ PHP_REMOVE_USR_LIB(LDFLAGS)
+@@ -1289,7 +1289,7 @@ PHP_REMOVE_USR_LIB(LDFLAGS)
  EXTRA_LDFLAGS="$EXTRA_LDFLAGS $PHP_LDFLAGS"
  EXTRA_LDFLAGS_PROGRAM="$EXTRA_LDFLAGS_PROGRAM $PHP_LDFLAGS"
  

--- a/lang/php8/patches/0041-Add-patch-to-remove-build-timestamps-from-generated-.patch
+++ b/lang/php8/patches/0041-Add-patch-to-remove-build-timestamps-from-generated-.patch
@@ -6,7 +6,7 @@ Subject: Add patch to remove build timestamps from generated binaries.
 
 --- a/ext/standard/info.c
 +++ b/ext/standard/info.c
-@@ -791,7 +791,6 @@ PHPAPI ZEND_COLD void php_print_info(int
+@@ -792,7 +792,6 @@ PHPAPI ZEND_COLD void php_print_info(int
  		php_info_print_box_end();
  		php_info_print_table_start();
  		php_info_print_table_row(2, "System", ZSTR_VAL(php_uname));

--- a/lang/php8/patches/1001-ext-opcache-fix-detection-of-shm-mmap.patch
+++ b/lang/php8/patches/1001-ext-opcache-fix-detection-of-shm-mmap.patch
@@ -41,7 +41,7 @@ Signed-off-by: Michael Heimpold <mhei@heimpold.de>
 +    AC_CHECK_FUNC(mmap,[dnl
 +        AC_DEFINE(HAVE_SHM_MMAP_ANON, 1, [Define if you have mmap(MAP_ANON) SHM support])
 +        have_shm_mmap_anon=yes],[have_shm_mmap_anon=no])])
-   AC_MSG_RESULT([$have_shm_mmap_anon=yes])
+   AC_MSG_RESULT([$have_shm_mmap_anon])
  
    PHP_CHECK_FUNC_LIB(shm_open, rt, root)
 @@ -294,8 +300,11 @@ int main() {

--- a/lang/php8/patches/1004-disable-phar-command.patch
+++ b/lang/php8/patches/1004-disable-phar-command.patch
@@ -11,7 +11,7 @@
  
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1423,13 +1423,13 @@ CFLAGS_CLEAN="$CFLAGS \$(PROF_FLAGS)"
+@@ -1434,13 +1434,13 @@ CFLAGS_CLEAN="$CFLAGS \$(PROF_FLAGS)"
  CFLAGS="\$(CFLAGS_CLEAN) $standard_libtool_flag"
  CXXFLAGS="$CXXFLAGS $standard_libtool_flag \$(PROF_FLAGS)"
  

--- a/lang/php8/test.sh
+++ b/lang/php8/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+case "$1" in
+	php8-cgi)
+		php8-cgi -v | grep "$2"
+		;;
+	php8-cli)
+		php8-cli -v | grep "$2"
+		;;
+	php8-fpm)
+		php8-fpm -v | grep "$2"
+		;;
+	php8-mod-*)
+		PHP_MOD="${1#php8-mod-}"
+		PHP_MOD="${PHP_MOD//-/_}"
+
+		opkg install php8-cli
+
+		php8-cli -m | grep -i "$PHP_MOD"
+		;;
+	*)
+		;;
+esac


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs

Description:
This backports all accumulated updates for php8 .