### PR TITLE
[21.02] node: bump to 14.17.4

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v14.17.1
+PKG_VERSION:=v14.17.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=ddf1d2d56ddf35ecd98c5ea5ddcd690b245899f289559b4330c921255f5a247f
+PKG_HASH:=ae7bf4e784f8c8027ffa1e3757f37d2bd5925d0c48988c4d7f07e4515853cf2c
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,6 +1,6 @@
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1202,7 +1202,8 @@ Module._initPaths = function() {
+@@ -1189,7 +1189,8 @@ Module._initPaths = function() {
      path.resolve(process.execPath, '..') :
      path.resolve(process.execPath, '..', '..');
  


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: 21.02, arm
Run tested: (qemu 5.2.0) arm

Description:
Update to v14.17.4

July 2021 Security Releases:

Use after free on close http2 on stream canceling (High) (CVE-2021-22930)
Node.js is vulnerable to a use after free attack where an attacker might be able to exploit the memory corruption, to change process behavior.
You can read more about it in https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22930

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
