### PR TITLE
[21.02] simple-adblock: update to 1.8.7-6

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.8.7
-PKG_RELEASE:=3
+PKG_RELEASE:=6
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 # Copyright 2017-2020 Stan Grishin (stangri@melmac.net)
-# shellcheck disable=SC2039,SC1091,SC2016
+# shellcheck disable=SC2039,SC1091,SC2016,SC3043,SC3057,SC3060
 PKG_VERSION='dev-test'
 
 # shellcheck disable=SC2034
@@ -9,12 +9,20 @@ START=94
 USE_PROCD=1
 LC_ALL=C
 
-extra_command 'check' 'Checks if specified domain is found in current block-list'
-extra_command 'dl' 'Force-downloads all enabled block-list'
-extra_command 'killcache' 'Delete all cached files'
-extra_command 'sizes' 'Displays the file-sizes of enabled block-listo'
-extra_command 'show' 'Shows the service last-run status'
-extra_command 'version' 'Show version information'
+if type extra_command 1>/dev/null 2>&1; then
+	extra_command 'check' 'Checks if specified domain is found in current block-list'
+	extra_command 'dl' 'Force-downloads all enabled block-list'
+	extra_command 'killcache' 'Delete all cached files'
+	extra_command 'sizes' 'Displays the file-sizes of enabled block-lists'
+	extra_command 'version' 'Show version information'
+else
+# shellcheck disable=SC2034
+	EXTRA_COMMANDS='check dl killcache sizes status_service version'
+# shellcheck disable=SC2034
+	EXTRA_HELP='	check	Checks if specified domain is found in current block-list
+	dl	Force-downloads all enabled block-list
+	sizes	Displays the file-sizes of enabled block-lists'
+fi
 
 readonly packageName='simple-adblock'
 readonly serviceName="$packageName $PKG_VERSION"
@@ -574,7 +582,7 @@ process_url() {
 	else
 		type='Allowed'; D_TMP="$A_TMP";
 	fi
-	if [ "${1:0:5}" == "https" ] && [ -z "$isSSLSupported" ]; then
+	if [ "${1:0:5}" = "https" ] && [ -z "$isSSLSupported" ]; then
 		output 1 "$_FAIL_"
 		output 2 "[DL] $type $label $__FAIL__\\n"
 		echo "errorNoSSLSupport|${1}" >> "$sharedMemoryError"
@@ -867,7 +875,7 @@ start_service() {
 	elif [ "$action" = 'restart' ] || [ "$1" = 'restart' ]; then
 		action='restart'
 	elif [ -s "$outputFile" ] && [ "$status" = "statusSuccess" ] && [ -z "$error" ]; then
-		showstatus
+		status_service
 		exit 0
 	else
 		action='download'
@@ -986,12 +994,12 @@ start_service() {
 		jsonOps del message
 		jsonOps set status "statusSuccess"
 		jsonOps set stats "$serviceName is blocking $(wc -l < "$outputFile") domains (with ${targetDNS})"
-		showstatus
+		status_service
 	else
 		output 0 "$__FAIL__\\n";
 		jsonOps set status "statusFail"
 		jsonOps add error "errorOhSnap"
-		showstatus
+		status_service
 	fi
 }
 
@@ -1014,10 +1022,10 @@ killcache() {
 	return 0
 }
 
-show() { showstatus; }
-status_service() { showstatus; }
-showstatus() {
+status_service() {
 	local c url status message error stats
+	config_load "$packageName"
+	config_get verbosity 'config' 'verbosity' '2'
 	status="$(jsonOps get status)"
 	message="$(jsonOps get message)"
 	error="$(jsonOps get error)"
@@ -1041,7 +1049,7 @@ showstatus() {
 				*)
 					output "$_ERROR_: $(getErrorText "$c")!\\n";;
 			esac
-			let n=n+1
+			n=$((n+1))
 		done
 	fi
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-105, 21.02.0-rc4
Run tested: x86_64, Sophos SG-105, 21.02.0-rc4, start, lists download, check blocking, check status

Description:
* supports newer shellcheck
* restore EXTRA_COMMANDS compatibility with 19.07
* move status display from various functions to status_service
* bugfix: status_service line break after output
* minor arythmetic fix in status_service

Signed-off-by: Stan Grishin <stangri@melmac.net>
