### PR TITLE
gnuplot: Updated gnuplot to 5.4.2

### DIFF
--- a/utils/gnuplot/Makefile
+++ b/utils/gnuplot/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnuplot
-PKG_VERSION:=5.4.1
-PKG_RELEASE:=1
+PKG_VERSION:=5.4.2
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Matteo Cicuttin <datafl4sh@toxicnet.eu>
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/gnuplot-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/gnuplot
-PKG_HASH:=6b690485567eaeb938c26936e5e0681cf70c856d273cc2c45fabf64d8bc6590e
+PKG_HASH:=e57c75e1318133951d32a83bcdc4aff17fed28722c4e71f2305cfc2ae1cae7ba
 PKG_CAT:=zcat
 PKG_FIXUP:=autoreconf
 


### PR DESCRIPTION
gnuplot: Updated gnuplot to 5.4.2
    
Maintainer: @datafl4sh
Compile tested: x86, sunxi, bcm27xx
Run tested: x86, sunxi, bcm27xx
    
Description: Updated gnuplot from 5.4.1 to 5.4.2
Signed-off-by: Matteo Cicuttin <datafl4sh@toxicnet.eu>

