### PR TITLE
atlas-sw-probe: fix copypaste error and clean tmp dir on exit

### DIFF
--- a/net/atlas-sw-probe/Makefile
+++ b/net/atlas-sw-probe/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=atlas-sw-probe
 PKG_VERSION:=5020
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/RIPE-NCC/ripe-atlas-software-probe.git

--- a/net/atlas-sw-probe/files/atlas.init
+++ b/net/atlas-sw-probe/files/atlas.init
@@ -100,7 +100,7 @@ create_key() {
 
 	#Link priv/pub key
 	[ -f $PRIV_KEY_FILE ] || ln -s $probe_key $PRIV_KEY_FILE
-	[ -f $PRIV_KEY_FILE ] || ln -s $probe_pub_key $PUB_KEY_FILE
+	[ -f $PUB_KEY_FILE ] || ln -s $probe_pub_key $PUB_KEY_FILE
 
 	#Fix permission
 	chown atlas $probe_key $probe_pub_key
@@ -177,6 +177,9 @@ stop_service() {
 			kill "$tunnel_pid"
 		fi
 	fi
+
+	# Clean run dir
+	rm -r $TMP_BASE_DIR
 }
 
 safe_mkdir() {


### PR DESCRIPTION
- Fix copypaste error for PUB_KEY link creation
- Clean tmp dir on exit to clear any remaining data

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>