### PR TITLE
dnsproxy: Update to 0.39.1

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.39.0
+PKG_VERSION:=0.39.1
 PKG_RELEASE:=$(AUTORELESE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=00cf9978670e51be14cab262638735321afa917c3b4f46c0c5a189731ee124bf
+PKG_HASH:=dcd87517ebb88b899b1f89314cfe2c32d6cb202f9b3f7a6f3173cf951f1c3734
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: ipq807x, rockchip
Run tested: rk3328 nanopi-r2s

Description:
Updated to latest 0.39.1 release.
Related commit: AdguardTeam/dnsproxy@7b49e7c4f30c2f