### PR TITLE
iperf3: add uci server handling

### DIFF
--- a/net/iperf3/Makefile
+++ b/net/iperf3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
 PKG_VERSION:=3.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.es.net/pub/iperf
@@ -63,6 +63,12 @@ define Package/iperf3/description
  characteristics.
 endef
 
+define Package/iperf3/conffiles
+/etc/config/iperf3
+endef
+
+Package/iperf3-ssl/conffiles = $(Package/iperf3/conffiles)
+
 # autoreconf fails if the README file isn't present
 define Build/Prepare
 	$(call Build/Prepare/Default)
@@ -70,11 +76,31 @@ define Build/Prepare
 endef
 
 define Package/iperf3/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/etc/init.d/iperf3 $(1)/etc/init.d/
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/etc/config/iperf3 $(1)/etc/config/
+
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) ./files/usr/libexec/iperf3-ubus-redirect \
+		$(1)/usr/libexec/
+
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/iperf3 $(1)/usr/bin/
 endef
 
 define Package/iperf3-ssl/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/etc/init.d/iperf3 $(1)/etc/init.d/
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/etc/config/iperf3 $(1)/etc/config/
+
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) ./files/usr/libexec/iperf3-ubus-redirect \
+		$(1)/usr/libexec/
+
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/iperf3 $(1)/usr/bin/
 endef

--- a/net/iperf3/files/etc/config/iperf3
+++ b/net/iperf3/files/etc/config/iperf3
@@ -1,0 +1,16 @@
+
+#config server wan
+#	option enabled '1'
+#	option port '5202'
+#	option iface 'wan'
+#	option redirect '1'
+#	option interval '1'
+
+config client internet
+	option server 'speedtest.wtnet.de'
+	option port '5201'
+	option duration '10'
+	option proto 'any'
+	option reverse '0'
+	option udp '1'
+	option redirect '1'

--- a/net/iperf3/files/etc/init.d/iperf3
+++ b/net/iperf3/files/etc/init.d/iperf3
@@ -1,0 +1,140 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+START=50
+PROG_DEFAULT="/usr/bin/iperf3"
+PROG_REDIRECT="/usr/libexec/iperf3-ubus-redirect"
+
+DIR="/var/run/iperf3"
+PIDFILE="${DIR}/pidfile"
+LOGFILE="${DIR}/logfile"
+
+. $IPKG_INSTROOT/lib/functions/network.sh
+
+start_server() {
+	local cfg="$1"
+
+	local enabled port iface interval proto ip redirect prog
+
+	config_get_bool enabled "$cfg" 'enabled' 1
+	[ $enabled -gt 0 ] || return
+
+	rm -f "${LOGFILE}-${cfg}.log"
+
+	config_get port "$cfg" port "5201"
+	if [ -z "$port" ]; then
+		echo "No server port configured" >&2
+		exit 1
+	fi
+
+	config_get proto "$cfg" proto 'any'
+	config_get iface "$cfg" iface ''
+
+	if [ "$proto" = "ipv4" ] && [ "$iface" != '' ]; then
+		network_get_ipaddr ip "$iface"
+	elif [ "$proto" = "ipv6" ] && [ "$iface" != '' ]; then
+		network_get_ipaddr6 ip "$iface"
+	fi
+
+	config_get interval "$cfg" interval '1'
+	config_get_bool redirect "$cfg" 'redirect' 0
+
+	if [ "$redirect" -eq 1 ]; then
+		prog="$PROG_REDIRECT"
+	else
+		prog="$PROG_DEFAULT"
+	fi
+
+	procd_open_instance "$cfg"
+	procd_set_param command "$prog" --server
+	[ -n "$ip" ] && procd_append_param command --bind "$ip"
+	procd_append_param command --port "$port"
+	procd_append_param command --interval "$interval"
+	[ "$redirect" -eq 0 ] && procd_append_param command --logfile "${LOGFILE}-${cfg}.log"
+	procd_append_param command --forceflush
+	procd_set_param pidfile "${PIDFILE}-${cfg}.pid"
+	procd_set_param respawn
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger "iperf3"
+}
+
+start_service() {
+	mkdir -p "$DIR"
+	config_load iperf3
+	config_foreach start_server server
+}
+
+start_client() {
+	local cfg="$1"
+
+	local server port duration reverse proto udp
+	local version redirect json prog
+
+	config_load iperf3
+	config_get server "$cfg" server
+	config_get port "$cfg" port '5201'
+	config_get duration "$cfg" duration '10'
+	config_get_bool reverse "$cfg" reverse '0'
+	config_get_bool udp "$cfg" udp '0'
+
+	config_get proto "$cfg" proto "any"
+	if [ "$proto" = "ipv6" ]; then
+		version="--version6"
+	elif [ "$proto" = "ipv4" ]; then
+		version="--version4"
+	fi
+
+	if [ -z "$server" ]; then
+		echo "No server configured" >&2
+		exit 1
+	fi
+
+	rm -f "${LOGFILE}-${cfg}.log"
+
+	config_get_bool redirect "$cfg" 'redirect' 0
+	config_get_bool json "$cfg" 'json' 0
+
+	if [ "$redirect" -eq 1 ]; then
+		prog="$PROG_REDIRECT"
+	else
+		prog="$PROG_DEFAULT"
+	fi
+
+	procd_open_instance "$cfg"
+	procd_set_param command "$prog"
+	procd_append_param command --client "$server"
+	procd_append_param command --port "$port"
+	procd_append_param command --time "$duration"
+	[ "$proto" != "any" ] && procd_append_param command "$version"
+	[ "$redirect" -eq 0 ] && {
+		procd_append_param command --logfile "${LOGFILE}-${cfg}.log"
+		[ "$json" -eq 1 ] && procd_append_param command --json
+	}
+	[ "$reverse" -eq 1 ] && procd_append_param command --reverse
+	[ "$udp" -eq 1 ] && procd_append_param command --udp
+	procd_append_param command --forceflush
+	procd_close_instance
+}
+
+extra_command "client" "<cfg> Start a client"
+
+client() {
+	local cfg="$1"
+
+	local section_type
+
+	section_type="$(uci_get iperf3 "$cfg")"
+
+	if [ "${section_type}" != "client" ]; then
+		echo "Client config \"${cfg}\" not found."
+		exit 1
+	fi
+
+	mkdir -p "$DIR"
+	rc_procd start_client "$cfg"
+}

--- a/net/iperf3/files/usr/libexec/iperf3-ubus-redirect
+++ b/net/iperf3/files/usr/libexec/iperf3-ubus-redirect
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+trap_with_arg() {
+	local func="$1"; shift
+	local pid="$1"; shift
+
+	for sig in $@; do
+		# shellcheck disable=SC2064
+		trap "$func $sig $pid" "$sig"
+	done
+}
+
+func_trap() {
+	kill "-${1}" "$2" 2>/dev/null
+}
+
+main() {
+	local args="$@"
+	local child
+
+	sh -c "echo \$\$; exec iperf3 $args" | {
+		local ppid
+
+		read -r ppid
+		trap_with_arg func_trap "$ppid" SIGINT SIGTERM SIGKILL
+		while read -r line; do
+			ubus send luci.iperf3.notify.data '{ "line": "'"$line"'" }'
+		done
+	} &
+
+	child=$!
+	kill -SIGSTOP $child
+	trap_with_arg func_trap "$child" SIGINT SIGTERM SIGKILL
+	kill -SIGCONT $child
+	wait $child
+}
+
+main "$@"


### PR DESCRIPTION
Maintainer: @pprindeville
Compile tested: not needed only script changes
Run tested: x86_64, APU3, latest openwrt master (iperf3 with uci client/server)

Server iperf3 uci config
```
config server lan
        option enabled '1'
        option port '5202'
        option iface 'lan'
        option redirect '1'
```

Client iperf3 uci config:
```
config client lan
        option server '192.168.0.53'
        option port '5202'
        option proto 'ipv4'
        option redirect '1'
```

Execute the command `/etc/init.d/perf3 client lan` to start a scan against the server und the client device

Description:

As discussed an suggest in the [P/R](https://github.com/openwrt/luci/pull/4651) I have extended the iperf3.
With the following improvements.

- Add uci hanndling
- Redirect output to `ubus listen luci.iperf3.notify.data` As for the path, I'm not sure whether we should use luci or something else. Suggestions are welcome ;-)

This commits adds the possibility that iperf3 can be configured via
the uci. The functionality has also been extended so that the output of
iperf3 (server/client) sends a notification event via the ubus to the  `luci.iperf3.notify.data` endpoint.


@stangri @wjowsa Could you also look at my proposal? I think this is a generally valid proposal and would simplify the LuCI. You just have to figure out how to subscribe to the ubus notification in the LuCI and show them.

Then, from my point of view, we would no longer need this [patch](https://patchwork.ozlabs.org/project/openwrt/patch/20201110080209.6368-1-wojciech.jowsa@gmail.com/) and could move on. As discussed with @jow- a while a go this has some security issues.

