### PR TITLE
fix "extra_command: not found" in nginx

### DIFF
--- a/net/nginx/files/nginx.init
+++ b/net/nginx/files/nginx.init
@@ -66,7 +66,7 @@ reload_service() {
 }
 
 
-extra_command "relog" "Reopen log files (without reloading)"
+# extra_command "relog" "Reopen log files (without reloading)"
 relog() {
 	[ -d /var/log/nginx ] || mkdir -p /var/log/nginx
 	procd_send_signal nginx '*' USR1


### PR DESCRIPTION


Maintainer: @lqzhgood
Compile tested: not needed
Run tested: x86_64, latest openwrt master

Description:
fix "extra_command: not found" in  `/etc/init.d/nginx start`