### PR TITLE
python3-distro: update to version 1.6.0

### DIFF
--- a/lang/python/python-distro/Makefile
+++ b/lang/python/python-distro/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-distro
-PKG_VERSION:=1.5.0
-PKG_RELEASE:=3
+PKG_VERSION:=1.6.0
+PKG_RELEASE:=1
 
 PYPI_NAME:=distro
-PKG_HASH:=0e58756ae38fbd8fc3020d54badb8eae17c5b9dcbed388b17bb55b8a5928df92
+PKG_HASH:=83f5e5a09f9c5f68f60173de572930effbcc0287bb84fdc4426cb4168c088424
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0
@@ -20,7 +20,7 @@ define Package/python3-distro
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Distro - an OS platform information API
-  URL:=https://github.com/nir0s/distro
+  URL:=https://github.com/python-distro/distro
   DEPENDS:=+python3-light +python3-logging
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86-64
Run tested: master x86-64

Description:
New upstream update