### PR TITLE
stubby: Add multi WAN support for procd trigger

### DIFF
--- a/net/stubby/Makefile
+++ b/net/stubby/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stubby
 PKG_VERSION:=0.4.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/getdnsapi/$(PKG_NAME)

--- a/net/stubby/files/stubby.init
+++ b/net/stubby/files/stubby.init
@@ -266,9 +266,12 @@ service_triggers()
     trigger="$(uci_get stubby global trigger)"
     delay="$(uci_get stubby global triggerdelay "2")"
 
-    if [ "$trigger" != "none" ] && [ "$trigger" != "timed" ]; then
-        PROCD_RELOAD_DELAY=$((${delay:-2} * 1000))
-        procd_add_interface_trigger "interface.*.up" "$trigger" "$stubby_init" start
-    fi
+    PROCD_RELOAD_DELAY=$((${delay:-2} * 1000))
+
+    for trigger_item in $trigger
+    do
+        procd_add_interface_trigger "interface.*.up" "$trigger_item" "$stubby_init" start
+    done
+
     procd_add_reload_trigger "stubby"
 }


### PR DESCRIPTION
Maintainer: No one, previous maintainer no longer wishes to be a maintainer see https://github.com/openwrt/packages/issues/15723#issuecomment-860279906

Compile tested: N/A
Run tested: Linksys WRT3200ACM OpenWrt 19.07.7

Description:

This adds multi WAN trigger support for stubby, in the stubby config you can now supply multiple WAN interfaces separated with a space, currently you cannot do this. For multi WAN environments you would most likely want to have Stubby be able to have triggers on multiple WAN interfaces to not break DNS resolution if a WAN interface goes down.

Original credit/author: https://forum.openwrt.org/t/stubby-option-trigger-help/56694

As this is minor change to the init script, can this also be cherry picked across 21.02 and 19.07?
