### PR TITLE
[19.07] stubby: Add multi WAN support for procd trigger

### DIFF
--- a/net/stubby/files/stubby.init
+++ b/net/stubby/files/stubby.init
@@ -268,7 +268,10 @@ service_triggers()
 
     if [ "$trigger" != "none" ] && [ "$trigger" != "timed" ]; then
         PROCD_RELOAD_DELAY=$((${delay:-2} * 1000))
-        procd_add_interface_trigger "interface.*.up" "$trigger" "$stubby_init" start
+        for trigger_item in $trigger
+        do
+            procd_add_interface_trigger "interface.*.up" "$trigger_item" "$stubby_init" start
+        done
     fi
     procd_add_reload_trigger "stubby"
 }


### PR DESCRIPTION
Maintainer: No one, previous maintainer no longer wishes to be a maintainer see https://github.com/openwrt/packages/issues/15723#issuecomment-860279906

Compile tested: N/A
Run tested: Linksys WRT3200ACM OpenWrt 19.07.7

Description:

This adds multi WAN trigger support for stubby, in the stubby config you can now supply multiple WAN interfaces separated with a space, currently you cannot do this. For multi WAN environments you would most likely want to have Stubby be able to have triggers on multiple WAN interfaces to not break DNS resolution if a WAN interface goes down.

Original credit/author: https://forum.openwrt.org/t/stubby-option-trigger-help/56694
