### PR TITLE
[21.02] libxslt: fix compilation because of wrong libxml2 check in configure script

### DIFF
--- a/libs/libxslt/patches/010-fix-xml2-config-check.patch
+++ b/libs/libxslt/patches/010-fix-xml2-config-check.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -546,7 +546,7 @@ dnl make sure xml2-config is executable,
+ dnl test version and init our variables
+ dnl
+ 
+-if test "x$LIBXML_LIBS" = "x" && ${XML_CONFIG} --libs print > /dev/null 2>&1
++if test "x$LIBXML_LIBS" = "x" && ${XML_CONFIG} --libs > /dev/null 2>&1
+ then
+     AC_MSG_CHECKING(for libxml libraries >= $LIBXML_REQUIRED_VERSION)
+     XMLVERS=`$XML_CONFIG --version`


### PR DESCRIPTION
Compilation failed after libxml2 update. More details: https://github.com/GNOME/libxslt/commit/90c34c8bb90e095a8a8fe8b2ce368bd9ff1837cc
