### PR TITLE
knot: update to version 3.1.0, knot-resolver: update to version 5.4.0

### DIFF
--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -10,12 +10,12 @@ PKG_RELRO_FULL:=0
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot-resolver
-PKG_VERSION:=5.3.2
-PKG_RELEASE:=2
+PKG_VERSION:=5.4.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-resolver
-PKG_HASH:=8b6f447d5fe93422d4c129a2d4004a977369c3aa6e55258ead1cbd488bc01436
+PKG_HASH:=534af671b98433b23b57039acc9d7d3c100a4888a8cf9aeba36161774ca0815e
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=GPL-3.0-later
@@ -57,6 +57,7 @@ define Package/knot-resolver/config
 	source "$(SOURCE)/Config.in"
 endef
 
+# kres_gen_test breaks on cross, fix is already upstream
 MESON_ARGS+= \
 	$(if $(CONFIG_PACKAGE_knot-resolver_dnstap), -Ddnstap=enabled,-Ddnstap=disabled) \
 	-Dcapng=disabled \
@@ -69,6 +70,7 @@ MESON_ARGS+= \
 	-Dkeyfile_default=/etc/knot-resolver/root.keys \
 	-Dprefix=/usr \
 	-Dunit_tests=disabled \
+	-Dkres_gen_test=false \
 	-Dutils=disabled
 
 define Package/knot-resolver/install

--- a/net/knot-resolver/patches/030-fix-policy-hack.patch
+++ b/net/knot-resolver/patches/030-fix-policy-hack.patch
@@ -2,7 +2,7 @@ This patch fixes the problem with forwarding in knot-resolver v4.3.0.
 It reintroduces a fix which enables  policy related hack (knot/knot-resolver#205 (comment 94566) )
 --- a/modules/policy/policy.lua
 +++ b/modules/policy/policy.lua
-@@ -982,7 +982,7 @@ policy.layer = {
+@@ -984,7 +984,7 @@ policy.layer = {
  		if bit.band(state, bit.bor(kres.FAIL, kres.DONE)) ~= 0 then return state end
  		local qry = req:initial() -- same as :current() but more descriptive
  		return policy.evaluate(policy.rules, req, qry, state)

--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014-2019 CZ.NIC, z.s.p.o. <knot-dns@labs.nic.cz>
+# Copyright (C) 2014-2021 CZ.NIC, z.s.p.o. <knot-dns@labs.nic.cz>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.0.8
+PKG_VERSION:=3.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=df723949c19ebecf9a7118894c3127e292eb09dc7274b5ce9b527409f42edfb0
+PKG_HASH:=54323712e3cbc3d4c70a15777818fd2ff0de30cebb6c22e2946372b15b2653ed
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8

--- a/net/knot/patches/01_zscanner_tests.patch
+++ b/net/knot/patches/01_zscanner_tests.patch
@@ -19,5 +19,5 @@
 -ZSCANNER_TOOL="$BUILD"/zscanner-tool
 +ZSCANNER_TOOL="$SOURCE"/zscanner-tool
  
- plan 84
+ plan 86
  


### PR DESCRIPTION
Maintainer: @ja-pa, @salzmdan
Compile tested: armv7, Turris Omnia, OpenWrt master, aarch64, Turris MOX
Run tested: Turris MOX, aarch64

Description: updating knot to 3.1.0 changes soname, and knot-resolver supports knot 3.1 from version 5.4.0, so both updates are in the same PR. For cross, kres_gen_test needs to be disabled, it is already fixed upstream.
cc @BKPepe