### PR TITLE
kea: add init script and hooks to support HA

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -183,6 +183,17 @@ Control Agent.
 endef
 
 ###### *************************************************************************
+define Package/kea-uci
+	$(call Package/kea/Default)
+	TITLE+=UCI support
+	DEPENDS:=@(PACKAGE_kea-ctrl||PACKAGE_kea-dhcp4||PACKAGE_kea-dhcp6||PACKAGE_kea-dhcp-ddns)
+endef
+define Package/kea-uci/description
+	Kea PROCD/UCI support. This package installs a UCI config file and
+	a PROCD service file.
+endef
+
+###### *************************************************************************
 HOST_CONFIGURE_ARGS += \
 	--with-boost-include="$(STAGING_DIR_HOSTPKG)" \
 	--with-log4cplus="$(STAGING_DIR_HOSTPKG)" \
@@ -296,6 +307,12 @@ define Package/kea-shell/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/kea-shell $(1)/usr/sbin/kea-shell
 endef
 
+define Package/kea-uci/install
+	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/init.d
+	$(INSTALL_CONF) ./files/kea.config $(1)/etc/config/kea
+	$(INSTALL_BIN) ./files/kea.init $(1)/etc/init.d/kea
+endef
+
 $(eval $(call HostBuild))
 $(eval $(call BuildPackage,kea-libs))
 $(eval $(call BuildPackage,kea-ctrl))
@@ -308,3 +325,4 @@ $(eval $(call BuildPackage,kea-hook-lease-cmds))
 $(eval $(call BuildPackage,kea-lfc))
 $(eval $(call BuildPackage,kea-perfdhcp))
 $(eval $(call BuildPackage,kea-shell))
+$(eval $(call BuildPackage,kea-uci))

--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -120,6 +120,16 @@ define Package/kea-admin/description
 checking versions, upgrading etc.).
 endef
 
+###### *************************************************************************
+define Package/kea-hook-lease-cmds
+	$(call Package/kea/Default)
+	TITLE+=Lease Commands hook library
+	DEPENDS:=+kea-libs
+endef
+define Package/kea-hook-lease-cmds/description
+	The lease commands hook library.
+endef
+
 ##### *************************************************************************
 define Package/kea-lfc
 	$(call Package/kea/Default)
@@ -235,6 +245,11 @@ define Package/kea-admin/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/kea-admin $(1)/usr/sbin/kea-admin
 endef
 
+define Package/kea-hook-lease-cmds/install
+	$(INSTALL_DIR) $(1)/usr/lib/kea/hooks
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/kea/hooks/libdhcp_lease_cmds.so $(1)/usr/lib/kea/hooks
+endef
+
 define Package/kea-ctrl/install
 	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/kea
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/keactrl $(1)/usr/sbin/keactrl
@@ -265,6 +280,7 @@ $(eval $(call BuildPackage,kea-dhcp4))
 $(eval $(call BuildPackage,kea-dhcp6))
 $(eval $(call BuildPackage,kea-dhcp-ddns))
 $(eval $(call BuildPackage,kea-admin))
+$(eval $(call BuildPackage,kea-hook-lease-cmds))
 $(eval $(call BuildPackage,kea-lfc))
 $(eval $(call BuildPackage,kea-perfdhcp))
 $(eval $(call BuildPackage,kea-shell))

--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -39,6 +39,14 @@ define Package/kea/Default
   URL:=https://www.isc.org/kea
 endef
 
+define Package/kea/conffiles
+/etc/kea/
+endef
+
+Package/kea-ctrl/conffiles = $(Package/kea/conffiles)
+Package/kea-dhcp4/conffiles = $(Package/kea/conffiles)
+Package/kea-dhcp6/conffiles = $(Package/kea/conffiles)
+Package/kea-dhcp-ddns/conffiles = $(Package/kea/conffiles)
 
 ###### *************************************************************************
 define Package/kea

--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -121,6 +121,16 @@ checking versions, upgrading etc.).
 endef
 
 ###### *************************************************************************
+define Package/kea-hook-ha
+	$(call Package/kea/Default)
+	TITLE+=High Availability hook library
+	DEPENDS:=+kea-libs +kea-hook-lease-cmds
+endef
+define Package/kea-hook-ha/description
+	The high availability hook library.
+endef
+
+###### *************************************************************************
 define Package/kea-hook-lease-cmds
 	$(call Package/kea/Default)
 	TITLE+=Lease Commands hook library
@@ -245,6 +255,11 @@ define Package/kea-admin/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/kea-admin $(1)/usr/sbin/kea-admin
 endef
 
+define Package/kea-hook-ha/install
+	$(INSTALL_DIR) $(1)/usr/lib/kea/hooks
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/kea/hooks/libdhcp_ha.so $(1)/usr/lib/kea/hooks
+endef
+
 define Package/kea-hook-lease-cmds/install
 	$(INSTALL_DIR) $(1)/usr/lib/kea/hooks
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/kea/hooks/libdhcp_lease_cmds.so $(1)/usr/lib/kea/hooks
@@ -280,6 +295,7 @@ $(eval $(call BuildPackage,kea-dhcp4))
 $(eval $(call BuildPackage,kea-dhcp6))
 $(eval $(call BuildPackage,kea-dhcp-ddns))
 $(eval $(call BuildPackage,kea-admin))
+$(eval $(call BuildPackage,kea-hook-ha))
 $(eval $(call BuildPackage,kea-hook-lease-cmds))
 $(eval $(call BuildPackage,kea-lfc))
 $(eval $(call BuildPackage,kea-perfdhcp))

--- a/net/kea/files/kea.config
+++ b/net/kea/files/kea.config
@@ -1,0 +1,11 @@
+config service 'ctrl_agent'
+	option disabled '1'
+
+config service 'dhcp4'
+	option disabled '1'
+
+config service 'dhcp6'
+	option disabled '1'
+
+config service 'dhcp_ddns'
+	option disabled '1'

--- a/net/kea/files/kea.init
+++ b/net/kea/files/kea.init
@@ -1,0 +1,41 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=25
+STOP=85
+
+BIN_PATH="/usr/sbin"
+CONF_PATH="/etc/kea"
+
+start_service() {
+	config_load "kea"
+	config_foreach start_kea "service"
+}
+
+start_kea() {
+	local cfg="$1"
+
+	config_get_bool disabled "$cfg" disabled 0
+	[ "$disabled" = "0" ] || return
+
+	config_get name "$cfg" name "$cfg"
+
+	case "$name" in
+		ctrl_agent|dhcp4|dhcp6|dhcp_ddns)
+			name="${name/_/-}"
+			cmd="${BIN_PATH}/kea-${name}"
+			cnf="${CONF_PATH}/kea-${name}.conf"
+			;;
+		*)
+			return 0
+	esac
+
+	procd_open_instance "$name"
+	procd_set_param command "$cmd" -c "$cnf"
+	procd_set_param env KEA_LOCKFILE_DIR=/tmp
+	procd_append_param env KEA_PIDFILE_DIR=/tmp
+	procd_set_param file "$cnf"
+	procd_set_param stderr 1
+	procd_set_param stdout 1
+	procd_close_instance ctrl_agent
+}


### PR DESCRIPTION
Maintainer: @rosysong 
Compile tested: OpenWrt master r17265-e3096c384c on mvebu
Run tested: OpenWrt master r17265-e3096c384c on mvebu

Description:
This PR adds 2 hooks that are required to run Kea in High-Availability mode, defines conffiles so configuration survives reboot, and adds a procd init script that can start all 4 services if they are not disabled in UCI.