### PR TITLE
modemmanager: support setting plmn

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_SOURCE_VERSION:=1.20.6
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/README.md
+++ b/net/modemmanager/README.md
@@ -22,6 +22,7 @@ Once installed, you can configure the 2G/3G/4G modem connections directly in
         option password    'vodafone'
         option pincode     '7423'
         option iptype      'ipv4'
+        option plmn        '214001'
         option lowpower    '1'
         option signalrate  '30'
 
@@ -35,6 +36,8 @@ allowing all protocols.
 
 The 'iptype' option supports any of these values: 'ipv4', 'ipv6' or 'ipv4v6'.
 It will default to 'ipv4' if not given.
+
+The 'plmn' option allows to set the network operator MCCMNC.
 
 The 'signalrate' option set's the signal refresh rate (in seconds) for the device.
 You can call signal info with command: mmcli -m 0 --signal-get

--- a/net/modemmanager/files/modemmanager.proto
+++ b/net/modemmanager/files/modemmanager.proto
@@ -343,6 +343,7 @@ proto_modemmanager_init_config() {
 	proto_config_add_string	 password
 	proto_config_add_string	 pincode
 	proto_config_add_string	 iptype
+	proto_config_add_string	 plmn
 	proto_config_add_int	 signalrate
 	proto_config_add_boolean lowpower
 	proto_config_add_defaults
@@ -355,11 +356,11 @@ proto_modemmanager_setup() {
 	local bearermethod_ipv4 bearermethod_ipv6 auth cliauth
 	local operatorname operatorid registration accesstech signalquality
 
-	local device apn allowedauth username password pincode iptype metric signalrate
+	local device apn allowedauth username password pincode iptype plmn metric signalrate
 
 	local address prefix gateway mtu dns1 dns2
 
-	json_get_vars device apn allowedauth username password pincode iptype metric signalrate
+	json_get_vars device apn allowedauth username password pincode iptype plmn metric signalrate
 
 	# validate sysfs path given in config
 	[ -n "${device}" ] || {
@@ -392,7 +393,7 @@ proto_modemmanager_setup() {
 	echo "starting connection with apn '${apn}'..."
 	proto_notify_error "${interface}" MM_CONNECT_IN_PROGRESS
 
-	connectargs="apn=${apn}${iptype:+,ip-type=${iptype}}${cliauth:+,allowed-auth=${cliauth}}${username:+,user=${username}}${password:+,password=${password}}${pincode:+,pin=${pincode}}"
+	connectargs="apn=${apn}${iptype:+,ip-type=${iptype}}${plmn:+,operator-id=${plmn}}${cliauth:+,allowed-auth=${cliauth}}${username:+,user=${username}}${password:+,password=${password}}${pincode:+,pin=${pincode}}"
 	mmcli --modem="${device}" --timeout 120 --simple-connect="${connectargs}" || {
 		proto_notify_error "${interface}" MM_CONNECT_FAILED
 		proto_block_restart "${interface}"


### PR DESCRIPTION
Maintainer: @nickberry17 
Compile tested: no (changed bash script only)
Run tested: ramips, DWR-921, openwrt-19.07 branch (git-21.044.30835-34e0d65) / OpenWrt 19.07.7 r11306-c4a6851c72

Tested connection using netifd with and without plmn setting

Description: 
This change allows to set network operator MCC:MNC and connect to different network with better signal quality and speed.
