### PR TITLE
sudo: bump to version 1.9.7p2

### DIFF
--- a/admin/sudo/Makefile
+++ b/admin/sudo/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sudo
-PKG_VERSION:=1.9.7
-PKG_RELEASE:=1
+PKG_VERSION:=1.9.7p2
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.sudo.ws/dist
-PKG_HASH:=2bbe7c2d6699b84d950ef9a43f09d4d967b8bc244b73bc095c4202068ddbe549
+PKG_HASH:=28b5ee725dbf89a7852f42f309ca877d2810a9531b4eecfe59f3a84b6b4afca8
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 

--- a/admin/sudo/patches/010-cross-compile-fixes.patch
+++ b/admin/sudo/patches/010-cross-compile-fixes.patch
@@ -1,6 +1,6 @@
 --- a/lib/util/Makefile.in
 +++ b/lib/util/Makefile.in
-@@ -221,10 +221,10 @@ libsudo_util.la: $(LTOBJS) @LT_LDDEP@
+@@ -223,10 +223,10 @@ libsudo_util.la: $(LTOBJS) @LT_LDDEP@
  	esac
  
  siglist.c: mksiglist


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/7057e054855561e7695c4e9a14de38e39217041a
Run tested: x86  https://github.com/openwrt/openwrt/commit/7057e054855561e7695c4e9a14de38e39217041a

-------------------------------------------------------------------

Also switch to AUTORELEASE for PKG_RELEASE.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>