### PR TITLE
redis: update to version 6.2.5

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
-PKG_VERSION:=6.2.4
+PKG_VERSION:=6.2.5
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=ba32c406a10fc2c09426e2be2787d74ff204eb3a2e496d87cff76a476b6ae16e
+PKG_HASH:=4b9a75709a1b74b3785e20a6c158cab94cf52298aa381eea947a678a60d551ae
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS7), OpenWrt master
Run tested: Turris Omnia (TOS7), OpenWrt master

Description:
This PR updates redis to version 6.2.5. Changelog https://raw.githubusercontent.com/redis/redis/6.2/00-RELEASENOTES
and fixes CVE-2021-32761 on 32bit systems.

Upgrade urgency SECURITY

