### PR TITLE
collectd: select interface by default

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -377,6 +377,7 @@ define BuildPlugin
   $$(call Package/collectd/Default)
     TITLE:=$(2) plugin
     DEPENDS:= collectd $(4)
+    DEFAULT:=$(if $(subst interface,,$(1)),n,y)
   endef
 
   define Package/collectd-mod-$(1)/install


### PR DESCRIPTION
this is needed for commit in luci which allows disabling interface to keep default config as it is