### PR TITLE
syncthing: update to version 1.18.1

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.18.0
+PKG_VERSION:=1.18.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=169d3579b74083d4115b4d324620a7f0888e4b1a3ad3dac71d46d76d51322900
+PKG_HASH:=3f6b8e87a59e72ab3389d89364524e6abec454d4c36aaf3e334ac6fe37915584
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 


### PR DESCRIPTION
Maintainer: @aparcar
Compile tested: armv7, Turris Omnia, OpenWrt 21.02-rc4
Run tested: armv7, Turris Omnia, OpenWrt 21.02-rc4, run, add one remote, sync a few files

Description: this is a bugfix release, changelog: https://github.com/syncthing/syncthing/releases/tag/v1.18.1
