### PR TITLE
stress-ng: add missing libkmod dependency

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -27,7 +27,7 @@ define Package/stress-ng
   CATEGORY:=Utilities
   TITLE:=stress-ng is a stress test utility
   URL:=https://kernel.ubuntu.com/~cking/stress-ng/
-  DEPENDS:=+zlib +libbsd +libaio +libsctp
+  DEPENDS:=+zlib +libbsd +libaio +libsctp +libkmod
 endef
 
 define Package/stress-ng/description


### PR DESCRIPTION
This fixes build problem introduced in commit 9a1bb4baf55f ("stress-ng: bump to version 0.13.00"):
Package stress-ng is missing dependencies for the following libraries:
libkmod.so.2

Fixes: 9a1bb4baf55f ("stress-ng: bump to version 0.13.00")
Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>

Maintainer: @commodo
Compile tested: Netgear XR700  OpenWrt SNAPSHOT r17335-5337e42a8be7
Run tested: Netgear XR700  OpenWrt SNAPSHOT r17335-5337e42a8be7
