### PR TITLE
lua-rs232: don't rely on detected luadir

### DIFF
--- a/lang/lua-rs232/Makefile
+++ b/lang/lua-rs232/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=lua-rs232
 PKG_SOURCE_DATE:=2019-11-20
 PKG_SOURCE_VERSION:=c106c94d1a5a84e8582c936528303528608776c2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/srdgame/librs232
@@ -42,6 +42,7 @@ endef
 
 TARGET_CFLAGS += -ffunction-sections -fdata-sections
 TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
+MAKE_FLAGS += luadir='$$$${prefix}/lib/lua' luaexecdir='$$$${exec_prefix}/lib/lua'
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/librs232
@@ -49,7 +50,7 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/librs232* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/lua
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/lua/5.1/luars232* $(1)/usr/lib/lua
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/lua/luars232* $(1)/usr/lib/lua
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/librs232.pc $(1)/usr/lib/pkgconfig
 endef
@@ -58,7 +59,7 @@ define Package/lua-rs232/install
 	$(INSTALL_DIR) $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/librs232.so* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/lua
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/lua/5.1/luars232* $(1)/usr/lib/lua
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/lua/luars232* $(1)/usr/lib/lua
 endef
 
 $(eval $(call BuildPackage,lua-rs232))


### PR DESCRIPTION
Maintainer: @srdgame 
Compile tested: mvebu, openwrt master
Run tested: N/A

Description:
If TOPDIR starts with `/usr`, then the configure script will use the staging tree hierarchy instead of using plain /usr/lib.  For example, if `TOPDIR=/usr/src/openwrt`, then the files will not be available under `$(PKG_INSTALL_DIR)/usr/lib/lua/5.1/`, as expected, but under `$(PKG_INSTALL_DIR)/usr/src/openwrt/staging_dir/hostpkg/lib/lua/5.1/`.

Set the correct path when calling 'make'.  As a bonus, the hardcoded version number in the Makefile can be dropped.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

Here's a build log showing the error.  Here, you can see the files being installed into `/usr/local/src/openwrt/build_dir/target-arm_cortex-a9+neon_musl_eabi/lua-rs232-2019-11-20-c106c94d/ipkg-install/usr/local/src/openwrt/staging_dir/hostpkg/lib/lua/5.1`
```
make[6]: Entering directory '/usr/local/src/openwrt/build_dir/target-arm_cortex-a9+neon_musl_eabi/lua-rs232-2019-11-20-c106c94d/bindings/lua'
make[7]: Entering directory '/usr/local/src/openwrt/build_dir/target-arm_cortex-a9+neon_musl_eabi/lua-rs232-2019-11-20-c106c94d/bindings/lua'
 /bin/mkdir -p '/usr/local/src/openwrt/build_dir/target-arm_cortex-a9+neon_musl_eabi/lua-rs232-2019-11-20-c106c94d/ipkg-install/usr/local/src/openwrt/staging_dir/hostpkg/lib/lua/5.1'
 /bin/sh ../../libtool   --mode=install /usr/local/src/openwrt/staging_dir/host/bin/install -c   luars232.la '/usr/local/src/openwrt/build_dir/target-arm_cortex-a9+neon_musl_eabi/lua-rs232-2019-11-20-c106c94d/ipkg-install/usr/local/src/openwrt/staging_dir/hostpkg/lib/lua/5.1'
```
And then when we want to package these files, we're expecting them at `/usr/local/src/openwrt/build_dir/target-arm_cortex-a9+neon_musl_eabi/lua-rs232-2019-11-20-c106c94d/ipkg-install/usr/lib/lua/5.1`
```
install: cannot stat '/usr/local/src/openwrt/build_dir/target-arm_cortex-a9+neon_musl_eabi/lua-rs232-2019-11-20-c106c94d/ipkg-install/usr/lib/lua/5.1/luars232*': No such file or directory
make[3]: *** [Makefile:69: /usr/local/src/openwrt/build_dir/target-arm_cortex-a9+neon_musl_eabi/lua-rs232-2019-11-20-c106c94d/.pkgdir/lua-rs232.installed] Error 1
```

Since we are installing them without the `/5.1/` directory, we might as well set `luadir` without it.