### PR TITLE
ksmbd: use hostname only as name

### DIFF
--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
 PKG_VERSION:=3.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/ksmbd-tools/tar.gz/$(PKG_VERSION)?

--- a/net/ksmbd-tools/files/ksmbd.init
+++ b/net/ksmbd-tools/files/ksmbd.init
@@ -27,7 +27,7 @@ smb_header()
 	)
 
 	# we dont use netbios anymore as default and wsd/avahi is dns based
-	hostname="$(cat /proc/sys/kernel/hostname | tr -d '{};%?=#\n')"
+	hostname="$(sed 's/\..*//' /proc/sys/kernel/hostname | tr -d '{};%?=#\n')"
 
 	config_get_sane workgroup "$1" workgroup "WORKGROUP"
 	config_get_sane description "$1" description "Ksmbd on OpenWrt"


### PR DESCRIPTION
even if a fqdn (with domain) is set by user
