### PR TITLE
knot: update to version 3.1.1

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.1.0
+PKG_VERSION:=3.1.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=54323712e3cbc3d4c70a15777818fd2ff0de30cebb6c22e2946372b15b2653ed
+PKG_HASH:=75bfb1acaca774ed3dd781dc74780298dc0fd51b54e4b61015e7487d6cd2067c
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 6.0 (hbd)
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 5.1.10 (hbs), all tests successful (1 skipped)

Description:

- Release patch