### PR TITLE
tinc: use 'uci_get_state' instead of 'uci -P /var/state get'

### DIFF
--- a/net/tinc/Makefile
+++ b/net/tinc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tinc
 PKG_VERSION:=1.1-git
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=http://tinc-vpn.org/git/tinc

--- a/net/tinc/files/tinc.init
+++ b/net/tinc/files/tinc.init
@@ -61,7 +61,7 @@ append_conf_params() {
 		for v in $v; do
 			# Look up OpenWRT interface names
 			[ "$p" = "BindToInterface" ] && {
-				local ifname=$(uci -P /var/state get network.$v.ifname 2>&-)
+				local ifname=$(uci_get_state network "$v" ifname "")
 				[ -n "$ifname" ] && v="$ifname"
 			}
 


### PR DESCRIPTION
Maintainer: @ErwanMAS 
Compile tested: NO
Run tested: NO

Description:
This package is not broken by the network config ifname -> device transition, but I do think it's cleaner to use uci_get_state wrapper


