### PR TITLE
nft-qos: simplify ifname retrieval

### DIFF
--- a/net/nft-qos/Makefile
+++ b/net/nft-qos/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nft-qos
 PKG_VERSION:=1.0.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPL-2.0
 
 PKG_MAINTAINER:=Rosy Song <rosysong@rosinson.com>


### PR DESCRIPTION
Maintainer: @rosysong 
Compile tested: NO
Run tested: NO
Description:

network_get_device should be enough, and since https://git.openwrt.org/?p=openwrt/openwrt.git;a=commitdiff;h=4b9a67362d70c544b85078b8d5c661f43f7472d9
uci network config interface sections use 'device' instead of 'ifname',
rendering the fallback useless

Creating as draft as this needs testing by someone before merging
