### PR TITLE
django: bump to version 3.2.6

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=3.2.5
-PKG_RELEASE:=1
+PKG_VERSION:=3.2.6
+PKG_RELEASE:=$(AUTORELEASE)
 
 PYPI_NAME:=Django
-PKG_HASH:=3da05fea54fdec2315b54a563d5b59f3b4e2b1e69c3a5841dda35019c01855cd
+PKG_HASH:=f27f8544c9d4c383bbe007c57e3235918e258364577373d4920e9162837be022
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Peter Stadler <peter.stadler@student.uibk.ac.at>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me, @peter-stadler 
Compile tested: x86 https://github.com/openwrt/openwrt/commit/7057e054855561e7695c4e9a14de38e39217041a
Run tested: x86 https://github.com/openwrt/openwrt/commit/7057e054855561e7695c4e9a14de38e39217041a

--------------------------------------------------------------------------------

And switch to AUTORELEASE for PKG_RELEASE.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>