### PR TITLE
acpica: bump to 20210730

### DIFF
--- a/utils/acpica-unix/Makefile
+++ b/utils/acpica-unix/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acpica-unix
-PKG_VERSION:=20181213
+PKG_VERSION:=20210730
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://acpica.org/sites/$(patsubst %-unix,%,$(PKG_NAME))/files/$(PKG_SOURCE_URL)
-PKG_HASH:=fc90006775c635ba86c5bbf08590ac98ab10e1f9eff6d8951385f57dd3a6f8ed
+PKG_HASH:=4a0c14d5148666612aa0555c5179eaa86230602394fd1bc3d16b506fcf49b5de
 PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>
 
 PKG_LICENSE:=GPL-2.0


### PR DESCRIPTION
Maintainer: @pprindeville 
Compile tested: OpenWrt master r17276-b1bff5cb57 x86/64
Run tested: no, please suggest reliable test

Description:
Fixes compilation with GCC 10.