### PR TITLE
collectd-mod-ping: add support for MaxMissed

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.12.0
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \

--- a/utils/collectd/files/usr/share/collectd/plugin/ping.json
+++ b/utils/collectd/files/usr/share/collectd/plugin/ping.json
@@ -1,7 +1,8 @@
 {
 	"string": [
 		"TTL",
-		"Interval"
+		"Interval",
+		"MaxMissed"
 	],
 	"list": [
 		"Host"


### PR DESCRIPTION
Signed-off-by: John Kohl <jtk@bostonpog.org>

Maintainer: Florian Eckert <fe@dev.tdt.de> @feckert
Compile tested: ipq40xx, Linksys MR8300, 21.02.0-rc4
Run tested: ipq40xx, Linksys MR8300, 21.02.0-rc4

I tested setting the value to -1 does not re-resolve hosts after pings fail.
Watched DNS traffic with tcpdump to see that setting the value to positive integer results in a DNS re-resolve after that many ping failures.  I swapped my phone between two networks reachable from the same router, and saw that after switching networks, collectd switched to pinging the new address after the desired number of failures.

`/etc/collectd.conf` ping section set like this:
```
LoadPlugin ping
<Plugin ping>
	TTL 127
	Interval 10
	AddressFamily any
	MaxMissed 10
	Host "redgarage.lan"
	Host "front-porch-cam.lan"
	Host "back-yard-cam.lan"
	Host "192.168.1.1"
	Host "homeautohub.lan"
</Plugin>
```

Description:

Add support for MaxMissed in collectd-mod-ping.  This is documented in collectd:
https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_ping

This is most usable with a corresponding change to luci-app-statistics to accept hostnames and setting of MaxMissed.
https://github.com/openwrt/luci/pull/5269