### PR TITLE
tcpreplay: avoid host lib leakage

### DIFF
--- a/net/tcpreplay/Makefile
+++ b/net/tcpreplay/Makefile
@@ -131,7 +131,8 @@ CONFIGURE_VARS += \
 	ac_cv_lib_nl_nl_cache_alloc=no \
 	ac_cv_lib_nl_genl_3_genl_connect=no \
 	ac_cv_lib_nl_3_nl_cache_alloc=no \
-	ac_cv_lib_dbus_1_dbus_malloc=no
+	ac_cv_lib_dbus_1_dbus_malloc=no \
+	ac_cv_path_pcncfg=no
 
 CONFIGURE_ARGS += \
 	--enable-force-pf \


### PR DESCRIPTION
Maintainer: @commodo
Compile tested: OpenWrt master r17331-4d81f08771 on x86/64
Run tested: NA

Description:
On hosts that have pcapnav-config installed, there is host lib leakage.
From config.log:

LNAVLIB='-L/usr/lib64 -lpcapnav -lpcap'
LNAV_CFLAGS='-I/usr/include'

Fix this by disabling pcapnav-config, which isn't available anyway.