### PR TITLE
fish: don't build docs

### DIFF
--- a/utils/fish/Makefile
+++ b/utils/fish/Makefile
@@ -36,6 +36,8 @@ define Package/fish/description
   configuration required.
 endef
 
+CMAKE_OPTIONS += -DBUILD_DOCS=NO
+
 define Package/fish/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fish $(1)/usr/bin


### PR DESCRIPTION
Maintainer: @jqqqqqqqqqq
Compile tested: OpenWrt master r17331-4d81f08771 on x86/64
Run tested: NA

Description:
Building docs fails due to fish_indent not being available. As we don't
install docs anyway, simply disable docs build.

```
[118/119] cd /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1 && mkdir -p /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/user_doc/html/_static/ && env PATH="/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1:$PATH" /usr/bin/sphinx-build -q -b html -c /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/doc_src -d /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/user_doc/doctrees /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/doc_src /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/user_doc/html
FAILED: CMakeFiles/sphinx-docs
cd /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1 && mkdir -p /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/user_doc/html/_static/ && env PATH="/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1:$PATH" /usr/bin/sphinx-build -q -b html -c /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/doc_src -d /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/user_doc/doctrees /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/doc_src /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/user_doc/html

Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/sphinx/config.py", line 323, in eval_config_file
    exec(code, namespace)
  File "/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/doc_src/conf.py", line 82, in <module>
    ret = subprocess.check_output(
  File "/usr/lib/python3.9/subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.9/subprocess.py", line 505, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.9/subprocess.py", line 1821, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'fish_indent'

[119/119] cd /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1 && env PATH="/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1:$PATH" /usr/bin/sphinx-build -q -b man -c /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/doc_src -d /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/user_doc/doctrees /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/doc_src /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/user_doc/man/man1
FAILED: CMakeFiles/sphinx-manpages
cd /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1 && env PATH="/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1:$PATH" /usr/bin/sphinx-build -q -b man -c /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/doc_src -d /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/user_doc/doctrees /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/doc_src /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/user_doc/man/man1

Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/sphinx/config.py", line 323, in eval_config_file
    exec(code, namespace)
  File "/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/fish-3.3.1/doc_src/conf.py", line 82, in <module>
    ret = subprocess.check_output(
  File "/usr/lib/python3.9/subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.9/subprocess.py", line 505, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.9/subprocess.py", line 1821, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'fish_indent'

ninja: build stopped: subcommand failed.
```