### PR TITLE
gnuplot: fix host lib leakage

### DIFF
--- a/utils/gnuplot/Makefile
+++ b/utils/gnuplot/Makefile
@@ -29,6 +29,8 @@ CONFIGURE_ARGS += \
     --without-latex \
     --without-libcerf
 
+CONFIGURE_VARS += ac_cv_have_x="have_x=no"
+
 # Since Qt is disabled there is no C++ code, so CXX is forced
 # to CC in order to avoid dependency on libstdcpp. This is 
 # horrible, but 'DEPENDS:=+libstdcpp' does not work for some


### PR DESCRIPTION
Maintainer: @datafl4sh 
Compile tested: OpenWrt master r17331-4d81f08771 on x86/64
Run tested: NA

Description:
The package does not build due to host lib leakage, as evidenced by
config.log:

X_CFLAGS=' -I/usr/include'
X_LIBS=' -L/usr/lib'

Fix this by disabling X with a configure var.