### PR TITLE
zabbix: Call killall with the -s parameter

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=5.0.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/5.0/
@@ -266,7 +266,7 @@ endef
 define Package/zabbix-extra-network/postinst
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
-	killall -HUP ubusd
+	killall -s HUP ubusd
 fi
 endef
 
@@ -279,7 +279,7 @@ endef
 define Package/zabbix-extra-wifi/postinst
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
-	killall -HUP ubusd
+	killall -s HUP ubusd
 fi
 endef
 


### PR DESCRIPTION
Some versions of killall do support the `killall -SIGNAL` syntax and
have only `-s SIGNAL` which should be supported everywhere.

I see the problem with *killall (PSmisc) 23.3* on latest TurrisOS 5.2

Signed-off-by: Jan Baier <jan.baier@amagical.net>

Maintainer: @champtar
Compile tested: aarch64_cortex-a53