### PR TITLE
perl: perlmod.mk: wrap hostpkg perl usage around flock

### DIFF
--- a/lang/perl/perlmod.mk
+++ b/lang/perl/perlmod.mk
@@ -32,39 +32,49 @@ PERL_TESTSDIR:=/usr/share/perl/perl-tests
 PERLBASE_TESTSDIR:=/usr/share/perl/perlbase-tests
 PERLMOD_TESTSDIR:=/usr/share/perl/perlmod-tests
 
+FLOCK:=$(STAGING_DIR_HOST)/bin/flock
+
 define perlmod/host/relink
 	rm -f $(1)/Makefile.aperl
-	$(MAKE) -C $(1) perl
-	$(INSTALL_BIN) $(1)/perl $(PERL_CMD)
-	$(INSTALL_BIN) $(1)/perl $(STAGING_DIR_HOSTPKG)/usr/bin/perl
+	($(FLOCK) -w 900 9 || { echo perlmod/host/relink: failed to acquire lock; exit 1; }; \
+	    $(MAKE) -C $(1) perl && \
+	    $(INSTALL_BIN) $(1)/perl $(PERL_CMD) && \
+	    $(INSTALL_BIN) $(1)/perl $(STAGING_DIR_HOSTPKG)/usr/bin/perl \
+	) 9> $(TMP_DIR)/.perlmod-perl.flock
 endef
 
 define perlmod/host/Configure
 	(cd $(HOST_BUILD_DIR); \
+	$(FLOCK) -s -w 300 9 || { echo perlmod/host/Configure: failed to acquire lock; exit 1; }; \
 	PERL_MM_USE_DEFAULT=1 \
 	$(2) \
 	$(PERL_CMD) Makefile.PL \
 		$(1) \
-	);
+	) 9> $(TMP_DIR)/.perlmod-perl.flock;
 endef
 
 define perlmod/host/Compile
+	($(FLOCK) -s -w 300 9 || { echo perlmod/host/Compile: failed to acquire lock; exit 1; }; \
 	$(2) \
 	$(MAKE) -C $(HOST_BUILD_DIR) \
 		$(1) \
-		install
+		install \
+	) 9> $(TMP_DIR)/.perlmod-perl.flock
 endef
 
 define perlmod/host/Install
+	($(FLOCK) -s -w 300 9 || { echo perlmod/host/Install: failed to acquire lock; exit 1; }; \
 	$(2) \
 	$(MAKE) -C $(HOST_BUILD_DIR) \
 		$(1) \
-		install
+		install \
+	) 9> $(TMP_DIR)/.perlmod-perl.flock
 	$(call perlmod/host/relink,$(HOST_BUILD_DIR))
 endef
 
 define perlmod/Configure
 	(cd $(if $(3),$(3),$(PKG_BUILD_DIR)); \
+	 $(FLOCK) -s -w 300 9 || { echo perlmod/Configure: failed to acquire lock; exit 1; }; \
 	 (echo -e 'use Config;\n\n$$$${tied %Config::Config}{cpprun}="$(GNU_TARGET_NAME)-cpp -E";\n' ; cat Makefile.PL) | \
 	 PERL_MM_USE_DEFAULT=1 \
 	 $(2) \
@@ -114,16 +124,18 @@ define perlmod/Configure
 		INSTALLVENDORMAN3DIR=" " \
 		LINKTYPE=dynamic \
 		DESTDIR=$(PKG_INSTALL_DIR) \
-	)
+	) 9> $(TMP_DIR)/.perlmod-perl.flock
 	sed -i -e 's!^PERL_INC = .*!PERL_INC = $(STAGING_DIR)/usr/lib/perl5/$(PERL_VERSION)/CORE/!' $(if $(3),$(3),$(PKG_BUILD_DIR))/Makefile
 endef
 
 define perlmod/Compile
+	($(FLOCK) -s -w 300 9 || { echo perlmod/Compile: failed to acquire lock; exit 1; }; \
 	PERL5LIB=$(PERL_LIB) \
 	$(2) \
 	$(MAKE) -C $(if $(3),$(3),$(PKG_BUILD_DIR)) \
 		$(1) \
-		install
+		install \
+	) 9> $(TMP_DIR)/.perlmod-perl.flock
 endef
 
 define perlmod/Install/NoStrip


### PR DESCRIPTION
Maintainer: @Naoir @pprindeville 
Compile tested: x86_64 host running Gentoo, openwrt master
Run tested:  `make -j6 package/perl-mail-spamassassin/compile`

Description:
Avoid parallel relinking of the host perl binary by wrapping it around a flock call.

Sometimes, two packages will try to relink the static host perl binary at the same time.  Neither of them will have the other's module linked it, and one of them will unavoidably clobber the other one's binary.

This will lead to errors when a package will not be able to find a module that was supposed to be installed.

In order to avoid locking up the build process forever, there's a 300 second timeout when trying to acquire the lock.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

----

Continuing my perl parallel build debugging...

@stintel, @neheb, you may enjoy this one as well.

The errors are not easily reproducible, but show up from time to time.  There are a couple of them right now at:
https://downloads.openwrt.org/snapshots/faillogs/arm_fa526/packages/perl-mail-spamassassin/ssl/compile.txt
https://downloads.openwrt.org/snapshots/faillogs/arm_cortex-a5_vfpv4/packages/perl-mail-spamassassin/ssl/compile.txt

Here's the interesting part:
```
dependency check complete...

REQUIRED module missing: NetAddr::IP
optional module missing: Digest::SHA1
optional module missing: DB_File
optional module missing: Mail::SPF
optional module missing: GeoIP2::Database::Reader
optional module missing: Geo::IP
optional module missing: IP::Country::DB_File
optional module missing: Net::CIDR::Lite
optional module missing: Razor2
optional module missing: IO::Socket::INET6
optional module missing: IO::Socket::SSL
optional module missing: Mail::DKIM
optional module missing: LWP::UserAgent
optional module missing: HTTP::Date
optional module missing: Encode::Detect::Detector
optional module missing: Net::Patricia
optional module missing: BSD::Resource
optional module missing: Archive::Zip
optional module missing: IO::String
optional binary missing or nonfunctional: wget
optional binary missing or nonfunctional: fetch
optional binary missing or nonfunctional: re2c

warning: some functionality may not be available,
please read the above report before continuing!

/builder/shared-workdir/build/sdk/staging_dir/host/bin/sed: can't read /builder/shared-workdir/build/sdk/build_dir/target-arm_cortex-a5+vfpv4_musl_eabi/perl-mail-spamassassin-ssl/Mail-SpamAssassin-3.4.6/Makefile: No such file or directory
make[3]: *** [Makefile:104: /builder/shared-workdir/build/sdk/build_dir/target-arm_cortex-a5+vfpv4_musl_eabi/perl-mail-spamassassin-ssl/Mail-SpamAssassin-3.4.6/.configured_68b329da9893e34099c7d8ad5cb9c940] Error 2
```

Our host perl binary is configured to have its modules built into the main executable, not supporting dynamic loading of modules.  Therefore, we need to relink the perl binary every time a host module is added.  When we do this in parallel, there's a chance that more than one package will try to relink the binary at the same time.  The one that finish last will clobber the first package's relinking, without their modules, since they both started with the same set of linked modules.  Then, when a dependent package tries to test the module's presence, such as perl-mail-spamassassin does, it will not find the one that got clobbered.

It's interesting enough for me that spamassassin's module detection is done with the hostpkg perl installed modules (I did not know how that stuff worked).  The module presence detection is done by running `eval "use $moddef->{module} $required_version; 1"` (Mail-SpamAssassin-3.4.6/lib/Mail/SpamAssassin/Util/DependencyInfo.pm:643) with the hostpkg perl, so it shows no output.  When I managed to run the test from the openwrt perl, then I finally saw what was going on.

Cheers