### PR TITLE
tinyproxy: pass DisableViaHeader option

### DIFF
--- a/net/tinyproxy/files/tinyproxy.init
+++ b/net/tinyproxy/files/tinyproxy.init
@@ -121,6 +121,7 @@ start_proxy() {
 	proxy_atom "$1" MaxRequestsPerChild
 	proxy_list "$1" Allow
 
+	proxy_flag "$1" DisableViaHeader
 	proxy_string "$1" ViaProxyName
 	proxy_string "$1" Filter
 


### PR DESCRIPTION
Maintainer: @jow- 
Run tested: Mi Router 4A (MIR4A), mt76x8, OpenWrt 19.07

Description:
The option is not processed in /etc/init.d/tinyproxy ( https://github.com/openwrt/packages/issues/1656 )