### PR TITLE
Call killall with the -s parameter

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.8.7
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -116,8 +116,8 @@ compare_values() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
 is_chaos_calmer() { ubus -S call system board | grep -q 'Chaos Calmer'; }
 led_on(){ if [ -n "${1}" ] && [ -e "${1}/trigger" ]; then echo 'default-on' > "${1}/trigger" 2>&1; fi; }
 led_off(){ if [ -n "${1}" ] &&  [ -e "${1}/trigger" ]; then echo 'none' > "${1}/trigger" 2>&1; fi; }
-dnsmasq_hup() { killall -q -HUP dnsmasq; }
-dnsmasq_kill() { killall -q -KILL dnsmasq; }
+dnsmasq_hup() { killall -q -s HUP dnsmasq; }
+dnsmasq_kill() { killall -q -s KILL dnsmasq; }
 dnsmasq_restart() { /etc/init.d/dnsmasq restart >/dev/null 2>&1; }
 unbound_restart() { /etc/init.d/unbound restart >/dev/null 2>&1; }
 is_force_dns_active() { iptables-save | grep -q -w -- '--dport 53'; }

--- a/net/vpn-policy-routing/Makefile
+++ b/net/vpn-policy-routing/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vpn-policy-routing
 PKG_VERSION:=0.3.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 

--- a/net/vpn-policy-routing/files/vpn-policy-routing.init
+++ b/net/vpn-policy-routing/files/vpn-policy-routing.init
@@ -154,7 +154,7 @@ is_domain() { str_contains "$1" '[a-zA-Z]'; }
 is_phys_dev() { [ "${1:0:1}" = "@" ] && ip l show | grep -E -q "^\\d+\\W+${1:1}"; }
 is_turris() { /bin/ubus -S call system board | /bin/grep 'Turris' | /bin/grep -q '15.05'; }
 is_chaos_calmer() { ubus -S call system board | grep -q 'Chaos Calmer'; }
-dnsmasq_kill() { killall -q -HUP dnsmasq; }
+dnsmasq_kill() { killall -q -s HUP dnsmasq; }
 dnsmasq_restart() { output 3 'Restarting DNSMASQ '; if /etc/init.d/dnsmasq restart >/dev/null 2>&1; then output_okn; else output_failn; fi; }
 is_default_dev() { [ "$1" = "$(ip -4 r | grep -m1 'dev' | grep -Eso 'dev [^ ]*' | awk '{print $2}')" ]; }
 is_supported_iface_dev() {

--- a/utils/banhosts/Makefile
+++ b/utils/banhosts/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banhostlist
 PKG_VERSION:=1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_MAINTAINER:=Matteo Croce <matteo@openwrt.org>

--- a/utils/banhosts/files/updatebanhost
+++ b/utils/banhosts/files/updatebanhost
@@ -6,7 +6,7 @@ gethosts() {
 	logger -t "banhost[$$]" "Update $file"
 	wget -qO- http://winhelp2002.mvps.org/hosts.txt |awk 'BEGIN{printf "0.0.0.0"}/^0\.0\.0\.0/{printf " "$2}END{exit(!FNR)}' >$file || exit 1
 	echo -n $time >$file.time
-	exec killall -HUP dnsmasq
+	exec killall -s HUP dnsmasq
 }
 
 if [ "$ACTION" = ifup -a "$INTERFACE" = wan ]; then

--- a/utils/bmx7-dnsupdate/Makefile
+++ b/utils/bmx7-dnsupdate/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bmx7-dnsupdate
 PKG_VERSION:=0.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/utils/bmx7-dnsupdate/files/usr/bin/bmx7-dnsupdate
+++ b/utils/bmx7-dnsupdate/files/usr/bin/bmx7-dnsupdate
@@ -22,7 +22,7 @@ while true; do
 
     # reload dnsmasq to apply changes
     logger -t bmx7-dnsupdate "dnsmasq updated due to new hosts"
-    killall -HUP dnsmasq
+    killall -s HUP dnsmasq
 
     # block until originators changes
     inotifywait -e create -e delete -q /var/run/bmx7/json/originators/ || sleep 10


### PR DESCRIPTION
Some versions of killall do support the killall -SIGNAL syntax and
have only -s SIGNAL which should be supported everywhere.

The problem exists with killall (PSmisc) 23.3 on latest TurrisOS 5.2

Maintainer: @stangri, @teknoraver, @aparcar 

Description: Fixing issue in other packages as suggested in #16381 