### PR TITLE
[19.07] mc: update to 2.8.27

### DIFF
--- a/utils/mc/Makefile
+++ b/utils/mc/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mc
-PKG_VERSION:=4.8.25
+PKG_VERSION:=4.8.27
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -14,7 +14,7 @@ PKG_CPE_ID:=cpe:/a:midnight_commander:midnight_commander
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://ftp.midnight-commander.org/
-PKG_HASH:=ffc19617f20ebb23330acd3998b7fd559a042d172fa55746d53d246697b2548a
+PKG_HASH:=31be59225ffa9920816e9a8b3be0ab225a16d19e4faf46890f25bdffa02a4ff4
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf gettext-version
 PKG_BUILD_DEPENDS:=MC_VFS:libtirpc

--- a/utils/mc/patches/010-subshell.patch
+++ b/utils/mc/patches/010-subshell.patch
@@ -1,6 +1,6 @@
--- a/src/subshell/common.c
+--- a/src/subshell/common.c
 +++ b/src/subshell/common.c
-@@ -836,7 +836,7 @@ init_subshell_precmd (char *precmd, size
+@@ -1140,7 +1140,7 @@ init_subshell_precmd (char *precmd, size
                      "else "
                      "[ \"${PWD##$HOME/}\" = \"$PWD\" ] && MC_PWD=\"$PWD\" || MC_PWD=\"~/${PWD##$HOME/}\"; "
                      "fi; "

--- a/utils/mc/patches/020-fix-mouse-handling-newer-terminfo.patch
+++ b/utils/mc/patches/020-fix-mouse-handling-newer-terminfo.patch
@@ -1,6 +1,6 @@
 --- a/lib/tty/tty.c
 +++ b/lib/tty/tty.c
-@@ -370,7 +370,7 @@ tty_init_xterm_support (gboolean is_xter
+@@ -402,7 +402,7 @@ tty_init_xterm_support (gboolean is_xter
      if (xmouse_seq != NULL)
      {
          if (strcmp (xmouse_seq, ESC_STR "[<") == 0)


### PR DESCRIPTION
Maintainer: N/A
Compile tested: armv7, Turris Omnia, OpenWrt 19.07
Run tested: armv7, Turris Omnia, OpenWrt 20.02

Description:
* fixes CVE-2021-36370
* refresh patches