### PR TITLE
Update info URL in Makefile for BCP38

### DIFF
--- a/net/bcp38/Makefile
+++ b/net/bcp38/Makefile
@@ -25,7 +25,7 @@ endef
 
 define Package/bcp38/description
  bcp38 implements IETF BCP38 for home routers.
- See https://tools.ietf.org/html/bcp38.
+ See https://www.rfc-editor.org/info/bcp38.
 
  This package provides BCP38 for IPv4 only - IPv6 uses source 
  specific default routes, so no firewall configuration is needed.


### PR DESCRIPTION
Maintainer: me / @tohojo 
Compile tested: N/A
Run tested: N/A

Description:

The url `https://tools.ietf.org/html/bcp38` redirects currently to the one proposed in this PR `https://www.rfc-editor.org/info/bcp38`.

Makes sense to point straight to the final one, where resides the useful information.
