### PR TITLE
gnupg: remove the GCC if

### DIFF
--- a/utils/gnupg/Makefile
+++ b/utils/gnupg/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnupg
 PKG_VERSION:=1.4.23
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/gnupg
@@ -87,7 +87,7 @@ CONFIGURE_ARGS += \
 MAKE_FLAGS += \
 	SUBDIRS="m4 intl zlib util mpi cipher tools g10 keyserver ${checks}" \
 
-TARGET_CFLAGS += $(if $(CONFIG_GCC_USE_VERSION_10),-DEXTERN_UNLESS_MAIN_MODULE=static)
+TARGET_CFLAGS += -DEXTERN_UNLESS_MAIN_MODULE=static
 
 define Package/gnupg/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Doesn't seem to work without advanced toolchain settings.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ath79