### PR TITLE
dnscrypt-proxy2: Upgrade to 2.1.0

### DIFF
--- a/net/dnscrypt-proxy2/Makefile
+++ b/net/dnscrypt-proxy2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy2
-PKG_VERSION:=2.0.45
-PKG_RELEASE:=2
+PKG_VERSION:=2.1.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=dnscrypt-proxy-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/DNSCrypt/dnscrypt-proxy/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=f7aac28c6a60404683d436072b89d18ed3bb309f8d8a95c8e87ad250da190821
+PKG_HASH:=4af43a2143a1d0f9b430f5f08981417cb4475cc590daf79d11c9a0487f72fadc
 PKG_BUILD_DIR:=$(BUILD_DIR)/dnscrypt-proxy-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
@@ -25,9 +25,13 @@ PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
 GO_PKG:=github.com/DNSCrypt/dnscrypt-proxy
+GO_PKG_LDFLAGS:=-s -w
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
+
+GO_MOD_ARGS:=
+GO_PKG_BUILD_VARS+= GO111MODULE=off
 
 define Package/dnscrypt-proxy2
   SECTION:=net


### PR DESCRIPTION
Signed-off-by: Ted Hess <thess@kitschensync.net>

Maintainer: @BKPepe 
Compile tested: IPQ806x, trunk
Run tested: IPQ806x, R7800, trunk, in daily use

Description:
Upgrade dnscrypt-proxy2 to latest release. from DNSCrypt/dnscrypt-proxy.
Adjusted build options to turn on GOPATH mode for GO 1.16 by forcing GO111MODULE=off.

I am by no stretch of the imagination a GO programmer - this change was necessary after updating dnscrypt-proxy to 2.1.0 and having the build fail with "no matched packages" in the `go build` step. I found this article after much searching for a solution:
https://go.dev/blog/go116-module-changes
