### PR TITLE
[21.02] https-dns-proxy: patch CMakeList.txt to use OpenWrt CFLAGS

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2021-07-29
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/

--- a/net/https-dns-proxy/patches/010-fix-cmakelists.patch
+++ b/net/https-dns-proxy/patches/010-fix-cmakelists.patch
@@ -1,0 +1,19 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,12 +12,12 @@ function(define_file_basename_for_source
+   endforeach()
+ endfunction()
+ 
+-set(CMAKE_BUILD_TYPE "Debug")
++#set(CMAKE_BUILD_TYPE "Debug")
+ #set(CMAKE_BUILD_TYPE "Release")
+ 
+-set(CMAKE_C_FLAGS "-Wall -Wextra --pedantic -Wno-strict-aliasing -Wno-variadic-macros")
+-set(CMAKE_C_FLAGS_DEBUG "-g -DDEBUG")
+-set(CMAKE_C_FLAGS_RELEASE "-O2")
++#set(CMAKE_C_FLAGS "-Wall -Wextra --pedantic -Wno-strict-aliasing -Wno-variadic-macros")
++#set(CMAKE_C_FLAGS_DEBUG "-g -DDEBUG")
++#set(CMAKE_C_FLAGS_RELEASE "-O2")
+ 
+ if ((CMAKE_C_COMPILER_ID MATCHES GNU   AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 9) OR
+     (CMAKE_C_COMPILER_ID MATCHES Clang AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 10))


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-105, OpenWrt 21.02.0-rc4
Run tested: x86_64, Sophos SG-105, OpenWrt 21.02.0-rc4, test name resolution

This fixes compilation issues with ASLR PIE enabled

We were compiling with '-g -DDEBUG'

https-dns-proxy_2021-07-29-*_arm_cortex-a9_vfpv3-d16.ipk
shrink from 19514 to 19095

Signed-off-by: Etienne Champetier <champetier.etienne@gmail.com>
(cherry picked from commit 374e1dd56e1742273b261f25a69fd3d46741e357)
