### PR TITLE
net-snmp: update to 5.9.1

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
-PKG_VERSION:=5.9
-PKG_RELEASE:=1
+PKG_VERSION:=5.9.1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp
-PKG_HASH:=04303a66f85d6d8b16d3cc53bde50428877c82ab524e17591dfceaeb94df6071
+PKG_HASH:=eb7fd4a44de6cddbffd9a92a85ad1309e5c1054fb9d5a7dd93079c8953f48c3f
 PKG_MAINTAINER:=Stijn Tintel <stijn@linux-ipv6.be>
 PKG_LICENSE:=MIT BSD-3-Clause-Clear
 PKG_CPE_ID:=cpe:/a:net-snmp:net-snmp

--- a/net/net-snmp/patches/170-ldflags.patch
+++ b/net/net-snmp/patches/170-ldflags.patch
@@ -1,7 +1,7 @@
 --- a/Makefile.top
 +++ b/Makefile.top
-@@ -87,7 +87,7 @@ LIBCURRENT  = 40
- LIBAGE      = 0
+@@ -87,7 +87,7 @@ LIBCURRENT  = 41
+ LIBAGE      = 1
  LIBREVISION = 0
  
 -LIB_LD_CMD      = $(LIBTOOL) --mode=link $(LINKCC) $(CFLAGS) -rpath $(libdir) -version-info $(LIBCURRENT):$(LIBREVISION):$(LIBAGE) -o

--- a/net/net-snmp/patches/900-musl-compat.patch
+++ b/net/net-snmp/patches/900-musl-compat.patch
@@ -1,12 +1,11 @@
 --- a/agent/mibgroup/iwlib.h
 +++ b/agent/mibgroup/iwlib.h
-@@ -85,6 +85,11 @@
+@@ -85,6 +85,10 @@
        && LINUX_VERSION_CODE < KERNEL_VERSION(2,1,0)
  #define LIBC5_HEADERS
  
 +/* Musl */
-+#elif !defined(__GLIBC__) && !defined(__UCLIBC__) \
-+      && LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0)
++#elif !defined(__GLIBC__) && LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0)
 +#define GENERIC_HEADERS
 +
  /* Unsupported combination */


### PR DESCRIPTION
Switch to AUTORELEASE for simplicity.

Refresh patches and fixup musl patch. There's no need to check for
uClibc as it defines __GLIBC__.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @stintel 
Compile tested: ath79