### PR TITLE
travelmate: update to 2.0.6

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=2.0.5
-PKG_RELEASE:=3
+PKG_VERSION:=2.0.6
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/travelmate/files/travelmate.vpn
+++ b/net/travelmate/files/travelmate.vpn
@@ -1,5 +1,5 @@
 #!/bin/sh
-# vpn switch for travelmate
+# vpn handler called by travelmate
 # Copyright (c) 2020-2021 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
@@ -31,7 +31,7 @@ trm_fetch="$(command -v curl)"
 f_net() {
 	local json_rc result="net nok"
 
-	json_rc="$(${trm_fetch} --user-agent "${trm_useragent}" --referer "http://www.example.com" --connect-timeout $((trm_maxwait / 10)) --header "Cache-Control: no-cache, no-store, must-revalidate" --header "Pragma: no-cache" --header "Expires: 0" --write-out "%{response_code}" --silent --output /dev/null "${trm_captiveurl}")"
+	json_rc="$(${trm_fetch} --user-agent "${trm_useragent}" --referer "http://www.example.com" --header "Cache-Control: no-cache, no-store, must-revalidate, max-age=0" --write-out "%{response_code}" --silent --output /dev/null --max-time $((trm_maxwait / 6)) "${trm_captiveurl}")"
 	if [ "${json_rc}" = "200" ] || [ "${json_rc}" = "204" ]; then
 		result="net ok"
 	fi


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL.iNet GL-AR750S (NOR/NAND), OpenWrt SNAPSHOT r17341-5c13177c55

Description:
* replaced pipe input for a while/read-loop with a here document/variable as input
  (fix various subshell related bugs and oddities)
* further improve abort and re-connection handling
* prevent alleged detected connection failures (false positives) with an additional gw check,
  to stabilize VPN connections in particular

Signed-off-by: Dirk Brenken <dev@brenken.org>
