### PR TITLE
ddns-scripts: PowerDNS script

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 PKG_LICENSE:=GPL-2.0
 
@@ -181,6 +181,21 @@ define Package/ddns-scripts-gandi/description
 endef
 
 
+define Package/ddns-scripts-pdns
+  $(call Package/ddns-scripts/Default)
+  TITLE:=PowerDNS API
+  DEPENDS:=ddns-scripts +curl
+endef
+
+define Package/ddns-scripts-pdns/description
+  Dynamic DNS Client scripts extension for "PowerDNS" via API.
+  It requires:
+  "option param_opt(Optional Parameter)" to be a valid root URL for the PowerDNS webserver
+  "option username" to be a valid subdomain for the PowerDNS domain
+  "option password" to be a valid API key for the PowerDNS webserver
+endef
+
+
 define Build/Configure
 endef
 
@@ -251,6 +266,7 @@ define Package/ddns-scripts-services/install
 	rm $(1)/usr/share/ddns/default/route53-v1.json
 	rm $(1)/usr/share/ddns/default/cnkuai.cn.json
 	rm $(1)/usr/share/ddns/default/gandi.net.json
+	rm $(1)/usr/share/ddns/default/pdns.json
 endef
 
 
@@ -425,6 +441,25 @@ exit 0
 endef
 
 
+define Package/ddns-scripts-pdns/install
+	$(INSTALL_DIR) $(1)/usr/lib/ddns
+	$(INSTALL_BIN) ./files/usr/lib/ddns/update_pdns.sh \
+		$(1)/usr/lib/ddns
+
+	$(INSTALL_DIR) $(1)/usr/share/ddns/default
+	$(INSTALL_DATA) ./files/usr/share/ddns/default/pdns.json \
+		$(1)/usr/share/ddns/default
+endef
+
+define Package/ddns-scripts-pdns/prerm
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	/etc/init.d/ddns stop
+fi
+exit 0
+endef
+
+
 $(eval $(call BuildPackage,ddns-scripts))
 $(eval $(call BuildPackage,ddns-scripts-services))
 $(eval $(call BuildPackage,ddns-scripts-cloudflare))
@@ -436,3 +471,4 @@ $(eval $(call BuildPackage,ddns-scripts-nsupdate))
 $(eval $(call BuildPackage,ddns-scripts-route53))
 $(eval $(call BuildPackage,ddns-scripts-cnkuai))
 $(eval $(call BuildPackage,ddns-scripts-gandi))
+$(eval $(call BuildPackage,ddns-scripts-pdns))

--- a/net/ddns-scripts/files/usr/lib/ddns/update_pdns.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_pdns.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Derived from update_gandi_net.sh
+. /usr/share/libubox/jshn.sh
+
+local __TTL=600
+local __RRTYPE
+local __STATUS
+
+[ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing subdomain as 'username'"
+[ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing API Key as 'password'"
+[ -z "$param_opt" ] && write_log 14 "Service section not configured correctly! Missing PowerDNS URL as 'Optional Parameter'(param_opt)"
+
+# Create endpoint from $param_opt
+# e.g. param_opt=http://127.0.0.1:8081
+local __ENDPOINT="$param_opt/api/v1/servers/localhost/zones"
+
+[ $use_ipv6 -ne 0 ] && __RRTYPE="AAAA" || __RRTYPE="A"
+
+# Build JSON payload
+json_init
+json_add_array rrsets
+json_add_object
+	json_add_string name "$username.$domain"
+	json_add_string type "$__RRTYPE"
+	json_add_int ttl $__TTL
+	json_add_string changetype "REPLACE"
+	json_add_array records
+	json_add_object
+		json_add_string content "$__IP"
+		json_add_boolean disabled 0
+	json_close_object
+	json_close_array
+json_close_object
+json_close_array
+
+__STATUS=$(curl -Ss -X PATCH "$__ENDPOINT/$domain" \
+	-H "X-Api-Key: $password" \
+	-H "Content-Type: application/json" \
+	-d "$(json_dump)" \
+	-w "%{http_code}\n" \
+	-o $DATFILE 2>$ERRFILE)
+
+
+if [ $? -ne 0 ]; then
+	write_log 14 "Curl failed: $(cat $ERRFILE)"
+	return 1
+elif [ -z $__STATUS ] || [ $__STATUS != 204 ]; then
+	write_log 14 "PowerDNS request failed: $__STATUS \n$(cat $DATFILE)"
+	return 1
+fi
+
+return 0

--- a/net/ddns-scripts/files/usr/share/ddns/default/pdns.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/pdns.json
@@ -1,0 +1,9 @@
+{
+	"name": "PowerDNS",
+	"ipv4": {
+		"url": "update_pdns.sh"
+	},
+	"ipv6": {
+		"url": "update_pdns.sh"
+	}
+}


### PR DESCRIPTION
Updete DDNS on a PowerDNS server via API calls

Maintainer: me
Compile tested: N/A only bash and make scripts
Run tested: Archer C7, OpenWrt 21.02 (Have not tested the `Makefile`)

Description:
It can be used for finer access control and PowerDNS servers served behind reverse proxies.

Closes #11594 