### PR TITLE
bump ModemManager and libs

### DIFF
--- a/libs/libmbim/Makefile
+++ b/libs/libmbim/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmbim
 PKG_VERSION:=1.26.0
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libmbim

--- a/libs/libmbim/Makefile
+++ b/libs/libmbim/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmbim
-PKG_VERSION:=1.24.8
+PKG_VERSION:=1.26.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libmbim
-PKG_HASH:=02590736163fff10e5732191fccc1b9920969616ddc59613a003052a116a3c25
+PKG_HASH:=1e1f0926b22c77210442129eca689722ecf324ab9c9abf421a5c989f46e813cf
 
-PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
+PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
 PKG_VERSION:=1.28.8
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_VERSION:=1.28.6
+PKG_VERSION:=1.28.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
-PKG_HASH:=cbb890893de1dee06ea5ebdac2d22f0469314a6f93f15f61f2f1206a1c9ae5fd
+PKG_HASH:=6e3bbbd200bc1b64b23f6254fef9212f2699ec77cfb32075d2ba5079c73a9f78
 
-PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
+PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
-PKG_VERSION:=1.16.6
+PKG_VERSION:=1.16.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
-PKG_HASH:=2a90b6260f66d3135609d62667ada73416694d717e7fd9b73223e3703a499617
+PKG_HASH:=2ccf1f716c2d121e8e6709bcf8af29ee86971a90adacca2e8d6288b30278862e
 PKG_BUILD_DIR:=$(BUILD_DIR)/ModemManager-$(PKG_VERSION)
 
-PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
+PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.16.10
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79/ Telco T1
Run tested: ath79 Telco T1. Checked basic functionality, confirmed new functionality

Description:

Updated maintainer email address and switched to autorelease as well.

ModemManager 1.16.10
-------------------------------------------

  * QMI:
    ** Fixed use of uninitialized memory in the 3GPP registration logic when running NAS Set System Selection Preference.

  * MBIM:
    ** Remove trailing 'F' in ICCIDs.
    ** Increased the timeout of the first MBIM command after the port is opened, in order to leave time to the module to finish booting properly.

  * plugins:
    ** icera: fixed segfault during the connection reset logic.
    ** fibocom: add port type hints for the NL668-AM.
    ** fibocom: fix supporting QMI based devices.
    ** huawei: ignored ^LWURC URCs.
    ** huawei: fixed memory leak when processing GETPORTMODE hints.
    ** cinterion: increased ^SCFG? timeout to 120s.
    ** Updated all AT/QCDM/GPS port type hints in all plugins to bind them to TTY ports only.

  * Several other minor improvements and fixes.

Overview of changes in libqmi 1.28.8
----------------------------------------

  * libqmi-glib:
    ** Fix CTL "Set Data Format" output TLV prerequisites.
    ** Fix double free in the qmiwwan based net port manager.


Overview of changes in libmbim 1.26
----------------------------------------

  * Build now requires GLib/GObject/GIO 2.56.

  * The GUdev optional build/runtime requirement is now fully dropped, it's no longer used.

  * Building from git no longer requires autoconf-archive, the needed AX_ macros are now shipped inside m4/.

  * In addition to building from a source release tarball, or building from git checkouts using the GNU autotools suite (autoconf/automake/libtool), this release includes the initial  support for the meson build system. The meson port is not fully complete yet, as there are some missing things in the doc generation steps, but for system integration or development  purposes, the port should be fully operational. This major release, including all its stable updates in the 1.26.x series, will be the last ones providing support for GNU autotools. The next major release will likely be a meson-only one, and will therefore not be based on a source release tarball any more, but on specific git tags instead.

  * Implemented new link management operations, exclusively for the cdc_mbim driver for now. These new operations allow creating or deleting VLAN network interfaces in order to run multiplexed data sessions over one single physical network interface.

  * Added support for the Microsoft-defined SAR service, including the following operations:
    ** MBIM_CID_MS_SAR_CONFIG
    ** MBIM_CID_MS_SAR_TRANSMISSION_STATUS

  * Added support for the Microsoft-defined UICC Low Level Access service, including the following operations:
    ** MBIM_CID_MS_UICC_LOW_LEVEL_ACCESS_ATR
    ** MBIM_CID_MS_UICC_LOW_LEVEL_ACCESS_OPEN_CHANNEL
    ** MBIM_CID_MS_UICC_LOW_LEVEL_ACCESS_CLOSE_CHANNEL
    ** MBIM_CID_MS_UICC_LOW_LEVEL_ACCESS_APDU
    ** MBIM_CID_MS_UICC_LOW_LEVEL_ACCESS_TERMINAL_CAPABILITY
    ** MBIM_CID_MS_UICC_LOW_LEVEL_ACCESS_RESET

  * Added support for the Qualcomm-defined QDU service, including the following operations:
    ** MBIM_CID_QDU_UPDATE_SESSION
    ** MBIM_CID_QDU_FILE_OPEN
    ** MBIM_CID_QDU_FILE_WRITE

  * Extended the Microsoft-defined Basic Connect Extensions service, including the following operations:
    ** MBIM_CID_MS_BASIC_CONNECT_EXTENSIONS_DEVICE_CAPS
    ** MBIM_CID_MS_BASIC_CONNECT_EXTENSIONS_SYS_CAPS
    ** MBIM_CID_MS_BASIC_CONNECT_EXTENSIONS_SLOT_INFO_STATUS
    ** MBIM_CID_MS_BASIC_CONNECT_EXTENSIONS_DEVICE_SLOT_MAPPINGS

  * libmbim-glib:
    ** Logic updated to make sure full packets are written at once, instead of writing them in chunks.
    ** Updated the "LTE attach status" APIs in order to avoid creating unneeded struct types in the interface. The older methods have been deprecated and maintained in the library for compatibility purposes only.

  * mbim-proxy:
    ** Internal buffer size updated from 512 bytes to 4096 bytes.

  * mbimcli:
    ** New '--ms-set-sar-config' and '--ms-query-sar-config' actions.
    ** New '--ms-set-transmission-status' and '--ms-query-transmission-status' actions.
    ** Updated '--enter-pin', '--disable-pin' and '--unlock-pin' to allow other PIN types, not just assuming PIN1.
    ** New '--link-add', '--link-delete', '--link-list' and '--link-delete-all' actions.
    ** New '--ms-query-sys-caps' action.
    ** New '--ms-query-slot-info-status' action.
    ** New '--ms-query-device-slot-mappings' and '--ms-set-device-slot-mappings' actions.
    ** Renamed '--ms-query-lte-attach-status' to '--ms-query-lte-attach-info', and kept the old name for compatibility purposes.

  * mbim-network:
    ** When using the mbim-proxy, skip trying to manage the MBIM session and transaction ids as that is implicitly done by the proxy already.

  * Several other minor improvements and fixes.

The following features which were backported to 1.24.x releases are also present in libmbim 1.26.0:

  * Fixed merged subscribe list reporting and handling in the proxy.
  * Fixed transaction id handling when multiple fragments are involved.
  * Fixed read overflows on malformed messages.
  * Skip warnings if descriptors file cannot be read, as in new MBIM backends other than cdc_mbim.


