### PR TITLE
tailscale: update to version 1.12.3

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.12.1
+PKG_VERSION:=1.12.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=tailscale-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=9a94e6073f5e171c9ba6c3f5ca291bdae688c8e26fb586c3df4302204af77e86
+PKG_HASH:=05e5b1d382cad7ac5737d87d0b61277791c75938468c2c662f21665998d431e9
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS7), OpenWrt master
Run tested: Turris Omnia (TOS7), OpenWrt master

Description:
This PR updates tailscale to version 1.12.3. Changelog https://github.com/tailscale/tailscale/releases/tag/v1.12.3

