### PR TITLE
[19.07] postgresql: disable PIC

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -24,6 +24,7 @@ PKG_FIXUP:=autoreconf
 PKG_MACRO_PATHS:=config
 PKG_BUILD_DEPENDS:=postgresql/host
 PKG_INSTALL:=1
+PKG_ASLR_PIE:=0
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: aarch64, Turris MOX, OpenWrt 19.07
Run tested: N/A

Description: with PIC enabled, build fails with:
```
ld: access/gist/gistproc.o: in function `rtree_internal_consistent':
gistproc.c:(.text+0x188): relocation truncated to fit: R_AARCH64_LD64_GOTPAGE_LO15 against symbol `DirectFunctionCall2Coll' defined in .text section in utils/fmgr/fmgr.o
ld: gistproc.c:(.text+0x188): warning: too many GOT entries for -fpic, please recompile with -fPIC
ld: final link failed: symbol needs debug section which does not exist
collect2: error: ld returned 1 exit status
```
Related-to: 8e9ad7bb5117edea4df08cd9a2de62685103a4b3