### PR TITLE
openvswitch: add option for OpenFlow datapath desc

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -17,7 +17,7 @@ include ./openvswitch.mk
 #
 PKG_NAME:=openvswitch
 PKG_VERSION:=$(ovs_version)
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openvswitch.org/releases/
 PKG_HASH:=7d5797f2bf2449c6a266149e88f72123540f7fe7f31ad52902057ae8d8f88c38

--- a/net/openvswitch/README.md
+++ b/net/openvswitch/README.md
@@ -85,12 +85,13 @@ after adding or changing these options.
 The ovs_bridge section also supports the options below,
 for initialising a virtual bridge with an OpenFlow controller.
 
-| Name        | Type    | Required | Default                        | Description                                                |
-|-------------|---------|----------|--------------------------------|------------------------------------------------------------|
-| disabled    | boolean | no       | 0                              | If set to true, disable initialisation of the named bridge |
-| name        | string  | no       | Inherits UCI config block name | The name of the switch in the OVS daemon                   |
-| controller  | string  | no       | (none)                         | The endpoint of an OpenFlow controller for this bridge     |
-| datapath_id | string  | no       | (none)                         | The OpenFlow datapath ID for this bridge                   |
+| Name          | Type    | Required | Default                        | Description                                                |
+|---------------|---------|----------|--------------------------------|------------------------------------------------------------|
+| disabled      | boolean | no       | 0                              | If set to true, disable initialisation of the named bridge |
+| name          | string  | no       | Inherits UCI config block name | The name of the switch in the OVS daemon                   |
+| controller    | string  | no       | (none)                         | The endpoint of an OpenFlow controller for this bridge     |
+| datapath_id   | string  | no       | (none)                         | The OpenFlow datapath ID for this bridge                   |
+| datapath_desc | string  | no       | (none)                         | The OpenFlow datapath description for this bridge          |
 
 The ovs_port section can be used to add ports to a bridge. It supports the options below.
 

--- a/net/openvswitch/files/openvswitch.config
+++ b/net/openvswitch/files/openvswitch.config
@@ -14,6 +14,7 @@ config ovs_bridge
 	option disabled 1
 	option name 'my-bridge'
 	option controller 'tcp:192.168.0.1'
+	option datapath_desc ''
 	option datapath_id ''
 
 config ovs_port

--- a/net/openvswitch/files/openvswitch.init
+++ b/net/openvswitch/files/openvswitch.init
@@ -187,6 +187,17 @@ ovs_bridge_validate_datapath_id() {
 	fi
 }
 
+ovs_bridge_validate_datapath_desc() {
+	local dpdesc="$1"
+
+	if [ "$(echo $dpdesc | wc -c)" -le 255 ]; then
+		return 0
+	else
+		logger -t openvswitch "invalid datapath_desc: $dpdesc"
+		return 1
+	fi
+}
+
 ovs_bridge_init() {
 	local cfg="$1"
 
@@ -205,6 +216,13 @@ ovs_bridge_init() {
 	[ -n "$datapath_id" ] && {
 		ovs_bridge_validate_datapath_id "$datapath_id" && {
 			ovs-vsctl --if-exists set bridge "$name" other-config:datapath-id="$datapath_id"
+		}
+	}
+
+	config_get datapath_desc "$cfg" datapath_desc
+	[ -n "$datapath_desc" ] && {
+		ovs_bridge_validate_datapath_desc "$datapath_desc" && {
+			ovs-vsctl --if-exists set bridge "$name" other-config:dp-desc="$datapath_desc"
 		}
 	}
 


### PR DESCRIPTION
Maintainer: @yousong 
Compile tested: OpenWrt master r17397-669d920e27 on x86/64
Run tested: OpenWrt master r17397-669d920e27 on x86/64

Description:
Add a UCI config option to set the OpenFlow datapath description. This
allows setting a human readable description of the bridge, e.g.
"Building x, Floor y, AP z", which makes it easier to recognize the AP.