### PR TITLE
mdio-tools: fix buildbot build

### DIFF
--- a/net/mdio-tools/Makefile
+++ b/net/mdio-tools/Makefile
@@ -35,4 +35,9 @@ define Package/mdio-tools/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/mdio/mdio $(1)/usr/bin/
 endef
 
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(SED) 's/m4_esyscmd_s(.*)/$(PKG_VERSION)/' $(PKG_BUILD_DIR)/configure.ac
+endef
+
 $(eval $(call BuildPackage,mdio-tools))


### PR DESCRIPTION
On buildbots the build fails because git isn't finding any git repo and
then AC_INIT refuses to run:

fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
configure.ac:5: error: AC_INIT should be called with package and version arguments

Address this by substituting the git command with $(PKG_VERSION).

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @dmascord 
Compile tested: master
Run tested: N/A, build fix

Description:
Hi Damian,

A suggestion to get the build to complete on OpenWrt build bots.

Kind regards,
Seb