### PR TITLE
Htop sensors

### DIFF
--- a/admin/htop/Makefile
+++ b/admin/htop/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=htop
 PKG_VERSION:=3.0.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/htop-dev/htop/tar.gz/$(PKG_VERSION)?
@@ -19,7 +19,7 @@ PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:htop:htop
 
-
+PKG_BUILD_DEPENDS:=lm-sensors
 PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1


### PR DESCRIPTION
Maintainer: @neheb @hnyman @champtar
Compile tested: x86_64
Run tested: bcm27xx/bcm2711/RPi4B
Description: Hitting F2 within htop should allow for an optional display of the CPU temp if compiled against lm-sensors but we currently do not build as such.  I tested the resulting package on my RPi4 but this hardware does not use kernel modules for temp so I did not see data displayed but I did see the missing prompt and "N/A" when enabled consistent with functional htop.

