### PR TITLE
Compile with GCC-10 fails without -fcommon option

### DIFF
--- a/net/aircrack-ng/Makefile
+++ b/net/aircrack-ng/Makefile
@@ -90,7 +90,7 @@ CONFIGURE_ARGS += \
 	$(if $(CONFIG_AIRCRACK_NG_HWLOC),--enable-hwloc,--disable-hwloc) \
 	$(if $(CONFIG_AIRCRACK_NG_SQLITE3),--with-sqlite3=$(STAGING_DIR)/usr,--without-sqlite3)
 
-TARGET_CFLAGS += -Wall -Wextra -ffunction-sections -fdata-sections
+TARGET_CFLAGS += -Wall -Wextra -ffunction-sections -fdata-sections -fcommon
 
 ifeq ($(CONFIG_AIRCRACK_NG_OPTIMIZE_SPEED),y)
 	TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS)) -O3


### PR DESCRIPTION
Without this it fails to build in latest trunk which uses gcc-10:
/openwrt/snapshot/staging_dir/toolchain-mips_24kc_gcc-10.3.0_musl/lib/gcc/mips-openwrt-linux-musl/10.3.0/../../../../mips-openwrt-linux-musl/bin/ld: ./.libs/libradiotap.a(radiotap.o):(.bss.__packed+0x0): multiple definition of `__packed'; lib/osdep/.libs/libaircrack_osdep_la-linux.o:(.bss.__packed+0x0): first defined here

Tested on ath79 platform

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
