### PR TITLE
memcached: use memcached user

### DIFF
--- a/net/memcached/Makefile
+++ b/net/memcached/Makefile
@@ -32,6 +32,7 @@ define Package/memcached
   DEPENDS:=+libevent2 +libpthread
   TITLE:=The high-performance, distributed memory object caching system
   URL:=https://memcached.org/
+  USERID:=memcached=441:memcached=441
 endef
 
 define Package/memcached/description

--- a/net/memcached/files/memcached.config
+++ b/net/memcached/files/memcached.config
@@ -1,5 +1,5 @@
 config memcached
-	option user 'nobody'
+	option user 'memcached'
 	option maxconn '1024'
 	option listen '0.0.0.0'
 	option port '11211'

--- a/net/memcached/files/memcached.init
+++ b/net/memcached/files/memcached.init
@@ -12,7 +12,7 @@ start_instance () {
 	config_get port "$section" port
 	config_get memory "$section" memory
 
-	service_start /usr/bin/memcached -d -u ${user:-nobody} \
+	service_start /usr/bin/memcached -d -u ${user:-memcached} \
 		-c ${maxconn:-1024} -l ${listen:-0.0.0.0} \
 		-p ${port:-11211} -U ${port:-11211} -m ${memory:-64}
 }


### PR DESCRIPTION
This avoid using `nobody` as user since multiple services fallback to
this user, resulting in a security issue. The UID was taken from Gentoos
`acct-user` repository.

https://gitweb.gentoo.org/repo/gentoo.git/tree/acct-user/memcached/memcached-0-r1.ebuild

Signed-off-by: Paul Spooren <mail@aparcar.org>

Maintainer: Thomas Heil <heil@terminal-consulting.de>