### PR TITLE
nextdns: Update to version 1.36.0

### DIFF
--- a/net/nextdns/Makefile
+++ b/net/nextdns/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nextdns
-PKG_VERSION:=1.35.0
+PKG_VERSION:=1.36.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=nextdns-$(PKG_VERSION).tar.gz
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.github.com/nextdns/nextdns/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=b0b5cc73d660b13f2bc9825f0a19983f7206dde1edde7abda683a6392dc355c7
+PKG_HASH:=7d29146eea9c99017bcd48b0fc17b873e87097c64b1cc45587cd7b0cab1194e0
 
 PKG_MAINTAINER:=Olivier Poitrey <rs@nextdns.io>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Update to version 1.36.0