### PR TITLE
yq: Update to 4.12.0

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.11.2
+PKG_VERSION:=4.12.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=910f64ceceabed5f63550a29923c158612be94f2855b0d10fdb549d8ad826a5f
+PKG_HASH:=6de20ab91dbec759627cd3db312c6739f7e4a177d989a5093ef8548e88d605bc
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip, x86_64
Run tested: rk3328 nanopi-r2s

Description:
- Can now convert yaml to properties properties format
- Fixed document header/footer comment handling when merging
- pretty print yaml 1.1 compatibility

Release note: https://github.com/mikefarah/yq/releases/tag/v4.12.0