### PR TITLE
usbip: Add init script for usbip-server

### DIFF
--- a/net/usbip/Makefile
+++ b/net/usbip/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=usbip
-PKG_RELEASE:=13
+PKG_RELEASE:=14
 PKG_LICENSE:=GPL-2.0-only
 
 # Since kernel 2.6.39.1 userspace tools are inside the kernel tree
@@ -67,6 +67,10 @@ define Package/usbip-server
   DEPENDS+= usbip +kmod-usbip-server
 endef
 
+define Package/usbip-server/conffiles
+/etc/config/usbipd
+endef
+
 CONFIGURE_PATH:=.
 MAKE_PATH:=.
 LIBTOOL_PATHS:=.
@@ -91,8 +95,10 @@ define Package/usbip-client/install
 endef
 
 define Package/usbip-server/install
-	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/init.d $(1)/etc/config
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/usbipd $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/usbipd.init $(1)/etc/init.d/usbipd
+	$(INSTALL_DATA) ./files/usbipd.conf $(1)/etc/config/usbipd
 endef
 
 $(eval $(call BuildPackage,usbip))

--- a/net/usbip/files/usbipd.conf
+++ b/net/usbip/files/usbipd.conf
@@ -1,0 +1,12 @@
+
+config server
+	option enable '1'
+
+	# Set listen port
+	#option port ''
+
+	# Listen on IPv4
+	option ipv4 '1'
+
+	# Listen on IPv6
+	option ipv6 '1'

--- a/net/usbip/files/usbipd.init
+++ b/net/usbip/files/usbipd.init
@@ -1,0 +1,31 @@
+#!/bin/sh /etc/rc.common
+
+START=80
+USE_PROCD=1
+
+usbipd_instance() {
+    local config="$1"
+    local enable
+    local port
+    local ipv4
+    local ipv6
+    
+    config_get_bool enable "$config" enable 1
+    [ "${enable}" = "0" ] && return 1
+
+    config_get port "$config" port
+    config_get_bool ipv4 "$config" ipv4 1
+    config_get_bool ipv6 "$config" ipv6 1
+    
+    procd_open_instance usbipd
+    procd_set_param command /usr/sbin/usbipd
+    [ -n "${port}" ] && procd_append_param command -t${port}
+    [ "${ipv4}" = "1" ] && procd_append_param command --ipv4 
+    [ "${ipv6}" = "1" ] && procd_append_param command --ipv6 
+    procd_close_instance
+}
+
+start_service() {
+    config_load usbipd
+    config_foreach usbipd_instance server
+}


### PR DESCRIPTION
Maintainer: @nunojpg (last changes were made by @neheb)
Compile tested: ramips-mt76x8, GL.iNet GL-MT300N V2, OpenWrt 21.02.0-rc4
Run tested: ramips-mt76x8, GL.iNet GL-MT300N V2, OpenWrt 21.02.0-rc4, package installs and daemon is started, config settings work 

Description:

This adds a simple procd init.d script and a uci config for the usbip-server.