### PR TITLE
dnsproxy: Update to 0.39.4

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.39.1
+PKG_VERSION:=0.39.4
 PKG_RELEASE:=$(AUTORELESE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=dcd87517ebb88b899b1f89314cfe2c32d6cb202f9b3f7a6f3173cf951f1c3734
+PKG_HASH:=51ab423880141e6ded073f1d5bec7c9e68c3d54df380e75913dbc87aa264237b
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip
Run tested: rk3328 nanopi-r2s

Description:
Release note: 
- https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.39.3
- https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.39.4