### PR TITLE
[openwrt-21.02] yq: Update to 4.12.1

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.12.0
+PKG_VERSION:=4.12.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6de20ab91dbec759627cd3db312c6739f7e4a177d989a5093ef8548e88d605bc
+PKG_HASH:=a1cc4aef9f7a7b72eb39dd8cf0fb9d726d7c2f19ec817bead9843859649ac3f3
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm27xx
Run tested: bcm2710 raspberrypi-3b

Description:
Fixed merge comment issue.

Release note: https://github.com/mikefarah/yq/releases/tag/v4.12.1