### PR TITLE
acme: Fix uhttpd restart to load new certificates (issue #16256)

### DIFF
--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -145,7 +145,7 @@ post_checks() {
 			UHTTPD_LISTEN_HTTP=
 		fi
 		uci commit uhttpd
-		/etc/init.d/uhttpd reload
+		/etc/init.d/uhttpd restart
 	fi
 
 	if [ -e /etc/init.d/nginx ] && { [ "$NGINX_WEBSERVER" -eq 1 ] || [ "$UPDATE_NGINX" -eq 1 ]; }; then


### PR DESCRIPTION
Maintainer: @tohojo
Compile tested: No
Run tested: No

Description:
You have to restart `uhttpd` after cert updates for it to load them.
Right now I have to manually restart `uhttpd` after a cert expires and a reload won't work (see #16256). I am guessing because the process still has the old cert files loaded (although they are already replaced on the filesystem). You can check and see that `/etc/init.d/uhttpd reload` does not start a new process (no new PID for `uhttpd`).

Sorry for not really testing this but I am guessing this change might be small enough for it to not break anything major. Although if there are concerns about the script restarting `uhttpd` too often you might want to make a few more changes (see [my comment in the issue](https://github.com/openwrt/packages/issues/16256#issuecomment-903186029))

Best regards
scde