### PR TITLE
keepalived: update to version 2.2.4

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
-PKG_VERSION:=2.2.2
+PKG_VERSION:=2.2.4
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software
-PKG_HASH:=103692bd5345a4ed9f4581632ea636214fdf53e45682e200aab122c4fa674ece
+PKG_HASH:=0138d69087d44beaaa589527f0cfa6885958b320a837147d02b6b7df73ebc1df
 
 PKG_CPE_ID:=cpe:/a:keepalived:keepalived
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64 and lantiq_xrx200, latest openwrt master
Run tested: lantiq_xrx200

Description:
```
root@VR2-106149 ~ # keepalived -v
Keepalived v2.2.4 (08/21,2021)

Copyright(C) 2001-2021 Alexandre Cassen, <acassen@gmail.com>

Built with kernel headers for Linux 5.4.142
Running on Linux 5.4.142 #0 SMP Mon Aug 30 07:18:56 2021
Distro: APOS master-Nelson-211-gb2fcf021b

configure options: --target=mips-openwrt-linux --host=mips-openwrt-linux --build=x86_64-pc-linux-gnu --program-prefix= --program-suffix= --prefix=/usr --exec-prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --libexecdir=/usr/lib --sysconfdir=/etc --datadir=/usr/share --localstatedir=/var --mandir=/usr/man --infodir=/usr/info --disable-nls --with-init=SYSV --disable-nftables --disable-track-process --with-run-dir=/var/run --enable-sha1 --disable-libipset-dynamic build_alias=x86_64-pc-linux-gnu host_alias=mips-openwrt-linux target_alias=mips-openwrt-linux PKG_CONFIG=/home/bbworker/bbworker/owrt_master_lantiq_xrx200/System6/build/openwrt/staging_dir/host/bin/pkg-config PKG_CONFIG_PATH=/home/bbworker/bbworker/owrt_master_lantiq_xrx200/System6/build/openwrt/staging_dir/target-mips_24kc_musl/usr/lib/pkgconfig:/home/bbworker/bbworker/owrt_master_lantiq_xrx200/System6/build/openwrt/staging_dir/target-mips_24kc_musl/usr/share/pkgconfig PKG_CONFIG_LIBDIR=/home/bbworker/bbworker/owrt_master_lantiq_xrx200/System6/build/openwrt/staging_dir/target-mips_24kc_musl/usr/lib/pkgconfig:/home/bbworker/bbworker/owrt_master_lantiq_xrx200/System6/build/openwrt/staging_dir/target-mips_24kc_musl/usr/share/pkgconfig CC=mips-openwrt-linux-musl-gcc CFLAGS=-Os -pipe -mno-branch-likely -mips32r2 -mtune=24kc -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -msoft-float -mips16 -minterlink-mips16 -fmacro-prefix-map=/home/bbworker/bbworker/owrt_master_lantiq_xrx200/System6/build/openwrt/build_dir/target-mips_24kc_musl/keepalived-2.2.4=keepalived-2.2.4 -Wformat -Werror=format-security -DPIC -fpic -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -I/home/bbworker/bbworker/owrt_master_lantiq_xrx200/System6/build/openwrt/build_dir/target-mips_24kc_musl/linux-lantiq_xrx200/linux-5.4.142  LDFLAGS=-L/home/bbworker/bbworker/owrt_master_lantiq_xrx200/System6/build/openwrt/staging_dir/toolchain-mips_24kc_gcc-10.3.0_musl/usr/lib -L/home/bbworker/bbworker/owrt_master_lantiq_xrx200/System6/build/openwrt/staging_dir/toolchain-mips_24kc_gcc-10.3.0_musl/lib -DPIC -fpic -specs=/home/bbworker/bbworker/owrt_master_lantiq_xrx200/System6/build/openwrt/include/hardened-ld-pie.specs -znow -zrelro  CPPFLAGS=-I/home/bbworker/bbworker/owrt_master_lantiq_xrx200/System6/build/openwrt/staging_dir/toolchain-mips_24kc_gcc-10.3.0_musl/usr/include -I/home/bbworker/bbworker/owrt_master_lantiq_xrx200/System6/build/openwrt/staging_dir/toolchain-mips_24kc_gcc-10.3.0_musl/include/fortify -I/home/bbworker/bbworker/owrt_master_lantiq_xrx200/System6/build/openwrt/staging_dir/toolchain-mips_24kc_gcc-10.3.0_musl/include

Config options:  LIBIPSET LVS VRRP VRRP_AUTH VRRP_VMAC DISABLE_TRACK_PROCESS OLD_CHKSUM_COMPAT INIT=SYSV

System options:  VSYSLOG MEMFD_CREATE IPV4_DEVCONF LIBNL3 RTA_ENCAP RTA_EXPIRES RTA_NEWDST RTA_PREF FRA_SUPPRESS_PREFIXLEN FRA_SUPPRESS_IFGROUP FRA_TUN_ID RTAX_CC_ALGO RTAX_QUICKACK RTEXT_FILTER_SKIP_STATS FRA_L3MDEV FRA_UID_RANGE RTAX_FASTOPEN_NO_COOKIE RTA_VIA FRA_PROTOCOL FRA_IP_PROTO FRA_SPORT_RANGE FRA_DPORT_RANGE RTA_TTL_PROPAGATE IFA_FLAGS LWTUNNEL_ENCAP_MPLS LWTUNNEL_ENCAP_ILA IPTABLES NET_LINUX_IF_H_COLLISION NETINET_LINUX_IF_ETHER_H_COLLISION LIBIPVS_NETLINK IPVS_DEST_ATTR_ADDR_FAMILY IPVS_SYNCD_ATTRIBUTES IPVS_64BIT_STATS IPVS_TUN_TYPE IPVS_TUN_CSUM IPVS_TUN_GRE VRRP_IPVLAN IFLA_LINK_NETNSID INET6_ADDR_GEN_MODE VRF SO_MARK
```