### PR TITLE
acme: add haproxy support

### DIFF
--- a/net/acme/files/acme.config
+++ b/net/acme/files/acme.config
@@ -9,6 +9,7 @@ config cert 'example_wildcard'
 	option keylength 2048
 	option update_uhttpd 1
 	option update_nginx 1
+	option update_haproxy 0
 	list domains example.org
 	list domains sub.example.org
 	list domains *.sub.example.org
@@ -26,6 +27,7 @@ config cert 'example'
 	option keylength 2048
 	option update_uhttpd 1
 	option update_nginx 1
+	option update_haproxy 0
 	list domains example.org
 	list domains sub.example.org
 	option webroot ""


### PR DESCRIPTION
Maintainer: @tohojo
Compile tested: (x86-64, x86, 21.02.0-rc4)
Run tested: (x86-64, x86, 21.02.0-rc4, tests done)

Description:

acme: add haproxy support.

If haproxy was installed, deploy cert file to haproxy and restart haproxy.