### PR TITLE
ntfs-3g: bump to 2021.8.22 (CVE fixes)

### DIFF
--- a/utils/ntfs-3g/Makefile
+++ b/utils/ntfs-3g/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntfs-3g
-PKG_VERSION:=2017.3.23
-PKG_RELEASE:=4
+PKG_VERSION:=2021.8.22
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)_ntfsprogs-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://www.tuxera.com/opensource/
-PKG_HASH:=3e5a021d7b761261836dcb305370af299793eedbded731df3d6943802e1262d5
+PKG_HASH:=55b883aa05d94b2ec746ef3966cb41e66bed6db99f22ddd41d1b8b94bb202efb
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=GPL-2.0-only LGPL-2.1-or-later
@@ -205,12 +205,11 @@ fi
 endef
 
 define Package/ntfs-3g-utils/install
-	$(INSTALL_DIR) $(1)/sbin
-	$(LN) ../usr/sbin/mkntfs $(1)/sbin/mkfs.ntfs
-	$(INSTALL_DIR) $(1)/usr/bin
+	rm -f $(PKG_INSTALL_DIR)/usr/sbin/mkfs.ntfs
+	$(INSTALL_DIR) $(1)/usr/{bin,sbin}
 	$(FIND) $(PKG_INSTALL_DIR)/usr/bin/ -type f ! -regex '.*[^/]*ntfs-3g[^/]*' -exec $(INSTALL_BIN) {} $(1)/usr/bin/ \;
-	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/* $(1)/usr/sbin/
+	$(LN) mkntfs $(1)/usr/sbin/mkfs.ntfs
 endef
 
 $(eval $(call BuildPackage,ntfs-3g))


### PR DESCRIPTION
Upstream announced new release which includes fixes for 21 CVEs (see
[1]).

Upstream changed the symlink "mkfs.ntfs" to respect "--sbin-dir". So
this commit adjusts this likewise in the Makefile.

[1] https://www.openwall.com/lists/oss-security/2021/08/30/1

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @thess 
Compile tested: master and 21.02-rc4 sdk
Run tested: 21.02-rc4, created type "7" partition on usb stick, formatted it with mkfs.ntfs, mounted it, copied a few files, unmounted it. Then I plugged the usb stick into windows laptop. It was able to read the stick fine.

Description:
Bump. Might be worth considering for a backport considering the CVEs.