### PR TITLE
perlbase-data: Add dependency on perlbase-scalar

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -11,7 +11,7 @@ include perlver.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=$(PERL_VERSION)
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_URL:=\
 		https://cpan.metacpan.org/src/5.0 \

--- a/lang/perl/perlbase.mk
+++ b/lang/perl/perlbase.mk
@@ -328,7 +328,7 @@ $(eval $(call BuildPackage,perlbase-cwd))
 define Package/perlbase-data
 $(call Package/perlbase-template)
 TITLE:=Data perl module
-DEPENDS+=+perlbase-bytes +perlbase-essential
+DEPENDS+=+perlbase-bytes +perlbase-essential +perlbase-scalar
 endef
 
 define Package/perlbase-data/install


### PR DESCRIPTION
Data::Dumper requires Scalar::Util -> add missing dependency.

Signed-off-by: Robert Högberg <robert.hogberg@gmail.com>

Maintainer: @pprindeville, @Naoir 
Compile tested: No
Run tested: No