### PR TITLE
[21.02] libssh: update to 0.9.6

### DIFF
--- a/libs/libssh/Makefile
+++ b/libs/libssh/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libssh
-PKG_VERSION:=0.9.5
+PKG_VERSION:=0.9.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.libssh.org/files/0.9/
-PKG_HASH:=acffef2da98e761fc1fd9c4fddde0f3af60ab44c4f5af05cd1b2d60a3fa08718
+PKG_HASH:=86bcf885bd9b80466fe0e05453c58b877df61afa8ba947a58c356d7f0fab829b
 
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
 PKG_LICENSE:=LGPL-2.1-or-later BSD-2-Clause


### PR DESCRIPTION
Maintainer: @mislavn
Compile tested: aarch64, Turris MOX, OpenWrt 21.02
Run tested: aarch64, Turris MOX, OpenWrt 21.02, connected to tmate (which uses libssh) over ssh

Description: backport of #16472
* fixes CVE-2021-3634