### PR TITLE
[openwrt-19.07] treewide: Remove GO_PKG_LDFLAGS for stripping binaries

### DIFF
--- a/net/kcptun/Makefile
+++ b/net/kcptun/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kcptun
 PKG_VERSION:=20190725
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/xtaci/kcptun/tar.gz/v${PKG_VERSION}?
@@ -47,7 +47,6 @@ Package/kcptun-c/description = $(Package/kcptun/description)
 Package/kcptun-s/description = $(Package/kcptun/description)
 
 GO_PKG_LDFLAGS_X:=main.VERSION=$(PKG_VERSION)
-GO_PKG_LDFLAGS:=-s -w
 
 define Package/kcptun/install
 	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))

--- a/net/nextdns/Makefile
+++ b/net/nextdns/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nextdns
 PKG_VERSION:=1.36.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=nextdns-$(PKG_VERSION).tar.gz
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
@@ -25,7 +25,6 @@ PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
 GO_PKG:=github.com/nextdns/nextdns
-GO_PKG_LDFLAGS:=-s -w
 GO_PKG_LDFLAGS_X:=main.version=$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk

--- a/net/restic-rest-server/Makefile
+++ b/net/restic-rest-server/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=restic-rest-server
 PKG_VERSION:=0.9.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/rest-server-$(PKG_VERSION)
 PKG_SOURCE:=rest-server-$(PKG_VERSION).tar.gz
@@ -19,7 +19,6 @@ PKG_USE_MIPS16:=0
 
 GO_PKG:=github.com/restic/rest-server/
 GO_PKG_BUILD_PKG:=github.com/restic/rest-server/cmd/rest-server/
-GO_PKG_LDFLAGS:=-s -w
 GO_PKG_LDFLAGS_X:=main.version=$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk

--- a/utils/restic/Makefile
+++ b/utils/restic/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=restic
 PKG_VERSION:=0.9.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/restic/restic/tar.gz/v${PKG_VERSION}?
@@ -18,7 +18,6 @@ PKG_USE_MIPS16:=0
 
 GO_PKG:=github.com/restic/restic/
 GO_PKG_BUILD_PKG:=github.com/restic/restic/cmd/restic/
-GO_PKG_LDFLAGS:=-s -w
 GO_PKG_LDFLAGS_X:=main.version=$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: @liudf0716 (kcptun), @rs (nextdns), @gekmihesg (restic, restic-rest-server)
Compile tested: armvirt-32, 19.07.8 sdk
Run tested: none

Description:
The `"-s -w"` flags in `GO_PKG_LDFLAGS` tells the Go compiler to strip the binaries it produces. Since the default Go package build process will strip binaries when `CONFIG_USE_STRIP` or `CONFIG_USE_SSTRIP` are selected, these flags are unnecessary.

When `CONFIG_NO_STRIP` is selected, these flags override the user's intention of building unstripped packages.

This removes these flags for all relevant packages.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>