### PR TITLE
tor: bump to 0.4.6.7 stable

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.6.6
+PKG_VERSION:=0.4.6.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=3423189ba455372021ed44e0be576d181f2908cbd9bdef202d9c11c950882e12
+PKG_HASH:=ff665ce121b2952110bd98b9c8741b5593bf6c01ac09033ad848ed92c2510f9a
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @hauke, @tripolar

Run tested (tor-basic):
mvebu/cortexa9, master