### PR TITLE
hplip:: add a patch to fix PIE builds

### DIFF
--- a/utils/hplip/patches/070-respect-cflags.patch
+++ b/utils/hplip/patches/070-respect-cflags.patch
@@ -1,0 +1,29 @@
+--- a/configure.in
++++ b/configure.in
+@@ -632,14 +632,14 @@ if test "$class_driver" = "no" && test "
+    fi
+ fi
+ 
+-SAVE_CPPFLAGS="$CPPFLAGS"
++SAVE_CFLAGS="$CFLAGS"
+ CFLAGS=`python-config --includes`
+-if [ $? -eq 0 ] 
++if test $? -eq 0
+ then
+    echo $FLAGS
+ else
+ CFLAGS=`python3-config --includes`
+-   if [ $? -eq 0 ]
++   if test $? -eq 0
+    then
+    echo $FLAGS
+    fi
+@@ -659,7 +659,7 @@ if test "$class_driver" = "no" && test "
+    AS_IF([test "x$FOUND_HEADER" != "xyes"],
+           [AC_MSG_ERROR([cannot find python-devel support], 6)])
+ fi
+-CFLAGS="$save_CFLAGS"
++CFLAGS="$SAVE_CFLAGS"
+ 
+ if test "$hpijs_only_build" = "no" && test "$scan_build" = "yes" && test "$hpcups_only_build" = "no"; then
+    AC_CHECK_LIB([sane], [sane_open], [LIBS="$LIBS"], [AC_MSG_ERROR([cannot find sane-backends-devel support (or --disable-scan-build)], 12)])


### PR DESCRIPTION
Maintainer: @luizluca
Compile tested: aarch64, Turris MOX, OpenWrt 21.02

Description: PIE breaks the build:
```
ld: hp-hp.o: relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `stderr' which may bind externally can not be used when making a shared object; recompile with -fPIC
ld: hp-hp.o(.text+0xb8): unresolvable R_AARCH64_ADR_PREL_PG_HI21 relocation against symbol `stderr'
ld: final link failed: bad value
collect2: error: ld returned 1 exit status
```
