### PR TITLE
libtorrent-rasterbar: update to 2.0.4

### DIFF
--- a/libs/libtorrent-rasterbar/Makefile
+++ b/libs/libtorrent-rasterbar/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtorrent-rasterbar
-PKG_VERSION:=2.0.2
+PKG_VERSION:=2.0.4
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/arvidn/libtorrent/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=d5960e8c9f80f62126d723c6cc0522e7900c9c323f28994027eae3325fe03a3f
+PKG_HASH:=dfbc0d67c75e828530ee2b705442196429eaf255a3f757099e69c95f33e6f940
 
 PKG_MAINTAINER:=David Yang <mmyangfl@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/libs/libtorrent-rasterbar/patches/010-boost.patch
+++ b/libs/libtorrent-rasterbar/patches/010-boost.patch
@@ -1,0 +1,31 @@
+From 8ed34b67df8c795780f80db5be35ad468713110e Mon Sep 17 00:00:00 2001
+From: arvidn <arvid@libtorrent.org>
+Date: Thu, 19 Aug 2021 11:54:13 +0200
+Subject: [PATCH] bump handler allocation sizes for boost-1.77 (linux)
+
+---
+ include/libtorrent/aux_/allocating_handler.hpp | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+--- a/include/libtorrent/aux_/allocating_handler.hpp
++++ b/include/libtorrent/aux_/allocating_handler.hpp
+@@ -122,14 +122,14 @@ namespace libtorrent { namespace aux {
+ 	constexpr std::size_t fuzzer_write_cost = 0;
+ 	constexpr std::size_t fuzzer_read_cost = 0;
+ #endif
+-	constexpr std::size_t write_handler_max_size = tracking + debug_write_iter + openssl_write_cost + fuzzer_write_cost + 152;
+-	constexpr std::size_t read_handler_max_size = tracking + debug_read_iter + openssl_read_cost + fuzzer_read_cost + 152;
+-	constexpr std::size_t udp_handler_max_size = tracking + 144;
+-	constexpr std::size_t utp_handler_max_size = tracking + 168;
++	constexpr std::size_t write_handler_max_size = tracking + debug_write_iter + openssl_write_cost + fuzzer_write_cost + 168;
++	constexpr std::size_t read_handler_max_size = tracking + debug_read_iter + openssl_read_cost + fuzzer_read_cost + 168;
++	constexpr std::size_t udp_handler_max_size = tracking + 160;
++	constexpr std::size_t utp_handler_max_size = tracking + 184;
+ 	constexpr std::size_t abort_handler_max_size = tracking + 72;
+ 	constexpr std::size_t submit_handler_max_size = tracking + 72;
+ 	constexpr std::size_t deferred_handler_max_size = tracking + 80;
+-	constexpr std::size_t tick_handler_max_size = tracking + 112;
++	constexpr std::size_t tick_handler_max_size = tracking + 128;
+ #endif
+ 
+ 	enum HandlerName


### PR DESCRIPTION
Fixes compilation with boost 1.77

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @yangfl 
Compile tested: ath79
