### PR TITLE
kea: fix compilation with boost 1.77

### DIFF
--- a/net/kea/patches/040-map.patch
+++ b/net/kea/patches/040-map.patch
@@ -1,0 +1,10 @@
+--- a/src/lib/dhcpsrv/timer_mgr.cc
++++ b/src/lib/dhcpsrv/timer_mgr.cc
+@@ -12,6 +12,7 @@
+ #include <exceptions/exceptions.h>
+ 
+ #include <functional>
++#include <map>
+ #include <utility>
+ 
+ using namespace isc;


### PR DESCRIPTION
Missing header.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @rosysong @hbl0307106015
Compile tested: ath79