### PR TITLE
libzip: fix compilation without SSL

### DIFF
--- a/libs/libzip/Makefile
+++ b/libs/libzip/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libzip
 PKG_VERSION:=1.8.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://libzip.org/download/

--- a/libs/libzip/patches/010-nossl.patch
+++ b/libs/libzip/patches/010-nossl.patch
@@ -1,0 +1,13 @@
+--- a/lib/zipint.h
++++ b/lib/zipint.h
+@@ -180,8 +180,10 @@ zip_source_t *zip_source_pkware_decode(z
+ zip_source_t *zip_source_pkware_encode(zip_t *, zip_source_t *, zip_uint16_t, int, const char *);
+ int zip_source_remove(zip_source_t *);
+ zip_int64_t zip_source_supports(zip_source_t *src);
++#ifdef HAVE_CRYPTO
+ zip_source_t *zip_source_winzip_aes_decode(zip_t *, zip_source_t *, zip_uint16_t, int, const char *);
+ zip_source_t *zip_source_winzip_aes_encode(zip_t *, zip_source_t *, zip_uint16_t, int, const char *);
++#endif
+ zip_source_t *zip_source_buffer_with_attributes(zip_t *za, const void *data, zip_uint64_t len, int freep, zip_file_attributes_t *attributes);
+ zip_source_t *zip_source_buffer_with_attributes_create(const void *data, zip_uint64_t len, int freep, zip_file_attributes_t *attributes, zip_error_t *error);
+ 


### PR DESCRIPTION
Linker error. No idea why.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mhei 
Compile tested: ath79

In my local environment, something changed and now linking is more strict. I have no idea why.