### PR TITLE
libuwsc: fix compilation without ssl

### DIFF
--- a/libs/libuwsc/patches/020-ssl.patch
+++ b/libs/libuwsc/patches/020-ssl.patch
@@ -1,0 +1,7 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,4 +5,3 @@ project(libuwsc C)
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+ 
+ add_subdirectory(src)
+-add_subdirectory(example)


### PR DESCRIPTION
The examples require SSL support.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @zhaojh329 
Compile tested: ath79