### PR TITLE
python-astral: update to version 2.2

### DIFF
--- a/lang/python/python-astral/Makefile
+++ b/lang/python/python-astral/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+# Copyright (C) 2019-2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-astral
-PKG_VERSION:=1.10.1
-PKG_RELEASE:=2
+PKG_VERSION:=2.2
+PKG_RELEASE:=1
 
 PYPI_NAME:=astral
-PKG_HASH:=d2a67243c4503131c856cafb1b1276de52a86e5b8a1d507b7e08bee51cb67bf1
+PKG_HASH:=e41d9967d5c48be421346552f0f4dedad43ff39a83574f5ff2ad32b6627b6fbe
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu, cortexa9, OpenWrt 21.02
Run tested: Turris Omnia, mvebu, cortexa9, OpenWrt 21.02

Description:

1. Add dependency for `python3-distutils`
```
Searching python-astral (showing max 3 matches per file, 1 line of context):

    Found imports for: distutils
        monkeypatch.py-   4-	import sys
        monkeypatch.py:   5:	import distutils.dist
        monkeypatch.py:   6:	from distutils.util import check_environ
        monkeypatch.py:   7:	from distutils.debug import DEBUG
        monkeypatch.py-   8-	import setuptools.command.sdist

Suggested dependencies for python-astral:
    +python3-distutils
```

2. Run tested astral:
```
root@turris:~# python3
Python 3.9.6 (default, Sep 05 2021, 23:55:28) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
i>>> import astral
>>> from astral import LocationInfo
>>> city = LocationInfo("London", "England", "Europe/London", 51.5, -0.116)
>>> print((
...     f"Information for {city.name}/{city.region}\n"
...     f"Timezone: {city.timezone}\n"
...     f"Latitude: {city.latitude:.02f}; Longitude: {city.longitude:.02f}\n"
... ))
Information for London/England
Timezone: Europe/London
Latitude: 51.50; Longitude: -0.12

>>> 
```

3. This version is used by Home Assistant and I would like to cherry-pick it to OpenWrt 21.02.
Changelog for Astral: https://astral.readthedocs.io/en/latest/index.html
