### PR TITLE
python-aiohttp: update to version 3.7.4post0

### DIFF
--- a/lang/python/python-aiohttp/Makefile
+++ b/lang/python/python-aiohttp/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aiohttp
-PKG_VERSION:=3.7.4
+PKG_VERSION:=3.7.4.post0
 PKG_RELEASE:=1
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=5d84ecc73141d0a0d61ece0742bb7ff5751b0657dab8405f899d3ceb104cc7de
+PKG_HASH:=493d3299ebe5f5a7c66b9819eacdcfbbaaf1a8e84911ddffcdc48888497afecf
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu, cortexa9, OpenWrt 21.02
Run tested: Turris Omnia, mvebu, cortexa9, OpenWrt 21.02

Description:
Changelog:
- Bumped upper bound of the chardet runtime dependency to allow their v4.0 version stream.

From https://github.com/aio-libs/aiohttp/blob/a1158c5389854f9885c30e08b0020e2d7d8a290f/CHANGES.rst