### PR TITLE
python-certifi: update to version 2021.5.30

### DIFF
--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
-PKG_VERSION:=2020.6.20
+PKG_VERSION:=2021.5.30
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
@@ -14,7 +14,7 @@ PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PYPI_NAME:=certifi
-PKG_HASH:=5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3
+PKG_HASH:=2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: @cotequeiroz 
Compile tested: Turris Omnia, mvebu, cortexa9, OpenWrt 21.02
Run tested: Turris Omnia, mvebu, cortexa9, OpenWrt 21.02
```
python3
Python 3.9.6 (default, Sep 05 2021, 23:55:28) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import certifi
>>> certifi.where()
'/usr/lib/python3.9/site-packages/certifi/cacert.pem'
```


Description:
- Update to version [2021.5.30](https://github.com/certifi/python-certifi/releases/tag/2021.05.30)
