### PR TITLE
acme: Fix uhttpd restart to load new certificates

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme
 PKG_VERSION:=2.8.7
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/acmesh-official/acme.sh/tar.gz/$(PKG_VERSION)?

--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -152,7 +152,7 @@ post_checks()
 			UHTTPD_LISTEN_HTTP=
 		fi
 		uci commit uhttpd
-		/etc/init.d/uhttpd reload
+		/etc/init.d/uhttpd restart
 	fi
 
 	if [ -e /etc/init.d/nginx ] && ( [ "$NGINX_WEBSERVER" -eq 1 ] || [ "$UPDATE_NGINX" -eq 1 ] ); then


### PR DESCRIPTION
Maintainer: @tohojo
Compile tested: -
Run tested: -

Description:
Bring the merged fix (#16482) from `master` to the `openwrt-21.02` branch.

@neheb I also bumped the `PKG_RELEASE` to 6. Is this done correctly this time?

Best regards
Dennis
