### PR TITLE
grep: use posix shebang for egrep/fgrep

### DIFF
--- a/utils/grep/Makefile
+++ b/utils/grep/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grep
 PKG_VERSION:=3.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/grep
@@ -22,6 +22,8 @@ PKG_CPE_ID:=cpe:/a:gnu:grep
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+
+MAKE_FLAGS += SHELL="/bin/sh"
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Maintainer: @Zokormazo
Compile tested: -
Run tested: -
Related issue: https://github.com/openwrt/packages/issues/16548

Description:
Use POSIX shebang for egrep/fgrep instead of the variable/Bash.
The issue affects both master and openwrt-21.02.

Signed-off-by: Vladislav Grigoryev <vg.aetera@gmail.com>