### PR TITLE
python-yarl: update to version 1.6.3

### DIFF
--- a/lang/python/python-yarl/Makefile
+++ b/lang/python/python-yarl/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+# Copyright (C) 2019-2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yarl
-PKG_VERSION:=1.6.2
+PKG_VERSION:=1.6.3
 PKG_RELEASE:=1
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=c45b49b59a5724869899798e1bbd447ac486215269511d3b76b4c235a1b766b6
+PKG_HASH:=8a9066529240171b68893d60dca86a763eae2139dd42f42106b03cf4b426bf10
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Run & compile tested: Turris Omnia, mvebu, cortexa9, OpenWrt 21.02
```
root@turris:~# python3
Python 3.9.6 (default, Sep 05 2021, 23:55:28) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from yarl import URL
>>> url = URL('https://www.python.org/~guido?arg=1#frag')
>>> url
URL('https://www.python.org/~guido?arg=1#frag')
>>> 
```

Description:
- update to version [1.6.3](https://github.com/aio-libs/yarl/releases/tag/v1.6.3)