### PR TITLE
fail2ban: fix package for fail2ban v0.11.2

### DIFF
--- a/net/fail2ban/Makefile
+++ b/net/fail2ban/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fail2ban
 PKG_VERSION:=0.11.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fail2ban/fail2ban/tar.gz/$(PKG_VERSION)?
@@ -46,12 +46,16 @@ define Package/fail2ban/conffiles
 /etc/config/fail2ban
 endef
 
+define Py3Package/fail2ban/filespec
++|$(PYTHON3_PKG_DIR)
+-|$(PYTHON3_PKG_DIR)/fail2ban/tests
+endef
+
 define Py3Package/fail2ban/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fail2ban-server $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fail2ban-client $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fail2ban-regex $(1)/usr/bin/
-	$(LN) /usr/bin/python3 $(1)/usr/bin/fail2ban-python
 
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/fail2ban.config $(1)/etc/config/fail2ban

--- a/net/fail2ban/patches/001-fail2ban-fix-python3-script.patch
+++ b/net/fail2ban/patches/001-fail2ban-fix-python3-script.patch
@@ -1,0 +1,8 @@
+--- a/config/filter.d/ignorecommands/apache-fakegooglebot
++++ b/config/filter.d/ignorecommands/apache-fakegooglebot
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env fail2ban-python
++#!/usr/bin/env python3
+ # Inspired by https://isc.sans.edu/forums/diary/When+Google+isnt+Google/15968/
+ #
+ # Written in Python to reuse built-in Python batteries and not depend on


### PR DESCRIPTION
fail2ban v0.11.2 package version 2

Following PR #15098, add fixes to build fail2ban package:
- remove use of fail2ban-python (directly use python3 in script)
- remove link to python3 in /usr/bin (break the package build)
- remove python-tests (reduce the package size)

Signed-off-by: Kerma Gérald <gandalf@gk2.net>

Maintainer: Kerma Gérald / @erdoukki / gandalf@gk2.net 
Compile tested: (aarch64_cortex-a53, espressobin board, OpenWrt master)
Run tested: (aarch64_cortex-a53, espressobin board, OpenWrt master)

Description:
https://github.com/openwrt/packages/pull/15098#issuecomment-912067680
@jefferyto @neheb 