### PR TITLE
python3-speedtest-cli: update to 2.1.3

### DIFF
--- a/lang/python/python3-speedtest-cli/Makefile
+++ b/lang/python/python3-speedtest-cli/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python3-speedtest-cli
-PKG_VERSION:=2.1.2
-PKG_RELEASE:=2
+PKG_VERSION:=2.1.3
+PKG_RELEASE:=1
 
 PYPI_NAME:=speedtest-cli
-PKG_HASH:=cf1d386222f94c324e3125ba9a0d187e46d4a13dca08c023bdb9a23096be2e54
+PKG_HASH:=5e2773233cedb5fa3d8120eb7f97bcc4974b5221b254d33ff16e2f1d413d90f0
 
 PKG_MAINTAINER:=Jaymin Patel <jem.patel@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
This includes a fix for a breaking change in the Speedtest API.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>

Maintainer: @jempatel  
Compile tested: mpc85xx 21.02, x86_64 21.02
Run tested: mpc85xx p2041rdb 21.02 / x86_64 21.02

Description:
An error like below was consistently seen (taken from 2.1.2 on Ubuntu 20.04, I did not take note of the OpenWrt stack trace at the time) when attempting to run a test:
```
Traceback (most recent call last):
  File "/usr/bin/speedtest-cli", line 11, in <module>
    load_entry_point('speedtest-cli==2.1.2', 'console_scripts', 'speedtest-cli')()
  File "/usr/lib/python3/dist-packages/speedtest.py", line 1986, in main
    shell()
  File "/usr/lib/python3/dist-packages/speedtest.py", line 1872, in shell
    speedtest = Speedtest(
  File "/usr/lib/python3/dist-packages/speedtest.py", line 1091, in __init__
    self.get_config()
  File "/usr/lib/python3/dist-packages/speedtest.py", line 1173, in get_config
    ignore_servers = list(
ValueError: invalid literal for int() with base 10: ''
```