### PR TITLE
haproxy: Update HAProxy to v2.4.4

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=2.4.3
-PKG_RELEASE:=1
+PKG_VERSION:=2.4.4
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/2.4/src
-PKG_HASH:=ce479380be5464faa881dcd829618931b60130ffeb01c88bc2bf95e230046405
+PKG_HASH:=116b7329cebee5dab8ba47ad70feeabd0c91680d9ef68c28e41c34869920d1fe
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Christian Lachner <gladiac@gmail.com>

--- a/net/haproxy/get-latest-patches.sh
+++ b/net/haproxy/get-latest-patches.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CLONEURL=https://git.haproxy.org/git/haproxy-2.4.git
-BASE_TAG=v2.4.3
+BASE_TAG=v2.4.4
 TMP_REPODIR=tmprepo
 PATCHESDIR=patches
 


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Christian Lachner <gladiac@gmail.com> (/me)
Compile tested: mips, ipq806x, x86, arc700
Run tested: ipq806x (r7800)

Description: Update HAProxy to v2.4.4
- **This update fixes CVE-2021-40346**; see: [JFrog: Critical Vulnerability in HAProxy (CVE-2021-40346): Integer Overflow Enables HTTP Smuggling](https://jfrog.com/blog/critical-vulnerability-in-haproxy-cve-2021-40346-integer-overflow-enables-http-smuggling/)
- Update haproxy download URL and hash
- Make use of $(AUTORELEASE) for PKG_RELEASE