### PR TITLE
[openwrt-19-07] haproxy: Update HAProxy to v2.0.25

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=2.0.21
+PKG_VERSION:=2.0.25
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/2.0/src
-PKG_HASH:=9823fd0e33d77827538edc3ac86fb5d5c099e63350bdafc3beaa2632491a0132
+PKG_HASH:=97b0f1e8d786364c9594b087b0c2ad03c575f3e52f6fabd11045cc6d35f2f934
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Christian Lachner <gladiac@gmail.com>

--- a/net/haproxy/get-latest-patches.sh
+++ b/net/haproxy/get-latest-patches.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CLONEURL=https://git.haproxy.org/git/haproxy-2.0.git
-BASE_TAG=v2.0.21
+BASE_TAG=v2.0.25
 TMP_REPODIR=tmprepo
 PATCHESDIR=patches
 


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Christian Lachner <gladiac@gmail.com> (/me)
Compile tested: mips, ipq806x, x86, arc700

Description: Update HAProxy to v2.0.25
- **This update fixes CVE-2021-40346**; see: [JFrog: Critical Vulnerability in HAProxy (CVE-2021-40346): Integer Overflow Enables HTTP Smuggling](https://jfrog.com/blog/critical-vulnerability-in-haproxy-cve-2021-40346-integer-overflow-enables-http-smuggling/)
- Update haproxy download URL and hash