### PR TITLE
bind: update to version 9.16.20

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.16.18
+PKG_VERSION:=9.16.20
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=3c6263a4364eb5dce233f9f22b90acfa1ec2488d534f91d21663d0ac25ce5e65
+PKG_HASH:=4d0d93c0d0b63080609e84625f24ff8777f8d164e78a75b1c19c334ce42d5b58
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/patches/002-map-format-fix.patch
+++ b/net/bind/patches/002-map-format-fix.patch
@@ -1,0 +1,23 @@
+From b70a2c2d074a57aac4b1ec996b881a5b93a2cf39 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20=C5=A0pa=C4=8Dek?= <pspacek@isc.org>
+Date: Thu, 19 Aug 2021 19:54:44 +0200
+Subject: [PATCH] increase MAPAPI
+
+bump the map zonefile version number to avoid an assertion
+failure when loading map files from versions of BIND prior to
+the most recent change to the in-memory structure of zone
+databases.
+
+(cherry picked from commit 4a68c7be225ddc3443d647bb8257278c1fdb4da8)
+---
+ lib/dns/mapapi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/lib/dns/mapapi
++++ b/lib/dns/mapapi
+@@ -13,4 +13,4 @@
+ # Whenever releasing a new major release of BIND9, set this value
+ # back to 1.0 when releasing the first alpha.  Map files are *never*
+ # compatible across major releases.
+-MAPAPI=2.0
++MAPAPI=3.0


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07.8
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07.8 - Dig works, DNS resolving via named works, too.

Description:
- Changelog: http://ftp.iij.ad.jp/pub/network/isc/bind9/9.16.20/RELEASE-NOTES-bind-9.16.20.html
- Fixes [CVE-2021-25218](https://nvd.nist.gov/vuln/detail/CVE-2021-25218)
