### PR TITLE
[openwrt-21.02] wsdd2: update to git (2021-08-09), switch to Netgear repo

### DIFF
--- a/net/wsdd2/Makefile
+++ b/net/wsdd2/Makefile
@@ -4,10 +4,10 @@ PKG_NAME:=wsdd2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/Andy2244/wsdd2.git
-PKG_SOURCE_DATE:=2021-06-28
-PKG_SOURCE_VERSION:=062a9542d4bad31f3a9c6f36c9d9ea53c01ebdf6
-PKG_MIRROR_HASH:=651662d165c63925f5932dc716beb4949aa03755ea04300bb7dfd5f186a8b69a
+PKG_SOURCE_URL:=https://github.com/Netgear/wsdd2.git
+PKG_SOURCE_DATE:=2021-08-09
+PKG_SOURCE_VERSION:=bcc51c3ee97df57a8c0efdbd0ac4097deb3029d0
+PKG_MIRROR_HASH:=46285c90e6f28586edae2e4b8e5f5c850a0dd6655c1f0e01076e05bddd4725fb
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only
@@ -20,7 +20,7 @@ define Package/wsdd2
   CATEGORY:=Network
   SUBMENU:=IP Addresses and Names
   TITLE:=Web Services for Devices (WSD) daemon
-  URL:=https://kb.netgear.com/2649/NETGEAR-Open-Source-Code-for-Programmers-GPL
+  URL:=https://github.com/Netgear/wsdd2
 endef
 
 define Package/wsdd2/description


### PR DESCRIPTION
Maintainer: me
Compile tested: arm
Run tested:

Description:
* update to git (2021-08-09)
* switch to Netgear repo