### PR TITLE
owntone: update to 28.2

### DIFF
--- a/sound/owntone/Makefile
+++ b/sound/owntone/Makefile
@@ -7,13 +7,13 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=forked-daapd
-PKG_VERSION:=27.4
+PKG_NAME:=owntone
+PKG_VERSION:=28.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://github.com/ejurgensen/$(PKG_NAME)/releases/download/$(PKG_VERSION)/
-PKG_HASH:=00f71c687df268a3c4db77cecf37972e76832a99e34f09750d07a92934a0bfa8
+PKG_SOURCE_URL:=https://github.com/owntone/owntone-server/releases/download/$(PKG_VERSION)/
+PKG_HASH:=7e5a0142d852569dc28a99a2e26568856717544e894904aa0e63950fdafa2666
 
 PKG_FIXUP:=autoreconf
 PKG_USE_MIPS16:=0
@@ -26,38 +26,33 @@ PKG_LICENSE_FILES:=COPYING
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
-define Package/forked-daapd
+define Package/owntone
 SECTION:=sound
 CATEGORY:=Sound
 TITLE:=iTunes (DAAP) server for Apple Remote and AirPlay
-URL:=https://github.com/ejurgensen/forked-daapd
+URL:=https://github.com/owntone/owntone-server
 DEPENDS:=+libgpg-error +libgcrypt +libgdbm +zlib +libexpat +libunistring \
 	+libevent2 +libdaemon +libantlr3c +confuse +alsa-lib +libffmpeg-full \
 	+mxml +libavahi-client +sqlite3-cli +libplist +libcurl +libjson-c \
-	+libprotobuf-c +libgnutls +libsodium +libwebsockets $(ICONV_DEPENDS) \
-	+libuuid
+	+libprotobuf-c +libgnutls +libsodium +libwebsockets +libuuid $(ICONV_DEPENDS)
 endef
 
-define Package/forked-daapd/description
-  forked-daapd is a Linux/FreeBSD DAAP (iTunes), MPD (Music Player Daemon) and
+define Package/owntone/description
+  OwnTone is a Linux/FreeBSD DAAP (iTunes), MPD (Music Player Daemon) and
   RSP (Roku) media server. It has support for AirPlay speakers, Chromecast,
   Apple Remote (and compatibles), MPD clients, internet radio and LastFM. It
   does not support AirPlay/Chromecast video.
 endef
 
-define Package/forked-daapd/conffiles
-/etc/forked-daapd.conf
+define Package/owntone/conffiles
+/etc/owntone.conf
 endef
 
 CONFIGURE_ARGS += \
-	--enable-lastfm \
-	--enable-mpd \
 	--enable-chromecast \
-	--enable-verification \
-	--enable-webinterface \
-	--disable-spotify \
-	--with-libplist \
-	--with-libwebsockets \
+	--disable-install_systemd \
+	--disable-install_conf_file \
+	--disable-install_user \
 	--with-alsa \
 	--without-pulseaudio \
 	--without-libevent_pthreads
@@ -65,15 +60,15 @@ CONFIGURE_ARGS += \
 TARGET_CFLAGS += $(FPIC)
 TARGET_LDFLAGS += -Wl,-rpath-link,$(STAGING_DIR)/usr/lib
 
-define Package/forked-daapd/install
+define Package/owntone/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/forked-daapd $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/owntone $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc
-	$(INSTALL_CONF) ./files/forked-daapd.conf $(1)/etc/forked-daapd.conf
-	$(INSTALL_DIR) $(1)/usr/lib/forked-daapd
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/forked-daapd/* $(1)/usr/lib/forked-daapd/
+	$(INSTALL_CONF) ./files/owntone.conf $(1)/etc/owntone.conf
+	$(INSTALL_DIR) $(1)/usr/lib/owntone
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/owntone/* $(1)/usr/lib/owntone/
 	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) ./files/forked-daapd.init $(1)/etc/init.d/forked-daapd
+	$(INSTALL_BIN) ./files/owntone.init $(1)/etc/init.d/owntone
 endef
 
-$(eval $(call BuildPackage,forked-daapd))
+$(eval $(call BuildPackage,owntone))

--- a/sound/owntone/files/owntone.conf
+++ b/sound/owntone/files/owntone.conf
@@ -1,4 +1,4 @@
-# A quick guide to configuring forked-daapd:
+# A quick guide to configuring OwnTone:
 #
 # For regular use, the most important setting to configure is "directories",
 # which should be the location of your media. Whatever user you have set as
@@ -11,14 +11,19 @@ general {
 	# Username
 	# Make sure the user has read access to the library directories you set
 	# below, and full access to the databases, log and local audio
-	uid = "daapd"
+	uid = "owntone"
 
 	# Database location
-#	db_path = "/var/cache/forked-daapd/songs3.db"
+#	db_path = "/var/cache/owntone/songs3.db"
+
+	# Database backup location
+	# Uncomment and specify a full path to enable abilty to use REST endpoint
+	# to initiate backup of songs3.db
+#	db_backup_path = "/var/cache/owntone/songs3.bak"
 
 	# Log file and level
 	# Available levels: fatal, log, warning, info, debug, spam
-	logfile = "/var/log/forked-daapd.log"
+	logfile = "/var/log/owntone.log"
 	loglevel = log
 
 	# Admin password for the web interface
@@ -29,6 +34,10 @@ general {
 	# Websocket port for the web interface.
 #	websocket_port = 3688
 
+	# Websocket interface to bind listener to (e.g. "eth0"). Default is
+	# disabled, which means listen on all interfaces.
+#	websocket_interface = ""
+
 	# Sets who is allowed to connect without authorisation. This applies to
 	# client types like Remotes, DAAP clients (iTunes) and to the web
 	# interface. Options are "any", "localhost" or the prefix to one or
@@ -36,10 +45,15 @@ general {
 #	trusted_networks = { "localhost", "192.168", "fd" }
 
 	# Enable/disable IPv6
-	ipv6 = no
+	ipv6 = yes
+
+	# Set this if you want the server to bind to a specific IP address. Can
+	# be ipv6 or ipv4. Default (commented out or "::") is to listen on all
+	# IP addresses.
+#	bind_address = "::"
 
 	# Location of cache database
-#	cache_path = "/var/cache/forked-daapd/cache.db"
+#	cache_path = "/var/cache/owntone/cache.db"
 
 	# DAAP requests that take longer than this threshold (in msec) get their
 	# replies cached for next time. Set to 0 to disable caching.
@@ -126,7 +140,7 @@ library {
 #	name_radio      = "Radio"
 
 	# Artwork file names (without file type extension)
-	# forked-daapd will look for jpg and png files with these base names
+	# OwnTone will look for jpg and png files with these base names
 #	artwork_basenames = { "artwork", "cover", "Folder" }
 
 	# Enable searching for artwork corresponding to each individual media
@@ -148,11 +162,11 @@ library {
 #	filepath_ignore = { "myregex" }
 
 	# Disable startup file scanning
-	# When forked-daapd starts it will do an initial file scan of your
+	# When OwnTone starts it will do an initial file scan of your
 	# library (and then watch it for changes). If you are sure your library
-	# never changes while forked-daapd is not running, you can disable the
+	# never changes while OwnTone is not running, you can disable the
 	# initial file scan and save some system ressources. Disabling this scan
-	# may lead to forked-daapd's database coming out of sync with the
+	# may lead to OwnTone's database coming out of sync with the
 	# library. If that happens read the instructions in the README on how
 	# to trigger a rescan.
 #	filescan_disable = false
@@ -170,7 +184,7 @@ library {
 	# Decoding options for DAAP clients
 	# Since iTunes has native support for mpeg, mp4a, mp4v, alac and wav,
 	# such files will be sent as they are. Any other formats will be decoded
-	# to raw wav. If forked-daapd detects a non-iTunes DAAP client, it is
+	# to raw wav. If OwnTone detects a non-iTunes DAAP client, it is
 	# assumed to only support mpeg and wav, other formats will be decoded.
 	# Here you can change when to decode. Note that these settings have no
 	# effect on AirPlay.
@@ -202,7 +216,7 @@ library {
 #	allow_modifying_stored_playlists = false
 
 	# A directory in one of the library directories that will be used as the default
-	# playlist directory. forked-dapd creates new playlists in this directory if only
+	# playlist directory. OwnTone creates new playlists in this directory if only
 	# a playlist name is provided (requires "allow_modify_stored_playlists" set to true).
 #	default_playlist_directory = ""
 }
@@ -256,8 +270,7 @@ audio {
 # README about ALSA for details. Note that these settings will override the ALSA
 # settings in the "audio" section above.
 #alsa "card name" {
-	# Name - used in the speaker list in Remote
-	# If not set, the card name will be used
+	# Name used in the speaker list. If not set, the card name will be used.
 #	nickname = "Computer"
 
 	# Mixer channel to use for volume control
@@ -270,7 +283,7 @@ audio {
 #}
 
 # Pipe output
-# Allows forked-daapd to output audio data to a named pipe
+# Allows OwnTone to output audio data to a named pipe
 #fifo {
 #	nickname = "fifo"
 #	path = "/path/to/fifo"
@@ -278,8 +291,9 @@ audio {
 
 # AirPlay settings common to all devices
 #airplay_shared {
-        # UDP ports used when airplay devices make connections back to forked-daapd
-        # (choosing specific ports may be helpful when running forked-daapd behind a firewall)
+        # UDP ports used when airplay devices make connections back to
+	# OwnTone (choosing specific ports may be helpful when running
+	# OwnTone behind a firewall)
 #       control_port = 0
 #       timing_port = 0
 #}
@@ -287,7 +301,7 @@ audio {
 # AirPlay per device settings
 # (make sure you get the capitalization of the device name right)
 #airplay "My AirPlay device" {
-	# forked-daapd's volume goes to 11! If that's more than you can handle
+	# OwnTone's volume goes to 11! If that's more than you can handle
 	# you can set a lower value here
 #	max_volume = 11
 
@@ -297,32 +311,51 @@ audio {
 
 	# Enable this option to keep a particular AirPlay device in the speaker
 	# list and thus ignore mdns notifications about it no longer being
-	# present. The speaker will remain until restart of forked-daapd.
+	# present. The speaker will remain until restart of OwnTone.
 #	permanent = false
 
 	# Some devices spuriously disconnect during playback, and based on the
-	# device type forked-daapd may attempt to reconnect. Setting this option
+	# device type OwnTone may attempt to reconnect. Setting this option
 	# overrides this so reconnecting is either always enabled or disabled.
 #	reconnect = false
 
 	# AirPlay password
 #	password = "s1kr3t"
+
+	# Disable AirPlay 1 (RAOP)
+#	raop_disable = false
+
+	# Name used in the speaker list, overrides name from the device
+#	nickname = "My speaker name"
 #}
 
 # Chromecast settings
 # (make sure you get the capitalization of the device name right)
 #chromecast "My Chromecast device" {
+	# OwnTone's volume goes to 11! If that's more than you can handle
+	# you can set a lower value here
+#	max_volume = 11
+
 	# Enable this option to exclude a particular device from the speaker
 	# list
 #	exclude = false
+
+	# Name used in the speaker list, overrides name from the device
+#	nickname = "My speaker name"
 #}
 
 # Spotify settings (only have effect if Spotify enabled - see README/INSTALL)
 spotify {
+	# The server can stream from Spotify using either its own implementation
+	# or using Spotify's libspotify (which was deprecated many years ago)
+#	use_libspotify = false
+
 	# Directory where user settings should be stored (credentials)
-#	settings_dir = "/var/cache/forked-daapd/libspotify"
+	# (only has effect with libspotify)
+#	settings_dir = "/var/cache/owntone/libspotify"
 
 	# Cache directory
+	# (only has effect with libspotify)
 #	cache_dir = "/tmp"
 
 	# Set preferred bitrate for music streaming
@@ -361,7 +394,7 @@ mpd {
 	# work). Set to 0 to disable serving artwork over http.
 #	http_port = 0
 
-	# By default forked-daapd will - like iTunes - clear the playqueue if
+	# By default OwnTone will - like iTunes - clear the playqueue if
 	# playback stops. Setting clear_queue_on_stop_disable to true will keep
 	# the playlist like MPD does. Note that some dacp clients do not show
 	# the playqueue if playback is stopped.

--- a/sound/owntone/files/owntone.init
+++ b/sound/owntone/files/owntone.init
@@ -2,8 +2,8 @@
 # Copyright (C) 2014 OpenWrt.org
 
 START=99
-BIN=/usr/sbin/forked-daapd
-PID=/var/run/forked-daapd.pid
+BIN=/usr/sbin/owntone
+PID=/var/run/owntone.pid
 SSD=start-stop-daemon
 
 start() {


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79, trunk
Run tested: no

Description:
Since version 28.0 forked-daapd is called owntone. This updates to 28.2 and makes the name change.

Also:
- added new required dependency on libuuid
- remove --disable-spotify since Spotify is now supported without requiring proprietary libspotify
- removed configure flags that are enabled by default anyway (mpd, verification etc.)
- add --disable-install_xxx since that is done by OpenWrt's build