### PR TITLE
[21.02] unbound: update version to 1.13.2 and backport fix

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -158,6 +158,8 @@ define Package/libunbound/config
 	endif
 endef
 
+CONFIGURE_VARS += UNAME=Linux
+
 CONFIGURE_ARGS += \
 	--disable-dsa \
 	--disable-gost \

--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.13.1
+PKG_VERSION:=1.13.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound
-PKG_HASH:=8504d97b8fc5bd897345c95d116e0ee0ddf8c8ff99590ab2b4bd13278c9f50b8
+PKG_HASH:=0a13b547f3b92a026b5ebd0423f54c991e5718037fd9f72445817f6a040e1a83
 
 PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/unbound/patches/010-configure_uname.patch
+++ b/net/unbound/patches/010-configure_uname.patch
@@ -1,0 +1,20 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -765,7 +765,7 @@ if test x_$ub_test_python != x_no; then
+    fi
+ fi
+ 
+-if test "`uname`" = "NetBSD"; then
++if test "${UNAME:-`uname`}" = "NetBSD"; then
+ 	NETBSD_LINTFLAGS='"-D__RENAME(x)=" -D_NETINET_IN_H_'
+ 	AC_SUBST(NETBSD_LINTFLAGS)
+ fi
+@@ -1210,7 +1210,7 @@ esac
+ AC_ARG_ENABLE(tfo-client, AS_HELP_STRING([--enable-tfo-client],[Enable TCP Fast Open for client mode]))
+ case "$enable_tfo_client" in
+ 	yes)
+-		case `uname` in
++		case ${UNAME:-`uname`} in
+ 			Linux) AC_CHECK_DECL([MSG_FASTOPEN], [AC_MSG_WARN([Check the platform specific TFO kernel parameters are correctly configured to support client mode TFO])],
+ 			                     [AC_MSG_ERROR([TCP Fast Open is not available for client mode: please rerun without --enable-tfo-client])], 
+ 			                     [AC_INCLUDES_DEFAULT 

--- a/net/unbound/patches/010-configure_uname.patch
+++ b/net/unbound/patches/010-configure_uname.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -765,7 +765,7 @@ if test x_$ub_test_python != x_no; then
+@@ -772,7 +772,7 @@ if test x_$ub_test_python != x_no; then
     fi
  fi
  
@@ -9,12 +9,3 @@
  	NETBSD_LINTFLAGS='"-D__RENAME(x)=" -D_NETINET_IN_H_'
  	AC_SUBST(NETBSD_LINTFLAGS)
  fi
-@@ -1210,7 +1210,7 @@ esac
- AC_ARG_ENABLE(tfo-client, AS_HELP_STRING([--enable-tfo-client],[Enable TCP Fast Open for client mode]))
- case "$enable_tfo_client" in
- 	yes)
--		case `uname` in
-+		case ${UNAME:-`uname`} in
- 			Linux) AC_CHECK_DECL([MSG_FASTOPEN], [AC_MSG_WARN([Check the platform specific TFO kernel parameters are correctly configured to support client mode TFO])],
- 			                     [AC_MSG_ERROR([TCP Fast Open is not available for client mode: please rerun without --enable-tfo-client])], 
- 			                     [AC_INCLUDES_DEFAULT 

--- a/net/unbound/patches/100-example-conf-in.patch
+++ b/net/unbound/patches/100-example-conf-in.patch
@@ -2,7 +2,6 @@ OpenWrt (modification):
 Patch the default configuration file with the tiny memory
 configuration example from Unbound documentation. This is the best
 starting point for embedded routers if one is not going to use UCI.
-
 --- a/doc/example.conf.in
 +++ b/doc/example.conf.in
 @@ -19,6 +19,76 @@ server:

--- a/net/unbound/patches/200-Squelch-permission-denied-errors-for-udp.patch
+++ b/net/unbound/patches/200-Squelch-permission-denied-errors-for-udp.patch
@@ -1,0 +1,44 @@
+From ad45e9b89ee18bbfeff0ed45da2c243ac17acfe6 Mon Sep 17 00:00:00 2001
+From: "W.C.A. Wijngaards" <wouter@nlnetlabs.nl>
+Date: Fri, 13 Aug 2021 09:27:58 +0200
+Subject: [PATCH] - Fix for #431: Squelch permission denied errors for udp
+ connect,   and udp send, they are visible at higher verbosity settings.
+
+---
+ doc/Changelog              | 2 ++
+ services/outside_network.c | 1 +
+ util/netevent.c            | 1 +
+ 3 files changed, 4 insertions(+)
+
+# diff --git a/doc/Changelog b/doc/Changelog
+# index 62c747c85..1cd0f3bad 100644
+# --- a/doc/Changelog
+# +++ b/doc/Changelog
+# @@ -1,5 +1,7 @@
+#  13 August 2021: Wouter
+#  	- Support using system-wide crypto policies.
+# +	- Fix for #431: Squelch permission denied errors for udp connect,
+# +	  and udp send, they are visible at higher verbosity settings.
+ 
+#  12 August 2021: George
+#  	- Merge PR #514, from ziollek: Docker environment for run tests.
+--- a/services/outside_network.c
++++ b/services/outside_network.c
+@@ -1962,6 +1962,7 @@ static int udp_connect_needs_log(int err
+ 	case ENETDOWN:
+ #  endif
+ 	case EPERM:
++	case EACCES:
+ 		if(verbosity >= VERB_ALGO)
+ 			return 1;
+ 		return 0;
+--- a/util/netevent.c
++++ b/util/netevent.c
+@@ -300,6 +300,7 @@ udp_send_errno_needs_log(struct sockaddr
+ 		case ENETDOWN:
+ #  endif
+ 		case EPERM:
++		case EACCES:
+ 			if(verbosity < VERB_ALGO)
+ 				return 0;
+ 		default:


### PR DESCRIPTION
Backport version update to 1.13.2 and some fixes to prevent log spam when ipv6 connection drops.