### PR TITLE
php7: fix config file upgrade issue (fixes #14623)

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=7.4.23
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=PHP-3.01
@@ -526,6 +526,26 @@ define Package/php7-fpm/conffiles
 /etc/php7-fpm.conf
 /etc/php7-fpm.d/
 /etc/config/php7-fpm
+endef
+
+define Package/php7-mod-openssl/postinst
+#!/bin/sh
+[ -n "$$IPKG_INSTROOT" ] || {
+	if [ -e "/etc/php7/20_openssl.ini" ] && [ -e "/etc/php7/15_openssl.ini" ]; then
+		echo "Renaming PHP ini file '/etc/php7/20_openssl.ini' -> '/etc/php7/15_openssl.ini'"
+		mv /etc/php7/20_openssl.ini /etc/php7/15_openssl.ini
+	fi
+}
+endef
+
+define Package/php7-mod-mysqli/postinst
+#!/bin/sh
+[ -n "$$IPKG_INSTROOT" ] || {
+	if [ -e "/etc/php7/20_mysqli.ini" ] && [ -e "/etc/php7/30_mysqli.ini" ]; then
+		echo "Renaming PHP ini file '/etc/php7/20_mysqli.ini' -> '/etc/php7/30_mysqli.ini'"
+		mv /etc/php7/20_mysqli.ini /etc/php7/30_mysqli.ini
+	fi
+}
 endef
 
 define Build/Prepare


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs - not sysupgrade path as describe in original issue description but manual created files and then installed packages

Description:

The addressed issue is related to #6893 as its resolution
is actually causing the problem.

When changing the priority of the config file it happens
that after a sysupgrade the previous file is restored
and the new file is added, ending up in a situation
like this:

/etc/php7/15_openssl.ini
/etc/php7/20_openssl.ini

Causing a double extension=openssl.so to be parsed,
which is not appropriate and leads to error message.

The same problem might also occur for mysqli since there
was also a priority change - let's take care about this
at the same time.

The solution is to remove one of the files. Since it is
a configuration file, the user might have adjusted it, so
lets just use the previous version to replace the new
installed version.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
