### PR TITLE
[21.02] fail2ban: initial package and fix

### DIFF
--- a/lang/python/python3-pyinotify/Makefile
+++ b/lang/python/python3-pyinotify/Makefile
@@ -1,0 +1,40 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-pyinotify
+PKG_VERSION:=0.9.6
+PKG_RELEASE:=1
+
+PYPI_NAME:=pyinotify
+PKG_HASH:=9c998a5d7606ca835065cdabc013ae6c66eb9ea76a00a1e3bc6e0cfe2b4f71f4
+
+PKG_MAINTAINER:=Gerald Kerma <gandalf@gk2.net>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=COPYING
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-pyinotify
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Linux filesystem events monitoring
+  URL:=https://github.com/seb-m/pyinotify
+  DEPENDS:= +python3-light \
+  +python3-ctypes \
+  +python3-logging
+endef
+
+define Package/python3-pyinotify/description
+  Pyinotify is a Python module for monitoring filesystems changes.
+endef
+
+$(eval $(call Py3Package,python3-pyinotify))
+$(eval $(call BuildPackage,python3-pyinotify))
+$(eval $(call BuildPackage,python3-pyinotify-src))

--- a/net/fail2ban/Makefile
+++ b/net/fail2ban/Makefile
@@ -1,0 +1,76 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=fail2ban
+PKG_VERSION:=0.11.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/fail2ban/fail2ban/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=383108e5f8644cefb288537950923b7520f642e7e114efb843f6e7ea9268b1e0
+
+PKG_MAINTAINER:=Gerald Kerma <gandalf@gk2.net>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/python/python3-package.mk
+
+define Package/fail2ban
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=ban hosts that cause multiple authentication errors
+  URL:=https://www.fail2ban.org/
+  DEPENDS:= \
+  +iptables \
+  +python3-light \
+  +python3-ctypes \
+  +python3-distutils \
+  +python3-email \
+  +python3-logging \
+  +python3-sqlite3 \
+  +python3-urllib \
+  +python3-pkg-resources
+endef
+
+define Package/fail2ban/description
+  Fail2Ban scans log files like /var/log/auth.log and bans IP addresses conducting too many failed login attempts.
+endef
+
+define Package/fail2ban/conffiles
+/etc/fail2ban/
+/etc/config/fail2ban
+endef
+
+define Py3Package/fail2ban/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fail2ban-server $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fail2ban-client $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fail2ban-regex $(1)/usr/bin/
+	$(LN) /usr/bin/python3 $(1)/usr/bin/fail2ban-python
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/fail2ban.config $(1)/etc/config/fail2ban
+	$(INSTALL_BIN) ./files/firewall.fail2ban $(1)/etc/firewall.fail2ban
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/fail2ban.init $(1)/etc/init.d/fail2ban
+
+	$(INSTALL_DIR) $(1)/etc/fail2ban/
+	$(CP) $(PKG_BUILD_DIR)/config/* $(1)/etc/fail2ban/
+
+	$(INSTALL_DIR) $(1)/etc/fail2ban/fail2ban.d
+	$(INSTALL_DATA) ./files/db.conf $(1)/etc/fail2ban/fail2ban.d/db.conf
+	$(INSTALL_DATA) ./files/uci.conf $(1)/etc/fail2ban/fail2ban.d/uci.conf
+
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/fail2ban.defaults $(1)/etc/uci-defaults/99_fail2ban
+endef
+
+$(eval $(call Py3Package,fail2ban))
+$(eval $(call BuildPackage,fail2ban))
+$(eval $(call BuildPackage,fail2ban-src))

--- a/net/fail2ban/Makefile
+++ b/net/fail2ban/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fail2ban
 PKG_VERSION:=0.11.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fail2ban/fail2ban/tar.gz/$(PKG_VERSION)?
@@ -46,12 +46,16 @@ define Package/fail2ban/conffiles
 /etc/config/fail2ban
 endef
 
+define Py3Package/fail2ban/filespec
++|$(PYTHON3_PKG_DIR)
+-|$(PYTHON3_PKG_DIR)/fail2ban/tests
+endef
+
 define Py3Package/fail2ban/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fail2ban-server $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fail2ban-client $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fail2ban-regex $(1)/usr/bin/
-	$(LN) /usr/bin/python3 $(1)/usr/bin/fail2ban-python
 
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/fail2ban.config $(1)/etc/config/fail2ban

--- a/net/fail2ban/files/db.conf
+++ b/net/fail2ban/files/db.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+dbpurgeage = 10d

--- a/net/fail2ban/files/fail2ban.config
+++ b/net/fail2ban/files/fail2ban.config
@@ -1,0 +1,2 @@
+config fail2ban 'fail2ban'
+	option dbfile '/var/lib/fail2ban/fail2ban.sqlite3'

--- a/net/fail2ban/files/fail2ban.defaults
+++ b/net/fail2ban/files/fail2ban.defaults
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# unfortunately, UCI doesn't provide a nice way to add an anonymous section only if it doesn't already exist
+if ! uci show firewall | grep -q firewall.fail2ban; then
+  name="$(uci add firewall include)"
+  uci set "firewall.${name}.path=/etc/firewall.fail2ban"
+  uci set "firewall.${name}.enabled=1"
+  uci set "firewall.${name}.reload=1"
+  echo -e "Adding the following UCI config:\n $(uci changes)"
+  uci commit
+fi
+
+exit 0

--- a/net/fail2ban/files/fail2ban.init
+++ b/net/fail2ban/files/fail2ban.init
@@ -1,0 +1,57 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2020 Martin Pecka, 3-clause BSD license (see LICENSE file)
+
+START=95
+
+USE_PROCD=1
+
+RUNDIR=/var/run/fail2ban
+CONFDIR=/etc/fail2ban
+RUNCONFDIR=/var/etc/fail2ban
+RUNCONF="${RUNCONFDIR}/fail2ban.conf"
+
+service_triggers() {
+	procd_add_reload_trigger fail2ban
+}
+
+init_config() {
+	mkdir -m 0755 -p "${RUNCONFDIR}"
+
+	rm -f "${RUNCONF}"
+
+	config_load fail2ban
+	config_get dbfile fail2ban dbfile /var/lib/fail2ban/fail2ban.sqlite3
+
+	echo "[Definition]" > "${RUNCONF}"
+	echo -n "dbfile = " >> "${RUNCONF}"
+	echo $dbfile >> "${RUNCONF}"
+}
+
+start_service() {
+	init_config
+
+	mkdir -m 0755 -p "${RUNDIR}"
+
+	procd_open_instance
+
+	procd_set_param file ${CONFDIR}/action.d/*.conf
+	procd_set_param file ${CONFDIR}/action.d/*.local
+	procd_set_param file ${CONFDIR}/filter.d/*.conf
+	procd_set_param file ${CONFDIR}/filter.d/*.local
+	procd_set_param file ${CONFDIR}/jail.d/*.conf
+	procd_set_param file ${CONFDIR}/jail.d/*.local
+	procd_set_param file ${CONFDIR}/fail2ban.d/*.conf
+	procd_set_param file ${CONFDIR}/fail2ban.d/*.local
+	procd_set_param file ${CONFDIR}/*.conf
+	procd_set_param file ${CONFDIR}/*.local
+
+	procd_set_param command /usr/bin/fail2ban-server -xf -p "${RUNDIR}/fail2ban.pid" -s "${RUNDIR}/fail2ban.sock" start
+	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+	procd_close_instance
+}
+
+reload_service()
+{
+	stop
+	start
+}

--- a/net/fail2ban/files/firewall.fail2ban
+++ b/net/fail2ban/files/firewall.fail2ban
@@ -1,0 +1,3 @@
+#!/bin/sh
+/etc/init.d/fail2ban restart
+exit 0

--- a/net/fail2ban/files/uci.conf
+++ b/net/fail2ban/files/uci.conf
@@ -1,0 +1,2 @@
+[INCLUDES]
+after = /var/etc/fail2ban/fail2ban.conf

--- a/net/fail2ban/patches/001-fail2ban-fix-python3-script.patch
+++ b/net/fail2ban/patches/001-fail2ban-fix-python3-script.patch
@@ -1,0 +1,8 @@
+--- a/config/filter.d/ignorecommands/apache-fakegooglebot
++++ b/config/filter.d/ignorecommands/apache-fakegooglebot
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env fail2ban-python
++#!/usr/bin/env python3
+ # Inspired by https://isc.sans.edu/forums/diary/When+Google+isnt+Google/15968/
+ #
+ # Written in Python to reuse built-in Python batteries and not depend on


### PR DESCRIPTION
fail2ban v0.11.2 package for OpenWrt 21.02

Maintainer: Kerma Gérald / @erdoukki / gandalf@gk2.net
Compile tested: (aarch64_cortex-a53, espressobin board, OpenWrt master/19.07/21.02)
Run tested: (aarch64_cortex-a53, espressobin board, OpenWrt master/19.07/21.02)

Description:
fail2ban: initial package and fix for 21.02 cherry-picked

https://github.com/openwrt/packages/pull/15098 (e267803346aad6fd1ab3e8d02f2ee0d97748fc7a)
https://github.com/openwrt/packages/pull/16554 (a4f24a353e540c111b0139c72866f6382fb6b581)

@jefferyto @neheb