### PR TITLE
[19.07] ntfs-3g: patch CVE-2019-9755

### DIFF
--- a/utils/ntfs-3g/Makefile
+++ b/utils/ntfs-3g/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntfs-3g
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_VERSION:=2017.3.23
 PKG_SOURCE:=$(PKG_NAME)_ntfsprogs-$(PKG_VERSION).tgz

--- a/utils/ntfs-3g/patches/CVE-2019-9755.patch
+++ b/utils/ntfs-3g/patches/CVE-2019-9755.patch
@@ -1,0 +1,56 @@
+From 85c1634a26faa572d3c558d4cf8aaaca5202d4e9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jean-Pierre=20Andr=C3=A9?= <jean-pierre.andre@wanadoo.fr>
+Date: Wed, 19 Dec 2018 15:57:50 +0100
+Subject: [PATCH] Fixed reporting an error when failed to build the mountpoint
+
+The size check was inefficient because getcwd() uses an unsigned int
+argument.
+---
+ src/lowntfs-3g.c | 6 +++++-
+ src/ntfs-3g.c    | 6 +++++-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+--- a/src/lowntfs-3g.c
++++ b/src/lowntfs-3g.c
+@@ -4323,7 +4323,8 @@ int main(int argc, char *argv[])
+ 	else {
+ 		ctx->abs_mnt_point = (char*)ntfs_malloc(PATH_MAX);
+ 		if (ctx->abs_mnt_point) {
+-			if (getcwd(ctx->abs_mnt_point,
++			if ((strlen(opts.mnt_point) < PATH_MAX)
++			    && getcwd(ctx->abs_mnt_point,
+ 				     PATH_MAX - strlen(opts.mnt_point) - 1)) {
+ 				strcat(ctx->abs_mnt_point, "/");
+ 				strcat(ctx->abs_mnt_point, opts.mnt_point);
+@@ -4331,6 +4332,9 @@ int main(int argc, char *argv[])
+ 			/* Solaris also wants the absolute mount point */
+ 				opts.mnt_point = ctx->abs_mnt_point;
+ #endif /* defined(__sun) && defined (__SVR4) */
++			} else {
++				free(ctx->abs_mnt_point);
++				ctx->abs_mnt_point = (char*)NULL;
+ 			}
+ 		}
+ 	}
+--- a/src/ntfs-3g.c
++++ b/src/ntfs-3g.c
+@@ -4123,7 +4123,8 @@ int main(int argc, char *argv[])
+ 	else {
+ 		ctx->abs_mnt_point = (char*)ntfs_malloc(PATH_MAX);
+ 		if (ctx->abs_mnt_point) {
+-			if (getcwd(ctx->abs_mnt_point,
++			if ((strlen(opts.mnt_point) < PATH_MAX)
++			    && getcwd(ctx->abs_mnt_point,
+ 				     PATH_MAX - strlen(opts.mnt_point) - 1)) {
+ 				strcat(ctx->abs_mnt_point, "/");
+ 				strcat(ctx->abs_mnt_point, opts.mnt_point);
+@@ -4131,6 +4132,9 @@ int main(int argc, char *argv[])
+ 			/* Solaris also wants the absolute mount point */
+ 				opts.mnt_point = ctx->abs_mnt_point;
+ #endif /* defined(__sun) && defined (__SVR4) */
++			} else {
++				free(ctx->abs_mnt_point);
++				ctx->abs_mnt_point = (char*)NULL;
+ 			}
+ 		}
+ 	}


### PR DESCRIPTION
Maintainer: @thess
Compile tested: aarch64, Turris MOX, OpenWrt 21.02
Run tested: aarch64, Turris MOX, OpenWrt 19.07

Description: This CVE is not as important as other CVEs, but the upstream patch applies well and other distributions patch this as well.