### PR TITLE
docker-compose: remove python3-websocket-client dependency

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-compose
 PKG_VERSION:=1.29.2
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PYPI_NAME:=docker-compose
 PKG_HASH:=4c8cd9d21d237412793d18bd33110049ee9af8dab3fe2c213bbd0733959b09b7
@@ -37,7 +37,6 @@ define Package/docker-compose
       +python3-pkg-resources \
       +python3-requests \
       +python3-texttable \
-      +python3-websocket-client \
       +python3-yaml
 endef
 


### PR DESCRIPTION
Maintainer: @jmarcet
Compile tested: aarch64, Turris MOX, OpenWrt 21.02

Description:
They don't use websocket-client since 2014, but they still list it in dependencies: docker/compose#8455

The dependency is still pulled in through python3-docker

* switch to AUTORELEASE