### PR TITLE
[21.02] fail2ban: fix hotplug when disabled

### DIFF
--- a/net/fail2ban/Makefile
+++ b/net/fail2ban/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fail2ban
 PKG_VERSION:=0.11.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fail2ban/fail2ban/tar.gz/$(PKG_VERSION)?

--- a/net/fail2ban/files/firewall.fail2ban
+++ b/net/fail2ban/files/firewall.fail2ban
@@ -1,3 +1,3 @@
 #!/bin/sh
-/etc/init.d/fail2ban restart
+/etc/init.d/fail2ban enabled && /etc/init.d/fail2ban restart
 exit 0


### PR DESCRIPTION
Maintainer: @erdoukki 
Compile tested: -
Run tested: MVEBU - Marvell EspressoBinBoard v7 eMMC - OpenWrt 19.07.7

Description:
Avoid restarting fail2ban by hotplug when the service is disabled.
Related issue: https://github.com/openwrt/packages/issues/16601

Signed-off-by: Vladislav Grigoryev <vg.aetera@gmail.com>
(cherry picked from commit 57aab9f1d15fd694ffdf6a83d73d15497d1a5f08)
Signed-off-by: Kerma Gérald <gandalf@gk2.net>