### PR TITLE
prometheus-node-exporter-lua-nat_traffic: Improve node_nat_traffic prometheus metric.

### DIFF
--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/nat_traffic.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/nat_traffic.lua
@@ -1,30 +1,26 @@
 local function scrape()
   -- documetation about nf_conntrack:
   -- https://www.frozentux.net/iptables-tutorial/chunkyhtml/x1309.html
-  nat_metric =  metric("node_nat_traffic", "gauge" )
+  nat_metric =  metric("node_nat_traffic", "counter" )
   for e in io.lines("/proc/net/nf_conntrack") do
-    -- output(string.format("%s\n",e  ))
     local fields = space_split(e)
-    local src, dest, bytes;
-    bytes = 0;
+    local src, sport, dest, dport, bytes;
+    local direction = "transmit";
     for _, field in ipairs(fields) do
       if src == nil and string.match(field, '^src') then
         src = string.match(field,"src=([^ ]+)");
+      elseif string.match(field, '^sport') then
+        sport = string.match(field,"sport=([^ ]+)");
       elseif dest == nil and string.match(field, '^dst') then
         dest = string.match(field,"dst=([^ ]+)");
+      elseif string.match(field, '^dport') then
+        dport = string.match(field,"dport=([^ ]+)");
       elseif string.match(field, '^bytes') then
-        local b = string.match(field, "bytes=([^ ]+)");
-        bytes = bytes + b;
-        -- output(string.format("\t%d %s",ii,field  ));
+        local labels = { src = src, dest = dest, direction=direction, sport=sport, dport=dport }
+        nat_metric(labels, string.match(field, "bytes=([^ ]+)"));
+        direction = "receive"
       end
-
     end
-    -- local src, dest, bytes = string.match(natstat[i], "src=([^ ]+) dst=([^ ]+) .- bytes=([^ ]+)");
-    -- local src, dest, bytes = string.match(natstat[i], "src=([^ ]+) dst=([^ ]+) sport=[^ ]+ dport=[^ ]+ packets=[^ ]+ bytes=([^ ]+)")
-
-    local labels = { src = src, dest = dest }
-    -- output(string.format("src=|%s| dest=|%s| bytes=|%s|", src, dest, bytes  ))
-    nat_metric(labels, bytes )
   end
 end
 


### PR DESCRIPTION
Maintainer: @mweinelt 
Compile tested: N/A, lua-only changes
Run tested: RaspberryPI CM4, OpenWrt 21.02-SNAPSHOT r15935-2db7fe792e

Description:
This change does 3 things:
 1) For each connection output 2 metrics; a `transmit` and a `receive` bytes counter.
 2) Update the node_nat_traffic metric type from `gauge` to `counter`.  The total number of bytes transferred is a natural counter.  See: https://prometheus.io/docs/concepts/metric_types/
 3) Adds the source and destination ports for each connection.  This ensures that when a src has multiple connections to a dest we don't get multiple lines with the same label values.
