### PR TITLE
banip: Updated firehol URLs to use direct links per firehol's Github README

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
 PKG_VERSION:=0.7.10
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/banip/files/banip.sources
+++ b/net/banip/files/banip.sources
@@ -72,25 +72,25 @@
 		"descurl": "https://feodotracker.abuse.ch"
 	},
 	"firehol1": {
-		"url_4": "https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level1.netset",
+		"url_4": "https://iplists.firehol.org/files/firehol_level1.netset",
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)([[:space:]]|$)/{print \"add firehol1_4 \"$1}",
 		"focus": "Firehol Level 1 compilation",
 		"descurl": "https://iplists.firehol.org/?ipset=firehol_level1"
 	},
 	"firehol2": {
-		"url_4": "https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level2.netset",
+		"url_4": "https://iplists.firehol.org/files/firehol_level2.netset",
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)([[:space:]]|$)/{print \"add firehol2_4 \"$1}",
 		"focus": "Firehol Level 2 compilation",
 		"descurl": "https://iplists.firehol.org/?ipset=firehol_level2"
 	},
 	"firehol3": {
-		"url_4": "https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level3.netset",
+		"url_4": "https://iplists.firehol.org/files/firehol_level3.netset",
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)([[:space:]]|$)/{print \"add firehol3_4 \"$1}",
 		"focus": "Firehol Level 3 compilation",
 		"descurl": "https://iplists.firehol.org/?ipset=firehol_level3"
 	},
 	"firehol4": {
-		"url_4": "https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level4.netset",
+		"url_4": "https://iplists.firehol.org/files/firehol_level4.netset",
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)([[:space:]]|$)/{print \"add firehol4_4 \"$1}",
 		"focus": "Firehol Level 4 compilation",
 		"descurl": "https://iplists.firehol.org/?ipset=firehol_level4"


### PR DESCRIPTION
Signed-off-by: Richard Gering <rg4github@dutchies.us>

Maintainer: @dibdot
Compile tested: ipq806x-generic-netgear_r7800, OpenWRT 21.02.0
Run tested: ipq806x-generic-netgear_r7800, OpenWRT 21.02.0

Description:
The firehol URLs pull ipsets from their Github page, which can be significantly out of sync because these are now only updated once a day. Their README states:

_Due to the amount of data and the frequency of the updates on this repo, github has requested to limit the number of updates. The site https://iplists.firehol.org has direct links to all the files in this repo._ 

The firehol source URLs were updated accordingly.