### PR TITLE
autoconf: fix shebang

### DIFF
--- a/devel/autoconf/Makefile
+++ b/devel/autoconf/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=autoconf
 PKG_VERSION:=2.70
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=@GNU/autoconf
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -39,9 +39,12 @@ endef
 
 CONFIGURE_VARS += M4=m4 EMACS=no
 
+FIX_PATHS = $(SED) '1c \#!/usr/bin/perl' -e 's| /[^ ]*/bin/perl| /usr/bin/perl|g'
+
 define Package/autoconf/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+	grep -rEl "#\!.*perl" $(1)/usr/bin/ | xargs $(FIX_PATHS)
 	$(INSTALL_DIR) $(1)/usr/share/autoconf
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/autoconf/INSTALL \
 	$(1)/usr/share/autoconf/

--- a/devel/autoconf/test.sh
+++ b/devel/autoconf/test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+autoconf --version | grep $2 && \
+autoheader --version | grep $2 && \
+autom4te --version | grep $2 && \
+autoreconf --version | grep $2 && \
+autoscan --version | grep $2 && \
+autoupdate --version | grep $2 && \
+ifnames --version | grep $2


### PR DESCRIPTION
Maintainer: @neheb 
Compile tested: microsoft-standard-WSL2, OpenWrt 21.02
Run tested: arch: aarch64, device: raspberry pi 4, version: OpenWrt 21.02-SNAPSHOT, r16282-601864c09e
Description:
Fix shebang errors for autom4te, autoreconf, autoheader, autoscan, autoupdate, ifnames.
resolve openwrt/packages#16604
The solution come from [devel/automake](https://github.com/openwrt/packages/blob/master/devel/automake/Makefile)