### PR TITLE
[openwrt-21.02] yq: Update to 4.13.0

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.12.1
+PKG_VERSION:=4.13.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=a1cc4aef9f7a7b72eb39dd8cf0fb9d726d7c2f19ec817bead9843859649ac3f3
+PKG_HASH:=37c48c300f64c191f7b7e84d9002f6cba464c9437c79a367affe5b2d85f8fd3b
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm27xx
Run tested: bcm2710 raspberrypi-3b

Description:
Release note: https://github.com/mikefarah/yq/releases/tag/v4.13.0