### PR TITLE
qemu: fix compilation on 64 bit platforms

### DIFF
--- a/utils/qemu/patches/0008-falloc.patch
+++ b/utils/qemu/patches/0008-falloc.patch
@@ -1,0 +1,12 @@
+--- a/block/export/fuse.c
++++ b/block/export/fuse.c
+@@ -31,6 +31,9 @@
+ #include <fuse.h>
+ #include <fuse_lowlevel.h>
+ 
++#if defined(CONFIG_FALLOCATE_PUNCH_HOLE) || defined(CONFIG_FALLOCATE_ZERO_RANGE)
++#include <linux/falloc.h>
++#endif
+ 
+ /* Prevent overly long bounce buffer allocations */
+ #define FUSE_MAX_BOUNCE_BYTES (MIN(BDRV_REQUEST_MAX_BYTES, 64 * 1024 * 1024))

--- a/utils/qemu/patches/0009-fs.patch
+++ b/utils/qemu/patches/0009-fs.patch
@@ -1,0 +1,40 @@
+From 28031d5c7427aec6d6138920b92c59b999a349ed Mon Sep 17 00:00:00 2001
+From: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+Date: Sat, 28 Aug 2021 00:03:01 +0200
+Subject: [PATCH] block/export/fuse.c: fix fuse-lseek on uclibc or musl
+
+Include linux/fs.h to avoid the following build failure on uclibc or
+musl raised since version 6.0.0:
+
+../block/export/fuse.c: In function 'fuse_lseek':
+../block/export/fuse.c:641:19: error: 'SEEK_HOLE' undeclared (first use in this function)
+  641 |     if (whence != SEEK_HOLE && whence != SEEK_DATA) {
+      |                   ^~~~~~~~~
+../block/export/fuse.c:641:19: note: each undeclared identifier is reported only once for each function it appears in
+../block/export/fuse.c:641:42: error: 'SEEK_DATA' undeclared (first use in this function); did you mean 'SEEK_SET'?
+  641 |     if (whence != SEEK_HOLE && whence != SEEK_DATA) {
+      |                                          ^~~~~~~~~
+      |                                          SEEK_SET
+
+Fixes:
+ - http://autobuild.buildroot.org/results/33c90ebf04997f4d3557cfa66abc9cf9a3076137
+
+Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+Message-Id: <20210827220301.272887-1-fontaine.fabrice@gmail.com>
+Signed-off-by: Hanna Reitz <hreitz@redhat.com>
+---
+ block/export/fuse.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/block/export/fuse.c
++++ b/block/export/fuse.c
+@@ -38,6 +38,9 @@
+ /* Prevent overly long bounce buffer allocations */
+ #define FUSE_MAX_BOUNCE_BYTES (MIN(BDRV_REQUEST_MAX_BYTES, 64 * 1024 * 1024))
+ 
++#ifdef __linux__
++#include <linux/fs.h>
++#endif
+ 
+ typedef struct FuseExport {
+     BlockExport common;

--- a/utils/qemu/patches/0010-no-tests.patch
+++ b/utils/qemu/patches/0010-no-tests.patch
@@ -1,0 +1,24 @@
+--- a/meson.build
++++ b/meson.build
+@@ -2297,10 +2297,6 @@ specific_ss.add_all(when: 'CONFIG_BSD_US
+ linux_user_ss.add(files('gdbstub.c', 'thunk.c'))
+ specific_ss.add_all(when: 'CONFIG_LINUX_USER', if_true: linux_user_ss)
+ 
+-# needed for fuzzing binaries
+-subdir('tests/qtest/libqos')
+-subdir('tests/qtest/fuzz')
+-
+ # accel modules
+ tcg_real_module_ss = ss.source_set()
+ tcg_real_module_ss.add_all(when: 'CONFIG_TCG_MODULAR', if_true: tcg_module_ss)
+@@ -2780,10 +2776,6 @@ subdir('scripts')
+ subdir('tools')
+ subdir('pc-bios')
+ subdir('docs')
+-subdir('tests')
+-if gtk.found()
+-  subdir('po')
+-endif
+ 
+ if host_machine.system() == 'windows'
+   nsis_cmd = [


### PR DESCRIPTION
Last patch is for mips. Second is an upstream backport. First is needed
for at least musl 1.2.x

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @yousong 
Compile tested: mips64el