### PR TITLE
Update tinc.init to include GraphDumpFile option

### DIFF
--- a/net/tinc/files/tinc.init
+++ b/net/tinc/files/tinc.init
@@ -189,6 +189,7 @@ prepare_net() {
 		Ed25519PrivateKeyFile \
 		ECDSAPublicKey \
 		Forwarding \
+		GraphDumpFile \
 		Interface \
 		ListenAddress \
 		LocalDiscoveryAddress \


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
