### PR TITLE
fail2ban: patch CVE-2021-32749

### DIFF
--- a/net/fail2ban/Makefile
+++ b/net/fail2ban/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fail2ban
 PKG_VERSION:=0.11.2
-PKG_RELEASE:=3
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fail2ban/fail2ban/tar.gz/$(PKG_VERSION)?

--- a/net/fail2ban/patches/CVE-2021-32749.patch
+++ b/net/fail2ban/patches/CVE-2021-32749.patch
@@ -1,0 +1,143 @@
+From 410a6ce5c80dd981c22752da034f2529b5eee844 Mon Sep 17 00:00:00 2001
+From: sebres <serg.brester@sebres.de>
+Date: Mon, 21 Jun 2021 17:12:53 +0200
+Subject: [PATCH] fixed possible RCE vulnerability, unset escape variable
+ (default tilde) stops consider "~" char after new-line as composing escape
+ sequence
+
+---
+ config/action.d/complain.conf         | 2 +-
+ config/action.d/dshield.conf          | 2 +-
+ config/action.d/mail-buffered.conf    | 8 ++++----
+ config/action.d/mail-whois-lines.conf | 2 +-
+ config/action.d/mail-whois.conf       | 6 +++---
+ config/action.d/mail.conf             | 6 +++---
+ 6 files changed, 13 insertions(+), 13 deletions(-)
+
+--- a/config/action.d/complain.conf
++++ b/config/action.d/complain.conf
+@@ -102,7 +102,7 @@ logpath = /dev/null
+ # Notes.:  Your system mail command. Is passed 2 args: subject and recipient
+ # Values:  CMD
+ #
+-mailcmd = mail -s
++mailcmd = mail -E 'set escape' -s
+ 
+ # Option:  mailargs
+ # Notes.:  Additional arguments to mail command. e.g. for standard Unix mail:
+--- a/config/action.d/dshield.conf
++++ b/config/action.d/dshield.conf
+@@ -179,7 +179,7 @@ tcpflags =
+ # Notes.:  Your system mail command. Is passed 2 args: subject and recipient
+ # Values:  CMD
+ #
+-mailcmd = mail -s
++mailcmd = mail -E 'set escape' -s
+ 
+ # Option:  mailargs
+ # Notes.:  Additional arguments to mail command. e.g. for standard Unix mail:
+--- a/config/action.d/mail-buffered.conf
++++ b/config/action.d/mail-buffered.conf
+@@ -17,7 +17,7 @@ actionstart = printf %%b "Hi,\n
+               The jail <name> has been started successfully.\n
+               Output will be buffered until <lines> lines are available.\n
+               Regards,\n
+-              Fail2Ban"|mail -s "[Fail2Ban] <name>: started on <fq-hostname>" <dest>
++              Fail2Ban"|mail -E 'set escape' -s "[Fail2Ban] <name>: started on <fq-hostname>" <dest>
+ 
+ # Option:  actionstop
+ # Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
+@@ -28,13 +28,13 @@ actionstop = if [ -f <tmpfile> ]; then
+                  These hosts have been banned by Fail2Ban.\n
+                  `cat <tmpfile>`
+                  Regards,\n
+-                 Fail2Ban"|mail -s "[Fail2Ban] <name>: Summary from <fq-hostname>" <dest>
++                 Fail2Ban"|mail -E 'set escape' -s "[Fail2Ban] <name>: Summary from <fq-hostname>" <dest>
+                  rm <tmpfile>
+              fi
+              printf %%b "Hi,\n
+              The jail <name> has been stopped.\n
+              Regards,\n
+-             Fail2Ban"|mail -s "[Fail2Ban] <name>: stopped on <fq-hostname>" <dest>
++             Fail2Ban"|mail -E 'set escape' -s "[Fail2Ban] <name>: stopped on <fq-hostname>" <dest>
+ 
+ # Option:  actioncheck
+ # Notes.:  command executed once before each actionban command
+@@ -55,7 +55,7 @@ actionban = printf %%b "`date`: <ip> (<f
+                 These hosts have been banned by Fail2Ban.\n
+                 `cat <tmpfile>`
+                 \nRegards,\n
+-                Fail2Ban"|mail -s "[Fail2Ban] <name>: Summary" <dest>
++                Fail2Ban"|mail -E 'set escape' -s "[Fail2Ban] <name>: Summary" <dest>
+                 rm <tmpfile>
+             fi
+ 
+--- a/config/action.d/mail-whois-lines.conf
++++ b/config/action.d/mail-whois-lines.conf
+@@ -72,7 +72,7 @@ actionunban =
+ # Notes.:  Your system mail command. Is passed 2 args: subject and recipient
+ # Values:  CMD
+ #
+-mailcmd = mail -s
++mailcmd = mail -E 'set escape' -s
+ 
+ # Default name of the chain
+ #
+--- a/config/action.d/mail-whois.conf
++++ b/config/action.d/mail-whois.conf
+@@ -20,7 +20,7 @@ norestored = 1
+ actionstart = printf %%b "Hi,\n
+               The jail <name> has been started successfully.\n
+               Regards,\n
+-              Fail2Ban"|mail -s "[Fail2Ban] <name>: started on <fq-hostname>" <dest>
++              Fail2Ban"|mail -E 'set escape' -s "[Fail2Ban] <name>: started on <fq-hostname>" <dest>
+ 
+ # Option:  actionstop
+ # Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
+@@ -29,7 +29,7 @@ actionstart = printf %%b "Hi,\n
+ actionstop = printf %%b "Hi,\n
+              The jail <name> has been stopped.\n
+              Regards,\n
+-             Fail2Ban"|mail -s "[Fail2Ban] <name>: stopped on <fq-hostname>" <dest>
++             Fail2Ban"|mail -E 'set escape' -s "[Fail2Ban] <name>: stopped on <fq-hostname>" <dest>
+ 
+ # Option:  actioncheck
+ # Notes.:  command executed once before each actionban command
+@@ -49,7 +49,7 @@ actionban = printf %%b "Hi,\n
+             Here is more information about <ip> :\n
+             `%(_whois_command)s`\n
+             Regards,\n
+-            Fail2Ban"|mail -s "[Fail2Ban] <name>: banned <ip> from <fq-hostname>" <dest>
++            Fail2Ban"|mail -E 'set escape' -s "[Fail2Ban] <name>: banned <ip> from <fq-hostname>" <dest>
+ 
+ # Option:  actionunban
+ # Notes.:  command executed when unbanning an IP. Take care that the
+--- a/config/action.d/mail.conf
++++ b/config/action.d/mail.conf
+@@ -16,7 +16,7 @@ norestored = 1
+ actionstart = printf %%b "Hi,\n
+               The jail <name> has been started successfully.\n
+               Regards,\n
+-              Fail2Ban"|mail -s "[Fail2Ban] <name>: started  on <fq-hostname>" <dest>
++              Fail2Ban"|mail -E 'set escape' -s "[Fail2Ban] <name>: started  on <fq-hostname>" <dest>
+ 
+ # Option:  actionstop
+ # Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
+@@ -25,7 +25,7 @@ actionstart = printf %%b "Hi,\n
+ actionstop = printf %%b "Hi,\n
+              The jail <name> has been stopped.\n
+              Regards,\n
+-             Fail2Ban"|mail -s "[Fail2Ban] <name>: stopped on <fq-hostname>" <dest>
++             Fail2Ban"|mail -E 'set escape' -s "[Fail2Ban] <name>: stopped on <fq-hostname>" <dest>
+ 
+ # Option:  actioncheck
+ # Notes.:  command executed once before each actionban command
+@@ -43,7 +43,7 @@ actionban = printf %%b "Hi,\n
+             The IP <ip> has just been banned by Fail2Ban after
+             <failures> attempts against <name>.\n
+             Regards,\n
+-            Fail2Ban"|mail -s "[Fail2Ban] <name>: banned <ip> from <fq-hostname>" <dest>
++            Fail2Ban"|mail -E 'set escape' -s "[Fail2Ban] <name>: banned <ip> from <fq-hostname>" <dest>
+ 
+ # Option:  actionunban
+ # Notes.:  command executed when unbanning an IP. Take care that the


### PR DESCRIPTION
Maintainer: @erdoukki
Compile tested: aarch64, Turris MOX, OpenWrt 21.02

Description: The patch is imported from the project's master, so it will be fixed in the next release. This fix should also be backported to 21.02.
