### PR TITLE
miniupnpd: add force_forwarding option support

### DIFF
--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -62,6 +62,7 @@ upnpd() {
 	local use_stun stun_host stun_port uuid notify_interval presentation_url
 	local upnp_lease_file clean_ruleset_threshold clean_ruleset_interval
 	local ipv6_disable
+	local force_forwarding
 
 	local enabled
 	config_get_bool enabled config enabled 1
@@ -89,6 +90,7 @@ upnpd() {
 	config_get clean_ruleset_threshold config clean_ruleset_threshold
 	config_get clean_ruleset_interval config clean_ruleset_interval
 	config_get ipv6_disable config ipv6_disable 0
+	config_get force_forwarding config force_forwarding 0
 
 	local conf ifname ifname6
 
@@ -141,6 +143,7 @@ upnpd() {
 		upnpd_write_bool igdv1 0 force_igd_desc_v1
 		upnpd_write_bool use_stun 0 ext_perform_stun
 		upnpd_write_bool ipv6_disable $ipv6_disable
+		upnpd_write_bool force_forwarding $force_forwarding
 
 		[ "$use_stun" -eq 0 ] || {
 			[ -n "$stun_host" ] && echo "ext_stun_host=$stun_host"

--- a/net/miniupnpd/files/upnpd.config
+++ b/net/miniupnpd/files/upnpd.config
@@ -2,6 +2,7 @@ config upnpd config
 	option enabled		0
 	option enable_natpmp	1
 	option enable_upnp	1
+	option force_forwarding 0
 	option secure_mode	1
 	option log_output	0
 	option download		1024

--- a/net/miniupnpd/patches/301-options-force_forwarding-support.patch
+++ b/net/miniupnpd/patches/301-options-force_forwarding-support.patch
@@ -1,0 +1,209 @@
+From 09690d550a1ad3cc3a8cba79aa2e970c3b2b8fbe Mon Sep 17 00:00:00 2001
+From: Chen Minqiang <ptpt52@gmail.com>
+Date: Sun, 5 Jul 2020 10:42:52 +0800
+Subject: [PATCH] options: force_forwarding support
+
+This make the port forwarding force to work even
+when the router is behind NAT
+
+Signed-off-by: Chen Minqiang <ptpt52@gmail.com>
+---
+ miniupnpd.c      | 12 ++++++++----
+ miniupnpd.conf   |  2 ++
+ natpmp.c         |  2 +-
+ options.c        |  1 +
+ options.h        |  1 +
+ testgetifaddr.c  |  2 ++
+ testportinuse.c  |  2 ++
+ upnpdescgen.c    |  2 +-
+ upnpglobalvars.h |  2 ++
+ upnpredirect.c   |  2 +-
+ upnpsoap.c       |  6 +++++-
+ 11 files changed, 26 insertions(+), 8 deletions(-)
+
+diff --git a/miniupnpd.c b/miniupnpd.c
+index f13dd8d..21ce4d3 100644
+--- a/miniupnpd.c
++++ b/miniupnpd.c
+@@ -1009,7 +1009,7 @@ parselanaddr(struct lan_addr_s * lan_addr, const char * str)
+ 				fprintf(stderr, "Error parsing address : %s\n", lan_addr->ext_ip_str);
+ 				return -1;
+ 			}
+-			if(addr_is_reserved(&lan_addr->ext_ip_addr)) {
++			if(addr_is_reserved(&lan_addr->ext_ip_addr) && !GETFLAG(FORCEFORWARDINGMASK)) {
+ 				/* error */
+ 				fprintf(stderr, "Error: option ext_ip address contains reserved / private address : %s\n", lan_addr->ext_ip_str);
+ 				return -1;
+@@ -1241,6 +1241,10 @@ init(int argc, char * * argv, struct runtime_vars * v)
+ 			case UPNPEXT_IP:
+ 				use_ext_ip_addr = ary_options[i].value;
+ 				break;
++			case UPNP_FORCE_FORWARDING:
++				if(strcmp(ary_options[i].value, "yes") == 0)
++					SETFLAG(FORCEFORWARDINGMASK);
++				break;
+ 			case UPNPEXT_PERFORM_STUN:
+ 				if(strcmp(ary_options[i].value, "yes") == 0)
+ 					SETFLAG(PERFORMSTUNMASK);
+@@ -1779,7 +1783,7 @@ init(int argc, char * * argv, struct runtime_vars * v)
+ 			fprintf(stderr, "Error: option ext_ip contains invalid address %s\n", use_ext_ip_addr);
+ 			return 1;
+ 		}
+-		if (addr_is_reserved(&addr)) {
++		if (addr_is_reserved(&addr) && !GETFLAG(FORCEFORWARDINGMASK)) {
+ 			fprintf(stderr, "Error: option ext_ip contains reserved / private address %s, not public routable\n", use_ext_ip_addr);
+ 			return 1;
+ 		}
+@@ -2190,7 +2194,7 @@ main(int argc, char * * argv)
+ 		struct in_addr addr;
+ 		if (getifaddr(ext_if_name, if_addr, INET_ADDRSTRLEN, &addr, NULL) < 0) {
+ 			syslog(LOG_WARNING, "Cannot get IP address for ext interface %s. Network is down", ext_if_name);
+-		} else if (addr_is_reserved(&addr)) {
++		} else if (addr_is_reserved(&addr) && !GETFLAG(FORCEFORWARDINGMASK)) {
+ 			syslog(LOG_INFO, "Reserved / private IP address %s on ext interface %s: Port forwarding is impossible", if_addr, ext_if_name);
+ 			syslog(LOG_INFO, "You are probably behind NAT, enable option ext_perform_stun=yes to detect public IP address");
+ 			syslog(LOG_INFO, "Or use ext_ip= / -o option to declare public IP address");
+@@ -2460,7 +2464,7 @@ main(int argc, char * * argv)
+ 				char if_addr[INET_ADDRSTRLEN];
+ 				struct in_addr addr;
+ 				if (getifaddr(ext_if_name, if_addr, INET_ADDRSTRLEN, &addr, NULL) == 0) {
+-					int reserved = addr_is_reserved(&addr);
++					int reserved = addr_is_reserved(&addr) && !GETFLAG(FORCEFORWARDINGMASK);
+ 					if (disable_port_forwarding && !reserved) {
+ 						syslog(LOG_INFO, "Public IP address %s on ext interface %s: Port forwarding is enabled", if_addr, ext_if_name);
+ 					} else if (!disable_port_forwarding && reserved) {
+diff --git a/miniupnpd.conf b/miniupnpd.conf
+index 6355532..68a1fda 100644
+--- a/miniupnpd.conf
++++ b/miniupnpd.conf
+@@ -9,6 +9,8 @@
+ # Setting ext_ip is also useful in double NAT setup, you can declare here
+ # the public IP address.
+ #ext_ip=
++#force forwarding enable for upnp: default is no
++#force_forwarding=yes
+ # WAN interface must have public IP address. Otherwise it is behind NAT
+ # and port forwarding is impossible. In some cases WAN interface can be
+ # behind unrestricted full-cone NAT 1:1 when all incoming traffic is NAT-ed and
+diff --git a/natpmp.c b/natpmp.c
+index 14690a6..e3acce1 100644
+--- a/natpmp.c
++++ b/natpmp.c
+@@ -108,7 +108,7 @@ static void FillPublicAddressResponse(unsigned char * resp, in_addr_t senderaddr
+ 			syslog(LOG_ERR, "Failed to get IP for interface %s", ext_if_name);
+ 			resp[3] = 3;	/* Network Failure (e.g. NAT box itself
+ 			                 * has not obtained a DHCP lease) */
+-		} else if (addr_is_reserved(&addr)) {
++		} else if (addr_is_reserved(&addr) && !GETFLAG(FORCEFORWARDINGMASK)) {
+ 			resp[3] = 3;	/* Network Failure, box has not obtained
+ 			                   public IP address */
+ 		} else {
+diff --git a/options.c b/options.c
+index 05fa317..9ff0502 100644
+--- a/options.c
++++ b/options.c
+@@ -34,6 +34,7 @@ static const struct {
+ 	{ UPNPEXT_IFNAME6, "ext_ifname6" },
+ #endif
+ 	{ UPNPEXT_IP,	"ext_ip" },
++	{ UPNP_FORCE_FORWARDING, "force_forwarding" },
+ 	{ UPNPEXT_PERFORM_STUN, "ext_perform_stun" },
+ 	{ UPNPEXT_STUN_HOST, "ext_stun_host" },
+ 	{ UPNPEXT_STUN_PORT, "ext_stun_port" },
+diff --git a/options.h b/options.h
+index 96cdbbf..f9cf201 100644
+--- a/options.h
++++ b/options.h
+@@ -21,6 +21,7 @@ enum upnpconfigoptions {
+ 	UPNPEXT_IFNAME6,		/* ext_ifname6 */
+ #endif
+ 	UPNPEXT_IP,				/* ext_ip */
++	UPNP_FORCE_FORWARDING, /* force forwarding enable for upnp */
+ 	UPNPEXT_PERFORM_STUN,		/* ext_perform_stun */
+ 	UPNPEXT_STUN_HOST,		/* ext_stun_host */
+ 	UPNPEXT_STUN_PORT,		/* ext_stun_port */
+diff --git a/testgetifaddr.c b/testgetifaddr.c
+index 8045b89..b5cdbb4 100644
+--- a/testgetifaddr.c
++++ b/testgetifaddr.c
+@@ -13,6 +13,8 @@
+ #include "config.h"
+ #include "getifaddr.h"
+ 
++int runtime_flags = 0;
++
+ #if defined(__sun)
+ /* solaris 10 does not define LOG_PERROR */
+ #define LOG_PERROR 0
+diff --git a/testportinuse.c b/testportinuse.c
+index 98574c6..507f830 100644
+--- a/testportinuse.c
++++ b/testportinuse.c
+@@ -14,6 +14,8 @@
+ #include "config.h"
+ #include "portinuse.h"
+ 
++int runtime_flags = 0;
++
+ int main(int argc, char * * argv)
+ {
+ #ifndef CHECK_PORTINUSE
+diff --git a/upnpdescgen.c b/upnpdescgen.c
+index 46110f2..3a86c09 100644
+--- a/upnpdescgen.c
++++ b/upnpdescgen.c
+@@ -1290,7 +1290,7 @@ genEventVars(int * len, const struct serviceDesc * s)
+ 				else {
+ 					struct in_addr addr;
+ 					char ext_ip_addr[INET_ADDRSTRLEN];
+-					if(getifaddr(ext_if_name, ext_ip_addr, INET_ADDRSTRLEN, &addr, NULL) < 0 || addr_is_reserved(&addr)) {
++					if(getifaddr(ext_if_name, ext_ip_addr, INET_ADDRSTRLEN, &addr, NULL) < 0 || (addr_is_reserved(&addr) && !GETFLAG(FORCEFORWARDINGMASK))) {
+ 						str = strcat_str(str, len, &tmplen, "0.0.0.0");
+ 					} else {
+ 						str = strcat_str(str, len, &tmplen, ext_ip_addr);
+diff --git a/upnpglobalvars.h b/upnpglobalvars.h
+index a474353..a36f515 100644
+--- a/upnpglobalvars.h
++++ b/upnpglobalvars.h
+@@ -84,6 +84,8 @@ extern int runtime_flags;
+ 
+ #define PERFORMSTUNMASK    0x1000
+ 
++#define FORCEFORWARDINGMASK 0x2000
++
+ #define SETFLAG(mask)	runtime_flags |= mask
+ #define GETFLAG(mask)	(runtime_flags & mask)
+ #define CLEARFLAG(mask)	runtime_flags &= ~mask
+diff --git a/upnpredirect.c b/upnpredirect.c
+index 07fa229..c9fc7ac 100644
+--- a/upnpredirect.c
++++ b/upnpredirect.c
+@@ -444,7 +444,7 @@ upnp_redirect_internal(const char * rhost, unsigned short eport,
+ {
+ 	/*syslog(LOG_INFO, "redirecting port %hu to %s:%hu protocol %s for: %s",
+ 		eport, iaddr, iport, protocol, desc);			*/
+-	if(disable_port_forwarding)
++	if(disable_port_forwarding && !GETFLAG(FORCEFORWARDINGMASK))
+ 		return -1;
+ 	if(add_redirect_rule2(ext_if_name, rhost, eport, iaddr, iport, proto,
+ 	                      desc, timestamp) < 0) {
+diff --git a/upnpsoap.c b/upnpsoap.c
+index fb4b70e..932df62 100644
+--- a/upnpsoap.c
++++ b/upnpsoap.c
+@@ -348,7 +348,11 @@ GetExternalIPAddress(struct upnphttp * h, const char * action, const char * ns)
+ 			ext_ip_addr[0] = '\0';
+ 		} else if (addr_is_reserved(&addr)) {
+ 			syslog(LOG_NOTICE, "private/reserved address %s is not suitable for external IP", ext_ip_addr);
+-			ext_ip_addr[0] = '\0';
++			if (!GETFLAG(FORCEFORWARDINGMASK)) {
++				ext_ip_addr[0] = '\0';
++			} else {
++				syslog(LOG_NOTICE, "force_forwarding enable, private/reserved address %s used as external IP", ext_ip_addr);
++			}
+ 		}
+ 	}
+ #else
+-- 
+2.17.1
+


### PR DESCRIPTION
This option replace the 'ext_ip_reserved_ignore', and replace the
patch with new one

as addr_is_reserved() behavior should not be changed, so drop the
ext_ip_reserved_ignore

use a force_forwarding option to make the port forwarding force to
work when the router is behind NAT

by default force_forwarding is set to 0(disabled), where change
nothing with the original behavior, and users can turn it on
according to their wishes

related: https://github.com/openwrt/packages/pull/16011