### PR TITLE
ieee8021xclient: fix DEPENDS to not create a dependency loop

### DIFF
--- a/net/ieee8021xclient/Makefile
+++ b/net/ieee8021xclient/Makefile
@@ -20,7 +20,7 @@ define Package/ieee8021xclient
   CATEGORY:=Network
   MAINTAINER:=David Yang <mmyangfl@gmail.com>
   TITLE:=Wired 802.1x client config support
-  DEPENDS:=+wpa_supplicant
+  DEPENDS:=@(PACKAGE_wpa-supplicant||PACKAGE_wpad)
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
Signed-off-by: Andrew Powers-Holmes <andrew@omnom.net>

Maintainer: @yangfl / David Yang <mmyangfl@gmail.com>
Compile tested: ath79, ramips, full buildbot Snapshot image config used (all platforms), with this package selected and deselected
Run tested: ath79, Sophos AP55C + ramips (mt7620), D-Link DIR-510L / TP-Link TL-MR3040

Description:
This resolves the build dependency loop created in #16527 - a side-effect of the main hostapd `Makefile` being kind of a mess, as has been discussed in IRC, and the better way to fix this would be to fix up that Makefile and add some properties that external packages can use in `DEPENDS` to request things like "a fully functional WPA supplicant of some kind", but for the time being this fixes failure to build for all images.

See #16532 for more info/discussion around this, #15983 for the original package add, and some discussion in #16525. I do not necessarily expect this PR to be merged, but opening it will allow users to apply the patch relatively quickly and easily if they need a temporary fix.