### PR TITLE
syncthing: update to 1.18.2

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.18.1
+PKG_VERSION:=1.18.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=3f6b8e87a59e72ab3389d89364524e6abec454d4c36aaf3e334ac6fe37915584
+PKG_HASH:=afe2ae979da3b4f1af8aeabd7e1704807242913b516e0b6585510821c9d6d4f2
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 


### PR DESCRIPTION
Maintainer: @aparcar
Compile tested: aarch64, Turris MOX, OpenWrt 21.02
Run tested: aarch64, Turris MOX, OpenWrt 21.02

Description: just a few small bugfixes