### PR TITLE
lxc-auto: step by 1 sec up to $maxtimeout

### DIFF
--- a/utils/lxc/files/lxc-auto.init
+++ b/utils/lxc/files/lxc-auto.init
@@ -35,11 +35,9 @@ stop_container() {
 	fi
 
 	if [ -n "$name" ]; then
-		if [ "$timeout" = "0" ]; then
-			/usr/bin/lxc-stop -n "$name" &
-		else
-			/usr/bin/lxc-stop -n "$name" -t $timeout &
-		fi
+		[ "$timeout" = "0" ] && postargs=" -t $max_timeout"
+		/usr/bin/lxc-stop -n "$name" "$postargs" &
+		export STOPPID=$!
 	fi
 }
 
@@ -54,7 +52,13 @@ stop() {
 	# ensure e.g. shutdown doesn't occur before maximum timeout on
 	# containers that are shutting down
 	if [ $max_timeout -gt 0 ]; then
-		sleep $max_timeout
+		for i in $(seq 1 $max_timeout); do
+			if [ -d /proc/"$STOPPID" ]; then
+				sleep 1s
+			else
+				return 0
+			fi
+		done
 	fi
 }
 


### PR DESCRIPTION
If the user defines a `$max_timeout` of 30, the service will wait 30 seconds before it considers `xc-stop` complete even though `lxc-stop` might actually finish much sooner.  This introduces an unneeded delay.

This commit changes the behavior to check once per second to see when `lxc-stop` actually stops doing so up to `$max_timeout`. 
 It also slightly simplifies the code with logic to append the -t $max_timeout to the script.

Signed-off-by: John Audia <graysky@archlinux.us>

Maintainer: @neheb @BKPepe @cotequeiroz @aparcar @hammer-is @robimarko @ecsv @danielfdickinson