### PR TITLE
lxc: remove legacy cgroups from common.conf

### DIFF
--- a/utils/lxc/patches/021-remove-legacy-cgroup-support.patch
+++ b/utils/lxc/patches/021-remove-legacy-cgroup-support.patch
@@ -1,0 +1,38 @@
+--- a/config/templates/common.conf.in
++++ b/config/templates/common.conf.in
+@@ -15,35 +15,6 @@ lxc.cap.drop = mac_admin mac_override sy
+ # Ensure hostname is changed on clone
+ lxc.hook.clone = @LXCHOOKDIR@/clonehostname
+ 
+-# Default legacy cgroup configuration
+-#
+-# CGroup allowlist
+-lxc.cgroup.devices.deny = a
+-## Allow any mknod (but not reading/writing the node)
+-lxc.cgroup.devices.allow = c *:* m
+-lxc.cgroup.devices.allow = b *:* m
+-## Allow specific devices
+-### /dev/null
+-lxc.cgroup.devices.allow = c 1:3 rwm
+-### /dev/zero
+-lxc.cgroup.devices.allow = c 1:5 rwm
+-### /dev/full
+-lxc.cgroup.devices.allow = c 1:7 rwm
+-### /dev/tty
+-lxc.cgroup.devices.allow = c 5:0 rwm
+-### /dev/console
+-lxc.cgroup.devices.allow = c 5:1 rwm
+-### /dev/ptmx
+-lxc.cgroup.devices.allow = c 5:2 rwm
+-### /dev/random
+-lxc.cgroup.devices.allow = c 1:8 rwm
+-### /dev/urandom
+-lxc.cgroup.devices.allow = c 1:9 rwm
+-### /dev/pts/*
+-lxc.cgroup.devices.allow = c 136:* rwm
+-### fuse
+-lxc.cgroup.devices.allow = c 10:229 rwm
+-
+ # Default unified cgroup configuration
+ #
+ # CGroup allowlist


### PR DESCRIPTION
I am unaware of any kernel currently provided that retains cgroup v1 support.  This patch removes these lines in `/usr/share/lxc/config/common.conf` to allow for error free usage.

Providing common.conf as-is will result in failure to start. One solution is to comment out the legacy lines.[1] This requires users to either provide a custom version of this file on their builds or to manually edit it with each update.

Since many do not build their own, the first option is not available to them.  Manually editing the file with each update will cause a failure to start containers set to auto-start upon rebooting into the update.

1. https://forum.openwrt.org/t/openwrt-arm64-quick-lxc-howto-guide-lms-in-debian-system-in-lxc-container/99835

Signed-off-by: John Audia <graysky@archlinux.us>
(cherry picked from commit 049cf1e1b0fef97f98ad77a8a26d0fa1b6dad174)

Maintainer: @neheb @BKPepe @cotequeiroz @aparcar @hammer-is @robimarko @danielfdickinson

Compile tested: bcm2711/RPi4B
Run tested: bcm2711/RPi4B
