### PR TITLE
bump libqmi and modemmanager

### DIFF
--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_VERSION:=1.28.8
+PKG_VERSION:=1.30.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
-PKG_HASH:=6e3bbbd200bc1b64b23f6254fef9212f2699ec77cfb32075d2ba5079c73a9f78
+PKG_HASH:=be01ece0ea2c2194cbea5744bf5aaf06c04ba5fb7ec7887a13116c76d114fedd
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
-PKG_VERSION:=1.16.10
+PKG_VERSION:=1.18.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
-PKG_HASH:=2ccf1f716c2d121e8e6709bcf8af29ee86971a90adacca2e8d6288b30278862e
+PKG_HASH:=374be158ae1c1fb38a29eef1cc3cdf89ff3536b48ff1320d208ab204ea6c5f8a
 PKG_BUILD_DIR:=$(BUILD_DIR)/ModemManager-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>


### PR DESCRIPTION
Maintainer: @nickberry17
Compile tested: aarch64, Raspberry Pi 4 Model B Rev 1.1, OpenWrt SNAPSHOT, r17531-f413e4835e
Run tested: as above. checked basic functionality

Description:

Switch to new branch of stable releases for libqmi and modemmanager.

```
Overview of changes in libqmi 1.30.2
----------------------------------------

 * Build:
   ** meson: fix disabling introspection support.

 * New request/response/indications:
   ** voice: implement "Get All Call Status" request/response.

Overview of changes in libqmi 1.30.0
----------------------------------------

 * Build now requires GLib/GObject/GIO 2.56 and libgudev 232.

 * Building from git no longer requires autoconf-archive, the needed AX_ macros
   are now shipped inside m4/.

 * In addition to building from a source release tarball, or building from git
   checkouts using the GNU autotools suite (autoconf/automake/libtool), this
   release includes the initial support for the meson build system. The meson
   port is not fully complete yet, as there are some missing things in the doc
   generation steps, but for system integration or development purposes, the
   port should be fully operational. This major release, including all its
   stable updates in the 1.30.x series, will be the last ones providing support
   for GNU autotools. The next major release will likely be a meson-only one,
   and will therefore not be based on a source release tarball any more, but
   on specific git tags instead.

 * Updated the build to allow better control of the built-in RMNET support:
   ** A new '--disable-rmnet' configure flag is available to request fully
      disabling the RMNET support. When RMNET support is disabled, the link
      management operations are done with the add_mux/del_mux qmi_wwan API
      exclusively.
   ** The library sources now ship the RMNET specific types from the kernel API
      in a custom internal header, so that we don't require the latest kernel
      headers during configure time and build time.
   ** A new 'QMI_RMNET_SUPPORTED' symbol is given to flag the existence of the
      RMNET support in the libqmi-glib headers.

 * New services:
   ** New 'DPM' (Data Port Mapper) service, which allows setting up the binding
      between TX/RX endpoint ids in the hardware and the control port interface,
      required for IPA based Qualcomm SoCs.

 * New request/response/indications:
   ** nas: implement "Get Preferred Networks" request/response.
   ** nas: implement "Set Preferred Networks" request/response.
   ** nas: implement "Network Reject" indications
   ** uim: implement "Get Configuration" request/response.
   ** uim: implement "Depersonalization" request/response.
   ** voice: implement "Manage Calls" request/response.
   ** voice: implement "Supplementary Service" indication.
   ** voice: implement "Set Supplementary Service" request/response.
   ** voice: implement "Get Call Waiting" request/response.

 * New TLVs supported in existing messages:
   ** nas: added the "Network Reject Information" TLV in "Register Indications".
   ** nas: renamed several TLVs in the "System Info" response and indication
      messages, in order to provide a QmiNasRejectCause value instead of a plain
      guint8. The old names were flagged as deprecated and added to the compat
      layer in order to avoid breaking API.
      *** Renamed the "GSM System Info" TLV to "GSM System Info v2".
      *** Renamed the "WCDMA System Info" TLV to "WCDMA System Info v2".
      *** Renamed the "LTE System Info" TLV to "LTE System Info v2".
      *** Renamed the "TD SCMA System Info" TLV to "TD SCMA System Info v2".
   ** nas: added the "NR5G ARFCN" and "NR5G Cell Information" TLVs in "Get Cell
      Location Info".
   ** wds: added the "APN Type" TLV in "Get Profile Settings".
   ** wds: added the "APN Type" TLV in "Create Profile".
   ** wds: added the "APN Type" TLV in "Modify Profile".
   ** nas: renamed the "Common Info" TLV in "Swi Get Status" to "Common Info v2"
      in order to read the temperature field as a signed integer. The old name
      was flagged as deprecated and added to the compat layer in order to avoid
      breaking API.
   ** nas: renamed the "MNC PDS Digit Include Status" TLV in "Get System
      Selection Preference" to "MNC PCS Digit Include Status". The old name was
      flagged as deprecated and added to the compat layer in order to avoid
      breaking API.
   ** wda: added the "Uplink Data Aggregation Max Datagrams", "Uplink Data
      Aggregation Max Size", "Download Minimum Padding" and "Flow Control" TLVs
      in "Get Data Format" and "Set Data Format" responses.
   ** nas: added the "NR5G Service Status Info", "NR5G System Info", "EUTRA with
      NR5G availability", DCNR restriction Info" and "NR5G Tracking Area Code"
      TLVs in "Get System Info".

 * libqmi-glib:
   ** Added support for 'hsic', 'bam-dmux' and 'unknown' endpoint types.
   ** Added support for QMAPv2, QMAPv3 and QMAPv4 data aggregation types.
   ** Added support for 'NGRAN' access technology identifier.
   ** New 'qmi_device_add_link_with_flags()' method, in order to give e.g. rmnet
      specific checksum offload related flags when creating a new link.

 * qmicli:
   ** New '--nas-get-preferred-networks' command.
   ** New '--nas-set-preferred-networks' command.
   ** New '--uim-get-configuration' command.
   ** New '--uim-depersonalization' command.
   ** New '--wms-get-routes' command.
   ** New '--dpm-open-port' command.
   ** New '--dpm-close-port' command.
   ** Updated '--wds-create-profile' with an additional 'apn-type-mask' setting.
   ** Updated '--wds-modify-profile' with an additional 'apn-type-mask' setting.
   ** Updated '--link-add' with an additional optional 'flags' setting.

 * qmi-network:
   ** New PROFILE configuration setting to allow specifying which WDS profile to
      use when connecting.
   ** New IP-TYPE configuration setting to allow selecting the IP type requested
      (e.g. IPv4 or IPv6).

 * collections:
   ** basic: added voice call management operations.
   ** basic: added voice supplementary service related operations.
   ** basic: added NAS preferred networks related operations.
   ** basic: added NAS network reject indications.
   ** basic: added UIM depersonalization related operations.

 * Several other minor improvements and fixes.

The following features which were backported to 1.28.x releases are also present
in libqmi 1.30.0:

   ** gir: bindings updated to make all output TLV fields optional.
   ** gir: bindings fixed with correct string/struct return annotations.
   ** build: updated to disable gtkdocize during autoreconf.
   ** build: updated to avoid gtkdoc-rebase on local install step.
   ** libqmi-glib: added initial "wwan" subsystem support.
   ** dms: implement "Foxconn Set FCC Authentication" command.
```

```
ModemManager 1.18.2
-------------------------------------------

 * build,meson:
   ** The minimum required meson version is now 0.53.0.
   ** Fixed generation of shared utils and plugin modules, so that they don't
      include and export symbols that are internal of the daemon.
   ** Fixed the definition of the plugins directory path so that it's an
      absolute one instead of one relative to the prefix.
   ** Fixed the usage of the systemd suspend/resume build option.
   ** Optional features like introspection support, QMI support, MBIM support,
      QRTR support... are all now defined as meson 'features' (i.e. 'auto',
      'enabled' or 'disabled') instead of booleans (i.e. 'false' or 'true').
   ** Several other improvements and fixes.

 * plugins:
   ** novatel: fix crash when returning a NULL timezone without any error set.

ModemManager 1.18.0
-------------------------------------------
This is a new stable release of ModemManager.

The following notes are directed to package maintainers:

 * This version now requires:
   ** glib2 >= 2.56
   ** libgudev >= 232
   ** libmbim >= 1.26.0 (for the optional MBIM support)
   ** libqmi >= 1.30.2 (for the optional QMI support)
   ** libqrtr-glib >= 1.0.0 (for the optional QRTR support)

 * The ModemManager.service file for systemd integration provided in the sources
   is updated as follows:
   ** 'CAP_NET_ADMIN' is now required in the 'CapabilityBoundingSet' field.
   ** 'AF_NETLINK' and 'AF_QIPCRTR' are now required in the
      'RestrictAddressFamilies' field.
   If the system where ModemManager is being integrated provides a custom
   systemd service configuration, these updates should be considered.

 * The LEGACY and PARANOID filter types that were allowed options in the
   '--filter-policy' option in the ModemManager daemon were deprecated in
   version 1.16.0 and have now been completely removed, along with the vid:pid
   blacklist of devices and the vid:pid greylist of RS232<->USB adapters.

 * Building from git no longer requires autoconf-archive, the needed AX_ macros
   are now shipped inside m4/.

 * In addition to building from a source release tarball, or building from git
   checkouts using the GNU autotools suite (autoconf/automake/libtool), this
   release includes the initial support for the meson build system. The meson
   port is not fully complete yet, as there are some missing things in the doc
   generation and test steps, but for system integration or development
   purposes, the port should be fully operational. This major release, including
   all its stable updates in the 1.18.x series, will be the last ones providing
   support for GNU autotools. The next major release will likely be a meson-only
   one, and will therefore not be based on a source release tarball any more,
   but on specific git tags instead.

The most important features and changes in this release are the following:

 * Data session multiplexing can now be enabled in QMI and MBIM modems, e.g. so
   that multiple different APNs can be connected separately over a single
   network interface. The multiplexing is disabled by default in this release,
   except for cases where it's required (e.g. if non-multiplexed sessions aren't
   supported) like IPA based Qualcomm SoCs. Users can request the multiplexing
   support explicitly via settings when creating the connection bearer object.

   In order to allow easy testing of the multiplexing feature without requiring
   any additional change in the stack, a new '--test-multiplex-requested' option
   in the daemon allows to switch the default (when not explicitly given by the
   user) to attempt to use multiplexing.

   It is worth noting that when multiplexing is enabled, the data network
   interface used by the modem will be a virtual network interface created in
   runtime, and will therefore have a different name than the real network
   interface exposed by the modem. If there are additional settings in the
   system relying on the data network interface name (e.g. iptables rules), they
   may need to be updated.

 * The ModemManager daemon can run now in a 'quick suspend/resume' mode, in
   which no explicit data disconnection is triggered on suspend, and no explicit
   device re-probing from scratch is launched on resume. Instead, the daemon
   will try to refresh the state of all interfaces upon suspend, e.g. to see if
   the module keeps registered to the same operator, to see if it is still
   connected, and so on.

   This mode of operation is useful when the WWAN module stays awake while the
   host is suspended, and can be enabled with the '--test-quick-suspend-resume'
   option in the daemon.

 * API:
   ** New '3gppProfileManager' interface, providing operations on the list of
      connection profiles stored in the 3GPP module. This interface is
      implemented for all AT, QMI and MBIM protocols.
   ** New 'DisableFacilityLock()' method in the 3GPP interface, implemented for
      QMI and MBIM devices.
   ** The 'MaxBearers' property is now deprecated, as it didn't provide any
      additional information to what 'MaxActiveBearers' already provides.
   ** New 'MaxActiveMultiplexedBearers' property, listing how many bearers can
      be connected at the same time if multiplexing is enabled.
   ** New settings in the bearer properties, applicable to both the
      'Simple.Connect()' and 'Modem.CreateBearer()' methods:
      *** 'multiplex': which allows the user to specify whether multiplexing
          should be avoided ('none'), whether it should be mandatory
	  ('required') or whether it should be enabled if available or skipped
	  if unavailable ('requested').
      *** 'profile-id': which allows the user to request a connection attempt
          with an existing profile stored in the module.
      *** 'apn-type': which allows the user to specify the purpose of a given
          connection, e.g. the user could create a connection to an APN
	  providing default internet connectivity and another one to an APN
	  providing access to the MMS gateway. This setting may or may not be
	  stored in the module itself, it depends on the type of module.
   ** New 'Multiplexed' boolean property in the Bearer object, specifying
      whether the bearer is connected through a multiplexed interface.
   ** New 'ConnectionError' property in the bearer object, specifying the last
      error reported by the module during a failed connection attempt or during
      a network-initiated disconnection.
   ** Updated the list of enum values in the MMMobileEquipmentError' type,
      according to the error codes defined in v17.1.0 of 3GPP TS 27.007.

 * Core:
   ** iconv() features support is detected at runtime, and logged when the
      daemon starts.
   ** Updated the base modem object to allow plugins to specify the types of
      data ports they support, based on the specific plugin implementations,
      e.g. so that a modem supporting only AT+PPP can ignore NET ports and
      vice versa.
   ** Added support for modems exposing control ports via QRTR channels.

 * Modem interface:
   ** The Dual SIM logic that would iterate over all slots during initialization
      is updated, so that we only report the information that we can gather
      without any explicit slot change. E.g. with QMI we can know whether there
      is a SIM in the non-active slot, and the ICCID of that SIM, but we cannot
      know the MCCMNC or the operator name of the SIM unless we change to that
      slot. We must not do slot changes arbitrarily like that, and so that logic
      is removed, even if we lose some of the information that we were providing
      in the interface.

 * Location interface:
   ** The multi-sentence NMEA trace support is updated to include additional
      possible trace types in addition to GSV (e.g. ALM, GSV, RTE, SFI) and also
      when coming from other constellations, not just GPS.

 * SIM:
   ** New 'PreferredNetworks' property and 'SetPreferredNetworks' method,
      implemented using '+CPOL' for generic AT modems and 'NAS Get/Set Preferred
      Networks' for QMI modems. Several different modules and plugins (e.g.
      Sierra Wireless EM7345, Telit LN930, SIM7070, all Option and Iridium
      devices...) have this feature explicitly disabled due to '+CPOL' not
      behaving properly (even crashing the module sometimes).

 * QMI:
   ** The logic that decides which data mode (802.3 or raw-ip) is used in
      modules managed by the qmi_wwan driver changes in this release. Until now,
      if a module reported itself as configured in 802.3 mode on boot, that mode
      would be the one used in normal operation. Due to the new multiplexing
      feature, this is no longer true, and if possible the daemon will always
      try to switch the module to raw-ip, and fallback to 802.3 only if raw-ip
      is unsupported.
   ** Enabled both AT and QMI indications for the messaging and voice interfaces
      so that new SMS and call events are reported via both channels. This
      solves issues seen in the Pinephone when waking up from suspend.
   ** Enabled network reject indications.
   ** If operator name not updated through standard indications, it will be
      explicitly queried with 'NAS Get Plmn Name'.
   ** Added support for transfer-route MT messages.
   ** Increased the QMI open timeout to 45s, as required by the newest modules.
   ** Implemented additional logic to read the status of the different facility
      locks in the module.
   ** Updated ICCID reading logic to parse it as hex instead of BCD.
   ** Improved handling of the MNC PCS digit in the operations involving MCCMNC.
   ** Automatically run the 'DPM Open Port' logic on IPA based setups to bind
      the hardware tx/rx endpoints with the logical ones in the QMI protocol.
   ** Implemented support for the Voice interface and its operations, not only
      standard voice call management, but also support for the supplementary
      services. Voice call management will be done completely using QMI, even
      if the new call indications are notified via AT URCs.

 * MBIM:
   ** Implemented support for Dual SIM in non-QMI MBIM devices, using the
      Microsoft Basic Connect Extensions service.
   ** Increased the timeout for the MBIM_CID_HOME_PROVIDER query to 30s.
   ** Updated to load model string using QMI over MBIM if available.
   ** Increased the MBIM open timeout to 45s, as required by the newest modules.

 * SMS:
   ** Defined a common timeout of 180s for all send operations.

 * libmm-glib:
   ** Updated with new methods and types to handle all the DBus API updates.
   ** Extended with additional methods in the Location3gpp object to get/set the
      full operator MCCMNC string, instead of integers without MNC PCS digit
      info.
   ** Extended the 'ModemLocation' interface with methods to get the signaled
      location updates; i.e. without requiring an explicit GetLocation(), and
      obviously only supported when location signaling is explicitly enabled.
   ** Updated the way the internal monitored properties are handled in the
      different types, now using some handy helper macros to share the same
      logic among all.

 * Plugins:
   ** zte: disabled CIND/CMER support.
   ** qcom-soc: added support for QRTR+IPA based setups.
   ** qcom-soc: added support for the WWAN subsystem instead of RPMSG.
   ** quectel: enabled QGPSXTRA by default when starting the GNSS engine.
   ** quectel: add support for EM120/160 PCIe modules.
   ** quectel: added Firehose update method.
   ** ublox: added additional URAT combinations.
   ** ublox: flagged UBANDSEL as unsupported in the SARA-R4 and -N4 modules.
   ** cinterion: added new custom MBIM based modem with shared reset operation.
   ** cinterion: ignored the MBIM Intel Firmware Update service completely.
   ** foxconn: added custom carrier config setup for the T77W968 module.

The following features which were backported to 1.16.x releases are also present
in ModemManager 1.18.0:

 * core: added support for the new 'WWAN' subsystem in Linux kernel 5.13,
   enabling PCIe-only modules.
 * core: The charset conversion methods rework, including the avoiding of the
   iconv() //TRANSLIT extension support, which isn't available in all libc
   implementations.
 * qmi: the logic managing allowed/preferred modes was fixed for multimode
   devices like the MC7304, making sure the acquisition order preference always
   had the same items.
 * serial: when modem is connected with AT+PPP, ignore forced disconnections, so
   that we don't take ownership of the PPP port before pppd has released it.
 * foxconn: added support for the T99W175 (SDX55) module, including built-in FCC
   unlock procedure.
 * foxconn: added new MBIM QDU firmware update method.
```