### PR TITLE
python-docker: Update to 5.0.2

### DIFF
--- a/lang/python/python-docker/Makefile
+++ b/lang/python/python-docker/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-docker
-PKG_VERSION:=5.0.0
+PKG_VERSION:=5.0.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=docker
-PKG_HASH:=3e8bc47534e0ca9331d72c32f2881bb13b93ded0bcdeab3c833fb7cf61c0a9a5
+PKG_HASH:=21ec4998e90dff7a7aaaa098ca8d839c7de412b89e6f6c30908372d58fecf663
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86-64
Run tested: master x86-64

Description: Upstream updates

Bugfixes:

 - Fix disable_buffering regression

 - Bring back support for ssh identity file

 - Cleanup remaining python-2 dependencies

 - Fix image save example in docs

Miscellaneous:

 - Bump urllib3 to 1.26.5

 - Bump requests to 2.26.0

Signed-off-by: Javier Marcet <javier@marcet.info>

