### PR TITLE
python3-texttable: update to version 1.6.4

### DIFF
--- a/lang/python/python-texttable/Makefile
+++ b/lang/python/python-texttable/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-texttable
-PKG_VERSION:=1.6.3
+PKG_VERSION:=1.6.4
 PKG_RELEASE:=1
 
 PYPI_NAME:=texttable
-PKG_HASH:=ce0faf21aa77d806bbff22b107cc22cce68dc9438f97a2df32c93e9afa4ce436
+PKG_HASH:=42ee7b9e15f7b225747c3fa08f43c5d6c83bc899f80ff9bae9319334824076e9
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86-64
Run tested: master x86-64

Description: Upstream update

 - Fix alignment bug when deco is modified

Signed-off-by: Javier Marcet <javier@marcet.info>
