### PR TITLE
nut: Add the option to compile Nut NetXML drivers with the Nut package.

### DIFF
--- a/net/nut/Config.in
+++ b/net/nut/Config.in
@@ -30,3 +30,10 @@
 		help
 			If you have a UPS connected via serial cable, select this.
 		default y
+
+        config NUT_DRIVER_NEON
+                depends on PACKAGE_nut
+                bool "Build with suport for netxml drivers"
+                help
+                        If you have a UPS connected via netxml, select this.
+                default y

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -24,6 +24,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_NUT_DRIVER_SNMP \
 	CONFIG_NUT_DRIVER_USB \
 	CONFIG_NUT_DRIVER_SERIAL \
+	CONFIG_NUT_DRIVER_NEON \
 	CONFIG_NUT_SSL \
 	CONFIG_PACKAGE_nut-web-cgi
 
@@ -98,6 +99,7 @@ define Package/nut-common
 	DEPENDS:= nut \
 		+NUT_DRIVER_SNMP:libnetsnmp \
 		+NUT_DRIVER_USB:libusb-compat \
+		+NUT_DRIVER_NEON:libneon \
 		+NUT_SSL:libopenssl
 endef
 
@@ -369,6 +371,7 @@ define DriverPackage
 		$(if $(filter $(1),snmp),DEPENDS+= @NUT_DRIVER_SNMP)
 		$(if $(filter $(1),usb),DEPENDS+= @NUT_DRIVER_USB)
 		$(if $(filter $(1),serial),DEPENDS+= @NUT_DRIVER_SERIAL)
+                $(if $(filter $(1),neon),DEPENDS+= @NUT_DRIVER_NEON)
         endef
 	# Deliberately empty description in order to trigger a build failure.
 	# It should be overridden by the list below, and when updating to a
@@ -405,6 +408,7 @@ USB_LIBUSB_DRIVERLIST = usbhid-ups bcmxcp_usb tripplite_usb \
  blazer_usb richcomm_usb riello_usb \
  nutdrv_atcl_usb \
  nutdrv_qx
+NEONXML_DRIVERLIST = netxml-ups
 # END: DO NOT EDIT!
 SERIAL_DRIVERLIST_IGNORE:=skel clone-outlet nutdrv_qx
 # nutdrv_qx can be either USB or serial. Given most routers have USB
@@ -417,6 +421,7 @@ SERIAL_DRIVERLIST_IGNORE:=skel clone-outlet nutdrv_qx
 $(foreach d,$(filter-out $(SERIAL_DRIVERLIST_IGNORE),$(SERIAL_DRIVERLIST)),$(eval $(call DriverPackage,serial,$(d))))
 $(foreach d,$(SNMP_DRIVERLIST),$(eval $(call DriverPackage,snmp,$(d))))
 $(foreach d,$(USB_LIBUSB_DRIVERLIST),$(eval $(call DriverPackage,usb,$(d))))
+$(foreach d,$(NEONXML_DRIVERLIST),$(eval $(call DriverPackage,neon,$(d))))
 
 $(eval $(call DriverDescription,serial,al175,\
 	Driver for Eltek UPS models with AL175 alarm module))
@@ -516,6 +521,8 @@ $(eval $(call DriverDescription,usb,nutdrv_atcl_usb,\
 	Driver for ATCL FOR UPS equipment))
 $(eval $(call DriverDescription,usb,nutdrv_qx,\
 	Driver for Q* protocol serial and USB based UPS equipment))
+$(eval $(call DriverDescription,neon,netxml-ups,\
+        Driver for NetXML based UPS equipment))
 
 CONFIGURE_ARGS += \
 	--sysconfdir=/etc/nut \
@@ -526,7 +533,7 @@ CONFIGURE_ARGS += \
 	--$(if $(CONFIG_NUT_DRIVER_SNMP),with,without)-snmp \
 	--$(if $(CONFIG_NUT_DRIVER_SERIAL),with,without)-serial \
 	--without-doc \
-	--without-neon \
+        --$(if $(CONFIG_NUT_DRIVER_NEON),with,without)-neon \
 	--without-powerman \
 	--without-wrap \
 	--with-hotplug-dir=/etc/hotplug \
@@ -566,3 +573,4 @@ $(eval $(call BuildPackage,nut-avahi-service))
 $(foreach d,$(filter-out $(SERIAL_DRIVERLIST_IGNORE),$(SERIAL_DRIVERLIST)),$(eval $(call BuildPackage,nut-driver-$(d))))
 $(foreach d,$(SNMP_DRIVERLIST),$(eval $(call BuildPackage,nut-driver-$(d))))
 $(foreach d,$(USB_LIBUSB_DRIVERLIST),$(eval $(call BuildPackage,nut-driver-$(d))))
+$(foreach d,$(NEONXML_DRIVERLIST),$(eval $(call BuildPackage,nut-driver-$(d))))

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -176,6 +176,11 @@ build_driver_config() {
 	get_write_driver_config "$cfg" vendor
 	get_write_driver_config "$cfg" vendorid
 
+	# Params specific to NetXML driver
+        get_write_driver_config "$cfg" login
+        get_write_driver_config "$cfg" password
+        get_write_driver_config "$cfg" subscribe 0 1
+
 	defoverride() {
 		local overvar="$1"
 		local defover="$2"


### PR DESCRIPTION
Also modifies the nut-server init script to include options specific to the netxml driver.

Signed-off-by: Seb Belcher <sdjbelcher@gmail.com>

Maintainer: unknown
Compile tested: x86_64
Run tested: x86_64

Description:
Add the option to compile Nut NetXML drivers with the Nut package.