### PR TITLE
[collectd]: stop warning non-existent directory

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -352,6 +352,8 @@ define Package/collectd/conffiles
 endef
 
 define Package/collectd/install
+	$(INSTALL_DIR) $(1)/etc/collectd/conf.d
+
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/collectd $(1)/usr/sbin/
 


### PR DESCRIPTION
A fresh install of luci-app-statistics expects /etc/collectd/conf.d/ to be created on the file system but the package does not create this target.  You can see output in logread to this effect:
```
 configfile: stat (/etc/collectd/conf.d) failed: No such file or directory
```

Originally reported against luci-app-statistics here but this is probably the best place to fix it:   https://github.com/openwrt/luci/issues/5373

Signed-off-by: John Audia <graysky@archlinux.us>

Maintainer: @hnyman 