### PR TITLE
keepalived: fix build with IPVS disabled

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -208,9 +208,11 @@ define Package/keepalived/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/keepalived \
 		$(1)/usr/sbin/
 
+ifeq ($(CONFIG_KEEPALIVED_LVS),y)
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/genhash \
 		$(1)/usr/bin/
+endif
 
 	$(INSTALL_DIR) $(1)/etc/keepalived
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/keepalived/keepalived.conf \


### PR DESCRIPTION
Maintainer: @feckert @scrpi 
Compile tested: master r17554-da5bb885e1 on octeon
Run tested: N/A

Description:
The genhash binary is only built when IPVS is enabled, so make its
installation depend on IPVS being enabled.