### PR TITLE
nnn: update to 4.2

### DIFF
--- a/utils/nnn/Makefile
+++ b/utils/nnn/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nnn
-PKG_VERSION:=3.6
-PKG_RELEASE:=1
+PKG_VERSION:=4.2
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jarun/nnn/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=875094caebcc22ecf53b3722d139b127d25e1d5563a954342f32ded8980978b5
+PKG_HASH:=5675f9fe53bddfd92681ef88bf6c0fab3ad897f9e74dd6cdff32fe1fa62c687f
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
@@ -21,7 +21,7 @@ define Package/nnn
   CATEGORY:=Utilities
   TITLE:=Full-featured terminal file manager
   URL:=https://github.com/jarun/nnn
-  DEPENDS:=+libncurses +libreadline
+  DEPENDS:=+libncurses +libreadline +musl-fts
 endef
 
 define Package/nnn/description

--- a/utils/nnn/patches/musl-fts.patch
+++ b/utils/nnn/patches/musl-fts.patch
@@ -1,0 +1,11 @@
+--- a/Makefile
++++ b/Makefile
+@@ -129,7 +129,7 @@ CFLAGS += -std=c11 -Wall -Wextra -Wshado
+ CFLAGS += $(CFLAGS_OPTIMIZATION)
+ CFLAGS += $(CFLAGS_CURSES)
+ 
+-LDLIBS += $(LDLIBS_CURSES) -lpthread
++LDLIBS += $(LDLIBS_CURSES) -lpthread -lfts
+ 
+ # static compilation needs libgpm development package
+ ifeq ($(strip $(O_STATIC)),1)


### PR DESCRIPTION
Maintainer: @BKPepe
Compile tested: armv7, Turris Omnia, OpenWrt 21.02
Run tested: armv7, Turris Omnia, OpenWrt 21.02

Description: They started using fts in some version, so it now needs musl-fts and a small patch. Alpine uses the same patch.