### PR TITLE
attendedsysupgrade-common: use sysupgrade.openwrt.org

### DIFF
--- a/utils/attendedsysupgrade-common/files/attendedsysupgrade.defaults
+++ b/utils/attendedsysupgrade-common/files/attendedsysupgrade.defaults
@@ -6,7 +6,7 @@ touch /etc/config/attendedsysupgrade
 
 uci -q batch <<EOF
 set attendedsysupgrade.server=server
-set attendedsysupgrade.server.url='https://asu.aparcar.org'
+set attendedsysupgrade.server.url='https://sysupgrade.openwrt.org'
 
 set attendedsysupgrade.client=client
 set attendedsysupgrade.client.upgrade_packages='1'


### PR DESCRIPTION
A new server was added which runs within the OpenWrt cloud, it's much
faster and should be used instead. For development the server at
https://asu.aparcar.org stays available.

Signed-off-by: Paul Spooren <mail@aparcar.org>