### PR TITLE
prometheus-node-exporter-lua: fix broken control flow

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2021.07.24
+PKG_VERSION:=2021.09.24
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/hostapd_stations.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/hostapd_stations.lua
@@ -19,7 +19,7 @@ local function get_wifi_interface_labels()
       local bss_idx = -1
       for line in hostapd_status:gmatch("[^\r\n]+") do
         local name, value = string.match(line, "(.+)=(.+)")
-        elseif name == "freq" then
+        if name == "freq" then
           hostapd["freq"] = value
         elseif name == "channel" then
           hostapd["channel"] = value


### PR DESCRIPTION
Maintainer: @champtar
Compile tested: ath79-generic
Run tested: unifi {ac {lite,mesh},}

Description:

I introduced this issue in 2849ec248d0bcdce700abab9062f74cefccadee4. It prevents the exporter from starting.

Should be ported to openwrt-21.02.