### PR TITLE
libexif: update to 0.6.23

### DIFF
--- a/libs/libexif/Makefile
+++ b/libs/libexif/Makefile
@@ -8,19 +8,21 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libexif
-PKG_VERSION:=0.6.22
-PKG_RELEASE:=1
+PKG_VERSION:=0.6.23
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/$(PKG_NAME)-0_6_22-release/
-PKG_HASH:=5048f1c8fc509cc636c2f97f4b40c293338b6041a5652082d5ee2cf54b530c56
+PKG_SOURCE_URL:=https://github.com/libexif/libexif/releases/download/v$(PKG_VERSION)
+PKG_HASH:=a740a99920eb81ae0aa802bb46e683ce6e0cde061c210f5d5bde5b8572380431
 
-PKG_LICENSE:=LGPL-2.1
+PK_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
+PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:libexif:libexif
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -29,7 +31,6 @@ define Package/libexif
   CATEGORY:=Libraries
   TITLE:=library for jpeg files with exif tags
   URL:=https://libexif.github.io/
-  MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 endef
 
 define Package/libexif/description

--- a/libs/libexif/patches/100-no_doc.patch
+++ b/libs/libexif/patches/100-no_doc.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -393,7 +393,7 @@ target_alias = @target_alias@
+@@ -406,7 +406,7 @@ target_alias = @target_alias@
  top_build_prefix = @top_build_prefix@
  top_builddir = @top_builddir@
  top_srcdir = @top_srcdir@


### PR DESCRIPTION
Switch to AUTORELEASE for simplicity.

Fix license information.

Add PKG_BUILD_PARALLEL for faster compilation.

Fixes CVE-2020-0198 and CVE-2020-0452.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @flyn-org 
Compile tested: ath79