### PR TITLE
htop: update to 3.1.0

### DIFF
--- a/admin/htop/Makefile
+++ b/admin/htop/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=htop
-PKG_VERSION:=3.0.5
-PKG_RELEASE:=2
+PKG_VERSION:=3.1.0
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/htop-dev/htop/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=4c2629bd50895bd24082ba2f81f8c972348aa2298cc6edc6a21a7fa18b73990c
+PKG_HASH:=200a4f9331d0e5048bf9bda6a8dee38248c557e471b9e57ff3784853efd613a9
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
@@ -56,8 +56,9 @@ define Package/htop/config
 endef
 
 CONFIGURE_ARGS += \
-	--with-sensors=$(if $(CONFIG_HTOP_LMSENSORS),yes,no) \
-	--enable-linux-affinity \
+	$(if $(CONFIG_HTOP_LMSENSORS),--enable-sensors,) \
+	--enable-affinity \
+	--enable-capabilities=no \
 	--disable-unicode \
 	--disable-hwloc
 

--- a/admin/htop/patches/001-backport-automake-fix.patch
+++ b/admin/htop/patches/001-backport-automake-fix.patch
@@ -1,0 +1,109 @@
+From 3d3474b3fc4272840310414aaa2edaed2c52a08e Mon Sep 17 00:00:00 2001
+From: Nathan Scott <nathans@redhat.com>
+Date: Thu, 23 Sep 2021 10:06:38 +1000
+Subject: [PATCH] Adjust Makefile.am macro definitions for older automake
+ versions
+
+Fixes: https://github.com/htop-dev/htop/issues/803
+PR: https://github.com/htop-dev/htop/issues/810
+
+
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,3 +1,11 @@
++if !HTOP_PCP
++bin_PROGRAMS = htop
++myhtopplatprogram = htop.c
++else
++bin_PROGRAMS = pcp-htop
++myhtopplatprogram = pcp-htop.c
++endif
++
+ dist_man_MANS = htop.1
+ EXTRA_DIST = \
+ 	$(dist_man_MANS) \
+@@ -181,7 +189,6 @@ linux_platform_sources = \
+ 
+ if HTOP_LINUX
+ AM_LDFLAGS += -rdynamic
+-myhtopplatprogram = htop
+ myhtopplatheaders = $(linux_platform_headers)
+ myhtopplatsources = $(linux_platform_sources)
+ endif
+@@ -214,7 +221,6 @@ freebsd_platform_sources = \
+ 	zfs/ZfsCompressedArcMeter.c
+ 
+ if HTOP_FREEBSD
+-myhtopplatprogram = htop
+ myhtopplatheaders = $(freebsd_platform_headers)
+ myhtopplatsources = $(freebsd_platform_sources)
+ endif
+@@ -240,7 +246,6 @@ dragonflybsd_platform_sources = \
+ 	generic/uname.c
+ 
+ if HTOP_DRAGONFLYBSD
+-myhtopplatprogram = htop
+ myhtopplatheaders = $(dragonflybsd_platform_headers)
+ myhtopplatsources = $(dragonflybsd_platform_sources)
+ endif
+@@ -266,7 +271,6 @@ netbsd_platform_sources = \
+ 	netbsd/NetBSDProcessList.c
+ 
+ if HTOP_NETBSD
+-myhtopplatprogram = htop
+ myhtopplatheaders = $(netbsd_platform_headers)
+ myhtopplatsources = $(netbsd_platform_sources)
+ endif
+@@ -292,7 +296,6 @@ openbsd_platform_sources = \
+ 	openbsd/Platform.c
+ 
+ if HTOP_OPENBSD
+-myhtopplatprogram = htop
+ myhtopplatheaders = $(openbsd_platform_headers)
+ myhtopplatsources = $(openbsd_platform_sources)
+ endif
+@@ -326,7 +329,6 @@ darwin_platform_sources = \
+ 
+ if HTOP_DARWIN
+ AM_LDFLAGS += -framework IOKit -framework CoreFoundation
+-myhtopplatprogram = htop
+ myhtopplatheaders = $(darwin_platform_headers)
+ myhtopplatsources = $(darwin_platform_sources)
+ endif
+@@ -357,7 +359,6 @@ solaris_platform_sources = \
+ 	zfs/ZfsCompressedArcMeter.c
+ 
+ if HTOP_SOLARIS
+-myhtopplatprogram = htop
+ myhtopplatheaders = $(solaris_platform_headers)
+ myhtopplatsources = $(solaris_platform_sources)
+ endif
+@@ -393,10 +394,9 @@ pcp_platform_sources = \
+ 	zfs/ZfsCompressedArcMeter.c
+ 
+ if HTOP_PCP
+-myhtopplatprogram = pcp-htop
+ myhtopplatheaders = $(pcp_platform_headers)
+ myhtopplatsources = $(pcp_platform_sources)
+-pcp_htop_SOURCES  = $(myhtopplatprogram).c $(myhtopheaders) $(myhtopplatheaders) $(myhtopsources) $(myhtopplatsources)
++pcp_htop_SOURCES  = $(myhtopplatprogram) $(myhtopheaders) $(myhtopplatheaders) $(myhtopsources) $(myhtopplatsources)
+ endif
+ 
+ # Unsupported
+@@ -416,15 +416,13 @@ unsupported_platform_sources = \
+ 	unsupported/UnsupportedProcessList.c
+ 
+ if HTOP_UNSUPPORTED
+-myhtopplatprogram = htop
+ myhtopplatsources = $(unsupported_platform_sources)
+ myhtopplatheaders = $(unsupported_platform_headers)
+ endif
+ 
+ # ----
+ 
+-bin_PROGRAMS = $(myhtopplatprogram)
+-htop_SOURCES = $(myhtopplatprogram).c $(myhtopheaders) $(myhtopplatheaders) $(myhtopsources) $(myhtopplatsources)
++htop_SOURCES = $(myhtopplatprogram) $(myhtopheaders) $(myhtopplatheaders) $(myhtopsources) $(myhtopplatsources)
+ nodist_htop_SOURCES = config.h
+ 
+ target:


### PR DESCRIPTION
Update htop to version 3.1.0

* Adjust Makefile configuration options to update
   (affinity, sensors)
* Backport post-release fix for old automake versions (like ours)
    Fixes: https://github.com/htop-dev/htop/issues/803
    PR: https://github.com/htop-dev/htop/issues/810
* Switch to PKG_RELEASE autorelease in Makefile

Maintainer:  @champtar 
Run tested: ipq806x/R7800, mt7622/RT3200
