### PR TITLE
smcroute: update to version 2.5.3

### DIFF
--- a/net/smcroute/Makefile
+++ b/net/smcroute/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=smcroute
-PKG_VERSION:=2.5.2
+PKG_VERSION:=2.5.3
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/troglobit/smcroute/releases/download/$(PKG_VERSION)
-PKG_HASH:=7eca88389cc08cbfe75f787e02ab32a390ef806555069a08abe8d7fa925ed094
+PKG_HASH:=4342b95c99e410cab75e9ee80f20480e0170d8b07b8e31553ba1bec3e377fc56
 
 PKG_FIXUP:=autoreconf
 


### PR DESCRIPTION
Signed-off-by: Moritz Warning <moritzwarning@web.de>

Maintainer: me
Compile tested (ath79/generic, 8devices-Carambola2)
