### PR TITLE
php7: fix module loading with glibc (refs #16642)

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=7.4.23
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=PHP-3.01
@@ -174,6 +174,10 @@ CONFIGURE_ARGS+= \
 	--without-valgrind \
 	--with-external-pcre \
 	--with-zlib="$(STAGING_DIR)/usr"
+
+ifeq ($(CONFIG_LIBC_USE_GLIBC),y)
+TARGET_LDFLAGS += -ldl
+endif
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_php7-mod-bcmath),)
   CONFIGURE_ARGS+= --enable-bcmath=shared


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs

Description:

Without -ldl linker flag .so extensions are not loaded
when glibc is used. Fix it by providing adjusted LDFLAGS
for this case.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
