### PR TITLE
ttyd: fix ssl ca option init

### DIFF
--- a/utils/ttyd/Makefile
+++ b/utils/ttyd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ttyd
 PKG_VERSION:=1.6.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tsl0922/ttyd/tar.gz/$(PKG_VERSION)?

--- a/utils/ttyd/patches/090-fix-ssl-ca-option-init.patch
+++ b/utils/ttyd/patches/090-fix-ssl-ca-option-init.patch
@@ -1,0 +1,14 @@
+--- a/src/server.c
++++ b/src/server.c
+@@ -509,9 +509,10 @@ int main(int argc, char **argv) {
+   if (ssl) {
+     info.ssl_cert_filepath = cert_path;
+     info.ssl_private_key_filepath = key_path;
+-    if (strlen(ca_path) > 0)
++    if (strlen(ca_path) > 0) {
+       info.ssl_ca_filepath = ca_path;
+       info.options |= LWS_SERVER_OPTION_REQUIRE_VALID_OPENSSL_CLIENT_CERT;
++    }
+ #if LWS_LIBRARY_VERSION_MAJOR >= 2
+     info.options |= LWS_SERVER_OPTION_REDIRECT_HTTP_TO_HTTPS;
+ #endif


### PR DESCRIPTION
Maintainer:  @tsl0922 
Compile tested: (ipq806x, nbg6817, OpenWrt 21.02)
Run tested: (ipq806x, nbg6817, OpenWrt 21.02, tests done)

https://github.com/openwrt/packages/issues/14577
