### PR TITLE
openssh: update to 8.8p1

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
-PKG_VERSION:=8.7p1
+PKG_VERSION:=8.8p1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
 		https://ftp.spline.de/pub/OpenBSD/OpenSSH/portable/
-PKG_HASH:=7ca34b8bb24ae9e50f33792b7091b3841d7e1b440ff57bc9fabddf01e2ed1e24
+PKG_HASH:=4590890ea9bb9ace4f71ae331785a3a5823232435161960ed5fc86588f331fe9
 
 PKG_LICENSE:=BSD ISC
 PKG_LICENSE_FILES:=LICENCE


### PR DESCRIPTION
Maintainer: @tripolar
Compile tested: tp-link archer c7 v2 / ath79 / master
Run tested: tp-link archer c7 v2 / ath79 / master

    Server running and accepting connections
    Client connecting to servers

Description:
Version bump to 8.8p1

Signed-off-by: Sibren Vasse <github@sibrenvasse.nl>