### PR TITLE
tinc: update to 1.1pre18

### DIFF
--- a/net/tinc/Makefile
+++ b/net/tinc/Makefile
@@ -8,23 +8,24 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tinc
-PKG_VERSION:=1.1-git
-PKG_RELEASE:=3
+PKG_VERSION:=1.1pre18
+PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=http://tinc-vpn.org/git/tinc
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=3ee0d5dd
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
-PKG_MIRROR_HASH:=fe57dcce5c17ec2cea96fefc69c5af977df7d457f1ae7c4775e00a21878a2c19
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://tinc-vpn.org/packages
+PKG_HASH:=2757ddc62cf64b411f569db2fa85c25ec846c0db110023f6befb33691f078986
 
+PKG_MAINTAINER:=Erwan Mas <erwan@mas.nom.fr>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:tinc:tinc
 
-PKG_BUILD_PARALLEL:=1
-PKG_CONFIG_DEPENDS:=zlib lzo openssl
-PKG_BUILD_DEPENDS:=zlib lzo openssl
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+PKG_CONFIG_DEPENDS:=zlib lzo openssl
+PKG_BUILD_DEPENDS:=zlib lzo openssl
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -34,7 +35,6 @@ define Package/tinc
   DEPENDS:=+kmod-tun +liblzo +libopenssl +librt +zlib
   TITLE:=VPN tunneling daemon
   URL:=http://www.tinc-vpn.org/
-  MAINTAINER:=Erwan Mas <erwan@mas.nom.fr>
   SUBMENU:=VPN
 endef
 
@@ -43,17 +43,12 @@ define Package/tinc/description
   encryption to create a secure private network between hosts on the Internet.
 endef
 
-TARGET_CFLAGS += -std=gnu99
-
 CONFIGURE_ARGS += \
 	--with-kernel="$(LINUX_DIR)" \
 	--disable-curses \
 	--disable-readline \
 	--with-lzo-include="$(STAGING_DIR)/usr/include/lzo" \
 	--with-zlib="$(STAGING_DIR)/usr"
-
-CONFIGURE_VARS += \
-	ac_cv_have_decl_OpenSSL_add_all_algorithms=yes
 
 define Package/tinc/install
 	$(INSTALL_DIR) $(1)/usr/sbin

--- a/net/tinc/patches/010-code-libtool.patch
+++ b/net/tinc/patches/010-code-libtool.patch
@@ -1,0 +1,10 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -8,7 +8,6 @@ ACLOCAL_AMFLAGS = -I m4
+ 
+ EXTRA_DIST = COPYING.README README.android
+ 
+-@CODE_COVERAGE_RULES@
+ 
+ # If git describe works, force autoconf to run in order to make sure we have the
+ # current version number from git in the resulting configure script.


### PR DESCRIPTION
Switch to AUTORELEASE for simplicity.

Switch to normal tarballs.

Add license information.

Reorganize Makefile for consistency between packages.

Add libtool patch fixing compilation under some conditions.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ErwanMAS 
Compile tested: ath79