### PR TITLE
libseccomp: update to 2.5.2

### DIFF
--- a/libs/libseccomp/Makefile
+++ b/libs/libseccomp/Makefile
@@ -8,19 +8,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libseccomp
-PKG_VERSION:=2.5.1
-PKG_RELEASE:=1
+PKG_VERSION:=2.5.2
+PKG_RELEASE:=$(AUTORELEASE)
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/seccomp/libseccomp/releases/download/v$(PKG_VERSION)/
-PKG_HASH:=ee307e383c77aa7995abc5ada544d51c9723ae399768a97667d4cdb3c3a30d55
+PKG_HASH:=17a652dfb491d96be893960e9b791914936ee16c13b777a3caf562fe48cb87df
 
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <nmav@gnutls.org>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:libseccomp_project:libseccomp
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=gperf/host

--- a/libs/libseccomp/patches/010-no-code-coverage.patch
+++ b/libs/libseccomp/patches/010-no-code-coverage.patch
@@ -1,0 +1,10 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -16,7 +16,6 @@
+ # along with this library; if not, see <http://www.gnu.org/licenses>.
+ #
+ 
+-@CODE_COVERAGE_RULES@
+ 
+ CODE_COVERAGE_OUTPUT_FILE = libseccomp.lcov.info
+ CODE_COVERAGE_OUTPUT_DIRECTORY = libseccomp.lcov.html.d


### PR DESCRIPTION
Use AUTORELEASE for simplicity.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nmav 
Compile tested: ath79