### PR TITLE
zerotier: update to 1.6.6

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
-PKG_VERSION:=1.6.5
+PKG_VERSION:=1.6.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=a437ec9e8a4987ed48c0e5af3895a057dcc0307ab38af90dd7729a131097f222
+PKG_HASH:=6c95ffca4a64bf948abbf3e550a0c4881b17cf45ff2f55e2a389d095f9be81a5
 PKG_BUILD_DIR:=$(BUILD_DIR)/ZeroTierOne-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>


### PR DESCRIPTION
This is a security release (see [1]).

[1] https://www.zerotier.com/2021/09/21/incident-response-to-september-20th-2021

Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
(cherry picked from commit 7f50af89496751206a764c244a7f93a4acde9c34)

Maintainer: me
