### PR TITLE
python3: enable bluetooth support by default

### DIFF
--- a/lang/python/python3/Config-python3-light.in
+++ b/lang/python/python3/Config-python3-light.in
@@ -1,9 +1,5 @@
 menu "Configuration"
 
-config PYTHON3_BLUETOOTH_SUPPORT
-	bool "Enable Bluetooth support"
-	default n
-
 config PYTHON3_HOST_PIP_CACHE_WORLD_READABLE
 	bool "Ensure host pip cache is world-readable"
 	default n

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 include ../python3-version.mk
 
 PKG_NAME:=python3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=$(PYTHON3_VERSION).$(PYTHON3_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -41,10 +41,9 @@ HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/Python-$(PKG_VERSION)
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_python3-pkg-resources \
-	CONFIG_PACKAGE_python3-setuptools CONFIG_PACKAGE_python3-pip \
-	CONFIG_PYTHON3_BLUETOOTH_SUPPORT
+	CONFIG_PACKAGE_python3-setuptools CONFIG_PACKAGE_python3-pip
 
-PKG_BUILD_DEPENDS:=python3/host
+PKG_BUILD_DEPENDS:=bluez python3/host
 HOST_BUILD_DEPENDS:=bzip2/host expat/host libffi/host
 
 include $(INCLUDE_DIR)/host-build.mk
@@ -92,7 +91,7 @@ endef
 define Package/python3-light
 $(call Package/python3/Default)
   TITLE:=Python $(PYTHON3_VERSION) light installation
-  DEPENDS:=+python3-base +libffi +libbz2 +PYTHON3_BLUETOOTH_SUPPORT:bluez-libs +libuuid
+  DEPENDS:=+python3-base +libffi +libbz2 +libuuid
 endef
 
 define Package/python3-light/config
@@ -149,10 +148,6 @@ EXTRA_LDFLAGS+= \
 	-L$(PKG_BUILD_DIR) \
 	-L$(STAGING_DIR)/usr/lib -L$(STAGING_DIR)/lib
 
-DISABLE_BLUETOOTH:= \
-	ac_cv_header_bluetooth_bluetooth_h=no \
-	ac_cv_header_bluetooth_h=no
-
 CONFIGURE_ARGS+= \
 	--enable-optimizations \
 	--enable-shared \
@@ -163,8 +158,7 @@ CONFIGURE_ARGS+= \
 	$(if $(CONFIG_IPV6),--enable-ipv6) \
 	$(if $(findstring mips,$(CONFIG_ARCH)),,--with-lto) \
 	CONFIG_SITE="$(PKG_BUILD_DIR)/config.site" \
-	OPT="$(TARGET_CFLAGS)" \
-	$(if $(CONFIG_PYTHON3_BLUETOOTH_SUPPORT),,$(DISABLE_BLUETOOTH))
+	OPT="$(TARGET_CFLAGS)"
 
 define Build/Prepare
 	$(call Build/Prepare/Default)


### PR DESCRIPTION
Maintainer: me, @jefferyto 
Compile tested: x86 https://github.com/openwrt/openwrt/commit/fc050c7b53116b6e3f2c31797b27cfc76af60e74
Run tested: x86 https://github.com/openwrt/openwrt/commit/fc050c7b53116b6e3f2c31797b27cfc76af60e74

--------------------------------------------------------------------------------

Bluetooth support requires bluez-libs present, but they are only required
for the build, and don't seem to be needed to be present on the target.

There isn't any linking required to libbluetooth. It's only the bluetooth.h
header that is required for building BT support into Python.

For testing, this snippet was used from `Lib/test/test_socket.py` (inside
cpython):
```
def _have_socket_bluetooth():
    """Check whether AF_BLUETOOTH sockets are supported on this host."""
    try:
        # RFCOMM is supported by all platforms with bluetooth support. Windows
        # does not support omitting the protocol.
        s = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_STREAM, socket.BTPROTO_RFCOMM)
    except (AttributeError, OSError):
        return False
    else:
        s.close()
    return True
```

Fixes: https://github.com/openwrt/packages/issues/16544

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>