### PR TITLE
php8: update to 8.0.11

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.0.10
-PKG_RELEASE:=2
+PKG_VERSION:=8.0.11
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=PHP-3.01
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=66dc4d1bc86d9c1bc255b51b79d337ed1a7a035cf71230daabbf9a4ca35795eb
+PKG_HASH:=e3e5f764ae57b31eb65244a45512f0b22d7bef05f2052b23989c053901552e16
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs, musl

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
