### PR TITLE
php7: update to 7.4.24

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=7.4.23
-PKG_RELEASE:=3
+PKG_VERSION:=7.4.24
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=PHP-3.01
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=cea52313fcffe56343bcd3c66dbb23cd5507dc559cc2e3547cf8f5452e88a05d
+PKG_HASH:=ff7658ee2f6d8af05b48c21146af5f502e121def4e76e862df5ec9fa06e98734
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs, musl
Run tested: mxs

Description:

This fixes:
    - CVE-2021-21706

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
