### PR TITLE
fontconfig: avoid compilation problem (on Ubuntu)

### DIFF
--- a/utils/fontconfig/patches/001-revert-upstream-meson-commit.patch
+++ b/utils/fontconfig/patches/001-revert-upstream-meson-commit.patch
@@ -1,0 +1,26 @@
+Revert partially the upstream commit ae9ac2a1
+
+  Subject: [PATCH] meson: fix cross-compilation issues with gperf header file preprocessing
+
+  Pass c_args to the compiler when preprocessing the gperf header file,
+  they might contain important bits without which compilation/preprocessing
+  might fail (e.g. with clang on Android). cc.cmd_array() does not include
+  the c_args and we can't easily look them up from the meson.build file, so
+  we have to retrieve from the introspection info.
+
+  This is basically the Meson equivalent to commit 57103773.
+
+Revert the host_cargs related part of the patch
+
+
+--- a/src/cutout.py
++++ b/src/cutout.py
+@@ -24,7 +24,7 @@ if __name__== '__main__':
+                 break
+ 
+     cpp = args[1]
+-    ret = subprocess.run(cpp + host_cargs + [args[0].input], stdout=subprocess.PIPE, check=True)
++    ret = subprocess.run(cpp + [args[0].input], stdout=subprocess.PIPE, check=True)
+ 
+     stdout = ret.stdout.decode('utf8')
+ 


### PR DESCRIPTION
Partially revert an upstream commit to avoid build breakage on Ubuntu.

Refrerence to discussion starting at
https://github.com/openwrt/packages/pull/16726#issuecomment-927309052

upstream commit:
https://gitlab.freedesktop.org/fontconfig/fontconfig/-/commit/ae9ac2a1bfb6fa800b99791b6fc36711dd0c1fbc
`meson: fix cross-compilation issues with gperf header file preprocessing`

Maintainer: -
Compile tested: ipq806x/R7800, mt7622/E8450, mvebu/WRT3200ACM
Run tested: ipq806x/R7800
