### PR TITLE
stress-ng: bump to 0.13.03

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.13.01
+PKG_VERSION:=0.13.03
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://kernel.ubuntu.com/~cking/tarballs/stress-ng
-PKG_HASH:=f37f739e4d15343360a47980b67dc8b2a6bf3d4d3ef727d55e2dd99a0b64f9ea
+PKG_HASH:=3e60d605e378d86a8591a30d6e557bed709d82a5b19616378002cd8ff0037a8b
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/fc050c7b53116b6e3f2c31797b27cfc76af60e74
Run tested: x86 https://github.com/openwrt/openwrt/commit/fc050c7b53116b6e3f2c31797b27cfc76af60e74

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>