### PR TITLE
collectd: sqm_collect: handle being orphaned

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.12.0
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \

--- a/utils/collectd/files/exec-scripts/sqm_collectd.sh
+++ b/utils/collectd/files/exec-scripts/sqm_collectd.sh
@@ -99,7 +99,8 @@ process_qdisc() {
 	json_cleanup
 }
 
-while true ; do
+# while not orphaned
+while [ $(awk '$1 ~ "^PPid:" {print $2}' /proc/$$/status) -ne 1 ] ; do
 	for ifc in "$@" ; do
 		process_qdisc "$ifc"
 	done


### PR DESCRIPTION
If the master collectd instance gets shut down in an uncontrolled
manner (crashes!) then sqm_collect scripts will be left orphaned and
will run forever.

Modify script to check if it still has a parent and if not, exit.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>