### PR TITLE
dns-over-https: Add dns-over-https

### DIFF
--- a/net/dns-over-https/Makefile
+++ b/net/dns-over-https/Makefile
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2021 Martin Schneider <martschneider@google.com>
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dns-over-https
+PKG_VERSION:=2.3.0
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/m13253/dns-over-https/tar.gz/v${PKG_VERSION}?
+PKG_HASH:=887456b25396a0234ef351e474079198b5b81bccf63cc6eedefef9d2d81821f2
+
+PKG_MAINTAINER:=Martin Schneider <martschneider@google.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/m13253/dns-over-https
+GO_PKG_INSTALL_BIN_PATH:=/usr/sbin
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/dns-over-https
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=IP Addresses and Names
+  TITLE:=Query DNS over HTTPS
+  URL:=https://github.com/m13253/dns-over-https
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/dns-over-https/description
+  Client and server software to query DNS over HTTPS, using Google DNS-over-HTTPS protocol and IETF DNS-over-HTTPS (RFC 8484).
+endef
+
+define Package/dns-over-https/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+	$(INSTALL_DIR) $(1)/etc/dns-over-https
+	$(CP) $(PKG_BUILD_DIR)/doh-client/doh-client.conf $(1)/etc/dns-over-https/doh-client.conf
+	$(CP) $(PKG_BUILD_DIR)/doh-server/doh-server.conf $(1)/etc/dns-over-https/doh-server.conf
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/doh-client.init $(1)/etc/init.d/doh-client
+	$(INSTALL_BIN) ./files/doh-server.init $(1)/etc/init.d/doh-server
+endef
+
+$(eval $(call GoBinPackage,dns-over-https))
+$(eval $(call BuildPackage,dns-over-https))

--- a/net/dns-over-https/files/doh-client.init
+++ b/net/dns-over-https/files/doh-client.init
@@ -1,0 +1,21 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+# starts before dnsmasq starts
+START=18
+# stops before networking stops
+STOP=89
+
+PROG=/usr/sbin/doh-client
+CONFIGFILE=/etc/dns-over-https/doh-client.conf
+
+start_service() {
+        procd_open_instance
+        procd_set_param command "$PROG" -conf "$CONFIGFILE"
+        procd_set_param file "$CONFIGFILE"
+        procd_set_param stdout 1
+        procd_set_param stderr 1
+        procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+        procd_close_instance
+}

--- a/net/dns-over-https/files/doh-server.init
+++ b/net/dns-over-https/files/doh-server.init
@@ -1,0 +1,21 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+# starts before dnsmasq starts
+START=18
+# stops before networking stops
+STOP=89
+
+PROG=/usr/sbin/doh-server
+CONFIGFILE=/etc/dns-over-https/doh-server.conf
+
+start_service() {
+        procd_open_instance
+        procd_set_param command "$PROG" -conf "$CONFIGFILE"
+        procd_set_param file "$CONFIGFILE"
+        procd_set_param stdout 1
+        procd_set_param stderr 1
+        procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+        procd_close_instance
+}


### PR DESCRIPTION
Signed-off-by: Martin Schneider <martschneider@google.com>

Maintainer: @martinschneider
Compile tested: x86-64, ipq806x, 21.02.0-rc3
Run tested: x86-64, 21.02.0-rc3. Run the DOH server as a proxy for Cloudflare behind nginx and succesfully send DOH queries to it using curl.

Description:
Client and server software to query DNS over HTTPS, using Google DNS-over-HTTPS protocol and IETF DNS-over-HTTPS (RFC 8484). https://github.com/m13253/dns-over-https

The following is one example use-case for the server part, utilizing `nginx` and `doh-server` as a proxy for an upstream DNS server like Google or Cloudflare.

```
                              +------------------------+
                              |  Upstream DNS server   |
                              |  8.8.8.8, 1.1.1.1      |
                              +-----------+------------+
                                          |
                              +-----------+------------+
                              |       doh-server       |
                              +-----------+------------+
                                          |
                              +-----------+------------+
+--------------------------+  |       Webserver        |
+          Clients         +--+       e.g. nginx       |
+--------------------------+  +------------------------+
```