### PR TITLE
travelmate: support meta-refresh with single-quote

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
 PKG_VERSION:=2.0.7
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -491,7 +491,7 @@ f_net() {
 				result="net cp '${json_cp}'"
 			else
 				if [ "${json_rc}" = "200" ] || [ "${json_rc}" = "204" ]; then
-					html_cp="$(printf "%s" "${html_raw}" | awk 'match(tolower($0),/^.*<meta[ \t]+http-equiv=["]*refresh.*[ \t;]url=/){print substr(tolower($0),RLENGTH+1)}' | awk 'BEGIN{FS="[:/]"}{printf "%s",$4;exit}')"
+					html_cp="$(printf "%s" "${html_raw}" | awk 'match(tolower($0),/^.*<meta[ \t]+http-equiv=['\''"]*refresh.*[ \t;]url=/){print substr(tolower($0),RLENGTH+1)}' | awk 'BEGIN{FS="[:/]"}{printf "%s",$4;exit}')"
 					if [ -n "${html_cp}" ]; then
 						result="net cp '${html_cp}'"
 					else


### PR DESCRIPTION
Currently `travelmate` only support `<meta` tag if it contains `"`.
This updates `travelmate.sh` to support`'` as well.

This works, because we want to emit `['"]` in a single arg:

- we close current string with `'`
- we open a new string with `"`, emit `'` (needed character), close a string `"`
- we open a new string `'` till the rest of string, and include `"` double quotes

```shell
root@slate:~# echo '['"'"'"]'
['"]
```

Maintainer: me / @dibdot
Compile tested: ath79/nand
Run tested: OpenWrt 21.02.0 r16279-5cc0535800, GL.iNet GL-AR750S (NOR/NAND)

Description:
