### PR TITLE
tailscale: update to version 1.16.0

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.12.3
+PKG_VERSION:=1.16.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=tailscale-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=05e5b1d382cad7ac5737d87d0b61277791c75938468c2c662f21665998d431e9
+PKG_HASH:=dae0eaa5aef8cb9d3cdd83cb07039b57b202c44e4f581e26cfee98707c251c78
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: `@ja-pa`
Compile tested: mipsel_24kc / MT7621
Run tested: ~~mipsel_24kc / MT7621 on a RB750Gr3~~ TODO
Description: Updating to latest stable from https://pkgs.tailscale.com/stable/#static