### PR TITLE
zerotier: fix cross compile in macOS

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
 PKG_VERSION:=1.6.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
@@ -46,6 +46,7 @@ endif
 
 MAKE_FLAGS += \
 	DEFS="" \
+	OSTYPE="Linux" \
 
 define Build/Compile
 	$(call Build/Compile/Default,one)


### PR DESCRIPTION
zerotier's Makefile use `uname` to detect target when cross compile
uname should always be 'linux'

Signed-off-by: Liangbin Lian <jjm2473@gmail.com>

Maintainer: Moritz Warning <moritzwarning@web.de>
Compile tested: macOS 10.15.7, openwrt 19.07
Run tested: skipped

Description:
