### PR TITLE
ddns-scripts: add infomaniak.com provider

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=14
+PKG_RELEASE:=15
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/infomaniak.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/infomaniak.com.json
@@ -1,0 +1,11 @@
+{
+	"name": "infomaniak.com",
+	"ipv4": {
+		"url": "https://[USERNAME]:[PASSWORD]@infomaniak.com/nic/update?hostname=[DOMAIN]&myip=[IP]",
+		"answer": "good|nochg"
+	},
+	"ipv6": {
+		"url": "https://[USERNAME]:[PASSWORD]@infomaniak.com/nic/update?hostname=[DOMAIN]&myip=[IP]",
+		"answer": "good|nochg"
+	}
+}

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -37,6 +37,7 @@ editdns.net
 goip.de
 google.com
 he.net
+infomaniak.com
 inwx.de
 joker.com
 loopia.se


### PR DESCRIPTION
Maintainer:  @feckert 
Compile tested: Not applicable
Run tested: x86-64 ,OpenWrt 21.02, tests done

Description:
add infomaniak.com provider