### PR TITLE
tang: Fix installation error, missing fi statement

### DIFF
--- a/utils/tang/Makefile
+++ b/utils/tang/Makefile
@@ -55,6 +55,7 @@ if [ -z "$${IPKG_INSTROOT}" ]; then
 	KEYS=$(find /usr/share/tang/db/ -name "*.jw*" -maxdepth 1 | wc -l)
 	if [ "${KEYS}" = "0" ]; then # if db is empty generate new key pair
 		/usr/libexec/tangd-keygen /usr/share/tang/db/
+	fi
 	(cat /etc/services | grep -E "tangd.*8888\/tcp") > /dev/null \
 		|| echo -e "tangd\t\t8888/tcp" >> /etc/services
 fi


### PR DESCRIPTION
Compile tested: ramips Snapshot

Description:

Fix installation error, missing `fi` statement

Fix commit d49c79b76b7c7659e063290d1bc7d7fad626780a tang: remove outdated key handling.

if statement is not closed duo remove `fi`.

```
root@OpenWrt:/# opkg install tang
Package tang (10-3) installed in root is up to date.
Configuring tang.
//usr/lib/opkg/info/tang.postinst: /usr/lib/opkg/info/tang.postinst-pkg: line 9: syntax error: unexpected end of file (expecting "fi")
Collected errors:
 * pkg_run_script: package "tang" postinst script returned status 2.
 * opkg_configure: tang.postinst returned 2.
```

Signed-off-by: René van Dorst <opensource@vdorst.com>
