### PR TITLE
htop: explicitly disable some build options

### DIFF
--- a/admin/htop/Makefile
+++ b/admin/htop/Makefile
@@ -56,9 +56,10 @@ define Package/htop/config
 endef
 
 CONFIGURE_ARGS += \
-	$(if $(CONFIG_HTOP_LMSENSORS),--enable-sensors,) \
+	--$(if $(CONFIG_HTOP_LMSENSORS),en,dis)able-sensors \
 	--enable-affinity \
-	--enable-capabilities=no \
+	--disable-capabilities \
+	--disable-delayacct \
 	--disable-unicode \
 	--disable-hwloc
 


### PR DESCRIPTION
Maintainer: me
Compile tested: malta / latest master
```
configure: WARNING: unrecognized options: --disable-nls

  htop 3.1.0

  platform:                  linux
  os-release file:           /etc/os-release
  (Linux) proc directory:    /proc
  (Linux) openvz:            no
  (Linux) vserver:           no
  (Linux) ancient vserver:   no
  (Linux) delay accounting:  no
  (Linux) sensors:           no
  (Linux) capabilities:      no
  unicode:                   no
  affinity:                  yes
  hwloc:                     no
  debug:                     no
  static:                    no
```
Run tested: no

Description:
Since 3.1.0 delayacct option is enabled if the needed dependencies
are detected, it was previously disabled.
Sensors also check for dependency so we need to explicitly
disable it when not enabled.

Fixes 5f916720551ad5ea5ac86cf5e122fc2c0c34cc15
