### PR TITLE
prometheus-node-exporter-lua: add dsl error vectors to ltq-dsl

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2021.09.24
+PKG_VERSION:=2021.10.31
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/ltq-dsl.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/ltq-dsl.lua
@@ -10,6 +10,7 @@ local function scrape()
   local dsl_max_datarate = metric("dsl_max_datarate", "gauge")
   local dsl_error_seconds_total = metric("dsl_error_seconds_total", "counter")
   local dsl_errors_total = metric("dsl_errors_total", "counter")
+  local dsl_erb_total = metric("dsl_erb_total", "counter")
 
   local u = ubus.connect()
   local m = u:call("dsl", "metrics", {})
@@ -21,11 +22,13 @@ local function scrape()
     chipset = m.chipset,
     firmware_version = m.firmware_version,
     api_version = m.api_version,
+    driver_version = m.driver_version,
   }, 1)
 
   -- dsl line settings information
   metric("dsl_line_info", "gauge", {
     annex = m.annex,
+    standard = m.standard,
     mode = m.mode,
     profile = m.profile,
   }, 1)
@@ -81,6 +84,12 @@ local function scrape()
   dsl_errors_total({err="non pre-emptive crc error", loc="far"}, m.errors.far.crc_p)
   dsl_errors_total({err="pre-emptive crc error", loc="near"}, m.errors.near.crcp_p)
   dsl_errors_total({err="pre-emptive crc error", loc="far"}, m.errors.far.crcp_p)
+
+  -- dsl error vectors
+  if m.erb ~= nil then
+    dsl_erb_total({counter="sent"}, m.erb.sent)
+    dsl_erb_total({counter="discarded"}, m.erb.discarded)
+  end
 end
 
 return { scrape = scrape }


### PR DESCRIPTION
Maintainer: @champtar 
    
These are useful stats to debug vector related line deteriorations, see [0].

NOTE: this depends on https://github.com/openwrt/openwrt/pull/4633

[0] https://forum.openwrt.org/t/vectoring-on-lantiq-vrx200-vr9-missing-callback-for-sending-error-samples/104046