### PR TITLE
mdns-repeater: add package for mdns-repeater

### DIFF
--- a/net/mdns-repeater/Makefile
+++ b/net/mdns-repeater/Makefile
@@ -1,0 +1,47 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See LICENSE.txt for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mdns-repeater
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE_URL:=https://github.com/kennylevinsen/mdns-repeater.git
+PKG_SOURCE_PROTO=git
+PKG_SOURCE_DATE:=2020-05-03
+PKG_SOURCE_VERSION:=921d8850e988d0bd8d60899d933c4ad3094d73ca
+PKG_MIRROR_HASH:=11c1988d42ec36945516697be93a6f7f7155535a432af61bcf61ef4a19fec439
+
+PKG_MAINTAINER:=Alexander Koenig <alex@lisas.de>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=LICENSE.txt
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/mdns-repeater
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Multicast DNS repeater for Linux
+  URL:=https://github.com/kennylevinsen/mdns-repeater
+endef
+
+TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include
+
+define Build/Compile
+	CFLAGS="$(TARGET_CFLAGS)" CPPFLAGS="$(TARGET_CPPFLAGS)" $(MAKE) -C $(PKG_BUILD_DIR) $(TARGET_CONFIGURE_OPTS)
+endef
+
+define Package/mdns-repeater/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/mdns-repeater $(1)/usr/sbin/
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/mdns-repeater.init $(1)/etc/init.d/mdns-repeater
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/mdns_repeater.conf $(1)/etc/config/mdns_repeater
+endef
+
+$(eval $(call BuildPackage,mdns-repeater))

--- a/net/mdns-repeater/files/mdns-repeater.init
+++ b/net/mdns-repeater/files/mdns-repeater.init
@@ -1,0 +1,35 @@
+#!/bin/sh /etc/rc.common
+
+START=50
+STOP=50
+
+USE_PROCD=1
+PROG=/usr/sbin/mdns-repeater
+
+start_service() {
+	config_load mdns_repeater
+	local interfaces
+	config_get interfaces main interface
+	procd_open_instance
+	procd_set_param command $PROG -f $interfaces
+	# -f generates a lot of debug output
+	# no forwarding of stderr to logs
+	procd_set_param file /etc/config/mdns_repeater
+	procd_close_instance
+}
+
+reload_service() {
+	restart
+}
+
+interface_trigger() {
+	procd_add_reload_interface_trigger "$1"
+}
+
+service_triggers() {
+	procd_add_reload_trigger "mdns_repeater"
+
+	config_load mdns_repeater
+	config_list_foreach main interface interface_trigger
+}
+

--- a/net/mdns-repeater/files/mdns_repeater.conf
+++ b/net/mdns-repeater/files/mdns_repeater.conf
@@ -1,0 +1,5 @@
+
+config mdns_repeater 'main'
+	list interface 'br-lan'
+	list interface 'eth0.2'
+


### PR DESCRIPTION
Maintainer: Alexander König / @axkg
Compile tested: ar71xx, generic, 19.07.8
Run tested: ar71xx, wr1043nd, 19.07.7

Description: This adds a package for mdns-repeater, an alternative for avahi's reflector feature that is not compatible with some mDNS/Bonjour applications.
