### PR TITLE
[21.02] php8: update to 8.0.11

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.0.9
+PKG_VERSION:=8.0.10
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=71a01b2b56544e20e28696ad5b366e431a0984eaa39aa5e35426a4843e172010
+PKG_HASH:=66dc4d1bc86d9c1bc255b51b79d337ed1a7a035cf71230daabbf9a4ca35795eb
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0

--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=8.0.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=PHP-3.01
@@ -174,6 +174,10 @@ CONFIGURE_ARGS+= \
 	--without-valgrind \
 	--with-external-pcre \
 	--with-zlib="$(STAGING_DIR)/usr"
+
+ifeq ($(CONFIG_LIBC_USE_GLIBC),y)
+TARGET_LDFLAGS += -ldl
+endif
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-bcmath),)
   CONFIGURE_ARGS+= --enable-bcmath=shared

--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.0.10
-PKG_RELEASE:=2
+PKG_VERSION:=8.0.11
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=PHP-3.01
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=66dc4d1bc86d9c1bc255b51b79d337ed1a7a035cf71230daabbf9a4ca35795eb
+PKG_HASH:=e3e5f764ae57b31eb65244a45512f0b22d7bef05f2052b23989c053901552e16
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0

--- a/lang/php8/patches/0007-Add-support-for-use-of-the-system-timezone-database.patch
+++ b/lang/php8/patches/0007-Add-support-for-use-of-the-system-timezone-database.patch
@@ -99,7 +99,7 @@ r1: initial revision
  	/* read ID */
  	version = (*tzf)[3] - '0';
  	*tzf += 4;
-@@ -418,7 +436,429 @@ void timelib_dump_tzinfo(timelib_tzinfo
+@@ -435,7 +453,429 @@ void timelib_dump_tzinfo(timelib_tzinfo
  	}
  }
  
@@ -530,7 +530,7 @@ r1: initial revision
  {
  	int left = 0, right = tzdb->index_size - 1;
  
-@@ -444,9 +884,48 @@ static int seek_to_tz_position(const uns
+@@ -461,9 +901,48 @@ static int seek_to_tz_position(const uns
  	return 0;
  }
  
@@ -579,7 +579,7 @@ r1: initial revision
  }
  
  const timelib_tzdb_index_entry *timelib_timezone_identifiers_list(const timelib_tzdb *tzdb, int *count)
-@@ -458,7 +937,30 @@ const timelib_tzdb_index_entry *timelib_
+@@ -475,7 +954,30 @@ const timelib_tzdb_index_entry *timelib_
  int timelib_timezone_id_is_valid(const char *timezone, const timelib_tzdb *tzdb)
  {
  	const unsigned char *tzf;
@@ -611,7 +611,7 @@ r1: initial revision
  }
  
  static int skip_64bit_preamble(const unsigned char **tzf, timelib_tzinfo *tz)
-@@ -500,12 +1002,14 @@ static timelib_tzinfo* timelib_tzinfo_ct
+@@ -517,6 +1019,8 @@ static timelib_tzinfo* timelib_tzinfo_ct
  timelib_tzinfo *timelib_parse_tzfile(const char *timezone, const timelib_tzdb *tzdb, int *error_code)
  {
  	const unsigned char *tzf;
@@ -620,14 +620,16 @@ r1: initial revision
  	timelib_tzinfo *tmp;
  	int version;
  	int transitions_result, types_result;
- 	unsigned int type; /* TIMELIB_TZINFO_PHP or TIMELIB_TZINFO_ZONEINFO */
+@@ -524,7 +1028,7 @@ timelib_tzinfo *timelib_parse_tzfile(con
+ 
+ 	*error_code = TIMELIB_ERROR_NO_ERROR;
  
 -	if (seek_to_tz_position(&tzf, timezone, tzdb)) {
 +	if (seek_to_tz_position(&tzf, timezone, &memmap, &maplen, tzdb)) {
  		tmp = timelib_tzinfo_ctor(timezone);
  
  		version = read_preamble(&tzf, tmp, &type);
-@@ -540,11 +1044,36 @@ timelib_tzinfo *timelib_parse_tzfile(con
+@@ -563,11 +1067,36 @@ timelib_tzinfo *timelib_parse_tzfile(con
  		}
  		skip_posix_string(&tzf, tmp);
  

--- a/lang/php8/patches/0022-Use-system-timezone.patch
+++ b/lang/php8/patches/0022-Use-system-timezone.patch
@@ -15,7 +15,7 @@ To be used in tandem with use_embedded_timezonedb.patch and use_embedded_timezon
 
 --- a/ext/date/php_date.c
 +++ b/ext/date/php_date.c
-@@ -538,6 +538,23 @@ static char* guess_timezone(const timeli
+@@ -545,6 +545,23 @@ static char* guess_timezone(const timeli
  		DATEG(timezone_valid) = 1;
  		return DATEG(default_timezone);
  	}

--- a/lang/php8/patches/0041-Add-patch-to-remove-build-timestamps-from-generated-.patch
+++ b/lang/php8/patches/0041-Add-patch-to-remove-build-timestamps-from-generated-.patch
@@ -40,7 +40,7 @@ Subject: Add patch to remove build timestamps from generated binaries.
    PHP_SUBST(LIBPHP_CFLAGS)
 --- a/sapi/cgi/cgi_main.c
 +++ b/sapi/cgi/cgi_main.c
-@@ -2371,9 +2371,9 @@ parent_loop_end:
+@@ -2372,9 +2372,9 @@ parent_loop_end:
  							SG(headers_sent) = 1;
  							SG(request_info).no_headers = 1;
  #if ZEND_DEBUG
@@ -67,7 +67,7 @@ Subject: Add patch to remove build timestamps from generated binaries.
  #else
 --- a/sapi/fpm/fpm/fpm_main.c
 +++ b/sapi/fpm/fpm/fpm_main.c
-@@ -1691,9 +1691,9 @@ int main(int argc, char *argv[])
+@@ -1692,9 +1692,9 @@ int main(int argc, char *argv[])
  				SG(request_info).no_headers = 1;
  
  #if ZEND_DEBUG


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs

Description:

Backport/cherry-pick of glibc fix and update to latest upstream version.
