### PR TITLE
hs20: switch dependencies to php8

### DIFF
--- a/net/hs20/Makefile
+++ b/net/hs20/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hs20
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git
@@ -77,7 +77,7 @@ define Package/hs20-server
   SUBMENU:=WirelessAPD
   TITLE:=Hotspot 2.0 OSU server
   URL:=http://hostap.epitest.fi/
-  DEPENDS:=+hs20-common +libopenssl +libsqlite3 +libxml2 +php7 +php7-cgi +php7-mod-xml +php7-mod-pdo-sqlite +openssl-util +sqlite3-cli +uhttpd +xxd
+  DEPENDS:=+hs20-common +libopenssl +libsqlite3 +libxml2 +php8 +php8-cgi +php8-mod-xml +php8-mod-pdo-sqlite +openssl-util +sqlite3-cli +uhttpd +xxd
 endef
 
 define Package/hs20-server/description

--- a/net/hs20/files/hs20-server.defaults
+++ b/net/hs20/files/hs20-server.defaults
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 uci -q get uhttpd.main.interpreter | grep -q "^\.php" || uci -q batch <<-EOF >/dev/null
-add_list uhttpd.main.interpreter='.php=/usr/bin/php-cgi'
+add_list uhttpd.main.interpreter='.php=/usr/bin/php8-cgi'
 commit uhttpd
 EOF
 


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: mxs
Run tested: **no** - @dangowrt: please check!

Description:

This updates the package dependencies to php8 to prepare getting rid of php7.
Since I'm not familiar with hs20, I cannot really runtime test.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>

