### PR TITLE
hiredis: fix compilation with macOS

### DIFF
--- a/libs/hiredis/Makefile
+++ b/libs/hiredis/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hiredis
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/redis/hiredis/tar.gz/v$(PKG_VERSION)?
@@ -35,7 +35,7 @@ define Package/libhiredis/description
 	Hiredis is a minimalistic C client library for the Redis database.
 endef
 
-MAKE_FLAGS += ARCH="" DEBUG="" PREFIX="/usr"
+MAKE_FLAGS += ARCH="" DEBUG="" PREFIX="/usr" uname_S="Linux"
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/hiredis/adapters


### PR DESCRIPTION
uname is used to test the host OS. Override it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: macOS