### PR TITLE
ccid: fix compilation under macOS

### DIFF
--- a/utils/ccid/patches/010-macos.patch
+++ b/utils/ccid/patches/010-macos.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -79,7 +79,7 @@ AC_CHECK_FUNCS(select strerror strncpy m
+ # Select OS specific versions of source files.
+ AC_SUBST(BUNDLE_HOST)
+ AC_SUBST(DYN_LIB_EXT)
+-BUNDLE_HOST=`uname | sed -e s,/,_,`
++BUNDLE_HOST=Linux
+ DYN_LIB_EXT="so"
+ case "$BUNDLE_HOST" in
+ Darwin)


### PR DESCRIPTION
Remove a bad uname check.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: macOS