### PR TITLE
cgroupfs-mount: conflict with procd-ujail

### DIFF
--- a/utils/cgroupfs-mount/Makefile
+++ b/utils/cgroupfs-mount/Makefile
@@ -25,6 +25,7 @@ define Package/cgroupfs-mount
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=cgroup mount scripts
+  CONFLICTS:=procd-ujail
   DEPENDS:=+mount-utils
   MENU:=1
 endef


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503 / cc @dangowrt 
Compile tested: NA
Run tested: NA

Description:
The procd ujail feature expects the unified cgroup hierarchy to be
mounted on /sys/fs/cgroups. Normally, procd takes care of this, but
having cgroupfs-mount installed will cause the unified hierarchy to be
unmounted and mounts the legacy cgroup hierarchy instead. This
completely breaks procd-ujail, so add a conflict to avoid installing
this package when procd-ujail is enabled.