### PR TITLE
collectd: sqm_collect: optimise parent search

### DIFF
--- a/utils/collectd/files/exec-scripts/sqm_collectd.sh
+++ b/utils/collectd/files/exec-scripts/sqm_collectd.sh
@@ -100,7 +100,7 @@ process_qdisc() {
 }
 
 # while not orphaned
-while [ $(awk '$1 ~ "^PPid:" {print $2}' /proc/$$/status) -ne 1 ] ; do
+while [ $(awk '$1 ~ "^PPid:" {print $2;exit}' /proc/$$/status) -ne 1 ] ; do
 	for ifc in "$@" ; do
 		process_qdisc "$ifc"
 	done


### PR DESCRIPTION
There can be only 1 parent process ID, so as soon as we find it, print
it and exit - there's no point searching any of the following lines

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
