### PR TITLE
autossh: fix procd env issue

### DIFF
--- a/net/autossh/Makefile
+++ b/net/autossh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=autossh
 PKG_VERSION:=1.4g
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://www.harding.motd.ca/autossh/

--- a/net/autossh/files/autossh.init
+++ b/net/autossh/files/autossh.init
@@ -18,8 +18,7 @@ start_instance() {
 	procd_open_instance
 	procd_set_param command /usr/sbin/autossh -M ${monitorport:-20000} ${ssh}
 	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
-	procd_set_param env AUTOSSH_GATETIME="${gatetime:-30}"
-	procd_set_param env AUTOSSH_POLL="${poll:-600}"
+	procd_set_param env AUTOSSH_GATETIME="${gatetime:-30}" AUTOSSH_POLL="${poll:-600}"
 	procd_close_instance
 }
 


### PR DESCRIPTION
This commit fixes an issue where the `AUTOSSH_GATETIME` is not available in the `procd`  environment which gets overwritten by the second `procd_set_param env` call.
It now calls the `procd_set_param env` once with the two variables, instead of twice.

Maintainer: @bk138 
Compile tested:  21.02 and master for: ath79, glinet_gl-ar150 and bcm27xx_bcm2711, rpi-4
Run tested: 21.02 and master for: ath79, glinet_gl-ar150 and bcm27xx_bcm2711, rpi-4

Description:
The changes introduced by @ja-pa (#13235) which are now available in 21.02 add two calls to `procd_set_param env`, one for `AUTOSSH_GATETIME` and another for `AUTOSSH_POLL`. The last, overwrites the environment leaving `AUTOSSH_GATETIME` not defined in the `procd` instance for `autossh`.

This keeps one from using the `AUTOSSH_GATETIME` value (and its AUTOSSH_GATETIME=0 feature) in `autossh`. 