### PR TITLE
openblas: fix compilation with mips x4k series CPU

### DIFF
--- a/libs/openblas/Makefile
+++ b/libs/openblas/Makefile
@@ -58,13 +58,13 @@ ifeq ($(ARCH),aarch64)
 else ifeq ($(ARCH),arm)
   OPENBLAS_TARGET:=ARMV5
 else ifeq ($(ARCH),mips)
-  ifeq ($(CPU_TYPE),24kc)
+  ifneq ($(filter 24k% 74k%,$(CPU_TYPE)),)
     OPENBLAS_TARGET:=MIPS24K
-  endif # CPU_TYPE == 24kc
+  endif # CPU_TYPE == 24k* or 74k*
 else ifeq ($(ARCH),mipsel)
-  ifeq ($(CPU_TYPE),24kc)
+  ifneq ($(filter 24k% 74k%,$(CPU_TYPE)),)
     OPENBLAS_TARGET:=MIPS24K
-  endif # CPU_TYPE == 24kc
+  endif # CPU_TYPE == 24k* or 74k*
 else ifeq ($(ARCH),powerpc)
   OPENBLAS_TARGET:=PPC440
 endif


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: ath79/TP-Link Archer C6, built with `CONFIG_CPU_TYPE="74kc"`, on master.
Run tested: same arch, using a small test program from https://www.hpc.ntnu.no/idun/software-on-idun/openblas/
``` C
/*  blas_test.c : Example using BLAS matrix multiply code sgemm */

#include <stdio.h>
#include <cblas.h>

int main(void)
{
  const int lda=3, ldb=3, ldc=3;
  int m, n, k;
  float alpha, beta;

  float a[] = { 0.11, 0.21, 0.12,
                0.15, 0.13, 0.17,
                0.22, 0.13, 0.23 };

  float b[] = { 1011, 1021, 1018,
                1031, 1012, 1021,
                1022, 1032, 1015 };

  float c[] = { 0.00, 0.00, 0,00,
                0.00, 0.00, 0,00,
                0.00, 0.00, 0,00 };

  m = 3; n = 3; k = 3;

  alpha = 1.0; beta = 0.0;

  cblas_sgemm (CblasColMajor, CblasNoTrans, CblasNoTrans,
                m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);

  printf ("[ %g, %g, %g\n", c[0], c[1], c[2]);
  printf ("  %g, %g, %g\n", c[3], c[4], c[5]);
  printf ("  %g, %g, %g ]\n", c[6], c[7], c[8]);

  return 0;
}
```

Description:
Anything later than MIPS 24k can run MIPS 24k code.  Set OPENBLAS_TARGET
to MIPS24K in those cases.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

It should fix current build errors for mipsel_74kc, mipsel_24kc_24kf, and of course, if you have a custom build on mips_74kc, like I just did 😜 