### PR TITLE
dockerd: update to 20.10.9

### DIFF
--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker
-PKG_VERSION:=20.10.8
-PKG_RELEASE:=1
+PKG_VERSION:=20.10.9
+PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/docker/cli
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=cde34bbefd70fa27b44dfa904c40db84b89abf237e5267dcd08603b459a89253
-PKG_GIT_SHORT_COMMIT:=3967b7d # SHA1 used within the docker executables
+PKG_HASH:=d91010813824070dd2380013c8f343e61e6dda170f7853f024bda39b432b64ba
+PKG_GIT_SHORT_COMMIT:=c2ea9bc # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=20.10.8
-PKG_RELEASE:=2
+PKG_VERSION:=20.10.9
+PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=2505d00032f5d40ead5ac779c2840303dcead04713c93ba974be4c19b3ab8d0a
-PKG_GIT_SHORT_COMMIT:=75249d8 # SHA1 used within the docker executables
+PKG_HASH:=359e8854d0d51bc884d434f182f64ca62f25fbbe7b9c6a336eb09f212fe8cc9a
+PKG_GIT_SHORT_COMMIT:=79ea9d3 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: aarch64, Turris MOX, 21.02
Run tested: aarch64, Turris MOX, 21.02

Description: small releases which fix a bunch of CVEs, most notably CVE-2021-41089 - "attempting to copy files using docker cp into a specially-crafted container can result in Unix file permission changes for existing files in the host's filesystem"

This update should backported to 21.02