### PR TITLE
[21.02] perl: perlmod.mk: use flock when hostpkg/perl used

### DIFF
--- a/lang/perl/perlmod.mk
+++ b/lang/perl/perlmod.mk
@@ -32,39 +32,49 @@ PERL_TESTSDIR:=/usr/share/perl/perl-tests
 PERLBASE_TESTSDIR:=/usr/share/perl/perlbase-tests
 PERLMOD_TESTSDIR:=/usr/share/perl/perlmod-tests
 
+FLOCK:=$(STAGING_DIR_HOST)/bin/flock
+
 define perlmod/host/relink
 	rm -f $(1)/Makefile.aperl
-	$(MAKE) -C $(1) perl
-	$(INSTALL_BIN) $(1)/perl $(PERL_CMD)
-	$(INSTALL_BIN) $(1)/perl $(STAGING_DIR_HOSTPKG)/usr/bin/perl
+	($(FLOCK) -w 900 9 || { echo perlmod/host/relink: failed to acquire lock; exit 1; }; \
+	    $(MAKE) -C $(1) perl && \
+	    $(INSTALL_BIN) $(1)/perl $(PERL_CMD) && \
+	    $(INSTALL_BIN) $(1)/perl $(STAGING_DIR_HOSTPKG)/usr/bin/perl \
+	) 9> $(TMP_DIR)/.perlmod-perl.flock
 endef
 
 define perlmod/host/Configure
 	(cd $(HOST_BUILD_DIR); \
+	$(FLOCK) -s -w 300 9 || { echo perlmod/host/Configure: failed to acquire lock; exit 1; }; \
 	PERL_MM_USE_DEFAULT=1 \
 	$(2) \
 	$(PERL_CMD) Makefile.PL \
 		$(1) \
-	);
+	) 9> $(TMP_DIR)/.perlmod-perl.flock;
 endef
 
 define perlmod/host/Compile
+	($(FLOCK) -s -w 300 9 || { echo perlmod/host/Compile: failed to acquire lock; exit 1; }; \
 	$(2) \
 	$(MAKE) -C $(HOST_BUILD_DIR) \
 		$(1) \
-		install
+		install \
+	) 9> $(TMP_DIR)/.perlmod-perl.flock
 endef
 
 define perlmod/host/Install
+	($(FLOCK) -s -w 300 9 || { echo perlmod/host/Install: failed to acquire lock; exit 1; }; \
 	$(2) \
 	$(MAKE) -C $(HOST_BUILD_DIR) \
 		$(1) \
-		install
+		install \
+	) 9> $(TMP_DIR)/.perlmod-perl.flock
 	$(call perlmod/host/relink,$(HOST_BUILD_DIR))
 endef
 
 define perlmod/Configure
 	(cd $(if $(3),$(3),$(PKG_BUILD_DIR)); \
+	 $(FLOCK) -s -w 300 9 || { echo perlmod/Configure: failed to acquire lock; exit 1; }; \
 	 (echo -e 'use Config;\n\n$$$${tied %Config::Config}{cpprun}="$(GNU_TARGET_NAME)-cpp -E";\n' ; cat Makefile.PL) | \
 	 PERL_MM_USE_DEFAULT=1 \
 	 $(2) \
@@ -114,16 +124,18 @@ define perlmod/Configure
 		INSTALLVENDORMAN3DIR=" " \
 		LINKTYPE=dynamic \
 		DESTDIR=$(PKG_INSTALL_DIR) \
-	)
+	) 9> $(TMP_DIR)/.perlmod-perl.flock
 	sed -i -e 's!^PERL_INC = .*!PERL_INC = $(STAGING_DIR)/usr/lib/perl5/$(PERL_VERSION)/CORE/!' $(if $(3),$(3),$(PKG_BUILD_DIR))/Makefile
 endef
 
 define perlmod/Compile
+	($(FLOCK) -s -w 300 9 || { echo perlmod/Compile: failed to acquire lock; exit 1; }; \
 	PERL5LIB=$(PERL_LIB) \
 	$(2) \
 	$(MAKE) -C $(if $(3),$(3),$(PKG_BUILD_DIR)) \
 		$(1) \
-		install
+		install \
+	) 9> $(TMP_DIR)/.perlmod-perl.flock
 endef
 
 define perlmod/Install/NoStrip


### PR DESCRIPTION
Maintainer: @Naoir @pprindeville 
Compile tested: not with 21.02, actually, but it is successful in master since August, and locally in 19.07, bulding for mvebu and ar71xx/tiny
Run tested: N/A

Description:

Avoid parallel relinking and usage of the host perl binary by wrapping
its usage around flock calls.

Sometimes, two packages will try to relink the static host perl binary
at the same time.  Neither of them will have the other's module linked
in, and one of them will unavoidably clobber the other one's binary.

This will lead to errors when a package will not be able to find a
module that was supposed to be installed.

To fix that, an exclusive flock is used when relinking, with a 900
seconds timeout to avoid locking up the build process forever.

This is not enough because the binary may be concurrently used to build
another module package; perl is used in Configure, Compile, and Install
procedures.  If timing is right, a package will fail with a "permission
denied" error.

So a shared flock call is added in Configure, Compile, and Install
definitions for host and target, with a shorter, 300 seconds timeout.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
(cherry picked from commit 1e18c4324fd1fb43764057fb8f4e9c1ea4a17553)