### PR TITLE
gcc: enable parallel building

### DIFF
--- a/devel/gcc/Makefile
+++ b/devel/gcc/Makefile
@@ -24,7 +24,7 @@ endef
 PKG_NAME:=gcc
 # PKG_VERSION=7.3.0
 PKG_VERSION=7.4.0
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_SOURCE_URL:=@GNU/gcc/gcc-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_INSTALL:=1
@@ -168,8 +168,10 @@ define Build/Configure
 endef
 
 define Build/Compile
-	export SHELL="$(BASH)"; $(MAKE_VARS) $(MAKE) -C $(PKG_BUILD_DIR) \
-			DESTDIR="$(PKG_INSTALL_DIR)" $(MAKE_ARGS) all install
+	export SHELL="$(BASH)"; $(MAKE_VARS) $(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+			DESTDIR="$(PKG_INSTALL_DIR)" $(MAKE_ARGS) all
+	export SHELL="$(BASH)"; $(MAKE_VARS) $(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+			DESTDIR="$(PKG_INSTALL_DIR)" $(MAKE_ARGS) install
 endef
 
 ENVCFLAGS:="$(TARGET_OPTIMIZATION) $(EXTRA_OPTIMIZATION)


### PR DESCRIPTION
Maintainer: @noblepepper 
Compile tested: mvebu, ath79, ramips, mediatek
Run tested: N/A

Description:
Even though `PKG_BUILD_PARALLEL` is set for the package, the package calls `$(MAKE)` without `$(PKG_JOBS)`, so it was always built with only one job.

Fix this by adding `$(PKG_JOBS)` to the `$(MAKE)` call, and calling make install only after make all is finished.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

I haven't studied this in depth to see if overriding `Build/Compile` is really needed, or if there's a simpler way to enable parallel execution.  I know that keeping `all install` in the same line fails if `$(PKG_JOBS)` is just added.