### PR TITLE
simple-adblock: delete obsolete iptables-dependent function

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.8.7
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -120,7 +120,6 @@ dnsmasq_hup() { killall -q -s HUP dnsmasq; }
 dnsmasq_kill() { killall -q -s KILL dnsmasq; }
 dnsmasq_restart() { /etc/init.d/dnsmasq restart >/dev/null 2>&1; }
 unbound_restart() { /etc/init.d/unbound restart >/dev/null 2>&1; }
-is_force_dns_active() { iptables-save | grep -q -w -- '--dport 53'; }
 is_present() { command -v "$1" >/dev/null 2>&1; }
 
 output() {


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-105, OpenWrt 21.02.0
Run tested: x86_64, Sophos SG-105, OpenWrt 21.02.0, start

Signed-off-by: Stan Grishin <stangri@melmac.net>
