### PR TITLE
crowdsec-firewall-bouncer: initial package v0.0.15

### DIFF
--- a/net/crowdsec-firewall-bouncer/Makefile
+++ b/net/crowdsec-firewall-bouncer/Makefile
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (C) 2021 Gerald Kerma
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=crowdsec-firewall-bouncer
+PKG_VERSION:=0.0.15
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/crowdsecurity/cs-firewall-bouncer
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_SOURCE_DATE:=2021903
+PKG_MIRROR_HASH:=2ef7e4f935056d648a6b45bb09ebb5846262ac9d745229b1442051abdd214c86
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Gerald Kerma <gandalf@gk2.net>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+CSFB_BUILD_VERSION?=$(PKG_SOURCE_VERSION)
+CSFB_BUILD_GOVERSION=$(shell go version | cut -d " " -f3 | sed -r 's/[go]+//g')
+CWD_BUILD_TIMESTAMP:=$(SOURCE_DATE_EPOCH)
+CSFB_BUILD_TAG=openwrt
+
+CSFB_VERSION_PKG:=github.com/crowdsecurity/cs-firewall-bouncer/pkg/version
+
+GO_PKG:=github.com/crowdsecurity/cs-firewall-bouncer
+
+GO_PKG_LDFLAGS_X:=$(CSFB_VERSION_PKG).Version=$(CSFB_BUILD_VERSION) \
+	$(CSFB_VERSION_PKG).BuildDate=$(CSFB_BUILD_TIMESTAMP) \
+	$(CSFB_VERSION_PKG).Tag=$(CSFB_BUILD_TAG) \
+	$(CSFB_VERSION_PKG).GoVersion=$(CSFB_BUILD_GOVERSION)
+
+GO_PKG_INSTALL_ALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/crowdsec-firewall-bouncer/Default
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Firewall bouncer for Crowdsec
+  URL:=https://github.com/crowdsecurity/cs-firewall-bouncer/
+endef
+
+define Package/crowdsec-firewall-bouncer
+$(call Package/crowdsec-firewall-bouncer/Default)
+  DEPENDS:=@(PACKAGE_iptables||PACKAGE_nftables) \
+	$(GO_ARCH_DEPENDS) \
+	+crowdsec
+endef
+
+define Package/golang-crowdsec-firewall-bouncer-dev
+$(call Package/crowdsec-firewall-bouncer/Default)
+$(call GoPackage/GoSubMenu)
+  TITLE+= (source files)
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+  PKGARCH:=all
+endef
+
+define Package/crowdsec-firewall-bouncer/Default/description
+  Crowdsec bouncer written in golang for firewalls.
+
+  crowdsec-firewall-bouncer will fetch new and old decisions
+  from a CrowdSec API to add them in a blocklist used by supported firewalls.
+
+  You must install iptables+ipset or nftables.
+endef
+
+define Package/crowdsec-firewall-bouncer/description
+$(call Package/crowdsec-firewall-bouncer/Default/description)
+
+  This package contains the main program.
+endef
+
+define Package/golang-crowdsec-firewall-bouncer-dev/description
+$(call Package/crowdsec-firewall-bouncer/Default/description)
+
+  This package provides the source files for the program.
+endef
+
+define Package/crowdsec-firewall-bouncer/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+
+	$(INSTALL_DIR) $(1)/etc/crowdsec/bouncers
+	$(INSTALL_DATA) \
+		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/config/crowdsec-firewall-bouncer.yaml \
+		$(1)/etc/crowdsec/bouncers
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) \
+		./files/crowdsec-firewall-bouncer.initd \
+		$(1)/etc/init.d/crowdsec-firewall-bouncer
+
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_BIN) \
+		./files/crowdsec-firewall-bouncer.firewall \
+		$(1)/etc/firewall.cs
+
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) \
+		./files/crowdsec-firewall-bouncer.defaults \
+		$(1)/etc/uci-defaults/99_crowdsec-firewall-bouncer
+endef
+
+define Package/crowdsec-firewall-bouncer/conffiles
+/etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+endef
+
+$(eval $(call GoBinPackage,crowdsec-firewall-bouncer))
+$(eval $(call BuildPackage,crowdsec-firewall-bouncer))

--- a/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.defaults
+++ b/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.defaults
@@ -1,0 +1,23 @@
+#!/bin/sh
+API_KEY=""
+CONFIG=/etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+## Gen&ConfigApiKey
+if grep -q "${API_KEY}" "$CONFIG"; then
+	echo API key already registered...
+else
+	SUFFIX=`tr -dc A-Za-z0-9 </dev/urandom | head -c 8`
+	API_KEY=`/usr/bin/cscli bouncers add cs-firewall-bouncer-${SUFFIX} -o raw`
+	sed -i "s,^\(\s*api_key\s*:\s*\).*\$,\1$API_KEY," $CONFIG
+fi
+
+# unfortunately, UCI doesn't provide a nice way to add an anonymous section only if it doesn't already exist
+if ! uci show firewall | grep -q firewall.cs; then
+  name="$(uci add firewall include)"
+  uci set "firewall.${name}.path=/etc/firewall.cs"
+  uci set "firewall.${name}.enabled=1"
+  uci set "firewall.${name}.reload=1"
+  echo -e "Adding the following UCI config:\n $(uci changes)"
+  uci commit
+fi
+
+exit 0

--- a/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.firewall
+++ b/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.firewall
@@ -1,0 +1,4 @@
+#!/bin/sh
+/etc/init.d/crowdsec enabled && /etc/init.d/crowdsec restart
+/etc/init.d/crowdsec-firewall-bouncer enabled && /etc/init.d/crowdsec-firewall-bouncer restart
+exit 0

--- a/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.initd
+++ b/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.initd
@@ -1,0 +1,69 @@
+#!/bin/sh /etc/rc.common
+# (C) 2021 Gerald Kerma
+
+START=99
+USE_PROCD=1
+NAME=crowdsec-firewall-bouncer
+PROG=/usr/bin/cs-firewall-bouncer
+CONFIG=/etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+BACKEND=iptables
+VARCONFIGDIR=/var/etc/crowdsec/bouncers
+VARCONFIG=/var/etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+FW_BACKEND="iptables"
+
+service_triggers() {
+	procd_add_reload_trigger crowdsec-firewall-bouncer
+}
+
+init_config() {
+	## CheckFirewall
+	iptables="true"
+	which iptables > /dev/null
+	FW_BACKEND=""
+	if [[ $? != 0 ]]; then
+	  echo "iptables is not present"
+	  iptables="false"
+	else
+	  FW_BACKEND="iptables"
+	  echo "iptables found"
+	fi
+
+	nftables="true"
+	which nft > /dev/null
+	if [[ $? != 0 ]]; then
+	  echo "nftables is not present"
+	  nftables="false"
+	else
+	  FW_BACKEND="nftables"
+	  echo "nftables found"
+	fi
+
+	if [ "$nftables" = "true" -a "$iptables" = "true" ]; then
+	  echo "Found nftables(default) and iptables..."
+	fi
+
+	if [ "$FW_BACKEND" = "iptables" ]; then
+	  which ipset > /dev/null
+	  if [[ $? != 0 ]]; then
+	    echo "ipset not found, install it !"
+	  fi
+	fi
+	BACKEND=$FW_BACKEND
+
+	# Create tmp dir & permissions if needed
+	if [ ! -d "${VARCONFIGDIR}" ]; then
+		mkdir -m 0755 -p "${VARCONFIGDIR}"
+	fi;
+
+	cp $CONFIG $VARCONFIG
+
+	sed -i "s,^\(\s*mode\s*:\s*\).*\$,\1$BACKEND," $VARCONFIG
+}
+
+start_service() {
+	init_config
+
+	procd_open_instance
+	procd_set_param command "$PROG" -c "$VARCONFIG"
+	procd_close_instance
+}

--- a/net/crowdsec-firewall-bouncer/patches/001-fix_config_iptables_chains.patch
+++ b/net/crowdsec-firewall-bouncer/patches/001-fix_config_iptables_chains.patch
@@ -1,0 +1,9 @@
+--- a/config/crowdsec-firewall-bouncer.yaml
++++ b/config/crowdsec-firewall-bouncer.yaml
+@@ -15,5 +15,5 @@ deny_log: false
+ #if present, insert rule in those chains
+ iptables_chains:
+   - INPUT
+-#  - FORWARD
++  - FORWARD
+ #  - DOCKER-USER


### PR DESCRIPTION
/net/crowdsec-firewall-bouncer/

crowdsec-firewall-bouncer will fetch new and old decisions from
 a CrowdSec API to add them in a blocklist used by supported firewalls.

Signed-off-by: Kerma Gérald <gandalf@gk2.net>

> CrowdSec - the open-source and participative IPS able to analyze visitor behavior & provide an adapted response to all kinds of attacks. It also leverages the crowd power to generate a global CTI database to protect the user network. 

Maintainer: Gérald Kerma <Gandalf@Gk2.net> 

Compile tested: 
- ARM64, MVEBU, EspressoBin & EspressoBin Ultra, OpenWrt master)
- MIPS, MT7621, Xiaomi Mi Router 3 Pro, OpenWrt master)

Run tested: 
- ARM64, MVEBU, EspressoBin & EspressoBin Ultra, OpenWrt version 19.07.7 & 21.02-RC4)

Short Descritpion: 
CrowdSec is an Open Source Participative Security IPS.

Description:
Crowdsec - An open-source, lightweight agent to detect and respond to bad behaviours. It also automatically benefits from our global community-wide IP reputation database.
crowdsec-firewall-bouncer will fetch new and old decisions from a CrowdSec API to add them in a blocklist used by supported firewalls.

References:
https://github.com/crowdsecurity/crowdsec/issues/685

CrowdSec is the new Fail2Ban alternative...
CrowdSec is an open-source and collaborative EDR.
Analyze behaviors, respond to attacks & share signals across the community.

> CrowdSec is a free, modern & collaborative behavior detection engine, coupled with a global IP reputation network. It stacks on fail2ban's philosophy but is IPV6 compatible and 60x faster (Go vs Python), uses Grok patterns to parse logs and YAML scenario to identify behaviors. CrowdSec is engineered for modern Cloud / Containers / VM based infrastructures (by decoupling detection and remediation). Once detected you can remedy threats with various bouncers (firewall block, nginx http 403, Captchas, etc.) while the aggressive IP can be sent to CrowdSec for curation before being shared among all users to further improve everyone's security.

More @ https://crowdsec.net/

Use case (POC):
On an OpenWrt based router, you can quickly and efficiently ban a collaborative list of bad guys IP source, you can also centralize remote servers access attempts and ban on bad access attempts scenarios directly on your OpenWrt Internet access gateway...

Forum Topic : 
https://forum.openwrt.org/t/crowdsec-packages-for-openwrt/102648/