### PR TITLE
[WIP] smcroute: avoid spurious errors

### DIFF
--- a/net/smcroute/Makefile
+++ b/net/smcroute/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=smcroute
 PKG_VERSION:=2.5.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 

--- a/net/smcroute/patches/0001-Avoid-trying-to-delete-inactive-VIFs.patch
+++ b/net/smcroute/patches/0001-Avoid-trying-to-delete-inactive-VIFs.patch
@@ -1,0 +1,50 @@
+From 8ce1d117a31e35d97fb955b82edf13514267eaab Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Tue, 28 Sep 2021 11:09:47 +0200
+Subject: [PATCH] Avoid trying to delete inactive VIFs
+
+When probing interfaces at startup, there's a check for IFF_MULTICAST,
+if this flag is not set we try to delete its corresponding VIF/MIF.
+This is for hanlding .conf reload scenarios where an interface has had
+its MULTICAST flag dropped.
+
+However, when starting up on Linux systems, the loopback interface has
+no MULTICAST flag set.  This leads to the following bogus warning:
+
+   Failed deleting VIF for iface lo: Resource temporarily unavailable
+
+This patch makes sure to check if we have a registered kernel VIF/MIF
+for an interface before attempting to delete it.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ src/mroute.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/mroute.c b/src/mroute.c
+index 291e9c4..6a80a47 100644
+--- a/src/mroute.c
++++ b/src/mroute.c
+@@ -298,6 +298,9 @@ static int mroute4_del_vif(struct iface *iface)
+ 	if (iface->mrdisc)
+ 		rc = mrdisc_deregister(iface->vif);
+ 
++	if (iface->vif == ALL_VIFS)
++		return 0;
++
+ 	if (kern_vif_del(iface)) {
+ 		switch (errno) {
+ 		case ENOENT:
+@@ -910,6 +913,9 @@ static int mroute6_del_mif(struct iface *iface)
+ {
+ 	int rc = 0;
+ 
++	if (iface->mif == ALL_VIFS)
++		return 0;
++
+ 	if (kern_mif_del(iface) && errno != ENOENT) {
+ 		switch (errno) {
+ 		case ENOENT:
+-- 
+2.33.0
+


### PR DESCRIPTION
Add patch to avoid trying to delete localhost interface.

Signed-off-by: Moritz Warning <moritzwarning@web.de>

Maintainer: me
Compile tested: ramips/mt7620, Nexx wt3020 OpenWrt master
Run tested: TODO
