### PR TITLE
github-ci: also build mipsel_24kc / mt7621

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -22,6 +22,10 @@ jobs:
           - arch: mips_24kc
             target: ath79-generic
             runtime_test: false
+          
+          - arch: mipsel_24kc
+            target: mt7621
+            runtime_test: false
 
           - arch: powerpc_464fp
             target: apm821xx-nand


### PR DESCRIPTION
Maintainer: @aparcar
Compile tested: N/A
Run tested: N/A

Description: This seems like a fairly popular configuration and is at least handy for me for temporary testing. Furthermore, more GitHub actions usage is free, so why not run this in parallel?