### PR TITLE
git-lfs: update to version 3.0.1

### DIFF
--- a/net/git-lfs/Makefile
+++ b/net/git-lfs/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=git-lfs
-PKG_VERSION:=2.13.3
+PKG_VERSION:=3.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/git-lfs/git-lfs/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=f8bd7a06e61e47417eb54c3a0db809ea864a9322629b5544b78661edab17b950
+PKG_HASH:=ea47feff8cf10855393dd20f22a7168c462043c7a654a5fd0546af0a9d28a3a2
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS7), OpenWrt 21.02
Run tested: Turris Omnia (TOS7), OpenWrt 21.02

Description:
This PR updates git-lfs to version 3.0.1. Changelog https://github.com/git-lfs/git-lfs/blob/main/CHANGELOG.md

