### PR TITLE
transmission: update seccomp file

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=3.00
-PKG_RELEASE:=14
+PKG_RELEASE:=15
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master

--- a/net/transmission/files/transmission-daemon.json
+++ b/net/transmission/files/transmission-daemon.json
@@ -85,9 +85,19 @@
 				"uname",
 				"unlink",
 				"statfs64",
-				"umask",
 				"write",
-				"writev"
+				"writev",
+				"newfstatat",
+				"ppoll",
+				"openat",
+				"pselect6",
+				"readlinkat",
+				"renameat",
+				"mkdirat",
+				"statfs",
+				"faccessat",
+				"unlinkat",
+				"getenv"
 			],
 			"action": "SCMP_ACT_ALLOW"
 		}


### PR DESCRIPTION
Maintainer:  @dangowrt  @neheb 
Compile tested: x86_64, openwrt master(e672d1b387)
Run tested: aarch64, raspberry pi 4B, OpenWrt SNAPSHOT(r17727-e672d1b387)

Description:
The transmision-daemon.json file is generated by using `/etc/init.d/transmission trace`, using the original seccomp failed to boot on my device.