### PR TITLE
acme: update to 3.0.1

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme
-PKG_VERSION:=2.8.7
-PKG_RELEASE:=6
+PKG_VERSION:=3.0.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/acmesh-official/acme.sh/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=774010429730882f6bbfcd3756ff0fa755846106664841092af828a814159861
+PKG_HASH:=6212cc0c2bca99a7dd6cbb4236b4c7dd5d1113dab0841e66dae4d307d902a8e6
 PKG_BUILD_DIR:=$(BUILD_DIR)/acme.sh-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>

--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -279,11 +279,17 @@ issue_cert()
 	acme_args="$acme_args $(for d in $domains; do echo -n "-d $d "; done)"
 	acme_args="$acme_args --keylength $keylength"
 	[ -n "$ACCOUNT_EMAIL" ] && acme_args="$acme_args --accountemail $ACCOUNT_EMAIL"
-	[ "$use_staging" -eq "1" ] && acme_args="$acme_args --staging"
 
 	if [ -n "$acme_server" ]; then
 		log "Using custom ACME server URL"
 		acme_args="$acme_args --server $acme_server"
+	else
+		# default to letsencrypt because the upstream default may change
+		if [ "$use_staging" -eq "1" ]; then
+			acme_args="$acme_args --server letsencrypt_test"
+		else
+			acme_args="$acme_args --server letsencrypt"
+		fi
 	fi
 
 	if [ -n "$days" ]; then


### PR DESCRIPTION
On September the 29th, the certificate for R3, the intermediate
CA of Let's Encrypt expired, followed by the root CA expiration
on September the 30th. Update the acme client to 3.0.1,
to make sure newly generated certificates are using the new CA.
This is a backport of 468fc5fca429ca4276dfcfb4136a0d741ed9038b.
https://github.com/openwrt/packages/pull/16801

Default to letsencrypt because the upstream default may change.
Passing --staging is no longer needed, since --serever will
select a staging server if needed.

Maintainer: @tohojo 
Compile tested: (arm_cortex-a9+vfpv3-d16_musl_eabi, WRT3200, OpenWrt 21.02)

