### PR TITLE
python-docker: Update to 5.0.3

### DIFF
--- a/lang/python/python-docker/Makefile
+++ b/lang/python/python-docker/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-docker
-PKG_VERSION:=5.0.2
+PKG_VERSION:=5.0.3
 PKG_RELEASE:=1
 
 PYPI_NAME:=docker
-PKG_HASH:=21ec4998e90dff7a7aaaa098ca8d839c7de412b89e6f6c30908372d58fecf663
+PKG_HASH:=d916a26b62970e7c2f554110ed6af04c7ccff8e9f81ad17d0d40c75637e227fb
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream update
```
Features:
 - Add cap_add and cap_drop parameters to service create and
 ContainerSpec
 - Add templating parameter to config create

Bugfixes:
 - Fix getting a read timeout for logs/attach with a tty and slow
 output

Miscellaneous:
 - Fix documentation examples
```
