### PR TITLE
[19.07] tor: update to 0.4.5.10

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.4.9
+PKG_VERSION:=0.4.5.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=e320d04b99ac27d5b7e0d1d5b85fd5b4f3dbb24528196f07520688b45e026e4c
+PKG_HASH:=8fe32222f8f2b4e65c6f50ac32eb4dfca59b8af71d0d16781f7ee5bec4c00743
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE
@@ -97,6 +97,8 @@ CONFIGURE_ARGS += \
 	--with-openssl-dir="$(STAGING_DIR)/usr" \
 	--with-zlib-dir="$(STAGING_DIR)/usr" \
 	--disable-asciidoc \
+	--disable-html-manual \
+	--disable-manpage \
 	--disable-seccomp \
 	--disable-libscrypt \
 	--disable-unittests \
@@ -106,6 +108,8 @@ CONFIGURE_ARGS += \
 	--with-tor-group=tor
 
 TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
+TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto \
+       $(if $(CONFIG_OPENSSL_ENGINE),,-DDISABLE_ENGINES)
 TARGET_LDFLAGS += -Wl,--gc-sections -flto
 
 ifneq ($(CONFIG_SSP_SUPPORT),y)

--- a/net/tor/patches/001-torrc.patch
+++ b/net/tor/patches/001-torrc.patch
@@ -18,8 +18,8 @@
  
  ## The port on which Tor will listen for local connections from Tor
  ## controller applications, as documented in control-spec.txt.
-@@ -238,3 +238,4 @@
- #%include /etc/torrc.d/
- #%include /etc/torrc.custom
+@@ -251,3 +251,4 @@
+ ## The %include option can be used recursively.
+ #%include /etc/torrc.d/*.conf
  
 +User tor


### PR DESCRIPTION
Maintainer: @hauke @tripolar
Compile tested: armv7, Turris Omnia, OpenWrt 19.07
Run tested: armv7, Turris Omnia, OpenWrt 19.07

Description:
* 0.4.4 is not an LTS series, so it's not getting security fixes and people running tor relays with 0.4.4 will be evicted from the tor network. 0.4.5 is an LTS series - https://forum.turris.cz/t/request-to-update-tor-in-openwrt-19-07/15991
* fix building without OpenSSL engine support (from e30f0480c829cf0340a16fe8499a95c7c2fd6f89)
* refresh patches

According to the changelog, 0.4.5 has some potential incompatibilities with older configs, but they should be very rare.