### PR TITLE
python3-jsonschema: update to new major version v4.0.1

### DIFF
--- a/lang/python/python-jsonschema/Makefile
+++ b/lang/python/python-jsonschema/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-jsonschema
-PKG_VERSION:=3.2.0
-PKG_RELEASE:=5
+PKG_VERSION:=4.0.1
+PKG_RELEASE:=1
 
 PYPI_NAME:=jsonschema
-PKG_HASH:=c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a
+PKG_HASH:=48f4e74f8bec0c2f75e9fcfffa264e78342873e1b57e2cfeae54864cc5e9e4dd
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=MIT

--- a/lang/python/python-jsonschema/Makefile
+++ b/lang/python/python-jsonschema/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-jsonschema
-PKG_VERSION:=4.0.1
+PKG_VERSION:=4.1.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=jsonschema
-PKG_HASH:=48f4e74f8bec0c2f75e9fcfffa264e78342873e1b57e2cfeae54864cc5e9e4dd
+PKG_HASH:=5c1a282ee6b74235057421fd0f766ac5f2972f77440927f6471c9e8493632fac
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=MIT

--- a/lang/python/python-jsonschema/patches/001-setup.patch
+++ b/lang/python/python-jsonschema/patches/001-setup.patch
@@ -1,0 +1,5 @@
+--- /dev/null	2021-10-11 11:05:13.171263746 +0200
++++ ./setup.py	2021-10-11 11:30:59.592359002 +0200
+@@ -0,0 +1,2 @@
++from setuptools import setup
++setup(use_scm_version=True)


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream update.

I had to copy `setup.py` from previous version to get it built, not sure why
it was dropped or forgotten.
Other than that no detected problems.

```
 - Partial support for Draft 2020-12 (as well as 2019-09).

 - False and 0 are now properly considered non-equal even
 recursively within a container (#686). As part of this change,
 uniqueItems validation may be slower in some cases. Please feel
 free to report any significant performance regressions, though in
 some cases they may be difficult to address given the specification
 requirement.

 - The CLI has been improved, and in particular now supports a --output
 option (with plain (default) or pretty arguments) to control the
 output format. Future work may add additional machine-parsable output
 formats.

 - Code surrounding DEFAULT_TYPES and the legacy mechanism for
 specifying types to validators have been removed, as per the deprecation
 policy. Validators should use the TypeChecker object to customize
 the set of Python types corresponding to JSON Schema types.

 - Validation errors now have a json_path attribute, describing their
 location in JSON path format

 - Support for the IP address and domain name formats has been improved

 - Support for Python 2 has been dropped, with python_requires properly
 set.

 - multipleOf could overflow when given sufficiently large numbers. Now,
 when an overflow occurs, jsonschema will fall back to using fraction
 division (#746).

 - jsonschema.__version__, jsonschema.validators.validators,
 jsonschema.validators.meta_schemas and
 jsonschema.RefResolver.in_scope have been deprecated, as has
 passing a second-argument schema to Validator.iter_errors and
 Validator.is_valid.

This patch release fixes an issue with the way python_requires was
declared (i.e. with how the supported Python versions were declared).
```

