### PR TITLE
oniguruma: bump to 6.9.7.1

### DIFF
--- a/libs/oniguruma/Makefile
+++ b/libs/oniguruma/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=oniguruma
-PKG_VERSION:=6.9.6
+PKG_VERSION:=6.9.7.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=onig-v$(subst _,-,$(PKG_VERSION)).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/kkos/oniguruma/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=aec9f6902ad8b7bb53b2c55d04686ea75da89a06694836b0362cb206578dfe89
+PKG_HASH:=8f9a75b7d90dde0942c30a8b3c17889b2fecf190690988cc381c4e525cbbd22b
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=BSD-2-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79, mediatek
Run tested: mediatek, Linksys EA8450, master

Description:

Changelog:

*  NEW API: ONIG_OPTION_CALLBACK_EACH_MATCH
*  NEW API: ONIG_OPTION_IGNORECASE_IS_ASCII
*  NEW API: ONIG_SYNTAX_PYTHON
*  Fixed some problems found by OSS-Fuzz
*  fix: replace UChar to OnigUChar in oniguruma.h

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

