### PR TITLE
usteer: add package

### DIFF
--- a/net/usteer/Makefile
+++ b/net/usteer/Makefile
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=usteer
+PKG_SOURCE_DATE:=2021-09-21
+PKG_SOURCE_VERSION:=fc1fadf5eb7684db952e72558f26dffbf3c4dfda
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://git.openwrt.org/project/usteer.git
+PKG_MIRROR_HASH:=9bcd496a3416d2c805eff37df36b6a0564db6f40d44d7c0070962f01ee1d55d2
+
+PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
+PKG_LICENSE:=GPL-2.0-only
+
+PKG_BUILD_DEPENDS:=libpcap
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/usteer
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libubox +libubus +libblobmsg-json +libnl-tiny
+  TITLE:=OpenWrt AP roaming assist daemon
+endef
+
+define Package/usteer/conffiles
+/etc/config/usteer
+endef
+
+define Package/usteer/install
+	$(INSTALL_DIR) $(1)/sbin $(1)/etc/init.d $(1)/etc/config
+
+	$(CP) $(PKG_BUILD_DIR)/openwrt/usteer/files/etc/config/usteer $(1)/etc/config/usteer
+
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openwrt/usteer/files/etc/init.d/usteer $(1)/etc/init.d/usteer
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/usteerd $(1)/sbin/usteerd
+endef
+
+$(eval $(call BuildPackage,usteer))

--- a/net/usteer/patches/001-usteer-fix-missing-struct-definition.patch
+++ b/net/usteer/patches/001-usteer-fix-missing-struct-definition.patch
@@ -1,0 +1,24 @@
+From cacf1686db8adb4e7a35a85f0988c30ab5d96864 Mon Sep 17 00:00:00 2001
+From: David Bauer <mail@david-bauer.net>
+Date: Wed, 13 Oct 2021 00:13:48 +0200
+Subject: [PATCH] usteer: fix missing struct definition
+
+When compiling for targets using glibc, usteer compilation would fail
+due to undefined struct in6_pktinfo. In this case, use the struct
+definition provided by Linux UAPI.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+---
+ remote.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/remote.c
++++ b/remote.c
+@@ -17,6 +17,7 @@
+  *   Copyright (C) 2020 John Crispin <john@phrozen.org> 
+  */
+ 
++#define _GNU_SOURCE
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <netinet/in.h>


### PR DESCRIPTION
Maintainer: me / @blocktrron 
Compile tested: ath79/generic
Run tested: ath79/generic (UAP AC Lite)

Description:

This commits adds the new usteer package to the packages feed.

usteer is a daemon for steering wireless clients across frequency
bands as well as between multiple access points on a network.