### PR TITLE
zerotier: add respawn procd param

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
 PKG_VERSION:=1.6.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
@@ -77,4 +77,3 @@ endif
 endef
 
 $(eval $(call BuildPackage,zerotier))
-

--- a/net/zerotier/files/etc/init.d/zerotier
+++ b/net/zerotier/files/etc/init.d/zerotier
@@ -94,6 +94,7 @@ start_instance() {
 	procd_open_instance
 	procd_set_param command $PROG $args $path
 	procd_set_param stderr 1
+	procd_set_param respawn
 	procd_close_instance
 }
 


### PR DESCRIPTION
Maintainer: me / @mwarning 
Compile tested: x86-64, generic, OpenWrt Snapshot
Run tested: x86-64, generic, OpenWrt Snapshot

Description:
Zerotier-one got segment fault in some situations. Add 'respawn' option to keep it running.