### PR TITLE
node: bump to 14.18.1 / October 12th 2021 Security Releases

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v14.17.4
+PKG_VERSION:=v14.18.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=ae7bf4e784f8c8027ffa1e3757f37d2bd5925d0c48988c4d7f07e4515853cf2c
+PKG_HASH:=3fa1d71adddfab2f5e3e41874b4eddbdf92b65cade4a43922fb1e437afcf89ed
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,6 +1,6 @@
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1189,7 +1189,8 @@ Module._initPaths = function() {
+@@ -1202,7 +1202,8 @@ Module._initPaths = function() {
      path.resolve(process.execPath, '..') :
      path.resolve(process.execPath, '..', '..');
  

--- a/lang/node/patches/999-fix_building_with_system_c-ares_on_Linux.patch
+++ b/lang/node/patches/999-fix_building_with_system_c-ares_on_Linux.patch
@@ -1,0 +1,42 @@
+From 8699aa501c4d4e1567ebe8901e5ec80cadaa9323 Mon Sep 17 00:00:00 2001
+From: Felix Yan <felixonmars@archlinux.org>
+Date: Thu, 12 Aug 2021 02:44:43 +0800
+Subject: [PATCH] deps: fix building with system c-ares on Linux
+
+The change in #39724 breaks building with system c-ares
+(`--shared-cares`):
+```
+In file included from ../src/cares_wrap.cc:25:
+../src/cares_wrap.h:25:11: fatal error: ares_nameser.h: No such file or
+directory
+   25 | # include <ares_nameser.h>
+      |           ^~~~~~~~~~~~~~~~
+```
+
+Since `ares_nameser.h` isn't available with a default system c-ares
+installation, let's add back the include check and use the old
+`arpa/nameser.h` routine instead.
+
+Tested to build fine on Arch Linux with shared c-ares.
+---
+ src/cares_wrap.h | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+--- a/src/cares_wrap.h
++++ b/src/cares_wrap.h
+@@ -22,7 +22,15 @@
+ # include <netdb.h>
+ #endif  // __POSIX__
+ 
++#if defined(__ANDROID__) || \
++    defined(__MINGW32__) || \
++    defined(__OpenBSD__) || \
++    defined(_MSC_VER)
++
+ # include <ares_nameser.h>
++#else
++# include <arpa/nameser.h>
++#endif
+ 
+ namespace node {
+ namespace cares_wrap {

--- a/lang/node/patches/999-localhost-no-addrconfig.patch
+++ b/lang/node/patches/999-localhost-no-addrconfig.patch
@@ -13,7 +13,7 @@ Forwarded: https://github.com/nodejs/node/issues/33816
  //
  // Permission is hereby granted, free of charge, to any person obtaining a
  // copy of this software and associated documentation files (the
-@@ -1028,13 +1029,6 @@ function lookupAndConnect(self, options)
+@@ -1039,13 +1040,6 @@ function lookupAndConnect(self, options)
      hints: options.hints || 0
    };
  


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: head, aarch64, arm, i386, x86_64, mipsel (pistachio) 
Run tested: (qemu 6.1.0) aarch64, arm, i386, x86_64

Description:
Update to v14.18.1

October 12th 2021 Security Releases:
 HTTP Request Smuggling due to spaced in headers (Medium)(CVE-2021-22959)
 HTTP Request Smuggling when parsing the body (Medium)(CVE-2021-22960)

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
