### PR TITLE
knot-resolver: update to 5.4.2

### DIFF
--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -10,12 +10,12 @@ PKG_RELRO_FULL:=0
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot-resolver
-PKG_VERSION:=5.4.0
+PKG_VERSION:=5.4.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-resolver
-PKG_HASH:=534af671b98433b23b57039acc9d7d3c100a4888a8cf9aeba36161774ca0815e
+PKG_HASH:=ea6a219571a752056669bae3f2c0c3ed0bec58af5ab832d505a3ec9c4063a58b
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=GPL-3.0-later
@@ -56,7 +56,6 @@ define Package/knot-resolver/config
 	source "$(SOURCE)/Config.in"
 endef
 
-# kres_gen_test breaks on cross, fix is already upstream
 MESON_ARGS+= \
 	$(if $(CONFIG_PACKAGE_knot-resolver_dnstap), -Ddnstap=enabled,-Ddnstap=disabled) \
 	-Dcapng=disabled \
@@ -69,7 +68,6 @@ MESON_ARGS+= \
 	-Dkeyfile_default=/etc/knot-resolver/root.keys \
 	-Dprefix=/usr \
 	-Dunit_tests=disabled \
-	-Dkres_gen_test=false \
 	-Dutils=disabled
 
 define Package/knot-resolver/install

--- a/net/knot-resolver/patches/030-fix-policy-hack.patch
+++ b/net/knot-resolver/patches/030-fix-policy-hack.patch
@@ -2,7 +2,7 @@ This patch fixes the problem with forwarding in knot-resolver v4.3.0.
 It reintroduces a fix which enables  policy related hack (knot/knot-resolver#205 (comment 94566) )
 --- a/modules/policy/policy.lua
 +++ b/modules/policy/policy.lua
-@@ -984,7 +984,7 @@ policy.layer = {
+@@ -1000,7 +1000,7 @@ policy.layer = {
  		if bit.band(state, bit.bor(kres.FAIL, kres.DONE)) ~= 0 then return state end
  		local qry = req:initial() -- same as :current() but more descriptive
  		return policy.evaluate(policy.rules, req, qry, state)


### PR DESCRIPTION
Maintainer: @ja-pa
Compile tested: aarch64, Turris MOX, OpenWrt 21.02
Run tested: aarch64, Turris MOX, OpenWrt 21.02

Description:
* refresh patches
* disabling kres_gen_test is not required anymore for cross compilation, it was fixed upstream with the 5.4.1 release
