### PR TITLE
lua-wsapi: build each variant in its own dir

### DIFF
--- a/lang/lua-wsapi/Makefile
+++ b/lang/lua-wsapi/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lua-wsapi
 PKG_VERSION:=1.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/keplerproject/wsapi/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=48dc7aba0fd2e96a3e5ef51045b5d923964f6ae299de761aa0467031ad44e987
-PKG_BUILD_DIR:=$(BUILD_DIR)/wsapi-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/wsapi-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Dirk Chang <dirk@kooiot.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @srdgame 
Compile tested: mvebu
Run tested: not needed - no binary change

Description:
This avoids unnecessary package rebuilds, when running make back to back.

Right now, since both variants are built in (I should say extracted to) the same directory, when you run make a second time, check-compile will point this out:
```
Prerequisite '/build_dir/target.../wsapi-1.7/.built' is newer than target 'bin/packages/.../lua-wsapi-base_1.7-1_all.ipk'.
```
because the last time it had ran, the build directory was used by the `xavante` variant, which happened after it had built the `base` ipk.  Then the package gets rebuilt unnecessarily.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>