### PR TITLE
simple-adblock: update to 1.8.8-1

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -5,8 +5,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
-PKG_VERSION:=1.8.7
-PKG_RELEASE:=8
+PKG_VERSION:=1.8.8
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -1082,32 +1082,37 @@ service_triggers() {
 
 check() {
 	load_package_config
-	local c string="$1" 
+	local c string="$1"
 	c="$(grep -c "$string" "$outputFile")"
+	c="${c:-0}"
 	if [ ! -s "$outputFile" ]; then
 		echo "No block-list ('$outputFile') found."
 	elif [ -z "$string" ]; then
 		echo "Usage: /etc/init.d/${packageName} check string"
 	elif [ "$c" -gt 0 ]; then
-		if [ "$c" -gt 1 ]; then
+		if [ "$c" -eq 1 ]; then
+			echo "Found 1 match for '$string' in '$outputFile':"
+		elif [ "$c" -le 20 ]; then
 			echo "Found $c matches for '$string' in '$outputFile':"
 		else
-			echo "Found 1 match for '$string' in '$outputFile':"
+			echo "Found $c matches for '$string' in '$outputFile'."
 		fi
-		case "$targetDNS" in
-			dnsmasq.addnhosts)
-				grep "$string" "$outputFile" | sed 's|^127.0.0.1 ||;s|^:: ||;';;
-			dnsmasq.conf)
-				grep "$string" "$outputFile" | sed 's|local=/||;s|/$||;';;
-			dnsmasq.ipset)
-				grep "$string" "$outputFile" | sed 's|ipset=/||;s|/adb$||;';;
-			dnsmasq.servers)
-				grep "$string" "$outputFile" | sed 's|server=/||;s|/$||;';;
-			unbound.adb_list)
-				grep "$string" "$outputFile" | sed 's|^local-zone: "||;s|" static$||;';;
-		esac
+		if [ "$c" -le 20 ]; then
+			case "$targetDNS" in
+				dnsmasq.addnhosts)
+					grep "$string" "$outputFile" | sed 's|^127.0.0.1 ||;s|^:: ||;';;
+				dnsmasq.conf)
+					grep "$string" "$outputFile" | sed 's|local=/||;s|/$||;';;
+				dnsmasq.ipset)
+					grep "$string" "$outputFile" | sed 's|ipset=/||;s|/adb$||;';;
+				dnsmasq.servers)
+					grep "$string" "$outputFile" | sed 's|server=/||;s|/$||;';;
+				unbound.adb_list)
+					grep "$string" "$outputFile" | sed 's|^local-zone: "||;s|" static$||;';;
+			esac
+		fi
 	else
-		echo "The $string is not found in current block-list ('$outputFile')."
+		echo "The '$string' is not found in current block-list ('$outputFile')."
 	fi
 }
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-105, OpenWrt 21.02.0
Run tested: x86_64, Sophos SG-105, OpenWrt 21.02.0, start/dl/check

Description:
* update 'check' function

Signed-off-by: Stan Grishin <stangri@melmac.net>
