### PR TITLE
openfortivpn: add PEM cert/key, persistent support

### DIFF
--- a/net/openfortivpn/Makefile
+++ b/net/openfortivpn/Makefile
@@ -54,12 +54,15 @@ define Package/openfortivpn/install
 	$(INSTALL_DIR) \
 	  $(1)/usr/sbin \
           $(1)/lib/netifd/proto \
-	  $(1)/etc/hotplug.d/iface
+	  $(1)/etc/hotplug.d/iface \
+	  $(1)/etc/openfortivpn \
+	  $(1)/lib/upgrade/keep.d
 
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/openfortivpn $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/openfortivpn-wrapper $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/openfortivpn.sh $(1)/lib/netifd/proto/
 	$(INSTALL_BIN) ./files/openfortivpn-ppp-up $(1)/lib/netifd/openfortivpn-ppp-up
+	$(INSTALL_DATA) ./files/openfortivpn.upgrade $(1)/lib/upgrade/keep.d/openfortivpn
 endef
 
 $(eval $(call BuildPackage,openfortivpn))

--- a/net/openfortivpn/files/openfortivpn.sh
+++ b/net/openfortivpn/files/openfortivpn.sh
@@ -132,6 +132,10 @@ proto_openfortivpn_setup() {
 	        mkdir -p '/var/etc/openfortivpn/peers'
 	}
 
+	[ -f /etc/openfortivpn/user-cert-$config.pem ] && append_args "--user-cert=/etc/openfortivpn/user-cert-$config.pem"
+	[ -f /etc/openfortivpn/user-key-$config.pem ] && append_args "--user-key=/etc/openfortivpn/user-key-$config.pem"
+	[ -f /etc/openfortivpn/ca-$config.pem ] && append_args "--ca-file=/etc/openfortivpn/ca-$config.pem"
+
 	callfile="/var/etc/openfortivpn/peers/$config"
 	echo "115200
 :$local_ip

--- a/net/openfortivpn/files/openfortivpn.sh
+++ b/net/openfortivpn/files/openfortivpn.sh
@@ -19,6 +19,7 @@ proto_openfortivpn_init_config() {
 	proto_config_add_string "local_ip"
 	proto_config_add_string "username"
 	proto_config_add_string "password"
+	proto_config_add_int "persist_int"
 	proto_config_add_string "trusted_cert"
 	proto_config_add_string "remote_status_check"
 	no_device=1
@@ -30,10 +31,10 @@ proto_openfortivpn_setup() {
 
 	local msg ifname ip server_ips pwfile callfile
 
-	local peeraddr port tunlink local_ip username password trusted_cert \
-	      remote_status_check
-	json_get_vars host peeraddr port tunlink local_ip username password trusted_cert \
-		      remote_status_check
+	local peeraddr port tunlink local_ip username password persist_int \
+	      trusted_cert remote_status_check
+	json_get_vars host peeraddr port tunlink local_ip username password persist_int \
+		      trusted_cert remote_status_check
 
 	ifname="vpn-$config"
 
@@ -116,6 +117,7 @@ proto_openfortivpn_setup() {
 	        append_args "--ifname=$iface_device_name"
 	}
 
+	[ -n "$persist_int" ] && append_args "--persistent=$persist_int"
 	[ -n "$trusted_cert" ] && append_args "--trusted-cert=$trusted_cert"
 	[ -n "$username" ] && append_args -u "$username"
 	[ -n "$password" ] && {

--- a/net/openfortivpn/files/openfortivpn.upgrade
+++ b/net/openfortivpn/files/openfortivpn.upgrade
@@ -1,0 +1,3 @@
+/etc/openfortivpn/user-cert-*.pem
+/etc/openfortivpn/user-key-*.pem
+/etc/openfortivpn/ca-*.pem


### PR DESCRIPTION
Maintainer: @lucize
Compile tested: bcm53xx
Run tested: same

Linked luci PR: [#5448](https://github.com/openwrt/luci/pull/5448)

Description:
Add support for user cert/key and CA cert. This is largely replicated from openconnect.

Secondly add the persistent option to reconnect when the connection times out due to inactivity (by default this is 5 minutes).

Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>