### PR TITLE
expat: don't build host libs

### DIFF
--- a/lang/perl-xml-parser/Makefile
+++ b/lang/perl-xml-parser/Makefile
@@ -21,7 +21,7 @@ PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
 PKG_BUILD_DIR:=$(BUILD_DIR)/perl/XML-Parser-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/perl/XML-Parser-$(PKG_VERSION)
 
-HOST_BUILD_DEPENDS:=perl/host expat/host
+HOST_BUILD_DEPENDS:=perl/host
 
 EXPAT_LIBPATH:=$(STAGING_DIR)/usr/lib
 EXPAT_INCPATH:=$(STAGING_DIR)/usr/include

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -44,7 +44,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_python3-setuptools CONFIG_PACKAGE_python3-pip
 
 PKG_BUILD_DEPENDS:=bluez python3/host
-HOST_BUILD_DEPENDS:=bzip2/host expat/host libffi/host
+HOST_BUILD_DEPENDS:=bzip2/host libffi/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk

--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -20,7 +20,6 @@ PKG_CPE_ID:=cpe:/a:libexpat:expat
 
 CMAKE_INSTALL:=1
 
-include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
@@ -35,7 +34,7 @@ define Package/libexpat/description
  A fast, non-validating, stream-oriented XML parsing library.
 endef
 
-OPTIONS += \
+CMAKE_OPTIONS += \
 	-DDOCBOOK_TO_MAN=OFF \
 	-DEXPAT_BUILD_TOOLS=OFF \
 	-DEXPAT_BUILD_EXAMPLES=OFF \
@@ -47,13 +46,9 @@ OPTIONS += \
 	-DEXPAT_NS=OFF \
 	-DEXPAT_DEV_URANDOM=OFF
 
-CMAKE_OPTIONS += $(OPTIONS)
-CMAKE_HOST_OPTIONS += $(OPTIONS)
-
 define Package/libexpat/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libexpat.so.* $(1)/usr/lib/
 endef
 
-$(eval $(call HostBuild))
 $(eval $(call BuildPackage,libexpat))


### PR DESCRIPTION
tools/expat is actually what's used by the various packages that
supposedly depend on expat/host.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: ath79

ping @jefferyto 