### PR TITLE
[21.02] vpn-policy-routing: bugfixes: killall and tmpfs params

### DIFF
--- a/net/vpn-policy-routing/files/vpn-policy-routing.init
+++ b/net/vpn-policy-routing/files/vpn-policy-routing.init
@@ -154,7 +154,7 @@ is_domain() { str_contains "$1" '[a-zA-Z]'; }
 is_phys_dev() { [ "${1:0:1}" = "@" ] && ip l show | grep -E -q "^\\d+\\W+${1:1}"; }
 is_turris() { /bin/ubus -S call system board | /bin/grep 'Turris' | /bin/grep -q '15.05'; }
 is_chaos_calmer() { ubus -S call system board | grep -q 'Chaos Calmer'; }
-dnsmasq_kill() { killall -q -HUP dnsmasq; }
+dnsmasq_kill() { killall -q -s HUP dnsmasq; }
 dnsmasq_restart() { output 3 'Restarting DNSMASQ '; if /etc/init.d/dnsmasq restart >/dev/null 2>&1; then output_okn; else output_failn; fi; }
 is_default_dev() { [ "$1" = "$(ip -4 r | grep -m1 'dev' | grep -Eso 'dev [^ ]*' | awk '{print $2}')" ]; }
 is_supported_iface_dev() {
@@ -971,7 +971,7 @@ start_service() {
 	is_wan_up || return 1
 
 	iptables -t 'mangle' --list 'VPR_PREROUTING' >/dev/null 2>&1 || unset reloadedIface
-	[ -n "$(tmpfs get status)" ] || unset reloadedIface
+	[ -n "$(tmpfs get gateway)" ] || unset reloadedIface
 
 	if [ -s "$dnsmasqFile" ]; then
 		dnsmasqStoredHash="$(md5sum $dnsmasqFile | awk '{ print $1; }')"


### PR DESCRIPTION
Maintainer: me

Description:
* bugfix: change killall param from -HUP to -s HUP
* bugfix: change tmpfs param from status to gateway

Signed-off-by: Stan Grishin <stangri@melmac.net>
(cherry picked from commit 2b6c8d827369a29d3546c6bae27121aeb93e7f9a)

