### PR TITLE
tvheadend: add patch to update hdhomerun

### DIFF
--- a/multimedia/tvheadend/patches/001-Makefile.hdhomerun-update-library-to-version-2018081.patch
+++ b/multimedia/tvheadend/patches/001-Makefile.hdhomerun-update-library-to-version-2018081.patch
@@ -1,0 +1,29 @@
+From 7d657f0a87be1f135f7e5146b06e26121691c33a Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Mon, 18 Oct 2021 22:54:02 +0200
+Subject: [PATCH] Makefile.hdhomerun: update library to version 20180817
+
+The previous tarball is not available and because of that, the
+compilation of tvheadend does not proceed.
+
+The latest version can not be used somehow as the compilation fails.
+---
+ Makefile.hdhomerun | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/Makefile.hdhomerun
++++ b/Makefile.hdhomerun
+@@ -32,10 +32,10 @@ endif
+ # Upstream Packages
+ # ###########################################################################
+ 
+-LIBHDHR         = libhdhomerun_20171221
++LIBHDHR         = libhdhomerun_20180817
+ LIBHDHR_TB      = $(LIBHDHR).tgz
+-LIBHDHR_URL     = http://download.silicondust.com/hdhomerun/$(LIBHDHR_TB)
+-LIBHDHR_SHA1    = 6b019728eadea3af7a5686ed5ba44e970bca7365
++LIBHDHR_URL     = https://download.silicondust.com/hdhomerun/$(LIBHDHR_TB)
++LIBHDHR_SHA1    = 052868bde3a5713c55b4d060b77e0bc3a0d891d6
+ 
+ # ###########################################################################
+ # Library Config


### PR DESCRIPTION
Maintainer: @M95D
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 21.02
Run tested: N/A, not using hdhomerun

Description:
- Tarball with libhdhomerun_20171221 [1] was removed from upstream repository
and as it can not be found.

[1] http://download.silicondust.com/hdhomerun/libhdhomerun_20171221.tgz

This should be backported to OpenWrt 21.02 as currently the packages fails in master and also in 21.02.
Faillog: https://downloads.openwrt.org/releases/faillogs-21.02/powerpc_8540/packages/tvheadend/compile.txt

Snip
```
Final Binary:
  /builder/shared-workdir/build/sdk/build_dir/target-powerpc_8540_musl/tvheadend-4.2.8/build.linux/tvheadend

Tvheadend Data Directory:
  /usr/share/tvheadend

make[4]: Entering directory '/builder/shared-workdir/build/sdk/build_dir/target-powerpc_8540_musl/tvheadend-4.2.8'
Receiving data/dvb-scan from https://github.com/tvheadend/dtv-scan-tables.git#tvheadend
make -f Makefile.hdhomerun libcacheget
make[5]: Entering directory '/builder/shared-workdir/build/sdk/build_dir/target-powerpc_8540_musl/tvheadend-4.2.8'
DOWNLOAD        misc/staticlib/unknown/powerpc/hdhomerun-8081b801eb8e8403e7ba2d1b7c2015777051d47a.tgz / kZ54ee7ZUvsSYmb9VGSpnmoVzcAUhpBXLq8k
Traceback (most recent call last):
  File "/builder/shared-workdir/build/sdk/build_dir/target-powerpc_8540_musl/tvheadend-4.2.8/support/pcloud.py", line 13, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
FAILED TO DOWNLOAD  (BUT THIS IS NOT A FATAL ERROR! DO NOT REPORT THAT!)
make[5]: Leaving directory '/builder/shared-workdir/build/sdk/build_dir/target-powerpc_8540_musl/tvheadend-4.2.8'
make -f Makefile.hdhomerun build
make[5]: Entering directory '/builder/shared-workdir/build/sdk/build_dir/target-powerpc_8540_musl/tvheadend-4.2.8'
WGET            http://download.silicondust.com/hdhomerun/libhdhomerun_20171221.tgz
http://download.silicondust.com/hdhomerun/libhdhomerun_20171221.tgz:
2021-10-18 19:12:59 ERROR 404: Not Found.
make[5]: *** [Makefile.hdhomerun:79: /builder/shared-workdir/build/sdk/build_dir/target-powerpc_8540_musl/tvheadend-4.2.8/build.linux/hdhomerun/libhdhomerun_20171221/.tvh_download] Error 8
make[5]: Leaving directory '/builder/shared-workdir/build/sdk/build_dir/target-powerpc_8540_musl/tvheadend-4.2.8'
make[4]: *** [Makefile:800: /builder/shared-workdir/build/sdk/build_dir/target-powerpc_8540_musl/tvheadend-4.2.8/build.linux/hdhomerun/libhdhomerun/libhdhomerun.a] Error 2
make[4]: Leaving directory '/builder/shared-workdir/build/sdk/build_dir/target-powerpc_8540_musl/tvheadend-4.2.8'
make[3]: *** [Makefile:100: /builder/shared-workdir/build/sdk/build_dir/target-powerpc_8540_musl/tvheadend-4.2.8/.built] Error 2
time: package/feeds/packages/tvheadend/compile#3.54#1.97#10.15
```
