### PR TITLE
miniflux: new package

### DIFF
--- a/utils/miniflux/Makefile
+++ b/utils/miniflux/Makefile
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=miniflux
+PKG_VERSION:=2.0.33
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/miniflux/v2/tar.gz/${PKG_VERSION}?
+PKG_HASH:=b61c9ddb62be8f1cc15a70a1c916d55f8ac47299df9c2323552eb275a36d2cc3
+
+PKG_MAINTAINER:=Michal Vasilek <michal.vasilek@nic.cz>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/v2-$(PKG_VERSION)
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=miniflux.app
+GO_PKG_LDFLAGS_X:=miniflux.app/version.Version=$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/miniflux
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Feed reader
+  USERID:=miniflux=1120:miniflux=1120
+  URL:=https://miniflux.app
+  DEPENDS:=$(GO_ARCH_DEPENDS) +pgsql-server
+endef
+
+define Package/miniflux/description
+  Miniflux is a small and simple feed reader.
+endef
+
+define Package/miniflux/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_CONF) ./files/miniflux.conf $(1)/etc/config/miniflux
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/miniflux.init $(1)/etc/init.d/miniflux
+endef
+
+define Package/miniflux/conffiles
+/etc/config/miniflux
+endef
+
+$(eval $(call GoBinPackage,miniflux))
+$(eval $(call BuildPackage,miniflux))

--- a/utils/miniflux/files/miniflux.conf
+++ b/utils/miniflux/files/miniflux.conf
@@ -1,0 +1,20 @@
+package miniflux
+
+config miniflux main
+	# if set, all other uci settings are ignored
+	option config_file ''
+
+	option listen_address '127.0.0.1:5433'
+
+	# run migrations on each start, disabling this will make miniflux fail to
+	# start on the next upgrade until migrations are ran manually
+	option migrate 1
+
+config miniflux database
+	# if set, all other options in this section will be ignored
+	option url ''
+
+	option user miniflux
+	option password ''
+	option sslmode disable
+	option dbname miniflux

--- a/utils/miniflux/files/miniflux.init
+++ b/utils/miniflux/files/miniflux.init
@@ -1,0 +1,44 @@
+#!/bin/sh /etc/rc.common
+
+# Copyright (C) 2021 CZ.NIC z.s.p.o. (https://www.nic.cz/)
+
+START=70
+
+USE_PROCD=1
+PROG=/usr/bin/miniflux.app
+
+start_service() {
+	local config_file
+	config_load miniflux
+
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_append_param user miniflux
+
+	config_get config_file main config_file
+	if [ -n "$config_file" ]; then
+		procd_append_param command -config-file="$config_file"
+	else
+		local listen_address run_migrations database_url
+		config_get listen_address main listen_address
+		procd_append_param env LISTEN_ADDR="$listen_address"
+		config_get run_migrations main run_migrations
+		[ "$run_migrations" = 1 ] && procd_append_param env RUN_MIGRATIONS=1
+
+		config_get database_url database url
+		if [ -z "$database_url" ]; then
+			local database_user database_password database_dbname database_sslmode
+			config_get database_user database user
+			config_get database_password database password
+			config_get database_dbname database dbname
+			config_get database_sslmode database sslmode
+			database_url="user=$database_user password=$database_password dbname=$database_dbname sslmode=$database_sslmode"
+		fi
+		procd_append_param env DATABASE_URL="$database_url"
+	fi
+
+	procd_set_param file "$config_file"
+	procd_set_param respawn
+	procd_set_param stderr 1
+	procd_close_instance
+}

--- a/utils/miniflux/test.sh
+++ b/utils/miniflux/test.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+miniflux.app -version | grep "$2"


### PR DESCRIPTION
Maintainer: me
Compile tested: armv7, Turris Omnia, OpenWrt 21.02
Run tested: armv7, Turris Omnia, OpenWrt 21.02

Description: miniflux is a feed reader using PostgreSQL, so it needs some setup, enabling the service is not enough. After starting the postgresql service, run
```
opkg install pgsql-cli-extra
createuser -U postgres -P miniflux
createdb -U postgres -O miniflux miniflux
psql -U postgres miniflux -c 'create extension hstore'
psql -U postgres -c 'ALTER USER miniflux WITH SUPERUSER;'
DATABASE_URL='user=postgres password=XXX dbname=miniflux sslmode=disable' miniflux.app -migrate
DATABASE_URL='user=postgres password=XXX dbname=miniflux sslmode=disable' miniflux.app -create-admin
DATABASE_URL='user=postgres password=XXX dbname=miniflux sslmode=disable' miniflux.app
```
then change the database password in /etc/config/miniflux and run the miniflux service.

I chose port 5433 as the default port to avoid conflicts, but maybe 8080 (or something similar) would make more sense (?)
