### PR TITLE
modemmanager: add support for wwan subsystem in hotplug

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -131,6 +131,9 @@ define Package/modemmanager/install
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/tty
 	$(INSTALL_DATA) ./files/25-modemmanager-tty $(1)/etc/hotplug.d/tty
 
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/wwan
+	$(INSTALL_DATA) ./files/25-modemmanager-wwan $(1)/etc/hotplug.d/wwan
+
 	$(INSTALL_DIR) $(1)/lib/netifd/proto
 	$(INSTALL_BIN) ./files/modemmanager.proto $(1)/lib/netifd/proto/modemmanager.sh
 endef

--- a/net/modemmanager/files/25-modemmanager-wwan
+++ b/net/modemmanager/files/25-modemmanager-wwan
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Copyright (C) 2021 Aleksander Morgado <aleksander@aleksander.es>
+
+# Load hotplug common utilities
+. /usr/share/ModemManager/modemmanager.common
+
+# We require a device name
+[ -n "$DEVNAME" ] || exit
+
+# Always make sure the rundir exists
+mkdir -m 0755 -p "${MODEMMANAGER_RUNDIR}"
+
+# Report wwan
+mm_log "${ACTION} wwan control port ${DEVNAME}: event processed"
+mm_report_event "${ACTION}" "${DEVNAME}" "wwan" "/sys${DEVPATH}"


### PR DESCRIPTION
WWAN devices may now be exposed in the new 'wwan' subsystem in the
kernel (since 5.13), initially applicable to devices exposed in PCIe
(no USB), but at some point may also apply to USB devices that until
now were exposed via other subsystems (e.g. usbmisc, tty).

Signed-off-by: Aleksander Morgado <aleksander@aleksander.es>

Maintainer: @nickberry17
Compile tested: openwrt 21.02, target bcm2711 (RPi CM4)
Run tested: Tested with a Sierra Wireless EM9191 running in PCIe mode (PCIE_DIS pin low).
