### PR TITLE
dawn: respawn dawn in case of crash

### DIFF
--- a/net/dawn/files/dawn.init
+++ b/net/dawn/files/dawn.init
@@ -52,6 +52,9 @@ start_service()
 	echo "Starting Service..."
 	procd_open_instance
 	procd_set_param command $PROG
+
+	procd_set_param respawn 3600 15 0
+
 	procd_set_param stdout 0 # here it is possible to remove the debug output...
 	procd_set_param stderr 1
 	if [ ${_network_option} -eq 2 ]; then


### PR DESCRIPTION
Some users report that DAWN sometimes crashes after a while. Mostly
this happens after the new update has been rolled out.

Since I would not like to go back to the older version, I add as
a workaround for now that DAWN automatically respawned.

Workaround for:
https://github.com/berlin-open-wireless-lab/DAWN/issues/151

Signed-off-by: Nick Hainke <vincent@systemli.org>

Maintainer: me
Compile tested: tbd
Run tested: tbd
