### PR TITLE
bossa: add bossa

### DIFF
--- a/utils/bossa/Makefile
+++ b/utils/bossa/Makefile
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bossa
+PKG_VERSION:=1.9.1
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/shumatech/BOSSA/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=ca650455dfa36cbd029010167347525bea424717a71a691381c0811591c93e72
+PKG_BUILD_DIR:=$(BUILD_DIR)/BOSSA-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/bossa
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libstdcpp
+  TITLE:=Utility to flash ARM microcontrollers
+  URL:=http://www.shumatech.com/web/products/bossa
+endef
+
+define Package/bossa/description
+ BOSSA is a flash programming utility for Atmel's SAM family of flash-based
+ ARM microcontrollers. The motivation behind BOSSA is to create a simple,
+ easy-to-use, open source utility to replace Atmel's SAM-BA software.
+endef
+
+define Build/Compile
+	COMMON_CXXFLAGS="$(TARGET_CFLAGS) $(EXTRA_CFLAGS) $(TARGET_CPPFLAGS) $(EXTRA_CPPFLAGS)" \
+	COMMON_LDFLAGS="$(TARGET_LINKFLAGS) $(TARGET_LDFLAGS)" \
+	$(MAKE) -C $(PKG_BUILD_DIR) $(TARGET_CONFIGURE_OPTS) CFLAGS="$(TARGET_CFLAGS)" bin/bossac
+endef
+
+define Package/bossa/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/bossac $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,bossa))

--- a/utils/bossa/patches/902-musl_fd.patch
+++ b/utils/bossa/patches/902-musl_fd.patch
@@ -1,0 +1,12 @@
+--- a/src/PosixSerialPort.cpp
++++ b/src/PosixSerialPort.cpp
+@@ -39,6 +39,9 @@
+ 
+ #include <string>
+ 
++/* __MUSL__ */
++#include <sys/select.h>
++
+ #ifndef B460800
+ #define B460800 460800
+ #endif


### PR DESCRIPTION
Based on the work of Hirokazu MORIKAWA (nxhack):
https://github.com/nxhack/openwrt-arduino-packages/tree/master/bossa
    
BOSSA is a flash programming utility for Atmel's SAM family of flash-based ARM microcontrollers. The motivation behind BOSSA is to create a simple, easy-to-use, open source utility to replace Atmel's SAM-BA software.

Runtested with feather m0, flashing firmware to it on banana pi r64.
However, I needed to add a reset of serial connection with python:

```python
import serial

com = serial.Serial()
com.port = '/dev/ttyACM0'
com.baudrate = 1200
com.timeout = 1
com.stopbits = 1
com.parity = serial.PARITY_NONE
com.setDTR(False)
com.open()
com.close()
```