### PR TITLE
gnunet: fix compilation with big endian

### DIFF
--- a/net/gnunet/patches/010-endian.patch
+++ b/net/gnunet/patches/010-endian.patch
@@ -1,0 +1,18 @@
+--- a/src/include/gnunet_common.h
++++ b/src/include/gnunet_common.h
+@@ -142,7 +142,6 @@ enum GNUNET_GenericReturnValue
+  * Endian operations
+  */
+ 
+-#if __BYTE_ORDER == __LITTLE_ENDIAN
+ #if defined(__linux__)
+ #define BYTE_SWAP_16(x) __bswap_16 (x)
+ #define BYTE_SWAP_32(x) __bswap_32 (x)
+@@ -162,6 +161,7 @@ enum GNUNET_GenericReturnValue
+                                              56))
+ #endif
+ 
++#if __BYTE_ORDER == __LITTLE_ENDIAN
+ #define GNUNET_htobe16(x) BYTE_SWAP_16 (x)
+ #define GNUNET_htole16(x) (x)
+ #define GNUNET_be16toh(x) BYTE_SWAP_16 (x)

--- a/net/gnunet/patches/100-fix-opus-and-pulse-library-detection.patch
+++ b/net/gnunet/patches/100-fix-opus-and-pulse-library-detection.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -813,10 +813,12 @@ AC_ARG_WITH(libpulse,
+@@ -851,10 +851,12 @@ AC_ARG_WITH(libpulse,
              LDFLAGS="-L$with_libpulse/lib $LDFLAGS"
              CPPFLAGS="-I$with_libpulse/include $CPPFLAGS"
              AC_CHECK_HEADERS(pulse/simple.h,
@@ -17,7 +17,7 @@
          ])
      ],
      [AC_MSG_RESULT([--with-libpulse not specified])
-@@ -856,10 +858,12 @@ AC_ARG_WITH(libopus,
+@@ -894,10 +896,12 @@ AC_ARG_WITH(libopus,
          LDFLAGS="-L$with_libopus/lib $LDFLAGS"
          CPPFLAGS="-I$with_libopus/include $CPPFLAGS"
          AC_CHECK_HEADERS(opus/opus.h,


### PR DESCRIPTION
if is in the wrong spot.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: ath79