### PR TITLE
frr: fixes add pythontools and update to latest

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 PKG_NAME:=frr
 PKG_VERSION:=7.5.1
-PKG_RELEASE:=1
-PKG_SOURCE_DATE:=2021-03-25
+PKG_RELEASE:=2
+PKG_SOURCE_DATE:=2021-08-26
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_DATE).tar.gz
-PKG_SOURCE_VERSION:=18f209926fb659790926b82dd4e30727311d22aa
+PKG_SOURCE_VERSION:=4cc14d346bdedc81a52b2981f9f568176513dc3e
 PKG_SOURCE_URL:=https://codeload.github.com/FRRouting/frr/tar.gz/$(PKG_SOURCE_VERSION)?
 
 
-PKG_HASH:=a2e21ea5f5c73afda521280c7b1bab3e6734f78517e7cf1b86cbbc0e5f9856cc
+PKG_HASH:=dd0ec4616b85f5142c9e4ecc4a17b944000a3219bedf9d091484503e8c91e0e7
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
@@ -121,6 +121,12 @@ define Package/frr-zebra
   CONFLICTS:=quagga-zebra
 endef
 
+define Package/frr-pythontools
+  $(call Package/frr/Default)
+  TITLE:=Python reload tool
+  DEPENDS+=+frr-libfrr +python3-base +python3-light +python3-logging
+endef
+
 ##Migrate from quagga
 ##should test file exists and link in frr folder
 #define Package/frr/postinst
@@ -218,6 +224,13 @@ define Package/frr-libfrr/install
 	$(INSTALL_CONF) ./files/{frr.conf,daemons} $(1)/etc/frr/
 endef
 
+define Package/frr-pythontools/install
+	$(INSTALL_DIR) $(1)/usr/lib/frr $(1)/usr/sbin $(1)/etc/frr
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/*.py $(1)/usr/lib/frr/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/frr-reload $(1)/usr/sbin/
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/tools/etc/frr/support_bundle_commands.conf $(1)/etc/frr/
+endef
+
 define Package/frr-vtysh/install
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/etc/frr
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/vtysh $(1)/usr/bin/
@@ -227,6 +240,7 @@ endef
 $(eval $(call HostBuild))
 $(eval $(call BuildPackage,frr))
 $(eval $(call BuildPackage,frr-libfrr))
+$(eval $(call BuildPackage,frr-pythontools))
 $(eval $(call BuildPackage,frr-watchfrr))
 $(eval $(call BuildPackage,frr-zebra))
 $(eval $(call BuildPackage,frr-vtysh))

--- a/net/frr/files/frr
+++ b/net/frr/files/frr
@@ -28,14 +28,30 @@ start() {
 	daemon_start watchfrr
 }
 stop() {
+	all_daemon_list all_daemons
+	# Kill any currently monitored daemons that are no longer enabled.
+	# Traverse command line args in reverse order, bailing out when we hit
+	# an argument that is not a daemon. Otherwise, if it's not in the
+	# new daemon list, stop it.
+	watchfrr_pid=`pidof watchfrr`
+	for i in `tr '\0' '\n' < /proc/$watchfrr_pid/cmdline | sed -n '1!G;h;$p'`; do
+	in_list $i $all_daemons || break
+	in_list $i $daemons || daemon_stop $i
+	done
 	daemon_stop watchfrr
-	all_stop --reallyall
+#	all_stop --reallyall
 	exit ${still_running:-0}
 }
 
 restart() {
+	all_daemon_list all_daemons
+	watchfrr_pid=`pidof watchfrr`
+	for i in `tr '\0' '\n' < /proc/$watchfrr_pid/cmdline | sed -n '1!G;h;$p'`; do
+	in_list $i $all_daemons || break
+	in_list $i $daemons || daemon_stop $i
+	done
 	daemon_stop watchfrr
-	all_stop --reallyall
+#	all_stop --reallyall
 
 	daemon_list daemons
 	watchfrr_options="$watchfrr_options $daemons"
@@ -50,6 +66,7 @@ status() {
 }
 
 reload() {
+	RELOAD_SCRIPT="/usr/sbin/frr-reload"
 	if [ ! -x "$RELOAD_SCRIPT" ]; then
 		log_failure_msg "The frr-pythontools package is required for reload functionality."
 		exit 1

--- a/net/frr/files/frrcommon.sh
+++ b/net/frr/files/frrcommon.sh
@@ -125,6 +125,41 @@ daemon_list() {
 	[ -n "$dvar" ] && eval $dvar="\"$disabled\""
 }
 
+all_daemon_list() {
+	# note $1 specifies the name of a global variable to be set
+	local enabled evar daemon inst oldifs i
+	enabled=""
+	evar="$1"
+
+	for daemon in $DAEMONS; do
+		eval inst=\$${daemon}_instances
+		if [ -n "$inst" ]; then
+			oldifs="${IFS}"
+			IFS="${IFS},"
+			for i in $inst; do
+				enabled="$enabled $daemon-$i"
+			done
+			IFS="${oldifs}"
+		else
+		    enabled="$enabled $daemon"
+		fi
+	done
+
+	enabled="${enabled# }"
+	[ -z "$evar" ] && echo "$enabled"
+	[ -n "$evar" ] && eval $evar="\"$enabled\""
+}
+
+in_list() {
+	local item i
+	item="$1"
+	shift 1
+	for i in "$@"; do
+		[ "$item" = "$i" ] && return 0
+	done
+	return 1
+}
+
 #
 # individual daemon management
 #

--- a/net/frr/patches/049-clear_ip_ospf_process_and_neighbor.patch
+++ b/net/frr/patches/049-clear_ip_ospf_process_and_neighbor.patch
@@ -327,7 +327,7 @@ Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>
  }
  
  /* For OSPF area sort by area id. */
-@@ -839,14 +890,11 @@ static struct ospf_area *ospf_area_new(s
+@@ -826,14 +877,11 @@ static struct ospf_area *ospf_area_new(s
  	return new;
  }
  
@@ -343,7 +343,7 @@ Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>
  	LSDB_LOOP (ROUTER_LSDB(area), rn, lsa)
  		ospf_discard_from_db(area->ospf, area->lsdb, lsa);
  	LSDB_LOOP (NETWORK_LSDB(area), rn, lsa)
-@@ -864,6 +912,15 @@ static void ospf_area_free(struct ospf_a
+@@ -851,6 +899,15 @@ static void ospf_area_free(struct ospf_a
  		ospf_discard_from_db(area->ospf, area->lsdb, lsa);
  
  	ospf_lsdb_delete_all(area->lsdb);
@@ -361,9 +361,9 @@ Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>
  	ospf_lsa_unlock(&area->router_lsa_self);
 --- a/ospfd/ospfd.h
 +++ b/ospfd/ospfd.h
-@@ -523,7 +523,11 @@ extern struct ospf *ospf_lookup_by_inst_
- 					     const char *name);
+@@ -519,7 +519,11 @@ extern struct ospf *ospf_lookup_by_inst_
  extern struct ospf *ospf_lookup_by_vrf_id(vrf_id_t vrf_id);
+ extern uint32_t ospf_count_area_params(struct ospf *ospf);
  extern void ospf_finish(struct ospf *);
 +extern void ospf_process_refresh_data(struct ospf *ospf, bool reset);
  extern void ospf_router_id_update(struct ospf *ospf);
@@ -373,7 +373,7 @@ Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>
  extern int ospf_network_set(struct ospf *, struct prefix_ipv4 *, struct in_addr,
  			    int);
  extern int ospf_network_unset(struct ospf *, struct prefix_ipv4 *,
-@@ -548,6 +552,7 @@ extern int ospf_area_shortcut_set(struct
+@@ -544,6 +548,7 @@ extern int ospf_area_shortcut_set(struct
  extern int ospf_area_shortcut_unset(struct ospf *, struct ospf_area *);
  extern int ospf_timers_refresh_set(struct ospf *, int);
  extern int ospf_timers_refresh_unset(struct ospf *);

--- a/net/frr/patches/050-ospf_nbr_nbma_lookup_next.patch
+++ b/net/frr/patches/050-ospf_nbr_nbma_lookup_next.patch
@@ -56,7 +56,7 @@ Signed-off-by: Donald Sharp <sharpd@nvidia.com>
  
 --- a/ospfd/ospfd.c
 +++ b/ospfd/ospfd.c
-@@ -1932,35 +1932,6 @@ struct ospf_nbr_nbma *ospf_nbr_nbma_look
+@@ -1919,35 +1919,6 @@ struct ospf_nbr_nbma *ospf_nbr_nbma_look
  	return NULL;
  }
  
@@ -94,7 +94,7 @@ Signed-off-by: Donald Sharp <sharpd@nvidia.com>
  	struct ospf_nbr_nbma *nbr_nbma;
 --- a/ospfd/ospfd.h
 +++ b/ospfd/ospfd.h
-@@ -567,8 +567,6 @@ extern void ospf_terminate(void);
+@@ -563,8 +563,6 @@ extern void ospf_terminate(void);
  extern void ospf_nbr_nbma_if_update(struct ospf *, struct ospf_interface *);
  extern struct ospf_nbr_nbma *ospf_nbr_nbma_lookup(struct ospf *,
  						  struct in_addr);

--- a/net/frr/patches/051-ospfd_instance_fixes.patch
+++ b/net/frr/patches/051-ospfd_instance_fixes.patch
@@ -432,7 +432,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  }
  
  
-@@ -3324,11 +3330,11 @@ DEFUN (show_ip_ospf_instance,
+@@ -3326,11 +3332,11 @@ DEFUN (show_ip_ospf_instance,
  	json_object *json = NULL;
  
  	instance = strtoul(argv[idx_number]->arg, NULL, 10);
@@ -447,7 +447,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  		return CMD_SUCCESS;
  
  	if (uj)
-@@ -4014,11 +4020,11 @@ DEFUN (show_ip_ospf_instance_interface,
+@@ -4016,11 +4022,11 @@ DEFUN (show_ip_ospf_instance_interface,
  	json_object *json = NULL;
  
  	instance = strtoul(argv[idx_number]->arg, NULL, 10);
@@ -462,7 +462,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  		return CMD_SUCCESS;
  
  	if (uj)
-@@ -4407,11 +4413,11 @@ DEFUN (show_ip_ospf_instance_neighbor,
+@@ -4409,11 +4415,11 @@ DEFUN (show_ip_ospf_instance_neighbor,
  	int ret = CMD_SUCCESS;
  
  	instance = strtoul(argv[idx_number]->arg, NULL, 10);
@@ -477,7 +477,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  		return CMD_SUCCESS;
  
  	if (uj)
-@@ -4619,11 +4625,11 @@ DEFUN (show_ip_ospf_instance_neighbor_al
+@@ -4621,11 +4627,11 @@ DEFUN (show_ip_ospf_instance_neighbor_al
  	int ret = CMD_SUCCESS;
  
  	instance = strtoul(argv[idx_number]->arg, NULL, 10);
@@ -492,7 +492,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  		return CMD_SUCCESS;
  	if (uj)
  		json = json_object_new_object();
-@@ -4759,11 +4765,11 @@ DEFUN (show_ip_ospf_instance_neighbor_in
+@@ -4761,11 +4767,11 @@ DEFUN (show_ip_ospf_instance_neighbor_in
  		show_ip_ospf_neighbour_header(vty);
  
  	instance = strtoul(argv[idx_number]->arg, NULL, 10);
@@ -507,7 +507,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  		return CMD_SUCCESS;
  
  	if (!uj)
-@@ -5168,11 +5174,11 @@ DEFPY (show_ip_ospf_instance_neighbor_id
+@@ -5170,11 +5176,11 @@ DEFPY (show_ip_ospf_instance_neighbor_id
  {
  	struct ospf *ospf;
  
@@ -522,7 +522,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  		return CMD_SUCCESS;
  
  	return show_ip_ospf_neighbor_id_common(vty, ospf, &router_id, !!json,
-@@ -5341,11 +5347,11 @@ DEFUN (show_ip_ospf_instance_neighbor_de
+@@ -5343,11 +5349,11 @@ DEFUN (show_ip_ospf_instance_neighbor_de
  	int ret = CMD_SUCCESS;
  
  	instance = strtoul(argv[idx_number]->arg, NULL, 10);
@@ -537,7 +537,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  		return CMD_SUCCESS;
  
  	if (uj)
-@@ -5536,11 +5542,11 @@ DEFUN (show_ip_ospf_instance_neighbor_de
+@@ -5538,11 +5544,11 @@ DEFUN (show_ip_ospf_instance_neighbor_de
  	int ret = CMD_SUCCESS;
  
  	instance = strtoul(argv[idx_number]->arg, NULL, 10);
@@ -552,7 +552,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  		return CMD_SUCCESS;
  
  	if (uj)
-@@ -5668,11 +5674,11 @@ DEFUN (show_ip_ospf_instance_neighbor_in
+@@ -5670,11 +5676,11 @@ DEFUN (show_ip_ospf_instance_neighbor_in
  	bool uj = use_json(argc, argv);
  
  	instance = strtoul(argv[idx_number]->arg, NULL, 10);
@@ -567,7 +567,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  		return CMD_SUCCESS;
  
  	return show_ip_ospf_neighbor_int_detail_common(vty, ospf, idx_ifname,
-@@ -6418,10 +6424,11 @@ DEFUN (show_ip_ospf_instance_database,
+@@ -6420,10 +6426,11 @@ DEFUN (show_ip_ospf_instance_database,
  
  	if (argv_find(argv, argc, "(1-65535)", &idx)) {
  		instance = strtoul(argv[idx]->arg, NULL, 10);
@@ -582,7 +582,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  			return CMD_SUCCESS;
  
  		return (show_ip_ospf_database_common(vty, ospf, idx ? 1 : 0,
-@@ -6482,15 +6489,12 @@ DEFUN (show_ip_ospf_instance_database_ma
+@@ -6484,15 +6491,12 @@ DEFUN (show_ip_ospf_instance_database_ma
  	unsigned short instance = 0;
  
  	instance = strtoul(argv[idx_number]->arg, NULL, 10);
@@ -601,7 +601,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  
  	return show_ip_ospf_database_common(vty, ospf, 1, argc, argv, 0);
  }
-@@ -6576,13 +6580,12 @@ DEFUN (show_ip_ospf_instance_database_ty
+@@ -6578,13 +6582,12 @@ DEFUN (show_ip_ospf_instance_database_ty
  
  	if (argv_find(argv, argc, "(1-65535)", &idx)) {
  		instance = strtoul(argv[idx]->arg, NULL, 10);
@@ -619,7 +619,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  
  		return (show_ip_ospf_database_type_adv_router_common(
  			vty, ospf, idx ? 1 : 0, argc, argv, use_vrf));
-@@ -8033,7 +8036,7 @@ DEFUN (ip_ospf_area,
+@@ -8035,7 +8038,7 @@ DEFUN (ip_ospf_area,
  	else
  		ospf = ospf_lookup_instance(instance);
  
@@ -628,7 +628,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  		/*
  		 * At this point we know we have received
  		 * an instance and there is no ospf instance
-@@ -8158,7 +8161,7 @@ DEFUN (no_ip_ospf_area,
+@@ -8159,7 +8162,7 @@ DEFUN (no_ip_ospf_area,
  	else
  		ospf = ospf_lookup_instance(instance);
  
@@ -718,7 +718,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  extern struct zclient *zclient;
  
  
-@@ -468,36 +470,28 @@ static void ospf_init(struct ospf *ospf)
+@@ -438,36 +440,28 @@ static void ospf_init(struct ospf *ospf)
  	ospf_router_id_update(ospf);
  }
  
@@ -765,7 +765,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  		ospf_init(ospf);
 --- a/ospfd/ospfd.h
 +++ b/ospfd/ospfd.h
-@@ -507,6 +507,7 @@ struct ospf_nbr_nbma {
+@@ -502,6 +502,7 @@ struct ospf_nbr_nbma {
  
  /* Extern variables. */
  extern struct ospf_master *om;
@@ -773,7 +773,7 @@ Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>
  extern const int ospf_redistributed_proto_max;
  extern struct zclient *zclient;
  extern struct thread_master *master;
-@@ -516,9 +517,9 @@ extern struct zebra_privs_t ospfd_privs;
+@@ -511,9 +512,9 @@ extern struct zebra_privs_t ospfd_privs;
  /* Prototypes. */
  extern const char *ospf_redist_string(unsigned int route_type);
  extern struct ospf *ospf_lookup_instance(unsigned short);

--- a/net/frr/patches/052-nhrpd_support_for_multicast.patch
+++ b/net/frr/patches/052-nhrpd_support_for_multicast.patch
@@ -753,7 +753,7 @@ Signed-off-by: Reuben Dowle <reuben.dowle@4rf.com>
  		   N.B. Options 1 & 2 share basically the same logic. */
 --- a/ospfd/ospf_vty.c
 +++ b/ospfd/ospf_vty.c
-@@ -7560,20 +7560,21 @@ DEFUN_HIDDEN (no_ospf_hello_interval,
+@@ -7562,20 +7562,21 @@ DEFUN_HIDDEN (no_ospf_hello_interval,
  	return no_ip_ospf_hello_interval(self, vty, argc, argv);
  }
  
@@ -785,7 +785,7 @@ Signed-off-by: Reuben Dowle <reuben.dowle@4rf.com>
  	struct route_node *rn;
  
  	if (old_type == OSPF_IFTYPE_LOOPBACK) {
-@@ -7582,16 +7583,22 @@ DEFUN (ip_ospf_network,
+@@ -7584,16 +7585,22 @@ DEFUN (ip_ospf_network,
  		return CMD_WARNING_CONFIG_FAILED;
  	}
  
@@ -810,7 +810,7 @@ Signed-off-by: Reuben Dowle <reuben.dowle@4rf.com>
  		return CMD_SUCCESS;
  
  	SET_IF_PARAM(IF_DEF_PARAMS(ifp), type);
-@@ -7603,6 +7610,7 @@ DEFUN (ip_ospf_network,
+@@ -7605,6 +7612,7 @@ DEFUN (ip_ospf_network,
  			continue;
  
  		oi->type = IF_DEF_PARAMS(ifp)->type;
@@ -818,7 +818,7 @@ Signed-off-by: Reuben Dowle <reuben.dowle@4rf.com>
  
  		if (oi->state > ISM_Down) {
  			OSPF_ISM_EVENT_EXECUTE(oi, ISM_InterfaceDown);
-@@ -7643,6 +7651,7 @@ DEFUN (no_ip_ospf_network,
+@@ -7645,6 +7653,7 @@ DEFUN (no_ip_ospf_network,
  	struct route_node *rn;
  
  	IF_DEF_PARAMS(ifp)->type = ospf_default_iftype(ifp);
@@ -839,7 +839,7 @@ Signed-off-by: Reuben Dowle <reuben.dowle@4rf.com>
  							inet_ntoa(
 --- a/ospfd/ospfd.c
 +++ b/ospfd/ospfd.c
-@@ -1017,6 +1017,7 @@ static void add_ospf_interface(struct co
+@@ -1004,6 +1004,7 @@ static void add_ospf_interface(struct co
  	/* If network type is specified previously,
  	   skip network type setting. */
  	oi->type = IF_DEF_PARAMS(co->ifp)->type;

--- a/net/frr/patches/999-thread_reverse.patch
+++ b/net/frr/patches/999-thread_reverse.patch
@@ -1,0 +1,111 @@
+--- a/lib/thread.c
++++ b/lib/thread.c
+@@ -723,13 +723,9 @@ static void thread_free(struct thread_ma
+ 	XFREE(MTYPE_THREAD, thread);
+ }
+ 
+-static int fd_poll(struct thread_master *m, const struct timeval *timer_wait,
+-		   bool *eintr_p)
++static int fd_poll(struct thread_master *m, struct pollfd *pfds, nfds_t pfdsize,
++		   nfds_t count, const struct timeval *timer_wait)
+ {
+-	sigset_t origsigs;
+-	unsigned char trash[64];
+-	nfds_t count = m->handler.copycount;
+-
+ 	/*
+ 	 * If timer_wait is null here, that means poll() should block
+ 	 * indefinitely, unless the thread_master has overridden it by setting
+@@ -760,58 +756,15 @@ static int fd_poll(struct thread_master
+ 	rcu_assert_read_unlocked();
+ 
+ 	/* add poll pipe poker */
+-	assert(count + 1 < m->handler.pfdsize);
+-	m->handler.copy[count].fd = m->io_pipe[0];
+-	m->handler.copy[count].events = POLLIN;
+-	m->handler.copy[count].revents = 0x00;
+-
+-	/* We need to deal with a signal-handling race here: we
+-	 * don't want to miss a crucial signal, such as SIGTERM or SIGINT,
+-	 * that may arrive just before we enter poll(). We will block the
+-	 * key signals, then check whether any have arrived - if so, we return
+-	 * before calling poll(). If not, we'll re-enable the signals
+-	 * in the ppoll() call.
+-	 */
+-
+-	sigemptyset(&origsigs);
+-	if (m->handle_signals) {
+-		/* Main pthread that handles the app signals */
+-		if (frr_sigevent_check(&origsigs)) {
+-			/* Signal to process - restore signal mask and return */
+-			pthread_sigmask(SIG_SETMASK, &origsigs, NULL);
+-			num = -1;
+-			*eintr_p = true;
+-			goto done;
+-		}
+-	} else {
+-		/* Don't make any changes for the non-main pthreads */
+-		pthread_sigmask(SIG_SETMASK, NULL, &origsigs);
+-	}
+-
+-#if defined(HAVE_PPOLL)
+-	struct timespec ts, *tsp;
+-
+-	if (timeout >= 0) {
+-		ts.tv_sec = timeout / 1000;
+-		ts.tv_nsec = (timeout % 1000) * 1000000;
+-		tsp = &ts;
+-	} else
+-		tsp = NULL;
+-
+-	num = ppoll(m->handler.copy, count + 1, tsp, &origsigs);
+-	pthread_sigmask(SIG_SETMASK, &origsigs, NULL);
+-#else
+-	/* Not ideal - there is a race after we restore the signal mask */
+-	pthread_sigmask(SIG_SETMASK, &origsigs, NULL);
+-	num = poll(m->handler.copy, count + 1, timeout);
+-#endif
+-
+-done:
++	assert(count + 1 < pfdsize);
++	pfds[count].fd = m->io_pipe[0];
++	pfds[count].events = POLLIN;
++	pfds[count].revents = 0x00;
+ 
+-	if (num < 0 && errno == EINTR)
+-		*eintr_p = true;
++	num = poll(pfds, count + 1, timeout);
+ 
+-	if (num > 0 && m->handler.copy[count].revents != 0 && num--)
++	unsigned char trash[64];
++	if (num > 0 && pfds[count].revents != 0 && num--)
+ 		while (read(m->io_pipe[0], &trash, sizeof(trash)) > 0)
+ 			;
+ 
+@@ -1438,7 +1391,7 @@ struct thread *thread_fetch(struct threa
+ 	struct timeval zerotime = {0, 0};
+ 	struct timeval tv;
+ 	struct timeval *tw = NULL;
+-	bool eintr_p = false;
++
+ 	int num = 0;
+ 
+ 	do {
+@@ -1510,14 +1463,14 @@ struct thread *thread_fetch(struct threa
+ 
+ 		pthread_mutex_unlock(&m->mtx);
+ 		{
+-			eintr_p = false;
+-			num = fd_poll(m, tw, &eintr_p);
++			num = fd_poll(m, m->handler.copy, m->handler.pfdsize,
++				      m->handler.copycount, tw);
+ 		}
+ 		pthread_mutex_lock(&m->mtx);
+ 
+ 		/* Handle any errors received in poll() */
+ 		if (num < 0) {
+-			if (eintr_p) {
++			if (errno == EINTR) {
+ 				pthread_mutex_unlock(&m->mtx);
+ 				/* loop around to signal handler */
+ 				continue;


### PR DESCRIPTION
ospf running in instance mode will keep cpu to 100% revert offending commit
also added pythontools

if daemon is disabled in the file while running also close that daemon

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

Maintainer: me
Tested ramips

frr 8+ needs libelf-dev in host so without [1] I can't update to it, also libyang will need to be updated to 2+

1 - https://patchwork.ozlabs.org/project/openwrt/patch/d0bd2212-a002-0cf9-2625-82ff50a14d96@powerneth.ro/