### PR TITLE
dosfstools: fix AM_ICONV triggered build error

### DIFF
--- a/utils/dosfstools/Makefile
+++ b/utils/dosfstools/Makefile
@@ -22,7 +22,6 @@ PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:dosfstools_project:dosfstools
 
 PKG_INSTALL:=1
-PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk


### PR DESCRIPTION
The AM_ICONV macro produces a faulty Makefile unless iconv is
explicitly disabled:

 gcc -Wall -Wextra -Wno-sign-compare -Wno-missing-field-initializers \
  -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -O2 \
  -I/usr/local/src/openwrt/staging_dir/host/include \
  -L/usr/local/src/openwrt/staging_dir/host/lib \
  -o fsck.fat check.o file.o fsck.fat.o lfn.o boot.o common.o fat.o io.o \
  charconv.o @LIBICONV@
 gcc: error: LIBICONV@: No such file or directory
 make[4]: *** [Makefile:449: fsck.fat] Error 1

Signed-off-by: Bjørn Mork <bjorn@mork.no>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
