### PR TITLE
php8: update to 8.0.12

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.0.11
+PKG_VERSION:=8.0.12
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=e3e5f764ae57b31eb65244a45512f0b22d7bef05f2052b23989c053901552e16
+PKG_HASH:=a501017b3b0fd3023223ea25d98e87369b782f8a82310c4033d7ea6a989fea0a
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs

Description:

This fixes:
    - CVE-2021-21703

Signed-off-by: Michael Heimpold <mhei@heimpold.de>