### PR TITLE
[openwrt-21.02] yq: Update to 4.13.5

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.13.4
+PKG_VERSION:=4.13.5
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=5d18ce2b2877a42a9765fceb7617f5aae3e0bc4e9f44c3048f9c9928a19bf965
+PKG_HASH:=c0d637e7d7d5f370960af713e0f7e769e1b0876f71a844373d0307cbba68c4b2
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm27xx
Run tested: bcm2710 raspberrypi-3b

Description:
Bug fixes and performance improvements.
Release note: https://github.com/mikefarah/yq/releases/tag/v4.13.5
(cherry picked from commit 336577fe29f569d8a7455603ba92cdde14dde300)
