### PR TITLE
[openwrt-21.02] rclone: bring up packages

### DIFF
--- a/net/rclone-ng/Makefile
+++ b/net/rclone-ng/Makefile
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2020 Elon Huang <elonhhuang@gmail.com>
+# Copyright (C) 2021 ImmortalWrt.org
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rclone-ng
+PKG_VERSION:=0.5.0
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=RcloneNg-v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/ElonH/RcloneNg/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=0b4916ddd0bacb5b358dc8d36b64c30f4182c0ace3eb06cda94b6578c419dcd9
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILE:=LICENSE
+PKG_MAINTAINER:=Elon Huang <elonhhuang@gmail.com> \
+		Tianling Shen <cnsztl@immortalwrt.org>
+
+include $(INCLUDE_DIR)/package.mk
+
+TAR_CMD:=$(HOST_TAR) -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
+
+define Package/rclone-ng
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Cloud Manager
+  TITLE:=An angular web application for rclone
+  URL:=https://github.com/ElonH/RcloneNg
+  DEPENDS:=+rclone-config
+  PKGARCH:=all
+endef
+
+define Build/Compile
+endef
+
+define Package/rclone-ng/install
+	$(INSTALL_DIR) $(1)/www
+	$(CP) $(PKG_BUILD_DIR)/RcloneNg $(1)/www
+endef
+
+$(eval $(call BuildPackage,rclone-ng))

--- a/net/rclone-webui-react/Makefile
+++ b/net/rclone-webui-react/Makefile
@@ -1,0 +1,47 @@
+# SPDX-Identifier-License: GPL-3.0-or-later
+#
+# Copyright (C) 2019 Elon Huang <elonhhuang@gmail.com>
+# Copyright (C) 2021 ImmortalWrt.org
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rclone-webui-react
+PKG_VERSION:=2.0.5
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
+PKG_SOURCE_URL:=https://github.com/rclone/rclone-webui-react/releases/download/v$(PKG_VERSION)/currentbuild.zip?
+PKG_HASH:=afd6836ecc5c5a1161e25cb0633c1167eb5933bb5069545680d69fcba635f011
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILE:=LICENSE
+PKG_MAINTAINER:=Elon Huang <elonhhuang@gmail.com> \
+		Tianling Shen <cnsztl@immortalwrt.org>
+
+include $(INCLUDE_DIR)/package.mk
+
+UNZIP_CMD:=unzip -q -d $(PKG_BUILD_DIR) $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/rclone-webui-react
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Cloud Manager
+  TITLE:=A reactjs based web UI for rclone
+  URL:=https://github.com/rclone/rclone-webui-react
+  DEPENDS:=+rclone-config
+  PKGARCH:=all
+endef
+
+define Package/rclone-webui-react/description
+  A full fledged UI for the rclone cloud sync tool.
+endef
+
+define Build/Compile
+endef
+
+define Package/rclone-webui-react/install
+	$(INSTALL_DIR) $(1)/www/rclone-webui-react
+	$(CP) $(PKG_BUILD_DIR)/build/* $(1)/www/rclone-webui-react
+endef
+
+$(eval $(call BuildPackage,rclone-webui-react))

--- a/net/rclone/Makefile
+++ b/net/rclone/Makefile
@@ -1,0 +1,82 @@
+# SPDX-Identifier-License: GPL-3.0-or-later
+#
+# Copyright (C) 2019 Elon Huang <elonhhuang@gmail.com>
+# Copyright (C) 2021 ImmortalWrt.org
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rclone
+PKG_VERSION:=1.56.2
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/rclone/rclone/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=a5b0b7dfe17d9ec74e3a33415eec4331c61d800d8823621e61c6164e8f88c567
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILE:=LICENSE
+PKG_MAINTAINER:=Elon Huang <elonhhuang@gmail.com> \
+		Tianling Shen <cnsztl@immortalwrt.org>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/rclone/rclone
+GO_PKG_EXCLUDES:=test
+GO_PKG_LDFLAGS_X:= \
+	github.com/rclone/rclone/fs.Version=v$(PKG_VERSION) \
+	main.Version=v$(PKG_VERSION) \
+	main.BuildUser=openwrt \
+	main.BuildHost=openwrt
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/rclone/Default
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=File Transfer
+  TITLE:=rsync for cloud storage
+  URL:=https://rclone.org
+endef
+
+define Package/rclone
+  $(call Package/rclone/Default)
+  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle +fuse-utils
+  USERID:=rclone:rclone
+endef
+
+define Package/rclone-config
+  TITLE+= (Config Scripts)
+  DEPENDS:=+rclone
+endef
+
+define Package/rclone/description
+  Rclone ("rsync for cloud storage") is a command line program to sync
+  files and directories to and from different cloud storage providers.
+endef
+
+define Package/rclone-config/conffiles
+/etc/config/rclone
+endef
+
+# Disable CGO due to ld linker issue
+GO_PKG_TARGET_VARS:=$(filter-out CGO_ENABLED=%,$(GO_PKG_TARGET_VARS)) CGO_ENABLED=0
+
+define Package/rclone/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/rclone $(1)/usr/bin/
+endef
+
+define Package/rclone-config/install
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_CONF) $(CURDIR)/files/rclone.config $(1)/etc/config/rclone
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) $(CURDIR)/files/rclone.init $(1)/etc/init.d/rclone
+endef
+
+$(eval $(call GoBinPackage,rclone))
+$(eval $(call BuildPackage,rclone))
+$(eval $(call BuildPackage,rclone-config))

--- a/net/rclone/files/rclone.config
+++ b/net/rclone/files/rclone.config
@@ -1,0 +1,18 @@
+
+config global 'global'
+	option enabled '0'
+
+config conf 'config'
+	option config_path '/etc/rclone/rclone.conf'
+	option port '5572'
+	option username 'admin'
+	option password 'admin'
+	option addr_type 'lan'
+
+config proxy 'proxy'
+	option enabled '0'
+	option proxy_addr 'socks5://127.0.0.1:1080'
+
+config log 'log'
+	option path '/var/log/rclone/output'
+

--- a/net/rclone/files/rclone.init
+++ b/net/rclone/files/rclone.init
@@ -21,8 +21,8 @@ start_service() {
 	config_load "${CONFIGURATION}"
 
 	local enabled
-	config_get enabled global enabled
-	if [ "$enabled" = "1" ]; then
+	config_get_bool enabled global enabled
+	if [ "$enabled" -ne "1" ]; then
 		_info 'Instance "rclone" is disabled.'
 		return 1
 	else
@@ -43,7 +43,7 @@ start_service() {
 	config_get username config username
 	config_get password config password
 
-	config_get proxy_enable proxy enabled
+	config_get_bool proxy_enable proxy enabled
 	config_get proxy_addr proxy proxy_addr
 
 	if [ "${addr_type}" = "local" ]; then
@@ -56,12 +56,15 @@ start_service() {
 
 	local config_dir="${config_path%/*}"
 	[ -d "$config_dir" ] || mkdir -p "$config_dir"
+	touch "${config_path}"
+	chown rclone "${config_path}"
 
 	[ -d "/lib/upgrade/keep.d" ] || mkdir -p "/lib/upgrade/keep.d/"
 	echo "$config_path" > "/lib/upgrade/keep.d/luci-app-rclone"
 
 	local log_dir="${log_path%/*}"
 	[ -d "$log_dir" ] || mkdir -p "$log_dir"
+	chown -R rclone:rclone "$log_dir"
 
 	procd_open_instance
 
@@ -71,7 +74,7 @@ start_service() {
 	procd_append_param command "--config=$config_path"
 	procd_append_param command "--rc-allow-origin=*"
 	procd_append_param command "--log-file=${log_path}"
-	if [ "${proxy_enable}" = "1" ]; then
+	if [ "${proxy_enable}" -eq "1" ]; then
 		procd_set_param    env all_proxy="$proxy_addr" https_proxy="$proxy_addr" http_proxy="$proxy_addr"
 		procd_append_param env ALL_PROXY="$proxy_addr" HTTPS_PROXY="$proxy_addr" HTTP_PROXY="$proxy_addr"
 	fi

--- a/net/rclone/files/rclone.init
+++ b/net/rclone/files/rclone.init
@@ -1,0 +1,97 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2019 Elon Huang <elonhhuang@gmail.com>
+
+USE_PROCD=1
+
+START=95
+STOP=10
+
+APP="rclone"
+CONFIGURATION="rclone"
+
+_info() {
+	logger -p daemon.info -t "$APP" "$*"
+}
+
+_err() {
+	logger -p daemon.err -t "$APP" "$*"
+}
+
+start_service() {
+	config_load "${CONFIGURATION}"
+
+	local enabled
+	config_get enabled global enabled
+	if [ "$enabled" = "1" ]; then
+		_info 'Instance "rclone" is disabled.'
+		return 1
+	else
+		_info 'Instance "rclone" is starting.'
+	fi
+
+	local config_path log_path
+	local addr addr_type port
+	local username password
+	local proxy_enable proxy_addr
+
+	config_get config_path config config_path
+	config_get log_path log path
+
+	config_get addr_type config addr_type
+	config_get port config port
+
+	config_get username config username
+	config_get password config password
+
+	config_get proxy_enable proxy enabled
+	config_get proxy_addr proxy proxy_addr
+
+	if [ "${addr_type}" = "local" ]; then
+		addr="$(uci get network.loopback.ipaddr)"
+	elif [ "${addr_type}" = "lan" ]; then
+		addr="$(uci get network.lan.ipaddr)"
+	else
+		addr=""
+	fi
+
+	local config_dir="${config_path%/*}"
+	[ -d "$config_dir" ] || mkdir -p "$config_dir"
+
+	[ -d "/lib/upgrade/keep.d" ] || mkdir -p "/lib/upgrade/keep.d/"
+	echo "$config_path" > "/lib/upgrade/keep.d/luci-app-rclone"
+
+	local log_dir="${log_path%/*}"
+	[ -d "$log_dir" ] || mkdir -p "$log_dir"
+
+	procd_open_instance
+
+	procd_set_param command /usr/bin/$APP rcd -vv
+	procd_append_param command "--rc-addr=$addr:$port"
+	procd_append_param command "--rc-user=$username" "--rc-pass=$password"
+	procd_append_param command "--config=$config_path"
+	procd_append_param command "--rc-allow-origin=*"
+	procd_append_param command "--log-file=${log_path}"
+	if [ "${proxy_enable}" = "1" ]; then
+		procd_set_param    env all_proxy="$proxy_addr" https_proxy="$proxy_addr" http_proxy="$proxy_addr"
+		procd_append_param env ALL_PROXY="$proxy_addr" HTTPS_PROXY="$proxy_addr" HTTP_PROXY="$proxy_addr"
+	fi
+
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	# procd_set_param pidfile /var/run/rclone.pid
+	procd_set_param respawn
+
+	procd_set_param user rclone
+	procd_set_param group rclone
+
+	procd_close_instance
+}
+
+reload_service() {
+	stop
+	start
+}
+
+service_triggers() {
+	procd_add_reload_trigger "rclone"
+}

--- a/net/rclone/test.sh
+++ b/net/rclone/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rclone version | grep "$2"


### PR DESCRIPTION
Maintainer: @ElonH, me
Compile tested: bcm27xx/bcm2710
Run tested: RaspberryPi 3B

Description:
Rclone ("rsync for cloud storage") is a command line program to sync
files and directories to and from different cloud storage providers.

This is a backport for openwrt-21.02 based on PR #16871 #16894.

I got really positive feedback in https://forum.openwrt.org/t/getting-rclone-into-openwrt/108614,
however, I think it's worthy to have such a nice utility in stable release.

Ping @aparcar @BKPepe @jefferyto @neheb @PolynomialDivision