### PR TITLE
redis: update to version 6.2.6

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
-PKG_VERSION:=6.2.5
+PKG_VERSION:=6.2.6
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=4b9a75709a1b74b3785e20a6c158cab94cf52298aa381eea947a678a60d551ae
+PKG_HASH:=5b2b8b7a50111ef395bf1c1d5be11e6e167ac018125055daa8b5c2317ae131ab
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS7), OpenWrt master
Run tested: Turris Omnia (TOS7), OpenWrt master

Description:
This PR updates redis to version 6.2.6. It fixes multiple security issues [changelog](https://raw.githubusercontent.com/redis/redis/6.2/00-RELEASENOTES).

Upgrade urgency: **SECURITY**

CVE list:
- CVE-2021-41099
- CVE-2021-32762
- CVE-2021-32687
- CVE-2021-32675
- CVE-2021-32672
- CVE-2021-32628
- CVE-2021-32627
- CVE-2021-32626
