### PR TITLE
fuse-overlayfs: update to 1.7.1

### DIFF
--- a/utils/fuse-overlayfs/Makefile
+++ b/utils/fuse-overlayfs/Makefile
@@ -1,17 +1,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fuse-overlayfs
-PKG_VERSION:=1.5.0
+PKG_VERSION:=1.7.1
 PKG_RELEASE:=$(AUTORELEASE)
-
-PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
-
-PKG_LICENSE:=GPL-3.0-or-later
-PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containers/fuse-overlayfs/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6c81b65b71067b303aaa9871f512c2cabc23e2b793f19c6c854d01a492b5a923
+PKG_HASH:=fe2c076aed7b8669e7970301a99c0b197759b611035d8199de4c0add7d2fb2b4
+
+PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1

--- a/utils/fuse-overlayfs/patches/010-m4.patch
+++ b/utils/fuse-overlayfs/patches/010-m4.patch
@@ -1,0 +1,22 @@
+--- a/m4/stdint.m4
++++ b/m4/stdint.m4
+@@ -15,7 +15,7 @@ AC_DEFUN_ONCE([gl_STDINT_H],
+   AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
+ 
+   AC_REQUIRE([gl_LIMITS_H])
+-  AC_REQUIRE([gt_TYPE_WINT_T])
++  AC_REQUIRE([gt_TYPE_WINT_T_FO])
+ 
+   dnl Check for long long int and unsigned long long int.
+   AC_REQUIRE([AC_TYPE_LONG_LONG_INT])
+--- a/m4/wint_t.m4
++++ b/m4/wint_t.m4
+@@ -9,7 +9,7 @@ dnl Test whether <wchar.h> has the 'wint
+ dnl <wchar.h> or <wctype.h> would, if present, override 'wint_t'.
+ dnl Prerequisite: AC_PROG_CC
+ 
+-AC_DEFUN([gt_TYPE_WINT_T],
++AC_DEFUN([gt_TYPE_WINT_T_FO],
+ [
+   AC_CACHE_CHECK([for wint_t], [gt_cv_c_wint_t],
+     [AC_COMPILE_IFELSE(


### PR DESCRIPTION
Rearrange Makefile for consistency between packages.

Add m4 patch to fix compilation under some systems.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @flyn-org 
Compile tested: ath79 