### PR TITLE
dawn: set symm_enc default to 0

### DIFF
--- a/net/dawn/files/dawn.config
+++ b/net/dawn/files/dawn.config
@@ -6,7 +6,7 @@ config network
     option network_option       '2' # 0 udp broadcast, 1 multicast, 2 tcp
     option shared_key           'Niiiiiiiiiiiiick'
     option iv                   'Niiiiiiiiiiiiick'
-    option use_symm_enc         '1'
+    option use_symm_enc         '0'
     option collision_domain     '-1'     # enter here aps which are in the same collision domain
     option bandwidth            '-1'     # enter network bandwidth
 


### PR DESCRIPTION
User mpeleshenko reported that symm encryption breaks hearing map.
Set the default to 0.
