### PR TITLE
bind: detect new interfaces when they come up 

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -69,6 +69,7 @@ endef
 define Package/bind-server
   $(call Package/bind/Default)
   TITLE+= DNS server
+  DEPENDS+= libcap
 endef
 
 define Package/bind-server/config
@@ -135,7 +136,6 @@ export BUILD_CC="$(TARGET_CC)"
 TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
 CONFIGURE_ARGS += \
-	--disable-linux-caps \
 	--with-openssl="$(STAGING_DIR)/usr" \
 	--with-libtool \
 	--without-lmdb \


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile tested: x86_64, generic, HEAD (af56075a8f)
Run tested: same, running on production router

Description:

Here's the test data:

```
root@OpenWrt:~# pidof named
8243
root@OpenWrt:~# ifdown lan2
root@OpenWrt:~# pidof named
8243
root@OpenWrt:~# ifup lan2
root@OpenWrt:~# pidof named
9572
root@OpenWrt:~# 
```
