### PR TITLE
dnsproxy: Update to 0.39.9

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.39.8
+PKG_VERSION:=0.39.9
 PKG_RELEASE:=$(AUTORELESE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=99a6b0a1471507d6946ad9116218b6ea4054224f5d9d9faf901e77a500ba074e
+PKG_HASH:=837c39edd1e40b5ab25636765d4310f1f23d8c57a25ecf799bdc595d4bfb5dae
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: ipq807x, rockchip/armv8
Run tested: rk3328 nanopi-r2s

Description:
Release note: https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.39.9