### PR TITLE
stress-ng: bump to version 0.13.05

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.13.03
+PKG_VERSION:=0.13.05
 PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://kernel.ubuntu.com/~cking/tarballs/stress-ng
-PKG_HASH:=3e60d605e378d86a8591a30d6e557bed709d82a5b19616378002cd8ff0037a8b
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/ColinIanKing/stress-ng/tar.gz/refs/tags/V$(PKG_VERSION)?
+PKG_HASH:=3de49e1100866634f549e99c1644283d0cde817b844a69dcf7f80afa2227d350
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only
@@ -26,7 +26,7 @@ define Package/stress-ng
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=stress-ng is a stress test utility
-  URL:=https://kernel.ubuntu.com/~cking/stress-ng/
+  URL:=https://github.com/ColinIanKing/stress-ng
   DEPENDS:=+zlib +libbsd +libaio +libsctp +libkmod
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/333f93333ee52309ce664dcf78a84b79d50f9f48
Run tested: x86 https://github.com/openwrt/openwrt/commit/333f93333ee52309ce664dcf78a84b79d50f9f48


And switch to Github URLs.
The old one isn't working anymore.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>