### PR TITLE
[19.07] tvheadend: add patch to update libhdhomerun

### DIFF
--- a/multimedia/tvheadend/Makefile
+++ b/multimedia/tvheadend/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tvheadend
 PKG_VERSION:=4.0.10
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tvheadend/tvheadend/tar.gz/v$(PKG_VERSION)?

--- a/multimedia/tvheadend/patches/100-libhdhomerun-upgrade-to-20180817.patch
+++ b/multimedia/tvheadend/patches/100-libhdhomerun-upgrade-to-20180817.patch
@@ -1,0 +1,35 @@
+From fa245accd43adfbafbd60aea74fb1fc87b551b1a Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Wed, 27 Oct 2021 13:46:14 +0200
+Subject: [PATCH] libhdhomerun: upgrade to 20180817
+
+This version of libhdhomerun was tested in tvheadend master and works
+with version 4.2 (there was submitted PR by me, but still not accepted)
+
+I dont have any plans to submit this against ancient version of
+tvheadend (4.0), feel free to send this to upstream.
+---
+ Makefile.hdhomerun | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile.hdhomerun b/Makefile.hdhomerun
+index 943ffec24..c5d9dd41f 100644
+--- a/Makefile.hdhomerun
++++ b/Makefile.hdhomerun
+@@ -49,10 +49,10 @@ LIBHDHRDIR = $(ROOTDIR)/libhdhomerun_static
+ 
+ export PATH := $(LIBHDHRDIR)/build/bin:$(PATH)
+ 
+-LIBHDHR         = libhdhomerun_20150826
++LIBHDHR         = libhdhomerun_20180817
+ LIBHDHR_TB      = $(LIBHDHR).tgz
+-LIBHDHR_URL     = http://download.silicondust.com/hdhomerun/$(LIBHDHR_TB)
+-LIBHDHR_SHA1    = 24ce6003b1e815ec4c642d180b621c1d524ca1cf
++LIBHDHR_URL     = https://download.silicondust.com/hdhomerun/$(LIBHDHR_TB)
++LIBHDHR_SHA1    = 052868bde3a5713c55b4d060b77e0bc3a0d891d6
+ 
+ .PHONY: build
+ build: $(LIBHDHRDIR)/$(LIBHDHR)/.tvh_build
+-- 
+2.30.2
+


### PR DESCRIPTION
Maintainer: none
Compile tested: Turris Omnia, mvebu (cortex-a9), latest branch - OpenWrt 19.07
Run tested: N/A

Description:

- Fixes:  https://downloads.openwrt.org/releases/faillogs-19.07/aarch64_cortex-a53/packages/tvheadend/compile.txt

Snip:
```
/builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/tvheadend-4.0.10/build.linux/src/input/mpegts/satip/satip_rtsp.o src/input/mpegts/satip/satip_rtsp.c
cc1: note: someone does not honour COPTS correctly, passed 2 times
aarch64-openwrt-linux-musl-gcc -MD -MP -Os -pipe -mcpu=cortex-a53 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -iremap/builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/tvheadend-4.0.10:tvheadend-4.0.10 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -I/builder/shared-workdir/build/sdk/staging_dir/target-aarch64_cortex-a53_musl/usr/lib/libiconv-stub/include -I/builder/shared-workdir/build/sdk/staging_dir/target-aarch64_cortex-a53_musl/usr/lib/libintl-stub/include  -I/builder/shared-workdir/build/sdk/staging_dir/target-aarch64_cortex-a53_musl/usr/include -I/builder/shared-workdir/build/sdk/staging_dir/target-aarch64_cortex-a53_musl/include -I/builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.5.0_musl/usr/include -I/builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.5.0_musl/include/fortify -I/builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.5.0_musl/include -I/builder/shared-workdir/build/sdk/staging_dir/target-aarch64_cortex-a53_musl/usr/lib/libiconv-stub/include -I/builder/shared-workdir/build/sdk/staging_dir/target-aarch64_cortex-a53_musl/usr/lib/libintl-stub/include  -Os -pipe -mcpu=cortex-a53 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -iremap/builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/tvheadend-4.0.10:tvheadend-4.0.10 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -I/builder/shared-workdir/build/sdk/staging_dir/target-aarch64_cortex-a53_musl/usr/lib/libiconv-stub/include -I/builder/shared-workdir/build/sdk/staging_dir/target-aarch64_cortex-a53_musl/usr/lib/libintl-stub/include  -I/builder/shared-workdir/build/sdk/staging_dir/target-aarch64_cortex-a53_musl/usr/include -I/builder/shared-workdir/build/sdk/staging_dir/target-aarch64_cortex-a53_musl/usr/include -g -O2 -Wunused-result -Wmissing-prototypes -fms-extensions -funsigned-char -fno-strict-aliasing -D_FILE_OFFSET_BITS=64 -I/builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/tvheadend-4.0.10/build.linux -I/builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/tvheadend-4.0.10/src -I/builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/tvheadend-4.0.10 -I/builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/tvheadend-4.0.10/libhdhomerun_static -c -o /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/tvheadend-4.0.10/build.linux/src/input/mpegts/tvhdhomerun/tvhdhomerun.o src/input/mpegts/tvhdhomerun/tvhdhomerun.c
cc1: note: someone does not honour COPTS correctly, passed 2 times
In file included from src/input/mpegts/tvhdhomerun/tvhdhomerun.c:25:0:
src/input/mpegts/tvhdhomerun/tvhdhomerun_private.h:27:10: fatal error: libhdhomerun/hdhomerun.h: No such file or directory
 #include <libhdhomerun/hdhomerun.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[4]: *** [Makefile:442: /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/tvheadend-4.0.10/build.linux/src/input/mpegts/tvhdhomerun/tvhdhomerun.o] Error 1
make[4]: Leaving directory '/builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/tvheadend-4.0.10'
make[3]: *** [Makefile:98: /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/tvheadend-4.0.10/.built] Error 2
time: package/feeds/packages/tvheadend/compile#71.18#8.80#85.41
```
