### PR TITLE
ffmpeg: update to version 3.4.9 (security fix)

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
-PKG_VERSION:=3.4.7
-PKG_RELEASE:=3
+PKG_VERSION:=3.4.9
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
-PKG_HASH:=efd01782fd29b62505c973f5b61a65632d7b435dc9f4a6c97e92e6afd36cf5c8
+PKG_HASH:=496fb4a9c396406e24841f3f3f108a7ae6397d6d1106ac1f953317c4529b1635
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Ian Leonard <antonlacon@gmail.com>
 

--- a/multimedia/ffmpeg/patches/010-pkgconfig.patch
+++ b/multimedia/ffmpeg/patches/010-pkgconfig.patch
@@ -1,6 +1,6 @@
 --- a/ffbuild/pkgconfig_generate.sh
 +++ b/ffbuild/pkgconfig_generate.sh
-@@ -28,9 +28,9 @@ version=$(grep ${name}_VERSION= $name/${name}.version | cut -d= -f2)
+@@ -28,9 +28,9 @@ version=$(grep ${name}_VERSION= $name/${
  
  cat <<EOF > $name/$fullname.pc
  prefix=$prefix

--- a/multimedia/ffmpeg/patches/020-ffmpeg-fix-build-with-fdk-aac-2.0.patch
+++ b/multimedia/ffmpeg/patches/020-ffmpeg-fix-build-with-fdk-aac-2.0.patch
@@ -17,8 +17,6 @@ Signed-off-by: Martin Storsjö <martin@martin.st>
  libavcodec/libfdk-aacenc.c | 34 +++++++++++++++++++++++++---------
  1 file changed, 25 insertions(+), 9 deletions(-)
 
-diff --git a/libavcodec/libfdk-aacenc.c b/libavcodec/libfdk-aacenc.c
-index c340a1e3e0c..2ad768ed44e 100644
 --- a/libavcodec/libfdk-aacenc.c
 +++ b/libavcodec/libfdk-aacenc.c
 @@ -26,6 +26,11 @@
@@ -33,7 +31,7 @@ index c340a1e3e0c..2ad768ed44e 100644
  typedef struct AACContext {
      const AVClass *class;
      HANDLE_AACENCODER handle;
-@@ -286,7 +291,11 @@ static av_cold int aac_encode_init(AVCodecContext *avctx)
+@@ -286,7 +291,11 @@ static av_cold int aac_encode_init(AVCod
      }
  
      avctx->frame_size = info.frameLength;
@@ -45,7 +43,7 @@ index c340a1e3e0c..2ad768ed44e 100644
      ff_af_queue_init(avctx, &s->afq);
  
      if (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER) {
-@@ -319,28 +328,35 @@ static int aac_encode_frame(AVCodecContext *avctx, AVPacket *avpkt,
+@@ -319,28 +328,35 @@ static int aac_encode_frame(AVCodecConte
      int out_buffer_size, out_buffer_element_size;
      void *in_ptr, *out_ptr;
      int ret;
@@ -64,15 +62,16 @@ index c340a1e3e0c..2ad768ed44e 100644
 -        in_ptr                   = frame->data[0];
 -        in_buffer_size           = 2 * avctx->channels * frame->nb_samples;
 -        in_buffer_element_size   = 2;
-+        in_ptr               = frame->data[0];
-+        in_buffer_size       = 2 * avctx->channels * frame->nb_samples;
- 
+-
 -        in_args.numInSamples     = avctx->channels * frame->nb_samples;
 -        in_buf.numBufs           = 1;
 -        in_buf.bufs              = &in_ptr;
 -        in_buf.bufferIdentifiers = &in_buffer_identifier;
 -        in_buf.bufSizes          = &in_buffer_size;
 -        in_buf.bufElSizes        = &in_buffer_element_size;
++        in_ptr               = frame->data[0];
++        in_buffer_size       = 2 * avctx->channels * frame->nb_samples;
++
 +        in_args.numInSamples = avctx->channels * frame->nb_samples;
  
          /* add current frame to the queue */

--- a/multimedia/ffmpeg/patches/030-fdkaac-version.patch
+++ b/multimedia/ffmpeg/patches/030-fdkaac-version.patch
@@ -19,8 +19,6 @@ Signed-off-by: Martin Storsjö <martin@martin.st>
  libavcodec/libfdk-aacenc.c |  6 +++---
  2 files changed, 11 insertions(+), 8 deletions(-)
 
-diff --git a/libavcodec/libfdk-aacdec.c b/libavcodec/libfdk-aacdec.c
-index 3be65155b5f..c3d3b70fc93 100644
 --- a/libavcodec/libfdk-aacdec.c
 +++ b/libavcodec/libfdk-aacdec.c
 @@ -25,9 +25,12 @@
@@ -39,7 +37,7 @@ index 3be65155b5f..c3d3b70fc93 100644
  #define AAC_PCM_MAX_OUTPUT_CHANNELS AAC_PCM_OUTPUT_CHANNELS
  #endif
  
-@@ -72,7 +75,7 @@ static const AVOption fdk_aac_dec_options[] = {
+@@ -72,7 +75,7 @@ static const AVOption fdk_aac_dec_option
                       OFFSET(drc_level),      AV_OPT_TYPE_INT,   { .i64 = -1},  -1, 127, AD, NULL    },
      { "drc_heavy", "Dynamic Range Control: heavy compression, where [1] is on (RF mode) and [0] is off",
                       OFFSET(drc_heavy),      AV_OPT_TYPE_INT,   { .i64 = -1},  -1, 1,   AD, NULL    },
@@ -48,7 +46,7 @@ index 3be65155b5f..c3d3b70fc93 100644
      { "level_limit", "Signal level limiting", OFFSET(level_limit), AV_OPT_TYPE_INT, { .i64 = 0 }, -1, 1, AD },
  #endif
      { NULL }
-@@ -293,7 +296,7 @@ static av_cold int fdk_aac_decode_init(AVCodecContext *avctx)
+@@ -293,7 +296,7 @@ static av_cold int fdk_aac_decode_init(A
          }
      }
  
@@ -57,11 +55,9 @@ index 3be65155b5f..c3d3b70fc93 100644
      if (aacDecoder_SetParam(s->handle, AAC_PCM_LIMITER_ENABLE, s->level_limit) != AAC_DEC_OK) {
          av_log(avctx, AV_LOG_ERROR, "Unable to set in signal level limiting in the decoder\n");
          return AVERROR_UNKNOWN;
-diff --git a/libavcodec/libfdk-aacenc.c b/libavcodec/libfdk-aacenc.c
-index 2ad768ed44e..92ad1762aea 100644
 --- a/libavcodec/libfdk-aacenc.c
 +++ b/libavcodec/libfdk-aacenc.c
-@@ -156,7 +156,7 @@ static av_cold int aac_encode_init(AVCodecContext *avctx)
+@@ -156,7 +156,7 @@ static av_cold int aac_encode_init(AVCod
      case 6: mode = MODE_1_2_2_1; sce = 2; cpe = 2; break;
  /* The version macro is introduced the same time as the 7.1 support, so this
     should suffice. */
@@ -70,7 +66,7 @@ index 2ad768ed44e..92ad1762aea 100644
      case 8:
          sce = 2;
          cpe = 3;
-@@ -291,7 +291,7 @@ static av_cold int aac_encode_init(AVCodecContext *avctx)
+@@ -291,7 +291,7 @@ static av_cold int aac_encode_init(AVCod
      }
  
      avctx->frame_size = info.frameLength;
@@ -79,7 +75,7 @@ index 2ad768ed44e..92ad1762aea 100644
      avctx->initial_padding = info.nDelay;
  #else
      avctx->initial_padding = info.encoderDelay;
-@@ -412,7 +412,7 @@ static const uint64_t aac_channel_layout[] = {
+@@ -412,7 +412,7 @@ static const uint64_t aac_channel_layout
      AV_CH_LAYOUT_4POINT0,
      AV_CH_LAYOUT_5POINT0_BACK,
      AV_CH_LAYOUT_5POINT1_BACK,

--- a/multimedia/ffmpeg/patches/040-fdkaac-eld.patch
+++ b/multimedia/ffmpeg/patches/040-fdkaac-eld.patch
@@ -13,8 +13,6 @@ Signed-off-by: Martin Storsjö <martin@martin.st>
  libavcodec/libfdk-aacenc.c | 27 ++++++++++++++++++++++++++-
  1 file changed, 26 insertions(+), 1 deletion(-)
 
-diff --git a/libavcodec/libfdk-aacenc.c b/libavcodec/libfdk-aacenc.c
-index 92ad1762aea..f71a276403e 100644
 --- a/libavcodec/libfdk-aacenc.c
 +++ b/libavcodec/libfdk-aacenc.c
 @@ -36,6 +36,7 @@ typedef struct AACContext {
@@ -35,7 +33,7 @@ index 92ad1762aea..f71a276403e 100644
      { "signaling", "SBR/PS signaling style", offsetof(AACContext, signaling), AV_OPT_TYPE_INT, { .i64 = -1 }, -1, 2, AV_OPT_FLAG_AUDIO_PARAM | AV_OPT_FLAG_ENCODING_PARAM, "signaling" },
      { "default", "Choose signaling implicitly (explicit hierarchical by default, implicit if global header is disabled)", 0, AV_OPT_TYPE_CONST, { .i64 = -1 }, 0, 0, AV_OPT_FLAG_AUDIO_PARAM | AV_OPT_FLAG_ENCODING_PARAM, "signaling" },
      { "implicit", "Implicit backwards compatible signaling", 0, AV_OPT_TYPE_CONST, { .i64 = 0 }, 0, 0, AV_OPT_FLAG_AUDIO_PARAM | AV_OPT_FLAG_ENCODING_PARAM, "signaling" },
-@@ -149,7 +153,28 @@ static av_cold int aac_encode_init(AVCodecContext *avctx)
+@@ -149,7 +153,28 @@ static av_cold int aac_encode_init(AVCod
  
      switch (avctx->channels) {
      case 1: mode = MODE_1;       sce = 1; cpe = 0; break;

--- a/multimedia/ffmpeg/patches/050-fdkaac-define.patch
+++ b/multimedia/ffmpeg/patches/050-fdkaac-define.patch
@@ -19,8 +19,6 @@ Signed-off-by: Martin Storsjö <martin@martin.st>
  libavcodec/libfdk-aacenc.c | 9 ++++++---
  2 files changed, 12 insertions(+), 6 deletions(-)
 
-diff --git a/libavcodec/libfdk-aacdec.c b/libavcodec/libfdk-aacdec.c
-index ca70a49ad46..63856232d9e 100644
 --- a/libavcodec/libfdk-aacdec.c
 +++ b/libavcodec/libfdk-aacdec.c
 @@ -25,10 +25,13 @@
@@ -40,8 +38,6 @@ index ca70a49ad46..63856232d9e 100644
  
  #if !FDKDEC_VER_AT_LEAST(2, 5) // < 2.5.10
  #define AAC_PCM_MAX_OUTPUT_CHANNELS AAC_PCM_OUTPUT_CHANNELS
-diff --git a/libavcodec/libfdk-aacenc.c b/libavcodec/libfdk-aacenc.c
-index f71a276403e..3b492ef8f48 100644
 --- a/libavcodec/libfdk-aacenc.c
 +++ b/libavcodec/libfdk-aacenc.c
 @@ -26,10 +26,13 @@


### PR DESCRIPTION
Maintainer: @antonlacon @thess
Compile tested: Turris Omnia, mvebu (cortex-a9), latest branch - OpenWrt 19.07
Run tested: N/A

Description:
- Fixes:
CVE-2020-13904
CVE-2020-2044
CVE-2020-20453
CVE-2020-22015
CVE-2020-22019
CVE-2020-22033
CVE-2020-22021
CVE-2020-22037
CVE-2020-35965
CVE-2021-38114
CVE-2021-38171
CVE-2021-38291

- Refresh patches