### PR TITLE
bind: deprecate managed-keys

### DIFF
--- a/net/bind/files/bind/bind.keys
+++ b/net/bind/files/bind/bind.keys
@@ -19,7 +19,7 @@
 # replace this file with a current version.  The latest version of
 # bind.keys can always be obtained from ISC at https://www.isc.org/bind-keys.
 
-managed-keys {
+trust-anchors {
         # ISC DLV: See https://www.isc.org/solutions/dlv for details.
         #
         # NOTE: The ISC DLV zone is being phased out as of February 2017;


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile tested: x86_64, generic, HEAD (af56075a8f)
Run tested: same, installed on production firewall

Description:

Now when I start `named`, I no longer see this annoying message:

```
Oct 27 21:29:34 OpenWrt named[22207]: /etc/bind/bind.keys:22: option 'managed-keys' is deprecated
```
