### PR TITLE
uwsgi: bump version and use less workarounds

### DIFF
--- a/net/uwsgi/Makefile
+++ b/net/uwsgi/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uwsgi
-PKG_VERSION:=2.0.19.1
+PKG_VERSION:=2.0.20
 PKG_RELEASE:=1
 
-PYPI_NAME:=uWSGI
-PKG_HASH:=faa85e053c0b1be4d5585b0858d3a511d2cd10201802e8676060fd0a109e5869
+PYPI_NAME:=uwsgi
+PKG_HASH:=88ab9867d8973d8ae84719cf233b7dafc54326fcaec89683c3f9f77c002cdff9
 PKG_BUILD_DEPENDS:=python3/host
 PYTHON3_PKG_BUILD:=0
 
@@ -18,9 +18,6 @@ include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
 #for LINUX_UNAME_VERSION:
 include $(INCLUDE_DIR)/kernel.mk
-
-#the .tar.gz does not wrap it into a uWSGI dir; do not use "$(1)/..":
-TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 
 define Package/uwsgi
   SECTION:=net

--- a/net/uwsgi/patches/001-dont-hardcode-zlib.patch
+++ b/net/uwsgi/patches/001-dont-hardcode-zlib.patch
@@ -1,6 +1,6 @@
 --- a/uwsgiconfig.py
 +++ b/uwsgiconfig.py
-@@ -856,11 +856,11 @@ class uConf(object):
+@@ -859,11 +859,11 @@ class uConf(object):
                  self.cflags.append('-DUWSGI_HAS_EXECINFO')
                  report['execinfo'] = True
  

--- a/net/uwsgi/patches/002-dont-override-toolchain-optimization.patch
+++ b/net/uwsgi/patches/002-dont-override-toolchain-optimization.patch
@@ -1,6 +1,6 @@
 --- a/uwsgiconfig.py
 +++ b/uwsgiconfig.py
-@@ -685,7 +685,7 @@ class uConf(object):
+@@ -688,7 +688,7 @@ class uConf(object):
              self.include_path += os.environ['UWSGI_INCLUDES'].split(',')
  
  

--- a/net/uwsgi/patches/003-hard-code-Linux-as-compilation-os.patch
+++ b/net/uwsgi/patches/003-hard-code-Linux-as-compilation-os.patch
@@ -1,6 +1,6 @@
 --- a/uwsgiconfig.py
 +++ b/uwsgiconfig.py
-@@ -5,9 +5,9 @@ uwsgi_version = '2.0.19.1'
+@@ -5,9 +5,9 @@ uwsgi_version = '2.0.20'
  import os
  import re
  import time

--- a/net/uwsgi/patches/020-uwsgiconfig-system-python3.patch
+++ b/net/uwsgi/patches/020-uwsgiconfig-system-python3.patch
@@ -1,8 +1,0 @@
---- a/Makefile
-+++ b/Makefile
-@@ -1,4 +1,4 @@
--PYTHON := python
-+PYTHON ?= python3
- 
- all:
- 	$(PYTHON) uwsgiconfig.py --build $(PROFILE)


### PR DESCRIPTION
Maintainer: @Ansuel 
Compile tested: x86_64, master
Run tested: x86_64, master, run etebase

Description: Update to the newest version adopting pypi name and line numbers in patches and removing custom tar command and patch for using python3 (as it changed upstream).
