### PR TITLE
ntfs-3g: update config's help syntax

### DIFF
--- a/utils/ntfs-3g/Makefile
+++ b/utils/ntfs-3g/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntfs-3g
 PKG_VERSION:=2021.8.22
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)_ntfsprogs-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://www.tuxera.com/opensource/
@@ -61,7 +61,7 @@ define Package/ntfs-3g/config
 config PACKAGE_NTFS-3G_USE_LIBFUSE
 	bool "use external FUSE library, selects package libfuse"
 	depends on PACKAGE_ntfs-3g
-	---help---
+	help
 	Ntfs-3g by default uses a minimalized lite version of FUSE.
 	If libfuse is part of your filesystem anyway (because of sshfs, owfs
 	etc.) it makes sense to activate this option and save some kilobytes


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: `make menuconfig` tested, with current kconfig-v5.6, and with kconfig-v5.14.  This should be trivial enough
Run tested: N/A

Description:
Change ---help--- to plain 'help' in Package/ntfs-3g/config, as newer versions of kconfig have removed the command's older name.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
