### PR TITLE
bind: Bump to 9.16.22

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.16.21
+PKG_VERSION:=9.16.22
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=65da5fd4fb80b7d0d7452876f81fd6d67cdcee54a5e3c1d65610334665dfa815
+PKG_HASH:=65e7b2af6479db346e2fc99bcfb6ec3240066468e09dbec575ebc7c57d994061
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
The following CVEs are addressed:

* CVE-2021-25219: The "lame-ttl" option is now forcibly set to 0. This
  effectively disables the lame server cache, as it could previously
  be abused by an attacker to significantly degrade resolver performance.

Signed-off-by: Noah Meyerhans <frodo@morgul.net>

Maintainer: me 
Compile tested: OpenWRT 19.07 mipsel_24kc (malta)
Run tested: OpenWRT 19.07 mipsel_24kc (malta), basic authoritative and recursive functionality

Description: Update to the latest 9.16.x release for CVE-2021-25219 fixes
