### PR TITLE
bind: Bump to 9.17.19

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.17.13
+PKG_VERSION:=9.17.19
 PKG_RELEASE:=$(AUTORELEASE)
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=bf485ac49715d43fa65c2c6e33271aab965bcd1b461fe2ac9f439754a210e6c7
+PKG_HASH:=6cddd714f01b71bb0265fde445be781d1a0ee5e909b9645407893596111d228d
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
The following CVE updates are included:

* CVE-2021-25219: The "lame-ttl" option is now forcibly set to 0. This
  effectively disables the lame server cache, as it could previously be
  abused by an attacker to significantly degrade resolver performance.

* CVE-2021-25218: An assertion failure occurred when named attempted
  to send a UDP packet that exceeded the MTU size, if Response Rate
  Limiting (RRL) was enabled.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
Signed-off-by: Noah Meyerhans <frodo@morgul.net>

(cherry-picked from commit c2de702cbdb0034a84550589195fe95df25572b9)

Maintainer: me
Compile tested: x86_64 (qemu) r16327-a77ea2f05f
Run tested: x86_64. Basic recursive and authoritative functionality

Description: Update to the latest bind 9.17.x release to pick up CVE fixes. 
