### PR TITLE
bind: Bump to version 9.11.36

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.11.19
+PKG_VERSION:=9.11.36
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -21,7 +21,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=0dee554a4caa368948b32da9a0c97b516c19103bc13ff5b3762c5d8552f52329
+PKG_HASH:=c953fcb6703b395aaa53e65ff8b2869b69a5303dd60507cba2201305e1811681
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
The following security issues are addressed with this change:

CVE-2020-8619
CVE-2020-8622
CVE-2020-8623
CVE-2020-8624
CVE-2020-8625
CVE-2021-25214
CVE-2021-25215
CVE-2021-25216
CVE-2021-25219

A complete description of the changes with this BIND release is
available in the release notes at
https://ftp.isc.org/isc/bind9/9.11.36/RELEASE-NOTES-bind-9.11.36.html

Signed-off-by: Noah Meyerhans <frodo@morgul.net>

Maintainer: me 
Compile tested: x86 (qemu) OpenWrt 18.06-SNAPSHOT r8080-9f2a40c72f
Run tested: same

Description: Update to the latest bind 9.11 release 
