### PR TITLE
openvswitch: bring up member ports

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -17,7 +17,7 @@ include ./openvswitch.mk
 #
 PKG_NAME:=openvswitch
 PKG_VERSION:=$(ovs_version)
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openvswitch.org/releases/
 PKG_HASH:=7d5797f2bf2449c6a266149e88f72123540f7fe7f31ad52902057ae8d8f88c38

--- a/net/openvswitch/files/openvswitch.init
+++ b/net/openvswitch/files/openvswitch.init
@@ -121,6 +121,7 @@ ovs_bridge_port_add() {
 	}
 
 	ovs-vsctl --may-exist add-port "$name" "$port" ${type:+ -- set interface "$port" type="$type"}
+	ovs_bridge_port_up "$port"
 	__port_list="$__port_list ${port} "
 }
 
@@ -162,6 +163,7 @@ ovs_bridge_port_add_complex() {
 	ovs-vsctl --may-exist add-port "$bridge" "$port" ${tag:+tag="$tag"} \
 		${ofport:+ -- set interface "$port" ofport_request="$ofport"} \
 		${type:+ -- set interface "$port" type="$type"}
+	ovs_bridge_port_up "$port"
 	__port_list="$__port_list ${port} "
 }
 
@@ -172,6 +174,12 @@ ovs_bridge_port_cleanup() {
 			*) ovs-vsctl del-port "$port";;
 		esac
 	done
+}
+
+ovs_bridge_port_up() {
+	local port="$1"
+
+	ip link set dev "$port" up
 }
 
 ovs_bridge_validate_datapath_id() {


### PR DESCRIPTION
Maintainer: @yousong 
Compile tested: NA
Run tested: OpenWrt 21.02-SNAPSHOT, r16273

Description:
Open vSwitch does not bring up ports automatically. This is not a
problem for wireless ports, or for ports configured in
/etc/config/network, but other ports will be down, and require manual
interaction to be brought up. Configuring them with proto none will
cause netifd to do some actions on them, which might cause undefined
results, and will also bloat the UCI config file.

The cleanest solution is to bring all member ports up as part of the
init script.