### PR TITLE
nfs-kernel-server: move hardcoded /run to /tmp/run

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
 PKG_VERSION:=2.5.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_HASH:=546ce4b51eeebc66e354b6cc6ca0ce509437efbdef0caaf99389534eef0e598b
 
 PKG_SOURCE_URL:=@SF/nfs

--- a/net/nfs-kernel-server/patches/110-move-hardcoded-rundir.patch
+++ b/net/nfs-kernel-server/patches/110-move-hardcoded-rundir.patch
@@ -1,0 +1,44 @@
+--- a/utils/blkmapd/device-discovery.c
++++ b/utils/blkmapd/device-discovery.c
+@@ -64,7 +64,7 @@
+ #define EVENT_BUFSIZE (1024 * EVENT_SIZE)
+ 
+ #define RPCPIPE_DIR	"/var/lib/nfs/rpc_pipefs"
+-#define PID_FILE	"/run/blkmapd.pid"
++#define PID_FILE	"/tmp/run/blkmapd.pid"
+ 
+ #define CONF_SAVE(w, f) do {			\
+ 	char *p = f;				\
+--- a/utils/gssd/gssd.h
++++ b/utils/gssd/gssd.h
+@@ -44,7 +44,7 @@
+ #define DNOTIFY_SIGNAL		(SIGRTMIN + 3)
+ 
+ #define GSSD_DEFAULT_CRED_DIR			"/tmp"
+-#define GSSD_USER_CRED_DIR			"/run/user/%U"
++#define GSSD_USER_CRED_DIR			"/tmp/run/user/%U"
+ #define GSSD_DEFAULT_CRED_PREFIX		"krb5cc"
+ #define GSSD_DEFAULT_MACHINE_CRED_SUFFIX	"machine"
+ #define GSSD_DEFAULT_KEYTAB_FILE		"/etc/krb5.keytab"
+--- a/utils/statd/sm-notify.c
++++ b/utils/statd/sm-notify.c
+@@ -913,7 +913,7 @@ static int record_pid(void)
+ 	int fd;
+ 
+ 	(void)snprintf(pid, sizeof(pid), "%d\n", (int)getpid());
+-	fd = open("/run/sm-notify.pid", O_CREAT|O_EXCL|O_WRONLY, 0600);
++	fd = open("/tmp/run/sm-notify.pid", O_CREAT|O_EXCL|O_WRONLY, 0600);
+ 	if (fd < 0)
+ 		return 0;
+ 
+--- a/utils/statd/statd.c
++++ b/utils/statd/statd.c
+@@ -161,7 +161,7 @@ usage(void)
+ 	fprintf(stderr,"      -H                   Specify a high-availability callout program.\n");
+ }
+ 
+-static const char *pidfile = "/run/rpc.statd.pid";
++static const char *pidfile = "/tmp/run/rpc.statd.pid";
+ 
+ int pidfd = -1;
+ static void create_pidfile(void)


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: BananaPi R2 (mediatek/mt7623, ARM Cortex A7)
Run tested: BananaPi R2 (mediatek/mt7623, ARM Cortex A7)

Description:
statd currently fails to start due to missing /run which doesn't exist on OpenWrt.
Add a patch moving /run to /tmp/run as the path is hardcoded in several places and cannot be configured neither at buildtime nor at runtime.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>
