### PR TITLE
gnunet: fix invalid group spec for postgres

### DIFF
--- a/net/gnunet/Makefile
+++ b/net/gnunet/Makefile
@@ -321,7 +321,7 @@ CONFLICTS_fs-mysql:=gnunet-fs-pgsql gnunet-fs-sqlite
 
 DEPENDS_pgsql:=+libpq +pgsql-server
 LIB_pgsql:=pq
-USERID_pgsql:=gnunet=958::postgres=5432
+USERID_pgsql:=gnunet=958:postgres=5432
 
 DEPENDS_dhtcache-pgsql:=+gnunet-pgsql
 PLUGIN_dhtcache-pgsql:=datacache_postgres


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: N/A
Run tested: N/A

Description:
Fixes warning in CI:
feeds/packages_ci/net/gnunet/Makefile: invalid group spec :postgres=5432
feeds/packages/net/gnunet/Makefile: invalid group spec :postgres=5432
