### PR TITLE
[openwrt-21.02] yq: Update to 4.14.1

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.13.5
+PKG_VERSION:=4.14.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c0d637e7d7d5f370960af713e0f7e769e1b0876f71a844373d0307cbba68c4b2
+PKG_HASH:=294300a8c182c3f8e1f537ad2feebb6d0651f61330f33504bdc502f48992bf84
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm27xx
Run tested: bcm2710 raspberrypi-3b

Description:
Added new operators and bug fixes.
Release note: https://github.com/mikefarah/yq/releases/tag/v4.14.1
(cherry picked from commit 06bb78cf4db6543c9d33b3066373837ffb9ee1dc)
