### PR TITLE
qemu: disable libfuse

### DIFF
--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -383,6 +383,7 @@ CONFIGURE_ARGS +=			\
 	--disable-debug-mutex		\
 	--disable-debug-tcg		\
 	--disable-docs			\
+	--disable-fuse			\
 	--disable-gcrypt		\
 	--with-git-submodules=ignore	\
 	--disable-glusterfs		\


### PR DESCRIPTION
Fixes x86 build.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @yousong 

Fixes: https://github.com/openwrt/packages/issues/16650