### PR TITLE
telegraf: Update packate to version 1.20.3

### DIFF
--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -59,6 +59,12 @@ define Package/telegraf-full/description
 	(Full build. including all plugins)
 endef
 
+define Package/telegraf/conffiles
+/etc/telegraf.conf
+endef
+
+Package/telegraf-full/conffiles = $(Package/telegraf/conffiles)
+
 define Build/Prepare
 	$(call Build/Prepare/Default)
 ifeq ($(BUILD_VARIANT),small)
@@ -70,7 +76,7 @@ define Package/telegraf/install
 	$(call GoPackage/Package/Install/Bin,$(1))
 	$(INSTALL_DIR) $(1)/etc/init.d $(1)/etc/config
 	$(INSTALL_BIN) ./files/etc/init.d/telegraf $(1)/etc/init.d/telegraf
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/etc/telegraf.conf $(1)/etc/config/telegraf.conf
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/etc/telegraf.conf $(1)/etc/telegraf.conf
 endef
 
 define Package/telegraf-full/install

--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telegraf
-PKG_VERSION:=1.20.2
+PKG_VERSION:=1.20.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=3b0db9f48a76bb5076eded0ceab6ea568b295bbc525cdd8ad1ecf700ef317c18
+PKG_HASH:=cf8fd4d38970648281101e8a71b1a48c5765c8aaa9d67619c00272c9192e9057
 
 PKG_MAINTAINER:=Jonathan Pagel <jonny_tischbein@systemli.org>
 PKG_LICENSE:=MIT

--- a/utils/telegraf/files/etc/init.d/telegraf
+++ b/utils/telegraf/files/etc/init.d/telegraf
@@ -7,7 +7,7 @@ STOP=01
 
 start_service() {
     procd_open_instance
-    procd_set_param command /usr/bin/telegraf --config /etc/config/telegraf.conf
+    procd_set_param command /usr/bin/telegraf --config /etc/telegraf.conf
     procd_set_param stdout 1
     procd_set_param stderr 1
     procd_close_instance


### PR DESCRIPTION
Signed-off-by: Jonathan Pagel jonny_tischbein@systemli.org

Maintainer:
me

Compile tested:
on amd64 for aarch64 on https://git.openwrt.org/openwrt/openwrt.git commit 3bbc476e9306b1b0f51070d4dd24f90878458146

Run tested:
aarch64 (Banana PI R64), package installed, configured, starting via /etc/init.d/, configuring telegraf config and successfull working of input plugin prometheus and output plugin influxdb tested.

Description:
Update to version 1.20.3

Telegraf is a plugin-driven agent for collecting and sending metrics and events. It supports various inputs (including prometheus endpoints) and is able to send data into InfluxDB. https://www.influxdata.com/time-series-platform/telegraf/