### PR TITLE
bind: created /var/run/named directory

### DIFF
--- a/net/bind/files/named.init
+++ b/net/bind/files/named.init
@@ -21,7 +21,6 @@ dyndir=/tmp/bind
 
 conf_local_file=$dyndir/named.conf.local
 
-
 fix_perms() {
     for dir in $libdir $logdir $cachedir $dyndir; do
 	test -e "$dir" || {
@@ -40,6 +39,13 @@ start_service() {
     user_exists bind 57 || user_add bind 57
     group_exists bind 57 || group_add bind 57
     fix_perms
+
+    local runnamed=$(dirname $pid_file)
+    # with dropped privileges, we need this created for us
+    [ -d $runnamed ] || {
+	mkdir -m 0755 $runnamed
+	chown bind.bind $runnamed
+    }
 
     rndc-confgen > $rndc_temp
 


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile tested: x86_64, generic, HEAD (af56075a8f)
Run tested: same, running on production router

Description:

Side-effect of dropping capabilities(7) with last commit is now we need the `/var/run/named/` directory created for us at startup.
