### PR TITLE
ddns-scripts: use HTTPS for spdyn

### DIFF
--- a/net/ddns-scripts/files/usr/share/ddns/default/spdyn.de.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/spdyn.de.json
@@ -1,11 +1,11 @@
 {
 	"name": "spdyn.de",
 	"ipv4": {
-		"url": "http://[USERNAME]:[PASSWORD]@update.spdyn.de/nic/update?hostname=[DOMAIN]&myip=[IP]",
+		"url": "https://update.spdyn.de/nic/update?hostname=[DOMAIN]&myip=[IP]&user=[USERNAME]&pass=[PASSWORD]",
 		"answer": "good|nochg"
 	},
 	"ipv6": {
-		"url": "http://[USERNAME]:[PASSWORD]@update.spdyn.de/nic/update?hostname=[DOMAIN]&myip=[IP]",
+		"url": "https://update.spdyn.de/nic/update?hostname=[DOMAIN]&myip=[IP]&user=[USERNAME]&pass=[PASSWORD]",
 		"answer": "good|nochg"
 	}
 }


### PR DESCRIPTION
Maintainer: me\ @BKPepe 
Run tested: (put here arch, model, OpenWrt version, tests done)
Qualcomm Atheros QCA9558 ver 1 rev 0
TP-Link Archer C7 v2
OpenWrt 21.02.1 r16325-88151b8303 / LuCI openwrt-21.02 branch git-21.301.66596-f28aaa3

Description:
spdyn.de recommends ddns updates via https. 

This closes https://github.com/openwrt/packages/issues/17028

Signed-off-by: Peter Gransdorfer <Peter.Gransdorfer@cattronix.com>