### PR TITLE
libyang: et all to 2+

### DIFF
--- a/libs/libnetconf2/Makefile
+++ b/libs/libnetconf2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnetconf2
-PKG_VERSION:=1.1.43
+PKG_VERSION:=2.0.24
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/CESNET/libnetconf2/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=66139fc9e68aa89c82235f4135dba9e44f5db663541279c14c74131e22b7f571
+PKG_HASH:=78ffa0bd85823abd321a1dbb09c1ead36612f2a12049638a14bb081567f86ade
 
 PKG_MAINTAINER:=Jakov Smolic <jakov.smolic@sartura.hr>
 PKG_LICENSE:=BSD-3-Clause

--- a/libs/libnetconf2/patches/001-cmake_not_updated.patch
+++ b/libs/libnetconf2/patches/001-cmake_not_updated.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -180,7 +180,7 @@ endif()
+@@ -235,7 +235,7 @@ endif()
  # dependencies - libssh
  if(ENABLE_SSH)
      find_package(LibSSH 0.7.1 REQUIRED)

--- a/libs/libyang/Makefile
+++ b/libs/libyang/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libyang
-PKG_VERSION:=1.0.225
+PKG_VERSION:=2.0.112
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/CESNET/libyang/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=1b736443d2c69b5d7a71ac412655e6edab0647b18f35f7bf504b0a24e06cb046
+PKG_HASH:=184dd67c66c1ad968a2ee4d0950fb6b103834917b04b17af9c7bca80967636ee
 
 PKG_MAINTAINER:=Jakov Smolic <jakov.smolic@sartura.hr>
 PKG_LICENSE:=BSD-3-Clause
@@ -30,15 +30,7 @@ define Package/libyang
   CATEGORY:=Libraries
   TITLE:=YANG data modeling language library
   URL:=https://github.com/CESNET/libyang
-  DEPENDS:=+libpcre +libpthread
-endef
-
-define Package/libyang-cpp
-  SECTION:=libs
-  CATEGORY:=Libraries
-  TITLE:=YANG data modeling C++ language library
-  URL:=https://github.com/CESNET/libyang
-  DEPENDS:=+libyang +libstdcpp
+  DEPENDS:=+libpcre2 +libpthread
 endef
 
 define Package/yanglint
@@ -54,26 +46,9 @@ define Package/libyang/description
  The library is used e.g. in libnetconf2, Netopeer2 or sysrepo projects.
 endef
 
-CMAKE_OPTIONS += \
-	-DENABLE_LYD_PRIV:BOOL=ON \
-	-DCMAKE_BUILD_TYPE:String="Release" \
-	-DGEN_LANGUAGE_BINDINGS=ON \
-	-DGEN_PYTHON_BINDINGS=OFF
-
 define Package/libyang/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libyang.so* $(1)/usr/lib/
-
-	$(INSTALL_DIR) $(1)/usr/lib/libyang1
-	$(INSTALL_DIR) $(1)/usr/lib/libyang1/extensions
-	$(INSTALL_DIR) $(1)/usr/lib/libyang1/user_types
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libyang1/extensions/* $(1)/usr/lib/libyang1/extensions
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libyang1/user_types/* $(1)/usr/lib/libyang1/user_types
-endef
-
-define Package/libyang-cpp/install
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libyang-cpp.so* $(1)/usr/lib/
 endef
 
 define Package/yanglint/install
@@ -82,5 +57,4 @@ define Package/yanglint/install
 endef
 
 $(eval $(call BuildPackage,libyang))
-$(eval $(call BuildPackage,libyang-cpp))
 $(eval $(call BuildPackage,yanglint))

--- a/net/netopeer2/Makefile
+++ b/net/netopeer2/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netopeer2
-PKG_VERSION:=1.1.70
+PKG_VERSION:=2.0.35
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/CESNET/Netopeer2/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=7fc1a3520ee4bb488112f502e34cea465464dc933d2a5742a72eb32a6dfe3b3f
+PKG_HASH:=dedae40419cfddd09c1be7bb536b3a762ec8dcd568c2bfe803c0f6789a5ca834
 
 PKG_MAINTAINER:=Jakov Smolic <jakov.smolic@sartura.hr>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/sysrepo/Makefile
+++ b/net/sysrepo/Makefile
@@ -8,24 +8,21 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sysrepo
-PKG_VERSION:=1.4.122
+PKG_VERSION:=2.0.53
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/sysrepo/sysrepo/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2cc7537a03f48dc3c955436e1e0ed077bc3b31a755d6979d24ca42e1187fce01
+PKG_HASH:=fe09da5f40fb53e3fb97268a134cc0ed3003f0018d0d117c73e81e1553a11f30
 
 PKG_MAINTAINER:=Jakov Smolic <jakov.smolic@sartura.hr>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 CMAKE_INSTALL:=1
-PKG_BUILD_DEPENDS:=swig/host
-PYTHON3_PKG_BUILD:=0
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
-include ../../lang/python/python3-package.mk
 
 define Package/libsysrepo
   SECTION:=libs
@@ -33,15 +30,6 @@ define Package/libsysrepo
   TITLE:=YANG-based data store library
   URL:=https://www.sysrepo.org/
   DEPENDS:=+libyang +libatomic +libprotobuf-c +libev +libredblack +librt +libpthread
-endef
-
-define Package/python3-sysrepo
-  SECTION:=lang
-  CATEGORY:=Languages
-  SUBMENU:=Python
-  TITLE:=YANG-based data store library - Python 3 bindings
-  URL:=https://www.sysrepo.org/
-  DEPENDS:=+libsysrepo +libstdcpp +python3-base +libyang-cpp
 endef
 
 define Package/sysrepo
@@ -72,7 +60,6 @@ define Package/sysrepo/description
 Sysrepo is an YANG-based configuration and operational state data store for Unix/Linux applications.
 endef
 
-SWIG_VERSION:=4.0.1
 
 CMAKE_OPTIONS += \
 	-DENABLE_TESTS:BOOL=FALSE \
@@ -80,11 +67,8 @@ CMAKE_OPTIONS += \
 	-DCMAKE_INSTALL_PREFIX=/usr \
 	-DCMAKE_BUILD_TYPE="Package" \
 	-DREPOSITORY_LOC:PATH=/etc/sysrepo \
-	-DCMAKE_DISABLE_FIND_PACKAGE_SWIG=FALSE \
-	-DSWIG_EXECUTABLE=$(STAGING_DIR_HOSTPKG)/bin/swig \
 	-DCALL_TARGET_BINS_DIRECTLY=OFF \
-	-DGEN_LANGUAGE_BINDINGS:BOOL=TRUE \
-	-DGEN_PYTHON_BINDINGS:BOOL=TRUE
+	-DGEN_LANGUAGE_BINDINGS:BOOL=TRUE
 
 define Package/libsysrepo/install
 	$(INSTALL_DIR) $(1)/usr/lib
@@ -99,14 +83,6 @@ define Package/libsysrepo/install
 
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/libsysrepo.default $(1)/etc/uci-defaults/95_libsysrepo
-endef
-
-define Package/python3-sysrepo/install
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsysrepo-cpp.so* $(1)/usr/lib
-	$(INSTALL_DIR) $(1)$(PYTHON3_PKG_DIR)
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/bindings/python/sysrepo.py $(1)$(PYTHON3_PKG_DIR)
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/bindings/python/_sysrepo.so $(1)$(PYTHON3_PKG_DIR)
 endef
 
 define Package/sysrepo/install
@@ -128,7 +104,6 @@ define Package/sysrepocfg/install
 endef
 
 $(eval $(call BuildPackage,libsysrepo))
-$(eval $(call BuildPackage,python3-sysrepo))
 $(eval $(call BuildPackage,sysrepo))
 $(eval $(call BuildPackage,sysrepoctl))
 $(eval $(call BuildPackage,sysrepocfg))

--- a/net/sysrepo/patches/009-fix_inclusion.patch
+++ b/net/sysrepo/patches/009-fix_inclusion.patch
@@ -1,0 +1,10 @@
+--- a/src/sysrepo_types.h
++++ b/src/sysrepo_types.h
+@@ -19,6 +19,7 @@
+ 
+ #include <inttypes.h>
+ #include <stddef.h>
++#include <sys/stat.h>
+ 
+ struct lyd_node;
+ struct timespec;


### PR DESCRIPTION
Maintainer: @jsmolic 
Tested x86,kirkwood and ramips

update libyang and all the applications needed to 2.x
this is needed for frr 8+