### PR TITLE
avahi: do not compile against host's libc

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=avahi
 PKG_VERSION:=0.8
-PKG_RELEASE:=7
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lathiat/avahi/releases/download/v$(PKG_VERSION) \
@@ -23,6 +23,7 @@ PKG_CPE_ID:=cpe:/a:avahi:avahi
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -252,6 +253,8 @@ endef
 
 TARGET_CFLAGS += $(FPIC) -DGETTEXT_PACKAGE
 
+CONFIGURE_VARS += LT_SYS_LIBRARY_PATH="$(TOOLCHAIN_DIR)/lib"
+
 CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
@@ -290,7 +293,10 @@ CONFIGURE_ARGS += \
 	--with-avahi-group=nogroup \
 	--with-avahi-priv-access-group=nogroup \
 	--with-autoipd-user=nobody \
-	--with-autoipd-group=nogroup
+	--with-autoipd-group=nogroup \
+	--with-sysroot=$(TOOLCHAIN_DIR) \
+	--disable-compat-howl \
+	--disable-nls
 
 ifeq ($(BUILD_VARIANT),dbus)
 ifneq ($(CONFIG_PACKAGE_libavahi-compat-libdnssd),)


### PR DESCRIPTION
On ArchLinux (and maybe on some other's too) avahi links against host system's libc
instead of target systems (atleast for libdnnsd). This patch fixes the issue and
should have no negative impact when building on other systems.

I also changed release to $(AUTORELEASE)

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>

Maintainer: Ted Hess / @thess
Compile tested: x86_64 recent master
Run tested: x86_64 recent master