### PR TITLE
boringssl: remove dependency on golang

### DIFF
--- a/libs/boringssl/Makefile
+++ b/libs/boringssl/Makefile
@@ -28,7 +28,7 @@ define Package/boringssl
 	CATEGORY:=Libraries
 	TITLE:=An implementation of the TLS protocol
 	URL:=https://boringssl.googlesource.com/boringssl/
-	DEPENDS:=+libstdcpp $(GO_ARCH_DEPENDS) @!(mips||mips64)
+	DEPENDS:=+libstdcpp @!(mips||mips64||powerpc||powerpc64||arc)
 endef
 
 define Package/boringssl/description


### PR DESCRIPTION
This commit removes the unnecessary runtime dependency on Go. Go is only
required during buildtime.

Signed-off-by: Martin Schneider <martschneider@google.com>

Maintainer: me
Compile tested: x86_64
Run tested: x86_64