### PR TITLE
gnutls: don't run aclocal --install

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
 PKG_VERSION:=3.7.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz

--- a/libs/gnutls/patches/020-dont-install-m4-files.patch
+++ b/libs/gnutls/patches/020-dont-install-m4-files.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cote2004-github@yahoo.com>
+Date: Mon, 25 Oct 2021 08:49:21 -0300
+Subject: Do not install m4 files
+
+Do not use --install when calling aclocal.  That flag instructs aclocal to
+copy third-party files to the first -I directory.  The intention here is to
+copy files to the package build dir (m4).  However, our toolchain prepends
+the build-system's m4 dir to the list, causing the --install flag to
+install an older version to the buildsystem m4 dir, causing failures in
+other packages.
+
+Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
+
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -57,7 +57,7 @@ if ENABLE_DOC
+ SUBDIRS += doc
+ endif
+ 
+-ACLOCAL_AMFLAGS = -I m4 -I src/libopts/m4 -I src/gl/m4 -I lib/unistring/m4 --install
++ACLOCAL_AMFLAGS = -I m4 -I src/libopts/m4 -I src/gl/m4 -I lib/unistring/m4
+ 
+ EXTRA_DIST = cfg.mk maint.mk CONTRIBUTING.md README.md LICENSE AUTHORS NEWS \
+ 	ChangeLog THANKS INSTALL.md RELEASES.md


### PR DESCRIPTION
Maintainer: @nmav 
Compile tested: mediatek, master
Run tested: N/A

Description:
Remove the `--install` parameter when running `aclocal`.  The `--install` argument is used to copy third-party files to the first `-I` directory.  
`gnutls` has `-I m4` first, which would copy files to its local build directory.  However, openwrt preppends the staging dir m4 directory, causing `aclocal --install` to copy an old definition of `ax_code_coverage.m4` into the staging dir.

If strace is built after gnutls, compilation will fail:

```
    Makefile:9303: *** missing separator.  Stop.

The version of ax_code_coverage.m4 that gets installed does not define
@CODE_COVERAGE_RULES@.
```
Removing the `--install` parameter in gnutls solves the issue.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

@neheb 
I saw you got strace to not use `ax_code_coverage.m4`, which is fine on its own.  However, we may end up having trouble with other outdated files in the future if we don't change this behavior.