### PR TITLE
less: remove less-wide

### DIFF
--- a/utils/less/Makefile
+++ b/utils/less/Makefile
@@ -12,7 +12,8 @@ PKG_VERSION:=590
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.greenwoodsoftware.com/less
+PKG_SOURCE_URL:= @GNU/less \
+	http://www.greenwoodsoftware.com/less
 PKG_HASH:=6aadf54be8bf57d0e2999a3c5d67b1de63808bb90deb8f77b028eafae3a08e10
 
 PKG_LICENSE:=GPL-3.0-or-later
@@ -25,56 +26,23 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/less/Default
+define Package/less
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Pager program similar to more
   URL:=http://www.greenwoodsoftware.com/less/
   ALTERNATIVES:=200:/usr/bin/less:/usr/libexec/less-gnu
-endef
-
-define Package/less/Default/description
-  Full version of GNU less utility
-endef
-
-define Package/less
-  $(call Package/less/Default)
-  DEPENDS:=+libncurses
-  VARIANT:=narrow
+  DEPENDS:=+libncursesw
+  PROVIDES:=less-wide
 endef
 
 define Package/less/description
-  $(call Package/less/Default/description)
+  Full version of GNU less utility
 endef
-
-define Package/less-wide
-  $(call Package/less/Default)
-  TITLE+= (Unicode)
-  DEPENDS:=+libncursesw
-  VARIANT:=wide
-endef
-
-define Package/less-wide/description
-  $(call Package/less/Default/description)
-  This package contains the Unicode enabled version of less.
-endef
-
-ifeq ($(BUILD_VARIANT),narrow)
-	CONFIGURE_VARS += \
-		ac_cv_lib_ncursesw_initscr=no
-endif
-
-ifeq ($(BUILD_VARIANT),wide)
-	CONFIGURE_VARS += \
-		ac_cv_lib_ncursesw_initscr=yes
-endif
 
 define Package/less/install
 	$(INSTALL_DIR) $(1)/usr/libexec
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/less $(1)/usr/libexec/less-gnu
 endef
 
-Package/less-wide/install = $(Package/less/install)
-
 $(eval $(call BuildPackage,less))
-$(eval $(call BuildPackage,less-wide))


### PR DESCRIPTION
Maintainer: @neheb 
Compile tested: ath79/nand
Run tested: ath79/nand

Description:
The package `less` and `less-wide` has same content of the binary file. It's not necessary to keep both packages.
Add `PROVIDES` for legacy compat.