### PR TITLE
mariadb, liburing: fix liburing dependency failure (use liburing if kernel supports it)

### DIFF
--- a/libs/liburing/Makefile
+++ b/libs/liburing/Makefile
@@ -22,6 +22,7 @@ define Package/liburing
   CATEGORY:=Libraries
   TITLE:=io_uring library
   URL:=https://git.kernel.dk/cgit/liburing
+  DEPENDS:=@KERNEL_IO_URING
 endef
 
 define Package/liburing/description

--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
 PKG_VERSION:=10.6.4
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := https://archive.mariadb.org/$(PKG_NAME)-$(PKG_VERSION)/source
@@ -36,6 +36,7 @@ MARIADB_SOCKET=/var/run/mysqld/mysqld.sock
 
 MARIADB_DISABLE_ENGINES := \
 	cassandra \
+	columnstore \
 	example \
 	mroonga \
 	oqgraph \

--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -82,6 +82,7 @@ MARIADB_SERVER_PLUGINS := \
 
 PKG_CONFIG_DEPENDS := \
 	$(patsubst %,CONFIG_PACKAGE_$(PKG_NAME)-server-plugin-%,$(subst _,-,$(MARIADB_SERVER_PLUGINS))) \
+	CONFIG_KERNEL_IO_URING \
 	CONFIG_PACKAGE_mariadb-server
 
 plugin-auth_ed25519             := PLUGIN_AUTH_ED25519
@@ -284,7 +285,8 @@ define Package/mariadb-server-base
   $(call Package/mariadb/Default)
   DEPENDS:=mariadb-common \
 	  $(MARIADB_COMMON_DEPENDS) \
-	  +libaio \
+	  +!KERNEL_IO_URING:libaio \
+	  +KERNEL_IO_URING:liburing \
 	  +liblzma \
 	  +libpcre2 \
 	  +resolveip


### PR DESCRIPTION
Maintainer: @miska, @gladiac1337  
Compile tested: mediatek, Linksys EA8450
Run tested: needs run-testing

Description:
This fixes the problem of liburing dependency in mariadb.  If kernel io uring support is turned off, then mariadb will pick  libaio as a fallback.
I had to add the `KERNEL_IO_URING` dependency to liburing, otherwise it would get built for a system that will not support it.  Then mariadb will detect liburing, and we won't be able to build it with libaio without a patch.

Also included is a commit disabling columnstore engine.  At least here, it will pick-up the boost library, and will attempt to configure columnstore, failing.  I noticed that the bots are not trying to build it, even though they did find boost.  Here's the part where columnstore is involved:
```
== MariaDB-Columnstore 5.6.2
-- Could NOT find Boost: missing: thread date_time chrono (found /builder/shared-workdir/build/sdk/staging_dir/hostpkg/lib/cmake/Boost-1.77.0/BoostConfig.cmake (found suitable version "1.77.0", minimum required is "1.53.0"))
-- Required Boost libraries not found!
```
