### PR TITLE
cni-plugins-nft: update to 1.0.11

### DIFF
--- a/utils/cni-plugins-nft/Makefile
+++ b/utils/cni-plugins-nft/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cni-plugins-nft
-PKG_VERSION:=1.0.5
+PKG_VERSION:=1.0.11
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/greenpau/cni-plugins/archive/v$(PKG_VERSION)
-PKG_HASH:=c8cbdfe43c144cf0df834555698312e8fd3daf6f2c5ac35e7959b90b91b154ad
+PKG_HASH:=f6c68268893c9d9967dd4d8f3684df0f4f989e7ebf373e72b20d1f290ff9e240
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Update compatibility with CNI v1.0.1

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>

Maintainer: Oskari Rauta / @oskarirauta (find it by checking history of the package Makefile)
Compile tested: x86_64, pc, recent snapshot
Run tested: x86_64, pc, recent snapshot