### PR TITLE
docker-compose: Update to version 2.1.0

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,49 +1,47 @@
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=docker-compose
-PKG_VERSION:=1.29.2
+PKG_NAME:=compose
+PKG_VERSION:=2.1.0
 PKG_RELEASE:=$(AUTORELEASE)
-
-PYPI_NAME:=docker-compose
-PKG_HASH:=4c8cd9d21d237412793d18bd33110049ee9af8dab3fe2c213bbd0733959b09b7
-
-PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-include ../../lang/python/pypi.mk
-include $(INCLUDE_DIR)/package.mk
-include ../../lang/python/python3-package.mk
+PKG_SOURCE:=v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
+PKG_HASH:=48b20b1b75de0e517deb0e29122ecdb01982f136e68429bdf6a97121701d4274
 
-PYTHON3_PKG_SETUP_ARGS:=
+PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/docker/compose/v2
+GO_PKG_BUILD_PKG:=github.com/docker/compose/v2/cmd
+GO_PKG_LDFLAGS_X:=github.com/docker/compose/v2/internal.Version=v$(PKG_VERSION)
+GO_PKG_TAGS:=e2e,kube
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
 
 define Package/docker-compose
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Docker Compose
   URL:=https://github.com/docker/compose
-  DEPENDS+=+docker \
-      +python3-light \
-      +python3-cached-property \
-      +python3-distro \
-      +python3-distutils \
-      +python3-docopt \
-      +python3-docker \
-      +python3-dockerpty \
-      +python3-dotenv \
-      +python3-jsonschema \
-      +python3-logging \
-      +python3-openssl \
-      +python3-pkg-resources \
-      +python3-requests \
-      +python3-texttable \
-      +python3-yaml
+  DEPENDS:=$(GO_ARCH_DEPENDS) +docker
 endef
 
 define Package/docker-compose/description
   Multi-container orchestration for Docker
 endef
 
-$(eval $(call Py3Package,docker-compose))
+define Package/docker-compose/install
+	$(INSTALL_DIR) $(1)/usr/lib/docker/cli-plugins/
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/cmd $(1)/usr/lib/docker/cli-plugins/docker-compose
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(LN) ../lib/docker/cli-plugins/docker-compose $(1)/usr/bin/docker-compose
+endef
+
+$(eval $(call GoBinPackage,docker-compose))
 $(eval $(call BuildPackage,docker-compose))
-$(eval $(call BuildPackage,docker-compose-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
Major upstream update, switching from Python to Golang.
I missed the previous one a few days ago.

Since I've had to redo the Makefile, I am not entirely sure I did it
in an optimal way. It is built locally, without resorting to docker
or git like the upstream Makefile tries to do.

It is now installed to `/usr/lib/docker/cli-plugins/docker-compose`
and symlinked to `/usr/bin/docker-compose`. That way it can now
be run as `docker-compose` or as `docker compose`.

Also, I wonder what to do with all the old python dependencies,
namely:

`python-cached-property, python-distro, python-docker,
python-dockerpty, python-docopt, python-dotenv,
python-jsonschema, python-paramiko, python-pynacl,
python-texttable & python-websocket-client`

I'm the current maintainer of all those packages, after this update
I'm dropping them from my regular builds since I only used them
with this package.

This update has recreated all my containers, and the only caveat
was I had to enclose in `""` a couple variables in an `.env` file.
Other than that, it has smoothly replaced the python version.


Docker Compose V2 is a major version bump release of Docker Compose.
It has been completely rewritten from scratch in Golang (V1 was in
Python).

Features:

 - Added support for running the plugin as a standalone program. Like
 docker-compose v1 would behave compute sha256 checksums while releasing

Bugfixes:

 - Allow combination of --status and --services
 - Fix build cache_from option
 - Fix compose up on README.md
 - Make --status a multi-flag
 - No longer fail when inferred .env is a directory

Misc

 - Stop ticker after use on ttyWriter
 - Use uname -m for cross platform suffixes
 - Add note about installing it system-wide
 - Bump containerd 1.5.5

What's Changed

 - Fix support for devices by @ndeloof in #8732
 - Make command descriptions consistent by @mat007 in #8739
 - Restore missing version commands by @Shikachuu in #8738
 - Add step in README to install on linux by @Yopadd in #8755
 - log --follow must stop when container get killed by @ndeloof in
 #8726
 - Fix index out of range on compose.buildContainerMountOptions by
 @ulyssessouza in #8750
 - Pass runtime option to containerCreate by @ndeloof in #8783
 - Fix compose down --timeout/-t flag by @debdutdeb in #8788
 - Fix network_mode "service:x" by @ulyssessouza in #8792
 - Make service>build>dockerfile a simple filename by @ulyssessouza
 in #8779
 - Compose exec cannot process more than 32KB of data by @resios in
 #8815
 - Actually fix Compose exec cannot process more than 32KB of data by
 @resios in #8816
 - Fix project settings' options order by @ulyssessouza in #8819
 - Update link to Docker Community Slack by @mat007 in #8824
 - Add support for DOCKER_DEFAULT_PLATFORM by @ndeloof in #8848
 - COMPOSE_COMPATIBILITY can be set by .env file by @ndeloof in #8847
 - Add support for EnableIPv6 by @ndeloof in #8851
 - Avoid test flakyness by ordering volumes before checking by
 @ulyssessouza in #8858
 - Update README.md: typographical edit of "About update..." by
 @youssefeldakar in #8838
 - Add support for classic builder by @ulyssessouza in #8818
 - Fix typo: netwok -> network by @Mygao in #8789
 - Bump compose-go to v1.0.5 by @ulyssessouza in #8870
