### PR TITLE
v4l2tools: fix missing dependency

### DIFF
--- a/multimedia/v4l2tools/Makefile
+++ b/multimedia/v4l2tools/Makefile
@@ -26,7 +26,7 @@ define Package/v4l2tools
 	SECTION:=multimedia
 	CATEGORY:=Multimedia
 	TITLE:=v4l2tools
-	DEPENDS:=+libstdcpp +libjpeg
+	DEPENDS:=+libstdcpp +libjpeg +libvpx
 	URL:=https://github.com/mpromonet/v4l2tools
 endef
 


### PR DESCRIPTION
Should fix errors in the form of:

    Package v4l2tools is missing dependencies for the following libraries: libvpx.so.6

Signed-off-by: Nick Hainke <vincent@systemli.org>

Maintainer: @mpromonet
Compile tested: tbd
Run tested: tbd
