### PR TITLE
openblas: default to MIPS24K target for all mips32 targets

### DIFF
--- a/libs/openblas/Makefile
+++ b/libs/openblas/Makefile
@@ -58,13 +58,9 @@ ifeq ($(ARCH),aarch64)
 else ifeq ($(ARCH),arm)
   OPENBLAS_TARGET:=ARMV5
 else ifeq ($(ARCH),mips)
-  ifneq ($(filter 24k% 74k%,$(CPU_TYPE)),)
-    OPENBLAS_TARGET:=MIPS24K
-  endif # CPU_TYPE == 24k* or 74k*
+  OPENBLAS_TARGET:=MIPS24K
 else ifeq ($(ARCH),mipsel)
-  ifneq ($(filter 24k% 74k%,$(CPU_TYPE)),)
-    OPENBLAS_TARGET:=MIPS24K
-  endif # CPU_TYPE == 24k* or 74k*
+  OPENBLAS_TARGET:=MIPS24K
 else ifeq ($(ARCH),powerpc)
   OPENBLAS_TARGET:=PPC440
 endif


### PR DESCRIPTION
Maintainer: me
Compile tested: master mips32 (Broadcom BMIPS)
Run tested: n/a

----------------------------------------------------

Reported via:
  https://github.com/openwrt/packages/pull/16823#issuecomment-945312460

This fails in mips_mip32 targets with the output listed below.

Using the MIPS24K target works fine.

```
mips-openwrt-linux-musl-gcc -c -Os -pipe -mno-branch-likely -mips32 -mtune=mips32 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -msoft-float -ffile-prefix-map=/builder/shared-workdir/build/sdk/build_dir/target-mips_mips32_musl/OpenBLAS-0.3.18=OpenBLAS-0.3.18 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro  -I/builder/shared-workdir/build/sdk/staging_dir/toolchain-mips_mips32_gcc-11.2.0_musl/usr/include -I/builder/shared-workdir/build/sdk/staging_dir/toolchain-mips_mips32_gcc-11.2.0_musl/include/fortify -I/builder/shared-workdir/build/sdk/staging_dir/toolchain-mips_mips32_gcc-11.2.0_musl/include   -DMAX_STACK_ALLOC=2048 -Wall -mabi=32 -DF_INTERFACE_GFORT -fPIC -DNO_LAPACK -DNO_LAPACKE -DNO_AVX512 -DSMP_SERVER -DNO_WARMUP -DMAX_CPU_NUMBER=2 -DMAX_PARALLEL_NUMBER=1 -DBUILD_SINGLE=1 -DBUILD_DOUBLE=1 -DBUILD_COMPLEX=1 -DBUILD_COMPLEX16=1 -DVERSION=\"0.3.18\" -UASMNAME -UASMFNAME -UNAME -UCNAME -UCHAR_NAME -UCHAR_CNAME -DASMNAME= -DASMFNAME=_ -DNAME=_ -DCNAME= -DCHAR_NAME=\"_\" -DCHAR_CNAME=\"\" -DNO_AFFINITY -I.  -DMAX_STACK_ALLOC=2048 -Wall -mabi=32 -DF_INTERFACE_GFORT -fPIC -DNO_LAPACK -DNO_LAPACKE -DNO_AVX512 -DSMP_SERVER -DNO_WARMUP -DMAX_CPU_NUMBER=2 -DMAX_PARALLEL_NUMBER=1 -DBUILD_SINGLE=1 -DBUILD_DOUBLE=1 -DBUILD_COMPLEX=1 -DBUILD_COMPLEX16=1 -DVERSION=\"0.3.18\" -UASMNAME -UASMFNAME -UNAME -UCNAME -UCHAR_NAME -UCHAR_CNAME -DASMNAME=sgemm -DASMFNAME=sgemm_ -DNAME=sgemm_ -DCNAME=sgemm -DCHAR_NAME=\"sgemm_\" -DCHAR_CNAME=\"sgemm\" -DNO_AFFINITY -I.. -I. -UDOUBLE  -UCOMPLEX gemm.c -o sgemm.o
In file included from ../common.h:581,
                 from gemm.c:41:
gemm.c: In function 'sgemm_':
../param.h:3477:25: error: 'sgemm_p' undeclared (first use in this function); did you mean 'sgemm_'?
 3477 | #define SGEMM_DEFAULT_P sgemm_p
      |                         ^~~~~~~
../common_param.h:1334:25: note: in expansion of macro 'SGEMM_DEFAULT_P'
 1334 | #define SGEMM_P         SGEMM_DEFAULT_P
      |                         ^~~~~~~~~~~~~~~
../common_param.h:1482:33: note: in expansion of macro 'SGEMM_P'
 1482 | #define GEMM_P                  SGEMM_P
      |                                 ^~~~~~~
gemm.c:494:37: note: in expansion of macro 'GEMM_P'
  494 |   sb = (XFLOAT *)(((BLASLONG)sa + ((GEMM_P * GEMM_Q * COMPSIZE * SIZE + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
      |                                     ^~~~~~
../param.h:3477:25: note: each undeclared identifier is reported only once for each function it appears in
 3477 | #define SGEMM_DEFAULT_P sgemm_p
      |                         ^~~~~~~
../common_param.h:1334:25: note: in expansion of macro 'SGEMM_DEFAULT_P'
 1334 | #define SGEMM_P         SGEMM_DEFAULT_P
      |                         ^~~~~~~~~~~~~~~
../common_param.h:1482:33: note: in expansion of macro 'SGEMM_P'
 1482 | #define GEMM_P                  SGEMM_P
      |                                 ^~~~~~~
gemm.c:494:37: note: in expansion of macro 'GEMM_P'
  494 |   sb = (XFLOAT *)(((BLASLONG)sa + ((GEMM_P * GEMM_Q * COMPSIZE * SIZE + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
      |                                     ^~~~~~
make[5]: *** [Makefile:1295: sgemm.o] Error 1
make[5]: Leaving directory '/builder/shared-workdir/
```

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>