### PR TITLE
artifacts: use git commit sha in name

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -98,13 +98,13 @@ jobs:
       - name: Store packages
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.arch}}-packages
+          name: ${{ matrix.arch}}-${{ github.sha}}-packages
           path: "*.ipk"
 
       - name: Store logs
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.arch}}-logs
+          name: ${{ matrix.arch}}-${{ github.sha}}-logs
           path: logs/
 
       - name: Remove logs


### PR DESCRIPTION
I removed the PR template because this is not a package update. This PR adds the commit hash to the artifact filenames (the packages and logs collections), so that downloads of those artifacts can be tracked back to the builds that generated them.

If you like this, here's an additional proposal: I add a small metadata file to each artifact collection, so that, once unpacked, a user can also see what branch, PR number, etc. generated this artifact.

Thoughts?