### PR TITLE
pdns-recursor: Update to v4.5.7

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
-PKG_VERSION:=4.5.5
+PKG_VERSION:=4.5.7
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=a836a39b99fcc21873e4ba3a60aa9915a33fac7b44922696e9a257f551fe05fb
+PKG_HASH:=ad4db2d4af4630757f786f3719225c2e37481257d676803a54194c7679d07bab
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>
 PKG_LICENCE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: @Habbie
Compile tested:ramips (MIPS), HLK-7621 evaluation board, OpenWrt commit 9f90a89655d41ba8afcd8018d7bc8b3753beb17e
Run tested: ramips (MIPS), HLK-7621 evaluation board, OpenWrt commit 9f90a89655d41ba8afcd8018d7bc8b3753beb17e, ran it and checked that it responded with the correct records when digging random domains

Description:
This PR updates PowerDNS Recursor to its latest version, v4.5.7.