### PR TITLE
v4l2tools: get rid of x264 and vpx

### DIFF
--- a/multimedia/v4l2tools/patches/010-no-vpx-x264.patch
+++ b/multimedia/v4l2tools/patches/010-no-vpx-x264.patch
@@ -1,0 +1,18 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -39,7 +39,6 @@ target_link_libraries (${PROJECT_NAME} y
+ find_package(PkgConfig)
+ 
+ # x264
+-pkg_check_modules(X264 x264)
+ if (X264_FOUND) 
+   include_directories(${X264_INCLUDE_DIR})
+   target_link_libraries(${PROJECT_NAME} ${X264_LIBRARIES})
+@@ -55,7 +54,6 @@ if (X265_FOUND)
+ endif()
+ 
+ # vpx
+-pkg_check_modules(VPX vpx)
+ if (VPX_FOUND) 
+   include_directories(${VPX_INCLUDE_DIR})
+   target_link_libraries(${PROJECT_NAME} ${VPX_LIBRARIES})


### PR DESCRIPTION
Patched as it seems they can't be disabled.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mpromonet 
Compile tested: ath79