### PR TITLE
v4l2tools: add vpx dependency if library installed

### DIFF
--- a/multimedia/v4l2tools/Makefile
+++ b/multimedia/v4l2tools/Makefile
@@ -7,13 +7,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v4l2tools
-PKG_VERSION:=0.1.5
+PKG_VERSION:=0.1.7
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/mpromonet/v4l2tools.git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
-PKG_MIRROR_HASH:=af63df7f88c1031aa5a438d175d77ca9c976e48eb55ff78a6ff6d2bd7272ac51
+PKG_MIRROR_HASH:=ded23eef11efbba8467ba58c5e69071ab4b34c0d29ad1a4fdc96683cfe2aff3c
 
 PKG_MAINTAINER:=Michel Promonet<michel.promonet@free.fr>
 PKG_LICENSE:=Unlicense
@@ -22,13 +22,21 @@ PKG_LICENSE_FILES:=LICENCE
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
+PKG_CONFIG_DEPENDS := CONFIG_PACKAGE_libvpx
+
 define Package/v4l2tools
 	SECTION:=multimedia
 	CATEGORY:=Multimedia
 	TITLE:=v4l2tools
-	DEPENDS:=+libstdcpp +libjpeg
+	DEPENDS:=+libstdcpp +libjpeg +PACKAGE_libvpx:libvpx
 	URL:=https://github.com/mpromonet/v4l2tools
 endef
+
+CMAKE_OPTIONS += \
+       -DWITH_JPEG=ON \
+       -DWITH_VPX=$(if $(CONFIG_PACKAGE_libvpx),ON,OFF) \
+       -DWITH_X264=OFF \
+       -DWITH_X265=OFF 
 
 define Package/v4l2tools/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Signed-off-by: Michel Promonet <michel.promonet@free.fr>

Maintainer: @mpromonet 
Compile tested: (arch:arm7, model:bcm2709, OpenWrt master)
Run tested: ( arch:arm7, model:bcm2709, OpenWrt master)
    * start v4l2tool to compress YUYV to VP80 on virtual v4l2loopback device
    * start v4l2rtspserver consuming virtual v4l2loopback device, get the stream remotely using ffplay

Description: 
Fix for https://github.com/openwrt/packages/issues/17072 adding vpx dependency when this library is selected