### PR TITLE
mjpg-streamer: fix missing runpath

### DIFF
--- a/multimedia/mjpg-streamer/Makefile
+++ b/multimedia/mjpg-streamer/Makefile
@@ -175,6 +175,8 @@ $(call Package/mjpg-streamer/Default/description)
 This package provides simple version of the web content.
 endef
 
+CMAKE_OPTIONS += -DCMAKE_SKIP_RPATH=FALSE
+
 CAMBOZOLA:=cambozola-0.936.tar.gz
 
 # Distribution URL doesn't always have the correct version


### PR DESCRIPTION
This partially reverts ac5912e9cb7761b5153bc12343f1af8b224c1d29.
CMAKE_SKIP_RPATH=TRUE is set in include/cmake.mk, so the commit removed
this from some packages as it is the default anyway. But in
mjpg-streamer Makefile this was not set to "TRUE", but to "FALSE". So
this line shouldn't have been removed.

With this revert the runpath is back and modules can be loaded again
from "/usr/lib/mjpg-streamer":

```
readelf -d build_dir/target-mips_24kc_musl/mjpg-streamer-1.0.0/ipkg-mips_24kc/mjpg-streamer/usr/bin/mjpg_streamer

Dynamic section at offset 0x1c0 contains 35 entries:
  Tag        Type                         Name/Value
 0x00000001 (NEEDED)                     Shared library: [libjpeg.so.62]
 0x00000001 (NEEDED)                     Shared library: [libgcc_s.so.1]
 0x00000001 (NEEDED)                     Shared library: [libc.so]
 0x0000001d (RUNPATH)                    Library runpath: [/usr/lib/mjpg-streamer]
```

Resolve #17081

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @Roger @thess 
Compile tested: ath79 master
Run tested: N/A

Description:
Fixes issue #17081