### PR TITLE
mutt, postfix: prevent exposing config options when not selected

### DIFF
--- a/mail/mutt/Makefile
+++ b/mail/mutt/Makefile
@@ -33,6 +33,7 @@ define Package/mutt
   DEPENDS:=+MUTT_GNUTLS:libgnutls +MUTT_OPENSSL:libopenssl +libncursesw +MUTT_SASL:libsasl2 +terminfo +zlib
   TITLE:=Console mail client
   URL:=http://www.mutt.org/
+  MENU:=1
 endef
 
 define Package/mutt/description
@@ -59,38 +60,42 @@ define Package/mutt/install
 endef
 
 define Package/mutt/config
-	menu "Select mutt build options"
-		config MUTT_POP
-			bool "POP support"
-			default y
-			help
-			  Enables POP support in mutt.
-		config MUTT_IMAP
-			bool "IMAP support"
-			default y
-			help
-			  Enables IMAP support in mutt
-		config MUTT_SMTP
-			bool "SMTP support"
-			default n
-			help
-			  Enables SMTP support in mutt.
-		config MUTT_SASL
-			bool "SASL support"
-			default n
-			help
-			  Enables SASL support in mutt (libsasl2).
-		config MUTT_GNUTLS
-			bool "GnuTLS support"
-			default n
-			help
-			  Enables GnuTLS support in mutt (libgnutls).
-		config MUTT_OPENSSL
-			bool "OpenSSL support"
-			default y
-			help
-			  Enables OpenSSL support in mutt (libopenssl).
-	endmenu
+	config MUTT_POP
+		depends on PACKAGE_mutt
+		bool "POP support"
+		default y
+		help
+			Enables POP support in mutt.
+	config MUTT_IMAP
+		depends on PACKAGE_mutt
+		bool "IMAP support"
+		default y
+		help
+			Enables IMAP support in mutt
+	config MUTT_SMTP
+		depends on PACKAGE_mutt
+		bool "SMTP support"
+		default n
+		help
+			Enables SMTP support in mutt.
+	config MUTT_SASL
+		depends on PACKAGE_mutt
+		bool "SASL support"
+		default n
+		help
+			Enables SASL support in mutt (libsasl2).
+	config MUTT_GNUTLS
+		depends on PACKAGE_mutt
+		bool "GnuTLS support"
+		default n
+		help
+			Enables GnuTLS support in mutt (libgnutls).
+	config MUTT_OPENSSL
+		depends on PACKAGE_mutt
+		bool "OpenSSL support"
+		default y
+		help
+			Enables OpenSSL support in mutt (libopenssl).
 endef
 
 $(eval $(call BuildPackage,mutt))

--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -45,6 +45,7 @@ define Package/postfix
   	postdrop=26:postdrop=26
   URL:=http://www.postfix.org/
   DEPENDS:=+POSTFIX_CDB:tinycdb +POSTFIX_TLS:libopenssl +POSTFIX_SASL:libsasl2 +POSTFIX_LDAP:libopenldap +POSTFIX_DB:libdb47 +POSTFIX_SQLITE:libsqlite3 +POSTFIX_MYSQL:libmysqlclient +POSTFIX_PGSQL:libpq +POSTFIX_EAI:icu +POSTFIX_PCRE:libpcre
+  MENU:=1
 endef
 
 define Package/postfix/description
@@ -52,63 +53,71 @@ define Package/postfix/description
 endef
 
 define Package/postfix/config
-	menu "Select postfix build options"
-		config POSTFIX_TLS
-			bool "TLS support"
-			default y
-			help
-			  Implements TLS support in postfix (using OpenSSL).
-		config POSTFIX_SASL
-			bool "SASL support"
-			default y
-			help
-			  Implements SASL support in postfix (using Cyrus SASL).
-		config POSTFIX_LDAP
-			bool "LDAP support"
-			default y
-			help
-			  Implements LDAP support in postfix (using OpenLDAP).
-		config POSTFIX_DB
-			bool "BerkeleyDB support"
-			default n
-			help
-			  Implements support for btree and hash files using Berkeley DB.
-		config POSTFIX_CDB
-			bool "CDB support"
-			default y
-			help
-			  Implements support for cdb files using tinycdb
-		config POSTFIX_SQLITE
-			bool "SQLITE support"
-			default y
-			help
-			  Implements support for SQLite3 DB
-		config POSTFIX_MYSQL
-			bool "MYSQL support"
-			default n
-			help
-			  Implements support for MySQL
-		config POSTFIX_PGSQL
-			bool "PostgreSQL support"
-			default n
-			help
-			  Implement support for PostgreSQL
-		config POSTFIX_PCRE
-			bool "PCRE support"
-			default y
-			help
-			  Implement support for Perl Compatible Regular Expressions
-		config POSTFIX_EAI
-			bool "SMTPUTF8 support"
-			default n
-			help
-			  Enable Postfix support for Email Address Internationalization
-			  (EAI) as defined in RFC 6531 (SMTPUTF8 extension), RFC 6532
-			  (Internationalized email headers) and RFC 6533
-			  (Internationalized delivery status notifications).
-			  Since version 3.0, Postfix fully supports UTF-8 email
-			  addresses and UTF-8 message header values.
-	endmenu
+	config POSTFIX_TLS
+		depends on PACKAGE_postfix
+		bool "TLS support"
+		default y
+		help
+			Implements TLS support in postfix (using OpenSSL).
+	config POSTFIX_SASL
+		depends on PACKAGE_postfix
+		bool "SASL support"
+		default y
+		help
+			Implements SASL support in postfix (using Cyrus SASL).
+	config POSTFIX_LDAP
+		depends on PACKAGE_postfix
+		bool "LDAP support"
+		default y
+		help
+			Implements LDAP support in postfix (using OpenLDAP).
+	config POSTFIX_DB
+		depends on PACKAGE_postfix
+		bool "BerkeleyDB support"
+		default n
+		help
+			Implements support for btree and hash files using Berkeley DB.
+	config POSTFIX_CDB
+		depends on PACKAGE_postfix
+		bool "CDB support"
+		default y
+		help
+			Implements support for cdb files using tinycdb
+	config POSTFIX_SQLITE
+		depends on PACKAGE_postfix
+		bool "SQLITE support"
+		default y
+		help
+			Implements support for SQLite3 DB
+	config POSTFIX_MYSQL
+		depends on PACKAGE_postfix
+		bool "MYSQL support"
+		default n
+		help
+			Implements support for MySQL
+	config POSTFIX_PGSQL
+		depends on PACKAGE_postfix
+		bool "PostgreSQL support"
+		default n
+		help
+			Implement support for PostgreSQL
+	config POSTFIX_PCRE
+		depends on PACKAGE_postfix
+		bool "PCRE support"
+		default y
+		help
+			Implement support for Perl Compatible Regular Expressions
+	config POSTFIX_EAI
+		depends on PACKAGE_postfix
+		bool "SMTPUTF8 support"
+		default n
+		help
+			Enable Postfix support for Email Address Internationalization
+			(EAI) as defined in RFC 6531 (SMTPUTF8 extension), RFC 6532
+			(Internationalized email headers) and RFC 6533
+			(Internationalized delivery status notifications).
+			Since version 3.0, Postfix fully supports UTF-8 email
+			addresses and UTF-8 message header values.
 endef
 
 CCARGS=-DNO_NIS -fcommon


### PR DESCRIPTION
Maintainers: @philenotfound, @Shulyaka

Description:
When the package is not selected, mutt and postfix config options will still appear in the config. Add a "depends on" to ensure they only show when the relevant package is selected.
