### PR TITLE
bossa: add patch to fix flash failures on serial

### DIFF
--- a/utils/bossa/patches/101-PosixSerialPort-Call-tcdrain-to-write-serial-data.patch
+++ b/utils/bossa/patches/101-PosixSerialPort-Call-tcdrain-to-write-serial-data.patch
@@ -1,0 +1,24 @@
+From 0fd3078b4863002e5d384d7e453d668841414abe Mon Sep 17 00:00:00 2001
+From: Kay Sievers <kay@vrfy.org>
+Date: Wed, 13 Jan 2021 01:34:08 +0100
+Subject: [PATCH] PosixSerialPort: Call tcdrain() to write serial data
+GithubPR: 150
+
+---
+ src/PosixSerialPort.cpp | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+--- a/src/PosixSerialPort.cpp
++++ b/src/PosixSerialPort.cpp
+@@ -290,10 +290,7 @@ PosixSerialPort::put(int c)
+ void
+ PosixSerialPort::flush()
+ {
+-    // There isn't a reliable way to flush on a file descriptor
+-    // so we just wait it out.  One millisecond is the USB poll
+-    // interval so that should cover it.
+-    usleep(1000);
++    tcdrain(_devfd);
+ }
+ 
+ bool


### PR DESCRIPTION
Maintainer: @PolynomialDivision 
Compile tested: master / omap
Run tested: 19.07 / omap

Description:
bossa only waited 1ms for the serial device instead calling
tcdrain().
Without this patch bossa is failing 8/10 times.
Patch has been submitted as PR#150 upstream but is still waiting
for the maintainers for feedback.

