### PR TITLE
CI: do not crash during PKG-INFO generation if there are no packages

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -128,7 +128,7 @@ jobs:
           done
           echo >> PKG-INFO
           echo Full file listing: >> PKG-INFO
-          ls -al *.ipk >> PKG-INFO
+          ls -al *.ipk >> PKG-INFO || true
           cat PKG-INFO
 
       - name: Store packages


### PR DESCRIPTION
Signed-off-by: Peter van Dijk <peter.van.dijk@powerdns.com>

reported in #17103, tested in https://github.com/PowerDNS/openwrt-packages/pull/1