### PR TITLE
modemmanager: fix physdev sysfs path detection in PCIe modems

### DIFF
--- a/net/modemmanager/files/modemmanager.common
+++ b/net/modemmanager/files/modemmanager.common
@@ -39,8 +39,17 @@ mm_find_physdev_sysfs_path() {
 		# avoid infinite loops iterating
 		[ -z "${tmp_path}" ] || [ "${tmp_path}" = "/" ] && return
 
-		# the physical device will be that with a idVendor and idProduct pair of files
+		# For USB devices, the physical device will be that with a idVendor
+		# and idProduct pair of files
 		[ -f "${tmp_path}"/idVendor ] && [ -f "${tmp_path}"/idProduct ] && {
+			tmp_path=$(readlink -f "$tmp_path")
+			echo "${tmp_path}"
+			return
+		}
+
+		# For PCI devices, the physical device will be that with a vendor
+		# and device pair of files
+		[ -f "${tmp_path}"/vendor ] && [ -f "${tmp_path}"/device ] && {
 			tmp_path=$(readlink -f "$tmp_path")
 			echo "${tmp_path}"
 			return


### PR DESCRIPTION
The PCIe physdev path lookup relies on the 'vendor' and 'device'
attribute files, instead of the 'idVendor' and 'idProduct' ones, which
are USB specific.

Signed-off-by: Aleksander Morgado <aleksander@aleksander.es>

Maintainer: @nickberry17 
