### PR TITLE
ovs,ovn: remove python-six dep

### DIFF
--- a/lang/python/python-six/Makefile
+++ b/lang/python/python-six/Makefile
@@ -18,10 +18,7 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
-HOST_BUILD_DEPENDS:=python3/host
-
 include ../pypi.mk
-include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
@@ -40,14 +37,6 @@ for smoothing over the differences between the Python versions with the goal of
 writing Python code that is compatible on both Python versions.  See the
 documentation for more information on what is provided.
 endef
-
-define Host/Compile
-	$(call HostPython3/ModSetup,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
-endef
-
-Host/Install:=
-
-$(eval $(call HostBuild))
 
 $(eval $(call Py3Package,python3-six))
 $(eval $(call BuildPackage,python3-six))

--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -17,7 +17,7 @@ include ./openvswitch.mk
 #
 PKG_NAME:=openvswitch
 PKG_VERSION:=$(ovs_version)
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openvswitch.org/releases/
 PKG_HASH:=7d5797f2bf2449c6a266149e88f72123540f7fe7f31ad52902057ae8d8f88c38
@@ -27,7 +27,7 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:openvswitch:openvswitch
 
 PKG_BUILD_DIR:=$(ovs_builddir)
-PKG_BUILD_DEPENDS+=python3/host python-six/host
+PKG_BUILD_DEPENDS+=python3/host
 PKG_USE_MIPS16:=0
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf
@@ -234,7 +234,7 @@ $(eval $(call OvsPackageTemplate,openvswitch))
 
 ovs_python3_title:=Open vSwitch (Python3 library)
 ovs_python3_hidden:=
-ovs_python3_depends:=+PACKAGE_openvswitch-python3:python3 +PACKAGE_openvswitch-python3:python3-six
+ovs_python3_depends:=+PACKAGE_openvswitch-python3:python3
 define ovs_python3_install
 	$$(INSTALL_DIR) $$(1)$$(PYTHON3_PKG_DIR)
 	$$(CP) $$(PKG_INSTALL_DIR)/usr/share/openvswitch/python/ovs $$(1)$$(PYTHON3_PKG_DIR)

--- a/net/ovn/Makefile
+++ b/net/ovn/Makefile
@@ -10,7 +10,7 @@ include ../openvswitch/openvswitch.mk
 
 PKG_NAME:=ovn
 PKG_VERSION:=20.12.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/ovn-org/ovn.git
@@ -22,7 +22,7 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:openvswitch:openvswitch
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
-PKG_BUILD_DEPENDS+=python3/host python-six/host
+PKG_BUILD_DEPENDS+=python3/host
 PKG_USE_MIPS16:=0
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf

--- a/net/ovn/patches/0002-build-skip-tests-and-docs.patch
+++ b/net/ovn/patches/0002-build-skip-tests-and-docs.patch
@@ -10,7 +10,7 @@ Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
 
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -483,11 +483,9 @@ dist-docs:
+@@ -479,11 +479,9 @@ dist-docs:
  
  
  include automake.mk


### PR DESCRIPTION
Maintainer: me & @jefferyto for python-six, @yousong for OVS & OVN
Compile tested: x86 https://github.com/openwrt/openwrt/commit/83f1d72dea093836d8c4f6a8a1ace7c56ac05059
Run tested: n/a

Six is no longer a requirement for OVS and OVN for some time now.
This change removes it and also the host-build from python-six.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>