### PR TITLE
docker-compose: Update to version 2.1.1

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.1.0
+PKG_VERSION:=2.1.1
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=48b20b1b75de0e517deb0e29122ecdb01982f136e68429bdf6a97121701d4274
+PKG_HASH:=5c9246c34cafeb51b3289c016cb2cbdd08b3eda87b0f8d4cc02fd7630cfdbd7b
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New small upstream update, for some reason flagged as `PRE-RELEASE`, although I got the update in Arch already.

What's Changed:

 - Fix the maintainers array in MAINTAINERS by @rumpl in #8868

 - Introduce up --wait condition by @ndeloof in #8777

 - Don't exit on container destroy events by @sdt in #8859

 - Update golang to 1.17 by @rumpl in #8873

 - Support inherited environment vars on exec by @ulyssessouza in #8857

 - Restore support for multiple build-args by @ndeloof in #8889
