### PR TITLE
[19.07] php7: Update and clean up distributed php7.ini

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=7.2.34
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 

--- a/lang/php7/files/php.ini
+++ b/lang/php7/files/php.ini
@@ -1,12 +1,12 @@
 [PHP]
-zend.ze1_compatibility_mode = Off
 
-; Language Options
+;;;;;;;;;;;;;;;;;;;;
+; Language Options ;
+;;;;;;;;;;;;;;;;;;;;
 
 engine = On
 ;short_open_tag = Off
-precision    =  12
-y2k_compliance = On
+precision = 12
 output_buffering = Off
 ;output_handler =
 zlib.output_compression = Off
@@ -15,71 +15,43 @@ zlib.output_compression = Off
 implicit_flush = Off
 unserialize_callback_func =
 serialize_precision = 100
-
 ;open_basedir =
 disable_functions =
 disable_classes =
-
-; Colors for Syntax Highlighting mode.  Anything that's acceptable in
-; <span style="color: ???????"> would work.
-;highlight.string  = #DD0000
+;highlight.string = #DD0000
 ;highlight.comment = #FF9900
 ;highlight.keyword = #007700
-;highlight.bg      = #FFFFFF
+;highlight.bg = #FFFFFF
 ;highlight.default = #0000BB
-;highlight.html    = #000000
-
+;highlight.html = #000000
 ;ignore_user_abort = On
 ;realpath_cache_size = 16k
 ;realpath_cache_ttl = 120
+;zend.enable_gc = On
+;zend.multibyte = Off
+;zend.script_encoding =
 
-; Miscellaneous
+;;;;;;;;;;;;;;;;;
+; Miscellaneous ;
+;;;;;;;;;;;;;;;;;
 
 expose_php = On
 
-; Resource Limits
+;;;;;;;;;;;;;;;;;;;
+; Resource Limits ;
+;;;;;;;;;;;;;;;;;;;
 
-max_execution_time = 30	; Maximum execution time of each script, in seconds.
-max_input_time = 60	; Maximum amount of time each script may spend parsing request data.
+max_execution_time = 30
+max_input_time = 60
 ;max_input_nesting_level = 64
-memory_limit = 8M	; Maximum amount of memory a script may consume.
+;max_input_vars = 1000
+memory_limit = 8M
 
-; Error handling and logging
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Error handling and logging ;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; Error Level Constants:
-; E_ALL             - All errors and warnings (includes E_STRICT as of PHP 6.0.0)
-; E_ERROR           - fatal run-time errors
-; E_RECOVERABLE_ERROR  - almost fatal run-time errors
-; E_WARNING         - run-time warnings (non-fatal errors)
-; E_PARSE           - compile-time parse errors
-; E_NOTICE          - run-time notices (these are warnings which often result
-;                     from a bug in your code, but it's possible that it was
-;                     intentional (e.g., using an uninitialized variable and
-;                     relying on the fact it's automatically initialized to an
-;                     empty string)
-; E_STRICT			- run-time notices, enable to have PHP suggest changes
-;                     to your code which will ensure the best interoperability
-;                     and forward compatibility of your code
-; E_CORE_ERROR      - fatal errors that occur during PHP's initial startup
-; E_CORE_WARNING    - warnings (non-fatal errors) that occur during PHP's
-;                     initial startup
-; E_COMPILE_ERROR   - fatal compile-time errors
-; E_COMPILE_WARNING - compile-time warnings (non-fatal errors)
-; E_USER_ERROR      - user-generated error message
-; E_USER_WARNING    - user-generated warning message
-; E_USER_NOTICE     - user-generated notice message
-; E_DEPRECATED      - warn about code that will not work in future versions
-;                     of PHP
-; E_USER_DEPRECATED - user-generated deprecation warnings
-;
-; Common Values:
-;   E_ALL & ~E_NOTICE  (Show all errors, except for notices and coding standards warnings.)
-;   E_ALL & ~E_NOTICE | E_STRICT  (Show all errors, except for notices)
-;   E_COMPILE_ERROR|E_RECOVERABLE_ERROR|E_ERROR|E_CORE_ERROR  (Show only errors)
-;   E_ALL | E_STRICT  (Show all errors, warnings and notices including coding standards.)
-; Default Value: E_ALL & ~E_NOTICE
-error_reporting  =  E_ALL & ~E_NOTICE & ~E_STRICT
-
+error_reporting = E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT
 display_errors = On
 display_startup_errors = Off
 log_errors = Off
@@ -92,61 +64,66 @@ track_errors = Off
 ;html_errors = Off
 ;docref_root = "/phpmanual/"
 ;docref_ext = .html
-;error_prepend_string = "<font color=#ff0000>"
-;error_append_string = "</font>"
-; Log errors to specified file.
-;error_log = /var/log/php_errors.log
-; Log errors to syslog.
+;error_prepend_string = "<span style='color: #ff0000'>"
+;error_append_string = "</span>"
 ;error_log = syslog
 
-; Data Handling
+;;;;;;;;;;;;;;;;;
+; Data Handling ;
+;;;;;;;;;;;;;;;;;
 
 ;arg_separator.output = "&amp;"
 ;arg_separator.input = ";&"
 variables_order = "EGPCS"
 request_order = "GP"
-register_globals = Off
-register_long_arrays = Off
 register_argc_argv = On
 auto_globals_jit = On
+;enable_post_data_reading = Off
 post_max_size = 8M
-;magic_quotes_gpc = Off
-magic_quotes_runtime = Off
-magic_quotes_sybase = Off
 auto_prepend_file =
 auto_append_file =
 default_mimetype = "text/html"
-;default_charset = "iso-8859-1"
-;always_populate_raw_post_data = On
+;default_charset = "UTF-8"
+;internal_encoding =
+;input_encoding =
+;output_encoding =
 
-; Paths and Directories
+;;;;;;;;;;;;;;;;;;;;;;;;;
+; Paths and Directories ;
+;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; UNIX: "/path1:/path2"
 ;include_path = ".:/php/includes"
 doc_root = "/www"
 user_dir =
 extension_dir = "/usr/lib/php"
+;sys_temp_dir = "/tmp"
 enable_dl = On
 ;cgi.force_redirect = 1
 ;cgi.nph = 1
-;cgi.redirect_status_env = ;
-cgi.fix_pathinfo=1
-;fastcgi.impersonate = 1;
+;cgi.redirect_status_env =
+cgi.fix_pathinfo = 1
+;cgi.discard_path = 1
+;fastcgi.impersonate = 1
 ;fastcgi.logging = 0
 ;cgi.rfc2616_headers = 0
+;cgi.check_shebang_line = 1
 
-; File Uploads
+;;;;;;;;;;;;;;;;
+; File Uploads ;
+;;;;;;;;;;;;;;;;
 
 file_uploads = On
 upload_tmp_dir = "/tmp"
 upload_max_filesize = 2M
 max_file_uploads = 20
 
-; Fopen wrappers
+;;;;;;;;;;;;;;;;;;
+; Fopen wrappers ;
+;;;;;;;;;;;;;;;;;;
 
 allow_url_fopen = On
 allow_url_include = Off
-;from="john@doe.com"
-;user_agent="PHP"
+;from = "john@doe.com"
+;user_agent = "PHP"
 default_socket_timeout = 60
 ;auto_detect_line_endings = Off


### PR DESCRIPTION
Clean up and update distributed `php.ini` for php 7.2.34

Description:
- Cleaned up whitespace and removed comments (refer to official PHP documentation for that)
- Removed directives that no longer exist as of PHP 7.2.34
- Added `~E_DEPRECATED` to `error_reporting`

All the changes except `error_reporting` are strictly non functional, i.e. of the things not commented out, the ones removed have no effect on the current PHP version.

The only functional change is the addition of `~E_DEPRECATED` to `error_reporting` which I believe fits well together with `~E_NOTICE` and `~E_STRICT`, also officially recommended for production.

Directives removed that no longer exist as of PHP 7.2.34:
- `zend.ze1_compatibility_mode`
- `y2k_compliance`
- `register_globals`
- `register_long_arrays`
- `magic_quotes_gpc`
- `magic_quotes_runtime`
- `magic_quotes_sybase`
- `always_populate_raw_post_data`

This PR is strictly for 19.07, I will do a separate PR for the branches above as they distribute a different PHP version.

Maintainer: @mhei (Michael Heimpold)
