### PR TITLE
[21.02] cyrus-sasl: patch CVE-2019-19906

### DIFF
--- a/libs/cyrus-sasl/Makefile
+++ b/libs/cyrus-sasl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cyrus-sasl
 PKG_VERSION:=2.1.27
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 

--- a/libs/cyrus-sasl/patches/CVE-2019-19906.patch
+++ b/libs/cyrus-sasl/patches/CVE-2019-19906.patch
@@ -1,0 +1,23 @@
+From dcc9f51cbd4ed622cfb0f9b1c141eb2ffe3b12f1 Mon Sep 17 00:00:00 2001
+From: Quanah Gibson-Mount <quanah@symas.com>
+Date: Tue, 18 Feb 2020 19:05:12 +0000
+Subject: [PATCH] Fix #587
+
+Off by one error in common.c, CVE-2019-19906.
+
+Thanks to Stephan Zeisberg for reporting
+---
+ lib/common.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/lib/common.c
++++ b/lib/common.c
+@@ -190,7 +190,7 @@ int _sasl_add_string(char **out, size_t
+ 
+   if (add==NULL) add = "(null)";
+ 
+-  addlen=strlen(add); /* only compute once */
++  addlen=strlen(add)+1; /* only compute once */
+   if (_buf_alloc(out, alloclen, (*outlen)+addlen)!=SASL_OK)
+     return SASL_NOMEM;
+ 


### PR DESCRIPTION
Maintainer: @flyn-org
Compile tested: aarch64, Turris MOX, OpenWrt 21.02

Description: https://nvd.nist.gov/vuln/detail/CVE-2019-19906
