### PR TITLE
yq: Update to 4.14.2

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.14.1
+PKG_VERSION:=4.14.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=294300a8c182c3f8e1f537ad2feebb6d0651f61330f33504bdc502f48992bf84
+PKG_HASH:=2917a72bc0cb0fbd132b3257ff9162db83d129adc5670f7661c29a873684e04a
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: ipq807x, rockchip
Run tested: rk3328 nanopi-r2s

Description:
bug fixes.
Release note: https://github.com/mikefarah/yq/releases/tag/v4.14.2