### PR TITLE
ddns-scripts: Fix typo in route53 update script

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=15
+PKG_RELEASE:=16
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_route53_v1.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_route53_v1.sh
@@ -4,7 +4,7 @@
 # 2017 Max Berger <max at berger dot name>
 
 [ -z "${CURL_SSL}" ] && write_log 14 "Amazon AWS Route53 communication require cURL with SSL support. Please install"
-[ -z "{$username}" ] && write_log 14 "Service section not configured correctly! Missing key as 'username'"
+[ -z "${username}" ] && write_log 14 "Service section not configured correctly! Missing key as 'username'"
 [ -z "${password}" ] && write_log 14 "Service section not configured correctly! Missing secret as 'password'"
 [ -z "${domain}" ] && write_log 14 "Service section not configured correctly! Missing zone id as 'domain'"
 


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: N/A
Run tested: No

Description: Fix typo in the route53 ddns update script that caused it not to recognise a missing username key