### PR TITLE
smcroute: update to 2.5.4

### DIFF
--- a/net/smcroute/Makefile
+++ b/net/smcroute/Makefile
@@ -8,16 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=smcroute
-PKG_VERSION:=2.5.3
+PKG_VERSION:=2.5.4
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/troglobit/smcroute/releases/download/$(PKG_VERSION)
-PKG_HASH:=4342b95c99e410cab75e9ee80f20480e0170d8b07b8e31553ba1bec3e377fc56
-
-PKG_FIXUP:=autoreconf
+PKG_HASH:=96b890fd6fbf8553010f62beda991742f7b4e7e8aea3e75335fb6048b15869da
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Signed-off-by: Moritz Warning <moritzwarning@web.de>

Maintainer: me
Compile tested: ath79/generic, OpenWrt master
Run tested: not tested