### PR TITLE
zerotier: update to 1.8.2

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -6,14 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
-PKG_VERSION:=1.8.1
+PKG_VERSION:=1.8.2
 PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/zerotier/ZeroTierOne.git
-PKG_SOURCE_DATE:=2021-11-05
-PKG_SOURCE_VERSION:=7a626abf156a9dbac45a14061e5e1a182083a61c
-PKG_MIRROR_HASH:=b98ca72e72ee4ad8f9fed2ddb14599c94a9e78fd5f44fd9920b4b0e5c6f9dcf7
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=e5695df264cf5fe45582c61976bcfbdfa49ff491e91d5b520acd1e14a057fd2c
+PKG_BUILD_DIR:=$(BUILD_DIR)/ZeroTierOne-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
 PKG_LICENSE:=BSL 1.1

--- a/net/zerotier/patches/0001-fix-makefile.patch
+++ b/net/zerotier/patches/0001-fix-makefile.patch
@@ -35,7 +35,7 @@
  endif
  
  ifeq ($(ZT_QNAP), 1)
-@@ -270,7 +270,7 @@ ifeq ($(ZT_CONTROLLER),1)
+@@ -280,7 +280,7 @@ ifeq ($(ZT_CONTROLLER),1)
  endif
  
  # ARM32 hell -- use conservative CFLAGS


### PR DESCRIPTION
Signed-off-by: Moritz Warning <moritzwarning@web.de>

Maintainer: me
Compile tested: ath79/generic, OpenWrt master
Run tested: not tested

Update und switch back to release source package.