### PR TITLE
[openwrt-21.02] rclone: Update to 1.57.0

### DIFF
--- a/net/rclone/Makefile
+++ b/net/rclone/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rclone
-PKG_VERSION:=1.56.2
+PKG_VERSION:=1.57.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/rclone/rclone/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=a5b0b7dfe17d9ec74e3a33415eec4331c61d800d8823621e61c6164e8f88c567
+PKG_HASH:=294f7a6b0874509997d3a9ffae7c74f0c45b687df0ac7d7742f284ad3814fe55
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILE:=LICENSE
@@ -60,9 +60,6 @@ endef
 define Package/rclone-config/conffiles
 /etc/config/rclone
 endef
-
-# Disable CGO due to ld linker issue
-GO_PKG_TARGET_VARS:=$(filter-out CGO_ENABLED=%,$(GO_PKG_TARGET_VARS)) CGO_ENABLED=0
 
 define Package/rclone/install
 	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))

--- a/net/rclone/patches/010-disable-plugins.patch
+++ b/net/rclone/patches/010-disable-plugins.patch
@@ -1,0 +1,22 @@
+--- a/librclone/librclone.go
++++ b/librclone/librclone.go
+@@ -37,7 +37,7 @@ import (
+ 	_ "github.com/rclone/rclone/backend/all"   // import all backends
+ 	_ "github.com/rclone/rclone/fs/operations" // import operations/* rc commands
+ 	_ "github.com/rclone/rclone/fs/sync"       // import sync/*
+-	_ "github.com/rclone/rclone/lib/plugin"    // import plugins
++	// _ "github.com/rclone/rclone/lib/plugin"    // import plugins
+ )
+ 
+ // RcloneInitialize initializes rclone as a library
+--- a/rclone.go
++++ b/rclone.go
+@@ -7,7 +7,7 @@ import (
+ 	_ "github.com/rclone/rclone/backend/all" // import all backends
+ 	"github.com/rclone/rclone/cmd"
+ 	_ "github.com/rclone/rclone/cmd/all"    // import all commands
+-	_ "github.com/rclone/rclone/lib/plugin" // import plugins
++	// _ "github.com/rclone/rclone/lib/plugin" // import plugins
+ )
+ 
+ func main() {

--- a/net/rclone/test.sh
+++ b/net/rclone/test.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-rclone version | grep "$2"
+case "$1" in
+	"rclone")
+		rclone version | grep "$2"
+		;;
+esac


### PR DESCRIPTION
Maintainer: @ElonH, me
Compile tested: bcm27xx/bcm2710
Run tested: raspberrypi-3b

Description:
Disabled unused plugins and re-enabled CGO.
Fixed test script
Changelog: https://rclone.org/changelog/#v1-57-0-2021-11-01
(cherry picked from commit f712dc311e7c9b76b324e826f85eb2a5dfe33e62)