### PR TITLE
banip: update nginx matching

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
 PKG_VERSION:=0.7.10
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/banip/files/banip.sh
+++ b/net/banip/files/banip.sh
@@ -813,7 +813,7 @@ f_bgsrv() {
 			ban_search="${ban_search}luci: failed login|"
 		fi
 		if printf "%s\n" "${ban_logterms}" | grep -q "nginx"; then
-			ban_search="${ban_search}nginx\[[0-9]+\]:.*\[error\].*open().*client: [[:alnum:].:]+|"
+			ban_search="${ban_search}nginx(\[[0-9]+\])?:.*\[error\].*open().*client: [[:alnum:].:]+|"
 		fi
 		(
 			"${ban_logservice}" "${ban_search%?}" &


### PR DESCRIPTION
Currently banip matches nginx log entries starting with
nginx[number]:...

I am running a containerized nginx with alpine as base, which
ends up adding log entries without [number] part..
like this:
nginx:...

This patch updates regex for nginx log entry search to include
both versions.

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>

Maintainer: Dirk Brenken / @dibdot 
Compile tested: x86_64, pc, recent git