### PR TITLE
syslog-ng: update to version 3.35.1

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
-PKG_VERSION:=3.34.1
+PKG_VERSION:=3.35.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
@@ -11,7 +11,7 @@ PKG_CPE_ID:=cpe:/a:balabit:syslog-ng
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syslog-ng/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
-PKG_HASH:=cece39ec1c68c88d493705e0a528b83d038da384e89d4838393ccc75f62a2d4c
+PKG_HASH:=1d0238b06b3e5987c859e5b529ecee738f75bacff04b149398b1fe8cbb121e53
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1

--- a/admin/syslog-ng/files/syslog-ng.conf
+++ b/admin/syslog-ng/files/syslog-ng.conf
@@ -4,7 +4,7 @@
 # More details about these settings can be found here:
 # https://www.syslog-ng.com/technical-documents/list/syslog-ng-open-source-edition
 
-@version: 3.33
+@version: 3.35
 @include "scl.conf"
 
 options {


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris 1.x, powerpc 8540, OpenWrt 19.07 and for current version, it will be done by CI
Run tested: Turris 1.x, powerpc 8540, OpenWrt 19.07 and for current version, it will be done by Github Actions

Description:

- Changelog: https://github.com/syslog-ng/syslog-ng/releases/tag/syslog-ng-3.35.1