### PR TITLE
pdns: Update to 4.5.2

### DIFF
--- a/net/pdns/Makefile
+++ b/net/pdns/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns
-PKG_VERSION:=4.5.1
+PKG_VERSION:=4.5.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=74d63c7aa0474de3c2137bb808164691a1a3a62942d2a9a70b648cd277923f9b
+PKG_HASH:=93d94a2500b1b3288dde0e76da7c40095382d93f0998d0f15449d1e6fc033641
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>
 PKG_LICENCE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: @Habbie 
Compile tested:ramips (MIPS), HLK-7621 evaluation board, OpenWrt commit 959a0308e5ac3af5a27fc5c401e8e11b5d316c6f
Run tested: ramips (MIPS), HLK-7621 evaluation board, OpenWrt commit 959a0308e5ac3af5a27fc5c401e8e11b5d316c6f, ran it and checked that it responded to `dig -p 5353 chaos txt version.pdns @192.168.5.1`

Description:
This PR updates PowerDNS Authoritative Server to its latest version, v4.5.2.