### PR TITLE
netifyd: update to 3.09

### DIFF
--- a/net/netifyd/Makefile
+++ b/net/netifyd/Makefile
@@ -1,12 +1,12 @@
 #
-# Copyright (C) 2016-2020 eGloo, Incorporated
+# Copyright (C) 2016-2021 eGloo, Incorporated
 #
 # This is free software, licensed under the GNU General Public License v2.
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifyd
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Darryl Sokoloski <darryl@egloo.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 
@@ -16,10 +16,10 @@ PKG_INSTALL:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.com/netify.ai/public/netify-agent.git
-PKG_SOURCE_DATE:=2021-05-19
-PKG_SOURCE_VERSION:=v3.07
-#PKG_SOURCE_VERSION:=a22c66b9d916347b34f6d26de2a95c94f446401b
-PKG_MIRROR_HASH:=de6c4ce7bb00ec72478a7eeaa44b1a30d2ef64202f8524a000bce6015441a5ca
+PKG_SOURCE_DATE:=2021-11-17
+PKG_SOURCE_VERSION:=v3.09
+#PKG_SOURCE_VERSION:=358ec2b0ac321e0608e78c75f6b7434ed1aec326
+PKG_MIRROR_HASH:=660079a75a17a07c638b25dab0ecc972c02fec2124930068bfcf15d28abf4121
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -74,7 +74,7 @@ endif
 
 define Build/Configure
 	(cd $(PKG_BUILD_DIR); ./autogen.sh)
-	$(call Build/Configure/Default,$(CONFIGURE_ARGS))
+	$(call Build/Configure/Default)
 endef
 
 define Build/InstallDev

--- a/net/netifyd/files/netifyd.init
+++ b/net/netifyd/files/netifyd.init
@@ -67,7 +67,7 @@ start_netifyd() {
 	procd_open_instance
 	procd_set_param file /etc/netifyd.conf
 	procd_set_param term_timeout 20
-	procd_set_param respawn
+	procd_set_param respawn 3600 5 0
 	procd_set_param command $PROG -R
 
 	config_list_foreach "$instance" options append_params
@@ -91,4 +91,8 @@ start_service() {
 
 	config_load netifyd
 	config_foreach start_netifyd netifyd
+}
+
+reload_service() {
+	procd_send_signal netifyd
 }


### PR DESCRIPTION
Signed-off-by: Darryl Sokoloski darryl@sokoloski.ca

Maintainer: Darryl Sokoloski / @dsokoloski
Compile tested: arm_cortex-a15_neon-vfpv4, TP-Link Archer C2600, master
Run tested: TP-Link Archer C2600

Description:

OpenWrt:
[IMP] Added infinite respawn.
[IMP] Added reload support to OpenWrt init script.
[FIX] Auto-configuration options passing.
[FIX] Handling of device filter expressions from internal/external_if uci options.

General:
[FIX] Default provisioning URL fall-back (sink_url).
[FIX] Crash on start-up when a connecting socket client is waiting.
[FIX] Atomic variable access (must use load()).
[FIX] Endless loop condition parsing socket config.
[FIX] Flow stats being reset before flow_purge messages were written to socket(s).
[IMP] Added new option: maximum number of flows
[IMP] Persistent and volatile state paths are now configurable at build time.
[IMP] Silenced modprobe warnings.
[IMP] Added new flow metadata rehash logic.
[IMP] Added experimental support for jemalloc.
[IMP] Added TCP sequence tracking.
[IMP] Attempt to release memory back to the OS more aggressively (malloc_trim).
[IMP] Added support for UUIDs from pipe/exec sources.
[IMP] Enabled support for multiple simultaenous socket types (INET and UNIX).

Plugin Support:
[IMP] Added plugin event system (ex: RELOAD, STATUS_UPDATE).
[IMP] Always update the connection tracking ID (when available) for all flows.
[IMP] Added plugin version support (plugin versions are now visible from netifyd --help).
[IMP] New plugin type: stats