### PR TITLE
conntrack-tools: import patch to fix cache

### DIFF
--- a/net/conntrack-tools/Makefile
+++ b/net/conntrack-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=conntrack-tools
 PKG_VERSION:=1.4.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.netfilter.org/projects/conntrack-tools/files

--- a/net/conntrack-tools/patches/002-conntrackd-do-not-include-conntrack-ID-in-hashtable-cmp.patch
+++ b/net/conntrack-tools/patches/002-conntrackd-do-not-include-conntrack-ID-in-hashtable-cmp.patch
@@ -1,0 +1,40 @@
+From ed875ee2dc98fe8fd7f5d171ec33a96606682495 Mon Sep 17 00:00:00 2001
+From: Pablo Neira Ayuso <pablo@netfilter.org>
+Date: Mon, 8 Nov 2021 12:26:55 +0100
+Subject: conntrackd: do not include conntrack ID in hashtable cmp
+
+Depending on your conntrackd configuration, events might get lost,
+leaving stuck entries in the cache forever. Skip checking the conntrack
+ID to allow for lazy cleanup by when a new entry that is represented by
+the same tuple is added.
+
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ src/cache-ct.c | 11 +----------
+ 1 file changed, 1 insertion(+), 10 deletions(-)
+
+--- a/src/cache-ct.c
++++ b/src/cache-ct.c
+@@ -88,21 +88,12 @@ cache_ct_hash(const void *data, const st
+ 	return ret;
+ }
+ 
+-/* master conntrack of expectations have no ID */
+-static inline int
+-cache_ct_cmp_id(const struct nf_conntrack *ct1, const struct nf_conntrack *ct2)
+-{
+-	return nfct_attr_is_set(ct2, ATTR_ID) ?
+-	       nfct_get_attr_u32(ct1, ATTR_ID) == nfct_get_attr_u32(ct2, ATTR_ID) : 1;
+-}
+-
+ static int cache_ct_cmp(const void *data1, const void *data2)
+ {
+ 	const struct cache_object *obj = data1;
+ 	const struct nf_conntrack *ct = data2;
+ 
+-	return nfct_cmp(obj->ptr, ct, NFCT_CMP_ORIG) &&
+-	       cache_ct_cmp_id(obj->ptr, ct);
++	return nfct_cmp(obj->ptr, ct, NFCT_CMP_ORIG);
+ }
+ 
+ static void *cache_ct_alloc(void)


### PR DESCRIPTION
As written in the commit message:

Depending on your conntrackd configuration, events might get lost,
leaving stuck entries in the cache forever. Skip checking the conntrack
ID to allow for lazy cleanup by when a new entry that is represented by
the same tuple is added.

Maintainer: @jow- 
Compile tested: Edge Router 4 (trunk)
Run tested: Edge Router 4
