### PR TITLE
telegraf: Update package to version 1.20.4

### DIFF
--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telegraf
-PKG_VERSION:=1.20.3
+PKG_VERSION:=1.20.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=cf8fd4d38970648281101e8a71b1a48c5765c8aaa9d67619c00272c9192e9057
+PKG_HASH:=75b6edbee5084bdf6e8cc216588d17b3e248d141baef5e917036f172099d6732
 
 PKG_MAINTAINER:=Jonathan Pagel <jonny_tischbein@systemli.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Signed-off-by: Jonathan Pagel jonny_tischbein@systemli.org

Maintainer:
me

Compile tested:
on amd64 for aarch64 on https://git.openwrt.org/openwrt/openwrt.git commit b3237baf63b2b38c257ba9f6488d54fc89d5ed69

Run tested:
aarch64 (Banana PI R64), package installed, configured, starting via /etc/init.d/, configuring telegraf config and successfull working of input plugin prometheus and output plugin influxdb tested.

Description:
Update to version 1.20.4

Telegraf is a plugin-driven agent for collecting and sending metrics and events. It supports various inputs (including prometheus endpoints) and is able to send data into InfluxDB. https://www.influxdata.com/time-series-platform/telegraf/