### PR TITLE
zabbix: fix 6in4 network interface discovery

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=5.0.7
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/5.0/

--- a/admin/zabbix/files/network
+++ b/admin/zabbix/files/network
@@ -3,4 +3,4 @@
 # network interface discovery
 # example: {"data":[{"{#IF}":"lo", "{#NET}":"loopback"},{"{#IF}":"br-lan", "{#NET}":"lan"},{"{#IF}":"eth0.1", "{#NET}":"wan"}]}
 #
-UserParameter=netowrt.discovery,lua -l ubus -e 'u=ubus.connect();list="{\"data\":[";dump=u:call("network.interface", "dump", {});for _, intf in ipairs(dump.interface) do list=list.."{\"{#IF}\":\""..intf.device.."\", \"{#NET}\":\""..intf.interface.."\"},";end;list=string.gsub(list,",$","");print(list.."]}")'
+UserParameter=netowrt.discovery,lua -l ubus -e 'u=ubus.connect();list="{\"data\":[";dump=u:call("network.interface", "dump", {});for _, intf in ipairs(dump.interface) do list=list.."{\"{#IF}\":\""..(intf.device or intf.l3_device).."\", \"{#NET}\":\""..intf.interface.."\"},";end;list=string.gsub(list,",$","");print(list.."]}")'


### PR DESCRIPTION
Those devices don't have 'device' propery, only 'l3_device', which
causes 'attempt to concatenate field 'device' (a nil value)' lua error.

Use 'l3_device' as a fallback in this case.

Signed-off-by: Jacek Konieczny <jajcus@jajcus.net>

Maintainer: @champtar
Compile tested: none
Run tested: OpenWrt 21.02.1, r16325-88151b8303 – modified file installed zabbix agent restarted, results checked on zabbix server

Description:
Fixes Zabbix network discovery when 6in4 tunnel is in use.

Before:
```
root@OpenWrt:~# zabbix_agentd -t netowrt.discovery
netowrt.discovery                            
 [t|lua: (command line):1: attempt to concatenate field 'device' (a nil value)
stack traceback:
        (command line):1: in main chunk
        [C]: ?]
```

After:
```
root@OpenWrt:~# zabbix_agentd -t netowrt.discovery
netowrt.discovery                             [t|{"data":[{"{#IF}":"br-lan", "{#NET}":"lan"},{"{#IF}":"lo", "{#NET}":"loopback"},{"{#IF}":"wan", "{#NET}":"wan"},{"{#IF}":"6in4-wan6", "{#NET}":"wan6"}]}]
```