### PR TITLE
prometheus-node-exporter-lua: listen on ipv4 and ipv6

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2021.10.31
+PKG_VERSION:=2021.11.19
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/utils/prometheus-node-exporter-lua/files/etc/config/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/etc/config/prometheus-node-exporter-lua
@@ -1,4 +1,4 @@
 config prometheus-node-exporter-lua 'main'
 	option listen_interface 'loopback'
-	option listen_ipv6 '0'
+	option listen_family 'any'
 	option listen_port '9100'

--- a/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
@@ -11,39 +11,58 @@ _log() {
 start_service() {
 	. /lib/functions/network.sh
 
-	local interface ipv6 port bind
+	local interface family ipv6 port bind bind6 bind4
 
 	config_load prometheus-node-exporter-lua.main
 	config_get interface "main" listen_interface "loopback"
-	config_get_bool ipv6 "main" listen_ipv6 0
+	# Compatibility with old conf
+	config_get_bool ipv6 "main" listen_ipv6
+	config_get family "main" listen_family "any"
 	config_get port "main" listen_port 9100
 
-	if [ "$interface" = "*" ]; then
-		[ "$ipv6" = 1 ] && bind="::" || bind="0.0.0.0"
-	else
-		if [ "$ipv6" = 1 ]; then
-			network_get_ipaddr6 bind "$interface"
-		else
-			network_get_ipaddr bind "$interface"
-		fi
+	# Migration from ipv6 to family
+	if [ "$ipv6" ]; then
+		_log "please migrate from ipv6 to family"
+		case "$ipv6" in
+			0) family="ipv4";;
+			1) family="ipv6";;
+		esac
+		unset ipv6
+	fi
 
-		network_is_up "$interface" && [ -n "$bind" ] || {
+	if [ "$interface" != "*" ]; then
+		if [ "$family" = "any" ] || [ "$family" = "ipv4" ]; then
+			network_get_ipaddrs bind4 "$interface"
+		fi
+		if [ "$family" = "any" ] || [ "$family" = "ipv6" ]; then
+			network_get_ipaddrs6 bind6 "$interface"
+		fi
+		network_is_up "$interface" && ([ -n "$bind6" ] || [ -n "$bind4" ]) || {
 			_log "defering start until listen interface $interface becomes ready"
 			return 0
 		}
+		set -- $bind4 $bind6
+	else
+		set -- ::
 	fi
 
-	procd_open_instance
+	for bind; do
+		procd_open_instance "$bind"
 
-	procd_set_param command /usr/bin/prometheus-node-exporter-lua
-	procd_append_param command --bind ${bind}
-	procd_append_param command --port ${port}
+		procd_set_param command /usr/bin/prometheus-node-exporter-lua
+		procd_append_param command --bind ${bind}
+		procd_append_param command --port ${port}
+		case "$family" in
+			"ipv4") procd_append_param command -4;;
+			"ipv6") procd_append_param command -6;;
+		esac
 
-	procd_set_param stdout 1
-	procd_set_param stderr 1
-	procd_set_param respawn
+		procd_set_param stdout 1
+		procd_set_param stderr 1
+		procd_set_param respawn
 
-	procd_close_instance
+		procd_close_instance
+	done
 }
 
 service_triggers()

--- a/utils/prometheus-node-exporter-lua/files/usr/bin/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/bin/prometheus-node-exporter-lua
@@ -108,12 +108,19 @@ end
 
 -- Main program
 
+family="any"
 for k,v in ipairs(arg) do
   if (v == "-p") or (v == "--port") then
     port = arg[k+1]
   end
   if (v == "-b") or (v == "--bind") then
     bind = arg[k+1]
+  end
+  if (v == "-4") then
+    family="ipv4"
+  end
+  if (v == "-6") then
+    family="ipv6"
   end
 end
 
@@ -128,7 +135,37 @@ end
 ls_fd:close()
 
 if port then
-  server = assert(socket.bind(bind, port))
+
+  if not bind then
+    if family == "ipv4" then
+      bind="0.0.0.0"
+    else
+      bind="::"
+    end
+  else
+    if family == "any" then
+      addrinfo, err = socket.dns.getaddrinfo(bind)
+      for i, alt in ipairs(addrinfo) do
+        if alt.family == "inet" then
+	  -- socket.tcp does not respect ipv6-v6only==false and
+          -- socket.tcp6 does not bind to ipv4 addresses
+          family="ipv4"
+	  break
+        end
+      end
+    end
+  end
+
+  if family == "ipv4" then
+    server = assert(socket.tcp4())
+  else
+    server = assert(socket.tcp6())
+    server:setoption("ipv6-v6only", family == "ipv6")
+  end
+  server:setoption("reuseaddr", true)
+
+  assert(server:bind(bind, port))
+  assert(server:listen())
 
   while 1 do
     client = server:accept()


### PR DESCRIPTION
Permits the daemon to listen on both protocol family and
also on all interface addresses (using different instances)

* prometheus-node-exporter-lua script:
- Add new parameters (-4, -6) to select socket family in
prometheus-node-exporter-lua. By default it will use both
- Make bind optional. It will use :: or 0.0.0.0 as needed.

* prometheus-node-exporter-lua config:
- listen_family now defines the socket family (ipv4, ipv6 or any)
- listen_ipv6 is gone, although if present, it will be converted
  to listen_family, overhiding its settings

* prometheus-node-exporter-lua init script:
- when a listen_interface is defined (not '*'), it will launch an
  instance for each interface address, respecting listen_family

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: @champtar 
Compile tested: noarch
Run tested: x86_64

Description:
