### PR TITLE
bind: bump to 9.17.20

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.17.19
+PKG_VERSION:=9.17.20
 PKG_RELEASE:=$(AUTORELEASE)
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=6cddd714f01b71bb0265fde445be781d1a0ee5e909b9645407893596111d228d
+PKG_HASH:=93a961f6b4072af260c5d900299eb660defec035f9a000c864ea5b78869a4d35
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Signed-off-by: Noah Meyerhans <frodo@morgul.net>

Maintainer: me
Compile tested: master: x86, malta
Run tested: master: master/malta - verified recursive functionality (dnssec and unsigned), rndc status, server restart

Detailed upstream change list is at:
https://ftp.isc.org/isc/bind9/9.17.20/CHANGES
