### PR TITLE
libvpx: update to 1.11.0

### DIFF
--- a/libs/libvpx/Makefile
+++ b/libs/libvpx/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libvpx
-PKG_VERSION:=1.10.0
+PKG_VERSION:=1.11.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://chromium.googlesource.com/webm/libvpx
-PKG_MIRROR_HASH:=2f4d342e8efe566449dc5b2211dac22df81ec28792804b34d47c7dadf5c8a136
+PKG_MIRROR_HASH:=495e1f6d389d1c3b613a97927df7750aa499c649fd11eec6e1c9dcf5f403f134
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>


### PR DESCRIPTION
2021-09-27 v1.11.0 "Smew Duck"
  This maintenance release adds support for VBR mode in VP9 rate control
  interface, new codec controls to get quantization parameters and loop filter
  levels, and includes several improvements to NEON and numerous bug fixes.

  - Upgrading:
    New codec control is added to get quantization parameters and loop filter
    levels.

    VBR mode is supported in VP9 rate control library.

  - Enhancement:
    Numerous improvements for Neon optimizations.
    Code clean-up and refactoring.
    Calculation of rd multiplier is changed with BDRATE gains.

  - Bug fixes:
    Fix to overflow on duration.
    Fix to several instances of -Wunused-but-set-variable.
    Fix to avoid chroma resampling for 420mpeg2 input.
    Fix to overflow in calc_iframe_target_size.
    Fix to disallow skipping transform and quantization.
    Fix some -Wsign-compare warnings in simple_encode.
    Fix input file path in simple_encode_test.
    Fix valid range for under/over_shoot pct.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: me
Compile tested: mipsel_24kc arm_cortex-a9_vfpv3-d16 aarch64_cortex-a53 mips_24kc x86_64 arc_arc700 i386_pentium4
Run tested: x86_64 (qemu)

```
root@OpenWrt:~# opkg update
root@OpenWrt:~# opkg install /tmp/libvpx*.ipk /tmp/gst1-mod-vpx*.ipk
root@OpenWrt:~# opkg install gstreamer1-utils gst1-mod-vpx gst1-mod-videotestsrc gst1-mod-matroska gst1-mod-hls uhttpd
root@OpenWrt:~# /etc/init.d/uhttpd start
root@OpenWrt:~# cd /www && gst-launch-1.0 videotestsrc is-live=true ! vp8enc deadline=1 cpu-used=4 lag-in-frames=0 ! webmmux streamable=true ! hlssink max-files=5 target-duration=5
root@OpenWrt:~# cd /www && gst-launch-1.0 videotestsrc is-live=true ! vp9enc deadline=1 cpu-used=4 lag-in-frames=0 ! webmmux streamable=true ! hlssink max-files=5 target-duration=5

PC ~$ gst-play-1.0 http://192.168.1.1/playlist.m3u8
```



Description:

