### PR TITLE
libxml2: build host static lib with -fPIC

### DIFF
--- a/libs/libxml2/Makefile
+++ b/libs/libxml2/Makefile
@@ -70,6 +70,7 @@ define Package/libxml2-utils/description
 endef
 
 TARGET_CFLAGS += $(FPIC)
+HOST_CFLAGS += -fPIC
 
 CONFIGURE_ARGS += \
 	--enable-shared \


### PR DESCRIPTION
Maintainer: @mhei 
Compile tested: arm_cortexa7+neon-vfp4
Run tested: mediatek/mt7623 (bananapi,bpi-r2)
Description:
libxslt/host is complaing that static libxml2 should be with -fPIC.
Unconditionally enable -fPIC for for host build of libxml2.

Fixes: dc701d61b ("libxml2: don't build host shared libraries")
Signed-off-by: Daniel Golle <daniel@makrotopia.org>
