### PR TITLE
perl-try-tiny: update to 0.31

### DIFF
--- a/lang/perl-try-tiny/Makefile
+++ b/lang/perl-try-tiny/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-try-tiny
-PKG_VERSION:=0.30
-PKG_RELEASE:=2
+PKG_VERSION:=0.31
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/E/ET/ETHER/
 PKG_SOURCE:=Try-Tiny-$(PKG_VERSION).tar.gz
-PKG_HASH:=da5bd0d5c903519bbf10bb9ba0cb7bcac0563882bcfe4503aee3fb143eddef6b
+PKG_HASH:=3300d31d8a4075b26d8f46ce864a1d913e0e8467ceeba6655d5d2b2e206c11be
 PKG_BUILD_DIR:=$(BUILD_DIR)/perl/Try-Tiny-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Matt Merhar <mattmerhar@protonmail.com>


### PR DESCRIPTION
Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>

Maintainer: me
Compile tested: 21.02.0, x86_64
Run tested: 21.02.0, x86_64

Description:

This is mostly just docs / test suite changes without any functional ones. I did basic tests against perl-www, the only in-tree package depending on this one.