### PR TITLE
openvswitch: document missing options

### DIFF
--- a/net/openvswitch/README.md
+++ b/net/openvswitch/README.md
@@ -85,14 +85,16 @@ after adding or changing these options.
 The ovs_bridge section also supports the options below,
 for initialising a virtual bridge with an OpenFlow controller.
 
-| Name          | Type    | Required | Default                        | Description                                                |
-|---------------|---------|----------|--------------------------------|------------------------------------------------------------|
-| disabled      | boolean | no       | 0                              | If set to true, disable initialisation of the named bridge |
-| name          | string  | no       | Inherits UCI config block name | The name of the switch in the OVS daemon                   |
-| controller    | string  | no       | (none)                         | The endpoint of an OpenFlow controller for this bridge     |
-| datapath_id   | string  | no       | (none)                         | The OpenFlow datapath ID for this bridge                   |
-| datapath_desc | string  | no       | (none)                         | The OpenFlow datapath description for this bridge          |
-| fail_mode     | string  | no       | standalone                     | The bridge failure mode                                    |
+| Name               | Type    | Required | Default                        | Description                                                |
+|--------------------|---------|----------|--------------------------------|------------------------------------------------------------|
+| disabled           | boolean | no       | 0                              | If set to true, disable initialisation of the named bridge |
+| name               | string  | no       | Inherits UCI config block name | The name of the switch in the OVS daemon                   |
+| controller         | string  | no       | (none)                         | The endpoint of an OpenFlow controller for this bridge     |
+| datapath_id        | string  | no       | (none)                         | The OpenFlow datapath ID for this bridge                   |
+| datapath_desc      | string  | no       | (none)                         | The OpenFlow datapath description for this bridge          |
+| drop_unknown_ports | boolean | no       | 0                              | Remove ports not defined in UCI from the bridge            |
+| fail_mode          | string  | no       | standalone                     | The bridge failure mode                                    |
+| ports              | list    | no       | (none)                         | List of ports to add to the bridge                         |
 
 The ovs_port section can be used to add ports to a bridge. It supports the options below.
 


### PR DESCRIPTION
Maintainer: @yousong 
Compile tested: NA
Run tested: NA

Description:
Commit 1038ac1 ("openvswitch: add support for definining bridge ports...")
added two new options:
- drop_unknown_ports
- ports
They are missing from the README, so add them.