### PR TITLE
slirp4netns: new package

### DIFF
--- a/utils/slirp4netns/Makefile
+++ b/utils/slirp4netns/Makefile
@@ -1,0 +1,39 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=slirp4netns
+PKG_VERSION:=1.1.9
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/rootless-containers/slirp4netns/archive/v$(PKG_VERSION)
+PKG_HASH:=5ff0d3e4bf6b11c8a4fcf5bd3219b8d52096e3b8cc73ca760aa554bb1eb08768
+
+PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/slirp4netns
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=slirp4netns
+  DEPENDS:=@!arc +libslirp +libseccomp +glib2 +libcap
+  URL:=https://github.com/rootless-containers/slirp4netns
+endef
+
+define Package/slirp4netns/description
+  User-mode networking for unprivileged network namespaces
+endef
+
+define Package/slirp4netns/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/slirp4netns $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,slirp4netns))


### PR DESCRIPTION
Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>

Maintainer: Oskari Rauta / @oskarirauta
Compile tested: x86_64, recent git
Run tested: x86_64, recent git

Description:
slirp4netns is required for rootless containers (at least on podman) for networking.
slirp4netns requires libslirp, which is in PR #17197