### PR TITLE
conmon: remove unnecessary dependency

### DIFF
--- a/utils/conmon/Makefile
+++ b/utils/conmon/Makefile
@@ -12,7 +12,7 @@ PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DEPENDS:=golang/host libseccomp
+PKG_BUILD_DEPENDS:=libseccomp
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk


### PR DESCRIPTION
this patch removes unnecessary dependency to golang/host
as pointed out by @jefferyto earlier at #17063 

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>

Maintainer: Oskari Rauta / @oskarirauta
Compile tested: x86_64, git
Run tested: x86_64, git