### PR TITLE
apparmor,domoticz: use $(PYTHON3_VERSION) instead of hardcoding it in the Makefile

### DIFF
--- a/utils/apparmor/Makefile
+++ b/utils/apparmor/Makefile
@@ -192,13 +192,13 @@ define Package/apparmor-utils/install
 	$(INSTALL_DIR) $(1)/usr/share/apparmor/easyprof/templates $(1)/usr/share/apparmor/easyprof/policygroups
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)-utils/usr/share/apparmor/easyprof/templates/* $(1)/usr/share/apparmor/easyprof/templates/
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)-utils/usr/share/apparmor/easyprof/policygroups/* $(1)/usr/share/apparmor/easyprof/policygroups/
-	$(INSTALL_DIR) $(1)/usr/lib/python3.9/site-packages $(1)/usr/lib/python3.9/site-packages/apparmor $(1)/usr/lib/python3.9/site-packages/apparmor/rule
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)-utils/usr/lib/python3.9/site-packages/*.egg-info \
-		$(1)/usr/lib/python3.9/site-packages/
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)-utils/usr/lib/python3.9/site-packages/apparmor/*.py \
-		$(1)/usr/lib/python3.9/site-packages/apparmor/
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)-utils/usr/lib/python3.9/site-packages/apparmor/rule/*.py \
-		$(1)/usr/lib/python3.9/site-packages/apparmor/rule
+	$(INSTALL_DIR) $(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages $(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages/apparmor $(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages/apparmor/rule
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)-utils/usr/lib/python$(PYTHON3_VERSION)/site-packages/*.egg-info \
+		$(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)-utils/usr/lib/python$(PYTHON3_VERSION)/site-packages/apparmor/*.py \
+		$(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages/apparmor/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)-utils/usr/lib/python$(PYTHON3_VERSION)/site-packages/apparmor/rule/*.py \
+		$(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages/apparmor/rule
 	$(INSTALL_DIR) $(1)/etc/init.d $(1)/lib/functions
 	$(INSTALL_BIN) ./files/apparmor.sh $(1)/lib/functions/
 	$(INSTALL_BIN) ./files/apparmor.init $(1)/etc/init.d/apparmor

--- a/utils/domoticz/Makefile
+++ b/utils/domoticz/Makefile
@@ -75,7 +75,6 @@ CMAKE_OPTIONS += \
 
 TARGET_CFLAGS += -flto
 TARGET_CXXFLAGS += -DWITH_GPIO -flto
-TARGET_LDFLAGS += -lpython3.9
 
 define Build/Prepare
 	$(call Build/Prepare/Default)


### PR DESCRIPTION
Maintainer: @oskarirauta, @dwmw2 
Compile tested: mediatek, aarch64
Run tested: none

Description:
The packages fail to build with python 3.10, because the python version was hardcoded to the packages' Makefile, and there was a recent python change from 3.9 to 3.10.

Instead of hardcoding the pyton version, use `PYTHON3_VERSION` from python3-version.mk (included by `python3-package.mk`).

I have not run-tested them, but I did check that the apparmor files where properly installed in `/usr/lib/python3.10/site-packages`.