### PR TITLE
ddns-scripts: Fix wrong whitespace in preinst and postinst scripts

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -151,11 +151,12 @@ endef
 
 ###### *************************************************************************
 define Package/ddns-scripts/preinst
-	#!/bin/sh
-	# if NOT run buildroot then stop service
-	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
-	exit 0	# suppress errors
+#!/bin/sh
+# if NOT run buildroot then stop service
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
+exit 0	# suppress errors
 endef
+
 define Package/ddns-scripts/install
 	$(INSTALL_DIR)  $(1)/etc/uci-defaults
 	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns
@@ -172,268 +173,288 @@ define Package/ddns-scripts/install
 	$(INSTALL_DIR)  $(1)/usr/lib/ddns
 	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/dynamic_dns_*.sh $(1)/usr/lib/ddns
 endef
+
 define Package/ddns-scripts/postinst
-	#!/bin/sh
-	# if NOT run buildroot and PKG_UPGRADE then (re)start service if enabled
-	[ -z "$${IPKG_INSTROOT}" -a "$${PKG_UPGRADE}" = "1" ] && {
-		[ -x /etc/uci-defaults/ddns ] && \
-			/etc/uci-defaults/ddns && \
-				rm -f /etc/uci-defaults/ddns >/dev/null 2>&1
-		/etc/init.d/ddns enabled && \
-			/etc/init.d/ddns start >/dev/null 2>&1
-	}
-	exit 0	# suppress errors
+#!/bin/sh
+# if NOT run buildroot and PKG_UPGRADE then (re)start service if enabled
+[ -z "$${IPKG_INSTROOT}" -a "$${PKG_UPGRADE}" = "1" ] && {
+	[ -x /etc/uci-defaults/ddns ] && \
+		/etc/uci-defaults/ddns && \
+			rm -f /etc/uci-defaults/ddns >/dev/null 2>&1
+	/etc/init.d/ddns enabled && \
+		/etc/init.d/ddns start >/dev/null 2>&1
+}
+exit 0	# suppress errors
 endef
+
 define Package/ddns-scripts/prerm
-	#!/bin/sh
-	# if run within buildroot exit
-	[ -n "$${IPKG_INSTROOT}" ] && exit 0
-	# stop running scripts
-	/etc/init.d/ddns stop
-	/etc/init.d/ddns disable
-	# clear LuCI indexcache
-	rm -f /tmp/luci-indexcache >/dev/null 2>&1
-	exit 0	# suppress errors
+#!/bin/sh
+# if run within buildroot exit
+[ -n "$${IPKG_INSTROOT}" ] && exit 0
+# stop running scripts
+/etc/init.d/ddns stop
+/etc/init.d/ddns disable
+# clear LuCI indexcache
+rm -f /tmp/luci-indexcache >/dev/null 2>&1
+exit 0	# suppress errors
 endef
 
 ###### *************************************************************************
 define Package/ddns-scripts_cloudflare.com-v4/preinst
-	#!/bin/sh
-	# if NOT run buildroot then stop service
-	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
-	exit 0	# suppress errors
+#!/bin/sh
+# if NOT run buildroot then stop service
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
+exit 0	# suppress errors
 endef
+
 define Package/ddns-scripts_cloudflare.com-v4/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_cloudflare.com-v4
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/update_cloudflare_com_v4.sh $(1)/usr/lib/ddns
 endef
+
 define Package/ddns-scripts_cloudflare.com-v4/postinst
-	#!/bin/sh
-	# remove old services file entries
-	/bin/sed -i '/cloudflare\.com-v4/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
-	/bin/sed -i '/cloudflare\.com-v4/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
-	# and create new
-	printf "%s\\t%s\\n" '"cloudflare.com-v4"' '"update_cloudflare_com_v4.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
-	printf "%s\\t%s\\n" '"cloudflare.com-v4"' '"update_cloudflare_com_v4.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
-	# on real system restart service if enabled
-	[ -z "$${IPKG_INSTROOT}" ] && {
-		[ -x /etc/uci-defaults/ddns_cloudflare.com-v4 ] && \
-			/etc/uci-defaults/ddns_cloudflare.com-v4 && \
-				rm -f /etc/uci-defaults/ddns_cloudflare.com-v4 >/dev/null 2>&1
-		/etc/init.d/ddns enabled && \
-			/etc/init.d/ddns start >/dev/null 2>&1
-	}
-	exit 0	# suppress errors
+#!/bin/sh
+# remove old services file entries
+/bin/sed -i '/cloudflare\.com-v4/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
+/bin/sed -i '/cloudflare\.com-v4/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+# and create new
+printf "%s\\t%s\\n" '"cloudflare.com-v4"' '"update_cloudflare_com_v4.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+printf "%s\\t%s\\n" '"cloudflare.com-v4"' '"update_cloudflare_com_v4.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
+# on real system restart service if enabled
+[ -z "$${IPKG_INSTROOT}" ] && {
+	[ -x /etc/uci-defaults/ddns_cloudflare.com-v4 ] && \
+		/etc/uci-defaults/ddns_cloudflare.com-v4 && \
+			rm -f /etc/uci-defaults/ddns_cloudflare.com-v4 >/dev/null 2>&1
+	/etc/init.d/ddns enabled && \
+		/etc/init.d/ddns start >/dev/null 2>&1
+}
+exit 0	# suppress errors
 endef
+
 define Package/ddns-scripts_cloudflare.com-v4/prerm
-	#!/bin/sh
-	# if NOT run buildroot then stop service
-	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
-	# remove services file entries
-	/bin/sed -i '/cloudflare\.com-v4/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
-	/bin/sed -i '/cloudflare\.com-v4/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
-	exit 0	# suppress errors
+#!/bin/sh
+# if NOT run buildroot then stop service
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
+# remove services file entries
+/bin/sed -i '/cloudflare\.com-v4/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
+/bin/sed -i '/cloudflare\.com-v4/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+exit 0	# suppress errors
 endef
 
 ###### *************************************************************************
 define Package/ddns-scripts_freedns_42_pl/preinst
-	#!/bin/sh
-	# if NOT run buildroot then stop service
-	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
-	exit 0	# suppress errors
+#!/bin/sh
+# if NOT run buildroot then stop service
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
+exit 0	# suppress errors
 endef
+
 define Package/ddns-scripts_freedns_42_pl/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_freedns_42_pl
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/update_freedns_42_pl.sh $(1)/usr/lib/ddns
 endef
+
 define Package/ddns-scripts_freedns_42_pl/postinst
-	#!/bin/sh
-	# remove old services file entries
-	/bin/sed -i '/freedns\.42\.pl/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
-	# and create new
-	printf "%s\\t%s\\n" '"freedns.42.pl"' '"update_freedns_42_pl.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
-	# on real system restart service if enabled
-	[ -z "$${IPKG_INSTROOT}" ] && {
-		[ -x /etc/uci-defaults/ddns_freedns_42_pl ] && \
-			/etc/uci-defaults/ddns_freedns_42_pl && \
-				rm -f /etc/uci-defaults/ddns_freedns_42_pl >/dev/null 2>&1
-		/etc/init.d/ddns enabled && \
-			/etc/init.d/ddns start >/dev/null 2>&1
-	}
-	exit 0	# suppress errors
+#!/bin/sh
+# remove old services file entries
+/bin/sed -i '/freedns\.42\.pl/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
+# and create new
+printf "%s\\t%s\\n" '"freedns.42.pl"' '"update_freedns_42_pl.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+# on real system restart service if enabled
+[ -z "$${IPKG_INSTROOT}" ] && {
+	[ -x /etc/uci-defaults/ddns_freedns_42_pl ] && \
+		/etc/uci-defaults/ddns_freedns_42_pl && \
+			rm -f /etc/uci-defaults/ddns_freedns_42_pl >/dev/null 2>&1
+	/etc/init.d/ddns enabled && \
+		/etc/init.d/ddns start >/dev/null 2>&1
+}
+exit 0	# suppress errors
 endef
+
 define Package/ddns-scripts_freedns_42_pl/prerm
-	#!/bin/sh
-	# if NOT run buildroot then stop service
-	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop		>/dev/null 2>&1
-	# remove services file entries
-	/bin/sed -i '/freedns\.42\.pl/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
-	exit 0	# suppress errors
+#!/bin/sh
+# if NOT run buildroot then stop service
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop		>/dev/null 2>&1
+# remove services file entries
+/bin/sed -i '/freedns\.42\.pl/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
+exit 0	# suppress errors
 endef
 
 ###### *************************************************************************
 define Package/ddns-scripts_godaddy.com-v1/preinst
-	#!/bin/sh
-	# if NOT run buildroot then stop service
-	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
-	exit 0	# suppress errors
+#!/bin/sh
+# if NOT run buildroot then stop service
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
+exit 0	# suppress errors
 endef
+
 define Package/ddns-scripts_godaddy.com-v1/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_godaddy.com-v1
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/update_godaddy_com_v1.sh $(1)/usr/lib/ddns
 endef
+
 define Package/ddns-scripts_godaddy.com-v1/postinst
-	#!/bin/sh
-	# remove old services file entries
-	/bin/sed -i '/godaddy\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
-	/bin/sed -i '/godaddy\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
-	# and create new
-	printf "%s\\t%s\\n" '"godaddy.com-v1"' '"update_godaddy_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
-	printf "%s\\t%s\\n" '"godaddy.com-v1"' '"update_godaddy_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
-	# on real system restart service if enabled
-	[ -z "$${IPKG_INSTROOT}" ] && {
-		[ -x /etc/uci-defaults/ddns_godaddy.com-v1 ] && \
-			/etc/uci-defaults/ddns_godaddy.com-v1 && \
-				rm -f /etc/uci-defaults/ddns_godaddy.com-v1 >/dev/null 2>&1
-		/etc/init.d/ddns enabled \
-			&& /etc/init.d/ddns start >/dev/null 2>&1
-	}
-	exit 0	# suppress errors
+#!/bin/sh
+# remove old services file entries
+/bin/sed -i '/godaddy\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
+/bin/sed -i '/godaddy\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+# and create new
+printf "%s\\t%s\\n" '"godaddy.com-v1"' '"update_godaddy_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+printf "%s\\t%s\\n" '"godaddy.com-v1"' '"update_godaddy_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
+# on real system restart service if enabled
+[ -z "$${IPKG_INSTROOT}" ] && {
+	[ -x /etc/uci-defaults/ddns_godaddy.com-v1 ] && \
+		/etc/uci-defaults/ddns_godaddy.com-v1 && \
+			rm -f /etc/uci-defaults/ddns_godaddy.com-v1 >/dev/null 2>&1
+	/etc/init.d/ddns enabled \
+		&& /etc/init.d/ddns start >/dev/null 2>&1
+}
+exit 0	# suppress errors
 endef
+
 define Package/ddns-scripts_godaddy.com-v1/prerm
-	#!/bin/sh
-	# if NOT run buildroot then stop service
-	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
-	# remove services file entries
-	/bin/sed -i '/godaddy\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
-	/bin/sed -i '/godaddy\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
-	exit 0	# suppress errors
+#!/bin/sh
+# if NOT run buildroot then stop service
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
+# remove services file entries
+/bin/sed -i '/godaddy\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
+/bin/sed -i '/godaddy\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+exit 0	# suppress errors
 endef
 
 ###### *************************************************************************
 define Package/ddns-scripts_no-ip_com/preinst
-	#!/bin/sh
-	# if NOT run buildroot then stop service
-	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
-	exit 0	# suppress errors
+#!/bin/sh
+# if NOT run buildroot then stop service
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
+exit 0	# suppress errors
 endef
+
 define Package/ddns-scripts_no-ip_com/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_no-ip_com
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/update_no-ip_com.sh $(1)/usr/lib/ddns
 endef
+
 define Package/ddns-scripts_no-ip_com/postinst
-	#!/bin/sh
-	# remove old services file entries
-	/bin/sed -i '/no-ip\.com/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
-	# and create new
-	printf "%s\\t%s\\n" '"no-ip.com"' '"update_no-ip_com.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
-	# on real system restart service if enabled
-	[ -z "$${IPKG_INSTROOT}" ] && {
-		[ -x /etc/uci-defaults/ddns_no-ip_com ] && \
-			/etc/uci-defaults/ddns_no-ip_com && \
-				rm -f /etc/uci-defaults/ddns_no-ip_com >/dev/null 2>&1
-		/etc/init.d/ddns enabled && \
-			/etc/init.d/ddns start >/dev/null 2>&1
-	}
-	exit 0	# suppress errors
+#!/bin/sh
+# remove old services file entries
+/bin/sed -i '/no-ip\.com/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
+# and create new
+printf "%s\\t%s\\n" '"no-ip.com"' '"update_no-ip_com.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+# on real system restart service if enabled
+[ -z "$${IPKG_INSTROOT}" ] && {
+	[ -x /etc/uci-defaults/ddns_no-ip_com ] && \
+		/etc/uci-defaults/ddns_no-ip_com && \
+			rm -f /etc/uci-defaults/ddns_no-ip_com >/dev/null 2>&1
+	/etc/init.d/ddns enabled && \
+		/etc/init.d/ddns start >/dev/null 2>&1
+}
+exit 0	# suppress errors
 endef
+
 define Package/ddns-scripts_no-ip_com/prerm
-	#!/bin/sh
-	# if NOT run buildroot then stop service
-	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop		>/dev/null 2>&1
-	# remove services file entries
-	/bin/sed -i '/no-ip\.com/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
-	exit 0	# suppress errors
+#!/bin/sh
+# if NOT run buildroot then stop service
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop		>/dev/null 2>&1
+# remove services file entries
+/bin/sed -i '/no-ip\.com/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
+exit 0	# suppress errors
 endef
 
 ###### *************************************************************************
 define Package/ddns-scripts_nsupdate/preinst
-	#!/bin/sh
-	# if NOT run buildroot then stop service
-	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
-	exit 0	# suppress errors
+#!/bin/sh
+# if NOT run buildroot then stop service
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
+exit 0	# suppress errors
 endef
+
 define Package/ddns-scripts_nsupdate/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_nsupdate
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/update_nsupdate.sh $(1)/usr/lib/ddns
 endef
+
 define Package/ddns-scripts_nsupdate/postinst
-	#!/bin/sh
-	# remove old services file entries
-	/bin/sed -i '/bind-nsupdate/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
-	/bin/sed -i '/bind-nsupdate/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
-	# and create new
-	printf "%s\\t%s\\n" '"bind-nsupdate"' '"update_nsupdate.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
-	printf "%s\\t%s\\n" '"bind-nsupdate"' '"update_nsupdate.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
-	# on real system restart service if enabled
-	[ -z "$${IPKG_INSTROOT}" ] && {
-		[ -x /etc/uci-defaults/ddns_nsupdate ] && \
-			/etc/uci-defaults/ddns_nsupdate && \
-				rm -f /etc/uci-defaults/ddns_nsupdate >/dev/null 2>&1
-		/etc/init.d/ddns enabled && \
-			/etc/init.d/ddns start >/dev/null 2>&1
-	}
-	exit 0	# suppress errors
+#!/bin/sh
+# remove old services file entries
+/bin/sed -i '/bind-nsupdate/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
+/bin/sed -i '/bind-nsupdate/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+# and create new
+printf "%s\\t%s\\n" '"bind-nsupdate"' '"update_nsupdate.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+printf "%s\\t%s\\n" '"bind-nsupdate"' '"update_nsupdate.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
+# on real system restart service if enabled
+[ -z "$${IPKG_INSTROOT}" ] && {
+	[ -x /etc/uci-defaults/ddns_nsupdate ] && \
+		/etc/uci-defaults/ddns_nsupdate && \
+			rm -f /etc/uci-defaults/ddns_nsupdate >/dev/null 2>&1
+	/etc/init.d/ddns enabled && \
+		/etc/init.d/ddns start >/dev/null 2>&1
+}
+exit 0	# suppress errors
 endef
+
 define Package/ddns-scripts_nsupdate/prerm
-	#!/bin/sh
-	# if NOT run buildroot then stop service
-	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop			>/dev/null 2>&1
-	# remove services file entries
-	/bin/sed -i '/bind-nsupdate/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
-	/bin/sed -i '/bind-nsupdate/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
-	exit 0	# suppress errors
+#!/bin/sh
+# if NOT run buildroot then stop service
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop			>/dev/null 2>&1
+# remove services file entries
+/bin/sed -i '/bind-nsupdate/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
+/bin/sed -i '/bind-nsupdate/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+exit 0	# suppress errors
 endef
 
 ###### *************************************************************************
 define Package/ddns-scripts_route53-v1/preinst
-	#!/bin/sh
-	# if NOT run buildroot then stop service
-	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
-	exit 0	# suppress errors
+#!/bin/sh
+# if NOT run buildroot then stop service
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
+exit 0	# suppress errors
 endef
+
 define Package/ddns-scripts_route53-v1/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_route53-v1
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/update_route53_v1.sh $(1)/usr/lib/ddns
 endef
+
 define Package/ddns-scripts_route53-v1/postinst
-	#!/bin/sh
-	# remove old services file entries
-	/bin/sed -i '/route53-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
-	/bin/sed -i '/route53-v1/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
-	# and create new
-	printf "%s\\t%s\\n" '"route53-v1"' '"update_route53_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
-	printf "%s\\t%s\\n" '"route53-v1"' '"update_route53_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
-	# on real system restart service if enabled
-	[ -z "$${IPKG_INSTROOT}" ] && {
-		[ -x /etc/uci-defaults/ddns_route53-v1 ] && \
-			/etc/uci-defaults/ddns_route53-v1 && \
-				rm -f /etc/uci-defaults/route53.com-v1 >/dev/null 2>&1
-		/etc/init.d/ddns enabled \
-			&& /etc/init.d/ddns start >/dev/null 2>&1
-	}
-	exit 0	# suppress errors
+#!/bin/sh
+# remove old services file entries
+/bin/sed -i '/route53-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
+/bin/sed -i '/route53-v1/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+# and create new
+printf "%s\\t%s\\n" '"route53-v1"' '"update_route53_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+printf "%s\\t%s\\n" '"route53-v1"' '"update_route53_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
+# on real system restart service if enabled
+[ -z "$${IPKG_INSTROOT}" ] && {
+	[ -x /etc/uci-defaults/ddns_route53-v1 ] && \
+		/etc/uci-defaults/ddns_route53-v1 && \
+			rm -f /etc/uci-defaults/route53.com-v1 >/dev/null 2>&1
+	/etc/init.d/ddns enabled \
+		&& /etc/init.d/ddns start >/dev/null 2>&1
+}
+exit 0	# suppress errors
 endef
+
 define Package/ddns-scripts_route53-v1/prerm
-	#!/bin/sh
-	# if NOT run buildroot then stop service
-	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
-	# remove services file entries
-	/bin/sed -i 'route53-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
-	/bin/sed -i 'route53-v1/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
-	exit 0	# suppress errors
+#!/bin/sh
+# if NOT run buildroot then stop service
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
+# remove services file entries
+/bin/sed -i 'route53-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
+/bin/sed -i 'route53-v1/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+exit 0	# suppress errors
 endef
 
 ###### *************************************************************************


### PR DESCRIPTION
Maintainer: unkown?
Compile tested: no
Run tested: no

Description: Fixes #16143 by removing superfluous whitespace at the beginnings of preinst/postinst shell scripts. The scripts are apparently generated as is directly from the makefile, which means the scripts begin with `\t#!/bin/sh` and the interpreter is not happy with that.

Alternatively, it should be enough to unindent the shebang lines only. However, it would seem weird to me.
