### PR TITLE
haproxy: Update HAProxy to v2.4.9

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=2.4.7
+PKG_VERSION:=2.4.9
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/2.4/src
-PKG_HASH:=52af97f72f22ffd8a7a995fafc696291d37818feda50a23caef7dc0622421845
+PKG_HASH:=d56c7fe3c5afedd1b9a19e1b7f8f954feaf50a9c2f205f99891043858b72a763
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Christian Lachner <gladiac@gmail.com>
@@ -102,13 +102,13 @@ define Build/Compile
 		PCREDIR="$(STAGING_DIR)/usr/" \
 		USE_LUA=1 LUA_LIB_NAME="lua5.3" LUA_INC="$(STAGING_DIR)/usr/include/lua5.3" LUA_LIB="$(STAGING_DIR)/usr/lib" \
 		SMALL_OPTS="-DBUFSIZE=16384 -DMAXREWRITE=1030 -DSYSTEM_MAXCONN=165530" \
-		USE_ZLIB=1 USE_PCRE=1 USE_PCRE_JIT=1 USE_PTHREAD_PSHARED=1 USE_PROMEX=1 \
+		USE_ZLIB=1 USE_PCRE=1 USE_PCRE_JIT=1 USE_PTHREAD_PSHARED=1 USE_LIBATOMIC=1 USE_PROMEX=1 \
 		VERSION="$(PKG_VERSION)" SUBVERS="-$(PKG_RELEASE)" \
 		VERDATE="$(shell date -d @$(SOURCE_DATE_EPOCH) '+%Y/%m/%d')" IGNOREGIT=1 \
 		$(ADDON) \
 		CFLAGS="$(TARGET_CFLAGS) -fno-strict-aliasing -Wdeclaration-after-statement -Wno-unused-label -Wno-sign-compare -Wno-unused-parameter -Wno-clobbered -Wno-missing-field-initializers -Wno-cast-function-type -Wno-address-of-packed-member -Wtype-limits -Wshift-negative-value -Wshift-overflow=2 -Wduplicated-cond -Wnull-dereference -fwrapv -fasynchronous-unwind-tables -Wno-null-dereference" \
 		LD="$(TARGET_CC)" \
-		LDFLAGS="$(TARGET_LDFLAGS) -latomic"
+		LDFLAGS="$(TARGET_LDFLAGS)"
 
 	$(MAKE_VARS) $(MAKE) -C $(PKG_BUILD_DIR) \
 		DESTDIR="$(PKG_INSTALL_DIR)" \

--- a/net/haproxy/get-latest-patches.sh
+++ b/net/haproxy/get-latest-patches.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CLONEURL=https://git.haproxy.org/git/haproxy-2.4.git
-BASE_TAG=v2.4.4
+BASE_TAG=v2.4.9
 TMP_REPODIR=tmprepo
 PATCHESDIR=patches
 

--- a/net/haproxy/patches/000-BUILD-MINOR-server-fix-compilation-without-SSL.patch
+++ b/net/haproxy/patches/000-BUILD-MINOR-server-fix-compilation-without-SSL.patch
@@ -1,0 +1,87 @@
+commit ea489aa18caacf057880c67b933689c363307a23
+Author: Amaury Denoyelle <adenoyelle@haproxy.com>
+Date:   Thu Nov 25 10:20:19 2021 +0100
+
+    BUILD/MINOR: server: fix compilation without SSL
+    
+    The build without SSL was broken by the following backported commit:
+      8e99b84dba7755e73563093a8fcedb25e70e7b94
+      MEDIUM: server/backend: implement websocket protocol selection
+    
+    Fix this by checking the ALPN only if USE_OPENSSL and
+    TLSEXT_TYPE_application_layer_protocol_negotiation are defined. Else
+    always use the server mux-proto.
+    
+    No need to backport.
+
+--- a/src/server.c
++++ b/src/server.c
+@@ -204,7 +204,33 @@ void srv_set_dyncookie(struct server *s)
+  */
+ int srv_check_reuse_ws(struct server *srv)
+ {
+-	if (srv->mux_proto || srv->use_ssl != 1 || !srv->ssl_ctx.alpn_str) {
++#if defined(USE_OPENSSL) && defined(TLSEXT_TYPE_application_layer_protocol_negotiation)
++	if (!srv->mux_proto && srv->use_ssl && srv->ssl_ctx.alpn_str) {
++		/* ALPN selection.
++		 * Based on the assumption that only "h2" and "http/1.1" token
++		 * are used on server ALPN.
++		 */
++		const struct ist alpn = ist2(srv->ssl_ctx.alpn_str,
++		                             srv->ssl_ctx.alpn_len);
++
++		switch (srv->ws) {
++		case SRV_WS_AUTO:
++			/* for auto mode, consider reuse as possible if the
++			 * server uses a single protocol ALPN
++			 */
++			if (!istchr(alpn, ','))
++				return 1;
++			break;
++
++		case SRV_WS_H2:
++			return isteq(alpn, ist("\x02h2"));
++
++		case SRV_WS_H1:
++			return isteq(alpn, ist("\x08http/1.1"));
++		}
++	}
++	else {
++#endif /* defined(OPENSSL) && defined(TLSEXT_TYPE_application_layer_protocol_negotiation) */
+ 		/* explicit srv.mux_proto or no ALPN : srv.mux_proto is used
+ 		 * for mux selection.
+ 		 */
+@@ -232,31 +258,9 @@ int srv_check_reuse_ws(struct server *sr
+ 				return 1;
+ 			break;
+ 		}
++#if defined(USE_OPENSSL) && defined(TLSEXT_TYPE_application_layer_protocol_negotiation)
+ 	}
+-	else {
+-		/* ALPN selection.
+-		 * Based on the assumption that only "h2" and "http/1.1" token
+-		 * are used on server ALPN.
+-		 */
+-		const struct ist alpn = ist2(srv->ssl_ctx.alpn_str,
+-		                             srv->ssl_ctx.alpn_len);
+-
+-		switch (srv->ws) {
+-		case SRV_WS_AUTO:
+-			/* for auto mode, consider reuse as possible if the
+-			 * server uses a single protocol ALPN
+-			 */
+-			if (!istchr(alpn, ','))
+-				return 1;
+-			break;
+-
+-		case SRV_WS_H2:
+-			return isteq(alpn, ist("\x02h2"));
+-
+-		case SRV_WS_H1:
+-			return isteq(alpn, ist("\x08http/1.1"));
+-		}
+-	}
++#endif /* defined(OPENSSL) && defined(TLSEXT_TYPE_application_layer_protocol_negotiation) */
+ 
+ 	return 0;
+ }


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Christian Lachner <gladiac@gmail.com> (/me)
Compile tested: mips, ipq806x, x86, arc700
Run tested: ipq806x (r7800)

Description: Update HAProxy to v2.4.9
- Update haproxy download URL and hash
- Switched over to using USE_LIBATOMIC in favor of -latomic
- Added a patch which fixes nossl builds