### PR TITLE
ovpn-dco: Avoid building against musl headers

### DIFF
--- a/kernel/ovpn-dco/Makefile
+++ b/kernel/ovpn-dco/Makefile
@@ -37,6 +37,7 @@ define KernelPackage/ovpn-dco/description
 endef
 
 NOSTDINC_FLAGS += \
+	$(KERNEL_NOSTDINC_FLAGS) \
 	-I$(PKG_BUILD_DIR)/include \
 	-include $(PKG_BUILD_DIR)/linux-compat.h
 


### PR DESCRIPTION
Maintainer: @zhaojh329
Compile tested: OpenWrt master x86-64
Run tested: -

Description:


The musl headers contain defines which are incompatible with kernel builds. For example alltypes.h contain a __BIG_ENDIAN define. This will force various kernel functions/macros to be build in a way which requires the target system to be big endian. But if the target system is actually little endian, these function will then not perform there intended tasks. The actual (hard to debug) effects can vary between minor problems and fatal errors.

This is port of the fix from OpenWrt's commit 9ac47ee46918 ("build: use -nostdinc and -isystem in NOSTDINC_FLAGS for out-of-tree kernel modules")

Fixes: 17cd1793bbec ("ovpn-dco: Add package")