### PR TITLE
docker-compose: Update to version 2.2.0

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.1.1
+PKG_VERSION:=2.2.0
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=5c9246c34cafeb51b3289c016cb2cbdd08b3eda87b0f8d4cc02fd7630cfdbd7b
+PKG_HASH:=5699734a4625507cf3e2382e056a0ff7ec60c9e1d654d8c7d93baf844313bcf9
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream update

What's Changed:

 - Better detect container will restart by @ndeloof in #8898

 - Type mismatch checking tmpfs conflicting options by @ndeloof in
  #8904

 - Remove unused flag by @ulyssessouza in #8923

 - Use Dockerfile directly when path is absolute otherwise join it
 with Context path by @glours in #8929

 - Interrupt printer when compose log is cancelled by @ndeloof in
 #8926

 - Restore compose build to support context set as a git URL by
 @ndeloof in #8933

 - Upgrade containerd version - security fix by @glours in #8936

 - Don't SetRawTerminal when run is ran with -T by @ndeloof in #8938

 - Fix typo in --wait option mechanism by @PierreAntoineGuillaume in
 #8888

 - Detect volume we didn't created and ask user to explicitely mark
 them as external by @ndeloof in #8941

 - Bump compose-go to v1.0.8 by @mat007 in #8956

 - Don't normalize compose model in compatibility mode by @ndeloof
 in #8943

 - Don't try to start services with 0 replicas by @akerouanton in
 #8834

 - Introduce docker compose config --images by @ndeloof in #8955

 - Introduce run —quiet-pull to align with up by @ndeloof in #8947
