### PR TITLE
ksmbd-tools: Fix ksmbd service is semi-killed at system startup

### DIFF
--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
 PKG_VERSION:=3.4.2
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/ksmbd-tools/tar.gz/$(PKG_VERSION)?

--- a/net/ksmbd-tools/files/ksmbd.init
+++ b/net/ksmbd-tools/files/ksmbd.init
@@ -151,7 +151,7 @@ start_service()
 	fi
 	
 	# NOTE: We don't do a soft-reload via signal, since [global] smb.conf setting changes will be ignored, so always reset hard.
-	kill_server
+	[ -e /sys/module/ksmbd ] && stop_service
 	
 	[ ! -e /sys/module/ksmbd ] && modprobe ksmbd 2> /dev/null
 	if [ ! -e /sys/module/ksmbd ]; then


### PR DESCRIPTION
The configuration for the ksmbd service is auto-generated when the OpenWRT configuration changes, and also during startup, hence ksmbd.init has to reload the kernel module. It does that by calling kill_server, which does not perform cleanup. This results in ksmbd being killed but not restarted properly during boot.
This patch resolves the issue by using stop_service, which performs proper cleanup.

https://forum.openwrt.org/t/ksmbd-samba3-4-alternative-ex-cifsd-smbd-package-support-thread/51695/68

Maintainer: @Andy2244 
Compile tested: (x86_x64, OpenWrt version r18176)
Run tested: (x86_x64, OpenWrt version r18176, tests done: startup, change config)

@neheb 