### PR TITLE
ddns-scripts: Fix DigitalOcean JSON payload

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=16
+PKG_RELEASE:=17
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_digitalocean_com_v2.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_digitalocean_com_v2.sh
@@ -22,10 +22,8 @@
 
 # Construct JSON payload
 json_init
-json_add_object
-	json_add_string name "$username"
-	json_add_string data "$__IP"
-json_close_object
+json_add_string name "$username"
+json_add_string data "$__IP"
 
 __STATUS=$(curl -Ss -X PUT "https://api.digitalocean.com/v2/domains/${domain}/records/${param_opt}" \
 	-H "Authorization: Bearer ${password}" \


### PR DESCRIPTION
Signed-off-by: George Giannou <giannoug@gmail.com>

Maintainer: @feckert
Compile tested: N/A
Run tested: ASUS RT-AC58U / ARMv7 Processor rev 5 (v7l) / OpenWrt 21.02.0-rc3 r16172-2aba3e9784 / LuCI openwrt-21.02 branch git-21.163.64918-ba57ec5. Tested that it updates hostnames after IP renewal

Description:
This is a fix for a previous PR (#17120). It seems that the JSON object is created incorrectly and returned empty ({ }). Update returns 200 with an empty body, but the hostname doesn't update 🤕 Removing `json_add_object` and `json_close_object` fix the issue, the payload is correctly created and the IPs are updated with the new value.