### PR TITLE
[RFC] mwan3: convert src_ip and dest_ip hanling to uci list

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.10.12
+PKG_VERSION:=2.11.0
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -727,10 +727,8 @@ mwan3_set_user_iptables_rule()
 	config_get timeout "$1" timeout 600
 	config_get ipset "$1" ipset
 	config_get proto "$1" proto all
-	config_get src_ip "$1" src_ip
 	config_get src_iface "$1" src_iface
 	config_get src_port "$1" src_port
-	config_get dest_ip "$1" dest_ip
 	config_get dest_port "$1" dest_port
 	config_get use_policy "$1" use_policy
 	config_get family "$1" family any
@@ -742,13 +740,51 @@ mwan3_set_user_iptables_rule()
 	[ "$family" = "ipv4" ] && [ "$ipv" = "ipv6" ] && return
 	[ "$family" = "ipv6" ] && [ "$ipv" = "ipv4" ] && return
 
-	for ipaddr in "$src_ip" "$dest_ip"; do
-		if [ -n "$ipaddr" ] && { { [ "$ipv" = "ipv4" ] && echo "$ipaddr" | grep -qE "$IPv6_REGEX"; } ||
-						 { [ "$ipv" = "ipv6" ] && echo "$ipaddr" | grep -qE $IPv4_REGEX; } }; then
-			LOG warn "invalid $ipv address $ipaddr specified for rule $rule"
-			return
+	local ip_valid=1
+	mwan3_valid_rule_ip() {
+		local ipaddr="$1"
+		local ipv="$2"
+		local rule="$3"
+		local direction="$4"
+
+		local result=0
+
+		case "$ipv" in
+			"ipv6")
+				echo "$ipaddr" | grep -Eq "$IPv6_REGEX"
+				result="$?"
+				if [ "$result" = "1" ]; then
+					LOG warn "Invalid '$ipv' address '$ipaddr' specified for rule '$rule'"
+					export ip_valid=0
+				fi
+				;;
+			"ipv4")
+				echo "$ipaddr" | grep -Eq "$IPv4_REGEX"
+				result="$?"
+				if [ "$result" = "1" ]; then
+					LOG warn "Invalid '$ipv' address '$ipaddr' specified for rule '$rule'"
+					export ip_valid=0
+				fi
+				;;
+		esac
+
+		if [ "${direction}" = "scp_ip" ]; then
+			export scp_ip="${src_ip}${ipaddr},"
+		else
+			export dest_ip="${dest_ip}${ipaddr},"
 		fi
-	done
+	}
+
+	config_list_foreach "$1" src_ip mwan3_valid_rule_ip "$ipv" "$rule" "src_ip"
+	config_list_foreach "$1" dest_ip mwan3_valid_rule_ip "$ipv" "$rule" "dest_ip"
+
+	if [ "$ip_valid" -eq 0 ]; then
+		return
+	fi
+
+	# Strip last comma from string
+	dest_ip="${dest_ip%,}"
+	src_ip="${src_ip%,}"
 
 	if [ -n "$src_iface" ]; then
 		network_get_device src_dev "$src_iface"


### PR DESCRIPTION
Maintainer: me / @aaronjg 
Compile tested: not needed script changes
Run tested: x86_64, APU3, OpenWrt latest master

Description:
The 'src_ip' and 'dest_ip' option on a rule cannot take only one value.
Until now it was possible to add several with comma separation. This
option is now converted into a list so that no extra handling has to be
applied during validation in the LuCI.

The following issue took me to turn into a list
https://github.com/openwrt/luci/issues/5333

Could you validate this in your setup?
@jamesmacwhite @ptpt52 

The LuCI change and an upgrade script must still be created TODO
