### PR TITLE
zerotier: add configuration reload trigger

### DIFF
--- a/net/zerotier/files/etc/init.d/zerotier
+++ b/net/zerotier/files/etc/init.d/zerotier
@@ -115,3 +115,12 @@ stop_service() {
 	config_foreach stop_instance 'zerotier'
 	rm -f ${CONFIG_PATH}
 }
+
+reload_service() {
+	stop
+	start
+}
+
+service_triggers() {
+	procd_add_reload_trigger 'zerotier'
+}


### PR DESCRIPTION
Maintainer: @mwarning 
Compile tested: -
Run tested: -

Description:

Ensure that the zerotier service is automatically restarted when the uci
configuration is modified.

Ref: https://forum.openwrt.org/t/reloading-a-service-when-config-changes/113488/3