### PR TITLE
[19.07] libs/c-ares: fix domain hijacking CVE-2021-3672

### DIFF
--- a/libs/c-ares/Makefile
+++ b/libs/c-ares/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=c-ares
 PKG_VERSION:=1.15.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_LICENSE:=MIT
 PKG_CPE_ID:=cpe:/a:c-ares_project:c-ares
 

--- a/libs/c-ares/patches/0001-ares_expand_name-should-escape-more-characters.patch
+++ b/libs/c-ares/patches/0001-ares_expand_name-should-escape-more-characters.patch
@@ -1,0 +1,88 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: bradh352 <brad@brad-house.com>
+Date: Fri, 11 Jun 2021 11:27:45 -0400
+Subject: [PATCH] ares_expand_name() should escape more characters
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+RFC1035 5.1 specifies some reserved characters and escaping sequences
+that are allowed to be specified.  Expand the list of reserved characters
+and also escape non-printable characters using the \DDD format as
+specified in the RFC.
+
+Bug Reported By: philipp.jeitner@sit.fraunhofer.de
+Fix By: Brad House (@bradh352)
+[rebased onto 1.15.0]
+Signed-off-by: Petr Štetiar <ynezz@true.cz>
+---
+ ares_expand_name.c | 41 ++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 38 insertions(+), 3 deletions(-)
+
+diff --git a/ares_expand_name.c b/ares_expand_name.c
+index 3a38e6737e93..8604543fc39d 100644
+--- a/ares_expand_name.c
++++ b/ares_expand_name.c
+@@ -38,6 +38,26 @@
+ static int name_length(const unsigned char *encoded, const unsigned char *abuf,
+                        int alen);
+ 
++/* Reserved characters for names that need to be escaped */
++static int is_reservedch(int ch)
++{
++  switch (ch) {
++    case '"':
++    case '.':
++    case ';':
++    case '\\':
++    case '(':
++    case ')':
++    case '@':
++    case '$':
++      return 1;
++    default:
++      break;
++  }
++
++  return 0;
++}
++
+ /* Expand an RFC1035-encoded domain name given by encoded.  The
+  * containing message is given by abuf and alen.  The result given by
+  * *s, which is set to a NUL-terminated allocated buffer.  *enclen is
+@@ -117,9 +137,18 @@ int ares_expand_name(const unsigned char *encoded, const unsigned char *abuf,
+           p++;
+           while (len--)
+             {
+-              if (*p == '.' || *p == '\\')
++              if (!isprint(*p)) {
++                /* Output as \DDD for consistency with RFC1035 5.1 */
++                *q++ = '\\';
++                *q++ = '0' + *p / 100;
++                *q++ = '0' + (*p % 100) / 10;
++                *q++ = '0' + (*p % 10);
++              } else if (is_reservedch(*p)) {
+                 *q++ = '\\';
+-              *q++ = *p;
++                *q++ = *p;
++              } else {
++                *q++ = *p;
++              }
+               p++;
+             }
+           *q++ = '.';
+@@ -177,7 +206,13 @@ static int name_length(const unsigned char *encoded, const unsigned char *abuf,
+           encoded++;
+           while (offset--)
+             {
+-              n += (*encoded == '.' || *encoded == '\\') ? 2 : 1;
++              if (!isprint(*encoded)) {
++                n += 4;
++              } else if (is_reservedch(*encoded)) {
++                n += 2;
++              } else {
++                n += 1;
++              }
+               encoded++;
+             }
+           n++;

--- a/libs/c-ares/patches/0002-ares_expand_name-fix-formatting-and-handling-of-root.patch
+++ b/libs/c-ares/patches/0002-ares_expand_name-fix-formatting-and-handling-of-root.patch
@@ -1,0 +1,113 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: bradh352 <brad@brad-house.com>
+Date: Fri, 11 Jun 2021 12:39:24 -0400
+Subject: [PATCH] ares_expand_name(): fix formatting and handling of root name
+ response
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes issue introduced in prior commit with formatting and handling
+of parsing a root name response which should not be escaped.
+
+Fix By: Brad House
+[rebased onto 1.15.0]
+Signed-off-by: Petr Štetiar <ynezz@true.cz>
+---
+ ares_expand_name.c | 62 ++++++++++++++++++++++++++++++----------------
+ 1 file changed, 40 insertions(+), 22 deletions(-)
+
+diff --git a/ares_expand_name.c b/ares_expand_name.c
+index 8604543fc39d..f89ee3f7a602 100644
+--- a/ares_expand_name.c
++++ b/ares_expand_name.c
+@@ -133,27 +133,37 @@ int ares_expand_name(const unsigned char *encoded, const unsigned char *abuf,
+         }
+       else
+         {
+-          len = *p;
++          int name_len = *p;
++          len = name_len;
+           p++;
++
+           while (len--)
+             {
+-              if (!isprint(*p)) {
+-                /* Output as \DDD for consistency with RFC1035 5.1 */
+-                *q++ = '\\';
+-                *q++ = '0' + *p / 100;
+-                *q++ = '0' + (*p % 100) / 10;
+-                *q++ = '0' + (*p % 10);
+-              } else if (is_reservedch(*p)) {
+-                *q++ = '\\';
+-                *q++ = *p;
+-              } else {
+-                *q++ = *p;
+-              }
++              /* Output as \DDD for consistency with RFC1035 5.1, except
++               * for the special case of a root name response  */
++              if (!isprint(*p) && !(name_len == 1 && *p == 0))
++                {
++
++                  *q++ = '\\';
++                  *q++ = '0' + *p / 100;
++                  *q++ = '0' + (*p % 100) / 10;
++                  *q++ = '0' + (*p % 10);
++                }
++              else if (is_reservedch(*p))
++                {
++                  *q++ = '\\';
++                  *q++ = *p;
++                }
++              else
++                {
++                  *q++ = *p;
++                }
+               p++;
+             }
+           *q++ = '.';
+         }
+-    }
++     }
++
+   if (!indir)
+     *enclen = aresx_uztosl(p + 1U - encoded);
+ 
+@@ -200,21 +210,29 @@ static int name_length(const unsigned char *encoded, const unsigned char *abuf,
+         }
+       else if (top == 0x00)
+         {
+-          offset = *encoded;
++          int name_len = *encoded;
++          offset = name_len;
+           if (encoded + offset + 1 >= abuf + alen)
+             return -1;
+           encoded++;
++
+           while (offset--)
+             {
+-              if (!isprint(*encoded)) {
+-                n += 4;
+-              } else if (is_reservedch(*encoded)) {
+-                n += 2;
+-              } else {
+-                n += 1;
+-              }
++              if (!isprint(*encoded) && !(name_len == 1 && *encoded == 0))
++                {
++                  n += 4;
++                }
++              else if (is_reservedch(*encoded))
++                {
++                  n += 2;
++                }
++              else
++                {
++                  n += 1;
++                }
+               encoded++;
+             }
++
+           n++;
+         }
+       else


### PR DESCRIPTION
Maintainer: @karlp 
Compile tested: arm_cortex-a9
Run tested: None

Description:

Missing input validation of host names returned by Domain Name Servers
in the c-ares library can lead to output of wrong hostnames (leading to
Domain Hijacking).

I've just taken [patch](https://github.com/c-ares/c-ares/compare/809d5e8..44c009b.patch) from the [advisory](https://c-ares.org/adv_20210810.html) and rebased it onto 1.15.0 version.