### PR TITLE
minicom: remove PKG_FIXUP:autoreconf

### DIFF
--- a/utils/minicom/Makefile
+++ b/utils/minicom/Makefile
@@ -20,8 +20,6 @@ PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:minicom:minicom
 
-PKG_FIXUP:=autoreconf
-
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Maintainer: @neheb 
Compile tested: x86_64 APU3 and lantiq_xrx200, latest openwrt master
Run tested: x86_64 APU3 and lantiq_xrx200, latest openwrt master, start minicom

Description:
```
root@st-dev-07 ~ # minicom -v
minicom version 2.8
Copyright (C) Miquel van Smoorenburg.

This program is free software; you can redistribute it and/or
modify it under the terms of the GNU General Public License
as published by the Free Software Foundation; either version
2 of the License, or (at your option) any later version.
```

The definition PKG_FIXUP=:autorenconf is no longer necessary. If this
option is not removed, I get the following compilation error warning.

configure.ac:125: warning: macro 'AM_GNU_GETTEXT' not found in library
configure.ac:126: warning: macro 'AM_GNU_GETTEXT_VERSION' not found in library

And the compilation stops with the following message.

./configure: line 6690: syntax error near unexpected token `external'
./configure: line 6690: `AM_GNU_GETTEXT(external)'

Removing the `PKG_FIXUP` solves this.

Fixes #17208 
