### PR TITLE
modemmanager: bump to 1.18.4 with patch

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
-PKG_VERSION:=1.18.2
+PKG_VERSION:=1.18.4
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
-PKG_HASH:=374be158ae1c1fb38a29eef1cc3cdf89ff3536b48ff1320d208ab204ea6c5f8a
+PKG_HASH:=11fb970f63e2da88df4b6d8759e4ee649944c515244b979bf50a7a6df1d7f199
 PKG_BUILD_DIR:=$(BUILD_DIR)/ModemManager-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>

--- a/net/modemmanager/patches/010-udev-avoid-0-9-as-shell-globbing-patters.patch
+++ b/net/modemmanager/patches/010-udev-avoid-0-9-as-shell-globbing-patters.patch
@@ -1,0 +1,60 @@
+From e9f254ba3f923248efffe4fd458dc5e5469e0f73 Mon Sep 17 00:00:00 2001
+From: Aleksander Morgado <aleksander@aleksander.es>
+Date: Wed, 1 Dec 2021 21:40:00 +0100
+Subject: [PATCH] udev: avoid [0-9]* as shell globbing patterns
+
+The udev rules expect matches based on shell globbing pattern, not
+based on regex. This means that "[0-9]*" doesn't mean "zero or more
+digits", it actually means "one digit and zero or more other
+characters".
+
+So, avoid the regex like match, even if it worked for us, because it
+didn't mean what we thought it meant, plus, it breaks our custom udev
+rules processing logic, in which we convert the input patterns into
+real regex expressions.
+
+See https://bbs.archlinux.org/viewtopic.php?pid=1415916#p1415916
+
+While at it, also make sure that the wildcard matching is done
+exclusively for prefix and suffix matches, never in the middle of
+a string, or our custom rules parser would not match correctly.
+---
+ plugins/qcom-soc/77-mm-qcom-soc.rules | 8 ++++----
+ src/80-mm-candidate.rules             | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+--- a/plugins/qcom-soc/77-mm-qcom-soc.rules
++++ b/plugins/qcom-soc/77-mm-qcom-soc.rules
+@@ -24,17 +24,17 @@ ENV{ID_MM_QCOM_SOC}="1"
+ ENV{ID_MM_PHYSDEV_UID}="qcom-soc"
+ 
+ # port type hints for the rpmsgexport-ed ports
+-SUBSYSTEM=="rpmsg", ATTR{name}=="DATA[0-9]*_CNTL", ENV{ID_MM_PORT_TYPE_QMI}="1"
+-SUBSYSTEM=="rpmsg", ATTR{name}=="DATA[0-9]",       ENV{ID_MM_PORT_TYPE_AT_SECONDARY}="1"
++SUBSYSTEM=="rpmsg", ATTR{name}=="DATA*", ATTR{name}=="*_CNTL", ENV{ID_MM_PORT_TYPE_QMI}="1"
++SUBSYSTEM=="rpmsg", ATTR{name}=="DATA*", ATTR{name}!="*_CNTL", ENV{ID_MM_PORT_TYPE_AT_SECONDARY}="1"
+ 
+ # ignore every other port without explicit hints
+ SUBSYSTEM=="rpmsg", ENV{ID_MM_PORT_TYPE_QMI}!="1", ENV{ID_MM_PORT_TYPE_AT_SECONDARY}!="1", ENV{ID_MM_PORT_IGNORE}="1"
+ 
+ # explicitly ignore ports intended for USB tethering (DATA40, DATA40_CNTL)
+ SUBSYSTEM=="rpmsg", ATTR{name}=="DATA40*", ENV{ID_MM_PORT_IGNORE}="1"
+-KERNEL=="rmnet_usb[0-9]*", ENV{ID_MM_PORT_IGNORE}="1"
++KERNEL=="rmnet_usb*", ENV{ID_MM_PORT_IGNORE}="1"
+ 
+ # flag all rpmsg ports under this plugin as candidate
+-KERNEL=="rpmsg[0-9]*", SUBSYSTEM=="rpmsg", ENV{ID_MM_CANDIDATE}="1"
++KERNEL=="rpmsg*", SUBSYSTEM=="rpmsg", ENV{ID_MM_CANDIDATE}="1"
+ 
+ LABEL="mm_qcom_soc_end"
+--- a/src/80-mm-candidate.rules
++++ b/src/80-mm-candidate.rules
+@@ -15,7 +15,7 @@ KERNEL=="rfcomm*", DEVPATH=="*/virtual/*
+ 
+ SUBSYSTEM=="tty", ENV{ID_MM_CANDIDATE}="1"
+ SUBSYSTEM=="net", ENV{ID_MM_CANDIDATE}="1"
+-KERNEL=="cdc-wdm[0-9]*", SUBSYSTEM=="usbmisc", ENV{ID_MM_CANDIDATE}="1"
++KERNEL=="cdc-wdm*", SUBSYSTEM=="usbmisc", ENV{ID_MM_CANDIDATE}="1"
+ 
+ # WWAN subsystem port handling
+ #  - All USB devices ignored for now, only PCI devices expected


### PR DESCRIPTION
The included patch corrects an issue preventing udev rules from
being parsed correctly. [1][2]

This patch should not be needed after the next release. [3]

More information:
[1] https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/commit/e9f254ba3f923248efffe4fd458dc5e5469e0f73
[2] https://lists.freedesktop.org/archives/modemmanager-devel/2021-December/009024.html
[3] https://lists.freedesktop.org/archives/modemmanager-devel/2021-December/009022.html

Signed-off-by: Nicholas Smith <nicholas@nbembedded.com>

Maintainer: me 
Compile tested: ipq4019 OpenWrt master
Run tested: ipq4019 OpenWrt master Telco X1 Pro
