### PR TITLE
knot-resolver: update to version 5.4.3

### DIFF
--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -10,12 +10,12 @@ PKG_RELRO_FULL:=0
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot-resolver
-PKG_VERSION:=5.4.2
+PKG_VERSION:=5.4.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-resolver
-PKG_HASH:=ea6a219571a752056669bae3f2c0c3ed0bec58af5ab832d505a3ec9c4063a58b
+PKG_HASH:=488729eb93190336b6bca10de0d78ecb7919f77fcab105debc0a644aa7d0a506
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=GPL-3.0-later

--- a/net/knot-resolver/patches/030-fix-policy-hack.patch
+++ b/net/knot-resolver/patches/030-fix-policy-hack.patch
@@ -2,7 +2,7 @@ This patch fixes the problem with forwarding in knot-resolver v4.3.0.
 It reintroduces a fix which enables  policy related hack (knot/knot-resolver#205 (comment 94566) )
 --- a/modules/policy/policy.lua
 +++ b/modules/policy/policy.lua
-@@ -1000,7 +1000,7 @@ policy.layer = {
+@@ -1047,7 +1047,7 @@ policy.layer = {
  		if bit.band(state, bit.bor(kres.FAIL, kres.DONE)) ~= 0 then return state end
  		local qry = req:initial() -- same as :current() but more descriptive
  		return policy.evaluate(policy.rules, req, qry, state)


### PR DESCRIPTION
Maintainers: @ja-pa
Compile and run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 21.02.1

Description:

- Release notes:
https://www.knot-resolver.cz/2021-12-01-knot-resolver-5.4.3.html
