### PR TITLE
openwisp-config: refactoring and update openwisp-config package

### DIFF
--- a/admin/openwisp-config/Makefile
+++ b/admin/openwisp-config/Makefile
@@ -5,48 +5,43 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openwisp-config
-PKG_SOURCE_VERSION:=0.5.0
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/openwisp/openwisp-config.git
-PKG_MIRROR_HASH:=337a3a9542a0898da9f951256b0d19b6bc87ced98f4ec6dc9646172b551880ef
 PKG_MAINTAINER:=Federico Capoano <f.capoano@openwisp.io>
 PKG_LICENSE:=GPL3.0-or-later
+
+PKG_SOURCE_URL:=https://github.com/openwisp/openwisp-config.git
+PKG_MIRROR_HASH:=b1f5682715cc5b5623b2acf49ebb75d8bac1b58094981b61ede3ca392bdfa269
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2021-12-07
+PKG_SOURCE_VERSION:=08df34db29180a0d13c2e357723e8c546523014a
 PKGARCH:=all
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/openwisp-config/default
-	TITLE:=Remote configuration management agent ($(2) variant)
-	CATEGORY:=Administration
-	SECTION:=admin
-	SUBMENU:=openwisp
-	DEPENDS:=+curl +lua +libuci-lua +luafilesystem +luci-lib-nixio $(3)
-	VARIANT:=$(1)
-	PKGARCH:=all
-	URL:=http://openwisp.org
+define Package/openwisp-config
+  TITLE:=Remote configuration management agent
+  CATEGORY:=Administration
+  SECTION:=admin
+  SUBMENU:=openwisp
+  DEPENDS:=+curl \
+    +lua \
+    +libuci-lua \
+    +luafilesystem \
+    +luci-lib-nixio \
+    +ca-certificates
+  PKGARCH:=all
+  URL:=https://openwisp.org
 endef
-
-Package/openwisp-config-openssl=$(call Package/openwisp-config/default,openssl,OpenSSL,+ca-certificates +libopenssl)
-Package/openwisp-config-mbedtls=$(call Package/openwisp-config/default,mbedtls,mbedTLS,+ca-certificates +libmbedtls)
-Package/openwisp-config-wolfssl=$(call Package/openwisp-config/default,wolfssl,WolfSSL,+ca-certificates +libwolfssl)
-Package/openwisp-config-nossl=$(call Package/openwisp-config/default,nossl,No SSL)
 
 define Build/Compile
 endef
 
-define Package/openwisp-config-$(BUILD_VARIANT)/conffiles
+define Package/openwisp-config/conffiles
 /etc/config/openwisp
 endef
 
-CONFIG_OPENWISP_UCI:=ssl
-
-ifeq ($(BUILD_VARIANT),nossl)
-    CONFIG_OPENWISP_UCI:=nossl
-endif
-
-define Package/openwisp-config-$(BUILD_VARIANT)/install
+define Package/openwisp-config/install
 	$(INSTALL_DIR) \
 		$(1)/usr/sbin \
 		$(1)/etc/init.d \
@@ -62,7 +57,7 @@ define Package/openwisp-config-$(BUILD_VARIANT)/install
 		$(PKG_BUILD_DIR)/openwisp-config/files/openwisp.init \
 		$(1)/etc/init.d/openwisp_config
 
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/openwisp-config/files/openwisp-$(CONFIG_OPENWISP_UCI).config \
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/openwisp-config/files/openwisp.config \
 		$(1)/etc/config/openwisp
 
 	$(INSTALL_BIN) \
@@ -104,7 +99,4 @@ define Package/openwisp-config-$(BUILD_VARIANT)/install
 	$(CP) $(PKG_BUILD_DIR)/VERSION $(1)/etc/openwisp/
 endef
 
-$(eval $(call BuildPackage,openwisp-config-openssl))
-$(eval $(call BuildPackage,openwisp-config-mbedtls))
-$(eval $(call BuildPackage,openwisp-config-wolfssl))
-$(eval $(call BuildPackage,openwisp-config-nossl))
+$(eval $(call BuildPackage,openwisp-config))


### PR DESCRIPTION
Maintainer: @nemesisdesign 
Compile tested: x86_64, APU3, latest OpenWrt
Run tested: No (no source changes)

Description:
With the last upstream change, all build variants were removed so that we only have one package.
It is now called openwisp-config.
