### PR TITLE
zabbix: update to 5.0.18

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=5.0.7
-PKG_RELEASE:=4
+PKG_VERSION:=5.0.18
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/5.0/
-PKG_HASH:=d762f8a9aa9e8717d2e85d2a82d27316ea5c2b214eb00aff41b6e9b06107916a
+PKG_HASH:=7d15c4d683801edc2bdcda3fd94afdf6a7142a1a92aa71f4a9220af8e39d9e0e
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=GPL-2.0


### PR DESCRIPTION
Updated to latest 5.0 LTS minor release

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: Etienne CHAMPETIER <champetier.etienne@gmail.com>
Compile tested: mipsel, tplink_tl-mr3020-v3, openwrt master dd681838d370f1f6f6fa1bf1f22b0414322292f3
Run tested: mipsel, tplink_tl-mr3020-v3, openwrt master dd681838d370f1f6f6fa1bf1f22b0414322292f3, tests done
