### PR TITLE
nss: update to 3.73

### DIFF
--- a/libs/nss/Makefile
+++ b/libs/nss/Makefile
@@ -7,14 +7,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nss
-PKG_VERSION:=3.69
+PKG_VERSION:=3.73
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
     https://download.cdn.mozilla.net/pub/security/$(PKG_NAME)/releases/NSS_$(subst .,_,$(PKG_VERSION))_RTM/src \
     https://archive.mozilla.org/pub/security/$(PKG_NAME)/releases/NSS_$(subst .,_,$(PKG_VERSION))_RTM/src
-PKG_HASH:=c880205a365e0dd488ff29fdea82716ff9fcde9da6f3b703d636f8fc08008799
+PKG_HASH:=566d3a68da9b10d7da9ef84eb4fe182f8f04e20d85c55d1bf360bb2c0096d8e5
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENCE:=MPL-2.0


### PR DESCRIPTION
    Update to 3.73 to alievate critical vulnerability CVE-2021-43527:
    Memory corruption via DER-encoded DSA and RSA-PSS signatures

    https://www.mozilla.org/en-US/security/advisories/mfsa2021-51/

    Signed-off-by: Donald Hoskins <grommish@gmail.com>