### PR TITLE
nft-qos: fix include on build

### DIFF
--- a/net/nft-qos/Makefile
+++ b/net/nft-qos/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nft-qos
 PKG_VERSION:=1.0.6
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-2.0
 
 PKG_MAINTAINER:=Rosy Song <rosysong@rosinson.com>

--- a/net/nft-qos/files/lib/monitor.sh
+++ b/net/nft-qos/files/lib/monitor.sh
@@ -6,7 +6,7 @@
 . /lib/nft-qos/core.sh
 
 qosdef_monitor_get_ip_handle() { # <family> <chain> <ip>
-	echo $(nft list chain $1 nft-qos-monitor $2 -a 2>/dev/null | grep $3 | awk '{print $11}')
+	echo $(nft -a list chain $1 nft-qos-monitor $2 2>/dev/null | grep $3 | awk '{print $11}')
 }
 
 qosdef_monitor_add() { # <mac> <ip> <hostname>

--- a/net/nft-qos/files/nft-qos.init
+++ b/net/nft-qos/files/nft-qos.init
@@ -3,12 +3,14 @@
 # Copyright (C) 2018 rosysong@rosinson.com
 #
 
-. "${IPKG_INSTROOT}/lib/nft-qos/core.sh"
-. "${IPKG_INSTROOT}/lib/nft-qos/monitor.sh"
-. "${IPKG_INSTROOT}/lib/nft-qos/dynamic.sh"
-. "${IPKG_INSTROOT}/lib/nft-qos/static.sh"
-. "${IPKG_INSTROOT}/lib/nft-qos/mac.sh"
-. "${IPKG_INSTROOT}/lib/nft-qos/priority.sh"
+if [ -z "${IPKG_INSTROOT}" ]; then
+	. /lib/nft-qos/core.sh
+	. /lib/nft-qos/monitor.sh
+	. /lib/nft-qos/dynamic.sh
+	. /lib/nft-qos/static.sh
+	. /lib/nft-qos/mac.sh
+	. /lib/nft-qos/priority.sh
+fi
 
 START=99
 USE_PROCD=1


### PR DESCRIPTION
commit: f88485f572ec1ff9082106ccf0ccb20fc7af5801 which adds
IPKG_INSTROOT to source is ineffective for this package.

Source includes only when empty.

Signed-off-by: Imran Khan <gururug@gmail.com>