### PR TITLE
fail2ban: Python 3.10 compatibility

### DIFF
--- a/net/fail2ban/patches/010-python3.10_compat.patch
+++ b/net/fail2ban/patches/010-python3.10_compat.patch
@@ -1,0 +1,25 @@
+From 2b6bb2c1bed8f7009631e8f8c306fa3160324a49 Mon Sep 17 00:00:00 2001
+From: "Sergey G. Brester" <serg.brester@sebres.de>
+Date: Mon, 8 Feb 2021 17:19:24 +0100
+Subject: [PATCH] follow bpo-37324: :ref:`collections-abstract-base-classes`
+ moved to the :mod:`collections.abc` module
+
+(since 3.10-alpha.5 `MutableMapping` is missing in collections module)
+---
+ fail2ban/server/action.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/fail2ban/server/action.py
++++ b/fail2ban/server/action.py
+@@ -30,7 +30,10 @@ import tempfile
+ import threading
+ import time
+ from abc import ABCMeta
+-from collections import MutableMapping
++try:
++	from collections.abc import MutableMapping
++except ImportError:
++	from collections import MutableMapping
+ 
+ from .failregex import mapTag2Opt
+ from .ipdns import DNSUtils


### PR DESCRIPTION
Maintainer: @erdoukki.
Compile tested: Clean Debian 10 host, Entware repo ([commit](https://github.com/Entware/entware-packages/commit/4fd5c07cc15bff0db8cdae1757a29711cf78688e#diff-e06b1de33869405a2eb02a2842806a83955d97e85952b7e5de3c0aadc116f549)).
Run tested: Entware, mipsel feed

Description: fixes following runtime error on Python 3.10.0:
```
~ # fail2ban-server --dp
ERROR: cannot import name 'MutableMapping' from 'collections' (/lib/python3.10/collections/__init__.pyc)
```