### PR TITLE
bt-agent: add new package

### DIFF
--- a/utils/bluez-tools/Makefile
+++ b/utils/bluez-tools/Makefile
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2021 Karl Osterseher <karli_o@gmx.at>
+#
+# This is free software, licensed under the GNU General Public License v2.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bluez-tools
+PKG_VERSION:=20201025.f653217
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_MAINTAINER:=Karl Osterseher <karli_o@gmx.at>
+
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/khvzak/bluez-tools.git
+PKG_SOURCE_DATE:=2020-10-25
+PKG_SOURCE_VERSION:=f65321736475429316f07ee94ec0deac8e46ec4a
+PKG_MIRROR_HASH:=a0a7856738fcee12df8894239608d8cc4a7af92574d9bdb5a0b68a8a5455214b
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/bluez-tools-$(PKG_VERSION)
+
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/bluez-tools
+  SECTION:=Utilities
+  CATEGORY:=Utilities
+  DEPENDS:=+bluez-daemon +glib2
+  TITLE:=Bluetooth tools
+  URL:=https://github.com/khvzak/bluez-tools
+endef
+
+define Package/bluez-tools/description
+  Bluetooth tools for bluez daemon. This will install bt-agent only!
+endef
+
+define Package/bluez-tools/conffiles
+  /etc/config/btagent
+endef
+
+define Package/bluez-tools/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/btagent.init $(1)/etc/init.d/btagent
+	$(INSTALL_DIR) $(1)/etc/config
+	$(CP) ./files/btagent.cfg $(1)/etc/config/btagent
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/bt-agent $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,bluez-tools))

--- a/utils/bluez-tools/files/btagent.cfg
+++ b/utils/bluez-tools/files/btagent.cfg
@@ -1,0 +1,3 @@
+config btagent
+	option mac '*'
+	option pin '0000'

--- a/utils/bluez-tools/files/btagent.init
+++ b/utils/bluez-tools/files/btagent.init
@@ -1,0 +1,37 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+START=90
+
+SERVICE_NAME=bt-agent
+SERVICE_PID_FILE=/var/run/$SERVICE_NAME.pid
+
+DAEMON=/usr/bin/$SERVICE_NAME
+
+AGENT_PIN_FILE=/tmp/btagent.cfg
+AGENT_CAPABILITIES=NoInputNoOutput
+
+handle_bt_agent() {
+	local config="$1"
+	local custom="$2"
+	
+	local macAdr
+	local pinCode	
+	config_get macAdr "$config" mac
+	config_get pinCode "$config" pin
+	echo "$macAdr, $pinCode" >> $AGENT_PIN_FILE
+}
+
+start_service()
+{
+	config_load btagent
+	config_foreach handle_bt_agent btagent
+	
+	procd_open_instance
+	procd_set_param command "$DAEMON"
+	procd_append_param command "-c" "$AGENT_CAPABILITIES"
+	procd_append_param command "-p" "$AGENT_PIN_FILE"
+	procd_set_param pidfile $SERVICE_PID_FILE
+	procd_close_instance
+}


### PR DESCRIPTION
Maintainer: me

Compile tested:
target-arm_cortex-a7+neon-vfpv4_musl_eabi
Model: Mikrotik hAP ac² (RBD52G-5HacD2HnD-TC)
```
# uname -a
# Linux 5.4.0-91-generic #102~18.04.1-Ubuntu SMP Thu Nov 11 14:46:36 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
```

Run tested:
Model: Mikrotik hAP ac² (RBD52G-5HacD2HnD-TC)
```
# uname -a
# Linux OpenWrt 5.10.80 #0 SMP Fri Nov 26 20:33:09 2021 armv7l GNU/Linux
```

tests done:
pairing using Android 7 Smartphone
connecting and playback using bluez-alsa configured as an a2dp sink

Description:
The Platform is also running bluez-alsa making it an A2DP sink. Pairing works with bluez-alsa service stopped. With bluez-alsa service started and configured as a2dp-sink it is also connectable and playback works flawless.