### PR TITLE
nfs-kernel-server: fix build on macos arm64

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
 PKG_VERSION:=2.5.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_HASH:=546ce4b51eeebc66e354b6cc6ca0ce509437efbdef0caaf99389534eef0e598b
 
 PKG_SOURCE_URL:=@SF/nfs
@@ -150,6 +150,7 @@ HOST_CONFIGURE_VARS += \
 	ac_cv_header_nfsidmap_h=yes \
 	ac_cv_header_blkid_blkid_h=yes \
 	ac_cv_lib_resolv___res_querydomain=yes \
+	ac_cv_func_prctl=yes \
 	GSSGLUE_CFLAGS=" " \
 	GSSGLUE_LIBS=" " \
 	RPCSECGSS_CFLAGS=" " \

--- a/net/nfs-kernel-server/patches/200-fix-macos-build.patch
+++ b/net/nfs-kernel-server/patches/200-fix-macos-build.patch
@@ -1,0 +1,17 @@
+fix stat64 issue for modern macos versions (including macos arm64)
+
+--- a/tools/rpcgen/rpc_main.c
++++ b/tools/rpcgen/rpc_main.c
+@@ -62,6 +62,12 @@
+ #define EXTEND	1		/* alias for TRUE */
+ #define DONT_EXTEND	0	/* alias for FALSE */
+ 
++#ifdef __APPLE__
++# if __DARWIN_ONLY_64_BIT_INO_T
++#  define stat64 stat
++# endif
++#endif
++
+ struct commandline
+   {
+     int cflag;			/* xdr C routines */


### PR DESCRIPTION
Previously, @ptpt52 user propose https://github.com/openwrt/packages/pull/17261 but that PR is not compatible with non-macos building hosts.

This patch doesn't not break compilation on non-macos building hosts

1. prctl() check is not required for host-compile on macos so this
check is removed from configure script for darwin targets

2. __DARWIN_ONLY_64_BIT_INO_T is true on macos arm64 so struct stat64
and stat64() are not available. This patch defines stat64 as stat if
__DARWIN_ONLY_64_BIT_INO_T is true


Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: Peter Wagner <tripolar@gmx.at>
Run tested: mipsel; tplink,tl-mr3020-v3; OpenWrt version 56b14fdeb24b63b26ae948aa2fa6b1ce4b9df1fd, tests done

