### PR TITLE
snort3: update to 3.1.18.0, and update libdaq3 and hwloc dependencies

### DIFF
--- a/libs/hwloc/Makefile
+++ b/libs/hwloc/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hwloc
-PKG_VERSION:=2.3.0
-PKG_RELEASE:=1
+PKG_VERSION:=2.6.0
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=https://download.open-mpi.org/release/$(PKG_NAME)/v2.3
-PKG_HASH:=b607f6097873f69ef6b4b01e66e0dcb45f9939e8979827284664bbf0d4018a64
+PKG_SOURCE_URL:=https://download.open-mpi.org/release/$(PKG_NAME)/v2.6
+PKG_HASH:=e1f073e44e28c296ff848dead5e9bd6e2426b77f95ead1792358958e859fa83a
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=BSD-3-Clause

--- a/libs/libdaq3/Makefile
+++ b/libs/libdaq3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdaq3
-PKG_VERSION:=3.0.3
+PKG_VERSION:=3.0.5
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -17,7 +17,7 @@ PKG_LICENSE:=GPL-2.0-only
 
 PKG_SOURCE:=libdaq-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/snort3/libdaq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=920344f5c98ac68b401d1bc92ebaed78b0d15779b0480c213db279d0a60acc32
+PKG_HASH:=4281464c5502037669e69d314b628df863420f590c4999c5b567c8016cd1e658
 PKG_BUILD_DIR:=$(BUILD_DIR)/libdaq-$(PKG_VERSION)
 
 PKG_FIXUP:=autoreconf

--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
-PKG_VERSION:=3.1.4.0
+PKG_VERSION:=3.1.18.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
-PKG_HASH:=a68af8ea46a038dfb0ad489e8d11dee62a3e63cb4a639f6bb4fac4ded955fe11
+PKG_HASH:=6e45c16b1815d832b5d6edcd2b705e7838e25c76bfd54b3e86c55ecba6de420a
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=GPL-2.0-only
@@ -25,7 +25,7 @@ define Package/snort3
   SUBMENU:=Firewall
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre +libpthread +libuuid +zlib +libhwloc +libtirpc +luajit
+  DEPENDS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre +libpthread +libuuid +zlib +libhwloc +libtirpc +luajit +libatomic
   TITLE:=Lightweight Network Intrusion Detection System
   URL:=http://www.snort.org/
   MENU:=1
@@ -78,11 +78,11 @@ define Package/snort3/install
 
 	$(INSTALL_DIR) $(1)/usr/lib/snort
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/snort/daqs/daq_hext.so \
+		$(PKG_INSTALL_DIR)/usr/lib/snort/daq/daq_hext.so \
 		$(1)/usr/lib/snort/
 
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/snort/daqs/daq_file.so \
+		$(PKG_INSTALL_DIR)/usr/lib/snort/daq/daq_file.so \
 		$(1)/usr/lib/snort/
 
 	$(INSTALL_DIR) $(1)/usr/share/lua

--- a/net/snort3/patches/010-update-openssl.patch
+++ b/net/snort3/patches/010-update-openssl.patch
@@ -1,13 +1,13 @@
 --- a/src/network_inspectors/appid/appid_inspector.cc
 +++ b/src/network_inspectors/appid/appid_inspector.cc
-@@ -64,7 +64,6 @@ static THREAD_LOCAL PacketTracer::Tracer
+@@ -66,7 +66,6 @@ static THREAD_LOCAL PacketTracer::Tracer
  //           should probably be done outside of appid
  static void openssl_cleanup()
  {
 -    CRYPTO_cleanup_all_ex_data();
  }
  
- static void populate_trace_data(Flow& flow, const OdpContext& odp_context)
+ static void add_appid_to_packet_trace(Flow& flow, const OdpContext& odp_context)
 --- a/src/utils/util.cc
 +++ b/src/utils/util.cc
 @@ -111,7 +111,7 @@ int DisplayBanner()

--- a/net/snort3/patches/020-libatomic.patch
+++ b/net/snort3/patches/020-libatomic.patch
@@ -1,0 +1,75 @@
+--- /dev/null
++++ b/cmake/FindAtomic.cmake
+@@ -0,0 +1,11 @@
++find_library(ATOMIC_LIBRARIES NAMES atomic
++    HINTS ${ATOMIC_LIBRARIES_DIR_HINT})
++
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(Atomic DEFAULT_MSG ATOMIC_LIBRARIES)
++
++mark_as_advanced(ATOMIC_LIBRARIES)
++
++if (ATOMIC_LIBRARIES)
++    set(HAVE_ATOMIC "1")
++endif()
+--- a/cmake/include_libraries.cmake
++++ b/cmake/include_libraries.cmake
+@@ -15,6 +15,7 @@ if (ENABLE_UNIT_TESTS)
+ endif (ENABLE_UNIT_TESTS)
+ 
+ # optional libraries
++find_package(Atomic QUIET)
+ find_package(LibLZMA QUIET)
+ find_package(Asciidoc QUIET)
+ find_package(DBLATEX QUIET)
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -116,6 +116,14 @@ else ()
+     DAQ Modules:    Dynamic")
+ endif ()
+ 
++if (HAVE_ATOMIC)
++    message("\
++    libatomic:      ON")
++else ()
++    message("\
++    libatomic:      OFF")
++endif ()
++
+ if (HAVE_FLATBUFFERS)
+     message("\
+     Flatbuffers:    ON")
+--- a/configure_cmake.sh
++++ b/configure_cmake.sh
+@@ -108,6 +108,8 @@ Optional Packages:
+                             libhs include directory
+     --with-hyperscan-libraries=DIR
+                             libhs library directory
++    --with-atomic-libraries=DIR
++                            atomic library directory
+     --with-flatbuffers-includes=DIR
+                             flatbuffers include directory
+     --with-flatbuffers-libraries=DIR
+@@ -447,6 +449,9 @@ while [ $# -ne 0 ]; do
+         --with-hyperscan-libraries=*)
+             append_cache_entry HS_LIBRARIES_DIR PATH $optarg
+             ;;
++        --with-atomic-libraries=*)
++            append_cache_entry ATOMIC_LIBRARIES_DIR_HINT PATH $optarg
++            ;;
+         --with-flatbuffers-includes=*)
+             append_cache_entry FLATBUFFERS_INCLUDE_DIR_HINT PATH $optarg
+             ;;
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -25,6 +25,10 @@ set(EXTERNAL_INCLUDES
+     ${ZLIB_INCLUDE_DIRS}
+ )
+ 
++if ( HAVE_ATOMIC )
++    LIST(APPEND EXTERNAL_LIBRARIES ${ATOMIC_LIBRARIES})
++endif()
++
+ if ( ENABLE_STATIC_DAQ )
+     LIST(APPEND EXTERNAL_LIBRARIES ${DAQ_STATIC_MODULE_LIBS})
+ endif ()


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64
Run tested: x86_64

Description:
