### PR TITLE
ddns-scripts: add ns1.com provider

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=19
+PKG_RELEASE:=20
 
 PKG_LICENSE:=GPL-2.0
 
@@ -127,6 +127,19 @@ endef
 
 define Package/ddns-scripts-noip/description
   Dynamic DNS Client scripts extension for "no-ip.com".
+endef
+
+define Package/ddns-scripts-ns1
+  $(call Package/ddns-scripts/Default)
+  TITLE:=NS1 API
+  DEPENDS:=ddns-scripts +curl
+endef
+
+define Package/ddns-scripts-ns1/description
+  Dynamic DNS Client scripts extension for "ns1.com".
+  It requires:
+  "option username" to be a valid zone for ns1.com
+  "option password" to be a valid API key for ns1.com
 endef
 
 
@@ -298,6 +311,7 @@ define Package/ddns-scripts-services/install
 	rm $(1)/usr/share/ddns/default/gandi.net.json
 	rm $(1)/usr/share/ddns/default/pdns.json
 	rm $(1)/usr/share/ddns/default/transip.nl.json
+	rm $(1)/usr/share/ddns/default/ns1.com.json
 endef
 
 
@@ -407,6 +421,25 @@ define Package/ddns-scripts-noip/install
 endef
 
 define Package/ddns-scripts-noip/prerm
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	/etc/init.d/ddns stop
+fi
+exit 0
+endef
+
+
+define Package/ddns-scripts-ns1/install
+	$(INSTALL_DIR) $(1)/usr/lib/ddns
+	$(INSTALL_BIN) ./files/usr/lib/ddns/update_ns1_com.sh \
+		$(1)/usr/lib/ddns
+
+	$(INSTALL_DIR) $(1)/usr/share/ddns/default
+	$(INSTALL_DATA) ./files/usr/share/ddns/default/ns1.com.json \
+		$(1)/usr/share/ddns/default
+endef
+
+define Package/ddns-scripts-ns1/prerm
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
 	/etc/init.d/ddns stop
@@ -543,3 +576,4 @@ $(eval $(call BuildPackage,ddns-scripts-cnkuai))
 $(eval $(call BuildPackage,ddns-scripts-gandi))
 $(eval $(call BuildPackage,ddns-scripts-pdns))
 $(eval $(call BuildPackage,ddns-scripts-transip))
+$(eval $(call BuildPackage,ddns-scripts-ns1))

--- a/net/ddns-scripts/files/usr/lib/ddns/update_ns1_com.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_ns1_com.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# Derived from update_gandi_net.sh
+
+. /usr/share/libubox/jshn.sh
+
+local __ENDPOINT="https://api.nsone.net/v1"
+local __TTL=600
+local __RRTYPE
+local __URL
+local __STATUS
+
+[ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing zone as 'username'"
+[ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing API Key as 'password'"
+
+[ $use_ipv6 -ne 0 ] && __RRTYPE="AAAA" || __RRTYPE="A"
+
+# Construct JSON payload
+json_init
+# {"answers":[{"answer":["1.1.1.1"]}]}
+json_add_array answers
+json_add_object
+json_add_array answer
+json_add_string "" "$__IP"
+json_close_array
+json_close_object
+json_close_array
+
+__URL="$__ENDPOINT/zones/$username/$domain/$__RRTYPE"
+
+__STATUS=$(curl -s -X POST "$__URL" \
+	-H "X-NSONE-Key: $password" \
+	-H "Content-Type: application/json" \
+	-d "$(json_dump)" \
+	-w "%{http_code}\n" -o $DATFILE 2>$ERRFILE)
+
+if [ $? -ne 0 ]; then
+	write_log 14 "Curl failed: $(cat $ERRFILE)"
+	return 1
+elif [ -z $__STATUS ] || [ $__STATUS != 200 ]; then
+	write_log 4 "Request failed: $__STATUS, NS1 answered: $(cat $DATFILE)"
+	if [ $__STATUS = 404 ]; then
+		write_log 4 "Status is 404, trying to create a DNS record"
+
+		json_init
+		json_add_string "zone" "$username"
+		json_add_string "domain" "$domain"
+		json_add_string "type" "$__RRTYPE"
+		json_add_string "ttl" "$__TTL"
+		json_add_array answers
+		json_add_object
+		json_add_array answer
+		json_add_string "" "$__IP"
+		json_close_array
+		json_close_object
+		json_close_array
+
+		__STATUS=$(curl -s -X PUT "$__URL" \
+			-H "X-NSONE-Key: $password" \
+			-H "Content-Type: application/json" \
+			-d "$(json_dump)" \
+			-w "%{http_code}\n" -o $DATFILE 2>$ERRFILE)
+
+		if [ $? -ne 0 ]; then
+			write_log 14 "Curl failed: $(cat $ERRFILE)"
+			return 1
+		elif [ -z $__STATUS ] || [ $__STATUS != 200 ]; then
+			write_log 14 "Request failed: $__STATUS, NS1 answered: $(cat $DATFILE)"
+			return 1
+		fi
+	else
+		return 1
+	fi
+fi
+
+write_log 7 "NS1 answered: $(cat $DATFILE)"
+
+return 0

--- a/net/ddns-scripts/files/usr/share/ddns/default/ns1.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/ns1.com.json
@@ -1,0 +1,9 @@
+{
+	"name": "ns1.com",
+	"ipv4": {
+		"url": "update_ns1_com.sh"
+	},
+	"ipv6": {
+		"url": "update_ns1_com.sh"
+	}
+}


### PR DESCRIPTION
Signed-off-by: Richard Yu <yurichard3839@gmail.com>

Maintainer: @feckert ?
Compile tested: N/A
Run tested: x86_64

Description:
[NS1.com](https://ns1.com/)'s record is based on the domain and reocrd type, all IPs are in record's answers array.
When updating, new "answers" will override the old ones. The only way to keep old IPs is to read first, modify and update.
Since DDNS users rarely need multiple IPs, I didn't implement such function. Other settings such as TTL will not change during update.

Another question: Is `PKG_VERSION` really useful for this package? Looks like it doesn't change for a year. Maybe a date-based version code is useful.