### PR TITLE
bandwidthd: migrate dependencies to php8 (fixes #17296)

### DIFF
--- a/utils/bandwidthd/Makefile
+++ b/utils/bandwidthd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bandwidthd
 PKG_VERSION:=2.0.1-35
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/NethServer/bandwidthd/tar.gz/$(PKG_VERSION)?
@@ -48,14 +48,14 @@ define Package/bandwidthd-sqlite
 $(call Package/bandwidthd/Default)
   TITLE += (with sqlite enabled)
   VARIANT:=sqlite
-  DEPENDS:=+libgd +libpcap +libsqlite3 +php7 +php7-cgi +php7-mod-gd +php7-mod-pdo +php7-mod-pdo-sqlite
+  DEPENDS:=+libgd +libpcap +libsqlite3 +php8 +php8-cgi +php8-mod-gd +php8-mod-pdo +php8-mod-pdo-sqlite
 endef
 
 define Package/bandwidthd-php
 $(call Package/bandwidthd/Default)
   TITLE = PHP files to graph bandwidthd data from postgresql
   VARIANT:=php
-  DEPENDS:=+libpcre +libxml2 +php7 +php7-cgi +php7-mod-pgsql +php7-mod-gd
+  DEPENDS:=+libpcre +libxml2 +php8 +php8-cgi +php8-mod-pgsql +php8-mod-gd
 endef
 
 define Package/bandwidthd/description


### PR DESCRIPTION
Maintainer: @padre-lacroix 
Compile tested: mxs
Run tested: -

Description:

This package was forgotten when all other packages were upgraded to PHP8.
So let's upgrade the dependencies here as well.

Thanks to @feckert, for pointing this out.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>