### PR TITLE
conmon: update to v2.0.31

### DIFF
--- a/utils/conmon/Makefile
+++ b/utils/conmon/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=conmon
-PKG_VERSION:=2.0.30
+PKG_VERSION:=2.0.31
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containers/$(PKG_NAME)/archive/v$(PKG_VERSION)
-PKG_HASH:=4b0a98fbe8a63c42f60edac25c19aa6606caa7b1e4fe7846fc7f7de0b566ba25
+PKG_HASH:=76286480065d4cf9b24610c159c683710fe9c8b9f753518f804f22bbb59796a8
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
 - conmon: free userdata files before exec cleanup
 - logging: new mode -l passthrough

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>

Maintainer: Oskari Rauta / @oskarirauta
Compile tested: x86_64
Run tested: x86_64