### PR TITLE
chrony: update to 4.2

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
-PKG_VERSION:=4.1
-PKG_RELEASE:=2
+PKG_VERSION:=4.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.tuxfamily.org/chrony/
-PKG_HASH:=ed76f2d3f9347ac6221a91ad4bd553dd0565ac188cd7490d0801d08f7171164c
+PKG_HASH:=273f9fd15c328ed6f3a5f6ba6baec35a421a34a73bb725605329b1712048db9a
 
 PKG_MAINTAINER:=Miroslav Lichvar <mlichvar0@gmail.com>
 PKG_LICENSE:=GPL-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: (mips, mt7621, OpenWrt 21.02)
Run tested: (mips, mt7621 (Cudy WR1300), OpenWrt 21.02, tested NTP+NTS)
