### PR TITLE
tailscale: update to 1.18.2

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.12.3
+PKG_VERSION:=1.18.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=tailscale-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=05e5b1d382cad7ac5737d87d0b61277791c75938468c2c662f21665998d431e9
+PKG_HASH:=57206181868299027689651b6cd133627acad0c8c38f0151f469ab36d4130012
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: @ja-pa
Compile tested: aarch64_cortex-a53, bcm27xx, OpenWrt 21.02.1 on Debian 11 aarch64
Run tested: aarch64, Raspberry Pi 3B+, OpenWrt 21.02.1, installed and connected to my Tailscale network with it

Description: This is latest upstream release as of creation of this PR.
