### PR TITLE
jose: remove libjose

### DIFF
--- a/libs/jose/Makefile
+++ b/libs/jose/Makefile
@@ -19,20 +19,15 @@ PKG_MAINTAINER:=Tibor Dudlák <tibor.dudlak@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=COPYING
 
+PKG_BUILD_DEPENDS:=openssl
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/meson.mk
-
-define Package/libjose
-  SECTION:=libs
-  TITLE:=Provides a full crypto stack including key generation, signing and encryption.
-  DEPENDS:=+zlib +jansson +libopenssl +libpthread
-  URL:=https://github.com/latchset/jose
-endef
 
 define Package/jose
   SECTION:=utils
   TITLE:=Provides a full crypto stack including key generation, signing and encryption.
-  DEPENDS:=+libjose
+  DEPENDS:=+jansson
   URL:=https://github.com/latchset/jose
 endef
 
@@ -42,25 +37,17 @@ define Package/jose/description
 	crypto stack including key generation, signing and encryption.
 endef
 
-define Package/libjose/description
-	libjose is a library for performing various tasks on JSON
-	Object Signing and Encryption (JOSE) objects. José provides a full
-	crypto stack including key generation, signing and encryption.
-endef
+MESON_ARGS += \
+	-Ddefault_library=static
 
 define Build/InstallDev
 	$(INSTALL_DIR)	$(1)/usr/lib
 	$(INSTALL_DIR)  $(1)/usr/include
 	$(INSTALL_DIR)	$(1)/usr/include/$(PKG_NAME)
 	$(INSTALL_DIR)	$(1)/usr/lib/pkgconfig
-	$(CP)	$(PKG_INSTALL_DIR)/usr/lib/lib$(PKG_NAME).so*	$(1)/usr/lib
+	$(CP)	$(PKG_INSTALL_DIR)/usr/lib/lib$(PKG_NAME).a	$(1)/usr/lib
 	$(CP)	$(PKG_INSTALL_DIR)/usr/include/$(PKG_NAME)/*.h	$(1)/usr/include/$(PKG_NAME)
 	$(CP)	$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc	$(1)/usr/lib/pkgconfig
-endef
-
-define Package/libjose/install
-	$(INSTALL_DIR)	$(1)/usr/lib
-	$(CP)		$(PKG_INSTALL_DIR)/usr/lib/lib$(PKG_NAME).so*	$(1)/usr/lib/
 endef
 
 define Package/jose/install
@@ -68,5 +55,4 @@ define Package/jose/install
 	$(INSTALL_BIN)  $(PKG_INSTALL_DIR)/usr/bin/$(PKG_NAME)          $(1)/usr/bin/
 endef
 
-$(eval $(call BuildPackage,libjose))
 $(eval $(call BuildPackage,jose))


### PR DESCRIPTION
It can be built statically as nothing else uses it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Tiboris 
Compile tested: ath79