### PR TITLE
sqm-scripts: drop redundant dependency

### DIFF
--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=sqm-scripts
 PKG_SOURCE_VERSION:=5d7e7977e14e147d5bcfa8a5f01636c7ab230fa4
 PKG_VERSION:=1.5.1
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/tohojo/sqm-scripts
@@ -24,9 +24,8 @@ include $(INCLUDE_DIR)/package.mk
 define Package/sqm-scripts
   SECTION:=net
   CATEGORY:=Base system
-  DEPENDS:=+tc +kmod-sched-core +kmod-ifb +iptables \
-	+iptables-mod-ipopt +iptables-mod-conntrack-extra \
-	+kmod-sched-cake
+  DEPENDS:=+tc +kmod-sched-cake +kmod-ifb +iptables \
+	+iptables-mod-ipopt +iptables-mod-conntrack-extra
   TITLE:=SQM Scripts (QoS)
   PKGARCH:=all
 endef


### PR DESCRIPTION
The `kmod-sched-cake` package already depends on `kmod-sched-core`, there's no need
for explicitly stating the dependency.

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>

Maintainer: @tohojo 
