### PR TITLE
openvpn: update to 2.5.5

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.5.4
+PKG_VERSION:=2.5.5
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=56c0dcd27ab938c4ad07469c86eb8b7408ef64c3e68f98497db8c03f11792436
+PKG_HASH:=119bd69fa0210838f6cdaa273696dc738efa200f454dbe11eb6dfb75dfb6003b
 
 PKG_MAINTAINER:=Magnus Kroken <mkroken@gmail.com>
 


### PR DESCRIPTION
Maintainer: me / @mkrkn
Compile tested: ramips/mt7620 TP-Link Archer C50 v1, ramips/mt7621 Xiaomi Mi router 3 Pro, ath79/generic TP-Link WDR-3500
Run tested: ramips/mt7620 TP-Link Archer C50 v1, ramips/mt7621 Xiaomi Mi router 3 Pro, ath79/generic TP-Link WDR-3500

openvpn: update to 2.5.5

use of CFG Spectre-mitigations in MSVC builds
bring back OpenSSL config loading to Windows builds
several build fixes, refer to https://github.com/OpenVPN/openvpn/blob/release/2.5/Changes.rst
