### PR TITLE
openldap: hide configurables when libopenldap is not enabled

### DIFF
--- a/libs/openldap/Config.in
+++ b/libs/openldap/Config.in
@@ -1,0 +1,44 @@
+if PACKAGE_libopenldap
+	config OPENLDAP_DEBUG
+		bool "Enable debugging information"
+		default y
+		help
+		  Enable debugging information. This option must be enabled
+		  for the loglevel directive to work.
+	config OPENLDAP_CRYPT
+		bool "Crypt(3) passwords support"
+		default n
+		help
+		  With crypt(3) password storage scheme enabled, OpenLDAP can
+		  receive and store SHA-256 and SHA-512 password hashes from
+		  Samba AD-DC. If this option is disabled, synchronization of
+		  passwords between Samba AD-DC (v4.5 and above) and OpenLDAP
+		  requires use of cleartext passwords.
+		  To enable crypt(3) password synchronization functionality:
+		  1. Re-include crypt(3) support in OpenWRT by enabling 'Include
+		  crypt() support for SHA256, SHA512 and Blowfish ciphers' option
+		  in "Advanced configuration options (for developers)" ->
+		  "Toolchain Options".
+		  2. Provision AD-DC with 'password hash userPassword schemes'
+		  option. For more information, see smb.conf manpage for details
+		  on 'password hash userPassword schemes'.
+		  3. Use a script to synchronize passwords from AD-DC to
+		  OpenLDAP. See samba-tool manpage for 'user syncpasswords'.
+	config OPENLDAP_MONITOR
+		bool "Enable monitor backend"
+		default n
+		help
+		  Enable monitor backend to obtain information about the running
+		  status of the daemon. See OpenLDAP documentation for more
+		  information.
+	config OPENLDAP_DB47
+		bool "Berkeley DB support"
+		default n
+		help
+		  Enable Berkeley DB support (BDB).
+	config OPENLDAP_ICU
+		bool "ICU support"
+		default n
+		help
+		  Enable ICU (International Components for Unicode) support.
+endif

--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -55,49 +55,8 @@ define Package/libopenldap
   TITLE+= (libraries)
 endef
 
-define Package/libopenldap/config
-  config OPENLDAP_DEBUG
-	bool "Enable debugging information"
-	default y
-	help
-		Enable debugging information. This option must be enabled
-		for the loglevel directive to work.
-  config OPENLDAP_CRYPT
-	bool "Crypt(3) passwords support"
-	default n
-	help
-		With crypt(3) password storage scheme enabled, OpenLDAP can
-		receive and store SHA-256 and SHA-512 password hashes from
-		Samba AD-DC. If this option is disabled, synchronization of
-		passwords between Samba AD-DC (v4.5 and above) and OpenLDAP
-		requires use of cleartext passwords.
-		To enable crypt(3) password synchronization functionality:
-		1. Re-include crypt(3) support in OpenWRT by enabling 'Include
-		crypt() support for SHA256, SHA512 and Blowfish ciphers' option
-		in "Advanced configuration options (for developers)" ->
-		"Toolchain Options".
-		2. Provision AD-DC with 'password hash userPassword schemes'
-		option. For more information, see smb.conf manpage for details
-		on 'password hash userPassword schemes'.
-		3. Use a script to synchronize passwords from AD-DC to
-		OpenLDAP. See samba-tool manpage for 'user syncpasswords'.
-  config OPENLDAP_MONITOR
-	bool "Enable monitor backend"
-	default n
-	help
-		Enable monitor backend to obtain information about the running
-		status of the daemon. See OpenLDAP documentation for more
-		information.
-  config OPENLDAP_DB47
-	bool "Berkeley DB support"
-	default n
-	help
-		Enable Berkeley DB support (BDB).
-  config OPENLDAP_ICU
-	bool "ICU support"
-	default n
-	help
-		Enable ICU (International Components for Unicode) support.
+define Package/openldap/config
+  source "$(SOURCE)/Config.in"
 endef
 
 define Package/libopenldap/description


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: bcm53xx
Run tested: N/A

Description: When openldap is not enabled, the following configurables remain present
in the config:

CONFIG_OPENLDAP_DEBUG=y
\# CONFIG_OPENLDAP_CRYPT is not set
\# CONFIG_OPENLDAP_MONITOR is not set
\# CONFIG_OPENLDAP_DB47 is not set
\# CONFIG_OPENLDAP_ICU is not set

This patch adds a libopenldap dependency for each option, removing the
above from .config when libopenldap is not used.

Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>
