### PR TITLE
logrotate: add logrotate.d to conffiles definition

### DIFF
--- a/utils/logrotate/Makefile
+++ b/utils/logrotate/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=logrotate
 PKG_VERSION:=3.17.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/logrotate/logrotate/releases/download/$(PKG_VERSION)
@@ -49,6 +49,7 @@ endef
 
 define Package/logrotate/conffiles
 /etc/logrotate.conf
+/etc/logrotate.d
 endef
 
 CONFIGURE_ARGS += \


### PR DESCRIPTION
Maintainer: @bk138
Compile tested: bcm53xx
Run tested: bcm53xx

Description:

Currently the contents of logrotate.d is not kept across sysupgrades.
Add this directory to the conffiles definition to ensure its content is
maintained.

Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>
