### PR TITLE
ookla-speedtest package

### DIFF
--- a/net/ookla-speedtest/Makefile
+++ b/net/ookla-speedtest/Makefile
@@ -1,0 +1,42 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ookla-speedtest
+PKG_VERSION:=1.1.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-linux-x86_64.tgz
+PKG_SOURCE_URL:=https://install.speedtest.net/app/cli/
+PKG_HASH:=970477fdfee4d741e75f088faf648f9b51c7be04313fb88ffb5de07eb1a3040c
+
+PKG_MAINTAINER:=James White <james@jmwhite.co.uk>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ookla-speedtest
+    SECTION=:net
+    CATEGORY:=Network
+    DEPENDS:=@TARGET_x86_64
+    TITLE:=Ookla Speedtest CLI
+    URL:=https://www.speedtest.net/apps/cli
+endef
+
+define Package/speedtest-cli/description
+    Speedtest CLI brings the trusted technology and global server network behind
+    Speedtest to the command line. Built for software developers, system
+    administrators and computer enthusiasts alike, Speedtest CLI is the first
+    official Linux-native Speedtest application backed by Ookla.
+endef
+
+define Build/Prepare
+    $(Build/Prepare/Default)
+endef
+
+define Build/Compile
+endef
+
+define Package/ookla-speedtest/install
+    $(INSTALL_DIR) $(1)/usr/bin
+    $(INSTALL_BIN) $(BUILD_DIR)/speedtest $(1)/usr/bin/speedtest
+endef
+
+$(eval $(call BuildPackage,ookla-speedtest))


### PR DESCRIPTION
Ookla Speedtest has an official CLI client which is statically linked and can run on OpenWrt, however it is only supported for certain architectures and the source code for it is also not published due to Ookla potentially giving up "trade secrets" or certain inner workings of their product.

I used the following Makefile as a starting point, with the objective of being able to have a installable package in OpenWrt repositories.

https://raw.githubusercontent.com/pyther/openwrt-feed/master/net/ookla-speedtest/Makefile
Credit to Matthew Gyurgyik @pyther who wrote the original Makefile, however it is hard coded to the x86_64 binary.

It would be good to allow the Makefile to be able to pull the correct binary relative to the architecture, but I'm thinking it could get quite messy. Ookla's binary naming may not align to OpenWrt directly and the PKG_HASH will need to be changed for each different binary, along with restricting the package itself to only supported architectures. 

If OpenWrt devs or maintainers could offer any assistance with making this more multi arch aware so other targets can benefit, I'd be happy to look into it, but for now I've taken the original Makefile from @pyther and just updated it to the standards outlined here: https://openwrt.org/docs/guide-developer/packages

Any advice or guidance on achieving the above is welcome!