### PR TITLE
crowdsec-firewall-bouncer: remove crowdsec package dependency

### DIFF
--- a/net/crowdsec-firewall-bouncer/Makefile
+++ b/net/crowdsec-firewall-bouncer/Makefile
@@ -52,8 +52,7 @@ endef
 define Package/crowdsec-firewall-bouncer
 $(call Package/crowdsec-firewall-bouncer/Default)
   DEPENDS:=@(PACKAGE_iptables||PACKAGE_nftables) \
-	$(GO_ARCH_DEPENDS) \
-	+crowdsec
+	$(GO_ARCH_DEPENDS)
 endef
 
 define Package/golang-crowdsec-firewall-bouncer-dev


### PR DESCRIPTION
Maintainer: me / @erdoukki 
Compile tested: (none)
Run tested: (none)

Remove un-necessary crowdsec package dependency, to be able to use
crowdsec-firewall-bouncer independently from crowdsec local installation.
(with remote API)

Fix issue: https://github.com/openwrt/packages/issues/17406

Description:
  using crowdsec-firewall-bouncer on many OpenWRT devices connected
  with my domain LAPI server (which collect many crowdsec machines,
  mostly nginx), it works great. Actually, crowdsec package is not
  mandatory for that usage, it would be great if it was not a dependency.

Signed-off-by: Kerma Gérald <gandalf@gk2.net>