### PR TITLE
Update syncthing to 1.18.5

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.18.2
+PKG_VERSION:=1.18.5
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=afe2ae979da3b4f1af8aeabd7e1704807242913b516e0b6585510821c9d6d4f2
+PKG_HASH:=c64db4d5fe6ae6525d2333fdd5cb41243e56430ced377c59ca69731a1183df1f
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 

--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -6,6 +6,7 @@ PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
+# Performed by sha256sum [syncthing source file] cli command
 PKG_HASH:=c64db4d5fe6ae6525d2333fdd5cb41243e56430ced377c59ca69731a1183df1f
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)


### PR DESCRIPTION
Maintainer: @aparcar
Compile tested: Linksys WRT32X
Run tested: Linksys WRT32X

Description: update utils/syncthing to 1.18.5 version


