### PR TITLE
Add exporter for dnsmasq dhcp leases

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2021.12.21
+PKG_VERSION:=2022.01.05
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
@@ -88,6 +88,17 @@ endef
 define Package/prometheus-node-exporter-lua-dawn/install
 	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/dawn.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
+define Package/prometheus-node-exporter-lua-dnsmasq_dhcp_leases
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (dnsmasq dhcp leases collector)
+  DEPENDS:=prometheus-node-exporter-lua
+endef
+
+define Package/prometheus-node-exporter-lua-dnsmasq_dhcp_leases/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/dnsmasq_dhcp_leases.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
 define Package/prometheus-node-exporter-lua-hostapd_stations
@@ -215,6 +226,7 @@ $(eval $(call BuildPackage,prometheus-node-exporter-lua))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx6))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx7))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-dawn))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-dnsmasq_dhcp_leases))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-hostapd_stations))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-hostapd_ubus_stations))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-ltq-dsl))

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/dnsmasq_dhcp_leases.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/dnsmasq_dhcp_leases.lua
@@ -1,0 +1,41 @@
+local ubus = require "ubus"
+local u = ubus.connect()
+
+local lease_file = "/tmp/dhcp.leases"
+
+-- get the configured lease file from uci
+local lease_file_cfg = u:call("uci", "get", {config="dhcp", section="@dnsmasq[0]", option="leasefile"})
+if lease_file_cfg ~= nil then
+    lease_file = lease_file_cfg.value
+end
+
+local function scrape()
+    local metric_dhcp = metric("dnsmasq_dhcp_lease_expiry_time_seconds", "gauge")
+    f = io.input(lease_file)
+    for line in f:lines() do
+        i = 0
+        value = 0
+        labels = {}
+        for token in line.gmatch(line, "[^%s]+") do
+            if i == 0 then
+                value = token
+            elseif i == 1 then
+                labels["mac"] = token:lower()
+            elseif i == 2 then
+                labels["ip"] = token
+            elseif i == 3 then
+                if token == "*" then
+                    token = ""
+                end
+                labels["hostname"] = token
+            elseif i == 4 then
+                labels["uuid"] = token:lower()
+            end
+            i = i + 1
+        end
+        metric_dhcp(labels, value)
+    end
+    f:close()
+end
+
+return { scrape = scrape }


### PR DESCRIPTION
This adds a lua prometheus node exporter, which can expose the DHCP lease expiry time.