### PR TITLE
Ensure mac address is lower cased

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2021.12.21
+PKG_VERSION:=2022.01.02
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
@@ -34,7 +34,7 @@ local function scrape()
         for mac, station in pairs(assoclist) do
           local labels = {
             ifname = ifname,
-            mac = mac,
+            mac = mac:lower(),
           }
           if station.signal and station.signal ~= 0 then
             metric_wifi_station_signal(labels, station.signal)


### PR DESCRIPTION
Most other exporter would use a lower-cased mac hex format for the `mac=` label. This changes allows to match them up using PromQL.

