### PR TITLE
mwan3: fix mwan3 flush conntrack table call

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.10.12
+PKG_VERSION:=2.10.13
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -26,7 +26,6 @@ mwan3_init
 /etc/init.d/mwan3 running || {
 	[ "$MWAN3_STARTUP" = "init" ] || procd_lock
 	LOG notice "mwan3 hotplug $ACTION on $INTERFACE not called because globally disabled"
-	mwan3_flush_conntrack "$INTERFACE" "$ACTION"
 	exit 0
 }
 
@@ -85,4 +84,7 @@ case "$ACTION" in
 		mwan3_set_policies_iptables
 	;;
 esac
+
+mwan3_flush_conntrack "$INTERFACE" "$ACTION"
+
 exit 0


### PR DESCRIPTION
Maintainer: me and @aaronjg 
Compile tested: no
Run tested: x86_64, APU3

Description:
fixes #17402 thanks to @champtar for reporting this
We should also backport this to openwr-21.02 after merge
