### PR TITLE
i2pd: Update to 2.40.0, update init.rc script, UCI config and Makefile

### DIFF
--- a/net/i2pd/Makefile
+++ b/net/i2pd/Makefile
@@ -1,6 +1,7 @@
 #
 # Copyright (C) 2015, 2016 gxcreator
 # Copyright (C) 2017 OpenWrt.org
+# Copyright (C) 2021-2022 PurpleI2P team
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,19 +10,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=i2pd
-PKG_VERSION:=2.38.0
+PKG_VERSION:=2.40.0
 PKG_RELEASE:=1
+PKG_BUILD_PARALLEL:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/PurpleI2P/i2pd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=8452f5323795a1846d554096c08fffe5ac35897867b93a5079605df8f80a3089
+PKG_HASH:=4443f484ad40753e892170a26c8ee8126e8338bf416d04eab0c55c1c94a4e193
 
 PKG_MAINTAINER:=David Yang <mmyangfl@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
-
-PKG_BUILD_PARALLEL:=1
-PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -36,45 +35,35 @@ define Package/i2pd
 endef
 
 define Package/i2pd/description
-	I2P (Invisible Internet Protocol) is a universal anonymous network layer. All
-	communications over I2P are anonymous and end-to-end encrypted, participants
-	don't reveal their real IP addresses.
+  I2P (Invisible Internet Protocol) is a universal anonymous network layer. All
+  communications over I2P are anonymous and end-to-end encrypted, participants
+  don't reveal their real IP addresses.
 endef
+
+TARGET_LDFLAGS+=-latomic
 
 define Package/i2pd/conffiles
 /etc/config/i2pd
 /etc/i2pd/i2pd.conf
 /etc/i2pd/tunnels.conf
-/etc/i2pd/tunnels.d/
+/etc/i2pd/tunnels.d/*
 endef
-
-define Build/Prepare
-	$(Build/Prepare/Default)
-	# race condition
-	cd $(PKG_BUILD_DIR); $(MAKE) mk_obj_dir
-endef
-
-TARGET_LDFLAGS+=-latomic
 
 define Package/i2pd/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/i2pd $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/i2pd.init $(1)/etc/init.d/i2pd
 	$(INSTALL_DIR) $(1)/usr/share/i2pd
 	$(CP) $(PKG_BUILD_DIR)/contrib/certificates  $(1)/usr/share/i2pd
 	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_DATA) ./files/i2pd.config $(1)/etc/config/i2pd
+	$(INSTALL_CONF) ./files/i2pd.config $(1)/etc/config/i2pd
 	$(INSTALL_DIR) $(1)/etc/i2pd
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/contrib/i2pd.conf $(1)/etc/i2pd
-	$(SED) ' \
-		s/127.0.0.1/192.168.1.1/g; \
-		s/datadir = \/var\/lib/datadir = \/etc/ \
-	' $(1)/etc/i2pd/i2pd.conf
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/contrib/tunnels.conf $(1)/etc/i2pd
-	$(INSTALL_DIR) $(1)/etc/i2pd/tunnels.d
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/contrib/tunnels.d/*.conf  $(1)/etc/i2pd/tunnels.d
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/contrib/i2pd.conf $(1)/etc/i2pd
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/contrib/tunnels.conf $(1)/etc/i2pd
 	# subscriptions.txt deprecated, see #8088
-	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) ./files/i2pd.init $(1)/etc/init.d/i2pd
+	$(INSTALL_DIR) $(1)/etc/i2pd/tunnels.d
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/contrib/tunnels.d/README $(1)/etc/i2pd/tunnels.d
 endef
 
 $(eval $(call BuildPackage,i2pd))

--- a/net/i2pd/files/i2pd.config
+++ b/net/i2pd/files/i2pd.config
@@ -1,20 +1,20 @@
 config i2pd
-	# Make sure your directories have the right owner! (i2pd:i2pd)
-
-	# Set where i2pd should store its data (netDB, certificates, addresses,
-	# etc). By default we store it in RAM so no data is written to ROM.
-	# If you store data permanently, you may want to enable
-	# 'profiles = true' and 'addressbook = true' in i2pd.conf.
-	#### IMPORTANT! ####
-	# Data is consistently rewritten. DO NOT POINT IT TO INNER ROM. Flash
-	# will die.
+	# Set where i2pd should store its data (netDB, certificates, addresses, etc)
+	# By default we store it in RAM so no data is written to ROM.
+	# IMPORTANT!
+	# Data is consistently rewritten. DO NOT POINT IT TO INNER ROM. Flash will
+	# die.
 	option data_dir '/var/lib/i2pd'
 
-	# If you don't store i2pd data permanently, you can still choose to
-	# store only addressbooks. If not, i2pd will be forced to do HTTP
-	# reseeding on every start. Storing addressbook may be useful
-	# if HTTP reseeding is not possible or blocked (by censorship).
-	# Even addressbook doesn't take up too much space, extroot is still
-	# strongly recommended to avoid flash wear-out.
-	# Enable 'addressbook = true' in i2pd.conf to make it take effect.
+	# If you don't store i2pd data permanently, you can still choose to store only
+	# netDb. If not, i2pd will be forced to do HTTP reseeding on every start.
+	# Storing netDb may be useful if HTTP reseeding is not possible or blocked
+	# (by censorship).
+	# Even netDb doesn't take up too much space, extroot is still strongly
+	# recommended to avoid flash wear-out.
+	#option netdb_dir '/etc/i2pd/netDb'
+
+	# Also you can store permanently addressbook, which is used for accessing
+	# to i2p addresses using human-understandable addresses in .i2p zone.
+	# If not, it will be fetched from subscription at start after 3 minutes.
 	#option addressbook_dir '/etc/i2pd/addressbook'

--- a/net/i2pd/files/i2pd.init
+++ b/net/i2pd/files/i2pd.init
@@ -1,5 +1,6 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2017 OpenWrt.org
+# Copyright (C) 2021-2022 PurpleI2P team
 
 USE_PROCD=1
 
@@ -14,42 +15,54 @@ PIDFILE=/var/run/i2pd.pid
 DATADIR=/var/lib/i2pd
 CONFFILE=/etc/i2pd/i2pd.conf
 
-
-
-i2pd_start() {
-	local cfg="$1"
-	local data_dir
-	local addressbook_dir
+start_instance() {
+	local data_dir netdb_dir addressbook_dir cfg="$1"
 
 	config_get data_dir "$cfg" data_dir "$DATADIR"
+	config_get netdb_dir "$cfg" netdb_dir
 	config_get addressbook_dir "$cfg" addressbook_dir
 
 	## Setting up data dir
-	if [ ! -d "$data_dir" ] ; then
+	if [ ! -d "$data_dir" ]; then
 		mkdir -p "$data_dir"
-		chown "$USER:$GROUP" "$data_dir"
 		ln -s /usr/share/i2pd/certificates "$data_dir/certificates"
-		if [ -n "$addressbook_dir" ] ; then
-			if [ ! -d "$addressbook_dir" ] ; then
-				mkdir -p "$addressbook_dir"
-				chown "$USER:$GROUP" "$addressbook_dir"
-			fi
-			ln -s "$addressbook_dir" "$data_dir/addressbook"
-		fi
+		ln -s /etc/i2pd/i2pd.conf "$data_dir/i2pd.conf"
+		ln -s /etc/i2pd/tunnels.conf "$data_dir/tunnels.conf"
+		ln -s /etc/i2pd/tunnels.d "$data_dir/tunnels.d"
 	fi
-	[ -d "$DATADIR" ] || ln -s "$data_dir" "$DATADIR"
+
+	if [ -n "$netdb_dir" ]; then
+		if [ ! -d "$netdb_dir" ]; then
+			mkdir -p "$netdb_dir"
+		fi
+		ln -s "$netdb_dir" "$data_dir/netDb"
+	fi
+
+	if [ -n "$addressbook_dir" ]; then
+		if [ ! -d "$addressbook_dir" ]; then
+			mkdir -p "$addressbook_dir"
+		fi
+		ln -s "$addressbook_dir" "$data_dir/addressbook"
+	fi
 
 	## We need permissions
+	chown "$USER:$GROUP" "$data_dir"
+
+	if [ -n "$netdb_dir" ]; then
+		chown "$USER:$GROUP" "$netdb_dir"
+	fi
+
+	if [ -n "$addressbook_dir" ]; then
+		chown "$USER:$GROUP" "$addressbook_dir"
+	fi
+
 	touch "$PIDFILE"
 	chown "$USER:adm" "$PIDFILE"
-	chown "$USER:adm" "$CONFFILE"
 
 	procd_open_instance
-	procd_set_param command "$PROG" --service --conf="$CONFFILE" --pidfile "$PIDFILE"
-	procd_set_param env "HOME=$DATADIR"
-	## For debugging, provide about 512 MB on external storage for coredump and adjust /proc/sys/kernel/core_pattern
-	# echo "/tmp/coredumps/core.%e.%p.%s.%t" > /proc/sys/kernel/core_pattern
-	# procd_set_param limits core="unlimited unlimited"
+	procd_set_param command "$PROG" --datadir="$data_dir" --conf="$CONFFILE" --pidfile "$PIDFILE"
+	## Don't know about i2pd user's HOME
+	procd_set_param env "HOME=$data_dir"
 	procd_set_param limits nofile=4096
 	procd_set_param stdout 1
 	procd_set_param stderr 1
@@ -58,23 +71,7 @@ i2pd_start() {
 	procd_close_instance
 }
 
-
 start_service() {
-	local instance="$1"
-	local instance_found=0
-
-	config_cb() {
-		local type="$1"
-		local name="$2"
-		[ "$type" = "i2pd" -a -n "$instance" -a "$instance" = "$name" ] && instance_found=1
-	}
-
-	config_load i2pd
-
-	if [ -n "$instance" ]; then
-		[ "$instance_found" = 0 ] && return
-		i2pd_start "$instance"
-	else
-		config_foreach i2pd_start i2pd
-	fi
+	config_load "i2pd"
+	config_foreach start_instance "i2pd"
 }

--- a/net/i2pd/patches/010-config.patch
+++ b/net/i2pd/patches/010-config.patch
@@ -1,6 +1,6 @@
 --- a/contrib/i2pd.conf
 +++ b/contrib/i2pd.conf
-@@ -8,12 +8,12 @@
+@@ -8,16 +8,16 @@
  
  ## Tunnels config file
  ## Default: ~/.i2pd/tunnels.conf or /var/lib/i2pd/tunnels.conf
@@ -13,71 +13,82 @@
 -# tunnelsdir = /var/lib/i2pd/tunnels.d
 +tunnelsdir = /etc/i2pd/tunnels.d
  
+ ## Path to certificates used for verifying .su3, families
+ ## Default: ~/.i2pd/certificates or /var/lib/i2pd/certificates
+-# certsdir = /var/lib/i2pd/certificates
++certsdir = /usr/share/i2pd/certificates
+ 
  ## Where to write pidfile (default: i2pd.pid, not used in Windows)
  # pidfile = /run/i2pd.pid
-@@ -26,12 +26,12 @@
- ##  * stdout - print log entries to stdout
- ##  * file - log entries to a file
- ##  * syslog - use syslog, see man 3 syslog
--# log = file
-+log = syslog
- ## Path to logfile (default - autodetect)
+@@ -35,7 +35,7 @@
  # logfile = /var/log/i2pd/i2pd.log
  ## Log messages above this level (debug, info, *warn, error, none)
  ## If you set it to none, logging will be disabled
 -# loglevel = warn
-+loglevel = error
++loglevel = none
  ## Write full CLF-formatted date and time to log (default: write only time)
  # logclftime = true
  
-@@ -84,7 +84,7 @@ ipv6 = false
- 
- ## Router will not accept transit tunnels, disabling transit traffic completely
- ## (default = false)
--# notransit = true
-+notransit = true
- 
- ## Router will be floodfill
- ## Note: that mode uses much more network connections and CPU!
-@@ -95,8 +95,10 @@ ipv6 = false
+@@ -99,9 +99,9 @@ ipv6 = false
+ [http]
+ ## Web Console settings
  ## Uncomment and set to 'false' to disable Web Console
- # enabled = true
+-# enabled = true
++enabled = true
  ## Address and port service will listen on
 -address = 127.0.0.1
 +address = 192.168.1.1
-+# address = ::
  port = 7070
-+# strictheaders = false
  ## Path to web console, default "/"
  # webroot = /
- ## Uncomment following lines to enable Web Console authentication
-@@ -108,7 +110,7 @@ port = 7070
+@@ -116,9 +116,9 @@ port = 7070
+ 
+ [httpproxy]
  ## Uncomment and set to 'false' to disable HTTP Proxy
- # enabled = true
+-# enabled = true
++enabled = true
  ## Address and port service will listen on
 -address = 127.0.0.1
 +address = 192.168.1.1
  port = 4444
  ## Optional keys file for proxy local destination
  # keys = http-proxy-keys.dat
-@@ -122,7 +124,7 @@ port = 4444
+@@ -130,9 +130,9 @@ port = 4444
+ 
+ [socksproxy]
  ## Uncomment and set to 'false' to disable SOCKS Proxy
- # enabled = true
+-# enabled = true
++enabled = true
  ## Address and port service will listen on
 -address = 127.0.0.1
 +address = 192.168.1.1
  port = 4447
  ## Optional keys file for proxy local destination
  # keys = socks-proxy-keys.dat
-@@ -237,9 +239,9 @@ verify = true
+@@ -146,7 +146,7 @@ port = 4447
  
- [persist]
- ## Save peer profiles on disk (default: true)
--# profiles = true
-+profiles = false
- ## Save full addresses on disk (default: true)
--# addressbook = true
-+addressbook = false
+ [sam]
+ ## Comment or set to 'false' to disable SAM Bridge
+-enabled = true
++enabled = false
+ ## Address and port service will listen on
+ # address = 127.0.0.1
+ # port = 7656
+@@ -181,7 +181,7 @@ enabled = true
  
- [cpuext]
- ## Use CPU AES-NI instructions set when work with cryptography when available (default: true)
+ [upnp]
+ ## Enable or disable UPnP: automatic port forwarding (enabled by default in WINDOWS, ANDROID)
+-# enabled = false
++enabled = false
+ ## Name i2pd appears in UPnP forwardings list (default = I2Pd)
+ # name = I2Pd
+ 
+@@ -222,7 +222,7 @@ verify = true
+ 
+ [limits]
+ ## Maximum active transit sessions (default:2500)
+-# transittunnels = 2500
++transittunnels = 500
+ ## Limit number of open file descriptors (0 - use system limit)
+ # openfiles = 0
+ ## Maximum size of corefile in Kb (0 - use system limit)


### PR DESCRIPTION
Maintainer: @yangfl
Compile tested: mipsel_24k, MT7621, 19.07.7 and 21.02.1
Run tested: mipsel_24k, MT7621, 19.07.7 and 21.02.1. Tested installation, running more than week

Description:
* Updating i2pd package to 2.40.0
* Rewrite `Makefile`
* Rewrite init.rc configuration and script
* Add preconfigured `i2pd.conf`
* Drop patch for config file

Notes about preconfigured i2pd.conf:
```ini
[persist]
# profiles = false
# addressbook = false
```
I've dropped old patch, where persistance configuration was set to false, but here you can see that they are commented. That was done because by default application saves data to RAM.

Can that update be backported to 21.02 and 19.07 without any changes?