### PR TITLE
acpica-unix: Update to 20211217

### DIFF
--- a/utils/acpica-unix/Makefile
+++ b/utils/acpica-unix/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acpica-unix
-PKG_VERSION:=20210730
-PKG_RELEASE:=2
+PKG_VERSION:=20211217
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://acpica.org/sites/$(patsubst %-unix,%,$(PKG_NAME))/files/$(PKG_SOURCE_URL)
-PKG_HASH:=4a0c14d5148666612aa0555c5179eaa86230602394fd1bc3d16b506fcf49b5de
+PKG_HASH:=2511f85828820d747fa3e2c3433d3a38c22db3d9c2fd900e1a84eb4173cb5992
 PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>
 
 PKG_LICENSE:=GPL-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, generic, HEAD (236c3ea730)
Run tested: same, built and installed on VM test router

Description:

Update to 20211217