### PR TITLE
django-restframework: bump to version 3.13.1

### DIFF
--- a/lang/python/django-restframework/Makefile
+++ b/lang/python/django-restframework/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-restframework
-PKG_VERSION:=3.12.4
-PKG_RELEASE:=1
+PKG_VERSION:=3.13.1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PYPI_NAME:=djangorestframework
-PKG_HASH:=f747949a8ddac876e879190df194b925c177cdeb725a099db1460872f7c0a7f2
+PKG_HASH:=0c33407ce23acc68eca2a6e46424b008c9c02eceb8cf18581921d0092bc1f2ee
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/962c58558010bd302793ac24284c4f9db8fe287f
Run tested: x86 https://github.com/openwrt/openwrt/commit/962c58558010bd302793ac24284c4f9db8fe287f

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>