### PR TITLE
update ksmd to 3.4.3

### DIFF
--- a/kernel/ksmbd/Makefile
+++ b/kernel/ksmbd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd
-PKG_VERSION:=3.4.2
+PKG_VERSION:=3.4.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/cifsd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=939fd4829b5aeadce75b51d2b22046f4e41d2b15ee6489b37f481f33c152a6f3
+PKG_HASH:=a910c55d9e6924775e00504eddd00b49788603af29d0772cb9fb6722c189f628
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
tested ok on mvebu and ath79

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
