### PR TITLE
dnsproxy: Update to 0.40.2

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.40.1
+PKG_VERSION:=0.40.2
 PKG_RELEASE:=$(AUTORELESE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=f968e5c38ce27e5bb827138d2f5991397fb338bceaa9566399f5d52ef8c26d80
+PKG_HASH:=3e58b49ac5caa19d11790ae8dbba4dd9d509a05bd005e31c0a110b8836109ec7
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: ipq807x, rockchip/armv8
Run tested: rk3328 nanopi-r2s

Description:
Release note: https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.40.2