### PR TITLE
zabbix: update to version 4.0.37

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=4.0.16
-PKG_RELEASE:=3
+PKG_VERSION:=4.0.37
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SF/zabbix
-PKG_HASH:=a8d7e18230e62a7bd3fd9af5830a2b1b22818468b5da3deb673865ce40dc4d42
+PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/4.0/
+PKG_HASH:=5ae7b197c236cc0eb78f24d10def1b3123fefa29b048ec5ce0b11d5271fc8e9b
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=GPL-2.0


### PR DESCRIPTION
Maintainer: @champtar 
Compile tested: Turris 1.1, powerpc_8540, OpenWrt 19.07.8
Run tested: same, server seems to work, more tests will be done soon.

Description:
- Fixes [CVE-2020-15803](https://nvd.nist.gov/vuln/detail/CVE-2020-15803), [CVE-2021-27927](https://nvd.nist.gov/vuln/detail/CVE-2021-27927)

- SourceForge does not provide tarball for version 4.0.37 and it was
necessary to use Zabbix CDN to download it.