### PR TITLE
transmission: add ca_bundle support with procd-ujail

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=3.00
-PKG_RELEASE:=17
+PKG_RELEASE:=18
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -67,6 +67,9 @@ transmission() {
 	config_get nice "$cfg" nice 0
 	local web_home
 	config_get web_home "$cfg" 'web_home'
+	local ca_bundle
+	config_get_bool ca_bundle "$cfg" ca_bundle 1
+	[ "$ca_bundle" -gt 0 ] && ca_bundle_file="/etc/ssl/certs/ca-certificates.crt"
 	local seccomp_path
 
 	local MEM
@@ -152,6 +155,7 @@ transmission() {
 	fi
 
 	[ -d "$web_home" ] && procd_set_param env TRANSMISSION_WEB_HOME="$web_home"
+	[ "$ca_bundle" -gt 0 ] && procd_set_param env CURL_CA_BUNDLE="$ca_bundle_file"
 
 	procd_add_jail transmission log
 	procd_add_jail_mount "$config_file"
@@ -162,6 +166,7 @@ transmission() {
 	procd_add_jail_mount_rw "$download_dir"
 	web_home="${web_home:-/usr/share/transmission/web}"
 	[ -d "$web_home" ] && procd_add_jail_mount "$web_home"
+	[ -f "$ca_bundle_file" ] && procd_add_jail_mount "$ca_bundle_file"
 	procd_close_instance
 }
 


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: bcm53xx
Run tested: bcm53xx

Description:

With procd-ujail enabled, it is not possible to use HTTPS URLs, for
example when either for downloading torrent files or blocklists. The
followig example occurs when downloading a URL from the "Upload Torrent
Files" dialogue box:

Error adding
"https://releases.ubuntu.com/21.10/ubuntu-21.10-desktop-amd64.iso.torrent":
gotMetadataFromURL: http error 0: No Response

syslog will also hint that no CA_BUNDLE is being used:

transmission-daemon[6683]: [2021-12-30 20:01:30.990] web will verify
tracker certs using envvar CURL_CA_BUNDLE: none (web.c:455)

This patch rectifies this issue by adding a ca_bundle configurable,
enabled by default. This explicitly fixes the ca_bundle file location
to /etc/ssl/certs/ca-certificates.crt and adds this file to the procd
jail. On subsequent testing, HTTPS URL download functionality is
restored.

Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>