### PR TITLE
python-stem: backport patch to fix Python 3.10

### DIFF
--- a/lang/python/python-stem/Makefile
+++ b/lang/python/python-stem/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-stem
 PKG_VERSION:=1.8.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=stem
 PKG_HASH:=a0b48ea6224e95f22aa34c0bc3415f0eb4667ddeae3dfb5e32a6920c185568c2

--- a/lang/python/python-stem/patches/001-fixes-for-Python310.patch
+++ b/lang/python/python-stem/patches/001-fixes-for-Python310.patch
@@ -1,0 +1,36 @@
+From 36bcb170ba9097885902513640075eac2e6ce384 Mon Sep 17 00:00:00 2001
+From: Calin Culianu <calin.culianu@gmail.com>
+Date: Mon, 8 Nov 2021 18:15:59 -0600
+Subject: [PATCH] Fixup for Python 3.10
+
+Closes issue #109.  Long story short: a few names from collection are
+now moved to collection.abc exclusively starting in Python 3.10. The
+only name this app uses from there that was moved is
+`collections.Iterable`.  Python versions starting from 3.3 support both
+`collections.Iterable` and `collections.abc.Iterable` as the way to refer to
+this class, which Python 3.10 being the first one to drop
+`collections.Iterable`.  So.. we just work around this API quirk
+and always refer ot it as `collections.abc.Iterable`.
+---
+ stem/control.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/stem/control.py
++++ b/stem/control.py
+@@ -249,6 +249,7 @@ If you're fine with allowing your script
+ 
+ import calendar
+ import collections
++import collections.abc
+ import functools
+ import inspect
+ import io
+@@ -2532,7 +2533,7 @@ class Controller(BaseController):
+     for param, value in params:
+       if isinstance(value, str):
+         query_comp.append('%s="%s"' % (param, value.strip()))
+-      elif isinstance(value, collections.Iterable):
++      elif isinstance(value, collections.abc.Iterable):
+         query_comp.extend(['%s="%s"' % (param, val.strip()) for val in value])
+       elif not value:
+         query_comp.append(param)


### PR DESCRIPTION
Maintainer: @jmarcet 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:

- backport commit https://github.com/torproject/stem/commit/36bcb170ba9097885902513640075eac2e6ce38 from upstream as suggested by @paper42 