### PR TITLE
nnn: update to version 4.4

### DIFF
--- a/utils/nnn/Makefile
+++ b/utils/nnn/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nnn
-PKG_VERSION:=4.2
+PKG_VERSION:=4.4
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jarun/nnn/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=5675f9fe53bddfd92681ef88bf6c0fab3ad897f9e74dd6cdff32fe1fa62c687f
+PKG_HASH:=e04a3f0f0c2af1e18cb6f005d18267c7703644274d21bb93f03b30e4fd3d1653
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=BSD-2-Clause

--- a/utils/nnn/patches/musl-fts.patch
+++ b/utils/nnn/patches/musl-fts.patch
@@ -1,6 +1,6 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -129,7 +129,7 @@ CFLAGS += -std=c11 -Wall -Wextra -Wshado
+@@ -135,7 +135,7 @@ CFLAGS += -std=c11 -Wall -Wextra -Wshado
  CFLAGS += $(CFLAGS_OPTIMIZATION)
  CFLAGS += $(CFLAGS_CURSES)
  


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:

- 4.3 changelog: https://github.com/jarun/nnn/releases/tag/v4.3
- 4.4 changelog: https://github.com/jarun/nnn/releases/tag/v4.4
