### PR TITLE
python-zeroconf: update to version 0.38.1

### DIFF
--- a/lang/python/python-zeroconf/Makefile
+++ b/lang/python/python-zeroconf/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-zeroconf
-PKG_VERSION:=0.29.0
+PKG_VERSION:=0.38.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=zeroconf
-PKG_HASH:=7aefbb658b452b1fd7e51124364f938c6f5e42d6ea893fa2557bea8c06c540af
+PKG_HASH:=10c501b25d8881b656e56c34674d98fe6bc752240a572e74f918bc849c93ba9c
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Briefly run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
- Changelog: https://github.com/jstasiak/python-zeroconf/blob/6a11f24e1fc9d73f0dbb62efd834f17a9bd451c4/README.rst