### PR TITLE
libtorrent-rasterbar: backport patch to fix compilation with boost 1.…

### DIFF
--- a/libs/libtorrent-rasterbar/patches/010-update-boost-1780.patch
+++ b/libs/libtorrent-rasterbar/patches/010-update-boost-1780.patch
@@ -1,0 +1,44 @@
+From 71d608fceca7e61c9d124f9ea83f71b06eda3b17 Mon Sep 17 00:00:00 2001
+From: arvidn <arvid@libtorrent.org>
+Date: Sun, 12 Dec 2021 21:52:15 +0100
+Subject: [PATCH] update allocator sizes for boost-1.78
+
+---
+ include/libtorrent/aux_/allocating_handler.hpp | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+--- a/include/libtorrent/aux_/allocating_handler.hpp
++++ b/include/libtorrent/aux_/allocating_handler.hpp
+@@ -77,11 +77,11 @@ namespace libtorrent { namespace aux {
+ 	constexpr std::size_t openssl_write_cost = 0;
+ #endif
+ 
+-	constexpr std::size_t read_handler_max_size = tracking + debug_read_iter + openssl_read_cost + 102 + 8 * sizeof(void*);
+-	constexpr std::size_t write_handler_max_size = tracking + debug_write_iter + openssl_write_cost + 102 + 8 * sizeof(void*);
+-	constexpr std::size_t udp_handler_max_size = tracking + debug_tick + 144 + 8 * sizeof(void*);
+-	constexpr std::size_t utp_handler_max_size = tracking + debug_tick + 168 + 8 * sizeof(void*);
+-	constexpr std::size_t tick_handler_max_size = tracking + debug_tick + 160;
++	constexpr std::size_t read_handler_max_size = tracking + debug_read_iter + openssl_read_cost + 102 + 9 * sizeof(void*);
++	constexpr std::size_t write_handler_max_size = tracking + debug_write_iter + openssl_write_cost + 102 + 9 * sizeof(void*);
++	constexpr std::size_t udp_handler_max_size = tracking + debug_tick + 144 + 9 * sizeof(void*);
++	constexpr std::size_t utp_handler_max_size = tracking + debug_tick + 168 + 9 * sizeof(void*);
++	constexpr std::size_t tick_handler_max_size = tracking + debug_tick + 168;
+ 	constexpr std::size_t abort_handler_max_size = tracking + debug_tick + 104;
+ 	constexpr std::size_t submit_handler_max_size = tracking + debug_tick + 104;
+ 	constexpr std::size_t deferred_handler_max_size = tracking + debug_tick + 112;
+@@ -124,12 +124,12 @@ namespace libtorrent { namespace aux {
+ #endif
+ 	constexpr std::size_t write_handler_max_size = tracking + debug_write_iter + openssl_write_cost + fuzzer_write_cost + 168;
+ 	constexpr std::size_t read_handler_max_size = tracking + debug_read_iter + openssl_read_cost + fuzzer_read_cost + 168;
+-	constexpr std::size_t udp_handler_max_size = tracking + 160;
+-	constexpr std::size_t utp_handler_max_size = tracking + 184;
++	constexpr std::size_t udp_handler_max_size = tracking + 168;
++	constexpr std::size_t utp_handler_max_size = tracking + 192;
+ 	constexpr std::size_t abort_handler_max_size = tracking + 72;
+ 	constexpr std::size_t submit_handler_max_size = tracking + 72;
+ 	constexpr std::size_t deferred_handler_max_size = tracking + 80;
+-	constexpr std::size_t tick_handler_max_size = tracking + 128;
++	constexpr std::size_t tick_handler_max_size = tracking + 136;
+ #endif
+ 
+ 	enum HandlerName


### PR DESCRIPTION
Maintainer: @yangfl
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master


Description:

Spotted issue on OpenWrt snapshots faillogs for ``aarch64_cortex-a53``

```
/builder/shared-workdir/build/sdk/staging_dir/target-aarch64_cortex-a53_musl/usr/include/boost/asio/basic_socket.hpp:1811:73:   required from 'auto boost::asio::basic_socket<Protocol, Executor>::async_wait(boost::asio::socket_base::wait_type, WaitHandler&&) [with WaitHandler = libtorrent::aux::allocating_handler<libtorrent::aux::session_impl::on_udp_packet(std::weak_ptr<libtorrent::aux::session_udp_socket>, std::weak_ptr<libtorrent::aux::listen_socket_t>, libtorrent::aux::transport, const error_code&)::<lambda(const error_code&)>, 184, libtorrent::aux::utp_handler>; Protocol = boost::asio::ip::udp; Executor = boost::asio::any_io_executor]'
/builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/libtorrent-rasterbar-2.0.5/include/libtorrent/udp_socket.hpp:78:23:   required from 'void libtorrent::udp_socket::async_read(Handler&&) [with Handler = libtorrent::aux::allocating_handler<libtorrent::aux::session_impl::on_udp_packet(std::weak_ptr<libtorrent::aux::session_udp_socket>, std::weak_ptr<libtorrent::aux::listen_socket_t>, libtorrent::aux::transport, const error_code&)::<lambda(const error_code&)>, 184, libtorrent::aux::utp_handler>]'
/builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/libtorrent-rasterbar-2.0.5/src/session_impl.cpp:2654:21:   required from here
/builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/libtorrent-rasterbar-2.0.5/include/libtorrent/aux_/allocating_handler.hpp:180:47: error: static assertion failed: Handler buffer not large enough, please increase it
/builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/libtorrent-rasterbar-2.0.5/include/libtorrent/aux_/allocating_handler.hpp:180:47: note: '(((long unsigned int)libtorrent::aux::required_size<192>::value) <= ((long unsigned int)libtorrent::aux::available_size<184>::value))' evaluates to false
[92/165] Building CXX object CMakeFiles/torrent-rasterbar.dir/src/session_params.cpp.o
ninja: build stopped: subcommand failed.
```

Source: https://downloads.openwrt.org/snapshots/faillogs/aarch64_cortex-a53/packages/libtorrent-rasterbar/compile.txt

Backported this patch to fix this:
https://github.com/arvidn/libtorrent/commit/71d608fceca7e61c9d124f9ea83f71b06eda3b17