### PR TITLE
netdata: Update init script to use -D rather than -nd

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
 PKG_VERSION:=1.30.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
 PKG_LICENSE:=GPL-3.0-or-later

--- a/admin/netdata/files/netdata.init
+++ b/admin/netdata/files/netdata.init
@@ -14,7 +14,7 @@ start_service() {
 	mkdir -m 0755 -p /var/log/netdata
 	chown nobody /var/log/netdata
 	procd_open_instance
-	procd_set_param command $APPBINARY -nd -c $CONFIGFILE
+	procd_set_param command $APPBINARY -D -c $CONFIGFILE
 	procd_set_param file $CONFIGFILE
 	procd_set_param respawn
 	procd_close_instance


### PR DESCRIPTION
Signed-off-by: James White <james@jmwhite.co.uk>

Maintainer: @BKPepe @diizzyy
Compile tested: N/A
Run tested: OpenWrt 19.07.8

Description:

When netdata is started via the current init script, the following deprecation notice is logged:

```
/usr/sbin/netdata: deprecated option -- -nd -- please use -D instead.
 2021-12-31 16:41:00: netdata INFO  : MAIN : SIGNAL: Not enabling reaper
```

This updates the init script to use `-D` rather than `-nd` as recommended by the log message.
