### PR TITLE
iputils: bump to 20211215

### DIFF
--- a/net/iputils/Makefile
+++ b/net/iputils/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iputils
-PKG_VERSION:=20210202
+PKG_VERSION:=20211215
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/iputils/iputils/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=3f557ecfd2ace873801231d2c1f42de73ced9fbc1ef3a438d847688b5fb0e8ab
+PKG_HASH:=b6f67fc705490673ff4471d006221b4a2f1b1180b929d9fefd771352621ccedf
 PKG_BUILD_DIR:=$(BUILD_DIR)/iputils-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -38,7 +38,7 @@ MESON_ARGS += \
 	-DBUILD_ARPING=true \
 	-DBUILD_CLOCKDIFF=true \
 	-DBUILD_TRACEPATH=true \
-	-DBUILD_TFTPD=true
+	-DSKIP_TESTS=true
 
 define Package/iputils/Default
   SECTION:=net
@@ -128,24 +128,7 @@ ifdef CONFIG_TRACEPATH_LEGACY_SYMLINKS
 endif
 endef
 
-### tftp
-
-define Package/iputils-tftpd
-  $(call Package/iputils/Default)
-  TITLE:=iputils-tftpd
-endef
-
-define Package/iputils-tftpd/description
-  Trivial File Transfer Protocol server
-endef
-
-define Package/iputils-tftpd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/tftpd $(1)/usr/sbin/
-endef
-
 $(eval $(call BuildPackage,iputils-ping))
 $(eval $(call BuildPackage,iputils-arping))
 $(eval $(call BuildPackage,iputils-clockdiff))
 $(eval $(call BuildPackage,iputils-tracepath))
-$(eval $(call BuildPackage,iputils-tftpd))

--- a/net/iputils/patches/001_version_fix.patch
+++ b/net/iputils/patches/001_version_fix.patch
@@ -1,7 +1,7 @@
 Description: set a static version string rather than discern it from git
 --- a/meson.build
 +++ b/meson.build
-@@ -17,6 +17,7 @@ add_project_arguments(
+@@ -19,6 +19,7 @@ add_project_arguments(
  
  conf = configuration_data()
  conf.set_quoted('PACKAGE_NAME', meson.project_name())
@@ -9,7 +9,7 @@ Description: set a static version string rather than discern it from git
  conf.set('_GNU_SOURCE', 1, description : 'Enable GNU extensions on systems that have them.')
  
  build_arping = get_option('BUILD_ARPING')
-@@ -207,10 +208,10 @@ foreach h : [
+@@ -208,10 +209,10 @@ foreach h : [
  	endif
  endforeach
  


### PR DESCRIPTION
Drop the tftpd binary, which is no longer provided upstream.  Users
should switch to the atftp server as a replacement.

Avoid executing runtime tests, which are not supported in cross-build
environments.

Maintainer: me
Compile tested: x86 (master)
Run tested: x86 (master): ping/tracepath/arping


