### PR TITLE
jool: update to 4.1.6, add init files and default configuration

### DIFF
--- a/net/jool/Makefile
+++ b/net/jool/Makefile
@@ -8,12 +8,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=jool
-PKG_VERSION:=4.1.5
-PKG_RELEASE:=1
+PKG_VERSION:=4.1.6
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/NICMx/Jool/releases/download/v$(PKG_VERSION)
-PKG_HASH:=ec130a3659acff5450e74924d5f9da52540539fc213b5842fb3a8fd7d919ccf9
+PKG_HASH:=dccfde88e3b97a7d1c44c53b6541b74873a04f50bb8cfd187eb399d5ae8d2c81
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0-only
@@ -50,6 +50,7 @@ define Build/Compile
 	$(call Build/Compile/Default)
 endef
 
+
 define Package/jool/Default
   SECTION:=net
   CATEGORY:=Network
@@ -60,16 +61,6 @@ define Package/jool/Default/description
   Jool is an Open Source SIIT and NAT64 for Linux.
 endef
 
-define Package/jool
-  $(call Package/jool/Default)
-  TITLE:=Jool meta-package
-  DEPENDS:=+kmod-jool +jool-tools
-  BUILDONLY:=1
-endef
-
-define Package/jool/description
-  $(call Package/jool/Default/description)
-endef
 
 define KernelPackage/jool
   SECTION:=kernel
@@ -86,6 +77,11 @@ define KernelPackage/jool
     $(PKG_BUILD_DIR)/src/mod/common/jool_common.$(LINUX_KMOD_SUFFIX) \
     $(PKG_BUILD_DIR)/src/mod/nat64/jool.$(LINUX_KMOD_SUFFIX) \
     $(PKG_BUILD_DIR)/src/mod/siit/jool_siit.$(LINUX_KMOD_SUFFIX)
+  JOOL_AUTOLOAD:= \
+    jool \
+    jool_siit
+  AUTOLOAD:=$(call AutoLoad,46,jool_common)
+  AUTOLOAD:=$(call AutoLoad,48,$(JOOL_AUTOLOAD))
 endef
 
 define KernelPackage/jool/description
@@ -94,10 +90,11 @@ define KernelPackage/jool/description
   This package provides the kernel module for Jool.
 endef
 
+
 define Package/jool-tools
   $(call Package/jool/Default)
   TITLE:=Jool userspace control programs
-  DEPENDS:=+libnl +libxtables
+  DEPENDS:=+kmod-jool +libnl +libxtables
 endef
 
 define Package/jool-tools/description
@@ -106,6 +103,7 @@ define Package/jool-tools/description
   This package provides the userspace control programs for Jool.
 endef
 
+
 CONFIGURE_ARGS += \
 	--disable-shared \
 	--without-bash-completion-dir
@@ -113,6 +111,11 @@ CONFIGURE_ARGS += \
 CONFIGURE_VARS += \
 	ac_cv_func_memset=yes \
 	ac_cv_func_strcasecmp=yes
+
+JOOL_AUTOLOAD:= \
+	jool_common \
+	jool \
+	jool_siit
 
 define Package/jool-tools/install
 	$(INSTALL_DIR) $(1)/usr/bin/
@@ -125,8 +128,18 @@ define Package/jool-tools/install
 		$(1)/usr/lib/iptables
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/iptables/libxt_JOOL.so \
 		$(1)/usr/lib/iptables
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/jool.config $(1)/etc/config/jool
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/jool.init $(1)/etc/init.d/jool
+
+	$(INSTALL_DIR) $(1)/etc/jool
+	$(INSTALL_DATA) ./files/jool-nat64.conf.json $(1)/etc/jool/jool-nat64.conf.json.default
+	$(INSTALL_DATA) ./files/jool-siit.conf.json $(1)/etc/jool/jool-siit.conf.json.default
+	$(INSTALL_DATA) ./files/readme.md $(1)/etc/jool/readme.md
 endef
 
-$(eval $(call BuildPackage,jool))
 $(eval $(call KernelPackage,jool))
 $(eval $(call BuildPackage,jool-tools))

--- a/net/jool/files/jool-nat64.conf.json
+++ b/net/jool/files/jool-nat64.conf.json
@@ -1,0 +1,75 @@
+{
+	"comment": "Sample full NAT64 configuration.",
+	"comment": "Configuration details at https://jool.mx/en/usr-flags-global.html",
+
+	"instance": "default",
+	"framework": "netfilter",
+
+	"global": {
+		"pool6": "64:ff9b::/96",
+
+		"manually-enabled": false,
+
+		"zeroize-traffic-class": false,
+		"override-tos": false,
+		"tos": 0,
+		"mtu-plateaus": [65535, 32000, 17914, 8166, 4352, 2002, 1492, 1006, 508, 296, 68],
+		"maximum-simultaneous-opens": 10,
+		"source-icmpv6-errors-better": true,
+		"handle-rst-during-fin-rcv": false,
+		"f-args": 11,
+
+		"logging-bib": false,
+		"logging-session": false,
+
+		"address-dependent-filtering": false,
+		"drop-icmpv6-info": false,
+		"drop-externally-initiated-tcp": false,
+
+		"udp-timeout": "5:00",
+		"tcp-est-timeout": "2:00:00",
+		"tcp-trans-timeout": "4:00",
+		"icmp-timeout": "1:00",
+
+		"ss-enabled": false,
+		"ss-flush-asap": true,
+		"ss-flush-deadline": 2000,
+		"ss-capacity": 512,
+		"ss-max-payload": 1452
+	},
+
+	"pool4": [
+		{
+			"mark": 1,
+			"protocol": "UDP",
+			"prefix": "192.0.2.1",
+			"port range": "61001-62000",
+			"max-iterations": 1500
+		}, {
+			"comment": "mark, port range and max-iterations are optional.",
+			"protocol": "TCP",
+			"prefix": "192.0.2.2/31"
+		}, {
+			"mark": 1,
+			"protocol": "ICMP",
+			"prefix": "192.0.2.1/32",
+			"port range": "1000-2000"
+		}
+	],
+
+	"bib": [
+		{
+			"protocol": "TCP",
+			"ipv6 address": "2001:db8::1#80",
+			"ipv4 address": "192.0.2.2#80"
+		}, {
+			"protocol": "UDP",
+			"ipv6 address": "2001:db8::2#10000",
+			"ipv4 address": "192.0.2.1#61500"
+		}, {
+			"protocol": "ICMP",
+			"ipv6 address": "2001:db8:AAAA::1#44",
+			"ipv4 address": "192.0.2.1#1044"
+		}
+	]
+}

--- a/net/jool/files/jool-siit.conf.json
+++ b/net/jool/files/jool-siit.conf.json
@@ -1,0 +1,48 @@
+{
+	"comment": "Sample full SIIT configuration.",
+	"comment": "Configuration details at https://jool.mx/en/usr-flags-global.html",
+
+	"instance": "instance name",
+	"framework": "netfilter",
+
+	"global": {
+		"comment": "pool6 and the RFC6791v4 pool belong here, ever since Jool 4.",
+		"pool6": "64:ff9b::/96",
+		"manually-enabled": true,
+		"zeroize-traffic-class": false,
+		"override-tos": false,
+		"tos": 0,
+		"mtu-plateaus": [65535, 32000, 17914, 8166, 4352, 2002, 1492, 1006, 508, 296, 68],
+		"amend-udp-checksum-zero": false,
+		"eam-hairpin-mode": "intrinsic",
+		"randomize-rfc6791-addresses": true,
+		"rfc6791v6-prefix": null,
+		"rfc6791v4-prefix": null
+	},
+
+	"eamt": [
+		{
+			"comment": {
+				"text": "Here's a compound comment.",
+				"more": "Its type is not checked, after all.",
+				"date": "2019-01-06",
+				"whatever": 1234
+			},
+			"ipv6 prefix": "2001:db8:1::/128",
+			"ipv4 prefix": "192.0.2.0"
+		}, {
+			"ipv6 prefix": "2001:db8:2::",
+			"ipv4 prefix": "192.0.2.1/32"
+		}, {
+			"ipv6 prefix": "2001:db8:3::/124",
+			"ipv4 prefix": "192.0.2.16/28"
+		}
+	],
+
+	"comment": "This comment is relevant to blacklist4 maybe.",
+	"blacklist4": [
+		"198.51.100.0",
+		"198.51.100.2/32",
+		"198.51.100.32/27"
+	]
+}

--- a/net/jool/files/jool.config
+++ b/net/jool/files/jool.config
@@ -1,0 +1,8 @@
+config jool 'general'
+	option enabled '0'
+
+config jool 'nat64'
+        option enabled '0'
+
+config jool 'siit'
+        option enabled '0'

--- a/net/jool/files/jool.init
+++ b/net/jool/files/jool.init
@@ -1,0 +1,57 @@
+#!/bin/sh /etc/rc.common
+
+START=54
+STOP=54
+
+PROG_NAT64="/usr/bin/jool"
+PROG_SIIT="/usr/bin/jool_siit"
+
+CONFIGFILE_NAT64="/etc/jool/jool-nat64.conf.json"
+CONFIGFILE_SIIT="/etc/jool/jool-siit.conf.json"
+
+config_parser(){
+	enabled=0
+	enabled_nat64=0
+	enabled_siit=0
+
+	config_load "jool"
+
+	#verify if the services are enabled in the configuration and populate it's variables
+	config_get_bool enabled general enabled 0
+	config_get_bool enabled_nat64 nat64 enabled 0
+	config_get_bool enabled_siit siit enabled 0
+
+	#If the main service is not enabled exit
+	[ "$enabled" -eq 0 ] && return 1
+
+	#if nat64 is enabled continue
+	if [ "$enabled_nat64" -gt 0 ]; then
+		#check if the orer is to start or stop
+		if [ "$1" -gt 0 ]; then
+			#start jool
+			$PROG_NAT64 file handle $CONFIGFILE_NAT64
+		else
+			$PROG_NAT64 -f $CONFIGFILE_NAT64 instance remove
+		fi
+	fi
+
+	#if siit is enabled continue
+	if [ "$enabled_siit" -gt 0 ]; then
+		#check if the orer is to start or stop
+		if [ "$1" -gt 0 ]; then
+			#start jool
+			$PROG_SIIT file handle $CONFIGFILE_SIIT
+		else
+			$PROG_SIIT -f $CONFIGFILE_SIIT instance remove
+		fi
+	fi
+}
+
+start() {
+	config_parser 1
+}
+
+stop() {
+	config_parser 0
+
+}

--- a/net/jool/files/readme.md
+++ b/net/jool/files/readme.md
@@ -1,0 +1,28 @@
+# [Jool](https://www.jool.mx)
+
+## Documentation
+
+[See here](https://www.jool.mx/en/documentation.html).
+
+You might also want to see [contact info](https://www.jool.mx/en/contact.html).
+
+## Usage
+
+### Start script
+
+This package includes a start script that will:
+    1. Read the configuration file `/etc/config/jool`
+    2. Determine what services are active
+    3. Run jool with procd
+
+For now this means that:
+    * The services will be disabled by default in the uci config `(/etc/config/jool)`
+    * The only uci configuration support available for the package is to enable or disable each instance or the entire deamon
+    * There is no uci support and configuration will be saved at `/etc/jool/*
+    * Only one instance of jool(nat64) can run with the boot script
+    * Only one instance of jool(siit) can run with the boot script
+    * For now there is no way of overriding of the configuration file's paths
+
+The configuration files the startup script useses for each jool instance are:
+    * jool(nat64): `/etc/jool/jool-nat64.conf.json`
+    * jool(siit): `/etc/jool/jool-siit.conf.json`


### PR DESCRIPTION
Compile tested: WRT3200ACM on the latest trunk
Run tested: WRT3200ACM on the latest trunk

Description:

This commit adds support for starting and running jool through init scripts, with default config files as examples.

This is also my first time with startup scripts, so all advices are welcome!

Signed-off-by: Tiago Gaspar <tiagogaspar8@gmail.com>