### PR TITLE
treewide: add missing BUILDONLY

### DIFF
--- a/libs/libcups/Makefile
+++ b/libs/libcups/Makefile
@@ -33,6 +33,7 @@ $(call Package/cups/Default)
   CATEGORY:=Libraries
   DEPENDS:=+zlib +libpthread +libpng +libjpeg +libusb-1.0
   TITLE:=Common UNIX Printing System - Core library
+  BUILDONLY:=1
 endef
 
 define Package/libcups/description

--- a/libs/libevhtp/Makefile
+++ b/libs/libevhtp/Makefile
@@ -36,6 +36,7 @@ define Package/libevhtp
     TITLE:=A more flexible replacement for libevent's httpd API
     URL:=https://github.com/criticalstack/libevhtp
     DEPENDS:=+libevent2 +libevent2-openssl +libevent2-pthreads +oniguruma
+    BUILDONLY:=1
 endef
 
 define Package/libevhtp/description

--- a/libs/libowfat/Makefile
+++ b/libs/libowfat/Makefile
@@ -28,6 +28,7 @@ define Package/libowfat
   CATEGORY:=Libraries
   TITLE:=reimplemented libdjb under GPL
   URL:=https://www.fefe.de/libowfat/
+  BUILDONLY:=1
 endef
 
 define Build/Configure

--- a/libs/libtorrent/Makefile
+++ b/libs/libtorrent/Makefile
@@ -31,6 +31,7 @@ define Package/libtorrent
   TITLE:=Rakshasa's BitTorrent library
   URL:=https://rakshasa.github.io/rtorrent/
   DEPENDS:=+libopenssl +libstdcpp +zlib
+  BUILDONLY:=1
 endef
 
 define Package/libtorrent/description

--- a/libs/nacl/Makefile
+++ b/libs/nacl/Makefile
@@ -27,6 +27,7 @@ define Package/nacl
   CATEGORY:=Libraries
   TITLE:=NaCl Networking and Cryptography library
   URL:=http://nacl.cace-project.eu/
+  BUILDONLY:=1
 endef
 
 define Build/Compile

--- a/net/lksctp-tools/Makefile
+++ b/net/lksctp-tools/Makefile
@@ -46,6 +46,7 @@ $(call Package/lksctp-tools/Default)
   TITLE+= (meta)
   URL:=http://lksctp.sourceforge.net
   DEPENDS:=+libsctp +sctp-tools
+  BUILDONLY:=1
 endef
 
 define Package/sctp-tools

--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -100,6 +100,7 @@ define Package/snmpd-static
 $(call Package/net-snmp/Default)
   DEPENDS:=+snmpd
   TITLE:=Open source SNMP implementation (daemon)
+  BUILDONLY:=1
 endef
 
 

--- a/utils/sane-backends/Makefile
+++ b/utils/sane-backends/Makefile
@@ -41,6 +41,7 @@ $(call Package/sane-backends/Default)
   CATEGORY:=Utilities
   TITLE+= (drivers)
   DEPENDS:=+ALL:sane-backends-all
+  BUILDONLY:=1
 endef
 
 define Package/sane-backends/description


### PR DESCRIPTION
On OpenWrt 19.07, I found issue:

> Makefile:290: WARNING: skipping snmpd-static -- package has no install section

In newer branches, it was fixed by this PR: https://github.com/openwrt/packages/pull/13651

cc: @neheb 