### PR TITLE
libuhttpd: add compatibility for wolfssl >= 5.0

### DIFF
--- a/libs/libuhttpd/Makefile
+++ b/libs/libuhttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuhttpd
 PKG_VERSION:=3.12.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://github.com/zhaojh329/libuhttpd/releases/download/v$(PKG_VERSION)

--- a/libs/libuhttpd/patches/100-wolfssl_5_support.patch
+++ b/libs/libuhttpd/patches/100-wolfssl_5_support.patch
@@ -1,0 +1,21 @@
+commit 91b66a6b402b790f3c8cebb0420ef549744ee197
+Author: Sergey V. Lobanov <sergey@lobanov.in>
+Date:   Mon Jan 3 19:25:45 2022 +0300
+
+    add compatibility for wolfssl >= 5.0
+    
+    NTRU support has been removed in wolfssl 5.0 so it is required to
+    mask NTRU specific code if wolfssl >= 5.0
+
+--- a/src/ssl/openssl.c
++++ b/src/ssl/openssl.c
+@@ -314,7 +314,9 @@ static bool handle_wolfssl_asn_error(voi
+     case ASN_SIG_HASH_E:
+     case ASN_SIG_KEY_E:
+     case ASN_DH_KEY_E:
++#if LIBWOLFSSL_VERSION_HEX < 0x05000000
+     case ASN_NTRU_KEY_E:
++#endif
+     case ASN_CRIT_EXT_E:
+     case ASN_ALT_NAME_E:
+     case ASN_NO_PEM_HEADER:


### PR DESCRIPTION
NTRU support has been removed in wolfssl 5.0 so it is required to
mask NTRU specific code if wolfssl >= 5.0

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @zhaojh329 
Compile tested: (armvirt/64, OpenWrt trunk)
Run tested: (armvirt/64, OpenWrt trunk, tests done)

Description: see above

PR to upstream: https://github.com/zhaojh329/ssl/pull/2