### PR TITLE
Update Makefile: add dependency of 'ip-full'

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -27,7 +27,8 @@ define Package/mwan3
      +iptables \
      +iptables-mod-conntrack-extra \
      +iptables-mod-ipopt \
-     +jshn
+     +jshn \
+     +ip-full
    TITLE:=Multiwan hotplug script with connection tracking support
    MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
    PKGARCH:=all


### PR DESCRIPTION
Maintainer: Florian Eckert
Compile tested: none, as just the dependencies are affected during opkg install
Run tested: 21.02 release with and without 'ip-full' install shows that 'ip-full' is required for mwan3 to work.

Description:
* a clean install of mwan3 in openwrt-21.02 does not work, as vital features are missing in the busybox implementation of 'ip' that is installed by default
* installation of 'ip-full' resolves this and mwan3 works as designed
* => 'ip-full' is mandatory and thus must be in the dependancies of 'mwan3' package.