### PR TITLE
nut: fix typo in nut-monitor init script

### DIFF
--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -95,7 +95,7 @@ nut_upsmon_conf() {
 		echo "NOTIFYFLAG COMMOK $(setnotify "$cfg" commoknotify)" ; \
 		echo "NOTIFYFLAG COMMBAD $(setnotify "$cfg" commbadnotify)" ; \
 		echo "NOTIFYFLAG SHUTDOWN $(setnotify "$cfg" shutdownnotify)" ; \
-		echo "NOTIFYFLAG REPLBATT $(setnotify "$cfg" repolbattnotify)" ; \
+		echo "NOTIFYFLAG REPLBATT $(setnotify "$cfg" replbattnotify)" ; \
 		echo "NOTIFYFLAG NOCOMM $(setnotify "$cfg" nocommnotify)" ; \
 		echo "NOTIFYFLAG NOPARENT $(setnotify "$cfg" noparentnotify)" ; \
 	} >> "$UPSMON_C"


### PR DESCRIPTION
Maintainer: none
Compile tested: x86_64, OpenWrt master
Run tested: x86_64, OpenWrt master

Description:
There is a typo in the nut-monitor init script causing an uci option to be missed when building daemon config file.
