### PR TITLE
nut: refactor upssched uci-defaults script

### DIFF
--- a/net/nut/files/nut-sched.default
+++ b/net/nut/files/nut-sched.default
@@ -1,10 +1,53 @@
 #!/bin/sh
 
-uci batch <<EOF
-set nut_monitor.@upsmon[-1]=upsmon
-set nut_monitor.@upsmon[-1].notifycmd=/usr/bin/upssched-cmd
-set nut_monitor.@upsmon[-1].defaultnotify="SYSLOG EXEC"
-commit nut_monitor
-EOF
+. "${IPKG_INSTROOT}"/lib/functions.sh
 
+REMOVEDEFAULTNOTIFY=0
+SKIPADDSYSLOG=0
+SKIPADDEXEC=0
+SKIPADDNOTIFYCMD=0
 
+upsmon() {
+	local cfg="$1"
+	local val
+
+	config_get val "$cfg" notifycmd
+	if [ -n "$val" ]; then
+		SKIPADDNOTIFYCMD=1
+	fi
+
+	config_get val "$cfg" defaultnotify
+	if [ -n "$val" ]; then
+		if echo "$val" |grep -q "IGNORE"; then
+			REMOVEDEFAULTNOTIFY=1
+		else
+			SKIPADDSYSLOG=1
+			if echo "$val" |grep -q "EXEC"; then
+				SKIPADDEXEC=1
+			fi
+		fi
+	fi
+}
+
+config_load nut_monitor
+config_foreach upsmon upsmon
+
+uci set nut_monitor.@upsmon[-1]=upsmon
+
+if [ "$SKIPADDNOTIFYCMD" != "1" ]; then
+	uci set nut_monitor.@upsmon[-1].notifycmd=/usr/sbin/upssched
+fi
+
+if [ "$REMOVEDEFAULTNOTIFY" = "1" ]; then
+	uci delete nut_monitor.@upsmon[-1].defaultnotify || true
+fi
+
+if [ "$SKIPADDEXEC" != "1" ]; then
+	uci add_list nut_monitor.@upsmon[-1].defaultnotify="EXEC"
+fi
+
+if [ "$SKIPADDSYSLOG" != "1" ]; then
+	uci add_list nut_monitor.@upsmon[-1].defaultnotify="SYSLOG"
+fi
+
+uci commit nut_monitor


### PR DESCRIPTION
Maintainer: none
Compile tested: x86_64, OpenWrt master
Run tested: x86_64, OpenWrt master

Description:
Add checks not to overwrite defaultnotify options in the nut-sendmail-notify fashion.
Use lists for defaultnotify instead of option.
Add check not to overwrite notifycmd if already defined, if - for example - you run your own case...esac script to call upssched, mailsend or anything else depending on notify type...
upssched-cmd script must not be called directly, it is called by the upssched binary with needed arguments, so call /usr/sbin/upssched in notifycmd.