### PR TITLE
stubby: explicitly disable static linking

### DIFF
--- a/net/stubby/Makefile
+++ b/net/stubby/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stubby
 PKG_VERSION:=0.4.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/getdnsapi/$(PKG_NAME)
@@ -44,6 +44,9 @@ define Package/stubby/conffiles
 /etc/stubby/stubby.yml
 /etc/config/stubby
 endef
+
+# Disable static linking
+CMAKE_OPTIONS += -DENABLE_GETDNS_STATIC_LINK=OFF
 
 define Package/stubby/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
Although undocumented, there's a way to explicitly disable static linking in
Stubby, setting the CMake build option ENABLE_GETDNS_STATIC_LINK to OFF (ON by
default). Make it so.

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>

@jonathanunderwood, @neheb, this will stop `stubby` from linking to anything but `getdns` and `libyaml`. I tried to reproduce @anomeome's build failure to no avail, but in any case this seems the right thing to do. Thoughts?