### PR TITLE
Nut: nut-monitor and nut-upssched fixes and enhancements

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=23
+PKG_RELEASE:=24
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=24
+PKG_RELEASE:=25
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=25
+PKG_RELEASE:=26
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/

--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -95,7 +95,7 @@ nut_upsmon_conf() {
 		echo "NOTIFYFLAG COMMOK $(setnotify "$cfg" commoknotify)" ; \
 		echo "NOTIFYFLAG COMMBAD $(setnotify "$cfg" commbadnotify)" ; \
 		echo "NOTIFYFLAG SHUTDOWN $(setnotify "$cfg" shutdownnotify)" ; \
-		echo "NOTIFYFLAG REPLBATT $(setnotify "$cfg" repolbattnotify)" ; \
+		echo "NOTIFYFLAG REPLBATT $(setnotify "$cfg" replbattnotify)" ; \
 		echo "NOTIFYFLAG NOCOMM $(setnotify "$cfg" nocommnotify)" ; \
 		echo "NOTIFYFLAG NOPARENT $(setnotify "$cfg" noparentnotify)" ; \
 	} >> "$UPSMON_C"

--- a/net/nut/files/nut-sched.default
+++ b/net/nut/files/nut-sched.default
@@ -1,10 +1,53 @@
 #!/bin/sh
 
-uci batch <<EOF
-set nut_monitor.@upsmon[-1]=upsmon
-set nut_monitor.@upsmon[-1].notifycmd=/usr/bin/upssched-cmd
-set nut_monitor.@upsmon[-1].defaultnotify="SYSLOG EXEC"
-commit nut_monitor
-EOF
+. "${IPKG_INSTROOT}"/lib/functions.sh
 
+REMOVEDEFAULTNOTIFY=0
+SKIPADDSYSLOG=0
+SKIPADDEXEC=0
+SKIPADDNOTIFYCMD=0
 
+upsmon() {
+	local cfg="$1"
+	local val
+
+	config_get val "$cfg" notifycmd
+	if [ -n "$val" ]; then
+		SKIPADDNOTIFYCMD=1
+	fi
+
+	config_get val "$cfg" defaultnotify
+	if [ -n "$val" ]; then
+		if echo "$val" |grep -q "IGNORE"; then
+			REMOVEDEFAULTNOTIFY=1
+		else
+			SKIPADDSYSLOG=1
+			if echo "$val" |grep -q "EXEC"; then
+				SKIPADDEXEC=1
+			fi
+		fi
+	fi
+}
+
+config_load nut_monitor
+config_foreach upsmon upsmon
+
+uci set nut_monitor.@upsmon[-1]=upsmon
+
+if [ "$SKIPADDNOTIFYCMD" != "1" ]; then
+	uci set nut_monitor.@upsmon[-1].notifycmd=/usr/sbin/upssched
+fi
+
+if [ "$REMOVEDEFAULTNOTIFY" = "1" ]; then
+	uci delete nut_monitor.@upsmon[-1].defaultnotify || true
+fi
+
+if [ "$SKIPADDEXEC" != "1" ]; then
+	uci add_list nut_monitor.@upsmon[-1].defaultnotify="EXEC"
+fi
+
+if [ "$SKIPADDSYSLOG" != "1" ]; then
+	uci add_list nut_monitor.@upsmon[-1].defaultnotify="SYSLOG"
+fi
+
+uci commit nut_monitor

--- a/net/nut/files/nut_monitor
+++ b/net/nut/files/nut_monitor
@@ -3,7 +3,7 @@
 #	option minsupplies 1
 #	option shutdowncmd '/usr/sbin/nutshutdown'
 #	option notifycmd /path/to/cmd
-#	list defaultnotify SYSLOG
+#	list defaultnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
 #	option pollfreq 5
 #	option pollfreqalert 5
 # 	option hostsync 15
@@ -18,16 +18,16 @@
 #	option replbattmsg "replace battery message"
 #	option nocommmsg "no communications message"
 #	option noparentmsg "no parent message"
-#	option onlinenotify "online notify flag 1|0"
-#	option onbattnotify "on battery notify flag 1|0"
-#	option lowbattnotify "low battery notify flag 1|0"
-#	option fsdnotify "forced shutdown notify flag 1|0"
-#	option comoknotify "communications restored notify flag 1|0"
-#	option combadnotify "communications bad notify flag 1|0"
-#	option shutdownotify "shutdown notify flag 1|0"
-#	option replbattnotify "replace battery notify flag 1|0"
-#	option nocommnotify "no communications notify flag 1|0"
-#	option noparentnotify "no parent notify flag 1|0"
+#	list onlinenotify SYSLOG # can be SYSLOG or EXEC or IGNORE
+#	list onbattnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
+#	list lowbattnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
+#	list fsdnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
+#	list comoknotify SYSLOG # can be SYSLOG or EXEC or IGNORE
+#	list combadnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
+#	list shutdownotify SYSLOG # can be SYSLOG or EXEC or IGNORE
+#	list replbattnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
+#	list nocommnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
+#	list noparentnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
 #	option rbwarntime 4200 # replace battery warn time
 #	option nocommwarntime 300 # no communications warn time
 #	option finaldelay 5 # final delay


### PR DESCRIPTION
Maintainer: none
Compile tested: x86_64, OpenWrt master
Run tested: x86_64, OpenWrt master

Description:
nut: fix typo in nut-monitor init script
This fixes a typo in the nut-monitor init script when building config file from uci config.

nut: refactor nut-monitor uci config file
Convert notifyflags options to lists as supported by the init script, so multiple options can be chosen.
Add SYSLOG default option to individuals notifyflags instead of deprecated flag 1|0.
Add comment for defaultnotify and individuals notifyflags about possible values.

nut: refactor upssched uci-defaults script
Add checks not to overwrite defaultnotify options in the nut-sendmail-notify fashion.
Use lists for defaultnotify instead of option.
Add check not to overwrite notifycmd if already defined, if - for example - you run your own case...esac script to call upssched, mailsend or anything else depending on notify type...
upssched-cmd script must not be called directly, it is called by the upssched binary with needed arguments, so call /usr/sbin/upssched in notifycmd.