### PR TITLE
dockerd: Add "log-driver" option

### DIFF
--- a/utils/dockerd/files/dockerd.init
+++ b/utils/dockerd/files/dockerd.init
@@ -175,6 +175,7 @@ process_config() {
 
 	# Don't add these options by default
 	# omission == docker defaults
+	config_get log_driver globals log_driver ""
 	config_get bip globals bip ""
 	config_get registry_mirrors globals registry_mirrors ""
 	config_get hosts globals hosts ""
@@ -189,6 +190,7 @@ process_config() {
 	json_add_string "data-root" "${data_root}"
 	json_add_string "log-level" "${log_level}"
 	json_add_boolean "iptables" "${iptables}"
+	[ -z "${log_driver}" ] || json_add_string "log-driver" "${log_driver}"
 	[ -z "${bip}" ] || json_add_string "bip" "${bip}"
 	[ -z "${registry_mirrors}" ] || json_add_array "registry-mirrors"
 	[ -z "${registry_mirrors}" ] || config_list_foreach globals registry_mirrors json_add_array_string

--- a/utils/dockerd/files/etc/config/dockerd
+++ b/utils/dockerd/files/etc/config/dockerd
@@ -1,4 +1,5 @@
 # The following settings require a restart of docker to take full effect, A reload will only have partial or no effect:
+# log_driver
 # bip
 # blocked_interfaces
 # extra_iptables_args
@@ -7,6 +8,7 @@
 config globals 'globals'
 #	option alt_config_file '/etc/docker/daemon.json'
 	option data_root '/opt/docker/'
+#	option log_driver 'local'
 	option log_level 'warn'
 	option iptables '1'
 #	list hosts 'unix:///var/run/docker.sock'


### PR DESCRIPTION
Signed-off-by: Nicola Corna <nicola@corna.info>

Maintainer: @G-M0N3Y-2503
Compile tested: **not built**, modified directly `/etc/init.d/dockerd` and `/etc/config/dockerd` on my router
Run tested: tested on x86-64 (PCEngines apu4d4); `/tmp/dockerd/daemon.json` and the logging driver reported by `docker info` change as expected

Description:
The [docker guide](https://docs.docker.com/config/containers/logging/configure/) suggests using the "local" log driver to avoid disk exhaustion, as the default one "json-file" does not perform log rotation. This commit adds the option "log_driver" to let the user choose the logging driver, but does not change default one.