### PR TITLE
krb5: fix build on macos

### DIFF
--- a/net/krb5/patches/002_remove_unnecessary_flag_in_macos_build.patch
+++ b/net/krb5/patches/002_remove_unnecessary_flag_in_macos_build.patch
@@ -1,0 +1,44 @@
+commit 3c66c1fec7ce4edeff284a5e4abe32d0b4398539
+Author: Nikhil Benesch <nikhil.benesch@gmail.com>
+Date:   Wed Dec 22 18:58:17 2021 -0500
+
+    Remove unnecessary flag in macOS build
+    
+    The configuration logic for adding the `-search_paths_first` linker
+    flag on Darwin does not correctly handle cross compilation.  It should
+    check the value of $krb5_cv_host rather than `uname -s` to detect when
+    the compilation target is Darwin, rather than the build machine.
+    
+    It turns out `-search_paths_first` has been the default behavior of ld
+    on macOS since XCode 4.  So just remove that bit of logic entirely.
+    (The flag was added in commit acd27af0e845f8b93de2e226cc2ec9ac8af52077
+    in 2004; XCode 4 was released in 2010.)
+    
+    [ghudson@mit.edu: edited commit message]
+
+--- a/src/aclocal.m4
++++ b/src/aclocal.m4
+@@ -585,10 +585,6 @@ if test "$GCC" = yes ; then
+       CFLAGS="$CFLAGS -fno-common"
+       ;;
+     esac
+-    case "$LD $LDFLAGS" in
+-    *-Wl,-search_paths_first*) ;;
+-    *) LDFLAGS="${LDFLAGS} -Wl,-search_paths_first" ;;
+-    esac
+   fi
+ else
+   if test "`uname -s`" = AIX ; then
+--- a/src/configure
++++ b/src/configure
+@@ -4978,10 +4978,6 @@ $as_echo "$as_me: disabling the use of c
+       CFLAGS="$CFLAGS -fno-common"
+       ;;
+     esac
+-    case "$LD $LDFLAGS" in
+-    *-Wl,-search_paths_first*) ;;
+-    *) LDFLAGS="${LDFLAGS} -Wl,-search_paths_first" ;;
+-    esac
+   fi
+ else
+   if test "`uname -s`" = AIX ; then


### PR DESCRIPTION
search_paths_first is not supported by GCC so this darwin-specific
option should not be used during build process

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @flyn-org 
Compile tested: (armvirt/64, OpenWrt trunk)
Run tested: (armvirt/64, OpenWrt trunk, tests done)

Description: see above
