### PR TITLE
boost: fix libboost_context for mips64

### DIFF
--- a/libs/boost/patches/030-mips1.patch
+++ b/libs/boost/patches/030-mips1.patch
@@ -1,0 +1,63 @@
+--- a/boostcpp.jam
++++ b/boostcpp.jam
+@@ -634,7 +634,7 @@ rule address-model ( )
+     return <conditional>@boostcpp.deduce-address-model ;
+ }
+ 
+-local deducable-architectures = arm mips1 power riscv s390x sparc x86 combined ;
++local deducable-architectures = arm mips power riscv s390x sparc x86 combined ;
+ feature.feature deduced-architecture : $(deducable-architectures) : propagated optional composite hidden ;
+ for a in $(deducable-architectures)
+ {
+@@ -645,10 +645,10 @@ rule deduce-architecture ( properties *
+ {
+     local result ;
+     local filtered = [ toolset-properties $(properties) ] ;
+-    local names = arm mips1 power riscv s390x sparc x86 combined ;
++    local names = arm mips power riscv s390x sparc x86 combined ;
+     local idx = [ configure.find-builds "default architecture" : $(filtered)
+         : /boost/architecture//arm
+-        : /boost/architecture//mips1
++        : /boost/architecture//mips
+         : /boost/architecture//power
+         : /boost/architecture//riscv
+         : /boost/architecture//s390x
+--- a/libs/atomic/build/atomic-arch-config.jam
++++ b/libs/atomic/build/atomic-arch-config.jam
+@@ -27,9 +27,9 @@ rule deduce-architecture ( properties *
+         {
+             return arm ;
+         }
+-        else if [ configure.builds /boost/architecture//mips1 : $(properties) : "mips1" ]
++        else if [ configure.builds /boost/architecture//mips : $(properties) : "mips" ]
+         {
+-            return mips1 ;
++            return mips ;
+         }
+         else if [ configure.builds /boost/architecture//power : $(properties) : "power" ]
+         {
+--- a/libs/config/checks/architecture/Jamfile.jam
++++ b/libs/config/checks/architecture/Jamfile.jam
+@@ -18,7 +18,7 @@ obj 64 : 64.cpp ;
+ 
+ obj arm      : arm.cpp ;
+ obj combined : combined.cpp ;
+-obj mips1    : mips1.cpp ;
++obj mips     : mips1.cpp ;
+ obj power    : power.cpp ;
+ obj riscv    : riscv.cpp ;
+ obj sparc    : sparc.cpp ;
+--- a/libs/log/build/log-arch-config.jam
++++ b/libs/log/build/log-arch-config.jam
+@@ -56,9 +56,9 @@ rule deduce-architecture ( properties *
+         {
+             return arm ;
+         }
+-        else if [ configure.builds /boost/architecture//mips1 : $(properties) : mips1 ]
++        else if [ configure.builds /boost/architecture//mips : $(properties) : mips ]
+         {
+-            return mips1 ;
++            return mips ;
+         }
+         else if [ configure.builds /boost/architecture//power : $(properties) : power ]
+         {

--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -14,7 +14,7 @@ PKG_LICENCE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:powerdns:recursor
 
 PKG_FIXUP:=autoreconf
-PKG_INSTALL:=1
+PKG_INSTALL:=2
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
There was an upstream patch that changes mips1 to mips.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ClaymorePT 
Compile tested: mips64

Temporarily added a garbage pdns-recursor commit to see if CI fails.