### PR TITLE
[21.02] wg-installer: add ipv4 support

### DIFF
--- a/net/wg-installer/wg-server/config/wgserver.conf
+++ b/net/wg-installer/wg-server/config/wgserver.conf
@@ -2,5 +2,6 @@ config server
     option port_start '51820'
     option port_end '52820'
     option base_prefix '2002::/64'
+    option base_v4prefix '10.0.0.1/24'
     option wg_key '/root/wg.key'
     option wg_pub '/root/wg.pub'

--- a/net/wg-installer/wg-server/lib/wg_functions.sh
+++ b/net/wg-installer/wg-server/lib/wg_functions.sh
@@ -33,6 +33,14 @@ wg_register () {
 	wg set $ifname listen-port $port private-key $gw_key peer $public_key allowed-ips ::0/0
 	ip -6 a a $gw_ip_assign dev $ifname
 	ip -6 a a fe80::1/64 dev $ifname
+
+	v4prefix=$(uci get wgserver.@server[0].base_v4prefix)
+	if [ $? -eq 0 ]; then
+		gw_ipv4=$(owipcalc $v4prefix add $offset next 32) # gateway ip
+		gw_ipv4_assign="${gw_ipv4}/32"
+		ip a a $gw_ipv4_assign dev $ifname
+	fi
+
 	ip link set up dev $ifname
 	ip link set mtu $mtu dev $ifname
 
@@ -40,6 +48,9 @@ wg_register () {
 	json_init
 	json_add_string "pubkey" $wg_server_pubkey
 	json_add_string "gw_ip" $gw_ip_assign
+	if test -n "${gw_ipv4_assign-}"; then
+		json_add_string "gw_ipv4" $gw_ipv4_assign
+	fi
 	json_add_int "port" $port
 
 	echo $(json_dump)


### PR DESCRIPTION
Add base_v4prefix to allow ipv4 mesh connections.
