### PR TITLE
crowdsec: update to 1.2.2

### DIFF
--- a/net/crowdsec/Makefile
+++ b/net/crowdsec/Makefile
@@ -1,19 +1,17 @@
 # SPDX-License-Identifier: MIT
 #
-# Copyright (C) 2021 Gerald Kerma
+# Copyright (C) 2021-2022 Gerald Kerma
 #
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crowdsec
-PKG_VERSION:=1.2.1
+PKG_VERSION:=1.2.2
 PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/crowdsecurity/crowdsec
-PKG_SOURCE_VERSION:=v$(PKG_VERSION)
-PKG_SOURCE_DATE:=20211117
-PKG_MIRROR_HASH:=dfe50e5fb4d32fb6c21275b3f13a837ad64a9054e78076b44325376dc003fc64
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/crowdsecurity/crowdsec/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=b815ac4fafa25f0e657b56baaba9a093ef64fbe7336e4bc29208eb47ed1af5e6
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -24,24 +22,23 @@ PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
 CWD_SYSTEM:=openwrt
-CWD_BUILD_VERSION?=$(PKG_SOURCE_VERSION)
+
+CWD_BUILD_VERSION?=v$(PKG_VERSION)
 CWD_BUILD_GOVERSION:=$(shell go version | cut -d " " -f3 | sed -E 's/[go]+//g')
 CWD_BUILD_CODENAME:=alphaga
-CWD_BUILD_TIMESTAMP:=$(SOURCE_DATE_EPOCH)
-CWD_BUILD_TAG:=openwrt
+CWD_BUILD_TIMESTAMP:=$(shell date +%F"_"%T)
+CWD_BUILD_TAG:=openwrt-$(PKG_VERSION)-$(PKG_RELEASE)
 
 CWD_VERSION_PKG:=github.com/crowdsecurity/crowdsec/pkg/cwversion
 
 GO_PKG:=github.com/crowdsecurity/crowdsec
-
+GO_PKG_INSTALL_ALL:=1
 GO_PKG_LDFLAGS_X:=$(CWD_VERSION_PKG).Version=$(CWD_BUILD_VERSION) \
 	$(CWD_VERSION_PKG).System=$(CWD_SYSTEM) \
 	$(CWD_VERSION_PKG).BuildDate=$(CWD_BUILD_TIMESTAMP) \
 	$(CWD_VERSION_PKG).Codename=$(CWD_BUILD_CODENAME)  \
 	$(CWD_VERSION_PKG).Tag=$(CWD_BUILD_TAG) \
 	$(CWD_VERSION_PKG).GoVersion=$(CWD_BUILD_GOVERSION)
-
-GO_PKG_INSTALL_ALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk


### PR DESCRIPTION
Maintainer: Kerma Gérald <gandalf@gk2.net> / @erdoukki
Run tested: (test done on MVEBU arch53 EspressoBin & EspressoBin-ULTRA, OpenWrt 19.07.x and 21.02.x)
Compile tested: (arch=cortexa53, host=amd64)

Description:

Update crowdsec to latest upstream release version 1.2.2

Makefile rework
- use tagged version for download

Signed-off-by: Kerma Gérald <gandalf@gk2.net>