### PR TITLE
netdata flavor with cloud enabled

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -61,8 +61,7 @@ CONFIGURE_ARGS += \
 	--disable-plugin-cups \
 	--disable-plugin-xenstat \
 	--disable-backend-prometheus-remote-write \
-	--disable-unit-tests \
-	--disable-cloud
+	--disable-unit-tests
 
 define Package/netdata/conffiles
 /etc/netdata/


### PR DESCRIPTION
Flavor were cloud is enabled

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
