### PR TITLE
luaossl: fix build on macos

### DIFF
--- a/lang/luaossl/Makefile
+++ b/lang/luaossl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luaossl
 PKG_VERSION:=20200709
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Siger Yang <sigeryeung@gmail.com>
 
 PKG_MIRROR_HASH:=6dbca3cdc50ed7e3b0821783da2407accfb6d25addc3edf1d8e17b00530f5a25

--- a/lang/luaossl/patches/900_fix_build_on_macos.patch
+++ b/lang/luaossl/patches/900_fix_build_on_macos.patch
@@ -1,0 +1,15 @@
+commit 8686cae32fc04045c1404c2febf84242c298bf0d
+Author: Sergey V. Lobanov <sergey@lobanov.in>
+Date:   Fri Jan 7 23:00:03 2022 +0300
+
+    fix build on macos
+    
+    OpenWrt is always Linux. Disable OS detection
+
+--- a/mk/vendor.os
++++ b/mk/vendor.os
+@@ -1,3 +1,3 @@
+ #!/bin/sh
+ 
+-uname -s
++echo Linux


### PR DESCRIPTION
luaossl detects OS and changes compilation flags depends on OS.
If Darwin is detected then it adds GCC non-compatible flags.
OpenWrt is always Linux so build OS detection is disabled

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @sigeryang 
Compile tested: (armvirt/64, OpenWrt trunk)
Run tested: (armvirt/64, OpenWrt trunk, tests done)

Description: see above
