### PR TITLE
luasql: fix build on macos

### DIFF
--- a/lang/luasql/Makefile
+++ b/lang/luasql/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luasql
 PKG_VERSION:=2.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/keplerproject/luasql/tar.gz/v$(PKG_VERSION)?
@@ -94,6 +94,7 @@ ifeq ($(BUILD_VARIANT),sqlite3)
 endif
 
 MAKE_FLAGS += \
+	LIB_OPTION="-shared" \
 	CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS)" \
 	$(BUILD_VARIANT)
 


### PR DESCRIPTION
luasql ./config scripts checks `uname -s` output and changes
LIB_OPTION from '-static' to macos specific if detected OS is
Darwin. These flags are not compatible with GCC

OpenWrt is always Linux, this patch removes Darwin
specific stuff from compilation flags

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: -
Compile tested: (armvirt/64, OpenWrt trunk)
Run tested: (armvirt/64, OpenWrt trunk, tests done)

Description: see above
