### PR TITLE
luajit: fix build on macos (ldconfig issue)

### DIFF
--- a/lang/luajit/Makefile
+++ b/lang/luajit/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luajit
 PKG_VERSION:=2.1.0-beta3
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=LuaJIT-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://luajit.org/download

--- a/lang/luajit/patches/030_fix_posix_install_with_missing_or_incompatible_ldconfig.patch
+++ b/lang/luajit/patches/030_fix_posix_install_with_missing_or_incompatible_ldconfig.patch
@@ -1,0 +1,26 @@
+commit 18c9cf7d3788a8f7408df45df92fc4ae3bcc0d80
+Author: Mike Pall <mike>
+Date:   Sat Jan 25 17:37:12 2020 +0100
+
+    Fix POSIX install with missing or incompatible ldconfig.
+
+--- a/Makefile
++++ b/Makefile
+@@ -75,7 +75,7 @@ SYMLINK= ln -sf
+ INSTALL_X= install -m 0755
+ INSTALL_F= install -m 0644
+ UNINSTALL= $(RM)
+-LDCONFIG= ldconfig -n
++LDCONFIG= ldconfig -n 2>/dev/null
+ SED_PC= sed -e "s|^prefix=.*|prefix=$(PREFIX)|" \
+             -e "s|^multilib=.*|multilib=$(MULTILIB)|"
+ 
+@@ -121,7 +121,7 @@ install: $(INSTALL_DEP)
+ 	$(RM) $(INSTALL_DYN) $(INSTALL_SHORT1) $(INSTALL_SHORT2)
+ 	cd src && test -f $(FILE_SO) && \
+ 	  $(INSTALL_X) $(FILE_SO) $(INSTALL_DYN) && \
+-	  $(LDCONFIG) $(INSTALL_LIB) && \
++	  ( $(LDCONFIG) $(INSTALL_LIB) || : ) && \
+ 	  $(SYMLINK) $(INSTALL_SONAME) $(INSTALL_SHORT1) && \
+ 	  $(SYMLINK) $(INSTALL_SONAME) $(INSTALL_SHORT2) || :
+ 	cd etc && $(INSTALL_F) $(FILE_MAN) $(INSTALL_MAN)


### PR DESCRIPTION
fix ldconfig build issue. This patch is a backport from upstream:
https://github.com/LuaJIT/LuaJIT/commit/18c9cf7d3788a8f7408df45df92fc4ae3bcc0d80

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @milani 
Compile tested: (armvirt/64, OpenWrt trunk)
Run tested: (armvirt/64, OpenWrt trunk, tests done)

Description: see above
