### PR TITLE
lua-curl-v3: fix build on macos

### DIFF
--- a/lang/lua-curl-v3/Makefile
+++ b/lang/lua-curl-v3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lua-curl-v3
 PKG_VERSION:=0.3.13-snapshot
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
@@ -28,6 +28,9 @@ define Package/lua-curl-v3
     DEPENDS:=+libcurl +lua
     MAINTAINER:=Rainer Poisel <rainer.poisel@gmail.com>
 endef
+
+MAKE_FLAGS += \
+	UNAME="Linux"
 
 define Package/lua-curl-v3/description
 	Lua bindings to libcurl (Lua-cURLv3)


### PR DESCRIPTION
lua-curl-v3 detects OS and changes compilation flags depends on OS.
If Darwin is detected then it adds GCC non-compatible flags.
OpenWrt is always Linux, OS detection is disabled via UNAME=Linux
as a part of MAKE_FLAGS

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @rpoisel 
Compile tested: (armvirt/64, OpenWrt trunk)
Run tested: (armvirt/64, OpenWrt trunk, tests done)

Description: see above
