### PR TITLE
bossa: fix build on macos

### DIFF
--- a/utils/bossa/Makefile
+++ b/utils/bossa/Makefile
@@ -33,6 +33,7 @@ endef
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) bin/bossac \
+    OS="Linux" \
     CC="$(TARGET_CC_NOCACHE)" \
     CXX="$(TARGET_CXX_NOCACHE)" \
     CFLAGS="$(TARGET_CFLAGS) $(EXTRA_CFLAGS)" \

--- a/utils/bossa/patches/102_allow_override_os.patch
+++ b/utils/bossa/patches/102_allow_override_os.patch
@@ -1,0 +1,18 @@
+commit 7b1ee33f339bd0d69a7295facda7b3d2b4b55d1a
+Author: Sergey V. Lobanov <sergey@lobanov.in>
+Date:   Sat Jan 8 14:22:21 2022 +0300
+
+    allow override OS to support cross-compile compilation if build OS
+    host OS are different (e.g. build on MacOS for Linux)
+
+--- a/Makefile
++++ b/Makefile
+@@ -28,7 +28,7 @@ INSTALLDIR=install
+ #
+ # Determine OS
+ #
+-OS:=$(shell uname -s | cut -c -7)
++OS?=$(shell uname -s | cut -c -7)
+ 
+ #
+ # Windows rules


### PR DESCRIPTION
override OS=Linux Makefile variable to support building on macos

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

PR to upstream: https://github.com/shumatech/BOSSA/pull/158

Maintainer: @PolynomialDivision
Compile tested: (armvirt/64, OpenWrt trunk)
Run tested: (armvirt/64, OpenWrt trunk, tests done)

Description: see above
