### PR TITLE
fuse: fix compilation with recent glibc

### DIFF
--- a/utils/fuse/Makefile
+++ b/utils/fuse/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=fuse
 PKG_VERSION:=2.9.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/libfuse/libfuse/releases/download/$(PKG_NAME)-$(PKG_VERSION)

--- a/utils/fuse/patches/300-closefrom.patch
+++ b/utils/fuse/patches/300-closefrom.patch
@@ -1,0 +1,20 @@
+--- a/util/ulockmgr_server.c
++++ b/util/ulockmgr_server.c
+@@ -124,7 +124,7 @@ static int receive_message(int sock, voi
+ 	return res;
+ }
+ 
+-static int closefrom(int minfd)
++static int closefrom2(int minfd)
+ {
+ 	DIR *dir = opendir("/proc/self/fd");
+ 	if (dir) {
+@@ -384,7 +384,7 @@ int main(int argc, char *argv[])
+ 		dup2(nullfd, 1);
+ 	}
+ 	close(3);
+-	closefrom(5);
++	closefrom2(5);
+ 	while (1) {
+ 		char c;
+ 		int sock;


### PR DESCRIPTION
closefrom is implemented now.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: arc700