### PR TITLE
ddns-scripts-cloudflare: allow explicit zone_id

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=20
+PKG_RELEASE:=21
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
@@ -15,7 +15,7 @@
 # option password  - cloudflare api key, you can get it from cloudflare.com/my-account/
 # option domain    - "hostname@yourdomain.TLD"	# syntax changed to remove split_FQDN() function and tld_names.dat.gz
 #
-# The proxy status would not be changed by this script. Please change it in Cloudflare dashboard manually. 
+# The proxy status would not be changed by this script. Please change it in Cloudflare dashboard manually.
 #
 # variable __IP already defined with the ip-address to use for update
 #
@@ -134,15 +134,19 @@ else
 fi
 __PRGBASE="$__PRGBASE --header 'Content-Type: application/json' "
 
-# read zone id for registered domain.TLD
-__RUNPROG="$__PRGBASE --request GET '$__URLBASE/zones?name=$__DOMAIN'"
-cloudflare_transfer || return 1
-# extract zone id
-__ZONEID=$(grep -o '"id":\s*"[^"]*' $DATFILE | grep -o '[^"]*$' | head -1)
-[ -z "$__ZONEID" ] && {
-	write_log 4 "Could not detect 'zone id' for domain.tld: '$__DOMAIN'"
-	return 127
-}
+if [ -n "$zone_id"]; then
+	__ZONEID="$zone_id"
+else
+	# read zone id for registered domain.TLD
+	__RUNPROG="$__PRGBASE --request GET '$__URLBASE/zones?name=$__DOMAIN'"
+	cloudflare_transfer || return 1
+	# extract zone id
+	__ZONEID=$(grep -o '"id":\s*"[^"]*' $DATFILE | grep -o '[^"]*$' | head -1)
+	[ -z "$__ZONEID" ] && {
+		write_log 4 "Could not detect 'zone id' for domain.tld: '$__DOMAIN'"
+		return 127
+	}
+fi
 
 # read record id for A or AAAA record of host.domain.TLD
 __RUNPROG="$__PRGBASE --request GET '$__URLBASE/zones/$__ZONEID/dns_records?name=$__HOST&type=$__TYPE'"


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:

When zone id is explicitly provided, there is no need for the API token to have read permission. Inspired by acme.sh's cloudflare logic.