### PR TITLE
wg-installer: fix typo in cleanup function

### DIFF
--- a/net/wg-installer/common/wg.sh
+++ b/net/wg-installer/common/wg.sh
@@ -32,7 +32,7 @@ check_wg_neighbors() {
         delete=1
         for ip in $ips; do
             if [ $ip != $linklocal ] && [ $(owipcalc $ip linklocal) -eq 1 ]; then
-                delte=0
+                delete=0
                 break
             fi
         done


### PR DESCRIPTION
The delete variable was misspelled leading to devices always being removed although they had connected neighbors.
