### PR TITLE
[21.02] wg-installer: fix typo in cleanup function

### DIFF
--- a/net/wg-installer/common/wg.sh
+++ b/net/wg-installer/common/wg.sh
@@ -32,7 +32,7 @@ check_wg_neighbors() {
         delete=1
         for ip in $ips; do
             if [ $ip != $linklocal ] && [ $(owipcalc $ip linklocal) -eq 1 ]; then
-                delte=0
+                delete=0
                 break
             fi
         done


### PR DESCRIPTION
The delete variable was misspelled leading to devices always being removed although they had connected neighbors.

Signed-off-by: Nick Hainke <vincent@systemli.org>
(cherry picked from commit 0e416dadd1281878388445007e45df741c387335)
