### PR TITLE
glib2: disable fortify source

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -25,6 +25,7 @@ HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/glib-$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=libiconv/host
 HOST_BUILD_DEPENDS:=libiconv/host libffi/host pcre/host
 PKG_CONFIG_DEPENDS:=CONFIG_BUILD_NLS
+PKG_FORTIFY_SOURCE:=0
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/host-build.mk


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: OpenWrt master r18531-0f50d3daff on qoriq
Run tested: OpenWrt master r18531-0f50d3daff on qoriq

Description:
The glib2 package fails to build when CONFIG_PKG_FORTIFY_SOURCE_1 or
CONFIG_PKG_FORTIFY_SOURCE_2 is enabled in the OpenWrt config:

In file included from ../glib/libcharset/localcharset.c:28:
/home/stijn/Development/OpenWrt/openwrt/staging_dir/toolchain-powerpc64_e5500_gcc-11.2.0_musl/include/fortify/stdio.h: In function 'snprintf':
/home/stijn/Development/OpenWrt/openwrt/staging_dir/toolchain-powerpc64_e5500_gcc-11.2.0_musl/include/fortify/stdio.h:101:9: error: format not a string literal, argument types not checked [-Werror=format-nonliteral]
  101 |         return __orig_snprintf(__s, __n, __f, __builtin_va_arg_pack());
      |         ^~~~~~
/home/stijn/Development/OpenWrt/openwrt/staging_dir/toolchain-powerpc64_e5500_gcc-11.2.0_musl/include/fortify/stdio.h: In function 'sprintf':
/home/stijn/Development/OpenWrt/openwrt/staging_dir/toolchain-powerpc64_e5500_gcc-11.2.0_musl/include/fortify/stdio.h:110:17: error: format not a string literal, argument types not checked [-Werror=format-nonliteral]
  110 |                 __r = __orig_snprintf(__s, __b, __f, __builtin_va_arg_pack());
      |                 ^~~
/home/stijn/Development/OpenWrt/openwrt/staging_dir/toolchain-powerpc64_e5500_gcc-11.2.0_musl/include/fortify/stdio.h:114:17: error: format not a string literal, argument types not checked [-Werror=format-nonliteral]
  114 |                 __r = __orig_sprintf(__s, __f, __builtin_va_arg_pack());
      |                 ^~~

Disable fortify source for the package as a workaround.