### PR TITLE
erlang: update to version 24.2

### DIFF
--- a/lang/erlang/Makefile
+++ b/lang/erlang/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=erlang
-PKG_VERSION:=23.0
-PKG_RELEASE:=5
+PKG_VERSION:=24.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=otp_src_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= http://www.erlang.org/download/
-PKG_HASH:=42dcf3c721f4de59fe74ae7b65950c2174c46dc8d1dd4e27c0594d86f606a635
+PKG_HASH:=af0f1928dcd16cd5746feeca8325811865578bf1a110a443d353ea3e509e6d41
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.txt
@@ -46,8 +46,8 @@ endef
 
 define Package/erlang
 $(call Package/erlang/Default)
-  DEPENDS+= +libncurses +librt +zlib
-  PROVIDES:= erlang-erts=10.0.1 erlang-kernel=6.0 erlang-sasl=3.2 erlang-stdlib=3.5
+  DEPENDS+= +libncurses +librt +zlib +libstdcpp
+  PROVIDES:= erlang-erts=12.2 erlang-kernel=8.2 erlang-sasl=4.1.1 erlang-stdlib=3.17
 endef
 
 define Package/erlang/description
@@ -61,7 +61,7 @@ endef
 define Package/erlang-asn1
 $(call Package/erlang/Default)
   TITLE:=Abstract Syntax Notation One (ASN.1) support
-  VERSION:=5.0.6
+  VERSION:=5.0.17
   DEPENDS+= +erlang +erlang-syntax-tools
 endef
 
@@ -76,8 +76,8 @@ endef
 define Package/erlang-compiler
 $(call Package/erlang/Default)
   TITLE:=Byte code compiler
-  VERSION:=7.2
-  DEPENDS+= +erlang +erlang-hipe
+  VERSION:=8.0.4
+  DEPENDS+= +erlang
 endef
 
 define Package/erlang-compiler/description
@@ -91,7 +91,7 @@ endef
 define Package/erlang-crypto
 $(call Package/erlang/Default)
   TITLE:=Cryptography support
-  VERSION:=4.3
+  VERSION:=5.0.5
   DEPENDS+= +erlang +libopenssl
 endef
 
@@ -103,25 +103,10 @@ $(call Package/erlang/Default/description)
 endef
 
 
-define Package/erlang-hipe
-$(call Package/erlang/Default)
-  TITLE:=High Performance Erlang
-  VERSION:=3.18
-  DEPENDS+= +erlang
-endef
-
-define Package/erlang-hipe/description
-$(call Package/erlang/Default/description)
- .
- This Erlang/OTP package provides HiPE (High Performance Erlang)
- support.
-endef
-
-
 define Package/erlang-inets
 $(call Package/erlang/Default)
   TITLE:=Internet clients and servers
-  VERSION:=7.0
+  VERSION:=7.5
   DEPENDS+= +erlang
 endef
 
@@ -137,7 +122,7 @@ endef
 define Package/erlang-mnesia
 $(call Package/erlang/Default)
   TITLE:=Distributed database
-  VERSION:=4.15.4
+  VERSION:=4.20.1
   DEPENDS+= +erlang
 endef
 
@@ -154,7 +139,7 @@ endef
 define Package/erlang-runtime-tools
 $(call Package/erlang/Default)
   TITLE:=Low-profile debugging/tracing tools
-  VERSION:=1.13
+  VERSION:=1.17
   DEPENDS+= +erlang
 endef
 
@@ -169,7 +154,7 @@ endef
 define Package/erlang-snmp
 $(call Package/erlang/Default)
   TITLE:=Simple Network Management Protocol (SNMP) support
-  VERSION:=5.2.11
+  VERSION:=5.11
   DEPENDS+= +erlang +erlang-asn1
 endef
 
@@ -185,7 +170,7 @@ endef
 define Package/erlang-public-key
 $(call Package/erlang/Default)
   TITLE:=Public Key support
-  VERSION:=1.6
+  VERSION:=1.11.3
   DEPENDS+= +erlang +erlang-crypto +erlang-asn1
 endef
 
@@ -199,7 +184,7 @@ endef
 define Package/erlang-ssh
 $(call Package/erlang/Default)
   TITLE:=Secure Shell (SSH) support
-  VERSION:=4.7
+  VERSION:=4.13
   DEPENDS+= +erlang +erlang-crypto
 endef
 
@@ -214,7 +199,7 @@ endef
 define Package/erlang-ssl
 $(call Package/erlang/Default)
   TITLE:=Secure Sockets Layer (SSL) support
-  VERSION:=9.0
+  VERSION:=10.6
   DEPENDS+= +erlang +erlang-crypto
 endef
 
@@ -229,7 +214,7 @@ endef
 define Package/erlang-syntax-tools
 $(call Package/erlang/Default)
   TITLE:=Abstract Erlang syntax trees handling support
-  VERSION:=2.1.5
+  VERSION:=2.6
   DEPENDS+= +erlang
 endef
 
@@ -244,7 +229,7 @@ endef
 define Package/erlang-tools
 $(call Package/erlang/Default)
   TITLE:=Erlang tools support
-  VERSION:=3.0
+  VERSION:=3.5.2
   DEPENDS+= +erlang
 endef
 
@@ -258,7 +243,7 @@ endef
 define Package/erlang-reltool
 $(call Package/erlang/Default)
   TITLE:=Erlang reltool support
-  VERSION:=0.7.6
+  VERSION:=0.9
   DEPENDS+= +erlang
 endef
 
@@ -272,7 +257,7 @@ endef
 define Package/erlang-erl-interface
 $(call Package/erlang/Default)
   TITLE:=Erlang erl_interface support
-  VERSION:=3.9.3
+  VERSION:=5.1
   DEPENDS+= +erlang
 endef
 
@@ -285,7 +270,7 @@ endef
 define Package/erlang-os_mon
 $(call Package/erlang/Default)
   TITLE:=Erlang OS Monitoring Application
-  VERSION:=2.4.5
+  VERSION:=2.7.1
   DEPENDS+= +erlang
 endef
 
@@ -301,7 +286,7 @@ endef
 define Package/erlang-xmerl
 $(call Package/erlang/Default)
   TITLE:=Erlang XML export
-  VERSION:=1.3.17
+  VERSION:=1.3.28
   DEPENDS+= +erlang
 endef
 
@@ -312,8 +297,14 @@ $(call Package/erlang/Default/description)
 endef
 
 # Host
+# host-compile is done with LibreSSL provided by OpenWrt tools/libressl
+
+HOST_CFLAGS += \
+        -DHAS_EVP_PKEY_CTX \
+        -DHAVE_EVP_CIPHER_CTX_COPY
 
 HOST_CONFIGURE_ARGS += \
+	--with-ssl="$(STAGING_DIR_HOST)" \
 	--disable-hipe \
 	--disable-pgo \
 	--disable-smp-support \
@@ -404,7 +395,6 @@ $(eval $(call BuildPackage,erlang))
 $(eval $(call BuildModule,asn1,asn1))
 $(eval $(call BuildModule,compiler,compiler))
 $(eval $(call BuildModule,crypto,crypto))
-$(eval $(call BuildModule,hipe,hipe))
 $(eval $(call BuildModule,inets,inets))
 $(eval $(call BuildModule,mnesia,mnesia))
 $(eval $(call BuildModule,runtime-tools,runtime_tools))

--- a/lang/erlang/patches/010-openssl-deprecated.patch
+++ b/lang/erlang/patches/010-openssl-deprecated.patch
@@ -1,24 +1,6 @@
---- a/lib/crypto/c_src/crypto_callback.c
-+++ b/lib/crypto/c_src/crypto_callback.c
-@@ -112,6 +112,7 @@ static ErlNifRWLock** lock_vec = NULL; /
- 
- #include <openssl/crypto.h>
- 
-+#if OPENSSL_VERSION_NUMBER < PACKED_OPENSSL_VERSION_PLAIN(1,1,0)
- static INLINE void locking(int mode, ErlNifRWLock* lock)
- {
-     switch (mode) {
-@@ -132,7 +133,6 @@ static INLINE void locking(int mode, Erl
-     }
- }
- 
--#if OPENSSL_VERSION_NUMBER < PACKED_OPENSSL_VERSION_PLAIN(1,1,0)
- static void locking_function(int mode, int n, const char *file, int line)
- {
-     locking(mode, lock_vec[n]);
 --- a/lib/crypto/c_src/engine.c
 +++ b/lib/crypto/c_src/engine.c
-@@ -244,7 +244,7 @@ ERL_NIF_TERM engine_load_dynamic_nif(Erl
+@@ -239,7 +239,7 @@ ERL_NIF_TERM engine_load_dynamic_nif(Erl
  #ifdef HAS_ENGINE_SUPPORT
      ASSERT(argc == 0);
  
@@ -29,9 +11,9 @@
      return atom_notsup;
 --- a/lib/crypto/c_src/info.c
 +++ b/lib/crypto/c_src/info.c
-@@ -20,6 +20,11 @@
+@@ -46,6 +46,11 @@
+ #endif
  
- #include "info.h"
  
 +#if OPENSSL_VERSION_NUMBER < PACKED_OPENSSL_VERSION_PLAIN(1,1,0)
 +#define OPENSSL_VERSION	SSLEAY_VERSION
@@ -40,8 +22,8 @@
 +
  #ifdef HAVE_DYNAMIC_CRYPTO_LIB
  
- # if defined(DEBUG)
-@@ -77,7 +82,7 @@ ERL_NIF_TERM info_lib(ErlNifEnv *env, in
+ char *crypto_callback_name = CB_NAME;
+@@ -132,7 +137,7 @@ ERL_NIF_TERM info_lib(ErlNifEnv *env, in
      ASSERT(argc == 0);
  
      name_sz = strlen(libname);
@@ -52,7 +34,7 @@
  
 --- a/lib/crypto/c_src/otp_test_engine.c
 +++ b/lib/crypto/c_src/otp_test_engine.c
-@@ -100,9 +100,11 @@ static int test_init(ENGINE *e) {
+@@ -101,9 +101,11 @@ static int test_init(ENGINE *e) {
          goto err;
  #endif /* if defined(FAKE_RSA_IMPL) */
  

--- a/lang/erlang/patches/020-erts-emulator-reorder-inclued-headers-paths.patch
+++ b/lang/erlang/patches/020-erts-emulator-reorder-inclued-headers-paths.patch
@@ -18,25 +18,34 @@ http://autobuild.buildroot.net/results/cbd/cbd8b54eef535f19d7d400fd269af1b3571d6
 Signed-off-by: Romain Naour <romain.naour@openwide.fr>
 [Bernd: rebased for erlang-21.0]
 Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
+[svlobanov: updated for erlang-24.2]
 ---
- erts/emulator/Makefile.in | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ erts/emulator/Makefile.in | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
 
 --- a/erts/emulator/Makefile.in
 +++ b/erts/emulator/Makefile.in
-@@ -751,7 +751,7 @@ endif
+@@ -800,7 +800,7 @@ endif
  # Usually the same as the default rule, but certain platforms (e.g. win32) mix
  # different compilers
- $(OBJDIR)/beam_emu.o: beam/beam_emu.c
+ $(OBJDIR)/beam_emu.o: beam/emu/beam_emu.c
 -	$(V_EMU_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
 +	$(V_EMU_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
  
- $(OBJDIR)/beam_emu.S: beam/beam_emu.c
+ $(OBJDIR)/beam_emu.S: beam/emu/beam_emu.c
  	$(V_EMU_CC) -S -fverbose-asm $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
-@@ -804,7 +804,7 @@ endif
+@@ -863,13 +863,13 @@ endif
  # General targets
  #
  $(OBJDIR)/%.o: beam/%.c
+-	$(V_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
++	$(V_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
+ 
+ $(OBJDIR)/%.o: beam/emu/%.c
+-	$(V_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
++	$(V_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
+ 
+ $(OBJDIR)/%.o: beam/jit/%.c
 -	$(V_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
 +	$(V_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
  


### PR DESCRIPTION
1. updated to 24.2  (RN: https://github.com/erlang/otp/releases/tag/OTP-24.2)
2. added libstdcpp dependency
3. erlang-hipe was removed in upstream
 (ref https://github.com/erlang/otp/commit/fccb8482efc47bf2e48911564df502f087cce5ed)
 everything related to erlang-hipe was removed from Makefile
4. updated and refreshed patches
5. host-compile ssl library forced to OpenWrt LibreSSL to avoid using system library

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @cretingame 
Compile tested: (all supported by CI, OpenWrt trunk)
Run tested: (x86/64, OpenWrt trunk, tests done)
Run tested: (armvirt/64, OpenWrt trunk, tests done)

Description: see above
