### PR TITLE
telegraf: Update package to version 1.21.2

### DIFF
--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telegraf
-PKG_VERSION:=1.21.1
+PKG_VERSION:=1.21.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=7ec38fa53747682290621b3162dbb0bb12cf73a559a689f8a75e1ec8b518da0b
+PKG_HASH:=2a6c0722c6999c438d316d5971502aa79abd92134c265ee0e53596cc125d175b
 
 PKG_MAINTAINER:=Jonathan Pagel <jonny_tischbein@systemli.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Signed-off-by: Jonathan Pagel jonny_tischbein@systemli.org

Maintainer:
me

Compile tested:
on amd64 for aarch64 on https://git.openwrt.org/openwrt/openwrt.git commit 0f50d3daff19a1eae513630a70f0c66af16db796

Run tested:
aarch64 (Banana PI R64), package installed, configured, starting via /etc/init.d/, configuring telegraf config and successfull working of input plugin cpu, prometheus and output plugin influxdb tested.

Description:
Update to version 1.21.2

Telegraf is a plugin-driven agent for collecting and sending metrics and events. It supports various inputs (including prometheus endpoints) and is able to send data into InfluxDB. https://www.influxdata.com/time-series-platform/telegraf/