### PR TITLE
gpgme: Fix compile with glibc 2.34

### DIFF
--- a/libs/gpgme/Makefile
+++ b/libs/gpgme/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gpgme
 PKG_VERSION:=1.16.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)

--- a/libs/gpgme/patches/001-Support-closefrom-also-for-glibc.patch
+++ b/libs/gpgme/patches/001-Support-closefrom-also-for-glibc.patch
@@ -1,0 +1,27 @@
+From: Jiri Kucera <sanczes@gmail.com>
+Date: Sun, 25 Jul 2021 09:35:54 +0000 (+0200)
+Subject: core: Support closefrom also for glibc.
+X-Git-Url: http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=commitdiff_plain;h=4b64774b6d13ffa4f59dddf947a97d61bcfa2f2e
+
+core: Support closefrom also for glibc.
+
+* src/posix-io.c (_gpgme_io_spawn): Use glibc's closefrom.
+--
+
+Since 2.34, glibc introduces closefrom (the implementation
+follows *BSD standard).
+
+Signed-off-by: Werner Koch <wk@gnupg.org>
+---
+
+--- a/src/posix-io.c
++++ b/src/posix-io.c
+@@ -570,7 +570,7 @@ _gpgme_io_spawn (const char *path, char
+               if (fd_list[i].fd > fd)
+                 fd = fd_list[i].fd;
+             fd++;
+-#if defined(__sun) || defined(__FreeBSD__)
++#if defined(__sun) || defined(__FreeBSD__) || defined(__GLIBC__)
+             closefrom (fd);
+             max_fds = fd;
+ #else /*!__sun */


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: archs (glibc)
Run tested: none

Description:
This backports a patch from upstream gpgme to fix compilation with glibc 2.34.

It fixes the following build problem:
posix-io.c: In function '_gpgme_io_spawn':
posix-io.c:577:23: error: void value not ignored as it ought to be
  577 |             while ((i = closefrom (fd)) && errno == EINTR)
      |                       ^
make[5]: *** [Makefile:947: posix-io.lo] Error 1

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>