### PR TITLE
radsecproxy: Fix compile with glibc 2.34

### DIFF
--- a/net/radsecproxy/Makefile
+++ b/net/radsecproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radsecproxy
 PKG_VERSION:=1.9.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/radsecproxy/radsecproxy/releases/download/$(PKG_VERSION)/

--- a/net/radsecproxy/patches/100-fix-setstacksize-for-glibc-2.34.patch
+++ b/net/radsecproxy/patches/100-fix-setstacksize-for-glibc-2.34.patch
@@ -1,0 +1,58 @@
+From 241164a201e03acce363e902fb25e452827211f0 Mon Sep 17 00:00:00 2001
+From: Fabian Mauchle <fabian.mauchle@switch.ch>
+Date: Mon, 26 Jul 2021 14:12:15 +0200
+Subject: [PATCH] fix setstacksize for glibc 2.34 (fix #91)
+
+---
+ ChangeLog     |  1 +
+ radsecproxy.c | 10 ++++++++--
+ radsecproxy.h | 12 +++---------
+ 3 files changed, 12 insertions(+), 11 deletions(-)
+
+--- a/radsecproxy.c
++++ b/radsecproxy.c
+@@ -3031,6 +3031,7 @@ int createpidfile(const char *pidfile) {
+ int radsecproxy_main(int argc, char **argv) {
+     pthread_t sigth;
+     sigset_t sigset;
++    size_t stacksize;
+     struct list_node *entry;
+     uint8_t foreground = 0, pretend = 0, loglevel = 0;
+     char *configfile = NULL, *pidfile = NULL;
+@@ -3042,8 +3043,13 @@ int radsecproxy_main(int argc, char **ar
+ 
+     if (pthread_attr_init(&pthread_attr))
+ 	debugx(1, DBG_ERR, "pthread_attr_init failed");
+-    if (pthread_attr_setstacksize(&pthread_attr, PTHREAD_STACK_SIZE))
+-	debugx(1, DBG_ERR, "pthread_attr_setstacksize failed");
++#if defined(PTHREAD_STACK_MIN)
++    stacksize = THREAD_STACK_SIZE > PTHREAD_STACK_MIN ? THREAD_STACK_SIZE : PTHREAD_STACK_MIN;
++#else
++    stacksize = THREAD_STACK_SIZE;
++#endif
++    if (pthread_attr_setstacksize(&pthread_attr, stacksize))
++        debug(DBG_WARN, "pthread_attr_setstacksize failed! Using system default. Memory footprint might be increased!");
+ #if defined(HAVE_MALLOPT)
+     if (mallopt(M_TRIM_THRESHOLD, 4 * 1024) != 1)
+ 	debugx(1, DBG_ERR, "mallopt failed");
+--- a/radsecproxy.h
++++ b/radsecproxy.h
+@@ -28,15 +28,9 @@
+ #define STATUS_SERVER_PERIOD 25
+ #define IDLE_TIMEOUT 300
+ 
+-/* We want PTHREAD_STACK_SIZE to be 32768, but some platforms
+- * have a higher minimum value defined in PTHREAD_STACK_MIN. */
+-#define PTHREAD_STACK_SIZE 32768
+-#if defined(PTHREAD_STACK_MIN)
+-#if PTHREAD_STACK_MIN > PTHREAD_STACK_SIZE
+-#undef PTHREAD_STACK_SIZE
+-#define PTHREAD_STACK_SIZE PTHREAD_STACK_MIN
+-#endif
+-#endif
++/* Target value for stack size.
++ * Some platforms might define higher minimums in PTHREAD_STACK_MIN. */
++#define THREAD_STACK_SIZE 32768
+ 
+ /* For systems that only support RFC 2292 Socket API, but not RFC 3542
+  * like Cygwin */

--- a/net/radsecproxy/patches/200-logdest-on-foreground.patch
+++ b/net/radsecproxy/patches/200-logdest-on-foreground.patch
@@ -1,6 +1,6 @@
 --- a/radsecproxy.c
 +++ b/radsecproxy.c
-@@ -3067,15 +3067,13 @@ int radsecproxy_main(int argc, char **ar
+@@ -3073,15 +3073,13 @@ int radsecproxy_main(int argc, char **ar
  	options.loglevel = loglevel;
      else if (options.loglevel)
  	debug_set_level(options.loglevel);


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: archs (glibc)
Run tested: none

Description:

This backports a patch from upstream radsecproxy to fix compilation with glibc 2.34.

It fixes the following build problem:
radsecproxy.h:35:5: error: missing binary operator before token "("
   35 | #if PTHREAD_STACK_MIN > PTHREAD_STACK_SIZE
      |     ^~~~~~~~~~~~~~~~~
make[5]: *** [Makefile:623: dtls.o] Error 1

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>