### PR TITLE
postfix: Fix compile with glibc 2.34

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postfix
 PKG_VERSION:=3.5.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \

--- a/mail/postfix/patches/100-correct-signature-of-closefrom-API.patch
+++ b/mail/postfix/patches/100-correct-signature-of-closefrom-API.patch
@@ -1,0 +1,97 @@
+From 1e451ddc15af1a4e19318c8b1ced46c5c41610d3 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 14 Jul 2021 18:08:30 -0700
+Subject: [PATCH] correct signature of closefrom() API
+
+glibc 2.34 introduced this function and finds this error which has been
+all along.
+
+Upstream-Status: Pending
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/util/sys_compat.c |  6 +++---
+ src/util/sys_defs.h   | 12 ++++++------
+ 2 files changed, 9 insertions(+), 9 deletions(-)
+
+--- a/src/util/sys_compat.c
++++ b/src/util/sys_compat.c
+@@ -286,7 +286,7 @@ int     dup2_pass_on_exec(int oldd, int
+ 
+ /* closefrom() - closes all file descriptors from the given one up */
+ 
+-int     closefrom(int lowfd)
++void     closefrom(int lowfd)
+ {
+     int     fd_limit = open_limit(0);
+     int     fd;
+@@ -298,14 +298,14 @@ int     closefrom(int lowfd)
+      */
+     if (lowfd < 0) {
+ 	errno = EBADF;
+-	return (-1);
++	return;
+     }
+     if (fd_limit > 500)
+ 	fd_limit = 500;
+     for (fd = lowfd; fd < fd_limit; fd++)
+ 	(void) close(fd);
+ 
+-    return (0);
++    return;
+ }
+ 
+ #endif
+--- a/src/util/sys_defs.h
++++ b/src/util/sys_defs.h
+@@ -1509,7 +1509,7 @@ extern int setsid(void);
+ #endif
+ 
+ #ifndef HAS_CLOSEFROM
+-extern int closefrom(int);
++extern void closefrom(int);
+ 
+ #endif
+ 
+@@ -1563,7 +1563,7 @@ typedef int pid_t;
+ 
+  /*
+   * Clang-style attribute tests.
+-  * 
++  *
+   * XXX Without the unconditional test below, gcc 4.6 will barf on ``elif
+   * defined(__clang__) && __has_attribute(__whatever__)'' with error message
+   * ``missing binary operator before token "("''.
+@@ -1577,7 +1577,7 @@ typedef int pid_t;
+   * warn for missing initializations and other trouble. However, OPENSTEP4
+   * gcc 2.7.x cannot handle this so we define this only if NORETURN isn't
+   * already defined above.
+-  * 
++  *
+   * Data point: gcc 2.7.2 has __attribute__ (Wietse Venema) but gcc 2.6.3 does
+   * not (Clive Jones). So we'll set the threshold at 2.7.
+   */
+@@ -1653,12 +1653,12 @@ typedef int pid_t;
+   * write to output parameters (for example, stat- or scanf-like functions)
+   * or from functions that have other useful side effects (for example,
+   * fseek- or rename-like functions).
+-  * 
++  *
+   * DO NOT use this for functions that write to a stream; it is entirely
+   * legitimate to detect write errors with fflush() or fclose() only. On the
+   * other hand most (but not all) functions that read from a stream must
+   * never ignore result values.
+-  * 
++  *
+   * XXX Prepending "(void)" won't shut up GCC. Clang behaves as expected.
+   */
+ #if ((__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || __GNUC__ > 3)
+@@ -1747,7 +1747,7 @@ typedef const char *CONST_CHAR_STAR;
+   * Safety. On some systems, ctype.h misbehaves with non-ASCII or negative
+   * characters. More importantly, Postfix uses the ISXXX() macros to ensure
+   * protocol compliance, so we have to rule out non-ASCII characters.
+-  * 
++  *
+   * XXX The (unsigned char) casts in isalnum() etc arguments are unnecessary
+   * because the ISASCII() guard already ensures that the values are
+   * non-negative; the casts are done anyway to shut up chatty compilers.


### PR DESCRIPTION
Maintainer: @Shulyaka 
Compile tested: archs (glibc)
Run tested: none

Description:


This adds a patch from Open embedded to fix compilation with glibc 2.34.
This patch was taken from here:
https://github.com/openembedded/meta-openembedded/blob/master/meta-networking/recipes-daemons/postfix/files/0007-correct-signature-of-closefrom-API.patch

It fixes the following build problem:
/builder/shared-workdir/build/sdk/staging_dir/toolchain-arc_arc700_gcc-11.2.0_glibc/include/unistd.h:366:13: error: conflicting types for 'closefrom'; have 'void(int)'
  366 | extern void closefrom (int __lowfd) __THROW;
      |             ^~~~~~~~~
In file included from attr_clnt.c:87:
./sys_defs.h:1511:12: note: previous declaration of 'closefrom' with type 'int(int)'
 1511 | extern int closefrom(int);
      |            ^~~~~~~~~
make: *** [Makefile:192: attr_clnt.o] Error 1

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
