### PR TITLE
docker-compose: Update to version 2.2.3

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.2.2
+PKG_VERSION:=2.2.3
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=001cf72f6bc8a8c43d100389e0bbd3d4d5f5c523f4e3f7ddd53f6a4cd2d6cb18
+PKG_HASH:=22210187e73732edd9fc02f122ea61481806c703af7b73d0a7351f2e8ed7c0b8
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream update

What's Changed

 -  compose images should list images of created containers by @kiniou

 -  Ignore missing (swarm) overlay networks by @ndeloof

 -  Remove intermediate containers when build succeeded in classic
 build by @notok

 -  compose ps: fix typo "unknow" -> "unknown" by @webignition

 -  Add 2 modes test mechanism by @ulyssessouza

 -  Handle "stop" event by @ndeloof

 -  Only kill running containers by @ulyssessouza

 -  compose cp doesn't need a full project and can copy from stopped
 containers by @ndeloof

 -  Add dependabot by @ulyssessouza

 -  Do not try to guess when to allocate a TTY and keep it as default
 by @ulyssessouza

 -  Bump github.com/golang/mock from 1.5.0 to 1.6.0 by @dependabot

 -  Bump github.com/spf13/cobra from 1.2.1 to 1.3.0 by @dependabot

 -  Bump github.com/hashicorp/go-multierror from 1.1.0 to 1.1.1 by
 @dependabot

 -  Bump github.com/buger/goterm from 1.0.0 to 1.0.3 by @dependabot

 -  Propagate GroupAdd from ServiceConfig to HostConfig by
 @lancechentw

 -  Bump github.com/containerd/console from 1.0.2 to 1.0.3 by
 @dependabot

 -  Bump github.com/AlecAivazis/survey/v2 from 2.2.3 to 2.3.2 by
 @dependabot

 -  Added volume bind option SELinux label :z :Z by @tymonx

 -  Downgrade goterm to 1.0.1 by @ulyssessouza

Signed-off-by: Javier Marcet <javier@marcet.info>
