### PR TITLE
python3-paramiko: update to version 2.9.2

### DIFF
--- a/lang/python/python-paramiko/Makefile
+++ b/lang/python/python-paramiko/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-paramiko
-PKG_VERSION:=2.9.1
+PKG_VERSION:=2.9.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=paramiko
-PKG_HASH:=a1fdded3b55f61d23389e4fe52d9ae428960ac958d2edf50373faa5d8926edd0
+PKG_HASH:=944a9e5dbdd413ab6c7951ea46b0ab40713235a9c4c5ca81cfe45c6f14fa677b
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream update

 - [Bug]: Enhanced log output when connecting to servers that do not
 support server-sig-algs extensions, making the new-as-of-2.9
 defaulting to SHA2 pubkey algorithms more obvious when it kicks in.

 - [Bug]: Connecting to servers which support server-sig-algs but
 which have no overlap between that list and what a Paramiko client
 supports, now raise an exception instead of defaulting to
 rsa-sha2-512 (since the use of server-sig-algs allows us to know
 what the server supports).
