### PR TITLE
neon: fix build on macos

### DIFF
--- a/libs/neon/Makefile
+++ b/libs/neon/Makefile
@@ -47,6 +47,9 @@ define Package/libneon/description
   - WebDAV metadata support; wrappers for PROPFIND and PROPPATCH to simplify property manipulation.
 endef
 
+CONFIGURE_VARS += \
+	ne_cv_os_uname="Linux"
+
 CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \


### PR DESCRIPTION
neon detects Darwin on target build and fails due to darwin-specific
build behaviour. OS detection is disable (as non required) via
ne_cv_os_uname=Linux as a part of CONFIGURE_VARS

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @fededim 
Compile tested: (armvirt/64, OpenWrt trunk)
Run tested: (armvirt/64, OpenWrt trunk, tests done)

Description: see above
