### PR TITLE
[21.02] wg-installer: fix cleanup script

### DIFF
--- a/net/wg-installer/common/wg.sh
+++ b/net/wg-installer/common/wg.sh
@@ -15,7 +15,7 @@ next_port () {
 }
 
 cleanup_wginterfaces() {
-    neighbors_available
+    check_wg_neighbors
 }
 
 delete_wg_interface() {


### PR DESCRIPTION
The wrong function was called.

Signed-off-by: Nick Hainke <vincent@systemli.org>
(cherry picked from commit e6afcf8f3c5ef428a954bda0f391f7b691d0de9f)