### PR TITLE
[21.02] fail2ban: fix 2to3 error

### DIFF
--- a/net/fail2ban/Makefile
+++ b/net/fail2ban/Makefile
@@ -1,6 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
+# Copyright (C) 2021-2022 Gerald Kerma
 #
 
 include $(TOPDIR)/rules.mk
@@ -19,6 +19,8 @@ PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
+
+HOST_BUILD_DEPENDS:=2to3/host
 
 define Package/fail2ban
   SECTION:=net
@@ -73,6 +75,11 @@ define Py3Package/fail2ban/install
 
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/fail2ban.defaults $(1)/etc/uci-defaults/99_fail2ban
+endef
+
+define Py3Build/Compile
+	cd $(PKG_BUILD_DIR) && ./fail2ban-2to3
+	$(call Py3Build/Compile/Default)
 endef
 
 $(eval $(call Py3Package,fail2ban))

--- a/net/fail2ban/patches/020-fix-2to3.patch
+++ b/net/fail2ban/patches/020-fix-2to3.patch
@@ -1,0 +1,62 @@
+From 196c55e93103d1e56d1336f27a5f2591b4e54fef Mon Sep 17 00:00:00 2001
+From: sebres <info@sebres.de>
+Date: Sun, 19 Sep 2021 18:49:18 +0200
+Subject: [PATCH] fix gh-3098: build fails with error in fail2ban setup
+ command: use_2to3 is invalid (setuptools 58+)
+
+---
+ setup.py | 16 +---------------
+ 1 file changed, 1 insertion(+), 15 deletions(-)
+
+--- a/setup.py
++++ b/setup.py
+@@ -56,7 +56,7 @@ import warnings
+ from glob import glob
+ 
+ from fail2ban.setup import updatePyExec
+-
++from fail2ban.version import version
+ 
+ source_dir = os.path.realpath(os.path.dirname(
+ 	# __file__ seems to be overwritten sometimes on some python versions (e.g. bug of 2.6 by running under cProfile, etc.):
+@@ -120,22 +120,12 @@ class install_scripts_f2b(install_script
+ # Wrapper to specify fail2ban own options:
+ class install_command_f2b(install):
+ 	user_options = install.user_options + [
+-		('disable-2to3', None, 'Specify to deactivate 2to3, e.g. if the install runs from fail2ban test-cases.'),
+ 		('without-tests', None, 'without tests files installation'),
+ 	]
+ 	def initialize_options(self):
+-		self.disable_2to3 = None
+ 		self.without_tests = not with_tests
+ 		install.initialize_options(self)
+ 	def finalize_options(self):
+-		global _2to3
+-		## in the test cases 2to3 should be already done (fail2ban-2to3):
+-		if self.disable_2to3:
+-			_2to3 = False
+-		if _2to3:
+-			cmdclass = self.distribution.cmdclass
+-			cmdclass['build_py'] = build_py_2to3
+-			cmdclass['build_scripts'] = build_scripts_2to3
+ 		if self.without_tests:
+ 			self.distribution.scripts.remove('bin/fail2ban-testcases')
+ 
+@@ -186,7 +176,6 @@ commands.'''
+ if setuptools:
+ 	setup_extra = {
+ 		'test_suite': "fail2ban.tests.utils.gatherTests",
+-		'use_2to3': True,
+ 	}
+ else:
+ 	setup_extra = {}
+@@ -210,9 +199,6 @@ if platform_system in ('linux', 'solaris
+ 		('/usr/share/doc/fail2ban', doc_files)
+ 	)
+ 
+-# Get version number, avoiding importing fail2ban.
+-# This is due to tests not functioning for python3 as 2to3 takes place later
+-exec(open(join("fail2ban", "version.py")).read())
+ 
+ setup(
+ 	name = "fail2ban",


### PR DESCRIPTION
Maintainer: Kerma Gérald gandalf@gk2.net / @erdoukki
Run tested: (test done on MVEBU arch53 EspressoBin & EspressoBin-ULTRA, OpenWrt 19.07.x and 21.02.x)
Compile tested: (arch=cortexa53, host=amd64)

Description:

Issue: 2to3 support has been removed in setuptools since version 58.0.0.

Fix: openwrt/packages#17311

Requirements: 2to3/host openwrt/packages#17429

Add upstream patch: https://github.com/fail2ban/fail2ban/commit/196c55e93103d1e56d1336f27a5f2591b4e54fef

To install/build for python3 from source, it is necessary to convert to py3
codebase before setup (invoke 2to3 or ./fail2ban-2to3 firstly).
> ./fail2ban-2to3
> python3 setup.py build

(cherry picked from commit ad0e1a1c3ce871da079779bf9ac706859445f3c5)
Signed-off-by: Kerma Gérald <gandalf@gk2.net>