### PR TITLE
stunnel: update to 5.61

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.60
-PKG_RELEASE:=2
+PKG_VERSION:=5.61
+PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
@@ -23,7 +23,7 @@ PKG_SOURCE_URL:= \
 	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=c45d765b1521861fea9b03b425b9dd7d48b3055128c0aec673bba5ef9b8f787d
+PKG_HASH:=91ea0ca6482d8f7e7d971ee64ab4f86a2817d038a372f0893e28315ef2015d7a
 
 PKG_FIXUP:=autoreconf
 PKG_FIXUP:=patch-libtool

--- a/net/stunnel/files/stunnel.init
+++ b/net/stunnel/files/stunnel.init
@@ -76,7 +76,7 @@ validate_service_options() {
 		'OCSPflag:list(or("NOCASIGN","NOCERTS","NOCHAIN","NOCHECKS","NODELEGATED","NOEXPLICIT","NOINTERN","NOSIGS","NOTIME","NOVERIFY","RESPID_KEY","TRUSTOTHER"))' \
 		'OCSPnonce:bool' \
 		'options:list(string)	' \
-		'protocol:or("cifs","connect","imap","nntp","pgsql","pop3","proxy","smtp","socks")' \
+		'protocol:or("cifs","capwin","capwinctrl","connect","imap","nntp","pgsql","pop3","proxy","smtp","socks")' \
 		'protocolAuthentication:or("basic","login","ntlm","plain")' \
 		'protocolDomain:hostname' \
 		'protocolHost_host:host' \


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, APU3, latest openwrt master
Run tested: x86_64, APU3l, OpenWrt master

Description:
I only started the service to see if the correct version was compiled.
```
root@st-dev-07 / # stunnel
2022.01.10 14:45:04 LOG5[ui]: stunnel 5.61 on x86_64-openwrt-linux-gnu platform
2022.01.10 14:45:04 LOG5[ui]: Compiled/running with OpenSSL 1.1.1m  14 Dec 2021
2022.01.10 14:45:04 LOG5[ui]: Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,OCSP,PSK,SNI
2022.01.10 14:45:04 LOG5[ui]: Reading configuration from file /etc/stunnel/stunnel.conf
2022.01.10 14:45:04 LOG5[ui]: UTF-8 byte order mark not detected
2022.01.10 14:45:04 LOG5[ui]: FIPS mode disabled
2022.01.10 14:45:04 LOG4[ui]: Service [dummy] needs authentication to prevent MITM attacks
2022.01.10 14:45:04 LOG5[ui]: Configuration successful
^C2022.01.10 14:45:08 LOG3[ui]: Received SIGINT; terminating
root@st-dev-07 / #
```

