### PR TITLE
gerbera: fix build on macos

### DIFF
--- a/multimedia/gerbera/Makefile
+++ b/multimedia/gerbera/Makefile
@@ -44,7 +44,7 @@ define Package/gerbera/conffiles
 endef
 
 CMAKE_OPTIONS += \
-	-DCMAKE_LINK_WHAT_YOU_USE=ON \
+	-DCMAKE_LINK_WHAT_YOU_USE=$(if $(CONFIG_HOST_OS_MACOS),OFF,ON) \
 	-DIconv_INCLUDE_DIR=$(ICONV_PREFIX)/include \
 	-DIconv_LIBRARY=$(ICONV_PREFIX)/lib/libiconv.a \
 	-DWITH_MAGIC=ON \


### PR DESCRIPTION
cmake LINK_WHAT_YOU_USE is not supported on macos, disable it if
macos is used to build gerbera package

compiled binary (sha256sum) exactly the same on macos and ubuntu

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: -
Compile tested: (armvirt/64, OpenWrt trunk)
Run tested: not really tested, but build was not changed on linux and it was compared the resulted binary between macos and linux (ubuntu 20.04). the result is the same:

```
sergey@ubnt20:~/openwrt/build_dir/target-aarch64_cortex-a53_musl/gerbera-1.9.1/ipkg-aarch64_cortex-a53/gerbera/usr/bin$ sha256sum *
df399d76e702b63f20f0e89e722d6e906f48d186969e7140650f7728554a37fd  gerbera

sergey@Sergeys-MacBook-Air bin % pwd
/Volumes/OpenWrt2/openwrt7/build_dir/target-aarch64_cortex-a53_musl/gerbera-1.9.1/ipkg-aarch64_cortex-a53/gerbera/usr/bin
sergey@Sergeys-MacBook-Air bin % sha256sum *
df399d76e702b63f20f0e89e722d6e906f48d186969e7140650f7728554a37fd  gerbera
```

Description: see above

CC: @neheb (there is no maintainer, but all commits were done by neheb)
