### PR TITLE
[21.02] wg-installer: fix using symlinks for conf files

### DIFF
--- a/net/wg-installer/Makefile
+++ b/net/wg-installer/Makefile
@@ -50,7 +50,7 @@ endef
 
 define Package/wg-installer-server-hotplug-babeld
 	$(call Package/wg-installer-server)
-	DEPENDS:=wg-installer-server
+	DEPENDS:=wg-installer-server +coreutils-dirname +coreutils-realpath
 endef
 
 define Package/wg-installer-server-hotplug-babeld/install
@@ -60,7 +60,7 @@ endef
 
 define Package/wg-installer-server-hotplug-olsrd
 	$(call Package/wg-installer-server)
-	DEPENDS:=wg-installer-server
+	DEPENDS:=wg-installer-server +coreutils-dirname +coreutils-realpath
 endef
 
 define Package/wg-installer-server-hotplug-olsrd/install

--- a/net/wg-installer/wg-server/hotplug.d/99-mesh-babeld
+++ b/net/wg-installer/wg-server/hotplug.d/99-mesh-babeld
@@ -14,7 +14,7 @@ fi
 if [ "${ACTION}" == "add" ]; then
 	uci add babeld interface
 	uci set babeld.@interface[-1].ifname="${INTERFACE}"
-	uci commit
+	uci -c "$(dirname $(realpath /etc/config/babeld))" commit babeld
 	/etc/init.d/babeld reload
 fi
 
@@ -26,6 +26,6 @@ if [ "${ACTION}" == "remove" ]; then
 		fi
 		i=$((i+1));
 	done
-	uci commit
+	uci -c "$(dirname $(realpath /etc/config/babeld))" commit babeld
 	/etc/init.d/babeld reload
 fi

--- a/net/wg-installer/wg-server/hotplug.d/99-mesh-olsrd
+++ b/net/wg-installer/wg-server/hotplug.d/99-mesh-olsrd
@@ -16,7 +16,7 @@ if [ "${ACTION}" == "add" ]; then
 	uci set olsrd.@Interface[-1].ignore=0
 	uci set olsrd.@Interface[-1].interface="${INTERFACE}"
 	uci set olsrd.@Interface[-1].Mode="ether"
-	uci commit
+	uci -c "$(dirname $(realpath /etc/config/olsrd))" commit olsrd
 	/etc/init.d/olsrd reload
 fi
 
@@ -28,6 +28,6 @@ if [ "${ACTION}" == "remove" ]; then
 		fi
 		i=$((i+1));
 	done
-	uci commit
+	uci -c "$(dirname $(realpath /etc/config/olsrd))" commit olsrd
 	/etc/init.d/olsrd reload
 fi


### PR DESCRIPTION
It is useful to symlink babeld and olsrd to /tmp/ if we frequently write to those config files.

Signed-off-by: Nick Hainke <vincent@systemli.org>
(cherry picked from commit 5e8301d7dc154b27b03dc2c24c111e41bb897293)