### PR TITLE
aria2: session file existence check

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
 PKG_VERSION:=1.36.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/aria2/aria2/releases/download/release-$(PKG_VERSION)/

--- a/net/aria2/files/aria2.init
+++ b/net/aria2/files/aria2.init
@@ -168,15 +168,25 @@ aria2_start() {
 	config_file_tmp="$config_dir/$NAME.conf.tmp"
 	session_file="$config_dir/$NAME.session.$section"
 
-	_make_dir "$config_dir" || {
-		_err "Can't create config dir: $config_dir"
+	# check directory existence before creating it
+	if [ ! -e "$config_dir" ]; then
+		_make_dir "$config_dir" || {
+			_err "Can't create config dir: $config_dir"
+			return 1
+		}
+	fi
+
+	_create_file "$config_file" "$config_file_tmp" || {
+		_err "Can't create files: $config_file, $config_file_tmp"
 		return 1
 	}
 
-	_create_file "$session_file" "$config_file" "$config_file_tmp" || {
-		_err "Can't create files: $session_file, $config_file, $config_file_tmp"
-		return 1
-	}
+	# check session file existence before creating it
+	if [ ! -e "$session_file" ]; then
+	 	_create_file "$session_file"|| { _err "Can't create files: $session_file"; return 1; }
+	elif [ ! -r "$session_file" ] || [ ! -w "$session_file" ]; then
+		_change_file_mode 600 "$session_file"
+	fi
 
 	# create tmp file
 	cat >"$config_file_tmp" <<-EOF


### PR DESCRIPTION
Maintainer: @kuoruan
Compile tested: MT7621,HC5962,R22.1.1
Run tested: MT7621, HC5962, R22.1.1, tests done

Description:
Aria2 session (downloading status) would loss every time aria2 service (re)starts, e.g. mannually restart aria2 service or after device reboot.

This problem is caused by unconditionally
1. directory creation of `$config_dir` in function `aria2_start()`;
2. file creation of `$session_file` by `_create_file()` in function `aria2_start()`.

In this PR, the existence of directory `$config_dir` and `$session_file` is checked before creating new ones. Further, if `$session_file` exists, check read&write permission of it. In this way, the `$session_file` can now survive aria2 service restart and device reboot.

# Verification
Verification of this contribution can be found here coolsnowwolf/packages#350.

Signed-off-by: Shengjiang Quan <qsj287068067@126.com>

