### PR TITLE
iodine: fix build on macos

### DIFF
--- a/net/iodine/Makefile
+++ b/net/iodine/Makefile
@@ -49,6 +49,9 @@ define Package/iodined/description
  iodine server version
 endef
 
+MAKE_FLAGS += \
+	TARGETOS="Linux"
+
 define Build/Configure
 endef
 


### PR DESCRIPTION
redefine TARGETOS=Linux due to OpenWrt is always Linux

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: uwe+openwrt@kleine-koenig.org
Compile tested: (armvirt/64, OpenWrt trunk)
Run tested: not really tested, but build for Linux is not changed and binary checksums on Linux (Ubuntu 20.04) and MacOS are the same:

```
sergey@Sergeys-MacBook-Air ipkg-aarch64_cortex-a53 % pwd
/Volumes/OpenWrt2/openwrt7/build_dir/target-aarch64_cortex-a53_musl/iodine-0.7.0/ipkg-aarch64_cortex-a53
sergey@Sergeys-MacBook-Air ipkg-aarch64_cortex-a53 % find  . -name "iodine*"   -exec sha256sum {} \; 2>&1 | grep -v directory | sort -n
d85ac445abc000555013fb89a8fc9af6b538fa7ec0f04d521bd56e2b052ba944  ./iodined/etc/init.d/iodined
d9670758a6150f69985e2ee3c43d5a2a562f98de4456c08df81d14758e68e021  ./iodined/etc/config/iodined
9c7817b69600c7cb3d7fe2c74adfbca330d5a47079f2e0d0d9c4d1c85d227174  ./iodine/usr/sbin/iodine
9f0f1351be8f0999cefb7ac25c99a860c9dcef9dab9a8e660cd20a03bbfa2ee4  ./iodined/usr/sbin/iodined


sergey@ubnt20:~/openwrt/build_dir/target-aarch64_cortex-a53_musl/iodine-0.7.0/ipkg-aarch64_cortex-a53$ find  . -name "iodine*"   -exec sha256sum {} \; 2>&1 | grep -v directory | sort -n
d85ac445abc000555013fb89a8fc9af6b538fa7ec0f04d521bd56e2b052ba944  ./iodined/etc/init.d/iodined
d9670758a6150f69985e2ee3c43d5a2a562f98de4456c08df81d14758e68e021  ./iodined/etc/config/iodined
9c7817b69600c7cb3d7fe2c74adfbca330d5a47079f2e0d0d9c4d1c85d227174  ./iodine/usr/sbin/iodine
9f0f1351be8f0999cefb7ac25c99a860c9dcef9dab9a8e660cd20a03bbfa2ee4  ./iodined/usr/sbin/iodined
```

Description: see above
