### PR TITLE
micropython,micropython-lib: Update to latest versions

### DIFF
--- a/lang/python/micropython-lib/Makefile
+++ b/lang/python/micropython-lib/Makefile
@@ -8,15 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=micropython-lib
-PKG_VERSION:=1.9.3
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/micropython/micropython-lib/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=66e15380eb109613263beb6825b8eecb9191088270c1a59e8c7d922dd57183c7
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/micropython/micropython-lib.git
+PKG_SOURCE_VERSION:=cdd260f0792d04a1ded99171b4c7a2582b7856b4
+PKG_SOURCE_DATE:=20211112
+PKG_MIRROR_HASH:=fea11185756e746e78cfe66dc4fa33830721cd94d726ac7cf4dde2e0a16d5041
 
-PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
-PKG_LICENSE:=MIT, PSFL
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+PKG_LICENSE:=MIT PSF-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_PARALLEL:=1
@@ -24,28 +25,29 @@ PKG_BUILD_PARALLEL:=1
 include $(INCLUDE_DIR)/package.mk
 
 define Package/micropython-lib
-    SUBMENU:=Python
-    SECTION:=lang
-    CATEGORY:=Languages
-    TITLE:=micropython-lib
-    URL:=https://github.com/micropython/micropython-lib
-    DEPENDS:=+micropython
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=micropython-lib
+  URL:=https://github.com/micropython/micropython-lib
+  DEPENDS:=+micropython
 endef
 
 define Package/micropython-lib/description
-    This package contains micropython-lib, a project to develop a non-monolothic
-    standard library for Micro Python. Note that this is a work in progress and
-    several libraries may be missing, incomplete or buggy.
+  This is a repository of libraries designed to be useful for writing
+  MicroPython applications.
 endef
 
-MAKE_FLAGS:=\
-	PREFIX=$(PKG_BUILD_DIR)/_install_tmp/dist \
-	install
+Build/Compile:=:
 
 define Package/micropython-lib/install
-	$(INSTALL_DIR) $(1)/usr/lib/micropython
-	$(CP) $(PKG_BUILD_DIR)/_install_tmp/dist/* $(1)/usr/lib/micropython
+	for dir in micropython python-ecosys python-stdlib unix-ffi; do \
+		$(INSTALL_DIR) $(1)/usr/lib/micropython/$$$$dir ; \
+		$(CP) $(PKG_BUILD_DIR)/$$$$dir/* $(1)/usr/lib/micropython/$$$$dir/ ; \
+	done
+	$(FIND) $(1)/usr/lib/micropython \
+		-not -type d \( -not -name '*.py' -o -name 'test_*' -o -name 'setup.py' \) -delete
+	$(FIND) $(1)/usr/lib/micropython -mindepth 1 -empty -type d -delete
 endef
 
 $(eval $(call BuildPackage,micropython-lib))
-

--- a/lang/python/micropython/Makefile
+++ b/lang/python/micropython/Makefile
@@ -8,47 +8,95 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=micropython
-PKG_VERSION:=1.9.4
-PKG_RELEASE:=2
+PKG_VERSION:=1.17
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/micropython/micropython/releases/download/v$(PKG_VERSION)
-PKG_HASH:=0db042011bffcbd65362b67eb3cca87eaefa9f2a55b747fa75e922c706b8ce1a
+PKG_HASH:=e322f915cee784de0f8614779cdb88fce175956975b3864e2d1898a53638a2f7
 
-PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_PARALLEL:=1
 
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 
-define Package/micropython
+define Package/micropython/default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  TITLE:=Micro Python
+  TITLE:=MicroPython
   URL:=https://micropython.org
   DEPENDS:=+libffi
+  PROVIDES:=micropython
 endef
 
-define Package/micropython/description
- This package contains Micro Python, a lean and fast implementation of the Python 3.4 programming language
- that is optimised to run on a microcontroller (and low power computers).
+define Package/micropython-mbedtls
+$(call Package/micropython/default)
+  TITLE+= (mbedtls)
+  DEPENDS+= +libmbedtls
+  VARIANT:=mbedtls
+  DEFAULT_VARIANT:=1
 endef
 
+define Package/micropython-nossl
+$(call Package/micropython/default)
+  TITLE+= (nossl)
+  VARIANT:=nossl
+endef
 
-MAKE_FLAGS += -C $(PKG_BUILD_DIR)/ports/unix FROZEN_MPY_DIR=
+define Package/micropython/default/description
+  MicroPython is a lean and efficient implementation of the Python 3
+  programming language that includes a small subset of the Python
+  standard library and is optimised to run on microcontrollers and in
+  constrained environments.
+endef
+
+define Package/micropython-mbedtls/description
+$(call Package/micropython/default/description)
+
+  This version uses the Mbed TLS library.
+endef
+
+define Package/micropython-nossl/description
+$(call Package/micropython/default/description)
+
+  This version is built without TLS and upip.
+endef
+
+MAKE_FLAGS += BUILD_VERBOSE=1
+
+ifneq ($(CONFIG_DEBUG),)
+  MAKE_FLAGS += DEBUG=1
+endif
+
+ifeq ($(BUILD_VARIANT),mbedtls)
+  MAKE_FLAGS += MICROPY_SSL_AXTLS=0 MICROPY_SSL_MBEDTLS=1
+endif
+
+ifeq ($(BUILD_VARIANT),nossl)
+  MAKE_FLAGS += MICROPY_PY_USSL=0 FROZEN_MANIFEST=
+endif
+
+MAKE_PATH = ports/unix
 
 define Build/Compile
-	$(call Build/Compile/Default,axtls)
+	+$(HOST_MAKE_VARS) \
+	$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/mpy-cross \
+		$(HOST_MAKE_FLAGS) BUILD_VERBOSE=1
 	$(call Build/Compile/Default)
-
 endef
 
-define Package/micropython/install
+define Package/micropython/default/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ports/unix/micropython $(1)/usr/bin/micropython
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ports/unix/micropython $(1)/usr/bin/
 endef
 
-$(eval $(call BuildPackage,micropython))
+Package/micropython-mbedtls/install = $(Package/micropython/default/install)
+Package/micropython-nossl/install = $(Package/micropython/default/install)
+
+$(eval $(call BuildPackage,micropython-mbedtls))
+$(eval $(call BuildPackage,micropython-nossl))

--- a/lang/python/micropython/patches/000-Makefile-no-errors.patch
+++ b/lang/python/micropython/patches/000-Makefile-no-errors.patch
@@ -1,11 +1,11 @@
 --- a/ports/unix/Makefile
 +++ b/ports/unix/Makefile
-@@ -21,7 +21,7 @@ INC +=  -I$(TOP)
+@@ -38,7 +38,7 @@ INC +=  -I$(TOP)
  INC += -I$(BUILD)
  
  # compiler settings
 -CWARN = -Wall -Werror
 +CWARN = -Wall
- CWARN += -Wpointer-arith -Wuninitialized
- CFLAGS = $(INC) $(CWARN) -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
+ CWARN += -Wextra -Wno-unused-parameter -Wpointer-arith -Wdouble-promotion -Wfloat-conversion
+ CFLAGS += $(INC) $(CWARN) -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT) -I$(VARIANT_DIR) $(CFLAGS_EXTRA)
  

--- a/lang/python/micropython/patches/020-mpy-cross-fix-flags.patch
+++ b/lang/python/micropython/patches/020-mpy-cross-fix-flags.patch
@@ -1,0 +1,20 @@
+--- a/mpy-cross/Makefile
++++ b/mpy-cross/Makefile
+@@ -19,7 +19,7 @@ INC += -I$(TOP)
+ # compiler settings
+ CWARN = -Wall -Werror
+ CWARN += -Wextra -Wno-unused-parameter -Wpointer-arith
+-CFLAGS = $(INC) $(CWARN) -std=gnu99 $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
++CFLAGS += $(INC) $(CWARN) -std=gnu99 $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
+ CFLAGS += -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables
+ 
+ # Debugging/Optimization
+@@ -42,7 +42,7 @@ else
+ # Use gcc syntax for map file
+ LDFLAGS_ARCH = -Wl,-Map=$@.map,--cref -Wl,--gc-sections
+ endif
+-LDFLAGS = $(LDFLAGS_MOD) $(LDFLAGS_ARCH) -lm $(LDFLAGS_EXTRA)
++LDFLAGS += $(LDFLAGS_MOD) $(LDFLAGS_ARCH) -lm $(LDFLAGS_EXTRA)
+ 
+ # source files
+ SRC_C = \

--- a/lang/python/micropython/patches/030-target-no-darwin.patch
+++ b/lang/python/micropython/patches/030-target-no-darwin.patch
@@ -1,0 +1,11 @@
+--- a/ports/unix/Makefile
++++ b/ports/unix/Makefile
+@@ -26,7 +26,7 @@ QSTR_DEFS = qstrdefsport.h
+ QSTR_GLOBAL_DEPENDENCIES = $(VARIANT_DIR)/mpconfigvariant.h
+ 
+ # OS name, for simple autoconfig
+-UNAME_S := $(shell uname -s)
++UNAME_S := Linux
+ 
+ # include py core make definitions
+ include $(TOP)/py/py.mk

--- a/lang/python/micropython/patches/040-extmod-use-external-mbedtls.patch
+++ b/lang/python/micropython/patches/040-extmod-use-external-mbedtls.patch
@@ -1,0 +1,95 @@
+From 9717338f1917fa5db63fe7c9758639417ab06f61 Mon Sep 17 00:00:00 2001
+From: yangfl <yangfl@users.noreply.github.com>
+Date: Mon, 4 Jan 2021 23:09:41 +0800
+Subject: [PATCH 06/10] extmod: Use system mbedtls
+
+---
+ extmod/extmod.mk | 77 ++----------------------------------------------
+ 1 file changed, 2 insertions(+), 75 deletions(-)
+
+--- a/extmod/extmod.mk
++++ b/extmod/extmod.mk
+@@ -66,81 +66,8 @@ SRC_MOD += $(addprefix $(AXTLS_DIR)/,\
+ 	crypto/sha1.c \
+ 	)
+ else ifeq ($(MICROPY_SSL_MBEDTLS),1)
+-MBEDTLS_DIR = lib/mbedtls
+-CFLAGS_MOD += -DMICROPY_SSL_MBEDTLS=1 -I$(TOP)/$(MBEDTLS_DIR)/include
+-SRC_MOD += $(addprefix $(MBEDTLS_DIR)/library/,\
+-	aes.c \
+-	aesni.c \
+-	arc4.c \
+-	asn1parse.c \
+-	asn1write.c \
+-	base64.c \
+-	bignum.c \
+-	blowfish.c \
+-	camellia.c \
+-	ccm.c \
+-	certs.c \
+-	chacha20.c \
+-	chachapoly.c \
+-	cipher.c \
+-	cipher_wrap.c \
+-	cmac.c \
+-	ctr_drbg.c \
+-	debug.c \
+-	des.c \
+-	dhm.c \
+-	ecdh.c \
+-	ecdsa.c \
+-	ecjpake.c \
+-	ecp.c \
+-	ecp_curves.c \
+-	entropy.c \
+-	entropy_poll.c \
+-	error.c \
+-	gcm.c \
+-	havege.c \
+-	hmac_drbg.c \
+-	md2.c \
+-	md4.c \
+-	md5.c \
+-	md.c \
+-	md_wrap.c \
+-	oid.c \
+-	padlock.c \
+-	pem.c \
+-	pk.c \
+-	pkcs11.c \
+-	pkcs12.c \
+-	pkcs5.c \
+-	pkparse.c \
+-	pk_wrap.c \
+-	pkwrite.c \
+-	platform.c \
+-	platform_util.c \
+-	poly1305.c \
+-	ripemd160.c \
+-	rsa.c \
+-	rsa_internal.c \
+-	sha1.c \
+-	sha256.c \
+-	sha512.c \
+-	ssl_cache.c \
+-	ssl_ciphersuites.c \
+-	ssl_cli.c \
+-	ssl_cookie.c \
+-	ssl_srv.c \
+-	ssl_ticket.c \
+-	ssl_tls.c \
+-	timing.c \
+-	x509.c \
+-	x509_create.c \
+-	x509_crl.c \
+-	x509_crt.c \
+-	x509_csr.c \
+-	x509write_crt.c \
+-	x509write_csr.c \
+-	xtea.c \
+-	)
++CFLAGS_MOD += -DMICROPY_SSL_MBEDTLS=1
++LDFLAGS_MOD += -lmbedx509 -lmbedtls -lmbedcrypto
+ endif
+ endif
+ 


### PR DESCRIPTION
Maintainer: @roger- (past maintainer), me (maintainer to-be)
Compile tested: armvirt-32/armvirt-64/malta-be/x86-generic/x86-64, 2022-01-10 snapshot sdk
Run tested: armvirt-32/armvirt-64/malta-be/x86-generic/x86-64 (qemu), 2022-01-10 snapshot

Description:
* micropython: Update to 1.17, reorganize package

  Previous versions used a bundled version of the axTLS library. The MicroPython project maintains their own [fork][1], as development of the library appears to have stopped (the last release was [version 2.1.5 in 2019][2]).

  This replaces the use of axTLS with two variants, one using mbedTLS and one with no TLS support (and no upip, as it uses the ussl module). The external mbedTLS patch (040-extmod-use-external-mbedtls.patch) comes from [Debian][3].

  This also sets myself as the maintainer.

  [1]: https://github.com/micropython/axtls
  [2]: https://sourceforge.net/projects/axtls/files/
  [3]: https://salsa.debian.org/yangfl-guest/micropython/-/blob/master/debian/patches/0006-extmod-Use-system-mbedtls.patch

  Signed-off-by: Jeffery To <jeffery.to@gmail.com>

* micropython-lib: Update to latest master

  The last tagged release (v1.9.3) was in 2017. This updates the package to the most recent commit of the master branch.

  This also sets myself at the maintainer.

  Signed-off-by: Jeffery To <jeffery.to@gmail.com>