### PR TITLE
mblaze: fix build on macos

### DIFF
--- a/mail/mblaze/Makefile
+++ b/mail/mblaze/Makefile
@@ -29,6 +29,9 @@ define Package/mblaze/description
   and interacting with mail messages which are stored in maildir folders.
 endef
 
+MAKE_FLAGS += \
+	OS="Linux"
+
 define Package/mblaze/install
 	$(INSTALL_DIR) $(1)/usr
 	$(CP) $(PKG_INSTALL_DIR)/usr/local/bin $(1)/usr


### PR DESCRIPTION
redefine OS=Linux due to OpenWrt is always Linux

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Compile tested: (armvirt/64, OpenWrt trunk)
Run tested: not really tested, but build for Linux is not changed and binary checksums on Linux (Ubuntu 20.04) and MacOS are the same.

Description: see above
