### PR TITLE
lynx: fix build on macos

### DIFF
--- a/net/lynx/Makefile
+++ b/net/lynx/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lynx
 PKG_VERSION:=2.8.9rel.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Leonid Esman <leonid.esman@gmail.com>
@@ -41,6 +41,10 @@ endef
 
 # customize as you need
 CONFIGURE_ARGS += --with-zlib --with-ssl \
+		  --with-build-cc="$(HOSTCC)" \
+		  --with-build-cflags="$(HOST_CFLAGS)" \
+		  --with-build-cppflags="$(HOST_CPPFLAGS)" \
+		  --with-build-ldflags="$(HOST_LDFLAGS)" \
 		  --enable-ipv6 \
 		  --with-screen=ncursesw \
 		  --enable-widec \


### PR DESCRIPTION
lynx uses host C-compiler to build internal utility that is used to
generate files required for target build. On MacOS it uses internal
clang with MacOS system headers so host build fails due to MacOS is
not Linux

Forced to use OpenWrt host C compiler using --with-build-*
./configure flags

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @LLE8 
Compile tested: (armvirt/64 OpenWrt trunk)
Run tested: (armvirt/64 OpenWrt trunkn, tests done)

Description: see above
