### PR TITLE
davfs2: add secrets file to conffiles definition

### DIFF
--- a/net/davfs2/Makefile
+++ b/net/davfs2/Makefile
@@ -54,6 +54,7 @@ endef
 
 define Package/davfs2/conffiles
 /etc/davfs2/davfs2.conf
+/etc/davfs2/secrets
 endef
 
 CONFIGURE_ARGS += \


### PR DESCRIPTION
Maintainer: @fededim
Compile tested: bcm53xx
Run tested: bcm53xx

Description:
davfs2 username and password information is typically stored in
/etc/davfs2/secrets. This information should be kept across sysupgrades.

Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>