### PR TITLE
lcdproc: fix build on macos

### DIFF
--- a/utils/lcdproc/Makefile
+++ b/utils/lcdproc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lcdproc
 PKG_VERSION:=0.5.9
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lcdproc/lcdproc/releases/download/v$(PKG_VERSION)/
@@ -108,6 +108,9 @@ $(call Package/lcdproc/Default-description)
 This package contains display drivers with external dependencies:
 $(LCDPROC_OTHER_DRIVERS_TEXT)
 endef
+
+CONFIGURE_VARS += \
+	ac_cv_mtab_file="/etc/mtab"
 
 CONFIGURE_ARGS += \
 	--disable-libX11 \


### PR DESCRIPTION
./configure script detects mtab file and fails build if mtab is not
found on build host. It is not required for OpenWrt build due to
mtab is always /etc/mtab on OpenWrt

MacOS doesn't have mtab file so disable it via ac_cv_mtab_file var

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @haraldg @pprindeville 
Compile tested: (armvirt/64, OpenWrt trunk)

Description: see above
