### PR TITLE
[21.02] wg-installer: allow defining link costs for hotplugs

### DIFF
--- a/net/wg-installer/wg-server/config/wgserver.conf
+++ b/net/wg-installer/wg-server/config/wgserver.conf
@@ -7,3 +7,9 @@ config server
     option wg_pub '/root/wg.pub'
     option wg_tmp_key '1'
     option timeout_handshake '600'
+
+config babeld_hotplug
+    option rxcost '1024'
+
+config olsrd_hotplug
+    option LinkQualityMult 'default 0.1'

--- a/net/wg-installer/wg-server/hotplug.d/99-mesh-babeld
+++ b/net/wg-installer/wg-server/hotplug.d/99-mesh-babeld
@@ -14,6 +14,11 @@ fi
 if [ "${ACTION}" == "add" ]; then
 	uci add babeld interface
 	uci set babeld.@interface[-1].ifname="${INTERFACE}"
+	uci get wgserver.@babeld_hotplug[0].rxcost
+	if [ $? ]; then
+		babeld_rxcost="$(uci get wgserver.@babeld_hotplug[0].rxcost)"
+		uci set babeld.@interface[-1].rxcost="$babeld_rxcost"
+	fi
 	uci -c "$(dirname $(realpath /etc/config/babeld))" commit babeld
 	/etc/init.d/babeld reload
 fi

--- a/net/wg-installer/wg-server/hotplug.d/99-mesh-olsrd
+++ b/net/wg-installer/wg-server/hotplug.d/99-mesh-olsrd
@@ -16,6 +16,11 @@ if [ "${ACTION}" == "add" ]; then
 	uci set olsrd.@Interface[-1].ignore=0
 	uci set olsrd.@Interface[-1].interface="${INTERFACE}"
 	uci set olsrd.@Interface[-1].Mode="ether"
+	uci get wgserver.@olsrd_hotplug[0].LinkQualityMult
+	if [ $? ]; then
+		olsrd_LinkQualityMult="$(uci get wgserver.@olsrd_hotplug[0].LinkQualityMult)"
+		uci set olsrd.@Interface[-1].LinkQualityMult="$olsrd_LinkQualityMult"
+	fi
 	uci -c "$(dirname $(realpath /etc/config/olsrd))" commit olsrd
 	/etc/init.d/olsrd reload
 fi


### PR DESCRIPTION
Add options to set link costs in mesh routing daemons.

Signed-off-by: Nick Hainke <vincent@systemli.org>
(cherry picked from commit ee879d37479cf66f8caf8d4354a0aeae3764f0a8)
