### PR TITLE
samba4: macOS compatibility - incomplete

### DIFF
--- a/net/samba4/patches/105-macos-compatibility.patch
+++ b/net/samba4/patches/105-macos-compatibility.patch
@@ -1,0 +1,11 @@
+--- a/buildtools/wafsamba/samba_cross.py
++++ b/buildtools/wafsamba/samba_cross.py
+@@ -134,7 +134,7 @@ class cross_Popen(Utils.subprocess.Popen
+                 cross_answers_incomplete = True
+                 add_answer(ca_file, msg, ans)
+             (retcode, retstring) = ans
+-            args = ['/bin/sh', '-c', "echo -n '%s'; exit %d" % (retstring, retcode)]
++            args = ['/bin/sh', '-c', "printf '%s'; exit %d" % (retstring, retcode)]
+         real_Popen.__init__(*(obj, args), **kw)
+ 
+ 


### PR DESCRIPTION
On macOS, `/bin/sh -c echo -n` does not support parameters, which results in `-n` being sent to the output:
`Checking uname sysname type : -n Linux`
Resolved by using `printf`.

@Andy2244 @neheb @regae @svlobanov Can you please have a look?
We can safely accept this patch as it is, and resolve the remaining issues in another patch, or discuss and solve the remaining build errors on macOS:
* detection of poptGetContext
* detection of statfs
* possibly other errors
```
Checking for system popt                                                          : yes
Checking for header popt.h                                                        : yes
Checking for library popt                                                         : no
Checking for poptGetContext                                                       : not found
Checking for library popt                                                         : no
Checking for poptGetContext                                                       : not found
ERROR: System library popt of version 0.0.0 not found, and bundling disabled
```
Possible workaround: remove `checkfunctions='poptGetContext'` in `buildtools/wafsamba/samba_third_party.py:15`.

Maintainer: @Andy2244 
Compile tested: fails on host macOS 11.6.2 x64, target x64, OpenWRT master f2c3875dfcbf82d993ebe20f9563125c5fde2c60

https://github.com/openwrt/openwrt/pull/4638#issuecomment-990655125