### PR TITLE
perl-device-serialport: fix build on macos

### DIFF
--- a/lang/perl-device-serialport/Makefile
+++ b/lang/perl-device-serialport/Makefile
@@ -41,7 +41,20 @@ define Build/Configure
 	$(call perlmod/Configure,,)
 endef
 
+MOD_CFLAGS_PERL += $(if $(CONFIG_HOST_OS_MACOS),-I$(PKG_BUILD_DIR)/macos_compat,)
+
 define Build/Compile
+
+ifeq ($(CONFIG_HOST_OS_MACOS),y)
+	#Zeroize macos specific system headers found by ./configure
+	mkdir -p $(PKG_BUILD_DIR)/macos_compat
+	mkdir -p $(PKG_BUILD_DIR)/macos_compat/sys
+	mkdir -p $(PKG_BUILD_DIR)/macos_compat/IOKit
+	mkdir -p $(PKG_BUILD_DIR)/macos_compat/IOKit/serial
+	echo '' > $(PKG_BUILD_DIR)/macos_compat/sys/ttycom.h
+	echo '' > $(PKG_BUILD_DIR)/macos_compat/IOKit/serial/ioss.h
+endif
+
 	$(call perlmod/Compile,,)
 endef
 


### PR DESCRIPTION
./configure script detects macos specific system headers
(IOKit/serial/ioss.h and sys/ttycom.h) that are not available
during compile time. There is no way to pass ac_cv_* vars to
./configure script due to perl wrappers

To fix this issue, fake(empty) headers provided during compile
time if build host is MacOS

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: Paul Oranje <por@xs4all.nl>
Compile tested: (armvirt/64, OpenWrt trunk)

Description: see above
