### PR TITLE
ddns-scripts: pass user agent string

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -745,6 +745,13 @@ do_transfer() {
 		# disable proxy if no set (there might be .wgetrc or .curlrc or wrong environment set)
 		[ -z "$proxy" ] && __PROG="$__PROG --no-proxy"
 
+		# user agent string if provided
+		if [ -n "$user_agent" ]; then
+			# replace single and double quotes
+			user_agent=$(echo $user_agent | sed "s/'/ /g" | sed 's/"/ /g')
+			__PROG="$__PROG --user-agent='$user_agent'"
+		fi
+
 		__RUNPROG="$__PROG '$__URL'"	# build final command
 		__PROG="GNU Wget"		# reuse for error logging
 

--- a/net/ddns-scripts/samples/ddns.config_sample
+++ b/net/ddns-scripts/samples/ddns.config_sample
@@ -221,6 +221,11 @@ config service "myddns"
 #	option ip_source "script"
 #	option ip_script ""
 
+	# This option can be used in combination with ip_source "web" and ip_url.
+	# It adds a given user agent string to the request.
+	# Will only be used when wget or wget-ssl is installed.
+#	option user_agent "Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/95.0"
+
 	###########
 	# force_ipversion option will set the "-4" respectively "-6" parameter
 	# on command line of transfer and DNS lookup program.


### PR DESCRIPTION
This adds a user agent string to the wget request.

Fixes #17507

Signed-off-by: Claudio Marelli <camarelli@gmx.net>