### PR TITLE
Mariadb owner fix & sudo dependency

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -265,7 +265,8 @@ define Package/mariadb-server-base
 	  +KERNEL_IO_URING:liburing \
 	  +liblzma \
 	  +libpcre2 \
-	  +resolveip
+	  +resolveip \
+	  +sudo
   TITLE:=MariaDB database server base
   USERID:=mariadb=376:mariadb=376
 endef

--- a/utils/mariadb/files/mysqld.init
+++ b/utils/mariadb/files/mysqld.init
@@ -152,6 +152,12 @@ start_service() {
 	# Migration from old versions
 	# shellcheck disable=SC2154
  	if [ "$(cat "$datadir"/.version 2> /dev/null)" \!= "$version" ] && [ "$autoupgrade" -gt 0 ]; then
+		# Check for correct owner
+		local owner="$(stat --format %U:%G "$datadir" 2> /dev/null)"
+		if [ -n "$owner" ] && [ "$owner" != "$my_user:$my_group" ]; then
+			chown -Rh "$my_user:$my_group" "$datadir"
+		fi
+
 		# Start upgrade instance without credentials
  		sudo -u "$my_user" mysqld --skip-networking --skip-grant-tables --socket=/tmp/mysql_upgrade.sock &
 		PID="$!"


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu/cortex-a9, OpenWrt 21.02
Run tested: Turris Omnia, mvebu/cortex-a9, OpenWrt 21.02, tested migration of datadir from different user

Description:
This makes sure that if in some previous version of MariaDB or MySQL datadir was owned by somebody else, it will have the owner corrected and the database will successfully start. Also fix dependency on sudo (#17602)

Tested-By: @BKPepe 