### PR TITLE
fix $zone_id empty error

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=21
+PKG_RELEASE:=22
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
@@ -134,7 +134,7 @@ else
 fi
 __PRGBASE="$__PRGBASE --header 'Content-Type: application/json' "
 
-if [ -n "$zone_id"]; then
+if [ -z "$zone_id" ]; then
 	__ZONEID="$zone_id"
 else
 	# read zone id for registered domain.TLD


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
the if statement that judge $zone_id if is blank needs to be reversed