### PR TITLE
softethervpn: fix build on macos

### DIFF
--- a/net/softethervpn/Makefile
+++ b/net/softethervpn/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=softethervpn
 PKG_VERSION:=4.38-9760
 PKG_VERREL:=rtm
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=softether-src-v$(PKG_VERSION)-$(PKG_VERREL).tar.gz
 PKG_SOURCE_URL:=https://github.com/SoftEtherVPN/SoftEtherVPN_Stable/releases/download/v$(PKG_VERSION)-$(PKG_VERREL)
@@ -37,12 +37,15 @@ include $(INCLUDE_DIR)/host-build.mk
 HOST_MAKE_FLAGS += -C $(HOST_BUILD_DIR)
 
 # Select 32 or 64 bit Makefile for host build depending on host architecture
-HOST_MAKE_FLAGS += -f src/makefiles/linux_$(if $(shell uname -m | grep 64),64,32)bit.mak
+HOST_MAKE_FLAGS += \
+	-f src/makefiles/$(if $(CONFIG_HOST_OS_MACOS),macos,linux)_$(if $(shell uname -m | grep 64),64,32)bit.mak
 
 HOST_LDFLAGS += -Wl,-rpath$(comma)$(STAGING_DIR_HOSTPKG)/lib
 # Prevent calling upstream configure
 define Host/Configure
 endef
+
+HOST_CFLAGS += $(if $(CONFIG_HOST_OS_MACOS),-Wno-implicit-function-declaration,)
 
 define Host/Compile
 	# Build hamcorebuilder using host compiler and let it generate

--- a/net/softethervpn/patches/140_allow-to-redefine-ar-and-ranlib.patch
+++ b/net/softethervpn/patches/140_allow-to-redefine-ar-and-ranlib.patch
@@ -1,0 +1,1181 @@
+https://github.com/SoftEtherVPN/SoftEtherVPN_Stable/pull/20
+
+From cb1e3b34c353fe4a8c717b673359a1d1bfcb83af Mon Sep 17 00:00:00 2001
+From: "Sergey V. Lobanov" <sergey@lobanov.in>
+Date: Sat, 15 Jan 2022 02:24:13 +0300
+Subject: [PATCH] allow to redefine ar and ranlib
+
+Makefiles call 'ar r' and 'ranlib' command. It causes issues on
+cross-compilation (e.g. build on macos for linux target)
+
+This patch allows to redifine ar and ranlib using AR and RANLIB
+Makefile variables
+
+This patch is fully backward compatible. Default values for AR=ar
+and RANLIB=ranlib to reproduce current behaviour if these variables
+are not set.
+
+Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>
+---
+ src/makefiles/freebsd_32bit.mak        | 20 ++++++++++++--------
+ src/makefiles/freebsd_32bit_nobits.mak | 20 ++++++++++++--------
+ src/makefiles/freebsd_64bit.mak        | 20 ++++++++++++--------
+ src/makefiles/freebsd_64bit_nobits.mak | 20 ++++++++++++--------
+ src/makefiles/linux_32bit.mak          | 20 ++++++++++++--------
+ src/makefiles/linux_32bit_nobits.mak   | 20 ++++++++++++--------
+ src/makefiles/linux_64bit.mak          | 20 ++++++++++++--------
+ src/makefiles/linux_64bit_nobits.mak   | 20 ++++++++++++--------
+ src/makefiles/macos_32bit.mak          | 20 ++++++++++++--------
+ src/makefiles/macos_32bit_nobits.mak   | 20 ++++++++++++--------
+ src/makefiles/macos_64bit.mak          | 20 ++++++++++++--------
+ src/makefiles/macos_64bit_nobits.mak   | 20 ++++++++++++--------
+ src/makefiles/openbsd_32bit.mak        | 20 ++++++++++++--------
+ src/makefiles/openbsd_32bit_nobits.mak | 20 ++++++++++++--------
+ src/makefiles/openbsd_64bit.mak        | 20 ++++++++++++--------
+ src/makefiles/openbsd_64bit_nobits.mak | 20 ++++++++++++--------
+ src/makefiles/solaris_32bit.mak        | 20 ++++++++++++--------
+ src/makefiles/solaris_32bit_nobits.mak | 20 ++++++++++++--------
+ src/makefiles/solaris_64bit.mak        | 20 ++++++++++++--------
+ src/makefiles/solaris_64bit_nobits.mak | 20 ++++++++++++--------
+ 20 files changed, 240 insertions(+), 160 deletions(-)
+
+--- a/src/makefiles/freebsd_32bit.mak
++++ b/src/makefiles/freebsd_32bit.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_BSD -DBRIDGE_BPF -DNO_VLAN -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -I/usr/local/include -I/usr/include -g -fsigned-char
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -L/usr/local/lib -L/usr/lib -lm -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/freebsd_32bit_nobits.mak
++++ b/src/makefiles/freebsd_32bit_nobits.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_BSD -DBRIDGE_BPF -DNO_VLAN -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -I/usr/local/include -I/usr/include -g -fsigned-char
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -L/usr/local/lib -L/usr/lib -lm -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/freebsd_64bit.mak
++++ b/src/makefiles/freebsd_64bit.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_BSD -DBRIDGE_BPF -DNO_VLAN -DCPU_64 -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -I/usr/local/include -I/usr/include -g -fsigned-char -m64
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -m64 -L/usr/local/lib -L/usr/lib -lm -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/freebsd_64bit_nobits.mak
++++ b/src/makefiles/freebsd_64bit_nobits.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_BSD -DBRIDGE_BPF -DNO_VLAN -DCPU_64 -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -I/usr/local/include -I/usr/include -g -fsigned-char
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -L/usr/local/lib -L/usr/lib -lm -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/linux_32bit.mak
++++ b/src/makefiles/linux_32bit.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_LINUX -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -lm -ldl -lrt -lpthread -lssl -lcrypto -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/linux_32bit_nobits.mak
++++ b/src/makefiles/linux_32bit_nobits.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_LINUX -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -lm -ldl -lrt -lpthread -lssl -lcrypto -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/linux_64bit.mak
++++ b/src/makefiles/linux_64bit.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_LINUX -DCPU_64 -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char -m64
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -m64 -lm -ldl -lrt -lpthread -lssl -lcrypto -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/linux_64bit_nobits.mak
++++ b/src/makefiles/linux_64bit_nobits.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_LINUX -DCPU_64 -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -lm -ldl -lrt -lpthread -lssl -lcrypto -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/macos_32bit.mak
++++ b/src/makefiles/macos_32bit.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_MACOS -DBRIDGE_PCAP -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -lm -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz -lpcap
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/macos_32bit_nobits.mak
++++ b/src/makefiles/macos_32bit_nobits.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_MACOS -DBRIDGE_PCAP -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -lm -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz -lpcap
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/macos_64bit.mak
++++ b/src/makefiles/macos_64bit.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_MACOS -DBRIDGE_PCAP -DCPU_64 -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char -m64
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -m64 -lm -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz -lpcap
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/macos_64bit_nobits.mak
++++ b/src/makefiles/macos_64bit_nobits.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_MACOS -DBRIDGE_PCAP -DCPU_64 -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -lm -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz -lpcap
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/openbsd_32bit.mak
++++ b/src/makefiles/openbsd_32bit.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_BSD -DNO_VLAN -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -I/usr/local/include -g -fsigned-char
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -L/usr/local/lib -lm -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/openbsd_32bit_nobits.mak
++++ b/src/makefiles/openbsd_32bit_nobits.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_BSD -DNO_VLAN -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -I/usr/local/include -g -fsigned-char
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -L/usr/local/lib -lm -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/openbsd_64bit.mak
++++ b/src/makefiles/openbsd_64bit.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_BSD -DNO_VLAN -DCPU_64 -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -I/usr/local/include -g -fsigned-char -m64
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -m64 -L/usr/local/lib -lm -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/openbsd_64bit_nobits.mak
++++ b/src/makefiles/openbsd_64bit_nobits.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_BSD -DNO_VLAN -DCPU_64 -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -I/usr/local/include -g -fsigned-char
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -L/usr/local/lib -lm -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/solaris_32bit.mak
++++ b/src/makefiles/solaris_32bit.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_SOLARIS -DNO_VLAN -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -lm -lrt -lnsl -lsocket -ldl -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/solaris_32bit_nobits.mak
++++ b/src/makefiles/solaris_32bit_nobits.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_SOLARIS -DNO_VLAN -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -lm -lrt -lnsl -lsocket -ldl -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/solaris_64bit.mak
++++ b/src/makefiles/solaris_64bit.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_SOLARIS -DNO_VLAN -DCPU_64 -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char -m64
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -m64 -lm -lrt -lnsl -lsocket -ldl -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2
+--- a/src/makefiles/solaris_64bit_nobits.mak
++++ b/src/makefiles/solaris_64bit_nobits.mak
+@@ -62,6 +62,10 @@
+ 
+ #CC=gcc
+ 
++AR=ar
++RANLIB=ranlib
++
++
+ OPTIONS_COMPILE_DEBUG=-D_DEBUG -DDEBUG -DUNIX -DUNIX_SOLARIS -DNO_VLAN -DCPU_64 -D_REENTRANT -DREENTRANT -D_THREAD_SAFE -D_THREADSAFE -DTHREAD_SAFE -DTHREADSAFE -D_FILE_OFFSET_BITS=64 -I./src/ -I./src/Cedar/ -I./src/Mayaqua/ -g -fsigned-char
+ 
+ OPTIONS_LINK_DEBUG=-g -fsigned-char -lm -lrt -lnsl -lsocket -ldl -lpthread -lssl -lcrypto -liconv -lreadline -lncurses -lz
+@@ -361,8 +365,8 @@ bin/vpnserver/vpnserver: tmp/as/vpnserve
+ 
+ tmp/as/vpnserver.a: tmp/objs/vpnserver.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnserver.a
+-	ar r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
+-	ranlib tmp/as/vpnserver.a
++	$(AR) r tmp/as/vpnserver.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnserver.o
++	$(RANLIB) tmp/as/vpnserver.a
+ 
+ bin/vpnserver/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnserver/hamcore.se2
+@@ -376,8 +380,8 @@ bin/vpnclient/vpnclient: tmp/as/vpnclien
+ 
+ tmp/as/vpnclient.a: tmp/objs/vpnclient.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnclient.a
+-	ar r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
+-	ranlib tmp/as/vpnclient.a
++	$(AR) r tmp/as/vpnclient.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnclient.o
++	$(RANLIB) tmp/as/vpnclient.a
+ 
+ bin/vpnclient/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnclient/hamcore.se2
+@@ -391,8 +395,8 @@ bin/vpnbridge/vpnbridge: tmp/as/vpnbridg
+ 
+ tmp/as/vpnbridge.a: tmp/objs/vpnbridge.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpnbridge.a
+-	ar r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
+-	ranlib tmp/as/vpnbridge.a
++	$(AR) r tmp/as/vpnbridge.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpnbridge.o
++	$(RANLIB) tmp/as/vpnbridge.a
+ 
+ bin/vpnbridge/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpnbridge/hamcore.se2
+@@ -406,8 +410,8 @@ bin/vpncmd/vpncmd: tmp/as/vpncmd.a bin/v
+ 
+ tmp/as/vpncmd.a: tmp/objs/vpncmd.o $(HEADERS_MAYAQUA) $(HEADERS_CEDAR) $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR)
+ 	rm -f tmp/as/vpncmd.a
+-	ar r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
+-	ranlib tmp/as/vpncmd.a
++	$(AR) r tmp/as/vpncmd.a $(OBJECTS_MAYAQUA) $(OBJECTS_CEDAR) tmp/objs/vpncmd.o
++	$(RANLIB) tmp/as/vpncmd.a
+ 
+ bin/vpncmd/hamcore.se2: src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+ 	cp src/bin/BuiltHamcoreFiles/unix/hamcore.se2 bin/vpncmd/hamcore.se2


### PR DESCRIPTION
host-compile fails on macos due to several reasons:
1. host-compile Makefile always selected for linux
2. macos host cc (clang) fails due to implicit-function-declaration
3. ar and ranlib tools are hardcoded in softethervpn Makefiles

All three issues are fixed by this patch

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @fededim 
Compile tested: (armvirt/64, OpenWrt trunk)

PR to upstream: https://github.com/SoftEtherVPN/SoftEtherVPN_Stable/pull/20

Description: see above
