### PR TITLE
crowdsec-firewall-bouncer: fix initd script

### DIFF
--- a/net/crowdsec-firewall-bouncer/Makefile
+++ b/net/crowdsec-firewall-bouncer/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 #
-# Copyright (C) 2021-2022 Gerald Kerma
+# Copyright (C) 2021-2022 Gerald Kerma <gandalf@gk2.net>
 #
 
 include $(TOPDIR)/rules.mk
@@ -24,7 +24,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/cs-firewall-bouncer-$(PKG_VERSION)
 
 CSFB_BUILD_VERSION?=v$(PKG_VERSION)
 CSFB_BUILD_GOVERSION:=$(shell go version | cut -d " " -f3 | sed -E 's/[go]+//g')
-CWD_BUILD_TIMESTAMP:=$(shell date +%F"_"%T)
+CSFB_BUILD_TIMESTAMP:=$(shell date +%F"_"%T)
 CSFB_BUILD_TAG:=openwrt-$(PKG_VERSION)-$(PKG_RELEASE)
 CSFB_VERSION_PKG:=github.com/crowdsecurity/cs-firewall-bouncer/pkg/version
 
@@ -42,7 +42,7 @@ define Package/crowdsec-firewall-bouncer/Default
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Firewall bouncer for Crowdsec
-  URL:=https://github.com/crowdsecurity/crowdsec-firewall-bouncer/
+  URL:=https://github.com/crowdsecurity/cs-firewall-bouncer/
 endef
 
 define Package/crowdsec-firewall-bouncer

--- a/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.initd
+++ b/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.initd
@@ -1,10 +1,10 @@
 #!/bin/sh /etc/rc.common
-# (C) 2021 Gerald Kerma
+# Copyright (C) 2021-2022 Gerald Kerma <gandalf@gk2.net>
 
 START=99
 USE_PROCD=1
 NAME=crowdsec-firewall-bouncer
-PROG=/usr/bin/crowdsec-firewall-bouncer
+PROG=/usr/bin/cs-firewall-bouncer
 CONFIG=/etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
 BACKEND=iptables
 VARCONFIGDIR=/var/etc/crowdsec/bouncers


### PR DESCRIPTION
Maintainer: Gérald Kerma / @erdoukki
Compile tested: (aarch64_cortex-a53, espressoBin, OpenWrt master and 21.02)
Run tested: (aarch64_cortex-a53, espressoBin, OpenWrt 21.02.x and 19.07.x, tests done)

Tests:
installation and upgrade: ok
ban working: ok
service start/restart/stop/status/disable: ok
logging: ok
detection of firewall (iptables+ipset/nftables): ok

OpenWrt Version tested:
21.02.x
19.07.x

Description:
crowdsec rename the binary from crowdsec-firewall-bouncer to cs-firewall-bouncer
the initd need the correct binary name to start the process
the link for github source need also to be fixed (only the information one)
fix the BuildDate
updated copyright

```
root@STARGATE:~# service crowdsec-firewall-bouncer restart
iptables found
nftables is not present
root@STARGATE:~# ps | grep crowd
10051 root      783m S    /usr/bin/crowdsec -c /var/etc/crowdsec/config.yaml
15744 root      694m S    /usr/bin/cs-firewall-bouncer -c /var/etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
15761 root      1228 S    grep crowd
```

```
root@STARGATE:~# cs-firewall-bouncer -V
version: v0.0.21-openwrt-0.0.21-2
BuildDate: 2022-01-15_08:15:14
GoVersion: 1.13.8
```

Signed-off-by: Kerma Gérald <gandalf@gk2.net>