### PR TITLE
crowdsec: update from upstream latest release 1.2.3

### DIFF
--- a/net/crowdsec/Makefile
+++ b/net/crowdsec/Makefile
@@ -1,17 +1,17 @@
 # SPDX-License-Identifier: MIT
 #
-# Copyright (C) 2021-2022 Gerald Kerma
+# Copyright (C) 2021-2022 Gerald Kerma <gandalf@gk2.net>
 #
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crowdsec
-PKG_VERSION:=1.2.2
+PKG_VERSION:=1.2.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/crowdsecurity/crowdsec/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=b815ac4fafa25f0e657b56baaba9a093ef64fbe7336e4bc29208eb47ed1af5e6
+PKG_HASH:=c94163ac2b90864149bd5ced3b77ecb5c9e9a68d3c7a938f23e05ef72da69938
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE

--- a/net/crowdsec/files/crowdsec.initd
+++ b/net/crowdsec/files/crowdsec.initd
@@ -1,5 +1,5 @@
 #!/bin/sh /etc/rc.common
-# (C) 2021 Gerald Kerma
+# Copyright (C) 2021-2022 Gerald Kerma <gandalf@gk2.net>
 
 START=99
 USE_PROCD=1


### PR DESCRIPTION
Maintainer: Gérald Kerma / @erdoukki
Compile tested: (aarch64_cortex-a53, espressoBin, OpenWrt master and 21.02)
Run tested: (aarch64_cortex-a53, espressoBin, OpenWrt 21.02.x and 19.07.x, tests done)

Tests:
installation and upgrade: ok
logging: ok
enroll in webconsole: ok
cscli: ok
service reload/restart/status/disable/enable: ok

OpenWrt Version tested:
21.02.x
19.07.x

Description:
update from latest upstream release 1.2.3
updated copyright

Changes (from 1.2.2):
https://github.com/crowdsecurity/crowdsec/compare/v1.2.2...v1.2.3

Tests:
```
root@STARGATE:~# crowdsec --version
2022/01/15 11:06:46 version: v1.2.2-openwrt-1.2.2-1
2022/01/15 11:06:46 Codename: alphaga
2022/01/15 11:06:46 BuildDate: 2022-01-14_14:21:08
2022/01/15 11:06:46 GoVersion: 
2022/01/15 11:06:46 Constraint_parser: >= 1.0, <= 2.0
2022/01/15 11:06:46 Constraint_scenario: >= 1.0, < 3.0
2022/01/15 11:06:46 Constraint_api: v1
2022/01/15 11:06:46 Constraint_acquis: >= 1.0, < 2.0
```
```
root@STARGATE:~# opkg install /root/crowdsec_1.2.3-2_aarch64_cortex-a53.ipk 
Upgrading crowdsec on root from 1.2.2-1 to 1.2.3-2...
Configuring crowdsec.
local API already registered...
online API already registered...
INFO[15-01-2022 11:07:37 AM] Wrote new 210740 bytes index to /etc/crowdsec/hub/.index.json 
WARN[15-01-2022 11:07:38 AM] crowdsecurity/syslog-logs : overwrite        
WARN[15-01-2022 11:07:38 AM] crowdsecurity/geoip-enrich : overwrite       
WARN[15-01-2022 11:07:38 AM] crowdsecurity/dateparse-enrich : overwrite   
WARN[15-01-2022 11:07:38 AM] crowdsecurity/sshd-logs : overwrite          
WARN[15-01-2022 11:07:39 AM] crowdsecurity/ssh-bf : overwrite             
WARN[15-01-2022 11:07:39 AM] crowdsecurity/ssh-slow-bf : overwrite        
WARN[15-01-2022 11:07:39 AM] crowdsecurity/sshd : overwrite               
WARN[15-01-2022 11:07:39 AM] crowdsecurity/sshd : overwrite               
WARN[15-01-2022 11:07:39 AM] crowdsecurity/linux : overwrite              
INFO[15-01-2022 11:07:39 AM] /etc/crowdsec/collections/sshd.yaml already exists. 
INFO[15-01-2022 11:07:39 AM] /etc/crowdsec/collections/linux.yaml already exists. 
INFO[15-01-2022 11:07:39 AM] Enabled crowdsecurity/linux                  
INFO[15-01-2022 11:07:39 AM] Run 'sudo systemctl reload crowdsec' for the new configuration to be effective. 
WARN[15-01-2022 11:07:39 AM] crowdsecurity/whitelists : overwrite         
INFO[15-01-2022 11:07:39 AM] Enabled crowdsecurity/whitelists             
INFO[15-01-2022 11:07:39 AM] Run 'sudo systemctl reload crowdsec' for the new configuration to be effective. 
INFO[15-01-2022 11:07:40 AM] Upgrading collections                        
INFO[15-01-2022 11:07:40 AM] crowdsecurity/linux : up-to-date             
INFO[15-01-2022 11:07:40 AM] crowdsecurity/sshd : up-to-date              
INFO[15-01-2022 11:07:40 AM] All collections are already up-to-date       
INFO[15-01-2022 11:07:40 AM] Upgrading parsers                            
INFO[15-01-2022 11:07:40 AM] crowdsecurity/geoip-enrich : up-to-date      
INFO[15-01-2022 11:07:40 AM] crowdsecurity/whitelists : up-to-date        
INFO[15-01-2022 11:07:40 AM] crowdsecurity/dateparse-enrich : up-to-date  
INFO[15-01-2022 11:07:40 AM] crowdsecurity/syslog-logs : up-to-date       
INFO[15-01-2022 11:07:40 AM] crowdsecurity/sshd-logs : up-to-date         
INFO[15-01-2022 11:07:40 AM] All parsers are already up-to-date           
INFO[15-01-2022 11:07:40 AM] Upgrading scenarios                          
INFO[15-01-2022 11:07:40 AM] crowdsecurity/ssh-slow-bf : up-to-date       
INFO[15-01-2022 11:07:40 AM] crowdsecurity/ssh-bf : up-to-date            
INFO[15-01-2022 11:07:40 AM] All scenarios are already up-to-date         
INFO[15-01-2022 11:07:40 AM] Upgrading postoverflows                      
INFO[15-01-2022 11:07:40 AM] No postoverflows installed, nothing to upgrade 
uci: Entry not found
Collected errors:
 * resolve_conffiles: Existing conffile /etc/crowdsec/online_api_credentials.yaml is different from the conffile in the new package. The new conffile will be placed at /etc/crowdsec/online_api_credentials.yaml-opkg.
 * resolve_conffiles: Existing conffile /etc/crowdsec/local_api_credentials.yaml is different from the conffile in the new package. The new conffile will be placed at /etc/crowdsec/local_api_credentials.yaml-opkg.
 * resolve_conffiles: Existing conffile /etc/crowdsec/config.yaml is different from the conffile in the new package. The new conffile will be placed at /etc/crowdsec/config.yaml-opkg.
```
```
root@STARGATE:~# crowdsec --version
2022/01/15 11:08:38 version: v1.2.3-openwrt-1.2.3-2
2022/01/15 11:08:38 Codename: alphaga
2022/01/15 11:08:38 BuildDate: 2022-01-15_10:03:09
2022/01/15 11:08:38 GoVersion: 1.13.8
2022/01/15 11:08:38 Constraint_parser: >= 1.0, <= 2.0
2022/01/15 11:08:38 Constraint_scenario: >= 1.0, < 3.0
2022/01/15 11:08:38 Constraint_api: v1
2022/01/15 11:08:38 Constraint_acquis: >= 1.0, < 2.0
```

Signed-off-by: Kerma Gérald <gandalf@gk2.net>