### PR TITLE
ddns-scripts: add dynv6.com prefix

### DIFF
--- a/net/ddns-scripts/files/usr/share/ddns/default/dynv6.com_Prefix
+++ b/net/ddns-scripts/files/usr/share/ddns/default/dynv6.com_Prefix
@@ -1,0 +1,11 @@
+{
+	"name": "dynv6.com - Prefix",
+	"ipv4": {
+		"url": "http://dynv6.com/api/update?hostname=[DOMAIN]&token=[PASSWORD]&ipv4=[IP]",
+		"answer": "updated|unchanged"
+	},
+	"ipv6": {
+		"url": "http://dynv6.com/api/update?hostname=[DOMAIN]&token=[PASSWORD]&ipv6prefix=[IP]",
+		"answer": "updated|unchanged"
+	}
+}


### PR DESCRIPTION
Just update ipv6 prefix for dynv6 domains

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:Just update ipv6 prefix for dynv6 domains
