### PR TITLE
wg-installer: switch to ubus call for olsrd hotplug

### DIFF
--- a/net/wg-installer/wg-server/hotplug.d/99-mesh-olsrd
+++ b/net/wg-installer/wg-server/hotplug.d/99-mesh-olsrd
@@ -12,27 +12,9 @@ if [ "${slicedint}" != "wg_" ]; then
 fi
 
 if [ "${ACTION}" == "add" ]; then
-	uci add olsrd Interface
-	uci set olsrd.@Interface[-1].ignore=0
-	uci set olsrd.@Interface[-1].interface="${INTERFACE}"
-	uci set olsrd.@Interface[-1].Mode="ether"
-	uci get wgserver.@olsrd_hotplug[0].LinkQualityMult
-	if [ $? ]; then
-		olsrd_LinkQualityMult="$(uci get wgserver.@olsrd_hotplug[0].LinkQualityMult)"
-		uci set olsrd.@Interface[-1].LinkQualityMult="$olsrd_LinkQualityMult"
-	fi
-	uci -c "$(dirname $(realpath /etc/config/olsrd))" commit olsrd
-	/etc/init.d/olsrd reload
+	ubus call olsrd add_interface '{"ifname":'\"$INTERFACE\"'}'
 fi
 
 if [ "${ACTION}" == "remove" ]; then
-	i=0
-	while uci get olsrd.@Interface[$i] &> /dev/null ; do
-		if [ "$(uci get olsrd.@Interface[$i].interface)" == "${INTERFACE}" ]; then
-			uci delete olsrd.@Interface[$i]
-		fi
-		i=$((i+1));
-	done
-	uci -c "$(dirname $(realpath /etc/config/olsrd))" commit olsrd
-	/etc/init.d/olsrd reload
+	ubus call olsrd del_interface '{"ifname":'\"$INTERFACE\"'}'
 fi


### PR DESCRIPTION
Use ubus ipc calls to add and remove interfaces.
