### PR TITLE
knxd: bump to new upstream version 0.14.53

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -11,12 +11,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
-PKG_VERSION:=0.14.52
-PKG_RELEASE:=2
+PKG_VERSION:=0.14.53
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/knxd/knxd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=15a3593970f530787ffb70c8bd53db924e61b3b5113fe05382eb2d0b0038859e
+PKG_HASH:=19a84b79e8f94087e4f7845ab21a53ced3d4d128c76efd4d1c3bd0c57b53287b
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/knxd/patches/0100-version.patch
+++ b/net/knxd/patches/0100-version.patch
@@ -7,4 +7,4 @@
 -test -d .git || exit
 -# git describe --tags
 -git log --format=format:%D | perl -ne 'next unless s#.*tag: ##; s#,.*##; next if m#/#; print; exit;'
-+echo -n "0.14.52"
++echo -n "0.14.53"


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>

Maintainer: me
Compile tested: mpc85xx, tl-wdr4900-v1, trunk
Compile tested: ath79, tplink_archer-c7-v4, trunk
Compile tested: ramips, mt7620a, trunk
Run tested: ath79, tp-link Archer C7 v4, trunk

Description:
new upstream release 0.14.53
