### PR TITLE
hwinfo: fix build on macos

### DIFF
--- a/utils/hwinfo/Makefile
+++ b/utils/hwinfo/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hwinfo
 PKG_VERSION:=21.71
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/openSUSE/hwinfo/tar.gz/$(PKG_VERSION)?
@@ -17,9 +17,6 @@ PKG_BUILD_DEPENDS:= hwinfo/host
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 
-# Execute in host build directory
-HOST_MAKE_FLAGS += -C $(HOST_BUILD_DIR)
-
 define Host/Configure
 	# copy uuid.h to another location in host build dir as that's where this package expects it
 	$(INSTALL_DIR) $(STAGING_DIR_HOST)/include/uuid/
@@ -29,7 +26,10 @@ endef
 define Host/Compile
 	# Build using host compiler and let it generate the files we need
 	# CFLAGS, CPPFLAGS & LDFLAGS need to be passed with CC because they are being ingored
-	CC="$(HOSTCC) $(HOST_CFLAGS) $(HOST_CPPFLAGS) $(HOST_LDFLAGS)" $(MAKE) $(HOST_MAKE_FLAGS)
+	CC="$(HOSTCC) $(HOST_CFLAGS) $(HOST_CPPFLAGS) $(HOST_LDFLAGS)" $(MAKE) \
+		-C $(HOST_BUILD_DIR)/src/isdn/cdb
+	CC="$(HOSTCC) $(HOST_CFLAGS) $(HOST_CPPFLAGS) $(HOST_LDFLAGS)" $(MAKE) \
+		-C $(HOST_BUILD_DIR)/src/ids
 endef
 
 define Host/Install

--- a/utils/hwinfo/patches/100_remove_malloc_h_headers_usage.patch
+++ b/utils/hwinfo/patches/100_remove_malloc_h_headers_usage.patch
@@ -1,0 +1,47 @@
+https://github.com/openSUSE/hwinfo/pull/110
+
+From 53d6a80f6645e5986a13a8475a2b114dfb3a9acc Mon Sep 17 00:00:00 2001
+From: "Sergey V. Lobanov" <sergey@lobanov.in>
+Date: Tue, 18 Jan 2022 02:24:25 +0300
+Subject: [PATCH] remove malloc.h headers usage
+
+malloc.h was deprecated many years ago, stdlib.h should be used
+(stdlib.h is already used)
+
+This patch removes malloc.h usage to build host-tools (isdn_cdb,
+mk_isdnhwdb) on systems without malloc.h header
+
+Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>
+---
+ src/isdn/cdb/cdb_read.h    | 1 -
+ src/isdn/cdb/isdn_cdb.c    | 1 -
+ src/isdn/cdb/mk_isdnhwdb.c | 1 -
+ 3 files changed, 3 deletions(-)
+
+--- a/src/isdn/cdb/cdb_read.h
++++ b/src/isdn/cdb/cdb_read.h
+@@ -1,6 +1,5 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+-#include <malloc.h>
+ #include <string.h>
+ #include <time.h>
+ #include "isdn_cdb_def.h"
+--- a/src/isdn/cdb/isdn_cdb.c
++++ b/src/isdn/cdb/isdn_cdb.c
+@@ -1,6 +1,5 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+-#include <malloc.h>
+ #include <string.h>
+ #include <time.h>
+ #include "lex.yy.c"
+--- a/src/isdn/cdb/mk_isdnhwdb.c
++++ b/src/isdn/cdb/mk_isdnhwdb.c
+@@ -1,6 +1,5 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+-#include <malloc.h>
+ #include <string.h>
+ #include <time.h>
+ #include "lex.yy.c"


### PR DESCRIPTION
hwinfo host-compile builds hwinfo entirely that is not really
required. It is required to build only some host tools to
generate ids and isdn related C-code

This patch changes host build to build only required host tools

Added patch to remove malloc.h using as deprecated, not required
and not supported on macos system (stdlib.h has required functions
on Linux and MacOS systems)

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @bobafetthotmail 
Compile tested: (armvirt/64, OpenWrt trunk)
Run tested: (armvirt/64, OpenWrt trunk)

PR to upstream https://github.com/openSUSE/hwinfo/pull/110

Description: see above
