### PR TITLE
lpc21isp: fix build on macos

### DIFF
--- a/devel/lpc21isp/Makefile
+++ b/devel/lpc21isp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lpc21isp
 PKG_VERSION:=197
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_LICENSE:=LGPL-3.0-or-later
 PKG_LICENSE_FILES:=README gpl.txt lgpl-3.0.txt
 
@@ -35,6 +35,9 @@ define Package/lpc21isp/description
 endef
 
 TARGET_CFLAGS += $(if $(CONFIG_USE_GLIBC),-lc -lgcc_eh)
+
+MAKE_FLAGS += \
+	OSTYPE="Linux"
 
 define Package/lpc21isp/install
 		$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
lpc21isp Makefile detects Darwin and defines __APPLE__ that is not
required for cross-compile build for OpenWrt

This patch sets OSTYPE="Linux" due to OpenWrt is always Linux

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @Skeen 
Compile tested: (armvirt/64, OpenWrt trunk)

Description: see above
