### PR TITLE
cryptsetup: update to version 2.4.3

### DIFF
--- a/utils/cryptsetup/Makefile
+++ b/utils/cryptsetup/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cryptsetup
-PKG_VERSION:=2.4.1
+PKG_VERSION:=2.4.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/cryptsetup/v2.4
-PKG_HASH:=a356a727a83a464ade566e95239622a22dbe4e0f482b198fdb04ab0d3a5a9c5f
+PKG_HASH:=fc0df945188172264ec5bf1d0bda08264fadc8a3f856d47eba91f31fe354b507
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: Turris MOX, mvebu/cortexa53, OpenWrt master
Run tested: Turris MOX, mvebu/cortexa53, OpenWrt master

Description:
- Fixes: CVE-2021-4122
- Update to version 2.4.3
  - changelog 2.4.2: https://mirrors.edge.kernel.org/pub/linux/utils/cryptsetup/v2.4/v2.4.2-ReleaseNotes
  - changelog 2.4.3: https://mirrors.edge.kernel.org/pub/linux/utils/cryptsetup/v2.4/v2.4.3-ReleaseNotes
  
 This should be applied to OpenWrt 21.02 as well.