### PR TITLE
ntpd: add option for enabling gpsd

### DIFF
--- a/net/ntpd/Makefile
+++ b/net/ntpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntp
 PKG_VERSION:=4.2.8p15
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/

--- a/net/ntpd/files/ntpd.init
+++ b/net/ntpd/files/ntpd.init
@@ -21,7 +21,7 @@ emit() {
 validate_ntp_section() {
 	uci_load_validate system timeserver "$1" "$2" \
 		'server:list(host)' 'enabled:bool:1' 'enable_server:bool:0' \
-		'interface:list(string)'
+		'interface:list(string)' 'enable_gpsd:bool:0'
 }
 
 start_ntpd_instance() {
@@ -57,6 +57,12 @@ start_ntpd_instance() {
 	emit "\n# No limits for local monitoring"
 	emit "restrict 127.0.0.1"
 	emit "restrict -6 ::1\n"
+
+	if [ "$enable_gpsd" != 0 ]; then
+		emit "\n# GPS"
+		emit "server 127.127.28.0 minpoll 4 prefer"
+		emit "fudge 127.127.28.0 refid GPS\n"
+	fi
 
 	if [ -n "$interface" ]; then
 		local loopback=$(ubus call network.interface dump | jsonfilter -e "@.interface[@.interface='loopback']['device']")


### PR DESCRIPTION
Time synchronization can also be done via gpsd. Until now you have to patch the init.d-file. Add an option that allows using ntpd in combination with gpsd.

Replaces the tutorial:
https://openwrt.org/docs/guide-user/services/ntp/gps

Now it is enough to set:
    option enable_gpsd '1'

Maintainer: @tripolar 
Compile tested: tbd
Run tested: master