### PR TITLE
CI: disable x86/64 due to constant failures

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -47,10 +47,6 @@ jobs:
             target: x86-geode
             runtime_test: true
 
-          - arch: x86_64
-            target: x86-64
-            runtime_test: true
-
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Due to constant build failures of `cryptodev-linux` the SDK should no
longer be used for CI testing.

Disable testing until `cryptodev-linux` is fixed fox x86/64.

Signed-off-by: Paul Spooren <mail@aparcar.org>