### PR TITLE
postfix: fix build on macos

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postfix
 PKG_VERSION:=3.5.8
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \

--- a/mail/postfix/patches/500-crosscompile.patch
+++ b/mail/postfix/patches/500-crosscompile.patch
@@ -5,15 +5,17 @@
  case $# in
   # Officially supported usage.
 - 0) SYSTEM=`(uname -s) 2>/dev/null`
-+ 0) SYSTEM="OpenWRT"
++ 0) SYSTEM="OpenWrt"
      RELEASE=`(uname -r) 2>/dev/null`
      # No ${x%%y} support in Solaris 11 /bin/sh
      RELEASE_MAJOR=`expr "$RELEASE" : '\([0-9]*\)'` || exit 1
-@@ -242,6 +242,15 @@ case "$SYSTEM" in
+@@ -242,6 +242,17 @@ case "$SYSTEM" in
  esac
  
  case "$SYSTEM.$RELEASE" in
-+   OpenWRT*)    SYSTYPE=LINUX$RELEASE_MAJOR
++   OpenWrt*)    SYSTYPE=LINUX5
++		AR="${CC-gcc}-ar"
++		RANLIB="${CC-gcc}-ranlib"
 +		SYSLIBS="$SYSLIBS -ldl"
 +		: ${SHLIB_SUFFIX=.so}
 +		: ${SHLIB_CFLAGS=-fPIC}


### PR DESCRIPTION
macos build fails due to two reasons:
1. using build host ar and ranlib tools
2. using uname -r to get kernel version

First issue is fixed by specifying ar and ranlib from toolchain
Second issue is fixed by specifying kernel release major version=5
Using 'uname -r' from build host for cross-compiling is not a good
idea even for Linux build host

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @Shulyaka 
Compile tested: (armvirt/64, OpenWrt trunk)
Run tested: (armvirt/64, OpenWrt trunk)

Description: see above
