### PR TITLE
[21.02] wg-installer: create wireguard key if it does not exist

### DIFF
--- a/net/wg-installer/Makefile
+++ b/net/wg-installer/Makefile
@@ -22,7 +22,7 @@ define Package/wg-installer-server
 	$(call Package/wg-installer/Default)
 	TITLE+= (server)
 	MENU:=1
-	DEPENDS+=+rpcd +uhttpd +uhttpd-mod-ubus
+	DEPENDS+=+rpcd +uhttpd +uhttpd-mod-ubus +coreutils-dirname
 endef
 
 define Package/wg-installer-server/install
@@ -53,7 +53,7 @@ endef
 
 define Package/wg-installer-server-hotplug-babeld
 	$(call Package/wg-installer-server)
-	DEPENDS:=wg-installer-server +coreutils-dirname +coreutils-realpath
+	DEPENDS:=wg-installer-server +coreutils-realpath
 endef
 
 define Package/wg-installer-server-hotplug-babeld/install
@@ -63,7 +63,7 @@ endef
 
 define Package/wg-installer-server-hotplug-olsrd
 	$(call Package/wg-installer-server)
-	DEPENDS:=wg-installer-server +coreutils-dirname +coreutils-realpath
+	DEPENDS:=wg-installer-server +coreutils-realpath
 endef
 
 define Package/wg-installer-server-hotplug-olsrd/install

--- a/net/wg-installer/wg-server/lib/wg_functions.sh
+++ b/net/wg-installer/wg-server/lib/wg_functions.sh
@@ -75,6 +75,9 @@ wg_register () {
 		gw_key="/tmp/run/wgserver/${ifname}.key"
 		gw_pub="/tmp/run/wgserver/${ifname}.pub"
 		wg genkey | tee "$gw_key" | wg pubkey > "$gw_pub"
+	else
+		[ -d "$(dirname $gw_key)" ] || mkdir -p "$(dirname $gw_key)"
+		[ -f "$gw_key" ] || wg genkey | tee "$gw_key" | wg pubkey > "$gw_pub"
 	fi
 	wg_server_pubkey=$(cat "$gw_pub")
 


### PR DESCRIPTION
Check if the key exists which is given by
    option wg_key '/etc/wgserver/wg.key'

Signed-off-by: Nick Hainke <vincent@systemli.org>
(cherry picked from commit 324fa79d7c8a90e899a81bbb3ae0c5a5a602f88e)

