### PR TITLE
wg-installer: remove unused dependency

### DIFF
--- a/net/wg-installer/Makefile
+++ b/net/wg-installer/Makefile
@@ -67,7 +67,7 @@ endef
 
 define Package/wg-installer-server-hotplug-olsrd
 	$(call Package/wg-installer-server)
-	DEPENDS:=wg-installer-server +coreutils-realpath
+	DEPENDS:=wg-installer-server
 endef
 
 define Package/wg-installer-server-hotplug-olsrd/install


### PR DESCRIPTION
Remove the dependency "coreutils-realpath" from wg-installer-server-hotplug-olsrd.
