### PR TITLE
[21.02] wg-installer: remove unused dependency

### DIFF
--- a/net/wg-installer/Makefile
+++ b/net/wg-installer/Makefile
@@ -63,7 +63,7 @@ endef
 
 define Package/wg-installer-server-hotplug-olsrd
 	$(call Package/wg-installer-server)
-	DEPENDS:=wg-installer-server +coreutils-realpath
+	DEPENDS:=wg-installer-server
 endef
 
 define Package/wg-installer-server-hotplug-olsrd/install


### PR DESCRIPTION
Remove the dependency "coreutils-realpath" from wg-installer-server-hotplug-olsrd.

Signed-off-by: Nick Hainke <vincent@systemli.org>
(cherry picked from commit fab86eb626b677f8329482f427c6837e59fe4597)
