### PR TITLE
libreswan: fix build on macos

### DIFF
--- a/net/libreswan/Makefile
+++ b/net/libreswan/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libreswan
 PKG_VERSION:=4.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.libreswan.org/
@@ -85,6 +85,8 @@ MAKE_FLAGS+= \
     FINALRUNDIR="/var/run/pluto" \
     FINALNSSDIR="/etc/ipsec.d" \
     MODPROBEARGS="-q" \
+    OSDEP=linux \
+    BUILDENV=linux \
     ARCH="$(LINUX_KARCH)" \
 
 define Build/Prepare


### PR DESCRIPTION
libreswan makefile detects macos (darwin) and changes build logic
but OpenWrt is always Linux so it is required to specify linux as
target platfrom

This patch specifies Linux as a target platfrom

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @lucize 
Compile tested: (armvirt/64, OpenWrt trunk)
