### PR TITLE
[21.02] crowdsec-firewall-bouncer: fix name in initd to start the process

### DIFF
--- a/net/crowdsec-firewall-bouncer/Makefile
+++ b/net/crowdsec-firewall-bouncer/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 #
-# Copyright (C) 2021-2022 Gerald Kerma
+# Copyright (C) 2021-2022 Gerald Kerma <gandalf@gk2.net>
 #
 
 include $(TOPDIR)/rules.mk
@@ -24,7 +24,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/cs-firewall-bouncer-$(PKG_VERSION)
 
 CSFB_BUILD_VERSION?=v$(PKG_VERSION)
 CSFB_BUILD_GOVERSION:=$(shell go version | cut -d " " -f3 | sed -E 's/[go]+//g')
-CWD_BUILD_TIMESTAMP:=$(shell date +%F"_"%T)
+CSFB_BUILD_TIMESTAMP:=$(shell date +%F"_"%T)
 CSFB_BUILD_TAG:=openwrt-$(PKG_VERSION)-$(PKG_RELEASE)
 CSFB_VERSION_PKG:=github.com/crowdsecurity/cs-firewall-bouncer/pkg/version
 
@@ -42,7 +42,7 @@ define Package/crowdsec-firewall-bouncer/Default
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Firewall bouncer for Crowdsec
-  URL:=https://github.com/crowdsecurity/crowdsec-firewall-bouncer/
+  URL:=https://github.com/crowdsecurity/cs-firewall-bouncer/
 endef
 
 define Package/crowdsec-firewall-bouncer

--- a/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.initd
+++ b/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.initd
@@ -1,10 +1,10 @@
 #!/bin/sh /etc/rc.common
-# (C) 2021 Gerald Kerma
+# Copyright (C) 2021-2022 Gerald Kerma <gandalf@gk2.net>
 
 START=99
 USE_PROCD=1
 NAME=crowdsec-firewall-bouncer
-PROG=/usr/bin/crowdsec-firewall-bouncer
+PROG=/usr/bin/cs-firewall-bouncer
 CONFIG=/etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
 BACKEND=iptables
 VARCONFIGDIR=/var/etc/crowdsec/bouncers


### PR DESCRIPTION
Maintainer: Gérald Kerma / @erdoukki
Compile tested: (aarch64_cortex-a53, espressoBin, OpenWrt master and 21.02)
Run tested: (aarch64_cortex-a53, espressoBin, OpenWrt 21.02.x, tests done)

Tests: OK

OpenWrt Version tested:
21.02.x

Description:

crowdsec rename the binary from crowdsec-firewall-bouncer to cs-firewall-bouncer
the initd need the correct binary name to start the process
the link for github source need also to be fixed (only the information one)
fix the BuildDate
updated copyright

Signed-off-by: Kerma Gérald <gandalf@gk2.net>
(cherry picked from commit d6b116cb43802048d883a13e2d2e95eea76ad565)