### PR TITLE
tvheadend: disable uriparser

### DIFF
--- a/multimedia/tvheadend/Makefile
+++ b/multimedia/tvheadend/Makefile
@@ -209,6 +209,7 @@ CONFIGURE_ARGS += \
 	--disable-libfdkaac_static \
 	--disable-pcloud_cache \
 	--enable-bundle \
+	--disable-uripaser \
 	--nowerror=unused-variable
 
 ## Transcoding | Remove these from CONFIGURE_ARGS.


### PR DESCRIPTION
Maintainer: @M95D 
Compile tested: OpenWrt master, OpenWrt 21.02 on mvebu/cortex-a9, mvebu/cortex-a53.

Description:
This avoids to add liburiparser as dependency.

Package tvheadend is missing dependencies for the following libraries:
liburiparser.so.1

Taken from: https://gitlab.nic.cz/turris/os/packages/-/commit/8c9d32cc30016e86c575ec96490ed8a98257af27

It would be nice if we can apply it on OpenWrt 21.02 as well.