### PR TITLE
crowdsec-nginx-bouncer: initial package

### DIFF
--- a/net/crowdsec-nginx-bouncer/Makefile
+++ b/net/crowdsec-nginx-bouncer/Makefile
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (C) 2021-2022 Gerald Kerma
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=crowdsec-nginx-bouncer
+PKG_VERSION:=0.0.7
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/crowdsecurity/cs-nginx-bouncer/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=489a269c65ebf477810826f6115a5fd63a3c14b72d5bcc8b4854b24f8c38b329
+PKG_BUILD_DIR:=$(BUILD_DIR)/cs-nginx-bouncer-$(PKG_VERSION)
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Gerald Kerma <gandalf@gk2.net>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/crowdsec-nginx-bouncer
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=nginx bouncer for Crowdsec
+  URL:=https://github.com/crowdsecurity/crowdsec-nginx-bouncer/
+  DEPENDS:=+lua \
+        +lua-cs-bouncer
+endef
+
+define Package/crowdsec-nginx-bouncer/description
+  Crowdsec bouncer is a lua bouncer for nginx.
+
+  New/unknown IP are checked against crowdsec API, and if request
+  should be blocked, a 403 is returned to the user, and put in cache.
+endef
+
+define Build/Compile
+endef
+
+define Package/crowdsec-nginx-bouncer/install
+	$(INSTALL_DIR) $(1)/etc/crowdsec/bouncers
+	$(INSTALL_DATA) \
+	        $(PKG_BUILD_DIR)/config/crowdsec.conf \
+	        $(1)/etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf
+
+	$(INSTALL_DIR) $(1)/etc/nginx/conf.d
+	$(INSTALL_DATA) \
+	        $(PKG_BUILD_DIR)/nginx/crowdsec_nginx.conf \
+	        $(1)/etc/nginx/conf.d/
+
+	$(INSTALL_DIR) $(1)/usr/lib/lua/crowdsec
+	$(INSTALL_DATA) \
+	        $(PKG_BUILD_DIR)/nginx/access.lua \
+	        $(1)/usr/lib/lua/crowdsec/
+
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) \
+		./files/crowdsec-nginx-bouncer.defaults \
+		$(1)/etc/uci-defaults/99_crowdsec-nginx-bouncer
+endef
+
+define Package/crowdsec-nginx-bouncer/conffiles
+/etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf
+endef
+
+$(eval $(call BuildPackage,crowdsec-nginx-bouncer))

--- a/net/crowdsec-nginx-bouncer/files/crowdsec-nginx-bouncer.defaults
+++ b/net/crowdsec-nginx-bouncer/files/crowdsec-nginx-bouncer.defaults
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+CONFIG=/etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf
+## Gen&ConfigApiKey
+if grep -q "{API_KEY}" "$CONFIG"; then
+	SUFFIX=`tr -dc A-Za-z0-9 </dev/urandom | head -c 8`
+	API_KEY=`/usr/bin/cscli bouncers add crowdsec-nginx-bouncer-${SUFFIX} -o raw`
+	sed -i "s,^\(\s*API_KEY\s*=\s*\).*\$,\1$API_KEY," $CONFIG
+else
+	echo API key already registered...
+fi
+
+exit 0

--- a/net/crowdsec-nginx-bouncer/patches/00_debian_crowdsec_nginx_fix.conf
+++ b/net/crowdsec-nginx-bouncer/patches/00_debian_crowdsec_nginx_fix.conf
@@ -1,0 +1,14 @@
+--- a/nginx/crowdsec_nginx.conf
++++ b/nginx/crowdsec_nginx.conf
+@@ -1,4 +1,4 @@
+-lua_package_path '/usr/local/lua/crowdsec/?.lua;;';
++lua_package_path '/usr/lib/lua/crowdsec/?.lua;;';
+ init_by_lua_block { 
+ 	cs = require "CrowdSec"
+ 	local ok, err = cs.init("/etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf", "crowdsec-nginx-bouncer/v0.0.7")
+@@ -9,4 +9,4 @@ init_by_lua_block {
+ 	ngx.log(ngx.ERR, "[Crowdsec] Initialisation done")
+ 	}
+ 
+-access_by_lua_file /usr/local/lua/crowdsec/access.lua;
++access_by_lua_file /usr/lib/lua/crowdsec/access.lua;


### PR DESCRIPTION
Maintainer: Gérald Kerma / @erdoukki
Compile tested: (aarch64_cortex-a53, espressoBin, OpenWrt master and 21.02)
Run tested: (aarch64_cortex-a53, espressoBin, OpenWrt 21.02.x, tests done)

Tests: OK

OpenWrt Version tested:
21.02.x

```
root@STARGATE:~# opkg install crowdsec-nginx-bouncer_0.0.7-0_aarch64_cortex-a53.ipk 
Installing crowdsec-nginx-bouncer (0.0.7-0) to root...
Configuring crowdsec-nginx-bouncer.
root@STARGATE:~# cat /etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf 
API_URL=http://127.0.0.1:8080
API_KEY= 1dcd9261c65116c9977829eacf8f1303
LOG_FILE=/var/log/crowdsec_lua_bouncer.log
LOG_LEVEL=INFO
CACHE_EXPIRATION=1
CACHE_SIZE=1000
```

Requirement lua-cs-bouncer -> https://github.com/openwrt/packages/pull/17667

Description:
  nginx bouncer for Crowdsec
  https://github.com/crowdsecurity/crowdsec-nginx-bouncer

  Crowdsec bouncer is a lua bouncer for nginx.

  New/unknown IP are checked against crowdsec API, and if request
  should be blocked, a 403 is returned to the user, and put in cache.

Signed-off-by: Kerma Gérald <gandalf@gk2.net>