### PR TITLE
jool: remove iptables support and update templates

### DIFF
--- a/net/jool/Makefile
+++ b/net/jool/Makefile
@@ -8,20 +8,25 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=jool
-PKG_VERSION:=4.1.6
+PKG_VERSION:=2022-01-20
 PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/NICMx/Jool/releases/download/v$(PKG_VERSION)
-PKG_HASH:=dccfde88e3b97a7d1c44c53b6541b74873a04f50bb8cfd187eb399d5ae8d2c81
-
-PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=COPYING
 
-PKG_INSTALL:=1
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/NICMx/Jool.git
+PKG_SOURCE_VERSION:=04ef98dd6c7528fc25f68bef304fb74c59cb7083
+PKG_MIRROR_HASH:=f17551f8ab80a75b6d7f4b5d9208013a4a8101298b80ae9adaa2892db30ac385
+
+PKG_BUILD_DIR=$(KERNEL_BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
+
+PKG_FIXUP:=autoreconf
+
+MAKE_PATH:=src/usr
+CONFIGURE_PATH:=src/usr
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -32,12 +37,14 @@ define Build/Compile
 		CROSS_COMPILE="$(TARGET_CROSS)" \
 		M="$(PKG_BUILD_DIR)/src/mod/common" \
 		V="$(V)" \
+		CFLAGS_MODULE=$(NOXTABLES) \
 		modules
 	$(MAKE) -C "$(LINUX_DIR)" \
 		KERNEL_DIR="$(LINUX_DIR)" \
 		ARCH="$(LINUX_KARCH)" \
 		CROSS_COMPILE="$(TARGET_CROSS)" \
 		M="$(PKG_BUILD_DIR)/src/mod/nat64" \
+		CFLAGS_MODULE=$(NOXTABLES) \
 		V="$(V)" \
 		modules
 	$(MAKE) -C "$(LINUX_DIR)" \
@@ -45,9 +52,15 @@ define Build/Compile
 		ARCH="$(LINUX_KARCH)" \
 		CROSS_COMPILE="$(TARGET_CROSS)" \
 		M="$(PKG_BUILD_DIR)/src/mod/siit" \
+		CFLAGS_MODULE=$(NOXTABLES) \
 		V="$(V)" \
 		modules
 	$(call Build/Compile/Default)
+endef
+
+define Build/Configure
+	(cd $(PKG_BUILD_DIR); ./autogen.sh );
+	$(call Build/Configure/Default, --with-xtables=no)
 endef
 
 
@@ -62,72 +75,59 @@ define Package/jool/Default/description
 endef
 
 
-define KernelPackage/jool
-  SECTION:=kernel
-  CATEGORY:=Kernel modules
-  SUBMENU:=Network Support
-  TITLE:=Jool kernel module
-  DEPENDS:= \
-    @IPV6 \
-    +kmod-crypto-md5 \
-    +kmod-nf-conntrack \
-    +kmod-nf-conntrack6 \
-    +kmod-nf-ipt
-  FILES:= \
-    $(PKG_BUILD_DIR)/src/mod/common/jool_common.$(LINUX_KMOD_SUFFIX) \
-    $(PKG_BUILD_DIR)/src/mod/nat64/jool.$(LINUX_KMOD_SUFFIX) \
-    $(PKG_BUILD_DIR)/src/mod/siit/jool_siit.$(LINUX_KMOD_SUFFIX)
-  JOOL_AUTOLOAD:= \
-    jool \
-    jool_siit
-  AUTOLOAD:=$(call AutoLoad,46,jool_common)
-  AUTOLOAD:=$(call AutoLoad,48,$(JOOL_AUTOLOAD))
+define KernelPackage/jool-netfilter
+	SECTION:=kernel
+	CATEGORY:=Kernel modules
+	SUBMENU:=Network Support
+	TITLE:=Jool kernel module
+	DEPENDS:= \
+		@IPV6 \
+		+kmod-crypto-md5 \
+		+kmod-nf-conntrack \
+		+kmod-nf-conntrack6
+	FILES:= \
+		$(PKG_BUILD_DIR)/src/mod/common/jool_common.$(LINUX_KMOD_SUFFIX) \
+		$(PKG_BUILD_DIR)/src/mod/nat64/jool.$(LINUX_KMOD_SUFFIX) \
+		$(PKG_BUILD_DIR)/src/mod/siit/jool_siit.$(LINUX_KMOD_SUFFIX)
+	AUTOLOAD:=$(call AutoLoad,48,$(JOOL_AUTOLOAD))
 endef
 
-define KernelPackage/jool/description
+define KernelPackage/jool-netfilter/description
   $(call Package/jool/Default/description)
 
-  This package provides the kernel module for Jool.
+  This package provides the kernel module for Jool with netfilter API Only.
 endef
 
 
-define Package/jool-tools
+define Package/jool-tools-netfilter
   $(call Package/jool/Default)
   TITLE:=Jool userspace control programs
-  DEPENDS:=+kmod-jool +libnl +libxtables
+  DEPENDS:=+libnl +kmod-jool-netfilter
 endef
 
-define Package/jool-tools/description
+define Package/jool-tools-netfilter/description
   $(call Package/jool/Default/description)
 
   This package provides the userspace control programs for Jool.
 endef
 
-
-CONFIGURE_ARGS += \
-	--disable-shared \
-	--without-bash-completion-dir
-
-CONFIGURE_VARS += \
-	ac_cv_func_memset=yes \
-	ac_cv_func_strcasecmp=yes
-
 JOOL_AUTOLOAD:= \
-	jool_common \
 	jool \
 	jool_siit
 
-define Package/jool-tools/install
-	$(INSTALL_DIR) $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/jool		$(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/joold		$(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/jool_siit	$(1)/usr/bin/
+NOXTABLES:=-DXTABLES_DISABLED
 
-	$(INSTALL_DIR) $(1)/usr/lib/iptables
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/iptables/libxt_JOOL_SIIT.so \
-		$(1)/usr/lib/iptables
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/iptables/libxt_JOOL.so \
-		$(1)/usr/lib/iptables
+define Package/jool-tools-netfilter/conffiles
+/etc/config/jool
+/etc/jool/jool-nat64.conf.json
+/etc/jool/jool-siit.conf.json
+endef
+
+define Package/jool-tools-netfilter/install
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/usr/nat64/jool		$(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/usr/joold/joold		$(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/usr/siit/jool_siit	$(1)/usr/bin/
 
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/jool.config $(1)/etc/config/jool
@@ -136,10 +136,10 @@ define Package/jool-tools/install
 	$(INSTALL_BIN) ./files/jool.init $(1)/etc/init.d/jool
 
 	$(INSTALL_DIR) $(1)/etc/jool
-	$(INSTALL_DATA) ./files/jool-nat64.conf.json $(1)/etc/jool/jool-nat64.conf.json.default
-	$(INSTALL_DATA) ./files/jool-siit.conf.json $(1)/etc/jool/jool-siit.conf.json.default
+	$(INSTALL_CONF) ./files/jool-nat64.conf.json $(1)/etc/jool/jool-nat64.conf.json
+	$(INSTALL_CONF) ./files/jool-siit.conf.json $(1)/etc/jool/jool-siit.conf.json
 	$(INSTALL_DATA) ./files/readme.md $(1)/etc/jool/readme.md
 endef
 
-$(eval $(call KernelPackage,jool))
-$(eval $(call BuildPackage,jool-tools))
+$(eval $(call KernelPackage,jool-netfilter))
+$(eval $(call BuildPackage,jool-tools-netfilter))

--- a/net/jool/files/jool-nat64.conf.json
+++ b/net/jool/files/jool-nat64.conf.json
@@ -1,8 +1,7 @@
 {
 	"comment": "Sample full NAT64 configuration.",
-	"comment": "Configuration details at https://jool.mx/en/usr-flags-global.html",
 
-	"instance": "default",
+	"instance": "instance name",
 	"framework": "netfilter",
 
 	"global": {
@@ -10,32 +9,32 @@
 
 		"manually-enabled": false,
 
-		"zeroize-traffic-class": false,
+		"zeroize-traffic-class": true,
 		"override-tos": false,
-		"tos": 0,
-		"mtu-plateaus": [65535, 32000, 17914, 8166, 4352, 2002, 1492, 1006, 508, 296, 68],
-		"maximum-simultaneous-opens": 10,
+		"tos": 254,
+		"mtu-plateaus": [1, 2, 3, 4, 5, 6],
+		"maximum-simultaneous-opens": 16,
 		"source-icmpv6-errors-better": true,
-		"handle-rst-during-fin-rcv": false,
-		"f-args": 11,
+		"handle-rst-during-fin-rcv": true,
+		"f-args": 10,
 
-		"logging-bib": false,
-		"logging-session": false,
+		"logging-bib": true,
+		"logging-session": true,
 
-		"address-dependent-filtering": false,
-		"drop-icmpv6-info": false,
-		"drop-externally-initiated-tcp": false,
+		"address-dependent-filtering": true,
+		"drop-icmpv6-info": true,
+		"drop-externally-initiated-tcp": true,
 
-		"udp-timeout": "5:00",
-		"tcp-est-timeout": "2:00:00",
-		"tcp-trans-timeout": "4:00",
-		"icmp-timeout": "1:00",
+		"udp-timeout": "1:00:00",
+		"tcp-est-timeout": "10:00:00",
+		"tcp-trans-timeout": "5:00",
+		"icmp-timeout": "5:30",
 
-		"ss-enabled": false,
-		"ss-flush-asap": true,
-		"ss-flush-deadline": 2000,
-		"ss-capacity": 512,
-		"ss-max-payload": 1452
+		"ss-enabled": true,
+		"ss-flush-asap": false,
+		"ss-flush-deadline": 1000,
+		"ss-capacity": 256,
+		"ss-max-payload": 600
 	},
 
 	"pool4": [

--- a/net/jool/files/jool-siit.conf.json
+++ b/net/jool/files/jool-siit.conf.json
@@ -1,6 +1,5 @@
 {
 	"comment": "Sample full SIIT configuration.",
-	"comment": "Configuration details at https://jool.mx/en/usr-flags-global.html",
 
 	"instance": "instance name",
 	"framework": "netfilter",
@@ -8,14 +7,14 @@
 	"global": {
 		"comment": "pool6 and the RFC6791v4 pool belong here, ever since Jool 4.",
 		"pool6": "64:ff9b::/96",
-		"manually-enabled": true,
-		"zeroize-traffic-class": false,
+		"manually-enabled": false,
+		"zeroize-traffic-class": true,
 		"override-tos": false,
-		"tos": 0,
-		"mtu-plateaus": [65535, 32000, 17914, 8166, 4352, 2002, 1492, 1006, 508, 296, 68],
-		"amend-udp-checksum-zero": false,
-		"eam-hairpin-mode": "intrinsic",
-		"randomize-rfc6791-addresses": true,
+		"tos": 254,
+		"mtu-plateaus": [1, 2, 3, 4, 5, 6],
+		"amend-udp-checksum-zero": true,
+		"eam-hairpin-mode": "simple",
+		"randomize-rfc6791-addresses": false,
 		"rfc6791v6-prefix": null,
 		"rfc6791v4-prefix": null
 	},
@@ -39,8 +38,8 @@
 		}
 	],
 
-	"comment": "This comment is relevant to blacklist4 maybe.",
-	"blacklist4": [
+	"comment": "This comment is relevant to denylist4 maybe.",
+	"denylist4": [
 		"198.51.100.0",
 		"198.51.100.2/32",
 		"198.51.100.32/27"

--- a/net/jool/patches/001-libtool-reduce-version.patch
+++ b/net/jool/patches/001-libtool-reduce-version.patch
@@ -1,0 +1,21 @@
+From: Tiago Gaspar <tiagogaspar8@gmail.com>
+Date: Fri, 21 Jan 2022 13:39:30 +0000
+Subject: [PATCH] libtool: Reduce the required version
+
+Current Openwrt's libtool verion is 2.4.2, yet, jool had the requirement
+set to 2.4.6 in source.
+Change that to Openwrt's version.
+
+Signed-off-by: Tiago Gaspar <tiagogaspar8@gmail.com>
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -5,7 +5,7 @@ AC_PREREQ([2.68])
+ AC_INIT([Jool], [4.1.6], [jool@nic.mx])
+ AC_CONFIG_SRCDIR([src/common/xlat.h])
+ AM_INIT_AUTOMAKE([subdir-objects])
+-LT_PREREQ([2.4.6])
++LT_PREREQ([2.4.2])
+ 
+ # Checks for programs.
+ AC_PROG_CC


### PR DESCRIPTION
Compile tested: WRT3200ACM on the latest master
Run tested: WRT3200ACM on the latest master

Description:

This pull request removes iptables backend support from jool and leaves only the netfilter backend support. This means that:
-  iptables and nftables firewall based systems (firewall3 and firewall 4) are supported trough the netfilter instance mode
-  the iptables/xtables mode support is disabled

For more information on the modes and how to use the new netfilter instance checkout https://www.jool.mx/en/intro-jool.html

This move is made out of the commit upstream that sets firewall4 as the default for new default builds and based on the conversation in #16818 and was decided that the netfilter interface is the priority since iptables support will be dropped in the foreseeable future.

While at it update the templates provided.