### PR TITLE
sqm-scripts: Change iptables dependency to iptables-nft

### DIFF
--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -24,8 +24,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/sqm-scripts
   SECTION:=net
   CATEGORY:=Base system
-  DEPENDS:=+tc +kmod-sched-cake +kmod-ifb +iptables \
-	+iptables-mod-ipopt +iptables-mod-conntrack-extra
+  DEPENDS:=+tc +kmod-sched-cake +kmod-ifb +iptables-nft +iptables-mod-ipopt
   TITLE:=SQM Scripts (QoS)
   PKGARCH:=all
 endef


### PR DESCRIPTION
There's only one of the shaper scripts (simple.qos) that uses iptables, and
it only uses it for matching DSCP bits and setting the fwmark. So we should
be fine with just the basic iptables-nft dependency, and this will allow
sqm-scripts to be installed with the new default nft-based firewall.

Maintainer: me 

Looking for testers; I don't have anything that runs snapshots these days...