### PR TITLE
wg-installer: fix multiple namespaces

### DIFF
--- a/net/wg-installer/common/wg.sh
+++ b/net/wg-installer/common/wg.sh
@@ -43,6 +43,7 @@ check_wg_neighbors() {
 }
 
 case $1 in
+next_port|\
 cleanup_wginterfaces)
     "$@"
     exit


### PR DESCRIPTION
Introduce "--netns" to create the wireguard interface in a different namespace.