### PR TITLE
collectd: remove libip4tc dependency

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.12.0
-PKG_RELEASE:=15
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \
@@ -229,7 +229,6 @@ $(call Package/collectd/Default)
   DEPENDS:= +libpthread \
 	  +zlib \
 	  +libltdl \
-	  +libip4tc \
 	  +jshn \
 	  +PACKAGE_collectd-mod-lua:liblua
   MENU:=1


### PR DESCRIPTION
Maintainer: Jo-Philipp Wich <jo@mein.io>, Hannu Nyman <hannu.nyman@iki.fi>
Compile tested: WRT3200ACM
Run tested: WRT3200ACM

Description:

Base collectd doesn't require libip4tc as stated in the collectd git:

* libiptc (optional)
For querying iptables counters
<http://netfilter.org/>

And libip4tc is already added as a dependency in the iptables plugin
because it needs it, so remove this dependency from the default collectd
to make it compatible with the new nftables firewall4 (by not selecting
any iptables components).