### PR TITLE
ddns-scripts: forced updates can now be properly disabled.

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
@@ -156,11 +156,11 @@ trap "trap_handler 15" 15	# SIGTERM	Termination
 #
 # force_interval	force to send an update to your service if no change was detected
 # force_unit		'days' 'hours' 'minutes' !!! force_interval="0" disables all forced updates, unless run_once=""
-#                   Or run_once=-1. This is to maintain backwards compatibility for configurations where run_once is not set.
+#					Or run_once=-1. This is to maintain backwards compatibility for configurations where run_once is not set.
 #
-# run_once          Boolean (1/0). If set to 1, run_once and exit. force_interval is checked for non-sero value 
-#                   Only; if 0, the IP address is not updated if there is no change detected. If force_interval != 0,
-#                   Then an update is sent in any case.
+# run_once          Boolean (1/0). If set to 1, run_once and exit. force_interval is checked for non-sero value
+#					Only; if 0, the IP address is not updated if there is no change detected. If force_interval != 0,
+#					Then an update is sent in any case.
 #
 # retry_interval	if error was detected retry in
 # retry_unit		'days' 'hours' 'minutes' 'seconds'
@@ -203,12 +203,12 @@ ERR_LAST=$?	# save return code - equal 0 if SECTION_ID found
 
 ### backwards compatibility:
 if [ $run_once -lt 0 ] ; then
-    if [ force_interval -eq 0 ] ; then
-        run_once=1
-        force_interval=1
-    else
-        run_once=0
-    fi
+	if [ force_interval -eq 0 ] ; then
+		run_once=1
+		force_interval=1
+	else
+		run_once=0
+	fi
 fi
 
 # url encode username (might be email or something like this)
@@ -368,7 +368,7 @@ while : ; do
 
 	# prepare update
 	# never updated or run-once forced then NEXT_TIME = 0
-	[ $run_once -eq 1 -a $FORCE_SECONDS -ge 1 -o $LAST_TIME -eq 0 ] \
+	[ $FORCE_SECONDS -ge 1 -a ( $run_once -eq 1 -o $LAST_TIME -eq 0 ) ] \
 		&& NEXT_TIME=0 \
 		|| NEXT_TIME=$(( $LAST_TIME + $FORCE_SECONDS ))
 
@@ -380,7 +380,7 @@ while : ; do
 			write_log 7 "Verbose Mode: $VERBOSE - NO UPDATE send"
 		elif [ "$LOCAL_IP" != "$REGISTERED_IP" ]; then
 			write_log 7 "Update needed - L: '$LOCAL_IP' <> R: '$REGISTERED_IP'"
-        elif [ $FORCE_SECONDS -gt 0 ]; then
+		else
 			write_log 7 "Forced Update - L: '$LOCAL_IP' == R: '$REGISTERED_IP'"
 		fi
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
@@ -203,7 +203,7 @@ ERR_LAST=$?	# save return code - equal 0 if SECTION_ID found
 
 ### backwards compatibility:
 if [ $run_once -lt 0 ] ; then
-	if [ force_interval -eq 0 ] ; then
+	if [ $force_interval -eq 0 ] ; then
 		run_once=1
 		force_interval=1
 	else

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
@@ -189,6 +189,7 @@ ERR_LAST=$?	# save return code - equal 0 if SECTION_ID found
 [ -z "$force_dnstcp" ]	  && force_dnstcp=0	# default UDP
 [ -z "$ip_source" ]	  && ip_source="network"
 [ -z "$is_glue" ]	  && is_glue=0		# default the ddns record is not a glue record
+[ -z "$run_once" ]    && run_once=-1    # default -1; needed for backwards compatibility with old configs. See issue #17641 in openwrt/packages github
 [ "$ip_source" = "network" -a -z "$ip_network" -a $use_ipv6 -eq 0 ] && ip_network="wan"  # IPv4: default wan
 [ "$ip_source" = "network" -a -z "$ip_network" -a $use_ipv6 -eq 1 ] && ip_network="wan6" # IPv6: default wan6
 [ "$ip_source" = "web" -a -z "$ip_url" -a $use_ipv6 -eq 0 ] && ip_url="http://checkip.dyndns.com"

--- a/net/ddns-scripts/samples/ddns.config_sample
+++ b/net/ddns-scripts/samples/ddns.config_sample
@@ -271,7 +271,7 @@ config service "myddns"
 	# a network to use for communication.
 	# should use option ip_source "web" (see above)
 	# Needs GNU Wget (with SSL support) or cURL to be installed.
-	# GNU Wget will use IP address and cURL the physical device 
+	# GNU Wget will use IP address and cURL the physical device
 	# of the given network
 	# default: none
 #	option bind_network "wan7"
@@ -295,26 +295,26 @@ config service "myddns"
 	# consult DDNS providers documentation if your DDNS entry might timeout.
 	# accepted unit entry’s: 'minutes' 'hours' 'days'
 	# minimum needs to be greater or equal check interval (see above)
-	# A setting of '0' means a forced update is never sent, if no IP address 
-    # change has been detected. However, always also set run_once (see the 
-    # corresponding setting). If run_once has not been set, force_interval=0 
-    # means a forced update (once) and exit! This is to maintain compatibility 
-    # with old configurations where run_once didn't exist. A configuration with
-    # missing run_once option is deprecated! 	
-    # default 3 days == 72 hours
+	# A setting of '0' means a forced update is never sent, if no IP address
+	# change has been detected. However, always also set run_once (see the
+	# corresponding setting). If run_once has not been set, force_interval=0
+	# means a forced update (once) and exit! This is to maintain compatibility
+	# with old configurations where run_once didn't exist. A configuration with
+	# missing run_once option is deprecated!
+	# default 3 days == 72 hours
 	option force_interval	'72'
 	option force_unit	'hours'
 
 	###########
-    # An option to tell the script to run once only. Also see force_interval;
-    # If force_interval=0, the script will not send any updates in case it detects
-    # the IP address has not been changed since last update. In case force_interval
-    # !=0, the update is forced, verified if the update was accepted by DNS
-	# (retry if not) and the script terminates. This is useful if you want to start 
-    # by your own (i.e. cron).
-    # NOTE: If this option is not set, old behaviour will be enabled to maintain 
-    # compatibility with old configurations.
-	# default: 0 
+	# An option to tell the script to run once only. Also see force_interval;
+	# If force_interval=0, the script will not send any updates in case it detects
+	# the IP address has not been changed since last update. In case force_interval
+	# !=0, the update is forced, verified if the update was accepted by DNS
+	# (retry if not) and the script terminates. This is useful if you want to start
+	# by your own (i.e. cron).
+	# NOTE: If this option is not set, old behaviour will be enabled to maintain
+	# compatibility with old configurations.
+	# default: 0
 	option run_once '0'
 
 	###########

--- a/net/ddns-scripts/samples/ddns.config_sample
+++ b/net/ddns-scripts/samples/ddns.config_sample
@@ -295,12 +295,27 @@ config service "myddns"
 	# consult DDNS providers documentation if your DDNS entry might timeout.
 	# accepted unit entry’s: 'minutes' 'hours' 'days'
 	# minimum needs to be greater or equal check interval (see above)
-	# A special setting of '0' is allowed, which forces the script to run once.
-	# It sends an update, verify if update was accepted by DNS
-	# (retry if not) and finish. Useful if you want to start by your own (i.e. cron)
-	# default 3 days == 72 hours
+	# A setting of '0' means a forced update is never sent, if no IP address 
+    # change has been detected. However, always also set run_once (see the 
+    # corresponding setting). If run_once has not been set, force_interval=0 
+    # means a forced update (once) and exit! This is to maintain compatibility 
+    # with old configurations where run_once didn't exist. A configuration with
+    # missing run_once option is deprecated! 	
+    # default 3 days == 72 hours
 	option force_interval	'72'
 	option force_unit	'hours'
+
+	###########
+    # An option to tell the script to run once only. Also see force_interval;
+    # If force_interval=0, the script will not send any updates in case it detects
+    # the IP address has not been changed since last update. In case force_interval
+    # !=0, the update is forced, verified if the update was accepted by DNS
+	# (retry if not) and the script terminates. This is useful if you want to start 
+    # by your own (i.e. cron).
+    # NOTE: If this option is not set, old behaviour will be enabled to maintain 
+    # compatibility with old configurations.
+	# default: 0 
+	option run_once '0'
 
 	###########
 	# if error happen on detecting, sending or updating the


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: not applicable
Run tested: NONE

Description: As per bug #17641, this pull request actually enables disabling forced updates. The issue is not nsupdate specific but applies to the general scripts (however not all service providers might have gripes with updates when IP address has not been changed).

I haven't tested this yet, and I should before this gets merged. These are the test cases I can think of:

1. Forced updates on, checks done at intervals.
2. Forced updates on, single run only.
3. Forced updates off, checks done at intervals.
4. Forced updates off, single run only.

In the meanwhile I would like to hear if anyone has any objections to this kind of patch or the documentation changes. The code and comments should be self-explanatory.

I've made it so that there is a new run_once configuration, as this is the way I believe this should be fixed to retain all functionality. If it is not set (as it will not be in existing configurations) the old behavior is retained (i.e. always forced updates at intervals, but if forced_interval=0 -> run_once is internally set to 1 and forced_interval=1). This means that users who use their old configuration will not need to do anything.