### PR TITLE
yq: Update to 4.17.2

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.16.2
+PKG_VERSION:=4.17.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=beb0f292d8375cddb82d25f11f5c203073c1d3e2437807450ddcad31758be8aa
+PKG_HASH:=a1bd57ef70e9a8457b977de006d2904fdceae462eb548e8a89de8f1b1b727369
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: ipq807x, rockchip
Run tested: rk3328 nanopi-r2s

Description:
Added XML support
Release note: https://github.com/mikefarah/yq/releases/tag/v4.17.2