### PR TITLE
wg-installer: fix multiple namespaces

### DIFF
--- a/net/wg-installer/common/wg.sh
+++ b/net/wg-installer/common/wg.sh
@@ -43,6 +43,7 @@ check_wg_neighbors() {
 }
 
 case $1 in
+next_port|\
 cleanup_wginterfaces)
     "$@"
     exit


### PR DESCRIPTION
Add flag "--lookup-default-namespace" to signal that wg-installer should look already established wireguard sessions in the default namespace.

Signed-off-by: Nick Hainke <vincent@systemli.org>
(cherry picked from commit 94efdcf02a723fbcdcc6a192e026e0c2f766a158)
