### PR TITLE
node: January 10th 2022 Security Releases

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v14.18.2
+PKG_VERSION:=v14.18.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=3e8a9ce10f8bcd3628eb6dd049f7f03c84ba9219be6f9743e2221154b9cc680b
+PKG_HASH:=783ac443cd343dd6c68d2abcf7e59e7b978a6a428f6a6025f9b84918b769d608
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: head, aarch64, arm, i386, x86_64, mipsel (pistachio)
 Run tested: (qemu 6.1.0) aarch64, arm, i386, x86_64

Description:
Update to v14.18.3

January 10th 2022 Security Releases:
Improper handling of URI Subject Alternative Names (Medium)(CVE-2021-44531)
Certificate Verification Bypass via String Injection (Medium)(CVE-2021-44532)
Incorrect handling of certificate subject and issuer fields (Medium)(CVE-2021-44533)
Prototype pollution via console.table properties (Low)(CVE-2022-21824)

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
