### PR TITLE
tcl: fix build on macos

### DIFF
--- a/lang/tcl/Makefile
+++ b/lang/tcl/Makefile
@@ -23,6 +23,7 @@ PKG_LICENSE:=TCL
 PKG_LICENSE_FILES:=license.terms
 PKG_CPE_ID:=cpe:/a:tcl_tk:tcl_tk
 
+PKG_BUILD_DEPENDS:=HOST_OS_MACOS:fakeuname/host
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
@@ -30,6 +31,10 @@ HOST_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
+
+ifeq ($(CONFIG_HOST_OS_MACOS),y)
+    include ../../utils/fakeuname/fakeuname.mk
+endif
 
 define Package/tcl
   SUBMENU:=Tcl
@@ -52,6 +57,7 @@ endef
 CONFIGURE_PATH := unix
 
 CONFIGURE_VARS += \
+	$(if $(CONFIG_HOST_OS_MACOS),PATH=$(FAKEUNAME_PATH):$(PATH)) \
 	tcl_cv_strtod_unbroken=ok
 
 CONFIGURE_ARGS += \


### PR DESCRIPTION
configure script detects Darwin and uses flags incompatible with
Linux target build.

This patch uses fakeuname tool if host OS is MacOS to avoid Darwin
detection on target build.

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @mistachkin 
Compile tested: (armivirt/64, OpenWrt trunk)
Run tested: (armivirt/64, OpenWrt trunk)

Description: This PR should not be merged until ~~https://github.com/openwrt/openwrt/pull/4993~~ https://github.com/openwrt/packages/pull/17702 is merged
