### PR TITLE
stress-ng: fix build on macos

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -36,6 +36,9 @@ was designed to exercise various physical subsystems of a computer as well as
 the various operating system kernel interfaces.
 endef
 
+MAKE_FLAGS += \
+	KERNEL=Linux
+
 define Package/stress-ng/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/stress-ng $(1)/usr/bin/


### PR DESCRIPTION
This patch adds KERNEL=Linux to MAKE_FLAGS to avod Darwin detection.
If Makefile detects Darwin, it removes -lbsd from build flags, but
this flag is required due to target is always Linux, not bsd-like.

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @commodo 
Compile tested: (armvirt/64, OpenWrt trunk)

Description: see above
