### PR TITLE
tvheadend: fix conffiles section

### DIFF
--- a/multimedia/tvheadend/Makefile
+++ b/multimedia/tvheadend/Makefile
@@ -230,7 +230,7 @@ define Build/Prepare
 		> $(PKG_BUILD_DIR)/debian/changelog
 endef
 
-define Package/conffiles
+define Package/tvheadend/conffiles
 /etc/config/tvheadend
 endef
 


### PR DESCRIPTION
Maintainer: @M95D
Compile and run tested: Turris 1.1, powerpc_8540, OpenWrt 21.02.1

Description:
The previous one was wrong, and it did not work. It could be checked
inside compiled package in control.tar.gz that there was missing
``conffiles`` file with content `/etc/config/tvheadend`

It is also possible to verify that the config is not overwritten on the router
by running ``opkg install tvheadend --force-reinstall``.