### PR TITLE
pdns: update to 4.6.0

### DIFF
--- a/net/pdns/Makefile
+++ b/net/pdns/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns
-PKG_VERSION:=4.5.2
+PKG_VERSION:=4.6.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=93d94a2500b1b3288dde0e76da7c40095382d93f0998d0f15449d1e6fc033641
+PKG_HASH:=b9effb7968a7badbb91eea431c73346482a67592684d84660edd8b7528cc1325
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>
 PKG_LICENCE:=GPL-2.0-only
@@ -178,7 +178,7 @@ CONFIGURE_ARGS+= \
 	--libdir=/usr/lib/powerdns  \
 	--with-dynmodules="$(foreach backend,$(PDNS_BACKENDS),$(if $(CONFIG_PACKAGE_pdns-backend-$(backend)),$(PDNS_BACKEND_$(backend)_LIB),))" \
 	--with-lua="lua" \
-	--with-modules="bind random" \
+	--with-modules="bind" \
 	--with-mysql-lib=$(STAGING_DIR)/usr \
 	--with-mysql-includes=$(STAGING_DIR)/usr \
 	$(if $(CONFIG_PACKAGE_pdns-tools),--enable-tools,) \

--- a/net/pdns/files/pdns.conf-dist
+++ b/net/pdns/files/pdns.conf-dist
@@ -236,6 +236,11 @@
 # domain-metadata-cache-ttl=
 
 #################################
+# edns-cookie-secret	When set, set a server cookie when responding to a query with a Client cookie (in hex)
+#
+# edns-cookie-secret=
+
+#################################
 # edns-subnet-processing	If we should act on EDNS Subnet options
 #
 # edns-subnet-processing=no
@@ -376,6 +381,11 @@
 # max-generate-steps=0
 
 #################################
+# max-include-depth	Maximum number of nested $INCLUDE directives while processing a zone file
+#
+# max-include-depth=20
+
+#################################
 # max-nsec3-iterations	Limit the number of NSEC3 hash iterations
 #
 # max-nsec3-iterations=100
@@ -459,6 +469,16 @@
 # primary	Act as a primary
 #
 # primary=no
+
+#################################
+# proxy-protocol-from	A Proxy Protocol header is only allowed from these subnets, and is mandatory then too.
+#
+# proxy-protocol-from=
+
+#################################
+# proxy-protocol-maximum-size	The maximum size of a proxy protocol payload, including the TLV values
+#
+# proxy-protocol-maximum-size=512
 
 #################################
 # query-cache-ttl	Seconds to store query results in the QueryCache
@@ -644,6 +664,11 @@
 # webserver-allow-from	Webserver/API access is only allowed from these subnets
 #
 # webserver-allow-from=127.0.0.1,::1
+
+#################################
+# webserver-hash-plaintext-credentials	Whether to hash passwords and api keys supplied in plaintext, to prevent keeping the plaintext version in memory at runtime
+#
+# webserver-hash-plaintext-credentials=no
 
 #################################
 # webserver-loglevel	Amount of logging in the webserver (none, normal, detailed)

--- a/net/pdns/patches/100-pdns-disable-pdns.conf-dist.patch
+++ b/net/pdns/patches/100-pdns-disable-pdns.conf-dist.patch
@@ -1,6 +1,6 @@
 --- a/pdns/Makefile.am
 +++ b/pdns/Makefile.am
-@@ -71,7 +71,6 @@ CLEANFILES = \
+@@ -72,7 +72,6 @@ CLEANFILES = \
  	backends/gsql/gsqlbackend.gcda \
  	backends/gsql/gsqlbackend.gcno \
  	backends/gsql/gsqlbackend.gcov \
@@ -8,7 +8,7 @@
  	apidocfiles.h
  
  if !HAVE_API_SWAGGER_JSON
-@@ -105,7 +104,6 @@ apidocfiles.h: api-swagger.yaml api-swag
+@@ -106,7 +105,6 @@ apidocfiles.h: api-swagger.yaml api-swag
  	./incfiles $^ > $@
  
  noinst_SCRIPTS = pdns.init
@@ -16,7 +16,7 @@
  
  sbin_PROGRAMS = pdns_server
  bin_PROGRAMS = \
-@@ -146,7 +144,7 @@ if IXFRDIST
+@@ -147,7 +145,7 @@ if IXFRDIST
  bin_PROGRAMS += \
  	ixfrdist
  
@@ -25,12 +25,12 @@
  	ixfrdist.example.yml
  endif
  
-@@ -1299,9 +1297,6 @@ dnspcap2protobuf_LDADD = \
+@@ -1313,9 +1311,6 @@ dnspcap2protobuf_LDADD = \
  	$(BOOST_PROGRAM_OPTIONS_LIBS) \
  	$(RT_LIBS)
  
 -pdns.conf-dist: pdns_server
--	$(AM_V_GEN)./pdns_server --config=default 2>/dev/null > $@
+-	$(AM_V_GEN)./pdns_server --config=default > $@
 -
  testrunner_SOURCES = \
  	arguments.cc \


### PR DESCRIPTION
* Bump to 4.6.0
* Remove "random" backend as it is gone upstream

Signed-off-by: Peter van Dijk <peter.van.dijk@powerdns.com>

Maintainer: me
Compile tested: github CI
Run tested: amd64 `openwrt/rootfs` Docker image
