### PR TITLE
fakeuname: add package

### DIFF
--- a/utils/fakeuname/Makefile
+++ b/utils/fakeuname/Makefile
@@ -1,0 +1,57 @@
+# Copyright (C) 2022 Sergey V. Lobanov <sergey@lobanov.in>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=fakeuname
+PKG_RELEASE:=$(COMMITCOUNT)
+PKG_LICENSE:=GPL-2.0-or-later
+
+PKG_MAINTAINER:=Sergey V. Lobanov <sergey@lobanov.in>
+
+PKG_HOST_ONLY:=1
+
+define Package/fakeuname
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Fake uname host tool for cross-compile purposes
+  BUILDONLY:=1
+endef
+
+define Package/fakeuname/description
+ Fakeuname is a host tool for cross-compile cross-platform builds
+ if configure or/and build scripts check uname output for target 
+ build and use invalid build flags. This tool should not be used 
+ in normal case if configure/build scripts allow to redefine 
+ required values instead of using uname output
+endef
+
+include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+
+define Host/Configure
+endef
+
+define Host/Compile
+	{ \
+	    cat src/header.py.inc; \
+	    echo machine = \"$(ARCH)\"; \
+	    echo kernel_release = \"$(LINUX_UNAME_VERSION)\"; \
+	    echo kernel_version = \"#0 $(shell date --date=@$(SOURCE_DATE_EPOCH))\"; \
+	    cat src/footer.py.inc; \
+	} > $(HOST_BUILD_DIR)/$(PKG_NAME)
+endef
+
+define Host/Install
+	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/lib/$(PKG_NAME)
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/$(PKG_NAME) $(STAGING_DIR_HOSTPKG)/lib/$(PKG_NAME)/uname
+endef
+
+define Host/Clean
+	rm -rf "$(STAGING_DIR_HOSTPKG)/lib/$(PKG_NAME)"
+endef
+
+$(eval $(call HostBuild))
+$(eval $(call BuildPackage,fakeuname))

--- a/utils/fakeuname/fakeuname.mk
+++ b/utils/fakeuname/fakeuname.mk
@@ -1,0 +1,1 @@
+FAKEUNAME_PATH=$(STAGING_DIR_HOSTPKG)/lib/fakeuname

--- a/utils/fakeuname/src/footer.py.inc
+++ b/utils/fakeuname/src/footer.py.inc
@@ -1,0 +1,20 @@
+
+args_dict = {
+    "-a" : "%s %s %s %s %s %s %s %s" % 
+            (kernel_name, nodename, kernel_release, kernel_version,
+            machine, processor, hardware_platform, operating_system),
+    "-m" : machine,
+    "-n" : nodename,
+    "-r" : kernel_release,
+    "-s" : kernel_name,
+    "-p" : processor,
+    "-v" : kernel_version,
+    "-i" : hardware_platform,
+    "-o" : operating_system,
+}
+
+input_args = sys.argv
+if len(input_args) == 1:
+    input_args = ["-s"]
+
+print(" ".join([args_dict[arg] for arg in input_args if arg in args_dict]))

--- a/utils/fakeuname/src/header.py.inc
+++ b/utils/fakeuname/src/header.py.inc
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# Copyright 2022 Sergey V. Lobanov <sergey@lobanov.in>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import sys
+
+kernel_name="Linux"
+operating_system="GNU/Linux"
+nodename="OpenWrt"
+processor="unknown"
+hardware_platform="unknown"
+


### PR DESCRIPTION
This package provides fakeuname host tool to avoid build platform
detection for invalid configure/build scripts that are not
friendly to cross-platform build.

This fake uname tool returns Linux as OS name and target Linux
version as OS version.

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: me 
Compile tested: host-only tool
Run tested: host-only tool
