### PR TITLE
miniupnpd: declare nftables variant as DEFAULT_VARIANT

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.2.3
-PKG_RELEASE:=2
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -41,7 +41,6 @@ endef
 
 define Package/miniupnpd-iptables
   $(call Package/miniupnpd/Default)
-  CONFLICTS:=miniupnpd-nftables
   DEPENDS+= \
 	+IPV6:ip6tables \
 	+IPV6:libip6tc \
@@ -58,6 +57,8 @@ define Package/miniupnpd-nftables
 	+libnftnl
   TITLE+= (nftables)
   VARIANT:=nftables
+  DEFAULT_VARIANT:=1
+  CONFLICTS:=miniupnpd-iptables
 endef
 
 define Package/miniupnpd/conffiles/Default


### PR DESCRIPTION
Declare the nftables variant as the DEFAULT_VARIANT as nftables firewall4 is the now default in OpenWrt.

Additionally,
 * toggle CONFLICTS placement to avoid circular dependency warning
 * use AUTORELEASE in PKG_RELEASE


Maintainer: nodoby
Compile tested: config logic tested with mediatek/mt7622
Run tested: -

Reference to https://github.com/openwrt/packages/pull/17094#issuecomment-1021624784
