### PR TITLE
isc-dhcp: fix build on macos

### DIFF
--- a/net/isc-dhcp/Makefile
+++ b/net/isc-dhcp/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=isc-dhcp
 UPSTREAM_NAME:=dhcp
 PKG_VERSION:=4.4.1
-PKG_RELEASE:=18
+PKG_RELEASE:=19
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -194,6 +194,7 @@ CONFIGURE_ARGS += \
 	--enable-paranoia		\
 	--disable-dependency-tracking	\
 	--with-randomdev=/dev/urandom \
+	ac_cv_path_AR=$(TARGET_AR) \
 	ac_cv_file__dev_random=yes
 
 ifeq ($(BUILD_VARIANT),ipv4)
@@ -209,6 +210,8 @@ define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR)			\
 		BUILD_CC="$(HOSTCC_NOCACHE)"		\
 		CROSS_CC="$(TARGET_CC)"			\
+		TARGET_AR="$(TARGET_AR)"		\
+		TARGET_RANLIB="$(TARGET_RANLIB)"	\
 		host_alias="$(GNU_TARGET_NAME)"		\
 		target_alias="$(GNU_TARGET_NAME)"	\
 		build_alias="$(GNU_HOST_NAME)"		\
@@ -217,6 +220,8 @@ define Build/Compile
 		DESTDIR="$(PKG_INSTALL_DIR)"		\
 		BUILD_CC="$(HOSTCC_NOCACHE)"		\
 		CROSS_CC="$(TARGET_CC)"			\
+		TARGET_AR="$(TARGET_AR)"		\
+		TARGET_RANLIB="$(TARGET_RANLIB)"	\
 		host_alias="$(GNU_TARGET_NAME)"		\
 		target_alias="$(GNU_TARGET_NAME)"	\
 		build_alias="$(GNU_HOST_NAME)"		\

--- a/net/isc-dhcp/patches/510-bind-CC.patch
+++ b/net/isc-dhcp/patches/510-bind-CC.patch
@@ -5,7 +5,7 @@
  		rm -rf ${cleandirs} ${cleanfiles} ;                     \
  		(cd ${bindsrcdir} &&                                    \
 -                 ./configure ${bindconfig} > ${binddir}/configure.log); \
-+		 export CC=${CROSS_CC} &&                               \
++		 export CC=${CROSS_CC} AR=${TARGET_AR} RANLIB=${TARGET_RANLIB} && \
 +                ./configure ${bindconfig} --disable-atomic             \
 +		 --disable-kqueue --disable-epoll --disable-kqueue      \
 +                --disable-epoll --disable-devpoll --without-openssl    \

--- a/net/isc-dhcp/patches/520-bind-no-catgets.patch
+++ b/net/isc-dhcp/patches/520-bind-no-catgets.patch
@@ -3,7 +3,7 @@
 @@ -57,6 +57,7 @@ bind1:
  		rm -rf ${cleandirs} ${cleanfiles} ;                     \
  		(cd ${bindsrcdir} &&                                    \
- 		 export CC=${CROSS_CC} &&                               \
+ 		 export CC=${CROSS_CC} AR=${TARGET_AR} RANLIB=${TARGET_RANLIB} && \
 +		 ac_cv_func_catgets=no					\
                  ./configure ${bindconfig} --disable-atomic             \
  		 --disable-kqueue --disable-epoll --disable-kqueue      \


### PR DESCRIPTION
isc-dhcp uses system ar tool so build fails on Darwin build host.
Embedded bind lib uses system ar and ranlib tools and fails on Darwin

This patch explicitly specifies ar and ranlib tools for target build

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @pprindeville 
Compile tested: (armvirt/64, OpenWrt trunk)

Description: see above
