### PR TITLE
Coova-chilli: improve init script

### DIFF
--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -132,8 +132,6 @@ define Package/coova-chilli/install
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/chilli.conf $(1)/etc/
 	$(INSTALL_DIR) $(1)/etc/chilli
 	$(CP) $(PKG_INSTALL_DIR)/etc/chilli/* $(1)/etc/chilli/
-	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
-	$(INSTALL_DATA) ./files/chilli.hotplug $(1)/etc/hotplug.d/iface/30-chilli
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/chilli* $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/usr/lib/

--- a/net/coova-chilli/files/chilli.hotplug
+++ b/net/coova-chilli/files/chilli.hotplug
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-[ "$ACTION" == "ifup" ] || exit 0
-
-[ "$INTERFACE" = "wan" ] && {
-	/etc/init.d/chilli restart
-}

--- a/net/coova-chilli/files/chilli.init
+++ b/net/coova-chilli/files/chilli.init
@@ -78,6 +78,9 @@ start_service() {
 }
 
 stop_service() {
+	for undofile in /var/run/chilli.tun*.sh; do
+		sh $undofile >& /dev/null
+	done
 	rm -f /var/run/chilli_*
 }
 

--- a/net/coova-chilli/files/chilli.init
+++ b/net/coova-chilli/files/chilli.init
@@ -52,19 +52,24 @@ start_chilli() {
 	config_get_bool disabled "$1" 'disabled' 0
 	[ $disabled = 1 ] && return
 
-	procd_open_instance "$cfg"
-	procd_set_param command /usr/sbin/chilli
-	procd_set_param file "$chilli_conf"
-	procd_append_param command \
-		--fg \
-		--conf "${base}.conf" \
-		--pidfile "${base}.pid" \
-		--cmdsocket "${base}.sock" \
-		--unixipc "${base}.ipc"
-	procd_set_param respawn
-	procd_set_param stdout 1
-	procd_set_param stderr 1
-	procd_close_instance
+	. /lib/functions/network.sh
+
+	local wanif ipaddr
+	if network_find_wan wanif && network_get_ipaddr ipaddr "$wanif"; then
+		procd_open_instance "$cfg"
+		procd_set_param command /usr/sbin/chilli
+		procd_set_param file "$chilli_conf"
+		procd_append_param command \
+			--fg \
+			--conf "${base}.conf" \
+			--pidfile "${base}.pid" \
+			--cmdsocket "${base}.sock" \
+			--unixipc "${base}.ipc"
+		procd_set_param respawn
+		procd_set_param stdout 1
+		procd_set_param stderr 1
+		procd_close_instance
+	fi
 }
 
 start_service() {

--- a/net/coova-chilli/files/chilli.init
+++ b/net/coova-chilli/files/chilli.init
@@ -6,6 +6,7 @@ USE_PROCD=1
 
 service_triggers() {
 	procd_add_reload_trigger "chilli"
+	procd_add_interface_trigger "interface.*.up" "wan" /etc/init.d/chilli restart
 }
 
 config_cb() {


### PR DESCRIPTION
Maintainer: @neheb 

Description: This series of patches intends to improve the Coova-Chilli init script by:

- postponing service startup until wan becomes available
- executing firewall cleanup at service shutdown
- removing an hotplug trigger that interfered with e.g. disabling the service
- proposing an alternative to said hotplug trigger

These patches are fully independent and can thus be cherry-picked as desired.

HTH