### PR TITLE
samba4: update to 4.14.11; fix AD_DC build

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.14.7
+PKG_VERSION:=4.14.11
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -13,7 +13,7 @@ PKG_SOURCE_URL:= \
 		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
-PKG_HASH:=6f50353f9602aa20245eb18ceb00e7e5ec793df0974aebd5254c38f16d8f1906
+PKG_HASH:=3d9ebbf3280c7cf5eac1b15aeff8857b31151abaec4d2987be015a66c2945d98
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only
@@ -66,7 +66,7 @@ define Package/samba4-libs
 	+PACKAGE_libpam:libpam \
 	+SAMBA4_SERVER_VFS:attr \
 	+SAMBA4_SERVER_AVAHI:libavahi-client \
-	+SAMBA4_SERVER_AD_DC:python3-cryptodome +SAMBA4_SERVER_AD_DC:libopenldap +SAMBA4_SERVER_AD_DC:jansson +SAMBA4_SERVER_AD_DC:libarchive +SAMBA4_SERVER_AD_DC:acl +SAMBA4_SERVER_AD_DC:attr
+	+SAMBA4_SERVER_AD_DC:python3-cryptodome +SAMBA4_SERVER_AD_DC:python3-markdown +SAMBA4_SERVER_AD_DC:python3-dns +SAMBA4_SERVER_AD_DC:libopenldap +SAMBA4_SERVER_AD_DC:jansson +SAMBA4_SERVER_AD_DC:libarchive +SAMBA4_SERVER_AD_DC:acl +SAMBA4_SERVER_AD_DC:attr
 endef
 
 define Package/samba4-server
@@ -259,7 +259,7 @@ ifdef CONFIG_KERNEL_IO_URING
 	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_io_uring,
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_VFS),y)
-	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_fruit,vfs_shadow_copy2,vfs_recycle,vfs_fake_perms,vfs_readonly,vfs_cap,vfs_offline,vfs_crossrename,vfs_catia,vfs_streams_xattr,vfs_xattr_tdb,vfs_default_quota,
+	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_fruit,vfs_shadow_copy2,vfs_recycle,vfs_fake_perms,vfs_readonly,vfs_cap,vfs_offline,vfs_crossrename,vfs_catia,vfs_streams_xattr,vfs_xattr_tdb,vfs_default_quota,vfs_widelinks,
 ifdef CONFIG_PACKAGE_kmod-fs-btrfs
 	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_btrfs,
 endif

--- a/net/samba4/patches/011-samba-4-14-disable-python-module-host-check.patch
+++ b/net/samba4/patches/011-samba-4-14-disable-python-module-host-check.patch
@@ -1,0 +1,15 @@
+--- a/python/wscript
++++ b/python/wscript
+@@ -73,9 +73,9 @@ def configure(conf):
+         for module, package in selftest_pkgs.items():
+             find_third_party_module(conf, module, package)
+ 
+-    if not Options.options.without_ad_dc:
+-        for module, package in ad_dc_pkgs.items():
+-            find_third_party_module(conf, module, package)
++#    if not Options.options.without_ad_dc:
++#       for module, package in ad_dc_pkgs.items():
++#           find_third_party_module(conf, module, package)
+ 
+ 
+ def build(bld):

--- a/net/samba4/patches/101-do-not-check-xsltproc-manpages.patch
+++ b/net/samba4/patches/101-do-not-check-xsltproc-manpages.patch
@@ -4,7 +4,7 @@ Signed-off-by: Bian Naimeng <biannm@cn.fujitsu.com>
 
 --- a/lib/ldb/wscript
 +++ b/lib/ldb/wscript
-@@ -143,7 +143,7 @@ def configure(conf):
+@@ -144,7 +144,7 @@ def configure(conf):
          conf.DEFINE('EXPECTED_SYSTEM_LDB_VERSION_RELEASE', int(v[2]))
  
      if conf.env.standalone_ldb:


### PR DESCRIPTION
Maintainer: me
Compile tested: arm/mvebu (master)
Run tested: arm/qemu (master)

Description:
* update to 4.14.11
* fix AD_DC build
* add vfs_widelinks to defaults
* refresh patches
* fixes: #16697, #17692
* fixes: CVE-2016-2124, CVE-2020-25717, CVE-2020-25718, CVE-2020-25719, CVE-2020-25721, CVE-2020-25722, CVE-2021-3738, CVE-2021-23192