### PR TITLE
frp: improve frp init script

### DIFF
--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -33,6 +33,11 @@ define Package/frp/install
 	$(INSTALL_CONF) ./files/$(2).config $(1)/etc/config/$(2)
 	$(INSTALL_DIR) $(1)/etc/init.d/
 	$(INSTALL_BIN) ./files/$(2).init $(1)/etc/init.d/$(2)
+
+	if [ -r ./files/$(2).uci-defaults ]; then \
+		$(INSTALL_DIR) $(1)/etc/uci-defaults; \
+		$(INSTALL_DATA) ./files/$(2).uci-defaults $(1)/etc/uci-defaults/$(2); \
+	fi
 endef
 
 define Package/frp/template

--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=frp
-PKG_VERSION:=0.38.0
+PKG_VERSION:=0.39.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=8a5e1af0455916ee17e1ad8d8bad32b637e50226d4bc991c0052fef88efc4745
+PKG_HASH:=639ad416587b03751569b0d51c097bcc52727643e0656064843efb5d0b08ba72
 
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/net/frp/files/frpc.init
+++ b/net/frp/files/frpc.init
@@ -37,6 +37,11 @@ config_cb() {
 	fi
 }
 
+service_triggers()
+{
+	procd_add_reload_trigger "$NAME"
+}
+
 start_service() {
 	local init_cfg=" "
 	local conf_file="/var/etc/$NAME.ini"
@@ -71,4 +76,9 @@ start_service() {
 	[ $respawn -eq 1 ] && procd_set_param respawn
 	[ -n "$env" ] && config_list_foreach "$init_cfg" env "procd_append_param env"
 	procd_close_instance
+}
+
+reload_service() {
+	stop
+	start
 }

--- a/net/frp/files/frpc.init
+++ b/net/frp/files/frpc.init
@@ -21,7 +21,9 @@ config_cb() {
 		option_cb() {
 			local option="$1"
 			local value="$2"
-			echo "$option = $value" >> "$conf_file"
+			[ "$option" = "name" ] && \
+			sed -i "s/$CONFIG_SECTION/$value/g" "$conf_file" || \
+			echo "$option = $value" >> "$conf_file";
 		}
 		list_cb() {
 			local name="$1"

--- a/net/frp/files/frpc.uci-defaults
+++ b/net/frp/files/frpc.uci-defaults
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+upgrade() {
+	local section=$1
+	local name
+	[ "$section" != "common" ] || return 0
+	config_get name $section name
+	if [ -z "$name" ]; then
+		uci_set frpc "$section" name "$section"
+		uci_commit frpc
+	fi
+}
+
+config_load frpc
+config_foreach upgrade conf
+
+exit 0

--- a/net/frp/files/frps.init
+++ b/net/frp/files/frps.init
@@ -35,6 +35,11 @@ config_cb() {
 	fi
 }
 
+service_triggers()
+{
+	procd_add_reload_trigger "$NAME"
+}
+
 start_service() {
 	local init_cfg=" "
 	local conf_file="/var/etc/$NAME.ini"
@@ -69,4 +74,9 @@ start_service() {
 	[ $respawn -eq 1 ] && procd_set_param respawn
 	[ -n "$env" ] && config_list_foreach "$init_cfg" env "procd_append_param env"
 	procd_close_instance
+}
+
+reload_service() {
+	stop
+	start
 }


### PR DESCRIPTION
Maintainer: @ysc3839
Run tested: x86_64

Description:
1. Use anonymous sections and extra name option to define the proxy settings.  Some words such as `-` are not allowed in the uci section name.
2. Add `service_trigger` and define the `reload_service` explicitly without which the service will not reload the conf files if it is modified by the LuCI.