### PR TITLE
clamav: update to version 0.104.2

### DIFF
--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=clamav
-PKG_VERSION:=0.104.0
+PKG_VERSION:=0.104.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.clamav.net/downloads/production/
-PKG_HASH:=a079d64cd55d6184510adfe0f341b2f278f7fb1bcc080d28d374298160f19cb2
+PKG_HASH:=3e45e46d9aaeb3a6956ed30376237ab7c4cd9573bc0f5d6fc15c588d30978d9d
 
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr> \
 		Lucian Cristian <lucian.cristian@gmail.com>

--- a/net/clamav/patches/100-cmake-fix-findcurses.patch
+++ b/net/clamav/patches/100-cmake-fix-findcurses.patch
@@ -1,0 +1,22 @@
+From 0f03ec698e67ea3c0f21ba021c922146d5ad07b2 Mon Sep 17 00:00:00 2001
+From: Carlos Velasco <carlos.velasco@nimastelecom.com>
+Date: Thu, 4 Nov 2021 09:11:06 +0100
+Subject: [PATCH] CMake: Fix FindCurses.cmake try packate ncursesw if ncurses
+ not found
+
+Change to pkg_search_module, first try to find ncurses pkg, if not found, then try with ncursesw pkg
+---
+ cmake/FindCURSES.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/cmake/FindCURSES.cmake
++++ b/cmake/FindCURSES.cmake
+@@ -43,7 +43,7 @@ The following cache variables may also b
+ 
+ find_package(PkgConfig QUIET)
+ # First try for NCurses
+-pkg_check_modules(PC_NCurses QUIET ncurses)
++pkg_search_module (PC_NCurses QUIET ncurses ncursesw)
+ 
+ find_path(NCURSES_INCLUDE_DIR
+   NAMES ncurses.h


### PR DESCRIPTION
Maintainer: @lucize
Compile and run tested: Turris Omnia, mvebu/cortex-a9, OpenWrt 21.02.1

Description:

- Updates to version 0.104.2
  - changelog 0.104.1: https://blog.clamav.net/2021/11/clamav-01034-and-01041-patch-releases.html
  - changelog 0.104.2: https://blog.clamav.net/2022/01/clamav-01035-and-01042-security-patch.html

- Backported upstream pending pull request (https://github.com/Cisco-Talos/clamav/pull/355) to fix following error:

CMake Error at /foo/staging_dir/host/share/cmake-3.19/Modules/FindPackageHandleStandardArgs.cmake:218 (message):
  Could NOT find CURSES (missing: CURSES_LIBRARY)
