### PR TITLE
prosody: update to version 0.11.13

### DIFF
--- a/net/prosody/Makefile
+++ b/net/prosody/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prosody
-PKG_VERSION:=0.11.7
+PKG_VERSION:=0.11.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://prosody.im/downloads/source
-PKG_HASH:=28ffc07653485cb63e22b387d3ea4825ee2baaee0c5827de4d6053a35b1c8747
+PKG_HASH:=39c61b346a09b5125b604cb969e14206cbbcb86c81156ffc6ba2d62527cf0432
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=MIT/X11


### PR DESCRIPTION
Maintainer: @heil
Compile and run tested: Turris Omnia, mvebu/cortex-a9, OpenWrt 21.02.1

Description:
Fixes CVEs:
- CVE-2022-0217
- CVE-2021-37601
- CVE-2021-32918
- CVE-2021-32920
- CVE-2021-32921
- CVE-2021-32917
- CVE-2021-32919

This one should be applied to OpenWrt 21.02 and also to OpenWrt 19.07 (if it works there)
