### PR TITLE
tvheadend: fix build on macos

### DIFF
--- a/multimedia/tvheadend/Makefile
+++ b/multimedia/tvheadend/Makefile
@@ -187,7 +187,17 @@ endif
 ##	CONFIGURE_ARGS += --disable-libopus
 ##endif
 
+#required to cross-compile hdhomerun on non-Linux build host
+MAKE_FLAGS += \
+	OS=Linux
+
+#required to always have "build.linux" dir, not "build.darwin" on macos
+CONFIGURE_VARS += \
+	PLATFORM=linux
+
+#--platfrom=linux is required to cross-compile tvheadend on non-Linux build host
 CONFIGURE_ARGS += \
+	--platform=linux \
 	--arch=$(ARCH) \
 	--disable-libsystemd_daemon \
 	--disable-dbus_1 \


### PR DESCRIPTION
tvheadend configure/make files detect Darwin build host and changes
build logic, but it fails compilation for OpenWrt target (Linux)

This patch explicitly specifies Linux as a target platfrom

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @M95D 
Compile tested: (armvirt/64, OpenWrt trunk edb41fea66ce3e6b7bec6edac5275706106f5380)

Description: see above
