### PR TITLE
sane-backends: fix build on macos

### DIFF
--- a/utils/sane-backends/Makefile
+++ b/utils/sane-backends/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sane-backends
 PKG_VERSION:=1.0.32
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://gitlab.com/sane-project/backends/uploads/104f09c07d35519cc8e72e604f11643f
@@ -238,7 +238,7 @@ define Package/sane-frontends/install
 endef
 
 define Package/sane-backends-all/install
-	/bin/true
+	true
 endef
 
 define Build/InstallDev


### PR DESCRIPTION
MacOS does not have /bin/true, but OpenWrt Makefile uses it so
build fails on macos

This patch removes absolute path (replaces /bin/true to true)

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @luizluca 
Compile tested: (armvirt/64, OpenWrt trunk edb41fea66ce3e6b7bec6edac5275706106f5380)

Description: see above
