### PR TITLE
radsecproxy: fix compilation with newer GCC

### DIFF
--- a/net/radsecproxy/Makefile
+++ b/net/radsecproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radsecproxy
 PKG_VERSION:=1.9.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/radsecproxy/radsecproxy/releases/download/$(PKG_VERSION)/

--- a/net/radsecproxy/patches/300-uninit.patch
+++ b/net/radsecproxy/patches/300-uninit.patch
@@ -1,0 +1,11 @@
+--- a/gconfig.c
++++ b/gconfig.c
+@@ -119,7 +119,7 @@ FILE *pushgconfpaths(struct gconffile **
+     int i;
+     FILE *f = NULL;
+     glob_t globbuf;
+-    char *path, *curfile = NULL, *dir;
++    char *path = NULL, *curfile = NULL, *dir;
+ 
+     /* if cfgpath is relative, make it relative to current config */
+     if (*cfgpath == '/')


### PR DESCRIPTION
Errors on uninitialized variable. Only on powerpc64 for some reason.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tohojo 
Compile tested: powerpc64

