### PR TITLE
canutils: fix format strings for mips and powerpc

### DIFF
--- a/utils/canutils/patches/010-sane.patch
+++ b/utils/canutils/patches/010-sane.patch
@@ -1,0 +1,30 @@
+From e370ad5256f4a0b37f70a5b2e4a56f2c37235026 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sun, 2 Jan 2022 15:21:50 -0800
+Subject: [PATCH] testj1939: fix 64-bit types for some platforms
+
+Revert commit that introduced PRIx64 to print an __u64, and added
+define to get the same types on all platforms.
+
+With __SANE_USERSPACE_TYPES__ the Linux headers use an unsigned long
+long for __u64 on all platforms, especially MIPS64.
+
+Fixes: eb9cfac9543b ("use PRIx64")
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>
+---
+ libj1939.h  | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/libj1939.h
++++ b/libj1939.h
+@@ -10,6 +10,9 @@
+  * as published by the Free Software Foundation
+  */
+ 
++/* needed on some 644 bit platforms to get consistent 64-bit types */
++#define __SANE_USERSPACE_TYPES__
++
+ #include <sys/socket.h>
+ #include <linux/can.h>
+ #include <linux/can/j1939.h>


### PR DESCRIPTION
It seems a define is needed to get these platforms to have the same
formats. Upstream backport.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @toxxin 
Compile tested: mips64