### PR TITLE
btrfs-progs: update to 5.16.1

### DIFF
--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btrfs-progs
-PKG_VERSION:=5.11
-PKG_RELEASE:=1
+PKG_VERSION:=5.16.1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/kdave/btrfs-progs
-PKG_HASH:=d41961b0a92160c80f894ad9a1882822889c2e1d084cbf3e08b8c214a5cf0137
+PKG_HASH:=3da4da5361cf86bddda80edb4c4f30ea076cb4ebec29904fa08afc930ef9e1a8
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Karel Kočí <karel.koci@nic.cz>
@@ -65,6 +65,7 @@ CONFIGURE_ARGS += \
 	--disable-backtrace \
 	--disable-convert \
 	--disable-documentation \
+	--disable-libudev \
 	--disable-python
 ifneq ($(CONFIG_BTRFS_PROGS_ZSTD),y)
 CONFIGURE_ARGS += --disable-zstd

--- a/utils/btrfs-progs/patches/010-64bit.patch
+++ b/utils/btrfs-progs/patches/010-64bit.patch
@@ -1,0 +1,43 @@
+From b5159062f079d451f23d7f2a0e7d9e2f84934f94 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sat, 29 Jan 2022 17:09:56 -0800
+Subject: [PATCH] btrfs-progs: fix 64-bit mips and powerpc types
+
+The kernel uses 'unsigned long' for u64 specifically for ppc64 and
+mips64.
+
+Remove asm/types.h include as it will get included properly later.
+
+Fixe -Wformat warnings.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+Signed-off-by: David Sterba <dsterba@suse.com>
+---
+ cmds/receive-dump.c | 1 -
+ kerncompat.h        | 5 +++++
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+--- a/cmds/receive-dump.c
++++ b/cmds/receive-dump.c
+@@ -31,7 +31,6 @@
+ #include <stdlib.h>
+ #include <time.h>
+ #include <ctype.h>
+-#include <asm/types.h>
+ #include <uuid/uuid.h>
+ #include "common/utils.h"
+ #include "cmds/commands.h"
+--- a/kerncompat.h
++++ b/kerncompat.h
+@@ -19,6 +19,11 @@
+ #ifndef __KERNCOMPAT_H__
+ #define __KERNCOMPAT_H__
+ 
++#ifndef __SANE_USERSPACE_TYPES__
++/* For PPC64 to get LL64 types */
++#define __SANE_USERSPACE_TYPES__
++#endif
++
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <errno.h>


### PR DESCRIPTION
Disable libudev to avoid dependency.

Add patch to fix 64-bit int types under ppc64 and mips64.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Cynerd 
Compile tested: mips64