### PR TITLE
dnsproxy: Update to 0.41.0

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.40.6
+PKG_VERSION:=0.41.0
 PKG_RELEASE:=$(AUTORELESE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6e4da43913169af5a97ecf3e524ac98a419482c7c49768aeb18072de384a6fb5
+PKG_HASH:=001b89436e4b9f3ac73fa98f838a733142ecd9ffa24387ce064eb1a5d99efbb2
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: ipq807x, rockchip/armv8
Run tested: rk3328 nanopi-r2s

Description:
Release note: https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.41.0