### PR TITLE
telegraf: add package version 1.21.3 to openwrt 21.02

### DIFF
--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=telegraf
+PKG_VERSION:=1.19.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=cec43bb0acfff8b4c963ffec6e3eab44ffb52c8f34e6a697207977cfd05882aa
+
+PKG_MAINTAINER:=Jonathan Pagel <jonny_tischbein@systemli.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/influxdata/telegraf
+GO_PKG_BUILD_PKG:=github.com/influxdata/telegraf/cmd/telegraf
+GO_PKG_LDFLAGS_X:=main.version=$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/telegraf/Default
+	SECTION:=utils
+	CATEGORY:=Utilities
+	TITLE:=Telegraf
+	DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/telegraf-full
+	$(call Package/telegraf/Default)
+	TITLE+= (Full)
+	VARIANT:=full
+endef
+
+define Package/telegraf
+	$(call Package/telegraf/Default)
+	TITLE+= (Small)
+	VARIANT:=small
+endef
+
+define Package/telegraf/description/Default
+	Telegraf is a plugin-driven agent for collecting and sending metrics and events.
+	It supports various inputs (including prometheus endpoints) and is able to send data into InfluxDB.
+endef
+
+define Package/telegraf/description
+	$(call Package/telegraf/description/Default)
+	(Small build. Most plugins excluded)
+endef
+
+define Package/telegraf-full/description
+	$(call Package/telegraf/description/Default)
+	(Full build. including all plugins)
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+ifeq ($(BUILD_VARIANT),small)
+	$(CP) ./variant-$(BUILD_VARIANT)/* $(PKG_BUILD_DIR)/
+endif
+endef
+
+define Package/telegraf/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+	$(INSTALL_DIR) $(1)/etc/init.d $(1)/etc/config
+	$(INSTALL_BIN) ./files/etc/init.d/telegraf $(1)/etc/init.d/telegraf
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/etc/telegraf.conf $(1)/etc/config/telegraf.conf
+endef
+
+define Package/telegraf-full/install
+	$(call Package/telegraf/install,$(1))
+endef
+
+$(eval $(call GoBinPackage,telegraf))
+$(eval $(call BuildPackage,telegraf))
+
+$(eval $(call GoBinPackage,telegraf-full))
+$(eval $(call BuildPackage,telegraf-full))

--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telegraf
-PKG_VERSION:=1.19.1
+PKG_VERSION:=1.21.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=cec43bb0acfff8b4c963ffec6e3eab44ffb52c8f34e6a697207977cfd05882aa
+PKG_HASH:=c117b930e82969080204382a2aa9df8572d05b18cfa0caf0ff62cb840af5ce71
 
 PKG_MAINTAINER:=Jonathan Pagel <jonny_tischbein@systemli.org>
 PKG_LICENSE:=MIT

--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -59,6 +59,12 @@ define Package/telegraf-full/description
 	(Full build. including all plugins)
 endef
 
+define Package/telegraf/conffiles
+/etc/telegraf.conf
+endef
+
+Package/telegraf-full/conffiles = $(Package/telegraf/conffiles)
+
 define Build/Prepare
 	$(call Build/Prepare/Default)
 ifeq ($(BUILD_VARIANT),small)
@@ -70,7 +76,7 @@ define Package/telegraf/install
 	$(call GoPackage/Package/Install/Bin,$(1))
 	$(INSTALL_DIR) $(1)/etc/init.d $(1)/etc/config
 	$(INSTALL_BIN) ./files/etc/init.d/telegraf $(1)/etc/init.d/telegraf
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/etc/telegraf.conf $(1)/etc/config/telegraf.conf
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/etc/telegraf.conf $(1)/etc/telegraf.conf
 endef
 
 define Package/telegraf-full/install

--- a/utils/telegraf/files/etc/init.d/telegraf
+++ b/utils/telegraf/files/etc/init.d/telegraf
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+START=95
+STOP=01
+
+start_service() {
+    procd_open_instance
+    procd_set_param command /usr/bin/telegraf --config /etc/config/telegraf.conf
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_close_instance
+}

--- a/utils/telegraf/files/etc/init.d/telegraf
+++ b/utils/telegraf/files/etc/init.d/telegraf
@@ -7,7 +7,7 @@ STOP=01
 
 start_service() {
     procd_open_instance
-    procd_set_param command /usr/bin/telegraf --config /etc/config/telegraf.conf
+    procd_set_param command /usr/bin/telegraf --config /etc/telegraf.conf
     procd_set_param stdout 1
     procd_set_param stderr 1
     procd_close_instance

--- a/utils/telegraf/variant-small/plugins/aggregators/all/all.go
+++ b/utils/telegraf/variant-small/plugins/aggregators/all/all.go
@@ -1,0 +1,5 @@
+package all
+
+import (
+	//Blank imports for plugins to register themselves
+)

--- a/utils/telegraf/variant-small/plugins/inputs/all/all.go
+++ b/utils/telegraf/variant-small/plugins/inputs/all/all.go
@@ -1,0 +1,30 @@
+package all
+
+import (
+	//Blank imports for plugins to register themselves
+	_ "github.com/influxdata/telegraf/plugins/inputs/cpu"
+	_ "github.com/influxdata/telegraf/plugins/inputs/ethtool"
+	_ "github.com/influxdata/telegraf/plugins/inputs/internal"
+	_ "github.com/influxdata/telegraf/plugins/inputs/interrupts"
+	_ "github.com/influxdata/telegraf/plugins/inputs/ipset"
+	_ "github.com/influxdata/telegraf/plugins/inputs/iptables"
+	_ "github.com/influxdata/telegraf/plugins/inputs/kernel"
+	_ "github.com/influxdata/telegraf/plugins/inputs/mem"
+	_ "github.com/influxdata/telegraf/plugins/inputs/net"
+	_ "github.com/influxdata/telegraf/plugins/inputs/net_response"
+	_ "github.com/influxdata/telegraf/plugins/inputs/ping"
+	_ "github.com/influxdata/telegraf/plugins/inputs/processes"
+	_ "github.com/influxdata/telegraf/plugins/inputs/procstat"
+	_ "github.com/influxdata/telegraf/plugins/inputs/prometheus"
+	_ "github.com/influxdata/telegraf/plugins/inputs/sensors"
+	_ "github.com/influxdata/telegraf/plugins/inputs/snmp"
+	_ "github.com/influxdata/telegraf/plugins/inputs/socket_listener"
+	_ "github.com/influxdata/telegraf/plugins/inputs/swap"
+	_ "github.com/influxdata/telegraf/plugins/inputs/syslog"
+	_ "github.com/influxdata/telegraf/plugins/inputs/system"
+	_ "github.com/influxdata/telegraf/plugins/inputs/tail"
+	_ "github.com/influxdata/telegraf/plugins/inputs/tcp_listener"
+	_ "github.com/influxdata/telegraf/plugins/inputs/udp_listener"
+	_ "github.com/influxdata/telegraf/plugins/inputs/wireguard"
+	_ "github.com/influxdata/telegraf/plugins/inputs/wireless"
+)

--- a/utils/telegraf/variant-small/plugins/outputs/all/all.go
+++ b/utils/telegraf/variant-small/plugins/outputs/all/all.go
@@ -1,0 +1,12 @@
+package all
+
+import (
+	//Blank imports for plugins to register themselves
+	_ "github.com/influxdata/telegraf/plugins/outputs/exec"
+	_ "github.com/influxdata/telegraf/plugins/outputs/file"
+	_ "github.com/influxdata/telegraf/plugins/outputs/graphite"
+	_ "github.com/influxdata/telegraf/plugins/outputs/http"
+	_ "github.com/influxdata/telegraf/plugins/outputs/influxdb"
+	_ "github.com/influxdata/telegraf/plugins/outputs/prometheus_client"
+	_ "github.com/influxdata/telegraf/plugins/outputs/syslog"
+)

--- a/utils/telegraf/variant-small/plugins/processors/all/all.go
+++ b/utils/telegraf/variant-small/plugins/processors/all/all.go
@@ -1,0 +1,5 @@
+package all
+
+import (
+	//Blank imports for plugins to register themselves
+)


### PR DESCRIPTION
Signed-off-by: Jonathan Pagel jonny_tischbein@systemli.org

Maintainer:
me

Compile tested:
on amd64 for x86

Run tested:
x86-64 VM

Description:
Add package with version 1.21.3 for openwrt 21.02

Telegraf is a plugin-driven agent for collecting and sending metrics and events. It supports various inputs (including prometheus endpoints) and is able to send data into InfluxDB. https://www.influxdata.com/time-series-platform/telegraf/