### PR TITLE
knxd: fix build on macos

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -12,7 +12,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
 PKG_VERSION:=0.14.53
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/knxd/knxd/tar.gz/$(PKG_VERSION)?

--- a/net/knxd/patches/101_add_clang_suport_as_build_cc.patch
+++ b/net/knxd/patches/101_add_clang_suport_as_build_cc.patch
@@ -1,0 +1,41 @@
+From: https://github.com/knxd/knxd/pull/531/commits/cb8a564d2c6250f712528e929892a5e7ddb74778
+
+From cb8a564d2c6250f712528e929892a5e7ddb74778 Mon Sep 17 00:00:00 2001
+From: "Sergey V. Lobanov" <sergey@lobanov.in>
+Date: Mon, 31 Jan 2022 01:34:20 +0300
+Subject: [PATCH] Add clang suport as build cc
+
+ccforbuild.m4 comes from gmp project (very old version).
+Current version does not support clang due to using GCC exit()
+builtin function. clang does not have exit() builtin function.
+
+GMP project fixed this issue by the commit https://gmplib.org/repo/gmp/rev/beda46a3c10d
+
+This patch backports "upstream" change (`exit(0)` relaced by
+`return 0` in conftest.c)
+
+Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>
+---
+ m4/ccforbuild.m4 | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/m4/ccforbuild.m4
++++ b/m4/ccforbuild.m4
+@@ -69,7 +69,7 @@ cat >conftest.c <<EOF
+ int
+ main ()
+ {
+-  exit(0);
++  return 0;
+ }
+ EOF
+ gmp_compile="$1 conftest.c"
+@@ -143,7 +143,7 @@ AC_CACHE_CHECK([for build system executa
+ int
+ main ()
+ {
+-  exit (0);
++  return 0;
+ }
+ EOF
+ for i in .exe ,ff8 ""; do


### PR DESCRIPTION
knxd compilation fails on macos due to clang does not support
exit() builtin function that is used to detect build cc

This commit adds a patch to fix this issue (replaces `exit 0` by
`return 0` in conftest.c)

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @tru7 
Compile tested: (armvirt/64, OpenWrt trunk)

Description: see above
