### PR TITLE
strongswan: Update to 5.9.5

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
-PKG_VERSION:=5.9.4
+PKG_VERSION:=5.9.5
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/
-PKG_HASH:=45fdf1a4c2af086d8ff5b76fd7b21d3b6f0890f365f83bf4c9a75dda26887518
+PKG_HASH:=983e4ef4a4c6c9d69f5fe6707c7fe0b2b9a9291943bbf4e008faab6bf91c0bdd
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>, Noel Kuntze <noel.kuntze@thermi.consulting>
 PKG_CPE_ID:=cpe:/a:strongswan:strongswan

--- a/net/strongswan/patches/0900-src-Patch-for-building-with-musl-on-openwrt-taken-ve.patch
+++ b/net/strongswan/patches/0900-src-Patch-for-building-with-musl-on-openwrt-taken-ve.patch
@@ -48,7 +48,7 @@ Subject: [PATCH 900/904] src: Patch for building with musl on openwrt (taken
  #include <linux/rtnetlink.h>
 --- a/src/libstrongswan/library.h
 +++ b/src/libstrongswan/library.h
-@@ -118,6 +118,7 @@
+@@ -119,6 +119,7 @@
  #include "utils/leak_detective.h"
  #include "plugins/plugin_loader.h"
  #include "settings/settings.h"

--- a/net/strongswan/patches/0904-gmpdh-Plugin-that-implements-gmp-DH-functions-in-an-.patch
+++ b/net/strongswan/patches/0904-gmpdh-Plugin-that-implements-gmp-DH-functions-in-an-.patch
@@ -52,7 +52,7 @@ Subject: [PATCH 904/904] gmpdh: Plugin that implements gmp DH functions in an
  	src/libstrongswan/plugins/aesni/Makefile
 --- a/src/libstrongswan/Makefile.am
 +++ b/src/libstrongswan/Makefile.am
-@@ -345,6 +345,13 @@ if MONOLITHIC
+@@ -348,6 +348,13 @@ if MONOLITHIC
  endif
  endif
  


### PR DESCRIPTION
Maintainer: me, @Thermi 
Compile tested: x86_64, generic, HEAD (236c3ea730)
Run tested: built and installed on remote production router

Description:

Update to 5.9.5.
