### PR TITLE
mktorrent: fix bad format for 64bit platforms

### DIFF
--- a/utils/mktorrent/Makefile
+++ b/utils/mktorrent/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mktorrent
 PKG_VERSION:=1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz

--- a/utils/mktorrent/patches/010-format.patch
+++ b/utils/mktorrent/patches/010-format.patch
@@ -1,0 +1,20 @@
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -61,6 +61,6 @@ OBJS = $(SRCS:.c=.o)
+ all: $(program)
+ 
+ %.o: %.c $(HEADERS) prefix
+-	$(CC) $(CFLAGS) $(DEFINES) -DPRIoff="\"$(OFFPRFX)d\"" -DVERSION="\"$(version)\"" -c $<
++	$(CC) $(CFLAGS) $(DEFINES) -DPRIoff="PRId64 \"d\"" -DVERSION="\"$(version)\"" -c $<
+ 
+ include rules.mk
+--- a/init.c
++++ b/init.c
+@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fi
+ #include <sys/stat.h>     /* the stat structure */
+ #include <unistd.h>       /* getopt(), getcwd(), sysconf() */
+ #include <string.h>       /* strcmp(), strlen(), strncpy() */
++#include <inttypes.h>
+ #ifdef USE_LONG_OPTIONS
+ #include <getopt.h>       /* getopt_long() */
+ #endif


### PR DESCRIPTION
The Makefile tries and fails to run a binary that sets it properly. Just
hardcode it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: ppc64