### PR TITLE
libdrm: fix bad formats for mips64 and ppc64

### DIFF
--- a/libs/libdrm/patches/010-64bit.patch
+++ b/libs/libdrm/patches/010-64bit.patch
@@ -1,0 +1,12 @@
+--- a/include/drm/drm.h
++++ b/include/drm/drm.h
+@@ -38,6 +38,9 @@
+ 
+ #if   defined(__linux__)
+ 
++#ifndef __SANE_USERSPACE_TYPES__
++#define __SANE_USERSPACE_TYPES__	/* For PPC64, to get LL64 types */
++#endif
+ #include <linux/types.h>
+ #include <asm/ioctl.h>
+ typedef unsigned int drm_handle_t;


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: ppc64