### PR TITLE
xinetd: fix bad printf formats

### DIFF
--- a/net/xinetd/Makefile
+++ b/net/xinetd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xinetd
 PKG_VERSION:=2.3.15
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/xinetd-org/xinetd/archive

--- a/net/xinetd/patches/005-format.patch
+++ b/net/xinetd/patches/005-format.patch
@@ -1,0 +1,23 @@
+--- a/xinetd/connection.c
++++ b/xinetd/connection.c
+@@ -14,6 +14,7 @@
+ #include <syslog.h>
+ #include <stdlib.h>
+ #include <unistd.h>
++#include <inttypes.h>
+ 
+ #include <netinet/tcp.h>
+ 
+@@ -218,11 +219,7 @@ void conn_dump( const connection_s *cp,
+ 
+    tabprint( fd, 1, "service = %s\n", SVC_ID( cp->co_sp ) ) ;
+    tabprint( fd, 1, "descriptor = %d\n", cp->co_descriptor ) ;
+-#if defined(__GNUC__) && !defined(__arch64__) && !defined(__alpha__)
+-   tabprint( fd, 1, "flags = %#llx\n", cp->co_flags ) ;
+-#else
+-   tabprint( fd, 1, "flags = %#lx\n", cp->co_flags ) ;
+-#endif
++   tabprint( fd, 1, "flags = %#" PRIx64 "\n", cp->co_flags ) ;
+    tabprint( fd, 1, "remote_address = %s,%d\n", name,
+                               ntohs( cp->co_remote_address.sa_in.sin_port ) ) ;
+ }


### PR DESCRIPTION
Easier to use the proper C macro.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @feckert 
Compile tested: ppc64