### PR TITLE
mtdev: fix bad printf formats

### DIFF
--- a/libs/mtdev/Makefile
+++ b/libs/mtdev/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mtdev
 PKG_VERSION:=1.1.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://bitmath.org/code/mtdev/

--- a/libs/mtdev/patches/010-format.patch
+++ b/libs/mtdev/patches/010-format.patch
@@ -1,0 +1,11 @@
+--- a/test/mtdev-test.c
++++ b/test/mtdev-test.c
+@@ -38,7 +38,7 @@
+ #endif
+ 
+ /* year-proof millisecond event time */
+-typedef uint64_t mstime_t;
++typedef unsigned long long mstime_t;
+ 
+ static int use_event(const struct input_event *ev)
+ {


### PR DESCRIPTION
Easiest to just change the type.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: ppc64