### PR TITLE
cmdpad: fix bad scanf format

### DIFF
--- a/utils/cmdpad/Makefile
+++ b/utils/cmdpad/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmdpad
 PKG_VERSION:=0.0.3
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=@SF/cmdpad

--- a/utils/cmdpad/patches/160-format.patch
+++ b/utils/cmdpad/patches/160-format.patch
@@ -1,0 +1,11 @@
+--- a/src/parse.c
++++ b/src/parse.c
+@@ -257,7 +257,7 @@ int ParseCommand( char * pchCommandLine)
+ 
+       pchValue = strtok( pchValue, ",") ; 
+       d2printf( "Value is '%s'\n", pchValue) ;
+-      if( (pchValue == NULL ) || ( sscanf( pchValue, "%d", &code) != 1) )
++      if( (pchValue == NULL ) || ( sscanf( pchValue, "%hu", &code) != 1) )
+ 	return -1 ;
+       
+       pchValue = strtok( NULL, ",") ;


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: ppc64