### PR TITLE
sockread: add missing header

### DIFF
--- a/utils/sockread/Makefile
+++ b/utils/sockread/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sockread
 PKG_VERSION:=1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=CC0-1.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/utils/sockread/src/main.c
+++ b/utils/sockread/src/main.c
@@ -1,4 +1,4 @@
-
+#include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>


### PR DESCRIPTION
Needed for memset, memcpy, and strerror.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mwarning 
Compile tested: ppc64