### PR TITLE
ddns-scripts: remove extra pipe

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=22
+PKG_RELEASE:=23
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/samples/update_sample.sh
+++ b/net/ddns-scripts/samples/update_sample.sh
@@ -24,7 +24,7 @@ local __URL="http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[D
 [ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'"
 
 # do replaces in URL
-__URL=$(echo $__URL |  | sed -e "s#\[USERNAME\]#$URL_USER#g" -e "s#\[PASSWORD\]#$URL_PASS#g" \
+__URL=$(echo $__URL | sed -e "s#\[USERNAME\]#$URL_USER#g" -e "s#\[PASSWORD\]#$URL_PASS#g" \
 			     -e "s#\[PARAMENC\]#$URL_PENC#g" -e "s#\[PARAMOPT\]#$param_opt#g" \
 			     -e "s#\[DOMAIN\]#$domain#g"     -e "s#\[IP\]#$__IP#g")
 [ $use_https -ne 0 ] && __URL=$(echo $__URL | sed -e 's#^http:#https:#')


### PR DESCRIPTION
Signed-off-by: André Herbst <moormaster@gmx.net>

Maintainer: @feckert
Compile tested: -
Run tested: -

Description:
The extra pipe caused an error WARN : PID 'xyz' exit WITH ERROR '2' when executing ddns update.