### PR TITLE
python-psutil: update to version 5.9.0, fix build on macos

### DIFF
--- a/lang/python/python-psutil/Makefile
+++ b/lang/python/python-psutil/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-psutil
-PKG_VERSION:=5.8.0
+PKG_VERSION:=5.9.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=psutil
-PKG_HASH:=0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6
+PKG_HASH:=869842dbd66bb80c3217158e629d6fceaecc3a3166d3d1faee515b05dd26ca25
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD 3-Clause
@@ -37,6 +37,9 @@ define Package/python3-psutil/description
   psutil is a cross-platform library for retrieving information
   on running processes and system utilization.
 endef
+
+PYTHON3_VARS += \
+	TARGET_SYS_PLATFORM=linux
 
 $(eval $(call Py3Package,python3-psutil))
 $(eval $(call BuildPackage,python3-psutil))

--- a/lang/python/python-psutil/patches/100_add_cross_platform_build_ability.patch
+++ b/lang/python/python-psutil/patches/100_add_cross_platform_build_ability.patch
@@ -1,0 +1,59 @@
+From: https://github.com/giampaolo/psutil/pull/2068/commits/9a5cb2b71d301a63ea765f02a196fd046e769685
+
+From 9a5cb2b71d301a63ea765f02a196fd046e769685 Mon Sep 17 00:00:00 2001
+From: "Sergey V. Lobanov" <sergey@lobanov.in>
+Date: Mon, 31 Jan 2022 17:48:14 +0300
+Subject: [PATCH] Add cross-platform build ability
+
+Currently it is not possible to build psutil on MacOS for Linux
+target using external toolchain. It fails due to build script
+detects build host OS and changes build logic according to detected
+OS.
+
+This patch allows to redefine os.name and sys.platform using ENV
+vars TARGET_OS_NAME and TARGET_SYS_PLATFORM. If these variables
+are not defined then os.name and sys.platform is used as it does
+currently.
+
+Using this patch it is possible to compile psutil on MacOS with
+OpenWrt GCC Toolchain (OpenWrt is Linux).
+
+Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>
+---
+ psutil/_common.py | 23 ++++++++++++++---------
+ 1 file changed, 14 insertions(+), 9 deletions(-)
+
+--- a/psutil/_common.py
++++ b/psutil/_common.py
+@@ -81,17 +81,22 @@ __all__ = [
+ # ===================================================================
+ 
+ 
+-POSIX = os.name == "posix"
+-WINDOWS = os.name == "nt"
+-LINUX = sys.platform.startswith("linux")
+-MACOS = sys.platform.startswith("darwin")
++# Allow to redefine os.name and sys.platform if build OS and target 
++# OS are different (e.g. build OS is MacOS, target OS is Linux)
++target_os_name = os.getenv('TARGET_OS_NAME', os.name)
++target_sys_platform = os.getenv('TARGET_SYS_PLATFORM', sys.platform)
++
++POSIX = target_os_name == "posix"
++WINDOWS = target_os_name == "nt"
++LINUX = target_sys_platform.startswith("linux")
++MACOS = target_sys_platform.startswith("darwin")
+ OSX = MACOS  # deprecated alias
+-FREEBSD = sys.platform.startswith(("freebsd", "midnightbsd"))
+-OPENBSD = sys.platform.startswith("openbsd")
+-NETBSD = sys.platform.startswith("netbsd")
++FREEBSD = target_sys_platform.startswith(("freebsd", "midnightbsd"))
++OPENBSD = target_sys_platform.startswith("openbsd")
++NETBSD = target_sys_platform.startswith("netbsd")
+ BSD = FREEBSD or OPENBSD or NETBSD
+-SUNOS = sys.platform.startswith(("sunos", "solaris"))
+-AIX = sys.platform.startswith("aix")
++SUNOS = target_sys_platform.startswith(("sunos", "solaris"))
++AIX = target_sys_platform.startswith("aix")
+ 
+ 
+ # ===================================================================


### PR DESCRIPTION
1. updated to 5.9.0

2. psutil can not be built on macos due to build script detects Darwin
using sys.platform and changes build logic to build for Darwin, but
OpenWrt is Linux.
This commit add patch to allow redefining sys.platform and uses
env var TARGET_SYS_PLATFORM to specify linux as sys platfrom.

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @ja-pa 
Compile tested: (armvirt/64, OpenWrt version r18681-5d110c0161)
Run tested: (armvirt/64, OpenWrt version r18681-5d110c0161, tests done)

```
root@OpenWrt:/# uname -a
Linux OpenWrt 5.10.92 #0 SMP Mon Jan 31 00:10:42 2022 aarch64 GNU/Linux
root@OpenWrt:/# cat /etc/openwrt_release 
DISTRIB_ID='OpenWrt'
DISTRIB_RELEASE='SNAPSHOT'
DISTRIB_REVISION='r18681-5d110c0161'
DISTRIB_TARGET='armvirt/64'
DISTRIB_ARCH='aarch64_cortex-a53'
DISTRIB_DESCRIPTION='OpenWrt SNAPSHOT r18681-5d110c0161'
DISTRIB_TAINTS='no-all'
root@OpenWrt:/# python
Python 3.10.2 (main, Jan 31 2022, 00:10:42) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import psutil
>>> print(psutil.__version__)
5.9.0
>>> psutil.cpu_times()
scputimes(user=0.93, nice=0.0, system=0.95, idle=501.24, iowait=0.0, irq=0.0, softirq=0.0, steal=0.0, guest=0.0, guest_nice=0.0)
>>> psutil.cpu_count()
2
>>> psutil.cpu_stats()
scpustats(ctx_switches=26232, interrupts=16379, soft_interrupts=19950, syscalls=0)
>>> 
```

PR to upstream: https://github.com/giampaolo/psutil/pull/2068/
