### PR TITLE
shairplay: Prioritize shairplay to reduce stuttering

### DIFF
--- a/sound/shairplay/files/shairplay.init
+++ b/sound/shairplay/files/shairplay.init
@@ -25,6 +25,7 @@ start_instance() {
 	procd_open_instance
 
 	procd_set_param command /usr/bin/shairplay
+	procd_set_param nice -10
 
 	append_arg "$cfg" apname "--apname" "AirPlay"
 	append_arg "$cfg" port "--server_port"


### PR DESCRIPTION
Maintainer: Álvaro Fernández Rojas <noltari@gmail.com>
Compile tested: config file tested live on system below
Run tested: lantiq/xway, avm_fritz_box_7320, OpenWrt 21.02.1, played music for a while while accessing shell commands and luci

Description:

mpd runs with a nice priority of -10 so i adopted that.
In my experience -10 eliminates stutter for shairplay on a FritzBox 7320 while not messing up any other processes.
If you feel like -10 is too high , -5 is still okay-ish.

EDIT: Sorry to fail the automated formalities test but im not comfortable with using my real name for my GitHub account.

Signed-off-by: HACKER3000 <hacker3000@posteo.org>