### PR TITLE
nut: fix build on macos

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=26
+PKG_RELEASE:=27
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/
@@ -524,6 +524,9 @@ $(eval $(call DriverDescription,usb,nutdrv_qx,\
 $(eval $(call DriverDescription,neon,netxml-ups,\
         Driver for NetXML based UPS equipment))
 
+CONFIGURE_VARS += \
+	ac_cv_path_AR=$(TARGET_AR)
+
 CONFIGURE_ARGS += \
 	--sysconfdir=/etc/nut \
 	--datadir=/usr/share/nut \
@@ -542,6 +545,7 @@ CONFIGURE_ARGS += \
 	--without-freeipmi \
 	--$(if $(CONFIG_NUT_SSL),with,without)-ssl $(if $(CONFIG_NUT_SSL),--with-openssl) \
 	--without-libltdl \
+	--without-macosx_ups \
 	--with-statepath=/var/run/nut \
 	--with-drvpath=/lib/nut \
 	--with-user=root \


### PR DESCRIPTION
nut build fails on macos due to:
1. configure script can not use AR env var due to OpenWrt build
system provides only executable name (e.g. aarch64-openwrt-linux-musl-gcc-ar)
but configure script checks if AR has '/'. As a result, configure
script ignores AR env var and uses system `ar` but macos `ar` is
not compatible with the objects generated by OpenWrt GCC toolchain.

This commit explicitly sets ac_cv_path_AR=$(TARGET_AR) to use
OpenWrt toolchain AR.

2. configure script detects if build host is macos and adds
macosx_ups driver as a build target, but this driver can not be
build with OpenWrt toolchain because OpenWrt is Linux.

This commit explicitly disables macosx_ups driver using configure
flag --without-macosx_ups

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: -
Compile tested: (armvirt/64, OpenWrt version b21bc3479d46e6a4c3cc6bf7c245d4b0ddccb7db)
Run tested: not really tested, but produced binaries are exactly the same before and after this patch on Linux build host, also, produced binaries on macos and linux are exactly the same (sha256sums are the same for all files in package)

Description: see above
