### PR TITLE
chaosvpn: fix build on macos

### DIFF
--- a/net/chaosvpn/Makefile
+++ b/net/chaosvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=chaosvpn
 
 PKG_VERSION:=2.19
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ryd/chaosvpn/tar.gz/v$(PKG_VERSION)?
@@ -38,6 +38,7 @@ define Package/chaosvpn/conffiles
 endef
 
 MAKE_FLAGS += \
+		OS=Linux \
 		COPT="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS) $(TARGET_LDFLAGS)"
 
 define Package/chaosvpn/install


### PR DESCRIPTION
chaosvpn Makefile detects Darwin (macos) and changes compilation
flags for macos target, but OpenWrt is always Linux so build fails.
This patch redefines OS=Linux to use Linux compilation flags.

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: Norbert Summer <git@o-g.at> (I can't find github nickname)
Compile tested: (armvirt/64, OpenWrt version b21bc3479d46e6a4c3cc6bf7c245d4b0ddccb7db)

Description: see above 
