### PR TITLE
ipmitool: add config options for ipmi kernel modules

### DIFF
--- a/admin/ipmitool/Config.in
+++ b/admin/ipmitool/Config.in
@@ -1,0 +1,15 @@
+if PACKAGE_ipmitool
+
+config IPMITOOL_KERNEL_MODULES
+	bool "Select system interface kernel modules for ipmitool"
+	default n
+	select PACKAGE_kmod-ipmi-handler
+	select PACKAGE_kmod-ipmi-si
+	select PACKAGE_kmod-ipmi-device-interface
+	help
+	  If not set, no kernel modules get installed on ipmitool package
+	  installation. The package ipmitool needs this kernel modules to
+	  work properly with the system interface.
+	  If in doubt, say "Y".
+
+endif

--- a/admin/ipmitool/Makefile
+++ b/admin/ipmitool/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ipmitool
 PKG_VERSION:=1.8.18
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
@@ -27,6 +27,10 @@ define Package/ipmitool
   TITLE:=Command-line interface to IPMI-enabled devices
   URL:=https://github.com/ipmitool/ipmitool
   MAINTAINER:=Alexander Couzens <lynxis@fe80.eu>
+endef
+
+define Package/ipmitool/config
+  source "$(SOURCE)/Config.in"
 endef
 
 define Package/ipmitool/Default/description


### PR DESCRIPTION
To use the IPMI system interface some kernel modules are required.

This PR adds a configuration option to select the required kernel modules if the use of the IPMI system interface is desirable.

This package depends on PR in another repo ([openwrt/packages#6274](https://github.com/openwrt/openwrt/pull/5020))

Signed-off-by: Helge Mader <ma@dev.tdt.de>
