### PR TITLE
wg-installer: use babeld add_interface function

### DIFF
--- a/net/wg-installer/Makefile
+++ b/net/wg-installer/Makefile
@@ -57,7 +57,7 @@ endef
 
 define Package/wg-installer-server-hotplug-babeld
 	$(call Package/wg-installer-server)
-	DEPENDS:=wg-installer-server +coreutils-realpath
+	DEPENDS:=wg-installer-server
 endef
 
 define Package/wg-installer-server-hotplug-babeld/install

--- a/net/wg-installer/wg-server/hotplug.d/99-mesh-babeld
+++ b/net/wg-installer/wg-server/hotplug.d/99-mesh-babeld
@@ -12,25 +12,5 @@ if [ "${slicedint}" != "wg_" ]; then
 fi
 
 if [ "${ACTION}" = "add" ]; then
-	uci add babeld interface
-	uci set babeld.@interface[-1].ifname="${INTERFACE}"
-	uci get wgserver.@babeld_hotplug[0].rxcost
-	if [ $? -eq 0 ]; then
-		babeld_rxcost="$(uci get wgserver.@babeld_hotplug[0].rxcost)"
-		uci set babeld.@interface[-1].rxcost="$babeld_rxcost"
-	fi
-	uci -c "$(dirname "$(realpath /etc/config/babeld)")" commit babeld
-	/etc/init.d/babeld reload
-fi
-
-if [ "${ACTION}" = "remove" ]; then
-	i=0
-	while uci get babeld.@interface[$i] &> /dev/null ; do
-		if [ "$(uci get babeld.@interface[$i].ifname)" = "${INTERFACE}" ]; then
-			uci delete babeld.@interface[$i]
-		fi
-		i=$((i+1));
-	done
-	uci -c "$(dirname "$(realpath /etc/config/babeld)")" commit babeld
-	/etc/init.d/babeld reload
+	ubus call babeld add_interface '{"ifname":'\""$INTERFACE"\"'}'
 fi


### PR DESCRIPTION
With commit 385200443554 ("babeld: add add_interface function") babeld has a new ubus function allowing to dynamically add an interface.

Before the add_interface function, we were required to reload babeld. The reload influenced the babeld routing. However, the remove part is still missing and will be added at a later stage.