### PR TITLE
bluelog: fix build on macos

### DIFF
--- a/utils/bluelog/Makefile
+++ b/utils/bluelog/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bluelog
 PKG_VERSION:=1.1.2
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=Bluelog-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/MS3FGX/Bluelog/tar.gz/$(PKG_VERSION)?
@@ -78,7 +78,7 @@ MAKE_FLAGS += \
 define Build/Prepare
 	$(eval $(call Download,oui.txt))
 	$(Build/Prepare/Default)
-	zcat $(DL_DIR)/$(OUI_SOURCE) > $(PKG_BUILD_DIR)/oui.tmp
+	gzip -dc $(DL_DIR)/$(OUI_SOURCE) > $(PKG_BUILD_DIR)/oui.tmp
 endef
 
 define Package/bluelog/install


### PR DESCRIPTION
bluelog can not be compiled on macos due to Apple zcat is not
compatible with GNU zcat.

This patch replaces `zcat` with `gzip -dc`. `gzip -dc` has the
same behavior on GNU and Apple environments.

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @nicolas-thill 
Compile tested: (armvirt/64, OpenWrt b21bc3479d46e6a4c3cc6bf7c245d4b0ddccb7db)

Description: see above
