### PR TITLE
bind: bump to 9.18.0

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.17.20
+PKG_VERSION:=9.18.0
 PKG_RELEASE:=$(AUTORELEASE)
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=93a961f6b4072af260c5d900299eb660defec035f9a000c864ea5b78869a4d35
+PKG_HASH:=56525bf5caf01fd8fd9d90910880cc0f8a90a27a97d169187d651d4ecf0c411c
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4
@@ -68,6 +68,7 @@ endef
 define Package/bind-server
   $(call Package/bind/Default)
   TITLE+= DNS server
+  DEPENDS+= +libcap
 endef
 
 define Package/bind-server/config


### PR DESCRIPTION
Signed-off-by: Noah Meyerhans <frodo@morgul.net>

Maintainer: me
Compile tested: x86_64, mvebu/cortex-a9
Run tested: mvebu/cortex-a9 (master/slave zone configurations, recursive service incl. DNSSEC validation)

Description:
Update 21.02 branch to the first bind stable release following the 9.17.x development series. Cherry-picked 127ef1207ba0484fadb224a46155a46b48150e34 from master