### PR TITLE
miniflux: update to 2.0.35

### DIFF
--- a/utils/miniflux/Makefile
+++ b/utils/miniflux/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniflux
-PKG_VERSION:=2.0.34
+PKG_VERSION:=2.0.35
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/miniflux/v2/tar.gz/${PKG_VERSION}?
-PKG_HASH:=ce065b8afa6d220b80b9c0b9afbfe3c42f08bc77718deaeb05864bd444b4d324
+PKG_HASH:=8f9693380754072d1a74671c6b645abe7ddb0c8d22651ebc867b1af6dfcc4229
 
 PKG_MAINTAINER:=Michal Vasilek <michal.vasilek@nic.cz>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64, Turris MOX, OpenWrt 21.02
Run tested: aarch64, Turris MOX, OpenWrt 21.02