### PR TITLE
bind: update to version 9.16.25

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.16.23
+PKG_VERSION:=9.16.25
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=dedb5e27aa9cb6a9ce3e872845887ff837b99e4e9a91a5e2fcd67cf6e1ef173c
+PKG_HASH:=9fa328850f82843ef8b7bf1ff5322cb68b110273a33f375ba41f35270f5e1ff3
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile tested: Turris 1.1, powerpc_8540, OpenWrt 19.07.8
Run tested: Turris Omnia, powerpc_8540, OpenWrt 19.07.8 - Dig works, DNS resolving via named works, too.

Description:
- 9.16.25: https://downloads.isc.org/isc/bind9/9.16.25/RELEASE-NOTES-bind-9.16.25.html