### PR TITLE
stunnel: update version to 5.62

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.61
-PKG_RELEASE:=1
+PKG_VERSION:=5.62
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
@@ -23,7 +23,7 @@ PKG_SOURCE_URL:= \
 	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=91ea0ca6482d8f7e7d971ee64ab4f86a2817d038a372f0893e28315ef2015d7a
+PKG_HASH:=9cf5bb949022aa66c736c1326554cca27d0641605a6370274edc4951eb5bd339
 
 PKG_FIXUP:=autoreconf
 PKG_FIXUP:=patch-libtool


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64 / lantiq_xrx200 , APU3 / xxx, latest
Run tested: x86_64 / lantiq_xrx200, APU3 / xxx, latest

Description:

lantiq_xrx200:
```
[ ] Initializing inetd mode configuration
[ ] Clients allowed=500
[.] stunnel 5.62 on mips-openwrt-linux-gnu platform
[.] Compiled/running with OpenSSL 1.1.1m  14 Dec 2021
[.] Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,OCSP,PSK,SNI
[ ] errno: (*__errno_location())
[ ] Initializing inetd mode configuration
[.] Reading configuration from file /etc/stunnel/stunnel.conf
[.] UTF-8 byte order mark not detected
[.] FIPS mode disabled
[ ] No PRNG seeding was required
[ ] Initializing service [dummy]
[ ] stunnel default security level set: 2
[ ] Ciphers: HIGH:!aNULL:!SSLv2:!DH:!kDHEPSK
[ ] TLSv1.3 ciphersuites: TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256
[ ] TLS options: 0x2100004555FAD91 (+0x0, -0x0)
[ ] Session resumption enabled
[ ] No certificate or private key specified
[:] Service [dummy] needs authentication to prevent MITM attacks
[ ] DH initialization skipped: client section
[ ] ECDH initialization
[ ] ECDH initialized with curves X25519:P-256:X448:P-521:P-384
[.] Configuration successful
[ ] Deallocating deployed section defaults
[ ] Binding service [dummy]
[ ] Listening file descriptor created (FD=9)
[ ] Setting accept socket options (FD=9)
[ ] Option SO_REUSEADDR set on accept socket
[.] Binding service [dummy] to ::1:6000: Address in use (125)
[ ] Listening file descriptor created (FD=9)
[ ] Setting accept socket options (FD=9)
[ ] Option SO_REUSEADDR set on accept socket
[.] Binding service [dummy] to 127.0.0.1:6000: Address in use (125)
[!] Binding service [dummy] failed
[ ] Unbinding service [dummy]
[ ] Service [dummy] closed
[ ] Deallocating deployed section defaults
[ ] Deallocating section [dummy]
[ ] Initializing inetd mode configuration
```

x86_64:
```
root@st-dev-07 ~ # stunnel
[ ] Initializing inetd mode configuration
[ ] Clients allowed=500
[.] stunnel 5.62 on x86_64-openwrt-linux-gnu platform
[.] Compiled/running with OpenSSL 1.1.1m  14 Dec 2021
[.] Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,OCSP,PSK,SNI
[ ] errno: (*__errno_location())
[ ] Initializing inetd mode configuration
[.] Reading configuration from file /etc/stunnel/stunnel.conf
[.] UTF-8 byte order mark not detected
[.] FIPS mode disabled
[ ] No PRNG seeding was required
[ ] Initializing service [dummy]
[ ] stunnel default security level set: 2
[ ] Ciphers: HIGH:!aNULL:!SSLv2:!DH:!kDHEPSK
[ ] TLSv1.3 ciphersuites: TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256
[ ] TLS options: 0x2100004 (+0x0, -0x0)
[ ] Session resumption enabled
[ ] No certificate or private key specified
[:] Service [dummy] needs authentication to prevent MITM attacks
[ ] DH initialization skipped: client section
[ ] ECDH initialization
[ ] ECDH initialized with curves X25519:P-256:X448:P-521:P-384
[.] Configuration successful
[ ] Deallocating deployed section defaults
[ ] Binding service [dummy]
[ ] Listening file descriptor created (FD=9)
[ ] Setting accept socket options (FD=9)
[ ] Option SO_REUSEADDR set on accept socket
[.] Binding service [dummy] to ::1:6000: Address in use (98)
[ ] Listening file descriptor created (FD=9)
[ ] Setting accept socket options (FD=9)
[ ] Option SO_REUSEADDR set on accept socket
[.] Binding service [dummy] to 127.0.0.1:6000: Address in use (98)
[!] Binding service [dummy] failed
[ ] Unbinding service [dummy]
[ ] Service [dummy] closed
[ ] Deallocating deployed section defaults
[ ] Deallocating section [dummy]
[ ] Initializing inetd mode configuration
```
