### PR TITLE
tinyionice: add package

### DIFF
--- a/utils/tinyionice/Makefile
+++ b/utils/tinyionice/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2022 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tinyionice
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/xyproto/tinyionice/tar.gz/v${PKG_VERSION}?
+PKG_HASH:=65d903b5d69ca1d121bc9ad1a635a49b49233a99121ce40730b3617048ff6a84
+
+PKG_MAINTAINER:=Michal Vasilek <michal.vasilek@nic.cz>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/tinyionice
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Independent fork of ionice from util-linux
+  URL:=https://github.com/xyproto/tinyionice
+endef
+
+define Package/tinyionice/Default/description
+  Independent fork of ionice from util-linux
+endef
+
+define Package/tinyionice/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,tinyionice))

--- a/utils/tinyionice/patches/0001-Add-a-makefile.patch
+++ b/utils/tinyionice/patches/0001-Add-a-makefile.patch
@@ -1,0 +1,34 @@
+From fd3c17ad5d4e3acaa5469f408e57bb9375253e4d Mon Sep 17 00:00:00 2001
+From: Michal Vasilek <michal.vasilek@nic.cz>
+Date: Thu, 3 Feb 2022 19:45:26 +0100
+Subject: [PATCH] Add a makefile
+
+---
+ Makefile | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+ create mode 100644 Makefile
+
+--- /dev/null
++++ b/Makefile
+@@ -0,0 +1,21 @@
++CC = cc
++CFLAGS=-O2 -fPIC -fstack-protector-strong -D_GNU_SOURCE -s -z norelro
++PREFIX=/usr
++BINDIR=$(PREFIX)/bin
++
++all: tinyionice
++
++tinyionice: main.c
++	$(CC) $(CFLAGS) $< -o $@
++
++install: tinyionice
++	install -D -m 755 tinyionice $(DESTDIR)/$(BINDIR)/tinyionice
++
++uninstall:
++	rm -f $(DESTDIR)/$(BINDIR)/tinyionice
++
++clean:
++	rm -f tinyionice
++
++
++.PHONY: all install uninstall clean

--- a/utils/tinyionice/test.sh
+++ b/utils/tinyionice/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+tinyionice --version | grep "$PKG_VERSION"


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64, Turris MOX, OpenWrt 21.02
Run tested: aarch64, Turris MOX, OpenWrt 21.02

Description: the default busybox configuration doesn't contain ionice, this is a tiny package (containing just one 9kB binary) which provides an independent implementation of ionice taken from utils-linux. I sent the patch for the makefile upstream.