### PR TITLE
ruby: update to 3.0.3

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=3.0.2
+PKG_VERSION:=3.0.3
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=570e7773100f625599575f363831166d91d49a1ab97d3ab6495af44774155c40
+PKG_HASH:=88cc7f0f021f15c4cd62b1f922e3a401697f7943551fe45b1fdf4f2417a17a9c
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: @luizluca
Compile tested: aarch64, Turris MOX, OpenWrt 21.02
Run tested: aarch64, Turris MOX, OpenWrt 21.02

Description: fixes CVEs:
* [CVE-2021-41817: Regular Expression Denial of Service Vulnerability of Date Parsing Methods](https://www.ruby-lang.org/en/news/2021/11/15/date-parsing-method-regexp-dos-cve-2021-41817/)
* [CVE-2021-41816: Buffer Overrun in CGI.escape_html](https://www.ruby-lang.org/en/news/2021/11/24/buffer-overrun-in-cgi-escape_html-cve-2021-41816/)
* [CVE-2021-41819: Cookie Prefix Spoofing in CGI::Cookie.parse](https://www.ruby-lang.org/en/news/2021/11/24/cookie-prefix-spoofing-in-cgi-cookie-parse-cve-2021-41819/)
