### PR TITLE
shorewall-lite: fix build on macos

### DIFF
--- a/net/shorewall-lite/Makefile
+++ b/net/shorewall-lite/Makefile
@@ -14,7 +14,7 @@ PKG_BUGFIX_MAJOR_VERSION:=8
 PKG_BUGFIX_MINOR_VERSION:=
 PKG_VERSION:=$(PKG_MAJOR_MINOR_VERSION).$(PKG_BUGFIX_MAJOR_VERSION)$(PKG_BUGFIX_MINOR_VERSION)
 PKG_DIRECTORY:=$(PKG_MAJOR_MINOR_VERSION).$(PKG_BUGFIX_MAJOR_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://shorewall.org/pub/shorewall/$(PKG_MAJOR_MINOR_VERSION)/shorewall-$(PKG_DIRECTORY)/ \
 	http://slovakia.shorewall.net/pub/shorewall/$(PKG_MAJOR_MINOR_VERSION)/shorewall-$(PKG_DIRECTORY)/ \
@@ -23,11 +23,16 @@ PKG_SOURCE_URL:=http://shorewall.org/pub/shorewall/$(PKG_MAJOR_MINOR_VERSION)/sh
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_HASH:=b6ebf750f9501818da0967c80c3d6f08cede5531e48b23ebbf241a2d1fad2cfd
 
+PKG_BUILD_DEPENDS:=HOST_OS_MACOS:fakeuname/host
+
 PKG_MAINTAINER:=Willem van den Akker <wvdakker@wilsoft.nl>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
+ifeq ($(CONFIG_HOST_OS_MACOS),y)
+    include ../../utils/fakeuname/fakeuname.mk
+endif
 
 define Package/shorewall-lite
     SECTION:=net
@@ -57,8 +62,27 @@ endef
 CONFIGURE_ARGS += \
 	vendor=openwrt
 
+# MacOS bash is too old for shorewall-lite, use OpenWrt host tools/bash built for macos hosts
+# use fakeuname to avoid 'if `uname` is Darwin' checks
+MACOS_ENV := \
+	PATH=$(FAKEUNAME_PATH):$(TARGET_PATH_PKG) \
+	$(BASH)
+
+CONFIGURE_VARS += \
+	$(if $(CONFIG_HOST_OS_MACOS),$(MACOS_ENV))
+
+# install.sh explicitly defines PATH= so fakeuname doesn't work. Remove PATH= on macos
+define Build/Prepare
+        $(call Build/Prepare/Default)
+ifeq ($(CONFIG_HOST_OS_MACOS),y)
+	$(SED) '/^PATH=/d' $(PKG_BUILD_DIR)/install.sh
+endif
+endef
+
 define Build/Compile
-	DESTDIR=$(PKG_INSTALL_DIR) $(PKG_BUILD_DIR)/install.sh
+	DESTDIR=$(PKG_INSTALL_DIR) \
+	$(if $(CONFIG_HOST_OS_MACOS),$(MACOS_ENV)) \
+	$(PKG_BUILD_DIR)/install.sh
 endef
 
 define Package/shorewall-lite/install


### PR DESCRIPTION
shorewall-lite macos build fails due to:

1. MacOS bash is too old (3.x), but shorewall-lite requires bash>4
This patch uses OpenWrt tools/bash built for macos (bash 5.x)

2. install.sh detects Darwin using uname and changes install logic,
but it fails in case of cross-platform build
This patch uses fakeuname/host tool to avoid Darwin detection

3. fakeuname does not work in install.sh because install.sh
redefines PATH.
This patch removes PATH=... from install.sh on macos

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @wvdakker
Compile tested: (armvirt/64, OpenWrt trunk b21bc3479d46e6a4c3cc6bf7c245d4b0ddccb7db)

Description: see above