### PR TITLE
bind: support compile-time exclusion of DNS-over-HTTPS support

### DIFF
--- a/net/bind/Config.in
+++ b/net/bind/Config.in
@@ -20,3 +20,17 @@ config BIND_LIBXML2
 		format. Building with libjson support will require the
 		libxml2 package to be installed as well.
 endif
+
+if PACKAGE_bind-libs
+
+config BIND_ENABLE_DOH
+	bool
+	default y
+	prompt "Include DNS-over-HTTPS support in bind"
+	help
+		BIND 9 supports DNS-over-HTTPS and enables it by
+		default.  This requires linking against libnghttp2.
+		You can disable DoHTTPS if you do not need it or need
+		to avoid the additional library dependency.
+
+endif

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -31,11 +31,10 @@ PKG_INSTALL:=1
 PKG_USE_MIPS16:=0
 PKG_BUILD_PARALLEL:=1
 
-PKG_BUILD_DEPENDS:=nghttp2
-
 PKG_CONFIG_DEPENDS := \
 	CONFIG_BIND_LIBJSON \
-	CONFIG_BIND_LIBXML2
+	CONFIG_BIND_LIBXML2 \
+	CONFIG_BIND_ENABLE_DOH
 
 PKG_BUILD_DEPENDS += BIND_LIBXML2:libxml2 BIND_LIBJSON:libjson-c
 
@@ -59,7 +58,7 @@ define Package/bind-libs
 	+libpthread \
 	+libatomic \
 	+libuv \
-	+libnghttp2 \
+	+BIND_ENABLE_DOH:libnghttp2 \
 	+BIND_LIBXML2:libxml2 \
 	+BIND_LIBJSON:libjson-c
   TITLE:=bind shared libraries
@@ -160,6 +159,14 @@ ifdef CONFIG_BIND_LIBXML2
 else
 	CONFIGURE_ARGS += \
 		--with-libxml2=no
+endif
+
+ifdef CONFIG_BIND_ENABLE_DOH
+	CONFIGURE_ARGS += \
+		--enable-doh
+else
+	CONFIGURE_ARGS += \
+		--disable-doh
 endif
 
 CONFIGURE_VARS += \


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64. Validated that the expected `configure` options were provided and that libnghttp2 was not linked when it was supposed to be disabled.
Run tested: x86_64. Basic named serving functionality inc. recursing resolution and authoritative service.

Description:

DoH is enabled by default, but disabling it removes the need to link against libnghttp2, which may be desirable more constrained environments. This change introduce a new Config option allowing support for DoH to be turned off if desired.