### PR TITLE
crowdsec: reworks

### DIFF
--- a/net/crowdsec/Makefile
+++ b/net/crowdsec/Makefile
@@ -21,24 +21,22 @@ PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
-CWD_SYSTEM:=openwrt
+DEFAULT_CONFIGPATH:=/etc/$(PKG_NAME)
+DEFAULT_DATAPATH:=/srv/$(PKG_NAME)/data
 
-CWD_BUILD_VERSION?=v$(PKG_VERSION)
-CWD_BUILD_GOVERSION:=$(shell go version | cut -d " " -f3 | sed -E 's/[go]+//g')
-CWD_BUILD_CODENAME:=alphaga
-CWD_BUILD_TIMESTAMP:=$(shell date +%F"_"%T)
-CWD_BUILD_TAG:=openwrt-$(PKG_VERSION)-$(PKG_RELEASE)
-
-CWD_VERSION_PKG:=github.com/crowdsecurity/crowdsec/pkg/cwversion
+CWD_VARS += BUILD_VERSION="v$(PKG_VERSION)"
+CWD_VARS += BUILD_TAG="openwrt-$(PKG_VERSION)-$(PKG_RELEASE)"
+CWD_VARS += BUILD_GOVERSION="$(shell go version | cut -d " " -f3 | sed -E 's/[go]+//g')"
+CWD_VARS += BUILD_CODENAME="alphaga"
+CWD_VARS += BUILD_TIMESTAMP="$(shell date +%F"_"%T)"
+CWD_VARS += DEFAULT_CONFIGDIR="${DEFAULT_CONFIGPATH}"
+CWD_VARS += DEFAULT_DATADIR="$(DEFAULT_DATAPATH)"
 
 GO_PKG:=github.com/crowdsecurity/crowdsec
 GO_PKG_INSTALL_ALL:=1
-GO_PKG_LDFLAGS_X:=$(CWD_VERSION_PKG).Version=$(CWD_BUILD_VERSION) \
-	$(CWD_VERSION_PKG).System=$(CWD_SYSTEM) \
-	$(CWD_VERSION_PKG).BuildDate=$(CWD_BUILD_TIMESTAMP) \
-	$(CWD_VERSION_PKG).Codename=$(CWD_BUILD_CODENAME)  \
-	$(CWD_VERSION_PKG).Tag=$(CWD_BUILD_TAG) \
-	$(CWD_VERSION_PKG).GoVersion=$(CWD_BUILD_GOVERSION)
+
+CGO_ENABLED = 1
+##GO111MODULE = on
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
@@ -83,68 +81,127 @@ $(call Package/crowdsec/Default/description)
 endef
 
 define Package/crowdsec/install
-	$(call GoPackage/Package/Install/Bin,$(1))
 
-	$(INSTALL_DIR) $(1)/etc/crowdsec
-	$(INSTALL_DIR) $(1)/etc/crowdsec/scenarios
-	$(INSTALL_DIR) $(1)/etc/crowdsec/postoverflows
-	$(INSTALL_DIR) $(1)/etc/crowdsec/collections
-	$(INSTALL_DIR) $(1)/etc/crowdsec/patterns
-	$(INSTALL_DIR) $(1)/etc/crowdsec/hub
+# CONFIG DIRECTORIES
+	$(INSTALL_DIR) $(1)$(DEFAULT_CONFIGPATH)
+	$(INSTALL_DIR) $(1)$(DEFAULT_CONFIGPATH)/scenarios
+	$(INSTALL_DIR) $(1)$(DEFAULT_CONFIGPATH)/postoverflows
+	$(INSTALL_DIR) $(1)$(DEFAULT_CONFIGPATH)/collections
+	$(INSTALL_DIR) $(1)$(DEFAULT_CONFIGPATH)/hub
+	$(INSTALL_DIR) $(1)$(DEFAULT_CONFIGPATH)/bouncers
 
+
+# CONFIG FILES
 	$(INSTALL_DATA) \
 		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/config/config.yaml \
-		$(1)/etc/crowdsec
+		$(1)$(DEFAULT_CONFIGPATH)
 	$(INSTALL_DATA) \
 		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/config/dev.yaml \
-		$(1)/etc/crowdsec
+		$(1)$(DEFAULT_CONFIGPATH)
 	$(INSTALL_DATA) \
 		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/config/user.yaml \
-		$(1)/etc/crowdsec
+		$(1)$(DEFAULT_CONFIGPATH)
 	$(INSTALL_DATA) \
 		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/config/acquis.yaml \
-		$(1)/etc/crowdsec
+		$(1)$(DEFAULT_CONFIGPATH)
 	$(INSTALL_DATA) \
 		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/config/profiles.yaml \
-		$(1)/etc/crowdsec
+		$(1)$(DEFAULT_CONFIGPATH)
 	$(INSTALL_DATA) \
 		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/config/simulation.yaml \
-		$(1)/etc/crowdsec
+		$(1)$(DEFAULT_CONFIGPATH)
 	$(INSTALL_DATA) \
 		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/config/local_api_credentials.yaml \
-		$(1)/etc/crowdsec
+		$(1)$(DEFAULT_CONFIGPATH)
 	$(INSTALL_DATA) \
 		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/config/online_api_credentials.yaml \
-		$(1)/etc/crowdsec
+		$(1)$(DEFAULT_CONFIGPATH)
 
+# CONFIG PATTERNS
+	$(INSTALL_DIR) $(1)$(DEFAULT_CONFIGPATH)/patterns
 	$(CP) \
 		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/config/patterns/* \
-		$(1)/etc/crowdsec/patterns
+		$(1)$(DEFAULT_CONFIGPATH)/patterns
 
-	$(INSTALL_DIR) $(1)/srv/crowdsec/data/
+# PLUGINS BINARIES
+	$(INSTALL_DIR) $(1)/usr/lib/crowdsec/plugins
+	$(INSTALL_BIN) \
+		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/plugins/notifications/slack/notification-slack \
+		$(1)/usr/lib/crowdsec/plugins
+	$(INSTALL_BIN) \
+		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/plugins/notifications/http/notification-http \
+		$(1)/usr/lib/crowdsec/plugins
+	$(INSTALL_BIN) \
+		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/plugins/notifications/splunk/notification-splunk \
+		$(1)/usr/lib/crowdsec/plugins
+	$(INSTALL_BIN) \
+		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/plugins/notifications/email/notification-email \
+		$(1)/usr/lib/crowdsec/plugins
 
+# PLUGINS CONFIG
+	$(INSTALL_DIR) $(1)$(DEFAULT_CONFIGPATH)/notifications
+	$(INSTALL_DATA) \
+		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/plugins/notifications/slack/slack.yaml \
+		$(1)$(DEFAULT_CONFIGPATH)/notifications/slack.yaml
+	$(INSTALL_DATA) \
+		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/plugins/notifications/http/http.yaml \
+		$(1)$(DEFAULT_CONFIGPATH)/notifications/http.yaml
+	$(INSTALL_DATA) \
+		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/plugins/notifications/splunk/splunk.yaml \
+		$(1)$(DEFAULT_CONFIGPATH)/notifications/splunk.yaml
+	$(INSTALL_DATA) \
+		$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/plugins/notifications/email/email.yaml \
+		$(1)$(DEFAULT_CONFIGPATH)/notifications/email.yaml
+
+# DATA
+	$(INSTALL_DIR) $(1)$(DEFAULT_DATAPATH)
+
+# INIT.D SERVICE
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) \
 		./files/crowdsec.initd \
-		$(1)/etc/init.d/crowdsec
+		$(1)/etc/init.d/$(PKG_NAME)
 
+# BINARIES
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/cmd/crowdsec/crowdsec \
+        $(1)/usr/bin/crowdsec
+	$(INSTALL_BIN) $(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/cmd/crowdsec-cli/cscli \
+        $(1)/usr/bin/cscli
+
+# UCI-CONFIG (POSTUPGRADE/POSTINSTALL)
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) \
 		./files/crowdsec.config \
-		$(1)/etc/config/crowdsec
+		$(1)/etc/config/$(PKG_NAME)
 
-	$(LN) /usr/bin/crowdsec-cli $(1)/usr/bin/cscli
-
+# UCI-DEFAULTS (POSTUPGRADE/POSTINSTALL)
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) \
 		./files/crowdsec.defaults \
 		$(1)/etc/uci-defaults/99_crowdsec
+
+# SCRIPT (TOOLS)
+	$(INSTALL_DIR) $(1)/usr/lib/crowdsec/scripts
+	$(INSTALL_BIN) \
+		./files/crowdsec.script \
+		$(1)/usr/lib/crowdsec/scripts/cs_script.sh
 endef
 
 define Package/crowdsec/conffiles
-/etc/crowdsec/
 /etc/config/crowdsec
+/etc/crowdsec/
+/etc/crowdsec/config.yaml
+/etc/crowdsec/acquis.yaml
+/etc/crowdsec/profiles.yaml
+/etc/crowdsec/notifications/
+/etc/crowdsec/bouncers/
 endef
 
-$(eval $(call GoBinPackage,crowdsec))
+# Reset golang-package.mk overrides so we can use the Makefile
+MAKE_VARS += $(GO_PKG_VARS)
+MAKE_VARS += $(CWD_VARS)
+MAKE_PATH:=$(GO_PKG_WORK_DIR_NAME)/build/src/$(GO_PKG)
+Build/Compile=$(call Build/Compile/Default)
+
 $(eval $(call BuildPackage,crowdsec))

--- a/net/crowdsec/files/crowdsec.config
+++ b/net/crowdsec/files/crowdsec.config
@@ -1,4 +1,7 @@
 config crowdsec 'crowdsec'
-	option data_dir '/srv/crowdsec/data'
-	option db_path '/srv/crowdsec/data/crowdsec.db'
+    option configdir    '/etc/crowdsec'
+	option data_dir     '/srv/crowdsec/data'
+	option db_path      '/srv/crowdsec/data/crowdsec.db'
+	option lapi_host    '127.0.0.1'
+	option lapi_port    '8888'
 

--- a/net/crowdsec/files/crowdsec.defaults
+++ b/net/crowdsec/files/crowdsec.defaults
@@ -1,26 +1,14 @@
 #!/bin/sh
+# SPDX-License-Identifier: MIT
+#
+# Copyright (C) 2021-2022 Gerald Kerma <gandalf@gk2.net>
+#
 
-CONFIG=/etc/crowdsec/config.yaml
-data_dir=`uci get "crowdsec.crowdsec.data_dir"`
-sed -i "s,^\(\s*data_dir\s*:\s*\).*\$,\1$data_dir," $CONFIG
-db_path=`uci get "crowdsec.crowdsec.db_path"`
-sed -i "s,^\(\s*db_path\s*:\s*\).*\$,\1$db_path," $CONFIG
+. /usr/lib/crowdsec/scripts/cs_script.sh
 
-# Create data dir & permissions if needed
-if [ ! -d "${data_dir}" ]; then
-	mkdir -m 0755 -p "${data_dir}"
-fi;
-
-if grep -q "login:" /etc/crowdsec/local_api_credentials.yaml; then
-	echo local API already registered...
-else
-	cscli -c /etc/crowdsec/config.yaml machines add -a -f /etc/crowdsec/local_api_credentials.yaml
-fi
-if [ -s /etc/crowdsec/online_api_credentials.yaml ]; then
-	echo online API already registered...
-else
-	cscli -c /etc/crowdsec/config.yaml capi register -f /etc/crowdsec/online_api_credentials.yaml
-fi
-cscli hub update && cscli collections install crowdsecurity/linux && cscli parsers install crowdsecurity/whitelists && cscli hub upgrade
+cs_prepare
+cs_init
+cs_register
+cs_hub
 
 exit 0

--- a/net/crowdsec/files/crowdsec.initd
+++ b/net/crowdsec/files/crowdsec.initd
@@ -1,5 +1,8 @@
 #!/bin/sh /etc/rc.common
+# SPDX-License-Identifier: MIT
+#
 # Copyright (C) 2021-2022 Gerald Kerma <gandalf@gk2.net>
+#
 
 START=99
 USE_PROCD=1
@@ -10,12 +13,18 @@ RUNCONFDIR=/srv/crowdsec/data
 VARCONFIGDIR=/var/etc/crowdsec
 VARCONFIG=/var/etc/crowdsec/config.yaml
 
+. /usr/lib/crowdsec/scripts/cs_script.sh
+
 service_triggers() {
 	procd_add_reload_trigger crowdsec
 }
 
 init_config() {
-	config_load crowdsec
+    cs_prepare
+	cs_init
+    cs_register
+#   cs_hub
+    config_load crowdsec
 	config_get data_dir crowdsec data_dir "${RUNCONFDIR}"
 	config_get db_path crowdsec db_path "${RUNCONFDIR}/crowdsec.db"
 

--- a/net/crowdsec/files/crowdsec.script
+++ b/net/crowdsec/files/crowdsec.script
@@ -1,0 +1,115 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+#
+# Copyright (C) 2021-2022 Gerald Kerma <gandalf@gk2.net>
+#
+
+CSCLI="/usr/bin/cscli"
+PLUGINSDIR="/usr/lib/crowdsec/plugins"
+CONFIGDIR="$(uci -q get "crowdsec.crowdsec.configdir")"
+if [ -z "${CONFIGDIR}" ]; then
+    CONFIGDIR="/etc/crowdsec"
+    uci -q set "crowdsec.crowdsec.configdir"="${CONFIGDIR}"
+    uci -q commit
+fi
+DATA_DIR="$(uci -q get "crowdsec.crowdsec.data_dir")"
+if [ -z "${DATA_DIR}" ]; then
+    DATA_DIR="/srv/crowdsec/data"
+    uci -q set "crowdsec.crowdsec.data_dir"="${DATA_DIR}"
+    uci -q commit
+fi
+DB_PATH="$(uci -q get "crowdsec.crowdsec.db_path")"
+if [ -z "${DB_PATH}" ]; then
+    DB_PATH="/srv/crowdsec/data/crowdsec.db"
+    uci -q set "crowdsec.crowdsec.db_path"="${DB_PATH}"
+    uci -q commit
+fi
+
+# Others
+CFG_FILE="${CONFIGDIR}/config.yaml"
+LOCALAPI="${CONFIGDIR}/local_api_credentials.yaml"
+ONLINEAPI="${CONFIGDIR}/online_api_credentials.yaml"
+HUBDIR="${CONFIGDIR}/hub"
+
+LAPI_HOST=$(uci -q get "crowdsec.crowdsec.lapi_host")
+if [ -z "${LAPI_HOST}" ]; then
+    LAPI_HOST=127.0.0.1
+    uci -q set "crowdsec.crowdsec.lapi_host"=${LAPI_HOST}
+    uci -q commit
+fi
+LAPI_PORT=$(uci -q get "crowdsec.crowdsec.lapi_port")
+if [ -z "${LAPI_PORT}" ]; then
+    LAPI_PORT=8888
+    uci -q set "crowdsec.crowdsec.lapi_port"=${LAPI_PORT}
+    uci -q commit
+fi
+LAPI_URL="http://${LAPI_HOST}:${LAPI_PORT}"
+
+cs_prepare ()
+{
+    # Create data dir & permissions if needed
+    if [ ! -d "${DATA_DIR}" ]; then
+	    mkdir -m 0755 -p "${DATA_DIR}"
+    fi;
+}
+
+cs_init ()
+{
+    # Prepare the config file if needed
+    if [ -e "${CFG_FILE}" ]; then
+        echo "Modify initial config file: ${CFG_FILE}"
+
+        sed -i "s,^\(\s*config_dir\s*:\s*\).*\$,\1${CONFIGDIR}," "${CFG_FILE}"
+        sed -i "s,^\(\s*data_dir\s*:\s*\).*\$,\1${DATA_DIR}," "${CFG_FILE}"
+        sed -i "s,^\(\s*db_path\s*:\s*\).*\$,\1${DB_PATH}," "${CFG_FILE}"
+        sed -i "s,^\(\s*simulation_path\s*:\s*\).*\$,\1${CONFIGDIR}/simulation.yaml," "${CFG_FILE}"
+        sed -i "s,^\(\s*hub_dir\s*:\s*\).*\$,\1${HUBDIR}," "${CFG_FILE}"
+        sed -i "s,^\(\s*index_path\s*:\s*\).*\$,\1${HUBDIR}/.index.json," "${CFG_FILE}"
+        sed -i "s,^\(\s*notification_dir\s*:\s*\).*\$,\1${CONFIGDIR}/notifications/," "${CFG_FILE}"
+        sed -i "s,^\(\s*plugin_dir\s*:\s*\).*\$,\1${PLUGINSDIR}," "${CFG_FILE}"
+        sed -i "s,^\(\s*acquisition_path\s*:\s*\).*\$,\1${CONFIGDIR}/acquis.yaml," "${CFG_FILE}"
+
+        sed -i "s,^\(\s*profiles_path\s*:\s*\).*\$,\1${CONFIGDIR}/profiles.yaml," "${CFG_FILE}"
+        sed -i "s,^\(\s*console_path\s*:\s*\).*\$,\1${CONFIGDIR}/console.yaml," "${CFG_FILE}"
+
+        sed -e "s|credentials_path: /etc/crowdsec/local_api_credentials.yaml|credentials_path: ${LOCALAPI}|g" -i "${CFG_FILE}"
+        sed -e "s|credentials_path: /etc/crowdsec/online_api_credentials.yaml|credentials_path: ${ONLINEAPI}|g" -i "${CFG_FILE}"
+
+        sed -i "s,^\(\s*listen_uri\s*:\s*\).*\$,\1${LAPI_HOST}:${LAPI_PORT}," "${CFG_FILE}"
+        sed -i "s,^\(\s*url\s*:\s*\).*\$,\1${LAPI_URL}," "${LOCALAPI}"
+    fi
+}
+
+cs_register ()
+{
+    if grep -q "login:" "${LOCALAPI}"; then
+        echo "INFO: local API already registered…"
+    else
+        if [ -e "/etc/machine-id" ]; then
+            MACHINEID=$(cat "/etc/machine-id")
+        elif [ -e "/var/lib/dbus/machine-id" ]; then
+            MACHINEID=$(cat "/var/lib/dbus/machine-id")
+        else
+            MACHINEID=$(uci -q get "system.@system[0].hostname")
+        fi
+    # api register
+        "${CSCLI}" -c "${CFG_FILE}" machines add --force "${MACHINEID}" -a -f "${LOCALAPI}" || echo "ERROR: unable to add machine to the local API!"
+    fi
+
+    if grep -q "login:" ${ONLINEAPI}; then
+        echo "INFO: online API already registered…"
+    else
+        "${CSCLI}" -c "${CFG_FILE}" capi register -f "${ONLINEAPI}" || echo "ERROR: unable to register to the Central API!"
+    fi
+}
+
+cs_hub ()
+{
+# FIXME: Do this only if hub is not already up to date !
+        "${CSCLI}" -c "${CFG_FILE}" hub update && \
+        "${CSCLI}" -c "${CFG_FILE}" collections install crowdsecurity/linux && \
+        "${CSCLI}" -c "${CFG_FILE}" collections install crowdsecurity/iptables && \
+        "${CSCLI}" -c "${CFG_FILE}" parsers install crowdsecurity/whitelists && \
+        "${CSCLI}" -c "${CFG_FILE}" hub upgrade
+}
+

--- a/net/crowdsec/patches/011-allow_Makefile_to_override_defaults_directories.patch
+++ b/net/crowdsec/patches/011-allow_Makefile_to_override_defaults_directories.patch
@@ -1,0 +1,271 @@
+From 35eea39db7736e03030d2fd351f40e30207d808f Mon Sep 17 00:00:00 2001
+From: mmetc <92726601+mmetc@users.noreply.github.com>
+Date: Tue, 1 Feb 2022 10:34:53 +0100
+Subject: [PATCH] allow Makefile to override /etc/crowdsec and
+ /var/lib/crowdsec/data (#1221)
+
+---
+ Makefile                     |  4 +++-
+ cmd/crowdsec-cli/config.go   | 12 +++++------
+ cmd/crowdsec-cli/machines.go |  3 ++-
+ cmd/crowdsec-cli/main.go     |  2 +-
+ cmd/crowdsec/main.go         |  2 +-
+ pkg/csconfig/api.go          |  2 +-
+ pkg/csconfig/api_test.go     |  2 +-
+ pkg/csconfig/config.go       | 41 +++++++++++++++++++++++++++---------
+ pkg/csconfig/console.go      |  9 ++++----
+ pkg/cstest/hubtest_item.go   |  4 ++--
+ 10 files changed, 53 insertions(+), 28 deletions(-)
+
+--- a/Makefile
++++ b/Makefile
+@@ -56,7 +56,9 @@ export LD_OPTS=-ldflags "-s -w -X github
+ -X github.com/crowdsecurity/crowdsec/pkg/cwversion.BuildDate=$(BUILD_TIMESTAMP) \
+ -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Codename=$(BUILD_CODENAME)  \
+ -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Tag=$(BUILD_TAG) \
+--X github.com/crowdsecurity/crowdsec/pkg/cwversion.GoVersion=$(BUILD_GOVERSION)"
++-X github.com/crowdsecurity/crowdsec/pkg/cwversion.GoVersion=$(BUILD_GOVERSION) \
++-X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultConfigDir=/etc/crowdsec \
++-X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultDataDir=/var/lib/crowdsec/data"
+ 
+ export LD_OPTS_STATIC=-ldflags "-s -w -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Version=$(BUILD_VERSION) \
+ -X github.com/crowdsecurity/crowdsec/pkg/cwversion.BuildDate=$(BUILD_TIMESTAMP) \
+--- a/cmd/crowdsec-cli/config.go
++++ b/cmd/crowdsec-cli/config.go
+@@ -51,7 +51,7 @@ func backupConfigToDirectory(dirPath str
+ 	}
+ 
+ 	if csConfig.ConfigPaths.SimulationFilePath != "" {
+-		backupSimulation := fmt.Sprintf("%s/simulation.yaml", dirPath)
++		backupSimulation := filepath.Join(dirPath, "simulation.yaml")
+ 		if err = types.CopyFile(csConfig.ConfigPaths.SimulationFilePath, backupSimulation); err != nil {
+ 			return fmt.Errorf("failed copy %s to %s : %s", csConfig.ConfigPaths.SimulationFilePath, backupSimulation, err)
+ 		}
+@@ -63,13 +63,13 @@ func backupConfigToDirectory(dirPath str
+ 	   - backup the other files of acquisition directory
+ 	*/
+ 	if csConfig.Crowdsec != nil && csConfig.Crowdsec.AcquisitionFilePath != "" {
+-		backupAcquisition := fmt.Sprintf("%s/acquis.yaml", dirPath)
++		backupAcquisition := filepath.Join(dirPath, "acquis.yaml")
+ 		if err = types.CopyFile(csConfig.Crowdsec.AcquisitionFilePath, backupAcquisition); err != nil {
+ 			return fmt.Errorf("failed copy %s to %s : %s", csConfig.Crowdsec.AcquisitionFilePath, backupAcquisition, err)
+ 		}
+ 	}
+ 
+-	acquisBackupDir := dirPath + "/acquis/"
++	acquisBackupDir := filepath.Join(dirPath, "acquis")
+ 	if err = os.Mkdir(acquisBackupDir, 0700); err != nil {
+ 		return fmt.Errorf("error while creating %s : %s", acquisBackupDir, err)
+ 	}
+@@ -80,7 +80,7 @@ func backupConfigToDirectory(dirPath str
+ 			if csConfig.Crowdsec.AcquisitionFilePath == acquisFile {
+ 				continue
+ 			}
+-			targetFname, err := filepath.Abs(acquisBackupDir + filepath.Base(acquisFile))
++			targetFname, err := filepath.Abs(filepath.Join(acquisBackupDir, filepath.Base(acquisFile)))
+ 			if err != nil {
+ 				return errors.Wrapf(err, "while saving %s to %s", acquisFile, acquisBackupDir)
+ 			}
+@@ -233,7 +233,7 @@ func restoreConfigFromDirectory(dirPath
+ 	}
+ 
+ 	//if there is files in the acquis backup dir, restore them
+-	acquisBackupDir := dirPath + "/acquis/*.yaml"
++	acquisBackupDir := filepath.Join(dirPath, "acquis", "*.yaml")
+ 	if acquisFiles, err := filepath.Glob(acquisBackupDir); err == nil {
+ 		for _, acquisFile := range acquisFiles {
+ 			targetFname, err := filepath.Abs(csConfig.Crowdsec.AcquisitionDirPath + "/" + filepath.Base(acquisFile))
+@@ -255,7 +255,7 @@ func restoreConfigFromDirectory(dirPath
+ 				log.Infof("skip this one")
+ 				continue
+ 			}
+-			targetFname, err := filepath.Abs(acquisBackupDir + filepath.Base(acquisFile))
++			targetFname, err := filepath.Abs(filepath.Join(acquisBackupDir, filepath.Base(acquisFile)))
+ 			if err != nil {
+ 				return errors.Wrapf(err, "while saving %s to %s", acquisFile, acquisBackupDir)
+ 			}
+--- a/cmd/crowdsec-cli/machines.go
++++ b/cmd/crowdsec-cli/machines.go
+@@ -268,7 +268,8 @@ cscli machines add MyTestMachine --passw
+ 		},
+ 	}
+ 	cmdMachinesAdd.Flags().StringVarP(&machinePassword, "password", "p", "", "machine password to login to the API")
+-	cmdMachinesAdd.Flags().StringVarP(&outputFile, "file", "f", "", "output file destination (defaults to /etc/crowdsec/local_api_credentials.yaml)")
++	cmdMachinesAdd.Flags().StringVarP(&outputFile, "file", "f", "",
++		"output file destination (defaults to "+csconfig.DefaultConfigPath("local_api_credentials.yaml"))
+ 	cmdMachinesAdd.Flags().StringVarP(&apiURL, "url", "u", "", "URL of the local API")
+ 	cmdMachinesAdd.Flags().BoolVarP(&interactive, "interactive", "i", false, "interfactive mode to enter the password")
+ 	cmdMachinesAdd.Flags().BoolVarP(&autoAdd, "auto", "a", false, "automatically generate password (and username if not provided)")
+--- a/cmd/crowdsec-cli/main.go
++++ b/cmd/crowdsec-cli/main.go
+@@ -139,7 +139,7 @@ It is meant to allow you to manage bans,
+ 	}
+ 	rootCmd.AddCommand(cmdVersion)
+ 
+-	rootCmd.PersistentFlags().StringVarP(&ConfigFilePath, "config", "c", "/etc/crowdsec/config.yaml", "path to crowdsec config file")
++	rootCmd.PersistentFlags().StringVarP(&ConfigFilePath, "config", "c", csconfig.DefaultConfigPath("config.yaml"), "path to crowdsec config file")
+ 	rootCmd.PersistentFlags().StringVarP(&OutputFormat, "output", "o", "", "Output format : human, json, raw.")
+ 	rootCmd.PersistentFlags().BoolVar(&dbg_lvl, "debug", false, "Set logging to debug.")
+ 	rootCmd.PersistentFlags().BoolVar(&nfo_lvl, "info", false, "Set logging to info.")
+--- a/cmd/crowdsec/main.go
++++ b/cmd/crowdsec/main.go
+@@ -186,7 +186,7 @@ func (l labelsMap) Set(label string) err
+ 
+ func (f *Flags) Parse() {
+ 
+-	flag.StringVar(&f.ConfigFile, "c", "/etc/crowdsec/config.yaml", "configuration file")
++	flag.StringVar(&f.ConfigFile, "c", csconfig.DefaultConfigPath("config.yaml"), "configuration file")
+ 	flag.BoolVar(&f.TraceLevel, "trace", false, "VERY verbose")
+ 	flag.BoolVar(&f.DebugLevel, "debug", false, "print debug-level on stdout")
+ 	flag.BoolVar(&f.InfoLevel, "info", false, "print info-level on stdout")
+--- a/pkg/csconfig/api.go
++++ b/pkg/csconfig/api.go
+@@ -123,7 +123,7 @@ func (c *Config) LoadAPIServer() error {
+ 			return errors.Wrap(err, "while loading profiles for LAPI")
+ 		}
+ 		if c.API.Server.ConsoleConfigPath == "" {
+-			c.API.Server.ConsoleConfigPath = DefaultConsoleConfgFilePath
++			c.API.Server.ConsoleConfigPath = DefaultConsoleConfigFilePath
+ 		}
+ 		if err := c.API.Server.LoadConsoleConfig(); err != nil {
+ 			return errors.Wrap(err, "while loading console options")
+--- a/pkg/csconfig/api_test.go
++++ b/pkg/csconfig/api_test.go
+@@ -207,7 +207,7 @@ func TestLoadAPIServer(t *testing.T) {
+ 					DbPath: "./tests/test.db",
+ 					Type:   "sqlite",
+ 				},
+-				ConsoleConfigPath: "/etc/crowdsec/console.yaml",
++				ConsoleConfigPath: DefaultConfigPath("console.yaml"),
+ 				ConsoleConfig: &ConsoleConfig{
+ 					ShareManualDecisions:  types.BoolPtr(false),
+ 					ShareTaintedScenarios: types.BoolPtr(true),
+--- a/pkg/csconfig/config.go
++++ b/pkg/csconfig/config.go
+@@ -4,13 +4,20 @@ import (
+ 	"fmt"
+ 	"io/ioutil"
+ 	"os"
++	"path/filepath"
+ 
+ 	"github.com/pkg/errors"
+ 	log "github.com/sirupsen/logrus"
+ 	"gopkg.in/yaml.v2"
+ )
+ 
+-/*top-level config : defaults,overriden by cfg file,overriden by cli*/
++// defaultConfigDir is the base path to all configuration files, to be overridden in the Makefile */
++var defaultConfigDir = "/etc/crowdsec"
++
++// defaultDataDir is the base path to all data files, to be overridden in the Makefile */
++var defaultDataDir = "/var/lib/crowdsec/data/"
++
++// Config contains top-level defaults -> overridden by configuration file -> overridden by CLI flags
+ type Config struct {
+ 	//just a path to ourself :p
+ 	FilePath     *string             `yaml:"-"`
+@@ -71,14 +78,14 @@ func NewDefaultConfig() *Config {
+ 		Level:   "full",
+ 	}
+ 	configPaths := ConfigurationPaths{
+-		ConfigDir:          "/etc/crowdsec/",
+-		DataDir:            "/var/lib/crowdsec/data/",
+-		SimulationFilePath: "/etc/crowdsec/config/simulation.yaml",
+-		HubDir:             "/etc/crowdsec/hub",
+-		HubIndexFile:       "/etc/crowdsec/hub/.index.json",
++		ConfigDir:          DefaultConfigPath("."),
++		DataDir:            DefaultDataPath("."),
++		SimulationFilePath: DefaultConfigPath("simulation.yaml"),
++		HubDir:             DefaultConfigPath("hub"),
++		HubIndexFile:       DefaultConfigPath("hub", ".index.json"),
+ 	}
+ 	crowdsecCfg := CrowdsecServiceCfg{
+-		AcquisitionFilePath: "/etc/crowdsec/config/acquis.yaml",
++		AcquisitionFilePath: DefaultConfigPath("acquis.yaml"),
+ 		ParserRoutinesCount: 1,
+ 	}
+ 
+@@ -88,20 +95,20 @@ func NewDefaultConfig() *Config {
+ 
+ 	apiCfg := APICfg{
+ 		Client: &LocalApiClientCfg{
+-			CredentialsFilePath: "/etc/crowdsec/config/lapi-secrets.yaml",
++			CredentialsFilePath: DefaultConfigPath("lapi-secrets.yaml"),
+ 		},
+ 		Server: &LocalApiServerCfg{
+ 			ListenURI:              "127.0.0.1:8080",
+ 			UseForwardedForHeaders: false,
+ 			OnlineClient: &OnlineApiClientCfg{
+-				CredentialsFilePath: "/etc/crowdsec/config/online-api-secrets.yaml",
++				CredentialsFilePath: DefaultConfigPath("config", "online-api-secrets.yaml"),
+ 			},
+ 		},
+ 	}
+ 
+ 	dbConfig := DatabaseCfg{
+ 		Type:   "sqlite",
+-		DbPath: "/var/lib/crowdsec/data/crowdsec.db",
++		DbPath: DefaultDataPath("crowdsec.db"),
+ 	}
+ 
+ 	globalCfg := Config{
+@@ -116,3 +123,17 @@ func NewDefaultConfig() *Config {
+ 
+ 	return &globalCfg
+ }
++
++// DefaultConfigPath returns the default path for a configuration resource
++// "elem" parameters are path components relative to the default cfg directory.
++func DefaultConfigPath(elem ...string) string {
++	elem = append([]string{defaultConfigDir}, elem...)
++	return filepath.Join(elem...)
++}
++
++// DefaultDataPath returns the the default path for a data resource.
++// "elem" parameters are path components relative to the default data directory.
++func DefaultDataPath(elem ...string) string {
++	elem = append([]string{defaultDataDir}, elem...)
++	return filepath.Join(elem...)
++}
+--- a/pkg/csconfig/console.go
++++ b/pkg/csconfig/console.go
+@@ -17,10 +17,10 @@ const (
+ 	SEND_MANUAL_SCENARIOS  = "manual"
+ )
+ 
+-var DefaultConsoleConfgFilePath = "/etc/crowdsec/console.yaml"
+-
+ var CONSOLE_CONFIGS = []string{SEND_CUSTOM_SCENARIOS, SEND_MANUAL_SCENARIOS, SEND_TAINTED_SCENARIOS}
+ 
++var DefaultConsoleConfigFilePath = DefaultConfigPath("console.yaml")
++
+ type ConsoleConfig struct {
+ 	ShareManualDecisions  *bool `yaml:"share_manual_decisions"`
+ 	ShareTaintedScenarios *bool `yaml:"share_tainted"`
+@@ -71,8 +71,9 @@ func (c *LocalApiServerCfg) DumpConsoleC
+ 		return errors.Wrapf(err, "while marshaling ConsoleConfig (for %s)", c.ConsoleConfigPath)
+ 	}
+ 	if c.ConsoleConfigPath == "" {
+-		log.Debugf("Empty console_path, defaulting to %s", DefaultConsoleConfgFilePath)
+-		c.ConsoleConfigPath = DefaultConsoleConfgFilePath
++		c.ConsoleConfigPath = DefaultConsoleConfigFilePath
++		log.Debugf("Empty console_path, defaulting to %s", c.ConsoleConfigPath)
++
+ 	}
+ 
+ 	if err := os.WriteFile(c.ConsoleConfigPath, out, 0600); err != nil {
+--- a/pkg/cstest/hubtest_item.go
++++ b/pkg/cstest/hubtest_item.go
+@@ -77,10 +77,10 @@ const (
+ 	ScenarioResultFileName = "bucket-dump.yaml"
+ 
+ 	BucketPourResultFileName = "bucketpour-dump.yaml"
+-
+-	crowdsecPatternsFolder = "/etc/crowdsec/patterns/"
+ )
+ 
++var crowdsecPatternsFolder = csconfig.DefaultConfigPath("patterns")
++
+ func NewTest(name string, hubTest *HubTest) (*HubTestItem, error) {
+ 	testPath := filepath.Join(hubTest.HubTestPath, name)
+ 	runtimeFolder := filepath.Join(testPath, "runtime")

--- a/net/crowdsec/patches/012-add_ENV_VARIABLES_to_override_defaults_directories.patch
+++ b/net/crowdsec/patches/012-add_ENV_VARIABLES_to_override_defaults_directories.patch
@@ -1,0 +1,50 @@
+From 6d1adb1784c71f9a8abe54addb63faf6f1f3d051 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kerma=20G=C3=A9rald?= <gandalf@gk2.net>
+Date: Tue, 1 Feb 2022 17:16:17 +0100
+Subject: [PATCH] Makefile: add ENV VARIABLES to override /etc/crowdsec and
+ /var/lib/crowdsec/data (#1224)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+to enhance:
+https://github.com/crowdsecurity/crowdsec/commit/35eea39db7736e03030d2fd351f40e30207d808f
+
+- add ENV VARIABLES to help defaults settings from script build (without hardcoded patch need)
+- add override also in static build
+
+Signed-off-by: Kerma Gérald <gandalf@gk2.net>
+---
+ Makefile | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+--- a/Makefile
++++ b/Makefile
+@@ -50,6 +50,8 @@ BUILD_GOVERSION="$(shell go version | cu
+ BUILD_CODENAME=$(shell cat RELEASE.json | jq -r .CodeName)
+ BUILD_TIMESTAMP=$(shell date +%F"_"%T)
+ BUILD_TAG?="$(shell git rev-parse HEAD)"
++DEFAULT_CONFIGDIR ?= "/etc/crowdsec"
++DEFAULT_DATADIR ?= "/var/lib/crowdsec/data"
+ 
+ export LD_OPTS=-ldflags "-s -w -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Version=$(BUILD_VERSION) \
+ -X github.com/crowdsecurity/crowdsec/pkg/cwversion.System=$(SYSTEM) \
+@@ -57,14 +59,16 @@ export LD_OPTS=-ldflags "-s -w -X github
+ -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Codename=$(BUILD_CODENAME)  \
+ -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Tag=$(BUILD_TAG) \
+ -X github.com/crowdsecurity/crowdsec/pkg/cwversion.GoVersion=$(BUILD_GOVERSION) \
+--X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultConfigDir=/etc/crowdsec \
+--X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultDataDir=/var/lib/crowdsec/data"
++-X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultConfigDir=$(DEFAULT_CONFIGDIR) \
++-X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultDataDir=$(DEFAULT_DATADIR)"
+ 
+ export LD_OPTS_STATIC=-ldflags "-s -w -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Version=$(BUILD_VERSION) \
+ -X github.com/crowdsecurity/crowdsec/pkg/cwversion.BuildDate=$(BUILD_TIMESTAMP) \
+ -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Codename=$(BUILD_CODENAME)  \
+ -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Tag=$(BUILD_TAG) \
+ -X github.com/crowdsecurity/crowdsec/pkg/cwversion.GoVersion=$(BUILD_GOVERSION) \
++-X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultConfigDir=$(DEFAULT_CONFIGDIR) \
++-X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultDataDir=$(DEFAULT_DATADIR) \
+ -extldflags '-static'"
+ 
+ RELDIR = crowdsec-$(BUILD_VERSION)


### PR DESCRIPTION
was : "crowdsec: install defaults notifications"
renamed to "crowdsec: reworks"

Maintainer: Gérald Kerma @erdoukki [gandalf@gk2.net](mailto:gandalf@gk2.net)
Environment: (all, OpenWrt Master & 21.02.x)
Tested: (MVEBU, EspressoBin & EspressoBin-Ultra, OpenWrt 21.02.x & 19.07.x)

Description:
https://docs.crowdsec.net/docs/next/notification_plugins/intro

> Crowdsec supports notification plugins, meant to be able to push alerts to third party services, for alerting or integration purposes. At the time of writting, plugins exists for [slack](https://docs.crowdsec.net/docs/next/notification_plugins/slack), [splunk](https://docs.crowdsec.net/docs/next/notification_plugins/splunk), and a generic [http push](https://docs.crowdsec.net/docs/next/notification_plugins/http) plugin (allowing to push to services such as [elasticsearch](https://docs.crowdsec.net/docs/next/notification_plugins/elastic)).

update crowdsec Makefile to fix plugins notifications build and install:
- use correct path in GO_PKG_BUILD_PKG to build plugins
- use INSTALL_DATA and INSTALL_BIN instead of CP to install plugins and config

other fix:
- add bouncers directory
- add upstream patches for default data and config directories
- rewrote & clean the defaults script (also verified with shellcheck)
- rewrote & clean the Makefile
- remove useless crowdsec-cli
- add configdir to config file
- add lapi_host and lapi_port to config file
- upgrade missing configs values to defaults in config file at upgrade
- add license and copyright
- use CWD_VARS for Makefile variables
- move defaults and init to a global script (cs-script.sh)
- add cs-script.sh /usr/lib/crowdsec/scripts/
- call initialisations scripts in initd
- fix plugins url in config
- preserve some modified configs from upgrade

Signed-off-by: Kerma Gérald <gandalf@gk2.net>