### PR TITLE
lxc-create: update depends to include getopt

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -39,7 +39,7 @@ LXC_SCRIPTS += \
 
 DEPENDS_APPLETS = +libpthread +libcap +liblxc
 
-DEPENDS_create = +lxc-configs +lxc-hooks +lxc-templates +flock
+DEPENDS_create = +lxc-configs +lxc-hooks +lxc-templates +flock +getopt
 
 define Package/lxc/Default
   SECTION:=utils


### PR DESCRIPTION
Fixes https://github.com/openwrt/packages/issues/16684
```
Build system: x86_64
Build-tested: bcm2711/RPi4B
Run-tested: bcm2711/RPi4B
```
Signed-off-by: John Audia <graysky@archlinux.us>

Maintainer: @robimarko @BKPepe @cotequeiroz 