### PR TITLE
mbusd: Repair UCI config file about parity

### DIFF
--- a/net/mbusd/files/mbusd.conf
+++ b/net/mbusd/files/mbusd.conf
@@ -9,7 +9,7 @@ config mbusd
 	option device '/dev/ttyUSB0'
 	option speed 19200
 	option databits 8
-	option parity 0
+	option parity 'N'
 	option stopbits 2
 	option rts 0
 

--- a/net/mbusd/files/mbusd.init
+++ b/net/mbusd/files/mbusd.init
@@ -14,7 +14,7 @@ mbusd_instance() {
 	[ "$enabled" -gt 0 ] || return 1
 
 
-	[ "$parity" = 0 ] && parity=n || parity=y
+	[ "$parity" = 0 ] && parity=n
 	[ "$rts" = 0 ] && rts=
 
 
@@ -50,7 +50,7 @@ validate_section_mbusd() {
 		'device:string' \
 		'speed:uinteger' \
 		'databits:uinteger' \
-		'parity:bool' \
+		'parity:string' \
 		'stopbits:uinteger' \
 		'rts:bool:0' \
 		'rtu_retries:uinteger' \


### PR DESCRIPTION
Signed-off-by: Chip Lee <chplee@gmail.com>

Maintainer: Chip Lee <chplee@gmail.com> / @Marcin Jurkowski <marcin1j@gmail.com>
Compile tested: MediaTek MT7620A ver:2 eco:6, Xiaomi MiWiFi Mini, OpenWrt 21.02.1
Run tested: MediaTek MT7620A ver:2 eco:6, Xiaomi MiWiFi Mini, OpenWrt 21.02.1, tests done

Description:
in mbusd, parity must be N, E or O, can't be y.