### PR TITLE
tesseract: fix build on macos

### DIFF
--- a/utils/tesseract/Makefile
+++ b/utils/tesseract/Makefile
@@ -35,6 +35,7 @@ endef
 TARGET_CFLAGS:=$(filter-out -O%,$(TARGET_CFLAGS)) -O3
 
 CMAKE_OPTIONS += \
+	-DAUTO_OPTIMIZE=OFF \
 	-DBUILD_TRAINING_TOOLS=OFF
 
 define Build/InstallDev


### PR DESCRIPTION
tesseract build script checks /proc/cpuinfo file, but this file is
not exist or darwin. This check is used for getting  optimized build
flags depends on CPU. This feature does not work in cross-compile
case and should be explicitly disabled.

This patch disables CPU detection using cmake option
BUILD_TRAINING_TOOLS=OFF.

Generated binaries (aarch64 target) are exactly the same on
Ubuntu 20.04 x86_64 and MacOS 11.6 arm64. Binaries generated on
Linux build host are not changed (the same checksums before and
after applying this patch).

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @vk496 
Compile tested: (armvirt/64, OpenWrt 4d904524effc9eb0cc5094574c55d3a520803223)
