### PR TITLE
net-snmp: move start order from 50 to 99

### DIFF
--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2008 OpenWrt.org
-START=50
+START=99
 
 USE_PROCD=1
 PROG="/usr/sbin/snmpd"


### PR DESCRIPTION
Maintainer: Stijn Tintel [stijn@linux-ipv6.be](mailto:stijn@linux-ipv6.be) @stintel
Compile tested: ath79, generic, ubnt_unifiac-lite, HEAD
Run tested: ath79, generic, ubnt_unifiac-lite, HEAD, ensure snmpd starts (and functions) after boot with no intervention

Description:

Fixes issue described in this [thread](https://forum.openwrt.org/t/snmpd-not-responding-on-boot/87882/37?page=2) on the forums.

Root cause: extroot is not fully up at S50, and thus `/etc/snmp/snmpd.conf` (linked to `/var/run/snmpd.conf`) is not available for `snmpd`, causing it to start in a "broken" (ie. default settings) state.

---
Signed-off-by: Seth Kingry [sjkingry@gmail.com](mailto:sjkingry@gmail.com)