### PR TITLE
adblock: make reproducible

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
 PKG_VERSION:=4.1.3
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 
@@ -59,7 +59,7 @@ define Package/adblock/install
 	$(INSTALL_CONF) ./files/adblock.whitelist $(1)/etc/adblock
 	$(INSTALL_CONF) ./files/adblock.categories $(1)/etc/adblock
 	$(INSTALL_CONF) ./files/adblock.sources $(1)/etc/adblock
-	gzip -9 $(1)/etc/adblock/adblock.sources
+	gzip -9n $(1)/etc/adblock/adblock.sources
 endef
 
 $(eval $(call BuildPackage,adblock))


### PR DESCRIPTION
Need to get rid of the timestamp.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dibdot 

https://tests.reproducible-builds.org/openwrt/dbd/packages/arm_cortex-a8_vfpv3/packages/adblock_4.1.3-1_all.ipk.html
