### PR TITLE
knot: update to 3.1.6

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.1.5
+PKG_VERSION:=3.1.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=2da6e50b0662297d55f80e349568224e07fe88cad20bee1d2e22f54bb32da064
+PKG_HASH:=e9ba1305d750dc08fb08687aec7ac55737ca073deaa0b867c884e0c0f2fdb753
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 5.3.4 (hbk)
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 5.3.1 (hbk), all tests successful (1 skipped)

Description:

- Release patch
