### PR TITLE
openssh-server: fix failsafe mode setup

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -183,7 +183,7 @@ CONFIGURE_ARGS += \
 	--without-pam
 endif
 
-CONFIGURE_VARS += LD="$(TARGET_CC)"
+CONFIGURE_VARS += LD="$(TARGET_CC)" PATH_PASSWD_PROG="/bin/passwd"
 
 ifeq ($(BUILD_VARIANT),with-pam)
 TARGET_LDFLAGS += -lpthread

--- a/net/openssh/files/sshd.failsafe
+++ b/net/openssh/files/sshd.failsafe
@@ -8,8 +8,6 @@ failsafe_sshd () {
 	sshd_tmpdir=/tmp/sshd
 	mkdir $sshd_tmpdir
 
-	sed -i 's/^root:.*/root::0:17000:::::/g' /etc/shadow
-
 	for type in ed25519; do
 		key=$sshd_tmpdir/ssh_host_${type}_key
 		ssh-keygen -N '' -t ${type} -f ${key}


### PR DESCRIPTION
Maintainer:  @tripolar
Compile tested: mipsel_24kc, ramips/mt7621, master
Run tested: mipsel_24kc, ramips/mt7621, master

Description:
Fixes openwrt/packages#17833