### PR TITLE
Revert "postfix: fix build on macos"

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postfix
 PKG_VERSION:=3.5.8
-PKG_RELEASE:=3
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \

--- a/mail/postfix/patches/500-crosscompile.patch
+++ b/mail/postfix/patches/500-crosscompile.patch
@@ -5,17 +5,15 @@
  case $# in
   # Officially supported usage.
 - 0) SYSTEM=`(uname -s) 2>/dev/null`
-+ 0) SYSTEM="OpenWrt"
++ 0) SYSTEM="OpenWRT"
      RELEASE=`(uname -r) 2>/dev/null`
      # No ${x%%y} support in Solaris 11 /bin/sh
      RELEASE_MAJOR=`expr "$RELEASE" : '\([0-9]*\)'` || exit 1
-@@ -242,6 +242,17 @@ case "$SYSTEM" in
+@@ -242,6 +242,15 @@ case "$SYSTEM" in
  esac
  
  case "$SYSTEM.$RELEASE" in
-+   OpenWrt*)    SYSTYPE=LINUX5
-+		AR="${CC-gcc}-ar"
-+		RANLIB="${CC-gcc}-ranlib"
++   OpenWRT*)    SYSTYPE=LINUX$RELEASE_MAJOR
 +		SYSLIBS="$SYSLIBS -ldl"
 +		: ${SHLIB_SUFFIX=.so}
 +		: ${SHLIB_CFLAGS=-fPIC}


### PR DESCRIPTION
Reverts openwrt/packages#17650 due to https://github.com/openwrt/packages/issues/17835

I will work on new patch, but it requires some time so let's revert it for now