### PR TITLE
unbound: update to version 1.15.0

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.14.0
+PKG_VERSION:=1.15.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound
-PKG_HASH:=6ef91cbf02d5299eab39328c0857393de7b4885a2fe7233ddfe3c124ff5a89c8
+PKG_HASH:=a480dc6c8937447b98d161fe911ffc76cfaffa2da18788781314e81339f1126f
 
 PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/unbound/patches/010-configure-uname.patch
+++ b/net/unbound/patches/010-configure-uname.patch
@@ -3,7 +3,7 @@ Fix cross compile errors by inserting an environment variable for the
 target. Use "uname" on host only if "UNAME" variable is empty.
 --- a/configure.ac
 +++ b/configure.ac
-@@ -777,7 +777,7 @@ if test x_$ub_test_python != x_no; then
+@@ -811,7 +811,7 @@ if test x_$ub_test_python != x_no; then
     fi
  fi
  


### PR DESCRIPTION
Maintainer: @EricLuehrsen 
Compile and run tested: Turris 1.1, OpenWrt 19.07 and OpenWrt 21.02, powerpc_8540

Description:
- Bump to 1.15.0
   - Changelog: https://www.nlnetlabs.nl/projects/unbound/download/#unbound-1-15-0