### PR TITLE
avahi: Changed the target file for the patch

### DIFF
--- a/libs/avahi/patches/020-revert-runtime-dir-systemd-change.patch
+++ b/libs/avahi/patches/020-revert-runtime-dir-systemd-change.patch
@@ -1,11 +1,11 @@
---- a/configure
-+++ b/configure
-@@ -24638,7 +24638,7 @@ _ACEOF
+--- a/configure.ac
++++ b/configure.ac
+@@ -1004,7 +1004,7 @@ AC_DEFINE_UNQUOTED(AVAHI_AUTOIPD_GROUP,"
  #
  # Avahi runtime dir
  #
 -avahi_runtime_dir="/run"
 +avahi_runtime_dir="${localstatedir}/run"
  avahi_socket="${avahi_runtime_dir}/avahi-daemon/socket"
- 
- 
+ AC_SUBST(avahi_runtime_dir)
+ AC_SUBST(avahi_socket)


### PR DESCRIPTION
Maintainer: @thess
Compile tested: head, aarch64
Run tested: aarch64

Description:
Fixed the affected issue in the latest commit
https://github.com/openwrt/packages/commit/8490d7096d67d868e1cc068c454ab3dbe683b6d8
```
daemon.err avahi-daemon[xxx]: mkdir("/run/avahi-daemon/"): No such file or directory
```

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>

