### PR TITLE
opendoas: add package

### DIFF
--- a/utils/opendoas/Makefile
+++ b/utils/opendoas/Makefile
@@ -1,0 +1,40 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=opendoas
+PKG_VERSION:=6.8.2
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/Duncaen/OpenDoas/releases/download/v$(PKG_VERSION)
+PKG_HASH:=4e98828056d6266bd8f2c93e6ecf12a63a71dbfd70a5ea99ccd4ab6d0745adf0
+
+PKG_MAINTAINER:=Michal Vasilek <michal.vasilek@nic.cz>
+PKG_LICENSE:=ISC, BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/opendoas
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Portable OpenBSD doas to execute commands as another user
+  URL:=https://github.com/Duncaen/OpenDoas
+endef
+
+define Package/opendoas/description
+ OpenDoas: a portable version of OpenBSD's doas command
+
+ doas is a minimal replacement for the venerable sudo. It was initially
+ written by Ted Unangst of the OpenBSD project to provide 95% of the features
+ of sudo with a fraction of the codebase.
+endef
+
+define Package/opendoas/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/doas $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,opendoas))

--- a/utils/opendoas/patches/configure-ignore-invalid-arguments.patch
+++ b/utils/opendoas/patches/configure-ignore-invalid-arguments.patch
@@ -1,0 +1,11 @@
+--- a/configure
++++ b/configure
+@@ -67,7 +67,7 @@ for x; do
+ 	--uid-max) UID_MAX=$var ;;
+ 	--gid-max) UID_MAX=$var ;;
+ 	--help|-h) usage ;;
+-	*) die "Error: unknown option $opt" ;;
++	*) echo "Error: unknown option $opt" ;;
+ 	esac
+ done
+ 

--- a/utils/opendoas/patches/makefile-remove-chown.patch
+++ b/utils/opendoas/patches/makefile-remove-chown.patch
@@ -1,0 +1,10 @@
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -21,7 +21,6 @@ install: ${PROG} ${PAM_DOAS} ${MAN}
+ 	mkdir -p -m 0755 ${DESTDIR}${MANDIR}/man1
+ 	mkdir -p -m 0755 ${DESTDIR}${MANDIR}/man5
+ 	cp -f ${PROG} ${DESTDIR}${BINDIR}
+-	chown ${BINOWN}:${BINGRP} ${DESTDIR}${BINDIR}/${PROG}
+ 	chmod ${BINMODE} ${DESTDIR}${BINDIR}/${PROG}
+ 	[ -n "${PAM_DOAS}" ] && cp ${PAM_DOAS} ${DESTDIR}${PAMDIR}/doas || true
+ 	[ -n "${PAM_DOAS}" ] && chmod 0644 ${DESTDIR}${PAMDIR}/doas || true


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64, Turris MOX, OpenWrt master
Run tested: aarch64, Turris MOX, OpenWrt master

Description: opendoas is a port of OpenBSD doas to Linux, it replaced sudo in the main alpine repository with 3.15.

if someone wants to test this, add this to `/etc/doas.conf`:
```
permit nopass <user> as root
```
and try running doas id -u as `<user>`