### PR TITLE
openvpn-easy-rsa: make it reproducible

### DIFF
--- a/net/openvpn-easy-rsa/Makefile
+++ b/net/openvpn-easy-rsa/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn-easy-rsa
 
 PKG_VERSION:=3.0.8
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_SOURCE_URL:=https://codeload.github.com/OpenVPN/easy-rsa/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=fd6b67d867c3b8afd53efa2ca015477f6658a02323e1799432083472ac0dd200

--- a/net/openvpn-easy-rsa/patches/100-Make-package-reproducible.patch
+++ b/net/openvpn-easy-rsa/patches/100-Make-package-reproducible.patch
@@ -1,0 +1,30 @@
+From fd2351615540dee6c86466d6e1138340baeebde4 Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Tue, 15 Feb 2022 01:37:06 -0300
+Subject: [PATCH] Make package reproducible
+
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+---
+ build/build-dist.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/build/build-dist.sh
++++ b/build/build-dist.sh
+@@ -80,7 +80,7 @@ stage_unix() {
+ 	
+ 	# FreeBSD does not accept -i without argument in a way also acceptable by GNU sed
+ 	sed -i.tmp -e "s/~VER~/$VERSION/" \
+-		   -e "s/~DATE~/$(date)/" \
++		   -e "s/~DATE~/$(SOURCE_DATE_EPOCH)/" \
+ 		   -e "s/~HOST~/$(hostname -s)/" \
+ 		   -e "s/~GITHEAD~/$(git rev-parse HEAD)/" \
+ 		   "$DIST_ROOT/unix/$PV/easyrsa" || die "Cannot update easyrsa version data"
+@@ -122,7 +122,7 @@ stage_win() {
+ 		done
+ 	
+ 		sed -i.tmp -e "s/~VER~/$VERSION/" \
+-			   -e "s/~DATE~/$(date)/" \
++			   -e "s/~DATE~/$(SOURCE_DATE_EPOCH)/" \
+ 			   -e "s/~HOST~/$(hostname -s)/" \
+ 			   -e "s/~GITHEAD~/$(git rev-parse HEAD)/" \
+ 			   "$DIST_ROOT/$win/$PV/easyrsa" || die "Cannot update easyrsa version data"


### PR DESCRIPTION
The "build" script was replacing a `~DATE~` with current date.
Now it uses `$(SOURCE_DATE_EPOCH)`.

Fixes #17848

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: me
Compile tested: trunk 
Run tested: not needed

Description:
