### PR TITLE
tvheadend: fix issue #17816

### DIFF
--- a/multimedia/tvheadend/files/tvheadend.init
+++ b/multimedia/tvheadend/files/tvheadend.init
@@ -10,7 +10,12 @@ TEMP_CONFIG=/tmp/tvheadend
 PERSISTENT_CONFIG=/etc/tvheadend
 
 execute_first_run() {
-	"$PROG" -c "$1" -B -C -A >/dev/null 2>&1
+	# This should create a new configuration including an admin account with no name and no password,
+	# but it aborts (-A) too early without saving it:
+	# "$PROG" -c "$1" -B -C -A >/dev/null 2>&1
+	# Instead, run it for 10s, then kill it:
+	"$PROG" -c "$1" -B -C & TVH_PID=$! ; sleep 10 ; kill $TVH_PID
+	# Remove this and go back to initial command when tvheadend bug is fixed.
 }
 
 ensure_config_exists() {


### PR DESCRIPTION
This is a temporary workaround until the tvheadend bug is fixed.

Maintainer: me
Compile tested: Not tested. I took it from master branch, removing the user and group options.
Run tested: r18404, I tested only the command, not whole package.

Description:
The command I replaced should create tvheadend initial admin account without password and save it to /etc/tvheadend. It does not. Tvheadend aborts execution before the configuration is saved to disk. It's a tvheadend bug.
This was fixed in master branch https://github.com/openwrt/packages/pull/16475, but that pull request makes lots of other changes and it was not included in this branch.