### PR TITLE
tvheadend: fix first-run

### DIFF
--- a/multimedia/tvheadend/files/tvheadend.init
+++ b/multimedia/tvheadend/files/tvheadend.init
@@ -10,7 +10,12 @@ TEMP_CONFIG=/tmp/tvheadend
 PERSISTENT_CONFIG=/etc/tvheadend
 
 execute_first_run() {
-	"$PROG" -c "$1" -B -C -A >/dev/null 2>&1
+	# This should create a new configuration including an admin account with no name and no password,
+	# but it aborts (-A) too early without saving it:
+	# "$PROG" -c "$1" -B -C -A >/dev/null 2>&1
+	# Instead, run it for 10s, then kill it:
+	"$PROG" -c "$1" -B -C & TVH_PID=$! ; sleep 10 ; kill $TVH_PID ; sleep 2
+	# Remove this and go back to initial command if it's working again in newer tvheadend versions.
 }
 
 ensure_config_exists() {


### PR DESCRIPTION
Maintainer: me
Compile tested: Not tested. I took it from master branch, removing the user and group options.
Run tested: r18404, I tested only the command, not whole package.

This was already fixed in master branch: https://github.com/openwrt/packages/pull/16475, but that pull request makes lots of other changes and it was not included in this branch. Fixes issue #17816.

Description:
The first-run command should create a new tvheadend configuration including an admin account with no name and no password, but it aborts (-A) too early without saving the files. I reported the bug here: https://tvheadend.org/issues/6140
This workaround fixes the problem by removing the tvheadend -A switch and replacing it with a 10s delay and a kill signal. That should be enough even for slow routers to generate and save the configuration. It is meant to be a temporary fix until tvheadend bug is resolved.