### PR TITLE
zabbix: add sqlite support for zabbix-proxy and add an init-script

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -308,6 +308,7 @@ endef
 define Package/zabbix-proxy/install
 	$(call Package/zabbix/install/sbin,$(1),proxy)
 	$(call Package/zabbix/install/etc,$(1),proxy)
+	$(call Package/zabbix/install/init.d,$(1),proxy)
 endef
 
 $(eval $(call BuildPackage,zabbix-agentd))

--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -64,6 +64,9 @@ choice
         config ZABBIX_POSTGRESQL
                 bool "PostgreSQL"
 
+        config ZABBIX_SQLITE
+                bool "SQLite"
+
 endchoice
 endef
 
@@ -113,7 +116,7 @@ endef
 define Package/zabbix-server
   $(call Package/zabbix/Default)
   TITLE+= server
-  DEPENDS += +ZABBIX_POSTGRESQL:libpq +ZABBIX_MYSQL:libmariadbclient +libevent2
+  DEPENDS += @((ZABBIX_MYSQL||ZABBIX_POSTGRESQL)) +ZABBIX_POSTGRESQL:libpq +ZABBIX_MYSQL:libmariadbclient +libevent2
 endef
 
 define Package/zabbix-server-frontend
@@ -127,7 +130,7 @@ endef
 define Package/zabbix-proxy
   $(call Package/zabbix/Default)
   TITLE+= proxy
-  DEPENDS += +ZABBIX_POSTGRESQL:libpq +ZABBIX_MYSQL:libmariadbclient +libevent2
+  DEPENDS += +ZABBIX_POSTGRESQL:libpq +ZABBIX_MYSQL:libmariadbclient +ZABBIX_SQLITE:libsqlite3 +libevent2
 endef
 
 define Package/zabbix-extra-mac80211/description
@@ -150,12 +153,13 @@ endef
 
 CONFIGURE_ARGS+= \
 	--enable-agent \
-	--enable-server \
+	$(if $(CONFIG_PACKAGE_zabbix-server),--enable,--disable)-server \
 	--enable-proxy \
 	$(call autoconf_bool,CONFIG_IPV6,ipv6) \
 	--disable-java \
 	$(if $(CONFIG_ZABBIX_MYSQL),--with-mysql) \
 	$(if $(CONFIG_ZABBIX_POSTGRESQL),--with-postgresql) \
+	$(if $(CONFIG_ZABBIX_SQLITE),--with-sqlite3) \
 	--with-libevent=$(STAGING_DIR)/usr/include/libevent \
 	--with-libpcre=$(STAGING_DIR)/usr/include \
 	--with-zlib=$(STAGING_DIR)/usr/include \

--- a/admin/zabbix/files/zabbix_proxy.init
+++ b/admin/zabbix/files/zabbix_proxy.init
@@ -1,0 +1,23 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2008-2011 OpenWrt.org
+
+START=60
+
+USE_PROCD=1
+PROG=/usr/sbin/zabbix_proxy
+CONFIG=/etc/zabbix_proxy.conf
+
+start_service() {
+	# Sometimes the proxy config was installed in /etc/zabbix/zabbix_proxy.conf
+	[ -f /etc/zabbix/zabbix_proxy.conf ] && mv /etc/zabbix/zabbix_proxy.conf ${CONFIG}
+
+	[ -f ${CONFIG} ] || return 1
+
+	procd_open_instance
+	procd_set_param command ${PROG} -c ${CONFIG} -f
+	procd_set_param respawn
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}
+


### PR DESCRIPTION
Maintainer: @champtar
Compile tested: lantiq, xrx200, 21.02
Run tested: lantiq, xrx200, 21.02

Description:
The first patch makes it possible to build zabbix-proxy with sqlite3 support.
Attention: by selcting "SQLite" as "Database Software" you are not able to build the zabbix-server package.

The second patch adds a simple init-script for the zabbix-proxy.

