### PR TITLE
fix Openwrt 21.02 docker build error when use glibc on x86_64 build

### DIFF
--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -15,6 +15,8 @@ PKG_GIT_SHORT_COMMIT:=e91ed57 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
+TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-lgcc_eh)
+
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -15,6 +15,8 @@ PKG_GIT_SHORT_COMMIT:=459d0df # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
+TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-lgcc_eh)
+
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
Maintainer: Gerard Ryan <G.M0N3Y.2503@gmail.com>

Compile tested: 
tested on build Openwrt21.02 x86_64 with glibc on ubuntu 20.04

Run tested:
OpenWrt 21.02-SNAPSHOT r16495-bf0c965af0 / LuCI openwrt-21.02 branch git-22.047.35373-cc582eb
Docker Version 20.10.12 
tested on Asus PN51-E1 Ryzen 5 5500U

Description:
fix docker and dockerd build error when using glibc on tartget arch x86_64