### PR TITLE
shared-mimo-info: fix compilation with BUILD_NLS

### DIFF
--- a/utils/shared-mime-info/Makefile
+++ b/utils/shared-mime-info/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shared-mime-info
 PKG_VERSION:=2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -19,6 +19,7 @@ PKG_SOURCE_URL:=https://gitlab.freedesktop.org/xdg/$(PKG_NAME)/-/archive/$(PKG_V
 PKG_HASH:=37df6475da31a8b5fc63a54ba0770a3eefa0a708b778cb6366dccee96393cb60
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/meson.mk
 
 define Package/shared-mime-info


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: Turris Omnia, mvebu, OpenWrt master
Run tested: N/A

When you have enabled full Native Language Support, it could not be
compiled due to this error:

ccache_cc  -o src/update-mime-database src/update-mime-database.p/update-mime-database.c.o -L/mox-master/build/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/usr/lib -L/mox-master/build/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/lib -Wl,--as-needed -Wl,--no-undefined -DPIC -fPIC -specs=/mox-master/build/include/hardened-ld-pie.specs -znow -zrelro -Wl,-rpath,/mox-master/build/staging_dir/target-aarch64_cortex-a53_musl/usr/lib -Wl,-rpath-link,/mox-master/build/staging_dir/target-aarch64_cortex-a53_musl/usr/lib -Wl,--start-group /mox-master/build/staging_dir/target-aarch64_cortex-a53_musl/usr/lib/libglib-2.0.so -L/mox-master/build/staging_dir/target-aarch64_cortex-a53_musl/usr/lib -lintl /mox-master/build/staging_dir/target-aarch64_cortex-a53_musl/usr/lib/libxml2.so -Wl,--end-group
/mox-master/build/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/11.2.0/../../../../aarch64-openwrt-linux-musl/bin/ld: cannot find -lintl
collect2: error: ld returned 1 exit status

It happens also on gcc

FIxes: #17892