### PR TITLE
tree: bump to 2.0.2

### DIFF
--- a/utils/tree/Makefile
+++ b/utils/tree/Makefile
@@ -9,9 +9,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tree
 PKG_RELEASE:=1
-PKG_VERSION:=1.8.0
+PKG_VERSION:=2.0.2
 PKG_SOURCE_URL:=http://mama.indstate.edu/users/ice/tree/src
-PKG_HASH:=715d5d4b434321ce74706d0dd067505bb60c5ea83b5f0b3655dae40aa6f9b7c2
+PKG_HASH:=7d693a1d88d3c4e70a73e03b8dbbdc12c2945d482647494f2f5bd83a479eeeaf
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_MAINTAINER:=Banglang Huang <banglang.huang@foxmail.com>


### PR DESCRIPTION
Update to latest upstream release.

Build system: x86_64
Build-tested: bcm2711/RPi4B
Run-tested: bcm2711/RPi4B

Signed-off-by: John Audia <graysky@archlinux.us>

Maintainer: @neheb @yousong @hbl0307106015