### PR TITLE
tvheadend: bind to LAN IP by default

### DIFF
--- a/multimedia/tvheadend/files/tvheadend.config
+++ b/multimedia/tvheadend/files/tvheadend.config
@@ -5,6 +5,8 @@
 
 config tvheadend server
 	option ipv6 '1'
+	# If bindaddr is not set, it will default to LAN IP address (uci get network.lan.ipaddr).
+	# To bind all interfaces, set it to "0.0.0.0".
 #	 option bindaddr '0.0.0.0'
 #	 option http_port '9981'
 #	 option http_root '/tvheadend'

--- a/multimedia/tvheadend/files/tvheadend.init
+++ b/multimedia/tvheadend/files/tvheadend.init
@@ -62,6 +62,7 @@ load_uci_config() {
 	config_get_bool ipv6 server ipv6 0
 	[ "$ipv6" -eq 1 ] && procd_append_param command --ipv6
 	config_get bindaddr server bindaddr
+	[ -z "$bindaddr" ] && bindaddr=$(uci get network.lan.ipaddr)
 	[ -n "$bindaddr" ] && procd_append_param command --bindaddr "$bindaddr"
 	config_get http_port server http_port
 	[ -n "$http_port" ] && procd_append_param command --http_port "$http_port"


### PR DESCRIPTION
Maintainer: me
Compile tested: not tested, compilation is not affected
Run tested: r18404

Description:
If config parameter is not set, tvheadend will bind to LAN IP address by default. If IP not found, the switch is not added and tvheadend will bind to 0.0.0.0, as it is now.
Fixes issue #16500 without requiring user to edit the config file. It's also more secure if firewall becomes disabled. There are no drawbacks that I can think of.