### PR TITLE
[21.02] php7: update to 7.4.28

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=7.4.27
+PKG_VERSION:=7.4.28
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=3f8b937310f155822752229c2c2feb8cc2621e25a728e7b94d0d74c128c43d0c
+PKG_HASH:=9cc3b6f6217b60582f78566b3814532c4b71d517876c25013ae51811e65d8fce
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: -

Description:

This fixes:
    - CVE-2021-21708

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
