### PR TITLE
utils/watchcat: restart failure time after network restart

### DIFF
--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=13
+PKG_RELEASE:=14
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -140,6 +140,8 @@ watchcat_monitor_network() {
 				watchcat_restart_all_network
 			fi
 			/etc/init.d/watchcat start
+			# Restart timer cycle.
+			time_lastcheck_withinternet="$time_now"
 		}
 
 	done


### PR DESCRIPTION
Maintainer: Nicholas Smith <nicholas@nbembedded.com>
Compile tested: -
Run tested: yes, with lte modem

Description:
Without this change these settings:
Mode: Restart Interface
Period: 30s
Check Interval: 5s
will do ping every 30s, if all pings are fail then
it try to take action every 5 second.

After apply this patch watchcat will try to send
ping every 5 second in next 30 sec before take action if
all pings are fail.

This is important for wireless uplinks like 3G/4G that
need some time to establish connection.
