### PR TITLE
docker: fix compilation with glibc

### DIFF
--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -39,6 +39,7 @@ endef
 GO_PKG_BUILD_VARS += GO111MODULE=auto
 TAR_OPTIONS:=--strip-components 1 $(TAR_OPTIONS)
 TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
+TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-lgcc_eh)
 
 define Build/Prepare
 	$(Build/Prepare/Default)


### PR DESCRIPTION
Maintainer: Gerard Ryan <G.M0N3Y.2503@gmail.com>

Compile tested: 
tested on build Openwrt21.02 x86_64 with glibc on ubuntu 20.04

Run tested:
OpenWrt 21.02-SNAPSHOT r16495-bf0c965af0 / LuCI openwrt-21.02 branch git-22.047.35373-cc582eb
Docker Version 20.10.12 
tested on Asus PN51-E1 Ryzen 5 5500U

Description:
fix docker build error when using glibc on tartget 