### PR TITLE
dockerd: fix compilation with glibc

### DIFF
--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -51,6 +51,7 @@ endef
 GO_PKG_BUILD_VARS += GO111MODULE=auto
 TAR_OPTIONS:=--strip-components 1 $(TAR_OPTIONS)
 TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
+TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-lgcc_eh)
 
 # $(1) = path to dependent package 'Makefile'
 # $(2) = relevant dependency '.installer' file


### PR DESCRIPTION
Signed-off-by: aghost <ggg17226@gmail.com>

Maintainer: Gerard Ryan [G.M0N3Y.2503@gmail.com](mailto:G.M0N3Y.2503@gmail.com)

Compile tested:
tested on build Openwrt21.02 x86_64 with glibc on ubuntu 20.04

Run tested:
OpenWrt 21.02-SNAPSHOT r16495-bf0c965af0 / LuCI openwrt-21.02 branch git-22.047.35373-cc582eb
Docker Version 20.10.12
tested on Asus PN51-E1 Ryzen 5 5500U

Description:
fix dockerd build error when using glibc on tartget arch x86_64