### PR TITLE
Stop taxing the resources of the FreeBSD project with htpdate requests

### DIFF
--- a/net/htpdate/files/htpdate.conf
+++ b/net/htpdate/files/htpdate.conf
@@ -3,7 +3,6 @@ config htpdate 'htpdate'
 	list server 'www.google.com'
 	list server 'www.yahoo.com'
 	list server 'www.linux.com'
-	list server 'www.freebsd.org'
 	option proxy_host ''
 	option proxy_port '8080'
 	option debug 0


### PR DESCRIPTION
Remove `www.freebsd.org` from the list of hosts that receive a constant deluge of HTTP requests from clients looking for the current date

FreeBSD has taken to removing the date header from its HTTP response due to this abuse.
