### PR TITLE
totem-pl-parser: disable libarchive and libgcrypt

### DIFF
--- a/libs/totem-pl-parser/Makefile
+++ b/libs/totem-pl-parser/Makefile
@@ -36,7 +36,8 @@ define Package/totem-pl-parser/decription
   totem-pl-parser is a simple GObject-based library to parse a host of playlist formats
 endef
 
-MESON_ARGS += -Dintrospection=false
+MESON_ARGS += -Dintrospection=false \
+              -Denable-libarchive=no
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/

--- a/libs/totem-pl-parser/Makefile
+++ b/libs/totem-pl-parser/Makefile
@@ -37,7 +37,8 @@ define Package/totem-pl-parser/decription
 endef
 
 MESON_ARGS += -Dintrospection=false \
-              -Denable-libarchive=no
+              -Denable-libarchive=no \
+              -Denable-libgcrypt=no
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: Turris Omnia, mvebu/cortex-a9, OpenWrt master
Run tested: N/A

Description:

1. In Turris OS, we have [libarchive](https://gitlab.nic.cz/turris/os/packages/-/blob/daeee6c908cf6eb2552133ae0446f1544d79dcd3/libs/uriparser/Makefile) package:

```
If the libarchive is present within the build environment, it is
automatically detected and enabled [1]. This causes that totem-pl-parser
is not compiled with this error:

Package totem-pl-parser is missing dependencies for the following libraries:
libarchive.so.18
``` 

[1] https://gitlab.gnome.org/GNOME/totem-pl-parser/-/blob/c6c1c51aefeac28499da9fe5cec4af2278ed1564/meson_options.txt#L1

TL;DR: It is important to compile ``libarchive`` and ``libgcrypt`` first and then compile ``totem-pl-parser``

2. OpenWrt buildbots fails:
I've checked builbot and I see that this package is failing: https://downloads.openwrt.org/snapshots/faillogs/aarch64_cortex-a72/packages/totem-pl-parser/compile.txt

Snip:

```
3.26.6/ipkg-install/usr/include/totem-pl-parser/1/plparser
Installing /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a72_musl/totem-pl-parser-3.26.6/plparse/totem-pl-playlist.h to /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a72_musl/totem-pl-parser-3.26.6/ipkg-install/usr/include/totem-pl-parser/1/plparser
Installing /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a72_musl/totem-pl-parser-3.26.6/plparse/totem-pl-parser-mini.h to /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a72_musl/totem-pl-parser-3.26.6/ipkg-install/usr/include/totem-pl-parser/1/plparser
Installing /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a72_musl/totem-pl-parser-3.26.6/openwrt-build/plparse/totem-pl-parser-features.h to /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a72_musl/totem-pl-parser-3.26.6/ipkg-install/usr/include/totem-pl-parser/1/plparser
Installing /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a72_musl/totem-pl-parser-3.26.6/plparse/README-videosite-script.md to /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a72_musl/totem-pl-parser-3.26.6/ipkg-install/usr/libexec/totem-pl-parser
Installing /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a72_musl/totem-pl-parser-3.26.6/openwrt-build/totem-plparser.pc to /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a72_musl/totem-pl-parser-3.26.6/ipkg-install/usr/lib/pkgconfig
Installing /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a72_musl/totem-pl-parser-3.26.6/openwrt-build/totem-plparser-mini.pc to /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a72_musl/totem-pl-parser-3.26.6/ipkg-install/usr/lib/pkgconfig
Package totem-pl-parser is missing dependencies for the following libraries:
libgcrypt.so.20
```

