### PR TITLE
tvheadend: fix group /dev/dvb permissions, add /etc/tvheadend to conffiles

### DIFF
--- a/multimedia/tvheadend/Makefile
+++ b/multimedia/tvheadend/Makefile
@@ -242,6 +242,7 @@ endef
 
 define Package/tvheadend/conffiles
 /etc/config/tvheadend
+/etc/tvheadend
 endef
 
 define Package/tvheadend/install

--- a/multimedia/tvheadend/files/dvb.hotplug
+++ b/multimedia/tvheadend/files/dvb.hotplug
@@ -1,7 +1,7 @@
 #!/bin/sh
 case "$ACTION" in
   add)
-    chown -R root:dvb /dev/dvb/*
-    chmod -R 660 /dev/dvb/*
+    chgrp -R dvb /dev/dvb/*
+    chmod -R g+rwX /dev/dvb/*
     ;;
 esac

--- a/multimedia/tvheadend/files/tvheadend.init
+++ b/multimedia/tvheadend/files/tvheadend.init
@@ -79,7 +79,8 @@ start_service() {
 	ensure_config_exists
 	procd_open_instance
 	procd_set_param file /etc/config/tvheadend
-	chown -R root:$TVH_GROUP /dev/dvb/*
+	chgrp -R $TVH_GROUP /dev/dvb/*
+	chmod -R g+rwX /dev/dvb/*
 	procd_set_param command "$PROG" -B -u $TVH_USER -g $TVH_GROUP
 	load_uci_config
 	procd_close_instance


### PR DESCRIPTION
Maintainer: @M95D 
Compile tested: mvebu
Run tested: mvebu/rb5009

Description: Fix group permissions so that tvheadend user can access adapters. Also add the /etc/tvheadend dir to conffiles to preserve it on sysupgrades.
