### PR TITLE
mpd-full: enable soxr

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -49,7 +49,7 @@ define Package/mpd-full
 $(call Package/mpd/Default)
   TITLE+= (full)
   DEPENDS+= +AUDIO_SUPPORT:pulseaudio-daemon +libvorbis +libmms +libnpupnp +libshout +yajl \
-            +libffmpeg +lame-lib +!BUILD_PATENTED:libmad
+            +libffmpeg +lame-lib +libsoxr +!BUILD_PATENTED:libmad
   PROVIDES:=mpd
   VARIANT:=full
 endef
@@ -156,7 +156,6 @@ MESON_ARGS += \
 	-Dshine=disabled \
 	-Dwave_encoder=true \
 	-Dlibsamplerate=disabled \
-	-Dsoxr=disabled \
 	-Dalsa=$(if $(CONFIG_AUDIO_SUPPORT),en,dis)abled \
 	-Dao=disabled \
 	-Dhttpd=true \
@@ -193,7 +192,8 @@ ifeq ($(BUILD_VARIANT),full)
 	-Dshout=enabled \
 	-Dyajl=enabled \
 	-Dvorbisenc=enabled \
-	-Dlame=enabled
+	-Dlame=enabled \
+	-Dsoxr=enabled
 
 ifeq ($(CONFIG_AUDIO_SUPPORT),y)
 	TARGET_LDFLAGS += -Wl,-rpath-link=$(STAGING_DIR)/usr/lib/pulseaudio
@@ -216,7 +216,8 @@ ifeq ($(BUILD_VARIANT),mini)
 	-Dpulse=disabled \
 	-Drecorder=false \
 	-Dshout=disabled \
-	-Dyajl=disabled
+	-Dyajl=disabled \
+	-Dsoxr=disabled
 endif
 
 define Package/mpd/install


### PR DESCRIPTION
Enable soxr resampler library.

"internal" resampler is really poor quality and libsamplerate
library is too heavy for tiny system.

Signed-off-by: Kazuhiro Ito <kzhr@d1.dion.ne.jp>

Maintainer: @neheb
Compile tested: master on oxnas target (PogoplugPro)
Run tested: same as above

Description:

I noticed resampling quality was very poor when I played 44.1kHz audio file on 48kHz USB audio device.  Mpd uses "internal" resampler, but its quality is poor as decsribed in documents.  Mpd can use better external resampler library, libsamplerate and soxr.  As far as I tested, the former was too heavy for my device and the latter is light and good enough.
