### PR TITLE
[openwrt-21.02] yq: Update to 4.20.2

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.20.1
+PKG_VERSION:=4.20.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=fb6a0b554bf6e6b379052d8abada3eaaf892916fb7a3dbe3a8667fde4c615efb
+PKG_HASH:=031c63dd98e564b9a74b842ffe8ae929085f1486f59a27d4feb7e118f40c8a1e
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm27xx
Run tested: bcm2710 raspberrypi-3b

Description:
- Backported from #17921 (7254169b12a9250538d1425644dd5e6c60463598)
