### PR TITLE
mwan3: update to version 2.11.0

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -25,6 +25,7 @@ define Package/mwan3
      +ip \
      +ipset \
      +iptables \
+     +IPV6:ip6tables \
      +iptables-mod-conntrack-extra \
      +iptables-mod-ipopt \
      +jshn

--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.10.13
+PKG_VERSION:=2.11.0
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -3,7 +3,6 @@
 . /lib/functions.sh
 . /lib/functions/network.sh
 . /lib/mwan3/mwan3.sh
-. /lib/mwan3/common.sh
 
 initscript=/etc/init.d/mwan3
 . /lib/functions/procd.sh

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -1,6 +1,5 @@
 #!/bin/sh /etc/rc.common
 
-. "${IPKG_INSTROOT}/lib/mwan3/common.sh"
 . "${IPKG_INSTROOT}/lib/functions/network.sh"
 . "${IPKG_INSTROOT}/lib/mwan3/mwan3.sh"
 

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -91,6 +91,8 @@ stop_service() {
 		} | $IPTR
 	done
 
+	# Needed for the firewall backend to release the ipsets reference
+	sleep 2
 	for ipset in $($IPS -n list | grep mwan3_); do
 		$IPS -q destroy $ipset
 	done

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -31,6 +31,7 @@ start_service() {
 	config_foreach start_tracker interface
 
 	mwan3_update_iface_to_table
+	mwan3_set_dynamic_ipset
 	mwan3_set_connected_ipset
 	mwan3_set_custom_ipset
 	mwan3_set_general_rules

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -95,10 +95,6 @@ stop_service() {
 		$IPS -q destroy $ipset
 	done
 
-	for ipset in $($IPS -n list | grep mwan3 | grep -E '_v4|_v6'); do
-		$IPS -q destroy $ipset
-	done
-
 	rm -rf $MWAN3_STATUS_DIR $MWAN3TRACK_STATUS_DIR
 
 }

--- a/net/mwan3/files/lib/mwan3/common.sh
+++ b/net/mwan3/files/lib/mwan3/common.sh
@@ -21,6 +21,12 @@ MAX_SLEEP=$(((1<<31)-1))
 command -v ip6tables > /dev/null
 NO_IPV6=$?
 
+IPS="ipset"
+IPT4="iptables -t mangle -w"
+IPT6="ip6tables -t mangle -w"
+IPT4R="iptables-restore -T mangle -w -n"
+IPT6R="ip6tables-restore -T mangle -w -n"
+
 LOG()
 {
 	local facility=$1; shift

--- a/net/mwan3/files/lib/mwan3/common.sh
+++ b/net/mwan3/files/lib/mwan3/common.sh
@@ -5,6 +5,7 @@ IP6="ip -6"
 SCRIPTNAME="$(basename "$0")"
 
 MWAN3_STATUS_DIR="/var/run/mwan3"
+MWAN3_STATUS_IPTABLES_LOG_DIR="${MWAN3_STATUS_DIR}/iptables_log"
 MWAN3TRACK_STATUS_DIR="/var/run/mwan3track"
 
 MWAN3_INTERFACE_MAX=""
@@ -118,6 +119,7 @@ mwan3_init()
 	config_load mwan3
 
 	[ -d $MWAN3_STATUS_DIR ] || mkdir -p $MWAN3_STATUS_DIR/iface_state
+	[ -d "$MWAN3_STATUS_IPTABLES_LOG_DIR" ] || mkdir -p "$MWAN3_STATUS_IPTABLES_LOG_DIR"
 
 	# mwan3's MARKing mask (at least 3 bits should be set)
 	if [ -e "${MWAN3_STATUS_DIR}/mmx_mask" ]; then

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -135,8 +135,10 @@ mwan3_set_custom_ipset()
 	mwan3_push_update -! create mwan3_custom_v4 hash:net
 	config_list_foreach "globals" "rt_table_lookup" mwan3_set_custom_ipset_v4
 
-	mwan3_push_update -! create mwan3_custom_v6 hash:net family inet6
-	config_list_foreach "globals" "rt_table_lookup" mwan3_set_custom_ipset_v6
+	if [ $NO_IPV6 -eq 0 ]; then
+		mwan3_push_update -! create mwan3_custom_v6 hash:net family inet6
+		config_list_foreach "globals" "rt_table_lookup" mwan3_set_custom_ipset_v6
+	fi
 
 	mwan3_push_update -! create mwan3_connected list:set
 	mwan3_push_update -! add mwan3_connected mwan3_custom_v4

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -250,7 +250,6 @@ mwan3_set_general_iptables()
 
 		if [ -n "${current##*-N mwan3_connected*}" ]; then
 			mwan3_push_update -N mwan3_connected
-			$IPS -! create mwan3_connected list:set
 			mwan3_push_update -A mwan3_connected \
 					  -m set --match-set mwan3_connected dst \
 					  -j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -342,9 +342,9 @@ mwan3_set_general_iptables()
 		mwan3_push_update COMMIT
 		mwan3_push_update ""
 		if [ "$IPT" = "$IPT4" ]; then
-			error=$(echo "$update" | $IPT4R 2>&1) || LOG error "set_general_iptables: $error"
+			error=$(echo "$update" | $IPT4R 2>&1) || LOG error "set_general_iptables (${family}): $error"
 		else
-			error=$(echo "$update" | $IPT6R 2>&1) || LOG error "set_general_iptables: $error"
+			error=$(echo "$update" | $IPT6R 2>&1) || LOG error "set_general_iptables (${family}): $error"
 		fi
 	done
 }
@@ -405,7 +405,7 @@ mwan3_create_iface_iptables()
 
 	mwan3_push_update COMMIT
 	mwan3_push_update ""
-	error=$(echo "$update" | $IPTR 2>&1) || LOG error "create_iface_iptables: $error"
+	error=$(echo "$update" | $IPTR 2>&1) || LOG error "create_iface_iptables (${1}): $error"
 
 }
 
@@ -434,7 +434,7 @@ mwan3_delete_iface_iptables()
 	mwan3_push_update COMMIT
 	mwan3_push_update ""
 
-	error=$(echo "$update" | $IPTR 2>&1) || LOG error "delete_iface_iptables_${1}: $error"
+	error=$(echo "$update" | $IPTR 2>&1) || LOG error "delete_iface_iptables (${1}): $error"
 }
 
 mwan3_extra_tables_routes()
@@ -766,7 +766,7 @@ mwan3_set_sticky_ipset()
 			hash:ip,mark markmask "$mmx" \
 			timeout "$timeout" family inet6
 
-	error=$(echo "$update" | $IPS restore 2>&1) || LOG error "set_sticky_ipset_${rule}: $error"
+	error=$(echo "$update" | $IPS restore 2>&1) || LOG error "set_sticky_ipset (${rule}): $error"
 }
 
 mwan3_set_user_iptables_rule()
@@ -969,7 +969,7 @@ mwan3_set_user_rules()
 
 		mwan3_push_update COMMIT
 		mwan3_push_update ""
-		error=$(echo "$update" | $IPTR 2>&1) || LOG error "set_user_rules: $error"
+		error=$(echo "$update" | $IPTR 2>&1) || LOG error "set_user_rules (${ipv}): $error"
 	done
 
 

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -140,7 +140,7 @@ mwan3_set_custom_ipset()
 
 	mwan3_push_update -! create mwan3_connected list:set
 	mwan3_push_update -! add mwan3_connected mwan3_custom_v4
-	mwan3_push_update -! add mwan3_connected mwan3_custom_v6
+	[ $NO_IPV6 -eq 0 ] && mwan3_push_update -! add mwan3_connected mwan3_custom_v6
 	error=$(echo "$update" | $IPS restore 2>&1) || LOG error "set_custom_ipset: $error"
 }
 

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -380,7 +380,7 @@ mwan3_create_iface_iptables()
 
 mwan3_delete_iface_iptables()
 {
-	local IPT
+	local IPT update
 	config_get family "$1" family ipv4
 
 	if [ "$family" = "ipv4" ]; then
@@ -392,12 +392,18 @@ mwan3_delete_iface_iptables()
 		IPT="$IPT6"
 	fi
 
-	$IPT -D mwan3_ifaces_in \
-	     -m mark --mark 0x0/$MMX_MASK \
-	     -j "mwan3_iface_in_$1" &> /dev/null
-	$IPT -F "mwan3_iface_in_$1" &> /dev/null
-	$IPT -X "mwan3_iface_in_$1" &> /dev/null
+	update="*mangle"
 
+	mwan3_push_update -D mwan3_ifaces_in \
+		-m mark --mark 0x0/$MMX_MASK \
+		-j "mwan3_iface_in_$1" &> /dev/null
+	mwan3_push_update -F "mwan3_iface_in_$1" &> /dev/null
+	mwan3_push_update -X "mwan3_iface_in_$1" &> /dev/null
+
+	mwan3_push_update COMMIT
+	mwan3_push_update ""
+
+	error=$(echo "$update" | $IPTR 2>&1) || LOG error "delete_iface_iptables_${1}: $error"
 }
 
 mwan3_extra_tables_routes()

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -1,12 +1,8 @@
 #!/bin/sh
 
 . "${IPKG_INSTROOT}/usr/share/libubox/jshn.sh"
+. "${IPKG_INSTROOT}/lib/mwan3/common.sh"
 
-IPS="ipset"
-IPT4="iptables -t mangle -w"
-IPT6="ip6tables -t mangle -w"
-IPT4R="iptables-restore -T mangle -w -n"
-IPT6R="ip6tables-restore -T mangle -w -n"
 CONNTRACK_FILE="/proc/net/nf_conntrack"
 IPv6_REGEX="([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|"
 IPv6_REGEX="${IPv6_REGEX}([0-9a-fA-F]{1,4}:){1,7}:|"

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -114,7 +114,7 @@ mwan3_set_custom_ipset_v4()
 
 	for custom_network_v4 in $($IP4 route list table "$1" | awk '{print $1}' | grep -E "$IPv4_REGEX"); do
 		LOG notice "Adding network $custom_network_v4 from table $1 to mwan3_custom_v4 ipset"
-		mwan3_push_update -! add mwan3_custom_v4 "$custom_network_v4"
+		mwan3_push_update -! add mwan3_custom_ipv4 "$custom_network_v4"
 	done
 }
 
@@ -124,7 +124,7 @@ mwan3_set_custom_ipset_v6()
 
 	for custom_network_v6 in $($IP6 route list table "$1" | awk '{print $1}' | grep -E "$IPv6_REGEX"); do
 		LOG notice "Adding network $custom_network_v6 from table $1 to mwan3_custom_v6 ipset"
-		mwan3_push_update -! add mwan3_custom_v6 "$custom_network_v6"
+		mwan3_push_update -! add mwan3_custom_ipv6 "$custom_network_v6"
 	done
 }
 
@@ -132,17 +132,16 @@ mwan3_set_custom_ipset()
 {
 	local update=""
 
-	mwan3_push_update -! create mwan3_custom_v4 hash:net
+	mwan3_push_update -! create mwan3_custom_ipv4 hash:net
+	mwan3_push_update flush mwan3_custom_ipv4
 	config_list_foreach "globals" "rt_table_lookup" mwan3_set_custom_ipset_v4
 
 	if [ $NO_IPV6 -eq 0 ]; then
-		mwan3_push_update -! create mwan3_custom_v6 hash:net family inet6
+		mwan3_push_update -! create mwan3_custom_ipv6 hash:net family inet6
+		mwan3_push_update flush mwan3_custom_ipv6
 		config_list_foreach "globals" "rt_table_lookup" mwan3_set_custom_ipset_v6
 	fi
 
-	mwan3_push_update -! create mwan3_connected list:set
-	mwan3_push_update -! add mwan3_connected mwan3_custom_v4
-	[ $NO_IPV6 -eq 0 ] && mwan3_push_update -! add mwan3_connected mwan3_custom_v6
 	error=$(echo "$update" | $IPS restore 2>&1) || LOG error "set_custom_ipset: $error"
 }
 
@@ -153,8 +152,8 @@ mwan3_set_connected_ipv4()
 	local candidate_list cidr_list
 	local update=""
 
-	mwan3_push_update -! create mwan3_connected_v4 hash:net
-	mwan3_push_update flush mwan3_connected_v4
+	mwan3_push_update -! create mwan3_connected_ipv4 hash:net
+	mwan3_push_update flush mwan3_connected_ipv4
 
 	candidate_list=""
 	cidr_list=""
@@ -172,14 +171,14 @@ mwan3_set_connected_ipv4()
 	done
 
 	for connected_network_v4 in $cidr_list; do
-		mwan3_push_update -! add mwan3_connected_v4 "$connected_network_v4"
+		mwan3_push_update -! add mwan3_connected_ipv4 "$connected_network_v4"
 	done
 	for connected_network_v4 in $candidate_list; do
-		mwan3_push_update -! add mwan3_connected_v4 "$connected_network_v4"
+		mwan3_push_update -! add mwan3_connected_ipv4 "$connected_network_v4"
 	done
 
-	mwan3_push_update add mwan3_connected_v4 224.0.0.0/3
-	mwan3_push_update -! add mwan3_connected mwan3_connected_v4
+	mwan3_push_update add mwan3_connected_ipv4 224.0.0.0/3
+
 	error=$(echo "$update" | $IPS restore 2>&1) || LOG error "set_connected_ipv4: $error"
 }
 
@@ -189,14 +188,13 @@ mwan3_set_connected_ipv6()
 	local update=""
 	[ $NO_IPV6 -eq 0 ] || return
 
-	mwan3_push_update -! create mwan3_connected_v6 hash:net family inet6
-	mwan3_push_update flush mwan3_connected_v6
+	mwan3_push_update -! create mwan3_connected_ipv6 hash:net family inet6
+	mwan3_push_update flush mwan3_connected_ipv6
 
 	for connected_network_v6 in $($IP6 route | awk '{print $1}' | grep -E "$IPv6_REGEX"); do
-		mwan3_push_update -! add mwan3_connected_v6 "$connected_network_v6"
+		mwan3_push_update -! add mwan3_connected_ipv6 "$connected_network_v6"
 	done
 
-	mwan3_push_update -! add mwan3_connected mwan3_connected_v6
 	error=$(echo "$update" | $IPS restore 2>&1) || LOG error "set_connected_ipv6: $error"
 }
 
@@ -205,18 +203,31 @@ mwan3_set_connected_ipset()
 	local error
 	local update=""
 
-	mwan3_push_update -! create mwan3_connected list:set
-	mwan3_push_update flush mwan3_connected
-
-	mwan3_push_update -! create mwan3_dynamic_v4 hash:net
-	mwan3_push_update -! add mwan3_connected mwan3_dynamic_v4
+	mwan3_push_update -! create mwan3_connected_ipv4 hash:net
+	mwan3_push_update flush mwan3_connected_ipv4
 
 	if [ $NO_IPV6 -eq 0 ]; then
-		mwan3_push_update -! create mwan3_dynamic_v6 hash:net family inet6
-		mwan3_push_update -! add mwan3_connected mwan3_dynamic_v6
+		mwan3_push_update -! create mwan3_connected_ipv6 hash:net family inet6
+		mwan3_push_update flush mwan3_connected_ipv6
 	fi
 
 	error=$(echo "$update" | $IPS restore 2>&1) || LOG error "set_connected_ipset: $error"
+}
+
+mwan3_set_dynamic_ipset()
+{
+	local error
+	local update=""
+
+	mwan3_push_update -! create mwan3_dynamic_ipv4 list:set
+	mwan3_push_update flush mwan3_dynamic_ipv4
+
+	if [ $NO_IPV6 -eq 0 ]; then
+		mwan3_push_update -! create mwan3_dynamic_ipv6 hash:net family inet6
+		mwan3_push_update flush mwan3_dynamic_ipv6
+	fi
+
+	error=$(echo "$update" | $IPS restore 2>&1) || LOG error "set_dynamic_ipset: $error"
 }
 
 mwan3_set_general_rules()
@@ -239,7 +250,8 @@ mwan3_set_general_rules()
 
 mwan3_set_general_iptables()
 {
-	local IPT current update error
+	local IPT current update error family
+
 	for IPT in "$IPT4" "$IPT6"; do
 		[ "$IPT" = "$IPT6" ] && [ $NO_IPV6 -ne 0 ] && continue
 		current="$($IPT -S)"$'\n'
@@ -248,12 +260,22 @@ mwan3_set_general_iptables()
 			mwan3_push_update -N mwan3_ifaces_in
 		fi
 
-		if [ -n "${current##*-N mwan3_connected*}" ]; then
-			mwan3_push_update -N mwan3_connected
-			mwan3_push_update -A mwan3_connected \
-					  -m set --match-set mwan3_connected dst \
-					  -j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
+		if [ "$IPT" = "$IPT6" ]; then
+			family="ipv6"
+		else
+			family="ipv4"
 		fi
+
+		for chain in custom connected dynamic; do
+			echo "${current}" | grep -q "\-N mwan3_${chain}_${family}$"
+			local ret="$?"
+			if [ "$ret" = 1 ]; then
+				mwan3_push_update -N mwan3_${chain}_${family}
+				mwan3_push_update -A mwan3_${chain}_${family} \
+					-m set --match-set mwan3_${chain}_${family} dst \
+					-j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
+			fi
+		done
 
 		if [ -n "${current##*-N mwan3_rules*}" ]; then
 			mwan3_push_update -N mwan3_rules
@@ -291,17 +313,24 @@ mwan3_set_general_iptables()
 			mwan3_push_update -A mwan3_hook \
 					  -m mark --mark 0x0/$MMX_MASK \
 					  -j mwan3_ifaces_in
-			mwan3_push_update -A mwan3_hook \
-					  -m mark --mark 0x0/$MMX_MASK \
-					  -j mwan3_connected
+
+			for chain in custom connected dynamic; do
+				mwan3_push_update -A mwan3_hook \
+					-m mark --mark 0x0/$MMX_MASK \
+					-j mwan3_${chain}_${family}
+			done
+
 			mwan3_push_update -A mwan3_hook \
 					  -m mark --mark 0x0/$MMX_MASK \
 					  -j mwan3_rules
 			mwan3_push_update -A mwan3_hook \
 					  -j CONNMARK --save-mark --nfmask "$MMX_MASK" --ctmask "$MMX_MASK"
-			mwan3_push_update -A mwan3_hook \
-					  -m mark ! --mark $MMX_DEFAULT/$MMX_MASK \
-					  -j mwan3_connected
+
+			for chain in custom connected dynamic; do
+				mwan3_push_update -A mwan3_hook \
+					-m mark ! --mark $MMX_DEFAULT/$MMX_MASK \
+					-j mwan3_${chain}_${family}
+			done
 		fi
 
 		if [ -n "${current##*-A PREROUTING -j mwan3_hook*}" ]; then
@@ -351,12 +380,14 @@ mwan3_create_iface_iptables()
 		mwan3_push_update -F "mwan3_iface_in_$1"
 	fi
 
-	mwan3_push_update -A "mwan3_iface_in_$1" \
-			  -i "$2" \
-			  -m set --match-set mwan3_connected src \
-			  -m mark --mark "0x0/$MMX_MASK" \
-			  -m comment --comment "default" \
-			  -j MARK --set-xmark "$MMX_DEFAULT/$MMX_MASK"
+	for chain in custom connected dynamic; do
+		mwan3_push_update -A "mwan3_iface_in_$1" \
+			-i "$2" \
+			-m set --match-set mwan3_${chain}_${family} src \
+			-m mark --mark "0x0/$MMX_MASK" \
+			-m comment --comment "default" \
+			-j MARK --set-xmark "$MMX_DEFAULT/$MMX_MASK"
+	done
 	mwan3_push_update -A "mwan3_iface_in_$1" \
 			  -i "$2" \
 			  -m mark --mark "0x0/$MMX_MASK" \
@@ -692,17 +723,22 @@ mwan3_set_policies_iptables()
 
 mwan3_set_sticky_iptables()
 {
+	local rule="${1}"
+	local interface="${2}"
+	local ipv="${3}"
+	local policy="${4}"
+
 	local id iface
 	for iface in $(echo "$current" | grep "^-A $policy" | cut -s -d'"' -f2 | awk '{print $1}'); do
-		if [ "$iface" = "$1" ]; then
+		if [ "$iface" = "$interface" ]; then
 
-			mwan3_get_iface_id id "$1"
+			mwan3_get_iface_id id "$iface"
 
 			[ -n "$id" ] || return 0
-			if [ -z "${current##*-N mwan3_iface_in_$1$'\n'*}" ]; then
+			if [ -z "${current##*-N mwan3_iface_in_${iface}$'\n'*}" ]; then
 				mwan3_push_update -I "mwan3_rule_$rule" \
 						  -m mark --mark "$(mwan3_id2mask id MMX_MASK)/$MMX_MASK" \
-						  -m set ! --match-set "mwan3_sticky_$rule" src,src \
+						  -m set ! --match-set "mwan3_sticky_${ipv}_${rule}" src,src \
 						  -j MARK --set-xmark "0x0/$MMX_MASK"
 				mwan3_push_update -I "mwan3_rule_$rule" \
 						  -m mark --mark "0/$MMX_MASK" \
@@ -721,20 +757,14 @@ mwan3_set_sticky_ipset()
 	local error
 	local update=""
 
-	mwan3_push_update -! create "mwan3_sticky_v4_$rule" \
+	mwan3_push_update -! create "mwan3_sticky_ipv4_$rule" \
 		hash:ip,mark markmask "$mmx" \
 		timeout "$timeout"
 
 	[ $NO_IPV6 -eq 0 ] &&
-		mwan3_push_update -! create "mwan3_sticky_v6_$rule" \
+		mwan3_push_update -! create "mwan3_sticky_ipv6_$rule" \
 			hash:ip,mark markmask "$mmx" \
 			timeout "$timeout" family inet6
-
-	mwan3_push_update -! create "mwan3_sticky_$rule" list:set
-
-	mwan3_push_update -! add "mwan3_sticky_$rule" "mwan3_sticky_v4_$rule"
-	[ $NO_IPV6 -eq 0 ] &&
-		mwan3_push_update -! add "mwan3_sticky_$rule" "mwan3_sticky_v6_$rule"
 
 	error=$(echo "$update" | $IPS restore 2>&1) || LOG error "set_sticky_ipset_${rule}: $error"
 }
@@ -836,7 +866,7 @@ mwan3_set_user_iptables_rule()
 		fi
 
 		mwan3_push_update -F "mwan3_rule_$1"
-		config_foreach mwan3_set_sticky_iptables interface $ipv
+		config_foreach mwan3_set_sticky_iptables interface $ipv "$policy"
 
 
 		mwan3_push_update -A "mwan3_rule_$1" \
@@ -844,10 +874,10 @@ mwan3_set_user_iptables_rule()
 				  -j "$policy"
 		mwan3_push_update -A "mwan3_rule_$1" \
 				  -m mark ! --mark 0xfc00/0xfc00 \
-				  -j SET --del-set "mwan3_sticky_$rule" src,src
+				  -j SET --del-set "mwan3_sticky_${ipv}_${rule}" src,src
 		mwan3_push_update -A "mwan3_rule_$1" \
 				  -m mark ! --mark 0xfc00/0xfc00 \
-				  -j SET --add-set "mwan3_sticky_$rule" src,src
+				  -j SET --add-set "mwan3_sticky_${ipv}_${rule}" src,src
 		policy="mwan3_rule_$1"
 	fi
 	if [ "$global_logging" = "1" ] && [ "$rule_logging" = "1" ]; then
@@ -1132,15 +1162,15 @@ mwan3_report_policies_v6()
 
 mwan3_report_connected_v4()
 {
-	if [ -n "$($IPT4 -S mwan3_connected 2> /dev/null)" ]; then
-		$IPS -o save list mwan3_connected_v4 | grep add | cut -d " " -f 3
+	if [ -n "$($IPT4 -S mwan3_connected_ipv4 2> /dev/null)" ]; then
+		$IPS -o save list mwan3_connected_ipv4 | grep add | cut -d " " -f 3
 	fi
 }
 
 mwan3_report_connected_v6()
 {
-	if [ -n "$($IPT6 -S mwan3_connected 2> /dev/null)" ]; then
-		$IPS -o save list mwan3_connected_v6 | grep add | cut -d " " -f 3
+	if [ -n "$($IPT6 -S mwan3_connected_ipv6 2> /dev/null)" ]; then
+		$IPS -o save list mwan3_connected_ipv6 | grep add | cut -d " " -f 3
 	fi
 }
 

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -142,6 +142,7 @@ mwan3_set_custom_ipset()
 		config_list_foreach "globals" "rt_table_lookup" mwan3_set_custom_ipset_v6
 	fi
 
+	echo "$update" > "${MWAN3_STATUS_IPTABLES_LOG_DIR}/ipset-set_custom_ipset.dump"
 	error=$(echo "$update" | $IPS restore 2>&1) || LOG error "set_custom_ipset: $error"
 }
 
@@ -179,6 +180,7 @@ mwan3_set_connected_ipv4()
 
 	mwan3_push_update add mwan3_connected_ipv4 224.0.0.0/3
 
+	echo "$update" > "${MWAN3_STATUS_IPTABLES_LOG_DIR}/ipset-set_connected_ipv4.dump"
 	error=$(echo "$update" | $IPS restore 2>&1) || LOG error "set_connected_ipv4: $error"
 }
 
@@ -195,6 +197,7 @@ mwan3_set_connected_ipv6()
 		mwan3_push_update -! add mwan3_connected_ipv6 "$connected_network_v6"
 	done
 
+	echo "$update" > "${MWAN3_STATUS_IPTABLES_LOG_DIR}/ipset-set_connected_ipv6.dump"
 	error=$(echo "$update" | $IPS restore 2>&1) || LOG error "set_connected_ipv6: $error"
 }
 
@@ -211,6 +214,7 @@ mwan3_set_connected_ipset()
 		mwan3_push_update flush mwan3_connected_ipv6
 	fi
 
+	echo "$update" > "${MWAN3_STATUS_IPTABLES_LOG_DIR}/ipset-set_connected_ipset.dump"
 	error=$(echo "$update" | $IPS restore 2>&1) || LOG error "set_connected_ipset: $error"
 }
 
@@ -227,6 +231,7 @@ mwan3_set_dynamic_ipset()
 		mwan3_push_update flush mwan3_dynamic_ipv6
 	fi
 
+	echo "$update" > "${MWAN3_STATUS_IPTABLES_LOG_DIR}/ipset-set_dynamic_ipset.dump"
 	error=$(echo "$update" | $IPS restore 2>&1) || LOG error "set_dynamic_ipset: $error"
 }
 
@@ -341,6 +346,8 @@ mwan3_set_general_iptables()
 		fi
 		mwan3_push_update COMMIT
 		mwan3_push_update ""
+
+		echo "$update" > "${MWAN3_STATUS_IPTABLES_LOG_DIR}/iptables-set_general_iptables-${family}.dump"
 		if [ "$IPT" = "$IPT4" ]; then
 			error=$(echo "$update" | $IPT4R 2>&1) || LOG error "set_general_iptables (${family}): $error"
 		else
@@ -405,8 +412,9 @@ mwan3_create_iface_iptables()
 
 	mwan3_push_update COMMIT
 	mwan3_push_update ""
-	error=$(echo "$update" | $IPTR 2>&1) || LOG error "create_iface_iptables (${1}): $error"
 
+	echo "$update" > "${MWAN3_STATUS_IPTABLES_LOG_DIR}/iptables-create_iface_iptables-${1}.dump"
+	error=$(echo "$update" | $IPTR 2>&1) || LOG error "create_iface_iptables (${1}): $error"
 }
 
 mwan3_delete_iface_iptables()
@@ -434,6 +442,7 @@ mwan3_delete_iface_iptables()
 	mwan3_push_update COMMIT
 	mwan3_push_update ""
 
+	echo "$update" > "${MWAN3_STATUS_IPTABLES_LOG_DIR}/iptables-delete_iface_iptables-${1}.dump"
 	error=$(echo "$update" | $IPTR 2>&1) || LOG error "delete_iface_iptables (${1}): $error"
 }
 
@@ -652,8 +661,9 @@ mwan3_set_policy()
 	fi
 	mwan3_push_update COMMIT
 	mwan3_push_update ""
-	error=$(echo "$update" | $IPTR 2>&1) || LOG error "set_policy ($1): $error"
 
+	echo "$update" > "${MWAN3_STATUS_IPTABLES_LOG_DIR}/iptables-set_policy-${1}.dump"
+	error=$(echo "$update" | $IPTR 2>&1) || LOG error "set_policy ($1): $error"
 }
 
 mwan3_create_policies_iptables()
@@ -700,6 +710,8 @@ mwan3_create_policies_iptables()
 		esac
 		mwan3_push_update COMMIT
 		mwan3_push_update ""
+
+		echo "$update" > "${MWAN3_STATUS_IPTABLES_LOG_DIR}/iptables-create_policies_iptables-${1}.dump"
 		if [ "$IPT" = "$IPT4" ]; then
 			error=$(echo "$update" | $IPT4R 2>&1) || LOG error "create_policies_iptables ($1): $error"
 		else
@@ -766,6 +778,7 @@ mwan3_set_sticky_ipset()
 			hash:ip,mark markmask "$mmx" \
 			timeout "$timeout" family inet6
 
+	echo "$update" > "${MWAN3_STATUS_IPTABLES_LOG_DIR}/ipset-set_sticky_ipset-${rule}.dump"
 	error=$(echo "$update" | $IPS restore 2>&1) || LOG error "set_sticky_ipset (${rule}): $error"
 }
 
@@ -969,6 +982,8 @@ mwan3_set_user_rules()
 
 		mwan3_push_update COMMIT
 		mwan3_push_update ""
+
+		echo "$update" > "${MWAN3_STATUS_IPTABLES_LOG_DIR}/iptables-set_user_rules-${ipv}.dump"
 		error=$(echo "$update" | $IPTR 2>&1) || LOG error "set_user_rules (${ipv}): $error"
 	done
 

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -5,10 +5,6 @@
 . /usr/share/libubox/jshn.sh
 . /lib/mwan3/common.sh
 
-IPS="ipset"
-IPT4="iptables -t mangle -w"
-IPT6="ip6tables -t mangle -w"
-
 report_connected_v4() {
 	local address
 

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -4,7 +4,6 @@
 . /usr/share/libubox/jshn.sh
 . /lib/functions/network.sh
 . /lib/mwan3/mwan3.sh
-. /lib/mwan3/common.sh
 
 command_help() {
 	local cmd="$1"

--- a/net/mwan3/files/usr/sbin/mwan3rtmon
+++ b/net/mwan3/files/usr/sbin/mwan3rtmon
@@ -3,7 +3,6 @@
 . /lib/functions.sh
 . /lib/functions/network.sh
 . /lib/mwan3/mwan3.sh
-. /lib/mwan3/common.sh
 
 trap_with_arg()
 {


### PR DESCRIPTION
Maintainer: me @aaronjg 
Compile tested: not needed only script changes
Run tested: x86_64, APU3, OpenWrt latest

Changes:
* Add ip6tables dependency to fix issue that was added by the iptables package renaming.
* Add debugging dump into `/var/run/mwan3/iptables_log` to see all iptables/ipset command that mwan3 do for debugging
* Move the iptables and ipset command definition to `/lib/mwan3/common.sh`.
* Since nftables does not support ipsets in ipsets (list:set), there is now a separate ipset and iptables rule for each ipset in mwan3. This is not mandatory, but it helps when porting from mwan3 to native nftables syntax without iptables-nft backend usage, to verify the rules.

@champtar @stangri @jamesmacwhite @brianjmurrell @ptpt52 
Could someone please verify my change with nftables before I merge it?