### PR TITLE
mdnsresponder: Fix nullpointer dereference while parsing interface list

### DIFF
--- a/net/mdnsresponder/Makefile
+++ b/net/mdnsresponder/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mDNSResponder
 PKG_VERSION:=IETF104
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=mDNSResponder-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://opensource.apple.com/tarballs/mDNSResponder/IETF/

--- a/net/mdnsresponder/patches/020-fix-core-dump-while-parsing-interface-list.patch
+++ b/net/mdnsresponder/patches/020-fix-core-dump-while-parsing-interface-list.patch
@@ -1,0 +1,18 @@
+From 1fb07b9524b4afed3a826c087db4dc48a7bfdb89 Mon Sep 17 00:00:00 2001
+From: Ted Lemon <elemon@apple.com>
+Date: Thu, 6 Jun 2019 13:35:43 -0400
+Subject: [PATCH] Fix core dump while parsing interface list on Posix
+
+---
+--- a/mDNSPosix/mDNSPosix.c
++++ b/mDNSPosix/mDNSPosix.c
+@@ -1320,7 +1320,8 @@ mDNSlocal int SetupInterfaceList(mDNS *c
+         struct ifaddrs *i = intfList;
+         while (i)
+         {
+-            if (     ((i->ifa_addr->sa_family == AF_INET)
++            if (     i->ifa_addr != NULL &&
++                     ((i->ifa_addr->sa_family == AF_INET)
+ #if HAVE_IPV6
+                       || (i->ifa_addr->sa_family == AF_INET6)
+ #endif


### PR DESCRIPTION
This patch was backported from https://github.com/IETF-Hackathon/mDNSResponder/commit/1fb07b9524b4afed3a826c087db4dc48a7bfdb8

Signed-off-by: Maarten Aertsen <maarten@rtsn.nl>
Fixes: #17915

Maintainer: unknown, @neheb would you willing to merge?
Compile tested: x86-64
Run tested: apu2, x86-64
