### PR TITLE
gg: Update to 0.2.3

### DIFF
--- a/net/gg/Makefile
+++ b/net/gg/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gg
-PKG_VERSION:=0.2.2
+PKG_VERSION:=0.2.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mzz2017/gg/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=201affc9fce191f4b1e123974364a77e4762d0c26c1af428f960d68e1b9ed267
+PKG_HASH:=ae508f1df0798c6b4c16c13035baa49c1e103a883c8f91ea2149446489ff1c78
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=AGPL-3.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8, x86/64
Run tested: rk3328 nanopi-r2s

Description:
Release note: https://github.com/mzz2017/gg/releases/tag/v0.2.3