### PR TITLE
mariadb: fix compilation with ppc64

### DIFF
--- a/utils/mariadb/patches/210-no-altivec.patch
+++ b/utils/mariadb/patches/210-no-altivec.patch
@@ -1,0 +1,21 @@
+--- a/mysys/CMakeLists.txt
++++ b/mysys/CMakeLists.txt
+@@ -141,7 +141,7 @@ ELSEIF(CMAKE_SYSTEM_PROCESSOR MATCHES "a
+   ENDIF()
+ ENDIF()
+ 
+-IF(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64|powerpc64" OR CMAKE_SYSTEM_NAME MATCHES AIX)
++IF(FALSE)
+   SET(MYSYS_SOURCES ${MYSYS_SOURCES} crc32/crc32_ppc64.c crc32/crc32c_ppc.c)
+   SET_SOURCE_FILES_PROPERTIES(crc32/crc32_ppc64.c crc32/crc32c_ppc.c PROPERTIES
+         COMPILE_FLAGS "${COMPILE_FLAGS} -maltivec -mvsx -mpower8-vector -mcrypto -mpower8-vector")
+--- a/mysys/crc32ieee.cc
++++ b/mysys/crc32ieee.cc
+@@ -52,7 +52,6 @@ static my_crc32_t init_crc32()
+ static const my_crc32_t my_checksum_func= init_crc32();
+ 
+ #ifdef __powerpc64__
+-# error "my_checksum() is defined in mysys/crc32/crc32_ppc64.c"
+ #endif
+ extern "C"
+ unsigned int my_checksum(unsigned int crc, const void *data, size_t len)


### PR DESCRIPTION
MariaDB's PPC64 CRC32 support requires AltiVec, which QoriQ does not
support. Disable it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @miska 
Compile tested: ppc64
