### PR TITLE
tcpproxy: fix Wformat warning

### DIFF
--- a/net/tcpproxy/Makefile
+++ b/net/tcpproxy/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tcpproxy
 PKG_VERSION:=1.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.spreadspace.org/tcpproxy/releases/

--- a/net/tcpproxy/patches/010-format.patch
+++ b/net/tcpproxy/patches/010-format.patch
@@ -1,0 +1,11 @@
+--- a/src/log.c
++++ b/src/log.c
+@@ -244,7 +244,7 @@ void log_print_hex_dump(log_prio_t prio,
+     for(i=0; i < len; i++) {
+       if(((i+1)*3) >= (MSG_LENGTH_MAX - offset))
+         break;
+-      snprintf(ptr, 3, "%02X ", buf[i]);
++      snprintf(ptr, 4, "%02X ", buf[i]);
+       ptr+=3;
+     }
+   }


### PR DESCRIPTION
snprintf call requires one more byte for NULL termunator.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @equinox0815 