### PR TITLE
perl: add powerpc64 support

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -11,7 +11,7 @@ include perlver.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=$(PERL_VERSION)
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE_URL:=\
 		https://cpan.metacpan.org/src/5.0 \

--- a/lang/perl/files/powerpc64.config
+++ b/lang/perl/files/powerpc64.config
@@ -1,0 +1,20 @@
+owrt:arch=powerpc
+owrt:bits=64
+owrt:endian=big
+
+ccsymbols='__gnu_linux__=1 __linux=1 __linux__=1 __unix=1 __unix__=1 system=linux system=posix system=unix'
+cppccsymbols='linux=1 unix=1'
+cppsymbols='_BIG_ENDIAN=1 __BIG_ENDIAN__=1 __ELF__=1 _FILE_OFFSET_BITS=64 __GLIBC__=2 __GLIBC_MINOR__=2 __GNUC__=3 __GNUC_MINOR__=4 __GNU_LIBRARY__=6 _LARGEFILE_SOURCE=1 _POSIX_C_SOURCE=199506L _POSIX_SOURCE=1 __STDC__=1 __USE_BSD=1 __USE_FILE_OFFSET64=1 __USE_LARGEFILE=1 __USE_MISC=1 __USE_POSIX=1 __USE_POSIX199309=1 __USE_POSIX199506=1 __USE_POSIX2=1 __USE_SVID=1 __linux=1 __linux__=1 __unix=1 __unix__=1'
+d_casti32='undef'
+d_double_style_ieee='define'
+d_modflproto='undef'
+doublekind='4'
+fpossize='24'
+longdblkind='0'
+need_va_copy='define'
+quadkind='3'
+
+owrt:sig_count='64'
+owrt:sigs='ZERO HUP INT QUIT ILL TRAP ABRT BUS FPE KILL USR1 SEGV USR2 PIPE ALRM TERM STKFLT CHLD CONT STOP TSTP TTIN TTOU URG XCPU XFSZ VTALRM PROF WINCH IO PWR SYS'
+owrt:sig_name_extra='IOT CLD POLL UNUSED'
+owrt:sig_num_extra='6 17 29 31'


### PR DESCRIPTION
Needed by the QoriQ target.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @pprindeville 
Compile tested: ppc64