### PR TITLE
p11-kit: update to 0.24.1

### DIFF
--- a/libs/p11-kit/Makefile
+++ b/libs/p11-kit/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=p11-kit
-PKG_VERSION:=0.24.0
+PKG_VERSION:=0.24.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/p11-glue/p11-kit/releases/download/$(PKG_VERSION)
-PKG_HASH:=81e6140584f635e4e956a1b93a32239acf3811ff5b2d3a5c6094e94e99d2c685
+PKG_HASH:=d8be783efd5cd4ae534cee4132338e3f40f182c3205d23b200094ec85faaaef8
 
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -47,7 +47,8 @@ MESON_ARGS += \
 	-Dstrict=false \
 	-Dsystemd=disabled \
 	-Dgtk_doc=false \
-	-Dman=false
+	-Dman=false \
+	-Dnls=false
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/p11-kit-1/p11-kit/


### PR DESCRIPTION
explicitly disable NLS

It seems it's only used for man pages, which are unused.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nmav 
Compile tested: various