### PR TITLE
sqm-scripts: switch back to iptables

### DIFF
--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -24,7 +24,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/sqm-scripts
   SECTION:=net
   CATEGORY:=Base system
-  DEPENDS:=+tc +kmod-sched-cake +kmod-ifb +iptables-nft +iptables-mod-ipopt
+  DEPENDS:=+tc +kmod-sched-cake +kmod-ifb +iptables +iptables-mod-ipopt
   TITLE:=SQM Scripts (QoS)
   PKGARCH:=all
 endef


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: no
Run tested: no

Description:
Following recent dependency rework, we can switch
between iptables-legacy and iptables-nft, and they both
PROVIDES iptables. Make it easier for user that want/need to
stick to firewall3/iptables-legacy to do so.