### PR TITLE
cloudflared: add new package

### DIFF
--- a/net/cloudflared/Makefile
+++ b/net/cloudflared/Makefile
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# Copyright (C) 2021 ImmortalWrt.org
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cloudflared
+PKG_VERSION:=2022.3.1
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/cloudflare/cloudflared/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=e3459bc83d9749d89d93e6ab2dcbc51872568d1fb144d7ab7d3656b29785e364
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/cloudflare/cloudflared
+GO_PKG_LDFLAGS_X:=main.Version=$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/cloudflared
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Web Servers/Proxies
+  TITLE:=Cloudflare Tunnel client
+  URL:=https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide
+  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+endef
+
+define Package/cloudflared/description
+  Contains the command-line client for Cloudflare Tunnel, a tunneling
+  daemon that proxies traffic from the Cloudflare network to your origins.
+
+  This daemon sits between Cloudflare network and your origin (e.g. a
+  webserver). Cloudflare attracts client requests and sends them to you
+  via this daemon, without requiring you to poke holes on your firewall
+  --- your origin can remain as closed as possible.
+endef
+
+define Package/cloudflared/conffiles
+/etc/config/cloudflared
+/etc/cloudflared/
+endef
+
+define Package/cloudflared/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+
+	$(INSTALL_DIR) $(1)/etc/cloudflared/
+	$(INSTALL_CONF) $(CURDIR)/files/sample_config.yml $(1)/etc/cloudflared/config.yml
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_CONF) $(CURDIR)/files/cloudflared.config $(1)/etc/config/cloudflared
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) $(CURDIR)/files/cloudflared.init $(1)/etc/init.d/cloudflared
+endef
+
+$(eval $(call GoBinPackage,cloudflared))
+$(eval $(call BuildPackage,cloudflared))

--- a/net/cloudflared/files/cloudflared.config
+++ b/net/cloudflared/files/cloudflared.config
@@ -1,0 +1,9 @@
+
+config cloudflared 'config'
+	option enabled '0'
+	option config '/etc/cloudflared/config.yml'
+	option origincert '/etc/cloudflared/cert.pem'
+	option region ''
+	option loglevel 'info'
+	option logfile '/var/log/cloudflared.log'
+

--- a/net/cloudflared/files/cloudflared.init
+++ b/net/cloudflared/files/cloudflared.init
@@ -1,0 +1,48 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2021 Tianling Shen <cnsztl@immortalwrt.org>
+
+USE_PROCD=1
+START=99
+
+CONF="cloudflared"
+PROG="/usr/bin/cloudflared"
+
+append_param_arg() {
+	local value
+	config_get value "config" "$1" $2
+	[ -n "$value" ] && procd_append_param command "--$1" "$value"
+}
+
+start_service() {
+	config_load "$CONF"
+
+	local enabled
+	config_get_bool enabled "config" "enabled"
+	[ "$enabled" -eq "1" ] || exit 1
+
+	procd_open_instance "$CONF"
+	procd_set_param command "$PROG" "tunnel"
+	procd_append_param command "--no-autoupdate"
+
+	append_param_arg "config" "/etc/cloudflared/config.yml"
+	append_param_arg "origincert" "/etc/cloudflared/cert.pem"
+	append_param_arg "region"
+	append_param_arg "loglevel"
+	append_param_arg "logfile"
+
+	procd_append_param command "run"
+
+	procd_set_param respawn
+	procd_set_param stderr 1
+
+	procd_close_instance
+}
+
+reload_service() {
+	stop
+	start
+}
+
+service_triggers() {
+	procd_add_reload_trigger "$CONF"
+}

--- a/net/cloudflared/files/sample_config.yml
+++ b/net/cloudflared/files/sample_config.yml
@@ -1,0 +1,3 @@
+url: http://localhost:8000
+tunnel: <Tunnel-UUID>
+credentials-file: /etc/cloudflared/<Tunnel-UUID>.json

--- a/net/cloudflared/test.sh
+++ b/net/cloudflared/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cloudflared --version | grep "$PKG_VERSION"


### PR DESCRIPTION
Maintainer: me
Compile tested: ramips/mt7621, rockchip/armv8, x86/64
Run tested: nanopi-r2s, x86_64 (via VMware)

Description:
Contains the command-line client for Cloudflare Tunnel, a tunneling
daemon that proxies traffic from the Cloudflare network to your origins.

This daemon sits between Cloudflare network and your origin (e.g. a
webserver). Cloudflare attracts client requests and sends them to you
via this daemon, without requiring you to poke holes on your firewall
--- your origin can remain as closed as possible.

Docs: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide

GitHub: https://github.com/cloudflare/cloudflared