### PR TITLE
ffmpeg: update to 5.0

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
-PKG_VERSION:=4.3.3
+PKG_VERSION:=5.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
-PKG_HASH:=9f0a68fbd74feb4e50dc220bddd59d84626774a53687fb737806ae00e5c6e9e6
+PKG_HASH:=51e919f7d205062c0fd4fae6243a84850391115104ccf1efc451733bc0ac7298
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Ian Leonard <antonlacon@gmail.com>
 

--- a/multimedia/ffmpeg/patches/030-h264-mips.patch
+++ b/multimedia/ffmpeg/patches/030-h264-mips.patch
@@ -1,16 +1,17 @@
 --- a/libavcodec/mips/cabac.h
 +++ b/libavcodec/mips/cabac.h
-@@ -28,6 +28,7 @@
+@@ -30,6 +30,7 @@
  #include "libavutil/mips/mmiutils.h"
  #include "config.h"
  
 +#ifndef __mips16
  #define get_cabac_inline get_cabac_inline_mips
  static av_always_inline int get_cabac_inline_mips(CABACContext *c,
-                                              uint8_t * const state){
-@@ -116,4 +117,5 @@ static av_always_inline int get_cabac_in
-     return bit;
- }
+                                                   uint8_t * const state){
+@@ -225,4 +226,6 @@ static av_always_inline int get_cabac_by
  
+     return res;
+ }
++
 +#endif
  #endif /* AVCODEC_MIPS_CABAC_H */

--- a/multimedia/ffmpeg/patches/050-glibc.patch
+++ b/multimedia/ffmpeg/patches/050-glibc.patch
@@ -1,6 +1,6 @@
 --- a/libavcodec/wmv2dsp.c
 +++ b/libavcodec/wmv2dsp.c
-@@ -263,6 +263,6 @@ av_cold void ff_wmv2dsp_init(WMV2DSPCont
+@@ -264,6 +264,6 @@ av_cold void ff_wmv2dsp_init(WMV2DSPCont
      c->put_mspel_pixels_tab[6] = put_mspel8_mc22_c;
      c->put_mspel_pixels_tab[7] = put_mspel8_mc32_c;
  

--- a/multimedia/ffmpeg/patches/060-configure-link-to-libatomic-when-its-present.patch
+++ b/multimedia/ffmpeg/patches/060-configure-link-to-libatomic-when-its-present.patch
@@ -1,0 +1,47 @@
+--- a/configure
++++ b/configure
+@@ -3791,20 +3791,20 @@ cws2fws_extralibs="zlib_extralibs"
+ 
+ # libraries, in any order
+ avcodec_deps="avutil"
+-avcodec_suggest="libm"
++avcodec_suggest="libm stdatomic"
+ avdevice_deps="avformat avcodec avutil"
+-avdevice_suggest="libm"
++avdevice_suggest="libm stdatomic"
+ avfilter_deps="avutil"
+-avfilter_suggest="libm"
++avfilter_suggest="libm stdatomic"
+ avformat_deps="avcodec avutil"
+-avformat_suggest="libm network zlib"
+-avutil_suggest="clock_gettime ffnvcodec libm libdrm libmfx opencl user32 vaapi vulkan videotoolbox corefoundation corevideo coremedia bcrypt"
++avformat_suggest="libm network zlib stdatomic"
++avutil_suggest="clock_gettime ffnvcodec libm libdrm libmfx opencl user32 vaapi vulkan videotoolbox corefoundation corevideo coremedia bcrypt stdatomic"
+ postproc_deps="avutil gpl"
+-postproc_suggest="libm"
++postproc_suggest="libm stdatomic"
+ swresample_deps="avutil"
+-swresample_suggest="libm libsoxr"
++swresample_suggest="libm libsoxr stdatomic"
+ swscale_deps="avutil"
+-swscale_suggest="libm"
++swscale_suggest="libm stdatomic"
+ 
+ avcodec_extralibs="pthreads_extralibs iconv_extralibs dxva2_extralibs"
+ avfilter_extralibs="pthreads_extralibs"
+@@ -6321,7 +6321,14 @@ check_headers asm/types.h
+ # it seems there are versions of clang in some distros that try to use the
+ # gcc headers, which explodes for stdatomic
+ # so we also check that atomics actually work here
+-check_builtin stdatomic stdatomic.h "atomic_int foo, bar = ATOMIC_VAR_INIT(-1); atomic_store(&foo, 0); foo += bar"
++#
++# some configurations also require linking to libatomic, so try
++# both with -latomic and without
++for LATOMIC in "-latomic" ""; do
++    check_builtin stdatomic stdatomic.h                                                 \
++        "atomic_int foo, bar = ATOMIC_VAR_INIT(-1); atomic_store(&foo, 0); foo += bar"  \
++        $LATOMIC && eval stdatomic_extralibs="\$LATOMIC" && break
++done
+ 
+ check_lib advapi32 "windows.h"            RegCloseKey          -ladvapi32
+ check_lib bcrypt   "windows.h bcrypt.h"   BCryptGenRandom      -lbcrypt &&


### PR DESCRIPTION
Bump to latest upstream version.

Manually rebased: `030-h264-mips.patch`
Backported: FFmpeg/FFmpeg/commit/2f0a214a6202516b4dda2bb22b6b3ac20e465d6d

Tested using:
```
ffmpeg -f lavfi -i testsrc=duration=10:size=1280x720:rate=30 testsrc.mpg
```
Resulting mpg was good.

Build system: x86_64
Build-tested: bcm2711/RPi4B
Run-tested: bcm2711/RPi4B

Signed-off-by: John Audia <graysky@archlinux.us>

Maintainer: @BKPepe @bkuhls @lipnitsk @antonlacon @neheb

