### PR TITLE
rng-tools: drop unneeded dep

### DIFF
--- a/utils/rng-tools/Makefile
+++ b/utils/rng-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rng-tools
 PKG_VERSION:=6.15
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/nhorman/rng-tools
@@ -32,7 +32,7 @@ define Package/rng-tools
   CATEGORY:=Utilities
   TITLE:=Daemon for adding entropy to kernel entropy pool
   URL:=https://github.com/nhorman/rng-tools
-  DEPENDS:=+libsysfs +libopenssl
+  DEPENDS:=+libopenssl
 endef
 
 define Package/rng-tools/description


### PR DESCRIPTION
Upstream dropped the libsysfs dep.[1]

1. https://github.com/nhorman/rng-tools/releases/tag/v6.12

Signed-off-by: John Audia <graysky@archlinux.us>

Maintainer: @Noltari @nwf @neheb