### PR TITLE
shadowsocks-libev: add tcp_extra/udp_extra options

### DIFF
--- a/net/shadowsocks-libev/Makefile
+++ b/net/shadowsocks-libev/Makefile
@@ -14,7 +14,7 @@ include $(TOPDIR)/rules.mk
 #
 PKG_NAME:=shadowsocks-libev
 PKG_VERSION:=3.3.5
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/shadowsocks/shadowsocks-libev/releases/download/v$(PKG_VERSION)

--- a/net/shadowsocks-libev/README.md
+++ b/net/shadowsocks-libev/README.md
@@ -71,6 +71,11 @@ We can have multiple instances of component and `server` sections.  The relation
 
 	local_default		[bypass], forward, checkdst
 
+	--- extra nftables statement added to the final tcp/udp forward rule
+
+	nft_tcp_extra		e.g. use 'tcp dport { 80, 443 }' to only forward connections with dport 80 or 443
+	nft_udp_extra		e.g. use 'udp dport { 53 }' to only forward connections with dport 53
+
 ss-rules now uses nft set for storing addresses/networks.  Those set names are also part of the API and can be populated by other programs, e.g. dnsmasq with builtin nft set support
 
 Note also that `src_ips_xx` and `dst_ips_xx` actually also accepts cidr network representation.  Option names are retained in its current form for backward compatibility coniderations
@@ -154,6 +159,8 @@ As for other options, change them only when you know the effect.
 		option src_default 'checkdst'
 		option dst_default 'forward'
 		option local_default 'forward'
+		# option nft_tcp_extra 'tcp dport { 80, 443 }' # tcp only forward connections with dport 80 or 443
+		# option nft_udp_extra 'udp dport { 53 }' # udp only forward connections with dport 53
 
 Restart shadowsocks-libev components
 

--- a/net/shadowsocks-libev/files/shadowsocks-libev.init
+++ b/net/shadowsocks-libev/files/shadowsocks-libev.init
@@ -152,6 +152,8 @@ ss_rules() {
 	json_add_string o_dst_bypass_file "$dst_ips_bypass_file"
 	json_add_string o_dst_forward_file "$dst_ips_forward_file"
 	json_add_string o_dst_default "$dst_default"
+	json_add_string o_nft_tcp_extra "$nft_tcp_extra"
+	json_add_string o_nft_udp_extra "$nft_udp_extra"
 	json_dump -i >"$tmp.json"
 
 	if ucode -S -i "$ssrules_uc" -E "$tmp.json" >"$tmp.nft" \
@@ -283,6 +285,8 @@ validate_ss_rules_section() {
 		'src_default:or("bypass", "forward", "checkdst"):checkdst' \
 		'dst_default:or("bypass", "forward"):bypass' \
 		'local_default:or("bypass", "forward", "checkdst"):bypass' \
+		'nft_tcp_extra:string' \
+		'nft_udp_extra:string' \
 		'ifnames:maxlength(15)'
 }
 

--- a/net/shadowsocks-libev/files/ss-rules/chain.uc
+++ b/net/shadowsocks-libev/files/ss-rules/chain.uc
@@ -97,7 +97,7 @@ chain ss_rules_dst_{{ proto }} {
 
 {%   if (proto == "tcp"): %}
 chain ss_rules_forward_{{ proto }} {
-	meta l4proto tcp redirect to :{{ redir_port }};
+	meta l4proto tcp {{ o_nft_tcp_extra }} redirect to :{{ redir_port }};
 }
 {%   let local_verdict = get_local_verdict(); if (local_verdict): %}
 chain ss_rules_local_out {
@@ -112,7 +112,7 @@ chain ss_rules_local_out {
 {%     endif %}
 {%   elif (proto == "udp"): %}
 chain ss_rules_forward_{{ proto }} {
-	meta l4proto udp meta mark set 1 tproxy to :{{ redir_port }};
+	meta l4proto udp {{ o_nft_udp_extra }} meta mark set 1 tproxy to :{{ redir_port }};
 }
 {%   endif %}
 {% endif %}


### PR DESCRIPTION
Maintainer: @yousong
Compile tested: (ramips/mt7621, r19033-495c4f4e19)
Run tested: (ramips/mt7621, r19033-495c4f4e19, tests done)

Description: Add extra statement to tcp/udp forward rule, example:

```
config ss_rules 'ss_rules'
    ...
    option tcp_extra 'tcp dport { 80, 443 }' # tcp only forward connections with dport 80 or 443
    option udp_extra 'udp dport { 53 }' # udp only forward connections with dport 53
```

This somewhat restores the old ipt_args functionality.