### PR TITLE
conmon: update to version 2.1.0

### DIFF
--- a/utils/conmon/Makefile
+++ b/utils/conmon/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=conmon
-PKG_VERSION:=2.0.32
+PKG_VERSION:=2.1.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containers/$(PKG_NAME)/archive/v$(PKG_VERSION)
-PKG_HASH:=0ffd17a185322779d14d9a64c39120900f1e0cc3297b18679a933f5f6ba06a75
+PKG_HASH:=874909d831feac75e452562087f6ea0eb39848ef144397bdd8f0daf579c5ee85
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/conmon/patches/010-remove-libdl-dep.patch
+++ b/utils/conmon/patches/010-remove-libdl-dep.patch
@@ -1,14 +1,21 @@
 --- a/meson.build
 +++ b/meson.build
-@@ -34,7 +34,6 @@ add_project_arguments('-Os', '-Wall', '-
-                       language : 'c')
+@@ -35,14 +35,6 @@ add_project_arguments('-Os', '-Wall', '-
  
  glib = dependency('glib-2.0')
--libdl = cc.find_library('dl')
  
+-cc = meson.get_compiler('c')
+-null_dep = dependency('', required : false)
+-if cc.has_function('dlopen')
+-  libdl = null_dep
+-else
+-  libdl = cc.find_library('dl')
+-endif
+-
  executable('conmon',
             ['src/conmon.c',
-@@ -71,7 +70,7 @@ executable('conmon',
+             'src/config.h',
+@@ -78,7 +70,7 @@ executable('conmon',
              'src/utils.h',
              'src/seccomp_notify.c',
              'src/seccomp_notify.h'],


### PR DESCRIPTION
This release contains bug fixes. Patch removing libdl depency was obsolete on my build, but might your mileage might vary; therefor, I refreshed it to support this version; end result is the same anyway even with this patch.

List of changes in release is available [here](https://github.com/containers/conmon/releases) if needed..

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>

Maintainer: Oskari Rauta / @oskarirauta
Compile tested: x86_64, recent git
Run tested: x86_64, recent git