### PR TITLE
dnsproxy: Update to 0.41.3

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.41.2
+PKG_VERSION:=0.41.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=ae67d86ffab7c5d63dac07ddf00463e4c32ef61247e86049f8f9126883e20944
+PKG_HASH:=ab0ba5dc1d05810159c8c51fdea5565c74b642614ff0f24960d13ba1c30a99bd
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: ipq807x, rockchip/armv8
Run tested: rk3328 nanopi-r2s

Description:
Release note: https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.41.3