### PR TITLE
gptfdisk: fix some warnings treated as errors

### DIFF
--- a/utils/gptfdisk/Makefile
+++ b/utils/gptfdisk/Makefile
@@ -72,7 +72,7 @@ define Package/fixparts/description
   Master Boot Record (MBR) partition tables
 endef
 
-TARGET_CXXFLAGS += -std=c++11 -ffunction-sections -fdata-sections -fno-rtti -flto
+TARGET_CXXFLAGS += -std=c++11 -ffunction-sections -fdata-sections -fno-rtti -flto -Wno-format-security
 TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
 define Package/gdisk/install


### PR DESCRIPTION
fixes `error: format not a string literal and no format arguments [-Werror=format-security]` during compile

part of verbose build output:
```
gptcurses.cc: In member function 'Space* GPTDataCurses::ShowSpace(int, int)':
gptcurses.cc:242:16: error: format not a string literal and no format arguments [-Werror=format-security]
  242 |          printw(BytesToIeee((space->lastLBA - space->firstLBA + 1), blockSize).c_str());
      |          ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gptcurses.cc:249:16: error: format not a string literal and no format arguments [-Werror=format-security]
  249 |          printw(BytesToIeee((space->lastLBA - space->firstLBA + 1), blockSize).c_str());
      |          ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gptcurses.cc:251:16: error: format not a string literal and no format arguments [-Werror=format-security]
  251 |          printw(space->origPart->GetTypeName().c_str());
      |          ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gptcurses.cc:257:16: error: format not a string literal and no format arguments [-Werror=format-security]
  257 |          printw(space->origPart->GetDescription().c_str());
      |          ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gptcurses.cc: In member function 'int GPTDataCurses::DisplayParts(int)':
gptcurses.cc:274:10: error: format not a string literal and no format arguments [-Werror=format-security]
  274 |    printw(theLine.c_str());
      |    ~~~~~~^~~~~~~~~~~~~~~~~
gptcurses.cc:277:10: error: format not a string literal and no format arguments [-Werror=format-security]
  277 |    printw(theLine.c_str());
      |    ~~~~~~^~~~~~~~~~~~~~~~~
gptcurses.cc: In member function 'void GPTDataCurses::ShowInfo(int)':
gptcurses.cc:336:29: warning: format '%lld' expects argument of type 'long long int', but argument 2 has type 'uint64_t' {aka 'long unsigned int'} [-Wformat=]
  336 |    printw("First sector: %lld (at %s)\n", partitions[partNum].GetFirstLBA(),
      |                          ~~~^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                             |                                            |
      |                             long long int                                uint64_t {aka long unsigned int}
      |                          %ld
gptcurses.cc:338:28: warning: format '%lld' expects argument of type 'long long int', but argument 2 has type 'uint64_t' {aka 'long unsigned int'} [-Wformat=]
  338 |    printw("Last sector: %lld (at %s)\n", partitions[partNum].GetLastLBA(),
      |                         ~~~^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                            |                                           
      |                            long long int                               uint64_t {aka long unsigned int}
      |                         %ld
gptcurses.cc:341:31: warning: format '%lld' expects argument of type 'long long int', but argument 2 has type 'uint64_t' {aka 'long unsigned int'} [-Wformat=]
  341 |    printw("Partition size: %lld sectors (%s)\n", size, BytesToIeee(size, blockSize).c_str());
      |                            ~~~^                  ~~~~
      |                               |                  |
      |                               long long int      uint64_t {aka long unsigned int}
      |                            %ld
gptcurses.cc:342:33: warning: format '%x' expects argument of type 'unsigned in', but argument 2 has type 'uint64_t' {aka 'long unsigned int'} [-Wformat=]
  342 |    printw("Attribute flags: %016x\n", partitions[partNum].GetAttributes().GetAttributes());
      |                             ~~~~^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                 |                                                      |
      |                                 unsigned int                                           uint64_t {aka long unsigned int}
      |                             %016lx
gptcurses.cc: In member function 'void GPTDataCurses::MakeNewPart()':
gptcurses.cc:444:32: warning: format '%lld' expects argument of type 'long long int', but argument 2 has type 'uint64_t' {aka 'long unsigned int'} [-Wformat=]
  444 |       printw("First sector (%lld-%lld, default = %lld): ", newFirstLBA, currentSpace->lastLBA, newFirstLBA);
      |                             ~~~^                           ~~~~~~~~~~~
      |                                |                           |
      |                                long long int               uint64_t {aka long unsigned int}
      |                             %ld
gptcurses.cc:444:37: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'uint64_t' {aka 'long unsigned int'} [-Wformat=]
  444 |       printw("First sector (%lld-%lld, default = %lld): ", newFirstLBA,currentSpace->lastLBA, newFirstLBA);
      |                                  ~~~^                                  ~~~~~~~~~~~~~~~~~~~~~
      |                                     |                                                 |
      |                                     long long int                                     uint64_t {aka long unsigned int}
      |                                  %ld
gptcurses.cc:444:53: warning: format '%lld' expects argument of type 'long long int', but argument 4 has type 'uint64_t' {aka 'long unsigned int'} [-Wformat=]
  444 |       printw("First sector (%lld-%lld, default = %lld): ", newFirstLBA, currentSpace->lastLBA, newFirstLBA);
      |                                                  ~~~^                                          ~~~~~~~~~~~
      |                                                     |                                          |
      |                                                     long long int                              uint64_t {aka long unsigned int}
      |                                                  %ld
gptcurses.cc:455:56: warning: format '%lld' expects argument of type 'long long int', but argument 2 has type 'uint64_t' {aka 'long unsigned int'} [-Wformat=]
  455 |       printw("Size in sectors or {KMGTP} (default = %lld): ", size);
      |                                                     ~~~^      ~~~~
      |                                                        |      |
      |                                                        |      uint64_t {aka long unsigned int}
      |                                                        long long int
      |                                                     %ld
gptcurses.cc: In member function 'void GPTDataCurses::DisplayOptions(char)':
gptcurses.cc:639:13: error: format not a string literal and no format arguments [-Werror=format-security]
  639 |       printw(optionDesc.c_str());
      |       ~~~~~~^~~~~~~~~~~~~~~~~~~~
gptcurses.cc: In member function 'void GPTDataCurses::DrawMenu()':
gptcurses.cc:751:10: error: format not a string literal and no format arguments [-Werror=format-security]
  751 |    printw(title.c_str());
      |    ~~~~~~^~~~~~~~~~~~~~~
gptcurses.cc:753:10: error: format not a string literal and no format arguments [-Werror=format-security]
  753 |    printw(drive.c_str());
      |    ~~~~~~^~~~~~~~~~~~~~~
gptcurses.cc:755:10: error: format not a string literal and no format arguments [-Werror=format-security]
  755 |    printw(size.str().c_str());
      |    ~~~~~~^~~~~~~~~~~~~~~~~~~~
gptcurses.cc: In function 'void Report(std::string)':
gptcurses.cc:805:10: error: format not a string literal and no format arguments [-Werror=format-security]
  805 |    printw(theText.c_str());
      |    ~~~~~~^~~~~~~~~~~~~~~~~
cc1plus: some warnings being treated as errors
make[3]: *** [<builtin>: gptcurses.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: Leaving directory '/usr/src/openwrt/build_dir/target-x86_64_musl/gptfdisk-1.0.8'
make[2]: *** [Makefile:101: /usr/src/openwrt/build_dir/target-x86_64_musl/gptfdisk-1.0.8/.built] Error 2
make[2]: Leaving directory '/usr/src/openwrt/feeds/packages/utils/gptfdisk'
time: package/feeds/packages/gptfdisk/compile#11.60#2.40#5.23
    ERROR: package/feeds/packages/gptfdisk failed to build.
```

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>

Maintainer: no one
Compile tested: x86_64, git snapshot
Run tested: x86_64, git snapshot
