### PR TITLE
Snort packages should conflict to each other

### DIFF
--- a/net/snort/Makefile
+++ b/net/snort/Makefile
@@ -34,6 +34,7 @@ define Package/snort
   DEPENDS:=+libdaq +libdnet +libnghttp2 +libopenssl +libpcap +libpcre +libpthread +libtirpc +libuuid +zlib +luajit +SNORT_LZMA:liblzma
   TITLE:=Lightweight Network Intrusion Detection System
   URL:=http://www.snort.org/
+  CONFLICTS:=snort3
   MENU:=1
 endef
 


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: N/A
Run tested: N/A

Fixes:
```
Packages 'snort3' and 'snort' do not conflict while providing same file: /usr/bin/u2boat
Packages 'snort3' and 'snort' do not conflict while providing same file: /usr/bin/u2spewfoo
Packages 'snort3' and 'snort' do not conflict while providing same file: /usr/bin/snort
Packages 'snort3' and 'snort' do not conflict while providing same file: /etc/init.d/snort
Packages 'snort3' and 'snort' do not conflict while providing same file: /etc/config/snort
```
