### PR TITLE
libarchive: add conflict to bsdtar/bsdtar-noopenssl

### DIFF
--- a/libs/libarchive/Makefile
+++ b/libs/libarchive/Makefile
@@ -53,6 +53,7 @@ endef
 define Package/bsdtar
   $(call Package/bsdtar/Default)
   DEPENDS:= +libarchive
+  CONFLICTS:=bsdtar-noopenssl
 endef
 
 define Package/bsdtar-noopenssl


### PR DESCRIPTION
Maintainer: @morgenroth 
Compile tested: Turris Omnia, mvebu, cortex-a9, OpenWrt 21.02.2
Run tested: N/A

Fixes:
```
Packages 'bsdtar' and 'bsdtar-noopenssl' do not conflict while providing same file: /usr/bin/bsdtar
