### PR TITLE
chicken-scheme: add conflict and small Makefile polishing

### DIFF
--- a/lang/chicken-scheme/Makefile
+++ b/lang/chicken-scheme/Makefile
@@ -22,16 +22,13 @@ PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
 
-
-
-
 define Package/chicken-scheme/Default
+  TITLE:=Chicken Scheme
   SECTION:=lang
   CATEGORY:=Languages
   URL:=https://call-cc.org
   ABI_VERSION:=11
 endef
-
 
 ##
 ## chicken-scheme-interpreter
@@ -39,9 +36,8 @@ endef
 
 define Package/chicken-scheme-interpreter
 $(call Package/chicken-scheme/Default)
-  TITLE:=Chicken Scheme -- interpreter only
-  SECTION:=lang
-  CATEGORY:=Languages
+  TITLE+=interpreter only
+  CONFLICTS:=chicken-scheme-full
 endef
 
 define Package/chicken-scheme-interpreter/description
@@ -95,9 +91,7 @@ include $(TOPDIR)/rules.mk
 
 define Package/chicken-scheme-full
 $(call Package/chicken-scheme/Default)
-  TITLE:=Chicken Scheme -- full package
-  SECTION:=lang
-  CATEGORY:=Languages
+  TITLE+=full package
   # csc depends on gcc; chicken-install uses the 'install' command from coreutils
   EXTRA_DEPENDS:= gcc, coreutils-install
 endef


### PR DESCRIPTION
Maintainer: @jpellegrini 
Compile tested: no, run only ``make menuconfig`` that there are no recursive dependencies.
Run tested: N/A

Description:

- No need to explicitly state two times section and category since this is
already done in define Package/chicken-scheme/Default
- Also add TITLE to Default

- Add conflict between chicken-scheme-interpreter and
  chicken-scheme-full
They both provide the same files:
/usr/lib/libchicken.so
/usr/lib/chicken/11/chicken.time.import.so
/usr/lib/chicken/11/chicken.fixnum.import.so
/usr/lib/chicken/11/chicken.internal.import.so
/usr/lib/chicken/11/chicken.tcp.import.so
/usr/lib/chicken/11/chicken.continuation.import.so
/usr/lib/chicken/11/chicken.port.import.so
/usr/lib/chicken/11/chicken.random.import.so
/usr/lib/chicken/11/chicken.compiler.user-pass.import.so
/usr/lib/chicken/11/chicken.process-context.import.so
/usr/lib/chicken/11/chicken.bitwise.import.so
/usr/lib/chicken/11/srfi-4.import.so
/usr/lib/chicken/11/chicken.load.import.so
/usr/lib/chicken/11/chicken.blob.import.so
/usr/lib/chicken/11/chicken.time.posix.import.so
/usr/lib/chicken/11/chicken.file.posix.import.so
/usr/lib/chicken/11/chicken.flonum.import.so
/usr/lib/chicken/11/chicken.condition.import.so
/usr/lib/chicken/11/chicken.pretty-print.import.so
/usr/lib/chicken/11/types.db
/usr/lib/chicken/11/chicken.foreign.import.so
/usr/lib/chicken/11/chicken.repl.import.so
/usr/lib/chicken/11/chicken.pathname.import.so
/usr/lib/chicken/11/chicken.sort.import.so
/usr/lib/chicken/11/chicken.keyword.import.so
/usr/lib/chicken/11/chicken.process.signal.import.so
/usr/lib/chicken/11/chicken.platform.import.so
/usr/lib/chicken/11/chicken.base.import.so
/usr/lib/chicken/11/chicken.syntax.import.so
/usr/lib/chicken/11/chicken.file.import.so
/usr/lib/chicken/11/chicken.memory.import.so
/usr/lib/chicken/11/chicken.gc.import.so
/usr/lib/chicken/11/chicken.io.import.so
/usr/lib/chicken/11/chicken.memory.representation.import.so
/usr/lib/chicken/11/chicken.process.import.so
/usr/lib/chicken/11/chicken.plist.import.so
/usr/lib/chicken/11/chicken.string.import.so
/usr/lib/chicken/11/chicken.errno.import.so
/usr/lib/chicken/11/chicken.format.import.so
/usr/lib/chicken/11/chicken.eval.import.so
/usr/lib/chicken/11/chicken.irregex.import.so
/usr/lib/chicken/11/chicken.process-context.posix.import.so
/usr/lib/chicken/11/chicken.read-syntax.import.so
/usr/lib/chicken/11/chicken.csi.import.so
/usr/lib/chicken/11/chicken.locative.import.so
/usr/bin/csi
