### PR TITLE
[21.02] Bump yggdrasil to 0.4.3

### DIFF
--- a/net/yggdrasil/Makefile
+++ b/net/yggdrasil/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yggdrasil
-PKG_VERSION:=0.4.2
+PKG_VERSION:=0.4.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=ac21671e2ed0bf5313d277dead703190c6bdccfe8bbb4ccb4ad8d1258ff79689
+PKG_HASH:=db793089eddfef628d30055d8b06a6a09f98bb38c3b4ede5265a4ad6eaa80d52
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-go-$(PKG_VERSION)
 
 PKG_MAINTAINER:=William Fleurant <meshnet@protonmail.com>


### PR DESCRIPTION
Maintainer: @wfleurant
Compile tested: none
Run tested: none

Description:
Cherrypicking from https://github.com/openwrt/packages/pull/17907