### PR TITLE
tinc: add creation  of hosts directory for each network configuration

### DIFF
--- a/net/tinc/files/tinc.init
+++ b/net/tinc/files/tinc.init
@@ -156,7 +156,7 @@ prepare_net() {
 	section_enabled "$s" || return 1
 
 	[ -d "$TMP_TINC/$s" ] && rm -rf "$TMP_TINC/$s/"
-	mkdir -p "$TMP_TINC/$s"
+	mkdir -p "$TMP_TINC/$s/hosts"
 	[ -d "/etc/tinc/$s" ] && cp -r "/etc/tinc/$s" "$TMP_TINC/"
 
 	# append flags


### PR DESCRIPTION
Signed-off-by: Erwan MAS <erwan@mas.nom.fr>

Maintainer: me / @ErwanMAS 
Compile tested: N/A
Run tested:   OpenWrt 21.02.2  

Description:
  when creating the temporary folder for each vpn add a empty directory hosts

