### PR TITLE
mdnsresponder: Fix nullpointer dereference while parsing interface list [21.02 backport]

### DIFF
--- a/net/mdnsresponder/Makefile
+++ b/net/mdnsresponder/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mDNSResponder
 PKG_VERSION:=IETF104
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=mDNSResponder-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://opensource.apple.com/tarballs/mDNSResponder/IETF/

--- a/net/mdnsresponder/patches/020-fix-core-dump-while-parsing-interface-list.patch
+++ b/net/mdnsresponder/patches/020-fix-core-dump-while-parsing-interface-list.patch
@@ -1,0 +1,18 @@
+From 1fb07b9524b4afed3a826c087db4dc48a7bfdb89 Mon Sep 17 00:00:00 2001
+From: Ted Lemon <elemon@apple.com>
+Date: Thu, 6 Jun 2019 13:35:43 -0400
+Subject: [PATCH] Fix core dump while parsing interface list on Posix
+
+---
+--- a/mDNSPosix/mDNSPosix.c
++++ b/mDNSPosix/mDNSPosix.c
+@@ -1320,7 +1320,8 @@ mDNSlocal int SetupInterfaceList(mDNS *c
+         struct ifaddrs *i = intfList;
+         while (i)
+         {
+-            if (     ((i->ifa_addr->sa_family == AF_INET)
++            if (     i->ifa_addr != NULL &&
++                     ((i->ifa_addr->sa_family == AF_INET)
+ #if HAVE_IPV6
+                       || (i->ifa_addr->sa_family == AF_INET6)
+ #endif


### PR DESCRIPTION
21.02 backport of #17943

Signed-off-by: Maarten Aertsen <spam-github@rtsn.nl>
Fixes: https://github.com/openwrt/packages/issues/17915
(cherry picked from commit a4b33ab169a3ca60cd12c2eb5155e899779d3570)

Maintainer: none, @neheb would you be willing to merge?
Compile tested: x86-64
Run tested: apu2
