### PR TITLE
chrony: add conflict between without NTS and NTS variant

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
 PKG_VERSION:=4.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.tuxfamily.org/chrony/
@@ -39,6 +39,7 @@ define Package/chrony
 $(call Package/chrony/Default)
   TITLE+= (without NTS)
   VARIANT:=normal
+  CONFLICTS:=chrony-nts
 endef
 
 define Package/chrony-nts


### PR DESCRIPTION
Maintainer: @mlichvar
Compile and run tested: N/A

Both packages provide the same files:
/usr/bin/chronyc
/usr/sbin/chronyd
/etc/chrony/chrony.conf
/etc/hotplug.d/iface/20-chrony
/etc/init.d/chronyd

They should not be installed side by side.