### PR TITLE
[21.02] curl: update to 7.82.0

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=curl
-PKG_VERSION:=7.80.0
+PKG_VERSION:=7.82.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://dl.uxnr.de/mirror/curl/ \
 	https://curl.askapache.com/download/ \
 	https://curl.se/download/
-PKG_HASH:=a132bd93188b938771135ac7c1f3ac1d3ce507c1fcbef8c471397639214ae2ab
+PKG_HASH:=0aaa12d7bd04b0966254f2703ce80dd5c38dbbd76af0297d3d690cdce58a583c
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING

--- a/net/curl/patches/200-no_docs_tests.patch
+++ b/net/curl/patches/200-no_docs_tests.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -195,7 +195,7 @@ CLEANFILES = $(VC6_LIBDSP) $(VC6_SRCDSP)
+@@ -156,7 +156,7 @@ CLEANFILES = $(VC10_LIBVCXPROJ) $(VC10_S
  bin_SCRIPTS = curl-config
  
  SUBDIRS = lib src
@@ -9,7 +9,7 @@
  
  pkgconfigdir = $(libdir)/pkgconfig
  pkgconfig_DATA = libcurl.pc
-@@ -309,8 +309,6 @@ cygwinbin:
+@@ -270,8 +270,6 @@ cygwinbin:
  # We extend the standard install with a custom hook:
  install-data-hook:
  	(cd include && $(MAKE) install)


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-135, OpenWrt 21.02.1
Run tested: x86_64, Sophos SG-135, OpenWrt 21.02.1, download file, print version

Description:
* changelog: https://curl.se/changes.html#7_82_0

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 38b3a5f857a8b282328cb1e0ada48793bd4bcce5)

I'll merge it in a week or so unless bugs are reported in master.