### PR TITLE
python3: Add Py3Build/InstallBuildDepends recipe

### DIFF
--- a/lang/python/README.md
+++ b/lang/python/README.md
@@ -369,3 +369,30 @@ HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:=setuptools-scm
 ```
 
 The Python package will be installed in `$(STAGING_DIR_HOSTPKG)/lib/pythonX.Y/site-packages`.
+
+#### Non-Python packages installing host-side Python packages
+
+Non-Python packages can also install host-side Python packages using the same mechanism:
+
+* Set `HOST_PYTHON3_PACKAGE_BUILD_DEPENDS` (see above for details).
+
+* Include `python3-package.mk` (set `PYTHON3_PKG_BUILD:=0` to avoid using the default Python package build recipes).
+
+* Call `Py3Build/InstallBuildDepends` to initiate the installation.
+
+For example:
+
+```
+PYTHON3_PKG_BUILD:=0
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:=setuptools-scm
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/python/python3-package.mk
+# If outside of the packages feed:
+# include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
+
+define Build/Compile
+	$(call Py3Build/InstallBuildDepends)
+	$(call Build/Compile/Default)
+endef
+```

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -215,10 +215,14 @@ define Py3Build/CheckHostPipVersionMatch
 endef
 endif
 
-define Py3Build/Compile/Default
+define Py3Build/InstallBuildDepends
 	$(if $(PYTHON3_PKG_HOST_PIP_INSTALL_ARGS), \
 		$(call HostPython3/PipInstall,$(PYTHON3_PKG_HOST_PIP_INSTALL_ARGS)) \
 	)
+endef
+
+define Py3Build/Compile/Default
+	$(call Py3Build/InstallBuildDepends)
 	$(call Python3/ModSetup, \
 		$(PYTHON3_PKG_SETUP_DIR), \
 		$(PYTHON3_PKG_SETUP_GLOBAL_ARGS) \

--- a/utils/apparmor/Makefile
+++ b/utils/apparmor/Makefile
@@ -132,9 +132,7 @@ endef
 
 define Build/Install
 	# Make sure we have python's setup tools installed
-	$(if $(PYTHON3_PKG_HOST_PIP_INSTALL_ARGS), \
-		$(call HostPython3/PipInstall,$(PYTHON3_PKG_HOST_PIP_INSTALL_ARGS)) \
-	)
+	$(call Py3Build/InstallBuildDepends)
 	$(INSTALL_DIR) $(PKG_INSTALL_DIR)-libapparmor $(PKG_INSTALL_DIR)-utils $(PKG_INSTALL_DIR)-profiles
 	# Installing libapparmor
 	+$(MAKE_VARS) PYTHON=$(HOST_PYTHON) VERSION=$(PYTHON3_VERSION) \


### PR DESCRIPTION
Maintainer: me, @oskarirauta (for apparmor)
Compile tested: armvirt-32, 2022-03-06 snapshot sdk
Run tested: none

Description:
This adds a recipe, `Py3Build/InstallBuildDepends`, that installs the requirements listed in `HOST_PYTHON3_PACKAGE_BUILD_DEPENDS`. This allows other (non-Python) packages to install host Python packages by calling this recipe, without having to know the internals of python3-package.mk.

This also updates apparmor to call this recipe.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>