### PR TITLE
cache-domains: Fixed hotplug script not running

### DIFF
--- a/utils/cache-domains/Makefile
+++ b/utils/cache-domains/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cache-domains
-PKG_VERSION:=2.3.0
+PKG_VERSION:=2.3.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>

--- a/utils/cache-domains/files/30-cache-domains
+++ b/utils/cache-domains/files/30-cache-domains
@@ -3,7 +3,7 @@
 . /lib/functions/network.sh
 network_find_wan WAN_IFACE
 
-if [ "${ACTION}" = "ifup" ] && [ "${INTERFACE}" = "${WAN_IFACE}" ] && [ ! -d /var/cache-domains ]; then
+if [ "${ACTION}" = "ifup" ] && [ "${INTERFACE}" = "${WAN_IFACE}" ] && [ ! -e /var/cache-domains/lancache.conf ]; then
 	for ATTEMPT in $(seq 1 3); do
 		if /usr/bin/cache-domains configure; then
 			break


### PR DESCRIPTION
Maintainer: me / @G-M0N3Y-2503
Compile tested: x86_x64, QEMU/KVM, `openwrt-21.02`
Run tested: x86_x64, x86_x64, `openwrt-21.02`

Description:
Fixed hotplug not correctly checking if cache-domains is already configured

master PR https://github.com/openwrt/packages/pull/18024