### PR TITLE
docker-compose: Update to version 2.3.2

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.2.3
+PKG_VERSION:=2.3.2
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=22210187e73732edd9fc02f122ea61481806c703af7b73d0a7351f2e8ed7c0b8
+PKG_HASH:=11c1ea791698ec04c56d69207cf7b256e11b8dd2b4ae7b21cb5cdf875f5fe00a
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream version.

What's Changed:

- 2.3.2:
  - Fix json format for version command by @victor-timofei
  - filter containers after project has been rebuilt from resources by
  @ndeloof
  - publish a draft release with auto generate release notes by
  @glours
  - map --interactive to StdinOpen by @ndeloof

- 2.3.1:
  - Support COMPOSE_IGNORE_ORPHANS for compose run by @PIG208
  - don't try to start dependencies when there are none by @ndeloof
  - don't failed when trying to stop or rm services with no containers
  ru… by @glours

- 2.3.0:
  - Don't wait forever for unhealthy dependencies by @benesch
  - Add progress output while waiting for dependencies by @benesch
  - Discard env_file section on convert/config by @ulyssessouza
  - Return only numbers in short version by @guillaumerose
  - Don't SetRawTerminal() when exec is run with -T by @x-yuri
  - only remove volumes set by compose file by @ndeloof
  - Set NetworkMode correctly according to network priorities by
  @laurazard
  - go.mod: github.com/buger/goterm v1.0.4 by @thaJeztah
  - Fix typo in reference/compose_up.md by @danBamikiya
  - Fix pause/unpause by only applying to running containers by
  @ulyssessouza
  - use CustomLabels for composeV2 metadata and not impact service
  hash by @ndeloof
  - use golangci-lint-action by @ndeloof
  - Adds support to list the config files on docker compose ls by
  @KoditkarVedant
  - declare --volume as an alias for --volumes by @ndeloof
  - bump buildx to 0.7.1 by @ndeloof
  - Wait and scale 0 by @glours
  - Bump github.com/containerd/containerd from 1.5.8 to 1.6.0 by
  @dependabot
  - COMPOSE_REMOVE_ORPHANS can be set to always apply --remove-orphans
  by @ndeloof
  - Using start, stop, restart from outside the working directory
  using --project-name (#9147) by @arhemd
  - exclude com.docker.compose.image label from service hash by
  @ndeloof
  - Bump compose-go 1.0.9 by @ulyssessouza
  - Bump compose-go 1.1.0 by @ulyssessouza
  - Bump docker/distribution -> v2.8.0 by @ulyssessouza
  - report external volume name not found by @ndeloof
  - Bump github.com/containerd/containerd from 1.6.0 to 1.6.1 by
  @dependabot
  - CONTRIBUTING.md file. Update slack sign-up link by @teror4uks
  - Add function to convert strings to bool by @ulyssessouza
  - Add -i and -t to run and exec by @ulyssessouza

Signed-off-by: Javier Marcet <javier@marcet.info>
