### PR TITLE
Revert "expat: add host build"

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -21,7 +21,6 @@ PKG_CPE_ID:=cpe:/a:libexpat:expat
 CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk
 
 define Package/libexpat
@@ -52,5 +51,4 @@ define Package/libexpat/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libexpat.so.* $(1)/usr/lib/
 endef
 
-$(eval $(call HostBuild))
 $(eval $(call BuildPackage,libexpat))


### PR DESCRIPTION
Maintainer: @thess (ping @neheb, @dangowrt)
Compile tested: N/A
Run tested: N/A

Description:
This reverts commit ca21bbf2edd64fffd044e0d6caf6975243a3fa4b.

5bf74f2 removed the host build of expat and updated packages to use tools/expat instead.

ca21bbf re-added the host build of expat for mesa (actually wayland) in the video feed.

Changing wayland to use tools/expat is the proper fix, and there is a [PR][1] open with this change. Therefore this commit can and should be reverted.

[1]: https://github.com/openwrt/video/pull/24

Signed-off-by: Jeffery To <jeffery.to@gmail.com>