### PR TITLE
python-websocket-client: update to 1.3.1

### DIFF
--- a/lang/python/python-websocket-client/Makefile
+++ b/lang/python/python-websocket-client/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-websocket-client
-PKG_VERSION:=1.2.1
+PKG_VERSION:=1.3.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=websocket-client
-PKG_HASH:=8dfb715d8a992f5712fff8c843adae94e22b22a99b2c5e6b0ec4a1a981cc4e0d
+PKG_HASH:=6278a75065395418283f887de7c3beafb3aa68dada5cacbe4b214e8d26da499b
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream version.

- 1.3.1:
  - Fix 10 year old bug and improve dispatcher handling for
  run_forever
  - Fix run_forever to never return None, only return True or False,
  and add two tests
  - Remove Python 3.6 support, EOL in Dec 2021

- 1.3.0:
  - BREAKING: Set Origin header to use https:// scheme when wss://
  WebSocket URL is passed
  - Replace deprecated/broken WebSocket URLs with working ones
  (6ad5197)
  - Add documentation referencing rel for automatic reconnection with
  run_forever()
  - Add missing opcodes 1012, 1013
  - Add errno.ENETUNREACH to improve error handling (da1b050)
  - Minor documentation improvements and typo fixes

- 1.2.3:
  - Fix broken run_forever() functionality

- 1.2.2:
  - Migrate wsdump script in setup.py from scripts to newer
  entry_points
  - Add support for ssl.SSLContext for arbitrary SSL parameters
  - Remove keep_running variable
  - Remove HAVE_CONTEXT_CHECK_HOSTNAME variable (dac1692)
  - Replace deprecated ssl.PROTOCOL_TLS with ssl.PROTOCOL_TLS_CLIENT
  - Simplify code and improve Python 3 support
  - Fill default license template fields
  - Update CI tests
  - Improve documentation

Signed-off-by: Javier Marcet <javier@marcet.info>
