### PR TITLE
podman: updates podman package

### DIFF
--- a/utils/podman/Makefile
+++ b/utils/podman/Makefile
@@ -36,36 +36,30 @@ define Download/default-policy
   HASH:=cddfaa8e6a7e5497b67cc0dd8e8517058d0c97de91bf46fff867528415f2d946
 endef
 
-define Package/podman/Default
+define Package/podman
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Podman
   URL:=https://podman.io
-endef
-
-define Package/podman
-  $(call Package/podman/Default)
-  DEPENDS:=$(GO_ARCH_DEPENDS) +conmon +cni +cni-plugins +btrfs-progs +glib2 +gnupg2 +uci-firewall +libgpg-error +libseccomp +libgpgme +nsenter +zoneinfo-simple +kmod-veth
-  CONFLICTS:=podman-selinux
-  VARIANT:=default
-  PROVIDES:=podman
-endef
-
-define Package/podman-selinux
-  $(call Package/podman/Default)
-  TITLE += with SELinux support
-  DEPENDS:=$(GO_ARCH_DEPENDS) +conmon +cni +cni-plugins +btrfs-progs +glib2 +gnupg2 +uci-firewall +libgpg-error +libseccomp +libgpgme +nsenter +zoneinfo-simple +kmod-veth +libselinux
-  VARIANT:=selinux
-  PROVIDES:=podman
+  DEPENDS:=$(GO_ARCH_DEPENDS) +conmon +cni +cni-plugins +btrfs-progs +glib2 +gnupg2 +uci-firewall +libgpg-error +libseccomp +libgpgme +nsenter +zoneinfo-simple +kmod-veth +catatonit +PODMAN_SELINUX_SUPPORT:libselinux +PODMAN_IPTABLES_FW:iptables
 endef
 
 define Package/podman/description
   Podman: A tool for managing OCI containers and pods
 endef
 
-define Package/podman-selinux/description
-  Podman: A tool for managing OCI containers and pods
-  SELinux enabled.
+define Package/podman/config
+  menu "Configuration"
+
+    config PODMAN_SELINUX_SUPPORT
+    bool "Enable SELinux support"
+    default n
+
+    config PODMAN_IPTABLES_FW
+    bool "Add iptabels firewall options to default podman network"
+    default n
+
+  endmenu
 endef
 
 define Package/podman/conffiles
@@ -76,12 +70,16 @@ define Package/podman/conffiles
 /etc/cni/net.d/87-podman-bridge.conflist
 endef
 
-Package/podman-selinux/conffiles = $(Package/podman/conffiles)
-
-ifeq ($(BUILD_VARIANT),selinux)
+ifdef CONFIG_PODMAN_SELINUX_SUPPORT
   GO_PKG_TAGS=seccomp,exclude_graphdriver_devicemapper,selinux,apparmor
 else
   GO_PKG_TAGS=seccomp,exclude_graphdriver_devicemapper,apparmor
+endif
+
+ifdef CONFIG_PODMAN_IPTABLES_FW
+  CNIFILE:=87-podman-bridge-iptables.conflist
+else
+  CNIFILE:=87-podman-bridge.conflist
 endif
 
 define Build/Prepare
@@ -98,7 +96,7 @@ define Package/podman/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/vendor/github.com/containers/storage/storage.conf $(1)/etc/containers/storage.conf
 	$(INSTALL_DATA) ./files/containers.conf $(1)/etc/containers/containers.conf
 	$(INSTALL_DIR) $(1)/etc/cni/net.d
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/cni/87-podman-bridge.conflist $(1)/etc/cni/net.d/
+	$(INSTALL_CONF) ./files/$(CNIFILE) $(1)/etc/cni/net.d/87-podman-bridge.conflist
 	$(INSTALL_DIR) $(1)/usr/share/containers
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/vendor/github.com/containers/common/pkg/seccomp/seccomp.json $(1)/usr/share/containers/
 	$(INSTALL_DIR) $(1)/etc/init.d
@@ -106,9 +104,5 @@ define Package/podman/install
 	$(SED) 's/driver = \"\"/driver = \"overlay\"/g' $(1)/etc/containers/storage.conf
 endef
 
-Package/podman-selinux/install = $(Package/podman/install)
-
 $(eval $(call GoBinPackage,podman))
 $(eval $(call BuildPackage,podman))
-$(eval $(call GoBinPackage,podman-selinux))
-$(eval $(call BuildPackage,podman-selinux))

--- a/utils/podman/files/87-podman-bridge-iptables.conflist
+++ b/utils/podman/files/87-podman-bridge-iptables.conflist
@@ -1,0 +1,37 @@
+{
+  "cniVersion": "0.4.0",
+  "name": "podman",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni-podman0",
+      "isGateway": true,
+      "ipMasq": true,
+      "hairpinMode": true,
+      "ipam": {
+        "type": "host-local",
+        "routes": [{ "dst": "0.0.0.0/0" }],
+        "ranges": [
+          [
+            {
+              "subnet": "10.88.0.0/16",
+              "gateway": "10.88.0.1"
+            }
+          ]
+        ]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {
+        "portMappings": true
+      }
+    },
+    {
+      "type": "firewall"
+    },
+    {
+      "type": "tuning"
+    }
+  ]
+}

--- a/utils/podman/files/87-podman-bridge.conflist
+++ b/utils/podman/files/87-podman-bridge.conflist
@@ -1,0 +1,28 @@
+{
+  "cniVersion": "0.4.0",
+  "name": "podman",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni-podman0",
+      "isGateway": true,
+      "ipMasq": true,
+      "hairpinMode": true,
+      "ipam": {
+        "type": "host-local",
+        "routes": [{ "dst": "0.0.0.0/0" }],
+        "ranges": [
+          [
+            {
+              "subnet": "10.88.0.0/16",
+              "gateway": "10.88.0.1"
+            }
+          ]
+        ]
+      }
+    },
+    {
+      "type": "tuning"
+    }
+  ]
+}


### PR DESCRIPTION
Description:

- add missing runtime depency catatonit ( #18009 )
 - removed SELinux variant, add config option for it instead, I do not believe we need variant of EVERY SELinux support capable software
 - add config option for iptables firewall setup in default cni network config, otherwise skip iptables part (part of nftables transition, use cni-plugins-nft for nftables fw support or better; forget about cni fw completely, instead use openwrt's own as that way your rules for containers do not disappear on firewall restart), adjusts depends accordingly

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>

Maintainer: Oskari Rauta / @oskarirauta
Compile tested: x86_64, recent git