### PR TITLE
yq: Update to 4.22.1

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.21.1
+PKG_VERSION:=4.22.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=27ba049e24a2f40db4010ad6574ce866fa1d43f4cb064de286e344e3c7911ef0
+PKG_HASH:=79b4f01774849323db7cc649a270ac4aaccacea2e97260b25f51a634670ecb6e
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8, x86/64
Run tested: rk3328 nanopi-r2s

Description:
Release note: https://github.com/mikefarah/yq/releases/tag/v4.22.1