### PR TITLE
treewide: remove rpath-link

### DIFF
--- a/libs/libcups/Makefile
+++ b/libs/libcups/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cups
 PKG_VERSION:=2.2.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-source.tar.gz
 PKG_SOURCE_URL:=https://github.com/apple/cups/releases/download/v$(PKG_VERSION)/
@@ -39,8 +39,6 @@ endef
 define Package/libcups/description
 	Common UNIX Printing System - Core library
 endef
-
-TARGET_LDFLAGS+=-Wl,-rpath-link=$(STAGING_DIR)/usr/lib
 
 CONFIGURE_ARGS+=--with-cups-user="nobody" \
 		--with-cups-group="nogroup" \

--- a/multimedia/fswebcam/Makefile
+++ b/multimedia/fswebcam/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fswebcam
 PKG_VERSION:=20140113
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.firestorm.cx/fswebcam/files \
@@ -40,7 +40,7 @@ define Package/fswebcam/description
 endef
 
 EXTRA_CFLAGS+= $(TARGET_CPPFLAGS)
-EXTRA_LDFLAGS+= $(TARGET_LDFLAGS) -Wl,-rpath-link,$(STAGING_DIR)/usr/lib
+EXTRA_LDFLAGS+= $(TARGET_LDFLAGS)
 
 define Package/fswebcam/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -100,8 +100,7 @@ TARGET_CFLAGS += -Wno-error=implicit-function-declaration \
 		 -Wno-error=undef \
 		 -Wno-error=missing-include-dirs
 
-TARGET_LDFLAGS += -Wl,-rpath-link=$(STAGING_DIR)/usr/lib \
-		  -L$(STAGING_DIR)/usr/lib/libevent
+TARGET_LDFLAGS += -L$(STAGING_DIR)/usr/lib/libevent
 
 CONFIGURE_ARGS += \
 	--disable-caps \

--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -478,8 +478,6 @@ CONFIGURE_ARGS+= \
 	) \
 	ac_cv_search___atomic_load=no
 
-EXTRA_LDFLAGS+= -Wl,-rpath-link,$(STAGING_DIR)/usr/lib
-
 define Package/strongswan/conffiles
 /etc/strongswan.conf
 /etc/strongswan.d/

--- a/net/vnstat/Makefile
+++ b/net/vnstat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vnstat
 PKG_VERSION:=1.18
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://humdi.net/vnstat
@@ -71,7 +71,7 @@ define Build/Compile/vnstati
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
 		$(TARGET_CONFIGURE_OPTS) \
 		CFLAGS="$(TARGET_CFLAGS) -I$(STAGING_DIR)/usr/include" \
-		LDFLAGS="$(TARGET_LDFLAGS) -Wl,-rpath-link,$(STAGING_DIR)/usr/lib" \
+		LDFLAGS="$(TARGET_LDFLAGS)" \
 		all
 endef
 

--- a/sound/owntone/Makefile
+++ b/sound/owntone/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=owntone
 PKG_VERSION:=28.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/owntone/owntone-server/releases/download/$(PKG_VERSION)/
@@ -58,7 +58,6 @@ CONFIGURE_ARGS += \
 	--without-libevent_pthreads
 
 TARGET_CFLAGS += $(FPIC)
-TARGET_LDFLAGS += -Wl,-rpath-link,$(STAGING_DIR)/usr/lib
 
 define Package/owntone/install
 	$(INSTALL_DIR) $(1)/usr/sbin

--- a/sound/sox/Makefile
+++ b/sound/sox/Makefile
@@ -17,13 +17,9 @@ PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=LGPL-2.1 GPL-2.0
 PKG_LICENSE_FILES:=COPYING LICENSE.LGPL LICENSE.GPL
 
-
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
-
-TARGET_LDFLAGS+= \
-	-Wl,-rpath-link=$(STAGING_DIR)/usr/lib
 
 define Package/sox
   SECTION:=sound

--- a/utils/bandwidthd/Makefile
+++ b/utils/bandwidthd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bandwidthd
 PKG_VERSION:=2.0.1-35
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/NethServer/bandwidthd/tar.gz/$(PKG_VERSION)?
@@ -139,7 +139,7 @@ CONFIGURE_ARGS += \
 endif
 
 EXTRA_CFLAGS+= $(TARGET_CPPFLAGS) -fgnu89-inline
-EXTRA_LDFLAGS+= $(TARGET_LDFLAGS) -Wl,-rpath-link,$(STAGING_DIR)/usr/lib
+EXTRA_LDFLAGS+= $(TARGET_LDFLAGS)
 
 define Package/bandwidthd/install
 	$(INSTALL_DIR) $(1)/usr/sbin

--- a/utils/mbtools/Makefile
+++ b/utils/mbtools/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=mbtools
 PKG_SOURCE_DATE:=2014-10-29
 PKG_SOURCE_VERSION:=149e9c69cec180f18cf8781cf5285b97352bf719
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/webstack/mbtools
@@ -31,7 +31,7 @@ define Package/mbtools
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Modbus tools
-  DEPENDS:=+glib2 +libmodbus $(INTL_DEPENDS)
+  DEPENDS:=+glib2 +libmodbus
 endef
 
 define Package/mbtools/description
@@ -39,13 +39,6 @@ define Package/mbtools/description
   received by a slave/server (writing of registers). mbcollect is able to act
   as client or server (in TCP or RTU)
 endef
-
-ifneq ($(INTL_FULL),)
-TARGET_LDFLAGS += \
-	-L$(INTL_PREFIX)/lib \
-	-Wl,-rpath-link=$(STAGING_DIR)/usr/lib
-
-endif
 
 define Package/mbtools/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/utils/owfs/Makefile
+++ b/utils/owfs/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=owfs
 PKG_VERSION:=3.2p4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/owfs/owfs/releases/download/v$(PKG_VERSION)
@@ -201,7 +201,6 @@ CONFIGURE_ARGS += \
 	$(if $(CONFIG_LIBOW_OWTRAFFIC),--enable-owtraffic,--disable-owtraffic)
 
 CONFIGURE_VARS += \
-	LDFLAGS="$(TARGET_LDFLAGS) -Wl,-rpath-link=$(STAGING_DIR)/usr/lib -Wl,-rpath-link=$(TOOLCHAIN_DIR)/usr/lib" \
 	lt_cv_sys_lib_dlsearch_path_spec="$(STAGING_DIR)/lib $(STAGING_DIR)/usr/lib" \
 	lt_cv_sys_lib_search_path_spec="$(STAGING_DIR)/lib $(STAGING_DIR)/usr/lib" \
 	shrext_cmds=".so" \


### PR DESCRIPTION
Most usages seem to be outdated and fixed a long time ago.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: various