### PR TITLE
softethervpn: remove rpath hack

### DIFF
--- a/net/softethervpn/Makefile
+++ b/net/softethervpn/Makefile
@@ -40,7 +40,6 @@ HOST_MAKE_FLAGS += -C $(HOST_BUILD_DIR)
 HOST_MAKE_FLAGS += \
 	-f src/makefiles/$(if $(CONFIG_HOST_OS_MACOS),macos,linux)_$(if $(shell uname -m | grep 64),64,32)bit.mak
 
-HOST_LDFLAGS += -Wl,-rpath$(comma)$(STAGING_DIR_HOSTPKG)/lib
 # Prevent calling upstream configure
 define Host/Configure
 endef


### PR DESCRIPTION
This was needed when readline was a shared library. Now that it's
static, this can be removed.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @fededim 
Compile tested: fedora 35