### PR TITLE
nano: add one even more feature rich variant

### DIFF
--- a/utils/nano/Makefile
+++ b/utils/nano/Makefile
@@ -46,6 +46,12 @@ define Package/nano-plus
   VARIANT:=plus
 endef
 
+define Package/nano-full
+  $(call Package/nano/Default)
+  TITLE:=GNU nano text editor (most features, Unicode)
+  VARIANT:=full
+endef
+
 define Package/nano/description
   Nano is a small and simple text editor for use on the terminal.
 
@@ -63,7 +69,34 @@ define Package/nano-plus/description
   $(call Package/nano/description)
 endef
 
-ifeq ($(BUILD_VARIANT),plus)
+define Package/nano-full/description
+  nano-full - most features enabled, including syntax highlighting,
+  multibuffer, Unicode/UTF-8, help, justify, nanorc, some key bindings)
+
+  $(call Package/nano/description)
+endef
+
+ifeq ($(BUILD_VARIANT),full)
+# full variant with most features included
+  CONFIGURE_ARGS += \
+	--enable-help \
+	--enable-justify \
+	--enable-linenumbers \
+	--enable-multibuffer \
+	--enable-nanorc \
+	--enable-utf8 \
+	--enable-browser \
+	--enable-color \
+	--enable-comment \
+	--disable-extra \
+	--disable-histories \
+	--disable-libmagic \
+	--disable-mouse \
+	--disable-operatingdir \
+	--disable-speller \
+	--disable-tabcomp \
+	--disable-wordcomp
+else ifeq ($(BUILD_VARIANT),plus)
 # plus variant with more features included
   CONFIGURE_ARGS += \
 	--enable-help \
@@ -104,6 +137,13 @@ define Package/nano-plus/install
 	$(call Package/nano/install,$1)
 endef
 
+define Package/nano-full/install
+	$(call Package/nano/install,$1)
+	$(INSTALL_DIR) $(1)/etc $(1)/usr/share/nano
+	$(INSTALL_CONF) ./files/nanorc $(1)/etc/nanorc
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/nano/*.nanorc $(1)/usr/share/nano/
+endef
+
 $(eval $(call BuildPackage,nano))
 $(eval $(call BuildPackage,nano-plus))
-
+$(eval $(call BuildPackage,nano-full))

--- a/utils/nano/files/nanorc
+++ b/utils/nano/files/nanorc
@@ -1,0 +1,2 @@
+## === Syntax coloring ===
+include "/usr/share/nano/*.nanorc"


### PR DESCRIPTION
nano-plus was a very welcome addition, something similar to what I had used for years already; since I do some development natively, I really enjoy c/c++ syntax colouring. And why not some other added features as well, not maybe suitable for devices with minimal flash, but for those cases where _size does not matter_ ... So I integrated my personal version of package to nano package.

So here's nano-full with nearly all the bells and whistles, but still - biggest and most visible change to nano-plus, is syntax colouring.

Some features for quite obvious reasons (from my point of view) were left out, like mouse support. This PR is not critically important; not so sure if it's that useful either, could be just me who wants more of his favourite editor, well anyway, here it is, incase that there is some interest..

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>

Maintainer:  Hannu Nyman / @hnyman 
Compile tested: x86_64, master
Run tested: x86_64, master