### PR TITLE
v2raya: add iptables as dependency

### DIFF
--- a/net/v2raya/Makefile
+++ b/net/v2raya/Makefile
@@ -37,6 +37,8 @@ define Package/v2raya
   SUBMENU:=Web Servers/Proxies
   DEPENDS:=$(GO_ARCH_DEPENDS) \
     +ca-bundle \
+    +iptables \
+    +IPV6:ip6tables \
     +iptables-mod-conntrack-extra \
     +iptables-mod-extra \
     +iptables-mod-filter \


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8, x86/64
Run tested: nanopi-r2s, x86_64 (via VMware)

Description:
This package requires to use iptables (no matter which variant).