### PR TITLE
bind: add subpackaging for ddns-confgen

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -96,7 +96,8 @@ define Package/bind-tools
 	+bind-nslookup \
 	+bind-dnssec \
 	+bind-host \
-	+bind-rndc
+	+bind-rndc \
+	+bind-ddns-confgen
 endef
 
 define Package/bind-rndc
@@ -129,6 +130,11 @@ define Package/bind-nslookup
   TITLE+= nslookup utility
   ALTERNATIVES:= \
 	  200:/usr/bin/nslookup:/usr/libexec/nslookup-bind
+endef
+
+define Package/bind-ddns-confgen
+  $(call Package/bind/Default)
+  TITLE+= administration tools (ddns-confgen and tsig-keygen only)
 endef
 
 export BUILD_CC="$(TARGET_CC)"
@@ -259,6 +265,12 @@ define Package/bind-nslookup/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nslookup $(1)/usr/libexec/nslookup-bind
 endef
 
+define Package/bind-ddns-confgen/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/ddns-confgen $(1)/usr/sbin/ddns-confgen
+	$(LN) -s ddns-confgen $(1)/usr/sbin/tsig-keygen
+endef
+
 $(eval $(call BuildPackage,bind-libs))
 $(eval $(call BuildPackage,bind-server))
 $(eval $(call BuildPackage,bind-server-filter-aaaa))
@@ -270,3 +282,4 @@ $(eval $(call BuildPackage,bind-dnssec))
 $(eval $(call BuildPackage,bind-host))
 $(eval $(call BuildPackage,bind-dig))
 $(eval $(call BuildPackage,bind-nslookup))
+$(eval $(call BuildPackage,bind-ddns-confgen))


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: x86_64, generic, HEAD (236c3ea730)
Run tested: same; built and installed on production router

Description:

Add `ddns-confgen` and `tsig-keygen` utilities as separate sub package.