### PR TITLE
keepalived: enable nftables filtering

### DIFF
--- a/net/keepalived/Config.in
+++ b/net/keepalived/Config.in
@@ -71,6 +71,15 @@ config KEEPALIVED_IPTABLES
 		Builds support for using iptables/ipsets for filtering packets
 		to VIPs
 
+config KEEPALIVED_NFTABLES
+	depends on KEEPALIVED_VRRP
+	bool
+	default y
+	prompt "Enable nftables for VIP filtering"
+	help
+		Builds support for using nftables for filtering packets
+		to VIPs
+
 config KEEPALIVED_SNMP_VRRP
 	depends on KEEPALIVED_VRRP
 	bool

--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -22,6 +22,7 @@ PKG_MAINTAINER:=Ben Kelly <ben@benjii.net> \
 		Florian Eckert <fe@dev.tdt.de>
 
 PKG_CONFIG_DEPENDS += \
+	KEEPALIVED_NFTABLES \
 	KEEPALIVED_VRRP \
 	KEEPALIVED_LVS \
 	KEEPALIVED_IPTABLES \
@@ -62,6 +63,7 @@ define Package/keepalived
     +libnl-genl \
     +libmagic \
     +libkmod \
+    +KEEPALIVED_NFTABLES:libnftnl \
     +KEEPALIVED_VRRP:kmod-macvlan \
     +KEEPALIVED_VRRP:libnl-route \
     +KEEPALIVED_VRRP:libnfnetlink \
@@ -87,7 +89,6 @@ endef
 
 CONFIGURE_ARGS+= \
 	--with-init=SYSV \
-	--disable-nftables \
 	--disable-track-process \
 	--runstatedir="/var/run"
 
@@ -113,6 +114,12 @@ endif
 
 
 ifeq ($(CONFIG_KEEPALIVED_VRRP),y)
+
+ifeq ($(CONFIG_KEEPALIVED_NFTABLES),)
+CONFIGURE_ARGS += \
+	--disable-nftables
+endif
+
 ifeq ($(CONFIG_KEEPALIVED_IPTABLES),)
 CONFIGURE_ARGS += \
 	--disable-iptables


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64 and lantiq_xrx200, APU3, latest
Run tested: x86_64, APU3, latest

Description:
Enable nftables filtering
