### PR TITLE
python3-paramiko: update to version 2.10.1

### DIFF
--- a/lang/python/python-paramiko/Makefile
+++ b/lang/python/python-paramiko/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-paramiko
-PKG_VERSION:=2.9.2
+PKG_VERSION:=2.10.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=paramiko
-PKG_HASH:=944a9e5dbdd413ab6c7951ea46b0ab40713235a9c4c5ca81cfe45c6f14fa677b
+PKG_HASH:=443f4da23ec24e9a9c0ea54017829c282abdda1d57110bf229360775ccd27a31
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream release.

2.10.1:

 - [Bug]: (CVE-2022-24302) Creation of new private key files using
 PKey subclasses was subject to a race condition between file creation
 & mode modification, which could be exploited by an attacker with
 knowledge of where the Paramiko-using code would write out such
 files.

 - This has been patched by using os.open and os.fdopen to ensure new
 files are opened with the correct mode immediately. We’ve left the
 subsequent explicit chmod in place to minimize any possible
 disruption, though it may get removed in future backwards-
 incompatible updates.

 - Thanks to Jan Schejbal for the report & feedback on the solution,
 and to Jeremy Katz at Tidelift for coordinating the disclosure.

2.10.0:

 - [Feature] Add support for OpenSSH’s Windows agent as a fallback
 when Putty/WinPageant isn’t available or functional. Reported by
 @benj56 with patches/PRs from @lewgordon and Patrick Spendrin.

 - [Feature] Add support for the %C token when parsing SSH config
 files. Foundational PR submitted by @jbrand42.

 - [Bug] Significantly speed up low-level read/write actions on
 SFTPFile objects by using bytearray/memoryview. This is unlikely to
 change anything for users of the higher level methods like
 SFTPClient.get or SFTPClient.getfo, but users of SFTPClient.open will
 likely see orders of magnitude improvements for files larger than a
 few megabytes in size.

 - Thanks to @jkji for the original report and to Sevastian Tchernov
 for the patch.

 - [Support] Add six explicitly to install-requires; it snuck into
 active use at some point but has only been indicated by transitive
 dependency on bcrypt until they somewhat-recently dropped it. This
 will be short-lived until we drop Python 2 support. Thanks to
 Sondre Lillebø Gundersen for catch & patch.

Signed-off-by: Javier Marcet <javier@marcet.info>
