### PR TITLE
named: don't leak mktemp files on reload

### DIFF
--- a/net/bind/files/named.init
+++ b/net/bind/files/named.init
@@ -12,7 +12,6 @@ config_dir=$(dirname $config_file)
 named_options_file=/etc/bind/named-rndc.conf
 rndc_conf_file=/etc/bind/rndc.conf
 pid_file=/var/run/named/named.pid
-rndc_temp=$(mktemp /tmp/rndc-confgen.XXXXXX)
 
 logdir=/var/log/named/
 cachedir=/var/cache/bind
@@ -46,6 +45,8 @@ start_service() {
 	mkdir -m 0755 $runnamed
 	chown bind.bind $runnamed
     }
+
+    local rndc_temp=$(mktemp /tmp/rndc-confgen.XXXXXX)
 
     rndc-confgen > $rndc_temp
 


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile tested: x86_64, generic, HEAD (236c3ea730)
Run tested: same, installed on production router

Description:

Unless we're using "mktemp -u ..." (not recommended), it will
create the temp file as part of its safety checking.  Thus you
should always remove the temp file, even if you never write/append
to it.