### PR TITLE
netdata: disable LZ4 compression support

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -57,6 +57,7 @@ CONFIGURE_ARGS += \
 	--without-libcap \
 	--disable-https \
 	--disable-dbengine \
+	--disable-compression \
 	--disable-plugin-nfacct \
 	--disable-plugin-freeipmi \
 	--disable-plugin-cups \


### PR DESCRIPTION
Maintainer: me and @diizzyy
Compile tested: Turris 1.1, powerpc_8540, OpenWrt master
Run tested: N/A

Description:

To avoid unnecessary dependency, let's disable it for now.
LZ4 can be also used for DB engine and HTTPS

Fixes:
Package netdata is missing dependencies for the following libraries:
liblz4.so.1

Reported by @neheb in https://github.com/openwrt/packages/pull/16339#issuecomment-1067518013