### PR TITLE
libudev-zero: backport latest changes to fix blocking on devices scan

### DIFF
--- a/libs/libudev-zero/patches/0001-readme-future-directions.patch
+++ b/libs/libudev-zero/patches/0001-readme-future-directions.patch
@@ -1,0 +1,24 @@
+From 3c2593376a7870c8ae6411ff3fc83c13da98f219 Mon Sep 17 00:00:00 2001
+From: illiliti <illiliti@protonmail.com>
+Date: Thu, 2 Sep 2021 21:39:59 +0300
+Subject: [PATCH 01/15] readme: future directions
+
+---
+ README.md | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/README.md
++++ b/README.md
+@@ -71,6 +71,12 @@ for example how it could be implemented
+ Don't hesitate to ask me everything you don't understand. I'm usually hanging
+ around in #kisslinux at libera.chat, but you can also email me or open an issue here.
+ 
++## Future directions
++
++1. Write a better cross-platform(*nix, maybe macos and windows) device enumeration library.
++2. Convince mainstream apps(libinput, wlroots, ...) to use new library instead of libudev.
++3. Declare libudev as obsolete library and archive this project.
++
+ ## Donate
+ 
+ You can send a donation to `BTC: 1BwrcsgtWZeLVvNeEQSg4A28a3yrGN3FpK`

--- a/libs/libudev-zero/patches/0002-udev_enumerate.c-fix-endless-loop-in-filter_property.patch
+++ b/libs/libudev-zero/patches/0002-udev_enumerate.c-fix-endless-loop-in-filter_property.patch
@@ -1,0 +1,30 @@
+From c7669d8eecd831e278bee8f5ee591d5b6577a445 Mon Sep 17 00:00:00 2001
+From: illiliti <illiliti@protonmail.com>
+Date: Sun, 5 Sep 2021 17:22:32 +0300
+Subject: [PATCH 02/15] udev_enumerate.c: fix endless loop in filter_property
+
+---
+ udev_enumerate.c | 12 +++++-------
+ 1 file changed, 5 insertions(+), 7 deletions(-)
+
+--- a/udev_enumerate.c
++++ b/udev_enumerate.c
+@@ -175,13 +175,11 @@ static int filter_property(struct udev_e
+             property2 = udev_list_entry_get_name(list_entry2);
+             value2 = udev_list_entry_get_value(list_entry2);
+ 
+-            if (!value || !value2) {
+-                continue;
+-            }
+-
+-            if (fnmatch(property, property2, 0) == 0 &&
+-                fnmatch(value, value2, 0) == 0) {
+-                return 1;
++            if (value && value2) {
++                if (fnmatch(property, property2, 0) == 0 &&
++                    fnmatch(value, value2, 0) == 0) {
++                    return 1;
++                }
+             }
+ 
+             list_entry2 = udev_list_entry_get_next(list_entry2);

--- a/libs/libudev-zero/patches/0003-readme-What-works-What-doesn-t-work.patch
+++ b/libs/libudev-zero/patches/0003-readme-What-works-What-doesn-t-work.patch
@@ -1,0 +1,40 @@
+From 99676e0e0463dc5674c6aff1d158ae3c796815d9 Mon Sep 17 00:00:00 2001
+From: illiliti <illiliti@protonmail.com>
+Date: Tue, 7 Sep 2021 01:49:28 +0300
+Subject: [PATCH 03/15] readme: What works -> What doesn't work
+
+---
+ README.md | 23 ++++++++++++-----------
+ 1 file changed, 12 insertions(+), 11 deletions(-)
+
+--- a/README.md
++++ b/README.md
+@@ -24,17 +24,18 @@ of `libudev` which can be used with any
+ [0] https://github.com/FreeBSDDesktop/libudev-devd  
+ [1] https://github.com/oasislinux/libinput
+ 
+-## What Works
++## What doesn't work
+ 
+-* [x] xorg-server
+-* [ ] dosfstools - need to implement udev_enumerate_add_match_parent()
+-* [x] libinput
+-* [x] usbutils
+-* [x] wlroots
+-* [x] weston
+-* [x] libusb
+-* [x] kwin
+-* [ ] ???
++* dosfstools - requires udev_enumerate_add_match_parent()
++* PulseAudio - highly depends on udev internal properties
++* udisks2 - highly depends on udev internal properties
++* android-tools - requires udev rules for non-root usage
++* NetworkManager - needs investigation
++* libgudev - needs investigation
++* PipeWare - depends on udev internal properties
++* ldm - depends on udev internal properties
++* lvm2 - uses deprecated `udev_queue` API
++* ???
+ 
+ ## Dependencies
+ 

--- a/libs/libudev-zero/patches/0004-readme-rewrite-why-add-pros-cons.patch
+++ b/libs/libudev-zero/patches/0004-readme-rewrite-why-add-pros-cons.patch
@@ -1,0 +1,68 @@
+From af4dc2ff14b020840bf5d4ac3501d639314fb55d Mon Sep 17 00:00:00 2001
+From: illiliti <illiliti@protonmail.com>
+Date: Wed, 8 Sep 2021 21:26:18 +0300
+Subject: [PATCH 04/15] readme: rewrite why, add pros/cons
+
+---
+ README.md | 50 +++++++++++++++++++++++++++++++-------------------
+ 1 file changed, 31 insertions(+), 19 deletions(-)
+
+--- a/README.md
++++ b/README.md
+@@ -4,25 +4,37 @@ Drop-in replacement for `libudev` intend
+ 
+ ## Why?
+ 
+-Because `udev` sucks, it is bloated and overengineered. `udev` is just
+-like `systemd`, it locks you into using non-portable crap that you can't
+-avoid because multiple programs depend on it. Look, even FreeBSD was forced
+-to rewrite[0] this crappy library because `libinput` hard-depends on `udev`.
+-Without `libinput` you can't use `wayland` and many other cool stuff.
+-
+-Michael Forney (author of `cproc`, `samurai`, Oasis Linux, ...) decided to
+-fork[1] `libinput` and remove the hard dependency on `udev`. However, this
+-fork has a drawback that requires patching applications to use `libinput_netlink`
+-instead of the `libinput_udev` API in order to use the automatic detection of
+-input devices and hotplugging. Static configuration is also required for anything
+-other than input devices (e.g drm devices).
+-
+-Thankfully `udev` has stable API and hopefully no changes will be made to it
+-the future. On this basis I decided to create this clean-room implementation
+-of `libudev` which can be used with any or without a device manager.
+-
+-[0] https://github.com/FreeBSDDesktop/libudev-devd  
+-[1] https://github.com/oasislinux/libinput
++We all know that systemd is very hostile towards portability. Udev inherited
++the same problem by exposing a very badly designed library interface. This is
++dramatically reduces portability, user choice and basically creates vendor
++lock-in because library interface highly tied to udev daemon.
++
++Another udev problem is non-portable home-grown language called "udev rules".
++Udev authors definitely don't know(or care) why it's better to avoid reinventing
++the wheel. Strictly speaking, I think they did that on purpose to overcomplicate
++udev as much as possible. Why? So that only authors(RedHat/IBM) can rule and dictate
++the future of udev. The recent eudev death only proves that it's really hard to
++support such unmaintainable mess.
++
++Udev hwdb is yet another illustration of systemd-like approach. What the hell
++"userspace /dev" has to do with parsing hardware database(pci.ids, usb.ids)
++and setting/remapping buttons? Udev smells like systemd by trying to implement
++all possible functionality in the single daemon/code base. Standalone UNIX-way
++programs much better suited for such purposes.
++
++Keep in mind that libudev-zero isn't ideal. Here is some pros/cons:
++
++### Pros
++
++* Very portable. Doesn't depend on GNU features.
++* No lock-in. Any device manager can be used, even smdev and CONFIG_UEVENT_HELPER.
++* Source code is much cleaner than udev because of less abstractions and clever code.
++
++### Cons
++
++* Udev rules must be converted to shell script in order to work with any device manager.
++* Udev hwdb interface isn't implemented. pciutils and usbutils will not display any meaningful info.
++* Many functions and interfaces still aren't implemented, which may lead to breakage in some programs.
+ 
+ ## What doesn't work
+ 

--- a/libs/libudev-zero/patches/0005-Makefile-add-stub-symbol-versioning.patch
+++ b/libs/libudev-zero/patches/0005-Makefile-add-stub-symbol-versioning.patch
@@ -1,0 +1,28 @@
+From 000ff7bf2fa463ea99afaea8503c2ed9f8a1852c Mon Sep 17 00:00:00 2001
+From: illiliti <illiliti@protonmail.com>
+Date: Wed, 8 Sep 2021 21:44:45 +0300
+Subject: [PATCH 05/15] Makefile: add stub symbol versioning
+
+Fixes: #38
+---
+ Makefile    | 3 ++-
+ libudev.sym | 1 +
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+ create mode 100644 libudev.sym
+
+--- a/Makefile
++++ b/Makefile
+@@ -8,7 +8,8 @@ PKGCONFIGDIR = ${LIBDIR}/pkgconfig
+ XCFLAGS = ${CPPFLAGS} ${CFLAGS} -std=c99 -fPIC -pthread -D_XOPEN_SOURCE=700 \
+ 		  -Wall -Wextra -Wpedantic -Wmissing-prototypes -Wstrict-prototypes \
+ 		  -Wno-unused-parameter
+-XLDFLAGS = ${LDFLAGS} -shared -Wl,-soname,libudev.so.1
++XLDFLAGS = ${LDFLAGS} -shared -Wl,-soname,libudev.so.1 \
++		   -Wl,-version-script,libudev.sym
+ XARFLAGS = -rc
+ 
+ OBJ = \
+--- /dev/null
++++ b/libudev.sym
+@@ -0,0 +1 @@
++LIBUDEV_183 {};

--- a/libs/libudev-zero/patches/0006-readme-pros-cons.patch
+++ b/libs/libudev-zero/patches/0006-readme-pros-cons.patch
@@ -1,0 +1,20 @@
+From 858f0b107f90b08d4031d2e3ca25a5f2145b61c4 Mon Sep 17 00:00:00 2001
+From: illiliti <illiliti@protonmail.com>
+Date: Thu, 9 Sep 2021 03:01:12 +0300
+Subject: [PATCH 06/15] readme: pros/cons
+
+---
+ README.md | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/README.md
++++ b/README.md
+@@ -22,6 +22,8 @@ and setting/remapping buttons? Udev smel
+ all possible functionality in the single daemon/code base. Standalone UNIX-way
+ programs much better suited for such purposes.
+ 
++## Pros/Cons
++
+ Keep in mind that libudev-zero isn't ideal. Here is some pros/cons:
+ 
+ ### Pros

--- a/libs/libudev-zero/patches/0007-readme-add-cups-and-workaround-for-pulseaudio.patch
+++ b/libs/libudev-zero/patches/0007-readme-add-cups-and-workaround-for-pulseaudio.patch
@@ -1,0 +1,28 @@
+From 6250984089514d7751985476a31d268c16b3d8f2 Mon Sep 17 00:00:00 2001
+From: illiliti <illiliti@protonmail.com>
+Date: Thu, 9 Sep 2021 23:53:51 +0300
+Subject: [PATCH 07/15] readme: add cups and workaround for pulseaudio
+
+---
+ README.md | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/README.md
++++ b/README.md
+@@ -41,7 +41,7 @@ Keep in mind that libudev-zero isn't ide
+ ## What doesn't work
+ 
+ * dosfstools - requires udev_enumerate_add_match_parent()
+-* PulseAudio - highly depends on udev internal properties
++* PulseAudio - highly depends on udev internal properties. [workaround](https://gist.github.com/capezotte/03ee5548218e819b06459819bb120b4b#pulseaudio)
+ * udisks2 - highly depends on udev internal properties
+ * android-tools - requires udev rules for non-root usage
+ * NetworkManager - needs investigation
+@@ -49,6 +49,7 @@ Keep in mind that libudev-zero isn't ide
+ * PipeWare - depends on udev internal properties
+ * ldm - depends on udev internal properties
+ * lvm2 - uses deprecated `udev_queue` API
++* cups - needs investigation
+ * ???
+ 
+ ## Dependencies

--- a/libs/libudev-zero/patches/0008-udev_device.c-ignore-devices-without-subsystem.patch
+++ b/libs/libudev-zero/patches/0008-udev_device.c-ignore-devices-without-subsystem.patch
@@ -1,0 +1,44 @@
+From caaa021290a1b84c44d084865c2512f4adf98297 Mon Sep 17 00:00:00 2001
+From: illiliti <illiliti@protonmail.com>
+Date: Fri, 8 Oct 2021 08:36:20 +0300
+Subject: [PATCH 08/15] udev_device.c: ignore devices without subsystem
+
+Do not allocate udev_device if device doesn't have subsystem.
+
+Fixes: #43
+---
+ udev_device.c | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+--- a/udev_device.c
++++ b/udev_device.c
+@@ -530,18 +530,18 @@ static void set_properties_from_props(st
+ 
+ struct udev_device *udev_device_new_from_syspath(struct udev *udev, const char *syspath)
+ {
+-    char path[PATH_MAX], file[PATH_MAX];
+     char *subsystem, *driver, *sysname;
+     struct udev_device *udev_device;
++    char path[PATH_MAX];
+     int i;
+ 
+     if (!udev || !syspath) {
+         return NULL;
+     }
+ 
+-    snprintf(file, sizeof(file), "%s/uevent", syspath);
++    subsystem = read_symlink(syspath, "subsystem");
+ 
+-    if (access(file, R_OK) == -1) {
++    if (!subsystem) {
+         return NULL;
+     }
+ 
+@@ -567,7 +567,6 @@ struct udev_device *udev_device_new_from
+ 
+     sysname = strrchr(path, '/') + 1;
+     driver = read_symlink(path, "driver");
+-    subsystem = read_symlink(path, "subsystem");
+ 
+     udev_list_entry_add(&udev_device->properties, "SUBSYSTEM", subsystem, 0);
+     udev_list_entry_add(&udev_device->properties, "SYSNAME", sysname, 0);

--- a/libs/libudev-zero/patches/0009-various-fix-memory-leaks.patch
+++ b/libs/libudev-zero/patches/0009-various-fix-memory-leaks.patch
@@ -1,0 +1,47 @@
+From 7265d305c27dee05436a25dc60481ad62e022756 Mon Sep 17 00:00:00 2001
+From: illiliti <illiliti@protonmail.com>
+Date: Fri, 8 Oct 2021 08:53:04 +0300
+Subject: [PATCH 09/15] various: fix memory leaks
+
+Closes: #41
+---
+ udev_device.c | 2 ++
+ udev_list.c   | 3 +++
+ 2 files changed, 5 insertions(+)
+
+--- a/udev_device.c
++++ b/udev_device.c
+@@ -546,12 +546,14 @@ struct udev_device *udev_device_new_from
+     }
+ 
+     if (!realpath(syspath, path)) {
++        free(subsystem);
+         return NULL;
+     }
+ 
+     udev_device = calloc(1, sizeof(*udev_device));
+ 
+     if (!udev_device) {
++        free(subsystem);
+         return NULL;
+     }
+ 
+--- a/udev_list.c
++++ b/udev_list.c
+@@ -78,6 +78,7 @@ struct udev_list_entry *udev_list_entry_
+     list_entry2->name = strdup(name);
+ 
+     if (!list_entry2->name) {
++        free(list_entry2);
+         return NULL;
+     }
+ 
+@@ -85,6 +86,8 @@ struct udev_list_entry *udev_list_entry_
+         list_entry2->value = strdup(value);
+ 
+         if (!list_entry2->value) {
++            free(list_entry2->name);
++            free(list_entry2);
+             return NULL;
+         }
+     }

--- a/libs/libudev-zero/patches/0010-Fix-typo.patch
+++ b/libs/libudev-zero/patches/0010-Fix-typo.patch
@@ -1,0 +1,20 @@
+From 6651ccc9d60637919f1c05a801f3edc3ba623cd7 Mon Sep 17 00:00:00 2001
+From: Firas Khalil Khana <firasuke@gmail.com>
+Date: Sun, 24 Oct 2021 19:59:06 +0300
+Subject: [PATCH 10/15] Fix typo
+
+---
+ README.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/README.md
++++ b/README.md
+@@ -46,7 +46,7 @@ Keep in mind that libudev-zero isn't ide
+ * android-tools - requires udev rules for non-root usage
+ * NetworkManager - needs investigation
+ * libgudev - needs investigation
+-* PipeWare - depends on udev internal properties
++* PipeWire - depends on udev internal properties
+ * ldm - depends on udev internal properties
+ * lvm2 - uses deprecated `udev_queue` API
+ * cups - needs investigation

--- a/libs/libudev-zero/patches/0011-Revert-Makefile-add-stub-symbol-versioning.patch
+++ b/libs/libudev-zero/patches/0011-Revert-Makefile-add-stub-symbol-versioning.patch
@@ -1,0 +1,28 @@
+From b8a0b953e6305dffeea57886fa379c5aca1b8397 Mon Sep 17 00:00:00 2001
+From: illiliti <illiliti@protonmail.com>
+Date: Tue, 16 Nov 2021 16:17:40 +0300
+Subject: [PATCH 11/15] Revert "Makefile: add stub symbol versioning"
+
+This reverts commit 000ff7bf2fa463ea99afaea8503c2ed9f8a1852c.
+---
+ Makefile    | 3 +--
+ libudev.sym | 1 -
+ 2 files changed, 1 insertion(+), 3 deletions(-)
+ delete mode 100644 libudev.sym
+
+--- a/Makefile
++++ b/Makefile
+@@ -8,8 +8,7 @@ PKGCONFIGDIR = ${LIBDIR}/pkgconfig
+ XCFLAGS = ${CPPFLAGS} ${CFLAGS} -std=c99 -fPIC -pthread -D_XOPEN_SOURCE=700 \
+ 		  -Wall -Wextra -Wpedantic -Wmissing-prototypes -Wstrict-prototypes \
+ 		  -Wno-unused-parameter
+-XLDFLAGS = ${LDFLAGS} -shared -Wl,-soname,libudev.so.1 \
+-		   -Wl,-version-script,libudev.sym
++XLDFLAGS = ${LDFLAGS} -shared -Wl,-soname,libudev.so.1
+ XARFLAGS = -rc
+ 
+ OBJ = \
+--- a/libudev.sym
++++ /dev/null
+@@ -1 +0,0 @@
+-LIBUDEV_183 {};

--- a/libs/libudev-zero/patches/0012-Revert-udev_enumerate.c-fix-pipeware.patch
+++ b/libs/libudev-zero/patches/0012-Revert-udev_enumerate.c-fix-pipeware.patch
@@ -1,0 +1,36 @@
+From ec47f63d6b2aeebec25efd64a0788329fdec7d0d Mon Sep 17 00:00:00 2001
+From: illiliti <illiliti@protonmail.com>
+Date: Tue, 16 Nov 2021 16:17:47 +0300
+Subject: [PATCH 12/15] Revert "udev_enumerate.c: fix pipeware"
+
+This reverts commit 4510b27a9b589a0ce82fef776c2648e19e79f2a4.
+---
+ udev_enumerate.c | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+--- a/udev_enumerate.c
++++ b/udev_enumerate.c
+@@ -240,7 +240,7 @@ static int filter_sysattr(struct udev_en
+ static void *add_device(void *ptr)
+ {
+     struct udev_enumerate_thread *thread = ptr;
+-    struct udev_device *udev_device, *parent;
++    struct udev_device *udev_device;
+ 
+     udev_device = udev_device_new_from_syspath(thread->udev_enumerate->udev, thread->path);
+ 
+@@ -256,14 +256,7 @@ static void *add_device(void *ptr)
+         return NULL;
+     }
+ 
+-    parent = udev_device_get_parent(udev_device);
+-
+     pthread_mutex_lock(thread->mutex);
+-
+-    if (parent) {
+-        udev_list_entry_add(&thread->udev_enumerate->devices, udev_device_get_syspath(parent), NULL, 0);
+-    }
+-
+     udev_list_entry_add(&thread->udev_enumerate->devices, udev_device_get_syspath(udev_device), NULL, 0);
+     pthread_mutex_unlock(thread->mutex);
+ 

--- a/libs/libudev-zero/patches/0013-readme-mention-PipeWire-patch.patch
+++ b/libs/libudev-zero/patches/0013-readme-mention-PipeWire-patch.patch
@@ -1,0 +1,20 @@
+From 938b959402552483f010401051eb800c04607a41 Mon Sep 17 00:00:00 2001
+From: illiliti <illiliti@protonmail.com>
+Date: Wed, 17 Nov 2021 00:20:57 +0300
+Subject: [PATCH 13/15] readme: mention PipeWire patch
+
+---
+ README.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/README.md
++++ b/README.md
+@@ -46,7 +46,7 @@ Keep in mind that libudev-zero isn't ide
+ * android-tools - requires udev rules for non-root usage
+ * NetworkManager - needs investigation
+ * libgudev - needs investigation
+-* PipeWire - depends on udev internal properties
++* PipeWire - depends on udev internal properties. [patch](https://github.com/illiliti/libudev-zero/issues/26#issuecomment-846858706)
+ * ldm - depends on udev internal properties
+ * lvm2 - uses deprecated `udev_queue` API
+ * cups - needs investigation

--- a/libs/libudev-zero/patches/0014-Makefile-support-static-only-builds.patch
+++ b/libs/libudev-zero/patches/0014-Makefile-support-static-only-builds.patch
@@ -1,0 +1,57 @@
+From 505c61819b371a1802e054fe2601e64f2dc6d79e Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Mon, 29 Nov 2021 22:38:45 +0000
+Subject: [PATCH 14/15] Makefile: support static-only builds
+
+One of the problems with udev is that systemd cannot be built
+statically[1].  With libudev-zero, on the other hand, no code changes
+are required to be able to do a static-only build, only Makefile
+changes.
+
+With this change, it's possible to "make install-static" to do a
+static-only build of libudev-zero.
+
+[1]: https://github.com/systemd/systemd/pull/20621#issuecomment-912014839
+---
+ Makefile | 24 ++++++++++++++++++------
+ 1 file changed, 18 insertions(+), 6 deletions(-)
+
+--- a/Makefile
++++ b/Makefile
+@@ -45,13 +45,24 @@ libudev.pc: libudev.pc.in
+ 		-e 's|@VERSION@|243|g' \
+ 		libudev.pc.in > libudev.pc
+ 
+-install: libudev.so.1 libudev.a libudev.pc
+-	mkdir -p         ${DESTDIR}${INCLUDEDIR} ${DESTDIR}${LIBDIR} ${DESTDIR}${PKGCONFIGDIR}
+-	cp -f udev.h  	 ${DESTDIR}${INCLUDEDIR}/libudev.h
+-	cp -f libudev.a  ${DESTDIR}${LIBDIR}/libudev.a
++install-headers: udev.h
++	mkdir -p ${DESTDIR}${INCLUDEDIR}
++	cp -f udev.h ${DESTDIR}${INCLUDEDIR}/libudev.h
++
++install-pkgconfig: libudev.pc
++	mkdir -p ${DESTDIR}${PKGCONFIGDIR}
++	cp -f libudev.pc ${DESTDIR}${PKGCONFIGDIR}/libudev.pc
++
++install-shared: libudev.so.1 install-headers install-pkgconfig
++	mkdir -p ${DESTDIR}${LIBDIR}
+ 	cp -f libudev.so.1 ${DESTDIR}${LIBDIR}/libudev.so.1
+ 	ln -fs libudev.so.1 ${DESTDIR}${LIBDIR}/libudev.so
+-	cp -f libudev.pc ${DESTDIR}${PKGCONFIGDIR}/libudev.pc
++
++install-static: libudev.a install-headers install-pkgconfig
++	mkdir -p ${DESTDIR}${LIBDIR}
++	cp -f libudev.a ${DESTDIR}${LIBDIR}/libudev.a
++
++install: install-shared install-static
+ 
+ uninstall:
+ 	rm -f ${DESTDIR}${LIBDIR}/libudev.a \
+@@ -63,4 +74,5 @@ uninstall:
+ clean:
+ 	rm -f libudev.so.1 libudev.a libudev.pc ${OBJ}
+ 
+-.PHONY: all clean install uninstall
++.PHONY: all clean install-headers install-pkgconfig install-shared \
++	install-static install uninstall

--- a/libs/libudev-zero/patches/0015-udev_enumerate.c-support-NULL-value-in-match-nomatch.patch
+++ b/libs/libudev-zero/patches/0015-udev_enumerate.c-support-NULL-value-in-match-nomatch.patch
@@ -1,0 +1,52 @@
+From 4154cf252c17297f98a8ca33693ead003b4509da Mon Sep 17 00:00:00 2001
+From: illiliti <illiliti@protonmail.com>
+Date: Thu, 16 Dec 2021 07:09:16 +0300
+Subject: [PATCH 15/15] udev_enumerate.c: support NULL value in match/nomatch
+
+Fixes: #45
+---
+ udev_enumerate.c | 16 +++++-----------
+ 1 file changed, 5 insertions(+), 11 deletions(-)
+
+--- a/udev_enumerate.c
++++ b/udev_enumerate.c
+@@ -193,20 +193,17 @@ static int filter_property(struct udev_e
+ 
+ static int filter_sysattr(struct udev_enumerate *udev_enumerate, struct udev_device *udev_device)
+ {
++    const char *sysattr, *value, *value2;
+     struct udev_list_entry *list_entry;
+-    const char *sysattr, *value;
+ 
+     list_entry = udev_list_entry_get_next(&udev_enumerate->sysattr_nomatch);
+ 
+     while (list_entry) {
+         sysattr = udev_list_entry_get_name(list_entry);
++        value2 = udev_list_entry_get_value(list_entry);
+         value = udev_device_get_sysattr_value(udev_device, sysattr);
+ 
+-        if (!value) {
+-            return 1;
+-        }
+-
+-        if (fnmatch(udev_list_entry_get_value(list_entry), value, 0) == 0) {
++        if (value && value2 && fnmatch(value2, value, 0) == 0) {
+             return 0;
+         }
+ 
+@@ -218,13 +215,10 @@ static int filter_sysattr(struct udev_en
+     if (list_entry) {
+         while (list_entry) {
+             sysattr = udev_list_entry_get_name(list_entry);
++            value2 = udev_list_entry_get_value(list_entry);
+             value = udev_device_get_sysattr_value(udev_device, sysattr);
+ 
+-            if (!value) {
+-                return 0;
+-            }
+-
+-            if (fnmatch(udev_list_entry_get_value(list_entry), value, 0) == 0) {
++            if (value && value2 && fnmatch(value2, value, 0) == 0) {
+                 return 1;
+             }
+ 


### PR DESCRIPTION
Maintainer: @dangowrt @neheb 
Compile tested: x86_64, APU3, latest
Run tested: x86_64, APU3, APU3, latest, yes

Description:
This change added the latest upstream changes since version 1.0.0.
When using the smart plugin from collectd, there are problems with the
function `udev_enumerate_scan_devices`. This function is blocked and no
longer returns. Backporting the latest fixes from libudev-zero solves
the problem with the collectd smart plugin.


