### PR TITLE
vim: remove vim/host

### DIFF
--- a/utils/device-observatory/Makefile
+++ b/utils/device-observatory/Makefile
@@ -9,7 +9,6 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=83b3f362f154a427abbd3af31b3c2dda9983cdc15f6b833d804727ef0fbdc72e
 
 PKG_LICENSE:=GPL-3.0-or-later
-PKG_BUILD_DEPENDS:=vim/host
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -21,10 +21,6 @@ PKG_CPE_ID:=cpe:/a:vim:vim
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)$(VIMVER)
 PKG_BUILD_PARALLEL:=1
 
-HOST_BUILD_DEPENDS:=libiconv/host
-HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)$(VIMVER)
-HOST_BUILD_PARALLEL:=1
-
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 
@@ -110,15 +106,6 @@ define Package/xxd/description
  xxd creates a hex dump of a given file or standard input, it can also convert
  a hex dump back to its original binary form.
 endef
-
-HOST_CONFIGURE_ARGS += \
-	--disable-acl \
-	--disable-gpm \
-	--disable-nls \
-	--disable-selinux \
-	--enable-gui=no \
-	--with-features=normal \
-	--without-x
 
 CONFIGURE_ARGS += \
 	--disable-gui \
@@ -257,4 +244,3 @@ $(eval $(call BuildPackage,vim-fuller))
 $(eval $(call BuildPackage,vim-runtime))
 $(eval $(call BuildPackage,vim-help))
 $(eval $(call BuildPackage,xxd))
-$(eval $(call HostBuild))


### PR DESCRIPTION
The only use of it is for xxd. tools/xxd was added in base so this can
go.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ratkaj 