### PR TITLE
glib2: remove rpath hack

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -27,6 +27,8 @@ HOST_BUILD_DEPENDS:=libiconv/host libffi/host pcre/host
 PKG_CONFIG_DEPENDS:=CONFIG_BUILD_NLS
 PKG_INSTALL:=1
 
+HOST_PATCH_DIR:=./patches-host
+
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -44,7 +46,6 @@ define Package/glib2/description
   The GLib library of C routines
 endef
 
-HOST_LDFLAGS += -Wl,-rpath,$(STAGING_DIR_HOSTPKG)/lib
 TARGET_CFLAGS += -ffunction-sections -fdata-sections
 TARGET_LDFLAGS += -Wl,--gc-sections $(if $(INTL_FULL),-lintl)
 

--- a/libs/glib2/patches-host/001-musl-libintl.patch
+++ b/libs/glib2/patches-host/001-musl-libintl.patch
@@ -1,0 +1,20 @@
+--- a/meson.build
++++ b/meson.build
+@@ -2047,9 +2047,6 @@ endif
+ # FIXME: glib-gettext.m4 has much more checks to detect broken/uncompatible
+ # implementations. This could be extended if issues are found in some platforms.
+ libintl_deps = []
+-if cc.has_function('ngettext', args : osx_ldflags)
+-  have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset')
+-else
+   # First just find the bare library.
+   libintl = cc.find_library('intl', required : false)
+   # The bare library probably won't link without help if it's static.
+@@ -2081,7 +2078,6 @@ else
+     have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset', args : osx_ldflags,
+                                                    dependencies : libintl_deps)
+   endif
+-endif
+ 
+ glib_conf.set('HAVE_BIND_TEXTDOMAIN_CODESET', have_bind_textdomain_codeset)
+ 


### PR DESCRIPTION
All libraries are linked statically.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 