### PR TITLE
chrony: enable LTO

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
 PKG_VERSION:=4.2
-PKG_RELEASE:=2
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.tuxfamily.org/chrony/

--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -79,6 +79,9 @@ CONFIGURE_ARGS+= \
 
 CONFIGURE_VARS+=CPPFLAGS=-DNDEBUG
 
+TARGET_CFLAGS += -flto
+TARGET_LDFLAGS += -flto
+
 define Package/chrony/install
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/usr/sbin/


### PR DESCRIPTION
Maintainer: @mlichvar
Compile tested: OpenWrt master r19124-832b90216f on qoriq
Run tested: OpenWrt master r19124-832b90216f on qoriq

Description:
Build chrony with LTO