### PR TITLE
ap51-flash: update to version 2022.0

### DIFF
--- a/utils/ap51-flash/Makefile
+++ b/utils/ap51-flash/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ap51-flash
 PKG_VERSION:=2019.0.1
-PKG_RELEASE:=2
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/ap51-flash/ap51-flash/releases/download/v$(PKG_VERSION)

--- a/utils/ap51-flash/Makefile
+++ b/utils/ap51-flash/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ap51-flash
-PKG_VERSION:=2019.0.1
+PKG_VERSION:=2022.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/ap51-flash/ap51-flash/releases/download/v$(PKG_VERSION)
-PKG_HASH:=7146a22576a23bfe36673980bc3795a97417692eaddb2f90b527074a7d7e42d5
+PKG_HASH:=54999e07906296f213b298a2a80ba5df59273da30ecba1b82f94d0edf1d5d7f8
 
 PKG_MAINTAINER:=Russell Senior <russell@personaltelco.net>
 PKG_LICENSE:=GPL-3.0-or-later CC0-1.0


### PR DESCRIPTION
Maintainer: @RussellSenior
Compile tested: ath79, x86
Run tested: x86, master

Description:

* Improve listing of ethernet devices under Linux
* Add support for modern Npcap DLLs
* Fix embedding of images with modern GCC versions
* coding style cleanups and refactoring
* added support for:
  - Datto AP440
  - Datto AP840
  - Datto AP840E
  - Datto TW420
  - Plasma Cloud PAX1800
