### PR TITLE
ibqmi/libmbim: fix configure warning on unrecognized options

### DIFF
--- a/libs/libmbim/Makefile
+++ b/libs/libmbim/Makefile
@@ -28,8 +28,7 @@ CONFIGURE_ARGS += \
 	--disable-gtk-doc \
 	--disable-gtk-doc-html \
 	--disable-gtk-doc-pdf \
-	--disable-silent-rules \
-	--enable-more-warnings=yes
+	--disable-silent-rules
 
 define Package/libmbim
   SECTION:=libs
@@ -57,7 +56,6 @@ define Package/mbim-utils
 endef
 
 CONFIGURE_ARGS += \
-	--without-udev \
 	--without-udev-base-dir
 
 define Build/InstallDev

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -66,7 +66,6 @@ CONFIGURE_ARGS += \
 	--disable-gtk-doc-pdf \
 	--disable-silent-rules \
 	--enable-firmware-update \
-	--enable-more-warnings=yes \
 	--without-udev \
 	--without-udev-base-dir
 


### PR DESCRIPTION
Maintainer: @nickberry17 
Compile tested: x86_64, APU3
Run tested: x86_64, APU3

Description:
This options are not known by this libs.
```
 Buildlog:
 configure: WARNING: unrecognized options: --disable-nls, --enable-more-warnings, --without-udev
```