### PR TITLE
rtl_433: Bump to release 21.12

### DIFF
--- a/utils/rtl_433/Makefile
+++ b/utils/rtl_433/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtl_433
-PKG_VERSION:=20.11
-PKG_RELEASE:=2
+PKG_VERSION:=21.12
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/merbanan/rtl_433/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=12a5cb7a733ba352467522c704d5b685aa6137582dc18aaa444d4891c29ee839
+PKG_HASH:=b362ef3410adec64aee7ad8e6d4d74875f1b3d59ef6fb4856e96adc03876dc65
 
 PKG_MAINTAINER:=Jasper Scholte <NightNL@outlook.com>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -21,19 +21,44 @@ PKG_LICENSE_FILES:=COPYING
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-define Package/rtl_433
-  TITLE:=Realtek RTL2832 based 433.92MHz generic data receiver
+define Package/rtl_433/default
+  TITLE:=Generic radio frequency data receiver
   SECTION:=utils
   CATEGORY:=Utilities
   DEPENDS:=+librtlsdr +rtl-sdr +libtool-bin
   URL:=https://github.com/merbanan/rtl_433
 endef
 
-define Package/rtl-sdr/description
-  rtl_433 turns your Realtek RTL2832 based DVB dongle into a 433.92MHz generic data receiver.
+define Package/rtl_433
+  $(call Package/rtl_433/default)
+  VARIANT:=nossl
+endef
+
+define Package/rtl_433-ssl
+  $(call Package/rtl_433/default)
+  TITLE+= (with SSL support)
+  DEPENDS+= +libopenssl
+  VARIANT:=ssl
+endef
+
+define Package/rtl_433/description
+  rtl_433 (despite the name) is a generic data receiver, mainly for the 433.92 MHz, 868 MHz (SRD), 315 MHz, 345 MHz, and 915 MHz ISM bands.
+
+  To use it with OpenWrt you need a Realtek RTL2832 based DVB USB dongle (SoapySDR is not supported).
+endef
+
+define Package/rtl_433-ssl/description
+  $(call Package/rtl_433/description)
+
+  This package includes OpenSSL support which allows you to send data to influxDB/MQTT using TLS.
 endef
 
 CMAKE_OPTIONS += -DENABLE_SOAPYSDR=NO
+ifeq ($(BUILD_VARIANT),ssl)
+  CMAKE_OPTIONS += -DENABLE_OPENSSL=ON
+else
+  CMAKE_OPTIONS += -DENABLE_OPENSSL=OFF
+endif
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
@@ -48,4 +73,9 @@ define Package/rtl_433/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/rtl_433 $(1)/usr/bin
 endef
 
+define Package/rtl_433-ssl/install
+	$(call Package/rtl_433/install,$(1))
+endef
+
 $(eval $(call BuildPackage,rtl_433))
+$(eval $(call BuildPackage,rtl_433-ssl))


### PR DESCRIPTION
rtl_433 can now use OpenSSL to send data to MQTT/influxDB using TLS.
A separate OpenWrt package has been created where OpenSSL support is
enabled.

Signed-off-by: Robert Högberg <robert.hogberg@gmail.com>

Maintainer: @TimelessNL
Compile tested: (ramips/rt3883, D-Link DIR-645, master)
Run tested: (ramips/rt3883, D-Link DIR-645, 21.02.2, tested: I can receive and decode radio signals)