### PR TITLE
openvpn: update to 2.5.6

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.5.5
+PKG_VERSION:=2.5.6
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=119bd69fa0210838f6cdaa273696dc738efa200f454dbe11eb6dfb75dfb6003b
+PKG_HASH:=13c7c3dc399d1b571cabf189c4d34ae34656ee72b6bde2a8059c1e9bc61574ed
 
 PKG_MAINTAINER:=Magnus Kroken <mkroken@gmail.com>
 

--- a/net/openvpn/patches/002-add-wolfssl-support.patch
+++ b/net/openvpn/patches/002-add-wolfssl-support.patch
@@ -70,7 +70,7 @@ Signed-off-by: Gert Doering <gert@greenie.muc.de>
  AC_ARG_VAR([PLUGINDIR], [Path of plug-in directory @<:@default=LIBDIR/openvpn/plugins@:>@])
  if test -n "${PLUGINDIR}"; then
  	plugindir="${PLUGINDIR}"
-@@ -1026,6 +1033,105 @@ elif test "${with_crypto_library}" = "mb
+@@ -1020,6 +1027,105 @@ elif test "${with_crypto_library}" = "mb
  	AC_DEFINE([ENABLE_CRYPTO_MBEDTLS], [1], [Use mbed TLS library])
  	CRYPTO_CFLAGS="${MBEDTLS_CFLAGS}"
  	CRYPTO_LIBS="${MBEDTLS_LIBS}"

--- a/net/openvpn/patches/210-build_always_use_internal_lz4.patch
+++ b/net/openvpn/patches/210-build_always_use_internal_lz4.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1183,68 +1183,15 @@ dnl
+@@ -1177,68 +1177,15 @@ dnl
  AC_ARG_VAR([LZ4_CFLAGS], [C compiler flags for lz4])
  AC_ARG_VAR([LZ4_LIBS], [linker flags for lz4])
  if test "$enable_lz4" = "yes" && test "$enable_comp_stub" = "no"; then


### PR DESCRIPTION
Compile tested: ramips/mt7620 TP-Link Archer C50 v1, ramips/mt7621 Xiaomi Mi router 3 Pro, ath79/generic TP-Link WDR-3500
Run tested: ramips/mt7620 TP-Link Archer C50 v1, ramips/mt7621 Xiaomi Mi router 3 Pro, ath79/generic TP-Link WDR-3500

openvpn: update to 2.5.6
bugfix release including one security fix ("Disallow multiple deferred authentication plug-ins.", CVE: 2022-0547)

several build fixes, refer to https://github.com/OpenVPN/openvpn/blob/release/2.5/Changes.rst