### PR TITLE
bind: bump to 9.16.27

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.16.25
+PKG_VERSION:=9.16.27
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=9fa328850f82843ef8b7bf1ff5322cb68b110273a33f375ba41f35270f5e1ff3
+PKG_HASH:=90902aaf104c81019d75d6f8b2f7ec40fcd249406f894b44e4a9c6b5e08bf566
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/patches/001-no-tests.patch
+++ b/net/bind/patches/001-no-tests.patch
@@ -1,6 +1,6 @@
 --- a/bin/Makefile.in
 +++ b/bin/Makefile.in
-@@ -12,7 +12,7 @@ VPATH =		@srcdir@
+@@ -14,7 +14,7 @@ VPATH =		@srcdir@
  top_srcdir =	@top_srcdir@
  
  SUBDIRS =	named rndc dig delv dnssec tools nsupdate check confgen \


### PR DESCRIPTION
Fixes security issues:

 * CVE-2022-0396 -- A synchronous call to closehandle_cb() caused
			isc__nm_process_sock_buffer() to be called recursively,
			which in turn left TCP connections hanging in the
			CLOSE_WAIT state blocking indefinitely when
			out-of-order processing was disabled.

 * CVE-2021-25220 -- The rules for acceptance of records into the cache
			have been tightened to prevent the possibility of
			poisoning if forwarders send records outside
			the configured bailiwick.

Signed-off-by: Noah Meyerhans <frodo@morgul.net>

Maintainer: me
Compile tested: 19.07, malta/mipsel_24kc
Run tested: 19.07, malta/mipsel_24kc DNS authoritative and recursive resolution

Description:

Fix security issues in the bind 9.16.x packages in OpenWRT 19.07