### PR TITLE
bind: update to 9.11.37

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.11.36
+PKG_VERSION:=9.11.37
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -21,7 +21,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=c953fcb6703b395aaa53e65ff8b2869b69a5303dd60507cba2201305e1811681
+PKG_HASH:=0d8efbe7ec166ada90e46add4267b7e7c934790cba9bd5af6b8380a4fbfb5aff
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION

Signed-off-by: Noah Meyerhans <frodo@morgul.net>

Maintainer: me 
Compile tested: openwrt-18.06 x86/generic
Run tested: openwrt-18.06 x86/generic. Tested DNS recursive and authoritative resolution.

Description:

Update bind 9.11.x for security issues:

 * CVE-2021-25220 -- The rules for acceptance of records into the cache
			have been tightened to prevent the possibility of
			poisoning if forwarders send records outside
			the configured bailiwick.

 * CVE-2021-25219 -- The "lame-ttl" option is now forcibly set to 0. This
			effectively disables the lame server cache, as it could
			previously be abused by an attacker to significantly
			degrade resolver performance.
