### PR TITLE
rclone: Update to 1.58.0

### DIFF
--- a/net/rclone/Makefile
+++ b/net/rclone/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rclone
-PKG_VERSION:=1.57.0
+PKG_VERSION:=1.58.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/rclone/rclone/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=294f7a6b0874509997d3a9ffae7c74f0c45b687df0ac7d7742f284ad3814fe55
+PKG_HASH:=b3f953a282964d6d73a7278ccb2bb836d9aca855e9dc5fb6f4bc986b0e5656fa
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILE:=LICENSE
@@ -48,6 +48,7 @@ define Package/rclone
 endef
 
 define Package/rclone-config
+  $(call Package/rclone/Default)
   TITLE+= (Config Scripts)
   DEPENDS:=+rclone
 endef

--- a/net/rclone/patches/010-disable-plugins.patch
+++ b/net/rclone/patches/010-disable-plugins.patch
@@ -6,9 +6,9 @@
  	_ "github.com/rclone/rclone/fs/sync"       // import sync/*
 -	_ "github.com/rclone/rclone/lib/plugin"    // import plugins
 +	// _ "github.com/rclone/rclone/lib/plugin"    // import plugins
- )
- 
- // RcloneInitialize initializes rclone as a library
+ 	_ "github.com/rclone/rclone/cmd/mount"     // import mount
+ 	_ "github.com/rclone/rclone/cmd/mount2"    // import mount2
+ 	_ "github.com/rclone/rclone/cmd/cmount"    // import cmount
 --- a/rclone.go
 +++ b/rclone.go
 @@ -7,7 +7,7 @@ import (


### PR DESCRIPTION
Maintainer: @ElonH, me
Compile tested: rockchip, x86
Run tested: rk3328 nanopi-r2s

Description:
Added missing call for rclone-config.
Refreshed patches.
Changelog: https://rclone.org/changelog/#v1-58-0-2022-03-18