### PR TITLE
wifi-presence: add new package

### DIFF
--- a/net/wifi-presence/Makefile
+++ b/net/wifi-presence/Makefile
@@ -1,0 +1,55 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=wifi-presence
+PKG_VERSION:=0.1.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=-$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/awilliams/wifi-presence/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=f5cf8bf36e3c17ad4b0486007532030760c22c5f63bd63707d911ab94bd744df
+
+PKG_LICENSE:=MIT
+PKG_MAINTAINER:=Adam Williams <pwnfactory@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/awilliams/wifi-presence
+GO_PKG_BUILD_PKG:=$(GO_PKG)/cmd/wifi-presence
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/wifi-presence
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=WiFi presence detection with Home Assistant integration
+  URL:=https://github.com/awilliams/wifi-presence
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/wifi-presence/description
+  WiFi presence detection with Home Assistant integration.
+  Publish WiFi client connect and disconnect events to MQTT.
+endef
+
+define Package/wifi-presence/conffiles
+/etc/config/wifi-presence
+endef
+
+define Package/wifi-presence/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/wifi-presence $(1)/usr/bin
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/wifi-presence.conf $(1)/etc/config/wifi-presence
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/wifi-presence.init $(1)/etc/init.d/wifi-presence
+endef
+
+$(eval $(call GoBinPackage,wifi-presence))
+$(eval $(call BuildPackage,wifi-presence))

--- a/net/wifi-presence/files/wifi-presence.conf
+++ b/net/wifi-presence/files/wifi-presence.conf
@@ -1,0 +1,46 @@
+config wifi-presence main
+	## MQTT broker address. Ex: 'tcp://192.168.1.2:1883'
+	## Required.
+	option mqttAddr ''
+
+	## MQTT client ID.
+	## Defaults to 'wifi-presence.<hostname>'
+	# option mqttID ''
+
+	## MQTT topic prefix.
+	## Defaults to 'wifi-presence'
+	# option mqttPrefix 'wifi-presence'
+
+	## MQTT username and password (optional).
+	# option mqttUsername ''
+	# option mqttPassword ''
+
+	## Verbose logging output if true.
+	## Defaults to false.
+	# option verbose 1
+
+	## Debounce duration (using Go duration syntax). Ex: '5s', '10m', '1s', '0'
+	## Time until a client is considered disconnected and MQTT disconnect message
+	## is published.
+	## Defaults to 10s.
+	# option debounce '10s'
+
+	## Access Point (AP) name. Included in MQTT topic and message payload.
+	## Defaults to hostname.
+	# option apName 'my-ap-name'
+
+	## hostapd control interface sockets.
+	## Separate multiple sockets using ':'. Ex: '/var/run/hostapd/wlan0:/var/run/hostapd/wlan1'.
+	## The hostadp configuration file contains the location where these sockets
+	## will be created.
+	## Defaults to any Unix socket(s) found in /var/run/hostapd, which is
+	## the default hostapd directory.
+	# option hostapdSocks ''
+
+	## Home Assistant options:
+	## Publish MQTT auto discovery messages for each configured device.
+	## Default is true.
+	# option hassAutodiscovery 1
+	## Set the MQTT topic prefix used by Home Assistant.
+	## Default is 'homeassistant' (also Home Assistant's default value).
+	# option hassPrefix 'homeassistant'

--- a/net/wifi-presence/files/wifi-presence.init
+++ b/net/wifi-presence/files/wifi-presence.init
@@ -1,0 +1,66 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+START=95
+# stops before networking stops
+STOP=89
+
+PROG=/usr/bin/wifi-presence
+CONF=wifi-presence
+
+start_service() {
+        # Load config.
+        config_load "${CONF}"
+
+        local apName
+        local debounce
+        local hassAutodiscovery
+        local hassPrefix
+        local hostapdSocks
+        local mqttAddr
+        local mqttID
+        local mqttUsername
+        local mqttPassword
+        local mqttPrefix
+        local sockDir
+        local verbose
+
+        config_get apName main apName
+        config_get debounce main debounce
+        config_get hassAutodiscovery main hassAutodiscovery
+        config_get hassPrefix main hassPrefix
+        config_get hostapdSocks main hostapdSocks
+        config_get mqttAddr main mqttAddr
+        config_get mqttID main mqttId
+        config_get mqttUsername main mqttUsername
+        config_get mqttPassword main mqttPassword
+        config_get mqttPrefix main mqttPrefix
+        config_get sockDir main sockDir
+        config_get_bool verbose main verbose
+
+        procd_open_instance
+
+        procd_set_param command ${PROG}
+        [ -n "${apName}" ] && procd_append_param command "-apName=${apName}"
+        [ -n "${debounce}" ] && procd_append_param command "-debounce=${debounce}"
+        [ -n "${hassAutodiscovery}" ] && procd_append_param command "-hass.autodiscovery=${hassAutodiscovery}"
+        [ -n "${hassPrefix}" ] && procd_append_param command "-hass.prefix=${hassPrefix}"
+        [ -n "${hostapdSocks}" ] && procd_append_param command "-hostapd.socks=${hostapdSocks}"
+        [ -n "${mqttAddr}" ] && procd_append_param command "-mqtt.addr=${mqttAddr}"
+        [ -n "${mqttID}" ] && procd_append_param command "-mqtt.id=${mqttID}"
+        [ -n "${mqttUsername}" ] && procd_append_param command "-mqtt.username=${mqttUsername}"
+        [ -n "${mqttPassword}" ] && procd_append_param command "-mqtt.password=${mqttPassword}"
+        [ -n "${mqttPrefix}" ] && procd_append_param command "-mqtt.prefix=${mqttPrefix}"
+        [ -n "${sockDir}" ] && procd_append_param command "-sockDir=${sockDir}"
+        [ -n "${verbose}" ] && procd_append_param command "-verbose=${verbose}"
+
+        procd_set_param file "/etc/config/${CONF}"
+        procd_set_param stdout 1
+        procd_set_param stderr 1
+
+        # Restart every 5 seconds, indefinitely.
+        procd_set_param respawn 0 5 0
+
+        procd_close_instance
+}


### PR DESCRIPTION
Maintainer: @awilliams

Compile tested: All 20.02 supported architectures except for PowerPC (not supported by Go). Built using OpenWrt SDK inside Docker container using [this](https://github.com/awilliams/wifi-presence/blob/openwrt/package.bash) script.
Run tested: Archer C7, Netgear Nighthawk X4S R7800, Ubiquiti UniFi AP-LR

Description:
Presence detection using WiFi connect/disconnect events published to MQTT. Works with Home Assistant via the [MQTT](https://www.home-assistant.io/integrations/device_tracker.mqtt/) integration. See [awilliams/wifi-presence](https://github.com/awilliams/wifi-presence) for more details. 