### PR TITLE
liboping: fix compilation with ncurses 6.3

### DIFF
--- a/libs/liboping/Makefile
+++ b/libs/liboping/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=liboping
 PKG_VERSION:=1.10.0
-PKG_RELEASE:=2
+PKG_RELEASE:=$(AUTORELEASE)
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=LGPL-2.1-or-later
 

--- a/libs/liboping/patches/05-fix-format-arguments-ncurses63.patch
+++ b/libs/liboping/patches/05-fix-format-arguments-ncurses63.patch
@@ -1,0 +1,30 @@
+--- a/src/oping.c
++++ b/src/oping.c
+@@ -1125,7 +1125,7 @@ static int update_graph_prettyping (ping
+ 			wattron (ctx->window, COLOR_PAIR(color));
+ 
+ 		if (has_utf8())
+-			mvwprintw (ctx->window, /* y = */ 3, /* x = */ x + 2, symbol);
++			mvwprintw (ctx->window, /* y = */ 3, /* x = */ x + 2, "%s", symbol);
+ 		else
+ 			mvwaddch (ctx->window, /* y = */ 3, /* x = */ x + 2, symbolc);
+ 
+@@ -1223,7 +1223,7 @@ static int update_graph_histogram (ping_
+ 			mvwaddch (ctx->window, /* y = */ 3, /* x = */ x + 2, ' ');
+ 		else if (has_utf8 ())
+ 			mvwprintw (ctx->window, /* y = */ 3, /* x = */ x + 2,
+-					hist_symbols_utf8[index]);
++					"%s", hist_symbols_utf8[index]);
+ 		else
+ 			mvwaddch (ctx->window, /* y = */ 3, /* x = */ x + 2,
+ 					hist_symbols_acs[index] | A_ALTCHARSET);
+@@ -1600,8 +1600,7 @@ static void update_host_hook (pingobj_it
+ 
+ 			HOST_PRINTF ("%zu bytes from %s (%s): icmp_seq=%u ttl=%i ",
+ 					data_len, context->host, context->addr,
+-					sequence, recv_ttl,
+-					format_qos (recv_qos, recv_qos_str, sizeof (recv_qos_str)));
++					sequence, recv_ttl);
+ 			if ((recv_qos != 0) || (opt_send_qos != 0))
+ 			{
+ 				HOST_PRINTF ("qos=%s ",


### PR DESCRIPTION
Fix compilation with ncurses 6.3 by adjusting the printf format strings.

Apparently ncurses 6.3 introduced some new formatting tweaks that broke things.

Fixes #18110

Reference to:
* https://github.com/octo/liboping/issues/62
* https://github.com/octo/liboping/pull/61
* https://salsa.debian.org/debian/liboping/-/blob/debian/debian/patches/fix_HOST_PRINTF_format_string.patch

Maintainer:  @jow- 

Runtested with mt7622/RT3200
