### PR TITLE
usteer: add package

### DIFF
--- a/net/usteer/Makefile
+++ b/net/usteer/Makefile
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=usteer
+PKG_SOURCE_DATE:=2022-03-18
+PKG_SOURCE_VERSION:=f4e120c9a3f460cd8478f072d4c7879e1bf98136
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://git.openwrt.org/project/usteer.git
+PKG_MIRROR_HASH:=6167eab61ca222cfe257c304b92e36a7883157abfb205ab2fffe521d332fb274
+
+PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
+PKG_LICENSE:=GPL-2.0-only
+
+PKG_BUILD_DEPENDS:=libpcap
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/usteer
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libubox +libubus +libblobmsg-json +libnl-tiny
+  TITLE:=OpenWrt AP roaming assist daemon
+endef
+
+define Package/usteer/conffiles
+/etc/config/usteer
+endef
+
+define Package/usteer/install
+	$(INSTALL_DIR) $(1)/sbin $(1)/etc/init.d $(1)/etc/config
+
+	$(CP) $(PKG_BUILD_DIR)/openwrt/usteer/files/etc/config/usteer $(1)/etc/config/usteer
+
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openwrt/usteer/files/etc/init.d/usteer $(1)/etc/init.d/usteer
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/usteerd $(1)/sbin/usteerd
+endef
+
+$(eval $(call BuildPackage,usteer))
+


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79-generic
Run tested: ath79-generic JOY-IT OR750

Description:
```
This commits adds the new usteer package to the packages feed.

usteer is a daemon for steering wireless clients across frequency
bands as well as between multiple access points on a network.

Signed-off-by: David Bauer <mail@david-bauer.net>
```