### PR TITLE
zoneinfo: updated to the latest release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2021 OpenWrt.org
+# Copyright (C) 2007-2022 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2021e
+PKG_VERSION:=2022a
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=07ec42b737d0d3c6be9c337f8abb5f00554a0f9cc4fcf01a703d69403b6bb2b1
+PKG_HASH:=ef7fffd9f4f50f4f58328b35022a32a5a056b245c5cb3d6791dddb342f871664
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=584666393a5424d13d27ec01183da17703273664742e049d4f62f62dab631775
+   HASH:=f8575e7e33be9ee265df2081092526b81c80abac3f4a04399ae9d4d91cdadac7
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT master
Run tested: n/a

Description:


   Briefly:

     Palestine will spring forward on 2022-03-27, not -03-26.
     zdump -v now outputs better failure indications.
     Bug fixes for code that reads corrupted TZif data.

   Changes to future timestamps

     Palestine will spring forward on 2022-03-27, not 2022-03-26.
     (Thanks to Heba Hamad.)  Predict future transitions for first
     Sunday >= March 25.  Additionally, predict fallbacks to be the first
     Friday on or after October 23, not October's last Friday, to be more
     consistent with recent practice.  The first differing fallback
     prediction is on 2025-10-24, not 2025-10-31.

   Changes to past timestamps

     From 1992 through spring 1996, Ukraine's DST transitions were at
     02:00 standard time, not at 01:00 UTC.  (Thanks to Alois Treindl.)

     Chile's Santiago Mean Time and its LMT precursor have been adjusted
     eastward by 1 second to align with past and present law.

   Changes to commentary

     Add several references for Chile's 1946/1947 transitions, some of
     which only affected portions of the country.

   Changes to code

     Fix bug when mktime gets confused by truncated TZif files with
     unspecified local time.  (Problem reported by Almaz Mingaleev.)

     Fix bug when 32-bit time_t code reads malformed 64-bit TZif data.
     (Problem reported by Christos Zoulas.)

     When reading a version 2 or later TZif file, the TZif reader now
     validates the version 1 header and data block only enough to skip
     over them, as recommended by RFC 8536 section 4.  Also, the TZif
     reader no longer mistakenly attempts to parse a version 1 TZIf
     file header as a TZ string.

     zdump -v now outputs "(localtime failed)" and "(gmtime failed)"
     when local time and UT cannot be determined for a timestamp.

   Changes to build procedure

     Distribution tarballs now use standard POSIX.1-1988 ustar format
     instead of GNU format.  Although the formats are almost identical
     for these tarballs, ustar headers' magic fields contain "ustar"
     instead of "ustar ", and their version fields contain "00" instead
     of " ".  The two formats are planned to diverge more significantly
     for tzdb releases after 2242-03-16 12:56:31 UTC, when the ustar
     format becomes obsolete and the tarballs switch to pax format, an
     extension of ustar.  For details about these formats, please see
     "pax - portable archive interchange", IEEE Std 1003.1-2017,
