### PR TITLE
nano: provide nano-full with most nano features enabled (also uci syntax coloring)

### DIFF
--- a/utils/nano/Makefile
+++ b/utils/nano/Makefile
@@ -46,6 +46,12 @@ define Package/nano-plus
   VARIANT:=plus
 endef
 
+define Package/nano-full
+  $(call Package/nano/Default)
+  TITLE:=GNU nano text editor (all features, Unicode)
+  VARIANT:=full
+endef
+
 define Package/nano/description
   Nano is a small and simple text editor for use on the terminal.
 
@@ -63,8 +69,25 @@ define Package/nano-plus/description
   $(call Package/nano/description)
 endef
 
-ifeq ($(BUILD_VARIANT),plus)
-# plus variant with more features included
+define Package/nano-full/description
+  nano-full - all features, including syntax highlighting (also uci),
+  multibuffer, Unicode/UTF-8, nanorc, some key bindings.
+  (libmagic-based file type detection is disabled)
+
+  Example /etc/nanorc is included. nanorc documentation at
+  https://www.nano-editor.org/dist/latest/nanorc.5.html
+
+  $(call Package/nano/description)
+endef
+
+ifeq ($(BUILD_VARIANT),full)
+# full variant with almost all features included
+  CONFIGURE_ARGS += \
+	--disable-extra \
+	--disable-libmagic \
+	--enable-utf8
+else ifeq ($(BUILD_VARIANT),plus)
+# plus variant with some features included
   CONFIGURE_ARGS += \
 	--enable-help \
 	--enable-justify \
@@ -95,6 +118,14 @@ endif
 CONFIGURE_VARS += \
 	ac_cv_header_regex_h=no \
 
+define Package/nano-plus/conffiles
+/etc/nanorc
+endef
+
+define Package/nano-full/conffiles
+/etc/nanorc
+endef
+
 define Package/nano/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/$(PKG_NAME) $(1)/usr/bin/
@@ -104,6 +135,15 @@ define Package/nano-plus/install
 	$(call Package/nano/install,$1)
 endef
 
+define Package/nano-full/install
+	$(call Package/nano/install,$1)
+	$(INSTALL_DIR) $(1)/etc $(1)/usr/share/nano
+	$(INSTALL_CONF) ./files/nanorc $(1)/etc/nanorc
+	$(INSTALL_DATA) ./files/uci.nanorc $(1)/usr/share/nano
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/nano/* $(1)/usr/share/nano
+endef
+
 $(eval $(call BuildPackage,nano))
 $(eval $(call BuildPackage,nano-plus))
+$(eval $(call BuildPackage,nano-full))
 

--- a/utils/nano/files/nanorc
+++ b/utils/nano/files/nanorc
@@ -1,0 +1,8 @@
+## General Settings ##
+set multibuffer         # Open multiple files
+set linenumbers         # show line numbers Alt+N to toggle
+
+## Syntax highlighting ##
+include /usr/share/nano/*.nanorc
+include /usr/share/nano/extra/*.nanorc
+

--- a/utils/nano/files/uci.nanorc
+++ b/utils/nano/files/uci.nanorc
@@ -1,0 +1,17 @@
+## Syntax highlighting for OpenWrt uci config files.
+
+syntax uci "/etc/config/*"
+comment "#"
+
+# Keywords
+color green "\<(package|config|option|list)\>"
+
+# Comments.
+color cyan "(^|[[:blank:]])#.*"
+
+# Strings.
+color yellow ""([^"\]|\\.)*"|'([^'\]|\\.)*'"
+
+# Trailing whitespace.
+color ,green "[[:space:]]+$"
+


### PR DESCRIPTION
Provide a new variant, nano-full, that enables almost all functionality of nano. Only libmagic file type detection
has been left out.

Ship with a minimal /etc/nanorc that the user can modify.

Provide color highlighting for the uci config files. I drafted a minimal color scheme for them.

Maintainer: me 
