### PR TITLE
telegraf: Update to version 1.22.0

### DIFF
--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telegraf
-PKG_VERSION:=1.21.4
+PKG_VERSION:=1.22.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=dc1f04662fe81c970019271a215979c5549aec86b896562376d69bc76d7eaeda
+PKG_HASH:=7d1624773e4e5c801eaaa0f52b75ee612cc12a975c625077a57cd7dbe612a2b3
 
 PKG_MAINTAINER:=Jonathan Pagel <jonny_tischbein@systemli.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Signed-off-by: Jonathan Pagel [jonny_tischbein@systemli.org](mailto:jonny_tischbein@systemli.org)

Maintainer:
me

Compile tested:
on amd64 for aarch64 on https://git.openwrt.org/openwrt/openwrt.git commit 0f50d3daff19a1eae513630a70f0c66af16db796

Run tested:
aarch64 (Banana PI R64), package installed, configured, starting via /etc/init.d/, configuring telegraf config and successfull working of input plugin cpu, prometheus and output plugin influxdb tested.

Description:
Update to version 1.22.0

Telegraf is a plugin-driven agent for collecting and sending metrics and events. It supports various inputs (including prometheus endpoints) and is able to send data into InfluxDB. https://www.influxdata.com/time-series-platform/telegraf/