### PR TITLE
telegraf: Update to version 1.22.0 to openwrt 21.02

### DIFF
--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telegraf
-PKG_VERSION:=1.21.3
+PKG_VERSION:=1.22.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c117b930e82969080204382a2aa9df8572d05b18cfa0caf0ff62cb840af5ce71
+PKG_HASH:=7d1624773e4e5c801eaaa0f52b75ee612cc12a975c625077a57cd7dbe612a2b3
 
 PKG_MAINTAINER:=Jonathan Pagel <jonny_tischbein@systemli.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Signed-off-by: Jonathan Pagel [jonny_tischbein@systemli.org](mailto:jonny_tischbein@systemli.org)
(cherry picked from commit https://github.com/openwrt/packages/commit/2c9c48582209a97e2e3ce9452e4cb15e9820886c)

Maintainer:
me

Compile tested:
on amd64 for x86

Run tested:
x86-64 VM

Description:
Add package with version 1.22.0 for openwrt 21.02

Telegraf is a plugin-driven agent for collecting and sending metrics and events. It supports various inputs (including prometheus endpoints) and is able to send data into InfluxDB. https://www.influxdata.com/time-series-platform/telegraf/