### PR TITLE
[21.02] ci: use openwrt/gh-action-sdk@v4

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -61,7 +61,7 @@ jobs:
           echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
 
       - name: Build
-        uses: openwrt/gh-action-sdk@v1
+        uses: openwrt/gh-action-sdk@v4
         env:
           ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
           FEEDNAME: packages_ci


### PR DESCRIPTION
[ Upstream commit b1355832a05f96d96081044a90b4c9137eb15fad ]

In order to use feeds from GH mirror for GH actions, thus saving a lot
of resources being wasted.

Signed-off-by: Petr Štetiar <ynezz@true.cz>