### PR TITLE
libmbim: switch to meson build tools

### DIFF
--- a/libs/libmbim/Makefile
+++ b/libs/libmbim/Makefile
@@ -8,27 +8,29 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmbim
-PKG_VERSION:=1.26.2
+PKG_SOURCE_VERSION:=1.26.2
 PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://www.freedesktop.org/software/libmbim
-PKG_HASH:=10c77bf5b5eb8c92ba80e9b519923ad9b898362bc8e1928e2bc9a17eeba649af
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/libmbim.git
+PKG_MIRROR_HASH:=47eb6511818271be66336fb67ec97de7925119b09ddbd0ffd06b3f76893a461e
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 
 PKG_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
+include $(INCLUDE_DIR)/meson.mk
 
-CONFIGURE_ARGS += \
-	--disable-static \
-	--disable-gtk-doc \
-	--disable-gtk-doc-html \
-	--disable-gtk-doc-pdf \
-	--disable-silent-rules
+TARGET_CFLAGS += -ffunction-sections -fdata-sections -fno-merge-all-constants -fmerge-constants
+TARGET_LDFLAGS += -Wl,--gc-sections
+
+MESON_ARGS += \
+	-Dintrospection=false \
+	-Dman=false \
+	-Dbash_completion=false \
+	-Db_lto=true
 
 define Package/libmbim
   SECTION:=libs
@@ -55,9 +57,6 @@ define Package/mbim-utils
   LICENSE_FILES:=COPYING
 endef
 
-CONFIGURE_ARGS += \
-	--without-udev-base-dir
-
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) \
@@ -76,11 +75,15 @@ define Build/InstallDev
 endef
 
 define Package/libmbim/install
-	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DIR) \
+		$(1)/usr/lib \
+		$(1)/usr/libexec
+
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/libmbim*.so.* \
 		$(1)/usr/lib/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/mbim-proxy $(1)/usr/lib/
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/libexec/mbim-proxy $(1)/usr/libexec/
 endef
 
 define Package/mbim-utils/install


### PR DESCRIPTION
Signed-off-by: Maxim Anisimov [maxim.anisimov.ua@gmail.com](mailto:maxim.anisimov.ua@gmail.com)

Maintainer: Nicholas Smith <nicholas@nbembedded.com>

Compile tested:
on amd64 for mipsel_24kc on https://git.openwrt.org/openwrt/openwrt.git commit c7bcbcd49280a79b287cc072cd0ca7de777a7ac4

Run tested:
Zbtlink ZBT-WG3526

Description:
Using https://gitlab.freedesktop.org/mobile-broadband/libmbim.git to download the source code.
Enabled lto and additional gcc flags for perfomance and less size
Modified to use meson as upstream has abandoned autotools.
Removed BUILD_PARALLEL options. These are default with ninja/meson.