### PR TITLE
libqmi: switch to meson build tools

### DIFF
--- a/libs/libqmi/Config.in
+++ b/libs/libqmi/Config.in
@@ -13,4 +13,19 @@ config LIBQMI_WITH_QRTR_GLIB
 	help
 	  Compile libqmi with QRTR support
 
+choice
+	prompt "Select QMI message collection to build"
+	default LIBQMI_COLLECTION_BASIC
+
+	config LIBQMI_COLLECTION_MINIMAL
+		depends on !MODEMMANAGER_WITH_QMI
+		bool "minimal"
+
+	config LIBQMI_COLLECTION_BASIC
+		bool "basic (default)"
+
+	config LIBQMI_COLLECTION_FULL
+		bool "full"
+endchoice
+
 endmenu

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -11,17 +11,22 @@ PKG_NAME:=libqmi
 PKG_VERSION:=1.30.4
 PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
-PKG_HASH:=00d7da30a4f8d1185f37cba289cfaf1dfcd04a58f2f76d6acfdf5b85312d6ed6
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/libqmi.git
+PKG_SOURCE_VERSION:=$(PKG_VERSION)
+PKG_MIRROR_HASH:=537eae29c36aba9757afd86e48b91c37c3fe3232037ad11fdd426297f6040a6b
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 
 PKG_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DEPENDS:=python3/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
+include $(INCLUDE_DIR)/meson.mk
+
+TARGET_CFLAGS += -ffunction-sections -fdata-sections -fno-merge-all-constants -fmerge-constants
+TARGET_LDFLAGS += -Wl,--gc-sections
 
 define Package/libqmi/config
   source "$(SOURCE)/Config.in"
@@ -59,26 +64,31 @@ define Package/libqmi-utils/description
   Utils to talk to QMI enabled modems
 endef
 
-CONFIGURE_ARGS += \
-	--disable-static \
-	--disable-gtk-doc \
-	--disable-gtk-doc-html \
-	--disable-gtk-doc-pdf \
-	--disable-silent-rules \
-	--enable-firmware-update \
-	--without-udev \
-	--without-udev-base-dir
+MESON_ARGS += \
+	-Dudev=false \
+	-Dintrospection=false \
+	-Dman=false \
+	-Dbash_completion=false \
+	-Db_lto=true
 
 ifeq ($(CONFIG_LIBQMI_WITH_MBIM_QMUX),y)
-	CONFIGURE_ARGS += --enable-mbim-qmux
+	MESON_ARGS += -Dmbim_qmux=true
 else
-	CONFIGURE_ARGS += --disable-mbim-qmux
+	MESON_ARGS += -Dmbim_qmux=false
 endif
 
 ifeq ($(CONFIG_LIBQMI_WITH_QRTR_GLIB),y)
-	CONFIGURE_ARGS += --enable-qrtr
+	MESON_ARGS += -Dqrtr=true
 else
-	CONFIGURE_ARGS += --disable-qrtr
+	MESON_ARGS += -Dqrtr=false
+endif
+
+ifeq ($(CONFIG_LIBQMI_COLLECTION_MINIMAL),y)
+	MESON_ARGS += -Dcollection=minimal
+else ifeq ($(CONFIG_LIBQMI_COLLECTION_BASIC),y)
+	MESON_ARGS += -Dcollection=basic
+else
+	MESON_ARGS += -Dcollection=full
 endif
 
 define Build/InstallDev
@@ -99,12 +109,15 @@ define Build/InstallDev
 endef
 
 define Package/libqmi/install
-	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DIR) \
+		$(1)/usr/lib \
+		$(1)/usr/libexec
+
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/libqmi*.so.* \
 		$(1)/usr/lib/
 
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/qmi-proxy $(1)/usr/lib/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/libexec/qmi-proxy $(1)/usr/libexec/
 endef
 
 define Package/qmi-utils/install


### PR DESCRIPTION
Signed-off-by: Maxim Anisimov [maxim.anisimov.ua@gmail.com](mailto:maxim.anisimov.ua@gmail.com)

Maintainer: Nicholas Smith <nicholas@nbembedded.com>

Compile tested:
on amd64 for mipsel_24kc on https://git.openwrt.org/openwrt/openwrt.git commit c7bcbcd49280a79b287cc072cd0ca7de777a7ac4

Run tested:
Zbtlink ZBT-WG3526

Description:
Using https://gitlab.freedesktop.org/mobile-broadband/libqmi.git to download the source code.
Enabled lto and additional gcc flags for perfomance and less size.
Added support for selecting qmi message collection.
Selected basic qmi message collection by default (modemmanager requires it).
Modified to use meson as upstream has abandoned autotools.
Removed BUILD_PARALLEL options. These are default with ninja/meson.