### PR TITLE
tvheadend: add noacl config option for server

### DIFF
--- a/multimedia/tvheadend/files/tvheadend.config
+++ b/multimedia/tvheadend/files/tvheadend.config
@@ -13,3 +13,4 @@ config tvheadend server
 #	 option htsp_port '9982'
 #	 option htsp_port2 '9983'
 #	 option xspf '0'
+#	 option noacl '0'

--- a/multimedia/tvheadend/files/tvheadend.init
+++ b/multimedia/tvheadend/files/tvheadend.init
@@ -74,6 +74,8 @@ load_uci_config() {
 	[ -n "$htsp_port2" ] && procd_append_param command --htsp_port "$htsp_port2"
 	config_get xspf server xspf 0
 	[ "$xspf" -eq 1 ] && procd_append_param command --xspf
+	config_get noacl server noacl 0
+	[ "$noacl" -eq 1 ] && procd_append_param command --noacl
 }
 
 start_service() {


### PR DESCRIPTION
Add support for --noacl option to disable all access control checks.

Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>

Maintainer: me / @M95D
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (Netgear XR700, ARMv7 , OpenWrt SNAPSHOT r19256-f25826cdc7bd, tests done)

See https://github.com/tvheadend/tvheadend/blob/master/docs/markdown/cmdline_options.md