### PR TITLE
v2raya: fix panic in go 1.18

### DIFF
--- a/net/v2raya/patches/010-fix-panic-in-go-1.18-462.patch
+++ b/net/v2raya/patches/010-fix-panic-in-go-1.18-462.patch
@@ -1,0 +1,32 @@
+From eb210b5e634b65838b50387891ad837590fb2b4e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=E9=AB=98=E6=B8=90=E7=A6=BB?= <admin@gaojianli.me>
+Date: Tue, 22 Mar 2022 15:28:50 +0800
+Subject: [PATCH] fix: panic in go 1.18 (#462)
+
+---
+ service/go.mod | 2 +-
+ service/go.sum | 2 ++
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+--- a/go.mod
++++ b/go.mod
+@@ -50,7 +50,7 @@ require (
+ 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
+ 	github.com/mattn/go-isatty v0.0.12 // indirect
+ 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
+-	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
++	github.com/modern-go/reflect2 v1.0.2 // indirect
+ 	github.com/pelletier/go-toml v1.2.0 // indirect
+ 	github.com/pires/go-proxyproto v0.6.1 // indirect
+ 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
+--- a/go.sum
++++ b/go.sum
+@@ -145,6 +145,8 @@ github.com/modern-go/concurrent v0.0.0-2
+ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
+ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
++github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
++github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
+ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
+ github.com/muhammadmuzzammil1998/jsonc v0.0.0-20201229145248-615b0916ca38 h1:0FrBxrkJ0hVembTb/e4EU5Ml6vLcOusAqymmYISg5Uo=


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8, x86/64
Run tested: rk3328 nanopi-r2s

Description:
Fix panic in go 1.18, the patch is taken from upstream commit v2rayA/v2rayA@eb210b5e634b65838b50387891ad837590fb2b4e.

Related PR: #18147