### PR TITLE
modemmanager: switch to meson build tools

### DIFF
--- a/net/modemmanager/Config.in
+++ b/net/modemmanager/Config.in
@@ -1,21 +1,30 @@
 menu "Configuration"
-depends on PACKAGE_modemmanager
+	depends on PACKAGE_modemmanager
 
-	config MODEMMANAGER_WITH_MBIM
-		bool "Include MBIM support"
-		default y
-		help
-		  Compile ModemManager with MBIM support
+config MODEMMANAGER_WITH_MBIM
+	bool "Include MBIM support"
+	default y
+	help
+	  Compile ModemManager with MBIM support
 
-	config MODEMMANAGER_WITH_QMI
-		bool "Include QMI support"
-		default y
-		help
-		  Compile ModemManager with QMI support
+config MODEMMANAGER_WITH_QMI
+	bool "Include QMI support"
+	default y
+	help
+	  Compile ModemManager with QMI support
 
-        config MODEMMANAGER_WITH_AT_COMMAND_VIA_DBUS
-                bool "Allow AT commands via DBus"
-                default n
-                help
-                  Compile ModemManager allowing AT commands without debug flag
+config MODEMMANAGER_WITH_QRTR
+	bool "Include QRTR support"
+	default y
+	depends on MODEMMANAGER_WITH_QMI
+	select LIBQMI_WITH_QRTR_GLIB
+	help
+	  Compile ModemManager with QRTR support
+
+config MODEMMANAGER_WITH_AT_COMMAND_VIA_DBUS
+	bool "Allow AT commands via DBus"
+	default n
+	help
+	  Compile ModemManager allowing AT commands without debug flag
+
 endmenu

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -8,23 +8,26 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
-PKG_VERSION:=1.18.6
+PKG_SOURCE_VERSION:=1.18.6
 PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
-PKG_HASH:=d4f804b31cf504239c5f1d4973c62095c00cba1ee9abb503718dac6d146a470a
-PKG_BUILD_DIR:=$(BUILD_DIR)/ModemManager-$(PKG_VERSION)
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git
+PKG_MIRROR_HASH:=72f1a865153745d05c482ed3a77f2045d24387f1f9a37177fe7bc35ab7663765
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DEPENDS:=glib2/host libxslt/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
+include $(INCLUDE_DIR)/meson.mk
+
+TARGET_CFLAGS += -ffunction-sections -fdata-sections -fno-merge-all-constants -fmerge-constants
+TARGET_LDFLAGS += -Wl,--gc-sections
 
 define Package/modemmanager/config
   source "$(SOURCE)/Config.in"
@@ -41,7 +44,8 @@ define Package/modemmanager
 	+dbus \
 	+ppp \
 	+MODEMMANAGER_WITH_MBIM:libmbim \
-	+MODEMMANAGER_WITH_QMI:libqmi
+	+MODEMMANAGER_WITH_QMI:libqmi \
+	+MODEMMANAGER_WITH_QRTR:libqrtr-glib
 endef
 
 define Package/modemmanager/description
@@ -50,35 +54,21 @@ define Package/modemmanager/description
   Select Utilities/usb-modeswitch if needed.
 endef
 
-CONFIGURE_ARGS += \
-	--without-polkit \
-	--without-udev \
-	--without-systemdsystemunitdir \
-	--disable-rpath \
-	--disable-gtk-doc
-
-ifeq ($(CONFIG_MODEMMANAGER_WITH_AT_COMMAND_VIA_DBUS),y)
-  CONFIGURE_ARGS += --with-at-command-via-dbus
-endif
-
-ifdef CONFIG_MODEMMANAGER_WITH_MBIM
-  CONFIGURE_ARGS += --with-mbim
-else
-  CONFIGURE_ARGS += --without-mbim
-endif
-
-ifdef CONFIG_MODEMMANAGER_WITH_QMI
-  CONFIGURE_ARGS += --with-qmi
-else
-  CONFIGURE_ARGS += --without-qmi
-endif
-
-define Build/Prepare
-	$(call Build/Prepare/Default)
-	( cd "$(PKG_BUILD_DIR)"; \
-		printf "all:\ninstall:\n" >po/Makefile.in.in; \
-	)
-endef
+MESON_ARGS += \
+	-Dudev=false \
+	-Dudevdir=/lib/udev \
+	-Dsystemdsystemunitdir=no \
+	-Dsystemd_suspend_resume=false \
+	-Dsystemd_journal=false \
+	-Dpolkit=no \
+	-Dintrospection=false \
+	-Dman=false \
+	-Dbash_completion=false \
+	-Db_lto=true \
+	-Dmbim=$(if $(CONFIG_MODEMMANAGER_WITH_MBIM),true,false) \
+	-Dqmi=$(if $(CONFIG_MODEMMANAGER_WITH_QMI),true,false) \
+	-Dqrtr=$(if $(CONFIG_MODEMMANAGER_WITH_QRTR),true,false) \
+	-Dat_command_via_dbus=$(if $(CONFIG_MODEMMANAGER_WITH_AT_COMMAND_VIA_DBUS),true,false)
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/ModemManager

--- a/net/modemmanager/patches/001-plugins-Fix-port-enums-includes.patch
+++ b/net/modemmanager/patches/001-plugins-Fix-port-enums-includes.patch
@@ -1,0 +1,88 @@
+--- a/plugins/broadmobi/mm-plugin-broadmobi.c
++++ b/plugins/broadmobi/mm-plugin-broadmobi.c
+@@ -19,7 +19,6 @@
+ #define _LIBMM_INSIDE_MM
+ #include <libmm-glib.h>
+ 
+-#include "mm-port-enums-types.h"
+ #include "mm-log-object.h"
+ #include "mm-plugin-broadmobi.h"
+ #include "mm-broadband-modem.h"
+--- a/plugins/dlink/mm-plugin-dlink.c
++++ b/plugins/dlink/mm-plugin-dlink.c
+@@ -19,7 +19,6 @@
+ #define _LIBMM_INSIDE_MM
+ #include <libmm-glib.h>
+ 
+-#include "mm-port-enums-types.h"
+ #include "mm-log-object.h"
+ #include "mm-plugin-dlink.h"
+ #include "mm-broadband-modem.h"
+--- a/plugins/meson.build
++++ b/plugins/meson.build
+@@ -461,7 +461,7 @@ if plugins_options['huawei']
+   plugins += {'plugin-huawei': {
+     'plugin': true,
+     'helper': {'sources': files('huawei/mm-modem-helpers-huawei.c'), 'include_directories': plugins_incs + [huawei_inc], 'c_args': common_c_args + ['-DMM_MODULE_NAME="huawei"']},
+-    'module': {'sources': sources + enums_sources, 'include_directories': plugins_incs + [huawei_inc], 'c_args': common_c_args + ['-DMM_MODULE_NAME="huawei"']},
++    'module': {'sources': sources + enums_sources + port_enums_sources, 'include_directories': plugins_incs + [huawei_inc], 'c_args': common_c_args + ['-DMM_MODULE_NAME="huawei"']},
+     'test': {'sources': files('huawei/tests/test-modem-helpers-huawei.c') + enums_sources, 'include_directories': huawei_inc, 'dependencies': libhelpers_dep},
+   }}
+ 
+--- a/plugins/telit/mm-plugin-telit.c
++++ b/plugins/telit/mm-plugin-telit.c
+@@ -21,7 +21,6 @@
+ #define _LIBMM_INSIDE_MM
+ #include <libmm-glib.h>
+ 
+-#include "mm-port-enums-types.h"
+ #include "mm-log-object.h"
+ #include "mm-modem-helpers.h"
+ #include "mm-plugin-telit.h"
+--- a/plugins/tplink/mm-plugin-tplink.c
++++ b/plugins/tplink/mm-plugin-tplink.c
+@@ -19,7 +19,6 @@
+ #define _LIBMM_INSIDE_MM
+ #include <libmm-glib.h>
+ 
+-#include "mm-port-enums-types.h"
+ #include "mm-log-object.h"
+ #include "mm-plugin-tplink.h"
+ #include "mm-broadband-modem.h"
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -147,15 +147,15 @@ endif
+ 
+ enums_types = 'mm-port-enums-types'
+ 
+-enums_sources = []
+-enums_sources += gnome.mkenums(
++port_enums_sources = []
++port_enums_sources += gnome.mkenums(
+   enums_types + '.c',
+   sources: headers,
+   c_template: build_aux_dir / enums_types + '.c.template',
+   fhead: '#include "mm-port-enums-types.h"',
+ )
+ 
+-enums_sources += gnome.mkenums(
++port_enums_sources += gnome.mkenums(
+   enums_types + '.h',
+   sources: headers,
+   h_template: build_aux_dir / enums_types + '.h.template',
+@@ -165,13 +165,13 @@ enums_sources += gnome.mkenums(
+ 
+ libport = static_library(
+   'port',
+-  sources: sources + enums_sources,
++  sources: sources + port_enums_sources,
+   include_directories: top_inc,
+   dependencies: deps + private_deps,
+ )
+ 
+ libport_dep = declare_dependency(
+-  sources: enums_sources[1],
++  sources: port_enums_sources[1],
+   include_directories: '.',
+   dependencies: deps,
+   link_with: libport,

--- a/net/modemmanager/patches/002-build-meson-Fix-daemon-enums-dependencies.patch
+++ b/net/modemmanager/patches/002-build-meson-Fix-daemon-enums-dependencies.patch
@@ -1,0 +1,96 @@
+--- a/plugins/meson.build
++++ b/plugins/meson.build
+@@ -88,7 +88,7 @@ if plugins_shared['icera']
+   plugins += {'shared-icera': {
+     'plugin': false,
+     'helper': {'sources': files('icera/mm-modem-helpers-icera.c'), 'include_directories': plugins_incs, 'c_args': common_c_args},
+-    'module': {'sources': sources, 'include_directories': plugins_incs, 'c_args': common_c_args},
++    'module': {'sources': sources + daemon_enums_sources, 'include_directories': plugins_incs, 'c_args': common_c_args},
+     'test': {'sources': files('icera/tests/test-modem-helpers-icera.c'), 'include_directories': plugins_incs + [icera_inc], 'dependencies': libhelpers_dep},
+   }}
+ endif
+@@ -185,7 +185,7 @@ if plugins_shared['telit']
+   plugins += {'shared-telit': {
+     'plugin': false,
+     'helper': {'sources': files('telit/mm-modem-helpers-telit.c'), 'include_directories': plugins_incs, 'c_args': common_c_args},
+-    'module': {'sources': sources, 'include_directories': plugins_incs + [telit_inc], 'c_args': common_c_args},
++    'module': {'sources': sources + daemon_enums_sources, 'include_directories': plugins_incs + [telit_inc], 'c_args': common_c_args},
+     'test': {'sources': files('telit/tests/test-mm-modem-helpers-telit.c'), 'include_directories': telit_inc, 'dependencies': libmm_test_common_dep},
+   }}
+ endif
+@@ -285,7 +285,7 @@ if plugins_options['cinterion']
+   plugins += {'plugin-cinterion': {
+     'plugin': true,
+     'helper': {'sources': files('cinterion/mm-modem-helpers-cinterion.c'), 'include_directories': plugins_incs, 'c_args': common_c_args},
+-    'module': {'sources': sources, 'include_directories': plugins_incs, 'c_args': common_c_args},
++    'module': {'sources': sources + daemon_enums_sources, 'include_directories': plugins_incs, 'c_args': common_c_args},
+     'test': {'sources': files('cinterion/tests/test-modem-helpers-cinterion.c'), 'include_directories': plugins_incs + [include_directories('cinterion')], 'dependencies': libport_dep},
+   }}
+ 
+@@ -460,8 +460,8 @@ if plugins_options['huawei']
+ 
+   plugins += {'plugin-huawei': {
+     'plugin': true,
+-    'helper': {'sources': files('huawei/mm-modem-helpers-huawei.c'), 'include_directories': plugins_incs + [huawei_inc], 'c_args': common_c_args + ['-DMM_MODULE_NAME="huawei"']},
+-    'module': {'sources': sources + enums_sources + port_enums_sources, 'include_directories': plugins_incs + [huawei_inc], 'c_args': common_c_args + ['-DMM_MODULE_NAME="huawei"']},
++    'helper': {'sources': files('huawei/mm-modem-helpers-huawei.c') + daemon_enums_sources, 'include_directories': plugins_incs + [huawei_inc], 'c_args': common_c_args + ['-DMM_MODULE_NAME="huawei"']},
++    'module': {'sources': sources + enums_sources + port_enums_sources + daemon_enums_sources, 'include_directories': plugins_incs + [huawei_inc], 'c_args': common_c_args + ['-DMM_MODULE_NAME="huawei"']},
+     'test': {'sources': files('huawei/tests/test-modem-helpers-huawei.c') + enums_sources, 'include_directories': huawei_inc, 'dependencies': libhelpers_dep},
+   }}
+ 
+@@ -534,7 +534,7 @@ if plugins_options['mbm']
+   plugins += {'plugin-ericsson-mbm': {
+     'plugin': true,
+     'helper': {'sources': files('mbm/mm-modem-helpers-mbm.c'), 'include_directories': plugins_incs, 'c_args': common_c_args + ['-DMM_MODULE_NAME="ericsson-mbm"']},
+-    'module': {'sources': sources, 'include_directories': plugins_incs, 'c_args': common_c_args + ['-DMM_MODULE_NAME="ericsson-mbm"']},
++    'module': {'sources': sources + daemon_enums_sources, 'include_directories': plugins_incs, 'c_args': common_c_args + ['-DMM_MODULE_NAME="ericsson-mbm"']},
+     'test': {'sources': files('mbm/tests/test-modem-helpers-mbm.c'), 'include_directories': plugins_incs + [include_directories('mbm')], 'dependencies': libhelpers_dep},
+   }}
+ 
+@@ -644,7 +644,7 @@ if plugins_options['option-hso']
+ 
+   plugins += {'plugin-option-hso': {
+     'plugin': true,
+-    'module': {'sources': sources, 'include_directories': plugins_incs, 'c_args': '-DMM_MODULE_NAME="option-hso"'},
++    'module': {'sources': sources + daemon_enums_sources, 'include_directories': plugins_incs, 'c_args': '-DMM_MODULE_NAME="option-hso"'},
+   }}
+ endif
+ 
+@@ -852,7 +852,7 @@ if plugins_options['ublox']
+   plugins += {'plugin-ublox': {
+     'plugin': true,
+     'helper': {'sources': files('ublox/mm-modem-helpers-ublox.c'), 'include_directories': plugins_incs, 'c_args': common_c_args},
+-    'module': {'sources': sources, 'include_directories': plugins_incs + [ublox_inc], 'c_args': common_c_args},
++    'module': {'sources': sources + daemon_enums_sources, 'include_directories': plugins_incs + [ublox_inc], 'c_args': common_c_args},
+     'test': {'sources': files('ublox/tests/test-modem-helpers-ublox.c'), 'include_directories': ublox_inc, 'dependencies': libmm_test_common_dep},
+   }}
+ 
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -225,14 +225,15 @@ sources = files(
+ 
+ enums_types = 'mm-daemon-enums-types'
+ 
+-sources += gnome.mkenums(
++daemon_enums_sources = []
++daemon_enums_sources += gnome.mkenums(
+   enums_types + '.c',
+   sources: headers,
+   c_template: build_aux_dir / enums_types + '.c.template',
+   fhead: '#include "mm-daemon-enums-types.h"',
+ )
+ 
+-sources += gnome.mkenums(
++daemon_enums_sources += gnome.mkenums(
+   enums_types + '.h',
+   sources: headers,
+   h_template: build_aux_dir / enums_types + '.h.template',
+@@ -296,7 +297,7 @@ endif
+ 
+ executable(
+   'ModemManager',
+-  sources: sources,
++  sources: sources + daemon_enums_sources,
+   include_directories: top_inc,
+   dependencies: deps,
+   c_args: c_args,


### PR DESCRIPTION
Signed-off-by: Maxim Anisimov [maxim.anisimov.ua@gmail.com](mailto:maxim.anisimov.ua@gmail.com)

Maintainer: Nicholas Smith <nicholas@nbembedded.com>

Compile tested:
on amd64 for mipsel_24kc on https://git.openwrt.org/openwrt/openwrt.git commit c7bcbcd49280a79b287cc072cd0ca7de777a7ac4

Run tested:
Zbtlink ZBT-WG3526

Description:
Using https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git to download the source code.
Added compile option to compile qrtr support.
Enabled lto and additional gcc flags for perfomance and less size.
Modified to use meson as upstream has abandoned autotools.
Removed BUILD_PARALLEL options. These are default with ninja/meson.