### PR TITLE
prometheus-node-exporter-lua: add netclass.lua collector

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2021.12.21
+PKG_VERSION:=2022.03.28
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
@@ -43,6 +43,7 @@ define Package/prometheus-node-exporter-lua/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/netdev.lua      $(1)/usr/lib/lua/prometheus-collectors/
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/time.lua        $(1)/usr/lib/lua/prometheus-collectors/
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/uname.lua       $(1)/usr/lib/lua/prometheus-collectors/
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/netclass.lua    $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
 define Package/prometheus-node-exporter-lua/conffiles

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/netclass.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/netclass.lua
@@ -1,0 +1,77 @@
+local ubus = require "ubus"
+
+-- reference/further reading:
+-- - node_exporter netclass_linux (upstream metrics): https://github.com/prometheus/node_exporter/blob/master/collector/netclass_linux.go
+-- - relevant sysfs files: https://github.com/prometheus/procfs/blob/5f46783c017ef6a934fc8cfa6d1a2206db21401b/sysfs/net_class.go#L121
+-- - get devices / read files: https://github.com/openwrt/packages/blob/openwrt-21.02/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/snmp6.lua
+
+local function get_devices() -- based on hostapd_stations.lua
+  local u = ubus.connect()
+  local status = u:call("network.device", "status", {})
+  local devices = {}
+
+  for dev, dev_table in pairs(status) do
+    table.insert(devices, dev)
+  end
+  return devices
+end
+
+local function load(device, file) -- load a single sysfs file, trim trailing newline, return nil on error
+  local success, data = pcall(function () return string.gsub(get_contents("/sys/class/net/" .. device .. "/" .. file), "\n$", "") end)
+  if success then
+    return data
+  else
+    return nil
+  end
+end
+
+local function file_gauge(name, device, file)
+  local value = load(device, file)
+  if value ~= nil then
+    metric("node_network_" .. name, "gauge", {device = device}, tonumber(value))
+  end
+end
+
+local function file_counter(name, device, file)
+  local value = load(device, file)
+  if value ~= nil then
+    metric("node_network_" .. name, "counter", {device = device}, tonumber(value))
+  end
+end
+
+local function get_metric(device)
+  local address = load(device, "address")
+  local broadcast = load(device, "broadcast")
+  local duplex = load(device, "duplex")
+  local operstate = load(device, "operstate")
+  local ifalias = load(device, "ifalias")
+  metric("node_network_info", "gauge", {device = device, address = address, broadcast = broadcast, duplex = duplex, operstate = operstate, ifalias = ifalias}, 1)
+  file_gauge("address_assign_type", device, "addr_assign_type")
+  file_gauge("carrier", device, "carrier")
+  file_counter("carrier_changes_total", device, "carrier_changes")
+  file_counter("carrier_up_changes_total", device, "carrier_up_count")
+  file_counter("carrier_down_changes_total", device, "carrier_down_count")
+  file_gauge("device_id", device, "dev_id")
+  file_gauge("dormant", device, "dormant")
+  file_gauge("flags", device, "flags")
+  file_gauge("iface_id", device, "ifindex")
+  file_gauge("iface_link", device, "iflink")
+  file_gauge("iface_link_mode", device, "link_mode")
+  file_gauge("mtu_bytes", device, "mtu")
+  file_gauge("name_assign_type", device, "name_assign_type")
+  file_gauge("net_dev_group", device, "netdev_group")
+  file_gauge("transmit_queue_length", device, "tx_queue_len")
+  file_gauge("protocol_type", device, "type")
+  local speed = load(device, "speed")
+  if speed ~= nil and tonumber(speed) >= 0 then
+    metric("node_network_speed_bytes", "gauge", {device = device}, tonumber(speed)*1000*1000/8)
+  end
+end
+
+local function scrape()
+  for _, devicename in ipairs(get_devices()) do
+    get_metric(devicename)
+  end
+end
+
+return { scrape = scrape }


### PR DESCRIPTION
All current node_exporter netclass metrics will be available. This includes
speed metrics per lan port on supported DSA switches.

Maintainer: @mweinelt (I hope you are the right person to contact)
Compile tested: TODO
Run tested: 22.03-snapshot on Totolink X5000R, TP-Link Archer C7, Ubiquity Edgerouter X

Description:
The port speed can be read from `/sys/class/net/<device>/speed`. I noticed that this now works for some DSA enabled devices (edgerouter X, totolink).

Output Totolink X5000R for lan4:
```
node_network_info{duplex="full",broadcast="ff:ff:ff:ff:ff:ff",ifalias="",address="5c:92:5e:3c:8b:b0",device="lan4",operstate="up"} 1
node_network_address_assign_type{device="lan4"} 0
node_network_carrier{device="lan4"} 1
node_network_carrier_changes_total{device="lan4"} 1
node_network_carrier_up_changes_total{device="lan4"} 1
node_network_carrier_down_changes_total{device="lan4"} 0
node_network_device_id{device="lan4"} 0
node_network_dormant{device="lan4"} 0
node_network_flags{device="lan4"} 4867
node_network_iface_id{device="lan4"} 6
node_network_iface_link{device="lan4"} 2
node_network_iface_link_mode{device="lan4"} 0
node_network_mtu_bytes{device="lan4"} 1500
node_network_net_dev_group{device="lan4"} 0
node_network_transmit_queue_length{device="lan4"} 1000
node_network_protocol_type{device="lan4"} 1
node_network_speed_bytes{device="lan4"} 125000000
```

Another Totolink with a 100MBit SBC attached on lan4:
```
node_network_speed_bytes{device="br-lan"} 125000000
node_network_speed_bytes{device="wan"} 125000000
node_network_speed_bytes{device="eth0"} 125000000
node_network_speed_bytes{device="lan4"} 12500000
```

Output Archer C7:
```
node_network_info{duplex="full",broadcast="ff:ff:ff:ff:ff:ff",ifalias="",address="c4:6e:1f:81:1a:4a",device="eth1.1",operstate="up"} 1
node_network_address_assign_type{device="eth1.1"} 2
node_network_carrier{device="eth1.1"} 1
node_network_carrier_changes_total{device="eth1.1"} 0
node_network_carrier_up_changes_total{device="eth1.1"} 0
node_network_carrier_down_changes_total{device="eth1.1"} 0
node_network_device_id{device="eth1.1"} 0
node_network_dormant{device="eth1.1"} 0
node_network_flags{device="eth1.1"} 4867
node_network_iface_id{device="eth1.1"} 8
node_network_iface_link{device="eth1.1"} 3
node_network_iface_link_mode{device="eth1.1"} 0
node_network_mtu_bytes{device="eth1.1"} 1500
node_network_net_dev_group{device="eth1.1"} 0
node_network_transmit_queue_length{device="eth1.1"} 1000
node_network_protocol_type{device="eth1.1"} 1
node_network_speed_bytes{device="eth1.1"} 125000000
```

Reference output of rpi with node_exporter
```
node_network_address_assign_type{device="eth0"} 0
node_network_carrier{device="eth0"} 1
node_network_carrier_changes_total{device="eth0"} 1
node_network_carrier_down_changes_total{device="eth0"} 0
node_network_carrier_up_changes_total{device="eth0"} 1
node_network_device_id{device="eth0"} 0
node_network_dormant{device="eth0"} 0
node_network_flags{device="eth0"} 4099
node_network_iface_id{device="eth0"} 2
node_network_iface_link{device="eth0"} 2
node_network_iface_link_mode{device="eth0"} 0
node_network_info{address="dc:a6:32:f2:f3:aa",broadcast="ff:ff:ff:ff:ff:ff",device="eth0",duplex="half",ifalias="",operstate="up"} 1
node_network_mtu_bytes{device="eth0"} 1500
node_network_net_dev_group{device="eth0"} 0
node_network_protocol_type{device="eth0"} 1
node_network_speed_bytes{device="eth0"} 1.25e+07
```