### PR TITLE
pytz,evdev: bump versions

### DIFF
--- a/lang/python/python-evdev/Makefile
+++ b/lang/python/python-evdev/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=python-evdev
-PKG_VERSION:=1.4.0
-PKG_RELEASE:=1
+PKG_VERSION:=1.5.0
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_MAINTAINER:=Paulo Costa <me@paulo.costa.nom.br>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
 PYPI_NAME:=evdev
-PKG_HASH:=8782740eb1a86b187334c07feb5127d3faa0b236e113206dfe3ae8f77fb1aaf1
+PKG_HASH:=5b33b174f7c84576e7dd6071e438bf5ad227da95efd4356a39fe4c8355412fe6
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk

--- a/lang/python/python-pytz/Makefile
+++ b/lang/python/python-pytz/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pytz
-PKG_VERSION:=2021.3
+PKG_VERSION:=2022.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PYPI_NAME:=pytz
-PKG_HASH:=acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326
+PKG_HASH:=1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me, @paulo-raca (for evdev)
Compile tested: x86 https://github.com/openwrt/openwrt/commit/09f620019867365ed82a4b3d1d264f7a282f0941
Run tested: same

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>