### PR TITLE
docker-compose: Update to version 2.3.4

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.3.3
+PKG_VERSION:=2.3.4
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=bcca033859abfbb0949c4455725e5b01593f217f0b32b1d7f861c75c0b69f285
+PKG_HASH:=10657bbca710b7bfe7e17f259a4ab6cf69b890e7ac4b3bfc2444ef3086bd89cb
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream update.

What's Changed:

 - don't fail trying to remove container with no candidate by @ndeloof
 - recreate container after image has been rebuilt/pulled by @ndeloof
 - ps: un-deprecate --filter, and enhance docs by @thaJeztah
 - Bump github.com/spf13/cobra from 1.3.0 to 1.4.0 by @dependabot
 - Remove DEPRECATED text, since it's just the default by
 @ulyssessouza
 - Bump Buildx to v0.8.0 by @ndeloof
 - kill only need project name by @ndeloof
 - don't remove external volumes/networks by @ndeloof
 - use docker/cli RunExec and RunStart to handle all the
 interactive/tty/* terminal logic by @ndeloof
 - Validate doc on pr by @glours

Signed-off-by: Javier Marcet <javier@marcet.info>
