### PR TITLE
python3-paramiko: update to version 2.10.3

### DIFF
--- a/lang/python/python-paramiko/Makefile
+++ b/lang/python/python-paramiko/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-paramiko
-PKG_VERSION:=2.10.1
+PKG_VERSION:=2.10.3
 PKG_RELEASE:=1
 
 PYPI_NAME:=paramiko
-PKG_HASH:=443f4da23ec24e9a9c0ea54017829c282abdda1d57110bf229360775ccd27a31
+PKG_HASH:=ddb1977853aef82804b35d72a0e597b244fa326c404c350bd00c5b01dbfee71a
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream update.

2.10.2:

 - [Bug] Fix Python 2 compatibility breakage introduced in 2.10.1.
 Spotted by Christian Hammond.

2.10.3:

 - [Bug] Switch from module-global to thread-local storage when
 recording thread IDs for a logging helper; this should avoid one
 flavor of memory leak for long-running processes. Catch & patch via
 Richard Kojedzinszky.

 - [Bug] Certificate-based pubkey auth was inadvertently broken when
 adding SHA2 support; this has been fixed. Reported by Erik Forsberg
 and fixed by Jun Omae.

Signed-off-by: Javier Marcet <javier@marcet.info>
