### PR TITLE
gensio: Fix circular dependency error

### DIFF
--- a/net/gensio/Config.in
+++ b/net/gensio/Config.in
@@ -9,7 +9,7 @@
 		default n
 
 	config GENSIO_SCTP
-		depends on PACKAGE_libgensio
+		depends on PACKAGE_libgensio && IPV6
 		bool "Enable SCTP-support via libsctp"
 		default n
 

--- a/net/gensio/Makefile
+++ b/net/gensio/Makefile
@@ -93,7 +93,7 @@ $(call Package/gensio/Default)
   CATEGORY:=Libraries
   ABI_VERSION:=0
   MENU:=1
-  DEPENDS:=+GENSIO_SSL:libopenssl +GENSIO_WRAP:libwrap +GENSIO_SCTP:libsctp +GENSIO_PTHREADS:libpthread +GENSIO_AVAHI:libavahi-client +GENSIO_TCL:tcl +GENSIO_GLIB:glib2 +GENSIO_SSHD:libpam
+  DEPENDS:=+GENSIO_SSL:libopenssl +GENSIO_WRAP:libwrap +(IPV6&&GENSIO_SCTP):libsctp +GENSIO_PTHREADS:libpthread +GENSIO_AVAHI:libavahi-client +GENSIO_TCL:tcl +GENSIO_GLIB:glib2 +GENSIO_SSHD:libpam
 endef
 
 define Package/libgensio/description


### PR DESCRIPTION
Adding libsctp adds IPV6 dependency to gensio, so this patch is
an attempt at working around that with the goal of getting rid of
the circular dependency error.

Signed-off-by: Nita Vesa <werecatf@outlook.com>