### PR TITLE
libuv: bump to v1.44.1

### DIFF
--- a/libs/libuv/Makefile
+++ b/libs/libuv/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuv
-PKG_VERSION:=1.41.1
+PKG_VERSION:=1.44.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://dist.libuv.org/dist/v$(PKG_VERSION)/
-PKG_HASH:=65db0c7f2438bc8cd48865de282bf6670027f3557d6e3cb62fb65b2e350a687d
+PKG_HASH:=9d37b63430fe3b92a9386b949bebd8f0b4784a39a16964c82c9566247a76f64a
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
-PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
+PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:libuv_project:libuv


### PR DESCRIPTION
Changes:
* bumped version to 1.44.1
* bumped maintainer email

Signed-off-by: Marko Ratkaj <markoratkaj@gmail.com>

Maintainer: me / markoratkaj@gmail.com / \<@ratkaj>
Compile tested: bcm27xx, RPi3, OpenWrt master
Run tested: bcm27xx, RPi3, OpenWrt master

Description:
Simple package bump and update to my email
