### PR TITLE
dhcpcd: bump to 9.4.1

### DIFF
--- a/net/dhcpcd/Makefile
+++ b/net/dhcpcd/Makefile
@@ -8,19 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dhcpcd
-PKG_VERSION:=7.2.2
+PKG_VERSION:=9.4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=ftp://roy.marples.name/pub/dhcpcd \
     http://roy.marples.name/downloads/dhcpcd
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=3db7ff18cba9274da1d2176fb3c7cbe23926a8e58d5c8e244ad55c62d38ba09e
+PKG_HASH:=819357634efed1ea5cf44ec01b24d3d3f8852fec8b4249925dcc5667c54e376c
 
 PKG_LICENSE:=BSD-2c
 PKG_LICENSE_FILES:=
 PKG_CPE_ID:=cpe:/a:roy_marples:dhcpcd
 
-PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
+PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1


### PR DESCRIPTION
Changes:
* version bump to 9.4.1
* maintainer mail update

Signed-off-by: Marko Ratkaj <markoratkaj@gmail.com>

Maintainer: me / markoratkaj@gmail.com / <@ratkaj>
Compile tested: bcm27xx, RPi3, OpenWrt master
Run tested: bcm27xx, RPi3, OpenWrt master

Description:
Simple version bump and maintainer mail update. Work fine
