### PR TITLE
yara: bump to 4.2.0

### DIFF
--- a/utils/yara/Makefile
+++ b/utils/yara/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yara
-PKG_VERSION:=4.1.3
+PKG_VERSION:=4.2.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/VirusTotal/yara/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=3610ddd0c3645b8b9cfa7cfbafc0146f2df751ad8d6cd261a638bfff81efbc32
+PKG_HASH:=6f567d4e4b79a210cd57a820f59f19ee69b024188ef4645b1fc11488a4660951
 
-PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
+PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:virustotal:yara


### PR DESCRIPTION
Signed-off-by: Marko Ratkaj <markoratkaj@gmail.com>

Maintainer: me / markoratkaj@gmail.com / <@ratkaj>
Compile tested: bcm27xx, RPi3, OpenWrt master
Run tested: bcm27xx, RPi3, OpenWrt master

Description:
Simple bump and maintainer email update
Tested and working fine
