### PR TITLE
squid: bump to 4.17

### DIFF
--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squid
-PKG_VERSION:=4.16
+PKG_VERSION:=4.17
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www2.pl.squid-cache.org/Versions/v4/ \
 	http://www.squid-cache.org/Versions/v4/
-PKG_HASH:=7e00e891757c1c02dae546c9898f440c6031b684d8c243d6edab529076e3ba63
+PKG_HASH:=cb928ac08c7c86b151b1c8f827abe1a84d83181a2a86e0d512286163e1e31418
 
-PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
+PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_CPE_ID:=cpe:/a:squid-cache:squid
 


### PR DESCRIPTION
Signed-off-by: Marko Ratkaj <markoratkaj@gmail.com>

Maintainer: me / markoratkaj@gmail.com / <@ratkaj>
Compile tested: bcm27xx, RPi3, OpenWrt master
Run tested: bcm27xx, RPi3, OpenWrt master

Description:
Simple version bump and update to maintainer email. Working fine on my test machine and not a big change from 4.16 so not expecting any additional issues.

Changes from 4.16:
* WCCP: Validate packets better
Update WCCP to support exception based error handling for
parsing and processing we are moving Squid to for protocol
handling.
