### PR TITLE
powertop: add gettext-version fixup

### DIFF
--- a/utils/powertop/Makefile
+++ b/utils/powertop/Makefile
@@ -20,7 +20,7 @@ PKG_MAINTAINER:=Lucian Cristain <lucian.cristian@gmail.com>
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=COPYING
 
-PKG_FIXUP:=autoreconf
+PKG_FIXUP:=autoreconf gettext-version
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=gettext-full/host


### PR DESCRIPTION
I hit this locally on Fedora 35 for some reason.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 