### PR TITLE
ptunnel-ng: fix compilation with kernel 5.15

### DIFF
--- a/net/ptunnel-ng/Makefile
+++ b/net/ptunnel-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ptunnel-ng
 PKG_VERSION:=1.42
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/lnslbrty/ptunnel-ng/tar.gz/v$(PKG_VERSION)?

--- a/net/ptunnel-ng/patches/010-musl.patch
+++ b/net/ptunnel-ng/patches/010-musl.patch
@@ -1,0 +1,22 @@
+--- a/src/ptunnel.h
++++ b/src/ptunnel.h
+@@ -45,9 +45,6 @@
+ #define PING_TUNNEL_H 1
+ 
+ #ifndef WIN32
+-#ifdef HAVE_ICMPFILTER
+-#include <linux/icmp.h>
+-#endif
+ #ifdef HAVE_SYS_UNISTD_H
+ #include <sys/unistd.h>
+ #endif
+@@ -56,6 +53,9 @@
+ #include <netinet/in.h>
+ #include <arpa/inet.h>
+ #include <netdb.h>
++#ifdef HAVE_ICMPFILTER
++#include <linux/icmp.h>
++#endif
+ #include <pthread.h>
+ #include <errno.h>
+ #include <net/ethernet.h>


### PR DESCRIPTION
Some header change requires to include musl's headers first.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lnslbrty 