### PR TITLE
clamav: update maintainer email

### DIFF
--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -15,7 +15,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.clamav.net/downloads/production/
 PKG_HASH:=3e45e46d9aaeb3a6956ed30376237ab7c4cd9573bc0f5d6fc15c588d30978d9d
 
-PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr> \
+PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com> \
 		Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=COPYING*


### PR DESCRIPTION
Signed-off-by: Marko Ratkaj <markoratkaj@gmail.com>

Maintainer: me / markoratkaj@gmail.com / <@ratkaj>
Compile tested: bcm27xx, RPi3, OpenWrt master
Run tested: bcm27xx, RPi3, OpenWrt master

Description:
No longer associated with Sartura, old mail is inactive so switching to private email.
Sry for spamming pull requests, will merge once checks pass..

