### PR TITLE
python-dotenv: update to v0.20.0

### DIFF
--- a/lang/python/python-dotenv/Makefile
+++ b/lang/python/python-dotenv/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dotenv
-PKG_VERSION:=0.19.2
+PKG_VERSION:=0.20.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=python-dotenv
-PKG_HASH:=a5de49a31e953b45ff2d2fd434bbc2670e8db5273606c1e737cc6b93eff3655f
+PKG_HASH:=b7e3b04a59693c42c36f9ab1cc2acc46fa5df8c78e178fc33a8d4cd05c8d498f
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream update

Added:

 - Add encoding (Optional[str]) parameter to get_key, set_key and
 unset_key. (by @bbc2)

Fixed:

 - Use dict to specify the entry_points parameter of setuptools.setup
 (by @mgorny).
 - Don't build universal wheels (by @bbc2).

Signed-off-by: Javier Marcet <javier@marcet.info>
