### PR TITLE
prometheus-node-exporter-lua: add node_hwmon_temp_celsius metric

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -44,7 +44,7 @@ define Package/prometheus-node-exporter-lua/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/time.lua        $(1)/usr/lib/lua/prometheus-collectors/
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/uname.lua       $(1)/usr/lib/lua/prometheus-collectors/
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/netclass.lua    $(1)/usr/lib/lua/prometheus-collectors/
-  $(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/hwmon.lua       $(1)/usr/lib/lua/prometheus-collectors/
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/hwmon.lua       $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
 define Package/prometheus-node-exporter-lua/conffiles

--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2022.03.28
+PKG_VERSION:=2022.03.31
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
@@ -44,6 +44,7 @@ define Package/prometheus-node-exporter-lua/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/time.lua        $(1)/usr/lib/lua/prometheus-collectors/
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/uname.lua       $(1)/usr/lib/lua/prometheus-collectors/
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/netclass.lua    $(1)/usr/lib/lua/prometheus-collectors/
+  $(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/hwmon.lua       $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
 define Package/prometheus-node-exporter-lua/conffiles

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/hwmon.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/hwmon.lua
@@ -1,0 +1,15 @@
+local fs = require "nixio.fs"
+
+local function scrape()
+  local temp_metric = metric("node_hwmon_temp_celsius", "gauge")
+  for dir in fs.glob("/sys/class/thermal/thermal_zone0/hwmon*") do
+    for file in fs.glob(string.format("%s/temp*_input", dir)) do
+      local chip = get_contents(string.format("%s/name", dir)):gsub("%s+", "")
+      local sensor = string.match(file,"(temp%d)")
+      local temp = get_contents(file) / 1000.0
+      temp_metric({chip=chip, sensor=sensor}, temp)
+    end
+  end
+end
+
+return { scrape = scrape }


### PR DESCRIPTION
Maintainer: @mweinelt 
Compile tested: TODO
Run tested: OpenWrt R21.11.11 on FriendlyElec NanoPi R2S

Description:
add `node_hwmon_temp_celsius` metric, the value can be found from `/sys/class/thermal/thermal_zone0/hwmon*/temp*_input`, chip name from `/sys/class/thermal/thermal_zone0/hwmon*/name`, sensor is `temp*`.

Output:
```
# TYPE node_hwmon_temp_celsius gauge
node_hwmon_temp_celsius{sensor="temp1",chip="soc_thermal"} 45.454
node_scrape_collector_duration_seconds{collector="hwmon"} 0.00026392936706543
node_scrape_collector_success{collector="hwmon"} 1
```