### PR TITLE
procps-ng: add missing InstallDev section

### DIFF
--- a/utils/procps-ng/Makefile
+++ b/utils/procps-ng/Makefile
@@ -96,6 +96,12 @@ define Package/procps-ng/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libprocps.so* $(1)/usr/lib/
 endef
 
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
+endef
+
 define BuildPlugin
   define Package/procps-ng-$(1)/install
 	$(INSTALL_DIR) $$(1)/usr/libexec


### PR DESCRIPTION
This package seems to be missing an InstallDev section. Had a compile
failure for an application that needs to compile against libprocps

Signed-off-by: Marko Ratkaj <markoratkaj@gmail.com>

<@ratkaj>

Compile tested: bcm27xx & ipq40xx, OpenWrt master & 21.02
Run tested: bcm27xx & ipq40xx, OpenWrt master & 21.02

Description:
Preparing to opensource a major component. It needs to compile against libprocps so this is a first step.
