### PR TITLE
tor: bump to 0.4.6.10 stable

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.6.9
+PKG_VERSION:=0.4.6.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=c7e93380988ce20b82aa19c06cdb2f10302b72cfebec7c15b5b96bcfc94ca9a9
+PKG_HASH:=94ccd60e04e558f33be73032bc84ea241660f92f58cfb88789bda6893739e31c
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @tripolar

Run-tested:
tor-basic (mvebu/cortexa9, Turris Omnia)

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>