### PR TITLE
xtables-addons: update to 3.19

### DIFF
--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -9,9 +9,9 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=xtables-addons
-PKG_VERSION:=3.13
-PKG_RELEASE:=4
-PKG_HASH:=893c0c4ea09759cda1ab7e68f1281d125e59270f7b59e446204ce686c6a76d65
+PKG_VERSION:=3.19
+PKG_RELEASE:=$(AUTORELEASE)
+PKG_HASH:=5e36ea027ab15a84d9af1f3f8e84a78b80a617093657f08089bd44657722f661
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://inai.de/files/xtables-addons/
@@ -162,7 +162,7 @@ define Package/iptgeoip/install
 		$(1)/usr/lib/xtables-addons/
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/bin/xt_geoip_fetch \
+		$(PKG_INSTALL_DIR)/usr/bin/xt_geoip_query \
 		$(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/usr/share/xt_geoip
 	touch $(1)/usr/share/xt_geoip/.keep

--- a/net/xtables-addons/patches/001-fix-kernel-version-detection.patch
+++ b/net/xtables-addons/patches/001-fix-kernel-version-detection.patch
@@ -1,8 +1,8 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -44,7 +44,7 @@ regular_CFLAGS="-Wall -Waggregate-return
+@@ -42,7 +42,7 @@ regular_CFLAGS="-Wall -Waggregate-return
  
- if test -n "$kbuilddir"; then
+ AS_IF([test -n "$kbuilddir"], [
  	AC_MSG_CHECKING([kernel version that we will build against])
 -	krel="$(make -sC "$kbuilddir" M=$PWD kernelrelease | $AWK -v 'FS=[[^0-9.]]' '{print $1; exit}')"
 +	krel="$(make -sC "$kbuilddir" M=$PWD kernelversion | $AWK -v 'FS=[[^0-9.]]' '{print $1; exit}')"

--- a/net/xtables-addons/patches/200-add-lua-packetscript.patch
+++ b/net/xtables-addons/patches/200-add-lua-packetscript.patch
@@ -1137,7 +1137,7 @@
 +	struct xt_lua_tginfo *info = (void *)target->data;
 +
 +	info->state_id = 0;
-+	strncpy(info->function, "process_packet\0", sizeof("process_packet\0"));
++	strcpy(info->function, "process_packet\0");
 +}
 +
 +static int
@@ -5301,7 +5301,7 @@
 +      case OP_FORLOOP:
 +      case OP_FORPREP:
 +        checkreg(pt, a+3);
-+        /* go through */
++        fallthrough;
 +      case OP_JMP: {
 +        int dest = pc+1+b;
 +        /* not full check and jump is forward and do not skip `lastpc'? */
@@ -7716,6 +7716,7 @@
 +        }
 +        else if (sep == -1) return '[';
 +        else luaX_lexerror(ls, "invalid long string delimiter", TK_STRING);
++        fallthrough;
 +      }
 +      case '=': {
 +        next(ls);
@@ -7809,7 +7810,6 @@
 +  lua_assert(ls->lookahead.token == TK_EOS);
 +  ls->lookahead.token = llex(ls, &ls->lookahead.seminfo);
 +}
-+
 --- /dev/null
 +++ b/extensions/LUA/lua/llex.h
 @@ -0,0 +1,81 @@
@@ -12471,7 +12471,7 @@
 +      lua_number2int(k, n);
 +      if (luai_numeq(cast_num(k), nvalue(key))) /* index is int? */
 +        return luaH_getnum(t, k);  /* use specialized version */
-+      /* else go through */
++      fallthrough;
 +    }
 +    default: {
 +      Node *n = mainposition(t, key);
@@ -12766,7 +12766,7 @@
 +  if (!lua_isstring(L, -1))
 +    luaL_error(L, "invalid value (%s) at index %d in table for "
 +                  LUA_QL("concat"), luaL_typename(L, -1), i);
-+    luaL_addvalue(b);
++  luaL_addvalue(b);
 +}
 +
 +
@@ -17984,7 +17984,7 @@
 +	int32_t ret;
 +	struct lua_env * env = kmalloc(sizeof(struct lua_env), GFP_KERNEL);
 +
-+	if (!script_size > 0) {
++	if (!script_size) {
 +		pr_debug("LUA [%d]: script_size %lu < 0\n", state_id, script_size);
 +		return false;
 +	}


### PR DESCRIPTION
Fixes compilation with kernel 5.15.

Fixed changed binary name.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jow- 
Compile tested: mips64

There's no way this works properly with musl 1.2.0 and big endian. musl headers are leaking and definiing LITTLE_ENDIAN

```
mangix@ryzen ~/d/openwrt (mangix) [1]> rg _ENDIAN build_dir/target-mips64_mips64r2_64_musl/linux-malta_be64/xtables-addons-3.19/
build_dir/target-mips64_mips64r2_64_musl/linux-malta_be64/xtables-addons-3.19/extensions/libxt_geoip.c
52:#if __BYTE_ORDER == __LITTLE_ENDIAN
78:#if __BYTE_ORDER == __LITTLE_ENDIAN
116:#if __BYTE_ORDER == __LITTLE_ENDIAN

```