### PR TITLE
docker-compose: Update to version 2.4.0

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.3.4
+PKG_VERSION:=2.4.0
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=10657bbca710b7bfe7e17f259a4ab6cf69b890e7ac4b3bfc2444ef3086bd89cb
+PKG_HASH:=b0507aed3b86900f5199309dcfb8b2d4081d94e8ec045eec2bada8280dc9901b
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream update

What's Changed:

 - pass interactive flag to ExecOptions for the RunExec command by
 @glours
 - go.mod: pin k8s version to fix build on go1.16, and update buildx
 to v0.8.1 by @thaJeztah
 - support cache_from|to|no|pull by @ndeloof
 - fix race condition on start-stop e2e tests running in parrallel by
 @glours
 - Add support of ssh authentications defined in compose file or via
 cli… by @glours
 - fix typo in ssh option description by @mschoettle
 - Takes COMPOSE_PROJECT_NAME into consideration on commands by
 @ulyssessouza
 - Remove dead warning code by @ulyssessouza
 - Fix down command without any resource to delete by @ulyssessouza
 - vendor: github.com/containerd/containerd v1.6.2 by @thaJeztah

New Contributors:

 - @mschoettle made their first contribution

Signed-off-by: Javier Marcet <javier@marcet.info>