### PR TITLE
node: Major update from v14 to v16

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v14.18.3
+PKG_VERSION:=v16.14.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=783ac443cd343dd6c68d2abcf7e59e7b978a6a428f6a6025f9b84918b769d608
+PKG_HASH:=e922e215cc68eb5f94d33e8a0b61e2c863b7731cc8600ab955d3822da90ff8d1
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT
@@ -48,7 +48,7 @@ define Package/node/description
   an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js'
    package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
   *** The following preparations must be made on the host side. ***
-      1. gcc 6.3 or higher is required.
+      1. gcc 8.3 or higher is required.
       2. To build a 32-bit target, gcc-multilib, g++-multilib are required.
       3. Requires libatomic package. (If necessary, install the 32-bit library at the same time.)
      ex) sudo apt-get install gcc-multilib g++-multilib
@@ -141,10 +141,11 @@ define Package/node/install
 endef
 
 define Package/node-npm/install
+	$(RM) $(1)/usr/lib/node_modules/npm
 	$(INSTALL_DIR) $(1)/usr/lib/node_modules/npm
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/npm/{package.json,LICENSE} \
 		$(1)/usr/lib/node_modules/npm/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/npm/{AUTHORS,*.md} \
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/npm/README.md \
 		$(1)/usr/lib/node_modules/npm/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/npm/{node_modules,bin,lib} \
 		$(1)/usr/lib/node_modules/npm/

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,12 +1,12 @@
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1202,7 +1202,8 @@ Module._initPaths = function() {
+@@ -1238,7 +1238,8 @@ Module._initPaths = function() {
      path.resolve(process.execPath, '..') :
      path.resolve(process.execPath, '..', '..');
  
--  let paths = [path.resolve(prefixDir, 'lib', 'node')];
-+  let paths = [path.resolve(prefixDir, 'lib', 'node'),
-+               path.resolve(prefixDir, 'lib', 'node_modules')];
+-  const paths = [path.resolve(prefixDir, 'lib', 'node')];
++  const paths = [path.resolve(prefixDir, 'lib', 'node'),
++                 path.resolve(prefixDir, 'lib', 'node_modules')];
  
    if (homeDir) {
      ArrayPrototypeUnshift(paths, path.resolve(homeDir, '.node_libraries'));

--- a/lang/node/patches/004-musl_support.patch
+++ b/lang/node/patches/004-musl_support.patch
@@ -1,6 +1,6 @@
 --- a/deps/v8/src/base/platform/condition-variable.cc
 +++ b/deps/v8/src/base/platform/condition-variable.cc
-@@ -16,7 +16,7 @@ namespace base {
+@@ -20,7 +20,7 @@ namespace base {
  
  ConditionVariable::ConditionVariable() {
  #if (V8_OS_FREEBSD || V8_OS_NETBSD || V8_OS_OPENBSD || \
@@ -9,7 +9,7 @@
    // On Free/Net/OpenBSD and Linux with glibc we can change the time
    // source for pthread_cond_timedwait() to use the monotonic clock.
    pthread_condattr_t attr;
-@@ -92,7 +92,7 @@ bool ConditionVariable::WaitFor(Mutex* m
+@@ -96,7 +96,7 @@ bool ConditionVariable::WaitFor(Mutex* m
        &native_handle_, &mutex->native_handle(), &ts);
  #else
  #if (V8_OS_FREEBSD || V8_OS_NETBSD || V8_OS_OPENBSD || \
@@ -20,7 +20,7 @@
    result = clock_gettime(CLOCK_MONOTONIC, &ts);
 --- a/deps/v8/src/base/platform/platform-posix.cc
 +++ b/deps/v8/src/base/platform/platform-posix.cc
-@@ -839,7 +839,7 @@ bool Thread::Start() {
+@@ -883,7 +883,7 @@ bool Thread::Start() {
  #if V8_OS_MACOSX
      // Default on Mac OS X is 512kB -- bump up to 1MB
      stack_size = 1 * 1024 * 1024;
@@ -31,7 +31,7 @@
  #endif
 --- a/deps/v8/src/codegen/external-reference-table.cc
 +++ b/deps/v8/src/codegen/external-reference-table.cc
-@@ -9,7 +9,7 @@
+@@ -10,7 +10,7 @@
  #include "src/ic/stub-cache.h"
  #include "src/logging/counters.h"
  
@@ -39,4 +39,4 @@
 +#if defined(DEBUG) && defined(V8_OS_LINUX) && !defined(V8_OS_ANDROID) && defined(V8_LIBC_GLIBC)
  #define SYMBOLIZE_FUNCTION
  #include <execinfo.h>
- #include <vector>
+ 

--- a/lang/node/patches/007-fix_host_build_on_macos.patch
+++ b/lang/node/patches/007-fix_host_build_on_macos.patch
@@ -1,6 +1,6 @@
 --- a/tools/gyp/pylib/gyp/generator/make.py
 +++ b/tools/gyp/pylib/gyp/generator/make.py
-@@ -180,7 +180,7 @@ cmd_solink_module = $(LINK.$(TOOLSET)) -
+@@ -179,7 +179,7 @@ cmd_solink_module = $(LINK.$(TOOLSET)) -
  
  LINK_COMMANDS_MAC = """\
  quiet_cmd_alink = LIBTOOL-STATIC $@

--- a/lang/node/patches/010-execvp-arg-list-too-long.patch
+++ b/lang/node/patches/010-execvp-arg-list-too-long.patch
@@ -1,0 +1,236 @@
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/make.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/make.py
+@@ -154,6 +154,32 @@ cmd_alink_thin = rm -f $@ && $(AR.$(TOOL
+ quiet_cmd_link = LINK($(TOOLSET)) $@
+ cmd_link = $(LINK.$(TOOLSET)) -o $@ $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -Wl,--start-group $(LD_INPUTS) $(LIBS) -Wl,--end-group
+ 
++define xargs
++        $(1) $(wordlist 1,100,$(2))
++        $(if $(word 101,$(2)),$(call xargs,$(1),$(wordlist 101,$(words $(2)),$(2))))
++endef
++
++define write-to-file
++        @echo >$(1)
++        $(call xargs,printf "%s\\n" >>$(1),$(2))
++endef
++
++OBJ_FILE_LIST_SFX := ar-file-list
++
++define create_archive
++        $(eval OBJ_FILE_LIST := $(basename $(notdir $(1))).$(OBJ_FILE_LIST_SFX))
++        rm -f $(1) $(1).$(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crs $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
++define create_thin_archive
++        $(eval OBJ_FILE_LIST := $(basename $(notdir $(1))).$(OBJ_FILE_LIST_SFX))
++        rm -f $(1) $(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crsT $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
+ # We support two kinds of shared objects (.so):
+ # 1) shared_library, which is just bundling together many dependent libraries
+ # into a link line.
+@@ -198,6 +224,32 @@ cmd_alink = rm -f $@ && $(AR.$(TOOLSET))
+ quiet_cmd_alink_thin = AR($(TOOLSET)) $@
+ cmd_alink_thin = rm -f $@ && $(AR.$(TOOLSET)) crsT $@ $(filter %.o,$^)
+ 
++define xargs
++        $(1) $(wordlist 1,100,$(2))
++        $(if $(word 101,$(2)),$(call xargs,$(1),$(wordlist 101,$(words $(2)),$(2))))
++endef
++
++define write-to-file
++        @echo >$(1)
++        $(call xargs,printf "%s\\n" >>$(1),$(2))
++endef
++
++OBJ_FILE_LIST_SFX := ar-file-list
++
++define create_archive
++        $(eval OBJ_FILE_LIST := $(basename $(notdir $(1))).$(OBJ_FILE_LIST_SFX))
++        rm -f $(1) $(1).$(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crs $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
++define create_thin_archive
++        $(eval OBJ_FILE_LIST := $(basename $(notdir $(1))).$(OBJ_FILE_LIST_SFX))
++        rm -f $(1) $(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crsT $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
+ # Due to circular dependencies between libraries :(, we wrap the
+ # special "figure out circular dependencies" flags around the entire
+ # input list during linking.
+@@ -1768,21 +1820,35 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)
+                 self.flavor not in ("mac", "openbsd", "netbsd", "win")
+                 and not self.is_standalone_static_library
+             ):
+-                self.WriteDoCmd(
+-                    [self.output_binary],
+-                    link_deps,
+-                    "alink_thin",
+-                    part_of_all,
+-                    postbuilds=postbuilds,
+-                )
++                if self.flavor in ('linux', 'android'):
++                    self.WriteMakeRule(
++                        [self.output_binary],
++                        link_deps,
++                        actions = ['$(call create_thin_archive,$@,$^)']
++                    )
++                else:
++                    self.WriteDoCmd(
++                        [self.output_binary],
++                        link_deps,
++                        "alink_thin",
++                        part_of_all,
++                        postbuilds=postbuilds,
++                    )
+             else:
+-                self.WriteDoCmd(
+-                    [self.output_binary],
+-                    link_deps,
+-                    "alink",
+-                    part_of_all,
+-                    postbuilds=postbuilds,
+-                )
++                if self.flavor in ('linux', 'android'):
++                    self.WriteMakeRule(
++                        [self.output_binary],
++                        link_deps,
++                        actions = ['$(call create_archive,$@,$^)']
++                    )
++                else:
++                    self.WriteDoCmd(
++                        [self.output_binary],
++                        link_deps,
++                        "alink",
++                        part_of_all,
++                        postbuilds=postbuilds,
++                    )
+         elif self.type == "shared_library":
+             self.WriteLn(
+                 "%s: LD_INPUTS := %s"
+--- a/tools/gyp/pylib/gyp/generator/make.py
++++ b/tools/gyp/pylib/gyp/generator/make.py
+@@ -154,6 +154,32 @@ cmd_alink_thin = rm -f $@ && $(AR.$(TOOL
+ quiet_cmd_link = LINK($(TOOLSET)) $@
+ cmd_link = $(LINK.$(TOOLSET)) -o $@ $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -Wl,--start-group $(LD_INPUTS) $(LIBS) -Wl,--end-group
+ 
++define xargs
++        $(1) $(wordlist 1,100,$(2))
++        $(if $(word 101,$(2)),$(call xargs,$(1),$(wordlist 101,$(words $(2)),$(2))))
++endef
++
++define write-to-file
++        @echo >$(1)
++        $(call xargs,printf "%s\\n" >>$(1),$(2))
++endef
++
++OBJ_FILE_LIST_SFX := ar-file-list
++
++define create_archive
++        $(eval OBJ_FILE_LIST := $(basename $(notdir $(1))).$(OBJ_FILE_LIST_SFX))
++        rm -f $(1) $(1).$(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crs $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
++define create_thin_archive
++        $(eval OBJ_FILE_LIST := $(basename $(notdir $(1))).$(OBJ_FILE_LIST_SFX))
++        rm -f $(1) $(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crsT $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
+ # We support two kinds of shared objects (.so):
+ # 1) shared_library, which is just bundling together many dependent libraries
+ # into a link line.
+@@ -198,6 +224,32 @@ cmd_alink = rm -f $@ && $(AR.$(TOOLSET))
+ quiet_cmd_alink_thin = AR($(TOOLSET)) $@
+ cmd_alink_thin = rm -f $@ && $(AR.$(TOOLSET)) crsT $@ $(filter %.o,$^)
+ 
++define xargs
++        $(1) $(wordlist 1,100,$(2))
++        $(if $(word 101,$(2)),$(call xargs,$(1),$(wordlist 101,$(words $(2)),$(2))))
++endef
++
++define write-to-file
++        @echo >$(1)
++        $(call xargs,printf "%s\\n" >>$(1),$(2))
++endef
++
++OBJ_FILE_LIST_SFX := ar-file-list
++
++define create_archive
++        $(eval OBJ_FILE_LIST := $(basename $(notdir $(1))).$(OBJ_FILE_LIST_SFX))
++        rm -f $(1) $(1).$(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crs $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
++define create_thin_archive
++        $(eval OBJ_FILE_LIST := $(basename $(notdir $(1))).$(OBJ_FILE_LIST_SFX))
++        rm -f $(1) $(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crsT $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
+ # Due to circular dependencies between libraries :(, we wrap the
+ # special "figure out circular dependencies" flags around the entire
+ # input list during linking.
+@@ -1768,21 +1820,35 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)
+                 self.flavor not in ("mac", "openbsd", "netbsd", "win")
+                 and not self.is_standalone_static_library
+             ):
+-                self.WriteDoCmd(
+-                    [self.output_binary],
+-                    link_deps,
+-                    "alink_thin",
+-                    part_of_all,
+-                    postbuilds=postbuilds,
+-                )
++                if self.flavor in ('linux', 'android'):
++                    self.WriteMakeRule(
++                        [self.output_binary],
++                        link_deps,
++                        actions = ['$(call create_thin_archive,$@,$^)']
++                    )
++                else:
++                    self.WriteDoCmd(
++                        [self.output_binary],
++                        link_deps,
++                        'alink_thin',
++                        part_of_all,
++                        postbuilds=postbuilds
++                    )
+             else:
+-                self.WriteDoCmd(
+-                    [self.output_binary],
+-                    link_deps,
+-                    "alink",
+-                    part_of_all,
+-                    postbuilds=postbuilds,
+-                )
++                if self.flavor in ('linux', 'android'):
++                    self.WriteMakeRule(
++                        [self.output_binary],
++                        link_deps,
++                        actions = ['$(call create_archive,$@,$^)']
++                    )
++                else:
++                    self.WriteDoCmd(
++                        [self.output_binary],
++                        link_deps,
++                        'alink',
++                        part_of_all,
++                        postbuilds=postbuilds
++                    )
+         elif self.type == "shared_library":
+             self.WriteLn(
+                 "%s: LD_INPUTS := %s"

--- a/lang/node/patches/999-cast_for_mips32.patch
+++ b/lang/node/patches/999-cast_for_mips32.patch
@@ -1,0 +1,11 @@
+--- a/deps/v8/src/compiler/backend/mips/code-generator-mips.cc
++++ b/deps/v8/src/compiler/backend/mips/code-generator-mips.cc
+@@ -4230,7 +4230,7 @@ void CodeGenerator::AssembleReturn(Instr
+     } else if (FLAG_debug_code) {
+       __ Assert(eq, AbortReason::kUnexpectedAdditionalPopValue,
+                 g.ToRegister(additional_pop_count),
+-                Operand(static_cast<int64_t>(0)));
++                Operand(static_cast<int32_t>(0)));
+     }
+   }
+   // Functions with JS linkage have at least one parameter (the receiver).

--- a/lang/node/patches/999-delete_unnecessary_libraries_for_host_execute.patch
+++ b/lang/node/patches/999-delete_unnecessary_libraries_for_host_execute.patch
@@ -34,7 +34,7 @@
          '<@(icu_src_genccode)',
 --- a/tools/v8_gypfiles/v8.gyp
 +++ b/tools/v8_gypfiles/v8.gyp
-@@ -1310,6 +1310,7 @@
+@@ -1408,6 +1408,7 @@
      {
        'target_name': 'bytecode_builtins_list_generator',
        'type': 'executable',
@@ -42,7 +42,7 @@
        'conditions': [
          ['want_separate_host_toolset', {
            'toolsets': ['host'],
-@@ -1333,6 +1334,8 @@
+@@ -1432,6 +1433,8 @@
      {
        'target_name': 'mksnapshot',
        'type': 'executable',
@@ -51,7 +51,7 @@
        'dependencies': [
          'v8_base_without_compiler',
          'v8_compiler_for_mksnapshot',
-@@ -1354,6 +1357,7 @@
+@@ -1453,6 +1456,7 @@
      {
        'target_name': 'torque',
        'type': 'executable',
@@ -59,7 +59,7 @@
        'dependencies': [
          'torque_base',
          # "build/win:default_exe_manifest",
-@@ -1392,6 +1396,7 @@
+@@ -1491,6 +1495,7 @@
      {
        'target_name': 'torque-language-server',
        'type': 'executable',
@@ -67,7 +67,7 @@
        'conditions': [
          ['want_separate_host_toolset', {
            'toolsets': ['host'],
-@@ -1419,6 +1424,8 @@
+@@ -1518,6 +1523,8 @@
      {
        'target_name': 'gen-regexp-special-case',
        'type': 'executable',

--- a/lang/node/patches/999-deps-v8-src-trap-handler-trap-handler.h.patch
+++ b/lang/node/patches/999-deps-v8-src-trap-handler-trap-handler.h.patch
@@ -1,0 +1,29 @@
+--- a/deps/v8/src/trap-handler/trap-handler.h
++++ b/deps/v8/src/trap-handler/trap-handler.h
+@@ -17,19 +17,16 @@ namespace v8 {
+ namespace internal {
+ namespace trap_handler {
+ 
+-// X64 on Linux, Windows, MacOS, FreeBSD.
+-#if V8_HOST_ARCH_X64 && V8_TARGET_ARCH_X64 &&                        \
+-    ((V8_OS_LINUX && !V8_OS_ANDROID) || V8_OS_WIN || V8_OS_MACOSX || \
+-     V8_OS_FREEBSD)
++#if V8_TARGET_ARCH_X64 && V8_OS_LINUX && !V8_OS_ANDROID
+ #define V8_TRAP_HANDLER_SUPPORTED true
+-// Arm64 (non-simulator) on Mac.
+-#elif V8_TARGET_ARCH_ARM64 && V8_HOST_ARCH_ARM64 && V8_OS_MACOSX
++#elif V8_TARGET_ARCH_X64 && V8_OS_WIN
+ #define V8_TRAP_HANDLER_SUPPORTED true
+-// Arm64 simulator on x64 on Linux or Mac.
+-#elif V8_TARGET_ARCH_ARM64 && V8_HOST_ARCH_X64 && (V8_OS_LINUX || V8_OS_MACOSX)
+-#define V8_TRAP_HANDLER_VIA_SIMULATOR
++#elif V8_TARGET_ARCH_X64 && V8_OS_MACOSX
++#define V8_TRAP_HANDLER_SUPPORTED true
++#elif V8_TARGET_ARCH_X64 && V8_OS_FREEBSD
++#define V8_TRAP_HANDLER_SUPPORTED true
++#elif V8_HOST_ARCH_ARM64 && V8_TARGET_ARCH_ARM64 && V8_OS_MACOSX
+ #define V8_TRAP_HANDLER_SUPPORTED true
+-// Everything else is unsupported.
+ #else
+ #define V8_TRAP_HANDLER_SUPPORTED false
+ #endif

--- a/lang/node/patches/999-localhost-no-addrconfig.patch
+++ b/lang/node/patches/999-localhost-no-addrconfig.patch
@@ -13,7 +13,7 @@ Forwarded: https://github.com/nodejs/node/issues/33816
  //
  // Permission is hereby granted, free of charge, to any person obtaining a
  // copy of this software and associated documentation files (the
-@@ -1039,13 +1040,6 @@ function lookupAndConnect(self, options)
+@@ -1037,13 +1038,6 @@ function lookupAndConnect(self, options)
      hints: options.hints || 0
    };
  

--- a/lang/node/patches/999-v8_zlib_support.patch
+++ b/lang/node/patches/999-v8_zlib_support.patch
@@ -1,0 +1,97 @@
+--- a/deps/zlib/zlib.gyp
++++ b/deps/zlib/zlib.gyp
+@@ -43,10 +43,12 @@
+             'zutil.c',
+             'zutil.h',
+           ],
++          'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+           'include_dirs': [
+             '.',
+           ],
+           'direct_dependent_settings': {
++            'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+             'include_dirs': [
+               '.',
+             ],
+--- a/tools/v8_gypfiles/v8.gyp
++++ b/tools/v8_gypfiles/v8.gyp
+@@ -60,6 +60,7 @@
+       ],
+       'hard_dependency': 1,
+       'direct_dependent_settings': {
++        'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+         'include_dirs': [
+           '<(SHARED_INTERMEDIATE_DIR)',
+         ],
+@@ -195,6 +196,7 @@
+           '<@(torque_outputs_cc)',
+           '<@(torque_outputs_inc)',
+         ],
++        'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+         'include_dirs': [
+           '<(SHARED_INTERMEDIATE_DIR)',
+         ],
+@@ -216,6 +218,7 @@
+         'sources': [
+           '<(generate_bytecode_builtins_list_output)',
+         ],
++        'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+         'include_dirs': [
+           '<(generate_bytecode_output_root)',
+           '<(SHARED_INTERMEDIATE_DIR)',
+@@ -266,9 +269,11 @@
+         'v8_base_without_compiler',
+         'v8_shared_internal_headers',
+       ],
++      'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+       'include_dirs': [
+         '<(SHARED_INTERMEDIATE_DIR)',
+         '<(generate_bytecode_output_root)',
++        '<!@(echo "$STAGING_DIR"/usr/../usr/include)',
+       ],
+       'sources': [
+         '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_initializers.*?sources = ")',
+@@ -793,6 +798,7 @@
+       ],
+       'includes': ['inspector.gypi'],
+       'direct_dependent_settings': {
++        'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+         'include_dirs': [
+           '<(generate_bytecode_output_root)',
+           '<(SHARED_INTERMEDIATE_DIR)',
+@@ -1384,6 +1390,7 @@
+         }],
+       ],
+       'direct_dependent_settings': {
++        'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+         'include_dirs': [
+           '<(V8_ROOT)/include',
+         ],
+@@ -1748,6 +1755,7 @@
+          }],
+       ],
+       'direct_dependent_settings': {
++        'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+         'include_dirs': [
+           '<(V8_ROOT)/include',
+         ],
+@@ -1934,15 +1942,19 @@
+         }],
+       ],
+       'direct_dependent_settings': {
++        'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+         'include_dirs': [
+           '<(V8_ROOT)/third_party/zlib',
+           '<(V8_ROOT)/third_party/zlib/google',
++          '<!@(echo "$STAGING_DIR"/usr/../usr/include)',
+         ],
+       },
+       'defines': [ 'ZLIB_IMPLEMENTATION' ],
++      'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
+       'include_dirs': [
+         '<(V8_ROOT)/third_party/zlib',
+         '<(V8_ROOT)/third_party/zlib/google',
++        '<!@(echo "$STAGING_DIR"/usr/../usr/include)',
+       ],
+       'sources': [
+         '<(V8_ROOT)/third_party/zlib/adler32.c',


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: head, aarch64, arm, i386, x86_64, mipsel (pistachio)
 Run tested: (qemu 6.2.0) aarch64

Description:
Major update from v14 to v16

This update also changes npm from v6 to v8.
This change also requires node module packages to be modified.
Each package will be updated later.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
