### PR TITLE
[21.02]  ubnt-manager/prometheus-node-exporter-lua: add airos monitoring

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2021.02.15
+PKG_VERSION:=2022.04.03
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
@@ -232,6 +232,7 @@ $(eval $(call BuildPackage,prometheus-node-exporter-lua-nat_traffic))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-netstat))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-openwrt))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-textfile))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-ubnt-manager))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-uci_dhcp_host))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi_stations))

--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -166,6 +166,17 @@ define Package/prometheus-node-exporter-lua-textfile/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/textfile.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
+define Package/prometheus-node-exporter-lua-ubnt-manager
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (ubnt-manager collector)
+  DEPENDS:=prometheus-node-exporter-lua +ubnt-manager +lua-cjson
+endef
+
+define Package/prometheus-node-exporter-lua-ubnt-manager/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/ubnt-manager.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
 define Package/prometheus-node-exporter-lua-uci_dhcp_host
   $(call Package/prometheus-node-exporter-lua/Default)
   TITLE+= (uci_dhcp_host collector)

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/ubnt-manager.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/ubnt-manager.lua
@@ -1,0 +1,141 @@
+local function get_devices()
+    local handle = io.popen("ubnt-manager -l")
+    local result = handle:read("*a")
+    handle:close()
+
+    local devices = {}
+    for device in result:gmatch("%S+") do table.insert(devices, device) end
+    return devices
+end
+
+local function get_metric_airos6(device_data, label)
+    -- host
+    metric("ubnt_uptime", "counter", label, device_data['host']['uptime'])
+    metric("ubnt_totalram", "gauge", label, device_data['host']['totalram'])
+    metric("ubnt_freeram", "gauge", label, device_data['host']['freeram'])
+    metric("ubnt_cpuload", "gauge", label, device_data['host']['cpuload'])
+    metric("ubnt_cpubusy", "gauge", label, device_data['host']['cpubusy'])
+    metric("ubnt_cputotal", "gauge", label, device_data['host']['cputotal'])
+
+    -- wireless
+    metric("ubnt_channel", "gauge", label, device_data['wireless']['channel'])
+    local freqstring = {}
+    for freq in device_data['wireless']['frequency']:gmatch("%S+") do
+        table.insert(freqstring, freq)
+    end
+    if freqstring[1] then
+        metric("ubnt_frequency", "gauge", label, tonumber(freqstring[1]))
+    end
+
+    metric("ubnt_dfs", "gauge", label, tonumber(device_data['wireless']['dfs']))
+    metric("ubnt_signal", "gauge", label, device_data['wireless']['signal'])
+    metric("ubnt_rssi", "gauge", label, device_data['wireless']['rssi'])
+    metric("ubnt_noisef", "gauge", label, device_data['wireless']['noisef'])
+    metric("ubnt_txpower", "gauge", label, device_data['wireless']['txpower'])
+    metric("ubnt_distance", "gauge", label, device_data['wireless']['distance'])
+    metric("ubnt_txrate", "gauge", label,
+           tonumber(device_data['wireless']['txrate']))
+    metric("ubnt_rxrate", "gauge", label,
+           tonumber(device_data['wireless']['rxrate']))
+    metric("ubnt_count", "gauge", label, device_data['wireless']['count'])
+end
+
+local function get_metric_airos8(device_data, label)
+    -- host
+    metric("ubnt_uptime", "counter", label, device_data['host']['uptime'])
+    metric("ubnt_loadavg", "gauge", label, device_data['host']['loadavg'])
+    metric("ubnt_totalram", "gauge", label, device_data['host']['totalram'])
+    metric("ubnt_freeram", "gauge", label, device_data['host']['freeram'])
+    metric("ubnt_temperature", "gauge", label,
+           device_data['host']['temperature'])
+    metric("ubnt_cpuload", "gauge", label, device_data['host']['cpuload'])
+    metric("ubnt_timestamp", "counter", label, device_data['host']['timestamp'])
+
+    -- wireless
+    metric("ubnt_band", "gauge", label, device_data['wireless']['band'])
+    metric("ubnt_frequency", "gauge", label,
+           device_data['wireless']['frequency'])
+    metric("ubnt_center1_freq", "gauge", label,
+           device_data['wireless']['center1_freq'])
+    metric("ubnt_dfs", "gauge", label, device_data['wireless']['dfs'])
+    metric("ubnt_distance", "gauge", label, device_data['wireless']['distance'])
+    metric("ubnt_noisef", "gauge", label, device_data['wireless']['noisef'])
+    metric("ubnt_txpower", "gauge", label, device_data['wireless']['txpower'])
+    metric("ubnt_aprepeater", "gauge", label,
+           device_data['wireless']['aprepeater'])
+    metric("ubnt_rstatus", "gauge", label, device_data['wireless']['rstatus'])
+    metric("ubnt_chanbw", "gauge", label, device_data['wireless']['chanbw'])
+    metric("ubnt_rx_chainmask", "gauge", label,
+           device_data['wireless']['rx_chainmask'])
+    metric("ubnt_tx_chainmask", "gauge", label,
+           device_data['wireless']['tx_chainmask'])
+    metric("ubnt_cac_state", "gauge", label,
+           device_data['wireless']['cac_state'])
+    metric("ubnt_cac_timeout", "gauge", label,
+           device_data['wireless']['cac_timeout'])
+    metric("ubnt_rx_idx", "gauge", label, device_data['wireless']['rx_idx'])
+    metric("ubnt_rx_nss", "gauge", label, device_data['wireless']['rx_nss'])
+    metric("ubnt_tx_idx", "gauge", label, device_data['wireless']['tx_idx'])
+    metric("ubnt_tx_nss", "gauge", label, device_data['wireless']['tx_nss'])
+    metric("ubnt_count", "gauge", label, device_data['wireless']['count'])
+
+    -- wireless throughput
+    metric("ubnt_throughput_tx", "gauge", label,
+           device_data['wireless']['throughput']['tx'])
+    metric("ubnt_throughput_rx", "gauge", label,
+           device_data['wireless']['throughput']['rx'])
+
+    -- wireless polling
+    metric("ubnt_polling_cb_capacity", "gauge", label,
+           device_data['wireless']['polling']['cb_capacity'])
+    metric("ubnt_polling_dl_capacity", "gauge", label,
+           device_data['wireless']['polling']['dl_capacity'])
+    metric("ubnt_polling_ul_capacity", "gauge", label,
+           device_data['wireless']['polling']['ul_capacity'])
+    metric("ubnt_use", "gauge", label, device_data['wireless']['polling']['use'])
+    metric("ubnt_tx_use", "gauge", label,
+           device_data['wireless']['polling']['tx_use'])
+    metric("ubnt_rx_use", "gauge", label,
+           device_data['wireless']['polling']['rx_use'])
+    metric("ubnt_atpc_status", "gauge", label,
+           device_data['wireless']['polling']['atpc_status'])
+    metric("ubnt_atpc_status", "gauge", label,
+           device_data['wireless']['polling']['atpc_status'])
+end
+
+local function get_metric(device)
+    local json = require('cjson')
+    local handle = io.popen("ubnt-manager -j -t " .. device)
+    local result = handle:read("*a")
+    handle:close()
+    local device_data = json.decode(result)
+
+    if not device_data['host'] then return end
+    if not device_data['wireless'] then return end
+
+    local hostname = device_data['host']['hostname']
+    local devmodel = device_data['host']['devmodel']
+    local fwversion = device_data['host']['fwversion']
+    local essid = device_data['wireless']['essid']
+
+    local label = {
+        device = device,
+        hostname = hostname,
+        devmodel = devmodel,
+        fwversion = fwversion,
+        essid = essid
+    }
+
+    -- v6. vs v8.
+    if fwversion:find("v8.", 1, true) then
+        get_metric_airos8(device_data, label)
+    elseif fwversion:find("v6.", 1, true) then
+        get_metric_airos6(device_data, label)
+    end
+end
+
+local function scrape()
+    for _, device in ipairs(get_devices()) do get_metric(device) end
+end
+
+return {scrape = scrape}

--- a/utils/ubnt-manager/Makefile
+++ b/utils/ubnt-manager/Makefile
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ubnt-manager
+PKG_VERSION:=1
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
+PKG_LICENSE:=GPL-2.0-only
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ubnt-manager
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Managment app for Ubiquiti devices
+  PKGARCH:=all
+  EXTRA_DEPENDS:=dropbear
+endef
+
+define Package/ubnt-manager/description
+Managment app for Ubiquiti devices.
+endef
+
+define Package/ubnt-manager/conffiles
+/etc/config/ubnt-manager
+endef
+
+define Build/Compile
+endef
+
+define Package/ubnt-manager/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) ./files/ubnt-manager.sh $(1)/usr/bin/ubnt-manager
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/ubnt-manager.config $(1)/etc/config/ubnt-manager
+endef
+
+$(eval $(call BuildPackage,ubnt-manager))

--- a/utils/ubnt-manager/files/ubnt-manager.config
+++ b/utils/ubnt-manager/files/ubnt-manager.config
@@ -1,0 +1,9 @@
+config device 'sample_ap' # make sure to not use dashes in name
+	option target		'192.168.1.20'
+	option username		'ubnt'
+	option password		'ubnt'
+
+#config device 'sample_ap1'
+#	option target		'10.31.81.21'
+#	option username		'ubnt'
+#	option password		'...'

--- a/utils/ubnt-manager/files/ubnt-manager.sh
+++ b/utils/ubnt-manager/files/ubnt-manager.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+. /usr/share/libubox/jshn.sh
+. /lib/functions.sh
+
+log() {
+    local msg="$1"
+    logger -t ubnt-manager -s "$msg"
+}
+
+rexec() {
+    local target="$1"
+    local username="$2"
+    local password="$3"
+    local cmd="$4"
+    raw=$(DROPBEAR_PASSWORD="$password" ssh -y $username@$target "$cmd" 2>/dev/null)
+    ssh_result=$?
+}
+
+get_json_dump() {
+    local cmd="/usr/www/status.cgi"
+    rexec $* "$cmd"
+    echo $raw
+}
+
+handle_device() {
+    local device="${1//-/_}" # replace "-" with "_"
+    config_load ubnt-manager
+    config_get target "$device" target
+    config_get username "$device" username
+    config_get password "$device" password
+    ssh_result=0
+}
+
+add_device_to_list() {
+    local device="$1"
+    device_list="$device_list $device"
+}
+
+list_devices() {
+    device_list=""
+    config_load ubnt-manager
+    config_foreach add_device_to_list device device_list
+    echo $device_list
+}
+
+usage() {
+    cat <<EOF
+usage: ubnt-manager [command]
+-j    | --json          Dump json info
+-t    | --target        Target device
+-l    | --list-devices  List all devices
+-h    | --help          Brings up this menu
+EOF
+}
+
+while [ "$1" != "" ]; do
+    case $1 in
+    -t | --target)
+        shift
+        target=$1
+        handle_device $target
+        ;;
+    -j | --json)
+        json=1
+        ;;
+    -l | --list-devices)
+        list_devices
+        ;;
+    -h | --help)
+        usage
+        ;;
+    esac
+    shift
+done
+
+if [ ! -z $json ]; then
+    get_json_dump $target $username $password | sed 's/Content-Type:\ application\/json//'
+fi


### PR DESCRIPTION
Add ubnt-manager for managing airos devices. Based on that package ubnt-manager-collector collects statistics.