### PR TITLE
Fixing the aria2.init start issue.

### DIFF
--- a/net/aria2/files/aria2.init
+++ b/net/aria2/files/aria2.init
@@ -341,7 +341,7 @@ aria2_start() {
 		procd_set_param user "$user"
 
 	procd_add_jail "$NAME.$section" log
-	procd_add_jail_mount "$config_file"
+	procd_add_jail_mount "$ca_certificate" "$rpc_certificate" "$rpc_private_key"
 	procd_add_jail_mount_rw "$dir" "$config_dir" "$log"
 	procd_close_instance
 }


### PR DESCRIPTION
The orginal (procd_add_jail_mount "$config_file") will cause the init script unable to start the aria2 process.

Maintainer: me 
Compile tested: (Linux MIPS, OpenWrt 21.02.1)
Run tested: (Linux MIPS, OpenWrt 21.02.1)

Description:

Re-mount $config_file in $config_dir in jail will cause all files unreadable, besides, the second (procd_add_jail_mount_rw "$dir" "$config_dir") already contains the $config_file.
In addition to that, it is necessary to read-only all certificate files, so update "procd_add_jail_mount" from "$config_file" to ("$ca_certificate" "$rpc_certificate" "$rpc_private_key").