### PR TITLE
django: bump to version 4.0.3

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=4.0.2
+PKG_VERSION:=4.0.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PYPI_NAME:=Django
-PKG_HASH:=110fb58fb12eca59e072ad59fc42d771cd642dd7a2f2416582aa9da7a8ef954a
+PKG_HASH:=77ff2e7050e3324c9b67e29b6707754566f58514112a9ac73310f60cd5261930
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Peter Stadler <peter.stadler@student.uibk.ac.at>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me, @peter-stadler 
Compile tested: x86  https://github.com/openwrt/openwrt/commit/09f620019867365ed82a4b3d1d264f7a282f0941
Run tested: same


Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>