### PR TITLE
apfree-wifidog: fix compile error

### DIFF
--- a/net/apfree-wifidog/Makefile
+++ b/net/apfree-wifidog/Makefile
@@ -27,8 +27,7 @@ define Package/apfree-wifidog
   SUBMENU:=Captive Portals
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+zlib +iptables-mod-extra +iptables-mod-ipopt +kmod-ipt-nat +iptables-mod-nat-extra \
-           +libjson-c +ipset +libip4tc +libevent2 +libevent2-openssl +libuci +px5g
+  DEPENDS:=+zlib +firewall4 +iptables +libip4tc +libjson-c +libevent2 +libevent2-openssl +libuci +px5g
   TITLE:=Apfree's wireless captive portal solution
   URL:=https://github.com/liudf0716/apfree_wifidog
 endef


### PR DESCRIPTION
Maintainer: me 
Compile tested: x86/64, OpenWrt SNAPSHOT r19355-80f79beb95
Run tested: x86/64, OpenWrt SNAPSHOT r19355-80f79beb95
Description:

see https://github.com/openwrt/packages/issues/17978

Signed-off-by: Dengfeng Liu <liudf0716@gmail.com>