### PR TITLE
[openwrt-22.03] dnsproxy: Update to 0.42.1

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.42.0
+PKG_VERSION:=0.42.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=f04d58201ec92cbf769c2707536c68e10af043d15c23132e38bd93f50de6ff49
+PKG_HASH:=a3d60dcd6dc11730e25dabae3055e46470b80b33e1904398d562eb546227e9a4
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: mediatek/mt7622
Run tested: redmi ax6s

Description:
- Backported from #18245