### PR TITLE
pdns-recursor: disable parallel jobs

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -15,7 +15,7 @@ PKG_CPE_ID:=cpe:/a:powerdns:recursor
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
+PKG_BUILD_PARALLEL:=0
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Maintainer: @Habbie 
Compile tested: mediatek/mt7622, aarch64-cortexa53
Run tested: none; changes affect building only

Description:

Building with multiple jobs causes strange compilation errors:
mips-openwrt-linux-musl-g++: fatal error: Killed signal terminated program cc1plus
compilation terminated.
make[5]: *** [Makefile:1465: lua-recursor4.o] Error 1
make[5]: *** Waiting for unfinished jobs....

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>