### PR TITLE
uacme: add libev dependency to uacme-ualpn

### DIFF
--- a/net/uacme/Makefile
+++ b/net/uacme/Makefile
@@ -22,7 +22,6 @@ PKG_LICENSE_FILES:=COPYING
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-upstream-$(PKG_VERSION)
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_USE_MIPS16:=0
 
 PKG_CONFIG_DEPENDS:= \
   CONFIG_LIBCURL_GNUTLS \
@@ -54,7 +53,7 @@ endef
 
 define Package/uacme-ualpn
   $(call Package/uacme/Default)
-  DEPENDS:=+uacme
+  DEPENDS:=+uacme +PACKAGE_uacme-ualpn:libev
   TITLE:=ualpn for uacme
   URL:=https://github.com/ndilieto/uacme
 endef


### PR DESCRIPTION
Maintainer: @lucize 
Compile tested: mediatek/mt7622, aarch64-cortexa53, master
Run tested: *none*

Description:
The dependency has a PACKAGE_uacme-ualpn condition so that libev won't
be unnecessarily built if uacme-ualpn is not selected.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

