### PR TITLE
opensc: do not build man pages

### DIFF
--- a/utils/opensc/Makefile
+++ b/utils/opensc/Makefile
@@ -99,6 +99,7 @@ endef
 endef
 
 CONFIGURE_ARGS += \
+	--disable-man \
 	--disable-notify \
 	--disable-strict
 


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: mediatek/mt7622, aarch64-cortexa53, master
Run tested: none, this should not affect binaries

Description:

Add --disable-man to configure flags to skip building man pages.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

While building on gentoo with a2x installed, I get this failure:
```
make[6]: Entering directory '/home/equeiroz/src/openwrt/build_dir/target-aarch64_cortex-a53_musl/opensc-0.22.0/doc/tools'
sed -e 's|@pkgdatadir[@]|/usr/share/opensc|g' < cardos-tool.1.xml \
| xsltproc --nonet --path "./..:/usr/share/sgml/docbook/xsl-stylesheets/manpages" --xinclude -o cardos-tool.1 man.xsl cardos-tool.1.xml 2>/dev/null
make[6]: *** [Makefile:679: cardos-tool.1] Error 5
make[6]: Leaving directory '/home/equeiroz/src/openwrt/build_dir/target-aarch64_cortex-a53_musl/opensc-0.22.0/doc/tools'
```