### PR TITLE
libobsd: add new package

### DIFF
--- a/libs/libobsd/Makefile
+++ b/libs/libobsd/Makefile
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2022 Guilherme Janczak <guilherme.janczak@yandex.com>
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libobsd
+PKG_VERSION:=1.1.1
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/guijan/libobsd/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=332b72ba5f9a76c40f8a526771b78dae3ac3388f689f818c0ac4ab77ef52809d
+
+PKG_MAINTAINER:=Guilherme Janczak <guilherme.janczak@yandex.com>
+PKG_LICENSE:=ISC AND BSD-3-Clause AND BSD-4-Clause
+PKG_LICENSE_FILES:=LICENSE.txt
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/meson.mk
+
+define Package/libobsd
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Transparent OpenBSD compatibility library
+  URL:=https://github.com/guijan/libobsd/
+endef
+
+MESON_ARGS += -Ddefault_library=both
+
+define Package/libobsd/description
+  Libobsd is much like libbsd.
+  It is an attempt at writing a very similar library with more modern tools and
+  practices to make it easy to port, maintain, and add functions to the library.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/obsd $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libobsd.{a,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libobsd.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libobsd/install
+	$(INSTALL_DIR) $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libobsd.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libobsd))


### PR DESCRIPTION
Signed-off-by: Guilherme Janczak <guilherme.janczak@yandex.com>

Maintainer: me
Compile tested: sdk-22.03-SNAPSHOT-x86-64 (built April 7th)
Run tested: openwrt-22.03-snapshot-r19235-d0965dc174-x86-64 (built April 7th)

Description:
```
This adds the libobsd package. Libobsd is a transparent OpenBSD
compatibility library; the BSDs provide a similar set of libc functions,
so it can also serve as an alternative to the similar libbsd if programs
that make use of it are compiled against libobsd.
```

I actually did run test this package, I wrote a 2nd package for a program I wrote that uses it. Check out my [add-dictpw](https://github.com/guijan/packages/tree/add-dictpw/utils/dictpw) branch.

Here's a screenshot of the package in use:
![tmux_1649572387-N](https://user-images.githubusercontent.com/25590950/162605796-eeaa882a-2ff8-44c3-b5ab-08e38c5296c6.png)


I'm pinging @neheb as he showed interest in the package.
