### PR TITLE
prometheus-node-exporter-lua: wifi_stations: add tx_failures & tx_retries metrics

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2022.04.03
+PKG_VERSION:=2022.04.30
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
@@ -14,6 +14,8 @@ local function scrape()
   local metric_wifi_station_rx_bitrate = metric('wifi_station_receive_kilobits_per_second', 'gauge')
 
   local metric_wifi_station_tx_packets = metric("wifi_station_transmit_packets_total","counter")
+  local metric_wifi_station_tx_retries = metric("wifi_station_transmit_retries_total","counter")
+  local metric_wifi_station_tx_failures = metric("wifi_station_transmit_failures_total","counter")
   local metric_wifi_station_rx_packets = metric("wifi_station_receive_packets_total","counter")
 
   local metric_wifi_station_tx_bytes = metric('wifi_station_transmit_bytes_total', 'counter')
@@ -52,6 +54,9 @@ local function scrape()
             metric_wifi_station_rx_bitrate(labels, station.rx_rate)
           end
           metric_wifi_station_tx_packets(labels, station.tx_packets)
+          metric_wifi_station_tx_retries_total(labels, station.tx_retries)
+          metric_wifi_station_tx_failures_total(labels, station.tx_failures)
+
           metric_wifi_station_rx_packets(labels, station.rx_packets)
           if station.tx_bytes then
             metric_wifi_station_tx_bytes(labels, station.tx_bytes)


### PR DESCRIPTION
Maintainer: @champtar 
Compile tested: WIP
Run tested: WIP

Description:
Submit the tx_retries & tx_failures stats that already are collected by iwinfo.