### PR TITLE
zerotier: update to 1.8.8

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
-PKG_VERSION:=1.8.6
+PKG_VERSION:=1.8.8
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=40dce71426f2649e5159854c37560f5a0b634c23d4774453dae0b7ef620af22a
+PKG_HASH:=324799e10c04ccac43c67e733eacabe29d2cb3d2eb9b782f11b86c43ad714e3b
 PKG_BUILD_DIR:=$(BUILD_DIR)/ZeroTierOne-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
@@ -56,7 +56,7 @@ endif
 endef
 
 # Make binary smaller
-TARGET_CFLAGS += -ffunction-sections -fdata-sections -fPIE
+TARGET_CFLAGS += -ffunction-sections -fdata-sections
 TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
 define Package/zerotier/conffiles

--- a/net/zerotier/patches/0001-fix-makefile.patch
+++ b/net/zerotier/patches/0001-fix-makefile.patch
@@ -29,6 +29,22 @@ Subject: [PATCH 1/3] fix makefile
  	ONE_OBJS+=ext/libnatpmp/natpmp.o ext/libnatpmp/getgateway.o
  else
  	LDLIBS+=-lnatpmp
+@@ -66,12 +66,12 @@ ifeq ($(ZT_DEBUG),1)
+ 	# C25519 in particular is almost UNUSABLE in -O0 even on a 3ghz box!
+ node/Salsa20.o node/SHA512.o node/C25519.o node/Poly1305.o: CXXFLAGS=-Wall -O2 -g -pthread $(INCLUDES) $(DEFS)
+ else
+-	CFLAGS?=-O3 -fstack-protector -fPIE
++	CFLAGS?=-O3 -fstack-protector
+ 	override CFLAGS+=-Wall -Wno-deprecated -pthread $(INCLUDES) -DNDEBUG $(DEFS)
+-	CXXFLAGS?=-O3 -fstack-protector -fPIE
++	CXXFLAGS?=-O3 -fstack-protector
+ 	override CXXFLAGS+=-Wall -Wno-deprecated -std=c++11 -pthread $(INCLUDES) -DNDEBUG $(DEFS)
+-	LDFLAGS=-pie -Wl,-z,relro,-z,now
++	LDFLAGS+=-Wl,-z,relro,-z,now
+	RUSTFLAGS=--release
+ endif
+ 
+ ifeq ($(ZT_QNAP), 1)
 @@ -300,7 +300,7 @@ ifeq ($(ZT_CONTROLLER),1)
  endif
  


### PR DESCRIPTION
Compile tested: WRT1900ACV2 19.07;X86 OPENWRT
Run tested: WORKS WELL

Description:
Fix  Issues :https://github.com/mwarning/zerotier-openwrt/issues/99
update to 1.8.8

zerotier_1.8.8_arm_cortex-a9_vfpv3-d16 and zerotier_1.8.8-1_x86_64 test OK.