### PR TITLE
yq: Update to 4.24.4

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.24.2
+PKG_VERSION:=4.24.4
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=f85a01a3ed50c356d44e974224cf2be48039c73be65e9c8fe50d780fafa40f6d
+PKG_HASH:=0c5de9845a0cbbf86ccfa74f9a97f27a5a68b5dce7f9aba7995623116b18ca02
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT
@@ -16,7 +16,8 @@ PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
-GO_PKG:=github.com/mikefarah/yq
+GO_PKG:=github.com/mikefarah/yq/v4
+GO_PKG_LDFLAGS_X:=$(GO_PKG)/cmd.Version=$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk

--- a/utils/yq/test.sh
+++ b/utils/yq/test.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-yq --version 2>&1 | grep "${2#*v}"
+yq --version 2>&1 | grep "$PKG_VERSION"


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8, x86/64
Run tested: rk3328 nanopi-r2s

Description:
Updated GO_PKG due to upstream changes.

Release note:
- https://github.com/mikefarah/yq/releases/tag/v4.24.3
- https://github.com/mikefarah/yq/releases/tag/v4.24.4