### PR TITLE
[22.03] ooniprobe: Update v3.14.2

### DIFF
--- a/net/ooniprobe/Makefile
+++ b/net/ooniprobe/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ooniprobe
-PKG_VERSION:=3.10.1
+PKG_VERSION:=3.14.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=probe-cli-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ooni/probe-cli/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2b81c14133f39ac91c4ea6761be7a27d768cd88989b52ae72376d1d7b69de322
+PKG_HASH:=a0b71089444c899ba99c7f63f9e05819cdbe964cfa17bb95ca5672343e6aec22
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -25,7 +25,6 @@ PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
 GO_PKG:=github.com/ooni/probe-cli
-GO_PKG_TAGS:=PSIPHON_DISABLE_QUIC
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk


### PR DESCRIPTION
Signed-off-by: James White <james@jmwhite.co.uk>
(cherry picked from commit ddb4ccfeaf8fc6067b9265d44aa9b593a591fa68)

Maintainer: @ja-pa @jefferyto 
Compile tested: N/A
Run tested: N/A

Description:

This backports the latest update to OpenWrt 22.03. It has been recently run tested on both snapshot and 21.02
