### PR TITLE
[21.02] ooniprobe v3.14.2

### DIFF
--- a/net/ooniprobe/Makefile
+++ b/net/ooniprobe/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ooniprobe
-PKG_VERSION:=3.7.0
+PKG_VERSION:=3.8.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=probe-cli-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ooni/probe-cli/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=27f0eec380825f236f7ab3aff22dd29d7090ef47d1ce1ccb1e728e0b846b30ce
+PKG_HASH:=65bc4e592cadb99530be713798308d6950f67240bff6d90f2760fde11d750a83
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/ooniprobe/Makefile
+++ b/net/ooniprobe/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ooniprobe
-PKG_VERSION:=3.5.1
+PKG_VERSION:=3.5.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=probe-cli-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ooni/probe-cli/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8278f9318ef939c46169dc44e89bbc03915c660912e66be9c4b20d18d00816fe
+PKG_HASH:=56e419033715e1b2b61a82661f724148bab8fec4a28b2566a10e0a3051b3bade
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/ooniprobe/Makefile
+++ b/net/ooniprobe/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ooniprobe
-PKG_VERSION:=3.8.0
+PKG_VERSION:=3.9.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=probe-cli-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ooni/probe-cli/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=65bc4e592cadb99530be713798308d6950f67240bff6d90f2760fde11d750a83
+PKG_HASH:=92dc714472c473352d750d558962734a42894d67407e755f94fed8d099cc8504
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause
@@ -41,11 +41,6 @@ endef
 define Package/ooniprobe/description
   The next generation of  OONI(Open Observatory of Network Interference)
   Probe Command Line Interface.
-endef
-
-define Build/Configure
-	$(call GoPackage/Build/Configure)
-	cd $(PKG_BUILD_DIR) && $(STAGING_DIR_HOSTPKG)/bin/go run $(PKG_BUILD_DIR)/internal/cmd/getresources/getresources.go
 endef
 
 $(eval $(call GoBinPackage,ooniprobe))

--- a/net/ooniprobe/Makefile
+++ b/net/ooniprobe/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ooniprobe
-PKG_VERSION:=3.5.2
+PKG_VERSION:=3.7.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=probe-cli-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ooni/probe-cli/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=56e419033715e1b2b61a82661f724148bab8fec4a28b2566a10e0a3051b3bade
+PKG_HASH:=27f0eec380825f236f7ab3aff22dd29d7090ef47d1ce1ccb1e728e0b846b30ce
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause
@@ -41,6 +41,11 @@ endef
 define Package/ooniprobe/description
   The next generation of  OONI(Open Observatory of Network Interference)
   Probe Command Line Interface.
+endef
+
+define Build/Configure
+	$(call GoPackage/Build/Configure)
+	cd $(PKG_BUILD_DIR) && $(STAGING_DIR_HOSTPKG)/bin/go run $(PKG_BUILD_DIR)/internal/cmd/getresources/getresources.go
 endef
 
 $(eval $(call GoBinPackage,ooniprobe))

--- a/net/ooniprobe/Makefile
+++ b/net/ooniprobe/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ooniprobe
-PKG_VERSION:=3.9.0
+PKG_VERSION:=3.9.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=probe-cli-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ooni/probe-cli/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=92dc714472c473352d750d558962734a42894d67407e755f94fed8d099cc8504
+PKG_HASH:=d34dc096dfdebceaa027716fdf675eb9ab7f0085defb4235f52685d064bd5afa
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/ooniprobe/Makefile
+++ b/net/ooniprobe/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ooniprobe
-PKG_VERSION:=3.10.1
+PKG_VERSION:=3.14.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=probe-cli-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ooni/probe-cli/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2b81c14133f39ac91c4ea6761be7a27d768cd88989b52ae72376d1d7b69de322
+PKG_HASH:=a0b71089444c899ba99c7f63f9e05819cdbe964cfa17bb95ca5672343e6aec22
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause
@@ -25,7 +25,6 @@ PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
 GO_PKG:=github.com/ooni/probe-cli
-GO_PKG_TAGS:=PSIPHON_DISABLE_QUIC
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk

--- a/net/ooniprobe/Makefile
+++ b/net/ooniprobe/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ooniprobe
-PKG_VERSION:=3.9.2
+PKG_VERSION:=3.10.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=probe-cli-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ooni/probe-cli/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=d34dc096dfdebceaa027716fdf675eb9ab7f0085defb4235f52685d064bd5afa
+PKG_HASH:=2b81c14133f39ac91c4ea6761be7a27d768cd88989b52ae72376d1d7b69de322
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: @ja-pa @jefferyto 
Compile tested: armv7/mvebu
Run tested: OpenWrt 21.02 mvebu Linksys WRT3200ACM

Description:

The ooniprobe package in 21.02 is currently broken due to the version 3.5.1 using a much older version of Go (1.15) which leads to panics when trying to run commands. 

I have had to cherry-pick the previous updates to apply the latest 3.14.2 commit.

This will fix #18219, the various tools now run without errors:

```
root@linksys-wrt3200acm:~# ooniprobe version
3.14.2

root@linksys-wrt3200acm:~# apitool --help
Usage of apitool:
  -input string
        Input of the measurement
  -mode string
        One of: check, meta, raw
  -report-id string
        Report ID of the measurement
  -v    Enable verbose mode

root@linksys-wrt3200acm:~# miniooni --version
3.14.2