### PR TITLE
Fix for DNS API mode

### DIFF
--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -257,7 +257,6 @@ issue_cert()
 
 	handle_credentials() {
 		local credential="$1"
-		eval export `$credential`
 	}
 	config_list_foreach "$section" credentials handle_credentials
 

--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -257,7 +257,7 @@ issue_cert()
 
 	handle_credentials() {
 		local credential="$1"
-		eval export $credential
+		eval export `$credential`
 	}
 	config_list_foreach "$section" credentials handle_credentials
 


### PR DESCRIPTION
Maintainer: me / @tohojo 
Compile tested: NA
Run tested: ipq806x, Netgear Nighthawk X4S R7800, 22.03-SNAPSHOT

Description:
Without quoting run-acme throws the following error:
run-acme /usr/lib/acme/run-acme: export: line 257: /api key/: bad variable name daemon err err 1b