### PR TITLE
flex: use PKG_FIXUP:=autoreconf gettext-version

### DIFF
--- a/devel/flex/Makefile
+++ b/devel/flex/Makefile
@@ -13,7 +13,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/westes/flex/releases/download/v$(PKG_VERSION)/
 PKG_HASH:=e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995
 
-PKG_FIXUP:=autoreconf
+PKG_FIXUP:=autoreconf gettext-version
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=BSD-2-Clause


### PR DESCRIPTION
This change aims to fix build problems that produce the error "gettext
infrastructure mismatch".

References:
- See the commit comments at:
  https://github.com/openwrt/packages/commit/baaf7f95cb5259724e28158510d9bcd152d4f693

Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me

Compiles for me on x86_64, but requires testing from someone who can reproduce the "gettext infrastructure mismatch" error. @trippleflux, would you mind testing?