### PR TITLE
strongswan: add wolfssl plugin

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -95,6 +95,7 @@ PKG_MOD_AVAILABLE:= \
 	updown \
 	vici \
 	whitelist \
+	wolfssl \
 	x509 \
 	xauth-eap \
 	xauth-generic \
@@ -223,6 +224,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-updown \
 	+strongswan-mod-vici \
 	+strongswan-mod-whitelist \
+	+strongswan-mod-wolfssl \
 	+strongswan-mod-x509 \
 	+strongswan-mod-xauth-eap \
 	+strongswan-mod-xauth-generic \
@@ -735,6 +737,7 @@ $(eval $(call BuildPlugin,unity,Cisco Unity extension,))
 $(eval $(call BuildPlugin,updown,updown firewall,+iptables-legacy +iptables-mod-ipsec +kmod-ipt-ipsec))
 $(eval $(call BuildPlugin,vici,Versatile IKE Configuration Interface,))
 $(eval $(call BuildPlugin,whitelist,peer identity whitelisting,))
+$(eval $(call BuildPlugin,wolfssl,WolfSSL crypto,+PACKAGE_strongswan-mod-wolfssl:libwolfssl))
 $(eval $(call BuildPlugin,x509,x509 certificate,))
 $(eval $(call BuildPlugin,xauth-eap,EAP XAuth backend,))
 $(eval $(call BuildPlugin,xauth-generic,generic XAuth backend,))


### PR DESCRIPTION
Maintainer: @pprindeville @Thermi
Compile tested: With gcc 7.5.0 on v19.07 x86_64-glibc and musl; gcc 11.2.0 on master fb7ff6b027d1c69e97e6d39e688a969c164065c8 aarch64 musl
Run tested: v19.07 x86_64 musl, gcc 7.5.0; v22.03rc1 aarch64-cortexa53 musl (Linksys E8400)

Description: Adds WolfSSL module to strongswan

This is a rebase of #14043. The initial code there seems to have worked but comments were left regarding the state of the version. Since there seems to be no longer activity from the original author, I've taken his branch and cherry-picked it on top of master. The PKG_RELEASE bump no longer seems necessary due to the use of $AUTORELEASE.