### PR TITLE
telldus-core: use proper cmake argp

### DIFF
--- a/utils/telldus-core/Makefile
+++ b/utils/telldus-core/Makefile
@@ -23,6 +23,18 @@ PKG_BUILD_DEPENDS:=argp-standalone
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
+define Download/argp-cmake
+	URL:=@GITHUB/alehaa/CMake-argp/e7e77e68d062708edf055f944d3094b0ce0b11b8/cmake
+	FILE:=Findargp.cmake
+	HASH:=b74e961260d17bc9af868be59053e50739dc94e06cbe73e3fced414a070a29fd
+endef
+
+define Build/Prepare
+	$(eval $(call Download,argp-cmake))
+	$(Build/Prepare/Default)
+	$(CP) $(DL_DIR)/Findargp.cmake $(PKG_BUILD_DIR)/cmake/
+endef
+
 define Package/telldus-core
 	SECTION:=utils
 	CATEGORY:=Utilities

--- a/utils/telldus-core/patches/110-fix_warnings.patch
+++ b/utils/telldus-core/patches/110-fix_warnings.patch
@@ -6,7 +6,7 @@ Added a typecast (signed/unsigned char problem). Should be portable.
  std::string ProtocolIkea::getStringForMethod(int method, unsigned char level, Controller *) {
  	const char B1[] = {84, 84, 0};
 -	const char B0[] = {170, 0};
-+	const char B0[] = {(char)170, 0};
++	const char B0[] = {char(170), 0};
  
  	int intSystem = this->getIntParameter(L"system", 1, 16)-1;
  	int intFadeStyle = TelldusCore::comparei(this->getStringParameter(L"fade", L"true"), L"true");
@@ -17,7 +17,7 @@ Added a typecast (signed/unsigned char problem). Should be portable.
  	const unsigned char S = 59, L = 169;
  	const char B0[] = {S, S, 0};
 -	const char B1[] = {S, L, 0};
-+	const char B1[] = {S, (char)L, 0};
++	const char B1[] = {S, char(L), 0};
  	const unsigned char START_CODE[] = {'S', 255, 1, 255, 1, 255, 1, 100, 255, 1, 180, 0};
  	const unsigned char STOP_CODE[] = {S, 0};
  

--- a/utils/telldus-core/patches/900-openwrt_fixes_cmake.patch
+++ b/utils/telldus-core/patches/900-openwrt_fixes_cmake.patch
@@ -12,15 +12,22 @@ Adopted to OpenWrt target. Most likely these changes go elsewhere when done righ
  
 --- a/tdadmin/CMakeLists.txt
 +++ b/tdadmin/CMakeLists.txt
-@@ -38,8 +38,11 @@ ELSEIF (CMAKE_SYSTEM_NAME MATCHES "FreeB
- 		${ARGP_LIBRARY}
+@@ -30,16 +30,11 @@ ELSEIF (APPLE)
+ 	TARGET_LINK_LIBRARIES(tdadmin
+ 		TelldusCore
  	)
+-ELSEIF (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+-	# FreeBSD does not have argp in base libc; port devel/argp-standalone is required.
+-	FIND_LIBRARY(ARGP_LIBRARY argp)
+-	TARGET_LINK_LIBRARIES(tdadmin
+-		${CMAKE_BINARY_DIR}/client/libtelldus-core.so
+-		${ARGP_LIBRARY}
+-	)
  ELSE (WIN32)
-+	# Linux, in this case openwrt that requires argp-standalone
-+	FIND_LIBRARY(ARGP_LIBRARY argp)
++	FIND_PACKAGE(argp)
  	TARGET_LINK_LIBRARIES(tdadmin
  		${CMAKE_BINARY_DIR}/client/libtelldus-core.so
-+		${ARGP_LIBRARY}
++		${ARGP_LIBRARIES}
  	)
  ENDIF (WIN32)
  

--- a/utils/telldus-core/patches/980-auto-ptr.patch
+++ b/utils/telldus-core/patches/980-auto-ptr.patch
@@ -1,0 +1,20 @@
+--- a/service/DeviceManager.cpp
++++ b/service/DeviceManager.cpp
+@@ -74,7 +74,7 @@ void DeviceManager::executeActionEvent()
+ 	}
+ 	Log::notice("Execute a TellStick Action for device %i", data->deviceId);
+ 
+-	std::auto_ptr<TelldusCore::MutexLocker> deviceLocker(0);
++	std::unique_ptr<TelldusCore::MutexLocker> deviceLocker;
+ 	{
+ 		// devicelist locked
+ 		TelldusCore::MutexLocker deviceListLocker(&d->lock);
+@@ -84,7 +84,7 @@ void DeviceManager::executeActionEvent()
+ 			return;
+ 		}
+ 		// device locked
+-		deviceLocker = std::auto_ptr<TelldusCore::MutexLocker>(new TelldusCore::MutexLocker(it->second));
++		deviceLocker = std::make_unique<TelldusCore::MutexLocker>(it->second);
+ 		device = it->second;
+ 	}  // devicelist unlocked
+ 


### PR DESCRIPTION
Avoids linking to argp-standalone with glibc.

Some other minor fixes.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @PeterFromSweden 
Compile tested: mips64