### PR TITLE
mdio-tools: add kmod-mdio-netlink as dependencies

### DIFF
--- a/net/mdio-tools/Makefile
+++ b/net/mdio-tools/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mdio-tools
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://github.com/wkz/mdio-tools
 PKG_SOURCE_PROTO:=git
@@ -22,7 +22,7 @@ define Package/mdio-tools
   CATEGORY:=Utilities
   TITLE:=mdio-tools Linux MDIO register access
   URL:=https://github.com/wkz/mdio-tools.git
-  DEPENDS:=+libmnl
+  DEPENDS:=+kmod-mdio-netlink +libmnl
 endef
 
 define Package/mdio-tools/description


### PR DESCRIPTION
Maintainer: @dmascord

Otherwise it will fail as follows:
  failed to find a module named mdio-netlink
  ERROR: mdio-netlink module not detected, and could not be loaded.

Run-tested on: ramips/mt7621
