### PR TITLE
[21.02] Update speedtest cli v2.1.3

### DIFF
--- a/lang/python/python3-speedtest-cli/Makefile
+++ b/lang/python/python3-speedtest-cli/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python3-speedtest-cli
-PKG_VERSION:=2.1.2
-PKG_RELEASE:=2
+PKG_VERSION:=2.1.3
+PKG_RELEASE:=1
 
 PYPI_NAME:=speedtest-cli
-PKG_HASH:=cf1d386222f94c324e3125ba9a0d187e46d4a13dca08c023bdb9a23096be2e54
+PKG_HASH:=5e2773233cedb5fa3d8120eb7f97bcc4974b5221b254d33ff16e2f1d413d90f0
 
 PKG_MAINTAINER:=Jaymin Patel <jem.patel@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
This includes a fix for a breaking change in the Speedtest API.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>
(cherry picked from commit 77ebd65f4945ea116365ccab3070ab31bed99ce7)
Signed-off-by: James White <james@jmwhite.co.uk>

Maintainer: @jempatel
Compile tested: mvebu/cortexa9
Run tested: Linksys WRT3200ACM OpenWrt 21.02.2 r16495-bf0c965af0

Description:

Bumps package to 2.1.3, this has a fix for a breaking change in the API, the current version in 21.02 is 2.1.2 and is broken without this API fix.

```
root@linksys-wrt3200acm:~# speedtest-cli --version
speedtest-cli 2.1.3
Python 3.9.12 (main, Apr 11 2022, 20:52:57) [GCC 8.4.0]
root@linksys-wrt3200acm:~# speedtest-cli
Retrieving speedtest.net configuration...
Testing from Virgin Media (x.x.x.x)...
Retrieving speedtest.net server list...
Selecting best server based on ping...
Hosted by RETN (London) [178.99 km]: 30.616 ms
Testing download speed................................................................................
Download: 236.65 Mbit/s
Testing upload speed......................................................................................................
Upload: 34.35 Mbit/s
root@linksys-wrt3200acm:~#
```
