### PR TITLE
cloudreve: Update to 3.5.1

### DIFF
--- a/net/cloudreve/Makefile
+++ b/net/cloudreve/Makefile
@@ -5,19 +5,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cloudreve
-PKG_VERSION:=3.4.2
+PKG_VERSION:=3.5.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/cloudreve/Cloudreve.git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
-PKG_MIRROR_HASH:=7ceda70ae80582df46e0f110ad5d21c825aadcd75441be3e39c714e0c7d3ba19
+PKG_MIRROR_HASH:=d9892bf18c4e6af65d233d1263d873e94baf6ab55fa25438457800ae2e418642
 
 PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 
-PKG_BUILD_DEPENDS:=golang/host node/host node-yarn/host statik/host
+PKG_BUILD_DEPENDS:=golang/host node/host node-yarn/host
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
@@ -45,12 +45,9 @@ endef
 
 define Build/Compile
 	( \
-		pushd $(PKG_BUILD_DIR) ; \
-		cd assets ; \
+		pushd $(PKG_BUILD_DIR)/assets ; \
 		yarn install ; \
 		yarn run build ; \
-		cd ../ ; \
-		statik -src=assets/build/  -include=*.html,*.js,*.json,*.css,*.png,*.svg,*.ico -f ; \
 		popd ; \
 		$(call GoPackage/Build/Compile) ; \
 	)


### PR DESCRIPTION
Maintainer: me
Compile tested: x86/64
Run tested: x86_64

Description:
Removed statik which was deprecated by the project.

Release note:
- https://github.com/cloudreve/Cloudreve/releases/tag/3.4.3
- https://github.com/cloudreve/Cloudreve/releases/tag/3.5.0
- https://github.com/cloudreve/Cloudreve/releases/tag/3.5.1