### PR TITLE
stm32flash: update to version 0.7

### DIFF
--- a/utils/stm32flash/Makefile
+++ b/utils/stm32flash/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stm32flash
-PKG_VERSION:=0.6
+PKG_VERSION:=0.7
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
-PKG_HASH:=ee9b40d4d3e5cd28b993e08ae2a2c3c559b6bea8730cd7e1d40727dedb1dda09
+PKG_HASH:=c4c9cd8bec79da63b111d15713ef5cc2cd947deca411d35d6e3065e227dc414a
 
 PKG_MAINTAINER:=Christian Pointner <equinox@spreadspace.org>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Signed-off-by: Russell Senior <russell@personaltelco.net>

Maintainer: Christian Pointner <equinox@spreadspace.org> / @equinox0815
Compile tested: ramips/mt76x8, openwrt reboot-19502-g7a73221332
Run tested: ramips/mt76x8, openwrt reboot-19502-g7a73221332

Description: there was a bug in version 0.6 relating to page-by-page erase (see https://sourceforge.net/p/stm32flash/wiki/ChangeLog/) that was fixed in version 0.7
