### PR TITLE
[22.03] zerotier: fix segfault on ARM platforms

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -56,7 +56,7 @@ endif
 endef
 
 # Make binary smaller
-TARGET_CFLAGS += -ffunction-sections -fdata-sections -fPIE
+TARGET_CFLAGS += -ffunction-sections -fdata-sections
 TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
 define Package/zerotier/conffiles

--- a/net/zerotier/patches/0001-fix-makefile.patch
+++ b/net/zerotier/patches/0001-fix-makefile.patch
@@ -29,6 +29,21 @@ Subject: [PATCH 1/3] fix makefile
  	ONE_OBJS+=ext/libnatpmp/natpmp.o ext/libnatpmp/getgateway.o
  else
  	LDLIBS+=-lnatpmp
+@@ -66,11 +66,11 @@ ifeq ($(ZT_DEBUG),1)
+ 	# C25519 in particular is almost UNUSABLE in -O0 even on a 3ghz box!
+ node/Salsa20.o node/SHA512.o node/C25519.o node/Poly1305.o: CXXFLAGS=-Wall -O2 -g -pthread $(INCLUDES) $(DEFS)
+ else
+-	CFLAGS?=-O3 -fstack-protector -fPIE
++	CFLAGS?=-O3 -fstack-protector
+ 	override CFLAGS+=-Wall -Wno-deprecated -pthread $(INCLUDES) -DNDEBUG $(DEFS)
+-	CXXFLAGS?=-O3 -fstack-protector -fPIE
++	CXXFLAGS?=-O3 -fstack-protector
+ 	override CXXFLAGS+=-Wall -Wno-deprecated -std=c++11 -pthread $(INCLUDES) -DNDEBUG $(DEFS)
+-	LDFLAGS=-pie -Wl,-z,relro,-z,now
++	LDFLAGS+=-Wl,-z,relro,-z,now
+ 	RUSTFLAGS=--release
+ endif
+ 
 @@ -300,7 +300,7 @@ ifeq ($(ZT_CONTROLLER),1)
  endif
  


### PR DESCRIPTION
Signed-off-by: Moritz Warning <moritzwarning@web.de>

Maintainer: me 

Backport/cherry-picked from https://github.com/openwrt/packages/pull/18300
