### PR TITLE
[19.07] ruby: update to 2.6.10

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=2.6.9
+PKG_VERSION:=2.6.10
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=6a041d82ae6e0f02ccb1465e620d94a7196489d8a13d6018a160da42ebc1eece
+PKG_HASH:=5fd8ded51321b88fdc9c1b4b0eb1b951d2eddbc293865da0151612c2e814c1f2
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Fixes from 2.6.9:

https://github.com/advisories/GHSA-qg54-694p-wgpp: Regular Expression Denial of Service Vulnerability of
Date Parsing Methods
https://github.com/advisories/GHSA-4vf4-qmvg-mh7h: Cookie Prefix Spoofing in CGI::Cookie.parse
Fixes from 2.6.10:

CVE-2022-28739: Buffer overrun in String-to-Float conversion
After this release, Ruby 2.6 reaches EOL.

Signed-off-by: Luiz Angelo Daros de Luca [luizluca@gmail.com](mailto:luizluca@gmail.com)

Maintainer: me
Compile tested: armvirt_64,ath79_generic,mediatek_mt7622,mvebu_cortexa9,powerpc,ramips_mt7620,x86_64,x86_generic
Run tested: x86_64 running 'gem update'

Description:
This will be the last update to 19.07 but, as the fix was released before last 19.07.x, it would be interesting to have ruby fixed.