### PR TITLE
passh: updated per OpenWrt's common practice

### DIFF
--- a/utils/passh/Makefile
+++ b/utils/passh/Makefile
@@ -1,25 +1,25 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME    := passh
-PKG_VERSION := 1.0.1
-PKG_RELEASE := $(AUTORELEASE)
+PKG_NAME:=passh
+PKG_VERSION:=1.0.1
+PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE     := $(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL := https://codeload.github.com/clarkwang/passh/tar.gz/v$(PKG_VERSION)?
-PKG_HASH       := f6efc7127515b3716108fa28439caca561d16923404bb1a8f734b41340b3f14e
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/clarkwang/passh/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=f6efc7127515b3716108fa28439caca561d16923404bb1a8f734b41340b3f14e
 
-PKG_MAINTAINER    := Clark Wang <dearvoid@gmail.com>
-PKG_LICENSE       := GPL-3.0
-PKG_LICENSE_FILES := LICENSE
+PKG_MAINTAINER:=Clark Wang <dearvoid@gmail.com>
+PKG_LICENSE:=GPL-3.0-only
+PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
 
 define Package/passh
-  SECTION  := utils
-  CATEGORY := Utilities
-  TITLE    := an sshpass alternative
-  URL      := https://github.com/clarkwang/passh
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=an sshpass alternative
+  URL:=https://github.com/clarkwang/passh
 endef
 
 define Package/passh/description
@@ -27,7 +27,7 @@ define Package/passh/description
 endef
 
 define Build/Compile
-	$(TARGET_CC) $(TARGET_CFLAGS) -D_GNU_SOURCE $(TARGET_LDFLAGS) -Wall \
+	$(TARGET_CC) $(TARGET_CFLAGS) -D_GNU_SOURCE -Wall $(TARGET_LDFLAGS) \
 	    $(PKG_BUILD_DIR)/passh.c -o $(PKG_BUILD_DIR)/$(PKG_NAME)
 endef
 

--- a/utils/passh/test.sh
+++ b/utils/passh/test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+out=`$1 --version`
+if [ "$out" != "$1 $2" ]; then
+    exit 1
+fi


### PR DESCRIPTION
- removed extra white spaces in Makefile
- changed license from GPL-3.0 to GPL-3.0-only
- added test.sh

Signed-off-by: Clark Wang <dearvoid@gmail.com>

Maintainer: Clark Wang <dearvoid@gmail.com>
Compile tested: 21.02.3-ramips-mt7621
Run tested: 21.02.3-ramips-mt7621 (Netgear R6220)

Description:
