### PR TITLE
ffmpeg: update to version 4.3.4

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
-PKG_VERSION:=4.3.3
+PKG_VERSION:=4.3.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
-PKG_HASH:=9f0a68fbd74feb4e50dc220bddd59d84626774a53687fb737806ae00e5c6e9e6
+PKG_HASH:=c117d9b778be1be2d3889757567113c5e940bad6913b16f9e86c31509f9d742d
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Ian Leonard <antonlacon@gmail.com>
 


### PR DESCRIPTION
Maintainer: @antonlacon
Compile: Turris 1.1, powerpc_8540, OpenWrt 21.02.2
Run tested: N/A

Description:

Changelog: https://git.ffmpeg.org/gitweb/ffmpeg.git/shortlog/n4.3.4