### PR TITLE
wsdd2: Remove extra comma, which breaks the key-value pair of the '-b' parameter

### DIFF
--- a/net/wsdd2/files/wsdd2.init
+++ b/net/wsdd2/files/wsdd2.init
@@ -59,12 +59,12 @@ start_service() {
 	local board_sku
 
 	[ -e /tmp/sysinfo/board_name ] && {
-		board_vendor="$(awk -F',' '{print $1}' /tmp/sysinfo/board_name | tr ' ' '_' | tr -d ' \n')"
-		board_sku="$(awk -F',' '{print $2}' /tmp/sysinfo/board_name | tr ' ' '_' | tr -d ' \n')"
+		board_vendor="$(awk -F',' '{print $1}' /tmp/sysinfo/board_name | tr ' ' '_' | tr ',' '-' | tr -d ' \n')"
+		board_sku="$(awk -F',' '{print $2}' /tmp/sysinfo/board_name | tr ' ' '_' | tr ',' '-' |  tr -d ' \n')"
 	}
 
 	[ -e /tmp/sysinfo/model ] && {
-		board_model="$(awk -F':' '{print $1}' /tmp/sysinfo/model | tr ' ' '_' | tr -d ' \n')"
+		board_model="$(awk -F':' '{print $1}' /tmp/sysinfo/model | tr ' ' '_' | tr ',' '-' |  tr -d ' \n')"
 	}
 
 	[ -n "$board_vendor" ] && [ -n "$board_model" ] && {


### PR DESCRIPTION
Maintainer: @Andy2244
Compile tested: x86_64, OpenWrt v21.02.3
Run tested: x86_64, OpenWrt v21.02.3

Description:
The '-b' parameter of wsdd2 uses commas to separate key-value pairs, so the values ​​cannot contain extra commas.

I'm running OpenWrt v21.02.3 on VMware ESXi and my /tmp/sysinfo/model file content is:
```
root@OpenWrt:~# cat /tmp/sysinfo/model
VMware, Inc. VMware7,1
root@OpenWrt:~# cat /tmp/sysinfo/board_name
vmware-inc-vmware7-1
```
It will break the '-b' parameter and I can't start wsdd2 without this patch.
