### PR TITLE
22.03: update pdns, pdns-recursor, dnsdist

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
-PKG_VERSION:=4.6.0
+PKG_VERSION:=4.6.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=df06559398aebc594d2e1e27d177f981bdbbc17f968d6306a52aa7d1119fbcf2
+PKG_HASH:=da649850739fdd7baf2df645acc97752ccd390973b56b8e25171ea7b0d25ad20
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>
 PKG_LICENCE:=GPL-2.0-only

--- a/net/pdns/Makefile
+++ b/net/pdns/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns
-PKG_VERSION:=4.6.0
+PKG_VERSION:=4.6.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=b9effb7968a7badbb91eea431c73346482a67592684d84660edd8b7528cc1325
+PKG_HASH:=f443848944bb11bbb4850221613b3a01ffb57febf2671da6caa57362ee0b19b8
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>
 PKG_LICENCE:=GPL-2.0-only

--- a/net/pdns/patches/100-pdns-disable-pdns.conf-dist.patch
+++ b/net/pdns/patches/100-pdns-disable-pdns.conf-dist.patch
@@ -25,7 +25,7 @@
  	ixfrdist.example.yml
  endif
  
-@@ -1313,9 +1311,6 @@ dnspcap2protobuf_LDADD = \
+@@ -1314,9 +1312,6 @@ dnspcap2protobuf_LDADD = \
  	$(BOOST_PROGRAM_OPTIONS_LIBS) \
  	$(RT_LIBS)
  


### PR DESCRIPTION
Maintainer: me
Compile tested: pending
Run tested: pending

Description:
I cherry-picked the updates from master, and squashed them per product, while keeping all cherry-picked IDs in the commit messages.

I'll add dnsdist when #18370 is merged.