### PR TITLE
tgt: update to 1.0.82

### DIFF
--- a/net/tgt/Makefile
+++ b/net/tgt/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tgt
-PKG_VERSION:=1.0.81
-PKG_RELEASE:=1
+PKG_VERSION:=1.0.82
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fujita/tgt/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=f8a285549456f13fecf628131a73934ffcbb701bacb7d5802acee7b515ab5452
+PKG_HASH:=35156277465e0ced5f3ca7e301110a937a7a2b90bbb5aecbca1349b91ada1c2c
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-2.0-only
@@ -32,7 +32,7 @@ define Package/tgt/description
 The Linux target framework (tgt) is a user space SCSI target framework
 that supports the iSCSI and iSER transport protocols and that also
 supports multiple methods for accessing block storage. Tgt consists of
-a user-space daemon and user-space tools.
+user-space daemon and tools.
 endef
 
 define Build/Compile


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79, r19420-5cf5dce05a
Run tested: ath79, r19420-5cf5dce05a running in a chroot on a r15339+6-bc99b56d7e system. tgtd is able to export a LUN with a file used as a backing store. 
Description:
- update to 1.0.82
- switch to $(AUTORELEASE)
- sync the description with the GitHub project page