### PR TITLE
softflowd: add traffic capture filter

### DIFF
--- a/net/softflowd/Makefile
+++ b/net/softflowd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=softflowd
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/irino/softflowd/tar.gz/softflowd-$(PKG_VERSION)?

--- a/net/softflowd/files/softflowd.config
+++ b/net/softflowd/files/softflowd.config
@@ -12,3 +12,4 @@ config softflowd
 	option tracking_level 'full'
 	option track_ipv6     '0'
 	option sampling_rate  '100'
+	option filter         ''

--- a/net/softflowd/files/softflowd.init
+++ b/net/softflowd/files/softflowd.init
@@ -29,6 +29,7 @@ start_instance() {
 	[ "$enabled" -gt 0 ] || return 1
 
 	config_get pid_file "$section" 'pid_file'
+	config_get filter "$section" 'filter'
 
 	args=""
 	append_string "$section" 'interface' '-i'
@@ -45,7 +46,7 @@ start_instance() {
 	append_bool "$section" track_ipv6 '-6'
 
 	procd_open_instance
-	procd_set_param command /usr/sbin/softflowd -d $args${pid_file:+ -p $pid_file}
+	procd_set_param command /usr/sbin/softflowd -d $args${pid_file:+ -p $pid_file} "$filter"
 	procd_set_param respawn
 	procd_close_instance
 }


### PR DESCRIPTION
softflowd can filter the traffic with an optional bpf program,
specified on the command-line as a BPF expression

Signed-off-by: Jesus Fernandez Manzano <jesus.manzano@galgus.net>