### PR TITLE
flex: avoid using system gettext--build only the main program in the src directory

### DIFF
--- a/devel/flex/patches/100-disable-all-dirs-except-src.patch
+++ b/devel/flex/patches/100-disable-all-dirs-except-src.patch
@@ -1,13 +1,16 @@
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -43,10 +43,7 @@ EXTRA_DIST = \
+@@ -42,12 +42,7 @@ EXTRA_DIST = \
+ 	autogen.sh
  
  SUBDIRS = \
- 	src \
+-	src \
 -	doc \
 -	examples \
- 	po \
+-	po \
 -	tests \
- 	tools
+-	tools
++	src
  
  # Create the ChangeLog, but only if we're inside a git working directory
+ 


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: aarch64-cortexa53, mediatek/mt7622, master
Run tested: N/A, no change in final program 

Description:
~Add gettext-full/host to PKG_BUILD_DEPENDS, so that it will be used to
build the po files instead of the system binaries.~
Amend the patch that disabled tests and docs to remove everything but the `src` dir that builds the main flex program--the only file packaged.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

----

I've gotten the same failure as discussed in https://github.com/openwrt/packages/commit/baaf7f95cb5259724e28158510d9bcd152d4f693#commitcomment-71309725 - gettext version mismatch.

I've tried to reproduce it, but wasn't able.  Then I decided to build it from a clean tree:
```
make -j12 {toolchain,target,package/flex}/compile
```

Then, I've cleaned it and build it right after `gettext-full/host`:
```
make -j12 package/{flex/clean,{gettext-full/host,flex}/compile}
```
Comparing the build logs, it was apparent that if built before gettext-full/host, it would use the system gettext, which is not desired:
```
diff flex-2.6.4_{1,2}/compile.txt
1d0
< bash: line 1: /home/equeiroz/src/openwrt/staging_dir/hostpkg/bin/gettext: No such file or directory
8c7,25
< bash: line 1: /home/equeiroz/src/openwrt/staging_dir/hostpkg/bin/autopoint: No such file or directory
---
> Copying file ABOUT-NLS
> Copying file build-aux/config.rpath
> Copying file m4/gettext.m4
> Copying file m4/host-cpu-c-abi.m4
> Copying file m4/iconv.m4
> Copying file m4/intlmacosx.m4
> Copying file m4/lib-ld.m4
> Copying file m4/lib-link.m4
> Copying file m4/lib-prefix.m4
> Copying file m4/nls.m4
> Copying file m4/po.m4
> Copying file m4/progtest.m4
> Copying file po/Makefile.in.in
> Copying file po/Makevars.template
> Copying file po/Rules-quot
> Copying file po/en@boldquot.header
> Copying file po/en@quot.header
> Copying file po/insert-header.sin
> Copying file po/remove-potcdate.sin
28,30d44
< configure.ac:42: warning: The 'AM_PROG_MKDIR_P' macro is deprecated, and its use is discouraged.
< configure.ac:42: You should use the Autoconf-provided 'AC_PROG_MKDIR_P' macro instead,
< configure.ac:42: and use '$(MKDIR_P)' instead of '$(mkdir_p)'in your Makefile.am files.
51,53d64
< configure.ac:42: warning: The 'AM_PROG_MKDIR_P' macro is deprecated, and its use is discouraged.
< configure.ac:42: You should use the Autoconf-provided 'AC_PROG_MKDIR_P' macro instead,
< configure.ac:42: and use '$(MKDIR_P)' instead of '$(mkdir_p)'in your Makefile.am files.
138,142c149,153
< checking for msgfmt... /usr/bin/msgfmt
< checking for gmsgfmt... /usr/bin/gmsgfmt
< checking for xgettext... /usr/bin/xgettext
< checking for msgmerge... /usr/bin/msgmerge
< checking for ld used by GCC... aarch64-openwrt-linux-musl-ld
---
> checking for msgfmt... /home/equeiroz/src/openwrt/staging_dir/hostpkg/bin/msgfmt
> checking for gmsgfmt... /home/equeiroz/src/openwrt/staging_dir/hostpkg/bin/gmsgfmt
> checking for xgettext... /home/equeiroz/src/openwrt/staging_dir/hostpkg/bin/xgettext
> checking for msgmerge... /home/equeiroz/src/openwrt/staging_dir/hostpkg/bin/msgmerge
> checking for ld... aarch64-openwrt-linux-musl-ld
144a156,158
> checking 32-bit host C ABI... no
> checking for ELF binary format... yes
> checking for the common suffixes of directories in the library search path... lib,lib,lib64
146c160
< checking for CFLocaleCopyCurrent... no
---
> checking for CFLocaleCopyPreferredLanguages... no
332a347
> make[4]: Nothing to be done for 'all'.
396c411
< time: package/feeds/packages/flex/compile#18.88#1.48#21.26
---
> time: package/feeds/packages/flex/compile#20.15#1.76#22.69
```
The builds didn't fail at all; my previous failure may be due to bad luck with parallel building, but ensuring the order is advisable in this case, especially for reproducible builds.

**amended**
Avoid the problem altogether by only building the main program in the `src;` directory.  The helper programs shown above are still being checked, so it may pick up the host system ones, but they won't be used.