### PR TITLE
antfs: require kernel version 5.10 to build

### DIFF
--- a/kernel/antfs/Makefile
+++ b/kernel/antfs/Makefile
@@ -20,7 +20,7 @@ define KernelPackage/fs-antfs
 	TITLE:=AVM NTFS Read/Write Driver
 	FILES:=$(PKG_BUILD_DIR)/antfs.ko
 	AUTOLOAD:=$(call AutoLoad,30,antfs,1)
-	DEPENDS:=+kmod-nls-base
+	DEPENDS:=+kmod-nls-base @LINUX_5_10
 endef
 
 define KernelPackage/fs-antfs/description


### PR DESCRIPTION
ANTFS does not compile with OpenWrt's current testing kernel 5.15,
as it needs to be modified for the Linux 5.12 idmapped mounts changes
2f221d6f7b88 ("attr: handle idmapped mounts")
https://lore.kernel.org/all/20210121131959.646623-1-christian.brauner@ubuntu.com/

Signed-off-by: John Thomson <git@johnthomson.fastmail.com.au>

---

Maintainer: @dengqf6
Compile tested: ath79, master, testing kernel (5.15): no longer stop ALL_KMODS=y build
Run tested: N/A

---

excluding kernel 5.15 may be preferable to requiring 5.10?
`@!LINUX_5.15`