### PR TITLE
[21.02] django: bump to version 3.2.13

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=3.2.8
+PKG_VERSION:=3.2.13
 PKG_RELEASE:=$(AUTORELEASE)
 
 PYPI_NAME:=Django
-PKG_HASH:=f6d2c4069c9b9bfac03bedff927ea1f9e0d29e34525cec8a68fd28eb2a8df7af
+PKG_HASH:=6d93497a0a9bf6ba0e0b1a29cccdc40efbfc76297255b1309b3a884a688ec4b6
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Peter Stadler <peter.stadler@student.uibk.ac.at>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me, @peter-stadler 
Compile tested: n/a
Run tested: n/a


Fixes
https://nvd.nist.gov/vuln/detail/CVE-2022-28347
https://nvd.nist.gov/vuln/detail/CVE-2022-28346

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>