### PR TITLE
[22.03] django: bump to version 4.0.4

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=4.0.2
+PKG_VERSION:=4.0.4
 PKG_RELEASE:=$(AUTORELEASE)
 
 PYPI_NAME:=Django
-PKG_HASH:=110fb58fb12eca59e072ad59fc42d771cd642dd7a2f2416582aa9da7a8ef954a
+PKG_HASH:=4e8177858524417563cc0430f29ea249946d831eacb0068a1455686587df40b5
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Peter Stadler <peter.stadler@student.uibk.ac.at>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me, @peter-stadler 
Compile tested:  x86 https://github.com/openwrt/openwrt/commit/9a22943eb2670303393a2103f47fae312f484bd2
Run tested: x86 https://github.com/openwrt/openwrt/commit/9a22943eb2670303393a2103f47fae312f484bd2

same as PR #18401 

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>