### PR TITLE
Flask, Jinja2: change maintainer

### DIFF
--- a/lang/python/Flask/Makefile
+++ b/lang/python/Flask/Makefile
@@ -11,7 +11,7 @@ PKG_RELEASE:=$(AUTORELEASE)
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Šimon Bořek <simon.borek@nic.cz>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
 PKG_CPE_ID:=cpe:/a:palletsprojects:flask

--- a/lang/python/Jinja2/Makefile
+++ b/lang/python/Jinja2/Makefile
@@ -11,7 +11,7 @@ PKG_RELEASE:=$(AUTORELEASE)
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Šimon Bořek <simon.borek@nic.cz>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:pocoo:jinja2


### PR DESCRIPTION
Maintainer: @BKPepe
Compile tested: n/a
Run tested: n/a

Description:
As we are using Flask and Jinja2 packages in Turris OS and @dangowrt decided to no longer maintain these and some other Python packages I'd like to take Flask and Jinja2 package maintainership as was originally suggested in https://github.com/openwrt/packages/pull/17911 by @BKPepe.