### PR TITLE
dockerd: fix dependencies missing

### DIFF
--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -35,7 +35,7 @@ define Package/dockerd
   URL:=https://www.docker.com/
   DEPENDS:=$(GO_ARCH_DEPENDS) +btrfs-progs +ca-certificates +containerd +libdevmapper +libnetwork +tini \
            +KERNEL_SECCOMP:libseccomp +iptables-mod-extra +kmod-br-netfilter +kmod-ikconfig +kmod-nf-conntrack-netlink +kmod-nf-ipvs \
-           +kmod-nf-nat +kmod-veth
+           +kmod-nf-nat +kmod-veth +iptables-legacy +iptables-mod-nat-extra
   USERID:=docker:docker
   MENU:=1
 endef


### PR DESCRIPTION
Maintainer:  @G-M0N3Y-2503 

Compile tested:
tested on build Openwrt master x86_64 with musl on ubuntu 20.04 (amd64)

Run tested:
tested on amd64 qemu kvm vm 

Description:
fix dockerd dependencies missing, dockerd runtime require system has legacy iptables command and firewall nat support