### PR TITLE
[22.03] shadowsocks-libev: fix compat issue with newer version of ucode 

### DIFF
--- a/net/shadowsocks-libev/Makefile
+++ b/net/shadowsocks-libev/Makefile
@@ -14,7 +14,7 @@ include $(TOPDIR)/rules.mk
 #
 PKG_NAME:=shadowsocks-libev
 PKG_VERSION:=3.3.5
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/shadowsocks/shadowsocks-libev/releases/download/v$(PKG_VERSION)

--- a/net/shadowsocks-libev/files/shadowsocks-libev.init
+++ b/net/shadowsocks-libev/files/shadowsocks-libev.init
@@ -156,7 +156,7 @@ ss_rules() {
 	json_add_string o_nft_udp_extra "$nft_udp_extra"
 	json_dump -i >"$tmp.json"
 
-	if ucode -S -i "$ssrules_uc" -E "$tmp.json" >"$tmp.nft" \
+	if utpl -S -F "$tmp.json" "$ssrules_uc" >"$tmp.nft" \
 		&& ! cmp -s "$tmp.nft" "$ssrules_nft"; then
 		echo "table inet chk {include \"$tmp.nft\";}" >"$tmp.nft.chk"
 		if nft -f "$tmp.nft.chk" -c; then


### PR DESCRIPTION
Maintainer: @yousong
Compile tested: ath79/nand
Run tested: ath79/nand