### PR TITLE
usbip: remove unused libbsd and pthreads deps

### DIFF
--- a/net/usbip/Makefile
+++ b/net/usbip/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=usbip
-PKG_RELEASE:=14
+PKG_RELEASE:=15
 PKG_LICENSE:=GPL-2.0-only
 
 # Since kernel 2.6.39.1 userspace tools are inside the kernel tree
@@ -52,7 +52,7 @@ endef
 define Package/usbip
   $(call Package/usbip/Default)
   TITLE+= (common)
-  DEPENDS+= +libwrap +kmod-usbip +libudev +USE_GLIBC:libbsd +usbids
+  DEPENDS+= +libwrap +kmod-usbip +libudev +usbids
 endef
 
 define Package/usbip-client
@@ -81,7 +81,6 @@ define Build/Configure
 	$(call Build/Configure/Default)
 endef
 
-CONFIGURE_VARS+= $(if $(CONFIG_USE_GLIBC),LIBS='-lbsd -lpthread')
 CFLAGS+="$(TARGET_CFLAGS) -I$(STAGING_DIR)/usr/include"
 
 define Package/usbip/install


### PR DESCRIPTION
Maintainer: @nunojpg 
Compile tested: x64 glibc toolchain built from commit f757a8a09885e3c8bb76371e037b8c0731111980
Run tested: None

This package doesn't actually depend on libbsd and pthreads on glibc. The Makefile was adding them to the build, I don't undersand why, but I don't see any mention of either in usbip's source.

Found while working on https://github.com/openwrt/openwrt/pull/9714.