### PR TITLE
[openwrt-21.02] yq: Update to 4.25.1

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.24.5
+PKG_VERSION:=4.25.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8ffab12d2d527f0ac62823777201f8e5e78c9af5c754914274db2733da98c796
+PKG_HASH:=2f0736f0650bef121e31332e1f52c67e9bd975ca651e1507a2e5e3744c10e766
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm27xx/bcm2710
Run tested: raspberrypi 3b

Description:
- Backported from: #18412