### PR TITLE
dockerd: fix compilation with glibc

### DIFF
--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -51,6 +51,7 @@ endef
 GO_PKG_BUILD_VARS += GO111MODULE=auto
 TAR_OPTIONS:=--strip-components 1 $(TAR_OPTIONS)
 TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
+TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-lc -lgcc_eh)
 
 # $(1) = path to dependent package 'Makefile'
 # $(2) = relevant dependency '.installer' file


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503 

Compile tested:
tested on build Openwrt master x86_64 with glibc on ubuntu 20.04

Run tested:
tested on amd64 qemu kvm vm

Description:
fix dockerd build error when using glibc on tartget.
This change can also apply to branch 22.03

