### PR TITLE
tor: bump to 0.4.7.7 stable

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.6.10
+PKG_VERSION:=0.4.7.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=94ccd60e04e558f33be73032bc84ea241660f92f58cfb88789bda6893739e31c
+PKG_HASH:=3e131158b52b9435d7e43d1c47ef288b96d005342cc44b8c950bb403851a5b44
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @tripolar

The first stable release in the 0.4.7.x series.

Run-tested (tor-basic):
mediatek/mt7622 (Belkin RT3200)

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>