### PR TITLE
mtools: avoid picking libbsd dependency

### DIFF
--- a/utils/mtools/Makefile
+++ b/utils/mtools/Makefile
@@ -29,7 +29,9 @@ define Package/mtools/description
   Mtools is a collection of utilities to access MS-DOS disks from GNU and Unix without mounting them.
 endef
 
-CONFIGURE_VARS += ac_cv_have_x="have_x=no"
+CONFIGURE_VARS += \
+	ac_cv_have_x="have_x=no" \
+	ac_cv_lib_bsd_main=no
 
 define Package/mtools/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Maintainer: @oskarirauta 
Compile tested: ramips/rt3883, mipsel_74kc, openwrt master--also host-compiled under gentoo to ensure glibc does not need it.
Run tested: ramips/rt3883, mipsel_74kc, openwrt master

Description:

Even though commit 96ec989ed ("mtools: update to 4.0.39") correctly dropped libbsd dependency, the package's configure script will still link to it if the library is found.

Tell configure not to look for it by setting `ac_cv_lib_bsd_main=no`.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

CC: @guijan 