### PR TITLE
docker-compose: Update to version 2.5.0

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.4.1
+PKG_VERSION:=2.5.0
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=ebf56ab2f3912d49f4ef9a0e48b219cf9cbff958d20990a5ff9b7a8ced8e69fc
+PKG_HASH:=e002f4f50bfb1b3c937dc0a86a8a59395182fe1288e4ed3429db5771f68f7320
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream release. I've had to revert the update to runc 1.0.3 in order to build the docker in master but other than that compose is working fine.

What's Changed:

 - Fix search/replace typo in --no-TTY documentation by @ericfreese
 - Fix panic with down command when -p flag specified by @glours
 - use project we just created to start services by @ndeloof
 - include services declared by links as implicit dependencies by
 @ndeloof
 - pull to respect pull_policy by @ndeloof
 - don't ignore error by @ndeloof
 - project name MUST be lowercase by @ndeloof
 - add support for build secrets by @ndeloof
 - create also a checksums.txt file, add --binary by @MaxPeal
 - add support for ppc64le for docker compose by @snehakpersistent
 - inspect image ID after pull to se com.docker.compose.image by
 @ndeloof
 - Fix cannot setup IPAM gateway by @qnap-ericfan

New Contributors:

 - @ericfreese made their first contribution
 - @MaxPeal made their first contribution
 - @snehakpersistent made their first contribution
 - @qnap-ericfan made their first contribution

Signed-off-by: Javier Marcet <javier@marcet.info>
