### PR TITLE
python3-paramiko: update to version 2.10.4

### DIFF
--- a/lang/python/python-paramiko/Makefile
+++ b/lang/python/python-paramiko/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-paramiko
-PKG_VERSION:=2.10.3
+PKG_VERSION:=2.10.4
 PKG_RELEASE:=1
 
 PYPI_NAME:=paramiko
-PKG_HASH:=ddb1977853aef82804b35d72a0e597b244fa326c404c350bd00c5b01dbfee71a
+PKG_HASH:=3d2e650b6812ce6d160abff701d6ef4434ec97934b13e95cf1ad3da70ffb5c58
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream release.

 - [Bug] Servers offering certificate variants of hostkey algorithms
 (eg ssh-rsa-cert-v01@openssh.com) could not have their host keys
 verified by Paramiko clients, as it only ever considered non-cert key
 types for that part of connection handshaking. This has been fixed.

 - [Bug] PKey instances’ __eq__ did not have the usual safety guard in
 place to ensure they were being compared to another PKey object,
 causing occasional spurious BadHostKeyException (among other things).
 This has been fixed. Thanks to Shengdun Hua for the original report
 /patch and to Christopher Papke for the final version of the fix.

 - [Support] Update camelCase method calls against the threading
 module to be snake_case; this and related tweaks should fix some
 deprecation warnings under Python 3.10. Thanks to Karthikeyan
 Singaravelan for the report, @Narendra-Neerukonda for the patch, and
 to Thomas Grainger and Jun Omae for patch workshopping.

Signed-off-by: Javier Marcet <javier@marcet.info>
