### PR TITLE
strongswan: Update to 5.9.6

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
-PKG_VERSION:=5.9.5
+PKG_VERSION:=5.9.6
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/
-PKG_HASH:=983e4ef4a4c6c9d69f5fe6707c7fe0b2b9a9291943bbf4e008faab6bf91c0bdd
+PKG_HASH:=91d0978ac448912759b85452d8ff0d578aafd4507aaf4f1c1719f9d0c7318ab7
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>, Noel Kuntze <noel.kuntze@thermi.consulting>
 PKG_CPE_ID:=cpe:/a:strongswan:strongswan

--- a/net/strongswan/patches/010-enum-Fix-compiler-warnings.patch
+++ b/net/strongswan/patches/010-enum-Fix-compiler-warnings.patch
@@ -1,0 +1,19 @@
+commit d23c0ea81e630af3cfda89aeeb52146c0c84c960
+Author: Tobias Brunner <tobias@strongswan.org>
+Date:   Mon May 2 09:31:49 2022 +0200
+
+    enum: Fix compiler warning
+    
+    Closes strongswan/strongswan#1025
+
+--- a/src/libstrongswan/utils/enum.c
++++ b/src/libstrongswan/utils/enum.c
+@@ -97,7 +97,7 @@ char *enum_flags_to_string(enum_name_t *
+ 		return buf;
+ 	}
+ 
+-	if (snprintf(buf, len, e->names[0]) >= len)
++	if (snprintf(buf, len, "%s", e->names[0]) >= len)
+ 	{
+ 		return NULL;
+ 	}

--- a/net/strongswan/patches/0904-gmpdh-Plugin-that-implements-gmp-DH-functions-in-an-.patch
+++ b/net/strongswan/patches/0904-gmpdh-Plugin-that-implements-gmp-DH-functions-in-an-.patch
@@ -25,8 +25,8 @@ Subject: [PATCH 904/904] gmpdh: Plugin that implements gmp DH functions in an
 +ARG_DISBL_SET([gmpdh],          [disable GNU MP (libgmp) based static-linked crypto DH minimal implementation plugin.])
  ARG_DISBL_SET([curve25519],     [disable Curve25519 Diffie-Hellman plugin.])
  ARG_DISBL_SET([hmac],           [disable HMAC crypto implementation plugin.])
- ARG_ENABL_SET([md4],            [enable MD4 software implementation plugin.])
-@@ -1487,6 +1488,7 @@ ADD_PLUGIN([botan],                [s ch
+ ARG_DISBL_SET([kdf],            [disable KDF (prf+) implementation plugin.])
+@@ -1496,6 +1497,7 @@ ADD_PLUGIN([pkcs8],                [s ch
  ADD_PLUGIN([af-alg],               [s charon scepclient pki scripts medsrv attest nm cmd aikgen])
  ADD_PLUGIN([fips-prf],             [s charon nm cmd])
  ADD_PLUGIN([gmp],                  [s charon scepclient pki scripts manager medsrv attest nm cmd aikgen fuzz])
@@ -34,7 +34,7 @@ Subject: [PATCH 904/904] gmpdh: Plugin that implements gmp DH functions in an
  ADD_PLUGIN([curve25519],           [s charon pki scripts nm cmd])
  ADD_PLUGIN([agent],                [s charon nm cmd])
  ADD_PLUGIN([keychain],             [s charon cmd])
-@@ -1628,6 +1630,7 @@ AM_CONDITIONAL(USE_SHA3, test x$sha3 = x
+@@ -1639,6 +1641,7 @@ AM_CONDITIONAL(USE_SHA3, test x$sha3 = x
  AM_CONDITIONAL(USE_MGF1, test x$mgf1 = xtrue)
  AM_CONDITIONAL(USE_FIPS_PRF, test x$fips_prf = xtrue)
  AM_CONDITIONAL(USE_GMP, test x$gmp = xtrue)
@@ -42,7 +42,7 @@ Subject: [PATCH 904/904] gmpdh: Plugin that implements gmp DH functions in an
  AM_CONDITIONAL(USE_CURVE25519, test x$curve25519 = xtrue)
  AM_CONDITIONAL(USE_RDRAND, test x$rdrand = xtrue)
  AM_CONDITIONAL(USE_AESNI, test x$aesni = xtrue)
-@@ -1905,6 +1908,7 @@ AC_CONFIG_FILES([
+@@ -1918,6 +1921,7 @@ AC_CONFIG_FILES([
  	src/libstrongswan/plugins/mgf1/Makefile
  	src/libstrongswan/plugins/fips_prf/Makefile
  	src/libstrongswan/plugins/gmp/Makefile
@@ -52,7 +52,7 @@ Subject: [PATCH 904/904] gmpdh: Plugin that implements gmp DH functions in an
  	src/libstrongswan/plugins/aesni/Makefile
 --- a/src/libstrongswan/Makefile.am
 +++ b/src/libstrongswan/Makefile.am
-@@ -348,6 +348,13 @@ if MONOLITHIC
+@@ -353,6 +353,13 @@ if MONOLITHIC
  endif
  endif
  


### PR DESCRIPTION
Maintainer: me, @Thermi 
Compile tested: x86_64, generic, HEAD (41be1a2de2)
Run tested: same, installed on production router

Description:

Version bump to 5.9.6