### PR TITLE
Rust-lang: Rust 1.60.0 Build HOST Toolchain

### DIFF
--- a/lang/rust_host/Makefile
+++ b/lang/rust_host/Makefile
@@ -1,0 +1,128 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rust_host
+PKG_VERSION:=1.60.0
+PKG_RELEASE:=1
+
+PKG_LICENSE:=Apache-2.0 MIT
+PKG_LICENSE_FILES:=LICENSE-APACHE LICENSE-MIT
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/rust-lang/rust.git
+PKG_SOURCE_DATE:=2022-04-07
+PKG_SOURCE_VERSION:=7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c
+PKG_MIRROR_HASH:=abf826ee61460ce7a64b87c956a88dfa157e283d5d465dd839b807d31fef4b83
+PKG_SOURCE_SUBDIR:=rust-$(PKG_VERSION)
+PKG_HOST_ONLY:=1
+
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/rust_host-$(PKG_VERSION)
+HOST_BUILD_PARALLEL:=1
+HOST_USE_NINJA:=1
+
+HOST_BUILD_DEPENDS:=python3/host llvm-project-rustc/host
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+
+TAR_CMD=$(HOST_TAR) --strip=1 -C $(1) $(TAR_OPTIONS) 
+HOST_STAMP_PREPARED=$(HOST_BUILD_DIR)/.prepared_$(RUSTC_HOST_ARCH)
+HOST_STAMP_BUILT=$(HOST_BUILD_DIR)/.built_$(RUSTC_HOST_ARCH)
+HOST_STAMP_CONFIGURED=$(HOST_BUILD_DIR)/.configured_$(RUSTC_HOST_ARCH)
+HOST_STAMP_INSTALLED=$(STAGING_DIR_HOST)/stamp/.rust_$(RUSTC_HOST_ARCH)_installed
+
+# Rust Environmental Vars
+CONFIG_HOST_SUFFIX:=$(shell cut -d"-" -f4 <<<"$(GNU_HOST_NAME)")
+RUSTC_HOST_ARCH:=$(HOST_ARCH)-unknown-linux-$(CONFIG_HOST_SUFFIX)
+RUSTC_TARGET_ARCH:=$(REAL_GNU_TARGET_NAME)
+CARGO_HOME:=$(STAGING_DIR_HOST)
+LLVM_DIR:=$(STAGING_DIR_HOST)/llvm-rust
+
+# Common Build Flags
+RUST_BUILD_FLAGS = \
+  LD_LIBRARY_PATH=$(LLVM_DIR)/lib \
+  CARGO_HOME="$(CARGO_HOME)" \
+  CXXFLAGS=-DLLVM_RUSTLLVM
+
+# Use External rust-lang specific LLVM
+RUST_UNINSTALL:=$(CARGO_HOME)/lib/rustlib/uninstall.sh
+RUST_TMP_DIR:=$(TMP_DIR)/rust-install
+
+# Set Configure Environmentals
+HOST_CONFIGURE_OPTS += CARGO_HOME="$(CARGO_HOME)"
+
+# The Flags are Common between HOST and TARGET
+RUST_COMMON_ARGS := \
+  --build=$(RUSTC_HOST_ARCH) \
+  --host=$(RUSTC_HOST_ARCH) \
+  --dist-compression-formats=xz \
+  --enable-llvm-link-shared \
+  --enable-llvm-plugins \
+  --enable-missing-tools \
+  --enable-ninja \
+  --enable-optimize \
+  --enable-optimize-llvm \
+  --enable-parallel-compiler \
+  --enable-sanitizers \
+  --release-channel=nightly \
+  --prefix=$(CARGO_HOME) \
+  --bindir=$(CARGO_HOME)/bin \
+  --libdir=$(CARGO_HOME)/lib \
+  --sysconfdir=$(CARGO_HOME)/etc \
+  --datadir=$(CARGO_HOME)/share \
+  --mandir=$(CARGO_HOME)/man \
+  --llvm-root=$(LLVM_DIR)
+
+##
+# Because OpenWrt uses default configure flags that are not recognized
+# we override the default and set our own.
+#
+# Rust HOST Configuration Arguments
+HOST_CONFIGURE_ARGS = \
+  --target=$(RUSTC_HOST_ARCH) \
+  ${RUST_COMMON_ARGS}
+
+define Host/Uninstall
+	# Call the Uninstall script
+	[ -f $(RUST_UNINSTALL) ] && \
+	  $(BASH) $(RUST_UNINSTALL) || echo No Uninstall
+
+	rm -rf $(RUST_TMP_DIR)
+endef
+
+# Installation is done via Host/Compile
+define Host/Install
+endef
+
+define Host/Prepare
+	# Ensure rust temp directory
+	[ -d $(RUST_TMP_DIR) ] || \
+	  mkdir -p $(RUST_TMP_DIR)
+
+	$(call Host/Prepare/Default)
+endef
+
+###
+# Build out stage1 artifacts only, stage2 is not needed
+# Only build out minimal tools required to build the tuples
+define Host/Compile
+	cd $(HOST_BUILD_DIR) && \
+	  LD_LIBRARY_PATH=$(LLVM_DIR)/lib:$(STAGING_DIR_HOST)/lib \
+	  CARGO_HOME="$(CARGO_HOME)" \
+	  $(PYTHON) x.py install --config ./config.toml --stage 1 cargo \
+	  library/std rustfmt src src/librustc
+endef
+
+$(eval $(call HostBuild))
+# $(eval $(call BuildPackage,rust))

--- a/lang/rust_host/patches/03-add_mips.patch
+++ b/lang/rust_host/patches/03-add_mips.patch
@@ -1,0 +1,30 @@
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -1016,6 +1016,7 @@
+     ("x86_64-unknown-none", x86_64_unknown_none),
+
+     ("mips64-openwrt-linux-musl", mips64_openwrt_linux_musl),
++    ("mips-openwrt-linux-musl", mips_openwrt_linux_musl),
+ }
+
+ /// Warnings encountered when parsing the target `json`.
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/mips_openwrt_linux_musl.rs
+@@ -0,0 +1,17 @@
++use crate::abi::Endian;
++use crate::spec::{Target, TargetOptions};
++
++pub fn target() -> Target {
++    let mut base = super::linux_musl_base::opts();
++    base.cpu = "mips32r2".to_string();
++    base.features = "+mips32r2,+soft-float".to_string();
++    base.max_atomic_width = Some(32);
++    base.crt_static_default = false;
++    Target {
++        llvm_target: "mips-unknown-linux-musl".to_string(),
++        pointer_width: 32,
++        data_layout: "E-m:m-p:32:32-i8:8:32-i16:16:32-i64:64-n32-S64".to_string(),
++        arch: "mips".to_string(),
++        options: TargetOptions { endian: Endian::Big, mcount: "_mcount".to_string(), ..base },
++    }
++}

--- a/lang/rust_host/patches/04-add_mipsel.patch
+++ b/lang/rust_host/patches/04-add_mipsel.patch
@@ -1,0 +1,29 @@
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/mipsel_openwrt_linux_musl.rs
+@@ -0,0 +1,16 @@
++use crate::spec::{Target, TargetOptions};
++
++pub fn target() -> Target {
++    let mut base = super::linux_musl_base::opts();
++    base.cpu = "mips32r2".to_string();
++    base.features = "+mips32r2,+soft-float".to_string();
++    base.max_atomic_width = Some(32);
++    base.crt_static_default = false;
++    Target {
++        llvm_target: "mipsel-unknown-linux-musl".to_string(),
++        pointer_width: 32,
++        data_layout: "e-m:m-p:32:32-i8:8:32-i16:16:32-i64:64-n32-S64".to_string(),
++        arch: "mips".to_string(),
++        options: TargetOptions { mcount: "_mcount".to_string(), ..base },
++    }
++}
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -1015,6 +1015,7 @@
+
+     ("mips64-openwrt-linux-musl", mips64_openwrt_linux_musl),
+     ("mips-openwrt-linux-musl", mips_openwrt_linux_musl),
++    ("mipsel-openwrt-linux-musl", mipsel_openwrt_linux_musl),
+ }
+
+ /// Warnings encountered when parsing the target `json`.

--- a/lang/rust_host/patches/05-add_aarch64.patch
+++ b/lang/rust_host/patches/05-add_aarch64.patch
@@ -1,0 +1,27 @@
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/aarch64_openwrt_linux_musl.rs
+@@ -0,0 +1,14 @@
++use crate::spec::{Target, TargetOptions};
++
++pub fn target() -> Target {
++    let mut base = super::linux_musl_base::opts();
++    base.max_atomic_width = Some(128);
++
++    Target {
++        llvm_target: "aarch64-unknown-linux-musl".to_string(),
++        pointer_width: 64,
++        data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128".to_string(),
++        arch: "aarch64".to_string(),
++        options: TargetOptions { mcount: "\u{1}_mcount".to_string(), ..base },
++    }
++}
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -1016,6 +1016,7 @@
+     ("mips64-openwrt-linux-musl", mips64_openwrt_linux_musl),
+     ("mips-openwrt-linux-musl", mips_openwrt_linux_musl),
+     ("mipsel-openwrt-linux-musl", mipsel_openwrt_linux_musl),
++    ("aarch64-openwrt-linux-musl", aarch64_openwrt_linux_musl),
+ }
+
+ /// Warnings encountered when parsing the target `json`.

--- a/lang/rust_host/patches/06-add_armv7.patch
+++ b/lang/rust_host/patches/06-add_armv7.patch
@@ -1,0 +1,38 @@
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/armv7_openwrt_linux_muslgnueabi.rs
+@@ -0,0 +1,25 @@
++use crate::spec::{Target, TargetOptions};
++
++// This target is for musl Linux on ARMv7 without thumb-mode, NEON or
++// hardfloat.
++
++pub fn target() -> Target {
++    // Most of these settings are copied from the armv7_unknown_linux_gnueabi
++    // target.
++    Target {
++        // It's important we use "gnueabi" and not "musleabi" here. LLVM uses it
++        // to determine the calling convention and float ABI, and it doesn't
++        // support the "musleabi" value.
++        llvm_target: "armv7-unknown-linux-gnueabi".to_string(),
++        pointer_width: 32,
++        data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
++        arch: "arm".to_string(),
++
++        options: TargetOptions {
++            abi: "eabi".to_string(),
++            max_atomic_width: Some(64),
++            mcount: "\u{1}mcount".to_string(),
++            ..super::linux_musl_base::opts()
++        },
++    }
++}
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -1017,6 +1017,7 @@
+     ("mips-openwrt-linux-musl", mips_openwrt_linux_musl),
+     ("mipsel-openwrt-linux-musl", mipsel_openwrt_linux_musl),
+     ("aarch64-openwrt-linux-musl", aarch64_openwrt_linux_musl),
++    ("armv7-openwrt-linux-muslgnueabi", armv7_openwrt_linux_muslgnueabi),
+ }
+
+ /// Warnings encountered when parsing the target `json`.

--- a/lang/rust_host/patches/07-add_armv7hf.patch
+++ b/lang/rust_host/patches/07-add_armv7hf.patch
@@ -1,0 +1,37 @@
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/armv7_openwrt_linux_muslgnueabihf.rs
+@@ -0,0 +1,24 @@
++use crate::spec::{Target, TargetOptions};
++
++// This target is for musl Linux on ARMv7 without thumb-mode or NEON.
++
++pub fn target() -> Target {
++    Target {
++        // It's important we use "gnueabihf" and not "musleabihf" here. LLVM
++        // uses it to determine the calling convention and float ABI, and LLVM
++        // doesn't support the "musleabihf" value.
++        llvm_target: "armv7-unknown-linux-gnueabihf".to_string(),
++        pointer_width: 32,
++        data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
++        arch: "arm".to_string(),
++
++        // Most of these settings are copied from the armv7_unknown_linux_gnueabihf
++        // target.
++        options: TargetOptions {
++            abi: "eabihf".to_string(),
++            max_atomic_width: Some(64),
++            mcount: "\u{1}mcount".to_string(),
++            ..super::linux_musl_base::opts()
++        },
++    }
++}
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -1018,6 +1018,7 @@
+     ("mipsel-openwrt-linux-musl", mipsel_openwrt_linux_musl),
+     ("aarch64-openwrt-linux-musl", aarch64_openwrt_linux_musl),
+     ("armv7-openwrt-linux-muslgnueabi", armv7_openwrt_linux_muslgnueabi),
++    ("armv7-openwrt-linux-muslgnueabihf", armv7_openwrt_linux_muslgnueabihf),
+ }
+
+ /// Warnings encountered when parsing the target `json`.

--- a/lang/rust_host/patches/08-add_powerpc64.patch
+++ b/lang/rust_host/patches/08-add_powerpc64.patch
@@ -1,0 +1,30 @@
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/powerpc64_openwrt_linux_musl.rs
+@@ -0,0 +1,17 @@
++use crate::abi::Endian;
++use crate::spec::{LinkerFlavor, Target, TargetOptions};
++
++pub fn target() -> Target {
++    let mut base = super::linux_musl_base::opts();
++    base.cpu = "ppc64".to_string();
++    base.pre_link_args.entry(LinkerFlavor::Gcc).or_default().push("-m64".to_string());
++    base.max_atomic_width = Some(64);
++
++    Target {
++        llvm_target: "powerpc64-unknown-linux-musl".to_string(),
++        pointer_width: 64,
++        data_layout: "E-m:e-i64:64-n32:64-S128-v256:256:256-v512:512:512".to_string(),
++        arch: "powerpc64".to_string(),
++        options: TargetOptions { endian: Endian::Big, mcount: "_mcount".to_string(), ..base },
++    }
++}
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -1019,6 +1019,7 @@
+     ("aarch64-openwrt-linux-musl", aarch64_openwrt_linux_musl),
+     ("armv7-openwrt-linux-muslgnueabi", armv7_openwrt_linux_muslgnueabi),
+     ("armv7-openwrt-linux-muslgnueabihf", armv7_openwrt_linux_muslgnueabihf),
++    ("powerpc64-openwrt-linux-musl", powerpc64_openwrt_linux_musl),
+ }
+
+ /// Warnings encountered when parsing the target `json`.

--- a/lang/rust_host/patches/09-add_x86_64.patch
+++ b/lang/rust_host/patches/09-add_x86_64.patch
@@ -1,0 +1,38 @@
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/x86_64_openwrt_linux_musl.rs
+@@ -0,0 +1,25 @@
++use crate::spec::{LinkerFlavor, SanitizerSet, StackProbeType, Target};
++
++pub fn target() -> Target {
++    let mut base = super::linux_musl_base::opts();
++    base.cpu = "x86-64".to_string();
++    base.max_atomic_width = Some(64);
++    base.pre_link_args.entry(LinkerFlavor::Gcc).or_default().push("-m64".to_string());
++    // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved
++    base.stack_probes = StackProbeType::Call;
++    base.static_position_independent_executables = true;
++    base.supported_sanitizers = SanitizerSet::ADDRESS
++        | SanitizerSet::CFI
++        | SanitizerSet::LEAK
++        | SanitizerSet::MEMORY
++        | SanitizerSet::THREAD;
++
++    Target {
++        llvm_target: "x86_64-unknown-linux-musl".to_string(),
++        pointer_width: 64,
++        data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
++            .to_string(),
++        arch: "x86_64".to_string(),
++        options: base,
++    }
++}
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -1020,6 +1020,7 @@
+     ("armv7-openwrt-linux-muslgnueabi", armv7_openwrt_linux_muslgnueabi),
+     ("armv7-openwrt-linux-muslgnueabihf", armv7_openwrt_linux_muslgnueabihf),
+     ("powerpc64-openwrt-linux-musl", powerpc64_openwrt_linux_musl),
++    ("x86_64-openwrt-linux-musl", x86_64_openwrt_linux_musl),
+ }
+
+ /// Warnings encountered when parsing the target `json`.

--- a/lang/rust_host/patches/10-add_arm.patch
+++ b/lang/rust_host/patches/10-add_arm.patch
@@ -1,0 +1,34 @@
+--- /dev/null   2022-04-12 18:46:38.250000000 -0400
++++ b/compiler/rustc_target/src/spec/arm_openwrt_linux_muslgnueabi.rs
+@@ -0,0 +1,21 @@
++use crate::spec::{Target, TargetOptions};
++
++pub fn target() -> Target {
++    Target {
++        // It's important we use "gnueabi" and not "musleabi" here. LLVM uses it
++        // to determine the calling convention and float ABI, and it doesn't
++        // support the "musleabi" value.
++        llvm_target: "arm-unknown-linux-gnueabi".to_string(),
++        pointer_width: 32,
++        data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
++        arch: "arm".to_string(),
++        options: TargetOptions {
++            abi: "eabi".to_string(),
++            // Most of these settings are copied from the arm_unknown_linux_gnueabi
++            // target.
++            max_atomic_width: Some(64),
++            mcount: "\u{1}mcount".to_string(),
++            ..super::linux_musl_base::opts()
++        },
++    }
++}
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -1030,6 +1030,7 @@ supported_targets! {
+     ("armv7-openwrt-linux-muslgnueabihf", armv7_openwrt_linux_muslgnueabihf),
+     ("powerpc64-openwrt-linux-musl", powerpc64_openwrt_linux_musl),
+     ("x86_64-openwrt-linux-musl", x86_64_openwrt_linux_musl),
++    ("arm-openwrt-linux-muslgnueabi", arm_openwrt_linux_muslgnueabi),
+ }
+ 
+ /// Warnings encountered when parsing the target `json`.

--- a/lang/rust_host/patches/11-add_armhf.patch
+++ b/lang/rust_host/patches/11-add_armhf.patch
@@ -1,0 +1,34 @@
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/arm_openwrt_linux_muslgnueabihf.rs
+@@ -0,0 +1,21 @@
++use crate::spec::{Target, TargetOptions};
++
++pub fn target() -> Target {
++    Target {
++        // It's important we use "gnueabihf" and not "musleabihf" here. LLVM
++        // uses it to determine the calling convention and float ABI, and it
++        // doesn't support the "musleabihf" value.
++        llvm_target: "arm-unknown-linux-gnueabihf".to_string(),
++        pointer_width: 32,
++        data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
++        arch: "arm".to_string(),
++        options: TargetOptions {
++            abi: "eabihf".to_string(),
++            // Most of these settings are copied from the arm_unknown_linux_gnueabihf
++            // target.
++            max_atomic_width: Some(64),
++            mcount: "\u{1}mcount".to_string(),
++            ..super::linux_musl_base::opts()
++        },
++    }
++}
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -1031,6 +1031,7 @@ supported_targets! {
+     ("powerpc64-openwrt-linux-musl", powerpc64_openwrt_linux_musl),
+     ("x86_64-openwrt-linux-musl", x86_64_openwrt_linux_musl),
+     ("arm-openwrt-linux-muslgnueabi", arm_openwrt_linux_muslgnueabi),
++    ("arm-openwrt-linux-muslgnueabihf", arm_openwrt_linux_muslgnueabihf),
+ }
+ 
+ /// Warnings encountered when parsing the target `json`.

--- a/lang/rust_host/patches/12-add_armv5tej.patch
+++ b/lang/rust_host/patches/12-add_armv5tej.patch
@@ -1,0 +1,35 @@
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/armv5tej_openwrt_linux_muslgnueabi.rs
+@@ -0,0 +1,22 @@
++use crate::spec::{Target, TargetOptions};
++
++pub fn target() -> Target {
++    Target {
++        // FIXME: this comment below does not seem applicable?
++        // It's important we use "gnueabihf" and not "musleabihf" here. LLVM
++        // uses it to determine the calling convention and float ABI, and LLVM
++        // doesn't support the "musleabihf" value.
++        llvm_target: "armv5tej-unknown-linux-gnueabi".to_string(),
++        pointer_width: 32,
++        data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
++        arch: "arm".to_string(),
++        options: TargetOptions {
++            abi: "eabi".to_string(),
++            // Atomic operations provided by compiler-builtins
++            max_atomic_width: Some(32),
++            mcount: "\u{1}mcount".to_string(),
++            has_thumb_interworking: true,
++            ..super::linux_musl_base::opts()
++        },
++    }
++}
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -1032,6 +1032,7 @@ supported_targets! {
+     ("x86_64-openwrt-linux-musl", x86_64_openwrt_linux_musl),
+     ("arm-openwrt-linux-muslgnueabi", arm_openwrt_linux_muslgnueabi),
+     ("arm-openwrt-linux-muslgnueabihf", arm_openwrt_linux_muslgnueabihf),
++    ("armv5tej-openwrt-linux-muslgnueabi", armv5tej_openwrt_linux_muslgnueabi),
+ }
+ 
+ /// Warnings encountered when parsing the target `json`.

--- a/lang/rust_host/patches/13-add_armv6k.patch
+++ b/lang/rust_host/patches/13-add_armv6k.patch
@@ -1,0 +1,34 @@
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/armv6k_openwrt_linux_muslgnueabi.rs
+@@ -0,0 +1,21 @@
++use crate::spec::{Target, TargetOptions};
++
++pub fn target() -> Target {
++    Target {
++        // It's important we use "gnueabi" and not "musleabi" here. LLVM uses it
++        // to determine the calling convention and float ABI, and it doesn't
++        // support the "musleabi" value.
++        llvm_target: "armv6k-unknown-linux-gnueabi".into(),
++        pointer_width: 32,
++        data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
++        arch: "arm".into(),
++        options: TargetOptions {
++            abi: "eabi".into(),
++            // Most of these settings are copied from the arm_unknown_linux_gnueabi
++            // target.
++            max_atomic_width: Some(64),
++            mcount: "\u{1}mcount".into(),
++            ..super::linux_musl_base::opts()
++        },
++    }
++}
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -1033,6 +1033,7 @@ supported_targets! {
+     ("arm-openwrt-linux-muslgnueabi", arm_openwrt_linux_muslgnueabi),
+     ("arm-openwrt-linux-muslgnueabihf", arm_openwrt_linux_muslgnueabihf),
+     ("armv5tej-openwrt-linux-muslgnueabi", armv5tej_openwrt_linux_muslgnueabi),
++    ("armv6k-openwrt-linux-muslgnueabi", armv6k_openwrt_linux_muslgnueabi),
+ }
+ 
+ /// Warnings encountered when parsing the target `json`.


### PR DESCRIPTION
Rust-lang toolchain is divided into two separate parts: Build HOST
and TARGET toolchains.  The HOST toolchain is persistent in
STAGING_DIR_HOST and compiled rustc/cargo for use by the TARGET
toolchains which require MUSL specific tags.

This package requires the rust specific LLVM (https://github.com/openwrt/packages/pull/18322)
PR to build and is a dependent for rust-lang TARGET toolchain (https://github.com/openwrt/packages/pull/13916)

Signed-off-by: Donald Hoskins <grommish@gmail.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
