### PR TITLE
audit: Fix compilation with kernel 5.15

### DIFF
--- a/utils/audit/Makefile
+++ b/utils/audit/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=audit
 PKG_VERSION:=2.8.5
-PKG_RELEASE:=2
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://people.redhat.com/sgrubb/audit

--- a/utils/audit/Makefile
+++ b/utils/audit/Makefile
@@ -24,7 +24,6 @@ PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-packages/$(PKG_NAME)-$(PKG_VERSION)
 PKG_USE_MIPS16:=0
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/host-build.mk
 
 define Package/audit/Default
   TITLE:=Audit Daemon
@@ -139,7 +138,6 @@ define Package/audit/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/auditd $(1)/usr/sbin/
 endef
 
-$(eval $(call HostBuild))
 $(eval $(call BuildPackage,libauparse))
 $(eval $(call BuildPackage,audit-utils))
 $(eval $(call BuildPackage,audit))

--- a/utils/audit/Makefile
+++ b/utils/audit/Makefile
@@ -19,6 +19,7 @@ PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:linux_audit_project:linux_audit
 
 PKG_FIXUP:=autoreconf
+PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-packages/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_USE_MIPS16:=0
 

--- a/utils/audit/patches/0003-Make-IPX-packet-interpretation-dependent-on-th.patch
+++ b/utils/audit/patches/0003-Make-IPX-packet-interpretation-dependent-on-th.patch
@@ -1,0 +1,52 @@
+From 6b09724c69d91668418ddb3af00da6db6755208c Mon Sep 17 00:00:00 2001
+From: Steve Grubb <sgrubb@redhat.com>
+Date: Thu, 2 Sep 2021 15:01:12 -0400
+Subject: [PATCH] Make IPX packet interpretation dependent on the ipx header
+ file existing
+
+--- a/auparse/interpret.c
++++ b/auparse/interpret.c
+@@ -44,8 +44,10 @@
+ #include <linux/ax25.h>
+ #include <linux/atm.h>
+ #include <linux/x25.h>
+-#include <linux/if.h>   // FIXME: remove when ipx.h is fixed
+-#include <linux/ipx.h>
++#ifdef HAVE_IPX_HEADERS
++  #include <linux/if.h>   // FIXME: remove when ipx.h is fixed
++  #include <linux/ipx.h>
++#endif
+ #include <linux/capability.h>
+ #include <sys/personality.h>
+ #include <sys/prctl.h>
+@@ -1158,6 +1160,7 @@ static const char *print_sockaddr(const
+ 					      x->sax25_call.ax25_call[6]);
+                         }
+                         break;
++#ifdef HAVE_IPX_HEADERS
+                 case AF_IPX:
+                         {
+                                 const struct sockaddr_ipx *ip =
+@@ -1167,6 +1170,7 @@ static const char *print_sockaddr(const
+ 					str, ip->sipx_port, ip->sipx_network);
+                         }
+                         break;
++#endif
+                 case AF_ATMPVC:
+                         {
+                                 const struct sockaddr_atmpvc* at =
+--- a/configure.ac
++++ b/configure.ac
+@@ -414,6 +414,12 @@ if test x"$LIBWRAP_LIBS" != "x"; then
+ 	AC_DEFINE_UNQUOTED(HAVE_LIBWRAP, [], Define if tcp_wrappers support is enabled )
+ fi
+ 
++# linux/ipx.h - deprecated in 2018
++AC_CHECK_HEADER(linux/ipx.h, ipx_headers=yes, ipx_headers=no)
++if test $ipx_headers = yes ; then
++	AC_DEFINE(HAVE_IPX_HEADERS,1,[IPX packet interpretation])
++fi
++
+ # See if we want to support lower capabilities for plugins
+ LIBCAP_NG_PATH
+ 


### PR DESCRIPTION
Maintainer: @tpetazzoni 
Compile tested:  mediatek/mt7622 (linux 5.15), aarch64, master
Run tested: none, but it is a trivial patch

Description:
Linux 5.15 does not have the linux/ipx.h header.

The patch is a partial cherry-pick (skipped ChangeLog) of upstream commit https://github.com/linux-audit/audit-userspace/commit/6b09724c6 ("Make IPX packet interpretation dependent on the ipx header file existing").

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

----

I've stumbled upon this while doing a `CONFIG_ALL` build to spot kernel-5.15 build problems.

For background, IPX support code was removed from linux in 2018;  the ipx.h header was left there until August 2021, when it was finally removed by https://github.com/torvalds/linux/commit/6c9b40844751ea30c72f7a2f92f4d704bc6b2927.