### PR TITLE
youtube-dl: update to 2021.12.17

### DIFF
--- a/multimedia/youtube-dl/Makefile
+++ b/multimedia/youtube-dl/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=youtube-dl
-PKG_VERSION:=2021.6.6
+PKG_VERSION:=2021.12.17
 PKG_RELEASE:=1
 
 PYPI_NAME:=youtube_dl
-PKG_HASH:=cb2d3ee002158ede783e97a82c95f3817594df54367ea6a77ce5ceea4772f0ab
+PKG_HASH:=bc59e86c5d15d887ac590454511f08ce2c47698d5a82c27bfe27b5d814bbaed2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Unlicense


### PR DESCRIPTION
Maintainer: @BKPepe
Compile tested: armv7, Turris Omnia, OpenWrt 21.02
Run tested: armv7, Turris Omnia, OpenWrt 21.02, downloaded a video, speed is the same as with the old version in 21.02