### PR TITLE
dockerd: Add firewall independent dependencies

### DIFF
--- a/utils/dockerd/Config.in
+++ b/utils/dockerd/Config.in
@@ -1,3 +1,10 @@
+config DOCKER_CHECK_CONFIG
+	bool "Installs check-config.sh with dependencies"
+	default n
+	depends on PACKAGE_dockerd
+	select PACKAGE_bash
+	select PACKAGE_kmod-ikconfig
+
 # These options are mostly specified by https://github.com/moby/moby/blob/master/contrib/check-config.sh
 
 config DOCKER_CGROUP_OPTIONS
@@ -61,6 +68,11 @@ endmenu
 menu "Storage"
 	depends on PACKAGE_dockerd
 
+	config DOCKER_STO_DEVMAPPER
+	bool "Enables support for devmapper snapshotting"
+		default n
+		select PACKAGE_libdevmapper
+
 	config DOCKER_STO_EXT4
 		bool "Enables support for ext3 or ext4 as the backing filesystem"
 		default n
@@ -71,4 +83,5 @@ menu "Storage"
 		bool "Enables support for btrfs as the backing filesystem"
 		default n
 		select KERNEL_BTRFS_FS_POSIX_ACL
+		select PACKAGE_btrfs-progs
 endmenu

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -33,9 +33,23 @@ define Package/dockerd
   CATEGORY:=Utilities
   TITLE:=Docker Community Edition Daemon
   URL:=https://www.docker.com/
-  DEPENDS:=$(GO_ARCH_DEPENDS) +btrfs-progs +ca-certificates +containerd +libdevmapper +libnetwork +tini \
-           +KERNEL_SECCOMP:libseccomp +iptables-mod-extra +kmod-br-netfilter +kmod-ikconfig +kmod-nf-conntrack-netlink +kmod-nf-ipvs \
-           +kmod-nf-nat +kmod-veth +iptables-legacy +iptables-mod-nat-extra
+  DEPENDS:=$(GO_ARCH_DEPENDS) \
+    +btrfs-progs \
+    +ca-certificates \
+    +containerd \
+    +iptables-legacy \
+    +iptables-mod-extra \
+    +iptables-mod-nat-extra \
+    +KERNEL_SECCOMP:libseccomp \
+    +kmod-br-netfilter \
+    +kmod-ikconfig \
+    +kmod-nf-conntrack-netlink \
+    +kmod-nf-ipvs \
+    +kmod-nf-nat \
+    +kmod-veth \
+    +libdevmapper \
+    +libnetwork \
+    +tini
   USERID:=docker:docker
   MENU:=1
 endef

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -34,22 +34,20 @@ define Package/dockerd
   TITLE:=Docker Community Edition Daemon
   URL:=https://www.docker.com/
   DEPENDS:=$(GO_ARCH_DEPENDS) \
-    +btrfs-progs \
     +ca-certificates \
     +containerd \
-    +iptables-legacy \
+    +iptables \
     +iptables-mod-extra \
-    +iptables-mod-nat-extra \
+    +IPV6:ip6tables \
+    +IPV6:kmod-ipt-nat6 \
     +KERNEL_SECCOMP:libseccomp \
-    +kmod-br-netfilter \
-    +kmod-ikconfig \
-    +kmod-nf-conntrack-netlink \
+    +kmod-ipt-nat \
+    +kmod-ipt-physdev \
     +kmod-nf-ipvs \
-    +kmod-nf-nat \
     +kmod-veth \
-    +libdevmapper \
     +libnetwork \
-    +tini
+    +tini \
+    +uci-firewall
   USERID:=docker:docker
   MENU:=1
 endef
@@ -146,8 +144,11 @@ define Package/dockerd/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bundles/binary-daemon/dockerd $(1)/usr/bin/
 
 	$(INSTALL_DIR) $(1)/opt/docker/
+
+  ifeq ($(CONFIG_DOCKER_CHECK_CONFIG),y)
 	$(INSTALL_DIR) $(1)/usr/share/docker/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/check-config.sh $(1)/usr/share/docker/
+  endif
 
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/dockerd.init $(1)/etc/init.d/dockerd

--- a/utils/dockerd/files/etc/config/dockerd
+++ b/utils/dockerd/files/etc/config/dockerd
@@ -21,8 +21,15 @@ config globals 'globals'
 #	list registry_mirrors 'https://<my-docker-mirror-host>'
 #	list registry_mirrors 'https://hub.docker.com'
 
-# Docker ignores fw3 rules and by default all external source IPs are allowed to connect to the Docker host.
+# Docker doesn't work well out of the box with fw4. This is because Docker relies on a compatibility layer that
+# naively translates iptables rules. For the best compatibility replace the following dependencies:
+# `firewall4` -> `firewall`
+# `iptables-nft` -> `iptables-legacy`
+# `ip6tables-nft` -> `ip6tables-legacy`
+
+# Docker undermines the fw3 rules. By default all external source IPs are allowed to connect to the Docker host.
 # See https://docs.docker.com/network/iptables/ for more details.
+
 # firewall config changes are only additive i.e firewall will need to be restarted first to clear old changes,
 # then docker restarted to load in new changes.
 config firewall 'firewall'


### PR DESCRIPTION
Maintainer: me @G-M0N3Y-2503
Compile tested: x86_x64, QEMU/KVM, `master`
Run tested: x86_x64, QEMU/KVM, `master` with fw3

Description:
Changed dependencies so that the docker will "work" with `fw4` or `fw3`.
Currently, `fw3` works as before as long as `iptables-legacy` and `ip6tables-legacy` are installed. Whereas `fw4` "works" with `iptables-nft` and `ip6tables-nft`, however, the default rulset undermines the docker rules and it doesn't seem like there is a reliable way to make them work together to make it work out of the box.
