### PR TITLE
kcptun: add tcp option

### DIFF
--- a/net/kcptun/README.md
+++ b/net/kcptun/README.md
@@ -26,6 +26,7 @@ Every section has a `disabled` option to temporarily turn off the instance.
 | keepalive | integer | --keepalive | seconds between heartbeats (default: 10) |
 | snmplog | string | --snmplog | collect snmp to file, aware of timeformat in golang, like: ./snmp-20060102.log |
 | snmpperiod | integer | --snmpperiod | snmp collect period, in seconds (default: 60) |
+| tcp | boolean | --tcp | to emulate a TCP connection(linux), need root privilege |
 | quiet | boolean | --quiet | suppress the 'stream open/close' messages |
 | gogc | integer |  | set GOGC environment variable, see [Memory Control](https://github.com/xtaci/kcptun#memory-control). |
 | syslog | boolean |  | redirect logs to syslog when set to 1, implemented by [procd](https://openwrt.org/docs/guide-developer/procd-init-scripts#service_parameters). (default: 0) |

--- a/net/kcptun/files/kcptun.config
+++ b/net/kcptun/files/kcptun.config
@@ -13,6 +13,7 @@ config server
 	option snmplog '/var/log/snmp.log'
 	option snmpperiod 60
 	option pprof 1
+	option tcp 0
 	option quiet 1
 	option syslog 1
 	option user nobody
@@ -38,6 +39,7 @@ config client
 	option smuxbuf 4194304
 	option streambuf 2097152
 	option keepalive 10
+	option tcp 0
 	option quiet 1
 	option gogc 20
 	option user nobody

--- a/net/kcptun/files/kcptun.init
+++ b/net/kcptun/files/kcptun.init
@@ -64,6 +64,7 @@ kcptun() {
 	[ -z "$keepalive" ] || json_add_int keepalive "$keepalive"
 	[ -z "$snmplog" ] || json_add_string snmplog "$snmplog"
 	[ -z "$snmpperiod" ] || json_add_int snmpperiod "$snmpperiod"
+	json_add_boolean tcp "$tcp"
 	json_add_boolean quiet "$quiet"
 	json_dump -i > "$confjson"
 
@@ -140,6 +141,7 @@ validate_common_options() {
 		'keepalive:uinteger' \
 		'snmplog:string' \
 		'snmpperiod:uinteger' \
+		'tcp:bool' \
 		'quiet:bool' \
 		'gogc:uinteger' \
 		'syslog:bool:1' \


### PR DESCRIPTION
Add a tcp option in the init.d script and config file.
This option is supported by the current version of kcptun.
I hope it can be cherry-picked to the branch openwrt-21.02 & openwrt-22.03.