### PR TITLE
bluez-tools: fix compile with BUILD_NLS

### DIFF
--- a/utils/bluez-tools/Makefile
+++ b/utils/bluez-tools/Makefile
@@ -26,6 +26,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/bluez-tools-$(PKG_VERSION)
 PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/bluez-tools
   SECTION:=Utilities


### PR DESCRIPTION
Maintainer: @CarlosDerSeher 
Compile tested: Turris MOX, mvebu/cortexa53, OpenWrt master
Run tested: N/A

Description:
Fixes:
ccache_cc  -Os -pipe -mcpu=cortex-a53 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -fmacro-prefix-map=/mox-openwrt-master/build/build_dir/target-aarch64_cortex-a53_musl/bluez-tools-20201025.f653217=bluez-tools-20201025.f653217 -Wformat -Werror=format-security -DPIC -fPIC -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wl,-z,now -Wl,-z,relro   -L/mox-openwrt-master/build/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/usr/lib -L/mox-openwrt-master/build/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/lib -DPIC -fPIC -specs=/mox-openwrt-master/build/include/hardened-ld-pie.specs -znow -zrelro  -o bt-adapter lib/agent-helper.o lib/dbus-common.o lib/helpers.o lib/manager.o lib/obex_agent.o lib/properties.o lib/sdp.o lib/bluez/adapter.o lib/bluez/agent_manager.o lib/bluez/alert_agent.o lib/bluez/alert.o lib/bluez/cycling_speed.o lib/bluez/cycling_speed_manager.o lib/bluez/device.o lib/bluez/health_channel.o lib/bluez/health_device.o lib/bluez/health_manager.o lib/bluez/heart_rate.o lib/bluez/heart_rate_manager.o lib/bluez/media.o lib/bluez/media_control.o lib/bluez/media_player.o lib/bluez/network.o lib/bluez/network_server.o lib/bluez/obex/obex_agent_manager.o lib/bluez/obex/obex_client.o lib/bluez/obex/obex_file_transfer.o lib/bluez/obex/obex_message_access.o lib/bluez/obex/obex_message.o lib/bluez/obex/obex_object_push.o lib/bluez/obex/obex_phonebook_access.o lib/bluez/obex/obex_session.o lib/bluez/obex/obex_synchronization.o lib/bluez/obex/obex_transfer.o lib/bluez/profile_manager.o lib/bluez/proximity_monitor.o lib/bluez/proximity_reporter.o lib/bluez/sim_access.o lib/bluez/thermometer.o lib/bluez/thermometer_manager.o bt-adapter.o -L/mox-openwrt-master/build/staging_dir/target-aarch64_cortex-a53_musl/usr/lib -lglib-2.0 -lintl  -L/mox-openwrt-master/build/staging_dir/target-aarch64_cortex-a53_musl/usr/lib -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lintl
/mox-openwrt-master/build/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/11.2.0/../../../../aarch64-openwrt-linux-musl/bin/ld: cannot find -lintl
/mox-openwrt-master/build/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/11.2.0/../../../../aarch64-openwrt-linux-musl/bin/ld: cannot find -lintl
collect2: error: ld returned 1 exit status
make[5]: *** [Makefile:580: bt-adapter] Error 1
