### PR TITLE
cni: update to v1.1.0

### DIFF
--- a/utils/cni/Makefile
+++ b/utils/cni/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cni
-PKG_VERSION:=1.0.1
+PKG_VERSION:=1.1.0
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containernetworking/$(PKG_NAME)/archive/v$(PKG_VERSION)
-PKG_HASH:=0e5376f70fb36c26935ddfb90b0da69736592ba8b577fbfb904750034c053d3b
+PKG_HASH:=d06305d6daf271838964c00591ddc53a9cc506e1e249b435ec31b0ea3353cbc5
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>, Paul Spooren <mail@aparcar.org>, Oskari Rauta <oskari.rauta@gmail.com>
 


### PR DESCRIPTION
A minor update to the CNI libraries and tooling.
This does not bump the protocol / spec version, which remains at v1.0.0.

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>

Maintainer: Daniel Golle / @dangowrt, Paul Spooren / @aparcar , Oskari Rauta / @oskarirauta 
Compile tested: x86_64
Run tested: x86_64
