### PR TITLE
slirp4netns: update to v1.2.0

### DIFF
--- a/utils/slirp4netns/Makefile
+++ b/utils/slirp4netns/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=slirp4netns
-PKG_VERSION:=1.1.12
+PKG_VERSION:=1.2.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/rootless-containers/slirp4netns/archive/v$(PKG_VERSION)
-PKG_HASH:=279dfe58a61b9d769f620b6c0552edd93daba75d7761f7c3742ec4d26aaa2962
+PKG_HASH:=b584edde686d3cfbac210cbdb93c4b0ba5d8cc0a6a4d92b9dfc3c5baec99c727
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Pending for libslirp #18486 (compiles with previous libslirp though just fine..)

Changelog:
https://github.com/rootless-containers/slirp4netns/releases

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>

Maintainer: Oskari Rauta / @oskarirauta
Compile tested: x86_64
Run tested: x86_64