### PR TITLE
nut: add cable type nut driver config

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=27
+PKG_RELEASE:=28
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -147,6 +147,7 @@ build_driver_config() {
 	echo "[$cfg]" >>"$UPS_C"
 
 	get_write_driver_config "$cfg" bus
+	get_write_driver_config "$cfg" cable
 	get_write_driver_config "$cfg" community
 	get_write_driver_config "$cfg" desc
 	get_write_driver_config "$cfg" driver "usbhid-ups"


### PR DESCRIPTION
retake of MR #18464

Maintainer: RobJE @robje
Compile tested: none
Run tested: 19.07.x and 21.02.3 (both hot-patched)

Description:
at least driver apcsmart-old (maybe more) allow for specifying the
type of cable used. My old UPS does will not function when cable type
is not specified.

This will add support for configuration option 'cable'
