### PR TITLE
[19.07] postgresql: security update to 11.16

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postgresql
-PKG_VERSION:=11.14
+PKG_VERSION:=11.16
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=PostgreSQL
@@ -17,7 +17,7 @@ PKG_SOURCE_URL:=\
 	http://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
 	ftp://ftp.postgresql.org/pub/source/v$(PKG_VERSION)
 
-PKG_HASH:=965c7f4be96fb64f9581852c58c4f05c3812d4ad823c0f3e2bdfe777c162f999
+PKG_HASH:=2dd9e111f0a5949ee7cacc065cea0fb21092929bae310ce05bf01b4ffc5103a5
 
 PKG_USE_MIPS16:=0
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: armv7, Turris Omnia, OpenWrt 19.07
Run tested: no

Description: fixes CVE-2022-1552