### PR TITLE
[21.02] postgresql: security update to 13.7

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postgresql
-PKG_VERSION:=13.5
+PKG_VERSION:=13.7
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=PostgreSQL
@@ -17,7 +17,7 @@ PKG_SOURCE_URL:=\
 	http://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
 	ftp://ftp.postgresql.org/pub/source/v$(PKG_VERSION)
 
-PKG_HASH:=9b81067a55edbaabc418aacef457dd8477642827499560b00615a6ea6c13f6b3
+PKG_HASH:=1b905bf4f3d83614a393b3c51fd345910fd261e4f5124a68d9a1fdd3a2a46399
 
 PKG_USE_MIPS16:=0
 PKG_FIXUP:=autoreconf

--- a/libs/postgresql/patches/900-pg_ctl-setuid.patch
+++ b/libs/postgresql/patches/900-pg_ctl-setuid.patch
@@ -8,7 +8,7 @@
  static char *argv0 = NULL;
  static bool allow_core_files = false;
  static time_t start_time;
-@@ -2055,6 +2056,9 @@ do_help(void)
+@@ -2087,6 +2088,9 @@ do_help(void)
  #endif
  	printf(_("  -s, --silent           only print errors, no informational messages\n"));
  	printf(_("  -t, --timeout=SECS     seconds to wait when using -w option\n"));
@@ -18,7 +18,7 @@
  	printf(_("  -V, --version          output version information, then exit\n"));
  	printf(_("  -w, --wait             wait until operation completes (default)\n"));
  	printf(_("  -W, --no-wait          do not wait until operation completes\n"));
-@@ -2267,6 +2271,7 @@ main(int argc, char **argv)
+@@ -2299,6 +2303,7 @@ main(int argc, char **argv)
  		{"options", required_argument, NULL, 'o'},
  		{"silent", no_argument, NULL, 's'},
  		{"timeout", required_argument, NULL, 't'},
@@ -26,7 +26,7 @@
  		{"core-files", no_argument, NULL, 'c'},
  		{"wait", no_argument, NULL, 'w'},
  		{"no-wait", no_argument, NULL, 'W'},
-@@ -2307,20 +2312,6 @@ main(int argc, char **argv)
+@@ -2339,20 +2344,6 @@ main(int argc, char **argv)
  		}
  	}
  
@@ -47,7 +47,7 @@
  
  	env_wait = getenv("PGCTLTIMEOUT");
  	if (env_wait != NULL)
-@@ -2407,11 +2398,15 @@ main(int argc, char **argv)
+@@ -2439,11 +2430,15 @@ main(int argc, char **argv)
  					wait_seconds_arg = true;
  					break;
  				case 'U':
@@ -63,7 +63,7 @@
  					break;
  				case 'w':
  					do_wait = true;
-@@ -2493,6 +2488,41 @@ main(int argc, char **argv)
+@@ -2525,6 +2520,41 @@ main(int argc, char **argv)
  		exit(1);
  	}
  


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: armv7, Turris Omnia, OpenWrt 21.02
Run tested: armv7, Turris Omnia, OpenWrt 21.02

Description: fixes CVE-2022-1552, #18526 is an update for 19.07, but I can't currently build and test an update for master and 22.03, should I create the PR anyway and mention that or would you like to take care of it @dangowrt?