### PR TITLE
lxc: export systemd cgroups after install

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -177,6 +177,10 @@ define Package/lxc-auto/install
 	$(INSTALL_BIN) ./files/lxc-auto.init $(1)/etc/init.d/lxc-auto
 endef
 
+define Package/lxc-auto/postinst
+[ "$${PKG_UPGRADE}" = "0" ] && /etc/init.d/lxc-auto boot
+endef
+
 define Package/lxc-common/conffiles
 /etc/lxc/default.conf
 /etc/lxc/lxc.conf


### PR DESCRIPTION
Maintainer: @ratkaj
Compile tested: armv7, Turris Omnia, OpenWrt 21.02
Run tested: armv7, Turris Omnia, OpenWrt 21.02

Description: otherwise, a user would have to either manually run /etc/init.d/lxc-auto boot or reboot the system to start using lxc.