### PR TITLE
mosquitto: add missing 'persistence' section in config

### DIFF
--- a/net/mosquitto/files/etc/config/mosquitto
+++ b/net/mosquitto/files/etc/config/mosquitto
@@ -2,3 +2,5 @@ config owrt owrt
     option use_uci 0
 
 config mosquitto mosquitto
+
+config persistence persistence


### PR DESCRIPTION
Section 'Persistence' in 'luci-app-mosquitto' is unusable without 'persistence' section in config file.

Signed-off-by: Ptilopsis Leucotis <PtilopsisLeucotis@yandex.com>