### PR TITLE
libcoap: fix broken links on install

### DIFF
--- a/libs/libcoap/Makefile
+++ b/libs/libcoap/Makefile
@@ -79,7 +79,7 @@ endef
 
 define Package/libcoap/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcoap-$(ABI_VERSION).so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcoap-$(ABI_VERSION)*.so* $(1)/usr/lib/
 endef
 
 define Package/coap-client/install


### PR DESCRIPTION
This commit fixes an issue where the `libcoap-3-notls.so` is not installed, in some cases leaving the target's root with no library and just a broken link from `libcoap-3.so` to `libcoap-3-notls.so`.

Latest maintainer: @neheb 

One can reproduce this by enabling `CONFIG_PACKAGE_libcoap` in  [`master`](https://github.com/openwrt/packages) or [`v22.03`](https://github.com/openwrt/packages/tree/openwrt-22.03) on a build for any target.

then one checks for broken `libcoap3*` links, there should be a similar result to the following:

```
$ find ./ -type l -name "libcoap-3*" -exec file {} \; | grep broken
./staging_dir/target-aarch64_cortex-a72_musl/root-bcm27xx/usr/lib/libcoap-3.so: broken symbolic link to libcoap-3-notls.so
./build_dir/target-aarch64_cortex-a72_musl/libcoap-4.3.0/.pkgdir/libcoap/usr/lib/libcoap-3.so: broken symbolic link to libcoap-3-notls.so
./build_dir/target-aarch64_cortex-a72_musl/libcoap-4.3.0/ipkg-aarch64_cortex-a72/libcoap/usr/lib/libcoap-3.so: broken symbolic link to libcoap-3-notls.so
./build_dir/target-aarch64_cortex-a72_musl/root.orig-bcm27xx/usr/lib/libcoap-3.so: broken symbolic link to libcoap-3-notls.so
./build_dir/target-aarch64_cortex-a72_musl/root-bcm27xx/usr/lib/libcoap-3.so: broken symbolic link to libcoap-3-notls.so
```