### PR TITLE
openconnect: fix OpenSSL build without deprecated API

### DIFF
--- a/net/openconnect/Config.in
+++ b/net/openconnect/Config.in
@@ -12,7 +12,6 @@ config OPENCONNECT_GNUTLS
 
 config OPENCONNECT_OPENSSL
 	bool "OpenSSL"
-	select OPENSSL_WITH_DEPRECATED
 
 endchoice
 

--- a/net/openconnect/patches/001-Use-OpenSSL_version-not-deprecated-SSLeay_version.patch
+++ b/net/openconnect/patches/001-Use-OpenSSL_version-not-deprecated-SSLeay_version.patch
@@ -1,0 +1,34 @@
+From 01b7e75034e6d838d7750a828eccaa8dd534f152 Mon Sep 17 00:00:00 2001
+From: David Woodhouse <dwmw2@infradead.org>
+Date: Thu, 12 May 2022 15:55:59 +0100
+Subject: [PATCH] Use OpenSSL_version() not deprecated SSLeay_version()
+
+Fixes: #428
+
+Signed-off-by: David Woodhouse <dwmw2@infradead.org>
+---
+ openssl.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+--- a/openssl.c
++++ b/openssl.c
+@@ -49,6 +49,8 @@
+ typedef int (*X509_STORE_CTX_get_issuer_fn)(X509 **issuer,
+ 					    X509_STORE_CTX *ctx, X509 *x);
+ #define X509_STORE_CTX_get_get_issuer(ctx) ((ctx)->get_issuer)
++#define OpenSSL_version SSLeay_version
++#define OPENSSL_VERSION SSLEAY_VERSION
+ #endif
+ 
+ static char tls_library_version[32] = "";
+@@ -56,7 +58,9 @@ static char tls_library_version[32] = ""
+ const char *openconnect_get_tls_library_version(void)
+ {
+ 	if (!*tls_library_version) {
+-		strncpy(tls_library_version, SSLeay_version(SSLEAY_VERSION), sizeof(tls_library_version));
++		strncpy(tls_library_version,
++			OpenSSL_version(OPENSSL_VERSION),
++			sizeof(tls_library_version));
+ 		tls_library_version[sizeof(tls_library_version)-1]='\0';
+ 	}
+ 	return tls_library_version;


### PR DESCRIPTION
Backport a patch in order to allow building OpenConnect against OpenSSL 1.1.x
without the need for deprecated API (further fixes will be required for OpenSSL
3.x, though).

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>

Maintainer: @nmav 
Run-tested: mediatek/mt7622