### PR TITLE
strongswan: use own updown script

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -418,6 +418,22 @@ $(call Package/strongswan/description/Default)
  eap-peap, tnc-tnccs
 endef
 
+define Package/strongswan-updown-iptables
+  $(call Package/strongswan/Default)
+  TITLE+= updown iptables
+  DEPENDS:=strongswan \
+    +strongswan-mod-updown \
+    +iptables \
+    +IPV6:ip6tables \
+    +iptables-mod-ipsec \
+    +kmod-ipt-ipsec
+endef
+
+define Package/strongswan-updown-iptables/description
+  $(call Package/strongswan/description/Default)
+  This package contains the hotplug script for updown to add iptables rules.
+endef
+
 define BuildPlugin
   define Package/strongswan-mod-$(1)
     $$(call Package/strongswan/Default)
@@ -583,6 +599,12 @@ define Package/strongswan-libtls/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ipsec/libtls.so.* $(1)/usr/lib/ipsec/
 endef
 
+define Package/strongswan-updown-iptables/install
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/ipsec
+	$(CP) ./files/etc/hotplug.d/ipsec/02-iptables \
+		$(1)/etc/hotplug.d/ipsec/02-iptables
+endef
+
 define Plugin/duplicheck/install
 	$(INSTALL_DIR) $(1)/usr/lib/ipsec/plugins
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ipsec/duplicheck $(1)/usr/lib/ipsec/
@@ -649,6 +671,7 @@ $(eval $(call BuildPackage,strongswan-pki))
 $(eval $(call BuildPackage,strongswan-swanctl))
 $(eval $(call BuildPackage,strongswan-gencerts))
 $(eval $(call BuildPackage,strongswan-libtls))
+$(eval $(call BuildPackage,strongswan-updown-iptables))
 $(eval $(call BuildPlugin,addrblock,RFC 3779 address block constraint support,))
 $(eval $(call BuildPlugin,aes,AES crypto,))
 $(eval $(call BuildPlugin,agent,SSH agent signing,))

--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -434,6 +434,20 @@ define Package/strongswan-updown-iptables/description
   This package contains the hotplug script for updown to add iptables rules.
 endef
 
+define Package/strongswan-updown-nftables
+  $(call Package/strongswan/Default)
+  TITLE+= updown nftables
+  DEPENDS:=strongswan \
+    +strongswan-mod-updown \
+    +nftables \
+    +kmod-nft-xfrm
+endef
+
+define Package/strongswan-updown-nftables/description
+  $(call Package/strongswan/description/Default)
+  This package contains the hotplug script for updown to add nftables rules.
+endef
+
 define BuildPlugin
   define Package/strongswan-mod-$(1)
     $$(call Package/strongswan/Default)
@@ -605,6 +619,24 @@ define Package/strongswan-updown-iptables/install
 		$(1)/etc/hotplug.d/ipsec/02-iptables
 endef
 
+define Package/strongswan-updown-nftables/install
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/ipsec
+	$(CP) ./files/etc/hotplug.d/ipsec/02-nftables \
+		$(1)/etc/hotplug.d/ipsec/02-nftables
+
+	$(INSTALL_DIR) $(1)/usr/share/nftables.d/chain-pre/input
+	$(LN) /tmp/strongswan/nftables.d/pre-input.nft \
+		$(1)/usr/share/nftables.d/chain-pre/input/10_strongswan.nft
+
+	$(INSTALL_DIR) $(1)/usr/share/nftables.d/chain-pre/output
+	$(LN) /tmp/strongswan/nftables.d/pre-output.nft \
+		$(1)/usr/share/nftables.d/chain-pre/output/10_strongswan.nft
+
+	$(INSTALL_DIR) $(1)/usr/share/nftables.d/chain-pre/forward
+	$(LN) /tmp/strongswan/nftables.d/pre-forward.nft \
+		$(1)/usr/share/nftables.d/chain-pre/forward/10_strongswan.nft
+endef
+
 define Plugin/duplicheck/install
 	$(INSTALL_DIR) $(1)/usr/lib/ipsec/plugins
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ipsec/duplicheck $(1)/usr/lib/ipsec/
@@ -672,6 +704,7 @@ $(eval $(call BuildPackage,strongswan-swanctl))
 $(eval $(call BuildPackage,strongswan-gencerts))
 $(eval $(call BuildPackage,strongswan-libtls))
 $(eval $(call BuildPackage,strongswan-updown-iptables))
+$(eval $(call BuildPackage,strongswan-updown-nftables))
 $(eval $(call BuildPlugin,addrblock,RFC 3779 address block constraint support,))
 $(eval $(call BuildPlugin,aes,AES crypto,))
 $(eval $(call BuildPlugin,agent,SSH agent signing,))

--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -610,8 +610,11 @@ endef
 
 define Plugin/updown/install
 	$(INSTALL_DIR) $(1)/usr/lib/ipsec/plugins
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ipsec/_updown $(1)/usr/lib/ipsec/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ipsec/plugins/libstrongswan-updown.so $(1)/usr/lib/ipsec/plugins/
+
+	# Install OpenWrt updown script to call all scripts in '/etc/hotplug.d/ipsec'
+	$(CP) ./files/usr/lib/ipsec/_updown-owrt $(1)/usr/lib/ipsec
+
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/ipsec
 	$(CP) ./files/etc/hotplug.d/ipsec/01-user \
 		$(1)/etc/hotplug.d/ipsec/01-user
@@ -717,7 +720,7 @@ $(eval $(call BuildPlugin,sshkey,SSH key decoding,))
 $(eval $(call BuildPlugin,stroke,Stroke,+strongswan-charon +strongswan-ipsec))
 $(eval $(call BuildPlugin,test-vectors,crypto test vectors,))
 $(eval $(call BuildPlugin,unity,Cisco Unity extension,))
-$(eval $(call BuildPlugin,updown,updown firewall,+iptables +IPV6:ip6tables +iptables-mod-ipsec +kmod-ipt-ipsec))
+$(eval $(call BuildPlugin,updown,script execution,))
 $(eval $(call BuildPlugin,vici,Versatile IKE Configuration Interface,))
 $(eval $(call BuildPlugin,whitelist,peer identity whitelisting,))
 $(eval $(call BuildPlugin,wolfssl,WolfSSL crypto,+PACKAGE_strongswan-mod-wolfssl:libwolfssl))

--- a/net/strongswan/files/etc/hotplug.d/ipsec/02-iptables
+++ b/net/strongswan/files/etc/hotplug.d/ipsec/02-iptables
@@ -1,0 +1,568 @@
+#!/bin/sh
+# default updown script
+#
+# Copyright (C) 2003-2004 Nigel Meteringham
+# Copyright (C) 2003-2004 Tuomo Soini
+# Copyright (C) 2002-2004 Michael Richardson
+# Copyright (C) 2005-2007 Andreas Steffen <andreas.steffen@strongswan.org>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+
+# CAUTION:  Installing a new version of strongSwan will install a new
+# copy of this script, wiping out any custom changes you make.  If
+# you need changes, make a copy of this under another name, and customize
+# that, and use the (left/right)updown parameters in ipsec.conf to make
+# strongSwan use yours instead of this default one.
+#      PLUTO_VERSION
+#              indicates  what  version of this interface is being
+#              used.  This document describes version  1.1.   This
+#              is upwardly compatible with version 1.0.
+#
+#       PLUTO_VERB
+#              specifies the name of the operation to be performed
+#              (prepare-host, prepare-client, up-host, up-client,
+#              down-host, or down-client).  If the address family
+#              for security gateway to security gateway communica-
+#              tions is IPv6, then a suffix of -v6 is added to the
+#              verb.
+#
+#       PLUTO_CONNECTION
+#              is the name of the  connection  for  which  we  are
+#              routing.
+#
+#       PLUTO_INTERFACE
+#              is the name of the ipsec interface to be used.
+#
+#       PLUTO_REQID
+#              is the reqid of the AH|ESP policy
+#
+#       PLUTO_PROTO
+#              is the negotiated IPsec protocol, ah|esp
+#
+#       PLUTO_IPCOMP
+#              is not empty if IPComp was negotiated
+#
+#       PLUTO_UNIQUEID
+#              is the unique identifier of the associated IKE_SA
+#
+#       PLUTO_ME
+#              is the IP address of our host.
+#
+#       PLUTO_MY_ID
+#              is the ID of our host.
+#
+#       PLUTO_MY_CLIENT
+#              is the IP address / count of our client subnet.  If
+#              the  client  is  just  the  host,  this will be the
+#              host's own IP address / max (where max  is  32  for
+#              IPv4 and 128 for IPv6).
+#
+#       PLUTO_MY_SOURCEIP
+#       PLUTO_MY_SOURCEIP4_$i
+#       PLUTO_MY_SOURCEIP6_$i
+#              contains IPv4/IPv6 virtual IP received from a responder,
+#              $i enumerates from 1 to the number of IP per address family.
+#              PLUTO_MY_SOURCEIP is a legacy variable and equal to the first
+#              virtual IP, IPv4 or IPv6.
+#
+#       PLUTO_MY_PROTOCOL
+#              is the IP protocol that will be transported.
+#
+#       PLUTO_MY_PORT
+#              is  the  UDP/TCP  port  to  which  the IPsec SA  is
+#              restricted on our side.  For ICMP/ICMPv6 this contains the
+#              message type, and PLUTO_PEER_PORT the message code.
+#
+#       PLUTO_PEER
+#              is the IP address of our peer.
+#
+#       PLUTO_PEER_ID
+#              is the ID of our peer.
+#
+#       PLUTO_PEER_CLIENT
+#              is the IP address / count of the peer's client sub-
+#              net.   If the client is just the peer, this will be
+#              the peer's own IP address / max (where  max  is  32
+#              for IPv4 and 128 for IPv6).
+#
+#       PLUTO_PEER_SOURCEIP
+#       PLUTO_PEER_SOURCEIP4_$i
+#       PLUTO_PEER_SOURCEIP6_$i
+#              contains IPv4/IPv6 virtual IP sent to an initiator,
+#              $i enumerates from 1 to the number of IP per address family.
+#              PLUTO_PEER_SOURCEIP is a legacy variable and equal to the first
+#              virtual IP, IPv4 or IPv6.
+#
+#       PLUTO_PEER_PROTOCOL
+#              is the IP protocol that will be transported.
+#
+#       PLUTO_PEER_PORT
+#              is  the  UDP/TCP  port  to  which  the IPsec SA  is
+#              restricted on the peer side.  For ICMP/ICMPv6 this contains the
+#              message code, and PLUTO_MY_PORT the message type.
+#
+#       PLUTO_XAUTH_ID
+#              is an optional user ID employed by the XAUTH protocol
+#
+#       PLUTO_MARK_IN
+#              is an optional XFRM mark set on the inbound IPsec SA
+#
+#       PLUTO_MARK_OUT
+#              is an optional XFRM mark set on the outbound IPsec SA
+#
+#       PLUTO_IF_ID_IN
+#              is an optional XFRM interface ID set on the inbound IPsec SA
+#
+#       PLUTO_IF_ID_OUT
+#              is an optional XFRM interface ID set on the outbound IPsec SA
+#
+#       PLUTO_UDP_ENC
+#              contains the remote UDP port in the case of ESP_IN_UDP
+#              encapsulation
+#
+#       PLUTO_DNS4_$i
+#       PLUTO_DNS6_$i
+#              contains IPv4/IPv6 DNS server attribute received from a
+#              responder, $i enumerates from 1 to the number of servers per
+#              address family.
+#
+
+# define a minimum PATH environment in case it is not set
+PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/sbin"
+export PATH
+
+LOG_VPN=1
+LOG_TAG="hotplug.d/ipsec/02-iptables"
+LOG_PRIO="daemon.notice"
+
+IPSEC_POLICY="-m policy --pol ipsec --proto $PLUTO_PROTO --reqid $PLUTO_REQID"
+IPSEC_POLICY_IN="$IPSEC_POLICY --dir in"
+IPSEC_POLICY_OUT="$IPSEC_POLICY --dir out"
+
+ICMP_TYPE_OPTION=""
+S_MY_PORT=""
+D_MY_PORT=""
+S_PEER_PORT=""
+D_PEER_PORT=""
+
+check_parameter() {
+	local param="$1"
+
+	case "$param:$*" in
+	':') ;;
+	iptables:iptables) ;;
+	custom:*) ;;
+	*)
+		echo "$0: unknown parameters \`$*'" >&2
+		exit 2
+		;;
+	esac
+}
+
+set_icmp_type() {
+
+	case "$PLUTO_MY_PROTOCOL" in
+	1)
+		# ICMP
+		ICMP_TYPE_OPTION="--icmp-type"
+		;;
+	58)
+		# ICMPv6
+		ICMP_TYPE_OPTION="--icmpv6-type"
+		;;
+	*) ;;
+	esac
+
+	# are there port numbers?
+	if [ "$PLUTO_MY_PORT" != 0 ]; then
+		if [ -n "$ICMP_TYPE_OPTION" ]; then
+			S_MY_PORT="$ICMP_TYPE_OPTION $PLUTO_MY_PORT"
+			D_MY_PORT="$ICMP_TYPE_OPTION $PLUTO_MY_PORT"
+		else
+			S_MY_PORT="--sport $PLUTO_MY_PORT"
+			D_MY_PORT="--dport $PLUTO_MY_PORT"
+		fi
+	fi
+	if [ "$PLUTO_PEER_PORT" != 0 ]; then
+		if [ -n "$ICMP_TYPE_OPTION" ]; then
+			S_MY_PORT="$S_MY_PORT/$PLUTO_PEER_PORT"
+			D_MY_PORT="$D_MY_PORT/$PLUTO_PEER_PORT"
+		else
+			S_PEER_PORT="--sport $PLUTO_PEER_PORT"
+			D_PEER_PORT="--dport $PLUTO_PEER_PORT"
+		fi
+	fi
+}
+
+log_connection() {
+	local action="$1"
+	local mask="$2"
+	local client="$3"
+
+	local message=""
+
+	if [ "$LOG_VPN" -eq "1" ]; then
+		if [ "$PLUTO_PEER_CLIENT" = "$PLUTO_PEER/$mask" ]; then
+			message="[$action] + $PLUTO_PEER_ID $PLUTO_PEER -- $PLUTO_ME"
+		else
+			message="[$action] + $PLUTO_PEER_ID $PLUTO_PEER_CLIENT == $PLUTO_PEER -- $PLUTO_ME"
+		fi
+
+		if [ -n "$client" ]; then
+			message="$message == $client"
+		fi
+
+		logger -t $LOG_TAG \
+			-p $LOG_PRIO \
+			"$message"
+	fi
+}
+
+main() {
+	local command="$1"
+
+	check_parameter
+	set_icmp_type
+
+	case "$PLUTO_VERB:$command" in
+	up-host:iptables)
+		# connection to me, with (left/right)firewall=yes, coming up
+		# This is used only by the default updown script, not by your custom
+		# ones, so do not mess with it; see CAUTION comment up at top.
+		iptables -I INPUT 1 \
+			-i $PLUTO_INTERFACE \
+			-p $PLUTO_MY_PROTOCOL \
+			-s $PLUTO_PEER_CLIENT $S_PEER_PORT \
+			-d $PLUTO_ME $D_MY_PORT \
+			$IPSEC_POLICY_IN \
+			-j ACCEPT
+		iptables -I OUTPUT 1 \
+			-o $PLUTO_INTERFACE \
+			-p $PLUTO_PEER_PROTOCOL \
+			-s $PLUTO_ME $S_MY_PORT \
+			$IPSEC_POLICY_OUT \
+			-d $PLUTO_PEER_CLIENT $D_PEER_PORT \
+			-j ACCEPT
+		# allow IPIP traffic because of the implicit SA created by the kernel if
+		# IPComp is used (for small inbound packets that are not compressed)
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			iptables -I INPUT 1 \
+				-i $PLUTO_INTERFACE \
+				-p 4 \
+				-s $PLUTO_PEER \
+				-d $PLUTO_ME \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+		fi
+		log_connection "up-host" "32" ""
+		;;
+	down-host:iptables)
+		# connection to me, with (left/right)firewall=yes, going down
+		# This is used only by the default updown script, not by your custom
+		# ones, so do not mess with it; see CAUTION comment up at top.
+		iptables -D INPUT \
+			-i $PLUTO_INTERFACE \
+			-p $PLUTO_MY_PROTOCOL \
+			-s $PLUTO_PEER_CLIENT $S_PEER_PORT \
+			-d $PLUTO_ME $D_MY_PORT \
+			$IPSEC_POLICY_IN \
+			-j ACCEPT
+		iptables -D OUTPUT \
+			-o $PLUTO_INTERFACE \
+			-p $PLUTO_PEER_PROTOCOL \
+			-s $PLUTO_ME $S_MY_PORT \
+			-d $PLUTO_PEER_CLIENT $D_PEER_PORT \
+			$IPSEC_POLICY_OUT \
+			-j ACCEPT
+		# IPIP exception teardown
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			iptables -D INPUT \
+				-i $PLUTO_INTERFACE \
+				-p 4 \
+				-s $PLUTO_PEER \
+				-d $PLUTO_ME \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+		fi
+		log_connection "down-host" "32" ""
+		;;
+	up-client:iptables)
+		# connection to client subnet, with (left/right)firewall=yes, coming up
+		# This is used only by the default updown script, not by your custom
+		# ones, so do not mess with it; see CAUTION comment up at top.
+		if [ "$PLUTO_PEER_CLIENT" != "$PLUTO_MY_SOURCEIP/32" ]; then
+			iptables -I FORWARD 1 \
+				-o $PLUTO_INTERFACE \
+				-p $PLUTO_PEER_PROTOCOL \
+				-s $PLUTO_MY_CLIENT $S_MY_PORT \
+				-d $PLUTO_PEER_CLIENT $D_PEER_PORT \
+				$IPSEC_POLICY_OUT \
+				-j ACCEPT
+			iptables -I FORWARD 1 \
+				-i $PLUTO_INTERFACE \
+				-p $PLUTO_MY_PROTOCOL \
+				-s $PLUTO_PEER_CLIENT $S_PEER_PORT \
+				-d $PLUTO_MY_CLIENT $D_MY_PORT \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+		fi
+		# a virtual IP requires an INPUT and OUTPUT rule on the host
+		# or sometimes host access via the internal IP is needed
+		if [ -n "$PLUTO_MY_SOURCEIP" -o -n "$PLUTO_HOST_ACCESS" ]; then
+			iptables -I INPUT 1 \
+				-i $PLUTO_INTERFACE \
+				-p $PLUTO_MY_PROTOCOL \
+				-s $PLUTO_PEER_CLIENT $S_PEER_PORT \
+				-d $PLUTO_MY_CLIENT $D_MY_PORT \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+			iptables -I OUTPUT 1 \
+				-o $PLUTO_INTERFACE \
+				-p $PLUTO_PEER_PROTOCOL \
+				-s $PLUTO_MY_CLIENT $S_MY_PORT \
+				-d $PLUTO_PEER_CLIENT $D_PEER_PORT \
+				$IPSEC_POLICY_OUT \
+				-j ACCEPT
+		fi
+		# allow IPIP traffic because of the implicit SA created by the kernel if
+		# IPComp is used (for small inbound packets that are not compressed).
+		# INPUT is correct here even for forwarded traffic.
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			iptables -I INPUT 1 \
+				-i $PLUTO_INTERFACE \
+				-p 4 \
+				-s $PLUTO_PEER \
+				-d $PLUTO_ME \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+		fi
+		log_connection "up-client" "32" "$PLUTO_MY_CLIENT"
+		;;
+	down-client:iptables)
+		# connection to client subnet, with (left/right)firewall=yes, going down
+		# This is used only by the default updown script, not by your custom
+		# ones, so do not mess with it; see CAUTION comment up at top.
+		if [ "$PLUTO_PEER_CLIENT" != "$PLUTO_MY_SOURCEIP/32" ]; then
+			iptables -D FORWARD \
+				-o $PLUTO_INTERFACE \
+				-p $PLUTO_PEER_PROTOCOL \
+				-s $PLUTO_MY_CLIENT $S_MY_PORT \
+				-d $PLUTO_PEER_CLIENT $D_PEER_PORT \
+				$IPSEC_POLICY_OUT \
+				-j ACCEPT
+			iptables -D FORWARD \
+				-i $PLUTO_INTERFACE \
+				-p $PLUTO_MY_PROTOCOL \
+				-s $PLUTO_PEER_CLIENT $S_PEER_PORT \
+				-d $PLUTO_MY_CLIENT $D_MY_PORT \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+		fi
+		# a virtual IP requires an INPUT and OUTPUT rule on the host
+		# or sometimes host access via the internal IP is needed
+		if [ -n "$PLUTO_MY_SOURCEIP" -o -n "$PLUTO_HOST_ACCESS" ]; then
+			iptables -D INPUT \
+				-i $PLUTO_INTERFACE \
+				-p $PLUTO_MY_PROTOCOL \
+				-s $PLUTO_PEER_CLIENT $S_PEER_PORT \
+				-d $PLUTO_MY_CLIENT $D_MY_PORT \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+			iptables -D OUTPUT \
+				-o $PLUTO_INTERFACE \
+				-p $PLUTO_PEER_PROTOCOL \
+				-s $PLUTO_MY_CLIENT $S_MY_PORT \
+				-d $PLUTO_PEER_CLIENT $D_PEER_PORT \
+				$IPSEC_POLICY_OUT \
+				-j ACCEPT
+		fi
+		# IPIP exception teardown
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			iptables -D INPUT \
+				-i $PLUTO_INTERFACE \
+				-p 4 \
+				-s $PLUTO_PEER \
+				-d $PLUTO_ME \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+		fi
+		log_connection "down-client" "32" "$PLUTO_MY_CLIENT"
+		;;
+	#
+	# IPv6
+	#
+	up-host-v6:iptables)
+		# connection to me, with (left/right)firewall=yes, coming up
+		# This is used only by the default updown script, not by your custom
+		# ones, so do not mess with it; see CAUTION comment up at top.
+		ip6tables -I INPUT 1 \
+			-i $PLUTO_INTERFACE \
+			-p $PLUTO_MY_PROTOCOL \
+			-s $PLUTO_PEER_CLIENT $S_PEER_PORT \
+			-d $PLUTO_ME $D_MY_PORT \
+			$IPSEC_POLICY_IN \
+			-j ACCEPT
+		ip6tables -I OUTPUT 1 \
+			-o $PLUTO_INTERFACE \
+			-p $PLUTO_PEER_PROTOCOL \
+			-s $PLUTO_ME $S_MY_PORT \
+			-d $PLUTO_PEER_CLIENT $D_PEER_PORT \
+			$IPSEC_POLICY_OUT \
+			-j ACCEPT
+		# allow IP6IP6 traffic because of the implicit SA created by the kernel if
+		# IPComp is used (for small inbound packets that are not compressed)
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			ip6tables -I INPUT 1 \
+				-i $PLUTO_INTERFACE \
+				-p 41 \
+				-s $PLUTO_PEER \
+				-d $PLUTO_ME \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+		fi
+		log_connection "up-host-v6" "128" ""
+		;;
+	down-host-v6:iptables)
+		# connection to me, with (left/right)firewall=yes, going down
+		# This is used only by the default updown script, not by your custom
+		# ones, so do not mess with it; see CAUTION comment up at top.
+		ip6tables -D INPUT \
+			-i $PLUTO_INTERFACE \
+			-p $PLUTO_MY_PROTOCOL \
+			-s $PLUTO_PEER_CLIENT $S_PEER_PORT \
+			-d $PLUTO_ME $D_MY_PORT \
+			$IPSEC_POLICY_IN \
+			-j ACCEPT
+		ip6tables -D OUTPUT \
+			-o $PLUTO_INTERFACE \
+			-p $PLUTO_PEER_PROTOCOL \
+			-s $PLUTO_ME $S_MY_PORT \
+			-d $PLUTO_PEER_CLIENT $D_PEER_PORT \
+			$IPSEC_POLICY_OUT \
+			-j ACCEPT
+		# IP6IP6 exception teardown
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			ip6tables -D INPUT \
+				-i $PLUTO_INTERFACE \
+				-p 41 \
+				-s $PLUTO_PEER \
+				-d $PLUTO_ME \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+		fi
+		log_connection "down-host-v6" "128" ""
+		;;
+	up-client-v6:iptables)
+		# connection to client subnet, with (left/right)firewall=yes, coming up
+		# This is used only by the default updown script, not by your custom
+		# ones, so do not mess with it; see CAUTION comment up at top.
+		if [ "$PLUTO_PEER_CLIENT" != "$PLUTO_MY_SOURCEIP/128" ]; then
+			ip6tables -I FORWARD 1 \
+				-o $PLUTO_INTERFACE \
+				-p $PLUTO_PEER_PROTOCOL \
+				-s $PLUTO_MY_CLIENT $S_MY_PORT \
+				-d $PLUTO_PEER_CLIENT $D_PEER_PORT \
+				$IPSEC_POLICY_OUT \
+				-j ACCEPT
+			ip6tables -I FORWARD 1 \
+				-i $PLUTO_INTERFACE \
+				-p $PLUTO_MY_PROTOCOL \
+				-s $PLUTO_PEER_CLIENT $S_PEER_PORT \
+				-d $PLUTO_MY_CLIENT $D_MY_PORT \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+		fi
+		# a virtual IP requires an INPUT and OUTPUT rule on the host
+		# or sometimes host access via the internal IP is needed
+		if [ -n "$PLUTO_MY_SOURCEIP" -o -n "$PLUTO_HOST_ACCESS" ]; then
+			ip6tables -I INPUT 1 \
+				-i $PLUTO_INTERFACE \
+				-p $PLUTO_MY_PROTOCOL \
+				-s $PLUTO_PEER_CLIENT $S_PEER_PORT \
+				-d $PLUTO_MY_CLIENT $D_MY_PORT \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+			ip6tables -I OUTPUT 1 \
+				-o $PLUTO_INTERFACE \
+				-p $PLUTO_PEER_PROTOCOL \
+				-s $PLUTO_MY_CLIENT $S_MY_PORT \
+				-d $PLUTO_PEER_CLIENT $D_PEER_PORT \
+				$IPSEC_POLICY_OUT \
+				-j ACCEPT
+		fi
+		# allow IP6IP6 traffic because of the implicit SA created by the kernel if
+		# IPComp is used (for small inbound packets that are not compressed).
+		# INPUT is correct here even for forwarded traffic.
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			ip6tables -I INPUT 1 \
+				-i $PLUTO_INTERFACE \
+				-p 41 \
+				-s $PLUTO_PEER \
+				-d $PLUTO_ME \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+		fi
+		log_connection "up-client-v6" "128" "$PLUTO_MY_CLIENT"
+		;;
+	down-client-v6:iptables)
+		# connection to client subnet, with (left/right)firewall=yes, going down
+		# This is used only by the default updown script, not by your custom
+		# ones, so do not mess with it; see CAUTION comment up at top.
+		if [ "$PLUTO_PEER_CLIENT" != "$PLUTO_MY_SOURCEIP/128" ]; then
+			ip6tables -D FORWARD \
+				-o $PLUTO_INTERFACE \
+				-p $PLUTO_PEER_PROTOCOL \
+				-s $PLUTO_MY_CLIENT $S_MY_PORT \
+				-d $PLUTO_PEER_CLIENT $D_PEER_PORT \
+				$IPSEC_POLICY_OUT \
+				-j ACCEPT
+			ip6tables -D FORWARD \
+				-i $PLUTO_INTERFACE \
+				-p $PLUTO_MY_PROTOCOL \
+				-s $PLUTO_PEER_CLIENT $S_PEER_PORT \
+				-d $PLUTO_MY_CLIENT $D_MY_PORT \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+		fi
+		# a virtual IP requires an INPUT and OUTPUT rule on the host
+		# or sometimes host access via the internal IP is needed
+		if [ -n "$PLUTO_MY_SOURCEIP" -o -n "$PLUTO_HOST_ACCESS" ]; then
+			ip6tables -D INPUT \
+				-i $PLUTO_INTERFACE \
+				-p $PLUTO_MY_PROTOCOL \
+				-s $PLUTO_PEER_CLIENT $S_PEER_PORT \
+				-d $PLUTO_MY_CLIENT $D_MY_PORT \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+			ip6tables -D OUTPUT \
+				-o $PLUTO_INTERFACE \
+				-p $PLUTO_PEER_PROTOCOL \
+				-s $PLUTO_MY_CLIENT $S_MY_PORT \
+				-d $PLUTO_PEER_CLIENT $D_PEER_PORT \
+				$IPSEC_POLICY_OUT \
+				-j ACCEPT
+		fi
+		# IP6IP6 exception teardown
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			ip6tables -D INPUT \
+				-i $PLUTO_INTERFACE \
+				-p 41 \
+				-s $PLUTO_PEER \
+				-d $PLUTO_ME \
+				$IPSEC_POLICY_IN \
+				-j ACCEPT
+		fi
+		log_connection "down-client-v6" "128" "$PLUTO_MY_CLIENT"
+		;;
+	esac
+}
+
+main "$2"

--- a/net/strongswan/files/etc/hotplug.d/ipsec/02-nftables
+++ b/net/strongswan/files/etc/hotplug.d/ipsec/02-nftables
@@ -1,0 +1,488 @@
+#!/bin/sh
+# default updown script
+#
+# Copyright (C) 2003-2004 Nigel Meteringham
+# Copyright (C) 2003-2004 Tuomo Soini
+# Copyright (C) 2002-2004 Michael Richardson
+# Copyright (C) 2005-2007 Andreas Steffen <andreas.steffen@strongswan.org>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+
+# CAUTION:  Installing a new version of strongSwan will install a new
+# copy of this script, wiping out any custom changes you make.  If
+# you need changes, make a copy of this under another name, and customize
+# that, and use the (left/right)updown parameters in ipsec.conf to make
+# strongSwan use yours instead of this default one.
+#      PLUTO_VERSION
+#              indicates  what  version of this interface is being
+#              used.  This document describes version  1.1.   This
+#              is upwardly compatible with version 1.0.
+#
+#       PLUTO_VERB
+#              specifies the name of the operation to be performed
+#              (prepare-host, prepare-client, up-host, up-client,
+#              down-host, or down-client).  If the address family
+#              for security gateway to security gateway communica-
+#              tions is IPv6, then a suffix of -v6 is added to the
+#              verb.
+#
+#       PLUTO_CONNECTION
+#              is the name of the  connection  for  which  we  are
+#              routing.
+#
+#       PLUTO_INTERFACE
+#              is the name of the ipsec interface to be used.
+#
+#       PLUTO_REQID
+#              is the reqid of the AH|ESP policy
+#
+#       PLUTO_PROTO
+#              is the negotiated IPsec protocol, ah|esp
+#
+#       PLUTO_IPCOMP
+#              is not empty if IPComp was negotiated
+#
+#       PLUTO_UNIQUEID
+#              is the unique identifier of the associated IKE_SA
+#
+#       PLUTO_ME
+#              is the IP address of our host.
+#
+#       PLUTO_MY_ID
+#              is the ID of our host.
+#
+#       PLUTO_MY_CLIENT
+#              is the IP address / count of our client subnet.  If
+#              the  client  is  just  the  host,  this will be the
+#              host's own IP address / max (where max  is  32  for
+#              IPv4 and 128 for IPv6).
+#
+#       PLUTO_MY_SOURCEIP
+#       PLUTO_MY_SOURCEIP4_$i
+#       PLUTO_MY_SOURCEIP6_$i
+#              contains IPv4/IPv6 virtual IP received from a responder,
+#              $i enumerates from 1 to the number of IP per address family.
+#              PLUTO_MY_SOURCEIP is a legacy variable and equal to the first
+#              virtual IP, IPv4 or IPv6.
+#
+#       PLUTO_MY_PROTOCOL
+#              is the IP protocol that will be transported.
+#
+#       PLUTO_MY_PORT
+#              is  the  UDP/TCP  port  to  which  the IPsec SA  is
+#              restricted on our side.  For ICMP/ICMPv6 this contains the
+#              message type, and PLUTO_PEER_PORT the message code.
+#
+#       PLUTO_PEER
+#              is the IP address of our peer.
+#
+#       PLUTO_PEER_ID
+#              is the ID of our peer.
+#
+#       PLUTO_PEER_CLIENT
+#              is the IP address / count of the peer's client sub-
+#              net.   If the client is just the peer, this will be
+#              the peer's own IP address / max (where  max  is  32
+#              for IPv4 and 128 for IPv6).
+#
+#       PLUTO_PEER_SOURCEIP
+#       PLUTO_PEER_SOURCEIP4_$i
+#       PLUTO_PEER_SOURCEIP6_$i
+#              contains IPv4/IPv6 virtual IP sent to an initiator,
+#              $i enumerates from 1 to the number of IP per address family.
+#              PLUTO_PEER_SOURCEIP is a legacy variable and equal to the first
+#              virtual IP, IPv4 or IPv6.
+#
+#       PLUTO_PEER_PROTOCOL
+#              is the IP protocol that will be transported.
+#
+#       PLUTO_PEER_PORT
+#              is  the  UDP/TCP  port  to  which  the IPsec SA  is
+#              restricted on the peer side.  For ICMP/ICMPv6 this contains the
+#              message code, and PLUTO_MY_PORT the message type.
+#
+#       PLUTO_XAUTH_ID
+#              is an optional user ID employed by the XAUTH protocol
+#
+#       PLUTO_MARK_IN
+#              is an optional XFRM mark set on the inbound IPsec SA
+#
+#       PLUTO_MARK_OUT
+#              is an optional XFRM mark set on the outbound IPsec SA
+#
+#       PLUTO_IF_ID_IN
+#              is an optional XFRM interface ID set on the inbound IPsec SA
+#
+#       PLUTO_IF_ID_OUT
+#              is an optional XFRM interface ID set on the outbound IPsec SA
+#
+#       PLUTO_UDP_ENC
+#              contains the remote UDP port in the case of ESP_IN_UDP
+#              encapsulation
+#
+#       PLUTO_DNS4_$i
+#       PLUTO_DNS6_$i
+#              contains IPv4/IPv6 DNS server attribute received from a
+#              responder, $i enumerates from 1 to the number of servers per
+#              address family.
+#
+
+# define a minimum PATH environment in case it is not set
+PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/sbin"
+export PATH
+
+LOG_VPN=1
+LOG_TAG="hotplug.d/ipsec/02-nftables"
+LOG_PRIO="daemon.notice"
+
+PRE_INPUT_FILE="/tmp/strongswan/nftables.d/pre-input.nft"
+PRE_INPUT_RULES_DIR="/tmp/strongswan/nftables.d/pre-input-rules.d"
+PRE_OUTPUT_FILE="/tmp/strongswan/nftables.d/pre-output.nft"
+PRE_OUTPUT_RULES_DIR="/tmp/strongswan/nftables.d/pre-output-rules.d"
+PRE_FORWARD_FILE="/tmp/strongswan/nftables.d/pre-forward.nft"
+PRE_FORWARD_RULES_DIR="/tmp/strongswan/nftables.d/pre-forward-rules.d"
+
+log_connection() {
+	local action="$1"
+	local mask="$2"
+	local client="$3"
+
+	local message=""
+
+	if [ "$LOG_VPN" -eq "1" ]; then
+		if [ "$PLUTO_PEER_CLIENT" = "$PLUTO_PEER/$mask" ]; then
+			message="[$action] + $PLUTO_PEER_ID $PLUTO_PEER -- $PLUTO_ME"
+		else
+			message="[$action] + $PLUTO_PEER_ID $PLUTO_PEER_CLIENT == $PLUTO_PEER -- $PLUTO_ME"
+		fi
+
+		if [ -n "$client" ]; then
+			message="$message == $client"
+		fi
+
+		logger -t $LOG_TAG \
+			-p $LOG_PRIO \
+			"$message"
+	fi
+}
+
+escape_sed() {
+	echo "$1" | sed 's/\//\\\//g'
+}
+
+main() {
+	local command="$1"
+
+	local line pluto_my_client pluto_peer_client pluto_me pluto_peer
+
+	pluto_my_client=$(escape_sed "${PLUTO_MY_CLIENT}")
+	pluto_peer_client=$(escape_sed "${PLUTO_PEER_CLIENT}")
+	pluto_me=$(escape_sed "${PLUTO_ME}")
+	pluto_peer=$(escape_sed "${PLUTO_PEER}")
+
+	case "$PLUTO_VERB:$command" in
+	#
+	# IPv4
+	#
+	up-host:iptables)
+		printf "meta iifname %s meta ipsec exists ipsec in reqid %s ip saddr %s ip daddr %s accept\n" \
+			"${PLUTO_INTERFACE}" \
+			"${PLUTO_REQID}" \
+			"${PLUTO_PEER_CLIENT}" \
+			"${PLUTO_ME}" >>"${PRE_INPUT_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+		printf "meta oifname %s meta ipsec exists ipsec out reqid %s ip saddr %s ip daddr %s accept\n" \
+			"${PLUTO_INTERFACE}" \
+			"${PLUTO_REQID}" \
+			"${PLUTO_ME}" \
+			"${PLUTO_PEER_CLIENT}" >>"${PRE_OUTPUT_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+		# allow IPIP traffic because of the implicit SA created by the kernel if
+		# IPComp is used (for small inbound packets that are not compressed)
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			printf "protocol %s meta iifname %s meta ipsec exists ipsec in reqid %s ip saddr %s ip daddr %s accept\n" \
+				"4" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${PLUTO_PEER}" \
+				"${PLUTO_ME}" >>"${PRE_INPUT_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+		fi
+		log_connection "up-host" "32" ""
+		;;
+	down-host:iptables)
+		line="$(printf "/meta iifname %s meta ipsec exists ipsec in reqid %s ip saddr %s ip daddr %s accept/d" \
+			"${PLUTO_INTERFACE}" \
+			"${PLUTO_REQID}" \
+			"${pluto_peer_client}" \
+			"${pluto_me}")"
+		busybox sed -e "$line" -i "${PRE_INPUT_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+		line="$(printf "/meta oifname %s meta ipsec exists ipsec out reqid %s ip saddr %s ip daddr %s accept/d" \
+			"${PLUTO_INTERFACE}" \
+			"${PLUTO_REQID}" \
+			"${pluto_me}" \
+			"${pluto_peer_client}")"
+		busybox sed -e "$line" -i "${PRE_OUTPUT_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			line="$(printf "/protocol %s meta iifname %s meta ipsec exists ipsec in reqid %s ip saddr %s ip daddr %s accept/d" \
+				"4" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${pluto_peer}" \
+				"${pluto_me}")"
+			busybox sed -e "$line" -i "${PRE_INPUT_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+		fi
+		log_connection "down-host" "32" ""
+		;;
+	up-client:iptables)
+		if [ "$PLUTO_PEER_CLIENT" != "$PLUTO_MY_SOURCEIP/32" ]; then
+			printf "meta oifname %s meta ipsec exists ipsec out reqid %s ip saddr %s ip daddr %s accept\n" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${PLUTO_MY_CLIENT}" \
+				"${PLUTO_PEER_CLIENT}" >>"${PRE_FORWARD_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+			printf "meta iifname %s meta ipsec exists ipsec in reqid %s ip saddr %s ip daddr %s accept\n" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${PLUTO_PEER_CLIENT}" \
+				"${PLUTO_MY_CLIENT}" >>"${PRE_FORWARD_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+		fi
+		# a virtual IP requires an INPUT and OUTPUT rule on the host
+		# or sometimes host access via the internal IP is needed
+		if [ -n "$PLUTO_MY_SOURCEIP" -o -n "$PLUTO_HOST_ACCESS" ]; then
+			printf "meta iifname %s meta ipsec exists ipsec in reqid %s ip saddr %s ip daddr %s accept\n" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${PLUTO_PEER_CLIENT}" \
+				"${PLUTO_MY_CLIENT}" >>"${PRE_INPUT_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+			printf "meta oifname %s ipsec out reqid %s ip saddr %s ip daddr %s accept\n" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${PLUTO_MY_CLIENT}" \
+				"${PLUTO_PEER_CLIENT}" >>"${PRE_OUTPUT_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+		fi
+		# allow IPIP traffic because of the implicit SA created by the kernel if
+		# IPComp is used (for small inbound packets that are not compressed).
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			printf "protocol %s meta iifname %s meta ipsec exists ipsec in reqid %s ip saddr %s ip daddr %s accept\n" \
+				"4" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${PLUTO_PEER}" \
+				"${PLUTO_ME}" >>"${PRE_INPUT_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+		fi
+		log_connection "up-client" "32" "$PLUTO_MY_CLIENT"
+		;;
+	down-client:iptables)
+		if [ "$PLUTO_PEER_CLIENT" != "$PLUTO_MY_SOURCEIP/32" ]; then
+			line="$(printf "/meta oifname %s meta ipsec exists ipsec out reqid %s ip saddr %s ip daddr %s accept/d" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${pluto_my_client}" \
+				"${pluto_peer_client}")"
+			busybox sed -e "$line" -i "${PRE_FORWARD_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+			line="$(printf "/meta iifname %s meta ipsec exists ipsec in reqid %s ip saddr %s ip daddr %s accept/d" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${pluto_peer_client}" \
+				"${pluto_my_client}")"
+			busybox sed -e "$line" -i "${PRE_FORWARD_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+		fi
+		if [ -n "$PLUTO_MY_SOURCEIP" -o -n "$PLUTO_HOST_ACCESS" ]; then
+			line="$(printf "/meta iifname %s meta ipsec exists ipsec in reqid %s ip saddr %s ip daddr %s accept/d" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${pluto_peer_client}" \
+				"${pluto_my_client}")"
+			busybox sed -e "$line" -i "${PRE_INPUT_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+			line="$(printf "/meta oifname %s ipsec out reqid %s ip saddr %s ip daddr %s accept/d" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${pluto_my_client}" \
+				"${pluto_peer_client}")"
+			busybox sed -e "$line" -i "${PRE_OUTPUT_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+		fi
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			line="$(printf "/protocol %s meta iifname %s meta ipsec exists ipsec in reqid %s ip saddr %s ip daddr %s accept/d" \
+				"4" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${pluto_peer}" \
+				"${pluto_me}")"
+			busybox sed -e "$line" -i "${PRE_INPUT_RULES_DIR}/ipv4-${PLUTO_REQID}.nft"
+		fi
+		log_connection "down-client" "32" "$PLUTO_MY_CLIENT"
+		;;
+	#
+	# IPv6
+	#
+	up-host-v6:iptables)
+		printf "meta iifname %s meta ipsec exists ipsec in reqid %s ip6 saddr %s ip6 daddr %s accept\n" \
+			"${PLUTO_INTERFACE}" \
+			"${PLUTO_REQID}" \
+			"${PLUTO_PEER_CLIENT}" \
+			"${PLUTO_ME}" >>"${PRE_INPUT_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+		printf "meta oifname %s meta ipsec exists ipsec out reqid %s ip6 saddr %s ip6 daddr %s accept\n" \
+			"${PLUTO_INTERFACE}" \
+			"${PLUTO_REQID}" \
+			"${PLUTO_ME}" \
+			"${PLUTO_PEER_CLIENT}" >>"${PRE_OUTPUT_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+		# allow IPIP traffic because of the implicit SA created by the kernel if
+		# IPComp is used (for small inbound packets that are not compressed)
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			printf "protocol %s meta iifname %s meta ipsec exists ipsec in reqid %s ip6 saddr %s ip6 daddr %s accept\n" \
+				"41" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${PLUTO_PEER}" \
+				"${PLUTO_ME}" >>"${PRE_INPUT_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+		fi
+		log_connection "up-host-v6" "128" ""
+		;;
+	down-host-v6:iptables)
+		line="$(printf "/meta iifname %s meta ipsec exists ipsec in reqid %s ip6 saddr %s ip6 daddr %s accept/d" \
+			"${PLUTO_INTERFACE}" \
+			"${PLUTO_REQID}" \
+			"${pluto_peer_client}" \
+			"${pluto_me}")"
+		busybox sed -e "$line" -i "${PRE_INPUT_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+		line="$(printf "/meta oifname %s meta ipsec exists ipsec out reqid %s ip6 saddr %s ip6 daddr %s accept/d" \
+			"${PLUTO_INTERFACE}" \
+			"${PLUTO_REQID}" \
+			"${pluto_me}" \
+			"${pluto_peer_client}")"
+		busybox sed -e "$line" -i "${PRE_OUTPUT_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			line="$(printf "/protocol %s meta iifname %s meta ipsec exists ipsec in reqid %s ip6 saddr %s ip6 daddr %s accept/d" \
+				"41" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${pluto_peer}" \
+				"${pluto_me}")"
+			busybox sed -e "$line" -i "${PRE_INPUT_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+		fi
+		log_connection "down-host-v6" "128" ""
+		;;
+	up-client-v6:iptables)
+		if [ "$PLUTO_PEER_CLIENT" != "$PLUTO_MY_SOURCEIP/128" ]; then
+			printf "meta oifname %s meta ipsec exists ipsec out reqid %s ip6 saddr %s ip6 daddr %s accept\n" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${PLUTO_MY_CLIENT}" \
+				"${PLUTO_PEER_CLIENT}" >>"${PRE_FORWARD_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+			printf "meta iifname %s meta ipsec exists ipsec in reqid %s ip6 saddr %s ip6 daddr %s accept\n" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${PLUTO_PEER_CLIENT}" \
+				"${PLUTO_MY_CLIENT}" >>"${PRE_FORWARD_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+		fi
+		# a virtual IP requires an INPUT and OUTPUT rule on the host
+		# or sometimes host access via the internal IP is needed
+		if [ -n "$PLUTO_MY_SOURCEIP" -o -n "$PLUTO_HOST_ACCESS" ]; then
+			printf "meta iifname %s meta ipsec exists ipsec in reqid %s ip6 saddr %s ip6 daddr %s accept\n" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${PLUTO_PEER_CLIENT}" \
+				"${PLUTO_MY_CLIENT}" >>"${PRE_INPUT_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+			printf "meta oifname %s ipsec out reqid %s ip6 saddr %s ip6 daddr %s accept\n" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${PLUTO_MY_CLIENT}" \
+				"${PLUTO_PEER_CLIENT}" >>"${PRE_OUTPUT_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+		fi
+		# allow IPIP traffic because of the implicit SA created by the kernel if
+		# IPComp is used (for small inbound packets that are not compressed).
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			printf "protocol %s meta iifname %s meta ipsec exists ipsec in reqid %s ip6 saddr %s ip6 daddr %s accept\n" \
+				"41" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${PLUTO_PEER}" \
+				"${PLUTO_ME}" >>"${PRE_INPUT_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+		fi
+		log_connection "up-client-v6" "128" "$PLUTO_MY_CLIENT"
+		;;
+	down-client-v6:iptables)
+		if [ "$PLUTO_PEER_CLIENT" != "$PLUTO_MY_SOURCEIP/128" ]; then
+			line="$(printf "/meta oifname %s meta ipsec exists ipsec out reqid %s ip6 saddr %s ip6 daddr %s accept/d" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${pluto_my_client}" \
+				"${pluto_peer_client}")"
+			busybox sed -e "$line" -i "${PRE_FORWARD_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+
+			line="$(printf "/meta iifname %s meta ipsec exists ipsec in reqid %s ip6 saddr %s ip6 daddr %s accept/d" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${pluto_peer_client}" \
+				"${pluto_my_client}")"
+			busybox sed -e "$line" -i "${PRE_FORWARD_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+		fi
+		if [ -n "$PLUTO_MY_SOURCEIP" -o -n "$PLUTO_HOST_ACCESS" ]; then
+			line="$(printf "/meta iifname %s meta ipsec exists ipsec in reqid %s ip6 saddr %s ip6 daddr %s accept/d" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${pluto_peer_client}" \
+				"${pluto_my_client}")"
+			busybox sed -e "$line" -i "${PRE_INPUT_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+			line="$(printf "/meta oifname %s ipsec out reqid %s ip6 saddr %s ip6 daddr %s accept/d" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${pluto_my_client}" \
+				"${pluto_peer_client}")"
+			busybox sed -e "$line" -i "${PRE_OUTPUT_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+		fi
+		if [ -n "$PLUTO_IPCOMP" ]; then
+			line="$(printf "/protocol %s meta iifname %s meta ipsec exists ipsec in reqid %s ip6 saddr %s ip6 daddr %s accept/d" \
+				"41" \
+				"${PLUTO_INTERFACE}" \
+				"${PLUTO_REQID}" \
+				"${pluto_peer}" \
+				"${pluto_me}")"
+			busybox sed -e "$line" -i "${PRE_INPUT_RULES_DIR}/ipv6-${PLUTO_REQID}.nft"
+		fi
+		log_connection "down-client-v6" "128" "$PLUTO_MY_CLIENT"
+		;;
+	*)
+		exit 0
+		;;
+	esac
+
+	# Generate nft input include file for fw4
+	rm -rf "$PRE_INPUT_FILE"
+	for f in $PRE_INPUT_RULES_DIR/*; do
+		# Check if file exists
+		[ -f "$f" ] || continue
+		cat $f >>"$PRE_INPUT_FILE"
+	done
+
+	# Generate nft output include file for fw4
+	rm -rf "$PRE_OUTPUT_FILE"
+	for f in $PRE_OUTPUT_RULES_DIR/*; do
+		# Check if file exists
+		[ -f "$f" ] || continue
+		cat $f >>"$PRE_OUTPUT_FILE"
+	done
+
+	# Generate nft forward include file for fw4
+	rm -rf "$PRE_FORWARD_FILE"
+	for f in $PRE_FORWARD_RULES_DIR/*; do
+		# Check if file exists
+		[ -f "$f" ] || continue
+		cat $f >>"$PRE_FORWARD_FILE"
+	done
+
+	# Reload fw4 to reread nft strongswan rules
+	/etc/init.d/firewall reload
+}
+
+mkdir -p "$PRE_INPUT_RULES_DIR"
+mkdir -p "$PRE_OUTPUT_RULES_DIR"
+mkdir -p "$PRE_FORWARD_RULES_DIR"
+
+main "$2"

--- a/net/strongswan/files/usr/lib/ipsec/_updown-owrt
+++ b/net/strongswan/files/usr/lib/ipsec/_updown-owrt
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/sbin/hotplug-call ipsec "$1"


### PR DESCRIPTION
Maintainer: @pprindeville, @Thermi
Compile tested: x86_64, APU3, OpenWrt 21.02
Run tested: x86_64, APU3, OpenWrt 21.02, start a connection

Description:

Stongswan does provide an own updown script in its source package.
This should serve as a basis and can be extended by the user. With
openwrt it is usual that a new updown script is installed with a
new version.

To fit better into the hotplug script handling of openwrt and because of
using iptables commands directly this commits moves the current source
updown script its own ipsec hotplug script.

Additionally a nftables updown package is added to fix strongswan with
fw4 (nftables).
From my point of view we should also update the ipsec init script to use
the new `_updown-openwrt` as default and not the `_updown` script from the
strongswan source

The following subtasks must be merged before hand:

- [x] https://github.com/openwrt/openwrt/pull/9909 merged https://github.com/openwrt/openwrt/commit/9379bc2fcf905568ef329a121c8c8a11fc98b02c
- [x] [fw4 include feature](https://patchwork.ozlabs.org/project/openwrt/patch/20220627105920.2317450-1-fe@dev.tdt.de/)
