### PR TITLE
wifi-presence: Add config for process user/group

### DIFF
--- a/net/wifi-presence/Makefile
+++ b/net/wifi-presence/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifi-presence
 PKG_VERSION:=0.1.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=-$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/awilliams/wifi-presence/tar.gz/v$(PKG_VERSION)?

--- a/net/wifi-presence/files/wifi-presence.conf
+++ b/net/wifi-presence/files/wifi-presence.conf
@@ -44,3 +44,12 @@ config wifi-presence main
 	## Set the MQTT topic prefix used by Home Assistant.
 	## Default is 'homeassistant' (also Home Assistant's default value).
 	# option hassPrefix 'homeassistant'
+
+	## Set the user and group that runs the wifi-presence process.
+	## This can be useful to change if using seccomp, where the hostapd
+	## socket files are owned by the 'network' user and group.
+	## Use network / network when seccomp is enabled, otherwise root / root.
+	## If unspecified, then the owner of the sockets in the /var/run/hostapd/
+	## directory will be used.
+	# option runAsUser 'network'
+	# option runAsGroup 'network'

--- a/net/wifi-presence/files/wifi-presence.init
+++ b/net/wifi-presence/files/wifi-presence.init
@@ -26,6 +26,9 @@ start_service() {
         local sockDir
         local verbose
 
+        local runAsUser
+        local runAsGroup
+
         config_get apName main apName
         config_get debounce main debounce
         config_get hassAutodiscovery main hassAutodiscovery
@@ -38,6 +41,9 @@ start_service() {
         config_get mqttPrefix main mqttPrefix
         config_get sockDir main sockDir
         config_get_bool verbose main verbose
+
+        config_get runAsUser main runAsUser
+        config_get runAsGroup main runAsGroup
 
         procd_open_instance
 
@@ -54,6 +60,22 @@ start_service() {
         [ -n "${mqttPrefix}" ] && procd_append_param command "-mqtt.prefix=${mqttPrefix}"
         [ -n "${sockDir}" ] && procd_append_param command "-sockDir=${sockDir}"
         [ -n "${verbose}" ] && procd_append_param command "-verbose=${verbose}"
+
+        if [ -z "${runAsUser}" ] && [ -z "${runAsGroup}" ]; then
+          # If both runAsUser and runAsGroup are unspecified, then
+          # determine their values by looking at the owner of the hostapd sockets.
+          #
+          # It would be preferable to use 'stat' to determine the owner of the socket,
+          # but it may not be present on all systems, so instead we revert to parsing ls output.
+          local sockOwner=$(find /var/run/hostapd/ -type s -maxdepth 1 -exec ls -ld {} \; | head -n 1 | awk '{ print $3 }')
+          if [ -n "${sockOwner}" ]; then
+            runAsUser="${sockOwner}"
+            runAsGroup="${sockOwner}"
+          fi
+        fi
+
+        [ -n "${runAsUser}" ] && procd_set_param user "${runAsUser}"
+        [ -n "${runAsGroup}" ] && procd_set_param group "${runAsGroup}"
 
         procd_set_param file "/etc/config/${CONF}"
         procd_set_param stdout 1


### PR DESCRIPTION
On systems using seccomp, the hostapd socket files will be owned by the
'network' user/group ([source][0]). In this case, if wifi-presence is
run as root/root, then it does not have permissions to open the
hostapd socket files. 

This was discussed in awilliams/wifi-presence#3.

This change allows the process user/group to be specified in
`/etc/config/wifi-presence`. If no explicit user/group is set, then the
init script will use the owner of the socket files in `/var/run/hostapd/`
to determine the appropriate process user/group.

[0]: https://github.com/openwrt/openwrt/blob/ec6293febc244d187e71a6e54f44920be679cde4/package/network/services/hostapd/files/wpad.init#L35-L36
