### PR TITLE
[21.02] openldap: update to 2.4.58

### DIFF
--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -8,15 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
-PKG_VERSION:=2.4.57
-PKG_RELEASE:=1
+PKG_VERSION:=2.4.58
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://gpl.savoirfairelinux.net/pub/mirrors/openldap/openldap-release/ \
-	http://mirror.eu.oneandone.net/software/openldap/openldap-release/ \
-	http://mirror.switch.ch/ftp/software/mirror/OpenLDAP/openldap-release/ \
+	https://mirror.eu.oneandone.net/software/openldap/openldap-release/ \
 	https://www.openldap.org/software/download/OpenLDAP/openldap-release/
-PKG_HASH:=c7ba47e1e6ecb5b436f3d43281df57abeffa99262141aec822628bc220f6b45a
+PKG_HASH:=57b59254be15d0bf6a9ab3d514c1c05777b02123291533134a87c94468f8f47b
 PKG_LICENSE:=OLDAP-2.8
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:openldap:openldap
@@ -37,7 +36,7 @@ define Package/libopenldap/Default
   CATEGORY:=Network
   SUBMENU:=OpenLDAP
   TITLE:=LDAP directory suite
-  URL:=http://www.openldap.org/
+  URL:=https://www.openldap.org/
   MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 endef
 


### PR DESCRIPTION
Maintainer: @flyn-org
Compile tested: armv7l, Turris Omnia, OpenWrt 21.02

Description:
(cherry picked from commit f200ccd6fc6050357874e4732533aee14a6b2ea1)

* remove a dead mirror
* use https
* fixes CVE-2021-27212
