### PR TITLE
watchcat: add support for running a script

### DIFF
--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=14
+PKG_RELEASE:=15
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=15
+PKG_RELEASE:=16
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/utils/watchcat/files/watchcat.init
+++ b/utils/watchcat/files/watchcat.init
@@ -9,7 +9,7 @@ append_string() {
 	varname="$1"
 	add="$2"
 	separator="${3:- }"
-	actual
+	local actual
 	eval "actual=\$$varname"
 
 	new="${actual:+$actual$separator}$add"
@@ -41,6 +41,7 @@ config_watchcat() {
 	config_get interface "$1" interface
 	config_get mmifacename "$1" mmifacename
 	config_get_bool unlockbands "$1" unlockbands "0"
+	config_get addressfamily "$1" addressfamily "any"
 
 	# Fix potential typo in mode and provide backward compatibility.
 	[ "$mode" = "allways" ] && mode="periodic_reboot"
@@ -93,19 +94,19 @@ config_watchcat() {
 	periodic_reboot)
 		procd_open_instance "watchcat_${1}"
 		procd_set_param command /usr/bin/watchcat.sh "periodic_reboot" "$period" "$forcedelay"
-		procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+		procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 		procd_close_instance
 		;;
 	ping_reboot)
 		procd_open_instance "watchcat_${1}"
-		procd_set_param command /usr/bin/watchcat.sh "ping_reboot" "$period" "$forcedelay" "$pinghosts" "$pingperiod" "$pingsize"
-		procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+		procd_set_param command /usr/bin/watchcat.sh "ping_reboot" "$period" "$forcedelay" "$pinghosts" "$pingperiod" "$pingsize" "$addressfamily"
+		procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 		procd_close_instance
 		;;
 	restart_iface)
 		procd_open_instance "watchcat_${1}"
-		procd_set_param command /usr/bin/watchcat.sh "restart_iface" "$period" "$pinghosts" "$pingperiod" "$pingsize" "$interface" "$mmifacename"
-		procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+		procd_set_param command /usr/bin/watchcat.sh "restart_iface" "$period" "$pinghosts" "$pingperiod" "$pingsize" "$interface" "$mmifacename" "$unlockbands" "$addressfamily"
+		procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 		procd_close_instance
 		;;
 	*)

--- a/utils/watchcat/files/watchcat.init
+++ b/utils/watchcat/files/watchcat.init
@@ -42,6 +42,7 @@ config_watchcat() {
 	config_get mmifacename "$1" mmifacename
 	config_get_bool unlockbands "$1" unlockbands "0"
 	config_get addressfamily "$1" addressfamily "any"
+	config_get script "$1" script
 
 	# Fix potential typo in mode and provide backward compatibility.
 	[ "$mode" = "allways" ] && mode="periodic_reboot"
@@ -49,8 +50,8 @@ config_watchcat() {
 	[ "$mode" = "ping" ] && mode="ping_reboot"
 
 	# Checks for settings common to all operation modes
-	if [ "$mode" != "periodic_reboot" ] && [ "$mode" != "ping_reboot" ] && [ "$mode" != "restart_iface" ]; then
-		append_string "error" "mode must be 'periodic_reboot' or 'ping_reboot' or 'restart_iface'" "; "
+	if [ "$mode" != "periodic_reboot" ] && [ "$mode" != "ping_reboot" ] && [ "$mode" != "restart_iface" ] && [ "$mode" != "run_script" ]; then
+		append_string "error" "mode must be 'periodic_reboot' or 'ping_reboot' or 'restart_iface' or 'run_script'" "; "
 	fi
 
 	period="$(time_to_seconds "$period")"
@@ -58,7 +59,7 @@ config_watchcat() {
 		append_string "error" "period has invalid format. Use time value(ex: '30'; '4m'; '6h'; '2d')" "; "
 
 	# ping_reboot mode and restart_iface mode specific checks
-	if [ "$mode" = "ping_reboot" ] || [ "$mode" = "restart_iface" ]; then
+	if [ "$mode" = "ping_reboot" ] || [ "$mode" = "restart_iface" ] || [ "$mode" = "run_script" ]; then
 		if [ -z "$error" ]; then
 			pingperiod_default="$((period / 5))"
 			pingperiod="$(time_to_seconds "$pingperiod")"
@@ -76,6 +77,10 @@ config_watchcat() {
 				append_string "error" "Check interval is less than 30s. For robust operation with ModemManager modem interfaces it is recommended to set the period to at least 30s."
 			fi
 		fi
+	fi
+
+	if [ "$mode" = "run_script" ] && [ -z "$script" ]; then
+		append_string "error" "run_script mode requires a script"
 	fi
 
 	# ping_reboot mode and periodic_reboot mode specific checks
@@ -106,6 +111,12 @@ config_watchcat() {
 	restart_iface)
 		procd_open_instance "watchcat_${1}"
 		procd_set_param command /usr/bin/watchcat.sh "restart_iface" "$period" "$pinghosts" "$pingperiod" "$pingsize" "$interface" "$mmifacename" "$unlockbands" "$addressfamily"
+		procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
+		procd_close_instance
+		;;
+	run_script)
+		procd_open_instance "watchcat_${1}"
+		procd_set_param command /usr/bin/watchcat.sh "run_script" "$period" "$pinghosts" "$pingperiod" "$pingsize" "$interface" "$addressfamily" "$script"
 		procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 		procd_close_instance
 		;;


### PR DESCRIPTION
Maintainer: @roger- 
Compile tested: ipq806x, R7800, 22.03.0-rc1
Run tested: ipq40xx, MR8300, 22.03.0-rc1
recent commiters: @rozhuk-im @neheb and @nickberry17 

Description:
* added a new mode, `run_script` to run a script, with similar logic to the `restart_iface` mode.  I need this to be able to restart *only* wan6, but not wan, on the same underlying interface eth0.
* added explicit IPv4/IPv6 support for the ping
* fixed incomplete support for unlockbands configuration value
* cleaned up some logging commands

I've got corresponding luci changes in https://github.com/openwrt/luci/pull/5824
