### PR TITLE
[22.03] node-hid: Support for npm@8

### DIFF
--- a/lang/node-hid/Makefile
+++ b/lang/node-hid/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=node-hid
 PKG_NAME:=$(PKG_NPM_NAME)
 PKG_VERSION:=2.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://registry.npmjs.org/$(PKG_NPM_NAME)/-/
@@ -48,9 +48,7 @@ TMPNPM:=$(shell mktemp -u XXXXXXXXXX)
 TARGET_CFLAGS+=$(FPIC) -I$(STAGING_DIR)/usr/include/libusb-1.0
 TARGET_LDFLAGS+=$(if $(ICONV_FULL),-liconv)
 
-define Build/Compile
-	GYP_DEFINES='driver="hidraw"' \
-	$(MAKE_VARS) \
+NPM_FLAGS=$(MAKE_VARS) \
 	$(MAKE_FLAGS) \
 	npm_config_arch=$(NODEJS_CPU) \
 	npm_config_target_arch=$(NODEJS_CPU) \
@@ -58,8 +56,12 @@ define Build/Compile
 	npm_config_nodedir=$(STAGING_DIR)/usr/ \
 	npm_config_prefix=$(PKG_INSTALL_DIR)/usr/ \
 	npm_config_cache=$(TMP_DIR)/npm-cache-$(TMPNPM) \
-	npm_config_tmp=$(TMP_DIR)/npm-tmp-$(TMPNPM) \
-	npm install -g $(PKG_BUILD_DIR)
+	npm_config_tmp=$(TMP_DIR)/npm-tmp-$(TMPNPM)
+
+define Build/Compile
+	$(NPM_FLAGS) npm i -g --production $(PKG_BUILD_DIR) --ignore-scripts
+	GYP_DEFINES='driver="hidraw"' \
+	$(NPM_FLAGS) npm i --production --prefix=$(PKG_BUILD_DIR) --target_arch=$(NODEJS_CPU) --prefer-dedupe
 	rm -rf $(TMP_DIR)/npm-tmp-$(TMPNPM)
 	rm -rf $(TMP_DIR)/npm-cache-$(TMPNPM)
 endef


### PR DESCRIPTION
Maintainer: me 
Compile tested: 22.03, arm
Run tested: (qemu 6.2.0) arm

Description:
With the upgrade of node.js to version 16, the npm version will also change to version 8.
This fix is to support npm@8. npm@6 can also build without problems.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
(cherry picked from commit 20876aadf847d4266a1636d5f41d4a2c4f8b0f7c)
