### PR TITLE
[22.03] node-yarn: Support for npm@8

### DIFF
--- a/lang/node-yarn/Makefile
+++ b/lang/node-yarn/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=yarn
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=1.22.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://registry.npmjs.org/$(PKG_NPM_NAME)/-/
@@ -43,13 +43,19 @@ TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 
 HOSTTMPNPM:=$(shell mktemp -u XXXXXXXXXX)
 
-define Host/Compile
-	$(HOST_MAKE_VARS) \
+HOST_NPM_FLAGS=$(HOST_MAKE_VARS) \
+	$(HOST_MAKE_FLAGS) \
+	npm_config_arch=$(NODEJS_CPU) \
+	npm_config_target_arch=$(NODEJS_CPU) \
+	npm_config_build_from_source=true \
 	npm_config_nodedir=$(STAGING_DIR)/usr/ \
 	npm_config_prefix=$(HOST_INSTALL_DIR)/usr/ \
 	npm_config_cache=$(TMP_DIR)/npm-cache-$(HOSTTMPNPM) \
-	npm_config_tmp=$(TMP_DIR)/npm-tmp-$(HOSTTMPNPM) \
-	npm install -g $(HOST_BUILD_DIR)
+	npm_config_tmp=$(TMP_DIR)/npm-tmp-$(HOSTTMPNPM)
+
+define Host/Compile
+	$(HOST_NPM_FLAGS) npm i -g --production $(HOST_BUILD_DIR)
+	$(HOST_NPM_FLAGS) npm i --production --prefix=$(HOST_BUILD_DIR) --target_arch=$(NODEJS_CPU) --prefer-dedupe
 	rm -rf $(TMP_DIR)/npm-tmp-$(HOSTTMPNPM)
 	rm -rf $(TMP_DIR)/npm-cache-$(HOSTTMPNPM)
 endef


### PR DESCRIPTION
Maintainer: me  @patrikx3 @dobo90
Compile tested: 22.03, arm
Run tested: (qemu 6.2.0) arm

Description:
With the upgrade of node.js to version 16, the npm version will also change to version 8.
This fix is to support npm@8. npm@6 can also build without problems.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
(cherry picked from commit 285efba8ea9c3f49334c54cd6a96b2721deb0e2b)
