### PR TITLE
stubby: restart on trigger interfaces

### DIFF
--- a/net/stubby/files/stubby.init
+++ b/net/stubby/files/stubby.init
@@ -270,7 +270,7 @@ service_triggers()
 
     for trigger_item in $trigger
     do
-        procd_add_interface_trigger "interface.*.up" "$trigger_item" "$stubby_init" start
+        procd_add_interface_trigger "interface.*" "$trigger_item" "$stubby_init" restart
     done
 
     procd_add_reload_trigger "stubby"


### PR DESCRIPTION
Force restart stubby if any of the trigger interfaces goes up or down.
Avoids DoT DNS lookup timeouts when default route changes, in case of multiple
upstream interfaces.

Run tested: latest 22.03, two upstream wan interfaces in stubby "trigger" config in /etc/config/stubby
