### PR TITLE
python3-paramiko: update to version 2.11.0

### DIFF
--- a/lang/python/python-paramiko/Makefile
+++ b/lang/python/python-paramiko/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-paramiko
-PKG_VERSION:=2.10.4
+PKG_VERSION:=2.11.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=paramiko
-PKG_HASH:=3d2e650b6812ce6d160abff701d6ef4434ec97934b13e95cf1ad3da70ffb5c58
+PKG_HASH:=003e6bee7c034c21fbb051bf83dc0a9ee4106204dd3c53054c71452cc4ec3938
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream version.

2.11.0:

 - [Feature] Add SSH config token expansion (eg %h, %p) when parsing
 ProxyJump directives. Patch courtesy of Bruno Inec.

 - [Support] (via #2011) Apply unittest skipIf to tests currently
 using SHA1 in their critical path, to avoid failures on systems
 starting to disable SHA1 outright in their crypto backends (eg RHEL
 9). Report & patch via Paul Howarth.

 - [Support] Update camelCase method calls against the threading
 module to be snake_case; this and related tweaks should fix some
 deprecation warnings under Python 3.10. Thanks to Karthikeyan
 Singaravelan for the report, @Narendra-Neerukonda for the patch,
 and to Thomas Grainger and Jun Omae for patch workshopping.

 - [Support] Recent versions of Cryptography have deprecated Blowfish
 algorithm support; in lieu of an easy method for users to remove it
 from the list of algorithms Paramiko tries to import and use, we’ve
 decided to remove it from our “preferred algorithms” list. This will
 both discourage use of a weak algorithm, and avoid warnings. Credit
 for report/patch goes to Mike Roest.

2.10.5:

 - [Bug] Windows-native SSH agent support as merged in 2.10 could
 encounter Errno 22 OSError exceptions in some scenarios (eg server
 not cleanly closing a relevant named pipe). This has been worked
 around and should be less problematic. Reported by Danilo Campana
 Fuchs and patched by Jun Omae.

 - [Bug] OpenSSH 7.7 and older has a bug preventing it from
 understanding how to perform SHA2 signature verification for RSA
 certificates (specifically certs - not keys), so when we added SHA2
 support it broke all clients using RSA certificates with these
 servers. This has been fixed in a manner similar to what OpenSSH’s
 own client does: a version check is performed and the algorithm used
 is downgraded if needed. Reported by Adarsh Chauhan, with fix
 suggested by Jun Omae.

 - [Bug] Align signature verification algorithm with OpenSSH re:
 zero-padding signatures which don’t match their nominal size/length.
 This shouldn’t affect most users, but will help Paramiko-implemented
 SSH servers handle poorly behaved clients such as PuTTY. Thanks to
 Jun Omae for catch & patch.

Signed-off-by: Javier Marcet <javier@marcet.info>
