### PR TITLE
docker-compose: Update to version 2.5.1

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.5.0
+PKG_VERSION:=2.5.1
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=e002f4f50bfb1b3c937dc0a86a8a59395182fe1288e4ed3429db5771f68f7320
+PKG_HASH:=f3eeaac99d2467fe482f499787ae38f66738bc0641dbf34a6045f34aaab893b7
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream version.

What's Changed:

 - Fix relative paths on envfile label by @ulyssessouza
 - down: Reject all arguments by @Jille
 - Clarify what default work dir is when multiple compose files by
 @quite
 - compose down exit=0 if nothing to remove by @ndeloof
 - cp command: copy to all containers of a service as default
 behaviour by @glours
 - Fix extra space printed with --no-log-prefix option by @jan4843
 - bump compose-go to 1.2.5 by @ndeloof

New Contributors:

 - @Jille made their first contribution
 - @quite made their first contribution
 - @jan4843 made their first contribution

Signed-off-by: Javier Marcet <javier@marcet.info>
