### PR TITLE
dnslookup: Update to 1.7.0

### DIFF
--- a/net/dnslookup/Makefile
+++ b/net/dnslookup/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnslookup
-PKG_VERSION:=1.6.0
+PKG_VERSION:=1.7.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ameshkov/dnslookup/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c877a6a65f31dfb84db251491dfbeb88e7afb0fe865316d9ec8389764b89299a
+PKG_HASH:=1be8fa1b4d8e3b442dbfba9f463292e81b3c3fbd9a0cf3918a553b46a5014046
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip
Run tested: rk3328 nanopi-r2s

Description:
Release note: https://github.com/ameshkov/dnslookup/releases/tag/v1.7.0
