### PR TITLE
gcc: depend on libzstd

### DIFF
--- a/devel/gcc/Makefile
+++ b/devel/gcc/Makefile
@@ -55,7 +55,7 @@ define Package/gcc
   CATEGORY:=Development
   TITLE:=gcc
   MAINTAINER:=W. Michael Petullo <mike@flyn.org>
-  DEPENDS:= +binutils +libstdcpp @!arc
+  DEPENDS:= +binutils +libstdcpp +libzstd @!arc
   MENU:=1
 endef
 


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me

Description:
Should fix https://github.com/openwrt/packages/pull/18532#issuecomment-1137816824.