### PR TITLE
[21.02] node: bump to v14.19.3

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v14.18.3
+PKG_VERSION:=v14.19.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=783ac443cd343dd6c68d2abcf7e59e7b978a6a428f6a6025f9b84918b769d608
+PKG_HASH:=5cf45b1f1aca77523acf36240c1d53a999279070a7711eabf23346f88b0cc994
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi
 Compile tested: 21.02, arm
 Run tested: (qemu 6.2.0) arm

Description:
Updates OpenSSL to 1.1.1o (No impact in openwrt)
Upgrade npm to v6.14.17.
etc...

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
