### PR TITLE
haproxy: Update haproxy.cfg mode health deprecated

### DIFF
--- a/net/haproxy/files/haproxy.cfg
+++ b/net/haproxy/files/haproxy.cfg
@@ -100,8 +100,5 @@ listen local_health_check
 	bind :60000
 
 	# This is a health check
-	mode health
-
-	# Enable HTTP-style responses: "HTTP/1.0 200 OK"
-	# else just print "OK".
-	#option httpchk
+	mode http
+	http-request return status 200


### PR DESCRIPTION
mode health is deprecated and removed in actual haproxy versions.
Replace it with mode http and return status 200
Haven't investigate how to replicate returning "OK" in body, this works as
uncommenting option httpchk in the previous versions.
Without this change haproxy won't start because errors in config.

Signed-off-by: David Santamaría Rogado <howl.nsp@gmail.com>