### PR TITLE
OpenConnect proxy support

### DIFF
--- a/net/openconnect/README
+++ b/net/openconnect/README
@@ -11,6 +11,7 @@ config interface 'MYVPN'
 	option password 'secret'
 	option serverhash 'AE7FF6A0426F0A0CD0A02EB9EC3C5066FAEB0B25'
 	option defaultroute '0'
+	# option proxy 'http://proxy.example.com:8080'
 	option authgroup 'DEFAULT'
 	# usergroup option, if required by some servers
 	# option usergroup 'USERGROUP'

--- a/net/openconnect/README
+++ b/net/openconnect/README
@@ -16,6 +16,9 @@ config interface 'MYVPN'
 	# usergroup option, if required by some servers
 	# option usergroup 'USERGROUP'
 
+	# Reconnect after a temporary network down time (in seconds)
+	#option reconnect_timeout '30'
+
 	# For second factor auth:
 
 	# when a fixed 2FA password can be used

--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -18,6 +18,7 @@ proto_openconnect_init_config() {
 	proto_config_add_int "port"
 	proto_config_add_int "mtu"
 	proto_config_add_int "juniper"
+	proto_config_add_int "reconnect_timeout"
 	proto_config_add_string "vpn_protocol"
 	proto_config_add_boolean "no_dtls"
 	proto_config_add_string "interface"
@@ -59,6 +60,7 @@ proto_openconnect_setup() {
 		password2 \
 		port \
 		proxy \
+		reconnect_timeout \
 		server \
 		serverhash \
 		token_mode \
@@ -134,6 +136,7 @@ proto_openconnect_setup() {
 	[ -n "$os" ] && append_args "--os=$os"
 	[ -n "$csd_wrapper" ] && [ -x "$csd_wrapper" ] && append_args "--csd-wrapper=$csd_wrapper"
 	[ -n "$proxy" ] && append_args "--proxy=$proxy"
+	[ -n "$reconnect_timeout" ] && append_args "--reconnect-timeout=$reconnect_timeout"
 
 	json_for_each_item proto_openconnect_add_form_entry form_entry
 

--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -32,6 +32,7 @@ proto_openconnect_init_config() {
 	proto_config_add_string "token_script"
 	proto_config_add_string "os"
 	proto_config_add_string "csd_wrapper"
+	proto_config_add_string "proxy"
 	proto_config_add_array 'form_entry:regex("[^:]+:[^=]+=.*")'
 	no_device=1
 	available=1
@@ -57,6 +58,7 @@ proto_openconnect_setup() {
 		password \
 		password2 \
 		port \
+		proxy \
 		server \
 		serverhash \
 		token_mode \
@@ -131,6 +133,7 @@ proto_openconnect_setup() {
 	[ -n "$token_secret" ] && append_args "--token-secret=$token_secret"
 	[ -n "$os" ] && append_args "--os=$os"
 	[ -n "$csd_wrapper" ] && [ -x "$csd_wrapper" ] && append_args "--csd-wrapper=$csd_wrapper"
+	[ -n "$proxy" ] && append_args "--proxy=$proxy"
 
 	json_for_each_item proto_openconnect_add_form_entry form_entry
 


### PR DESCRIPTION
Add support for the `--proxy` and `--reconnect-timeout` options, which we have been using in production for a couple of years now via this out-of-tree patch.