### PR TITLE
adguardhome: Increase init start value to avoid network race conditions

### DIFF
--- a/net/adguardhome/files/adguardhome.init
+++ b/net/adguardhome/files/adguardhome.init
@@ -4,8 +4,8 @@ PROG=/usr/bin/AdGuardHome
 
 USE_PROCD=1
 
-# starts after network starts
-START=21
+# starts just after network starts to avoid some network race conditions
+START=25
 # stops before networking stops
 STOP=89
 


### PR DESCRIPTION
Signed-off-by: James White <james@jmwhite.co.uk>

Maintainer: @dobo90 @alaviss 
Compile tested: N/A
Run tested: N/A

Description:

There have been various reports of AdGuardHome not starting on boot. It is due to certain network race conditions being present

Here's an example: https://github.com/openwrt/packages/issues/18585

Bumping the start value slightly may resolve the most common like network binds not being able. It will however probably not solve all issues, but we want to keep the START value fairly reasonable given DNS should be available relatively early in the boot process.