### PR TITLE
cloudflared: Update to 2022.5.3

### DIFF
--- a/net/cloudflared/Makefile
+++ b/net/cloudflared/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cloudflared
-PKG_VERSION:=2022.5.1
+PKG_VERSION:=2022.5.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cloudflare/cloudflared/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=9ddf09100b3c9ee8c1a0cf0ba3d5ff85ee04987bfa51e885a32dec83df5dfee2
+PKG_HASH:=d5d55a143afb918dad279490bc36e4d3537c2b862cdecfcd5dfe5bb52af63e7e
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8, x86/64
Run tested: nanopi-r2s

Description:
Release note:
- https://github.com/cloudflare/cloudflared/commit/08a8101308a4d32cf53e13940afeea49b49fbc42
- https://github.com/cloudflare/cloudflared/commit/919227fc91ba0be49a14111ffbda6f012fd2f8a2