### PR TITLE
yggdrasil: stop properly

### DIFF
--- a/net/yggdrasil/files/yggdrasil.init
+++ b/net/yggdrasil/files/yggdrasil.init
@@ -22,11 +22,6 @@ start_service()
 	procd_close_instance
 }
 
-stop_service()
-{
-	killall yggdrasil
-}
-
 reload_service()
 {
 	restart


### PR DESCRIPTION
Maintainer:  @aparcar 
Compile tested: 22.03, mips24kc, mikrotik hap
Run tested: 22.03, mips24kc, mikrotik hap

Description:

Previously it was using killall with procd respand enabled

This was causing yggdrasil to restart after being killed

```
root@r3test-hap:/# service yggdrasil stop ; echo $? ; sleep 10s ; ps | grep yggdrasil
Terminated
143
 6701 root      653m S    /usr/sbin/yggdrasil -useconffile /tmp/yggdrasil.conf
 6748 root      1308 S    grep yggdrasil
```

Now it's just using whatever procd is using and see there, it actually stops

```
root@r3test-hap:/# service yggdrasil stop ; echo $? ; sleep 10s ; ps | grep yggdrasil
0
 6802 root      1308 S    grep yggdrasil
```

I assume there was some procd bug that kept it from being used properly
