### PR TITLE
docker-compose: Update to version 2.6.0

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.5.1
+PKG_VERSION:=2.6.0
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=f3eeaac99d2467fe482f499787ae38f66738bc0641dbf34a6045f34aaab893b7
+PKG_HASH:=b01b998dbc29478ec989a9df4ebaf4017b7406bba1847b061632f0a7a9841751
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream update.

What's Changed:

 - fix TestLocalComposeUp which fail locally and bump compose-go to
 1.2.7 by @glours
 - attach only to services declared by project applying profiles by
 @ndeloof
 - Add ddev's e2e test by @ulyssessouza
 - Fix local run of make e2e-compose-standalone by @ulyssessouza
 - fix: prevent flickering prompt when pulling same image from N
 services by @maxcleme
 - add tags property to build section by @glours
 - update golang version to 1.18 by @glours
 - bump compose-go to 1.2.6 by @maxcleme
 - add e2e tests to verify env variables priority by @glours
 - Import dotenv file to os environment by @ulyssessouza

New Contributors:

 - @maxcleme made their first contribution

Signed-off-by: Javier Marcet <javier@marcet.info>
