### PR TITLE
New Package: mqttled-0.1.0

### DIFF
--- a/utils/mqttled/Makefile
+++ b/utils/mqttled/Makefile
@@ -1,0 +1,58 @@
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mqttled
+PKG_VERSION:=0.1.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=mqttled
+PKG_HASH:=20f46b7114b6ddace6e0faaaa078640f609c3d495e4ccff8d8caeb77ac5418f7
+
+PKG_MAINTAINER:=Tom Grime <tom.grime@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENCE
+
+include ../../lang/python/pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/python/python3-package.mk
+
+define Package/mqttled
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=LED Control from MQTT 
+  URL:=https://github.com/trevortrevor/mqttled/
+  DEPENDS:= \
+    +python3-paho-mqtt \
+	+python3-uci \
+	+python3-idna \
+	+python3-jsonpath-ng \
+	+python3-yaml \
+	+python3-schema \
+	+python3-netifaces \
+	+python3-logging \
+	+python3-urllib \
+	+python3-asyncio \
+	+python3-pkg-resources
+
+endef
+
+define Package/mqttled/description
+	Exposes the LEDs of your device to an MQTT broker with optional Home Assistant auto discovery
+endef
+
+define Py3Package/mqttled/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mqttled $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/mqttled.init $(1)/etc/init.d/mqttled
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/mqttled.config $(1)/etc/config/mqttled
+endef
+
+define Package/mqttled/conffiles
+/etc/config/mqttled
+endef
+
+$(eval $(call Py3Package,mqttled))
+$(eval $(call BuildPackage,mqttled))

--- a/utils/mqttled/files/mqttled.config
+++ b/utils/mqttled/files/mqttled.config
@@ -1,0 +1,34 @@
+config mqtt 'mqtt'
+    #MQTT Broker Address
+    option host '192.168.1.1'
+    option port '1883'
+    #May work without this, should bind to all interfaces. Needs to be an interface matching in /etc/config/network
+    option interface 'lan'
+    option username ''
+    option password ''
+    #Not tested
+    option tls '0'
+    option cert ''
+    option discovery 'homeassistant'
+    #Set your topic here: e.g. OpenWRTleds/CustomDevice/led1
+    option basetopic 'OpenWRTleds'
+    option subtopic 'CustomDevice'
+    #Reported in the 'device' page in Home Assistant
+    option model 'OpenWRT Device'
+
+config leds 'leds'
+    #Setting this to 1 will ignore any includes
+    option includeall '1'
+    #excluded LEDs will allways be supressed
+    list exclude 'mt76-phy0'
+    list exclude 'rt2800soc-phy1::assoc'
+    list exclude 'rt2800soc-phy1::quality'
+    list exclude 'rt2800soc-phy1::radio'
+    #list include 'blue:internet'
+
+config trigger 'triggers'
+    #Only triggers listed here will be presented to HA as 'effects'
+    list triggers 'none'
+    list triggers 'default-on'
+    list triggers 'heartbeat'
+    list triggers 'timer'

--- a/utils/mqttled/files/mqttled.init
+++ b/utils/mqttled/files/mqttled.init
@@ -1,0 +1,16 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=99
+
+USE_PROCD=1
+
+PROG=/usr/bin/mqttled
+
+start_service() {
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}


### PR DESCRIPTION
Maintainer: me
Compile tested: mips_24kc / 21.02.03 / Lenovo Y1
Run tested: mips_24kc / 21.02.03 / Lenovo Y1

PyPi: https://pypi.org/project/mqttled/
Description:
Control of LEDs through MQTT. Published LED information to MQTT broker. Sub'd to the broker and translates commands to manual LED control through echo 'trigger' > /sys/class/leds/led/trigger
Configured through UCI
