### PR TITLE
samba4: add riscv64 support

### DIFF
--- a/net/samba4/waf-cross-answers/riscv64.txt
+++ b/net/samba4/waf-cross-answers/riscv64.txt
@@ -1,0 +1,38 @@
+Checking uname sysname type: "Linux"
+Checking simple C program: "hello world"
+rpath library support: OK
+-Wl,--version-script support: OK
+Checking getconf LFS_CFLAGS: NO
+Checking for large file support without additional flags: OK
+Checking correct behavior of strtoll: OK
+Checking for working strptime: NO
+Checking for C99 vsnprintf: "1"
+Checking for HAVE_SHARED_MMAP: OK
+Checking for HAVE_MREMAP: OK
+Checking for HAVE_INCOHERENT_MMAP: NO
+Checking for HAVE_SECURE_MKSTEMP: OK
+Checking for HAVE_IFACE_GETIFADDRS: OK
+Checking value of NSIG: "65"
+Checking value of _NSIG: "65"
+Checking value of SIGRTMAX: "64"
+Checking value of SIGRTMIN: "35"
+Checking for a 64-bit host to support lmdb: OK
+Checking value of GNUTLS_CIPHER_AES_128_CFB8: "29"
+Checking value of GNUTLS_MAC_AES_CMAC_128: "203"
+Checking errno of iconv for illegal multibyte sequence: OK
+Checking for kernel change notify support: OK
+Checking for Linux kernel oplocks: OK
+Checking for kernel share modes: OK
+Checking whether POSIX capabilities are available: OK
+Checking if can we convert from CP850 to UCS-2LE: OK
+Checking if can we convert from UTF-8 to UCS-2LE: OK
+vfs_fileid checking for statfs() and struct statfs.f_fsid: OK
+Checking whether we can use Linux thread-specific credentials: OK
+Checking whether fcntl locking is available: OK
+Checking whether fcntl lock supports open file description locks: NO
+Checking whether fcntl supports flags to send direct I/O availability signals: OK
+Checking whether fcntl supports setting/geting hints: (-11, "")
+Checking for the maximum value of the 'time_t' type: OK
+Checking whether the realpath function allows a NULL argument: OK
+Checking for ftruncate extend: OK
+getcwd takes a NULL argument: OK


### PR DESCRIPTION
Maintainer: @Andy2244 
Compile tested: riscv64

Description:
Add waf-cross-answers for compiling on riscv64 arch, required for sifiveu target.

Signed-off-by: Zoltan HERPAI <wigyori@uid0.hu>