### PR TITLE
openblas: compile with RISCV64_GENERIC target on riscv64 arch

### DIFF
--- a/libs/openblas/Makefile
+++ b/libs/openblas/Makefile
@@ -63,6 +63,8 @@ else ifeq ($(ARCH),mipsel)
   OPENBLAS_TARGET:=MIPS24K
 else ifeq ($(ARCH),powerpc)
   OPENBLAS_TARGET:=PPC440
+else ifeq ($(ARCH),riscv64)
+  OPENBLAS_TARGET:=RISCV64_GENERIC
 endif
 endif # ifeq ($(OPENBLAS_TARGET),)
 


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: riscv64
Run tested: riscv64

Description:
Specify target as RISCV64_GENERIC when compiling the package on a riscv64 target. (C910V wouldn't work as the SoCs covered by the sifiveu target don't have the V instruction set extension.)

Signed-off-by: Zoltan HERPAI <wigyori@uid0.hu>