### PR TITLE
libndpi: fix pcre2 dependency name

### DIFF
--- a/libs/libndpi/Makefile
+++ b/libs/libndpi/Makefile
@@ -44,7 +44,7 @@ define Package/libndpi
   CATEGORY:=Libraries
   TITLE:=Library for deep-packet inspection
   URL:=https://github.com/ntop/nDPI
-  DEPENDS:=+LIBNDPI_GCRYPT:libgcrypt +LIBNDPI_PCRE2:pcre2 +LIBNDPI_MAXMINDDB:libmaxminddb +libpcap +libjson-c
+  DEPENDS:=+LIBNDPI_GCRYPT:libgcrypt +LIBNDPI_PCRE2:libpcre2 +LIBNDPI_MAXMINDDB:libmaxminddb +libpcap +libjson-c
 endef
 
 define Package/libndpi/description


### PR DESCRIPTION
Signed-off-by: Toni Uhlig <matzeton@googlemail.com>

Maintainer: me

Description:
