### PR TITLE
openvpn: update to 2.5.7

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.5.6
+PKG_VERSION:=2.5.7
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=13c7c3dc399d1b571cabf189c4d34ae34656ee72b6bde2a8059c1e9bc61574ed
+PKG_HASH:=313bca7e996a4f59ef9940dd87c6c4b9168064db9be6cabebd37cd65f13759ed
 
 PKG_MAINTAINER:=Magnus Kroken <mkroken@gmail.com>
 

--- a/net/openvpn/patches/002-add-wolfssl-support.patch
+++ b/net/openvpn/patches/002-add-wolfssl-support.patch
@@ -67,10 +67,10 @@ Signed-off-by: Gert Doering <gert@greenie.muc.de>
 +	[enable_wolfssl_options_h="yes"]
 +)
 +
- AC_ARG_VAR([PLUGINDIR], [Path of plug-in directory @<:@default=LIBDIR/openvpn/plugins@:>@])
- if test -n "${PLUGINDIR}"; then
- 	plugindir="${PLUGINDIR}"
-@@ -1020,6 +1027,105 @@ elif test "${with_crypto_library}" = "mb
+ AC_ARG_WITH(
+ 	[openssl-engine],
+ 	[AS_HELP_STRING([--with-openssl-engine], [enable engine support with OpenSSL. Default enabled for OpenSSL < 3.0, auto,yes,no @<:@default=auto@:>@])],
+@@ -1054,6 +1061,105 @@ elif test "${with_crypto_library}" = "mb
  	AC_DEFINE([ENABLE_CRYPTO_MBEDTLS], [1], [Use mbed TLS library])
  	CRYPTO_CFLAGS="${MBEDTLS_CFLAGS}"
  	CRYPTO_LIBS="${MBEDTLS_LIBS}"

--- a/net/openvpn/patches/100-mbedtls-disable-runtime-version-check.patch
+++ b/net/openvpn/patches/100-mbedtls-disable-runtime-version-check.patch
@@ -1,6 +1,6 @@
 --- a/src/openvpn/ssl_mbedtls.c
 +++ b/src/openvpn/ssl_mbedtls.c
-@@ -1538,7 +1538,7 @@ const char *
+@@ -1539,7 +1539,7 @@ const char *
  get_ssl_library_version(void)
  {
      static char mbedtls_version[30];

--- a/net/openvpn/patches/210-build_always_use_internal_lz4.patch
+++ b/net/openvpn/patches/210-build_always_use_internal_lz4.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1177,68 +1177,15 @@ dnl
+@@ -1211,68 +1211,15 @@ dnl
  AC_ARG_VAR([LZ4_CFLAGS], [C compiler flags for lz4])
  AC_ARG_VAR([LZ4_LIBS], [linker flags for lz4])
  if test "$enable_lz4" = "yes" && test "$enable_comp_stub" = "no"; then

--- a/net/openvpn/patches/220-disable_des.patch
+++ b/net/openvpn/patches/220-disable_des.patch
@@ -11,7 +11,7 @@
   * Should we include proxy digest auth functionality
 --- a/src/openvpn/crypto_mbedtls.c
 +++ b/src/openvpn/crypto_mbedtls.c
-@@ -383,6 +383,7 @@ int
+@@ -396,6 +396,7 @@ int
  key_des_num_cblocks(const mbedtls_cipher_info_t *kt)
  {
      int ret = 0;
@@ -19,7 +19,7 @@
      if (kt->type == MBEDTLS_CIPHER_DES_CBC)
      {
          ret = 1;
-@@ -395,6 +396,7 @@ key_des_num_cblocks(const mbedtls_cipher
+@@ -408,6 +409,7 @@ key_des_num_cblocks(const mbedtls_cipher
      {
          ret = 3;
      }
@@ -27,7 +27,7 @@
  
      dmsg(D_CRYPTO_DEBUG, "CRYPTO INFO: n_DES_cblocks=%d", ret);
      return ret;
-@@ -403,6 +405,7 @@ key_des_num_cblocks(const mbedtls_cipher
+@@ -416,6 +418,7 @@ key_des_num_cblocks(const mbedtls_cipher
  bool
  key_des_check(uint8_t *key, int key_len, int ndc)
  {
@@ -35,7 +35,7 @@
      int i;
      struct buffer b;
  
-@@ -431,11 +434,15 @@ key_des_check(uint8_t *key, int key_len,
+@@ -444,11 +447,15 @@ key_des_check(uint8_t *key, int key_len,
  
  err:
      return false;
@@ -51,7 +51,7 @@
      int i;
      struct buffer b;
  
-@@ -450,6 +457,7 @@ key_des_fixup(uint8_t *key, int key_len,
+@@ -463,6 +470,7 @@ key_des_fixup(uint8_t *key, int key_len,
          }
          mbedtls_des_key_set_parity(key);
      }
@@ -59,7 +59,7 @@
  }
  
  /*
-@@ -770,10 +778,12 @@ cipher_des_encrypt_ecb(const unsigned ch
+@@ -783,10 +791,12 @@ cipher_des_encrypt_ecb(const unsigned ch
                         unsigned char *src,
                         unsigned char *dst)
  {


### PR DESCRIPTION


Maintainer: me / @mkrkn 
Compile tested: ramips/mt7620 TP-Link Archer C50 v1, ramips/mt7621 Xiaomi Mi router 3 Pro, ath79/generic TP-Link WDR-3500
Run tested: ramips/mt7620 TP-Link Archer C50 v1, ramips/mt7621 Xiaomi Mi router 3 Pro, ath79/generic TP-Link WDR-3500


Added limited support for OpenSSL 3.0
Fixed some bugs
