### PR TITLE
glib2: update libintl handling

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -98,10 +98,6 @@ define Build/InstallDev
 		$(1)/usr/lib/
 
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-ifneq ($(INTL_FULL),)
-	$(SED) '/^Libs:/s/$$$$/ -lintl/' \
-		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/glib-2.0.pc
-endif
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc \
 		$(1)/usr/lib/pkgconfig

--- a/libs/glib2/patches/007-openwrt-libintl.patch
+++ b/libs/glib2/patches/007-openwrt-libintl.patch
@@ -1,0 +1,15 @@
+--- a/meson.build
++++ b/meson.build
+@@ -2045,8 +2045,11 @@ endif
+ # proxy-libintl subproject.
+ # FIXME: glib-gettext.m4 has much more checks to detect broken/uncompatible
+ # implementations. This could be extended if issues are found in some platforms.
++#
++# 007-openwrt-libintl.patch: with BUILD_NLS=y use libintl-full, else use libc
++#
+ libintl_deps = []
+-if cc.has_function('ngettext', args : osx_ldflags)
++if get_option('nls').disabled() and cc.has_function('ngettext', args : osx_ldflags)
+   have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset')
+ else
+   # First just find the bare library.


### PR DESCRIPTION
glib2's meson.build runs check cc.has_function('ngettext', args :
osx_ldflags) and, if successful, it never looks for non-libc libintl.
For musl and glibc this test is always successful.

glib2 unconditionally sets ENABLE_NLS, so during compile <libintl.h>
gets included always. But then we have a disconnect when the OpenWrt pkg
is being built with BUILD_NLS=y, because the <libintl.h> will be from
libintl-full but glib2 will not link to libintl-full.

With BUILD_NLS=n there's no problem, because the <libintl.h> will be
from libc.

In lieu of proper libintl detection in glib2's meson build, removing the
SED call from the Makefile together with the added patch sorts this out.
The SED call can be removed because when we force libintl-full use, the
meson build will put the necessary linker flag into the pkg-config file
itself.

Alpine Linux does something similar (see [1]), but they always force
the use of the external libintl. I assume they always go for full NLS
support.

[1] https://git.alpinelinux.org/aports/tree/main/glib/musl-libintl.patch

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @neheb 
Compile tested: master ath79 with BUILD_NLS=y and BUILD_NLS=n
Run tested: N/A

Description:
Pull request as discussed in #13090 

Kind regards,
Seb