### PR TITLE
unbound: update to 1.16.0

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.15.0
+PKG_VERSION:=1.16.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound
-PKG_HASH:=a480dc6c8937447b98d161fe911ffc76cfaffa2da18788781314e81339f1126f
+PKG_HASH:=6701534c938eb019626601191edc6d012fc534c09d2418d5b92827db0cbe48a5
 
 PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/unbound/patches/010-configure-uname.patch
+++ b/net/unbound/patches/010-configure-uname.patch
@@ -3,7 +3,7 @@ Fix cross compile errors by inserting an environment variable for the
 target. Use "uname" on host only if "UNAME" variable is empty.
 --- a/configure.ac
 +++ b/configure.ac
-@@ -811,7 +811,7 @@ if test x_$ub_test_python != x_no; then
+@@ -812,7 +812,7 @@ if test x_$ub_test_python != x_no; then
     fi
  fi
  


### PR DESCRIPTION
Signed-off-by: Stijn Segers <foss@volatilesystems.org>

Maintainer: @EricLuehrsen 
Compile tested: mvebu/cortexa72, RB5009UG+S+IN
Run tested: mvebu/cortexa72, RB5009UG+S+IN

Description: Update to 1.16.0
