### PR TITLE
beep: change git repository includes fixes for CVE fixes

### DIFF
--- a/utils/beep/Makefile
+++ b/utils/beep/Makefile
@@ -8,19 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=beep
-PKG_REV:=0d790fa45777896749a885c3b93b2c1476d59f20
-PKG_VERSION:=1.3
-PKG_RELEASE:=3
+PKG_VERSION:=1.4.12
+PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://github.com/johnath/beep.git
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=$(PKG_REV)
-PKG_MIRROR_HASH:=fc97d41e68d7b7e43a972e3416dd9326acc40efe66856271ccb36e3678464dec
-
-PKG_LICENSE:=GPL-2.0
+PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/spkr-beep/beep/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=6188d0f0c180db7a30467b5b6065a3cb5d2665b937d2e8c40366efb52bf689fe
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -29,11 +25,11 @@ define Package/beep
   CATEGORY:=Sound
   DEPENDS:=+TARGET_x86:kmod-pcspkr @!TARGET_x86:kmod-gpio-beeper
   TITLE:=Play beep sounds through a PC speaker
-  URL:=http://johnath.com/beep/README
+  URL:=https://github.com/spkr-beep/beep
 endef
 
 define Package/beep/description
-	This program plays beeps through the PC speaker
+  This program plays beeps through the PC speaker
 endef
 
 MAKE_FLAGS += \

--- a/utils/beep/patches/0001-GNUmakefile-comment-out-D_FORTIFY_SOURCE.patch
+++ b/utils/beep/patches/0001-GNUmakefile-comment-out-D_FORTIFY_SOURCE.patch
@@ -1,0 +1,29 @@
+From 937b2e633754c1234cc0037e47c77f7735704a12 Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Tue, 7 Jun 2022 17:55:59 +0200
+Subject: [PATCH] GNUmakefile: comment out D_FORTIFY_SOURCE
+
+Fixes:
+<command-line>: error: "_FORTIFY_SOURCE" redefined [-Werror]
+<command-line>: note: this is the location of the previous definition
+cc1: all warnings being treated as errors
+---
+ GNUmakefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/GNUmakefile b/GNUmakefile
+index a27b453..97af743 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -160,7 +160,7 @@ $(eval $(call CHECK_CFLAGS,common_CFLAGS,-Wno-padded))
+ $(eval $(call CHECK_CFLAGS,common_CFLAGS,-Werror=format-security))
+ $(eval $(call CHECK_CFLAGS,common_CFLAGS,-Wno-disabled-macro-expansion))
+ $(eval $(call CHECK_CFLAGS,common_CFLAGS,-Wno-format-nonliteral))
+-$(eval $(call CHECK_CFLAGS,CPPFLAGS,-D_FORTIFY_SOURCE=2))
++# $(eval $(call CHECK_CFLAGS,CPPFLAGS,-D_FORTIFY_SOURCE=2))
+ $(eval $(call CHECK_CFLAGS,CPPFLAGS,-D_GLIBCXX_ASSERTIONS))
+ # $(eval $(call CHECK_CFLAGS,CFLAGS,-Wp$$(comma)-D_FORTIFY_SOURCE=2))
+ # $(eval $(call CHECK_CFLAGS,CFLAGS,-Wp$$(comma)-D_GLIBCXX_ASSERTIONS))
+-- 
+2.34.1
+


### PR DESCRIPTION
Maintainer: n/a
Compile tested: OpenWrt 21.02.03, Turris Omnia, mvebu/cortex-a9
Run tested: N/A

Description:

My commit was sitting for some time in my stash and I did not have time to finish it. Let's solve it once for all.

Changed Git repository, which is used for Fedora packaging
https://github.com/johnath/beep/issues/11#issuecomment-450277122

Fixed CVEs:
CVE-2018-0492 - https://nvd.nist.gov/vuln/detail/CVE-2018-0492
CVE-2018-1000532 - https://nvd.nist.gov/vuln/detail/CVE-2018-1000532

cc: @zpc0 who were findling around this package

