### PR TITLE
[22.03] node: bump to v16.15.0

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v16.14.2
+PKG_VERSION:=v16.15.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=e922e215cc68eb5f94d33e8a0b61e2c863b7731cc8600ab955d3822da90ff8d1
+PKG_HASH:=a0f812efc43f78321eca08957960a48f5e6bf97004d5058c8dd3b03c646ea4f7
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT
@@ -141,7 +141,6 @@ define Package/node/install
 endef
 
 define Package/node-npm/install
-	$(RM) $(1)/usr/lib/node_modules/npm
 	$(INSTALL_DIR) $(1)/usr/lib/node_modules/npm
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/npm/{package.json,LICENSE} \
 		$(1)/usr/lib/node_modules/npm/
@@ -152,6 +151,11 @@ define Package/node-npm/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(LN) ../lib/node_modules/npm/bin/npm-cli.js $(1)/usr/bin/npm
 	$(LN) ../lib/node_modules/npm/bin/npx-cli.js $(1)/usr/bin/npx
+endef
+
+define Host/Install
+	$(RM) -rf $(1)/lib/node_modules/npm
+	$(call Host/Install/Default)
 endef
 
 $(eval $(call HostBuild))

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,6 +1,6 @@
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1238,7 +1238,8 @@ Module._initPaths = function() {
+@@ -1240,7 +1240,8 @@ Module._initPaths = function() {
      path.resolve(process.execPath, '..') :
      path.resolve(process.execPath, '..', '..');
  

--- a/lang/node/patches/999-localhost-no-addrconfig.patch
+++ b/lang/node/patches/999-localhost-no-addrconfig.patch
@@ -13,7 +13,7 @@ Forwarded: https://github.com/nodejs/node/issues/33816
  //
  // Permission is hereby granted, free of charge, to any person obtaining a
  // copy of this software and associated documentation files (the
-@@ -1037,13 +1038,6 @@ function lookupAndConnect(self, options)
+@@ -1059,13 +1060,6 @@ function lookupAndConnect(self, options)
      hints: options.hints || 0
    };
  


### PR DESCRIPTION
Maintainer: me @ianchi
 Compile tested: 22.03, arm
 Run tested: (qemu 7.0.0) arm

Description:
Update from  v16.15.0
Changed handling of host's npm problems due to npm updates.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
(cherry picked from commit fcfd2599d9fad84301a42b9597e9a71bdd0f267f)
