### PR TITLE
dnsproxy: Update to 0.43.1

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.43.0
+PKG_VERSION:=0.43.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=b20a544b9085beda02e50e84819b42526ce90b8745a3dbbec9fe3adfe76e44d4
+PKG_HASH:=2e69c1bd610727acdf24a37010fac3d1dfd6bf66527552b3221d22cc11d51296
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8
Run tested: nanopi-r2s

Description:
Release note: https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.43.1