### PR TITLE
xray-core: increase nofile limitation

### DIFF
--- a/net/xray-core/files/xray.init
+++ b/net/xray-core/files/xray.init
@@ -39,6 +39,8 @@ start_service() {
 	procd_set_param env XRAY_LOCATION_ASSET="$datadir"
 	procd_set_param file $conffiles
 
+	procd_set_param limits core="unlimited"
+	procd_set_param limits nofile="1000000 1000000"
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_set_param respawn


### PR DESCRIPTION
Maintainer: me

Description:
This fixes "too many open files" error caused by max-file limitation
when xray processes large traffic.

Fixes: #18701