### PR TITLE
tailscale: fix --version

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -27,6 +27,8 @@ PKG_USE_MIPS16:=0
 GO_PKG:=\
 	tailscale.com/cmd/tailscale \
 	tailscale.com/cmd/tailscaled
+GO_PKG_LDFLAGS:=-X 'tailscale.com/version.Long=$(PKG_VERSION)-$(PKG_RELEASE) (OpenWrt)'
+GO_PKG_LDFLAGS_X:=tailscale.com/version.Short=$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk

--- a/net/tailscale/test.sh
+++ b/net/tailscale/test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+if command -v tailscale; then
+    tailscale version | grep "$2" || exit 1
+fi
+
+if command -v tailscaled; then
+    tailscaled -version | grep "$2"
+fi


### PR DESCRIPTION
Maintainer: @ja-pa
Compile tested: armv7l, Turris Omnia, OpenWrt 21.02
Run tested: armv7l, Turris Omnia, OpenWrt 21.02

Description: --version reporting doesn't work well if it's not specified in go ldflags. Is it possible to test two binaries from two packages like this?