### PR TITLE
domoticz: fix compilation with GCC12

### DIFF
--- a/utils/domoticz/patches/010-gcc12.patch
+++ b/utils/domoticz/patches/010-gcc12.patch
@@ -1,0 +1,29 @@
+From 2975b1113d9540f39b6bade3b6d459b61c2e5007 Mon Sep 17 00:00:00 2001
+From: Arjen de Korte <build+github@de-korte.org>
+Date: Sun, 15 May 2022 19:00:02 +0200
+Subject: [PATCH] Fix compilation with GCC12
+
+Building domoticz fails under GCC12 with the following error:
+
+In file included from /usr/include/c++/12/utility:68,
+                 from /home/abuild/rpmbuild/BUILD/domoticz-2022.1/main/LuaTable.cpp:10:
+/usr/include/c++/12/bits/stl_relops.h:86:5: error: template with C linkage
+   86 |     template <class _Tp>
+      |     ^~~~~~~~
+---
+ main/LuaTable.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/main/LuaTable.cpp
++++ b/main/LuaTable.cpp
+@@ -6,9 +6,9 @@ extern "C" {
+ #include <lua.h>
+ #include <lualib.h>
+ #include <lauxlib.h>
++}
+ 
+ #include <utility>
+-}
+ 
+ CLuaTable::CLuaTable(lua_State *lua_state, const std::string &Name)
+ {


### PR DESCRIPTION
Upstream backport

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dwmw2 
Compile tested: mips24