### PR TITLE
openvpn: Enable managment server support by default

### DIFF
--- a/net/openvpn/Config-mbedtls.in
+++ b/net/openvpn/Config-mbedtls.in
@@ -14,7 +14,7 @@ config OPENVPN_mbedtls_ENABLE_LZ4
 
 config OPENVPN_mbedtls_ENABLE_MANAGEMENT
 	bool "Enable management server support"
-	default n
+	default y
 
 #config OPENVPN_mbedtls_ENABLE_PKCS11
 #	bool "Enable pkcs11 support"

--- a/net/openvpn/Config-openssl.in
+++ b/net/openvpn/Config-openssl.in
@@ -18,7 +18,7 @@ config OPENVPN_openssl_ENABLE_X509_ALT_USERNAME
 
 config OPENVPN_openssl_ENABLE_MANAGEMENT
 	bool "Enable management server support"
-	default n
+	default y
 
 #config OPENVPN_openssl_ENABLE_PKCS11
 #	bool "Enable pkcs11 support"

--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.5.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \


### PR DESCRIPTION
It makes no sense to disable support for this parameter.
Compiled files are the same length.
In luci-app-openvpn, it is in the settings.

Signed-off-by: Max S Kash <asukms@ya.ru>
