### PR TITLE
[openwrt-22.03] xray-core: Update to 1.5.7

### DIFF
--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-core
-PKG_VERSION:=1.5.6
+PKG_VERSION:=1.5.7
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/XTLS/Xray-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=62f2f6574391cf600b6b18a6c9f0fd93c1da9775043bb2c7d81c8ce80b80f923
+PKG_HASH:=6e1761b63da7fb17da98aa6cf74d224882467cd9825c12eb0ab28eacf8d92d19
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MPL-2.0

--- a/net/xray-core/files/xray.init
+++ b/net/xray-core/files/xray.init
@@ -39,6 +39,8 @@ start_service() {
 	procd_set_param env XRAY_LOCATION_ASSET="$datadir"
 	procd_set_param file $conffiles
 
+	procd_set_param limits core="unlimited"
+	procd_set_param limits nofile="1000000 1000000"
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_set_param respawn


### PR DESCRIPTION
Maintainer: me
Compile tested: mediatek/mt7622
Run tested: redmi ax6s

Description:
Backported from:
- #18694
- #18705