### PR TITLE
python-jsonschema: Update to 4.6.0

### DIFF
--- a/lang/python/python-jsonschema/Makefile
+++ b/lang/python/python-jsonschema/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-jsonschema
-PKG_VERSION:=4.5.1
+PKG_VERSION:=4.6.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=jsonschema
-PKG_HASH:=7c6d882619340c3347a1bf7315e147e6d3dae439033ae6383d6acb908c101dfc
+PKG_HASH:=9d6397ba4a6c0bf0300736057f649e3e12ecbc07d3e81a0dacb72de4e9801957
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream update

What's Changed:

 - Add package_url for changelog by @fhightower
 - Only validate unevaluated properties/items on applicable types by
 @EpicWink
 - Mark library as typed (PEP-561) by @ssbarnea
 - Add v4.5.1 to changelog by @sirosen
 - Modernize the packaging setup via PEP 621 and Hatch. by @Julian

New Contributors:

 - @fhightower made their first contribution
 - @EpicWink made their first contribution

Signed-off-by: Javier Marcet <javier@marcet.info>
