### PR TITLE
libpsl: remove iconv link flag

### DIFF
--- a/libs/libpsl/Makefile
+++ b/libs/libpsl/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpsl
 PKG_VERSION:=0.21.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/rockdaboot/libpsl/releases/download/$(PKG_VERSION)
@@ -39,8 +39,6 @@ endef
 MESON_ARGS += \
 	-Druntime=libidn2 \
 	-Dbuiltin=libidn2
-
-TARGET_LDFLAGS += -liconv
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib $(1)/usr/lib/pkgconfig

--- a/libs/libpsl/patches/020-iconv.patch
+++ b/libs/libpsl/patches/020-iconv.patch
@@ -1,0 +1,29 @@
+--- a/meson.build
++++ b/meson.build
+@@ -20,6 +20,7 @@ libicu_dep = notfound
+ libidn_dep = notfound
+ libunistring = notfound
+ networking_deps = notfound
++libiconv_dep = notfound
+ 
+ # FIXME: Cleanup this when Meson gets 'feature-combo':
+ # https://github.com/mesonbuild/meson/issues/4566
+@@ -86,6 +87,7 @@ endif
+ if libidn2_dep.found() or libidn_dep.found()
+   # Check for libunistring, we need it for psl_str_to_utf8lower()
+   libunistring = cc.find_library('unistring')
++  libiconv_dep = dependency('iconv')
+ endif
+ 
+ if host_machine.system() == 'windows'
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -19,7 +19,7 @@ cargs = [
+ libpsl = library('psl', sources, suffixes_dafsa_h,
+   include_directories : [configinc, includedir],
+   c_args : cargs,
+-  dependencies : [libidn2_dep, libidn_dep, libicu_dep, libunistring, networking_deps],
++  dependencies : [libidn2_dep, libidn_dep, libicu_dep, libunistring, networking_deps, libiconv_dep],
+   version: lt_version,
+   install: true,
+ )


### PR DESCRIPTION
Was needed with the Autotools build.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @flyn-org 
Compile tested: mips24