### PR TITLE
clamav: use standard CMake find_package for iconv

### DIFF
--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -70,8 +70,6 @@ CMAKE_OPTIONS += \
 	-DENABLE_EXAMPLES=OFF \
 	-DENABLE_UNRAR=OFF \
 	-DENABLE_SYSTEMD=OFF \
-	-DIconv_INCLUDE_DIR=$(ICONV_PREFIX)/include \
-	-DIconv_LIBRARY=$(ICONV_PREFIX)/lib/libiconv.$(if $(ICONV_FULL),so,a) \
 	-DHAVE_SYSTEM_LFS_FTS=O$(if $(CONFIG_USE_GLIBC),N,FF)
 
 TARGET_CXXFLAGS += -ffunction-sections -fdata-sections -fno-rtti -flto

--- a/net/clamav/patches/020-iconv.patch
+++ b/net/clamav/patches/020-iconv.patch
@@ -1,0 +1,63 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -448,7 +448,7 @@ endif()
+ 
+ # libclamav feature dependencies
+ if(NOT WIN32)
+-    find_package(Iconv REQUIRED)
++    find_package(Iconv)
+     # Set variable required by libclamav to use iconv
+     set(HAVE_ICONV 1)
+ endif()
+--- a/libclamav/CMakeLists.txt
++++ b/libclamav/CMakeLists.txt
+@@ -536,10 +536,39 @@ if(ENABLE_SHARED_LIB)
+                 ClamAV::win32_compat
+                 wsock32 ws2_32 )
+     else()
++        if(Iconv_FOUND)
++            if(NOT Iconv_IS_BUILT_IN)
++                target_link_libraries(clamav PRIVATE Iconv::Iconv)
++                set(CMAKE_REQUIRED_LIBRARIES "Iconv::Iconv")
++            endif()
++        else()
++            # Sometime the build environment is not setup
++            # in a way CMake can find Iconv on its own by default.
++            # But if we simply link against iconv (-liconv), the build may succeed
++            # due to other compiler/link flags.
++            set(CMAKE_REQUIRED_LIBRARIES "iconv")
++            check_c_source_compiles("
++                #include <stddef.h>
++                #include <iconv.h>
++                int main() {
++                    char *a, *b;
++                    size_t i, j;
++                    iconv_t ic;
++                    ic = iconv_open(\"to\", \"from\");
++                    iconv(ic, &a, &i, &b, &j);
++                    iconv_close(ic);
++                }
++                "
++                Iconv_EXPLICITLY_AT_ENV)
++            if(Iconv_EXPLICITLY_AT_ENV)
++                target_link_libraries(clamav PRIVATE iconv)
++            else()
++                message(FATAL_ERROR "Iconv is not found, make sure to provide it in the build environment")
++            endif()
++        endif()
+         target_link_libraries( clamav
+             PUBLIC
+                 Threads::Threads
+-                Iconv::Iconv
+                 ${CMAKE_DL_LIBS}
+                 m )
+     endif()
+@@ -556,8 +585,6 @@ if(ENABLE_SHARED_LIB)
+ 
+     if(WIN32)
+         set_target_properties( clamav PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON )
+-    else()
+-        target_link_libraries( clamav PUBLIC Iconv::Iconv )
+     endif()
+     if(WIN32)
+         install( TARGETS clamav DESTINATION . COMPONENT libraries )


### PR DESCRIPTION
Fixes compilation without libiconv-stub.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: mips24