### PR TITLE
ksmbd-tools: only add -liconv with BUILD_NLS

### DIFF
--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -12,15 +12,13 @@ PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
-PKG_FIXUP:=autoreconf
-PKG_REMOVE_FILES:=autogen.sh
 PKG_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
 
 PKG_BUILD_DEPENDS:=glib2
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
+include $(INCLUDE_DIR)/meson.mk
 
 TAR_OPTIONS+= --strip-components 1
 TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
@@ -30,7 +28,7 @@ define Package/ksmbd-tools/Default
   CATEGORY:=Network
   SUBMENU:=Filesystem
   TITLE:=Kernel SMB
-  URL:=https://github.com/cifsd-team/cifsd-tools
+  URL:=https://github.com/cifsd-team/ksmbd-tools
   DEPENDS:= $(ICONV_DEPENDS) $(INTL_DEPENDS)
 endef
 
@@ -89,18 +87,16 @@ define Package/ksmbd-avahi-service/description
   Ksmbd (smb/445) Daemon service via mDNS/DNS-SD.
 endef
 
-CONFIGURE_ARGS += \
-	--disable-shared \
-	--enable-static
+MESON_ARGS += \
+	-Db_lto=true \
+	-Dkrb5=disabled
 
-CONFIGURE_VARS += GLIB_LIBS="$(STAGING_DIR)/usr/lib/libglib-2.0.a"
-
-TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
-TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed -liconv $(if $(INTL_FULL),-lintl) $(if $(CONFIG_USE_GLIBC),-lpthread)
+TARGET_CFLAGS += -ffunction-sections -fdata-sections
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
 define Package/ksmbd-server/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/ksmbd.mountd $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ksmbd.mountd $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/ksmbd $(1)/etc/init.d
 	$(INSTALL_CONF) ./files/ksmbd.config $(1)/etc/config/ksmbd
 	$(INSTALL_DATA) ./files/smb.conf.template $(1)/etc/ksmbd/
@@ -111,10 +107,10 @@ define Package/ksmbd-server/install
 endef
 
 define Package/ksmbd-utils/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/ksmbd.adduser $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ksmbd.adduser $(1)/usr/bin/
 ifeq ($(CONFIG_KSMBD_UTILS_SHAREADD),y)
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/ksmbd.addshare $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ksmbd.addshare $(1)/usr/bin/
 endif
 endef
 

--- a/net/ksmbd-tools/patches/010-meson.patch
+++ b/net/ksmbd-tools/patches/010-meson.patch
@@ -1,0 +1,142 @@
+From a8ed6b5a752bd7e50940c9e198af3edc3af0d5f7 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sat, 2 Jan 2021 21:05:53 -0800
+Subject: [PATCH] add meson build
+
+meson compiles faster and is simpler than autotools.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ addshare/meson.build | 10 ++++++++++
+ adduser/meson.build  | 12 ++++++++++++
+ control/meson.build  |  8 ++++++++
+ lib/meson.build      | 18 ++++++++++++++++++
+ meson.build          | 29 +++++++++++++++++++++++++++++
+ meson_options.txt    |  3 +++
+ mountd/meson.build   | 16 ++++++++++++++++
+ 7 files changed, 96 insertions(+)
+ create mode 100644 addshare/meson.build
+ create mode 100644 adduser/meson.build
+ create mode 100644 control/meson.build
+ create mode 100644 lib/meson.build
+ create mode 100644 meson.build
+ create mode 100644 meson_options.txt
+ create mode 100644 mountd/meson.build
+
+--- /dev/null
++++ b/addshare/meson.build
+@@ -0,0 +1,10 @@
++addshare = executable(
++  'ksmbd.addshare',
++  'share_admin.c',
++  'addshare.c',
++  'share_admin.h',
++  dependencies: [glib_dep, netlink_dep],
++  include_directories: tools_incdir,
++  link_with: libksmbdtools,
++  install: true,
++)
+--- /dev/null
++++ b/adduser/meson.build
+@@ -0,0 +1,12 @@
++adduser = executable(
++  'ksmbd.adduser',
++  'md4_hash.c',
++  'user_admin.c',
++  'adduser.c',
++  'md4_hash.h',
++  'user_admin.h',
++  dependencies: [glib_dep, netlink_dep],
++  include_directories: tools_incdir,
++  link_with: libksmbdtools,
++  install: true,
++)
+--- /dev/null
++++ b/control/meson.build
+@@ -0,0 +1,8 @@
++control = executable(
++  'ksmbd.control',
++  'control.c',
++  dependencies: [glib_dep, netlink_dep],
++  include_directories: tools_incdir,
++  link_with: libksmbdtools,
++  install: true,
++)
+--- /dev/null
++++ b/lib/meson.build
+@@ -0,0 +1,18 @@
++core_files = [
++  'management/tree_conn.c',
++  'management/user.c',
++  'management/share.c',
++  'management/session.c',
++  'config_parser.c',
++  'ksmbdtools.c',
++]
++
++if krb5_dep.found()
++  core_files += [
++    'management/spnego.c',
++    'asn1.c',
++    'management/spnego_krb5.c',
++  ]
++endif
++
++libksmbdtools = static_library('ksmbdtools', core_files, include_directories: tools_incdir, dependencies: [glib_dep, krb5_dep])
+--- /dev/null
++++ b/meson.build
+@@ -0,0 +1,29 @@
++project('ksmbsd-tools', 'c', version: '3.3.2', default_options: 'c_std=gnu99')
++
++tools_incdir = include_directories(['include', '.'])
++
++glib_dep = dependency('glib-2.0', static: true)
++netlink_dep = dependency('libnl-genl-3.0')
++krb5_dep = dependency('krb5', required: get_option('krb5'))
++
++cc = meson.get_compiler('c')
++
++cdata = configuration_data()
++add_project_arguments('-DHAVE_CONFIG_H', language: 'c')
++if krb5_dep.found()
++  cdata.set('CONFIG_KRB5', krb5_dep.found())
++  cdata.set('HAVE_KRB5_KEYBLOCK_KEYVALUE', cc.has_member('krb5_keyblock', 'keyvalue', prefix: '#include <krb5.h>'))
++  cdata.set('HAVE_KRB5_AUTHENTICATOR_CLIENT', cc.has_member('krb5_authenticator', 'client', prefix: '#include <krb5.h>'))
++  cdata.set('HAVE_KRB5_AUTH_CON_GETRECVSUBKEY', cc.has_header_symbol('krb5.h', 'krb5_auth_con_getrecvsubkey'))
++  cdata.set('HAVE_KRB5_AUTH_CON_GETAUTHENTICATOR_DOUBLE_POINTER', true)
++endif
++cfile = configure_file(
++  output: 'config.h',
++  configuration: cdata,
++)
++
++subdir('lib')
++subdir('addshare')
++subdir('adduser')
++subdir('control')
++subdir('mountd')
+--- /dev/null
++++ b/meson_options.txt
+@@ -0,0 +1,3 @@
++option('krb5', type : 'feature',
++  description : 'Build with Kerberos support',
++)
+--- /dev/null
++++ b/mountd/meson.build
+@@ -0,0 +1,16 @@
++mountd = executable(
++  'ksmbd.mountd',
++  'worker.c',
++  'ipc.c',
++  'rpc.c',
++  'rpc_srvsvc.c',
++  'rpc_wkssvc.c',
++  'mountd.c',
++  'smbacl.c',
++  'rpc_samr.c',
++  'rpc_lsarpc.c',
++  dependencies: [glib_dep, netlink_dep],
++  include_directories: tools_incdir,
++  link_with: libksmbdtools,
++  install: true,
++)


### PR DESCRIPTION
Fixes compilation without libiconv-stub.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Andy2244 
Compile tested: mips24