### PR TITLE
lxc: export systemd cgroups after install

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -61,6 +61,10 @@ define Package/lxc-auto
   DEPENDS+=+lxc-start +lxc-stop
 endef
 
+define Package/lxc-auto/postinst
+[ -n "$${IPKG_INSTROOT}" ] || [ "$${PKG_UPGRADE}" = 1 ] || /etc/init.d/lxc-auto boot
+endef
+
 define Package/lxc-auto/description
  LXC is the userspace control package for Linux Containers, a lightweight
  virtual system mechanism sometimes described as "chroot on steroids".


### PR DESCRIPTION
Maintainer: @ratkaj
Compile tested: armv7l, Turris Omnia, OpenWrt 21.02
Run tested: armv7l, Turris Omnia, OpenWrt 21.02

Description: otherwise, a user would have to either manually run `/etc/init.d/lxc-auto boot` or reboot the system to start using lxc.

originally committed in 2cde10b95053bf958a4001fb0a82c4563bf345e2 (#18528) by me
reverted in 039912dec5d3ba2b0f6f53ab8330ab9fea2f7adf by @stintel

The fix is from @jow-'s idea on IRC

