### PR TITLE
ttymidi-sysex: add package

### DIFF
--- a/multimedia/ttymidi-sysex/Makefile
+++ b/multimedia/ttymidi-sysex/Makefile
@@ -1,0 +1,50 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ttymidi-sysex
+PKG_SOURCE_DATE:=2021-05-07
+PKG_SOURCE_VERSION:=e519a1167253e24ae35caed0371fed5bd4f26061
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/cchaussat/ttymidi-sysex
+PKG_MIRROR_HASH:=8d6bb738a08a65c25fcc442777750abbee812a24a29236242032e2d761774541
+
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ttymidi-sysex
+  SECTION:=sound
+  CATEGORY:=Sound
+  TITLE:=ttymidi (with full bi-di sysex support)
+  URL:=https://github.com/cchaussat/ttymidi-sysex
+  DEPENDS:=+alsa-lib
+endef
+
+define Package/ttymidi-sysex/description
+ttymidi is a GPL-licensed program that allows external serial devices
+to interface with ALSA MIDI applications. The main motivation behind
+ttymidi was to make Arduino boards talk to MIDI applications without
+the need to use (or build) any extra hardware. 
+endef
+
+TARGET_CFLAGS += -flto
+TARGET_LDFLAGS += -lasound -Wl,--gc-sections,--as-needed
+
+define Build/Configure
+endef
+
+define Build/Compile
+	( cd $(PKG_BUILD_DIR) ; $(TARGET_CC) $(TARGET_CFLAGS) $(TARGET_CPPFLAGS) $(TARGET_LDFLAGS) -o ttymidi-sysex ttymidi-sysex.c $(if $(CONFIG_USE_GLIBC),,$(STAGING_DIR)/usr/lib/libargp.a) )
+endef
+
+define Package/ttymidi-sysex/install
+	$(INSTALL_DIR) $(1)/usr/bin $(1)/etc/init.d $(1)/etc/uci-defaults
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ttymidi-sysex $(1)/usr/bin/
+	$(INSTALL_BIN) ./files/ttymidi-sysex.init $(1)/etc/init.d/ttymidi-sysex
+	$(INSTALL_DATA) ./files/ttymidi-sysex.defaults $(1)/etc/uci-defaults/90-ttymidi-sysex
+endef
+
+$(eval $(call BuildPackage,ttymidi-sysex))

--- a/multimedia/ttymidi-sysex/files/ttymidi-sysex.defaults
+++ b/multimedia/ttymidi-sysex/files/ttymidi-sysex.defaults
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+[ -e /etc/config/ttymidi ] || {
+	touch /etc/config/ttymidi
+	uci add ttymidi ttymidi
+	uci set ttymidi.@ttymidi[0].enabled=0
+	uci set ttymidi.@ttymidi[0].name=ttymidi
+	uci set ttymidi.@ttymidi[0].baudrate=115200
+	uci set ttymidi.@ttymidi[0].device=/dev/ttyUSB0
+	uci commit
+}

--- a/multimedia/ttymidi-sysex/files/ttymidi-sysex.init
+++ b/multimedia/ttymidi-sysex/files/ttymidi-sysex.init
@@ -1,0 +1,41 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=99
+STOP=15
+
+append_arg() {
+	local cfg="$1"
+	local opt="$2"
+	local var="$3"
+	local def="$4"
+	local val
+	config_get val "$cfg" "$var"
+	[ -n "$val" ] || [ -n "$def" ] && procd_append_param command "$opt" "${val:-$def}"
+}
+
+start_instance() {
+	local cfg="$1"
+	local enabled 
+
+	config_get_bool enabled "$cfg" 'enabled' 1
+	[ "$enabled" -gt 0 ] || return 0
+
+	procd_open_instance
+	procd_set_param command /usr/bin/ttymidi-sysex
+	append_arg "$cfg" -b baudrate
+	append_arg "$cfg" -n name
+	append_arg "$cfg" -s device
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn
+	procd_close_instance
+}
+
+start_service() {
+	config_load ttymidi && config_foreach start_instance ttymidi
+}
+
+service_triggers() {
+	procd_add_reload_trigger ttymidi
+}


### PR DESCRIPTION
This adds an improved version of [ttymidi](https://github.com/cjbarnes18/ttymidi) with full support for SysEx MIDI messages.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>