### PR TITLE
rtpmidid: add package

### DIFF
--- a/multimedia/rtpmidid/Makefile
+++ b/multimedia/rtpmidid/Makefile
@@ -1,0 +1,44 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rtpmidid
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE_DATE:=2022-06-13
+PKG_SOURCE_VERSION:=835b6352f9c0b3aaee4acd81f3a6ae3fe58adb50
+PKG_HASH:=89f6e806843815482707902e982d34e6bcc4e7913345d98f2e1c78dc111718fb
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_DATE).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/davidmoreno/rtpmidid/tar.gz/$(PKG_SOURCE_VERSION)?
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
+
+PKG_LICENSE:=GPL-3.0-or-later LGPL-2.1-or-later
+PKG_LICENSE_FILES:=LICENSE.md LICENSE-lib.txt LICENSE-daemon.txt
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/rtpmidid
+  SECTION:=sound
+  CATEGORY:=Sound
+  TITLE:=RTP MIDI User Space Driver Daemon for Linux
+  URL:=https://github.com/davidmoreno/rtpmidid/
+  DEPENDS:=+alsa-lib +libavahi-client +libfmt
+endef
+
+define Package/rtpmidid/description
+rtpmidid is an user daemon, and when a RTP MIDI device is announced
+using mDNS (also known as Zeroconf, Avahi, and multicast DNS) it
+exposes this ALSA sequencer port.
+endef
+
+define Build/Install
+endef
+
+define Package/rtpmidid/install
+	$(INSTALL_DIR) $(1)/usr/bin $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/rtpmidid $(1)/usr/bin/
+	$(INSTALL_BIN) ./files/rtpmidid.init $(1)/etc/init.d/rtpmidid
+endef
+
+$(eval $(call BuildPackage,rtpmidid))

--- a/multimedia/rtpmidid/files/rtpmidid.init
+++ b/multimedia/rtpmidid/files/rtpmidid.init
@@ -1,0 +1,16 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=99
+STOP=15
+
+start_service() {
+	[ -d /var/run/rtpmidid ] || mkdir -m 0755 -p /var/run/rtpmidid
+
+	procd_open_instance
+	procd_set_param command /usr/bin/rtpmidid
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn
+	procd_close_instance
+}


### PR DESCRIPTION
Add RTP MIDI server package allowing to import/export local MIDI clients or hardware devices to the local network using Apple's RTP MIDI protocol.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>