### PR TITLE
rrdbackup: back up luci-statistics RRD data to flash during shutdown 

### DIFF
--- a/utils/rrdbackup/LICENSE.md
+++ b/utils/rrdbackup/LICENSE.md
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/utils/rrdbackup/Makefile
+++ b/utils/rrdbackup/Makefile
@@ -1,0 +1,44 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rrdbackup
+PKG_VERSION:=1
+PKG_RELEASE:=1
+
+PKG_LICENSE:=Unlicense
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/rrdbackup
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Enable the backup and restore of the RRD database for collectd during orderly reboots
+  URL:=https://github.com/sqrwf/openwrt-rrdbackup
+  PKGARCH:=all
+  MAINTAINER:=John Kohl <jtk.git@bostonpog.org>
+  EXTRA_DEPENDS:=luci-app-statistics
+endef
+
+define Package/rrdbackup/description
+ rrdbackup provides a startup/shutdown script that backs up the RRD collectd
+ database to flash and restores it to volatile storage during orderly reboots.
+endef
+
+define Package/rrdbackup/conffiles
+/etc/collectd/rrdbackup.tgz
+endef
+
+define Build/Compile
+endef
+
+define Build/Configure
+endef
+
+define Build/Install
+endef
+
+define Package/rrdbackup/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) files/rrdbackup $(1)/etc/init.d/rrdbackup
+endef
+
+$(eval $(call BuildPackage,rrdbackup))

--- a/utils/rrdbackup/files/rrdbackup
+++ b/utils/rrdbackup/files/rrdbackup
@@ -1,0 +1,46 @@
+#!/bin/sh /etc/rc.common
+
+
+# OpenWrt init.d script to backup/restore the collectd RRD database, to have it persist across (planned) reboots
+# https://github.com/sqrwf/openwrt-rrdbackup/
+
+# This is free and unencumbered software released into the public domain.
+# For more information, please refer to <http://unlicense.org/>
+
+
+# backup target directory and file
+BACKUP_DIR=/etc/collectd
+BACKUP_FILE=rrdbackup.tgz
+
+# directory containing collectd's RRD files (usually /tmp/rrd)
+# root relative, i.e. no slash in front (to mitigate tar "leading '/'" warning)
+RRD_DIR=tmp/rrd
+
+# queue rrdbackup to start before collectd starts (80) and stop after collect stops (10):
+START=79
+STOP=11
+
+# "backup" command to manually backup database (e.g. from cronjob)
+# for completeness, "restore" is also possible although I struggle to come up with a use case
+EXTRA_COMMANDS="backup restore"
+EXTRA_HELP="        backup          Backup current rrd database"
+
+backup() {
+	TMP_FILE=$(mktemp -u)
+	tar -czf "$TMP_FILE" -C / "$RRD_DIR"
+	mkdir -p "$BACKUP_DIR"
+	mv "$TMP_FILE" "$BACKUP_DIR/$BACKUP_FILE"
+	rm -f "$TMP_FILE"
+}
+
+restore() {
+	[ -f "$BACKUP_DIR/$BACKUP_FILE" ] && tar -xzf "$BACKUP_DIR/$BACKUP_FILE" -C /
+}
+
+start() {
+	restore
+}
+
+stop() {
+	backup
+}


### PR DESCRIPTION
Using @sqrwf 's repository as the source, but maybe he would be happy to put the rrdbackup init script directly into a package file and skip the git repo downloads in this Makefile?
(can't quite figure out how to tag him)

Definitely this is a draft form, glad to take comments/suggestions

I find it useful to have this as a full package, so that I can install it into my image-builder images and manage upgrade easier.
Still have to do this, I think, since it seems sysupgrade doesn't do an orderly reboot/shutdown:
```
/etc/init.d/luci_statistics stop
/etc/init.d/rrdbackup stop
```
<then run sysupgrade>

