### PR TITLE
[22.03] node: bump to v16.15.1

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v16.15.0
+PKG_VERSION:=v16.15.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=a0f812efc43f78321eca08957960a48f5e6bf97004d5058c8dd3b03c646ea4f7
+PKG_HASH:=d4e99d3c1f69711109a67525571058e6009cddbc228e7d723b8fb4a454169b7d
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT
@@ -96,10 +96,11 @@ endif
 
 MAKE_VARS+= \
 	DESTCPU=$(NODEJS_CPU) \
-	NO_LOAD='cctest.target.mk embedtest.target.mk node_mksnapshot.target.mk' \
+	NO_LOAD='cctest.target.mk embedtest.target.mk node_mksnapshot.target.mk overlapped-checker.target.mk \
+		mkcodecache.target.mk tools/v8_gypfiles/torque_base.target.mk tools/v8_gypfiles/v8_init.target.mk' \
 	LD_LIBRARY_PATH=$(STAGING_DIR_HOSTPKG)/share/icu/current/lib
 
-HOST_MAKE_VARS+=NO_LOAD='cctest.target.mk embedtest.target.mk'
+HOST_MAKE_VARS+=NO_LOAD='cctest.target.mk embedtest.target.mk overlapped-checker.target.mk'
 
 CONFIGURE_VARS:= \
 	CC="$(TARGET_CC) $(TARGET_OPTIMIZATION)" \

--- a/lang/node/patches/999-delete_unnecessary_libraries_for_host_execute.patch
+++ b/lang/node/patches/999-delete_unnecessary_libraries_for_host_execute.patch
@@ -34,7 +34,7 @@
          '<@(icu_src_genccode)',
 --- a/tools/v8_gypfiles/v8.gyp
 +++ b/tools/v8_gypfiles/v8.gyp
-@@ -1408,6 +1408,7 @@
+@@ -1363,6 +1363,7 @@
      {
        'target_name': 'bytecode_builtins_list_generator',
        'type': 'executable',
@@ -42,7 +42,7 @@
        'conditions': [
          ['want_separate_host_toolset', {
            'toolsets': ['host'],
-@@ -1432,6 +1433,8 @@
+@@ -1387,6 +1388,8 @@
      {
        'target_name': 'mksnapshot',
        'type': 'executable',
@@ -51,7 +51,7 @@
        'dependencies': [
          'v8_base_without_compiler',
          'v8_compiler_for_mksnapshot',
-@@ -1453,6 +1456,7 @@
+@@ -1408,6 +1411,7 @@
      {
        'target_name': 'torque',
        'type': 'executable',
@@ -59,7 +59,7 @@
        'dependencies': [
          'torque_base',
          # "build/win:default_exe_manifest",
-@@ -1491,6 +1495,7 @@
+@@ -1446,6 +1450,7 @@
      {
        'target_name': 'torque-language-server',
        'type': 'executable',
@@ -67,7 +67,7 @@
        'conditions': [
          ['want_separate_host_toolset', {
            'toolsets': ['host'],
-@@ -1518,6 +1523,8 @@
+@@ -1473,6 +1478,8 @@
      {
        'target_name': 'gen-regexp-special-case',
        'type': 'executable',

--- a/lang/node/patches/999-v8_zlib_support.patch
+++ b/lang/node/patches/999-v8_zlib_support.patch
@@ -23,7 +23,7 @@
          'include_dirs': [
            '<(SHARED_INTERMEDIATE_DIR)',
          ],
-@@ -195,6 +196,7 @@
+@@ -181,6 +182,7 @@
            '<@(torque_outputs_cc)',
            '<@(torque_outputs_inc)',
          ],
@@ -31,7 +31,7 @@
          'include_dirs': [
            '<(SHARED_INTERMEDIATE_DIR)',
          ],
-@@ -216,6 +218,7 @@
+@@ -202,6 +204,7 @@
          'sources': [
            '<(generate_bytecode_builtins_list_output)',
          ],
@@ -39,7 +39,7 @@
          'include_dirs': [
            '<(generate_bytecode_output_root)',
            '<(SHARED_INTERMEDIATE_DIR)',
-@@ -266,9 +269,11 @@
+@@ -249,9 +252,11 @@
          'v8_base_without_compiler',
          'v8_shared_internal_headers',
        ],
@@ -51,7 +51,7 @@
        ],
        'sources': [
          '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_initializers.*?sources = ")',
-@@ -793,6 +798,7 @@
+@@ -754,6 +759,7 @@
        ],
        'includes': ['inspector.gypi'],
        'direct_dependent_settings': {
@@ -59,7 +59,7 @@
          'include_dirs': [
            '<(generate_bytecode_output_root)',
            '<(SHARED_INTERMEDIATE_DIR)',
-@@ -1384,6 +1390,7 @@
+@@ -1343,6 +1349,7 @@
          }],
        ],
        'direct_dependent_settings': {
@@ -67,7 +67,7 @@
          'include_dirs': [
            '<(V8_ROOT)/include',
          ],
-@@ -1748,6 +1755,7 @@
+@@ -1691,6 +1698,7 @@
           }],
        ],
        'direct_dependent_settings': {
@@ -75,7 +75,7 @@
          'include_dirs': [
            '<(V8_ROOT)/include',
          ],
-@@ -1934,15 +1942,19 @@
+@@ -1871,15 +1879,19 @@
          }],
        ],
        'direct_dependent_settings': {


### PR DESCRIPTION
Maintainer: me @ianchi
Compile tested: 22.03, arm
 Run tested: (qemu 7.0.0) arm

Description:
Upgrade npm to 8.11.0
Suppressed unnecessary builds.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
(cherry picked from commit d8dc54ceea04070a6999c5a3b2e86225fec0d498)
