### PR TITLE
prometheus-node-exporter-lua: fix waiting for interface

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2022.04.30
+PKG_VERSION:=2022.06.12
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
@@ -11,12 +11,21 @@ _log() {
 start_service() {
 	. /lib/functions/network.sh
 
-	local interface port bind
+	local interface port bind4 bind6
 
 	config_load prometheus-node-exporter-lua.main
 	config_get keepalive "main" http_keepalive 70
 	config_get interface "main" listen_interface "loopback"
 	config_get port "main" listen_port 9100
+
+	[ "$interface" = "*" ] || {
+		network_get_ipaddr  bind4 "$interface"
+		network_get_ipaddr6 bind6 "$interface"
+		[ -n "$bind4$bind6" ] || {
+			_log "defering start until listen interface $interface becomes ready"
+			return 0
+		}
+    }
 
 	procd_open_instance
 
@@ -26,14 +35,8 @@ start_service() {
 	if [ "$interface" = "*" ]; then
 		procd_append_param command -p $port
 	else
-		network_is_up "$interface" || {
-			_log "defering start until listen interface $interface becomes ready"
-			return 0
-		}
-		network_get_ipaddr6 bind "$interface"
-		[ -n "$bind" ] && procd_append_param command -p [$bind]:$port
-		network_get_ipaddr bind "$interface"
-		[ -n "$bind" ] && procd_append_param command -p $bind:$port
+		[ -n "$bind4" ] && procd_append_param command -p $bind4:$port
+		[ -n "$bind6" ] && procd_append_param command -p [$bind6]:$port
 	fi
 
 	procd_set_param stdout 1


### PR DESCRIPTION
Maintainer: me
Compile/Run tested: tested by @Hurricos

Description:
Instead of waiting for interface to be up,
wait for it to have IPs, as this is what we need.

Also do not call procd_open_instance when not ready.