### PR TITLE
kea: create /var/run/kea in init script

### DIFF
--- a/net/kea/files/kea.init
+++ b/net/kea/files/kea.init
@@ -8,6 +8,8 @@ BIN_PATH="/usr/sbin"
 CONF_PATH="/etc/kea"
 
 start_service() {
+	mkdir -p /var/run/kea
+
 	config_load "kea"
 	config_foreach start_kea "service"
 }


### PR DESCRIPTION
Maintainer: @rosysong
Compile tested: NA
Run tested: NA

Description:
Kea expects /var/run/kea to exist. Without it, errors occur:

  Mon Jun 13 10:31:45 2022 daemon.err kea-dhcp6[2977]: Unable to use interprocess sync lockfile (No such file or directory): /var/run/kea/logger_lockfile
