### PR TITLE
modemmanager: explicitly disconnect even if no bearers found

### DIFF
--- a/net/modemmanager/files/modemmanager.proto
+++ b/net/modemmanager/files/modemmanager.proto
@@ -515,7 +515,8 @@ proto_modemmanager_teardown() {
 	modemstatus=$(mmcli --modem="${device}" --output-keyvalue)
 	bearerpath=$(modemmanager_get_field "${modemstatus}" "modem.generic.bearers.value\[1\]")
 	[ -n "${bearerpath}" ] || {
-		echo "couldn't load bearer path"
+		echo "couldn't load bearer path: disconnecting anyway"
+		mmcli --modem="${device}" --simple-disconnect >/dev/null 2>&1
 		return
 	}
 


### PR DESCRIPTION
A network restart where netifd is cleanly restarted involves bringing
the network interfaces down. The 'modemmanager' protocol handler will
run a mmcli --simple-disconnect in this case, but only if there are
bearer objects found.

If the network restart happened *during* the connection attempt
procedure, while the modem is e.g. being registered in the network, no
bearer objects exist yet, and so, we would skip doing anything during
the interface teardown operation. This would lead to the original
connection attempt succeeding, so leaving the modem in ModemManager
in connected state, while the associated interface in netifd is
reported down.

Maintainer: @nickberry17 
Compile tested: x86_64
Run tested: x86_64