### PR TITLE
[22.03] dnsdist: update to 1.7.2

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsdist
-PKG_VERSION:=1.7.1
+PKG_VERSION:=1.7.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=273a8212be2ddfaf754f752bcda4c2abc671ca5d42f776263312eb4661ea2d66
+PKG_HASH:=524bd2bb05aa2e05982a971ae8510f2812303ab4486a3861b62212d06b1127cd
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Signed-off-by: Peter van Dijk <peter.van.dijk@powerdns.com>
(cherry picked from commit 573829d625fecdd90e3a7e3e7f195e7d8875833a)

Maintainer: me
Compile tested:
Run tested:

Description:
