### PR TITLE
ncdu: update to 1.17 and add blue option

### DIFF
--- a/utils/ncdu/Makefile
+++ b/utils/ncdu/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ncdu
-PKG_VERSION:=1.16
+PKG_VERSION:=1.17
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dev.yorhel.nl/download
-PKG_HASH:=2b915752a183fae014b5e5b1f0a135b4b408de7488c716e325217c2513980fd4
+PKG_HASH:=810745a8ed1ab3788c87d3aea4cc1a14edf6ee226f764bcc383e024ba56adbf1
 
 PKG_MAINTAINER:=Charles E. Lehner <cel@celehner.com>
 PKG_LICENSE:=MIT

--- a/utils/ncdu/patches/900-use-alternative-color.patch
+++ b/utils/ncdu/patches/900-use-alternative-color.patch
@@ -1,0 +1,26 @@
+--- a/src/util.h
++++ b/src/util.h
+@@ -36,18 +36,18 @@
+   C(DEFAULT,     _,_,0  ,    _,      _,    0,    WHITE,  BLACK,0)\
+   C(BOX_TITLE,   _,_,B  ,    BLUE,   _,    B,    BLUE,   BLACK,B)\
+   C(HD,          _,_,R  ,    BLACK,  CYAN, 0,    BLACK,  CYAN, 0)    /* header & footer */\
+-  C(SEL,         _,_,R  ,    WHITE,  GREEN,B,    WHITE,  GREEN,B)\
++  C(SEL,         _,_,R  ,    WHITE,   BLUE,B,    WHITE,  GREEN,B)\
+   C(NUM,         _,_,0  ,    YELLOW, _,    B,    YELLOW, BLACK,B)\
+   C(NUM_HD,      _,_,R  ,    YELLOW, CYAN, B,    YELLOW, CYAN, B)\
+-  C(NUM_SEL,     _,_,R  ,    YELLOW, GREEN,B,    YELLOW, GREEN,B)\
++  C(NUM_SEL,     _,_,R  ,    YELLOW,  BLUE,B,    YELLOW, GREEN,B)\
+   C(KEY,         _,_,B  ,    YELLOW, _,    B,    YELLOW, BLACK,B)\
+   C(KEY_HD,      _,_,B|R,    YELLOW, CYAN, B,    YELLOW, CYAN, B)\
+   C(DIR,         _,_,0  ,    BLUE,   _,    B,    BLUE,   BLACK,B)\
+-  C(DIR_SEL,     _,_,R  ,    BLUE,   GREEN,B,    BLUE,   GREEN,B)\
++  C(DIR_SEL,     _,_,R  ,    BLUE,    BLUE,B,    BLUE,   GREEN,B)\
+   C(FLAG,        _,_,0  ,    RED,    _,    0,    RED,    BLACK,0)\
+-  C(FLAG_SEL,    _,_,R  ,    RED,    GREEN,0,    RED,    GREEN,0)\
++  C(FLAG_SEL,    _,_,R  ,    RED,     BLUE,0,    RED,    GREEN,0)\
+   C(GRAPH,       _,_,0  ,    MAGENTA,_,    0,    MAGENTA,BLACK,0)\
+-  C(GRAPH_SEL,   _,_,R  ,    MAGENTA,GREEN,0,    MAGENTA,GREEN,0)
++  C(GRAPH_SEL,   _,_,R  ,    MAGENTA, BLUE,0,    MAGENTA,GREEN,0)
+ 
+ enum ui_coltype {
+ #define C(name, ...) UIC_##name,


### PR DESCRIPTION
Upstream bump and add a patch to use a blue highlight color for the dark color scheme (`--color dark`) as some users find the default bright green is too intense.  Note that invoking ncdu without the `--color` switch at use uses the upstream default bright green, so users will need to call ncdu with `--color dark` in order to get the blue color.

Signed-off-by: John Audia <therealgraysky@proton.me>

@neheb @clehner 