### PR TITLE
cloudflared: Update to 2022.6.2

### DIFF
--- a/net/cloudflared/Makefile
+++ b/net/cloudflared/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cloudflared
-PKG_VERSION:=2022.5.3
+PKG_VERSION:=2022.6.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cloudflare/cloudflared/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=d5d55a143afb918dad279490bc36e4d3537c2b862cdecfcd5dfe5bb52af63e7e
+PKG_HASH:=599ea11ff7f6a8941eb2cdbc1eced0419eb3dec85104f3f7a6a8268f4d0e722a
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8, x86/64
Run tested: nanopi-r2s

Description:
Release note:
- https://github.com/cloudflare/cloudflared/commit/6c3d2fc33977e4de6309d478c704d008751efc36
- https://github.com/cloudflare/cloudflared/commit/7d0a2710003588a58b2535270624d0db571ea9df
- https://github.com/cloudflare/cloudflared/commit/420e80ea501d532365955e8383d4bfffd1078602