### PR TITLE
v2raya: Update to 1.5.8.1

### DIFF
--- a/net/v2raya/Makefile
+++ b/net/v2raya/Makefile
@@ -5,19 +5,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v2rayA
-PKG_VERSION:=1.5.7
+PKG_VERSION:=1.5.8.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/v2rayA/v2rayA/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6d203ef95ac2a48f6f1808b93fc1cd1a4f32a0419710d0c7a74169f27c38ed9c
+PKG_HASH:=822ec4a93933d93aed1bda6f9a3c08915135c0fc33bebe5e69b293cf30fe35c2
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/service
 
 PKG_LICENSE:=AGPL-3.0-only
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 
-PKG_BUILD_DEPENDS:=golang/host node/host node-yarn/host
+PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
@@ -58,13 +58,20 @@ define Package/v2raya/conffiles
 /etc/config/v2raya
 endef
 
-define Build/Compile
+WEB_FILE:=$(PKG_NAME)-web-$(PKG_VERSION).tar.gz
+define Download/v2raya-web
+	URL:=https://codeload.github.com/v2rayA/v2raya-web/tar.gz/v$(PKG_VERSION)?
+	URL_FILE:=$(WEB_FILE)
+	FILE:=$(WEB_FILE)
+	HASH:=b13beac91d75c64af4ca6d7365716968702ce1be3f0c3e94d26e01daa07f223b
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+
 	( \
-		pushd $(PKG_BUILD_DIR)/../gui ; \
-		yarn ; \
-		OUTPUT_DIR=../service/server/router/web yarn build ; \
-		popd ; \
-		$(call GoPackage/Build/Compile) ; \
+		mkdir -p $(PKG_BUILD_DIR)/server/router/web ; \
+		gzip -dc $(DL_DIR)/$(WEB_FILE) | $(HOST_TAR) -C $(PKG_BUILD_DIR)/server/router/web $(TAR_OPTIONS) ; \
 	)
 endef
 
@@ -79,5 +86,6 @@ define Package/v2raya/install
 	$(INSTALL_BIN) $(CURDIR)/files/v2raya.init $(1)/etc/init.d/v2raya
 endef
 
+$(eval $(call Download,v2raya-web))
 $(eval $(call GoBinPackage,v2raya))
 $(eval $(call BuildPackage,v2raya))

--- a/net/v2raya/files/v2raya.init
+++ b/net/v2raya/files/v2raya.init
@@ -53,6 +53,7 @@ start_service() {
 	append_env_bool "config" "log_disable_timestamp"
 
 	procd_set_param limits core="unlimited"
+	procd_set_param limits nofile="1000000 1000000"
 	procd_set_param respawn
 	procd_set_param stdout 1
 	procd_set_param stderr 1


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8
Run tested: nanopi-r2s

Description:
1. Switched to use prebuilt web files to get rid of massive Node.js.
2. Increased nofile limitation to avoid "too many open files" error.

Release note: https://github.com/v2rayA/v2rayA/releases/tag/v1.5.8.1