### PR TITLE
owntone: update to 28.4

### DIFF
--- a/sound/owntone/Makefile
+++ b/sound/owntone/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=owntone
-PKG_VERSION:=28.2
-PKG_RELEASE:=2
+PKG_VERSION:=28.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/owntone/owntone-server/releases/download/$(PKG_VERSION)/
-PKG_HASH:=7e5a0142d852569dc28a99a2e26568856717544e894904aa0e63950fdafa2666
+PKG_HASH:=6b3dcfe0c51aa6424a0a0c695b2f0350302dfde3351e19961224847076889c92
 
 PKG_FIXUP:=autoreconf
 PKG_USE_MIPS16:=0
@@ -32,7 +32,7 @@ CATEGORY:=Sound
 TITLE:=iTunes (DAAP) server for Apple Remote and AirPlay
 URL:=https://github.com/owntone/owntone-server
 DEPENDS:=+libgpg-error +libgcrypt +libgdbm +zlib +libexpat +libunistring \
-	+libevent2 +libdaemon +libantlr3c +confuse +alsa-lib +libffmpeg-full \
+	+libevent2 +libdaemon +confuse +alsa-lib +libffmpeg-full \
 	+mxml +libavahi-client +sqlite3-cli +libplist +libcurl +libjson-c \
 	+libprotobuf-c +libgnutls +libsodium +libwebsockets +libuuid $(ICONV_DEPENDS)
 endef
@@ -40,8 +40,8 @@ endef
 define Package/owntone/description
   OwnTone is a Linux/FreeBSD DAAP (iTunes), MPD (Music Player Daemon) and
   RSP (Roku) media server. It has support for AirPlay speakers, Chromecast,
-  Apple Remote (and compatibles), MPD clients, internet radio and LastFM. It
-  does not support AirPlay/Chromecast video.
+  Apple Remote (and compatibles), MPD clients, Spotify, internet radio and
+  LastFM. It does not support AirPlay/Chromecast video.
 endef
 
 define Package/owntone/conffiles
@@ -68,6 +68,8 @@ define Package/owntone/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/owntone/* $(1)/usr/lib/owntone/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/owntone.init $(1)/etc/init.d/owntone
+	$(INSTALL_DIR) $(1)/usr/share/owntone
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/owntone/htdocs $(1)/usr/share/owntone
 endef
 
 $(eval $(call BuildPackage,owntone))

--- a/sound/owntone/files/owntone.conf
+++ b/sound/owntone/files/owntone.conf
@@ -219,6 +219,12 @@ library {
 	# playlist directory. OwnTone creates new playlists in this directory if only
 	# a playlist name is provided (requires "allow_modify_stored_playlists" set to true).
 #	default_playlist_directory = ""
+
+	# By default OwnTone will - like iTunes - clear the playqueue if
+	# playback stops. Setting clear_queue_on_stop_disable to true will keep
+	# the playlist like MPD does. Note that some dacp clients do not show
+	# the playqueue if playback is stopped.
+#	clear_queue_on_stop_disable = false
 }
 
 # Local audio output
@@ -346,18 +352,6 @@ audio {
 
 # Spotify settings (only have effect if Spotify enabled - see README/INSTALL)
 spotify {
-	# The server can stream from Spotify using either its own implementation
-	# or using Spotify's libspotify (which was deprecated many years ago)
-#	use_libspotify = false
-
-	# Directory where user settings should be stored (credentials)
-	# (only has effect with libspotify)
-#	settings_dir = "/var/cache/owntone/libspotify"
-
-	# Cache directory
-	# (only has effect with libspotify)
-#	cache_dir = "/tmp"
-
 	# Set preferred bitrate for music streaming
 	# 0: No preference (default), 1: 96kbps, 2: 160kbps, 3: 320kbps
 #	bitrate = 0
@@ -383,6 +377,23 @@ spotify {
 #	album_override = false
 }
 
+# RCP/Roku Soundbridge output settings
+# (make sure you get the capitalization of the device name right)
+#rcp "My SoundBridge device" {
+	# Enable this option to exclude a particular device from the speaker
+	# list
+#	exclude = false
+
+	# A Roku/SoundBridge can power up in 2 modes: (default) reconnect to the 
+	# previously used library (ie OwnTone) or in a 'cleared library' mode.
+	# The Roku power up behaviour is affected by how OwnTone disconnects
+	# from the Roku device.
+	#
+	# Set to false to maintain default Roku power on behaviour
+#	clear_on_close = false
+#}
+
+
 # MPD configuration (only have effect if MPD enabled - see README/INSTALL)
 mpd {
 	# TCP port to listen on for MPD client requests.
@@ -393,12 +404,6 @@ mpd {
 	# clients and will need additional configuration in the MPD client to
 	# work). Set to 0 to disable serving artwork over http.
 #	http_port = 0
-
-	# By default OwnTone will - like iTunes - clear the playqueue if
-	# playback stops. Setting clear_queue_on_stop_disable to true will keep
-	# the playlist like MPD does. Note that some dacp clients do not show
-	# the playqueue if playback is stopped.
-#	clear_queue_on_stop_disable = false
 }
 
 # SQLite configuration (allows to modify the operation of the SQLite databases)


### PR DESCRIPTION
Signed-off-by: Espen Jürgensen <espenjurgensen+openwrt@gmail.com>

Maintainer: me
Compile tested: x86_64, r18609
Run tested: no

Description:
Update to 28.4, incl. install web UI, remove libantlr3c dependency, add Spotify support to description, update conf file