### PR TITLE
fail2ban: fix patch for python 3.10

### DIFF
--- a/net/fail2ban/patches/010-python3.10_compat.patch
+++ b/net/fail2ban/patches/010-python3.10_compat.patch
@@ -1,8 +1,9 @@
 From 2b6bb2c1bed8f7009631e8f8c306fa3160324a49 Mon Sep 17 00:00:00 2001
 From: "Sergey G. Brester" <serg.brester@sebres.de>
 Date: Mon, 8 Feb 2021 17:19:24 +0100
-Subject: [PATCH] follow bpo-37324: :ref:`collections-abstract-base-classes`
- moved to the :mod:`collections.abc` module
+Subject: [PATCH 2/4] follow bpo-37324:
+ :ref:`collections-abstract-base-classes` moved to the :mod:`collections.abc`
+ module
 
 (since 3.10-alpha.5 `MutableMapping` is missing in collections module)
 ---
@@ -23,3 +24,31 @@ Subject: [PATCH] follow bpo-37324: :ref:`collections-abstract-base-classes`
  
  from .failregex import mapTag2Opt
  from .ipdns import DNSUtils
+--- a/fail2ban/server/actions.py
++++ b/fail2ban/server/actions.py
+@@ -28,7 +28,10 @@ import logging
+ import os
+ import sys
+ import time
+-from collections import Mapping
++try:
++	from collections.abc import Mapping
++except ImportError:
++	from collections import Mapping
+ try:
+ 	from collections import OrderedDict
+ except ImportError:
+--- a/fail2ban/server/jails.py
++++ b/fail2ban/server/jails.py
+@@ -22,7 +22,10 @@ __copyright__ = "Copyright (c) 2004 Cyri
+ __license__ = "GPL"
+ 
+ from threading import Lock
+-from collections import Mapping
++try:
++	from collections.abc import Mapping
++except ImportError:
++	from collections import Mapping
+ 
+ from ..exceptions import DuplicateJailException, UnknownJailException
+ from .jail import Jail


### PR DESCRIPTION
Maintainer: @erdoukki
Compile tested: x86_64, OpenWrt master
Compile tested: x86_64, docker, OpenWrt master

Description: 89d5d2e091c8da10a1c963158a6de92b05079116 only patched importing MutableMapping from collections, but importing Mapping has to be patched too

Closes: #18681

This should also be backported to 22.03

cc @ryzhovau