### PR TITLE
dnsdist: switch from liblua to luajit

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -115,7 +115,7 @@ define Package/dnsdist
 	  +libedit \
 	  +libstdcpp \
 	  +lmdb \
-	  +liblua \
+	  +luajit \
 	  +tinycdb
   URL:=https://dnsdist.org/
 endef
@@ -144,7 +144,7 @@ TARGET_CXX+=-std=c++17
 
 CONFIGURE_ARGS+= \
 	--with-pic \
-	--with-lua=lua \
+	--with-lua=luajit \
 	$(if $(CONFIG_DNSDIST_SODIUM),--enable-dnscrypt --with-libsodium,--disable-dnscrypt --without-libsodium) \
 	$(if $(CONFIG_DNSDIST_DNSTAP),--enable-dnstap=yes,--enable-dnstap=no) \
 	$(if $(CONFIG_DNSDIST_RE2),--with,--without)-re2 \


### PR DESCRIPTION
Maintainer: me
Compile tested: openwrt master, built on Debian 11; openwrt 19.07, built on Debian 11
Run tested: openwrt master on edgerouter lite; openwrt 19.07 on tp-link archer c7 v5 (after locally backporting this change to 19.07)

Description:
luajit provides higher performance for requests handled in Lua hooks.
It also enables access to dnsdist functionality only exposed via FFI,
and allows configurations/hooks to call functions in any C library
without providing separate bindings.

