### PR TITLE
[21.02] php8: update to 8.0.20

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.0.19
+PKG_VERSION:=8.0.20
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=ba62219c4b0486cbb2a04f0796749a46b0ee1f5a142ed454212b4e2460cb0fab
+PKG_HASH:=973fec765336ee01f47536a5db1c2eee98df9d34a41522b7b6c760159bf0a77b
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0

--- a/lang/php8/patches/0041-Add-patch-to-remove-build-timestamps-from-generated-.patch
+++ b/lang/php8/patches/0041-Add-patch-to-remove-build-timestamps-from-generated-.patch
@@ -54,7 +54,7 @@ Subject: Add patch to remove build timestamps from generated binaries.
  							fcgi_shutdown();
 --- a/sapi/cli/php_cli.c
 +++ b/sapi/cli/php_cli.c
-@@ -633,8 +633,8 @@ static int do_cli(int argc, char **argv)
+@@ -635,8 +635,8 @@ static int do_cli(int argc, char **argv)
  				goto out;
  
  			case 'v': /* show php version & quit */


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs

Description:

This fixes:
    - CVE-2022-31625
    - CVE-2022-31626

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
