### PR TITLE
haproxy: Update HAProxy to v2.6.1

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=2.4.17
+PKG_VERSION:=2.6.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://www.haproxy.org/download/2.4/src
-PKG_HASH:=416ca95d51bb57eaea0d6657c06a760faa63473dca10ac6f9e68b994088d73f4
+PKG_SOURCE_URL:=https://www.haproxy.org/download/2.6/src
+PKG_HASH:=915b351e6450d183342c4cdcda7771eac4f0f72bf90582adcd15a01c700d29b1
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Christian Lachner <gladiac@gmail.com>

--- a/net/haproxy/get-latest-patches.sh
+++ b/net/haproxy/get-latest-patches.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-CLONEURL=https://git.haproxy.org/git/haproxy-2.4.git
-BASE_TAG=v2.4.17
+CLONEURL=https://git.haproxy.org/git/haproxy-2.6.git
+BASE_TAG=v2.6.1
 TMP_REPODIR=tmprepo
 PATCHESDIR=patches
 


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Christian Lachner <gladiac@gmail.com> (/me)
Compile tested: mips, ipq806x, i386, arc700
Run tested: ipq806x (r7800)

Description: Update HAProxy to v2.6.1
- New major LTS release (see: https://www.mail-archive.com/haproxy@formilux.org/msg42371.html)
- Sadly, no QUIC/H3 support for now because the QuicTLS library - which is a fork of OpenSSL - would be needed. However, we do not have a package for that and I currently do not want to build and statically link it into the haproxy package
- Update haproxy download URL and hash