### PR TITLE
knot-resolver: update to version 5.5.1

### DIFF
--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -10,12 +10,12 @@ PKG_RELRO_FULL:=0
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot-resolver
-PKG_VERSION:=5.4.3
+PKG_VERSION:=5.5.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-resolver
-PKG_HASH:=488729eb93190336b6bca10de0d78ecb7919f77fcab105debc0a644aa7d0a506
+PKG_HASH:=9bad1edfd6631446da2d2331bd869887d7fe502f6eeaf62b2e43e2c113f02b6d
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=GPL-3.0-later

--- a/net/knot-resolver/patches/030-fix-policy-hack.patch
+++ b/net/knot-resolver/patches/030-fix-policy-hack.patch
@@ -2,7 +2,7 @@ This patch fixes the problem with forwarding in knot-resolver v4.3.0.
 It reintroduces a fix which enables  policy related hack (knot/knot-resolver#205 (comment 94566) )
 --- a/modules/policy/policy.lua
 +++ b/modules/policy/policy.lua
-@@ -1047,7 +1047,7 @@ policy.layer = {
+@@ -1098,7 +1098,7 @@ policy.layer = {
  		if bit.band(state, bit.bor(kres.FAIL, kres.DONE)) ~= 0 then return state end
  		local qry = req:initial() -- same as :current() but more descriptive
  		return policy.evaluate(policy.rules, req, qry, state)


### PR DESCRIPTION
Maintainer: @ja-pa 
Compile and run tested on these two routers:
- Turris Omnia, mvebu/cortex-a9, Turris OS 6.0 based on OpenWrt 21.02.3
- Turris 1.1, powerpc/8540, Turris OS 6.0 based on OpenWrt 21.02.3

Changelog for versions:
- 5.4.4 [1]
- 5.5.0 [2]
- 5.5.1 [3]

[1] https://www.knot-resolver.cz/2022-01-05-knot-resolver-5.4.4.html
[2] https://www.knot-resolver.cz/2022-03-15-knot-resolver-5.5.0.html
[3] https://www.knot-resolver.cz/2022-06-14-knot-resolver-5.5.1.html
