### PR TITLE
irqbalance: handle deepestcache option

### DIFF
--- a/utils/irqbalance/files/irqbalance.config
+++ b/utils/irqbalance/files/irqbalance.config
@@ -1,6 +1,10 @@
 config irqbalance 'irqbalance'
 	option enabled '0'
 
+	# Level at which irqbalance partitions cache domains.
+	# Default is 2 (L2$).
+	#option deepestcache '2'
+
 	# The default value is 10 seconds
 	#option interval '10'
 

--- a/utils/irqbalance/files/irqbalance.init
+++ b/utils/irqbalance/files/irqbalance.init
@@ -16,6 +16,9 @@ start_service() {
 	config_get_bool enabled irqbalance enabled 0
 	[ "$enabled" -gt 0 ] || return 0
 
+	# 2 is the default
+	config_get deepestcache irqbalance deepestcache 2
+
 	# 10 is the default
 	config_get interval irqbalance interval 10
 
@@ -28,7 +31,7 @@ start_service() {
 	config_list_foreach irqbalance banirq handle_banirq_value
 
 	procd_open_instance "irqbalance"
-	procd_set_param command /usr/sbin/irqbalance -f -t "$interval" "$banirq"
+	procd_set_param command /usr/sbin/irqbalance -f -c "$deepestcache" -t "$interval" "$banirq"
 	procd_set_param respawn
 	procd_close_instance
 }


### PR DESCRIPTION
Allow the user to specify the level at which irqbalance assumes the cache
domains are partitioned. Keep the default value of 2.

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>

Maintainer: @hnyman