### PR TITLE
[19.07] libgd: install pkgconfig file

### DIFF
--- a/libs/libgd/Makefile
+++ b/libs/libgd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgd
 PKG_VERSION:=2.2.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/gd-$(PKG_VERSION)/
@@ -104,6 +104,8 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgd.{a,la,so*} $(1)/usr/lib/
 	$(INSTALL_DIR) $(2)/bin
 	$(LN) ../../usr/bin/gdlib-config $(2)/bin/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/gdlib.pc $(1)/usr/lib/pkgconfig/gdlib.pc
 endef
 
 define Package/libgd/install


### PR DESCRIPTION
Maintainer: @jow-
Compile tested: aarch64, Turris MOX, OpenWrt 19.07
Run tested: -

Description: I needed the pkgconfig file for an unrelated build that won't go to openwrt, but I think it makes sense to upstream this change. 