### PR TITLE
[master]rp-pppoe: update to 3.15

### DIFF
--- a/net/rp-pppoe/Makefile
+++ b/net/rp-pppoe/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2016 OpenWrt.org
+# Copyright (C) 2006-2022 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.

--- a/net/rp-pppoe/Makefile
+++ b/net/rp-pppoe/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2022 OpenWrt.org
+# Copyright (C) 2006-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.

--- a/net/rp-pppoe/Makefile
+++ b/net/rp-pppoe/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rp-pppoe
-PKG_VERSION:=3.14
-PKG_RELEASE:=3
+PKG_VERSION:=3.15
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dianne.skoll.ca/projects/rp-pppoe/download
-PKG_HASH:=7825232f64ab4d618ef074d62d145ae43d6edc91b9a718c6130a4742bac40e2a
+PKG_HASH:=b1f318bc7e4e5b0fd8a8e23e8803f5e6e43165245a5a10a7162a92a6cf17829a
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=LGPL-2.0-or-later
@@ -29,7 +29,7 @@ define Package/rp-pppoe/Default
   SECTION:=net
   CATEGORY:=Network
   TITLE:=PPPoE (PPP over Ethernet)
-  URL:=https://dianne.skoll.ca/projects/rp-pppoe/
+  URL:=https://github.com/dfskoll/rp-pppoe
   SUBMENU:=Dial-in/up
 endef
 


### PR DESCRIPTION
Changes from version 3.14 to 3.15:

- Release 3.15 (2021-05-07)

- src/pppoe.c: Don't ignore SIGTERM and SIGINT.  Send PADT and exit
  if one of those signals is received.

- General: Switch from net-tools (ifconfig and friends) to iproute2 (ip ...)
  on Linux.

**The author agrees to transfer the original code to the new code Github repository with limited support and update maintenance. The last maintenance update date on the Github repository is May 20, 2022.**

The Github code repository mentioned on the author's homepage of Rp-PPPoE
https://dianne.skoll.ca/projects/rp-pppoe/
https://dianne.skoll.ca/pipermail/rp-pppoe/2021q3/thread.html
https://dianne.skoll.ca/pipermail/rp-pppoe/2021q4/thread.html

Signed-off-by: openwrtdiy <57249132+openwrtdiy@users.noreply.github.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
