### PR TITLE
bind: update to version 9.18.4

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.18.1
+PKG_VERSION:=9.18.4
 PKG_RELEASE:=$(AUTORELEASE)
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=57c7afd871694d615cb4defb1c1bd6ed023350943d7458414db8d493ef560427
+PKG_HASH:=f277ae50159a00c300eb926a9c5d51953038a936bd8242d6913dfb6eac42761d
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile tested: Turris 1.1, powerpc_8540, OpenWrt 21.02.3
Run tested: Turris Omnia, powerpc_8540, OpenWrt 21.02.3
:white_check_mark: dig
:white_check_mark: DNS resolving via ``named``

Fixes:
- [CVE-2022-1183](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1183)