### PR TITLE
(22.03) dnsdist: switch from liblua to luajit

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -115,7 +115,7 @@ define Package/dnsdist
 	  +libedit \
 	  +libstdcpp \
 	  +lmdb \
-	  +liblua \
+	  +luajit \
 	  +tinycdb
   URL:=https://dnsdist.org/
 endef
@@ -144,7 +144,7 @@ TARGET_CXX+=-std=c++17
 
 CONFIGURE_ARGS+= \
 	--with-pic \
-	--with-lua=lua \
+	--with-lua=luajit \
 	$(if $(CONFIG_DNSDIST_SODIUM),--enable-dnscrypt --with-libsodium,--disable-dnscrypt --without-libsodium) \
 	$(if $(CONFIG_DNSDIST_DNSTAP),--enable-dnstap=yes,--enable-dnstap=no) \
 	$(if $(CONFIG_DNSDIST_RE2),--with,--without)-re2 \


### PR DESCRIPTION
backport of #18787 for 22.03

luajit provides higher performance for requests handled in Lua hooks.
It also enables access to dnsdist functionality only exposed via FFI,
and allows configurations/hooks to call functions in any C library
without providing separate bindings.

Signed-off-by: Peter van Dijk <peter.van.dijk@powerdns.com>
(cherry picked from commit 283b269c7c0f164311b11d459953b1b34f6974cf)

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
