### PR TITLE
syslog-ng: update to version 3.37.1

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
-PKG_VERSION:=3.36.1
+PKG_VERSION:=3.37.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
@@ -11,7 +11,7 @@ PKG_CPE_ID:=cpe:/a:balabit:syslog-ng
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syslog-ng/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
-PKG_HASH:=90a25c9767fe749db50f118ddfc92ec71399763d2ecd5ad4f11ff5eea049e60b
+PKG_HASH:=d67a320cb896cd5d62f24d9e1bec138847fa4618ae13a3946cae2b75c528ee14
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1

--- a/admin/syslog-ng/files/syslog-ng.conf
+++ b/admin/syslog-ng/files/syslog-ng.conf
@@ -4,7 +4,7 @@
 # More details about these settings can be found here:
 # https://www.syslog-ng.com/technical-documents/list/syslog-ng-open-source-edition
 
-@version: 3.36
+@version: 3.37
 @include "scl.conf"
 
 options {


### PR DESCRIPTION
Maintainer: me
Compile and run tested: Turris 1.1, powerpc_8540, OpenWrt 21.02.3

- Changelog:
https://github.com/syslog-ng/syslog-ng/releases/tag/syslog-ng-3.37.1

- Bump config version