### PR TITLE
[21.02] protobuf: fix 022aef6

### DIFF
--- a/libs/protobuf/Makefile
+++ b/libs/protobuf/Makefile
@@ -24,7 +24,7 @@ CMAKE_SOURCE_SUBDIR:=cmake
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
-include ../../devel/ninja/ninja-cmake.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/protobuf/Default
   SECTION:=libs


### PR DESCRIPTION
The cherry-pick done in 022aef6 includes changing the build setup from
cmake to ninja, but it was overlooked that this was actually reverted in
2e654b1.

The ninja build results in headers not being installed for the host pkg,
so protobuf-c/host can't be build.

This commit reverts the package back to cmake.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @kenkeys 
Compile tested: ath70 21.02 sdk
Run tested: N/A

Description:
Fix commit 022aef6 from @neheb committed by @BKPepe (see related [build failures](https://downloads.openwrt.org/releases/faillogs-21.02/)).

Kind regards,
Seb