### PR TITLE
wifitoggle: set button to wlan, disable auto-disable timer by default

### DIFF
--- a/utils/wifitoggle/files/wifitoggle.config
+++ b/utils/wifitoggle/files/wifitoggle.config
@@ -1,8 +1,8 @@
 config wifitoggle
-	option button	'wps'
+	option button	'wlan'
 
 	option persistent	'0' 
-	option timer		'600'
+	option timer		'0'
 
 	#option led_sysfs		'wrt160nl:amber:wps'
 	# Leaving this option empty, makes sure that no LED is touched


### PR DESCRIPTION
Maintainer: not quite sure
Run tested: OpenWRT snapshot

Description:
I think the default config of wifitoggle is unreasonable, so I made some changes to it. 
Wifitoggle turned wifi off several minutes after turning it on by default. It is confusing for users.

I have added signoff to my commit message.

Sorry, I don't know I have to use real name to sign it off, fixed. 