### PR TITLE
php8: update to 8.1.7

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.1.6
+PKG_VERSION:=8.1.7
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=da38d65bb0d5dd56f711cd478204f2b62a74a2c2b0d2d523a78d6eb865b2364c
+PKG_HASH:=f042322f1b5a9f7c2decb84b7086ef676896c2f7178739b9672afafa964ed0e5
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs

Description:

This fixes:
    - CVE-2022-31625
    - CVE-2022-31626

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
