### PR TITLE
docker-compose: Update to version 2.6.1

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.6.0
+PKG_VERSION:=2.6.1
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=b01b998dbc29478ec989a9df4ebaf4017b7406bba1847b061632f0a7a9841751
+PKG_HASH:=7d4ad5354e382809368016210b33c4f6c3bca68da15e36edc671da00fb234666
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream release

Enhancements:

 - Support for setting secret from env variable by @ndeloof

Fixes:

 - Do not start unrelated dependencies on run by @laurazard
 - Fix service not found errors when using --no-deps by @nicksieger
 - Respect COMPOSE_REMOVE_ORPHANS env var on down by @nicksieger
 - Fix project level bind mounts volumes by @ulyssessouza
 - Respect deploy.limits.cpus and deploy.limits.pids by @glours

Internal:

 - Upgrade: Go v1.18.3 by @thaJeztah
 - Upgrade: compose-go v1.2.8 by @milas
 - Upgrade: buildx v0.8.2 by @dependabot
 - Upgrade: containerd v1.6.6 by @dependabot

Signed-off-by: Javier Marcet <javier@marcet.info>
