### PR TITLE
tor: bump to 0.4.7.8 stable

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.7.7
+PKG_VERSION:=0.4.7.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=3e131158b52b9435d7e43d1c47ef288b96d005342cc44b8c950bb403851a5b44
+PKG_HASH:=9e9a5c67ad2acdd5f0f8be14ed591fed076b1708abf8344066990a0fa66fe195
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
From the changelog…

  o Major bugfixes (congestion control, TROVE-2022-001):
    - Fix a scenario where RTT estimation can become wedged, seriously
      degrading congestion control performance on all circuits. This
      impacts clients, onion services, and relays, and can be triggered
      remotely by a malicious endpoint. Tracked as CVE-2022-33903. Fixes
      bug 40626; bugfix on 0.4.7.5-alpha.

  o Minor features (fallbackdir):
    - Regenerate fallback directories generated on June 17, 2022.

  o Minor features (geoip data):
    - Update the geoip files to match the IPFire Location Database, as
      retrieved on 2022/06/17.

  o Minor bugfixes (linux seccomp2 sandbox):
    - Allow the rseq system call in the sandbox. This solves a crash
      issue with glibc 2.35 on Linux. Patch from pmu-ipf. Fixes bug
      40601; bugfix on 0.3.5.11.

  o Minor bugfixes (logging):
    - Demote a harmless warn log message about finding a second hop to
      from warn level to info level, if we do not have enough
      descriptors yet. Leave it at notice level for other cases. Fixes
      bug 40603; bugfix on 0.4.7.1-alpha.
    - Demote a notice log message about "Unexpected path length" to info
      level. These cases seem to happen arbitrarily, and we likely will
      never find all of them before the switch to arti. Fixes bug 40612;
      bugfix on 0.4.7.5-alpha.

  o Minor bugfixes (relay, logging):
    - Demote a harmless XOFF log message to from notice level to info
      level. Fixes bug 40620; bugfix on 0.4.7.5-alpha.

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>

Maintainer: @tripolar