### PR TITLE
libv4l: Change dependency from libudev-zero to libudev

### DIFF
--- a/libs/libv4l/Makefile
+++ b/libs/libv4l/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v4l-utils
 PKG_VERSION:=1.20.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.linuxtv.org/downloads/v4l-utils
@@ -64,7 +64,7 @@ define Package/v4l-utils
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE+= utilities
-  DEPENDS:= +libudev-zero +libv4l +libstdcpp $(ICONV_DEPENDS) $(INTL_DEPENDS)
+  DEPENDS:= +libudev +libv4l +libstdcpp $(ICONV_DEPENDS) $(INTL_DEPENDS)
   LICENSE:=GPL-2.0-or-later
   LICENSE_FILES:=COPYING
 endef


### PR DESCRIPTION
Maintainer: Ted Hess <thess@kitschensync.net>
Compile tested: (mipsbe, 8dev Rambutan, OpenWrt v22.03.0-rc4)
Run tested: (mipsbe, 8dev Rambutan, OpenWrt v22.03.0-rc4)

Description:
`libudev-zero` dependency causes issues when other `libudev` provider is present, e.g. `eudev`. Especially, it was trying to select both `libudev-zero` and `libudev` what caused the conflict in my case.
Instead, when `libudev` is used, it just looks for any available package which provides the library.