### PR TITLE
totem-pl-parser: depend on shared-mime-info

### DIFF
--- a/libs/totem-pl-parser/Makefile
+++ b/libs/totem-pl-parser/Makefile
@@ -26,7 +26,7 @@ include $(INCLUDE_DIR)/meson.mk
 define Package/totem-pl-parser
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+glib2 +libxml2
+  DEPENDS:=+glib2 +libxml2 +shared-mime-info
   TITLE:=totem-pl-parser
   URL:=https://gitlab.gnome.org/GNOME/totem-pl-parser
 endef


### PR DESCRIPTION
The totem-pl-parser library seems to rely on freedesktop.org's MIME-type
definitions to parse playlist files. Without them, parsing will produce
a TOTEM_PL_PARSER_RESULT_IGNORED error.

Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me

Description:
