### PR TITLE
prometheus-node-exporter: Add package for upstream node_exporter

### DIFF
--- a/utils/prometheus-node-exporter/Makefile
+++ b/utils/prometheus-node-exporter/Makefile
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=prometheus-node-exporter
+PKG_VERSION:=1.3.1
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR=$(BUILD_DIR)/node_exporter-$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/prometheus/node_exporter/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=66856b6b8953e094c46d7dd5aabd32801375cf4d13d9fe388e320cbaeaff573a
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Shenghao Yang <me@shenghaoyang.info>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/prometheus/node_exporter
+GO_PKG_BUILD_PKG:=$(GO_PKG)
+GO_PKG_TAGS:=netgo,osusergo,static_build
+GO_PKG_LDFLAGS_X:=\
+	github.com/prometheus/common/version.Version=v$(PKG_VERSION) \
+	github.com/prometheus/common/version.Revision=a2321e7b940ddcff26873612bccdf7cd4c42b6b6 \
+	github.com/prometheus/common/version.Branch=HEAD \
+	github.com/prometheus/common/version.BuildUser=openwrt \
+	github.com/prometheus/common/version.BuildDate=$(SOURCE_DATE_EPOCH)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/prometheus-node-exporter
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Exporter for machine metrics
+  URL:=https://github.com/prometheus/node_exporter
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/prometheus-node-exporter/description
+Prometheus exporter for hardware and OS metrics exposed by *NIX kernels,
+written in Go with pluggable metric collectors.
+endef
+
+define Package/prometheus-node-exporter/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+	mv $(1)/$(GO_PKG_INSTALL_BIN_PATH)/node_exporter $(1)/usr/bin/prometheus-node-exporter
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/etc/config/prometheus-node-exporter $(1)/etc/config/prometheus-node-exporter
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/etc/init.d/prometheus-node-exporter $(1)/etc/init.d/prometheus-node-exporter
+	$(INSTALL_DIR) $(1)/usr/share/doc/prometheus-node-exporter
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/NOTICE $(1)/usr/share/doc/prometheus-node-exporter/NOTICE
+endef
+
+define Package/prometheus-node-exporter/conffiles
+/etc/config/prometheus-node-exporter
+endef
+
+$(eval $(call GoBinPackage,prometheus-node-exporter))
+$(eval $(call BuildPackage,prometheus-node-exporter))

--- a/utils/prometheus-node-exporter/files/etc/config/prometheus-node-exporter
+++ b/utils/prometheus-node-exporter/files/etc/config/prometheus-node-exporter
@@ -1,0 +1,4 @@
+config prometheus-node-exporter 'main'
+	# Add arguments for node_exporter using the args list option
+	#list args '--arg0=value'
+	#list args '--arg1=value'

--- a/utils/prometheus-node-exporter/files/etc/init.d/prometheus-node-exporter
+++ b/utils/prometheus-node-exporter/files/etc/init.d/prometheus-node-exporter
@@ -1,0 +1,26 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+START=95
+STOP=01
+
+add_arg() {
+	procd_append_param command "$1"
+}
+
+start_service() {
+	config_load prometheus-node-exporter
+
+	procd_open_instance
+
+	procd_set_param command /usr/bin/prometheus-node-exporter
+	procd_set_param user nobody
+	procd_set_param group nogroup
+	procd_set_param no_new_privs 1
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	config_list_foreach "main" args add_arg
+
+	procd_close_instance
+}

--- a/utils/prometheus-node-exporter/test.sh
+++ b/utils/prometheus-node-exporter/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+prometheus-node-exporter --version | grep "$2"


### PR DESCRIPTION
Prometheus exporter for hardware and OS metrics exposed by
*NIX kernels, written in Go with pluggable metric collectors.

Signed-off-by: Shenghao Yang <me@shenghaoyang.info>

Maintainer: me
Compile tested:

Arch | Board | Version | Package size | Installed (binary) size
-----|-------|---------|--------------|------------------------
arm_cortex-a7_neon-vfpv4 | ipq40xx/generic | SNAPSHOT r19958-aae3a8a254 | 4.5MB | 11.6MB, though jffs2 appears to compress it a fair bit more to ~6.x MB
aarch64_cortex-a53 | mediatek/mt7622 | SNAPSHOT r19958-aae3a8a254 | 4.4MB | 11.7MB

Run tested:

Arch | Board | Model | Version
-----|-------|-------|--------
arm_cortex-a7_neon-vfpv4 | ipq40xx/generic | GL-B1300 | SNAPSHOT r19934+18-9d06e5a773 (w/DSA patches)
aarch64_cortex-a53 | mediatek/mt7622 | Linksys E8450 | SNAPSHOT r19958-aae3a8a254 

Tested with default collector set, scraped by local VictoriaMetrics instance.

Description:

Packages the upstream Prometheus node exporter, which provides more metrics than the existing lua exporter (thermal zones, hwmon, ethtool). Also helps to ensure a consistent set of metrics in (previously) mixed lua exporter / upstream exporter environments.

Useful when combined with the lua collector providing OpenWrt specific stats. Duplicate metrics can be filtered out using the lua collector's `collect=` query parameter during scrapes.

PS:

Is there a convention for setting the `LDFLAGS` conventionally handled by `promu`? I checked a few packagers, and they seem to be setting it this way:

Packager | Version | Revision | Branch
---------|---------|----------|-------
Upstream (from release binaries on GitHub) | 1.3.1   | git hash | HEAD
Arch     | 1.3.1   | 1.3.1 | tarball
Debian 11 | 1.3.1 |  1.1.2+ds-2.1 (salsa git tag + .1? - not too familiar with Debian packaging) | debian/sid (salsa branch) 

I set those according to what upstream set, but if anyone has any better ideas...