### PR TITLE
restic-rest-server: update to 0.11.0

### DIFF
--- a/net/restic-rest-server/Makefile
+++ b/net/restic-rest-server/Makefile
@@ -1,17 +1,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=restic-rest-server
-PKG_VERSION:=0.9.7
-PKG_RELEASE:=5
+PKG_VERSION:=0.11.0
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/rest-server-$(PKG_VERSION)
 PKG_SOURCE:=rest-server-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/restic/rest-server/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=922811cfc49879f7086fe559d25ec1bb4169b2c4a5df3559b499e6292f435661
+PKG_HASH:=cd9b35ad2224244207a967ebbc78d84f4298d725e95c1fa9341ed95a350ea68f
 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Markus Weippert <markus@gekmihesg.de>
+PKG_MAINTAINER:=Tom Stöveken <tom@naaa.de>
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1

--- a/net/restic-rest-server/files/etc/config/restic-rest-server
+++ b/net/restic-rest-server/files/etc/config/restic-rest-server
@@ -3,11 +3,16 @@ config rest-server
 	option path '/mnt/backup'			# data directory (default "/tmp/restic")
 	#option append_only '1'				# enable append only mode
 	#option cpuprofile '/mnt/backup/cpuprofile'	# write CPU profile to file
-	#option debug '1'				# output debug messages
+	#option debug '1'					# output debug messages
+	#option htpasswd_file '.htpasswd'	# location of .htpasswd file (default: "<data directory>/.htpasswd")
 	#option listen ':8000'				# listen address (default ":8000")
-	#option log '/mnt/backup/http.log'		# log HTTP requests in the combined log format
+	#option log '/mnt/backup/http.log'	# log HTTP requests in the combined log format
+	#option max_size '1000000'			# the maximum size of the repository in bytes
+	#option no_auth '1'					# disable .htpasswd authentication
+	#option no_verify_upload '1'		# do not verify the integrity of uploaded data. DO NOT enable unless the rest-server runs on a very low-power device
 	#option private_repos '1'			# users can only access their private repo
 	#option prometheus '1'				# enable Prometheus metrics
-	#option tls '1'					# turn on TLS support
+	#option prometheus_no_auth '1'		# disable auth for Prometheus /metrics endpoint
+	#option tls '1'						# turn on TLS support
 	#option tls_cert '/mnt/backup/public_key'	# TLS certificate path
 	#option tls_key '/mnt/backup/private_key'	# TLS key path

--- a/net/restic-rest-server/files/etc/init.d/restic-rest-server
+++ b/net/restic-rest-server/files/etc/init.d/restic-rest-server
@@ -15,11 +15,11 @@ start_instance() {
 
 	procd_open_instance "$cfg"
 	procd_set_param command "$PROG"
-	for var in append_only debug private_repos prometheus tls; do
+	for var in append_only debug no_auth no_verify_upload private_repos prometheus prometheus_no_auth tls; do
 		config_get_bool val "$cfg" "$var" 0
 		[ "$val" = 0 ] || procd_append_param command "--${var//_/-}"
 	done
-	for var in cpuprofile listen log path tls_cert tls_key; do
+	for var in cpuprofile htpasswd_file listen log max_size path tls_cert tls_key; do
 		config_get val "$cfg" "$var"
 		[ -z "$val" ] || procd_append_param command "--${var//_/-}" "$val"
 	done
@@ -28,7 +28,6 @@ start_instance() {
 	procd_set_param respawn
 	procd_close_instance
 }
-
 
 service_triggers() {
 	procd_add_reload_trigger restic-rest-server


### PR DESCRIPTION
Maintainer: Tom Stöveken <tom@naaa.de>, Markus Weippert handed over, see: https://github.com/openwrt/packages/pull/18715#issuecomment-1153567619
Compile tested: SDK for OpenWrt 21.02.3
Run tested: x86/64, J&W Technologies I1171D001 Intel(R) Celeron(R) CPU N3160 @ 1.60GHz, OpenWrt 21.02.3

Description:
Updated to version 0.11.0
Added new configuration parameters

Signed-off-by: Tom Stöveken <tom@naaa.de>