### PR TITLE
radcli: uptdate to 1.3.0

### DIFF
--- a/libs/libradcli/Makefile
+++ b/libs/libradcli/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libradcli
-PKG_VERSION:=1.2.11
+PKG_VERSION:=1.3.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=radcli-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/radcli/radcli/releases/download/$(PKG_VERSION)
-PKG_HASH:=b6210e4c7deae235bb8c4e9df20c4f82c8bc2bda6d6214d50c5667660ab38548
+PKG_HASH:=20ddc8429d5912dfa2e71fafc93881844ce98e898c041b1dd7f757b9ddc8fcfd
 PKG_BUILD_DIR:=$(BUILD_DIR)/radcli-$(PKG_VERSION)
 
 PKG_INSTALL:=1


### PR DESCRIPTION
- Removed duplicate function definition from util.h
- Increased size of dictionary vendor and values to 32-bits from 16;
  this breaks the ABI from the previous release.
- Corrected a string termination issue in rc_avpair_tostr()
- Added functions to create dictionary without a file:
      rc_dict_addattr
      rc_dict_addval
      rc_dict_addvend

Signed-off-by: Nick Hainke <vincent@systemli.org>

Maintainer: @nmav 
