### PR TITLE
[22.03] collectd: Fix various issues with lantiq dsl metrics.

### DIFF
--- a/utils/collectd/files/lua-scripts/dsl.lua
+++ b/utils/collectd/files/lua-scripts/dsl.lua
@@ -44,7 +44,7 @@ local line_vars = {
 		type = "bitrate"
 	},
 	{
-		name = "latn",
+		name = "interleave_delay",
 		type = "latency"
 	}
 }
@@ -52,19 +52,19 @@ local line_vars = {
 local errors = {
 	{
 		name = "uas",
-		type = "gauge"
+		type = "count"
 	},
 	{
 		name = "rx_corrupted",
-		type = "gauge"
+		type = "errors"
 	},
 	{
 		name = "rx_retransmitted",
-		type = "gauge"
+		type = "errors"
 	},
 	{
 		name = "tx_retransmitted",
-		type = "gauge"
+		type = "errors"
 	}
 }
 
@@ -80,14 +80,6 @@ local erb_vars = {
 }
 
 local general_vars = {
-	{
-		name = "profile",
-		type = "gauge"
-	},
-	{
-		name = "mode",
-		type = "gauge"
-	},
 	{
 		name = "state_num",
 		type = "gauge"
@@ -117,6 +109,13 @@ local function get_values(hostname, variables, metrics, direction)
 		if metrics and metrics[name] ~= nil then
 			local value = metrics[name]
 			local metric = build_metric(name, direction)
+			if information["type"] == "bool" then
+				if metrics[name] == true then
+					value = 1
+				else
+					value = 0
+				end
+			end
 
 			local t = {
 				host = host,


### PR DESCRIPTION
- Handle bool values correctly. We get the values as bool, but collectd
  requires a bool value to be numeric in the range [0, 1].
- Remove profile and mode values. Those are strings, which cannot be
  represented by collectd.
- Update collectd type for some values.
- Fix latn value being present twice.

Cherry-picks eb632da5bbd732bbffc2761fbb191267ef2375d0

Signed-off-by: Dominik Riebeling <bluebrother@posteo.de>
