### PR TITLE
  gnutls: adjust to new configure.ac syntax

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -135,8 +135,8 @@ CONFIGURE_ARGS+= \
 	--with-librt-prefix="$(LIBRT_ROOT_DIR)/" \
 	--with-pic \
 	--with-system-priority-file="" \
-	--without-libzstd \
-	--without-zlib
+	--without-zlib \
+	--without-zstd
 
 ifneq ($(CONFIG_GNUTLS_EXT_LIBTASN1),y)
 CONFIGURE_ARGS += --with-included-libtasn1

--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -135,6 +135,7 @@ CONFIGURE_ARGS+= \
 	--with-librt-prefix="$(LIBRT_ROOT_DIR)/" \
 	--with-pic \
 	--with-system-priority-file="" \
+	--without-brotli \
 	--without-zlib \
 	--without-zstd
 


### PR DESCRIPTION
Configure.ac syntax changed to:
  Old: --without-libbrotli --without-libzstd (also --with-*)
  New: --without-brotli --without-zstd (also --with-*)
  https://github.com/gnutls/gnutls/commit/6b794e49d1a14e43f9e08023f958364712c3c89a

Fixes: 6385813ddfb4 ("gnutls: update to 3.7.5")

Maintainer: @nmav 