### PR TITLE
xtables-addons: update to 3.21 (backport to openwrt-22.03 branch)

### DIFF
--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -9,9 +9,9 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=xtables-addons
-PKG_VERSION:=3.13
-PKG_RELEASE:=4
-PKG_HASH:=893c0c4ea09759cda1ab7e68f1281d125e59270f7b59e446204ce686c6a76d65
+PKG_VERSION:=3.19
+PKG_RELEASE:=$(AUTORELEASE)
+PKG_HASH:=5e36ea027ab15a84d9af1f3f8e84a78b80a617093657f08089bd44657722f661
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://inai.de/files/xtables-addons/
@@ -162,7 +162,7 @@ define Package/iptgeoip/install
 		$(1)/usr/lib/xtables-addons/
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/bin/xt_geoip_fetch \
+		$(PKG_INSTALL_DIR)/usr/bin/xt_geoip_query \
 		$(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/usr/share/xt_geoip
 	touch $(1)/usr/share/xt_geoip/.keep

--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -7,9 +7,9 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=xtables-addons
-PKG_VERSION:=3.20
+PKG_VERSION:=3.21
 PKG_RELEASE:=$(AUTORELEASE)
-PKG_HASH:=359d625658ecc2190b9f164e067d83070a949ac64f81fcddd484be5d14fa116e
+PKG_HASH:=2e09ac129a14f5e9c23b115ebcdfff4aa84e2aeba1268dbdf39b2d752bd71e19
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://inai.de/files/xtables-addons/

--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -1,8 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-only
 #
 # Copyright (C) 2009-2013 OpenWrt.org
-#
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
 #
 
 include $(TOPDIR)/rules.mk
@@ -16,11 +14,13 @@ PKG_HASH:=5e36ea027ab15a84d9af1f3f8e84a78b80a617093657f08089bd44657722f661
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://inai.de/files/xtables-addons/
 PKG_BUILD_DEPENDS:=iptables
+
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
 PKG_ASLR_PIE:=0

--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -7,9 +7,9 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=xtables-addons
-PKG_VERSION:=3.19
+PKG_VERSION:=3.20
 PKG_RELEASE:=$(AUTORELEASE)
-PKG_HASH:=5e36ea027ab15a84d9af1f3f8e84a78b80a617093657f08089bd44657722f661
+PKG_HASH:=359d625658ecc2190b9f164e067d83070a949ac64f81fcddd484be5d14fa116e
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://inai.de/files/xtables-addons/

--- a/net/xtables-addons/patches/001-fix-kernel-version-detection.patch
+++ b/net/xtables-addons/patches/001-fix-kernel-version-detection.patch
@@ -1,8 +1,8 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -44,7 +44,7 @@ regular_CFLAGS="-Wall -Waggregate-return
+@@ -42,7 +42,7 @@ regular_CFLAGS="-Wall -Waggregate-return
  
- if test -n "$kbuilddir"; then
+ AS_IF([test -n "$kbuilddir"], [
  	AC_MSG_CHECKING([kernel version that we will build against])
 -	krel="$(make -sC "$kbuilddir" M=$PWD kernelrelease | $AWK -v 'FS=[[^0-9.]]' '{print $1; exit}')"
 +	krel="$(make -sC "$kbuilddir" M=$PWD kernelversion | $AWK -v 'FS=[[^0-9.]]' '{print $1; exit}')"

--- a/net/xtables-addons/patches/200-add-lua-packetscript.patch
+++ b/net/xtables-addons/patches/200-add-lua-packetscript.patch
@@ -1137,7 +1137,7 @@
 +	struct xt_lua_tginfo *info = (void *)target->data;
 +
 +	info->state_id = 0;
-+	strncpy(info->function, "process_packet\0", sizeof("process_packet\0"));
++	strcpy(info->function, "process_packet\0");
 +}
 +
 +static int
@@ -5301,7 +5301,7 @@
 +      case OP_FORLOOP:
 +      case OP_FORPREP:
 +        checkreg(pt, a+3);
-+        /* go through */
++        fallthrough;
 +      case OP_JMP: {
 +        int dest = pc+1+b;
 +        /* not full check and jump is forward and do not skip `lastpc'? */
@@ -7716,6 +7716,7 @@
 +        }
 +        else if (sep == -1) return '[';
 +        else luaX_lexerror(ls, "invalid long string delimiter", TK_STRING);
++        fallthrough;
 +      }
 +      case '=': {
 +        next(ls);
@@ -7809,7 +7810,6 @@
 +  lua_assert(ls->lookahead.token == TK_EOS);
 +  ls->lookahead.token = llex(ls, &ls->lookahead.seminfo);
 +}
-+
 --- /dev/null
 +++ b/extensions/LUA/lua/llex.h
 @@ -0,0 +1,81 @@
@@ -12471,7 +12471,7 @@
 +      lua_number2int(k, n);
 +      if (luai_numeq(cast_num(k), nvalue(key))) /* index is int? */
 +        return luaH_getnum(t, k);  /* use specialized version */
-+      /* else go through */
++      fallthrough;
 +    }
 +    default: {
 +      Node *n = mainposition(t, key);
@@ -12766,7 +12766,7 @@
 +  if (!lua_isstring(L, -1))
 +    luaL_error(L, "invalid value (%s) at index %d in table for "
 +                  LUA_QL("concat"), luaL_typename(L, -1), i);
-+    luaL_addvalue(b);
++  luaL_addvalue(b);
 +}
 +
 +
@@ -17984,7 +17984,7 @@
 +	int32_t ret;
 +	struct lua_env * env = kmalloc(sizeof(struct lua_env), GFP_KERNEL);
 +
-+	if (!script_size > 0) {
++	if (!script_size) {
 +		pr_debug("LUA [%d]: script_size %lu < 0\n", state_id, script_size);
 +		return false;
 +	}


### PR DESCRIPTION
Maintainer: @jow-
Compile tested: mvebu/cortexa9, Linksys WRT1900ACS v2,  `openwrt-22.03 - 5c7aed8b1e7336686860479cc6f0716ca6bf7016`
Run tested: mvebu/cortexa9, Linksys WRT1900ACS v2,  `openwrt-22.03 - 5c7aed8b1e7336686860479cc6f0716ca6bf7016`

Description:
Basically the same as in https://github.com/openwrt/packages/pull/18802 with the remaining commits. Because the  kernel in the `openwrt-22.03` branch as been updated to 5.10.127 (commit 6b44a6e73184593845d3521b1e21fd44e3a9d2f4)

Also included cherry picked commits from master:
 - xtables-addons: add PKG_LICENSE_FILES and use SPDX  (https://github.com/openwrt/packages/commit/b4d00c1c203850644387378c37410f6216c998cf)
 - xtables-addons: fix various warning in lua patch (https://github.com/openwrt/packages/commit/1cd93b673bfc01969946072a3d6989633e596804)