### PR TITLE
netifyd: Updated to v4.2.0.

### DIFF
--- a/net/netifyd/Makefile
+++ b/net/netifyd/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016-2021 eGloo, Incorporated
+# Copyright (C) 2016-2022 eGloo Incorporated
 #
 # This is free software, licensed under the GNU General Public License v2.
 
@@ -16,10 +16,10 @@ PKG_INSTALL:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.com/netify.ai/public/netify-agent.git
-PKG_SOURCE_DATE:=2021-11-17
-PKG_SOURCE_VERSION:=v3.09
-#PKG_SOURCE_VERSION:=358ec2b0ac321e0608e78c75f6b7434ed1aec326
-PKG_MIRROR_HASH:=660079a75a17a07c638b25dab0ecc972c02fec2124930068bfcf15d28abf4121
+PKG_SOURCE_DATE:=2022-07-04
+PKG_SOURCE_VERSION:=v4.2.0
+#PKG_SOURCE_VERSION:=e3dc824d8f49ddc49a2b392b4960def267a01ba8
+PKG_MIRROR_HASH:=53b98bbc1c9442952c2cd3118de30100da9a366116ad253d14ba990671926a35
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -49,6 +49,7 @@ define Package/netifyd/conffiles
 /etc/netify.d/agent.uuid
 /etc/netify.d/serial.uuid
 /etc/netify.d/site.uuid
+/etc/netify.d/netify-categories.json
 endef
 
 TARGET_CFLAGS+=-ffunction-sections -fdata-sections -Wno-psabi
@@ -59,6 +60,7 @@ CONFIGURE_ARGS+= \
 	--sharedstatedir=/var/run \
 	--enable-lean-and-mean \
 	--disable-libtcmalloc \
+	--disable-jemalloc \
 	--without-systemdsystemunitdir \
 	--without-tmpfilesdir
 
@@ -84,13 +86,12 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/netifyd/pcap-compat/*.h $(1)/usr/include/netifyd/pcap-compat
 	$(INSTALL_DIR) $(1)/usr/include/netifyd/nlohmann
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/netifyd/nlohmann/*.hpp $(1)/usr/include/netifyd/nlohmann
-	$(INSTALL_DIR) $(1)/usr/include/libndpi-2.9.0
-	$(INSTALL_DIR) $(1)/usr/include/libndpi-2.9.0/libndpi
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/libndpi-2.9.0/libndpi/*.h $(1)/usr/include/libndpi-2.9.0/libndpi
+	$(INSTALL_DIR) $(1)/usr/include/ndpi
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/ndpi/*.h $(1)/usr/include/ndpi
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetifyd.{a,so*} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetifyd.{a,so*} $(1)/usr/lib
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libnetifyd.pc $(1)/usr/lib/pkgconfig/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libnetifyd.pc $(1)/usr/lib/pkgconfig
 endef
 
 define Package/netifyd/install
@@ -103,9 +104,10 @@ define Package/netifyd/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/netifyd $(1)/usr/sbin
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetifyd.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetifyd.so.* $(1)/usr/lib
 	$(INSTALL_DIR) $(1)/etc/netify.d
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/deploy/netify-sink.conf $(1)/etc/netify.d/netify-sink.conf
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/deploy/netify-apps.conf $(1)/etc/netify.d
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/deploy/netify-categories.json $(1)/etc/netify.d
 	$(INSTALL_DIR) $(1)/usr/share/netifyd
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/deploy/functions.sh $(1)/usr/share/netifyd
 endef

--- a/net/netifyd/files/netifyd.init
+++ b/net/netifyd/files/netifyd.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 #
-# Copyright (C) 2016-2021 eGloo, Incorporated
+# Copyright (C) 2016-2022 eGloo Incorporated
 #
 # This is free software, licensed under the GNU General Public License v2.
 


### PR DESCRIPTION
Signed-off-by: Darryl Sokoloski <darryl@sokoloski.ca>

Maintainer: Darryl Sokoloski / @dsokoloski
Compile tested: arm_cortex-a15_neon-vfpv4, TP-Link Archer C2600, master
Run tested: TP-Link Archer C2600

## Summary

Netify Agent v4.2.0 stable release incorporates a host of new features and improvements such as a completely new application definitions implementation, a new applications configuration file-format, Netify API integration with automatic application/protocol category updates, refined classifications using "soft-dissectors", support for applying application categories to lists of custom domains, significant memory utilization reductions, and a complete reintegration of the latest nDPI master branch.

## Improvements

- Decoupled application definitions from nDPI.  The Agent now processes all application definitions and look-ups internally.  A new radix tree implementation is used to store application network blocks (CIDR).  These changes significantly reduce memory utilization.
- With the new application definition implementation comes a new configuration file-format.  The new format supports Application Domain Transforms for matching complex domains which are commonly used by CDNs.  Documentation for the new file-format can be found [here](https://gitlab.com/netify.ai/public/netify-agent/-/wikis/application%20definitions).
- Added application and protocol category support with automatic Netify API updates.
- Added the ability to enable or disable specific protocols at start-up.  It's now possible to customize the DPI processing for the environment and/or platform capabilities.
- Implemented additional packet processing.  Some dissectors can extract additional metadata but require addition packet processing after detection (ex: TLS).  Flows can now be updated post-detection which is indicated by a new "_flow_updated_" field.
- For pcap capture sources, the "_snap length_" has been increased from 1,536 to 65,535 bytes.  Some dissectors have interesting metadata that could be past 1,536 bytes.  This value is now a configurable option, "_max_capture_length_".
- The maximum number of packets to process used to be set individually for TCP and UDP.  This is now unified as "_max_detection_pkts_", and has been increased from 10 to 32 packets.  Some dissectors with extra packet processing require more than 10 packets.
- Improved packet processing performance.  Removed unnecessary select() calls.
- Significantly reduced the amount of packets queued during flow statistics collection.  Instead of entirely locking a capture source flows are now associated with a locking bucket (flow_map mutex).
- Further reduced the amount of time a flow lock bucket is held during statistics collection / processing.
- Introduced "soft-dissectors".  Detections can now be refined using simple flow-criteria expressions.
- Custom lists of domains can now be loaded to apply a user-selected application category.
- Added support for plugin version reporting.
- Added plugin event system.  Plugins can now be notified of certain Agent events such as a SIGHUP (reload) signal.
- Added tracking of TCP resets.
- Immediately purge TCP flows on FIN.
- Added protocol refinement using new port map.
- Improved application, category, and protocol "_dump_" command-line options.
- Added complete command-line options help.
- Added support for nDPI debug messages.
- [**lxc**] Added SIGPWR handler.
- [**linux**] Extract connection tracking ID and mark values for all flows (when enabled).
- [**openwrt**] Added daemon reload support via procd.
- [**openwrt**] Improved network interface auto-detection for 21.02.
- [**freebsd**] Added support for PKG files.

## Bug Fixes
- Fixed crash on start-up when a connecting socket client is waiting.
- Fixed default provisioning URL fall-back (sink_url).
- Fixed crashes on purge by refactoring flow expiration and purge logic.
- Fixed packet timestamps for offline captures.
- Fixed tracking of TCP sequence errors.
- Added missing newline for "_agent_status_" socket messages.
- [**freebsd**] Various compilation and packaging fixes.

Full release notes are available [here](https://gitlab.com/netify.ai/public/netify-agent/-/releases/4.2.0).