### PR TITLE
 cloudflared: Update to 2022.7.1

### DIFF
--- a/net/cloudflared/Makefile
+++ b/net/cloudflared/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cloudflared
-PKG_VERSION:=2022.6.2
+PKG_VERSION:=2022.7.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cloudflare/cloudflared/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=599ea11ff7f6a8941eb2cdbc1eced0419eb3dec85104f3f7a6a8268f4d0e722a
+PKG_HASH:=3a822faaed7ae90be5ba4920f9226cd85367402d2c5a2bf2f0732c37cad6599d
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8, x86/64
Run tested: nanopi-r2s

Description:
Release note:
- https://github.com/cloudflare/cloudflared/commit/6a6ba704f1d5b83e5fa6e8f6e80c6243b3018c2a
- https://github.com/cloudflare/cloudflared/commit/ac7fdd5572007bb8b5ccb7d466f0461ee9977627
- https://github.com/cloudflare/cloudflared/commit/06f7ba45233942b72349685fb7ede38c2783dd65