### PR TITLE
[openwrt-21.02] python-cryptography: Fix failing build

### DIFF
--- a/lang/python/python-cryptography/Makefile
+++ b/lang/python/python-cryptography/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptography
 PKG_VERSION:=3.4.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=cryptography
 PKG_HASH:=94cc5ed4ceaefcbe5bf38c8fba6a21fc1d365bb8fb826ea1688e3370b2e24a1c

--- a/lang/python/python-cryptography/patches/0004-disable-rust.patch
+++ b/lang/python/python-cryptography/patches/0004-disable-rust.patch
@@ -9,9 +9,12 @@
  except ImportError:
      print(
          """
-@@ -45,7 +45,7 @@ setuptools_rust = "setuptools-rust>=0.11
+@@ -43,9 +43,9 @@ with open(os.path.join(src_dir, "cryptog
+ # `pyproject.toml`
+ setuptools_rust = "setuptools-rust>=0.11.4"
  install_requirements = ["cffi>=1.12"]
- setup_requirements = install_requirements + [setuptools_rust]
+-setup_requirements = install_requirements + [setuptools_rust]
++setup_requirements = install_requirements
  
 -if os.environ.get("CRYPTOGRAPHY_DONT_BUILD_RUST"):
 +if True:


### PR DESCRIPTION
Maintainer: me
Compile tested: none (cherry picked from #18883)
Run tested: none

Description:
Fixes https://github.com/openwrt/packages/issues/18876.
Fixes https://github.com/openwrt/packages/issues/18879.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 9e3b7d78837b7181b859472894aa243a2eae595b)