### PR TITLE
netsniff-ng: build and package mausezahn and it's dependency libcli

### DIFF
--- a/libs/libcli/Makefile
+++ b/libs/libcli/Makefile
@@ -1,0 +1,57 @@
+# Copyright (C) 2022 Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libcli
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://github.com/dparrish/libcli.git
+PKG_SOURCE_DATE:=2022-07-06
+PKG_SOURCE_VERSION:=V1.10.7
+PKG_MIRROR_HASH:=7698898364d91a1abf9e19c588a19c9587615106cf1caaf2a7e135f9ce1b1b45
+
+PKG_MAINTAINER:=Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+PKG_LICENSE:=LGPL-2.1
+PKG_LICENSE_FILES:=COPYING
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libcli
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=libcli
+  URL:=https://dparrish.com/link/libcli
+  DEPENDS:=+libc
+endef
+
+define Package/libcli/description
+  Libcli provides a shared library for including a Cisco-like
+  command-line interface into other software.
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		CC="$(TARGET_CC)" \
+		LDFLAGS="$(TARGET_LDFLAGS)" \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		TESTS=0 \
+		all install
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/local/include/libcli.h $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/local/lib/libcli.so* $(1)/usr/lib/
+endef
+
+define Package/libcli/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/local/lib/libcli.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libcli))

--- a/net/netsniff-ng/Makefile
+++ b/net/netsniff-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netsniff-ng
 PKG_VERSION:=0.6.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netsniff-ng/netsniff-ng/tar.gz/v$(PKG_VERSION)?
@@ -15,20 +15,41 @@ PKG_LICENSE_FILES:=COPYING
 PKG_USE_MIPS16:=0
 PKG_BUILD_PARALLEL:=1
 
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_PACKAGE_mausezahn \
+	CONFIG_PACKAGE_netsniff-ng
+
 include $(INCLUDE_DIR)/package.mk
 
-define Package/netsniff-ng
+define Package/netsniff-ng/Default
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libpthread +libpcap +libncurses +zlib +liburcu +libsodium +libnetfilter-conntrack
-  TITLE:=netsniff-ng
+  DEPENDS:=+libpthread +libpcap
   URL:=https://github.com/netsniff-ng/netsniff-ng
+endef
+
+define Package/netsniff-ng
+  $(call Package/netsniff-ng/Default)
+  DEPENDS+=+libncurses +libnetfilter-conntrack +libsodium +liburcu +zlib
+  TITLE:=netsniff-ng
 endef
 
 define Package/netsniff-ng/description
 	netsniff-ng is a free, performant Linux network analyzer and
 	networking toolkit. If you will, the Swiss army knife for network
 	packets.
+endef
+
+define Package/mausezahn
+  $(call Package/netsniff-ng/Default)
+  DEPENDS+=+libcli +libnet-1.2.x
+  TITLE:=mausezahn
+endef
+
+define Package/mausezahn/description
+	Mausezahn is a traffic generator written which allows sending
+	nearly every possible and impossible packet. It is mainly used
+	to test VoIP or multicast networks.
 endef
 
 define Build/Configure
@@ -66,4 +87,10 @@ define Package/netsniff-ng/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/curvetun/curvetun $(1)/usr/sbin/
 endef
 
+define Package/mausezahn/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/mausezahn/mausezahn $(1)/usr/sbin/
+endef
+
 $(eval $(call BuildPackage,netsniff-ng))
+$(eval $(call BuildPackage,mausezahn))


### PR DESCRIPTION
Maintainer: @utoni (netsniff-ng) and myself (libcli)
Compile tested: Lantiq xRX200 BT Home Hub 5A
Run tested: Lantiq xRX200 BT Home Hub 5A

Preconditions:
- [x] this includes #18880 which needs to be merged first

Description:
mausezahn is a multicast traffic generator and heavily used by kernel selftests (`tools/testing/selftests/net/forwarding/`). packaging mausezahn is a pre-condition for an upcoming package with these kernel selftests

netsniff-ng's `configure` script is smart enough to auto-detect which dependencies are available and based on that which tools to build. building mausezahn without netsniff-ng and vice versa is possible, meaning we don't need to pull in libcli for netsniff-ng builds or pull in zlib for mausezahn buillds