### PR TITLE
ser2net: schedule start later during boot (fixes #18872)

### DIFF
--- a/net/ser2net/Makefile
+++ b/net/ser2net/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ser2net
 PKG_VERSION:=4.3.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/ser2net

--- a/net/ser2net/files/ser2net.init
+++ b/net/ser2net/files/ser2net.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2017 Michael Heimpold
 
-START=75
+START=99
 STOP=10
 
 USE_PROCD=1
@@ -189,4 +189,3 @@ start_service() {
 service_triggers() {
 	procd_add_reload_trigger "ser2net"
 }
-


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: -

Description:

Usually, no other local service depends on the start of ser2net, so
let's start it later in the boot process.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>