### PR TITLE
[19.07] libarchive: fix ext2fs build race error condition

### DIFF
--- a/libs/libarchive/Makefile
+++ b/libs/libarchive/Makefile
@@ -91,6 +91,14 @@ else
 	CONFIGURE_ARGS += --with-openssl
 endif
 
+EXTRA_CFLAGS += "-I$(PKG_BUILD_DIR)/extra-includes"
+
+define Build/Configure
+	$(INSTALL_DIR) $(PKG_BUILD_DIR)/extra-includes/
+	$(CP) -R $(STAGING_DIR_HOST)/include/ext2fs $(PKG_BUILD_DIR)/extra-includes/
+	$(Build/Configure/Default)
+endef
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/


### PR DESCRIPTION
This is backport of 797945dfaa0e7de8d6b0ada472bda63bb27f0cdc commit.

Maintainer: @morgenroth
Compile tested: N/A
Run tested: N/A

Description:

libarchive looks for ext2fs headers during configure, and if it finds
them it will expect to find them during compile, or on the rare occasion
when they aren't it will fail:

      libarchive/archive_entry.c:59:55: fatal error: ext2fs/ext2_fs.h: No such file or directory

As we just need headers for some type constants, let's re-use headers
from tools/e2fsprogs package which are always available.