### PR TITLE
nebula: update to 1.6.0

### DIFF
--- a/net/nebula/Makefile
+++ b/net/nebula/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nebula
-PKG_VERSION:=1.5.0
+PKG_VERSION:=1.6.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/slackhq/nebula/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=f67684a8eba6da91de3601afc97567fddd0e198973bba950fcf15cded92cdc50
+PKG_HASH:=b16638b99d80a4ae6373f7757a0064dc0defd3f9e165617e7b5c3be9e64d3605
 
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=MIT

--- a/net/nebula/files/nebula.init
+++ b/net/nebula/files/nebula.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
-# Copyright 2021 Stan Grishin (stangri@melmac.net)
-# shellcheck disable=SC2039
+# Copyright 2021 Stan Grishin (stangri@melmac.ca)
+# shellcheck disable=SC2039,SC3043
 PKG_VERSION='dev-test'
 
 # shellcheck disable=SC2034


### PR DESCRIPTION
Maintainer: me
Compile tested: not tested, want to run this thru CI
Run tested: not tested, don't have a device with snapshot build

Description:
* Update to https://github.com/slackhq/nebula/releases/tag/v1.6.0
* Update maintainer's email address
* Update for newest shellcheck

Signed-off-by: Stan Grishin <stangri@melmac.ca>
