### PR TITLE
modemmanager: fix mm_log() invocations in 25-modemmanager* files

### DIFF
--- a/net/modemmanager/files/25-modemmanager-net
+++ b/net/modemmanager/files/25-modemmanager-net
@@ -12,7 +12,7 @@
 mkdir -m 0755 -p "${MODEMMANAGER_RUNDIR}"
 
 # Report network interface
-mm_log "${ACTION} network interface ${INTERFACE}: event processed"
+mm_log "info" "${ACTION} network interface ${INTERFACE}: event processed"
 mm_report_event "${ACTION}" "${INTERFACE}" "net" "/sys${DEVPATH}"
 
 # Look for an associated cdc-wdm interface
@@ -26,6 +26,6 @@ esac
 
 # Report cdc-wdm device, if any
 [ -n "${cdcwdm}" ] && {
-	mm_log "${ACTION} cdc interface ${cdcwdm}: custom event processed"
+	mm_log "info" "${ACTION} cdc interface ${cdcwdm}: custom event processed"
 	mm_report_event "${ACTION}" "${cdcwdm}" "usbmisc" "/sys${DEVPATH}"
 }

--- a/net/modemmanager/files/25-modemmanager-tty
+++ b/net/modemmanager/files/25-modemmanager-tty
@@ -12,5 +12,5 @@
 mkdir -m 0755 -p "${MODEMMANAGER_RUNDIR}"
 
 # Report TTY
-mm_log "${ACTION} serial interface ${DEVNAME}: event processed"
+mm_log "info" "${ACTION} serial interface ${DEVNAME}: event processed"
 mm_report_event "${ACTION}" "${DEVNAME}" "tty" "/sys${DEVPATH}"

--- a/net/modemmanager/files/25-modemmanager-wwan
+++ b/net/modemmanager/files/25-modemmanager-wwan
@@ -11,5 +11,5 @@
 mkdir -m 0755 -p "${MODEMMANAGER_RUNDIR}"
 
 # Report wwan
-mm_log "${ACTION} wwan control port ${DEVNAME}: event processed"
+mm_log "info" "${ACTION} wwan control port ${DEVNAME}: event processed"
 mm_report_event "${ACTION}" "${DEVNAME}" "wwan" "/sys${DEVPATH}"


### PR DESCRIPTION
Definition of mm_log() was changed in
45a56a889943b437f78fa2bfca3d5d8ac555c77e but 25-modemmanager* weren't
changed.

Signed-off-by: Arkadiusz Drabczyk <arkadiusz@drabczyk.org>

Maintainer: @nickberry17 
Compile tested: x86-64 Slackware OS, CONFIG_TARGET_ipq40xx, OpenWrt 22.03.0-rc4
Run tested: armv7l, InHand Networks VG710, OpenWrt 22.03.0-rc4
The purpose of the test was to check if 'event processed' logs show up in logread:

    root@OpenWrt:~# logread  | grep 'event processed'
    Wed Jul 13 11:48:57 2022 daemon.info ModemManager[4273]: hotplug: add network interface br-lan: event processed

Description:
