### PR TITLE
domoticz: fix read of "disabled" uci configuration parameter

### DIFF
--- a/utils/domoticz/files/domoticz.init
+++ b/utils/domoticz/files/domoticz.init
@@ -7,7 +7,10 @@ PIDFILE=/var/run/domoticz.pid
 
 start_domoticz() {
 	local section="$1"
-	local loglevel sslcert sslpass sslwww syslog userdata
+	local disabled loglevel sslcert sslpass sslwww syslog userdata
+
+	config_get_bool disabled "$section" "disabled" 0
+	[ "$disabled" -gt 0 ] && return
 
 	config_get loglevel "$section" "loglevel"
 	config_get sslcert "$section" "sslcert"
@@ -17,6 +20,11 @@ start_domoticz() {
 	config_get sslwww "$section" "sslwww"
 	config_get syslog "$section" "syslog"
 	config_get userdata "$section" "userdata" userdata /var/lib/domoticz
+
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_append_param command -noupdates
+	procd_append_param command -approot /usr/share/domoticz/
 
 	[ -n "$loglevel" ] && procd_append_param command -loglevel "$loglevel"
 	[ -n "$syslog" ] && procd_append_param command -syslog "$syslog"
@@ -47,25 +55,16 @@ start_domoticz() {
 		[ -n "$sslpass" ] && procd_append_param command -sslpass "$sslpass"
 		[ -n "$ssldhparam" ] && procd_append_param command -ssldhparam "$ssldhparam"
 	} || procd_append_param command -sslwww 0
-}
-
-start_service() {
-	procd_open_instance
-
-	procd_set_param command "$PROG"
-	procd_append_param command -noupdates
-	procd_append_param command -approot /usr/share/domoticz/
-
-	config_load "domoticz"
-	config_get_bool disabled "$section" "disabled" 0
-	[ "$disabled" -gt 0 ] && return 1
-	config_foreach start_domoticz domoticz
 
 	procd_set_param pidfile "$PIDFILE"
 	procd_set_param respawn
 	procd_set_param stdout 0
 	procd_set_param term_timeout 10
 	procd_set_param user "domoticz"
-
 	procd_close_instance
+}
+
+start_service() {
+	config_load "domoticz"
+	config_foreach start_domoticz domoticz
 }


### PR DESCRIPTION
The domoticz init script didn't properly read the "disabled"
configuration parameter and instead the service was always started.

Signed-off-by: Robert Högberg <robert.hogberg@gmail.com>

Maintainer: @dwmw2
Compile tested: no
Run tested: ath79, D-Link DIR-825 B1, OpenWrt 21.02.3 - I have verified that starting domoticz with and without "disabled" set works as expected