### PR TITLE
libxml2: add libiconv path to pkg-config file

### DIFF
--- a/libs/libxml2/Makefile
+++ b/libs/libxml2/Makefile
@@ -100,6 +100,7 @@ CONFIGURE_ARGS += \
 	--with-xpath \
 	--with-xptr \
 	--with-zlib=$(STAGING_DIR)/usr \
+	--with-iconv$(if $(ICONV_PREFIX),="$(ICONV_PREFIX)") \
 	--without-lzma
 
 HOST_CONFIGURE_ARGS += \


### PR DESCRIPTION
Needed for applications that use libxml-2.0.pc Libs.private params
to link with -liconv library.

Signed-off-by: Alin Nastac <alin.nastac@gmail.com>
