### PR TITLE
[21.02] telegraf: update to version 1.23.2 on openwrt 21.02

### DIFF
--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telegraf
-PKG_VERSION:=1.23.0
+PKG_VERSION:=1.23.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=097f0ae89332dd55c121dbb6b5f81b151a0f0418c11d26b430b33be31ca90d0b
+PKG_HASH:=7d0721908b3a2b3d36e922a1a77b782a955af4b9ee0dc0cb6b66b03594bc6efa
 
 PKG_MAINTAINER:=Jonathan Pagel <jonny_tischbein@systemli.org>
 PKG_LICENSE:=MIT

--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telegraf
-PKG_VERSION:=1.23.1
+PKG_VERSION:=1.23.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=7d0721908b3a2b3d36e922a1a77b782a955af4b9ee0dc0cb6b66b03594bc6efa
+PKG_HASH:=01a0a5345a2d74e638e704993366f250195210e1f99f967ca18379ae6c2377d7
 
 PKG_MAINTAINER:=Jonathan Pagel <jonny_tischbein@systemli.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
(cherry picked from commit https://github.com/openwrt/packages/commit/591f8cad333b36962aefbeccc6b0fa77e5826429)
Signed-off-by: Jonathan Pagel [jonny_tischbein@systemli.org](mailto:jonny_tischbein@systemli.org)

Maintainer:
me

Compile tested:
on amd64 for aarch64_cortex-a53

Run tested:
only compile test this time

Description:
Add package with version 1.23.2 on openwrt 21.02

Telegraf is a plugin-driven agent for collecting and sending metrics and events. It supports various inputs (including prometheus endpoints) and is able to send data into InfluxDB. https://www.influxdata.com/time-series-platform/telegraf/