### PR TITLE
libnpupnp: update to 4.2.3

### DIFF
--- a/libs/libnpupnp/Makefile
+++ b/libs/libnpupnp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnpupnp
-PKG_VERSION:=4.2.1
+PKG_VERSION:=4.2.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.lesbonscomptes.com/upmpdcli/downloads
-PKG_HASH:=e0e59eb2d3d024e827050428e0e7eb228355912a38c85eb30bfeb2f0926eca4c
+PKG_HASH:=fdf053c47acbbae104ffd8743fcd662634cf2e4fe7e3a81c3a1a8c5934d10d0e
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer:
Compile tested: mipsel