### PR TITLE
pcre2: add zlib build dependency

### DIFF
--- a/libs/pcre2/Makefile
+++ b/libs/pcre2/Makefile
@@ -25,6 +25,8 @@ PKG_CONFIG_DEPENDS:=\
 	CONFIG_PACKAGE_libpcre2-32 \
 	CONFIG_PCRE2_JIT_ENABLED
 
+PKG_BUILD_DEPENDS:=zlib
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 


### PR DESCRIPTION
Otherwise the host zlib gets picked up.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @InBetweenNames 
Compile tested: mipsel