### PR TITLE
sudo: don't build with MIPS16

### DIFF
--- a/admin/sudo/Makefile
+++ b/admin/sudo/Makefile
@@ -23,6 +23,7 @@ PKG_CPE_ID:=cpe:/a:todd_miller:sudo
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
GCC12 doesn't implement some security flags used by sudo.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @commodo 
Compile tested: mipsel