### PR TITLE
libuwsc: fix compiltation with wolfSSL.

### DIFF
--- a/libs/libuwsc/patches/100-cmake-fix-wolfssl-detection.patch
+++ b/libs/libuwsc/patches/100-cmake-fix-wolfssl-detection.patch
@@ -1,0 +1,10 @@
+--- a/src/ssl.c
++++ b/src/ssl.c
+@@ -54,6 +54,7 @@ struct uwsc_ssl_ctx {
+ #include <openssl/err.h>
+ #elif UWSC_HAVE_WOLFSSL
+ #define WC_NO_HARDEN
++#include <wolfssl/options.h>
+ #include <wolfssl/openssl/ssl.h>
+ #include <wolfssl/openssl/err.h>
+ #endif


### PR DESCRIPTION
Maintainer: @zhaojh329
Compile tested: mediatek/mt7622, aarch64_cortex-a53, master
Run tested: none

Description:
wolfssl/options.h needs to be included before the other wolfssl headers
to enable OpenSSL API required to build the package.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

Upstream has already handled this a while ago, but there's not been a new release since then.
Makefile has `PKG_RELEASE:=$(AUTORELEASE)`.
