### PR TITLE
glib2: remove libiconv/host build dependency

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -22,8 +22,7 @@ PKG_CPE_ID:=cpe:/a:gnome:glib
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/glib-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/glib-$(PKG_VERSION)
-PKG_BUILD_DEPENDS:=libiconv/host
-HOST_BUILD_DEPENDS:=libiconv/host libffi/host pcre/host
+HOST_BUILD_DEPENDS:=libffi/host pcre/host
 PKG_CONFIG_DEPENDS:=CONFIG_BUILD_NLS
 
 include $(INCLUDE_DIR)/host-build.mk


### PR DESCRIPTION
No longer present. The original reason for having it was an unfortunate
side effect of the way meson uses HOST_LDFLAGS. Since the transistion to
use dependency('iconv'), this is no longer relevant.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 