### PR TITLE
postfix: fix download failure

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
-	https://cdn.postfix.johnriley.me/mirrors/postfix-release/official/ \
+	https://de.postfix.org/ftpmirror/official/ \
 	http://ftp.porcupine.org/mirrors/postfix-release/official/
 PKG_HASH:=22582628cf3edc18c5155c9ff44543dd95a9435fb68135d76a99f572cb07456f
 


### PR DESCRIPTION
Maintainer: @Shulyaka
Compile tested: aarch64, Turris MOX, OpenWrt 21.02
Run tested: -

Description: https://cdn.postfix.johnriley.me serves a certificate for a different domain name. This commit should be backported to all branches, should I make a separate PR for each branch even for a simple change like this or would it be easier for you to just cherry pick it manually?