### PR TITLE
geth: update to 1.10.20

### DIFF
--- a/net/geth/Makefile
+++ b/net/geth/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=go-ethereum
-PKG_VERSION:=1.9.25
+PKG_VERSION:=1.10.20
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ethereum/go-ethereum/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=d7b733aeef4eba97f5351ba435001fa7365f55adabffdfdda909700335e98b0e
+PKG_HASH:=15ff54f0a4444eb9faa7c1f6219d3a1db5d547178b4eef6679bb601abc681f9d
 
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
 PKG_LICENSE:=GPL-3.0-or-later LGPL-3.0-or-later
@@ -22,6 +22,7 @@ PKG_LICENSE_FILES:=COPYING COPYING.LESSER
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
+PKG_CONFIG_DEPENDS:=CONFIG_BUILD_NLS
 
 GO_PKG:=github.com/ethereum/go-ethereum
 GO_PKG_BUILD_PKG:=github.com/ethereum/go-ethereum/cmd/geth
@@ -44,7 +45,7 @@ that run exactly as programmed without possibility of downtime, censorship,
 fraud or third party interference.
 endef
 
-TARGET_LDFLAGS += -liconv
+TARGET_LDFLAGS += $(if $(ICONV_FULL),-liconv)
 
 define Package/geth/install
 	$(call GoPackage/Package/Install/Bin,$(1))


### PR DESCRIPTION
Fix compilation with latest iconv changes.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mislavn
Compile tested: mipsel

Does anyone even use this?