### PR TITLE
python3: update patches for libressl to fix hashlib build error

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 include ../python3-version.mk
 
 PKG_NAME:=python3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=$(PYTHON3_VERSION).$(PYTHON3_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -326,10 +326,6 @@ HOST_CONFIGURE_VARS += \
 HOST_MAKE_VARS += \
 	USE_PYTHON_CONFIG_PY=1
 endif
-
-# FIXME: remove when removing patch '028-host-python-support-ssl-with-libressl.patch'
-HOST_CFLAGS += \
-	-DOPENWRT_HOST_BUILD
 
 HOST_CONFIGURE_ARGS+= \
 	--enable-optimizations \

--- a/lang/python/python3/patches/026-openssl-feature-flags.patch
+++ b/lang/python/python3/patches/026-openssl-feature-flags.patch
@@ -1,12 +1,47 @@
 --- a/Modules/_hashopenssl.c
 +++ b/Modules/_hashopenssl.c
-@@ -48,7 +48,9 @@
+@@ -45,10 +45,12 @@
+ 
+ #define MUNCH_SIZE INT_MAX
+ 
++#if !defined(LIBRESSL_VERSION_NUMBER)
  #define PY_OPENSSL_HAS_SCRYPT 1
  #define PY_OPENSSL_HAS_SHA3 1
  #define PY_OPENSSL_HAS_SHAKE 1
-+#ifndef OPENSSL_NO_BLAKE2
  #define PY_OPENSSL_HAS_BLAKE2 1
 +#endif
  
  #if OPENSSL_VERSION_NUMBER >= 0x30000000L
  #define PY_EVP_MD EVP_MD
+@@ -119,6 +121,7 @@ static const py_hashentry_t py_hashes[]
+     PY_HASH_ENTRY(Py_hash_sha256, "SHA256", SN_sha256, NID_sha256),
+     PY_HASH_ENTRY(Py_hash_sha384, "SHA384", SN_sha384, NID_sha384),
+     PY_HASH_ENTRY(Py_hash_sha512, "SHA512", SN_sha512, NID_sha512),
++#if !defined(LIBRESSL_VERSION_NUMBER)
+     /* truncated sha2 */
+     PY_HASH_ENTRY(Py_hash_sha512_224, "SHA512_224", SN_sha512_224, NID_sha512_224),
+     PY_HASH_ENTRY(Py_hash_sha512_256, "SHA512_256", SN_sha512_256, NID_sha512_256),
+@@ -133,6 +136,7 @@ static const py_hashentry_t py_hashes[]
+     /* blake2 digest */
+     PY_HASH_ENTRY(Py_hash_blake2s, "blake2s256", SN_blake2s256, NID_blake2s256),
+     PY_HASH_ENTRY(Py_hash_blake2b, "blake2b512", SN_blake2b512, NID_blake2b512),
++#endif
+     PY_HASH_ENTRY(NULL, NULL, NULL, 0),
+ };
+ 
+@@ -873,11 +877,15 @@ py_evp_fromname(PyObject *module, const
+         goto exit;
+     }
+ 
++#if defined(LIBRESSL_VERSION_NUMBER)
++    type = get_hashlib_state(module)->EVPtype;
++#else
+     if ((EVP_MD_flags(digest) & EVP_MD_FLAG_XOF) == EVP_MD_FLAG_XOF) {
+         type = get_hashlib_state(module)->EVPXOFtype;
+     } else {
+         type = get_hashlib_state(module)->EVPtype;
+     }
++#endif
+ 
+     self = newEVPobject(type);
+     if (self == NULL) {

--- a/lang/python/python3/patches/028-host-python-support-ssl-with-libressl.patch
+++ b/lang/python/python3/patches/028-host-python-support-ssl-with-libressl.patch
@@ -1,117 +1,27 @@
 --- a/Modules/_ssl.c
 +++ b/Modules/_ssl.c
-@@ -67,7 +67,18 @@
+@@ -67,6 +67,12 @@
  #  error "OPENSSL_THREADS is not defined, Python requires thread-safe OpenSSL"
  #endif
  
-+#ifdef OPENWRT_HOST_BUILD
-+#undef TLS1_3_VERSION
-+static STACK_OF(X509) *SSL_get0_verified_chain(const SSL *s)
-+{
-+    return NULL;
-+}
- 
++#ifdef LIBRESSL_VERSION_NUMBER
 +static int SSL_CTX_get_security_level(const SSL_CTX *ctx)
 +{
-+    return 0;
++    return 1;
 +}
 +#endif
  
+ 
  struct py_ssl_error_code {
-     const char *mnemonic;
-@@ -291,8 +302,10 @@ typedef struct {
-     int post_handshake_auth;
- #endif
-     PyObject *msg_cb;
-+#ifndef OPENWRT_HOST_BUILD
-     PyObject *keylog_filename;
-     BIO *keylog_bio;
-+#endif
-     /* Cached module state, also used in SSLSocket and SSLSession code. */
-     _sslmodulestate *state;
- } PySSLContext;
-@@ -2358,8 +2371,14 @@ _ssl__SSLSocket_write_impl(PySSLSocket *
- 
-     do {
-         PySSL_BEGIN_ALLOW_THREADS
-+#ifdef OPENWRT_HOST_BUILD
-+        retval = SSL_write(self->ssl, b->buf, (int)b->len);
-+        if (retval > 0) count = retval;
-+        err = _PySSL_errno(retval <= 0, self->ssl, retval);
+@@ -169,7 +175,11 @@ extern const SSL_METHOD *TLSv1_2_method(
+  * Based on Hynek's excellent blog post (update 2021-02-11)
+  * https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
+  */
++#ifndef LIBRESSL_VERSION_NUMBER
+   #define PY_SSL_DEFAULT_CIPHER_STRING "@SECLEVEL=2:ECDH+AESGCM:ECDH+CHACHA20:ECDH+AES:DHE+AES:!aNULL:!eNULL:!aDSS:!SHA1:!AESCCM"
 +#else
-         retval = SSL_write_ex(self->ssl, b->buf, (size_t)b->len, &count);
-         err = _PySSL_errno(retval == 0, self->ssl, retval);
++  #define PY_SSL_DEFAULT_CIPHER_STRING "ECDH+AESGCM:ECDH+CHACHA20:ECDH+AES:DHE+AES:!aNULL:!eNULL:!aDSS:!SHA1:!AESCCM"
 +#endif
-         PySSL_END_ALLOW_THREADS
-         self->err = err;
- 
-@@ -2510,8 +2529,14 @@ _ssl__SSLSocket_read_impl(PySSLSocket *s
- 
-     do {
-         PySSL_BEGIN_ALLOW_THREADS
-+#ifdef OPENWRT_HOST_BUILD
-+        retval = SSL_read(self->ssl, mem, len);
-+        if (retval > 0) count = retval;
-+        err = _PySSL_errno(retval <= 0, self->ssl, retval);
-+#else
-         retval = SSL_read_ex(self->ssl, mem, (size_t)len, &count);
-         err = _PySSL_errno(retval == 0, self->ssl, retval);
-+#endif
-         PySSL_END_ALLOW_THREADS
-         self->err = err;
- 
-@@ -3074,8 +3099,10 @@ _ssl__SSLContext_impl(PyTypeObject *type
-     self->hostflags = X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS;
-     self->protocol = proto_version;
-     self->msg_cb = NULL;
-+#ifndef OPENWRT_HOST_BUILD
-     self->keylog_filename = NULL;
-     self->keylog_bio = NULL;
-+#endif
-     self->alpn_protocols = NULL;
-     self->set_sni_cb = NULL;
-     self->state = get_ssl_state(module);
-@@ -3199,6 +3226,7 @@ context_clear(PySSLContext *self)
- {
-     Py_CLEAR(self->set_sni_cb);
-     Py_CLEAR(self->msg_cb);
-+#ifndef OPENWRT_HOST_BUILD
-     Py_CLEAR(self->keylog_filename);
-     if (self->keylog_bio != NULL) {
-         PySSL_BEGIN_ALLOW_THREADS
-@@ -3206,6 +3234,7 @@ context_clear(PySSLContext *self)
-         PySSL_END_ALLOW_THREADS
-         self->keylog_bio = NULL;
-     }
-+#endif
-     return 0;
- }
- 
-@@ -4615,8 +4644,10 @@ static PyGetSetDef context_getsetlist[]
-                         (setter) set_minimum_version, NULL},
-     {"maximum_version", (getter) get_maximum_version,
-                         (setter) set_maximum_version, NULL},
-+#ifndef OPENWRT_HOST_BUILD
-     {"keylog_filename", (getter) _PySSLContext_get_keylog_filename,
-                         (setter) _PySSLContext_set_keylog_filename, NULL},
-+#endif
-     {"_msg_callback", (getter) _PySSLContext_get_msg_callback,
-                       (setter) _PySSLContext_set_msg_callback, NULL},
-     {"sni_callback", (getter) get_sni_callback,
---- a/Modules/_ssl/debughelpers.c
-+++ b/Modules/_ssl/debughelpers.c
-@@ -114,6 +114,8 @@ _PySSLContext_set_msg_callback(PySSLCont
-     return 0;
- }
- 
-+#ifndef OPENWRT_HOST_BUILD
-+
- static void
- _PySSL_keylog_callback(const SSL *ssl, const char *line)
- {
-@@ -217,3 +219,5 @@ _PySSLContext_set_keylog_filename(PySSLC
-     SSL_CTX_set_keylog_callback(self->ctx, _PySSL_keylog_callback);
-     return 0;
- }
-+
-+#endif
+   #ifndef PY_SSL_MIN_PROTOCOL
+     #define PY_SSL_MIN_PROTOCOL TLS1_2_VERSION
+   #endif


### PR DESCRIPTION
Based upon patches from OpenBSD[0] and Gentoo[1].

Switched to the LibreSSL provided LIBRESSL_VERSION_NUMBER macro, which
makes OPENWRT_HOST_BUILD redundant.

[0] https://github.com/openbsd/ports/tree/master/lang/python/3.10/patches
[1] https://github.com/gentoo/libressl/tree/master/dev-lang/python/files

Signed-off-by: Andre Heider <a.heider@gmail.com>

Maintainer: @jefferyto 
Compile tested: ipq40xx/master
Run tested: no

This fixes the build error reported in https://github.com/openwrt/openwrt/pull/10299#issuecomment-1188755924
Just compile time tested.
