### PR TITLE
opusfile: add autoreconf

### DIFF
--- a/libs/opusfile/Makefile
+++ b/libs/opusfile/Makefile
@@ -7,16 +7,19 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opusfile
 PKG_VERSION:=0.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://downloads.xiph.org/releases/opus/
 PKG_HASH:=118d8601c12dd6a44f52423e68ca9083cc9f2bfe72da7a8c1acb22a80ae3550b
+
+PKG_MAINTAINER:=Eduardo Abinader <eduardoabinader@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Eduardo Abinader <eduardoabinader@gmail.com>
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Fixes compilation under some hosts.

Added PKG_BUILD_PARALLEL for faster compilation.

Some small cleanups for consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @eduardoabinader 

Fixes: https://github.com/openwrt/packages/issues/18983