### PR TITLE
Avoid building unused package dependencies

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -104,7 +104,7 @@ endef
 define Package/libgnutls-dane
 $(call Package/gnutls/Default)
   TITLE+= (libgnutls-dane library)
-  DEPENDS:= +libgnutls +libunbound
+  DEPENDS:= +libgnutls +PACKAGE_libgnutls-dane:libunbound
 endef
 
 define Package/libgnutls/description

--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -45,7 +45,7 @@ endef
 define Package/chrony-nts
 $(call Package/chrony/Default)
   TITLE+= (with NTS)
-  DEPENDS+= +libgnutls +ca-bundle
+  DEPENDS+= +PACKAGE_chrony-nts:libgnutls +PACKAGE_chrony-nts:ca-bundle
   VARIANT:=with-nts
 endef
 

--- a/net/gensio/Makefile
+++ b/net/gensio/Makefile
@@ -33,6 +33,8 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_GENSIO_TCL \
 	CONFIG_GENSIO_SSHD
 
+PKG_BUILD_DEPENDS:=PACKAGE_python3-gensio:swig
+
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
 
@@ -130,8 +132,7 @@ $(call Package/gensio/Default)
   TITLE+= (Python3-bindings)
   SECTION:=lang
   CATEGORY:=Languages
-  BUILD_DEPENDS:=+swig +python3
-  DEPENDS:=+python3-light +libgensio
+  DEPENDS:=+PACKAGE_python3-gensio:python3-light +libgensio
 endef
 
 define Package/python3-gensio/description
@@ -146,7 +147,7 @@ $(call Package/gensio/Default)
   SECTION:=libs
   CATEGORY:=Libraries
   ABI_VERSION:=0
-  DEPENDS:=+libgensio +libstdcpp
+  DEPENDS:=+libgensio +PACKAGE_libgensiocpp:libstdcpp
 endef
 
 define Package/libgensiocpp/description


### PR DESCRIPTION
This prevents building of unused packages during OpenWRT image build