### PR TITLE
ffmpeg: update to 5.1

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
-PKG_VERSION:=5.0.1
+PKG_VERSION:=5.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
-PKG_HASH:=ef2efae259ce80a240de48ec85ecb062cecca26e4352ffb3fda562c21a93007b
+PKG_HASH:=55eb6aab5ee235550fa54a33eaf8bf1b4ec66c01453182b12f6a993d75698b03
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Ian Leonard <antonlacon@gmail.com>
 

--- a/multimedia/ffmpeg/patches/050-glibc.patch
+++ b/multimedia/ffmpeg/patches/050-glibc.patch
@@ -1,10 +1,11 @@
 --- a/libavcodec/wmv2dsp.c
 +++ b/libavcodec/wmv2dsp.c
-@@ -264,6 +264,6 @@ av_cold void ff_wmv2dsp_init(WMV2DSPCont
+@@ -264,7 +264,7 @@ av_cold void ff_wmv2dsp_init(WMV2DSPCont
      c->put_mspel_pixels_tab[6] = put_mspel8_mc22_c;
      c->put_mspel_pixels_tab[7] = put_mspel8_mc32_c;
  
--    if (ARCH_MIPS)
-+    if (ARCH_MIPS64)
-         ff_wmv2dsp_init_mips(c);
+-#if ARCH_MIPS
++#if ARCH_MIPS64
+     ff_wmv2dsp_init_mips(c);
+ #endif
  }


### PR DESCRIPTION
Bump to latest upstream version, manually rebased: 050-glibc.patch

Tested using: ffmpeg -f lavfi -i testsrc=duration=10:size=1280x720:rate=30 testsrc.mpg

Resulting mpg was good.

Build system: x86_64
Build-tested: bcm2711/RPi4B
Run-tested: bcm2711/RPi4B

Signed-off-by: John Audia <therealgraysky@proton.me>

Maintainer: @thess