### PR TITLE
erlang: workaround LibreSSL-3.5.0 compat issues

### DIFF
--- a/lang/erlang/Makefile
+++ b/lang/erlang/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=erlang
 PKG_VERSION:=24.2
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=otp_src_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= http://www.erlang.org/download/

--- a/lang/erlang/patches/030-crypto-Make-configure-flag-disable-otp-test-engine.patch
+++ b/lang/erlang/patches/030-crypto-Make-configure-flag-disable-otp-test-engine.patch
@@ -1,0 +1,86 @@
+From ca2fed6c60039003f255ffe7a5d98744b8ebdedc Mon Sep 17 00:00:00 2001
+From: Hans Nilsson <hans@erlang.org>
+Date: Thu, 17 Feb 2022 12:22:06 +0100
+Subject: [PATCH] crypto: Make configure flag --disable-otp-test-engine
+
+---
+ lib/crypto/c_src/Makefile.in | 16 ++++++++++++++--
+ lib/crypto/configure.in      | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 2 deletions(-)
+
+--- a/lib/crypto/c_src/Makefile.in
++++ b/lib/crypto/c_src/Makefile.in
+@@ -119,11 +119,17 @@ CRYPTO_STATIC_OBJS = $(patsubst $(OBJDIR
+ 
+ NIF_ARCHIVE = $(LIBDIR)/crypto$(TYPEMARKER).a
+ 
+-TEST_ENGINE_OBJS = $(OBJDIR)/otp_test_engine$(TYPEMARKER).o
+-
+ NIF_LIB = $(LIBDIR)/crypto$(TYPEMARKER).@DED_EXT@
+ CALLBACK_LIB = $(LIBDIR)/crypto_callback$(TYPEMARKER).@DED_EXT@
++
++DISABLE_OTP_TEST_ENGINE = @DISABLE_OTP_TEST_ENGINE@
++ifeq ($(DISABLE_OTP_TEST_ENGINE),yes)
++TEST_ENGINE_LIB =
++TEST_ENGINE_OBJS =
++else
+ TEST_ENGINE_LIB = $(LIBDIR)/otp_test_engine$(TYPEMARKER).@DED_EXT@
++TEST_ENGINE_OBJS = $(OBJDIR)/otp_test_engine$(TYPEMARKER).o
++endif
+ 
+ DYNAMIC_CRYPTO_LIB=@SSL_DYNAMIC_ONLY@
+ # Wierd that we compile as if dynamically linking when statically
+@@ -182,6 +188,8 @@ debug opt valgrind asan: $(NIF_LIB) $(CA
+ 
+ static_lib: $(NIF_ARCHIVE)
+ 
++ifeq ($(DISABLE_OTP_TEST_ENGINE),yes)
++else
+ $(OBJDIR)/otp_test_engine$(TYPEMARKER).o: otp_test_engine.c
+ 	$(V_at)$(INSTALL_DIR) $(OBJDIR)
+ 	$(V_CC) -c -o $@ $(filter-out -Wmissing-prototypes,$(ALL_CFLAGS)) $<
+@@ -193,6 +201,7 @@ $(LIBDIR)/otp_test_engine$(TYPEMARKER).s
+ $(LIBDIR)/otp_test_engine$(TYPEMARKER).dll: $(TEST_ENGINE_OBJS)
+ 	$(V_at)$(INSTALL_DIR) $(LIBDIR)
+ 	$(V_LD) $(LDFLAGS) -o $@  $(SSL_DED_LD_RUNTIME_LIBRARY_PATH) -L$(SSL_LIBDIR) $(TEST_ENGINE_OBJS) -l$(SSL_CRYPTO_LIBNAME) -l$(SSL_SSL_LIBNAME) $(SSL_EXTRA_LIBS)
++endif
+ 
+ $(OBJDIR)/%$(TYPEMARKER).o: %.c
+ 	$(V_at)$(INSTALL_DIR) $(OBJDIR)
+@@ -255,7 +264,10 @@ release_spec: opt
+ ifeq ($(DYNAMIC_OR_WIN_CRYPTO_LIB),yes)
+ 	$(INSTALL_PROGRAM) $(CALLBACK_LIB) "$(RELSYSDIR)/priv/lib"
+ endif
++ifeq ($(DISABLE_OTP_TEST_ENGINE),yes)
++else
+ 	$(INSTALL_PROGRAM) $(TEST_ENGINE_LIB) "$(RELSYSDIR)/priv/lib"
++endif
+ 
+ release_docs_spec:
+ 
+--- a/lib/crypto/configure.in
++++ b/lib/crypto/configure.in
+@@ -156,6 +156,15 @@ AS_HELP_STRING([--disable-evp-hmac],
+     *)    DISABLE_EVP_HMAC=0;;
+   esac ], DISABLE_EVP_HMAC=0)
+ 
++
++AC_ARG_ENABLE(otp-test-engine,
++AS_HELP_STRING([--disable-otp-test-engine],
++	       [intentionally undocumented workaround]),
++[ case "$enableval" in
++    no)   DISABLE_OTP_TEST_ENGINE=yes;;
++    *)    DISABLE_OTP_TEST_ENGINE=no;;
++  esac ], DISABLE_OTP_TEST_ENGINE=no)
++
+ AC_ARG_ENABLE(deprecated_warnings,
+ AS_HELP_STRING([--disable-deprecated-warnings],
+ 	       [disable warnings for deprecated functions in cryptolib (default is to warn, except for OpenSSL 3.x where the default is not to warn)]),
+@@ -826,6 +835,7 @@ AC_SUBST(SSL_DED_LD_RUNTIME_LIBRARY_PATH
+ AC_SUBST(SSL_DYNAMIC_ONLY)
+ AC_SUBST(DISABLE_EVP_DH)
+ AC_SUBST(DISABLE_EVP_HMAC)
++AC_SUBST(DISABLE_OTP_TEST_ENGINE)
+ 
+ AC_OUTPUT(c_src/$host/Makefile:c_src/Makefile.in)
+ 

--- a/lang/erlang/patches/031-Update-configure-scripts.patch
+++ b/lang/erlang/patches/031-Update-configure-scripts.patch
@@ -1,0 +1,63 @@
+From 4d48c33d413957dc95fc8b921f9708eb0705c796 Mon Sep 17 00:00:00 2001
+From: Hans Nilsson <hans@erlang.org>
+Date: Wed, 16 Feb 2022 09:28:38 +0100
+Subject: [PATCH] Update configure scripts
+
+---
+ lib/crypto/configure | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+--- a/lib/crypto/configure
++++ b/lib/crypto/configure
+@@ -621,6 +621,7 @@ ac_includes_default="\
+ 
+ ac_subst_vars='LTLIBOBJS
+ LIBOBJS
++DISABLE_OTP_TEST_ENGINE
+ DISABLE_EVP_HMAC
+ DISABLE_EVP_DH
+ SSL_DYNAMIC_ONLY
+@@ -747,6 +748,7 @@ with_ssl_rpath
+ enable_dynamic_ssl_lib
+ enable_evp_dh
+ enable_evp_hmac
++enable_otp_test_engine
+ enable_deprecated_warnings
+ enable_fips
+ '
+@@ -1420,6 +1422,8 @@ Optional Features:
+                           the crypto NIF
+   --disable-evp-dh        intentionally undocumented workaround
+   --disable-evp-hmac      intentionally undocumented workaround
++  --disable-otp-test-engine
++                          intentionally undocumented workaround
+   --disable-deprecated-warnings
+                           disable warnings for deprecated functions in
+                           cryptolib (default is to warn, except for OpenSSL
+@@ -5096,6 +5100,18 @@ else
+ fi
+ 
+ 
++
++# Check whether --enable-otp-test-engine was given.
++if test "${enable_otp_test_engine+set}" = set; then :
++  enableval=$enable_otp_test_engine;  case "$enableval" in
++    no)   DISABLE_OTP_TEST_ENGINE=yes;;
++    *)    DISABLE_OTP_TEST_ENGINE=no;;
++  esac
++else
++  DISABLE_OTP_TEST_ENGINE=no
++fi
++
++
+ # Check whether --enable-deprecated_warnings was given.
+ if test "${enable_deprecated_warnings+set}" = set; then :
+   enableval=$enable_deprecated_warnings;  case "$enableval" in
+@@ -6319,6 +6335,7 @@ fi
+ 
+ 
+ 
++
+ 
+ 
+ 

--- a/lang/erlang/patches/032-crypto-do-disable-otp-test-engine-for-LibreSSL-3.5.0.patch
+++ b/lang/erlang/patches/032-crypto-do-disable-otp-test-engine-for-LibreSSL-3.5.0.patch
@@ -1,0 +1,45 @@
+From 4e3d154c0f1bd975016eaa2d842affd230b736cc Mon Sep 17 00:00:00 2001
+From: Hans Nilsson <hans@erlang.org>
+Date: Mon, 21 Feb 2022 14:58:08 +0100
+Subject: [PATCH] crypto: do --disable-otp-test-engine for LibreSSL >= 3.5.0
+
+---
+ lib/crypto/configure.in | 17 +++++++++++++++--
+ 1 file changed, 15 insertions(+), 2 deletions(-)
+
+--- a/lib/crypto/configure.in
++++ b/lib/crypto/configure.in
+@@ -159,11 +159,11 @@ AS_HELP_STRING([--disable-evp-hmac],
+ 
+ AC_ARG_ENABLE(otp-test-engine,
+ AS_HELP_STRING([--disable-otp-test-engine],
+-	       [intentionally undocumented workaround]),
++	       [Disable build of the otp_test_engine. (default is --enable-otp-test-engine, unless for LibreSSL >= 3.5.0 where default is --disable-otp-test-engine)]),
+ [ case "$enableval" in
+     no)   DISABLE_OTP_TEST_ENGINE=yes;;
+     *)    DISABLE_OTP_TEST_ENGINE=no;;
+-  esac ], DISABLE_OTP_TEST_ENGINE=no)
++  esac ], DISABLE_OTP_TEST_ENGINE=default)
+ 
+ AC_ARG_ENABLE(deprecated_warnings,
+ AS_HELP_STRING([--disable-deprecated-warnings],
+@@ -245,6 +245,19 @@ yes
+ 		 ],
+ 		 [v3_include=yes],
+ 		 [v3_include=no])
++
++if test "x$DISABLE_OTP_TEST_ENGINE" = "xdefault"; then
++# Get default value for the --disable-otp-test-engine. Depends on cryptolib version
++          AC_EGREP_CPP(^yes.?$,[
++#include <openssl/opensslv.h>
++#if LIBRESSL_VERSION_NUMBER >= 0x3050000fL
++yes
++#endif
++        		 ],
++	                 [DISABLE_OTP_TEST_ENGINE=yes],
++                         [DISABLE_OTP_TEST_ENGINE=no])
++    fi
++
+     CPPFLAGS="$save_CPPFLAGS"
+ 
+     if test $valid_include != yes; then

--- a/lang/erlang/patches/033-Update-configure-scripts.patch
+++ b/lang/erlang/patches/033-Update-configure-scripts.patch
@@ -1,0 +1,89 @@
+From 2f27f4bf85971dc8d8e0c2dcef133729835458c5 Mon Sep 17 00:00:00 2001
+From: Hans Nilsson <hans@erlang.org>
+Date: Mon, 21 Feb 2022 14:58:35 +0100
+Subject: [PATCH] Update configure scripts
+
+---
+ lib/crypto/configure | 50 ++++++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 48 insertions(+), 2 deletions(-)
+
+--- a/lib/crypto/configure
++++ b/lib/crypto/configure
+@@ -1423,7 +1423,9 @@ Optional Features:
+   --disable-evp-dh        intentionally undocumented workaround
+   --disable-evp-hmac      intentionally undocumented workaround
+   --disable-otp-test-engine
+-                          intentionally undocumented workaround
++                          Disable build of the otp_test_engine. (default is
++                          --enable-otp-test-engine, unless for LibreSSL >=
++                          3.5.0 where default is --disable-otp-test-engine)
+   --disable-deprecated-warnings
+                           disable warnings for deprecated functions in
+                           cryptolib (default is to warn, except for OpenSSL
+@@ -5108,7 +5110,7 @@ if test "${enable_otp_test_engine+set}"
+     *)    DISABLE_OTP_TEST_ENGINE=no;;
+   esac
+ else
+-  DISABLE_OTP_TEST_ENGINE=no
++  DISABLE_OTP_TEST_ENGINE=default
+ fi
+ 
+ 
+@@ -5300,6 +5302,28 @@ else
+ fi
+ rm -f conftest*
+ 
++
++if test "x$DISABLE_OTP_TEST_ENGINE" = "xdefault"; then
++# Get default value for the --disable-otp-test-engine. Depends on cryptolib version
++          cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++#include <openssl/opensslv.h>
++#if LIBRESSL_VERSION_NUMBER >= 0x3050000fL
++yes
++#endif
++
++_ACEOF
++if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
++  $EGREP "^yes.?$" >/dev/null 2>&1; then :
++  DISABLE_OTP_TEST_ENGINE=yes
++else
++  DISABLE_OTP_TEST_ENGINE=no
++fi
++rm -f conftest*
++
++    fi
++
+     CPPFLAGS="$save_CPPFLAGS"
+ 
+     if test $valid_include != yes; then
+@@ -5705,6 +5729,28 @@ else
+ fi
+ rm -f conftest*
+ 
++
++if test "x$DISABLE_OTP_TEST_ENGINE" = "xdefault"; then
++# Get default value for the --disable-otp-test-engine. Depends on cryptolib version
++          cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++#include <openssl/opensslv.h>
++#if LIBRESSL_VERSION_NUMBER >= 0x3050000fL
++yes
++#endif
++
++_ACEOF
++if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
++  $EGREP "^yes.?$" >/dev/null 2>&1; then :
++  DISABLE_OTP_TEST_ENGINE=yes
++else
++  DISABLE_OTP_TEST_ENGINE=no
++fi
++rm -f conftest*
++
++    fi
++
+     CPPFLAGS="$save_CPPFLAGS"
+ 
+     if test $valid_include != yes; then


### PR DESCRIPTION
Cherry-pick four upstream commits that prevent building of
otp_test_engine when LibreSSL-3.5.0 is used.

Since OpenWrt bumped LibreSSL to 3.5.3 the erlang host builds fail to
complete.

```
 CC	../priv/obj/x86_64-pc-linux-gnu/otp_test_engine.o
otp_test_engine.c: In function 'test_engine_md5_init':
otp_test_engine.c:144:34: error: dereferencing pointer to incomplete type 'EVP_MD_CTX' {aka 'struct env_md_ctx_st'}
 #define data(ctx) ((MD5_CTX *)ctx->md_data)
                                  ^~
```

Also switch to AUTORELEASE.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: Arnaud Sautaux (didn't find github handle)
Compile tested: ath79 master sdk
Run tested: N/A

Description:
Add upstream commits to make erlang/host compile again.