### PR TITLE
acme.sh Support for --reloadcmd

### DIFF
--- a/net/acme/files/acme.config
+++ b/net/acme/files/acme.config
@@ -28,6 +28,7 @@ config cert 'example'
 	option update_uhttpd 1
 	option update_nginx 1
 	option update_haproxy 0
+	# option reloadcmd ""
 	list domains example.org
 	list domains sub.example.org
 	option webroot ""

--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -192,6 +192,7 @@ issue_cert() {
 	local update_uhttpd
 	local update_nginx
 	local update_haproxy
+	local reloadcmd
 	local keylength
 	local keylength_ecc=0
 	local domains
@@ -212,6 +213,7 @@ issue_cert() {
 	config_get_bool update_uhttpd "$section" update_uhttpd
 	config_get_bool update_nginx "$section" update_nginx
 	config_get_bool update_haproxy "$section" update_haproxy
+	config_get reloadcmd "$section" reloadcmd
 	config_get calias "$section" calias
 	config_get dalias "$section" dalias
 	config_get domains "$section" domains
@@ -234,6 +236,8 @@ issue_cert() {
 
 	set -- $domains
 	main_domain=$1
+
+	[ -n "$reloadcmd" ] && acme_args="$acme_args --reloadcmd \"$reloadcmd\""
 
 	if [ -n "$user_setup" ] && [ -f "$user_setup" ]; then
 		log "Running user-provided setup script from $user_setup."


### PR DESCRIPTION
Maintainer: @tohojo

Description: I need to restart lighttpd and emailrelay but this is not supported out of the box. Not a big deal because we can use the `--reloadcmd` option with `/etc/init.d/lighttpd restart`. But the reloadcmd is not supported yet.
The PR adds it's support.

But it doesn't work if the command contains a space like in the `/etc/init.d/lighttpd restart`:
```
acme: Running acme.sh as '/usr/lib/acme/acme.sh --home /etc/acme --renew -d example.com --debug --reloadcmd "/etc/init.d/lighttpd restart" --ecc'
Unknown parameter : restart"
```

This is some problem here:
```sh
run_acme() {
	debug "Running acme.sh as '$ACME $*'"
	$ACME "$@"
}
```

I have no idea how to fix that. 