### PR TITLE
nextdns: fix init.d creation when the package is built-in

### DIFF
--- a/net/nextdns/Makefile
+++ b/net/nextdns/Makefile
@@ -50,13 +50,14 @@ define Package/nextdns/install
 
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nextdns.config $(1)/etc/config/nextdns
+
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/nextdns.defaults $(1)/etc/uci-defaults/nextdns
 endef
 
 define Package/nextdns/postinst
 #!/bin/sh
-if [ -z "$${IPKG_INSTROOT}" ]; then
-  nextdns install
-fi
+[ -n "$${IPKG_INSTROOT}" ] || (. /etc/uci-defaults/nextdns) && rm -f /etc/uci-defaults/nextdns
 endef
 
 define Package/nextdns/prerm

--- a/net/nextdns/files/nextdns.defaults
+++ b/net/nextdns/files/nextdns.defaults
@@ -1,0 +1,2 @@
+nextdns install
+service nextdns enable


### PR DESCRIPTION
Signed-off-by: Timothy Redaelli <tredaelli@redhat.com>

Maintainer: @rs 
Compile tested: compiled openwrt last-master for linksys_e8450 (mt7622) with nextdns selected as built-in (=y)
Run tested:
tested on openwrt last-master on linksys_e8450 (mt7622) by just build an image with nextdns selected as built-in (=y) and checking that nextdns is running and it's working correctly

Description:
postinst, in this case, it's not executed then the package is installed as built-in.
uci-defaults it's executed on the first boot after a firmware update, so just use it