### PR TITLE
stress-ng: update to 0.14.03

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.13.05
+PKG_VERSION:=0.14.03
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ColinIanKing/stress-ng/tar.gz/refs/tags/V$(PKG_VERSION)?
-PKG_HASH:=3de49e1100866634f549e99c1644283d0cde817b844a69dcf7f80afa2227d350
+PKG_HASH:=95012c62883ab5826e6157557a075df98cce3cbce2a48bb40851bcc968a8441a
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only
@@ -27,7 +27,7 @@ define Package/stress-ng
   CATEGORY:=Utilities
   TITLE:=stress-ng is a stress test utility
   URL:=https://github.com/ColinIanKing/stress-ng
-  DEPENDS:=+zlib +libbsd +libaio +libsctp +libkmod
+  DEPENDS:=+zlib +libbsd +libaio +libsctp +libkmod +libatomic
 endef
 
 define Package/stress-ng/description

--- a/utils/stress-ng/patches/010-dont_define_fortify.patch
+++ b/utils/stress-ng/patches/010-dont_define_fortify.patch
@@ -1,0 +1,13 @@
+--- a/stress-ng.h
++++ b/stress-ng.h
+@@ -34,10 +34,6 @@
+ #ifndef _LARGEFILE64_SOURCE
+ #define _LARGEFILE64_SOURCE
+ #endif
+-#if !defined(__PCC__) && 	\
+-    !defined(__TINYC__)
+-#define _FORTIFY_SOURCE 2
+-#endif
+ 
+ #if !defined(_FILE_OFFSET_BITS)
+ #define _FILE_OFFSET_BITS 	(64)

--- a/utils/stress-ng/patches/020-stress-sysinval-fix-fstat-fstat64-compat-check.patch
+++ b/utils/stress-ng/patches/020-stress-sysinval-fix-fstat-fstat64-compat-check.patch
@@ -1,0 +1,37 @@
+From a5e564bdd14dbda666fc7caffecc0f6e3527df85 Mon Sep 17 00:00:00 2001
+From: Alexandru Ardelean <ardeleanalex@gmail.com>
+Date: Fri, 12 Aug 2022 15:36:02 +0300
+Subject: [PATCH] stress-sysinval: fix fstat/fstat64 compat check
+
+It seems that __NR_fstat64 may be defined while __NR_fstat may be
+undefined.
+Looking at the kernel file 'include/uapi/asm-generic/unistd.h' this looks
+possible where there is a 32-bit arch.
+
+In any case, checking that __NR_fstat64 exists/has-a-value when adding it
+to the table looks like a good idea, vs adding __NR_fstat.
+
+This was found when updating stress-ng here:
+  https://github.com/openwrt/packages/pull/19048
+
+The ARCHS (or ARC) build is failing. No idea why it's the only one.
+But this patch fixes it.
+
+Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>
+---
+ stress-sysinval.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/stress-sysinval.c
++++ b/stress-sysinval.c
+@@ -590,8 +590,8 @@ static const stress_syscall_arg_t stress
+ 	{ SYS(fstat), 2, { ARG_FD, ARG_PTR_WR, 0, 0, 0, 0 } },
+ #endif
+ #if DEFSYS(fstat64)
+-	{ SYS(fstat), 2, { ARG_FD, ARG_PTR, 0, 0, 0, 0 } },
+-	{ SYS(fstat), 2, { ARG_FD, ARG_PTR_WR, 0, 0, 0, 0 } },
++	{ SYS(fstat64), 2, { ARG_FD, ARG_PTR, 0, 0, 0, 0 } },
++	{ SYS(fstat64), 2, { ARG_FD, ARG_PTR_WR, 0, 0, 0, 0 } },
+ #endif
+ #if DEFSYS(fstatat)
+ 	{ SYS(fstatat), 4, { ARG_DIRFD, ARG_EMPTY_FILENAME, ARG_PTR, ARG_FLAG, 0, 0 } },


### PR DESCRIPTION
Signed-off-by: Guilherme Janczak <guilherme.janczak@yandex.com>

Maintainer: @commodo
Compile tested: x64, latest snapshot SDK as of today
