### PR TITLE
[22.03] telegraf: Update to version 1.23.3

### DIFF
--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telegraf
-PKG_VERSION:=1.23.2
+PKG_VERSION:=1.23.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=01a0a5345a2d74e638e704993366f250195210e1f99f967ca18379ae6c2377d7
+PKG_HASH:=984612d5d74b014e82e03069c2430b7868cc9c4c40b2215f43dc5533b105fe3d
 
 PKG_MAINTAINER:=Jonathan Pagel <jonny_tischbein@systemli.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
(cherry picked from commit https://github.com/openwrt/packages/commit/281d156a35830003e3844af6f195958715731dfb)
Signed-off-by: Jonathan Pagel [jonny_tischbein@systemli.org](mailto:jonny_tischbein@systemli.org)

Maintainer:
me

Compile tested:
on amd64 for aarch64_cortex-a53

Run tested:
only compile test this time

Description:
Add package with version 1.23.3 on openwrt 22.03

Telegraf is a plugin-driven agent for collecting and sending metrics and events. It supports various inputs (including prometheus endpoints) and is able to send data into InfluxDB. https://www.influxdata.com/time-series-platform/telegraf/