### PR TITLE
stunnel: update version to 5.65

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.64
+PKG_VERSION:=5.65
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_LICENSE:=GPL-2.0-or-later
@@ -23,7 +23,7 @@ PKG_SOURCE_URL:= \
 	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=eebe53ed116ba43b2e786762b0c2b91511e7b74857ad4765824e7199e6faf883
+PKG_HASH:=60c500063bd1feff2877f5726e38278c086f96c178f03f09d264a2012d6bf7fc
 
 PKG_FIXUP:=autoreconf
 PKG_FIXUP:=patch-libtool


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64 and lantiq_xrx200, APU3, latest master
Run tested:  x86_64, APU3, `stunnel -h`

Description:
update version to 5.65

`stunnel -h`
```
root@st-dev-07 ~ # stunnel -h
[ ] Initializing inetd mode configuration
[ ] Clients allowed=500
[.] stunnel 5.65 on x86_64-openwrt-linux-gnu platform
[.] Compiled/running with OpenSSL 1.1.1q  5 Jul 2022
[.] Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,OCSP,PSK,SNI
[ ] errno: (*__errno_location())
[!] Invalid configuration file name "-h"
[!] realpath: No such file or directory (2)
```
