### PR TITLE
[22.03] curl: switch default SSL to mbedTLS

### DIFF
--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -4,7 +4,7 @@ comment "SSL support"
 
 choice
 	prompt "Selected SSL library"
-	default LIBCURL_WOLFSSL
+	default LIBCURL_MBEDTLS
 
 	config LIBCURL_MBEDTLS
 		bool "mbed TLS"


### PR DESCRIPTION
Maintainer: me

Description:
The decision to switch the default to wolfSSL was taken because of
hostapd back from when curl was in base. Unfortunately, not only is
wolfSSL bigger but it has also been causing issues recently. There's
also no relation between hostapd and curl.

Signed-off-by: Rosen Penev <rosenp@gmail.com>
(cherry picked from commit 0a65e4c6fa84e13a1732c26260615c1ad5efea5b)
