### PR TITLE
HTOP: add temperature sensor for Marvell Armada XP

### DIFF
--- a/admin/htop/patches/010-add-temp-sensor-mvebu-armada-xp.patch
+++ b/admin/htop/patches/010-add-temp-sensor-mvebu-armada-xp.patch
@@ -1,0 +1,10 @@
+--- a/linux/LibSensors.c
++++ b/linux/LibSensors.c
+@@ -130,6 +130,7 @@ static int tempDriverPriority(const sens
+       { "cpu_thermal", 0 },
+       { "k10temp",     0 },
+       { "zenpower",    0 },
++      { "f10182b0.thermal",0},	// Marvell Armada XP
+       /* Low priority drivers */
+       { "acpitz",      1 },
+    };


### PR DESCRIPTION
Maintainer: none, last updated by @graysky2 
Compile tested: Gentoo Linux on x86-64, OpenWrt r19971
Run tested: Linksys WRT-1900AC v1, OpenWrt r19971, htop works and shows the same CPU temperature as luci-statistics.

Description:
Add Marvell Armada XP temperature sensor to htop list of sensors. This will enable htop to display CPU temperature on these routers in the same way it does on x86 platforms.

To show temperature on Armada XP routers these options must be enabled:
- kernel CONFIG_ARMADA_THERMAL (already selected),
- kernel CONFIG_THERMAL_HWMON (already selected),
- openwrt CONFIG_HTOP_LMSENSORS and dependencies (not selected by default afaik).