### PR TITLE
hfsprogs: remove unused libbsd

### DIFF
--- a/utils/hfsprogs/Makefile
+++ b/utils/hfsprogs/Makefile
@@ -28,7 +28,7 @@ define Package/hfsprogs/Default
   SECTION:=utils
   CATEGORY:=Utilities
   SUBMENU:=Filesystem
-  DEPENDS:=+libopenssl +USE_GLIBC:libbsd
+  DEPENDS:=+libopenssl
 endef
 
 define Package/hfsfsck
@@ -60,7 +60,7 @@ define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		$(TARGET_CONFIGURE_OPTS) \
 		CFLAGS+="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS) -I$(PKG_BUILD_DIR)/include -DDEBUG_BUILD=0 -D_FILE_OFFSET_BITS=64 -D LINUX=1 -D BSD=1 -D VERSION=\\\"$(PKG_VERSION)\\\"" \
-		LDFLAGS+="$(TARGET_LDFLAGS) $(if $(CONFIG_USE_GLIBC),-lbsd)" \
+		LDFLAGS+="$(TARGET_LDFLAGS)" \
 		all
 endef
 


### PR DESCRIPTION
Wikipedia says "[Starting with macOS 10.15, HFS disks can no longer be read](https://en.wikipedia.org/wiki/MacOS_10.15)". hfsprogs also deals with the related HFS+ filesystem, Wikipedia says HFS+ was "[replaced with the Apple File System (APFS), released with macOS High Sierra](https://en.wikipedia.org/wiki/HFS_Plus)". This means support for HFS was removed from macOS in 2019, and HFS+ was deprecated in 2017.
Maybe we could drop this package instead? Tell me if so.

Signed-off-by: Guilherme Janczak <guilherme.janczak@yandex.com>

Maintainer: nobody
Compile tested: x64 glibc master

Description:
```
hfsprogs uses libbsd for strlcpy(), but the strlcpy() calls are inside
`#ifdef` and don't show up on the OpenWRT package.
```