### PR TITLE
auc: use recommended User-Agent header and sent client

### DIFF
--- a/utils/auc/src/auc.c
+++ b/utils/auc/src/auc.c
@@ -1483,7 +1483,7 @@ int main(int args, char *argv[]) {
 	unsigned char argc = 1;
 	bool force = false, use_get = false, in_queue = false, dont_ask = false, release_only = false;
 
-	snprintf(user_agent, sizeof(user_agent), "%s (%s)", argv[0], AUC_VERSION);
+	snprintf(user_agent, sizeof(user_agent), "%s/%s", argv[0], AUC_VERSION);
 	fprintf(stdout, "%s\n", user_agent);
 
 	while (argc<args) {
@@ -1657,6 +1657,7 @@ int main(int args, char *argv[]) {
 		*tmp = '_';
 
 	blobmsg_add_string(&reqbuf, "profile", sanetized_board_name);
+	blobmsg_add_string(&reqbuf, "client", user_agent);
 	blobmsg_add_u8(&reqbuf, "diff_packages", 1);
 
 	req_add_selected_packages(&reqbuf);


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: CI
Run tested: CI

Description:

The usual format for the User-Agent header is `name/version`, replace the
current format which is `name (version)`.

Additionally send the value within the image request JSON data as `client`. For
web clients it is not possible to modify the User-Agent header, it's based on
the browser. To avoid a special case for `auc`, add the `client` value.

Signed-off-by: Paul Spooren <mail@aparcar.org>
