### PR TITLE
tree: update upstream source

### DIFF
--- a/utils/tree/Makefile
+++ b/utils/tree/Makefile
@@ -8,12 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tree
-PKG_RELEASE:=1
 PKG_VERSION:=2.0.2
-PKG_SOURCE_URL:=http://mama.indstate.edu/users/ice/tree/src
-PKG_HASH:=7d693a1d88d3c4e70a73e03b8dbbdc12c2945d482647494f2f5bd83a479eeeaf
+PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/Old-Man-Programmer/$(PKG_NAME)/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=753af251ba6446f4d40cc00064e73c55e910d95245a23d63a31ae1f36d444c1f
+
 PKG_MAINTAINER:=Banglang Huang <banglang.huang@foxmail.com>
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Update Makefile to use new source URL and corresponding variables due to old source url stating, "notice this site is likely going to be shutdown after over 28 years. I will likely be moving all my code-bases to https://gitlab.com/OldManProgrammer"[1]

1. http://mama.indstate.edu/users/ice/tree

Signed-off-by: John Audia <therealgraysky@proton.me>

Maintainer: @neheb @hbl0307106015