### PR TITLE
auc: change server_issues link to openwrt

### DIFF
--- a/utils/auc/src/auc.c
+++ b/utils/auc/src/auc.c
@@ -64,7 +64,7 @@
 #define DPRINTF(...)
 #endif
 
-static const char server_issues[]="https://github.com/aparcar/asu/issues";
+static const char server_issues[]="https://github.com/openwrt/asu/issues";
 
 static struct ubus_context *ctx;
 static struct uclient *ucl = NULL;


### PR DESCRIPTION
Signed-off-by: Andreas <962868+Anteus@users.noreply.github.com>

Maintainer: @dangowrt
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description: auc: change server_issues link to openwrt github as aparcars doesn't have an issues tab.

Fixes: #19095