### PR TITLE
watchcat: fix broken ping invocation for no-address-family configuration

### DIFF
--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=16
+PKG_RELEASE:=17
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -137,12 +137,12 @@ watchcat_monitor_network() {
 		for host in $ping_hosts; do
 			if [ "$iface" != "" ]; then
 				ping_result="$(
-					ping "$ping_family" -I "$iface" -s "$ping_size" -c 1 "$host" &> /dev/null
+					ping $ping_family -I "$iface" -s "$ping_size" -c 1 "$host" &> /dev/null
 					echo $?
 				)"
 			else
 				ping_result="$(
-					ping "$ping_family" -s "$ping_size" -c 1 "$host" &> /dev/null
+					ping $ping_family -s "$ping_size" -c 1 "$host" &> /dev/null
 					echo $?
 				)"
 			fi
@@ -218,12 +218,12 @@ watchcat_ping() {
 		for host in $ping_hosts; do
 			if [ "$iface" != "" ]; then
 				ping_result="$(
-					ping "$ping_family" -I "$iface" -s "$ping_size" -c 1 "$host" &> /dev/null
+					ping $ping_family -I "$iface" -s "$ping_size" -c 1 "$host" &> /dev/null
 					echo $?
 				)"
 			else
 				ping_result="$(
-					ping "$ping_family" -s "$ping_size" -c 1 "$host" &> /dev/null
+					ping $ping_family -s "$ping_size" -c 1 "$host" &> /dev/null
 					echo $?
 				)"
 			fi


### PR DESCRIPTION
Fix for issue #19010

Signed-off-by: John Kohl <jtk.git@bostonpog.org>

Maintainer: @roger-
Compile tested: ramips , 22.03.0-latest
Run tested: ramips, 22.03.0-latest
recent commiters: @rozhuk-im @neheb and @nickberry17