### PR TITLE
 ksmbd-tools: cherry-pick master changes into 21.02

### DIFF
--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
-PKG_VERSION:=3.4.4
+PKG_VERSION:=3.4.5
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/ksmbd-tools/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=cc7cc2fcbeed052176894a8dbbf290919c3735b320401c6492cf17f1ba1a3548
+PKG_HASH:=e22e5bef29ffa2670fc82c490ad4dc6eb00963b4f963dd1852c811b437c77ee1
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
-PKG_VERSION:=3.4.2
+PKG_VERSION:=3.4.4
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/ksmbd-tools/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=fb79bf9201321adb33f8a5f0a12bd205a86b2d4bb057a9f98e0e9521664c2bcd
+PKG_HASH:=cc7cc2fcbeed052176894a8dbbf290919c3735b320401c6492cf17f1ba1a3548
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/ksmbd-tools/files/ksmbd.init
+++ b/net/ksmbd-tools/files/ksmbd.init
@@ -1,6 +1,7 @@
 #!/bin/sh /etc/rc.common
 
 START=98
+STOP=05
 USE_PROCD=1
 
 SMBD_IFACE=""


### PR DESCRIPTION
```
ksmbd-tools: update to 3.4.5

Major changes are:

Add support for Heimdal as the Kerberos 5 implementation.
Add smbd max io size parameter.
Accept global share options.

Signed-off-by: Rosen Penev <rosenp@gmail.com>
(cherry picked from commit d513df080d55c902623050030cc800afd85ee92d)
```
```
ksmbd-tools: update to 3.4.4

Signed-off-by: Rosen Penev <rosenp@gmail.com>
(cherry picked from commit 3ffd540b049dd521dd62f43427f61f264396ad97)
```
```
ksmbd: set stoplevel

to allow graceful stop of the daemon

Signed-off-by: Fritz D. Ansel <fdansel@yandex.ru>
(cherry picked from commit 28ed2b82c5f6f73f2e41357b39a89714959d2a82)
```