### PR TITLE
Remove SoftEther enterprise function restriction on open source version

### DIFF
--- a/net/softethervpn/patches/150_remove-enterprise-function-restriction.patch
+++ b/net/softethervpn/patches/150_remove-enterprise-function-restriction.patch
@@ -1,0 +1,10 @@
+--- a/src/Cedar/Server.c
++++ a/src/Cedar/Server.c
+@@ -10901,6 +10901,7 @@
+ // 
+ bool SiIsEnterpriseFunctionsRestrictedOnOpenSource(CEDAR *c)
+ {
++	return false;
+ 	char region[128];
+ 	bool ret = false;
+ 	// Validate arguments


### PR DESCRIPTION
Maintainer: @parkycai
Compile tested: x86_64
Run tested: x86_64

Description:
Please see this page [http://www.softether.org/5-download/history](http://www.softether.org/5-download/history)
"On VPN Servers in People's Republic of China, the above five functions are currently disabled by default, under the orders from Beijing. Although Chinese users can enable these functions manually, Enterprise users in People's Republic of China are recommended to use these enterprise functions with PacketiX VPN Server 4.0 Chinese Edition."
This patch removes the restrictions.