### PR TITLE
zabbix: add fping dependency

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=5.0.18
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/5.0/
@@ -113,7 +113,10 @@ endef
 define Package/zabbix-server
   $(call Package/zabbix/Default)
   TITLE+= server
-  DEPENDS += +ZABBIX_POSTGRESQL:libpq +ZABBIX_MYSQL:libmariadbclient +libevent2
+  DEPENDS += +ZABBIX_POSTGRESQL:libpq \
+    +ZABBIX_MYSQL:libmariadbclient \
+    +libevent2 \
+    +fping
 endef
 
 define Package/zabbix-server-frontend
@@ -127,7 +130,10 @@ endef
 define Package/zabbix-proxy
   $(call Package/zabbix/Default)
   TITLE+= proxy
-  DEPENDS += +ZABBIX_POSTGRESQL:libpq +ZABBIX_MYSQL:libmariadbclient +libevent2
+  DEPENDS += +ZABBIX_POSTGRESQL:libpq \
+    +ZABBIX_MYSQL:libmariadbclient \
+    +libevent2 \
+    +fping
 endef
 
 define Package/zabbix-extra-mac80211/description


### PR DESCRIPTION

Maintainer: @champtar
Compile tested: x86_64, APU3, latest openwrt master
Run tested: x86_64, APU3, latest openwrt master

Description:
If fping is not installed on the system the following message is show if
hosts should be monitored via icmp.

Log-Message:
"At least one of '/usr/sbin/fping', '/usr/sbin/fping6' must exist. Both
are missing in the system."

To fix this also, add a dependency to 'fping' for 'zabbix-server' and
'zabbix-proxy' for installation to allow icmp hosts monitoring.
