### PR TITLE
python-paho-mqtt: add missing dependency

### DIFF
--- a/lang/python/python-paho-mqtt/Makefile
+++ b/lang/python/python-paho-mqtt/Makefile
@@ -25,7 +25,7 @@ define Package/python3-paho-mqtt
   SUBMENU:=Python
   TITLE:=MQTT version 5.0/3.1.1 client class
   URL:=http://eclipse.org/paho
-  DEPENDS:=+python3-light
+  DEPENDS:=+python3-light +python3-uuid
 endef
 
 define Package/python3-paho-mqtt/description


### PR DESCRIPTION
The uuid module has been split out into a separate package with the update to Python 3.10, so it needs to be added as a dependency here.

This also applies to the 22.03 branch.

Maintainers: @BKPepe, @commodo 