### PR TITLE
rclone: fix init script on CIDR format ipaddr

### DIFF
--- a/net/rclone/files/rclone.init
+++ b/net/rclone/files/rclone.init
@@ -47,12 +47,13 @@ start_service() {
 	config_get proxy_addr proxy proxy_addr
 
 	if [ "${addr_type}" = "local" ]; then
-		addr="$(uci get network.loopback.ipaddr)"
+		addr="$(uci get network.loopback.ipaddr | cut -d' ' -f1)"
 	elif [ "${addr_type}" = "lan" ]; then
-		addr="$(uci get network.lan.ipaddr)"
+		addr="$(uci get network.lan.ipaddr | cut -d' ' -f1)"
 	else
 		addr=""
 	fi
+	addr="${addr%/*}"
 
 	local config_dir="${config_path%/*}"
 	[ -d "$config_dir" ] || mkdir -p "$config_dir"


### PR DESCRIPTION
Signed-off-by: Liangbin Lian <jjm2473@gmail.com>

Maintainer: Elon Huang <elonhhuang@gmail.com>
Compile tested: none
Run tested: ARS2, arm64, openwrt 21.02.3

Description:
fix rclone init script on CIDR format ipaddr