### PR TITLE
python3: backport and fix target musl libc detection

### DIFF
--- a/lang/python/python3/patches/030-bpo-43112-detect-musl-as-a-separate-SOABI-GH-24502.patch
+++ b/lang/python/python3/patches/030-bpo-43112-detect-musl-as-a-separate-SOABI-GH-24502.patch
@@ -1,0 +1,75 @@
+From 3f79de7b8411c76a1fcd1ca850ea62500be7a881 Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Sat, 29 Jan 2022 00:02:54 +0100
+Subject: [PATCH 1/2] bpo-43112: detect musl as a separate SOABI (GH-24502)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+musl libc and gnu libc are not ABI compatible so we need set different
+SOABI for musl and not simply assume that all linux is linux-gnu.
+
+Replace linux-gnu with the detected os for the build from config.guess
+for linux-musl*.
+
+(cherry picked from commit 1f036ede59e2c4befc07714cf76603c591d5c972)
+Signed-off-by: Šimon Bořek <simon.borek@nic.cz>
+---
+ Lib/test/test_sysconfig.py                                | 8 ++++----
+ .../next/Build/2021-02-10-17-54-04.bpo-43112.H5Lat6.rst   | 1 +
+ configure                                                 | 5 +++++
+ configure.ac                                              | 5 +++++
+ 4 files changed, 15 insertions(+), 4 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-02-10-17-54-04.bpo-43112.H5Lat6.rst
+
+--- a/Lib/test/test_sysconfig.py
++++ b/Lib/test/test_sysconfig.py
+@@ -425,11 +425,11 @@ class TestSysConfig(unittest.TestCase):
+             self.assertTrue('linux' in suffix, suffix)
+         if re.match('(i[3-6]86|x86_64)$', machine):
+             if ctypes.sizeof(ctypes.c_char_p()) == 4:
+-                self.assertTrue(suffix.endswith('i386-linux-gnu.so') or
+-                                suffix.endswith('x86_64-linux-gnux32.so'),
+-                                suffix)
++                expected_suffixes = 'i386-linux-gnu.so', 'x86_64-linux-gnux32.so', 'i386-linux-musl.so'
+             else: # 8 byte pointer size
+-                self.assertTrue(suffix.endswith('x86_64-linux-gnu.so'), suffix)
++                expected_suffixes = 'x86_64-linux-gnu.so', 'x86_64-linux-musl.so'
++            self.assertTrue(suffix.endswith(expected_suffixes),
++                            f'unexpected suffix {suffix!r}')
+ 
+     @unittest.skipUnless(sys.platform == 'darwin', 'OS X-specific test')
+     def test_osx_ext_suffix(self):
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-02-10-17-54-04.bpo-43112.H5Lat6.rst
+@@ -0,0 +1 @@
++Detect musl libc as a separate SOABI (tagged as ``linux-musl``).
+\ No newline at end of file
+--- a/configure
++++ b/configure
+@@ -5376,6 +5376,11 @@ EOF
+ 
+ if $CPP $CPPFLAGS conftest.c >conftest.out 2>/dev/null; then
+   PLATFORM_TRIPLET=`grep -v '^#' conftest.out | grep -v '^ *$' | tr -d ' 	'`
++  case "$build_os" in
++  linux-musl*)
++    PLATFORM_TRIPLET=`echo "$PLATFORM_TRIPLET" | sed 's/linux-gnu/linux-musl/'`
++    ;;
++  esac
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PLATFORM_TRIPLET" >&5
+ $as_echo "$PLATFORM_TRIPLET" >&6; }
+ else
+--- a/configure.ac
++++ b/configure.ac
+@@ -866,6 +866,11 @@ EOF
+ 
+ if $CPP $CPPFLAGS conftest.c >conftest.out 2>/dev/null; then
+   PLATFORM_TRIPLET=`grep -v '^#' conftest.out | grep -v '^ *$' | tr -d ' 	'`
++  case "$build_os" in
++  linux-musl*)
++    PLATFORM_TRIPLET=`echo "$PLATFORM_TRIPLET" | sed 's/linux-gnu/linux-musl/'`
++    ;;
++  esac
+   AC_MSG_RESULT([$PLATFORM_TRIPLET])
+ else
+   AC_MSG_RESULT([none])

--- a/lang/python/python3/patches/131-configure_ac-switch-PLATFORM_TRIPLET-suffix-to-musl.patch
+++ b/lang/python/python3/patches/131-configure_ac-switch-PLATFORM_TRIPLET-suffix-to-musl.patch
@@ -1,0 +1,49 @@
+From 15d512cc35106392ed7583d0e000d9a1b865f1e1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C5=A0imon=20Bo=C5=99ek?= <simon.borek@nic.cz>
+Date: Mon, 27 Jun 2022 13:53:37 +0200
+Subject: [PATCH 2/2] configure.ac: switch PLATFORM_TRIPLET suffix to '-musl'
+ based on `host_os` instead of `build_os`
+
+As `build_os` and `host_os` are results of autoconf's `AC_CANONICAL_BUILD`
+and `AC_CANONICAL_HOST` macros[^1], the former refers to the system running the build
+and the latter to the system that will run the compiled program.
+
+`PLATFORM_TRIPLET` should refer to the target platform when cross-compiling.
+Its libc related part should be therefore derived from the target platform as well
+- which is currently not the case - `PLATFORM_TRIPLET` '-gnu' suffix is/isn't switched to '-musl'
+based on `build-os` rather than `host-os` which leads to error message[^2]
+and build failure when compiling Python on glibc system for musl target.
+
+[^1]: https://www.gnu.org/software/autoconf/manual/autoconf-2.68/html_node/Canonicalizing.html ,
+https://www.gnu.org/software/autoconf/manual/autoconf-2.68/html_node/Specifying-Target-Triplets.html
+[^2]: "internal configure error for the platform triplet, please file a bug report"
+
+Co-authored-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Šimon Bořek <simon.borek@nic.cz>
+---
+ configure    | 2 +-
+ configure.ac | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+--- a/configure
++++ b/configure
+@@ -5376,7 +5376,7 @@ EOF
+ 
+ if $CPP $CPPFLAGS conftest.c >conftest.out 2>/dev/null; then
+   PLATFORM_TRIPLET=`grep -v '^#' conftest.out | grep -v '^ *$' | tr -d ' 	'`
+-  case "$build_os" in
++  case "$host_os" in
+   linux-musl*)
+     PLATFORM_TRIPLET=`echo "$PLATFORM_TRIPLET" | sed 's/linux-gnu/linux-musl/'`
+     ;;
+--- a/configure.ac
++++ b/configure.ac
+@@ -866,7 +866,7 @@ EOF
+ 
+ if $CPP $CPPFLAGS conftest.c >conftest.out 2>/dev/null; then
+   PLATFORM_TRIPLET=`grep -v '^#' conftest.out | grep -v '^ *$' | tr -d ' 	'`
+-  case "$build_os" in
++  case "$host_os" in
+   linux-musl*)
+     PLATFORM_TRIPLET=`echo "$PLATFORM_TRIPLET" | sed 's/linux-gnu/linux-musl/'`
+     ;;


### PR DESCRIPTION
Patch 030:
Backported from Python main branch[^1] for Python to distinguish between glibc and musl libc SOABI.

Patch 131:
Changes PLATFORM_TRIPLET -gnu/-musl suffix detection (performed by the backported patch)
to be based on the target OS instead of the building OS.

See included patches for more detailed descriptions.

Specifically this fixes cross-compilation for mpc8548 CPUs with SPE instructions[^2] enabled.

[^1]: merged to python:main as https://github.com/python/cpython/pull/24502 'bpo-43112: detect musl as a separate SOABI'
[^2]: https://www.nxp.com/docs/en/reference-manual/SPEPEM.pdf

Co-authored-by: Pali Rohár <pali@kernel.org>
Signed-off-by: Šimon Bořek <simon.borek@nic.cz>

Maintainer: @jefferyto
Compile and run tested: mpc85xx/p2020, Turris 1.x, OpenWrt 21.02 and master