### PR TITLE
squashfs-tools: enable zstd compression by default

### DIFF
--- a/utils/squashfs-tools/Config.in
+++ b/utils/squashfs-tools/Config.in
@@ -20,4 +20,4 @@ config SQUASHFS_TOOLS_ZSTD_SUPPORT
 	depends on PACKAGE_squashfs-tools-mksquashfs || PACKAGE_squashfs-tools-unsquashfs
 	bool "Enable ZSTD support"
 	select PACKAGE_libzstd
-	default n
+	default y


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/beeb49740bb4f68aadf92095984a2d1f9a488956 
Run tested: x86 https://github.com/openwrt/openwrt/commit/beeb49740bb4f68aadf92095984a2d1f9a488956 

----------------------

Requested via:
  https://github.com/openwrt/packages/issues/19111

PKG_RELEASE is set to AUTORELEASE, so no need to bump.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>