### PR TITLE
mxml: update to 3.3.1

### DIFF
--- a/libs/mxml/Makefile
+++ b/libs/mxml/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mxml
-PKG_VERSION:=3.3
+PKG_VERSION:=3.3.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/michaelrsweet/$(PKG_NAME)/releases/download/v$(PKG_VERSION)/
-PKG_HASH:=7cf976366f9e8e4f8cff7d35a59bcf6201c769fce9e58015d64f4b6de1fe3dd8
+PKG_HASH:=0c663ed1fe393b5619f80101798202eea43534abd7c8aff389022fd8c1dacc32
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Signed-off-by: Espen Jürgensen <espenjurgensen+openwrt@gmail.com>

Maintainer: me
Compile tested: x86_64, r18609
Run tested: no

Description:
Update to 3.3.1 (just a fix for a POSIX thread cleanup bug)