### PR TITLE
[22.03] squashfs-tools: enable zstd compression by default

### DIFF
--- a/utils/squashfs-tools/Config.in
+++ b/utils/squashfs-tools/Config.in
@@ -20,4 +20,4 @@ config SQUASHFS_TOOLS_ZSTD_SUPPORT
 	depends on PACKAGE_squashfs-tools-mksquashfs || PACKAGE_squashfs-tools-unsquashfs
 	bool "Enable ZSTD support"
 	select PACKAGE_libzstd
-	default n
+	default y


### PR DESCRIPTION
Maintainer: me
Compile tested: on PR https://github.com/openwrt/packages/pull/19114
Run tested: on PR https://github.com/openwrt/packages/pull/19114


Requested via:
  https://github.com/openwrt/packages/issues/19111

PKG_RELEASE is set to AUTORELEASE, so no need to bump.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>
(cherry picked from commit f0d45ba3401df4559b17370a19f7800894365d6a)