### PR TITLE
libgpg-error: update to 1.45

### DIFF
--- a/libs/libgpg-error/Makefile
+++ b/libs/libgpg-error/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgpg-error
-PKG_VERSION:=1.43
+PKG_VERSION:=1.45
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://mirrors.dotsrc.org/gcrypt/libgpg-error \
 		http://ring.ksc.gr.jp/archives/net/gnupg/libgpg-error \
 		https://www.gnupg.org/ftp/gcrypt/libgpg-error
-PKG_HASH:=a9ab83ca7acc442a5bd846a75b920285ff79bdb4e3d34aa382be88ed2c3aebaf
+PKG_HASH:=570f8ee4fb4bff7b7495cff920c275002aea2147e9a1d220c068213267f80a26
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: @flyn-org
Compile tested: mpc85xx/p2020, Turris 1.x, OpenWrt 21.02 and master

Description:

Backport from master.

Versions 1.44+ incorporate commit `0150919b6a8244be1055d01ad21d6fa47788ab0e`
```
build: Detect more flexible musl variants of GNU

* configure.ac: expand *-*-linux-musl to *-*-linux-musl*.
```
fixing build error when compiling for mpc85xx target with SPE ISA extension[^1] enabled (currently not OpenWrt default) among other things.

[^1]: https://www.nxp.com/docs/en/reference-manual/SPEPEM.pdf