### PR TITLE
prometheus-node-exporter-lua: add realtek-poe exporter

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2022.08.07
+PKG_VERSION:=2022.08.08
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
@@ -224,6 +224,17 @@ define Package/prometheus-node-exporter-lua-snmp6/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/snmp6.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
+define Package/prometheus-node-exporter-lua-realtek-poe
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (realtek-poe collector)
+  DEPENDS:=prometheus-node-exporter-lua +libubus-lua +realtek-poe
+endef
+
+define Package/prometheus-node-exporter-lua-realtek-poe/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/realtek-poe.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
 $(eval $(call BuildPackage,prometheus-node-exporter-lua))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx6))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx7))
@@ -240,3 +251,4 @@ $(eval $(call BuildPackage,prometheus-node-exporter-lua-uci_dhcp_host))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi_stations))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-snmp6))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-realtek-poe))

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/realtek-poe.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/realtek-poe.lua
@@ -1,0 +1,87 @@
+require "ubus"
+
+local METRIC_NAMESPACE = "realtek_poe"
+
+-- possible poe modes for a port
+--   realtek-poe/src/main.c
+--   static int poe_reply_port_ext_config()
+local POE_MODES = {
+    "PoE",
+    "Legacy",
+    "pre-PoE+",
+    "PoE+"
+}
+
+-- possible poe states for a port
+--   realtek-poe/src/main.c
+--   static int poe_reply_4_port_status()
+local POE_STATES = {
+    "Disabled",
+    "Searching",
+    "Delivering power",
+    "Fault",
+    "Other fault",
+    "Requesting power"
+}
+
+-- --
+-- scraping function
+-- --
+local function scrape()
+    -- connect to ubus
+    local conn = ubus.connect()
+    if not conn then
+        error("Failed to connect to ubusd")
+    end
+
+    -- call poe info
+    local poe_info = conn:call("poe", "info", {})
+    if not poe_info then
+        error("Failed to call 'poe info'. Is realtek-poe installed and running ?")
+    end
+
+    -- close ubus handle
+    conn:close()
+
+    -- helper vars
+    local mcu         = poe_info["mcu"]
+    local ports       = poe_info["ports"]
+    local budget      = poe_info["budget"]
+    local firmware    = poe_info["firmware"]
+    local consumption = poe_info["consumption"]
+
+    -- push info, budget and consumption metric
+    metric(METRIC_NAMESPACE .. "_switch_info", "gauge", { mcu=mcu, firmware=firmware }, 1)
+    metric(METRIC_NAMESPACE .. "_switch_budget_watts", "gauge", nil, budget)
+    metric(METRIC_NAMESPACE .. "_switch_consumption_watts", "gauge", nil, consumption)
+
+    -- push per port priority metrics
+    local priority_metric = metric(METRIC_NAMESPACE .. "_port_priority", "gauge")
+    for port, values in pairs(ports) do
+        priority_metric({ device=port }, values["priority"])
+    end
+
+    -- push per port consumption metrics
+    local consumption_metric = metric(METRIC_NAMESPACE .. "_port_consumption_watts", "gauge")
+    for port, values in pairs(ports) do
+        consumption_metric({ device=port }, (values["consumption"] ~= nil and values["consumption"] or 0))
+    end
+
+    -- push per port state metrics
+    local state_metric = metric(METRIC_NAMESPACE .. "_port_state", "gauge")
+    for _, state in ipairs(POE_STATES) do
+        for port, values in pairs(ports) do
+            state_metric({ device=port, state=state }, (values["status"] == state and 1 or 0))
+        end
+    end
+
+    -- push per port mode metrics
+    local mode_metric = metric(METRIC_NAMESPACE .. "_port_mode", "gauge")
+    for _, mode in ipairs(POE_MODES) do
+        for port, values in pairs(ports) do
+            mode_metric({ device=port, mode=mode }, (values["mode"] == mode and 1 or 0))
+        end
+    end
+end
+
+return { scrape = scrape }


### PR DESCRIPTION
Maintainer: `Gregor Michels <hirnpfirsich@brainpeach.de>`
Compile tested: for `realtek rtl838x` on `amd64` (`snapshot`)
Run tested: `realtek rtl838x`, `Zyxel GS190010HP`, (`snapshot`)

Description:
```
exposes PoE metrics obtained from realtek-poe

 # HELP realtek_poe_switch_info information about the poe controller
 # TYPE realtek_poe_switch_info gauge
 realtek_poe_switch_info{mcu="ST Micro ST32F100 Microcontroller",firmware="v22.4"} 1

 # HELP realtek_poe_switch_budget_watts overall power budget
 # TYPE realtek_poe_switch_budget_watts gauge
 realtek_poe_switch_budget_watts 77

 # HELP realtek_poe_switch_consumption_watts overall power consumption
 # TYPE realtek_poe_switch_consumption_watts gauge
 realtek_poe_switch_consumption_watts 5

 # HELP realtek_poe_port_priority poe priority of port
 # TYPE realtek_poe_port_priority gauge
 realtek_poe_port_priority{device="lan1"} 1
 realtek_poe_port_priority{device="lan2"} 1
 [...]

 # HELP realtek_poe_port_consumption_watts per port power consumption
 # TYPE realtek_poe_port_consumption_watts gauge
 realtek_poe_port_consumption_watts{device="lan1"} 0
 realtek_poe_port_consumption_watts{device="lan2"} 0
 [...]

 # HELP realtek_poe_port_state per port poe state
 # TYPE realtek_poe_port_state gauge
 realtek_poe_port_state{device="lan1",state="Disabled"} 0
 realtek_poe_port_state{device="lan1",state="Searching"} 1
 [...]
 (states: Disabled, Searching, Delivering power, Fault, Other fault, Requesting power)

 # HELP realtek_poe_port_mode per port poe mode
 # TYPE realtek_poe_port_mode gauge
 realtek_poe_port_mode{device="lan1",mode="PoE"} 0
 realtek_poe_port_mode{device="lan1",mode="PoE+"} 1
 [...]
 (modes: PoE, Legacy, pre-PoE+, PoE+)

Signed-off-by: Gregor Michels <hirnpfirsich@brainpeach.de>
```