### PR TITLE
gnutls: update to 3.7.7

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
-PKG_VERSION:=3.7.6
+PKG_VERSION:=3.7.7
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7
-PKG_HASH:=77065719a345bfb18faa250134be4c53bef70c1bd61f6c0c23ceb8b44f0262ff
+PKG_HASH:=be9143d0d58eab64dba9b77114aaafac529b6c0d7e81de6bdf1c9b59027d2106
 
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <nmav@gnutls.org>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
- libgnutls: Fixed double free during verification of pkcs7 signatures.
  Reported by Jaak Ristioja (#1383). [GNUTLS-SA-2022-07-07, CVSS: medium]
  [CVE-2022-2509]

- libgnutls: gnutls_hkdf_expand now only accepts LENGTH argument less than or
  equal to 255 times hash digest size, to comply with RFC 5869 2.3.

- libgnutls: Length limit for TLS PSK usernames has been increased
  from 128 to 65535 characters (#1323).

- libgnutls: AES-GCM encryption function now limits plaintext
  length to 2^39-256 bits, according to SP800-38D 5.2.1.1.

- libgnutls: New block cipher functions have been added to transparently
  handle padding.  gnutls_cipher_encrypt3 and gnutls_cipher_decrypt3 can be
  used in combination of GNUTLS_CIPHER_PADDING_PKCS7 flag to automatically
  add/remove padding if the length of the original plaintext is not a multiple
  of the block size.

- libgnutls: New function for manual FIPS self-testing.

API and ABI modifications:
- gnutls_fips140_run_self_tests: New function
- gnutls_cipher_encrypt3: New function
- gnutls_cipher_decrypt3: New function
- gnutls_cipher_padding_flags_t: New enum

Maintainer: @nmav 