### PR TITLE
shadowsocks-libev: ss-rules: nft rule cleanup on reload

### DIFF
--- a/net/shadowsocks-libev/Makefile
+++ b/net/shadowsocks-libev/Makefile
@@ -14,7 +14,7 @@ include $(TOPDIR)/rules.mk
 #
 PKG_NAME:=shadowsocks-libev
 PKG_VERSION:=3.3.5
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/shadowsocks/shadowsocks-libev/releases/download/v$(PKG_VERSION)

--- a/net/shadowsocks-libev/files/shadowsocks-libev.init
+++ b/net/shadowsocks-libev/files/shadowsocks-libev.init
@@ -112,7 +112,7 @@ ss_rules_cb() {
 	fi
 }
 
-ss_rules() {
+ss_rules_nft_gen() {
 	local cfg="ss_rules"
 	local cfgtype
 	local local_port_tcp local_port_udp
@@ -125,7 +125,7 @@ ss_rules() {
 
 	eval "$(validate_ss_rules_section "$cfg" ss_validate_mklocal)"
 	validate_ss_rules_section "$cfg" || return 1
-	[ "$disabled" = 0 ] || return 0
+	[ "$disabled" = 0 ] || return 2
 
 	eval local_port_tcp="\$ss_rules_redir_tcp_$redir_tcp"
 	eval local_port_udp="\$ss_rules_redir_udp_$redir_udp"
@@ -161,12 +161,25 @@ ss_rules() {
 		echo "table inet chk {include \"$tmp.nft\";}" >"$tmp.nft.chk"
 		if nft -f "$tmp.nft.chk" -c; then
 			mv "$tmp.nft" "$ssrules_nft"
-			fw4 reload
+			fw4 restart
 		fi
 		rm -f "$tmp.nft.chk"
 	fi
 	rm -f "$tmp.json"
 	rm -f "$tmp.nft"
+}
+
+ss_rules_nft_reset() {
+	if [ -f "$ssrules_nft" ]; then
+		rm -f "$ssrules_nft"
+		fw4 restart
+	fi
+}
+
+ss_rules() {
+	if ! ss_rules_nft_gen; then
+		ss_rules_nft_reset
+	fi
 }
 
 start_service() {
@@ -181,10 +194,7 @@ start_service() {
 }
 
 stop_service() {
-	if [ -f "$ssrules_nft" ]; then
-		rm -f "$ssrules_nft"
-		fw4 reload
-	fi
+	ss_rules_nft_reset
 	rm -rf "$ss_confdir"
 }
 


### PR DESCRIPTION

Maintainer: me
Compile tested: n/a
Run tested: x86/64 qemu

Description:

Remove nft rules file generated by ss-rules if ss-rules was or should be
turned off for by configuration.  Use "fw4 restart" instead of "fw4
reload" to force the runtime rule reloading

Ref: https://github.com/openwrt/packages/pull/17937#issuecomment-1207357037
Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
