### PR TITLE
shadowsocks-libev: ss-rules: setup policy rules for udp/ip6

### DIFF
--- a/net/shadowsocks-libev/Makefile
+++ b/net/shadowsocks-libev/Makefile
@@ -14,7 +14,7 @@ include $(TOPDIR)/rules.mk
 #
 PKG_NAME:=shadowsocks-libev
 PKG_VERSION:=3.3.5
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/shadowsocks/shadowsocks-libev/releases/download/v$(PKG_VERSION)

--- a/net/shadowsocks-libev/files/ss-rules/chain.uc
+++ b/net/shadowsocks-libev/files/ss-rules/chain.uc
@@ -52,10 +52,14 @@ if (proto == "tcp") {
 	redir_port = o_redir_udp_port;
 	if (system("
 		set -o errexit
-		while ip rule del fwmark 1 lookup 100 2>/dev/null; do true; done
-		      ip rule add fwmark 1 lookup 100
-		ip route flush table 100 2>/dev/null || true
-		ip route add local default dev lo table 100
+		iprr() {
+			while ip $1 rule del fwmark 1 lookup 100 2>/dev/null; do true; done
+			      ip $1 rule add fwmark 1 lookup 100
+			ip $1 route flush table 100 2>/dev/null || true
+			ip $1 route add local default dev lo table 100
+		}
+		iprr -4
+		iprr -6
 	") != 0) {
 		return ;
 	}


### PR DESCRIPTION
Maintainer: me
Compile tested: n/a
Run tested: x86/64 qemu

Supersedes: https://github.com/openwrt/packages/pull/18852
Fixes: https://github.com/openwrt/packages/issues/18850
Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>

