### PR TITLE
ksmbd-hotplug: add package with hotplug script for auto-sharing

### DIFF
--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -84,6 +84,12 @@ define Package/ksmbd-avahi-service/description
   Ksmbd (smb/445) Daemon service via mDNS/DNS-SD.
 endef
 
+define Package/ksmbd-hotplug
+  $(call Package/ksmbd-tools/Default)
+  TITLE+= hotplug script for auto sharing
+  DEPENDS:=+blockd
+endef
+
 MESON_ARGS += \
 	-Db_lto=true \
 	-Dkrb5=disabled
@@ -116,6 +122,11 @@ define Package/ksmbd-avahi-service/install
 	$(INSTALL_DATA) ./files/smb.service $(1)/etc/avahi/services/
 endef
 
+define Package/ksmbd-hotplug/install
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/mount
+	$(INSTALL_CONF) ./files/ksmbd.hotplug $(1)/etc/hotplug.d/mount/60-ksmbd
+endef
+
 define Package/ksmbd-server/conffiles
 /etc/config/ksmbd
 /etc/ksmbd/smb.conf.template
@@ -130,3 +141,4 @@ endef
 $(eval $(call BuildPackage,ksmbd-server))
 $(eval $(call BuildPackage,ksmbd-utils))
 $(eval $(call BuildPackage,ksmbd-avahi-service))
+$(eval $(call BuildPackage,ksmbd-hotplug))

--- a/net/ksmbd-tools/files/ksmbd.hotplug
+++ b/net/ksmbd-tools/files/ksmbd.hotplug
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+. /usr/share/libubox/jshn.sh
+
+device_get_vars() {
+	json_init
+	json_load "$(ubus call block info)"
+
+	json_select devices || return 1
+
+	json_get_keys keys
+	for key in $keys
+	do
+		json_select $key
+
+		json_get_var device device
+		[ "$device" = "$1" ] && {
+			shift
+			json_get_vars $@
+			json_select ..
+			json_select ..
+			return 0
+		}
+
+		json_select ..
+	done
+
+	json_select ..
+
+	return 2
+}
+
+[ -f /var/run/config/ksmbd ] || {
+	mkdir -p /var/run/config && touch /var/run/config/ksmbd
+}
+
+[ "$ACTION" = "add" ] && {
+	device_get_vars $DEVICE label mount || {
+		logger -t ksmbd-hotplug "Failed to get $DEVICE info"
+		exit 1
+	}
+	[ -n "$mount" ] && {
+		uci -c /var/run/config batch <<-EOF
+			set ksmbd.$DEVICE="share"
+			set ksmbd.$DEVICE.name="${label:-$DEVICE}"
+			set ksmbd.$DEVICE.path="$mount"
+			set ksmbd.$DEVICE.browseable="yes"
+			set ksmbd.$DEVICE.read_only="yes"
+			set ksmbd.$DEVICE.guest_ok="yes"
+			commit ksmbd
+		EOF
+		/etc/init.d/ksmbd reload
+	}
+}
+
+[ "$ACTION" = "remove" ] && {
+	uci -c /var/run/config batch <<-EOF
+		delete ksmbd.$DEVICE
+		commit ksmbd
+	EOF
+	/etc/init.d/ksmbd reload
+}

--- a/net/ksmbd-tools/files/ksmbd.init
+++ b/net/ksmbd-tools/files/ksmbd.init
@@ -116,6 +116,7 @@ init_config()
 	mkdir -p /var/etc/ksmbd
 
 	config_load ksmbd
+	CONFIG_APPEND=1 UCI_CONFIG_DIR=/var/run/config config_load ksmbd
 	config_foreach smb_header globals
 	config_foreach smb_add_share share
 }


### PR DESCRIPTION
Maintainer: me / @neheb / @jow-

Description:
```
ksmbd-tools: add package with hotplug.d script for auto sharing

One of common use cases for SMB3 server in routers is sharing hotplugged
drives. Users make many attempts setting that up which often are not
optimal.

This script handles it in the cleanest way by using:
1. hotplug.d mount subsystem
2. runtime config in the /var/run/config/

It provides a working basic solution that can be later adjusted by
modifying provided hotplug script.

A pretty much idential solution was part of the samba36 package. It was
added in the OpenWrt commit ef1efa756e0d0 ("samba36: add package with
hotplug.d script for auto sharing") as an answer for feature required by
the Rosinson company.
```
```
ksmbd-tools: append config from /var/run/config/ for runtime shares

Dynamically created shares shouldn't be stored in the /etc/config/
because of:
1. Flash wearing
2. Risk of inconsistent state on reboots

With this change all automation/hotplug.d scripts can store runtime in
the /var/run/config/samba. It's useful e.g. for USB drives that user
wants to be automatically shared.

Also: automated scripts should never call "uci [foo] commit" as that
could flush incomplete config. This problem also gets solved.

Identical feature was added to samba36 in the OpenWrt commit
5a59e2c059866 ("samba36: append config from /var/run/config/ for runtime
shares") but wasn't ported to ksmbd until now.
```