### PR TITLE
syslog-ng: fix OOM issues by adding support for logrotate

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -33,7 +33,7 @@ define Package/syslog-ng
   CATEGORY:=Administration
   TITLE:=A powerful syslog daemon
   URL:=https://www.syslog-ng.com/products/open-source-log-management/
-  DEPENDS:=+libpcre +glib2 +libopenssl +libpthread +librt +zlib +libdbi +libjson-c +libcurl +libuuid
+  DEPENDS:=+libpcre +glib2 +libopenssl +libpthread +librt +zlib +libdbi +libjson-c +libcurl +libuuid +SYSLOGNG_LOGROTATE:logrotate
 endef
 
 define Package/syslog-ng/description
@@ -48,10 +48,38 @@ define Package/syslog-ng/conffiles
 /etc/scl.conf
 endef
 
+define Package/syslog-ng/config
+config SYSLOGNG_LOGROTATE
+	bool "Logrotate support"
+	depends on PACKAGE_syslog-ng
+	default n
+	help
+	  It adds support for logrotate functionality.
+
+config SYSLOGNG_LOGROTATE_MAXSIZE
+	string "Maximum size of /var/log/messages log file"
+	depends on SYSLOGNG_LOGROTATE
+	default "1M"
+	help
+	  Log files are rotated when they grow bigger than defined size bytes.
+
+config SYSLOGNG_LOGROTATE_ROTATE_COUNT
+	int "Maximum rotation count for /var/log/messages log file"
+	depends on SYSLOGNG_LOGROTATE
+	default 1
+	help
+	  Log files are rotated count times before being removed or mailed to
+	  the address specified in a mail directive. If count is 0, old
+	  versions are removed rather than rotated.
+endef
+
 define Build/Configure
 	$(SED) 's,-I/usr/include,,' $(PKG_BUILD_DIR)/configure
 	$(Build/Configure/Default)
 endef
+
+LOGROTATE_MAXSIZE:=$(call qstrip,$(CONFIG_SYSLOGNG_LOGROTATE_MAXSIZE))
+LOGROTATE_ROTATE:=$(call qstrip,$(CONFIG_SYSLOGNG_LOGROTATE_ROTATE_COUNT))
 
 CONFIGURE_ARGS +=  \
 	--disable-afsnmp \
@@ -98,6 +126,14 @@ define Package/syslog-ng/install
 
 	$(INSTALL_DIR) $(1)/usr/share/syslog-ng/include/
 	$(CP) -r ./files/scl $(1)/usr/share/syslog-ng/include/
+
+ifneq ($(strip $(CONFIG_SYSLOGNG_LOGROTATE)),)
+	$(INSTALL_DIR) $(1)/etc/logrotate.d
+	sed \
+		-e 's#@MAXSIZE@#$(LOGROTATE_MAXSIZE)#g' \
+		-e 's#@ROTATE@#$(LOGROTATE_ROTATE)#g' \
+		./files/syslog-ng.logrotate > $(1)/etc/logrotate.d/syslog-ng.conf
+endif
 endef
 
 define Package/syslog-ng/postinst

--- a/admin/syslog-ng/files/syslog-ng.logrotate
+++ b/admin/syslog-ng/files/syslog-ng.logrotate
@@ -1,0 +1,12 @@
+/var/log/messages {
+	compress
+	copytruncate
+	delaycompress
+	notifempty
+	maxsize @MAXSIZE@
+	missingok
+	postrotate
+		/usr/sbin/syslog-ng-ctl reload > /dev/null
+	endscript
+	rotate @ROTATE@
+}


### PR DESCRIPTION
Maintainer: @BKPepe 
Compile tested: glinet-b1300, turris-omnia, 19.07, 22.03
Run tested: glinet-b1300, turris-omnia, 19.07, 22.03

Description:

With heavy system logging which goes by default into `/var/log/messages`
log file which is usually placed in tmpfs/RAM one can trigger OOM killer
fairly easily, thus killing random processes and in some cases making
system unusable.

This is likely happening due to the fact, that Linux by default uses 1/2
of available RAM for tmpfs, which might be for example an issue on low
RAM devices with ath10k wireless.

So let's fix it by adding logrotate functionality which should limit the
size of `/var/log/messages` log file to 1M by default, but could be
tweaked by config knob if needed be.
