### PR TITLE
strongswan: bundle mgf1 with everything

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -260,6 +260,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-hmac \
 	+strongswan-mod-kernel-netlink \
 	+strongswan-mod-md5 \
+	+strongswan-mod-mgf1 \
 	+strongswan-mod-nonce \
 	+strongswan-mod-pem \
 	+strongswan-mod-pgp \
@@ -298,6 +299,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-hmac \
 	+strongswan-mod-kernel-netlink \
 	+strongswan-mod-md5 \
+	+strongswan-mod-mgf1 \
 	+strongswan-mod-nonce \
 	+strongswan-mod-pubkey \
 	+strongswan-mod-random \
@@ -325,6 +327,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-gmp \
 	+strongswan-mod-hmac \
 	+strongswan-mod-kernel-netlink \
+	+strongswan-mod-mgf1 \
 	+strongswan-mod-nonce \
 	+strongswan-mod-pubkey \
 	+strongswan-mod-random \


### PR DESCRIPTION
Maintainer: me, @Thermi 
Compile tested: x86_64, generic, HEAD (23c77384f3)
Run tested: same, installed on production router

Description:

Everything needs mgf1 plugin.