### PR TITLE
mqttled: update to 0.1.2

### DIFF
--- a/utils/mqttled/Makefile
+++ b/utils/mqttled/Makefile
@@ -2,11 +2,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mqttled
-PKG_VERSION:=0.1.0
+PKG_VERSION:=0.1.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=mqttled
-PKG_HASH:=20f46b7114b6ddace6e0faaaa078640f609c3d495e4ccff8d8caeb77ac5418f7
+PKG_HASH:=eb94af853605f4f1ea3c34b66e2f84f3d9845d795529ae8429feb954e74876d7
 
 PKG_MAINTAINER:=Tom Grime <tom.grime@gmail.com>
 PKG_LICENSE:=MIT

--- a/utils/mqttled/files/mqttled.config
+++ b/utils/mqttled/files/mqttled.config
@@ -26,6 +26,16 @@ config leds 'leds'
     list exclude 'rt2800soc-phy1::radio'
     #list include 'blue:internet'
 
+config rgb 'rgb'
+    # Exposes 3 LEDs to HomeAssistant as a single RGB LED
+    option enablergb '0'
+    # The name of the RGB LED to expose to HomeAssistant
+    option name 'RGB'
+    # The IDs of the three colored LEDs
+    option red 'LED0_Red'
+    option green 'LED0_Green'
+    option blue 'LED0_Blue'
+
 config trigger 'triggers'
     #Only triggers listed here will be presented to HA as 'effects'
     list triggers 'none'


### PR DESCRIPTION
Signed-off-by: Tom Grime <tom.grime@gmail.com>

Maintainer: me 
Compile tested: lantiq/xrx200 HH5A 21.02.03
Run tested: lantiq/xrx200 HH5A 21.02.03

Description:
Bump to support RGB LEDs and fix brightness control