### PR TITLE
libwebp: bump to version 1.2.4

### DIFF
--- a/libs/libwebp/Makefile
+++ b/libs/libwebp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libwebp
-PKG_VERSION:=1.2.3
+PKG_VERSION:=1.2.4
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://storage.googleapis.com/downloads.webmproject.org/releases/webp
-PKG_HASH:=f5d7ab2390b06b8a934a4fc35784291b3885b557780d099bd32f09241f9d83f9
+PKG_HASH:=7bf5a8a28cc69bcfa8cb214f2c3095703c6b73ac5fba4d5480c205331d9494df
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https:://github.com/openwrt/commit/beeb49740bb4f68aadf92095984a2d1f9a488956
Run tested: x86 https:://github.com/openwrt/commit/beeb49740bb4f68aadf92095984a2d1f9a488956

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>