### PR TITLE
ariang: update to 1.2.4

### DIFF
--- a/net/ariang/Makefile
+++ b/net/ariang/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ariang
-PKG_VERSION:=1.2.3
+PKG_VERSION:=1.2.4
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
 PKG_SOURCE_URL:=https://github.com/mayswind/AriaNg/releases/download/$(PKG_VERSION)
-PKG_HASH:=061af099d5772933889254ef926f34f973fd8c0ed82e24c7520b242eba00763f
+PKG_HASH:=a72dc5d7640e864c2dd528c88db493a3056087412537e87c6c5a98141a482380
 UNPACK_CMD=unzip -q -d $(1) $(DL_DIR)/$(PKG_SOURCE)
 
 PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>


### PR DESCRIPTION
Maintainer: @Ansuel @neheb
Compile tested: x86_64
Run tested: x86_64

Changelog: https://github.com/mayswind/AriaNg/releases

Signed-off-by: Van Waholtz <vanwaholtz@gmail.com>