### PR TITLE
iperf: Updated to 2.1.8

### DIFF
--- a/net/iperf/Makefile
+++ b/net/iperf/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
-PKG_VERSION:=2.1.3
+PKG_VERSION:=2.1.8
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=dfe2197e2842fe9c9d9677bf1cb20a5a9ccfcb9a9de79f9927c39f73204ba003
+PKG_HASH:=8e2cf2fbc9d0d4d1cf9d109b1e328459f9622993dc9a4c5a7dc8a2088fb7beaf
 PKG_SOURCE_URL:=@SF/iperf2
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
@@ -45,6 +45,7 @@ define Package/iperf/config
 endef
 
 CONFIGURE_ARGS += \
+	--enable-fastsampling \
 	$(call autoconf_bool,CONFIG_IPERF_ENABLE_MULTICAST,multicast) \
 	$(call autoconf_bool,CONFIG_IPV6,ipv6)
 


### PR DESCRIPTION
Enabling fast sampling to support four digit (e.g., 1.0000) precision in reports' timestamps. Useful for sub-millisecond sampling.

Changelog: https://sourceforge.net/p/iperf2/code/ci/2-1-8/tree/README

Signed-off-by: Alberto Martinez-Alvarez <amteza@gmail.com>

Maintainer: @nbd168
Compile tested: ath79, ramips, bcm27xx
