### PR TITLE
bluld: Do not include kernel headers into user space application

### DIFF
--- a/utils/bluld/Makefile
+++ b/utils/bluld/Makefile
@@ -16,9 +16,6 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/kernel.mk
 
-EXTRA_CXXFLAGS = -I$(LINUX_DIR)/include
-EXTRA_CFLAGS = -I$(LINUX_DIR)/include
-
 include $(INCLUDE_DIR)/cmake.mk
 
 define Package/bluld


### PR DESCRIPTION
Maintainer: @ktgeek 
Compile tested: aarch64 / glibc
Run tested: no

Description:

Remove the extra include for kernel headers from this user space
application. These extra includes are causing compile errors when
compiling with glibc. User space applications should not need such
headers.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
