### PR TITLE
dnscrypt-proxy2: update to version 2.1.2

### DIFF
--- a/net/dnscrypt-proxy2/Makefile
+++ b/net/dnscrypt-proxy2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy2
-PKG_VERSION:=2.1.1
+PKG_VERSION:=2.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=dnscrypt-proxy-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/DNSCrypt/dnscrypt-proxy/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=cc4a2f274ce48c3731ff981e940e6475d912fb356a80481e91725e81d67bde14
+PKG_HASH:=aa55fd52b9c1b983405bf98b42ec754f5d6f59b429ba9c98115df617eef5dea4
 PKG_BUILD_DIR:=$(BUILD_DIR)/dnscrypt-proxy-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>


### PR DESCRIPTION
Maintainer: @BKPepe 
Run tested: Linksys_wrt32x, mvebu (cortex-a9),  OpenWrt 22.03.0-rc6

Description:

update to version [2.1.2](https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/2.1.2)

Fixes: https://github.com/openwrt/packages/issues/19149
