### PR TITLE
opendoas: fix build with PAM

### DIFF
--- a/utils/opendoas/Makefile
+++ b/utils/opendoas/Makefile
@@ -22,6 +22,7 @@ define Package/opendoas
   CATEGORY:=Utilities
   TITLE:=Portable OpenBSD doas to execute commands as another user
   URL:=https://github.com/Duncaen/OpenDoas
+  DEPENDS:=+BUSYBOX_CONFIG_PAM:libpam
 endef
 
 define Package/opendoas/description


### PR DESCRIPTION
Maintainer: me
Compile tested: armv7l, Turris Omnia, OpenWrt master
Run tested: no

Description: When PAM is available, the build system will detect and use it, but the
package dependency was missing.

cc @neheb