### PR TITLE
yt-dlp: update to 2022.8.14

### DIFF
--- a/multimedia/yt-dlp/Makefile
+++ b/multimedia/yt-dlp/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yt-dlp
-PKG_VERSION:=2022.7.18
+PKG_VERSION:=2022.8.14
 PKG_RELEASE:=1
 
 PYPI_NAME:=yt-dlp
-PKG_HASH:=0e7b81fc6ac8d1b7d3fffa79f9044ca4163784422582c9a3593305da2a69ec02
+PKG_HASH:=9a2ceb76a4cc48aa80127eff8a853d9c8b7efe8be121c2123dcbfd3d06bc945f
 
 PKG_MAINTAINER:=Michal Vasilek <michal.vasilek@nic.cz>
 PKG_LICENSE:=Unlicense


### PR DESCRIPTION
Maintainer: me
Compile tested: armv7l, Turris Omnia, OpenWrt master
Run tested: armv7l, Turris Omnia, OpenWrt 21.02

Description:
