### PR TITLE
qemu: enable usb passthrough by default

### DIFF
--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -261,6 +261,7 @@ config QEMU_UI_SPICE
 
 config QEMU_DEV_USB
 	bool "QEMU USB passthrough support"
+	default y
 
 config QEMU_SECCOMP
 	bool "Enable support for seccomp in QEMU"


### PR DESCRIPTION
The total uncompressed size increase (qemu-system-x86_64 and the new libusb dependency) is less than 1%.

Maintainer: @yousong
Compile tested: built with the current SDK docker image on x86_64 for x86_64
Run tested: `qemu-system-x86_64 -device help` now returns `usb_host` and I can correctly pass a physical device to the VM.