### PR TITLE
luaossl: update to rel-20220711

### DIFF
--- a/lang/luaossl/Makefile
+++ b/lang/luaossl/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Siger Yang <sigeryeung@gmail.com>
+# Copyright (C) 2021 Siger Yang <siger.yang@outlook.com>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luaossl
-PKG_VERSION:=20200709
-PKG_RELEASE:=2
-PKG_MAINTAINER:=Siger Yang <sigeryeung@gmail.com>
+PKG_VERSION:=20220711
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Siger Yang <siger.yang@outlook.com>
 
-PKG_MIRROR_HASH:=6dbca3cdc50ed7e3b0821783da2407accfb6d25addc3edf1d8e17b00530f5a25
+PKG_MIRROR_HASH:=60d747778b0a526616c89d27a695d35e36f774b0035f7ff523c8d4bdbb02d075
 PKG_SOURCE_URL:=https://github.com/wahern/luaossl.git
 PKG_SOURCE_VERSION:=rel-$(PKG_VERSION)
 PKG_SOURCE_PROTO:=git


### PR DESCRIPTION
Maintainer: me
Compile tested: mipsel_24kc, YOUKU YK1, 21.02.1
Run tested: mipsel_24kc, YOUKU YK1, 21.02.1

```
Lua 5.1.5  Copyright (C) 1994-2012 Lua.org, PUC-Rio (double int32)
> for k, v in pairs(require('openssl')) do print(k, v) end
NO_MDC2	true
NO_NEXTPROTONEG	true
NO_RC5	true
NO_UNIT_TEST	true
NO_RFC3779	true
NO_SEED	true
NO_IDEA	true
NO_MD2	true
SSLEAY_VERSION	0
SHLIB_VERSION_NUMBER	1.1
NO_EC2M	true
OPENSSL_VERSION_NUMBER	269488335
NO_SCTP	true
NO_CAMELLIA	true
NO_WHIRLPOOL	true
SSLEAY_CFLAGS	1
SSLEAY_DIR	4
extensionSupported	function: 0x4132f0
SSLEAY_BUILT_ON	2
SSLEAY_PLATFORM	3
version	function: 0x134a1e0
VERSION_NUMBER	269488335
NO_STATIC_ENGINE	true
VERSION_TEXT	OpenSSL 1.1.1l  24 Aug 2021
SHLIB_VERSION_HISTORY	
SSLEAY_VERSION_NUMBER	269488335
> 
```

Description:
