### PR TITLE
shadowsocks-libev: use github master branch

### DIFF
--- a/net/shadowsocks-libev/Makefile
+++ b/net/shadowsocks-libev/Makefile
@@ -14,11 +14,15 @@ include $(TOPDIR)/rules.mk
 #
 PKG_NAME:=shadowsocks-libev
 PKG_VERSION:=3.3.5
-PKG_RELEASE:=7
+PKG_RELEASE:=8
+PKG_SOURCE_DATE:=2022-07-28
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/shadowsocks/shadowsocks-libev/releases/download/v$(PKG_VERSION)
-PKG_HASH:=cfc8eded35360f4b67e18dc447b0c00cddb29cc57a3cec48b135e5fb87433488
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/shadowsocks/shadowsocks-libev.git
+PKG_SOURCE_VERSION:=d3e73c6ce652168963cb10c8284c89f2cf4df16e
+PKG_MIRROR_HASH:=f31d25507852d71245d797143d2a7a70ff2f7ebbc28f8d7c461ab000c96c5b87
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 


### PR DESCRIPTION
Signed-off-by: Toni Uhlig <matzeton@googlemail.com>

Maintainer:Yousong Zhou <yszhou4tech@gmail.com>
Compile tested: mvebu, ARMv7, r20351+10-60738feded
Run tested: mvebu, ARMv7, r20351+10-60738feded

Description:

The last official release is from September 2020. I guess there won't be any more release as this project is just there for bug fixes. And there were lot's of bug fixes commit since 09.2020.