### PR TITLE
travelmate: update 2.1.0

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=2.0.9
-PKG_RELEASE:=2
+PKG_VERSION:=2.1.0
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/travelmate/files/chs-hotel.login
+++ b/net/travelmate/files/chs-hotel.login
@@ -1,6 +1,6 @@
 #!/bin/sh
 # captive portal auto-login script for chs hotels (DE)
-# Copyright (c) 2020-2021 Dirk Brenken (dev@brenken.org)
+# Copyright (c) 2020-2022 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
 # set (s)hellcheck exceptions
@@ -10,7 +10,6 @@
 
 export LC_ALL=C
 export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-set -o pipefail
 
 trm_domain="hotspot.internet-for-guests.com"
 trm_useragent="$(uci_get travelmate global trm_useragent "Mozilla/5.0 (Linux x86_64; rv:90.0) Gecko/20100101 Firefox/90.0")"

--- a/net/travelmate/files/generic-user-pass.login
+++ b/net/travelmate/files/generic-user-pass.login
@@ -1,6 +1,6 @@
 #!/bin/sh
 # captive portal auto-login script template with credentials as parameters
-# Copyright (c) 2020-2021 Dirk Brenken (dev@brenken.org)
+# Copyright (c) 2020-2022 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
 # set (s)hellcheck exceptions
@@ -10,7 +10,6 @@
 
 export LC_ALL=C
 export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-set -o pipefail
 
 user="${1}"
 password="${2}"

--- a/net/travelmate/files/h-hotels.login
+++ b/net/travelmate/files/h-hotels.login
@@ -1,6 +1,6 @@
 #!/bin/sh
 # captive portal auto-login script for Telekom hotspots in h+hotels (DE)
-# Copyright (c) 2020-2021 Dirk Brenken (dev@brenken.org)
+# Copyright (c) 2020-2022 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
 # set (s)hellcheck exceptions
@@ -10,7 +10,6 @@
 
 export LC_ALL=C
 export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-set -o pipefail
 
 trm_domain="hotspot.t-mobile.net"
 trm_useragent="$(uci_get travelmate global trm_useragent "Mozilla/5.0 (Linux x86_64; rv:90.0) Gecko/20100101 Firefox/90.0")"

--- a/net/travelmate/files/julianahoeve.login
+++ b/net/travelmate/files/julianahoeve.login
@@ -1,6 +1,6 @@
 #!/bin/sh
 # captive portal auto-login script for Julianahoeve beach resort (NL)
-# Copyright (c) 2021 Dirk Brenken (dev@brenken.org)
+# Copyright (c) 2021-2022 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
 # set (s)hellcheck exceptions
@@ -10,7 +10,6 @@
 
 export LC_ALL=C
 export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-set -o pipefail
 
 trm_domain="n23.network-auth.com"
 trm_useragent="$(uci_get travelmate global trm_useragent "Mozilla/5.0 (Linux x86_64; rv:90.0) Gecko/20100101 Firefox/90.0")"

--- a/net/travelmate/files/telekom.login
+++ b/net/travelmate/files/telekom.login
@@ -1,6 +1,6 @@
 #!/bin/sh
 # captive portal auto-login script for telekom hotspots (DE)
-# Copyright (c) 2021 Dirk Brenken (dev@brenken.org)
+# Copyright (c) 2021-2022 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
 # set (s)hellcheck exceptions
@@ -12,28 +12,27 @@
 #
 urlencode()
 {
-    local chr str="${1}" len="${#1}" pos=0
+	local chr str="${1}" len="${#1}" pos=0
 
-    while [ "${pos}" -lt "${len}" ]; do
-        chr="${str:pos:1}"
-        case "${chr}" in
-            [a-zA-Z0-9.~_-])
-                printf "%s" "${chr}"
-                ;;
-            " ")
-                printf "%%20"
-                ;;
-            *)
-                printf "%%%02X" "'${chr}"
-                ;;
-        esac
-        pos=$((pos + 1))
-    done
+	while [ "${pos}" -lt "${len}" ]; do
+		chr="${str:pos:1}"
+		case "${chr}" in
+			[a-zA-Z0-9.~_-])
+				printf "%s" "${chr}"
+				;;
+			" ")
+				printf "%%20"
+				;;
+			*)
+				printf "%%%02X" "'${chr}"
+				;;
+		esac
+		pos=$((pos + 1))
+		done
 }
 
 export LC_ALL=C
 export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-set -o pipefail
 
 username="$(urlencode "${1}")"
 password="$(urlencode "${2}")"

--- a/net/travelmate/files/tplink-omada.login
+++ b/net/travelmate/files/tplink-omada.login
@@ -1,0 +1,126 @@
+#!/bin/sh
+# captive portal auto-login script for TP-Link Omada (authType=0 only)
+# Copyright (c) 2022 Sebastian Muszynski <basti@linkt.de>
+# This is free software, licensed under the GNU General Public License v3
+
+# set (s)hellcheck exceptions
+# shellcheck disable=1091,2181,3037,3043,3057
+
+. "/lib/functions.sh"
+. "/usr/share/libubox/jshn.sh"
+
+urlencode()
+{
+	local chr str="${1}" len="${#1}" pos=0
+
+	while [ "${pos}" -lt "${len}" ]; do
+		chr="${str:pos:1}"
+		case "${chr}" in
+			[a-zA-Z0-9.~_-])
+				printf "%s" "${chr}"
+				;;
+			" ")
+				printf "%%20"
+				;;
+			*)
+				printf "%%%02X" "'${chr}"
+				;;
+		esac
+		pos=$((pos + 1))
+	done
+}
+
+urldecode()
+{
+	echo -e "$(sed 's/+/ /g;s/%\(..\)/\\x\1/g;')"
+}
+
+request_parameter()
+{
+	grep -oE "$1=[^&]+" | cut -d= -f2
+}
+
+export LC_ALL=C
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+
+trm_captiveurl="$(uci_get travelmate global trm_captiveurl "http://detectportal.firefox.com")"
+trm_maxwait="$(uci_get travelmate global trm_maxwait "30")"
+trm_fetch="$(command -v curl) --connect-timeout $((trm_maxwait / 6)) --silent"
+
+raw_html="$(${trm_fetch} --show-error "${trm_captiveurl}")"
+
+if [ $? -ne 0 ];
+then
+	echo "The captive portal didn't respond"
+	exit 1
+fi
+
+if [ "$raw_html" = "success" ];
+then
+	echo "Internet access already available"
+	exit 0
+fi
+
+redirect_url=$(echo "$raw_html" | grep -oE 'location.href="[^\"]+"' | cut -d\" -f2)
+
+portal_baseurl=$(echo "$redirect_url" | cut -d/ -f1-4)
+client_mac=$(echo "$redirect_url" | request_parameter cid)
+ap_mac=$(echo "$redirect_url" | request_parameter ap)
+ssid=$(echo "$redirect_url" | request_parameter ssid | urldecode)
+radio_id=$(echo "$redirect_url" | request_parameter rid)
+url=$(echo "$redirect_url" | request_parameter u | urldecode)
+
+${trm_fetch} "${portal_baseurl}/pubKey" | jsonfilter -e '@.result.key' > /tmp/trm-omada-pub.key
+if [ $? -ne 0 ];
+then
+	exit 2
+fi
+
+json_init
+json_add_string "clientMac" "$client_mac"
+json_add_string "apMac" "$ap_mac"
+json_add_string "ssidName" "$ssid"
+json_add_int "radioId" "$radio_id"
+json_add_string "originUrl" "$url"
+json_close_object
+incomplete_auth_request="$(json_dump)"
+
+auth_type=$(${trm_fetch} "${portal_baseurl}/getPortalPageSetting" \
+	-H 'Accept: application/json' \
+	-H 'Content-Type: application/json' \
+	-H 'X-Requested-With: XMLHttpRequest' \
+	--data-raw "$incomplete_auth_request" | jsonfilter -e '@.result.authType')
+
+if [ "$auth_type" -ne 0 ];
+then
+	echo "Unsupported auth type: $auth_type"
+	exit 3
+fi
+
+aes_key=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 16)
+aes_key_hex=$(printf "%s" "$aes_key" | hexdump -e '16/1 "%02x"')
+aes_vi=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 16)
+aes_vi_hex=$(printf "%s" "$aes_vi" | hexdump -e '16/1 "%02x"')
+
+rsa_encrypted_aes_secrets=$(printf "%s" "${aes_key}${aes_vi}" | openssl rsautl -encrypt -pubin -inkey /tmp/trm-omada-pub.key | base64 -w 0)
+rsa_encrypted_aes_secrets_urlencoded=$(urlencode "$rsa_encrypted_aes_secrets")
+
+json_load "$incomplete_auth_request"
+json_add_int "authType" "$auth_type"
+json_close_object
+auth_request="$(json_dump)"
+
+aes_encrypted_auth_request="$(echo "$auth_request" | openssl enc -aes-128-cbc -K "$aes_key_hex" -iv "$aes_vi_hex" -a -A)"
+
+auth_response=$(${trm_fetch} "${portal_baseurl}/auth?key=$rsa_encrypted_aes_secrets_urlencoded" \
+	-H 'Content-Type: text/plain' \
+	-H 'X-Requested-With: XMLHttpRequest' \
+	--data-raw "$aes_encrypted_auth_request" \
+	--insecure)
+
+if echo "$auth_response" | grep -q '{"errorCode":0}';
+then
+	exit 0
+fi
+
+exit 255

--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -1,5 +1,5 @@
 #!/bin/sh /etc/rc.common
-# Copyright (c) 2016-2021 Dirk Brenken (dev@brenken.org)
+# Copyright (c) 2016-2022 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
 # set (s)hellcheck exceptions

--- a/net/travelmate/files/travelmate.mail
+++ b/net/travelmate/files/travelmate.mail
@@ -1,6 +1,6 @@
 #!/bin/sh
 # send mail script for travelmate notifications
-# Copyright (c) 2020-2021 Dirk Brenken (dev@brenken.org)
+# Copyright (c) 2020-2022 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
 # set (s)hellcheck exceptions
@@ -12,7 +12,6 @@
 
 export LC_ALL=C
 export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-set -o pipefail
 
 trm_debug="$(uci_get travelmate global trm_debug "0")"
 trm_mailreceiver="$(uci_get travelmate global trm_mailreceiver)"

--- a/net/travelmate/files/travelmate.vpn
+++ b/net/travelmate/files/travelmate.vpn
@@ -12,12 +12,12 @@
 
 export LC_ALL=C
 export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-set -o pipefail
 
 vpn="${1}"
 vpn_action="${2}"
 vpn_service="${3}"
 vpn_iface="${4}"
+vpn_instance="${5}"
 trm_maxwait="$(uci_get travelmate global trm_maxwait "30")"
 trm_captiveurl="$(uci_get travelmate global trm_captiveurl "http://detectportal.firefox.com")"
 trm_useragent="$(uci_get travelmate global trm_useragent "Mozilla/5.0 (Linux x86_64; rv:90.0) Gecko/20100101 Firefox/90.0")"
@@ -35,40 +35,44 @@ f_net() {
 	printf "%s" "${result}"
 }
 
-vpn_status="$(ubus -S call network.interface."${vpn_iface}" status 2>/dev/null | jsonfilter -q -l1 -e '@.up')"
-if [ "${vpn}" = "1" ] && [ "${vpn_action}" = "enable" ] && [ "${vpn_status}" != "true" ]; then
-	if [ "${vpn_service}" = "openvpn" ] && [ -x "/etc/init.d/openvpn" ]; then
-		/etc/init.d/openvpn start
-	fi
-	ifup "${vpn_iface}"
-	cnt=0
-	while true; do
+if [ "${vpn}" = "1" ] && [ "${vpn_action%_*}" = "enable" ]; then
+	if [ "${vpn_action}" = "enable_keep" ]; then
 		vpn_status="$(ubus -S call network.interface."${vpn_iface}" status 2>/dev/null | jsonfilter -q -l1 -e '@.up')"
-		if [ "${vpn_status}" = "true" ]; then
-			net_status="$(f_net)"
-			if [ "${net_status}" = "net ok" ]; then
-				: >"${trm_vpnfile}"
-				"${trm_logger}" -p "info" -t "trm-vpn  [${$}]" "${vpn_service} client connection enabled" 2>/dev/null
-				break
-			fi
+	fi
+	if [ "${vpn_action}" = "enable" ] || [ "${vpn_status}" != "true" ]; then
+		if [ "${vpn_service}" = "openvpn" ] && [ -n "${vpn_instance}" ] && [ -x "/etc/init.d/openvpn" ] && ! /etc/init.d/openvpn running "${vpn_instance}"; then
+			/etc/init.d/openvpn start "${vpn_instance}"
 		fi
-		if [ "${cnt}" -ge "$((trm_maxwait / 3))" ]; then
-			ifdown "${vpn_iface}"
-			if [ "${vpn_service}" = "openvpn" ] && [ -x "/etc/init.d/openvpn" ]; then
-				/etc/init.d/openvpn stop
+		ifup "${vpn_iface}"
+		cnt=0
+		while true; do
+			vpn_status="$(ubus -S call network.interface."${vpn_iface}" status 2>/dev/null | jsonfilter -q -l1 -e '@.up')"
+			if [ "${vpn_status}" = "true" ]; then
+				net_status="$(f_net)"
+				if [ "${net_status}" = "net ok" ]; then
+					: >"${trm_vpnfile}"
+					"${trm_logger}" -p "info" -t "trm-vpn  [${$}]" "${vpn_service} client connection enabled '${vpn_iface}/${vpn_instance:-"-"}'" 2>/dev/null
+					break
+				fi
 			fi
-			rm -f "${trm_vpnfile}"
-			"${trm_logger}" -p "info" -t "trm-vpn  [${$}]" "${vpn_service} client connection can't be established" 2>/dev/null
-			exit 1
-		fi
-		sleep 1
-		cnt="$((cnt + 1))"
-	done
-elif { [ "${vpn}" != "1" ] && [ "${vpn_action}" = "enable" ]; } || [ "${vpn_action}" = "disable" ]; then
+			if [ "${cnt}" -ge "$((trm_maxwait / 3))" ]; then
+				ifdown "${vpn_iface}"
+				if [ "${vpn_service}" = "openvpn" ] && [ -n "${vpn_instance}" ] && [ -x "/etc/init.d/openvpn" ] && /etc/init.d/openvpn running "${vpn_instance}"; then
+					/etc/init.d/openvpn stop "${vpn_instance}"
+				fi
+				rm -f "${trm_vpnfile}"
+				"${trm_logger}" -p "info" -t "trm-vpn  [${$}]" "${vpn_service} client connection can't be established '${vpn_iface}/${vpn_instance:-"-"}'" 2>/dev/null
+				return 1
+			fi
+			sleep 1
+			cnt="$((cnt + 1))"
+		done
+	fi
+elif { [ "${vpn}" != "1" ] && [ "${vpn_action%_*}" = "enable" ]; } || [ "${vpn_action}" = "disable" ]; then
 	ifdown "${vpn_iface}"
-	if [ "${vpn_service}" = "openvpn" ] && [ -x "/etc/init.d/openvpn" ]; then
-		/etc/init.d/openvpn stop
+	if [ "${vpn_service}" = "openvpn" ] && [ -n "${vpn_instance}" ] && [ -x "/etc/init.d/openvpn" ] && /etc/init.d/openvpn running "${vpn_instance}"; then
+		/etc/init.d/openvpn stop "${vpn_instance}"
 	fi
 	rm -f "${trm_vpnfile}"
-	"${trm_logger}" -p "info" -t "trm-vpn  [${$}]" "${vpn_service} client connection disabled" 2>/dev/null
+	"${trm_logger}" -p "info" -t "trm-vpn  [${$}]" "${vpn_service} client connection disabled '${vpn_iface}/${vpn_instance:-"-"}'" 2>/dev/null
 fi

--- a/net/travelmate/files/travelmate_ntp.hotplug
+++ b/net/travelmate/files/travelmate_ntp.hotplug
@@ -1,6 +1,6 @@
 #!/bin/sh
 # ntp hotplug script for travelmate
-# Copyright (c) 2020-2021 Dirk Brenken (dev@brenken.org)
+# Copyright (c) 2020-2022 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
 # set (s)hellcheck exceptions

--- a/net/travelmate/files/vodafone.login
+++ b/net/travelmate/files/vodafone.login
@@ -1,6 +1,6 @@
 #!/bin/sh
 # captive portal auto-login script for vodafone hotspots (DE)
-# Copyright (c) 2021 Dirk Brenken (dev@brenken.org)
+# Copyright (c) 2021-2022 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
 # set (s)hellcheck exceptions
@@ -10,7 +10,6 @@
 
 export LC_ALL=C
 export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-set -o pipefail
 
 username="${1}"
 password="${2}"

--- a/net/travelmate/files/wifibahn.login
+++ b/net/travelmate/files/wifibahn.login
@@ -1,6 +1,6 @@
 #!/bin/sh
 # captive portal auto-login script for bahn hotspots (DE)
-# Copyright (c) 2020-2021 Dirk Brenken (dev@brenken.org)
+# Copyright (c) 2020-2022 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
 # set (s)hellcheck exceptions
@@ -10,7 +10,6 @@
 
 export LC_ALL=C
 export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-set -o pipefail
 
 trm_domain="wifi.bahn.de"
 trm_useragent="$(uci_get travelmate global trm_useragent "Mozilla/5.0 (Linux x86_64; rv:90.0) Gecko/20100101 Firefox/90.0")"


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: not relevant, script only
Run tested: GL.iNet GL-MT1300, OpenWrt SNAPSHOT r20333-a9eb5cce7e

Description:
* vpn support can be disabled (enabled by default), fixes #19107 (see trm_vpn option)
* vpn support can be limited to certain interfaces (see trm_vpnifacelist list option)
* openvpn support works now per instance (same as wireguard today)
* add an auto-login script for tplink-omada hotspots provided by Sebastian Muszynski <basti@linkt.de>
* remove pipefail command, see #19043 for reference

Signed-off-by: Dirk Brenken <dev@brenken.org>
