### PR TITLE
openocd: enable bcm2835gpio on bcm27xx

### DIFF
--- a/utils/openocd/Makefile
+++ b/utils/openocd/Makefile
@@ -73,6 +73,10 @@ CONFIGURE_ARGS += \
 	--enable-sysfsgpio \
 	--enable-linuxgpiod
 
+ifeq ($(CONFIG_TARGET_bcm27xx),y)
+	CONFIGURE_ARGS += --enable-bcm2835gpio
+endif
+
 TARGET_CFLAGS += -DRELSTR=\\\"-$(PKG_VERSION)-$(PKG_RELEASE)-OpenWrt\\\"
 
 define Build/Compile


### PR DESCRIPTION
Maintainer: @paulfertser
Compile tested: OpenWrt master r20360-832e7b8172 bcm27xx/bcm2711
Run tested: OpenWrt master r20360-832e7b8172 bcm27xx/bcm2711
