### PR TITLE
tinc: backport  from master modifications 

### DIFF
--- a/net/tinc/Makefile
+++ b/net/tinc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tinc
 PKG_VERSION:=1.1-git
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=http://tinc-vpn.org/git/tinc

--- a/net/tinc/files/tinc.init
+++ b/net/tinc/files/tinc.init
@@ -156,7 +156,7 @@ prepare_net() {
 	section_enabled "$s" || return 1
 
 	[ -d "$TMP_TINC/$s" ] && rm -rf "$TMP_TINC/$s/"
-	mkdir -p "$TMP_TINC/$s"
+	mkdir -p "$TMP_TINC/$s/hosts"
 	[ -d "/etc/tinc/$s" ] && cp -r "/etc/tinc/$s" "$TMP_TINC/"
 
 	# append flags

--- a/net/tinc/files/tinc.init
+++ b/net/tinc/files/tinc.init
@@ -61,7 +61,7 @@ append_conf_params() {
 		for v in $v; do
 			# Look up OpenWRT interface names
 			[ "$p" = "BindToInterface" ] && {
-				local ifname=$(uci -P /var/state get network.$v.ifname 2>&-)
+				local ifname=$(uci_get_state network "$v" ifname "")
 				[ -n "$ifname" ] && v="$ifname"
 			}
 


### PR DESCRIPTION

Signed-off-by: Erwan MAS <erwan@mas.nom.fr>

Maintainer: me 
Compile tested: N/A
Run tested: Linksys WRT1900ACS with 21.02.3 on mvebu/cortexa9 
Description:

backport of :
   - use 'uci_get_state' instead of 'uci -P /var/state get'  ( 440d3c04505719df09e39706e6af7c470a49d458 )
   - add creation of hosts directory for each network configuration ( fb99d50c1edd4be765bef6d55bee26bfb90576b6 )
