### PR TITLE
boost: restores patch for libboost_context for mips64

### DIFF
--- a/libs/boost/patches/010-mips1.patch
+++ b/libs/boost/patches/010-mips1.patch
@@ -1,0 +1,38 @@
+--- a/boostcpp.jam
++++ b/boostcpp.jam
+@@ -634,7 +634,7 @@ rule address-model ( )
+     return <conditional>@boostcpp.deduce-address-model ;
+ }
+ 
+-local deducable-architectures = arm mips1 power riscv s390x sparc x86 combined ;
++local deducable-architectures = arm mips power riscv s390x sparc x86 combined ;
+ feature.feature deduced-architecture : $(deducable-architectures) : propagated optional composite hidden ;
+ for a in $(deducable-architectures)
+ {
+@@ -645,10 +645,10 @@ rule deduce-architecture ( properties *
+ {
+     local result ;
+     local filtered = [ toolset-properties $(properties) ] ;
+-    local names = arm mips1 power riscv s390x sparc x86 combined ;
++    local names = arm mips power riscv s390x sparc x86 combined ;
+     local idx = [ configure.find-builds "default architecture" : $(filtered)
+         : /boost/architecture//arm
+-        : /boost/architecture//mips1
++        : /boost/architecture//mips
+         : /boost/architecture//power
+         : /boost/architecture//riscv
+         : /boost/architecture//s390x
+--- a/libs/atomic/build/atomic-arch-config.jam
++++ b/libs/atomic/build/atomic-arch-config.jam
+@@ -27,9 +27,9 @@ rule deduce-architecture ( properties *
+         {
+             return arm ;
+         }
+-        else if [ configure.builds /boost/architecture//mips1 : $(properties) : "mips1" ]
++        else if [ configure.builds /boost/architecture//mips : $(properties) : "mips" ]
+         {
+-            return mips1 ;
++            return mips ;
+         }
+         else if [ configure.builds /boost/architecture//power : $(properties) : "power" ]
+         {


### PR DESCRIPTION
Maintainer: @ClaymorePT 
Compile tested: octeonplus mips64 using musl
Run tested: N/A

Description:

This commit restores the patch for libboost_context for mips64 given
that the upstream update added in 1.80.0 does not fully fixes the issue.

Signed-off-by: Carlos Miguel Ferreira <carlosmf.pt@gmail.com>


