### PR TITLE
[22.03] django: bump to version 4.0.7

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=4.0.6
+PKG_VERSION:=4.0.7
 PKG_RELEASE:=$(AUTORELEASE)
 
 PYPI_NAME:=Django
-PKG_HASH:=a67a793ff6827fd373555537dca0da293a63a316fe34cb7f367f898ccca3c3ae
+PKG_HASH:=9c6d5ad36be798e562ddcaa6b17b1c3ff2d3c4f529a47432b69fb9a30f847461
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Peter Stadler <peter.stadler@student.uibk.ac.at>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me, @peter-stadler 
Compile tested: n/a
Run tested: n/a

Fixes: https://nvd.nist.gov/vuln/detail/CVE-2022-36359

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>