### PR TITLE
vim: variants conflict with each other

### DIFF
--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -45,12 +45,16 @@ endef
 define Package/vim-full
   $(call Package/vim/Default)
   TITLE+= (Normal)
+  PROVIDES:=vim
+  CONFLICTS:=vim
 endef
 
 
 define Package/vim-fuller
   $(call Package/vim/Default)
   TITLE+= (Big)
+  PROVIDES:=vim vim-full
+  CONFLICTS:=vim vim-full
 endef
 
 define Package/vim-runtime


### PR DESCRIPTION
Maintainer: @ratkaj 
Compile tested: N/A
Run tested: N/A

Description:

This adds conflicts between the variants,
because they provide the same files, and it should not be
possible to install them side by side. Otherwise, it might happen that
half files would be from one variant and the other half from the
other.
    
Also, adds provides as if you request to install ``vim`` and
``vim-full``, then the request could be satisfied even they collide,
because ``vim-full`` provides ``vim`` package.

Fixes: https://forum.turris.cz/t/installing-vim-fuller-breaks-automatic-updates/16720
