### PR TITLE
libgd: add conflicts to each other

### DIFF
--- a/libs/libgd/Makefile
+++ b/libs/libgd/Makefile
@@ -43,6 +43,8 @@ define Package/libgd-full
   DEPENDS+=+libtiff +libfreetype
   TITLE+=(full)
   VARIANT:=full
+  PROVIDES:=libgd
+  CONFLICTS:=libgd
 endef
 
 define Package/libgd/description/default


### PR DESCRIPTION
Maintainer: @jow- introduced by @flyn-org in https://github.com/openwrt/packages/commit/0762c72cc53c0e5504981f09d243e71674070fca
Compile tested: N/A
Run tested: N/A

The full variant should conflict with the default variant. This prevents that
libgd and libgd-full could be installed side by side, and also, the full
variant should provide the libgd. Otherwise, if you install libgd-full,
you can not install vnstat.

Fixes: https://forum.turris.cz/t/updater-okpg-collision-of-dependencies/17520/3