### PR TITLE
stress-ng: add libjpeg dep

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -27,7 +27,7 @@ define Package/stress-ng
   CATEGORY:=Utilities
   TITLE:=stress-ng is a stress test utility
   URL:=https://github.com/ColinIanKing/stress-ng
-  DEPENDS:=+zlib +libbsd +libaio +libsctp +libkmod +libatomic
+  DEPENDS:=+zlib +libbsd +libaio +libsctp +libkmod +libatomic +libjpeg
 endef
 
 define Package/stress-ng/description


### PR DESCRIPTION
Maintainer: me
Compile tested: x86  https://github.com/openwrt/openwrt/commit/beeb49740bb4f68aadf92095984a2d1f9a488956
Run tested: x86  https://github.com/openwrt/openwrt/commit/beeb49740bb4f68aadf92095984a2d1f9a488956


Fixes: https://github.com/openwrt/packages/issues/19210

If libjpeg isn't selected by another package, all is fine.
But if it is selected, the stress-ng build will see it and try to build the
jpeg stressor. This would usually fail sometime and link-time.

In any case, it's better to just pick-up libjpeg as a dependency of
stress-ng. If people want to stress their system with this tool, they can
probably expect libjpeg as well.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>