### PR TITLE
pdns-recursor: update to 4.7.2

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
-PKG_VERSION:=4.7.1
+PKG_VERSION:=4.7.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=d2f94573a6f0e63a1034ca2b301c27ebf2e1300a655ba669cc502d5ea8d6ec68
+PKG_HASH:=bdb4190790fe759778d6f0515afbbcc0a28b3e7e1b83c570caaf38419d57820d
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>
 PKG_LICENCE:=GPL-2.0-only


### PR DESCRIPTION
Signed-off-by: Peter van Dijk <peter.van.dijk@powerdns.com>

Maintainer: me
Compile tested: CI
Run tested: after CI

Description:

security update - https://doc.powerdns.com/recursor/security-advisories/powerdns-advisory-2022-02.html