### PR TITLE
python-pycares: add new package

### DIFF
--- a/lang/python/python-pycares/Makefile
+++ b/lang/python/python-pycares/Makefile
@@ -1,0 +1,38 @@
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pycares
+PKG_VERSION:=4.2.2
+PKG_RELEASE:=$(AUTORELEASE)
+
+PYPI_NAME:=pycares
+PKG_HASH:=e1f57a8004370080694bd6fb969a1ffc9171a59c6824d54f791c1b2e4d298385
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Fabian Lipken <dynasticorpheus@gmail.com>
+
+PKG_BUILD_DEPENDS:=libffi/host
+
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:=cffi  # cffi>=1.5.0
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-pycares
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Python interface for c-ares
+  URL:=https://github.com/saghul/pycares
+  DEPENDS:=+python3-light +python3-cffi
+endef
+
+define Package/python3-pycares/description
+Python interface for c-ares
+endef
+
+$(eval $(call Py3Package,python3-pycares))
+$(eval $(call BuildPackage,python3-pycares))
+$(eval $(call BuildPackage,python3-pycares-src))


### PR DESCRIPTION
Maintainer: @dynasticorpheus 

Compile / Run tested: Linksys_wrt32x, mvebu (cortex-a9), OpenWrt 22.03.0-rc6

Description: Add new package [pycares](https://pypi.org/project/pycares/)
