### PR TITLE
libssh: update to 0.10.0

### DIFF
--- a/libs/libssh/Makefile
+++ b/libs/libssh/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libssh
-PKG_VERSION:=0.9.6
+PKG_VERSION:=0.10.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://www.libssh.org/files/0.9/
-PKG_HASH:=86bcf885bd9b80466fe0e05453c58b877df61afa8ba947a58c356d7f0fab829b
+PKG_SOURCE_URL:=https://www.libssh.org/files/0.10/
+PKG_HASH:=0dc158c534cd838ad0b785a82dec586de40da7e096523ae6c08c9b7bd2af0b57
 
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
 PKG_LICENSE:=LGPL-2.1-or-later BSD-2-Clause


### PR DESCRIPTION
Release Notes:
https://www.libssh.org/2022/08/26/libssh-0-10-0/

Maintainer: @mislavn
