### PR TITLE
python-jsonschema: Update to 4.15.0

### DIFF
--- a/lang/python/python-jsonschema/Makefile
+++ b/lang/python/python-jsonschema/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-jsonschema
-PKG_VERSION:=4.15.0
+PKG_VERSION:=4.16.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=jsonschema
-PKG_HASH:=21f4979391bdceb044e502fd8e79e738c0cdfbdc8773f9a49b5769461e82fe1e
+PKG_HASH:=165059f076eff6971bae5b742fc029a7b4ef3f9bcf04c14e4776a7605de14b23
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=MIT

--- a/lang/python/python-jsonschema/Makefile
+++ b/lang/python/python-jsonschema/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-jsonschema
-PKG_VERSION:=4.9.0
+PKG_VERSION:=4.15.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=jsonschema
-PKG_HASH:=df10e65c8f3687a48e93d0d348ce0ce5f897b5a28e9bbcbbe8f7c7eaf019e850
+PKG_HASH:=21f4979391bdceb044e502fd8e79e738c0cdfbdc8773f9a49b5769461e82fe1e
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=MIT

--- a/lang/python/python-jsonschema/patches/001-setup.patch
+++ b/lang/python/python-jsonschema/patches/001-setup.patch
@@ -3,3 +3,102 @@
 @@ -0,0 +1,2 @@
 +from setuptools import setup
 +setup(use_scm_version=True)
+--- /dev/null
++++ b/setup.cfg
+@@ -0,0 +1,96 @@
++[metadata]
++name = jsonschema
++url = https://github.com/python-jsonschema/jsonschema
++project_urls = 
++	Funding = https://github.com/sponsors/Julian
++	Tidelift = https://tidelift.com/subscription/pkg/pypi-jsonschema?utm_source=pypi-jsonschema&utm_medium=referral&utm_campaign=pypi-link
++	Documentation = https://python-jsonschema.readthedocs.io/
++	Changelog = https://github.com/python-jsonschema/jsonschema/blob/main/CHANGELOG.rst
++	Source = https://github.com/python-jsonschema/jsonschema
++	Issues = https://github.com/python-jsonschema/jsonschema/issues/
++description = An implementation of JSON Schema validation for Python
++long_description = file: README.rst
++long_description_content_type = text/x-rst
++author = Julian Berman
++author_email = Julian+jsonschema@GrayVines.com
++license = MIT
++classifiers = 
++	Development Status :: 5 - Production/Stable
++	Intended Audience :: Developers
++	License :: OSI Approved :: MIT License
++	Operating System :: OS Independent
++	Programming Language :: Python
++	Programming Language :: Python :: 3.7
++	Programming Language :: Python :: 3.8
++	Programming Language :: Python :: 3.9
++	Programming Language :: Python :: 3.10
++	Programming Language :: Python :: 3.11
++	Programming Language :: Python :: Implementation :: CPython
++	Programming Language :: Python :: Implementation :: PyPy
++
++[options]
++packages = find:
++python_requires = >=3.7
++install_requires = 
++	attrs>=17.4.0
++	importlib_metadata;python_version<'3.8'
++	importlib_resources>=1.4.0;python_version<'3.9'
++	pyrsistent>=0.14.0,!=0.17.0,!=0.17.1,!=0.17.2
++	typing_extensions;python_version<'3.8'
++
++[options.extras_require]
++format = 
++	fqdn
++	idna
++	isoduration
++	jsonpointer>1.13
++	rfc3339-validator
++	rfc3987
++	uri_template
++	webcolors>=1.11
++format_nongpl = 
++	fqdn
++	idna
++	isoduration
++	jsonpointer>1.13
++	rfc3339-validator
++	rfc3986-validator>0.1.0
++	uri_template
++	webcolors>=1.11
++
++[options.entry_points]
++console_scripts = 
++	jsonschema = jsonschema.cli:main
++
++[options.package_data]
++jsonschema = schemas/*.json, schemas/*/*.json
++
++[flake8]
++ban-relative-imports = true
++inline-quotes = "
++exclude = 
++	jsonschema/__init__.py
++	jsonschema/_reflect.py
++ignore = 
++	B008,  # Barring function calls in default args. Ha, no.
++	B306,  # See https://github.com/PyCQA/flake8-bugbear/issues/131
++	W503,  # (flake8 default) old PEP8 boolean operator line breaks
++
++[mypy]
++ignore_missing_imports = true
++
++[pydocstyle]
++match = (?!(test_|_|compat|cli)).*\.py  # see PyCQA/pydocstyle#323
++add-select = 
++	D410, # Trailing whitespace plz
++add-ignore = 
++	D107,  # Hah, no
++	D200,  # 1-line docstrings don't need to be on one line
++	D202,  # One line is fine.
++	D412,  # Trailing whitespace plz
++	D413,  # No trailing whitespace plz
++
++[egg_info]
++tag_build = 
++tag_date = 0
++


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream [release](https://github.com/python-jsonschema/jsonschema/releases).