### PR TITLE
docker-compose: Update to version 2.10.2

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.9.0
+PKG_VERSION:=2.10.2
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=582f3dacb3e96e9a07ff3b9d137b508377a769309b84f6faa8722d7f5a226353
+PKG_HASH:=74c86d544fcfb80bb2d3b58187bd017adb0e62863d22114a66c14fc94fdbc421
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream [release](https://github.com/docker/compose/releases).
Third one in a few hours.