### PR TITLE
microsocks: add low resource SOCKS5 TCP/IP only proxy server

### DIFF
--- a/net/microsocks/Makefile
+++ b/net/microsocks/Makefile
@@ -1,0 +1,46 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=microsocks
+PKG_VERSION:=1.0.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/rofl0r/microsocks/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=6801559b6f8e17240ed8eef17a36eea8643412b5a7476980fd4e24b02a021b82
+
+PKG_MAINTAINER:=Mateusz Korniak <matkorgithubcom@ant.gliwice.pl>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/microsocks
+  SECTION:=net
+  SUBMENU:=Web Servers/Proxies
+  CATEGORY:=Network
+  TITLE:=SOCKS5 TCP/IP only proxy
+endef
+
+define Package/microsocks/description
+  Low resource SOCKS5 proxy.
+  Supports only SOCKS5 protocol and forwarding only TCP/IP connections.
+endef
+
+define Package/microsocks/conffiles
+/etc/config/microsocks
+endef
+
+TARGET_CFLAGS+= -flto
+TARGET_LDFLAGS+= -flto -Wl,--gc-sections,--as-needed
+
+define Package/microsocks/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/microsocks $(1)/usr/bin
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/microsocks.config $(1)/etc/config/microsocks
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/microsocks.init $(1)/etc/init.d/microsocks
+endef
+
+$(eval $(call BuildPackage,microsocks))

--- a/net/microsocks/files/microsocks.config
+++ b/net/microsocks/files/microsocks.config
@@ -1,0 +1,9 @@
+
+config microsocks 'config'
+	option enabled '0'
+	option bindaddr ''
+	option listenip '127.0.0.1'
+	option port '1080'
+	option user ''
+	option password ''
+	option auth_once '0' # Boolean, must be used together with user/pass

--- a/net/microsocks/files/microsocks.init
+++ b/net/microsocks/files/microsocks.init
@@ -1,0 +1,54 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=95
+
+CONF="microsocks"
+
+start_service() {
+	config_load "$CONF"
+    
+	local _enabled
+	config_get_bool _enabled "config" "enabled" "0"
+	[ "$_enabled" -eq "1" ] || return 1
+    
+    	local _port
+	local _listenip
+	local _bindaddr
+	local _user
+	local _format
+	local _auth_once
+
+	config_get _port "config" "port"
+	config_get _listenip "config" "listenip"
+	config_get _bindaddr "config" "bindaddr"
+	config_get _user "config" "user"
+	config_get _password "config" "password"
+	config_get_bool _auth_once "config" "auth_once" 0
+    
+	procd_open_instance "$CONF"
+	procd_set_param command /usr/bin/microsocks
+	[ -z "$_port" ] || procd_append_param command -p "${_port}"
+	[ -z "$_listenip" ] || procd_append_param command -i "${_listenip}"
+	[ -z "$_bindaddr" ] || procd_append_param command -b "${_bindaddr}"
+	[ -z "$_user" ] || procd_append_param command -u "${_user}"
+	[ -z "$_password" ] || procd_append_param command -P "${_password}"
+	[ "$_auth_once" -eq "0" ] || procd_append_param command -1
+	
+	procd_set_param respawn
+	procd_set_param stderr 1
+	# TODO: Make it dependable on some verbose/debug config setting?
+	# procd_set_param stdout 1
+    
+	procd_close_instance
+}
+
+
+reload_service() {
+	stop
+	start
+}
+
+service_triggers() { 
+	procd_add_reload_trigger "$CONF" 
+}


### PR DESCRIPTION
Initial version 1.0.3

Signed-off-by: Mateusz Korniak <matkorgithubcom@ant.gliwice.pl>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: mipsel_24kc, Ubuntu
Run tested: mipsel_24kc , Netgear WAC104, OpenWrt 21.02.3 r16554-1d4dea6d4f / LuCI openwrt-21.02 branch git-22.083.69138-0a0ce2a
Tested on production load for few weeks now, without issues.

Description:
Tiny TCP/IP only, SOCKS5 only proxy server.

Note: PR contains all changes from older PR https://github.com/openwrt/packages/pull/18999
