### PR TITLE
libssh: update to 0.10.2

### DIFF
--- a/libs/libssh/Makefile
+++ b/libs/libssh/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libssh
-PKG_VERSION:=0.10.0
+PKG_VERSION:=0.10.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.libssh.org/files/0.10/
-PKG_HASH:=0dc158c534cd838ad0b785a82dec586de40da7e096523ae6c08c9b7bd2af0b57
+PKG_HASH:=15b83d7b74c8c67f758fb32faf1d9a35d5f8f50db523276a419e9876530f098a
 
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
 PKG_LICENSE:=LGPL-2.1-or-later BSD-2-Clause


### PR DESCRIPTION
Release notes:
https://www.libssh.org/2022/09/02/libssh-0-10-2/

Maintainer: @mislavn (but is not responding?)
Compile tested: CI
Run tested: no
