### PR TITLE
[openwrt-22.03] dnsproxy: Update to 0.44.0

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.43.1
+PKG_VERSION:=0.44.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2e69c1bd610727acdf24a37010fac3d1dfd6bf66527552b3221d22cc11d51296
+PKG_HASH:=a9617296fe668296d121baa266bd6beba5582834fce3bf9375d084de683cd664
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: mediatek/mt7622
Run tested: redmi ax6s

Description:
- Backported from: #19300
