### PR TITLE
memcached: update to 1.6.17

### DIFF
--- a/net/memcached/Makefile
+++ b/net/memcached/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=memcached
-PKG_VERSION:=1.6.15
+PKG_VERSION:=1.6.17
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://memcached.org/files
-PKG_HASH:=8d7abe3d649378edbba16f42ef1d66ca3f2ac075f2eb97145ce164388e6ed515
+PKG_HASH:=2055e373613d8fc21529aff9f0adce3e23b9ce01ba0478d30e7941d9f2bd1224
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Update to latest version.

Release Notes:
- 1.6.16: https://github.com/memcached/memcached/wiki/ReleaseNotes1616
- 1.6.17: https://github.com/memcached/memcached/wiki/ReleaseNotes1617

Maintainer: @heil
Compile tested: ipq40xx
Run tested: mikrotik sxtsq 5ac
