### PR TITLE
nlbwmon: add init.d shutdown to preserve state on shutdown/reboot

### DIFF
--- a/net/nlbwmon/files/nlbwmon.init
+++ b/net/nlbwmon/files/nlbwmon.init
@@ -1,6 +1,7 @@
 #!/bin/sh /etc/rc.common
 
 START=60
+STOP=89
 
 USE_PROCD=1
 NAME=nlbwmon
@@ -104,5 +105,10 @@ service_triggers() {
 
 	config_load dhcp
 	config_foreach add_interface_trigger dhcp
+}
+
+shutdown() {
+	stop
+	sleep 1
 }
 


### PR DESCRIPTION
Signed-off-by: Chad Fraleigh <chadf@triularity.org>

Maintainer: @jow-

Run tested: ramips-mt7620, Wavlink WL-WN530HG4, OpenWrt 21.02.3 r16554-1d4dea6d4f / LuCI openwrt-21.02 branch git-22.167.28411-ee8170b,
 - Dropped in new /etc/init.d/nlbwmon,
 - Ran: /etc/init.d/nlbwmon enable
 - Did init.d stop & start, and system reboot.

Description:
State information since last commit interval is not saved during
shutdown/reboot.

By default the database directory is mounted on a tmpfs filesystem,
but becomes an issue when using a persistent directory.

Added to init.d stop sequence and included sleep to allow dying process
time to write state before filesystems are unmounted.

Notes:
There is still a small window of potential lost data between stopping of this service and stopping of the network. Since network stop and umount both run at step 90, there is no predictable opportunity to save state after the network has stopped but while the filesystems are available. /etc/init.d/network would need to be moved to stop step 88 or earlier to fix that.