### PR TITLE
boinc: run the executable in ujail

### DIFF
--- a/net/boinc/Makefile
+++ b/net/boinc/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boinc
 PKG_VERSION:=7.16.16
 PKG_VERSION_SHORT:=$(shell echo $(PKG_VERSION)| cut -f1,2 -d.)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_DATE:=2020-02-25
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/boinc/files/boinc-client.init
+++ b/net/boinc/files/boinc-client.init
@@ -4,7 +4,7 @@ START=99
 USE_PROCD=1
 
 BOINCEXE_NAME=boinc_client
-BOINCDIR=/opt/boinc/
+BOINCDIR=/opt/boinc
 PRESETDIR=/usr/share/boinc
 BOINCUSR=boinc
 BOINCEXE_OPTS="--check_all_logins --redirectio --dir $BOINCDIR"
@@ -41,13 +41,20 @@ start_service() {
    # now use procd to start boinc
    procd_open_instance $BOINCEXE_NAME
 
-   procd_set_param command $BOINCEXE_NAME
+   procd_set_param command $(which $BOINCEXE_NAME)
    procd_append_param command $BOINCEXE_OPTS
    procd_set_param user $BOINCUSR
    procd_set_param limits core="unlimited"
    procd_set_param stdout 1
    procd_set_param stderr 1
    procd_set_param pidfile $PID_FILE
+
+   procd_add_jail $BOINCEXE_NAME log requirejail
+   procd_add_jail_mount /etc/TZ
+   procd_add_jail_mount /proc/cpuinfo /proc/meminfo
+   procd_add_jail_mount /etc/ssl/certs/ca-certificates.crt
+   procd_add_jail_mount $PRESETDIR
+   procd_add_jail_mount_rw $BOINCDIR
 
    procd_close_instance
 }


### PR DESCRIPTION
Maintainer:  @N30dG
Compile tested: x86_64
Run tested: x86_64

The boinc app is running as root, yet downloads pre-compiled binaries from external sources. It is safer to run in a jail.

Signed-off-by: Marc Benoit <marcb62185@gmail.com>
