### PR TITLE
open-vm-tools: enable clone customization

### DIFF
--- a/libs/libmspack/Makefile
+++ b/libs/libmspack/Makefile
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2021 TDT AG <development@tdt.de>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See https://www.gnu.org/licenses/gpl-2.0.txt for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libmspack
+PKG_VERSION:=0.10.1alpha
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://www.cabextract.org.uk/$(PKG_NAME)/
+PKG_HASH:=bac862dee6e0fc10d92c70212441d9f8ad9b0222edc9a708c3ead4adb1b24a8e
+
+PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=COPYING.LIB
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libmspack
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Compressors and decompressors for Microsoft formats
+  DEPENDS:=@TARGET_x86
+  URL:=https://github.com/kyz/libmspack
+endef
+
+define Package/libmspack/description
+  The purpose of libmspack is to provide compressors and decompressors,
+  archivers and dearchivers for Microsoft compression formats: CAB, CHM, WIM,
+  LIT, HLP, KWAJ and SZDD. It is also designed to be easily embeddable,
+  stable, robust and resource-efficient.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/mspack.h \
+		$(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc \
+		$(1)/usr/lib/pkgconfig
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* \
+		$(1)/usr/lib
+endef
+
+define Package/libmspack/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* \
+		$(1)/usr/lib
+endef
+
+$(eval $(call BuildPackage,libmspack))

--- a/utils/open-vm-tools/Makefile
+++ b/utils/open-vm-tools/Makefile
@@ -35,7 +35,11 @@ endef
 
 define Package/open-vm-tools
 $(call Package/open-vm-tools/Default)
-  DEPENDS:=@TARGET_x86 +glib2 +libpthread +libtirpc
+  DEPENDS:=@TARGET_x86 \
+	+glib2 \
+	+libpthread \
+	+libtirpc \
+	+libmspack
   TITLE:=open-vm-tools
   URL:=https://github.com/vmware/open-vm-tools
   MAINTAINER:=Yuhei OKAWA <tochiro.srchack@gmail.com>
@@ -68,7 +72,6 @@ CONFIGURE_ARGS+= \
 	--without-pam \
 	--disable-grabbitmqproxy \
 	--disable-vgauth \
-	--disable-deploypkg \
 	--without-root-privileges \
 	--without-kernel-modules \
 	--without-dnet \
@@ -105,11 +108,13 @@ define Package/open-vm-tools/install
 
 	$(INSTALL_DIR) $(1)/sbin/
 	$(INSTALL_BIN) ./files/shutdown $(1)/sbin/
+	$(INSTALL_BIN) ./files/telinit $(1)/sbin/
 
 	$(INSTALL_DIR) $(1)/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libguestlib.so* $(1)/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libhgfs.so* $(1)/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libvmtools.so* $(1)/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libDeployPkg.so* $(1)/lib/
 
 	$(INSTALL_DIR) $(1)/usr/lib/open-vm-tools/plugins/common/
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/open-vm-tools/plugins/common/libhgfsServer.so $(1)/usr/lib/open-vm-tools/plugins/common/
@@ -120,6 +125,7 @@ define Package/open-vm-tools/install
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/open-vm-tools/plugins/vmsvc/libpowerOps.so $(1)/usr/lib/open-vm-tools/plugins/vmsvc/
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/open-vm-tools/plugins/vmsvc/libtimeSync.so $(1)/usr/lib/open-vm-tools/plugins/vmsvc/
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/open-vm-tools/plugins/vmsvc/libvmbackup.so $(1)/usr/lib/open-vm-tools/plugins/vmsvc/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/open-vm-tools/plugins/vmsvc/libdeployPkgPlugin.so $(1)/usr/lib/open-vm-tools/plugins/vmsvc/
 
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/block/
 	$(INSTALL_BIN) ./files/vmware-scsi.hotplug $(1)/etc/hotplug.d/block/80-vmware-scsi

--- a/utils/open-vm-tools/Makefile
+++ b/utils/open-vm-tools/Makefile
@@ -39,7 +39,8 @@ $(call Package/open-vm-tools/Default)
 	+glib2 \
 	+libpthread \
 	+libtirpc \
-	+libmspack
+	+libmspack \
+	+libdnet
   TITLE:=open-vm-tools
   URL:=https://github.com/vmware/open-vm-tools
   MAINTAINER:=Yuhei OKAWA <tochiro.srchack@gmail.com>
@@ -74,7 +75,6 @@ CONFIGURE_ARGS+= \
 	--disable-vgauth \
 	--without-root-privileges \
 	--without-kernel-modules \
-	--without-dnet \
 	--with-tirpc \
 	--without-x \
 	--without-gtk2 \

--- a/utils/open-vm-tools/files/telinit
+++ b/utils/open-vm-tools/files/telinit
@@ -1,0 +1,4 @@
+#!/bin/sh
+#compatibility script for traditional customization
+
+/sbin/reboot

--- a/utils/open-vm-tools/files/tools.conf
+++ b/utils/open-vm-tools/files/tools.conf
@@ -1,2 +1,9 @@
 [guestinfo]
 disable-perf-mon=1
+
+[logging]
+log=true
+vmtoolsd.level=debug
+vmsvc.level=debug
+vmusr.level=debug
+toolboxcmd.level=debug


### PR DESCRIPTION
Maintainer: @neheb  @srchack
Compile tested: x86_64, VMware-Image, OpenWrt latest master
Run tested: x86_64, VMware-Image, OpenWrt latest master

Description:
VMware offers the option of creating machines as templates and then cloning them.
In order for this to work with an OpenWrt Image, the cloned system must be customizable to set the for example the following options.
- Hostname
- IP

For this to work the open-vm-tools in OpenWrt must first support it.
This pullrequest enables the necessary compilation options and also adds the necessary lib dependencies.

In addition, the Perl script on the VMware-ESXi must be extended so that it also recognizes the OpenWrt distribution.
For this I have patched the perl script on the ESXi that works with my setup.

Patches:
[0001-OpenWrt-add-customization.txt](https://github.com/openwrt/packages/files/9490091/0001-OpenWrt-add-customization.txt)
[0002-scripts-synced-with-latest-vcenter-6.7-version.txt](https://github.com/openwrt/packages/files/9490090/0002-scripts-synced-with-latest-vcenter-6.7-version.txt)

I am using VMware `version 6.7.0.53000`


