### PR TITLE
collectd: extend network uci plugin

### DIFF
--- a/utils/collectd/files/collectd.init
+++ b/utils/collectd/files/collectd.init
@@ -153,11 +153,58 @@ process_network() {
 	printf "</Plugin>\n\n" >> "$COLLECTD_CONF"
 }
 
+process_network_server() {
+	local cfg="$1"
+	local SecurityLevel="$2"
+
+	local Username Password ResolveInterval
+
+	config_get Username "$cfg" Username
+	[ -z "$Username" ] && {
+		$LOG notice "SecurityLevel set to '$SecurityLevel' but no option Username found in config '$cfg'"
+		return 1
+	}
+	printf "\\t\\tUsername \"%s\"\n" "${Username}" >> "$COLLECTD_CONF"
+
+	config_get Password "$cfg" Password
+	[ -z "$Password" ] && {
+		$LOG notice "SecurityLevel set to '$SecurityLevel' but no option Password found in config '$cfg'"
+		return 2
+	}
+	printf "\\t\\tPassword \"%s\"\n" "${Password}" >> "$COLLECTD_CONF"
+
+	config_get ResolveInterval "$cfg" ResolveInterval
+	[ -z "$ResolveInterval" ] || {
+		printf "\\t\\tResolveInterval \"%s\"\n" "${ResolveInterval}" >> "$COLLECTD_CONF"
+	}
+}
+
+process_network_listen() {
+	local cfg="$1"
+
+	local auth_file="/tmp/collectd-auth-${cfg}.conf"
+	local auth_set
+
+	rm -rf "${auth_file}"
+	add_auth() {
+		echo "$1" >> "${auth_file}"
+		auth_set=1
+	}
+	config_list_foreach "$cfg" auth add_auth
+
+	[ -z "$auth_set" ] && {
+		$LOG notice "SecurityLevel set to '$SecurityLevel' but no list option auth found in config '$cfg'"
+		return 1
+	}
+
+	printf "\\t\\tAuthFile \"%s\"\n" "${auth_file}" >> "$COLLECTD_CONF"
+}
+
 process_network_sections() {
 	local cfg="$1"
 	local section="$2"
 
-	local host port output
+	local host port output rvalue SecurityLevel Interface
 
 	config_get host "$cfg" host
 	[ -z "$host" ] && {
@@ -173,9 +220,42 @@ process_network_sections() {
 
 	config_get port "$cfg" port
 	if [ -z "$port" ]; then
-		printf "\\t%s\n" "${output}" >> "$COLLECTD_CONF"
+		printf "\\t<%s>\n" "${output}" >> "$COLLECTD_CONF"
 	else
-		printf "\\t%s \"%s\"\n" "${output}" "${port}" >> "$COLLECTD_CONF"
+		printf "\\t<%s \"%s\">\n" "${output}" "${port}" >> "$COLLECTD_CONF"
+	fi
+
+	config_get SecurityLevel "$cfg" SecurityLevel 'None'
+	[ -z "$SecurityLevel" ] || {
+		printf "\\t\\tSecurityLevel \"%s\"\n" "${SecurityLevel}" >> "$COLLECTD_CONF"
+	}
+
+	if [ "$SecurityLevel" != "None" ]; then
+		case "$section" in
+			server)
+				process_network_server "$cfg" "$SecurityLevel"
+				rvalue="$?"
+				[ "$rvalue" != 0 ] && return 0
+				;;
+			listen)
+				process_network_listen "$cfg" "$SecurityLevel"
+				rvalue="$?"
+				[ "$rvalue" != 0 ] && return 0
+				;;
+		esac
+	else
+		$LOG notice "SecurityLevel set to 'None' for '$cfg'"
+	fi
+
+	config_get Interface "$cfg" Interface
+	[ -z "$Interface" ] || {
+		printf "\\t\\tInterface \"%s\"\n" "${Interface}" >> "$COLLECTD_CONF"
+	}
+
+	if [ "$section" = "server" ]; then
+		printf "\\t</Server>\n" >> "$COLLECTD_CONF"
+	else
+		printf "\\t</Listen>\n" >> "$COLLECTD_CONF"
 	fi
 }
 


### PR DESCRIPTION
Maintainer: @hnyman 
Compile tested: not needed, script changes
Run tested: x86_64, APU3, OpenWrt lastest

Description:

The network plugin from collectd also has the option to encrypt the
metrics when sending them to another server. Until now, this was not
possible via the UCI. This commit adds that feature.

Tests:

I have set up a telegraf server with the required encryption and configurred the collectd via uci to send the data in encrypted form.
**UCI-Config:**
```
config network_server
        option host '172.16.2.250'
        option port '25826'
        option SecurityLevel 'Encrypt'
        option Username 'VR2-106149'
        option Password 'Ahchae4w'
```
**Collectd-output:**
```
<Plugin network>
        <Server "172.16.2.250" "25826">
                SecurityLevel "Encrypt"
                Username "VR2-106149"
                Password "Ahchae4w"
        </Server>
        Forward true
</Plugin>
```

I have not tested the encrypted reception.
However, I have generated a collectd config from the following uci config.

**UCI-Config:**
```
config network_listen
        option host '192.168.0.53'
        option port '25826'
        option SecurityLevel 'Encrypted'
        list auth 'user0: 1234'
        list auth 'user1: 3456'
```

**Collectd-output:**
```
<Plugin network>
        <Listen "192.168.0.53" "25826">
                SecurityLevel "Encrypt"
                AuthFile "/tmp/collectd-auth-cfg090ebd.conf"
        </Listen>
        <Server "172.16.2.250" "25826">
                SecurityLevel "Encrypt"
                Username "VR2-106149"
                Password "Ahchae4w"
        </Server>
        Forward true
</Plugin>
```

**Auth-File:**
```
root@VR2-106149 ~ # cat /tmp/collectd-auth-cfg090ebd.conf
user0: 1234
user1: 3456
```