### PR TITLE
nextdns: initialize nextdns from /etc/uci-defaults

### DIFF
--- a/net/nextdns/Makefile
+++ b/net/nextdns/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nextdns
 PKG_VERSION:=1.37.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=nextdns-$(PKG_VERSION).tar.gz
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
@@ -50,13 +50,9 @@ define Package/nextdns/install
 
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nextdns.config $(1)/etc/config/nextdns
-endef
 
-define Package/nextdns/postinst
-#!/bin/sh
-if [ -z "$${IPKG_INSTROOT}" ]; then
-  nextdns install
-fi
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/nextdns.defaults $(1)/etc/uci-defaults/nextdns
 endef
 
 define Package/nextdns/prerm

--- a/net/nextdns/files/nextdns.defaults
+++ b/net/nextdns/files/nextdns.defaults
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+/usr/sbin/nextdns install
+# opkg automatically enables each service, but not image builder,
+#   so enable it here to cover both cases
+/etc/init.d/nextdns enable
+
+exit 0


### PR DESCRIPTION
Maintainer: @rs 

When nextdns is prepackaged into firmware, the post install section does not run. This PR moves that logic into /etc/uci-defaults/nextdns to cover both cases.

The same as https://github.com/openwrt/packages/pull/19045 , but addresses the comments in the original MR.

Signed-off-by: Marc Benoit <marcb62185@gmail.com>

