### PR TITLE
miniupnpd: rework firewall4 integration

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -11,10 +11,12 @@ PKG_NAME:=miniupnpd
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/miniupnp/miniupnp.git
-PKG_SOURCE_DATE:=2022-08-06
-PKG_SOURCE_VERSION:=fa42d8f9316bf9c1ca14317e5a6e0d4a21365629
-PKG_MIRROR_HASH:=06662c7cf8f553f625cd968d12ea732db4193706510ed0db6e8bdd1c6b935c50
+PKG_SOURCE_DATE:=2022-08-31
+PKG_SOURCE_VERSION:=68c8ec508a421f4f4af67a63e3eb6f497d2531e1
+PKG_MIRROR_HASH:=68a3170ec73149c4cf4855b1ce6e031557cc12bff85a58421bb94785daaf225d
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)/miniupnpd
+
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=BSD-3-Clause
@@ -113,6 +115,12 @@ endef
 
 define Package/miniupnpd-nftables/install
 	$(call Package/miniupnpd/install/Default,$1)
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DIR) $(1)/usr/share/miniupnpd
+	$(INSTALL_BIN) ./files/miniupnpd.defaults.nftables $(1)/etc/uci-defaults/99-miniupnpd
+	$(INSTALL_DATA) ./files/firewall4.include $(1)/usr/share/miniupnpd/firewall.include
+	$(INSTALL_DIR) $(1)/usr/share/nftables.d
+	$(CP) ./files/nftables.d/* $(1)/usr/share/nftables.d/
 endef
 
 $(eval $(call BuildPackage,miniupnpd-iptables))

--- a/net/miniupnpd/files/firewall4.include
+++ b/net/miniupnpd/files/firewall4.include
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+/etc/init.d/miniupnpd enabled && /etc/init.d/miniupnpd restart
+exit 0

--- a/net/miniupnpd/files/miniupnpd.defaults.nftables
+++ b/net/miniupnpd/files/miniupnpd.defaults.nftables
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+uci -q batch <<-EOT
+	delete firewall.miniupnpd
+	set firewall.miniupnpd=include
+	set firewall.miniupnpd.type=script
+	set firewall.miniupnpd.path=/usr/share/miniupnpd/firewall.include
+	commit firewall
+EOT
+
+exit 0

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -172,13 +172,13 @@ upnpd() {
 
 		config_foreach conf_rule_add perm_rule
 
-		if [ "Z$FW" = "Zfw4" ]; then
+		if [ "$FW" = "fw4" ]; then
 			#When using nftables configure miniupnpd to use its own table and chains
-			echo "upnp_table_name=miniupnpd"
-			echo "upnp_nat_table_name=miniupnpd"
-			echo "upnp_forward_chain=forward"
-			echo "upnp_nat_chain=prerouting"
-			echo "upnp_nat_postrouting_chain=postrouting"
+			echo "upnp_table_name=fw4"
+			echo "upnp_nat_table_name=fw4"
+			echo "upnp_forward_chain=upnp_forward"
+			echo "upnp_nat_chain=upnp_prerouting"
+			echo "upnp_nat_postrouting_chain=upnp_postrouting"
 		fi
 
 		} > "$tmpconf"
@@ -186,20 +186,17 @@ upnpd() {
 
 	if [ -n "$ifname" ]; then
 		# start firewall
-		if [ "Z$FW" = "Zfw4" ]; then
-			#Add a miniupnpd table so that when fw4 reloads port-forwadings aren't lost, also give it priority so that port-forwards are considered before standard firewall rules
-			nft add table inet miniupnpd
-			nft add chain inet miniupnpd forward { type filter hook forward priority -20 \; policy accept \; comment \"Miniupnpd forwarding table\" \; }
-			nft add chain inet miniupnpd prerouting { type nat hook prerouting priority dstnat -20 \; policy accept \; comment \"Miniupnpd prerouting table\" \; }
-			nft add chain inet miniupnpd postrouting { type nat hook postrouting priority srcnat -20 \; policy accept \; comment \"Miniupnpd postrouting table\" \; }
+		if [ "$FW" = "fw4" ]; then
+			nft -s -t -n list chain inet fw4 upnp_forward >/dev/null 2>&1 || fw4 reload
 		else
-			iptables -L MINIUPNPD >/dev/null 2>&1 || fw3 reload			
+			iptables -L MINIUPNPD >/dev/null 2>&1 || fw3 reload
 		fi
 	else
 		logger -t "upnp daemon" "external interface not found, not starting"
 	fi
 
 	procd_open_instance
+	procd_set_param file "$conf" "/etc/config/firewall"
 	procd_set_param command "$PROG"
 	procd_append_param command -f "$conf"
 	[ "$log_output" = "1" ] && procd_append_param command -d
@@ -207,14 +204,15 @@ upnpd() {
 }
 
 stop_service() {
-	if [ "Z$FW" = "Zfw3" ]; then
+	if [ "$FW" = "fw3" ]; then
 		iptables -t nat -F MINIUPNPD 2>/dev/null
 		iptables -t nat -F MINIUPNPD-POSTROUTING 2>/dev/null
 		iptables -t filter -F MINIUPNPD 2>/dev/null
 		[ -x /usr/sbin/ip6tables ] && ip6tables -t filter -F MINIUPNPD 2>/dev/null
 	else
-		#delete the table removing port-forwardings when exiting
-		nft delete table inet miniupnpd
+		nft flush chain inet fw4 upnp_forward 2>/dev/null
+		nft flush chain inet fw4 upnp_prerouting 2>/dev/null
+		nft flush chain inet fw4 upnp_postrouting 2>/dev/null
 	fi
 }
 

--- a/net/miniupnpd/files/nftables.d/chain-post/dstnat/20-miniupnpd.nft
+++ b/net/miniupnpd/files/nftables.d/chain-post/dstnat/20-miniupnpd.nft
@@ -1,0 +1,1 @@
+jump upnp_prerouting comment "Hook into miniupnpd prerouting chain";

--- a/net/miniupnpd/files/nftables.d/chain-post/forward/20-miniupnpd.nft
+++ b/net/miniupnpd/files/nftables.d/chain-post/forward/20-miniupnpd.nft
@@ -1,0 +1,1 @@
+jump upnp_forward comment "Hook into miniupnpd forwarding chain";

--- a/net/miniupnpd/files/nftables.d/chain-post/srcnat/20-miniupnpd.nft
+++ b/net/miniupnpd/files/nftables.d/chain-post/srcnat/20-miniupnpd.nft
@@ -1,0 +1,1 @@
+jump upnp_postrouting comment "Hook into miniupnpd postrouting chain";

--- a/net/miniupnpd/files/nftables.d/table-post/20-miniupnpd.nft
+++ b/net/miniupnpd/files/nftables.d/table-post/20-miniupnpd.nft
@@ -1,0 +1,3 @@
+chain upnp_forward {}
+chain upnp_prerouting {}
+chain upnp_postrouting {}


### PR DESCRIPTION
Maintainer: currently unassigned
Compile tested: r20484+1-6790e1a892 x86/64 QEMU, r20484+1-6790e1a892 mt7621 er-x
Run tested: mt7621, er-x

Description from the commit:

 - Bump to the latest Git version in order to increase the package version
   for simpler opkg upgrade of the broken version

 - (Re-)Introduce PKG_RELEASE into the package, omitting it may lead to
   opkg segmentation faults under certain circumstances

 - Utilize automatic include hooks to drop the isolated miniupnpd table
   in favor to chains within the main inet fw4 table, otherwise PCP is
   unreliable as the upnp table might accept traffic which is later
   rejected by fw4

 - Install a fw4 script hook to restart miniupnpd on fw4 restarts and
   reloads in order to repopulate the upnp chains with forward rules

 - Register the used miniupnpd configuration file and the firewall uci
   configuration as change sources, otherwise `/etc/init.d/miniupnpd reload`
   has no effect if the firewall or upnpd config was changed


Discussion:

While using a separate nft table is cleaner in theory, it has a number of practical issues, mainly the fact that `ACCEPT` verdicts for flows are not carried over from one table to another. This means that when the upnp table accepts certain traffic, e.g. due to
PCP staged rules or uPNP port forwards, the traffic might still end up getting dropped by generic fw4 policies. One solution proposal for this was making fw4 unconditionally accept flows whose related conntrack is in DNAT state, but that would only solve uPNP port forward cases, not PCP forward allow rules that do not involve any DNAT or SNAT.

Another consideration is that `fw4 restart` might change its behavior to flush the *entire* ruleset and not just the fw4 table in the future, in which case we would need to re-introduce rule-restoration logic anyway, regardless of a potentially separate upnp table.

Due to this, I decided to rework the firewall integration approach to mostly mirror what we did with iptables in the past, but using
modern include facilities provided by fw4 - means the chain declarations and jump rules are static nft snippets which we include into appropriate places of the ruleset. What remains in the script include is a simple restart of the miniupnpd service to ensure
that firewall reloads or restarts lead to a reinitialization of the miniupnpd service and the restoration of nft rules from the leasefile.