### PR TITLE
keepalived: add status rpc and service improvement

### DIFF
--- a/net/keepalived/Config.in
+++ b/net/keepalived/Config.in
@@ -130,14 +130,6 @@ config KEEPALIVED_DBUS
 	help
 		Builds support for using DBus with VRRP
 
-config KEEPALIVED_JSON
-	depends on KEEPALIVED_VRRP
-	bool
-	default n
-	prompt "Enable JSON support with VRRP"
-	help
-		Builds support for using JSON output for VRRP
-
 config KEEPALIVED_VRRP_AUTH
 	depends on KEEPALIVED_VRRP
 	bool

--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -33,7 +33,6 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_KEEPALIVED_SNMP_RFC3 \
 	CONFIG_KEEPALIVED_SNMP_REPLY_V3_FOR_V2 \
 	CONFIG_KEEPALIVED_DBUS \
-	CONFIG_KEEPALIVED_JSON \
 	CONFIG_KEEPALIVED_ROUTES \
 	CONFIG_IPV6
 
@@ -58,6 +57,8 @@ define Package/keepalived
     +libnl-genl \
     +libmagic \
     +libkmod \
+    +kmod-nf-ipvs \
+    +libjson-c \
     +KEEPALIVED_NFTABLES:libnftnl \
     +KEEPALIVED_VRRP:kmod-macvlan \
     +KEEPALIVED_VRRP:libnl-route \
@@ -68,7 +69,6 @@ define Package/keepalived
     +KEEPALIVED_IPTABLES:libxtables \
     +KEEPALIVED_IPTABLES:libipset \
     +(KEEPALIVED_SNMP_VRRP||KEEPALIVED_SNMP_CHECKER||KEEPALIVED_SNMP_RFC2||KEEPALIVED_SNMP_RFC3):libnetsnmp \
-    +KEEPALIVED_JSON:libjson-c \
     +KEEPALIVED_DBUS:glib2
 endef
 
@@ -83,6 +83,7 @@ define Package/keepalived/conffiles
 endef
 
 CONFIGURE_ARGS+= \
+	--enable-json \
 	--with-init=SYSV \
 	--disable-track-process \
 	--runstatedir="/var/run"
@@ -146,11 +147,6 @@ CONFIGURE_ARGS += \
 	--disable-snmp-reply-v3-for-v2
 endif
 endif # CONFIG_KEEPALIVED_SNMP_RFC3
-
-ifeq ($(CONFIG_KEEPALIVED_JSON),y)
-CONFIGURE_ARGS += \
-	--enable-json
-endif
 
 ifeq ($(CONFIG_KEEPALIVED_VRRP_AUTH),)
 CONFIGURE_ARGS += \
@@ -240,6 +236,10 @@ endif
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/keepalived
 	$(INSTALL_DATA) ./files/hotplug-user \
 		$(1)/etc/hotplug.d/keepalived/01-user
+
+	$(INSTALL_DIR) $(1)/usr/libexec/rpcd
+	$(INSTALL_BIN) ./files/usr/libexec/rpcd/keepalived \
+		$(1)/usr/libexec/rpcd/keepalived
 
 ifneq ($(CONFIG_KEEPALIVED_SNMP_VRRP)$(CONFIG_KEEPALIVED_SNMP_CHECKER)$(CONFIG_KEEPALIVED_SNMP_RFC2)$(CONFIG_KEEPALIVED_SNMP_RFC3),)
 	$(INSTALL_DIR) $(1)/usr/share/snmp/mibs

--- a/net/keepalived/files/keepalived.init
+++ b/net/keepalived/files/keepalived.init
@@ -100,6 +100,7 @@ globals() {
 
 	printf '%bscript_user root\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
 	printf '%benable_script_security\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
+	printf '%bprocess_names\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
 
 	config_get notification_email "$1" notification_email
 	print_list_indent notification_email
@@ -126,6 +127,7 @@ print_ipaddress_indent() {
 	config_get address "$section" address
 	config_get device "$section" device
 	config_get scope "$section" scope
+	config_get label_suffix "$section" label_suffix vip
 
 	# Default indent
 	[ -z "$indent" ] && indent="$INDENT_1"
@@ -137,7 +139,7 @@ print_ipaddress_indent() {
 		printf '%b%s' "$indent" "$address" >> "$KEEPALIVED_CONF"
 	else
 		# Add IP address/netmask and device
-		printf '%b%s dev %s' "$indent" "$address" "$device">> "$KEEPALIVED_CONF"
+		printf '%b%s dev %s label %s' "$indent" "$address" "$device" "$device:$label_suffix" >> "$KEEPALIVED_CONF"
 		# Add scope
 		[ -n "$scope" ] && printf ' scope %s' "$scope" >> "$KEEPALIVED_CONF"
 	fi
@@ -196,7 +198,27 @@ print_route_indent() {
 	# Add table
 	[ -n "$table" ] && printf ' table %s' "$table" >> "$KEEPALIVED_CONF"
 	printf '\n' >> "$KEEPALIVED_CONF"
+}
 
+print_track_script_indent() {
+	local section="$1"
+	local curr_track_elem="$2"
+	local indent="$3"
+
+	local name value weight direction
+	config_get name "$section" name
+	[ "$name" != "$curr_track_elem" ] && return 0
+
+	config_get value "$section" value
+	config_get weight "$section" weight
+	config_get direction "$section" direction
+
+	[ -z "$value" ] && return 0
+	[ "$direction" != "reverse" ] && [ "$direction" != "noreverse" ] && unset direction
+
+	printf '%b%s' "$indent" "$value" >> "$KEEPALIVED_CONF"
+	[ -n "$weight" ] && printf ' weight %s' "$weight ${direction:+${direction}}" >> "$KEEPALIVED_CONF"
+	printf '\n' >> "$KEEPALIVED_CONF"
 }
 
 print_track_elem_indent() {
@@ -349,7 +371,7 @@ vrrp_instance() {
 		[ -z "$optval" ] && continue
 		printf '%b%s {\n' "${INDENT_1}" "$opt" >> "$KEEPALIVED_CONF"
 		for t in $optval; do
-			printf '%b%s\n' "${INDENT_2}" "$optval" >> "$KEEPALIVED_CONF"
+			config_foreach print_track_script_indent track_script "$t" "$INDENT_2"
 		done
 		printf '%b}\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
 	done

--- a/net/keepalived/files/usr/libexec/rpcd/keepalived
+++ b/net/keepalived/files/usr/libexec/rpcd/keepalived
@@ -1,0 +1,96 @@
+#!/bin/sh
+
+. /lib/functions.sh
+. /usr/share/libubox/jshn.sh
+
+RPC_SCRIPTS=/usr/libexec/keepalived/rpc
+
+[ -d $RPC_SCRIPTS ] && include $RPC_SCRIPTS
+
+__function__() {
+	type "$1" > /dev/null 2>&1
+}
+
+foreach_extra() {
+	local file obj
+
+	[ ! -d $RPC_SCRIPTS ] && return
+
+	for file in $RPC_SCRIPTS/*; do
+		obj="${file##*/}"
+		$1 "${obj%%.*}"
+	done
+}
+
+keepalived_dump() {
+	local stats_file="/tmp/keepalived.json"
+	local pids
+
+	[ -f "$stats_file" ] && rm -f "$stats_file"
+
+	pids=$(pidof /usr/sbin/keepalived)
+	if [ -n "$pids" ]; then
+		kill -37 $pids > /dev/null 2>&1
+		json_load "{ \"status\" :  $(cat $stats_file) }"
+	else
+		json_init
+	fi
+
+	json_dump
+}
+
+call_extra() {
+	if __function__ "$1"; then
+		$1
+	else
+		json_init
+		json_add_string error "invalid call $1"
+		json_dump
+	fi
+}
+
+call_method() {
+	case "$1" in
+		dump)
+			keepalived_dump
+			;;
+		*)
+			call_extra $1
+			;;
+	esac
+}
+
+list_extra() {
+	if __function__ "${1}_help"; then
+		${1}_help
+	else
+		json_add_object "$1"
+		json_close_object
+	fi
+}
+
+list_methods() {
+	local file
+
+	json_init
+
+	json_add_object dump
+	json_close_object
+
+	foreach_extra list_extra ${1}
+
+	json_dump
+}
+
+main () {
+	case "$1" in
+		list)
+			list_methods
+			;;
+		call)
+			call_method $2
+			;;
+	esac
+}
+
+main "$@"


### PR DESCRIPTION
keepalived: add status rpc and service improvement
    
- enable json by default to generate json stats
- add rpc to generate json status
- add kmod-nf-ipvs dependencies for virtual servers
- set default vip labels on virtual interfaces
- set process name for keepalived child processes

Signed-off-by: Jaymin Patel <jem.patel@gmail.com>

Maintainer: @feckert 
Run tested: x86-64, aarch64, virtual box, master

Description:
- add RPC to generate JSON status and fix dependencies for ipvs

**We need this for https://github.com/openwrt/luci/pull/5965**