### PR TITLE
python-docker: Update to 6.0.0

### DIFF
--- a/lang/python/python-docker/Makefile
+++ b/lang/python/python-docker/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-docker
-PKG_VERSION:=5.0.3
+PKG_VERSION:=6.0.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=docker
-PKG_HASH:=d916a26b62970e7c2f554110ed6af04c7ccff8e9f81ad17d0d40c75637e227fb
+PKG_HASH:=19e330470af40167d293b0352578c1fa22d74b34d3edf5d4ff90ebc203bbb2f1
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0
@@ -25,8 +25,8 @@ define Package/python3-docker
   URL:=https://github.com/docker/docker-py
   DEPENDS:=\
 	  +python3-light +python3-distutils +python3-logging \
-	  +python3-openssl +python3-paramiko +python3-six +python3-requests \
-	  +python3-websocket-client
+	  +python3-openssl +python3-packaging +python3-paramiko +python3-six \
+	  +python3-requests +python3-urllib3 +python3-websocket-client
 endef
 
 define Package/python3-docker/description


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream version.

`python3-packaging` is a new dep, `python3-urllib3` should have been there earlier, and I haven't found any use of `python3-six` within the package anymore, it is just referenced in a text file but I'm not sure if I'm missing anything.
