### PR TITLE
python-dotenv: update to v0.21.0

### DIFF
--- a/lang/python/python-dotenv/Makefile
+++ b/lang/python/python-dotenv/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dotenv
-PKG_VERSION:=0.20.0
+PKG_VERSION:=0.21.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=python-dotenv
-PKG_HASH:=b7e3b04a59693c42c36f9ab1cc2acc46fa5df8c78e178fc33a8d4cd05c8d498f
+PKG_HASH:=b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=BSD-3-Clause
@@ -21,7 +21,7 @@ define Package/python3-dotenv
   SUBMENU:=Python
   TITLE:=Add .env support to your django/flask apps in development and deployments
   URL:=http://github.com/theskumar/python-dotenv
-  DEPENDS:=+python3-light +python3-logging
+  DEPENDS:=+python3-click +python3-light +python3-logging
 endef
 
 define Package/python3-dotenv/description


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream version.

I've added `python3-click` as dependency since the standalone `dotenv` was being installed but failed to run without it. Furthermore, the error you get says to `pip install dotenv[cli]` which doesn't show in any way the `click` dep.

Added:

 - CLI: add support for invocations via 'python -m'.
 - load_dotenv function now returns False.
 - CLI: add --format= option to list command.

Fixed:

 - Drop Python 3.5 and 3.6 and upgrade GA
 - Use open instead of io.open.
 - Improve documentation for variables without a value
 - Add parse_it to Related Projects
 - Update README.md
 - Improve documentation with direct use of MkDocs

Signed-off-by: Javier Marcet <javier@marcet.info>

