### PR TITLE
python-websocket-client: update to 1.4.1

### DIFF
--- a/lang/python/python-websocket-client/Makefile
+++ b/lang/python/python-websocket-client/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-websocket-client
-PKG_VERSION:=1.3.3
+PKG_VERSION:=1.4.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=websocket-client
-PKG_HASH:=d58c5f284d6a9bf8379dab423259fe8f85b70d5fa5d2916d5791a84594b122b1
+PKG_HASH:=f9611eb65c8241a67fb373bef040b3cf8ad377a9f6546a12b620b6511e8ea9ef
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream version.

  - Fix stack growth bug when `run_forever` reconnects
  - Add doctest CI for sphinx docs code examples (d150099)
  - General docs improvements
  - Fix automatic reconnect with `run_forever`
  - Allow a timeout to be set when using a proxy

Signed-off-by: Javier Marcet <javier@marcet.info>

