### PR TITLE
vpnc-script: restart dnsmasq when openconnect disconnects

### DIFF
--- a/net/vpnc-scripts/Makefile
+++ b/net/vpnc-scripts/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vpnc-scripts
 PKG_VERSION:=20151220
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/vpnc-scripts/files/vpnc-script
+++ b/net/vpnc-scripts/files/vpnc-script
@@ -164,7 +164,11 @@ do_connect() {
 }
 
 do_disconnect() {
-	rm -f "/tmp/dnsmasq.d/openconnect.$TUNDEV"
+	if [ -f "/tmp/dnsmasq.d/openconnect.$TUNDEV" ]; then
+		rm -f "/tmp/dnsmasq.d/openconnect.$TUNDEV"
+		/etc/init.d/dnsmasq restart
+	fi
+
 	proto_init_update "$TUNDEV" 0
 	proto_send_update "$INTERFACE"
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:

Upon openconnect disconnecting it will remove a "/tmp/dnsmasq.d/openconnect.$TUNDEV" config but doesn't restart dnsmasq automatically.

This commit fixes this issue.

Signed-off-by: David Bentham <db260179@gmail.com>