### PR TITLE
iperf3/python-iperf3: add python-iperf3 and necessary libs

### DIFF
--- a/lang/python/python3-iperf3/Makefile
+++ b/lang/python/python3-iperf3/Makefile
@@ -1,0 +1,33 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-iperf3
+PKG_VERSION:=0.1.11
+PKG_RELEASE:=1
+
+PYPI_NAME:=iperf3
+PKG_HASH:=d50eebbf2dcf445a173f98a82f9c433e0302d3dfb7987e1f21b86b35ef63ce26
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-iperf3
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Python wrapper around iperf3.
+  URL:=https://github.com/thiezn/iperf3-python
+  DEPENDS:=+python3-light +python3-ctypes +libiperf3
+endef
+
+define Package/python3-iperf3/description
+  iperf3 for python provides a wrapper around the iperf3 utility.
+endef
+
+$(eval $(call Py3Package,python3-iperf3))
+$(eval $(call BuildPackage,python3-iperf3))
+$(eval $(call BuildPackage,python3-iperf3-src))

--- a/net/iperf3/Makefile
+++ b/net/iperf3/Makefile
@@ -32,6 +32,7 @@ define Package/iperf3/default
   CATEGORY:=Network
   TITLE:=Internet Protocol bandwidth measuring tool
   URL:=https://github.com/esnet/iperf
+  DEPENDS:=+libiperf3
 endef
 
 define Package/iperf3
@@ -43,14 +44,20 @@ define Package/iperf3-ssl
 $(call Package/iperf3/default)
   TITLE+= with iperf_auth support
   VARIANT:=ssl
-  DEPENDS:= +libopenssl
+  DEPENDS+=+libopenssl
+endef
+
+define Package/libiperf3
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Internet Protocol bandwidth measuring library
+  URL:=https://github.com/esnet/iperf
 endef
 
 TARGET_CFLAGS += -D_GNU_SOURCE
-CONFIGURE_ARGS += --disable-shared
 
 ifeq ($(BUILD_VARIANT),ssl)
-	CONFIGURE_ARGS += --with-openssl="$(STAGING_DIR)/usr"
+	CONFIGURE_ARGS += --with-openssl="$(STAGING_DIR)/usr" --disable-shared
 else
 	CONFIGURE_ARGS += --without-openssl
 endif
@@ -61,6 +68,17 @@ define Package/iperf3/description
  Iperf is a modern alternative for measuring TCP and UDP bandwidth
  performance, allowing the tuning of various parameters and
  characteristics.
+endef
+
+define Package/libiperf3/description
+ Libiperf is a library providing an API for iperf3 functionality.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libiperf.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
 endef
 
 # autoreconf fails if the README file isn't present
@@ -79,5 +97,11 @@ define Package/iperf3-ssl/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/iperf3 $(1)/usr/bin/
 endef
 
+define Package/iperf3/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libiperf.so.* $(1)/usr/lib
+endef
+
 $(eval $(call BuildPackage,iperf3))
 $(eval $(call BuildPackage,iperf3-ssl))
+$(eval $(call BuildPackage,libiperf3))


### PR DESCRIPTION
```
iperf3: add shared libiperf library and link iperf3 dynamically

Add library for creating own functions with iperf3 functionality.
Example: https://github.com/esnet/iperf/blob/master/examples/mis.c
This library is needed by python3-iperf3.

Build iperf3 binary with dynamically linked libiperf3. However, still
build iperf3-ssl as static binary due to a lack of shipping two libiperf
versions.
```

```
python3-iperf3: add iperf3 python wrapper

This wrapper gives us an easy to use api for using iperf3 in python.
```

Maintainer: @nbd168 
Compile tested: belkin rt3200
Run tested: belkin rt3200
