### PR TITLE
tree: bump to 2.0.4

### DIFF
--- a/utils/tree/Makefile
+++ b/utils/tree/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tree
-PKG_VERSION:=2.0.2
+PKG_VERSION:=2.0.4
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/Old-Man-Programmer/$(PKG_NAME)/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=753af251ba6446f4d40cc00064e73c55e910d95245a23d63a31ae1f36d444c1f
+PKG_HASH:=3ebeaf77a3b3829bcf665329e9d0f3624079c2c4cb4ef14cf6d7129a1a208b59
 
 PKG_MAINTAINER:=Banglang Huang <banglang.huang@foxmail.com>
 


### PR DESCRIPTION
Upstream update

Signed-off-by: John Audia <therealgraysky@proton.me>

Maintainer:  @hbl0307106015