### PR TITLE
[22.03] aria2: Fix aria2.init start issue

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
 PKG_VERSION:=1.36.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/aria2/aria2/releases/download/release-$(PKG_VERSION)/

--- a/net/aria2/files/aria2.init
+++ b/net/aria2/files/aria2.init
@@ -341,7 +341,7 @@ aria2_start() {
 		procd_set_param user "$user"
 
 	procd_add_jail "$NAME.$section" log
-	procd_add_jail_mount "$config_file"
+	procd_add_jail_mount "$ca_certificate" "$certificate" "$rpc_certificate" "$rpc_private_key"
 	procd_add_jail_mount_rw "$dir" "$config_dir" "$log"
 	procd_close_instance
 }


### PR DESCRIPTION
Maintainer: @Narakuku 

Description:

Re-mount '$config_file' inside the '$config_dir' will cause aria2 process unable to start.

Signed-off-by: Naraku J <74468372+Narakuku@users.noreply.github.com>
(cherry picked from commit 3eba8468e1e93e5f66df20aa3f8ebe5d3f1cffea)

