### PR TITLE
treewide: change argp-standalone to a direct dependency

### DIFF
--- a/libs/libv4l/Makefile
+++ b/libs/libv4l/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v4l-utils
 PKG_VERSION:=1.20.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.linuxtv.org/downloads/v4l-utils
@@ -19,8 +19,6 @@ PKG_USE_MIPS16:=0
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-
-PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -50,7 +48,7 @@ define Package/libv4l
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE+= wrapper libraries
-  DEPENDS := +libpthread +librt $(ICONV_DEPENDS)
+  DEPENDS := +libpthread +librt $(ICONV_DEPENDS) +!USE_GLIBC:argp-standalone
   LICENSE:=LGPL-2.1-or-later
   LICENSE_FILES:=COPYING.libv4l
 endef

--- a/multimedia/ttymidi-sysex/Makefile
+++ b/multimedia/ttymidi-sysex/Makefile
@@ -11,7 +11,6 @@ PKG_MIRROR_HASH:=8d6bb738a08a65c25fcc442777750abbee812a24a29236242032e2d76177454
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
-PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -20,7 +19,7 @@ define Package/ttymidi-sysex
   CATEGORY:=Sound
   TITLE:=ttymidi (with full bi-di sysex support)
   URL:=https://github.com/cchaussat/ttymidi-sysex
-  DEPENDS:=+alsa-lib
+  DEPENDS:=+alsa-lib +!USE_GLIBC:argp-standalone
 endef
 
 define Package/ttymidi-sysex/description

--- a/net/addrwatch/Makefile
+++ b/net/addrwatch/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=addrwatch
 PKG_VERSION:=1.0.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/fln/addrwatch/releases/download/v$(PKG_VERSION)
@@ -21,7 +21,6 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_DEPENDS:=USE_MUSL:argp-standalone
 PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
@@ -42,7 +41,7 @@ endef
 
 define Package/addrwatch
 $(call Package/addrwatch/Default)
-  DEPENDS:=+libpcap +libevent2
+  DEPENDS:=+libpcap +libevent2 +!USE_GLIBC:argp-standalone
 endef
 
 define Package/addrwatch/description

--- a/net/jool/Makefile
+++ b/net/jool/Makefile
@@ -21,7 +21,6 @@ PKG_MIRROR_HASH:=6ef000459858a87e206c903828f428d469c18221789cb65fec91a8d822b0178
 
 PKG_BUILD_DIR=$(KERNEL_BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
 
 PKG_FIXUP:=autoreconf
 
@@ -102,7 +101,7 @@ endef
 define Package/jool-tools-netfilter
   $(call Package/jool/Default)
   TITLE:=Jool userspace control programs
-  DEPENDS:=+libnl +kmod-jool-netfilter
+  DEPENDS:=+libnl +kmod-jool-netfilter +!USE_GLIBC:argp-standalone
 endef
 
 define Package/jool-tools-netfilter/description

--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -12,7 +12,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
 PKG_VERSION:=0.14.53
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/knxd/knxd/tar.gz/$(PKG_VERSION)?
@@ -25,7 +25,6 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -33,7 +32,7 @@ define Package/knxd
   SECTION:=net
   CATEGORY:=Network
   TITLE:=EIB KNX daemon
-  DEPENDS:=+libusb-1.0 +libev +libfmt
+  DEPENDS:=+libusb-1.0 +libev +libfmt +!USE_GLIBC:argp-standalone
 endef
 
 define Package/knxd/description

--- a/net/linknx/Makefile
+++ b/net/linknx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linknx
 PKG_VERSION:=0.0.1.38
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-${PKG_VERSION}.tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/linknx/linknx/tar.gz/$(PKG_VERSION)?
@@ -19,7 +19,6 @@ PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DEPENDS:=USE_UCLIBC:argp-standalone USE_MUSL:argp-standalone
 PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
@@ -30,7 +29,8 @@ define Package/linknx
   CATEGORY:=Network
   TITLE:=KNX home automation platform
   URL:=https://github.com/linknx/linknx
-  DEPENDS:=+pthsem +lua +luac +libcurl +libesmtp +libstdcpp $(ICONV_DEPENDS)
+  DEPENDS:=+pthsem +lua +luac +libcurl +libesmtp +libstdcpp $(ICONV_DEPENDS) \
+           +!USE_GLIBC:argp-standalone
 endef
 
 CONFIGURE_ARGS+= \

--- a/utils/crun/Makefile
+++ b/utils/crun/Makefile
@@ -10,7 +10,6 @@ PKG_SOURCE_DATE:=2022-05-09
 PKG_SOURCE_VERSION:=85649a8c561f7fbf018e5c5640a7e9370c80ce73
 PKG_MIRROR_HASH:=69b7db70fc13d16244609bbbd5240792519810a60d9f68ba6d5ed3def1b23fe9
 
-PKG_BUILD_DEPENDS:=argp-standalone
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -26,7 +25,7 @@ define Package/crun
   CATEGORY:=Utilities
   TITLE:=crun
   URL:=https://github.com/containers/crun
-  DEPENDS:=@!arc +libseccomp +libcap
+  DEPENDS:=@!arc +!USE_GLIBC:argp-standalone +libseccomp +libcap
 endef
 
 define Package/crun/description

--- a/utils/cryptsetup/Makefile
+++ b/utils/cryptsetup/Makefile
@@ -23,8 +23,6 @@ PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
-PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
-
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
@@ -34,7 +32,8 @@ define Package/cryptsetup
   SUBMENU:=Encryption
   TITLE:=Cryptsetup
   DEPENDS:=$(ICONV_DEPENDS) $(INTL_DEPENDS) +libblkid +libuuid +libpopt +lvm2 \
-           +libdevmapper +libjson-c +@KERNEL_DIRECT_IO +kmod-crypto-user
+           +libdevmapper +libjson-c +@KERNEL_DIRECT_IO +kmod-crypto-user \
+           +!USE_GLIBC:argp-standalone
   URL:=https://gitlab.com/cryptsetup/cryptsetup/
 endef
 

--- a/utils/readsb/Makefile
+++ b/utils/readsb/Makefile
@@ -18,7 +18,6 @@ PKG_LICENSE_FILES:=COPYING LICENSE
 
 PKG_MAINTAINER:=Stijn Tintel <stijn@linux-ipv6.be>
 
-PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -26,9 +25,9 @@ include $(INCLUDE_DIR)/package.mk
 define Package/readsb/default
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libncurses
+  DEPENDS:=+libncurses +!USE_GLIBC:argp-standalone
   TITLE:=Mode-S/ADSB/TIS decoder for various devices
-  URL:=https://github.com/Mictronic/readsb
+  URL:=https://github.com/Mictronics/readsb
 endef
 
 define Package/readsb

--- a/utils/rng-tools/Makefile
+++ b/utils/rng-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rng-tools
 PKG_VERSION:=6.15
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/nhorman/rng-tools
@@ -23,7 +23,6 @@ PKG_LICENSE_FILES:=COPYING
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -32,7 +31,7 @@ define Package/rng-tools
   CATEGORY:=Utilities
   TITLE:=Daemon for adding entropy to kernel entropy pool
   URL:=https://github.com/nhorman/rng-tools
-  DEPENDS:=+libopenssl
+  DEPENDS:=+libopenssl +!USE_GLIBC:argp-standalone
 endef
 
 define Package/rng-tools/description

--- a/utils/telldus-core/Makefile
+++ b/utils/telldus-core/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telldus-core
 PKG_VERSION:=2.1.2
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.telldus.com/TellStick/Software/telldus-core/
@@ -18,7 +18,6 @@ PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=LICENSE
 
 CMAKE_INSTALL:=1
-PKG_BUILD_DEPENDS:=argp-standalone
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -40,7 +39,7 @@ define Package/telldus-core
 	CATEGORY:=Utilities
 	TITLE:=Telldus TellStick USB interface
 	URL:=https://telldus.com
-	DEPENDS:=+confuse +libftdi +libstdcpp
+	DEPENDS:=+confuse +libftdi +libstdcpp +!USE_GLIBC:argp-standalone
 endef
 
 define Package/telldus-core/description


### PR DESCRIPTION
As preparation to build argp-standalone as dynamic library, change all packets with a build dependency for it to a direct dependency. Without this the build will link against the dynamic library and the buildsystem will complain about the missing dependency.

Signed-off-by: Thomas Langer <tlanger@maxlinear.com>
