### PR TITLE
wifi-presence: Update to version v0.2.0

### DIFF
--- a/net/wifi-presence/Makefile
+++ b/net/wifi-presence/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifi-presence
-PKG_VERSION:=0.1.2
-PKG_RELEASE:=2
+PKG_VERSION:=0.2.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=-$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/awilliams/wifi-presence/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=f5cf8bf36e3c17ad4b0486007532030760c22c5f63bd63707d911ab94bd744df
+PKG_HASH:=d3b4f2e33ba423e353ad17a000f67690c7c84b136726e683a9cb24be53889407
 
 PKG_LICENSE:=MIT
 PKG_MAINTAINER:=Adam Williams <pwnfactory@gmail.com>


### PR DESCRIPTION
Maintainer: me / @awilliams 
Compile tested: 
OpenWRT 22.03.0
- arm_arm1176jzf-s_vfp
- arm_arm926ej-s
- arm_cortex-a15_neon-vfpv4
- arm_cortex-a5_vfpv4
- arm_cortex-a7
- arm_cortex-a7_neon-vfpv4
- arm_cortex-a7_vfpv4
- arm_cortex-a8_vfpv3
- arm_cortex-a9
- arm_cortex-a9_neon
- arm_cortex-a9_vfpv3-d16
- arm_fa526
- arm_mpcore
- arm_xscale
- i386_pentium-mmx
- i386_pentium4
- mips64_octeonplus
- mips_24kc
- mips_4kec
- mips_mips32
- mipsel_24kc
- mipsel_24kc_24kf
- mipsel_74kc
- mipsel_mips32

Run tested:
- Tested on 2 different routers running OpenWRT 22.03.0 for 24+ hours

Description:

This version better decodes SSID names which contain emoji, control characters, and other non-ascii characters.

https://github.com/awilliams/wifi-presence/pull/8
