### PR TITLE
prometheus/collectd: adapt dependencies for the dsl collector 

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -528,4 +528,4 @@ $(eval $(call BuildPlugin,write-graphite,Carbon/Graphite output,write_graphite,+
 $(eval $(call BuildPlugin,write-http,HTTP POST output,write_http,+PACKAGE_collectd-mod-write-http:libcurl))
 
 $(eval $(call BuildScriptPlugin,sqm,SQM/qdisc collection,sqm_collectd,+PACKAGE_collectd-mod-sqm:collectd-mod-exec))
-$(eval $(call BuildScriptLuaPlugin,ltq-dsl,Lantiq DSL collection,dsl,@TARGET_lantiq_xrx200 +PACKAGE_collectd-mod-ltq-dsl:collectd-mod-lua +libubus-lua))
+$(eval $(call BuildScriptLuaPlugin,ltq-dsl,Lantiq DSL collection,dsl,ltq-dsl-app +PACKAGE_collectd-mod-ltq-dsl:collectd-mod-lua +libubus-lua))

--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -117,7 +117,7 @@ endef
 define Package/prometheus-node-exporter-lua-ltq-dsl
   $(call Package/prometheus-node-exporter-lua/Default)
   TITLE+= (lantiq dsl collector)
-  DEPENDS:=prometheus-node-exporter-lua @(PACKAGE_ltq-adsl-app||PACKAGE_ltq-vdsl-app)
+  DEPENDS:=prometheus-node-exporter-lua ltq-dsl-app
 endef
 
 define Package/prometheus-node-exporter-lua-ltq-dsl/install


### PR DESCRIPTION
This depends on https://github.com/openwrt/openwrt/pull/10586

It simplifies and cleans up the dependencies of consumers of the dsl ubus stats.

Maintainers: @champtar @jow- @hnyman 
I tested prometheus, but not collectd, so cc @jekkos @feckert