### PR TITLE
opendoas: avoid libpam dependency

### DIFF
--- a/utils/opendoas/Makefile
+++ b/utils/opendoas/Makefile
@@ -33,6 +33,8 @@ define Package/opendoas/description
  of sudo with a fraction of the codebase.
 endef
 
+CONFIGURE_ARGS += $(if $(CONFIG_BUSYBOX_CONFIG_PAM),--with,--without)-pam
+
 define Package/opendoas/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/doas $(1)/usr/bin/


### PR DESCRIPTION
Maintainer: @paper42 
Compile tested: meditek/mt7622, aarch64, master
Run tested: N/A

Description:

Package is failing to build because it picks up libpam dependency regardless of `BUSYBOX_CONFIG_PAM`.
Use configure args --with-pam, --without-pam to assert the option.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>