### PR TITLE
libgd: avoid recursive and redundant dependencies

### DIFF
--- a/libs/libgd/Makefile
+++ b/libs/libgd/Makefile
@@ -26,7 +26,7 @@ include $(INCLUDE_DIR)/cmake.mk
 define Package/libgd/default
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libjpeg +libpng +libwebp +LIBGD_TIFF:libtiff +LIBGD_FREETYPE:libfreetype
+  DEPENDS:=+libjpeg +libpng +libwebp
   TITLE:=The GD graphics library
   URL:=https://libgd.github.io/
 endef
@@ -36,6 +36,7 @@ define Package/libgd
   MENU:=1
   DEPENDS+=+LIBGD_TIFF:libtiff +LIBGD_FREETYPE:libfreetype
   VARIANT:=default
+  CONFLICTS:=libgd-full
 endef
 
 define Package/libgd-full
@@ -44,7 +45,6 @@ define Package/libgd-full
   TITLE+=(full)
   VARIANT:=full
   PROVIDES:=libgd
-  CONFLICTS:=libgd
 endef
 
 define Package/libgd/description/default


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: mediatek/mt7622, aarch64, OpenWrt Master
Run tested: no run test, but tested with `make menuconfig` to ensure that the default libgd was picked up as dependency.

Description:
Change the CONFLICTS line from the libgd-full to libgd to fix a recursive dependency.

While at it, remove the redundant `+LIBGD_TIFF:libtiff +LIBGD_FREETYPE:libfreetype` dependencies from Package/libgd/default.