### PR TITLE
nut: avoid picking up libi2c dependency, fix collectd build

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.8.0
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.8/
@@ -541,6 +541,7 @@ CONFIGURE_ARGS += \
 	--with$(if $(CONFIG_PACKAGE_nut-web-cgi),,out)-cgi \
 	--without-ipmi \
 	--without-freeipmi \
+	--without-linux-i2c \
 	--$(if $(CONFIG_NUT_SSL),with,without)-ssl $(if $(CONFIG_NUT_SSL),--with-openssl) \
 	--without-libltdl \
 	--without-macosx_ups \

--- a/net/nut/patches/001-clients-upsclient.h-ensure-time_t-is-defined.patch
+++ b/net/nut/patches/001-clients-upsclient.h-ensure-time_t-is-defined.patch
@@ -1,0 +1,27 @@
+From cafd77993ec5e16634b774b65bf6da9b34a21fc5 Mon Sep 17 00:00:00 2001
+From: Jim Klimov <jimklimov+nut@gmail.com>
+Date: Wed, 31 Aug 2022 11:24:19 +0200
+Subject: [PATCH] clients/upsclient.h: ensure time_t is defined
+
+
+--- a/clients/upsclient.h
++++ b/clients/upsclient.h
+@@ -41,6 +41,18 @@
+ 	#include <limits.h>
+ #endif
+ 
++/* Not including NUT timehead.h because this is part of end-user API */
++#ifdef TIME_WITH_SYS_TIME
++# include <sys/time.h>
++# include <time.h>
++#else
++# ifdef HAVE_SYS_TIME_H
++#  include <sys/time.h>
++# else
++#  include <time.h>
++# endif
++#endif
++
+ #ifdef __cplusplus
+ /* *INDENT-OFF* */
+ extern "C" {


### PR DESCRIPTION
Maintainer: none listed
Compile tested: mediatek/mt7622, aarch64, openwrt master
Run tested: none

Description:

Add --without-linux-i2c to configure arguments to avoid using i2c if found in the staging dir.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

Adding a commit with an upstream patch that fixes collectd build:
```
src/nut.c:40:2: error: #error "Unable to determine the UPS connection type."
   40 | #error "Unable to determine the UPS connection type."
      |  ^~~~~
src/nut.c:46:3: error: unknown type name 'collectd_upsconn_t'
```
The failure to detect UPS was due to `time_t` not being defined by nut `upsclient.h`.