### PR TITLE
midisport-firmware: add package

### DIFF
--- a/multimedia/midisport-firmware/Makefile
+++ b/multimedia/midisport-firmware/Makefile
@@ -1,0 +1,57 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=midisport-firmware
+PKG_VERSION:=1.2
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=@SF/usb-midi-fw/$(PKG_NAME)/$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=2aa82ef0bf26647fbdda4c2e9ed0033b41bd0f1b4020b87fa073e4462a048b2d
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE_FILES:=LICENCE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/midisport-firmware
+  SECTION:=firmware
+  CATEGORY:=Firmware
+  URL:=https://sourceforge.net/projects/usb-midi-fw
+  TITLE:=M-Audio USB MIDI Firmware
+  DEPENDS:=+fxload
+  PKGARCH:=all
+endef
+
+define Package/midisport-firmware/description
+This package allows you to use the MidiSport USB MIDI interfaces from
+M-Audio/Midiman.
+
+Supported devices:
+- MidiSport 1x1
+- MidiSport 2x2
+- MidiSport 4x4
+- MidiSport 8x8
+- MidiSport Uno
+- Keystation
+- Oxygen
+- Radium
+
+(You don't need a firmware download for the USB Audio Quattro, Duo, or
+MidiSport 2x4.)
+endef
+
+define Build/Configure
+	true
+endef
+
+define Build/Compile
+	true
+endef
+
+define Package/midisport-firmware/install
+	$(INSTALL_DIR) $(1)/usr/share/usb/maudio $(1)/etc/hotplug.d/usb
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/*.ihx $(1)/usr/share/usb/maudio
+	$(INSTALL_DATA) ./files/midisport-firmware.hotplug $(1)/etc/hotplug.d/usb/50-midisport-firmware
+endef
+
+$(eval $(call BuildPackage,midisport-firmware))

--- a/multimedia/midisport-firmware/files/midisport-firmware.hotplug
+++ b/multimedia/midisport-firmware/files/midisport-firmware.hotplug
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+midisport_load() {
+	local MIDISPORT_FWDIR="/usr/share/usb/maudio"
+	local FXLOAD="/usr/sbin/fxload"
+	case "$DEVPATH" in "/"*".[1-9]") return 0 ;; esac
+	[ "$BUSNUM" ] || return 19
+	[ "$DEVNUM" ] || return 19
+	[ -x "$FXLOAD" ] || return 2
+	"$FXLOAD" -V | grep -q libusb || return 95
+	$FXLOAD -t an21 -p $BUSNUM,$DEVNUM \
+		-s "$MIDISPORT_FWDIR/MidiSportLoader.ihx" \
+		-I "$MIDISPORT_FWDIR/MidiSport${1}.ihx"
+}
+
+if [ "$ACTION" = "add" ]; then
+	case "$PRODUCT" in
+	"763/1001/"*)
+		midisport_load 2x2
+		;;
+	"763/1010/"*)
+		midisport_load 1x1
+		;;
+	"763/1014/"*)
+		midisport_load KS
+		;;
+	"763/1020/"*)
+		midisport_load 4x4
+		;;
+	"763/1031/110")
+		midisport_load 8x8-2.10
+		;;
+	"763/1031/121")
+		midisport_load 8x8-2.21
+		;;
+	esac
+fi


### PR DESCRIPTION
Add package with user-space loaded firmware for M-Audio USB MIDI interfaces.
Implement OpenWrt-specific hotplug script which uses 'fxload' from libusb examples.

Depends on https://github.com/openwrt/openwrt/pull/10716

Signed-off-by: Daniel Golle <daniel@makrotopia.org>
