### PR TITLE
collectd: disable nut plugin (incompatibility with nut 2.8.0)

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -494,7 +494,7 @@ $(eval $(call BuildPlugin,netlink,netlink input,netlink,+PACKAGE_collectd-mod-ne
 $(eval $(call BuildPlugin,network,network input/output,network,+PACKAGE_COLLECTD_ENCRYPTED_NETWORK:libgcrypt))
 $(eval $(call BuildPlugin,nginx,nginx status input,nginx,+PACKAGE_collectd-mod-nginx:libcurl))
 $(eval $(call BuildPlugin,ntpd,NTP daemon status input,ntpd,))
-$(eval $(call BuildPlugin,nut,UPS monitoring input,nut,+PACKAGE_collectd-mod-nut:nut-common))
+$(eval $(call BuildPlugin,nut,UPS monitoring input,nut,+PACKAGE_collectd-mod-nut:nut-common @BROKEN))
 $(eval $(call BuildPlugin,olsrd,OLSRd status input,olsrd,))
 $(eval $(call BuildPlugin,openvpn,OpenVPN traffic/compression input,openvpn,))
 $(eval $(call BuildPlugin,ping,ping status input,ping,+PACKAGE_collectd-mod-ping:liboping))


### PR DESCRIPTION
Temporarily disable nut plugin by marking it BROKEN. Apparently the upstream collectd plugin is not yet compatible with nut 2.8.0.

I tried the upstream PR 4043, but it does not help, as it apparently requires at least one specific UPS type to be defined/compiled.

        nut . . . . . . . . . no (required data types for NUT API were not detected) (dependency error)

If there is a requirement to specify some UPS data type when compiling nut, it might be problematic for the generic OpenWrt buildbot context.


Maintainer: me

