### PR TITLE
jose: fix static library usage

### DIFF
--- a/libs/jose/Makefile
+++ b/libs/jose/Makefile
@@ -19,15 +19,13 @@ PKG_MAINTAINER:=Tibor Dudlák <tibor.dudlak@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=COPYING
 
-PKG_BUILD_DEPENDS:=openssl
-
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/meson.mk
 
 define Package/jose
   SECTION:=utils
   TITLE:=Provides a full crypto stack including key generation, signing and encryption.
-  DEPENDS:=+jansson
+  DEPENDS:=+jansson +libopenssl +zlib
   URL:=https://github.com/latchset/jose
 endef
 

--- a/libs/jose/patches/010-whole.patch
+++ b/libs/jose/patches/010-whole.patch
@@ -1,0 +1,10 @@
+--- a/cmd/meson.build
++++ b/cmd/meson.build
+@@ -22,6 +22,6 @@ executable(meson.project_name(),
+   'alg.c',
+   'fmt.c',
+   dependencies: jansson,
+-  link_with: libjose,
++  link_whole: libjose,
+   install: true
+ )


### PR DESCRIPTION
When libjose is built statically, it must use --whole-archive as it uses GCC's constructor attribute to initialize itself.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Tiboris 
Compile tested: Fedora 36

ping @nilsmeyer @jilroy