### PR TITLE
grep: use libpcre2

### DIFF
--- a/utils/grep/Makefile
+++ b/utils/grep/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grep
 PKG_VERSION:=3.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/grep
@@ -31,7 +31,7 @@ define Package/grep
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=grep search utility - full version
-  DEPENDS:=+libpcre
+  DEPENDS:=+libpcre2
   URL:=https://www.gnu.org/software/grep/
   ALTERNATIVES:=\
     300:/bin/egrep:/usr/libexec/egrep-gnu \


### PR DESCRIPTION
We should use libpcre2 instead of libpcre in the new grep version.

Maintainer: @Zokormazo 
Compile tested: ipq40xx
Run tested: ipq40xx avm fritz!box 4040