### PR TITLE
telldus-core: add missing include

### DIFF
--- a/utils/telldus-core/Makefile
+++ b/utils/telldus-core/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telldus-core
 PKG_VERSION:=2.1.2
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.telldus.com/TellStick/Software/telldus-core/

--- a/utils/telldus-core/patches/100-add_includes.patch
+++ b/utils/telldus-core/patches/100-add_includes.patch
@@ -1,7 +1,7 @@
 Added missing includes required by openwrt. Expected to be portable.
 --- a/common/Socket_unix.cpp
 +++ b/common/Socket_unix.cpp
-@@ -8,6 +8,7 @@
+@@ -8,9 +8,11 @@
  #include <stdio.h>
  #include <unistd.h>
  #include <sys/socket.h>
@@ -9,6 +9,10 @@ Added missing includes required by openwrt. Expected to be portable.
  #include <sys/un.h>
  #include <fcntl.h>
  #include <math.h>
++#include <cstring>
+ #include <string>
+ 
+ #include "common/Socket.h"
 --- a/service/ConnectionListener_unix.cpp
 +++ b/service/ConnectionListener_unix.cpp
 @@ -13,6 +13,7 @@


### PR DESCRIPTION
Needed for memset.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @PeterFromSweden 