### PR TITLE
[21.02] knot: update to version 3.2.1

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.2.0
+PKG_VERSION:=3.2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=426d120994daf93af348aa6c48428e583dd286656415de4daf7a59106fd98631
+PKG_HASH:=51efa36f92679b25d43dbf8ba543e9f26138559f0fa1ba5fae172f5400659c8f
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8


### PR DESCRIPTION
Maintainer: @Payne-X6
Compile tested: aarch64, Turris MOX, OpenWrt 21.02
Run tested: aarch64, Turris MOX, OpenWrt 21.02

Description: This is a bugfix release, so it should go to all supported stable versions including 21.02, it's currently only in master and 22.03.