### PR TITLE
[22.03] libxml2: update to 2.10.2

### DIFF
--- a/libs/libxml2/Makefile
+++ b/libs/libxml2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxml2
-PKG_VERSION:=2.9.14
+PKG_VERSION:=2.10.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/libxml2/$(basename $(PKG_VERSION))
-PKG_HASH:=60d74a257d1ccec0475e749cba2f21559e48139efba6ff28224357c7c798dfee
+PKG_HASH:=d240abe6da9c65cb1900dd9bf3a3501ccf88b3c2a1cb98317d03f272dda5b265
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
@@ -21,7 +21,6 @@ PKG_CPE_ID:=cpe:/a:xmlsoft:libxml2
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 
-PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=0
 
@@ -77,7 +76,6 @@ CONFIGURE_ARGS += \
 	--with-c14n \
 	--without-catalog \
 	--with-debug \
-	--without-docbook \
 	--with-html \
 	--without-ftp \
 	--without-http \
@@ -109,7 +107,6 @@ HOST_CONFIGURE_ARGS += \
 	--with-c14n \
 	--without-catalog \
 	--with-debug \
-	--without-docbook \
 	--with-html \
 	--without-ftp \
 	--without-http \


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs

Description:

This fixes:
- CVE-2022-2309

Release Notes:
- https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.10.0
- https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.10.1
- https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.10.2

Also drop removed docbook compile switch.
Disable PKG_FIXUP to allow backporting.

Signed-off-by: Nick Hainke <vincent@systemli.org>
Signed-off-by: Michael Heimpold <mhei@heimpold.de>
(cherry picked from commit dc21121cf9c1c51649f0ffdaffd26326e53b4f45)
