### PR TITLE
adblock: add lightswitch05 source

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
 PKG_VERSION:=4.1.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -23,6 +23,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 | firetv_tracking     |         | S    | tracking         | [Link](https://github.com/Perflyst/PiHoleBlocklist)                               |
 | games_tracking      |         | S    | tracking         | [Link](https://www.gameindustry.eu)                                               |
 | hblock              |         | XL   | compilation      | [Link](https://hblock.molinero.dev)                                               |
+| lightswitch05       |         | XL   | compilation      | [Link](https://github.com/lightswitch05/hosts)                                    |
 | notracking          |         | XL   | tracking         | [Link](https://github.com/notracking/hosts-blocklists)                            |
 | oisd_basic          |         | L    | general          | [Link](https://oisd.nl)                                                           |
 | oisd_nsfw           |         | XL   | general          | [Link](https://oisd.nl)                                                           |

--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -90,6 +90,13 @@
 		"focus": "compilation",
 		"descurl": "https://hblock.molinero.dev"
 	},
+	 "lightswitch05": {
+                "url": "https://www.github.developerdan.com/hosts/lists/ads-and-tracking-extended.txt",
+		"rule": "/^0\\.0\\.0\\.0[[:space:]]+([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($2)}",
+                "size": "XL",
+                "focus": "compilation",
+                "descurl": "https://github.com/lightswitch05/hosts"
+        },
 	"notracking": {
 		"url": "https://raw.githubusercontent.com/notracking/hosts-blocklists/master/dnscrypt-proxy/dnscrypt-proxy.blacklist.txt",
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",


### PR DESCRIPTION
Signed-off-by: james-mcguire <jamesm51@gmail.com>

Maintainer: @dibdot
Compile tested: N/A
Run tested: ARMv7, ipq806x, Netgear R7800, working locally with 22.03

Description: Adds a new blocklist [source](https://github.com/lightswitch05/hosts) to adblock
