### PR TITLE
knot-resolver: update to 5.5.3

### DIFF
--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -10,12 +10,12 @@ PKG_RELRO_FULL:=0
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot-resolver
-PKG_VERSION:=5.5.1
+PKG_VERSION:=5.5.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-resolver
-PKG_HASH:=9bad1edfd6631446da2d2331bd869887d7fe502f6eeaf62b2e43e2c113f02b6d
+PKG_HASH:=a38f57c68b7d237d662784d8406e6098aad66a148f44dcf498d1e9664c5fed2d
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=GPL-3.0-later

--- a/net/knot-resolver/patches/010-fix-lmdb.patch
+++ b/net/knot-resolver/patches/010-fix-lmdb.patch
@@ -1,5 +1,5 @@
 This is just workaround. It should be removed after proper fixing in upstream.
-Patch fixes problem with lmdb pkg config. It also adds workaround for get_option
+Patch fixes problem with lmdb pkg confing. It also adds workaround for get_option
 which is now not propagated in OpenWrt meson host package.
 --- a/meson.build
 +++ b/meson.build

--- a/net/knot-resolver/patches/030-fix-policy-hack.patch
+++ b/net/knot-resolver/patches/030-fix-policy-hack.patch
@@ -2,7 +2,7 @@ This patch fixes the problem with forwarding in knot-resolver v4.3.0.
 It reintroduces a fix which enables  policy related hack (knot/knot-resolver#205 (comment 94566) )
 --- a/modules/policy/policy.lua
 +++ b/modules/policy/policy.lua
-@@ -1098,7 +1098,7 @@ policy.layer = {
+@@ -1093,7 +1093,7 @@ policy.layer = {
  		if bit.band(state, bit.bor(kres.FAIL, kres.DONE)) ~= 0 then return state end
  		local qry = req:initial() -- same as :current() but more descriptive
  		return policy.evaluate(policy.rules, req, qry, state)


### PR DESCRIPTION
Maintainer: @ja-pa
Compile tested: aarch64, Turris MOX, OpenWrt 21.02 (tested on Turris OS which has a separate package for knot-resolver)
Run tested: aarch64, Turris MOX, OpenWrt 21.02

Description: fixes CVE-2022-40188, this update should be backported to all stable branches.

cc @BKPepe