### PR TITLE
glib2: backport locale fix

### DIFF
--- a/libs/glib2/patches/020-locale.patch
+++ b/libs/glib2/patches/020-locale.patch
@@ -1,0 +1,24 @@
+From ebcc3c01db27b79af38b42c3c52a79d0225f744c Mon Sep 17 00:00:00 2001
+From: Seungha Yang <seungha@centricular.com>
+Date: Sun, 14 Aug 2022 04:56:20 +0900
+Subject: [PATCH] glib-mkenums: Specify output encoding as UTF-8 explicitly for
+ non-English locale
+
+Fixup regression introduced by
+https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2797
+---
+ gobject/glib-mkenums.in | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/gobject/glib-mkenums.in
++++ b/gobject/glib-mkenums.in
+@@ -19,6 +19,9 @@ import errno
+ import codecs
+ import locale
+ 
++# Non-english locale systems might complain to unrecognized character
++sys.stdout = io.TextIOWrapper(sys.stdout.detach(), encoding='utf-8')
++
+ VERSION_STR = '''glib-mkenums version @VERSION@
+ glib-mkenums comes with ABSOLUTELY NO WARRANTY.
+ You may redistribute copies of glib-mkenums under the terms of


### PR DESCRIPTION
Fixes compilation with non English locale.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 

ping @zxlhhyccc