### PR TITLE
dnsproxy: Update to 0.45.0

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.44.0
+PKG_VERSION:=0.45.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=a9617296fe668296d121baa266bd6beba5582834fce3bf9375d084de683cd664
+PKG_HASH:=58d8ba7dc5947e96ba2e0790c5b3be9e8ec2909eb4e51e7652027a8b4b4a6ad1
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8
Run tested: nanopi-r2s

Description:
Added `DNS-over-HTTP/3` support.
Release note: https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.45.0