### PR TITLE
dnslookup: Update to 1.8.0

### DIFF
--- a/net/dnslookup/Makefile
+++ b/net/dnslookup/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnslookup
-PKG_VERSION:=1.7.3
+PKG_VERSION:=1.8.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ameshkov/dnslookup/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c63d2dc8c357045e28f29ec716e3c20e39a2c1be4dc4313c6c2ab62838e5e2db
+PKG_HASH:=8358291240a27f20f4d635f9a27a9373144b723c4d73ee01374a9ed5c02126bd
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8
Run tested: rk3328 nanopi-r2s

Description:
Added `DNS-over-HTTP/3` support.
Release note: https://github.com/ameshkov/dnslookup/releases/tag/v1.8.0