### PR TITLE
gatling: backport package gatling to 22.03

### DIFF
--- a/net/gatling/Makefile
+++ b/net/gatling/Makefile
@@ -1,0 +1,40 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gatling
+PKG_VERSION:=0.16
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://www.fefe.de/gatling/
+PKG_HASH:=5f96438ee201d7f1f6c2e0849ff273b196bdc7493f29a719ce8ed08c8be6365b
+
+PKG_BUILD_DEPENDS:=px5g-mbedtls libowfat
+
+PKG_MAINTAINER:=Martin Hübner <martin.hubner@web.de>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/gatling
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Web Servers/Proxies
+  TITLE:=gatling - a high performance web server
+  URL:=https://www.fefe.de/gatling/
+  DEPENDS:=+zlib +libcap +libopenssl
+endef
+
+define Package/gatling/description
+  gatling - a high performance web server
+  with a a rather small binary size but a decent set of extra features
+  like ftp, basic htaccess and basic DoS-Protection.
+  Gatling is particularly good in situations with very high load.
+endef
+
+define Package/gatling/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/gatling $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,gatling))

--- a/net/gatling/patches/010-decrease_optimisation.patch
+++ b/net/gatling/patches/010-decrease_optimisation.patch
@@ -1,0 +1,25 @@
+gatling: decrease optimisation
+
+When compiling on MIPS-architectures, in -O2 there happen some
+errors on interlinking. Linker will will fail with:
+
+```
+Unsupported jump between ISA modes; consider recompiling with interlinking enabled
+```
+
+Reducing optimisation works around these errors and looks like
+a fairly common solution to this problem.
+https://forum.openwrt.org/t/unsupported-jump-between-isa-modes-consider-recompiling-with-interlinking-enabled/55786
+
+Signed-off-by: Martin Hübner <martin.hubner@web.de>
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -47,7 +47,7 @@ ifneq ($(DEBUG),)
+ CFLAGS+=-g -Og
+ LDFLAGS+=-g
+ else
+-CFLAGS+=-O2 -fomit-frame-pointer -I/usr/local/include
++CFLAGS+=-O1 -fomit-frame-pointer -I/usr/local/include
+ LDFLAGS+=-s
+ ifneq ($(DIET),)
+ DIET+=-Os

--- a/net/gatling/patches/020-configure_features.patch
+++ b/net/gatling/patches/020-configure_features.patch
@@ -1,0 +1,30 @@
+gatling: configure features
+
+Disables SMB-support, as only deprecated SMBv1 is supported,
+which most users wouldn't use anyway. Avoids potential
+vulnerabilities.
+
+Activates threaded opening: Thus gatling will open files in
+threads to open kernel I/O scheduling opportunities.
+
+Signed-off-by: Martin Hübner <martin.hubner@web.de>
+--- a/gatling_features.h
++++ b/gatling_features.h
+@@ -7,7 +7,7 @@
+ 
+ #define SUPPORT_SERVERSTATUS
+ // #define SUPPORT_DAV
+-#define SUPPORT_SMB
++// #define SUPPORT_SMB
+ #define SUPPORT_FTP
+ #define SUPPORT_PROXY
+ /* #define DEBUG to enable more verbose debug messages for tracking fd
+@@ -36,7 +36,7 @@
+ #define SUPPORT_FALLBACK_REDIR
+ 
+ /* open files in threads to open kernel I/O scheduling opportunities */
+-#undef SUPPORT_THREADED_OPEN
++#define SUPPORT_THREADED_OPEN
+ 
+ /* try to divine MIME type by looking at content */
+ #define SUPPORT_MIMEMAGIC

--- a/net/gatling/test.sh
+++ b/net/gatling/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+gatling -h


### PR DESCRIPTION
Gatling is a high-performance webserver from fefe. It gives a fairly decent feature-set at really small size. And its fast.

Co-authored-by: Josef Schlehofer <pepe.schlehofer@gmail.com>
Signed-off-by: Martin Hübner <martin.hubner@web.de>
(cherry picked from commit 83ff83e32055dc50b01fffe7bae9ea113655756b)

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: see commit in master-branch #19136
Run tested: see commit in master-branch #19136
