### PR TITLE
[22.03] squid: fix compilation with libxml (fixes #19099)

### DIFF
--- a/net/squid/patches/020-libxml-drop-xmlSetFeature.patch
+++ b/net/squid/patches/020-libxml-drop-xmlSetFeature.patch
@@ -1,0 +1,10 @@
+--- a/src/esi/Libxml2Parser.cc
++++ b/src/esi/Libxml2Parser.cc
+@@ -91,7 +91,6 @@ ESILibxml2Parser::ESILibxml2Parser(ESIPa
+ 
+     /* TODO: grab the document encoding from the headers */
+     parser = xmlCreatePushParserCtxt(&sax, static_cast<void *>(this), NULL, 0, NULL);
+-    xmlSetFeature(parser, "substitute entities", 0);
+ 
+     if (entity_doc == NULL)
+         entity_doc = htmlNewDoc(NULL, NULL);


### PR DESCRIPTION
Maintainer: @ratkaj
Compile tested: mxs
Run tested: -

Description:

Add a patch which removes a call in Libxml2Parser.cc to 'xmlSetFeature'. This function belongs to the 'depreciated' API part and is not available in OpenWrt builds.

According to my understanding, this call can be removed safely since it disables the feature "substitute entities" which is disabled by default.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
(cherry picked from commit 3ec47dc85cc4b191be1b2fee3195680343f770e1)
