### PR TITLE
unbound: update to version 1.16.3

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.16.2
+PKG_VERSION:=1.16.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound
-PKG_HASH:=2e32f283820c24c51ca1dd8afecfdb747c7385a137abe865c99db4b257403581
+PKG_HASH:=ea0c6665e2c3325b769eac1dfccd60fe1828d5fcf662650039eccb3f67edb28e
 
 PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/unbound/patches/010-configure-uname.patch
+++ b/net/unbound/patches/010-configure-uname.patch
@@ -3,7 +3,7 @@ Fix cross compile errors by inserting an environment variable for the
 target. Use "uname" on host only if "UNAME" variable is empty.
 --- a/configure.ac
 +++ b/configure.ac
-@@ -814,7 +814,7 @@ if test x_$ub_test_python != x_no; then
+@@ -815,7 +815,7 @@ if test x_$ub_test_python != x_no; then
     fi
  fi
  


### PR DESCRIPTION
Maintainer: @EricLuehrsen 
Compile tested: All Turris routers (Turris 1.x, Turris Omnia, Turris MOX) on all OpenWrt supported versions and as well with OpenWrt 19.07
Run tested: TBD

Description:
Changelog: https://www.nlnetlabs.nl/projects/unbound/download/#unbound-1-16-3
- Fixes: [CVE-2022-3204](https://nlnetlabs.nl/downloads/unbound/CVE-2022-3204.txt)