### PR TITLE
gnunet: add without-libjose to fix buildbot compilation

### DIFF
--- a/net/gnunet/Makefile
+++ b/net/gnunet/Makefile
@@ -44,7 +44,8 @@ CONFIGURE_ARGS+= \
 	--with-png=$(STAGING_DIR)/usr \
 	--with-pulse=$(STAGING_DIR)/usr \
 	--with-libunistring-prefix=$(STAGING_DIR)/usr \
-	--with-microhttpd=$(STAGING_DIR)/usr
+	--with-microhttpd=$(STAGING_DIR)/usr \
+	--without-libjose
 
 # upstream now provides --with-pulseaudio but doesn't detect rpath
 TARGET_LDFLAGS+= -Wl,-rpath-link=$(STAGING_DIR)/usr/lib/pulseaudio


### PR DESCRIPTION
The build process picks up the libjose library although it is not selected as dependency by gnunet.

Fixes errors in the form of:
  Package gnunet-rest is missing dependencies for the following libraries:
  libjose.so.0

Maintainer: @dangowrt 
Compile tested: banana pi r64
Run tested: no
