### PR TITLE
[21.02] tor: update to 0.4.7.10

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.7.7
+PKG_VERSION:=0.4.7.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=3e131158b52b9435d7e43d1c47ef288b96d005342cc44b8c950bb403851a5b44
+PKG_HASH:=647e56dfa59ea36dab052027fcfc7663905c826c03509363c456900ecd435a5b
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Release Notes:
https://forum.torproject.net/t/urgent-stable-release-0-4-5-14-0-4-6-12-and-0-4-7-10

Maintainer: @hauke 
Compile tested: ci
Run tested: noone
