### PR TITLE
zabbix: update to 6.2.3

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=5.0.18
+PKG_VERSION:=6.2.3
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/5.0/
-PKG_HASH:=7d15c4d683801edc2bdcda3fd94afdf6a7142a1a92aa71f4a9220af8e39d9e0e
+PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/6.2/
+PKG_HASH:=2be7e57fb33a55fee71480598e317ffa6a8ee5a39639a7e1b42b2ea6872107b5
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/admin/zabbix/patches/010-change-agentd-config.patch
+++ b/admin/zabbix/patches/010-change-agentd-config.patch
@@ -35,16 +35,16 @@
  
  ##### Active checks related
  
-@@ -151,8 +149,6 @@ Server=127.0.0.1
+@@ -164,8 +162,6 @@ Server=127.0.0.1
  # Default:
  # ServerActive=
  
 -ServerActive=127.0.0.1
 -
  ### Option: Hostname
- #	Unique, case sensitive hostname.
- #	Required for active checks and must match hostname as configured on the server.
-@@ -162,8 +158,6 @@ ServerActive=127.0.0.1
+ #	List of comma delimited unique, case sensitive hostnames.
+ #	Required for active checks and must match hostnames as configured on the server.
+@@ -175,8 +171,6 @@ ServerActive=127.0.0.1
  # Default:
  # Hostname=
  
@@ -53,7 +53,7 @@
  ### Option: HostnameItem
  #	Item used for generating Hostname if it is undefined. Ignored if Hostname is defined.
  #	Does not support UserParameters or aliases.
-@@ -303,8 +297,8 @@ Hostname=Zabbix server
+@@ -326,8 +320,8 @@ Hostname=Zabbix server
  # Include=
  
  # Include=/usr/local/etc/zabbix_agentd.userparams.conf

--- a/admin/zabbix/patches/110-reproducible-builds.patch
+++ b/admin/zabbix/patches/110-reproducible-builds.patch
@@ -1,11 +1,11 @@
 --- a/src/libs/zbxcommon/str.c
 +++ b/src/libs/zbxcommon/str.c
-@@ -54,7 +54,7 @@ static const char	help_message_footer[]
- void	version(void)
+@@ -49,7 +49,7 @@ static const char	help_message_footer[]
+ void	zbx_version(void)
  {
  	printf("%s (Zabbix) %s\n", title_message, ZABBIX_VERSION);
 -	printf("Revision %s %s, compilation time: %s %s\n\n", ZABBIX_REVISION, ZABBIX_REVDATE, __DATE__, __TIME__);
 +	printf("Revision %s %s\n\n", ZABBIX_REVISION, ZABBIX_REVDATE);
  	puts(copyright_message);
- #if defined(HAVE_GNUTLS) || defined(HAVE_OPENSSL)
- 	printf("\n");
+ }
+ 


### PR DESCRIPTION
Updated to 6.2.3 version.
Refreshed patches.

Compile tested: aarch64 cortex-a53
Run tested: aarch64 cortex-a53

Signed-off-by: Scott Roberts <ttocsr@gmail.com>