### PR TITLE
unbound: update control cert uci processing

### DIFF
--- a/net/unbound/files/defaults.sh
+++ b/net/unbound/files/defaults.sh
@@ -53,10 +53,10 @@ UB_TIME_FILE=$UB_VARDIR/hotplug.time
 UB_SKIP_FILE=$UB_VARDIR/skip.time
 
 # control app keys
-UB_CTLKEY_FILE=$UB_ETCDIR/unbound_control.key
-UB_CTLPEM_FILE=$UB_ETCDIR/unbound_control.pem
-UB_SRVKEY_FILE=$UB_ETCDIR/unbound_server.key
-UB_SRVPEM_FILE=$UB_ETCDIR/unbound_server.pem
+UB_CTLKEY_FILE=unbound_control.key
+UB_CTLPEM_FILE=unbound_control.pem
+UB_SRVKEY_FILE=unbound_server.key
+UB_SRVPEM_FILE=unbound_server.pem
 
 # similar default SOA / NS RR as Unbound uses for private ARPA zones
 UB_XSER=$(( $( date +%s ) / 60 ))

--- a/net/unbound/files/unbound.sh
+++ b/net/unbound/files/unbound.sh
@@ -295,18 +295,18 @@ unbound_mkdir() {
 
 
   if [ -x /usr/sbin/unbound-control-setup ] ; then
-    if [ ! -f $UB_CTLKEY_FILE ] || [ ! -f $UB_CTLPEM_FILE ] \
-    || [ ! -f $UB_SRVKEY_FILE ] || [ ! -f $UB_SRVPEM_FILE ] ; then
+    if [ ! -f $UB_ETCDIR/$UB_CTLKEY_FILE ] || [ ! -f $UB_ETCDIR/$UB_CTLPEM_FILE ] \
+    || [ ! -f $UB_ETCDIR/$UB_SRVKEY_FILE ] || [ ! -f $UB_ETCDIR/$UB_SRVPEM_FILE ] ; then
       case "$UB_D_CONTROL" in
         [2-3])
           # unbound-control-setup for encrypt opt. 2 and 3, but not 4 "static"
           /usr/sbin/unbound-control-setup -d $UB_ETCDIR
 
-          chown -R unbound:unbound  $UB_CTLKEY_FILE $UB_CTLPEM_FILE \
-                                    $UB_SRVKEY_FILE $UB_SRVPEM_FILE
+          chown -R unbound:unbound  $UB_ETCDIR/$UB_CTLKEY_FILE $UB_ETCDIR/$UB_CTLPEM_FILE \
+                                    $UB_ETCDIR/$UB_SRVKEY_FILE $UB_ETCDIR/$UB_SRVPEM_FILE
 
-          chmod 640 $UB_CTLKEY_FILE $UB_CTLPEM_FILE \
-                    $UB_SRVKEY_FILE $UB_SRVPEM_FILE
+          chmod 640 $UB_ETCDIR/$UB_CTLKEY_FILE $UB_ETCDIR/$UB_CTLPEM_FILE \
+                    $UB_ETCDIR/$UB_SRVKEY_FILE $UB_ETCDIR/$UB_SRVPEM_FILE
           ;;
       esac
     fi
@@ -338,11 +338,14 @@ unbound_control() {
 
 
   if [ $UB_D_CONTROL -gt 1 ] ; then
-    if [ ! -f $UB_CTLKEY_FILE ] || [ ! -f $UB_CTLPEM_FILE ] \
-    || [ ! -f $UB_SRVKEY_FILE ] || [ ! -f $UB_SRVPEM_FILE ] ; then
+    if [ ! -f $UB_ETCDIR/$UB_CTLKEY_FILE ] || [ ! -f $UB_ETCDIR/$UB_CTLPEM_FILE ] \
+    || [ ! -f $UB_ETCDIR/$UB_SRVKEY_FILE ] || [ ! -f $UB_ETCDIR/$UB_SRVPEM_FILE ] ; then
       # Key files need to be present; if unbound-control-setup was found, then
       # they might have been made during unbound_makedir() above.
       UB_D_CONTROL=0
+    else
+      cp -a $UB_ETCDIR/$UB_CTLKEY_FILE $UB_ETCDIR/$UB_CTLPEM_FILE \
+            $UB_ETCDIR/$UB_SRVKEY_FILE $UB_ETCDIR/$UB_SRVPEM_FILE $UB_VARDIR/
     fi
   fi
 


### PR DESCRIPTION
Run tested: unbound 1.16.2 with these changes and uci "unbound_control"="4", with self-generated certificates in /etc/unbound, ensure that unbound-control on a remote system can successfully interact with the server.

Description: unbound prepends the config dir path to the cert file name config values. This change makes the cert file name values in the generated unbound.conf be only the file names and corresponding path changes in unbound.sh for the cert files. Also, update unbound.sh to copy the cert files from /etc/unbound to /var/lib/unbound

Maintainer: @EricLuehrsen 