### PR TITLE
python3: use tools/expat for host build

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -330,7 +330,7 @@ endif
 HOST_CONFIGURE_ARGS+= \
 	--enable-optimizations \
 	--with-ensurepip=upgrade \
-	--with-system-expat=$(STAGING_DIR_HOSTPKG) \
+	--with-system-expat=$(STAGING_DIR_HOST) \
 	--with-ssl-default-suites=openssl \
 	--without-cxx-main \
 	--without-pymalloc \


### PR DESCRIPTION
Oversight from when the expat host build was removed.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @commodo @jefferyto 