### PR TITLE
ddns-scripts: store device's current IP in <section>.curr_ip file

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=27
+PKG_RELEASE:=28
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -36,6 +36,7 @@ PIDFILE=""		# pid file
 UPDFILE=""		# store UPTIME of last update
 DATFILE=""		# save stdout data of WGet and other external programs called
 ERRFILE=""		# save stderr output of WGet and other external programs called
+CURR_IP_FILE=""
 IPFILE=""		# store registered IP for read by LuCI status
 TLDFILE=/usr/share/public_suffix_list.dat.gz	# TLD file used by split_FQDN
 
@@ -1043,6 +1044,7 @@ get_current_ip () {
 		fi
 		# valid data found return here
 		[ -n "$__DATA" ] && {
+			[ -n "$CURR_IP_FILE" ] && echo "$__DATA" > $CURR_IP_FILE
 			eval "$1=\"$__DATA\""
 			return 0
 		}

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
@@ -100,6 +100,7 @@ PIDFILE="$ddns_rundir/$SECTION_ID.pid"	# Process ID file
 UPDFILE="$ddns_rundir/$SECTION_ID.update"	# last update successful send (system uptime)
 DATFILE="$ddns_rundir/$SECTION_ID.dat"	# save stdout data of WGet and other extern programs called
 ERRFILE="$ddns_rundir/$SECTION_ID.err"	# save stderr output of WGet and other extern programs called
+CURR_IP_FILE="$ddns_rundir/$SECTION_ID.curr_ip"
 IPFILE="$ddns_rundir/$SECTION_ID.ip"	#
 LOGFILE="$ddns_logdir/$SECTION_ID.log"	# log file
 


### PR DESCRIPTION
```
This should be useful for user interfaces (e.g. LuCI) to display DDNS
status. If current IP differs from registered IP it may suggest user
that there is a problem. It could happen if DNS change hasn't propagated
yet or DDNS provider refused change for some reason.
```