### PR TITLE
lcd4linux: minor init improvments

### DIFF
--- a/utils/lcd4linux/Makefile
+++ b/utils/lcd4linux/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lcd4linux
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/feckert/lcd4linux

--- a/utils/lcd4linux/files/lcd4linux.init
+++ b/utils/lcd4linux/files/lcd4linux.init
@@ -5,10 +5,19 @@ START=98
 USE_PROCD=1
 
 PROG="/usr/bin/lcd4linux"
-CONFIGFILE="/etc/lcd4linux.conf"
+STATIC_CONFIG="/etc/lcd4linux.conf"
+DYNAMIC_CONFIG="/tmp/lcd4linux.conf"
 
 start_service() {
-	[ -f /etc/lcd4linux.conf ] || return 1
+	if [ -f "$DYNAMIC_CONFIG" ]; then
+		CONFIGFILE="$DYNAMIC_CONFIG"
+	elif [ -f "$STATIC_CONFIG" ]; then
+		CONFIGFILE="$STATIC_CONFIG"
+	else
+		echo "No config found"
+		return 1
+	fi
+
 	procd_open_instance
 	procd_set_param command "$PROG"
 	procd_append_param command -F

--- a/utils/lcd4linux/files/lcd4linux.init
+++ b/utils/lcd4linux/files/lcd4linux.init
@@ -4,6 +4,7 @@
 START=98
 USE_PROCD=1
 
+DEBUG=1
 PROG="/usr/bin/lcd4linux"
 STATIC_CONFIG="/etc/lcd4linux.conf"
 DYNAMIC_CONFIG="/tmp/lcd4linux.conf"
@@ -24,6 +25,11 @@ start_service() {
 	procd_append_param command -q
 	procd_append_param command -o /tmp/lcd4linux.png
 	procd_append_param command -f "$CONFIGFILE"
+	[ "$DEBUG" = 1 ] && {
+		procd_append_param command -vv
+		procd_set_param stdout 1
+		procd_set_param stderr 1
+	}
 	procd_set_param file "$CONFIGFILE"
 	procd_close_instance
 }


### PR DESCRIPTION
Maintainer: me 
Compile tested: only script changes
Run tested: x86_64, APU3 OpenWrt master, tests done

Description:

* Until now, the configuration must be stored under '/etc/lcd4linux.conf'. So that the configuration can also be changed dynamically, it makes sense to store this under /tmp and load them from this directory. The init script first checks whether there is a configuration under '/etc/lcd4linux.conf' and only then does it try to find it under '/tmp/lcd4linux.conf'. If there is no configuration, an error message is shown.

* Setting the DEBUG variable in the init script to '1' enables the
lcd4linux verbose mode, by setting the arg '-vv'. The option also
redirects the error and stdout to the syslog.