### PR TITLE
libmodbus: update to 3.1.8

### DIFF
--- a/libs/libmodbus/Makefile
+++ b/libs/libmodbus/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmodbus
-PKG_VERSION:=3.1.7
+PKG_VERSION:=3.1.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://libmodbus.org/releases
-PKG_HASH:=7dfe958431d0570b271e1a5b329b76a658e89c614cf119eb5aadb725c87f8fbd
+PKG_SOURCE_URL:=https://github.com/stephane/libmodbus/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=b122f2bc29f749702a22c0a760a7ca2182d541f5fa26bf25e3431f907b606f3c
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 
@@ -36,7 +36,7 @@ define Package/libmodbus/description
   A Modbus library for Linux, Mac OS X, FreeBSD, QNX and Win32.
 endef
 
-CONFIGURE_ARGS += --without-documentation --disable-tests
+CONFIGURE_ARGS += --disable-tests
 TARGET_CFLAGS += $(FPIC)
 
 define Build/InstallDev


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs, custom board

Description:

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
