### PR TITLE
zabbix: add variants for SSL support

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -24,32 +24,11 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 PKG_CONFIG_DEPENDS:= \
-  CONFIG_ZABBIX_GNUTLS \
-  CONFIG_ZABBIX_OPENSSL \
   CONFIG_ZABBIX_MYSQL \
   CONFIG_ZABBIX_POSTGRESQL
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
-
-define Package/zabbix-agentd/config
-comment "SSL support"
-
-choice
-        prompt "Selected SSL library"
-        default ZABBIX_NOSSL
-
-        config ZABBIX_OPENSSL
-                bool "OpenSSL"
-
-        config ZABBIX_GNUTLS
-                bool "GnuTLS"
-
-        config ZABBIX_NOSSL
-                bool "No SSL support"
-
-endchoice
-endef
 
 define Package/zabbix-server/config
 comment "Database Software"
@@ -74,12 +53,31 @@ define Package/zabbix/Default
   TITLE:=Zabbix
   URL:=https://www.zabbix.com/
   USERID:=zabbix=53:zabbix=53
-  DEPENDS += $(ICONV_DEPENDS) +libpcre +zlib +ZABBIX_GNUTLS:libgnutls +ZABBIX_OPENSSL:libopenssl
+  DEPENDS+=$(ICONV_DEPENDS) +libpcre +zlib
 endef
 
 define Package/zabbix-agentd
   $(call Package/zabbix/Default)
   TITLE+= agentd
+  PROVIDES:=zabbix-agentd
+  VARIANT:=nossl
+  DEFAULT_VARIANT:=1
+endef
+
+define Package/zabbix-agentd-openssl
+  $(call Package/zabbix/Default)
+  TITLE+= agentd (with OpenSSL)
+  DEPENDS+= +libopenssl
+  PROVIDES:=zabbix-agentd
+  VARIANT:=openssl
+endef
+
+define Package/zabbix-agentd-gnutls
+  $(call Package/zabbix/Default)
+  TITLE+= agentd (with GnuTLS)
+  DEPENDS+= +libgnutls
+  PROVIDES:=zabbix-agentd
+  VARIANT:=gnutls
 endef
 
 define Package/zabbix-extra-mac80211
@@ -103,20 +101,81 @@ endef
 define Package/zabbix-sender
   $(call Package/zabbix/Default)
   TITLE+= sender
+  PROVIDES:=zabbix-sender
+  VARIANT:=nossl
+  DEFAULT_VARIANT:=1
+endef
+
+define Package/zabbix-sender-openssl
+  $(call Package/zabbix/Default)
+  TITLE+= sender (with OpenSSL)
+  DEPENDS+= +libopenssl
+  PROVIDES:=zabbix-sender
+  VARIANT:=openssl
+endef
+
+define Package/zabbix-sender-gnutls
+  $(call Package/zabbix/Default)
+  TITLE+= sender (with GnuTLS)
+  DEPENDS+= +libgnutls
+  PROVIDES:=zabbix-sender
+  VARIANT:=gnutls
 endef
 
 define Package/zabbix-get
   $(call Package/zabbix/Default)
   TITLE+= get
+  PROVIDES:=zabbix-get
+  VARIANT:=nossl
+  DEFAULT_VARIANT:=1
 endef
 
-define Package/zabbix-server
+define Package/zabbix-get-openssl
+  $(call Package/zabbix/Default)
+  TITLE+= get (with OpenSSL)
+  DEPENDS+= +libopenssl
+  PROVIDES:=zabbix-get
+  VARIANT:=openssl
+endef
+
+define Package/zabbix-get-gnutls
+  $(call Package/zabbix/Default)
+  TITLE+= get (with GnuTLS)
+  DEPENDS+= +libgnutls
+  PROVIDES:=zabbix-get
+  VARIANT:=gnutls
+endef
+
+define Package/zabbix-server/Default
   $(call Package/zabbix/Default)
   TITLE+= server
   DEPENDS += +ZABBIX_POSTGRESQL:libpq \
     +ZABBIX_MYSQL:libmariadbclient \
     +libevent2 \
     +fping
+endef
+
+define Package/zabbix-server
+  $(call Package/zabbix-server/Default)
+  PROVIDES:=zabbix-server
+  VARIANT:=nossl
+  DEFAULT_VARIANT:=1
+endef
+
+define Package/zabbix-server-openssl
+  $(call Package/zabbix-server/Default)
+  TITLE+= (with OpenSSL)
+  PROVIDES:=zabbix-server
+  DEPENDS+= +libopenssl
+  VARIANT:=openssl
+endef
+
+define Package/zabbix-server-gnutls
+  $(call Package/zabbix-server/Default)
+  TITLE+= (with GnuTLS)
+  PROVIDES:=zabbix-server
+  DEPENDS+= +libgnutls
+  VARIANT:=gnutls
 endef
 
 define Package/zabbix-server-frontend
@@ -127,13 +186,36 @@ define Package/zabbix-server-frontend
   +php8-mod-session +php8-mod-sockets +php8-mod-mbstring +php8-mod-gettext
 endef
 
-define Package/zabbix-proxy
+define Package/zabbix-proxy/Default
   $(call Package/zabbix/Default)
   TITLE+= proxy
   DEPENDS += +ZABBIX_POSTGRESQL:libpq \
     +ZABBIX_MYSQL:libmariadbclient \
     +libevent2 \
     +fping
+endef
+
+define Package/zabbix-proxy
+  $(call Package/zabbix-proxy/Default)
+  PROVIDES:=zabbix-proxy
+  VARIANT:=nossl
+  DEFAULT_VARIANT:=1
+endef
+
+define Package/zabbix-proxy-openssl
+  $(call Package/zabbix-proxy/Default)
+  TITLE+= (with OpenSSL)
+  PROVIDES:=zabbix-proxy
+  DEPENDS+= +libopenssl
+  VARIANT:=openssl
+endef
+
+define Package/zabbix-proxy-gnutls
+  $(call Package/zabbix-proxy/Default)
+  TITLE+= (with GnuTLS)
+  PROVIDES:=zabbix-proxy
+  DEPENDS+= +libgnutls
+  VARIANT:=gnutls
 endef
 
 define Package/zabbix-extra-mac80211/description
@@ -164,9 +246,15 @@ CONFIGURE_ARGS+= \
 	$(if $(CONFIG_ZABBIX_POSTGRESQL),--with-postgresql) \
 	--with-libevent=$(STAGING_DIR)/usr/include/libevent \
 	--with-libpcre=$(STAGING_DIR)/usr/include \
-	--with-zlib=$(STAGING_DIR)/usr/include \
-	$(if $(CONFIG_ZABBIX_GNUTLS),--with-gnutls="$(STAGING_DIR)/usr") \
-	$(if $(CONFIG_ZABBIX_OPENSSL),--with-openssl="$(STAGING_DIR)/usr")
+	--with-zlib=$(STAGING_DIR)/usr/include
+
+ifeq ($(BUILD_VARIANT),openssl)
+	CONFIGURE_ARGS+= --with-openssl="$(STAGING_DIR)/usr"
+endif
+
+ifeq ($(BUILD_VARIANT),gnutls)
+	CONFIGURE_ARGS+= --with-gnutls="$(STAGING_DIR)/usr"
+endif
 
 CONFIGURE_VARS += \
 	ac_cv_header_sys_sysinfo_h=no
@@ -221,12 +309,20 @@ endef
 define Package/zabbix-agentd/conffiles
 /etc/zabbix_agentd.conf
 endef
+Package/zabbix-agentd-openssl/conffiles = $(Package/zabbix-agentd/conffiles)
+Package/zabbix-agentd-gnutls/conffiles = $(Package/zabbix-agentd/conffiles)
+
 define Package/zabbix-server/conffiles
 /etc/zabbix_server.conf
 endef
+Package/zabbix-server-openssl/conffiles = $(Package/zabbix-server/conffiles)
+Package/zabbix-server-gnutls/conffiles = $(Package/zabbix-server/conffiles)
+
 define Package/zabbix-proxy/conffiles
 /etc/zabbix_proxy.conf
 endef
+Package/zabbix-proxy-openssl/conffiles = $(Package/zabbix-proxy/conffiles)
+Package/zabbix-proxy-gnutls/conffiles = $(Package/zabbix-proxy/conffiles)
 
 ifdef CONFIG_PACKAGE_zabbix-extra-mac80211
 define Build/Prepare/zabbix-extra-mac80211
@@ -255,6 +351,8 @@ define Package/zabbix-agentd/install
 	$(call Package/zabbix/install/etc,$(1),agentd)
 	$(call Package/zabbix/install/init.d,$(1),agentd)
 endef
+Package/zabbix-agentd-openssl/install = $(Package/zabbix-agentd/install)
+Package/zabbix-agentd-gnutls/install = $(Package/zabbix-agentd/install)
 
 define Package/zabbix-extra-mac80211/install
 	$(call Package/zabbix/install/zabbix.conf.d,$(1),mac80211)
@@ -292,15 +390,21 @@ endef
 define Package/zabbix-sender/install
 	$(call Package/zabbix/install/bin,$(1),sender)
 endef
+Package/zabbix-sender-openssl/install = $(Package/zabbix-sender/install)
+Package/zabbix-sender-gnutls/install = $(Package/zabbix-sender/install)
 
 define Package/zabbix-get/install
 	$(call Package/zabbix/install/bin,$(1),get)
 endef
+Package/zabbix-get-openssl/install = $(Package/zabbix-get/install)
+Package/zabbix-get-gnutls/install = $(Package/zabbix-get/install)
 
 define Package/zabbix-server/install
 	$(call Package/zabbix/install/sbin,$(1),server)
 	$(call Package/zabbix/install/etc,$(1),server)
 endef
+Package/zabbix-server-openssl/install = $(Package/zabbix-server/install)
+Package/zabbix-server-gnutls/install = $(Package/zabbix-server/install)
 
 define Package/zabbix-server-frontend/install
 	$(INSTALL_DIR) $(1)/www/zabbix
@@ -311,13 +415,25 @@ define Package/zabbix-proxy/install
 	$(call Package/zabbix/install/sbin,$(1),proxy)
 	$(call Package/zabbix/install/etc,$(1),proxy)
 endef
+Package/zabbix-proxy-openssl/install = $(Package/zabbix-proxy/install)
+Package/zabbix-proxy-gnutls/install = $(Package/zabbix-proxy/install)
 
 $(eval $(call BuildPackage,zabbix-agentd))
+$(eval $(call BuildPackage,zabbix-agentd-openssl))
+$(eval $(call BuildPackage,zabbix-agentd-gnutls))
 $(eval $(call BuildPackage,zabbix-extra-mac80211))
 $(eval $(call BuildPackage,zabbix-extra-network))
 $(eval $(call BuildPackage,zabbix-extra-wifi))
 $(eval $(call BuildPackage,zabbix-sender))
+$(eval $(call BuildPackage,zabbix-sender-openssl))
+$(eval $(call BuildPackage,zabbix-sender-gnutls))
 $(eval $(call BuildPackage,zabbix-server))
+$(eval $(call BuildPackage,zabbix-server-openssl))
+$(eval $(call BuildPackage,zabbix-server-gnutls))
 $(eval $(call BuildPackage,zabbix-server-frontend))
 $(eval $(call BuildPackage,zabbix-proxy))
+$(eval $(call BuildPackage,zabbix-proxy-openssl))
+$(eval $(call BuildPackage,zabbix-proxy-gnutls))
 $(eval $(call BuildPackage,zabbix-get))
+$(eval $(call BuildPackage,zabbix-get-openssl))
+$(eval $(call BuildPackage,zabbix-get-gnutls))


### PR DESCRIPTION
opkg does not offer ssl varients of zabbix-agentd. resolve this by adding ssl varients.

Compile tested: aarch64 cortex-a53
Run tested: aarch64 cortex-a53

Signed-off-by: Scott Roberts <ttocsr@gmail.com>

Supersedes: https://github.com/openwrt/packages/pull/17846