### PR TITLE
jq: fix hash mismatch problem

### DIFF
--- a/utils/jq/Makefile
+++ b/utils/jq/Makefile
@@ -12,11 +12,14 @@ PKG_VERSION:=1.6
 PKG_RELEASE:=2
 PKG_LICENSE:=BSD
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/stedolan/jq/releases/download/jq-$(PKG_VERSION)/
-PKG_HASH:=9625784cf2e4fd9842f1d407681ce4878b5b0dcddbcd31c6135114a30c71e6a8
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/stedolan/jq.git
+PKG_SOURCE_DATE:=2018-11-02
+PKG_SOURCE_VERSION:=2e01ff1fb69609540b2bdc4e62a60499f2b2fb8e
+PKG_MIRROR_HASH:=ee52d2dce67dfbea633020d11a908d5818145a2bf87e5a0a17c0ff6885a428a7
 PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: @ratkaj 
Compile tested: x86 openwrt 22.03.0
Run tested: x86 openwrt 22.03.0 test done

Description:
change jq source from github to openwrt source, because openwrt hacked/changed jq

[#lede10195](https://github.com/coolsnowwolf/lede/issues/10195) mentioned this problem.