### PR TITLE
lighttpd: remove deprecated modules

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.67
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 # release candidate ~rcX testing; remove for release
 #PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-1.4.67
 
@@ -184,7 +184,6 @@ $(eval $(call BuildPlugin,ajp13,AJP13 Tomcat connector,,30))
 $(eval $(call BuildPlugin,alias,Directory alias,,30))
 $(eval $(call BuildPlugin,cgi,CGI,,30))
 $(eval $(call BuildPlugin,deflate,Compress dynamic output,+PACKAGE_lighttpd-mod-deflate:zlib,30))
-$(eval $(call BuildPlugin,evasive,Evasive,,30))
 $(eval $(call BuildPlugin,evhost,Enhanced Virtual-Hosting,,30))
 $(eval $(call BuildPlugin,expire,Expire,,30))
 $(eval $(call BuildPlugin,extforward,Extract client,,30))
@@ -199,16 +198,13 @@ $(eval $(call BuildPlugin,proxy,Proxy,,30))
 $(eval $(call BuildPlugin,rewrite,URL rewriting,+PACKAGE_lighttpd-mod-rewrite:libpcre2,30))
 $(eval $(call BuildPlugin,rrdtool,RRDtool,,30))
 $(eval $(call BuildPlugin,scgi,SCGI,,30))
-$(eval $(call BuildPlugin,secdownload,Secure and fast download,+PACKAGE_lighttpd-mod-secdownload:libnettle,30))
 $(eval $(call BuildPlugin,setenv,Environment variable setting,,30))
 $(eval $(call BuildPlugin,simple_vhost,Simple virtual hosting,,30))
 $(eval $(call BuildPlugin,sockproxy,sockproxy,,30))
 $(eval $(call BuildPlugin,ssi,SSI,,30))
 $(eval $(call BuildPlugin,staticfile,staticfile,,30))
 $(eval $(call BuildPlugin,status,Server status display,,30))
-$(eval $(call BuildPlugin,uploadprogress,Upload Progress,,30))
 $(eval $(call BuildPlugin,userdir,User directory,,30))
-$(eval $(call BuildPlugin,usertrack,User tracking,+PACKAGE_lighttpd-mod-usertrack:libnettle,30))
 $(eval $(call BuildPlugin,vhostdb,Virtual Host Database,,30))
 $(eval $(call BuildPlugin,vhostdb_dbi,Virtual Host Database (DBI),lighttpd-mod-vhostdb +PACKAGE_lighttpd-mod-vhostdb_dbi:libdbi,30))
 $(eval $(call BuildPlugin,vhostdb_ldap,Virtual Host Database (LDAP),lighttpd-mod-vhostdb +PACKAGE_lighttpd-mod-vhostdb_ldap:libopenldap,30))


### PR DESCRIPTION
Maintainer: @flyn-org
Compile tested: arm_cortex-a9 OpenWrt master

Description:
lighttpd: remove deprecated modules

All of 2022, each lighttpd release has repeated announcements deprecating some minor modules for which full replacements written in lua are available and can be run using [lighttpd mod_magnet](https://wiki.lighttpd.net/Docs_ModMagnet).  The latest release announcement can be found at: https://www.lighttpd.net/2022/9/17/1.4.67/

From the **Future Scheduled Behavior Changes** section of the annoucement:

*    Continue gradual deprecation of “mini-application” lighttpd modules
    for which mod_magnet lua implementations are better and more flexible.
    Please post on lighttpd forums to share feedback if you use these modules.
    Forums: https://redmine.lighttpd.net/projects/lighttpd/boards

*    Deprecated: mod_evasive will be removed.
    mod_evasive can be replaced by mod_magnet and a few lines of lua:
    Replacement: https://wiki.lighttpd.net/ModMagnetExamples#lua-mod_evasive
    https://wiki.lighttpd.net/AbsoLUAtion#Fight-DDoS
    https://wiki.lighttpd.net/AbsoLUAtion#Mod_Security

*    Deprecated: mod_secdownload will be removed.
    mod_secdownload can be replaced by mod_magnet and a few lines of lua:
    Replacement: https://wiki.lighttpd.net/ModMagnetExamples#lua-mod_secdownload
    mod_secdownload historically uses insecure MD5 though SHA1, SHA256 available

*    Deprecated: mod_uploadprogress will be removed.
    mod_uploadprogress can be replaced by mod_magnet and a few lines of lua:
    Replacement: https://wiki.lighttpd.net/ModMagnetExamples#lua-mod_uploadprogress

*   Deprecated: mod_usertrack will be removed.
    mod_usertrack can be replaced by mod_magnet and a few lines of lua:
    Replacement: https://wiki.lighttpd.net/ModMagnetExamples#lua-mod_usertrack
    mod_usertrack historically uses insecure MD5.