### PR TITLE
mwan3: support offload routing modifier

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.11.1
+PKG_VERSION:=2.11.2
 PKG_RELEASE:=3
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>

--- a/net/mwan3/files/lib/mwan3/common.sh
+++ b/net/mwan3/files/lib/mwan3/common.sh
@@ -140,7 +140,7 @@ mwan3_init()
 	# remove "linkdown", expiry and source based routing modifiers from route lines
 	config_get_bool source_routing globals source_routing 0
 	[ $source_routing -eq 1 ] && unset source_routing
-	MWAN3_ROUTE_LINE_EXP="s/linkdown //; s/expires [0-9]\+sec//; s/error [0-9]\+//; ${source_routing:+s/default\(.*\) from [^ ]*/default\1/;} p"
+	MWAN3_ROUTE_LINE_EXP="s/offload//; s/linkdown //; s/expires [0-9]\+sec//; s/error [0-9]\+//; ${source_routing:+s/default\(.*\) from [^ ]*/default\1/;} p"
 
 	# mark mask constants
 	bitcnt=$(mwan3_count_one_bits MMX_MASK)


### PR DESCRIPTION
Signed-off-by: Denys Yarkovyi <dyarkovoy@gmail.com>

Maintainer: @feckert
Compile tested: RTL8380, Netgear GS308T v1, OpenWrt OpenWrt SNAPSHOT r20775-165b66d910
Run tested: RTL8380, Netgear GS308T v1, OpenWrt OpenWrt SNAPSHOT r20775-165b66d910, routes are being added correctly

Description:
This solves https://github.com/openwrt/packages/issues/19488 by supporting a routing modifier "offload"
