### PR TITLE
[22.03] https-dns-proxy: bugfix: prevent canary domains duplicates

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2021-11-22
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -257,7 +257,7 @@ dnsmasq_doh_server() {
 		add)
 			if [ "$forceDNS" -ne 0 ]; then
 				for i in $canaryDomains; do
-					uci_add_list 'dhcp' "$cfg" 'server' "/${i}/"
+					uci_add_list_if_new 'dhcp' "$cfg" 'server' "/${i}/"
 				done
 			fi
 			case $address in


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-135, OpenWrt 22.03.0
Run tested: x86_64, Sophos SG-135, OpenWrt 22.03.0, start twice, verify no duplicates for canary domains

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit f99ada410fa799b419ca7819ed2bbcf779ec3d12)
