### PR TITLE
node: bump to v16.17.1

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v16.17.0
+PKG_VERSION:=v16.17.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=1d28c285685e446985921bc963565ca9c0c5f4fda9755e489c06808ea9795645
+PKG_HASH:=6721feb4152d56d2c6b358ce397abd5a7f1daf09ee2e25c5021b9b4d3f86a330
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: head, aarch64, arm, i386, x86_64, mipsel (pistachio) 
Run tested: (qemu 7.1.0) aarch64

Description:
Update to v16.17.1

The following CVEs are fixed in this release:
* CVE-2022-32212: DNS rebinding in --inspect on macOS (High) * Insufficient fix for macOS devices on v18.5.0
* CVE-2022-32222: Node 18 reads openssl.cnf from /home/iojs/build/ upon startup on MacOS (Medium)
* CVE-2022-32213: HTTP Request Smuggling - Flawed Parsing of Transfer-Encoding (Medium) * Insufficient fix on v18.5.0
* CVE-2022-32215: HTTP Request Smuggling - Incorrect Parsing of Multi-line Transfer-Encoding (Medium) * Insufficient fix on v18.5.0
* CVE-2022-35256: HTTP Request Smuggling - Incorrect Parsing of Header Fields (Medium)
* CVE-2022-35255: Weak randomness in WebCrypto keygen More detailed information on each of the vulnerabilities can be found in September 22nd 2022 Security Releases blog post.

llhttp updated to 6.0.10
llhttp is updated to 6.0.10 which includes fixes for the following vulnerabilities.
* HTTP Request Smuggling - CVE-2022-32213 bypass via obs-fold mechanic (Medium)(CVE-2022-32213 ): The llhttp parser in the http module does not correctly parse and validate Transfer-Encoding headers. This can lead to HTTP Request Smuggling (HRS).
* HTTP Request Smuggling - Incorrect Parsing of Multi-line Transfer-Encoding (Medium)(CVE-2022-32215): The llhttp parser in the http module does not correctly handle multi-line Transfer-Encoding headers. This can lead to HTTP Request Smuggling (HRS).
* HTTP Request Smuggling - Incorrect Parsing of Header Fields (Medium)(CVE-35256): The llhttp parser in the http does not correctly handle header fields that are not terminated with CLRF. This can lead to HTTP Request Smuggling (HRS).

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
