### PR TITLE
lighttpd: document crypto lib options in Makefile

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,9 +9,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.67
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 # release candidate ~rcX testing; remove for release
-#PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-1.4.67
+#PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x
@@ -22,12 +22,57 @@ PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:lighttpd:lighttpd
 
-PKG_CONFIG_DEPENDS:=CONFIG_LIGHTTPD_SSL $(patsubst %,CONFIG_PACKAGE_lighttpd-mod-%,$(REBUILD_MODULES))
+# list config packages affecting MESON_ARGS
+REBUILD_MODULES:= \
+  authn_dbi \
+  authn_gssapi \
+  authn_ldap \
+  authn_pam \
+  authn_sasl \
+  deflate \
+  gnutls \
+  magnet \
+  maxminddb \
+  mbedtls \
+  nss \
+  openssl \
+  vhostdb_dbi \
+  vhostdb_ldap \
+  vhostdb_mysql \
+  vhostdb_pgsql \
+  webdav \
+  wolfssl \
 
-REBUILD_MODULES=authn_gssapi authn_ldap magnet webdav
+PKG_CONFIG_DEPENDS:= \
+  $(patsubst %,CONFIG_PACKAGE_lighttpd-mod-%,$(REBUILD_MODULES)) \
+  CONFIG_LIGHTTPD_PCRE2 \
+  CONFIG_LIGHTTPD_CRYPTOLIB_NONE \
+  CONFIG_LIGHTTPD_CRYPTOLIB_NETTLE \
+  CONFIG_LIGHTTPD_CRYPTOLIB_MBEDTLS \
+  CONFIG_LIGHTTPD_CRYPTOLIB_WOLFSSL
+
+PKG_BUILD_DEPENDS:= \
+  LIGHTTPD_PCRE2:pcre2 \
+  LIGHTTPD_CRYPTOLIB_NETTLE:nettle \
+  LIGHTTPD_CRYPTOLIB_MBEDTLS:mbedtls \
+  LIGHTTPD_CRYPTOLIB_WOLFSSL:wolfssl
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/meson.mk
+
+# choose crypto lib for lighttpd to use for crypto algorithms
+# (separate from lighttpd TLS modules, which are each standalone)
+ifdef CONFIG_LIGHTTPD_CRYPTOLIB_NONE)
+  cryptolib=
+else ifdef CONFIG_LIGHTTPD_CRYPTOLIB_NETTLE
+  cryptolib=libnettle
+else ifdef CONFIG_LIGHTTPD_CRYPTOLIB_MBEDTLS
+  cryptolib=libmbedtls
+  TARGET_CPPFLAGS += -DFORCE_MBEDTLS_CRYPTO
+else ifdef CONFIG_LIGHTTPD_CRYPTOLIB_WOLFSSL
+  cryptolib=libwolfssl
+  TARGET_CPPFLAGS += -DFORCE_WOLFSSL_CRYPTO
+endif
 
 define Package/lighttpd/Default
   SECTION:=net
@@ -39,13 +84,15 @@ endef
 define Package/lighttpd
   $(call Package/lighttpd/Default)
   MENU:=1
-  DEPENDS:=+libnettle +libpcre2 +libpthread +LIGHTTPD_LOGROTATE:logrotate
+  DEPENDS:=+libpthread +LIGHTTPD_LOGROTATE:logrotate \
+           $(if $(CONFIG_LIGHTTPD_PCRE2),+libpcre2,) \
+           $(if $(cryptolib),+$(cryptolib),)
   TITLE:=A flexible and lightweight web server
 endef
 
 define Package/lighttpd/config
 config LIGHTTPD_SSL
-	bool "SSL support"
+	bool "SSL support (recommended)"
 	depends on PACKAGE_lighttpd
 	default y
 	help
@@ -65,6 +112,34 @@ config LIGHTTPD_SSL_SELECT
         depends on LIGHTTPD_SSL
         default m if !LIGHTTPD_SSL_DEPENDS
         select PACKAGE_lighttpd-mod-openssl
+
+config LIGHTTPD_PCRE2
+	bool "PCRE2 support (recommended)"
+	depends on PACKAGE_lighttpd
+	default y
+	help
+	  PCRE2 regular expressions for lighttpd.conf conditions
+
+if PACKAGE_lighttpd
+	choice
+		prompt "crypto library"
+		default LIGHTTPD_CRYPTOLIB_NETTLE
+		help
+		  library to use for cryptographic algorithms
+
+		config LIGHTTPD_CRYPTOLIB_NONE
+			bool "None"
+
+		config LIGHTTPD_CRYPTOLIB_NETTLE
+			bool "libnettle"
+
+		config LIGHTTPD_CRYPTOLIB_MBEDTLS
+			bool "libmbedtls"
+
+		config LIGHTTPD_CRYPTOLIB_WOLFSSL
+			bool "libwolfssl"
+	endchoice
+endif
 
 config LIGHTTPD_LOGROTATE
 	bool "Logrotate support"
@@ -89,11 +164,11 @@ MESON_ARGS += \
 	-Dwith_maxminddb=$(if $(CONFIG_PACKAGE_lighttpd-mod-maxminddb),true,false) \
 	-Dwith_mbedtls=$(if $(CONFIG_PACKAGE_lighttpd-mod-mbedtls),true,false) \
 	-Dwith_mysql=$(if $(CONFIG_PACKAGE_lighttpd-mod-vhostdb_mysql),true,false) \
-	-Dwith_nettle=true \
+	-Dwith_nettle=$(if $(filter libnettle,$(cryptolib)),true,false) \
 	-Dwith_nss=$(if $(CONFIG_PACKAGE_lighttpd-mod-nss),true,false) \
 	-Dwith_openssl=$(if $(CONFIG_PACKAGE_lighttpd-mod-openssl),true,false) \
 	-Dwith_pam=$(if $(CONFIG_PACKAGE_lighttpd-mod-authn_pam),true,false) \
-	-Dwith_pcre2=true \
+	-Dwith_pcre2=$(if $(CONFIG_LIGHTTPD_PCRE2),true,false) \
 	-Dwith_pgsql=$(if $(CONFIG_PACKAGE_lighttpd-mod-vhostdb_pgsql),true,false) \
 	-Dwith_sasl=$(if $(CONFIG_PACKAGE_lighttpd-mod-authn_sasl),true,false) \
 	-Dwith_webdav_locks=$(if $(CONFIG_PACKAGE_lighttpd-mod-webdav),true,false) \
@@ -165,19 +240,14 @@ endef
 
 $(eval $(call BuildPackage,lighttpd))
 
-# First, permit redirect from HTTP to HTTPS.
-$(eval $(call BuildPlugin,redirect,URL redirection,+PACKAGE_lighttpd-mod-redirect:libpcre2,10))
-
-# Next, permit authentication.
-$(eval $(call BuildPlugin,auth,Authentication,+PACKAGE_lighttpd-mod-auth:libnettle,20))
-$(eval $(call BuildPlugin,authn_dbi,DBI-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_dbi:libnettle +PACKAGE_lighttpd-mod-authn_dbi:libdbi,20))
-$(eval $(call BuildPlugin,authn_file,File-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_file:libnettle,20))
+$(eval $(call BuildPlugin,auth,Authentication,$(if $(cryptolib),+PACKAGE_lighttpd-mod-auth:$(cryptolib),),20))
+$(eval $(call BuildPlugin,authn_dbi,DBI-based authentication,lighttpd-mod-auth $(if $(cryptolib),+PACKAGE_lighttpd-mod-authn_dbi:$(cryptolib),) +PACKAGE_lighttpd-mod-authn_dbi:libdbi,20))
+$(eval $(call BuildPlugin,authn_file,File-based authentication,lighttpd-mod-auth $(if $(cryptolib),+PACKAGE_lighttpd-mod-authn_file:$(cryptolib),),20))
 $(eval $(call BuildPlugin,authn_gssapi,Kerberos-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_gssapi:krb5-libs,20))
 $(eval $(call BuildPlugin,authn_ldap,LDAP-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_ldap:libopenldap,20))
 $(eval $(call BuildPlugin,authn_pam,PAM-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_pam:libpam,20))
 $(eval $(call BuildPlugin,authn_sasl,SASL-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_sasl:libsasl2,20))
 
-# Finally, everything else.
 $(eval $(call BuildPlugin,access,Access restrictions,,30))
 $(eval $(call BuildPlugin,accesslog,Access logging,,30))
 $(eval $(call BuildPlugin,ajp13,AJP13 Tomcat connector,,30))
@@ -195,7 +265,8 @@ $(eval $(call BuildPlugin,mbedtls,TLS using mbedtls,@LIGHTTPD_SSL +PACKAGE_light
 $(eval $(call BuildPlugin,nss,TLS using nss,@LIGHTTPD_SSL +PACKAGE_lighttpd-mod-nss:libnss,30))
 $(eval $(call BuildPlugin,openssl,TLS using openssl,@LIGHTTPD_SSL +PACKAGE_lighttpd-mod-openssl:libopenssl,30))
 $(eval $(call BuildPlugin,proxy,Proxy,,30))
-$(eval $(call BuildPlugin,rewrite,URL rewriting,+PACKAGE_lighttpd-mod-rewrite:libpcre2,30))
+$(eval $(call BuildPlugin,redirect,URL redirection,$(if $(CONFIG_LIGHTTPD_PCRE2),+PACKAGE_lighttpd-mod-redirect:libpcre2,),10))
+$(eval $(call BuildPlugin,rewrite,URL rewriting,$(if $(CONFIG_LIGHTTPD_PCRE2),+PACKAGE_lighttpd-mod-rewrite:libpcre2,),30))
 $(eval $(call BuildPlugin,rrdtool,RRDtool,,30))
 $(eval $(call BuildPlugin,scgi,SCGI,,30))
 $(eval $(call BuildPlugin,setenv,Environment variable setting,,30))
@@ -212,4 +283,4 @@ $(eval $(call BuildPlugin,vhostdb_mysql,Virtual Host Database (MariaDB),lighttpd
 $(eval $(call BuildPlugin,vhostdb_pgsql,Virtual Host Database (PostgreSQL),lighttpd-mod-vhostdb +PACKAGE_lighttpd-mod-vhostdb_pgsql:libpq,30))
 $(eval $(call BuildPlugin,webdav,WebDAV,+PACKAGE_lighttpd-mod-webdav:libsqlite3 +PACKAGE_lighttpd-mod-webdav:libuuid +PACKAGE_lighttpd-mod-webdav:libxml2,30))
 $(eval $(call BuildPlugin,wolfssl,TLS using wolfssl,@LIGHTTPD_SSL +PACKAGE_lighttpd-mod-wolfssl:libwolfssl,30))
-$(eval $(call BuildPlugin,wstunnel,Websocket tunneling,+PACKAGE_lighttpd-mod-wstunnel:libnettle,30))
+$(eval $(call BuildPlugin,wstunnel,Websocket tunneling,$(if $(cryptolib),+PACKAGE_lighttpd-mod-wstunnel:$(cryptolib),),30))


### PR DESCRIPTION
Maintainer: @flyn-org
Compile tested: arm_cortex-a9 OpenWrt master

Description:
lighttpd: document crypto lib options in Makefile

Follow-up from https://github.com/openwrt/packages/issues/18851

I suspect there will be some discussion about how to do this, and perhaps to create an option in the config, so I will mark this as a draft.

---

Please note that due to a merge (https://github.com/openwrt/packages/commit/845d81ca0976c82829addc23e9e8b95885c910ee)  which occurred after https://github.com/openwrt/packages/pull/19498 was submitted but before the PR was merged, PKG_RELEASE was not bumped twice, as it should have been.  I do not think it a big deal since the end result is that the package was rebuilt.  However, the change made in the PR might not get to people until the next package release if they had downloaded PKG_RELEASE=2 before the PR was merged.