### PR TITLE
isc-dhcp: support sending explicit default route

### DIFF
--- a/net/isc-dhcp/files/dhcpd.init
+++ b/net/isc-dhcp/files/dhcpd.init
@@ -157,7 +157,7 @@ append_routes() {
 		octets=$((($prefix + 7) / 8))
 		compacted="$(echo "$network" | cut -d. -f1-$octets)"
 
-		string="${string:+, }$(explode "$prefix.$compacted.$router")"
+		string="${string:+, }$(explode "$prefix${compacted:+.$compacted}.$router")"
 	done
 
 	echo " option classless-ipv4-route $string;"


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, generic, HEAD (60738feded)
Run tested: same, installed on production router

Description:

For the default route (0/0), the prefix is 0, therefore 0 destination octets are specified, and the destination descriptor is just the width (0), with no subsequent octets of subnet portion.