### PR TITLE
modemmanager: Adding support for 'allow_roaming' option to configure roaming support on modem connection

### DIFF
--- a/net/modemmanager/README.md
+++ b/net/modemmanager/README.md
@@ -24,6 +24,7 @@ Once installed, you can configure the 2G/3G/4G modem connections directly in
         option iptype      'ipv4'
         option lowpower    '1'
         option signalrate  '30'
+        option allow_roaming '1'
 
 Only 'device' and 'proto' are mandatory options, the remaining ones are all
 optional.

--- a/net/modemmanager/files/modemmanager.proto
+++ b/net/modemmanager/files/modemmanager.proto
@@ -345,6 +345,7 @@ proto_modemmanager_init_config() {
 	proto_config_add_string	 iptype
 	proto_config_add_int	 signalrate
 	proto_config_add_boolean lowpower
+	proto_config_add_boolean allow_roaming
 	proto_config_add_defaults
 }
 
@@ -355,11 +356,11 @@ proto_modemmanager_setup() {
 	local bearermethod_ipv4 bearermethod_ipv6 auth cliauth
 	local operatorname operatorid registration accesstech signalquality
 
-	local device apn allowedauth username password pincode iptype metric signalrate
+	local device apn allowedauth username password pincode iptype metric signalrate allow_roaming
 
 	local address prefix gateway mtu dns1 dns2
 
-	json_get_vars device apn allowedauth username password pincode iptype metric signalrate
+	json_get_vars device apn allowedauth username password pincode iptype metric signalrate allow_roaming
 
 	# validate sysfs path given in config
 	[ -n "${device}" ] || {
@@ -397,7 +398,15 @@ proto_modemmanager_setup() {
 	echo "starting connection with apn '${apn}'..."
 	proto_notify_error "${interface}" MM_CONNECT_IN_PROGRESS
 
-	connectargs="apn=${apn}${iptype:+,ip-type=${iptype}}${cliauth:+,allowed-auth=${cliauth}}${username:+,user=${username}}${password:+,password=${password}}${pincode:+,pin=${pincode}}"
+	# setup allow-roaming parameter
+	if [ -n "${allow_roaming}" ] && [ "${allow_roaming}" -eq 0 ];then
+		allow_roaming="no"
+	else
+		# allowed unless a user set the opposite
+		allow_roaming="yes"
+	fi
+
+	connectargs="apn=${apn},allow-roaming=${allow_roaming}${iptype:+,ip-type=${iptype}}${cliauth:+,allowed-auth=${cliauth}}${username:+,user=${username}}${password:+,password=${password}}${pincode:+,pin=${pincode}}"
 	mmcli --modem="${device}" --timeout 120 --simple-connect="${connectargs}" || {
 		proto_notify_error "${interface}" MM_CONNECT_FAILED
 		proto_block_restart "${interface}"


### PR DESCRIPTION
Signed-off-by: Francisco Jose Alvarez <francisco.alvarez@galgus.net>

Maintainer: @mips171  [nicholas@nbembedded.com], @aleksander0m 
Compile tested: ath79
Run tested: Tested with RM500Q-AE modem

Description:

'allow_roaming' allows you to configure roaming support for the modem connection by uci option