### PR TITLE
python-certifi: bump to 2022.9.24

### DIFF
--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
-PKG_VERSION:=2021.10.8
+PKG_VERSION:=2022.9.24
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
@@ -14,7 +14,7 @@ PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PYPI_NAME:=certifi
-PKG_HASH:=78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872
+PKG_HASH:=0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -26,7 +26,7 @@ define Package/python3-certifi
   CATEGORY:=Languages
   TITLE:=Python package for Mozilla's CA Bundle
   URL:=http://certifi.io/
-  DEPENDS:=+python3-light
+  DEPENDS:=+python3-light +python3-urllib
 endef
 
 define Package/python3-certifi/description


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64, mediatek/mt7622, Linksys E8450
Run tested: same as above.  Tested with python3 -m certifi

Description:
This version updates the CA bundle, and needs urllib as dependency.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

----

As for the urllib dependency, it is not used directly in the code, but appears to be an importlib dependency, installed by python3-light.  When I first tried to run it, it failed:
```
# python3 -m certifi
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 187, in _run_module_as_main
  File "/usr/lib/python3.10/runpy.py", line 146, in _get_module_details
  File "/usr/lib/python3.10/runpy.py", line 110, in _get_module_details
  File "/usr/lib/python3.10/site-packages/certifi/__init__.py", line 1, in <module>
  File "/usr/lib/python3.10/site-packages/certifi/core.py", line 46, in <module>
  File "/usr/lib/python3.10/importlib/resources.py", line 4, in <module>
  File "/usr/lib/python3.10/importlib/_common.py", line 2, in <module>
  File "/usr/lib/python3.10/pathlib.py", line 14, in <module>
ModuleNotFoundError: No module named 'urllib'
```
python3-light, by definition, can't handle everything.  I just want to make sure this behavior is by design before I add a redundant dependency.  Ping @jefferyto 