### PR TITLE
bind: bump to 9.18.7

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.18.1
+PKG_VERSION:=9.18.7
 PKG_RELEASE:=$(AUTORELEASE)
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=57c7afd871694d615cb4defb1c1bd6ed023350943d7458414db8d493ef560427
+PKG_HASH:=9e2acf1698f49d70ad12ffbad39ec6716a7da524e9ebd98429c7c70ba1262981
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Fixes multiple security issues:


CVE-2022-38178 - Fix memory leak in EdDSA verify processing

CVE-2022-3080 - Fix serve-stale crash that could happen when
			stale-answer-client-timeout was set to 0 and there was
			a stale CNAME in the cache for an incoming query

CVE-2022-2906 - Fix memory leaks in the DH code when using OpenSSL 3.0.0
			and later versions. The openssldh_compare(),
			openssldh_paramcompare(), and openssldh_todns()
			functions were affected

CVE-2022-2881 - When an HTTP connection was reused to get
			statistics from the stats channel, and zlib
			compression was in use, each successive
			response sent larger and larger blocks of memory,
			potentially reading past the end of the allocated
			buffer

CVE-2022-2795 - Prevent excessive resource use while processing large
			delegations

Signed-off-by: Noah Meyerhans <frodo@morgul.net>
(cherry picked from commit 58bcd3fad37eaf56d4dbeecc0c73abe464e7e987)

Maintainer: me
Compile tested: x86_64
Run tested: x86_64

