### PR TITLE
django-restframework: bump to version 3.14.0

### DIFF
--- a/lang/python/django-restframework/Makefile
+++ b/lang/python/django-restframework/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-restframework
-PKG_VERSION:=3.13.1
+PKG_VERSION:=3.14.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PYPI_NAME:=djangorestframework
-PKG_HASH:=0c33407ce23acc68eca2a6e46424b008c9c02eceb8cf18581921d0092bc1f2ee
+PKG_HASH:=579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/3848cf458ef998fc9971edd6a01cc9cdb43fbef9
Run tested: same version

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>