### PR TITLE
curl: allow curl builds with IDN support

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -6,10 +6,11 @@
 #
 
 include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=7.85.0
-PKG_RELEASE:=$(AUTORELEASE).1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-135, OpenWrt 22.03
Run tested: x86_64, Sophos SG-135, OpenWrt 22.03, install new package, verify that it requires libidn2

Description:
* fixes https://github.com/openwrt/packages/issues/18736

Signed-off-by: Stan Grishin <stangri@melmac.ca>

@ynezz @neheb could you please review/provide feedback on this? I'm getting out of my depth.
