### PR TITLE
gnutls: update to 3.7.8

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
-PKG_VERSION:=3.7.7
+PKG_VERSION:=3.7.8
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7
-PKG_HASH:=be9143d0d58eab64dba9b77114aaafac529b6c0d7e81de6bdf1c9b59027d2106
+PKG_HASH:=c58ad39af0670efe6a8aee5e3a8b2331a1200418b64b7c51977fb396d4617114
 
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <nmav@gnutls.org>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Release Notes:
https://lists.gnupg.org/pipermail/gnutls-help/2022-September/004765.html

Signed-off-by: Nick Hainke <vincent@systemli.org>

Maintainer: @nmav 
Compile tested: CI
Run tested: no
