### PR TITLE
squeezelite: add opus codec support

### DIFF
--- a/sound/squeezelite/Makefile
+++ b/sound/squeezelite/Makefile
@@ -36,8 +36,9 @@ define Package/squeezelite-full
     $(call Package/squeezelite/default)
     TITLE+= (full)
     DEPENDS+= +libflac +libvorbis +libmpg123 +libfaad2 \
-              +SQUEEZELITE_WMA:libffmpeg-audio-dec \
-              +SQUEEZELITE_SSL:libopenssl
+              +SQUEEZELITE_OPUS:libopusfile \
+              +SQUEEZELITE_SSL:libopenssl \
+              +SQUEEZELITE_WMA:libffmpeg-audio-dec
     VARIANT:=full
 endef
 
@@ -73,6 +74,12 @@ define Package/squeezelite/config/default
 	    help
 		Include SSL/TLS support for use with e.g. https media URLs
 	    default n
+
+	config SQUEEZELITE_OPUS
+	    bool "Opus codec support"
+	    help
+		Include Opus codec support
+	    default n
 endef
 
 define Package/squeezelite-full/config
@@ -91,7 +98,7 @@ define Package/squeezelite/description/default
     Squeezelite is a small headless squeezebox emulator for linux using alsa audio output
     It is aimed at supporting high quality audio at multiple sample rates including
     44.1/48/88.2/96/176.4/192k/352.8/384kHz
-    Supported codecs: mp3, flac, ogg, aac, (wma and alac via ffmpeg)
+    Supported codecs: mp3, flac, ogg, aac, (wma and alac via ffmpeg), opus (optional)
     Native support for PCM builtin
     Optional support of DSD playback via PCM for DoP capable DAC
     Optional resampling to match sound device
@@ -123,6 +130,11 @@ endif
 
 ifeq ($(CONFIG_SQUEEZELITE_SSL),y)
     opts+= -DUSE_SSL
+endif
+
+ifeq ($(CONFIG_SQUEEZELITE_OPUS),y)
+    opts+= -DOPUS
+    TARGET_CFLAGS+=-I$(STAGING_DIR)/usr/include/opus
 endif
 
 ifeq ($(BUILD_VARIANT),full)


### PR DESCRIPTION
Signed-off-by: Robert Högberg <robert.hogberg@gmail.com>

Maintainer: @thess 
Compile tested: ath79, D-Link DIR-825 B1, OpenWrt 21.02
Run tested: ath79, D-Link DIR-825 B1, OpenWrt 21.02 - I've verified that playing opus and mp3 files works
