### PR TITLE
ddns-scripts: add PROVIDES for old package names

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=27
+PKG_RELEASE:=28
 
 PKG_LICENSE:=GPL-2.0
 
@@ -50,6 +50,7 @@ endef
 define Package/ddns-scripts-services
   $(call Package/ddns-scripts/Default)
   TITLE:=Common ddns providers
+  PROVIDES:=ddns-scripts_service
 endef
 
 define Package/ddns-scripts-services/description
@@ -61,6 +62,7 @@ define Package/ddns-scripts-cloudflare
   $(call Package/ddns-scripts/Default)
   TITLE:=Extension for cloudflare.com API v4
   DEPENDS:=ddns-scripts +curl
+  PROVIDES:=ddns-scripts_digitalocean.com-v2
 endef
 
 define Package/ddns-scripts-cloudflare/description
@@ -72,6 +74,7 @@ define Package/ddns-scripts-freedns
   $(call Package/ddns-scripts/Default)
   TITLE:=Extension for freedns.42.pl
   DEPENDS:=ddns-scripts +curl
+  PROVIDES:=ddns-scripts_freedns_42_pl
 endef
 
 define Package/ddns-scripts-freedns/description
@@ -83,6 +86,7 @@ define Package/ddns-scripts-godaddy
   $(call Package/ddns-scripts/Default)
   TITLE:=Extension for godaddy.com API v1
   DEPENDS:=ddns-scripts +curl
+  PROVIDES:=ddns-scripts_godaddy.com-v1
 endef
 
 define Package/ddns-scripts-godaddy/description
@@ -123,6 +127,7 @@ define Package/ddns-scripts-noip
   $(call Package/ddns-scripts/Default)
   TITLE:=Extension for no-ip.com
   DEPENDS:=ddns-scripts
+  PROVIDES:=ddns-scripts_no-ip_com
 endef
 
 define Package/ddns-scripts-noip/description
@@ -147,6 +152,7 @@ define Package/ddns-scripts-nsupdate
   $(call Package/ddns-scripts/Default)
   TITLE:=Extension for using bind nsupdate.
   DEPENDS:=ddns-scripts +bind-client
+  PROVIDES:=ddns-scripts_nsupdate
 endef
 
 define Package/ddns-scripts-nsupdate/description
@@ -164,6 +170,7 @@ define Package/ddns-scripts-route53
   $(call Package/ddns-scripts/Default)
   TITLE:=Extension for route53 API v1
   DEPENDS:=ddns-scripts +curl +openssl-util
+  PROVIDES:=ddns-scripts_route53-v1
 endef
 
 define Package/ddns-scripts-route53/description
@@ -180,6 +187,7 @@ define Package/ddns-scripts-cnkuai
   $(call Package/ddns-scripts/Default)
   TITLE:=CnKuai API
   DEPENDS:=ddns-scripts +curl +giflib-utils
+  PROVIDES:=ddns-scripts_cnkuai_cn
 endef
 
 define Package/ddns-scripts-cnkuai/description


### PR DESCRIPTION
Maintainer: I can't find anyone in the Makefile and looking at history doesn't help
Compile tested: armv7l, Turris Omnia, OpenWrt 21.02
Run tested: -

Description:
* ddns-scripts-services: provide ddns-scripts_service
* ddns-scripts-cloudflare: provide ddns-scripts_digitalocean.com-v2
* ddns-scripts-freedns: provide ddns-scripts_freedns_42_pl
* ddns-scripts-godaddy: provide ddns-scripts_godaddy.com-v1
* ddns-scripts-noip: provide ddns-scripts_no-ip_com
* ddns-scripts-nsupdate: provide ddns-scripts_nsupdate
* ddns-scripts-route53: provide ddns-scripts_route53-v1
* ddns-scripts-cnkuai: provide ddns-scripts_cnkuai_cn

https://github.com/openwrt/packages/pull/13509 by @feckert renamed many ddns-scripts packages, but didn't include a PROVIDES for the old package names to make updates work well.

This is should be applied to all stable branches because the rename happened with 21.02.