### PR TITLE
iputils: provide iputils-ping6 in iputils-ping

### DIFF
--- a/net/iputils/Makefile
+++ b/net/iputils/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iputils
 PKG_VERSION:=20211215
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/iputils/iputils/tar.gz/$(PKG_VERSION)?
@@ -51,6 +51,7 @@ define Package/iputils-ping
   $(call Package/iputils/Default)
   TITLE:=iputils-ping
   DEPENDS:=+kmod-crypto-md5
+  PROVIDES:=iputils-ping6
 endef
 
 define Package/iputils-ping/config


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile tested: armv7l, Turris Omnia, OpenWrt 21.02

Description: iputils-ping6 was a subpackage of the iputils package providing the ping4 and ping6 command before iputils was moved from core to packages. Currently ping4 and ping6 are replaced by ping -4/-6 and compatibility symlinks are only installed when explicitly told so with an option, but the functionality is always provided by iputils-ping.
