### PR TITLE
xfrpc: allow server_addr as ip or domain

### DIFF
--- a/net/xfrpc/files/xfrpc.init
+++ b/net/xfrpc/files/xfrpc.init
@@ -34,14 +34,16 @@ handle_xfrpc() {
 			;;
 		http|https)
 			config_get custom_domains "$name" custom_domains
-			echo "custom_domains = $custom_domains" >> "$config"
+			[ -z "$custom_domains" ] || echo "custom_domains = $custom_domains" >> "$config"
+			config_get subdomain "$name" subdomain
+			[ -z "$subdomain" ] || echo "subdomain = $subdomain" >> "$config"
 			;;
 		esac
 	}
 
 	if [ "$name" = "common" ]; then
 		uci_validate_section xfrpc xfrp "$name" \
-				'server_addr:ipaddr' \
+				'server_addr:host' \
 				'server_port:uinteger' \
 				'token:string:'	
 


### PR DESCRIPTION
Maintainer: @liudf0716
Compile tested: x86_64, OpenWrt 21.02.2 r16495-bf0c965af0
Run tested: x86_64, OpenWrt 21.02.2 r16495-bf0c965af0

Description:

1. allow server_addr as ip or domain
2. add subdomain support 

Signed-off-by: Dengfeng Liu <liudf0716@gmail.com>
