### PR TITLE
samba4: change perl dependency to fix menuconfig

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -21,7 +21,7 @@ PKG_CPE_ID:=cpe:/a:samba:samba
 
 # samba4=(asn1_compile,compile_et) rpcsvc-proto=(rpcgen)
 HOST_BUILD_DEPENDS:=python3/host rpcsvc-proto/host perl/host perl-parse-yapp/host
-PKG_BUILD_DEPENDS:=samba4/host libtasn1/host
+PKG_BUILD_DEPENDS:=samba4/host libtasn1/host perl/host
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_SAMBA4_SERVER_NETBIOS \
@@ -61,7 +61,7 @@ endef
 define Package/samba4-libs
   $(call Package/samba4/Default)
   TITLE+= libs
-  DEPENDS:= +libtirpc +libreadline +libpopt +libcap +zlib +libgnutls +perlbase-json-pp +libtasn1 +libuuid +libopenssl +libpthread +KERNEL_IO_URING:liburing \
+  DEPENDS:= +libtirpc +libreadline +libpopt +libcap +zlib +libgnutls +libtasn1 +libuuid +libopenssl +libpthread +KERNEL_IO_URING:liburing \
 	+PACKAGE_libpam:libpam \
 	+SAMBA4_SERVER_VFS:attr \
 	+SAMBA4_SERVER_AVAHI:libavahi-client \


### PR DESCRIPTION
Adding perlbase-json-pp to samba4-libs dependencies was the wrong approach and caused samba packages not to be offered by menuconfig. AFAIK perlbase-json-pp is a perl helper to building samba4 and seems to be already included in perl/host so use that instead to fix the menuconfig issues.

Signed-off-by: Andrew Sim <andrewsimz@gmail.com>