### PR TITLE
curl: use wolfssl for TARGET_mpc85xx

### DIFF
--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -4,6 +4,7 @@ comment "SSL support"
 
 choice
 	prompt "Selected SSL library"
+	default LIBCURL_WOLFSSL if TARGET_mpc85xx
 	default LIBCURL_MBEDTLS
 
 	config LIBCURL_MBEDTLS

--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=7.85.0
-PKG_RELEASE:=$(AUTORELEASE).1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \


### PR DESCRIPTION
Curl does not work with mbedtls. This is a known issue:
- https://github.com/Mbed-TLS/mbedtls/issues/6430
- https://github.com/openwrt/openwrt/issues/7937
- https://github.com/openwrt/packages/issues/5293
- https://forum.openwrt.org/t/curl-illegal-instruction-17-01-0-r3205-59508e3-mpc85xx-generic/2697

Use wolfssl instead of mbedtls.

Maintainer: @stangri 
Compile tested: OpenWrt 22.03 Snapshot (same for master)
Run tested: OpenWrt 22.03 Snapshot (same for master)
