### PR TITLE
https-dns-proxy: upstream bugfix for ca_info

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
-PKG_VERSION:=2022-08-12
+PKG_VERSION:=2022-10-15
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/
-PKG_SOURCE_DATE:=2022-08-12
-PKG_SOURCE_VERSION:=a344d192e22e0c133aecfd766fefa7474cf2594f
-PKG_MIRROR_HASH:=d3de80df13157e1f5066689880a7132532895d24b36f16c9f0b2acf764cf773f
+PKG_SOURCE_DATE:=2022-10-15
+PKG_SOURCE_VERSION:=f52a85f3edabecfbab41d9244c63a1c6b8aaf49b
+PKG_MIRROR_HASH:=dd8a55255e8859a462fcfd736577fec40731b39a4783325640518745009b0dee
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -44,7 +44,7 @@ define Package/https-dns-proxy/install
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/https_dns_proxy $(1)/usr/sbin/https-dns-proxy
 	$(INSTALL_BIN) ./files/https-dns-proxy.init $(1)/etc/init.d/https-dns-proxy
-	$(SED) "s|^\(PKG_VERSION\).*|\1='$(PKG_VERSION)-$(PKG_RELEASE)'|" $(1)/etc/init.d/https-dns-proxy
+	$(SED) "s|^\(readonly PKG_VERSION\).*|\1='$(PKG_VERSION)-$(PKG_RELEASE)'|" $(1)/etc/init.d/https-dns-proxy
 	$(INSTALL_CONF) ./files/https-dns-proxy.config $(1)/etc/config/https-dns-proxy
 endef
 

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -1,7 +1,6 @@
 #!/bin/sh /etc/rc.common
 # Copyright 2019-2022 Stan Grishin (stangri@melmac.ca)
-# shellcheck disable=SC1091,SC2039,SC3043,SC3060
-PKG_VERSION='dev-test'
+# shellcheck disable=SC1091,SC3043,SC3060
 
 # shellcheck disable=SC2034
 START=80
@@ -15,6 +14,7 @@ else
 	EXTRA_COMMANDS='version'
 fi
 
+readonly PKG_VERSION='dev-test'
 readonly packageName='https-dns-proxy'
 readonly serviceName="$packageName $PKG_VERSION"
 readonly sharedMemoryOutput="/dev/shm/$packageName-output"
@@ -254,6 +254,7 @@ service_triggers() {
 	network_find_wan wan
 	network_find_wan6 wan6
 	wan="${wan:-wan}"
+	wan6="${wan6:-wan6}"
 	for i in "$wan" "$wan6"; do
 		procd_add_interface_trigger "interface.*" "$i" "/etc/init.d/${packageName}" restart
 	done


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-135, OpenWrt 22.03.1
Run tested: x86_64, Sophos SG-135, OpenWrt 22.03.1, test dns resolution

Description:
* upstream bugfix: Add a forgotten 'NULL' initialize for ca_info if not manually set
* make init script PKG_VERSION variable readonly so that a shellcheck excettion can be removed
* add procd interface trigger to 'wan6' if IPv6 wan interface name cannot be obtained on start

Signed-off-by: Stan Grishin <stangri@melmac.ca>

