### PR TITLE
treewide: fix procd service inactive

### DIFF
--- a/net/cloudflared/files/cloudflared.init
+++ b/net/cloudflared/files/cloudflared.init
@@ -18,7 +18,7 @@ start_service() {
 
 	local enabled
 	config_get_bool enabled "config" "enabled"
-	[ "$enabled" -eq "1" ] || exit 1
+	[ "$enabled" -eq "1" ] || return 1
 
 	procd_open_instance "$CONF"
 	procd_set_param command "$PROG" "tunnel"

--- a/net/dnsproxy/files/dnsproxy.init
+++ b/net/dnsproxy/files/dnsproxy.init
@@ -88,7 +88,7 @@ load_config_param() {
 start_service() {
 	config_load "$CONF"
 
-	is_enabled "global" "enabled" || exit 1
+	is_enabled "global" "enabled" || return 1
 
 	procd_open_instance "$CONF"
 	procd_set_param command "$PROG"

--- a/net/v2ray-core/files/v2ray.init
+++ b/net/v2ray-core/files/v2ray.init
@@ -11,7 +11,7 @@ start_service() {
 
 	local enabled
 	config_get_bool enabled "enabled" "enabled" "0"
-	[ "$enabled" -eq "0" ] && exit 1
+	[ "$enabled" -eq "1" ] || return 1
 
 	local confdir
 	local conffiles

--- a/net/v2raya/files/v2raya.init
+++ b/net/v2raya/files/v2raya.init
@@ -34,7 +34,7 @@ append_env_bool() {
 start_service() {
 	config_load "$CONF"
 
-	is_enabled "config" "enabled" || exit 1
+	is_enabled "config" "enabled" || return 1
 
 	procd_open_instance "$CONF"
 	procd_set_param command "$PROG"

--- a/net/xray-core/files/xray.init
+++ b/net/xray-core/files/xray.init
@@ -10,8 +10,8 @@ start_service() {
 	config_load "$CONF"
 
 	local enabled
-	config_get enabled "enabled" "enabled" "0"
-	[ "$enabled" -eq "0" ] && exit 1
+	config_get_bool enabled "enabled" "enabled" "0"
+	[ "$enabled" -eq "1" ] || return 1
 
 	local confdir
 	local conffiles


### PR DESCRIPTION
Maintainer: me
Compile tested: N/A
Run tested: NanoPi R2S

Description:
Exit directly will result procd service inactive and uci configuration changes are no longer monitored.