### PR TITLE
We've compared all packages in the package feed against the current N…

### DIFF
--- a/libs/boringssl/Makefile
+++ b/libs/boringssl/Makefile
@@ -5,6 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=boringssl
+PKG_CPE_ID:=cpe:/a:google:boringssl
 PKG_VERSION:=20210608
 PKG_RELEASE:=$(AUTORELEASE)
 

--- a/libs/leptonica/Makefile
+++ b/libs/leptonica/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=leptonica
+PKG_CPE_ID:=cpe:/a:leptonica:leptonica
 PKG_VERSION:=1.80.0
 PKG_RELEASE:=$(AUTORELEASE)
 

--- a/libs/libdaemon/Makefile
+++ b/libs/libdaemon/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdaemon
+PKG_CPE_ID:=cpe:/a:libdaemon_project:libdaemon
 PKG_VERSION:=0.14
 PKG_RELEASE:=5
 

--- a/libs/libidn/Makefile
+++ b/libs/libidn/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libidn
+PKG_CPE_ID:=cpe:/a:gnu:libidn
 PKG_VERSION:=1.36
 PKG_RELEASE:=1
 

--- a/libs/libjpeg-turbo/Makefile
+++ b/libs/libjpeg-turbo/Makefile
@@ -1,6 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libjpeg-turbo
+PKG_CPE_ID:=cpe:/a:d.r.commander:libjpeg-turbo
 PKG_VERSION:=2.1.2
 PKG_RELEASE:=$(AUTORELEASE)
 

--- a/libs/libmicrohttpd/Makefile
+++ b/libs/libmicrohttpd/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmicrohttpd
+PKG_CPE_ID:=cpe:/a:gnu:libmicrohttpd
 PKG_VERSION:=0.9.75
 PKG_RELEASE:=$(AUTORELEASE)
 

--- a/libs/libpciaccess/Makefile
+++ b/libs/libpciaccess/Makefile
@@ -6,6 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpciaccess
+PKG_CPE_ID:=cpe:/a:x:libxfont
 PKG_VERSION:=0.16
 PKG_RELEASE:=1
 

--- a/libs/libtirpc/Makefile
+++ b/libs/libtirpc/Makefile
@@ -1,6 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtirpc
+PKG_CPE_ID:=cpe:/a:libtirpc_project:libtirpc
 PKG_VERSION:=1.3.2
 PKG_RELEASE:=$(AUTORELEASE)
 

--- a/libs/libunistring/Makefile
+++ b/libs/libunistring/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libunistring
+PKG_CPE_ID:=cpe:/a:gnu:libunistring
 PKG_VERSION:=1.0
 PKG_RELEASE:=1
 PKG_HASH:=5bab55b49f75d77ed26b257997e919b693f29fd4a1bc22e0e6e024c246c72741

--- a/libs/lzo/Makefile
+++ b/libs/lzo/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lzo
+PKG_CPE_ID:=cpe:/a:lzo_project:lzo
 PKG_VERSION:=2.10
 PKG_RELEASE:=4
 

--- a/libs/spice-protocol/Makefile
+++ b/libs/spice-protocol/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=spice-protocol
+PKG_CPE_ID:=cpe:/a:redhat:spice
 PKG_VERSION:=0.14.4
 PKG_RELEASE:=1
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz

--- a/libs/tcp_wrappers/Makefile
+++ b/libs/tcp_wrappers/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tcp_wrappers
+PKG_CPE_ID:=cpe:/a:libwrap_project:libwrap
 PKG_VERSION:=7.6
 PKG_RELEASE:=4
 

--- a/multimedia/minidlna/Makefile
+++ b/multimedia/minidlna/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=minidlna
+PKG_CPE_ID:=cpe:/a:minidlna_project:minidlna
 PKG_VERSION:=1.3.0
 PKG_RELEASE:=2
 

--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -6,6 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
+PKG_CPE_ID:=cpe:/a:adguard:adguardhome
 PKG_VERSION:=0.107.12
 PKG_RELEASE:=1
 

--- a/net/iperf/Makefile
+++ b/net/iperf/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
+PKG_CPE_ID:=cpe:/a:iperf2_project:iperf2
 PKG_VERSION:=2.1.8
 PKG_RELEASE:=$(AUTORELEASE)
 

--- a/net/iperf3/Makefile
+++ b/net/iperf3/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
+PKG_CPE_ID:=cpe:/a:es:iperf3
 PKG_VERSION:=3.12
 PKG_RELEASE:=1
 

--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -10,6 +10,7 @@ PKG_RELRO_FULL:=0
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot-resolver
+PKG_CPE_ID:=cpe:/a:knot-resolver:knot_resolver
 PKG_VERSION:=5.5.3
 PKG_RELEASE:=1
 

--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -7,6 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
+PKG_CPE_ID:=cpe:/a:linux-nfs:nfs-utils
 PKG_VERSION:=2.5.4
 PKG_RELEASE:=5
 PKG_HASH:=546ce4b51eeebc66e354b6cc6ca0ce509437efbdef0caaf99389534eef0e598b

--- a/net/nsd/Makefile
+++ b/net/nsd/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nsd
+PKG_CPE_ID:=cpe:/a:freebsd:name_server_daemon
 PKG_VERSION:=4.2.4
 PKG_RELEASE:=1
 

--- a/sound/sox/Makefile
+++ b/sound/sox/Makefile
@@ -6,6 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sox
+PKG_CPE_ID:=cpe:/a:sound_exchange_project:sound_exchange
 PKG_VERSION:=14.4.2
 PKG_RELEASE:=4
 

--- a/utils/cgroupfs-mount/Makefile
+++ b/utils/cgroupfs-mount/Makefile
@@ -1,6 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgroupfs-mount
+PKG_CPE_ID:=cpe:/a:cgroupfs-mount_project:cgroupfs-mount
 PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git

--- a/utils/ecdsautils/Makefile
+++ b/utils/ecdsautils/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ecdsautils
+PKG_CPE_ID:=cpe:/a:ecdsautils_project:ecdsautils
 PKG_VERSION:=0.4.1
 PKG_RELEASE:=1
 

--- a/utils/gnupg/Makefile
+++ b/utils/gnupg/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnupg
+PKG_CPE_ID:=cpe:/a:gnupg:gnupg
 PKG_VERSION:=1.4.23
 PKG_RELEASE:=4
 

--- a/utils/gnupg2/Makefile
+++ b/utils/gnupg2/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnupg
+PKG_CPE_ID:=cpe:/a:gnupg:gnupg
 PKG_VERSION:=2.2.23
 PKG_RELEASE:=2
 

--- a/utils/gnuplot/Makefile
+++ b/utils/gnuplot/Makefile
@@ -1,6 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnuplot
+PKG_CPE_ID:=cpe:/a:gnuplot_project:gnuplot
 PKG_VERSION:=5.4.2
 PKG_RELEASE:=2
 PKG_MAINTAINER:=Matteo Cicuttin <datafl4sh@toxicnet.eu>

--- a/utils/haserl/Makefile
+++ b/utils/haserl/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haserl
+PKG_CPE_ID:=cpe:/a:haserl_project:haserl
 PKG_VERSION:=0.9.36
 PKG_RELEASE:=$(AUTORELEASE)
 

--- a/utils/procps-ng/Makefile
+++ b/utils/procps-ng/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=procps-ng
+PKG_CPE_ID:=cpe:/a:procps-ng_project:procps-ng
 PKG_VERSION:=3.3.16
 PKG_RELEASE:=3
 

--- a/utils/rng-tools/Makefile
+++ b/utils/rng-tools/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rng-tools
+PKG_CPE_ID:=cpe:/a:rng-tools_project:rng-tools
 PKG_VERSION:=6.15
 PKG_RELEASE:=2
 

--- a/utils/setserial/Makefile
+++ b/utils/setserial/Makefile
@@ -1,6 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=setserial
+PKG_CPE_ID:=cpe:/a:setserial_project:setserial
 PKG_VERSION:=2.17
 PKG_RELEASE:=3
 


### PR DESCRIPTION
We've compared all packages in the package feed against the current NIST dictionary and found these 29 with a known CPE ID which was still missing.