### PR TITLE
[21.02] modemmanager: report network initiated disconnections to netifd

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -109,6 +109,9 @@ define Package/modemmanager/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ModemManager/libmm-shared-*.so* $(1)/usr/lib/ModemManager
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ModemManager/libmm-plugin-*.so* $(1)/usr/lib/ModemManager
 
+	$(INSTALL_DIR) $(1)/usr/lib/ModemManager/connection.d
+	$(INSTALL_BIN) ./files/10-report-down $(1)/usr/lib/ModemManager/connection.d
+
 	$(INSTALL_DIR) $(1)/etc/dbus-1/system.d
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/dbus-1/system.d/org.freedesktop.ModemManager1.conf $(1)/etc/dbus-1/system.d
 

--- a/net/modemmanager/files/10-report-down
+++ b/net/modemmanager/files/10-report-down
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: CC0-1.0
+# 2022 Aleksander Morgado <aleksander@aleksander.es>
+#
+# Automatically report to netifd that the underlying modem
+# is really disconnected
+#
+# require program name and at least 4 arguments
+[ $# -lt 4 ] && exit 1
+
+MODEM_PATH="$1"
+BEARER_PATH="$2"
+INTERFACE="$3"
+STATE="$4"
+
+[ "${STATE}" = "disconnected" ] || exit 0
+
+. /usr/share/ModemManager/modemmanager.common
+. /lib/netifd/netifd-proto.sh
+INCLUDE_ONLY=1 . /lib/netifd/proto/modemmanager.sh
+
+MODEM_STATUS=$(mmcli --modem="${MODEM_PATH}" --output-keyvalue)
+[ -n "${MODEM_STATUS}" ] || exit 1
+
+MODEM_DEVICE=$(modemmanager_get_field "${MODEM_STATUS}" "modem.generic.device")
+[ -n "${MODEM_DEVICE}" ] || exit 2
+
+CFG=$(mm_get_modem_config "${MODEM_DEVICE}")
+[ -n "${CFG}" ] || exit 3
+
+logger -t "modemmanager" "interface ${CFG} (network device ${INTERFACE}) ${STATE}"
+proto_init_update $INTERFACE 0
+proto_send_update $CFG
+exit 0


### PR DESCRIPTION
The new connection dispatcher scripts support integrated in ModemManager 1.18.8 allows us to provide a openwrt-specific dispatcher script used to report netifd that the underlying network connection is down.

See also https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/775

Fixes https://github.com/openwrt/openwrt/issues/8368 Fixes https://github.com/openwrt/packages/issues/14096

Signed-off-by: Aleksander Morgado <aleksander@aleksander.es>
(cherry picked from commit bc754f31cfdb004eefa43038f8f0827922107fc6)
