### PR TITLE
adblock: Add blocklist sources

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
 PKG_VERSION:=4.1.4
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -11,6 +11,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 | Source              | Enabled | Size | Focus            | Information                                                                       |
 | :------------------ | :-----: | :--- | :--------------- | :-------------------------------------------------------------------------------- |
 | adaway              | x       | S    | mobile           | [Link](https://github.com/AdAway/adaway.github.io)                                |
+| abp                 |         | XXL  | general          | [Link](https://github.com/abp-filters/abp-filters-anti-cv)                        |
 | adguard             | x       | L    | general          | [Link](https://adguard.com)                                                       |
 | adguard_tracking    |         | S    | tracking         | [Link](https://github.com/AdguardTeam/cname-trackers)                             |
 | android_tracking    |         | S    | tracking         | [Link](https://github.com/Perflyst/PiHoleBlocklist)                               |
@@ -18,12 +19,18 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 | anti_ad             |         | L    | compilation      | [Link](https://github.com/privacy-protection-tools/anti-AD/blob/master/README.md) |
 | anudeep             |         | M    | compilation      | [Link](https://github.com/anudeepND/blacklist)                                    |
 | bitcoin             |         | S    | mining           | [Link](https://github.com/hoshsadiq/adblock-nocoin-list)                          |
+| cookies             |         | XXL  | cookies          | [Link](https://easylist.to)                                                       |
+| cpbl                |         | XXL  | compilation      | [Link](https://github.com/bongochong/CombinedPrivacyBlockLists)                   |
 | disconnect          | x       | S    | general          | [Link](https://disconnect.me)                                                     |
+| doh_blocklist       |         | S    | doh_server       | [Link](https://github.com/dibdot/DoH-IP-blocklists)                               |
+| easylist            |         | XXL  | compilation      | [Link](https://easylist.to)                                                       |
+| easyprivacy         |         | XXL  | tracking         | [Link](https://easylist.to)                                                       |
 | energized           |         | VAR  | compilation      | [Link](https://energized.pro)                                                     |
 | firetv_tracking     |         | S    | tracking         | [Link](https://github.com/Perflyst/PiHoleBlocklist)                               |
 | games_tracking      |         | S    | tracking         | [Link](https://www.gameindustry.eu)                                               |
 | hblock              |         | XL   | compilation      | [Link](https://hblock.molinero.dev)                                               |
 | lightswitch05       |         | XL   | compilation      | [Link](https://github.com/lightswitch05/hosts)                                    |
+| notifications       |         | M    | notifications    | [Link](https://easylist.to)                                                       |
 | notracking          |         | XL   | tracking         | [Link](https://github.com/notracking/hosts-blocklists)                            |
 | oisd_basic          |         | L    | general          | [Link](https://oisd.nl)                                                           |
 | oisd_nsfw           |         | XL   | general          | [Link](https://oisd.nl)                                                           |
@@ -38,6 +45,8 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 | reg_fr              |         | S    | reg_france       | [Link](https://forums.lanik.us/viewforum.php?f=91)                                |
 | reg_id              |         | M    | reg_indonesia    | [Link](https://easylist.to)                                                       |
 | reg_it              |         | M    | reg_italy        | [Link](https://easylist.to)                                                       |
+| reg_jp1             |         | XXL  | reg_japan        | [Link](https://github.com/k2jp/abp-japanese-filters)                              |
+| reg_jp2             |         | XL   | reg_japan        | [Link](https://tofukko.r.ribbon.to)                                               |
 | reg_kr              |         | S    | reg_korea        | [Link](https://github.com/List-KR/List-KR)                                        |
 | reg_nl              |         | M    | reg_netherlands  | [Link](https://easylist.to)                                                       |
 | reg_pl1             |         | S    | reg_poland       | [Link](https://kadantiscam.netlify.com)                                           |
@@ -47,6 +56,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 | reg_se              |         | M    | reg_sweden       | [Link](https://github.com/lassekongo83/Frellwits-filter-lists)                    |
 | reg_vn              |         | S    | reg_vietnam      | [Link](https://bigdargon.github.io/hostsVN)                                       |
 | smarttv_tracking    |         | S    | tracking         | [Link](https://github.com/Perflyst/PiHoleBlocklist)                               |
+| social              |         | XXL  | social           | [Link](https://easylist.to)                                                       |
 | spam404             |         | S    | general          | [Link](https://github.com/Dawsey21)                                               |
 | stevenblack         |         | VAR  | compilation      | [Link](https://github.com/StevenBlack/hosts)                                      |
 | stopforumspam       |         | S    | spam             | [Link](https://www.stopforumspam.com)                                             |

--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -6,6 +6,13 @@
 		"focus": "mobile",
 		"descurl": "https://github.com/AdAway/adaway.github.io"
 	},
+	"abp": {
+		"url": "https://easylist-downloads.adblockplus.org/abp-filters-anti-cv.txt",
+		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
+		"size": "XXL",
+		"focus": "general",
+		"descurl": "https://github.com/abp-filters/abp-filters-anti-cv"
+	},
 	"adguard": {
 		"url": "https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt",
 		"rule": "BEGIN{FS=\"[\/|^|\\r]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+[\\/\\^\\r]+$/{print tolower($3)}",
@@ -55,6 +62,20 @@
 		"focus": "mining",
 		"descurl": "https://github.com/hoshsadiq/adblock-nocoin-list"
 	},
+	"cookies": {
+		"url": "https://easylist-downloads.adblockplus.org/i_dont_care_about_cookies.txt",
+		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
+		"size": "XXL",
+		"focus": "cookies",
+		"descurl": "https://easylist.to"
+	},
+	"cpbl": {
+		"url": "https://raw.githubusercontent.com/bongochong/CombinedPrivacyBlockLists/master/cpbl-abp-list.txt",
+		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
+		"size": "XXL",
+		"focus": "compilation",
+		"descurl": "https://github.com/bongochong/CombinedPrivacyBlockLists"
+	},
 	"disconnect": {
 		"url": "https://s3.amazonaws.com/lists.disconnect.me/simple_malvertising.txt",
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
@@ -68,6 +89,20 @@
 		"size": "S",
 		"focus": "doh_server",
 		"descurl": "https://github.com/dibdot/DoH-IP-blocklists"
+	},
+	"easylist": {
+		"url": "https://easylist-downloads.adblockplus.org/easylist.txt",
+		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
+		"size": "XXL",
+		"focus": "compilation",
+		"descurl": "https://easylist.to"
+	},
+	"easyprivacy": {
+		"url": "https://easylist-downloads.adblockplus.org/easyprivacy.txt",
+		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
+		"size": "XXL",
+		"focus": "tracking",
+		"descurl": "https://easylist.to"
 	},
 	"energized": {
 		"url": "https://block.energized.pro/",
@@ -103,6 +138,13 @@
 		"size": "XL",
 		"focus": "compilation",
 		"descurl": "https://github.com/lightswitch05/hosts"
+	},
+	"notifications": {
+		"url": "https://easylist-downloads.adblockplus.org/fanboy-notifications.txt",
+		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
+		"size": "M",
+		"focus": "notifications",
+		"descurl": "https://easylist.to"
 	},
 	"notracking": {
 		"url": "https://raw.githubusercontent.com/notracking/hosts-blocklists/master/dnscrypt-proxy/dnscrypt-proxy.blacklist.txt",
@@ -202,6 +244,20 @@
 		"focus": "reg_italy",
 		"descurl": "https://easylist.to"
 	},
+	"reg_jp1": {
+		"url": "https://raw.githubusercontent.com/k2jp/abp-japanese-filters/master/abpjf.txt",
+		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
+		"size": "XXL",
+		"focus": "reg_japan",
+		"descurl": "https://github.com/k2jp/abp-japanese-filters"
+	},
+	"reg_jp2": {
+		"url": "https://raw.githubusercontent.com/tofukko/filter/master/Adblock_Plus_list.txt",
+		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
+		"size": "XL",
+		"focus": "reg_japan",
+		"descurl": "https://tofukko.r.ribbon.to"
+	},
 	"reg_kr": {
 		"url": "https://raw.githubusercontent.com/List-KR/List-KR/master/filters-share/adservice.txt",
 		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
@@ -264,6 +320,13 @@
 		"size": "S",
 		"focus": "tracking",
 		"descurl": "https://github.com/Perflyst/PiHoleBlocklist"
+	},
+	"social": {
+		"url": "https://easylist-downloads.adblockplus.org/fanboy-social.txt",
+		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
+		"size": "XXL",
+		"focus": "social",
+		"descurl": "https://easylist.to"
 	},
 	"spam404": {
 		"url": "https://raw.githubusercontent.com/Dawsey21/Lists/master/main-blacklist.txt",


### PR DESCRIPTION
Maintainer: @dibdot
Compile tested: N/A
Run tested: ramips/mt7621, NETGEAR WAX202, OpenWrt 22.03.1, downloads and adblocking

Description:
  - Add blocklist sources:
    - https://easylist-downloads.adblockplus.org/abp-filters-anti-cv.txt
    - https://easylist-downloads.adblockplus.org/i_dont_care_about_cookies.txt
    - https://raw.githubusercontent.com/bongochong/CombinedPrivacyBlockLists/master/cpbl-abp-list.txt
    - https://easylist-downloads.adblockplus.org/easylist.txt
    - https://easylist-downloads.adblockplus.org/easyprivacy.txt
    - https://easylist-downloads.adblockplus.org/fanboy-notifications.txt
    - https://raw.githubusercontent.com/k2jp/abp-japanese-filters/master/abpjf.txt
    - https://raw.githubusercontent.com/tofukko/filter/master/Adblock_Plus_list.txt
    - https://easylist-downloads.adblockplus.org/fanboy-social.txt
  - Change README:
    - Add blocklist sources
    - Fix 'doh_blocklist' is missing
  - Change Makefile:
    - Update 'PKG_RELEASE'

Signed-off-by: CaffeeLake <PascalCoffeeLake@gmail.com>
