### PR TITLE
adblock: update 4.1.5

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=4.1.4
-PKG_RELEASE:=5
+PKG_VERSION:=4.1.5
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -18,7 +18,11 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 | anti_ad             |         | L    | compilation      | [Link](https://github.com/privacy-protection-tools/anti-AD/blob/master/README.md) |
 | anudeep             |         | M    | compilation      | [Link](https://github.com/anudeepND/blacklist)                                    |
 | bitcoin             |         | S    | mining           | [Link](https://github.com/hoshsadiq/adblock-nocoin-list)                          |
+| cpbl                |         | XL   | compilation      | [Link](https://github.com/bongochong/CombinedPrivacyBlockLists)                   |
 | disconnect          | x       | S    | general          | [Link](https://disconnect.me)                                                     |
+| doh_blocklist       |         | S    | doh_server       | [Link](https://github.com/dibdot/DoH-IP-blocklists)                               |
+| easylist            |         | M    | compilation      | [Link](https://easylist.to)                                                       |
+| easyprivacy         |         | M    | tracking         | [Link](https://easylist.to)                                                       |
 | energized           |         | VAR  | compilation      | [Link](https://energized.pro)                                                     |
 | firetv_tracking     |         | S    | tracking         | [Link](https://github.com/Perflyst/PiHoleBlocklist)                               |
 | games_tracking      |         | S    | tracking         | [Link](https://www.gameindustry.eu)                                               |
@@ -30,21 +34,21 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 | oisd_full           |         | XXL  | general          | [Link](https://oisd.nl)                                                           |
 | openphish           |         | S    | phishing         | [Link](https://openphish.com)                                                     |
 | phishing_army       |         | S    | phishing         | [Link](https://phishing.army)                                                     |
-| reg_cn              |         | M    | reg_china        | [Link](https://easylist.to)                                                       |
-| reg_cz              |         | M    | reg_czech+slovak | [Link](https://easylist.to)                                                       |
-| reg_de              |         | M    | reg_germany      | [Link](https://easylist.to)                                                       |
-| reg_es              |         | M    | reg_espania      | [Link](https://easylist.to)                                                       |
+| reg_cn              |         | S    | reg_china        | [Link](https://easylist.to)                                                       |
+| reg_cz              |         | S    | reg_czech+slovak | [Link](https://easylist.to)                                                       |
+| reg_de              |         | S    | reg_germany      | [Link](https://easylist.to)                                                       |
+| reg_es              |         | S    | reg_espania      | [Link](https://easylist.to)                                                       |
 | reg_fi              |         | S    | reg_finland      | [Link](https://github.com/finnish-easylist-addition)                              |
-| reg_fr              |         | S    | reg_france       | [Link](https://forums.lanik.us/viewforum.php?f=91)                                |
-| reg_id              |         | M    | reg_indonesia    | [Link](https://easylist.to)                                                       |
-| reg_it              |         | M    | reg_italy        | [Link](https://easylist.to)                                                       |
+| reg_fr              |         | M    | reg_france       | [Link](https://forums.lanik.us/viewforum.php?f=91)                                |
+| reg_id              |         | S    | reg_indonesia    | [Link](https://easylist.to)                                                       |
+| reg_it              |         | S    | reg_italy        | [Link](https://easylist.to)                                                       |
+| reg_jp              |         | S    | reg_japan        | [Link](https://github.com/k2jp/abp-japanese-filters)                              |
 | reg_kr              |         | S    | reg_korea        | [Link](https://github.com/List-KR/List-KR)                                        |
-| reg_nl              |         | M    | reg_netherlands  | [Link](https://easylist.to)                                                       |
-| reg_pl1             |         | S    | reg_poland       | [Link](https://kadantiscam.netlify.com)                                           |
-| reg_pl2             |         | S    | reg_poland       | [Link](https://www.certyficate.it)                                                |
-| reg_ro              |         | M    | reg_romania      | [Link](https://easylist.to)                                                       |
-| reg_ru              |         | M    | reg_russia       | [Link](https://easylist.to)                                                       |
-| reg_se              |         | M    | reg_sweden       | [Link](https://github.com/lassekongo83/Frellwits-filter-lists)                    |
+| reg_nl              |         | S    | reg_netherlands  | [Link](https://easylist.to)                                                       |
+| reg_pl              |         | M    | reg_poland       | [Link](https://kadantiscam.netlify.com)                                           |
+| reg_ro              |         | S    | reg_romania      | [Link](https://easylist.to)                                                       |
+| reg_ru              |         | S    | reg_russia       | [Link](https://easylist.to)                                                       |
+| reg_se              |         | S    | reg_sweden       | [Link](https://github.com/lassekongo83/Frellwits-filter-lists)                    |
 | reg_vn              |         | S    | reg_vietnam      | [Link](https://bigdargon.github.io/hostsVN)                                       |
 | smarttv_tracking    |         | S    | tracking         | [Link](https://github.com/Perflyst/PiHoleBlocklist)                               |
 | spam404             |         | S    | general          | [Link](https://github.com/Dawsey21)                                               |
@@ -97,9 +101,8 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 
 ## Prerequisites
 * [OpenWrt](https://openwrt.org), tested with the stable release series and with the latest rolling snapshot releases.  
-  <b>Please note:</b> Older OpenWrt releases like 18.06.x or 17.01.x are _not_ supported!  
   <b>Please note:</b> Devices with less than 128 MByte RAM are _not_ supported!  
-* A usual setup with an enabled DNS backend at minimum - dump AP modes without a working DNS backend are _not_ supported
+* A usual setup with an enabled DNS backend at minimum - dumb AP modes without a working DNS backend are _not_ supported
 * A download utility with SSL support: 'wget', 'uclient-fetch' with one of the 'libustream-*' ssl libraries, 'aria2c' or 'curl' is required
 * A certificate store such as 'ca-bundle' or 'ca-certificates', as adblock checks the validity of the SSL certificates of all download sites by default
 * Optional E-Mail notification support: for E-Mail notifications you need to install the additional 'msmtp' package

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -12,7 +12,7 @@ if [ -n "$(type -t extra_command)" ]; then
 	extra_command "suspend" "Suspend adblock processing"
 	extra_command "resume" "Resume adblock processing"
 	extra_command "query" "<domain> Query active blocklists and backups for a specific domain"
-	extra_command "report" "[[<cli>|<mail>|<gen>|<json>] [<count>] [<search>]] Print DNS statistics with an optional search parameter"
+	extra_command "report" "[[<cli>|<mail>|<gen>|<json>] [<top_count>] [<res_count>] [<search>]] Print DNS statistics with an optional search parameter"
 	extra_command "list" "[<add>|<add_sha>|<add_utc>|<add_eng>|<add_stb>|<remove>|<remove_sha>|<remove_utc>|<remove_eng>|<remove_stb>] <source(s)> List/Edit available sources"
 	extra_command "timer" "[<add> <tasks> <hour> [<minute>] [<weekday>]]|[<remove> <line no.>] List/Edit cron update intervals"
 else
@@ -82,7 +82,7 @@ query() {
 }
 
 report() {
-	rc_procd "${adb_script}" report "${1:-"cli"}" "${2}" "${3}"
+	rc_procd "${adb_script}" report "${1:-"cli"}" "${2}" "${3}" "${4}"
 }
 
 list() {

--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -55,6 +55,13 @@
 		"focus": "mining",
 		"descurl": "https://github.com/hoshsadiq/adblock-nocoin-list"
 	},
+	"cpbl": {
+		"url": "https://raw.githubusercontent.com/bongochong/CombinedPrivacyBlockLists/master/NoFormatting/BlacklistedDomains.txt",
+		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
+		"size": "XL",
+		"focus": "compilation",
+		"descurl": "https://github.com/bongochong/CombinedPrivacyBlockLists"
+	},
 	"disconnect": {
 		"url": "https://s3.amazonaws.com/lists.disconnect.me/simple_malvertising.txt",
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
@@ -68,6 +75,20 @@
 		"size": "S",
 		"focus": "doh_server",
 		"descurl": "https://github.com/dibdot/DoH-IP-blocklists"
+	},
+	"easylist": {
+		"url": "https://easylist-downloads.adblockplus.org/easylist.txt",
+		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
+		"size": "M",
+		"focus": "compilation",
+		"descurl": "https://easylist.to"
+	},
+	"easyprivacy": {
+		"url": "https://easylist-downloads.adblockplus.org/easyprivacy.txt",
+		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
+		"size": "M",
+		"focus": "tracking",
+		"descurl": "https://easylist.to"
 	},
 	"energized": {
 		"url": "https://block.energized.pro/",
@@ -147,30 +168,30 @@
 		"descurl": "https://phishing.army"
 	},
 	"reg_cn": {
-		"url": "https://easylist-downloads.adblockplus.org/easylistchina+easylist.txt",
+		"url": "https://easylist-downloads.adblockplus.org/easylistchina.txt",
 		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
-		"size": "M",
+		"size": "S",
 		"focus": "reg_china",
 		"descurl": "https://easylist.to"
 	},
 	"reg_cz": {
-		"url": "https://easylist-downloads.adblockplus.org/easylistczechslovak+easylist.txt",
+		"url": "https://easylist-downloads.adblockplus.org/easylistczechslovak.txt",
 		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
-		"size": "M",
+		"size": "S",
 		"focus": "reg_czech+slovak",
 		"descurl": "https://easylist.to"
 	},
 	"reg_de": {
-		"url": "https://easylist-downloads.adblockplus.org/easylistgermany+easylist.txt",
+		"url": "https://easylist-downloads.adblockplus.org/easylistgermany.txt",
 		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
-		"size": "M",
+		"size": "S",
 		"focus": "reg_germany",
 		"descurl": "https://easylist.to"
 	},
 	"reg_es": {
-		"url": "https://easylist-downloads.adblockplus.org/easylistspanish+easylist.txt",
+		"url": "https://easylist-downloads.adblockplus.org/easylistspanish.txt",
 		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
-		"size": "M",
+		"size": "S",
 		"focus": "reg_spain",
 		"descurl": "https://easylist.to"
 	},
@@ -182,25 +203,32 @@
 		"descurl": "https://github.com/finnish-easylist-addition"
 	},
 	"reg_fr": {
-		"url": "https://easylist-downloads.adblockplus.org/liste_fr+easylist.txt",
+		"url": "https://easylist-downloads.adblockplus.org/liste_fr.txt",
 		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
 		"size": "M",
 		"focus": "reg_france",
 		"descurl": "https://forums.lanik.us/viewforum.php?f=91"
 	},
 	"reg_id": {
-		"url": "https://easylist-downloads.adblockplus.org/abpindo+easylist.txt",
+		"url": "https://easylist-downloads.adblockplus.org/abpindo.txt",
 		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
-		"size": "M",
+		"size": "S",
 		"focus": "reg_indonesia",
 		"descurl": "https://easylist.to"
 	},
 	"reg_it": {
-		"url": "https://easylist-downloads.adblockplus.org/easylistitaly+easylist.txt",
+		"url": "https://easylist-downloads.adblockplus.org/easylistitaly.txt",
 		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
-		"size": "M",
+		"size": "S",
 		"focus": "reg_italy",
 		"descurl": "https://easylist.to"
+	},
+	"reg_jp": {
+		"url": "https://raw.githubusercontent.com/k2jp/abp-japanese-filters/master/abpjf.txt",
+		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
+		"size": "S",
+		"focus": "reg_japan",
+		"descurl": "https://github.com/k2jp/abp-japanese-filters"
 	},
 	"reg_kr": {
 		"url": "https://raw.githubusercontent.com/List-KR/List-KR/master/filters-share/adservice.txt",
@@ -210,46 +238,39 @@
 		"descurl": "https://github.com/List-KR/List-KR"
 	},
 	"reg_nl": {
-		"url": "https://easylist-downloads.adblockplus.org/easylistdutch+easylist.txt",
+		"url": "https://easylist-downloads.adblockplus.org/easylistdutch.txt",
 		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
-		"size": "M",
+		"size": "S",
 		"focus": "reg_netherlands",
 		"descurl": "https://easylist.to"
 	},
-	"reg_pl1": {
+	"reg_pl": {
 		"url": "https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADhosts.txt",
 		"rule": "/^0\\.0\\.0\\.0[[:space:]]+([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($2)}",
-		"size": "S",
+		"size": "M",
 		"focus": "reg_poland",
 		"descurl": "https://kadantiscam.netlify.app"
 	},
-	"reg_pl2": {
-		"url": "https://raw.githubusercontent.com/MajkiIT/polish-ads-filter/master/polish-pihole-filters/hostfile.txt",
-		"rule": "/^0\\.0\\.0\\.0[[:space:]]+([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($2)}",
-		"size": "S",
-		"focus": "reg_poland",
-		"descurl": "https://www.certyficate.it"
-	},
 	"reg_ro": {
-		"url": "https://easylist-downloads.adblockplus.org/rolist+easylist.txt",
+		"url": "https://easylist-downloads.adblockplus.org/rolist.txt",
 		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
-		"size": "M",
+		"size": "S",
 		"focus": "reg_romania",
+		"descurl": "https://easylist.to"
+	},
+	"reg_ru": {
+		"url": "https://easylist-downloads.adblockplus.org/ruadlist.txt",
+		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
+		"size": "S",
+		"focus": "reg_russia",
 		"descurl": "https://easylist.to"
 	},
 	"reg_se": {
 		"url": "https://raw.githubusercontent.com/lassekongo83/Frellwits-filter-lists/master/Frellwits-Swedish-Hosts-File.txt",
 		"rule": "/^127\\.0\\.0\\.1[[:space:]]+([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($2)}",
-		"size": "s",
+		"size": "S",
 		"focus": "reg_sweden",
 		"descurl": "https://github.com/lassekongo83/Frellwits-filter-lists"
-	},
-	"reg_ru": {
-		"url": "https://easylist-downloads.adblockplus.org/ruadlist+easylist.txt",
-		"rule": "BEGIN{FS=\"[|^]\"}/^\\|\\|([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+\\^(\\$third-party)?$/{print tolower($3)}",
-		"size": "M",
-		"focus": "reg_russia",
-		"descurl": "https://easylist.to"
 	},
 	"reg_vn": {
 		"url": "https://raw.githubusercontent.com/bigdargon/hostsVN/master/hosts",


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: n/a
Run tested: Turris Omnia, OpenWrt SNAPSHOT r20964-b58f3c573d

Description:
* made the reporting/top statistics flexible, see "top_count" parm in CLI or in LuCI (default 10), fixes #19622
* added the new blocklist source cpbl (provided by PascalCoffeeLake@gmail.com)
* added/separated Easylist/Easyprivacy blocklist sources (provided by PascalCoffeeLake@gmail.com)
* added reg_jp blocklist_source (provided by PascalCoffeeLake@gmail.com)
* removed the easylist addons from the other regional lists
* removed the second/obsolete pl regional list and renamed the first one to "reg_pl"
* updated the readme

Signed-off-by: Dirk Brenken <dev@brenken.org>
