### PR TITLE
ddns-scripts: fix cloudflare&digitalocean provides

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=28
+PKG_RELEASE:=29
 
 PKG_LICENSE:=GPL-2.0
 
@@ -62,7 +62,7 @@ define Package/ddns-scripts-cloudflare
   $(call Package/ddns-scripts/Default)
   TITLE:=Extension for cloudflare.com API v4
   DEPENDS:=ddns-scripts +curl
-  PROVIDES:=ddns-scripts_digitalocean.com-v2
+  PROVIDES:=ddns-scripts_cloudflare.com-v4
 endef
 
 define Package/ddns-scripts-cloudflare/description
@@ -98,6 +98,7 @@ define Package/ddns-scripts-digitalocean
   $(call Package/ddns-scripts/Default)
   TITLE:=Extention for digitalocean.com API v2
   DEPENDS:=ddns-scripts +curl
+  PROVIDES:=ddns-scripts_digitalocean.com-v2
 endef
 
 define Package/ddns-scripts-digitalocean/description


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: no
Run tested: no

Description: Fixes mistake in dbe79e409d4d772d607364b47116a108508bb466 (#19597), the cloudflare PROVIDES got mixed up with digitalocean.

I am sorry about this mistake

cc @BKPepe @feckert