### PR TITLE
https-dns-proxy: bugfix: remove wan6 from procd triggers

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2022-10-15
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/

--- a/net/https-dns-proxy/files/https-dns-proxy.config
+++ b/net/https-dns-proxy/files/https-dns-proxy.config
@@ -13,6 +13,7 @@ config main 'config'
 #	list force_dns_port '4434'
 #	list force_dns_port '5443'
 #	list force_dns_port '8443'
+	option wan6_trigger '0'
 
 config https-dns-proxy
 	option bootstrap_dns '1.1.1.1,1.0.0.1'

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -30,6 +30,7 @@ canary_domains_mozilla=
 update_dnsmasq_config=
 force_dns=
 force_dns_port=
+wan6_trigger=
 
 str_contains() { [ -n "$1" ] &&[ -n "$2" ] && [ "${1//$2}" != "$1" ]; }
 is_mac_address() { expr "$1" : '[0-9A-F][0-9A-F]:[0-9A-F][0-9A-F]:[0-9A-F][0-9A-F]:[0-9A-F][0-9A-F]:[0-9A-F][0-9A-F]:[0-9A-F][0-9A-F]$' >/dev/null; }
@@ -216,6 +217,7 @@ start_service() {
 	config_get_bool canary_domains_mozilla  'config' 'canary_domains_mozilla' '1'
 	config_get_bool force_dns	              'config' 'force_dns' '1'
 	config_get force_dns_port	              'config' 'force_dns_port' '53 853'
+	config_get_bool wan6_trigger            'config' 'wan6_trigger' '0'
 	if [ "$canary_domains_icloud" -ne 0 ]; then
 		canaryDomains="${canaryDomains:+$canaryDomains }${canaryDomainsiCloud}"
 	fi
@@ -252,13 +254,15 @@ service_triggers() {
 	. /lib/functions/network.sh
 	network_flush_cache
 	network_find_wan wan
-	network_find_wan6 wan6
 	wan="${wan:-wan}"
-	wan6="${wan6:-wan6}"
+	if [ "$wan6_trigger" -ne 0 ]; then
+		network_find_wan6 wan6
+		wan6="${wan6:-wan6}"
+	fi
 	for i in "$wan" "$wan6"; do
-		procd_add_interface_trigger "interface.*" "$i" "/etc/init.d/${packageName}" restart
+		procd_add_interface_trigger "interface.*" "$i" "/etc/init.d/${packageName}" start
 	done
-	procd_add_config_trigger "config.change" "$packageName" "/etc/init.d/${packageName}" restart
+	procd_add_config_trigger "config.change" "$packageName" "/etc/init.d/${packageName}" start
 }
 
 service_started() { procd_set_config_changed firewall; }


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-135, OpenWrt 22.03.2
Run tested:  x86_64, Sophos SG-135, OpenWrt 22.03.2, start, observe no unnecessary dnsmasq restarts

Description:
* fixes https://github.com/openwrt/packages/issues/19631

Thanks @dibdot!

Signed-off-by: Stan Grishin <stangri@melmac.ca>
