### PR TITLE
coova-chilli compile fix for linux 5.17

### DIFF
--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coova-chilli
 PKG_VERSION:=1.6
-PKG_RELEASE:=9.1
+PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/coova/coova-chilli/tar.gz/$(PKG_VERSION)?

--- a/net/coova-chilli/patches/011-kernel517.patch
+++ b/net/coova-chilli/patches/011-kernel517.patch
@@ -1,0 +1,34 @@
+From: John Thomson <git@johnthomson.fastmail.com.au>
+Date: 21 Oct 2022 13:00:00 +1000
+Subject: [PATCH] xt_coova: fix kernel>=5.17
+
+Linux kernel 5.17 removed PDE_DATA, and replaced it with pde_data [0]
+
+[0]: https://github.com/torvalds/linux/commit/359745d78351c6f5442435f81549f0207ece28aa
+
+Signed-off-by: John Thomson <git@johnthomson.fastmail.com.au>
+
+--- a/src/linux/xt_coova.c
++++ b/src/linux/xt_coova.c
+@@ -470,7 +470,9 @@ static int coova_seq_open(struct inode *
+ 	if (st == NULL)
+ 		return -ENOMEM;
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
++	st->table = pde_data(inode);
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
+ 	st->table = PDE_DATA(inode);
+ #else
+ 	st->table = pde->data;
+@@ -482,7 +484,9 @@ static ssize_t
+ coova_mt_proc_write(struct file *file, const char __user *input,
+ 		    size_t size, loff_t *loff)
+ {
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
++	struct coova_table *t = pde_data(file_inode(file));
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
+ 	struct coova_table *t = PDE_DATA(file_inode(file));
+ #else
+ 	const struct proc_dir_entry *pde = PDE(file->f_path.dentry->d_inode);


### PR DESCRIPTION
Maintainer: @teslamint | @neheb
Compile tested: aarch64 armvirt
Run tested: no

Description:
Add patch to fix linux 5.17 removal of PDE_DATA: https://github.com/torvalds/linux/commit/359745d78351c6f5442435f81549f0207ece28aa

A `CONFIG_ALL_KMODS=y` build with work-in-progress kernel 6.1rc1 stopped on this package