### PR TITLE
net-snmp: change persistent directory and add support v3 in compile

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -41,7 +41,7 @@ define Package/libnetsnmp
 $(call Package/net-snmp/Default)
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libnl-tiny +libpci +libpcre
+  DEPENDS:=+libnl-tiny +libpci +libpcre +libopenssl
   TITLE:=Open source SNMP implementation (libraries)
 endef
 
@@ -203,7 +203,7 @@ CONFIGURE_ARGS += \
 	--with-mib-modules="$(SNMP_MIB_MODULES_INCLUDED)" \
 	--with-out-transports="$(SNMP_TRANSPORTS_EXCLUDED)" \
 	--with-transports="$(SNMP_TRANSPORTS_INCLUDED)" \
-	--without-openssl \
+	--with-openssl=yes \
 	--without-libwrap \
 	--without-mysql \
 	--without-rpm \

--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -191,7 +191,7 @@ CONFIGURE_ARGS += \
 	--enable-static \
 	--with-endianness=$(if $(CONFIG_BIG_ENDIAN),big,little) \
 	--with-logfile=/var/log/snmpd.log \
-	--with-persistent-directory=/usr/lib/snmp/ \
+	--with-persistent-directory=/usr/lib/net-snmp/ \
 	--with-default-snmp-version=1 \
 	--with-sys-contact=root@localhost \
 	--with-sys-location=Unknown \

--- a/net/net-snmp/files/snmpd.conf
+++ b/net/net-snmp/files/snmpd.conf
@@ -128,3 +128,13 @@ config engineid
 config snmpd general
 	option enabled '1'
 #	list network 'wan'
+
+config user
+#	option enabled '1'
+#	option username 'snmpv3user'
+#	option perm 'rw'
+#	option authProto 'SHA'
+#	option privProto 'AES'
+#	option authKey '123456780'
+#	option privKey '123456789'
+

--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -6,6 +6,7 @@ USE_PROCD=1
 PROG="/usr/sbin/snmpd"
 
 CONFIGFILE="/var/run/snmpd.conf"
+SNMPD_FILE="/usr/lib/net-snmp/snmpd.conf"
 
 snmpd_agent_add() {
 	local cfg="$1"
@@ -104,6 +105,34 @@ snmpd_access_add() {
 	config_get notify "$cfg" notify
 	[ -n "$notify" ] || return 0
 	echo "access $group $context $version $level $prefix $read $write $notify" >> $CONFIGFILE
+}
+
+snmpd_user_add() {
+	local cfg="$1"
+	config_get enabled "$cfg" enabled
+	[ "$enabled" == "1" ] || return 0
+	config_get username "$cfg" username
+	[ -n "$username" ] || return 0
+	config_get perm "$cfg" perm
+	[ -n "$perm" ] || return 0
+	usercmd="rouser"
+	[ "$perm" == "rw" ] && usercmd="rwuser"
+	config_get authProto "$cfg" authProto
+	[ -n "$authProto" ] || return 0
+	config_get privProto "$cfg" privProto
+	[ -n "$privProto" ] || return 0
+	config_get authKey "$cfg" authKey
+	[ -n "$authKey" ] || return 0
+	config_get privKey "$cfg" privKey
+	[ "$privProto" != "NO" ] && [ -z "$privKey" ] && return 0
+	str="createUser $username $authProto \"$authKey\""
+	secLevel="authnopriv"
+	if [ "$privProto" != "NO" ]; then
+		secLevel="authpriv"
+		str="${str} $privProto \"$privKey\""
+	fi
+	echo "$usercmd $username $secLevel" >> $CONFIGFILE
+	echo "$str" >> $CONFIGFILE
 }
 
 snmpd_trap_hostname_add() {
@@ -283,6 +312,7 @@ snmpd_setup_fw_rules() {
 
 start_service() {
 	[ -f "$CONFIGFILE" ] && rm -f "$CONFIGFILE"
+	[ -f "$SNMPD_FILE" ] && sed -i '/usmUser/d' $SNMPD_FILE
 
 	config_load snmpd
 
@@ -304,6 +334,7 @@ start_service() {
 	config_foreach snmpd_access_default_add access_default
 	config_foreach snmpd_access_HostName_add access_HostName
 	config_foreach snmpd_access_HostIP_add access_HostIP
+	config_foreach snmpd_user_add user
 	config_foreach snmpd_pass_add pass
 	config_foreach snmpd_exec_add exec
 	config_foreach snmpd_extend_add extend


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
net/net-snmp/Makefile: change persistent directory and add v3 compile 
net/net-snmp/files/snmpd.conf: add v3 user config
net/net-snmp/files/snmpd.init: add v3 user init

to fix bug:  
    1. Using net-snmp v3, the EngineBoots no increase auto in persistent file when restart snmpd server
    2. After changed V3 user config, it no changed in persistent file when restart snmpd server