### PR TITLE
[22.03] simple-adblock: remove unnecessary procd_add_reload_interface_trigger

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.9.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -1320,7 +1320,6 @@ status_service() { load_validate_config 'config' adb_status "''"; }
 service_triggers() {
 	procd_open_trigger
 		procd_add_config_trigger 'config.change' "${packageName}" /etc/init.d/${packageName} reload
-		procd_add_reload_interface_trigger 'wan'
 		procd_add_interface_trigger 'interface.*.up' 'wan' /etc/init.d/${packageName} reload
 	procd_close_trigger
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-135, OpenWrt 22.03.2
Run tested: x86_64, Sophos SG-135, OpenWrt 22.03.2, start service, check ubus entries

Description:
* remove unnecessary procd_add_reload_interface_trigger

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit ef067f6304b36ed036b07f241819521d3ba10991)
