### PR TITLE
https-dns-proxy: bugfix: prevent creation of empty interface trigger

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2022-10-15
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -269,7 +269,7 @@ service_triggers() {
 		network_find_wan6 wan6
 		wan6="${wan6:-wan6}"
 	fi
-	for i in "$wan" "$wan6"; do
+	for i in $wan $wan6; do
 		procd_add_interface_trigger "interface.*" "$i" "/etc/init.d/${packageName}" start
 	done
 	procd_add_config_trigger "config.change" "$packageName" "/etc/init.d/${packageName}" start


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-135, OpenWrt 22.03.2
Run tested: x86_64, Sophos SG-135, OpenWrt 22.03.2, start service, check ubus entries

Description:
* When $wan/$wan6 are empty but double-quoted, it leads to creation of an interface trigger with empty interface

Signed-off-by: Stan Grishin <stangri@melmac.ca>
