### PR TITLE
mariadb: Drop unused rundir fix socket dir perms

### DIFF
--- a/utils/mariadb/files/mysqld.init
+++ b/utils/mariadb/files/mysqld.init
@@ -67,7 +67,6 @@ mysqld_status() {
 start_service() {
 	conf=/etc/mysql/my.cnf
 	logdir=/var/log/mysql
-	rundir=/var/run/mysqld
 	version="$(mysqld --version | sed -n 's|.*Ver[[:blank:]]*\([0-9.]*\)-.*|\1|p')"
 
 	# Few basic checks
@@ -134,14 +133,11 @@ start_service() {
 	fi
 
 	# Make sure all required directories exists and have correct rights
-	for i in "$logdir" "$rundir" "$sockdir"; do
+	for i in "$logdir" "$sockdir"; do
 		opts="-m 0750"
 		if ! [ -e "$i" ]; then
-			# $rundir needs to be accessible for
-			# clients
-			if [ "$i" = "$rundir" ]; then
-				opts=
-			fi
+			# $sockdir needs to be accessible for clients
+			[ "$i" = "$sockdir" ] && opts="-m 0755"
 			# shellcheck disable=SC2086
 			mkdir -p $opts "$i"
 		fi


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, Turris Omnia, OpenWrt 21.02
Run tested: mvebu, Turris Omnia, OpenWrt 21.02, runs, client is able to connect

Description:
We had been creating "rundir" but it was never used, probably leftover from some removed function. At the same time, we were setting quite strict rights to the socket directory (while comments sugested otherwise).

Fix for #19641