### PR TITLE
[21.02] mariadb: Update to the latest version 10.4.26

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2018 Sebastian Kemper <sebastian_ml@gmx.net>
-# Copyright (C) 2021 Michal Hrusecky <michal@hrusecky.net>
+# Copyright (C) 2021-2022 Michal Hrusecky <michal@hrusecky.net>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,13 +9,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
-PKG_VERSION:=10.4.22
-PKG_RELEASE:=3
+PKG_VERSION:=10.4.26
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := https://archive.mariadb.org/$(PKG_NAME)-$(PKG_VERSION)/source
 
-PKG_HASH:=44bdc36eeb02888296e961718bae808f3faab268ed49160a785248db60500c00
+PKG_HASH:=715ac7e23afc3b8a559c6cc998cdb1973d90f621b2bdd7603e2c6e53860b2ddf
 PKG_MAINTAINER:=Michal Hrusecky <Michal@Hrusecky.net>
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=COPYING THIRDPARTY

--- a/utils/mariadb/patches/100-fix_hostname.patch
+++ b/utils/mariadb/patches/100-fix_hostname.patch
@@ -1,6 +1,6 @@
 --- a/scripts/mysql_install_db.sh
 +++ b/scripts/mysql_install_db.sh
-@@ -418,7 +418,7 @@ fi
+@@ -424,7 +424,7 @@ fi
  
  
  # Try to determine the hostname

--- a/utils/mariadb/patches/180-relax-mysql_install-db-wrt-pam-tool.patch
+++ b/utils/mariadb/patches/180-relax-mysql_install-db-wrt-pam-tool.patch
@@ -1,6 +1,6 @@
 --- a/scripts/mysql_install_db.sh
 +++ b/scripts/mysql_install_db.sh
-@@ -358,6 +358,14 @@ then
+@@ -364,6 +364,14 @@ then
      exit 1
    fi
    plugindir=`find_in_dirs --dir auth_pam.so $basedir/lib*/plugin $basedir/lib*/mysql/plugin $basedir/lib/*/mariadb19/plugin`
@@ -15,7 +15,7 @@
    pamtooldir=$plugindir
  # relative from where the script was run for a relocatable install
  elif test -n "$dirname0" -a -x "$rel_mysqld" -a ! "$rel_mysqld" -ef "@sbindir@/mysqld"
-@@ -477,7 +485,9 @@ do
+@@ -488,7 +496,9 @@ do
    fi
  done
  
@@ -26,7 +26,7 @@
  then
    if test -z "$srcdir" -a "$in_rpm" -eq 0
    then
-@@ -498,6 +508,10 @@ then
+@@ -509,6 +519,10 @@ then
          echo
      fi
    fi

--- a/utils/mariadb/patches/190-replace-hostname-in-mysqld_safe.patch
+++ b/utils/mariadb/patches/190-replace-hostname-in-mysqld_safe.patch
@@ -1,6 +1,6 @@
 --- a/scripts/mysqld_safe.sh
 +++ b/scripts/mysqld_safe.sh
-@@ -246,7 +246,7 @@ wsrep_recover_position() {
+@@ -247,7 +247,7 @@ wsrep_recover_position() {
      return 1
    fi
  
@@ -9,7 +9,7 @@
  
    local wr_options="--disable-log-error  --pid-file='$wr_pidfile'"
  
-@@ -666,7 +666,7 @@ then
+@@ -668,7 +668,7 @@ then
          * ) err_log="$DATADIR/$err_log" ;;
        esac
      else
@@ -18,7 +18,7 @@
      fi
    fi
  
-@@ -745,7 +745,7 @@ fi
+@@ -754,7 +754,7 @@ fi
  
  if test -z "$pid_file"
  then

--- a/utils/mariadb/patches/200-no-selinux.patch
+++ b/utils/mariadb/patches/200-no-selinux.patch
@@ -1,6 +1,6 @@
 --- a/support-files/CMakeLists.txt
 +++ b/support-files/CMakeLists.txt
-@@ -61,7 +61,7 @@ IF(UNIX)
+@@ -62,7 +62,7 @@ IF(UNIX)
      INSTALL(FILES magic DESTINATION ${inst_location} COMPONENT SupportFiles)
      INSTALL(DIRECTORY policy DESTINATION ${inst_location} COMPONENT SupportFiles)
      FIND_PROGRAM(CHECKMODULE checkmodule)


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, Turris Omnia, OpenWrt 21.02
Run tested: mvebu, Turris Omnia, OpenWrt 21.02, runs, client is able to connect

Description:

Keeping the major version, bumping just a minor version. It includes various bug fixes and security fixes. For details, see:

https://mariadb.com/kb/en/mariadb-10426-release-notes/
https://mariadb.com/kb/en/mariadb-10425-release-notes/
https://mariadb.com/kb/en/mariadb-10424-release-notes/
https://mariadb.com/kb/en/mariadb-10423-release-notes/

While at it, also switching to AUTORELEASE and refreshing patches.