### PR TITLE
acme: refactor

### DIFF
--- a/net/acme-acmesh/files/hook.sh
+++ b/net/acme-acmesh/files/hook.sh
@@ -4,6 +4,7 @@ ACME=/usr/lib/acme/client/acme.sh
 LOG_TAG=acme-acmesh
 # webroot option deprecated, use the hardcoded value directly in the next major version
 WEBROOT=${webroot:-/var/run/acme/challenge}
+NOTIFY=/usr/lib/acme/notify
 
 # shellcheck source=net/acme/files/functions.sh
 . /usr/lib/acme/functions.sh
@@ -12,9 +13,7 @@ WEBROOT=${webroot:-/var/run/acme/challenge}
 export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 export NO_TIMESTAMP=1
 
-cmd="$1"
-
-case $cmd in
+case $1 in
 get)
 	set --
 	[ "$debug" = 1 ] && set -- "$@" --debug
@@ -38,20 +37,25 @@ get)
 			staging_moved=1
 		else
 			set -- "$@" --renew --home "$state_dir" -d "$main_domain"
-			log info "$*"
-			trap 'ACTION=renewed-failed hotplug-call acme;exit 1' INT
-			"$ACME" "$@"
+			log info "$ACME $*"
+			trap '$NOTIFY renew-failed;exit 1' INT
+			$ACME "$@"
 			status=$?
 			trap - INT
 
 			case $status in
-			0) ;; # renewed ok, handled by acme.sh hook, ignore.
-			2) ;; # renew skipped, ignore.
+			0)
+				$NOTIFY renewed
+				exit;;
+			2)
+				# renew skipped, ignore.
+				exit
+				;;
 			*)
-				ACTION=renew-failed hotplug-call acme
+				$NOTIFY renew-failed
+				exit 1
 				;;
 			esac
-			return 0
 		fi
 	fi
 
@@ -92,11 +96,11 @@ get)
 
 	set -- "$@" --issue --home "$state_dir"
 
-	log info "$*"
-	trap 'ACTION=issue-failed hotplug-call acme;exit 1' INT
+	log info "$ACME $*"
+	trap '$NOTIFY issue-failed;exit 1' INT
 	"$ACME" "$@" \
-		--pre-hook 'ACTION=prepare hotplug-call acme' \
-		--renew-hook 'ACTION=renewed hotplug-call acme'
+		--pre-hook "$NOTIFY prepare" \
+		--renew-hook "$NOTIFY renewed"
 	status=$?
 	trap - INT
 
@@ -106,7 +110,7 @@ get)
 		ln -s "$domain_dir/$main_domain.key" /etc/ssl/acme
 		ln -s "$domain_dir/fullchain.cer" "/etc/ssl/acme/$main_domain.fullchain.cer"
 		ln -s "$domain_dir/ca.cer" "/etc/ssl/acme/$main_domain.chain.cer"
-		ACTION=issued hotplug-call acme
+		$NOTIFY issued
 		;;
 	*)
 		if [ "$staging_moved" = 1 ]; then
@@ -117,8 +121,7 @@ get)
 			mv "$domain_dir" "$failed_dir"
 			log err "State moved to $failed_dir"
 		fi
-		ACTION=issue-failed hotplug-call acme
-		return 0
+		$NOTIFY issue-failed
 		;;
 	esac
 	;;

--- a/net/acme-acmesh/files/hook.sh
+++ b/net/acme-acmesh/files/hook.sh
@@ -87,6 +87,9 @@ get)
 		elif [ "$calias" ]; then
 			set -- "$@" --challenge-alias "$calias"
 		fi
+		if [ "$dns_wait" ]; then
+			set -- "$@" --dnssleep "$dns_wait"
+		fi
 	elif [ "$standalone" = 1 ]; then
 		set -- "$@" --standalone --listen-v6
 	else

--- a/net/acme-common/Makefile
+++ b/net/acme-common/Makefile
@@ -34,6 +34,7 @@ define Package/acme-common/conffiles
 endef
 
 define Package/acme-common/install
+	$(INSTALL_DIR) $(1)/etc/ssl/acme
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/acme.config $(1)/etc/config/acme
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/net/acme-common/Makefile
+++ b/net/acme-common/Makefile
@@ -41,10 +41,12 @@ define Package/acme-common/install
 	$(INSTALL_BIN) ./files/acme.sh $(1)/usr/bin/acme
 	$(INSTALL_DIR) $(1)/usr/lib/acme
 	$(INSTALL_DATA) ./files/functions.sh $(1)/usr/lib/acme
+	$(INSTALL_BIN) ./files/acme-notify.sh $(1)/usr/lib/acme/notify
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/acme.init $(1)/etc/init.d/acme
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_DATA) ./files/acme.uci-defaults $(1)/etc/uci-defaults/acme
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/acme
 endef
 
 define Package/acme/postinst

--- a/net/acme-common/Makefile
+++ b/net/acme-common/Makefile
@@ -34,7 +34,6 @@ define Package/acme-common/conffiles
 endef
 
 define Package/acme-common/install
-	$(INSTALL_DIR) $(1)/etc/acme
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/acme.config $(1)/etc/config/acme
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/net/acme-common/Makefile
+++ b/net/acme-common/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-common
-PKG_VERSION:=1.0.0
+PKG_VERSION:=1.0.1
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/acme-common/files/acme-notify.sh
+++ b/net/acme-common/files/acme-notify.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -u
+
+event="$1"
+
+# Call hotplug first, giving scripts a chance to modify certificates before
+# reloadaing the services
+ACTION=$event hotplug-call acme
+
+case $event in
+renewed)
+    ubus call service event '{"type":"acme.renew","data":{}}'
+    ;;
+issued)
+    ubus call service event '{"type":"acme.issue","data":{}}'
+    ;;
+esac

--- a/net/acme-common/files/acme.config
+++ b/net/acme-common/files/acme.config
@@ -5,7 +5,7 @@ config acme
 
 config cert 'example_wildcard'
 	option enabled 0
-	option use_staging 1
+	option staging 1
 	list domains example.org
 	list domains sub.example.org
 	list domains *.sub.example.org
@@ -17,6 +17,6 @@ config cert 'example_wildcard'
 
 config cert 'example'
 	option enabled 0
-	option use_staging 1
+	option staging 1
 	list domains example.org
 	list domains sub.example.org

--- a/net/acme-common/files/acme.sh
+++ b/net/acme-common/files/acme.sh
@@ -131,7 +131,6 @@ get)
 	config_load acme
 	config_foreach load_globals acme
 
-	mkdir -p /etc/ssl/acme
 	trap cleanup EXIT
 	config_foreach get_cert cert
 	;;

--- a/net/acme-common/files/acme.sh
+++ b/net/acme-common/files/acme.sh
@@ -59,6 +59,8 @@ load_options() {
 	export days
 	config_get standalone "$section" standalone 0
 	export standalone
+	config_get dns_wait "$section" dns_wait
+	export dns_wait
 
 	config_get webroot "$section" webroot
 	export webroot

--- a/net/acme-common/files/acme.sh
+++ b/net/acme-common/files/acme.sh
@@ -36,7 +36,7 @@ load_options() {
 	section=$1
 
 	# compatibility for old option name
-	config_get_bool use_staging "$section" staging
+	config_get_bool staging "$section" use_staging
 	if [ -z "$staging" ]; then
 		config_get_bool staging "$section" staging 0
 	fi

--- a/net/acme-common/files/acme.sh
+++ b/net/acme-common/files/acme.sh
@@ -8,7 +8,7 @@
 #
 # Authors: Toke Høiland-Jørgensen <toke@toke.dk>
 
-export state_dir='/etc/acme'
+export state_dir=/etc/acme
 export account_email=
 export debug=0
 export challenge_dir='/var/run/acme/challenge'

--- a/net/haproxy/files/acme.hotplug
+++ b/net/haproxy/files/acme.hotplug
@@ -6,7 +6,3 @@ issued|renewed)
 		>"/etc/ssl/acme/$main_domain.combined.cer"
 	;;
 esac
-
-if [ "$ACTION" = renewed ]; then
-	/etc/init.d/haproxy reload
-fi

--- a/net/haproxy/files/haproxy.init
+++ b/net/haproxy/files/haproxy.init
@@ -18,6 +18,10 @@ start_service() {
 	procd_close_instance
 }
 
+service_triggers() {
+	procd_add_raw_trigger acme.renew 5000 /etc/init.d/haproxy reload
+}
+
 extra_command "check" "Check haproxy config"
 check() {
 	$HAPROXY_BIN -c -q -V -f $HAPROXY_CONFIG

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.21.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -376,9 +376,6 @@ ifeq ($(CONFIG_NGINX_NAXSI),y)
 endif
 	$(if $(CONFIG_NGINX_NAXSI),$($(INSTALL_BIN) $(PKG_BUILD_DIR)/nginx-naxsi/naxsi_config/naxsi_core.rules $(1)/etc/nginx))
 	$(if $(CONFIG_NGINX_NAXSI),$(chmod 0640 $(1)/etc/nginx/naxsi_core.rules))
-
-	$(INSTALL_DIR) $(1)/etc/hotplug.d/acme
-	$(INSTALL_DATA) ./files/acme.hotplug $(1)/etc/hotplug.d/acme/00-nginx
 endef
 
 Package/nginx-all-module/install = $(Package/nginx-ssl/install)

--- a/net/nginx/files/acme.hotplug
+++ b/net/nginx/files/acme.hotplug
@@ -1,3 +1,0 @@
-if [ "$ACTION" = renewed ]; then
-	/etc/init.d/nginx reload
-fi

--- a/net/nginx/files/nginx.init
+++ b/net/nginx/files/nginx.init
@@ -66,6 +66,11 @@ reload_service() {
 }
 
 
+service_triggers() {
+	procd_add_raw_trigger acme.renew 5000 /etc/init.d/nginx reload
+}
+
+
 extra_command "relog" "Reopen log files (without reloading)"
 relog() {
 	[ -d /var/log/nginx ] || mkdir -p /var/log/nginx


### PR DESCRIPTION
- Move notifying logic out of acme hooks
- Prevent concurrent running of `acme get`
- Use procd instead of hotplug to reload services (leaving hotplug for user scripts only)
- Fix a bug where switching from staging to production didn't trigger the renew event

Signed-off-by: Glen Huang <i@glenhuang.com>

Maintainer: @tohojo

Description:

Using hotplug to reload a service can inadvertently restarting it if it was stopped, as pointed out by @ptpt52.

This PR make services use procd instead, which is how it should be properly done IMO. It also moves the actual notifying logic out of hooks, since they really shouldn't be concerned about how to actually do that.

@tohojo, if you think the design is good I will change other related services too.