### PR TITLE
samba4: update to 4.17.1

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.17.0
+PKG_VERSION:=4.17.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -13,7 +13,7 @@ PKG_SOURCE_URL:= \
 		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
-PKG_HASH:=04868ecda82fcbeda7b8bf519a2461a64d55c6e70efc6f6053b2fbba55f1823a
+PKG_HASH:=1b939d03f8ca57194c413ed863014a3850c9ce9f9e31c2a7df706806fba77c01
 
 PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILES:=COPYING

--- a/net/samba4/patches/021-source4-msgsock-nvram-fix.patch
+++ b/net/samba4/patches/021-source4-msgsock-nvram-fix.patch
@@ -1,6 +1,6 @@
 --- a/source4/lib/messaging/messaging.c
 +++ b/source4/lib/messaging/messaging.c
-@@ -500,7 +500,7 @@ struct imessaging_context *imessaging_in
+@@ -514,7 +514,7 @@ static struct imessaging_context *imessa
  		goto fail;
  	}
  


### PR DESCRIPTION
* update to 4.17.1
* changelog: https://www.samba.org/samba/history/samba-4.17.1
* refresh patch

Signed-off-by: Andrew Sim <andrewsimz@gmail.com>

Maintainer: no one
Compile tested: mediatek: mt7622
Run tested: mediatek: mt7622

