### PR TITLE
[22.03] bandwidthd: fix time_t problem

### DIFF
--- a/utils/bandwidthd/Makefile
+++ b/utils/bandwidthd/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2017 OpenWrt.org
+# Copyright (C) 2006-2022 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bandwidthd
 PKG_VERSION:=2.0.1-35
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/NethServer/bandwidthd/tar.gz/$(PKG_VERSION)?

--- a/utils/bandwidthd/patches/040-64bit-time-t.patch
+++ b/utils/bandwidthd/patches/040-64bit-time-t.patch
@@ -1,5 +1,14 @@
 --- a/bandwidthd.c
 +++ b/bandwidthd.c
+@@ -103,7 +103,7 @@ void bd_CollectingData(char *filename)
+ 		}
+ 	}
+ 
+-int WriteOutWebpages(long int timestamp)
++int WriteOutWebpages(time_t timestamp)
+ {
+ 	struct IPDataStore *DataStore = IPDataStore;
+ 	struct SummaryData **SummaryData;
 @@ -893,7 +893,7 @@ void StoreIPDataInCDF(struct IPData IncD
  		{
  		IPData = &IncData[counter];
@@ -36,3 +45,34 @@
  			goto End_RecoverDataFromCdf;
  
  		if (!timestamp) // First run through loop
+--- a/graph.c
++++ b/graph.c
+@@ -767,8 +767,8 @@ void PrepareXAxis(gdImagePtr im, time_t
+     int black, red;
+     time_t sample_begin, sample_end;    
+     struct tm *timestruct;
+-    long int MarkTime;
+-	long int MarkTimeStep;
++    time_t MarkTime;
++    time_t MarkTimeStep;
+     double x;
+     
+     sample_begin=timestamp-config.range;
+@@ -786,7 +786,7 @@ void PrepareXAxis(gdImagePtr im, time_t
+ 	if ((24*60*60*(XWIDTH-XOFFSET))/config.range > (XWIDTH-XOFFSET)/10)
+ 		{
+ 		// Day bars
+-	    timestruct = localtime((time_t *)&sample_begin);
++	    timestruct = localtime(&sample_begin);
+     	timestruct->tm_sec = 0;
+ 	    timestruct->tm_min = 0;
+     	timestruct->tm_hour = 0;
+@@ -805,7 +805,7 @@ void PrepareXAxis(gdImagePtr im, time_t
+ 	        gdImageLine(im, x, 0, x, YHEIGHT-YOFFSET, red);
+     	    gdImageLine(im, x+1, 0, x+1, YHEIGHT-YOFFSET, red);
+ 	
+-    	    timestruct = localtime((time_t *)&MarkTime);
++    	    timestruct = localtime(&MarkTime);
+ 	        strftime(buffer, 100, "%a, %b %d", timestruct);
+     	    gdImageString(im, gdFontSmall, x-30,  YHEIGHT-YOFFSET+10, buffer, black);        
+ 


### PR DESCRIPTION
Maintainer: me / @padre-lacroix 
Compile tested: mips_24kc on 22.03
Run tested: Qualcomm Atheros QCA9558 ver 1 rev 0, TP-Link Archer C7 v2, OpenWRT 22.03.0 r19685-512e76967f

Description:
Fixes issue #19510 with the change in time_t with musl 1.2 on a 32 bits system.
The three variants (bandwidthd-no-db, bandwidthd-sqlite and bandwidthd-pgsql) have been tested and found to creating the graphs correctly.

Signed-off-by: Jean-Michel Lacroix <lacroix@lepine-lacroix.info>