### PR TITLE
siit: fix kernel 5.16 compile

### DIFF
--- a/net/siit/Makefile
+++ b/net/siit/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=siit
 PKG_VERSION:=1.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-2.0-or-later
 
 include $(INCLUDE_DIR)/package.mk

--- a/net/siit/src/siit.c
+++ b/net/siit/src/siit.c
@@ -1376,7 +1376,7 @@ static void
 siit_init(struct net_device *dev)
 {
 	ether_setup(dev);    /* assign some of the fields */
-	random_ether_addr(dev->dev_addr);
+	eth_hw_addr_random(dev);
 
 	/*
 	 * Assign device function.


### PR DESCRIPTION
Maintainer: 
Compile tested: aarch64 kernel 6.1rc1 WIP
Run tested: no

Description:
```
siit-1.2/siit.c:1379:9: error: implicit declaration of function 'random_ether_addr' [-Werror=implicit-function-declaration]
 1379 |         random_ether_addr(dev->dev_addr);
      |         ^~~~~~~~~~~~~~~~~
```

Linux 3.6 renamed random_ether_addr to eth_random_addr [0] Linux 5.16 removed random_ether_addr [1]

[0]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0a4dd594982a321699000218715e28664ec49169 [1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ba530fea8ca1b57ee71d4e62f287a5d7ed92f789
