### PR TITLE
https-dns-proxy: bugfix: restore empty server; misc improvements

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2022-10-15
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -128,8 +128,9 @@ append_bootstrap() {
 }
 
 start_instance() {
-	local cfg="$1" param listen_addr listen_port ipv6_resolvers_only p
+	local cfg="$1" param listen_addr listen_port ipv6_resolvers_only p url
 
+	config_get url "$cfg" 'resolver_url'
 	config_get_bool ipv6_resolvers_only "$cfg" 'use_ipv6_resolvers_only' '0'
 	append_parm "$cfg" 'resolver_url' '-r'
 	append_parm "$cfg" 'listen_addr' '-a' '127.0.0.1'
@@ -151,8 +152,9 @@ start_instance() {
 	procd_set_param stderr 1
 	procd_set_param stdout 1
 	procd_set_param respawn
+	procd_open_data
+	json_add_string url "$url"
 	if [ "$force_dns" -ne 0 ]; then
-		procd_open_data
 		json_add_array firewall
 		for p in $force_dns_port; do
 			if netstat -tuln | grep 'LISTEN' | grep ":${p}" >/dev/null 2>&1 || [ "$p" = '53' ]; then
@@ -177,8 +179,8 @@ start_instance() {
 			fi
 		done
 		json_close_array
-		procd_close_data
 	fi
+	procd_close_data
 	procd_close_instance
 
 	if [ "$?" ]; then
@@ -269,10 +271,10 @@ service_triggers() {
 		network_find_wan6 wan6
 		wan6="${wan6:-wan6}"
 	fi
-	for i in $wan $wan6; do
-		procd_add_interface_trigger "interface.*" "$i" "/etc/init.d/${packageName}" start
+	for i in "$wan" "$wan6"; do
+		[ -n "$i" ] && procd_add_interface_trigger "interface.*" "$i" "/etc/init.d/${packageName}" start
 	done
-	procd_add_config_trigger "config.change" "$packageName" "/etc/init.d/${packageName}" start
+	procd_add_config_trigger "config.change" "$packageName" "/etc/init.d/${packageName}" reload
 }
 
 service_started() { procd_set_config_changed firewall; }
@@ -341,7 +343,7 @@ dnsmasq_restore_server_backup() {
 		fi
 		uci_remove 'dhcp' "$cfg" 'doh_backup_noresolv'
 	fi
-	if [ -n "$(uci_get 'dhcp' "$cfg" 'doh_backup_server')" ]; then
+	if uci_get 'dhcp' "$cfg" 'doh_backup_server' >/dev/null 2>&1; then
 		dnsmasq_doh_server "$cfg" 'remove'
 		for i in $(uci_get 'dhcp' "$cfg" 'doh_backup_server'); do
 			uci_add_list_if_new 'dhcp' "$cfg" 'server' "$i"


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-135, OpenWrt 22.03.2
Run tested:  x86_64, Sophos SG-135, OpenWrt 22.03.2, test empty dnsmasq servers, check ubus entries

Description:
* bugfix: properly restore empty server config for dnsmasq (to address issue brought up in https://github.com/stangri/source.openwrt.melmac.net/pull/162)
* better handling of non-existant wan/wan6 interface for triggers
* add resolver url to ubus data for future-proofing WebUI js move

Signed-off-by: Stan Grishin <stangri@melmac.ca>
