### PR TITLE
ffmpeg: add conflicts and provides

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -333,6 +333,7 @@ define Package/libffmpeg-audio-dec
 $(call Package/libffmpeg/Default)
  TITLE+= (audio)
  VARIANT:=audio-dec
+ CONFLICTS:=libffmpeg-full
 endef
 
 define Package/libffmpeg-audio-dec/description
@@ -351,6 +352,7 @@ $(call Package/libffmpeg/Default)
     +PACKAGE_libx264:libx264 \
     +!PACKAGE_libx264:fdk-aac
  VARIANT:=full
+ PROVIDES:=libffmpeg-mini libffmpeg-audio-dec
 endef
 
 
@@ -365,6 +367,7 @@ define Package/libffmpeg-mini
 $(call Package/libffmpeg/Default)
  TITLE+= (mini)
  VARIANT:=mini
+ CONFLICTS:=libffmpeg-full
 endef
 
 define Package/libffmpeg-mini/description


### PR DESCRIPTION
Maintainer: @thess @antonlacon 
Compile tested: Turris Omnia, OpenWrt 21.02.5, mvebu/cortex-a9
Run tested: Turris Omnia, OpenWrt 21.02.5, mvebu/cortex-a9

Description:

Motivation of this change is that full variants provides the mini variant and as well audio-dec package, thus you can not install both as it fails with the following output:
```
Collected errors:
 * check_data_file_clashes: Package libffmpeg-audio-dec wants to install file /usr/lib/libavcodec.so.58 But that file is already provided by package  * libffmpeg-full
 * check_data_file_clashes: Package libffmpeg-audio-dec wants to install file /usr/lib/libavcodec.so.58.91.100 But that file is already provided by package  * libffmpeg-full
 * check_data_file_clashes: Package libffmpeg-audio-dec wants to install file /usr/lib/libavdevice.so.58 But that file is already provided by package  * libffmpeg-full
 * check_data_file_clashes: Package libffmpeg-audio-dec wants to install file /usr/lib/libavdevice.so.58.10.100 But that file is already provided by package  * libffmpeg-full
 * check_data_file_clashes: Package libffmpeg-audio-dec wants to install file /usr/lib/libavformat.so.58 But that file is already provided by package  * libffmpeg-full
 * check_data_file_clashes: Package libffmpeg-audio-dec wants to install file /usr/lib/libavformat.so.58.45.100 But that file is already provided by package  * libffmpeg-full
 * check_data_file_clashes: Package libffmpeg-audio-dec wants to install file /usr/lib/libavutil.so.56 But that file is already provided by package  * libffmpeg-full
 * check_data_file_clashes: Package libffmpeg-audio-dec wants to install file /usr/lib/libavutil.so.56.51.100 But that file is already provided by package  * libffmpeg-full
 * opkg_install_cmd: Cannot install package libffmpeg-audio-dec.
```

Let's change it to:
```
Installing libffmpeg-audio-dec (4.3.4-1) to root... Collected errors:
 * check_conflicts_for: The following packages conflict with libffmpeg-audio-dec:
 * check_conflicts_for:         libffmpeg-full *
 * opkg_install_cmd: Cannot install package libffmpeg-audio-dec.
```
