### PR TITLE
privoxy: correctly format /etc/services additions

### DIFF
--- a/net/privoxy/Makefile
+++ b/net/privoxy/Makefile
@@ -157,8 +157,15 @@ endef
 
 define Package/privoxy/postinst
 	#!/bin/sh
-	grep -i privoxy $${IPKG_INSTROOT}/etc/services >/dev/null 2>&1 || \
-		echo -e "privoxy\t8118" >> $${IPKG_INSTROOT}/etc/services
+	# if exists, update previous version entry missing protocol
+	(grep -E "privoxy.*8118$" $${IPKG_INSTROOT}/etc/services) > /dev/null \
+		&& sed -i "s/privoxy.*8118/privoxy\t\t8118\/tcp/" $${IPKG_INSTROOT}/etc/services
+
+	# add missing tcp and udp entries
+	(grep -E "privoxy.*8118\/tcp" $${IPKG_INSTROOT}/etc/services) > /dev/null \
+		|| echo -e "privoxy\t\t8118/tcp" >> $${IPKG_INSTROOT}/etc/services
+	(grep -E "privoxy.*8118\/udp" $${IPKG_INSTROOT}/etc/services) > /dev/null \
+		|| echo -e "privoxy\t\t8118/udp" >> $${IPKG_INSTROOT}/etc/services
 endef
 
 $(eval $(call BuildPackage,privoxy))


### PR DESCRIPTION
Maintainer:
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:

This adds the missing protocol (e.g. /tcp and /udp) to the entry in /etc/services. If the entry already exists, it will add the /tcp to it. Otherwise, it will look and add the tcp and udp entries if either is missing.

fixes: #19665

Signed-off-by: Josh Powers <powersj@fastmail.com>