### PR TITLE
libwebsockets: full variant provides OpenSSL

### DIFF
--- a/libs/libwebsockets/Makefile
+++ b/libs/libwebsockets/Makefile
@@ -56,6 +56,7 @@ define Package/libwebsockets-openssl
 	TITLE += (OpenSSL)
 	DEPENDS += +libopenssl
 	VARIANT:=openssl
+	CONFLICTS:=libwebsockets-full
 endef
 
 define Package/libwebsockets-mbedtls
@@ -70,6 +71,7 @@ define Package/libwebsockets-full
 	TITLE += (Full - OpenSSL, libuv, plugins, CGI)
 	DEPENDS += +libopenssl +libuv
 	VARIANT:=full
+	PROVIDES:=libwebsockets-openssl
 endef
 
 ifeq ($(BUILD_VARIANT),openssl)

--- a/libs/libwebsockets/Makefile
+++ b/libs/libwebsockets/Makefile
@@ -64,6 +64,7 @@ define Package/libwebsockets-mbedtls
 	TITLE += (mbedTLS)
 	DEPENDS += +libmbedtls
 	VARIANT:=mbedtls
+	CONFLICTS:=libwebsockets-openssl
 endef
 
 define Package/libwebsockets-full


### PR DESCRIPTION
Maintainer: @karlp 
Compile tested: Turris 1.1, OpenWrt 21.02.5, mpc85xx/p2020
Run tested: 

- **conflicts OpenSSL and full variant:**

Before:
 ```
 root@turris:~# opkg list-installed | grep libwebsockets
libwebsockets-openssl - 3.1.0-2
root@turris:~# opkg install libwebsockets-full
Installing libwebsockets-full (3.1.0-2) to root...
Downloading https://repo.turris.cz/hbk/omnia/packages/packages/libwebsockets-full_3.1.0-2_arm_cortex-a9_vfpv3-d16.ipk
Collected errors:
 * check_data_file_clashes: Package libwebsockets-full wants to install file /usr/lib/libwebsockets.so
	But that file is already provided by package  * libwebsockets-openssl
 * check_data_file_clashes: Package libwebsockets-full wants to install file /usr/lib/libwebsockets.so.14
	But that file is already provided by package  * libwebsockets-openssl
 * opkg_install_cmd: Cannot install package libwebsockets-full.
 ```
 
 After:
 ```
 root@turris:~# opkg install libwebsockets-full_3.1.0-3_powerpc_8548.ipk 
Installing libwebsockets-full (3.1.0-3) to root...
Configuring libwebsockets-full.
root@turris:~# opkg install libwebsockets-openssl_3.1.0-3_powerpc_8548.ipk 
Installing libwebsockets-openssl (3.1.0-3) to root...
Collected errors:
 * check_conflicts_for: The following packages conflict with libwebsockets-openssl:
 * check_conflicts_for: 	libwebsockets-full * 
 * opkg_install_cmd: Cannot install package libwebsockets-openssl.

 ```
- **full variant provides OpenSSL:**
```
root@turris:~# opkg list-installed | grep libwebsockets
libwebsockets-full - 3.1.0-2
root@turris:~# opkg install ttyd
Installing ttyd (1.6.3-3) to root...
Downloading https://repo.turris.cz/hbt/turris1x/packages/packages/ttyd_1.6.3-3_powerpc_8548.ipk
Configuring ttyd.
root@turris:~# opkg install mosquitto-ssl
Package mosquitto-ssl (2.0.15-1) installed in root is up to date.

root@turris:~# opkg remove libwebsockets-full
No packages removed.
Collected errors:
 * print_dependents_warning: Package libwebsockets-full is depended upon by packages:
 * print_dependents_warning: 	ttyd
 * print_dependents_warning: 	mosquitto-ssl
 * print_dependents_warning: These might cease to work if package libwebsockets-full is removed.

 * print_dependents_warning: Force removal of this package with --force-depends.
 * print_dependents_warning: Force removal of this package and its dependents
 * print_dependents_warning: with --force-removal-of-dependent-packages.
```

Description:

For some time, it is not possible to install ttyd and mosquitto-ssl at the same time, so let's solve it that libwebsockets-full provides libwebsockets-openssl. This allows to install ttyd and mosquitto at the same time.

Also, we need to add conflict, because we should not have installed libwebsockets-openssl and libwebsockets-full at the same time as they provides the same files.

Fixes: https://github.com/openwrt/packages/issues/11632
