### PR TITLE
lighttpd: backport patch to fix dummy Sec-WebSocket-Key

### DIFF
--- a/net/lighttpd/patches/010-fix-dummy-Sec-WebSocket-Key-in-proxy_and_cgi.patch
+++ b/net/lighttpd/patches/010-fix-dummy-Sec-WebSocket-Key-in-proxy_and_cgi.patch
@@ -1,0 +1,39 @@
+From cda9b71653bb6a633957f653fa08e819b32e601e Mon Sep 17 00:00:00 2001
+From: Shulyaka <Shulyaka@gmail.com>
+Date: Sun, 23 Oct 2022 13:29:22 +0300
+Subject: [PATCH] [mod_proxy,mod_cgi] fix dummy Sec-WebSocket-Key
+
+fix dummy Sec-WebSocket-Key value to remove excess '\n'
+
+x-ref:
+  "Fix websocket HTTP/2 to HTTP/1.1 proxy"
+  https://github.com/lighttpd/lighttpd1.4/pull/123
+
+github: closes #123
+---
+ src/mod_cgi.c   | 2 +-
+ src/mod_proxy.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+--- a/src/mod_cgi.c
++++ b/src/mod_cgi.c
+@@ -874,7 +874,7 @@ static int cgi_create_env(request_st * c
+ 			if (!http_header_request_get(r, HTTP_HEADER_OTHER,
+ 			                             CONST_STR_LEN("Sec-WebSocket-Key")))
+ 				cgi_env_add(env, CONST_STR_LEN("HTTP_SEC_WEBSOCKET_KEY"),
+-				                 CONST_STR_LEN("MDAwMDAwMDAwMDAwMDAwMAo="));
++				                 CONST_STR_LEN("MDAwMDAwMDAwMDAwMDAwMA=="));
+ 			/*(Upgrade and Connection should not exist for HTTP/2 request)*/
+ 			cgi_env_add(env, CONST_STR_LEN("HTTP_UPGRADE"), CONST_STR_LEN("websocket"));
+ 			cgi_env_add(env, CONST_STR_LEN("HTTP_CONNECTION"), CONST_STR_LEN("upgrade"));
+--- a/src/mod_proxy.c
++++ b/src/mod_proxy.c
+@@ -1013,7 +1013,7 @@ static handler_t proxy_create_env(gw_han
+ 		if (!http_header_request_get(r, HTTP_HEADER_OTHER,
+ 		                             CONST_STR_LEN("Sec-WebSocket-Key")))
+ 			buffer_append_string_len(b, CONST_STR_LEN(
+-			  "\r\nSec-WebSocket-Key: MDAwMDAwMDAwMDAwMDAwMAo="));
++			  "\r\nSec-WebSocket-Key: MDAwMDAwMDAwMDAwMDAwMA=="));
+ 		buffer_append_string_len(b, CONST_STR_LEN(
+ 		                              "\r\nUpgrade: websocket"
+ 		                              "\r\nConnection: close, upgrade\r\n\r\n"));


### PR DESCRIPTION
Maintainer: @gstrauss 
Compile tested: all Turris routers
Run tested: N/A

Description:
It was requested in https://gitlab.nic.cz/turris/os/packages/-/issues/873
  - Backports: https://github.com/lighttpd/lighttpd1.4/commit/cda9b71653bb6a633957f653fa08e819b32e601e
