### PR TITLE
ci: update github actions to v3

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -52,7 +52,7 @@ jobs:
             runtime_test: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -132,7 +132,7 @@ jobs:
           cat PKG-INFO
 
       - name: Store packages
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{env.ARCHIVE_NAME}}-packages
           path: |
@@ -140,7 +140,7 @@ jobs:
             PKG-INFO
 
       - name: Store logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{env.ARCHIVE_NAME}}-logs
           path: |


### PR DESCRIPTION
Update checkout and upload-artifact action to v3 to mute nodejs deprecation warning.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>