### PR TITLE
[22.03] https-dns-proxy: rename options

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2022-10-15
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/
@@ -23,7 +23,7 @@ define Package/https-dns-proxy
 	CATEGORY:=Network
 	TITLE:=DNS Over HTTPS Proxy
 	URL:=https://docs.openwrt.melmac.net/https-dns-proxy/
-	DEPENDS:=+libcares +libcurl +libev +ca-bundle
+	DEPENDS:=+libcares +libcurl +libev +ca-bundle +jsonfilter
 	CONFLICTS:=https_dns_proxy
 endef
 
@@ -40,12 +40,14 @@ endef
 define Package/https-dns-proxy/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_DIR) ${1}/etc/config
+	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
+	$(INSTALL_DIR) $(1)/etc/uci-defaults/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/https_dns_proxy $(1)/usr/sbin/https-dns-proxy
 	$(INSTALL_BIN) ./files/https-dns-proxy.init $(1)/etc/init.d/https-dns-proxy
 	$(SED) "s|^\(readonly PKG_VERSION\).*|\1='$(PKG_VERSION)-$(PKG_RELEASE)'|" $(1)/etc/init.d/https-dns-proxy
 	$(INSTALL_CONF) ./files/https-dns-proxy.config $(1)/etc/config/https-dns-proxy
+	$(INSTALL_BIN) ./files/https-dns-proxy.defaults $(1)/etc/uci-defaults/50-https-dns-proxy-migrate-options.sh
 endef
 
 $(eval $(call BuildPackage,https-dns-proxy))

--- a/net/https-dns-proxy/files/https-dns-proxy.config
+++ b/net/https-dns-proxy/files/https-dns-proxy.config
@@ -1,7 +1,7 @@
 config main 'config'
-	option update_dnsmasq_config '*'
 	option canary_domains_icloud '1'
 	option canary_domains_mozilla '1'
+	option dnsmasq_config_update '*'
 	option force_dns '1'
 	list force_dns_port '53'
 	list force_dns_port '853'
@@ -13,7 +13,7 @@ config main 'config'
 #	list force_dns_port '4434'
 #	list force_dns_port '5443'
 #	list force_dns_port '8443'
-	option wan6_trigger '0'
+	option procd_trigger_wan6 '0'
 
 config https-dns-proxy
 	option bootstrap_dns '1.1.1.1,1.0.0.1'

--- a/net/https-dns-proxy/files/https-dns-proxy.defaults
+++ b/net/https-dns-proxy/files/https-dns-proxy.defaults
@@ -1,0 +1,3 @@
+#!/bin/sh
+	sed -i "s|update_dnsmasq_config|dnsmasq_config_update|" "/etc/config/https-dns-proxy"
+	sed -i "s|wan6_trigger|procd_trigger_wan6|" "/etc/config/https-dns-proxy"

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -186,11 +186,11 @@ start_instance() {
 	if [ "$?" ]; then
 		config_get listen_addr "$cfg" 'listen_addr' '127.0.0.1'
 		config_get listen_port "$cfg" 'listen_port' "$port"
-		if [ "$update_dnsmasq_config" = '*' ]; then
+		if [ "$dnsmasq_config_update" = '*' ]; then
 			config_load 'dhcp'
 			config_foreach dnsmasq_doh_server 'dnsmasq' 'add' "${listen_addr}" "${listen_port}"
-		elif [ -n "$update_dnsmasq_config" ]; then
-			for i in $update_dnsmasq_config; do
+		elif [ -n "$dnsmasq_config_update" ]; then
+			for i in $dnsmasq_config_update; do
 				if [ -n "$(uci_get 'dhcp' "@dnsmasq[$i]")" ]; then
 					dnsmasq_doh_server "@dnsmasq[$i]" 'add' "${listen_addr}" "${listen_port}"
 				elif [ -n "$(uci_get 'dhcp' "$i")" ]; then
@@ -208,11 +208,11 @@ start_instance() {
 
 start_service() {
 	local canaryDomains canary_domains_icloud canary_domains_mozilla
-	local update_dnsmasq_config force_dns force_dns_port 
+	local dnsmasq_config_update force_dns force_dns_port 
 	local port=5053
 	output "Starting $serviceName "
 	config_load "$packageName"
-	config_get update_dnsmasq_config        'config' 'update_dnsmasq_config' '*'
+	config_get dnsmasq_config_update        'config' 'dnsmasq_config_update' '*'
 	config_get_bool canary_domains_icloud   'config' 'canary_domains_icloud' '1'
 	config_get_bool canary_domains_mozilla  'config' 'canary_domains_mozilla' '1'
 	config_get_bool force_dns	              'config' 'force_dns' '1'
@@ -235,11 +235,11 @@ start_service() {
 
 stop_service() {
 	local canaryDomains canary_domains_icloud canary_domains_mozilla
-	local update_dnsmasq_config
+	local dnsmasq_config_update
 	local s=0
 	output "Stopping $serviceName "
 	config_load "$packageName"
-	config_get update_dnsmasq_config        'config' 'update_dnsmasq_config' '*'
+	config_get dnsmasq_config_update        'config' 'dnsmasq_config_update' '*'
 	config_get_bool canary_domains_icloud   'config' 'canary_domains_icloud' '1'
 	config_get_bool canary_domains_mozilla  'config' 'canary_domains_mozilla' '1'
 	if [ "$canary_domains_icloud" -ne 0 ]; then
@@ -260,14 +260,14 @@ stop_service() {
 # shellcheck disable=SC1091
 service_triggers() {
 	local wan wan6 i
-	local wan6_trigger
+	local procd_trigger_wan6
 	config_load "$packageName"
-	config_get_bool wan6_trigger 'config' 'wan6_trigger' '0'
+	config_get_bool procd_trigger_wan6 'config' 'procd_trigger_wan6' '0'
 	. /lib/functions/network.sh
 	network_flush_cache
 	network_find_wan wan
 	wan="${wan:-wan}"
-	if [ "$wan6_trigger" -ne 0 ]; then
+	if [ "$procd_trigger_wan6" -ne 0 ]; then
 		network_find_wan6 wan6
 		wan6="${wan6:-wan6}"
 	fi
@@ -357,10 +357,10 @@ dhcp_backup() {
 	config_load 'dhcp'
 	case "$1" in
 		create)
-			if [ "$update_dnsmasq_config" = "*" ]; then
+			if [ "$dnsmasq_config_update" = "*" ]; then
 				config_foreach dnsmasq_create_server_backup 'dnsmasq'
-			elif [ -n "$update_dnsmasq_config" ]; then
-				for i in $update_dnsmasq_config; do
+			elif [ -n "$dnsmasq_config_update" ]; then
+				for i in $dnsmasq_config_update; do
 					if [ -n "$(uci_get 'dhcp' "@dnsmasq[$i]")" ]; then
 						dnsmasq_create_server_backup "@dnsmasq[$i]"
 					elif [ -n "$(uci_get 'dhcp' "$i")" ]; then


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-135, OpenWrt 22.03.2
Run tested: x86_64, Sophos SG-135, OpenWrt 22.03.2, verify config

Description:
* rename wan6_trigger to procd_trigger_wan6
* rename update_dnsmasq_config to dnsmasq_config_update
* add the uci-defaults file to run sed on config file
* update Makefile to include uci-defaults file

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 6bd055284c4f1f633e3d1cd857dc14adbe27c2f5)
