### PR TITLE
dnsproxy: Update to 0.46.2

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.45.4
+PKG_VERSION:=0.46.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=b50c826e3442e88a347d5851dbe9a9505b89b21d01c90737430226a54c6207ce
+PKG_HASH:=8ce720f258747b0ff74b9889c93c616efe3b7267d04283a1338d2ff1e24d661e
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8
Run tested: nanopi-r2s

Description:
Release note:
https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.46.0
https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.46.1
https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.46.2