### PR TITLE
libwebsockets: fix recursive dependency

### DIFF
--- a/libs/libwebsockets/Makefile
+++ b/libs/libwebsockets/Makefile
@@ -48,7 +48,6 @@ define Package/libwebsockets/Default
 	DEPENDS:=+zlib +libcap
 	URL:=https://libwebsockets.org
 	MAINTAINER:=Karl Palsson <karlp@etactica.com>
-	PROVIDES:= libwebsockets
 endef
 
 define Package/libwebsockets-openssl
@@ -64,6 +63,7 @@ define Package/libwebsockets-mbedtls
 	TITLE += (mbedTLS)
 	DEPENDS += +libmbedtls
 	VARIANT:=mbedtls
+	PROVIDES:=libwebsockets
 	CONFLICTS:=libwebsockets-openssl
 endef
 
@@ -72,7 +72,7 @@ define Package/libwebsockets-full
 	TITLE += (Full - OpenSSL, libuv, plugins, CGI)
 	DEPENDS += +libopenssl +libuv
 	VARIANT:=full
-	PROVIDES:=libwebsockets-openssl
+	PROVIDES:=libwebsockets libwebsockets-openssl
 endef
 
 ifeq ($(BUILD_VARIANT),openssl)


### PR DESCRIPTION
Maintainer: @karlp 
Compile tested: no, only verified by ``make menuconfig``
Run tested: no, only verified by ``make menuconfig``

While running `make menuconfig`, it was discovered then there is a recursive dependency like this:
```
tmp/.config-package.in:59138:error: recursive dependency detected! tmp/.config-package.in:59138:	symbol PACKAGE_libwebsockets-openssl is selected by PACKAGE_libwebsockets-mbedtls tmp/.config-package.in:59122:	symbol PACKAGE_libwebsockets-mbedtls depends on PACKAGE_libwebsockets-openssl
```

It is not possible with the recently added conflicts that two packages (OpenSSL and full variant, which uses OpenSSL as well), which are almost the same provides the same named package libwebsockets as their conflict - Mbed TLS.

Fixes: 676c5c72b5eeb583da2603e399fac085fa442c59 ("libwebsockets: OpenSSL and mbedTLS variants should conflict")

Reported by: @hnyman and @zxlhhyccc 
Thanks!

___

It was almost the last minute change, mea culpa on this one guys!