### PR TITLE
gdbm: configure with `--without-readline`

### DIFF
--- a/libs/gdbm/Makefile
+++ b/libs/gdbm/Makefile
@@ -39,7 +39,8 @@ endef
 
 CONFIGURE_ARGS += \
 	--enable-libgdbm-compat \
-	--enable-shared
+	--enable-shared \
+	--without-readline
 
 define Build/Compile
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \


### PR DESCRIPTION
**Maintainer**: @Naoir (but they haven't been active on GitHub 2016)
**Compile tested**: `openwrt-sdk-22.03.2-mvebu-cortexa9`
**Run tested**: **none**, I'm not familiar with `gdbm`, so I don't know how to test it.
  It seems low risk though, since `gdbm` will automatically be built without readline support, depending on which order packages are built.

**Description**:

By default, `gdbm` configures/builds with `readline` and curses support if they exist.

This can cause race conditions when compiling `gdbm` and `ncurses` in parallel, as `gdbm` may try to link to `ncurses` when it doesn't exist.

Additionally, it also means that the built `.ipk` might have a hidden dependency on the `readline` and `ncurses` shared libraries.

This commit forces `gdbm` to skip using `readline`/`ncurses`, since it's unlikely that anybody is using the line-editing feature of `gdbm`.

See [gdbm's README][1] for more info.

[1]: https://git.gnu.org.ua/gdbm.git/tree/README?h=v1.21#n50