### PR TITLE
attendedsysupgrade-common: update ASU CA pubkey

### DIFF
--- a/utils/attendedsysupgrade-common/Makefile
+++ b/utils/attendedsysupgrade-common/Makefile
@@ -49,10 +49,10 @@ endef
 
 define Package/attendedsysupgrade-common/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults/
-	$(INSTALL_BIN) ./files/attendedsysupgrade.defaults $(1)/etc/uci-defaults/attendedsysupgrade
+	$(INSTALL_DATA) ./files/attendedsysupgrade.defaults $(1)/etc/uci-defaults/attendedsysupgrade
 
 	$(INSTALL_DIR) $(1)/etc/opkg/keys/
-	$(INSTALL_BIN) ./files/86241a707a30cb7f $(1)/etc/opkg/keys/86241a707a30cb7f
+	$(INSTALL_DATA) ./files/8a11255d14aef6c8 $(1)/etc/opkg/keys/8a11255d14aef6c8
 endef
 
 $(eval $(call BuildPackage,attendedsysupgrade-common))

--- a/utils/attendedsysupgrade-common/files/86241a707a30cb7f
+++ b/utils/attendedsysupgrade-common/files/86241a707a30cb7f
@@ -1,2 +1,0 @@
-untrusted comment: ASU CA pubkey
-RWSGJBpwejDLf4OApA5SOavh0GBlBFY9FhqxnivUQHpi0/t0QRI98LPW

--- a/utils/attendedsysupgrade-common/files/8a11255d14aef6c8
+++ b/utils/attendedsysupgrade-common/files/8a11255d14aef6c8
@@ -1,0 +1,2 @@
+untrusted comment: ASU CA pubkey 2022
+RWSKESVdFK72yB0Y5q0ckpqqXU+51UbFYYMPRrOTMdNjvLkU1tjJTSiU


### PR DESCRIPTION
The old key was overwritten during a machine migration and the current worker key is no longer valid. To create new valid worker certificates this commit adds a new CA pubkey.

To update running OpenWrt devices via a client one needs to force install it or upgrade to the latest version of
`attendedsysupgrade-common` - I'm sorry for the inconvenience.

Signed-off-by: Paul Spooren <mail@aparcar.org>