### PR TITLE
mpd: depend the full variant on pulseaudio instead of pulseaudio-daemon

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -48,7 +48,7 @@ endef
 define Package/mpd-full
 $(call Package/mpd/Default)
   TITLE+= (full)
-  DEPENDS+= +AUDIO_SUPPORT:pulseaudio-daemon +libvorbis +libmms +libnpupnp +libshout +yajl \
+  DEPENDS+= +AUDIO_SUPPORT:pulseaudio +libvorbis +libmms +libnpupnp +libshout +yajl \
             +libffmpeg +lame-lib +libsoxr +!BUILD_PATENTED:libmad
   PROVIDES:=mpd
   VARIANT:=full


### PR DESCRIPTION
`pulseaudio` is provided by both `pulseaudio-daemon` and `pulseaudio-daemon-avahi`.

Fixes: #19187
Fixes: 2ed62adc5914 ("mpd: enable pulseaudio in full package")

----

Maintainer: @neheb 
Compile tested: `ath79/generic`: `tplink_tl-wr1043nd-v4` (following **jow-**'s [example](https://forum.openwrt.org/t/luci-rewrite-in-ucode-testers-wanted/137250))
Run tested: `ipq40xx/generic`: `glinet_gl-b1300`
