### PR TITLE
kadnode: fix newlines in config file

### DIFF
--- a/net/kadnode/Makefile
+++ b/net/kadnode/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kadnode
 PKG_VERSION:=2.3.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=https://codeload.github.com/mwarning/KadNode/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=kadnode-$(PKG_VERSION).tar.gz

--- a/net/kadnode/files/kadnode.init
+++ b/net/kadnode/files/kadnode.init
@@ -15,8 +15,7 @@ boot()
 
 xappend() {
 	local name="$2" value="$1"
-	OPTS="$OPTS--${name//_/-} ${value//'/\\'}
-"
+	OPTS="\n$OPTS--${name//_/-} ${value//'/\\'}"
 }
 
 append_opts_list() {
@@ -67,7 +66,7 @@ start_instance() {
 		xappend "" "cmd_disable_stdin"
 	fi
 
-	echo "$OPTS" > $CONFIG_FILE
+	echo -e "$OPTS" > $CONFIG_FILE
 
 	procd_open_instance
 	procd_set_param command $PROG


### PR DESCRIPTION
Signed-off-by: Moritz Warning <moritzwarning@web.de>

Maintainer: me 
Compile+Run tested: Nexx WT3020, ramips/mt7620, OpenWrt master
Tested: without cahnge: kadnode does not start, with change: kadnode starts

