### PR TITLE
curl: include nls.mk

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -6,6 +6,7 @@
 #
 
 include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=7.86.0


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-135, OpenWrt 22.03.2

Signed-off-by: Stan Grishin <stangri@melmac.ca>

Description:


        this patch AFAIK fixes compilation when CONFIG_BUILD_NLS is enabled.

_Originally posted by @neheb in https://github.com/openwrt/packages/issues/19563#issuecomment-1296334225_
      