### PR TITLE
apcupsd: remove header file patch

### DIFF
--- a/net/apcupsd/Makefile
+++ b/net/apcupsd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apcupsd
 PKG_VERSION:=3.14.14
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0

--- a/net/apcupsd/patches/010-fix-usb.patch
+++ b/net/apcupsd/patches/010-fix-usb.patch
@@ -1,8 +1,0 @@
---- a/include/libusb.h.in
-+++ b/include/libusb.h.in
-@@ -6,4 +6,4 @@
-  * path at configure time and various apcupsd bits include this
-  * when they need libusb's usb.h.
-  */
--#include "@LIBUSBH@"
-+#include "usb.h"


### PR DESCRIPTION
Seems to be from a time when pkgconfig returned the wrong path.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tru7 
Compile tested: mt7621