### PR TITLE
yq: Update to 4.29.2

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.28.1
+PKG_VERSION:=4.29.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=fde7e2d1d79c927f0d36a4d2b5fadff516db8285d88363cf7af34239512c084d
+PKG_HASH:=4a349c7858793463555c12df698757265a3e46d6b107adac75fabc46d9591df6
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8, x86/64
Run tested: nanopi-r2s

Description:
Release note:
https://github.com/mikefarah/yq/releases/tag/v4.28.2
https://github.com/mikefarah/yq/releases/tag/v4.29.1
https://github.com/mikefarah/yq/releases/tag/v4.29.2