### PR TITLE
openvpn: add possibility to set param "compress" without algorithm

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.5.7
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/openvpn.init
+++ b/net/openvpn/files/openvpn.init
@@ -42,6 +42,7 @@ append_params() {
 		config_get v "$s" "$p"
 		IFS="$LIST_SEP"
 		for v in $v; do
+			[ "$v" = "frames_only" ] && [ "$p" = "compress" ] && unset v && append_param "$s" "$p" && echo >> "/var/etc/openvpn-$s.conf"
 			[ -n "$v" ] && [ "$p" != "push" ] && append_param "$s" "$p" && echo " $v" >> "/var/etc/openvpn-$s.conf"
 			[ -n "$v" ] && [ "$p" = "push" ] && append_param "$s" "$p" && echo " \"$v\"" >> "/var/etc/openvpn-$s.conf"
 		done


### PR DESCRIPTION
Maintainer: @AuthorReflex  / @mkrkn
Compile tested: lantiq/xrx200, x86/64
Run tested: lantiq/xrx200, x86/64

Description:
In some situations you need to set the compress param without an algorithm. Compression will be turned off, but the packet framing for compression will still be enabled, allowing a different setting to be pushed later.

As it is not possible to have options with optional values at the moment, I've introduced a pseudo value "frames_only" which will be removed in the init script.

I'm re-sending this PR after openvpn moved from openwrt core to packages feed: https://github.com/openwrt/openwrt/pull/2694

After this got merged, I'll create a PR for luci as well.
