### PR TITLE
[22.03] curl: include nls.mk

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -6,6 +6,7 @@
 #
 
 include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=7.85.0


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-135, OpenWrt 22.03.2

Description:


        this patch AFAIK fixes compilation when CONFIG_BUILD_NLS is enabled.

_Originally posted by @neheb in https://github.com/openwrt/packages/issues/19563#issuecomment-1296334225_
      Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit d66435208cabfe84b3f24ee47781cb90f94bbadc)
