### PR TITLE
zoneinfo: updated to the latest release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2022e
+PKG_VERSION:=2022f
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=8de4c2686dce3d1aae9030719e6814931c216a2d5e891ec3d332e6f6516aeccd
+PKG_HASH:=9990d71f675d212567b931fe8aae1cab7027f89fefb8a79d808a6933a67af000
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=d40280253980e89168e6be4275a852bf9521524d47684de3135b9a5ca387710b
+   HASH:=e4543e90f84f91fa82809ea98930052fdbc13880c8a623ee3a4eaa42f8a64c15
 endef
 
 $(eval $(call Download,tzcode))
@@ -103,7 +103,6 @@ define Package/zoneinfo-all
 $(call Package/zoneinfo/Default)
   TITLE:=Zone Information (all zones)
   DEPENDS:= \
-	+zoneinfo-simple \
 	+zoneinfo-core \
 	+zoneinfo-africa \
 	+zoneinfo-northamerica \
@@ -145,6 +144,10 @@ define Package/zoneinfo-core/install
 	  $(CP) $(PKG_INSTALL_DIR)/zoneinfo/$$$$i \
 	      $(1)/usr/share/zoneinfo ; \
 	done
+endef
+
+define Package/zoneinfo-all/install
+	:
 endef
 
 define Package/zoneinfo-simple/install


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT master
Run tested: n/a

Description:


   Briefly:

     Mexico will no longer observe DST except near the US border.
     Chihuahua moves to year-round -06 on 2022-10-30.
     Fiji no longer observes DST.
     Move links to 'backward'.
     In vanguard form, GMT is now a Zone and Etc/GMT a link.
     zic now supports links to links, and vanguard form uses this.
     Simplify four Ontario zones.
     Fix a Y2438 bug when reading TZif data.
     Enable 64-bit time_t on 32-bit glibc platforms.
     Omit large-file support when no longer needed.
     In C code, use some C23 features if available.
     Remove no-longer-needed workaround for Qt bug 53071.

   Changes to future timestamps

     Mexico will no longer observe DST after 2022, except for areas
     near the US border that continue to observe US DST rules.
     On 2022-10-30 at 02:00 the Mexican state of Chihuahua moves
     from -07 (-06 with DST) to year-round -06, thus not changing
     its clocks that day.  The new law states that Chihuahua
     near the US border no longer observes US DST.
     (Thanks to gera for the heads-up about Chihuahua.)

     Fiji will not observe DST in 2022/3.  (Thanks to Shalvin Narayan.)
     For now, assume DST is suspended indefinitely.

   Changes to data

     Move links to 'backward' to ease and simplify link maintenance.
     This affects generated data only if you use 'make BACKWARD='.

     GMT is now a Zone and Etc/GMT a link instead of vice versa,
     as GMT is needed for leap second support whereas Etc/GMT is not.
     However, this change exposes a bug in TZUpdater 2.3.2 so it is
     present only in vanguard form for now.

     Vanguard form now uses links to links, as zic now supports this.

   Changes to past timestamps

     Simplify four Ontario zones, as most of the post-1970 differences
     seem to have been imaginary.  (Problem reported by Chris Walton.)
     Move America/Nipigon, America/Rainy_River, and America/Thunder_Bay
     to 'backzone'; backward-compatibility links still work, albeit
     with some different timestamps before November 2005.

   Changes to code

     zic now supports links to links regardless of input line order.
     For example, if Australia/Sydney is a Zone, the lines
       Link Australia/Canberra Australia/ACT
       Link Australia/Sydney Australia/Canberra
     now work correctly, even though the shell commands
       ln Australia/Canberra Australia/ACT
       ln Australia/Sydney Australia/Canberra
     would fail because the first command attempts to use a link
     Australia/Canberra that does not exist until after the second
     command is executed.  Previously, zic had unspecified behavior if
     a Link line's target was another link, and zic often misbehaved if
     a Link line's target was a later Link line.

     Fix line number in zic's diagnostic for a link to a link.

     Fix a bug that caused localtime to mishandle timestamps starting
     in the year 2438 when reading data generated by 'zic -b fat' when
     distant-future DST transitions occur at times given in standard
     time or in UT, not the usual case of local time.  This occurs when
     the corresponding .zi Rule lines specify DST transitions with TO
     columns of 'max' and AT columns that end in 's' or 'u'.  The
     number 2438 comes from the 32-bit limit in the year 2038, plus the
     400-year Gregorian cycle.  (Problem reported by Bradley White.)

     On glibc 2.34 and later, which optionally supports 64-bit time_t
     on platforms like x86 where time_t was traditionally 32 bits,
     default time_t to 64 instead of 32 bits.  This lets functions like
     localtime support timestamps after the year 2038, and fixes
     year-2038 problems in zic when accessing files dated after 2038.
     To continue to limit time_t to 32 bits on these platforms, use
     "make CFLAGS='-D_TIME_BITS=32'".

     In C code, do not enable large-file support on platforms like AIX
     and macOS that no longer need it now that tzcode does not use
     off_t or related functions like 'stat'.  Large-file support is
     still enabled by default on GNU/Linux, as it is needed for 64-bit
     time_t support.

     In C code, prefer C23 keywords to pre-C23 macros for alignof,
     bool, false, and true.  Also, use the following C23 features if
     available: __has_include, unreachable.

     zic no longer works around Qt bug 53071, as the relevant Qt
     releases have been out of support since 2019.  This change affects
     only fat TZif files, as thin files never had the workaround.

     zdump no longer modifies the environ vector when compiled on
     platforms lacking tm_zone or when compiled with -DUSE_LTZ=0.
     This avoid undefined behavior on POSIX platforms.

OpenWrt packaging:
  *  Updated zoneinfo-all meta-package to fix warnings on build ( closes #19734 ) 
  *  Removed zoneinfo-simple from dependencies of zoneinfo-all as its contents are included in other packages.

