### PR TITLE
php8: update to 8.1.12

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.1.11
+PKG_VERSION:=8.1.12
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=3005198d7303f87ab31bc30695de76e8ad62783f806b6ab9744da59fe41cc5bd
+PKG_HASH:=08243359e2204d842082269eedc15f08d2eca726d0e65b93fb11f4bfc51bbbab
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0

--- a/lang/php8/patches/0025-php-5.4.9-fixheader.patch
+++ b/lang/php8/patches/0025-php-5.4.9-fixheader.patch
@@ -9,7 +9,7 @@ Make generated php_config.h constant across rebuilds.
 
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1389,7 +1389,7 @@ PHP_REMOVE_USR_LIB(LDFLAGS)
+@@ -1399,7 +1399,7 @@ PHP_REMOVE_USR_LIB(LDFLAGS)
  EXTRA_LDFLAGS="$EXTRA_LDFLAGS $PHP_LDFLAGS"
  EXTRA_LDFLAGS_PROGRAM="$EXTRA_LDFLAGS_PROGRAM $PHP_LDFLAGS"
  

--- a/lang/php8/patches/1004-disable-phar-command.patch
+++ b/lang/php8/patches/1004-disable-phar-command.patch
@@ -11,7 +11,7 @@
  
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1566,13 +1566,13 @@ CFLAGS_CLEAN="$CFLAGS \$(PROF_FLAGS)"
+@@ -1576,13 +1576,13 @@ CFLAGS_CLEAN="$CFLAGS \$(PROF_FLAGS)"
  CFLAGS="\$(CFLAGS_CLEAN) $standard_libtool_flag"
  CXXFLAGS="$CXXFLAGS $standard_libtool_flag \$(PROF_FLAGS)"
  


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs

Description:

This fixes:
    - CVE-2022-31630
    - CVE-2022-37454

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
