### PR TITLE
curl: bugfix: building as selected package doesn't break build

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -124,6 +124,7 @@ CONFIGURE_ARGS += \
 	\
 	$(call autoconf_bool,CONFIG_IPV6,ipv6) \
 	\
+	$(if $(CONFIG_LIBCURL_WOLFSSL)$(CONFIG_LIBCURL_GNUTLS)$(CONFIG_LIBCURL_OPENSSL)$(CONFIG_LIBCURL_MBEDTLS),,--without-ssl) \
 	$(if $(CONFIG_LIBCURL_WOLFSSL),--with-wolfssl="$(STAGING_DIR)/usr",--without-wolfssl) \
 	$(if $(CONFIG_LIBCURL_GNUTLS),--with-gnutls="$(STAGING_DIR)/usr",--without-gnutls) \
 	$(if $(CONFIG_LIBCURL_OPENSSL),--with-openssl="$(STAGING_DIR)/usr",--without-openssl) \


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-135, OpenWrt 22.03.2, tested compile as a standalone package only

Description:
* discovered and fixed by @ptpt52 [here](https://github.com/openwrt/packages/commit/88009b2d5e394c1822ec55734b63b434981a2a9d#commitcomment-88604318)

Signed-off-by: Stan Grishin <stangri@melmac.ca>