### PR TITLE
tailscale: preserve tailscaled state file

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -77,6 +77,7 @@ endef
 
 define Package/tailscaled/conffiles
 /etc/config/tailscale
+/etc/tailscale/tailscaled.state
 endef
 
 $(eval $(call BuildPackage,tailscale))


### PR DESCRIPTION

Signed-off-by: Carlo Alberto Ferraris <cafxx@strayorange.com>

Maintainer: @ja-pa 
Compile tested: N/A
Run tested: N/A (but I manually added the same line in the backup/restore configuration, and tailscale continued working correctly after a sysupgrade)

Description: Fixes #19774 
