### PR TITLE
librespeed-cli: add package

### DIFF
--- a/utils/librespeed-cli/Makefile
+++ b/utils/librespeed-cli/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2022 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=librespeed-cli
+PKG_VERSION:=1.0.10
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/librespeed/speedtest-cli/tar.gz/v${PKG_VERSION}?
+PKG_HASH:=904ec84f41714d5a7ab778534d332219cd254fdd0f97cc33ebb3540d31fb802c
+
+PKG_MAINTAINER:=Michal Vasilek <michal.vasilek@nic.cz>
+PKG_LICENSE:=LGPL-3.0-only
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/speedtest-cli-$(PKG_VERSION)
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/librespeed/speedtest-cli
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/librespeed-cli
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Command line client for LibreSpeed
+  URL:=https://github.com/librespeed/speedtest-cli
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/librespeed-cli/description
+  LibreSpeed client for measuring internet speed from command line.
+endef
+
+$(eval $(call GoBinPackage,librespeed-cli))
+$(eval $(call BuildPackage,librespeed-cli))


### PR DESCRIPTION
Maintainer: me
Compile tested: armv7, Turris Omnia, OpenWrt 21.02
Run tested: armv7, Turris Omnia, OpenWrt 21.02

Description: The binary name is speedtest-cli, but speedtest-cli is usually a different package in distributions.
