### PR TITLE
pulseadio: fix conffiles for pulseadio-daemon-avahi package

### DIFF
--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -66,7 +66,7 @@ define Package/pulseaudio-daemon/conffiles
 /etc/pulse/system.pa
 endef
 
-Package/pulseaudio-daemon/conffiles = $(Package/pulseaudio-daemon-avahi/conffiles)
+Package/pulseaudio-daemon-avahi/conffiles = $(Package/pulseaudio-daemon/conffiles)
 
 define Package/pulseaudio-tools
   SECTION:=sound


### PR DESCRIPTION
Maintainer: @tripolar
Compile tested: verified that conffiles in the packages are correct now
Run tested: N/A

Description:

- Fixes: https://github.com/openwrt/packages/pull/19733#issuecomment-1298842720
Thanks @hnyman for reporting!
