### PR TITLE
[21.02] mpd: depend the full variant on pulseaudio instead of pulseaudio-daemon

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -47,7 +47,7 @@ endef
 define Package/mpd-full
 $(call Package/mpd/Default)
   TITLE+= (full)
-  DEPENDS+= +AUDIO_SUPPORT:pulseaudio-daemon +libvorbis +libmms +libnpupnp +libshout +yajl \
+  DEPENDS+= +AUDIO_SUPPORT:pulseaudio +libvorbis +libmms +libnpupnp +libshout +yajl \
             +BUILD_PATENTED:libffmpeg +!BUILD_PATENTED:libmad
   PROVIDES:=mpd
   VARIANT:=full


### PR DESCRIPTION
Maintainer: @neheb

Description:
- cherry-picked #19728