### PR TITLE
Revert "fcgi: remove"

### DIFF
--- a/libs/fcgi/Makefile
+++ b/libs/fcgi/Makefile
@@ -1,0 +1,77 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=fcgi
+PKG_VERSION:=2.4.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)2-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/FastCGI-Archives/fcgi2/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=1fe83501edfc3a7ec96bb1e69db3fd5ea1730135bd73ab152186fd0b437013bc
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)2-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jacob Siverskog <jacob@teenageengineering.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.TERMS
+
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/uclibc++.mk
+include $(INCLUDE_DIR)/package.mk
+
+define Package/fcgi/Default
+  SECTION:=libs
+  CATEGORY:=Libraries
+  URL:=https://fastcgi-archives.github.io/
+endef
+
+define Package/fcgi
+  $(call Package/fcgi/Default)
+  MENU:=1
+  DEPENDS:=+libpthread
+  TITLE:=Shared library of FastCGI
+endef
+
+define Package/fcgixx
+  $(call Package/fcgi/Default)
+  DEPENDS:=fcgi $(CXX_DEPENDS)
+  TITLE:=Shared library of FastCGI++
+endef
+
+define Package/fcgi/description
+ FastCGI is a language independent, scalable, open extension to
+ CGI that provides high performance without the limitations of
+ server specific APIs.
+endef
+
+TARGET_CXXFLAGS += -fno-rtti -flto
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/fastcgi.h $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/fcgi{app,_config,misc,o,os,_stdio}.h $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfcgi{,++}.{a,so*} $(1)/usr/lib/
+endef
+
+define Package/fcgi/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/cgi-fcgi $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfcgi.so.* $(1)/usr/lib/
+endef
+
+define Package/fcgixx/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfcgi++.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,fcgi))
+$(eval $(call BuildPackage,fcgixx))

--- a/libs/fcgi/Makefile
+++ b/libs/fcgi/Makefile
@@ -14,7 +14,7 @@ PKG_SOURCE_URL:=https://codeload.github.com/FastCGI-Archives/fcgi2/tar.gz/$(PKG_
 PKG_HASH:=1fe83501edfc3a7ec96bb1e69db3fd5ea1730135bd73ab152186fd0b437013bc
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)2-$(PKG_VERSION)
 
-PKG_MAINTAINER:=Jacob Siverskog <jacob@teenageengineering.com>
+PKG_MAINTAINER:=Petr Štetiar <ynezz@true.cz>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.TERMS
 

--- a/libs/fcgi/Makefile
+++ b/libs/fcgi/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fcgi
 PKG_VERSION:=2.4.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
-PKG_SOURCE:=$(PKG_NAME)2-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/FastCGI-Archives/fcgi2/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=1fe83501edfc3a7ec96bb1e69db3fd5ea1730135bd73ab152186fd0b437013bc
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)2-$(PKG_VERSION)
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/FastCGI-Archives/fcgi2
+PKG_MIRROR_HASH:=e4a6cf23b4c9b00b111aaed817a8beb33191b10581e005f794a9f801bb4abc43
 
 PKG_MAINTAINER:=Petr Štetiar <ynezz@true.cz>
 PKG_LICENSE:=MIT

--- a/libs/fcgi/patches/100-fcgio-int-type-fix.patch
+++ b/libs/fcgi/patches/100-fcgio-int-type-fix.patch
@@ -1,0 +1,35 @@
+--- a/include/fcgio.h
++++ b/include/fcgio.h
+@@ -77,10 +77,10 @@ protected:
+     virtual int sync();
+ 
+     // Remove and return the current character.
+-    virtual int uflow();
++    virtual int_type uflow();
+ 
+     // Fill the get area (if buffered) and return the current character.
+-    virtual int underflow();
++    virtual int_type underflow();
+ 
+     // Use a buffer.  The only reasons that a buffer would be useful is
+     // to support the use of the unget()/putback() or seek() methods.  Using
+--- a/libfcgi/fcgio.cpp
++++ b/libfcgi/fcgio.cpp
+@@ -86,7 +86,7 @@ int fcgi_streambuf::sync()
+ }
+ 
+ // uflow() removes the char, underflow() doesn't
+-int fcgi_streambuf::uflow() 
++std::basic_streambuf<char>::int_type fcgi_streambuf::uflow()
+ {
+     if (this->bufsize)
+     {
+@@ -100,7 +100,7 @@ int fcgi_streambuf::uflow()
+     }
+ }
+ 				
+-int fcgi_streambuf::underflow()
++std::basic_streambuf<char>::int_type fcgi_streambuf::underflow()
+ {
+     if (this->bufsize)
+     {


### PR DESCRIPTION
Compile tested: OpenWrt 22.03 x86/64, ipq40xx, mvebu/cortexa9
Run tested: OpenWrt 22.03 x86/64, ipq40xx, mvebu/cortexa9

This reverts commit 65ef6c646af7906f066badde93521b25c8445cdc where @neheb removed fcgi library for "Nothing uses this." reason.

I've noticed this missing library while rebasing downstream project from OpenWrt 19.07 release base to OpenWrt 22.03, as there is [amx-fcgi](https://gitlab.com/prpl-foundation/components/ambiorix/applications/amx-fcgi) system component which depends on this library.

So I would like to fix that regression by adding back the removed library package.