### PR TITLE
modemmanager: fix unquoted strings when launching pppd

### DIFF
--- a/net/modemmanager/files/modemmanager.proto
+++ b/net/modemmanager/files/modemmanager.proto
@@ -156,8 +156,8 @@ modemmanager_connected_method_ppp_ipv4() {
 		novj \
 		noauth \
 		$authopts \
-		${username:+ user $username} \
-		${password:+ password $password} \
+		${username:+ user "$username"} \
+		${password:+ password "$password"} \
 		lcp-echo-failure 5 \
 		lcp-echo-interval 15 \
 		lock \


### PR DESCRIPTION
Signed-off-by: Aleksander Morgado <aleksander@aleksander.es>

