### PR TITLE
openvpn: update to 2.5.8

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.5.7
-PKG_RELEASE:=4
+PKG_VERSION:=2.5.8
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=313bca7e996a4f59ef9940dd87c6c4b9168064db9be6cabebd37cd65f13759ed
+PKG_HASH:=2bbd0026469902037ee6499b68283d5ab36c74e36cae3112082cfdf6c77a0c57
 
 PKG_MAINTAINER:=Magnus Kroken <mkroken@gmail.com>
 


### PR DESCRIPTION
Maintainer: @mkrkn
Compile tested: ramips/mt7620, ramips/mt621, bcm47xx/legacy
Run tested: TP-Link Archer C50, Xiaomi Mi Router 3 pro, Asus WL-500gpv2

Mostly bugfix release
For details refer to https://github.com/OpenVPN/openvpn/blob/v2.5.8/Changes.rst

