### PR TITLE
libsoup3: update to 3.2.1

### DIFF
--- a/libs/libsoup3/Makefile
+++ b/libs/libsoup3/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsoup3
-PKG_VERSION:=3.0.6
+PKG_VERSION:=3.2.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=libsoup-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=@GNOME/libsoup/3.0
-PKG_HASH:=b45d59f840b9acf9bb45fd45854e3ef672f57e3ab957401c3ad8d7502ac23da6
+PKG_SOURCE_URL:=@GNOME/libsoup/3.2
+PKG_HASH:=b1eb3d2c3be49fbbd051a71f6532c9626bcecea69783190690cd7e4dfdf28f29
 PKG_BUILD_DIR:=$(BUILD_DIR)/libsoup-$(PKG_VERSION)
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -40,7 +40,6 @@ MESON_ARGS += \
 	-Dtls_check=false \
 	-Dintrospection=disabled \
 	-Dvapi=disabled \
-	-Dgtk_doc=false \
 	-Dtests=false \
 	-Dinstalled_tests=false \
 	-Dsysprof=disabled


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @flyn-org 