### PR TITLE
libarchive: Backport build fix for glibc 2.36

### DIFF
--- a/libs/libarchive/patches/001-libarchive-Do-not-include-sys-mount.h-when-linux-fs.h-is-present.patch
+++ b/libs/libarchive/patches/001-libarchive-Do-not-include-sys-mount.h-when-linux-fs.h-is-present.patch
@@ -1,0 +1,39 @@
+From a2f68263a1da5ad227bcb9cd8fa91b93c8b6c99f Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 25 Jul 2022 10:56:53 -0700
+Subject: [PATCH] libarchive: Do not include sys/mount.h when linux/fs.h is
+ present
+
+These headers are in conflict and only one is needed by
+archive_read_disk_posix.c therefore include linux/fs.h if it exists
+otherwise include sys/mount.h
+
+It also helps compiling with glibc 2.36
+where sys/mount.h conflicts with linux/mount.h see [1]
+
+[1] https://sourceware.org/glibc/wiki/Release/2.36
+---
+ libarchive/archive_read_disk_posix.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+--- a/libarchive/archive_read_disk_posix.c
++++ b/libarchive/archive_read_disk_posix.c
+@@ -34,9 +34,6 @@ __FBSDID("$FreeBSD$");
+ #ifdef HAVE_SYS_PARAM_H
+ #include <sys/param.h>
+ #endif
+-#ifdef HAVE_SYS_MOUNT_H
+-#include <sys/mount.h>
+-#endif
+ #ifdef HAVE_SYS_STAT_H
+ #include <sys/stat.h>
+ #endif
+@@ -54,6 +51,8 @@ __FBSDID("$FreeBSD$");
+ #endif
+ #ifdef HAVE_LINUX_FS_H
+ #include <linux/fs.h>
++#elif HAVE_SYS_MOUNT_H
++#include <sys/mount.h>
+ #endif
+ /*
+  * Some Linux distributions have both linux/ext2_fs.h and ext2fs/ext2_fs.h.


### PR DESCRIPTION
Maintainer: @morgenroth 
Compile tested: mips_24kc_glibc
Run tested: none

This backports a build fix for libarchive when compiling against glibc 2.36.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
