### PR TITLE
libowfat: Fix compile with glibc 2.36

### DIFF
--- a/libs/libowfat/Makefile
+++ b/libs/libowfat/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libowfat
 PKG_VERSION:=0.32
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.fefe.de/libowfat

--- a/libs/libowfat/patches/012-remove-deprecated.patch
+++ b/libs/libowfat/patches/012-remove-deprecated.patch
@@ -1,0 +1,16 @@
+--- a/scan/scan_iso8601.c
++++ b/scan/scan_iso8601.c
+@@ -1,5 +1,4 @@
+ #define _GNU_SOURCE
+-#define __deprecated__
+ #include "scan.h"
+ #include "byte.h"
+ #include "case.h"
+--- a/scan/scan_httpdate.c
++++ b/scan/scan_httpdate.c
+@@ -1,5 +1,4 @@
+ #define _GNU_SOURCE
+-#define __deprecated__
+ #include "scan.h"
+ #include "byte.h"
+ #include "case.h"


### PR DESCRIPTION
Maintainer: @danwrt 
Compile tested: mips_24kc_glibc
Run tested: none

This fixes the following error message seen when compiling against glibc 2.36:
                 from scan/scan_httpdate.c:3:
include/sys/cdefs.h:338:65: error: macro "__has_attribute" requires an identifier
  338 | #if __GNUC_PREREQ (3,2) || __glibc_has_attribute (__deprecated__)

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>