### PR TITLE
samba4: update to 4.17.2

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.17.1
+PKG_VERSION:=4.17.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -13,7 +13,7 @@ PKG_SOURCE_URL:= \
 		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
-PKG_HASH:=1b939d03f8ca57194c413ed863014a3850c9ce9f9e31c2a7df706806fba77c01
+PKG_HASH:=e55ddf4d5178f8c84316abf53c5edd7b35399e3b7d86bcb81b75261c827bb3b8
 
 PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
update samba to 4.17.2

* CVE-2022-3437: There is a limited write heap buffer overflow in the GSSAPI unwrap_des() and unwrap_des3() routines of Heimdal (included in Samba). https://www.samba.org/samba/security/CVE-2022-3437.html

* CVE-2022-3592: A malicious client can use a symlink to escape the exported directory.
https://www.samba.org/samba/security/CVE-2022-3592.html

Signed-off-by: Andrew Sim <andrewsimz@gmail.com>

Maintainer: nobody
Compile tested: mediatek, mt7622
Run tested: 
