### PR TITLE
strongswan: Update to 5.9.8

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
-PKG_VERSION:=5.9.7
+PKG_VERSION:=5.9.8
 PKG_RELEASE:=$(AUTORELEASE).1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/
-PKG_HASH:=9e64a2ba62efeac81abff1d962522404ebc6ed6c0d352a23ab7c0b2c639e3fcf
+PKG_HASH:=d3303a43c0bd7b75a12b64855e8edcb53696f06190364f26d1533bde1f2e453c
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>, Noel Kuntze <noel.kuntze@thermi.consulting>
 PKG_CPE_ID:=cpe:/a:strongswan:strongswan
@@ -232,7 +232,6 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-xauth-generic \
 	+strongswan-mod-xcbc \
 	+strongswan-pki \
-	+strongswan-scepclient \
 	+strongswan-swanctl \
 	@DEVEL
 endef
@@ -396,23 +395,12 @@ endef
 define Package/strongswan-pki
 $(call Package/strongswan/Default)
   TITLE+= PKI tool
-  DEPENDS:= strongswan
+  DEPENDS:= strongswan strongswan-libtls
 endef
 
 define Package/strongswan-pki/description
 $(call Package/strongswan/description/Default)
  This package contains the pki tool.
-endef
-
-define Package/strongswan-scepclient
-$(call Package/strongswan/Default)
-  TITLE+= SCEP client
-  DEPENDS:= strongswan
-endef
-
-define Package/strongswan-scepclient/description
-$(call Package/strongswan/description/Default)
- This package contains the SCEP client.
 endef
 
 define Package/strongswan-swanctl
@@ -478,7 +466,6 @@ CONFIGURE_ARGS+= \
 	--with-systemdsystemunitdir=no \
 	$(if $(CONFIG_PACKAGE_strongswan-charon-cmd),--enable-cmd,--disable-cmd) \
 	$(if $(CONFIG_PACKAGE_strongswan-pki),--enable-pki,--disable-pki) \
-	$(if $(CONFIG_PACKAGE_strongswan-scepclient),--enable-scepclient,--disable-scepclient) \
 	--with-random-device=/dev/random \
 	--with-urandom-device=/dev/urandom \
 	--with-routing-table="$(call qstrip,$(CONFIG_STRONGSWAN_ROUTING_TABLE))" \
@@ -572,13 +559,6 @@ define Package/strongswan-pki/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/pki $(1)/usr/bin/
 endef
 
-define Package/strongswan-scepclient/install
-	$(INSTALL_DIR) $(1)/etc/strongswan.d
-	$(CP) $(PKG_INSTALL_DIR)/etc/strongswan.d/scepclient.conf $(1)/etc/strongswan.d/
-	$(INSTALL_DIR) $(1)/usr/lib/ipsec
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/ipsec/scepclient $(1)/usr/lib/ipsec/
-endef
-
 define Package/strongswan-swanctl/conffiles
 /etc/config/ipsec
 /etc/swanctl/
@@ -666,7 +646,6 @@ $(eval $(call BuildPackage,strongswan-charon-cmd))
 $(eval $(call BuildPackage,strongswan-ipsec))
 $(eval $(call BuildPackage,strongswan-libnttfft))
 $(eval $(call BuildPackage,strongswan-pki))
-$(eval $(call BuildPackage,strongswan-scepclient))
 $(eval $(call BuildPackage,strongswan-swanctl))
 $(eval $(call BuildPackage,strongswan-gencerts))
 $(eval $(call BuildPackage,strongswan-libtls))

--- a/net/strongswan/patches/0904-gmpdh-Plugin-that-implements-gmp-DH-functions-in-an-.patch
+++ b/net/strongswan/patches/0904-gmpdh-Plugin-that-implements-gmp-DH-functions-in-an-.patch
@@ -19,22 +19,22 @@ Subject: [PATCH 904/904] gmpdh: Plugin that implements gmp DH functions in an
 --- a/configure.ac
 +++ b/configure.ac
 @@ -147,6 +147,7 @@ ARG_DISBL_SET([fips-prf],       [disable
- ARG_ENABL_SET([gcm],            [enables the GCM AEAD wrapper crypto plugin.])
+ ARG_DISBL_SET([gcm],            [disable the GCM AEAD wrapper crypto plugin.])
  ARG_ENABL_SET([gcrypt],         [enables the libgcrypt plugin.])
  ARG_DISBL_SET([gmp],            [disable GNU MP (libgmp) based crypto implementation plugin.])
 +ARG_DISBL_SET([gmpdh],          [disable GNU MP (libgmp) based static-linked crypto DH minimal implementation plugin.])
  ARG_DISBL_SET([curve25519],     [disable Curve25519 Diffie-Hellman plugin.])
  ARG_DISBL_SET([hmac],           [disable HMAC crypto implementation plugin.])
  ARG_DISBL_SET([kdf],            [disable KDF (prf+) implementation plugin.])
-@@ -1542,6 +1543,7 @@ ADD_PLUGIN([pkcs8],                [s ch
- ADD_PLUGIN([af-alg],               [s charon scepclient pki scripts medsrv attest nm cmd aikgen])
+@@ -1566,6 +1567,7 @@ ADD_PLUGIN([pkcs8],                [s ch
+ ADD_PLUGIN([af-alg],               [s charon pki scripts medsrv attest nm cmd aikgen])
  ADD_PLUGIN([fips-prf],             [s charon nm cmd])
- ADD_PLUGIN([gmp],                  [s charon scepclient pki scripts manager medsrv attest nm cmd aikgen fuzz])
-+ADD_PLUGIN([gmpdh],                [s charon scepclient pki scripts manager medsrv attest nm cmd aikgen])
+ ADD_PLUGIN([gmp],                  [s charon pki scripts manager medsrv attest nm cmd aikgen fuzz])
++ADD_PLUGIN([gmpdh],                [s charon pki scripts manager medsrv attest nm cmd aikgen])
  ADD_PLUGIN([curve25519],           [s charon pki scripts nm cmd])
  ADD_PLUGIN([agent],                [s charon nm cmd])
  ADD_PLUGIN([keychain],             [s charon cmd])
-@@ -1685,6 +1687,7 @@ AM_CONDITIONAL(USE_SHA3, test x$sha3 = x
+@@ -1708,6 +1710,7 @@ AM_CONDITIONAL(USE_SHA3, test x$sha3 = x
  AM_CONDITIONAL(USE_MGF1, test x$mgf1 = xtrue)
  AM_CONDITIONAL(USE_FIPS_PRF, test x$fips_prf = xtrue)
  AM_CONDITIONAL(USE_GMP, test x$gmp = xtrue)
@@ -42,7 +42,7 @@ Subject: [PATCH 904/904] gmpdh: Plugin that implements gmp DH functions in an
  AM_CONDITIONAL(USE_CURVE25519, test x$curve25519 = xtrue)
  AM_CONDITIONAL(USE_RDRAND, test x$rdrand = xtrue)
  AM_CONDITIONAL(USE_AESNI, test x$aesni = xtrue)
-@@ -1964,6 +1967,7 @@ AC_CONFIG_FILES([
+@@ -1985,6 +1988,7 @@ AC_CONFIG_FILES([
  	src/libstrongswan/plugins/mgf1/Makefile
  	src/libstrongswan/plugins/fips_prf/Makefile
  	src/libstrongswan/plugins/gmp/Makefile


### PR DESCRIPTION
Maintainer: me, @Thermi 
Compile tested: x86_64, generic, HEAD (#c3b9f00aaa)
Run tested: same, installed on production router

Description:

Update to 5.9.8 and drop scepclient.