### PR TITLE
sudo: bump to verison 1.9.12p1

### DIFF
--- a/admin/sudo/Makefile
+++ b/admin/sudo/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sudo
-PKG_VERSION:=1.9.12
+PKG_VERSION:=1.9.12p1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.sudo.ws/dist
-PKG_HASH:=de15733888170c56834daafd34bf983db10fb21039742fcfc396bd32168d6362
+PKG_HASH:=475a18a8eb3da8b2917ceab063a6baf51ea09128c3c47e3e0e33ab7497bab7d8
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86, mips64, aarch64 https://github.com/openwrt/openwrt/commit/41691ce9ac10b3aaaf7c05e6e5b55b626f66949b
Run tested: x86  https://github.com/openwrt/openwrt/commit/41691ce9ac10b3aaaf7c05e6e5b55b626f66949b

Fixes: https://github.com/openwrt/packages/issues/19816

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>