### PR TITLE
isc-dhcp: Fix logic to detect if the config file is unchanged

### DIFF
--- a/net/isc-dhcp/files/dhcpd.init
+++ b/net/isc-dhcp/files/dhcpd.init
@@ -466,8 +466,6 @@ general_config() {
 		local need_reload=
 
 		cp -p $conf_local_file ${conf_local_file}_
-		cmp -s $conf_local_file ${conf_local_file}_ || need_reload=1
-		rm -f ${conf_local_file}_
 
 		cat <<EOF > $conf_local_file
 zone "$domain" {
@@ -493,6 +491,9 @@ zone "$mynet.in-addr.arpa" {
 
 EOF
 		done
+
+		cmp -s $conf_local_file ${conf_local_file}_ || need_reload=1
+		rm -f ${conf_local_file}_
 
 		[ -n "$need_reload" ] && /etc/init.d/named reload
 		sleep 1


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, generic, HEAD (c3b9f00aaa)
Run tested: same, installed on production router

Description:

Compare config files after regenerating the new version.
