### PR TITLE
qcsuper: add package with dependencies

### DIFF
--- a/lang/python/python-crcmod/Makefile
+++ b/lang/python/python-crcmod/Makefile
@@ -1,0 +1,38 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-crcmod
+PKG_VERSION:=1.7
+PKG_RELEASE:=1
+
+PYPI_NAME:=crcmod
+PKG_HASH:=dc7051a0db5f2bd48665a990d3ec1cc305a466a77358ca4492826f41f283601e
+
+PKG_LICENSE:=MIT
+PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
+
+PYTHON3_PKG_SETUP_ARGS:=
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-crcmod
+  SECTION:=lang-python
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=python3-crcmod
+  URL:=http://crcmod.sourceforge.net/
+  DEPENDS:=+python3-light
+endef
+
+define Package/python3-crcmod/description
+The software in this package is a Python module for generating
+objects that compute the Cyclic Redundancy Check (CRC).
+endef
+
+$(eval $(call Py3Package,python3-crcmod))
+$(eval $(call BuildPackage,python3-crcmod))
+$(eval $(call BuildPackage,python3-crcmod-src))

--- a/lang/python/python-pycrate/Makefile
+++ b/lang/python/python-pycrate/Makefile
@@ -1,0 +1,39 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pycrate
+PKG_VERSION:=0.5.5
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/P1sec/pycrate/archive/refs/tags/$(PKG_VERSION).tar.gz?
+PKG_HASH:=73072234359cdc11d7c6790c367d5565fdaea284a07df882b8b5295f2a4f83d1
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/pycrate-$(PKG_VERSION)
+
+PKG_LICENSE:=LGPL-2.1
+PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-pycrate
+  SECTION:=lang-python
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=python3-pycrate
+  URL:=https://github.com/P1sec/pycrate
+  DEPENDS:=+python3-light
+endef
+
+define Package/python3-pycrate/description
+Provides a runtime for encoding and decoding data structures, including CSN.1
+and ASN.1. Additionally, it features a 3G and LTE mobile core network.
+endef
+
+$(eval $(call Py3Package,python3-pycrate))
+$(eval $(call BuildPackage,python3-pycrate))
+$(eval $(call BuildPackage,python3-pycrate-src))

--- a/net/qcsuper/Makefile
+++ b/net/qcsuper/Makefile
@@ -1,0 +1,58 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=qcsuper
+PKG_VERSION:=2022-08-11
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/P1sec/QCSuper.git
+PKG_SOURCE_VERSION:=5c4e5295bf336bcce63c8ad7112ac04dee4b04fd
+PKG_MIRROR_HASH:=45ec6f839945f3c3cbd21ca973f3df2e8972113e32995bf5435403eea6872596
+
+PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
+PKG_LICENSE:=GPL-3.0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/qcsuper
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+python3-light +python3-pyserial +python3-crcmod +python3-ctypes +python3-pycrate +python3-logging +python3-urllib
+  TITLE:=QCSuper
+  URL:=https://github.com/P1sec/QCSuper
+endef
+
+define Package/qcsuper/description
+QCSuper is a tool communicating with Qualcomm-based modems,
+allowing to capture raw 2G/3G/4G radio frames, among other things.
+
+It will allow you to generate PCAP captures of it using an USB dongle
+or an existing capture in another format.
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/qcsuper/install
+	$(INSTALL_DIR) $(1)/usr/lib/qcsuper/inputs $(1)/usr/lib/qcsuper/modules $(1)/usr/lib/qcsuper/protocol $(1)/usr/bin
+
+	$(CP) $(PKG_BUILD_DIR)/inputs/* $(1)/usr/lib/qcsuper/inputs/
+	$(RM) -rf $(1)/usr/lib/qcsuper/inputs/external
+	$(RM) -rf $(1)/usr/lib/qcsuper/inputs/adb_bridge
+	$(RM) -rf $(1)/usr/lib/qcsuper/inputs/adb_wsl2_bridge
+
+	$(CP) $(PKG_BUILD_DIR)/modules/* $(1)/usr/lib/qcsuper/modules/
+
+	$(CP) $(PKG_BUILD_DIR)/protocol/* $(1)/usr/lib/qcsuper/protocol/
+
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/qcsuper.py $(1)/usr/lib/qcsuper/
+	$(LN) /usr/lib/qcsuper/qcsuper.py $(1)/usr/bin/qcsuper
+endef
+
+$(eval $(call BuildPackage,qcsuper))


### PR DESCRIPTION
Maintainer: me
Compile tested: x86-64 / ipq40xx-generic
Run tested: apu4d4 / GL.iNet GL-AP1300

Description:

QCSuper is a diagnostic tool which allows to capture cellular frames using a Qualcomm USB modems debug port.
