### PR TITLE
shadowsocks-libev: ss-rules: Add 'auto-merge' flag to avoid conflicts

### DIFF
--- a/net/shadowsocks-libev/Makefile
+++ b/net/shadowsocks-libev/Makefile
@@ -14,7 +14,7 @@ include $(TOPDIR)/rules.mk
 #
 PKG_NAME:=shadowsocks-libev
 PKG_VERSION:=3.3.5
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/shadowsocks/shadowsocks-libev/releases/download/v$(PKG_VERSION)

--- a/net/shadowsocks-libev/files/ss-rules/set.uc
+++ b/net/shadowsocks-libev/files/ss-rules/set.uc
@@ -102,6 +102,7 @@ function set_elements(suf, af) {
 set {{ set_name(suf, af) }} {
 	type ipv{{af}}_addr;
 	flags interval;
+	auto-merge;
 {%   let elems = set_elements(suf, af); if (length(elems)): %}
 	elements = {
 {%     for (let i = 0; i < length(elems); i++): %}


### PR DESCRIPTION
Signed-off-by: Li Xin <i@crzidea.com>

Maintainer: @yousong 
Compile tested: ramips/mt7621 OpenWrt 22.03.2
Run tested: ramips/mt7621 OpenWrt 22.03.2
Description:

Need `auto-merge` flag to solve CIDR elements conflicts, example:
http://git.netfilter.org/nftables/commit/?id=30f667920601d01107398cbb85da45fdb1237212
