### PR TITLE
yq: Update to 4.30.1

### DIFF
--- a/utils/yq/Makefile
+++ b/utils/yq/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yq
-PKG_VERSION:=4.29.2
+PKG_VERSION:=4.30.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikefarah/yq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=4a349c7858793463555c12df698757265a3e46d6b107adac75fabc46d9591df6
+PKG_HASH:=bffd28abbfd1037a9f1424bfa38276d7917c4ebfaee88d88ac117223c3c22291
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8, x86/64
Run tested: nanopi-r2s

Description:
Release note:
https://github.com/mikefarah/yq/releases/tag/v4.30.1