### PR TITLE
prometheus-node-exporter-lua: wifi: Follow prometheus best practices

### DIFF
--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi.lua
@@ -9,6 +9,7 @@ local function scrape()
   local metric_wifi_network_bitrate = metric("wifi_network_bitrate","gauge")
   local metric_wifi_network_noise = metric("wifi_network_noise_dbm","gauge")
   local metric_wifi_network_signal = metric("wifi_network_signal_dbm","gauge")
+  local metric_wifi_network_stations_total = metric("wifi_network_stations_total","gauge")
 
   local u = ubus.connect()
   local status = u:call("network.wireless", "status", {})
@@ -50,11 +51,17 @@ local function scrape()
           quality = math.floor((100 / qm) * qc)
         end
 
+        local stations = 0
+        for _ in pairs(iw.assoclist(ifname)) do
+          stations = stations + 1
+        end
+
         metric_wifi_network_config(network_config_labels, 1)
         metric_wifi_network_quality(network_labels, quality)
         metric_wifi_network_noise(network_labels, iw.noise(ifname) or 0)
         metric_wifi_network_bitrate(network_labels, iw.bitrate(ifname) or 0)
         metric_wifi_network_signal(network_labels, iw.signal(ifname) or -255)
+        metric_wifi_network_stations_total(network_labels, stations)
       end
     end
   end

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi.lua
@@ -2,6 +2,9 @@ local ubus = require "ubus"
 local iwinfo = require "iwinfo"
 
 local function scrape()
+  local metric_wifi_radio_config = metric("wifi_radio_config","gauge")
+  local metric_wifi_radio_channel = metric("wifi_radio_channel","gauge")
+  local metric_wifi_network_config = metric("wifi_network_config","gauge")
   local metric_wifi_network_quality = metric("wifi_network_quality","gauge")
   local metric_wifi_network_bitrate = metric("wifi_network_bitrate","gauge")
   local metric_wifi_network_noise = metric("wifi_network_noise_dbm","gauge")
@@ -11,19 +14,33 @@ local function scrape()
   local status = u:call("network.wireless", "status", {})
 
   for dev, dev_table in pairs(status) do
+    local radio_config = dev_table['config']
+    local radio_config_labels = {
+      radio = dev,
+      hwmode = radio_config['hwmode'],
+      channel = radio_config['channel'],
+      country = radio_config['country'],
+    }
+    local radio_labels = {
+      radio = dev,
+    }
+    metric_wifi_radio_config(radio_config_labels, 1)
+    metric_wifi_radio_channel(radio_labels, radio_config['channel'])
+
     for _, intf in ipairs(dev_table['interfaces']) do
       local ifname = intf['ifname']
       if ifname ~= nil then
         local iw = iwinfo[iwinfo.type(ifname)]
-        local labels = {
-          channel = iw.channel(ifname),
+        local network_config_labels = {
           ssid = iw.ssid(ifname),
           bssid = string.lower(iw.bssid(ifname)),
           mode = iw.mode(ifname),
           ifname = ifname,
-          country = iw.country(ifname),
-          frequency = iw.frequency(ifname),
-          device = dev,
+          radio = dev,
+        }
+        local network_labels = {
+          ifname = ifname,
+          radio = dev,
         }
 
         local qc = iw.quality(ifname) or 0
@@ -33,10 +50,11 @@ local function scrape()
           quality = math.floor((100 / qm) * qc)
         end
 
-        metric_wifi_network_quality(labels, quality)
-        metric_wifi_network_noise(labels, iw.noise(ifname) or 0)
-        metric_wifi_network_bitrate(labels, iw.bitrate(ifname) or 0)
-        metric_wifi_network_signal(labels, iw.signal(ifname) or -255)
+        metric_wifi_network_config(network_config_labels, 1)
+        metric_wifi_network_quality(network_labels, quality)
+        metric_wifi_network_noise(network_labels, iw.noise(ifname) or 0)
+        metric_wifi_network_bitrate(network_labels, iw.bitrate(ifname) or 0)
+        metric_wifi_network_signal(network_labels, iw.signal(ifname) or -255)
       end
     end
   end


### PR DESCRIPTION
Maintainer: @champtar
Compile tested: ath79 (glinet_6416, tplink_archer-c7-v5), ramips (zbtlink_zbt-wg2626), 21.02 
Run tested: ath79 (glinet_6416, tplink_archer-c7-v5), ramips (zbtlink_zbt-wg2626), 21.02

This series fix the wifi collector to better follow prometheus best practices and not create an unnecessary amount of time series in the prometheus database.