### PR TITLE
CI: deprecate $(AUTORELEASE) via comments

### DIFF
--- a/.github/workflows/check-autorelease-deprecation.yml
+++ b/.github/workflows/check-autorelease-deprecation.yml
@@ -1,0 +1,86 @@
+name: Check autorelease deprecation
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, converted_to_draft, ready_for_review, edited]
+
+jobs:
+  build:
+    name: Check autorelease deprecation
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Determine branch name
+        run: |
+          BRANCH="${GITHUB_BASE_REF#refs/heads/}"
+          echo "Building for $BRANCH"
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+      - name: Determine changed packages
+        run: |
+          # only detect packages with changes
+          PKG_ROOTS=$(find . -name Makefile | \
+            grep -v ".*/src/Makefile" | \
+            sed -e 's@./\(.*\)/Makefile@\1/@')
+          CHANGES=$(git diff --diff-filter=d --name-only origin/$BRANCH...)
+
+          for ROOT in $PKG_ROOTS; do
+            for CHANGE in $CHANGES; do
+              if [[ "$CHANGE" == "$ROOT"* ]]; then
+                if grep -q '$(AUTORELEASE)' "$ROOT/Makefile"; then
+                  CONTAINS_AUTORELEASE+="$ROOT"
+                fi
+                break
+              fi
+            done
+          done
+
+          if [ -n "$CONTAINS_AUTORELEASE" ]; then
+            cat > "$GITHUB_WORKSPACE/pr_comment.md" << EOF
+          Please do no longer set *PKG_RELEASE* to *AUTORELEASE* as the
+          feature is deprecated. Please use an integer instead. Below is a
+          list of affected packages including correct *PKG_RELEASE*:
+
+          EOF
+          else
+            echo "No usage of *AUTORELEASE* found in changes" > "$GITHUB_WORKSPACE/pr_comment.md"
+          fi
+
+          for ROOT in $CONTAINS_AUTORELEASE; do
+            echo -n "  - ${ROOT}Makefile: PKG_RELEASE:=" >> "$GITHUB_WORKSPACE/pr_comment.md"
+            last_bump="$(git log --pretty=format:'%h %s' "$ROOT" |
+              grep --max-count=1 -e ': [uU]pdate to ' -e ': [bB]ump to ' |
+              cut -f 1 -d ' ')"
+
+            if [ -n "$last_bump" ]; then
+              echo -n $(($(git rev-list --count "$last_bump..HEAD" "$ROOT") + 2)) >> "$GITHUB_WORKSPACE/pr_comment.md"
+            else
+              echo -n $(($(git rev-list --count HEAD "$ROOT") + 2)) >> "$GITHUB_WORKSPACE/pr_comment.md"
+            fi
+            echo >> "$GITHUB_WORKSPACE/pr_comment.md"
+          done
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-file: 'pr_comment.md'
+          edit-mode: replace


### PR DESCRIPTION
Autorelease causes some issues like heavy bandwidth usage as well as non-deterministic package releases whenever someone doesn't use the full git log.

With this comment all modified packages are checked and if they use the autorelease feature, kindly comment to the user to change that.

Signed-off-by: Paul Spooren <paul.spooren@rhebo.com>