### PR TITLE
acme: make certificates use .crt as the extension

### DIFF
--- a/net/acme-acmesh/files/hook.sh
+++ b/net/acme-acmesh/files/hook.sh
@@ -46,7 +46,8 @@ get)
 			case $status in
 			0)
 				$NOTIFY renewed
-				exit;;
+				exit
+				;;
 			2)
 				# renew skipped, ignore.
 				exit
@@ -109,10 +110,10 @@ get)
 
 	case $status in
 	0)
-		ln -s "$domain_dir/$main_domain.cer" /etc/ssl/acme
+		ln -s "$domain_dir/$main_domain.cer" "/etc/ssl/acme/$main_domain.crt"
 		ln -s "$domain_dir/$main_domain.key" /etc/ssl/acme
-		ln -s "$domain_dir/fullchain.cer" "/etc/ssl/acme/$main_domain.fullchain.cer"
-		ln -s "$domain_dir/ca.cer" "/etc/ssl/acme/$main_domain.chain.cer"
+		ln -s "$domain_dir/fullchain.cer" "/etc/ssl/acme/$main_domain.fullchain.crt"
+		ln -s "$domain_dir/ca.cer" "/etc/ssl/acme/$main_domain.chain.crt"
 		$NOTIFY issued
 		;;
 	*)


### PR DESCRIPTION
Signed-off-by: Glen Huang <i@glenhuang.com>

Maintainer: @tohojo
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
This was an omission from my part in the initial PR.

Since uhttpd uses `.crt` as the certification extension name, I think the standard name in acme package should follow that convention, and we should make the change when there aren't many acme packages that have adopted the new architecture.

This change should be backward-compatible, since it only affects new certificates.
