### PR TITLE
libgpg-error: copy gpg-error.pc to staging directory

### DIFF
--- a/libs/libgpg-error/Makefile
+++ b/libs/libgpg-error/Makefile
@@ -91,6 +91,11 @@ define Build/InstallDev
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/share/aclocal/gpgrt.m4 \
 		$(1)/usr/share/aclocal/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/gpg-error.pc \
+		$(1)/usr/lib/pkgconfig
 endef
 
 define Package/libgpg-error/install


### PR DESCRIPTION
Packages like libassuan and libksba would not compile after updating libgpg-error to 1.46. This was because gpg-error.m4 (and thus the affected packages' configure scripts) relies on gpgrt-config, which in turn needs access to gpg-error.pc. This modifies the libgpg-error build process to copy gpg-error.pc to OpenWrt's staging directory, so that it is available for subsequent dependent package builds.

Fixes: https://github.com/openwrt/packages/issues/19880

Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: x86_64 master

Description:
