### PR TITLE
acme: ensure symlinks for renewed certificates

### DIFF
--- a/net/acme-acmesh/Makefile
+++ b/net/acme-acmesh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-acmesh
 PKG_VERSION:=3.0.1
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/acmesh-official/acme.sh/tar.gz/$(PKG_VERSION)?

--- a/net/acme-acmesh/files/hook.sh
+++ b/net/acme-acmesh/files/hook.sh
@@ -45,6 +45,20 @@ get)
 
 			case $status in
 			0)
+				mkdir -p /etc/ssl/acme
+				if [ ! -e "/etc/ssl/acme/$main_domain.crt" ]; then
+					ln -s "$domain_dir/$main_domain.cer" "/etc/ssl/acme/$main_domain.crt"
+				fi
+				if [ ! -e "/etc/ssl/acme/$main_domain.key" ]; then
+					ln -s "$domain_dir/$main_domain.key" "/etc/ssl/acme/$main_domain.key"
+				fi
+				if [ ! -e "/etc/ssl/acme/$main_domain.fullchain.crt" ]; then
+					ln -s "$domain_dir/fullchain.cer" "/etc/ssl/acme/$main_domain.fullchain.crt"
+				fi
+				if [ ! -e "/etc/ssl/acme/$main_domain.chain.crt" ]; then
+					ln -s "$domain_dir/ca.cer" "/etc/ssl/acme/$main_domain.chain.crt"
+				fi
+
 				$NOTIFY renewed
 				exit
 				;;
@@ -111,7 +125,7 @@ get)
 	case $status in
 	0)
 		ln -s "$domain_dir/$main_domain.cer" "/etc/ssl/acme/$main_domain.crt"
-		ln -s "$domain_dir/$main_domain.key" /etc/ssl/acme
+		ln -s "$domain_dir/$main_domain.key" "/etc/ssl/acme/$main_domain.key"
 		ln -s "$domain_dir/fullchain.cer" "/etc/ssl/acme/$main_domain.fullchain.crt"
 		ln -s "$domain_dir/ca.cer" "/etc/ssl/acme/$main_domain.chain.crt"
 		$NOTIFY issued


### PR DESCRIPTION
Signed-off-by: Glen Huang <i@glenhuang.com>

Maintainer: @tohojo
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
This should make #19936 backward-compatible.