### PR TITLE
libxslt: fix compilation with libiconv-full

### DIFF
--- a/libs/libxslt/Makefile
+++ b/libs/libxslt/Makefile
@@ -88,6 +88,12 @@ CMAKE_OPTIONS += \
 	-DLIBXSLT_WITH_THREADS=ON \
 	-DLIBXSLT_WITH_XSLT_DEBUG=OFF
 
+ifeq ($(CONFIG_BUILD_NLS),y)
+	CMAKE_OPTIONS += \
+		-DIconv_INCLUDE_DIR=$(ICONV_PREFIX)/include \
+		-DIconv_LIBRARY=$(ICONV_PREFIX)/lib/libiconv.so
+endif
+
 define Build/InstallDev/Xslt
 	$(INSTALL_DIR) $(1)/usr/bin $(2)/bin $(1)/usr/include/libxslt \
 		$(1)/usr/include/libexslt $(1)/usr/lib \

--- a/libs/libxslt/patches/010-iconv.patch
+++ b/libs/libxslt/patches/010-iconv.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -345,7 +345,7 @@ endif()
+ add_executable(xsltproc xsltproc/xsltproc.c)
+ add_executable(LibXslt::xsltproc ALIAS xsltproc)
+ target_include_directories(xsltproc PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+-target_link_libraries(xsltproc LibExslt LibXslt)
++target_link_libraries(xsltproc LibExslt LibXslt ${Iconv_LIBRARY})
+ install(TARGETS xsltproc EXPORT LibXslt RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT programs)
+ 
+ if(LIBXSLT_WITH_TESTS)


### PR DESCRIPTION
From a hidapi pull request:

by default find_file/find_library doesn't respect CFLAGS/LDFLAGS, and FindIconv fails to find Iconv

Specify the location manually.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jslachta 
'
ping @M95D 