### PR TITLE
librespeed-cli: rename binary to librespeed-cli

### DIFF
--- a/utils/librespeed-cli/Makefile
+++ b/utils/librespeed-cli/Makefile
@@ -41,5 +41,11 @@ define Package/librespeed-cli/description
   LibreSpeed client for measuring internet speed from command line.
 endef
 
+define Package/librespeed-cli/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/speedtest-cli $(1)/usr/bin/librespeed-cli
+endef
+
 $(eval $(call GoBinPackage,librespeed-cli))
 $(eval $(call BuildPackage,librespeed-cli))


### PR DESCRIPTION
Maintainer: me
Compile tested: armv7, Turris Omnia, OpenWrt 21.02
Run tested: armv7, Turris Omnia, OpenWrt 21.02

Description: upstream names the binary librespeed-cli and this avoids a conflict with python3-speedtest-cli

cc @1715173329