### PR TITLE
tvheadend: update to git master 2022-11-20

### DIFF
--- a/multimedia/tvheadend/Makefile
+++ b/multimedia/tvheadend/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tvheadend
-PKG_VERSION:=2021-11-16
+PKG_VERSION:=2022-11-20
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/tvheadend/tvheadend.git
-PKG_MIRROR_HASH:=1645e90b6b8f104f2749fb0911493010f7ae3176253f2a96a4d6094536207c03
-PKG_SOURCE_VERSION:=2efe90cdcf74fdc4179692d283cf46c85e1cf681
-PKG_SOURCE_DATE:=2021-11-16
+PKG_MIRROR_HASH:=9c1bb3eea3f3539454d17e4c6aabc774a104a772aa34ed39f248521cf6488ce5
+PKG_SOURCE_VERSION:=0ff96106aa2e0f9a384c3a2662ca005797a6b399
+PKG_SOURCE_DATE:=2022-11-20
 
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=LICENSE.md
@@ -220,6 +220,7 @@ CONFIGURE_ARGS += \
 	--disable-pcloud_cache \
 	--enable-bundle \
 	--disable-uriparser \
+	--disable-execinfo \
 	--nowerror=unused-variable
 
 ## Transcoding | Remove these from CONFIGURE_ARGS.

--- a/multimedia/tvheadend/files/tvheadend.init
+++ b/multimedia/tvheadend/files/tvheadend.init
@@ -18,11 +18,12 @@ TVH_GROUP=dvb
 
 
 execute_first_run() {
+	# $1 is the config dir. Default: /etc/tvheadend
 	mkdir -p "$1"
 	chown -R $TVH_USER "$1"
 	# This should create a new configuration including an admin account with no name and no password,
 	# but it aborts (-A) without saving it:
-	#"$PROG" -c "$1" -B -C -A -u $TVH_USER -g $TVH_GROUP >/dev/null 2>&1
+	# "$PROG" -c "$1" -B -C -A -u $TVH_USER -g $TVH_GROUP >/dev/null 2>&1
 	# Instead, run it for 10s then kill it:
 	"$PROG" -c "$1" -B -C -u $TVH_USER -g $TVH_GROUP & TVH_PID=$! ; sleep 10 ; kill $TVH_PID ; sleep 2
 }
@@ -41,15 +42,15 @@ ensure_config_exists() {
 	fi
 
 	# if use_temp_epgdb is enabled (default), most of the config is put to config_path
-	# (or /etc/config), except for epgdb.v2, which grows quite large and is write-heavy,
+	# (or /etc/config), except for epgdb.v3, which grows quite large and is write-heavy,
 	# so it's put into volatile tmpfs
-	# epgdb.v2 is created and symlinked to main config dir upon each start (if it doesn't exist)
+	# epgdb.v3 is created and symlinked to main config dir upon each start (if it doesn't exist)
 	config_get_bool use_temp_epgdb service use_temp_epgdb 1
 	if [ "$use_temp_epgdb" == "1" ]; then
-		TEMP_EPG="${TEMP_CONFIG}/epgdb.v2"
-		[ ! -f "$TEMP_EPG" ] && mkdir -p "$TEMP_CONFIG" && touch "$TEMP_EPG" && chmod 700 "$TEMP_EPG"
+		TEMP_EPG="${TEMP_CONFIG}/epgdb.v3"
+		[ ! -f "$TEMP_EPG" ] && mkdir -p "$TEMP_CONFIG" && touch "$TEMP_EPG" && chmod 755 "$TEMP_CONFIG" && chmod 644 "$TEMP_EPG" && chown -R $TVH_USER "$TEMP_CONFIG"
 		[ -z "$config_path" ] && config_path="$PERSISTENT_CONFIG"
-		ln -sf "$TEMP_EPG" "${config_path}/epgdb.v2"
+		ln -sf "$TEMP_EPG" "${config_path}/epgdb.v3"
 	fi
 }
 


### PR DESCRIPTION
Maintainer: me
Compile tested: host x86-64, target mvebu, OpenWrt git master (yesterday)
Run tested: Linksys WRT-1900ACv1, OpenWrt r19971
Tests done:
- install package = OK
- /etc/init.d/tvheadend start = OK
- /etc/init.d/tvheadend stop = OK
- start server manually in console foreground = OK (no unusual errors)
- open web interface = OK
- scan local DVB-C network = OK
- check EPG = loads OK
- stream a TV channel to a desktop PC = OK
- check temporary EPG DB file = OK (EPGDB symlink created, permissions set, not empty)

Did not test:
- initial setup, when no previous configuration exists (but no changes were done here, so it should be OK)

Description:
Latest commit to the tvheadend master branch fixes an issue that affects OpenWrt users:
EPG database file overwrites tvheadend symlink with a real file.
This pull request updates tvheadend to include that commit.
It also updates init script to use the new file: epgdb.v3