### PR TITLE
github-ci: error on any shell errors

### DIFF
--- a/.github/workflows/entrypoint.sh
+++ b/.github/workflows/entrypoint.sh
@@ -1,10 +1,14 @@
 #!/bin/sh
 
+# not enabling `errtrace` and `pipefail` since those are bash specific
+set -o errexit # failing commands causes script to fail
+set -o nounset # undefined variables causes script to fail 
+
 mkdir -p /var/lock/
 
 opkg update
 
-[ -n "$CI_HELPER" ] || CI_HELPER="/ci/.github/workflows/ci_helpers.sh"
+[ -n "${CI_HELPER:=''}" ] || CI_HELPER="/ci/.github/workflows/ci_helpers.sh"
 
 for PKG in /ci/*.ipk; do
 	tar -xzOf "$PKG" ./control.tar.gz | tar xzf - ./control 


### PR DESCRIPTION
**Maintainer:** N/A (not a package, GitHub CI)
**Compile tested:** N/A
**Run tested:** Tested with a PR on my fork: https://github.com/aloisklink/packages/pull/1

**Description:**

Enable `errexit` and `nounset` [POSIX shell options][1] in `.github/workflows/entrypoint.sh` so that the script fails if any command within the script fails.

Fixes: https://github.com/openwrt/packages/issues/19953

[1]: https://pubs.opengroup.org/onlinepubs/9699919799//utilities/V3_chap02.html#set

---

This mainly helps debug errors in the `preinst`/`postinst` scripts, as they will cause `opkg install "$PKG"` to return with a non-zero exit code, which will then cause the `entrypoint.sh` script to immediately exit, and cause GitHub Actions CI to fail.

The same should also apply to the `prerm`/`postrm` scripts when running `opkg remove "$PKG_NAME"` command, but I haven't tested it.

I have a test PR in https://github.com/aloisklink/packages/pull/1 where I show this change working by showing a `privoxy` test failing, then passing after I fix the `preinst` script.

@M95D, I've added a `Reported-by` git trailer in my commit with your details :) Let me know if you're unhappy with this.

### Potential issues

This might cause a bunch of packages to start failing CI if their `preinst`/`postinst` scripts were previously broken! This might cause some confusion, especially if this is only detected when making unrelated PRs.

Is it worth running the `multi-arch-test-build.yml` on every package in this repo? I'm unsure if there is an easy way to do this, maybe we can do it manually in a fork by making some dummy changes to each package's Makefile, but then we might encounter GitHub Actions timeout issues (I think they can only run for 6 hours).