### PR TITLE
privoxy: fix `preinst`/`postinst` indentation

### DIFF
--- a/net/privoxy/Makefile
+++ b/net/privoxy/Makefile
@@ -118,13 +118,13 @@ define Package/privoxy/conffiles
 endef
 
 define Package/privoxy/preinst
-	#!/bin/sh
-	[ -n "$${IPKG_INSTROOT}" ] && exit 0	# if run within buildroot exit
+#!/bin/sh
+[ -n "$${IPKG_INSTROOT}" ] && exit 0	# if run within buildroot exit
 
-	# stop service if PKG_UPGRADE
-	[ "$${PKG_UPGRADE}" = "1" ] && /etc/init.d/privoxy stop >/dev/null 2>&1
-		
-	exit 0	# suppress errors from stop command
+# stop service if PKG_UPGRADE
+[ "$${PKG_UPGRADE}" = "1" ] && /etc/init.d/privoxy stop >/dev/null 2>&1
+	
+exit 0	# suppress errors from stop command
 endef
 
 define Package/privoxy/install
@@ -156,16 +156,16 @@ define Package/privoxy/install
 endef
 
 define Package/privoxy/postinst
-	#!/bin/sh
-	# if exists, update previous version entry missing protocol
-	(grep -E "privoxy.*8118$$" $${IPKG_INSTROOT}/etc/services) > /dev/null \
-		&& sed -i "s/privoxy.*8118/privoxy\t\t8118\/tcp/" $${IPKG_INSTROOT}/etc/services
+#!/bin/sh
+# if exists, update previous version entry missing protocol
+(grep -E "privoxy.*8118$$" $${IPKG_INSTROOT}/etc/services) > /dev/null \
+	&& sed -i "s/privoxy.*8118/privoxy\t\t8118\/tcp/" $${IPKG_INSTROOT}/etc/services
 
-	# add missing tcp and udp entries
-	(grep -E "privoxy.*8118\/tcp" $${IPKG_INSTROOT}/etc/services) > /dev/null \
-		|| echo -e "privoxy\t\t8118/tcp" >> $${IPKG_INSTROOT}/etc/services
-	(grep -E "privoxy.*8118\/udp" $${IPKG_INSTROOT}/etc/services) > /dev/null \
-		|| echo -e "privoxy\t\t8118/udp" >> $${IPKG_INSTROOT}/etc/services
+# add missing tcp and udp entries
+(grep -E "privoxy.*8118\/tcp" $${IPKG_INSTROOT}/etc/services) > /dev/null \
+	|| echo -e "privoxy\t\t8118/tcp" >> $${IPKG_INSTROOT}/etc/services
+(grep -E "privoxy.*8118\/udp" $${IPKG_INSTROOT}/etc/services) > /dev/null \
+	|| echo -e "privoxy\t\t8118/udp" >> $${IPKG_INSTROOT}/etc/services
 endef
 
 $(eval $(call BuildPackage,privoxy))


### PR DESCRIPTION
- **Maintainer**: `PKG_MAINTAINER` field is blank.
- **Compile tested**: Tested with my PR https://github.com/openwrt/packages/pull/19964 that causes the `multi-arch-test-build.yml` action to fail if the `opkg install ...` command fails.

  In https://github.com/aloisklink/packages/pull/1, you can see that before this change, `arm_cortex-a15_neon-vfpv4` and `aarch64_cortex-a53` fails, but after this change, `opkg install` succeeds
- **Run tested**: Not tested on any real devices.

**Description:**

Fix the indentation of the `preinst`/`postinst` scripts for the `privoxy` package.

Because these scripts didn't start with `#!/bin/sh` (they instead started with the TAB character), `/bin/sh` was not used to start them.

On `x86_64` and `i386_pentium-mmx`, this seems to be fine, but when using `arm_cortex-a15_neon-vfpv4` and `aarch64_cortex-a53` through QEMU, running `opkg install` fails with a:

```
Installing privoxy (3.0.33-3) to root...
Collected errors:
 * pkg_run_script: package "privoxy" preinst script returned status 1.
 * preinst_configure: Aborting installation of privoxy.
 * opkg_install_cmd: Cannot install package privoxy.
```

---

~**I've made this PR on top of https://github.com/openwrt/packages/pull/19951, to avoid merge conflicts (that PR is only a one character change), so I may need to `git rebase` once that PR is merged**~ Rebased onto `master` to include commit https://github.com/openwrt/packages/commit/46e4def61f6b670daac1725df8f3fc4475fe5450

Reported by @M95D in https://github.com/openwrt/packages/pull/19951#pullrequestreview-1188923498 and https://github.com/openwrt/packages/issues/19953#issuecomment-1323220446 (I've added them in a `Reported-by:` line in the git commit description)

I did a quick search of this repo using the below RegExs, and I think there might be other packages that are affected by this same bug:

- RegEx: `preinst\n\t` (no other packages found)
- RegEx: `postinst\n\t`
  - `gcc` (also matched by `postrm\n\t`)
  - `keepalived-sync`
  - `simple-adblock` (also matched by `prerm\n\t`)
  - `vpn-policy-routing` (also matched by `prerm\n\t`)
  - `vpnbypass` (also matched by `prerm\n\t`)
  - `wg-installer-server`
- RegEx: `postrm\n\t`
  - `gcc` (also matched by `postinst\n\t`)
  - `arp-scan-database`
  - `keepalived-sync`
  - `fish`

After https://github.com/openwrt/packages/pull/19964 is merged, GitHub Actions CI will automatically fail if `opkg install` fails, so it might be worth testing those packages.

I've also noticed that some packages, like `gitolite` or `krb5-server`, are completely missing a shebang in their `postinst` script, so it's possible that these packages will also fail to `opkg install` on some platforms.

