### PR TITLE
samba4: support both user map and valid users on same time

### DIFF
--- a/net/samba4/files/samba.init
+++ b/net/samba4/files/samba.init
@@ -115,9 +115,8 @@ smb_add_share() {
 		if [ "$force_root" -eq 1 ]; then
 			printf "\tforce user = root\n"
 			printf "\tforce group = root\n"
-		else
-			[ -n "$users" ] && printf "\tvalid users = %s\n" "$users"
 		fi
+		[ -n "$users" ] && printf "\tvalid users = %s\n" "$users"
 
 		[ -n "$create_mask" ] && printf "\tcreate mask = %s\n" "$create_mask"
 		[ -n "$dir_mask" ] && printf "\tdirectory mask = %s\n" "$dir_mask"


### PR DESCRIPTION

Compile tested: arm64, Easepi ARS2, openwrt 21.02.3
Run tested: arm64, Easepi ARS2, openwrt 21.02.3

Description:
support both user map and valid users on same time.
`valid users` is for validate logining user, `user map` is map user to root after login, there is not conflicts.

Signed-off-by: Liangbin Lian <jjm2473@gmail.com>
