### PR TITLE
gnupg: compile with -fcommon

### DIFF
--- a/utils/gnupg/Makefile
+++ b/utils/gnupg/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnupg
 PKG_VERSION:=1.4.23
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/gnupg
@@ -87,7 +87,7 @@ CONFIGURE_ARGS += \
 MAKE_FLAGS += \
 	SUBDIRS="m4 intl zlib util mpi cipher tools g10 keyserver ${checks}" \
 
-TARGET_CFLAGS += -DEXTERN_UNLESS_MAIN_MODULE=static
+TARGET_CFLAGS += -fcommon
 
 define Package/gnupg/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
This fixes a segfault because gnupg/g10/options.h struct opt is otherwise not shared between the different compilation units, resulting in `opt.homedir` being `NULL` when passed to make_filename. Most subcommands are affected, including `--list-keys`, `-i`, and `--export-ownertrust`.

```console
$ gpg1 -i

gpg: signal 11 caught ... exiting
Segmentation fault

(gdb) bt
    #0  0x00007f17bb2185e2 in strlen (s=s@entry=0x0) at src/string/strlen.c:17
    #1  0x0000000000460ea0 in make_filename (first_part=first_part@entry=0x0) at gnupg-1.4.23/util/fileutil.c:174
    #2  0x000000000040ee42 in keydb_add_resource (url=url@entry=0x46bfe3 "secring.gpg", flags=flags@entry=4, secret=secret@entry=1)
        at gnupg-1.4.23/g10/keydb.c:238
    #3  0x00000000004062ee in main (argc=<optimized out>, argv=<optimized out>) at gnupg-1.4.23/g10/gpg.c:3323
```

Building the gnupg for OpenWRT v21.02.5 two times in the same buildroot with the only difference being cherry-picking https://github.com/openwrt/packages/commit/2811f18da717f88842b1a72d2d2a5eab3041535, results in the first gnupg_1.4.23.ipk working and the second gnupg_1.4.23.ipk segfaulting.

The command `gpg1 --list-keys --no-default-keyring` segfaults at another place, also caused by `opt.homedir` being `NULL`.

GnuPG v2 is not affected by this issue.


Maintainer: @neheb
Compile tested: OpenWrt 22.03.2, x86-64 and ath79
Run tested: the gpg commands worked again on a mips_24kc router with this patch applied
