### PR TITLE
ddns-scripts: update_gandi_net: improve logging & add timeout

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=29
+PKG_RELEASE:=30
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_gandi_net.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_gandi_net.sh
@@ -20,14 +20,23 @@ json_add_array rrset_values
 json_add_string "" "$__IP"
 json_close_array
 
+# Log the curl command
+write_log 7 "curl -s -X PUT \"$__ENDPOINT/domains/$domain/records/$username/$__RRTYPE\" \
+	-H \"Authorization: Apikey $password\" \
+	-H \"Content-Type: application/json\" \
+	-d \"$(json_dump)\" \
+	--connect-timeout 30"
+
 __STATUS=$(curl -s -X PUT "$__ENDPOINT/domains/$domain/records/$username/$__RRTYPE" \
 	-H "Authorization: Apikey $password" \
 	-H "Content-Type: application/json" \
 	-d "$(json_dump)" \
+	--connect-timeout 30 \
 	-w "%{http_code}\n" -o $DATFILE 2>$ERRFILE)
 
-if [ $? -ne 0 ]; then
-	write_log 14 "Curl failed: $(cat $ERRFILE)"
+local __ERRNO=$?
+if [ $__ERRNO -ne 0 ]; then
+	write_log 14 "Curl failed with $__ERRNO: $(cat $ERRFILE)"
 	return 1
 elif [ -z $__STATUS ] || [ $__STATUS != 201 ]; then
 	write_log 14 "LiveDNS failed: $__STATUS \ngandi.net answered: $(cat $DATFILE)"


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: (dynamic script, so no compilation)
Run tested:
 - arch: ath79/generic
 - model: TP-Link Archer C7 v2
 - version: OpenWrt 22.03.2 r19803-9a599fee93 / LuCI openwrt-22.03 branch git-22.288.45147-96ec0cd
 - tests done: Replaced the script file, `rm /var/run/ddns/* /var/log/ddns/* && service ddns restart`, checked that the logs look like expected. Tried triggering an update when rate-limited to test the added timeout.

Description:
- Some gandi.net updates seemed flaky, but it was hard to know from the logs what went wrong, so I added to the logs
  - the executed curl command to be able to test it manually
  - the curl exit status
- Turns out sometimes the request would just hang, and eventually curl would return with exit status `35`. I think that it's better to clearly be able to distinguish flaky connections, so I added 30 second timeout, which seems reasonable to me.