### PR TITLE
[22.03] simple-adblock: bugfix: detect dnsmasq ipset support

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.9.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -393,7 +393,7 @@ load_environment() {
 	output "$_ERROR_: $serviceName failed to discover WAN gateway.\\n"; return 1;
 }
 
-dnsmasq() {
+resolver() {
 	local cfg="$1" param="$2"
 	case "$param" in
 		dnsmasq.addnhosts)
@@ -430,10 +430,10 @@ dns() {
 
 			config_load 'dhcp'
 			if [ "$dns_instance" = "*" ]; then
-				config_foreach dnsmasq 'dnsmasq' "$dns"
+				config_foreach resolver 'dnsmasq' "$dns"
 			elif [ -n "$dns_instance" ]; then
 				for i in $dns_instance; do
-					dnsmasq "@dnsmasq[$i]" "$dns" || dnsmasq "$i" "$dns"
+					resolver "@dnsmasq[$i]" "$dns" || resolver "$i" "$dns"
 				done
 			fi
 
@@ -1426,7 +1426,7 @@ killcache() {
 	rm -f "$dnsmasqServersCache" "$dnsmasqServersGzip"
 	rm -f "$unboundCache" "$unboundGzip"
 	config_load 'dhcp'
-	config_foreach dnsmasq 'dnsmasq' 'cleanup'
+	config_foreach resolver 'dnsmasq' 'cleanup'
 	uci_commit 'dhcp'
 	return 0
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-135, OpenWrt 22.03.2
Run tested: x86_64, Sophos SG-135, OpenWrt 22.03.2, start service

Description:

* Fixes https://github.com/openwrt/packages/issues/19978, thank you @parona-source for the report/patch!

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit cc10774e6e3799ac86af83d8c35c6a37fd73c15a)
