### PR TITLE
snort3: unified configs: local.lua and homenet.lua

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.1.48.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
@@ -90,7 +90,8 @@ define Package/snort3/install
 		$(PKG_INSTALL_DIR)/usr/include/snort/lua/snort_plugin.lua \
 		$(1)/usr/share/lua/
 
-	$(INSTALL_DIR) $(1)/etc/snort
+	$(INSTALL_DIR) $(1)/etc/snort/{rules,lists,builtin_rules,so_rules}
+
 	$(INSTALL_CONF) \
 		$(PKG_INSTALL_DIR)/usr/etc/snort/*.lua \
 		$(1)/etc/snort
@@ -107,6 +108,25 @@ define Package/snort3/install
 	$(INSTALL_CONF) \
 		./files/snort.config \
 		$(1)/etc/config/snort
+	$(INSTALL_CONF) \
+		./files/local.lua \
+		$(1)/etc/snort
+	$(INSTALL_CONF) \
+		./files/homenet.lua \
+		$(1)/etc/snort
+	sed \
+		-i -e "/^EXTERNAL_NET\\s\\+=/ a include 'homenet.lua'" \
+		-e "/^HOME_NET\\s\\+=/ i -- we set HOME_NET and EXTERNAL_NET here or via an included file" \
+		-e 's/^\(HOME_NET\s\+=\)/--\1/g' \
+		-e 's/^\(EXTERNAL_NET\s\+=\)/--\1/g' \
+		$(1)/etc/snort/snort.lua
+	sed \
+		-i -e "s/^\\(RULE_PATH\\s\\+=\\).*/\\1 'rules'/g" \
+		-e "s/^\\(BUILTIN_RULE_PATH\\s\\+=\\).*/\\1 'builtin_rules'/g" \
+		-e "s/^\\(PLUGIN_RULE_PATH\\s\\+=\\).*/\\1 'so_rules'/g" \
+		-e "s/^\\(WHITE_LIST_PATH\\s\\+=\\).*/\\1 'lists'/g" \
+		-e "s/^\\(BLACK_LIST_PATH\\s\\+=\\).*/\\1 'lists'/g" \
+		$(1)/etc/snort/snort_defaults.lua
 endef
 
 $(eval $(call BuildPackage,snort3))

--- a/net/snort3/files/homenet.lua
+++ b/net/snort3/files/homenet.lua
@@ -1,0 +1,3 @@
+-- setup HOME_NET below with your IP range/ranges to protect
+HOME_NET = [[ 192.168.1.0/24 10.1.0.1/24 ]]
+EXTERNAL_NET = "!$HOME_NET"

--- a/net/snort3/files/local.lua
+++ b/net/snort3/files/local.lua
@@ -1,0 +1,52 @@
+-- use ths file to customize any functions defined in /etc/snort/snort.lua
+
+-- switch tap to inline in ips and uncomment the below to run snort in inline mode
+--snort = {}
+--snort["-Q"] = ''
+
+ips = {
+  mode = tap,
+  -- mode = inline,
+  variables = default_variables,
+  -- uncomment and change the below to reflect rules or symlinks to rules on your filesystem
+  -- include = RULE_PATH .. '/snort.rules',
+}
+
+daq = {
+  module_dirs = {
+    '/usr/lib/daq',
+  },
+  modules = {
+    {
+      name = 'afpacket',
+      mode = 'inline',
+    }
+  }
+}
+
+alert_syslog = {
+  level = 'info',
+}
+
+-- To log to a file, uncomment the below and manually create the dir defined in output.logdir
+--output.logdir = '/var/log/snort'
+--alert_fast = {
+--  file = true,
+--  packet = false,
+--}
+
+normalizer = {
+  tcp = {
+    ips = true,
+  }
+}
+
+file_policy = {
+  enable_type = true,
+  enable_signature = true,
+  rules = {
+    use = {
+      verdict = 'log', enable_file_type = true, enable_file_signature = true
+    }
+  }
+}

--- a/net/snort3/files/snort.config
+++ b/net/snort3/files/snort.config
@@ -1,4 +1,3 @@
 config snort 'snort'
 	option config_dir '/etc/snort/'
-	option alert_module 'alert_syslog'
 	option interface 'eth0'

--- a/net/snort3/files/snort.init
+++ b/net/snort3/files/snort.init
@@ -9,7 +9,6 @@ PROG=/usr/bin/snort
 validate_snort_section() {
 	uci_validate_section snort snort "${1}" \
 		'config_dir:string' \
-		'alert_module:string' \
 		'interface:string'
 }
 
@@ -22,7 +21,7 @@ start_service() {
 	}
 
 	procd_open_instance
-	procd_set_param command $PROG -q --daq-dir /usr/lib/daq/ -i "$interface" -c "$config_dir/snort.lua" -A "$alert_module"
+	procd_set_param command $PROG -q -i "$interface" -c "${config_dir%/}/snort.lua" --tweaks local
 	procd_set_param env SNORT_LUA_PATH="$config_dir"
 	procd_set_param file $CONFIGFILE
 	procd_set_param respawn


### PR DESCRIPTION
This commit adds `/etc/snort/local.lua` and `/etc/snort/homenet.lua` for user defined config options which is more simplistic than modifying upstream files directly. That can be tedious and decisive to maintain in sync with upstream changes.  The init script has been adjusted accordingly.

Acknowledgment to amish who maintains the Arch Linux [snort-nfqueue package](https://aur.archlinux.org/packages/snort-nfqueue) for these ideas and initial code.

Another modification is dropping the following args in the call to `/usr/bin/snort` by the init system as these options are provided in `/etc/snort/local.lua`:

 * --daq-dir /usr/lib/daq/
 * -A "$alert_module"

Instructions to configure snort3:
```
1. Edit /etc/snort/homenet.lua and redefine HOME_NET and EXTERNAL_NET, for example:    
       HOME_NET = [[ 10.9.8.0/24 192.168.1.0/24 ]]
       EXTERNAL_NET = "!$HOME_NET"
    
2. Edit /etc/snort/local.lua to setup options unique to your use case of snort.
   The default ones I included should be sane for the role of IDS (alert only), 
   but users may easily uncomment some options therein to use IPS (drop) mode.
    
3. Install or symlink rules to /etc/snort/rules/snort.rules edit optionally edit
   /etc/snort/local.lua to define extra rules files if not using unified 'snort.rules'
```
Signed-off-by: John Audia <therealgraysky@proton.me>