### PR TITLE
uacme: use UCI instead of iptables for firewall configuration

### DIFF
--- a/net/uacme/Makefile
+++ b/net/uacme/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uacme
 PKG_VERSION:=1.7.3
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ndilieto/uacme/tar.gz/upstream/$(PKG_VERSION)?


### PR DESCRIPTION
Maintainer: @lucize 

Description: Here is an attempt to make uacme compatible with nft firewall implementation.
This has been missing as identified in https://github.com/openwrt/packages/issues/16818