### PR TITLE
lighttpd: lighttpd.conf vars, doc comments, config guidance

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.67
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 # release candidate ~rcX testing; remove for release
 #PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 

--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -267,7 +267,7 @@ $(eval $(call BuildPlugin,openssl,TLS using openssl,@LIGHTTPD_SSL +PACKAGE_light
 $(eval $(call BuildPlugin,proxy,Proxy,,30))
 $(eval $(call BuildPlugin,redirect,URL redirection,$(if $(CONFIG_LIGHTTPD_PCRE2),+PACKAGE_lighttpd-mod-redirect:libpcre2,),10))
 $(eval $(call BuildPlugin,rewrite,URL rewriting,$(if $(CONFIG_LIGHTTPD_PCRE2),+PACKAGE_lighttpd-mod-rewrite:libpcre2,),30))
-$(eval $(call BuildPlugin,rrdtool,RRDtool,,30))
+$(eval $(call BuildPlugin,rrdtool,RRDtool,rrdtool1,30))
 $(eval $(call BuildPlugin,scgi,SCGI,,30))
 $(eval $(call BuildPlugin,setenv,Environment variable setting,,30))
 $(eval $(call BuildPlugin,simple_vhost,Simple virtual hosting,,30))

--- a/net/lighttpd/files/lighttpd.conf
+++ b/net/lighttpd/files/lighttpd.conf
@@ -1,34 +1,41 @@
-server.document-root        = "/www"
+### Documentation
+# https://wiki.lighttpd.net/
+#
+### Configuration Syntax
+# https://wiki.lighttpd.net/Docs_Configuration
+#
+### Configuration Options
+# https://wiki.lighttpd.net/Docs_ConfigurationOptions
+#
+### Configuration Variables (potentially used in /etc/lighttpd/conf.d/*.conf)
+var.log_root    = "/var/log/lighttpd/"
+var.server_root = "/www/"
+var.state_dir   = "/var/run/"
+var.home_dir    = "/var/lib/lighttpd/"
+var.conf_dir    = "/etc/lighttpd"
+var.vhosts_dir  = server_root + "/vhosts"
+var.cache_dir   = "/var/cache/lighttpd"
+var.socket_dir  = home_dir + "/sockets"
+
+### OpenWRT lighttpd base configuration
+server.document-root        = server_root
 server.upload-dirs          = ( "/tmp" )
-server.errorlog             = "/var/log/lighttpd/error.log"
-server.pid-file             = "/var/run/lighttpd.pid"
+server.errorlog             = log_root + "error.log"
+server.pid-file             = state_dir + "lighttpd.pid"
 server.username             = "http"
 server.groupname            = "www-data"
 
+# historical; preserved for compatibility; should have been disabled by default
 index-file.names            = ( "index.php", "index.html",
                                 "index.htm", "default.htm",
                               )
 
 static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
 
-### Features
-#https://redmine.lighttpd.net/projects/lighttpd/wiki/Server_feature-flagsDetails
-server.feature-flags       += ("server.graceful-shutdown-timeout" => 5)
-#server.feature-flags       += ("server.graceful-restart-bg" => "enable")
-
-### Options that are useful but not always necessary:
-#server.chroot               = "/"
-#server.port                 = 81
-#server.bind                 = "localhost"
-#server.tag                  = "lighttpd"
-#server.errorlog-use-syslog  = "enable"
-#server.network-backend      = "writev"
-
-### Use IPv6 if available
-#include_shell "/usr/share/lighttpd/use-ipv6.pl"
-
-#dir-listing.encoding        = "utf-8"
-#dir-listing.activate        = "enable"
-
 include "/etc/lighttpd/mime.conf"
 include "/etc/lighttpd/conf.d/*.conf"
+
+### Customizations
+# customizations should generally be placed in separate files such as
+#   /etc/lighttpd/conf.d/00_vars.conf    # override variables for conf.d/*.conf
+#   /etc/lighttpd/conf.d/zz_custom.conf  # override other conf.d/*.conf settings

--- a/net/lighttpd/files/lighttpd.init
+++ b/net/lighttpd/files/lighttpd.init
@@ -16,10 +16,12 @@ validate_conf() {
 
 start_service() {
 	user_exists http || user_add http
-	[ -d /var/log/lighttpd ] || {
-		mkdir -m 0775 -p /var/log/lighttpd
-		chgrp www-data /var/log/lighttpd
-	}
+	for i in /var/log/lighttpd /var/lib/lighttpd /var/cache/lighttpd; do
+		[ -d "$i" ] || {
+			mkdir -m 0775 -p "$i"
+			chgrp www-data "$i"
+		}
+	done
 
 	validate_conf || exit 1
 

--- a/net/lighttpd/files/lighttpd.init
+++ b/net/lighttpd/files/lighttpd.init
@@ -8,8 +8,8 @@ USE_PROCD=1
 PROG=/usr/sbin/lighttpd
 
 validate_conf() {
-	$PROG -tt -f /etc/lighttpd/lighttpd.conf >/dev/null 2>&1 || {
-		echo "validation failed"
+	$PROG -tt -f /etc/lighttpd/lighttpd.conf >/dev/null || {
+		echo 1>&2 "lighttpd.conf validation failed"
 		return 1
 	}
 }
@@ -34,6 +34,7 @@ service_triggers() {
 }
 
 reload_service() {
+	validate_conf || exit 1
 	# lighttpd graceful restart (SIGUSR1)
 	procd_send_signal lighttpd '*' USR1
 }


### PR DESCRIPTION
Maintainer: @flyn-org
Compile tested: arm_cortex-a9 OpenWrt master

Description:
* lighttpd.init: print stderr trace if lighttpd.conf validation fails
* lighttpd.conf: variables, documentation comments, configuration guidance
* lighttpd-mod-rrdtool: add dependency on rrdtool1

lighttpd.conf shipped with openwrt differs from upstream source tree `doc/config/lighttpd.conf`, but openwrt uses upstream `doc/config/conf.d/*`.  Some variables defined in upstream source tree `doc/config/lighttpd.conf` are not available in lighttpd.conf shipped with openwrt, leading to broken lighttpd configs on openwrt with lighttpd-mod-rrdtool and lighttpd-mod-webdav openwrt packages.

This PR updates the lighttpd.conf shipped with openwrt to define missing variables, and updates lighttpd.init to create additional directories, if needed.