### PR TITLE
tvheadend: add conditions for -O3 and LTO optimizations

### DIFF
--- a/multimedia/tvheadend/Config.in
+++ b/multimedia/tvheadend/Config.in
@@ -3,10 +3,10 @@ comment "Generic options"
 
 config TVHEADEND_OPTIMIZE_SPEED
   bool "Optimize for speed"
-  depends on PACKAGE_tvheadend
+  depends on PACKAGE_tvheadend && (arm || aarch64 || x86_64)
   default n
   help
-    Optimize tvheadend for speed instead of size. This option adds -O2 and LTO (Link Time Optimization).
+    Optimize tvheadend for speed instead of size. This option adds -O3 and LTO (Link Time Optimization).
     Note: No benchmarks were performed when this option was added. Speed improvements (if any) are not known.
 
 config TVHEADEND_TRACE

--- a/multimedia/tvheadend/Makefile
+++ b/multimedia/tvheadend/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tvheadend
 PKG_VERSION:=2022-11-20
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/tvheadend/tvheadend.git


### PR DESCRIPTION
Maintainer: me
Compile tested: no.
Run tested: no. Tested only the menuconfig.

Description:
Building for arc, mips and powerpc platforms fails if -O3 and LTO optimizations are enabled. This patch removes that option for everything other than arm and x86_64. These are known to work. Fixes issue #19923.
Also fixes a typo in the description.