### PR TITLE
libqmi: fix build regressions

### DIFF
--- a/libs/libqmi/Config.in
+++ b/libs/libqmi/Config.in
@@ -13,4 +13,19 @@ config LIBQMI_WITH_QRTR_GLIB
 	help
 	  Compile libqmi with QRTR support
 
+choice
+	prompt "Select QMI message collection to build"
+	default LIBQMI_COLLECTION_BASIC
+
+	config LIBQMI_COLLECTION_MINIMAL
+		depends on !MODEMMANAGER_WITH_QMI
+		bool "minimal"
+
+	config LIBQMI_COLLECTION_BASIC
+		bool "basic (default)"
+
+	config LIBQMI_COLLECTION_FULL
+		bool "full"
+endchoice
+
 endmenu

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_SOURCE_VERSION:=1.30.6
+PKG_SOURCE_VERSION:=1.30.8
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/libqmi.git
-PKG_MIRROR_HASH:=034dc3b9e5ddb1acd9bb8c2a07f3f8a576d47b7f70942b61b82c4dfc8f805186
+PKG_MIRROR_HASH:=a0fa33a89011bdb593f66fd0b674f2a7c31f87e43ffd7f3e9a515b00864c4a91
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_SOURCE_VERSION:=1.30.4
+PKG_SOURCE_VERSION:=1.30.6
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/libqmi.git
-PKG_MIRROR_HASH:=537eae29c36aba9757afd86e48b91c37c3fe3232037ad11fdd426297f6040a6b
+PKG_MIRROR_HASH:=034dc3b9e5ddb1acd9bb8c2a07f3f8a576d47b7f70942b61b82c4dfc8f805186
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -11,17 +11,22 @@ PKG_NAME:=libqmi
 PKG_VERSION:=1.30.4
 PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
-PKG_HASH:=00d7da30a4f8d1185f37cba289cfaf1dfcd04a58f2f76d6acfdf5b85312d6ed6
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/libqmi.git
+PKG_SOURCE_VERSION:=$(PKG_VERSION)
+PKG_MIRROR_HASH:=537eae29c36aba9757afd86e48b91c37c3fe3232037ad11fdd426297f6040a6b
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 
 PKG_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DEPENDS:=python3/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
+include ../../devel/meson/meson.mk
+
+TARGET_CFLAGS += -ffunction-sections -fdata-sections -fno-merge-all-constants -fmerge-constants
+TARGET_LDFLAGS += -Wl,--gc-sections
 
 define Package/libqmi/config
   source "$(SOURCE)/Config.in"
@@ -59,26 +64,31 @@ define Package/libqmi-utils/description
   Utils to talk to QMI enabled modems
 endef
 
-CONFIGURE_ARGS += \
-	--disable-static \
-	--disable-gtk-doc \
-	--disable-gtk-doc-html \
-	--disable-gtk-doc-pdf \
-	--disable-silent-rules \
-	--enable-firmware-update \
-	--without-udev \
-	--without-udev-base-dir
+MESON_ARGS += \
+	-Dudev=false \
+	-Dintrospection=false \
+	-Dman=false \
+	-Dbash_completion=false \
+	-Db_lto=true
 
 ifeq ($(CONFIG_LIBQMI_WITH_MBIM_QMUX),y)
-	CONFIGURE_ARGS += --enable-mbim-qmux
+	MESON_ARGS += -Dmbim_qmux=true
 else
-	CONFIGURE_ARGS += --disable-mbim-qmux
+	MESON_ARGS += -Dmbim_qmux=false
 endif
 
 ifeq ($(CONFIG_LIBQMI_WITH_QRTR_GLIB),y)
-	CONFIGURE_ARGS += --enable-qrtr
+	MESON_ARGS += -Dqrtr=true
 else
-	CONFIGURE_ARGS += --disable-qrtr
+	MESON_ARGS += -Dqrtr=false
+endif
+
+ifeq ($(CONFIG_LIBQMI_COLLECTION_MINIMAL),y)
+	MESON_ARGS += -Dcollection=minimal
+else ifeq ($(CONFIG_LIBQMI_COLLECTION_BASIC),y)
+	MESON_ARGS += -Dcollection=basic
+else
+	MESON_ARGS += -Dcollection=full
 endif
 
 define Build/InstallDev
@@ -99,12 +109,15 @@ define Build/InstallDev
 endef
 
 define Package/libqmi/install
-	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DIR) \
+		$(1)/usr/lib \
+		$(1)/usr/libexec
+
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/libqmi*.so.* \
 		$(1)/usr/lib/
 
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/qmi-proxy $(1)/usr/lib/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/libexec/qmi-proxy $(1)/usr/libexec/
 endef
 
 define Package/qmi-utils/install

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_VERSION:=1.30.8
+PKG_VERSION:=1.30.4
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
-PKG_HASH:=862482ce9e3ad0bd65d264334ee311cdb94b9df2863b5b7136309b41b8ac1990
+PKG_HASH:=00d7da30a4f8d1185f37cba289cfaf1dfcd04a58f2f76d6acfdf5b85312d6ed6
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,18 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_VERSION:=1.30.4
+PKG_SOURCE_VERSION:=1.30.4
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/libqmi.git
-PKG_SOURCE_VERSION:=$(PKG_VERSION)
 PKG_MIRROR_HASH:=537eae29c36aba9757afd86e48b91c37c3fe3232037ad11fdd426297f6040a6b
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 
 PKG_INSTALL:=1
-PKG_BUILD_DEPENDS:=python3/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -69,27 +67,11 @@ MESON_ARGS += \
 	-Dintrospection=false \
 	-Dman=false \
 	-Dbash_completion=false \
-	-Db_lto=true
-
-ifeq ($(CONFIG_LIBQMI_WITH_MBIM_QMUX),y)
-	MESON_ARGS += -Dmbim_qmux=true
-else
-	MESON_ARGS += -Dmbim_qmux=false
-endif
-
-ifeq ($(CONFIG_LIBQMI_WITH_QRTR_GLIB),y)
-	MESON_ARGS += -Dqrtr=true
-else
-	MESON_ARGS += -Dqrtr=false
-endif
-
-ifeq ($(CONFIG_LIBQMI_COLLECTION_MINIMAL),y)
-	MESON_ARGS += -Dcollection=minimal
-else ifeq ($(CONFIG_LIBQMI_COLLECTION_BASIC),y)
-	MESON_ARGS += -Dcollection=basic
-else
-	MESON_ARGS += -Dcollection=full
-endif
+	-Db_lto=true \
+	-Dmbim_qmux=$(if $(CONFIG_LIBQMI_WITH_MBIM_QMUX),true,false) \
+	-Dqrtr=$(if $(CONFIG_LIBQMI_WITH_QRTR_GLIB),true,false) \
+	-Dcollection=$(if $(CONFIG_LIBQMI_COLLECTION_MINIMAL),minimal\
+		    ,$(if $(CONFIG_LIBQMI_COLLECTION_BASIC),basic,full))
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
Maintainer: @BKPepe @nemesisdesign @aleksander0m 
Compile tested: x86_64, latest owrt-21.02
Run tested: no

Description:
Fix compilation for libqmi. Since merging of https://github.com/openwrt/packages/pull/19648 the libqmi does not build anymore. I got the following error.
`
SHELL= flock /home/feckert/workspace/openwrt/LDM-owrt-21.02/build/openwrt/tmp/.libqmi-1.30.8.tar.xz.flock -c '          /home/feckert/workspace/openwrt/LDM-owrt-21.02/build/openwrt/scripts/download.pl "/home/feckert/dl" "libqmi-1.30.8.tar.xz" "862482ce9e3ad0bd65d264334ee311cdb94b9df2863b5b7136309b41b8ac1990" "" "https://www.freedesktop.org/software/libqmi"
`
I already updated the HASH but then I got another error that `No rule to make target` !
Only the backport of the latest master changes fixes my issues.
If I am backporting the latest master changes for owrt-21.02 my build works again.