### PR TITLE
frp：add enable options

### DIFF
--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=frp
 PKG_VERSION:=0.45.0
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v${PKG_VERSION}?

--- a/net/frp/files/frpc.config
+++ b/net/frp/files/frpc.config
@@ -11,6 +11,7 @@ config init
 #	list conf_inc '/etc/frp/frpc.d/frpc_full.ini'
 
 config conf 'common'
+	option enabled '0'
 	option server_addr 127.0.0.1
 	option server_port 7000
 #	List options with name="_" will be directly appended to config file

--- a/net/frp/files/frpc.init
+++ b/net/frp/files/frpc.init
@@ -49,6 +49,10 @@ start_service() {
 	> "$conf_file"
 	config_load "$NAME"
 
+	local enabled
+		config_get_bool enabled "common" 'enabled' '0'
+		[ "$enabled" = "1" ] || return 1
+
 	local stdout stderr user group respawn env conf_inc
 	uci_validate_section "$NAME" init "$init_cfg" \
 		'stdout:bool:1' \

--- a/net/frp/files/frps.config
+++ b/net/frp/files/frps.config
@@ -11,6 +11,7 @@ config init
 #	list conf_inc '/etc/frp/frps.d/frps_full.ini'
 
 config conf 'common'
+	option enabled '0'
 	option bind_port 7000
 #	List options with name="_" will be directly appended to config file
 #	list _ '# Key-A=Value-A'

--- a/net/frp/files/frps.init
+++ b/net/frp/files/frps.init
@@ -47,6 +47,10 @@ start_service() {
 	> "$conf_file"
 	config_load "$NAME"
 
+	local enabled
+		config_get_bool enabled "common" 'enabled' '0'
+		[ "$enabled" = "1" ] || return 1
+
 	local stdout stderr user group respawn env conf_inc
 	uci_validate_section "$NAME" init "$init_cfg" \
 		'stdout:bool:1' \


### PR DESCRIPTION
Because luci-app-frpc and luci-app-frps do not have the enable option, you cannot control whether to enable or disable the plug-in.