### PR TITLE
frp：add enable options

### DIFF
--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=frp
 PKG_VERSION:=0.45.0
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v${PKG_VERSION}?


### PR DESCRIPTION
Because luci-app-frpc and luci-app-frps do not have the enable option, you cannot control whether to enable or disable the plug-in.