### PR TITLE
irqbalance: Managing the package status only on services

### DIFF
--- a/utils/irqbalance/Makefile
+++ b/utils/irqbalance/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=irqbalance
-PKG_VERSION:=1.9.3
+PKG_VERSION:=1.9.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git

--- a/utils/irqbalance/Makefile
+++ b/utils/irqbalance/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=irqbalance
-PKG_VERSION:=1.9.2
+PKG_VERSION:=1.9.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git

--- a/utils/irqbalance/files/irqbalance.config
+++ b/utils/irqbalance/files/irqbalance.config
@@ -1,5 +1,5 @@
 config irqbalance 'irqbalance'
-	option enabled '0'
+	option enabled '1'
 
 	# Level at which irqbalance partitions cache domains.
 	# Default is 2 (L2$).


### PR DESCRIPTION
Maintainer: @hnyman 
Compile tested: IPQ807x, Xiaomi AX9000, r21394-1d82c6b4e3
Run tested: IPQ807x, Xiaomi AX9000, r21394-1d82c6b4e3
Signed-off-by: Tiago Freire <redalert2004@gmail.com>


Description:
The ```as is``` package configuration leads to misleading managing, after its installation. The ```service``` command won't run unless you dig on the documentation to find this flag to be enabled priory the ```service```, under the configuration file.

The proposal is to manage the package status only under the ```services``` method, making the enable flag always ```true```.