### PR TITLE
snort3: update to 3.1.48.0-1

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
-PKG_VERSION:=3.1.47.0
+PKG_VERSION:=3.1.48.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
-PKG_HASH:=7565411db11b453a98f8bd88eeef0fa9f2e85416a8f595e710aa19c430228b8c
+PKG_HASH:=65df088a8cac11e59f0b71a7f98fc9d21eeb0e31d35280c470c985172947ebfe
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=GPL-2.0-only

--- a/net/snort3/patches/900-fix_build_for_archs_contain_plus.patch
+++ b/net/snort3/patches/900-fix_build_for_archs_contain_plus.patch
@@ -1,0 +1,16 @@
+--- a/cmake/FindFlexLexer.cmake
++++ b/cmake/FindFlexLexer.cmake
+@@ -16,11 +16,11 @@ macro(FLEX NAME LEXER_IN LEXER_OUT)
+         COMPILE_FLAGS ${FLEX_FLAGS}
+     )
+ 
+-    # we use '+' as a separator for 'sed' to avoid conflicts with '/' in paths from LEXER_OUT
++    # we use '|' as a separator for 'sed' to avoid conflicts with '/' in paths from LEXER_OUT
+     add_custom_command(
+         OUTPUT ${LEXER_OUT}
+         COMMAND sed -e
+-            "s+void yyFlexLexer::LexerError+yynoreturn void yyFlexLexer::LexerError+;s+${LEXER_OUT}.tmp+${LEXER_OUT}+"
++            "s|void yyFlexLexer::LexerError|yynoreturn void yyFlexLexer::LexerError|;s|${LEXER_OUT}.tmp|${LEXER_OUT}|"
+             ${FLEX_${NAME}_OUTPUTS} > ${LEXER_OUT}
+         DEPENDS ${FLEX_${NAME}_OUTPUTS}
+         VERBATIM


### PR DESCRIPTION
Build system: x86_64
Build-tested: bcm2711/RPi4B
Run-tested: bcm2711/RPi4B

Signed-off-by: John Audia <therealgraysky@proton.me>

Maintainer: @flyn-org 

This should be merged before https://github.com/openwrt/packages/pull/19989