### PR TITLE
safe-search: fix use with dnsmasq in ujail

### DIFF
--- a/net/safe-search/Makefile
+++ b/net/safe-search/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=safe-search
 PKG_VERSION:=2.0.1
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=11
 PKG_LICENSE:=MIT
 PKG_MAINTAINER:=Gregory L. Dietsche <Gregory.Dietsche@cuw.edu>
 

--- a/net/safe-search/files/safe-search.defaults
+++ b/net/safe-search/files/safe-search.defaults
@@ -5,6 +5,8 @@
 #
 uci del_list dhcp.@dnsmasq[0].addnhosts=/etc/safe-search/enabled
 uci add_list dhcp.@dnsmasq[0].addnhosts=/etc/safe-search/enabled
+uci del_list dhcp.@dnsmasq[0].addn_mount=/etc/safe-search/available
+uci add_list dhcp.@dnsmasq[0].addn_mount=/etc/safe-search/available
 uci commit dhcp
 
 /usr/sbin/safe-search-maintenance


### PR DESCRIPTION
Maintainer: @farmergreg
Compile tested: none
Run tested: none

Description:
The safe-search package creates symlinks in a configured additional hosts directory. The link targets are inside another directory which has to be made available to dnsmasq as well.
Now that support for adding additional paths to dnsmasq was added by commit openwrt/openwrt@aa12a0fdd1c5a004281633c5b0758da1781bb41c implement adding this path using the existing uci-defaults script.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>
