### PR TITLE
bpfcountd: remove incomplete/broken namespace feature

### DIFF
--- a/net/bpfcountd/files/etc/init.d/bpfcountd
+++ b/net/bpfcountd/files/etc/init.d/bpfcountd
@@ -10,7 +10,6 @@ UNIXSOCKDIR=/var/run/bpfcountd
 
 bpfcountd_start() {
 	local cfg="$1"
-	local namespace="$2"
 	local disabled
 
 	local ifname
@@ -37,14 +36,12 @@ bpfcountd_start() {
 		return 0
 	}
 
-	[ -z "$namespace" ] && namespace="bpfcountd"
-
-	procd_open_instance "$namespace.$cfg"
+	procd_open_instance "$cfg"
 
 	procd_set_param command /usr/sbin/bpfcountd
 	procd_append_param command -i "$ifname"
 	procd_append_param command -f "$filterfile"
-	procd_append_param command -u $UNIXSOCKDIR/"$namespace.$cfg".sock
+	procd_append_param command -u $UNIXSOCKDIR/"$cfg".sock
 	[ -n "$prefilter" ] && procd_append_param command -F "$prefilter"
 	[ -n "$buffersize" ] && procd_append_param command -b "$buffersize"
 
@@ -56,7 +53,6 @@ bpfcountd_start() {
 
 start_service() {
 	local cfg="$1"
-	local namespace="$2"
 	local instance_found=0
 
 	. /lib/functions/network.sh
@@ -75,22 +71,19 @@ start_service() {
 
 	if [ -n "$cfg" ]; then
 		[ "$instance_found" -gt 0 ] || return
-		bpfcountd_start "$cfg" "$namespace"
+		bpfcountd_start "$cfg"
 	else
-		config_foreach bpfcountd_start bpfcountd "$namespace"
+		config_foreach bpfcountd_start bpfcountd
 	fi
 }
 
 stop_service() {
 	local cfg="$1"
-	local namespace="$2"
-
-	[ -z "$namespace" ] && namespace="bpfcountd"
 
 	if [ -n "$cfg" ]; then
-		rm $UNIXSOCKDIR/$namespace.$cfg.sock
+		rm $UNIXSOCKDIR/$cfg.sock
 	else
-		rm $UNIXSOCKDIR/$namespace.*.sock
+		rm $UNIXSOCKDIR/*.sock
 	fi
 }
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86-generic
Run tested: KVM / qemu-standard-pc-i440fx-piix-1996

Description:

The original idea of the extra namespace variable was to set up bpfcountd from other daemons etc. independent of what a user configured in /etc/config/bpfcountd for instance. Like:

```
 $ UCI_CONFIG_DIR=/var/run/bpfcountd/gluon-config \
   /etc/init.d/bpfcountd start "" gluon
```

However there are still issues with this approach:

1) Instance specific stop calls like:

```
 $ /etc/init.d/bpfcountd stop <instance-name> <namespace>"
```

will not  stop the according namespaced instance, as the stop() in /etc/rc.common will call procd_kill() without the namespace prefix. And we can't overwrite that behaviour. And asking a user to use "... start \<in\> \<ns\>" and "... stop \<ns\>.\<in\>" is confusing. (and currently "... stop \<ns\>.\<in\>" would not remove the correct unix socket).

2) A stop call without an instance/config name would always stop all instances. So the namespace variable would be ignored. While start without an instance "works", but:

3) It would stop any process that is not in the currently selected UCI_CONFIG_DIR.

As all this is not easily fixable without changing OpenWrt internals, just remove the whole namespace idea for now.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>