### PR TITLE
openssh: update to 9.1p1

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
-PKG_VERSION:=9.0p1
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=9.1p1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
 		https://ftp.spline.de/pub/OpenBSD/OpenSSH/portable/
-PKG_HASH:=03974302161e9ecce32153cfa10012f1e65c8f3750f573a73ab1befd5972a28a
+PKG_HASH:=19f85009c7e3e23787f0236fbb1578392ab4d4bf9f8ec5fe6bc1cd7e8bfdd288
 
 PKG_LICENSE:=BSD ISC
 PKG_LICENSE_FILES:=LICENCE


### PR DESCRIPTION
Maintainer: @tripolar
Compile tested: all architectures / master
Run tested: MIR4A / ramips / master

Server running and accepting connections
Client connecting to servers

Description:
Version bump to 9.1p1

Signed-off-by: Sibren Vasse <github@sibrenvasse.nl>