### PR TITLE
django: bump version 4.1.3

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=4.1.1
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=4.1.3
+PKG_RELEASE:=1
 
 PYPI_NAME:=Django
-PKG_HASH:=a153ffd5143bf26a877bfae2f4ec736ebd8924a46600ca089ad96b54a1d4e28e
+PKG_HASH:=678bbfc8604eb246ed54e2063f0765f13b321a50526bdc8cb1f943eda7fa31f1
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Peter Stadler <peter.stadler@student.uibk.ac.at>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: @commodo and me
Compile tested: x86_64, qemu, master snapshot
Run tested: x86_64, qemu, master snapshot, serve etebase

Description: fix CVE-2022-41323
