### PR TITLE
natmap: merge "ipv4" and "ipv6" options into single "family" option

### DIFF
--- a/net/natmap/files/natmap.config
+++ b/net/natmap/files/natmap.config
@@ -1,7 +1,6 @@
 config natmap
 	option enable '0'
-	option ipv4 '0'
-	option ipv6 '0'
+	option family ''
 	option udp_mode '1'
 	option interface ''
 	option interval ''

--- a/net/natmap/files/natmap.init
+++ b/net/natmap/files/natmap.init
@@ -18,8 +18,7 @@ load_interfaces() {
 validate_section_natmap() {
 	uci_load_validate "${NAME}" natmap "$1" "$2" \
 		'enable:bool:1' \
-		'ipv4:bool:0' \
-		'ipv6:bool:0' \
+		'family:string' \
 		'udp_mode:bool:0' \
 		'interface:string' \
 		'interval:uinteger' \
@@ -44,8 +43,8 @@ natmap_instance() {
 		${stun_server:+-s "$stun_server"} \
 		${http_server:+-h "$http_server"}
 
-	[ "${ipv4}" = 1 ] && procd_append_param command -4
-	[ "${ipv6}" = 1 ] && procd_append_param command -6
+	[ "${family}" = ipv4 ] && procd_append_param command -4
+	[ "${family}" = ipv6 ] && procd_append_param command -6
 	[ "${udp_mode}" = 1 ] && procd_append_param command -u
 
 	[ -n "$interface" ] && {


### PR DESCRIPTION
Maintainer: me
Compile tested: x86-64, 22.03.2
Run tested: x86-64, 22.03.2

Description:
When writing luci app, I found that `ipv4` and `ipv6` options should be merged into single option, for better user experience. Sorry for my mistake.
This PR should be backported to 22.03.2.