### PR TITLE
zoneinfo: updated to the latest release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2022f
+PKG_VERSION:=2022g
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=9990d71f675d212567b931fe8aae1cab7027f89fefb8a79d808a6933a67af000
+PKG_HASH:=4491db8281ae94a84d939e427bdd83dc389f26764d27d9a5c52d782c16764478
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=e4543e90f84f91fa82809ea98930052fdbc13880c8a623ee3a4eaa42f8a64c15
+   HASH:=9610bb0b9656ff404c361a41f3286da53064b5469d84f00c9cb2314c8614da74
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT master
Run tested: n/a

Description:

   Briefly:

     The northern edge of Chihuahua changes to US timekeeping.
     Much of Greenland stops changing clocks after March 2023.
     Fix some pre-1996 timestamps in northern Canada.
     C89 is now deprecated; please use C99 or later.
     Portability fixes for AIX, libintl, MS-Windows, musl, z/OS
     In C code, use more C23 features if available.
     C23 timegm now supported by default
     Fixes for unlikely integer overflows

   Changes to future timestamps

     In the Mexican state of Chihuahua, the border strip near the US
     will change to agree with nearby US locations on 2022-11-30.
     The strip's western part, represented by Ciudad Ju?rez, switches
     from -06 all year to -07/-06 with US DST rules, like El Paso, TX.
     The eastern part, represented by Ojinaga, will observe US DST next
     year, like Presidio, TX.  (Thanks to Heitor David Pinto.)
     A new Zone America/Ciudad_Juarez splits from America/Ojinaga.

     Much of Greenland, represented by America/Nuuk, stops observing
     winter time after March 2023, so its daylight saving time becomes
     standard time.  (Thanks to Jonas Nyrup and J?rgen Appel.)

   Changes to past timestamps

     Changes for pre-1996 northern Canada (thanks to Chris Walton):

       Merge America/Iqaluit and America/Pangnirtung into the former,
       with a backward compatibility link for the latter name.
       There is no good evidence the two locations differ since 1970.
       This change affects pre-1996 America/Pangnirtung timestamps.

       Cambridge Bay, Inuvik, Iqaluit, Rankin Inlet, Resolute and
       Yellowknife did not observe DST in 1965, and did observe DST
       from 1972 through 1979.

       Whitehorse moved from -09 to -08 on 1966-02-27, not 1967-05-28.

     Colombia's 1993 fallback was 02-06 24:00, not 04-04 00:00.
     (Thanks to Alois Treindl.)

     Singapore's 1981-12-31 change was at 16:00 UTC (23:30 local time),
     not 24:00 local time.  (Thanks to Geoff Clare via Robert Elz.)

   Changes to code

     Although tzcode still works with C89, bugs found in recent routine
     maintenance indicate that bitrot has set in and that in practice
     C89 is no longer used to build tzcode.  As it is a maintenance
     burden, support for C89 is planned to be removed soon.  Instead,
     please use compilers compatible with C99, C11, C17, or C23.

     timegm, which tzcode implemented in 1989, will finally be
     standardized 34 years later as part of C23, so timegm is now
     supported even if STD_INSPIRED is not defined.

     Fix bug in zdump's tzalloc emulation on hosts that lack tm_zone.
     (Problem reported by ?o?n Tr?n C?ng Danh.)

     Fix bug in zic on hosts where malloc(0) yields NULL on success.
     (Problem reported by Tim McBrayer for AIX 6.1.)

     Fix zic configuration to avoid linkage failures on some platforms.
     (Problems reported by Gilmore Davidson and Igor Ivanov.)

     Work around MS-Windows nmake incompatibility with POSIX.
     (Problem reported by Manuela Friedrich.)

     Port mktime and strftime to debugging platforms where accessing
     uninitialized data has undefined behavior (strftime problem
     reported by Robert Elz).

     Check more carefully for unlikely integer overflows, preferring
     C23 <stdckdint.h> to overflow checking by hand, as the latter has
     had obscure bugs.

   Changes to build procedure

     New Makefile rule check_mild that skips checking whether Link
     lines are in the file 'backward'.  (Inspired by a suggestion from
     Stephen Colebourne.)

