### PR TITLE
perl: enable threading support for aarch64 by default

### DIFF
--- a/lang/perl/Config.in
+++ b/lang/perl/Config.in
@@ -3,7 +3,7 @@ menu "Configuration"
 
 config PERL_THREADS
     bool "Enable threading support"
-    default y if (mips || mipsel || i386 || i686 || x86_64 || armeb || arm)
+    default y if (mips || mipsel || i386 || i686 || x86_64 || armeb || arm || aarch64)
     default n
 
 config PERL_TESTS


### PR DESCRIPTION
Perl threads seem to be supported and working for aarch64, and including aarch64 here would allow packages like freeswitch-mod-perl to become available from the standard OpwnWrt package repository for popular routers such as the Linksys E8450 and Belkin RT3200.

Signed-off-by: Doug Thomson <dwt62f+github@gmail.com>

Maintainer: @pprindeville
Compile tested:  aarch64_cortex-a53, OpenWrt 22.03.2
Run tested: Linksys E8540 (Mediatek  mt7622), OpenWrt 22.03.2

Description:
When I set up my new Linksys E8450 router I was puzzled to find that I could not install the freeswitch-mod-perl package - it simply does not exist in the repository. Tracing this back (thanks to @micmac1), it turns out that mod-perl requires Perl threads, and that the Perl threads option defaults to disabled for the aarch64 architecture.

The Linksys E8450 uses a Mediatek  mt7622, which has an Arm Cortex-A53 processor, and as far as I can see it supports Perl threads perfectly well. It certainly works well enough to allow my router to run some Perl code from freeswitch-mod-perl.

It would be greatly appreciated by me, and I am sure many other users, if Perl threads could be enabled by default on this architecture!