### PR TITLE
[22.03] lxc-auto: made init script compatible with image builder

### DIFF
--- a/utils/lxc/files/lxc-auto.init
+++ b/utils/lxc/files/lxc-auto.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 
-. /lib/functions.sh
+. "${IPKG_INSTROOT}"/lib/functions.sh
 
 START=99
 STOP=00


### PR DESCRIPTION
Maintainer: @ratkaj @BKPepe

A back port of https://github.com/openwrt/packages/pull/19316 

Fixes this message from image builder:
```
Finalizing root filesystem...
/build/openwrt-imagebuilder/build_dir/target-x86_64_musl/root-x86/etc/init.d/lxc-auto: line 3: /lib/functions.sh: No such file or directory
Enabling boot
Enabling cgroupfs-mount
Enabling collectd
Closes https://github.com/openwrt/packages/issues/19292
```

Signed-off-by: Marc Benoit [marcb62185@gmail.com](mailto:marcb62185@gmail.com)