### PR TITLE
prometheus-node-exporter-lua: add thermal zone exporter

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2022.08.08
+PKG_VERSION:=2022.12.11
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
@@ -34,17 +34,18 @@ define Package/prometheus-node-exporter-lua/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) ./files/usr/bin/prometheus-node-exporter-lua $(1)/usr/bin/prometheus-node-exporter-lua
 	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/cpu.lua         $(1)/usr/lib/lua/prometheus-collectors/
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/conntrack.lua   $(1)/usr/lib/lua/prometheus-collectors/
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/entropy.lua     $(1)/usr/lib/lua/prometheus-collectors/
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/filefd.lua      $(1)/usr/lib/lua/prometheus-collectors/
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/loadavg.lua     $(1)/usr/lib/lua/prometheus-collectors/
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/meminfo.lua     $(1)/usr/lib/lua/prometheus-collectors/
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/netdev.lua      $(1)/usr/lib/lua/prometheus-collectors/
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/selinux.lua     $(1)/usr/lib/lua/prometheus-collectors/
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/time.lua        $(1)/usr/lib/lua/prometheus-collectors/
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/uname.lua       $(1)/usr/lib/lua/prometheus-collectors/
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/netclass.lua    $(1)/usr/lib/lua/prometheus-collectors/
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/cpu.lua           $(1)/usr/lib/lua/prometheus-collectors/
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/conntrack.lua     $(1)/usr/lib/lua/prometheus-collectors/
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/entropy.lua       $(1)/usr/lib/lua/prometheus-collectors/
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/filefd.lua        $(1)/usr/lib/lua/prometheus-collectors/
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/loadavg.lua       $(1)/usr/lib/lua/prometheus-collectors/
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/meminfo.lua       $(1)/usr/lib/lua/prometheus-collectors/
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/netdev.lua        $(1)/usr/lib/lua/prometheus-collectors/
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/selinux.lua       $(1)/usr/lib/lua/prometheus-collectors/
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/time.lua          $(1)/usr/lib/lua/prometheus-collectors/
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/uname.lua         $(1)/usr/lib/lua/prometheus-collectors/
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/netclass.lua      $(1)/usr/lib/lua/prometheus-collectors/
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/thermal_zone.lua  $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
 define Package/prometheus-node-exporter-lua/conffiles

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/thermal_zone.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/thermal_zone.lua
@@ -1,0 +1,13 @@
+local fs = require "nixio.fs"
+
+local function scrape()
+  for zone in fs.glob("/sys/class/thermal/thermal_zone[0-9]*") do
+    local temp = string.gsub(get_contents(zone .. "/temp"), "[\n|\r]", "")
+    local s_type = string.gsub(get_contents(zone .. "/type"), "[\n\r]", "")
+    local name = string.match(fs.basename(zone), "thermal_zone(.+)")
+
+    metric("node_thermal_zone_temp", "gauge", {name=name, type=s_type}, temp / 1000.0)
+  end
+end
+
+return { scrape = scrape }


### PR DESCRIPTION
Maintainer: @champtar 
Compile tested: Ubuntu 22.04 x64
Run tested: nanopi-r2s(OpenWrt 21.02.3)

Description: 
Adding thermal zone exporter to monitor temperature of device:
```shell
# TYPE node_thermal_zone_temp gauge
node_thermal_zone_temp{name="0",type="soc-thermal"} 49.09
node_scrape_collector_duration_seconds{collector="thermal_zone"} 0.00050687789916992
node_scrape_collector_success{collector="thermal_zone"} 1
```
<img width="996" alt="image" src="https://user-images.githubusercontent.com/6239652/206907967-3f255821-01db-4c23-8330-3efc9262b593.png">

---

Official node exporter implementation: 
- https://github.com/prometheus/node_exporter/blob/master/collector/thermal_zone_linux.go
- https://github.com/prometheus/procfs/blob/master/sysfs/class_thermal.go#L42