### PR TITLE
Update tailscale to 1.34

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.32.3
+PKG_VERSION:=1.34.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=tailscale-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=4cf88a1d754240ce71b29d3a65ca480091ad9c614ac99c541cef6fdaf0585dd4
+PKG_HASH:=0311c76e3013a729e8234a89c138b9e4d79d0e559ca6bc58ac921c4838e27403
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Signed-off-by: jwischka <jeff@wisch.org>

Maintainer: Jan Pavlinec <jan.pavlinec1@gmail.com> (find it by checking history of the package Makefile)
Compile tested: 22.03, mvebu, ipq40xx, mt762x/1
Run tested: Multiple devices, tested builds and functionality.

Description:
