### PR TITLE
pbr: detect missing iptables

### DIFF
--- a/net/pbr/Makefile
+++ b/net/pbr/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 

--- a/net/pbr/files/etc/init.d/pbr.init
+++ b/net/pbr/files/etc/init.d/pbr.init
@@ -109,6 +109,7 @@ get_text() {
 	case "$1" in
 		errorConfigValidation) r="Config ($packageConfigFile) validation failure!";;
 		errorNoIpFull) r="ip-full binary cannot be found!";;
+		errorNoIptables) r="iptables binary cannot be found!";;
 		errorNoIpset) r="Resolver set support (${resolver_set}) requires ipset, but ipset binary cannot be found!";;
 		errorNoNft) r="Resolver set support (${resolver_set}) requires nftables, but nft binary cannot be found!";;
 		errorResolverNotSupported) r="Resolver set (${resolver_set}) is not supported on this system!";;
@@ -335,6 +336,12 @@ load_environment() {
 		if [ ! -x "$ip_full" ]; then
 			state add 'errorSummary' 'errorNoIpFull'
 			return 1
+		fi
+		if ! is_nft; then
+			if [ -z "$iptables" ] || [ ! -x "$iptables" ]; then
+				state add 'errorSummary' 'errorNoIptables'
+				return 1
+			fi
 		fi
 		resolver 'check_support'
 	fi


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-135, OpenWrt 22.03.2
Run tested: x86_64, Sophos SG-135, OpenWrt 22.03.2, install/start

Signed-off-by: Stan Grishin <stangri@melmac.ca>
