### PR TITLE
ruby: update to 3.1.3

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,15 +11,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=3.1.2
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=3.1.3
+PKG_RELEASE:=1
 
 # First two numbes
 PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VERSION))))
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=ca10d017f8a1b6d247556622c841fc56b90c03b1803f87198da1e4fd3ec3bf2a
+PKG_HASH:=4ee161939826bcdfdafa757cf8e293a7f14e357f62be7144f040335cc8c7371a
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING

--- a/lang/ruby/patches/001-fix-build-with-libressl-3.5.patch
+++ b/lang/ruby/patches/001-fix-build-with-libressl-3.5.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Fix build with LibreSSL 3.5
 
 --- a/ext/openssl/ossl_pkey.c
 +++ b/ext/openssl/ossl_pkey.c
-@@ -670,7 +670,7 @@ ossl_pkey_export_traditional(int argc, V
+@@ -710,7 +710,7 @@ ossl_pkey_export_traditional(int argc, V
  	}
      }
      else {


### PR DESCRIPTION
This release includes a security fix.

- CVE-2021-33621: HTTP response splitting in CGI

For more details:
- https://www.ruby-lang.org/en/news/2022/11/24/ruby-3-1-3-released/

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>