### PR TITLE
knot: update to version 3.2.4

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.2.3
+PKG_VERSION:=3.2.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=f736ef284358923e312f8e1e3c6ce7c97b20965b09eb65705e9f7e3d5e9a9d79
+PKG_HASH:=299e8de918f9fc7ecbe625b41cb085e47cdda542612efbd51cd5ec60deb9dd13
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 6.0 (hbk)
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 6.0 (hbk)

Description:

- Release upgrade (https://www.knot-dns.cz/2022-12-12-version-324.html)