### PR TITLE
simple-adblock: bugfix: add dnsmasq.nftset to uci_load_validate

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.9.3
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -1510,7 +1510,7 @@ load_validate_config() {
 		'verbosity:range(0,2):2' \
 		'procd_trigger_wan6:bool:0' \
 		'led:or("", "none", file, device, string)' \
-		'dns:or("dnsmasq.addnhosts", "dnsmasq.conf", "dnsmasq.ipset", "dnsmasq.servers", "unbound.adb_list"):dnsmasq.servers' \
+		'dns:or("dnsmasq.addnhosts", "dnsmasq.conf", "dnsmasq.ipset", "dnsmasq.nftset", "dnsmasq.servers", "unbound.adb_list"):dnsmasq.servers' \
 		'dns_instance:or(list(integer, string)):0' \
 		'allowed_domain:list(string)' \
 		'allowed_domains_url:list(string)' \


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-135, OpenWrt 22.03.2
Run tested:  x86_64, Sophos SG-135, OpenWrt 22.03.2, install, start with dnsmasq.nftset option.

Description:
* fixes https://github.com/openwrt/openwrt/issues/11481 thanks to:
* https://github.com/mistepien for reporting
* https://github.com/dave14305 for diagnosing

Signed-off-by: Stan Grishin <stangri@melmac.ca>
