### PR TITLE
bluez: avoid hcidump out-of-boundary array access

### DIFF
--- a/utils/bluez/patches/301-hcidump-crash-fix.patch
+++ b/utils/bluez/patches/301-hcidump-crash-fix.patch
@@ -1,0 +1,20 @@
+Index: bluez-5.49/tools/parser/hci.c
+===================================================================
+--- bluez-5.49.orig/tools/parser/hci.c
++++ bluez-5.49/tools/parser/hci.c
+@@ -3667,7 +3667,14 @@ static inline void le_meta_ev_dump(int l
+ 	frm->len -= EVT_LE_META_EVENT_SIZE;
+ 
+ 	p_indent(level, frm);
+-	printf("%s\n", ev_le_meta_str[subevent]);
++	if ( subevent >= 0 && subevent <= LE_EV_NUM )
++	{
++		printf("%s\n", ev_le_meta_str[subevent]);
++	}
++	else
++	{
++		printf("Undefined--> %d\n", subevent);
++	}
+ 
+ 	switch (mevt->subevent) {
+ 	case EVT_LE_CONN_COMPLETE:


### PR DESCRIPTION
- add index range check for array ev_le_meta_str in le_meta_ev_dump()

Signed-off-by: Jing Qian <jqian@calamp.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
