### PR TITLE
miniflux: update to 2.0.41

### DIFF
--- a/utils/miniflux/Makefile
+++ b/utils/miniflux/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniflux
-PKG_VERSION:=2.0.38
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=2.0.41
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/miniflux/v2/tar.gz/${PKG_VERSION}?
-PKG_HASH:=8c2e35a91d9b47a0879bcee4c23f342375293e97cee9639bb44b359b21e14d2a
+PKG_HASH:=01e150ebfba12c8b5ca7c1d9d5a5976d018081cafc11228d6f77a48ac3333e1b
 
 PKG_MAINTAINER:=Michal Vasilek <michal.vasilek@nic.cz>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: armv7, Turris Omnia, OpenWrt 21.02
Run tested: armv7, Turris Omnia, OpenWrt 21.02
