### PR TITLE
acme: Export the canonical paths for certificates and challenges

### DIFF
--- a/net/acme-acmesh/Makefile
+++ b/net/acme-acmesh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-acmesh
 PKG_VERSION:=3.0.1
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/acmesh-official/acme.sh/tar.gz/$(PKG_VERSION)?

--- a/net/acme-acmesh/files/hook.sh
+++ b/net/acme-acmesh/files/hook.sh
@@ -20,6 +20,7 @@ link_certs()
     domain_dir="$1"
     main_domain="$2"
 
+    (umask 077; cat "$domain_dir/fullchain.cer" "$domain_dir/$main_domain.key" > "$domain_dir/combined.cer")
 
     if [ ! -e "$CERT_DIR/$main_domain.crt" ]; then
 		ln -s "$domain_dir/$main_domain.cer" "$CERT_DIR/$main_domain.crt"
@@ -29,6 +30,9 @@ link_certs()
     fi
     if [ ! -e "$CERT_DIR/$main_domain.fullchain.crt" ]; then
 		ln -s "$domain_dir/fullchain.cer" "$CERT_DIR/$main_domain.fullchain.crt"
+    fi
+    if [ ! -e "$CERT_DIR/$main_domain.combined.crt" ]; then
+		ln -s "$domain_dir/combined.cer" "$CERT_DIR/$main_domain.combined.crt"
     fi
     if [ ! -e "$CERT_DIR/$main_domain.chain.crt" ]; then
 		ln -s "$domain_dir/ca.cer" "$CERT_DIR/$main_domain.chain.crt"

--- a/net/acme-acmesh/files/hook.sh
+++ b/net/acme-acmesh/files/hook.sh
@@ -2,8 +2,8 @@
 set -u
 ACME=/usr/lib/acme/client/acme.sh
 LOG_TAG=acme-acmesh
-# webroot option deprecated, use the hardcoded value directly in the next major version
-WEBROOT=${webroot:-$challenge_dir}
+# webroot option deprecated, use the exported value directly in the next major version
+WEBROOT=${webroot:-$CHALLENGE_DIR}
 NOTIFY=/usr/lib/acme/notify
 
 # shellcheck source=net/acme/files/functions.sh
@@ -12,6 +12,28 @@ NOTIFY=/usr/lib/acme/notify
 # Needed by acme.sh
 export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 export NO_TIMESTAMP=1
+
+link_certs()
+{
+    local main_domain
+    local domain_dir
+    domain_dir="$1"
+    main_domain="$2"
+
+
+    if [ ! -e "$CERT_DIR/$main_domain.crt" ]; then
+		ln -s "$domain_dir/$main_domain.cer" "$CERT_DIR/$main_domain.crt"
+    fi
+    if [ ! -e "$CERT_DIR/$main_domain.key" ]; then
+		ln -s "$domain_dir/$main_domain.key" "$CERT_DIR/$main_domain.key"
+    fi
+    if [ ! -e "$CERT_DIR/$main_domain.fullchain.crt" ]; then
+		ln -s "$domain_dir/fullchain.cer" "$CERT_DIR/$main_domain.fullchain.crt"
+    fi
+    if [ ! -e "$CERT_DIR/$main_domain.chain.crt" ]; then
+		ln -s "$domain_dir/ca.cer" "$CERT_DIR/$main_domain.chain.crt"
+    fi
+}
 
 case $1 in
 get)
@@ -45,20 +67,7 @@ get)
 
 			case $status in
 			0)
-				mkdir -p /etc/ssl/acme
-				if [ ! -e "/etc/ssl/acme/$main_domain.crt" ]; then
-					ln -s "$domain_dir/$main_domain.cer" "/etc/ssl/acme/$main_domain.crt"
-				fi
-				if [ ! -e "/etc/ssl/acme/$main_domain.key" ]; then
-					ln -s "$domain_dir/$main_domain.key" "/etc/ssl/acme/$main_domain.key"
-				fi
-				if [ ! -e "/etc/ssl/acme/$main_domain.fullchain.crt" ]; then
-					ln -s "$domain_dir/fullchain.cer" "/etc/ssl/acme/$main_domain.fullchain.crt"
-				fi
-				if [ ! -e "/etc/ssl/acme/$main_domain.chain.crt" ]; then
-					ln -s "$domain_dir/ca.cer" "/etc/ssl/acme/$main_domain.chain.crt"
-				fi
-
+                                link_certs "$domain_dir" "$main_domain"
 				$NOTIFY renewed
 				exit
 				;;
@@ -124,10 +133,7 @@ get)
 
 	case $status in
 	0)
-		ln -s "$domain_dir/$main_domain.cer" "/etc/ssl/acme/$main_domain.crt"
-		ln -s "$domain_dir/$main_domain.key" "/etc/ssl/acme/$main_domain.key"
-		ln -s "$domain_dir/fullchain.cer" "/etc/ssl/acme/$main_domain.fullchain.crt"
-		ln -s "$domain_dir/ca.cer" "/etc/ssl/acme/$main_domain.chain.crt"
+                link_certs "$domain_dir" "$main_domain"
 		$NOTIFY issued
 		;;
 	*)

--- a/net/acme-common/files/acme.sh
+++ b/net/acme-common/files/acme.sh
@@ -9,7 +9,8 @@
 # Authors: Toke Høiland-Jørgensen <toke@toke.dk>
 
 run_dir=/var/run/acme
-export challenge_dir=$run_dir/challenge
+export CHALLENGE_DIR=$run_dir/challenge
+export CERT_DIR=/etc/ssl/acme
 NFT_HANDLE=
 HOOK=/usr/lib/acme/hook
 LOG_TAG=acme
@@ -63,7 +64,7 @@ load_options() {
 	config_get webroot "$section" webroot
 	export webroot
 	if [ "$webroot" ]; then
-		log warn "Option \"webroot\" is deprecated, please remove it and change your web server's config so it serves ACME challenge requests from $challenge_dir."
+		log warn "Option \"webroot\" is deprecated, please remove it and change your web server's config so it serves ACME challenge requests from $CHALLENGE_DIR."
 	fi
 }
 
@@ -79,7 +80,7 @@ get_cert() {
 
 	load_options "$section"
 	if [ -z "$dns" ] && [ "$standalone" = 0 ]; then
-		mkdir -p "$challenge_dir"
+		mkdir -p "$CHALLENGE_DIR"
 	fi
 
 	if [ "$standalone" = 1 ] && [ -z "$NFT_HANDLE" ]; then
@@ -109,7 +110,7 @@ load_globals() {
 
 	config_get state_dir "$section" state_dir
 	if [ "$state_dir" ]; then
-		log warn "Option \"state_dir\" is deprecated, please remove it. Certificates now exist in /etc/ssl/acme."
+		log warn "Option \"state_dir\" is deprecated, please remove it. Certificates now exist in $CERT_DIR."
 		mkdir -p "$state_dir"
 	else
 		state_dir=/etc/acme

--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
 PKG_VERSION:=2.6.6
-PKG_RELEASE:=103
+PKG_RELEASE:=104
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/2.6/src
@@ -122,8 +122,6 @@ define Package/haproxy/install
 	$(INSTALL_CONF) ./files/haproxy.cfg $(1)/etc/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/haproxy.init $(1)/etc/init.d/haproxy
-	$(INSTALL_DIR) $(1)/etc/hotplug.d/acme
-	$(INSTALL_DATA) ./files/acme.hotplug $(1)/etc/hotplug.d/acme/00-haproxy
 endef
 
 Package/haproxy-nossl/install = $(Package/haproxy/install)

--- a/net/haproxy/files/acme.hotplug
+++ b/net/haproxy/files/acme.hotplug
@@ -1,8 +1,0 @@
-case $ACTION in
-issued|renewed)
-	cat \
-		"/etc/ssl/acme/$main_domain.fullchain.crt" \
-		"/etc/ssl/acme/$main_domain.key" \
-		>"/etc/ssl/acme/$main_domain.combined.crt"
-	;;
-esac


### PR DESCRIPTION
This adds an export of the canonical paths for certificates and challenges so
the contract for consumers becomes explicit. Also contains a couple of cleanups
to make use of those exports in the hook scripts.

Cc @hgl