### PR TITLE
gsocket: upstream update to 1.4.39

### DIFF
--- a/net/gsocket/Makefile
+++ b/net/gsocket/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gsocket
-PKG_VERSION:=1.4.37
+PKG_VERSION:=1.4.39
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/hackerschoice/gsocket/releases/download/v$(PKG_VERSION)/
-PKG_HASH:=4f64f71a7d6b8be79754e7bf2109675ffc8a3e37a4a55b08c95a1b1d25e458e5
+PKG_HASH:=2042b3773e03285939fe7f0d0597a77c8d4958644b1d8a366cc71d384f1e5c30
 
 PKG_MAINTAINER:=Ralf Kaiser <skyper@thc.org>
 PKG_LICENSE:=BSD-2-Clause
@@ -71,3 +71,4 @@ define Package/gsocket/install
 endef
 
 $(eval $(call BuildPackage,gsocket))
+


### PR DESCRIPTION
Signed-off-by: Ralf Kaiser <skyper@thc.org>

Maintainer: Ralf Kaiser @SkyperTHC
Compile tested: mips_24kc, Openwrt 22.03.0-rc4
Run tested: mips_24kc

Description:
  Global Socket allows two workstations on different private networks to
  communicate with each other. Through firewalls and through NAT - like
  there is no firewall.

  The TCP connection is secured with AES-256 and using OpenSSL's SRP
  protocol (RFC 5054). It does not require a PKI and has forward
  secrecy and (optional) TOR support.

  The gsocket tools derive temporary session keys and IDs and connect
  two TCP pipes through the Global Socket Relay Network (GSRN). This is
  done regardless and independent of the local IP Address or geographical
  location.

  The session keys (secrets) never leave the workstation. The GSRN sees only
  the encrypted traffic.

  The workhorse is 'gs-netcat' which opens a ssh-like interactive PTY
  command shell to a remote workstation (which resides on a private and
  remote network and/or behind a firewall).