### PR TITLE
dosfstools: fix PKG_SOURCE

### DIFF
--- a/utils/dosfstools/Makefile
+++ b/utils/dosfstools/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dosfstools
 PKG_VERSION:=4.2
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=4
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/dosfstools/dosfstools/releases/download/v$(PKG_VERSION)/ \
 		http://fossies.org/linux/misc
-PKG_HASH:=ba7c716ff9b8208a3bba5094a77584a7dc814141de09ab4ce1ae9b84bbcd7844
+PKG_HASH:=64926eebf90092dca21b14259a5301b7b98e7b1943e8a201c7d726084809b527
 
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
Maintainer: @Noltari 
Compile tested: NA
Run tested: NA

Description:
Both mirrors provided in the Makefile only serve gzipped tarballs.