### PR TITLE
apr-util: disable parallel build

### DIFF
--- a/libs/apr-util/Makefile
+++ b/libs/apr-util/Makefile
@@ -21,8 +21,6 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_CPE_ID:=cpe:/a:apache:apr-util
 
-PKG_BUILD_PARALLEL:=1
-
 PKG_CONFIG_DEPENDS := \
 	CONFIG_PACKAGE_libaprutil-crypto-openssl \
 	CONFIG_PACKAGE_libaprutil-dbd-mysql \


### PR DESCRIPTION
Maintainer: Thomas Heil, but I can't find a github nickname and it seems like they are not active in OpenWrt since 2018
Compile tested: armv7, Turris Omnia, OpenWrt master
Run tested: no

Description: Build reliably fails with -j20 for me with OpenWrt master and Debian 11, it works with -j1. It seems like this was also reported [here](https://github.com/openwrt/packages/issues/17669#issuecomment-1019166192)

```
/bin/bash /build/build/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/share/build-1/libtool --silent --mode=compile ccache_cc   -Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -mfloat-abi=hard -fmacro-prefix-map=/build/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/apr-1.7.0=apr-1.7.0 -Wformat -Werror=format-security -DPIC -fpic -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wl,-z,now -Wl,-z,relro  -DHAVE_CONFIG_H  -DLINUX -D_REENTRANT -D_GNU_SOURCE  -I/build/build/staging_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-11.3.0_musl_eabi/usr/include -I/build/build/staging_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-11.3.0_musl_eabi/include/fortify -I/build/build/staging_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-11.3.0_musl_eabi/include  -I/build/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/apr-util-1.6.1/include -I/build/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/apr-util-1.6.1/include/private -I/build/build/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/include -I/build/build/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/include/mysql/  -I/build/build/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/include/apr-1  -I/build/build/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/include -I/build/build/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/lib/libiconv-full/include  -o dbm/sdbm/sdbm_pair.lo -c dbm/sdbm/sdbm_pair.c && touch dbm/sdbm/sdbm_pair.lo
crypto/apr_passwd.c:200:1: fatal error: error closing -: Broken pipe
  200 | }
      | ^
compilation terminated.
make[4]: *** [/build/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/apr-util-1.6.1/build/rules.mk:206: crypto/apr_passwd.lo] Error 1
make[4]: *** Waiting for unfinished jobs....
crypto/apr_crypto.c:606:1: fatal error: error writing to -: Broken pipe
  606 | }
      | ^
compilation terminated.
make[4]: *** [/build/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/apr-util-1.6.1/build/rules.mk:206: crypto/apr_crypto.lo] Error 1
crypto/apr_md4.c:396:1: fatal error: error writing to -: Broken pipe
  396 | }
      | ^
compilation terminated.
make[4]: *** [/build/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/apr-util-1.6.1/build/rules.mk:206: crypto/apr_md4.lo] Error 1
crypto/apr_sha1.c:368:1: fatal error: error writing to -: Broken pipe
  368 | }
      | ^
compilation terminated.
make[4]: *** [/build/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/apr-util-1.6.1/build/rules.mk:206: crypto/apr_sha1.lo] Error 1
crypto/apr_md5.c:666:1: fatal error: error writing to -: Broken pipe
  666 | }
      | ^
compilation terminated.
make[4]: *** [/build/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/apr-util-1.6.1/build/rules.mk:206: crypto/apr_md5.lo] Error 1
make[4]: Leaving directory '/build/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/apr-util-1.6.1'
make[3]: *** [/build/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/apr-util-1.6.1/build/rules.mk:118: all-recursive] Error 1
make[3]: Leaving directory '/build/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/apr-util-1.6.1'
make[2]: *** [Makefile:166: /build/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/apr-util-1.6.1/.built] Error 2
make[2]: Leaving directory '/build/build/feeds/packages/libs/apr-util'
time: package/feeds/packages/apr-util/compile#4.44#2.67#6.46
    ERROR: package/feeds/packages/apr-util failed to build.
make[1]: *** [package/Makefile:116: package/feeds/packages/apr-util/compile] Error 1
make[1]: Leaving directory '/build/build'
```