### PR TITLE
transmission: fix TRANSMISSION_WEB_HOME not work

### DIFF
--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -158,9 +158,6 @@ transmission() {
 		logger -t transmission "Starting with $USE virt mem"
 	fi
 
-	[ -d "$web_home" ] && procd_set_param env TRANSMISSION_WEB_HOME="$web_home"
-	[ "$ca_bundle" -gt 0 ] && procd_set_param env CURL_CA_BUNDLE="$ca_bundle_file"
-
 	procd_add_jail transmission log
 	procd_add_jail_mount "$config_file"
 	procd_add_jail_mount_rw "$config_dir/resume"
@@ -173,6 +170,10 @@ transmission() {
 	web_home="${web_home:-/usr/share/transmission/web}"
 	[ -d "$web_home" ] && procd_add_jail_mount "$web_home"
 	[ -f "$ca_bundle_file" ] && procd_add_jail_mount "$ca_bundle_file"
+	
+	[ -d "$web_home" ] && procd_set_param env TRANSMISSION_WEB_HOME="$web_home"
+	[ "$ca_bundle" -gt 0 ] && procd_set_param env CURL_CA_BUNDLE="$ca_bundle_file"
+	
 	procd_close_instance
 }
 


### PR DESCRIPTION
after some test, `procd_set_param env TRANSMISSION_WEB_HOME` only work after `procd_add_jail_mount`

Signed-off-by: Mumu  Li <1243962+imebeh@users.noreply.github.com>