### PR TITLE
lxc: Fix compilation with glibc 2.36

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=5.0.1
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/

--- a/utils/lxc/patches/001-build-detect-where-struct-mount_attr-is-declared.patch
+++ b/utils/lxc/patches/001-build-detect-where-struct-mount_attr-is-declared.patch
@@ -1,0 +1,173 @@
+From c1115e1503bf955c97f4cf3b925a6a9f619764c3 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <brauner@kernel.org>
+Date: Tue, 9 Aug 2022 16:14:25 +0200
+Subject: build: detect where struct mount_attr is declared
+
+Fixes: #4176
+Signed-off-by: Christian Brauner (Microsoft) <christian.brauner@ubuntu.com>
+---
+ meson.build                | 30 ++++++++++++++++++++++++++++--
+ src/lxc/conf.c             |  6 +++---
+ src/lxc/conf.h             |  2 +-
+ src/lxc/mount_utils.c      |  6 +++---
+ src/lxc/syscall_wrappers.h | 12 ++++++++++--
+ 5 files changed, 45 insertions(+), 11 deletions(-)
+
+--- a/meson.build
++++ b/meson.build
+@@ -589,7 +589,6 @@ decl_headers = '''
+ foreach decl: [
+     '__aligned_u64',
+     'struct clone_args',
+-    'struct mount_attr',
+     'struct open_how',
+     'struct rtnl_link_stats64',
+ ]
+@@ -609,7 +608,6 @@ foreach tuple: [
+     ['struct seccomp_notif_sizes'],
+     ['struct clone_args'],
+     ['__aligned_u64'],
+-    ['struct mount_attr'],
+     ['struct open_how'],
+     ['struct rtnl_link_stats64'],
+ ]
+@@ -629,6 +627,34 @@ foreach tuple: [
+     endif
+ endforeach
+ 
++## Types.
++decl_headers = '''
++#include <sys/mount.h>
++'''
++
++# We get -1 if the size cannot be determined
++if cc.sizeof('struct mount_attr', prefix: decl_headers, args: '-D_GNU_SOURCE') > 0
++    srcconf.set10('HAVE_' + 'struct mount_attr'.underscorify().to_upper(), true)
++    found_types += 'struct mount_attr (sys/mount.h)'
++else
++    srcconf.set10('HAVE_' + 'struct mount_attr'.underscorify().to_upper(), false)
++    missing_types += 'struct mount_attr (sys/mount.h)'
++endif
++
++## Types.
++decl_headers = '''
++#include <linux/mount.h>
++'''
++
++# We get -1 if the size cannot be determined
++if cc.sizeof('struct mount_attr', prefix: decl_headers, args: '-D_GNU_SOURCE') > 0
++    srcconf.set10('HAVE_UAPI_' + 'struct mount_attr'.underscorify().to_upper(), true)
++    found_types += 'struct mount_attr (linux/mount.h)'
++else
++    srcconf.set10('HAVE_UAPI_' + 'struct mount_attr'.underscorify().to_upper(), false)
++    missing_types += 'struct mount_attr (linux/mount.h)'
++endif
++
+ ## Headers.
+ foreach ident: [
+     ['bpf',               '''#include <sys/syscall.h>
+--- a/src/lxc/conf.c
++++ b/src/lxc/conf.c
+@@ -2885,7 +2885,7 @@ static int __lxc_idmapped_mounts_child(s
+ 		struct lxc_mount_options opts = {};
+ 		int dfd_from;
+ 		const char *source_relative, *target_relative;
+-		struct lxc_mount_attr attr = {};
++		struct mount_attr attr = {};
+ 
+ 		ret = parse_lxc_mount_attrs(&opts, mntent.mnt_opts);
+ 		if (ret < 0)
+@@ -3005,7 +3005,7 @@ static int __lxc_idmapped_mounts_child(s
+ 
+ 		/* Set propagation mount options. */
+ 		if (opts.attr.propagation) {
+-			attr = (struct lxc_mount_attr) {
++			attr = (struct mount_attr) {
+ 				.propagation = opts.attr.propagation,
+ 			};
+ 
+@@ -4109,7 +4109,7 @@ int lxc_idmapped_mounts_parent(struct lx
+ 
+ 	for (;;) {
+ 		__do_close int fd_from = -EBADF, fd_userns = -EBADF;
+-		struct lxc_mount_attr attr = {};
++		struct mount_attr attr = {};
+ 		struct lxc_mount_options opts = {};
+ 		ssize_t ret;
+ 
+--- a/src/lxc/conf.h
++++ b/src/lxc/conf.h
+@@ -223,7 +223,7 @@ struct lxc_mount_options {
+ 	unsigned long mnt_flags;
+ 	unsigned long prop_flags;
+ 	char *data;
+-	struct lxc_mount_attr attr;
++	struct mount_attr attr;
+ 	char *raw_options;
+ };
+ 
+--- a/src/lxc/mount_utils.c
++++ b/src/lxc/mount_utils.c
+@@ -31,7 +31,7 @@ lxc_log_define(mount_utils, lxc);
+  * setting in @attr_set, but must also specify MOUNT_ATTR__ATIME in the
+  * @attr_clr field.
+  */
+-static inline void set_atime(struct lxc_mount_attr *attr)
++static inline void set_atime(struct mount_attr *attr)
+ {
+ 	switch (attr->attr_set & MOUNT_ATTR__ATIME) {
+ 	case MOUNT_ATTR_RELATIME:
+@@ -272,7 +272,7 @@ int create_detached_idmapped_mount(const
+ {
+ 	__do_close int fd_tree_from = -EBADF;
+ 	unsigned int open_tree_flags = OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC;
+-	struct lxc_mount_attr attr = {
++	struct mount_attr attr = {
+ 		.attr_set	= MOUNT_ATTR_IDMAP | attr_set,
+ 		.attr_clr	= attr_clr,
+ 		.userns_fd	= userns_fd,
+@@ -335,7 +335,7 @@ int __fd_bind_mount(int dfd_from, const
+ 		    __u64 attr_clr, __u64 propagation, int userns_fd,
+ 		    bool recursive)
+ {
+-	struct lxc_mount_attr attr = {
++	struct mount_attr attr = {
+ 		.attr_set	= attr_set,
+ 		.attr_clr	= attr_clr,
+ 		.propagation	= propagation,
+--- a/src/lxc/syscall_wrappers.h
++++ b/src/lxc/syscall_wrappers.h
+@@ -18,6 +18,12 @@
+ #include "macro.h"
+ #include "syscall_numbers.h"
+ 
++#if HAVE_STRUCT_MOUNT_ATTR
++#include <sys/mount.h>
++#elif HAVE_UAPI_STRUCT_MOUNT_ATTR
++#include <linux/mount.h>
++#endif
++
+ #ifdef HAVE_LINUX_MEMFD_H
+ #include <linux/memfd.h>
+ #endif
+@@ -210,16 +216,18 @@ extern int fsmount(int fs_fd, unsigned i
+ /*
+  * mount_setattr()
+  */
+-struct lxc_mount_attr {
++#if !HAVE_STRUCT_MOUNT_ATTR && !HAVE_UAPI_STRUCT_MOUNT_ATTR
++struct mount_attr {
+ 	__u64 attr_set;
+ 	__u64 attr_clr;
+ 	__u64 propagation;
+ 	__u64 userns_fd;
+ };
++#endif
+ 
+ #if !HAVE_MOUNT_SETATTR
+ static inline int mount_setattr(int dfd, const char *path, unsigned int flags,
+-				struct lxc_mount_attr *attr, size_t size)
++				struct mount_attr *attr, size_t size)
+ {
+ 	return syscall(__NR_mount_setattr, dfd, path, flags, attr, size);
+ }

--- a/utils/lxc/patches/002-build-detect-sys-pidfd.h-availability.patch
+++ b/utils/lxc/patches/002-build-detect-sys-pidfd.h-availability.patch
@@ -1,0 +1,47 @@
+From ef1e0607b82e27350c2d677d649c6a0a9693fd40 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <brauner@kernel.org>
+Date: Tue, 9 Aug 2022 16:27:40 +0200
+Subject: build: detect sys/pidfd.h availability
+
+Fixes: #4176
+Signed-off-by: Christian Brauner (Microsoft) <christian.brauner@ubuntu.com>
+---
+ meson.build             | 1 +
+ src/lxc/process_utils.h | 6 ++++++
+ 2 files changed, 7 insertions(+)
+
+--- a/meson.build
++++ b/meson.build
+@@ -734,6 +734,7 @@ foreach tuple: [
+     ['sys/resource.h'],
+     ['sys/memfd.h'],
+     ['sys/personality.h'],
++    ['sys/pidfd.h'],
+     ['sys/signalfd.h'],
+     ['sys/timerfd.h'],
+     ['pty.h'],
+--- a/src/lxc/process_utils.h
++++ b/src/lxc/process_utils.h
+@@ -15,6 +15,10 @@
+ #include <sys/syscall.h>
+ #include <unistd.h>
+ 
++#if HAVE_SYS_PIDFD_H
++#include <sys/pidfd.h>
++#endif
++
+ #include "compiler.h"
+ #include "syscall_numbers.h"
+ 
+@@ -136,9 +140,11 @@
+ #endif
+ 
+ /* waitid */
++#if !HAVE_SYS_PIDFD_H
+ #ifndef P_PIDFD
+ #define P_PIDFD 3
+ #endif
++#endif
+ 
+ #ifndef CLONE_ARGS_SIZE_VER0
+ #define CLONE_ARGS_SIZE_VER0 64 /* sizeof first published struct */

--- a/utils/lxc/patches/003-build-check-for-FS_CONFIG_-header-symbol-in-sys-moun.patch
+++ b/utils/lxc/patches/003-build-check-for-FS_CONFIG_-header-symbol-in-sys-moun.patch
@@ -1,0 +1,143 @@
+From cbabe8abf11e7e7fb49c123bae31efdd9bc8f1e8 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <brauner@kernel.org>
+Date: Tue, 9 Aug 2022 17:19:40 +0200
+Subject: build: check for FS_CONFIG_* header symbol in sys/mount.h
+
+Fixes: #4176
+Signed-off-by: Christian Brauner (Microsoft) <christian.brauner@ubuntu.com>
+---
+ meson.build           | 59 +++++++++++++++++++++++++++++++++++++++++--
+ src/lxc/mount_utils.h | 16 ++++++++++++
+ 2 files changed, 73 insertions(+), 2 deletions(-)
+
+--- a/meson.build
++++ b/meson.build
+@@ -638,8 +638,7 @@ if cc.sizeof('struct mount_attr', prefix
+     found_types += 'struct mount_attr (sys/mount.h)'
+ else
+     srcconf.set10('HAVE_' + 'struct mount_attr'.underscorify().to_upper(), false)
+-    missing_types += 'struct mount_attr (sys/mount.h)'
+-endif
++    missing_types += 'struct mount_attr (sys/mount.h)' endif
+ 
+ ## Types.
+ decl_headers = '''
+@@ -655,6 +654,62 @@ else
+     missing_types += 'struct mount_attr (linux/mount.h)'
+ endif
+ 
++if cc.has_header_symbol('sys/mount.h', 'FSCONFIG_SET_FLAG')
++    srcconf.set10('HAVE_' + 'FSCONFIG_SET_FLAG'.underscorify().to_upper(), true)
++    found_types += 'FSCONFIG_SET_FLAG'
++else
++    srcconf.set10('HAVE_' + 'FSCONFIG_SET_FLAG'.underscorify().to_upper(), false)
++    missing_types += 'FSCONFIG_SET_FLAG'
++endif
++
++if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_STRING')
++    srcconf.set10('HAVE_' + 'FS_CONFIG_SET_STRING'.underscorify().to_upper(), true)
++    found_types += 'FS_CONFIG_SET_STRING'
++else
++    srcconf.set10('HAVE_' + 'FS_CONFIG_SET_STRING'.underscorify().to_upper(), false)
++    missing_types += 'FS_CONFIG_SET_STRING'
++endif
++
++if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_BINARY')
++    srcconf.set10('HAVE_' + 'FS_CONFIG_SET_BINARY'.underscorify().to_upper(), true)
++    found_types += 'FS_CONFIG_SET_BINARY'
++else
++    srcconf.set10('HAVE_' + 'FS_CONFIG_SET_BINARY'.underscorify().to_upper(), false)
++    missing_types += 'FS_CONFIG_SET_BINARY'
++endif
++
++if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_PATH_EMPTY')
++    srcconf.set10('HAVE_' + 'FS_CONFIG_SET_PATH_EMPTY'.underscorify().to_upper(), true)
++    found_types += 'FS_CONFIG_SET_PATH_EMPTY'
++else
++    srcconf.set10('HAVE_' + 'FS_CONFIG_SET_PATH_EMPTY'.underscorify().to_upper(), false)
++    missing_types += 'FS_CONFIG_SET_PATH_EMPTY'
++endif
++
++if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_PATH_FD')
++    srcconf.set10('HAVE_' + 'FS_CONFIG_SET_PATH_FD'.underscorify().to_upper(), true)
++    found_types += 'FS_CONFIG_SET_PATH_FD'
++else
++    srcconf.set10('HAVE_' + 'FS_CONFIG_SET_PATH_FD'.underscorify().to_upper(), false)
++    missing_types += 'FS_CONFIG_SET_PATH_FD'
++endif
++
++if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_CMD_CREATE')
++    srcconf.set10('HAVE_' + 'FS_CONFIG_SET_CMD_CREATE'.underscorify().to_upper(), true)
++    found_types += 'FS_CONFIG_SET_CMD_CREATE'
++else
++    srcconf.set10('HAVE_' + 'FS_CONFIG_SET_CMD_CREATE'.underscorify().to_upper(), false)
++    missing_types += 'FS_CONFIG_SET_CMD_CREATE'
++endif
++
++if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_CMD_RECONFIGURE')
++    srcconf.set10('HAVE_' + 'FS_CONFIG_SET_CMD_RECONFIGURE'.underscorify().to_upper(), true)
++    found_types += 'FS_CONFIG_SET_CMD_RECONFIGURE'
++else
++    srcconf.set10('HAVE_' + 'FS_CONFIG_SET_CMD_RECONFIGURE'.underscorify().to_upper(), false)
++    missing_types += 'FS_CONFIG_SET_CMD_RECONFIGURE'
++endif
++
+ ## Headers.
+ foreach ident: [
+     ['bpf',               '''#include <sys/syscall.h>
+--- a/src/lxc/mount_utils.h
++++ b/src/lxc/mount_utils.h
+@@ -82,37 +82,53 @@ struct lxc_rootfs;
+ #endif
+ 
+ /* fsconfig() commands */
++#if !HAVE_FSCONFIG_SET_FLAG
+ #ifndef FSCONFIG_SET_FLAG
+ #define FSCONFIG_SET_FLAG 0 /* Set parameter, supplying no value */
+ #endif
++#endif
+ 
++#if !HAVE_FSCONFIG_SET_STRING
+ #ifndef FSCONFIG_SET_STRING
+ #define FSCONFIG_SET_STRING 1 /* Set parameter, supplying a string value */
+ #endif
++#endif
+ 
++#if !HAVE_FSCONFIG_SET_BINARY
+ #ifndef FSCONFIG_SET_BINARY
+ #define FSCONFIG_SET_BINARY 2 /* Set parameter, supplying a binary blob value */
+ #endif
++#endif
+ 
++#if !HAVE_FSCONFIG_SET_PATH
+ #ifndef FSCONFIG_SET_PATH
+ #define FSCONFIG_SET_PATH 3 /* Set parameter, supplying an object by path */
+ #endif
++#endif
+ 
++#if !HAVE_FSCONFIG_SET_PATH_EMPTY
+ #ifndef FSCONFIG_SET_PATH_EMPTY
+ #define FSCONFIG_SET_PATH_EMPTY 4 /* Set parameter, supplying an object by (empty) path */
+ #endif
++#endif
+ 
++#if !HAVE_FSCONFIG_SET_FD
+ #ifndef FSCONFIG_SET_FD
+ #define FSCONFIG_SET_FD 5 /* Set parameter, supplying an object by fd */
+ #endif
++#endif
+ 
++#if !HAVE_FSCONFIG_CMD_CREATE
+ #ifndef FSCONFIG_CMD_CREATE
+ #define FSCONFIG_CMD_CREATE 6 /* Invoke superblock creation */
+ #endif
++#endif
+ 
++#if !FSCONFIG_CMD_RECONFIGURE
+ #ifndef FSCONFIG_CMD_RECONFIGURE
+ #define	FSCONFIG_CMD_RECONFIGURE 7	/* Invoke superblock reconfiguration */
+ #endif
++#endif
+ 
+ /* fsmount() flags */
+ #ifndef FSMOUNT_CLOEXEC

--- a/utils/lxc/patches/011-tree-wide-wipe-direct-or-indirect-linux-mount.h-incl.patch
+++ b/utils/lxc/patches/011-tree-wide-wipe-direct-or-indirect-linux-mount.h-incl.patch
@@ -1,0 +1,197 @@
+From 4771699fd97b1e9ee7dc4f7cfe01c8ddd698f682 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <brauner@kernel.org>
+Date: Wed, 10 Aug 2022 11:42:52 +0200
+Subject: tree-wide: wipe direct or indirect linux/mount.h inclusion
+
+It is incompatible with sys/mount.h and causes massive headaches.
+
+Signed-off-by: Christian Brauner (Microsoft) <christian.brauner@ubuntu.com>
+---
+ meson.build                | 44 +++++++++++++-------------------------
+ src/lxc/macro.h            | 13 +++++++++++
+ src/lxc/mount_utils.h      |  2 +-
+ src/lxc/syscall_wrappers.h |  9 ++------
+ src/lxc/utils.c            |  2 --
+ 5 files changed, 31 insertions(+), 39 deletions(-)
+
+--- a/meson.build
++++ b/meson.build
+@@ -627,7 +627,6 @@ foreach tuple: [
+     endif
+ endforeach
+ 
+-## Types.
+ decl_headers = '''
+ #include <sys/mount.h>
+ '''
+@@ -640,74 +639,61 @@ else
+     srcconf.set10('HAVE_' + 'struct mount_attr'.underscorify().to_upper(), false)
+     missing_types += 'struct mount_attr (sys/mount.h)' endif
+ 
+-## Types.
+-decl_headers = '''
+-#include <linux/mount.h>
+-'''
+-
+-# We get -1 if the size cannot be determined
+-if cc.sizeof('struct mount_attr', prefix: decl_headers, args: '-D_GNU_SOURCE') > 0
+-    srcconf.set10('HAVE_UAPI_' + 'struct mount_attr'.underscorify().to_upper(), true)
+-    found_types += 'struct mount_attr (linux/mount.h)'
+-else
+-    srcconf.set10('HAVE_UAPI_' + 'struct mount_attr'.underscorify().to_upper(), false)
+-    missing_types += 'struct mount_attr (linux/mount.h)'
+-endif
+-
++## Check if sys/mount.h defines the fsconfig commands
+ if cc.has_header_symbol('sys/mount.h', 'FSCONFIG_SET_FLAG')
+     srcconf.set10('HAVE_' + 'FSCONFIG_SET_FLAG'.underscorify().to_upper(), true)
+-    found_types += 'FSCONFIG_SET_FLAG'
++    found_types += 'FSCONFIG_SET_FLAG (sys/mount.h)'
+ else
+     srcconf.set10('HAVE_' + 'FSCONFIG_SET_FLAG'.underscorify().to_upper(), false)
+-    missing_types += 'FSCONFIG_SET_FLAG'
++    missing_types += 'FSCONFIG_SET_FLAG (sys/mount.h)'
+ endif
+ 
+ if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_STRING')
+     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_STRING'.underscorify().to_upper(), true)
+-    found_types += 'FS_CONFIG_SET_STRING'
++    found_types += 'FS_CONFIG_SET_STRING (sys/mount.h)'
+ else
+     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_STRING'.underscorify().to_upper(), false)
+-    missing_types += 'FS_CONFIG_SET_STRING'
++    missing_types += 'FS_CONFIG_SET_STRING (sys/mount.h)'
+ endif
+ 
+ if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_BINARY')
+     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_BINARY'.underscorify().to_upper(), true)
+-    found_types += 'FS_CONFIG_SET_BINARY'
++    found_types += 'FS_CONFIG_SET_BINARY (sys/mount.h)'
+ else
+     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_BINARY'.underscorify().to_upper(), false)
+-    missing_types += 'FS_CONFIG_SET_BINARY'
++    missing_types += 'FS_CONFIG_SET_BINARY (sys/mount.h)'
+ endif
+ 
+ if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_PATH_EMPTY')
+     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_PATH_EMPTY'.underscorify().to_upper(), true)
+-    found_types += 'FS_CONFIG_SET_PATH_EMPTY'
++    found_types += 'FS_CONFIG_SET_PATH_EMPTY (sys/mount.h)'
+ else
+     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_PATH_EMPTY'.underscorify().to_upper(), false)
+-    missing_types += 'FS_CONFIG_SET_PATH_EMPTY'
++    missing_types += 'FS_CONFIG_SET_PATH_EMPTY (sys/mount.h)'
+ endif
+ 
+ if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_PATH_FD')
+     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_PATH_FD'.underscorify().to_upper(), true)
+-    found_types += 'FS_CONFIG_SET_PATH_FD'
++    found_types += 'FS_CONFIG_SET_PATH_FD (sys/mount.h)'
+ else
+     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_PATH_FD'.underscorify().to_upper(), false)
+-    missing_types += 'FS_CONFIG_SET_PATH_FD'
++    missing_types += 'FS_CONFIG_SET_PATH_FD (sys/mount.h)'
+ endif
+ 
+ if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_CMD_CREATE')
+     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_CMD_CREATE'.underscorify().to_upper(), true)
+-    found_types += 'FS_CONFIG_SET_CMD_CREATE'
++    found_types += 'FS_CONFIG_SET_CMD_CREAT (sys/mount.h)'
+ else
+     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_CMD_CREATE'.underscorify().to_upper(), false)
+-    missing_types += 'FS_CONFIG_SET_CMD_CREATE'
++    missing_types += 'FS_CONFIG_SET_CMD_CREATE (sys/mount.h)'
+ endif
+ 
+ if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_CMD_RECONFIGURE')
+     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_CMD_RECONFIGURE'.underscorify().to_upper(), true)
+-    found_types += 'FS_CONFIG_SET_CMD_RECONFIGURE'
++    found_types += 'FS_CONFIG_SET_CMD_RECONFIGURE (sys/mount.h)'
+ else
+     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_CMD_RECONFIGURE'.underscorify().to_upper(), false)
+-    missing_types += 'FS_CONFIG_SET_CMD_RECONFIGURE'
++    missing_types += 'FS_CONFIG_SET_CMD_RECONFIGURE (sys/mount.h)'
+ endif
+ 
+ ## Headers.
+--- a/src/lxc/macro.h
++++ b/src/lxc/macro.h
+@@ -8,6 +8,7 @@
+ #include <asm/types.h>
+ #include <limits.h>
+ #include <linux/if_link.h>
++#include <linux/ioctl.h>
+ #include <linux/loop.h>
+ #include <linux/netlink.h>
+ #include <linux/rtnetlink.h>
+@@ -812,4 +813,16 @@ static inline bool is_set(__u32 bit, __u
+ 
+ #define BIT(nr) (1UL << (nr))
+ 
++#ifndef FS_IOC_GETFLAGS
++#define FS_IOC_GETFLAGS _IOR('f', 1, long)
++#endif
++
++#ifndef FS_IOC_SETFLAGS
++#define FS_IOC_SETFLAGS _IOW('f', 2, long)
++#endif
++
++#ifndef FS_IMMUTABLE_FL
++#define FS_IMMUTABLE_FL 0x00000010 /* Immutable file */
++#endif
++
+ #endif /* __LXC_MACRO_H */
+--- a/src/lxc/mount_utils.h
++++ b/src/lxc/mount_utils.h
+@@ -124,7 +124,7 @@ struct lxc_rootfs;
+ #endif
+ #endif
+ 
+-#if !FSCONFIG_CMD_RECONFIGURE
++#if !HAVE_FSCONFIG_CMD_RECONFIGURE
+ #ifndef FSCONFIG_CMD_RECONFIGURE
+ #define	FSCONFIG_CMD_RECONFIGURE 7	/* Invoke superblock reconfiguration */
+ #endif
+--- a/src/lxc/syscall_wrappers.h
++++ b/src/lxc/syscall_wrappers.h
+@@ -10,6 +10,7 @@
+ #include <linux/keyctl.h>
+ #include <sched.h>
+ #include <stdint.h>
++#include <sys/mount.h>
+ #include <sys/prctl.h>
+ #include <sys/syscall.h>
+ #include <sys/types.h>
+@@ -18,12 +19,6 @@
+ #include "macro.h"
+ #include "syscall_numbers.h"
+ 
+-#if HAVE_STRUCT_MOUNT_ATTR
+-#include <sys/mount.h>
+-#elif HAVE_UAPI_STRUCT_MOUNT_ATTR
+-#include <linux/mount.h>
+-#endif
+-
+ #ifdef HAVE_LINUX_MEMFD_H
+ #include <linux/memfd.h>
+ #endif
+@@ -216,7 +211,7 @@ extern int fsmount(int fs_fd, unsigned i
+ /*
+  * mount_setattr()
+  */
+-#if !HAVE_STRUCT_MOUNT_ATTR && !HAVE_UAPI_STRUCT_MOUNT_ATTR
++#if !HAVE_STRUCT_MOUNT_ATTR
+ struct mount_attr {
+ 	__u64 attr_set;
+ 	__u64 attr_clr;
+--- a/src/lxc/utils.c
++++ b/src/lxc/utils.c
+@@ -19,8 +19,6 @@
+ #include <string.h>
+ #include <sys/mman.h>
+ #include <sys/mount.h>
+-/* Needs to be after sys/mount.h header */
+-#include <linux/fs.h>
+ #include <sys/param.h>
+ #include <sys/prctl.h>
+ #include <sys/stat.h>

--- a/utils/lxc/patches/012-tree-wide-use-struct-clone_args-directly.patch
+++ b/utils/lxc/patches/012-tree-wide-use-struct-clone_args-directly.patch
@@ -1,0 +1,99 @@
+From 63468abd3287ebd5cc4ed9205334217031049fb4 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <brauner@kernel.org>
+Date: Wed, 10 Aug 2022 12:03:54 +0200
+Subject: tree-wide: use struct clone_args directly
+
+Signed-off-by: Christian Brauner (Microsoft) <christian.brauner@ubuntu.com>
+---
+ meson.build             | 1 -
+ src/lxc/process_utils.c | 2 +-
+ src/lxc/process_utils.h | 7 ++++---
+ src/lxc/start.c         | 2 +-
+ src/lxc/start.h         | 1 -
+ src/tests/reboot.c      | 2 --
+ 6 files changed, 6 insertions(+), 9 deletions(-)
+
+--- a/meson.build
++++ b/meson.build
+@@ -582,7 +582,6 @@ decl_headers = '''
+ #include <linux/fs.h>
+ #include <linux/if_link.h>
+ #include <linux/openat2.h>
+-#include <linux/sched.h>
+ #include <linux/types.h>
+ '''
+ 
+--- a/src/lxc/process_utils.c
++++ b/src/lxc/process_utils.c
+@@ -90,7 +90,7 @@ __returns_twice pid_t lxc_raw_legacy_clo
+ __returns_twice pid_t lxc_raw_clone(unsigned long flags, int *pidfd)
+ {
+ 	pid_t pid;
+-	struct lxc_clone_args args = {
++	struct clone_args args = {
+ 		.flags		= flags,
+ 		.pidfd		= ptr_to_u64(pidfd),
+ 	};
+--- a/src/lxc/process_utils.h
++++ b/src/lxc/process_utils.h
+@@ -5,7 +5,6 @@
+ 
+ #include "config.h"
+ 
+-#include <linux/sched.h>
+ #include <sched.h>
+ #include <signal.h>
+ #include <stdbool.h>
+@@ -165,7 +164,8 @@
+ #define u64_to_ptr(x) ((void *)(uintptr_t)x)
+ #endif
+ 
+-struct lxc_clone_args {
++#if !HAVE_STRUCT_CLONE_ARGS
++struct clone_args {
+ 	__aligned_u64 flags;
+ 	__aligned_u64 pidfd;
+ 	__aligned_u64 child_tid;
+@@ -178,8 +178,9 @@ struct lxc_clone_args {
+ 	__aligned_u64 set_tid_size;
+ 	__aligned_u64 cgroup;
+ };
++#endif
+ 
+-__returns_twice static inline pid_t lxc_clone3(struct lxc_clone_args *args, size_t size)
++__returns_twice static inline pid_t lxc_clone3(struct clone_args *args, size_t size)
+ {
+ 	return syscall(__NR_clone3, args, size);
+ }
+--- a/src/lxc/start.c
++++ b/src/lxc/start.c
+@@ -1673,7 +1673,7 @@ static int lxc_spawn(struct lxc_handler
+ 	} else {
+ 		int cgroup_fd = -EBADF;
+ 
+-		struct lxc_clone_args clone_args = {
++		struct clone_args clone_args = {
+ 			.flags = handler->clone_flags,
+ 			.pidfd = ptr_to_u64(&handler->pidfd),
+ 			.exit_signal = SIGCHLD,
+--- a/src/lxc/start.h
++++ b/src/lxc/start.h
+@@ -5,7 +5,6 @@
+ 
+ #include "config.h"
+ 
+-#include <linux/sched.h>
+ #include <sched.h>
+ #include <signal.h>
+ #include <stdbool.h>
+--- a/src/tests/reboot.c
++++ b/src/tests/reboot.c
+@@ -32,8 +32,6 @@
+ 
+ #include "namespace.h"
+ 
+-#include <sched.h>
+-#include <linux/sched.h>
+ #include <linux/reboot.h>
+ 
+ int clone(int (*fn)(void *), void *child_stack, int flags, void *arg, ...);

--- a/utils/lxc/patches/013-tree-wide-use-struct-open_how-directly.patch
+++ b/utils/lxc/patches/013-tree-wide-use-struct-open_how-directly.patch
@@ -1,0 +1,112 @@
+From 133aa416ca2a5996090ec0e697e253646364d274 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <brauner@kernel.org>
+Date: Wed, 10 Aug 2022 12:18:49 +0200
+Subject: tree-wide: use struct open_how directly
+
+Signed-off-by: Christian Brauner (Microsoft) <christian.brauner@ubuntu.com>
+---
+ meson.build                | 2 --
+ src/lxc/file_utils.c       | 2 +-
+ src/lxc/mount_utils.c      | 8 ++++----
+ src/lxc/syscall_wrappers.h | 6 ++++--
+ src/lxc/utils.c            | 2 +-
+ 5 files changed, 10 insertions(+), 10 deletions(-)
+
+--- a/meson.build
++++ b/meson.build
+@@ -579,9 +579,7 @@ decl_headers = '''
+ #include <uchar.h>
+ #include <sys/mount.h>
+ #include <sys/stat.h>
+-#include <linux/fs.h>
+ #include <linux/if_link.h>
+-#include <linux/openat2.h>
+ #include <linux/types.h>
+ '''
+ 
+--- a/src/lxc/file_utils.c
++++ b/src/lxc/file_utils.c
+@@ -652,7 +652,7 @@ int open_at(int dfd, const char *path, u
+ 	    unsigned int resolve_flags, mode_t mode)
+ {
+ 	__do_close int fd = -EBADF;
+-	struct lxc_open_how how = {
++	struct open_how how = {
+ 		.flags		= o_flags,
+ 		.mode		= mode,
+ 		.resolve	= resolve_flags,
+--- a/src/lxc/mount_utils.c
++++ b/src/lxc/mount_utils.c
+@@ -186,7 +186,7 @@ int fs_prepare(const char *fs_name,
+ 	int fd_from;
+ 
+ 	if (!is_empty_string(path_from)) {
+-		struct lxc_open_how how = {
++		struct open_how how = {
+ 			.flags		= o_flags_from,
+ 			.resolve	= resolve_flags_from,
+ 		};
+@@ -237,7 +237,7 @@ int fs_attach(int fd_fs,
+ 	int fd_to, ret;
+ 
+ 	if (!is_empty_string(path_to)) {
+-		struct lxc_open_how how = {
++		struct open_how how = {
+ 			.flags		= o_flags_to,
+ 			.resolve	= resolve_flags_to,
+ 		};
+@@ -308,7 +308,7 @@ int move_detached_mount(int dfd_from, in
+ 	int fd_to, ret;
+ 
+ 	if (!is_empty_string(path_to)) {
+-		struct lxc_open_how how = {
++		struct open_how how = {
+ 			.flags		= o_flags_to,
+ 			.resolve	= resolve_flags_to,
+ 		};
+@@ -348,7 +348,7 @@ int __fd_bind_mount(int dfd_from, const
+ 	set_atime(&attr);
+ 
+ 	if (!is_empty_string(path_from)) {
+-		struct lxc_open_how how = {
++		struct open_how how = {
+ 			.flags		= o_flags_from,
+ 			.resolve	= resolve_flags_from,
+ 		};
+--- a/src/lxc/syscall_wrappers.h
++++ b/src/lxc/syscall_wrappers.h
+@@ -240,11 +240,13 @@ static inline int mount_setattr(int dfd,
+  * @mode: O_CREAT/O_TMPFILE file mode.
+  * @resolve: RESOLVE_* flags.
+  */
+-struct lxc_open_how {
++#if !HAVE_STRUCT_OPEN_HOW
++struct open_how {
+ 	__u64 flags;
+ 	__u64 mode;
+ 	__u64 resolve;
+ };
++#endif
+ 
+ /* how->resolve flags for openat2(2). */
+ #ifndef RESOLVE_NO_XDEV
+@@ -296,7 +298,7 @@ struct lxc_open_how {
+ #define PROTECT_OPEN_RW (O_CLOEXEC | O_NOCTTY | O_RDWR | O_NOFOLLOW)
+ 
+ #if !HAVE_OPENAT2
+-static inline int openat2(int dfd, const char *filename, struct lxc_open_how *how, size_t size)
++static inline int openat2(int dfd, const char *filename, struct open_how *how, size_t size)
+ {
+ 	return syscall(__NR_openat2, dfd, filename, how, size);
+ }
+--- a/src/lxc/utils.c
++++ b/src/lxc/utils.c
+@@ -1095,7 +1095,7 @@ int __safe_mount_beneath_at(int beneath_
+ 			    unsigned int flags, const void *data)
+ {
+ 	__do_close int source_fd = -EBADF, target_fd = -EBADF;
+-	struct lxc_open_how how = {
++	struct open_how how = {
+ 		.flags		= PROTECT_OPATH_DIRECTORY,
+ 		.resolve	= PROTECT_LOOKUP_BENEATH_WITH_MAGICLINKS,
+ 	};


### PR DESCRIPTION
Maintainer: @ratkaj 
Compile tested: malta/be
Run tested: none

Description:

Backport patches from upstream lxc master to fix compilation against glibc 2.36.

The changes were added in these pull requests:
https://github.com/lxc/lxc/pull/4179
https://github.com/lxc/lxc/pull/4181

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>



