### PR TITLE
boost: Updates package to version 1.81.0

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -11,13 +11,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=boost
-PKG_VERSION:=1.80.0
-PKG_SOURCE_VERSION:=1_80_0
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=1.81.0
+PKG_SOURCE_VERSION:=1_81_0
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://boostorg.jfrog.io/artifactory/main/release/$(PKG_VERSION)/source/
-PKG_HASH:=1e19565d82e43bc59209a168f5ac899d3ba471d55c7610c677d4ccf2c9c500c0
+PKG_HASH:=71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa
 
 PKG_MAINTAINER:=Carlos M. Ferreira <carlosmf.pt@gmail.com>
 PKG_LICENSE:=BSL-1.0
@@ -42,7 +42,7 @@ define Package/boost/Default
 endef
 
 define Package/boost/description
-This package provides the Boost v1.80.0 libraries.
+This package provides the Boost v1.81.0 libraries.
 Boost is a set of free, peer-reviewed, portable C++ source libraries.
 
 This package provides the following run-time libraries:
@@ -74,10 +74,11 @@ This package provides the following run-time libraries:
  - thread
  - timer
  - type_erasure
+ - url (new)
  - wave
 
 There are many more header-only libraries supported by Boost.
-See more at http://www.boost.org/doc/libs/1_78_0/
+See more at http://www.boost.org/doc/libs/1_81_0/
 endef
 
 PKG_BUILD_DEPENDS:=boost/host
@@ -362,6 +363,7 @@ $(eval $(call DefineBoostLibrary,system))
 $(eval $(call DefineBoostLibrary,thread,system chrono atomic))
 $(eval $(call DefineBoostLibrary,timer,chrono))
 $(eval $(call DefineBoostLibrary,type_erasure,chrono system thread))
+$(eval $(call DefineBoostLibrary,url))
 $(eval $(call DefineBoostLibrary,wave,date_time thread filesystem))
 
 include $(INCLUDE_DIR)/host-build.mk

--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.81.0
 PKG_SOURCE_VERSION:=1_81_0
-PKG_RELEASE:=4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://boostorg.jfrog.io/artifactory/main/release/$(PKG_VERSION)/source/


### PR DESCRIPTION
Maintainer:  @ClaymorePT 
Compile tested: Octeon PLus
Run tested: N/A

Description:

This commit updates boost to version 1.81.0

A new library is available:
- URL [[1]]: A library for parsing, modifying, and printing URLs using only C++11, from Vinnie Falco and Alan de Freitas. Features include fast compilation, strong invariants, and strict compliance using a memory-friendly approach.

More info about Boost 1.81.0 can be found at the usual place [[2]].

[1]: https://www.boost.org/doc/libs/1_81_0/libs/url/doc/html/index.html
[2]: https://www.boost.org/users/history/version_1_81_0.html

Signed-off-by: Carlos Miguel Ferreira <carlosmf.pt@gmail.com>