### PR TITLE
snort3: update to 3.1.50.0

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
-PKG_VERSION:=3.1.48.0
-PKG_RELEASE:=2
+PKG_VERSION:=3.1.49.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
-PKG_HASH:=65df088a8cac11e59f0b71a7f98fc9d21eeb0e31d35280c470c985172947ebfe
+PKG_HASH:=3ad422f27855a73f83483fefa844bdc4ef247f9e0a21d1fa54d6c8ea20105fcb
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=GPL-2.0-only

--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
-PKG_VERSION:=3.1.49.0
+PKG_VERSION:=3.1.50.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
-PKG_HASH:=3ad422f27855a73f83483fefa844bdc4ef247f9e0a21d1fa54d6c8ea20105fcb
+PKG_HASH:=983497578587c5b1291994608fef70700d7f251461e79ac897751bba57cc56b5
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=GPL-2.0-only

--- a/net/snort3/files/local.lua
+++ b/net/snort3/files/local.lua
@@ -2,7 +2,7 @@
 
 -- switch tap to inline in ips and uncomment the below to run snort in inline mode
 --snort = {}
---snort["-Q"] = ''
+--snort["-Q"] = true
 
 ips = {
   mode = tap,
@@ -50,3 +50,10 @@ file_policy = {
     }
   }
 }
+
+-- To use openappid with snort, install the openappid package and uncomment the below
+--appid = {
+--    app_detector_dir = '/usr/lib/openappid',
+--    log_stats = true,
+--    app_stats_period = 60,
+--}


### PR DESCRIPTION
Upstream bump
```
    Build system: x86_64
    Build-tested: bcm2711/RPi4B
    Run-tested: bcm2711/RPi4B
```

Signed-off-by: John Audia <therealgraysky@proton.me>

Maintainer: @flyn-org 