### PR TITLE
dos2unix: Deactivate NLS support

### DIFF
--- a/utils/dos2unix/Makefile
+++ b/utils/dos2unix/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dos2unix
 PKG_VERSION:=7.4.3
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://waterlan.home.xs4all.nl/dos2unix/ \
@@ -22,7 +22,7 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-MAKE_FLAGS+= D2U_OS=Linux
+MAKE_FLAGS+= D2U_OS=Linux ENABLE_NLS=
 
 define dos2unix/template
   define Package/$(1)


### PR DESCRIPTION
Maintainer: @1715173329 
Compile tested: malta/be
Run tested: none

Description:

Without this patch the build uses the msgfmt application which is
provided by the host tool gettext in OpenWrt. Instead of adding the
dependency to gettext remove NLS support.

This fixes the following build error:
-------------------------------------------
msgfmt -c po/da.po -o po/da.mo
make[4]: msgfmt: No such file or directory
make[4]: *** [Makefile:472: po/da.mo] Error 127