### PR TITLE
postfix: Fix compile against glibc 2.36

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postfix
 PKG_VERSION:=3.5.8
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \

--- a/mail/postfix/patches/502-detect-glibc.patch
+++ b/mail/postfix/patches/502-detect-glibc.patch
@@ -1,0 +1,12 @@
+--- a/src/util/sys_defs.h
++++ b/src/util/sys_defs.h
+@@ -749,7 +749,8 @@ extern int initgroups(const char *, int)
+  /*
+   * LINUX.
+   */
+-#if defined(LINUX2) || defined(LINUX3) || defined(LINUX4) || defined(LINUX5)
++#if defined(LINUX2) || defined(LINUX3) || defined(LINUX4) || defined(LINUX5) \
++	|| defined(LINUX6)
+ #define SUPPORTED
+ #define UINT32_TYPE	unsigned int
+ #define UINT16_TYPE	unsigned short


### PR DESCRIPTION

Maintainer: @Shulyaka 
Compile tested: malta/be
Run tested: None

Description:
This backports a change from postfix 3.8, I do not know exactly why it detects Linux 6 here, but this is needed to fix compilation with glibc 2.36.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
