### PR TITLE
Fix motion gettext

### DIFF
--- a/multimedia/motion/Makefile
+++ b/multimedia/motion/Makefile
@@ -24,6 +24,7 @@ PKG_CPE_ID:=cpe:/a:lavrsen:motion
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DEPENDS:=gettext-full/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk


### PR DESCRIPTION
Maintainer:  @mips171 (original Roger D <rogerdammit [at] gmail.com>)
Compile tested: (ARM, Linksys, OpenWrt version 22.03.2)

Description:
Package compile fails without.