### PR TITLE
update `cni` and `cni-plugins`

### DIFF
--- a/utils/cni-plugins/Makefile
+++ b/utils/cni-plugins/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cni-plugins
-PKG_VERSION:=1.0.1
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=1.1.1
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containernetworking/plugins/archive/v$(PKG_VERSION)
-PKG_HASH:=2ba3cd9f341a7190885b60d363f6f23c6d20d975a7a0ab579dd516f8c6117619
+PKG_HASH:=c86c44877c47f69cd23611e22029ab26b613f620195b76b3ec20f589367a7962
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>, Paul Spooren <mail@aparcar.org>
 

--- a/utils/cni/Makefile
+++ b/utils/cni/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cni
-PKG_VERSION:=1.1.0
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=1.1.2
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containernetworking/$(PKG_NAME)/archive/v$(PKG_VERSION)
-PKG_HASH:=d06305d6daf271838964c00591ddc53a9cc506e1e249b435ec31b0ea3353cbc5
+PKG_HASH:=7d4bcaf83acdd54b3dc216f7aa5b5e1b32cb797d9c6af601a2c26b97470ed743
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>, Paul Spooren <mail@aparcar.org>, Oskari Rauta <oskari.rauta@gmail.com>
 


### PR DESCRIPTION
Maintainer: me, @oskarirauta, @aparcar 
Compile tested: none
Run tested: none

Description:
Update [`cni`](https://github.com/containernetworking/cni) to [1.1.2](https://github.com/containernetworking/cni/releases/tag/v1.1.2)

Update [`cni-plugins`](https://github.com/containernetworking/plugins) to to [1.1.1](https://github.com/containernetworking/plugins/releases/tag/v1.1.1)