### PR TITLE
lvm2: update LVM2 to 2.03.17 and DM to 1.02.187

### DIFF
--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -9,12 +9,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=LVM2
-PKG_VERSION:=2.03.16
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=2.03.17
+PKG_VERSION_DM:=1.02.187
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://sourceware.org/pub/lvm2
-PKG_HASH:=e661ece15b5d88d8abe39a4c1e1db2f43e1896f019948bb98b0e15d777680786
+PKG_HASH:=7286cfa9651828c589389509546333b8da965dfa84a1a4c8ab3e681a47fabae7
 PKG_BUILD_DIR:=$(BUILD_DIR)/lvm2-$(BUILD_VARIANT)/$(PKG_NAME).$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
@@ -31,6 +32,7 @@ define Package/libdevmapper/Default
   CATEGORY:=Libraries
   TITLE:=The Linux Kernel Device Mapper userspace library
   URL:=https://sourceware.org/dm/
+  VERSION:=$(PKG_VERSION_DM)
   DEPENDS:=+kmod-dm +libpthread +libuuid +librt +libblkid
 endef
 

--- a/utils/lvm2/patches/002-const-stdio.patch
+++ b/utils/lvm2/patches/002-const-stdio.patch
@@ -1,6 +1,6 @@
 --- a/lib/commands/toolcontext.c
 +++ b/lib/commands/toolcontext.c
-@@ -1673,7 +1673,7 @@ struct cmd_context *create_toolcontext(u
+@@ -1667,7 +1667,7 @@ struct cmd_context *create_toolcontext(u
  	/* FIXME Make this configurable? */
  	reset_lvm_errno(1);
  
@@ -9,7 +9,7 @@
  	/* Set in/out stream buffering before glibc */
  	if (set_buffering
  #ifdef SYS_gettid
-@@ -2053,7 +2053,7 @@ void destroy_toolcontext(struct cmd_cont
+@@ -2045,7 +2045,7 @@ void destroy_toolcontext(struct cmd_cont
  		dm_hash_destroy(cmd->cft_def_hash);
  
  	dm_device_list_destroy(&cmd->cache_dm_devs);
@@ -20,7 +20,7 @@
  		if (is_valid_fd(STDIN_FILENO) &&
 --- a/tools/lvmcmdline.c
 +++ b/tools/lvmcmdline.c
-@@ -3398,6 +3398,7 @@ int lvm_split(char *str, int *argc, char
+@@ -3419,6 +3419,7 @@ int lvm_split(char *str, int *argc, char
  /* Make sure we have always valid filedescriptors 0,1,2 */
  static int _check_standard_fds(void)
  {
@@ -28,7 +28,7 @@
  	int err = is_valid_fd(STDERR_FILENO);
  
  	if (!is_valid_fd(STDIN_FILENO) &&
-@@ -3424,6 +3425,12 @@ static int _check_standard_fds(void)
+@@ -3445,6 +3446,12 @@ static int _check_standard_fds(void)
  		       strerror(errno));
  		return 0;
  	}

--- a/utils/lvm2/patches/003-no-mallinfo.patch
+++ b/utils/lvm2/patches/003-no-mallinfo.patch
@@ -1,11 +1,11 @@
 --- a/lib/mm/memlock.c
 +++ b/lib/mm/memlock.c
-@@ -187,12 +187,15 @@ static void _allocate_memory(void)
+@@ -198,12 +198,15 @@ static void _allocate_memory(void)
           *  memory on free(), this is good enough for our purposes.
           */
  	while (missing > 0) {
 +#ifdef __GLIBC__
- 		struct mallinfo inf = mallinfo();
+ 		struct MALLINFO inf = MALLINFO();
  		hblks = inf.hblks;
 +#endif
  
@@ -13,10 +13,10 @@
  			_touch_memory(areas[area], _size_malloc_tmp);
  
 +#ifdef __GLIBC__
- 		inf = mallinfo();
+ 		inf = MALLINFO();
  
  		if (hblks < inf.hblks) {
-@@ -202,9 +205,12 @@ static void _allocate_memory(void)
+@@ -213,9 +216,12 @@ static void _allocate_memory(void)
  			free(areas[area]);
  			_size_malloc_tmp /= 2;
  		} else {
@@ -29,7 +29,7 @@
  
  		if (area == max_areas && missing > 0) {
  			/* Too bad. Warn the user and proceed, as things are
-@@ -525,8 +531,13 @@ static void _lock_mem(struct cmd_context
+@@ -536,8 +542,13 @@ static void _lock_mem(struct cmd_context
  	 * will not block memory locked thread
  	 * Note: assuming _memlock_count_daemon is updated before _memlock_count
  	 */

--- a/utils/lvm2/patches/004-missing-includes.patch
+++ b/utils/lvm2/patches/004-missing-includes.patch
@@ -1,0 +1,10 @@
+--- a/tools/vgimportdevices.c
++++ b/tools/vgimportdevices.c
+@@ -15,6 +15,7 @@
+ #include "tools.h"
+ #include "lib/cache/lvmcache.h"
+ #include "lib/device/device_id.h"
++#include <sys/file.h>
+ 
+ struct vgimportdevices_params {
+ 	uint32_t added_devices;


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: none

Description:

Version 2.03.17 - 10th November 2022
====================================
  Add new options (--fs, --fsmode) for FS handling when resizing LVs.
  Fix 'lvremove -S|--select LV' to not also remove its historical LV right away.
  Fix lv_active field type to binary so --select and --binary applies properly.
  Switch to use mallinfo2 and use it only with glibc.
  Error out in lvm shell if using a cmd argument not supported in the shell.
  Fix lvm shell's lastlog command to report previous pre-command failures.
  Extend VDO and VDOPOOL without flushing and locking fs.
  Add --valuesonly option to lvmconfig to print only values without keys.
  Updates configure with recent autoconf tooling.
  Fix lvconvert --test --type vdo-pool execution.
  Add json_std output format for more JSON standard compliant version of output.
  Fix vdo_slab_size_mb value for converted VDO volume.
  Fix many corner cases in device_id, including handling of S/N duplicates.
  Fix various issues in lvmdbusd.

libdm changes:

Version 1.02.187 - 10th November 2022
=====================================
  Add DM_REPORT_GROUP_JSON_STD for more JSON standard compliant output format.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>