### PR TITLE
exfatprogs: update to version 1.2.0

### DIFF
--- a/utils/exfatprogs/Makefile
+++ b/utils/exfatprogs/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=exfatprogs
-PKG_VERSION:=1.1.3
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=1.2.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/$(PKG_NAME)/$(PKG_NAME)/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=e3ee4fb5af4abc9335aed7a749c319917c652ac1af687ba40aabd04a6b71f1ca
+PKG_HASH:=afeaf10c99f70204941427d9cdc62b0219ff7f7d5eb0f1a179b0d7bf6cfedbad
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: none

Description:
CHANGES:

 * fsck.exfat: Keep traveling files even if there is a corrupted directory entry set.

 * fsck.exfat: Introduce the option "b" to recover a boot sector even if an exFAT filesystem is not found.

 * fsck.exfat: Introduce the option "s" to create files in "/LOST+FOUND", which have clusters allocated but was not belonged to any files.

 * fsck.exfat: Rename '.' and '..' entry name to the one user want.

NEW FEATURES:

 * fsck.exfat: Repair corruptions of an exFAT filesystem. Please refer to fsck.exfat manpage to see what kind of corruptions can be repaired.

 * exfat2img: Dump metadata of an exFAT filesystem. Please refer to exfat2img manpage to see how to use it.

BUG FIXES:

 * fsck.exfat: Fix an infinite loop while traveling files.

 * tune.exfat: Fix bitmap entry corruption when adding new volume lablel.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>