### PR TITLE
postgresql: update to version 14.6

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -5,8 +5,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postgresql
-PKG_VERSION:=14.5
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=14.6
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=PostgreSQL
 PKG_CPE_ID:=cpe:/a:postgresql:postgresql
@@ -17,7 +17,7 @@ PKG_SOURCE_URL:=\
 	http://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
 	ftp://ftp.postgresql.org/pub/source/v$(PKG_VERSION)
 
-PKG_HASH:=d4f72cb5fb857c9a9f75ec8cf091a1771272802f2178f0b2e65b7b6ff64f4a30
+PKG_HASH:=508840fc1809d39ab72274d5f137dabb9fd7fb4f933da4168aeebb20069edf22
 
 PKG_USE_MIPS16:=0
 PKG_FIXUP:=autoreconf

--- a/libs/postgresql/patches/700-no-arm-crc-march-change.patch
+++ b/libs/postgresql/patches/700-no-arm-crc-march-change.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2141,9 +2141,9 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [
+@@ -2156,9 +2156,9 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [
  # flags. If not, check if adding -march=armv8-a+crc flag helps.
  # CFLAGS_ARMV8_CRC32C is set if the extra flag is required.
  PGAC_ARMV8_CRC32C_INTRINSICS([])


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: none

Description:
This release contains a variety of fixes from 14.5.

See https://www.postgresql.org/docs/release/14.6/ for details.