### PR TITLE
hwloc: update to 2.8.0

### DIFF
--- a/libs/hwloc/Makefile
+++ b/libs/hwloc/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hwloc
-PKG_VERSION:=2.7.1
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=2.8.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=https://download.open-mpi.org/release/$(PKG_NAME)/v2.7
-PKG_HASH:=0d4e1d36c3a72c5d61901bfd477337f5a4c7e0a975da57165237d00e35ef528d
+PKG_SOURCE_URL:=https://download.open-mpi.org/release/$(PKG_NAME)/v2.8
+PKG_HASH:=348a72fcd48c32a823ee1da149ae992203e7ad033549e64aed6ea6eeb01f42c1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64 master

Description:
