### PR TITLE
Werkzeug: update to version 2.2.2

### DIFF
--- a/lang/python/Werkzeug/Makefile
+++ b/lang/python/Werkzeug/Makefile
@@ -5,11 +5,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=Werkzeug
-PKG_VERSION:=2.0.2
+PKG_VERSION:=2.2.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=aa2bb6fc8dee8d6c504c0ac1e7f5f7dc5810a9903e793b6f715a9f015bdadb9a
+PKG_HASH:=7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: none

Description:
## Version 2.2.2
### Released 2022-08-08

  Fix router to restore the 2.1 strict_slashes == False behaviour
  whereby leaf-requests match branch rules and vice versa.
  pallets/werkzeug#2489

  Fix router to identify invalid rules rather than hang parsing them,
  and to correctly parse / within converter arguments.
  pallets/werkzeug#2489

  Update subpackage imports in werkzeug.routing to use the import as
  syntax for explicitly re-exporting public attributes.
  pallets/werkzeug#2493

  Parsing of some invalid header characters is more robust.
  pallets/werkzeug#2494

  When starting the development server, a warning not to use it in a
  production deployment is always shown. pallets/werkzeug#2480

  LocalProxy.__wrapped__ is always set to the wrapped object when the
  proxy is unbound, fixing an issue in doctest that would cause it to
  fail. pallets/werkzeug#2485

  Address one ResourceWarning related to the socket used by run_simple.
  pallets/werkzeug#2421

## Version 2.2.1
### Released 2022-07-27

  Fix router so that /path/ will match a rule /path if strict slashes
  mode is disabled for the rule. pallets/werkzeug#2467

  Fix router so that partial part matches are not allowed i.e. /2df
  does not match /<int>. pallets/werkzeug#2470

  Fix router static part weighting, so that simpler routes are matched
  before more complex ones. pallets/werkzeug#2471

  Restore ValidationError to be importable from werkzeug.routing.
  pallets/werkzeug#2465

## Version 2.2.0
### Released 2022-07-23

  Deprecated get_script_name, get_query_string, peek_path_info,
  pop_path_info, and extract_path_info. pallets/werkzeug#2461

  Remove previously deprecated code. pallets/werkzeug#2461

  Add MarkupSafe as a dependency and use it to escape values when
  rendering HTML. pallets/werkzeug#2419

  Added the werkzeug.debug.preserve_context mechanism for restoring
  context-local data for a request when running code in the debug
  console. pallets/werkzeug#2439

  Fix compatibility with Python 3.11 by ensuring that end_lineno and
  end_col_offset are present on AST nodes. pallets/werkzeug#2425

  Add a new faster matching router based on a state machine.
  pallets/werkzeug#2433

  Fix branch leaf path masking branch paths when strict-slashes is
  disabled. pallets/werkzeug#1074

  Names within options headers are always converted to lowercase. This
  matches RFC 6266 that the case is not relevant. pallets/werkzeug#2442

  AnyConverter validates the value passed for it when building URLs.
  pallets/werkzeug#2388

  The debugger shows enhanced error locations in tracebacks in Python
  3.11. pallets/werkzeug#2407

  Added Sans-IO is_resource_modified and parse_cookie functions based
  on WSGI versions. pallets/werkzeug#2408

  Added Sans-IO get_content_length function. pallets/werkzeug#2415

  Don’t assume a mimetype for test responses. pallets/werkzeug#2450

  Type checking FileStorage accepts os.PathLike. pallets/werkzeug#2418

## Version 2.1.2
### Released 2022-04-28

  The development server does not set Transfer-Encoding: chunked for
  1xx, 204, 304, and HEAD responses. pallets/werkzeug#2375

  Response HTML for exceptions and redirects starts with <!doctype
  html> and <html lang=en>. pallets/werkzeug#2390

  Fix ability to set some cache_control attributes to False.
  pallets/werkzeug#2379

  Disable keep-alive connections in the development server, which are
  not supported sufficiently by Python’s http.server.
  pallets/werkzeug#2397

## Version 2.1.1
### Released 2022-04-01

  ResponseCacheControl.s_maxage converts its value to an int, like
  max_age. pallets/werkzeug#2364

## Version 2.1.0
### Released 2022-03-28

  Drop support for Python 3.6. pallets/werkzeug#2277

  Using gevent or eventlet requires greenlet>=1.0 or PyPy>=7.3.7.
  werkzeug.locals and contextvars will not work correctly with older
  versions. pallets/werkzeug#2278

  Remove previously deprecated code. pallets/werkzeug#2276

    Remove the non-standard shutdown function from the WSGI environ
    when running the development server. See the docs for alternatives.

    Request and response mixins have all been merged into the Request
    and Response classes.

    The user agent parser and the useragents module is removed. The
    user_agent module provides an interface that can be subclassed to
    add a parser, such as ua-parser. By default it only stores the
    whole string.

    The test client returns TestResponse instances and can no longer be
    treated as a tuple. All data is available as properties on the
    response.

    Remove locals.get_ident and related thread-local code from locals,
    it no longer makes sense when moving to a contextvars-based
    implementation.

    Remove the python -m werkzeug.serving CLI.

    The has_key method on some mapping datastructures; use key in data
    instead.

    Request.disable_data_descriptor is removed, pass shallow=True
    instead.

    Remove the no_etag parameter from Response.freeze().

    Remove the HTTPException.wrap class method.

    Remove the cookie_date function. Use http_date instead.

    Remove the pbkdf2_hex, pbkdf2_bin, and safe_str_cmp functions. Use
    equivalents in hashlib and hmac modules instead.

    Remove the Href class.

    Remove the HTMLBuilder class.

    Remove the invalidate_cached_property function. Use del obj.attr
    instead.

    Remove bind_arguments and validate_arguments. Use Signature.bind()
    and inspect.signature() instead.

    Remove detect_utf_encoding, it’s built-in to json.loads.

    Remove format_string, use string.Template instead.

    Remove escape and unescape. Use MarkupSafe instead.

  The multiple parameter of parse_options_header is deprecated.
  pallets/werkzeug#2357

  Rely on PEP 538 and PEP 540 to handle decoding file names with the
  correct filesystem encoding. The filesystem module is removed.
  pallets/werkzeug#1760

  Default values passed to Headers are validated the same way values
  added later are. pallets/werkzeug#1608

  Setting CacheControl int properties, such as max_age, will convert
  the value to an int. pallets/werkzeug#2230

  Always use socket.fromfd when restarting the dev server.
  pallets/werkzeug#2287

  When passing a dict of URL values to Map.build, list values do not
  filter out None or collapse to a single value. Passing a MultiDict
  does collapse single items. This undoes a previous change that made
  it difficult to pass a list, or None values in a list, to custom URL
  converters. pallets/werkzeug#2249

  run_simple shows instructions for dealing with “address already in
  use” errors, including extra instructions for macOS.
  pallets/werkzeug#2321

  Extend list of characters considered always safe in URLs based on RFC
  3986. pallets/werkzeug#2319

  Optimize the stat reloader to avoid watching unnecessary files in
  more cases. The watchdog reloader is still recommended for
  performance and accuracy. pallets/werkzeug#2141

  The development server uses Transfer-Encoding: chunked for streaming
  responses when it is configured for HTTP/1.1. pallets/werkzeug#2090,
  pallets/werkzeug#1327, pallets/werkzeug#2091

  The development server uses HTTP/1.1, which enables keep-alive
  connections and chunked streaming responses, when threaded or
  processes is enabled. pallets/werkzeug#2323

  cached_property works for classes with __slots__ if a corresponding
  _cache_{name} slot is added. pallets/werkzeug#2332

  Refactor the debugger traceback formatter to use Python’s built-in
  traceback module as much as possible. pallets/werkzeug#1753

  The TestResponse.text property is a shortcut for
  r.get_data(as_text=True), for convenient testing against text instead
  of bytes. pallets/werkzeug#2337

  safe_join ensures that the path remains relative if the trusted
  directory is the empty string. pallets/werkzeug#2349

  Percent-encoded newlines (%0a), which are decoded by WSGI servers,
  are considered when routing instead of terminating the match early.
  pallets/werkzeug#2350

  The test client doesn’t set duplicate headers for CONTENT_LENGTH and
  CONTENT_TYPE. pallets/werkzeug#2348

  append_slash_redirect handles PATH_INFO with internal slashes.
  pallets/werkzeug#1972, pallets/werkzeug#2338

  The default status code for append_slash_redirect is 308 instead of
  301. This preserves the request body, and matches a previous change to strict_slashes in routing. pallets/werkzeug#2351

  Fix ValueError: I/O operation on closed file. with the test client
  when following more than one redirect. pallets/werkzeug#2353

  Response.autocorrect_location_header is disabled by default. The
  Location header URL will remain relative, and exclude the scheme and
  domain, by default. pallets/werkzeug#2352

  Request.get_json() will raise a 400 BadRequest error if the
  Content-Type header is not application/json. This makes a very common
  source of confusion more visible. pallets/werkzeug#2339

## Version 2.0.3
### Released 2022-02-07

  ProxyFix supports IPv6 addresses. pallets/werkzeug#2262

  Type annotation for Response.make_conditional,
  HTTPException.get_response, and Map.bind_to_environ accepts Request
  in addition to WSGIEnvironment for the first parameter.
  pallets/werkzeug#2290

  Fix type annotation for Request.user_agent_class.
  pallets/werkzeug#2273

  Accessing LocalProxy.__class__ and __doc__ on an unbound proxy
  returns the fallback value instead of a method object.
  pallets/werkzeug#2188

  Redirects with the test client set RAW_URI and REQUEST_URI correctly.
  pallets/werkzeug#2151

Signed-off-by: Daniel Golle <daniel@makrotopia.org>