### PR TITLE
[22.03 backport] telnet-bsd: add package

### DIFF
--- a/net/telnet-bsd/Makefile
+++ b/net/telnet-bsd/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2017 Daniel Engberg <daniel.engberg.lists@pyret.net>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=telnet-bsd
+PKG_VERSION=1.2
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=COPYING
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=http://mirror.netcologne.de/gentoo/distfiles/
+PKG_SOURCE_SUBDIR=$(PKG_NAME)-$(PKG_VERSION)
+PKG_HASH:=d6a9d26740ef75565cb1ed8ff11e327d240e6734748b2d1d2e96c126849e4733
+
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+
+TARGET_CFLAGS+= -Wno-format-security
+
+define Package/telnet-bsd
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libncurses
+  TITLE:=telnet-bsd
+  URL:=https://www.openbsd.org/
+endef
+
+define Package/telnet-bsd/description
+  Telnet client ported from OpenBSD
+endef
+
+define Package/telnet-bsd/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/telnet/telnet $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,telnet-bsd))

--- a/net/telnet-bsd/patches/001-telnet-bsd-1.2-fbsd.patch
+++ b/net/telnet-bsd/patches/001-telnet-bsd-1.2-fbsd.patch
@@ -1,0 +1,95 @@
+--- a/configure.in
++++ b/configure.in
+@@ -12,6 +12,8 @@ ALL_LINGUAS="de"
+ AC_SUBST(PACKAGE)
+ AC_SUBST(VERSION)
+ 
++AC_CHECK_HEADERS([pty.h utmp.h])
++
+ if test x"$ac_default_prefix" = x"/usr"
+ then
+ 	if test x"${mandir}" = x'${prefix}/man'
+--- a/telnet/commands.c
++++ b/telnet/commands.c
+@@ -29,11 +29,13 @@
+ 
+ #include "telnet_locl.h"
+ #include <err.h>
++#include <unistd.h>
+ 
+ #if	defined(IPPROTO_IP) && defined(IP_TOS)
+ int tos = -1;
+ #endif /* defined(IPPROTO_IP) && defined(IP_TOS) */
+ 
++extern char **environ;
+ char *hostname;
+ 
+ typedef int (*intrtn_t) __P ((int, char **));
+--- a/telnet/ring.h
++++ b/telnet/ring.h
+@@ -29,6 +29,7 @@
+  */
+ 
+ #include <sys/cdefs.h>
++#include <sys/types.h>
+ #define P __P
+ 
+ /*
+--- a/telnetd/setproctitle.c
++++ b/telnetd/setproctitle.c
+@@ -72,6 +72,7 @@ char setproctitle_rcsid[] =
+ static char **Argv = NULL;		/* pointer to argument vector */
+ static char *LastArgv = NULL;		/* end of argv */
+ static char Argv0[128];			/* program name */
++extern char **environ;
+ 
+ void
+ initsetproctitle(int argc, char **argv, char **envp)
+@@ -86,10 +87,10 @@ initsetproctitle(int argc, char **argv,
+ 
+ 	for (i = 0; envp[i] != NULL; i++)
+ 		continue;
+-	__environ = (char **) malloc(sizeof (char *) * (i + 1));
++	environ = (char **) malloc(sizeof (char *) * (i + 1));
+ 	for (i = 0; envp[i] != NULL; i++)
+-		__environ[i] = strdup(envp[i]);
+-	__environ[i] = NULL;
++		environ[i] = strdup(envp[i]);
++	environ[i] = NULL;
+ 
+ 	/*
+ 	**  Save start and extent of argv for setproctitle.
+--- a/telnetd/sys_term.c
++++ b/telnetd/sys_term.c
+@@ -27,8 +27,15 @@
+  * SUCH DAMAGE.
+  */
+ 
++#include <config.h>
++
++#include <sys/types.h>
++#ifdef HAVE_UTMP_H 
+ #include <utmp.h>
++#endif
++#ifdef HAVE_PTY_H
+ #include <pty.h>
++#endif
+ 
+ #include "telnetd.h"
+ #include "pathnames.h"
+@@ -820,6 +827,7 @@ addarg (struct argv_stuff *avs, const ch
+ void
+ cleanup (int sig)
+ {
++#if !defined(__FreeBSD__) || __FreeBSD__ < 9
+   sigset_t sigset;
+   char *p;
+   (void) sig;
+@@ -847,6 +855,7 @@ cleanup (int sig)
+   *p = 'p';
+   chmod (line, 0666);
+   chown (line, 0, 0);
++#endif
+   shutdown (net, 2);
+   exit (1);
+ }

--- a/net/telnet-bsd/patches/002-dont-compile-telnetd.patch
+++ b/net/telnet-bsd/patches/002-dont-compile-telnetd.patch
@@ -1,0 +1,42 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -3,7 +3,7 @@
+ #
+ AUTOMAKE_OPTIONS = 1.8 gnits dist-bzip2
+ #
+-SUBDIRS = m4 telnet telnetd
++SUBDIRS = m4 telnet
+ 
+ CLEANFILES = *~
+ 
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -164,7 +164,7 @@ target_vendor = @target_vendor@
+ #
+ AUTOMAKE_OPTIONS = 1.8 gnits dist-bzip2
+ #
+-SUBDIRS = m4 telnet telnetd
++SUBDIRS = m4 telnet
+ CLEANFILES = *~
+ ACLOCAL_AMFLAGS = -I m4
+ all: config.h
+--- a/configure
++++ b/configure
+@@ -3279,7 +3279,7 @@ _ACEOF
+ fi
+ 
+ 
+-                                        ac_config_files="$ac_config_files Makefile m4/Makefile telnet/Makefile telnetd/Makefile"
++                                        ac_config_files="$ac_config_files Makefile m4/Makefile telnet/Makefile"
+ 
+ cat >confcache <<\_ACEOF
+ # This file is a shell script that caches the results of configure
+--- a/configure.in
++++ b/configure.in
+@@ -54,5 +54,5 @@ AC_SUBST(PIE_LDFLAGS)
+ dnl Checks for typedefs, structures, and compiler characteristics.
+ AC_C_CONST
+ 
+-AC_CONFIG_FILES([Makefile m4/Makefile telnet/Makefile telnetd/Makefile])
++AC_CONFIG_FILES([Makefile m4/Makefile telnet/Makefile])
+ AC_OUTPUT

--- a/net/telnet-bsd/patches/telnet-bsd-1.2-format-security.patch
+++ b/net/telnet-bsd/patches/telnet-bsd-1.2-format-security.patch
@@ -1,0 +1,52 @@
+--- a/telnet/utilities.c
++++ b/telnet/utilities.c
+@@ -739,22 +739,22 @@ printsub(char direction, unsigned char *
+ 		case ENV_VAR:
+ 		  if (pointer[1] == TELQUAL_SEND)
+ 		    goto def_case;
+-		  fprintf(NetTrace, "\" VAR " + noquote);
++		  fprintf(NetTrace, "%s", "\" VAR " + noquote);
+ 		  noquote = 2;
+ 		  break;
+ 
+ 		case ENV_VALUE:
+-		  fprintf(NetTrace, "\" VALUE " + noquote);
++		  fprintf(NetTrace, "%s", "\" VALUE " + noquote);
+ 		  noquote = 2;
+ 		  break;
+ 
+ 		case ENV_ESC:
+-		  fprintf(NetTrace, "\" ESC " + noquote);
++		  fprintf(NetTrace, "%s", "\" ESC " + noquote);
+ 		  noquote = 2;
+ 		  break;
+ 
+ 		case ENV_USERVAR:
+-		  fprintf(NetTrace, "\" USERVAR " + noquote);
++		  fprintf(NetTrace, "%s", "\" USERVAR " + noquote);
+ 		  noquote = 2;
+ 		  break;
+ 
+--- a/telnetd/utility.c
++++ b/telnetd/utility.c
+@@ -897,17 +897,17 @@ printsub(char direction, unsigned char *
+ 			case ENV_VAR:
+ 			    if (pointer[1] == TELQUAL_SEND)
+ 				goto def_case;
+-			    netoprintf("\" VAR " + noquote);
++			    netoprintf("%s", "\" VAR " + noquote);
+ 			    noquote = 2;
+ 			    break;
+ 
+ 			case ENV_VALUE:
+-			    netoprintf("\" VALUE " + noquote);
++			    netoprintf("%s", "\" VALUE " + noquote);
+ 			    noquote = 2;
+ 			    break;
+ 
+ 			case ENV_ESC:
+-			    netoprintf("\" ESC " + noquote);
++			    netoprintf("%s", "\" ESC " + noquote);
+ 			    noquote = 2;
+ 			    break;
+ 

--- a/net/telnet-bsd/patches/telnet-bsd-1.2-musl.patch
+++ b/net/telnet-bsd/patches/telnet-bsd-1.2-musl.patch
@@ -1,0 +1,36 @@
+--- a/telnet/misc-proto.h
++++ b/telnet/misc-proto.h
+@@ -63,7 +63,7 @@
+ #ifndef	__MISC_PROTO__
+ #define	__MISC_PROTO__
+ 
+-#include <sys/cdefs.h>
++#define	__P(protos) protos /* full-blown ANSI C */
+ 
+ void auth_encrypt_init __P((char *, char *, char *, int));
+ void auth_encrypt_user __P((char *));
+--- a/telnet/ring.h
++++ b/telnet/ring.h
+@@ -28,8 +28,8 @@
+  *
+  */
+ 
+-#include <sys/cdefs.h>
+ #include <sys/types.h>
++#define	__P(protos) protos /* full-blown ANSI C */
+ #define P __P
+ 
+ /*
+--- a/telnetd/sys_term.c
++++ b/telnetd/sys_term.c
+@@ -838,8 +838,10 @@ cleanup (int sig)
+    * receive another signal while we're in that function. */
+   sigfillset(&sigset);
+   sigprocmask(SIG_SETMASK, &sigset, &sigset);
++#if defined(logwtmp)
+   if (logout (p))
+     logwtmp (p, "", "");
++#endif
+   sigprocmask(SIG_SETMASK, &sigset, NULL);
+ #ifdef PARANOID_TTYS
+   /*


### PR DESCRIPTION
The telnet-bsd package currently only exist in master: this PR aims to bring it into current stable release.

It is a leaf package, sole provider and not affecting existing things, so hopefully backporting should be acceptable.