### PR TITLE
[22.03] node: bump to v16.19.0

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v16.18.0
+PKG_VERSION:=v16.19.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=fcfe6ad2340f229061d3e81a94df167fe3f77e01712dedc0144a0e7d58e2c69b
+PKG_HASH:=4f1fec1aea2392f6eb6d1d040b01e7ee3e51e762a9791dfea590920bc1156706
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,6 +1,6 @@
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1290,7 +1290,8 @@ Module._initPaths = function() {
+@@ -1300,7 +1300,8 @@ Module._initPaths = function() {
      path.resolve(process.execPath, '..') :
      path.resolve(process.execPath, '..', '..');
  


### PR DESCRIPTION
Maintainer: me @ianchi
Compile tested: 22.03, arm
Run tested: (qemu 7.2.0) arm

Description:

Notable Changes
*OpenSSL 1.1.1s
*Root certificates updated to NSS 3.85
*Time zone update to 2022f

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
(cherry picked from commit f8bd5eaa6edcf437130118295380c93f2acdfdc3)
