### PR TITLE
sshtunnel: add pxycmd option

### DIFF
--- a/net/sshtunnel/Makefile
+++ b/net/sshtunnel/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sshtunnel
 PKG_VERSION:=4
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_LICENSE:=GPL-2.0-or-later
 
 PKG_MAINTAINER:=Nuno Goncalves <nunojpg@gmail.com>

--- a/net/sshtunnel/files/sshtunnel.init
+++ b/net/sshtunnel/files/sshtunnel.init
@@ -52,7 +52,8 @@ validate_server_section() {
 		'ServerAliveInterval:min(0)' \
 		'StrictHostKeyChecking:or("yes", "no", "accept-new")' \
 		'TCPKeepAlive:or("yes", "no")' \
-		'VerifyHostKeyDNS:or("yes", "no")'
+		'VerifyHostKeyDNS:or("yes", "no")' \
+		'ProxyCommand:string(1)'
 }
 
 validate_tunnelR_section() {
@@ -177,6 +178,17 @@ load_server() {
 	append_params CheckHostIP Compression CompressionLevel IdentityFile \
 		LogLevel PKCS11Provider ServerAliveCountMax ServerAliveInterval \
 		StrictHostKeyChecking TCPKeepAlive VerifyHostKeyDNS
+
+	if [ -n "$ProxyCommand" ]; then
+		ProxyCommand=$(echo $ProxyCommand | sed "s/%h/"${hostname}"/g")
+		ProxyCommand=$(echo $ProxyCommand | sed "s/%p/"${port}"/g")
+
+		local proxy_option=/tmp/sshtunnel.proxycommand.$server.sh
+		echo "#!/bin/sh"             > $proxy_option
+		echo "exec ${ProxyCommand}" >> $proxy_option
+		chmod a+x $proxy_option
+		ARGS_options="$ARGS_options -o ProxyCommand=$proxy_option"
+	fi
 
 	ARGS="$ARGS_options -o ExitOnForwardFailure=yes -o BatchMode=yes -nN $ARGS_tunnels -p $port $user@$hostname"
 

--- a/net/sshtunnel/files/uci_sshtunnel
+++ b/net/sshtunnel/files/uci_sshtunnel
@@ -21,6 +21,7 @@
 #	option StrictHostKeyChecking	accept-new
 #	option TCPKeepAlive		yes
 #	option VerifyHostKeyDNS		yes
+#	option ProxyCommand		'ncat --proxy-type http --proxy-auth user:pass --proxy ip:port %h %p'
 
 # tunnelR(emote) - when the connection will be initiated to the R(emote) endpoint at
 # remoteaddress:remoteport and then forwarded to localaddress:localport


### PR DESCRIPTION
Maintainer: @nunojpg
Compile tested: mips
Run tested: TP-Link Archer C2 v3, OpenWrt 19.07.2

Description:

A simple update to support the ProxyCommand parameter. Installing the OpenSSH client and NCat tool it's possible to stablish the SSH tunnel over an authenticated HTTP proxy or over a SOCKS4/5 proxy.

This implementation fully works when using the OpenSSH client and one compatible helper tool (NCat as example).

Replaces https://github.com/openwrt/packages/pull/13887

Signed-off-by: Lars Theorin [lars18th@users.noreply.github.com](mailto:lars18th@users.noreply.github.com)

