### PR TITLE
libgpiod: add missing kernel build options via KCONFIG

### DIFF
--- a/libs/libgpiod/Makefile
+++ b/libs/libgpiod/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgpiod
 PKG_VERSION:=1.6.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/libs/libgpiod/
@@ -43,6 +43,9 @@ define Package/libgpiod
   CATEGORY:=Libraries
   URL:=https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
   TITLE:=Library for interacting with Linux's GPIO character device
+  KCONFIG:= \
+    CONFIG_GPIO_CDEV=y \
+    CONFIG_GPIO_CDEV_V1=y
   DEPENDS:=@GPIO_SUPPORT
 endef
 


### PR DESCRIPTION
Maintainer: @mhei or @neheb 
Compile tested: x86_64, APU3, master
Run tested: x86_64, APU3, OpenWrt master,tests done)

Description:

This library needs the kernel config option 'CONFIG_GPIO_CDEV_V1=y' to be set. If this is not set, the tool 'gpioinfo' produces the error message 'error creating line iterator'. Add the missing kernel config option to build CDEV with API Version 1 fixes this. Other distributions does have the same issue: https://bugs.gentoo.org/807334

```
gpiochip3 - 7 lines:
        line   0: "front-led1" "apu:green:1" output active-low [used]
        line   1: "front-led2" "apu:green:2" output active-low [used]
        line   2: "front-led3" "apu:green:3" output active-low [used]
        line   3: "front-button" "front button" input active-low [used]
        line   4:    "simswap"       unused  output  active-high
        line   5: "mpcie2_reset" unused output active-high
        line   6: "mpcie3_reset" unused output active-high
```
