### PR TITLE
[21.02] node: bump to v14.21.2

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v14.20.1
+PKG_VERSION:=v14.21.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=365057ea661923cbfa71bdd7a8d0ace9ddff8d22d431ad92355f8433cecff14d
+PKG_HASH:=d8f09a0f16773a77613c3817606f6d455624992d9c43443aca15e91807a1ff03
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: 21.02, arm
 Run tested: (qemu 7.2.0) arm

Description:

Notable changes
* CVE-2022-43548: DNS rebinding in --inspect via invalid octal IP address (Medium)
* OpenSSL 1.1.1s
* Root certificates updated to NSS 3.85
* Time zone update to 2022f

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
