### PR TITLE
sshuttle: Add new meta package for opkg install

### DIFF
--- a/net/sshuttle/Makefile
+++ b/net/sshuttle/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sshuttle
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=1
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=f5a3ed1e5ab1213c7a6df860af41f1a903ab2cafbfef71f371acdcff21e69ee6

--- a/net/sshuttle/Makefile
+++ b/net/sshuttle/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Thomas Cujé
+# Copyright (C) 2022-2023 Thomas Cujé
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -23,20 +23,20 @@ include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
 
 define Package/sshuttle
-  SUBMENU:=SSH
-  SECTION:=net
-  CATEGORY:=Network
-  TITLE:=Full-featured VPN over an SSH tunnel
-  URL:=https://github.com/sshuttle/sshuttle
-  EXTRA_DEPENDS:= \
-  	python3-light \
-  	python3-ctypes \
-  	python3-urllib
-  PKGARCH:=all
+	SUBMENU:=SSH
+	SECTION:=net
+	CATEGORY:=Network
+	TITLE:=Full-featured VPN over an SSH tunnel
+	URL:=https://github.com/sshuttle/sshuttle
+	EXTRA_DEPENDS:= \
+		python3-light \
+		python3-ctypes \
+		python3-urllib
+	PKGARCH:=all
 endef
 
 define Package/sshuttle/description
-  Transparent proxy server that works as a poor man's VPN. Forwards over ssh. Doesn't require admin. Works with Linux and MacOS. Supports DNS tunneling.
+	Transparent proxy server that works as a poor man's VPN. Forwards over ssh. Doesn't require admin. Works with Linux and MacOS. Supports DNS tunneling.
 endef
 
 define Package/sshuttle/conffiles

--- a/net/sshuttle/Makefile
+++ b/net/sshuttle/Makefile
@@ -32,6 +32,7 @@ define Package/sshuttle
   	+python3-light \
   	+python3-ctypes \
   	+python3-urllib
+  PKGARCH:=all
 endef
 
 define Package/sshuttle/description

--- a/net/sshuttle/Makefile
+++ b/net/sshuttle/Makefile
@@ -37,18 +37,22 @@ define Package/sshuttle
 endef
 
 define Package/sshuttle/description
-  Transparent proxy server that works as a poor man's VPN. Forwards over ssh. Doesn't require admin. Works with Linux and MacOS. Supports DNS tunneling.
+Transparent proxy server that works as a poor man's VPN. Forwards over ssh. Doesn't require admin. Works with Linux and MacOS. Supports DNS tunneling.
 endef
 
 define Package/sshuttle/conffiles
 /etc/config/sshuttle
 endef
 
-define Package/sshuttle/install
-	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) ./files/sshuttle.init $(1)/etc/init.d/sshuttle
+define Py3Package/sshuttle/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sshuttle $(1)/usr/bin/
+
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/sshuttle.config $(1)/etc/config/sshuttle
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/sshuttle.init $(1)/etc/init.d/sshuttle
 endef
 
 $(eval $(call Py3Package,sshuttle))

--- a/net/sshuttle/Makefile
+++ b/net/sshuttle/Makefile
@@ -16,6 +16,8 @@ PKG_HASH:=f5a3ed1e5ab1213c7a6df860af41f1a903ab2cafbfef71f371acdcff21e69ee6
 
 PKG_MAINTAINER:=Thomas Cujé <dev.cuje@freenet.de>
 PKG_LICENSE:=LGPL-2.1-only
+PKG_LICENSE_FILES:=LICENSE
+
 
 include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk

--- a/net/sshuttle/Makefile
+++ b/net/sshuttle/Makefile
@@ -28,10 +28,10 @@ define Package/sshuttle
   CATEGORY:=Network
   TITLE:=sshuttle: where transparent proxy meets VPN meets ssh
   URL:=https://github.com/sshuttle/sshuttle
-  DEPENDS:= \
-  	+python3-light \
-  	+python3-ctypes \
-  	+python3-urllib
+  EXTRA_DEPENDS:= \
+  	python3-light \
+  	python3-ctypes \
+  	python3-urllib
   PKGARCH:=all
 endef
 

--- a/net/sshuttle/Makefile
+++ b/net/sshuttle/Makefile
@@ -11,22 +11,29 @@ PKG_NAME:=sshuttle
 PKG_VERSION:=1.1.1
 PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/sshuttle/sshuttle/archive/refs/tags/v$(PKG_VERSION).tar.gz
-PKG_HASH:=87b6343da4b7ea164cc1638a3ff25c41cf9dbc70bbc84bc4df8c41f963a4b0b9
+PYPI_NAME:=$(PKG_NAME)
+PKG_HASH:=f5a3ed1e5ab1213c7a6df860af41f1a903ab2cafbfef71f371acdcff21e69ee6
 
 PKG_MAINTAINER:=Thomas Cujé <dev.cuje@freenet.de>
 PKG_LICENSE:=LGPL-2.1-only
 
+include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include ../../lang/python/python3-package.mk
 
 define Package/sshuttle
   SUBMENU:=SSH
   SECTION:=net
   CATEGORY:=Network
   TITLE:=sshuttle: where transparent proxy meets VPN meets ssh
-  DEPENDS:=+python3 +python3-pip +iptables-mod-extra +iptables-mod-nat-extra +iptables-mod-ipopt
-  PKGARCH:=all
+  URL:=https://github.com/sshuttle/sshuttle
+  DEPENDS:= \
+  +python3-light \
+  +python3-ctypes \
+  +python3-urllib \
+  +iptables-mod-extra \
+  +iptables-mod-nat-extra \
+  +iptables-mod-ipopt
 endef
 
 define Package/sshuttle/description
@@ -37,9 +44,6 @@ define Package/sshuttle/conffiles
 /etc/config/sshuttle
 endef
 
-define Build/Compile
-endef
-
 define Package/sshuttle/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/sshuttle.init $(1)/etc/init.d/sshuttle
@@ -47,9 +51,6 @@ define Package/sshuttle/install
 	$(INSTALL_CONF) ./files/sshuttle.config $(1)/etc/config/sshuttle
 endef
 
-define Package/sshuttle/postinst
-#!/bin/sh
-/usr/bin/pip3 install sshuttle==$(PKG_VERSION)
-endef
-
+$(eval $(call Py3Package,sshuttle))
 $(eval $(call BuildPackage,sshuttle))
+$(eval $(call BuildPackage,sshuttle-src))

--- a/net/sshuttle/Makefile
+++ b/net/sshuttle/Makefile
@@ -43,6 +43,20 @@ define Package/sshuttle/conffiles
 /etc/config/sshuttle
 endef
 
+# Some sshuttle script files are copied to SSH remote hosts and are therefore mandatory.
+# This causes the otherwise pre-compiled package to contain the source package.
+# Compare with https://github.com/sshuttle/sshuttle/blob/v1.1.1/sshuttle/ssh.py#L95-L103
+# Since the source is very small in general, to reduce complexity
+# and support all architectures no explicit filtering is used.
+define Package/sshuttle/install
+	$(call Py3Package/sshuttle/install,$(1))
+	$(call Py3Package/ProcessFilespec,sshuttle,$(PKG_INSTALL_DIR),$(1))
+	$(call Python3/DeleteEmptyDirs,$(1))
+	if [ -d "$(1)/usr/bin" ]; then \
+		$(call Python3/FixShebang,$(1)/usr/bin/*) ; \
+	fi
+endef
+
 define Py3Package/sshuttle/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sshuttle $(1)/usr/bin/
@@ -56,4 +70,3 @@ endef
 
 $(eval $(call Py3Package,sshuttle))
 $(eval $(call BuildPackage,sshuttle))
-$(eval $(call BuildPackage,sshuttle-src))

--- a/net/sshuttle/Makefile
+++ b/net/sshuttle/Makefile
@@ -18,7 +18,6 @@ PKG_MAINTAINER:=Thomas Cujé <dev.cuje@freenet.de>
 PKG_LICENSE:=LGPL-2.1-only
 PKG_LICENSE_FILES:=LICENSE
 
-
 include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
@@ -30,12 +29,9 @@ define Package/sshuttle
   TITLE:=sshuttle: where transparent proxy meets VPN meets ssh
   URL:=https://github.com/sshuttle/sshuttle
   DEPENDS:= \
-  +python3-light \
-  +python3-ctypes \
-  +python3-urllib \
-  +iptables-mod-extra \
-  +iptables-mod-nat-extra \
-  +iptables-mod-ipopt
+  	+python3-light \
+  	+python3-ctypes \
+  	+python3-urllib
 endef
 
 define Package/sshuttle/description

--- a/net/sshuttle/Makefile
+++ b/net/sshuttle/Makefile
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2022 Thomas Cujé
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=sshuttle
+PKG_VERSION:=1.1.1
+PKG_RELEASE:=1
+PKG_LICENSE:=LGPL-2.1-only
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/sshuttle/sshuttle/archive/refs/tags/v$(PKG_VERSION).tar.gz
+
+PKG_MAINTAINER:=Thomas Cujé <dev.cuje@freenet.de>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/sshuttle
+  SUBMENU:=SSH
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=sshuttle: where transparent proxy meets VPN meets ssh
+  DEPENDS:=+python3 +python3-pip +iptables-mod-extra +iptables-mod-nat-extra +iptables-mod-ipopt
+  PKGARCH:=all
+endef
+
+define Package/sshuttle/description
+  Transparent proxy server that works as a poor man's VPN. Forwards over ssh. Doesn't require admin. Works with Linux and MacOS. Supports DNS tunneling.
+endef
+
+define Package/sshuttle/conffiles
+/etc/config/sshuttle
+endef
+
+define Build/Compile
+endef
+
+define Package/sshuttle/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/sshuttle.init $(1)/etc/init.d/sshuttle
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/sshuttle.config $(1)/etc/config/sshuttle
+endef
+
+define Package/sshuttle/postinst
+#!/bin/sh
+/usr/bin/pip3 install sshuttle==$(PKG_VERSION)
+endef
+
+$(eval $(call BuildPackage,sshuttle))

--- a/net/sshuttle/Makefile
+++ b/net/sshuttle/Makefile
@@ -11,11 +11,11 @@ PKG_NAME:=sshuttle
 PKG_VERSION:=1.1.1
 PKG_RELEASE:=1
 
-PYPI_NAME:=$(PKG_NAME)
+PYPI_NAME:=sshuttle
 PKG_HASH:=f5a3ed1e5ab1213c7a6df860af41f1a903ab2cafbfef71f371acdcff21e69ee6
 
 PKG_MAINTAINER:=Thomas Cujé <dev.cuje@freenet.de>
-PKG_LICENSE:=LGPL-2.1-only
+PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=LICENSE
 
 include ../../lang/python/pypi.mk
@@ -26,7 +26,7 @@ define Package/sshuttle
   SUBMENU:=SSH
   SECTION:=net
   CATEGORY:=Network
-  TITLE:=sshuttle: where transparent proxy meets VPN meets ssh
+  TITLE:=Full-featured VPN over an SSH tunnel
   URL:=https://github.com/sshuttle/sshuttle
   EXTRA_DEPENDS:= \
   	python3-light \
@@ -36,7 +36,7 @@ define Package/sshuttle
 endef
 
 define Package/sshuttle/description
-Transparent proxy server that works as a poor man's VPN. Forwards over ssh. Doesn't require admin. Works with Linux and MacOS. Supports DNS tunneling.
+  Transparent proxy server that works as a poor man's VPN. Forwards over ssh. Doesn't require admin. Works with Linux and MacOS. Supports DNS tunneling.
 endef
 
 define Package/sshuttle/conffiles

--- a/net/sshuttle/Makefile
+++ b/net/sshuttle/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sshuttle
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=1
-PKG_LICENSE:=LGPL-2.1-only
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/sshuttle/sshuttle/archive/refs/tags/v$(PKG_VERSION).tar.gz
 PKG_HASH:=87b6343da4b7ea164cc1638a3ff25c41cf9dbc70bbc84bc4df8c41f963a4b0b9
 
 PKG_MAINTAINER:=Thomas Cujé <dev.cuje@freenet.de>
+PKG_LICENSE:=LGPL-2.1-only
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/sshuttle/Makefile
+++ b/net/sshuttle/Makefile
@@ -14,6 +14,7 @@ PKG_LICENSE:=LGPL-2.1-only
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/sshuttle/sshuttle/archive/refs/tags/v$(PKG_VERSION).tar.gz
+PKG_HASH:=87b6343da4b7ea164cc1638a3ff25c41cf9dbc70bbc84bc4df8c41f963a4b0b9
 
 PKG_MAINTAINER:=Thomas Cujé <dev.cuje@freenet.de>
 

--- a/net/sshuttle/files/sshuttle.config
+++ b/net/sshuttle/files/sshuttle.config
@@ -16,7 +16,7 @@
 
 #config gateway '90.60.90.77'
 #    option listen                   '192.168.1.1:9090'
-#    option subnets                  '90.60.90.0/24' (or) '90.60.90.105,90.60.90.106'
+#    list subnets                    '90.60.90.0/24' (or) '90.60.90.105,90.60.90.106'
 #    option method                   'auto'
 #    option auto_hosts               'no'
 #    option auto_nets                'no'

--- a/net/sshuttle/files/sshuttle.config
+++ b/net/sshuttle/files/sshuttle.config
@@ -1,0 +1,39 @@
+# In the examples below, the IP addresses have the following meanings
+#
+# 90.60.90.77   - ssh server to become the gateway for locally captured traffic
+#                 can be a full fledged ssh host definition like: [username@]sshserver[:port]
+#                 or may reference an entry in the ~/.ssh/config file like: remote-ssh-gateway
+#
+# 90.60.90.0/24 - remote address of a subnet to forward using the given ssh host 90.60.90.77
+#                 specify 0/0 to forward all IPv4 or ::/0 for all IPv6 traffic
+#
+# 192.168.1.1   - internal lan network IP of this routing device for sshuttle to listen on
+#                 use 0.0.0.0 to listen on all interfaces and IP addresses
+#                 Listening on WAN side provides unrestricted access to remote networks!
+#
+# detailed parameter documentation can be found at https://sshuttle.readthedocs.io/en/stable/manpage.html
+#
+
+#config gateway '90.60.90.77'
+#    option listen                   '192.168.1.1:9090'
+#    option subnets                  '90.60.90.0/24' (or) '90.60.90.105,90.60.90.106'
+#    option method                   'auto'
+#    option auto_hosts               'no'
+#    option auto_nets                'no'
+#    option dns                      'no'
+#    list ns_hosts                   '8.8.8.8'
+#    list ns_hosts                   '9.9.9.9'
+#    option to_ns                    '90.60.90.1'
+#    option python                   'python3'
+#    option exclude_subnet           '192.168.0.0/24'
+#    option exclude_file             '/etc/config/sshuttle.subnets.excluded'
+#    option verbose                  'no'
+#    option ssh_cmd                  'ssh'
+#    list seed_hosts                 '90.60.90.105'
+#    list seed_hosts                 '90.60.90.106'
+#    option latency_control          'yes'
+#    option latency_buffer_size      '32768'
+#    option subnets_file             '/etc/config/sshuttle.subnets'
+#    option syslog                   'no'
+#    option disable_ipv6             'yes'
+#    option mark                     '0x01'

--- a/net/sshuttle/files/sshuttle.config
+++ b/net/sshuttle/files/sshuttle.config
@@ -1,39 +1,39 @@
 # In the examples below, the IP addresses have the following meanings
 #
-# 90.60.90.77   - ssh server to become the gateway for locally captured traffic
-#                 can be a full fledged ssh host definition like: [username@]sshserver[:port]
-#                 or may reference an entry in the ~/.ssh/config file like: remote-ssh-gateway
+# 90.60.90.77	- ssh server to become the gateway for locally captured traffic
+#					can be a full fledged ssh host definition like: [username@]sshserver[:port]
+#					or may reference an entry in the ~/.ssh/config file like: remote-ssh-gateway
 #
-# 90.60.90.0/24 - remote address of a subnet to forward using the given ssh host 90.60.90.77
-#                 specify 0/0 to forward all IPv4 or ::/0 for all IPv6 traffic
+# 90.60.90.0/24	- remote address of a subnet to forward using the given ssh host 90.60.90.77
+#					specify 0/0 to forward all IPv4 or ::/0 for all IPv6 traffic
 #
-# 192.168.1.1   - internal lan network IP of this routing device for sshuttle to listen on
-#                 use 0.0.0.0 to listen on all interfaces and IP addresses
-#                 Listening on WAN side provides unrestricted access to remote networks!
+# 192.168.1.1	- internal lan network IP of this routing device for sshuttle to listen on
+#					use 0.0.0.0 to listen on all interfaces and IP addresses
+#					Listening on WAN side provides unrestricted access to remote networks!
 #
 # detailed parameter documentation can be found at https://sshuttle.readthedocs.io/en/stable/manpage.html
 #
 
 #config gateway '90.60.90.77'
-#    option listen                   '192.168.1.1:9090'
-#    list subnets                    '90.60.90.0/24' (or) '90.60.90.105,90.60.90.106'
-#    option method                   'auto'
-#    option auto_hosts               'no'
-#    option auto_nets                'no'
-#    option dns                      'no'
-#    list ns_hosts                   '8.8.8.8'
-#    list ns_hosts                   '9.9.9.9'
-#    option to_ns                    '90.60.90.1'
-#    option python                   'python3'
-#    option exclude_subnet           '192.168.0.0/24'
-#    option exclude_file             '/etc/config/sshuttle.subnets.excluded'
-#    option verbose                  'no'
-#    option ssh_cmd                  'ssh'
-#    list seed_hosts                 '90.60.90.105'
-#    list seed_hosts                 '90.60.90.106'
-#    option latency_control          'yes'
-#    option latency_buffer_size      '32768'
-#    option subnets_file             '/etc/config/sshuttle.subnets'
-#    option syslog                   'no'
-#    option disable_ipv6             'yes'
-#    option mark                     '0x01'
+#	option listen				'192.168.1.1:9090'
+#	list subnets				'90.60.90.0/24' (or) '90.60.90.105,90.60.90.106'
+#	option method				'auto'
+#	option auto_hosts			'no'
+#	option auto_nets			'no'
+#	option dns					'no'
+#	list ns_hosts				'8.8.8.8'
+#	list ns_hosts				'9.9.9.9'
+#	option to_ns				'90.60.90.1'
+#	option python				'python3'
+#	option exclude_subnet		'192.168.0.0/24'
+#	option exclude_file			'/etc/config/sshuttle.subnets.excluded'
+#	option verbose				'no'
+#	option ssh_cmd				'ssh'
+#	list seed_hosts				'90.60.90.105'
+#	list seed_hosts				'90.60.90.106'
+#	option latency_control		'yes'
+#	option latency_buffer_size	'32768'
+#	option subnets_file			'/etc/config/sshuttle.subnets'
+#	option syslog				'no'
+#	option disable_ipv6			'yes'
+#	option mark					'0x01'

--- a/net/sshuttle/files/sshuttle.init
+++ b/net/sshuttle/files/sshuttle.init
@@ -25,22 +25,20 @@ append_params() {
     for v in $v; do
       if [ -n "$v" ] && [ "$v" != "no" ]; then
         if [ "$p" = "subnets" ]; then
-          args="$args $v"
+          ARGS="$ARGS $v"
         elif [ "$p" = "method" ]; then
           set -- "$@" "--method" "$v"
         else
           p="--$( echo "$p" | sed -e 's|_|-|g' )"
           if [ "$v" = "yes" ]; then
-            args="$args $p"
+            ARGS="$ARGS $p"
           elif [ "$v" != "no" ]; then
-            args="$args $p=$v"
+            ARGS="$ARGS $p=$v"
           fi
         fi
       fi
     done
   done
-
-  ARGS="${args# *}"
 }
 
 validate_gateway_section() {
@@ -72,11 +70,12 @@ load_gateway() {
 
   [ "$2" = 0 ] || { _err "gateway $gateway: validation failed"; return 1; }
 
+  ARGS="--remote=$1 --pidfile=/var/run/sshuttle.$1.pid"
+
   append_params listen subnets method auto_hosts auto_nets dns ns_hosts to_ns \
     python exclude_subnet exclude_file verbose ssh_cmd seed_hosts latency_control \
     latency_buffer_size subnets_file syslog disable_ipv6 mark
 
-  ARGS="--remote=$1 --pidfile=/var/run/sshuttle.$1.pid $ARGS"
   _log "Using sshuttle instance $gateway with args: $ARGS"
 
   procd_open_instance "$gateway"

--- a/net/sshuttle/files/sshuttle.init
+++ b/net/sshuttle/files/sshuttle.init
@@ -1,0 +1,108 @@
+#!/bin/sh /etc/rc.common
+#
+# Copyright (C) 2022 Thomas Cujé
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+# shellcheck disable=SC2034
+START=99
+STOP=01
+USE_PROCD=1
+
+_log() {
+  logger -p daemon.info -t sshuttle "$@"
+}
+
+append_params() {
+  for p in "$@"; do
+    eval "v=\$$p"
+    for v in $v; do
+      if [ -n "$v" ] && [ "$v" != "no" ]; then
+        if [ "$p" != "subnets" ]; then
+          p="--$( echo "$p" | sed -e 's|_|-|g' )"
+          if [ "$v" = "yes" ]; then
+            args="$args $p"
+          else
+            args="$args $p=$v"
+          fi
+        else
+          args="$args $v"
+        fi
+      fi
+    done
+  done
+
+  ARGS="${args# *}"
+}
+
+validate_gateway_section() {
+  uci_load_validate sshuttle gateway "$1" "$2" \
+    'listen:string' \
+    'subnets:list(string)' \
+    'method:or("auto", "nat", "nft", "tproxy", "pf", "ipfw")' \
+    'auto_hosts:or("yes", "no")' \
+    'auto_nets:or("yes", "no")' \
+    'dns:or("yes", "no")' \
+    'ns_hosts:list(host)' \
+    'to_ns:host' \
+    'python:string' \
+    'exclude_subnet:list(string)' \
+    'exclude_file:file' \
+    'verbose:or("yes", "no")' \
+    'ssh_cmd:string' \
+    'seed_hosts:list(host)' \
+    'latency_control:or("yes", "no")' \
+    'latency_buffer_size:integer' \
+    'subnets_file:file' \
+    'syslog:or("yes", "no")' \
+    'disable_ipv6:or("yes", "no")' \
+    'mark:string'
+}
+
+load_gateway() {
+  gateway="$1"
+
+  [ "$2" = 0 ] || { _err "gateway $gateway: validation failed"; return 1; }
+
+  append_params listen subnets method auto_hosts auto_nets dns ns_hosts to_ns \
+    python exclude_subnet exclude_file verbose ssh_cmd seed_hosts latency_control \
+    latency_buffer_size subnets_file syslog disable_ipv6 mark
+
+  ARGS="--remote=$1 --pidfile=/var/run/sshuttle.$1.pid $ARGS"
+  _log "Using sshuttle instance $gateway with args: $ARGS"
+
+  procd_open_instance "$gateway"
+  procd_set_param command "/usr/bin/sshuttle" $ARGS
+  procd_set_param stdout 1
+  procd_set_param stderr 1
+  procd_set_param respawn 0 60 1
+  procd_close_instance
+}
+
+service_triggers() {
+  procd_add_reload_trigger "sshuttle"
+
+  procd_open_validate
+  validate_gateway_section "$@"
+  procd_close_validate
+}
+
+start_service() {
+  _log "Starting sshuttle instances"
+  config_load "sshuttle"
+  config_foreach validate_gateway_section "gateway" load_gateway
+}
+
+stop_service() {
+  _log "Stopping sshuttle instances"
+  for pid_file in "/var/run/sshuttle."*.pid; do
+    [ -f "$pid_file" ] || continue
+    sshuttle_pid="$(cat "$pid_file")"
+    # test if process is still running
+    if kill -0 "$sshuttle_pid" 2>/dev/null; then
+      kill "$sshuttle_pid"
+    fi
+  done
+}

--- a/net/sshuttle/files/sshuttle.init
+++ b/net/sshuttle/files/sshuttle.init
@@ -95,7 +95,17 @@ service_triggers() {
 }
 
 start_service() {
-  _log "Starting sshuttle instances"
+  _log "Starting all sshuttle instances"
   config_load "sshuttle"
   config_foreach validate_gateway_section "gateway" load_gateway
+}
+
+reload_service() {
+  _log "Reloading all sshuttle instances"
+  stop
+  start
+}
+
+stop_service() {
+  _log "Stopping all sshuttle instances"
 }

--- a/net/sshuttle/files/sshuttle.init
+++ b/net/sshuttle/files/sshuttle.init
@@ -12,7 +12,7 @@ STOP=01
 USE_PROCD=1
 
 _log() {
-  logger -p daemon.info -t sshuttle "$@"
+	logger -p daemon.info -t sshuttle "$@"
 }
 
 _err() {
@@ -20,92 +20,92 @@ _err() {
 }
 
 append_params() {
-  for p in "$@"; do
-    eval "v=\$$p"
-    for v in $v; do
-      if [ -n "$v" ] && [ "$v" != "no" ]; then
-        if [ "$p" = "subnets" ]; then
-          ARGS="$ARGS $v"
-        elif [ "$p" = "method" ]; then
-          set -- "$@" "--method" "$v"
-        else
-          p="--$( echo "$p" | sed -e 's|_|-|g' )"
-          if [ "$v" = "yes" ]; then
-            ARGS="$ARGS $p"
-          elif [ "$v" != "no" ]; then
-            ARGS="$ARGS $p=$v"
-          fi
-        fi
-      fi
-    done
-  done
+	for p in "$@"; do
+		eval "v=\$$p"
+		for v in $v; do
+			if [ -n "$v" ] && [ "$v" != "no" ]; then
+				if [ "$p" = "subnets" ]; then
+					ARGS="$ARGS $v"
+				elif [ "$p" = "method" ]; then
+					set -- "$@" "--method" "$v"
+				else
+					p="--$( echo "$p" | sed -e 's|_|-|g' )"
+					if [ "$v" = "yes" ]; then
+						ARGS="$ARGS $p"
+					elif [ "$v" != "no" ]; then
+						ARGS="$ARGS $p=$v"
+					fi
+				fi
+			fi
+		done
+	done
 }
 
 validate_gateway_section() {
-  uci_load_validate sshuttle gateway "$1" "$2" \
-    'listen:string' \
-    'subnets:list(string)' \
-    'method:or("auto", "nat", "nft", "tproxy", "pf", "ipfw")' \
-    'auto_hosts:or("yes", "no")' \
-    'auto_nets:or("yes", "no")' \
-    'dns:or("yes", "no")' \
-    'ns_hosts:list(host)' \
-    'to_ns:host' \
-    'python:string' \
-    'exclude_subnet:list(string)' \
-    'exclude_file:file' \
-    'verbose:or("yes", "no")' \
-    'ssh_cmd:string' \
-    'seed_hosts:list(host)' \
-    'latency_control:or("yes", "no")' \
-    'latency_buffer_size:integer' \
-    'subnets_file:file' \
-    'syslog:or("yes", "no")' \
-    'disable_ipv6:or("yes", "no")' \
-    'mark:string'
+	uci_load_validate sshuttle gateway "$1" "$2" \
+		'listen:string' \
+		'subnets:list(string)' \
+		'method:or("auto", "nat", "nft", "tproxy", "pf", "ipfw")' \
+		'auto_hosts:or("yes", "no")' \
+		'auto_nets:or("yes", "no")' \
+		'dns:or("yes", "no")' \
+		'ns_hosts:list(host)' \
+		'to_ns:host' \
+		'python:string' \
+		'exclude_subnet:list(string)' \
+		'exclude_file:file' \
+		'verbose:or("yes", "no")' \
+		'ssh_cmd:string' \
+		'seed_hosts:list(host)' \
+		'latency_control:or("yes", "no")' \
+		'latency_buffer_size:integer' \
+		'subnets_file:file' \
+		'syslog:or("yes", "no")' \
+		'disable_ipv6:or("yes", "no")' \
+		'mark:string'
 }
 
 load_gateway() {
-  gateway="$1"
+	gateway="$1"
 
-  [ "$2" = 0 ] || { _err "gateway $gateway: validation failed"; return 1; }
+	[ "$2" = 0 ] || { _err "gateway $gateway: validation failed"; return 1; }
 
-  ARGS="--remote=$1 --pidfile=/var/run/sshuttle.$1.pid"
+	ARGS="--remote=$1 --pidfile=/var/run/sshuttle.$1.pid"
 
-  append_params listen subnets method auto_hosts auto_nets dns ns_hosts to_ns \
-    python exclude_subnet exclude_file verbose ssh_cmd seed_hosts latency_control \
-    latency_buffer_size subnets_file syslog disable_ipv6 mark
+	append_params listen subnets method auto_hosts auto_nets dns ns_hosts to_ns \
+		python exclude_subnet exclude_file verbose ssh_cmd seed_hosts latency_control \
+		latency_buffer_size subnets_file syslog disable_ipv6 mark
 
-  _log "Using sshuttle instance $gateway with args: $ARGS"
+	_log "Using sshuttle instance $gateway with args: $ARGS"
 
-  procd_open_instance "$gateway"
-  procd_set_param command "/usr/bin/sshuttle" $ARGS
-  procd_set_param stdout 1
-  procd_set_param stderr 1
-  procd_set_param respawn 0 60 1
-  procd_close_instance
+	procd_open_instance "$gateway"
+	procd_set_param command "/usr/bin/sshuttle" $ARGS
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn 0 60 1
+	procd_close_instance
 }
 
 service_triggers() {
-  procd_add_reload_trigger "sshuttle"
+	procd_add_reload_trigger "sshuttle"
 
-  procd_open_validate
-  validate_gateway_section "$@"
-  procd_close_validate
+	procd_open_validate
+	validate_gateway_section "$@"
+	procd_close_validate
 }
 
 start_service() {
-  _log "Starting all sshuttle instances"
-  config_load "sshuttle"
-  config_foreach validate_gateway_section "gateway" load_gateway
+	_log "Starting all sshuttle instances"
+	config_load "sshuttle"
+	config_foreach validate_gateway_section "gateway" load_gateway
 }
 
 reload_service() {
-  _log "Reloading all sshuttle instances"
-  stop
-  start
+	_log "Reloading all sshuttle instances"
+	stop
+	start
 }
 
 stop_service() {
-  _log "Stopping all sshuttle instances"
+	_log "Stopping all sshuttle instances"
 }

--- a/net/sshuttle/files/sshuttle.init
+++ b/net/sshuttle/files/sshuttle.init
@@ -15,20 +15,26 @@ _log() {
   logger -p daemon.info -t sshuttle "$@"
 }
 
+_err() {
+	logger -p daemon.err -t sshuttle "$@"
+}
+
 append_params() {
   for p in "$@"; do
     eval "v=\$$p"
     for v in $v; do
       if [ -n "$v" ] && [ "$v" != "no" ]; then
-        if [ "$p" != "subnets" ]; then
+        if [ "$p" = "subnets" ]; then
+          args="$args $v"
+        elif [ "$p" = "method" ]; then
+          set -- "$@" "--method" "$v"
+        else
           p="--$( echo "$p" | sed -e 's|_|-|g' )"
           if [ "$v" = "yes" ]; then
             args="$args $p"
-          else
+          elif [ "$v" != "no" ]; then
             args="$args $p=$v"
           fi
-        else
-          args="$args $v"
         fi
       fi
     done
@@ -93,16 +99,4 @@ start_service() {
   _log "Starting sshuttle instances"
   config_load "sshuttle"
   config_foreach validate_gateway_section "gateway" load_gateway
-}
-
-stop_service() {
-  _log "Stopping sshuttle instances"
-  for pid_file in "/var/run/sshuttle."*.pid; do
-    [ -f "$pid_file" ] || continue
-    sshuttle_pid="$(cat "$pid_file")"
-    # test if process is still running
-    if kill -0 "$sshuttle_pid" 2>/dev/null; then
-      kill "$sshuttle_pid"
-    fi
-  done
 }


### PR DESCRIPTION
Signed-off-by: Thomas Cujé <dev.cuje@freenet.de>

Maintainer: me / @tcuje
Compile tested: ARMv8 Processor rev 4, FriendlyElec NanoPi R2S, OpenWrt 22.03.2 r19803-9a599fee93
Run tested: ARMv8 Processor rev 4, FriendlyElec NanoPi R2S, OpenWrt 22.03.2 r19803-9a599fee93, tests: install/uninstall/opkg info, installed service start/stop/restart/reload, config correctly forwarded as args

Description:
This is a new meta package to conveniently install sshuttle (https://github.com/sshuttle/sshuttle) as a PROCD service in OpenWRT routers. Details like version, title and description kept as seen in sshuttle. All mandatory dependencies are referenced (see https://sshuttle.readthedocs.io/en/stable/openwrt.html) and available in OpenWRT. Example config with explanation is provided and installed in an inactive state.

Most arguments of sshuttle supported (compare https://sshuttle.readthedocs.io/en/stable/manpage.html#synopsis). Argument `--daemon` not being supported, since PROCD requires services to run in the foreground (see https://openwrt.org/docs/guide-developer/procd-init-scripts#procd_init_script_parameters). Argument `--pidfile` not supported, to have pid-filenames in a well known format, which can be controlled for all processes from the service. Arguments `--firewall` and `--hostwatch` not supported, for being sshuttle internal use only. Arguments ` --sudoers-no-modify` and ` --sudoers-user` not supported, because they don't apply for most OpenWRT systems.

I'll be actively using this package and sshuttle for my own purposes in the future. I'll be happy to maintain this package, update it with new sshuttle releases or take care of maintenance work with the package itself.

First time contributing here; Hi all! Any feedback welcome