### PR TITLE
libwebsockets: fix uloop support

### DIFF
--- a/libs/libwebsockets/Makefile
+++ b/libs/libwebsockets/Makefile
@@ -45,7 +45,7 @@ define Package/libwebsockets/Default
 	SECTION:=libs
 	CATEGORY:=Libraries
 	TITLE:=libwebsockets
-	DEPENDS:=+zlib +libcap
+	DEPENDS:=+zlib +libcap +libubox
 	URL:=https://libwebsockets.org
 	MAINTAINER:=Karl Palsson <karlp@etactica.com>
 endef
@@ -97,7 +97,7 @@ endif
 
 define Package/libwebsockets/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libwebsockets.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libwebsockets*.so* $(1)/usr/lib/
 endef
 
 Package/libwebsockets-mbedtls/install = $(Package/libwebsockets/install)


### PR DESCRIPTION
The commit adding uloop support failed to actually install the .so and add the correct dependencies.

[2022/12/26 18:19:38:1835] E: lws_create_context: failed to load evlib_uloop

Fixes: 1557ac367a ("libwebsockets: enable built in uloop support")
Signed-off-by: John Crispin <john@phrozen.org>