### PR TITLE
golang: backport an upstream fix for non-retpoline-compatible error

### DIFF
--- a/lang/golang/golang/patches/010-cmd-compile-turn-off-jump-tables-when-spectre-retpolines-.patch
+++ b/lang/golang/golang/patches/010-cmd-compile-turn-off-jump-tables-when-spectre-retpolines-.patch
@@ -1,0 +1,67 @@
+From 156578067111742b55718066c91b8ec66d35e03d Mon Sep 17 00:00:00 2001
+From: Keith Randall <khr@golang.org>
+Date: Mon, 5 Dec 2022 16:26:26 -0800
+Subject: [PATCH] [release-branch.go1.19] cmd/compile: turn off jump tables
+ when spectre retpolines are on
+
+Fixes #57100
+
+Change-Id: I6ab659abbca1ae0ac8710674d39aec116fab0baa
+Reviewed-on: https://go-review.googlesource.com/c/go/+/455336
+Reviewed-by: Keith Randall <khr@google.com>
+Reviewed-by: Cherry Mui <cherryyz@google.com>
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Run-TryBot: Keith Randall <khr@golang.org>
+(cherry picked from commit 1eb0465fa596a2d6e9c1a632499989544f0d7e68)
+Reviewed-on: https://go-review.googlesource.com/c/go/+/455416
+Reviewed-by: Michael Pratt <mpratt@google.com>
+---
+ src/cmd/compile/internal/walk/switch.go |  2 +-
+ test/codegen/retpoline.go               | 28 +++++++++++++++++++++++++
+ 2 files changed, 29 insertions(+), 1 deletion(-)
+
+--- a/src/cmd/compile/internal/walk/switch.go
++++ b/src/cmd/compile/internal/walk/switch.go
+@@ -289,7 +289,7 @@ func (s *exprSwitch) tryJumpTable(cc []e
+ 	const minCases = 8   // have at least minCases cases in the switch
+ 	const minDensity = 4 // use at least 1 out of every minDensity entries
+ 
+-	if !go119UseJumpTables || base.Flag.N != 0 || !ssagen.Arch.LinkArch.CanJumpTable {
++	if !go119UseJumpTables || base.Flag.N != 0 || !ssagen.Arch.LinkArch.CanJumpTable || base.Ctxt.Retpoline {
+ 		return false
+ 	}
+ 	if len(cc) < minCases {
+--- a/test/codegen/retpoline.go
++++ b/test/codegen/retpoline.go
+@@ -12,3 +12,31 @@ func CallInterface(x interface{ M() }) {
+ 	// amd64:`CALL\truntime.retpoline`
+ 	x.M()
+ }
++
++// Check to make sure that jump tables are disabled
++// when retpoline is on. See issue 57097.
++func noJumpTables(x int) int {
++	switch x {
++	case 0:
++		return 0
++	case 1:
++		return 1
++	case 2:
++		return 2
++	case 3:
++		return 3
++	case 4:
++		return 4
++	case 5:
++		return 5
++	case 6:
++		return 6
++	case 7:
++		return 7
++	case 8:
++		return 8
++	case 9:
++		return 9
++	}
++	return 10
++}


### PR DESCRIPTION
Maintainer: @jefferyto 
Compile tested: x86/64
Run tested: n/a

Description:
Upstream commit: golang/go@156578067111742b55718066c91b8ec66d35e03d
Fixes: #20026