### PR TITLE
icecast: add libxml2 include directory

### DIFF
--- a/multimedia/icecast/Makefile
+++ b/multimedia/icecast/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=icecast
 PKG_VERSION:=2.4.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.xiph.org/releases/icecast/
@@ -55,6 +55,7 @@ CONFIGURE_ARGS+= \
 	--with-vorbis="$(STAGING_DIR)/usr" \
 	--with-xslt-config="$(STAGING_DIR)/usr/bin/xslt-config"
 
+TARGET_CFLAGS+= -I$(STAGING_DIR)/usr/include/libxml2
 
 # Manually edit configure in case both vorbis and tremor host packages are installed
 define Build/Configure


### PR DESCRIPTION
Maintainer: @andrenarchy @thess 
Compile tested: aarch64/cortex-a53, master
Run tested: none

Description:

Fixes this error:
cfgfile.c:26:10: fatal error: libxml/xmlmemory.h: No such file or directory
   26 | #include <libxml/xmlmemory.h>
      |          ^~~~~~~~~~~~~~~~~~~~

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>