### PR TITLE
libreswan: set DNSSEC_ROOTKEY_FILE, LINUX_VARIANT

### DIFF
--- a/net/libreswan/Makefile
+++ b/net/libreswan/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libreswan
 PKG_VERSION:=4.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.libreswan.org/
@@ -84,9 +84,11 @@ MAKE_FLAGS+= \
     PREFIX="/usr" \
     FINALRUNDIR="/var/run/pluto" \
     FINALNSSDIR="/etc/ipsec.d" \
+    DEFAULT_DNSSEC_ROOTKEY_FILE=/etc/unbound/root.key \
     MODPROBEARGS="-q" \
     OSDEP=linux \
     BUILDENV=linux \
+    LINUX_VARIANT="openwrt" \
     ARCH="$(LINUX_KARCH)" \
 
 define Build/Prepare


### PR DESCRIPTION
Maintainer: @lucize 
Compile tested: aarch64/cortex-a53
Run tested: * **none** *

Description:
Libreswan will set DEFAULT_DNSSEC_ROOTKEY_FILE from the LINUX_VARIANT variable, which is taken from the ID field in /etc/os-release.  This points to the host file, which is wrong.

Set both variables when calling make.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

I spotted this when compiling with `CONFIG_ALL` on Gentoo.

This will set `LINUX_VARIANT` if it is not defined:

``` Makefile
  export LINUX_VARIANT := $(sort $(shell sed -n -e 's/"//g' -e 's/^ID_LIKE=//p' -e 's/^ID=//p' /etc/os-release))
```
See https://github.com/libreswan/libreswan/blob/cb5d01e70f55c7de56ba086dadedd06328c23725/mk/defaults/linux.mk#L7-L28

Most of the time, it is checked if it matches an empty string, except in https://github.com/libreswan/libreswan/blob/cb5d01e70f55c7de56ba086dadedd06328c23725/mk/defaults/linux.mk#L38-L81

``` Makefile
#
# Debian derived; ubuntu derived
#
ifneq ($(filter debian ubuntu,$(LINUX_VARIANT)),)
  DEFAULT_DNSSEC_ROOTKEY_FILE ?= /usr/share/dns/root.key
  ifeq ($(LINUX_VERSION_CODENAME),buster) # Debian 10 (Buster); until June 2024
    USE_NSS_KDF ?= false
  endif
  ifeq ($(LINUX_VERSION_CODENAME),focal)  # Ubuntu 20.04 LTS (Focal Fossa); until April 2025
    USE_NSS_KDF ?= false
  endif
  ifeq ($(LINUX_VERSION_CODENAME),bionic) # Ubuntu 18.04 LTS (Bionic Beaver); until April 2023
    USE_NSS_KDF ?= false
    USE_XFRM_INTERFACE_IFLA_HEADER ?= true
    USE_NSS_IPSEC_PROFILE ?= false
  endif
endif

#
# Fedora derived
#
ifneq ($(filter fedora,$(LINUX_VARIANT)),)
  DEFAULT_DNSSEC_ROOTKEY_FILE ?= /var/lib/unbound/root.key
  USE_LINUX_AUDIT ?= true
  USE_SECCOMP ?= true
  USE_LABELED_IPSEC ?= true
endif
#
# OpenSuSe derived
# https://en.opensuse.org/SDB:SUSE_and_openSUSE_Products_Version_Outputs
#
ifneq ($(filter suse,$(LINUX_VARIANT)),)
  # https://lists.opensuse.org/archives/list/users@lists.opensuse.org/message/HYB6CKB7DPMPAN7BGUC6MRHE6TWZDABI/
  DEFAULT_DNSSEC_ROOTKEY_FILE ?= /var/lib/unbound/root.key
endif
#
# Arch Linux derived
#
ifneq ($(filter arch,$(LINUX_VARIANT)),)
  # https://wiki.archlinux.org/title/unbound#Root_hints
  DEFAULT_DNSSEC_ROOTKEY_FILE ?= /etc/trusted-key.key
endif
```

All of the settings are already defined in our Makefile, except for `DEFAULT_DNSSEC_ROOTKEY_FILE`.  Unbound in OpenWrt installs it in `/etc/unbound/root.key`, so none of the distros in the code will get it right.  If it is not set--my case with Gentoo--you get an error from:

``` Makefile
ifndef DEFAULT_DNSSEC_ROOTKEY_FILE
$(error DEFAULT_DNSSEC_ROOTKEY_FILE unknown)
endif
```
https://github.com/libreswan/libreswan/blob/cb5d01e70f55c7de56ba086dadedd06328c23725/mk/config.mk#L707-L709

To be safe, I set `LINUX_VARIANT` to "OpenWrt", which is what one would get from `/etc/os-release`, left `LINUX_VERSION_ID` unset (taken from `VERSION_ID` in `/etc/os-release`, not used anywhere), and set `DEFAULT_DNSSEC_ROOTKEY_FILE` to `/etc/unbound/root/key`.

I have not run-tested this. The change affects run-time, so I urge someone using the package to test it.  It should be harmless in theory.

The root key is wrong no matter what distro is used to build this, and no one has noticed it specifically.  This is a indication that the feature is not being used.  An alternative to this would be to just disable dnssec and save some room.
