### PR TITLE
bump stubby to 0.4.3 

### DIFF
--- a/net/stubby/Makefile
+++ b/net/stubby/Makefile
@@ -5,8 +5,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stubby
-PKG_VERSION:=0.4.2
-PKG_RELEASE:=1
+PKG_VERSION:=0.4.3
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/getdnsapi/$(PKG_NAME)


### PR DESCRIPTION
Signed-off-by: Rudy Andram <rmandrad@gmail.com>

Maintainer: me @neheb 
Compile tested: aarch64/ipq8074
Run tested: aarch64 /ipq8074

Description: minor release fixing two issues
Fix Issue https://github.com/getdnsapi/stubby/issues/330 and PR#324: PrivateUsers=false needed in systemd stubby.service file for stubby to start. Thanks Archcan and Petr Menšík
    PR https://github.com/getdnsapi/stubby/pull/323: Reduce log messages when interface is offline. Thanks Russ Bubley and Andre Heider
