### PR TITLE
strongswan: fix typo in strongswan-mod-nonce description

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.8
-PKG_RELEASE:=$(AUTORELEASE).1
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/
@@ -691,7 +691,7 @@ $(eval $(call BuildPlugin,kernel-netlink,netlink kernel interface,))
 $(eval $(call BuildPlugin,ldap,LDAP,+PACKAGE_strongswan-mod-ldap:libopenldap))
 $(eval $(call BuildPlugin,led,LED blink on IKE activity,))
 $(eval $(call BuildPlugin,load-tester,load testing,))
-$(eval $(call BuildPlugin,nonce,nonce genereation,))
+$(eval $(call BuildPlugin,nonce,nonce generation,))
 $(eval $(call BuildPlugin,md4,MD4 crypto,))
 $(eval $(call BuildPlugin,md5,MD5 crypto,))
 $(eval $(call BuildPlugin,mgf1,MGF1 crypto,))


### PR DESCRIPTION
Maintainer: @pprindeville @Thermi 
Compile tested: NA
Run tested: NA

Description:
Fixes: #16691
Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>