### PR TITLE
bind: start up with -4 if not listening on ipv6 addresses

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.18.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>

--- a/net/bind/files/named.init
+++ b/net/bind/files/named.init
@@ -30,6 +30,10 @@ fix_perms() {
     done
 }
 
+no_ipv6() {
+    [ -z "$(ip -6 -o route show default)" ]
+}
+
 reload_service() {
     rndc -q reload
 }
@@ -68,8 +72,11 @@ start_service() {
 
     touch $conf_local_file
 
+    local args=
+    [ no_ipv6 ] && args="-4"
+
     procd_open_instance
-    procd_set_param command /usr/sbin/named -u bind -f -c $config_file
+    procd_set_param command /usr/sbin/named -u bind -f $args -c $config_file
     procd_set_param file $config_file \
 			 $config_dir/bind.keys \
 			 $named_options_file \


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile tested: x86_64, generic, HEAD (fb15cb4ce95)
Run tested: same, running on production router

Description:

On startup, my logging fills up with noise about not being able to reach the IPv6 addresses of the root name servers:

```
Dec 27 17:14:24 OpenWrt named[9965]: network unreachable resolving '_.org/A/IN': 2001:500:200::b#53
Dec 27 17:14:24 OpenWrt named[9965]: network unreachable resolving '_.org/A/IN': 2001:500:9f::42#53
Dec 27 17:14:24 OpenWrt named[9965]: network unreachable resolving '_.org/A/IN': 2001:dc3::35#53
Dec 27 17:14:24 OpenWrt named[9965]: network unreachable resolving '_.org/A/IN': 2001:500:1::53#53
```

This is normal.  My MSP (Sparklight) doesn't do IPv6.  To eliminate this noise, we can pass `-4` to named when it gets started.
