### PR TITLE
python-jsonschema: Update to 4.17.3

### DIFF
--- a/lang/python/python-jsonschema/Makefile
+++ b/lang/python/python-jsonschema/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-jsonschema
-PKG_VERSION:=4.16.0
+PKG_VERSION:=4.17.3
 PKG_RELEASE:=1
 
 PYPI_NAME:=jsonschema
-PKG_HASH:=165059f076eff6971bae5b742fc029a7b4ef3f9bcf04c14e4776a7605de14b23
+PKG_HASH:=0f864437ab8b6076ba6707453ef8f98a6a0d512a80e93f8abdb676f737ecb60d
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream release. [Changelog](https://github.com/python-jsonschema/jsonschema/releases)