### PR TITLE
libtorrent-rasterbar: Update to 2.0.8

### DIFF
--- a/libs/libtorrent-rasterbar/Makefile
+++ b/libs/libtorrent-rasterbar/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtorrent-rasterbar
-PKG_VERSION:=2.0.7
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=2.0.8
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/arvidn/libtorrent/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=1c8209fdf765be7bc989e9cbd1d9dc3d5a6a57cb979205e73e925c9c72ebe8ce
+PKG_HASH:=29e5c5395de8126ed1b24d0540a9477fbb158b536021cd65aaf9de34d0aadb46
 
 PKG_MAINTAINER:=David Yang <mmyangfl@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -47,11 +47,11 @@ endef
 #endef
 
 define Download/try_signal
-	VERSION:=751a7e5a5be14892bcfdff1e63c653bcbf71cf39
+	VERSION:=105cce59972f925a33aa6b1c3109e4cd3caf583d
 	SUBDIR:=deps/try_signal
 	FILE:=$(PKG_NAME)-try_signal-$$(VERSION).tar.xz
 	URL:=https://github.com/arvidn/try_signal.git
-	MIRROR_HASH:=32a432e35e81c79f21c49744f00696c112e0deab45d15d91c61ceb63fe25a5f8
+	MIRROR_HASH:=da81da67d52b7a731c21148573b68bf8dc7863616d6ae1f81845b7afb29e8f00
 	PROTO:=git
 endef
 $(eval $(call Download,try_signal))


### PR DESCRIPTION
Maintainer: @yangfl
Compile tested: rockchip/armv8, x86/64
Run tested: -

Description:
Release note: https://github.com/arvidn/libtorrent/releases/tag/v2.0.8
