### PR TITLE
byobu: fix missing dependency on tmux

### DIFF
--- a/utils/byobu/Makefile
+++ b/utils/byobu/Makefile
@@ -36,7 +36,7 @@ endef
 define Package/byobu
 $(call Package/byobu/Default)
   TITLE:=Text-based window manager and terminal multiplexer
-  DEPENDS:=+python3-light +python3-newt
+  DEPENDS:=+python3-light +python3-newt +!PACKAGE_screen:tmux
 endef
 
 define Package/byobu-utils


### PR DESCRIPTION
Maintainer: @jefferyto 
Compile tested: N/A
Run tested: FB7520@[r21588-2e0e25c9f7](https://github.com/openwrt/openwrt/commit/2e0e25c9f7)

Description:
You can´t launch byobu without having tmux installed:
```
root@FB7520:~# byobu
/usr/bin/byobu: exec: line 242: tmux: not found
```
Installing it fixes the issue so it should be a dependency:
```
root@FB7520:~# opkg install tmux
Installing tmux (3.3a-1) to root...
Downloading https://downloads.openwrt.org/snapshots/packages/arm_cortex-a7_neon-vfpv4/packages/tmux_3.3a-1_arm_cortex-a7_neon-vfpv4.ipk
Installing libevent2-core7 (2.1.12-1) to root...
Downloading https://downloads.openwrt.org/snapshots/packages/arm_cortex-a7_neon-vfpv4/base/libevent2-core7_2.1.12-1_arm_cortex-a7_neon-vfpv4.ipk
Configuring libevent2-core7.
Configuring tmux.
root@FB7520:~# byobu

Welcome to the light, powerful, text window manager, Byobu.
```