### PR TITLE
qfirehose: new package

### DIFF
--- a/utils/qfirehose/Makefile
+++ b/utils/qfirehose/Makefile
@@ -1,0 +1,55 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=qfirehose
+PKG_VERSION:=1.4.9
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/nippynetworks/qfirehose/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=b7c04f9356823c6ee0f4ca152e8fd2015f34b95490cea68461a060993befadef
+
+PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
+PKG_LICENSE:=
+PKG_LICENSE_FILES:=NOTICE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/qfirehose
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Quectel Firehose Recovery application
+  URL:=https://github.com/nippynetworks/qfirehose
+endef
+
+define Package/qfirehose/description
+  Utility that is able to flash firmwares on Quectel's modems.
+  Usage: qfirehose -f FW_PATH
+  
+  Warning.
+
+   - Use of software is completely on your own risk.
+     Flashing wrong firmware or failed flash can brick your modem permanently.
+     Avoid flashing, if device works without issues and updated firmware does not contain new necessary changes.
+     Do not flash, if you are not willing to take this risk or do not know what you are doing.
+
+   - After succesful flashing, you should use terminal to issue factory reset for modem settings with AT&F command.
+
+   - mPCIe users (mostly): If modem has completely disappeared after succesful flashing, reason might be that some firmware updates
+     set default mode to USB3 which is unsupported by some mPCIe slots, in this case, you should connect it to USB
+     port using mPCIe -> USB adapter, even most of cheap chinese modules can reveal device. After this you should issue
+     a command to use USB2, which may vary between models, but on most Quectel modems is: AT+QUSBCFG="SS",0
+     Changing value on end of AT command 0 to 1, selects USB3 instead. Refer to documents of your modem.
+endef
+
+define Build/Configure
+	$(RM) $(PKG_BUILD_DIR)/QFirehose
+endef
+
+MAKE_ARGS += linux
+
+define Package/qfirehose/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/QFirehose $(1)/usr/bin/qfirehose
+endef
+
+$(eval $(call BuildPackage,qfirehose))


### PR DESCRIPTION
Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>

Maintainer: Oskari Rauta / @oskarirauta
Compile tested: x86_64, x86_64, recent git
Run tested: x86_64, x86_64, recent git

Description:
Utility to flash firmware updates to quectel modems (ON YOUR OWN RISK!).
Verified to work, tested on Quectel EP06 with firmware EP06ELAR03A08M4G -> EP06ELAR04A06M4G.
After flashing required a AT command for selecting USB2 instead of USB3 for modem to appear into system,
minimal instructions included in package description. Software is not licensed/"totally open source" for customers of Quectel.