### PR TITLE
dfu-programmer: update to 1.0.0

### DIFF
--- a/utils/dfu-programmer/Makefile
+++ b/utils/dfu-programmer/Makefile
@@ -1,26 +1,21 @@
-#
-# Copyright (C) 2015 OpenWrt.org
-#
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
-
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dfu-programmer
-PKG_VERSION:=0.7.2
+PKG_VERSION:=1.0.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_VERSION)
-PKG_HASH:=1db4d36b1aedab2adc976e8faa5495df3cf82dc4bf883633dc6ba71f7c4af995
+PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=867eaf0a8cd10123715491807ab99cecb54dc6f09dddade4b2a42b0b0ef9e6b0
 
 PKG_MAINTAINER:=Stefan Hellermann <stefan@the2masters.de>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+MAKE_PATH:=src
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -29,7 +24,7 @@ define Package/dfu-programmer
   CATEGORY:=Utilities
   SUBMENU:=Microcontroller programming
   TITLE:=USB programmer for Atmel microcontrollers
-  URL:=http://dfu-programmer.github.io/
+  URL:=https://github.com/dfu-programmer/dfu-programmer
   DEPENDS:=+libusb-1.0
 endef
 

--- a/utils/dfu-programmer/patches/000-remove-docs-etc.patch
+++ b/utils/dfu-programmer/patches/000-remove-docs-etc.patch
@@ -1,0 +1,9 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -28,5 +28,5 @@ AC_FUNC_MEMCMP
+ # Checks for libusb.
+ AC_SEARCH_LIBS(libusb_init, usb-1.0,, [AC_MSG_ERROR([libusb 1.0 not found])])
+ 
+-AC_CONFIG_FILES(fedora/dfu-programmer.spec Makefile docs/Makefile src/Makefile)
++AC_CONFIG_FILES(src/Makefile)
+ AC_OUTPUT


### PR DESCRIPTION
The project website http://dfu-programmer.github.io seams dead, but there are new releases on github. They just released 1.0.0, update to it.

I removed docs, bash-completion and the fedora spec file from configure.ac to fix cross compilation problems.

Signed-off-by: Stefan Hellermann <stefan@the2masters.de>

Maintainer: me
Compile tested: ath79 (tplink wdr4300) + mt7622 (ubnt unifi 6 lr)
Run tested: ath79 (tplink wdr4300) 
