### PR TITLE
bind: disable geoip

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -143,6 +143,7 @@ export BUILD_CC="$(TARGET_CC)"
 TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
 CONFIGURE_ARGS += \
+	--disable-geoip \
 	--with-openssl="$(STAGING_DIR)/usr" \
 	--without-lmdb \
 	--enable-epoll \


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
After last update bind is binding to `libmaxminddb` when it founds it while building.