### PR TITLE
ztdns: new package

### DIFF
--- a/net/ztdns/Makefile
+++ b/net/ztdns/Makefile
@@ -1,0 +1,40 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ztdns
+PKG_VERSION:=0.0.2
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/palonsoro/ztdns.git
+PKG_SOURCE_DATE:=2023-01-08
+PKG_SOURCE_VERSION:=1510cb47083989549ce2ed53d01b56a79df69ad0
+PKG_MIRROR_HASH:=5054c934e030e337edb43659beb23f6cac1401c0ba63453be5b446c885c50041
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/uxbh/ztdns
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/ztdns
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=ZerotierDNS
+  URL:=https://github.com/uxbh/ztdns
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/ztdns/description
+  ztDNS is a dedicated DNS server for a ZeroTier virtual network.
+  It is alternative to Zerotier's own zeronsd.
+endef
+
+$(eval $(call GoBinPackage,ztdns))
+$(eval $(call BuildPackage,ztdns))


### PR DESCRIPTION
Maintainer: me / @oskarirauta 
Compile tested: x86_64 / recent git
Run tested: x86_64 / recent git

Description:
ztDNS is a dedicated DNS server for a ZeroTier virtual network.
ztdns is alternative to Zerotier's own zeronds.

Package requested by @ehrenmann1977 here https://github.com/uxbh/ztdns/issues/30
I used palonsoro's repository as it comes with newer Go support and compiles without patching.

I would rather had provided official zeronds- but unfortunately it is written in rust, and (cross-)compiling
rust code in openwrt buildroot does not currently seem to be officially supported, there were solutions though-
but it seemed a bit too complicated. If one day, openwrt would provide support for rust as well, I might take this
into re-consideration, but for now- I hope ztdns brings joy for those missing it.

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>