### PR TITLE
ddns-scripts: add strato ipv6 support

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=31
+PKG_RELEASE:=32
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/strato.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/strato.com.json
@@ -3,5 +3,9 @@
 	"ipv4": {
 		"url": "http://[USERNAME]:[PASSWORD]@dyndns.strato.com/nic/update?hostname=[DOMAIN]&myip=[IP]",
 		"answer": "good|nochg"
+	},
+	"ipv6": {
+		"url": "http://[USERNAME]:[PASSWORD]@dyndns.strato.com/nic/update?hostname=[DOMAIN]&myip=[IP]",
+		"answer": "good|nochg"
 	}
 }


### PR DESCRIPTION
Maintainer: ?
Compile tested: x86 ath79 ramips
Run tested: x86 ath79 ramips

Description:
ddns-scripts: add strato ipv6 support