### PR TITLE
Knot, ocserv: disable libmaxminddb detection

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
 PKG_VERSION:=3.2.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
@@ -151,6 +151,7 @@ CONFIGURE_ARGS += 			\
 	--enable-recvmmsg=no		\
 	--enable-cap-ng=no            	\
 	--enable-xdp=no                 \
+	--enable-maxminddb=no		\
 	--disable-fastparser		\
 	--without-libidn		\
 	--with-libnghttp2=no		\

--- a/net/ocserv/Makefile
+++ b/net/ocserv/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ocserv
 PKG_VERSION:=1.1.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_USE_MIPS16:=0
 
 PKG_BUILD_DIR :=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
@@ -63,6 +63,7 @@ CONFIGURE_ARGS+= \
 	--with-libreadline-prefix="$(STAGING_DIR)/" \
 	--without-libnl \
 	--without-gssapi \
+	--without-maxmind \
 	--with-libcrypt-prefix="$(STAGING_DIR)/" \
 	--with-libev-prefix="$(STAGING_DIR)/" \
 	--without-lz4 \


### PR DESCRIPTION
Maintainer: @salzmdan  @nmav 
Compile tested: ipq806x/R7800,  CI (in this PR)
Run tested: -

Knot and ocserv are currently broken in buildbot for both master and 22.03 due to libmaxminddb detection.
Disable detection in both.

(Libmaxmind got a pkgconfig file a few days ago with #20215 , which caused the libraryt to be detected by knot and ocserv, breaking the buildbot compilation of those packages. Fix things with configure.ac options to disable detection.)

This needs to be backported to 22.03, too.