### PR TITLE
acpica-unix: update version and fix gcc12 build

### DIFF
--- a/utils/acpica-unix/Makefile
+++ b/utils/acpica-unix/Makefile
@@ -8,12 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acpica-unix
-PKG_VERSION:=20211217
+PKG_VERSION:=20221020
 PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://acpica.org/sites/$(patsubst %-unix,%,$(PKG_NAME))/files/$(PKG_SOURCE_URL)
-PKG_HASH:=2511f85828820d747fa3e2c3433d3a38c22db3d9c2fd900e1a84eb4173cb5992
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar_0.gz
+PKG_CAT:=gzip -dc
+PKG_SOURCE_URL:=https://acpica.org/sites/$(patsubst %-unix,%,$(PKG_NAME))/files/
+PKG_HASH:=33a2e394aca0ca57d4018afe3da340dfad5eb45b1b9300e81dd595fda07cf1c5
 PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>
 
 PKG_LICENSE:=GPL-2.0

--- a/utils/acpica-unix/Makefile
+++ b/utils/acpica-unix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acpica-unix
 PKG_VERSION:=20221020
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar_0.gz
 PKG_CAT:=gzip -dc

--- a/utils/acpica-unix/Makefile
+++ b/utils/acpica-unix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acpica-unix
 PKG_VERSION:=20221020
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar_0.gz
 PKG_CAT:=gzip -dc

--- a/utils/acpica-unix/patches/0001-ACPI_CAST_PTR-cast-through-void.patch
+++ b/utils/acpica-unix/patches/0001-ACPI_CAST_PTR-cast-through-void.patch
@@ -1,0 +1,22 @@
+From 0f814783ef9ed3a50e15cab08579218ec45b4640 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Thomas=20Wei=C3=9Fschuh?= <thomas@t-8ch.de>
+Date: Sat, 21 May 2022 12:15:16 +0200
+Subject: [PATCH 1/3] ACPI_CAST_PTR: cast through "void *"
+
+Not all pointer are castable to integers directly and ACPI_UINTPTR_T is
+not guaranteed to be "void *".
+---
+ source/include/actypes.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/source/include/actypes.h
++++ b/source/include/actypes.h
+@@ -649,7 +649,7 @@ typedef UINT64
+ 
+ /* Pointer manipulation */
+ 
+-#define ACPI_CAST_PTR(t, p)             ((t *) (ACPI_UINTPTR_T) (p))
++#define ACPI_CAST_PTR(t, p)             ((t *) (ACPI_UINTPTR_T) (void *) (p))
+ #define ACPI_CAST_INDIRECT_PTR(t, p)    ((t **) (ACPI_UINTPTR_T) (p))
+ #define ACPI_ADD_PTR(t, a, b)           ACPI_CAST_PTR (t, (ACPI_CAST_PTR (UINT8, (a)) + (ACPI_SIZE)(b)))
+ #define ACPI_SUB_PTR(t, a, b)           ACPI_CAST_PTR (t, (ACPI_CAST_PTR (UINT8, (a)) - (ACPI_SIZE)(b)))

--- a/utils/acpica-unix/patches/0002-Linux-non-kernel-Use-use-uintptr_t-for-ACPI_UINTPTR_.patch
+++ b/utils/acpica-unix/patches/0002-Linux-non-kernel-Use-use-uintptr_t-for-ACPI_UINTPTR_.patch
@@ -1,0 +1,37 @@
+From 6b7a78c41c04772a30923c8c0ba71770d55ac815 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Thomas=20Wei=C3=9Fschuh?= <thomas@t-8ch.de>
+Date: Sat, 21 May 2022 12:17:14 +0200
+Subject: [PATCH 2/3] Linux non-kernel: Use use uintptr_t for ACPI_UINTPTR_T
+
+---
+ source/include/platform/aclinux.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+--- a/source/include/platform/aclinux.h
++++ b/source/include/platform/aclinux.h
+@@ -168,6 +168,8 @@
+ #define ACPI_USE_DO_WHILE_0
+ #define ACPI_IGNORE_PACKAGE_RESOLUTION_ERRORS
+ 
++#define ACPI_UINTPTR_T uintptr_t
++
+ 
+ #ifdef __KERNEL__
+ 
+@@ -252,8 +254,6 @@
+ #define ACPI_SPINLOCK               spinlock_t *
+ #define ACPI_CPU_FLAGS              unsigned long
+ 
+-#define ACPI_UINTPTR_T              uintptr_t
+-
+ #define ACPI_TO_INTEGER(p)          ((uintptr_t)(p))
+ #define ACPI_OFFSET(d, f)           offsetof(d, f)
+ 
+@@ -311,6 +311,7 @@
+ 
+ #ifdef ACPI_USE_STANDARD_HEADERS
+ #include <unistd.h>
++#include <stdint.h>
+ #endif
+ 
+ /* Define/disable kernel-specific declarators */

--- a/utils/acpica-unix/patches/0003-debug-use-UINT_PTR_T-to-store-stack-boundaries.patch
+++ b/utils/acpica-unix/patches/0003-debug-use-UINT_PTR_T-to-store-stack-boundaries.patch
@@ -1,0 +1,85 @@
+From 2185f7d5d7a5650dbcb6a05e9de41f340cd3b865 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Thomas=20Wei=C3=9Fschuh?= <thomas@t-8ch.de>
+Date: Sat, 21 May 2022 12:17:58 +0200
+Subject: [PATCH 3/3] debug: use UINT_PTR_T to store stack boundaries
+
+GCC12 complains about storing invalid pointers, store them as integers
+instead.
+
+obj/acpiexec ../../../source/components/utilities/utdebug.c
+../../../source/components/utilities/utdebug.c: In function 'AcpiUtInitStackPtrTrace':
+../../../source/components/utilities/utdebug.c:188:31: error: storing the address of local variable 'CurrentSp' in 'AcpiGbl_EntryStackPointer' [-Werror=dangling-pointer=]
+  188 |     AcpiGbl_EntryStackPointer = &CurrentSp;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
+../../../source/components/utilities/utdebug.c:185:29: note: 'CurrentSp' declared here
+  185 |     ACPI_SIZE               CurrentSp;
+      |                             ^~~~~~~~~
+
+Fixes #771
+---
+ source/components/debugger/dbstats.c  | 4 ++--
+ source/components/utilities/utdebug.c | 6 +++---
+ source/components/utilities/utinit.c  | 2 +-
+ source/include/acglobal.h             | 4 ++--
+ 4 files changed, 8 insertions(+), 8 deletions(-)
+
+--- a/source/components/debugger/dbstats.c
++++ b/source/components/debugger/dbstats.c
+@@ -647,8 +647,8 @@ AcpiDbDisplayStatistics (
+             AcpiGbl_EntryStackPointer, AcpiGbl_LowestStackPointer);
+ 
+         AcpiOsPrintf ("\nSubsystem Stack Usage:\n\n");
+-        AcpiOsPrintf ("Entry Stack Pointer          %p\n", AcpiGbl_EntryStackPointer);
+-        AcpiOsPrintf ("Lowest Stack Pointer         %p\n", AcpiGbl_LowestStackPointer);
++        AcpiOsPrintf ("Entry Stack Pointer          %p\n", ACPI_TO_POINTER(AcpiGbl_EntryStackPointer));
++        AcpiOsPrintf ("Lowest Stack Pointer         %p\n", ACPI_TO_POINTER(AcpiGbl_LowestStackPointer));
+         AcpiOsPrintf ("Stack Use                    %X (%u)\n", Temp, Temp);
+         AcpiOsPrintf ("Deepest Procedure Nesting    %u\n", AcpiGbl_DeepestNesting);
+ #endif
+--- a/source/components/utilities/utdebug.c
++++ b/source/components/utilities/utdebug.c
+@@ -185,7 +185,7 @@ AcpiUtInitStackPtrTrace (
+     ACPI_SIZE               CurrentSp;
+ 
+ 
+-    AcpiGbl_EntryStackPointer = &CurrentSp;
++    AcpiGbl_EntryStackPointer = ACPI_TO_INTEGER(&CurrentSp);
+ }
+ 
+ 
+@@ -208,9 +208,9 @@ AcpiUtTrackStackPtr (
+     ACPI_SIZE               CurrentSp;
+ 
+ 
+-    if (&CurrentSp < AcpiGbl_LowestStackPointer)
++    if (ACPI_TO_INTEGER(&CurrentSp) < AcpiGbl_LowestStackPointer)
+     {
+-        AcpiGbl_LowestStackPointer = &CurrentSp;
++        AcpiGbl_LowestStackPointer = ACPI_TO_INTEGER(&CurrentSp);
+     }
+ 
+     if (AcpiGbl_NestingLevel > AcpiGbl_DeepestNesting)
+--- a/source/components/utilities/utinit.c
++++ b/source/components/utilities/utinit.c
+@@ -359,7 +359,7 @@ AcpiUtInitGlobals (
+ #endif
+ 
+ #ifdef ACPI_DEBUG_OUTPUT
+-    AcpiGbl_LowestStackPointer          = ACPI_CAST_PTR (ACPI_SIZE, ACPI_SIZE_MAX);
++    AcpiGbl_LowestStackPointer          = ACPI_SIZE_MAX;
+ #endif
+ 
+ #ifdef ACPI_DBG_TRACK_ALLOCATIONS
+--- a/source/include/acglobal.h
++++ b/source/include/acglobal.h
+@@ -332,8 +332,8 @@ extern const ACPI_PREDEFINED_NAMES
+ ACPI_GLOBAL (UINT32,                    AcpiGbl_CurrentNodeCount);
+ ACPI_GLOBAL (UINT32,                    AcpiGbl_CurrentNodeSize);
+ ACPI_GLOBAL (UINT32,                    AcpiGbl_MaxConcurrentNodeCount);
+-ACPI_GLOBAL (ACPI_SIZE *,               AcpiGbl_EntryStackPointer);
+-ACPI_GLOBAL (ACPI_SIZE *,               AcpiGbl_LowestStackPointer);
++ACPI_GLOBAL (ACPI_UINTPTR_T,            AcpiGbl_EntryStackPointer);
++ACPI_GLOBAL (ACPI_UINTPTR_T,            AcpiGbl_LowestStackPointer);
+ ACPI_GLOBAL (UINT32,                    AcpiGbl_DeepestNesting);
+ ACPI_INIT_GLOBAL (UINT32,               AcpiGbl_NestingLevel, 0);
+ #endif


### PR DESCRIPTION
Maintainer: @pprindeville 
Compile tested: x86_64, APU3, latest version
Run tested: x86_64, APU3, latest version

Description:
Update version to 20221020
Remove deprectated AUTORELEASE feature
Backport pending [patches](https://github.com/acpica/acpica/pull/776) from upstream repository to fix gcc12 build [issue](https://github.com/acpica/acpica/issues/771)

