### PR TITLE
[openwrt-21.02] transmission: fix "settings.json.tmp.XXXXXX": Permission denied

### DIFF
--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -66,7 +66,7 @@ transmission() {
 	local nice
 	config_get nice "$cfg" nice 0
 	local web_home
-	config_get web_home "$cfg" 'web_home'
+	config_get web_home "$cfg" 'web_home' '/usr/share/transmission/web'
 	local seccomp_path
 
 	local MEM
@@ -154,11 +154,10 @@ transmission() {
 	[ -d "$web_home" ] && procd_set_param env TRANSMISSION_WEB_HOME="$web_home"
 
 	procd_add_jail transmission log
-	procd_add_jail_mount "$config_file"
+	procd_add_jail_mount_rw "$config_dir"
 	procd_add_jail_mount_rw "$config_dir/resume"
 	procd_add_jail_mount_rw "$config_dir/torrents"
 	procd_add_jail_mount_rw "$config_dir/blocklists"
-	procd_add_jail_mount_rw "$config_dir/stats.json"
 	procd_add_jail_mount_rw "$download_dir"
 	[ -d "$web_home" ] && procd_add_jail_mount_rw "$web_home"
 	procd_close_instance


### PR DESCRIPTION
Two bug fix:

1. Syslog: Couldn't save temporary file "/tmp/transmission/settings.json.tmp.XXXXXX": Permission denied (variant.c:1235)
2. Browser http://router-ip:9091/transmission/web is "404: Not Found"

Maintainer: @dangowrt / CC: @neheb
Compile tested: n/a
Run tested: 21.02.5-x86-64

Description:

1. Syslog: Couldn't save temporary file "/tmp/transmission/settings.json.tmp.XXXXXX": Permission denied (variant.c:1235)
2. Browser http://router-ip:9091/transmission/web is "404: Not Found"
