### PR TITLE
strongswan: Update to 5.9.9

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
-PKG_VERSION:=5.9.8
-PKG_RELEASE:=5
+PKG_VERSION:=5.9.9
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/
-PKG_HASH:=d3303a43c0bd7b75a12b64855e8edcb53696f06190364f26d1533bde1f2e453c
+PKG_HASH:=5e16580998834658c17cebfb31dd637e728669cf2fdd325460234a4643b8d81d
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>, Noel Kuntze <noel.kuntze@thermi.consulting>
 PKG_CPE_ID:=cpe:/a:strongswan:strongswan

--- a/net/strongswan/patches/0905-undef-wolfssl-RNG.patch
+++ b/net/strongswan/patches/0905-undef-wolfssl-RNG.patch
@@ -1,0 +1,12 @@
+--- a/src/libstrongswan/plugins/wolfssl/wolfssl_plugin.c
++++ b/src/libstrongswan/plugins/wolfssl/wolfssl_plugin.c
+@@ -50,6 +50,9 @@
+ #ifndef FIPS_MODE
+ #define FIPS_MODE 0
+ #endif
++#ifdef RNG
++#undef RNG
++#endif
+ 
+ typedef struct private_wolfssl_plugin_t private_wolfssl_plugin_t;
+ 


### PR DESCRIPTION
Maintainer: me, @Thermi 
Compile tested: x86_64, generic, HEAD (fb15cb4ce95)
Run tested: same, installed on production router

Description:

Update to version 5.9.9.