### PR TITLE
xinetd: add processing of redirect option in init script

### DIFF
--- a/net/xinetd/Makefile
+++ b/net/xinetd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xinetd
 PKG_VERSION:=2.3.15
-PKG_RELEASE:=13
+PKG_RELEASE:=14
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/xinetd-org/xinetd/archive

--- a/net/xinetd/files/xinetd.init
+++ b/net/xinetd/files/xinetd.init
@@ -62,7 +62,22 @@ config_cb() {
 			local option="$1"
 			local value="$2"
 
-			[ -n "$value" ] && [ "$option" != "name" ] && echo -e "\t$option = $value" >> $GENERATED_CONF_FILE
+			# for the redirect option we have to convert the '[ip address]:port' notation
+			# in config file to 'ip_address port' in the xinetd config file
+			if [ "$option" = "redirect" ] && [ -n "$value" ]; then
+				local redirect_ip=""
+				local redirect_port=""
+
+				redirect_ip="$(echo ${value%:*})"
+				redirect_ip="$(echo ${redirect_ip//\[/})"
+				redirect_ip="$(echo ${redirect_ip//\]/})"
+
+				redirect_port="$(echo ${value##*:})"
+
+				echo -e "\t$option = $redirect_ip $redirect_port" >> $GENERATED_CONF_FILE
+			else
+				[ -n "$value" ] && [ "$option" != "name" ] && echo -e "\t$option = $value" >> $GENERATED_CONF_FILE
+			fi
 		}
 
 		# redefined callback for lists when calling config_load


### PR DESCRIPTION
This extension is based on the issue https://github.com/openwrt/luci/issues/6151 and implements the requested `redirect` feature.

The redirect option from within the uci config file which is written as `[ipv6addr]:port` or `ipv4addr:port` has to be converted to the format `ipaddr port` to be understood by xinetd.

