### PR TITLE
autossh: Add dropbear proxy (-J) support

### DIFF
--- a/net/autossh/Makefile
+++ b/net/autossh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=autossh
 PKG_VERSION:=1.4g
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://www.harding.motd.ca/autossh/

--- a/net/autossh/files/autossh.config
+++ b/net/autossh/files/autossh.config
@@ -1,5 +1,6 @@
 config autossh
 	option ssh	'-i /etc/dropbear/id_rsa -N -T -R 2222:localhost:22 user@host'
+	#option dropbearproxy 'ncat --proxy 127.0.0.1:9050 --proxy-type socks5 1.2.3.4 22'
 	option gatetime	'0'
 	option monitorport	'20000'
 	option poll	'600'

--- a/net/autossh/files/autossh.init
+++ b/net/autossh/files/autossh.init
@@ -8,6 +8,7 @@ start_instance() {
 	local section="$1"
 
 	config_get ssh "$section" 'ssh'
+	config_get dropbearproxy "$section" 'dropbearproxy'
 	config_get gatetime "$section" 'gatetime'
 	config_get monitorport "$section" 'monitorport'
 	config_get poll "$section" 'poll'
@@ -17,6 +18,9 @@ start_instance() {
 
 	procd_open_instance
 	procd_set_param command /usr/sbin/autossh -M ${monitorport:-20000} ${ssh}
+	if [ "$dropbearproxy" ]; then
+		procd_append_param command -J "${dropbearproxy}"
+	fi
 	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
 	procd_set_param env AUTOSSH_GATETIME="${gatetime:-30}" AUTOSSH_POLL="${poll:-600}"
 	procd_close_instance


### PR DESCRIPTION
Maintainer: @jempatel, @neheb 
Compile tested: x86 22.03.3
Run tested: x86 22.03.3

Description:
It's not possible to pass quoted string as a single argument using uci, which makes it impossible to supply proxy string to dropbear.

Additional option solves this issue.

Signed-off-by: ValdikSS <iam@valdikss.org.ru>