### PR TITLE
python-requests: update URL

### DIFF
--- a/lang/python/python-requests/Makefile
+++ b/lang/python/python-requests/Makefile
@@ -28,7 +28,7 @@ define Package/python3-requests
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=HTTP library for Python
-  URL:=https://2.python-requests.org/
+  URL:=https://requests.readthedocs.io
   DEPENDS:= \
 	  +python3-light  \
 	  +python3-chardet  \


### PR DESCRIPTION
The old 2.python-requests.org URL is not reachable on modern browsers, and is not the current canonical URL for the project.  Update to the current best URL for the project.

Signed-off-by: Karl Palsson <karlp@etactica.com>

Maintainer: @commodo @BKPepe 
Compile tested: n/a, description URL change only
Run tested: n/a, description URL change only