### PR TITLE
autossh: return from instance function, not exit the script

### DIFF
--- a/net/autossh/Makefile
+++ b/net/autossh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=autossh
 PKG_VERSION:=1.4g
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://www.harding.motd.ca/autossh/

--- a/net/autossh/files/autossh.init
+++ b/net/autossh/files/autossh.init
@@ -13,7 +13,7 @@ start_instance() {
 	config_get poll "$section" 'poll'
 	config_get_bool enabled "$section" 'enabled' '1'
 
-	[ "$enabled" = 1 ] || exit 0
+	[ "$enabled" = 1 ] || return 1
 
 	procd_open_instance
 	procd_set_param command /usr/sbin/autossh -M ${monitorport:-20000} ${ssh}


### PR DESCRIPTION
In case of disabled configuration instances in the top of configuration file, enabled instances won't be started as the first disabled instance would result in init script termination.

Signed-off-by: ValdikSS <iam@valdikss.org.ru>

Maintainer: @bk138 
