### PR TITLE
modemmanager: Allow qcom-soc modems

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_SOURCE_VERSION:=1.20.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/modemmanager.proto
+++ b/net/modemmanager/files/modemmanager.proto
@@ -368,7 +368,8 @@ proto_modemmanager_setup() {
 		proto_set_available "${interface}" 0
 		return 1
 	}
-	[ -e "${device}" ] || {
+	# "qcom-soc" is a special case on devices where modem is part of the SoC.
+	[ -e "${device}" ] || [ "${device}" = "qcom-soc" ] || {
 		echo "Device not found in sysfs"
 		proto_set_available "${interface}" 0
 		return 1


### PR DESCRIPTION
qcom-soc is a special case modem on devices where it is part of the SoC, which is the case on some Qualcomm chipsets.
Don't fail if the device field is set to this value.

Signed-off-by: Nikita Travkin <nikita@trvn.ru>

Maintainer: @mips171 [[nicholas@nbembedded.com](mailto:nicholas@nbembedded.com)], @aleksander0m

Relevant PR: [openwrt/WIP: introduce Snapdragon 410 based devices](https://github.com/openwrt/openwrt/pull/11729)