### PR TITLE
tor: fix daemon reloading

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
 PKG_VERSION:=0.4.8.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \

--- a/net/tor/files/tor.init
+++ b/net/tor/files/tor.init
@@ -32,7 +32,7 @@ generate_conf() {
 }
 
 reload_service() {
-	procd_send_signal /usr/sbin/tor
+	procd_send_signal tor
 }
 
 start_service() {


### PR DESCRIPTION
procd requires init script name, not the path to executable

Signed-off-by: ValdikSS ValdikSS <iam@valdikss.org.ru>

Maintainer: @rsalvaterra
