### PR TITLE
lrzsz: update to v0.12.21rc and fix a CVE

### DIFF
--- a/utils/lrzsz/Makefile
+++ b/utils/lrzsz/Makefile
@@ -8,16 +8,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lrzsz
-PKG_VERSION:=0.12.20
-PKG_RELEASE:=3
+PKG_VERSION:=0.12.21
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://ohse.de/uwe/releases/
-PKG_HASH:=c28b36b14bddb014d9e9c97c52459852f97bd405f89113f30bee45ed92728ff1
+PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.gz
+PKG_SOURCE_URL:=@DEBIAN/pool/main/l/lrzsz/
+PKG_HASH:=3262e5df47b108d33e184ff3bf5af14ddca1ac15118ac4ed9171a57c1593ae00
+PKG_BUILD_DIR=$(BUILD_DIR)/lrzsz-990823
 
 PKG_MAINTAINER:=Hsing-Wang Liao <kuoruan@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:lrzsz_project
 
 PKG_INSTALL:=1
 
@@ -26,15 +28,24 @@ include $(INCLUDE_DIR)/package.mk
 define Package/lrzsz
   SECTION:=utils
   CATEGORY:=Utilities
-  TITLE:=X, Y and Z-modem protocols
+  TITLE:=Tools for zmodem/xmodem/ymodem file transfer
   URL:=https://ohse.de/uwe/software/lrzsz.html
 endef
 
 define Package/lrzsz/description
-	Transfer files in your login sessions.
-	Very leightweight and straight forward.
-	You just need a terminal client that can do
-	either X, Y or Z-modem file transfers.
+  lrzsz is a cosmetically modified zmodem/ymodem/xmodem package built
+  from the public-domain version of Chuck Forsberg's rzsz package.
+
+  These programs use error correcting protocols ({z,x,y}modem) to send
+  (sz, sx, sb) and receive (rz, rx, rb) files over a dial-in serial port
+  from a variety of programs running under various operating systems.
+endef
+
+# to stop automake from running, the bundled autohell crap is too old
+define Build/Configure
+	touch $(PKG_BUILD_DIR)/*
+	touch $(PKG_BUILD_DIR)/*/*
+	$(call Build/Configure/Default)
 endef
 
 define Package/lrzsz/install

--- a/utils/lrzsz/patches/001-siginterrupt-after-the-call-to-signal-otherwise-ymod.patch
+++ b/utils/lrzsz/patches/001-siginterrupt-after-the-call-to-signal-otherwise-ymod.patch
@@ -1,0 +1,22 @@
+From 89fef6d8dc539ed6225b46b8e755e08bbf48d27b Mon Sep 17 00:00:00 2001
+From: Uwe Ohse <uwe@ohse.de>
+Date: Sun, 1 Mar 2020 22:34:24 +0000
+Subject: [PATCH] siginterrupt after the call to signal, otherwise ymodem
+ transfer hangs. WTF?
+
+---
+ src/zreadline.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/src/zreadline.c
++++ b/src/zreadline.c
+@@ -71,6 +71,9 @@ readline_internal(unsigned int timeout)
+ 			vstringf("Calling read: alarm=%d  Readnum=%d ",
+ 			  n, readline_readnum);
+ 		signal(SIGALRM, zreadline_alarm_handler); 
++#ifdef HAVE_SIGINTERRUPT
++		siginterrupt(SIGALRM,1);
++#endif  
+ 		alarm(n);
+ 	}
+ 	else if (Verbose > 5)

--- a/utils/lrzsz/patches/002-may-be-security-fix-avoid-possible-underflow.patch
+++ b/utils/lrzsz/patches/002-may-be-security-fix-avoid-possible-underflow.patch
@@ -1,0 +1,28 @@
+From a7c525191aa725f4ebb7b489cdd7dd854a4e42fb Mon Sep 17 00:00:00 2001
+From: Uwe Ohse <uwe@ohse.de>
+Date: Sun, 1 Mar 2020 22:35:28 +0000
+Subject: [PATCH] may-be-security-fix: avoid possible underflow
+
+Fixes: CVE-2018-10195
+
+[a.heider: mention CVE in commit message]
+---
+ src/zm.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+--- a/src/zm.c
++++ b/src/zm.c
+@@ -432,10 +432,11 @@ zsdata(const char *buf, size_t length, i
+ 	VPRINTF(3,("zsdata: %lu %s", (unsigned long) length, 
+ 		Zendnames[(frameend-ZCRCE)&3]));
+ 	crc = 0;
+-	do {
++	while (length>0) {
+ 		zsendline(*buf); crc = updcrc((0377 & *buf), crc);
+ 		buf++;
+-	} while (--length>0);
++		length--;
++	}
+ 	xsendline(ZDLE); xsendline(frameend);
+ 	crc = updcrc(frameend, crc);
+ 

--- a/utils/lrzsz/patches/100-install_delete_fix.patch
+++ b/utils/lrzsz/patches/100-install_delete_fix.patch
@@ -1,6 +1,6 @@
 --- a/src/Makefile.in
 +++ b/src/Makefile.in
-@@ -372,13 +372,13 @@ install-exec-local:
+@@ -414,13 +414,13 @@ install-exec-local:
  	rm -f $(DESTDIR)/$(bindir)/`echo lsb | sed -e '$(transform)'`
  	ln $(DESTDIR)/$(bindir)/`echo lsz |sed -e '$(transform)'` \
  		$(DESTDIR)/$(bindir)/`echo lsb |sed -e '$(transform)'` 

--- a/utils/lrzsz/patches/200-format.patch
+++ b/utils/lrzsz/patches/200-format.patch
@@ -10,7 +10,7 @@
  
 --- a/src/lrz.c
 +++ b/src/lrz.c
-@@ -2319,7 +2319,7 @@ exec2(const char *s)
+@@ -2296,7 +2296,7 @@ exec2(const char *s)
  	if (*s == '!')
  		++s;
  	io_mode(0,0);
@@ -31,7 +31,7 @@
  #endif
 --- a/src/lsz.c
 +++ b/src/lsz.c
-@@ -1997,7 +1997,7 @@ zsendfdata (struct zm_fileinfo *zi)
+@@ -1988,7 +1988,7 @@ zsendfdata (struct zm_fileinfo *zi)
  		blklen = calc_blklen (total_sent);
  		total_sent += blklen + OVERHEAD;
  		if (Verbose > 2 && blklen != old)
@@ -40,29 +40,9 @@
  #ifdef HAVE_MMAP
  		if (mm_addr) {
  			if (zi->bytes_sent + blklen < mm_size)
---- a/src/tcp.c
-+++ b/src/tcp.c
-@@ -56,7 +56,7 @@ tcp_server (char *buf)
- 	struct sockaddr_in s;
- 	struct sockaddr_in t;
- 	int on=1;
--	size_t len;
-+	socklen_t len;
- 
- 	if ((sock = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
- 		error(1,errno,"socket");
-@@ -91,7 +91,7 @@ tcp_accept (int d)
- {
- 	int so;
- 	struct  sockaddr_in s;
--	size_t namelen;
-+	socklen_t namelen;
- 	int num=0;
- 
- 	namelen = sizeof(s);
 --- a/src/zm.c
 +++ b/src/zm.c
-@@ -451,7 +451,7 @@ zsda32(const char *buf, size_t length, i
+@@ -453,7 +453,7 @@ zsda32(const char *buf, size_t length, i
  	int c;
  	unsigned long crc;
  	int i;
@@ -73,7 +53,7 @@
  	zsendline_s(buf,length);
 --- a/src/zreadline.c
 +++ b/src/zreadline.c
-@@ -68,13 +68,13 @@ readline_internal(unsigned int timeout)
+@@ -68,7 +68,7 @@ readline_internal(unsigned int timeout)
  		else if (n==0)
  			n=1;
  		if (Verbose > 5)
@@ -81,6 +61,8 @@
 +			vstringf("Calling read: alarm=%u  Readnum=%zu ",
  			  n, readline_readnum);
  		signal(SIGALRM, zreadline_alarm_handler); 
+ #ifdef HAVE_SIGINTERRUPT
+@@ -77,7 +77,7 @@ readline_internal(unsigned int timeout)
  		alarm(n);
  	}
  	else if (Verbose > 5)


### PR DESCRIPTION
This updates to v0.12.21rc from 1999 (sic), which was never officially released. There're fixes in there, and it's what debian ships, so let's use that too. While at it, use debian's autohell hack and package description too.

Patch 1 fixes a hang with musl.
Patch 2 fixes CVE-2018-10195, add PKG_CPE_ID while at it.

Refesh the rest.

Fixes: CVE-2018-10195
Signed-off-by: Andre Heider <a.heider@gmail.com>

Maintainer: Hsing-Wang Liao @kuoruan 
Compile tested: ipq40xx
Run tested: ipq40xx