### PR TITLE
[22.03] pbr: update to 1.0.1-14

### DIFF
--- a/net/pbr/Makefile
+++ b/net/pbr/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=3
+PKG_RELEASE:=14
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 
@@ -125,8 +125,8 @@ define Package/pbr/prerm
 	# check if we are on real system
 	if [ -z "$${IPKG_INSTROOT}" ]; then
 		uci -q delete firewall.pbr || true
-		echo "Stopping pbr service... "
-		/etc/init.d/pbr stop || true
+		echo -n "Stopping pbr service... "
+		/etc/init.d/pbr stop && echo "OK" || echo "FAIL"
 		echo -n "Removing rc.d symlink for pbr... "
 		/etc/init.d/pbr disable && echo "OK" || echo "FAIL"
 	fi
@@ -146,7 +146,7 @@ define Package/pbr-iptables/postinst
 	#!/bin/sh
 	# check if we are on real system
 	if [ -z "$${IPKG_INSTROOT}" ]; then
-		echo -n "Installing rc.d symlink for pbr... "
+		echo -n "Installing rc.d symlink for pbr-iptables... "
 		/etc/init.d/pbr enable && echo "OK" || echo "FAIL"
 	fi
 	exit 0
@@ -157,9 +157,9 @@ define Package/pbr-iptables/prerm
 	# check if we are on real system
 	if [ -z "$${IPKG_INSTROOT}" ]; then
 		uci -q delete firewall.pbr || true
-		echo "Stopping pbr service... "
-		/etc/init.d/pbr stop || true
-		echo -n "Removing rc.d symlink for pbr... "
+		echo -n "Stopping pbr-iptables service... "
+		/etc/init.d/pbr stop && echo "OK" || echo "FAIL"
+		echo -n "Removing rc.d symlink for pbr-iptables... "
 		/etc/init.d/pbr disable && echo "OK" || echo "FAIL"
 	fi
 	exit 0
@@ -169,12 +169,8 @@ define Package/pbr-netifd/postinst
 	#!/bin/sh
 	# check if we are on real system
 	if [ -z "$${IPKG_INSTROOT}" ]; then
-		echo -n "Installing rc.d symlink for pbr... "
+		echo -n "Installing rc.d symlink for pbr-netifd... "
 		/etc/init.d/pbr enable && echo "OK" || echo "FAIL"
-	#	echo -n "Installing netifd support for pbr... "
-	#	/etc/init.d/pbr netifd install && echo "OK" || echo "FAIL"
-	#	echo -n "Restarting network... "
-	#	/etc/init.d/network restart && echo "OK" || echo "FAIL"
 	fi
 	exit 0
 endef
@@ -184,14 +180,10 @@ define Package/pbr-netifd/prerm
 	# check if we are on real system
 	if [ -z "$${IPKG_INSTROOT}" ]; then
 		uci -q delete firewall.pbr || true
-		echo "Stopping pbr service... "
-		/etc/init.d/pbr stop || true
-	#	echo -n "Removing netifd support for pbr... "
-	#	/etc/init.d/pbr netifd remove && echo "OK" || echo "FAIL"
+		echo -n "Stopping pbr-netifd service... "
+		/etc/init.d/pbr stop && echo "OK" || echo "FAIL"
 		echo -n "Removing rc.d symlink for pbr... "
 		/etc/init.d/pbr disable && echo "OK" || echo "FAIL"
-	#	echo -n "Restarting network... "
-	#	/etc/init.d/network restart && echo "OK" || echo "FAIL"
 	fi
 	exit 0
 endef

--- a/net/pbr/files/etc/init.d/pbr.init
+++ b/net/pbr/files/etc/init.d/pbr.init
@@ -447,8 +447,8 @@ ips() {
 
 	case "$command" in
 		add)
-			ips4 -q -! add "$ipset4" comment "$comment" && ipv4_error=0
-			ips6 -q -! add "$ipset6" comment "$comment" && ipv6_error=0
+			ips4 -q -! add "$ipset4" ["$param"] comment "$comment" && ipv4_error=0
+			ips6 -q -! add "$ipset6" ["$param"] comment "$comment" && ipv6_error=0
 		;;
 		add_agh_element)
 			[ -n "$ipv6_enabled" ] || unset ipset6
@@ -1934,6 +1934,11 @@ user_file_process() {
 		output_ok
 		return 0
 	fi
+}
+
+boot() {
+	ubus -t 30 wait_for network.interface 2>/dev/null
+	rc_procd start_service 'on_boot'
 }
 
 on_firewall_reload() { 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos SG-105, OpenWrt 22.03.3
Run tested: x86_64, Sophos SG-105, OpenWrt 22.03.3, start, verify status

Description:
* improve install/uninstall messages
* fix ips add command
* add boot() to init file

Also includes previous commits:
Bugfixes:
* better error information for empty tid/mark and failure to resolve domains
* better handling of entries in /etc/iproute2/rt_tables

Updates:
* add provides: pbr to variants
* introduce nft_user_set_policy and nft_user_set_counter to control options for user nft sets this service creates
* use counters in internal nft sets

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit f4f899f6f992db1e92f02881649e1580958dae18)

