### PR TITLE
ddns-scripts: add hosting.de provider

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=33
+PKG_RELEASE:=34
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/hosting.de.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/hosting.de.json
@@ -1,0 +1,11 @@
+{
+	"name": "hosting.de",
+	"ipv4": {
+		"url": "https://[USERNAME]:[PASSWORD]@ddns.hosting.de/nic/update?hostname=[DOMAIN]&myip=[IP]",
+		"answer": "good|nochg"
+	},
+	"ipv6": {
+		"url": "https://[USERNAME]:[PASSWORD]@ddns.hosting.de/nic/update?hostname=[DOMAIN]&myip=[IP]",
+		"answer": "good|nochg"
+	}
+}

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -32,6 +32,7 @@ easydns.com
 goip.de
 google.com
 he.net
+hosting.de
 infomaniak.com
 inwx.de
 joker.com


### PR DESCRIPTION
Add hosting.de provider. To use dynamic DNS you have to create a DDNS host with a separate DDNS user.

Note: As of 2023-01-17 hosting.de does not work with wget which will fail with `400: Bad Request` (it will work with `--auth-no-challenge`). You should use curl instead. I have reported that to the provider.

Maintainer: ?