### PR TITLE
uvol: fix regression in handling fractional megabytes free

### DIFF
--- a/utils/uvol/Makefile
+++ b/utils/uvol/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uvol
-PKG_VERSION:=0.8
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=0.9
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/utils/uvol/files/autopart.defaults
+++ b/utils/uvol/files/autopart.defaults
@@ -56,23 +56,14 @@ part_fixup() {
 
 get_free_area() {
 	local found=
-	sfdisk -q -F "$1" 2>/dev/null | while read -r start end sectors size; do
+	sfdisk --bytes -q -F "$1" 2>/dev/null | while read -r start end sectors size; do
 		case $start in
 		*"Unpartitioned"* | *"Units:"* | *"Sector"* | *"Start"* )
 			continue
 			;;
 		[0-9]*)
-			case "$size" in
-				*"k" | *"b")
-					continue
-					;;
-				*"M")
-					[ "${size%%.*M}" -lt 100 ] && continue
-					;;
-				*"G" | *"T")
-					;;
-			esac
-			[ "$found" ] || echo "start=$start, size=$((end - start))"
+			[ $size" -lt $((100 * 1024 * 1024)) ] && continue
+			[ "$found" ] || echo "start=$start, size=$sectors"
 			found=1
 			;;
 		esac


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: x86_64, generic, HEAD (0a35d3f992)
Run tested: same, installed on test VM

Description:

Handle case of integral free size in megabytes; also simplify free size computation.

Fixes issue #20343
