### PR TITLE
acpica-unix: Update to 20221020

### DIFF
--- a/utils/acpica-unix/Makefile
+++ b/utils/acpica-unix/Makefile
@@ -8,12 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acpica-unix
-PKG_VERSION:=20211217
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=20221020
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_CAT:=zcat
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar_0.gz
 PKG_SOURCE_URL:=https://acpica.org/sites/$(patsubst %-unix,%,$(PKG_NAME))/files/$(PKG_SOURCE_URL)
-PKG_HASH:=2511f85828820d747fa3e2c3433d3a38c22db3d9c2fd900e1a84eb4173cb5992
+PKG_HASH:=33a2e394aca0ca57d4018afe3da340dfad5eb45b1b9300e81dd595fda07cf1c5
 PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>
 
 PKG_LICENSE:=GPL-2.0

--- a/utils/acpica-unix/patches/900-acpica-dangling-pointer.patch
+++ b/utils/acpica-unix/patches/900-acpica-dangling-pointer.patch
@@ -1,0 +1,13 @@
+--- a/source/components/utilities/utdebug.c
++++ b/source/components/utilities/utdebug.c
+@@ -185,7 +185,10 @@ AcpiUtInitStackPtrTrace (
+     ACPI_SIZE               CurrentSp;
+ 
+ 
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wdangling-pointer"
+     AcpiGbl_EntryStackPointer = &CurrentSp;
++#pragma GCC diagnostic pop
+ }
+ 
+ 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, generic, HEAD (0a35d3f992)
Run tested: same, installed on production router

Description:
