### PR TITLE
atlas-sw-probe: add more binaries

### DIFF
--- a/net/atlas-sw-probe/Makefile
+++ b/net/atlas-sw-probe/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=atlas-sw-probe
 PKG_VERSION:=5080
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/RIPE-NCC/ripe-atlas-software-probe.git
@@ -90,7 +90,8 @@ define Package/atlas-sw-probe/install
 	echo "prod" > $(1)/$(SCRIPTS_DIR)/state/mode
 
 	# Copy scripts
-	$(CP) $(PKG_BUILD_DIR)/bin/{ATLAS,common-pre.sh,common.sh,reginit.sh,resolvconf} $(1)/$(SCRIPTS_DIR)/bin/
+	$(CP) $(PKG_BUILD_DIR)/bin/{ATLAS,resolvconf} $(1)/$(SCRIPTS_DIR)/bin/
+	$(CP) $(PKG_BUILD_DIR)/bin/*.sh $(1)/$(SCRIPTS_DIR)/bin/
 	$(CP) $(PKG_BUILD_DIR)/bin/arch/{linux,openwrt-sw-probe} $(1)/$(SCRIPTS_DIR)/bin/arch/
 
 	# Create config info


### PR DESCRIPTION
Maintainer: @ja-pa 
Compile tested: Turris 1.1, mpc85xx/p2020, OpenWrt 21.02.5
Run tested: Turris 1.1, mpc85xx/p2020, OpenWrt 21.02.5

They were added in these commits [1] [2] and if they are not included, the RIPE Atlas SW Probe does not work correctly.

This should also prevent this from happening in the future as it now. We include all files with .sh extension file type.

[1] https://github.com/RIPE-NCC/ripe-atlas-software-probe/commit/70ced29fc3217dd8d61e2b78506b6103ded100aa
[2] https://github.com/RIPE-NCC/ripe-atlas-software-probe/commit/71a4ff0e68c55464f766ddb9f1dfe21b22e530db

Fixes: https://github.com/openwrt/packages/issues/20338