### PR TITLE
unbound: update to version 1.17.1

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.17.0
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=1.17.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound
-PKG_HASH:=dcbc95d7891d9f910c66e4edc9f1f2fde4dea2eec18e3af9f75aed44a02f1341
+PKG_HASH:=ee4085cecce12584e600f3d814a28fa822dfaacec1f94c84bfd67f8a5571a5f4
 
 PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/unbound/patches/010-configure-uname.patch
+++ b/net/unbound/patches/010-configure-uname.patch
@@ -3,7 +3,7 @@ Fix cross compile errors by inserting an environment variable for the
 target. Use "uname" on host only if "UNAME" variable is empty.
 --- a/configure.ac
 +++ b/configure.ac
-@@ -818,7 +818,7 @@ if test x_$ub_test_python != x_no; then
+@@ -819,7 +819,7 @@ if test x_$ub_test_python != x_no; then
     fi
  fi
  


### PR DESCRIPTION
Maintainer: @EricLuehrsen 
Compile tested: Turris 1.1, mpc85xx/p2020, OpenWrt 21.02.5
Run tested: Turris 1.1, mpc85xx/p2020, OpenWrt 21.02.5

Release notes:
- https://www.nlnetlabs.nl/news/2023/Jan/12/unbound-1.17.1-released/