### PR TITLE
goeap_proxy: New package for EAP proxy written in GO

### DIFF
--- a/net/goeap_proxy/Makefile
+++ b/net/goeap_proxy/Makefile
@@ -1,0 +1,52 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=goeap_proxy
+PKG_VERSION:=0.3.0
+PKG_RELEASE:=1
+PKG_MAINTAINER:= Gabriel Rodriguez <lifehacksback@gmail.com>
+PKG_LICENSE:=none
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/pyther/goeap_proxy.git
+PKG_MIRROR_HASH:=e4014a8dc317d3325d02c1ae81678d6552628bd7a3e253c8ad01a6912ec49dbf
+PKG_SOURCE_VERSION:=3abd66cf35c70b86fe75989ca64c7a72cc8fa797
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/pyther/goeap_proxy
+GO_PKG_LDFLAGS_X:=main.Version=$(PKG_VERSION) main.BuildStamp=$(shell date +%FT%T%z)
+
+include $(INCLUDE_DIR)/package.mk
+include $(TOPDIR)/feeds/packages/lang/golang/golang-package.mk
+
+define Package/goeap_proxy
+	SECTION=:net
+ 	CATEGORY:=Network
+	TITLE:=Proxy EAP packets between interfaces
+  	URL:=https://github.com/pyther/goeap_proxy
+	DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/goeap_proxy/description
+Daemon written in GO to proxy EAP Authentication packets
+
+endef
+
+define Package/goeap_proxy/conffiles
+/etc/config/goeap_proxy
+endef
+
+define Package/goeap_proxy/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/etc/init.d/goeap_proxy $(1)/etc/init.d/goeap_proxy
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/etc/config/goeap_proxy $(1)/etc/config/goeap_proxy
+endef
+
+$(eval $(call GoBinPackage,goeap_proxy))
+$(eval $(call BuildPackage,goeap_proxy))

--- a/net/goeap_proxy/files/etc/config/goeap_proxy
+++ b/net/goeap_proxy/files/etc/config/goeap_proxy
@@ -1,0 +1,5 @@
+//updated for 0.3.0 and for routers using DSA (Distributed Switch Architecture)
+config goeap_proxy 'devices'
+	option wan 'wan'
+	option router 'lan4'
+	option ignore_logoff 0

--- a/net/goeap_proxy/files/etc/init.d/goeap_proxy
+++ b/net/goeap_proxy/files/etc/init.d/goeap_proxy
@@ -1,0 +1,45 @@
+#!/bin/sh /etc/rc.common
+#
+
+START=25
+USE_PROCD=1
+
+PROG="/usr/bin/goeap_proxy"
+
+boot()
+{
+    config_load goeap_proxy # load config files
+    config_get wan devices wan # create a variable var; letting it know it's a device and assigning the 'wan'
+    config_get lan devices lan
+    ubus -t 30 wait_for "network.${wan}.device" "network.${lan}.device" # updated for DSA (v22.02+)
+    rc_procd start_service
+}
+
+start_service()
+{
+    config_load goeap_proxy # load config files
+    config_get wan devices wan
+    config_get lan devices lan4 # change 'lan4' to your switch's port
+    config_get_bool ignore_logoff interface 'ignore_logoff' '0'
+
+    local if_wan=$(uci get "network.${wan}.device")
+    local if_router=$(uci get "network.@device[4].name") # my device has 4 ports and I use the 4th port
+
+    procd_open_instance
+    # attempt to restart every 30 seconds, the eap proxy for internet connectivity
+    procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-30} ${respawn_retry:-0}
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_set_param command $PROG
+    procd_append_param command "${if_wan}"
+    procd_append_param command "${if_router}"
+    if [ $ignore_logoff != "0" ]; then
+        procd_append_param command -ignore-logoff
+    fi
+    procd_close_instance
+}
+
+service_triggers()
+{
+    procd_add_reload_trigger "goeap_proxy" "network"
+}


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu/wrt3200acm&wrt1900acv1/v22.03.3
Run tested: mvebu/wrt3200acm&wrt1900acv1/v22.03.3

Description:
New Package for goeap_proxy written by Matthew Gyurgyik (pyther). Allows router to bypass AT&T gateway and connect directly to ONT you still need to have a gateway.

Signed-off-by: Gabriel Rodriguez <<lifehacksback@gmail.com>>
