### PR TITLE
v4l2tools: Fix compile on MIPS with glibc

### DIFF
--- a/multimedia/v4l2tools/Makefile
+++ b/multimedia/v4l2tools/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v4l2tools
 PKG_VERSION:=0.1.8
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/mpromonet/v4l2tools.git

--- a/multimedia/v4l2tools/patches/100-fix-mips-build.patch
+++ b/multimedia/v4l2tools/patches/100-fix-mips-build.patch
@@ -1,0 +1,17 @@
+Fix the build on MIPS with glibc.
+
+Without this patch I am getting these error messages:
+openwrt/tmp/ccvKKhvb.s: Assembler messages:
+openwrt/tmp/ccvKKhvb.s:59: Error: opcode not supported on this processor: mips1 (mips1) `pref 0,0($2)'
+....
+
+--- a/libyuv/source/row_mips.cc
++++ b/libyuv/source/row_mips.cc
+@@ -24,6 +24,7 @@ void CopyRow_MIPS(const uint8* src, uint
+   __asm__ __volatile__ (
+     ".set      noreorder                         \n"
+     ".set      noat                              \n"
++    ".set      mips32                            \n"
+     "slti      $at, %[count], 8                  \n"
+     "bne       $at ,$zero, $last8                \n"
+     "xor       $t8, %[src], %[dst]               \n"


### PR DESCRIPTION
This fixes a compile problem seen with glibc on MIPS.

````
Without this patch I am getting these error messages:
openwrt/tmp/ccvKKhvb.s: Assembler messages:
openwrt/tmp/ccvKKhvb.s:59: Error: opcode not supported on this processor: mips1 (mips1) `pref 0,0($2)'
````

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>

Maintainer: @mpromonet 
Compile tested: mlata/be glibc
Run tested: none

Description:
