### PR TITLE
[21.02] wifidog: fix compilation with more recent wolfssl

### DIFF
--- a/net/wifidog/Makefile
+++ b/net/wifidog/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifidog
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/wifidog/wifidog-gateway

--- a/net/wifidog/patches/030-wolfssl-options.patch
+++ b/net/wifidog/patches/030-wolfssl-options.patch
@@ -1,0 +1,18 @@
+--- a/src/simple_http.c
++++ b/src/simple_http.c
+@@ -28,6 +28,7 @@
+ #include <arpa/inet.h>
+ #include <errno.h>
+ #include <unistd.h>
++#include <pthread.h>
+ #include <string.h>
+ #include <syslog.h>
+ 
+@@ -37,6 +38,7 @@
+ #include "pstring.h"
+ 
+ #ifdef USE_CYASSL
++#include <cyassl/options.h>
+ #include <cyassl/ssl.h>
+ #include "conf.h"
+ /* For CYASSL_MAX_ERROR_SZ */


### PR DESCRIPTION
Unbreak wifidog in 21.02 by cherry-picking the same fix for wolfssl as in master and 22.03

(cherry picked from commit 4605f98b413b4b0433199e4fe6d3685344cbf933)

PR for CI testing.
