### PR TITLE
crun: add libgcrypt dependency

### DIFF
--- a/utils/crun/Makefile
+++ b/utils/crun/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crun
 PKG_VERSION:=1.7.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/containers/crun.git
@@ -26,7 +26,7 @@ define Package/crun
   CATEGORY:=Utilities
   TITLE:=crun
   URL:=https://github.com/containers/crun
-  DEPENDS:=@!arc +libseccomp +libcap
+  DEPENDS:=@!arc +libseccomp +libcap +libgcrypt
 endef
 
 define Package/crun/description


### PR DESCRIPTION
Maintainer: @oskarirauta 
Compile tested: x86/64
Run tested: n/a

Description:
Fixes: ad0aa1b2fc64e8 ("crun: update to 1.7.2")
Related discussion: #20262
