### PR TITLE
python-build: add support for pyproject.toml files (reboot of #17130)

### DIFF
--- a/lang/python/python3-host.mk
+++ b/lang/python/python3-host.mk
@@ -51,6 +51,12 @@ HOST_PYTHON3_PIP:=$(STAGING_DIR_HOSTPKG)/bin/pip$(PYTHON3_VERSION)
 
 HOST_PYTHON3_PIP_CACHE_DIR:=$(DL_DIR)/pip-cache
 
+define SetupPyShim
+	if [ -f $(1)/pyproject.toml ] && [ ! -f $(1)/setup.py ] ; then \
+		$(CP) $(python3_mk_path)setup.py.shim $(1)setup.py ; \
+	fi
+endef
+
 # Multiple concurrent pip processes can lead to errors or unexpected results: https://github.com/pypa/pip/issues/2361
 # $(1) => packages to install
 define HostPython3/PipInstall
@@ -75,8 +81,9 @@ endef
 # $(2) => additional arguments to setup.py
 # $(3) => additional variables
 define HostPython3/ModSetup
+	$(call SetupPyShim,$(HOST_BUILD_DIR)/$(strip $(1)))
 	$(call HostPython3/Run, \
 		$(HOST_BUILD_DIR)/$(strip $(1)), \
 		setup.py $(2), \
-		$(3))
+		$(3) PY_PKG_VERSION=$(PKG_VERSION))
 endef

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -62,10 +62,11 @@ endef
 # $(3) => additional variables
 define Python3/ModSetup
 	$(INSTALL_DIR) $(PKG_INSTALL_DIR)/$(PYTHON3_PKG_DIR)
+	$(call SetupPyShim,$(PKG_BUILD_DIR)/$(strip $(1)))
 	$(call Python3/Run, \
 		$(PKG_BUILD_DIR)/$(strip $(1)), \
 		setup.py $(2), \
-		$(3))
+		$(3) PY_PKG_VERSION=$(PKG_VERSION))
 endef
 
 define Python3/FixShebang

--- a/lang/python/setup.py.shim
+++ b/lang/python/setup.py.shim
@@ -1,0 +1,6 @@
+import os
+import setuptools
+
+# FIXME: see about getting rid of PY_PKG_VERSION asap when setuptools handles this correctly
+if __name__ == "__main__":
+    setuptools.setup(version=os.environ['PY_PKG_VERSION'])


### PR DESCRIPTION
Maintainer: @jefferyto
Compile tested: x86 https://github.com/openwrt/commit/6e3acebe35cfc584e145e495b175ae5308d2f2bc
Run tested: x86 https://github.com/openwrt/commit/6e3acebe35cfc584e145e495b175ae5308d2f2bc

------------------------------------------------------------------------

A new PEP 517 (https://www.python.org/dev/peps/pep-0517/) has defined that Python packages can be shipped without any `setup.py` file, and that a `pyproject.toml` file is sufficient.

A `setup.py` shim layer is suggested as a method for running the build.

For these cases, we will add a support in the OpenWrt build-system to provide the default `setup.py` shim layer in case this file does not exist, but there is a `pyproject.toml` file.

We also seem to need to tweak the shim layer with the PKG_VERSION, otherwise the detected version is 0.0.0.
We will need to see if this will be fixed later in setuptools{-scm}.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>