### PR TITLE
pbr: bugfix: fix is_domain()

### DIFF
--- a/net/pbr/Makefile
+++ b/net/pbr/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=14
+PKG_RELEASE:=16
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 

--- a/net/pbr/files/etc/config/pbr
+++ b/net/pbr/files/etc/config/pbr
@@ -35,11 +35,3 @@ config policy
 	option interface 'wan'
 	option dest_addr 'plex.tv my.plexapp.com emby.media app.emby.media tv.emby.media'
 	option enabled '0'
-
-config policy
-	option name 'WireGuard Server'
-	option interface 'wan'
-	option src_port '51820'
-	option chain 'OUTPUT'
-	option proto 'udp'
-	option enabled '0'

--- a/net/pbr/files/etc/init.d/pbr.init
+++ b/net/pbr/files/etc/init.d/pbr.init
@@ -254,7 +254,7 @@ is_ipv6_global() { [ "${1:0:4}" = "2001" ]; }
 # is_ipv6_global() { is_ipv6 "$1" && ! is_ipv6_link_local "$1" && ! is_ipv6_link_local "$1"; }
 is_list() { str_contains "$1" "," || str_contains "$1" " "; }
 is_netmask() { local ip="${1%/*}"; [ "$ip" != "$1" ] && is_ipv4 "$ip"; }
-is_domain() { str_contains "$1" '[a-zA-Z]'; }
+is_domain() { ! is_ipv6 "$1" && str_contains "$1" '[a-zA-Z]'; }
 is_phys_dev() { [ "${1:0:1}" = "@" ] && ip l show | grep -E -q "^\\d+\\W+${1:1}"; }
 dnsmasq_kill() { killall -q -s HUP dnsmasq; }
 dnsmasq_restart() { output 3 'Restarting dnsmasq '; if /etc/init.d/dnsmasq restart >/dev/null 2>&1; then output_okn; else output_failn; fi; }
@@ -579,7 +579,7 @@ nftset() {
 				fi
 				[ -z "$param4" ] &&	param4="$(resolveip_to_nftset4 "$param")"
 				[ -z "$param6" ] &&	param6="$(resolveip_to_nftset6 "$param")"
-				if [ -z "$param4" ] &&	[ -z "$param6" ]; then
+				if [ -z "$param4" ] && [ -z "$param6" ]; then
 					state add 'errorSummary' 'errorFailedToResolve' "$param"
 				else
 					nft4 add element inet "$nftTable" "$nftset4" "{ $param4 }" && ipv4_error=0


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-105w, OpenWrt 22.03.3
Run tested:  x86_64, Sophos XG-105w, OpenWrt 22.03.3, test proper processing of IPv6 in policies

Description:
* fixes https://github.com/openwrt/packages/issues/20352

Thanks @PussAzuki

Signed-off-by: Stan Grishin <stangri@melmac.ca>
