### PR TITLE
ncdu: update to 1.18

### DIFF
--- a/utils/ncdu/Makefile
+++ b/utils/ncdu/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ncdu
-PKG_VERSION:=1.17
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=1.18
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dev.yorhel.nl/download
-PKG_HASH:=810745a8ed1ab3788c87d3aea4cc1a14edf6ee226f764bcc383e024ba56adbf1
+PKG_HASH:=3c37a1a96580c9c5d2cc352dc3c5eef0d909158c05f1cc29db4712544c8b9f95
 
 PKG_MAINTAINER:=Charles E. Lehner <cel@celehner.com>
 PKG_LICENSE:=MIT

--- a/utils/ncdu/patches/900-use-alternative-color.patch
+++ b/utils/ncdu/patches/900-use-alternative-color.patch
@@ -1,6 +1,6 @@
 --- a/src/util.h
 +++ b/src/util.h
-@@ -36,18 +36,18 @@
+@@ -39,18 +39,18 @@ void die(const char *, ...);
    C(DEFAULT,     _,_,0  ,    _,      _,    0,    WHITE,  BLACK,0)\
    C(BOX_TITLE,   _,_,B  ,    BLUE,   _,    B,    BLUE,   BLACK,B)\
    C(HD,          _,_,R  ,    BLACK,  CYAN, 0,    BLACK,  CYAN, 0)    /* header & footer */\


### PR DESCRIPTION
Upstream bump

Build system: x86_64
Build-tested: bcm2711/RPi4B
Run-tested: bcm2711/RPi4B

Signed-off-by: John Audia <therealgraysky@proton.me>

Description: @clehner
