### PR TITLE
python3: Re-enable ensurepip module

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -156,7 +156,6 @@ CONFIGURE_ARGS+= \
 	--enable-shared \
 	--with-system-ffi \
 	--without-cxx-main \
-	--without-ensurepip \
 	--without-pymalloc \
 	--disable-test-modules \
 	$(if $(CONFIG_IPV6),--enable-ipv6) \


### PR DESCRIPTION
Signed-off-by: Krystian Kichewko krystiankichewko@gmail.com

Maintainer: @jefferyto @commodo @neheb 
Compile tested: arch64, Raspberry Pi Compute Module 4 IoT Router Carrier Board Mini, OpenWRT 21.02.3
Run tested: arch64, Raspberry Pi Compute Module 4 IoT Router Carrier Board Mini, OpenWRT 21.02.3

Description:

This pull request re-enables ensurepip module that is needed by some software like pipx and pipenv and also this should fix: https://github.com/openwrt/packages/issues/12707
