### PR TITLE
haproxy: update to v2.6.8

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=2.6.6
-PKG_RELEASE:=104
+PKG_VERSION:=2.6.8
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/2.6/src
-PKG_HASH:=d0c80c90c04ae79598b58b9749d53787f00f7b515175e7d8203f2796e6a6594d
+PKG_HASH:=a02ad64550dd30a94b25fd0e225ba699649d0c4037bca3b36b20e8e3235bb86f
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Christian Lachner <gladiac@gmail.com>

--- a/net/haproxy/get-latest-patches.sh
+++ b/net/haproxy/get-latest-patches.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CLONEURL=https://git.haproxy.org/git/haproxy-2.6.git
-BASE_TAG=v2.6.6
+BASE_TAG=v2.6.8
 TMP_REPODIR=tmprepo
 PATCHESDIR=patches
 


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Christian Lachner <gladiac@gmail.com> (/me)
Compile tested: ipq806x
Run tested: ipq806x (r7800)

Description: Update HAProxy to v2.6.8
- Update haproxy download URL and hash