### PR TITLE
python3: add 'ensurepip' to python3-pip sub-package

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 include ../python3-version.mk
 
 PKG_NAME:=python3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_VERSION:=$(PYTHON3_VERSION).$(PYTHON3_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -272,7 +272,6 @@ define Py3Package/python3-light/filespec
 +|/usr/lib/python$(PYTHON3_VERSION)
 -|/usr/lib/python$(PYTHON3_VERSION)/distutils/cygwinccompiler.py
 -|/usr/lib/python$(PYTHON3_VERSION)/distutils/command/wininst*
--|/usr/lib/python$(PYTHON3_VERSION)/ensurepip
 -|/usr/lib/python$(PYTHON3_VERSION)/idlelib
 -|/usr/lib/python$(PYTHON3_VERSION)/tkinter
 -|/usr/lib/python$(PYTHON3_VERSION)/turtledemo

--- a/lang/python/python3/files/python3-package-pip.mk
+++ b/lang/python/python3/files/python3-package-pip.mk
@@ -29,6 +29,7 @@ define Py3Package/python3-pip/install
 endef
 
 $(eval $(call Py3BasePackage,python3-pip, \
+	/usr/lib/python$(PYTHON3_VERSION)/ensurepip \
 	, \
 	DO_NOT_ADD_TO_PACKAGE_DEPENDS \
 ))


### PR DESCRIPTION
Maintainer: @jefferyto 
Compile tested: x86 https://github.com/openwrt/openwrt/commit/7396263680b951211f33f2aa266b11bdd0047adc
Run tested: x86 https://github.com/openwrt/openwrt/commit/7396263680b951211f33f2aa266b11bdd0047adc

-------------------------------------

Fixes:
  https://github.com/openwrt/packages/issues/12707

Seems to work.
Looking into the 'venv' lib, it seems it's installing pip & setuptools inside a virtual environment.

`python3-pip` is already ~6 MB.
This adds another ~3 MB.

But, this gives users the ability to run Python virtual environments, which is a pretty common feature of Python in production cases (usually web stuff).

Signed-off-by: Alexandru Ardelean <alex@shruggie.ro>