### PR TITLE
nextdns: Update to version 1.39.3

### DIFF
--- a/net/nextdns/Makefile
+++ b/net/nextdns/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nextdns
-PKG_VERSION:=1.39.0
+PKG_VERSION:=1.39.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=nextdns-$(PKG_VERSION).tar.gz
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.github.com/nextdns/nextdns/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2bbab16326245e1b1da89c2953283c463b6f4082e677a0d5de451c42ab9768c2
+PKG_HASH:=7bea7f8f76b338b0456655a52bf3b81d9f6db60696b06e64f3cce4f824d7dd89
 
 PKG_MAINTAINER:=Olivier Poitrey <rs@nextdns.io>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Update to version 1.39.3