### PR TITLE
bind: update to 9.18.11

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.18.10
-PKG_RELEASE:=3
+PKG_VERSION:=9.18.11
+PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=f415a92feb62568b50854a063cb231e257351f8672186d0ab031a49b3de2cac6
+PKG_HASH:=8ff3352812230cbcbda42df87cad961f94163d3da457c5e4bef8057fd5df2158
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: me 
Compile tested: x86/master (WIP)
Run tested: x86/master (WIP)

Description:
Fixes CVEs:
*  CVE-2022-3924: Fix serve-stale crash when recursive clients
      soft quota is reached.

* CVE-2022-3736: Handle RRSIG lookups when serve-stale is
      active.

* CVE-2022-3094: An UPDATE message flood could cause named to
      exhaust all available memory. This flaw was addressed by adding
      a new "update-quota" statement that controls the number of
      simultaneous UPDATE messages that can be processed or
      forwarded. The default is 100. A stats counter has been added to
      record events when the update quota is exceeded, and the XML and
      JSON statistics version numbers have been updated.