### PR TITLE
bind: bump to 9.16.37

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.16.33
+PKG_VERSION:=9.16.37
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=ec4fbea4b2e368d1824971509e33fa159224ad14b436034c6bcd46104c328d91
+PKG_HASH:=0e4661d522a2fe1f111c1f0685e7d6993d657f81dae24e7a75dbd8db3ef2e2ab
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Fixes multiple CVEs. Upstream changelog is
https://ftp.isc.org/isc/bind9/9.16.37/CHANGES

CVEs fixed:

CVE-2022-3924: Fix serve-stale crash when recursive clients soft quota
			is reached.

CVE-2022-3736: Handle RRSIG lookups when serve-stale is active.

CVE-2022-3094: An UPDATE message flood could cause named to exhaust all
			available memory. This flaw was addressed by adding a
			new "update-quota" statement that controls the number of
			simultaneous UPDATE messages that can be processed or
			forwarded. The default is 100. A stats counter has been
			added to record events when the update quota is
			exceeded, and the XML and JSON statistics version
			numbers have been updated.

Signed-off-by: Noah Meyerhans <frodo@morgul.net>

Maintainer: me
Compile tested: malta/19.07
Run tested: malta/19.07 runtime tests

