### PR TITLE
bind: add option to enable GSSAPI support

### DIFF
--- a/net/bind/Config.in
+++ b/net/bind/Config.in
@@ -33,4 +33,12 @@ config BIND_ENABLE_DOH
 		You can disable DoHTTPS if you do not need it or need
 		to avoid the additional library dependency.
 
+config BIND_ENABLE_GSSAPI
+	bool
+	default n
+	prompt "Include GSSPAI support in bind"
+	help
+		BIND 9 supports GSSAPI. This depends on libcomerr and krb5-libs.
+		Disable it by default as krb5-libs is rather large.
+
 endif

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.18.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -34,7 +34,8 @@ PKG_BUILD_PARALLEL:=1
 PKG_CONFIG_DEPENDS := \
 	CONFIG_BIND_LIBJSON \
 	CONFIG_BIND_LIBXML2 \
-	CONFIG_BIND_ENABLE_DOH
+	CONFIG_BIND_ENABLE_DOH \
+	CONFIG_BIND_ENABLE_GSSAPI
 
 PKG_BUILD_DEPENDS += BIND_LIBXML2:libxml2 BIND_LIBJSON:libjson-c
 
@@ -61,6 +62,8 @@ define Package/bind-libs
 	+libatomic \
 	+libuv \
 	+BIND_ENABLE_DOH:libnghttp2 \
+	+BIND_ENABLE_GSSAPI:krb5-libs \
+	+BIND_ENABLE_GSSAPI:libcomerr \
 	+BIND_LIBXML2:libxml2 \
 	+BIND_LIBJSON:libjson-c
   TITLE:=bind shared libraries
@@ -147,7 +150,6 @@ CONFIGURE_ARGS += \
 	--with-openssl="$(STAGING_DIR)/usr" \
 	--without-lmdb \
 	--enable-epoll \
-	--without-gssapi \
 	--without-readline \
 	--sysconfdir=/etc/bind
 
@@ -174,6 +176,14 @@ ifdef CONFIG_BIND_ENABLE_DOH
 else
 	CONFIGURE_ARGS += \
 		--disable-doh
+endif
+
+ifdef CONFIG_BIND_ENABLE_GSSAPI
+	CONFIGURE_ARGS += \
+		--with-gssapi
+else
+	CONFIGURE_ARGS += \
+		--without-gssapi
 endif
 
 CONFIGURE_VARS += \


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: OpenWrt master r21922-6e428a8490 on x86/64
Run tested: OpenWrt master r21922-6e428a8490 on x86/64

Description:
Samba4 running as Active Directory Domain Controller with the internal DNS backend requires the nsupdate binary with GSSAPI support.