### PR TITLE
Fixe uuid randomly generated after each startup

### DIFF
--- a/multimedia/minidlna/files/minidlna.init
+++ b/multimedia/minidlna/files/minidlna.init
@@ -6,6 +6,7 @@ START=81
 PROG=/usr/sbin/minidlnad
 USE_PROCD=1
 
+. /lib/functions.sh
 MINIDLNA_CONFIG_FILE="/var/etc/minidlna.conf"
 
 minidlna_cfg_addbool() {


### PR DESCRIPTION
Since /lib/functions.sh is not referenced in startup scripts, config_get will always fail and a new uuid will be set.

Signed-off-by: luochongjun <luochongjun@gl-inet.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
