### PR TITLE
tailscale: update to 1.36.0

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.32.3
+PKG_VERSION:=1.36.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=tailscale-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=4cf88a1d754240ce71b29d3a65ca480091ad9c614ac99c541cef6fdaf0585dd4
+PKG_HASH:=25b293a7e65d7b962f0c56454d66fa56c89c3aa995467218f24efa335b924c76
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -61,23 +61,43 @@ endef
 
 Package/tailscaled/description:=$(Package/tailscale/description)
 
+define Package/tailscaled/conffiles
+/etc/config/tailscale
+/etc/tailscale/tailscaled.state
+endef
+
+GO_IPTABLES_VERSION:=0.6.0
+GO_IPTABLES_FILE:=$(PKG_NAME)-go-iptables-$(GO_IPTABLES_VERSION).tar.gz
+
+define Download/go-iptables
+  URL:=https://codeload.github.com/coreos/go-iptables/tar.gz/v$(GO_IPTABLES_VERSION)?
+  URL_FILE:=$(GO_IPTABLES_FILE)
+  FILE:=$(GO_IPTABLES_FILE)
+  HASH:=a784cc17fcb17879f073eae47bc4c2e899f59f6906dac5a0aa7a9cc9f95ea66d
+endef
+
+define Build/Prepare
+	$(PKG_UNPACK)
+	[ ! -d ./src/ ] || $(CP) ./src/. $(PKG_BUILD_DIR)
+	$(eval $(call Download,go-iptables))
+	( \
+		mkdir -p $(PKG_BUILD_DIR)/patched/ ; \
+		gzip -dc $(DL_DIR)/$(GO_IPTABLES_FILE) | $(HOST_TAR) -C $(PKG_BUILD_DIR)/patched $(TAR_OPTIONS) ; \
+		mv $(PKG_BUILD_DIR)/patched/go-iptables-$(GO_IPTABLES_VERSION) $(PKG_BUILD_DIR)/patched/go-iptables ; \
+	)
+	$(Build/Patch)
+endef
+
 define Package/tailscale/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/tailscale $(1)/usr/sbin
 endef
 
 define Package/tailscaled/install
-	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/init.d $(1)/etc/config
 	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/tailscaled $(1)/usr/sbin
-	$(INSTALL_DIR) $(1)/etc/init.d/
 	$(INSTALL_BIN) ./files//tailscale.init $(1)/etc/init.d/tailscale
-	$(INSTALL_DIR) $(1)/etc/config/
 	$(INSTALL_DATA) ./files//tailscale.conf $(1)/etc/config/tailscale
-endef
-
-define Package/tailscaled/conffiles
-/etc/config/tailscale
-/etc/tailscale/tailscaled.state
 endef
 
 $(eval $(call BuildPackage,tailscale))

--- a/net/tailscale/README.md
+++ b/net/tailscale/README.md
@@ -25,4 +25,9 @@ Run command and finish device registration with the given URL.
 tailscale up
 ```
 
+If you are running with nftables, it is not supported by tailscale,
+so disable it and configure firewall by yourself and add argument
+--netfilter-mode off
+to tailscale up command to disable iptables use.
+
 After that, you should see your router in tailscale admin page.

--- a/net/tailscale/patches/010-fake_iptables.patch
+++ b/net/tailscale/patches/010-fake_iptables.patch
@@ -1,0 +1,53 @@
+--- a/go.mod
++++ b/go.mod
+@@ -2,6 +2,8 @@ module tailscale.com
+ 
+ go 1.19
+ 
++replace github.com/coreos/go-iptables => ./patched/go-iptables
++
+ require (
+ 	filippo.io/mkcert v1.4.3
+ 	github.com/Microsoft/go-winio v0.6.0
+--- a/patched/go-iptables/iptables/iptables.go
++++ b/patched/go-iptables/iptables/iptables.go
+@@ -149,12 +149,39 @@ func New(opts ...option) (*IPTables, err
+ 	return ipt, nil
+ }
+ 
++func NewFake(opts ...option) (*IPTables, error) {
++
++	ipt := &IPTables{
++		path:		   "/bin/false",
++		proto:		   ProtocolIPv4,
++		hasCheck:	   false,
++		hasWait:	   false,
++		waitSupportSecond: false,
++		hasRandomFully:	   false,
++		v1:		   0,
++		v2:		   0,
++		v3:		   0,
++		mode:		   "legacy",
++		timeout:	   0,
++	}
++
++	for _, opt := range opts {
++		opt(ipt)
++	}
++
++	return ipt, nil
++}
++
+ // New creates a new IPTables for the given proto.
+ // The proto will determine which command is used, either "iptables" or "ip6tables".
+ func NewWithProtocol(proto Protocol) (*IPTables, error) {
+ 	return New(IPFamily(proto), Timeout(0))
+ }
+ 
++func NewFakeWithProtocol(proto Protocol) (*IPTables, error) {
++	return NewFake(IPFamily(proto), Timeout(0))
++}
++
+ // Proto returns the protocol used by this IPTables.
+ func (ipt *IPTables) Proto() Protocol {
+ 	return ipt.proto

--- a/net/tailscale/patches/020-tailscaled_fake_iptables.patch
+++ b/net/tailscale/patches/020-tailscaled_fake_iptables.patch
@@ -1,0 +1,32 @@
+--- a/wgengine/router/router_linux.go
++++ b/wgengine/router/router_linux.go
+@@ -129,7 +129,7 @@ func newUserspaceRouter(logf logger.Logf
+ 
+ 	ipt4, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+ 	if err != nil {
+-		return nil, err
++		ipt4, err = iptables.NewFakeWithProtocol(iptables.ProtocolIPv4)
+ 	}
+ 
+ 	v6err := checkIPv6(logf)
+@@ -148,7 +148,7 @@ func newUserspaceRouter(logf logger.Logf
+ 		// if unavailable. We want that to be a non-fatal error.
+ 		ipt6, err = iptables.NewWithProtocol(iptables.ProtocolIPv6)
+ 		if err != nil {
+-			return nil, err
++			ipt6, err = iptables.NewFakeWithProtocol(iptables.ProtocolIPv6)
+ 		}
+ 	}
+ 
+@@ -1635,11 +1635,6 @@ func checkIPv6(logf logger.Logf) error {
+ 		return fmt.Errorf("kernel doesn't support IPv6 policy routing: %w", err)
+ 	}
+ 
+-	// Some distros ship ip6tables separately from iptables.
+-	if _, err := exec.LookPath("ip6tables"); err != nil {
+-		return err
+-	}
+-
+ 	return nil
+ }
+ 

--- a/net/tailscale/patches/030-default_to_netfilter_off.patch
+++ b/net/tailscale/patches/030-default_to_netfilter_off.patch
@@ -1,0 +1,11 @@
+--- a/cmd/tailscale/cli/up.go
++++ b/cmd/tailscale/cli/up.go
+@@ -143,7 +143,7 @@ func defaultNetfilterMode() string {
+ 	if distro.Get() == distro.Synology {
+ 		return "off"
+ 	}
+-	return "on"
++	return "off"
+ }
+ 
+ type upArgsT struct {

--- a/net/tailscale/test.sh
+++ b/net/tailscale/test.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
-if command -v tailscale; then
-    tailscale version | grep "$2" || exit 1
-fi
 
-if command -v tailscaled; then
-    tailscaled -version | grep "$2"
-fi
+case "$1" in
+	tailscale)
+		tailscale version | grep "$2"
+		;;
+	tailscaled)
+		tailscaled -version | grep "$2"
+		;;
+esac


### PR DESCRIPTION
Maintainer: Jan Pavlinec / @ja-pa
Compile tested: x86_64, recent git
Run tested: x86_64, recent git

 - Update tailscale to version 1.36.0
 - Patch iptables support

Tailscale does not (yet) support nftables.
Tailscale allows running with --netfilter=off allowing end-user to create his own firewall rules, but this affects only tailscale cli, not tailscaled daemon, so connection cannot be made without error telling that tailscaled was unable to determine execute iptables for determining it's version.

There is a work-around for those who do not want nft-iptables compatibility package; they can create a script to /usr/bin/iptables which responds to --version argument and echos fake version string
and on any other arguments or no arguments, just exits.

After this procedure and starting tailscale cli with netfilter off- it works. Openwrt has moved on to
nftables, so iptables manipulation seems unnecessary. Especially for other reasons, on Openwrt, firewall should be configured on it's own, because firewall rules made by other software, such as tailscale,
loose their firewalling rules when firewall restarts.

So I patched it to allow "fake" iptables pointing to executable /bin/false and ignoring version
request. And I also set cli to default to netfilter off setting.

If still end-user wants to use iptables, this patch does not make it impossible; just install
iptables, or nft-iptables, and run tailscale with argument --netfilter=on and it works out
as it did before, tailscaled daemon still matches with iptables if it is found in $PATH.

Release notes for version 1.36.0:
 - tailscale debug daemon-logs
 - tailscale version now advertises when you're on the unstable (dev) track
 - tailscale version --json for JSON output mode
 - --json output for tailscale lock status and tailscale lock log commands.
 - Handle cases where a node expires and we don't receive an update about it from the control server (https://github.com/tailscale/tailscale/pull/6929 and https://github.com/tailscale/tailscale/pull/6937).
 - tailscale status --json now includes KeyExpiry time and Expired boolean.
 - Support UPnP port mapping of gateway devices where they are deployed as a highly available pair (https://github.com/tailscale/tailscale/pull/6946).
 - Support arbitrary IP protocols like EOIP and GRE (https://github.com/tailscale/tailscale/pull/6423).
 - Fix exit node handling of a large number of SplitDNS domains (https://github.com/tailscale/tailscale/pull/6875).
 - Accept DNS-over-TCP responses up to 4KBytes.
 - Unix platforms: when /etc/resolv.conf needs to be overwritten for lack of options, a comment in the file now links to https://tailscale.com/s/resolvconf-overwrite
 - Tailscale SSH: ssh to tailscaled as a non-root user now works again, as long as you only ssh to the same user that tailscaled is running as

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>