### PR TITLE
mwan3: Handle iface reconnection while it's still offline

### DIFF
--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -405,6 +405,7 @@ main() {
 		fi
 		if [ "${IFUP_EVENT}" -eq 1 ]; then
 			LOG debug "Register ifup event on interface ${INTERFACE} (${DEVICE})"
+			score=$((down+up))
 			firstconnect
 			IFUP_EVENT=0
 		fi


### PR DESCRIPTION
Fix the following use case:

1. Pings are lost, and mwan3 moves the interface to the offline state, score becomes 0.
2. The underlying netdev goes down and up (reconnects).
3. The initial_state of the interface is "online" (the default), so mwan3 moves the interface to the online state and continues tracking.
4. At this point, score is still 0. Pings continue being lost, so the interface should actually become offline, but as the score is already 0 and never passes the "up" watermark, the interface stays online.

By resetting score to its initial value before calling firstconnect, ensure that the tracking restarts from scratch after the netdev reconnects, fixing the above issue.

Maintainer: @feckert
Run tested: ipq806x, Netgear R7800, OpenWrt 045baca10b157fcc57461392cf27838d147ae5bd, tested the above scenario.