### PR TITLE
Fix (x86_64) squashfs builds

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 include ../python3-version.mk
 
 PKG_NAME:=python3
-PKG_RELEASE:=3
+PKG_RELEASE:=2
 PKG_VERSION:=$(PYTHON3_VERSION).$(PYTHON3_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -272,6 +272,7 @@ define Py3Package/python3-light/filespec
 +|/usr/lib/python$(PYTHON3_VERSION)
 -|/usr/lib/python$(PYTHON3_VERSION)/distutils/cygwinccompiler.py
 -|/usr/lib/python$(PYTHON3_VERSION)/distutils/command/wininst*
+-|/usr/lib/python$(PYTHON3_VERSION)/ensurepip
 -|/usr/lib/python$(PYTHON3_VERSION)/idlelib
 -|/usr/lib/python$(PYTHON3_VERSION)/tkinter
 -|/usr/lib/python$(PYTHON3_VERSION)/turtledemo

--- a/lang/python/python3/files/python3-package-pip.mk
+++ b/lang/python/python3/files/python3-package-pip.mk
@@ -29,7 +29,6 @@ define Py3Package/python3-pip/install
 endef
 
 $(eval $(call Py3BasePackage,python3-pip, \
-	/usr/lib/python$(PYTHON3_VERSION)/ensurepip \
 	, \
 	DO_NOT_ADD_TO_PACKAGE_DEPENDS \
 ))


### PR DESCRIPTION
Description:
Revert "python3: add 'ensurepip' to python3-pip sub-package"

This reverts commit 1f317dfb75216904c92c3c8a64e088fb6b4c551b.

I have to revert it or the squashfs partition of x86_64 images built from current master is not mountable.

I've done several clean builds so I'm pretty confident this causes the breakage.
I still don't understand the relation though.
