### PR TITLE
bind: Fix ipv6 detection logic

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.18.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>

--- a/net/bind/files/named.init
+++ b/net/bind/files/named.init
@@ -73,7 +73,7 @@ start_service() {
     touch $conf_local_file
 
     local args=
-    [ no_ipv6 ] && args="-4"
+    no_ipv6 && args="-4"
 
     procd_open_instance
     procd_set_param command /usr/sbin/named -u bind -f $args -c $config_file


### PR DESCRIPTION
Bug was introduced in a7b770eec4370087a5ccd27887386dac9266214e and results in bind always stating with the `-4` flag.

Signed-off-by: Rucke Teg <rucketeg@protonmail.com>

Maintainer: @nmeyerhans
Compile tested: bcm2711, master
Run tested: bind starts without `-4` flag if ipv6 address is routable