### PR TITLE
openssh: update to 9.2p1

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -36,7 +36,6 @@ define Package/openssh/Default
 	MAINTAINER:=Peter Wagner <tripolar@gmx.at>
 	URL:=http://www.openssh.com/
 	SUBMENU:=SSH
-	VARIANT:=without-pam
 endef
 
 define Package/openssh-moduli
@@ -89,6 +88,7 @@ define Package/openssh-server
 	DEPENDS+= +openssh-keygen +OPENSSH_LIBFIDO2:libfido2
 	TITLE+= server
 	USERID:=sshd=22:sshd=22
+	VARIANT:=without-pam
 endef
 
 define Package/openssh-server/config

--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
-PKG_VERSION:=9.1p1
+PKG_VERSION:=9.2p1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
 		https://ftp.spline.de/pub/OpenBSD/OpenSSH/portable/
-PKG_HASH:=19f85009c7e3e23787f0236fbb1578392ab4d4bf9f8ec5fe6bc1cd7e8bfdd288
+PKG_HASH:=3f66dbf1655fb45f50e1c56da62ab01218c228807b21338d634ebcdf9d71cf46
 
 PKG_LICENSE:=BSD ISC
 PKG_LICENSE_FILES:=LICENCE


### PR DESCRIPTION
Maintainer: @tripolar
Compile tested: all architectures / master
Run tested: MIR4A / ramips / master

Server running and accepting connections
Client connecting to servers

Description:
Version bump to 9.2p1
Fix openssh-server-pam build (Fixes #20291)

Signed-off-by: Sibren Vasse <github@sibrenvasse.nl>