### PR TITLE
python-{chardet,evdev}: bump versions

### DIFF
--- a/lang/python/python-chardet/Makefile
+++ b/lang/python/python-chardet/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-chardet
-PKG_VERSION:=5.0.0
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=5.1.0
+PKG_RELEASE:=1
 PKG_LICENSE:=LGPL-2.1
 
 PYPI_NAME:=chardet
-PKG_HASH:=0368df2bfd78b5fc20572bb4e9bb7fb53e2c094f60ae9993339e8671d0afb8aa
+PKG_HASH:=0d62712b956bc154f85fb0a266e2a3c5913c2967e00348701b32411d6def31e5
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -26,7 +26,7 @@ define Package/python3-chardet
   MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
   URL:=https://github.com/chardet/chardet
   TITLE:=Universal encoding detector
-  DEPENDS:=+python3-light
+  DEPENDS:=+python3-light +python3-logging
 endef
 
 define Package/python3-chardet/description

--- a/lang/python/python-evdev/Makefile
+++ b/lang/python/python-evdev/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=python-evdev
-PKG_VERSION:=1.6.0
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=1.6.1
+PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_MAINTAINER:=Paulo Costa <me@paulo.costa.nom.br>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
 PYPI_NAME:=evdev
-PKG_HASH:=ecfa01b5c84f7e8c6ced3367ac95288f43cd84efbfd7dd7d0cdbfc0d18c87a6a
+PKG_HASH:=299db8628cc73b237fc1cc57d3c2948faa0756e2a58b6194b5bf81dc2081f1e3
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: me, @paulo-raca (co-maintainer for evdev)
Compile tested: x86 https://github.com/openwrt/openwrt/commit/059263dd6e9bed5cb0f817a9fe0bd287db921200
Run tested: x86 https://github.com/openwrt/openwrt/commit/059263dd6e9bed5cb0f817a9fe0bd287db921200


Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>