### PR TITLE
stress/stress-ng: bump versions

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.15.01
+PKG_VERSION:=0.15.03
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ColinIanKing/stress-ng/tar.gz/refs/tags/V$(PKG_VERSION)?
-PKG_HASH:=2168627350d8e3b7f4571732d6117ab054a9851600899c30ad82fd3c9649d644
+PKG_HASH:=7cceca64da37fd3c8db7167ed386fd7d3e1d9d6891a1f6227911ab8d4b17379c
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only

--- a/utils/stress/Makefile
+++ b/utils/stress/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress
+PKG_VERSION:=1.0.7
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=1.0.5
-PKG_SOURCE_URL:=https://github.com/resurrecting-open-source-projects/stress
-PKG_MIRROR_HASH:=711e42ead6fd220a98821aae0cf024930785e439d3d0d50663fed1b2cd021bd1
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://github.com/resurrecting-open-source-projects/stress/releases/download/${PKG_VERSION}/
+PKG_HASH:=e63adb57597e617c14ecb0d841b5d990460796d9e9ec69bd56fe645ef02eb239
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only

--- a/utils/stress/patches/010-usleep.patch
+++ b/utils/stress/patches/010-usleep.patch
@@ -1,46 +1,51 @@
 --- a/src/stress.c
 +++ b/src/stress.c
-@@ -263,6 +263,7 @@ main (int argc, char **argv)
+@@ -266,9 +266,12 @@ main (int argc, char **argv)
+     while ((forks = (do_cpu + do_io + do_vm + do_hdd)))
+     {
+         long long backoff, timeout = 0;
++        struct timespec b;
  
-       /* Calculate the backoff value so we get good fork throughput.  */
-       backoff = do_backoff * forks;
-+      struct timespec b = {backoff / 1000000, (backoff % 1000000) * 1000};
-       dbg (stdout, "using backoff sleep of %llius\n", backoff);
+         /* Calculate the backoff value so we get good fork throughput.  */
+         backoff = do_backoff * forks;
++        b.tv_sec = backoff / 1000000;
++        b.tv_nsec = (backoff % 1000000) * 1000;
+         dbg (stdout, "using backoff sleep of %llius\n", backoff);
  
-       /* If we are supposed to respect a timeout, calculate it.  */
-@@ -297,7 +298,7 @@ main (int argc, char **argv)
-             {
+         /* If we are supposed to respect a timeout, calculate it.  */
+@@ -304,7 +307,7 @@ main (int argc, char **argv)
              case 0:            /* child */
-               alarm (timeout);
--              usleep (backoff);
-+              nanosleep(&b, NULL);
-               if (do_dryrun)
-                 exit (0);
-               exit (hogcpu ());
-@@ -318,7 +319,7 @@ main (int argc, char **argv)
-             {
+                 worker_init();
+                 alarm (timeout);
+-                usleep (backoff);
++                nanosleep (&b, NULL);
+                 if (do_dryrun)
+                     exit (0);
+                 exit (hogcpu ());
+@@ -326,7 +329,7 @@ main (int argc, char **argv)
              case 0:            /* child */
-               alarm (timeout);
--              usleep (backoff);
-+              nanosleep(&b,&b);
-               if (do_dryrun)
-                 exit (0);
-               exit (hogio ());
-@@ -338,7 +339,7 @@ main (int argc, char **argv)
-             {
+                 worker_init();
+                 alarm (timeout);
+-                usleep (backoff);
++                nanosleep (&b, NULL);
+                 if (do_dryrun)
+                     exit (0);
+                 exit (hogio ());
+@@ -347,7 +350,7 @@ main (int argc, char **argv)
              case 0:            /* child */
-               alarm (timeout);
--              usleep (backoff);
-+              nanosleep(&b, &b);
-               if (do_dryrun)
-                 exit (0);
-               exit (hogvm
-@@ -359,7 +360,7 @@ main (int argc, char **argv)
-             {
+                 worker_init();
+                 alarm (timeout);
+-                usleep (backoff);
++                nanosleep (&b, NULL);
+                 if (do_dryrun)
+                     exit (0);
+                 exit (hogvm (do_vm_bytes, do_vm_stride, do_vm_hang, do_vm_keep));
+@@ -368,7 +371,7 @@ main (int argc, char **argv)
              case 0:            /* child */
-               alarm (timeout);
--              usleep (backoff);
-+              nanosleep(&b, &b);
-               if (do_dryrun)
-                 exit (0);
-               exit (hoghdd (do_hdd_bytes));
+                 worker_init();
+                 alarm (timeout);
+-                usleep (backoff);
++                nanosleep (&b, NULL);
+                 if (do_dryrun)
+                     exit (0);
+                 exit (hoghdd (do_hdd_bytes));


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/059263dd6e9bed5cb0f817a9fe0bd287db921200
Run tested: x86 https://github.com/openwrt/openwrt/commit/059263dd6e9bed5cb0f817a9fe0bd287db921200


Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>