### PR TITLE
[22.03] simple-adblock: update to 1.9.3-7

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.9.3
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/simple-adblock.conf
+++ b/net/simple-adblock/files/simple-adblock.conf
@@ -71,9 +71,9 @@ config simple-adblock 'config'
 # enabling this will disable processing of any other block/allow-lists
 #	option dnsmasq_config_file_url 'https://dnsmasq.oisd.nl/'
 
-# File size: 34.0M
+# File size: 19.0M
 # block-list too big for most routers
-#	list blocked_hosts_url 'https://hosts.oisd.nl/'
+#	list blocked_domains_url 'https://dbl.oisd.nl/'
 
 # site was down on last check
 #	list blocked_domains_url 'http://support.it-mate.co.uk/downloads/hosts.txt'

--- a/net/simple-adblock/files/simple-adblock.conf.update
+++ b/net/simple-adblock/files/simple-adblock.conf.update
@@ -4,7 +4,6 @@ s|blacklist_hosts_url|blocked_hosts_url|g
 s|blacklist_domains_url|blocked_domains_url|g
 s|blacklist_domain|blocked_domain|g
 s|ssl.bblck.me|cdn.jsdelivr.net/gh/paulgb/BarbBlock|g
-s|dbl.oisd.nl|hosts.oisd.nl|g
 s|raw.githubusercontent.com/StevenBlack/hosts/|cdn.jsdelivr.net/gh/StevenBlack/hosts@|g
 s|raw.githubusercontent.com/hoshsadiq/adblock-nocoin-list/|cdn.jsdelivr.net/gh/hoshsadiq/adblock-nocoin-list@|g
 s|raw.githubusercontent.com/jawz101/MobileAdTrackers/|cdn.jsdelivr.net/gh/jawz101/MobileAdTrackers@|g

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -1409,16 +1409,29 @@ adb_stop() {
 	fi
 }
 
+allow() { load_validate_config 'config' adb_allow "'$*'"; }
+boot() {
+	ubus -t 30 wait_for network.interface 2>/dev/null
+	rc_procd start_service 'on_boot'
+}
+check() { load_validate_config 'config' adb_check "'$*'"; }
+dl() { rc_procd start_service 'download'; }
+killcache() {
+	rm -f "$dnsmasqAddnhostsCache" "$dnsmasqAddnhostsGzip"
+	rm -f "$dnsmasqConfCache" "$dnsmasqConfGzip"
+	rm -f "$dnsmasqIpsetCache" "$dnsmasqIpsetGzip"
+	rm -f "$dnsmasqNftsetCache" "$dnsmasqNftsetGzip"
+	rm -f "$dnsmasqServersCache" "$dnsmasqServersGzip"
+	rm -f "$unboundCache" "$unboundGzip"
+	config_load 'dhcp'
+	config_foreach resolver 'dnsmasq' 'cleanup'
+	uci_commit 'dhcp'
+	return 0
+}
+reload_service() { rc_procd start_service 'restart'; }
+restart_service() { rc_procd start_service 'restart'; }
 service_started() { procd_set_config_changed firewall; }
 service_stopped() { procd_set_config_changed firewall; }
-restart_service() { rc_procd start_service 'restart'; }
-reload_service() { rc_procd start_service 'restart'; }
-start_service() { 
-	load_validate_config 'config' adb_config_update "'$*'"
-	load_validate_config 'config' adb_start "'$*'"
-}
-stop_service() { load_validate_config 'config' adb_stop "'$*'"; }
-status_service() { load_validate_config 'config' adb_status "''"; }
 service_triggers() {
 	local wan wan6 i
 	local procd_trigger_wan6
@@ -1437,22 +1450,13 @@ service_triggers() {
 	done
 	procd_add_config_trigger "config.change" "$packageName" "/etc/init.d/${packageName}" reload
 }
-allow() { load_validate_config 'config' adb_allow "'$*'"; }
-check() { load_validate_config 'config' adb_check "'$*'"; }
-dl() { rc_procd start_service 'download'; }
-killcache() {
-	rm -f "$dnsmasqAddnhostsCache" "$dnsmasqAddnhostsGzip"
-	rm -f "$dnsmasqConfCache" "$dnsmasqConfGzip"
-	rm -f "$dnsmasqIpsetCache" "$dnsmasqIpsetGzip"
-	rm -f "$dnsmasqNftsetCache" "$dnsmasqNftsetGzip"
-	rm -f "$dnsmasqServersCache" "$dnsmasqServersGzip"
-	rm -f "$unboundCache" "$unboundGzip"
-	config_load 'dhcp'
-	config_foreach resolver 'dnsmasq' 'cleanup'
-	uci_commit 'dhcp'
-	return 0
-}
 sizes() { load_validate_config 'config' adb_sizes "''"; }
+start_service() { 
+	load_validate_config 'config' adb_config_update "'$*'"
+	load_validate_config 'config' adb_start "'$*'"
+}
+status_service() { load_validate_config 'config' adb_status "''"; }
+stop_service() { load_validate_config 'config' adb_stop "'$*'"; }
 version() { echo "$PKG_VERSION"; }
 
 load_validate_config() {


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-105w, OpenWrt 22.03.3
Run tested: x86_64, Sophos XG-105w, OpenWrt 22.03.3, download lists

Description:
* add boot() function which waits for network. Interface to come up
* switch oisd.nl hosts entry to domains
* remove erroneous oisd substitution from config-update file

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 8c8384611b0a8f5d9e6aca46e8cf72918c74198b)
