### PR TITLE
dnscrypt-proxy2: update to version 2.1.4

### DIFF
--- a/net/dnscrypt-proxy2/Makefile
+++ b/net/dnscrypt-proxy2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy2
-PKG_VERSION:=2.1.2
+PKG_VERSION:=2.1.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=dnscrypt-proxy-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/DNSCrypt/dnscrypt-proxy/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=aa55fd52b9c1b983405bf98b42ec754f5d6f59b429ba9c98115df617eef5dea4
+PKG_HASH:=05f0a3e8c8f489caf95919e2a75a1ec4598edd3428d2b9dd357caba6adb2607d
 PKG_BUILD_DIR:=$(BUILD_DIR)/dnscrypt-proxy-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>


### PR DESCRIPTION
Maintainer: @BKPepe
Compile tested: Linksys WRT32X / OpenWrt SNAPSHOT r21885-f86658e269 
Run tested: Linksys WRT32X / OpenWrt SNAPSHOT r21885-f86658e269 

Description: dnscrypt-proxy2: update to version 2.1.4

Signed-off-by: Fabian Lipken <dynasticorpheus@gmail.com>