### PR TITLE
ddns-scripts: Add njal.la provider

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=35
+PKG_RELEASE:=36
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/njal.la.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/njal.la.json
@@ -1,0 +1,9 @@
+{
+	"name": "njal.la",
+	"ipv4": {
+		"url": "https://njal.la/update/?h=[DOMAIN]&k=[PASSWORD]&a=[IP]"
+	},
+	"ipv6": {
+		"url": "https://njal.la/update/?h=[DOMAIN]&k=[PASSWORD]&aaaa=[IP]"
+	}
+}

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -42,6 +42,7 @@ mydns.jp
 myonlineportal.net
 mythic-beasts.com
 namecheap.com
+njal.la
 no-ip.pl
 now-dns.com
 nsupdate.info


### PR DESCRIPTION
Description: Add njal.la provider. Use the key as password. Username is not needed.

Maintainer: me / @chris5560
Compile tested: x86-64 (APU2), ath79 (Archer C7) 
Run tested: x86-64 (APU2)

Fixes https://github.com/openwrt/packages/issues/16311

Signed-off-by: Tobias Hilbig <web.tobias@hilbig-ffb.de>
