### PR TITLE
docker-compose: Update to version 2.16.0

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.15.1
+PKG_VERSION:=2.16.0
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=8ace5441826c6f07f5aa12c1864f73d30a362703492d9ed4b2e2314d3b353b1b
+PKG_HASH:=556dc59075280442128f5b45a8ff37638fb357c2a956bd751dd0ba747c93e71d
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream release. [Changelog](https://github.com/docker/compose/releases/tag/v2.16.0)