### PR TITLE
snort3: update to 3.1.55.0

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
-PKG_VERSION:=3.1.53.0
+PKG_VERSION:=3.1.55.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
-PKG_HASH:=e76429903cc56353ab21c0f4c0ec495054ba82f56d8d94943930bc0c3165be4c
+PKG_HASH:=61cc080943a37b1c9ce1f398958ec0415181a31390dc165ebbf32d9af7b3dfa6
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Upstream bump

Build system: x86_64
Build-tested: bcm2711/RPi4B
Run-tested: bcm2711/RPi4B

Signed-off-by: John Audia <therealgraysky@proton.me>

Maintainer: @flyn-org