### PR TITLE
transmission: retrieve boolean config opts using `config_get_bool`

### DIFF
--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -58,15 +58,15 @@ transmission() {
 	local incomplete_dir
 	config_get incomplete_dir "$cfg" 'incomplete_dir' '/var/etc/transmission'
 	local incomplete_dir_enabled
-	config_get incomplete_dir_enabled "$cfg" 'incomplete_dir_enabled' 0
+	config_get_bool incomplete_dir_enabled "$cfg" 'incomplete_dir_enabled' 0
 	local watch_dir
 	config_get watch_dir "$cfg" 'watch_dir' '/var/etc/transmission'
 	local watch_dir_enabled
-	config_get watch_dir_enabled "$cfg" 'watch_dir_enabled' 0
+	config_get_bool watch_dir_enabled "$cfg" 'watch_dir_enabled' 0
 	local mem_percentage
 	config_get mem_percentage "$cfg" 'mem_percentage' '50'
 	local config_overwrite
-	config_get config_overwrite "$cfg" config_overwrite 1
+	config_get_bool config_overwrite "$cfg" config_overwrite 1
 	local nice
 	config_get nice "$cfg" nice 0
 	local web_home
@@ -196,9 +196,9 @@ transmission_mount_triggers() {
 		watch_dir watch_dir_enabled web_home service_dirs
 	config_get config_dir "$cfg" 'config_dir' '/var/etc/transmission'
 	config_get download_dir "$cfg" 'download_dir' '/var/etc/transmission'
-	config_get incomplete_dir_enabled "$cfg" 'incomplete_dir_enabled' 0
+	config_get_bool incomplete_dir_enabled "$cfg" 'incomplete_dir_enabled' 0
 	config_get incomplete_dir "$cfg" 'incomplete_dir' '/var/etc/transmission'
-	config_get watch_dir_enabled "$cfg" 'watch_dir_enabled' 0
+	config_get_bool watch_dir_enabled "$cfg" 'watch_dir_enabled' 0
 	config_get watch_dir "$cfg" 'watch_dir' '/var/etc/transmission'
 	config_get web_home "$cfg" 'web_home'
 


### PR DESCRIPTION
Signed-off-by: Salim B <git@salim.space>

Maintainer: @dangowrt / CC: @neheb
Compile tested: -
Run tested: OpenWrt 22.03 snapshot

# Description

The transmission UCI config options

- `config_overwrite`
- `incomplete_dir_enabled`
- `watch_dir_enabled`

are all booleans, so we have to retrieve them using `config_get_bool` in order to make sure they are properly interpreted in case the user sets them to a keyword (`true`/`false`, `on`/`off` etc.) and not an integer (`0`/`1`), cf. https://openwrt.org/docs/guide-developer/config-scripting#reading_booleans