### PR TITLE
knot: update to version 3.2.5

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.2.4
-PKG_RELEASE:=2
+PKG_VERSION:=3.2.5
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=299e8de918f9fc7ecbe625b41cb085e47cdda542612efbd51cd5ec60deb9dd13
+PKG_HASH:=c6b122e92baa179d09ba4c8ce5b0d42fb7475805f4ff9c81d5036acfaa161820
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 6.2.4 (hbk)
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 6.2.4 (hbk)

Description:

- Release upgrade (https://www.knot-dns.cz/2023-02-02-version-325.html)
