### PR TITLE
conmon: update to 2.1.6

### DIFF
--- a/utils/conmon/Makefile
+++ b/utils/conmon/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=conmon
-PKG_VERSION:=2.1.5
+PKG_VERSION:=2.1.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containers/$(PKG_NAME)/archive/v$(PKG_VERSION)
-PKG_HASH:=ee3179ee2b9a9107acec00eb546062cf7deb847f135a3b81503d22b0d226b3ed
+PKG_HASH:=340453f7aac43e6a1f9a5efe31f24471f8a7a997a849ad6d1ff3fb530a9e2874
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me / @oskarirauta
Compile tested: x86_64, recent git
Run tested: x86_64, recent git

Description:
Update conmon to version 2.1.6

**Changes**
Bug fixes
 - Fix OOM watcher for cgroupv2 oom_kill events

Misc
 - Use --detach instead of -d
 - ctrl: drop fifo perms to 0660

[Release notes](https://github.com/containers/conmon/releases/tag/v2.1.6)

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>