### PR TITLE
[22.03] kcptun: update to version 20230207

### DIFF
--- a/net/kcptun/Makefile
+++ b/net/kcptun/Makefile
@@ -1,13 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kcptun
-PKG_VERSION:=20210922
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=20230207
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/xtaci/kcptun/tar.gz/v${PKG_VERSION}?
-PKG_SOURCE_DATE:=2021-09-22
-PKG_HASH:=f6a08f0fe75fa85d15f9c0c28182c69a5ad909229b4c230a8cbe38f91ba2d038
+PKG_HASH:=09054b52d5799a8e47edb36f2db335d929d5bbb63a26f7ba2fe03c64ec39d550
 
 PKG_MAINTAINER:=Dengfeng Liu <liudf0716@gmail.com>, Chao Liu <expiron18@gmail.com>
 PKG_LICENSE:=MIT

--- a/net/kcptun/files/kcptun.config
+++ b/net/kcptun/files/kcptun.config
@@ -1,6 +1,6 @@
 config server
 	option disabled 1
-	option listen 29900
+	option listen '29900-30000'
 	option target '127.0.0.1'
 	option target_port 12948
 	option crypt 'aes'
@@ -22,7 +22,7 @@ config client
 	option bind_address '0.0.0.0'
 	option local_port 12948
 	option server 'vps'
-	option server_port 29900
+	option server_port '29900-30000'
 	option crypt 'aes'
 	option key 'secret'
 	option mode 'fast'

--- a/net/kcptun/files/kcptun.init
+++ b/net/kcptun/files/kcptun.init
@@ -148,7 +148,7 @@ validate_common_options() {
 
 validate_server_options() {
 	validate_common_options server "$@" \
-		'listen:port' \
+		'listen:or(port,portrange):29900-30000' \
 		'target:host' \
 		'target_port:port' \
 		'pprof:bool'
@@ -159,7 +159,7 @@ validate_client_options() {
 		'bind_address:ipaddr' \
 		'local_port:port' \
 		'server:host' \
-		'server_port:port' \
+		'server_port:or(port,portrange):29900-30000' \
 		'conn:uinteger' \
 		'autoexpire:uinteger' \
 		'scavengettl:uinteger'


### PR DESCRIPTION
Maintainer: Dengfeng Liu <liudf0716@gmail.com>, Chao Liu <expiron18@gmail.com>
Compile tested: x86_64, OpenWrt 22.03-SNAPSHOT r19160+900-7ea2f3d6e2
Run tested: x86_64, OpenWrt 22.03-SNAPSHOT r19160+900-7ea2f3d6e2

Description:
add support for port-range dailer, port-range listener

Signed-off-by: Dengfeng Liu <liudf0716@gmail.com>


