### PR TITLE
igmpproxy: add support for whitelist/blacklist in UCI

### DIFF
--- a/net/igmpproxy/Makefile
+++ b/net/igmpproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=igmpproxy
 PKG_VERSION:=0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/pali/igmpproxy/releases/download/${PKG_VERSION}/

--- a/net/igmpproxy/files/igmpproxy.config
+++ b/net/igmpproxy/files/igmpproxy.config
@@ -7,6 +7,8 @@ config phyint
 	option zone wan
 	option direction upstream
 	list altnet 192.168.1.0/24
+#	list whitelist 233.255.0.0/16
+#	list blacklist 233.255.1.0/24
 
 config phyint
 	option network lan

--- a/net/igmpproxy/files/igmpproxy.init
+++ b/net/igmpproxy/files/igmpproxy.init
@@ -23,11 +23,13 @@ igmp_header() {
 }
 
 igmp_add_phyint() {
-	local network direction altnets device up
+	local network direction altnets whitelist blacklist device up
 
 	config_get network $1 network
 	config_get direction $1 direction
 	config_get altnets $1 altnet
+	config_get whitelist $1 whitelist
+	config_get blacklist $1 blacklist
 
 	local status="$(ubus -S call "network.interface.$network" status)"
 	[ -n "$status" ] || return
@@ -51,6 +53,20 @@ igmp_add_phyint() {
 		local altnet
 		for altnet in $altnets; do
 			echo -e "\taltnet $altnet" >> /var/etc/igmpproxy.conf
+		done
+	fi
+
+	if [ -n "$whitelist" ]; then
+		local whitelist_net
+		for whitelist_net in $whitelist; do
+			echo -e "\twhitelist $whitelist_net" >> /var/etc/igmpproxy.conf
+		done
+	fi
+
+	if [ -n "$blacklist" ]; then
+		local blacklist_net
+		for blacklist_net in $blacklist; do
+			echo -e "\tblacklist $blacklist_net" >> /var/etc/igmpproxy.conf
 		done
 	fi
 }


### PR DESCRIPTION
This permits allowing/denying specific multicast networks to be proxied.

* `whitelist` was added in 0.2 (pali/igmpproxy@65f777e7f66b55239d935c1cf81bb5abc0f6c89f)
* `blacklist` was added in 0.4 (pali/igmpproxy@cfad33001fc5031399bdd073048ca86889378678)

Maintainer: @nbd168 (as per Makefile)
Compile tested: ipq40xx / Linksys EA8300 / openwrt/openwrt@19988b66d07f44be757c4a0e41be899dbf8c72dd
Run tested: ipq40xx / Linksys EA8300 / openwrt/openwrt@19988b66d07f44be757c4a0e41be899dbf8c72dd