### PR TITLE
miniflux: update to 2.0.42

### DIFF
--- a/utils/miniflux/Makefile
+++ b/utils/miniflux/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniflux
-PKG_VERSION:=2.0.41
+PKG_VERSION:=2.0.42
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/miniflux/v2/tar.gz/${PKG_VERSION}?
-PKG_HASH:=01e150ebfba12c8b5ca7c1d9d5a5976d018081cafc11228d6f77a48ac3333e1b
+PKG_HASH:=f050b2bc9839dd485047b9d7820dbb669668fd13135aa8b49dc0ad304e509fd5
 
 PKG_MAINTAINER:=Michal Vasilek <michal.vasilek@nic.cz>
 PKG_LICENSE:=Apache-2.0

--- a/utils/miniflux/files/miniflux.conf
+++ b/utils/miniflux/files/miniflux.conf
@@ -6,6 +6,8 @@ config miniflux main
 
 	option listen_address '127.0.0.1:5433'
 
+	option base_url ''
+
 	# run migrations on each start, disabling this will make miniflux fail to
 	# start on the next upgrade until migrations are ran manually
 	option migrate 1

--- a/utils/miniflux/files/miniflux.init
+++ b/utils/miniflux/files/miniflux.init
@@ -24,6 +24,8 @@ start_service() {
 		procd_append_param env LISTEN_ADDR="$listen_address"
 		config_get run_migrations main run_migrations
 		[ "$run_migrations" = 1 ] && procd_append_param env RUN_MIGRATIONS=1
+		config_get base_url main base_url
+		[ -n "$base_url" ] && procd_append_param env BASE_URL="$base_url"
 
 		config_get database_url database url
 		if [ -z "$database_url" ]; then


### PR DESCRIPTION
Maintainer: me
Compile tested: armv7l, Turris Omnia, OpenWrt 21.02
Run tested: armv7l, Turris Omnia, OpenWrt 21.02

Description: add BASE_URL to the init script, this is useful when running in a subpath and not directly on the root of a domain