### PR TITLE
irqbalance: Add upstream fix for AARCH64 irq name parsing

### DIFF
--- a/utils/irqbalance/Makefile
+++ b/utils/irqbalance/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=irqbalance
 PKG_VERSION:=1.9.2
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/Irqbalance/irqbalance.git

--- a/utils/irqbalance/patches/001-upstream-fix-aarch64-irq-parsing.patch
+++ b/utils/irqbalance/patches/001-upstream-fix-aarch64-irq-parsing.patch
@@ -1,0 +1,68 @@
+From bbcd9a42c3cec0935b960b7f2046f1fdfab4f7ef Mon Sep 17 00:00:00 2001
+From: Vignesh Raghavendra <vigneshr@ti.com>
+Date: Wed, 7 Dec 2022 19:46:19 +0530
+Subject: [PATCH] procinterrupts: Fix IRQ name parsing on certain arm64 SoC
+
+On arm64 SoCs like TI's K3 SoC and few other SoCs, IRQ names don't get
+parsed correct due to which they end up being classified into wrong
+class. Fix this by considering last token to contain IRQ name always.
+
+Eg.: /proc/interrupt
+
+cat /proc/interrupts
+           CPU0       CPU1       CPU2       CPU3
+ 11:       7155       8882       7235       7791     GICv3  30 Level     arch_timer
+ 14:          0          0          0          0     GICv3  23 Level     arm-pmu
+ 15:          0          0          0          0     GICv3 208 Level     4b00000.spi
+ 16:          0          0          0          0     GICv3 209 Level     4b10000.spi
+116:          0          0          0          0  MSI-INTA 1716234 Level     485c0100.dma-controller chan6
+134:        166          0          0          0  MSI-INTA 1970707 Level     8000000.ethernet-tx0
+224:        149          0          0          0  MSI-INTA 1971731 Level     8000000.ethernet
+
+W/o patch irqbalance -d
+IRQ (11) guessed as class 0
+IRQ (14) guessed as class 0
+IRQ (15) guessed as class 0
+IRQ (16) guessed as class 0
+IRQ 485c0100.dma-controller chan6(116) guessed as class 0
+IRQ (134) guessed as class 0
+IRQ (224) guessed as class 0
+
+W/ this patch
+IRQ arch_timer(11) guessed as class 0
+IRQ arm-pmu(14) guessed as class 0
+IRQ 4b00000.spi(15) guessed as class 0
+IRQ 4b10000.spi(16) guessed as class 0
+IRQ 485c0100.dma-controller chan6(116) guessed as class 0
+IRQ 8000000.ethernet-tx0(134) guessed as class 5
+IRQ 8000000.ethernet(224) guessed as class 5
+IRQ 8000000.ethernet(257) guessed as class 5
+IRQ -davinci_gpio  wl18xx(362) guessed as class
+
+Signed-off-by: Vignesh Raghavendra <vigneshr@ti.com>
+---
+ procinterrupts.c | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+--- a/procinterrupts.c
++++ b/procinterrupts.c
+@@ -178,12 +178,14 @@ void init_irq_class_and_type(char *saved
+ 	}
+ 
+ #ifdef AARCH64
+-	if (savedptr && strlen(savedptr) > 0) {
++	if (savedptr && strlen(savedptr) > 0)
+ 		snprintf(irq_fullname, PATH_MAX, "%s %s", last_token, savedptr);
+-		tmp = strchr(irq_fullname, '\n');
+-		if (tmp)
+-			*tmp = 0;
+-	}
++	else
++		snprintf(irq_fullname, PATH_MAX, "%s", last_token);
++
++	tmp = strchr(irq_fullname, '\n');
++	if (tmp)
++		*tmp = 0;
+ #else
+ 	snprintf(irq_fullname, PATH_MAX, "%s", last_token);
+ #endif


### PR DESCRIPTION
Add upstream fix for AARCH64 irq name parsing.

https://github.com/Irqbalance/irqbalance/pull/253

> On arm64 SoCs like TI's K3 SoC and few other SoCs,
> IRQ names don't get parsed correct due to which they
> end up being classified into wrong class. Fix this by
> considering last token to contain IRQ name always.

The fix seems to enable e.g. RT3200 to notice a few more interrupts and start balancing them.

Maintainer: me 
Run tested: mt7622/RT3200

... PR for CI testing ...
