### PR TITLE
cloudreve: Update to 3.7.1

### DIFF
--- a/net/cloudreve/Makefile
+++ b/net/cloudreve/Makefile
@@ -5,13 +5,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cloudreve
-PKG_VERSION:=3.6.2
+PKG_VERSION:=3.7.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/cloudreve/Cloudreve.git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
-PKG_MIRROR_HASH:=134dc707f8befaa9a193a2b0ae2eb2eebd3c5c70c291b5104bed458c63eedbb7
+PKG_MIRROR_HASH:=b70601111e727d879a709884bc28237861216b99abac02b6f542f5984ddd8c0d
 
 PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILES:=LICENSE
@@ -35,7 +35,7 @@ define Package/cloudreve
   SUBMENU:=Cloud Manager
   TITLE:=A project helps you build your own cloud in minutes
   URL:=https://cloudreve.org
-  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+  DEPENDS:=@(aarch64||arm||i386||i686||x86_64) +ca-bundle
 endef
 
 define Package/cloudreve/description


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8, x86/64
Run tested: nanopi-r2s

Description:
Dropped architectures that are no longer supported[^1][^2] by upstream.

Release note:
- https://github.com/cloudreve/Cloudreve/releases/tag/3.7.0
- https://github.com/cloudreve/Cloudreve/releases/tag/3.7.1

[^1]: https://github.com/cloudreve/Cloudreve/issues/1640
[^2]: https://pkg.go.dev/modernc.org/sqlite#hdr-Supported_platforms_and_architectures