### PR TITLE
git: update to 2.39.2

### DIFF
--- a/net/git/Makefile
+++ b/net/git/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=git
-PKG_VERSION:=2.34.7
+PKG_VERSION:=2.39.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/scm/git/
-PKG_HASH:=59754e404b7a5fd1544a67b50c2abdeb02b41012d831c02146cb148f1f3d2e5e
+PKG_HASH:=475f75f1373b2cd4e438706185175966d5c11f68c4db1e48c26257c43ddcf2d6
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
@@ -97,10 +97,6 @@ MAKE_FLAGS := \
 	NO_TCLTK="YesPlease" \
 	NO_INSTALL_HARDLINKS="yes" \
 	gitwebdir="/www/cgi-bin" \
-	GITWEB_JS="/gitweb/gitweb.js" \
-	GITWEB_CSS="/gitweb/gitweb.css" \
-	GITWEB_LOGO="/gitweb/gitweb-logo.png" \
-	GITWEB_FAVICON="/gitweb/gitweb-favicon.png" \
 	uname_S="Linux" \
 
 CONFIGURE_ARGS += \
@@ -153,6 +149,11 @@ endef
 define Package/git-gitweb/install
 	$(INSTALL_DIR) $(1)/www/cgi-bin $(1)/www/gitweb
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/www/cgi-bin/gitweb.cgi $(1)/www/cgi-bin/
+	# work around https://lore.kernel.org/git/80eb3972-4960-5727-ce86-acc3a4425fd4@nic.cz/T/#u
+	$(SED) 's,^our @stylesheets .*,our @stylesheets = ("/gitweb/gitweb.css");,' $(1)/www/cgi-bin/gitweb.cgi
+	$(SED) 's,^our $$$$logo .*,our $$$$logo = "/gitweb/git-logo.png";,' $(1)/www/cgi-bin/gitweb.cgi
+	$(SED) 's,^our $$$$favicon .*,our $$$$favicon = "/gitweb/git-favicon.png";,' $(1)/www/cgi-bin/gitweb.cgi
+	$(SED) 's,^our $$$$javascript .*,our $$$$javascript = "/gitweb/gitweb.js";,' $(1)/www/cgi-bin/gitweb.cgi
 	$(CP) $(PKG_INSTALL_DIR)/www/cgi-bin/static/* $(1)/www/gitweb/
 endef
 

--- a/net/git/patches/100-configure_for_crosscompiling.patch
+++ b/net/git/patches/100-configure_for_crosscompiling.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -966,7 +966,8 @@ AC_RUN_IFELSE(
+@@ -955,7 +955,8 @@ AC_RUN_IFELSE(
  		FILE *f = fopen(".", "r");
  		return f != NULL;]])],
  	[ac_cv_fread_reads_directories=no],
@@ -10,7 +10,7 @@
  ])
  if test $ac_cv_fread_reads_directories = yes; then
  	FREAD_READS_DIRECTORIES=UnfortunatelyYes
-@@ -1000,7 +1001,8 @@ AC_RUN_IFELSE(
+@@ -989,7 +990,8 @@ AC_RUN_IFELSE(
  		  if (snprintf(buf, 3, "%s", "12345") != 5
  		      || strcmp(buf, "12")) return 1]])],
  	[ac_cv_snprintf_returns_bogus=no],
@@ -20,7 +20,7 @@
  ])
  if test $ac_cv_snprintf_returns_bogus = yes; then
  	SNPRINTF_RETURNS_BOGUS=UnfortunatelyYes
-@@ -1023,7 +1025,8 @@ yippeeyeswehaveit
+@@ -1012,7 +1014,8 @@ yippeeyeswehaveit
  #endif
  ]),
  	[ac_cv_sane_mode_bits=yes],

--- a/net/git/patches/200-imapsend_without_curl.patch
+++ b/net/git/patches/200-imapsend_without_curl.patch
@@ -1,6 +1,6 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -1436,7 +1436,7 @@ else
+@@ -1621,7 +1621,7 @@ else
  	endif
  	curl_check := $(shell (echo 072200; $(CURL_CONFIG) --vernum | sed -e '/^70[BC]/s/^/0/') 2>/dev/null | sort -r | sed -ne 2p)
  	ifeq "$(curl_check)" "072200"

--- a/net/git/patches/300-openssl-deprecated.patch
+++ b/net/git/patches/300-openssl-deprecated.patch
@@ -14,7 +14,7 @@ Signed-off-by: Rosen Penev <rosenp@gmail.com>
 
 --- a/imap-send.c
 +++ b/imap-send.c
-@@ -284,8 +284,10 @@ static int ssl_socket_connect(struct ima
+@@ -274,8 +274,10 @@ static int ssl_socket_connect(struct ima
  	int ret;
  	X509 *cert;
  


### PR DESCRIPTION
Maintainer: @tripolar
Compile tested: armv7l, Turris Omnia, OpenWrt 21.02
Run tested: armv7l, Turris Omnia, OpenWrt 21.02, tested git clone and gitweb

Description: GITWEB_* variable values don't work as they should since 2.38, so let's remove them and add a workaround. This issue was reported in https://lore.kernel.org/git/80eb3972-4960-5727-ce86-acc3a4425fd4@nic.cz/T/#u

* refresh patches

earlier today I opened #20506 which is a small security update, this PR replaces it, but I will leave whether you choose to merge the small security update first and then this one or merge this PR and close the small security update to you. 