### PR TITLE
cni-protocol: new package

### DIFF
--- a/net/cni-protocol/Makefile
+++ b/net/cni-protocol/Makefile
@@ -1,0 +1,51 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cni-protocol
+PKG_VERSION:=20230217
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/cni-protocol
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=cni netifd protocol
+  PKGARCH:=all
+endef
+
+define Package/cni-protocol/description
+  protocol support for cni networks for netifd
+  makes defining network for podman and other similar
+  systems using cni networking much easier and simpler.
+
+  with cni protocol support, on a network, where firewall
+  and portmapper management is disabled, you may control
+  firewalling with openwrt's default firewall configuration.
+
+  for example, create a container that hosts web content on
+  port 80 with static ip on your cni network, if your
+  network is 10.88.0.0/16, use for eg. 10.88.0.101 as
+  your containers static ip address. Create a zone, cni
+  to your firewall and add your interface to it.
+
+  Now you can easily set up redirectiong to 10.88.0.101:80
+  to expose it's port 80 to wan for serving your website.
+
+  Protocol has one setting: device, on podman this often
+  is cni-podman0.
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/cni-protocol/install
+	$(INSTALL_DIR) $(1)/lib/netifd/proto
+	$(INSTALL_BIN) ./files/cni.sh $(1)/lib/netifd/proto/cni.sh
+endef
+
+$(eval $(call BuildPackage,cni-protocol))

--- a/net/cni-protocol/files/cni.sh
+++ b/net/cni-protocol/files/cni.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+[ -n "$INCLUDE_ONLY" ] || {
+	. /lib/functions.sh
+	. ../netifd-proto.sh
+	init_proto "$@"
+}
+
+proto_cni_init_config() {
+	no_device=0
+	available=0
+	no_proto_task=1
+	teardown_on_l3_link_down=1
+
+	proto_config_add_string "device:device"
+}
+
+proto_cni_setup() {
+
+	local cfg="$1"
+	local device ipaddr netmask broadcast route routemask routesrc
+
+	json_get_var device device
+
+	ipaddr=$(ip -4 -o a show "$device" | awk '{ print $4 }' | cut -d '/' -f1)
+	netmask=$(ip -4 -o a show "$device" | awk '{ print $4 }' | cut -d '/' -f2)
+	broadcast=$(ip -4 -o a show "$device" | awk '{ print $6 }')
+	route=$(ip -4 -o r show dev "$device" | awk '{ print $1 }' | cut -d '/' -f1)
+	routemask=$(ip -4 -o r show dev "$device" | awk '{ print $1 }' | cut -d '/' -f2)
+	routesrc=$(ip -4 -o r show dev "$device" | awk '{ print $7 }')
+
+	[ -z "$ipaddr" ] && {
+		echo "cni network $cfg does not have ip address"
+		proto_notify_error "$cfg" NO_IPADDRESS
+		return 1
+	}
+
+	proto_init_update "$device" 1
+	[ -n "$ipaddr" ] && proto_add_ipv4_address "$ipaddr" "$netmask" "$broadcast" ""
+	[ -n "$route" ] && proto_add_ipv4_route "$route" "$routemask" "" "$routesrc" ""
+	proto_send_update "$cfg"
+}
+
+proto_cni_teardown() {
+	local cfg="$1"
+	#proto_set_available "$cfg" 0
+	return 0
+}
+
+[ -n "$INCLUDE_ONLY" ] || {
+	add_protocol cni
+}


### PR DESCRIPTION
simple protocol support script for netifd.

netifd protocol support for cni networks makes
defining network for podman and other similar
systems using cni networking much easier and simpler.

with cni protocol support, on a cni network, where firewall and portmapper is disabled, you may control firewalling with openwrt's standard firewall configuration.

for example, create a container that hosts web content on port 80 with static ip on your cni network, if your network is 10.88.0.0/16, use for eg. 10.88.0.101 as your containers static ip address. Create a zone, cni to your firewall and add your interface to it. You could manage all this without protocol support, but this makes it a bit easier, especially when this is requirement for my upcoming luci protocol support for same thing- so no tinkering necessary if someone feels more comfortable on LuCi, or just wants to see his interfaces page without warning about unsupported protocol extension.

Now you can easily set up redirectiong to 10.88.0.101:80 to expose it's port 80 to wan for serving your website.
Protocol has only one setting: _device_, on podman this often is **cni-podman0**.

Maintainer: me / @oskarirauta
Compile tested: x86_64, recent git
Run tested: x86_64, recent git