### PR TITLE
django: bump to version 4.1.7

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=4.1.5
+PKG_VERSION:=4.1.7
 PKG_RELEASE:=1
 
 PYPI_NAME:=Django
-PKG_HASH:=ff56ebd7ead0fd5dbe06fe157b0024a7aaea2e0593bb3785fb594cf94dad58ef
+PKG_HASH:=44f714b81c5f190d9d2ddad01a532fe502fa01c4cb8faf1d081f4264ed15dcd8
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Peter Stadler <peter.stadler@student.uibk.ac.at>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me, @peter-stadler 
Compile tested: n/a
Run tested: n/a

Fixes:
   https://nvd.nist.gov/vuln/detail/CVE-2023-23969

Signed-off-by: Alexandru Ardelean <alex@shruggie.ro>