### PR TITLE
simple-adblock: implement procd_boot_wan_timeout support

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.9.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/simple-adblock.conf
+++ b/net/simple-adblock/files/simple-adblock.conf
@@ -27,6 +27,7 @@ config simple-adblock 'config'
 	option led 'none'
 	option parallel_downloads '1'
 	option procd_trigger_wan6 '0'
+	option procd_boot_wan_timeout '60'
 	option verbosity '2'
 
 # File size: 16.0K
@@ -71,9 +72,29 @@ config simple-adblock 'config'
 # enabling this will disable processing of any other block/allow-lists
 #	option dnsmasq_config_file_url 'https://dnsmasq.oisd.nl/'
 
-# File size: 19.0M
+# File size: 1.4M
 # block-list too big for most routers
-#	list blocked_domains_url 'https://dbl.oisd.nl/'
+#	list blocked_adblockplus_url 'https://small.oisd.nl/'
+
+# File size: 6.2M
+# block-list too big for most routers
+#	list blocked_adblockplus_url 'https://nsfw.oisd.nl/'
+
+# File size: 6.2M
+# block-list too big for most routers
+#	list blocked_adblockplus_url 'https://big.oisd.nl/'
+
+# File size: 1.5M
+# block-list too big for most routers
+#	list blocked_domains_url 'https://small.oisd.nl/domains'
+
+# File size: 7.8M
+# block-list too big for most routers
+#	list blocked_domains_url 'https://nsfw.oisd.nl/domains'
+
+# File size: 19.9M
+# block-list too big for most routers
+#	list blocked_domains_url 'https://big.oisd.nl/domains'
 
 # site was down on last check
 #	list blocked_domains_url 'http://support.it-mate.co.uk/downloads/hosts.txt'

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -210,17 +210,17 @@ output() {
 load_network() {
 	local param="$1"
 	local i j wan_if wan_gw wan_proto
-	local counter wan_if_timeout='20' wan_gw_timeout='5'
+	local counter wan_if_timeout="$procd_boot_wan_timeout" wan_gw_timeout='5'
 	counter=0
 	while [ -z "$wan_if" ]; do
 		network_flush_cache
 		network_find_wan wan_if
 		if [ -n "$wan_if" ]; then
-			output "WAN Interface found: '${wan_if}'.\\n"
+			output "WAN interface found: '${wan_if}'.\\n"
 			break
 		fi
 		if [ "$counter" -gt "$wan_if_timeout" ]; then
-			output "WAN Interface timeout, assuming 'wan'.\\n"
+			output "WAN interface timeout, assuming 'wan'.\\n"
 			wan_if='wan'
 			break
 		fi
@@ -238,11 +238,11 @@ load_network() {
 		network_flush_cache
 		network_get_gateway wan_gw "$wan_if"
 		if [ -n "$wan_gw" ]; then
-			output "WAN Gateway found: '${wan_gw}.'\\n"
+			output "WAN gateway found: '${wan_gw}.'\\n"
 			return 0
 		fi
 		counter=$((counter+1))
-		output "Waiting to discover $wan_if Gateway...\\n"
+		output "Waiting to discover $wan_if gateway...\\n"
 		sleep 1
 	done
 	json add error "errorNoWanGateway"
@@ -1573,11 +1573,12 @@ load_validate_config() {
 	local canary_domains_mozilla
 	local config_update_enabled
 	local config_update_url
-	local boot_delay
 	local download_timeout
 	local curl_max_file_size
 	local curl_retry
 	local verbosity
+	local procd_trigger_wan6
+	local procd_boot_wan_timeout
 	local led
 	local dns
 	local dns_instance
@@ -1606,6 +1607,7 @@ load_validate_config() {
 		'curl_retry:range(0,30):3' \
 		'verbosity:range(0,2):2' \
 		'procd_trigger_wan6:bool:0' \
+		'procd_boot_wan_timeout:integer:60' \
 		'led:or("", "none", file, device, string)' \
 		'dns:or("dnsmasq.addnhosts", "dnsmasq.conf", "dnsmasq.ipset", "dnsmasq.nftset", "dnsmasq.servers", "unbound.adb_list"):dnsmasq.servers' \
 		'dns_instance:or(list(integer, string)):0' \


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-105w, OpenWrt 22.03.3
Run tested: x86_64, Sophos XG-105w, OpenWrt 22.03.3, config update, lists dl/process

Description:
* implement procd_boot_wan_timeout support
* update config with oisd ABPlus and domains lists

