### PR TITLE
node: bump to v16.19.1

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v16.19.0
+PKG_VERSION:=v16.19.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=4f1fec1aea2392f6eb6d1d040b01e7ee3e51e762a9791dfea590920bc1156706
+PKG_HASH:=17fb716406198125b30c94dd3d1756207b297705626afe16d8dc479a65a1d8b5
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,6 +1,6 @@
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1300,7 +1300,8 @@ Module._initPaths = function() {
+@@ -1326,7 +1326,8 @@ Module._initPaths = function() {
      path.resolve(process.execPath, '..') :
      path.resolve(process.execPath, '..', '..');
  


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: head, aarch64, arm, i386, x86_64, mipsel (pistachio) 
Run tested: (qemu 7.2.0) aarch64

Description:
Thursday February 16 2023 Security Releases

Notable Changes
The following CVEs are fixed in this release:
* CVE-2023-23918: Node.js Permissions policies can be bypassed via process.mainModule (High)
* CVE-2023-23919: Node.js OpenSSL error handling issues in nodejs crypto library (Medium)
* CVE-2023-23936: Fetch API in Node.js did not protect against CRLF injection in host headers (Medium)
* CVE-2023-24807: Regular Expression Denial of Service in Headers in Node.js fetch API (Low)
* CVE-2023-23920: Node.js insecure loading of ICU data through ICU_DATA environment variable (Low) More detailed information on each of the vulnerabilities can be found in February 2023 Security Releases blog post.
