### PR TITLE
[21.02] node: bump to v14.21.3

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v14.21.2
+PKG_VERSION:=v14.21.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=d8f09a0f16773a77613c3817606f6d455624992d9c43443aca15e91807a1ff03
+PKG_HASH:=458ec092e60ad700ddcf079cb63d435c15da4c7bb3d3f99b9a8e58a99e54075e
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,6 +1,6 @@
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1202,7 +1202,8 @@ Module._initPaths = function() {
+@@ -1231,7 +1231,8 @@ Module._initPaths = function() {
      path.resolve(process.execPath, '..') :
      path.resolve(process.execPath, '..', '..');
  


### PR DESCRIPTION
Maintainer: me @ianchi
 Compile tested: 21.02, arm
 Run tested: (qemu 7.2.0) arm

Description:
Thursday February 16 2023 Security Releases

Notable Changes
The following CVEs are fixed in this release:
* CVE-2023-23918: Node.js Permissions policies can be bypassed via process.mainModule (High)
* CVE-2023-23920: Node.js insecure loading of ICU data through ICU_DATA environment variable (Low) More detailed information on each of the vulnerabilities can be found in February 2023 Security Releases blog post.