### PR TITLE
tor: update to version 0.4.7.13

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.7.12
+PKG_VERSION:=0.4.7.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=3b5d969712c467851bd028f314343ef15a97ea457191e93ffa97310b05b9e395
+PKG_HASH:=2079172cce034556f110048e26083ce9bea751f3154b0ad2809751815b11ea9d
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainers: @hauke (Hauke Mehrtens) and @tripolar (Peter Wagner)
Build system: Arch Linux x86_64
Build tested: r7800 OpenWrt git master (r22104-01262c921c)
Run tested: r7800 OpenWrt git master (r22104-01262c921c)
