### PR TITLE
ddns-scripts: enable IPv6 for easydns.com

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=34
+PKG_RELEASE:=35
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/easydns.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/easydns.com.json
@@ -3,5 +3,9 @@
 	"ipv4": {
 		"url": "http://[USERNAME]:[PASSWORD]@api.cp.easydns.com/dyn/generic.php?hostname=[DOMAIN]&myip=[IP]",
 		"answer": "OK|NOERROR"
+	},
+	"ipv6": {
+		"url": "http://[USERNAME]:[PASSWORD]@api.cp.easydns.com/dyn/generic.php?hostname=[DOMAIN]&myip=[IP]",
+		"answer": "OK|NOERROR"
 	}
 }


### PR DESCRIPTION
easydns.com has supported IPv6 for awhile now using the same update URL as IPv4. This duplicates the IPv4 entry for IPv6 to enable support for it.