### PR TITLE
[22.03] simple-adblock: bugfix: ensure directory for jsonFile is created

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.9.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -409,7 +409,7 @@ load_environment() {
 		;;
 	esac
 
-	for i in "$outputFile" "$outputCache" "$outputGzip"; do
+	for i in "$jsonFile" "$outputFile" "$outputCache" "$outputGzip"; do
 		if ! mkdir -p "$(dirname "$i")"; then
 			if [ "$param" != 'quiet' ]; then
 				json add error "errorOutputDirCreate" "$i"
@@ -668,6 +668,7 @@ json() {
 	json_add_string reload "$reload"
 	json_add_string restart "$restart"
 	json_close_object
+	mkdir -p "$(dirname "$jsonFile")"
 	json_dump > "$jsonFile"
 	sync
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-105w, OpenWrt 22.03.3
Run tested: x86_64, Sophos XG-105w, OpenWrt 22.03.3, start/dl

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 2bb10d0c2c9a2517acea9cadeaf2d390066f72f4)
