### PR TITLE
prometheus-node-exporter-lua: Add optional mwan3 collector

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
 PKG_VERSION:=2024.06.16
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -246,6 +246,17 @@ define Package/prometheus-node-exporter-lua-realtek-poe/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/realtek-poe.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
+define Package/prometheus-node-exporter-lua-mwan3
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (mwan3 collector)
+  DEPENDS:=prometheus-node-exporter-lua +mwan3
+endef
+
+define Package/prometheus-node-exporter-lua-mwan3/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/mwan3.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
 $(eval $(call BuildPackage,prometheus-node-exporter-lua))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx7))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-dawn))
@@ -264,3 +275,4 @@ $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi_stations))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-snmp6))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-realtek-poe))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-mwan3))

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/mwan3.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/mwan3.lua
@@ -1,0 +1,43 @@
+local ubus = require "ubus"
+
+local function scrape()
+    local u = ubus.connect()
+    local status = u:call("mwan3", "status", {})
+    if status == nil then
+        error("Could not get mwan3 status")
+    end
+
+    local mwan3_age = metric("mwan3_interface_age", "counter")
+    local mwan3_online = metric("mwan3_interface_online", "counter")
+    local mwan3_offline = metric("mwan3_interface_offline", "counter")
+    local mwan3_uptime = metric("mwan3_interface_uptime", "counter")
+    local mwan3_score = metric("mwan3_interface_score", "gauge")
+    local mwan3_lost = metric("mwan3_interface_lost", "counter")
+    local mwan3_turn = metric("mwan3_interface_turn", "counter")
+    local mwan3_status = metric("mwan3_interface_status", "gauge")
+    local mwan3_enabled = metric("mwan3_interface_enabled", "gauge")
+    local mwan3_running = metric("mwan3_interface_running", "gauge")
+    local mwan3_up = metric("mwan3_interface_up", "gauge")
+
+    local possible_status = {"offline", "online", "disconnecting", "connecting", "disabled", "notracking", "unknown"}
+
+    for iface, iface_details in pairs(status.interfaces) do
+        mwan3_age({interface = iface}, iface_details.age)
+        mwan3_online({interface = iface}, iface_details.online)
+        mwan3_offline({interface = iface}, iface_details.offline)
+        mwan3_uptime({interface = iface}, iface_details.uptime)
+        mwan3_score({interface = iface}, iface_details.score)
+        mwan3_lost({interface = iface}, iface_details.lost)
+        mwan3_turn({interface = iface}, iface_details.turn)
+        for _, s in ipairs(possible_status) do
+            local is_active_status = iface_details.status == s and 1 or 0
+            mwan3_status({interface = iface, status = s}, is_active_status)
+        end
+        mwan3_enabled({interface = iface}, iface_details.enabled and 1 or 0)
+        mwan3_running({interface = iface}, iface_details.running and 1 or 0)
+        mwan3_up({interface = iface}, iface_details.up and 1 or 0)
+    end
+
+end
+
+return { scrape = scrape }


### PR DESCRIPTION
Maintainer: @champtar
Compile tested: N/A
Run tested:
- x86_64 on Docker r22073-f06bd5bdb8
- mvebu/cortexa9 on 19.07.9 r11405-2a3558b0de

Description:
Adds prometheus collector for mwan3