### PR TITLE
[22.03] curl: update to 7.88.1

### DIFF
--- a/lang/perl-www-curl/patches/230-curl_7.88_compat.patch
+++ b/lang/perl-www-curl/patches/230-curl_7.88_compat.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.PL
++++ b/Makefile.PL
+@@ -127,7 +127,7 @@ if (!defined($curl_h)) {
+     close H;
+ 
+     for my $e (sort @syms) {
+-       if($e =~ /(OBSOLETE|^CURL_EXTERN|CURLOPT\z|^CURL_STRICTER\z|_LAST\z|_LASTENTRY\z|WIN32)/) {
++	if($e =~ /(OBSOLETE|^CURL_EXTERN|^CURL_STRICTER\z|^CURL_DID_MEMORY_FUNC_TYPEDEFS\z|_LAST\z|_LASTENTRY\z|^CURLINC_|^CURL_WIN32\z|^CURL_DEPRECATED\z|^CURL_IGNORE_DEPRECATION\z|^CURLOPTDEPRECATED\z|^CURLOPT\z)/) {
+           next;
+        }
+        my ($group) = $e =~ m/^([^_]+_)/;

--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -9,15 +9,15 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
-PKG_VERSION:=7.86.0
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=7.88.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \
 	https://dl.uxnr.de/mirror/curl/ \
 	https://curl.askapache.com/download/ \
 	https://curl.se/download/
-PKG_HASH:=2d61116e5f485581f6d59865377df4463f2e788677ac43222b496d4e49fb627b
+PKG_HASH:=1dae31b2a7c1fe269de99c0c31bb488346aab3459b5ffca909d6938249ae415f
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-105w, OpenWrt 22.03.3
Run tested: x86_64, Sophos XG-105w, OpenWrt 22.03.3, use with https-dns-proxy

Description:
* https://curl.se/changes.html#7_88_1

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 678bad7e86c51aa96dc2f9336f7ff32b19c6de99)
