### PR TITLE
Update packages/mail/sendmail/Makefile with IPV6 support.

### DIFF
--- a/mail/sendmail/Makefile
+++ b/mail/sendmail/Makefile
@@ -90,7 +90,7 @@ programs access to mail messages as they are being processed in order to
 filter meta-information and content.
 endef
 
-TARGET_CFLAGS += $(FPIC)
+TARGET_CFLAGS += $(FPIC) -DNETINET6 -DNEEDSGETIPNODE
 
 define Build/Prepare
 	$(Build/Prepare/Default)


### PR DESCRIPTION
This compiles libmilter with ipv6 support, allowing clamav, opendkim, and whatever else to work with ipv6 in their milters.

Maintainer: Don't think there is one anymore
Compile tested: cross-compile from ubuntu x64 vm to aarch64_cortex-a72 , 22.03.3 
Run tested: Ras pi, 22.03, aarch64_cortex-a72, etc

Description:
Without this, clamav and opendkim running as milters on postfix seem to work fine on ipv4, but when they receive any mail to filter from an ipv6 source they error out with an error containing the string "Unknown family 54", which when searching google reveals libmilter not being compiled with ipv6 support.

adding -DNETINET6 enables IP6 support, however, it uses three functions that are deprecated in glibc and completely not available in musl, adding -DNEEDSGETIPNODE causes the the functions and corresponding structure to be built.

 After compiling and installing, the errors are gone and opendkim still pops the message saying it validated and all appears good with the world of mail for a day.. now for that slight issue with spamassassin lol