### PR TITLE
ddns-scripts: fix URL endpoint to use ns1 latest API endpoints

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/update_ns1_com.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_ns1_com.sh
@@ -25,7 +25,7 @@ json_close_array
 json_close_object
 json_close_array
 
-__URL="$__ENDPOINT/zones/$username/$domain/$__RRTYPE"
+__URL="$__ENDPOINT/zones/$domain/$lookup_host/$__RRTYPE"
 
 __STATUS=$(curl -s -X POST "$__URL" \
 	-H "X-NSONE-Key: $password" \


### PR DESCRIPTION
Signed-off-by: Peter Kay <contact@kaypeter.com>

`NS1.com` uses a different API route endpoint to update records on their DNS domains. Currently, it uses `/v1/zones/{zoneName}/{domain}/{type}` found on their [documentation](https://ns1.com/api?docId=2185). The `ddns-script` used in openwrt instead uses  `/v1/zones/{username}/{domain}/{type}`.

I changed the shell script with the URL changes on my `openwrt` deployment and was able to get a successful API call:

```
 044132       : Detect local IP on 'network'
 044132       : Local IP 'REDACTED' detected on network 'wan'
 044132       : Forced Update - L: 'REDACTED' == R: 'REDACTED'
 044132       : parsing script '/usr/lib/ddns/update_ns1_com.sh'
 044134       : NS1 answered: {"domain":"REDACTED","meta":{},"filters":[],"ttl":3600,"zone_name":"REDACTED","networks":[0],"zone":"REDACTED","blocked_tags":[],"id":"REDACTED","regions":{},"type":"A","use_client_subnet":true,"tags":{},"answers":[{"answer":["REDACTED"],"id":"REDACTED"}],"link":null,"tier":1}
 044134  info : Forced update successful - IP: 'REDACTED' send
 044134       : Waiting 600 seconds (Check Interval)
 ```
 
 Should also probably update the `Password` field in the `ns1` DDNS Service `Basic Settings` to `API Token`. Password will not work here.