### PR TITLE
nfs-kernel-server: update to v2.6.2

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -7,9 +7,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
-PKG_VERSION:=2.5.4
-PKG_RELEASE:=5
-PKG_HASH:=546ce4b51eeebc66e354b6cc6ca0ce509437efbdef0caaf99389534eef0e598b
+PKG_VERSION:=2.6.2
+PKG_RELEASE:=1
+PKG_HASH:=26d46448982252e9e2c8346d10cf13e1143e7089c866f53e25db3359f3e9493c
 
 PKG_SOURCE_URL:=@SF/nfs
 PKG_SOURCE:=nfs-utils-$(PKG_VERSION).tar.xz
@@ -150,6 +150,9 @@ HOST_CONFIGURE_VARS += \
 	ac_cv_header_blkid_blkid_h=yes \
 	ac_cv_lib_resolv___res_querydomain=yes \
 	ac_cv_func_prctl=yes \
+	ac_cv_sizeof_size_t=0 \
+	ac_cv_func_getrpcbynumber=yes \
+	ac_cv_func_getrpcbynumber_r=yes \
 	enable_ipv6=no \
 	GSSGLUE_CFLAGS=" " \
 	GSSGLUE_LIBS=" " \

--- a/net/nfs-kernel-server/patches/110-move-hardcoded-rundir.patch
+++ b/net/nfs-kernel-server/patches/110-move-hardcoded-rundir.patch
@@ -3,7 +3,7 @@
 @@ -64,7 +64,7 @@
  #define EVENT_BUFSIZE (1024 * EVENT_SIZE)
  
- #define RPCPIPE_DIR	"/var/lib/nfs/rpc_pipefs"
+ #define RPCPIPE_DIR	NFS_STATEDIR "/rpc_pipefs"
 -#define PID_FILE	"/run/blkmapd.pid"
 +#define PID_FILE	"/tmp/run/blkmapd.pid"
  

--- a/net/nfs-kernel-server/patches/130-musl-svcgssd-sysconf.patch
+++ b/net/nfs-kernel-server/patches/130-musl-svcgssd-sysconf.patch
@@ -1,0 +1,144 @@
+--- a/support/nfsidmap/libnfsidmap.c
++++ b/support/nfsidmap/libnfsidmap.c
+@@ -452,11 +452,17 @@ int nfs4_init_name_mapping(char *conffil
+ 
+ 	nobody_user = conf_get_str("Mapping", "Nobody-User");
+ 	if (nobody_user) {
+-		size_t buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
++		long scbuflen = sysconf(_SC_GETPW_R_SIZE_MAX);
++		size_t buflen = 1024; /*value on my gentoo glibc system that has _SC_GETPW_R_SIZE_MAX*/
+ 		struct passwd *buf;
+ 		struct passwd *pw = NULL;
+ 		int err;
+ 
++		/*sysconf can return -1 when _SC_GETPW_R_SIZE_MAX is not defined, like on musl systems, if cast to size_t this will lead
++		  to an integer overflow, which leads to a buffer overflow and crashes svcgssd */
++		if (scbuflen > 0)
++			buflen = (size_t)scbuflen;
++
+ 		buf = malloc(sizeof(*buf) + buflen);
+ 		if (buf) {
+ 			err = getpwnam_r(nobody_user, buf, ((char *)buf) + sizeof(*buf), buflen, &pw);
+@@ -473,11 +479,17 @@ int nfs4_init_name_mapping(char *conffil
+ 
+ 	nobody_group = conf_get_str("Mapping", "Nobody-Group");
+ 	if (nobody_group) {
+-		size_t buflen = sysconf(_SC_GETGR_R_SIZE_MAX);
++		long scbuflen = sysconf(_SC_GETGR_R_SIZE_MAX);
++		size_t buflen = 1024; /*value on my gentoo glibc system that has _SC_GETGR_R_SIZE_MAX*/
+ 		struct group *buf;
+ 		struct group *gr = NULL;
+ 		int err;
+ 
++		/*sysconf can return -1 when _SC_GETGR_R_SIZE_MAX is not defined, like on musl systems, if cast to size_t this will lead
++		  to an integer overflow, which leads to a buffer overflow and crashes svcgssd */
++		if (scbuflen > 0)
++			buflen = (size_t)scbuflen;
++
+ 		buf = malloc(sizeof(*buf) + buflen);
+ 		if (buf) {
+ 			err = getgrnam_r(nobody_group, buf, ((char *)buf) + sizeof(*buf), buflen, &gr);
+--- a/support/nfsidmap/static.c
++++ b/support/nfsidmap/static.c
+@@ -98,10 +98,14 @@ static struct passwd *static_getpwnam(co
+ {
+ 	struct passwd *pw;
+ 	struct pwbuf *buf;
+-	size_t buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
++	long scbuflen = sysconf(_SC_GETPW_R_SIZE_MAX);
++	size_t buflen = 1024;
+ 	char *localname;
+ 	int err;
+ 
++	if (scbuflen > 0)
++		buflen = (size_t)scbuflen;
++
+ 	buf = malloc(sizeof(*buf) + buflen);
+ 	if (!buf) {
+ 		err = ENOMEM;
+@@ -149,10 +153,14 @@ static struct group *static_getgrnam(con
+ {
+ 	struct group *gr;
+ 	struct grbuf *buf;
+-	size_t buflen = sysconf(_SC_GETGR_R_SIZE_MAX);
++	long scbuflen = sysconf(_SC_GETGR_R_SIZE_MAX);
++	size_t buflen = 1024;
+ 	char *localgroup;
+ 	int err;
+ 
++	if (scbuflen > 0)
++		buflen = (size_t)scbuflen;
++
+ 	buf = malloc(sizeof(*buf) + buflen);
+ 	if (!buf) {
+ 		err = ENOMEM;
+--- a/support/nfsidmap/nss.c
++++ b/support/nfsidmap/nss.c
+@@ -91,9 +91,13 @@ static int nss_uid_to_name(uid_t uid, ch
+ 	struct passwd *pw = NULL;
+ 	struct passwd pwbuf;
+ 	char *buf;
+-	size_t buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
++	long scbuflen = sysconf(_SC_GETPW_R_SIZE_MAX);
++	size_t buflen = 1024;
+ 	int err = -ENOMEM;
+ 
++	if (scbuflen > 0)
++		buflen = (size_t)scbuflen;
++
+ 	buf = malloc(buflen);
+ 	if (!buf)
+ 		goto out;
+@@ -119,9 +123,13 @@ static int nss_gid_to_name(gid_t gid, ch
+ 	struct group *gr = NULL;
+ 	struct group grbuf;
+ 	char *buf;
+-	size_t buflen = sysconf(_SC_GETGR_R_SIZE_MAX);
++	long scbuflen = sysconf(_SC_GETGR_R_SIZE_MAX);
++	size_t buflen = 1024;
+ 	int err;
+ 
++	if (scbuflen > 0)
++		buflen = (size_t)scbuflen;
++
+ 	if (domain == NULL)
+ 		domain = get_default_domain();
+ 
+@@ -192,12 +200,13 @@ static struct passwd *nss_getpwnam(const
+ {
+ 	struct passwd *pw;
+ 	struct pwbuf *buf;
+-	size_t buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
++	long scbuflen = sysconf(_SC_GETPW_R_SIZE_MAX);
++	size_t buflen = 1024;
+ 	char *localname;
+ 	int err = ENOMEM;
+ 
+-	if (buflen > UINT_MAX)
+-		goto err;
++	if (scbuflen > 0)
++		buflen = (size_t)scbuflen;
+ 
+ 	buf = malloc(sizeof(*buf) + buflen);
+ 	if (buf == NULL)
+@@ -301,7 +310,8 @@ static int _nss_name_to_gid(char *name,
+ 	struct group *gr = NULL;
+ 	struct group grbuf;
+ 	char *buf, *domain;
+-	size_t buflen = sysconf(_SC_GETGR_R_SIZE_MAX);
++	long scbuflen = sysconf(_SC_GETGR_R_SIZE_MAX);
++	size_t buflen = 1024;
+ 	int err = -EINVAL;
+ 	char *localname = NULL;
+ 	char *ref_name = NULL;
+@@ -327,8 +337,8 @@ static int _nss_name_to_gid(char *name,
+ 	}
+ 
+ 	err = -ENOMEM;
+-	if (buflen > UINT_MAX)
+-		goto out_name;
++	if (scbuflen > 0)
++		buflen = (size_t)scbuflen;
+ 
+ 	do {
+ 		buf = malloc(buflen);

--- a/net/nfs-kernel-server/patches/200-fix-macos-build.patch
+++ b/net/nfs-kernel-server/patches/200-fix-macos-build.patch
@@ -2,9 +2,9 @@ fix stat64 issue for modern macos versions (including macos arm64)
 
 --- a/tools/rpcgen/rpc_main.c
 +++ b/tools/rpcgen/rpc_main.c
-@@ -62,6 +62,12 @@
- #define EXTEND	1		/* alias for TRUE */
- #define DONT_EXTEND	0	/* alias for FALSE */
+@@ -68,6 +68,12 @@
+ # endif
+ #endif
  
 +#ifdef __APPLE__
 +# if __DARWIN_ONLY_64_BIT_INO_T


### PR DESCRIPTION
Also added patch that is from alpine's same package to assist building on musl.
Some overrides for hostpkg configure were also necessary to make it possible to build **on** musl.

Maintainer: Peter Wagner / @tripolar 
Compile tested: x86_64, recent git
Run tested: x86_64, recent git