### PR TITLE
https-dns-proxy: 2022-10-15-11 update

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2022-10-15
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/

--- a/net/https-dns-proxy/files/https-dns-proxy.config
+++ b/net/https-dns-proxy/files/https-dns-proxy.config
@@ -19,7 +19,7 @@ config https-dns-proxy
 	option bootstrap_dns '1.1.1.1,1.0.0.1'
 	option resolver_url 'https://cloudflare-dns.com/dns-query'
 	option listen_addr '127.0.0.1'
-	option listen_port '5054'
+	option listen_port '5053'
 	option user 'nobody'
 	option group 'nogroup'
 
@@ -27,6 +27,6 @@ config https-dns-proxy
 	option bootstrap_dns '8.8.8.8,8.8.4.4'
 	option resolver_url 'https://dns.google/dns-query'
 	option listen_addr '127.0.0.1'
-	option listen_port '5053'
+	option listen_port '5054'
 	option user 'nobody'
 	option group 'nogroup'

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -127,6 +127,11 @@ append_bootstrap() {
 	[ "$ipv6_resolvers_only" -eq 0 ] && xappend '-4'
 }
 
+boot() {
+	ubus -t 30 wait_for network.interface 2>/dev/null
+	rc_procd start_service 'on_boot'
+}
+
 start_instance() {
 	local cfg="$1" param listen_addr listen_port ipv6_resolvers_only p url
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-105w, OpenWrt 22.03.3
Run tested: x86_64, Sophos XG-105w, OpenWrt 22.03.3, use https-dns-proxy for dns resolution

Description:
* config file update
* introduce boot() function

Signed-off-by: Stan Grishin [stangri@melmac.ca](mailto:stangri@melmac.ca)
