### PR TITLE
strongswan: Add the eap-dynamic plugin

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -40,6 +40,7 @@ PKG_MOD_AVAILABLE:= \
 	dhcp \
 	dnskey \
 	duplicheck \
+	eap-dynamic \
 	eap-identity \
 	eap-md5 \
 	eap-mschapv2 \
@@ -173,6 +174,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-dnskey \
 	+strongswan-mod-drbg \
 	+strongswan-mod-duplicheck \
+	+strongswan-mod-eap-dynamic \
 	+strongswan-mod-eap-identity \
 	+strongswan-mod-eap-md5 \
 	+strongswan-mod-eap-mschapv2 \
@@ -671,6 +673,7 @@ $(eval $(call BuildPlugin,dhcp,DHCP based attribute provider,))
 $(eval $(call BuildPlugin,dnskey,DNS RR key decoding,))
 $(eval $(call BuildPlugin,drbg,Deterministic random bit generator,,))
 $(eval $(call BuildPlugin,duplicheck,advanced duplicate checking,))
+$(eval $(call BuildPlugin,eap-dynamic,EAP dynamic selector,))
 $(eval $(call BuildPlugin,eap-identity,EAP identity helper,))
 $(eval $(call BuildPlugin,eap-md5,EAP MD5 (CHAP) EAP auth,))
 $(eval $(call BuildPlugin,eap-mschapv2,EAP MS-CHAPv2 EAP auth,+strongswan-mod-md4 +strongswan-mod-des))


### PR DESCRIPTION
Maintainer: @pprindeville @Thermi 
Compile tested: Linksys E8450, aarch64, OpenWrt 23.03.3
Run tested: Linksys E8450, aarch64, OpenWrt 23.03.3, configured the eap-dynamic plugin for both eap-tls and eap-radius.

```
#  swanctl --stats
uptime: 4 seconds, since Feb 27 17:48:31 2023
worker threads: 16 total, 11 idle, working: 4/0/1/0
job queues: 0/0/0/0
jobs scheduled: 5
IKE_SAs: 1 total, 0 half-open
loaded plugins: charon eap-dynamic aes des rc2 sha2 sha1 md5 random nonce x509 revocation constraints pubkey pkcs1 pgp dnskey sshkey pem openssl fips-prf gmp xcbc hmac attr kernel-netlink resolve socket-default connmark farp vici updown eap-identity eap-radius xauth-generic dhcp
```

Description:

This adds the ability to switch between various EAP modes when negotiating a Phase 1 association.