### PR TITLE
haproxy: update to v2.6.9

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=2.6.8
+PKG_VERSION:=2.6.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/2.6/src
-PKG_HASH:=a02ad64550dd30a94b25fd0e225ba699649d0c4037bca3b36b20e8e3235bb86f
+PKG_HASH:=f01a1c5f465dc1b5cd175d0b28b98beb4dfe82b5b5b63ddcc68d1df433641701
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Christian Lachner <gladiac@gmail.com>

--- a/net/haproxy/get-latest-patches.sh
+++ b/net/haproxy/get-latest-patches.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CLONEURL=https://git.haproxy.org/git/haproxy-2.6.git
-BASE_TAG=v2.6.8
+BASE_TAG=v2.6.9
 TMP_REPODIR=tmprepo
 PATCHESDIR=patches
 


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Christian Lachner <gladiac@gmail.com> (/me)
Compile tested: ipq806x
Run tested: ipq806x (r7800)

Description: Update HAProxy to v2.6.9
- Update haproxy download URL and hash
- This release fixes a critial flaw known as CVE-2023-25725. See: http://git.haproxy.org/?p=haproxy-2.6.git;a=commit;h=73be199c4f5f1ed468161a4c5e10ca77cd5989d8