### PR TITLE
haproxy: update to v2.4.22

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=2.4.17
+PKG_VERSION:=2.4.22
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/2.4/src
-PKG_HASH:=416ca95d51bb57eaea0d6657c06a760faa63473dca10ac6f9e68b994088d73f4
+PKG_HASH:=0895340b36b704a1dbb25fea3bbaee5ff606399d6943486ebd7f256fee846d3a
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Christian Lachner <gladiac@gmail.com>

--- a/net/haproxy/get-latest-patches.sh
+++ b/net/haproxy/get-latest-patches.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CLONEURL=https://git.haproxy.org/git/haproxy-2.4.git
-BASE_TAG=v2.4.17
+BASE_TAG=v2.4.22
 TMP_REPODIR=tmprepo
 PATCHESDIR=patches
 


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Christian Lachner <gladiac@gmail.com> (/me)
Compile tested: ipq806x
Run tested: ipq806x (r7800)

Description: Update HAProxy to v2.4.22
- Update haproxy download URL and hash
- This release fixes a critial flaw known as CVE-2023-25725. See: http://git.haproxy.org/?p=haproxy-2.4.git;a=commit;h=486cd730485c8a119ef65b3f792134b56e7941b4