### PR TITLE
haproxy: update to v2.2.29

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=2.2.24
+PKG_VERSION:=2.2.29
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/2.2/src
-PKG_HASH:=0e807310dce3a5293d2454d9c1b71eb8d16472305b66f076b384b50858b1e7f9
+PKG_HASH:=1e41f49674fbf5663b55c5f7919a7d05e480730653f2bcdec384b8836efc1fb0
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Christian Lachner <gladiac@gmail.com>

--- a/net/haproxy/get-latest-patches.sh
+++ b/net/haproxy/get-latest-patches.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CLONEURL=https://git.haproxy.org/git/haproxy-2.2.git
-BASE_TAG=v2.2.24
+BASE_TAG=v2.2.29
 TMP_REPODIR=tmprepo
 PATCHESDIR=patches
 


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Christian Lachner <gladiac@gmail.com> (/me)
Compile tested: ipq806x
Run tested: ipq806x (r7800)

Description: Update HAProxy to v2.2.29
- Update haproxy download URL and hash
- This release fixes a critial flaw known as CVE-2023-25725. See: http://git.haproxy.org/?p=haproxy-2.2.git;a=commit;h=4a4c90c2b04444d92c58873cfb19052f20280bc2