### PR TITLE
sed: remove old libpcre dependency

### DIFF
--- a/utils/sed/Makefile
+++ b/utils/sed/Makefile
@@ -29,7 +29,6 @@ define Package/sed
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=sed stream editor utility - full version
-  DEPENDS:=+libpcre
   URL:=https://www.gnu.org/software/sed/
   ALTERNATIVES:=300:/bin/sed:/usr/libexec/sed-gnu
 endef


### PR DESCRIPTION
Maintainer: @RussellSenior
Compile tested: aarch64 bananapi-r3 openwrt-git
Run tested: aarch64 bananapi-r3 openwrt-git

Description: sed has not depended on libpcre for a very long time from before sed 4.8 which was the first version added to OpenWrt

https://debbugs.gnu.org/cgi/bugreport.cgi?bug=22801
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=22647