### PR TITLE
samba4: update to 4.17.5

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,8 +2,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.17.2
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=4.17.5
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -13,7 +13,7 @@ PKG_SOURCE_URL:= \
 		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
-PKG_HASH:=e55ddf4d5178f8c84316abf53c5edd7b35399e3b7d86bcb81b75261c827bb3b8
+PKG_HASH:=ebb7880d474ffc09d73b5fc77bcbd657f6235910337331a9c24d7f69ca11442b
 
 PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILES:=COPYING

--- a/net/samba4/patches/021-source4-msgsock-nvram-fix.patch
+++ b/net/samba4/patches/021-source4-msgsock-nvram-fix.patch
@@ -1,6 +1,6 @@
 --- a/source4/lib/messaging/messaging.c
 +++ b/source4/lib/messaging/messaging.c
-@@ -514,7 +514,7 @@ static struct imessaging_context *imessa
+@@ -525,7 +525,7 @@ static struct imessaging_context *imessa
  		goto fail;
  	}
  


### PR DESCRIPTION
* update to 4.17.5
* changelog: https://www.samba.org/samba/history/samba-4.17.5
* refresh patch

* CVE-2022-42898: Samba's Kerberos libraries and AD DC failed to guard against integer overflows when parsing a PAC on a 32-bit system, which allowed an attacker with a forged PAC to corrupt the heap. https://www.samba.org/samba/security/CVE-2022-42898.html

* CVE-2022-37966: This is the Samba CVE for the Windows Kerberos RC4-HMAC Elevation of Privilege Vulnerability disclosed by Microsoft on Nov 8 2022.

  A Samba Active Directory DC will issue weak rc4-hmac session keys for use between modern clients and servers despite all modern Kerberos implementations supporting the aes256-cts-hmac-sha1-96 cipher.

  On Samba Active Directory DCs and members 'kerberos encryption types = legacy' would force rc4-hmac as a client even if the server supports aes128-cts-hmac-sha1-96 and/or aes256-cts-hmac-sha1-96. https://www.samba.org/samba/security/CVE-2022-37966.html

* CVE-2022-37967: This is the Samba CVE for the Windows Kerberos Elevation of Privilege Vulnerability disclosed by Microsoft on Nov 8 2022.

  A service account with the special constrained delegation permission could forge a more powerful ticket than the one it was presented with. https://www.samba.org/samba/security/CVE-2022-37967.html

* CVE-2022-38023: The "RC4" protection of the NetLogon Secure channel uses the same algorithms as rc4-hmac cryptography in Kerberos, and so must also be assumed to be weak. https://www.samba.org/samba/security/CVE-2022-38023.html

* BUG 15210: synthetic_pathref AFP_AfpInfo failed errors. This resolves errors logged during macOS TimeMachine backups. https://bugzilla.samba.org/show_bug.cgi?id=15210

Maintainer: me / @Gingernut1978
Compile tested: x86 APU2 OpenWrt SNAPSHOT r22167-1272cb0a0d
Run tested: x86 APU2 OpenWrt SNAPSHOT r22167-1272cb0a0d - Time Machine backup from macOS Ventura 13.2.1 ran without samba errors

Description:
Fixes excessive errors logged when a macOS TimeMachine backup to a samba share on the OpenWrt router starts.