### PR TITLE
acme: fix incompatibilty with image builder

### DIFF
--- a/net/acme-common/Makefile
+++ b/net/acme-common/Makefile
@@ -50,13 +50,17 @@ endef
 
 define Package/acme-common/postinst
 #!/bin/sh
-grep -q '/etc/init.d/acme' /etc/crontabs/root 2>/dev/null && exit 0
-echo "0 0 * * * /etc/init.d/acme start" >> /etc/crontabs/root
+if [ -z "$$IPKG_INSTROOT" ]; then
+	grep -q '/etc/init.d/acme' /etc/crontabs/root 2>/dev/null && exit 0
+	echo "0 0 * * * /etc/init.d/acme start" >> /etc/crontabs/root
+fi
 endef
 
 define Package/acme-common/prerm
 #!/bin/sh
-sed -i '\|/etc/init.d/acme|d' /etc/crontabs/root
+if [ -z "$$IPKG_INSTROOT" ]; then
+	sed -i '\|/etc/init.d/acme|d' /etc/crontabs/root
+fi
 endef
 
 define Build/Configure

--- a/net/acme-common/files/acme.init
+++ b/net/acme-common/files/acme.init
@@ -9,7 +9,7 @@ HOOK=/usr/lib/acme/hook
 LOG_TAG=acme
 
 # shellcheck source=net/acme/files/functions.sh
-. /usr/lib/acme/functions.sh
+. "$IPKG_INSTROOT/usr/lib/acme/functions.sh"
 
 cleanup() {
 	log debug "cleaning up"


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:

I'm not sure if directly writing to `$IPKG_INSTROOT/etc/crontabs/root` works. Will just leave uci-defaults alone for the time being. Using image builder is on my todo list tho, will update uci-defaults once I get to that.