### PR TITLE
upodman: new package

### DIFF
--- a/utils/upodman/Makefile
+++ b/utils/upodman/Makefile
@@ -1,0 +1,106 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=upodman
+PKG_VERSION:=0.98.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/oskarirauta/upodman/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=c05eddfe584fcb4e7e1a8893d676356b6332fd3ee6d292793097d16dcc33e6b9
+
+PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/upodman
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Podman manager via Ubus
+  URL:=https://github.com/oskarirauta/upodman
+  DEPENDS:=+libjson-c +libstdcpp +libubox +libuci +libblobmsg-json +libubus +podman
+endef
+
+define Package/upodman/description
+  upodman extends ubus with bindings to podman and allows
+  controlling and statistics over pods and containers through
+  ubus.
+
+  upodman is written in C++ except for ubus parts which are
+  externed from C. It uses staticly linked libcurl for unix
+  socket operations, because system's default libcurl might
+  not support unix sockets.
+endef
+
+MAKE_VARS += \
+	BUILD_DIR="$(PKG_BUILD_DIR)"
+
+CURL_VERSION:=7.87.0
+CURL_PATH:=$(PKG_BUILD_DIR)/curl-$(CURL_VERSION)
+CONFIGURE_PATH:=curl-$(CURL_VERSION)
+
+CONFIGURE_ARGS+= \
+		--disable-debug --enable-optimize --disable-curldebug --disable-ares \
+		--enable-rt --disable-ech --enable-shared=no --enable-static=yes --enable-http \
+		--disable-ftp --disable-file --disable-ldap --disable-ldaps --disable-rtsp \
+		--disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 \
+		--disable-imap --disable-smb --disable-smtp --disable-gopher --disable-mqtt \
+		--disable-manual --disable-ipv6 --enable-pthreads --enable-verbose --disable-sspi \
+		--disable-crypto-auth --disable-ntlm --disable-ntlm-wb --disable-tls-srp \
+		--enable-unix-sockets --disable-cookies --disable-socketpair --disable-http-auth \
+		--disable-doh --disable-mime --disable-dateparse --disable-netrc --disable-progress-meter \
+		--disable-dnsshuffle --enable-get-easy-options --disable-alt-svc --disable-headers-api \
+		--disable-hsts --disable-websockets --without-schannel --without-secure-transport \
+		--without-amissl --without-ssl --without-zlib --without-brotli --without-zstd \
+		--without-gssapi --without-ca-bundle --without-libpsl --without-libgsasl \
+		--without-libssh2 --without-libssh --without-wolfssh --without-librtmp \
+		--without-winidn --without-libidn2 --without-nghttp2 --without-ngtcp2 \
+		--without-nghttp3 --without-quiche --without-msh3 \
+		--without-zsh-functions-dir --without-fish-functions-dir
+
+define Build/Configure
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	mkdir -p $(CURL_PATH)
+	$(TAR) xzf $(PKG_BUILD_DIR)/dl/curl-$(CURL_VERSION).tar.gz -C $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+	$(call Build/Configure/Default)
+	$(SED) 's#DIST_SUBDIRS = \$$(SUBDIRS) tests packages scripts include docs#DIST_SUBDIRS = \$$(SUBDIRS) packages scripts include#g' $(CURL_PATH)/Makefile
+	$(SED) 's#cd docs && \$$(MAKE) install#echo not-installing-docs#g' $(CURL_PATH)/Makefile
+	$(SED) 's#cd docs/libcurl && \$$(MAKE) install#echo not-installing-docs#g' $(CURL_PATH)/Makefile
+	$(SED) 's#SUBDIRS = ../docs#SUBDIRS =#g' $(CURL_PATH)/src/Makefile
+	$(SED) 's#SUBDIRS = ../docs#SUBDIRS =#g' $(CURL_PATH)/src/Makefile.am
+endef
+
+define Build/Compile/Curl
+	+$(MAKE_VARS) \
+	$(MAKE) $(PKG_JOBS) -C $(CURL_PATH) \
+		$(MAKE_FLAGS);
+endef
+
+define Build/Install/Curl
+	$(MAKE_VARS) \
+	$(MAKE) -C $(CURL_PATH) \
+		$(MAKE_FLAGS) \
+	DESTDIR="$(CURL_PATH)/inst" \
+	install ;
+endef
+
+define Build/Compile
+	$(call Build/Compile/Curl)
+	$(call Build/Install/Curl)
+	$(call Build/Compile/Default)
+endef
+
+define Package/upodman/install
+	$(INSTALL_DIR) $(1)/usr/bin $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/upodman $(1)/usr/bin/
+	$(INSTALL_BIN) ./files/upodman.init $(1)/etc/init.d/upodman
+endef
+
+$(eval $(call BuildPackage,upodman))

--- a/utils/upodman/files/upodman.init
+++ b/utils/upodman/files/upodman.init
@@ -1,0 +1,17 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+
+USE_PROCD=1
+NAME=upodman
+PROG=/usr/bin/upodman
+
+start_service() {
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_close_instance
+}
+
+reload_service() {
+	procd_send_signal $PROG
+}


### PR DESCRIPTION
Maintainer: me / @oskarirauta
Compile tested: x86_64, latest git
Run tested: x86_64, latest git

This software can be used as a mini "remote controller" to podman.

One potential use case would be container management in LuCi. LuCi already has a quite comprehensive add-on for docker which I once ported to support podman (all but load and ram stats along with logs that caused some unexpected difficulties) for most parts and added POD support. Still, I think that full container management is best done in a terminal with provided tools and I loved how it was done with Cockpit, so it inspired me and I started to build something of my own based on it and from that idea, upodman was born.

You cannot create/remove pods/containers/images/networks; mostly you can use upodman to retrieve information that would normally be available through Rest API socket, but this will help you get it through ubus; there are also methods available that can be used to start/stop/restart container/pod - creating new pod or container has so many available options that I see no point of trying to integrate them to tool like this; u in front of name is _micro_ - so that's what this is for, some small podman management..

Not relevant to here, but I also have a luci-app-upodman using this, which provides interface such as in this example screenshot; I basicly wrote this application for that luci extension.

![upodman-screenshot](https://user-images.githubusercontent.com/1331742/222935480-725eda68-54af-40bf-b859-3fc657bb0bc5.png)

(In the image, there is nginx inside pod called servers, and then container agitated_ride that does not belong to any pod)