### PR TITLE
sing-box: update to 1.1.6

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.1.5
+PKG_VERSION:=1.1.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=a1e642362f41bd0e362cd9c8d2f0d29d2eca6a55a948677f6f03cfb81c4f0657
+PKG_HASH:=2fdf93fd49c9375cd14b2fe2e2163cbad4b65d0cfa422c592855e7810036ef56
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE

--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -27,7 +27,7 @@ define Package/sing-box
   SECTION:=net
   CATEGORY:=Network
   URL:=https://sing-box.sagernet.org
-  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle +kmod-tun
+  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle +kmod-inet-diag +kmod-tun
   USERID:=sing-box=5566:sing-box=5566
 endef
 
@@ -42,7 +42,6 @@ define Package/sing-box/config
 
 		config SINGBOX_WITH_ACME
 			bool "Build with ACME TLS certificate issuer support"
-			default n
 
 		config SINGBOX_WITH_CLASH_API
 			bool "Build with Clash API support"
@@ -50,15 +49,12 @@ define Package/sing-box/config
 
 		config SINGBOX_WITH_ECH
 			bool "Build with TLS ECH extension support for TLS outbound"
-			default n
 
 		config SINGBOX_WITH_EMBEDDED_TOR
 			bool "Build with embedded Tor support"
-			default n
 
 		config SINGBOX_WITH_GRPC
 			bool "Build with standard gRPC support"
-			default n
 
 		config SINGBOX_WITH_GVISOR
 			bool "Build with gVisor support"
@@ -66,7 +62,6 @@ define Package/sing-box/config
 
 		config SINGBOX_WITH_LWIP
 			bool "Build with LWIP Tun stack support"
-			default n
 
 		config SINGBOX_WITH_QUIC
 			bool "Build with QUIC support"
@@ -74,7 +69,6 @@ define Package/sing-box/config
 
 		config SINGBOX_WITH_SHADOWSOCKSR
 			bool "Build with ShadowsocksR support"
-			default n
 
 		config SINGBOX_WITH_UTLS
 			bool "Build with uTLS support for TLS outbound"
@@ -82,7 +76,6 @@ define Package/sing-box/config
 
 		config SINGBOX_WITH_V2RAY_API
 			bool "Build with V2Ray API support"
-			default n
 
 		config SINGBOX_WITH_WIREGUARD
 			bool "Build with WireGuard support"


### PR DESCRIPTION
Maintainer: me
Compile tested: (x86_64, OpenWrt snapshot)
Run tested: (x86_64, OpenWrt 22.03, tests done)

Description:

1. Add `kmod-inet-diag` as a dependency (https://github.com/openwrt/packages/pull/20486#issuecomment-1430610086)
2. Remove redundant `default n` (https://github.com/openwrt/packages/pull/20486#discussion_r1113008854)

