### PR TITLE
netbird: update to 0.14.2

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.12.0
+PKG_VERSION:=0.14.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c88b65bb9358e5a6f9c34882e77a3414b02d4c5ac13b76fb2e60b952af6a18d7
+PKG_HASH:=8ffef4569572b9eb93891e881cb7b3b9ba98b5596f3ffda3b433b32e364adb56
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Update from 0.12.0 -> 0.14.2

A lot of changes due to update of so many versions.
Release notes of all versions between 0.12.0 -> 0.14.2 is
available at https://github.com/netbirdio/netbird/releases

Maintainer: me / @oskarirauta
Compile tested: x86_64, latest git
Run tested: x86_64, latest git