### PR TITLE
curl: enable unix sockets by default

### DIFF
--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -139,7 +139,7 @@ config LIBCURL_ZSTD
 
 config LIBCURL_UNIX_SOCKETS
 	bool "Enable unix domain socket support"
-	default n
+	default y
 	help
 		Enable HTTP over unix domain sockets.
 		To use this with the curl command line, you specify the socket path to the new --unix-domain option.

--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=7.88.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \


### PR DESCRIPTION
 - changed Config.in to enable unix sockets support by default
 - release number bumped

Maintainer: Stan Grishin / @stangri 
Compile tested: x86_64 / latest git
Run tested: x86_64 / latest git

Description:
socket support is very handy when communicating with
various REST APIs.

Size increases are very small, nearly unnoticiable.

Tested-by: Stan Grishin <stangri@melmac.ca>
Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>