### PR TITLE
udp-broadcast-relay-redux-openwrt: add cgroupsns to jail

### DIFF
--- a/net/udp-broadcast-relay-redux-openwrt/Makefile
+++ b/net/udp-broadcast-relay-redux-openwrt/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=udp-broadcast-relay-redux
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0
 
 PKG_SOURCE_PROTO:=git

--- a/net/udp-broadcast-relay-redux-openwrt/files/udp-broadcast-relay-redux.init
+++ b/net/udp-broadcast-relay-redux-openwrt/files/udp-broadcast-relay-redux.init
@@ -58,7 +58,7 @@ udp_broadcast_relay_redux_instance() {
         procd_append_param command "-t" "$dest_override"
     fi
 
-    procd_add_jail ubr-${PIDCOUNT}
+    procd_add_jail ubr-${PIDCOUNT} cgroupsns
     procd_close_instance
 }
 


### PR DESCRIPTION
Maintainer:  @accwebs 
Compile tested: None, modified directly on my filesystem
Run tested: openwrt 22.03.3 ipq806x generic netgear_r7800

Description:

Added `cgroupsns` to jail, otherwise you get this failure:
```
Mon Mar  6 14:46:05 2023 user.err : jail: Not using namespaces, capabilities or seccomp !!!
```
Error is here, seems to indicate that we're running a jail without using any capability. https://lxr.openwrt.org/source/procd/jail/jail.c#L2847

Decided to use minimal effort approach

**Before:** Service "started successfully" and showed as "running", but `ps |grep udp` showed nothing, and actual packet forwarding didn't happen. Mentioned error message was logged on `logread -f`
**After:** Service works.
Modified this locally on my router, works well. 