### PR TITLE
Update modemmanager and dependencies

### DIFF
--- a/libs/libmbim/Makefile
+++ b/libs/libmbim/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmbim
-PKG_SOURCE_VERSION:=1.28.2
+PKG_SOURCE_VERSION:=1.28.4
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/libmbim.git
-PKG_MIRROR_HASH:=0b0b46016738fc22355d5a58c8a2d1b2f04906c49c51a50b57a09640d13b00b7
+PKG_MIRROR_HASH:=7ecc6d1e565392817311254045337907bbad015b46ec88542ea63594f47778be
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_SOURCE_VERSION:=1.32.2
+PKG_SOURCE_VERSION:=1.32.4
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/libqmi.git
-PKG_MIRROR_HASH:=711d16d75a6a9afaefcf2be1bc845a4a6181dff786dfbd079e41e91279a0be91
+PKG_MIRROR_HASH:=674f5848c56c11cdc2fbc82c52e5bc2a3a0fddb56315dc4220544688a7b0e17a
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
-PKG_SOURCE_VERSION:=1.20.2
+PKG_SOURCE_VERSION:=1.20.6
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git
-PKG_MIRROR_HASH:=f138effc693456c5040ec22e17c0a8b41143c3b17b62437462995c297a9150dc
+PKG_MIRROR_HASH:=e90103e2e42bb826bbbac83937a9a69f50348cd6ce0d8da655a12b65494ce7c9
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: @mips171
Compile tested: aarch64, Raspberry Pi 4 Model B Rev 1.1, OpenWrt SNAPSHOT, r22241-acb189179c
Run tested: as above. checked basic functionalities.

Description:

Update mobile broadband connectivity packages including

- `libmbim` (1.28.2 -> 1.28.4)
- `libqmi` (1.32.2 -> 1.32.4)
- `modemmanager` (1.20.2 -> 1.20.6)

```
Overview of changes in libmbim 1.28.4
----------------------------------------

 * libmbim-glib:
   ** Fixed context type conversions to consider all possible APN types.
   ** Duplicate UTF-16 strings during processing to avoid alignment issues.
```

```
Overview of changes in libqmi 1.32.4
----------------------------------------

 * libqmi-glib:
   ** Schedule indications with G_PRIORITY_DEFAULT to ensure correct processing
      order between responses and indications.

 * build:
   ** If QRTR enabled the pkg-config should publicly require libqrtr-glib.
```

```
Overview of changes in ModemManager 1.20.6
-------------------------------------------

 * build:
   ** New build option to allow disabling the installation of examples.

 * core:
   ** Fix crash when uninhibiting partially removed device.
   ** Fix crash when attempting to load an invalid shared utils library.

 * mmcli:
   ** Allow JSON and key/value output when creating SMS messages.
   ** Improved JSON output in network scan results.

 * libmm-glib:
   ** Avoid using g_time_zone_new_offset() unless glib >= 2.58.
   ** Fix flags to string conversion utils to allow multiple flags.

 * MBIM:
   ** Reset cached SIM info when SIM is unlocked.
   ** Fix synchronizing the state of the SIM hot swap configured flag.
   ** Fix bug cleaning up the LTE attach info unsolicited message handler.
   ** Fallback from QMI UIM service only if unsupported.
   ** Add missing support for 'emergency' APN type.

 * QMI:
   ** Fix processing and exposing PCOs.
   ** Fix power up on modems that don't support power state change indications.

 * plugins:
   ** telit: add additional support for 5G modems.
   ** telit: added port type hints for FN990 0x1070, 0x1071 compositions.
   ** telit: increase allowed initial delay in AT ports.
   ** telit: fallback to AT commands if loading revision via MBIM fails.
   ** quectel: add support for EC21-EUX usb modules.
   ** xmm: fix crash parsing XACT? response.


Overview of changes in ModemManager 1.20.4
-------------------------------------------

 * build:
   ** Don't hardcode building shared libraries, so that meson's default_library
      option can be used properly,
   ** po: Added missing Georgian translation in LINGUAS.

 * QMI:
   ** Fixed loading NR5G signal info.
   ** Fixed memory leaks when processing signal info.
   ** Correctly scaled the SNR value reported in NR5G.
   ** Fixed invalid use-after-free actions due to improper handling of proxy
      removal events.

 * MBIM:
   ** Fixed processing MbimSmsStatusFlag as flags, not as an enum.
   ** Fixed invalid use-after-free actions due to improper handling of proxy
      removal events.
   ** Chained up device notifications through the MMPortMbim object.

 * Messaging:
   ** Allowed Delete operation during enabling/disabling.

 * Core:
   ** Don't assume port tables always exist so that long-standing operations
      holding an object reference can finish cleanly even after the initial
      object disposal has already been run.

 * plugins:
   ** quectel: added new firehose/sahara support udev tags in new models.
   ** broadmobi: added MM_PLUGIN_REQUIRED_QCDM flag.
   ** cinterion: added a delay to the ^SWWAN? command.
   ** cinterion: added retry mechanism to the ^SWWAN? command.
```
