### PR TITLE
tiff: force libdeflate support to off

### DIFF
--- a/libs/tiff/Makefile
+++ b/libs/tiff/Makefile
@@ -64,7 +64,8 @@ CMAKE_OPTIONS += \
 	-Dzstd=OFF \
 	-Dwebp=OFF \
 	-Djpeg12=OFF \
-	-Dcxx=OFF
+	-Dcxx=OFF \
+	-Dlibdeflate=OFF
 
 define Build/InstallDev
 	$(call Build/InstallDev/cmake,$(1))


### PR DESCRIPTION
Commit 81d2b72 added a package providing libdeflate. Tiff by default links to it, causing a build error.

Package libtiff is missing dependencies for the following libraries: libdeflate.so.0

This commit forces libdeflate use off to avoid this. No revision bump is done because the package is currently not compiling anyway.

Maintainer: @jslachta 

Compile tested: ath79 master
Run tested: N/A

Description: fix current packaging issue
