### PR TITLE
CI: update build architectures

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -11,10 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: arc_archs
-            target: archs38-generic
-            runtime_test: false
-
           - arch: arm_cortex-a9_vfpv3-d16
             target: mvebu-cortexa9
             runtime_test: false
@@ -31,7 +27,7 @@ jobs:
             target: apm821xx-nand
             runtime_test: false
 
-          - arch: powerpc_8540
+          - arch: powerpc_8548
             target: mpc85xx-p1010
             runtime_test: false
 


### PR DESCRIPTION
Maintainer: @aparcar 
Compile tested: CI
Run tested: CI

Description:
- Removed arc_archs - archs38 was marked as source-only [^1].
- Renamed powerpc_8540 to powerpc_8548 [^2].

[^1]: https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=c01641bcc7236d2e2de3ea65444b0cf2898df351
[^2]: https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=2cad88b99fdae9766de84e6c1cb56f111eb53748