### PR TITLE
ddns-scripts: Add v2 API for mythic-beasts.com provider

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=36
+PKG_RELEASE:=37
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/mythic-beasts.com-v2.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/mythic-beasts.com-v2.json
@@ -1,0 +1,9 @@
+{
+        "name": "mythic-beasts.com (API v2)",
+        "ipv4": {
+                "url": "https://[USERNAME]:[PASSWORD]@ipv4.api.mythic-beasts.com/dns/v2/dynamic/[DOMAIN]"
+        },
+        "ipv6": {
+                "url": "https://[USERNAME]:[PASSWORD]@ipv6.api.mythic-beasts.com/dns/v2/dynamic/[DOMAIN]"
+        }
+}

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -41,6 +41,7 @@ moniker.com
 mydns.jp
 myonlineportal.net
 mythic-beasts.com
+mythic-beasts.com-v2
 namecheap.com
 njal.la
 no-ip.pl


### PR DESCRIPTION
Use USERNAME as the key, PASSWORD as the secret.

Mythic Beasts API v1 is still available, but v2 use is encouraged.

Maintainer: ?
Compile tested: ipq806x (Archer C2600)
Run tested: ipq806x (Archer C2600)

