### PR TITLE
lua-eco: update to 2.2.0

### DIFF
--- a/lang/lua-eco/Makefile
+++ b/lang/lua-eco/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lua-eco
-PKG_VERSION:=2.1.0
+PKG_VERSION:=2.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://github.com/zhaojh329/lua-eco/releases/download/v$(PKG_VERSION)
-PKG_HASH:=0e6d1906f15f350a825a4325cd579251baf6eb4b7ce6ef88f57357de49c0e00e
+PKG_HASH:=b45073ba93123d93ab7521b1e699c0f8f8f7de513342b16e2115a0f5a26f8014
 
 PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Signed-off-by: Jianhui Zhao [zhaojh329@gmail.com](mailto:zhaojh329@gmail.com)

Maintainer: me
Compile tested: x86, x86, master
Run tested: x86, x86, master, tests done

Description:
Release notes for 2.2.0: https://github.com/zhaojh329/lua-eco/releases/tag/v2.2.0