### PR TITLE
miniupnpd: bump to 2.3.3

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -8,15 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
-
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/miniupnp/miniupnp.git
-PKG_SOURCE_DATE:=2022-08-31
-PKG_SOURCE_VERSION:=68c8ec508a421f4f4af67a63e3eb6f497d2531e1
-PKG_MIRROR_HASH:=68a3170ec73149c4cf4855b1ce6e031557cc12bff85a58421bb94785daaf225d
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)/miniupnpd
-
+PKG_VERSION:=2.3.3
 PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=6fd7019f936ff88c41e7c822f46f10b51bd72d665978f6586483de75b30c36bf
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=BSD-3-Clause
@@ -28,9 +25,6 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/version.mk
-
-TAR_OPTIONS+= --strip-components 1
-TAR_CMD=$(HOST_TAR) -C $(1)/.. $(TAR_OPTIONS)
 
 define Package/miniupnpd/Default
   SECTION:=net


### PR DESCRIPTION
Maintainer: NA
Compile tested: NA
Run tested: NA

Untested as I don't run 22.03. CI should do compile tests, and if someone who does run 22.03 would be so kind to test this and report back, that would be appreciated.