### PR TITLE
Package dependencies for ble2mqtt python package

### DIFF
--- a/lang/python/python-aio-mqtt-mod/Makefile
+++ b/lang/python/python-aio-mqtt-mod/Makefile
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2023
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-aio-mqtt-mod
+PKG_VERSION:=0.3.3
+PKG_RELEASE:=1
+
+PYPI_NAME:=aio-mqtt-mod
+PKG_HASH:=2271f8a2fd6c6aea914896dc3d4dd6e384cd0da405b06dcfa566bd01f968bf9d
+
+PKG_MAINTAINER:=Quintin Hill <stuff@quintin.me.uk>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-aio-mqtt-mod
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Asynchronous MQTT client
+  URL:=https://github.com/devbis/aio-mqtt
+  DEPENDS:=+python3-light +python3-asyncio +python3-openssl
+endef
+
+define Package/python3-aio-mqtt-mod/description
+  Asynchronous MQTT client for 3.1.1 protocol version (mod).
+endef
+
+$(eval $(call Py3Package,python3-aio-mqtt-mod))
+$(eval $(call BuildPackage,python3-aio-mqtt-mod))
+$(eval $(call BuildPackage,python3-aio-mqtt-mod-src))

--- a/lang/python/python-ble2mqtt/Makefile
+++ b/lang/python/python-ble2mqtt/Makefile
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2023
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-ble2mqtt
+PKG_VERSION:=0.1.5
+PKG_RELEASE:=1
+
+PYPI_NAME:=ble2mqtt
+PKG_HASH:=0015cae0c36badb48cbd4a1c8b1a8029e45ab0891a95363fe00624c2629b4510
+
+PKG_MAINTAINER:=Quintin Hill <stuff@quintin.me.uk>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-ble2mqtt
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Bluetooth to MQTT bridge
+  URL:=https://github.com/devbis/ble2mqtt/
+  DEPENDS:=+python3-light +python3-aio-mqtt-mod +python3-asyncio +python3-bleak +python3-logging
+endef
+
+define Package/python3-ble2mqtt/description
+  Bluetooth to MQTT bridge, add your bluetooth-capable (including controllable)
+  devices to your smart home
+endef
+
+$(eval $(call Py3Package,python3-ble2mqtt))
+$(eval $(call BuildPackage,python3-ble2mqtt))
+$(eval $(call BuildPackage,python3-ble2mqtt-src))

--- a/lang/python/python-bleak/Makefile
+++ b/lang/python/python-bleak/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2023
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-bleak
+PKG_VERSION:=0.20.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=bleak
+PKG_HASH:=7f6fe69454ad5d4c0ab05ae4a9aa1aabd6926d7128eab2fac4ef8a58a72999ee
+
+PKG_MAINTAINER:=Quintin Hill <stuff@quintin.me.uk>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-bleak
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Bluetooth Low Energy platform Agnostic Klient
+  URL:=https://github.com/hbldh/bleak
+  DEPENDS:=+python3-light +python3-async-timeout +python3-asyncio \
+	+python3-dbus-fast +python3-ctypes +python3-logging
+endef
+
+define Package/python3-bleak/description
+  Bleak is an acronym for Bluetooth Low Energy platform Agnostic Klient.
+  Bleak is a GATT client software, capable of connecting to BLE devices acting
+  as GATT servers.  It is designed to provide a asynchronous, cross-platform
+  Python API to connect and communicate with e.g. sensors.
+endef
+
+$(eval $(call Py3Package,python3-bleak))
+$(eval $(call BuildPackage,python3-bleak))
+$(eval $(call BuildPackage,python3-bleak-src))

--- a/lang/python/python-dbus-fast/Makefile
+++ b/lang/python/python-dbus-fast/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2023
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-dbus-fast
+PKG_VERSION:=1.84.2
+PKG_RELEASE:=1
+
+PYPI_NAME:=dbus-fast
+PYPI_SOURCE_NAME:=dbus_fast
+PKG_HASH:=62b00b85c5835bff1d7ab5b12d494e588d92612bedbd7ca86176861729b8e4bc
+
+PKG_MAINTAINER:=Quintin Hill <stuff@quintin.me.uk>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-dbus-fast
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=A faster version of dbus-next
+  URL:=https://github.com/Bluetooth-Devices/dbus-fast
+  DEPENDS:=+python3-light +python3-async-timeout +python3-asyncio \
+	+python3-logging +python3-urllib +python3-xml
+endef
+
+define Package/python3-dbus-fast/description
+  dbus-fast is a Python library for DBus that aims to be a performant fully
+  featured high level library primarily geared towards integration of
+  applications into Linux desktop and mobile environments.
+endef
+
+$(eval $(call Py3Package,python3-dbus-fast))
+$(eval $(call BuildPackage,python3-dbus-fast))
+$(eval $(call BuildPackage,python3-dbus-fast-src))


### PR DESCRIPTION
Maintainer: me 
Compile tested: Unfortunately not (I tried without success to build this out on my machine but I think this is more of a failure in my setup.)  Hopefully CI will test this.
Run tested: Unfortunately not

Description: [ble2mqtt](https://github.com/devbis/ble2mqtt) is an interesting python package unfortunately it requires [Bleak](https://github.com/hbldh/bleak) which requires [dbus-fast](https://github.com/Bluetooth-Devices/dbus-fast) and this latter package cannot be successfully installed on a router with 128MB of RAM using pip (it runs out of memory and crashes).  This PR packages the dependencies for ble2mqtt but dbus-fast is the priority here.

