### PR TITLE
simple-adblock: update init file and config

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.9.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/simple-adblock.conf
+++ b/net/simple-adblock/files/simple-adblock.conf
@@ -64,6 +64,10 @@ config simple-adblock 'config'
 # block-list too big for most routers
 #	list blocked_hosts_url 'https://cdn.jsdelivr.net/gh/StevenBlack/hosts/hosts'
 
+# File size: 2.0M
+# block-list too big for most routers
+#	list blocked_domains_url https://cdn.jsdelivr.net/gh/bongochong/CombinedPrivacyBlockLists/NoFormatting/cpbl-ctld.txt
+
 # File size: 3.1M
 # block-list too big for most routers
 #	list blocked_hosts_url 'https://hostsfile.mine.nu/Hosts'

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -88,9 +88,6 @@ outputCache=
 awk='awk'
 load_environment_flag=
 
-. /lib/functions/network.sh
-. /usr/share/libubox/jshn.sh
-
 debug() { local i j; for i in "$@"; do eval "j=\$$i"; echo "${i}: ${j} "; done; }
 
 uci_add_list_if_new() {
@@ -1562,6 +1559,8 @@ stop_service() { load_validate_config 'config' adb_stop "'$*'"; }
 version() { echo "$PKG_VERSION"; }
 
 load_validate_config() {
+	. /lib/functions/network.sh
+	. /usr/share/libubox/jshn.sh
 	local enabled
 	local force_dns
 	local force_dns_port


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-105wr2, OpenWrt 22.03.3
Run tested:  x86_64, Sophos XG-105wr2, OpenWrt 22.03.3, install/start/stop

Description:
* move network.sh and jshn.sh includes into load_validate_config function to prevent errors when adding the package to image with the Image Builder
* add @bongochong compressed domains block-list to the config

Signed-off-by: Stan Grishin <stangri@melmac.ca>
