### PR TITLE
shadowsocks-libev: added support for ACL

### DIFF
--- a/net/shadowsocks-libev/Makefile
+++ b/net/shadowsocks-libev/Makefile
@@ -14,7 +14,7 @@ include $(TOPDIR)/rules.mk
 #
 PKG_NAME:=shadowsocks-libev
 PKG_VERSION:=3.3.5
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/shadowsocks/shadowsocks-libev/releases/download/v$(PKG_VERSION)

--- a/net/shadowsocks-libev/files/shadowsocks-libev.init
+++ b/net/shadowsocks-libev/files/shadowsocks-libev.init
@@ -81,6 +81,7 @@ ss_xxx() {
 	[ -z "$mtu" ] || json_add_int mtu "$mtu"
 	[ -z "$timeout" ] || json_add_int timeout "$timeout"
 	[ -z "$user" ] || json_add_string user "$user"
+	[ -z "$acl" ] || json_add_string acl "$acl"
 	json_dump -i >"$confjson"
 
 	procd_open_instance "$cfgtype.$cfg"
@@ -273,7 +274,8 @@ validate_server_section() {
 }
 
 validate_ss_local_section() {
-	validate_common_client_options_ ss_local "$1" "$2"
+	validate_common_client_options_ ss_local "$1" "$2" \
+	  'acl:file'
 }
 
 validate_ss_redir_section() {
@@ -307,7 +309,8 @@ validate_ss_server_section() {
 		'local_address:ipaddr' \
 		'local_ipv4_address:ip4addr' \
 		'local_ipv6_address:ip6addr' \
-		'bind_address:ipaddr'
+		'bind_address:ipaddr' \
+		'acl:file'
 }
 
 validate_ss_tunnel_section() {


### PR DESCRIPTION
Added ability to pass an Access Control List (--acl param) to forbid access to specified IP addresses

Maintainer: @yousong 
Compile tested: didn't compile, since this is only an init-file change
Run tested: MediaTek MT7628AN ver:1 eco:2, TP-Link TL-WR841N v13, OpenWrt 22.03.3 r20028-43d71ad93e
