### PR TITLE
zerotier: do not allow executable stack

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -58,8 +58,8 @@ endif
 endef
 
 # Make binary smaller
-TARGET_CFLAGS += -ffunction-sections -fdata-sections
-TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
+TARGET_CFLAGS += -ffunction-sections -fdata-sections -Wl,-z,noexecstack
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed -Wl,-z,noexecstack
 
 define Package/zerotier/conffiles
 /etc/config/zerotier


### PR DESCRIPTION
zerotier has executable stack.
`
[   11.343143] process '/usr/bin/zerotier-one' started with executable stack
`

executable stacks are not recommend, possibly provide a threat and there seems to be no real advantage of executable stack with zerotier - so let's build it without instead.

Some chatter about [executable stacks](https://security.stackexchange.com/questions/210785/how-and-why-is-executable-stack-dangerous) and a older feature request on [same subject](https://github.com/zerotier/ZeroTierOne/issues/1179) at zerotier's repository for reference.

Maintainer: Moritz Warning / @mwarning
Compile tested: x86_64 / latest git
Run tested: x86_64 / latest git