### PR TITLE
libjpeg-turbo: enable static library building

### DIFF
--- a/libs/libjpeg-turbo/Makefile
+++ b/libs/libjpeg-turbo/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libjpeg-turbo
 PKG_VERSION:=2.1.4
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
@@ -50,7 +50,7 @@ endef
 
 CMAKE_OPTIONS += \
 	-DENABLE_SHARED=ON \
-	-DENABLE_STATIC=OFF \
+	-DENABLE_STATIC=ON \
 	-DREQUIRE_SIMD=OFF \
 	-DWITH_12BIT=OFF \
 	-DWITH_ARITH_DEC=OFF \
@@ -73,6 +73,7 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libjpeg.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libjpeg.a $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc $(1)/usr/lib/pkgconfig/
 	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/libjpeg.pc


### PR DESCRIPTION
Allow build of libjpeg as a static library as well; one is provided for libpng and possibly for other
formats as well.

Maintainer: Rosen Penev / @neheb
Compile tested: x86_64 / latest git
Run tested: x86_64 / latest git

Description:
I have a application that can draw graphical content to frame buffer, including few image formats and
jpg is amongst supported formats. As software is meant for displaying a _boot splash_ and started early
from initrd, static linking is encouraged. But this would require static archive from libjpeg to be possible.

Static archive is not added to package, only to development libraries by this PR.