### PR TITLE
zerotier: update to 1.10.4

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
-PKG_VERSION:=1.10.3
+PKG_VERSION:=1.10.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=f2ce8a63a459a5fab129fb398e379b8c0875bdfeccb7bf15f9683ad22e43e629
+PKG_HASH:=5dc185a65baf8caa3fb739cbc8043677aa117604be9036a28c34f8fda5d6eafe
 PKG_BUILD_DIR:=$(BUILD_DIR)/ZeroTierOne-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>

--- a/net/zerotier/patches/0001-fix-makefile.patch
+++ b/net/zerotier/patches/0001-fix-makefile.patch
@@ -38,7 +38,7 @@ Subject: [PATCH 1/2] fix makefile
  	RUSTFLAGS=--release
  endif
  
-@@ -313,7 +313,7 @@ ifeq ($(ZT_CONTROLLER),1)
+@@ -316,7 +316,7 @@ ifeq ($(ZT_CONTROLLER),1)
  endif
  
  # ARM32 hell -- use conservative CFLAGS
@@ -47,7 +47,7 @@ Subject: [PATCH 1/2] fix makefile
  	ifeq ($(shell if [ -e /usr/bin/dpkg ]; then dpkg --print-architecture; fi),armel)
  		override CFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
  		override CXXFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
-@@ -340,8 +340,8 @@ ifeq ($(ZT_USE_ARM32_NEON_ASM_CRYPTO),1)
+@@ -343,8 +343,8 @@ ifeq ($(ZT_USE_ARM32_NEON_ASM_CRYPTO),1)
  endif
  
  # Position Independence


### PR DESCRIPTION
Maintainer: me
Compile tested: ramips/mt7620, Nexx wt3020, OpenWrt master
Run tested: ramips/mt7620, Nexx wt3020, OpenWrt master
Tested: ZeroTier starts

Description:
Minor changes: https://github.com/zerotier/ZeroTierOne/blob/dev/RELEASE-NOTES.md