### PR TITLE
gensio: fix python bindings build by using a pcre enabled host swig (fixes #20604)

### DIFF
--- a/libs/pcre2/Makefile
+++ b/libs/pcre2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pcre2
 PKG_VERSION:=10.37
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/pcre/$(PKG_NAME)/$(PKG_VERSION)
@@ -28,6 +28,7 @@ PKG_CONFIG_DEPENDS:=\
 PKG_BUILD_DEPENDS:=zlib
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk
 
 define Package/libpcre2/default
@@ -54,6 +55,18 @@ define Package/libpcre2-32
   $(call Package/libpcre2/default)
   TITLE:=A Perl Compatible Regular Expression library (32bit support)
 endef
+
+CMAKE_HOST_OPTIONS += \
+	-DBUILD_SHARED_LIBS=ON \
+	-DPCRE2_BUILD_PCRE2_8=ON \
+	-DPCRE2_BUILD_PCRE2_16=ON \
+	-DPCRE2_BUILD_PCRE2_32=ON \
+	-DPCRE2_DEBUG=OFF \
+	-DPCRE2_DISABLE_PERCENT_ZT=ON \
+	-DPCRE2_SUPPORT_JIT=OFF \
+	-DPCRE2_SHOW_REPORT=OFF \
+	-DPCRE2_BUILD_PCRE2GREP=OFF \
+	-DPCRE2_BUILD_TESTS=OFF
 
 CMAKE_OPTIONS += \
 	-DBUILD_SHARED_LIBS=ON \
@@ -92,3 +105,4 @@ endef
 $(eval $(call BuildPackage,libpcre2))
 $(eval $(call BuildPackage,libpcre2-16))
 $(eval $(call BuildPackage,libpcre2-32))
+$(eval $(call HostBuild))

--- a/net/gensio/Makefile
+++ b/net/gensio/Makefile
@@ -33,7 +33,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_GENSIO_TCL \
 	CONFIG_GENSIO_SSHD
 
-PKG_BUILD_DEPENDS:=PACKAGE_python3-gensio:swig
+PKG_BUILD_DEPENDS:=PACKAGE_python3-gensio:swig/host
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
@@ -132,7 +132,7 @@ $(call Package/gensio/Default)
   TITLE+= (Python3-bindings)
   SECTION:=lang
   CATEGORY:=Languages
-  DEPENDS:=+PACKAGE_python3-gensio:python3-light +libgensio
+  DEPENDS:=+PACKAGE_python3-gensio:python3-light +libgensiocpp
 endef
 
 define Package/python3-gensio/description

--- a/net/gensio/Makefile
+++ b/net/gensio/Makefile
@@ -129,9 +129,10 @@ endef
 
 define Package/python3-gensio
 $(call Package/gensio/Default)
-  TITLE+= (Python3-bindings)
+  TITLE+= (Python bindings)
   SECTION:=lang
   CATEGORY:=Languages
+  SUBMENU:=Python
   DEPENDS:=+PACKAGE_python3-gensio:python3-light +libgensiocpp
 endef
 

--- a/utils/swig/Makefile
+++ b/utils/swig/Makefile
@@ -20,6 +20,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_HOST_ONLY:=1
 HOST_BUILD_PARALLEL:=1
+HOST_BUILD_DEPENDS:=pcre2/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
@@ -33,7 +34,7 @@ define Package/swig
 endef
 
 HOST_CONFIGURE_ARGS += \
-	--without-pcre
+	--with-pcre
 
 define Package/swig/description
   tool that generates bindings for various languages


### PR DESCRIPTION
Issue reporter:  @jefferyto 
Maintainer: @InBetweenNames (pcre2), @nxhack + @blogic (swig), @WereCatf (gensio)
Compile tested: mxs
Run tested: mxs, Duckbill - only a basic Python module import with output of version string

Description:

As reported in #20604, the python3-gensio package cannot be built at the moment due to missing pcre support in swig.
This PR thus adds a host build for pcre as proposed by @jefferyto, it modifies the swig package to use it and finally adjusts the gensio package itself slightly.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
