### PR TITLE
[openwrt-22.03] golang: Update to 1.19.7

### DIFF
--- a/lang/golang/golang-values.mk
+++ b/lang/golang/golang-values.mk
@@ -77,6 +77,7 @@ unexport \
 # From https://pkg.go.dev/runtime#hdr-Environment_Variables
 unexport \
   GOGC \
+  GOMEMLIMIT \
   GOMAXPROCS \
   GORACE \
   GOTRACEBACK

--- a/lang/golang/golang/Makefile
+++ b/lang/golang/golang/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 GO_VERSION_MAJOR_MINOR:=1.19
-GO_VERSION_PATCH:=6
+GO_VERSION_PATCH:=7
 
 PKG_NAME:=golang
 PKG_VERSION:=$(GO_VERSION_MAJOR_MINOR)$(if $(GO_VERSION_PATCH),.$(GO_VERSION_PATCH))
@@ -20,7 +20,7 @@ GO_SOURCE_URLS:=https://dl.google.com/go/ \
 
 PKG_SOURCE:=go$(PKG_VERSION).src.tar.gz
 PKG_SOURCE_URL:=$(GO_SOURCE_URLS)
-PKG_HASH:=d7f0013f82e6d7f862cc6cb5c8cdb48eef5f2e239b35baa97e2f1a7466043767
+PKG_HASH:=775bdf285ceaba940da8a2fe20122500efd7a0b65dbcee85247854a8d7402633
 
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -65,7 +65,7 @@ HOST_GO_VALID_OS_ARCH:= \
   \
   linux_ppc64 linux_ppc64le \
   linux_mips linux_mipsle linux_mips64 linux_mips64le \
-  linux_riscv64 linux_s390x \
+  linux_loong64 linux_riscv64 linux_s390x \
   \
   openbsd_mips64
 
@@ -291,10 +291,9 @@ PKG_GO_LDFLAGS= \
 	-extldflags '$(patsubst -z%,-Wl$(comma)-z$(comma)%,$(TARGET_LDFLAGS))' \
 	$(if $(CONFIG_NO_STRIP)$(CONFIG_DEBUG),,-s -w)
 
-# setting -trimpath is not necessary here because the paths inside the
-# compiler binary are relative to GOROOT_FINAL (PKG_GO_ROOT), which is
-# static / not dependent on the build environment
 PKG_GO_INSTALL_ARGS= \
+	-buildvcs=false \
+	-trimpath \
 	-ldflags "all=$(PKG_GO_LDFLAGS)" \
 	$(if $(PKG_GO_GCFLAGS),-gcflags "all=$(PKG_GO_GCFLAGS)") \
 	$(if $(PKG_GO_ASMFLAGS),-asmflags "all=$(PKG_GO_ASMFLAGS)") \


### PR DESCRIPTION
Maintainer: me
Compile tested: none (cherry picked from #20661)
Run tested: none

Description:
Includes fix for CVE-2023-2453 (crypto/elliptic: specific unreduced P-256 scalars produce incorrect results).

This also includes makefile updates for Go 1.19.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 8677ed11e30b78de526dfacca58f24e041ff7833)