### PR TITLE
ddns-scripts: add hotplug trigger for device name

### DIFF
--- a/net/ddns-scripts/files/etc/hotplug.d/iface/ddns
+++ b/net/ddns-scripts/files/etc/hotplug.d/iface/ddns
@@ -1,11 +1,21 @@
 #!/bin/sh
 
+start_updater() {
+	/usr/lib/ddns/dynamic_dns_updater.sh -n "$INTERFACE" -- start
+	/usr/lib/ddns/dynamic_dns_updater.sh -n "$DEVICE" -- start
+}
+
+stop_updater() {
+	/usr/lib/ddns/dynamic_dns_updater.sh -n "$INTERFACE" -- stop
+	/usr/lib/ddns/dynamic_dns_updater.sh -n "$DEVICE" -- stop
+}
+
 # there are other ACTIONs like ifupdate we don't need
 case "$ACTION" in
-	ifup)					# OpenWrt is giving a network not phys. Interface
-		/etc/init.d/ddns enabled && /usr/lib/ddns/dynamic_dns_updater.sh -n "$INTERFACE" -- start
+	ifup)
+		/etc/init.d/ddns enabled && start_updater
 		;;
 	ifdown)
-		/usr/lib/ddns/dynamic_dns_updater.sh -n "$INTERFACE" -- stop
+		stop_updater
 		;;
 esac


### PR DESCRIPTION
Maintainer: me
Compile tested: no
Run tested: Unfortunately not

Description:
Users can register an ddns updater and bind it on an device, not an interface. 
So we must also trigger start/stop event for device name, not just interface name, otherwise this kind of updaters will not able to auto start/stop with hotplug event.
