### PR TITLE
openssh: update to 9.3p1

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
-PKG_VERSION:=9.2p1
+PKG_VERSION:=9.3p1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
 		https://ftp.spline.de/pub/OpenBSD/OpenSSH/portable/
-PKG_HASH:=3f66dbf1655fb45f50e1c56da62ab01218c228807b21338d634ebcdf9d71cf46
+PKG_HASH:=e9baba7701a76a51f3d85a62c383a3c9dcd97fa900b859bc7db114c1868af8a8
 
 PKG_LICENSE:=BSD ISC
 PKG_LICENSE_FILES:=LICENCE


### PR DESCRIPTION
Maintainer: @tripolar
Compile tested: all architectures / master
Run tested: MIR4A / ramips / master

Server running and accepting connections
Client connecting to servers

Description:
Version bump to 9.3p1

Signed-off-by: Sibren Vasse <github@sibrenvasse.nl>