### PR TITLE
rpcsvc-proto: fix build with updated autotools

### DIFF
--- a/libs/rpcsvc-proto/Makefile
+++ b/libs/rpcsvc-proto/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rpcsvc-proto
 PKG_VERSION:=1.4.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/thkukuk/rpcsvc-proto/releases/download/v$(PKG_VERSION)
@@ -13,6 +13,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
 
 HOST_BUILD_DEPENDS:=gettext-full/host
 PKG_BUILD_DEPENDS:=rpcsvc-proto/host


### PR DESCRIPTION
After recent autotools update, rpcsvc-proto no longer compiles without autoreconf fixup because automake 1.15 is not found.

Maintainer: Rosen Penev / @neheb
Compile tested: x86_64, latest git
Run tested: x86_64, latest git

Description:
latest version of open-vm-tools 12.2.0 needs rpcgen provided by this package which did not build.
@neheb mentioned as maintainer as package does not have maintainer but has been doing merges for this.