### PR TITLE
golang: Update to 1.20.2, refresh patch

### DIFF
--- a/lang/golang/golang-compiler.mk
+++ b/lang/golang/golang-compiler.mk
@@ -76,8 +76,10 @@ define GoCompiler/Default/Install/Bin
 	$(INSTALL_BIN) -p "$(1)/bin/$(4)"/* "$(2)/lib/go-$(3)/bin/"
   endif
 
-	$(INSTALL_DIR) "$(2)/lib/go-$(3)/pkg"
-	$(CP) "$(1)/pkg/$(4)$(if $(5),_$(5))" "$(2)/lib/go-$(3)/pkg/"
+	if [ -d "$(1)/pkg/$(4)$(if $(5),_$(5))" ]; then \
+		$(INSTALL_DIR) "$(2)/lib/go-$(3)/pkg" ; \
+		$(CP) "$(1)/pkg/$(4)$(if $(5),_$(5))" "$(2)/lib/go-$(3)/pkg/" ; \
+	fi
 
 	$(INSTALL_DIR) "$(2)/lib/go-$(3)/pkg/tool/$(4)"
 	$(INSTALL_BIN) -p "$(1)/pkg/tool/$(4)"/* "$(2)/lib/go-$(3)/pkg/tool/$(4)/"

--- a/lang/golang/golang-values.mk
+++ b/lang/golang/golang-values.mk
@@ -65,6 +65,10 @@ unexport \
   GOPPC64 \
   GOWASM
 
+# Environment variables for use with code coverage:
+unexport \
+  GOCOVERDIR
+
 # Special-purpose environment variables:
 unexport \
   GCCGOTOOLDIR \
@@ -202,12 +206,11 @@ GO_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||mips||mips64||mips64el||mipsel||pow
 
 # ASLR/PIE
 
-# From https://go.dev/src/cmd/internal/sys/supported.go
+# From https://go.dev/src/internal/platform/supported.go
 GO_PIE_SUPPORTED_OS_ARCH:= \
   android_386  android_amd64  android_arm  android_arm64 \
   linux_386    linux_amd64    linux_arm    linux_arm64 \
-  \
-  windows_386  windows_amd64  windows_arm \
+  windows_386  windows_amd64  windows_arm  windows_arm64 \
   \
   darwin_amd64 darwin_arm64 \
   ios_amd64    ios_arm64 \
@@ -219,7 +222,7 @@ GO_PIE_SUPPORTED_OS_ARCH:= \
   linux_ppc64le linux_riscv64 linux_s390x
 
 # From https://go.dev/src/cmd/go/internal/work/init.go
-go_pie_install_suffix=$(if $(filter $(1),aix_ppc64 windows_386 windows_amd64 windows_arm),,shared)
+go_pie_install_suffix=$(if $(filter $(1),aix_ppc64 windows_386 windows_amd64 windows_arm windows_arm64),,shared)
 
 ifneq ($(filter $(GO_HOST_OS_ARCH),$(GO_PIE_SUPPORTED_OS_ARCH)),)
   GO_HOST_PIE_SUPPORTED:=1

--- a/lang/golang/golang/Makefile
+++ b/lang/golang/golang/Makefile
@@ -7,8 +7,8 @@
 
 include $(TOPDIR)/rules.mk
 
-GO_VERSION_MAJOR_MINOR:=1.19
-GO_VERSION_PATCH:=7
+GO_VERSION_MAJOR_MINOR:=1.20
+GO_VERSION_PATCH:=2
 
 PKG_NAME:=golang
 PKG_VERSION:=$(GO_VERSION_MAJOR_MINOR)$(if $(GO_VERSION_PATCH),.$(GO_VERSION_PATCH))
@@ -20,7 +20,7 @@ GO_SOURCE_URLS:=https://dl.google.com/go/ \
 
 PKG_SOURCE:=go$(PKG_VERSION).src.tar.gz
 PKG_SOURCE_URL:=$(GO_SOURCE_URLS)
-PKG_HASH:=775bdf285ceaba940da8a2fe20122500efd7a0b65dbcee85247854a8d7402633
+PKG_HASH:=4d0e2850d197b4ddad3bdb0196300179d095bb3aefd4dfbc3b36702c3728f8ab
 
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -63,6 +63,8 @@ HOST_GO_VALID_OS_ARCH:= \
   aix_ppc64 \
   js_wasm \
   \
+  freebsd_riscv64 \
+  \
   linux_ppc64 linux_ppc64le \
   linux_mips linux_mipsle linux_mips64 linux_mips64le \
   linux_loong64 linux_riscv64 linux_s390x \
@@ -86,6 +88,12 @@ BOOTSTRAP_GO_VALID_OS_ARCH:= \
                  solaris_amd64 \
   windows_386    windows_amd64
 
+BOOTSTRAP_1_17_SOURCE:=go1.17.13.src.tar.gz
+BOOTSTRAP_1_17_SOURCE_URL:=$(GO_SOURCE_URLS)
+BOOTSTRAP_1_17_HASH:=a1a48b23afb206f95e7bbaa9b898d965f90826f6f1d1fc0c1d784ada0cd300fd
+
+BOOTSTRAP_1_17_BUILD_DIR:=$(HOST_BUILD_DIR)/.go_bootstrap_1.17
+
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 include ../golang-compiler.mk
@@ -94,6 +102,7 @@ include ../golang-package.mk
 PKG_UNPACK:=$(HOST_TAR) -C "$(PKG_BUILD_DIR)" --strip-components=1 -xzf "$(DL_DIR)/$(PKG_SOURCE)"
 HOST_UNPACK:=$(HOST_TAR) -C "$(HOST_BUILD_DIR)" --strip-components=1 -xzf "$(DL_DIR)/$(PKG_SOURCE)"
 BOOTSTRAP_UNPACK:=$(HOST_TAR) -C "$(BOOTSTRAP_BUILD_DIR)" --strip-components=1 -xzf "$(DL_DIR)/$(BOOTSTRAP_SOURCE)"
+BOOTSTRAP_1_17_UNPACK:=$(HOST_TAR) -C "$(BOOTSTRAP_1_17_BUILD_DIR)" --strip-components=1 -xzf "$(DL_DIR)/$(BOOTSTRAP_1_17_SOURCE)"
 
 # don't strip ELF executables in test data
 RSTRIP:=:
@@ -181,13 +190,29 @@ ifeq ($(BOOTSTRAP_ROOT_DIR),)
   $(eval $(call Download,golang-bootstrap))
 
   define Bootstrap/Prepare
-	mkdir -p "$(BOOTSTRAP_BUILD_DIR)"
-	$(BOOTSTRAP_UNPACK)
+	mkdir -p "$(BOOTSTRAP_BUILD_DIR)" && $(BOOTSTRAP_UNPACK) ;
   endef
   Hooks/HostPrepare/Post+=Bootstrap/Prepare
 
   $(eval $(call GoCompiler/AddProfile,Bootstrap,$(BOOTSTRAP_BUILD_DIR),,bootstrap,$(GO_HOST_OS_ARCH)))
 endif
+
+
+# Bootstrap 1.17
+
+define Download/golang-bootstrap-1.17
+  FILE:=$(BOOTSTRAP_1_17_SOURCE)
+  URL:=$(BOOTSTRAP_1_17_SOURCE_URL)
+  HASH:=$(BOOTSTRAP_1_17_HASH)
+endef
+$(eval $(call Download,golang-bootstrap-1.17))
+
+define Bootstrap-1.17/Prepare
+	mkdir -p "$(BOOTSTRAP_1_17_BUILD_DIR)" && $(BOOTSTRAP_1_17_UNPACK) ;
+endef
+Hooks/HostPrepare/Post+=Bootstrap-1.17/Prepare
+
+$(eval $(call GoCompiler/AddProfile,Bootstrap-1.17,$(BOOTSTRAP_1_17_BUILD_DIR),,bootstrap-1.17,$(GO_HOST_OS_ARCH)))
 
 
 # Host
@@ -220,8 +245,13 @@ define Host/Compile
 		$(HOST_GO_VARS) \
 	)
 
-	$(call GoCompiler/Host/Make, \
+	$(call GoCompiler/Bootstrap-1.17/Make, \
 		GOROOT_BOOTSTRAP="$(BOOTSTRAP_ROOT_DIR)" \
+		$(HOST_GO_VARS) \
+	)
+
+	$(call GoCompiler/Host/Make, \
+		GOROOT_BOOTSTRAP="$(BOOTSTRAP_1_17_BUILD_DIR)" \
 		$(if $(HOST_GO_ENABLE_PIE),GO_LDFLAGS="-buildmode pie") \
 		$(HOST_GO_VARS) \
 	)

--- a/lang/golang/golang/patches/001-cmd-link-use-gold-on-ARM-ARM64-only-if-gold-is-available.patch
+++ b/lang/golang/golang/patches/001-cmd-link-use-gold-on-ARM-ARM64-only-if-gold-is-available.patch
@@ -13,7 +13,7 @@ Fixes #22040.
 
 --- a/src/cmd/link/internal/ld/lib.go
 +++ b/src/cmd/link/internal/ld/lib.go
-@@ -1502,25 +1502,20 @@ func (ctxt *Link) hostlink() {
+@@ -1535,25 +1535,20 @@ func (ctxt *Link) hostlink() {
  		}
  
  		if ctxt.Arch.InFamily(sys.ARM, sys.ARM64) && buildcfg.GOOS == "linux" {


### PR DESCRIPTION
Maintainer: me
Compile tested: armvirt-32, 2023-03-13 snapshot sdk; armvirt-64/malta-be, 2023-03-05 snapshot sdk
Run tested: armvirt-32, 2023-03-13 snapshot; armvirt-64/malta-be, 2023-03-05 snapshot

Description:
Includes fixes for:

* 1.20.1:
  * CVE-2022-41722: path/filepath: path traversal in filepath.Clean on Windows
  * CVE-2022-41723: net/http: avoid quadratic complexity in HPACK decoding
  * CVE-2022-41724: crypto/tls: large handshake records may cause panics
  * CVE-2022-41725: net/http, mime/multipart: denial of service from excessive resource consumption

* 1.20.2:
  * CVE-2023-24532: crypto/elliptic: specific unreduced P-256 scalars produce incorrect results