### PR TITLE
tor: Add CONFLICTS for tor-basic

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
 PKG_VERSION:=0.4.7.13
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
@@ -61,6 +61,7 @@ endef
 define Package/tor-basic
 $(call Package/tor/Default)
   TITLE+= (no bridge/relay support)
+  CONFLICTS:=tor
   VARIANT:=basic
 endef
 


### PR DESCRIPTION
Maintainer: @hauke, @tripolar 
Compile tested: armvirt-32, 2023-03-19 snapshot sdk
Run tested: armvirt-32, 2023-03-19 snapshot

Description:
Currently, trying to install tor-basic while tor is installed results in data file clashes errors (for /etc/init.d/tor and /usr/sbin/tor).

This sets `CONFLICTS` for tor-basic so that proper package conflict checking takes place instead.