### PR TITLE
CI: Add --autoremove, ignore removal errors

### DIFF
--- a/.github/workflows/entrypoint.sh
+++ b/.github/workflows/entrypoint.sh
@@ -39,5 +39,5 @@ for PKG in /ci/*.ipk; do
 		echo "No test.sh script available"
 	fi
 
-	opkg remove "$PKG_NAME" --force-removal-of-dependent-packages --force-remove
+	opkg remove "$PKG_NAME" --force-removal-of-dependent-packages --force-remove --autoremove || true
 done


### PR DESCRIPTION
Maintainer: @aparcar (ping @neheb, @BKPepe)
Compile tested: N/A
Run tested: N/A

Description:
836b4e1c734f9705bfd8db0da0c04214c2647932 added `--force-removal-of-dependent-packages` but it does not do what the commit message says it does.

When package A depends on package B (package B is a dependency of package A; package A is a dependent of package B), trying to remove package B while package A is installed will result in an error. Adding `--force-removal-of-dependent-packages` in this case will cause the removal of package B and package A (package B's dependent).

But in the case of the CI testing step, it is package A that is being installed and removed. Removing package A with
`--force-removal-of-dependent-packages` will not cause package B (package A's dependency) to be removed.

This adds `--autoremove` to actually remove the package's dependencies.

This also ignores any errors returned by `opkg remove` as `--autoremove` can sometimes [falsely return an error][1].
    
[1]: https://github.com/openwrt/openwrt/issues/12241

Fixes: 836b4e1c734f ("github-ci: add --force-removal-of-dependent-packages")