### PR TITLE
Samba4:  Update to version 4.18.0

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.17.5
+PKG_VERSION:=4.18.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -13,7 +13,7 @@ PKG_SOURCE_URL:= \
 		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
-PKG_HASH:=ebb7880d474ffc09d73b5fc77bcbd657f6235910337331a9c24d7f69ca11442b
+PKG_HASH:=70348656ef807be9c8be4465ca157cef4d99818e234253d2c684cc18b8408149
 
 PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILES:=COPYING

--- a/net/samba4/patches/009-samba-4-11-fix-host-tools-checks.patch.patch
+++ b/net/samba4/patches/009-samba-4-11-fix-host-tools-checks.patch.patch
@@ -15,30 +15,3 @@
 +
 +check_system_heimdal_binary("compile_et")
 +check_system_heimdal_binary("asn1_compile")
---- a/wscript_configure_system_heimdal
-+++ b/wscript_configure_system_heimdal
-@@ -37,14 +37,6 @@ def check_system_heimdal_lib(name, funct
-     conf.define('USING_SYSTEM_%s' % name.upper(), 1)
-     return True
- 
--def check_system_heimdal_binary(name):
--    if conf.LIB_MAY_BE_BUNDLED(name):
--        return False
--    if not conf.find_program(name, var=name.upper()):
--        return False
--    conf.define('USING_SYSTEM_%s' % name.upper(), 1)
--    return True
--
- check_system_heimdal_lib("com_err", "com_right_r com_err", "com_err.h")
- 
- if check_system_heimdal_lib("roken", "rk_socket_set_reuseaddr", "roken.h"):
-@@ -86,9 +78,6 @@ finally:
- #if conf.CHECK_BUNDLED_SYSTEM('tommath', checkfunctions='mp_init', headers='tommath.h'):
- #    conf.define('USING_SYSTEM_TOMMATH', 1)
- 
--check_system_heimdal_binary("compile_et")
--check_system_heimdal_binary("asn1_compile")
--
- conf.env.KRB5_VENDOR = 'heimdal'
- conf.define('USING_SYSTEM_KRB5', 1)
- conf.define('USING_SYSTEM_HEIMDAL', 1)

--- a/net/samba4/patches/021-source4-msgsock-nvram-fix.patch
+++ b/net/samba4/patches/021-source4-msgsock-nvram-fix.patch
@@ -1,6 +1,6 @@
 --- a/source4/lib/messaging/messaging.c
 +++ b/source4/lib/messaging/messaging.c
-@@ -525,7 +525,7 @@ static struct imessaging_context *imessa
+@@ -526,7 +526,7 @@ static struct imessaging_context *imessa
  		goto fail;
  	}
  

--- a/net/samba4/patches/102-samba-4.11-unbundle-libbsd.patch
+++ b/net/samba4/patches/102-samba-4.11-unbundle-libbsd.patch
@@ -1,6 +1,6 @@
 --- a/lib/replace/wscript
 +++ b/lib/replace/wscript
-@@ -436,22 +436,13 @@ def configure(conf):
+@@ -434,22 +434,13 @@ def configure(conf):
  
      conf.CHECK_FUNCS('prctl dirname basename')
  
@@ -29,7 +29,7 @@
  
      conf.CHECK_CODE('''
                  struct ucred cred;
-@@ -834,9 +825,6 @@ syscall(SYS_copy_file_range,0,NULL,0,NUL
+@@ -832,9 +823,6 @@ syscall(SYS_copy_file_range,0,NULL,0,NUL
  
      # look for a method of finding the list of network interfaces
      for method in ['HAVE_IFACE_GETIFADDRS', 'HAVE_IFACE_AIX', 'HAVE_IFACE_IFCONF', 'HAVE_IFACE_IFREQ']:
@@ -39,7 +39,7 @@
          if conf.CHECK_CODE('''
                             #define %s 1
                             #define NO_CONFIG_H 1
-@@ -849,7 +837,7 @@ syscall(SYS_copy_file_range,0,NULL,0,NUL
+@@ -847,7 +835,7 @@ syscall(SYS_copy_file_range,0,NULL,0,NUL
                             #include "tests/getifaddrs.c"
                             ''' % method,
                             method,
@@ -48,7 +48,7 @@
                             addmain=False,
                             execute=True):
              break
-@@ -897,7 +885,6 @@ def build(bld):
+@@ -895,7 +883,6 @@ def build(bld):
                  break
  
      extra_libs = ''


### PR DESCRIPTION
Maintainer: nobody
Compile tested: Mediatek mt7622, Totolink A8000RU
Run tested:

Description: Update the Samba package to version 4.18.0

Samba release history: https://www.samba.org/samba/history/samba-4.18.0.html


