### PR TITLE
collectd: Fix ltq-dsl compilation errors

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -528,4 +528,4 @@ $(eval $(call BuildPlugin,write-graphite,Carbon/Graphite output,write_graphite,+
 $(eval $(call BuildPlugin,write-http,HTTP POST output,write_http,+PACKAGE_collectd-mod-write-http:libcurl))
 
 $(eval $(call BuildScriptPlugin,sqm,SQM/qdisc collection,sqm_collectd,+PACKAGE_collectd-mod-sqm:collectd-mod-exec))
-$(eval $(call BuildScriptLuaPlugin,ltq-dsl,Lantiq DSL collection,dsl,ltq-dsl-app +PACKAGE_collectd-mod-ltq-dsl:collectd-mod-lua +libubus-lua))
+$(eval $(call BuildScriptLuaPlugin,ltq-dsl,Lantiq DSL collection,dsl,@ltq-dsl-app +PACKAGE_collectd-mod-ltq-dsl:collectd-mod-lua +libubus-lua))


### PR DESCRIPTION
Description:

Per

https://github.com/openwrt/packages/pull/19396#issuecomment-1480780893

prefix ltq-dsl-app with a @ character to fix the compilation issues witnessed in PR #19396 and #20662

Compile tested: x86_64, git master
Run tested: No