### PR TITLE
Update cache-domains

### DIFF
--- a/utils/cache-domains/files/cache-domains
+++ b/utils/cache-domains/files/cache-domains
@@ -20,7 +20,7 @@ dnsmasq_conf() {
 
 		case ${1} in
 			add)
-				ln -sf "${CACHE_DOMAINS_CONF_FILE}" "${DNSMASQ_CONF_FILE}"
+				ln -f "${CACHE_DOMAINS_CONF_FILE}" "${DNSMASQ_CONF_FILE}"
 				;;
 			remove)
 				rm -f "${DNSMASQ_CONF_FILE}"


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: N/A
Run tested: ramips/mt7621 glinet_gl-mt1300 22.03.3

Description:
dnsmasq refuses to start with a file does not exist error if the configuration file(s) supplied to it is/are a symlink. Changing the script to make it a hardlink works around the problem. It is unclear why dnsmasq no longer is willing to accept/follow a symlink, as this did work correctly in previous openwrt releases. However, changing this to a hardlink (while hacky) is an immediate resolution, vs. tracking down the dnsmasq issue.