### PR TITLE
netbird: update to 0.14.5

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.14.4
+PKG_VERSION:=0.14.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=7cfad70cd0fecc2d0f7bf68a03efe05e5f6e1a3627998169dc07b7c9f8e3b8d2
+PKG_HASH:=2ea6be9c50a5ac241fbae35934c9c710697de39e8a0393f8e1800285a7904d0d
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Release Notes

Management

 - Introduce a new ACL engine based on Rego (Open Policy Agent) for firewall control
 - Personal access tokens generation as a first iteration toward public API release
 - Add Keycloak support as an IDP manager

Agent

 - Introduce a Firewall interface to apply granular access control (e.g., connection direction, port, or protocol level)
 - Make the agent run on Android (mobile support)

Changelog

 - Feat rego default policy
 - Don't drop Rules from file storage after migration to Policies
 - Add version info command to signal server
 - Feat firewall controller interface
 - Adding Personal Access Token generation
 - Exchange proxy mode via signal
 - Fix connstate indication
 - Mobile
 - PAT persistence
 - Add Keycloak Idp Manager
 - Adjustments for the change server flow
 - Disable peer expiration of peers added with setup keys
 - Add JWT middleware validation failure log

Maintainer: me / @oskarirauta
Compile tested: x86_64, latest git
Run tested: x86_64, latest git