### PR TITLE
curl: update to 8.0.1

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -9,15 +9,15 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
-PKG_VERSION:=7.88.1
-PKG_RELEASE:=2
+PKG_VERSION:=8.0.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \
 	https://dl.uxnr.de/mirror/curl/ \
 	https://curl.askapache.com/download/ \
 	https://curl.se/download/
-PKG_HASH:=1dae31b2a7c1fe269de99c0c31bb488346aab3459b5ffca909d6938249ae415f
+PKG_HASH:=0a381cd82f4d00a9a334438b8ca239afea5bfefcfa9a1025f2bf118e79e0b5f0
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: me
Compile tested: x86-64, Sophos XG-135r3, OpenWrt 22.03.3
Run tested: x86-64, Sophos XG-135r3, OpenWrt 22.03.3, test functionality with `https-dns-proxy`

Description:
* https://curl.se/changes.html#8_0_1
