### PR TITLE
Created utils/random-numgen package, an alternative to $RANDOM

### DIFF
--- a/utils/random-numgen/Makefile
+++ b/utils/random-numgen/Makefile
@@ -1,0 +1,39 @@
+# This is free software, licensed under the GNU General Public License v3.
+# See /LICENSES for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=random-numgen
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Ilario Gelmetti <ilario@sindominio.net>
+PKG_LICENSE:=GPL-3.0-or-later
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/random-numgen
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Generates a random number 0-65535
+endef
+
+define Package/random-numgen/description
+  Offers an alternative to the RANDOM shell variable,
+  generating a pseudo-random integer number from 0 to
+  65535 using /dev/urandom as a random data source.
+endef
+
+define Build/Compile
+endef
+
+define Build/Configure
+endef
+
+define Package/random-numgen/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) ./files/random-numgen $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,random-numgen))

--- a/utils/random-numgen/files/random-numgen
+++ b/utils/random-numgen/files/random-numgen
@@ -1,0 +1,7 @@
+#!/bin/sh
+#
+# Offers an alternative to the $RANDOM shell variable,
+# generating a pseudo-random integer number from 0 to
+# 32767 using /dev/urandom as a random data source.
+
+echo $(( $(hexdump -n 2 -e '"%u"' /dev/urandom) >> 1 ))


### PR DESCRIPTION
Maintainer: me / @ilario
Compile tested: OpenWrt 22.03 and OpenWrt 19.07, YouHua WR1200JS
Run tested: OpenWrt 22.03 and OpenWrt 19.07, YouHua WR1200JS

Description: 
By default, the `$RANDOM` shell variable is not available as Busybox does not have the `BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT` option activated.
This command gives an equivalent output, an integer from 0 to 65535.
Originally, we decided we needed such a command in LibreMesh to replace the usage of `$RANDOM`, as discussed here https://github.com/libremesh/lime-packages/issues/800 and here https://github.com/libremesh/lime-packages/pull/980.

I would be nice to have this also in the openwrt-22.03 branch.