### PR TITLE
isc-dhcp: Update to 4.4.3-P1

### DIFF
--- a/net/isc-dhcp/Makefile
+++ b/net/isc-dhcp/Makefile
@@ -9,8 +9,8 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=isc-dhcp
 UPSTREAM_NAME:=dhcp
-PKG_VERSION:=4.4.3
-PKG_RELEASE:=8
+PKG_VERSION:=4.4.3-P1
+PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -21,7 +21,7 @@ PKG_SOURCE:=$(UPSTREAM_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://ftp.isc.org/isc/dhcp/$(PKG_VERSION) \
 		http://ftp.funet.fi/pub/mirrors/ftp.isc.org/isc/dhcp/$(PKG_VERSION) \
 		http://ftp.iij.ad.jp/pub/network/isc/dhcp/$(PKG_VERSION)
-PKG_HASH:=0e3ec6b4c2a05ec0148874bcd999a66d05518378d77421f607fb0bc9d0135818
+PKG_HASH:=0ac416bb55997ca8632174fd10737fd61cdb8dba2752160a335775bc21dc73c7
 
 PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1

--- a/net/isc-dhcp/Makefile
+++ b/net/isc-dhcp/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=isc-dhcp
 UPSTREAM_NAME:=dhcp
 PKG_VERSION:=4.4.3
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -132,33 +132,15 @@ $(call Package/isc-dhcp-server/description)
  This package is compiled with IPv4 and IPv6 support.
 endef
 
-define Package/isc-dhcp-dyndns-ipv4
+define Package/isc-dhcp-dyndns
   $(call Package/isc-dhcp/Default)
   TITLE+= server dynamic DNS dependencies (meta)
-  DEPENDS+=isc-dhcp-server-ipv4 +bind-server +bind-client
-  VARIANT:=ipv4
-endef
-
-define Package/isc-dhcp-dyndns-ipv6
-  $(call Package/isc-dhcp/Default)
-  TITLE+= server dynamic DNS dependencies (meta)
-  DEPENDS+=isc-dhcp-server-ipv6 +bind-server +bind-client
-  VARIANT:=ipv6
+  DEPENDS+=@(PACKAGE_isc-dhcp-server-ipv4||PACKAGE_isc-dhcp-server-ipv6) +bind-server +bind-client
 endef
 
 define Package/isc-dhcp-dyndns/description
  implements the Dynamic Host Configuration Protocol (DHCP) and the Internet
  Bootstrap Protocol (BOOTP).
-endef
-
-define Package/isc-dhcp-dyndns-ipv4/description
-$(call Package/isc-dhcp-dyndns/description)
- This package is compiled with IPv4 support only.
-endef
-
-define Package/isc-dhcp-dyndns-ipv6/description
-$(call Package/isc-dhcp-dyndns/description)
- This package is compiled with IPv4 and IPv6 support.
 endef
 
 define Package/isc-dhcp-omshell-ipv4
@@ -257,7 +239,7 @@ define Package/isc-dhcp-server-ipv6/conffiles
 /etc/dhcpd6.conf
 endef
 
-define Package/isc-dhcp-dyndns-$(BUILD_VARIANT)/install
+define Package/isc-dhcp-dyndns/install
 	:
 endef
 
@@ -285,11 +267,10 @@ endef
 
 $(eval $(call BuildPackage,isc-dhcp-relay-ipv4))
 $(eval $(call BuildPackage,isc-dhcp-server-ipv4))
-$(eval $(call BuildPackage,isc-dhcp-dyndns-ipv4))
+$(eval $(call BuildPackage,isc-dhcp-dyndns))
 $(eval $(call BuildPackage,isc-dhcp-client-ipv4))
 $(eval $(call BuildPackage,isc-dhcp-omshell-ipv4))
 $(eval $(call BuildPackage,isc-dhcp-relay-ipv6))
 $(eval $(call BuildPackage,isc-dhcp-server-ipv6))
-$(eval $(call BuildPackage,isc-dhcp-dyndns-ipv6))
 $(eval $(call BuildPackage,isc-dhcp-client-ipv6))
 $(eval $(call BuildPackage,isc-dhcp-omshell-ipv6))


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, generic, HEAD (c98e09f01b)
Run tested: same, deployed on production router

Description:

Fixes CVE-2022-2928 and CVE-2022-2929