### PR TITLE
sing-box: update to 1.2.1

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.2.0
+PKG_VERSION:=1.2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=ec70c2eecf85788e82c29ec4ca129e25292d5fc66a510b4b713fe337650740a9
+PKG_HASH:=0f304b75c2e9f61e3f7808f23fe8fbe08161553475d9bec0dea4a5acf4452d2d
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: me
Compile tested: (x86_64, OpenWrt snapshot)
Run tested: (x86_64, OpenWrt snapshot, tests done)

Description:
Bug fixes. Refer to https://github.com/SagerNet/sing-box/releases/tag/v1.2.1.