### PR TITLE
Add gstreamer SRT streaming support

### DIFF
--- a/libs/libsrt/Config.in
+++ b/libs/libsrt/Config.in
@@ -1,0 +1,5 @@
+# libsrt config
+config LIBSRT_OPENSSL_SUPPORT
+	bool "Add openssl support"
+	depends on PACKAGE_libsrt
+	default n

--- a/libs/libsrt/Makefile
+++ b/libs/libsrt/Makefile
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2023 Koen Vandeputte <koen.vandeputte@citymesh.com>
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libsrt
+PKG_VERSION:=1.5.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/haivision/srt/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=af891e7a7ffab61aa76b296982038b3159da690f69ade7c119f445d924b3cf53
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Koen Vandeputte <koen.vandeputte@citymesh.com>
+PKG_LICENSE:=MPL-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_PACKAGE_libopenssl \
+	CONFIG_PACKAGE_libstdcpp \
+	CONFIG_PACKAGE_libatomic
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+CRYPTO_DEPENDS:=
+
+CMAKE_OPTIONS += \
+	-DENABLE_MONOTONIC_CLOCK=ON \
+	-DENABLE_APPS=OFF \
+	-DENABLE_STATIC=OFF \
+	-DENABLE_STDCXX_SYNC=OFF \
+	-DENABLE_ENCRYPTION=OFF
+
+define Package/libsrt
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=secure reliable transport
+  URL:=https://github.com/Haivision/srt
+  DEPENDS:=+libstdcpp +libatomic +LIBSRT_OPENSSL_SUPPORT:libopenssl
+endef
+
+define Package/libsrt/description
+ This package contains a library for srt streaming.
+endef
+
+define Package/libsrt/config
+	source "$(SOURCE)/Config.in"
+endef
+
+ifdef CONFIG_LIBSRT_OPENSSL_SUPPORT
+	CMAKE_OPTIONS += -DENABLE_ENCRYPTION=ON
+endif
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/srt.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libsrt/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsrt.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libsrt))

--- a/multimedia/gst1-plugins-bad/Makefile
+++ b/multimedia/gst1-plugins-bad/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-bad
 PKG_VERSION:=1.20.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=gst-plugins-bad-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gst-plugins-bad/
@@ -228,7 +228,7 @@ MESON_ARGS += \
 	$(call GST_COND_SELECT,sndfile) \
 	-Dsoundtouch=disabled \
 	-Dspandsp=disabled \
-	-Dsrt=disabled \
+	$(call GST_COND_SELECT,srt) \
 	-Dsrtp=disabled \
 	-Dteletext=disabled \
 	-Dtinyalsa=disabled \
@@ -415,6 +415,7 @@ $(eval $(call GstBuildPlugin,opusparse,OPUS streams library,pbutils,,+libopus))
 $(eval $(call GstBuildPlugin,sbc,sbc support,audio,,+sbc))
 $(eval $(call GstBuildPlugin,shm,POSIX shared memory source and sink,,,+librt))
 $(eval $(call GstBuildPlugin,sndfile,sndfile support,audio,,+libsndfile))
+$(eval $(call GstBuildPlugin,srt,srt support,,,+libsrt))
 #$(eval $(call GstBuildPlugin,srtp,srtp support,rtp,,+libsrtp))
 $(eval $(call GstBuildPlugin,webp,webp support,,,+libwebp))
 #$(eval $(call GstBuildPlugin,yadif,yadif support,,,))


### PR DESCRIPTION
Maintainer: me / @thess 
Compile tested: imx6 - master
Run tested: imx6 - master

Description:

Adds support for SRT streaming within gstreamer
Compile/runtime tested with both encryption enabled/disabled