### PR TITLE
dovecot: Fix iconv macro is missing compile error

### DIFF
--- a/mail/dovecot/Makefile
+++ b/mail/dovecot/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dovecot
 PKG_VERSION:=2.3.18
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dovecot.org/releases/2.3
@@ -36,6 +36,9 @@ include $(INCLUDE_DIR)/package.mk
 # iconv is needed when compiling with MySQL support. iconv will also be used by
 # dovecot itself.
 include $(INCLUDE_DIR)/nls.mk
+
+# need iconv.m4, otherwise error during autoreconf
+PKG_BUILD_DEPENDS:=gettext-full
 
 define Package/dovecot
   SECTION:=mail


### PR DESCRIPTION
Issue https://github.com/openwrt/packages/issues/20677 Solved by micmac1 https://github.com/openwrt/packages/issues/20677#issuecomment-1483774965 

Maintainer: Lucian Cristian,lucian.cristian@gmail.com<@lucize>
Compile tested: (Ubuntu 22.04 ramips r22400-1558bbd116)
Run tested: (ramips r22400-1558bbd116 mt7621, autorun on startup)

Description:
compile with imagebuilder master with no other packages than dovecot for arch ramips. does not build.

Looking at the provided logs autoreconf fails because the iconv macro is missing (iconv.m4). If I remember correctly the macro was provided earlier by libiconv package, but that's no longer the case.