### PR TITLE
ntfs3: new package

### DIFF
--- a/utils/ntfs3-mount/Makefile
+++ b/utils/ntfs3-mount/Makefile
@@ -1,0 +1,28 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ntfs3-mount
+PKG_RELEASE:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ntfs3-mount
+	SECTION:=utils
+	CATEGORY:=Utilities
+	SUBMENU:=Filesystem
+	TITLE:=NTFS mount script for NTFS read & write driver
+	PKGARCH:=all
+	DEPENDS:=+kmod-fs-ntfs3
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/ntfs3-mount/install
+	$(INSTALL_DIR) $(1)/sbin
+	$(INSTALL_BIN) ./files/mount.ntfs $(1)/sbin
+endef
+
+$(eval $(call BuildPackage,ntfs3-mount))

--- a/utils/ntfs3-mount/files/mount.ntfs
+++ b/utils/ntfs3-mount/files/mount.ntfs
@@ -1,0 +1,2 @@
+#!/bin/sh
+mount -t ntfs3 "$@"


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64
Run tested: ramips/mt7621, Newifi-D2, OpenWrt 22.03.2 r19803-9a599fee93

Description:

For `block-mount` to work with `ntfs3` driver, a helper is needed.

Other fork already has such package. See
https://github.com/coolsnowwolf/lede/blob/9b338b/package/lean/ntfs3-mount/Makefile

The source is modified from the dropped `antfs-mount` package.

