### PR TITLE
rust: update to 1.68.1

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
-PKG_VERSION:=1.68.0
+PKG_VERSION:=1.68.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
-PKG_HASH:=eaf4d8b19f23a232a4770fb53ab5e7acdedec11da1d02b0e5d491ca92ca96d62
+PKG_HASH:=ccb051df5701d4c588e3d0558f83e73e7eea0a9b165dab3e39dd2db8a6a25d03
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>

--- a/lang/rust/rust-package.mk
+++ b/lang/rust/rust-package.mk
@@ -27,7 +27,8 @@ define Build/Compile/Cargo
 		CARGO_HOME=$(CARGO_HOME) \
 		TARGET_CFLAGS="$(TARGET_CFLAGS) $(RUST_CFLAGS)" \
 		TARGET_CC=$(TARGET_CC_NOCACHE) \
-		CC=$(HOSTCC) \
+		CC=$(HOSTCC_NOCACHE) \
+		$(CARGO_VARS) \
 		cargo install -v \
 			--profile stripped \
 			--target $(RUSTC_TARGET_ARCH) \

--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -6,6 +6,7 @@
 CONFIG_HOST_SUFFIX:=$(word 4, $(subst -, ,$(GNU_HOST_NAME)))
 RUSTC_HOST_ARCH:=$(HOST_ARCH)-unknown-linux-$(CONFIG_HOST_SUFFIX)
 CARGO_HOME:=$(STAGING_DIR_HOSTPKG)/cargo
+CARGO_VARS:=
 
 ifeq ($(CONFIG_USE_MUSL),y)
 # Force linking of the SSP library for musl


### PR DESCRIPTION
also add new variable CARGO_VARS to make it possible to pass environment variables for cargo process.
This is necessary when for example, cross-compiling netavark.

Maintainer: Luca Barbato / @lu-zero 
Compile tested: x86_64, recent git
Run tested: x86_64, recent git

Description:
example of CARGO_VARS usage is available [here](https://github.com/oskarirauta/openwrt-rust/blob/main/net/netavark/Makefile) -  netavark requires pointing protoc binary to it (staging_dir/hostpkg/bin/protoc) as environment value PROTOC.
