### PR TITLE
respondd: add new package

### DIFF
--- a/net/respondd/Makefile
+++ b/net/respondd/Makefile
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2023 David Bauer <mail@david-bauer.net>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=respondd
+PKG_SOURCE_DATE:=2019-05-01
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/freifunk-gluon/respondd.git
+PKG_SOURCE_VERSION:=58405297e76f97d4752dc7511dc15bbc7a01e586
+PKG_MIRROR_HASH:=22bc00df280fe611cfc895528f17269f03af804ea4c2ca2dc62da2457d3a1ee0
+
+PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
+PKG_LICENSE:=BSD-2-Clause
+
+CMAKE_SOURCE_SUBDIR:=src
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/respondd
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=@IPV6 +libjson-c
+  TITLE:=Lightweight metadata multicast-responder
+endef
+
+define Package/respondd/description
+respondd is a server distributing information within a network.
+
+For doing so, respondd spawns a UDP socket (in Gluon 1001/udp),
+optionally joining a multicast group. When a request is received,
+the information requested is transmitted to the requester.
+
+All information is organized in a non-hierarchical namespace.
+Each entry identifies a request name (e.g. statistics, nodeinfo, ...)
+implemented by at least one "provider" C module. The respond is the
+result of merging the outputs of all providers for the given request
+name.
+endef
+
+define Package/respondd/conffiles
+/etc/config/respondd
+endef
+
+define Package/respondd/install
+	$(INSTALL_DIR) $(1)/usr/bin $(1)/etc/init.d $(1)/etc/config
+	$(INSTALL_CONF) ./files/respondd.config $(1)/etc/config/respondd
+	$(INSTALL_BIN) ./files/respondd.init $(1)/etc/init.d/respondd
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/respondd $(1)/usr/bin/
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/src/respondd.h $(1)/usr/include/
+endef
+
+$(eval $(call BuildPackage,respondd))

--- a/net/respondd/files/respondd.config
+++ b/net/respondd/files/respondd.config
@@ -1,0 +1,8 @@
+config daemon daemon
+	option port '1001'
+	option providers '/lib/respondd'
+
+config multicast-group lan
+	option group 'ff02::1'
+	option disabled '1'
+	list interface 'br-lan'

--- a/net/respondd/files/respondd.init
+++ b/net/respondd/files/respondd.init
@@ -1,0 +1,56 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+
+USE_PROCD=1
+PROG=/usr/bin/respondd
+NAME=respondd
+
+
+multicast_group()
+{
+	config_get group "$1" group
+	config_get interfaces "$1" interface
+	config_get disabled "$1" disabled 0
+
+	if [ "$disabled" -gt "0" ]; then
+		return
+	fi
+
+	procd_append_param command -g $group
+	for iface in "$interfaces"; do
+		procd_append_param command -i "$iface"
+	done
+}
+
+daemon_settings()
+{
+	config_get port "$1" port
+	config_get providers "$1" providers
+
+	procd_append_param command -p "$port"
+	procd_append_param command -d "$providers"
+}
+
+start_service()
+{
+	. /lib/functions.sh
+	. /lib/functions/network.sh
+
+	procd_open_instance
+	procd_set_param command "$PROG"
+
+	config_load respondd
+	config_foreach daemon_settings daemon
+	config_foreach multicast_group multicast-group
+
+	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+service_triggers()
+{
+	procd_add_config_trigger "config.change" "respondd" /etc/init.d/respondd reload
+	procd_add_interface_trigger "interface.*" 2000 /etc/init.d/respondd reload
+}


### PR DESCRIPTION
Maintainer: me
Compile tested: mpc85xx-p1020 / mediatek-filogic
Run tested: Extreme WS-AP3825 / ASUS TUF-AX4200
Description:

respondd is a server distributing information within a network.

For doing so, respondd spawns a UDP socket (in Gluon 1001/udp), optionally joining a multicast group. When a request is received, the information requested is transmitted to the requester.

All information is organized in a non-hierarchical namespace. Each entry identifies a request name (e.g. statistics, nodeinfo, ...) implemented by at least one "provider" C module. The respond is the result of merging the outputs of all providers for the given request name.