### PR TITLE
afalg_engine, gost_engine: adjust to new openssl module infrastructure

### DIFF
--- a/libs/afalg_engine/Config.in
+++ b/libs/afalg_engine/Config.in
@@ -9,19 +9,6 @@ if PACKAGE_libopenssl-afalg_sync
 	    This increases memory usage, and has problems when process fork
 	    with open digest contexts (openssh will not work because of it).
 
-    config AFALG_FALLBACK
-	bool "Enable software fallback feature"
-	default y
-	help
-	    Use software to fulfill small requests.  Using AF_ALG adds latency,
-	    which makes it slow to perform small requests.  Enabling this
-	    option overcomes this problem, at the cost of increased memory
-	    and CPU usage.  This is a new, experimental feature; if you
-	    encounter any problem, this is the first option to disable.
-	    The fallback will fail if you enable this engine alongside
-	    devcrypto, so you'll not be able to install both at the same
-	    time if this option is enabled.
-
     config AFALG_UPDATE_CTR_IV
 	bool "Don't rely on kernel to update CTR IV"
 	default y

--- a/libs/afalg_engine/Makefile
+++ b/libs/afalg_engine/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=afalg_engine
 PKG_VERSION:=1.2.0-beta.1
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/cotequeiroz/afalg_engine/archive/v$(PKG_VERSION)
@@ -25,7 +25,7 @@ PKG_CONFIG_DEPENDS:= \
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
-include $(INCLUDE_DIR)/openssl-engine.mk
+include $(INCLUDE_DIR)/openssl-module.mk
 
 $(eval $(call Package/openssl/add-engine,afalg,libopenssl-afalg_sync))
 define Package/libopenssl-afalg_sync
@@ -33,7 +33,7 @@ define Package/libopenssl-afalg_sync
     TITLE:=AF_ALG engine using sync crypto API
     URL:=https://github.com/cotequeiroz/afalg_engine
     DEPENDS += @!OPENSSL_ENGINE_BUILTIN_AFALG +kmod-crypto-user
-    CONFLICTS:=libopenssl-afalg $(if $(CONFIG_AFALG_FALLBACK),libopenssl-devcrypto)
+    CONFLICTS:=libopenssl-afalg
     MENU:=1
 endef
 
@@ -54,7 +54,6 @@ endef
 CMAKE_OPTIONS += \
 	-DOPENSSL_ENGINES_DIR=/usr/lib/$(ENGINES_DIR) \
 	-DDIGESTS=$(if $(CONFIG_AFALG_DIGESTS),ON,OFF) \
-	-DFALLBACK=$(if $(CONFIG_AFALG_FALLBACK),ON,OFF) \
 	-DUPDATE_CTR_IV=$(if $(CONFIG_AFALG_UPDATE_CTR_IV),ON,OFF) \
 	-DUSE_ZERO_COPY=$(if $(CONFIG_AFALG_ZERO_COPY),ON,OFF)
 

--- a/libs/afalg_engine/files/afalg.cnf
+++ b/libs/afalg_engine/files/afalg.cnf
@@ -1,4 +1,4 @@
-[afalg]
+[afalg_sect]
 # Leave this alone and configure algorithms with CIPERS/DIGESTS below
 default_algorithms = ALL
 

--- a/libs/gost_engine/Makefile
+++ b/libs/gost_engine/Makefile
@@ -1,19 +1,12 @@
 include $(TOPDIR)/rules.mk
-include $(INCLUDE_DIR)/openssl-engine.mk
+include $(INCLUDE_DIR)/openssl-module.mk
 
 PKG_NAME:=gost_engine
-ifeq ($(ENGINES_DIR),engines-1.1)
-  PKG_VERSION:=1.1.0.3
-  PKG_HASH:=fff725052e82c9adb5b738729b30141f61ac91fa457a4f4b5de18b8b24092f75
-  PKG_LICENSE:=OpenSSL
-  PATCH_DIR=./patches-1.1
-else
-  PKG_VERSION:=3.0.1
-  PKG_HASH:=bfeac85883724cfbe0ecc6d942ac0524b908143e019ab3d3b6abe47a3466a628
-  PKG_LICENSE:=Apache-2.0
-  PATCH_DIR=./patches-3
-endif
-PKG_RELEASE:=7
+PKG_VERSION:=3.0.1
+PKG_HASH:=bfeac85883724cfbe0ecc6d942ac0524b908143e019ab3d3b6abe47a3466a628
+PKG_LICENSE:=Apache-2.0
+PATCH_DIR=./patches-3
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/gost-engine/engine/archive/v$(PKG_VERSION)

--- a/libs/gost_engine/files/gost.cnf
+++ b/libs/gost_engine/files/gost.cnf
@@ -1,4 +1,4 @@
-[gost]
+[gost_sect]
 default_algorithms = ALL
 # CRYPT_PARAMS: OID of default GOST 28147-89 parameters It allows the
 # user to choose between different parameter sets of symmetric cipher


### PR DESCRIPTION
Maintainer: me
Compile tested: mediatek/mt7622, Linksys E8450, master
Run tested: same, tested with openssl cmdline util

Description:
This should be merged after https://github.com/openwrt/openwrt/pull/12151.
The package include file was renamed from `openssl-engine.mk` to `openssl-module.mk`.  Also, the name of the config section for the engine is now the name of the engine with `_sect` appended.

This removes the hack to build different versions of gost_engine depending on the openssl version in the main repository.
Also, the "software fallback" feature of afalg_engine was removed, since it will not be enabled with OpenSSL 3.0.