### PR TITLE
Fix no ip com

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=37
+PKG_RELEASE:=38
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -45,6 +45,7 @@ mythic-beasts.com-v2
 namecheap.com
 njal.la
 no-ip.pl
+no-ip.com
 now-dns.com
 nsupdate.info
 opendns.com


### PR DESCRIPTION
Put `no-ip.com` into the list available by default - corresponding json [file already exists](https://github.com/openwrt/packages/blob/master/net/ddns-scripts/files/usr/share/ddns/default/no-ip.com.json).

Signed-off-by: Michael Pliskin <michael.pliskin@gmail.com>