### PR TITLE
stress-ng: bump to version 0.15.06

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.15.03
+PKG_VERSION:=0.15.06
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ColinIanKing/stress-ng/tar.gz/refs/tags/V$(PKG_VERSION)?
-PKG_HASH:=7cceca64da37fd3c8db7167ed386fd7d3e1d9d6891a1f6227911ab8d4b17379c
+PKG_HASH:=c38cefcf0a83f6c65aed7c36e57a9a1ee8373418ef71cf089a75b0661dcd4623
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only

--- a/utils/stress-ng/patches/001-disable-gpu-stressor.patch
+++ b/utils/stress-ng/patches/001-disable-gpu-stressor.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.config
 +++ b/Makefile.config
-@@ -272,7 +272,7 @@ LD_GOLD:
+@@ -264,7 +264,7 @@ clean:
  libraries: \
  	configdir \
  	LIB_AIO LIB_APPARMOR LIB_BSD LIB_CRYPT LIB_DL \

--- a/utils/stress-ng/patches/002-disable-xxhash.patch
+++ b/utils/stress-ng/patches/002-disable-xxhash.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.config
 +++ b/Makefile.config
-@@ -274,7 +274,7 @@ libraries: \
+@@ -266,7 +266,7 @@ libraries: \
  	LIB_AIO LIB_APPARMOR LIB_BSD LIB_CRYPT LIB_DL \
  	LIB_IPSEC_MB LIB_JPEG \
  	LIB_JUDY LIB_KMOD LIB_MD LIB_PTHREAD LIB_PTHREAD_SPINLOCK \


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/0eebc6f0ddb0791406d30530e3fc25d39428bd5a
Run tested: x86 https://github.com/openwrt/openwrt/commit/0eebc6f0ddb0791406d30530e3fc25d39428bd5a

Signed-off-by: Alexandru Ardelean <alex@shruggie.ro>