### PR TITLE
zoneinfo: updated to the latest release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2022 OpenWrt.org
+# Copyright (C) 2007-2023 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2022g
+PKG_VERSION:=2023c
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=4491db8281ae94a84d939e427bdd83dc389f26764d27d9a5c52d782c16764478
+PKG_HASH:=3f510b5d1b4ae9bb38e485aa302a776b317fb3637bdb6404c4adf7b6cadd965c
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=9610bb0b9656ff404c361a41f3286da53064b5469d84f00c9cb2314c8614da74
+   HASH:=46d17f2bb19ad73290f03a203006152e0fa0d7b11e5b71467c4a823811b214e7
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT master
Run tested: n/a

Description:

The 2023c release of the tz code and data is available.

This release's code and data are identical to 2023a.  In other words,
this release reverts all changes made in 2023b other than commentary, as
that appears to be the best of a bad set of short-notice choices for
modeling this week's daylight saving chaos in Lebanon. (Thanks to Rany
Hany for the heads-up about the government's announcement this week.)

2023a  changes:

   Briefly:

     Egypt now uses DST again, from April through October.
     This year Morocco springs forward April 23, not April 30.
     Palestine delays the start of DST this year.
     Much of Greenland still uses DST from 2024 on.
     America/Yellowknife now links to America/Edmonton.
     tzselect can now use current time to help infer timezone.
     The code now defaults to C99 or later.
     Fix use of C23 attributes.

   Changes to future timestamps

     Starting in 2023, Egypt will observe DST from April's last Friday
     through October's last Thursday.  (Thanks to Ahmad ElDardiry.)
     Assume the transition times are 00:00 and 24:00, respectively.

     In 2023 Morocco's spring-forward transition after Ramadan
     will occur April 23, not April 30.  (Thanks to Milamber.)
     Adjust predictions for future years accordingly.  This affects
     predictions for 2023, 2031, 2038, and later years.

     This year Palestine will delay its spring forward from
     March 25 to April 29 due to Ramadan.  (Thanks to Heba Hamad.)
     Make guesses for future Ramadans too.

     Much of Greenland, represented by America/Nuuk, will continue to
     observe DST using European Union rules.  When combined with
     Greenland's decision not to change the clocks in fall 2023,
     America/Nuuk therefore changes from -03/-02 to -02/-01 effective
     2023-10-29 at 01:00 UTC.  (Thanks to Thomas M. Steenholdt.)
     This change from 2022g doesn't affect timestamps until 2024-03-30,
     and doesn't affect tm_isdst until 2023-03-25.

   Changes to past timestamps

     America/Yellowknife has changed from a Zone to a backward
     compatibility Link, as it no longer differs from America/Edmonton
     since 1970.  (Thanks to Almaz Mingaleev.)  This affects some
     pre-1948 timestamps.  The old data are now in 'backzone'.

   Changes to past time zone abbreviations

     When observing Moscow time, Europe/Kirov and Europe/Volgograd now
     use the abbreviations MSK/MSD instead of numeric abbreviations,
     for consistency with other timezones observing Moscow time.

   Changes to code

     You can now tell tzselect local time, to simplify later choices.
     Select the 'time' option in its first prompt.

     You can now compile with -DTZNAME_MAXIMUM=N to limit time zone
     abbreviations to N bytes (default 255).  The reference runtime
     library now rejects POSIX-style TZ strings that contain longer
     abbreviations, treating them as UTC.  Previously the limit was
     platform dependent and abbreviations were silently truncated to
     16 bytes even when the limit was greater than 16.

     The code by default is now designed for C99 or later.  To build in
     a C89 environment, compile with -DPORT_TO_C89.  To support C89
     callers of the tzcode library, compile with -DSUPPORT_C89.  The
     two new macros are transitional aids planned to be removed in a
     future version, when C99 or later will be required.

     The code now builds again on pre-C99 platforms, if you compile
     with -DPORT_TO_C89.  This fixes a bug introduced in 2022f.

     On C23-compatible platforms tzcode no longer uses syntax like
     'static [[noreturn]] void usage(void);'.  Instead, it uses
     '[[noreturn]] static void usage(void);' as strict C23 requires.
     (Problem reported by Houge Langley.)

     The code's functions now constrain their arguments with the C
     'restrict' keyword consistently with their documentation.
     This may allow future optimizations.

     zdump again builds standalone with ckdadd and without setenv,
     fixing a bug introduced in 2022g.  (Problem reported by panic.)

     leapseconds.awk can now process a leap seconds file that never
     expires; this might be useful if leap seconds are discontinued.

   Changes to commentary

     tz-link.html has a new section "Coordinating with governments and
     distributors".  (Thanks to Neil Fuller for some of the text.)

     To improve tzselect diagnostics, zone1970.tab's comments column is
     now limited to countries that have multiple timezones.

     Note that leap seconds are planned to be discontinued by 2035.