### PR TITLE
ddns-scripts: Enable no-ip.com by default.

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=37
+PKG_RELEASE:=38
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -44,6 +44,7 @@ mythic-beasts.com
 mythic-beasts.com-v2
 namecheap.com
 njal.la
+no-ip.com
 no-ip.pl
 now-dns.com
 nsupdate.info


### PR DESCRIPTION
ddns-scripts: Enable no-ip.com by default.

Signed-off-by: Michael Pliskin <michael.pliskin@gmail.com>