### PR TITLE
nano: make nanorc world readable

### DIFF
--- a/utils/nano/Makefile
+++ b/utils/nano/Makefile
@@ -141,6 +141,7 @@ define Package/nano-full/install
 	$(INSTALL_CONF) ./files/nanorc $(1)/etc/nanorc
 	$(INSTALL_DATA) ./files/uci.nanorc $(1)/usr/share/nano
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/nano/* $(1)/usr/share/nano
+	chmod 0644 $(1)/etc/nanorc
 endef
 
 $(eval $(call BuildPackage,nano))


### PR DESCRIPTION
If file /etc/nanorc is readable by everyone, "default" settings are available for users as well without necessarily requiring their own customized .nanorc in their home directory. Or if they want one, but want it to be based on system's default nanorc, they can copy it from /etc - without chmodding file, it is in-accessible for users.

Maintainer: Hannu Nyman / @hnyman 
Compile tested: x86_64, latest git
Run tested: x86_64, latest git

Description:
This makes system-wide nanorc usable by others than root user only.