### PR TITLE
lxc: enable building on hosts without distrosysconfdir

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=5.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/
@@ -33,7 +33,8 @@ MESON_ARGS += \
 	-Dselinux=false \
 	-Dseccomp=$(if $(CONFIG_LXC_SECCOMP),true,false) \
 	-Dexamples=false \
-	-Db_pie=true
+	-Db_pie=true \
+	-Ddistrosysconfdir=/etc/lxc
 
 LXC_APPLETS_BIN += \
 	attach autostart cgroup copy config console create destroy device \


### PR DESCRIPTION
Maintainer: Marko Ratkaj / @ratkaj 
Compile tested: x86_64, latest git
Run tested: x86_64, latest git

Description:
enable building on hosts without distrosysconfdir ( /etc/default, /etc/sysconfig, etc )