### PR TITLE
Python ble2mqtt

### DIFF
--- a/lang/python/python-ble2mqtt/Makefile
+++ b/lang/python/python-ble2mqtt/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-ble2mqtt
 PKG_VERSION:=0.1.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=ble2mqtt
 PKG_HASH:=0015cae0c36badb48cbd4a1c8b1a8029e45ab0891a95363fe00624c2629b4510
@@ -27,12 +27,17 @@ define Package/python3-ble2mqtt
   SUBMENU:=Python
   TITLE:=Bluetooth to MQTT bridge
   URL:=https://github.com/devbis/ble2mqtt/
-  DEPENDS:=+python3-light +python3-aio-mqtt-mod +python3-asyncio +python3-bleak +python3-logging
+  DEPENDS:=+python3-light +python3-aio-mqtt-mod +python3-asyncio +python3-bleak +python3-logging +python3-uuid
 endef
 
 define Package/python3-ble2mqtt/description
   Bluetooth to MQTT bridge, add your bluetooth-capable (including controllable)
   devices to your smart home
+endef
+
+define Py3Package/python3-ble2mqtt/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/ble2mqtt.init $(1)/etc/init.d/ble2mqtt
 endef
 
 $(eval $(call Py3Package,python3-ble2mqtt))

--- a/lang/python/python-ble2mqtt/files/ble2mqtt.init
+++ b/lang/python/python-ble2mqtt/files/ble2mqtt.init
@@ -1,0 +1,15 @@
+#!/bin/sh /etc/rc.common
+
+START=98
+USE_PROCD=1
+
+start_service()
+{
+    procd_open_instance
+
+    procd_set_param env BLE2MQTT_CONFIG=/etc/ble2mqtt.json
+    procd_set_param command /usr/bin/ble2mqtt
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_close_instance
+}

--- a/lang/python/python-bleak/Makefile
+++ b/lang/python/python-bleak/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-bleak
-PKG_VERSION:=0.20.0
+PKG_VERSION:=0.20.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=bleak
-PKG_HASH:=7f6fe69454ad5d4c0ab05ae4a9aa1aabd6926d7128eab2fac4ef8a58a72999ee
+PKG_HASH:=db599f5f100e252e9cdd4020c8657daca0371a3c697e87432abc702f3774cb4c
 
 PKG_MAINTAINER:=Quintin Hill <stuff@quintin.me.uk>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79 22.03.3 SDK
Run tested: Netgear r6260 snapshot successfully run ble2mqtt as a daemon and collected data over BLE.

Description:
Follow up to #20633.  This bumps the version of Bleak to get a bugfix, adds a missing dependency to ble2mqtt and also adds an init script (from the upstream README) to the ble2mqtt package.