### PR TITLE
lxc: set RUNTIME_PATH to the /var/run

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=5.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/
@@ -33,7 +33,8 @@ MESON_ARGS += \
 	-Dselinux=false \
 	-Dseccomp=$(if $(CONFIG_LXC_SECCOMP),true,false) \
 	-Dexamples=false \
-	-Db_pie=true
+	-Db_pie=true \
+	-Druntime-path=/var/run
 
 LXC_APPLETS_BIN += \
 	attach autostart cgroup copy config console create destroy device \

--- a/utils/lxc/files/lxc-auto.init
+++ b/utils/lxc/files/lxc-auto.init
@@ -69,9 +69,5 @@ boot() {
 		mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,none,name=systemd cgroup /sys/fs/cgroup/systemd
 	fi
 
-	if [ ! -d /run ]; then
-		ln -s /var/run /run
-	fi
-
 	start
 }


### PR DESCRIPTION
```
The default runtime directory used by LXC is /run which doesn't exist
in OpenWrt. It causes errors like:

Failed to create lock for foo
lxc-create: foo: tools/lxc_create.c: main: 260 Failed to create lxc container

There has been workaround for that in the lxc-auto.init but it requires
installing "lxc-auto" package. Replacing that "ln -s" workaround with
Makefile specifying RUNTIME_PATH define allows using pure "lxc" in
OpenWrt (without the "lxc-auto").
```