### PR TITLE
openssh: preserve authorized_keys

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
 PKG_VERSION:=9.3p1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
@@ -105,6 +105,7 @@ define Package/openssh-server/conffiles
 /etc/ssh/ssh_host_ed25519_key.pub
 /etc/ssh/ssh_host_rsa_key
 /etc/ssh/ssh_host_rsa_key.pub
+/root/.ssh/authorized_keys
 endef
 
 define Package/openssh-server-pam


### PR DESCRIPTION
Maintainer: @tripolar
Compile tested: x86-64 22.03.3
Run tested: x86-64 22.03.3

Description:
The root user is usually the user that clients ssh into with, so in most cases its authorized_keys determines what clients are allowed to ssh into this device. Without preserving this file, they could potentially be locked out after upgrading.