### PR TITLE
cache-domains: Fixed config files being outside of jail

### DIFF
--- a/utils/cache-domains/Makefile
+++ b/utils/cache-domains/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cache-domains
-PKG_VERSION:=2.3.1
-PKG_RELEASE:=2
+PKG_VERSION:=2.4.0
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
@@ -27,6 +27,9 @@ define Package/cache-domains/install/default
 
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface/
 	$(INSTALL_BIN) ./files/30-cache-domains $(1)/etc/hotplug.d/iface/
+
+	$(INSTALL_DIR) $(1)/usr/share/cache-domains/
+	$(INSTALL_BIN) ./files/test.sh $(1)/usr/share/cache-domains/
 endef
 
 Build/Compile=# Nothing to compile, just install the scripts

--- a/utils/cache-domains/files/cache-domains
+++ b/utils/cache-domains/files/cache-domains
@@ -6,30 +6,41 @@ set -e
 
 CACHE_DOMAINS_SRC="https://api.github.com/repos/uklans/cache-domains/tarball/master"
 CACHE_DOMAINS_DIR="/var/cache-domains"
-CACHE_DOMAINS_CONF_FILE="${CACHE_DOMAINS_DIR}/lancache.conf"
 CONFIG_FILE="/etc/cache-domains.json"
 
 dnsmasq_conf() {
+	local ACTION="${1}"
+	local ADDN_CONF_DIR="${2}"
 	local I=0
 	local DNSMASQ_CONF_DIR
 	local DNSMASQ_CONF_FILE
 
 	while uci_get "dhcp" "@dnsmasq[${I}]" > /dev/null; do
 		DNSMASQ_CONF_DIR="$(uci_get "dhcp" "@dnsmasq[${I}]" "confdir" "/tmp/dnsmasq.d" || :)"
-		DNSMASQ_CONF_FILE="${DNSMASQ_CONF_DIR}/$(basename "${CACHE_DOMAINS_CONF_FILE}")"
+		uci_remove_list "dhcp" "@dnsmasq[${I}]" "addnmount" "${ADDN_CONF_DIR}"
 
-		case ${1} in
+		mkdir -p "${DNSMASQ_CONF_DIR}"
+		case "${ACTION}" in
 			add)
-				ln -sf "${CACHE_DOMAINS_CONF_FILE}" "${DNSMASQ_CONF_FILE}"
+				ln -s "${ADDN_CONF_DIR}/"* "${DNSMASQ_CONF_DIR}" 2> /dev/null || :
+				uci_add_list "dhcp" "@dnsmasq[${I}]" "addnmount" "${ADDN_CONF_DIR}"
 				;;
 			remove)
-				rm -f "${DNSMASQ_CONF_FILE}"
+				for DNSMASQ_CONF_FILE in "${DNSMASQ_CONF_DIR}/"*; do
+					case "$(readlink "${DNSMASQ_CONF_FILE}" || echo "${DNSMASQ_CONF_FILE}")" in
+						"${ADDN_CONF_DIR}"*)
+							rm -f "${DNSMASQ_CONF_FILE}"
+							;;
+					esac
+				done
 				;;
 			*)
-				echo "ERROR: Invalid action '${1}' for dnsmasq_conf()"
+				echo "ERROR: Invalid action '${ACTION}' for dnsmasq_conf()"
 				return 1
 				;;
 		esac
+
+		uci_commit "dhcp"
 
 		I=$((${I} + 1))
 	done
@@ -59,18 +70,16 @@ configure() {
 	cd "${SOURCE_DIR}/scripts/"
 	cp "${CONFIG_FILE}" "config.json"
 	./create-dnsmasq.sh > /dev/null
-	cat "./output/dnsmasq/"*".conf" > "${CACHE_DOMAINS_CONF_FILE}"
 	cd "${INITIAL_DIR}"
-	rm -fr "${SOURCE_DIR}"
 
-	dnsmasq_conf add
+	dnsmasq_conf add "${SOURCE_DIR}/scripts/output/dnsmasq"
 }
 
 cleanup() {
-	dnsmasq_conf remove
+	dnsmasq_conf remove "${CACHE_DOMAINS_DIR}/$(ls "${CACHE_DOMAINS_DIR}")/scripts/output/dnsmasq"
 }
 
-case ${1} in
+case "${1}" in
 	config*)
 		configure
 		;;

--- a/utils/cache-domains/files/test.sh
+++ b/utils/cache-domains/files/test.sh
@@ -1,0 +1,51 @@
+#! /bin/sh
+
+set -o errexit
+
+test_url() {
+    echo "INFO: Testing '${2}' has ${1} addresses" >&2
+
+    case "${1}" in
+        IPv4)
+            nslookup -type=a "${2}"
+            ;;
+        IPv6)
+            nslookup -type=aaaa "${2}"
+            ;;
+        *)
+            echo "ERROR: Unknown IP version: ${1}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+cache_domains() {
+    echo "INFO: cache-domains ${1}" >&2
+    cache-domains "${1}"
+    sleep 5
+}
+
+cache_domains cleanup
+
+test_url IPv4 lancache.steamcontent.com | grep -q 'canonical name ='
+test_url IPv6 lancache.steamcontent.com | grep -q 'canonical name ='
+
+test_url IPv4 dist.blizzard.com | grep -q 'canonical name ='
+test_url IPv6 dist.blizzard.com | grep -q 'canonical name ='
+
+cache_domains configure
+
+test_url IPv4 lancache.steamcontent.com | grep -q '10.10.3.10'
+test_url IPv4 lancache.steamcontent.com | grep -q '10.10.3.11'
+test_url IPv6 lancache.steamcontent.com > /dev/null # None configured
+
+test_url IPv4 dist.blizzard.com | grep -q '10.10.3.13'
+test_url IPv6 dist.blizzard.com > /dev/null # None configured
+
+cache_domains cleanup
+
+test_url IPv4 lancache.steamcontent.com | grep -q 'canonical name ='
+test_url IPv6 lancache.steamcontent.com | grep -q 'canonical name ='
+
+test_url IPv4 dist.blizzard.com | grep -q 'canonical name ='
+test_url IPv6 dist.blizzard.com | grep -q 'canonical name ='


### PR DESCRIPTION
Maintainer: me @G-M0N3Y-2503
Compile tested: x86_x64, QEMU/KVM, master
Run tested: x86_x64, QEMU/KVM, master

Description:
This fix dnsmasq failing to startup once configured since the cache-domains config files are not included in the jail that dnsmasq runs inside.
Also, I've reduces the writes by symlinking each file to the dnsmasq directory instead of writing them all to one big file.
