### PR TITLE
node: bump to v18.16.0

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v18.15.0
+PKG_VERSION:=v18.16.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=8e44d65018ff973284195c23186469a0ea4082e97ec4200e5f5706d5584daa37
+PKG_HASH:=33d81a233e235a509adda4a4f2209008d04591979de6b3f0f67c1c906093f118
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT
@@ -118,10 +118,12 @@ CONFIGURE_ARGS:= \
 	--shared-libuv \
 	--shared-cares \
 	--with-intl=$(if $(CONFIG_NODEJS_ICU_SMALL),small-icu,$(if $(CONFIG_NODEJS_ICU_SYSTEM),system-icu,none)) \
-	$(if $(findstring +neon,$(CONFIG_CPU_TYPE)),--with-arm-fpu=neon) \
-	$(if $(findstring +vfp",$(CONFIG_CPU_TYPE)),--with-arm-fpu=vfp) \
-	$(if $(findstring +vfpv3",$(CONFIG_CPU_TYPE)),--with-arm-fpu=vfpv3-d16) \
+	$(if $(findstring +neon",$(CONFIG_CPU_TYPE)),--with-arm-fpu=neon) \
+	$(if $(findstring +neon-vfpv4",$(CONFIG_CPU_TYPE)),--with-arm-fpu=neon) \
 	$(if $(findstring +vfpv4",$(CONFIG_CPU_TYPE)),--with-arm-fpu=vfpv3) \
+	$(if $(findstring +vfp",$(CONFIG_CPU_TYPE)),--with-arm-fpu=vfp) \
+	$(if $(findstring +vfpv3",$(CONFIG_CPU_TYPE)),--with-arm-fpu=vfpv3) \
+	$(if $(findstring +vfpv3-d16",$(CONFIG_CPU_TYPE)),--with-arm-fpu=vfpv3-d16) \
 	--prefix=/usr
 
 HOST_CONFIGURE_VARS:=

--- a/lang/node/patches/999-localhost-no-addrconfig.patch
+++ b/lang/node/patches/999-localhost-no-addrconfig.patch
@@ -14,7 +14,7 @@ Forwarded: https://github.com/nodejs/node/issues/33816
  // Permission is hereby granted, free of charge, to any person obtaining a
  // copy of this software and associated documentation files (the
 @@ -1265,13 +1266,6 @@ function lookupAndConnect(self, options)
-     hints: options.hints || 0
+     hints: options.hints || 0,
    };
  
 -  if (!isWindows &&

--- a/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
+++ b/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
@@ -1,6 +1,6 @@
 --- a/configure.py
 +++ b/configure.py
-@@ -1290,7 +1290,6 @@ def configure_node(o):
+@@ -1296,7 +1296,6 @@ def configure_node(o):
  
    # Enable branch protection for arm64
    if target_arch == 'arm64':


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: head, aarch64, arm, i386, x86_64, mipsel (pistachio) 
Run tested: (qemu 7.2.0) aarch64

Description:
Update to v18.16.0
Fixed a bug when selecting arm-fpu for vfpv3-d16.

Notable changes
Add initial support for single executable applications 
Replace url parser with Ada
