### PR TITLE
openssh: add respawn and reloading via signal

### DIFF
--- a/net/openssh/files/sshd.init
+++ b/net/openssh/files/sshd.init
@@ -27,7 +27,12 @@ start_service() {
 	procd_open_instance
 	procd_add_mdns "ssh" "tcp" "$lport"
 	procd_set_param command $PROG -D
+	procd_set_param respawn
 	procd_close_instance
+}
+
+reload_service() {
+	procd_send_signal sshd
 }
 
 shutdown() {


### PR DESCRIPTION
Configure the openssh server to respawn. Reload by sending SIGHUP

Maintainer: @SibrenVasse 
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
Improvements to the OpenSSH init script. Respawning is added so that the OpenSSH server gets restarted in case it crashes. Reloading is implemented by sending SIGHUP to the OpenSSH server process. Before it would not re-read for example /etc/ssh/sshd_config when "/etc/init.d/sshd reload" was run.