### PR TITLE
[22.03] ruby: update to 3.0.6

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=3.0.5
+PKG_VERSION:=3.0.6
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=cf7cb5ba2030fe36596a40980cdecfd79a0337d35860876dc2b10a38675bddde
+PKG_HASH:=b5cbee93e62d85cfb2a408c49fa30a74231ae8409c2b3858e5f5ea254d7ddbd1
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING

--- a/lang/ruby/patches/100-musl.patch
+++ b/lang/ruby/patches/100-musl.patch
@@ -3,7 +3,7 @@ which was originally based on this file.
 
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2471,7 +2471,10 @@ AS_CASE([$rb_cv_coroutine], [yes|''], [
+@@ -2479,7 +2479,10 @@ AS_CASE([$rb_cv_coroutine], [yes|''], [
              rb_cv_coroutine=copy
          ],
          [


### PR DESCRIPTION
Maintainer: me
Compile tested: no (22.03 cannot be built in too recent machines)
Run tested: no

Description: