### PR TITLE
python-hatchling: Update to 1.14.0, add new host-only dependencies

### DIFF
--- a/lang/python/python-calver/Makefile
+++ b/lang/python/python-calver/Makefile
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2023 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-calver
+PKG_VERSION:=2022.6.26
+PKG_RELEASE:=1
+
+PYPI_NAME:=calver
+PKG_HASH:=e05493a3b17517ef1748fbe610da11f10485faa7c416b9d33fd4a52d74894f8b
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+PKG_HOST_ONLY:=1
+HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-wheel/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include ../python3-package.mk
+include ../python3-host-build.mk
+
+define Package/python3-calver
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Setuptools extension for CalVer package versions
+  URL:=https://github.com/di/calver
+  DEPENDS:=+python3-light
+  BUILDONLY:=1
+endef
+
+define Package/python3-calver/description
+The calver package is a setuptools extension for automatically defining
+your Python package version as a calendar version.
+endef
+
+$(eval $(call Py3Package,python3-calver))
+$(eval $(call BuildPackage,python3-calver))
+$(eval $(call BuildPackage,python3-calver-src))
+$(eval $(call HostBuild))

--- a/lang/python/python-hatchling/Makefile
+++ b/lang/python/python-hatchling/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-hatchling
-PKG_VERSION:=1.13.0
+PKG_VERSION:=1.14.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=hatchling
-PKG_HASH:=f8d275a2cc720735286b7c2e2bc35da05761e6d3695c2fa416550395f10c53c7
+PKG_HASH:=462ea91df03ff5d52813b5613fec1313a1a2059d2e37343e572b3f979867c5da
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
@@ -27,7 +27,8 @@ HOST_BUILD_DEPENDS:= \
 	python-packaging/host \
 	python-pathspec/host \
 	python-pluggy/host \
-	python-tomli/host
+	python-tomli/host \
+	python-trove-classifiers/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -48,7 +49,8 @@ define Package/python3-hatchling
       +python3-packaging \
       +python3-pathspec \
       +python3-pluggy \
-      +python3-tomli
+      +python3-tomli \
+      +python3-trove-classifiers
   BUILDONLY:=1
 endef
 

--- a/lang/python/python-trove-classifiers/Makefile
+++ b/lang/python/python-trove-classifiers/Makefile
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2023 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-trove-classifiers
+PKG_VERSION:=2023.3.9
+PKG_RELEASE:=1
+
+PYPI_NAME:=trove-classifiers
+PKG_HASH:=ee42f2f8c1d4bcfe35f746e472f07633570d485fab45407effc0379270a3bb03
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+PKG_HOST_ONLY:=1
+PKG_BUILD_DEPENDS:=python-calver/host
+HOST_BUILD_DEPENDS:= \
+	python3/host \
+	python-build/host \
+	python-installer/host \
+	python-wheel/host \
+	python-calver/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include ../python3-package.mk
+include ../python3-host-build.mk
+
+define Package/python3-trove-classifiers
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Canonical source for classifiers on PyPI (pypi.org).
+  URL:=https://github.com/pypa/trove-classifiers
+  DEPENDS:=+python3-light
+  BUILDONLY:=1
+endef
+
+define Package/python3-trove-classifiers/description
+Canonical source for classifiers on PyPI.
+
+Classifiers categorize projects per PEP 301. Use this package to
+validate classifiers in packages for PyPI upload or download.
+endef
+
+$(eval $(call Py3Package,python3-trove-classifiers))
+$(eval $(call BuildPackage,python3-trove-classifiers))
+$(eval $(call BuildPackage,python3-trove-classifiers-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: me
Compile tested: armvirt-32, 2023-04-10 snapshot sdk
Run tested: N/A

Description:
hatchling 1.14.0 added trove-classifiers as a dependency; trove-classifiers in turn depends on calver.