### PR TITLE
boost: Updates package to version 1.82.0

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -11,13 +11,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=boost
-PKG_VERSION:=1.81.0
-PKG_SOURCE_VERSION:=1_81_0
+PKG_VERSION:=1.82.0
+PKG_SOURCE_VERSION:=1_82_0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://boostorg.jfrog.io/artifactory/main/release/$(PKG_VERSION)/source/
-PKG_HASH:=71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa
+PKG_HASH:=a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6
 
 PKG_MAINTAINER:=Carlos M. Ferreira <carlosmf.pt@gmail.com>
 PKG_LICENSE:=BSL-1.0
@@ -42,7 +42,7 @@ define Package/boost/Default
 endef
 
 define Package/boost/description
-This package provides the Boost v1.81.0 libraries.
+This package provides the Boost v1.82.0 libraries.
 Boost is a set of free, peer-reviewed, portable C++ source libraries.
 
 This package provides the following run-time libraries:
@@ -74,11 +74,11 @@ This package provides the following run-time libraries:
  - thread
  - timer
  - type_erasure
- - url (new)
+ - url
  - wave
 
 There are many more header-only libraries supported by Boost.
-See more at http://www.boost.org/doc/libs/1_81_0/
+See more at http://www.boost.org/doc/libs/1_82_0/
 endef
 
 PKG_BUILD_DEPENDS:=boost/host


### PR DESCRIPTION
Maintainer: @ClaymorePT 
Compile tested: bcm27xx (bcm2711) - used development snapshot from the 17th of April.
Run tested: N/A

Description:
This commit updates boost to version 1.82.0

A new header-only library is available:
- MySql: a C++11 client for the MySQL database server, based on Boost.Asio, from Ruben Perez. [[1]]

More info about Boost 1.82.0 can be found at the usual place [[2]].

[1]: https://www.boost.org/doc/libs/1_82_0/libs/mysql/doc/html/index.html
[2]: https://www.boost.org/users/history/version_1_82_0.html

Signed-off-by: Carlos Miguel Ferreira <carlosmf.pt@gmail.com>
