### PR TITLE
python: Update find stdlib script

### DIFF
--- a/lang/python/python3-find-stdlib-depends.sh
+++ b/lang/python/python3-find-stdlib-depends.sh
@@ -14,11 +14,10 @@ python3-cgi: cgi
 python3-cgitb: cgitb
 python3-codecs: unicodedata
 python3-ctypes: ctypes
-python3-dbm: dbm
+python3-dbm: dbm dbm.dumb dbm.gnu dbm.ndbm
 python3-decimal: decimal
 python3-distutils: distutils
 python3-email: email
-python3-gdbm: dbm.gnu
 python3-logging: logging
 python3-lzma: lzma
 python3-multiprocessing: multiprocessing
@@ -29,6 +28,7 @@ python3-readline: readline
 python3-sqlite3: sqlite3
 python3-unittest: unittest
 python3-urllib: urllib
+python3-uuid: uuid
 python3-xml: xml xmlrpc
 "
 


### PR DESCRIPTION
Maintainer: me
Compile tested: N/A
Run tested: tested with borgbackup package

Description:
This updates the python3-find-stdlib-depends.sh script for these changes:

* The gdbm (dbm.gnu) package was merged into the dbm package in 78f6c2c5ad2fd3de8a33a1cddb02204177cf60ad.

* The uuid module was split into a separate package in 4e05541782edeb06b51d691dadf52648df24c940.