### PR TITLE
[21.02] bind: disable geoip because of maxminddb dep

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.18.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -136,6 +136,7 @@ TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
 CONFIGURE_ARGS += \
 	--disable-linux-caps \
+	--disable-geoip \
 	--with-openssl="$(STAGING_DIR)/usr" \
 	--with-libtool \
 	--without-lmdb \


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile tested: armv7l, Turris Omnia, OpenWrt 21.02
Run tested: -

Description: the libmaxminddb package recently added a pkgconfig file which caused the geoip feature to be enabled automatically and the package to fail when it has a new unexpected dependency
