### PR TITLE
kea: Update to 2.2.0

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -9,14 +9,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kea
-PKG_VERSION:=2.0.3
-PKG_RELEASE:=2
+PKG_VERSION:=2.2.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.isc.org/isc/kea/$(PKG_VERSION)
-PKG_HASH:=d642907374d17480ebe4df805b363dc9e230a955475a9f3e04a076b52d5c43ec
+PKG_HASH:=da7d90ca62a772602dac6e77e507319038422895ad68eeb142f1487d67d531d2
 
-PKG_MAINTAINER:=BangLang Huang<banglang.huang@foxmail.com>, Rosy Song<rosysong@rosinson.com>
+PKG_MAINTAINER:=BangLang Huang <banglang.huang@foxmail.com>, Rosy Song <rosysong@rosinson.com>
 PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=COPYING
 

--- a/net/kea/files/kea.init
+++ b/net/kea/files/kea.init
@@ -39,5 +39,5 @@ start_kea() {
 	procd_set_param file "$cnf"
 	procd_set_param stderr 1
 	procd_set_param stdout 1
-	procd_close_instance ctrl_agent
+	procd_close_instance
 }

--- a/net/kea/patches/003-no-test-compile.patch
+++ b/net/kea/patches/003-no-test-compile.patch
@@ -158,14 +158,6 @@
  
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
---- a/src/lib/cql/Makefile.am
-+++ b/src/lib/cql/Makefile.am
-@@ -1,4 +1,4 @@
--SUBDIRS = . testutils tests
-+SUBDIRS = .
- 
- AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
- AM_CPPFLAGS += $(BOOST_INCLUDES) $(CQL_CPPFLAGS)
 --- a/src/lib/cryptolink/Makefile.am
 +++ b/src/lib/cryptolink/Makefile.am
 @@ -1,4 +1,4 @@
@@ -203,8 +195,8 @@
 @@ -1,6 +1,6 @@
  AUTOMAKE_OPTIONS = subdir-objects
  
--SUBDIRS = . testutils tests benchmarks
-+SUBDIRS = . benchmarks
+-SUBDIRS = . testutils tests
++SUBDIRS = .
  
  # DATA_DIR is the directory where to put default CSV files and the DHCPv6
  # server ID file (i.e. the file where the server finds its DUID at startup).

--- a/net/kea/patches/004-replace-rev-with-awk.patch
+++ b/net/kea/patches/004-replace-rev-with-awk.patch
@@ -1,6 +1,6 @@
 --- a/src/bin/keactrl/keactrl.in
 +++ b/src/bin/keactrl/keactrl.in
-@@ -117,7 +117,7 @@ get_pid_from_file() {
+@@ -115,7 +115,7 @@ get_pid_from_file() {
      # Extract the name portion (from last slash to last dot) of the config file name
      # File name and extension are documented in src/lib/util/filename.h
      local conf_name

--- a/net/kea/patches/010-openssl-deprecated.patch
+++ b/net/kea/patches/010-openssl-deprecated.patch
@@ -1,6 +1,6 @@
 --- a/src/lib/cryptolink/openssl_link.cc
 +++ b/src/lib/cryptolink/openssl_link.cc
-@@ -79,7 +79,7 @@ CryptoLink::initialize() {
+@@ -77,7 +77,7 @@ CryptoLink::initialize(CryptoLink& c) {
  
  std::string
  CryptoLink::getVersion() {


### PR DESCRIPTION
Maintainer: @pangpang, @rosysong 
Compile tested: x86_64, generic, HEAD (c3cb2d48da)
Run tested: built but not installed yet

Description:

Update to 2.2.0
