### PR TITLE
nginx: split DAV_EXT from standard nginx DAV config

### DIFF
--- a/net/nginx/Config_ssl.in
+++ b/net/nginx/Config_ssl.in
@@ -15,6 +15,14 @@ config NGINX_DAV
 		Enable the HTTP and WebDAV methods PUT, DELETE, MKCOL, COPY and MOVE.
 	default n
 
+config NGINX_DAV_EXT
+	bool
+	prompt "Enable WebDAV EXT module"
+	select NGINX_DAV
+	help
+		Enable the WebDAV methods PROPFIND, OPTIONS, LOCK, UNLOCK.
+	default n
+
 config NGINX_UBUS
 	bool
 	prompt "Enable UBUS module"

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -27,6 +27,7 @@ PKG_BUILD_FLAGS:=gc-sections
 
 PKG_CONFIG_DEPENDS := \
 	CONFIG_NGINX_DAV \
+	CONFIG_NGINX_DAV_EXT \
 	CONFIG_NGINX_FLV \
 	CONFIG_NGINX_UBUS \
 	CONFIG_NGINX_STUB_STATUS \
@@ -248,7 +249,10 @@ ifneq ($(BUILD_VARIANT),all-module)
     ADDITIONAL_MODULES += --with-http_flv_module
   endif
   ifeq ($(CONFIG_NGINX_DAV),y)
-    ADDITIONAL_MODULES += --with-http_dav_module --add-module=$(PKG_BUILD_DIR)/nginx-dav-ext-module
+    ADDITIONAL_MODULES += --with-http_dav_module
+  endif
+  ifeq ($(CONFIG_NGINX_DAV_EXT),y)
+    ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/nginx-dav-ext-module
   endif
   ifeq ($(CONFIG_NGINX_UBUS),y)
     ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/nginx-ubus-module
@@ -297,6 +301,7 @@ else
   CONFIG_NGINX_NAXSI:=y
   CONFIG_NGINX_LUA:=y
   CONFIG_NGINX_DAV:=y
+  CONFIG_NGINX_DAV_EXT:=y
   CONFIG_NGINX_UBUS:=y
   ADDITIONAL_MODULES += --with-ipv6 --with-http_stub_status_module --with-http_flv_module \
 	--with-http_dav_module \
@@ -508,7 +513,7 @@ endef
 define Build/Patch
 	$(if $(QUILT),rm -rf $(PKG_BUILD_DIR)/patches; mkdir -p $(PKG_BUILD_DIR)/patches)
 	$(call PatchDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/nginx,nginx/)
-ifneq "$(or $(CONFIG_NGINX_DAV),$(QUILT))" ""
+ifneq "$(or $(CONFIG_NGINX_DAV_EXT),$(QUILT))" ""
 	$(call PatchDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/dav-nginx,dav-nginx/)
 endif
 ifneq "$(or $(CONFIG_NGINX_LUA),$(QUILT))" ""
@@ -562,7 +567,7 @@ ifeq ($(CONFIG_NGINX_TS_MODULE),y)
   $(Prepare/nginx-ts)
 endif
 
-ifneq "$(or $(CONFIG_NGINX_DAV),$(QUILT))" ""
+ifneq "$(or $(CONFIG_NGINX_DAV_EXT),$(QUILT))" ""
   $(eval $(call Download,nginx-dav-ext-module))
   $(Prepare/nginx-dav-ext-module)
 endif


### PR DESCRIPTION
Split DAV_EXT from standard nginx DAV config as additional WebDAV methods are provided by an external module.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

---

Maintainer: me

