### PR TITLE
mwan3: fix mwan3 doesn't detect the absence of the internet connection if an interface goes down and then up

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.11.4
+PKG_VERSION:=2.11.6
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -184,6 +184,7 @@ firstconnect() {
 	if [ "$STATUS" = "offline" ]; then
 		disconnected 1
 	else
+		score=$((down+up))
 		connected 1
 	fi
 }


### PR DESCRIPTION
After an interface goes down and then up, mwan3 doesn't detect the absence of the internet connection if the interface initial state is online. This commit fixes the issue.

Maintainer: @feckert
Compile tested: x86-64, OpenWrt master
Run tested: x86-64, OpenWrt master

Description:

On boot everything works fine:

1. Initial state of the interface is set to online.
2. Router boots up
3. Interface goes up, the state is set to online
4. mwan3track is launched, initial score is set to $((down+up)) upon mwan3track initialization.
5. mwan3track performs ping tests. If there is no internet connection, the score decreases and the interface becomes disconnected.

But if later the interface goes down:

1. Interface goes down. disconnected() function is called and score is reset to 0.
2. Interface goes up, the state is set to online
3. mwan3track performs ping tests. But if there is no internet connection, nothing is done because the score is already 0. Interface stays in online state.

Fix this issue by setting the score to it's initial value before calling connected() from firstconnect()
