### PR TITLE
strongswan: local_gateway unused in swanctl.init

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.10
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -418,7 +418,6 @@ config_connection() {
 
 	local enabled
 	local gateway
-	local local_gateway
 	local local_sourceip
 	local local_ip
 	local remote_gateway
@@ -477,10 +476,6 @@ config_connection() {
 	esac
 
 	[ "$gateway" = "any" ] && remote_gateway="%any" || remote_gateway="$gateway"
-
-	local ipdest
-	[ "$remote_gateway" = "%any" ] && ipdest="1.1.1.1" || ipdest="$remote_gateway"
-	local_gateway=`ip -o route get $ipdest | awk '/ src / { gsub(/^.* src /,""); gsub(/ .*$/, ""); print $0}'`
 
 	if [ -n "$local_key" ]; then
 		[ "$(dirname "$local_key")" != "." ] && \


### PR DESCRIPTION
Maintainer: me, @Thermi 
Compile tested: x86_64, generic, HEAD (c3cb2d48da)
Run tested: same, installed on production router

Description:

Drop remnants of rewrite of `ipsec.init`.