### PR TITLE
sedutil: Add new package

### DIFF
--- a/utils/sedutil/Makefile
+++ b/utils/sedutil/Makefile
@@ -1,0 +1,41 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=sedutil
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://github.com/Drive-Trust-Alliance/sedutil
+PKG_SOURCE_DATE:=2022-12-27
+PKG_SOURCE_VERSION:=7a0cda7f60cce346f72466e61ce006e5ea48fbc0
+PKG_MIRROR_HASH:=e11333bfa0760a46cbebcba35360e0f076e6219eb38ce1545179b8741476668a
+
+PKG_LICENSE_FILES:=README.md
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
+
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=lto
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/sedutil
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=The Drive Trust Alliance Self Encrypting Drive Utility
+  URL:=https://github.com/Drive-Trust-Alliance/sedutil
+  DEPENDS:=+libstdcpp
+endef
+
+define Package/sedutil/description
+This program and it's accompanying Pre-Boot Authorization image allow you to
+enable the locking in SED's that comply with the TCG OPAL 2.00 standard on bios
+machines.
+endef
+
+define Package/sedutil/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_BUILD_DIR)/{linuxpba,sedutil-cli} $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,sedutil))


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
The Drive Trust Alliance Self Encrypting Drive Utility

Tool to leverage Self Encrypting Drives (SED), common today among NVMEs.

[A Practical Guide to Use of Opal Drives](https://develop.trustedcomputinggroup.org/wp-content/uploads/2019/05/Opal_Drive_Guide_v1_Final_20190515.pdf)

It installs both `sedutil-cli` and `linuxpba`. I've only tested the former in OpenWrt. `linuxpba`, although interesting, makes booting, installing & upgrading quite more complex, and it's not compatible with 4K formatted drives, which is also the native format of modern NVME drives.

I think the most interesting option is using the former directly, from a preinit script, having the `boot` & `openwrt` partitions unencrypted.

[This comment](https://github.com/Drive-Trust-Alliance/sedutil/issues/90#issuecomment-1207190838) sheds some light on the matter.

I've been using it successfully together with a YubiKey, from a preinit script, see below. The only caveat was I had to enable `CONFIG_KERNEL_DEVTMPFS=y` in order to be able to use the YubiKey from the preinit environment since `ykchalresp` needs access to `/dev/bus/usb`.

There are patches to enable S3 suspend support but I don't think they're that interesting for OpenWrt.

```
❯ cat /lib/preinit/75_sedutil_opal
#!/bin/sh
# Copyright (C) 2023 Javier Marcet

do_sedutil_unlock() {
    echo "Unlocking OPAL drives during preinit" > /dev/kmsg

    mount -t devtmpfs devtmpfs /dev
    _pw="$( ykchalresp -1 SOME_CHALLENGE )"
    umount /dev

    if [ -z "${_pw}" ]; then
        echo "FAILED to unlock OPAL drives, could not get response from YubiKey" > /dev/kmsg
        return
    fi

    /usr/bin/sedutil-cli --setLockingRange 1 RW "${_pw}" /dev/nvme0n1 > /dev/kmsg || return

    echo "OPAL drives unlocked" > /dev/kmsg
}

boot_hook_add preinit_main do_sedutil_unlock
```
