### PR TITLE
snort3: update to 3.1.60.0

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
-PKG_VERSION:=3.1.59.0
+PKG_VERSION:=3.1.60.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
-PKG_HASH:=b4cfbce5b36ca546aac55a2545468a143643867ad9bc8560fe364eb9e10c074b
+PKG_HASH:=295bbeea93ead7835379d9c9332b1f82f9ecdd3741aeed267caf85bb887126a1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Upstream bump

Maintainer: @flyn-org
