### PR TITLE
samba4: decouple quotas from vfs option

### DIFF
--- a/net/samba4/Config.in
+++ b/net/samba4/Config.in
@@ -31,12 +31,22 @@ config SAMBA4_SERVER_AVAHI
 		Announce Samba resources via DNS/DNS-SD using the Avahi daemon, for Linux/Mac clients.
 	default y
 
+config SAMBA4_SERVER_QUOTAS
+	bool "Quotas support"
+	depends on PACKAGE_samba4-server
+	select SAMBA4_SERVER_VFS
+	help
+		Enable VFS Quotas
+		installs:
+			modules: vfs_default_quota
+	default n
+
 config SAMBA4_SERVER_VFS
 	bool "Common VFS modules"
 	depends on PACKAGE_samba4-server
 	help
 		installs:
-			modules: (vfs_btrfs) vfs_fruit vfs_shadow_copy2 vfs_recycle vfs_fake_perms vfs_readonly vfs_cap vfs_offline vfs_crossrename vfs_catia vfs_streams_xattr vfs_default_quota
+			modules: (vfs_btrfs) vfs_fruit vfs_shadow_copy2 vfs_recycle vfs_fake_perms vfs_readonly vfs_cap vfs_offline vfs_crossrename vfs_catia vfs_streams_xattr
 
 		Commonly used VFS modules, vfs_btrfs requires kmod-fs-btrfs to be selected separately
 	default y

--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -28,6 +28,7 @@ PKG_BUILD_DEPENDS:=samba4/host libtasn1/host perl/host
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_SAMBA4_SERVER_NETBIOS \
 	CONFIG_SAMBA4_SERVER_AVAHI \
+	CONFIG_SAMBA4_SERVER_QUOTAS \
 	CONFIG_SAMBA4_SERVER_VFS \
 	CONFIG_SAMBA4_SERVER_VFSX \
 	CONFIG_SAMBA4_SERVER_AD_DC \
@@ -122,7 +123,7 @@ define Package/samba4-utils
 endef
 
 define Package/samba4-utils/description
-  installs: smbstatus smbtree mvxattr smbtar smbcquotas
+  installs: smbstatus smbtree mvxattr smbtar (smbcquotas)
 
   Utilities collection
 endef
@@ -231,7 +232,7 @@ CONFIGURE_ARGS += \
 		--with-privatedir=/etc/samba
 
 # features
-ifeq ($(CONFIG_SAMBA4_SERVER_VFS),y)
+ifeq ($(CONFIG_SAMBA4_SERVER_QUOTAS),y)
 	CONFIGURE_ARGS += --with-quotas
 else
 	CONFIGURE_ARGS += --without-quotas
@@ -258,7 +259,10 @@ ifdef CONFIG_KERNEL_IO_URING
 	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_io_uring,
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_VFS),y)
-	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_fruit,vfs_shadow_copy2,vfs_recycle,vfs_fake_perms,vfs_readonly,vfs_cap,vfs_offline,vfs_crossrename,vfs_catia,vfs_streams_xattr,vfs_xattr_tdb,vfs_default_quota,vfs_widelinks,
+	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_fruit,vfs_shadow_copy2,vfs_recycle,vfs_fake_perms,vfs_readonly,vfs_cap,vfs_offline,vfs_crossrename,vfs_catia,vfs_streams_xattr,vfs_xattr_tdb,vfs_widelinks,
+ifeq ($(CONFIG_SAMBA4_SERVER_QUOTAS),y)
+	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_default_quota,
+endif
 ifdef CONFIG_PACKAGE_kmod-fs-btrfs
 	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_btrfs,
 endif
@@ -407,7 +411,7 @@ endef
 define Package/samba4-utils/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/{smbstatus,smbtree,mvxattr,smbtar} $(1)/usr/bin/
-ifeq ($(CONFIG_SAMBA4_SERVER_VFS),y)
+ifeq ($(CONFIG_SAMBA4_SERVER_QUOTAS),y)
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/smbcquotas $(1)/usr/bin/
 endif
 endef


### PR DESCRIPTION
Maintainer: nobody?
Compile tested: master x86_64
Run tested: master x86_64

Description:
I was trying to solve [this issue](https://bugzilla.samba.org/show_bug.cgi?id=10541) which showed up in my btrfs backed shares when they were accessed from a MacOS client.

Upon checking out samba's repo, it became clear the issue was within quotas and that they were opt in. After that I checked whether I could disable them in OpenWrt and that's when I saw we had them coupled to the VFS modules.

Turns out quotas can be disabled entirely, indeed solving the issue, and VFS modules are not affected, they get built, installed and can be used without issues. To my surprise, I could not only enable back a TimeMachine share I had and use it without the logs being flooded, but I also could keep the `fruit:time machine max size` option which for a moment I thought it could be dependent on quotas being enabled.

I set it to disabled as default although that's something debatable.

Also, enabling quotas enables the common VFS modules since building with only `SAMBA4_SERVER_QUOTAS` option enabled (without the auto select of `SAMBA4_SERVER_VFS`), the VFS modules get built and installed too.
