### PR TITLE
ruby: statically link extensions into host ruby

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -39,17 +39,8 @@ HOST_CONFIGURE_ARGS += \
 	--disable-install-rdoc \
 	--disable-install-capi \
 	--without-gmp \
-	--with-out-ext=-test-/array/resize,-test-/bignum,-test-/bug-3571,-test-/bug-5832,-test-/bug_reporter,-test-/class,-test-/debug,-test-/dln/empty,-test-/exception,-test-/fatal,-test-/file,-test-/float,-test-/funcall,-test-/gvl/call_without_gvl,-test-/hash,-test-/integer,-test-/iseq_load,-test-/iter,-test-/load/dot.dot,-test-/marshal/compat,-test-/marshal/internal_ivar,-test-/marshal/usr,-test-/memory_status,-test-/method,-test-/notimplement,-test-/num2int,-test-/path_to_class,-test-/popen_deadlock,-test-/postponed_job,-test-/printf,-test-/proc,-test-/rational,-test-/recursion,-test-/st/foreach,-test-/st/numhash,-test-/st/update,-test-/string,-test-/struct,-test-/symbol,-test-/time,-test-/tracepoint,-test-/typeddata,-test-/vm,-test-/wait_for_single_fd,-test-/win32/console,-test-/win32/dln,-test-/win32/fd_setsize,bigdecimal,cgi/escape,continuation,coverage,etc,fcntl,fiddle,io/console,json,json/generator,json/parser,mathn/complex,mathn/rational,nkf,objspace,pty,racc/cparse,rbconfig/sizeof,readline,rubyvm,syslog,win32,win32ole,win32/resolv
-
-# Does not compile with this. Workaround is --without-gmp
-# https://bugs.ruby-lang.org/issues/11940
-	#--with-static-linked-ext \
-
-# even not used, host build with restricted exts results in gems not being
-# compiled for target (probably some cross compiling problem like checking
-# host for selecting target features)
-#	--with-out-ext \
-#	--with-ext=thread,stringio \
+	--with-static-linked-ext \
+	--with-out-ext=-test-/*,bigdecimal,cgi/escape,continuation,coverage,etc,fcntl,fiddle,io/console,json,json/generator,json/parser,mathn/complex,mathn/rational,nkf,objspace,pty,racc/cparse,rbconfig/sizeof,readline,rubyvm,syslog,win32,win32ole,win32/resolv
 
 HOST_BUILD_DEPENDS:=yaml/host
 

--- a/libs/yaml/Makefile
+++ b/libs/yaml/Makefile
@@ -36,6 +36,8 @@ endef
 
 TARGET_CFLAGS += $(FPIC)
 
+HOST_CONFIGURE_ARGS += --disable-shared
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/yaml.h $(1)/usr/include/


### PR DESCRIPTION
Ruby uses extensions (.so files) that might also depend on other libraries. When the linker builds an executable, it will refer to the path it found the library, including those in the stagging dir. However, when it links a shared library (like ruby exts), it will let that dependency to be resolved at runtime.

During host and target build, ruby build script runs ruby scripts. When it loads a ext that depends on another library, it will, by default, look for the system libraries to satisfy that, breaking the build when it fails. Setting LD_LIBRARY_PATH to the stagging lib dir is a valid workaround.

Ruby can also be built statically linking all exts into ruby executable. That will make the linker point to the stagging library path, fixing the issue. It was used in the past but, at some point, ruby broke it. Now it is working as expected.

Closes #20839

While at it, clean up excluded extensions not used by host ruby.

Maintainer: me
Compile tested: master on x86_64 (fix for host build)
Run tested: none. host build fix.

Description:
