### PR TITLE
librespeed-go: root user is required to enable tls

### DIFF
--- a/net/librespeed-go/files/librespeed-go.init
+++ b/net/librespeed-go/files/librespeed-go.init
@@ -49,7 +49,7 @@ start_service() {
 	procd_set_param limits nofile="1000000 1000000"
 	procd_set_param respawn
 	procd_set_param stderr 1
-	procd_set_param user librespeed
+	procd_set_param user root
 
 	procd_add_jail "$CONF" log
 	procd_add_jail_mount "$TMPCONF"


### PR DESCRIPTION
Maintainer: Tianling Shen <cnsztl@immortalwrt.org>
Compile tested: x86_64, x86/64, 22.03.4
Run tested: x86_64, x86/64, 22.03.4

Description:
Take the following config as an example:
```
config librespeed-go 'config'
	option enabled '1'
	option listen_port '8989'
	option proxyprotocol_port '0'
	option server_lat '0'
	option server_lng '0'
	option redact_ip_addresses '0'
	option database_type 'none'
	option enable_http2 '1'
	option enable_tls '1'
	option tls_cert_file '/etc/librespeed-go/_lan.crt'
	option tls_key_file '/etc/librespeed-go/_lan.key'
```
Unable to start service when procd user not is root user

