### PR TITLE
iperf3: update to 3.13

### DIFF
--- a/net/iperf3/Makefile
+++ b/net/iperf3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
-PKG_VERSION:=3.12
+PKG_VERSION:=3.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.es.net/pub/iperf
-PKG_HASH:=72034ecfb6a7d6d67e384e19fb6efff3236ca4f7ed4c518d7db649c447e1ffd6
+PKG_HASH:=bee427aeb13d6a2ee22073f23261f63712d82befaa83ac8cb4db5da4c2bdc865
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Release Notes:
https://software.es.net/iperf/news.html#iperf-3-13-released

Maintainer: @nbd
Compile tested: mt7622
Run tested: Linksys E8450 (OpenWrt Snapshot)
