### PR TITLE
libpng: update to 1.6.39

### DIFF
--- a/libs/libpng/Makefile
+++ b/libs/libpng/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpng
-PKG_VERSION:=1.6.38
+PKG_VERSION:=1.6.39
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/libpng
-PKG_HASH:=b3683e8b8111ebf6f1ac004ebb6b0c975cd310ec469d98364388e9cedbfa68be
+PKG_HASH:=1f4696ce70b4ee5f85f1e1623dc1229b210029fa4b7aee573df3e2ba7b036937
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=Libpng GPL-2.0-or-later BSD-3-Clause


### PR DESCRIPTION
Changelog:
https://github.com/glennrp/libpng/blob/v1.6.39/CHANGES

Maintainer: @jow
Compile tested: mt7622
Run tested: tbd

@jow- Can you maybe runtest? This release does not seem to fix CVE-2022-3857 at least it is not mentioned in the relase notes nor I find a commit. :/