### PR TITLE
postgresql: update to 15.2

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postgresql
-PKG_VERSION:=15.1
+PKG_VERSION:=15.2
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=PostgreSQL
@@ -17,7 +17,7 @@ PKG_SOURCE_URL:=\
 	http://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
 	ftp://ftp.postgresql.org/pub/source/v$(PKG_VERSION)
 
-PKG_HASH:=64fdf23d734afad0dfe4077daca96ac51dcd697e68ae2d3d4ca6c45cb14e21ae
+PKG_HASH:=99a2171fc3d6b5b5f56b757a7a3cb85d509a38e4273805def23941ed2b8468c7
 
 PKG_BUILD_FLAGS:=no-mips16
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Release Notes:
https://www.postgresql.org/docs/release/15.2/

Fixes: CVE-2022-41862

Maintainer: @dangowrt 
Compile tested: mt7622
Run tested: tbd

@dangowrt Could you run-test? Otherwise, I need to make up some postgresql installation myself.
