### PR TITLE
go: find bootstrap automatically if go bin exists

### DIFF
--- a/lang/golang/golang/Makefile
+++ b/lang/golang/golang/Makefile
@@ -180,6 +180,12 @@ endef
 BOOTSTRAP_ROOT_DIR:=$(call qstrip,$(CONFIG_GOLANG_EXTERNAL_BOOTSTRAP_ROOT))
 
 ifeq ($(BOOTSTRAP_ROOT_DIR),)
+ifneq ($(shell go version 2>/dev/null | sed -E '/^go version .+/!d'),)
+  BOOTSTRAP_ROOT_DIR:=$(shell command -v go)
+endif
+endif
+
+ifeq ($(BOOTSTRAP_ROOT_DIR),)
   BOOTSTRAP_ROOT_DIR:=$(BOOTSTRAP_BUILD_DIR)
 
   define Download/golang-bootstrap


### PR DESCRIPTION
Maintainer: @jefferyto 
Compile tested: aarch64 master
Run tested: aarch64 master

Description:

When compiling go packages on a non-x86 host, users are very likely to hit the error that bootstrapping failed. This makes it less likely to happen by automatically find the host go bin if it exists.

The "go version" string [is hardcoded](https://cs.opensource.google/go/go/+/refs/tags/go1.20.3:src/cmd/go/internal/version/version.go;drc=2af48cbb7d85e5fdc635e75b99f949010c607786;l=76), so it should be safe to anchor.