### PR TITLE
restic: update to 0.15.2

### DIFF
--- a/utils/restic/Makefile
+++ b/utils/restic/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=restic
-PKG_VERSION:=0.15.1
+PKG_VERSION:=0.15.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/restic/restic/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=fce382fdcdac0158a35daa640766d5e8a6e7b342ae2b0b84f2aacdff13990c52
+PKG_HASH:=52aca841486eaf4fe6422b059aa05bbf20db94b957de1d3fca019ed2af8192b7
 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: Tom Stöveken <tom@naaa.de>
Compile tested: SDK for OpenWrt 22.03.4
Run tested: x86/64 @ Intel(R) Celeron(R) CPU N3160 @ 1.60GHz, OpenWrt 22.03.4

Description:
Updated to version 0.15.2