### PR TITLE
[22.03] libreswan: update to 4.10

### DIFF
--- a/net/libreswan/Makefile
+++ b/net/libreswan/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libreswan
-PKG_VERSION:=4.7
+PKG_VERSION:=4.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.libreswan.org/
-PKG_HASH:=ddd6337b3900063d870301c3d9f61f56107c765850fb00a163d360359ff3fc44
+PKG_HASH:=f642dcb635e909564ca8fd99ea44ab43f60723b4d76c158ed812978c45b398b9
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/libreswan/Makefile
+++ b/net/libreswan/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libreswan
-PKG_VERSION:=4.9
+PKG_VERSION:=4.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.libreswan.org/
-PKG_HASH:=f642dcb635e909564ca8fd99ea44ab43f60723b4d76c158ed812978c45b398b9
+PKG_HASH:=5a9400c25a8edba07420426fb55dcbaafdaa3702e5b0f2c19205a6c567248a7b
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/libreswan/patches/020-limits.patch
+++ b/net/libreswan/patches/020-limits.patch
@@ -1,6 +1,6 @@
 --- a/programs/pluto/connections.c
 +++ b/programs/pluto/connections.c
-@@ -34,6 +34,7 @@
+@@ -35,6 +35,7 @@
  #include <stdio.h>
  #include <stddef.h>
  #include <stdlib.h>


### PR DESCRIPTION
Release Notes:
https://github.com/libreswan/libreswan/releases/tag/v4.10

Fixes: CVE-2023-23009
Signed-off-by: Nick Hainke <vincent@systemli.org>
(cherry picked from commit 130e63931fe99b1e47989bb708543c5ebc12152a)

Maintainer: @lucize 
Compile tested: ci
Run tested: no


@lucize Is there any reason you did not update to a newer version on 22.03? Can we also go to 4.10 on 22.03 or do you want to leave it as 4.7. We may than have to backport the fix.