### PR TITLE
mwan3: fix addition of routes to mwan3_connected ipset

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.11.4
+PKG_VERSION:=2.11.7
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>

--- a/net/mwan3/files/usr/sbin/mwan3rtmon
+++ b/net/mwan3/files/usr/sbin/mwan3rtmon
@@ -75,7 +75,7 @@ mwan3_rtmon_route_handle()
 
 	if [ "$route_line" = "$1" ]; then
 		action="replace"
-		$IPS -! add mwan3_connected_${route_family##ip} ${route_line%% *}
+		$IPS -! add mwan3_connected_${route_family} ${route_line%% *}
 	else
 		action="del"
 		mwan3_set_connected_${route_family}


### PR DESCRIPTION
Addition of routes to mwan3_connected ipset was broken in 2.11.0. The commit fixes this issue.

Maintainer: @feckert 
Compile tested: x86-64, OpenWrt master
Run tested: x86-64, OpenWrt master

Description:

Addition of routes to mwan3_connected ipset was broken in 2.11.0.

The ipset name was changed from mwan3_connected_v4/6 to mwan3_connected_ipv4/6, but this change was not reflected in mwan3rtmon.

Fixes  #20779