### PR TITLE
nginx: refactor

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -295,7 +295,7 @@ define Package/nginx-mod-luci
   SUBMENU:=Web Servers/Proxies
   TITLE:=Support file for Nginx
   URL:=http://nginx.org/
-  DEPENDS:=+uwsgi +uwsgi-luci-support +nginx +nginx-mod-ubus
+  DEPENDS:=+uwsgi +uwsgi-luci-support +nginx-ssl +nginx-mod-ubus
   # TODO: add PROVIDES when removing nginx-mod-luci-ssl
   # PROVIDES:=nginx-mod-luci-ssl
 endef

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -25,6 +25,22 @@ PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 PKG_BUILD_FLAGS:=gc-sections
 
+# 3rd-party modules
+PKG_MOD_EXTRA := \
+	lua \
+	rtmp \
+	dav-ext \
+	naxsi \
+	brotli \
+	headers-more \
+	ts \
+	ubus
+# official and 3rd-party modules
+PKG_MOD_ALL := \
+	$(PKG_MOD_EXTRA) \
+	stream
+PKG_MOD_PATCHED := $(shell find patches -mindepth 1 -maxdepth 1 -type d -name 'nginx-mod-*' | sed -E 's,^patches/nginx-mod-,,')
+
 PKG_CONFIG_DEPENDS := \
 	CONFIG_NGINX_DAV \
 	CONFIG_NGINX_FLV \
@@ -63,7 +79,8 @@ PKG_CONFIG_DEPENDS := \
 	CONFIG_NGINX_HTTP_REAL_IP \
 	CONFIG_NGINX_HTTP_SECURE_LINK \
 	CONFIG_OPENSSL_ENGINE \
-	CONFIG_OPENSSL_WITH_NPN
+	CONFIG_OPENSSL_WITH_NPN \
+	$(foreach m,$(PKG_MOD_EXTRA),CONFIG_PACKAGE_$(m))
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -84,6 +101,10 @@ define Package/nginx/description
  written by Igor Sysoev.
 endef
 
+define Package/nginx/conffiles
+/etc/nginx/
+endef
+
 define Package/nginx-ssl
   $(Package/nginx/default)
   TITLE += with SSL support
@@ -99,194 +120,59 @@ Package/nginx-ssl/description = $(Package/nginx/description) \
   This variant is compiled with SSL support enabled. To enable additional module \
   select them in the nginx default configuration menu.
 
+define Package/nginx-ssl/config
+  source "$(SOURCE)/Config_ssl.in"
+endef
+
+Package/nginx-ssl/conffiles = $(Package/nginx/conffiles)
+
+IsEnabled = $(or $(filter full,$(BUILD_VARIANT)),$(CONFIG_$(1)))
+IsDisabled = $(if $(call IsEnabled,$(1)),,1)
+
+config_files := mime.types \
+	$(if $(call IsEnabled,NGINX_HTTP_CHARSET),koi-utf koi-win win-utf) \
+	$(if $(call IsEnabled,NGINX_HTTP_FASTCGI),fastcgi_params) \
+	$(if $(call IsEnabled,NGINX_HTTP_UWSGI),uwsgi_params) \
+	$(if $(call IsEnabled,NGINX_HTTP_SCGI),scgi_params)
+
+define Package/nginx-ssl/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/nginx $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/nginx/conf.d
+	$(INSTALL_DATA) $(addprefix $(PKG_INSTALL_DIR)/etc/nginx/,$(config_files)) $(1)/etc/nginx/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/nginx.init $(1)/etc/init.d/nginx
+endef
+
+define Package/nginx-ssl/prerm
+#!/bin/sh
+[ -z "$${IPKG_INSTROOT}" ] || exit 0
+[ "$${PKG_UPGRADE}" = "1" ] && exit 0
+eval $$(/usr/bin/nginx-util get_env)
+[ "$$(uci get "nginx.$${LAN_NAME}.$${MANAGE_SSL}")" = "self-signed" ] || exit 0
+rm -f "$$(uci get "nginx.$${LAN_NAME}.ssl_certificate")"
+rm -f "$$(uci get "nginx.$${LAN_NAME}.ssl_certificate_key")"
+exit 0
+endef
+
 define Package/nginx-full
   $(Package/nginx/default)
   TITLE += with ALL module selected
   DEPENDS+=+libpcre +nginx-ssl-util +zlib +libxml2 \
-  +nginx-mod-ubus +nginx-mod-naxsi +nginx-mod-lua \
-  +nginx-mod-dav-ext +nginx-mod-stream +nginx-mod-headers-more \
-  +nginx-mod-brotli +nginx-mod-rtmp +nginx-mod-ts
+    $(foreach m,$(PKG_MOD_ALL),+nginx-mod-$(m))
   EXTRA_DEPENDS:=nginx-ssl-util (>=1.5-1) (<2)
-  VARIANT:=all-module
+  VARIANT:=full
   PROVIDES += nginx-ssl
 endef
 
 Package/nginx-full/description = $(Package/nginx/description) \
   This variant is compiled with ALL module selected.
 
-define Package/nginx-ssl/config
-  source "$(SOURCE)/Config_ssl.in"
-endef
+Package/nginx-full/install = $(Package/nginx-ssl/install)
 
-config_files=mime.types
+Package/nginx-full/prerm = $(Package/nginx-ssl/prerm)
 
-define Package/nginx/conffiles
-/etc/nginx/
-endef
-
-Package/nginx-ssl/conffiles = $(Package/nginx/conffiles)
 Package/nginx-full/conffiles = $(Package/nginx/conffiles)
-
-ADDITIONAL_MODULES:= --with-http_ssl_module
-
-ifneq ($(BUILD_VARIANT),all-module)
-  ifneq ($(CONFIG_NGINX_HTTP_CACHE),y)
-    ADDITIONAL_MODULES += --without-http-cache
-  endif
-  ifneq ($(CONFIG_NGINX_PCRE),y)
-    ADDITIONAL_MODULES += --without-pcre
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_CHARSET),y)
-    ADDITIONAL_MODULES += --without-http_charset_module
-  else
-    config_files += koi-utf koi-win win-utf
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_GZIP),y)
-    ADDITIONAL_MODULES += --without-http_gzip_module
-  endif
-  ifeq ($(CONFIG_NGINX_HTTP_GZIP_STATIC),y)
-    ADDITIONAL_MODULES += --with-http_gzip_static_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_SSI),y)
-    ADDITIONAL_MODULES += --without-http_ssi_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_USERID),y)
-    ADDITIONAL_MODULES += --without-http_userid_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_ACCESS),y)
-    ADDITIONAL_MODULES += --without-http_access_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_AUTH_BASIC),y)
-    ADDITIONAL_MODULES += --without-http_auth_basic_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_AUTOINDEX),y)
-    ADDITIONAL_MODULES += --without-http_autoindex_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_GEO),y)
-    ADDITIONAL_MODULES += --without-http_geo_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_MAP),y)
-    ADDITIONAL_MODULES += --without-http_map_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_SPLIT_CLIENTS),y)
-    ADDITIONAL_MODULES += --without-http_split_clients_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_REFERER),y)
-    ADDITIONAL_MODULES += --without-http_referer_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_REWRITE),y)
-    ADDITIONAL_MODULES += --without-http_rewrite_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_PROXY),y)
-    ADDITIONAL_MODULES += --without-http_proxy_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_FASTCGI),y)
-    ADDITIONAL_MODULES += --without-http_fastcgi_module
-  else
-    config_files += fastcgi_params
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_UWSGI),y)
-    ADDITIONAL_MODULES += --without-http_uwsgi_module
-  else
-    config_files += uwsgi_params
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_SCGI),y)
-    ADDITIONAL_MODULES += --without-http_scgi_module
-  else
-    config_files += scgi_params
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_MEMCACHED),y)
-    ADDITIONAL_MODULES += --without-http_memcached_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_LIMIT_CONN),y)
-    ADDITIONAL_MODULES += --without-http_limit_conn_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_LIMIT_REQ),y)
-    ADDITIONAL_MODULES += --without-http_limit_req_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_EMPTY_GIF),y)
-    ADDITIONAL_MODULES += --without-http_empty_gif_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_BROWSER),y)
-    ADDITIONAL_MODULES += --without-http_browser_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_UPSTREAM_HASH),y)
-    ADDITIONAL_MODULES += --without-http_upstream_hash_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_UPSTREAM_IP_HASH),y)
-    ADDITIONAL_MODULES += --without-http_upstream_ip_hash_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_UPSTREAM_LEAST_CONN),y)
-    ADDITIONAL_MODULES += --without-http_upstream_least_conn_module
-  endif
-  ifneq ($(CONFIG_NGINX_HTTP_UPSTREAM_KEEPALIVE),y)
-    ADDITIONAL_MODULES += --without-http_upstream_keepalive_module
-  endif
-  ifeq ($(CONFIG_IPV6),y)
-    ADDITIONAL_MODULES += --with-ipv6
-  endif
-  ifeq ($(CONFIG_NGINX_STUB_STATUS),y)
-    ADDITIONAL_MODULES += --with-http_stub_status_module
-  endif
-  ifeq ($(CONFIG_NGINX_FLV),y)
-    ADDITIONAL_MODULES += --with-http_flv_module
-  endif
-  ifeq ($(CONFIG_NGINX_DAV),y)
-    ADDITIONAL_MODULES += --with-http_dav_module
-  endif
-  ifeq ($(CONFIG_NGINX_HTTP_AUTH_REQUEST),y)
-    ADDITIONAL_MODULES += --with-http_auth_request_module
-  endif
-  ifeq ($(CONFIG_NGINX_HTTP_V2),y)
-    ADDITIONAL_MODULES += --with-http_v2_module
-  endif
-  ifeq ($(CONFIG_NGINX_HTTP_REAL_IP),y)
-    ADDITIONAL_MODULES += --with-http_realip_module
-  endif
-  ifeq ($(CONFIG_NGINX_HTTP_SECURE_LINK),y)
-    ADDITIONAL_MODULES += --with-http_secure_link_module
-  endif
-  ifeq ($(CONFIG_NGINX_HTTP_SUB),y)
-	ADDITIONAL_MODULES += --with-http_sub_module
-  endif
-else
-  ADDITIONAL_MODULES += --with-ipv6 --with-http_stub_status_module --with-http_flv_module \
-	--with-http_dav_module \
-	--with-http_auth_request_module --with-http_v2_module --with-http_realip_module \
-	--with-http_secure_link_module --with-http_sub_module \
-  config_files += koi-utf koi-win win-utf fastcgi_params uwsgi_params
-endif
-
-ifneq ($(CONFIG_PACKAGE_nginx-mod-naxsi),)
-  ADDITIONAL_MODULES += --add-dynamic-module=$(PKG_BUILD_DIR)/nginx-naxsi/naxsi_src
-endif
-ifneq ($(CONFIG_PACKAGE_nginx-mod-lua),)
-  ADDITIONAL_MODULES += --add-dynamic-module=$(PKG_BUILD_DIR)/lua-nginx
-endif
-ifneq ($(CONFIG_PACKAGE_nginx-mod-dav-ext),)
-  ADDITIONAL_MODULES += --add-dynamic-module=$(PKG_BUILD_DIR)/nginx-dav-ext-module
-endif
-ifneq ($(CONFIG_PACKAGE_nginx-mod-stream),)
-  ADDITIONAL_MODULES += --with-stream=dynamic --with-stream_ssl_module --with-stream_ssl_preread_module
-endif
-ifneq ($(CONFIG_PACKAGE_nginx-mod-ubus),)
-  ADDITIONAL_MODULES += --add-dynamic-module=$(PKG_BUILD_DIR)/nginx-ubus-module
-endif
-ifneq ($(CONFIG_PACKAGE_nginx-mod-headers-more),)
-  ADDITIONAL_MODULES += --add-dynamic-module=$(PKG_BUILD_DIR)/nginx-headers-more
-endif
-ifneq ($(CONFIG_PACKAGE_nginx-mod-brotli),)
-  ADDITIONAL_MODULES += --add-dynamic-module=$(PKG_BUILD_DIR)/nginx-brotli
-endif
-ifneq ($(CONFIG_PACKAGE_nginx-mod-rtmp),)
-  ADDITIONAL_MODULES += --add-dynamic-module=$(PKG_BUILD_DIR)/nginx-rtmp
-endif
-ifneq ($(CONFIG_PACKAGE_nginx-mod-ts),)
-  ADDITIONAL_MODULES += --add-dynamic-module=$(PKG_BUILD_DIR)/nginx-ts
-endif
-ifeq ($(CONFIG_NGINX_GEOIP_MODULE),y)
-  ADDITIONAL_MODULES += --with-http_geoip_module=dynamic
-endif
 
 define Package/nginx-mod-luci
   TITLE:=Nginx on LuCI
@@ -304,89 +190,146 @@ define Package/nginx-mod-luci/description
  Support file for LuCI in nginx. Include custom nginx configuration, autostart script for uwsgi.
 endef
 
-NGINX_MODULES :=
+define Package/nginx-mod-luci/install
+	$(INSTALL_DIR) $(1)/etc/nginx/conf.d
+	$(INSTALL_CONF) ./files-luci-support/luci.locations $(1)/etc/nginx/conf.d/
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files-luci-support/60_nginx-luci-support $(1)/etc/uci-defaults/60_nginx-luci-support
+endef
+
+define Download/nginx-mod-headers-more
+  VERSION:=bea1be3bbf6af28f6aa8cf0c01c07ee1637e2bd0
+  URL:=https://github.com/openresty/headers-more-nginx-module.git
+  MIRROR_HASH:=3617bbf7a935208a1d8d5f86a8f9b770f6987e4d2b5663a9ab1b777217e3066b
+  PROTO:=git
+endef
+
+
+define Download/nginx-mod-brotli
+  VERSION:=e505dce68acc190cc5a1e780a3b0275e39f160ca
+  URL:=https://github.com/google/ngx_brotli.git
+  MIRROR_HASH:=04847f11ef808fed50f44b2af0ef3abf59ff0ffc06dfc7394d9ab51d53fef31f
+  PROTO:=git
+endef
+
+define Download/nginx-mod-rtmp
+  VERSION:=f0ea62342a4eca504b311cd5df910d026c3ea4cf
+  URL:=https://github.com/ut0mt8/nginx-rtmp-module.git
+  MIRROR_HASH:=d3f58066f0f858ed79f7f2b0c9b89de2ccc512c94ab3d0625f6dcff3df0b72c1
+  PROTO:=git
+endef
+
+define Download/nginx-mod-ts
+  VERSION:=ef2f874d95cc75747eb625a292524a702aefb0fd
+  URL:=https://github.com/arut/nginx-ts-module.git
+  MIRROR_HASH:=73938950bb286d40d9e54b0994d1a63827340c1156c72eb04d7041b25b20ec18
+  PROTO:=git
+endef
+
+define Download/nginx-mod-naxsi
+  VERSION:=951123ad456bdf5ac94e8d8819342fe3d49bc002
+  URL:=https://github.com/nbs-system/naxsi.git
+  MIRROR_HASH:=c734cae19a596affadd62a2df1b58d3df8d1364093a4e80a7cd1ab4555963535
+  PROTO:=git
+endef
+
+define Download/nginx-mod-lua
+  VERSION:=68acad14e4a8f42e31d4a4bb5ed44d6f5b55fc1c
+  URL:=https://github.com/openresty/lua-nginx-module.git
+  MIRROR_HASH:=366f24e1ba6221e34f6ba20ab29146438438f88c89fd71f9500d169b3f5aedf0
+  PROTO:=git
+endef
+
+define Download/nginx-mod-dav-ext
+  VERSION:=f5e30888a256136d9c550bf1ada77d6ea78a48af
+  URL:=https://github.com/arut/nginx-dav-ext-module.git
+  MIRROR_HASH:=70bb4c3907f4b783605500ba494e907aede11f8505702e370012abb3c177dc5b
+  PROTO:=git
+endef
+
+define Download/nginx-mod-ubus
+  VERSION:=b2d7260dcb428b2fb65540edb28d7538602b4a26
+  URL:=https://github.com/Ansuel/nginx-ubus-module.git
+  MIRROR_HASH:=472cef416d25effcac66c85417ab6596e634a7a64d45b709bb090892d567553c
+  PROTO:=git
+endef
+
+define Module/Download
+  define Download/nginx-mod-$(1) +=
+
+    SUBDIR:=nginx-mod-$(1)
+    FILE:=nginx-mod-$(1)-$$$$(VERSION).tar.xz
+  endef
+endef
+$(foreach m,$(PKG_MOD_EXTRA),$(eval $(call Module/Download,$(m))))
+
+define Module/nginx-mod-naxsi/install
+	$(INSTALL_DIR) $(1)/etc/nginx
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/nginx-mod-naxsi/naxsi_config/naxsi_core.rules $(1)/etc/nginx
+endef
+
+define Quilt/Refresh/Package
+	$(call Quilt/RefreshDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/nginx,nginx/)
+	$(foreach m,$(PKG_MOD_PATCHED),
+		$(call Quilt/RefreshDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/nginx-mod-$(m),nginx-mod-$(m)/)
+	)
+endef
+
+define Build/Patch
+	$(if $(QUILT),rm -rf $(PKG_BUILD_DIR)/patches; mkdir -p $(PKG_BUILD_DIR)/patches)
+	$(call PatchDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/nginx,nginx/)
+	$(foreach m,$(PKG_MOD_PATCHED),$(if $(or $(CONFIG_PACKAGE_nginx-mod-$(m)),$(QUILT)),
+		$(call PatchDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/nginx-mod-$(m),nginx-mod-$(m)/)
+	))
+	$(if $(QUILT),touch $(PKG_BUILD_DIR)/.quilt_used)
+endef
+
+define Module/Build/Prepare
+	$(eval $(call Download,nginx-mod-$(1)))
+	$(eval $(Download/nginx-mod-$(1)))
+	mkdir -p $(PKG_BUILD_DIR)/nginx-mod-$(1)
+	xzcat $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR)/nginx-mod-$(1) $(TAR_OPTIONS) --strip-components 1
+endef
+
+define Build/Prepare
+	rm -rf $(PKG_BUILD_DIR)
+	mkdir -p $(PKG_BUILD_DIR)
+	$(PKG_UNPACK)
+
+	$(foreach m,$(filter-out $(PKG_MOD_PATCHED),$(PKG_MOD_EXTRA)),$(if $(CONFIG_PACKAGE_nginx-mod-$(m)),
+		$(call Module/Build/Prepare,$(m))
+	))
+	$(foreach m,$(PKG_MOD_PATCHED),$(if $(or $(CONFIG_PACKAGE_nginx-mod-$(m)),$(QUILT)),
+		$(call Module/Build/Prepare,$(m))
+	))
+	$(Build/Patch)
+endef
 
 # $(1) module name
 # $(2) module additional dependency
 # $(3) module so name (stripped of the finaly _module.so)
 # $(4) module description
-define module
-  define Package/nginx-mod-$(strip $(1))
-	$(call Package/nginx/default)
-	DEPENDS:=+nginx-ssl $(2)
-	TITLE:=Nginx $(1) module
+define BuildModule
+  define Package/nginx-mod-$(1)
+    $(call Package/nginx/default)
+    DEPENDS:=+nginx-ssl $(2)
+    TITLE:=Nginx $(1) module
   endef
 
-  define Package/nginx-mod-$(strip $(1))/description
-   $(4)
+  define Package/nginx-mod-$(1)/description
+    $(strip $(4))
   endef
 
-  define Package/nginx-mod-$(strip $(1))/install
+  define Package/nginx-mod-$(1)/install
 	$(INSTALL_DIR) $$(1)/usr/lib/nginx/modules
-	$(INSTALL_BIN) $$(PKG_INSTALL_DIR)/usr/lib/nginx/modules/$(3)_module.so $$(1)/usr/lib/nginx/modules
+	$(foreach m,$(3),
+	  $(CP) $$(PKG_INSTALL_DIR)/usr/lib/nginx/modules/$(m)_module.so $$(1)/usr/lib/nginx/modules
+	)
+	$(call Module/nginx-mod-$(1)/install,$$(1))
   endef
 
-  NGINX_MODULES += nginx-mod-$(strip $(1))
+  $$(eval $$(call BuildPackage,nginx-mod-$(1)))
 endef
-
-define brotli
-  define Package/nginx-mod-brotli
-	$(call Package/nginx/default)
-	DEPENDS:=+nginx-ssl
-	TITLE:=Nginx Brotli module
-  endef
-
-  define Package/nginx-mod-brotli/description
-   Add support for brotli compression module.
-  endef
-
-  define Package/nginx-mod-brotli/install
-	$(INSTALL_DIR) $$(1)/usr/lib/nginx/modules
-	$(INSTALL_BIN) $$(PKG_INSTALL_DIR)/usr/lib/nginx/modules/ngx_http_brotli_filter_module.so $$(1)/usr/lib/nginx/modules
-	$(INSTALL_BIN) $$(PKG_INSTALL_DIR)/usr/lib/nginx/modules/ngx_http_brotli_static_module.so $$(1)/usr/lib/nginx/modules
-  endef
-
-  NGINX_MODULES += nginx-mod-brotli
-endef
-
-define naxsi
-  define Package/nginx-mod-naxsi
-	$(call Package/nginx/default)
-	DEPENDS:=+nginx-ssl
-	TITLE:=Nginx naxsi module
-  endef
-
-  define Package/nginx-mod-naxsi/description
-   Enable NAXSI module.
-  endef
-
-  define Package/nginx-mod-naxsi/install
-	$(INSTALL_DIR) $$(1)/usr/lib/nginx/modules
-	$(INSTALL_BIN) $$(PKG_INSTALL_DIR)/usr/lib/nginx/modules/ngx_http_naxsi_module.so $$(1)/usr/lib/nginx/modules
-
-	$(INSTALL_DIR) $$(1)/etc/nginx
-	$(INSTALL_BIN) $$(PKG_BUILD_DIR)/nginx-naxsi/naxsi_config/naxsi_core.rules $$(1)/etc/nginx
-	chmod 0640 $$(1)/etc/nginx/naxsi_core.rules
-
-	$(INSTALL_BIN) $$(PKG_BUILD_DIR)/nginx-naxsi/naxsi_config/naxsi_core.rules $$(1)/etc/nginx
-	chmod 0640 $$(1)/etc/nginx/naxsi_core.rules
-  endef
-
-  NGINX_MODULES += nginx-mod-naxsi
-endef
-
-$(eval $(call module,lua, +luajit,ngx_http_lua, Enable Lua module))
-$(eval $(call module,stream, +@NGINX_STREAM_CORE_MODULE,ngx_stream, Add support for NGINX request streaming.))
-$(eval $(call module,ubus, +libubus +libjson-c +libblobmsg-json +@NGINX_UBUS,ngx_http_ubus, Enable UBUS api support directly from the server.))
-$(eval $(call module,dav-ext, +@NGINX_DAV +libxml2,ngx_http_dav_ext, Enable the WebDAV methods PROPFIND OPTIONS LOCK UNLOCK.))
-$(eval $(call module,headers-more,,ngx_http_headers_more_filter, Set and clear input and output headers...more than "add"!))
-$(eval $(call module,rtmp,,ngx_rtmp, Add support for NGINX-based Media Streaming Server module. \
-		DASH enhanced - https://github.com/ut0mt8/nginx-rtmp-module))
-$(eval $(call module, ts,,ngx_http_ts, Add support for MPEG-TS Live Module module.))
-$(eval $(call brotli))
-$(eval $(call naxsi))
-
-PKG_CONFIG_DEPENDS += $(patsubst %,CONFIG_PACKAGE_%,$(NGINX_MODULES))
 
 TARGET_CFLAGS += -DNGX_LUA_NO_BY_LUA_BLOCK
 
@@ -398,243 +341,87 @@ endif
 CONFIGURE_VARS += CONFIG_BIG_ENDIAN=$(CONFIG_BIG_ENDIAN)
 
 CONFIGURE_ARGS += \
-			--crossbuild=Linux::$(ARCH) \
-			--prefix=/usr \
-			--conf-path=/etc/nginx/nginx.conf \
-			--modules-path=/usr/lib/nginx/modules \
-			--with-compat \
-			$(ADDITIONAL_MODULES) \
-			--error-log-path=stderr \
-			--pid-path=/var/run/nginx.pid \
-			--lock-path=/var/lock/nginx.lock \
-			--http-log-path=/var/log/nginx/access.log \
-			--http-client-body-temp-path=/var/lib/nginx/body \
-			--http-proxy-temp-path=/var/lib/nginx/proxy \
-			--http-fastcgi-temp-path=/var/lib/nginx/fastcgi \
-			--with-cc="$(TARGET_CC)" \
-			--with-cc-opt="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS)" \
-			--with-ld-opt="$(TARGET_LDFLAGS)" \
-			--without-http_upstream_zone_module \
-			--without-pcre2
-
-define Package/nginx-mod-luci/install
-	$(INSTALL_DIR) $(1)/etc/nginx/conf.d
-	$(INSTALL_CONF) ./files-luci-support/luci.locations $(1)/etc/nginx/conf.d/
-	$(INSTALL_DIR) $(1)/etc/uci-defaults
-	$(INSTALL_BIN) ./files-luci-support/60_nginx-luci-support $(1)/etc/uci-defaults/60_nginx-luci-support
-endef
-
-define Package/nginx-ssl/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/nginx $(1)/usr/sbin/
-	$(INSTALL_DIR) $(1)/etc/nginx/conf.d
-	$(INSTALL_DATA) $(addprefix $(PKG_INSTALL_DIR)/etc/nginx/,$(config_files)) $(1)/etc/nginx/
-	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) ./files/nginx.init $(1)/etc/init.d/nginx
-endef
-
-Package/nginx-full/install = $(Package/nginx-ssl/install)
-
-define Package/nginx-ssl/prerm
-#!/bin/sh
-[ -z "$${IPKG_INSTROOT}" ] || exit 0
-[ "$${PKG_UPGRADE}" = "1" ] && exit 0
-eval $$(/usr/bin/nginx-util get_env)
-[ "$$(uci get "nginx.$${LAN_NAME}.$${MANAGE_SSL}")" = "self-signed" ] || exit 0
-rm -f "$$(uci get "nginx.$${LAN_NAME}.ssl_certificate")"
-rm -f "$$(uci get "nginx.$${LAN_NAME}.ssl_certificate_key")"
-exit 0
-endef
-
-Package/nginx-full/prerm = $(Package/nginx-ssl/prerm)
-
-define Download/nginx-headers-more
-  VERSION:=bea1be3bbf6af28f6aa8cf0c01c07ee1637e2bd0
-  SUBDIR:=nginx-headers-more
-  FILE:=headers-more-nginx-module-$$(VERSION).tar.xz
-  URL:=https://github.com/openresty/headers-more-nginx-module.git
-  MIRROR_HASH:=3617bbf7a935208a1d8d5f86a8f9b770f6987e4d2b5663a9ab1b777217e3066b
-  PROTO:=git
-endef
-
-define Prepare/nginx-headers-more
-	$(eval $(Download/nginx-headers-more))
-	xzcat $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
-endef
-
-define Download/nginx-brotli
-  VERSION:=e505dce68acc190cc5a1e780a3b0275e39f160ca
-  SUBDIR:=nginx-brotli
-  FILE:=ngx-brotli-module-$$(VERSION).tar.xz
-  URL:=https://github.com/google/ngx_brotli.git
-  MIRROR_HASH:=04847f11ef808fed50f44b2af0ef3abf59ff0ffc06dfc7394d9ab51d53fef31f
-  PROTO:=git
-endef
-
-define Prepare/nginx-brotli
-	$(eval $(Download/nginx-brotli))
-	xzcat $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
-endef
-
-define Download/nginx-rtmp
-  VERSION:=f0ea62342a4eca504b311cd5df910d026c3ea4cf
-  SUBDIR:=nginx-rtmp
-  FILE:=ngx-rtmp-module-$$(VERSION).tar.xz
-  URL:=https://github.com/ut0mt8/nginx-rtmp-module.git
-  MIRROR_HASH:=d3f58066f0f858ed79f7f2b0c9b89de2ccc512c94ab3d0625f6dcff3df0b72c1
-  PROTO:=git
-endef
-
-define Prepare/nginx-rtmp
-	$(eval $(Download/nginx-rtmp))
-	xzcat $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
-endef
-
-define Download/nginx-ts
-  VERSION:=ef2f874d95cc75747eb625a292524a702aefb0fd
-  SUBDIR:=nginx-ts
-  FILE:=ngx-ts-module-$$(VERSION).tar.xz
-  URL:=https://github.com/arut/nginx-ts-module.git
-  MIRROR_HASH:=73938950bb286d40d9e54b0994d1a63827340c1156c72eb04d7041b25b20ec18
-  PROTO:=git
-endef
-
-define Prepare/nginx-ts
-	$(eval $(Download/nginx-ts))
-	xzcat $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
-endef
-
-define Download/nginx-naxsi
-  VERSION:=951123ad456bdf5ac94e8d8819342fe3d49bc002
-  SUBDIR:=nginx-naxsi
-  FILE:=nginx-naxsi-module-$$(VERSION).tar.xz
-  URL:=https://github.com/nbs-system/naxsi.git
-  MIRROR_HASH:=c734cae19a596affadd62a2df1b58d3df8d1364093a4e80a7cd1ab4555963535
-  PROTO:=git
-endef
-
-define Prepare/nginx-naxsi
-	$(eval $(Download/nginx-naxsi))
-	xzcat $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
-endef
-
-define Download/lua-nginx
-  VERSION:=68acad14e4a8f42e31d4a4bb5ed44d6f5b55fc1c
-  SUBDIR:=lua-nginx
-  FILE:=lua-nginx-module-$$(VERSION).tar.xz
-  URL:=https://github.com/openresty/lua-nginx-module.git
-  MIRROR_HASH:=366f24e1ba6221e34f6ba20ab29146438438f88c89fd71f9500d169b3f5aedf0
-  PROTO:=git
-endef
-
-define Prepare/lua-nginx
-	$(eval $(Download/lua-nginx))
-	xzcat $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
-endef
-
-define Download/nginx-dav-ext-module
-  VERSION:=f5e30888a256136d9c550bf1ada77d6ea78a48af
-  SUBDIR:=nginx-dav-ext-module
-  FILE:=nginx-dav-ext-module-$$(VERSION).tar.xz
-  URL:=https://github.com/arut/nginx-dav-ext-module.git
-  MIRROR_HASH:=70bb4c3907f4b783605500ba494e907aede11f8505702e370012abb3c177dc5b
-  PROTO:=git
-endef
-
-define Prepare/nginx-dav-ext-module
-	$(eval $(Download/nginx-dav-ext-module))
-	xzcat $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
-endef
-
-define Download/nginx-ubus-module
-  VERSION:=b2d7260dcb428b2fb65540edb28d7538602b4a26
-  SUBDIR:=nginx-ubus-module
-  FILE:=nginx-ubus-module-$$(VERSION).tar.xz
-  URL:=https://github.com/Ansuel/nginx-ubus-module.git
-  MIRROR_HASH:=472cef416d25effcac66c85417ab6596e634a7a64d45b709bb090892d567553c
-  PROTO:=git
-endef
-
-define Prepare/nginx-ubus-module
-	$(eval $(Download/nginx-ubus-module))
-	xzcat $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
-endef
-
-define Build/Patch
-	$(if $(QUILT),rm -rf $(PKG_BUILD_DIR)/patches; mkdir -p $(PKG_BUILD_DIR)/patches)
-	$(call PatchDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/nginx,nginx/)
-ifneq "$(or $(CONFIG_PACKAGE_nginx-mod-dav-ext),$(QUILT))" ""
-	$(call PatchDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/dav-nginx,dav-nginx/)
-endif
-ifneq "$(or $(CONFIG_PACKAGE_nginx-mod-lua),$(QUILT))" ""
-	$(call PatchDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/lua-nginx,lua-nginx/)
-endif
-ifneq "$(or $(CONFIG_PACKAGE_nginx-mod-rtmp),$(QUILT))" ""
-	$(call PatchDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/rtmp-nginx,rtmp-nginx/)
-endif
-	$(if $(QUILT),touch $(PKG_BUILD_DIR)/.quilt_used)
-endef
-
-define Quilt/Refresh/Package
-	$(call Quilt/RefreshDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/nginx,nginx/)
-	$(call Quilt/RefreshDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/dav-nginx,dav-nginx/)
-	$(call Quilt/RefreshDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/lua-nginx,lua-nginx/)
-	$(call Quilt/RefreshDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/rtmp-nginx,rtmp-nginx/)
-endef
-
-define Build/Prepare
-	rm -rf $(PKG_BUILD_DIR)
-	mkdir -p $(PKG_BUILD_DIR)
-	$(PKG_UNPACK)
-
-ifneq ($(CONFIG_PACKAGE_nginx-mod-naxsi),)
-  $(eval $(call Download,nginx-naxsi))
-  $(Prepare/nginx-naxsi)
-endif
-
-ifneq "$(or $(CONFIG_PACKAGE_nginx-mod-lua),$(QUILT))" ""
-  $(eval $(call Download,lua-nginx))
-  $(Prepare/lua-nginx)
-endif
-
-ifneq ($(CONFIG_PACKAGE_nginx-mod-brotli),)
-  $(eval $(call Download,nginx-brotli))
-  $(Prepare/nginx-brotli)
-endif
-
-ifneq ($(CONFIG_PACKAGE_nginx-mod-headers-more),)
-  $(eval $(call Download,nginx-headers-more))
-  $(Prepare/nginx-headers-more)
-endif
-
-ifneq "$(or $(CONFIG_PACKAGE_nginx-mod-rtmp),$(QUILT))" ""
-  $(eval $(call Download,nginx-rtmp))
-  $(Prepare/nginx-rtmp)
-endif
-
-ifneq ($(CONFIG_PACKAGE_nginx-mod-ts),)
-  $(eval $(call Download,nginx-ts))
-  $(Prepare/nginx-ts)
-endif
-
-ifneq "$(or $(CONFIG_PACKAGE_nginx-mod-dav-ext),$(QUILT))" ""
-  $(eval $(call Download,nginx-dav-ext-module))
-  $(Prepare/nginx-dav-ext-module)
-endif
-
-ifneq ($(CONFIG_PACKAGE_nginx-mod-ubus),)
-  $(eval $(call Download,nginx-ubus-module))
-  $(Prepare/nginx-ubus-module)
-endif
-
-	$(Build/Patch)
-endef
+	--crossbuild=Linux::$(ARCH) \
+	--prefix=/usr \
+	--conf-path=/etc/nginx/nginx.conf \
+	--modules-path=/usr/lib/nginx/modules \
+	--error-log-path=stderr \
+	--pid-path=/var/run/nginx.pid \
+	--lock-path=/var/lock/nginx.lock \
+	--http-log-path=/var/log/nginx/access.log \
+	--http-client-body-temp-path=/var/lib/nginx/body \
+	--http-proxy-temp-path=/var/lib/nginx/proxy \
+	--http-fastcgi-temp-path=/var/lib/nginx/fastcgi \
+	--with-cc="$(TARGET_CC)" \
+	--with-cc-opt="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS)" \
+	--with-ld-opt="$(TARGET_LDFLAGS)" \
+	--without-http_upstream_zone_module \
+	--without-pcre2 \
+	--with-compat \
+	--with-http_ssl_module \
+	$(if $(call IsDisabled,NGINX_HTTP_CACHE),--without-http-cache) \
+	$(if $(call IsDisabled,NGINX_PCRE),--without-pcre) \
+	$(if $(call IsDisabled,NGINX_HTTP_CHARSET),--without-http_charset_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_GZIP),--without-http_gzip_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_SSI),--without-http_ssi_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_USERID),--without-http_userid_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_ACCESS),--without-http_access_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_AUTH_BASIC),--without-http_auth_basic_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_AUTOINDEX),--without-http_autoindex_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_GEO),--without-http_geo_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_MAP),--without-http_map_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_SPLIT_CLIENTS),--without-http_split_clients_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_REFERER),--without-http_referer_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_REWRITE),--without-http_rewrite_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_PROXY),--without-http_proxy_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_FASTCGI),--without-http_fastcgi_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_UWSGI),--without-http_uwsgi_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_SCGI),--without-http_scgi_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_MEMCACHED),--without-http_memcached_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_LIMIT_CONN),--without-http_limit_conn_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_LIMIT_REQ),--without-http_limit_req_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_EMPTY_GIF),--without-http_empty_gif_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_BROWSER),--without-http_browser_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_UPSTREAM_HASH),--without-http_upstream_hash_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_UPSTREAM_IP_HASH),--without-http_upstream_ip_hash_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_UPSTREAM_LEAST_CONN),--without-http_upstream_least_conn_module) \
+	$(if $(call IsDisabled,NGINX_HTTP_UPSTREAM_KEEPALIVE),--without-http_upstream_keepalive_module) \
+	$(if $(call IsEnabled,IPV6),--with-ipv6) \
+	$(if $(call IsEnabled,NGINX_HTTP_GZIP_STATIC),--with-http_gzip_static_module) \
+	$(if $(call IsEnabled,NGINX_STUB_STATUS),--with-http_stub_status_module) \
+	$(if $(call IsEnabled,NGINX_FLV),--with-http_flv_module) \
+	$(if $(call IsEnabled,NGINX_DAV),--with-http_dav_module) \
+	$(if $(call IsEnabled,NGINX_HTTP_AUTH_REQUEST),--with-http_auth_request_module) \
+	$(if $(call IsEnabled,NGINX_HTTP_V2),--with-http_v2_module) \
+	$(if $(call IsEnabled,NGINX_HTTP_REAL_IP),--with-http_realip_module) \
+	$(if $(call IsEnabled,NGINX_HTTP_SECURE_LINK),--with-http_secure_link_module) \
+	$(if $(call IsEnabled,NGINX_HTTP_SUB),--with-http_sub_module) \
+	$(if $(CONFIG_PACKAGE_nginx-mod-stream),--with-stream=dynamic --with-stream_ssl_module --with-stream_ssl_preread_module) \
+	$(if $(CONFIG_PACKAGE_nginx-mod-naxsi),--add-dynamic-module=$(PKG_BUILD_DIR)/nginx-mod-naxsi/naxsi_src) \
+	$(foreach m,$(filter-out naxsi,$(PKG_MOD_EXTRA)), \
+		$(if $(CONFIG_PACKAGE_nginx-mod-$(m)),--add-dynamic-module=$(PKG_BUILD_DIR)/nginx-mod-$(m)))
 
 $(eval $(call BuildPackage,nginx-ssl))
 $(eval $(call BuildPackage,nginx-full))
 $(eval $(call BuildPackage,nginx-mod-luci))
-
-$(foreach m,$(NGINX_MODULES),$(eval $(call BuildPackage,$(m))))
+$(eval $(call BuildModule,stream,+@NGINX_STREAM_CORE_MODULE, \
+	ngx_stream, Add support for NGINX request streaming.))
+$(eval $(call BuildModule,lua,+luajit,ngx_http_lua, \
+	Enable Lua module))
+$(eval $(call BuildModule,ubus,+libubus +libjson-c +libblobmsg-json +@NGINX_UBUS, \
+	ngx_http_ubus,Enable UBUS api support directly from the server.))
+$(eval $(call BuildModule,dav-ext,+@NGINX_DAV +libxml2,ngx_http_dav_ext, \
+	Enable the WebDAV methods PROPFIND OPTIONS LOCK UNLOCK.))
+$(eval $(call BuildModule,headers-more,,ngx_http_headers_more_filter, \
+	Set and clear input and output headers...more than "add"!))
+$(eval $(call BuildModule,rtmp,,ngx_rtmp, \
+	Add support for NGINX-based Media Streaming Server module. DASH enhanced))
+$(eval $(call BuildModule,ts,,ngx_http_ts, \
+	Add support for MPEG-TS Live Module module.))
+$(eval $(call BuildModule,brotli,,ngx_http_brotli_filter ngx_http_brotli_static, \
+	Add support for brotli compression module.))
+$(eval $(call BuildModule,naxsi,,ngx_http_naxsi, \
+	Enable NAXSI module.))
 
 # TODO: remove after a transition period (together with pkg nginx-util):
 # It is for smoothly substituting nginx and nginx-mod-luci-ssl (by nginx-ssl

--- a/net/nginx/patches/nginx-mod-dav-ext/100-drop-libxslt-dep.patch
+++ b/net/nginx/patches/nginx-mod-dav-ext/100-drop-libxslt-dep.patch
@@ -1,5 +1,5 @@
---- a/nginx-dav-ext-module/config
-+++ b/nginx-dav-ext-module/config
+--- a/nginx-mod-dav-ext/config
++++ b/nginx-mod-dav-ext/config
 @@ -8,9 +8,8 @@ ngx_module_name=ngx_http_dav_ext_module
  # building nginx with the xslt module, in which case libxslt will
  # be linked anyway.  In other cases libxslt is just redundant.

--- a/net/nginx/patches/nginx-mod-lua/100-no_by_lua_block.patch
+++ b/net/nginx/patches/nginx-mod-lua/100-no_by_lua_block.patch
@@ -1,5 +1,5 @@
---- a/lua-nginx/src/ngx_http_lua_module.c
-+++ b/lua-nginx/src/ngx_http_lua_module.c
+--- a/nginx-mod-lua/src/ngx_http_lua_module.c
++++ b/nginx-mod-lua/src/ngx_http_lua_module.c
 @@ -207,12 +207,14 @@ static ngx_command_t ngx_http_lua_cmds[]
        offsetof(ngx_http_lua_loc_conf_t, log_socket_errors),
        NULL },

--- a/net/nginx/patches/nginx-mod-rtmp/100-bigedian.patch
+++ b/net/nginx/patches/nginx-mod-rtmp/100-bigedian.patch
@@ -12,8 +12,8 @@ Subject: [PATCH 1/3] arut's e0e278bc7fedd6f7465648d1d20df1a8422d60bf [removed
  ngx_rtmp_handler.c    | 108 +++++++++++++++++++++---------------------
  5 files changed, 68 insertions(+), 64 deletions(-)
 
---- a/nginx-rtmp/ngx_rtmp.c
-+++ b/nginx-rtmp/ngx_rtmp.c
+--- a/nginx-mod-rtmp/ngx_rtmp.c
++++ b/nginx-mod-rtmp/ngx_rtmp.c
 @@ -825,22 +825,6 @@ ngx_rtmp_fire_event(ngx_rtmp_session_t *
  }
  
@@ -37,8 +37,8 @@ Subject: [PATCH 1/3] arut's e0e278bc7fedd6f7465648d1d20df1a8422d60bf [removed
  static ngx_int_t
  ngx_rtmp_init_process(ngx_cycle_t *cycle)
  {
---- a/nginx-rtmp/ngx_rtmp.h
-+++ b/nginx-rtmp/ngx_rtmp.h
+--- a/nginx-mod-rtmp/ngx_rtmp.h
++++ b/nginx-mod-rtmp/ngx_rtmp.h
 @@ -417,34 +417,33 @@ ngx_int_t ngx_rtmp_fire_event(ngx_rtmp_s
  ngx_int_t ngx_rtmp_set_chunk_size(ngx_rtmp_session_t *s, ngx_uint_t size);
  
@@ -92,8 +92,8 @@ Subject: [PATCH 1/3] arut's e0e278bc7fedd6f7465648d1d20df1a8422d60bf [removed
  
  /* Receiving messages */
  ngx_int_t ngx_rtmp_receive_message(ngx_rtmp_session_t *s,
---- a/nginx-rtmp/ngx_rtmp_amf.c
-+++ b/nginx-rtmp/ngx_rtmp_amf.c
+--- a/nginx-mod-rtmp/ngx_rtmp_amf.c
++++ b/nginx-mod-rtmp/ngx_rtmp_amf.c
 @@ -10,23 +10,6 @@
  #include "ngx_rtmp.h"
  #include <string.h>
@@ -244,8 +244,8 @@ Subject: [PATCH 1/3] arut's e0e278bc7fedd6f7465648d1d20df1a8422d60bf [removed
                  {
                      return NGX_ERROR;
                  }
---- a/nginx-rtmp/ngx_rtmp_flv_module.c
-+++ b/nginx-rtmp/ngx_rtmp_flv_module.c
+--- a/nginx-mod-rtmp/ngx_rtmp_flv_module.c
++++ b/nginx-mod-rtmp/ngx_rtmp_flv_module.c
 @@ -102,7 +102,7 @@ ngx_rtmp_flv_fill_index(ngx_rtmp_amf_ctx
          return NGX_ERROR;
      }
@@ -294,8 +294,8 @@ Subject: [PATCH 1/3] arut's e0e278bc7fedd6f7465648d1d20df1a8422d60bf [removed
  
      ctx->offset += (sizeof(ngx_rtmp_flv_header) + size + 4);
  
---- a/nginx-rtmp/ngx_rtmp_handler.c
-+++ b/nginx-rtmp/ngx_rtmp_handler.c
+--- a/nginx-mod-rtmp/ngx_rtmp_handler.c
++++ b/nginx-mod-rtmp/ngx_rtmp_handler.c
 @@ -200,7 +200,7 @@ ngx_rtmp_recv(ngx_event_t *rev)
      ngx_rtmp_stream_t          *st, *st0;
      ngx_chain_t                *in, *head;
@@ -470,8 +470,8 @@ Subject: [PATCH 1/3] arut's e0e278bc7fedd6f7465648d1d20df1a8422d60bf [removed
  
          /* This CONTRADICTS the standard
           * but that's the way flash client
---- a/nginx-rtmp/ngx_rtmp_send.c
-+++ b/nginx-rtmp/ngx_rtmp_send.c
+--- a/nginx-mod-rtmp/ngx_rtmp_send.c
++++ b/nginx-mod-rtmp/ngx_rtmp_send.c
 @@ -33,13 +33,13 @@
      *(__b->last++) = (u_char)(utype);
  
@@ -491,8 +491,8 @@ Subject: [PATCH 1/3] arut's e0e278bc7fedd6f7465648d1d20df1a8422d60bf [removed
  
  #define NGX_RTMP_USER_END(s)                                                \
      ngx_rtmp_prepare_message(s, &__h, NULL, __l);                           \
---- a/nginx-rtmp/hls/ngx_rtmp_hls_module.c
-+++ b/nginx-rtmp/hls/ngx_rtmp_hls_module.c
+--- a/nginx-mod-rtmp/hls/ngx_rtmp_hls_module.c
++++ b/nginx-mod-rtmp/hls/ngx_rtmp_hls_module.c
 @@ -296,7 +296,7 @@ static ngx_command_t ngx_rtmp_hls_comman
        ngx_conf_set_enum_slot,
        NGX_RTMP_APP_CONF_OFFSET,
@@ -534,8 +534,8 @@ Subject: [PATCH 1/3] arut's e0e278bc7fedd6f7465648d1d20df1a8422d60bf [removed
  
          if (len == 0) {
              continue;
---- a/nginx-rtmp/ngx_rtmp_bitop.h
-+++ b/nginx-rtmp/ngx_rtmp_bitop.h
+--- a/nginx-mod-rtmp/ngx_rtmp_bitop.h
++++ b/nginx-mod-rtmp/ngx_rtmp_bitop.h
 @@ -40,7 +40,7 @@ uint64_t ngx_rtmp_bit_read_golomb(ngx_rt
      ((uint32_t) ngx_rtmp_bit_read(br, 32))
  
@@ -545,8 +545,8 @@ Subject: [PATCH 1/3] arut's e0e278bc7fedd6f7465648d1d20df1a8422d60bf [removed
  
  
  #endif /* _NGX_RTMP_BITOP_H_INCLUDED_ */
---- a/nginx-rtmp/ngx_rtmp_eval.c
-+++ b/nginx-rtmp/ngx_rtmp_eval.c
+--- a/nginx-mod-rtmp/ngx_rtmp_eval.c
++++ b/nginx-mod-rtmp/ngx_rtmp_eval.c
 @@ -166,7 +166,7 @@ ngx_rtmp_eval(void *ctx, ngx_str_t *in,
                          state = ESCAPE;
                          continue;
@@ -556,8 +556,8 @@ Subject: [PATCH 1/3] arut's e0e278bc7fedd6f7465648d1d20df1a8422d60bf [removed
              case ESCAPE:
                  ngx_rtmp_eval_append(&b, &c, 1, log);
                  state = NORMAL;
---- a/nginx-rtmp/ngx_rtmp_handshake.c
-+++ b/nginx-rtmp/ngx_rtmp_handshake.c
+--- a/nginx-mod-rtmp/ngx_rtmp_handshake.c
++++ b/nginx-mod-rtmp/ngx_rtmp_handshake.c
 @@ -264,7 +264,8 @@ ngx_rtmp_handshake_create_challenge(ngx_
      b = s->hs_buf;
      b->last = b->pos = b->start;
@@ -578,8 +578,8 @@ Subject: [PATCH 1/3] arut's e0e278bc7fedd6f7465648d1d20df1a8422d60bf [removed
  
      p = b->pos + 4;
      ngx_log_debug5(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
---- a/nginx-rtmp/ngx_rtmp_mp4_module.c
-+++ b/nginx-rtmp/ngx_rtmp_mp4_module.c
+--- a/nginx-mod-rtmp/ngx_rtmp_mp4_module.c
++++ b/nginx-mod-rtmp/ngx_rtmp_mp4_module.c
 @@ -528,9 +528,9 @@ ngx_rtmp_mp4_parse_mdhd(ngx_rtmp_session
              }
  
@@ -1330,8 +1330,8 @@ Subject: [PATCH 1/3] arut's e0e278bc7fedd6f7465648d1d20df1a8422d60bf [removed
              shift += sizeof(extended_size);
  
          } else if (size == 0) {
---- a/nginx-rtmp/ngx_rtmp_receive.c
-+++ b/nginx-rtmp/ngx_rtmp_receive.c
+--- a/nginx-mod-rtmp/ngx_rtmp_receive.c
++++ b/nginx-mod-rtmp/ngx_rtmp_receive.c
 @@ -17,7 +17,6 @@ ngx_rtmp_protocol_message_handler(ngx_rt
          ngx_rtmp_header_t *h, ngx_chain_t *in)
  {
@@ -1424,8 +1424,8 @@ Subject: [PATCH 1/3] arut's e0e278bc7fedd6f7465648d1d20df1a8422d60bf [removed
      return NGX_OK;
  }
  
---- a/nginx-rtmp/ngx_rtmp_record_module.c
-+++ b/nginx-rtmp/ngx_rtmp_record_module.c
+--- a/nginx-mod-rtmp/ngx_rtmp_record_module.c
++++ b/nginx-mod-rtmp/ngx_rtmp_record_module.c
 @@ -454,7 +454,7 @@ ngx_rtmp_record_node_open(ngx_rtmp_sessi
      ngx_err_t                   err;
      ngx_str_t                   path;


### PR DESCRIPTION
Maintainer: @Ansuel 
Compile tested: x86-64 master
Run tested: x86-64 master

Description:

Since modules now follow a naming convention, there is an opportunity to eliminate redundant code.

However, during the process, I found the following:

1. `CONFIG_NGINX_GEOIP_MODULE` didn't exist in Config_ssl.in, so it was never compiled. I tried to compile it, but nginx complained about the missing GeoIP library, which currently doesn't seem to exist in openwrt/packages? I removed the corresponding code for now, can restore if the GeoIP library exists.
2. ~~In menuconfig, if `nginx-full` is selected, it won't set any `CONFIG_NGINX_*` variables, leading `nginx-mod-dav-ext` to miss its `+@NGINX_DAV` dependency~~.
3. `nginx-full` depends on `nginx-mod-*`, which in turn depend on `nginx-ssl`, leading to conflict (current build error comes from this I believe).
4. ~~`STREAM_SSL_MODULE` and `STREAM_PREREAD_MODULE` are never used.~~
5. Should `nginx-mod-luci` be renamed to `nginx-luci` or something? Since it's not really a module.
6. ~~Should we remove `NGINX_STREAM_CORE_MODULE` and just offer `nginx-mod-stream`? Currently they seem to do the same thing~~.