### PR TITLE
ci, cache-domains: added pre-test.sh CI step

### DIFF
--- a/.github/workflows/entrypoint.sh
+++ b/.github/workflows/entrypoint.sh
@@ -26,9 +26,23 @@ for PKG in /ci/*.ipk; do
 
 	echo "Testing package $PKG_NAME in version $PKG_VERSION from $PKG_SOURCE"
 
-	opkg install "$PKG"
-
 	export PKG_NAME PKG_VERSION CI_HELPER
+
+	PRE_TEST_SCRIPT=$(find /ci/ -name "$PKG_SOURCE" -type d)/pre-test.sh
+
+	if [ -f "$PRE_TEST_SCRIPT" ]; then
+		echo "Use package specific pre-test.sh"
+		if sh "$PRE_TEST_SCRIPT" "$PKG_NAME" "$PKG_VERSION"; then
+			echo "Pre-test successful"
+		else
+			echo "Pre-test failed"
+			exit 1
+		fi
+	else
+		echo "No pre-test.sh script available"
+	fi
+
+	opkg install "$PKG"
 
 	TEST_SCRIPT=$(find /ci/ -name "$PKG_SOURCE" -type d)/test.sh
 

--- a/utils/cache-domains/Makefile
+++ b/utils/cache-domains/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cache-domains
 PKG_VERSION:=2.3.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 

--- a/utils/cache-domains/pre-test.sh
+++ b/utils/cache-domains/pre-test.sh
@@ -1,0 +1,24 @@
+#! /bin/sh
+
+set -o errexit
+
+case "${PKG_NAME}" in
+    cache-domains-openssl)
+        LIBUSTREAM_DEPS="libustream-openssl libopenssl3"
+        LIBUSTREAM_DEPS="${LIBUSTREAM_DEPS} libatomic1" # arm_cortex-a15_neon-vfpv4 extra dep
+        ;;
+    cache-domains-mbedtls)
+        LIBUSTREAM_DEPS="libustream-mbedtls libmbedtls"
+        ;;
+    cache-domains-wolfssl)
+        LIBUSTREAM_DEPS="libustream-wolfssl libwolfssl"
+        ;;
+esac
+
+# Replace the current libustream with the one PKG_NAME depends on.
+# opkg depends on libustream for https so we need to download the
+# replacement first and replace it offline.
+opkg download ${LIBUSTREAM_DEPS}
+opkg remove 'libustream-*'
+opkg install --offline-root / ./*.ipk
+rm ./*.ipk


### PR DESCRIPTION
Maintainer: me @G-M0N3Y-2503
Compile tested: x86_x64, QEMU/KVM, master
Run tested: x86_x64, QEMU/KVM, master

Description:

Some packages variants have conflicting dependencies with the base packages and the CI test will fail to install before anything can be done by the packages to setup the system for install.

This change adds a pre-test.sh that runs before the install so things like the default libustream variant can be swapped out as shown in the updated cache-domains.