### PR TITLE
aria2:fix ssl errors

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
 PKG_VERSION:=1.36.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/aria2/aria2/releases/download/release-$(PKG_VERSION)/

--- a/net/aria2/files/aria2.init
+++ b/net/aria2/files/aria2.init
@@ -105,7 +105,7 @@ aria2_validate() {
 		'bt_seed_unverified:or("true","false")' \
 		'bt_stop_timeout:uinteger' \
 		'bt_tracker:list(string)' \
-		'ca_certificate:file' \
+		'ca_certificate:string:/etc/ssl/certs/ca-certificates.crt' \
 		'certificate:file' \
 		'check_certificate:or("true","false"):true' \
 		'check_integrity:or("true","false")' \


### PR DESCRIPTION
Maintainer: @kuoruan 
Compile tested: x86 aarch64
Run tested: x86,19.07,x86

Description:
Sometimes use aria2 download file through https will cause error like this 'SSL/TLS handshake failure: unable to get local issuer certificate',it's due to ujail not mount ca-certificate.
And it also need chose ca-certificate by defalut.