### PR TITLE
zoneinfo: adjust to current timezone data file structure

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
 PKG_VERSION:=2023c
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 #As i couldn't find real license used "Public Domain"
 #as referense to http://www.iana.org/time-zones/repository/tz-link.html
@@ -32,7 +32,7 @@ endef
 $(eval $(call Download,tzcode))
 
 define Package/zoneinfo/Default
-  SUBMENU:=Zoneinfo
+  SUBMENU:=Time Zone info
   TITLE:=Zone Information
   SECTION:=utils
   CATEGORY:=Utilities
@@ -47,56 +47,63 @@ endef
 define Package/zoneinfo-simple
 $(call Package/zoneinfo/Default)
   TITLE:=Zone Information (simple)
+  DEPENDS+= +zoneinfo-core
 endef
 
 define Package/zoneinfo-africa
 $(call Package/zoneinfo/Default)
   TITLE:=Zone Information (Africa)
+  DEPENDS+= +zoneinfo-core
 endef
 
-define Package/zoneinfo-northamerica
+define Package/zoneinfo-america
 $(call Package/zoneinfo/Default)
-  TITLE:=Zone Information (NorthAmerica)
-endef
-
-define Package/zoneinfo-southamerica
-$(call Package/zoneinfo/Default)
-  TITLE:=Zone Information (SouthAmerica)
+  TITLE:=Zone Information (America North/South)
+  PROVIDES:=zoneinfo-northamerica zoneinfo-southamerica
+  DEPENDS+= +zoneinfo-core
 endef
 
 define Package/zoneinfo-poles
 $(call Package/zoneinfo/Default)
   TITLE:=Zone Information (Arctic, Antarctic)
+  DEPENDS+= +zoneinfo-core
 endef
 
 define Package/zoneinfo-asia
 $(call Package/zoneinfo/Default)
   TITLE:=Zone Information (Asia)
+  DEPENDS+= +zoneinfo-core
 endef
 
 define Package/zoneinfo-atlantic
 $(call Package/zoneinfo/Default)
-  TITLE:=Zone Information (Atlantic)
+  TITLE:=Zone Information (Atlantic Ocean)
+  DEPENDS+= +zoneinfo-core
 endef
 
 define Package/zoneinfo-australia-nz
 $(call Package/zoneinfo/Default)
   TITLE:=Zone Information (Australia-NZ)
+  DEPENDS+= +zoneinfo-core
 endef
 
 define Package/zoneinfo-pacific
 $(call Package/zoneinfo/Default)
-  TITLE:=Zone Information (Pacific)
+  TITLE:=Zone Information (Pacific Ocean)
+  DEPENDS+= +zoneinfo-core
 endef
 
 define Package/zoneinfo-europe
 $(call Package/zoneinfo/Default)
   TITLE:=Zone Information (Europe)
+  DEPENDS+= +zoneinfo-core
 endef
 
-define Package/zoneinfo-india
+define Package/zoneinfo-indian
 $(call Package/zoneinfo/Default)
-  TITLE:=Zone Information (India)
+  TITLE:=Zone Information (Indian Ocean)
+  PROVIDES:=zoneinfo-india
+  DEPENDS+= +zoneinfo-core
 endef
 
 define Package/zoneinfo-all
@@ -105,15 +112,14 @@ $(call Package/zoneinfo/Default)
   DEPENDS:= \
 	+zoneinfo-core \
 	+zoneinfo-africa \
-	+zoneinfo-northamerica \
-	+zoneinfo-southamerica \
+	+zoneinfo-america \
 	+zoneinfo-poles \
 	+zoneinfo-asia \
 	+zoneinfo-atlantic \
 	+zoneinfo-australia-nz \
 	+zoneinfo-pacific \
 	+zoneinfo-europe \
-	+zoneinfo-india
+	+zoneinfo-indian
 endef
 
 define Build/Prepare
@@ -136,7 +142,7 @@ endef
 define Package/zoneinfo-core/install
 	$(INSTALL_DIR) $(1)/usr/share/zoneinfo
 	for i in \
-		CET CST6CDT EET EST EST5EDT GB-Eire Eire \
+		CET CST6CDT EET EST EST5EDT GB-Eire \
 		GB    GMT   GMT+0 GMT-0 GMT0  Greenwich  \
 		HST   MET   MST   MST7MDT                \
 		PRC   PST8PDT ROC ROK     UCT   UTC      \
@@ -167,29 +173,19 @@ define Package/zoneinfo-simple/install
 endef
 
 define Package/zoneinfo-africa/install
-	$(INSTALL_DIR) $(1)/usr/share/zoneinfo/Africa
-	$(CP) $(PKG_INSTALL_DIR)/zoneinfo/Africa/* \
-	      $(1)/usr/share/zoneinfo/Africa
-endef
-
-define Package/zoneinfo-northamerica/install
 	$(INSTALL_DIR) $(1)/usr/share/zoneinfo
-	for i in US America Canada Mexico Cuba Jamaica Navajo ; do \
+	for i in Africa Egypt Libya ; do \
 	  $(CP) $(PKG_INSTALL_DIR)/zoneinfo/$$$$i \
 	      $(1)/usr/share/zoneinfo ; \
 	done
-	rm  -rf $(1)/usr/share/zoneinfo/America/Argentina
 endef
 
-define Package/zoneinfo-southamerica/install
+define Package/zoneinfo-america/install
 	$(INSTALL_DIR) $(1)/usr/share/zoneinfo
-	for i in Brazil Chile ; do \
+	for i in America Brazil Canada Chile Cuba Jamaica Mexico Navajo US ; do \
 	  $(CP) $(PKG_INSTALL_DIR)/zoneinfo/$$$$i \
 	      $(1)/usr/share/zoneinfo ; \
 	done
-	$(INSTALL_DIR) $(1)/usr/share/zoneinfo/America/Argentina
-	$(CP) $(PKG_INSTALL_DIR)/zoneinfo/America/Argentina/* \
-	      $(1)/usr/share/zoneinfo/America/Argentina
 endef
 
 define Package/zoneinfo-poles/install
@@ -202,7 +198,7 @@ endef
 
 define Package/zoneinfo-asia/install
 	$(INSTALL_DIR) $(1)/usr/share/zoneinfo
-	for i in Asia Japan Singapore Hongkong ; do \
+	for i in Asia Hongkong Iran Israel Japan Singapore ; do \
 	  $(CP) $(PKG_INSTALL_DIR)/zoneinfo/$$$$i \
 	      $(1)/usr/share/zoneinfo ; \
 	done
@@ -234,13 +230,13 @@ endef
 
 define Package/zoneinfo-europe/install
 	$(INSTALL_DIR) $(1)/usr/share/zoneinfo
-	for i in Europe Portugal Poland ; do \
+	for i in Europe Eire Portugal Poland Turkey ; do \
 	  $(CP) $(PKG_INSTALL_DIR)/zoneinfo/$$$$i \
 	      $(1)/usr/share/zoneinfo ; \
 	done
 endef
 
-define Package/zoneinfo-india/install
+define Package/zoneinfo-indian/install
 	$(INSTALL_DIR) $(1)/usr/share/zoneinfo
 	for i in Indian ; do \
 	  $(CP) $(PKG_INSTALL_DIR)/zoneinfo/$$$$i \
@@ -251,13 +247,12 @@ endef
 $(eval $(call BuildPackage,zoneinfo-simple))
 $(eval $(call BuildPackage,zoneinfo-core))
 $(eval $(call BuildPackage,zoneinfo-africa))
-$(eval $(call BuildPackage,zoneinfo-northamerica))
-$(eval $(call BuildPackage,zoneinfo-southamerica))
+$(eval $(call BuildPackage,zoneinfo-america))
 $(eval $(call BuildPackage,zoneinfo-poles))
 $(eval $(call BuildPackage,zoneinfo-asia))
 $(eval $(call BuildPackage,zoneinfo-atlantic))
 $(eval $(call BuildPackage,zoneinfo-australia-nz))
 $(eval $(call BuildPackage,zoneinfo-pacific))
 $(eval $(call BuildPackage,zoneinfo-europe))
-$(eval $(call BuildPackage,zoneinfo-india))
+$(eval $(call BuildPackage,zoneinfo-indian))
 $(eval $(call BuildPackage,zoneinfo-all))


### PR DESCRIPTION
Maintainer: @Wedmer 
Compile tested: ipq807x/DL_WRX36
Run tested: CI

Based on forum discussions every now and then, it seems that the zoneinfo packages are not quite clear and thier usage is not straightforward. E.g. https://forum.openwrt.org/t/php8-cli-timezone-database-segfault-at-34/152342/6 . Our structure has been mostly unchanged since 2015 (or even earlier), and the IANA timezone database and abbreviations have evolved since then.

Tweak the zoneinfo package to better match the current file structure in the upstream time zone database. Add missing aliases. Make some clarifications.

* Combine -northmerica and -southamerica into -america, as all current official America/xxx definitions were already in -northamerica and only the unofficial/deprecated Brazil/xxx, Chile and Argentina were in -southamerica. (Confusingly America/Sao_Paulo was in -northamerica, while Brazil was in -southamerica.)
  * Add PROVIDES for the old package names

* Add missing top-level dir country/nation alias links.
* Define Eire in -europe instead of -core.

* Rename -india to -indian, as it contains the Indian ocean islands instead of the actual Asia/Kolkata zone for the mainland India.
  * Add PROVIDES for the old package name

* Add 'Ocean' to all ocean zone titles.

* Make all zoneinfo-packages depend on zoneinfo-core, so that zone.tab, the UTC based definitions and the still existing short zone codes are always available.

* Clarify menuconfig menu as "Time Zone info"

