### PR TITLE
CI: Enable runtime_test for mips_24kc

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -17,7 +17,7 @@ jobs:
 
           - arch: mips_24kc
             target: ath79-generic
-            runtime_test: false
+            runtime_test: true
 
           - arch: mipsel_24kc
             target: mt7621
@@ -162,7 +162,9 @@ jobs:
       - name: Register QEMU
         if: ${{ matrix.runtime_test }}
         run: |
-          sudo docker run --rm --privileged aptman/qus -s -- -p
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static binfmt-support
+          sudo update-binfmts --import
 
       - name: Build Docker container
         if: ${{ matrix.runtime_test }}

--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.2.1
+PKG_VERSION:=1.2.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=0f304b75c2e9f61e3f7808f23fe8fbe08161553475d9bec0dea4a5acf4452d2d
+PKG_HASH:=8f7adf55ed9afe6ec0dd8b04ed64dd3a6243578ee779f909dfb3778fa2dbda10
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @aparcar @neheb @BKPepe @1715173329
Compile tested: CI modifications are tested on my local machine. Besides, the workflow has run successfully.
Run tested: N/A

Description:
The QEMU provided by Ubuntu supports emulating mips_24kc for a long time. Use it instead of the docker `aptman/qus` to enable runtime test for mips_24kc.

QEMU supports emulating mips_24kc since https://github.com/qemu/qemu/commit/77d119dd335f910c7f953a265726e3753c69a0bb. Both [`aptman/qus`](https://github.com/dbhi/qus) and [`multiarch/qemu-user-static`](https://github.com/multiarch/qemu-user-static) use an older version of `qemu-binfmt-conf.sh`.

Update sing-box to trigger the runtime test.