### PR TITLE
open-plc-utils: update to latest upstream version

### DIFF
--- a/utils/open-plc-utils/Makefile
+++ b/utils/open-plc-utils/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=open-plc-utils
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/qca/open-plc-utils.git
-PKG_SOURCE_VERSION:=358dfcf78bdaf7b0b13dcdf91cb1aae1789f2770
-PKG_MIRROR_HASH:=3b24033f3d2d9ac33778fb772837bc5e0a8891ac708bbe1f35336ff792baf9f8
+PKG_SOURCE_VERSION:=1ba7d5a042e4e8ff6858b08e113eec5dc4e89cf2
+PKG_MIRROR_HASH:=67a8c23a10b6b9e3437badad9f215d5350a766b1d0021c58d0ae092609be2b34
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 


### PR DESCRIPTION
This adds support for QCA7006AQ chipset identification.

Maintainer: me
Compile tested: mxs
Run tested: mxs, Duckbill
