### PR TITLE
sqlite3: Update to 3.41.2

### DIFF
--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqlite
-PKG_VERSION:=3410100
+PKG_VERSION:=3410200
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-autoconf-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.sqlite.org/2023/
-PKG_HASH:=4dadfbeab9f8e16c695d4fbbc51c16b2f77fb97ff4c1c3d139919dfc038c9e33
+PKG_HASH:=e98c100dd1da4e30fa460761dab7c0b91a50b785e167f8c57acc46514fae9499
 
 PKG_CPE_ID:=cpe:/a:sqlite:sqlite
 PKG_LICENSE:=PUBLICDOMAIN


### PR DESCRIPTION
Maintainer: nobody
Compile tested: ipq807x/generic
Run tested: redmi-ax6

Description:
Fixes CVE-2021-20227