### PR TITLE
isc-dhcp: Support for coexistence of IPv4 and IPv6

### DIFF
--- a/net/isc-dhcp/Makefile
+++ b/net/isc-dhcp/Makefile
@@ -132,15 +132,33 @@ $(call Package/isc-dhcp-server/description)
  This package is compiled with IPv4 and IPv6 support.
 endef
 
-define Package/isc-dhcp-dyndns
+define Package/isc-dhcp-dyndns-ipv4
   $(call Package/isc-dhcp/Default)
   TITLE+= server dynamic DNS dependencies (meta)
-  DEPENDS+=@(PACKAGE_isc-dhcp-server-ipv4||PACKAGE_isc-dhcp-server-ipv6) +bind-server +bind-client
+  DEPENDS+=isc-dhcp-server-ipv4 +bind-server +bind-client
+  VARIANT:=ipv4
+endef
+
+define Package/isc-dhcp-dyndns-ipv6
+  $(call Package/isc-dhcp/Default)
+  TITLE+= server dynamic DNS dependencies (meta)
+  DEPENDS+=isc-dhcp-server-ipv6 +bind-server +bind-client
+  VARIANT:=ipv6
 endef
 
 define Package/isc-dhcp-dyndns/description
  implements the Dynamic Host Configuration Protocol (DHCP) and the Internet
  Bootstrap Protocol (BOOTP).
+endef
+
+define Package/isc-dhcp-dyndns-ipv4/description
+$(call Package/isc-dhcp-dyndns/description)
+ This package is compiled with IPv4 support only.
+endef
+
+define Package/isc-dhcp-dyndns-ipv6/description
+$(call Package/isc-dhcp-dyndns/description)
+ This package is compiled with IPv4 and IPv6 support.
 endef
 
 define Package/isc-dhcp-omshell-ipv4
@@ -222,10 +240,14 @@ endef
 
 define Package/isc-dhcp-server-$(BUILD_VARIANT)/install
 	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/init.d $(1)/etc/uci-defaults
+ifeq ($(BUILD_VARIANT),ipv4)
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/dhcpd $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/dhcpd.init $(1)/etc/init.d/dhcpd
+	$(INSTALL_BIN) ./files/dhcpd.conf $(1)/etc
 	$(INSTALL_BIN) ./files/dhcpd.defaults $(1)/etc/uci-defaults
+endif
 ifeq ($(BUILD_VARIANT),ipv6)
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/dhcpd $(1)/usr/sbin/dhcpd6
 	$(INSTALL_BIN) ./files/dhcpd6.init $(1)/etc/init.d/dhcpd6
 	$(INSTALL_BIN) ./files/dhcpd6.conf $(1)/etc
 endif
@@ -239,7 +261,7 @@ define Package/isc-dhcp-server-ipv6/conffiles
 /etc/dhcpd6.conf
 endef
 
-define Package/isc-dhcp-dyndns/install
+define Package/isc-dhcp-dyndns-$(BUILD_VARIANT)/install
 	:
 endef
 
@@ -267,10 +289,11 @@ endef
 
 $(eval $(call BuildPackage,isc-dhcp-relay-ipv4))
 $(eval $(call BuildPackage,isc-dhcp-server-ipv4))
-$(eval $(call BuildPackage,isc-dhcp-dyndns))
+$(eval $(call BuildPackage,isc-dhcp-dyndns-ipv4))
 $(eval $(call BuildPackage,isc-dhcp-client-ipv4))
 $(eval $(call BuildPackage,isc-dhcp-omshell-ipv4))
 $(eval $(call BuildPackage,isc-dhcp-relay-ipv6))
 $(eval $(call BuildPackage,isc-dhcp-server-ipv6))
+$(eval $(call BuildPackage,isc-dhcp-dyndns-ipv6))
 $(eval $(call BuildPackage,isc-dhcp-client-ipv6))
 $(eval $(call BuildPackage,isc-dhcp-omshell-ipv6))

--- a/net/isc-dhcp/files/dhcpd6.init
+++ b/net/isc-dhcp/files/dhcpd6.init
@@ -11,7 +11,7 @@ start() {
 		touch $lease_file
 	fi
 
-	/usr/sbin/dhcpd -q -6 -cf $config_file -lf $lease_file -pf $pid_file $dhcp_ifs
+	/usr/sbin/dhcpd6 -q -6 -cf $config_file -lf $lease_file -pf $pid_file $dhcp_ifs
 
 	if [ $? -ne 0 ]; then
 		return 1


### PR DESCRIPTION
Maintainer: @pprindeville 
Compile tested: mt7622-linksys_e8450 on snapshot from mid-march
Run tested: mt7622-linksys_e8450 on snapshot from mid-march

Description:

Initial modifications to support coexistence of dhcpd for both IPv4 and IPv6. If you try to enable both now, it will fail during build and/or install, plus you only have a single binary. In theory, the single binary with flags should work, but for some reason it does not, or needs further changes to the build system. Thus producing a dhcpd6 binary that still requires a -6 flag when run.

It is possible this can be improved upon, and I am open to making any changes as needed, or anyone else is welcome. I used to maintain this in [my own feed](https://github.com/Obsidian-StudiosInc/openwrt-feed/tree/master/packages/isc-dhcp), when it was removed, so I am pleased that it is back in now. You can see some commit history there as to past issues with the different binary names, etc. I have been using this for a few months now, just lacked time to submit PR.