### PR TITLE
mwan3: fix some tunnels assigned the wrong mark

### DIFF
--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -338,6 +338,16 @@ mwan3_set_general_iptables()
 			done
 		fi
 
+		if [ -n "${current##*-N mwan3_pre*}" ]; then
+			mwan3_push_update -N mwan3_pre
+			mwan3_push_update -A mwan3_pre \
+					  -m mark ! --mark "0x0/$MMX_MASK" \
+					  -j MARK --set-xmark "0x0/$MMX_MASK"
+		fi
+
+		if [ -n "${current##*-A PREROUTING -j mwan3_pre*}" ]; then
+			mwan3_push_update -A PREROUTING -j mwan3_pre
+		fi
 		if [ -n "${current##*-A PREROUTING -j mwan3_hook*}" ]; then
 			mwan3_push_update -A PREROUTING -j mwan3_hook
 		fi


### PR DESCRIPTION
The mark of underlying tunnel connection is assigned to all incoming packets inside tunnel. This breaks mwan3 routing. Attempt to fix this by clearing the mark in incoming packets. Do not touch outgoing packets to make sure that tracking and "mwan3 use" command works as expected.

Maintainer: @feckert 
Compile tested: x86-64, OpenWrt master
Run tested: x86-64, OpenWrt master

Description:

There is an issue with some tunnels. The mark of underlying tunnel connection is assigned to all incoming packets inside tunnel. This breaks the routing, as replies to these packets may be sent to the wrong interface.
This applies, for example, to ipv6 tunnels (#14332 #18481), ipsec tunnels (#19607) and so on.
Fix this by resetting the mark in incoming packets.
This patch does not touch outgoing packets and doesn't break mwan3 wrapper library.

Fixes #14332 #18481 #19607
