### PR TITLE
mwan3: fix some tunnels assigned the wrong mark

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.12.1
+PKG_VERSION:=2.12.2
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -86,6 +86,7 @@ stop_service() {
 			[ -z "${table##*PREROUTING -j mwan3_pre*}" ] && echo "-D PREROUTING -j mwan3_pre"
 			[ -z "${table##*PREROUTING -j mwan3_hook*}" ] && echo "-D PREROUTING -j mwan3_hook"
 			[ -z "${table##*OUTPUT -j mwan3_hook*}" ] && echo "-D OUTPUT -j mwan3_hook"
+			[ -z "${table##*POSTROUTING -j mwan3_post*}" ] && echo "-D POSTROUTING -j mwan3_post"
 			echo "$table" | awk '{print "-F "$2}' | grep mwan3 | sort -u
 			echo "$table" | awk '{print "-X "$2}' | grep mwan3 | sort -u
 			echo "COMMIT"

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -83,6 +83,7 @@ stop_service() {
 		table="$($IPT -S)"
 		{
 			echo "*mangle";
+			[ -z "${table##*PREROUTING -j mwan3_pre*}" ] && echo "-D PREROUTING -j mwan3_pre"
 			[ -z "${table##*PREROUTING -j mwan3_hook*}" ] && echo "-D PREROUTING -j mwan3_hook"
 			[ -z "${table##*OUTPUT -j mwan3_hook*}" ] && echo "-D OUTPUT -j mwan3_hook"
 			echo "$table" | awk '{print "-F "$2}' | grep mwan3 | sort -u

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -338,6 +338,16 @@ mwan3_set_general_iptables()
 			done
 		fi
 
+		if [ -n "${current##*-N mwan3_pre*}" ]; then
+			mwan3_push_update -N mwan3_pre
+			mwan3_push_update -A mwan3_pre \
+					  -m mark ! --mark "0x0/$MMX_MASK" \
+					  -j MARK --set-xmark "0x0/$MMX_MASK"
+		fi
+
+		if [ -n "${current##*-A PREROUTING -j mwan3_pre*}" ]; then
+			mwan3_push_update -A PREROUTING -j mwan3_pre
+		fi
 		if [ -n "${current##*-A PREROUTING -j mwan3_hook*}" ]; then
 			mwan3_push_update -A PREROUTING -j mwan3_hook
 		fi

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -341,7 +341,6 @@ mwan3_set_general_iptables()
 		if [ -n "${current##*-N mwan3_pre*}" ]; then
 			mwan3_push_update -N mwan3_pre
 			mwan3_push_update -A mwan3_pre \
-					  -m mark ! --mark "0x0/$MMX_MASK" \
 					  -j MARK --set-xmark "0x0/$MMX_MASK"
 		fi
 

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -344,6 +344,12 @@ mwan3_set_general_iptables()
 					  -j MARK --set-xmark "0x0/$MMX_MASK"
 		fi
 
+		if [ -n "${current##*-N mwan3_post*}" ]; then
+			mwan3_push_update -N mwan3_post
+			mwan3_push_update -A mwan3_post \
+					  -j MARK --set-xmark "0x0/$MMX_MASK"
+		fi
+
 		if [ -n "${current##*-A PREROUTING -j mwan3_pre*}" ]; then
 			mwan3_push_update -A PREROUTING -j mwan3_pre
 		fi
@@ -352,6 +358,9 @@ mwan3_set_general_iptables()
 		fi
 		if [ -n "${current##*-A OUTPUT -j mwan3_hook*}" ]; then
 			mwan3_push_update -A OUTPUT -j mwan3_hook
+		fi
+		if [ -n "${current##*-A POSTROUTING -j mwan3_post*}" ]; then
+			mwan3_push_update -A POSTROUTING -j mwan3_post
 		fi
 		mwan3_push_update COMMIT
 		mwan3_push_update ""


### PR DESCRIPTION
The mark of underlying tunnel connection is assigned to all incoming packets inside tunnel. This breaks mwan3 routing. Attempt to fix this by clearing the mark in incoming packets. Do not touch outgoing packets to make sure that tracking and "mwan3 use" command works as expected.

Maintainer: @feckert
Compile tested: x86-64, OpenWrt master
Run tested: x86-64, OpenWrt master

Description:

There is an issue with some tunnels. The mark of underlying tunnel connection is assigned to all incoming packets inside tunnel. This breaks the routing, as replies to these packets may be sent to the wrong interface.
This applies, for example, to ipv6 tunnels (#14332 #18481), ipsec tunnels (#19607) and so on.
Fix this by resetting the mark in incoming packets.
This patch does not touch outgoing packets and doesn't break mwan3 wrapper library.

Fixes #14332 #18481 #19607