### PR TITLE
mwan3: fix mwan3 doesn't detect the absence of the internet connection if an interface goes down and then up

### DIFF
--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -128,6 +128,7 @@ connected() {
 	echo "online" > $MWAN3TRACK_STATUS_DIR/$INTERFACE/STATUS
 	echo "0" > $MWAN3TRACK_STATUS_DIR/$INTERFACE/OFFLINE
 	get_uptime > $MWAN3TRACK_STATUS_DIR/$INTERFACE/ONLINE
+	score=$((down+up))
 	host_up_count=0
 	lost=0
 	turn=0
@@ -358,7 +359,6 @@ main() {
 
 			if [ $score -eq $up ]; then
 				disconnected
-				score=0
 			fi
 		else
 			if [ $score -lt $((down+up)) ] && [ $lost -gt 0 ]; then


### PR DESCRIPTION
This commit addresses the following issues:
1) The interface goes down and score is reset to 0. Interface goes up, the interface initial state is online, and thus the state is set to online. mwan3track performs ping tests. But if there is no internet connection, nothing is done because the score is already 0 and the branch that handles disconnection does not call disconnecting/disconnected in that case. Interface stays in online state. 
2) The interface is connecting and score reaches score=up. The connected function is called but we do not bump the score. If we lose the internet connection right after that, we end up in disconnection branch with score<up, and disconnecting/disconnected function is not called, we just end up with score=0 and status=online like in previous scenario.

The solution is to reset the score in connected function in the same way as we set the score in disconnected.
Also remove the redundant setting of score=0 (already set in disconnected function).

Maintainer: @feckert 
Compile tested: x86-64, OpenWrt master
Run tested: x86-64, OpenWrt master

Description:
