### PR TITLE
nginx: fix missing module entry on package update

### DIFF
--- a/net/nginx-util/Makefile
+++ b/net/nginx-util/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx-util
 PKG_VERSION:=1.6
-PKG_RELEASE:=16
+PKG_RELEASE:=17
 PKG_MAINTAINER:=Peter Stadler <peter.stadler@student.uibk.ac.at>
 
 include $(INCLUDE_DIR)/package.mk

--- a/net/nginx-util/files/uci.conf.template
+++ b/net/nginx-util/files/uci.conf.template
@@ -1,6 +1,7 @@
 # Consider using UCI or creating files in /etc/nginx/conf.d/ for configuration.
 # Parsing UCI configuration is skipped if uci set nginx.global.uci_enable=false
 # For details see: https://openwrt.org/docs/guide-user/services/webserver/nginx
+# UCI_CONF_VERSION=1.1
 
 worker_processes auto;
 

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -402,6 +402,7 @@ CONFIGURE_ARGS += \
 			--prefix=/usr \
 			--conf-path=/etc/nginx/nginx.conf \
 			--modules-path=/usr/lib/nginx/modules \
+			--with-compat \
 			$(ADDITIONAL_MODULES) \
 			--error-log-path=stderr \
 			--pid-path=/var/run/nginx.pid \

--- a/net/nginx/files/nginx.init
+++ b/net/nginx/files/nginx.init
@@ -8,11 +8,27 @@ USE_PROCD=1
 G_OPTS="daemon off;"
 
 NGINX_UTIL="/usr/bin/nginx-util"
+UCI_CONF_TEMPLATE="/etc/nginx/uci.conf.template"
+LATEST_UCI_CONF_VERSION="1.1"
 
 eval $("${NGINX_UTIL}" get_env)
 
 CONF=""
 
+nginx_check_luci_template() {
+	UCI_CONF_VERSION="$(sed -nr 's/# UCI_CONF_VERSION=(.*)/\1/p' $UCI_CONF_TEMPLATE)"
+
+	# No need to migrate already latest version
+	if [ "$UCI_CONF_VERSION" = "$LATEST_UCI_CONF_VERSION" ]; then
+		return
+	fi
+
+	if [ -z "$UCI_CONF_VERSION" ]; then
+		echo "" >> $UCI_CONF_TEMPLATE
+		echo "include module.d/*.module;" >> $UCI_CONF_TEMPLATE
+		echo "# UCI_CONF_VERSION=1.1" >> $UCI_CONF_TEMPLATE
+	fi
+}
 
 nginx_init() {
 	[ -z "${CONF}" ] || return # already called.
@@ -22,6 +38,10 @@ nginx_init() {
 
 	rm -f "$(readlink "${UCI_CONF}")"
 	${NGINX_UTIL} init_lan
+
+	if [ -f $UCI_CONF_TEMPLATE ]; then
+		nginx_check_luci_template
+	fi
 
 	if [ -e "${UCI_CONF}" ]
 	then CONF="${UCI_CONF}"


### PR DESCRIPTION
Uci defaults script are run only on first installation. On package upgrade, the ubus module for the nginx-mod-luci is not installed in the nginx conf. Fix this by adding a post install script.

Fixes: 65a676ed56fb ("nginx: introduce support for dynamic modules")
Fixes: #20904

---


@anomeome can you test? I assume your problem was with upgrading the package right? or it was from a clean image?