### PR TITLE
rtl_433: update to 22.11

### DIFF
--- a/utils/rtl_433/Makefile
+++ b/utils/rtl_433/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtl_433
-PKG_VERSION:=21.12
+PKG_VERSION:=22.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/merbanan/rtl_433/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=b362ef3410adec64aee7ad8e6d4d74875f1b3d59ef6fb4856e96adc03876dc65
+PKG_HASH:=61a9163d69cc4b1da46aebbcaf969bd180a055a6b90f42ad281218cc4fbefb86
 
 PKG_MAINTAINER:=Jasper Scholte <NightNL@outlook.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: @TimelessNL 
Compile tested: ath79, D-Link DIR-825 B1, master and branch 22.03
Run tested: ath79, D-Link DIR-825 B1, branch 22.03, receiving data with USB dongle works
