### PR TITLE
[22.03] pbr: ipv6 & migration bugfixes

### DIFF
--- a/net/pbr/Makefile
+++ b/net/pbr/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=5
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 

--- a/net/pbr/files/etc/init.d/pbr.init
+++ b/net/pbr/files/etc/init.d/pbr.init
@@ -223,7 +223,7 @@ pbr_get_gateway6() {
 	local iface="$2" dev="$3" gw
 	network_get_gateway6 gw "$iface" true
 	if [ -z "$gw" ] || [ "$gw" = '::/0' ] || [ "$gw" = '::0/0' ] || [ "$gw" = '::' ]; then
-		gw="$($ip_bin -6 a list dev "$dev" 2>/dev/null | grep inet6 | awk '{print $2}')"
+		gw="$($ip_bin -6 a list dev "$dev" 2>/dev/null | grep inet6 | grep 'scope global' | awk '{print $2}')"
 	fi
 	eval "$1"='$gw'
 }
@@ -1748,7 +1748,7 @@ EOF
 					ipv6_error=0
 					if { [ -n "$gw6" ] && [ "$gw6" != "::/0" ]; } || [ "$strict_enforcement" -ne 0 ]; then
 						if [ -z "$gw6" ] || [ "$gw6" = "::/0" ]; then
-							$ip_bin -6 route add unreachable default table "$tid" || ipv6_error=1
+							$ip_bin -6 route add unreachable default table "$tid" >/dev/null 2>&1 || ipv6_error=1
 						elif $ip_bin -6 route list table main | grep -q " dev $dev6 "; then
 							while read -r i; do
 								i="$(echo "$i" | sed 's/ linkdown$//')"
@@ -1762,7 +1762,7 @@ EOF
 							$ip_bin -6 route add default dev "$dev6" table "$tid" >/dev/null 2>&1 || ipv6_error=1
 						fi
 					fi
-					$ip_bin -6 rule add fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" || ipv6_error=1
+					$ip_bin -6 rule add fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" >/dev/null 2>&1 || ipv6_error=1
 				fi
 			fi
 			if [ "$ipv4_error" -eq 0 ] || [ "$ipv6_error" -eq 0 ]; then

--- a/net/pbr/files/etc/uci-defaults/90-pbr
+++ b/net/pbr/files/etc/uci-defaults/90-pbr
@@ -5,6 +5,11 @@ readonly __OK__='\033[0;32m[\xe2\x9c\x93]\033[0m'
 
 # Transition from vpn-policy-routing
 if [ -s '/etc/config/vpn-policy-routing' ] && [ ! -s '/etc/config/pbr-opkg' ]; then
+	if [ -x '/etc/init.d/vpn-policy-routing' ]; then
+		echo "Stopping and disabling vpn-policy-routing."
+		/etc/init.d/vpn-policy-routing stop
+		/etc/init.d/vpn-policy-routing disable
+	fi
 	echo "Migrating vpn-policy-routing config file."
 	mv '/etc/config/pbr' '/etc/config/pbr-opkg'
 	sed 's/vpn-policy-routing/pbr/g' /etc/config/vpn-policy-routing > /etc/config/pbr


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 22.03.5
Run tested: x86_64, Sophos XG-135r3, OpenWrt 22.03.5, start & verify no error messages and IPv6 gw

Description:
* suppress RTNETLINK errors when inserting ipv6 routes
* only display global scope IPv6 gateways in status/WebUI
* stop and disable vpn-policy-routing when migrating

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit c2739705b98ebe37bb43f1650745c5e2336f163a)
