### PR TITLE
gnutls: update to v3.8.0

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
-PKG_VERSION:=3.7.8
-PKG_RELEASE:=2
+PKG_VERSION:=3.8.0
+PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7
-PKG_HASH:=c58ad39af0670efe6a8aee5e3a8b2331a1200418b64b7c51977fb396d4617114
+PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.8
+PKG_HASH:=0ea0d11a1660a1e63f960f157b197abe6d0c8cb3255be24e1fb3815930b9bdc5
 
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <nmav@gnutls.org>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/libs/gnutls/patches/010-m4.patch
+++ b/libs/gnutls/patches/010-m4.patch
@@ -62,12 +62,12 @@
      [AC_COMPILE_IFELSE(
 --- a/src/gl/m4/gnulib-comp.m4
 +++ b/src/gl/m4/gnulib-comp.m4
-@@ -1188,7 +1188,7 @@ changequote([, ])dnl
+@@ -1252,7 +1252,7 @@ changequote([, ])dnl
    gl_UNISTD_MODULE_INDICATOR([sleep])
    AC_CHECK_DECLS_ONCE([alarm])
    AC_REQUIRE([gt_TYPE_WCHAR_T])
 -  AC_REQUIRE([gt_TYPE_WINT_T])
 +  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
    gl_FUNC_STRERROR_R
-   if test $HAVE_DECL_STRERROR_R = 0 || test $REPLACE_STRERROR_R = 1; then
+   AS_IF([test $HAVE_DECL_STRERROR_R = 0 || test $REPLACE_STRERROR_R = 1], [
      AC_LIBOBJ([strerror_r])

--- a/libs/gnutls/patches/020-dont-install-m4-files.patch
+++ b/libs/gnutls/patches/020-dont-install-m4-files.patch
@@ -14,7 +14,7 @@ Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
 
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -57,7 +57,7 @@ if ENABLE_DOC
+@@ -48,7 +48,7 @@ if ENABLE_DOC
  SUBDIRS += doc
  endif
  


### PR DESCRIPTION
Fixes: https://github.com/openwrt/openwrt/issues/12542 

The detailed list of changes follows:

* Version 3.8.0 (released 2023-02-09)

** libgnutls: Fix a Bleichenbacher oracle in the TLS RSA key exchange. Reported by Hubert Kario (#1050). Fix developed by Alexander Sosedkin. [GNUTLS-SA-2020-07-14, CVSS: medium] [CVE-2023-0361]

** libgnutls: C++ library is now header only. All definitions from gnutlsxx.c have been moved into gnutlsxx.h. Users of the C++ interface have two options:
1. include gnutlsxx.h in their application and link against the C library. (default)
2. include gnutlsxx.h in their application, compile with GNUTLS_GNUTLSXX_NO_HEADERONLY macro defined and link against the C++ library.

** libgnutls: GNUTLS_NO_STATUS_REQUEST flag and %NO_STATUS_REQUEST priority modifier have been added to allow disabling of the status_request TLS extension in the client side.

** libgnutls: TLS heartbeat is disabled by default. The heartbeat extension in TLS (RFC 6520) is not widely used given other implementations dropped support for it. To enable back support for it, supply --enable-heartbeat-support to configure script.

** libgnutls: SRP authentication is now disabled by default. It is disabled because the SRP authentication in TLS is not up to date with the latest TLS standards and its ciphersuites are based on the CBC mode and SHA-1. To enable it back, supply --enable-srp-authentication option to configure script.

** libgnutls: All code has been indented using "indent -ppi1 -linux". CI/CD has been adjusted to catch regressions. This is implemented through devel/indent-gnutls, devel/indent-maybe and .gitlab-ci.yml’s commit-check. You may run devel/indent-gnutls to fix any indentation issues if you make code modifications.

** guile: Guile-bindings removed.
They have been extracted into a separate project to reduce complexity and to simplify maintenance, see <https://gitlab.com/gnutls/guile/>.

** minitasn1: Upgraded to libtasn1 version 4.19.

** API and ABI modifications:
GNUTLS_NO_STATUS_REQUEST: New flag
GNUTLS_SRTP_AEAD_AES_128_GCM: New gnutls_srtp_profile_t enum member GNUTLS_SRTP_AEAD_AES_256_GCM: New gnutls_srtp_profile_t enum member

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
