### PR TITLE
simple-adblock: add family to firewall json objects

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.9.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -1395,6 +1395,7 @@ adb_start() {
 				json_add_string proto "tcp udp"
 				json_add_string src_dport "$c"
 				json_add_string dest_port "$c"
+				json_add_string family any
 				json_add_boolean reflection 0
 				json_close_object
 			else


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 22.03
Run tested:  x86_64, Sophos XG-135r3, OpenWrt 22.03, test dns hijacking

Description:
* add family to firewall json objects, due to report that without explicit family declaration the hijacking didn't work for IPv6