### PR TITLE
[22.03] https-dns-proxy: fixes/improvements

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2022-10-15
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -17,7 +17,6 @@ fi
 readonly PKG_VERSION='dev-test'
 readonly packageName='https-dns-proxy'
 readonly serviceName="$packageName $PKG_VERSION"
-readonly sharedMemoryOutput="/dev/shm/$packageName-output"
 readonly _OK_='\033[0;32m\xe2\x9c\x93\033[0m'
 readonly _FAIL_='\033[0;31m\xe2\x9c\x97\033[0m'
 readonly PROG=/usr/sbin/https-dns-proxy
@@ -33,6 +32,7 @@ is_ipv4() { expr "$1" : '[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$' >/
 is_ipv6() { ! is_mac_address "$1" && str_contains "$1" ":"; }
 output() {
 	local msg memmsg logmsg
+	local sharedMemoryOutput="/dev/shm/$packageName-output"
 	[ -t 1 ] && printf "%b" "$@"
 	msg="${1//$serviceName /service }";
 	if [ "$(printf "%b" "$msg" | wc -l)" -gt 0 ]; then
@@ -171,6 +171,7 @@ start_instance() {
 				json_add_string proto 'tcp udp'
 				json_add_string src_dport "$p"
 				json_add_string dest_port "$p"
+				json_add_string family any
 				json_add_boolean reflection 0
 				json_close_object
 			else


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 22.03
Run tested: x86_64, Sophos XG-135r3, OpenWrt 22.03, test dns hijacking

Description:
* use shared memory to store output data
* add family option to firewall json objects, due to reports that IPv6 hijacking doesn't work without explicit family declaration

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 25801ddf7435e535fc0684911abdf6022549409f)
