### PR TITLE
zabbix: add patch for gnutls version handling

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=6.2.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/6.2/

--- a/admin/zabbix/patches/200-configure-fix-gnutls-version-search.patch
+++ b/admin/zabbix/patches/200-configure-fix-gnutls-version-search.patch
@@ -1,0 +1,41 @@
+--- a/configure
++++ b/configure
+@@ -11915,9 +11915,9 @@ $as_echo_n "checking for GnuTLS support.
+ 	minimal_gnutls_version_patch=18
+ 
+ 	# get version
+-	found_gnutls_version_major=`cat /usr/local/include/gnutls/gnutls.h | $EGREP \#define.*GNUTLS_VERSION_MAJOR | $AWK '{print $3;}'`
+-	found_gnutls_version_minor=`cat /usr/local/include/gnutls/gnutls.h | $EGREP \#define.*GNUTLS_VERSION_MINOR | $AWK '{print $3;}'`
+-	found_gnutls_version_patch=`cat /usr/local/include/gnutls/gnutls.h | $EGREP \#define.*GNUTLS_VERSION_PATCH | $AWK '{print $3;}'`
++	found_gnutls_version_major=`cat /usr/local/include/gnutls/gnutls.h | $EGREP 'define.*GNUTLS_VERSION_MAJOR' | $AWK '{print $4;}'`
++	found_gnutls_version_minor=`cat /usr/local/include/gnutls/gnutls.h | $EGREP 'define.*GNUTLS_VERSION_MINOR' | $AWK '{print $4;}'`
++	found_gnutls_version_patch=`cat /usr/local/include/gnutls/gnutls.h | $EGREP 'define.*GNUTLS_VERSION_PATCH' | $AWK '{print $4;}'`
+ 
+ 	if test $((found_gnutls_version_major)) -gt $((minimal_gnutls_version_major)); then
+ 		accept_gnutls_version="yes"
+@@ -11945,9 +11945,9 @@ $as_echo_n "checking for GnuTLS support.
+ 	minimal_gnutls_version_patch=18
+ 
+ 	# get version
+-	found_gnutls_version_major=`cat /usr/include/gnutls/gnutls.h | $EGREP \#define.*GNUTLS_VERSION_MAJOR | $AWK '{print $3;}'`
+-	found_gnutls_version_minor=`cat /usr/include/gnutls/gnutls.h | $EGREP \#define.*GNUTLS_VERSION_MINOR | $AWK '{print $3;}'`
+-	found_gnutls_version_patch=`cat /usr/include/gnutls/gnutls.h | $EGREP \#define.*GNUTLS_VERSION_PATCH | $AWK '{print $3;}'`
++	found_gnutls_version_major=`cat /usr/include/gnutls/gnutls.h | $EGREP 'define.*GNUTLS_VERSION_MAJOR' | $AWK '{print $4;}'`
++	found_gnutls_version_minor=`cat /usr/include/gnutls/gnutls.h | $EGREP 'define.*GNUTLS_VERSION_MINOR' | $AWK '{print $4;}'`
++	found_gnutls_version_patch=`cat /usr/include/gnutls/gnutls.h | $EGREP 'define.*GNUTLS_VERSION_PATCH' | $AWK '{print $4;}'`
+ 
+ 	if test $((found_gnutls_version_major)) -gt $((minimal_gnutls_version_major)); then
+ 		accept_gnutls_version="yes"
+@@ -11981,9 +11981,9 @@ $as_echo "no" >&6; }
+ 	minimal_gnutls_version_patch=18
+ 
+ 	# get version
+-	found_gnutls_version_major=`cat $_libgnutls_dir/include/gnutls/gnutls.h | $EGREP \#define.*GNUTLS_VERSION_MAJOR | $AWK '{print $3;}'`
+-	found_gnutls_version_minor=`cat $_libgnutls_dir/include/gnutls/gnutls.h | $EGREP \#define.*GNUTLS_VERSION_MINOR | $AWK '{print $3;}'`
+-	found_gnutls_version_patch=`cat $_libgnutls_dir/include/gnutls/gnutls.h | $EGREP \#define.*GNUTLS_VERSION_PATCH | $AWK '{print $3;}'`
++	found_gnutls_version_major=`cat $_libgnutls_dir/include/gnutls/gnutls.h | $EGREP 'define.*GNUTLS_VERSION_MAJOR' | $AWK '{print $4;}'`
++	found_gnutls_version_minor=`cat $_libgnutls_dir/include/gnutls/gnutls.h | $EGREP 'define.*GNUTLS_VERSION_MINOR' | $AWK '{print $4;}'`
++	found_gnutls_version_patch=`cat $_libgnutls_dir/include/gnutls/gnutls.h | $EGREP 'define.*GNUTLS_VERSION_PATCH' | $AWK '{print $4;}'`
+ 
+ 	if test $((found_gnutls_version_major)) -gt $((minimal_gnutls_version_major)); then
+ 		accept_gnutls_version="yes"


### PR DESCRIPTION
Maintainer: @champtar 
Compile tested: x86/64 and lantiq/xrx00

Description:
Zabbix checks the version of gnutls by search in the header gnutls.h. This is done with 'cat' and 'egrep'. The problem here is now that the preprocess definition did changed in gnutls.h in gntuls version 3.8.0, so the regex does not match anymore. The following error message a course in the log.

`configure: error: GnuTLS library version requirement not met (>= 3.1.18)`

To fix this the, regex must be corrected with this commit, so the version check does work again

**This is only needed for the current gnutls version 3.8.0. The master branch of gnutls already fixed this, so on rebasing to a new version of gnutls this patch can be removed from zabbix, because the check does work again.**
https://github.com/gnutls/gnutls/commit/18345986e29c820e64daced78232f236fd4a4e6e
