### PR TITLE
crowdsec-firewall-bouncer: new upstream release version 0.0.26

### DIFF
--- a/net/crowdsec-firewall-bouncer/Makefile
+++ b/net/crowdsec-firewall-bouncer/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crowdsec-firewall-bouncer
-PKG_VERSION:=0.0.25
+PKG_VERSION:=0.0.26
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/crowdsecurity/cs-firewall-bouncer/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=15ffaa38644215a4cf5e5d5d3a6fc6f0800057bc55d4bd25778d8e952679506e
+PKG_HASH:=2325df3f8d01e2c9b52db212a796b15b4992a135d5d278441277e97db353b2a7
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Signed-off-by: S. Brusch <ne20002@gmx.ch>

Maintainer: Kerma Gérald <gandalf@gk2.net>
Run tested: ipq40xx/generic, Fritzbox 4040, Openwrt 22.03.5

Update crowdsec-firewall-bouncer to latest upstream release version 0.0.26

(cherry picked from commit 05bc30fbb2636e8ef12326847f07cc3d788dbf4a)