### PR TITLE
CI: Run "apt-get update", do package run-tests only if target packages were built

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -160,21 +160,32 @@ jobs:
       - name: Remove logs
         run: sudo rm -rf logs/ || true
 
+      - name: Check if any packages were built
+        run: |
+          if [ -n "$(find . -maxdepth 1 -type f -name '*.ipk' -print -quit)" ]; then
+            echo "Found *.ipk files"
+            HAVE_IPKS=true
+          else
+            echo "No *.ipk files found"
+            HAVE_IPKS=false
+          fi
+          echo "HAVE_IPKS=$HAVE_IPKS" >> $GITHUB_ENV
+
       - name: Register QEMU
-        if: ${{ matrix.runtime_test }}
+        if: ${{ matrix.runtime_test && fromJSON(env.HAVE_IPKS) }}
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static binfmt-support
           sudo update-binfmts --import
 
       - name: Build Docker container
-        if: ${{ matrix.runtime_test }}
+        if: ${{ matrix.runtime_test && fromJSON(env.HAVE_IPKS) }}
         run: |
           docker build -t test-container --build-arg ARCH .github/workflows/
         env:
           ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
 
       - name: Test via Docker container
-        if: ${{ matrix.runtime_test }}
+        if: ${{ matrix.runtime_test && fromJSON(env.HAVE_IPKS) }}
         run: |
           docker run --rm -v $GITHUB_WORKSPACE:/ci test-container

--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -84,6 +84,7 @@ jobs:
 
       - name: Generate build keys
         run: |
+          sudo apt-get update
           sudo apt-get install -y signify-openbsd
           signify-openbsd -G -n -c 'DO NOT USE - OpenWrt packages feed CI' -p packages_ci.pub -s packages_ci.sec
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)


### PR DESCRIPTION
Maintainer: @aparcar (ping @neheb, @BKPepe, @1715173329)
Compile tested: test PR on my own fork ([with ipks](https://github.com/jefferyto/openwrt-packages/actions/runs/4934827250/jobs/8820347865), [no ipks](https://github.com/jefferyto/openwrt-packages/actions/runs/4934647133/jobs/8819952556))
Run tested: N/A

Description:
* **[CI: Run "apt-get update" before installing signify-openbsd](https://github.com/openwrt/packages/commit/fc4cac029af9101501e6d28419f99b40598b1627)**

  I forgot to add a `apt-get update` in #20845 :sweat_smile: 

* **[CI: Do package run-tests only if target packages were built](https://github.com/openwrt/packages/commit/817968f5c003edb034c7fbdf653662bf671e7b5a)**

  Currently, the package run-test phase will fail for PRs that only add/update host-only packages, as no target packages (*.ipk) are built.

  This checks if any target packages are built before attempting the run-tests.
