### PR TITLE
python-incremental: Add missing host build dependencies

### DIFF
--- a/lang/python/python-incremental/Makefile
+++ b/lang/python/python-incremental/Makefile
@@ -18,6 +18,8 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-wheel/host
+
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk


### PR DESCRIPTION
Maintainer: me
Compile tested: armvirt-32, 2023-05-08 snapshot sdk
Run tested: N/A

Description:
Fixes: 8d81b6732757 ("python-incremental: Update to 22.10.0, redo patch, add host build")