### PR TITLE
wsdd2: fix stopping service

### DIFF
--- a/net/wsdd2/Makefile
+++ b/net/wsdd2/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wsdd2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/Netgear/wsdd2.git

--- a/net/wsdd2/files/wsdd2.init
+++ b/net/wsdd2/files/wsdd2.init
@@ -29,8 +29,8 @@ start_service() {
 	}
 
 	[ -z "$SMB_CONF" ] && {
-		logger -p daemon.error -t 'wsdd2' "samba36/4 or ksmbd is not running, can't start wsdd2!"
-		exit 1
+		logger -p daemon.info -t 'wsdd2' "samba36/4 or ksmbd is not running"
+		return
 	}
 	
 	# cleanup comments


### PR DESCRIPTION
```
Function start_service() is called whenever service may need reloading.
If SMB server is not running it could be simply because it has been
stopped. Reloading service in such case is not an error so:
1. Don't log error as it isn't one
2. Don't exit with error code as it was confusing procd

This change fixes scenario like:
/etc/init.d/ksmbd stop
/etc/init.d/wsdd2 reload
(previously above wasn't stopping wsdd2)
```