### PR TITLE
glib2: fix host build offline build

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.74.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/$(word 1,$(subst ., ,$(PKG_VERSION))).$(word 2,$(subst ., ,$(PKG_VERSION)))
@@ -21,10 +21,12 @@ PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:gnome:glib
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/glib-$(PKG_VERSION)
-HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/glib-$(PKG_VERSION)
 PKG_CONFIG_DEPENDS:=CONFIG_BUILD_NLS
 PKG_FORTIFY_SOURCE:=0
 PKG_BUILD_FLAGS:=gc-sections
+
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/glib-$(PKG_VERSION)
+HOST_BUILD_DEPENDS:=pcre2/host libffi/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
@@ -61,7 +63,7 @@ COMP_ARGS= \
 	-Dglib_checks=true \
 	-Dlibelf=disabled
 
-MESON_HOST_ARGS += $(COMP_ARGS) -Dxattr=false -Ddefault_library=static -Dnls=disabled -Dwrap_mode=forcefallback
+MESON_HOST_ARGS += $(COMP_ARGS) -Dxattr=false -Ddefault_library=static -Dnls=disabled
 MESON_ARGS += $(COMP_ARGS) -Dxattr=true -Db_lto=true -Ddefault_library=both -Dnls=$(if $(CONFIG_BUILD_NLS),en,dis)abled
 
 define Build/InstallDev


### PR DESCRIPTION
Maintainer: @neheb
Compile tested: x86_64, openwrt master
Run tested: none

fixes #20219 

Description:
If buildsystem does not have a internet connection, then the build fails. This is because of the fact, that glib2 is downloading and building the missing dependencies during host compilation.

This cannot be allowed to happen. The package must also be built without an internet connection.

Adding the missing host build dependency and removing the 'forcefallback' fixes this issue.
