### PR TITLE
syslog-ng: start early

### DIFF
--- a/admin/syslog-ng/files/syslog-ng.init
+++ b/admin/syslog-ng/files/syslog-ng.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2006-2019 OpenWrt.org
 
-START=50
+START=12
 
 USE_PROCD=1
 


### PR DESCRIPTION
This is needed for services such as /etc/rc.d/S19dnsmasq that start
before S50syslog-ng and expect /dev/log to exist to mount it in jail.

Fixes https://github.com/openwrt/packages/issues/20971



Maintainer: @BKPepe
Compile tested:  x86-64 Ubuntu 22.04.1 LTS, CONFIG_TARGET_ipq40xx, OpenWrt 22.03.0-rc4
Run tested: armv7l, InHand Networks VG710, OpenWrt 22.03.0-rc4

The purpose of the test was to check if dnsmasq starts:

    root@OpenWrt:~# busybox ps w | grep '[d]nsmasq'
     4443 root      2408 S    {dnsmasq} /sbin/ujail -t 5 -n dnsmasq -u -l -r /bin/ubus -r /etc/TZ -r /etc/dnsmasq.conf -r /etc/ethers -
     4447 dnsmasq   1260 S    /usr/sbin/dnsmasq -C /var/etc/dnsmasq.conf.cfg01411c -k -x /var/run/dnsmasq/dnsmasq.cfg01411c.pid

Description: