### PR TITLE
[22.03] pbr: bugfix: create IPv6 routes

### DIFF
--- a/net/pbr/Makefile
+++ b/net/pbr/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=5
+PKG_RELEASE:=7
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 

--- a/net/pbr/files/etc/init.d/pbr.init
+++ b/net/pbr/files/etc/init.d/pbr.init
@@ -162,7 +162,7 @@ output_failn() { output 1 "$_FAIL_\\n"; output 2 "$__FAIL__\\n"; }
 # shellcheck disable=SC2317
 str_replace() { printf "%b" "$1" | sed -e "s/$(printf "%b" "$2")/$(printf "%b" "$3")/g"; }
 str_replace() { echo "${1//$2/$3}"; }
-str_contains() { [ -n "$1" ] &&[ -n "$2" ] && [ "${1//$2}" != "$1" ]; }
+str_contains() { [ -n "$1" ] && [ -n "$2" ] && [ "${1//$2}" != "$1" ]; }
 is_greater() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
 is_greater_or_equal() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" = "$2"; }
 str_contains_word() { echo "$1" | grep -q -w "$2"; }
@@ -304,7 +304,7 @@ get_nft_sets() { [ -x "$nft" ] && "$nft" list table inet "$nftTable" 2>/dev/null
 is_ipset_type_supported() { ipset help hash:"$1" >/dev/null 2>&1; }
 ubus_get_status() { ubus call service list "{ 'name': '$packageName' }" | jsonfilter -e "@.${packageName}.instances.main.data.status.${1}"; }
 ubus_get_iface() { ubus call service list "{ 'name': '$packageName' }" | jsonfilter -e "@.${packageName}.instances.main.data.interfaces[@.name='${1}']${2:+.$2}"; }
-opkg_get_version() { grep -m1 -A1 "$1" '/usr/lib/opkg/status' | grep -m1 'Version: ' | sed 's|Version: \(.*\)|\1|'; }
+opkg_get_version() { grep -m1 -A1 "Package: $1$" '/usr/lib/opkg/status' | grep -m1 'Version: ' | sed 's|Version: \(.*\)|\1|'; }
 
 load_package_config() {
 	config_load "$packageName"
@@ -1753,7 +1753,8 @@ EOF
 							while read -r i; do
 								i="$(echo "$i" | sed 's/ linkdown$//')"
 								i="$(echo "$i" | sed 's/ onlink$//')"
-								$ip_bin -6 route add "$i" table "$tid" >/dev/null 2>&1 || ipv6_error=1
+								# shellcheck disable=SC2086
+								$ip_bin -6 route add $i table "$tid" >/dev/null 2>&1 || ipv6_error=1
 							done << EOF
 							$($ip_bin -6 route list table main | grep " dev $dev6 ")
 EOF
@@ -1832,7 +1833,8 @@ EOF
 						$ip_bin -6 route add unreachable default table "$tid" || ipv6_error=1
 					elif $ip_bin -6 route list table main | grep -q " dev $dev6 "; then
 						while read -r i; do
-							$ip_bin -6 route add "$i" table "$tid" >/dev/null 2>&1 || ipv6_error=1
+							# shellcheck disable=SC2086
+							$ip_bin -6 route add $i table "$tid" >/dev/null 2>&1 || ipv6_error=1
 						done << EOF
 						$($ip_bin -6 route list table main | grep " dev $dev6 ")
 EOF
@@ -2310,6 +2312,11 @@ status_service_nft() {
 		echo "IPv4 table $((wan_tid + i)) route: $($ip_bin -4 route show table $((wan_tid + i)) | grep default)"
 		echo "IPv4 table $((wan_tid + i)) rule(s):"
 		$ip_bin -4 rule list table "$((wan_tid + i))"
+		if [ -n "$ipv6_enabled" ]; then
+			echo "IPv6 table $((wan_tid + i)) route: $($ip_bin -6 route show table $((wan_tid + i)) | grep default)"
+			echo "IPv6 table $((wan_tid + i)) rule(s):"
+			$ip_bin -6 route show table $((wan_tid + i))
+		fi
 		i=$((i + 1))
 	done
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 22.03.5
Run tested: x86_64, Sophos XG-135r3, OpenWrt 22.03.5, test IPv6 routes

Description:
* add missing space in str_contains
* unquote variable to make sure IPv6 rotues are added
* add IPv6 routes display to status output in nft mode

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 643e501c8d0209dbbc683447b4df0c4b2b9aed08)
