### PR TITLE
netavark: add new package

### DIFF
--- a/net/netavark/Makefile
+++ b/net/netavark/Makefile
@@ -1,0 +1,51 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=netavark
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/containers/netavark.git
+PKG_SOURCE_DATE:=2023-05-12
+PKG_SOURCE_VERSION:=07d63eadef1def977f2ece25b0f464f7e5d77be1
+PKG_MIRROR_HASH:=f7597d70528d039b984b2ecc6ef0e1f1c17aacfc7862907e5a79789ebe98aa89
+
+PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:= \
+	rust/host \
+	protobuf/host
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/netavark
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=$(RUST_ARCH_DEPENDS)
+  TITLE:=A container network stack
+  URL:=https://github.com/containers/netavark
+endef
+
+define Package/netavark/description
+  Netavark is a rust based network stack for containers. It is being designed to work with Podman but is also
+  applicable for other OCI container management applications.
+endef
+
+define Package/netavark/conffiles
+/etc/config/netavark
+endef
+
+CARGO_VARS += \
+	PROTOC=$(STAGING_DIR_HOSTPKG)/bin/protoc
+
+define Package/netavark/install
+	$(INSTALL_DIR) $(1)/etc/config $(1)/usr/lib/podman
+	$(INSTALL_CONF) ./files/netavark-config $(1)/etc/config/netavark
+	$(INSTALL_BIN) ./files/netavark-wrapper $(1)/usr/lib/podman/netavark
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/netavark $(1)/usr/lib/podman/netavark-bin
+endef
+
+$(eval $(call RustBinPackage,netavark))
+$(eval $(call BuildPackage,netavark))

--- a/net/netavark/files/netavark-config
+++ b/net/netavark/files/netavark-config
@@ -1,0 +1,3 @@
+
+config firewall
+	option driver 'none'

--- a/net/netavark/files/netavark-wrapper
+++ b/net/netavark/files/netavark-wrapper
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+FW_DRIVER=$(uci -q get 'netavark.@firewall[0].driver')
+[ -z "$FW_DRIVER" ] && FW_DRIVER="none"
+
+NETAVARK_FW="$FW_DRIVER" /usr/lib/podman/netavark-bin $@


### PR DESCRIPTION
podman is moving from cni to netavark. Netavark supports currently only iptables, so I was in touch some time ago with mainstream maintainer and provided a "none" firewall driver - to make it possible to use netavark without firewalling features. This was merged to mainstream. Driver cannot be selected at this time without environment variable that selects it, so I made a config file for openwrt and a wrapper script that takes advantage of it, since you cannot set it as a setting in containers.conf at this moment.

Available options are iptables, nftables and none - but selecting nftables just tells user that nftables isn't yet supported.

firewall "none" driver is not yet included in release, so that's why we use git version instead. I chose latest commit instead of commit with none driver.

next update of Podman, should use netavark over cni in openwrt package repository (software has had this feature already for some time..)

Description:
Netavark is a rust based network stack for containers. It is being designed to work with Podman but is also applicable for other OCI container management applications.

Maintainer: Oskari Rauta / @oskarirauta
Compile tested: x86_64, latest git
Run tested: x86_64, latest git