### PR TITLE
aardvark-dns: add new package

### DIFF
--- a/net/aardvark-dns/Makefile
+++ b/net/aardvark-dns/Makefile
@@ -1,0 +1,43 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=aardvark-dns
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/containers/aardvark-dns.git
+PKG_SOURCE_DATE:=2023-05-12
+PKG_SOURCE_VERSION:=6e06736707d8a84240858e968a54a083083e3a09
+PKG_MIRROR_HASH:=407d73c0a01b9fd6248a1ce058541707580db46a7d18f776780fe7922ba97391
+
+PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=rust/host
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/aardvark-dns
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=$(RUST_ARCH_DEPENDS)
+  TITLE:=authoritative dns server for container records
+  URL:=https://github.com/containers/aardvark-dns
+endef
+
+define Package/aardvark-dns/description
+  Aardvark-dns is an authoritative dns server for A/AAAA container records.
+  It can forward other requests to configured resolvers.
+
+  It is mostly intended to be used with Netavark which will
+  launch it automatically if both are installed.
+endef
+
+define Package/aardvark-dns/install
+	$(INSTALL_DIR) $(1)/usr/lib/podman
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/aardvark-dns $(1)/usr/lib/podman/
+endef
+
+$(eval $(call RustBinPackage,aardvark-dns))
+$(eval $(call BuildPackage,aardvark-dns))


### PR DESCRIPTION
aardvark-dns is companion for netavark #20995, recent cni replacement on podman git version used instead of release, to maintain maximal compatibility with netavark, also using git version.

Description:
Aardvark-dns is an authoritative dns server for A/AAAA container records. It can forward other requests to configured resolvers.

Maintainer: oskarirauta / @oskarirauta
Compile tested: x86_64, recent git
Run tested: x86_64, recent git