### PR TITLE
prometheus-node-exporter-lua: Add thermal collector

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2022.08.08
+PKG_VERSION:=2023.05.14
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
@@ -169,6 +169,17 @@ define Package/prometheus-node-exporter-lua-textfile/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/textfile.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
+define Package/prometheus-node-exporter-lua-thermal
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (thermal collector)
+  DEPENDS:=prometheus-node-exporter-lua
+endef
+
+define Package/prometheus-node-exporter-lua-thermal/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/thermal.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
 define Package/prometheus-node-exporter-lua-ubnt-manager
   $(call Package/prometheus-node-exporter-lua/Default)
   TITLE+= (ubnt-manager collector)
@@ -246,6 +257,7 @@ $(eval $(call BuildPackage,prometheus-node-exporter-lua-nat_traffic))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-netstat))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-openwrt))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-textfile))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-thermal))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-ubnt-manager))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-uci_dhcp_host))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi))

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/thermal.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/thermal.lua
@@ -1,0 +1,46 @@
+-- thermal collector
+local function scrape()
+  local i = 0
+  local temp_metric = metric("node_thermal_zone_temp", "gauge")
+
+  while true do
+    local zonePath = "/sys/class/thermal/thermal_zone" .. i
+
+    -- required attributes
+
+    local typ = string.match(get_contents(zonePath .. "/type"), "^%s*(.-)%s*$")
+    if not typ then
+      break
+    end
+
+    local policy = string.match(get_contents(zonePath .. "/policy"), "^%s*(.-)%s*$")
+    if not policy then
+      break
+    end
+
+    local temp = string.match(get_contents(zonePath .. "/temp"), "(%d+)")
+    if not temp then
+      break
+    end
+
+    local labels = {zone = i, type = typ, policy = policy}
+
+    -- optional attributes
+
+    local mode = string.match(get_contents(zonePath .. "/mode"), "^%s*(.-)%s*$")
+    if mode then
+      labels.mode = mode
+    end
+
+    local passive = string.match(get_contents(zonePath .. "/passive"), "(%d+)")
+    if passive then
+      labels.passive = passive
+    end
+
+    temp_metric(labels, temp / 1000)
+
+    i = i + 1
+  end
+end
+
+return { scrape = scrape }


### PR DESCRIPTION
Maintainer: @dhewg @champtar @jpds @PolynomialDivision @mweinelt (committed `Makefile` within the last two years)
Compile tested: N/A (the script is not compiled)
Run tested: aarch64, Raspberry Pi 4 Model B,  OpenWrt 22.03.0, r19685-512e76967f;
- Say `opkg install prometheus-node-exporter-lua` (plus some more exporters)
- Install the `thermal.lua` script in the `/usr/lib/lua/prometheus-collectors` directory
- Say `/etc/init.d/prometheus-node-exporter-lua restart`
- Manually inspect exported metrics with `wget -O- -4 http://localhost:9100/metrics`:
```
# TYPE node_thermal_temp gauge
node_thermal_temp{thermal_zone="0"} 50.147
node_scrape_collector_duration_seconds{collector="thermal"} 0.00015020370483398
node_scrape_collector_success{collector="thermal"} 1
```

Description:
This was the most straightforward way I could come up with to let me monitor the CPU temperature of my Raspberry Pi running OpenWrt, and it gets the job done for me.
- Do you think this would be useful enough for inclusion in an OpenWrt package like this?
- Does it belong in the main `prometheus-node-exporter-lua` package, as suggested in this pull request? Or is it better suited in its own package, similar to e.g. `prometheus-node-exporter-lua-wifi`?
- What do you think about the Prometheus metric and label naming?