### PR TITLE
gnutls: load libunistring-optional gnulib module

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
 PKG_VERSION:=3.8.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_BUILD_FLAGS:=no-mips16
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -132,6 +132,7 @@ CONFIGURE_ARGS+= \
 	--without-idn \
 	--with-default-trust-store-dir=/etc/ssl/certs/ \
 	--with-included-unistring \
+	--with-included-libunistring \
 	--with-librt-prefix="$(LIBRT_ROOT_DIR)/" \
 	--with-pic \
 	--with-system-priority-file="" \

--- a/libs/gnutls/patches/030-unistring-optional.patch
+++ b/libs/gnutls/patches/030-unistring-optional.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -471,6 +471,8 @@ DEFAULT_VALGRINDFLAGS='-q --error-exitco
+ 
+ gl_VALGRIND_TESTS_DEFAULT_NO
+ 
++gl_LIBUNISTRING_OPTIONAL
++
+ dnl Note that g*l_INIT are run after we check for library capabilities,
+ dnl to prevent issues from caching lib dependencies. See discussion
+ dnl in https://bugs.gentoo.org/show_bug.cgi?id=494940 and


### PR DESCRIPTION
Since a few days staging_dir/host/share/aclocal/ contains new m4 files (libunistring-base.m4, libunistring-optional.m4, libunistring.m4 etc.) that get applied during autoreconf. This changes the libunistring setup enough that we run into problem (builds fail).

Load the libunistring-optional gnulib module in configure.ac to be able to add/use the new configure switch "--with-included-libunistring".

This is at most a workaround. This should be followed up with gnutls upstream to clean this up.

Maintainer: @nmav 
Compile tested:sdk ath79
Run tested: N/A

Description:
This is regarding the gnutls build failure reported in issue #20969. It was suspected that this is related to gcc-13, but as it turns out it's just a broken interaction between gnutls and updated autoreconf macros.