### PR TITLE
xtables-addons: fix compilation warning on LUA module

### DIFF
--- a/net/xtables-addons/patches/300-fix-variable-length-array.patch
+++ b/net/xtables-addons/patches/300-fix-variable-length-array.patch
@@ -1,0 +1,37 @@
+--- a/extensions/LUA/byte_array.c
++++ b/extensions/LUA/byte_array.c
+@@ -107,12 +107,22 @@ static int32_t get_byte_array_size(lua_S
+ static int32_t byte_array_to_string(lua_State *L)
+ {
+ 	lua_packet_segment * array = checkbytearray(L, 1);
+-	uint8_t buf[(array->length * 3) + 255];
++	uint8_t *buf;
+ 	uint8_t hexval[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+-	char res[255 + (array->length * 3)]; /* make sure the buffer is big enough*/
++	char *res; /* make sure the buffer is big enough*/
+ 	int32_t i, n;
+ 	uint8_t *ptr = array->start + array->offset;
+ 
++	buf = kcalloc((array->length * 3) + 255, sizeof(*buf), GFP_KERNEL);
++	if (!buf)
++		return luaL_error(L, "byte_array_to_string, failed alloc buf buffer");
++
++	res = kcalloc((array->length * 3) + 255, sizeof(*res), GFP_KERNEL);
++	if (!res) {
++		kfree(buf);
++		return luaL_error(L, "byte_array_to_string, failed alloc res buffer");
++	}
++
+ 	for (i = 0; i < array->length; i++) {
+ 		buf[i * 3] = hexval[(ptr[i] >> 4) & 0xF];
+ 		buf[(i * 3) + 1] = hexval[ptr[i] & 0x0F];
+@@ -124,6 +134,9 @@ static int32_t byte_array_to_string(lua_
+ 
+ 	lua_pushlstring(L, res, n);
+ 
++	kfree(buf);
++	kfree(res);
++
+ 	return 1;
+ }
+ 

--- a/net/xtables-addons/patches/301-fix-compilation-warning-va_list-.patch
+++ b/net/xtables-addons/patches/301-fix-compilation-warning-va_list-.patch
@@ -1,0 +1,115 @@
+--- a/extensions/LUA/lua/lauxlib.c
++++ b/extensions/LUA/lua/lauxlib.c
+@@ -4,6 +4,10 @@
+ ** See Copyright Notice in lua.h
+ */
+ 
++#if defined(__KERNEL__)
++#define __need___va_list
++#endif
++
+ #include <stdarg.h>
+ 
+ #if !defined(__KERNEL__)
+--- a/extensions/LUA/lua/ldebug.c
++++ b/extensions/LUA/lua/ldebug.c
+@@ -4,6 +4,9 @@
+ ** See Copyright Notice in lua.h
+ */
+ 
++#if defined(__KERNEL__)
++#define __need___va_list
++#endif
+ 
+ #include <stdarg.h>
+ #include <stddef.h>
+--- a/extensions/LUA/lua/ldump.c
++++ b/extensions/LUA/lua/ldump.c
+@@ -4,6 +4,10 @@
+ ** See Copyright Notice in lua.h
+ */
+ 
++#if defined(__KERNEL__)
++#define __need___va_list
++#endif
++
+ #include <stddef.h>
+ 
+ #define ldump_c
+--- a/extensions/LUA/lua/lfunc.c
++++ b/extensions/LUA/lua/lfunc.c
+@@ -5,6 +5,10 @@
+ */
+ 
+ 
++#if defined(__KERNEL__)
++#define __need___va_list
++#endif
++
+ #include <stddef.h>
+ 
+ #define lfunc_c
+--- a/extensions/LUA/lua/llimits.h
++++ b/extensions/LUA/lua/llimits.h
+@@ -7,6 +7,10 @@
+ #ifndef llimits_h
+ #define llimits_h
+ 
++#if defined(__KERNEL__)
++#define __need___va_list
++#endif
++
+ #include <stddef.h>
+ 
+ #include "lua.h"
+--- a/extensions/LUA/lua/lmem.c
++++ b/extensions/LUA/lua/lmem.c
+@@ -4,6 +4,9 @@
+ ** See Copyright Notice in lua.h
+ */
+ 
++#if defined(__KERNEL__)
++#define __need___va_list
++#endif
+ 
+ #include <stddef.h>
+ 
+--- a/extensions/LUA/lua/lobject.c
++++ b/extensions/LUA/lua/lobject.c
+@@ -4,6 +4,10 @@
+ ** See Copyright Notice in lua.h
+ */
+ 
++#if defined(__KERNEL__)
++#define __need___va_list
++#endif
++
+ #include <stdarg.h>
+ 
+ #include <ctype.h>
+--- a/extensions/LUA/lua/lstate.c
++++ b/extensions/LUA/lua/lstate.c
+@@ -5,6 +5,10 @@
+ */
+ 
+ 
++#if defined(__KERNEL__)
++#define __need___va_list
++#endif
++
+ #include <stddef.h>
+ 
+ #define lstate_c
+--- a/extensions/LUA/lua/ltablib.c
++++ b/extensions/LUA/lua/ltablib.c
+@@ -5,6 +5,10 @@
+ */
+ 
+ 
++#if defined(__KERNEL__)
++#define __need___va_list
++#endif
++
+ #include <stddef.h>
+ 
+ #define ltablib_c

--- a/net/xtables-addons/patches/302-fix-always-false-condition.patch
+++ b/net/xtables-addons/patches/302-fix-always-false-condition.patch
@@ -1,0 +1,12 @@
+
+--- a/extensions/LUA/lua/ldump.c
++++ b/extensions/LUA/lua/ldump.c
+@@ -64,7 +64,7 @@ static void DumpVector(const void* b, in
+ 
+ static void DumpString(const TString* s, DumpState* D)
+ {
+- if (s==NULL || getstr(s)==NULL)
++ if (s==NULL)
+  {
+   size_t size=0;
+   DumpVar(size,D);


### PR DESCRIPTION
Fix multiple compilation warning that are now compilation error due to WERROR on kernel related to LUA module.

Fix compilation warning:
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/byte_array.c: In function 'byte_array_to_string': /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/byte_array.c:110:9: error: ISO C90 forbids variable length array 'buf' [-Werror=vla]
  110 |         uint8_t buf[(array->length * 3) + 255];
      |         ^~~~~~~
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/byte_array.c:112:9: error: ISO C90 forbids variable length array 'res' [-Werror=vla]
  112 |         char res[255 + (array->length * 3)]; /* make sure the buffer is big enough*/
      |         ^~~~
cc1: all warnings being treated as errors

In file included from ./include/linux/string.h:9,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/include/string.h:1,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/ldebug.c:10:
./include/linux/stdarg.h:6: error: "va_start" redefined [-Werror]
    6 | #define va_start(v, l)  __builtin_va_start(v, l)
      |
  CC [M]  /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lstrlib.o
In file included from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/ldebug.c:8: /home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:47: note: this is the location of the previous definition
   47 | #define va_start(v,l)   __builtin_va_start(v,l)
      |
./include/linux/stdarg.h:8: error: "va_arg" redefined [-Werror]
    8 | #define va_arg(v, T)    __builtin_va_arg(v, T)
      |
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:49: note: this is the location of the previous definition
   49 | #define va_arg(v,l)     __builtin_va_arg(v,l)
      |
./include/linux/stdarg.h:9: error: "va_copy" redefined [-Werror]
    9 | #define va_copy(d, s)   __builtin_va_copy(d, s)
      |
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:52: note: this is the location of the previous definition
   52 | #define va_copy(d,s)    __builtin_va_copy(d,s)
      |
  CC [M]  /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/ltable.o
In file included from ./include/linux/kernel.h:5,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/luaconf.h:16,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lua.h:15,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/ldump.c:12:
./include/linux/stdarg.h:6: error: "va_start" redefined [-Werror]
    6 | #define va_start(v, l)  __builtin_va_start(v, l)
      |
In file included from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lua.h:12:
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:47: note: this is the location of the previous definition
   47 | #define va_start(v,l)   __builtin_va_start(v,l)
      |
./include/linux/stdarg.h:8: error: "va_arg" redefined [-Werror]
    8 | #define va_arg(v, T)    __builtin_va_arg(v, T)
      |
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:49: note: this is the location of the previous definition
   49 | #define va_arg(v,l)     __builtin_va_arg(v,l)
      |
./include/linux/stdarg.h:9: error: "va_copy" redefined [-Werror]
    9 | #define va_copy(d, s)   __builtin_va_copy(d, s)
      |
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:52: note: this is the location of the previous definition
   52 | #define va_copy(d,s)    __builtin_va_copy(d,s)
      |
In file included from ./include/linux/kernel.h:5,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/luaconf.h:16,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lua.h:15,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lfunc.c:13:
./include/linux/stdarg.h:6: error: "va_start" redefined [-Werror]
    6 | #define va_start(v, l)  __builtin_va_start(v, l)
      |
In file included from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lua.h:12:
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:47: note: this is the location of the previous definition
   47 | #define va_start(v,l)   __builtin_va_start(v,l)
      |
./include/linux/stdarg.h:8: error: "va_arg" redefined [-Werror]
    8 | #define va_arg(v, T)    __builtin_va_arg(v, T)
      |
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:49: note: this is the location of the previous definition
   49 | #define va_arg(v,l)     __builtin_va_arg(v,l)
      |
./include/linux/stdarg.h:9: error: "va_copy" redefined [-Werror]
    9 | #define va_copy(d, s)   __builtin_va_copy(d, s)
      |
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:52: note: this is the location of the previous definition
   52 | #define va_copy(d,s)    __builtin_va_copy(d,s)
      |
In file included from ./include/linux/kernel.h:5,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/luaconf.h:16,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lua.h:15,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lmem.c:13:
./include/linux/stdarg.h:6: error: "va_start" redefined [-Werror]
    6 | #define va_start(v, l)  __builtin_va_start(v, l)
      |
In file included from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lua.h:12:
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:47: note: this is the location of the previous definition
   47 | #define va_start(v,l)   __builtin_va_start(v,l)
      |
./include/linux/stdarg.h:8: error: "va_arg" redefined [-Werror]
    8 | #define va_arg(v, T)    __builtin_va_arg(v, T)
      |
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:49: note: this is the location of the previous definition
   49 | #define va_arg(v,l)     __builtin_va_arg(v,l)
      |
./include/linux/stdarg.h:9: error: "va_copy" redefined [-Werror]
    9 | #define va_copy(d, s)   __builtin_va_copy(d, s)
      |
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:52: note: this is the location of the previous definition
   52 | #define va_copy(d,s)    __builtin_va_copy(d,s)
      |
In file included from ./include/linux/kernel.h:5,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/include/stdio.h:1,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lobject.c:10:
./include/linux/stdarg.h:6: error: "va_start" redefined [-Werror]
    6 | #define va_start(v, l)  __builtin_va_start(v, l)
      |
In file included from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lobject.c:7:
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:47: note: this is the location of the previous definition
   47 | #define va_start(v,l)   __builtin_va_start(v,l)
      |
./include/linux/stdarg.h:8: error: "va_arg" redefined [-Werror]
    8 | #define va_arg(v, T)    __builtin_va_arg(v, T)
      |
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:49: note: this is the location of the previous definition
   49 | #define va_arg(v,l)     __builtin_va_arg(v,l)
      |
./include/linux/stdarg.h:9: error: "va_copy" redefined [-Werror]
    9 | #define va_copy(d, s)   __builtin_va_copy(d, s)
      |
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:52: note: this is the location of the previous definition
   52 | #define va_copy(d,s)    __builtin_va_copy(d,s)
      |
In file included from ./include/linux/kernel.h:5,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/luaconf.h:16,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lua.h:15,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/llimits.h:12,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lopcodes.h:10,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lopcodes.c:11:
./include/linux/stdarg.h:6: error: "va_start" redefined [-Werror]
    6 | #define va_start(v, l)  __builtin_va_start(v, l)
      |
In file included from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lua.h:12:
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:47: note: this is the location of the previous definition
   47 | #define va_start(v,l)   __builtin_va_start(v,l)
      |
./include/linux/stdarg.h:8: error: "va_arg" redefined [-Werror]
    8 | #define va_arg(v, T)    __builtin_va_arg(v, T)
      |
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:49: note: this is the location of the previous definition
   49 | #define va_arg(v,l)     __builtin_va_arg(v,l)
      |
./include/linux/stdarg.h:9: error: "va_copy" redefined [-Werror]
    9 | #define va_copy(d, s)   __builtin_va_copy(d, s)
      |
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:52: note: this is the location of the previous definition
   52 | #define va_copy(d,s)    __builtin_va_copy(d,s)
      |
In file included from ./include/linux/kernel.h:5,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/luaconf.h:16,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lua.h:15,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lstate.c:13:
./include/linux/stdarg.h:6: error: "va_start" redefined [-Werror]
    6 | #define va_start(v, l)  __builtin_va_start(v, l)
      |
In file included from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/lua.h:12:
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:47: note: this is the location of the previous definition
   47 | #define va_start(v,l)   __builtin_va_start(v,l)
      |
./include/linux/stdarg.h:8: error: "va_arg" redefined [-Werror]
    8 | #define va_arg(v, T)    __builtin_va_arg(v, T)
      |
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:49: note: this is the location of the previous definition
   49 | #define va_arg(v,l)     __builtin_va_arg(v,l)
      |
./include/linux/stdarg.h:9: error: "va_copy" redefined [-Werror]
    9 | #define va_copy(d, s)   __builtin_va_copy(d, s)
      |
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/12.2.0/include/stdarg.h:52: note: this is the location of the previous definition
   52 | #define va_copy(d,s)    __builtin_va_copy(d,s)
      |
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/ldump.c: In function 'DumpString':
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/xtables-addons-3.21/extensions/LUA/lua/ldump.c:63:26: error: the comparison will always evaluate as 'false' for the pointer operand in 's + 24' must not be NULL [-Werror=address]
   63 |  if (s==NULL || getstr(s)==NULL)
      |                          ^~
cc1: all warnings being treated as errors

Fixes: #20993
Fixes: #21006
Co-developed-by: Chen Minqiang <ptpt52@gmail.com>

---

@ptpt52 @pprindeville ok?