### PR TITLE
xtables-addons: bump to 3.24, fix build errors since b2d1eb7

### DIFF
--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -8,7 +8,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=xtables-addons
 PKG_VERSION:=3.21
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_HASH:=2e09ac129a14f5e9c23b115ebcdfff4aa84e2aeba1268dbdf39b2d752bd71e19
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz

--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -7,9 +7,9 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=xtables-addons
-PKG_VERSION:=3.21
-PKG_RELEASE:=2
-PKG_HASH:=2e09ac129a14f5e9c23b115ebcdfff4aa84e2aeba1268dbdf39b2d752bd71e19
+PKG_VERSION:=3.24
+PKG_RELEASE:=1
+PKG_HASH:=3e823f71720519ced31c4c7d2bfaf7120d9c01c59a0843dfcbe93c95c64d81c1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://inai.de/files/xtables-addons/

--- a/net/xtables-addons/patches/001-fix-kernel-version-detection.patch
+++ b/net/xtables-addons/patches/001-fix-kernel-version-detection.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -42,7 +42,7 @@ regular_CFLAGS="-Wall -Waggregate-return
+@@ -41,7 +41,7 @@ regular_CFLAGS="-Wall -Waggregate-return
  
  AS_IF([test -n "$kbuilddir"], [
  	AC_MSG_CHECKING([kernel version that we will build against])

--- a/net/xtables-addons/patches/100-add-rtsp-conntrack.patch
+++ b/net/xtables-addons/patches/100-add-rtsp-conntrack.patch
@@ -1725,7 +1725,7 @@
 +module_exit(fini);
 --- a/extensions/Kbuild
 +++ b/extensions/Kbuild
-@@ -27,6 +27,7 @@ obj-${build_lscan}       += xt_lscan.o
+@@ -28,6 +28,7 @@ obj-${build_lscan}       += xt_lscan.o
  obj-${build_pknock}      += pknock/
  obj-${build_psd}         += xt_psd.o
  obj-${build_quota2}      += xt_quota2.o
@@ -1735,7 +1735,7 @@
  -include ${M}/Kbuild.*
 --- a/mconfig
 +++ b/mconfig
-@@ -23,3 +23,4 @@ build_lscan=m
+@@ -24,3 +24,4 @@ build_lscan=m
  build_pknock=m
  build_psd=m
  build_quota2=m

--- a/net/xtables-addons/patches/200-add-lua-packetscript.patch
+++ b/net/xtables-addons/patches/200-add-lua-packetscript.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ b/extensions/LUA/byte_array.c
-@@ -0,0 +1,145 @@
+@@ -0,0 +1,161 @@
 +/*
 + *	Copyright (C) 2010 University of Basel <http://cn.cs.unibas.ch/>
 + *	by Andre Graf <andre@dergraf.org>
@@ -110,11 +110,25 @@
 +static int32_t byte_array_to_string(lua_State *L)
 +{
 +	lua_packet_segment * array = checkbytearray(L, 1);
-+	uint8_t buf[(array->length * 3) + 255];
 +	uint8_t hexval[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
-+	char res[255 + (array->length * 3)]; /* make sure the buffer is big enough*/
++	uint8_t * buf;
++	char * res;
 +	int32_t i, n;
 +	uint8_t *ptr = array->start + array->offset;
++
++	buf = kcalloc((array->length * 3) + 255, sizeof(*buf), GFP_KERNEL);
++
++	if (!buf) {
++		return luaL_error(L, "byte_array_to_string, failed alloc buf buffer");
++	}
++
++	/* make sure the buffer is big enough*/
++	res = kcalloc((array->length * 3) + 255, sizeof(*res), GFP_KERNEL);
++
++	if (!res) {
++		kfree(buf);
++		return luaL_error(L, "byte_array_to_string, failed alloc res buffer");
++	}
 +
 +	for (i = 0; i < array->length; i++) {
 +		buf[i * 3] = hexval[(ptr[i] >> 4) & 0xF];
@@ -126,6 +140,8 @@
 +	n = sprintf(res, "byte_array: length: %d  value: %s", array->length, buf);
 +
 +	lua_pushlstring(L, res, n);
++	kfree(res);
++	kfree(buf);
 +
 +	return 1;
 +}
@@ -2453,14 +2469,12 @@
 +#endif
 --- /dev/null
 +++ b/extensions/LUA/lua/lauxlib.c
-@@ -0,0 +1,674 @@
+@@ -0,0 +1,672 @@
 +/*
 +** $Id: lauxlib.c,v 1.159.1.3 2008/01/21 13:20:51 roberto Exp $
 +** Auxiliary functions for building Lua libraries
 +** See Copyright Notice in lua.h
 +*/
-+
-+#include <stdarg.h>
 +
 +#if !defined(__KERNEL__)
 +#include <ctype.h>
@@ -4887,7 +4901,7 @@
 +#endif
 --- /dev/null
 +++ b/extensions/LUA/lua/ldebug.c
-@@ -0,0 +1,637 @@
+@@ -0,0 +1,636 @@
 +/*
 +** $Id: ldebug.c,v 2.29.1.6 2008/05/08 16:56:26 roberto Exp $
 +** Debug Interface
@@ -4895,7 +4909,6 @@
 +*/
 +
 +
-+#include <stdarg.h>
 +#include <stddef.h>
 +#include <string.h>
 +
@@ -6204,7 +6217,7 @@
 +
 +static void DumpString(const TString* s, DumpState* D)
 +{
-+ if (s==NULL || getstr(s)==NULL)
++ if (s==NULL)
 + {
 +  size_t size=0;
 +  DumpVar(size,D);
@@ -8165,14 +8178,12 @@
 +
 --- /dev/null
 +++ b/extensions/LUA/lua/lobject.c
-@@ -0,0 +1,215 @@
+@@ -0,0 +1,213 @@
 +/*
 +** $Id: lobject.c,v 2.22.1.1 2007/12/27 13:02:25 roberto Exp $
 +** Some generic functions over Lua objects
 +** See Copyright Notice in lua.h
 +*/
-+
-+#include <stdarg.h>
 +
 +#include <ctype.h>
 +#include <stdio.h>
@@ -13851,7 +13862,7 @@
 +
 --- /dev/null
 +++ b/extensions/LUA/lua/lua.h
-@@ -0,0 +1,387 @@
+@@ -0,0 +1,386 @@
 +/*
 +** $Id: lua.h,v 1.218.1.5 2008/08/06 13:30:12 roberto Exp $
 +** Lua - An Extensible Extension Language
@@ -13863,7 +13874,6 @@
 +#ifndef lua_h
 +#define lua_h
 +
-+#include <stdarg.h>
 +#include <stddef.h>
 +
 +#include "luaconf.h"

--- a/net/xtables-addons/patches/200-add-lua-packetscript.patch
+++ b/net/xtables-addons/patches/200-add-lua-packetscript.patch
@@ -18144,7 +18144,7 @@
 +
 --- a/extensions/Kbuild
 +++ b/extensions/Kbuild
-@@ -28,6 +28,7 @@ obj-${build_pknock}      += pknock/
+@@ -29,6 +29,7 @@ obj-${build_pknock}      += pknock/
  obj-${build_psd}         += xt_psd.o
  obj-${build_quota2}      += xt_quota2.o
  obj-${build_rtsp}        += rtsp/
@@ -18154,14 +18154,14 @@
  -include ${M}/Kbuild.*
 --- a/extensions/Mbuild
 +++ b/extensions/Mbuild
-@@ -23,3 +23,4 @@ obj-${build_pknock}      += pknock/
+@@ -24,3 +24,4 @@ obj-${build_pknock}      += pknock/
  obj-${build_psd}         += libxt_psd.so
  obj-${build_quota2}      += libxt_quota2.so
  obj-${build_gradm}       += libxt_gradm.so
 +obj-${build_LUA}         += LUA/
 --- a/mconfig
 +++ b/mconfig
-@@ -24,3 +24,4 @@ build_pknock=m
+@@ -25,3 +25,4 @@ build_pknock=m
  build_psd=m
  build_quota2=m
  build_rtsp=m


### PR DESCRIPTION
Use `kmalloc` and remove conflicting `#include <stdarg.h>`, to fix the following build warnings treated as errors since https://github.com/openwrt/openwrt/commit/b2d1eb717b6597e0145c98fc5f9f88a7dc219513

```
error: ISO C90 forbids variable length array 'buf' [-Werror=vla]
error: "va_start" redefined [-Werror]
error: "va_arg" redefined [-Werror]
error: "va_copy" redefined [-Werror]
getstr(s)==NULL is always false
```

Maintainer: @jow-
Compile tested: WRT3200ACM

@Ansuel @aparcar @neheb @pprindeville 