### PR TITLE
lighttpd: update to lighttpd 1.4.70 release hash - backport to openwrt 22.03

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
-PKG_VERSION:=1.4.69
-PKG_RELEASE:=2
+PKG_VERSION:=1.4.70
+PKG_RELEASE:=1
 # release candidate ~rcX testing; remove for release
 #PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x
-PKG_HASH:=16ac8db95e719629ba61949b99f8a26feba946a81d185215b28379bb4116b0b4
+PKG_HASH:=921ebe1cf4b6b9897e03779ab7a23a31f4ba40a1abe2067525c33cd3ce61fe85
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.69
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 # release candidate ~rcX testing; remove for release
 #PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
@@ -178,7 +178,7 @@ MESON_ARGS += \
 	-Dwith_zlib=$(if $(CONFIG_PACKAGE_lighttpd-mod-deflate),enabled,disabled) \
 	-Dwith_zstd=disabled
 
-BASE_MODULES:=dirlisting indexfile staticfile
+BASE_MODULES:=dirlisting
 
 define Package/lighttpd/conffiles
 /etc/lighttpd/lighttpd.conf
@@ -275,20 +275,58 @@ $(eval $(call BuildPlugin,webdav_min,WebDAV,,30))
 $(eval $(call BuildPlugin,wolfssl,TLS using wolfssl,@LIGHTTPD_SSL +PACKAGE_lighttpd-mod-wolfssl:libwolfssl,30))
 $(eval $(call BuildPlugin,wstunnel,Websocket tunneling,$(cryptolibdep),30))
 
-# included in BASE_MODULES:=dirlisting indexfile staticfile
+# (similar to BuildPlugin, but without associated .so)
+define BuiltinPlugin
+  define Package/lighttpd-mod-$(1)
+    $(call Package/lighttpd/Default)
+    DEPENDS:=lighttpd
+    ifneq ($(3),)
+      DEPENDS+= $(3)
+    endif
+    TITLE:=$(2) module
+  endef
+
+  define Package/lighttpd-mod-$(1)/conffiles
+/etc/lighttpd/conf.d/$(4)-$(1).conf
+  endef
+
+ ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-$(1)),)
+  define Package/lighttpd-mod-$(1)/install
+	$(INSTALL_DIR) $$(1)/etc/lighttpd/conf.d
+	if [ -f $(PKG_BUILD_DIR)/doc/config/conf.d/$(1).conf ]; then \
+		$(CP) $(PKG_BUILD_DIR)/doc/config/conf.d/$(1).conf $$(1)/etc/lighttpd/conf.d/$(4)-$(1).conf ; \
+		if ! grep -qF 'mod_$(1)' $$(1)/etc/lighttpd/conf.d/$(4)-$(1).conf; then \
+			sed -i "`sed '/^##/ !q' $$(1)/etc/lighttpd/conf.d/$(4)-$(1).conf | wc -l` i\
+server.modules += ( \"mod_$(1)\" )" $$(1)/etc/lighttpd/conf.d/$(4)-$(1).conf ; \
+		fi \
+	else \
+		echo 'server.modules += ( "mod_$(1)" )' > $$(1)/etc/lighttpd/conf.d/$(4)-$(1).conf ; \
+	fi
+  endef
+ endif
+
+  $$(eval $$(call BuildPackage,lighttpd-mod-$(1)))
+endef
+
+# included in BASE_MODULES:=dirlisting
 #$(eval $(call BuildPlugin,dirlisting,dirlisting,,30))
 
 # included in base lighttpd executable;
 # no longer loaded as separate dynamic modules
-#$(eval $(call BuildPlugin,indexfile,indexfile,,30))
-#$(eval $(call BuildPlugin,staticfile,staticfile,,30))
-$(eval $(call BuildPlugin,access,Access restrictions,,30))
-$(eval $(call BuildPlugin,alias,Directory alias,,30))
-$(eval $(call BuildPlugin,evhost,Enhanced Virtual-Hosting,,30))
-$(eval $(call BuildPlugin,expire,Expire,,30))
-$(eval $(call BuildPlugin,fastcgi,FastCGI,,30))
-$(eval $(call BuildPlugin,redirect,URL redirection,+LIGHTTPD_PCRE2:libpcre2,10))
-$(eval $(call BuildPlugin,rewrite,URL rewriting,+LIGHTTPD_PCRE2:libpcre2,30))
-$(eval $(call BuildPlugin,scgi,SCGI,,30))
-$(eval $(call BuildPlugin,setenv,Environment variable setting,,30))
-$(eval $(call BuildPlugin,simple_vhost,Simple virtual hosting,,30))
+# no longer in BASE_MODULES
+#$(eval $(call BuiltinPlugin,indexfile,indexfile,,30))
+#$(eval $(call BuiltinPlugin,staticfile,staticfile,,30))
+
+# included in base lighttpd executable;
+# no longer loaded as separate dynamic modules
+# though still need to be enabled in config
+$(eval $(call BuiltinPlugin,access,Access restrictions,,30))
+$(eval $(call BuiltinPlugin,alias,Directory alias,,30))
+$(eval $(call BuiltinPlugin,evhost,Enhanced Virtual-Hosting,,30))
+$(eval $(call BuiltinPlugin,expire,Expire,,30))
+$(eval $(call BuiltinPlugin,fastcgi,FastCGI,,30))
+$(eval $(call BuiltinPlugin,redirect,URL redirection,+LIGHTTPD_PCRE2:libpcre2,10))
+$(eval $(call BuiltinPlugin,rewrite,URL rewriting,+LIGHTTPD_PCRE2:libpcre2,30))
+$(eval $(call BuiltinPlugin,scgi,SCGI,,30))
+$(eval $(call BuiltinPlugin,setenv,Environment variable setting,,30))
+$(eval $(call BuiltinPlugin,simple_vhost,Simple virtual hosting,,30))

--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -178,7 +178,7 @@ MESON_ARGS += \
 	-Dwith_zlib=$(if $(CONFIG_PACKAGE_lighttpd-mod-deflate),enabled,disabled) \
 	-Dwith_zstd=disabled
 
-BASE_MODULES:=dirlisting
+BASE_MODULES:=dirlisting h2
 
 define Package/lighttpd/conffiles
 /etc/lighttpd/lighttpd.conf
@@ -308,8 +308,9 @@ server.modules += ( \"mod_$(1)\" )" $$(1)/etc/lighttpd/conf.d/$(4)-$(1).conf ; \
   $$(eval $$(call BuildPackage,lighttpd-mod-$(1)))
 endef
 
-# included in BASE_MODULES:=dirlisting
+# included in BASE_MODULES:=dirlisting h2
 #$(eval $(call BuildPlugin,dirlisting,dirlisting,,30))
+#$(eval $(call BuildPlugin,h2,HTTP/2,,30))
 
 # included in base lighttpd executable;
 # no longer loaded as separate dynamic modules

--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -61,17 +61,17 @@ PKG_BUILD_DEPENDS:= \
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/meson.mk
 
-# choose crypto lib for lighttpd to use for crypto algorithms
+# choose crypto lib for lighttpd to use for crypto algorithms (default: nettle)
 # (separate from lighttpd TLS modules, which are each standalone)
-ifdef CONFIG_LIGHTTPD_CRYPTOLIB_NONE)
-  cryptolib=
-else ifdef CONFIG_LIGHTTPD_CRYPTOLIB_NETTLE
-  cryptolib=libnettle
-else ifdef CONFIG_LIGHTTPD_CRYPTOLIB_MBEDTLS
-  cryptolib=libmbedtls
+cryptolibdep= \
+  +LIGHTTPD_CRYPTOLIB_NETTLE:libnettle \
+  +LIGHTTPD_CRYPTOLIB_MBEDTLS:libmbedtls \
+  +LIGHTTPD_CRYPTOLIB_WOLFSSL:libwolfssl
+ifdef CONFIG_LIGHTTPD_CRYPTOLIB_MBEDTLS
   TARGET_CPPFLAGS += -DFORCE_MBEDTLS_CRYPTO
 else ifdef CONFIG_LIGHTTPD_CRYPTOLIB_WOLFSSL
-  cryptolib=libwolfssl
+  # (Note: if CONFIG_LIGHTTPD_CRYPTOLIB_WOLFSSL is set,
+  #  then lighttpd-mod-mbedtls should not be selected to also be built)
   TARGET_CPPFLAGS += -DFORCE_WOLFSSL_CRYPTO
 endif
 
@@ -86,8 +86,8 @@ define Package/lighttpd
   $(call Package/lighttpd/Default)
   MENU:=1
   DEPENDS:=+libpthread +LIGHTTPD_LOGROTATE:logrotate \
-           $(if $(CONFIG_LIGHTTPD_PCRE2),+libpcre2,) \
-           $(if $(cryptolib),+$(cryptolib),)
+           +LIGHTTPD_PCRE2:libpcre2 \
+           $(cryptolibdep)
   TITLE:=A flexible and lightweight web server
 endef
 
@@ -164,7 +164,7 @@ MESON_ARGS += \
 	-Dwith_maxminddb=$(if $(CONFIG_PACKAGE_lighttpd-mod-maxminddb),enabled,disabled) \
 	-Dwith_mbedtls=$(if $(CONFIG_PACKAGE_lighttpd-mod-mbedtls),true,false) \
 	-Dwith_mysql=$(if $(CONFIG_PACKAGE_lighttpd-mod-vhostdb_mysql),enabled,disabled) \
-	-Dwith_nettle=$(if $(filter libnettle,$(cryptolib)),true,false) \
+	-Dwith_nettle=$(if $(CONFIG_LIGHTTPD_CRYPTOLIB_NETTLE),true,false) \
 	-Dwith_nss=$(if $(CONFIG_PACKAGE_lighttpd-mod-nss),true,false) \
 	-Dwith_openssl=$(if $(CONFIG_PACKAGE_lighttpd-mod-openssl),true,false) \
 	-Dwith_pam=$(if $(CONFIG_PACKAGE_lighttpd-mod-authn_pam),enabled,disabled) \
@@ -240,13 +240,13 @@ endef
 
 $(eval $(call BuildPackage,lighttpd))
 
-$(eval $(call BuildPlugin,auth,Authentication,$(if $(cryptolib),+PACKAGE_lighttpd-mod-auth:$(cryptolib),),20))
-$(eval $(call BuildPlugin,authn_dbi,DBI-based authentication,lighttpd-mod-auth $(if $(cryptolib),+PACKAGE_lighttpd-mod-authn_dbi:$(cryptolib),) +PACKAGE_lighttpd-mod-authn_dbi:libdbi,20))
-$(eval $(call BuildPlugin,authn_file,File-based authentication,lighttpd-mod-auth $(if $(cryptolib),+PACKAGE_lighttpd-mod-authn_file:$(cryptolib),),20))
-$(eval $(call BuildPlugin,authn_gssapi,Kerberos-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_gssapi:krb5-libs,20))
-$(eval $(call BuildPlugin,authn_ldap,LDAP-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_ldap:libopenldap,20))
-$(eval $(call BuildPlugin,authn_pam,PAM-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_pam:libpam,20))
-$(eval $(call BuildPlugin,authn_sasl,SASL-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_sasl:libsasl2,20))
+$(eval $(call BuildPlugin,auth,Authentication,$(cryptolibdep),20))
+$(eval $(call BuildPlugin,authn_dbi,DBI-based authentication,lighttpd-mod-auth libdbi $(cryptolibdep),20))
+$(eval $(call BuildPlugin,authn_file,File-based authentication,lighttpd-mod-auth $(cryptolibdep),20))
+$(eval $(call BuildPlugin,authn_gssapi,Kerberos-based authentication,lighttpd-mod-auth krb5-libs $(cryptolibdep),20))
+$(eval $(call BuildPlugin,authn_ldap,LDAP-based authentication,lighttpd-mod-auth libopenldap,20))
+$(eval $(call BuildPlugin,authn_pam,PAM-based authentication,lighttpd-mod-auth libpam,20))
+$(eval $(call BuildPlugin,authn_sasl,SASL-based authentication,lighttpd-mod-auth libsasl2,20))
 
 $(eval $(call BuildPlugin,accesslog,Access logging,,30))
 $(eval $(call BuildPlugin,ajp13,AJP13 Tomcat connector,,30))
@@ -273,7 +273,7 @@ $(eval $(call BuildPlugin,vhostdb_pgsql,Virtual Host Database (PostgreSQL),light
 $(eval $(call BuildPlugin,webdav,WebDAV,+PACKAGE_lighttpd-mod-webdav:libsqlite3 +PACKAGE_lighttpd-mod-webdav:libuuid +PACKAGE_lighttpd-mod-webdav:libxml2,30))
 $(eval $(call BuildPlugin,webdav_min,WebDAV,,30))
 $(eval $(call BuildPlugin,wolfssl,TLS using wolfssl,@LIGHTTPD_SSL +PACKAGE_lighttpd-mod-wolfssl:libwolfssl,30))
-$(eval $(call BuildPlugin,wstunnel,Websocket tunneling,$(if $(cryptolib),+PACKAGE_lighttpd-mod-wstunnel:$(cryptolib),),30))
+$(eval $(call BuildPlugin,wstunnel,Websocket tunneling,$(cryptolibdep),30))
 
 # included in BASE_MODULES:=dirlisting indexfile staticfile
 #$(eval $(call BuildPlugin,dirlisting,dirlisting,,30))
@@ -287,8 +287,8 @@ $(eval $(call BuildPlugin,alias,Directory alias,,30))
 $(eval $(call BuildPlugin,evhost,Enhanced Virtual-Hosting,,30))
 $(eval $(call BuildPlugin,expire,Expire,,30))
 $(eval $(call BuildPlugin,fastcgi,FastCGI,,30))
-$(eval $(call BuildPlugin,redirect,URL redirection,$(if $(CONFIG_LIGHTTPD_PCRE2),+PACKAGE_lighttpd-mod-redirect:libpcre2,),10))
-$(eval $(call BuildPlugin,rewrite,URL rewriting,$(if $(CONFIG_LIGHTTPD_PCRE2),+PACKAGE_lighttpd-mod-rewrite:libpcre2,),30))
+$(eval $(call BuildPlugin,redirect,URL redirection,+LIGHTTPD_PCRE2:libpcre2,10))
+$(eval $(call BuildPlugin,rewrite,URL rewriting,+LIGHTTPD_PCRE2:libpcre2,30))
 $(eval $(call BuildPlugin,scgi,SCGI,,30))
 $(eval $(call BuildPlugin,setenv,Environment variable setting,,30))
 $(eval $(call BuildPlugin,simple_vhost,Simple virtual hosting,,30))

--- a/net/lighttpd/patches/020-meson-mod_webdav_min.patch
+++ b/net/lighttpd/patches/020-meson-mod_webdav_min.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] [meson] mod_webdav_min w/o deps: xml2 sqlite3 uuid
 
 --- a/src/meson.build
 +++ b/src/meson.build
-@@ -865,6 +865,16 @@ if libsasl.found()
+@@ -879,6 +879,16 @@ if libsasl.found()
  	]
  endif
  

--- a/net/lighttpd/patches/030-mod_h2-HTTP-2-separate-mod.patch
+++ b/net/lighttpd/patches/030-mod_h2-HTTP-2-separate-mod.patch
@@ -1,0 +1,87 @@
+From 2892a7bf3f8ce92f41134fab25fbc2057f4a36bf Mon Sep 17 00:00:00 2001
+From: Glenn Strauss <gstrauss@gluelogic.com>
+Date: Wed, 10 May 2023 19:06:42 -0400
+Subject: [PATCH] [mod_h2] HTTP/2 separate module; no longer builtin
+
+---
+ src/CMakeLists.txt | 3 ---
+ src/Makefile.am    | 9 +++------
+ src/SConscript     | 4 +---
+ src/meson.build    | 3 ---
+ 4 files changed, 4 insertions(+), 15 deletions(-)
+
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -922,10 +922,7 @@ set(SERVER_SRC
+ 	response.c
+ 	connections.c
+ 	h1.c
+-	h2.c
+ 	sock_addr_cache.c
+-	ls-hpack/lshpack.c
+-	algo_xxhash.c
+ 	fdevent_impl.c
+ 	http_range.c
+ 	network.c
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -70,12 +70,10 @@ common_src=base64.c buffer.c burl.c log.
+ 
+ common_src += fdevent_win32.c fs_win32.c
+ 
+-src = server.c response.c connections.c h1.c h2.c \
++src = server.c response.c connections.c h1.c \
+ 	sock_addr_cache.c \
+ 	network.c \
+ 	network_write.c \
+-	ls-hpack/lshpack.c \
+-	algo_xxhash.c \
+ 	fdevent_impl.c \
+ 	http_range.c \
+ 	data_config.c \
+@@ -428,6 +426,8 @@ lighttpd_LDADD = \
+   $(FAM_LIBS) $(LIBEV_LIBS) $(LIBUNWIND_LIBS)
+ lighttpd_LDFLAGS = -export-dynamic
+ 
++lighttpd_SOURCES += h2.c ls-hpack/lshpack.c algo_xxhash.c
++lighttpd_LDADD += $(XXHASH_LIBS)
+ if BUILD_WITH_MAXMINDDB
+ lighttpd_SOURCES += mod_maxminddb.c
+ lighttpd_LDADD += $(MAXMINDDB_LIB)
+@@ -489,9 +489,6 @@ lighttpd_SOURCES += mod_wolfssl.c
+ lighttpd_CPPFLAGS += $(WOLFSSL_CFLAGS)
+ lighttpd_LDADD += $(WOLFSSL_LIBS)
+ endif
+-#(until switch to mod_h2)
+-#lighttpd_SOURCES += h2.c ls-hpack/lshpack.c algo_xxhash.c
+-#lighttpd_LDADD += $(XXHASH_LIBS)
+ 
+ else
+ 
+--- a/src/SConscript
++++ b/src/SConscript
+@@ -75,10 +75,8 @@ common_src = Split("base64.c buffer.c bu
+ 	ck.c \
+ ")
+ 
+-src = Split("server.c response.c connections.c h1.c h2.c \
++src = Split("server.c response.c connections.c h1.c \
+ 	sock_addr_cache.c \
+-	ls-hpack/lshpack.c \
+-	algo_xxhash.c \
+ 	fdevent_impl.c \
+ 	http_range.c \
+ 	network.c \
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -560,10 +560,7 @@ main_src = files(
+ 	'connections.c',
+ 	'data_config.c',
+ 	'h1.c',
+-	'h2.c',
+ 	'sock_addr_cache.c',
+-	'ls-hpack/lshpack.c',
+-	'algo_xxhash.c',
+ 	'fdevent_impl.c',
+ 	'http_range.c',
+ 	'network_write.c',


### PR DESCRIPTION
Maintainer: @flyn-org
Compile tested: arm_cortex-a9 OpenWrt master

Description:

backport #20980, but omit commits which change default cryptolib used by lighttpd

* update to lighttpd 1.4.70 release hash
* include mod_h2 in base package