### PR TITLE
nut: Fix permissions of /var/etc/nut

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.8.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.8/

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -135,6 +135,7 @@ build_server_config() {
 
 	if [ -n "$RUNAS" ]; then
 		chown "$RUNAS":"$(id -gn "$RUNAS")" "${STATEPATH}"
+		chgrp "$(id -gn "$RUNAS")" "$(dirname "$UPSD_C")"
 		chgrp "$(id -gn "$RUNAS")" "$USERS_C"
 		chgrp "$(id -gn "$RUNAS")" "$UPSD_C"
 	fi


### PR DESCRIPTION
Previously, upsd bailed out with

  `Can't open /etc/nut/ups.conf: Can't open /etc/nut/ups.conf: Permission denied`

and procd reported a crash loop.

Maintainer: @cyanidium (?)
Compile tested: n/a
Run tested: aarch64_generic, friendlyarm,nanopi-r4s, 22.03.5

Description:
Really just a very simple permission fix