### PR TITLE
luajit2: add new package, OpenResty's mantained branch of luajit

### DIFF
--- a/lang/luajit2/Makefile
+++ b/lang/luajit2/Makefile
@@ -1,0 +1,91 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=luajit2
+PKG_VERSION:=2.1-20230410
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/openresty/luajit2/archive/refs/tags/v$(PKG_VERSION).tar.gz?
+PKG_HASH:=77bbcbb24c3c78f51560017288f3118d995fe71240aa379f5818ff6b166712ff
+
+PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=COPYRIGHT
+
+PKG_BUILD_FLAGS:=no-mips16
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+
+define Package/luajit2
+ SECTION:=lang
+ CATEGORY:=Languages
+ SUBMENU:=Lua
+ TITLE:=LuaJIT from OpenResty
+ URL:=https://www.luajit.org
+ DEPENDS:=@(i386||x86_64||arm||armeb||aarch64||powerpc||mips||mipsel||mips64)
+ PROVIDES:=luajit
+endef
+
+define Package/luajit2/description
+ OpenResty's maintained branch of LuaJIT, a Just-In-Time (JIT) compiler for the Lua programming language
+endef
+
+ifeq ($(HOST_ARCH),$(filter $(HOST_ARCH), x86_64 mips64))
+  ifeq ($(CONFIG_ARCH_64BIT),)
+    HOST_BITS := -m32
+  endif
+endif
+
+define Build/Compile
+	$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+		HOST_CC="$(HOSTCC) $(HOST_CFLAGS) $(HOST_BITS)" \
+		CROSS="$(TARGET_CROSS)" \
+		DPREFIX=$(PKG_INSTALL_DIR)/usr \
+		PREFIX=/usr \
+		TARGET_SYS=Linux \
+		TARGET_CFLAGS="$(TARGET_CFLAGS)" \
+		BUILDMODE=dynamic
+	$(RM) -rf $(PKG_INSTALL_DIR)
+	mkdir -p $(PKG_INSTALL_DIR)
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		DPREFIX=$(PKG_INSTALL_DIR)/usr \
+		PREFIX=/usr \
+		TARGET_SYS=Linux \
+		install
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/luajit-2.1
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/luajit-2.1/*.{h,hpp} $(1)/usr/include/luajit-2.1
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/luajit.pc $(1)/usr/lib/pkgconfig/
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/luajit-* $(1)/usr/bin/$(PKG_NAME)
+endef
+
+define Package/luajit2/install
+	$(INSTALL_DIR) $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/luajit-* $(1)/usr/bin/$(PKG_NAME)
+endef
+
+define Host/Compile
+	$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR) \
+		DPREFIX=$(STAGING_DIR_HOSTPKG) \
+		TARGET_CFLAGS="$(HOST_CFLAGS)" \
+		TARGET_LDFLAGS="$(HOST_LDFLAGS)"
+endef
+
+define Host/Install
+	$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR) \
+		DPREFIX=$(STAGING_DIR_HOSTPKG) \
+		install
+	$(CP) $(STAGING_DIR_HOSTPKG)/bin/luajit-* $(STAGING_DIR_HOSTPKG)/bin/$(PKG_NAME)
+endef
+
+$(eval $(call HostBuild,luajit2))
+$(eval $(call BuildPackage,luajit2))

--- a/lang/luajit2/patches/010-lua-path.patch
+++ b/lang/luajit2/patches/010-lua-path.patch
@@ -1,0 +1,13 @@
+--- a/src/luaconf.h
++++ b/src/luaconf.h
+@@ -35,8 +35,8 @@
+ #ifndef LUA_LMULTILIB
+ #define LUA_LMULTILIB	"lib"
+ #endif
+-#define LUA_LROOT	"/usr/local"
+-#define LUA_LUADIR	"/lua/5.1/"
++#define LUA_LROOT	"/usr"
++#define LUA_LUADIR	"/lua/"
+ #define LUA_LJDIR	"/luajit-2.1.0-beta3/"
+ 
+ #ifdef LUA_ROOT


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de> & Ansuel Smith <ansuelsmth@gmail.com>
Compile tested: master x86-64
Run tested: master x86-64

Description:
This PR switches luajit to [OpenResty's fork](https://github.com/openresty/luajit2), so we get rid of:
```
$ nginx -c /etc/nginx/nginx.conf
2023/05/05 09:45:00 [alert] 12167#0: detected a LuaJIT version which is not OpenResty's; many optimizations will be disabled and performance will be compromised (see https://github.com/openresty/luajit2 for OpenResty's LuaJIT or, even better, consider using the OpenResty releases from https://openresty.org/en/download.html)
```

when using a lua module like [nginx-lua-prometheus](https://github.com/knyar/nginx-lua-prometheus)