### PR TITLE
lighttpd: update to lighttpd 1.4.70 release hash - backport to openwrt 21.02

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.69
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 # release candidate ~rcX testing; remove for release
 #PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
@@ -179,7 +179,7 @@ MESON_ARGS += \
 	-Dwith_zlib=$(if $(CONFIG_PACKAGE_lighttpd-mod-deflate),enabled,disabled) \
 	-Dwith_zstd=disabled
 
-BASE_MODULES:=dirlisting indexfile staticfile
+BASE_MODULES:=dirlisting
 
 define Package/lighttpd/conffiles
 /etc/lighttpd/lighttpd.conf
@@ -280,20 +280,58 @@ $(eval $(call BuildPlugin,webdav_min,WebDAV,,30))
 $(eval $(call BuildPlugin,wolfssl,TLS using wolfssl,@LIGHTTPD_SSL +PACKAGE_lighttpd-mod-wolfssl:libwolfssl,30))
 $(eval $(call BuildPlugin,wstunnel,Websocket tunneling,$(cryptolibdep),30))
 
-# included in BASE_MODULES:=dirlisting indexfile staticfile
+# (similar to BuildPlugin, but without associated .so)
+define BuiltinPlugin
+  define Package/lighttpd-mod-$(1)
+    $(call Package/lighttpd/Default)
+    DEPENDS:=lighttpd
+    ifneq ($(3),)
+      DEPENDS+= $(3)
+    endif
+    TITLE:=$(2) module
+  endef
+
+  define Package/lighttpd-mod-$(1)/conffiles
+/etc/lighttpd/conf.d/$(4)-$(1).conf
+  endef
+
+ ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-$(1)),)
+  define Package/lighttpd-mod-$(1)/install
+	$(INSTALL_DIR) $$(1)/etc/lighttpd/conf.d
+	if [ -f $(PKG_BUILD_DIR)/doc/config/conf.d/$(1).conf ]; then \
+		$(CP) $(PKG_BUILD_DIR)/doc/config/conf.d/$(1).conf $$(1)/etc/lighttpd/conf.d/$(4)-$(1).conf ; \
+		if ! grep -qF 'mod_$(1)' $$(1)/etc/lighttpd/conf.d/$(4)-$(1).conf; then \
+			sed -i "`sed '/^##/ !q' $$(1)/etc/lighttpd/conf.d/$(4)-$(1).conf | wc -l` i\
+server.modules += ( \"mod_$(1)\" )" $$(1)/etc/lighttpd/conf.d/$(4)-$(1).conf ; \
+		fi \
+	else \
+		echo 'server.modules += ( "mod_$(1)" )' > $$(1)/etc/lighttpd/conf.d/$(4)-$(1).conf ; \
+	fi
+  endef
+ endif
+
+  $$(eval $$(call BuildPackage,lighttpd-mod-$(1)))
+endef
+
+# included in BASE_MODULES:=dirlisting
 #$(eval $(call BuildPlugin,dirlisting,dirlisting,,30))
 
 # included in base lighttpd executable;
 # no longer loaded as separate dynamic modules
-#$(eval $(call BuildPlugin,indexfile,indexfile,,30))
-#$(eval $(call BuildPlugin,staticfile,staticfile,,30))
-$(eval $(call BuildPlugin,access,Access restrictions,,30))
-$(eval $(call BuildPlugin,alias,Directory alias,,30))
-$(eval $(call BuildPlugin,evhost,Enhanced Virtual-Hosting,,30))
-$(eval $(call BuildPlugin,expire,Expire,,30))
-$(eval $(call BuildPlugin,fastcgi,FastCGI,,30))
-$(eval $(call BuildPlugin,redirect,URL redirection,+LIGHTTPD_PCRE2:libpcre2,10))
-$(eval $(call BuildPlugin,rewrite,URL rewriting,+LIGHTTPD_PCRE2:libpcre2,30))
-$(eval $(call BuildPlugin,scgi,SCGI,,30))
-$(eval $(call BuildPlugin,setenv,Environment variable setting,,30))
-$(eval $(call BuildPlugin,simple_vhost,Simple virtual hosting,,30))
+# no longer in BASE_MODULES
+#$(eval $(call BuiltinPlugin,indexfile,indexfile,,30))
+#$(eval $(call BuiltinPlugin,staticfile,staticfile,,30))
+
+# included in base lighttpd executable;
+# no longer loaded as separate dynamic modules
+# though still need to be enabled in config
+$(eval $(call BuiltinPlugin,access,Access restrictions,,30))
+$(eval $(call BuiltinPlugin,alias,Directory alias,,30))
+$(eval $(call BuiltinPlugin,evhost,Enhanced Virtual-Hosting,,30))
+$(eval $(call BuiltinPlugin,expire,Expire,,30))
+$(eval $(call BuiltinPlugin,fastcgi,FastCGI,,30))
+$(eval $(call BuiltinPlugin,redirect,URL redirection,+LIGHTTPD_PCRE2:libpcre2,10))
+$(eval $(call BuiltinPlugin,rewrite,URL rewriting,+LIGHTTPD_PCRE2:libpcre2,30))
+$(eval $(call BuiltinPlugin,scgi,SCGI,,30))
+$(eval $(call BuiltinPlugin,setenv,Environment variable setting,,30))
+$(eval $(call BuiltinPlugin,simple_vhost,Simple virtual hosting,,30))

--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
-PKG_VERSION:=1.4.69
-PKG_RELEASE:=2
+PKG_VERSION:=1.4.70
+PKG_RELEASE:=1
 # release candidate ~rcX testing; remove for release
 #PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x
-PKG_HASH:=16ac8db95e719629ba61949b99f8a26feba946a81d185215b28379bb4116b0b4
+PKG_HASH:=921ebe1cf4b6b9897e03779ab7a23a31f4ba40a1abe2067525c33cd3ce61fe85
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -179,7 +179,7 @@ MESON_ARGS += \
 	-Dwith_zlib=$(if $(CONFIG_PACKAGE_lighttpd-mod-deflate),enabled,disabled) \
 	-Dwith_zstd=disabled
 
-BASE_MODULES:=dirlisting
+BASE_MODULES:=dirlisting h2
 
 define Package/lighttpd/conffiles
 /etc/lighttpd/lighttpd.conf
@@ -313,8 +313,9 @@ server.modules += ( \"mod_$(1)\" )" $$(1)/etc/lighttpd/conf.d/$(4)-$(1).conf ; \
   $$(eval $$(call BuildPackage,lighttpd-mod-$(1)))
 endef
 
-# included in BASE_MODULES:=dirlisting
+# included in BASE_MODULES:=dirlisting h2
 #$(eval $(call BuildPlugin,dirlisting,dirlisting,,30))
+#$(eval $(call BuildPlugin,h2,HTTP/2,,30))
 
 # included in base lighttpd executable;
 # no longer loaded as separate dynamic modules

--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -62,17 +62,17 @@ PKG_BUILD_DEPENDS:= \
 include $(INCLUDE_DIR)/package.mk
 include ../../devel/meson/meson.mk
 
-# choose crypto lib for lighttpd to use for crypto algorithms
+# choose crypto lib for lighttpd to use for crypto algorithms (default: nettle)
 # (separate from lighttpd TLS modules, which are each standalone)
-ifdef CONFIG_LIGHTTPD_CRYPTOLIB_NONE)
-  cryptolib=
-else ifdef CONFIG_LIGHTTPD_CRYPTOLIB_NETTLE
-  cryptolib=libnettle
-else ifdef CONFIG_LIGHTTPD_CRYPTOLIB_MBEDTLS
-  cryptolib=libmbedtls
+cryptolibdep= \
+  +LIGHTTPD_CRYPTOLIB_NETTLE:libnettle \
+  +LIGHTTPD_CRYPTOLIB_MBEDTLS:libmbedtls \
+  +LIGHTTPD_CRYPTOLIB_WOLFSSL:libwolfssl
+ifdef CONFIG_LIGHTTPD_CRYPTOLIB_MBEDTLS
   TARGET_CPPFLAGS += -DFORCE_MBEDTLS_CRYPTO
 else ifdef CONFIG_LIGHTTPD_CRYPTOLIB_WOLFSSL
-  cryptolib=libwolfssl
+  # (Note: if CONFIG_LIGHTTPD_CRYPTOLIB_WOLFSSL is set,
+  #  then lighttpd-mod-mbedtls should not be selected to also be built)
   TARGET_CPPFLAGS += -DFORCE_WOLFSSL_CRYPTO
 endif
 
@@ -88,9 +88,7 @@ define Package/lighttpd
   MENU:=1
   DEPENDS:=+libpthread +LIGHTTPD_LOGROTATE:logrotate \
            +LIGHTTPD_PCRE2:libpcre2 \
-           +LIGHTTPD_CRYPTOLIB_NETTLE:libnettle \
-           +LIGHTTPD_CRYPTOLIB_MBEDTLS:libmbedtls \
-           +LIGHTTPD_CRYPTOLIB_WOLFSSL:libwolfssl
+           $(cryptolibdep)
   TITLE:=A flexible and lightweight web server
 endef
 
@@ -167,7 +165,7 @@ MESON_ARGS += \
 	-Dwith_maxminddb=$(if $(CONFIG_PACKAGE_lighttpd-mod-maxminddb),enabled,disabled) \
 	-Dwith_mbedtls=$(if $(CONFIG_PACKAGE_lighttpd-mod-mbedtls),true,false) \
 	-Dwith_mysql=$(if $(CONFIG_PACKAGE_lighttpd-mod-vhostdb_mysql),enabled,disabled) \
-	-Dwith_nettle=$(if $(filter libnettle,$(cryptolib)),true,false) \
+	-Dwith_nettle=$(if $(CONFIG_LIGHTTPD_CRYPTOLIB_NETTLE),true,false) \
 	-Dwith_nss=$(if $(CONFIG_PACKAGE_lighttpd-mod-nss),true,false) \
 	-Dwith_openssl=$(if $(CONFIG_PACKAGE_lighttpd-mod-openssl),true,false) \
 	-Dwith_pam=$(if $(CONFIG_PACKAGE_lighttpd-mod-authn_pam),enabled,disabled) \
@@ -243,13 +241,13 @@ endef
 
 $(eval $(call BuildPackage,lighttpd))
 
-$(eval $(call BuildPlugin,auth,Authentication,$(if $(cryptolib),+PACKAGE_lighttpd-mod-auth:$(cryptolib),),20))
-$(eval $(call BuildPlugin,authn_dbi,DBI-based authentication,lighttpd-mod-auth $(if $(cryptolib),+PACKAGE_lighttpd-mod-authn_dbi:$(cryptolib),) +PACKAGE_lighttpd-mod-authn_dbi:libdbi,20))
-$(eval $(call BuildPlugin,authn_file,File-based authentication,lighttpd-mod-auth $(if $(cryptolib),+PACKAGE_lighttpd-mod-authn_file:$(cryptolib),),20))
-$(eval $(call BuildPlugin,authn_gssapi,Kerberos-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_gssapi:krb5-libs,20))
-$(eval $(call BuildPlugin,authn_ldap,LDAP-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_ldap:libopenldap,20))
-$(eval $(call BuildPlugin,authn_pam,PAM-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_pam:libpam,20))
-$(eval $(call BuildPlugin,authn_sasl,SASL-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_sasl:libsasl2,20))
+$(eval $(call BuildPlugin,auth,Authentication,$(cryptolibdep),20))
+$(eval $(call BuildPlugin,authn_dbi,DBI-based authentication,lighttpd-mod-auth libdbi $(cryptolibdep),20))
+$(eval $(call BuildPlugin,authn_file,File-based authentication,lighttpd-mod-auth $(cryptolibdep),20))
+$(eval $(call BuildPlugin,authn_gssapi,Kerberos-based authentication,lighttpd-mod-auth krb5-libs $(cryptolibdep),20))
+$(eval $(call BuildPlugin,authn_ldap,LDAP-based authentication,lighttpd-mod-auth libopenldap,20))
+$(eval $(call BuildPlugin,authn_pam,PAM-based authentication,lighttpd-mod-auth libpam,20))
+$(eval $(call BuildPlugin,authn_sasl,SASL-based authentication,lighttpd-mod-auth libsasl2,20))
 
 $(eval $(call BuildPlugin,accesslog,Access logging,,30))
 $(eval $(call BuildPlugin,ajp13,AJP13 Tomcat connector,,30))
@@ -280,7 +278,7 @@ $(eval $(call BuildPlugin,vhostdb_pgsql,Virtual Host Database (PostgreSQL),light
 $(eval $(call BuildPlugin,webdav,WebDAV,+PACKAGE_lighttpd-mod-webdav:libsqlite3 +PACKAGE_lighttpd-mod-webdav:libuuid +PACKAGE_lighttpd-mod-webdav:libxml2,30))
 $(eval $(call BuildPlugin,webdav_min,WebDAV,,30))
 $(eval $(call BuildPlugin,wolfssl,TLS using wolfssl,@LIGHTTPD_SSL +PACKAGE_lighttpd-mod-wolfssl:libwolfssl,30))
-$(eval $(call BuildPlugin,wstunnel,Websocket tunneling,$(if $(cryptolib),+PACKAGE_lighttpd-mod-wstunnel:$(cryptolib),),30))
+$(eval $(call BuildPlugin,wstunnel,Websocket tunneling,$(cryptolibdep),30))
 
 # included in BASE_MODULES:=dirlisting indexfile staticfile
 #$(eval $(call BuildPlugin,dirlisting,dirlisting,,30))
@@ -294,8 +292,8 @@ $(eval $(call BuildPlugin,alias,Directory alias,,30))
 $(eval $(call BuildPlugin,evhost,Enhanced Virtual-Hosting,,30))
 $(eval $(call BuildPlugin,expire,Expire,,30))
 $(eval $(call BuildPlugin,fastcgi,FastCGI,,30))
-$(eval $(call BuildPlugin,redirect,URL redirection,$(if $(CONFIG_LIGHTTPD_PCRE2),+PACKAGE_lighttpd-mod-redirect:libpcre2,),10))
-$(eval $(call BuildPlugin,rewrite,URL rewriting,$(if $(CONFIG_LIGHTTPD_PCRE2),+PACKAGE_lighttpd-mod-rewrite:libpcre2,),30))
+$(eval $(call BuildPlugin,redirect,URL redirection,+LIGHTTPD_PCRE2:libpcre2,10))
+$(eval $(call BuildPlugin,rewrite,URL rewriting,+LIGHTTPD_PCRE2:libpcre2,30))
 $(eval $(call BuildPlugin,scgi,SCGI,,30))
 $(eval $(call BuildPlugin,setenv,Environment variable setting,,30))
 $(eval $(call BuildPlugin,simple_vhost,Simple virtual hosting,,30))

--- a/net/lighttpd/patches/020-meson-mod_webdav_min.patch
+++ b/net/lighttpd/patches/020-meson-mod_webdav_min.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] [meson] mod_webdav_min w/o deps: xml2 sqlite3 uuid
 
 --- a/src/meson.build
 +++ b/src/meson.build
-@@ -865,6 +865,16 @@ if libsasl.found()
+@@ -879,6 +879,16 @@ if libsasl.found()
  	]
  endif
  

--- a/net/lighttpd/patches/030-mod_h2-HTTP-2-separate-mod.patch
+++ b/net/lighttpd/patches/030-mod_h2-HTTP-2-separate-mod.patch
@@ -1,0 +1,87 @@
+From 2892a7bf3f8ce92f41134fab25fbc2057f4a36bf Mon Sep 17 00:00:00 2001
+From: Glenn Strauss <gstrauss@gluelogic.com>
+Date: Wed, 10 May 2023 19:06:42 -0400
+Subject: [PATCH] [mod_h2] HTTP/2 separate module; no longer builtin
+
+---
+ src/CMakeLists.txt | 3 ---
+ src/Makefile.am    | 9 +++------
+ src/SConscript     | 4 +---
+ src/meson.build    | 3 ---
+ 4 files changed, 4 insertions(+), 15 deletions(-)
+
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -922,10 +922,7 @@ set(SERVER_SRC
+ 	response.c
+ 	connections.c
+ 	h1.c
+-	h2.c
+ 	sock_addr_cache.c
+-	ls-hpack/lshpack.c
+-	algo_xxhash.c
+ 	fdevent_impl.c
+ 	http_range.c
+ 	network.c
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -70,12 +70,10 @@ common_src=base64.c buffer.c burl.c log.
+ 
+ common_src += fdevent_win32.c fs_win32.c
+ 
+-src = server.c response.c connections.c h1.c h2.c \
++src = server.c response.c connections.c h1.c \
+ 	sock_addr_cache.c \
+ 	network.c \
+ 	network_write.c \
+-	ls-hpack/lshpack.c \
+-	algo_xxhash.c \
+ 	fdevent_impl.c \
+ 	http_range.c \
+ 	data_config.c \
+@@ -428,6 +426,8 @@ lighttpd_LDADD = \
+   $(FAM_LIBS) $(LIBEV_LIBS) $(LIBUNWIND_LIBS)
+ lighttpd_LDFLAGS = -export-dynamic
+ 
++lighttpd_SOURCES += h2.c ls-hpack/lshpack.c algo_xxhash.c
++lighttpd_LDADD += $(XXHASH_LIBS)
+ if BUILD_WITH_MAXMINDDB
+ lighttpd_SOURCES += mod_maxminddb.c
+ lighttpd_LDADD += $(MAXMINDDB_LIB)
+@@ -489,9 +489,6 @@ lighttpd_SOURCES += mod_wolfssl.c
+ lighttpd_CPPFLAGS += $(WOLFSSL_CFLAGS)
+ lighttpd_LDADD += $(WOLFSSL_LIBS)
+ endif
+-#(until switch to mod_h2)
+-#lighttpd_SOURCES += h2.c ls-hpack/lshpack.c algo_xxhash.c
+-#lighttpd_LDADD += $(XXHASH_LIBS)
+ 
+ else
+ 
+--- a/src/SConscript
++++ b/src/SConscript
+@@ -75,10 +75,8 @@ common_src = Split("base64.c buffer.c bu
+ 	ck.c \
+ ")
+ 
+-src = Split("server.c response.c connections.c h1.c h2.c \
++src = Split("server.c response.c connections.c h1.c \
+ 	sock_addr_cache.c \
+-	ls-hpack/lshpack.c \
+-	algo_xxhash.c \
+ 	fdevent_impl.c \
+ 	http_range.c \
+ 	network.c \
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -560,10 +560,7 @@ main_src = files(
+ 	'connections.c',
+ 	'data_config.c',
+ 	'h1.c',
+-	'h2.c',
+ 	'sock_addr_cache.c',
+-	'ls-hpack/lshpack.c',
+-	'algo_xxhash.c',
+ 	'fdevent_impl.c',
+ 	'http_range.c',
+ 	'network_write.c',

--- a/net/lighttpd/patches/030-restore-removed-modules.patch
+++ b/net/lighttpd/patches/030-restore-removed-modules.patch
@@ -1,4 +1,4 @@
-From 2bd3c1fe962812b4965bf64e9e1529541f9e96ff Mon Sep 17 00:00:00 2001
+From d3e4e8ad1493679392966f3adbbf7f7c7054cd0a Mon Sep 17 00:00:00 2001
 From: Glenn Strauss <gstrauss@gluelogic.com>
 Date: Thu, 13 Apr 2023 16:14:48 -0400
 Subject: [PATCH] Revert "[multiple] remove deprecated modules"
@@ -6,7 +6,7 @@ Subject: [PATCH] Revert "[multiple] remove deprecated modules"
 This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
 ---
  src/CMakeLists.txt       |   8 +
- src/Makefile.am          |  30 +++
+ src/Makefile.am          |  25 ++
  src/SConscript           |   4 +
  src/meson.build          |   4 +
  src/mod_evasive.c        | 194 +++++++++++++++
@@ -17,7 +17,7 @@ This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
  src/t/test_mod_evasive.c |  72 ++++++
  tests/lighttpd.conf      |  27 +++
  tests/request.t          | 192 ++++++++++++++-
- 12 files changed, 1610 insertions(+), 1 deletion(-)
+ 12 files changed, 1605 insertions(+), 1 deletion(-)
  create mode 100644 src/mod_evasive.c
  create mode 100644 src/mod_secdownload.c
  create mode 100644 src/mod_uploadprogress.c
@@ -26,32 +26,26 @@ This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
 
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -914,6 +914,7 @@ if(NOT WIN32)
- endif()
+@@ -953,14 +953,18 @@ add_and_install_library(mod_authn_file "
+ add_and_install_library(mod_cgi mod_cgi.c)
  add_and_install_library(mod_deflate mod_deflate.c)
  add_and_install_library(mod_dirlisting mod_dirlisting.c)
 +add_and_install_library(mod_evasive mod_evasive.c)
- add_and_install_library(mod_evhost mod_evhost.c)
- add_and_install_library(mod_expire mod_expire.c)
  add_and_install_library(mod_extforward mod_extforward.c)
-@@ -924,13 +925,16 @@ add_and_install_library(mod_redirect mod
- add_and_install_library(mod_rewrite mod_rewrite.c)
+ add_and_install_library(mod_h2 "h2.c;ls-hpack/lshpack.c;algo_xxhash.c")
+ add_and_install_library(mod_proxy mod_proxy.c)
  add_and_install_library(mod_rrdtool mod_rrdtool.c)
- add_and_install_library(mod_scgi mod_scgi.c)
 +add_and_install_library(mod_secdownload "mod_secdownload.c;algo_hmac.c")
- add_and_install_library(mod_setenv mod_setenv.c)
- add_and_install_library(mod_simple_vhost mod_simple_vhost.c)
  add_and_install_library(mod_sockproxy mod_sockproxy.c)
  add_and_install_library(mod_ssi mod_ssi.c)
- add_and_install_library(mod_staticfile mod_staticfile.c)
  add_and_install_library(mod_status mod_status.c)
 +add_and_install_library(mod_uploadprogress mod_uploadprogress.c)
  add_and_install_library(mod_userdir mod_userdir.c)
 +add_and_install_library(mod_usertrack mod_usertrack.c)
- add_and_install_library(mod_vhostdb "mod_vhostdb.c;mod_vhostdb_api.c")
- add_and_install_library(mod_webdav mod_webdav.c)
- add_and_install_library(mod_wstunnel mod_wstunnel.c)
-@@ -954,6 +958,7 @@ add_executable(test_mod
+ if(WIN32 AND NOT BUILD_STATIC)
+ add_and_install_library(mod_vhostdb "mod_vhostdb.c")
+ else()
+@@ -988,6 +992,7 @@ add_executable(test_mod
  	t/test_mod.c
  	t/test_mod_access.c
  	t/test_mod_alias.c
@@ -59,7 +53,7 @@ This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
  	t/test_mod_evhost.c
  	t/test_mod_indexfile.c
  	t/test_mod_simple_vhost.c
-@@ -1155,6 +1160,8 @@ if(NOT ${CRYPTO_LIBRARY} EQUAL "")
+@@ -1188,6 +1193,8 @@ if(NOT ${CRYPTO_LIBRARY} EQUAL "")
  	target_link_libraries(mod_auth ${CRYPTO_LIBRARY})
  	set(L_MOD_AUTHN_FILE ${L_MOD_AUTHN_FILE} ${CRYPTO_LIBRARY})
  	target_link_libraries(mod_authn_file ${L_MOD_AUTHN_FILE})
@@ -68,7 +62,7 @@ This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
  	target_link_libraries(mod_wstunnel ${CRYPTO_LIBRARY})
  	target_link_libraries(test_mod ${CRYPTO_LIBRARY})
  endif()
-@@ -1179,6 +1186,7 @@ if(HAVE_LIBMBEDTLS AND HAVE_LIBMEDCRYPTO
+@@ -1212,6 +1219,7 @@ if(HAVE_LIBMBEDTLS AND HAVE_LIBMEDCRYPTO
  	add_and_install_library(mod_mbedtls "mod_mbedtls.c")
  	set(L_MOD_MBEDTLS ${L_MOD_MBEDTLS} mbedtls mbedcrypto mbedx509)
  	target_link_libraries(mod_mbedtls ${L_MOD_MBEDTLS})
@@ -78,7 +72,7 @@ This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
  if(HAVE_LIBSSL3 AND HAVE_LIBSMIME3 AND HAVE_LIBNSS3 AND HAVE_LIBNSSUTIL3)
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
-@@ -128,6 +128,11 @@ mod_maxminddb_la_LDFLAGS = $(common_modu
+@@ -134,6 +134,11 @@ mod_maxminddb_la_LDFLAGS = $(common_modu
  mod_maxminddb_la_LIBADD = $(common_libadd) $(MAXMINDDB_LIB)
  endif
  
@@ -90,7 +84,7 @@ This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
  lib_LTLIBRARIES += mod_webdav.la
  mod_webdav_la_SOURCES = mod_webdav.c
  mod_webdav_la_CFLAGS = $(AM_CFLAGS) $(XML_CFLAGS) $(SQLITE_CFLAGS) 
-@@ -226,6 +231,11 @@ mod_rrdtool_la_SOURCES = mod_rrdtool.c
+@@ -207,6 +212,11 @@ mod_rrdtool_la_SOURCES = mod_rrdtool.c
  mod_rrdtool_la_LDFLAGS = $(common_module_ldflags)
  mod_rrdtool_la_LIBADD = $(common_libadd)
  
@@ -102,7 +96,7 @@ This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
  lib_LTLIBRARIES += mod_proxy.la
  mod_proxy_la_SOURCES = mod_proxy.c
  mod_proxy_la_LDFLAGS = $(common_module_ldflags)
-@@ -241,6 +251,16 @@ mod_ssi_la_SOURCES = mod_ssi.c
+@@ -222,6 +232,11 @@ mod_ssi_la_SOURCES = mod_ssi.c
  mod_ssi_la_LDFLAGS = $(common_module_ldflags)
  mod_ssi_la_LIBADD = $(common_libadd)
  
@@ -111,15 +105,10 @@ This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
 +mod_secdownload_la_LDFLAGS = $(common_module_ldflags)
 +mod_secdownload_la_LIBADD = $(common_libadd) $(CRYPTO_LIB)
 +
-+#lib_LTLIBRARIES += mod_httptls.la
-+#mod_httptls_la_SOURCES = mod_httptls.c
-+#mod_httptls_la_LDFLAGS = $(common_module_ldflags)
-+#mod_httptls_la_LIBADD = $(common_libadd)
-+
- lib_LTLIBRARIES += mod_expire.la
- mod_expire_la_SOURCES = mod_expire.c
- mod_expire_la_LDFLAGS = $(common_module_ldflags)
-@@ -391,6 +411,11 @@ mod_accesslog_la_SOURCES = mod_accesslog
+ lib_LTLIBRARIES += mod_ajp13.la
+ mod_ajp13_la_SOURCES = mod_ajp13.c
+ mod_ajp13_la_LDFLAGS = $(common_module_ldflags)
+@@ -336,6 +351,11 @@ mod_accesslog_la_SOURCES = mod_accesslog
  mod_accesslog_la_LDFLAGS = $(common_module_ldflags)
  mod_accesslog_la_LIBADD = $(common_libadd)
  
@@ -131,7 +120,7 @@ This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
  lib_LTLIBRARIES += mod_wstunnel.la
  mod_wstunnel_la_SOURCES = mod_wstunnel.c
  mod_wstunnel_la_LDFLAGS = $(common_module_ldflags)
-@@ -448,6 +473,7 @@ lighttpd_SOURCES = \
+@@ -394,6 +414,7 @@ lighttpd_SOURCES = \
    mod_deflate.c \
    mod_dirlisting.c \
    mod_evhost.c \
@@ -139,7 +128,7 @@ This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
    mod_expire.c \
    mod_extforward.c \
    mod_fastcgi.c \
-@@ -457,13 +483,16 @@ lighttpd_SOURCES = \
+@@ -403,13 +424,16 @@ lighttpd_SOURCES = \
    mod_rewrite.c \
    mod_rrdtool.c \
    mod_scgi.c \
@@ -156,7 +145,7 @@ This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
    mod_vhostdb.c \
    mod_vhostdb_api.c \
    mod_webdav.c
-@@ -573,6 +602,7 @@ t_test_configfile_LDADD = $(PCRE_LIB) $(
+@@ -521,6 +545,7 @@ t_test_configfile_LDADD = $(PCRE_LIB) $(
  t_test_mod_SOURCES = $(common_src) t/test_mod.c \
                       t/test_mod_access.c \
                       t/test_mod_alias.c \
@@ -166,24 +155,18 @@ This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
                       t/test_mod_simple_vhost.c \
 --- a/src/SConscript
 +++ b/src/SConscript
-@@ -119,6 +119,7 @@ modules = {
+@@ -116,14 +116,18 @@ modules = {
  	'mod_cgi' : { 'src' : [ 'mod_cgi.c' ] },
  	'mod_deflate' : { 'src' : [ 'mod_deflate.c' ], 'lib' : [ env['LIBZ'], env['LIBZSTD'], env['LIBBZ2'], env['LIBBROTLI'], env['LIBDEFLATE'], 'm' ] },
  	'mod_dirlisting' : { 'src' : [ 'mod_dirlisting.c' ] },
 +	'mod_evasive' : { 'src' : [ 'mod_evasive.c' ] },
- 	'mod_evhost' : { 'src' : [ 'mod_evhost.c' ] },
- 	'mod_expire' : { 'src' : [ 'mod_expire.c' ] },
  	'mod_extforward' : { 'src' : [ 'mod_extforward.c' ] },
-@@ -129,13 +130,16 @@ modules = {
- 	'mod_rewrite' : { 'src' : [ 'mod_rewrite.c' ] },
+ 	'mod_h2' : { 'src' : [ 'h2.c', 'ls-hpack/lshpack.c', 'algo_xxhash.c' ], 'lib' : [ env['LIBXXHASH'] ] },
+ 	'mod_proxy' : { 'src' : [ 'mod_proxy.c' ] },
  	'mod_rrdtool' : { 'src' : [ 'mod_rrdtool.c' ] },
- 	'mod_scgi' : { 'src' : [ 'mod_scgi.c' ] },
 +	'mod_secdownload' : { 'src' : [ 'mod_secdownload.c', 'algo_hmac.c' ], 'lib' : [ env['LIBCRYPTO'] ] },
- 	'mod_setenv' : { 'src' : [ 'mod_setenv.c' ] },
- 	'mod_simple_vhost' : { 'src' : [ 'mod_simple_vhost.c' ] },
  	'mod_sockproxy' : { 'src' : [ 'mod_sockproxy.c' ] },
  	'mod_ssi' : { 'src' : [ 'mod_ssi.c' ] },
- 	'mod_staticfile' : { 'src' : [ 'mod_staticfile.c' ] },
  	'mod_status' : { 'src' : [ 'mod_status.c' ] },
 +	'mod_uploadprogress' : { 'src' : [ 'mod_uploadprogress.c' ] },
  	'mod_userdir' : { 'src' : [ 'mod_userdir.c' ] },
@@ -193,24 +176,18 @@ This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
  	'mod_wstunnel' : { 'src' : [ 'mod_wstunnel.c' ], 'lib' : [ env['LIBCRYPTO'] ] },
 --- a/src/meson.build
 +++ b/src/meson.build
-@@ -751,6 +751,7 @@ modules = [
- 	[ 'mod_authn_file', [ 'mod_authn_file.c' ], [ libcrypt, libcrypto ] ],
+@@ -776,14 +776,18 @@ modules = [
+ 	[ 'mod_cgi', [ 'mod_cgi.c' ] ],
  	[ 'mod_deflate', [ 'mod_deflate.c' ], [ libbz2, libz, libzstd, libbrotli, libdeflate ] ],
  	[ 'mod_dirlisting', [ 'mod_dirlisting.c' ] ],
 +	[ 'mod_evasive', [ 'mod_evasive.c' ] ],
- 	[ 'mod_evhost', [ 'mod_evhost.c' ] ],
- 	[ 'mod_expire', [ 'mod_expire.c' ] ],
  	[ 'mod_extforward', [ 'mod_extforward.c' ] ],
-@@ -761,13 +762,16 @@ modules = [
- 	[ 'mod_rewrite', [ 'mod_rewrite.c' ] ],
+ 	[ 'mod_h2', [ 'h2.c', 'ls-hpack/lshpack.c', 'algo_xxhash.c' ], [ libxxhash ] ],
+ 	[ 'mod_proxy', [ 'mod_proxy.c' ], socket_libs ],
  	[ 'mod_rrdtool', [ 'mod_rrdtool.c' ] ],
- 	[ 'mod_scgi', [ 'mod_scgi.c' ], socket_libs ],
 +	[ 'mod_secdownload', [ 'mod_secdownload.c', 'algo_hmac.c' ], libcrypto ],
- 	[ 'mod_setenv', [ 'mod_setenv.c' ] ],
- 	[ 'mod_simple_vhost', [ 'mod_simple_vhost.c' ] ],
  	[ 'mod_sockproxy', [ 'mod_sockproxy.c' ] ],
  	[ 'mod_ssi', [ 'mod_ssi.c' ], socket_libs ],
- 	[ 'mod_staticfile', [ 'mod_staticfile.c' ] ],
  	[ 'mod_status', [ 'mod_status.c' ] ],
 +	[ 'mod_uploadprogress', [ 'mod_uploadprogress.c' ] ],
  	[ 'mod_userdir', [ 'mod_userdir.c' ] ],
@@ -1597,7 +1574,7 @@ This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
 +}
 --- a/tests/lighttpd.conf
 +++ b/tests/lighttpd.conf
-@@ -30,6 +30,7 @@ server.modules = (
+@@ -30,6 +30,7 @@ server.modules += (
  	"mod_simple_vhost",
  	"mod_cgi",
  	"mod_status",
@@ -1646,7 +1623,7 @@ This reverts commit fcf0dc3e336a5d62c58036cdb8fc9f4c099b178e.
  use LightyTest;
  
  my $tf = LightyTest->new();
-@@ -1592,6 +1592,196 @@ ok($tf_proxy->stop_proc == 0, "Stopping
+@@ -1593,6 +1593,196 @@ ok($tf_proxy->stop_proc == 0, "Stopping
  } while (0);
  
  

--- a/net/lighttpd/patches/040-revert-test_mod_evasive.patch
+++ b/net/lighttpd/patches/040-revert-test_mod_evasive.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] revert [meson] remove t/test_mod_evasive.c
 
 --- a/src/meson.build
 +++ b/src/meson.build
-@@ -721,6 +721,7 @@ test('test_mod', executable('test_mod',
+@@ -744,6 +744,7 @@ test('test_mod', executable('test_mod',
  		't/test_mod.c',
  		't/test_mod_access.c',
  		't/test_mod_alias.c',


### PR DESCRIPTION
Maintainer: @flyn-org
Compile tested: arm_cortex-a9 OpenWrt master

Description:

backport #20980, but omit commits which change default cryptolib used by lighttpd
This PR follows #21012: backport to 22.03.
Thie PR preserves lighttpd modules deprecated and removed in openwrt 22.03, same as in previous lighttpd 1.4.69 backport to openwrt 21.02

* update to lighttpd 1.4.70 release hash
* include mod_h2 in base package