### PR TITLE
openvpn: Add more hotplug events

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.5.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/openvpn.init
+++ b/net/openvpn/files/openvpn.init
@@ -153,6 +153,9 @@ openvpn_add_instance() {
 		--config "$conf" \
 		--up "/usr/libexec/openvpn-hotplug up $name" \
 		--down "/usr/libexec/openvpn-hotplug down $name" \
+		--route-up "/usr/libexec/openvpn-hotplug route-up $name" \
+		--route-pre-down "/usr/libexec/openvpn-hotplug route-pre-down $name" \
+		--ipchange "/usr/libexec/openvpn-hotplug ipchange $name" \
 		${up:+--setenv user_up "$up"} \
 		${down:+--setenv user_down "$down"} \
 		--script-security "${security:-2}" \


### PR DESCRIPTION
Maintainer: @mkrkn 
Compile tested: mvebu, Turris Omnia, TOS 7.0 ~ OpenWrt 22.03
Run tested: mvebu, Turris Omnia, TOS 7.0 ~ OpenWrt 22.03, custom scripts reacting to those events work

Description:

OpenVPN supports more hooks than just 'up' and 'down'. Especially reacting to 'route-up' and 'route-pre-down' events could be important. When routing table changes, it can make sense to adapt firewall, run some tests or change even more routes. This change passes those events to hotplug, so it is easy to react to them without changing configuration files provided by VPN provider.
