### PR TITLE
acl: fix compilation with musl 1.2.4

### DIFF
--- a/utils/acl/Makefile
+++ b/utils/acl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acl
 PKG_VERSION:=2.3.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.savannah.nongnu.org/cgit/acl.git/snapshot

--- a/utils/acl/patches/103-chacl-Use-portable-version-of-dirent-and-readdir.patch
+++ b/utils/acl/patches/103-chacl-Use-portable-version-of-dirent-and-readdir.patch
@@ -1,0 +1,33 @@
+From 2b42f64737adf6a2ddd491213580d6e9cdd2f5af Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 10 Nov 2022 18:04:15 -0800
+Subject: [PATCH] chacl: Use portable version of dirent and readdir
+
+Using 64bit versions on 32bit architectures should be enabled with
+--enable-largefile, this makes it portable across musl and glibc
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ tools/chacl.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/tools/chacl.c
++++ b/tools/chacl.c
+@@ -320,7 +320,7 @@ walk_dir(acl_t acl, acl_t dacl, const ch
+ {
+ 	int failed = 0;
+ 	DIR *dir;
+-	struct dirent64 *d;
++	struct dirent *d;
+ 	char *name;
+ 
+ 	if ((dir = opendir(fname)) == NULL) {
+@@ -332,7 +332,7 @@ walk_dir(acl_t acl, acl_t dacl, const ch
+ 		return(0);	/* got a file, not an error */
+ 	}
+ 
+-	while ((d = readdir64(dir)) != NULL) {
++	while ((d = readdir(dir)) != NULL) {
+ 		/* skip "." and ".." entries */
+ 		if (strcmp(d->d_name, ".") == 0 || strcmp(d->d_name, "..") == 0)
+ 			continue;


### PR DESCRIPTION
Maintainer: @mstorchak
Compile tested: rockchip/armv8
Run tested: n/a

Description:
musl 1.2.4 deprecated legacy "LFS64" ("large file support") interfaces so just having _GNU_SOURCE defined is not enough anymore.

Backport an upstream fix to replace these old functions.

Fixes: #21051