### PR TITLE
alsa: update to 1.2.9

### DIFF
--- a/libs/alsa-lib/Makefile
+++ b/libs/alsa-lib/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alsa-lib
-PKG_VERSION:=1.2.6.1
-PKG_RELEASE:=3
+PKG_VERSION:=1.2.9
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=ftp://ftp.alsa-project.org/pub/lib/ \
-		http://distfiles.gentoo.org/distfiles/
-PKG_HASH:=ad582993d52cdb5fb159a0beab60a6ac57eab0cc1bdf85dc4db6d6197f02333f
+PKG_SOURCE_URL:=https://www.alsa-project.org/files/pub/lib/ \
+		https://distfiles.gentoo.org/distfiles/
+PKG_HASH:=dc9c643fdc4ccfd0572cc685858dd41e08afb583f30460b317e4188275f615b2
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Peter Wagner <tripolar@gmx.at>

--- a/libs/alsa-lib/patches/200-usleep.patch
+++ b/libs/alsa-lib/patches/200-usleep.patch
@@ -17,9 +17,9 @@
  const char *_snd_module_pcm_shm = "";
 --- a/src/ucm/ucm_local.h
 +++ b/src/ucm/ucm_local.h
-@@ -58,6 +58,14 @@
- #define SEQUENCE_ELEMENT_TYPE_SYSSET		11
- #define SEQUENCE_ELEMENT_TYPE_CFGSAVE		12
+@@ -61,6 +61,14 @@
+ #define SEQUENCE_ELEMENT_TYPE_DEV_DISABLE_SEQ	14
+ #define SEQUENCE_ELEMENT_TYPE_DEV_DISABLE_ALL	15
  
 +#if _POSIX_C_SOURCE >= 200809L
 +#define usleep(a) \

--- a/libs/alsa-ucm-conf/Makefile
+++ b/libs/alsa-ucm-conf/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alsa-ucm-conf
-PKG_VERSION:=1.2.6.2
+PKG_VERSION:=1.2.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=ftp://ftp.alsa-project.org/pub/lib/ \
-		http://distfiles.gentoo.org/distfiles/
-PKG_HASH:=8be24fb9fe789ee2778ae6f32e18e8043fe7f8bc735871e9d17c68a04566a822
+PKG_SOURCE_URL:=https://www.alsa-project.org/files/pub/lib/ \
+		https://distfiles.gentoo.org/distfiles/
+PKG_HASH:=374f6833bfd77d0a4675e4aa2bfb79defe850e5a46a5d4542a45962f4b9e272a
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=BSD-3-Clause

--- a/sound/alsa-utils/Makefile
+++ b/sound/alsa-utils/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alsa-utils
-PKG_VERSION:=1.2.6
+PKG_VERSION:=1.2.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=ftp://ftp.alsa-project.org/pub/utils/ \
-		http://distfiles.gentoo.org/distfiles/
-PKG_HASH:=6a1efd8a1f1d9d38e489633eaec1fffa5c315663b316cab804be486887e6145d
+PKG_SOURCE_URL:=https://www.alsa-project.org/files/pub/utils/ \
+		https://distfiles.gentoo.org/distfiles/
+PKG_HASH:=e7623d4525595f92e11ce25ee9a97f2040a14c6e4dcd027aa96e06cbce7817bd
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: @thess @tripolar (cc @neheb)
Compile tested: rockchip/armv8
Run tested: n/a

Description:
* updated source url (prefer https rather than http/ftp)
* fixed build with musl 1.2.4