### PR TITLE
oath-toolkit: add InstallDev section

### DIFF
--- a/utils/oath-toolkit/Makefile
+++ b/utils/oath-toolkit/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=oath-toolkit
 PKG_VERSION:=2.6.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SAVANNAH/oath-toolkit
@@ -42,6 +42,13 @@ define Package/oath-toolkit/description
 	authentication systems. It contains shared libraries, command line
 	tools and a PAM module. Supported technologies include the event-based
 	HOTP algorithm (RFC4226) and the time-based TOTP algorithm (RFC6238).
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/liboath
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
 endef
 
 define Package/oath-toolkit/install


### PR DESCRIPTION
This package seems to be missing an InstallDev section. Had a compile failure for an application that needs to compile against liboath

Maintainer:  @famz
Compile tested: arm cortex-a7 ipq40xx, p2w_r619ac-128m, OpenWrt 22.03
Run tested:  arm cortex-a7 ipq40xx, p2w_r619ac-128m, OpenWrt 22.03

Description:
Some application like ocserv need liboath to enable otp feature, add InstallDev section to export include and pkgconfig files

Details in https://gitlab.com/openconnect/ocserv/-/issues/508#note_1388900513