### PR TITLE
banip: update 0.8.6-3

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
 PKG_VERSION:=0.8.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/banip/files/README.md
+++ b/net/banip/files/README.md
@@ -232,7 +232,7 @@ Available commands:
 ~# /etc/init.d/banip status
 ::: banIP runtime information
   + status            : active (nft: ✔, monitor: ✔)
-  + version           : 0.8.6-2
+  + version           : 0.8.6-3
   + element_count     : 172309
   + active_feeds      : allowlistvMAC, allowlistv6, allowlistv4, adawayv4, adguardtrackersv4, adawayv6, adguardv6, adguardv4, urlvirv4, adguardtrackersv6, oisdbigv6, oisdbigv4, blocklistvMAC, blocklistv4, blocklistv6
   + active_devices    : br-wan ::: wan, wan6


### PR DESCRIPTION
Maintainer: @dibdot 
Compile tested: x86_64, Generic, OpenWrt 22.03.5
Run tested: x86_64, Generic, OpenWrt 22.03.5, checked -> modifed /usr/lib/banip-functions.sh

Description:
* Grant up to 30 seconds on uplink detection to get an ip address. (e.g.  pppoe)