### PR TITLE
libreswan: update to 4.11

### DIFF
--- a/net/libreswan/Makefile
+++ b/net/libreswan/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libreswan
-PKG_VERSION:=4.10
+PKG_VERSION:=4.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.libreswan.org/
-PKG_HASH:=5a9400c25a8edba07420426fb55dcbaafdaa3702e5b0f2c19205a6c567248a7b
+PKG_HASH:=429a917fe4a55260f152cfb3188a587e5b12e94a14e240ac125319ff14b8c83d
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Fixes https://libreswan.org/security/CVE-2023-30570

Maintainer: me
Tested x86_64