### PR TITLE
inotify-tools: fix compilation with musl 1.2.4

### DIFF
--- a/utils/inotify-tools/Makefile
+++ b/utils/inotify-tools/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=inotify-tools
 PKG_VERSION:=3.20.11.0
 PKG_HASH:=58a3cde89e4a5111a87ac16b56b06a8f885460fca0aea51b69c856ce30a37a14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://codeload.github.com/rvoicilas/inotify-tools/tar.gz/$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -18,6 +18,10 @@ PKG_FIXUP:=autoreconf
 include $(INCLUDE_DIR)/package.mk
 
 CONFIGURE_ARGS+= --disable-doxygen
+
+ifneq ($(CONFIG_USE_MUSL),)
+  TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
+endif
 
 define Build/Prepare
 	$(call Build/Prepare/Default)


### PR DESCRIPTION
Fixes errors in the form of:
inotifytools.c: In function 'inotifytools_watch_recursively_with_exclude': inotifytools.c:1335:30: error: storage size of 'my_stat' isn't known
 1335 |         static struct stat64 my_stat;
      |                              ^~~~~~~
inotifytools.c:1342:36: error: implicit declaration of function 'lstat64'; did you mean 'lstat'? [-Werror=implicit-function-declaration]
 1342 |                         if ( -1 == lstat64( next_file, &my_stat ) ) {
      |                                    ^~~~~~~
      |                                    lstat
inotifytools.c:1335:30: error: unused variable 'my_stat' [-Werror=unused-variable]
 1335 |         static struct stat64 my_stat;
      |                              ^~~~~~~
inotifytools.c: In function 'isdir':
inotifytools.c:1621:30: error: storage size of 'my_stat' isn't known
 1621 |         static struct stat64 my_stat;
      |                              ^~~~~~~
inotifytools.c:1621:30: error: unused variable 'my_stat' [-Werror=unused-variable]
inotifytools.c:1630:1: error: control reaches end of non-void function [-Werror=return-type]
 1630 | }
      | ^
cc1: all warnings being treated as errors

Maintainer: @dangowrt 
Compile tested: CI
Run tested: no

