### PR TITLE
arp-scan: fix missing libcap dependency

### DIFF
--- a/net/arp-scan/Makefile
+++ b/net/arp-scan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=arp-scan
 PKG_VERSION:=1.10.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/royhills/arp-scan/tar.gz/$(PKG_VERSION)?
@@ -41,6 +41,9 @@ endef
 define Package/arp-scan/description
     ARP scanner
 endef
+
+CONFIGURE_ARGS += \
+	--without-libcap
 
 define Package/arp-scan/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
arp-scan complains about missing libcap dependency. Add it as package dependency to fix compilation.

Maintainer: @urusha
Compile tested: mt7622
Run tested: no
