### PR TITLE
btop: fix compilation with musl 1.2.4

### DIFF
--- a/admin/btop/Makefile
+++ b/admin/btop/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btop
 PKG_VERSION:=1.2.13
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://codeload.github.com/aristocratos/btop/tar.gz/v$(PKG_VERSION)?
@@ -36,6 +36,10 @@ MAKE_FLAGS+= \
 	PLATFORM=Linux \
 	OPTFLAGS="$(TARGET_CXXFLAGS)" \
 	LDCXXFLAGS="$(TARGET_LDFLAGS) -pthread"
+
+ifneq ($(CONFIG_USE_MUSL),)
+  TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
+endif
 
 define Package/btop/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
_LARGEFILE64_SOURCE has to be defined in the source, or CFLAGS can be used to pass -D_LARGEFILE64_SOURCE to allow to keep using LFS64 definitions.

Fixes errors in the form of:
Compiling src/linux/btop_collect.cpp
src/linux/btop_collect.cpp: In function 'Mem::mem_info& Mem::collect(bool)': src/linux/btop_collect.cpp:1082:58: error: aggregate 'Mem::collect(bool)::statvfs64 vfs' has incomplete type and cannot be defined
 1082 |                                         struct statvfs64 vfs;
      |                                                          ^~~
src/linux/btop_collect.cpp:1083:79: error: invalid use of incomplete type 'struct Mem::collect(bool)::statvfs64'
 1083 |                                         if (statvfs64(mountpoint.c_str(), &vfs) < 0) {
      |                                                                               ^
src/linux/btop_collect.cpp:1082:48: note: forward declaration of 'struct Mem::collect(bool)::statvfs64'
 1082 |                                         struct statvfs64 vfs;
      |                                                ^~~~~~~~~
make[3]: *** [Makefile:274: obj/linux/btop_collect.o] Error 1
make[3]: Leaving directory '/home/nick/openwrt/build_dir/target-aarch64_cortex-a53_musl/btop-1.2.13'
make[2]: *** [Makefile:53: /home/nick/openwrt/build_dir/target-aarch64_cortex-a53_musl/btop-1.2.13/.built] Error 2
make[2]: Leaving directory '/home/nick/openwrt/feeds/packages/admin/btop'
time: package/feeds/packages/btop/compile#2.57#0.17#3.02
    ERROR: package/feeds/packages/btop failed to build.

Maintainer: @1715173329 
Compile tested: mt7622
Run tested: no
