### PR TITLE
nfs-kernel-server: fix compilation with musl 1.2.4

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
 PKG_VERSION:=2.6.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_HASH:=26d46448982252e9e2c8346d10cf13e1143e7089c866f53e25db3359f3e9493c
 
 PKG_SOURCE_URL:=@SF/nfs
@@ -99,6 +99,10 @@ TARGET_CFLAGS += -Wno-error=implicit-function-declaration \
 		 -Wno-error=format-security \
 		 -Wno-error=undef \
 		 -Wno-error=missing-include-dirs
+
+ifneq ($(CONFIG_USE_MUSL),)
+  TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
+endif
 
 TARGET_LDFLAGS += -L$(STAGING_DIR)/usr/lib/libevent
 


### PR DESCRIPTION
Maintainer: nobody (cc @neheb)
Compile tested: rockchip/armv8
Run tested: n/a

Description:
musl 1.2.4 deprecated legacy "LFS64" ("large file support") interfaces so just having _GNU_SOURCE defined is not enough anymore.

Manually pass -D_LARGEFILE64_SOURCE to allow to keep using LFS64 definitions.