### PR TITLE
ripgrep: fix compilation with musl 1.2.4

### DIFF
--- a/utils/ripgrep/Makefile
+++ b/utils/ripgrep/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ripgrep
 PKG_VERSION:=13.0.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/BurntSushi/ripgrep/tar.gz/$(PKG_VERSION)?
@@ -35,6 +35,10 @@ define Package/ripgrep/description
   ripgrep (rg) recursively searches directories for a regex pattern
   while respecting your gitignore
 endef
+
+ifneq ($(CONFIG_USE_MUSL),)
+  TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
+endif
 
 $(eval $(call RustBinPackage,ripgrep))
 $(eval $(call BuildPackage,ripgrep))


### PR DESCRIPTION
_LARGEFILE64_SOURCE has to be defined in the source, or CFLAGS can be used to pass -D_LARGEFILE64_SOURCE to allow to keep using LFS64 definitions.

Fixes errors in the form of:
```
`std::sys::common::small_c_string::run_with_cstr_allocating':
          std.8518be91-cgu.12:(.text.unlikely._ZN3std3sys6common14small_c_string24run_with_cstr_allocating17h6b06bca7baec94a5E+0x6c): undefined reference to `lstat64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: /builder/shared-workdir/build/sdk/staging_dir/hostpkg/cargo/lib/rustlib/aarch64-unknown-linux-musl/lib/libstd-36c8b3e4cde7f9f5.rlib(std-36c8b3e4cde7f9f5.std.8518be91-cgu.12.rcgu.o): in function `std::sys::common::small_c_string::run_with_cstr_allocating':
          std.8518be91-cgu.12:(.text.unlikely._ZN3std3sys6common14small_c_string24run_with_cstr_allocating17haca87f88038fc6e4E+0x6c): undefined reference to `stat64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: /builder/shared-workdir/build/sdk/staging_dir/hostpkg/cargo/lib/rustlib/aarch64-unknown-linux-musl/lib/libstd-36c8b3e4cde7f9f5.rlib(std-36c8b3e4cde7f9f5.std.8518be91-cgu.6.rcgu.o): in function `std::backtrace_rs::symbolize::gimli::mmap':
          std.8518be91-cgu.6:(.text._ZN3std12backtrace_rs9symbolize5gimli4mmap17h3ca3a47d6f44f0e2E+0x140): undefined reference to `fstat64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: /builder/shared-workdir/build/sdk/staging_dir/hostpkg/cargo/lib/rustlib/aarch64-unknown-linux-musl/lib/libstd-36c8b3e4cde7f9f5.rlib(std-36c8b3e4cde7f9f5.std.8518be91-cgu.8.rcgu.o): in function `std::fs::File::metadata':
          std.8518be91-cgu.8:(.text._ZN3std2fs4File8metadata17hd8edcf64724e7edfE+0x28): undefined reference to `fstat64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: /builder/shared-workdir/build/sdk/staging_dir/hostpkg/cargo/lib/rustlib/aarch64-unknown-linux-musl/lib/libstd-36c8b3e4cde7f9f5.rlib(std-36c8b3e4cde7f9f5.std.8518be91-cgu.8.rcgu.o): in function `<std::fs::File as std::io::Read>::read_to_end':
          std.8518be91-cgu.8:(.text._ZN47_$LT$std..fs..File$u20$as$u20$std..io..Read$GT$11read_to_end17ha59da013b024ed84E+0x3c): undefined reference to `fstat64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: std.8518be91-cgu.8:(.text._ZN47_$LT$std..fs..File$u20$as$u20$std..io..Read$GT$11read_to_end17ha59da013b024ed84E+0x58): undefined reference to `lseek64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: std.8518be91-cgu.8:(.text._ZN47_$LT$std..fs..File$u20$as$u20$std..io..Read$GT$11read_to_end17ha59da013b024ed84E+0xbc): undefined reference to `lseek64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: /builder/shared-workdir/build/sdk/staging_dir/hostpkg/cargo/lib/rustlib/aarch64-unknown-linux-musl/lib/libstd-36c8b3e4cde7f9f5.rlib(std-36c8b3e4cde7f9f5.std.8518be91-cgu.8.rcgu.o): in function `<std::fs::File as std::io::Read>::read_to_string':
          std.8518be91-cgu.8:(.text._ZN47_$LT$std..fs..File$u20$as$u20$std..io..Read$GT$14read_to_string17hac1014cb573357e0E+0x3c): undefined reference to `fstat64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: std.8518be91-cgu.8:(.text._ZN47_$LT$std..fs..File$u20$as$u20$std..io..Read$GT$14read_to_string17hac1014cb573357e0E+0x58): undefined reference to `lseek64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: std.8518be91-cgu.8:(.text._ZN47_$LT$std..fs..File$u20$as$u20$std..io..Read$GT$14read_to_string17hac1014cb573357e0E+0xbc): undefined reference to `lseek64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: /builder/shared-workdir/build/sdk/staging_dir/hostpkg/cargo/lib/rustlib/aarch64-unknown-linux-musl/lib/libstd-36c8b3e4cde7f9f5.rlib(std-36c8b3e4cde7f9f5.std.8518be91-cgu.8.rcgu.o): in function `std::fs::metadata':
          std.8518be91-cgu.8:(.text._ZN3std2fs8metadata17h025e05998b4f6791E+0x84): undefined reference to `stat64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: /builder/shared-workdir/build/sdk/staging_dir/hostpkg/cargo/lib/rustlib/aarch64-unknown-linux-musl/lib/libstd-36c8b3e4cde7f9f5.rlib(std-36c8b3e4cde7f9f5.std.8518be91-cgu.13.rcgu.o): in function `<std::sys::unix::fs::ReadDir as core::iter::traits::iterator::Iterator>::next':
          std.8518be91-cgu.13:(.text._ZN86_$LT$std..sys..unix..fs..ReadDir$u20$as$u20$core..iter..traits..iterator..Iterator$GT$4next17h3aaa19c90400ffbbE+0x48): undefined reference to `readdir64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: std.8518be91-cgu.13:(.text._ZN86_$LT$std..sys..unix..fs..ReadDir$u20$as$u20$core..iter..traits..iterator..Iterator$GT$4next17h3aaa19c90400ffbbE+0x74): undefined reference to `readdir64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: /builder/shared-workdir/build/sdk/staging_dir/hostpkg/cargo/lib/rustlib/aarch64-unknown-linux-musl/lib/libstd-36c8b3e4cde7f9f5.rlib(std-36c8b3e4cde7f9f5.std.8518be91-cgu.13.rcgu.o): in function `std::sys::unix::fs::DirEntry::file_type':
          std.8518be91-cgu.13:(.text._ZN3std3sys4unix2fs8DirEntry9file_type17h0024a0d0184b9af0E+0x80): undefined reference to `fstatat64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: /builder/shared-workdir/build/sdk/staging_dir/hostpkg/cargo/lib/rustlib/aarch64-unknown-linux-musl/lib/libstd-36c8b3e4cde7f9f5.rlib(std-36c8b3e4cde7f9f5.std.8518be91-cgu.13.rcgu.o): in function `std::sys::unix::fs::File::open_c':
          std.8518be91-cgu.13:(.text._ZN3std3sys4unix2fs4File6open_c17hb3eaad2b27d5e957E+0x114): undefined reference to `open64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: /builder/shared-workdir/build/sdk/staging_dir/hostpkg/cargo/lib/rustlib/aarch64-unknown-linux-musl/lib/libstd-36c8b3e4cde7f9f5.rlib(std-36c8b3e4cde7f9f5.std.8518be91-cgu.13.rcgu.o): in function `std::sys::unix::fs::stat':
          std.8518be91-cgu.13:(.text._ZN3std3sys4unix2fs4stat17h98081aaad028dbd1E+0x94): undefined reference to `stat64'
          /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/12.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: /builder/shared-workdir/build/sdk/staging_dir/hostpkg/cargo/lib/rustlib/aarch64-unknown-linux-musl/lib/libstd-36c8b3e4cde7f9f5.rlib(std-36c8b3e4cde7f9f5.std.8518be91-cgu.13.rcgu.o): in function `std::sys::unix::fs::lstat':
          std.8518be91-cgu.13:(.text._ZN3std3sys4unix2fs5lstat17he0b1844f1e7f516bE+0x94): undefined reference to `lstat64'
          collect2: error: ld returned 1 exit status
```

Maintainer: @lu-zero 
Compile tested: CI
Run tested: no
