### PR TITLE
acpid: Update to 2.0.34

### DIFF
--- a/utils/acpid/Makefile
+++ b/utils/acpid/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acpid
-PKG_VERSION:=2.0.32
-PKG_RELEASE:=3
+PKG_VERSION:=2.0.34
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/acpid2
-PKG_HASH:=f2d2d30b3edc3234bd82f6f7186699a6aa3c85c8d20bc4e30e9b3c68a1ed157e
+PKG_HASH:=2d095c8cfcbc847caec746d62cdc8d0bff1ec1bc72ef7c674c721e04da6ab333
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/utils/acpid/patches/010-Replace-stat64-with-stat.patch
+++ b/utils/acpid/patches/010-Replace-stat64-with-stat.patch
@@ -1,0 +1,28 @@
+From 81df3ad69585629f952972228d7edb6da0596b94 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 14 Dec 2022 15:04:30 -0800
+Subject: [PATCH] Replace stat64 with stat
+
+It already checks for largefile support in configure.ac via
+AC_SYS_LARGEFILE macro, which will ensure that 64bit elements
+are correctly setup for stat APIs on platforms needing large
+file support.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ sock.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/sock.c
++++ b/sock.c
+@@ -54,8 +54,8 @@ int non_root_clients;
+ static int
+ isfdtype(int fd, int fdtype)
+ {
+-	struct stat64 st;
+-	if (fstat64(fd, &st) != 0)
++	struct stat st;
++	if (fstat(fd, &st) != 0)
+ 		return -1;
+ 	return ((st.st_mode & S_IFMT) == (mode_t)fdtype);
+ }


### PR DESCRIPTION
Maintainer: Thomas Heil / cc @neheb
Compile tested: rockchip/armv8
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
Backported an upstream commit to fix build with musl 1.2.4.
