### PR TITLE
libpciaccess: Update to 0.17

### DIFF
--- a/libs/libpciaccess/Makefile
+++ b/libs/libpciaccess/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpciaccess
-PKG_VERSION:=0.16
+PKG_VERSION:=0.17
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://www.x.org/releases/individual/lib/
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_HASH:=214c9d0d884fdd7375ec8da8dcb91a8d3169f263294c9a90c575bf1938b9f489
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_HASH:=74283ba3c974913029e7a547496a29145b07ec51732bbb5b5c58d5025ad95b73
 
 PKG_MAINTAINER:= Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENSE_FILES:=COPYING

--- a/libs/libpciaccess/patches/010-linux_sysfs-Use-pwrite-pread-instead-of-64bit-versions.patch
+++ b/libs/libpciaccess/patches/010-linux_sysfs-Use-pwrite-pread-instead-of-64bit-versions.patch
@@ -1,0 +1,39 @@
+From 833c86ce15cee2a84a37ae71015f236fd32615d9 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 11 Nov 2022 11:15:58 -0800
+Subject: [PATCH] linux_sysfs: Use pwrite/pread instead of 64bit versions
+
+pread64/pwrite64 are aliased to pread/pwrite when largefile support is
+enabled e.g. using _FILE_OFFSET_BITS=64 macro
+
+This helps it compile on latest musl C library based systems where these
+functions are put under _LARGEFILE64_SOURCE which is to be removed once
+all packages start using 64bit off_t, it works with glibc becuase
+_GNU_SOURCE feature macro also defines _LARGEFILE64_SOURCE, thats not
+the case with musl
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/linux_sysfs.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/src/linux_sysfs.c
++++ b/src/linux_sysfs.c
+@@ -462,7 +462,7 @@ pci_device_linux_sysfs_read( struct pci_
+ 
+ 
+     while ( temp_size > 0 ) {
+-	const ssize_t bytes = pread64( fd, data_bytes, temp_size, offset );
++	const ssize_t bytes = pread( fd, data_bytes, temp_size, offset );
+ 
+ 	/* If zero bytes were read, then we assume it's the end of the
+ 	 * config file.
+@@ -522,7 +522,7 @@ pci_device_linux_sysfs_write( struct pci
+ 
+ 
+     while ( temp_size > 0 ) {
+-	const ssize_t bytes = pwrite64( fd, data_bytes, temp_size, offset );
++	const ssize_t bytes = pwrite( fd, data_bytes, temp_size, offset );
+ 
+ 	/* If zero bytes were written, then we assume it's the end of the
+ 	 * config file.


### PR DESCRIPTION
Maintainer: @lucize
Compile tested: rockchip/armv8
Run tested: n/a

Description:
Backported an upstream commit to fix build with musl 1.2.4.
