### PR TITLE
tgt: Update to 1.0.86

### DIFF
--- a/net/tgt/Makefile
+++ b/net/tgt/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tgt
-PKG_VERSION:=1.0.83
-PKG_RELEASE:=2
+PKG_VERSION:=1.0.86
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fujita/tgt/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=a9ddb0ff32d3396416df9639f9f398d14a6051f505b5772d7d196df99df8b8da
+PKG_HASH:=af84c16bf8893d65666afcc0424b46dafddd2d0e5dcf818b319ea9ed3c3315a7
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-2.0-only
@@ -34,6 +34,10 @@ that supports the iSCSI and iSER transport protocols and that also
 supports multiple methods for accessing block storage. Tgt consists of
 user-space daemon and tools.
 endef
+
+ifneq ($(CONFIG_USE_MUSL),)
+  TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
+endif
 
 define Build/Compile
 	$(call Build/Compile/Default,programs)


### PR DESCRIPTION
Maintainer: @mstorchak
Compile tested: rockchip/armv8
Run tested: n/a

Description:
musl 1.2.4 deprecated legacy "LFS64" ("large file support") interfaces so just having _GNU_SOURCE defined is not enough anymore.

Manually pass -D_LARGEFILE64_SOURCE to allow to keep using LFS64 definitions.

while at it bump to latest version 1.0.86