### PR TITLE
python-attrs: Update to 23.1.0

### DIFF
--- a/lang/python/python-attrs/Makefile
+++ b/lang/python/python-attrs/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016-2018 OpenWrt.org
+# Copyright (C) 2016, 2018-2023 Jeffery To
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,15 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-attrs
-PKG_VERSION:=21.4.0
+PKG_VERSION:=23.1.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=attrs
-PKG_HASH:=626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
+PKG_HASH:=6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+PKG_BUILD_DEPENDS:=python-hatchling/host python-hatch-vcs/host python-hatch-fancy-pypi-readme/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: me
Compile tested: armvirt-32, 2023-05-15 snapshot sdk
Run tested: armvirt-32 (qemu), 2023-05-15 snapshot

Description:
The package now uses pyproject.toml-based builds with additional build dependencies.
