### PR TITLE
mblaze: fix compilation with musl 1.2.4

### DIFF
--- a/mail/mblaze/Makefile
+++ b/mail/mblaze/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mblaze
 PKG_VERSION:=1.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://leahneukirchen.org/releases

--- a/mail/mblaze/patches/010-mlist-use-fixed-width-integer-types-for-struct-linux_dire.patch
+++ b/mail/mblaze/patches/010-mlist-use-fixed-width-integer-types-for-struct-linux_dire.patch
@@ -1,0 +1,23 @@
+From 1babebc12c3ea8d3395f00c9607e863866c190fc Mon Sep 17 00:00:00 2001
+From: Michael Forney <mforney@mforney.org>
+Date: Wed, 7 Dec 2022 13:11:58 -0800
+Subject: [PATCH] mlist: use fixed-width integer types for struct
+ linux_dirent64 d_ino and d_off
+
+---
+ mlist.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/mlist.c
++++ b/mlist.c
+@@ -111,8 +111,8 @@ list(char *prefix, char *file)
+ #include <sys/syscall.h>
+ 
+ struct linux_dirent64 {
+-	ino64_t d_ino;           /* 64-bit inode number */
+-	off64_t d_off;           /* 64-bit offset to next structure */
++	uint64_t d_ino;          /* 64-bit inode number */
++	int64_t d_off;           /* 64-bit offset to next structure */
+ 	unsigned short d_reclen; /* Size of this dirent */
+ 	unsigned char d_type;    /* File type */
+ 	char d_name[];           /* Filename (null-terminated) */


### PR DESCRIPTION
Maintainer: @paper42
Compile tested: rockchip/armv8
Run tested: n/a

Description:
musl 1.2.4 deprecated legacy "LFS64" ("large file support") interfaces so just having _GNU_SOURCE defined is not enough anymore.

Backport an upstream fix to replace these old data types.
