### PR TITLE
xfsprogs: fix compilation with musl 1.2.4

### DIFF
--- a/utils/xfsprogs/Makefile
+++ b/utils/xfsprogs/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xfsprogs
 PKG_VERSION:=5.9.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/fs/xfs/xfsprogs
@@ -67,7 +67,7 @@ CONFIGURE_ARGS += \
 	--disable-scrub \
 	--disable-libicu
 
-TARGET_CFLAGS += -DHAVE_MAP_SYNC
+TARGET_CFLAGS += -DHAVE_MAP_SYNC $(if (CONFIG_USE_MUSL),-D_LARGEFILE64_SOURCE)
 TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-lrt)
 
 define Package/xfs-admin/install


### PR DESCRIPTION
musl 1.2.4 deprecated legacy "LFS64" ("large file support") interfaces so just having _GNU_SOURCE defined is not enough anymore.

Manually pass -D_LARGEFILE64_SOURCE to allow to keep using LFS64 definitions.

Maintainer: nobody
Compile tested: rockchip/armv8
Run tested: n/a
