### PR TITLE
xupnpd: fix compilation with musl 1.2.4

### DIFF
--- a/multimedia/xupnpd/Makefile
+++ b/multimedia/xupnpd/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=xupnpd
 PKG_REV:=e4e542d9b6d0043d470fda283e2cd325bbb91950
 PKG_VERSION:=2018-11-20
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/clark15b/xupnpd/tar.gz/$(PKG_REV)?
@@ -25,6 +25,10 @@ PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 include $(INCLUDE_DIR)/package.mk
 
 LUA_FLAGS:=-llua -lssl -lcrypto
+
+ifneq ($(CONFIG_USE_MUSL),)
+  TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
+endif
 
 define Build/Compile
 	(cd $(PKG_BUILD_DIR)/src; $(TARGET_CC) -v $(LUA_FLAGS) $(TARGET_CFLAGS) -fno-exceptions -fno-rtti -DWITH_URANDOM $(TARGET_CPPFLAGS) $(TARGET_LDFLAGS) -lm -ldl -lcrypt -o xupnpd *.c *.cpp)


### PR DESCRIPTION
musl 1.2.4 deprecated legacy "LFS64" ("large file support") interfaces so just having _GNU_SOURCE defined is not enough anymore.

Manually pass -D_LARGEFILE64_SOURCE to allow to keep using LFS64 definitions.

Maintainer: @Noltari
Compile tested: rockchip/armv8
Run tested: n/a