### PR TITLE
crowdsec: new upstream release version 1.5.1

### DIFF
--- a/net/crowdsec/Makefile
+++ b/net/crowdsec/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crowdsec
-PKG_VERSION:=1.4.6
-PKG_RELEASE:=2
+PKG_VERSION:=1.5.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/crowdsecurity/crowdsec/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=acec1560593da78e37acbf44f2337a1e3026646ece00ab02eded78f71a2adda3
+PKG_HASH:=427f11b1a788a482b4fec8d23edd27ef589a58e1ebd0cb15182f105ad26f128b
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE

--- a/net/crowdsec/patches/001-fix_config_data_dir.patch
+++ b/net/crowdsec/patches/001-fix_config_data_dir.patch
@@ -1,6 +1,6 @@
 --- a/config/config.yaml
 +++ b/config/config.yaml
-@@ -10,7 +10,7 @@ common:
+@@ -9,7 +9,7 @@ common:
    working_dir: .
  config_paths:
    config_dir: /etc/crowdsec/


### PR DESCRIPTION
Update crowdsec to latest upstream release version 1.5.1

Signed-off-by: S. Brusch <ne20002@gmx.ch>

Maintainer: Kerma Gérald <gandalf@gk2.net>
Run tested: ipq40xx/generic, Fritzbox 4040, Openwrt 22.03.5

Description: update to latest version of upstream
