### PR TITLE
libupm: Workaround for errors with GCC13

### DIFF
--- a/libs/libupm/Makefile
+++ b/libs/libupm/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libupm
 PKG_VERSION:=2.0.0
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/intel-iot-devkit/upm/tar.gz/v$(PKG_VERSION)?

--- a/libs/libupm/patches/011-gcc-13-compatibility-fixes.patch
+++ b/libs/libupm/patches/011-gcc-13-compatibility-fixes.patch
@@ -1,0 +1,26 @@
+--- a/src/mcp9808/mcp9808.hpp
++++ b/src/mcp9808/mcp9808.hpp
+@@ -30,6 +30,10 @@
+ #include <string>
+ #include <interfaces/iTemperature.hpp>
+ 
++#ifndef uint8_t
++#include <cstdint>
++#endif
++
+ #define MCP9808_REG_CONFIG  0x01
+ #define MCP9808_REG_AMBIENT_TEMP 0x05
+ #define MCP9808_REG_MANUF_ID 0x06
+--- a/src/micsv89/micsv89.hpp
++++ b/src/micsv89/micsv89.hpp
+@@ -27,6 +27,10 @@
+ #include <iostream>
+ #include <string>
+ 
++#ifndef uint8_t
++#include <cstdint>
++#endif
++
+ #include <interfaces/iGas.hpp>
+ 
+ namespace mraa { class I2c;}


### PR DESCRIPTION
Maintainer: @blogic, me
 Compile tested: head (with gcc13), aarch64
 Run tested: (qemu-8.0.0) aarch64

Description:
Workaround for errors with GCC13
 https://github.com/openwrt/packages/issues/20994

patch
 https://github.com/oskarirauta/local-overrides/blob/main/libs/libupm/patches/011-gcc-13-compatibility-fixes.patch

