### PR TITLE
xfsprogs: Update to 6.2.0

### DIFF
--- a/libs/inih/Makefile
+++ b/libs/inih/Makefile
@@ -1,0 +1,75 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=inih
+PKG_VERSION:=r56
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/benhoyt/inih/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=4f2ba6bd122d30281a8c7a4d5723b7af90b56aa828c0e88256d7fceda03a491a
+
+PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE.txt
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/meson.mk
+
+define Package/libinih/Default
+  SECTION:=libs
+  CATEGORY:=Libraries
+  URL:=https://github.com/benhoyt/inih
+endef
+
+define Package/libinih
+  $(call Package/libinih/Default)
+  TITLE:=Simple .INI file parser in C
+endef
+
+define Package/libinireader
+  $(call Package/libinih/Default)
+  TITLE:=C++ library and API for inih
+  DEPENDS:=+libinih +libstdcpp
+endef
+
+define Package/libinih/description
+  inih (INI Not Invented Here) is a simple .INI file parser written
+  in C. It's only a couple of pages of code, and it was designed to
+  be small and simple, so it's good for embedded systems. It's also
+  more or less compatible with Python's ConfigParser style of .INI
+  files, including RFC 822-style multi-line syntax and name: value
+  entries.
+endef
+
+Package/libinireader/description = $(Package/libinih/description)
+
+MESON_ARGS += \
+	-Ddefault_library=both \
+	-Ddistro_install=true \
+	-Dwith_INIReader=true \
+	-Dmulti-line_entries=true \
+	-Dutf-8_bom=true \
+	-Dinline_comments=true \
+	-Duse_heap=false
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/{ini,INIReader}.h $(1)/usr/include
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/{inih,INIReader}.pc $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{inih,INIReader}.a $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{inih,INIReader}.so* $(1)/usr/lib/
+endef
+
+define Package/libinih/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libinih.so* $(1)/usr/lib/
+endef
+
+define Package/libinireader/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libINIReader.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libinih))
+$(eval $(call BuildPackage,libinireader))

--- a/utils/xfsprogs/Makefile
+++ b/utils/xfsprogs/Makefile
@@ -8,20 +8,22 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xfsprogs
-PKG_VERSION:=5.9.0
-PKG_RELEASE:=3
+PKG_VERSION:=6.2.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/fs/xfs/xfsprogs
-PKG_HASH:=bc5c805596bc609a18dc1f1b4ed6a2821dba9f47408ec00e7799ceea1b2097f1
+PKG_HASH:=d67dcba5a28e0904b60886b6e5f752bc7c9c3a5c7096153855b5adca9db86c51
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=LICENSES/GPL-2.0
 PKG_CPE_ID:=cpe:/a:sgi:xfsprogs
 
-PKG_INSTALL:=1
+PKG_BUILD_DEPENDS:=inih
+PKG_BUILD_FLAGS:=no-mips16
 PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -29,7 +31,7 @@ define Package/xfsprogs/default
   SECTION:=utils
   CATEGORY:=Utilities
   SUBMENU:=Filesystem
-  DEPENDS:=+libuuid +libpthread
+  DEPENDS:=+liburcu +libuuid +libpthread
   URL:=https://xfs.org/
 endef
 
@@ -41,6 +43,7 @@ endef
 define Package/xfs-mkfs
 $(call Package/xfsprogs/default)
   TITLE:=Utility for creating XFS filesystems
+  DEPENDS+=+libinih
 endef
 
 define Package/xfs-fsck
@@ -67,7 +70,7 @@ CONFIGURE_ARGS += \
 	--disable-scrub \
 	--disable-libicu
 
-TARGET_CFLAGS += -DHAVE_MAP_SYNC $(if (CONFIG_USE_MUSL),-D_LARGEFILE64_SOURCE)
+TARGET_CFLAGS += -DHAVE_MAP_SYNC $(if $(CONFIG_USE_MUSL),-D_LARGEFILE64_SOURCE)
 TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-lrt)
 
 define Package/xfs-admin/install

--- a/utils/xfsprogs/patches/120-disable_assert.patch
+++ b/utils/xfsprogs/patches/120-disable_assert.patch
@@ -1,6 +1,6 @@
 --- a/libxfs/libxfs_priv.h
 +++ b/libxfs/libxfs_priv.h
-@@ -87,9 +87,6 @@ struct iomap;
+@@ -89,9 +89,6 @@ struct iomap;
  /* for all the support code that uses progname in error messages */
  extern char    *progname;
  


### PR DESCRIPTION
Maintainer: nobody
Compile tested: rockchip/armv8
Run tested: n/a

Description:
Changelogs:
```
xfsprogs-6.2.0 (24 Mar 2023)
	xfs_repair: fix incorrect dabtree hashval comparison (Darrick J. Wong)
	mkfs: protofile can now create directories with spaces  in their names (Darrick J. Wong)
	mkfs: check dirent names when reading protofile (Darrick J. Wong)
	xfs_io: fix bmap command not detecting realtime files with xattrs (Darrick J. Wong)
	xfs_io: set fs_path when opening files on foreign filesystems (Darrick J. Wong)
	xfs_scrub: fix broken realtime free blocks unit conversions (Darrick J. Wong)
	xfs_spaceman: fix broken -g behavior in freesp command (Darrick J. Wong)
	xfs_admin: correctly parse IO_OPTS parameters (Catherine Hoang)
	Fix autoconf during debian package builds (Dave Chinner)
	xfs_admin: fsuuid cmd can now retrive UUID of mounted filesystems (Catherine Hoang)

xfsprogs-6.1.1 (13 Jan 2023)
	- scrub: fix warnings/errors due to missing include (Holger Hoffstatte)
	- debian: Add missing pkg version to the changelog (Carlos Maiolino)

xfsprogs-6.1.0 (23 Dec 2022)
	- libxfs: kernel sync
	- libxfs: consume the xfs_warn mountpoint argument (Darrick J. Wong)
	- misc: add static to various sourcefile-local functions (Darrick J. Wong)
	- misc: add missing includes (Darrick J. Wong)
	- xfs_{db,repair}: fix XFS_REFC_COW_START usage (Darrick J. Wong)
	- xfs_repair: don't crash on unknown inode parents in dry run mode (Darrick J. Wong)
	- xfs_repair: retain superblock buffer to avoid write hook deadlock (Darrick J. Wong)
	- xfs_repair: Attempt log replay during boot time repair (Srikanth C S)
	- xfs_repair: covscan fixes (Carlos Maiolino)
	- xfs_db: create separate struct and field definitions for finobts (Darrick J. Wong)
	- xfs_db: fix dir3 block magic check (Darrick J. Wong)
	- xfs_db: fix octal conversion logic (Darrick J. Wong)
	- xfs_db: fix printing of reverse mapping record blockcounts (Darrick J. Wong)
	- xfs_io: don't display stripe alignment flags for rt files (Darrick J. Wong)
	- xfs_db: fix dir3 block magic check (Darrick J. Wong)
	- mkfs.xfs: add mkfs config file for the 6.1 LTS kernel (Darrick J. Wong)

xfsprogs-6.0.0 (11 Nov 2022)
	- libxfs: kernel sync
	- xfs_db: use preferable macro to seek offset for local dir3 (Xiaole He)
	- xfs_quota: optimize -L/-U calls for dump/report (Andrey Albershteyn)

xfsprogs-5.19.0 (12 Aug 2022)
	- xfs_repair: fix printf format specifiers on 32-bit (Darrick J. Wong)

xfsprogs-5.19.0-rc1 (05 Aug 2022)
	- libxfs: last bit of kernel sync
	- libxfs: Fix MAP_SYNC build failure on MIPS/musl (Darrick J. Wong)
	- mkfs: stop allowing tiny filesystems (Darrick J. Wong)
	- mkfs: complain about impossible log size constraints (Darrick J. Wong)
	- mkfs: ignore stripe geometry for small filesystems (Darrick J. Wong)
	- mkfs: update manpage of bigtime and inobtcount (Zhang Boyang)
	- mkfs: document large extent count in --help screen (Darrick J. Wong)
	- mkfs: fix segfault with incorrect options (Darrick J. Wong)
	- xfs_repair: Support upgrade to large extent counters (Chandan Babu R)
	- xfs_repair: check geometry before upgrades (Darrick J. Wong)
	- xfs_repair: ignore empty xattr leaf blocks (Darrick J. Wong)
	- xfs_repair: check rt summary/bitmap vs observations (Darrick J. Wong)
	- xfs_repair: check free rt extent count (Darrick J. Wong)
	- xfs_repair: detect/fix changed fields w/ nrext64 (Darrick J. Wong)
	- xfs_repair: clear DIFLAG2_NREXT64 w/o fs support (Darrick J. Wong) 
	- xfs_repair: ignore log_incompat inconsistencies (Darrick J. Wong)s
	- xfs_repair: rewrite secondary supers w/ needsrepair (Darrick J. Wong)
	- xfs_db: id the minlogsize transaction reservation (Darrick J. Wong)

xfsprogs-5.19.0-rc0 (22 Jun 2022)
	- libxfs changes merged from kernels 5.18 and 5.19-rc
	- mkfs: option to create with large extent counters (Chandan Babu R)
	- xfs_info: Report NREXT64 feature status (Chandan Babu R)
	- xfs_logprint: Log item printing for ATTRI & ATTRD (Allison Henderson)

xfsprogs-5.18.0 (03 Jun 2022)
	- xfsprogs: more autoconf modernisation (Darrick J. Wong)

xfsprogs-5.18.0-rc1 (27 May 2022)
	- mkfs: Fix memory leak (Pavel Reichl)
	- mkfs: don't trample the gid set in the protofile (Darrick J. Wong)
	- mkfs: various post-log-size-increase fixes (Darrick J. Wong)
	- xfs_scrub: various enhancements and fixes (Darrick J. Wong)
	- xfs_scrub: move to mallinfo2 when available (Darrick J. Wong)
	- metadump: be careful zeroing corrupt inode forks (Dave Chinner)
	- metadump: handle corruption errors without aborting (Dave Chinner)
	- metadump: warn about suspicious finobt trees (Darrick J. Wong)
	- xfs_repair: check ftype of . and . directory entries (Darrick J. Wong)
	- xfs_repair: detect v5 feature mismatch in backup sb ((Darrick J. Wong)
	- xfs_repair: fix sizing of the incore rt space usage map calculation
	- xfs_repair: warn about bad btree levels in AG hdrs (Darrick J. Wong)
	- xfs_io: add a quiet option to bulkstat (Dave Chinner)
	- xfs_db: report maxlevels for each btree type (Darrick J. Wong)
	- xfs_db: support computing btheight for all cursors (Darrick J. Wong)
	- xfs_db: don't move cursor when switching types (Andrey Albershteyn)
	- docs: note the removal of XFS_IOC_FSSETDM (Darrick J. Wong)
	- xfsprogs: autoconf modernisation (Dave Chinner)
	- debian: support multiarch for libhandle (Darrick J. Wong)
	- debian: bump compat level to 11 (Darrick J. Wong)
	- debian: refactor common options (Darrick J. Wong)

xfsprogs-5.18.0-rc0 (06 May 2022)
	- libxfs changes merged from kernels 5.17 and 5.18

xfsprogs-5.16.0 (04 May 2022)
	- libxfs: remove kernel stubs from xfs_shared.h (Eric Sandeen)
	- debian: Generate .gitcensus instead of .census (Bastian Germann))

xfsprogs-5.16.0-rc0 (28 Apr 2022)
	- libxfs changes merged from kernel 5.16

xfsprogs-5.15.0 (06 Apr 2022)
	- mkfs: increase the min log size to 64MB when possible (Eric Sandeen)
	- xfs_scrub: retry items that are ok except for XFAIL (Darrick J. Wong)
	- xfs_scrub: fix xfrog_scrub_metadata error reporting (Darrick J. Wong)

xfsprogs-5.15.0-rc1 (11 Mar 2022)
	- mkfs: enable inobtcount and bigtime by default (Darrick J. Wong)
	- mkfs: prevent corruption of suboption string values (Darrick J. Wong)
	- mkfs: document sample configuration file location (Darrick J. Wong)
	- mkfs: add configuration files for a few LTS kernels (Darrick J. Wong)
	- mkfs: add a config file for x86_64 pmem filesystems (Darrick J. Wong)
	- xfs_quota: don't exit on "project" cmd failure (Eric Sandeen)
	- xfs_repair: don't guess about failure reason in phase6 (Eric Sandeen)
	- xfs_repair: update 2ndary superblocks after upgrades (Darrick J. Wong)
	- xfs_scrub: fix reporting if we can't open devices (Darrick J. Wong)
	- xfs_scrub: report optional features in version (Darrick J. Wong)
	- libxcmd: use emacs mode for command history editing (Darrick J. Wong)
	- libfrog: always use the kernel GETFSMAP definitions (Darrick J. Wong)
	- mkfs.xfs(8): fix default inode allocator description (Eric Sandeen)
	- xfs_quota(8): fix up dump and report documentation (Eric Sandeen)
	- xfs_quota(8): document units in limit command (Eric Sandeen)
	- misc: add a crc32c self test to mkfs and repair (Darrick J. Wong)

xfsprogs-5.15.0-rc0 (03 Feb 2022)
	- libxfs changes merged from kernel 5.15

xfsprogs-5.14.2 (06 Dec 2021)
	- libxfs: move rogue fallthrough macro out of linux.h (Darrick J. Wong)

xfsprogs-5.14.1 (02 Dec 2021)
	- libxfs: fix atomic64_t for 32-bit architectures (Darrick J. Wong)
	- libfrog: fix crc32c self test code on cross builds (Darrick J. Wong)

xfsprogs-5.14.0 (19 Nov 2021)
	- debian: Fix FTBFS (Boian Bonev)
	- debian: Pass --build and --host to configure (Bastian Germann)
	- debian: Update Uploaders list (Bastian Germann)

xfsprogs-5.14.0-rc1 (12 Nov 2021)
	- xfsprogs: introduce liburcu support (Dave Chinner)
	- xfsprogs: convert atomic to uatomic (Dave Chinner)
	- xfsprogs: convert utilities to use "fallthrough;" (Darrick J. Wong)
	- libxfs: port xfs_set_inode_alloc from kernel (Darrick J. Wong)
	- mkfs: warn about V4 deprecation (Darrick J. Wong)
	- xfs_db: convert agresv to use for_each_perag (Darrick J. Wong)

xfsprogs-5.13.0 (20 Aug 2021)
	- No further changes

xfsprogs-5.13.0-rc1 (02 Aug 2021)
	- mkfs: validate rtextsz hint when rtinherit is set (Darrick J. Wong)
	- xfs_repair: invalidate dirhash when junking dirent (Darrick J. Wong)
	- xfs_repair: validate inherited rtextsz hint alignmt (Darrick J. Wong)
	- xfs_quota: allow truncate of grp & prj quota files (Darrick J. Wong)
	- xfs_io: allow callers to dump fs stats individually (Darrick J. Wong)
	- xfs_io: don't count fsmaps before querying fsmaps (Darrick J. Wong)
	- xfs_io: print header once when dumping fsmap in csv (Darrick J. Wong)
	- xfs_io: clean up the funshare command a bit (Darrick J. Wong)
	- xfs_io: fix broken funshare_cmd usage (Darrick J. Wong)

xfsprogs-5.13.0-rc0 (01 Jul 2021)
	- libxfs changes merged from kernel 5.13

xfsprogs-5.12.0 (21 May 2021)
	- No further changes

xfsprogs-5.12.0-rc1 (07 May 2021)
	- mkfs: don't default to too-large physical sector size (Jeff Moyer)
	- repair: phase 6 speedups (Dave Chinner, Gao Xiang)
	- man: Add dax mount option to man xfs(5) (Carlos Maiolino)
	- xfs_admin: pick up log arguments correctly (Darrick Wong)
	- xfs_growfs: support shrinking unused space (Gao Xiang)
	- libfrog: report inobtcount in geometry (Darrick Wong)
	- xfs_logprint: Fix buffer overflow printing quotaoff (Carlos Maiolino)
	- xfsprogs: include <signal.h> for platform_crash (Leah Neukirchen)
	- xfsprogs: remove BMV_IF_NO_DMAPI_READ flag (Anthony Iliopoulos)
	- workqueue: bound maximum queue depth (Dave Chinner)

xfsprogs-5.12.0-rc0 (12 Apr 2021)
	- libxfs changes merged from kernel 5.12

xfsprogs-5.11.0 (12 Mar 2021)
	- xfs_admin: don't hide xfs_repair output when upgrading (Darrick Wong)
	- man: document attr2, ikeep option deprecation in xfs.5 (Pavel Reichl)

xfsprogs-5.11.0-rc1 (23 Feb 2021)
	- mkfs: make use of xfs_validate_stripe_geometry() (Gao Xiang)
	- mkfs: fix wrong inobtcount usage error output (Zorro Lang)
	- xfs_repair: enable bigtime upgrade via repair (Darrick J. Wong)
	- xfs_repair: enable inobtcount upgrade via repair (Darrick J. Wong)
	- xfs_repair: set NEEDSREPAIR on first write (Darrick J. Wong)
	- xfs_repair: clear the needsrepair flag when done (Darrick J. Wong)
	- xfs_repair: check dquot id and type (Darrick J. Wong)
	- xfs_fsr: Verify bulkstat version in qsort's cmp() (Chandan Babu R)
	- xfs_fsr: Interpret args of qsort's cmp() correctly (Chandan Babu R)
	- xfs_scrub: load and unload libicu properly (Darrick J. Wong)
	- xfs_scrub: various fixes (Darrick J. Wong)
	- xfs_admin: support adding features to V5 filesystems (Darrick J. Wong)
	- xfs_admin: support filesystems with realtime devices (Darrick J. Wong)
	- man: mark all deprecated V4 format options (Darrick J. Wong)
	- misc: fix valgrind complaints (Darrick J. Wong)
	- xfs_db: disallow label/uuid setting if NEEDSREPAIR (Darrick J. Wong)
	- xfs_db: show NEEDSREPAIR in check & version commands (Darrick J. Wong)
	- xfs_db: add an ls command (Darrick J. Wong)
	- xfs_db: add a directory path lookup command (Darrick J. Wong)

xfsprogs-5.11.0-rc0 (12 Feb 2021)
	- libxfs changes merged from kernel 5.11
	- Debian packaging fixes (Bastian Germann)

xfsprogs-5.10.0 (11 Dec 2020)
	- xfs_repair: remove old code for mountpoint inodes (Anthony Iliopoulos)

xfsprogs-5.10.0-rc1 (04 Dec 2020)
	- xfsprogs: Add inode btree counter feature (Darrick Wong)
	- xfsprogs: Add bigtime feature for Y2038 (Darrick Wong)
	- xfsprogs: Polish translation update (Jakub Bogusz)
	- mkfs.xfs: Add config file feature (Dave Chinner)
	- mkfs.xfs: allow users to specify rtinherit=0 (Darrick Wong)
	- xfs_repair: simplify bmap_next_offset (Christoph Hellwig)
	- man: various manpage updates (Eric Sandeen)
	- libxfs: remove some old dead code (Dave Chinner)
	- libxfs: add realtime extent tracking (Darrick Wong)

xfsprogs-5.10.0-rc0 (17 Nov 2020)
	- libxfs changes merged from kernel 5.10
```