### PR TITLE
mariadb: fix gcc 13 building

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
 PKG_VERSION:=10.9.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := https://archive.mariadb.org/$(PKG_NAME)-$(PKG_VERSION)/source

--- a/utils/mariadb/patches/300-gcc-13-compatibility-fix.patch
+++ b/utils/mariadb/patches/300-gcc-13-compatibility-fix.patch
@@ -1,0 +1,10 @@
+--- a/tpool/aio_liburing.cc
++++ b/tpool/aio_liburing.cc
+@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fi
+ #include <algorithm>
+ #include <vector>
+ #include <thread>
++#include <stdexcept>
+ #include <mutex>
+ 
+ namespace


### PR DESCRIPTION
fixes this error with gcc 13:

```
- Configuring done (51.2s)
-- Generating done (0.3s)
-- Build files have been written to: /usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3
touch /usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/.configured_73ad54549cf584414d16280358124567
rm -f /usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/.built
touch /usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/.built_check
MAKEFLAGS="" /usr/src/openwrt/staging_dir/host/bin/ninja  -j1 -C /usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3 
ninja: Entering directory `/usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3'
[88/1406] Building C object libmariadb/libmariadb/CMakeFiles/mariadb_obj.dir/__/plugins/pvio/pvio_socket.c.o
In file included from /usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/libmariadb/plugins/pvio/pvio_socket.c:42:
/usr/src/openwrt/staging_dir/toolchain-x86_64_gcc-13.1.0_musl/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
    1 | #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
      |  ^~~~~~~
[397/1406] Building CXX object tpool/CMakeFiles/tpool.dir/aio_liburing.cc.o
FAILED: tpool/CMakeFiles/tpool.dir/aio_liburing.cc.o 
/usr/src/openwrt/staging_dir/toolchain-x86_64_gcc-13.1.0_musl/bin/x86_64-openwrt-linux-musl-g++ -DDBUG_TRACE -DHAVE_CONFIG_H -DHAVE_URING -D_FILE_OFFSET_BITS=64 -I/usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/wsrep-lib/include -I/usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/wsrep-lib/wsrep-API/v26 -I/usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/include -I/usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/include/providers -I/usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/tpool -Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -fmacro-prefix-map=/usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3=mariadb-10.9.3 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro   -I/usr/src/openwrt/staging_dir/toolchain-x86_64_gcc-13.1.0_musl/usr/include -I/usr/src/openwrt/staging_dir/toolchain-x86_64_gcc-13.1.0_musl/include/fortify -I/usr/src/openwrt/staging_dir/toolchain-x86_64_gcc-13.1.0_musl/include -DNDEBUG -DDBUG_OFF -std=gnu++11 -DHAVE_IO_URING_MLOCK_SIZE -MD -MT tpool/CMakeFiles/tpool.dir/aio_liburing.cc.o -MF tpool/CMakeFiles/tpool.dir/aio_liburing.cc.o.d -o tpool/CMakeFiles/tpool.dir/aio_liburing.cc.o -c /usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/tpool/[aio_liburing.cc](http://aio_liburing.cc/)
/usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/tpool/[aio_liburing.cc](http://aio_liburing.cc/): In constructor '{anonymous}::aio_uring::aio_uring(tpool::thread_pool*, int)':
/usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/tpool/[aio_liburing.cc:64](http://aio_liburing.cc:64/):18: error: 'runtime_error' is not a member of 'std'
   64 |       throw std::runtime_error("aio_uring()");
      |                  ^~~~~~~~~~~~~
/usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/tpool/[aio_liburing.cc:26](http://aio_liburing.cc:26/):1: note: 'std::runtime_error' is defined in header '<stdexcept>'; did you forget to '#include <stdexcept>'?
   25 | #include <thread>
  +++ |+#include <stdexcept>
   26 | #include <mutex>
/usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/tpool/[aio_liburing.cc](http://aio_liburing.cc/): In function 'tpool::aio* tpool::create_linux_aio(thread_pool*, int)':
/usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/tpool/[aio_liburing.cc:203](http://aio_liburing.cc:203/):17: error: 'runtime_error' in namespace 'std' does not name a type
  203 |   } catch (std::runtime_error& error) {
      |                 ^~~~~~~~~~~~~
/usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/tpool/[aio_liburing.cc:203](http://aio_liburing.cc:203/):12: note: 'std::runtime_error' is defined in header '<stdexcept>'; did you forget to '#include <stdexcept>'?
  203 |   } catch (std::runtime_error& error) {
      |            ^~~
ninja: build stopped: subcommand failed.
make[2]: *** [Makefile:544: /usr/src/openwrt/build_dir/target-x86_64_musl/mariadb-10.9.3/.built] Error 1
make[2]: Leaving directory '/usr/src/openwrt/feeds/packages/utils/mariadb'
time: package/feeds/packages/mariadb/compile#112.39#20.63#0.00
    ERROR: package/feeds/packages/mariadb failed to build.
```
Maintainer: @miska
Compile tested: x86_64/latest git
Run tested: none

Description:
Build fails with gcc 13.