### PR TITLE
gnutls: fix build with zabbix

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
 PKG_VERSION:=3.8.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_BUILD_FLAGS:=no-mips16
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz

--- a/libs/gnutls/patches/040-build-use-clang-format-on-off-annotation.patch
+++ b/libs/gnutls/patches/040-build-use-clang-format-on-off-annotation.patch
@@ -1,0 +1,490 @@
+From 18345986e29c820e64daced78232f236fd4a4e6e Mon Sep 17 00:00:00 2001
+From: Daiki Ueno <ueno@gnu.org>
+Date: Thu, 16 Mar 2023 16:21:37 +0900
+Subject: [PATCH] build: use /* clang-format {on|off} */ annotation
+
+Signed-off-by: Daiki Ueno <ueno@gnu.org>
+---
+ lib/includes/gnutls/abstract.h    |  4 ----
+ lib/includes/gnutls/compat.h      |  4 ----
+ lib/includes/gnutls/crypto.h      |  4 ----
+ lib/includes/gnutls/dtls.h        |  4 ----
+ lib/includes/gnutls/gnutls.h.in   | 18 ++++++++----------
+ lib/includes/gnutls/ocsp.h        |  4 ----
+ lib/includes/gnutls/openpgp.h     |  4 ----
+ lib/includes/gnutls/pkcs11.h      |  4 ----
+ lib/includes/gnutls/pkcs12.h      |  4 ----
+ lib/includes/gnutls/pkcs7.h       |  4 ----
+ lib/includes/gnutls/socket.h      |  4 ----
+ lib/includes/gnutls/system-keys.h |  4 ----
+ lib/includes/gnutls/tpm.h         |  4 ----
+ lib/includes/gnutls/urls.h        |  4 ----
+ lib/includes/gnutls/x509-ext.h    |  4 ----
+ lib/includes/gnutls/x509.h        |  4 ----
+ tests/test-chains-issuer-aia.h    |  4 ----
+ tests/test-chains.h               |  4 ----
+ 18 files changed, 8 insertions(+), 78 deletions(-)
+
+--- a/lib/includes/gnutls/abstract.h
++++ b/lib/includes/gnutls/abstract.h
+@@ -30,11 +30,9 @@
+ # include <gnutls/openpgp.h>
+ # include <gnutls/tpm.h>
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ /* Public key operations */
+ 
+@@ -748,10 +746,8 @@ gnutls_pubkey_print(gnutls_pubkey_t pubk
+ 		    gnutls_certificate_print_formats_t format,
+ 		    gnutls_datum_t * out);
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ #endif				/* GNUTLS_ABSTRACT_H */
+--- a/lib/includes/gnutls/compat.h
++++ b/lib/includes/gnutls/compat.h
+@@ -25,11 +25,9 @@
+ #ifndef GNUTLS_COMPAT_H
+ # define GNUTLS_COMPAT_H
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ # ifdef __GNUC__
+ 
+@@ -228,10 +226,8 @@ int gnutls_priority_compression_list(gnu
+ 				     const unsigned int **list)
+     _GNUTLS_GCC_ATTR_DEPRECATED;
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ #endif				/* GNUTLS_COMPAT_H */
+--- a/lib/includes/gnutls/crypto.h
++++ b/lib/includes/gnutls/crypto.h
+@@ -25,11 +25,9 @@
+ 
+ # include <gnutls/gnutls.h>
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ typedef struct api_cipher_hd_st *gnutls_cipher_hd_t;
+ 
+@@ -335,10 +333,8 @@ int gnutls_encode_gost_rs_value(gnutls_d
+ int gnutls_decode_gost_rs_value(const gnutls_datum_t * sig_value,
+ 				gnutls_datum_t * r, gnutls_datum_t * s);
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ #endif				/* GNUTLS_CRYPTO_H */
+--- a/lib/includes/gnutls/dtls.h
++++ b/lib/includes/gnutls/dtls.h
+@@ -29,11 +29,9 @@
+ 
+ # include <gnutls/gnutls.h>
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ # define GNUTLS_COOKIE_KEY_SIZE 16
+ 
+@@ -84,10 +82,8 @@ void gnutls_dtls_prestate_set(gnutls_ses
+ 
+ unsigned int gnutls_record_get_discarded(gnutls_session_t session);
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ #endif				/* GNUTLS_DTLS_H */
+--- a/lib/includes/gnutls/gnutls.h.in
++++ b/lib/includes/gnutls/gnutls.h.in
+@@ -45,19 +45,19 @@
+ /* Get time_t. */
+ # include <time.h>
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ # define GNUTLS_VERSION "@VERSION@"
+ 
+-# define GNUTLS_VERSION_MAJOR @MAJOR_VERSION@
+-# define GNUTLS_VERSION_MINOR @MINOR_VERSION@
+-# define GNUTLS_VERSION_PATCH @PATCH_VERSION@
++/* clang-format off */
++#define GNUTLS_VERSION_MAJOR @MAJOR_VERSION@
++#define GNUTLS_VERSION_MINOR @MINOR_VERSION@
++#define GNUTLS_VERSION_PATCH @PATCH_VERSION@
+ 
+-# define GNUTLS_VERSION_NUMBER @NUMBER_VERSION@
++#define GNUTLS_VERSION_NUMBER @NUMBER_VERSION@
++/* clang-format on */
+ 
+ # define GNUTLS_CIPHER_RIJNDAEL_128_CBC GNUTLS_CIPHER_AES_128_CBC
+ # define GNUTLS_CIPHER_RIJNDAEL_256_CBC GNUTLS_CIPHER_AES_256_CBC
+@@ -2365,9 +2365,9 @@ int gnutls_dh_params_cpy(gnutls_dh_param
+ 
+ /* Session stuff
+  */
+-/* *INDENT-OFF* */
++/* clang-format off */
+ @DEFINE_IOVEC_T@
+-/* *INDENT-ON* */
++/* clang-format on */
+ 
+ typedef ssize_t(*gnutls_pull_func) (gnutls_transport_ptr_t, void *, size_t);
+ typedef ssize_t(*gnutls_push_func) (gnutls_transport_ptr_t, const void *,
+@@ -3634,11 +3634,9 @@ gnutls_transport_is_ktls_enabled(gnutls_
+ # define GNUTLS_E_APPLICATION_ERROR_MAX -65000
+ # define GNUTLS_E_APPLICATION_ERROR_MIN -65500
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ # include <gnutls/compat.h>
+ 
+--- a/lib/includes/gnutls/ocsp.h
++++ b/lib/includes/gnutls/ocsp.h
+@@ -29,11 +29,9 @@
+ # include <gnutls/gnutls.h>
+ # include <gnutls/x509.h>
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ # define GNUTLS_OCSP_NONCE "1.3.6.1.5.5.7.48.1.2"
+ 
+@@ -269,10 +267,8 @@ gnutls_ocsp_resp_list_import2(gnutls_ocs
+ 			      const gnutls_datum_t * resp_data,
+ 			      gnutls_x509_crt_fmt_t format, unsigned int flags);
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ #endif				/* GNUTLS_OCSP_H */
+--- a/lib/includes/gnutls/openpgp.h
++++ b/lib/includes/gnutls/openpgp.h
+@@ -30,11 +30,9 @@
+ # include <gnutls/gnutls.h>
+ # include <limits.h>
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ /* Openpgp certificate stuff
+  */
+@@ -424,10 +422,8 @@ int gnutls_certificate_set_openpgp_keyri
+     (gnutls_certificate_credentials_t c, const char *file,
+      gnutls_openpgp_crt_fmt_t format) _GNUTLS_GCC_ATTR_DEPRECATED;
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ #endif				/* GNUTLS_OPENPGP_H */
+--- a/lib/includes/gnutls/pkcs11.h
++++ b/lib/includes/gnutls/pkcs11.h
+@@ -28,11 +28,9 @@
+ # include <gnutls/gnutls.h>
+ # include <gnutls/x509.h>
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ # define GNUTLS_PKCS11_MAX_PIN_LEN 256
+ 
+@@ -491,10 +489,8 @@ gnutls_pkcs11_copy_attached_extension(co
+ 
+ # define gnutls_x509_crt_import_pkcs11_url gnutls_x509_crt_import_url
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ #endif				/* GNUTLS_PKCS11_H */
+--- a/lib/includes/gnutls/pkcs12.h
++++ b/lib/includes/gnutls/pkcs12.h
+@@ -25,11 +25,9 @@
+ 
+ # include <gnutls/x509.h>
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ 	/* PKCS12 structures handling
+ 	 */
+@@ -138,10 +136,8 @@ int gnutls_pkcs12_bag_get_friendly_name(
+ int gnutls_pkcs12_bag_set_friendly_name(gnutls_pkcs12_bag_t bag,
+ 					unsigned indx, const char *name);
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ #endif				/* GNUTLS_PKCS12_H */
+--- a/lib/includes/gnutls/pkcs7.h
++++ b/lib/includes/gnutls/pkcs7.h
+@@ -31,11 +31,9 @@
+ # include <gnutls/gnutls.h>
+ # include <gnutls/x509.h>
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ /* PKCS7 structures handling
+  */
+@@ -149,10 +147,8 @@ int gnutls_pkcs7_print_signature_info(gn
+ 				      gnutls_certificate_print_formats_t format,
+ 				      gnutls_datum_t * out);
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ #endif				/* GNUTLS_PKCS7_H */
+--- a/lib/includes/gnutls/socket.h
++++ b/lib/includes/gnutls/socket.h
+@@ -31,11 +31,9 @@
+ /* Get socklen_t */
+ # include <sys/socket.h>
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ void gnutls_transport_set_fastopen(gnutls_session_t session,
+ 				   int fd,
+@@ -43,10 +41,8 @@ void gnutls_transport_set_fastopen(gnutl
+ 				   socklen_t connect_addrlen,
+ 				   unsigned int flags);
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ #endif				/* GNUTLS_SOCKET_H */
+--- a/lib/includes/gnutls/system-keys.h
++++ b/lib/includes/gnutls/system-keys.h
+@@ -31,11 +31,9 @@
+  * they will be requested through the pin callbacks.
+  */
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ struct system_key_iter_st;
+ typedef struct system_key_iter_st *gnutls_system_key_iter_t;
+@@ -54,10 +52,8 @@ int gnutls_system_key_add_x509(gnutls_x5
+ 			       gnutls_x509_privkey_t privkey, const char *label,
+ 			       char **cert_url, char **key_url);
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ #endif				/* GNUTLS_SYSTEM_KEYS_H */
+--- a/lib/includes/gnutls/tpm.h
++++ b/lib/includes/gnutls/tpm.h
+@@ -26,11 +26,9 @@
+ # include <gnutls/gnutls.h>
+ # include <gnutls/x509.h>
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ struct tpm_key_list_st;
+ typedef struct tpm_key_list_st *gnutls_tpm_key_list_t;
+@@ -71,10 +69,8 @@ int gnutls_tpm_get_registered(gnutls_tpm
+ int gnutls_tpm_privkey_delete(const char *url, const char *srk_password);
+ 
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ #endif				/* GNUTLS_TPM_H */
+--- a/lib/includes/gnutls/urls.h
++++ b/lib/includes/gnutls/urls.h
+@@ -31,11 +31,9 @@
+  * keys and certificates.
+  */
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ typedef int (*gnutls_privkey_import_url_func)(gnutls_privkey_t pkey,
+ 					      const char *url, unsigned flags);
+@@ -71,10 +69,8 @@ typedef struct gnutls_custom_url_st {
+ 
+ int gnutls_register_custom_url(const gnutls_custom_url_st * st);
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ #endif				/* GNUTLS_URLS_H */
+--- a/lib/includes/gnutls/x509-ext.h
++++ b/lib/includes/gnutls/x509-ext.h
+@@ -28,11 +28,9 @@
+ # include <gnutls/gnutls.h>
+ # include <gnutls/x509.h>
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ typedef struct gnutls_subject_alt_names_st *gnutls_subject_alt_names_t;
+ 
+@@ -215,10 +213,8 @@ int gnutls_x509_ct_sct_get(const gnutls_
+ 			   gnutls_sign_algorithm_t * sigalg,
+ 			   gnutls_datum_t * signature);
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ #endif				/* GNUTLS_X509_EXT_H */
+--- a/lib/includes/gnutls/x509.h
++++ b/lib/includes/gnutls/x509.h
+@@ -30,11 +30,9 @@
+ 
+ # include <gnutls/gnutls.h>
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-/* *INDENT-ON* */
+ 
+ /* Some OIDs usually found in Distinguished names, or
+  * in Subject Directory Attribute extensions.
+@@ -1710,10 +1708,8 @@ gnutls_x509_ext_print(gnutls_x509_ext_st
+ 
+ # include <gnutls/pkcs7.h>
+ 
+-/* *INDENT-OFF* */
+ #ifdef __cplusplus
+ }
+ #endif
+-/* *INDENT-ON* */
+ 
+ #endif				/* GNUTLS_X509_H */
+--- a/tests/test-chains-issuer-aia.h
++++ b/tests/test-chains-issuer-aia.h
+@@ -23,8 +23,6 @@
+ #ifndef GNUTLS_TESTS_TEST_CHAINS_ISSUER_AIA_H
+ # define GNUTLS_TESTS_TEST_CHAINS_ISSUER_AIA_H
+ 
+-/* *INDENT-OFF* */
+-
+ #define MAX_CHAIN 1
+ 
+ static const char *missing_cert_aia[] = {
+@@ -132,6 +130,4 @@ static const char *missing_cert_aia_ca[]
+ #  pragma GCC diagnostic pop
+ #endif
+ 
+-/* *INDENT-ON* */
+-
+ #endif				/* GNUTLS_TESTS_TEST_CHAINS_ISSUER_AIA_H */
+--- a/tests/test-chains.h
++++ b/tests/test-chains.h
+@@ -23,8 +23,6 @@
+ #ifndef GNUTLS_TESTS_TEST_CHAINS_H
+ # define GNUTLS_TESTS_TEST_CHAINS_H
+ 
+-/* *INDENT-OFF* */
+-
+ #define MAX_CHAIN 10
+ 
+ static const char *chain_with_no_subject_id_in_ca_ok[] = {
+@@ -4449,6 +4447,4 @@ static struct
+ #  pragma GCC diagnostic pop
+ #endif
+ 
+-/* *INDENT-ON* */
+-
+ #endif				/* GNUTLS_TESTS_TEST_CHAINS_H */


### PR DESCRIPTION
Maintainer: @nmav
Compile tested: rockchip/armv8
Run tested: n/a

Description:
Zabbix verifies the version of gnutls by search in the header gnutls.h. This is done with 'cat' and 'egrep'. The problem here is now that the preprocess definition did changed in gnutls.h, so the regex does not match anymore.

The following error message acourse in the log:
> configure: error: GnuTLS library version requirement not met (>= 3.1.18)

To fix this backport an upstream patch to let the regex work again.

Original PR: https://github.com/openwrt/packages/pull/20967
Cc: @feckert