### PR TITLE
cloudflared: support setting tunnel token

### DIFF
--- a/net/cloudflared/files/cloudflared.init
+++ b/net/cloudflared/files/cloudflared.init
@@ -31,6 +31,7 @@ start_service() {
 	append_param_arg "logfile"
 
 	procd_append_param command "run"
+	append_param_arg "token"
 
 	procd_set_param respawn
 	procd_set_param stderr 1


### PR DESCRIPTION
Maintainer: @1715173329 
Compile tested: N/A no compilation related changes
Run tested: N/A

Description:
Allows user to provide a token for Cloudflare tunnel. When provided along with credentials, this will take precedence.