### PR TITLE
evtest: don't build man page

### DIFF
--- a/utils/evtest/Makefile
+++ b/utils/evtest/Makefile
@@ -25,6 +25,8 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
+CONFIGURE_VARS += ac_cv_path_ASCIIDOC="" ac_cv_path_XMLTO=""
+
 define Package/evtest
   SECTION:=utils
   CATEGORY:=Utilities


### PR DESCRIPTION
Maintainer: @psidhu
Compile tested: mxs
Run tested: -

Description:

Just selecting this package resulted in a build error:

/home/mhei/openwrt.git/staging_dir/hostpkg/bin/python3: No module named asciidoc
make[4]: *** [Makefile:856: evtest.xml] Error 1

Since we usually do not need the man page, just prevent to build it by pre-setting two environments variables. Then the makefile warns about, but don't try to build.
