### PR TITLE
gensio: Fix build on build host with Go compiler

### DIFF
--- a/net/gensio/Makefile
+++ b/net/gensio/Makefile
@@ -45,6 +45,7 @@ CONFIGURE_ARGS += \
 	--$(if $(CONFIG_GENSIO_PTHREADS),with,without)-pthreads \
 	--$(if $(CONFIG_GENSIO_GLIB),with,without)-glib \
 	--$(if $(CONFIG_GENSIO_TCL),with,without)-tcl \
+	--without-go \
 	--without-openipmi \
 	--with-cplusplus \
 	--disable-doc


### PR DESCRIPTION
Maintainer: @WereCatf 
Compile tested: armvirt-32, 2023-05-15 snapshot sdk
Run tested: none

Description:
If the build host has the Go compiler installed, then configure will detect this and will try to compile gensio's Go support, leading to a build failure.

This disables Go support entirely to fix this build failure.