### PR TITLE
ocserv: add otp config option

### DIFF
--- a/net/ocserv/Config.in
+++ b/net/ocserv/Config.in
@@ -16,6 +16,10 @@ config OCSERV_RADIUS
 	bool "enable radius authentication"
 	default n
 
+config OCSERV_LIBOATH
+	bool "enable OTP"
+	default n
+
 config OCSERV_PROTOBUF
 	bool "use external libprotobuf"
 	default y

--- a/net/ocserv/Makefile
+++ b/net/ocserv/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ocserv
 PKG_VERSION:=1.1.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_BUILD_FLAGS:=no-mips16
 
 PKG_BUILD_DIR :=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
@@ -39,7 +39,7 @@ define Package/ocserv
   TITLE:=OpenConnect VPN server
   URL:=http://www.infradead.org/ocserv/
   MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
-  DEPENDS:= +OCSERV_RADIUS:libradcli +OCSERV_HTTP_PARSER:libhttp-parser +OCSERV_SECCOMP:libseccomp +libgnutls +certtool +libncurses +libreadline +OCSERV_PAM:libpam +OCSERV_PROTOBUF:libprotobuf-c +libev +kmod-tun
+  DEPENDS:= +OCSERV_RADIUS:libradcli +OCSERV_HTTP_PARSER:libhttp-parser +OCSERV_SECCOMP:libseccomp +libgnutls +certtool +libncurses +libreadline +OCSERV_PAM:libpam +OCSERV_PROTOBUF:libprotobuf-c +OCSERV_LIBOATH:oath-toolkit +libev +kmod-tun
   USERID:=ocserv=72:ocserv=72
 endef
 
@@ -87,6 +87,10 @@ endif
 
 ifneq ($(CONFIG_OCSERV_HTTP_PARSER),y)
 CONFIGURE_ARGS += --without-http-parser
+endif
+
+ifndef CONFIG_OCSERV_LIBOATH
+CONFIGURE_ARGS += --without-liboath
 endif
 
 define Package/ocserv/conffiles


### PR DESCRIPTION
Maintainer: @nmav
Compile tested: arm cortex-a7 ipq40xx, p2w_r619ac-128m, OpenWrt 22.03
Run tested: arm cortex-a7 ipq40xx, p2w_r619ac-128m, OpenWrt 22.03

Description:
Add option enable OTP feature and also fix build error in 
https://github.com/openwrt/packages/pull/21035#issuecomment-1554311549

when enable OCSERV_LIBOATH :
```
configure:
Summary of build options:
  version:              1.1.7
  Host type:            arm-openwrt-linux-gnu
  Install prefix:       /usr
  Compiler:             arm-openwrt-linux-muslgnueabi-gcc
  CFlags:               -Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -mfloat-abi=hard -fmacro-prefix-map=/mnt/openwrtZone/opmaster/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/ocserv-1.1.7=ocserv-1.1.7 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro  -Wall -Wno-strict-aliasing -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers -Wno-implicit-fallthrough -Wno-stringop-truncation
  CWrap testing:        no
  CWrap PAM testing:    no
  CWrap NSS testing:    no

  PAM auth backend:     no
  Radius auth backend:  no
  GSSAPI auth backend:  no
  OIDC Auth backend:    no
  Anyconnect compat:    yes
  TCP wrappers:         no
  namespaces:           yes
  systemd:              no
  (socket activation)
  worker isolation:     none
  Compression:          yes
  LZ4 compression:      no
  readline:             yes
  libnl3:               
  liboath:              yes
  libgeoip:             no
  libmaxminddb:         no
  glibc (sha2crypt):    no
  local talloc:         yes
  local protobuf-c:     no
  local PCL library:    yes
  local http-parser:    no
  seccomp trap:		no
  capture latency stats no
```

Default: 
```
configure:
Summary of build options:
  version:              1.1.7
  Host type:            arm-openwrt-linux-gnu
  Install prefix:       /usr
  Compiler:             arm-openwrt-linux-muslgnueabi-gcc
  CFlags:               -Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -mfloat-abi=hard -fmacro-prefix-map=/mnt/openwrtZone/opmaster/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/ocserv-1.1.7=ocserv-1.1.7 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro  -Wall -Wno-strict-aliasing -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers -Wno-implicit-fallthrough -Wno-stringop-truncation
  CWrap testing:        no
  CWrap PAM testing:    no
  CWrap NSS testing:    no

  PAM auth backend:     no
  Radius auth backend:  no
  GSSAPI auth backend:  no
  OIDC Auth backend:    no
  Anyconnect compat:    yes
  TCP wrappers:         no
  namespaces:           yes
  systemd:              no
  (socket activation)
  worker isolation:     none
  Compression:          yes
  LZ4 compression:      no
  readline:             yes
  libnl3:               
  liboath:              no
  libgeoip:             no
  libmaxminddb:         no
  glibc (sha2crypt):    no
  local talloc:         yes
  local protobuf-c:     no
  local PCL library:    yes
  local http-parser:    no
  seccomp trap:		no
  capture latency stats no
```
