### PR TITLE
ocserv: disable liboath detection

### DIFF
--- a/net/ocserv/Makefile
+++ b/net/ocserv/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ocserv
 PKG_VERSION:=1.1.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_BUILD_FLAGS:=no-mips16
 
 PKG_BUILD_DIR :=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
@@ -62,6 +62,7 @@ CONFIGURE_ARGS+= \
 	--with-pager="" \
 	--with-libreadline-prefix="$(STAGING_DIR)/" \
 	--without-libnl \
+	--without-liboath \
 	--without-gssapi \
 	--without-maxmind \
 	--with-libcrypt-prefix="$(STAGING_DIR)/" \


### PR DESCRIPTION
Disable liboath detection to fix a build error due to missing dependency.
(the liboath library is now detected, but is unncessary.)

Maintainer: @nmav
Compile tested: rockchip/armv8
Run tested: n/a