### PR TITLE
oath-toolkit and ocserv: Adjusting dependencies, split liboath from oath-toolkit, add oath pam module

### DIFF
--- a/net/ocserv/Config.in
+++ b/net/ocserv/Config.in
@@ -16,6 +16,10 @@ config OCSERV_RADIUS
 	bool "enable radius authentication"
 	default n
 
+config OCSERV_LIBOATH
+	bool "enable OTP"
+	default n
+
 config OCSERV_PROTOBUF
 	bool "use external libprotobuf"
 	default y

--- a/net/ocserv/Makefile
+++ b/net/ocserv/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ocserv
 PKG_VERSION:=1.1.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_BUILD_FLAGS:=no-mips16
 
 PKG_BUILD_DIR :=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
@@ -39,7 +39,7 @@ define Package/ocserv
   TITLE:=OpenConnect VPN server
   URL:=http://www.infradead.org/ocserv/
   MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
-  DEPENDS:= +OCSERV_RADIUS:libradcli +OCSERV_HTTP_PARSER:libhttp-parser +OCSERV_SECCOMP:libseccomp +libgnutls +certtool +libncurses +libreadline +OCSERV_PAM:libpam +OCSERV_PROTOBUF:libprotobuf-c +libev +kmod-tun
+  DEPENDS:= +OCSERV_RADIUS:libradcli +OCSERV_HTTP_PARSER:libhttp-parser +OCSERV_SECCOMP:libseccomp +libgnutls +certtool +libncurses +libreadline +OCSERV_PAM:libpam +OCSERV_PROTOBUF:libprotobuf-c +OCSERV_LIBOATH:liboath +libev +kmod-tun
   USERID:=ocserv=72:ocserv=72
 endef
 
@@ -87,6 +87,10 @@ endif
 
 ifneq ($(CONFIG_OCSERV_HTTP_PARSER),y)
 CONFIGURE_ARGS += --without-http-parser
+endif
+
+ifndef CONFIG_OCSERV_LIBOATH
+CONFIGURE_ARGS += --without-liboath
 endif
 
 define Package/ocserv/conffiles

--- a/utils/oath-toolkit/Makefile
+++ b/utils/oath-toolkit/Makefile
@@ -36,6 +36,14 @@ define Package/liboath
   URL:=http://www.nongnu.org/oath-toolkit/index.html
 endef
 
+define Package/oath-pam
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=The oath PAM module
+  URL:=http://www.nongnu.org/oath-toolkit/index.html
+  DEPENDS:= +libpam +liboath
+endef
+
 define Package/oath-toolkit
   SECTION:=utils
   CATEGORY:=Utilities
@@ -51,6 +59,8 @@ define Package/liboath/description
   HOTP algorithm (RFC4226) and the time-based TOTP algorithm (RFC6238).
 endef
 
+Package/oath-pam/description = $(Package/liboath/description)
+
 Package/oath-toolkit/description = $(Package/liboath/description)
 
 define Build/InstallDev
@@ -65,10 +75,16 @@ define Package/liboath/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liboath.so* $(1)/usr/lib/
 endef
 
+define Package/oath-pam/install
+	$(INSTALL_DIR) $(1)/usr/lib/security
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/security/pam_oath.so* $(1)/usr/lib/security/
+endef
+
 define Package/oath-toolkit/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/oathtool $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,liboath))
+$(eval $(call BuildPackage,oath-pam))
 $(eval $(call BuildPackage,oath-toolkit))

--- a/utils/oath-toolkit/Makefile
+++ b/utils/oath-toolkit/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=oath-toolkit
 PKG_VERSION:=2.6.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SAVANNAH/oath-toolkit
@@ -29,20 +29,29 @@ CONFIGURE_ARGS += \
 	--disable-xmltest \
 	--disable-pskc
 
+define Package/liboath
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=A shared and static C library for OATH handling
+  URL:=http://www.nongnu.org/oath-toolkit/index.html
+endef
+
 define Package/oath-toolkit
   SECTION:=utils
   CATEGORY:=Utilities
-  TITLE:=Toolkit for building one-time password authentication
+  TITLE:=A command line tool for generating and validating OTPs
   URL:=http://www.nongnu.org/oath-toolkit/index.html
-  DEPENDS:=
+  DEPENDS:= +liboath
 endef
 
-define Package/oath-toolkit/description
-	The OATH Toolkit provide components for building one-time password
-	authentication systems. It contains shared libraries, command line
-	tools and a PAM module. Supported technologies include the event-based
-	HOTP algorithm (RFC4226) and the time-based TOTP algorithm (RFC6238).
+define Package/liboath/description
+  The OATH Toolkit provide components for building one-time password
+  authentication systems. It contains shared libraries, command line
+  tools and a PAM module. Supported technologies include the event-based
+  HOTP algorithm (RFC4226) and the time-based TOTP algorithm (RFC6238).
 endef
+
+Package/oath-toolkit/description = $(Package/liboath/description)
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/liboath
@@ -51,11 +60,15 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
 endef
 
-define Package/oath-toolkit/install
-	$(INSTALL_DIR) $(1)/usr/bin
+define Package/liboath/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/oathtool $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liboath.so* $(1)/usr/lib/
 endef
 
+define Package/oath-toolkit/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/oathtool $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,liboath))
 $(eval $(call BuildPackage,oath-toolkit))


### PR DESCRIPTION
Maintainer: @nmav, @famz 
Compile tested: arm cortex-a7 ipq40xx, p2w_r619ac-128m, OpenWrt 22.03
Run tested: arm cortex-a7 ipq40xx, p2w_r619ac-128m, OpenWrt 22.03

Description:
base on https://github.com/openwrt/packages/pull/21111#issuecomment-1554902135 and https://github.com/openwrt/packages/pull/21035#issuecomment-1554311549

Split liboath from oath-toolkit (from @1715173329 )
Add option enable OTP feature and also fix build error
Add oath PAM authentication module
