### PR TITLE
transmission: add missing nls.mk include

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -34,6 +34,7 @@ PKG_CONFIG_DEPENDS:= \
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 include $(INCLUDE_DIR)/package-seccomp.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/transmission/template
   SUBMENU:=BitTorrent


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: OpenWrt r22977, built on x86-64 Gentoo Linux
Run tested: bcm27xx, Raspberry Pi 3B+, 64bit

Description:
Fixes issue #21016.