### PR TITLE
dos2unix: Update to 7.5.0

### DIFF
--- a/utils/dos2unix/Makefile
+++ b/utils/dos2unix/Makefile
@@ -5,13 +5,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dos2unix
-PKG_VERSION:=7.4.4
+PKG_VERSION:=7.5.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://waterlan.home.xs4all.nl/dos2unix/ \
                 @SF/dos2unix
-PKG_HASH:=28a841db0bd5827d645caba9d8015e3a71983dc6e398070b5287ee137ae4436e
+PKG_HASH:=7a3b01d01e214d62c2b3e04c3a92e0ddc728a385566e4c0356efa66fd6eb95af
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=BSD-2-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8
Run tested: n/a

Description:
```
2023-05-17 Erwin Waterlander <waterlan@xs4all.nl>
	* Version 7.5.0

2023-04-16 Erwin Waterlander <waterlan@xs4all.nl>
	* New option -O, --to-stdout to write to standard output.
	  Thanks to Victor.

2023-04-06 Erwin Waterlander <waterlan@xs4all.nl>
	* New option -e, --add-eol to add a line break to the last
	  line if there isn't one. Option --no-add-eol disables the
	  feature. Thanks to Anonymous.
	  See https://sourceforge.net/p/dos2unix/feature-requests/6/
```
