### PR TITLE
curl: update to 8.1.0

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
-PKG_VERSION:=8.0.1
+PKG_VERSION:=8.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -17,7 +17,7 @@ PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,
 	https://dl.uxnr.de/mirror/curl/ \
 	https://curl.askapache.com/download/ \
 	https://curl.se/download/
-PKG_HASH:=0a381cd82f4d00a9a334438b8ca239afea5bfefcfa9a1025f2bf118e79e0b5f0
+PKG_HASH:=6bd80ad4f07187015911216ee7185b90d285ac5162aed1bded144f9f93232a3c
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
@@ -26,7 +26,6 @@ PKG_CPE_ID:=cpe:/a:haxx:libcurl
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_FLAGS:=gc-sections
 
 PKG_CONFIG_DEPENDS:= \
   CONFIG_IPV6 \
@@ -108,6 +107,7 @@ endef
 
 TARGET_CFLAGS += $(FPIC)
 TARGET_CPPFLAGS += $(if $(CONFIG_LIBCURL_NTLM),,-DCURL_DISABLE_NTLM)
+TARGET_LDFLAGS += -Wl,--gc-sections
 
 CONFIGURE_ARGS += \
 	--disable-debug \

--- a/net/curl/patches/200-no_docs_tests.patch
+++ b/net/curl/patches/200-no_docs_tests.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -158,7 +158,7 @@ CLEANFILES = $(VC10_LIBVCXPROJ) $(VC10_S
+@@ -159,7 +159,7 @@ CLEANFILES = $(VC10_LIBVCXPROJ) $(VC10_S
  bin_SCRIPTS = curl-config
  
  SUBDIRS = lib src
@@ -9,7 +9,7 @@
  
  pkgconfigdir = $(libdir)/pkgconfig
  pkgconfig_DATA = libcurl.pc
-@@ -272,8 +272,6 @@ cygwinbin:
+@@ -273,8 +273,6 @@ cygwinbin:
  # We extend the standard install with a custom hook:
  install-data-hook:
  	(cd include && $(MAKE) install)


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 22.03.5
Run tested: x86_64, Sophos XG-135r3, OpenWrt 22.03.5, test resolution from https-dns-proxy

