### PR TITLE
openelp: Add new package

### DIFF
--- a/net/openelp/Makefile
+++ b/net/openelp/Makefile
@@ -1,0 +1,73 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=openelp
+PKG_VERSION:=0.9.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/cottsay/openelp/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=1427a2fe6f22856a66b9c687d7f14b7915abeeed64951ae596084f9366ec4256
+
+PKG_MAINTAINER:=Scott K Logan <logans@cottsay.net>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/libopenelp
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Open Source EchoLink Proxy Library
+  URL:=https://github.com/cottsay/openelp
+  DEPENDS:=+libpcre2
+  ABI_VERSION:=0
+endef
+
+define Package/openelp
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Open Source EchoLink Proxy
+  URL:=https://github.com/cottsay/openelp
+  DEPENDS:=+libopenelp
+endef
+
+define Package/libopenelp/description
+  Library backing OpenELP - an open source EchoLink proxy.
+endef
+
+define Package/openelp/description
+  OpenELP is an open source EchoLink proxy for Linux and Windows. It aims
+  to be efficient and maintain a small footprint, while still implementing
+  all of the features present in the official EchoLink proxy.
+
+  OpenELP also has the ability to bind to multiple network interfaces
+  which are routed to unique external IP addresses, and therefore is
+  capable of accepting connections from multiple clients simultaneously.
+endef
+
+CMAKE_OPTIONS += \
+  -DSYSCONF_INSTALL_DIR=/etc
+
+define Package/openelp/conffiles
+/etc/ELProxy.conf
+endef
+
+define Package/libopenelp/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libopenelp.so.* $(1)/usr/lib/
+endef
+
+define Package/openelp/install
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/ELProxy.conf $(1)/etc/
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/openelpd $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/openelp.init $(1)/etc/init.d/openelp
+endef
+
+$(eval $(call BuildPackage,libopenelp))
+$(eval $(call BuildPackage,openelp))

--- a/net/openelp/files/openelp.init
+++ b/net/openelp/files/openelp.init
@@ -1,0 +1,30 @@
+#!/bin/sh /etc/rc.common
+
+START=90
+STOP=10
+
+USE_PROCD=1
+
+NAME="openelp"
+PROG="/usr/bin/openelpd"
+CONFFILE="/etc/ELProxy.conf"
+
+extra_command "close" "Close the proxy to new connections"
+extra_command "version" "Show version information"
+
+start_service() {
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_append_param command -F -q -S "$CONFFILE"
+	procd_set_param stderr 1
+	procd_set_param file "$CONFFILE"
+	procd_close_instance
+}
+
+close() {
+	procd_send_signal openelp '*' USR1
+}
+
+version() {
+	"$PROG" -V
+}

--- a/net/openelp/test.sh
+++ b/net/openelp/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+case "$1" in
+	"openelp")
+		openelpd -V | grep "$2"
+		;;
+esac


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, OpenWrt SNAPSHOT, r23051-d6fef27f2dd4
Run tested: x86_64, OpenWrt SNAPSHOT, r23051-d6fef27f2dd4

Description:
OpenELP is an open source EchoLink proxy for Linux and Windows. It aims to be efficient and maintain a small footprint, while still implementing all of the features present in the official EchoLink proxy.

I am the upstream author and maintainer of this software.