### PR TITLE
openvpn-easy-rsa: update to 3.1.3

### DIFF
--- a/net/openvpn-easy-rsa/Makefile
+++ b/net/openvpn-easy-rsa/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn-easy-rsa
 
-PKG_VERSION:=3.0.8
-PKG_RELEASE:=4
+PKG_VERSION:=3.1.3
+PKG_RELEASE:=1
 PKG_SOURCE_URL:=https://codeload.github.com/OpenVPN/easy-rsa/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=fd6b67d867c3b8afd53efa2ca015477f6658a02323e1799432083472ac0dd200
+PKG_HASH:=f2967aa598cb603dd20791002e767d0ce58e300b04c9cff1b6d6b14fedae6a80
 
 # For git snapshots
 #PKG_SOURCE_PROTO:=git

--- a/net/openvpn-easy-rsa/patches/100-Make-package-reproducible.patch
+++ b/net/openvpn-easy-rsa/patches/100-Make-package-reproducible.patch
@@ -10,8 +10,8 @@ Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
 
 --- a/build/build-dist.sh
 +++ b/build/build-dist.sh
-@@ -80,7 +80,7 @@ stage_unix() {
- 	
+@@ -86,7 +86,7 @@ stage_unix() {
+ 
  	# FreeBSD does not accept -i without argument in a way also acceptable by GNU sed
  	sed -i.tmp -e "s/~VER~/$VERSION/" \
 -		   -e "s/~DATE~/$(date)/" \
@@ -19,9 +19,9 @@ Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
  		   -e "s/~HOST~/$(hostname -s)/" \
  		   -e "s/~GITHEAD~/$(git rev-parse HEAD)/" \
  		   "$DIST_ROOT/unix/$PV/easyrsa" || die "Cannot update easyrsa version data"
-@@ -122,7 +122,7 @@ stage_win() {
+@@ -128,7 +128,7 @@ stage_win() {
  		done
- 	
+ 
  		sed -i.tmp -e "s/~VER~/$VERSION/" \
 -			   -e "s/~DATE~/$(date)/" \
 +			   -e "s/~DATE~/$(SOURCE_DATE_EPOCH)/" \


### PR DESCRIPTION
Version 3.0.9 of EasyRSA introduces OpenSSL 3 (3.0.3) support.

For other changes, see:
- https://github.com/OpenVPN/easy-rsa/releases/tag/v3.0.9
- https://github.com/OpenVPN/easy-rsa/releases/tag/v3.1.0
- https://github.com/OpenVPN/easy-rsa/releases/tag/v3.1.1
- https://github.com/OpenVPN/easy-rsa/releases/tag/v3.1.2
- https://github.com/OpenVPN/easy-rsa/releases/tag/v3.1.3

Closes #21142

Maintainer: me
Compile tested: master on x86/64 (noarch package)
Run tested: x86/64 vm creating a CA with some certs.

Description:
