### PR TITLE
xtables-addons: fix xt_DNETMAP load when netfilter NAT is module

### DIFF
--- a/net/xtables-addons/patches/300-xt-DNETMAP-fix-CONFIG-NF-NAT-module-dependency.patch
+++ b/net/xtables-addons/patches/300-xt-DNETMAP-fix-CONFIG-NF-NAT-module-dependency.patch
@@ -1,0 +1,20 @@
+--- a/extensions/xt_DNETMAP.c
++++ b/extensions/xt_DNETMAP.c
+@@ -20,7 +20,7 @@
+ 
+ #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+ #include <linux/module.h>
+-#ifdef CONFIG_NF_NAT
++#if defined(CONFIG_NF_NAT) || defined(CONFIG_NF_NAT_MODULE)
+ #include <linux/inet.h>
+ #include <linux/ip.h>
+ #include <linux/netdevice.h>
+@@ -915,7 +915,7 @@ static void __exit dnetmap_tg_exit(void)
+ 	xt_unregister_target(&dnetmap_tg_reg);
+ 	unregister_pernet_subsys(&dnetmap_net_ops);
+ }
+-#else /* CONFIG_NF_NAT */
++#else /* CONFIG_NF_NAT || CONFIG_NF_NAT_MODULE */
+ static int __init dnetmap_tg_init(void)
+ {
+ 	pr_err("CONFIG_NF_NAT is not available in your kernel, hence this module cannot function.");


### PR DESCRIPTION
Maintainer: @jow-
Compile tested: ipq807x/Xiaomi AX3600 on snapshot
Run tested: ipq807x/Xiaomi AX3600 on snapshot

Description:
The xt_DNETMAP module fails to load when the netfilter NAT is built as a module.
This fixes the ifdef compile-time check to also account for this scenario.

@Ansuel @pprindeville