### PR TITLE
[openwrt-23.05] borgbackup: Move from lang/python into utils

### DIFF
--- a/utils/borgbackup/Makefile
+++ b/utils/borgbackup/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=borgbackup
 PKG_VERSION:=1.2.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PYPI_NAME:=borgbackup
 PKG_HASH:=a4bd54e9469e81b7a30a6711423115abc818d9cd844ecb1ca0e6104bc5374da8
@@ -18,15 +18,14 @@ PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Julien Malik <julien.malik@paraiso.me>
 
-include ../pypi.mk
+include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk
-include ../python3-package.mk
+include ../../lang/python/python3-package.mk
 
 # see #20462 and #12942: email and urllib shall come with python3-light
 define Package/borgbackup
-  SECTION:=lang
-  CATEGORY:=Languages
-  SUBMENU:=Python
+  SECTION:=utils
+  CATEGORY:=Utilities
   TITLE:=Deduplicated, encrypted, authenticated and compressed backups
   URL:=https://github.com/borgbackup/borg
   DEPENDS:= \


### PR DESCRIPTION
Maintainer: @julienmalik
Compile tested: none (cherry pick from #21099)
Run tested: none

Description:
lang/python is meant for Python libraries and other packages closely related to the Python language. It makes more sense for borgbackup to be in utils instead.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 5059cfccae8fda6837481569bdf3fff02144d614)