### PR TITLE
https-dns-proxy: fix time_t logging (#19366)

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2022-10-15
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/

--- a/net/https-dns-proxy/patches/030-fix-time_t-logging.patch
+++ b/net/https-dns-proxy/patches/030-fix-time_t-logging.patch
@@ -1,0 +1,13 @@
+--- a/src/logging.c
++++ b/src/logging.c
+@@ -77,8 +77,8 @@ void _log(const char *file, int line, in
+ 
+   struct timeval tv;
+   gettimeofday(&tv, NULL);
+-  fprintf(logf, "%s %8ld.%06ld %s:%d ", SeverityStr[severity], tv.tv_sec,
+-          tv.tv_usec, file, line);
++  fprintf(logf, "%s %8lld.%06lld %s:%d ", SeverityStr[severity], (long long)tv.tv_sec,
++          (long long)tv.tv_usec, file, line);
+ 
+   va_list args;
+   va_start(args, fmt);


### PR DESCRIPTION
There is a problem
"related to the change in time_t (32 bits to 64 bits on a 32 bit system)". This patch fixes fprintf() calls by explicitly casting to 64bit integers.

Maintainer: Stan Grishin <stangri@melmac.ca>
Compile tested: mips_24kc, TP-Link Archer C6 v2, r22998-066441b5e4
Run tested: mips_24kc, TP-Link Archer C6 v2, r22998-066441b5e4
