### PR TITLE
tailscale: update to 1.42.0

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.40.1
+PKG_VERSION:=1.42.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=tailscale-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=9c0a9648c921f695fc501536e69c8b4998d318256c8049de538f72fbe1491c18
+PKG_HASH:=09de9bacda98de8d733cff162572b7eac857d13db783776ba2a2450a44ecc5e9
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/tailscale/patches/010-fake_iptables.patch
+++ b/net/tailscale/patches/010-fake_iptables.patch
@@ -7,8 +7,8 @@
 +replace github.com/coreos/go-iptables => ./patched/go-iptables
 +
  require (
- 	filippo.io/mkcert v1.4.3
- 	github.com/Microsoft/go-winio v0.6.0
+ 	filippo.io/mkcert v1.4.4
+ 	github.com/Microsoft/go-winio v0.6.1
 --- a/patched/go-iptables/iptables/iptables.go
 +++ b/patched/go-iptables/iptables/iptables.go
 @@ -149,12 +149,39 @@ func New(opts ...option) (*IPTables, err


### PR DESCRIPTION
Signed-off-by: Zephyr Lykos <git@mochaa.ws>

Maintainer: @ja-pa @oskarirauta
Compile tested: `aarch64_cortex-a53` @ SNAPSHOT
Run tested: `aarch64_cortex-a53` @ SNAPSHOT, `redmi-ax6s`