### PR TITLE
[openwrt-23.05] python3: Fix unnecessary linking with libbsd

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -153,6 +153,11 @@ CONFIGURE_VARS += \
 	ac_cv_file__dev_ptc=no \
 	ac_cv_file__dev_ptmx=yes
 
+# Do not link with libbsd for flock
+# https://github.com/openwrt/packages/issues/21161
+CONFIGURE_VARS += \
+	ac_cv_lib_bsd_flock=no
+
 # Disable stdlib modules
 # Check for a better way in the future: https://github.com/python/cpython/issues/98558
 CONFIGURE_VARS += \


### PR DESCRIPTION
Maintainer: me
Compile tested: none (cherry pick of #21166)
Run tested: none

Description:
configure will try to link with libbsd for the flock function, even when flock is available without it.

Fixes: https://github.com/openwrt/packages/issues/21161
Fixes: 2445fe9fb25e ("python3: Update to 3.11.3, refresh/redo patches")
Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 60bf01cb606344619e002901646171da1e69c0f9)