### PR TITLE
[openwrt-23.05] uwsgi: Update to 2.0.21, refresh patches

### DIFF
--- a/net/uwsgi/Makefile
+++ b/net/uwsgi/Makefile
@@ -1,17 +1,26 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uwsgi
-PKG_VERSION:=2.0.20
-PKG_RELEASE:=2
+PKG_VERSION:=2.0.21
+PKG_RELEASE:=1
 
-PYPI_NAME:=uwsgi
-PKG_HASH:=88ab9867d8973d8ae84719cf233b7dafc54326fcaec89683c3f9f77c002cdff9
-PKG_BUILD_DEPENDS:=python3/host
-PYTHON3_PKG_BUILD:=0
+PYPI_NAME:=uWSGI
+PYPI_SOURCE_NAME:=uwsgi
+PKG_HASH:=35a30d83791329429bc04fe44183ce4ab512fcf6968070a7bfba42fc5a0552a9
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>
+
+PKG_BUILD_DEPENDS:=python3/host
+PYTHON3_PKG_BUILD:=0
+
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_PACKAGE_uwsgi-logfile-plugin \
+	CONFIG_PACKAGE_uwsgi-syslog-plugin \
+	CONFIG_PACKAGE_uwsgi-cgi-plugin \
+	CONFIG_PACKAGE_uwsgi-python3-plugin \
+	CONFIG_PACKAGE_uwsgi-luci-support
 
 include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -26,7 +35,6 @@ define Package/uwsgi
   TITLE:=The uWSGI server
   URL:=https://uwsgi-docs.readthedocs.io/en/latest/
   DEPENDS:=+libpcre +libcap +libuuid
-  MENU:=1
 endef
 
 define Package/uwsgi-logfile-plugin
@@ -35,7 +43,6 @@ define Package/uwsgi-logfile-plugin
   SUBMENU:=Web Servers/Proxies
   TITLE:=The Logfile plugin for the uWSGI server
   DEPENDS:=uwsgi
-  MDEPENDS:=uwsgi
 endef
 
 define Package/uwsgi-syslog-plugin
@@ -44,7 +51,6 @@ define Package/uwsgi-syslog-plugin
   SUBMENU:=Web Servers/Proxies
   TITLE:=The Syslog plugin for the uWSGI server
   DEPENDS:=uwsgi
-  MDEPENDS:=uwsgi
 endef
 
 define Package/uwsgi-cgi-plugin
@@ -53,7 +59,6 @@ define Package/uwsgi-cgi-plugin
   SUBMENU:=Web Servers/Proxies
   TITLE:=The CGI plugin for the uWSGI server
   DEPENDS:=uwsgi
-  MDEPENDS:=uwsgi
 endef
 
 define Package/uwsgi-python3-plugin
@@ -62,7 +67,6 @@ define Package/uwsgi-python3-plugin
   SUBMENU:=Web Servers/Proxies
   TITLE:=The Python3 plugin for the uWSGI server
   DEPENDS:=uwsgi +python3-light
-  MDEPENDS:=uwsgi
 endef
 
 define Package/uwsgi-luci-support
@@ -71,7 +75,6 @@ define Package/uwsgi-luci-support
   SUBMENU:=Web Servers/Proxies
   TITLE:=Support files for LuCI on Nginx
   DEPENDS:=uwsgi +uwsgi-syslog-plugin +uwsgi-cgi-plugin
-  MDEPENDS:=uwsgi
 endef
 
 define Package/uwsgi/description
@@ -98,23 +101,35 @@ define Package/uwsgi-luci-support/description
 	Support files for LuCI on Nginx
 endef
 
-MAKE_VARS+=\
+MAKE_VARS+= \
 	CPP=$(TARGET_CROSS)cpp \
-	PYTHON=$(STAGING_DIR_HOSTPKG)/bin/python3 \
 	LINUX_UNAME_VERSION=$(LINUX_UNAME_VERSION)
 
+MAKE_FLAGS+= PROFILE=openwrt
+
 define Build/Compile
-	$(call Build/Compile/Default,PROFILE=openwrt)
-	$(call Build/Compile/Default,plugin.logfile PROFILE=openwrt)
-	$(call Build/Compile/Default,plugin.syslog PROFILE=openwrt)
-	$(call Build/Compile/Default,plugin.cgi PROFILE=openwrt)
+	$(call Build/Compile/Default)
+
+  ifneq ($(CONFIG_PACKAGE_uwsgi-logfile-plugin),)
+	$(call Build/Compile/Default,plugin.logfile)
+  endif
+
+  ifneq ($(CONFIG_PACKAGE_uwsgi-syslog-plugin),)
+	$(call Build/Compile/Default,plugin.syslog)
+  endif
+
+  ifneq ($(CONFIG_PACKAGE_uwsgi-cgi-plugin),)
+	$(call Build/Compile/Default,plugin.cgi)
+  endif
+
+  ifneq ($(CONFIG_PACKAGE_uwsgi-python3-plugin),)
 	$(call Python3/Run, \
 		$(PKG_BUILD_DIR), \
 		uwsgiconfig.py --plugin plugins/python openwrt, \
-		CPP="$(TARGET_CROSS)cpp" \
-		LINUX_UNAME_VERSION=$(LINUX_UNAME_VERSION) \
+		$(MAKE_VARS) \
 		CFLAGS="$(TARGET_CPPFLAGS) -I$(PYTHON3_INC_DIR) $(TARGET_CFLAGS)" \
 	)
+  endif
 endef
 
 define Package/uwsgi/install

--- a/net/uwsgi/patches/003-hard-code-Linux-as-compilation-os.patch
+++ b/net/uwsgi/patches/003-hard-code-Linux-as-compilation-os.patch
@@ -1,6 +1,6 @@
 --- a/uwsgiconfig.py
 +++ b/uwsgiconfig.py
-@@ -5,9 +5,9 @@ uwsgi_version = '2.0.20'
+@@ -5,9 +5,9 @@ uwsgi_version = '2.0.21'
  import os
  import re
  import time


### PR DESCRIPTION
Maintainer: @Ansuel (ping @peter-stadler)
Compile tested: none (cherry pick from #21171)
Run tested: none

Description:
This version includes support for Python 3.11.

This also:

* Updates Build/Compile to only build selected subpackages.

* Removes the submenu in menuconfig; there are too few subpackages to justify the extra complexity.

Fixes: https://github.com/openwrt/packages/issues/21163
Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 4d8cc440a4341d0074269db76e1b9b29deeb2db4)