### PR TITLE
numpy: bump version to 1.24.3

### DIFF
--- a/lang/python/numpy/Makefile
+++ b/lang/python/numpy/Makefile
@@ -6,11 +6,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=numpy
-PKG_VERSION:=1.23.3
-PKG_RELEASE:=5
+PKG_VERSION:=1.24.3
+PKG_RELEASE:=1
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=51bf49c0cd1d52be0a240aa66f3458afc4b95d8993d2d04f0d91fa60c10af6cd
+PKG_HASH:=ab344f1bf21f140adab8e47fdbc7c35a477dc01408791f8ba00d018dd0bc5155
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 
@@ -53,6 +53,12 @@ config NUMPY_OPENBLAS_SUPPORT
 
 endmenu
 endef
+
+ifeq ($(ARCH),x86_64)
+# FIXME: temporary fix for x86_64 with GCC 13 + musl;
+#        numpy does not detect this compiler extension, so we just enable it
+TARGET_CFLAGS += -mavx512f
+endif
 
 define Build/Prepare/numpy-sitecfg
 	echo "[DEFAULT]"                                 >  $(PKG_BUILD_DIR)/site.cfg

--- a/lang/python/numpy/patches/001-unpin-build-dependencies.patch
+++ b/lang/python/numpy/patches/001-unpin-build-dependencies.patch
@@ -1,9 +1,9 @@
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -2,8 +2,8 @@
+@@ -1,8 +1,8 @@
+ [build-system]
  # Minimum requirements for the build system to execute.
  requires = [
-     "packaging==20.5; platform_machine=='arm64'",  # macos M1
 -    "setuptools==59.2.0",
 -    "wheel==0.37.0",
 +    "setuptools>=59.2.0",


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 & x86_64 https://github.com/openwrt/openwrt/commit/c815ecdebd77c3484f2cd0ef21e4c69d274ef33a
Run tested: x86 & x86_64 https://github.com/openwrt/openwrt/commit/c815ecdebd77c3484f2cd0ef21e4c69d274ef33a

Need to also fix build for GCC 13 + musl.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>