### PR TITLE
CI: add concurrency rules to skip redundant build

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -3,6 +3,10 @@ name: Test Build
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: Test ${{ matrix.arch }}


### PR DESCRIPTION
Add concurrency rules to skip redundant build to skip extra build test on force push on pull request.
