### PR TITLE
apparmor: gcc 13 compatibility fix

### DIFF
--- a/utils/apparmor/Makefile
+++ b/utils/apparmor/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apparmor
 PKG_VERSION:=3.0.3
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gitlab.com/apparmor/apparmor/-/archive/v$(PKG_VERSION)

--- a/utils/apparmor/patches/100-add-missing-cstdint-include.patch
+++ b/utils/apparmor/patches/100-add-missing-cstdint-include.patch
@@ -1,0 +1,32 @@
+From 64a64be7ffb5a84f27daa9f37ae8ad92800943d3 Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Mon, 23 May 2022 23:12:31 +0100
+Subject: [PATCH] parser/capability.h: add missing <cstdint> include
+
+Without the change apparmor build fails on this week's gcc-13 snapshot as:
+
+    capability.h:66:6: error: variable or field '__debug_capabilities' declared void
+       66 | void __debug_capabilities(uint64_t capset, const char *name);
+          |      ^~~~~~~~~~~~~~~~~~~~
+    capability.h:66:27: error: 'uint64_t' was not declared in this scope
+       66 | void __debug_capabilities(uint64_t capset, const char *name);
+          |                           ^~~~~~~~
+    capability.h:23:1: note: 'uint64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
+       22 | #include <linux/capability.h>
+      +++ |+#include <cstdint>
+       23 |
+---
+ parser/capability.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/parser/capability.h
++++ b/parser/capability.h
+@@ -19,6 +19,8 @@
+ #ifndef __AA_CAPABILITY_H
+ #define __AA_CAPABILITY_H
+ 
++#include <cstdint>
++
+ #define NO_BACKMAP_CAP 0xff
+ 
+ #ifndef CAP_PERFMON


### PR DESCRIPTION
Maintainers: 
me
@CodeFetch 
@paper42
@cotequeiroz 

Compile tested: x86_64, latest git (gcc 13)
Run tested: n/a

Description:
fixes following error, when building with gcc 13:

```
In file included from profile.h:21,
                 from profile.cc:15:
capability.h:46:6: error: variable or field '__debug_capabilities' declared void
   46 | void __debug_capabilities(uint64_t capset, const char *name);
      |      ^~~~~~~~~~~~~~~~~~~~
capability.h:46:27: error: 'uint64_t' was not declared in this scope
   46 | void __debug_capabilities(uint64_t capset, const char *name);
      |                           ^~~~~~~~
capability.h:1:1: note: 'uint64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
  +++ |+#include <cstdint>
    1 | /*
capability.h:46:44: error: expected primary-expression before 'const'
   46 | void __debug_capabilities(uint64_t capset, const char *name);
      |                                            ^~~~~
profile.h: In member function 'void capabilities::dump()':
profile.h:156:33: error: '__debug_capabilities' was not declared in this scope
  156 |                                 __debug_capabilities(allow, "Capabilities");
      |                                 ^~~~~~~~~~~~~~~~~~~~
profile.h:158:33: error: '__debug_capabilities' was not declared in this scope
  158 |                                 __debug_capabilities(audit, "Audit Caps");
      |                                 ^~~~~~~~~~~~~~~~~~~~
profile.h:160:33: error: '__debug_capabilities' was not declared in this scope
  160 |                                 __debug_capabilities(deny, "Deny Caps");
      |                                 ^~~~~~~~~~~~~~~~~~~~
profile.h:162:33: error: '__debug_capabilities' was not declared in this scope
  162 |                                 __debug_capabilities(quiet, "Quiet Caps");
      |                                 ^~~~~~~~~~~~~~~~~~~~
make[4]: *** [Makefile:297: profile.o] Error 1
make[4]: Leaving directory '/usr/src/openwrt/build_dir/target-x86_64_musl/apparmor-v3.0.3/parser'
make[3]: *** [Makefile:219: /usr/src/openwrt/build_dir/target-x86_64_musl/apparmor-v3.0.3/.built] Error 2
make[3]: Leaving directory '/usr/src/openwrt/feeds/packages/utils/apparmor'
time: package/feeds/packages/apparmor/compile#25.65#2.48#0.00
    ERROR: package/feeds/packages/apparmor failed to build.
```

Patch is backported from [upstream patch](https://gitlab.com/apparmor/apparmor/-/commit/64a64be7ffb5a84f27daa9f37ae8ad92800943d3.patch)

Someone still should make a PR against musl 1.2.4 - if I remember correctly, uint64_t isn't defined with musl 1.2.4, but unfortunately, I won't be doing it, because I am using musl compatibility patch openwrt/openwrt#12667 that masks those problems.. This though fixes issue with gcc 13.