### PR TITLE
python-packages: Replace --global-option with --build-option

### DIFF
--- a/lang/python/pillow/Makefile
+++ b/lang/python/pillow/Makefile
@@ -37,17 +37,17 @@ define Package/python3-pillow/description
 endef
 
 PYTHON3_PKG_BUILD_CONFIG_SETTINGS += \
-	--global-option=build_ext \
-	--global-option=--enable-zlib \
-	--global-option=--enable-jpeg \
-	--global-option=--enable-webp \
-	--global-option=--enable-webpmux \
-	--global-option=--enable-tiff \
-	--global-option=--enable-freetype \
-	--global-option=--disable-lcms \
-	--global-option=--disable-jpeg2000 \
-	--global-option=--disable-imagequant \
-	--global-option=--disable-platform-guessing
+	--build-option=build_ext \
+	--build-option=--enable-zlib \
+	--build-option=--enable-jpeg \
+	--build-option=--enable-webp \
+	--build-option=--enable-webpmux \
+	--build-option=--enable-tiff \
+	--build-option=--enable-freetype \
+	--build-option=--disable-lcms \
+	--build-option=--disable-jpeg2000 \
+	--build-option=--disable-imagequant \
+	--build-option=--disable-platform-guessing
 
 $(eval $(call Py3Package,python3-pillow))
 $(eval $(call BuildPackage,python3-pillow))

--- a/lang/python/python-evdev/Makefile
+++ b/lang/python/python-evdev/Makefile
@@ -40,10 +40,10 @@ endef
 LINUX_EVDEV_HEADERS="$(LINUX_DIR)/include/uapi/linux/input.h:$(LINUX_DIR)/include/uapi/linux/input-event-codes.h"
 
 PYTHON3_PKG_BUILD_CONFIG_SETTINGS:= \
-	--global-option=build \
-	--global-option=build_ecodes \
-	--global-option=--evdev-headers="$(LINUX_EVDEV_HEADERS)" \
-	--global-option=build_ext
+	--build-option=build \
+	--build-option=build_ecodes \
+	--build-option=--evdev-headers="$(LINUX_EVDEV_HEADERS)" \
+	--build-option=build_ext
 
 $(eval $(call Py3Package,python3-evdev))
 $(eval $(call BuildPackage,python3-evdev))


### PR DESCRIPTION
Maintainer: @commodo (python-evdev, pillow), @paulo-raca (python-evdev)
Compile tested: armvirt-32, 2023-05-21 snapshot sdk
Run tested: none

Description:
setuptools 64.0.0 deprecated the use of `--global-option` to [pass build parameters][1]. This replaces the use of `--global-option` with `--build-option`.

[1]: https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400