### PR TITLE
[22.03] curl: update to 8.1.1

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
-PKG_VERSION:=8.1.0
+PKG_VERSION:=8.1.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -17,7 +17,7 @@ PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,
 	https://dl.uxnr.de/mirror/curl/ \
 	https://curl.askapache.com/download/ \
 	https://curl.se/download/
-PKG_HASH:=6bd80ad4f07187015911216ee7185b90d285ac5162aed1bded144f9f93232a3c
+PKG_HASH:=08a948e061929645597c1ef7194e07b308b22084ff03fa7400b465e6c05149e5
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 22.03.5
Run tested: x86_64, Sophos XG-135r3, OpenWrt 22.03.5, test resolution from https-dns-proxy

Description:
* https://curl.se/changes.html#8_1_1

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit b126e765cc8bc100336ea42fab5f655c0d4c6325)
