### PR TITLE
Zile: Remove autoreconf

### DIFF
--- a/utils/zile/Makefile
+++ b/utils/zile/Makefile
@@ -1,6 +1,4 @@
 #
-# Copyright (C) 2006-2016 OpenWrt.org
-#
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
@@ -9,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zile
 PKG_VERSION:=2.3.24
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/zile
@@ -19,7 +17,6 @@ PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
-PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION

Maintainer: thess
Compile tested: several
Run tested: arm_cortex-a15, mipsel_24kc, x86

Description:
It is no longer required since gnulib is now local to host build environment (tools/gnulib).
