### PR TITLE
collectd: enable AllPortsSummary for tcpconns plugin

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.12.0
-PKG_RELEASE:=42
+PKG_RELEASE:=43
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \

--- a/utils/collectd/files/collectd.uci
+++ b/utils/collectd/files/collectd.uci
@@ -188,7 +188,8 @@ config globals 'globals'
 
 #config plugin 'tcpconns'
 #	option enable '0'
-#	list ListeningPort '0'
+#	option ListeningPorts '0'
+#	option AllPortsSummary '0'
 #	list LocalPort '22'
 #	list LocalPort '80'
 

--- a/utils/collectd/files/usr/share/collectd/plugin/tcpconns.json
+++ b/utils/collectd/files/usr/share/collectd/plugin/tcpconns.json
@@ -1,6 +1,7 @@
 {
 	"bool": [
-		"ListeningPorts"
+		"ListeningPorts",
+		"AllPortsSummary"
 	],
 	"list": [
 		"LocalPort",


### PR DESCRIPTION
Maintainer: @jow- , @hnyman 
Compile tested: aarch64_cortex-a53, ipq807x/generic, r22604+4-a247f49794
Run tested: aarch64_cortex-a53, ipq807x/generic, r22604+4-a247f49794

Description:
enable summarized stats for tcp connections, https://collectd.org/wiki/index.php/Plugin:TCPConns#Summary_of_all_ports