### PR TITLE
Prevent clearing of desec.io entries

### DIFF
--- a/lang/python/python3-find-stdlib-depends.sh
+++ b/lang/python/python3-find-stdlib-depends.sh
@@ -14,11 +14,10 @@ python3-cgi: cgi
 python3-cgitb: cgitb
 python3-codecs: unicodedata
 python3-ctypes: ctypes
-python3-dbm: dbm
+python3-dbm: dbm dbm.dumb dbm.gnu dbm.ndbm
 python3-decimal: decimal
 python3-distutils: distutils
 python3-email: email
-python3-gdbm: dbm.gnu
 python3-logging: logging
 python3-lzma: lzma
 python3-multiprocessing: multiprocessing
@@ -29,6 +28,7 @@ python3-readline: readline
 python3-sqlite3: sqlite3
 python3-unittest: unittest
 python3-urllib: urllib
+python3-uuid: uuid
 python3-xml: xml xmlrpc
 "
 


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:

When using both ipv4 and ipv6 entries on the same host, ddns is clearing A (or AAAA) record depending on the connection (ipv4 or ipv6)

see https://desec.readthedocs.io/en/latest/dyndns/update-api.html#determine-ip-addresses
