### PR TITLE
ddns: Prevent clearing of desec.io entries

### DIFF
--- a/net/ddns-scripts/files/usr/share/ddns/default/desec.io.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/desec.io.json
@@ -1,11 +1,11 @@
 {
 	"name": "desec.io",
 	"ipv4": {
-		"url": "http://update.dedyn.io/update?username=[USERNAME]&password=[PASSWORD]&hostname=[DOMAIN]&myipv4=[IP]",
+		"url": "http://update.dedyn.io/update?username=[USERNAME]&password=[PASSWORD]&hostname=[DOMAIN]&myipv4=[IP]&myipv6=preserve",
 		"answer": "good|nochg"
 	},
 	"ipv6": {
-		"url": "http://update.dedyn.io/update?username=[USERNAME]&password=[PASSWORD]&hostname=[DOMAIN]&myipv6=[IP]",
+		"url": "http://update.dedyn.io/update?username=[USERNAME]&password=[PASSWORD]&hostname=[DOMAIN]&myipv6=[IP]&myipv4=preserve",
 		"answer": "good|nochg"
 	}
 }


### PR DESCRIPTION
When using both ipv4 and ipv6 entries on the same host, ddns is clearing A (or AAAA) record depending on the connection (ipv4 or ipv6)

see https://desec.readthedocs.io/en/latest/dyndns/update-api.html#determine-ip-addresses

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
