### PR TITLE
[openwrt-23.05] python-gmpy2: Update to 2.1.5; add new dependencies

### DIFF
--- a/lang/python/python-gmpy2/Makefile
+++ b/lang/python/python-gmpy2/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015-2018 OpenWrt.org
+# Copyright (C) 2015-2016, 2018-2020, 2023 Jeffery To
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-gmpy2
-PKG_VERSION:=2.0.8
-PKG_RELEASE:=6
+PKG_VERSION:=2.1.5
+PKG_RELEASE:=1
 
 PYPI_NAME:=gmpy2
-PYPI_SOURCE_EXT:=zip
-PKG_HASH:=dd233e3288b90f21b0bb384bcc7a7e73557bb112ccf0032ad52aa614eb373d3f
+PKG_HASH:=bc297f1fd8c377ae67a4f493fc0f926e5d1b157e5c342e30a4d84dc7b9f95d96
 
 PKG_LICENSE:=LGPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING.LESSER
@@ -23,15 +22,13 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-PYTHON3_PKG_BUILD_CONFIG_SETTINGS:=--global-option=--nompfr
-
 define Package/python3-gmpy2
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=GMP/MPIR, MPFR, and MPC interface
   URL:=https://github.com/aleaxit/gmpy
-  DEPENDS:=+libgmp +python3-light
+  DEPENDS:=+libgmp +libmpc +libmpfr +python3-light
 endef
 
 define Package/python3-gmpy2/description

--- a/libs/libmpc/Makefile
+++ b/libs/libmpc/Makefile
@@ -1,0 +1,57 @@
+#
+# Copyright (C) 2023 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mpc
+PKG_VERSION:=1.3.1
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=@GNU/mpc/
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8
+
+PKG_LICENSE:=LGPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING.LESSER
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libmpc
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=GNU MPC library
+  URL:=https://www.multiprecision.org/mpc/
+  DEPENDS:=+libgmp +libmpfr
+  ABI_VERSION:=3
+endef
+
+define Package/libmpc/description
+GNU MPC is a portable library written in C for arbitrary precision
+arithmetic on complex numbers providing correct rounding. It implements
+a multiprecision equivalent of the C99 standard. It builds upon the GNU
+MP and the GNU MPFR libraries.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/mpc* $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmpc.{a,so*} $(1)/usr/lib/
+endef
+
+define Package/libmpc/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmpc.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libmpc))

--- a/libs/libmpc/patches/001-only-src.patch
+++ b/libs/libmpc/patches/001-only-src.patch
@@ -1,0 +1,22 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -23,7 +23,7 @@ ACLOCAL_AMFLAGS = -I m4
+ # VERSION = @VERSION@@GITVERSION@ # for development version
+ VERSION = @VERSION@
+ 
+-SUBDIRS = src tests doc tools
++SUBDIRS = src
+ 
+ EXTRA_HEADERS = src/mpc-log.h
+ include_HEADERS = src/mpc.h @MPC_LOG_H@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -376,7 +376,7 @@ top_build_prefix = @top_build_prefix@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+ ACLOCAL_AMFLAGS = -I m4
+-SUBDIRS = src tests doc tools
++SUBDIRS = src
+ EXTRA_HEADERS = src/mpc-log.h
+ include_HEADERS = src/mpc.h @MPC_LOG_H@
+ EXTRA_DIST = doc/fdl-1.3.texi src/mpc-log.h

--- a/libs/mpfr/Makefile
+++ b/libs/mpfr/Makefile
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2023 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mpfr
+PKG_VERSION:=4.2.0
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=@GNU/mpfr http://www.mpfr.org/mpfr-$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_HASH:=06a378df13501248c1b2db5aa977a2c8126ae849a9d9b7be2546fb4a9c26d993
+
+PKG_LICENSE:=LGPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING.LESSER
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+PKG_CPE_ID:=cpe:/a:mpfr:gnu_mpfr
+
+PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libmpfr
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=GNU MPFR library
+  URL:=https://www.mpfr.org/
+  DEPENDS:=+libgmp
+  ABI_VERSION:=6
+endef
+
+define Package/libmpfr/description
+MPFR is a portable library written in C for arbitrary precision
+arithmetic on floating-point numbers. It is based on the GNU MP library.
+It aims to provide a class of floating-point numbers with precise
+semantics.
+endef
+
+CONFIGURE_ARGS += \
+	--enable-thread-safe
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/mpf* $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmpfr.{a,so*} $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/mpfr.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libmpfr/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmpfr.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libmpfr))

--- a/libs/mpfr/patches/001-only-src.patch
+++ b/libs/mpfr/patches/001-only-src.patch
@@ -1,0 +1,22 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -38,7 +38,7 @@ AUTOMAKE_OPTIONS = gnu
+ # old Automake version.
+ ACLOCAL_AMFLAGS = -I m4
+ 
+-SUBDIRS = doc src tests tune tools/bench
++SUBDIRS = src
+ 
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = mpfr.pc
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -401,7 +401,7 @@ AUTOMAKE_OPTIONS = gnu
+ # libtoolize and in case some developer needs to switch back to an
+ # old Automake version.
+ ACLOCAL_AMFLAGS = -I m4
+-SUBDIRS = doc src tests tune tools/bench
++SUBDIRS = src
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = mpfr.pc
+ nobase_dist_doc_DATA = AUTHORS BUGS COPYING COPYING.LESSER NEWS TODO \


### PR DESCRIPTION
Maintainer: me
Compile tested: none (cherry picked from #21216)
Run tested: none

Description:
This updates python-gmpy2 to 2.1.5 and adds packages for two new dependencies, mpfr and mpc.