### PR TITLE
[openwrt-23.05] Werkzeug: Update to 2.3.4, rename source package

### DIFF
--- a/lang/python/python-werkzeug/Makefile
+++ b/lang/python/python-werkzeug/Makefile
@@ -4,12 +4,12 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=Werkzeug
-PKG_VERSION:=2.2.2
+PKG_NAME:=python-werkzeug
+PKG_VERSION:=2.3.4
 PKG_RELEASE:=1
 
-PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f
+PYPI_NAME:=Werkzeug
+PKG_HASH:=1d5a58e0377d1fe39d061a5de4469e414e78ccb1e1e59c0f5ad6fa1c36c52b76
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
@@ -23,13 +23,15 @@ define Package/python3-werkzeug
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  TITLE:=Werkzeug
+  TITLE:=Comprehensive WSGI web application library
   URL:=https://palletsprojects.com/p/werkzeug/
-  DEPENDS:=+python3-light +python3-email
+  DEPENDS:=+python3 +python3-markupsafe
 endef
 
 define Package/python3-werkzeug/description
- The comprehensive WSGI web application library.
+Werkzeug is a comprehensive WSGI web application library. It began as a
+simple collection of various utilities for WSGI applications and has
+become one of the most advanced WSGI utility libraries.
 endef
 
 $(eval $(call Py3Package,python3-werkzeug))


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: none (cherry pick from #21227)
Run tested: none

Description:
This renames the source package from Werkzeug to python-werkzeug to match other Python packages.

This also updates the package title, description, and list of dependencies.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 574d43fca627bdaee03f43a1be10ba35dd9dd26d)