### PR TITLE
openvpn: fix ipchange hotplug event

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.5.8
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/openvpn.init
+++ b/net/openvpn/files/openvpn.init
@@ -140,10 +140,11 @@ openvpn_get_credentials() {
 openvpn_add_instance() {
 	local name="$1"
 	local dir="$2"
-	local conf="$3"
+	local conf=$(basename "$3")
 	local security="$4"
 	local up="$5"
 	local down="$6"
+	local client=$(grep -qEx "client|tls-client" "$dir/$conf" && echo 1)
 
 	procd_open_instance "$name"
 	procd_set_param command "$PROG"	\
@@ -155,7 +156,7 @@ openvpn_add_instance() {
 		--down "/usr/libexec/openvpn-hotplug down $name" \
 		--route-up "/usr/libexec/openvpn-hotplug route-up $name" \
 		--route-pre-down "/usr/libexec/openvpn-hotplug route-pre-down $name" \
-		--ipchange "/usr/libexec/openvpn-hotplug ipchange $name" \
+		${client:+--ipchange "/usr/libexec/openvpn-hotplug ipchange $name"} \
 		${up:+--setenv user_up "$up"} \
 		${down:+--setenv user_down "$down"} \
 		--script-security "${security:-2}" \


### PR DESCRIPTION
Maintainer:  @mkrkn 
Compile tested: ramips/mt7621
Run tested:  ramips/mt7621 Xiaomi MI router 3 Pro

Description:
In f8a8b71e26b9bdbf86fbb7d4d1482637af7f3ba4 introduced new hotplug events. For server config, ipchange hotplug event produces an error. So, make ipchange hotplug event for client only

Fixes https://github.com/openwrt/packages/issues/21200