### PR TITLE
gawk: disable mpfr detection

### DIFF
--- a/utils/gawk/Makefile
+++ b/utils/gawk/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gawk
 PKG_VERSION:=5.2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/gawk
@@ -28,6 +28,8 @@ define Package/gawk
   TITLE:=GNU awk
   DEPENDS:=+libncursesw +libreadline
 endef
+
+CONFIGURE_ARGS+= --disable-mpfr
 
 define Package/gawk/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Disable mpfr detection to fix a build error due to (unncessary) missing dependency:

```
Package gawk is missing dependencies for the following libraries:
libgmp.so.10
libmpfr.so.6
```

Maintainer: @dangowrt 
Compile tested: rockchip/armv8
Run tested: n/a