### PR TITLE
nfs-kernel-server: remove libwrap from the dependencies

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
 PKG_VERSION:=2.6.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_HASH:=26d46448982252e9e2c8346d10cf13e1143e7089c866f53e25db3359f3e9493c
 
 PKG_SOURCE_URL:=@SF/nfs
@@ -32,7 +32,7 @@ define Package/nfs-kernel-server/Default
 	SECTION:=net
 	CATEGORY:=Network
 	SUBMENU:=Filesystem
-	DEPENDS:=+libwrap +libblkid +libuuid +libtirpc
+	DEPENDS:=+libblkid +libuuid +libtirpc
 	URL:=http://nfs.sourceforge.net/
 	MAINTAINER:=Peter Wagner <tripolar@gmx.at>
 endef


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: ipq807x/generic, r22604+4-a247f49794
Run tested: ipq807x/generic, r22604+4-a247f49794, mount nfs share

Description: remove libwrap from the dependencies since none of the binaries actually depend on it.

Cc: @neheb , @1715173329 
