### PR TITLE
snort3: update to 3.1.63.0

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
-PKG_VERSION:=3.1.62.0
+PKG_VERSION:=3.1.63.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
-PKG_HASH:=1f18936da65d52702f75e5b9ffe2cfbc9c9373201801ad275f6e636451f7e06f
+PKG_HASH:=7ca415ac8098cd5ee001dc751966d4a6028961ca9cfc788447b7ea7048f53f85
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Upstream bump

Build system: x86_64
Build-tested: bcm2711/RPi4B
Run-tested: bcm2711/RPi4B

Maintainer: @flyn-org