### PR TITLE
php8: fix linking on riscv64 platform

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -94,7 +94,7 @@ endef
 
 define Package/php8-cli
   $(call Package/php8/Default)
-  DEPENDS+= +PACKAGE_php8-mod-intl:libstdcpp
+  DEPENDS+= +PACKAGE_php8-mod-intl:libstdcpp +riscv64:libatomic
   TITLE+= (CLI)
 endef
 
@@ -105,7 +105,7 @@ endef
 
 define Package/php8-cgi
   $(call Package/php8/Default)
-  DEPENDS+= +PACKAGE_php8-mod-intl:libstdcpp
+  DEPENDS+= +PACKAGE_php8-mod-intl:libstdcpp +riscv64:libatomic
   TITLE+= (CGI & FastCGI)
 endef
 
@@ -127,7 +127,7 @@ endef
 
 define Package/php8-fpm
   $(call Package/php8/Default)
-  DEPENDS+= +PACKAGE_php8-mod-intl:libstdcpp
+  DEPENDS+= +PACKAGE_php8-mod-intl:libstdcpp +riscv64:libatomic
   TITLE+= (FPM)
 endef
 
@@ -159,6 +159,7 @@ define Package/apache-mod-php8
   CATEGORY:=Network
   DEPENDS+=PACKAGE_apache-mod-php8:apache \
 	   +PACKAGE_php8-mod-intl:libstdcpp \
+	   +riscv64:libatomic \
 	   +libpcre2 +zlib
   TITLE:=PHP8 module for Apache Web Server
 endef
@@ -196,6 +197,9 @@ TARGET_LDFLAGS += -ldl
 endif
 ifeq ($(CONFIG_USE_MUSL),y)
 TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
+endif
+ifneq ($(findstring riscv64,$(CONFIG_ARCH)),)
+TARGET_LDFLAGS += -latomic
 endif
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-bcmath),)
@@ -602,6 +606,8 @@ define BuildModule
 
   define Package/php8-mod-$(1)
     $(call Package/php8/Default)
+
+    DEPENDS+=+riscv64:libatomic
 
     ifneq ($(3),)
       DEPENDS+=$(3)


### PR DESCRIPTION
Maintainer: me
Compile tested: riscv64
Run tested: no

Description:

The buildbots failed for the mentioned platform with the following error: (I shortened the pathnames and broke long lines a little bit for readability)

.../lib/gcc/riscv64-openwrt-linux-musl/12.3.0/../../../../
  riscv64-openwrt-linux-musl/bin/ld: Zend/zend_execute_API.o: in function `.L533':
zend_execute_API.c:(.text+0x1b1c): undefined reference to `__atomic_exchange_1' .../riscv64-openwrt-linux-musl/bin/ld: Zend/zend_atomic.o:
  in function `zend_atomic_bool_exchange':
zend_atomic.c:(.text+0xc): undefined reference to `__atomic_exchange_1' collect2: error: ld returned 1 exit status
make[4]: *** [Makefile:350: sapi/cli/php] Error 1

Inspired by the blog post[1], linking to libatomic explicitly seems to do the trick.

[1] A RISC-V gcc pitfall revealed by a glibc update
https://blog.jiejiss.com/A-RISC-V-gcc-pitfall-revealed-by-a-glibc-update
