### PR TITLE
golang: Enable riscv64 for Go compiler and packages

### DIFF
--- a/lang/golang/golang-values.mk
+++ b/lang/golang/golang-values.mk
@@ -201,7 +201,7 @@ endif
 
 # Target Go
 
-GO_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||mips||mips64||mips64el||mipsel||powerpc64||x86_64)
+GO_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||mips||mips64||mips64el||mipsel||powerpc64||riscv64||x86_64)
 
 
 # ASLR/PIE


### PR DESCRIPTION
Maintainer: me
Compile tested: sifiveu-generic, 2023-06-02 snapshot sdk (compiled golang, obfs4proxy, tor-fw-firewall packages)
Run tested: none (can't get sifive_unleased image to load in qemu :sweat:)

Description:
Bring on the faillogs :laughing: 