### PR TITLE
rust: update to 1.70.0

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
-PKG_VERSION:=1.69.0
+PKG_VERSION:=1.70.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
-PKG_HASH:=fb05971867ad6ccabbd3720279f5a94b99f61024923187b56bb5c455fa3cf60f
+PKG_HASH:=b2bfae000b7a5040e4ec4bbc50a09f21548190cb7570b0ed77358368413bd27c
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>

--- a/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
+++ b/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
@@ -1,7 +1,7 @@
-From b74dbd080ea75ebcc371732ddbfeb81c96b8c5d5 Mon Sep 17 00:00:00 2001
+From d3000458501d339ea2043006924d431ead18769e Mon Sep 17 00:00:00 2001
 From: Luca Barbato <lu_zero@gentoo.org>
-Date: Fri, 10 Mar 2023 18:24:14 +0100
-Subject: [PATCH] Update xz2 and lzma-sys
+Date: Sun, 4 Jun 2023 19:32:28 +0000
+Subject: [PATCH] Update xz2 and use it static
 
 ---
  Cargo.lock               | 8 ++++----
@@ -10,15 +10,10 @@ Subject: [PATCH] Update xz2 and lzma-sys
  3 files changed, 9 insertions(+), 9 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 64df70f68e9..dff61db9893 100644
+index 12be36ef861..2cbfdb2bc06 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -2490,19 +2490,19 @@ version = "0.4.14"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
- dependencies = [
-  "cfg-if",
- ]
+@@ -3085,9 +3085,9 @@ dependencies = [
  
  [[package]]
  name = "lzma-sys"
@@ -30,17 +25,7 @@ index 64df70f68e9..dff61db9893 100644
  dependencies = [
   "cc",
   "libc",
-  "pkg-config",
- ]
- 
- [[package]]
- name = "mac"
-@@ -6341,19 +6341,19 @@ version = "0.2.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
- dependencies = [
-  "libc",
- ]
+@@ -7116,9 +7116,9 @@ dependencies = [
  
  [[package]]
  name = "xz2"
@@ -52,21 +37,11 @@ index 64df70f68e9..dff61db9893 100644
  dependencies = [
   "lzma-sys",
  ]
- 
- [[package]]
- name = "yaml-merge-keys"
- version = "0.4.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
 diff --git a/src/bootstrap/Cargo.lock b/src/bootstrap/Cargo.lock
-index 4a0ba592577..e75b4dbd12e 100644
+index a158d1f718e..9b0fb46f265 100644
 --- a/src/bootstrap/Cargo.lock
 +++ b/src/bootstrap/Cargo.lock
-@@ -351,19 +351,19 @@ version = "0.4.17"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
- dependencies = [
-  "cfg-if",
- ]
+@@ -389,9 +389,9 @@ dependencies = [
  
  [[package]]
  name = "lzma-sys"
@@ -78,17 +53,7 @@ index 4a0ba592577..e75b4dbd12e 100644
  dependencies = [
   "cc",
   "libc",
-  "pkg-config",
- ]
- 
- [[package]]
- name = "memchr"
-@@ -785,19 +785,19 @@ version = "0.2.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
- dependencies = [
-  "libc",
- ]
+@@ -847,9 +847,9 @@ dependencies = [
  
  [[package]]
  name = "xz2"
@@ -100,21 +65,11 @@ index 4a0ba592577..e75b4dbd12e 100644
  dependencies = [
   "lzma-sys",
  ]
- 
- [[package]]
- name = "yansi"
- version = "0.5.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
 diff --git a/src/bootstrap/Cargo.toml b/src/bootstrap/Cargo.toml
-index 22ceeca941e..9131fa5c341 100644
+index eeda6d7c121..f2d740b7614 100644
 --- a/src/bootstrap/Cargo.toml
 +++ b/src/bootstrap/Cargo.toml
-@@ -42,17 +42,17 @@ object = { version = "0.29.0", default-features = false, features = ["archive",
- serde = { version = "1.0.8", features = ["derive"] }
- serde_json = "1.0.2"
- sha2 = "0.10"
- tar = "0.4"
- toml = "0.5"
+@@ -51,7 +51,7 @@ toml = "0.5"
  ignore = "0.4.10"
  opener = "0.5"
  once_cell = "1.7.2"
@@ -123,11 +78,6 @@ index 22ceeca941e..9131fa5c341 100644
  walkdir = "2"
  
  # Dependencies needed by the build-metrics feature
- sysinfo = { version = "0.26.0", optional = true }
- 
- [target.'cfg(windows)'.dependencies.winapi]
- version = "0.3"
- features = [
 -- 
-2.39.1
+2.40.0
 


### PR DESCRIPTION
Maintainer: @lu-zero
Compile tested: current master, aarch64
Run tested: N/A

Description: It should fix the musl-1.2 issues on time_t affected platforms.
