### PR TITLE
python-typing-extensions: Update to 4.6.3

### DIFF
--- a/lang/python/python-typing-extensions/Makefile
+++ b/lang/python/python-typing-extensions/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-typing-extensions
-PKG_VERSION:=4.6.2
+PKG_VERSION:=4.6.3
 PKG_RELEASE:=1
 
 PYPI_NAME:=typing-extensions
 PYPI_SOURCE_NAME:=typing_extensions
-PKG_HASH:=06006244c70ac8ee83fa8282cb188f697b8db25bc8b4df07be1873c43897060c
+PKG_HASH:=d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>, Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=Python-2.0.1 0BSD


### PR DESCRIPTION
Maintainer: me, @ja-pa
Compile tested: armvirt-32, 2023-06-04 snapshot sdk
Run tested: none

Description:
