### PR TITLE
[openwrt-23.05] lcd4linux: fix build error for custom build

### DIFF
--- a/utils/lcd4linux/Makefile
+++ b/utils/lcd4linux/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lcd4linux
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/feckert/lcd4linux
@@ -194,6 +194,10 @@ $(call Package/lcd4linux/Default/description)
  drivers and plugins.
 endef
 
+
+CONFIGURE_VARS+= \
+	ANSICXX_TRUE=yes \
+	am__fastdepCXX_TRUE=yes
 
 CONFIGURE_ARGS+= \
 	--disable-rpath


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: rockchip/armv8
Run tested: n/a

Description:
cherry picked from commit 917ea9d214fe4a6ef8e000c50761ac6d302f8162