### PR TITLE
tree: bump to 2.1.1

### DIFF
--- a/utils/tree/Makefile
+++ b/utils/tree/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tree
-PKG_VERSION:=2.1.0
+PKG_VERSION:=2.1.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/Old-Man-Programmer/$(PKG_NAME)/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=e9da64f6bbf894840b76d5fb2d37282076febbc96076fc4e833b08fe42190ad2
+PKG_HASH:=1b70253994dca48a59d6ed99390132f4d55c486bf0658468f8520e7e63666a06
 
 PKG_MAINTAINER:=Banglang Huang <banglang.huang@foxmail.com>
 


### PR DESCRIPTION
    Build system: x86_64
    Build-tested: bcm2711/RPi4B
    Run-tested: bcm2711/RPi4B

Maintainer: @hbl0307106015