### PR TITLE
[openwrt-23.05] passlib: Update to 1.7.4, rename source package

### DIFF
--- a/lang/python/python-passlib/Makefile
+++ b/lang/python/python-passlib/Makefile
@@ -3,17 +3,18 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=passlib
-PKG_VERSION:=1.7.2
-PKG_RELEASE:=2
-PKG_LICENSE:=BSD-3-Clause
+PKG_NAME:=python-passlib
+PKG_VERSION:=1.7.4
+PKG_RELEASE:=1
 
-PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=8d666cef936198bc2ab47ee9b0410c94adf2ba798e5a84bf220be079ae7ab6a8
+PYPI_NAME:=passlib
+PKG_HASH:=defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
-
 include ../python3-package.mk
 
 define Package/python3-passlib
@@ -21,8 +22,8 @@ define Package/python3-passlib
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Comprehensive password hashing framework
-  URL:=https://bitbucket.org/ecollins/passlib
-  DEPENDS:=+python3 +python3-dateutil
+  URL:=https://passlib.readthedocs.io/
+  DEPENDS:=+python3
 endef
 
 define Package/python3-passlib/description
@@ -35,6 +36,5 @@ multi-user applications.
 endef
 
 $(eval $(call Py3Package,python3-passlib))
-
 $(eval $(call BuildPackage,python3-passlib))
 $(eval $(call BuildPackage,python3-passlib-src))


### PR DESCRIPTION
Maintainer: none
Compile tested: none (cherry picked from #21290)
Run tested: none

Description:
This renames the source package from passlib to python-passlib to match other Python packages.

This also updates the package URL and list of dependencies.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 5b965e4d79afae179080a8bf3b370e650045fe05)