### PR TITLE
rust: bump libc to 0.2.146

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
 PKG_VERSION:=1.70.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/

--- a/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
+++ b/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
@@ -9,8 +9,6 @@ Subject: [PATCH] Update xz2 and use it static
  src/bootstrap/Cargo.toml | 2 +-
  3 files changed, 9 insertions(+), 9 deletions(-)
 
-diff --git a/Cargo.lock b/Cargo.lock
-index 12be36ef861..2cbfdb2bc06 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
 @@ -3085,9 +3085,9 @@ dependencies = [
@@ -37,8 +35,6 @@ index 12be36ef861..2cbfdb2bc06 100644
  dependencies = [
   "lzma-sys",
  ]
-diff --git a/src/bootstrap/Cargo.lock b/src/bootstrap/Cargo.lock
-index a158d1f718e..9b0fb46f265 100644
 --- a/src/bootstrap/Cargo.lock
 +++ b/src/bootstrap/Cargo.lock
 @@ -389,9 +389,9 @@ dependencies = [
@@ -65,8 +61,6 @@ index a158d1f718e..9b0fb46f265 100644
  dependencies = [
   "lzma-sys",
  ]
-diff --git a/src/bootstrap/Cargo.toml b/src/bootstrap/Cargo.toml
-index eeda6d7c121..f2d740b7614 100644
 --- a/src/bootstrap/Cargo.toml
 +++ b/src/bootstrap/Cargo.toml
 @@ -51,7 +51,7 @@ toml = "0.5"
@@ -78,6 +72,3 @@ index eeda6d7c121..f2d740b7614 100644
  walkdir = "2"
  
  # Dependencies needed by the build-metrics feature
--- 
-2.40.0
-

--- a/lang/rust/patches/0002-Bumped-libc-version.patch
+++ b/lang/rust/patches/0002-Bumped-libc-version.patch
@@ -1,0 +1,35 @@
+From 032857e7e403f654129c45dc7e6718a9ad49e377 Mon Sep 17 00:00:00 2001
+From: Nikolay Arhipov <n@arhipov.net>
+Date: Tue, 6 Jun 2023 16:09:05 +0300
+Subject: [PATCH] Bumped libc version
+
+---
+ Cargo.lock             | 4 ++--
+ library/std/Cargo.toml | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -2933,9 +2933,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0e
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.140"
++version = "0.2.146"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
++checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+ dependencies = [
+  "rustc-std-workspace-core",
+ ]
+--- a/library/std/Cargo.toml
++++ b/library/std/Cargo.toml
+@@ -15,7 +15,7 @@ cfg-if = { version = "1.0", features = [
+ panic_unwind = { path = "../panic_unwind", optional = true }
+ panic_abort = { path = "../panic_abort" }
+ core = { path = "../core" }
+-libc = { version = "0.2.140", default-features = false, features = ['rustc-dep-of-std'] }
++libc = { version = "0.2.146", default-features = false, features = ['rustc-dep-of-std'] }
+ compiler_builtins = { version = "0.1.91" }
+ profiler_builtins = { path = "../profiler_builtins", optional = true }
+ unwind = { path = "../unwind" }


### PR DESCRIPTION
Fixes build with musl 1.2.4.
Upstream commit: https://github.com/rust-lang/rust/commit/032857e7e403f654129c45dc7e6718a9ad49e377

Maintainer: @lu-zero 
Compile tested: rockchip/armv8
Run tested: n/a