### PR TITLE
rust: enable riscv64 support

### DIFF
--- a/lang/rust/rust-package.mk
+++ b/lang/rust/rust-package.mk
@@ -16,7 +16,7 @@ endif
 include $(RUST_INCLUDE_DIR)/rust-values.mk
 
 # Support only a subset for now.
-RUST_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||mips||mipsel||mips64||mips64el||mipsel||powerpc64||x86_64)
+RUST_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||mips||mipsel||mips64||mips64el||mipsel||powerpc64||riscv64||x86_64)
 
 # $(1) path to the package (optional)
 # $(2) additional arguments to cargo (optional)

--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -33,6 +33,8 @@ RUSTC_TARGET_ARCH:=$(subst muslgnueabi,musleabi,$(RUSTC_TARGET_ARCH))
 
 ifeq ($(ARCH),i386)
   RUSTC_TARGET_ARCH:=$(subst i486,i586,$(RUSTC_TARGET_ARCH))
+else ifeq ($(ARCH),riscv64)
+  RUSTC_TARGET_ARCH:=$(subst riscv64,riscv64gc,$(RUSTC_TARGET_ARCH))
 endif
 
 # ARM Logic


### PR DESCRIPTION
rust natively supports riscv64 so let's enable it.

Maintainer: @lu-zero
Compile tested: sifiveu/generic (aardvark-dns)
Run tested: n/a