### PR TITLE
avahi: Import patches for security fixes

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=avahi
 PKG_VERSION:=0.8
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lathiat/avahi/releases/download/v$(PKG_VERSION) \

--- a/libs/avahi/patches/200-Fix-NULL-pointer-crashes-from-175.patch
+++ b/libs/avahi/patches/200-Fix-NULL-pointer-crashes-from-175.patch
@@ -1,0 +1,136 @@
+From 9d31939e55280a733d930b15ac9e4dda4497680c Mon Sep 17 00:00:00 2001
+From: Tommi Rantala <tommi.t.rantala@nokia.com>
+Date: Mon, 8 Feb 2021 11:04:43 +0200
+Subject: [PATCH] Fix NULL pointer crashes from #175
+
+avahi-daemon is crashing when running "ping .local".
+The crash is due to failing assertion from NULL pointer.
+Add missing NULL pointer checks to fix it.
+
+Introduced in #175 - merge commit 8f75a045709a780c8cf92a6a21e9d35b593bdecd
+
+[Retrieved from:
+https://github.com/lathiat/avahi/commit/9d31939e55280a733d930b15ac9e4dda4497680c]
+Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+---
+ avahi-core/browse-dns-server.c   | 5 ++++-
+ avahi-core/browse-domain.c       | 5 ++++-
+ avahi-core/browse-service-type.c | 3 +++
+ avahi-core/browse-service.c      | 3 +++
+ avahi-core/browse.c              | 3 +++
+ avahi-core/resolve-address.c     | 5 ++++-
+ avahi-core/resolve-host-name.c   | 5 ++++-
+ avahi-core/resolve-service.c     | 5 ++++-
+ 8 files changed, 29 insertions(+), 5 deletions(-)
+
+--- a/avahi-core/browse-dns-server.c
++++ b/avahi-core/browse-dns-server.c
+@@ -343,7 +343,10 @@ AvahiSDNSServerBrowser *avahi_s_dns_serv
+         AvahiSDNSServerBrowser* b;
+ 
+         b = avahi_s_dns_server_browser_prepare(server, interface, protocol, domain, type, aprotocol, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_dns_server_browser_start(b);
+ 
+         return b;
+-}
+\ No newline at end of file
++}
+--- a/avahi-core/browse-domain.c
++++ b/avahi-core/browse-domain.c
+@@ -253,7 +253,10 @@ AvahiSDomainBrowser *avahi_s_domain_brow
+         AvahiSDomainBrowser *b;
+ 
+         b = avahi_s_domain_browser_prepare(server, interface, protocol, domain, type, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_domain_browser_start(b);
+ 
+         return b;
+-}
+\ No newline at end of file
++}
+--- a/avahi-core/browse-service-type.c
++++ b/avahi-core/browse-service-type.c
+@@ -171,6 +171,9 @@ AvahiSServiceTypeBrowser *avahi_s_servic
+         AvahiSServiceTypeBrowser *b;
+ 
+         b = avahi_s_service_type_browser_prepare(server, interface, protocol, domain, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_service_type_browser_start(b);
+ 
+         return b;
+--- a/avahi-core/browse-service.c
++++ b/avahi-core/browse-service.c
+@@ -184,6 +184,9 @@ AvahiSServiceBrowser *avahi_s_service_br
+         AvahiSServiceBrowser *b;
+ 
+         b = avahi_s_service_browser_prepare(server, interface, protocol, service_type, domain, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_service_browser_start(b);
+ 
+         return b;
+--- a/avahi-core/browse.c
++++ b/avahi-core/browse.c
+@@ -634,6 +634,9 @@ AvahiSRecordBrowser *avahi_s_record_brow
+         AvahiSRecordBrowser *b;
+ 
+         b = avahi_s_record_browser_prepare(server, interface, protocol, key, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_record_browser_start_query(b);
+ 
+         return b;
+--- a/avahi-core/resolve-address.c
++++ b/avahi-core/resolve-address.c
+@@ -286,7 +286,10 @@ AvahiSAddressResolver *avahi_s_address_r
+         AvahiSAddressResolver *b;
+ 
+         b = avahi_s_address_resolver_prepare(server, interface, protocol, address, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_address_resolver_start(b);
+ 
+         return b;
+-}
+\ No newline at end of file
++}
+--- a/avahi-core/resolve-host-name.c
++++ b/avahi-core/resolve-host-name.c
+@@ -318,7 +318,10 @@ AvahiSHostNameResolver *avahi_s_host_nam
+         AvahiSHostNameResolver *b;
+ 
+         b = avahi_s_host_name_resolver_prepare(server, interface, protocol, host_name, aprotocol, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_host_name_resolver_start(b);
+ 
+         return b;
+-}
+\ No newline at end of file
++}
+--- a/avahi-core/resolve-service.c
++++ b/avahi-core/resolve-service.c
+@@ -519,7 +519,10 @@ AvahiSServiceResolver *avahi_s_service_r
+         AvahiSServiceResolver *b;
+ 
+         b = avahi_s_service_resolver_prepare(server, interface, protocol, name, type, domain, aprotocol, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_service_resolver_start(b);
+ 
+         return b;
+-}
+\ No newline at end of file
++}

--- a/libs/avahi/patches/201-Avoid-infinite-loop-in-avahi-daemon-by-handling-HUP-event.patch
+++ b/libs/avahi/patches/201-Avoid-infinite-loop-in-avahi-daemon-by-handling-HUP-event.patch
@@ -1,0 +1,36 @@
+From: Riccardo Schirone <sirmy15@gmail.com>
+Date: Fri, 26 Mar 2021 11:50:24 +0100
+Subject: Avoid infinite-loop in avahi-daemon by handling HUP event in
+ client_work
+
+If a client fills the input buffer, client_work() disables the
+AVAHI_WATCH_IN event, thus preventing the function from executing the
+`read` syscall the next times it is called. However, if the client then
+terminates the connection, the socket file descriptor receives a HUP
+event, which is not handled, thus the kernel keeps marking the HUP event
+as occurring. While iterating over the file descriptors that triggered
+an event, the client file descriptor will keep having the HUP event and
+the client_work() function is always called with AVAHI_WATCH_HUP but
+without nothing being done, thus entering an infinite loop.
+
+See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=984938
+
+(cherry picked from commit 447affe29991ee99c6b9732fc5f2c1048a611d3b)
+---
+ avahi-daemon/simple-protocol.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/avahi-daemon/simple-protocol.c
++++ b/avahi-daemon/simple-protocol.c
+@@ -424,6 +424,11 @@ static void client_work(AvahiWatch *watc
+         }
+     }
+ 
++    if (events & AVAHI_WATCH_HUP) {
++        client_free(c);
++        return;
++    }
++
+     c->server->poll_api->watch_update(
+         watch,
+         (c->outbuf_length > 0 ? AVAHI_WATCH_OUT : 0) |

--- a/libs/avahi/patches/202-avahi_dns_packet_consume_uint32-fix-potential-undefined-b.patch
+++ b/libs/avahi/patches/202-avahi_dns_packet_consume_uint32-fix-potential-undefined-b.patch
@@ -1,0 +1,27 @@
+From: traffic-millions <60914101+traffic-millions@users.noreply.github.com>
+Date: Tue, 3 Mar 2020 11:15:48 +0800
+Subject: avahi_dns_packet_consume_uint32: fix potential undefined behavior
+
+avahi_dns_packet_consume_uint32 left shifts uint8_t values by 8, 16 and 24 bits to combine them into a 32-bit value. This produces an undefined behavior warning with gcc -fsanitize when fed input values of 128 or 255 however in testing no actual unexpected behavior occurs in practice and the 32-bit uint32_t is always correctly produced as the final value is immediately stored into a uint32_t and the compiler appears to handle this "correctly".
+
+Cast the intermediate values to uint32_t to prevent this warning and ensure the intended result is explicit.
+
+Closes: #267
+Closes: #268
+Reference: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19304
+Origin: upstream, 0.9, commit:b897ca43ac100d326d118e5877da710eb7f836f9
+---
+ avahi-core/dns.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/avahi-core/dns.c
++++ b/avahi-core/dns.c
+@@ -455,7 +455,7 @@ int avahi_dns_packet_consume_uint32(Avah
+         return -1;
+ 
+     d = (uint8_t*) (AVAHI_DNS_PACKET_DATA(p) + p->rindex);
+-    *ret_v = (d[0] << 24) | (d[1] << 16) | (d[2] << 8) | d[3];
++    *ret_v = ((uint32_t)d[0] << 24) | ((uint32_t)d[1] << 16) | ((uint32_t)d[2] << 8) | (uint32_t)d[3];
+     p->rindex += sizeof(uint32_t);
+ 
+     return 0;

--- a/libs/avahi/patches/203-Do-not-disable-timeout-cleanup-on-watch-cleanup.patch
+++ b/libs/avahi/patches/203-Do-not-disable-timeout-cleanup-on-watch-cleanup.patch
@@ -1,0 +1,22 @@
+From: Gustavo Noronha Silva <gustavo@noronha.dev.br>
+Date: Sun, 2 Jan 2022 22:29:04 -0300
+Subject: Do not disable timeout cleanup on watch cleanup
+
+This was causing timeouts to never be removed from the linked list that
+tracks them, resulting in both memory and CPU usage to grow larger over
+time.
+---
+ avahi-common/simple-watch.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/avahi-common/simple-watch.c
++++ b/avahi-common/simple-watch.c
+@@ -238,7 +238,7 @@ static void cleanup_watches(AvahiSimpleP
+             destroy_watch(w);
+     }
+ 
+-    s->timeout_req_cleanup = 0;
++    s->watch_req_cleanup = 0;
+ }
+ 
+ static AvahiTimeout* timeout_new(const AvahiPoll *api, const struct timeval *tv, AvahiTimeoutCallback callback, void *userdata) {

--- a/libs/avahi/patches/204-Emit-error-if-requested-service-is-not-found.patch
+++ b/libs/avahi/patches/204-Emit-error-if-requested-service-is-not-found.patch
@@ -1,0 +1,54 @@
+From: =?utf-8?b?UGV0ciBNZW7FocOtaw==?= <pemensik@redhat.com>
+Date: Thu, 17 Nov 2022 01:51:53 +0100
+Subject: Emit error if requested service is not found
+
+It currently just crashes instead of replying with error. Check return
+value and emit error instead of passing NULL pointer to reply.
+
+Fixes #375
+
+(cherry picked from commit a2696da2f2c50ac43b6c4903f72290d5c3fa9f6f)
+---
+ avahi-daemon/dbus-protocol.c | 20 ++++++++++++++------
+ 1 file changed, 14 insertions(+), 6 deletions(-)
+
+--- a/avahi-daemon/dbus-protocol.c
++++ b/avahi-daemon/dbus-protocol.c
+@@ -375,10 +375,14 @@ static DBusHandlerResult dbus_get_altern
+     }
+ 
+     t = avahi_alternative_host_name(n);
+-    avahi_dbus_respond_string(c, m, t);
+-    avahi_free(t);
+-
+-    return DBUS_HANDLER_RESULT_HANDLED;
++    if (t) {
++        avahi_dbus_respond_string(c, m, t);
++        avahi_free(t);
++
++        return DBUS_HANDLER_RESULT_HANDLED;
++    } else {
++        return avahi_dbus_respond_error(c, m, AVAHI_ERR_NOT_FOUND, "Hostname not found");
++    }
+ }
+ 
+ static DBusHandlerResult dbus_get_alternative_service_name(DBusConnection *c, DBusMessage *m, DBusError *error) {
+@@ -389,10 +393,14 @@ static DBusHandlerResult dbus_get_altern
+     }
+ 
+     t = avahi_alternative_service_name(n);
+-    avahi_dbus_respond_string(c, m, t);
+-    avahi_free(t);
+-
+-    return DBUS_HANDLER_RESULT_HANDLED;
++    if (t) {
++        avahi_dbus_respond_string(c, m, t);
++        avahi_free(t);
++
++        return DBUS_HANDLER_RESULT_HANDLED;
++    } else {
++        return avahi_dbus_respond_error(c, m, AVAHI_ERR_NOT_FOUND, "Service not found");
++    }
+ }
+ 
+ static DBusHandlerResult dbus_create_new_entry_group(DBusConnection *c, DBusMessage *m, DBusError *error) {

--- a/libs/avahi/patches/205-conf-file-line-lengths.patch
+++ b/libs/avahi/patches/205-conf-file-line-lengths.patch
@@ -1,0 +1,11 @@
+--- a/avahi-daemon/ini-file-parser.c
++++ b/avahi-daemon/ini-file-parser.c
+@@ -50,7 +50,7 @@ AvahiIniFile* avahi_ini_file_load(const
+ 
+     line = 0;
+     while (!feof(fo)) {
+-        char ln[256], *s, *e;
++        char ln[1024], *s, *e;
+         AvahiIniFilePair *pair;
+ 
+         if (!(fgets(ln, sizeof(ln), fo)))


### PR DESCRIPTION
Maintainer: @thess
 Compile tested: head, aarch64, arm, i386, x86_64
Run tested: (qemu 8.0.2) aarch64

Description:
Imported patches included in debian and other package.

* 200-Fix-NULL-pointer-crashes-from-175.patch
   CVE-2021-3502
    A flaw was found in avahi 0.8-5. A reachable assertion is present in avahi_s_host_name_resolver_start function allowing a local attacker to crash the avahi service by requesting hostname resolutions through the avahi socket or dbus methods for invalid hostnames. The highest threat from this vulnerability is to the service availability.

* 201-Avoid-infinite-loop-in-avahi-daemon-by-handling-HUP-event.patch
  CVE-2021-3468
   A flaw was found in avahi in versions 0.6 up to 0.8. The event used to signal the termination of the client connection on the avahi Unix socket is not correctly handled in the client_work function, allowing a local attacker to trigger an infinite loop. The highest threat from this vulnerability is to the availability of the avahi service, which becomes unresponsive after this flaw is triggered.

* 202-avahi_dns_packet_consume_uint32-fix-potential-undefined-b.patch
   avahi_dns_packet_consume_uint32 left shifts uint8_t values by 8, 16 and 24 bits to combine them into a 32-bit value. This produces an undefined behavior warning with gcc -fsanitize when fed input values of 128 or 255 however in testing no actual unexpected behavior occurs in practice and the 32-bit uint32_t is always correctly produced as the final value is immediately stored into a uint32_t and the compiler appears to handle this "correctly". Cast the intermediate values to uint32_t to prevent this warning and ensure the intended result is explicit.

* 203-Do-not-disable-timeout-cleanup-on-watch-cleanup.patch
   This was causing timeouts to never be removed from the linked list that tracks them, resulting in both memory and CPU usage to grow larger over time.

* 204-Emit-error-if-requested-service-is-not-found.patch
  CVE-2023-1981
   It currently just crashes instead of replying with error. Check return value and emit error instead of passing NULL pointer to reply.

* 205-conf-file-line-lengths.patch
   Allow avahi-daemon.conf file to have lines longer than 256 characters (new limit 1024).

