### PR TITLE
knot: fix linking of riscv64 architecture

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -50,7 +50,7 @@ endef
 define Package/knot-libzscanner
 	$(call Package/knot-lib/Default)
 	TITLE+= zone parser library
-	DEPENDS+=@!arc
+	DEPENDS+=+riscv64:libatomic @!arc
 endef
 
 define Package/knot

--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
 PKG_VERSION:=3.2.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
@@ -37,7 +37,7 @@ define Package/knot/Default
 	CATEGORY:=Network
 	SUBMENU:=IP Addresses and Names
 	TITLE:=Knot DNS
-	DEPENDS=+libatomic
+	DEPENDS=+riscv64:libatomic
 	URL:=https://www.knot-dns.cz
 endef
 
@@ -188,6 +188,10 @@ define Build/InstallDev
 	$(INSTALL_DIR)							$(1)/usr/lib/pkgconfig
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc	$(1)/usr/lib/pkgconfig/
 endef
+endif
+
+ifneq ($(findstring riscv64,$(CONFIG_ARCH)),)
+TARGET_LDFLAGS += -latomic
 endif
 
 define Package/knot-libs/install


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan
Compile tested: no
Run tested: no

Description:
 - Fix package build on riscv64 architecture