### PR TITLE
treewide: remove COMMITCOUNT

### DIFF
--- a/utils/attendedsysupgrade-common/Makefile
+++ b/utils/attendedsysupgrade-common/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=attendedsysupgrade-common
-PKG_VERSION:=$(COMMITCOUNT)
+PKG_VERSION:=8
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/utils/fakeuname/Makefile
+++ b/utils/fakeuname/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fakeuname
-PKG_RELEASE:=$(COMMITCOUNT)
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0-or-later
 
 PKG_MAINTAINER:=Sergey V. Lobanov <sergey@lobanov.in>


### PR DESCRIPTION
Maintainer: @aparcar, @svlobanov

Description:
Automatically compute and substitute current values for all $(COMMITCOUNT) instances as this feature is deprecated and shouldn't be used.

Based on commit 0c10c224be81:

Change COMMITCOUNT in rules.mk to:
```
COMMITCOUNT = $(if $(DUMP),0,$(shell sed -i "s/\$$(COMMITCOUNT)/$(call commitcount)/" $(CURDIR)/Makefile))
```

then update all affected packages by:
```
for i in $(git -C feeds/packages grep -l COMMITCOUNT | sed 's^.*/\([^/]*\)/Makefile^\1^';);
do
	make package/$i/clean
done
```

All affected packages are untouched since 23.05 branching. It should be straightforward applying this patch also to that branch.