### PR TITLE
transmission: Fix env variables passing

### DIFF
--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -158,8 +158,8 @@ transmission() {
 		logger -t transmission "Starting with $USE virt mem"
 	fi
 
-	[ -d "$web_home" ] && procd_set_param env TRANSMISSION_WEB_HOME="$web_home"
-	[ "$ca_bundle" -gt 0 ] && procd_set_param env CURL_CA_BUNDLE="$ca_bundle_file"
+	[ -d "$web_home" ] && procd_append_param env TRANSMISSION_WEB_HOME="$web_home"
+	[ "$ca_bundle" -gt 0 ] && procd_append_param env CURL_CA_BUNDLE="$ca_bundle_file"
 
 	procd_add_jail transmission log
 	procd_add_jail_mount "$config_file"


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: N/A
Run tested: OpenWrt 22.03.5 on WD My Book Live

Description:
It's not possible to configure custom Transmission web home as corresp. environment variable gets overwritten by the command that sets CA bundle environment variable.

The fix is to replace `procd_set_param` with `procd_append_param`.