### PR TITLE
treewide: change references from armvirt to armsr

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -15,12 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: aarch64_cortex-a53
-            target: mvebu-cortexa53
+          - arch: aarch64_generic
+            target: armsr-armv8
             runtime_test: true
 
           - arch: arm_cortex-a15_neon-vfpv4
-            target: armvirt-32
+            target: armsr-armv7
             runtime_test: true
 
           - arch: arm_cortex-a9_vfpv3-d16

--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -459,7 +459,7 @@ $(eval $(call BuildPlugin,chrony,chrony status input,chrony,))
 $(eval $(call BuildPlugin,conntrack,connection tracking table size input,conntrack,))
 $(eval $(call BuildPlugin,contextswitch,context switch input,contextswitch,))
 $(eval $(call BuildPlugin,cpu,CPU input,cpu,))
-$(eval $(call BuildPlugin,cpufreq,CPU Freq input,cpufreq,@(TARGET_x86||TARGET_x86_64||TARGET_mvebu||TARGET_ipq806x||TARGET_armvirt||TARGET_ipq40xx||TARGET_bcm27xx_bcm2709||TARGET_rockchip||TARGET_mediatek||TARGET_ipq807x))) # Only enable on targets with CPUs supporting frequency scaling
+$(eval $(call BuildPlugin,cpufreq,CPU Freq input,cpufreq,@(TARGET_x86||TARGET_x86_64||TARGET_mvebu||TARGET_ipq806x||TARGET_armsr||TARGET_ipq40xx||TARGET_bcm27xx_bcm2709||TARGET_rockchip||TARGET_mediatek||TARGET_ipq807x))) # Only enable on targets with CPUs supporting frequency scaling
 $(eval $(call BuildPlugin,csv,CSV output,csv,))
 $(eval $(call BuildPlugin,curl,cURL input,curl,+PACKAGE_collectd-mod-curl:libcurl))
 #$(eval $(call BuildPlugin,dbi,relational database input,dbi,+PACKAGE_collectd-mod-dbi:libdbi))

--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -28,7 +28,7 @@ PKG_BUILD_DEPENDS+=spice-protocol
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/package.mk
 
-QEMU_DEPS_IN_GUEST := @(TARGET_x86_64||TARGET_armvirt||TARGET_malta)
+QEMU_DEPS_IN_GUEST := @(TARGET_x86_64||TARGET_armsr||TARGET_malta)
 QEMU_DEPS_IN_HOST := @(TARGET_x86_64||TARGET_sunxi)
 QEMU_DEPS_IN_HOST += +libstdcpp
 QEMU_DEPS_IN_HOST += $(ICONV_DEPENDS)


### PR DESCRIPTION
Maintainer: @hnyman @jow- for collected, @yousong for qemu, @aparcar for ci 
Compile tested: n/a
Run tested: n/a

Description:
armvirt target has been renamed to armsr (Arm SystemReady),
so the dependency need to be changed as well.

Related to https://github.com/openwrt/openwrt/pull/12832