### PR TITLE
crun: update v1.8.5

### DIFF
--- a/utils/crun/Makefile
+++ b/utils/crun/Makefile
@@ -1,14 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crun
-PKG_VERSION:=1.7.2
-PKG_RELEASE:=2
+PKG_VERSION:=1.8.5
+PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/containers/crun.git
-PKG_SOURCE_DATE:=2023-01-11
-PKG_SOURCE_VERSION:=4e5bd755c12a86f2e36962964f3eab7b3516d3ac
-PKG_MIRROR_HASH:=8e6b0f3e9dde982601f562683f5c744b03e630681afaf9aaacaa4c89ccec23dc
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/containers/crun/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=14e3d4b35767e02f2da97342e703a284738f2f0f86b4dbfb467f2b8b294ef391
 
 PKG_BUILD_DEPENDS:=argp-standalone
 PKG_BUILD_PARALLEL:=1
@@ -33,6 +31,18 @@ define Package/crun/description
   A fast and low-memory footprint OCI Container Runtime fully written in C.
 endef
 
+LIBOCISPEC_COMMIT:=19c05670c37a42c217caa7b141bcaada7867cc15
+
+define Download/libocispec
+  PROTO:=git
+  URL:=https://github.com/containers/libocispec.git
+  VERSION:=$(LIBOCISPEC_COMMIT)
+  MIRROR_HASH:=eacd0096e4acdcdb7f5062897e336934844b45d3b1d8a306801eb39ea9fae5c0
+  FILE:=libocispec-$(LIBOCISPEC_COMMIT).tar.xz
+  SUBDIR:=libocispec
+endef
+$(eval $(call Download,libocispec))
+
 CONFIGURE_ARGS+= \
 	--disable-systemd \
 	--enable-embedded-yajl \
@@ -44,6 +54,7 @@ CONFIGURE_ARGS+= \
 define Build/Prepare
 	$(call Build/Prepare/Default)
 	$(SED) '/#include <git-version.h>/d' $(PKG_BUILD_DIR)/src/crun.c
+	xzcat $(DL_DIR)/libocispec-$(LIBOCISPEC_COMMIT).tar.xz | $(HOST_TAR) -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
 endef
 
 define Build/Configure


### PR DESCRIPTION
Description:
Moved to from git to release version,
but release version does not have submodule
libocispec included, so additional download added.

Release notes: https://github.com/containers/crun/releases

Maintainer: me / @oskarirauta 
Compile tested: x86_64, latest git
Run tested: x86_64, latest git