### PR TITLE
nginx: bump to new 1.25.0 release

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
-PKG_VERSION:=1.24.0
-PKG_RELEASE:=3
+PKG_VERSION:=1.25.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
-PKG_HASH:=77a2541637b92a621e3ee76776c8b7b40cf6d707e69ba53a940283e30ff2f55d
+PKG_HASH:=5ed44d45943272a4e8a5bcf4434237210f2de31b903fca5e381c1bbd7eee1e8c
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de> \
 				Ansuel Smith <ansuelsmth@gmail.com>

--- a/net/nginx/patches/nginx/101-feature_test_fix.patch
+++ b/net/nginx/patches/nginx/101-feature_test_fix.patch
@@ -78,7 +78,7 @@
  ngx_feature_libs=
 --- a/auto/unix
 +++ b/auto/unix
-@@ -805,7 +805,7 @@ ngx_feature_test="void *p; p = memalign(
+@@ -853,7 +853,7 @@ ngx_feature_test="void *p; p = memalign(
  
  ngx_feature="mmap(MAP_ANON|MAP_SHARED)"
  ngx_feature_name="NGX_HAVE_MAP_ANON"
@@ -87,7 +87,7 @@
  ngx_feature_incs="#include <sys/mman.h>"
  ngx_feature_path=
  ngx_feature_libs=
-@@ -818,7 +818,7 @@ ngx_feature_test="void *p;
+@@ -866,7 +866,7 @@ ngx_feature_test="void *p;
  
  ngx_feature='mmap("/dev/zero", MAP_SHARED)'
  ngx_feature_name="NGX_HAVE_MAP_DEVZERO"
@@ -96,7 +96,7 @@
  ngx_feature_incs="#include <sys/mman.h>
                    #include <sys/stat.h>
                    #include <fcntl.h>"
-@@ -833,7 +833,7 @@ ngx_feature_test='void *p; int  fd;
+@@ -881,7 +881,7 @@ ngx_feature_test='void *p; int  fd;
  
  ngx_feature="System V shared memory"
  ngx_feature_name="NGX_HAVE_SYSVSHM"
@@ -105,7 +105,7 @@
  ngx_feature_incs="#include <sys/ipc.h>
                    #include <sys/shm.h>"
  ngx_feature_path=
-@@ -847,7 +847,7 @@ ngx_feature_test="int  id;
+@@ -895,7 +895,7 @@ ngx_feature_test="int  id;
  
  ngx_feature="POSIX semaphores"
  ngx_feature_name="NGX_HAVE_POSIX_SEM"

--- a/net/nginx/patches/nginx/201-ignore-invalid-options.patch
+++ b/net/nginx/patches/nginx/201-ignore-invalid-options.patch
@@ -1,6 +1,6 @@
 --- a/auto/options
 +++ b/auto/options
-@@ -402,8 +402,7 @@ $0: warning: the \"--with-sha1-asm\" opt
+@@ -411,8 +411,7 @@ $0: warning: the \"--with-sha1-asm\" opt
          --test-build-solaris-sendfilev)  NGX_TEST_BUILD_SOLARIS_SENDFILEV=YES ;;
  
          *)


### PR DESCRIPTION
Bump nginx to new 1.25.0 release.
Changes:

 *) Feature: experimental HTTP/3 support.

Every patch automatically refreshed.