### PR TITLE
glib2: disable gnulib printf

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.74.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=@GNOME/glib/$(word 1,$(subst ., ,$(PKG_VERSION))).$(word 2,$(subst ., ,$(PKG_VERSION)))
+PKG_SOURCE_URL:=@GNOME/glib/$(basename $(PKG_VERSION))
 PKG_HASH:=3652c7f072d7b031a6b5edd623f77ebc5dcd2ae698598abcc89ff39ca75add30
 
 PKG_MAINTAINER:=Peter Wagner <tripolar@gmx.at>

--- a/libs/glib2/patches/006-c99.patch
+++ b/libs/glib2/patches/006-c99.patch
@@ -1,0 +1,11 @@
+--- a/meson.build
++++ b/meson.build
+@@ -1045,7 +1045,7 @@ if host_system == 'windows' and (cc.get_
+   glib_conf.set('HAVE_C99_SNPRINTF', false)
+   glib_conf.set('HAVE_C99_VSNPRINTF', false)
+   glib_conf.set('HAVE_UNIX98_PRINTF', false)
+-elif not cc_can_run and host_system in ['ios', 'darwin']
++elif true
+   # All these are true when compiling natively on macOS, so we should use good
+   # defaults when building for iOS and tvOS.
+   glib_conf.set('HAVE_C99_SNPRINTF', true)


### PR DESCRIPTION
Maintainer: @neheb
Compile tested: mipsel_24kc_24kf master
Run tested: n/a

Description:
A compiler bug (suspiciously) blocks gnulib compilation for mipsel_24kc_24kf. While we had this patch to disable gnulib, it was accidentally removed by 5d27631d9fbca076eb6377fc8c10f474ce9f4fea. Add it back to fix the long broken build for mipsel_24kc_24kf.

Fixes: #19511