### PR TITLE
aardvark-dns: update to v1.6.0

### DIFF
--- a/net/aardvark-dns/Makefile
+++ b/net/aardvark-dns/Makefile
@@ -1,13 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aardvark-dns
+PKG_VERSION:=1.6.0
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/containers/aardvark-dns.git
-PKG_SOURCE_DATE:=2023-05-12
-PKG_SOURCE_VERSION:=6e06736707d8a84240858e968a54a083083e3a09
-PKG_MIRROR_HASH:=407d73c0a01b9fd6248a1ce058541707580db46a7d18f776780fe7922ba97391
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/containers/aardvark-dns/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=f3a2ff2d7baf07d8bf2785b6f1c9618db8aa188bd738b7f5cf1b0a31848232f5
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
aardvark-dns v1.6.0 was released,
so instead of using git version, use release -
similarly like netavark.
Very much hasn't changed but list of changes
is in git commit log of aardvark-dns.

Maintainer: me
Compile tested: x86_64, latest git
Run tested: x86_64, latest git