### PR TITLE
treewide: change armvirt target references to armsr (qemu,collectd,CI)

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -20,7 +20,7 @@ jobs:
             runtime_test: true
 
           - arch: arm_cortex-a15_neon-vfpv4
-            target: armvirt-32
+            target: armsr-armv7
             runtime_test: true
 
           - arch: arm_cortex-a9_vfpv3-d16

--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.12.0
-PKG_RELEASE:=43
+PKG_RELEASE:=44
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \
@@ -459,7 +459,7 @@ $(eval $(call BuildPlugin,chrony,chrony status input,chrony,))
 $(eval $(call BuildPlugin,conntrack,connection tracking table size input,conntrack,))
 $(eval $(call BuildPlugin,contextswitch,context switch input,contextswitch,))
 $(eval $(call BuildPlugin,cpu,CPU input,cpu,))
-$(eval $(call BuildPlugin,cpufreq,CPU Freq input,cpufreq,@(TARGET_x86||TARGET_x86_64||TARGET_mvebu||TARGET_ipq806x||TARGET_armvirt||TARGET_ipq40xx||TARGET_bcm27xx_bcm2709||TARGET_rockchip||TARGET_mediatek||TARGET_ipq807x))) # Only enable on targets with CPUs supporting frequency scaling
+$(eval $(call BuildPlugin,cpufreq,CPU Freq input,cpufreq,@(TARGET_x86||TARGET_x86_64||TARGET_mvebu||TARGET_ipq806x||TARGET_armsr||TARGET_ipq40xx||TARGET_bcm27xx_bcm2709||TARGET_rockchip||TARGET_mediatek||TARGET_ipq807x))) # Only enable on targets with CPUs supporting frequency scaling
 $(eval $(call BuildPlugin,csv,CSV output,csv,))
 $(eval $(call BuildPlugin,curl,cURL input,curl,+PACKAGE_collectd-mod-curl:libcurl))
 #$(eval $(call BuildPlugin,dbi,relational database input,dbi,+PACKAGE_collectd-mod-dbi:libdbi))

--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qemu
 PKG_VERSION:=8.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_HASH:=bb60f0341531181d6cc3969dd19a013d0427a87f918193970d9adb91131e56d0
 PKG_SOURCE_URL:=http://download.qemu.org/
@@ -28,7 +28,7 @@ PKG_BUILD_DEPENDS+=spice-protocol
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/package.mk
 
-QEMU_DEPS_IN_GUEST := @(TARGET_x86_64||TARGET_armvirt||TARGET_malta)
+QEMU_DEPS_IN_GUEST := @(TARGET_x86_64||TARGET_armsr||TARGET_malta)
 QEMU_DEPS_IN_HOST := @(TARGET_x86_64||TARGET_sunxi)
 QEMU_DEPS_IN_HOST += +libstdcpp
 QEMU_DEPS_IN_HOST += $(ICONV_DEPENDS)


### PR DESCRIPTION
A couple of days ago, the armvirt target was renamed to 'armsr' (Arm SystemReady) after the introduction of EFI and support for 'real' hardware.

There are a few `DEPENDS:=@TARGET_armvirt||@TARGET_etc` references in the OpenWrt feeds which need to be changed, as well as the GitHub workflow.

See http://lists.openwrt.org/pipermail/openwrt-devel/2023-June/041151.html and https://github.com/openwrt/openwrt/pull/12832
The same change is likely to occur for the 23.05 branch as well: https://github.com/openwrt/openwrt/pull/12817

Marking this is a DRAFT until the buildbot (and downloads.openwrt.org) catches up with the target name change.

qemu:
Maintainer: @yousong 

collectd (cpufreq module):
Maintainer: @akosiaris

Compile tested: armvirt/armv8
Run tested: armvirt/armv8 VM (qemu)
