### PR TITLE
libmraa: riscv64 not supported

### DIFF
--- a/libs/libmraa/Makefile
+++ b/libs/libmraa/Makefile
@@ -54,7 +54,7 @@ endef
 define Package/libmraa
   $(call Package/libmraa/Default)
   TITLE:=Eclipse MRAA lowlevel IO C/C++ library
-  DEPENDS:=+libstdcpp +libjson-c @!arc @!armeb @!powerpc
+  DEPENDS:=+libstdcpp +libjson-c @!arc @!armeb @!powerpc @!riscv64
 endef
 
 define Package/libmraa/description


### PR DESCRIPTION
Maintainer: @blogic me
Compile tested: head, riscv64
Run tested: N/A 

Description:
Addresses buildbot errors

> CMake Error at CMakeLists.txt:193 (message):
>  Only x86, arm, mips, PERIPHERALMAN and mock platforms currently supported
