### PR TITLE
watchcat: fix misleading prints about restarting network

### DIFF
--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=25
+PKG_RELEASE:=26
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>, Dharmik Parmar <dharmikparmar2004@yahoo.com>
 PKG_LICENSE:=GPL-2.0

--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -219,6 +219,7 @@ watchcat_monitor_network() {
 
 	ping_family="$(get_ping_family_flag "$address_family")"
 
+	about_to_restart_iface=1
 	while true; do
 		# account for the time ping took to return. With a ping time of 5s, ping might take more than that, so it is important to avoid even more delay.
 		time_now="$(cat /proc/uptime)"
@@ -231,6 +232,7 @@ watchcat_monitor_network() {
 		time_now="${time_now%%.*}"
 		time_lastcheck="$time_now"
 
+		end_result=1
 		for host in $ping_hosts; do
 			if [ "$ping_iface" != "" ]; then
 				ping_result="$(
@@ -246,16 +248,31 @@ watchcat_monitor_network() {
 
 			if [ "$ping_result" -eq 0 ]; then
 				time_lastcheck_withinternet="$time_now"
-			else
-				if [ "$script" != "" ]; then
-					logger -p daemon.info -t "watchcat[$$]" "Could not reach $host via \"$iface\" for \"$((time_now - time_lastcheck_withinternet))\" seconds. Will run the script after \"$failure_period\" seconds of failed reachability"
-				elif [ "$iface" != "" ]; then
-					logger -p daemon.info -t "watchcat[$$]" "Could not reach $host via \"$iface\" for \"$((time_now - time_lastcheck_withinternet))\" seconds. Will restart \"$iface\" after \"$failure_period\" seconds of failed reachability"
-				else
-					logger -p daemon.info -t "watchcat[$$]" "Could not reach $host for \"$((time_now - time_lastcheck_withinternet))\" seconds. Will restart networking after \"$failure_period\" seconds of failed reachability"
+				end_result=0
+				if [ "$about_to_restart_iface" -eq 0 ]; then
+					if [ "$script" != "" ]; then
+						logger -p daemon.info -t "watchcat[$$]" "$host replies to ping, running script cancelled"
+					elif [ "$iface" != "" ]; then
+						logger -p daemon.info -t "watchcat[$$]" "$host replies to ping, restarting \"$iface\" cancelled"
+					else
+						logger -p daemon.info -t "watchcat[$$]" "$host replies to ping, restarting networking cancelled"
+					fi
+					about_to_restart_iface=1
 				fi
+			else
+				logger -p daemon.info -t "watchcat[$$]" "Could not reach $host for \"$((time_now - time_lastcheck_withinternet))\" seconds."
 			fi
 		done
+		if [ "$end_result" -ne 0 ]; then
+			if [ "$script" != "" ]; then
+				logger -p daemon.info -t "watchcat[$$]" "Could not reach any configured host for \"$((time_now - time_lastcheck_withinternet))\" seconds. Will run the script after \"$failure_period\" seconds of failed reachability"
+			elif [ "$iface" != "" ]; then
+				logger -p daemon.info -t "watchcat[$$]" "Could not reach any configured host via \"$iface\" for \"$((time_now - time_lastcheck_withinternet))\" seconds. Will restart \"$iface\" after \"$failure_period\" seconds of failed reachability"
+			else
+				logger -p daemon.info -t "watchcat[$$]" "Could not reach any configured host for \"$((time_now - time_lastcheck_withinternet))\" seconds. Will restart networking after \"$failure_period\" seconds of failed reachability"
+			fi
+			about_to_restart_iface=0
+		fi
 
 		[ "$((time_now - time_lastcheck_withinternet))" -ge "$failure_period" ] && {
 			recovery_started="$time_now"
@@ -273,6 +290,7 @@ watchcat_monitor_network() {
 				fi
 			fi
 			/etc/init.d/watchcat start
+			about_to_restart_iface=1
 			# Optionally start a fresh failure window after the recovery action
 			# finishes instead of continuing to count the original outage.
 			if [ "$reset_failure_timer" = "1" ]; then


### PR DESCRIPTION
Maintainer: @roger-
Compile tested: ipq40xx, VG710, OpenWrt 22.03.0-rc4
Run tested: ipq40xx, VG710, OpenWrt 22.03.0-rc4

Description:
Noticed that watchcat prints it will restart an interface or networking (or run script) when pinging any configured host fails even though the action (restart/script run) is committed only if none of the hosts can be pinged.