### PR TITLE
cloudreve: Update to 3.8.0

### DIFF
--- a/net/cloudreve/Makefile
+++ b/net/cloudreve/Makefile
@@ -5,13 +5,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cloudreve
-PKG_VERSION:=3.7.1
+PKG_VERSION:=3.8.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/cloudreve/Cloudreve.git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
-PKG_MIRROR_HASH:=b70601111e727d879a709884bc28237861216b99abac02b6f542f5984ddd8c0d
+PKG_MIRROR_HASH:=4c05afb2193ab83bf144d75963f4757c1445317e68b2690727375a8e01f7ba3d
 
 PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILES:=LICENSE
@@ -35,7 +35,7 @@ define Package/cloudreve
   SUBMENU:=Cloud Manager
   TITLE:=A project helps you build your own cloud in minutes
   URL:=https://cloudreve.org
-  DEPENDS:=@(aarch64||arm||i386||i686||x86_64) +ca-bundle
+  DEPENDS:=@(aarch64||arm||i386||i686||riscv64||x86_64) +ca-bundle
 endef
 
 define Package/cloudreve/description
@@ -48,6 +48,8 @@ define Build/Compile
 		pushd $(PKG_BUILD_DIR)/assets ; \
 		yarn install ; \
 		yarn run build ; \
+		cd .. ; \
+		zip -r - assets/build > assets.zip ; \
 		popd ; \
 		$(call GoPackage/Build/Compile) ; \
 	)


### PR DESCRIPTION
Maintainer: me
Compile tested: rockchip/armv8
Run tested: nanopi-r2s

Description:
Updated cloudreve and added missing web frontend assets archive.