### PR TITLE
php8: revert workaround to fix linking on riscv64 platform

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -94,7 +94,7 @@ endef
 
 define Package/php8-cli
   $(call Package/php8/Default)
-  DEPENDS+= +PACKAGE_php8-mod-intl:libstdcpp +riscv64:libatomic
+  DEPENDS+= +PACKAGE_php8-mod-intl:libstdcpp
   TITLE+= (CLI)
 endef
 
@@ -105,7 +105,7 @@ endef
 
 define Package/php8-cgi
   $(call Package/php8/Default)
-  DEPENDS+= +PACKAGE_php8-mod-intl:libstdcpp +riscv64:libatomic
+  DEPENDS+= +PACKAGE_php8-mod-intl:libstdcpp
   TITLE+= (CGI & FastCGI)
 endef
 
@@ -127,7 +127,7 @@ endef
 
 define Package/php8-fpm
   $(call Package/php8/Default)
-  DEPENDS+= +PACKAGE_php8-mod-intl:libstdcpp +riscv64:libatomic
+  DEPENDS+= +PACKAGE_php8-mod-intl:libstdcpp
   TITLE+= (FPM)
 endef
 
@@ -159,7 +159,6 @@ define Package/apache-mod-php8
   CATEGORY:=Network
   DEPENDS+=PACKAGE_apache-mod-php8:apache \
 	   +PACKAGE_php8-mod-intl:libstdcpp \
-	   +riscv64:libatomic \
 	   +libpcre2 +zlib
   TITLE:=PHP8 module for Apache Web Server
 endef
@@ -197,9 +196,6 @@ TARGET_LDFLAGS += -ldl
 endif
 ifeq ($(CONFIG_USE_MUSL),y)
 TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
-endif
-ifneq ($(findstring riscv64,$(CONFIG_ARCH)),)
-TARGET_LDFLAGS += -latomic
 endif
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-bcmath),)
@@ -606,8 +602,6 @@ define BuildModule
 
   define Package/php8-mod-$(1)
     $(call Package/php8/Default)
-
-    DEPENDS+=+riscv64:libatomic
 
     ifneq ($(3),)
       DEPENDS+=$(3)


### PR DESCRIPTION
Maintainer: me
Compile tested: riscv64
Run tested: -

Description:

This reverts commit a2e76e49787e97253c02d72d27e3d304d68ff488.

Now that the issue is fixed on gcc side (see openwrt/openwrt@7b4a966), we can revert this workaround here.
