### PR TITLE
h2o: Reduce the flash and runtime memory footprint

### DIFF
--- a/libs/h2o/Makefile
+++ b/libs/h2o/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=h2o
 PKG_VERSION:=2.2.6
-PKG_RELEASE:=13
+PKG_RELEASE:=14
 
 PKG_SOURCE_URL:=https://codeload.github.com/h2o/h2o/tar.gz/v${PKG_VERSION}?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -26,7 +26,7 @@ define Package/libh2o-evloop
   CATEGORY:=Libraries
   TITLE:=H2O Library compiled with its own event loop
   URL:=https://h2o.examp1e.net/
-  DEPENDS:=+libopenssl +zlib +libyaml
+  DEPENDS:=+libopenssl +zlib
 endef
 
 define Package/libh2o

--- a/libs/h2o/patches/700-no-mime-map.patch
+++ b/libs/h2o/patches/700-no-mime-map.patch
@@ -1,0 +1,73 @@
+--- a/lib/core/config.c
++++ b/lib/core/config.c
+@@ -1,3 +1,4 @@
++
+ /*
+  * Copyright (c) 2014-2016 DeNA Co., Ltd.
+  *
+@@ -37,7 +38,9 @@ static h2o_hostconf_t *create_hostconf(h
+     hostconf->http2.push_preload = 1; /* enabled by default */
+     h2o_config_init_pathconf(&hostconf->fallback_path, globalconf, NULL, globalconf->mimemap);
+     hostconf->mimemap = globalconf->mimemap;
+-    h2o_mem_addref_shared(hostconf->mimemap);
++    if (hostconf->mimemap) {
++      h2o_mem_addref_shared(hostconf->mimemap);
++    }
+     return hostconf;
+ }
+ 
+@@ -54,7 +57,9 @@ static void destroy_hostconf(h2o_hostcon
+     }
+     free(hostconf->paths.entries);
+     h2o_config_dispose_pathconf(&hostconf->fallback_path);
+-    h2o_mem_release_shared(hostconf->mimemap);
++    if (hostconf->mimemap) {
++      h2o_mem_release_shared(hostconf->mimemap);
++    }
+ 
+     free(hostconf);
+ }
+@@ -136,8 +141,10 @@ void h2o_config_init_pathconf(h2o_pathco
+     h2o_chunked_register(pathconf);
+     if (path != NULL)
+         pathconf->path = h2o_strdup(NULL, path, SIZE_MAX);
+-    h2o_mem_addref_shared(mimemap);
+-    pathconf->mimemap = mimemap;
++    if (mimemap) {
++      h2o_mem_addref_shared(mimemap);
++      pathconf->mimemap = mimemap;
++    }
+     pathconf->error_log.emit_request_errors = 1;
+ }
+ 
+@@ -190,7 +197,7 @@ void h2o_config_init(h2o_globalconf_t *c
+     config->http2.latency_optimization.max_additional_delay = 10;
+     config->http2.latency_optimization.max_cwnd = 65535;
+     config->http2.callbacks = H2O_HTTP2_CALLBACKS;
+-    config->mimemap = h2o_mimemap_create();
++    // config->mimemap = h2o_mimemap_create();
+ 
+     h2o_configurator__init_core(config);
+ }
+@@ -279,7 +286,9 @@ void h2o_config_dispose(h2o_globalconf_t
+     }
+     free(config->hosts);
+ 
+-    h2o_mem_release_shared(config->mimemap);
++    if (config->mimemap) {
++      h2o_mem_release_shared(config->mimemap);
++    }
+     h2o_configurator__dispose_configurators(config);
+ }
+ 
+--- a/lib/core/request.c
++++ b/lib/core/request.c
+@@ -486,7 +486,7 @@ void h2o_req_fill_mime_attributes(h2o_re
+     ssize_t content_type_index;
+     h2o_mimemap_type_t *mime;
+ 
+-    if (req->res.mime_attr != NULL)
++    if (req->res.mime_attr != NULL || req->pathconf->mimemap == NULL)
+         return;
+ 
+     if ((content_type_index = h2o_find_header(&req->res.headers, H2O_TOKEN_CONTENT_TYPE, -1)) != -1 &&

--- a/libs/h2o/patches/800-smaller-write-buffer.patch
+++ b/libs/h2o/patches/800-smaller-write-buffer.patch
@@ -1,0 +1,11 @@
+--- a/include/h2o/http2_internal.h
++++ b/include/h2o/http2_internal.h
+@@ -33,7 +33,7 @@
+ typedef struct st_h2o_http2_conn_t h2o_http2_conn_t;
+ typedef struct st_h2o_http2_stream_t h2o_http2_stream_t;
+ 
+-#define H2O_HTTP2_DEFAULT_OUTBUF_SIZE 81920 /* the target size of each write call; connection flow control window + alpha */
++#define H2O_HTTP2_DEFAULT_OUTBUF_SIZE 8192 /* the target size of each write call; connection flow control window + alpha */
+ #define H2O_HTTP2_DEFAULT_OUTBUF_SOFT_MAX_SIZE 524288 /* 512KB; stops reading if size exceeds this value */
+ 
+ /* hpack */


### PR DESCRIPTION
Maintainer: @Habbie 
Compile tested: TP-Link Archer C7 AC1750 v5, 19.07 and 21.02
Run tested: TP-Link Archer C7 AC1750 v5, 19.07 and 21.02

Description:
Right now the dnsdist package is the sole user of the h2o library, and given the orientation taken by the project (see https://github.com/h2o/h2o/issues/3230) I don't think this will change. dnsdist itself is planning on dropping the dependency in the next version, 1.9. Given dnsdist's needs, this pull request reduces the flash and runtime memory footprint of the h2o library, and thus of the dnsdist program, by:
- dropping the yaml dependency
- not initializing the big mime types map at startup
- reducing the default HTTP/2 buffer

Signed-off-by: Remi Gacogne <remi.gacogne@powerdns.com>