### PR TITLE
[openwrt-23.05] backport riscv64 support

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -3,6 +3,10 @@ name: Test Build
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: Test ${{ matrix.arch }}

--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -15,9 +15,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - arch: aarch64_cortex-a53
+            target: mvebu-cortexa53
+            runtime_test: true
+
+          - arch: arm_cortex-a15_neon-vfpv4
+            target: armvirt-32
+            runtime_test: true
+
           - arch: arm_cortex-a9_vfpv3-d16
             target: mvebu-cortexa9
             runtime_test: false
+
+          - arch: i386_pentium-mmx
+            target: x86-geode
+            runtime_test: true
 
           - arch: mips_24kc
             target: ath79-generic
@@ -34,18 +46,6 @@ jobs:
           - arch: powerpc_8548
             target: mpc85xx-p1010
             runtime_test: false
-
-          - arch: aarch64_cortex-a53
-            target: mvebu-cortexa53
-            runtime_test: true
-
-          - arch: arm_cortex-a15_neon-vfpv4
-            target: armvirt-32
-            runtime_test: true
-
-          - arch: i386_pentium-mmx
-            target: x86-geode
-            runtime_test: true
 
           - arch: x86_64
             target: x86-64

--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -47,6 +47,10 @@ jobs:
             target: mpc85xx-p1010
             runtime_test: false
 
+          - arch: riscv64_riscv64
+            target: sifiveu-generic
+            runtime_test: false
+
           - arch: x86_64
             target: x86-64
             runtime_test: true

--- a/lang/golang/golang-values.mk
+++ b/lang/golang/golang-values.mk
@@ -201,7 +201,7 @@ endif
 
 # Target Go
 
-GO_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||mips||mips64||mips64el||mipsel||powerpc64||x86_64)
+GO_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||mips||mips64||mips64el||mipsel||powerpc64||riscv64||x86_64)
 
 
 # ASLR/PIE

--- a/lang/rust/rust-package.mk
+++ b/lang/rust/rust-package.mk
@@ -16,7 +16,7 @@ endif
 include $(RUST_INCLUDE_DIR)/rust-values.mk
 
 # Support only a subset for now.
-RUST_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||mips||mipsel||mips64||mips64el||mipsel||powerpc64||x86_64)
+RUST_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||mips||mipsel||mips64||mips64el||mipsel||powerpc64||riscv64||x86_64)
 
 # $(1) path to the package (optional)
 # $(2) additional arguments to cargo (optional)

--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -33,6 +33,8 @@ RUSTC_TARGET_ARCH:=$(subst muslgnueabi,musleabi,$(RUSTC_TARGET_ARCH))
 
 ifeq ($(ARCH),i386)
   RUSTC_TARGET_ARCH:=$(subst i486,i586,$(RUSTC_TARGET_ARCH))
+else ifeq ($(ARCH),riscv64)
+  RUSTC_TARGET_ARCH:=$(subst riscv64,riscv64gc,$(RUSTC_TARGET_ARCH))
 endif
 
 # ARM Logic

--- a/libs/libmraa/Makefile
+++ b/libs/libmraa/Makefile
@@ -54,7 +54,7 @@ endef
 define Package/libmraa
   $(call Package/libmraa/Default)
   TITLE:=Eclipse MRAA lowlevel IO C/C++ library
-  DEPENDS:=+libstdcpp +libjson-c @!arc @!armeb @!powerpc
+  DEPENDS:=+libstdcpp +libjson-c @!arc @!armeb @!powerpc @!riscv64
 endef
 
 define Package/libmraa/description


### PR DESCRIPTION
Maintainer: @aparcar for CI (Cc @jefferyto), @jefferyto for golang, @lu-zero for rust, @nxhack for libmraa
Compile tested: ci
Run tested: ci

Description:
The support for riscv64 has been backported to 23.05 branch: openwrt/openwrt@4a281a778999, so let's enable it here too.