### PR TITLE
[22.03] c-ares: bump to 1.19.1

### DIFF
--- a/libs/c-ares/Makefile
+++ b/libs/c-ares/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=c-ares
-PKG_VERSION:=1.18.1
+PKG_VERSION:=1.19.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://c-ares.org/download
-PKG_HASH:=1a7d52a8a84a9fbffb1be9133c0f6e17217d91ea5a6fa61f6b4729cda78ebbcf
+PKG_HASH:=321700399b72ed0e037d0074c629e7741f6b2ec2dda92956abe3e9671d3e268e
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.md
@@ -47,6 +47,13 @@ CMAKE_OPTIONS += \
 	-DCARES_STATIC_PIC=ON \
 	-DCARES_BUILD_TESTS=OFF \
 	-DCARES_BUILD_TOOLS=OFF
+
+define Build/InstallDev
+	$(call Build/InstallDev/cmake,$(1))
+	$(SED) 's,/usr/bin,$$$${prefix}/lib,g' $(1)/usr/lib/pkgconfig/libcares.pc
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/libcares.pc
+	$(SED) 's,/usr/lib,$$$${prefix}/lib,g' $(1)/usr/lib/pkgconfig/libcares.pc
+endef
 
 define Package/libcares/install
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
Maintainer: @karlp
Compile tested: 22.03, aarch64, arm, i386, x86_64
Run tested: aarch64 (qemu 8.0.2)

Description:
This is a security and bugfix release.

Security
 o CVE-2023-32067. High. 0-byte UDP payload causes Denial of Service
 o CVE-2023-31147. Moderate. Insufficient randomness in generation of DNS query IDs
 o CVE-2023-31130. Moderate. Buffer Underwrite in ares_inet_net_pton()
 o CVE-2023-31124. Low. AutoTools does not set CARES_RANDOM_FILE during cross compilation

Fixing libcares.pc
 The pkg-config file libcares.pc in version 1.19.1 has been changed to be unsuitable for OpenWrt
 and causes build errors with Openwrt packages that use libcares.
 For this reason, libcares.pc was replaced.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
(cherry picked from commit 4c4d3b900197785292ef92055effcccd7f3b805b)
