### PR TITLE
modemmanager: do not cache virtual device events and fix alias check

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_SOURCE_VERSION:=1.20.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_SOURCE_VERSION:=1.20.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/modemmanager.common
+++ b/net/modemmanager/files/modemmanager.common
@@ -273,6 +273,14 @@ mm_report_event() {
 	local subsystem="$3"
 	local sysfspath="$4"
 
+	# Do not save virtual devices
+	local virtual
+	virtual="$(echo "$sysfspath" | cut -d'/' -f4)"
+	[ "$virtual" = "virtual" ] && {
+		mm_log "debug" "sysfspath is a virtual device ($sysfspath)"
+		return
+	}
+
 	# Track/untrack events in cache
 	case "${action}" in
 		"add")

--- a/net/modemmanager/files/modemmanager.proto
+++ b/net/modemmanager/files/modemmanager.proto
@@ -368,11 +368,6 @@ proto_modemmanager_setup() {
 		proto_set_available "${interface}" 0
 		return 1
 	}
-	[ -e "${device}" ] || {
-		echo "Device not found in sysfs"
-		proto_set_available "${interface}" 0
-		return 1
-	}
 
 	# validate that ModemManager is handling the modem at the sysfs path
 	modemstatus=$(mmcli --modem="${device}" --output-keyvalue)


### PR DESCRIPTION
Maintainer: @aleksander0m
Compile tested: not needed only script changes
Run tested: x86/64, APU3, OpenWrt latest

Description:

1. On small systems with many virtual devices, the modem manager sometimes could not start because it took too long until all devices for the modem were recognised. This is because all system events that are stored in the file events.cache have to be processed. To speed up the processing, all devices under /sys/devices/virtual are now filtered out so that they do not have to be processed.
2. If an alias name is used for the modem, then a check if the device exists in sysfs does not work. To fix this remove the check if the sysfs device exists. The protocoll handler already checks if the modemmanger is responsible for this device on the next line.