### PR TITLE
alpine: disable parallel build

### DIFF
--- a/mail/alpine/Makefile
+++ b/mail/alpine/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alpine
 PKG_VERSION:=2.25
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://alpineapp.email/alpine/release/src/Old
@@ -20,7 +20,6 @@ PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk


### PR DESCRIPTION
Maintainer: @pesintta 
Compile tested: mediatek/mt7622, aarch64/cortex-a53
Run tested: none

Description:
Parallel build does not work because it may reach a point where OSTYPE might be needed before it is actually built.  They appear to run parallel to each other:

echo slx > OSTYPE
[...]
cat: OSTYPE: No such file or directory
sh: line 1: test: too many arguments
cat: OSTYPE: No such file or directory
Already built for -- you must do "make clean" first make[6]: *** [Makefile:706: rebuild] Error 1
make[6]: *** Waiting for unfinished jobs....
