### PR TITLE
mhz: add new package

### DIFF
--- a/utils/mhz/Makefile
+++ b/utils/mhz/Makefile
@@ -1,0 +1,33 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mhz
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://github.com/wtarreau/mhz.git
+PKG_SOURCE_DATE:=2023-06-17
+PKG_SOURCE_VERSION:=11aac2399780a1f7ea9f007b14af0464797d5cf1
+PKG_MIRROR_HASH:=b3ea0c9e6f111755c4207addef0ea210ace86bc6910c959c6fc489026897676f
+
+PKG_MAINTAINER:=Robert Marko <robimarko@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/mhz
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=CPU frequency measurement utility
+endef
+
+define Package/mhz/description
+  Tool to mathematically calculate the current CPU frequency.
+endef
+
+define Package/mhz/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/mhz $(1)/usr/sbin/mhz
+endef
+
+$(eval $(call BuildPackage,mhz))


### PR DESCRIPTION
mhz is a tool for mathematically calculating the current CPU frequency, it has proven to be a really good help while developing CPU frequency scaling solutions as it allows to independently prove that scaling actually works.

Now that the author has added a license we can package it for all to use.

Maintainer: me 
Compile tested: ipq807x
Run tested: ipq807x