### PR TITLE
esp2net: add Espressif ESP chip USB-Network proxy

### DIFF
--- a/net/esp2net/Makefile
+++ b/net/esp2net/Makefile
@@ -1,0 +1,48 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=esp2net
+PKG_RELEASE:=1
+
+PKG_LICENSE:=GPL-2.0-only
+PKG_MAINTAINER:=Nuno Gonçalves <nunojpg@gmail.com>
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://github.com/nunojpg/esp2net.git
+PKG_SOURCE_DATE:=2023-06-20
+PKG_SOURCE_VERSION:=be514c7a50bd8f3aac146ba267856d66cad1abd9
+PKG_MIRROR_HASH:=bb2d180887c14ee3e6bec51ccaae195274a09e4be108a7e69e2126df5245c0b7
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/esp2net
+	SECTION:=net
+	CATEGORY:=Network
+	TITLE:=Espressif ESP chip network monitor and flash proxy
+	DEPENDS:=+libstdcpp
+endef
+
+define Package/esp2net/description
+	Allows to flash a Espressif chip connected to this device.
+	The functionality is identical to "esp_rfc2217_server.py" but without Python.
+	Typically you want also to install one or more USB serial drivers:
+	 * kmod-usb-serial-cp210x
+	 * kmod-usb-serial-ftdi
+	 * kmod-usb-serial-ch341
+	 * kmod-usb-acm
+endef
+
+define Package/esp2net/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/esp2net $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/esp2net.init $(1)/etc/init.d/esp2net
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/esp2net.config $(1)/etc/config/esp2net
+endef
+
+define Package/esp2net/conffiles
+/etc/config/esp2net
+endef
+
+$(eval $(call BuildPackage,esp2net))

--- a/net/esp2net/files/esp2net.config
+++ b/net/esp2net/files/esp2net.config
@@ -1,0 +1,4 @@
+config esp2net
+	option uart '/dev/ttyUSB0'
+	option port '5001'
+	option disabled 1

--- a/net/esp2net/files/esp2net.init
+++ b/net/esp2net/files/esp2net.init
@@ -1,0 +1,32 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+START=95
+STOP=01
+
+CONFIGURATION=esp2net
+SECTION=esp2net
+
+parse_esp2net()
+{
+    local uart
+    local port
+    local disabled
+    config_get uart "${1}" uart
+    config_get port "${1}" port
+    config_get_bool disabled "${1}" disabled 0
+    [ "$disabled" -eq 1 ] && return;
+    procd_open_instance
+    procd_set_param respawn 3600 5 5
+    procd_set_param command /usr/sbin/esp2net "$uart" "$port"
+    procd_set_param file /etc/config/esp2net
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_close_instance
+}
+
+start_service() {
+    config_load "${CONFIGURATION}"
+    config_foreach parse_esp2net "${SECTION}"
+}


### PR DESCRIPTION
Maintainer: me
Run tested: ATH79, TP-Link TL-WDR3600, master
Description: Espressif ESP chip network monitor and flash proxy
