### PR TITLE
[23.05] node: June 20 2023 Security Releases

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v18.16.0
+PKG_VERSION:=v18.16.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=33d81a233e235a509adda4a4f2209008d04591979de6b3f0f67c1c906093f118
+PKG_HASH:=e8404f8c8d89fdfdf7e95bbbc6066bd0e571acba58f54492599b615fbeefe272
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,6 +1,6 @@
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1389,7 +1389,8 @@ Module._initPaths = function() {
+@@ -1391,7 +1391,8 @@ Module._initPaths = function() {
      path.resolve(process.execPath, '..') :
      path.resolve(process.execPath, '..', '..');
  


### PR DESCRIPTION
Maintainer: me @ianchi
 Compile tested: 23.05, aarch64, arm
Run tested: (qemu 8.0.2) aarch64

Description:
Update to v18.16.1

The following CVEs are fixed in this release:
* CVE-2023-30581: mainModule.__proto__ Bypass Experimental Policy Mechanism (High)
* CVE-2023-30585: Privilege escalation via Malicious Registry Key manipulation during Node.js installer repair process (Medium)
* CVE-2023-30588: Process interuption due to invalid Public Key information in x509 certificates (Medium)
* CVE-2023-30589: HTTP Request Smuggling via Empty headers separated by CR (Medium)
* CVE-2023-30590: DiffieHellman does not generate keys after setting a private key (Medium)

* OpenSSL Security Releases (Depends on shared library provided by OpenWrt)
  * OpenSSL security advisory 28th March.
  * OpenSSL security advisory 20th April.
  * OpenSSL security advisory 30th May

* c-ares vulnerabilities: (Depends on shared library provided by OpenWrt)
  * GHSA-9g78-jv2r-p7vc
  * GHSA-8r8p-23f3-64c2
  * GHSA-54xr-f67r-4pc4
  * GHSA-x6mf-cxr9-8q6v

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
(cherry picked from commit 286d1d11ae451e9e90897aacd7ae20ec76e2cab5)

