### PR TITLE
[23.05] nebula: update to 1.7.2 (and cosmetic fixes)

### DIFF
--- a/net/nebula/Makefile
+++ b/net/nebula/Makefile
@@ -1,15 +1,15 @@
-# Copyright 2021 Stan Grishin (stangri@melmac.ca)
+# Copyright 2023 Stan Grishin (stangri@melmac.ca)
 # This is free software, licensed under the MIT License.
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nebula
-PKG_VERSION:=1.6.1
+PKG_VERSION:=1.7.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/slackhq/nebula/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=9c343d998d2eab9473c3bf73d434b8a382d90b1f73095dd1114ecaf2e1c0970f
+PKG_HASH:=c4771ce6eb3e142f88f5f4c12443cfca140bf96b2746c74f9536bd1a362f3f88
 
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=MIT

--- a/net/nebula/files/nebula.init
+++ b/net/nebula/files/nebula.init
@@ -1,5 +1,5 @@
 #!/bin/sh /etc/rc.common
-# Copyright 2021 Stan Grishin (stangri@melmac.ca)
+# Copyright 2023 Stan Grishin (stangri@melmac.ca)
 # shellcheck disable=SC3043,SC3060
 
 # shellcheck disable=SC2034
@@ -10,7 +10,6 @@ USE_PROCD=1
 readonly PKG_VERSION='dev-test'
 readonly packageName='nebula-service'
 readonly serviceName="$packageName $PKG_VERSION"
-readonly sharedMemoryOutput="/dev/shm/$packageName-output"
 readonly PROG=/usr/sbin/nebula
 readonly _OK_='\033[0;32m\xe2\x9c\x93\033[0m'
 readonly _FAIL_='\033[0;31m\xe2\x9c\x97\033[0m'
@@ -21,6 +20,7 @@ version() { echo "Version: $PKG_VERSION"; }
 
 output() {
 	local msg memmsg logmsg
+	local sharedMemoryOutput="/dev/shm/$packageName-output"
 	[ -t 1 ] && printf "%b" "$@"
 	msg="${1//$serviceName /service }";
 	if [ "$(printf "%b" "$msg" | wc -l)" -gt 0 ]; then

--- a/net/nebula/files/nebula.proto
+++ b/net/nebula/files/nebula.proto
@@ -5,6 +5,8 @@ readonly PKG_VERSION='dev-test'
 readonly PROG=/usr/sbin/nebula
 readonly packageName='nebula-proto'
 
+# https://github.com/openwrt/openwrt/blob/fbf1835f46addf25a752a16be40d8f5617be3112/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+
 [ -x "$PROG" ] || { log "Main nebula executable '/usr/sbin/nebula' not found"; exit 1; }
 
 [ -n "$INCLUDE_ONLY" ] || {
@@ -17,7 +19,7 @@ readonly packageName='nebula-proto'
 log() { logger -t "$packageName" "$*"; }
 # https://gist.github.com/pkuczynski/8665367
 # shellcheck disable=SC2086,SC2155
-parse_yaml() {
+yaml_parse() {
 	local prefix=$2
 	local s='[[:space:]]*' w='[a-zA-Z0-9_-]*' fs="$(echo @|tr @ '\034'|tr -d '\015')"
 	sed -ne "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
@@ -48,11 +50,15 @@ proto_nebula_setup() {
 	proto_init_update "${interface}" 1
 
 	[ -s "$config_file" ] || { log "Config file not found or empty!"; return 1; }
-	eval "$(parse_yaml "$config_file" "yaml_")"
+	eval "$(yaml_parse "$config_file" "yaml_")"
 	[ "$yaml_tun_dev" = "$interface" ] || { log "Tunnel device in config file (${yaml_tun_dev}) doesn't match interface name (${interface})!"; return 1; }
 
 	log "Setting up ${interface} from $(basename "$config_file")."
 	proto_run_command "$interface" "$PROG" -config "$config_file"
+	# TODO: if lighthouse, open local port 4242
+	# TODO: else get local subnet from local_range variable, if not,
+	# TODO: iterate over each lighthouse/hosts and append /24
+	# TODO: ip route add "$yaml_local_range" "$yaml_tun_dev"
 	proto_add_data
 	json_add_array firewall
 		json_add_object ""

--- a/net/nebula/test.sh
+++ b/net/nebula/test.sh
@@ -3,6 +3,6 @@
 case "$1" in
 	nebula|nebula-cert) "/usr/sbin/${1}" -version 2>&1 | grep "$2"; return $?;;
 	nebula-proto) grep 'readonly PKG_VERSION=' /lib/netifd/proto/nebula.sh 2>&1 | grep "$2"; return $?;;
-#	nebula-service) "/etc/init.d/nebula" version 2>&1 | grep "$2"; return $?;;
+#	nebula-service) /etc/init.d/nebula version 2>&1 | grep "$2"; return $?;;
 	nebula-service) return 0;;
 esac


### PR DESCRIPTION
Maintainer: me
Compile tested: x86-64, Sophos XG-135r3, OpenWrt 23.05.0-rc1
Run tested: x86-64, Sophos XG-135r3, OpenWrt 22.03.5, test connectivity

Description:
* update binaries to 1.7.2
* move sharedMemoryOutput variable declaration into output function as it doesn't need to be global
  rename parse_yaml function to yaml_parse
* add TODOs for future development

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 204e6076d352d5c7232e18de0fcf58503ef6ae9b)

