### PR TITLE
Added checks to determine if crontabs have changed

### DIFF
--- a/utils/micrond/src/micrond.c
+++ b/utils/micrond/src/micrond.c
@@ -283,6 +283,16 @@ static void check_job(const job_t *job, const struct tm *tm) {
 }
 
 static void refresh_jobs(time_t *refresh_time) {
+	/* Remove all the jobs and free up memory */
+	job_t *to_delete;
+	job_t *head = jobs;
+	while(head->next != NULL) {
+		to_delete = head;
+		head = head->next;
+		free(to_delete);
+	}
+
+	/* re-initialize the jobs structure */
 	jobs = NULL;
 	read_crondir();
 	*refresh_time = time(NULL);


### PR DESCRIPTION
Maintainer: Florian Eckert <fe@dev.tdt.de> / @feckert 
Compile tested: x86_64
Run tested: x86_64

Description:

This change allows `micrond` to determine that there was a modification (or deletion) of a crontab file. At the completion of each event loop, the modification times of each file in the crontab directory is checked to determine if it is greater than the last time the files were read in. A final check is performed to determine if the list of crontab files has decreased (i.e. files were deleted). If any of these conditions are true, the current jobs will be dumped and all the files will be read in again. 

Notes about how change was tested: I created and tested this change on a OSX box. There is a difference in the string library--specifically the `sscanf()` function. While everything compiled and worked as expected, the `sscanf()` function was not able to match the `crontab` lines correctly due to the `m` modifier in the `sscanf()` calls. So even though the files had valid crontab entries, the `handle_line()` call would fail to identify the line as a crontab entry. Since there are no changes to the way that files are being parsed I am considering this as nothing that would break existing functionality. 

The new `check_for_updates()` function was tested by running `micrond` against a sample crontab entries. The creation of files, modification of files and the deletion of files triggered the `refresh_jobs()` function just as expected. 