### PR TITLE
nginx: update and add quic module

### DIFF
--- a/net/nginx/Config_ssl.in
+++ b/net/nginx/Config_ssl.in
@@ -175,6 +175,11 @@ config NGINX_HTTP_V2
 	prompt "Enable HTTP_V2 module"
 	default y
 
+config NGINX_HTTP_QUIC
+	bool
+	prompt "Enable QUIC support"
+	default n
+
 config NGINX_PCRE
 	bool
 	prompt "Enable PCRE library usage"

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
-PKG_VERSION:=1.25.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.25.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
-PKG_HASH:=5ed44d45943272a4e8a5bcf4434237210f2de31b903fca5e381c1bbd7eee1e8c
+PKG_HASH:=f09071ac46e0ea3adc0008ef0baca229fc6b4be4533baef9bbbfba7de29a8602
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de> \
 				Ansuel Smith <ansuelsmth@gmail.com>

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -76,6 +76,7 @@ PKG_CONFIG_DEPENDS := \
 	CONFIG_NGINX_HTTP_UPSTREAM_ZONE \
 	CONFIG_NGINX_HTTP_CACHE \
 	CONFIG_NGINX_HTTP_V2 \
+	CONFIG_NGINX_HTTP_QUIC \
 	CONFIG_NGINX_PCRE \
 	CONFIG_NGINX_HTTP_REAL_IP \
 	CONFIG_NGINX_HTTP_SECURE_LINK \
@@ -401,6 +402,7 @@ CONFIGURE_ARGS += \
 	$(if $(call IsEnabled,NGINX_FLV),--with-http_flv_module) \
 	$(if $(call IsEnabled,NGINX_DAV),--with-http_dav_module) \
 	$(if $(call IsEnabled,NGINX_HTTP_AUTH_REQUEST),--with-http_auth_request_module) \
+	$(if $(call IsEnabled,NGINX_HTTP_QUIC),--with-http_v3_module) \
 	$(if $(call IsEnabled,NGINX_HTTP_V2),--with-http_v2_module) \
 	$(if $(call IsEnabled,NGINX_HTTP_REAL_IP),--with-http_realip_module) \
 	$(if $(call IsEnabled,NGINX_HTTP_SECURE_LINK),--with-http_secure_link_module) \


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de> Ansuel Smith <ansuelsmth@gmail.com>
Compile tested: Xiaomi AX3600 ARM64
Run tested: Xiaomi AX3600 ARM64 on latest main/master

Description:
This commit updates nginx to 1.25.1 and adds support for http/3. This is an experimental version and isn't fully supported because nginx is being built with the regular OpenSSL and the regular one doesn't support quic.
Signed-off-by: Tiago Gaspar <tiagogaspar8@gmail.com>