### PR TITLE
[openwrt-23.05] python-packages: Take over maintainership from Daniel Golle

### DIFF
--- a/lang/python/click/Makefile
+++ b/lang/python/click/Makefile
@@ -11,7 +11,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=click
 PKG_HASH:=7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e
 
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 

--- a/lang/python/itsdangerous/Makefile
+++ b/lang/python/itsdangerous/Makefile
@@ -11,7 +11,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a
 
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 

--- a/lang/python/pyodbc/Makefile
+++ b/lang/python/pyodbc/Makefile
@@ -13,7 +13,7 @@ PKG_HASH:=e528bb70dd6d6299ee429868925df0866e3e919c772b9eff79c8e17920d8f116
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
 PKG_BUILD_DEPENDS:=unixodbc/host
 

--- a/lang/python/python-gnupg/Makefile
+++ b/lang/python/python-gnupg/Makefile
@@ -13,7 +13,7 @@ PKG_HASH:=2061f56b1942c29b92727bf9aecbd3cea3893acc9cccbdc7eb4604285efe4ac7
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.txt
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_CPE_ID:=cpe:/a:python:python-gnupg
 
 include ../pypi.mk

--- a/lang/python/python-libmodbus/Makefile
+++ b/lang/python/python-libmodbus/Makefile
@@ -6,7 +6,7 @@ PKG_VERSION:=0.5.0
 PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
 PYPI_NAME:=pylibmodbus
 PKG_HASH:=80f837304ffa8476145ea643f6b98aa94b205013a96f1e5173d7bdc776426aee

--- a/lang/python/python-markupsafe/Makefile
+++ b/lang/python/python-markupsafe/Makefile
@@ -11,7 +11,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=MarkupSafe
 PKG_HASH:=abcabc8c2b26036d62d4c746381a6f7cf60aafcc653198ad678306986b09450d
 
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
 

--- a/lang/python/python-werkzeug/Makefile
+++ b/lang/python/python-werkzeug/Makefile
@@ -11,7 +11,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=Werkzeug
 PKG_HASH:=1d5a58e0377d1fe39d061a5de4469e414e78ccb1e1e59c0f5ad6fa1c36c52b76
 
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
 


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: N/A (cherry picked from #21442)
Run tested: N/A

Description:
This was requested in https://github.com/openwrt/packages/pull/21227#issuecomment-1567676980.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit b5dbf77501b4b4921ebd4d6abc6389875b64d3fa)