### PR TITLE
python-libmodbus: Update to 0.6.2

### DIFF
--- a/lang/python/python-libmodbus/Makefile
+++ b/lang/python/python-libmodbus/Makefile
@@ -2,14 +2,15 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=python-libmodbus
-PKG_VERSION:=0.5.0
-PKG_RELEASE:=2
-
-PKG_LICENSE:=BSD-3-Clause
-PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+PKG_VERSION:=0.6.2
+PKG_RELEASE:=1
 
 PYPI_NAME:=pylibmodbus
-PKG_HASH:=80f837304ffa8476145ea643f6b98aa94b205013a96f1e5173d7bdc776426aee
+PKG_HASH:=7989af81f57cc7593c86b2d74201978e931bc80f6bbe62564273477fc7059c20
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -19,8 +20,8 @@ define Package/python3-libmodbus
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  TITLE:=pylibmodbus
-  URL:=https://pypi.org/project/pylibmodbus
+  TITLE:=Wrapper for libmodbus
+  URL:=https://github.com/stephane/pylibmodbus
   DEPENDS:=+libmodbus \
      +python3-light \
      +python3-cffi
@@ -32,3 +33,4 @@ endef
 
 $(eval $(call Py3Package,python3-libmodbus))
 $(eval $(call BuildPackage,python3-libmodbus))
+$(eval $(call BuildPackage,python3-libmodbus-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: armsr-armv7, 2023-06-24 snapshot sdk
Run tested: armsr-armv7 (qemu), 2023-06-24 snapshot

Description:
This also adds a source package (python3-libmodbus-src).