### PR TITLE
inadyn: update to 2.11.0

### DIFF
--- a/net/inadyn/Makefile
+++ b/net/inadyn/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=inadyn
-PKG_VERSION:=2.9.1
+PKG_VERSION:=2.11.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/troglobit/inadyn/releases/download/v$(PKG_VERSION)
-PKG_HASH:=0094d20cfcd431674b8d658e93169c7589bf8f2b351b2860818a1ca05f0218c5
+PKG_HASH:=9c8b2a425acb9681564e9fc25a319f2109c7d2ebe1ffe99b06d4a722efb6ecba
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: none
Compile tested: mipsel_24kc, Netgear R6220, master
Run tested: mipsel_24kc, Netgear R6220, 23.05 branch, verified that updating dynamic dns address works
