### PR TITLE
iodine: enhance uci configuration

### DIFF
--- a/net/iodine/Makefile
+++ b/net/iodine/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iodine
 PKG_VERSION:=0.8.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://code.kryo.se/iodine/

--- a/net/iodine/files/iodined.config
+++ b/net/iodine/files/iodined.config
@@ -1,5 +1,50 @@
+# Example configuration
+
 config iodined
-        option address     ''
-        option password    ''
-        option tunnelip    '10.0.0.1'
-        option tld     	   ''
+
+	# Enable this section? Default is 'yes' (compatible with older conffiles).
+	option enabled no
+
+	### Minimal required configuration:
+
+	# DNS traffic will be sent as queries for subdomains under this top domain.
+	option tld 'jod.example.net'
+
+	# Password (max. length 32) is just a basic authentication mechanism.
+	# It does *not* encrypt or protect tunnel data from manipulation.
+	option password ''
+
+	# IP address/subnet assigned to tunnel device (see "devname").
+	# Optional if device is preconfigured. Subnet defaults to /27, if not specified.
+	option tunnelip '10.0.0.1/27'
+
+	### Optional settings:
+
+	# TUN device to use. Defaults to 'dns0'.
+	#option devname 'jod1'
+
+	# Tunnel device MTU. Defaults to '1130'. Does not work if 'tunnelip' is unspecified.
+	#option mtu '1130'
+
+	# Service will listen on UDP 'port' at 'address'. Defaults to port 53 on all interfaces.
+	#option port '53'
+	#option address '0.0.0.0'
+
+	# By default, requests originating from non-matching IP addresses will be rejected.
+	# Set to 'no' when requests are routed via a cluster of DNS servers or client IP is not static.
+	#option checkip yes
+
+	# IP address to return in NS responses. Default is to use the query's destination address.
+	# When set to 'auto', myip.opendns.com is used to determine your public ip address.
+	#option externalip 'auto'
+
+	# chroot to directory after tunnel setup.
+	#option chroot ''
+
+	# Drop privleges and run as 'user' after tunnel setup.
+	#option user 'nobody'
+
+	# Forward DNS queries not matching the TLD option to this UDP port on localhost.
+	# Leave unconfigured, if you are uncertain about the implications.
+	#dnsport '53'
+

--- a/net/iodine/files/iodined.init
+++ b/net/iodine/files/iodined.init
@@ -2,26 +2,109 @@
 # Copyright (C) 2006-2011 OpenWrt.org
 
 START=50
+USE_PROCD=1
 
 start_instance () {
 	local section="$1"
+	local complain="$2"
+
+	local enable
+	local enabled
+	local address
+	local password
+	local tunnelip
+	local tld
+	local port
+	local devname
+	local mtu
+	local user
+	local chroot
+	local dnsport
+	local externalip
+	local checkip
+
+	if [ $complain ] && ! /sbin/uci get "iodined.$section" >/dev/null 2>&1; then
+		>&2 echo "Invalid section name / not found: $section"
+		return 1
+	fi
+
+	config_get_bool enable "$section" 'enable' 1
+	config_get_bool enabled "$section" 'enabled' 1
+
+	if [ $enable -eq 0 ] || [ $enabled -eq 0 ]; then
+		[ "$complain" ] && >&2 echo "Section is disabled: $section"
+		return 1
+	fi
+
 	config_get address  "$section" 'address'
 	config_get password "$section" 'password'
 	config_get tunnelip "$section" 'tunnelip'
 	config_get tld      "$section" 'tld'
 	config_get port     "$section" 'port'
-	
-	test -n "$address" || address='0.0.0.0'
-	test -n "$port" || port='53'
+	config_get devname  "$section" 'devname'
+	config_get mtu      "$section" 'mtu'
+	config_get user     "$section" 'user'
+	config_get chroot   "$section" 'chroot'
+	config_get dnsport  "$section" 'dnsport'
+	config_get externalip   "$section" 'externalip'
+	config_get_bool checkip "$section" 'checkip' 0
 
-	service_start /usr/sbin/iodined -l "$address" -P "$password" -p "$port" "$tunnelip" "$tld"
+	# Check for minimal config - would otherwise cause silent fail
+	if [ -z "$password" ] || [ -z "$tld" ]; then
+		>&2 echo "TLD or password missing in config section: $section"
+		return 1
+	fi
+	if [ -z "$tunnelip" ] && [ -z "$devname" ]; then
+		>&2 echo "At least one of 'tunnelip' | 'devname' must be configured in section: $section"
+		return 1
+	fi
+
+	# warn accidential edge case
+	if [ -z "$tunnelip" ] && [ -n "$mtu" ]; then
+		>&2 echo "Invalid configuration: 'mtu' without 'tunnelip' in section: $section"
+		return 1
+	fi
+
+	procd_open_instance "$section"
+	procd_set_param command /usr/sbin/iodined -f
+	procd_set_param stderr 1
+	procd_set_param respawn
+
+	procd_append_param command -P "$password"
+	[ -n "$address"	   ] && procd_append_param command -l "$address"
+	[ -n "$port"	   ] && procd_append_param command -p "$port"
+	[ -n "$devname"	   ] && procd_append_param command -d "$devname"
+	[ -n "$mtu"	   ] && procd_append_param command -m "$mtu"
+	[ -n "$user"	   ] && procd_append_param command -u "$user"
+	[ -n "$chroot"	   ] && procd_append_param command -t "$chroot"
+	[ -n "$dnsport"	   ] && procd_append_param command -b "$dnsport"
+	[ -n "$externalip" ] && procd_append_param command -n "$externalip"
+	[ $checkip -eq 0   ] && procd_append_param command -c
+
+	if [ -z "$tunnelip" ] && [ -z "$mtu" ]; then
+		# assuming preconfigured $devname interface. do not try to configure.
+		procd_append_param command -s
+
+		# in this case, tunnel_ip argument is ignored, yet required to start.
+		tunnelip='127.0.0.53'
+	fi
+
+	procd_append_param command "$tunnelip" "$tld" 
+	procd_close_instance
 }
 
-start() {
+start_service() {
+	local instance="$1"
+
 	config_load 'iodined'
-	config_foreach start_instance 'iodined'
+
+	if [ -n "$instance" ]; then
+		start_instance "$instance" complain
+	else
+		config_foreach start_instance 'iodined'
+	fi
 }
 
-stop() {
-	service_stop /usr/sbin/iodined
+service_triggers() {
+	procd_add_reload_trigger iodined
 }


### PR DESCRIPTION
Maintainer: @ukleinek
Compile tested: x86_64, Debian bookworm, OpenWrt 23.05.0-rc1
Run tested: x86_64, QEMU, OpenWRT 23.05.0-rc1: Tested start & stop functions

Description:
 * apply more arguments/options via init script
 * include enhanced config file w/ annotations
 * very small chance to breaking previous configs, since address no longer defaults to '0.0.0.0'
  iodined provides its own mechanism to do pretty much the same thing, which should be preferred
  iodined defaults to using port 53 if not specified