### PR TITLE
irqbalance: add banned_cpulist option

### DIFF
--- a/utils/irqbalance/files/irqbalance.config
+++ b/utils/irqbalance/files/irqbalance.config
@@ -8,6 +8,9 @@ config irqbalance 'irqbalance'
 	# The default value is 10 seconds
 	#option interval '10'
 
+	# Specify excluded cpulist
+	#option banned_cpulist '0'
+
 	# List of IRQ's to ignore
 	#list banirq '36'
 	#list banirq '69'

--- a/utils/irqbalance/files/irqbalance.init
+++ b/utils/irqbalance/files/irqbalance.init
@@ -22,6 +22,9 @@ start_service() {
 	# 10 is the default
 	config_get interval irqbalance interval 10
 
+	# empty is the default
+	config_get banned_cpulist irqbalance banned_cpulist ''
+
 	# A list of IRQ's to ignore
 	banirq=""
 	handle_banirq_value()
@@ -31,6 +34,13 @@ start_service() {
 	config_list_foreach irqbalance banirq handle_banirq_value
 
 	procd_open_instance "irqbalance"
+	set_banned_cpulist_env()
+	{
+		if [ -n "$banned_cpulist" ]; then
+			procd_set_param env IRQBALANCE_BANNED_CPULIST="$banned_cpulist"
+		fi
+	}
+	set_banned_cpulist_env
 	procd_set_param command /usr/sbin/irqbalance -f -c "$deepestcache" -t "$interval" "$banirq"
 	procd_set_param respawn
 	procd_close_instance


### PR DESCRIPTION
Maintainer: Hannu Nyman <hannu.nyman@iki.fi>
Compile tested: x86_64, Ubuntu 22.04, OpenWrt 22.03.5 
Run tested: ARMv7, ASUS RT-AC42U, OpenWrt 22.03.5

Description:

`IRQBALANCE_BANNED_CPULIST`: Provides a cpulist which irqbalance should ignore and never assign interrupts to. If not specified, irqbalance use mask of isolated and adaptive-ticks CPUs on the system as the default value.

Related documents (I couldn't find the official project ones): https://manpages.debian.org/unstable/irqbalance/irqbalance.1.en.html#IRQBALANCE_BANNED_CPULIST

Note: The `IRQBALANCE_BANNED_CPULIST` variable replaces the deprecated `IRQBALANCE_BANNED_CPUS` variable, and we do not need to add configuration options for the latter.