### PR TITLE
Update grilo and grilo-plugins to 0.3.16

### DIFF
--- a/multimedia/grilo-plugins/Makefile
+++ b/multimedia/grilo-plugins/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grilo-plugins
-PKG_VERSION:=0.3.14
+PKG_VERSION:=0.3.16
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/grilo-plugins/0.3/
-PKG_HASH:=686844b34ec73b24931ff6cc4f6033f0072947a6db60acdc7fb3eaf157a581c8
+PKG_HASH:=fe6f4dbe586c6b8ba2406394e202f22d009d642a96eb3a54f32f6a21d084cdcb
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPL-2.1-or-later
@@ -55,7 +55,6 @@ MESON_ARGS += \
 	-Denable-lua-factory=no \
 	-Denable-magnatune=$(if $(CONFIG_PACKAGE_grilo-plugins-magnatune),yes,no) \
 	-Denable-metadata-store=$(if $(CONFIG_PACKAGE_grilo-plugins-metadata-store),yes,no) \
-	-Denable-opensubtitles=$(if $(CONFIG_PACKAGE_grilo-plugins-opensubtitles),yes,no) \
 	-Denable-optical-media=no \
 	-Denable-podcasts=no \
 	-Denable-raitv=$(if $(CONFIG_PACKAGE_grilo-plugins-raitv),yes,no) \
@@ -99,7 +98,6 @@ $(eval $(call BuildPlugin,dmap,DAAP and DPAP sharing,daap dpap,libdmapsharing,30
 $(eval $(call BuildPlugin,gravatar,Gravatar provider,gravatar,,30))
 $(eval $(call BuildPlugin,magnatune,Magnatune sharing,magnatune,,30))
 $(eval $(call BuildPlugin,metadata-store,Metadata Store,metadatastore,,30))
-$(eval $(call BuildPlugin,opensubtitles,Open subtitles provider,opensubtitles,,30))
 $(eval $(call BuildPlugin,raitv,Rai.tv sharing,raitv,,30))
 $(eval $(call BuildPlugin,shoutcast,SHOUTcast sharing,shoutcast,,30))
 $(eval $(call BuildPlugin,tmdb,TMDb,tmdb,+json-glib,30))

--- a/multimedia/grilo/Makefile
+++ b/multimedia/grilo/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grilo
-PKG_VERSION:=0.3.14
+PKG_VERSION:=0.3.16
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/grilo/0.3/
-PKG_HASH:=0369d0b00bb0f59ba5f7aea8cfc665f38df14a5b4182d28c7c1e2cd15b518743
+PKG_HASH:=884580e8c5ece280df23aa63ff5234b7d48988a404df7d6bfccd1e77b473bd96
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPL-2.1-or-later
@@ -28,7 +28,7 @@ define Package/grilo
   CATEGORY:=Multimedia
   TITLE:=grilo
   URL:=https://wiki.gnome.org/Projects/Grilo
-  DEPENDS:=+glib2 +libsoup +libxml2
+  DEPENDS:=+glib2 +libsoup3 +libxml2
 endef
 
 define Package/grilo/decription


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64

Description:
This updates both the grilo and grilo-plugins packages to 0.3.16, which makes use of libsoup3 rather than libsoup. The plugins package had to drop the opensubtitles plugin because that plugin is not yet compatible with libsoup3.