### PR TITLE
inadyn: build both openssl and mbedtls variants

### DIFF
--- a/net/inadyn/Makefile
+++ b/net/inadyn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=inadyn
 PKG_VERSION:=2.11.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/troglobit/inadyn/releases/download/v$(PKG_VERSION)
@@ -24,32 +24,54 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/inadyn
+define Package/inadyn/default
+  TITLE:=A Dynamic DNS client with SSL/TLS support
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+confuse +libopenssl +ca-certificates
-  TITLE:=A Dynamic DNS client with SSL/TLS support
-  URL:=http://troglobit.com/project/inadyn/
   SUBMENU:=IP Addresses and Names
+  DEPENDS:=+confuse +ca-certificates
+  URL:=https://troglobit.com/projects/inadyn/
 endef
 
-define Package/inadyn/description
-  Inadyn is a small and simple Dynamic DNS, DDNS, client with HTTPS support
+define Package/inadyn-openssl
+  $(Package/inadyn/default)
+  TITLE += (uses OpenSSL)
+  VARIANT := openssl
+  PROVIDES := inadyn
+  DEPENDS += +PACKAGE_inadyn-openssl:libopenssl
 endef
 
-define Package/inadyn/conffiles
-/etc/inadyn.conf
+define Package/inadyn-mbedtls
+  $(Package/inadyn/default)
+  TITLE += (uses Mbed TLS)
+  VARIANT := mbedtls
+  DEPENDS += +PACKAGE_inadyn-mbedtls:libmbedtls
+  CONFLICTS := inadyn-openssl
 endef
 
 CONFIGURE_ARGS += \
-	--enable-shared \
-	--disable-static \
-	--enable-openssl \
-	--with-pic
+  --enable-shared \
+  --disable-static \
+  --with-pic
 
-define Package/inadyn/install
+ifeq ($(BUILD_VARIANT),openssl)
+CONFIGURE_ARGS += \
+  --enable-openssl
+else
+CONFIGURE_ARGS += \
+  --enable-mbedtls \
+  MbedTLS_CFLAGS="-I$(STAGING_DIR)/usr/include" \
+  MbedTLS_LIBS="-lmbedtls"
+endif
+
+define Package/inadyn-$(BUILD_VARIANT)/conffiles
+/etc/inadyn.conf
+endef
+
+define Package/inadyn-$(BUILD_VARIANT)/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/inadyn $(1)/usr/sbin/
 endef
 
-$(eval $(call BuildPackage,inadyn))
+$(eval $(call BuildPackage,inadyn-openssl))
+$(eval $(call BuildPackage,inadyn-mbedtls))


### PR DESCRIPTION
Maintainer: none
Compile tested: mipsel_24kc, Netgear R6220, master
Run tested: mipsel_24kc, Netgear R6220, 23.05 branch, verified that updating dynamic dns address works