### PR TITLE
python-websocket-client: update to 1.6.1

### DIFF
--- a/lang/python/python-websocket-client/Makefile
+++ b/lang/python/python-websocket-client/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-websocket-client
-PKG_VERSION:=1.5.1
+PKG_VERSION:=1.6.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=websocket-client
-PKG_HASH:=3f09e6d8230892547132177f575a4e3e73cfdf06526e20cc02aa1c3b47184d40
+PKG_HASH:=c951af98631d24f8df89ab1019fc365f2227c0892f12fd150e935607c79dd0dd
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream release

- 1.6.1
  - Fix Dispatcher keyboard interrupt. Should solve reconnect loop with rel

- 1.6.0
  - Fix teardown issue when ping thread is not properly ended
  - Fix double ping wait time on first ping
  - Minor typehints improvements

- 1.5.3
  - Add logic to avoid error in the case where content-length header does not exist, bug introduced in 1.5.2
  - Fix wsdump.py script typing, bug introduced in 1.5.2

- 1.5.2
  - Add typehints
  - Fix pytype errors
  - Fix args passed to logging function
  - Standardize PEP 3101 formatting
  - Add more verbose exception for unsuccessful handshake
