### PR TITLE
python-dotenv: update to v1.0.0

### DIFF
--- a/lang/python/python-dotenv/Makefile
+++ b/lang/python/python-dotenv/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dotenv
-PKG_VERSION:=0.21.0
+PKG_VERSION:=1.0.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=python-dotenv
-PKG_HASH:=b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045
+PKG_HASH:=a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream release

- 1.0.0:

  - What's Changed: - Handle situations where the cwd does not exist. - Add python-decouple as a related project - Drop support for python 3.7, add python 3.12-dev

- 0.21.1:

  - Added: - Use Python 3.11 non-beta in CI - Modernize variables code - Modernize main.py and parser.py code - Improve conciseness of cli.py and init.py - Improve error message for get and list commands when env file can't be opened - Updated Licence to align with BSD OSI template

