### PR TITLE
python3-paramiko: update to version 3.5.1

### DIFF
--- a/lang/python/python-paramiko/Makefile
+++ b/lang/python/python-paramiko/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-paramiko
-PKG_VERSION:=3.3.1
+PKG_VERSION:=3.4.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=paramiko
-PKG_HASH:=6a3777a961ac86dbef375c5f5b8d50014a1a96d0fd7f054a43bc880134b0ff77
+PKG_HASH:=aac08f26a31dc4dffd92821527d1682d99d52f9ef6851968114a8728f3c274d3
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/lang/python/python-paramiko/Makefile
+++ b/lang/python/python-paramiko/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-paramiko
-PKG_VERSION:=3.2.0
+PKG_VERSION:=3.3.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=paramiko
-PKG_HASH:=93cdce625a8a1dc12204439d45033f3261bdb2c201648cfcdc06f9fd0f94ec29
+PKG_HASH:=6a3777a961ac86dbef375c5f5b8d50014a1a96d0fd7f054a43bc880134b0ff77
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/lang/python/python-paramiko/Makefile
+++ b/lang/python/python-paramiko/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-paramiko
-PKG_VERSION:=3.4.0
+PKG_VERSION:=3.4.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=paramiko
-PKG_HASH:=aac08f26a31dc4dffd92821527d1682d99d52f9ef6851968114a8728f3c274d3
+PKG_HASH:=8b15302870af7f6652f2e038975c1d2973f06046cb5d7d65355668b3ecbece0c
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/lang/python/python-paramiko/Makefile
+++ b/lang/python/python-paramiko/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-paramiko
-PKG_VERSION:=2.12.0
-PKG_RELEASE:=2
+PKG_VERSION:=3.2.0
+PKG_RELEASE:=1
 
 PYPI_NAME:=paramiko
-PKG_HASH:=376885c05c5d6aa6e1f4608aac2a6b5b0548b1add40274477324605903d9cd49
+PKG_HASH:=93cdce625a8a1dc12204439d45033f3261bdb2c201648cfcdc06f9fd0f94ec29
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=LGPL-2.1-or-later
@@ -27,10 +27,11 @@ define Package/python3-paramiko
 endef
 
 define Package/python3-paramiko/description
-  Paramiko is a Python (2.7, 3.4+) implementation of the SSHv2 protocol,
-  providing both client and server functionality. While it leverages a Python
-  C extension for low level cryptography (Cryptography), Paramiko itself is a
-  pure Python interface around SSH networking concepts.
+  Paramiko is a pure-Python (3.6+) implementation of the SSHv2 protocol,
+  providing both client and server functionality. It provides the foundation
+  for the high-level SSH library Fabric, which is what we recommend you use
+  for common client use-cases such as running remote shell commands or
+  transferring files.
 endef
 
 $(eval $(call Py3Package,python3-paramiko))

--- a/lang/python/python-paramiko/Makefile
+++ b/lang/python/python-paramiko/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-paramiko
-PKG_VERSION:=3.4.1
+PKG_VERSION:=3.5.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=paramiko
-PKG_HASH:=8b15302870af7f6652f2e038975c1d2973f06046cb5d7d65355668b3ecbece0c
+PKG_HASH:=b2c665bc45b2b215bd7d7f039901b14b067da00f3a11e6640995fd58f2664822
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New (major) upstream release.

It breaks with the openssl in openwrt due to missing `FIPS` module. @cotequeiroz 

```
Traceback (most recent call last):
  File "/root/test-python.py", line 11, in <module>
    import paramiko
  File "/usr/lib/python3.11/site-packages/paramiko/__init__.py", line 22, in <module>
  File "/usr/lib/python3.11/site-packages/paramiko/transport.py", line 137, in <module>
  File "/usr/lib/python3.11/site-packages/paramiko/transport.py", line 211, in Transport
  File "/usr/lib/python3.11/site-packages/paramiko/kex_curve25519.py", line 30, in is_available
  File "/usr/lib/python3.11/site-packages/cryptography/hazmat/primitives/asymmetric/x25519.py", line 39, in generate
  File "/usr/lib/python3.11/site-packages/cryptography/hazmat/backends/openssl/__init__.py", line 6, in <module>
  File "/usr/lib/python3.11/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 113, in <module>
  File "/usr/lib/python3.11/site-packages/cryptography/hazmat/bindings/openssl/binding.py", line 14, in <module>
ImportError: Error relocating /usr/lib/python3.11/site-packages/cryptography/hazmat/bindings/_openssl.abi3.so: FIPS_mode_set: symbol not found
```