### PR TITLE
[openwrt-23.05] python-pluggy: Update to 1.2.0

### DIFF
--- a/lang/python/python-pluggy/Makefile
+++ b/lang/python/python-pluggy/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pluggy
-PKG_VERSION:=1.0.0
+PKG_VERSION:=1.2.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=pluggy
-PKG_HASH:=4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159
+PKG_HASH:=d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>, Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me, @ja-pa
Compile tested: none (cherry picked from #21438)
Run tested: none

Description:
Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit f6190a379bf1a9be9e9f5d6dc66f1357a2666ebd)