### PR TITLE
tailscale: update to 1.44.0

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.42.0
+PKG_VERSION:=1.44.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=tailscale-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=09de9bacda98de8d733cff162572b7eac857d13db783776ba2a2450a44ecc5e9
+PKG_HASH:=dc230cf3ac290140e573268a6e8f17124752ef064c8d3a86765a9dbb6f1bd354
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Signed-off-by: Zephyr Lykos <git@mochaa.ws>

Maintainer: @ja-pa @oskarirauta
Compile tested: `aarch64_cortex-a53` @ SNAPSHOT
Run tested: `aarch64_cortex-a53` @ SNAPSHOT, `redmi-ax6s`
