### PR TITLE
frp: update to 0.51.0

### DIFF
--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=frp
-PKG_VERSION:=0.48.0
+PKG_VERSION:=0.51.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=efba8ec9fad3369ce62631369f52b78a7248df426b5b54311e96231adac5cc76
+PKG_HASH:=80ccfa40c4e25309ddb48818f6342bc59f7639be83ab6ef59ffab5caeedc37e8
 
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: @ysc3839
Compile tested: (x86_64, OpenWrt snapshot)
Run tested: (x86_64, OpenWrt snapshot)

XTCP is incompatible with previous versions since 0.49.0.

Changelog:
https://github.com/fatedier/frp/releases/tag/v0.49.0
https://github.com/fatedier/frp/releases/tag/v0.50.0
https://github.com/fatedier/frp/releases/tag/v0.51.0

