### PR TITLE
nginx: don't install all module for FULL variant

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.25.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
@@ -160,16 +160,15 @@ endef
 
 define Package/nginx-full
   $(Package/nginx/default)
-  TITLE += with ALL module selected
-  DEPENDS+=+libpcre +nginx-ssl-util +zlib +libxml2 \
-    $(foreach m,$(PKG_MOD_ALL),+nginx-mod-$(m))
+  TITLE += with ALL config selected
+  DEPENDS+=+libpcre +nginx-ssl-util +zlib +libxml2
   EXTRA_DEPENDS:=nginx-ssl-util (>=1.5-1) (<2)
   VARIANT:=full
   PROVIDES += nginx-ssl
 endef
 
 Package/nginx-full/description = $(Package/nginx/description) \
-  This variant is compiled with ALL module selected.
+  This variant is compiled with ALL config selected.
 
 Package/nginx-full/install = $(Package/nginx-ssl/install)
 


### PR DESCRIPTION
We currently have a more or less circular dependency with nginx ssl and
full variant.

FULL variant depends on every nginx module. Every nginx module depends
on nginx-ssl.

Since nginx-full depends on an nginx module, nginx-ssl is installed as
module depends on it and then the installation fails as nginx-full
conflicts with nginx-ssl.

nginx-full in it's meaning is nginx built with every config selected and
it should not have module as dependency. In fact an user should always
install them separetly as while other things, local modification to the
nginx config file are required to include the just installed module.

To fix this circular dependency problem, drop the dependency on every
nginx module for FULL variant.

Fixes: https://github.com/openwrt/packages/issues/21300
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>