### PR TITLE
procs: Add new package

### DIFF
--- a/utils/procs/Makefile
+++ b/utils/procs/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# Copyright (C) 2023 Facundo Acevedo
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=procs
+PKG_VERSION:=0.14.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/dalance/procs/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=bb4f9d696081807ca105593092f8acd04ca339ae43fff29e0e820c6fc5e3f9ea
+
+PKG_MAINTAINER:=Facundo Acevedo <facevedo@disroot.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENCE
+
+PKG_BUILD_DEPENDS:=rust/host
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/procs
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Procs is feature-rich alternative to the 'ps'
+  DEPENDS:=$(RUST_ARCH_DEPENDS) 
+  URL:=https://github.com/dalance/procs/
+endef
+
+define Package/procs/description
+  Procs is a 'ps' command replacement written in Rust, offering 
+  enhanced usability and information display. 
+  Features include color-coded output, theme auto-detection, advanced
+  search, and extended process details
+  (TCP/UDP ports, Docker names, I/O throughput).
+  It also supports pager functionality, a 'top'-like watch mode, and
+  a process tree view​​.
+endef
+
+define Package/procs/conffiles
+/etc/procs/procs.toml
+endef
+
+define Package/procs/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/procs $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/procs
+	$(INSTALL_CONF) ./files/etc/procs/procs.toml $(1)/etc/procs/
+endef
+
+$(eval $(call RustBinPackage,procs))
+$(eval $(call BuildPackage,procs))

--- a/utils/procs/files/etc/procs/procs.toml
+++ b/utils/procs/files/etc/procs/procs.toml
@@ -1,0 +1,138 @@
+[[columns]]
+kind = "Pid"
+style = "BrightYellow|Yellow"
+numeric_search = true
+nonnumeric_search = false
+align = "Left"
+
+[[columns]]
+kind = "User"
+style = "BrightGreen|Green"
+numeric_search = false
+nonnumeric_search = true
+align = "Left"
+
+[[columns]]
+kind = "Separator"
+style = "White|BrightBlack"
+numeric_search = false
+nonnumeric_search = false
+align = "Left"
+
+[[columns]]
+kind = "Tty"
+style = "BrightWhite|Black"
+numeric_search = false
+nonnumeric_search = false
+align = "Left"
+
+[[columns]]
+kind = "UsageCpu"
+style = "ByPercentage"
+numeric_search = false
+nonnumeric_search = false
+align = "Right"
+
+[[columns]]
+kind = "UsageMem"
+style = "ByPercentage"
+numeric_search = false
+nonnumeric_search = false
+align = "Right"
+
+[[columns]]
+kind = "CpuTime"
+style = "BrightCyan|Cyan"
+numeric_search = false
+nonnumeric_search = false
+align = "Left"
+
+[[columns]]
+kind = "MultiSlot"
+style = "ByUnit"
+numeric_search = false
+nonnumeric_search = false
+align = "Right"
+
+[[columns]]
+kind = "Separator"
+style = "White|BrightBlack"
+numeric_search = false
+nonnumeric_search = false
+align = "Left"
+
+[[columns]]
+kind = "Command"
+style = "BrightWhite|Black"
+numeric_search = false
+nonnumeric_search = true
+align = "Left"
+
+[style]
+header = "BrightWhite|Black"
+unit = "BrightWhite|Black"
+tree = "BrightWhite|Black"
+
+[style.by_percentage]
+color_000 = "BrightBlue|Blue"
+color_025 = "BrightGreen|Green"
+color_050 = "BrightYellow|Yellow"
+color_075 = "BrightRed|Red"
+color_100 = "BrightRed|Red"
+
+[style.by_state]
+color_d = "BrightRed|Red"
+color_r = "BrightGreen|Green"
+color_s = "BrightBlue|Blue"
+color_t = "BrightCyan|Cyan"
+color_z = "BrightMagenta|Magenta"
+color_x = "BrightMagenta|Magenta"
+color_k = "BrightYellow|Yellow"
+color_w = "BrightYellow|Yellow"
+color_p = "BrightYellow|Yellow"
+
+[style.by_unit]
+color_k = "BrightBlue|Blue"
+color_m = "BrightGreen|Green"
+color_g = "BrightYellow|Yellow"
+color_t = "BrightRed|Red"
+color_p = "BrightRed|Red"
+color_x = "BrightBlue|Blue"
+
+[search]
+numeric_search = "Exact"
+nonnumeric_search = "Partial"
+logic = "And"
+case = "Smart"
+
+[display]
+show_self = false
+show_thread = false
+show_thread_in_tree = true
+show_parent_in_tree = true
+show_children_in_tree = true
+show_header = true
+show_footer = false
+cut_to_terminal = true
+cut_to_pager = false
+cut_to_pipe = false
+color_mode = "Auto"
+separator = "│"
+ascending = "▲"
+descending = "▼"
+tree_symbols = ["│", "─", "┬", "├", "└"]
+abbr_sid = true
+theme = "Auto"
+
+[sort]
+column = 0
+order = "Ascending"
+
+[docker]
+path = "unix:///var/run/docker.sock"
+
+[pager]
+mode = "Disable" # OpenWrt's less doen't support the flags '-SR', if needed install the full less pacakge
+detect_width = false
+use_builtin = false
+


### PR DESCRIPTION

Maintainer: me 
Compile tested: x86_64, container image: docker.io/openwrt/sdk:latest (4c7b0adaed32)
Run tested: x86_64, Vm Openwrt 22.03.5

Description:
Procs is a modern, feature-rich alternative to the 'ps' command written in Rust