### PR TITLE
File: update to version 5.44. Fix segfault

### DIFF
--- a/libs/file/Makefile
+++ b/libs/file/Makefile
@@ -82,20 +82,22 @@ define Build/InstallDev
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/magic.h $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libmagic.{a,so*} $(1)/usr/lib/
+	${INSTALL_DIR} $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/libmagic.pc $(1)/usr/lib/pkgconfig/
 endef
 
 define Package/file/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/file $(1)/usr/bin/
-	$(INSTALL_DIR) $(1)/usr/share/misc
-	$(SED) "/^#/d" $(PKG_INSTALL_DIR)/usr/share/file/magic
-	$(SED) "/^$$$$/d" $(PKG_INSTALL_DIR)/usr/share/file/magic
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/file/magic $(1)/usr/share/misc/
 endef
 
 define Package/libmagic/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmagic.so.* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/share/misc
+	$(SED) "/^#/d" $(PKG_INSTALL_DIR)/usr/share/file/magic
+	$(SED) "/^$$$$/d" $(PKG_INSTALL_DIR)/usr/share/file/magic
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/file/magic $(1)/usr/share/misc/
 endef
 
 $(eval $(call BuildPackage,file))

--- a/libs/file/Makefile
+++ b/libs/file/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=file
-PKG_VERSION:=5.41
-PKG_RELEASE:=2
+PKG_VERSION:=5.44
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.openpkg.org/components/cache/file/ \
 	ftp://ftp.astron.com/pub/file/
-PKG_HASH:=13e532c7b364f7d57e23dfeea3147103150cb90593a57af86c10e4f6e411603f
+PKG_HASH:=3751c7fba8dbc831cb8d7cc8aff21035459b8ce5155ef8b0880a27d028475f3b
 
 PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
 PKG_LICENSE:=BSD-2-Clause


### PR DESCRIPTION
Maintainer: me@vchrist.at
Compile tested: OpenWRT-23.05-rc2, arm_cortex-a7_neon-vfpv4, mips_24kc
Run tested: arm_cortex-a7_neon-vfpv4 (Linksys MR8300), mips_24kc (tplink_archer-a7), OpenWrt 23.05-rc2)

Description:
* Update package file to version 5.44.
* Fix segfaulting of executables depending on binary package libmagic if binary package file is not installed. libmagic needs file /usr/share/misc/magic to not segfault. Thus, install /usr/share/misc/magic along with libmagic and not with file.

Signed-off-by: Volker Christian <me@vchrist.at>
