### PR TITLE
Nlohmannjson: Update to version 3.11.2

### DIFF
--- a/libs/nlohmannjson/Makefile
+++ b/libs/nlohmannjson/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nlohmannjson
-PKG_VERSION:=3.10.2
-PKG_RELEASE:=2
+PKG_VERSION:=3.11.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
 PKG_SOURCE_URL:=https://codeload.github.com/nlohmann/json/zip/v$(PKG_VERSION)?
-PKG_HASH:=6e407a7a7a6fe2f20396270ed561afeda03cd238ccb32ad94b7f985b0aa113fe
+PKG_HASH:=95651d7d1fcf2e5c3163c3d37df6d6b3e9e5027299e6bd050d157322ceda9ac9
 PKG_BUILD_DIR:=$(BUILD_DIR)/json-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Leonid Esman <leonid.esman@gmail.com>
@@ -34,9 +34,10 @@ endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/nlohmann
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/nlohmann/json.hpp $(1)/usr/include/nlohmann
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/nlohmann/json.hpp $(1)/usr/include/nlohmann
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/nlohmann/json_fwd.hpp $(1)/usr/include/nlohmann
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/nlohmann_json.pc $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/nlohmann_json.pc $(1)/usr/lib/pkgconfig
 endef
 
 $(eval $(call BuildPackage,nlohmannjson))


### PR DESCRIPTION
Compile tested: OpenWRT-23.05-rc2, arm_cortex-a7_neon-vfpv4, mips_24kc
Run tested: arm_cortex-a7_neon-vfpv4 (Linksys MR8300), mips_24kc (tplink_archer-a7), OpenWrt 23.05-rc2)

* Update package nlohmannjson to version 3.11.2.
* Version 3.11.2 is source compatible with 3.10.2 so no package should fail to compile

Signed-off-by: Volker Christian <me@vchrist.at>
