### PR TITLE
nginx: opt out of lto usage

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.25.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
@@ -23,7 +23,7 @@ PKG_CPE_ID:=cpe:/a:nginx:nginx
 PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
-PKG_BUILD_FLAGS:=gc-sections
+PKG_BUILD_FLAGS:=gc-sections no-lto
 
 # 3rd-party modules
 PKG_MOD_EXTRA := \


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de> & Ansuel Smith <ansuelsmth@gmail.com>
Compile tested: master x86_64
Run tested: master x86_64

Description:
Fix building with `USE_LTO` enabled:

```
checking for TCP_FASTOPEN ... found
checking for TCP_INFO ... found
checking for accept4() ... found
checking for int size ...  bytes

./configure: error: can not detect int size
make[2]: *** [Makefile:463: /home/jmarcet/src/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/nginx-ssl/nginx-1.25.1/.configured_282713dc4924dc6e16ac2e4fc7ab1649] Error 1
make[2]: Leaving directory '/home/jmarcet/src/openwrt/openwrt-master-x64/feeds/packages/net/nginx'
time: package/feeds/packages/nginx/ssl/compile#1.21#0.79#1.91
    ERROR: package/feeds/packages/nginx failed to build (build variant: ssl).
make[1]: *** [package/Makefile:120: package/feeds/packages/nginx/compile] Error 1
make[1]: Leaving directory '/home/jmarcet/src/openwrt/openwrt-master-x64'
make: *** [/home/jmarcet/src/openwrt/openwrt-master-x64/include/toplevel.mk:232: package/feeds/packages/nginx/compile] Error 2
```
