### PR TITLE
libaio: opt out of lto usage

### DIFF
--- a/libs/libaio/Makefile
+++ b/libs/libaio/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libaio
 PKG_VERSION:=0.3.113
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://releases.pagure.org/libaio
@@ -20,7 +20,7 @@ PKG_LICENSE:=LGPL-2.1-only
 PKG_LICENSE_FILES:=COPYING
 
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_FLAGS:=no-mips16
+PKG_BUILD_FLAGS:=no-mips16 no-lto
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer:
Compile tested: master x86_64
Run tested: master x86_64

Description:
Fix building with `USE_LTO` enabled.

```
ccache x86_64-openwrt-linux-musl-gcc -shared -Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -ffile-prefix-map=/home/jmarcet/src/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/libaio-0.3.113=libaio-0.3.113 -ffunction-sections -fdata-sections -flto=auto -fno-fat-lto-objects -Wformat -Werror=format-security -DPIC -fpic -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wl,-z,now -Wl,-z,relro  -I/home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/usr/include -I/home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/include/fortify -I/home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/include  -Wall -I. -fPIC -Wl,--version-script=libaio.map -Wl,-soname=libaio.so.1 -o libaio.so.1.0.2 io_queue_init.os io_queue_release.os io_queue_wait.os io_queue_run.os io_getevents.os io_submit.os io_cancel.os io_setup.os io_destroy.os io_pgetevents.os raw_syscall.os compat-0_1.os -L/home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/usr/lib -L/home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/lib -fuse-ld=mold -Wl,--gc-sections -flto=auto -fuse-linker-plugin -DPIC -fpic -specs=/home/jmarcet/src/openwrt/openwrt-master-x64/include/hardened-ld-pie.specs -znow -zrelro
mold: warning: libaio.map: cannot assign version `LIBAIO_0.1` to symbol `io_queue_wait`: symbol not found
mold: warning: libaio.map: cannot assign version `LIBAIO_0.1` to symbol `io_cancel`: symbol not found
mold: warning: libaio.map: cannot assign version `LIBAIO_0.1` to symbol `io_getevents`: symbol not found
mold: warning: libaio.map: cannot assign version `LIBAIO_0.4` to symbol `io_cancel`: symbol not found
mold: warning: libaio.map: cannot assign version `LIBAIO_0.4` to symbol `io_getevents`: symbol not found
mold: warning: libaio.map: cannot assign version `LIBAIO_0.4` to symbol `io_queue_wait`: symbol not found
mold: warning: libaio.map: cannot assign version `LIBAIO_0.1` to symbol `io_queue_wait`: symbol not found
mold: warning: libaio.map: cannot assign version `LIBAIO_0.1` to symbol `io_cancel`: symbol not found
mold: warning: libaio.map: cannot assign version `LIBAIO_0.1` to symbol `io_getevents`: symbol not found
mold: warning: libaio.map: cannot assign version `LIBAIO_0.4` to symbol `io_cancel`: symbol not found
mold: warning: libaio.map: cannot assign version `LIBAIO_0.4` to symbol `io_getevents`: symbol not found
mold: warning: libaio.map: cannot assign version `LIBAIO_0.4` to symbol `io_queue_wait`: symbol not found
{standard input}: Assembler messages:
{standard input}: Error: invalid attempt to declare external version name as default in symbol `io_queue_wait@@LIBAIO_0.4'
make[5]: *** [/home/jmarcet/src/openwrt/openwrt-master-x64/tmp/ccoSIYlB.mk:2: /home/jmarcet/src/openwrt/openwrt-master-x64/tmp/cccsjhTF.ltrans0.ltrans.o] Error 1
lto-wrapper: fatal error: make returned 2 exit status
compilation terminated.
mold: fatal: lto-wrapper failed
collect2: error: ld returned 1 exit status
make[4]: *** [Makefile:59: libaio.so.1.0.2] Error 1
make[4]: Leaving directory '/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/libaio-0.3.113/src'
make[3]: *** [Makefile:14: all] Error 2
make[3]: Leaving directory '/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/libaio-0.3.113'
make[2]: *** [Makefile:50: /home/jmarcet/src/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/libaio-0.3.113/.built] Error 2
make[2]: Leaving directory '/home/jmarcet/src/openwrt/openwrt-master-x64/feeds/packages/libs/libaio'
time: package/feeds/packages/libaio/compile#0.11#0.08#0.11
    ERROR: package/feeds/packages/libaio failed to build.
make[1]: *** [package/Makefile:120: package/feeds/packages/libaio/compile] Error 1
make[1]: Leaving directory '/home/jmarcet/src/openwrt/openwrt-master-x64'
make: *** [/home/jmarcet/src/openwrt/openwrt-master-x64/include/toplevel.mk:232: package/feeds/packages/libaio/compile] Error 2
```
