### PR TITLE
ripgrep: opt out of lto usage

### DIFF
--- a/utils/ripgrep/Makefile
+++ b/utils/ripgrep/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ripgrep
 PKG_VERSION:=13.0.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/BurntSushi/ripgrep/tar.gz/$(PKG_VERSION)?
@@ -16,6 +16,7 @@ PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>
 PKG_LICENSE:=MIT Unlicense
 PKG_LICENSE_FILES:=LICENSE-MIT UNLICENSE
 
+PKG_BUILD_FLAGS:=no-lto
 PKG_BUILD_DEPENDS:=rust/host
 
 RUST_PKG_FEATURES:=pcre2


### PR DESCRIPTION
Maintainer: Luca Barbato <lu_zero@luminem.org>
Compile tested: master x86_64
Run tested: master x86_64

Description:
Fix building with `USE_LTO` enabled.

```
     Running `rustc --crate-name rg --edition=2018 crates/core/main.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=479 --crate-type bin --emit=dep-info,link -C opt-level=s -C embed-bitcode=no -C debuginfo=1 --cfg 'feature="pcre2"' -C metadata=e85fa2247f2cc221 -C extra-filename=-e85fa2247f2cc221 --out-dir /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps --target x86_64-unknown-linux-musl -C linker=x86_64-openwrt-linux-musl-gcc -C strip=symbols -L dependency=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps -L dependency=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/stripped/deps --extern bstr=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libbstr-ca9750fc8c911f35.rlib --extern clap=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libclap-ada93007945b0f88.rlib --extern grep=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libgrep-54c03a57cf6b6d2a.rlib --extern ignore=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libignore-fef01a97d078da4e.rlib --extern jemallocator=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libjemallocator-ebeab78fd93aba7e.rlib --extern lazy_static=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/liblazy_static-56dac0ec2507eedd.rlib --extern log=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/liblog-a6d5098c3285250e.rlib --extern num_cpus=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libnum_cpus-d995889e5e99d013.rlib --extern regex=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libregex-665ee23b7d10ff42.rlib --extern serde_json=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libserde_json-af929dad5af0599a.rlib --extern termcolor=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libtermcolor-c9d4235ac405eae2.rlib -Ctarget-feature=-crt-static -Clink-args= -L native=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/build/pcre2-sys-fedbc970a5ba414a/out -L native=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/build/jemalloc-sys-a9866d94d7691820/out/build/lib`
error: linking with `x86_64-openwrt-linux-musl-gcc` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-gnu/bin:/home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/bin:/home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin:/home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin:/home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/host/bin:/home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/host/bin:/home/jmarcet/bin:/home/jmarcet/.local/bin:/home/jmarcet/.config/yarn/global/node_modules/.bin:/home/jmarcet/.gem/ruby/3.0.0/bin:/home/jmarcet/go/bin:/opt/android-sdk/platform-tools:/usr/local/bin:/usr/local/sbin:/home/jmarcet/.tmuxifier/bin:/opt/google-cloud-sdk/bin:/usr/bin:/sbin:/opt/android-sdk/emulator:/opt/android-sdk/tools:/opt/android-sdk/tools/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/usr/local/rvm/bin:/home/jmarcet/.yarn/bin" VSLANG="1033" "x86_64-openwrt-linux-musl-gcc" "-m64" "/home/jmarcet/src/openwrt/openwrt-master-x64/tmp/rustcYWdMV7/symbols.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.0.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.1.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.10.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.11.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.12.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.13.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.14.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.15.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.2.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.3.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.4.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.5.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.6.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.7.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.8.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.9.rcgu.o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.1ezndngvg6qmnuy5.rcgu.o" "-Wl,--as-needed" "-L" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps" "-L" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/stripped/deps" "-L" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/build/pcre2-sys-fedbc970a5ba414a/out" "-L" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/build/jemalloc-sys-a9866d94d7691820/out/build/lib" "-L" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib" "-Wl,-Bstatic" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libjemallocator-ebeab78fd93aba7e.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libjemalloc_sys-c08dcc9625be5e59.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libnum_cpus-d995889e5e99d013.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libgrep-54c03a57cf6b6d2a.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libgrep_regex-83c3d4ecf6c731aa.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libregex_syntax-d1460c00b8ee22ac.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libgrep_printer-32e1e966cb23e0cb.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libbase64-5586e58b9199b58f.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libserde_json-af929dad5af0599a.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libryu-81b1cb13dfad965e.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libitoa-98e18ee8c97afc13.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libserde-0160e98dcb56b9bf.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libgrep_searcher-9082ce462320ae8c.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libmemmap2-68243b6766ba4984.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libencoding_rs_io-b979814c432a82fc.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libencoding_rs-c94ea99b0bcc9272.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libbytecount-e1929ad4d78a1e0b.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libgrep_pcre2-e30553b7503ddb17.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2_sys-e106c45ae4d23162.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libgrep_matcher-da51b642f6650223.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libgrep_cli-a35dd24226e755d2.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libatty-6750ff7c1ca1a3d1.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/liblibc-2aebafb640338791.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libtermcolor-c9d4235ac405eae2.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libclap-ada93007945b0f88.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libtextwrap-557fcedff4de3902.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libunicode_width-5771ebc755f948d2.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libstrsim-543c9dea930644ef.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libbitflags-54ab7251ee3541ef.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libignore-fef01a97d078da4e.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libcrossbeam_utils-e720a66b08a2d84b.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libwalkdir-f98928e9476516e1.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libsame_file-bc10b8d0408de175.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libthread_local-839766ec1e3386f1.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libcfg_if-03f0753a4c89b9c9.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libonce_cell-fa2edd6f3e3ba904.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libglobset-b4a17b652d05a044.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libfnv-1efdc11cae741fbc.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/liblog-a6d5098c3285250e.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libregex-665ee23b7d10ff42.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libregex_automata-db0e0245f4717173.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libaho_corasick-7eb91311dd3566c2.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libregex_syntax-046ff62549045ef4.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libbstr-ca9750fc8c911f35.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/liblazy_static-56dac0ec2507eedd.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libregex_automata-0df3dbf1ccd0c549.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libaho_corasick-c9995a86948d7061.rlib" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libmemchr-387f23804f0f63d0.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/libstd-0c318132b7855c1a.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/libpanic_unwind-23b0e69f1a2b7767.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/libobject-1ba0eec514f37af5.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/libmemchr-255b7927f5855e08.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/libaddr2line-742597d79ada7146.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/libgimli-f32f53fb89e2577b.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/librustc_demangle-66d8ef86c153bff7.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/libstd_detect-0e2f95ee16866810.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/libhashbrown-e7285109cb9692e4.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/libminiz_oxide-24272f3bf5d058b8.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/libadler-aa00aed3930867af.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/librustc_std_workspace_alloc-ae4ea7c6d825e036.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/libunwind-d823df869f9c2a14.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/libcfg_if-f67d42e610c8ec48.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/liblibc-45a20c6c20c47b60.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/liballoc-298f9cfb16a382c0.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/librustc_std_workspace_core-428d1f124be714ae.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/libcore-0294f3786eeebdff.rlib" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib/libcompiler_builtins-df28e0c79c532088.rlib" "-Wl,-Bdynamic" "-lpthread" "-lgcc_s" "-lc" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/mnt/caches/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/lib/rustlib/x86_64-unknown-linux-musl/lib" "-o" "/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,--strip-all" "-nodefaultlibs"
  = note: /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.12.rcgu.o: in function `<jemallocator::Jemalloc as core::alloc::global::GlobalAlloc>::alloc':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/jemallocator-0.3.2/src/lib.rs:81: undefined reference to `_rjem_mallocx'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.12.rcgu.o: in function `<jemallocator::Jemalloc as core::alloc::global::GlobalAlloc>::dealloc':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/jemallocator-0.3.2/src/lib.rs:99: undefined reference to `_rjem_sdallocx'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.12.rcgu.o: in function `<jemallocator::Jemalloc as core::alloc::global::GlobalAlloc>::realloc':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/jemallocator-0.3.2/src/lib.rs:105: undefined reference to `_rjem_rallocx'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/rg-e85fa2247f2cc221.rg.4b80fa34-cgu.12.rcgu.o: in function `<jemallocator::Jemalloc as core::alloc::global::GlobalAlloc>::alloc_zeroed':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/jemallocator-0.3.2/src/lib.rs:88: undefined reference to `_rjem_calloc'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/jemallocator-0.3.2/src/lib.rs:91: undefined reference to `_rjem_mallocx'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.2.rcgu.o): in function `<pcre2::ffi::Code as core::ops::drop::Drop>::drop':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:85: undefined reference to `pcre2_code_free_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.2.rcgu.o): in function `<pcre2::ffi::CompileContext as core::ops::drop::Drop>::drop':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:273: undefined reference to `pcre2_compile_context_free_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:273: undefined reference to `pcre2_compile_context_free_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.2.rcgu.o): in function `pcre2::ffi::CompileContext::set_newline':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:293: undefined reference to `pcre2_set_newline_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.2.rcgu.o): in function `pcre2::ffi::Code::jit_compile':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:121: undefined reference to `pcre2_jit_compile_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:121: undefined reference to `pcre2_jit_compile_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.3.rcgu.o): in function `<pcre2::ffi::CompileContext as core::ops::drop::Drop>::drop':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:273: undefined reference to `pcre2_compile_context_free_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.3.rcgu.o): in function `pcre2::ffi::is_jit_available':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:18: undefined reference to `pcre2_config_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.3.rcgu.o): in function `pcre2::ffi::Code::new':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:99: undefined reference to `pcre2_compile_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.3.rcgu.o): in function `<pcre2::ffi::CompileContext as core::ops::drop::Drop>::drop':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:273: undefined reference to `pcre2_compile_context_free_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.3.rcgu.o): in function `pcre2::ffi::Code::name_count':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:208: undefined reference to `pcre2_pattern_info_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.3.rcgu.o): in function `pcre2::ffi::Code::name_entry_size':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:230: undefined reference to `pcre2_pattern_info_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.3.rcgu.o): in function `pcre2::ffi::Code::raw_name_table':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:191: undefined reference to `pcre2_pattern_info_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.3.rcgu.o): in function `pcre2::ffi::Code::capture_count':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:249: undefined reference to `pcre2_pattern_info_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.3.rcgu.o): in function `pcre2::ffi::CompileContext::new':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:282: undefined reference to `pcre2_compile_context_create_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.3.rcgu.o): in function `<pcre2::ffi::MatchData as core::ops::drop::Drop>::drop':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:347: undefined reference to `pcre2_jit_stack_free_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:349: undefined reference to `pcre2_match_data_free_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:350: undefined reference to `pcre2_match_context_free_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.3.rcgu.o): in function `pcre2::ffi::MatchData::new':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:361: undefined reference to `pcre2_match_context_create_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:365: undefined reference to `pcre2_match_data_create_from_pattern_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:377: undefined reference to `pcre2_jit_stack_create_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:386: undefined reference to `pcre2_jit_stack_assign_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:396: undefined reference to `pcre2_get_ovector_pointer_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:398: undefined reference to `pcre2_get_ovector_count_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.3.rcgu.o): in function `pcre2::ffi::MatchData::find':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:446: undefined reference to `pcre2_match_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.5.rcgu.o): in function `<pcre2::ffi::CompileContext as core::ops::drop::Drop>::drop':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:273: undefined reference to `pcre2_compile_context_free_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.5.rcgu.o): in function `<pcre2::ffi::Code as core::ops::drop::Drop>::drop':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:85: undefined reference to `pcre2_code_free_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.5.rcgu.o): in function `<pcre2::ffi::CompileContext as core::ops::drop::Drop>::drop':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/ffi.rs:273: undefined reference to `pcre2_compile_context_free_8'
          /mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld: /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libpcre2-fc3ba39c79cf5b7f.rlib(pcre2-fc3ba39c79cf5b7f.pcre2.e9d347ad-cgu.8.rcgu.o): in function `pcre2::error::Error::error_message':
          /home/jmarcet/src/openwrt/openwrt-master-x64/staging_dir/hostpkg/cargo/registry/src/index.crates.io-6f17d22bba15001f/pcre2-0.2.4/src/error.rs:97: undefined reference to `pcre2_get_error_message_8'
          collect2: error: ld returned 1 exit status

  = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
  = note: use the `-l` flag to specify native libraries to link
  = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)

error: could not compile `ripgrep` (bin "rg") due to previous error

Caused by:
  process didn't exit successfully: `rustc --crate-name rg --edition=2018 crates/core/main.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=479 --crate-type bin --emit=dep-info,link -C opt-level=s -C embed-bitcode=no -C debuginfo=1 --cfg 'feature="pcre2"' -C metadata=e85fa2247f2cc221 -C extra-filename=-e85fa2247f2cc221 --out-dir /mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps --target x86_64-unknown-linux-musl -C linker=x86_64-openwrt-linux-musl-gcc -C strip=symbols -L dependency=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps -L dependency=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/stripped/deps --extern bstr=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libbstr-ca9750fc8c911f35.rlib --extern clap=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libclap-ada93007945b0f88.rlib --extern grep=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libgrep-54c03a57cf6b6d2a.rlib --extern ignore=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libignore-fef01a97d078da4e.rlib --extern jemallocator=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libjemallocator-ebeab78fd93aba7e.rlib --extern lazy_static=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/liblazy_static-56dac0ec2507eedd.rlib --extern log=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/liblog-a6d5098c3285250e.rlib --extern num_cpus=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libnum_cpus-d995889e5e99d013.rlib --extern regex=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libregex-665ee23b7d10ff42.rlib --extern serde_json=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libserde_json-af929dad5af0599a.rlib --extern termcolor=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/deps/libtermcolor-c9d4235ac405eae2.rlib -Ctarget-feature=-crt-static -Clink-args= -L native=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/build/pcre2-sys-fedbc970a5ba414a/out -L native=/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target/x86_64-unknown-linux-musl/stripped/build/jemalloc-sys-a9866d94d7691820/out/build/lib` (exit status: 1)
error: failed to compile `ripgrep v13.0.0 (/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0)`, intermediate artifacts can be found at `/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/target`
make[2]: *** [Makefile:43: /home/jmarcet/src/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/ripgrep-13.0.0/.built] Error 101
make[2]: Leaving directory '/home/jmarcet/src/openwrt/openwrt-master-x64/feeds/packages/utils/ripgrep'
time: package/feeds/packages/ripgrep/compile#104.40#6.56#10.27
    ERROR: package/feeds/packages/ripgrep failed to build.
make[1]: *** [package/Makefile:120: package/feeds/packages/ripgrep/compile] Error 1
make[1]: Leaving directory '/home/jmarcet/src/openwrt/openwrt-master-x64'
make: *** [/home/jmarcet/src/openwrt/openwrt-master-x64/include/toplevel.mk:232: package/feeds/packages/ripgrep/compile] Error 2
```