### PR TITLE
v4l2camera: add new package

### DIFF
--- a/multimedia/v4l2camera/Makefile
+++ b/multimedia/v4l2camera/Makefile
@@ -1,0 +1,88 @@
+# This software is in the public domain, furnished "as is", without technical
+# support, and with no warranty, express or implied, as to its usefulness for
+# any purpose.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=v4l2camera
+PKG_VERSION:=0.1.8
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/mpromonet/v4l2camera
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_MIRROR_HASH:=3e10898db18d8b36ab41ebc9fa5cb37928e5bb4043a5a8bb1257724ee71f41ff
+
+UI_FILE:=v4l2camera-ui-$(PKG_VERSION).tgz
+UI_HASH:=9a03905fde298abe028e01ba575006a5bff5182ed3d45da01eace045cfef2f82
+
+LIVE555_VERSION:=2023.01.19
+LIVE555_HASH:=a7c64913f7f7007c5fdc29ea811e3ca781f262271b3e42afdd4bc1041d86fa99
+LIVE555_FILE:=live.$(LIVE555_VERSION).tar.gz
+
+PKG_MAINTAINER:=Michel Promonet<michel.promonet@free.fr>
+PKG_LICENSE:=Unlicense
+PKG_LICENSE_FILES:=LICENCE
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+RSTRIP:=:
+
+define Package/v4l2camera
+  SECTION:=multimedia
+  CATEGORY:=Multimedia
+  TITLE:=v4l2camera
+  DEPENDS:=+libstdcpp 
+  URL:=https://github.com/mpromonet/v4l2camera
+endef
+
+define Package/v4l2camera/conffiles
+/etc/config/v4l2camera
+endef
+
+CMAKE_OPTIONS += \
+       -DWITH_SSL=OFF \
+       -DWITH_COMPRESS=OFF \
+       -DBUILD_UI=OFF
+
+define Download/live555
+	URL:=https://download.videolan.org/pub/contrib/live555/
+	FILE:=$(LIVE555_FILE)
+	HASH:=$(LIVE555_HASH)
+endef
+
+define Download/ui
+	URL:=https://registry.npmjs.org/v4l2camera-ui/-/
+	FILE:=$(UI_FILE)
+	HASH:=$(UI_HASH)
+endef
+
+define Build/Prepare
+	# download live555
+	$(eval $(call Download,live555))
+	mkdir -p $(PKG_BUILD_DIR)/live
+	$(TAR) -xf $(DL_DIR)/$(LIVE555_FILE) --strip=1 -C $(PKG_BUILD_DIR)/live
+
+	# download ui
+	$(eval $(call Download,ui))
+	mkdir -p $(PKG_BUILD_DIR)/vuejs
+	$(TAR) -xf $(DL_DIR)/$(UI_FILE) --strip=1 -C $(PKG_BUILD_DIR)/vuejs
+
+	$(Build/Prepare/Default)
+endef
+
+define Package/v4l2camera/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/v4l2camera $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/usr/share/v4l2camera
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/v4l2camera $(1)/usr/share/
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) files/v4l2camera.init $(1)/etc/init.d/v4l2camera
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) files/v4l2camera.config $(1)/etc/config/v4l2camera
+endef
+
+$(eval $(call BuildPackage,v4l2camera))

--- a/multimedia/v4l2camera/files/v4l2camera.config
+++ b/multimedia/v4l2camera/files/v4l2camera.config
@@ -1,0 +1,5 @@
+config v4l2camera 'core'
+	option enabled '0'
+	option device '/dev/video0'
+	option httpport '8080'
+	option rtspport '554'

--- a/multimedia/v4l2camera/files/v4l2camera.init
+++ b/multimedia/v4l2camera/files/v4l2camera.init
@@ -1,0 +1,63 @@
+#!/bin/sh /etc/rc.common
+
+START=90
+STOP=10
+
+USE_PROCD=1
+
+SERVICE=v4l2camera
+PROG=/usr/bin/$SERVICE
+
+error() {
+        logger -t "$SERVICE" "$@"
+}
+
+start_instance() {
+	local s="$1"
+
+	config_get_bool enabled "$1" 'enabled' 0
+	[ $enabled -eq 0 ] && return
+
+	# validate device
+	config_get device "$s" 'device'
+	if [ ! -c "$device" ]; then
+		error "device '$device' does not exist"
+		return 1
+	fi
+
+	# get options
+	config_get rtspport "$s" 'rtspport'
+	config_get httpport "$s" 'httpport'
+        config_get mode "$s" 'mode'
+        config_get format "$s" 'format'
+
+	# build args
+	local args="-p /usr/share/$SERVICE"
+	args="$args -R $rtspport"
+	args="$args -P $httpport"
+	if [ ! -z "$mode" ]; then
+		args="$args -G$mode"
+        fi
+        if [ ! -z "$format" ]; then
+                args="$args -f$format"
+        fi
+	cmd="$PROG $args $device"
+
+	# procd stuff
+	procd_open_instance
+	procd_set_param file /etc/config/$SERVICE
+	procd_set_param command $cmd
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_add_mdns "http" "tcp" "$httpport" "daemon=$SERVICE" "path=/"
+	procd_close_instance
+}
+
+start_service() {
+	config_load "$SERVICE"
+	config_foreach start_instance "$SERVICE"
+}
+
+service_triggers() {
+	procd_add_reload_trigger "$SERVICE"
+}

--- a/multimedia/v4l2camera/patches/001_live555_sprintf_format.patch
+++ b/multimedia/v4l2camera/patches/001_live555_sprintf_format.patch
@@ -1,0 +1,25 @@
+From: Michel Promonet <michel.promonet@free.fr>
+Subject: [PATCH] Fix crash formating time_t as long (it is a long long)
+Signed-off-by: Michel Promonet <michel.promonet@free.fr>
+
+---
+--- a/live/liveMedia/ServerMediaSession.cpp
++++ b/live/liveMedia/ServerMediaSession.cpp
+@@ -272,7 +272,7 @@ char* ServerMediaSession::generateSDPDes
+ 
+     char const* const sdpPrefixFmt =
+       "v=0\r\n"
+-      "o=- %ld%06ld %d IN %s %s\r\n"
++      "o=- %lld%06lld %d IN %s %s\r\n"
+       "s=%s\r\n"
+       "i=%s\r\n"
+       "t=0 0\r\n"
+@@ -300,7 +300,7 @@ char* ServerMediaSession::generateSDPDes
+ 
+     // Generate the SDP prefix (session-level lines):
+     snprintf(sdp, sdpLength, sdpPrefixFmt,
+-	     fCreationTime.tv_sec, fCreationTime.tv_usec, // o= <session id>
++	     (long long)fCreationTime.tv_sec, (long long)fCreationTime.tv_usec, // o= <session id>
+ 	     1, // o= <version> // (needs to change if params are modified)
+ 	     addressFamily == AF_INET ? "IP4" : "IP6", // o= <address family>
+ 	     ipAddressStr.val(), // o= <address>


### PR DESCRIPTION
Maintainer: @mpromonet
Compile tested: (sunxi, nanopi neo air, OpenWrt latest)
Run tested: (sunxi, nanopi neo air, OpenWrt latest, enable service, start it and connect to http server, connect with vlc to rtsp server)

Description:
Add v4l2camera that provide a simple web server to RTSP server feeded with V4L2 capture device