### PR TITLE
transmission: fix depends on libmbedtls

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=4.0.3
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/transmission/transmission/releases/download/$(PKG_VERSION)/
@@ -45,7 +45,7 @@ define Package/transmission/template
   DEPENDS:=+libatomic +libcurl +libdeflate +libdht +libevent2 \
 	   +libevent2-pthreads +libminiupnpc +libnatpmp +libpthread +libpsl \
 	   +librt +libutp +zlib +LIBCURL_NOSSL:libmbedtls \
-	   +LIBCURL_GNUTLS:libmbedtls
+	   +LIBCURL_GNUTLS:libmbedtls +LIBCURL_MBEDTLS:libmbedtls
 endef
 
 define Package/transmission-daemon


### PR DESCRIPTION
If a firmware build with curl without mbedtls, transmission installed from openwrt official repo will fail to start

Maintainer: Daniel Golle <daniel@makrotopia.org>
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
For example, a firmware build with curl with libopenssl, and firmware build without libmbedtls, install transmission from openwrt official repo, then transmission will fail to start.
