### PR TITLE
libre2: update to 2023-02-01

### DIFF
--- a/libs/libre2/Makefile
+++ b/libs/libre2/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=re2
-PKG_VERSION:=2021-02-02
-PKG_RELEASE:=2
+PKG_VERSION:=2023-02-01
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/google/re2/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=1396ab50c06c1a8885fb68bf49a5ecfd989163015fd96699a180d6414937f33f
+PKG_HASH:=cbce8b7803e856827201a132862e41af386e7afd9cc6d9a9bc7a4fa4d8ddbdde
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=BSD-3-Clause
@@ -23,7 +23,7 @@ define Package/re2
   DEPENDS:=+libstdcpp
   TITLE:=RE2 - C++ regular expression library
   URL:=https://github.com/google/re2
-  ABI_VERSION:=6
+  ABI_VERSION:=10
 endef
 
 define Package/re2/description


### PR DESCRIPTION
Fixes compilation with GCC13

Maintainer: 