### PR TITLE
shairport-sync: fix init script

### DIFF
--- a/sound/shairport-sync/Makefile
+++ b/sound/shairport-sync/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shairport-sync
 PKG_VERSION:=3.3.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikebrady/shairport-sync/tar.gz/$(PKG_VERSION)?

--- a/sound/shairport-sync/files/shairport-sync.init
+++ b/sound/shairport-sync/files/shairport-sync.init
@@ -26,7 +26,7 @@ append_str() {
 
 	config_get val "$cfg" "$var"
 	if [ -n "$val" ] || [ -n "$def" ]; then
-		printf "\t%s = \"${val:-$def}\";\n" "$opt"
+		printf "\t%s = \"%s\";\n" "$opt" "${val:-$def}"
 	fi
 }
 


### PR DESCRIPTION
'name' may contains '%h' or '%v', printf will fail on that

Maintainer: Ted Hess <thess@kitschensync.net>, Mike Brady <mikebrady@eircom.net>
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
