### PR TITLE
rust: compile host package per target

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -3,6 +3,7 @@
 # Copyright (C) 2023 Luca Barbato and Donald Hoskins
 
 include $(TOPDIR)/rules.mk
+include ./rust-values.mk
 
 PKG_NAME:=rust
 PKG_VERSION:=1.70.0
@@ -11,7 +12,7 @@ PKG_RELEASE:=2
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
 PKG_HASH:=b2bfae000b7a5040e4ec4bbc50a09f21548190cb7570b0ed77358368413bd27c
-HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/rustc-$(PKG_VERSION)-src
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/rustc-$(PKG_VERSION)-src-$(RUSTC_TARGET_ARCH)
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>
 PKG_LICENSE:=Apache-2.0 MIT
@@ -22,7 +23,9 @@ PKG_HOST_ONLY:=1
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
-include ./rust-values.mk
+
+TAR_OPTIONS+= --strip-components 1
+TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 
 define Package/rust
   SECTION:=lang

--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -5,7 +5,6 @@
 # Rust Environmental Vars
 CONFIG_HOST_SUFFIX:=$(word 4, $(subst -, ,$(GNU_HOST_NAME)))
 RUSTC_HOST_ARCH:=$(HOST_ARCH)-unknown-linux-$(CONFIG_HOST_SUFFIX)
-CARGO_HOME:=$(STAGING_DIR_HOSTPKG)/cargo
 CARGO_VARS:=
 
 ifeq ($(CONFIG_USE_MUSL),y)
@@ -51,3 +50,5 @@ endif
 ifeq ($(ARCH),aarch64)
     RUST_CFLAGS:=-mno-outline-atomics
 endif
+
+CARGO_HOME:=$(STAGING_DIR_HOSTPKG)/cargo-$(RUSTC_TARGET_ARCH)


### PR DESCRIPTION
Maintainer: @lu-zero 
Compile tested: Raspberry Pi bcm27xx/bcm2709, bcm27xx/bcm2708. OpenWrt `openwrt-23.05` branch
Run tested: Raspberry Pi bcm27xx/bcm2709, bcm27xx/bcm2708. OpenWrt `openwrt-23.05` branch

Description:

While the compiled binaries are intended to run on the host system, the rust/host package does include the target matching the configured OpenWrt target.

If using (for example) ./scripts/env to switch between different OpenWrt configurations, this will cause issues if the different configuration is for a different target. In such case there will be a mismatch between the available Rust target and OpenWrt target and the following error will be printed:

> error[E0463]: can't find crate for `core`
> note: the `XXX` target may not be installed

This fix will add the RUSTC_TARGET_ARCH as HOST_BUILD_DIR and CARGO_HOME suffix, such that rust/host will be compiled in case an OpenWrt configuration change causes the RUSTC_TARGET_ARCH to change.

Fixes #21530.