### PR TITLE
openvpn-openssl: Compile management interface by default

### DIFF
--- a/net/openvpn/Config-openssl.in
+++ b/net/openvpn/Config-openssl.in
@@ -18,7 +18,7 @@ config OPENVPN_openssl_ENABLE_X509_ALT_USERNAME
 
 config OPENVPN_openssl_ENABLE_MANAGEMENT
 	bool "Enable management server support"
-	default n
+	default y
 
 #config OPENVPN_openssl_ENABLE_PKCS11
 #	bool "Enable pkcs11 support"


### PR DESCRIPTION
resolves #21534

Compile tested: OpenWRT 22.03.5, OpenVPN 2.5.7, x86_64 openvpn-openssl & openvpn-mbedtls. Whereas opevpn-wolfssl failed.
Run tested: OpenWRT 22.03.5, OpenVPN 2.5.7, x86_64 all my existing OpenVPN server and client connections worked fine, especially the auth-user-pass-verify featured finally worked as expected. I have tested only the openvpn-openssl package. 

This patch is only for enabling it on the openvpn-openssl package.