### PR TITLE
[openwrt-23.05] ooniprobe: Update to 3.18.0

### DIFF
--- a/net/ooniprobe/Makefile
+++ b/net/ooniprobe/Makefile
@@ -8,16 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ooniprobe
-PKG_VERSION:=3.16.5
+PKG_VERSION:=3.18.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=probe-cli-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ooni/probe-cli/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=198f7a3507482bfbf0fb24c24f34e17c9f5adbfdf5d8c63774ecd816708a4438
+PKG_HASH:=d28c050226c9282d7155da6cabf5547ddd43dc11eecacc485b6c05161c2d1d88
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
-PKG_LICENSE:=BSD-3-Clause
-PKG_LICENSE_FILES:=LICENSE.md
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/probe-cli-$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=golang/host
@@ -25,6 +25,7 @@ PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/ooni/probe-cli
+GO_PKG_BUILD_PKG:=github.com/ooni/probe-cli/v3/cmd/ooniprobe
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
@@ -38,9 +39,15 @@ define Package/ooniprobe
 endef
 
 define Package/ooniprobe/description
-  The next generation of  OONI(Open Observatory of Network Interference)
+  The next generation of Open Observatory of Network Interference (OONI)
   Probe Command Line Interface.
 endef
+
+# Workaround for musl 1.2.4 compability in mattn/go-sqlite3
+# https://github.com/mattn/go-sqlite3/issues/1164
+ifneq ($(CONFIG_USE_MUSL),)
+  TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
+endif
 
 $(eval $(call GoBinPackage,ooniprobe))
 $(eval $(call BuildPackage,ooniprobe))


### PR DESCRIPTION
Maintainer: @ja-pa 
Compile tested: none (cherry picked from #21557)
Run tested: none

Description:
This version includes support for Go 1.20 (specifically 1.20.5).

This also:

* Adds a workaround for musl 1.2.4 compatibility in [mattn/go-sqlite3][1]

* Sets `GO_PKG_BUILD_PKG` to build the main binary (ooniprobe) only

* Updates the package license; the project was relicensed in [3.13.0][2]

[1]: https://github.com/mattn/go-sqlite3/issues/1164
[2]: https://github.com/ooni/probe-cli/pull/446

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit dc7382ec65c4f22bb1e363f7d89c3c427ade4b5d)