### PR TITLE
python-mako: Re-import host-only package from abandoned packages repo

### DIFF
--- a/lang/python/python-mako/Makefile
+++ b/lang/python/python-mako/Makefile
@@ -1,0 +1,58 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-mako
+PKG_VERSION:=1.2.4
+PKG_RELEASE:=1
+
+PYPI_NAME:=Mako
+PKG_HASH:=d60a3903dc3bb01a18ad6a89cdbe2e4eadc69c0bc8ef1e3773ba53d44c3f7a34
+
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_HOST_ONLY:=1
+HOST_BUILD_DEPENDS:= \
+	python3/host \
+	python-build/host \
+	python-installer/host \
+	python-wheel/host \
+	python-markupsafe/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include ../python3-package.mk
+include ../python3-host-build.mk
+
+define Package/python3-mako
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Super-fast templating language
+  URL:=https://www.makotemplates.org/
+  DEPENDS:=+python3-light +python3-urllib +python3-markupsafe
+  BUILDONLY:=1
+endef
+
+define Package/python3-mako/description
+Mako is a template library written in Python. It provides a familiar,
+non-XML syntax which compiles into Python modules for maximum
+performance. Mako's syntax and API borrows from the best ideas of many
+others, including Django templates, Cheetah, Myghty, and Genshi.
+Conceptually, Mako is an embedded Python (i.e. Python Server Page)
+language, which refines the familiar ideas of componentized layout and
+inheritance to produce one of the most straightforward and flexible
+models available, while also maintaining close ties to Python calling
+and scoping semantics.
+endef
+
+$(eval $(call Py3Package,python3-mako))
+$(eval $(call BuildPackage,python3-mako))
+$(eval $(call BuildPackage,python3-mako-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: me
Compile tested: armsr-armv7/x86-64, 2023-07-09 snapshot sdks
Run tested: N/A

Description:
Mako was removed in 60ce07b9a1d5c7a53297f177f10af68f3304be9e; at the time we were using host pip to install host Python packages and so having this package was not necessary.

With the move away from host pip and toward proper host packages, it would be better to have a Mako host-only package here to support the mesa package in the video feed.

This re-imports the package from the abandoned packages feed, updates the makefile with current Python package conventions, and updates the package to the latest version.