### PR TITLE
python-pytz: Add host build

### DIFF
--- a/lang/python/python-pytz/Makefile
+++ b/lang/python/python-pytz/Makefile
@@ -18,9 +18,13 @@ PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
 
+HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-wheel/host
+
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-pytz
   SUBMENU:=Python
@@ -38,3 +42,4 @@ endef
 $(eval $(call Py3Package,python3-pytz))
 $(eval $(call BuildPackage,python3-pytz))
 $(eval $(call BuildPackage,python3-pytz-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: armsr-armv7, 2023-07-09 snapshot sdk
Run tested: N/A

Description:
pytz is a dependency of Babel, so to add a host build of Babel a host build of pytz is necessary.