### PR TITLE
base16384: bump to version 2.2.4

### DIFF
--- a/utils/base16384/Makefile
+++ b/utils/base16384/Makefile
@@ -1,16 +1,16 @@
 # SPDX-Identifier-License: GPL-3.0-or-later
 #
-# Copyright (C) 2022 源 文雨 <fumiama@foxmail.com>
+# Copyright (C) 2022-2023 源 文雨 <fumiama@foxmail.com>
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=base16384
-PKG_VERSION:=2.2.2
+PKG_VERSION:=2.2.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fumiama/base16384/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=948da6d9eca3af64123a7df1aa0f71a81e38ab02815ab2218e71a7aface0035e
+PKG_HASH:=5701519bd07a58019bc5204ca93194026f2869969cb8bc2563cbcb450f2e80bf
 
 PKG_MAINTAINER:=源 文雨 <fumiama@foxmail.com>
 PKG_LICENSE:=GPL-3.0-or-later

--- a/utils/base16384/test.sh
+++ b/utils/base16384/test.sh
@@ -2,10 +2,11 @@
 
 case "$1" in
 	"base16384")
+        opkg install coreutils-base64
         i=1
-        while [ $i -le 100 ]; do
-            s="$(head /dev/urandom | head -c $i)"
-            if [ "$(echo $s)" != "$(echo $s | base16384 -e - - | base16384 -d - -)" ]; then
+        while [ $i -le 256 ]; do
+            s="$(head /dev/urandom | head -c $i | base64 -w 0)"
+            if [ "$(echo $s)" != "$(echo $s | base64 -d | base16384 -e - - | base16384 -d - - | base64 -w 0)" ]; then
                 exit $i
             fi
             i=$( expr $i + 1 )


### PR DESCRIPTION
Maintainer: me
Compile tested: x86/64, Generic PC, OpenWrt 22.03.2 r19803-9a599fee93
Run tested: x86/64, Generic PC, OpenWrt 22.03.2 r19803-9a599fee93

Signed-off-by: 源 文雨 <fumiama@foxmail.com>