### PR TITLE
transmission: add ftruncate syscall to seccomp

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=4.0.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/transmission/transmission/releases/download/$(PKG_VERSION)/

--- a/net/transmission/files/transmission-daemon.json
+++ b/net/transmission/files/transmission-daemon.json
@@ -27,6 +27,7 @@
 				"fchmod",
 				"fcntl",
 				"fcntl64",
+				"ftruncate",
 				"ftruncate64",
 				"fstat",
 				"fstat64",


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: no need, it's a config file
Run tested: Raspberry Pi 3B+, OpenWrt r22977

Description:
Fixes many crashes on my system. I found this missing syscall by looking at auditd logs. Unfortunately I didn't keep them.