### PR TITLE
Bump libudev-zero to 1.0.3 (latest)

### DIFF
--- a/libs/libudev-zero/Makefile
+++ b/libs/libudev-zero/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libudev-zero
-PKG_VERSION:=1.0.1
+PKG_VERSION:=1.0.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/illiliti/libudev-zero/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=c4cf149ea96295c1e6e86038d10c725344c751982ed4a790b06c76776923e0ea
+PKG_HASH:=0bd89b657d62d019598e6c7ed726ff8fed80e8ba092a83b484d66afb80b77da5
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: Taylor Brown <taylorami@hotmail.com> / Daniel Golle <daniel@makrotopia.org>
Compile tested: x86_64, Ubuntu Hyper-V Virtual Machine, OpenWrt 23.03.5
Run tested: x86_64, Hyper-V Virtual Machine, OpenWrt 22.03.5

Description:

Upgraded libudev-zero to 1.0.3 to resolve a [known compatibility issue](https://github.com/openwrt/openwrt/issues/12350) with usbip in recent versions of OpenWrt.

I have simply bumped the package version to the latest and updated the hash. I tested the build and package in my environment to confirm that it works and addresses this issue.

_*This is my first contribution to OpenWrt, and appreciate any feedback to help maintain the style and quality standards of the project._

Signed-off-by: taylorami@hotmail.com

