### PR TITLE
[openwrt-23.05] python-babel: Update to 2.12.1, add host build

### DIFF
--- a/lang/python/python-babel/Makefile
+++ b/lang/python/python-babel/Makefile
@@ -8,33 +8,36 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-babel
-PKG_VERSION:=2.9.1
+PKG_VERSION:=2.12.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=Babel
-PKG_HASH:=bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0
+PKG_HASH:=cc2d99999cd01d44420ae725a21c9e3711b3aadc7976d6147f622d8581963455
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
+HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-wheel/host
+
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-babel
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Internationalization utilities
-  URL:=https://babel.pocoo.org/en/latest/
+  URL:=https://babel.pocoo.org/
   DEPENDS:= \
-    +python3-cgi \
     +python3-decimal \
     +python3-distutils \
     +python3-email \
     +python3-light \
-    +python3-pytz \
+    +python3-logging \
     +python3-urllib
 endef
 
@@ -47,3 +50,4 @@ endef
 $(eval $(call Py3Package,python3-babel))
 $(eval $(call BuildPackage,python3-babel))
 $(eval $(call BuildPackage,python3-babel-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: @BKPepe 
Compile tested: none (cherry picked from #21581)
Run tested: none

Description:
Also updated dependencies for the new version.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 0174cea69757589be50b9dd774394ce18cf61dae)