### PR TITLE
file: Fix FTBFS due to missing dependency

### DIFF
--- a/libs/file/Makefile
+++ b/libs/file/Makefile
@@ -56,8 +56,10 @@ CONFIGURE_ARGS += \
 	--enable-xzlib \
 	--enable-zlib \
 	--disable-libseccomp \
+	--disable-lzlib \
 	--disable-rpath \
 	--disable-warnings \
+	--disable-zstdlib \
 	--without-pic
 
 MAKE_PATH := src


### PR DESCRIPTION
CC @ratkaj

Fixes #21583

* Be more strict in selecting linked in libraries during configuration time
* Add missing dependency on binary package libzstd

Both changes made in one pull-request because they are closely related.