### PR TITLE
jq: remove _GNU_SOURCE from Makefile and instead backport patch

### DIFF
--- a/utils/jq/Makefile
+++ b/utils/jq/Makefile
@@ -28,7 +28,7 @@ ifdef CONFIG_USE_MIPS16
   TARGET_CFLAGS += -fno-ipa-sra
 endif
 
-TARGET_CFLAGS += -std=c99 -D_GNU_SOURCE
+TARGET_CFLAGS += -std=c99
 
 CONFIGURE_ARGS+= \
 	--disable-docs \

--- a/utils/jq/patches/0010-C99-compatibility-enhancements-for-the-configure-scr.patch
+++ b/utils/jq/patches/0010-C99-compatibility-enhancements-for-the-configure-scr.patch
@@ -1,0 +1,42 @@
+From 52d5988afb5999c71fd24484a93efefa2a9e9a8f Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Wed, 14 Jun 2023 14:41:04 +0200
+Subject: [PATCH 1298/1298] C99 compatibility enhancements for the configure
+ script (#2519)
+
+* configure.ac: Enable system extensions
+
+Use AC_USE_SYSTEM_EXTENSIONS to build with _GNU_SOURCE (and similar
+macros on non-GNU systems), to avoid an implicit declaration of the
+strptime function.  This improves compatibility with future compilers
+which do not support implicit function declarations.
+
+* configure.ac: gettimeofday lives in <sys/time.h>
+
+The gettimeofday function is declared in <sys/time.h>, not <time.h>,
+according to POSIX and actual systems.  This avoids a configure
+probe failure with compilers which do not support implicit function
+declarations.
+---
+ configure.ac | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -22,6 +22,7 @@ AC_PROG_CPP_WERROR
+ AC_PROG_YACC
+ AC_OBJEXT
+ AC_EXEEXT
++AC_USE_SYSTEM_EXTENSIONS
+ LT_INIT([shared static win32-dll])
+ AM_PROG_CC_C_O
+ 
+@@ -129,7 +130,7 @@ AC_FIND_FUNC([gmtime_r], [c], [#include
+ AC_FIND_FUNC([gmtime], [c], [#include <time.h>], [0])
+ AC_FIND_FUNC([localtime_r], [c], [#include <time.h>], [0, 0])
+ AC_FIND_FUNC([localtime], [c], [#include <time.h>], [0])
+-AC_FIND_FUNC([gettimeofday], [c], [#include <time.h>], [0, 0])
++AC_FIND_FUNC([gettimeofday], [c], [#include <sys/time.h>], [0, 0])
+ AC_CHECK_MEMBER([struct tm.tm_gmtoff], [AC_DEFINE([HAVE_TM_TM_GMT_OFF],1,[Define to 1 if the system has the tm_gmt_off field in struct tm])],
+                 [], [[#include <time.h>]])
+ AC_CHECK_MEMBER([struct tm.__tm_gmtoff], [AC_DEFINE([HAVE_TM___TM_GMT_OFF],1,[Define to 1 if the system has the __tm_gmt_off field in struct tm])],


### PR DESCRIPTION
Commit 4bb18b04 added _GNU_SOURCE to jq's Makefile to fix a segfault. This has since been fixed upstream, so this commit backports the upstream patch instead. This keeps things closer to upstream, and it will prevent the Makefile from containing a redundant fix once upstream releases the next version.

Maintainer: @ratkaj 
Compile tested: x86_64 master
Run tested: x86_64 master
