### PR TITLE
[openwrt-23.05] golang: Update to 1.20.6

### DIFF
--- a/lang/golang/golang-build.sh
+++ b/lang/golang/golang-build.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+#
+# Copyright (C) 2020, 2022 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
 
 nl="
 "

--- a/lang/golang/golang-compiler.mk
+++ b/lang/golang/golang-compiler.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018, 2020 Jeffery To
+# Copyright (C) 2018, 2020-2021, 2023 Jeffery To
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.

--- a/lang/golang/golang-host-build.mk
+++ b/lang/golang/golang-host-build.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Jeffery To
+# Copyright (C) 2020, 2022 Jeffery To
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.

--- a/lang/golang/golang-package.mk
+++ b/lang/golang/golang-package.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018-2020 Jeffery To
+# Copyright (C) 2018-2022 Jeffery To
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.

--- a/lang/golang/golang-values.mk
+++ b/lang/golang/golang-values.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018, 2020 Jeffery To
+# Copyright (C) 2018-2023 Jeffery To
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.

--- a/lang/golang/golang/Makefile
+++ b/lang/golang/golang/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018, 2020 Jeffery To
+# Copyright (C) 2018-2023 Jeffery To
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 GO_VERSION_MAJOR_MINOR:=1.20
-GO_VERSION_PATCH:=5
+GO_VERSION_PATCH:=6
 
 PKG_NAME:=golang
 PKG_VERSION:=$(GO_VERSION_MAJOR_MINOR)$(if $(GO_VERSION_PATCH),.$(GO_VERSION_PATCH))
@@ -20,7 +20,7 @@ GO_SOURCE_URLS:=https://dl.google.com/go/ \
 
 PKG_SOURCE:=go$(PKG_VERSION).src.tar.gz
 PKG_SOURCE_URL:=$(GO_SOURCE_URLS)
-PKG_HASH:=9a15c133ba2cfafe79652f4815b62e7cfc267f68df1b9454c6ab2a3ca8b96a88
+PKG_HASH:=62ee5bc6fb55b8bae8f705e0cb8df86d6453626b4ecf93279e2867092e0b7f70
 
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/lang/golang/golang/files/go-gcc-helper
+++ b/lang/golang/golang/files/go-gcc-helper
@@ -1,4 +1,10 @@
 #!/bin/sh
+#
+# Copyright (C) 2018, 2020 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
 
 me=go-gcc-helper
 name="${0##*/}"

--- a/lang/golang/golang/test.sh
+++ b/lang/golang/golang/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ "$1" = golang ] || exit 0
+
+go version | grep -F " go$PKG_VERSION "


### PR DESCRIPTION
Maintainer: me
Compile tested: none (cherry picked from #21590)
Run tested: none

Description:
Includes fix for CVE-2023-29406 (net/http: insufficient sanitization of Host header).

This also updates the copyright information for various Go packaging files.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 8000a7f7691e733dd27dea30bed32dfc3d805ffb)