### PR TITLE
cpusage: remove AUTORELEASE

### DIFF
--- a/utils/cpusage/Makefile
+++ b/utils/cpusage/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cpusage
-PKG_VERSION:=$(AUTORELEASE)
+PKG_VERSION:=1
 PKG_MAINTAINER:=Thomas Hühn <thomas.huehn@hs-nordhausen.de>
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: @thuehn

Description:

Remove deprecated AUTORELEASE.

Commit 0c10c224be81 only handles the case where AUTORELEASE is used in PKG_RELEASE thus this package was left behind. Let's fix this up.

This packages is untouched since 23.05 branching. It should be straightforward applying this patch also to that branch.