### PR TITLE
[openwrt-23.05] rust: Update to 1.71.0 + compile host package per target

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -6,12 +6,12 @@ include $(TOPDIR)/rules.mk
 include ./rust-values.mk
 
 PKG_NAME:=rust
-PKG_VERSION:=1.70.0
-PKG_RELEASE:=3
+PKG_VERSION:=1.71.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
-PKG_HASH:=b2bfae000b7a5040e4ec4bbc50a09f21548190cb7570b0ed77358368413bd27c
+PKG_HASH:=a667e4abdc5588ebfea35c381e319d840ffbf8d2dbfb79771730573642034c96
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/rust-$(RUSTC_TARGET_ARCH)/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>

--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -3,15 +3,16 @@
 # Copyright (C) 2023 Luca Barbato and Donald Hoskins
 
 include $(TOPDIR)/rules.mk
+include ./rust-values.mk
 
 PKG_NAME:=rust
 PKG_VERSION:=1.70.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
 PKG_HASH:=b2bfae000b7a5040e4ec4bbc50a09f21548190cb7570b0ed77358368413bd27c
-HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/rustc-$(PKG_VERSION)-src
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/rust-$(RUSTC_TARGET_ARCH)/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>
 PKG_LICENSE:=Apache-2.0 MIT
@@ -22,7 +23,6 @@ PKG_HOST_ONLY:=1
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
-include ./rust-values.mk
 
 define Package/rust
   SECTION:=lang

--- a/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
+++ b/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
@@ -9,35 +9,9 @@ Subject: [PATCH] Update xz2 and use it static
  src/bootstrap/Cargo.toml | 2 +-
  3 files changed, 9 insertions(+), 9 deletions(-)
 
---- a/Cargo.lock
-+++ b/Cargo.lock
-@@ -3085,9 +3085,9 @@ dependencies = [
- 
- [[package]]
- name = "lzma-sys"
--version = "0.1.16"
-+version = "0.1.20"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "f24f76ec44a8ac23a31915d6e326bca17ce88da03096f1ff194925dc714dac99"
-+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
- dependencies = [
-  "cc",
-  "libc",
-@@ -7116,9 +7116,9 @@ dependencies = [
- 
- [[package]]
- name = "xz2"
--version = "0.1.6"
-+version = "0.1.7"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c179869f34fc7c01830d3ce7ea2086bc3a07e0d35289b667d0a8bf910258926c"
-+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
- dependencies = [
-  "lzma-sys",
- ]
 --- a/src/bootstrap/Cargo.lock
 +++ b/src/bootstrap/Cargo.lock
-@@ -389,9 +389,9 @@ dependencies = [
+@@ -443,9 +443,9 @@ dependencies = [
  
  [[package]]
  name = "lzma-sys"
@@ -49,7 +23,7 @@ Subject: [PATCH] Update xz2 and use it static
  dependencies = [
   "cc",
   "libc",
-@@ -847,9 +847,9 @@ dependencies = [
+@@ -912,9 +912,9 @@ dependencies = [
  
  [[package]]
  name = "xz2"
@@ -63,7 +37,7 @@ Subject: [PATCH] Update xz2 and use it static
  ]
 --- a/src/bootstrap/Cargo.toml
 +++ b/src/bootstrap/Cargo.toml
-@@ -51,7 +51,7 @@ toml = "0.5"
+@@ -50,7 +50,7 @@ toml = "0.5"
  ignore = "0.4.10"
  opener = "0.5"
  once_cell = "1.7.2"

--- a/lang/rust/patches/0002-Bumped-libc-version.patch
+++ b/lang/rust/patches/0002-Bumped-libc-version.patch
@@ -10,14 +10,14 @@ Subject: [PATCH] Bumped libc version
 
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -2933,9 +2933,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0e
+@@ -1988,9 +1988,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0e
  
  [[package]]
  name = "libc"
--version = "0.2.140"
+-version = "0.2.143"
 +version = "0.2.146"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+-checksum = "edc207893e85c5d6be840e969b496b53d94cec8be2d501b214f50daa97fa8024"
 +checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
  dependencies = [
   "rustc-std-workspace-core",
@@ -28,8 +28,8 @@ Subject: [PATCH] Bumped libc version
  panic_unwind = { path = "../panic_unwind", optional = true }
  panic_abort = { path = "../panic_abort" }
  core = { path = "../core" }
--libc = { version = "0.2.140", default-features = false, features = ['rustc-dep-of-std'] }
+-libc = { version = "0.2.143", default-features = false, features = ['rustc-dep-of-std'] }
 +libc = { version = "0.2.146", default-features = false, features = ['rustc-dep-of-std'] }
- compiler_builtins = { version = "0.1.91" }
+ compiler_builtins = { version = "0.1.92" }
  profiler_builtins = { path = "../profiler_builtins", optional = true }
  unwind = { path = "../unwind" }

--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -5,7 +5,7 @@
 # Rust Environmental Vars
 CONFIG_HOST_SUFFIX:=$(word 4, $(subst -, ,$(GNU_HOST_NAME)))
 RUSTC_HOST_ARCH:=$(HOST_ARCH)-unknown-linux-$(CONFIG_HOST_SUFFIX)
-CARGO_HOME:=$(STAGING_DIR_HOSTPKG)/cargo
+CARGO_HOME:=$(STAGING_DIR)/host/cargo
 CARGO_VARS:=
 
 ifeq ($(CONFIG_USE_MUSL),y)


### PR DESCRIPTION
Maintainer: @lu-zero / cc: @1715173329 
Compile tested: 
Run tested: 

Description:

This merges the changes from pull-request #21571 into the `openwrt-23.05` branch by cherry picking these commits from the `master` branch:

```
git cherry-pick -x f489e019ac4a15e974518d9928ef913a157d135a
git cherry-pick -x 971d326768b962dc4acdea181ae58b72c609e119
```

