### PR TITLE
yt-dlp: add missing dependencies

### DIFF
--- a/multimedia/yt-dlp/Makefile
+++ b/multimedia/yt-dlp/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yt-dlp
 PKG_VERSION:=2023.3.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=yt-dlp
 PKG_HASH:=265d5da97a76c15d7d9a4088a67b78acd5dcf6f8cfd8257c52f581ff996ff515
@@ -27,9 +27,11 @@ define Package/yt-dlp
     +python3-codecs \
     +python3-ctypes \
     +python3-email \
+    +python3-logging \
     +python3-openssl \
     +python3-sqlite3 \
     +python3-urllib \
+    +python3-uuid \
     +python3-xml
 endef
 


### PR DESCRIPTION
Maintainer: @paper42 
Compile tested: apm821xx, WD My Book Live, snapshot r23552+4
Run tested: not yet (the missing packages were installed manually via `opkg`)

Description:
Added missing python3-{logging,uuid} dependencies.

Before the fix, `yt-dlp` aborted due to missing `python3-logging` and `python3-uuid`.