### PR TITLE
snort3: update to 3.1.66.0

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
-PKG_VERSION:=3.1.65.0
+PKG_VERSION:=3.1.66.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
-PKG_HASH:=c798e34703e1e6710fa7eecc4684f2cac58e310f85ce5d5f832945a036e7f542
+PKG_HASH:=4481f882d767620e91fa6d97232ae9527cab06ba77087399c5dd91c72826e0bb
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Upstream bump

Build system: x86/64
Build-tested: x86/64
Run-tested: x86/64

Maintainer:  @flyn-org 
