### PR TITLE
python3-packages: Fix pip install package bug in host python

### DIFF
--- a/lang/python/python3-packages/Makefile
+++ b/lang/python/python3-packages/Makefile
@@ -89,8 +89,7 @@ req2dir=$(call recur,_req2dir,7,$(1))
 # --no-build-isolation, this is a new addition in pip3 and is needed when build
 #  depends on host modules
 HOST_PYTHON3_PIP_INSTALL=$(HOST_PYTHON3_PIP) install \
-	--root=$(1) \
-	--prefix=$(2) \
+	--prefix=$(1) \
 	--ignore-installed \
 	--no-build-isolation \
 	--no-compile \


### PR DESCRIPTION
Description:
after using python3-packages to install python package, it will install to wrong directory.
For example, I install cryptography in host python3.9, and package is located in `/mfs/xxxxx/xxxx/mt7986/openwrt/lede/staging_dir/hostpkg /mfs/xxxxx/xxxx/mt7986/openwrt/lede/staging_dir/hostpkg/lib/python3.9/ site-packages/cryptography`.
I change pip  pip parameter to --prefix=$(1) in python3-package Makefile, it will be solved.

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
