### PR TITLE
rust: put host build dir to target build dir

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -12,7 +12,7 @@ PKG_RELEASE:=1
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
 PKG_HASH:=a667e4abdc5588ebfea35c381e319d840ffbf8d2dbfb79771730573642034c96
-HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/rust-$(RUSTC_TARGET_ARCH)/rustc-$(PKG_VERSION)-src
+HOST_BUILD_DIR:=$(BUILD_DIR)/host/rust-$(RUSTC_TARGET_ARCH)/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>
 PKG_LICENSE:=Apache-2.0 MIT


### PR DESCRIPTION
Maintainer: @lu-zero 
Compile tested: rockchip/armv8
Run tested: n/a

Description:
```
When user runs `make clean` command, everything in `$(STAGING_DIR)`
(where we installed rust) will be removed, but `$(BUILD_DIR_HOST)`
(where we compiled rust and stored build stage) is untouched.

So when user starts a new build after that, OpenWrt buildroot will
still consider `rust` is installed already, resulting the build error
"cargo: command not found".

Fix this by moving to target build dir as well.

Fixes: f489e019ac4a ("rust: compile host package per target")
```

cc @brocaar
