### PR TITLE
memtester: add memtester package

### DIFF
--- a/utils/memtester/Makefile
+++ b/utils/memtester/Makefile
@@ -1,0 +1,38 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=memtester
+PKG_VERSION:=4.6.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pyropus.ca./software/memtester/old-versions/
+PKG_HASH:=c9fe4eb7e80c8cef5202f9065c4c0682f5616647c0455e916a5700f98e3dbb2e
+
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Aleksander Jan Bajkowski <olek2@wp.pl>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/memtester
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Userspace utility for testing the memory subsystem for faults
+  URL:=https://pyropus.ca./software/memtester/
+endef
+
+define Package/memtester/description
+ A userspace utility for testing the memory subsystem for faults.
+endef
+
+define Build/Configure
+	$(SED) 's|cc -O2|$(TARGET_CC) $(TARGET_CFLAGS)|' $(PKG_BUILD_DIR)/conf-cc
+	$(SED) 's|cc|$(TARGET_CC)|' $(PKG_BUILD_DIR)/conf-ld
+endef
+
+define Package/memtester/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/memtester $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,memtester))


### PR DESCRIPTION
Maintainer: @gwlim
Compile tested: lantiq/xrx200, BT Home Hub 5A, snapshot
Run tested: lantiq/xrx200, BT Home Hub 5A, snapshot

Description:
Memtester is a important utility to check for memory issues on devices

This PR is a continuation of https://github.com/openwrt/packages/pull/4777.

It looks like the memtester is being maintained again. There have been 3 realeases in the last 3 years.

Over the past few years, I have seen several threads regarding the missing memtester package[1-4]. So I think memtester will have a userbase, although it is a tool that is only used occasionally.

[1] [Memtester for 18.06](https://forum.openwrt.org/t/memtester-for-18-06/29489)
[2] [Any package or tool to run memory test from LEDE](https://forum.openwrt.org/t/any-package-or-tool-to-run-memory-test-from-lede/13250)
[3] [Memtest na OpenWRT ? (PL)](https://eko.one.pl/forum/viewtopic.php?id=13365)
[4] [memtester pod cc (PL)](https://eko.one.pl/forum/search.php?search_id=2146958331)