### PR TITLE
[23.05] https-dns-proxy: improve CLI messaging

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2023-05-25
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -67,7 +67,7 @@ uci_changes() {
 	/sbin/uci ${UCI_CONFIG_DIR:+-c $UCI_CONFIG_DIR} changes "$PACKAGE${CONFIG:+.$CONFIG}${OPTION:+.$OPTION}"
 }
 
-dnsmasq_restart() { [ -x /etc/init.d/dnsmasq ] || return 0; /etc/init.d/dnsmasq restart >/dev/null 2>&1; }
+dnsmasq_restart() { [ -x /etc/init.d/dnsmasq ] || return 1; /etc/init.d/dnsmasq restart >/dev/null 2>&1; }
 
 version() { echo "$PKG_VERSION"; }
 
@@ -223,7 +223,7 @@ start_service() {
 	local procd_fw_src_interfaces
 
 	local port=5053
-	output "Starting $serviceName "
+	output "Starting $serviceName instances "
 	config_load "$packageName"
 	config_get_bool canary_domains_icloud  'config' 'canary_domains_icloud' '1'
 	config_get_bool canary_domains_mozilla 'config' 'canary_domains_mozilla' '1'
@@ -240,11 +240,21 @@ start_service() {
 	dhcp_backup 'create'
 	config_load "$packageName"
 	config_foreach start_instance "$packageName"
-	if [ -n "$(uci_changes dhcp)" ]; then
-		uci_commit 'dhcp'
-		dnsmasq_restart
-	fi
 	output "\\n"
+	if [ -n "$(uci_changes dhcp)" ]; then
+		output "Updating dnsmasq config "
+		if uci_commit 'dhcp'; then
+			output_okn
+		else
+			output_failn
+		fi
+		output "Restarting dnsmasq "
+		if dnsmasq_restart; then
+			output_okn
+		else
+			output_failn
+		fi
+	fi
 }
 
 stop_service() {


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0-rc2
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0-rc2, start/stop

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 649fbcf9fcab34df3d39b0642cd5b566eefb569e)
