### PR TITLE
node: bump to v18.17.0

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v18.16.1
+PKG_VERSION:=v18.17.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=e8404f8c8d89fdfdf7e95bbbc6066bd0e571acba58f54492599b615fbeefe272
+PKG_HASH:=80c0faadf5ea39c213ccb9aa5c2432977a0f1b5a0b766852abd0de06f2770406
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/990-delete_unnecessary_libraries_for_host_execute.patch
+++ b/lang/node/patches/990-delete_unnecessary_libraries_for_host_execute.patch
@@ -8,7 +8,7 @@
        'dependencies': [ 'icutools', 'icu_implementation' ],
        'sources': [
          '<@(icu_src_genrb)'
-@@ -434,6 +435,7 @@
+@@ -440,6 +441,7 @@
        'target_name': 'iculslocs',
        'toolsets': [ 'host' ],
        'type': 'executable',
@@ -16,7 +16,7 @@
        'dependencies': [ 'icutools' ],
        'sources': [
          'iculslocs.cc',
-@@ -446,6 +448,7 @@
+@@ -458,6 +460,7 @@
        'target_name': 'icupkg',
        'toolsets': [ 'host' ],
        'type': 'executable',
@@ -24,7 +24,7 @@
        'dependencies': [ 'icutools' ],
        'sources': [
          '<@(icu_src_icupkg)',
-@@ -457,6 +460,7 @@
+@@ -475,6 +478,7 @@
        'target_name': 'genccode',
        'toolsets': [ 'host' ],
        'type': 'executable',
@@ -42,7 +42,7 @@
        'conditions': [
          ['want_separate_host_toolset', {
            'toolsets': ['host'],
-@@ -1421,6 +1422,8 @@
+@@ -1425,6 +1426,8 @@
      {
        'target_name': 'mksnapshot',
        'type': 'executable',
@@ -51,7 +51,7 @@
        'dependencies': [
          'v8_base_without_compiler',
          'v8_compiler_for_mksnapshot',
-@@ -1450,6 +1453,7 @@
+@@ -1458,6 +1461,7 @@
      {
        'target_name': 'torque',
        'type': 'executable',
@@ -59,7 +59,7 @@
        'dependencies': [
          'torque_base',
          # "build/win:default_exe_manifest",
-@@ -1488,6 +1492,7 @@
+@@ -1500,6 +1504,7 @@
      {
        'target_name': 'torque-language-server',
        'type': 'executable',
@@ -67,7 +67,7 @@
        'conditions': [
          ['want_separate_host_toolset', {
            'toolsets': ['host'],
-@@ -1515,6 +1520,8 @@
+@@ -1531,6 +1536,8 @@
      {
        'target_name': 'gen-regexp-special-case',
        'type': 'executable',

--- a/lang/node/patches/991-v8_zlib_support.patch
+++ b/lang/node/patches/991-v8_zlib_support.patch
@@ -62,7 +62,7 @@
          'include_dirs': [
            '<(V8_ROOT)/include',
          ],
-@@ -1737,6 +1744,7 @@
+@@ -1761,6 +1768,7 @@
           }],
        ],
        'direct_dependent_settings': {
@@ -70,7 +70,7 @@
          'include_dirs': [
            '<(V8_ROOT)/include',
          ],
-@@ -1917,15 +1925,19 @@
+@@ -1941,15 +1949,19 @@
          }],
        ],
        'direct_dependent_settings': {

--- a/lang/node/patches/992-v8_add_include_dirs.patch
+++ b/lang/node/patches/992-v8_add_include_dirs.patch
@@ -16,7 +16,7 @@
        'conditions': [
          ['OS=="win"', {
            'msvs_precompiled_header': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.h',
-@@ -1431,6 +1433,7 @@
+@@ -1435,6 +1437,7 @@
        'type': 'executable',
        'libraries!':[ '-lcrypto', '-lssl', '-lz', '-lhttp_parser', '-luv', '-lnghttp2', '-lcares' ],
        'library_dirs':[ '../../../../staging_dir/hostpkg/share/icu/current/lib' ],

--- a/lang/node/patches/999-localhost-no-addrconfig.patch
+++ b/lang/node/patches/999-localhost-no-addrconfig.patch
@@ -13,7 +13,7 @@ Forwarded: https://github.com/nodejs/node/issues/33816
  //
  // Permission is hereby granted, free of charge, to any person obtaining a
  // copy of this software and associated documentation files (the
-@@ -1265,13 +1266,6 @@ function lookupAndConnect(self, options)
+@@ -1266,13 +1267,6 @@ function lookupAndConnect(self, options)
      hints: options.hints || 0,
    };
  

--- a/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
+++ b/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
@@ -1,6 +1,6 @@
 --- a/configure.py
 +++ b/configure.py
-@@ -1296,7 +1296,6 @@ def configure_node(o):
+@@ -1291,7 +1291,6 @@ def configure_node(o):
  
    # Enable branch protection for arm64
    if target_arch == 'arm64':


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: head, aarch64, arm, i386, x86_64
Run tested: (qemu 8.0.3) aarch64

Description:
Update to v18.17.0

Notable Changes
*Ada 2.0
 Node.js v18.17.0 comes with the latest version of the URL parser, Ada. This update brings significant performance improvements to URL parsing, including enhancements to the url.domainToASCII and url.domainToUnicode functions in node:url.

*Web Crypto API
 Web Crypto API functions' arguments are now coerced and validated as per their WebIDL definitions like in other Web Crypto API implementations. This further improves interoperability with other implementations of Web Crypto API.

