### PR TITLE
easyloggingpp: Update version to 9.97.1

### DIFF
--- a/libs/easyloggingpp/Makefile
+++ b/libs/easyloggingpp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=easyloggingpp
-PKG_VERSION:=9.97.0
+PKG_VERSION:=9.97.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/abumq/easyloggingpp/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=9110638e21ef02428254af8688bf9e766483db8cc2624144aa3c59006907ce22
+PKG_HASH:=ebe473e17b13f1d1f16d0009689576625796947a711e14aec29530f39560c7c2
 
 PKG_MAINTAINER:=Volker Christian <me@vchrist.at>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me@vchrist.at

Changelog from upstream:
- Ensuring the build on ARM64 works
- Update gtest and cmake now requires C++14 because of that

Compile tested: 
- arm_cortex-a7_neon-vfpv4, 
- mips_24kc, 
- aarch64_cortex-a53

Run tested: 
- Linksys MR8300 (arm_cortex-a7_neon-vfpv4)
- GL.iNet GL-A1800 (arm_cortex-a7_neon-vfpv4)
- TP-Link Archer A7 (mips_24kc),
- GL.iNet GL-MT3000 (aarch64_cortex-a53)