### PR TITLE
transmission: add copy_file_range syscall to seccomp

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=4.0.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/transmission/transmission/releases/download/$(PKG_VERSION)/

--- a/net/transmission/files/transmission-daemon.json
+++ b/net/transmission/files/transmission-daemon.json
@@ -14,6 +14,7 @@
 				"clone",
 				"close",
 				"connect",
+				"copy_file_range",
 				"epoll_create1",
 				"epoll_ctl",
 				"epoll_pwait",


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: no need, it's a config file
Run tested: Raspberry Pi 3B+, OpenWrt r22977

Description:
Fixes this crash:
```
root@RPi3OpenWrt:/# grep -i seccomp /var/log/audit/audit.log
type=SECCOMP msg=audit(1689503903.597:16): auid=4294967295 uid=224 gid=1012 ses=4294967295 pid=1752 comm="transmission-da" exe="/usr/bin/transmission-daemon" sig=31 arch=c00000b7 syscall=285 compat=0 ip=0x7fa3b0eefc code=0x80000000
root@RPi3OpenWrt:/# ausyscall 285
copy_file_range
root@RPi3OpenWrt:/#
```