### PR TITLE
nft-qos: Repair Mac address speed limit does not take effect

### DIFF
--- a/net/nft-qos/Makefile
+++ b/net/nft-qos/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nft-qos
 PKG_VERSION:=1.0.6
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_LICENSE:=GPL-2.0
 
 PKG_MAINTAINER:=Rosy Song <rosysong@rosinson.com>

--- a/net/nft-qos/files/lib/core.sh
+++ b/net/nft-qos/files/lib/core.sh
@@ -84,8 +84,8 @@ qosdef_init_header() { # add header for nft script
 
 qosdef_init_env() {
 	# check interface type of lan
-	local lt="$(uci_get "network.lan.type")"
-	[ "$lt" = "bridge" ] && export NFT_QOS_HAS_BRIDGE="y"
+	local lt="$(uci_get "network.lan.device")"
+	[ "$lt" = "br-lan" ] && export NFT_QOS_HAS_BRIDGE="y"
 
 	# check if ipv6 support
 	[ -e /proc/sys/net/ipv6 ] && export NFT_QOS_INET_FAMILY="inet"


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
The following speed limits have been tested to work:
OpenWrt 23.05-SNAPSHOT
OpenWrt 22.03-SNAPSHOT
OpenWrt 21.02-SNAPSHOT
Dynamic network segment speed limit is valid
IP address static speed limit
MAC address speed limit

Test model:
Hostname	OpenWrt
Model	Default string Default string
Architecture	Intel(R) Celeron(R) CPU 3865U @ 1.80GHz
Target Platform	x86/64
Firmware Version	OpenWrt 23.05-SNAPSHOT
Kernel Version	5.15.120