### PR TITLE
knxd: new upstream version 0.14.59

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -11,12 +11,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
-PKG_VERSION:=0.14.58
+PKG_VERSION:=0.14.59
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/knxd/knxd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=4c58ca24c3b382649356b8d794453927f0722739eb5ca654a1bd8de0006b0404
+PKG_HASH:=8b8314ad4265cd48e9a257a1bcfd162b1084422f765082b45cceabdd70c0c164
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/knxd/patches/0100-version.patch
+++ b/net/knxd/patches/0100-version.patch
@@ -7,4 +7,4 @@
 -test -d .git || exit
 -# git describe --tags
 -git log --format=format:%D | perl -ne 'next unless s#.*tag: ##; s#,.*##; next if m#/#; print; exit;'
-+echo -n "0.14.58"
++echo -n "0.14.59"


### PR DESCRIPTION
Maintainer: me
Compile tested: mpc85xx, tl-wdr4900-v1, trunk
Compile tested: ath79, tplink_archer-c7-v4, trunk
Compile tested: ramips, mt7620a, trunk
Run tested: ath79, tp-link Archer C7 v4, trunk


Description:
new upstream release 0.14.59
