### PR TITLE
[openwrt-23.05] python3-maxminddb: Update to 2.4.0, rename source package

### DIFF
--- a/lang/python/python-maxminddb/Makefile
+++ b/lang/python/python-maxminddb/Makefile
@@ -8,12 +8,12 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=maxminddb
-PKG_VERSION:=2.0.3
+PKG_NAME:=python-maxminddb
+PKG_VERSION:=2.4.0
 PKG_RELEASE:=1
 
-PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=47e86a084dd814fac88c99ea34ba3278a74bc9de5a25f4b815b608798747c7dc
+PYPI_NAME:=maxminddb
+PKG_HASH:=81e54e53408bd502650e5969ccba16780af659ec1db1c44b2c997e4330a5ed96
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -28,7 +28,7 @@ define Package/python3-maxminddb
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Reader for the MaxMind DB format
-  URL:=https://dev.maxmind.com/
+  URL:=https://www.maxmind.com/
   DEPENDS:=+python3-light +libmaxminddb
 endef
 


### PR DESCRIPTION
Maintainer: @ja-pa
Compile tested: none (cherry picked from #21602)
Run tested: none

Description:
This renames the source package to python-maxminddb to match other Python packages.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit ca7fdf61dc128ab80917d8c415bd9676462d04ee)