### PR TITLE
[openwrt-23.05] python-aiohttp: Update to 3.8.5, add new dependencies

### DIFF
--- a/lang/python/python-aiohttp/Makefile
+++ b/lang/python/python-aiohttp/Makefile
@@ -7,16 +7,16 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=aiohttp
-PKG_VERSION:=3.7.4.post0
+PKG_NAME:=python-aiohttp
+PKG_VERSION:=3.8.5
 PKG_RELEASE:=1
 
-PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=493d3299ebe5f5a7c66b9819eacdcfbbaaf1a8e84911ddffcdc48888497afecf
+PYPI_NAME:=aiohttp
+PKG_HASH:=b9552ec52cc147dbf1944ac7ac98af7602e51ea2dcd076ed194ca3c0d1c7d0bc
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0
-PKG_LICENSE_FILES:=LICENSE
+PKG_LICENSE_FILES:=LICENSE.txt
 PKG_CPE_ID:=cpe:/a:aio-libs_project:aiohttp
 
 include ../pypi.mk
@@ -30,17 +30,14 @@ define Package/python3-aiohttp
   TITLE:=Async http client/server framework (asyncio)
   URL:=https://github.com/aio-libs/aiohttp
   DEPENDS:= \
-	+python3-light \
-	+python3-attrs \
-	+python3-chardet \
-	+python3-multidict \
+	+python3 \
+	+python3-aiosignal \
 	+python3-async-timeout \
-	+python3-yarl \
-	+python3-logging \
-	+python3-codecs \
-	+python3-cgi \
-	+python3-openssl \
-	+python3-typing-extensions
+	+python3-attrs \
+	+python3-charset-normalizer \
+	+python3-frozenlist \
+	+python3-multidict \
+	+python3-yarl
 endef
 
 define Package/python3-aiohttp/description

--- a/lang/python/python-aiosignal/Makefile
+++ b/lang/python/python-aiosignal/Makefile
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2023 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-aiosignal
+PKG_VERSION:=1.3.1
+PKG_RELEASE:=1
+
+PYPI_NAME:=aiosignal
+PKG_HASH:=54cd96e15e1649b75d6c87526a6ff0b6c1b0dd3459f43d9ca11d48c339b68cfc
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-aiosignal
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=List of registered asynchronous callbacks
+  URL:=https://github.com/aio-libs/aiosignal
+  DEPENDS:=+python3-light +python3-frozenlist
+endef
+
+define Package/python3-aiosignal/description
+A project to manage callbacks in asyncio projects.
+endef
+
+$(eval $(call Py3Package,python3-aiosignal))
+$(eval $(call BuildPackage,python3-aiosignal))
+$(eval $(call BuildPackage,python3-aiosignal-src))

--- a/lang/python/python-charset-normalizer/Makefile
+++ b/lang/python/python-charset-normalizer/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2023 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-charset-normalizer
+PKG_VERSION:=3.2.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=charset-normalizer
+PKG_HASH:=3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-charset-normalizer
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Real First Universal Charset Detector
+  URL:=https://github.com/Ousret/charset_normalizer
+  DEPENDS:=+python3-light +python3-codecs +python3-logging
+endef
+
+define Package/python3-charset-normalizer/description
+A library that helps you read text from an unknown charset encoding.
+Motivated by chardet, I'm trying to resolve the issue by taking a new
+approach. All IANA character set names for which the Python core library
+provides codecs are supported.
+endef
+
+$(eval $(call Py3Package,python3-charset-normalizer))
+$(eval $(call BuildPackage,python3-charset-normalizer))
+$(eval $(call BuildPackage,python3-charset-normalizer-src))

--- a/lang/python/python-frozenlist/Makefile
+++ b/lang/python/python-frozenlist/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2023 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-frozenlist
+PKG_VERSION:=1.4.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=frozenlist
+PKG_HASH:=09163bdf0b2907454042edb19f887c6d33806adc71fbd54afc14908bfdc22251
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-frozenlist
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=List-like structure
+  URL:=https://github.com/aio-libs/frozenlist
+  DEPENDS:=+python3-light
+endef
+
+define Package/python3-frozenlist/description
+frozenlist.FrozenList is a list-like structure which implements
+collections.abc.MutableSequence. The list is mutable until
+FrozenList.freeze is called, after which list modifications raise
+RuntimeError.
+endef
+
+$(eval $(call Py3Package,python3-frozenlist))
+$(eval $(call BuildPackage,python3-frozenlist))
+$(eval $(call BuildPackage,python3-frozenlist-src))


### PR DESCRIPTION
Maintainer: @BKPepe (python-aiohttp), me (new dependencies)
Compile tested: none (cherry-picked from #21611)
Run tested: none

Description:
This updates aiohttp to 3.8.5 and adds new dependencies (charset-normalizer, frozenlist, aiosignal). This version of aiohttp also depends on async-timeout >= 4 (#21656).