### PR TITLE
[openwrt-23.05] python-atomicwrites: Update to 1.4.1

### DIFF
--- a/lang/python/python-atomicwrites/Makefile
+++ b/lang/python/python-atomicwrites/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-atomicwrites
-PKG_VERSION:=1.4.0
+PKG_VERSION:=1.4.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=atomicwrites
-PKG_HASH:=ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a
+PKG_HASH:=81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @ja-pa
Compile tested: none (cherry picked from #21614)
Run tested: none

Description:
Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit d5ac6e103eb11d29f4e822fadb727225e0e80992)