### PR TITLE
python-certifi: add github runtime test

### DIFF
--- a/lang/python/python-certifi/test.sh
+++ b/lang/python/python-certifi/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+case "$1" in
+	*-src)
+		;;
+	python3-certifi)
+		BUNDLE=$(python3 -m certifi) || {
+			echo "Failed to run the certfi module script.  Exit status=$?." >&2
+			echo "Output='$BUNDLE'" >&2
+			exit 1
+		}
+		ls -l "$BUNDLE"
+		;;
+	*)
+		echo "Unexpected package '$1'" >&2
+		exit 1
+		;;
+esac


### PR DESCRIPTION
Maintainer: me
Compile tested by github actions
Run tested by github actions

Description:
This loads the module, which should return the path of the CA bundle and verifies that the file exists.

