### PR TITLE
curl: update to 8.2.1

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
-PKG_VERSION:=8.2.0
+PKG_VERSION:=8.2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -17,7 +17,7 @@ PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,
 	https://dl.uxnr.de/mirror/curl/ \
 	https://curl.askapache.com/download/ \
 	https://curl.se/download/
-PKG_HASH:=2859ec79e2cd96e976a99493547359b8001af1d1e21f3a3a3b846544ef54500f
+PKG_HASH:=dd322f6bd0a20e6cebdfd388f69e98c3d183bed792cf4713c8a7ef498cba4894
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0-rc2
Run tested:  x86_64, Sophos XG-135r3, OpenWrt 23.05.0-rc2, test function of https-dns-proxy

Description:
* https://curl.se/changes.html#8_2_1
