### PR TITLE
flip: add new package

### DIFF
--- a/utils/flip/Makefile
+++ b/utils/flip/Makefile
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2023 Kai Tetzlaff
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=flip
+PKG_VERSION:=1.20
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.gz
+PKG_SOURCE_URL:=@DEBIAN/pool/main/f/flip
+PKG_HASH:=4cd45e581c71d7bcf1ab824a47fb9263fe5371ce702879a7d2efa08d27253471
+
+PKG_MAINTAINER:=Kai Tetzlaff <openwrt@tetzco.de>
+PKG_LICENSE:=GPL-2.0-or-later
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/flip
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=convert text file line endings between Unix and DOS formats
+  URL:=http://packages.debian.org/flip
+endef
+
+define Package/flip/description
+  The program converts line endings of text files between MS-DOS and
+  *nix formats. It detects binary files in a nearly foolproof way and
+  leaves them alone unless you override this. It will also leave files
+  alone that are already in the right format and preserves file
+  timestamps. User interrupts are handled gracefully and no garbage or
+  corrupted files left behind.
+
+  The program does not convert files to a different character set, and
+  it can not handle old Apple Macintosh line endings that use CR only.
+endef
+
+EXTRA_CPPFLAGS += -DBSD -DIX -DSTDINCLUDE
+
+define Package/flip/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/flip $(1)/usr/bin/
+	$(LN) flip $(1)/usr/bin/toix
+	$(LN) flip $(1)/usr/bin/toms
+endef
+
+$(eval $(call BuildPackage,flip))

--- a/utils/flip/patches/10-debian-makefile.patch
+++ b/utils/flip/patches/10-debian-makefile.patch
@@ -1,0 +1,45 @@
+From: Jari Aalto <jari.aalto@cante.net>
+Date: Fri, 25 Dec 2020 12:53:36 -0500
+Subject: Add support for user set flags
+
+---
+ Makefile | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+--- a/Makefile
++++ b/Makefile
+@@ -34,10 +34,10 @@ MANDIR = /usr/man/man1/.
+ # (relatively unchanging) flags for compiler
+ 
+ CC = cc
+-CFLAGS =
++# CFLAGS =
+ CFMORE = -c -DNDEBUG -O -DVERSION=\"$(VERSION)\"
+ LD = cc
+-LDFLAGS = -o flip
++# LDFLAGS = -o flip
+ 
+ # If your system does not supply getopt as a library function,
+ # add getopt.o to the RHS list on the next line and uncomment the
+@@ -47,6 +47,8 @@ OBJS = flip.o
+ #getopt.o: getopt.c flip.h
+ #	$(CC) $(CFLAGS) $(CFMORE) $*.c
+ 
++all: flip
++
+ nothing:
+ 	@echo \
+ 	'Please type "make sys_v", "make bsd", "make uport", or "make ultrix"'
+@@ -64,10 +66,10 @@ ultrix:
+ 	make "CFLAGS=-DBSD -DULTRIX_BUG" flip
+ 
+ flip: $(OBJS)
+-	$(LD) $(LDFLAGS) $(OBJS)
++	$(LD) $(LDFLAGS) $(OBJS) -o flip
+ 
+ flip.o: flip.c flip.h
+-	$(CC) $(CFLAGS) $(CFMORE) $*.c
++	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFMORE) $*.c
+ 
+ clean:
+ 	rm -f *.o core flip

--- a/utils/flip/patches/20-debian-manpage.patch
+++ b/utils/flip/patches/20-debian-manpage.patch
@@ -1,0 +1,80 @@
+From: Jari Aalto <jari.aalto@cante.net>
+Date: Fri, 25 Dec 2020 12:53:36 -0500
+Subject: Correct hyphens
+
+---
+ flip.1 | 30 +++++++++++++++---------------
+ 1 file changed, 15 insertions(+), 15 deletions(-)
+
+--- a/flip.1
++++ b/flip.1
+@@ -53,7 +53,7 @@ to convert all files to **IX format you
+ .sp
+ .nf
+ .\"                    flip -u *.*  (under MS-DOS)
+-                    flip -u *
++                    flip \-u *
+ .\"    (under **IX)
+ .fi
+ .sp
+@@ -92,15 +92,15 @@ converts a file.
+ .sp
+ \fBflip\fP is normally invoked as:
+ .nf
+-               flip -umhvtb file ...
++               flip \-umhvtb file ...
+ .fi
+-One of -u, -m, or -h is required.  Switches may be given
++One of \-u, \-m, or \-h is required.  Switches may be given
+ separately or combined together after a dash.  For example,
+ the three command lines given below are equivalent:
+ .nf
+-               flip -uvt *.c
+-               flip -u -v -t *.c
+-               flip -u -vt *.c
++               flip \-uvt *.c
++               flip \-u \-v \-t *.c
++               flip \-u \-vt *.c
+ .fi
+ 
+ On systems that allow a program to know its own name, \fBflip\fP
+@@ -109,7 +109,7 @@ may be renamed (or linked) to a file cal
+ for conversion to **IX format, or to a file called toms
+ .\" (or toms.exe under MS-DOS) 
+ for conversion to MS-DOS format.  When invoked with the name toix or
+-toms, \fBflip\fP will act as if it were invoked with the -u or -m
++toms, \fBflip\fP will act as if it were invoked with the \-u or \-m
+ option respectively.
+ .\" 
+ .\" .SH RETURN VALUE
+@@ -117,22 +117,22 @@ option respectively.
+ .\" On error, it returns \-1, and \fIerrno\fP is set appropriately.
+ .SH OPTIONS
+ 
+-.IP -u
++.IP \-u
+ Convert to **IX format (CR LF => LF, lone CR or LF unchanged, trailing
+ control Z removed, embedded control Z unchanged).
+-.IP -m
++.IP \-m
+ Convert to MS-DOS format (lone LF => CR LF, lone CR unchanged).
+-.IP -h
++.IP \-h
+ Give a help message.
+-.IP -v
++.IP \-v
+ Be verbose, print filenames as they are processed.
+-.IP -t
++.IP \-t
+ Touch files (don't preserve timestamps).
+-.IP -s
++.IP \-s
+ Strip high bit.
+-.IP -b
++.IP \-b
+ Convert binary files too (else binary files are left unchanged).
+-.IP -z
++.IP \-z
+ Truncate file at first control Z encountered.
+ .SH AUTHOR
+ Rahul Dhesi <dhesi@bsu-cs.bsu.edu>.

--- a/utils/flip/patches/30-debian-stdin.patch
+++ b/utils/flip/patches/30-debian-stdin.patch
@@ -1,0 +1,39 @@
+From: Jari Aalto <jari.aalto@cante.net>
+Date: Fri, 25 Dec 2020 12:53:36 -0500
+Subject: Ignore files stat on stdio (CloseS: #518311).
+
+---
+ flip.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+--- a/flip.c
++++ b/flip.c
+@@ -317,7 +317,7 @@ enum choices which;
+ #endif
+    }
+ 
+-   if (!touch)
++   if (!touch  &&  ! use_stdio)
+       GETFT (infile, fname, timestamp);      /* save current timestamp */
+ 
+    assert (which == IXTOMS || which == MSTOIX);
+@@ -362,6 +362,8 @@ enum choices which;
+ 
+    if (!ferror(outfile) && fflush(outfile) != EOF && fclose(outfile) != EOF) {
+       int moved;
++      if (use_stdio)
++	  goto stdio_skip;
+ #ifdef IX
+       if (stat (tfname, &ofilestat)) {
+ 	/* can't get the file's permissions */
+@@ -391,6 +393,10 @@ enum choices which;
+ 	  }
+ 	}
+ #endif /* IX */
++
++
++      stdio_skip:
++
+       //      DELFILE (fname);
+       if (!use_stdio) {
+          moved = MVFILE (tfname, fname);

--- a/utils/flip/patches/40-openwrt.patch
+++ b/utils/flip/patches/40-openwrt.patch
@@ -1,0 +1,11 @@
+--- a/Makefile
++++ b/Makefile
+@@ -66,7 +66,7 @@ ultrix:
+ 	make "CFLAGS=-DBSD -DULTRIX_BUG" flip
+ 
+ flip: $(OBJS)
+-	$(LD) $(LDFLAGS) $(OBJS) -o flip
++	$(CC) $(LDFLAGS) $(OBJS) -o flip
+ 
+ flip.o: flip.c flip.h
+ 	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFMORE) $*.c

--- a/utils/flip/test.sh
+++ b/utils/flip/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+PKG_NAME="${1}"
+PKG_VERSION="${2}"
+
+toix -h 2>&1 | grep -q "${PKG_NAME} version ${PKG_VERSION}\\."


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64_musl
Run tested: x86_64_musl

Description:

  The program converts line endings of text files between MS-DOS and
  *nix formats. It detects binary files in a nearly foolproof way and
  leaves them alone unless you override this. It will also leave files
  alone that are already in the right format and preserves file
  timestamps. User interrupts are handled gracefully and no garbage or
  corrupted files left behind.

(copied from the Debian package description)