### PR TITLE
python-socketio: Update to 5.8.0

### DIFF
--- a/lang/python/python-socketio/Makefile
+++ b/lang/python/python-socketio/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-socketio
-PKG_VERSION:=5.2.1
+PKG_VERSION:=5.8.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=python-socketio
-PKG_HASH:=356a8a480fa316295b439d63a5f35a7a59fe65cee1ae35dee28e87d00e5aead6
+PKG_HASH:=e714f4dddfaaa0cb0e37a1e2deef2bb60590a5b9fea9c343dd8ca5e688416fd9
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=MIT
@@ -34,7 +34,7 @@ define Package/python3-socketio
 	+python3-engineio \
 	+python3-asyncio \
 	+python3-logging \
-	+python3-urllib
+	+python3-uuid
 endef
 
 define Package/python3-socketio/description


### PR DESCRIPTION
Maintainer: @ja-pa
Compile tested: armsr-armv7, 2023-07-29 snapshot sdk
Run tested: armsr-armv7 (qemu, basic module loading only), 2023-07-29 snapshot

Description:
