### PR TITLE
python-flask-socketio: Update to 5.3.5

### DIFF
--- a/lang/python/python-flask-socketio/Makefile
+++ b/lang/python/python-flask-socketio/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-flask-socketio
-PKG_VERSION:=5.3.1
+PKG_VERSION:=5.3.5
 PKG_RELEASE:=1
 
 PYPI_NAME:=Flask-SocketIO
-PKG_HASH:=fd0ed0fc1341671d92d5f5b2f5503916deb7aa7e2940e6636cfa2c087c828bf9
+PKG_HASH:=5f01158d10db71aa78c969b631ce3b9148b47ab0de1995158f9577f85b004d25
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @ja-pa
Compile tested: armsr-armv7, 2023-07-29 snapshot sdk
Run tested: armsr-armv7 (qemu, basic module loading only), 2023-07-29 snapshot

Description:
