### PR TITLE
Add ujail support to Adguard Home

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -42,10 +42,11 @@ define Package/adguardhome
 	TITLE:=Network-wide ads and trackers blocking DNS server
 	URL:=https://github.com/AdguardTeam/AdGuardHome
 	DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+	USERID:=adguardhome:adguardhome
 endef
 
 define Package/adguardhome/conffiles
-/etc/adguardhome.yaml
+/etc/adguardhome/adguardhome.yaml
 /etc/config/adguardhome
 endef
 
@@ -66,7 +67,9 @@ define Package/adguardhome/install
 	$(call GoPackage/Package/Install/Bin,$(1))
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/adguardhome.init $(1)/etc/init.d/adguardhome
-
+	$(INSTALL_DIR) $(1)/etc/adguardhome
+	$(INSTALL_DIR) $(1)/etc/capabilities
+	$(INSTALL_DATA) ./files/adguardhome.json $(1)/etc/capabilities/adguardhome.json
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DATA) ./files/adguardhome.config $(1)/etc/config/adguardhome
 endef

--- a/net/adguardhome/files/adguardhome.config
+++ b/net/adguardhome/files/adguardhome.config
@@ -1,3 +1,5 @@
 config adguardhome config
 	# Where to store persistent data by AdGuard Home
+	option confdir /etc/adguardhome
+	# Where to store temporary data by AdGuard Home
 	option workdir /var/adguardhome

--- a/net/adguardhome/files/adguardhome.init
+++ b/net/adguardhome/files/adguardhome.init
@@ -11,13 +11,26 @@ STOP=89
 
 start_service() {
   config_load adguardhome
+  config_get CONF_DIR config confdir
   config_get WORK_DIR config workdir
 
   [ -d "$WORK_DIR" ] || mkdir -m 0755 -p "$WORK_DIR"
+  chown adguardhome:adguardhome "$CONF_DIR" "$WORK_DIR"
 
   procd_open_instance
-  procd_set_param command "$PROG" -c /etc/adguardhome.yaml -w "$WORK_DIR" --no-check-update
+  procd_set_param command "$PROG" -c "$CONF_DIR"/adguardhome.yaml -w "$WORK_DIR" --no-check-update
   procd_set_param stdout 1
   procd_set_param stderr 1
+  [ -x /sbin/ujail -a -e /etc/capabilities/adguardhome.json ] && {
+     procd_add_jail adguardhome log procfs requirejail
+     procd_add_jail_mount "/etc/hosts"
+     procd_add_jail_mount "/etc/ssl/certs/ca-certificates.crt"
+     procd_add_jail_mount_rw "$CONF_DIR"
+     procd_add_jail_mount_rw "$WORK_DIR"
+     procd_set_param capabilities /etc/capabilities/adguardhome.json
+     procd_set_param user adguardhome
+     procd_set_param group adguardhome
+     procd_set_param no_new_privs 1
+  }
   procd_close_instance
 }

--- a/net/adguardhome/files/adguardhome.json
+++ b/net/adguardhome/files/adguardhome.json
@@ -1,0 +1,22 @@
+{
+        "bounding": [
+                "CAP_NET_BIND_SERVICE",
+                "CAP_NET_RAW"
+        ],
+        "effective": [
+                "CAP_NET_BIND_SERVICE",
+                "CAP_NET_RAW"
+        ],
+        "ambient": [
+                "CAP_NET_BIND_SERVICE",
+                "CAP_NET_RAW"
+        ],
+        "permitted": [
+                "CAP_NET_BIND_SERVICE",
+                "CAP_NET_RAW"
+        ],
+        "inheritable": [
+                "CAP_NET_BIND_SERVICE",
+                "CAP_NET_RAW"
+        ]
+}


### PR DESCRIPTION
Maintainer: Dobroslaw Kijowski <dobo90@gmail.com>
Compile tested: None
Run tested: x86 on 22.05.3

Description:

These changes add ujail support to the adguardhome package.

The config YAML file has been moved to /etc/adguardhome to allow for the daemon creating an ephemeral file before writing it to adguardhome.yaml.

Adguard Home also requires CAP_NET_BIND_SERVICE and CAP_NET_RAW for all options to function.
