### PR TITLE
[openwrt-23.05] python-cachetools: Update to 5.3.1

### DIFF
--- a/lang/python/python-cachetools/Makefile
+++ b/lang/python/python-cachetools/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cachetools
-PKG_VERSION:=3.1.1
-PKG_RELEASE:=2
+PKG_VERSION:=5.3.1
+PKG_RELEASE:=1
 
 PYPI_NAME:=cachetools
-PKG_HASH:=8ea2d3ce97850f31e4a08b0e2b5e6c34997d7216a9d2c98e0f3978630d4da69a
+PKG_HASH:=dce83f2d9b4e1f732a8cd44af8e8fab2dbe46201467fc98b3ef8f269092bf62b
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=MIT
@@ -32,7 +32,9 @@ define Package/python3-cachetools
 endef
 
 define Package/python3-cachetools/description
-  This module provides various memoizing collections and decorators, including variants of the Python 3 Standard Library lru_cache function decorator.
+This module provides various memoizing collections and decorators,
+including variants of the Python 3 Standard Library's @lru_cache
+function decorator.
 endef
 
 $(eval $(call Py3Package,python3-cachetools))


### PR DESCRIPTION
Maintainer: @BKPepe
Compile tested: none (cherry picked from #21670)
Run tested: none

Description:
Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 2eabda9a1ecd7aff1f340f4175395680a041b0f1)