### PR TITLE
[openwrt-23.05] python-certifi: Update to 2023.7.22, add github runtime test

### DIFF
--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
-PKG_VERSION:=2022.9.24
+PKG_VERSION:=2023.7.22
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
@@ -14,7 +14,7 @@ PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PYPI_NAME:=certifi
-PKG_HASH:=0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14
+PKG_HASH:=539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -25,13 +25,14 @@ define Package/python3-certifi
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Python package for Mozilla's CA Bundle
-  URL:=http://certifi.io/
+  URL:=https://github.com/certifi/python-certifi
   DEPENDS:=+python3-light +python3-urllib
 endef
 
 define Package/python3-certifi/description
-  Certifi is a carefully curated collection of Root Certificates for validating the
-  trustworthiness of SSL certificates while verifying the identity of TLS hosts.
+Certifi provides Mozilla's carefully curated collection of Root
+Certificates for validating the trustworthiness of SSL certificates
+while verifying the identity of TLS hosts.
 endef
 
 $(eval $(call Py3Package,python3-certifi))

--- a/lang/python/python-certifi/test.sh
+++ b/lang/python/python-certifi/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+case "$1" in
+	*-src)
+		;;
+	python3-certifi)
+		BUNDLE=$(python3 -m certifi) || {
+			echo "Failed to run the certfi module script.  Exit status=$?." >&2
+			echo "Output='$BUNDLE'" >&2
+			exit 1
+		}
+		ls -l "$BUNDLE"
+		;;
+	*)
+		echo "Unexpected package '$1'" >&2
+		exit 1
+		;;
+esac


### PR DESCRIPTION
Maintainer: @cotequeiroz
Compile tested: none (cherry picked from #21671 and #21680)
Run tested: none

Description:
