### PR TITLE
[openwrt-23.05] python-colorama: Update to 0.4.6

### DIFF
--- a/lang/python/python-colorama/Makefile
+++ b/lang/python/python-colorama/Makefile
@@ -1,14 +1,17 @@
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=colorama
-PKG_VERSION:=0.4.1
-PKG_RELEASE:=2
+PKG_NAME:=python-colorama
+PKG_VERSION:=0.4.6
+PKG_RELEASE:=1
 
-PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d
+PYPI_NAME:=colorama
+PKG_HASH:=08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44
 
 PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
-PKG_LICENSE:=MIT
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE.txt
+
+PKG_BUILD_DEPENDS:=python-hatchling/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -18,14 +21,14 @@ define Package/python3-colorama
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  TITLE:=colorama
+  TITLE:=Cross-platform colored terminal text
   URL:=https://github.com/tartley/colorama
-  DEPENDS:=+python3
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-colorama/description
-Makes ANSI escape character sequences
-(for producing colored terminal text and cursor positioning) work under MS Windows.
+Makes ANSI escape character sequences (for producing colored terminal
+text and cursor positioning) work under MS Windows.
 endef
 
 $(eval $(call Py3Package,python3-colorama))


### PR DESCRIPTION
Maintainer: @dddaniel
Compile tested: none (cherry picked from #21673)
Run tested: none

Description:
The package changed to the hatchling build backend.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 54f9f2777c79ef41013b02320a7050e5bae16d39)