### PR TITLE
postgresql: update to version 15.3

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postgresql
-PKG_VERSION:=15.2
+PKG_VERSION:=15.3
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=PostgreSQL
@@ -17,7 +17,7 @@ PKG_SOURCE_URL:=\
 	http://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
 	ftp://ftp.postgresql.org/pub/source/v$(PKG_VERSION)
 
-PKG_HASH:=99a2171fc3d6b5b5f56b757a7a3cb85d509a38e4273805def23941ed2b8468c7
+PKG_HASH:=ffc7d4891f00ffbf5c3f4eab7fbbced8460b8c0ee63c5a5167133b9e6599d932
 
 PKG_BUILD_FLAGS:=no-mips16
 PKG_FIXUP:=autoreconf

--- a/libs/postgresql/patches/700-no-arm-crc-march-change.patch
+++ b/libs/postgresql/patches/700-no-arm-crc-march-change.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2236,9 +2236,9 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [
+@@ -2239,9 +2239,9 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [
  # flags. If not, check if adding -march=armv8-a+crc flag helps.
  # CFLAGS_ARMV8_CRC32C is set if the extra flag is required.
  PGAC_ARMV8_CRC32C_INTRINSICS([])


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: BPi-R4 V00

Description:
Fixes security issues:
 * CVE-2023-2454
 * CVE-2023-2455

See release notes for details:
https://www.postgresql.org/about/news/postgresql-153-148-1311-1215-and-1120-released-2637/