### PR TITLE
libksba: update to version 1.6.4

### DIFF
--- a/libs/libksba/Makefile
+++ b/libs/libksba/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libksba
-PKG_VERSION:=1.6.2
+PKG_VERSION:=1.6.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
-PKG_HASH:=fce01ccac59812bddadffacff017dac2e4762bdb6ebc6ffe06f6ed4f6192c971
+PKG_HASH:=bbb43f032b9164d86c781ffe42213a83bf4f2fee91455edfa4654521b8b03b6b
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-3.0-or-later GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: -

Description:
# Changes since version 1.6.2

### 2023-06-19  Werner Koch  <wk@gnupg.org>
## Release 1.6.4.
	+ commit 557999424ebd13e70d6fc17e648a5dd2a06f440b

	Correctly detect write errors while creating CMS objects.
	+ commit 9ced7706f2738128aa5068727ea348c44f42e16e
	* src/cms.c (write_encrypted_cont): Take care of write errors.

### 2023-05-16  NIIBE Yutaka  <gniibe@fsij.org>

	build: Sync libtool from libgpg-error for 64-bit Windows.
	+ commit a920c2ff1a723031e8c6b8b61632bad46a740c83
	* build-aux/ltmain.hs: Update from libgpg-error.

### 2023-05-12  NIIBE Yutaka  <gniibe@fsij.org>

	tests: Use -no-fast-install LDFLAGS for Windows.
	+ commit 74fb95dbaf70d97b67793b29497b1e7b29a5e2f1
	* tests/Makefile.am [HAVE_W32_SYSTEM] (AM_LDFLAGS): Conditionalize.

### 2023-04-05  NIIBE Yutaka  <gniibe@fsij.org>

	build: Update gpg-error.m4.
	+ commit 53b9fa1d58ba522ca0eea4fe460719722e6e1ef5
	* m4/gpg-error.m4: Update from libgpg-error master.

### 2022-12-06  Werner Koch  <wk@gnupg.org>
## Release 1.6.3.
	+ commit bffa9b346071725363a483db547e7dced9721cb5

2022-11-23  Werner Koch  <wk@gnupg.org>

	Fix an integer overflow in the CRL signature parser.
	+ commit f61a5ea4e0f6a80fd4b28ef0174bee77793cf070
	* src/crl.c (parse_signature): N+N2 now checked for overflow.

	* src/ocsp.c (parse_response_extensions): Do not accept too large values. (parse_single_extensions): Ditto.

2022-11-02  NIIBE Yutaka  <gniibe@fsij.org>

	build: Update m4/libgcrypt.m4.
	+ commit 4076b60f7cef4fddc3d30f6e6d4078081dbc7167
	* m4/libgcrypt.m4: Update from libgcrypt master.

2022-11-01  NIIBE Yutaka  <gniibe@fsij.org>

	build: Prefer gpgrt-config when available.
	+ commit 13307b22882a220d206341e1196e74fd37418c2f
	* src/ksba.m4: Overriding the decision by --with-libksba-prefix, use gpgrt-config ksba when gpgrt-config is available.

2022-10-24  NIIBE Yutaka  <gniibe@fsij.org>

	build: Update gpg-error.m4.
	+ commit c3c1627f34234e3d54fe1f3411ac499dd7e3b3b0
	* m4/gpg-error.m4: Update from libgpg-error 1.46.
