### PR TITLE
cryptsetup: update to version 2.6.1

### DIFF
--- a/utils/cryptsetup/Makefile
+++ b/utils/cryptsetup/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cryptsetup
-PKG_VERSION:=2.6.0
-PKG_RELEASE:=2
+PKG_VERSION:=2.6.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/cryptsetup/v2.6
-PKG_HASH:=44397ba76e75a9cde5b02177bc63cd7af428a785788e3a7067733e7761842735
+PKG_HASH:=410ded65a1072ab9c8e41added37b9729c087fef4d2db02bb4ef529ad6da4693
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: -

Description:

Cryptsetup 2.6.1 Release Notes
==============================
Stable bug-fix release with minor extensions.

All users of cryptsetup 2.6.0 should upgrade to this version.

## Changes since version 2.6.0

* bitlk: Fixes for BitLocker-compatible on-disk metadata parser (found by new cryptsetup OSS-Fuzz fuzzers).
  - Fix a possible memory leak if the metadata contains more than one description field.
  - Harden parsing of metadata entries for key and description entries.
  - Fix broken metadata parsing that can cause a crash or out of memory.

* Fix possible iteration overflow in OpenSSL2 PBKDF2 crypto backend. OpenSSL2 uses a signed integer for PBKDF2 iteration count. As cryptsetup uses an unsigned value, this can lead to overflow and a decrease in the actual iteration count. This situation can happen only if the user specifies --pbkdf-force-iterations option. OpenSSL3 (and other supported crypto backends) are not affected.

* Fix compilation for new ISO C standards (gcc with -std=c11 and higher).

* fvault2: Fix compilation with very old uuid.h.

* verity: Fix possible hash offset setting overflow.

* bitlk: Fix use of startup BEK key on big-endian platforms.

* Fix compilation with latest musl library. Recent musl no longer implements lseek64() in some configurations. Use lseek() as 64-bit offset is mandatory for cryptsetup.

* Do not initiate encryption (reencryption command) when the header and data devices are the same. If data device reduction is not requsted, this leads to data corruption since LUKS metadata was written over the data device.

* Fix possible memory leak if crypt_load() fails.

* Always use passphrases with a minimal 8 chars length for benchmarking. Some enterprise distributions decided to set an unconditional check for PBKDF2 password length when running in FIPS mode. This questionable change led to unexpected failures during LUKS format and keyslot operations, where short passwords were used for benchmarking PBKDF2 speed. PBKDF2 benchmark calculations should not be affected by this change.