### PR TITLE
gpgme: update to version 1.21

### DIFF
--- a/libs/gpgme/Makefile
+++ b/libs/gpgme/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gpgme
-PKG_VERSION:=1.18.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.21.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
-PKG_HASH:=361d4eae47ce925dba0ea569af40e7b52c645c4ae2e65e5621bf1b6cdd8b0e9e
+PKG_HASH:=416e174e165734d84806253f8c96bda2993fd07f258c3aad5f053a6efd463e88
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: -

Description:
# Changes since version 1.18
2023-07-07  Werner Koch  <wk@gnupg.org>

	Release 1.21.0.
	+ commit 5bf3e6d0754a179b316f90a885371af99bc03ea1

2023-06-23  NIIBE Yutaka  <gniibe@fsij.org>

	build: Add BUILT_SOURCE for better dependency.
	+ commit 05ac1ce09ff199c715805cf601ea6d65e26c1fff
	* Makefile.am (BUILT_SOURCE): Add conf/config.h.

2023-06-21  Ingo Klöcker  <dev@ingo-kloecker.de>

	qt: Support reading signed/encrypted archives directly from a file.
	+ commit 1c2459a5927866931808141ac6c4157cd5e3a157
	* lang/qt/src/decryptverifyarchivejob.cpp, lang/qt/src/decryptverifyarchivejob.h (DecryptVerifyArchiveJob): Add member functions setInputFile, inputFile.
	* lang/qt/src/decryptverifyarchivejob_p.h (DecryptVerifyArchiveJobPrivate): Add member m_inputFilePath.
	* lang/qt/src/qgpgmedecryptverifyarchivejob.cpp (decrypt_verify): Move creation of indata to decrypt_verify_from_io_device. (decrypt_verify_from_io_device, decrypt_verify_from_file_name): New. (QGpgMEDecryptVerifyArchiveJob::start): Use decrypt_verify_from_io_device instead of decrypt_verify. (QGpgMEDecryptVerifyArchiveJobPrivate::startIt): Start the job with the values from member variables.

	* lang/qt/tests/run-decryptverifyarchivejob.cpp (createInput): Remove. (main): Remove creation of input. Make the job read the archive directly from the given archive name.

	core: Support reading the archive to decrypt/verify directly from a file
	+ commit 1a9f192ab450288aea7a889527e78afd2c067b59
	* src/engine-gpg.c (add_file_name_arg_or_data): New. (gpg_decrypt): Use add_file_name_arg_or_data instead of add_data for the ciphertext. (gpg_verify): Use add_file_name_arg_or_data instead of add_data for the signature and the signed text.

	* tests/run-decrypt.c (show_usage): New option --direct-file-io. (main): Parse new option. If option is given, then don't open input file, create simple data object instead of data object from stream and set input file name on input data.
	* tests/run-verify.c (show_usage): New option --direct-file-io. (main): Parse new option. If option is given, then don't open input files, create simple data objects instead of data objects from stream and set input file names on input data objects.

2023-06-19  Ingo Klöcker  <dev@ingo-kloecker.de>

	qt: Support writing signed/encrypted archives directly to a file.
	+ commit e608315392cc5b7ddf51e16dce5fe7e99b83f011
	* lang/qt/src/encryptarchivejob.cpp, lang/qt/src/encryptarchivejob.h (EncryptArchiveJob): Add member functions setRecipients, recipients, setInputPaths, inputPaths, setOutputFile, outputFile, setEncryptionFlags, encryptionFlags.
	* lang/qt/src/encryptarchivejob_p.h (EncryptArchiveJobPrivate): Add members m_recipients, m_inputPaths, m_outputFilePath, m_encryptionFlags.
	* lang/qt/src/qgpgmeencryptarchivejob.cpp (encrypt): Move creation of outdata to encrypt_to_io_device. (encrypt_to_io_device, encrypt_to_filename): New. (QGpgMEEncryptArchiveJob::start): Use encrypt_to_io_device instead of encrypt. (QGpgMEEncryptArchiveJobPrivate::startIt): Start the job with the values from member variables.
	* lang/qt/src/qgpgmesignarchivejob.cpp (sign): Move creation of outdata to sign_to_io_device. (sign_to_io_device, sign_to_filename): New. (QGpgMESignArchiveJob::start): Use sign_to_io_device instead of sign. (QGpgMESignArchiveJobPrivate::startIt): Start the job with the values from member variables.
	* lang/qt/src/qgpgmesignencryptarchivejob.cpp (sign_encrypt): Move creation of outdata to sign_encrypt_to_io_device. (sign_encrypt_to_io_device, sign_encrypt_to_filename): New. (QGpgMESignEncryptArchiveJob::start): Use sign_encrypt_to_io_device instead of sign_encrypt. (QGpgMESignEncryptArchiveJobPrivate::startIt): Start the job with the values from member variables.
	* lang/qt/src/signarchivejob.cpp, lang/qt/src/signarchivejob.h (SignArchiveJob): Add member functions setSigner, signers, setInputPaths, inputPaths, setOutputFile, outputFile.
	* lang/qt/src/signarchivejob_p.h (SignArchiveJobPrivate): Add members m_signers, m_inputPaths, m_outputFilePath.
	* lang/qt/src/signencryptarchivejob.cpp, lang/qt/src/signencryptarchivejob.h (SignEncryptArchiveJob): Add member functions setSigner, signers, setRecipients, recipients, setInputPaths, inputPaths, setOutputFile, outputFile, setEncryptionFlags, encryptionFlags.
	* lang/qt/src/signencryptarchivejob_p.h (SignEncryptArchiveJobPrivate): Add members m_signers, m_recipients, m_inputPaths, m_outputFilePath, m_encryptionFlags.

	* lang/qt/tests/run-encryptarchivejob.cpp (createOutput): Remove. (checkOutputFilePath): New. (main): Create file output writing to stdout if no archive name (or "-") is given. Exit if file with given archive name already exists. Make the jobs write the created archive directly to the given archive name.
	* lang/qt/tests/run-signarchivejob.cpp (createOutput): Remove. (checkOutputFilePath): New. (main): Create file output writing to stdout if no archive name (or "-") is given. Exit if file with given archive name already exists. Make the jobs write the created archive directly to the given archive name.

	core: Support writing the sign/encrypt output directly to a file.
	+ commit c38b6200396f703917e4c66aca068f90cfbad325
	* src/engine-gpg.c (gpg_encrypt): Pass output file name to gpg if output has file name set. (gpg_encrypt_sign): Ditto. (gpg_sign): Ditto.

	* tests/run-encrypt.c (show_usage): New option --output. (main): Parse new option. Set file name on output if --output is given. Do not print output if --output is given.
	* tests/run-sign.c (show_usage): New option --output. (main): Parse new option. Set file name on output if --output is given. Do not print output if --output is given.

	qt: Add a generic hook to start a job.
	+ commit 8b9fabf5d55419a68c2b0fc7fd1a90517c881d78
	* lang/qt/src/job.cpp, lang/qt/src/job.h (Job::startIt): New method.
	* lang/qt/src/job_p.h (JobPrivate::startIt): New pure virtual method.
	* lang/qt/src/qgpgmechangeexpiryjob.cpp (QGpgMEChangeExpiryJobPrivate::startIt): New.
	* lang/qt/src/qgpgmedecryptverifyarchivejob.cpp (QGpgMEDecryptVerifyArchiveJobPrivate::startIt): New.
	* lang/qt/src/qgpgmeencryptarchivejob.cpp (QGpgMEEncryptArchiveJobPrivate::startIt): New.
	* lang/qt/src/qgpgmeencryptjob.cpp (QGpgMEEncryptJobPrivate::startIt): New.
	* lang/qt/src/qgpgmeimportjob.cpp (QGpgMEImportJobPrivate::startIt): New.
	* lang/qt/src/qgpgmelistallkeysjob.cpp (QGpgMEListAllKeysJobPrivate::startIt): New.
	* lang/qt/src/qgpgmesignarchivejob.cpp (QGpgMESignArchiveJobPrivate::startIt): New.
	* lang/qt/src/qgpgmesignencryptarchivejob.cpp (QGpgMESignEncryptArchiveJobPrivate::startIt): New.
	* lang/qt/src/qgpgmesignencryptjob.cpp (QGpgMESignEncryptJobPrivate::startIt): New.

	qt: Make the run methods of ThreadedJobMixin public.
	+ commit 23526c3ff26be11e4ebb1294b6f60202881a066c
	* lang/qt/src/threadedjobmixin.h (ThreadedJobMixin::run): Make all overloads public.

	qt: Rename JobPrivate::start to JobPrivate::startNow.
	+ commit 4655b2dc6b33aca3bd6737eadadfb8afcf8694bd
	* lang/qt/src/job_p.h (JobPrivate::start): Rename to startNow.
	* lang/qt/src/job.cpp (Job::startNow): Adapt function call.
	* lang/qt/src/qgpgmechangeexpiryjob.cpp (QGpgMEChangeExpiryJobPrivate::start): Rename to startNow.
	* lang/qt/src/qgpgmedecryptverifyarchivejob.cpp (QGpgMEDecryptVerifyArchiveJobPrivate::start): Rename to startNow.
	* lang/qt/src/qgpgmeencryptarchivejob.cpp (QGpgMEEncryptArchiveJobPrivate::start): Rename to startNow.
	* lang/qt/src/qgpgmeencryptjob.cpp (QGpgMEEncryptJobPrivate::start): Rename to startNow.
	* lang/qt/src/qgpgmeimportjob.cpp (QGpgMEImportJobPrivate::start): Rename to startNow.
	* lang/qt/src/qgpgmelistallkeysjob.cpp (QGpgMEListAllKeysJobPrivate::start): Rename to startNow.
	* lang/qt/src/qgpgmesignarchivejob.cpp (QGpgMESignArchiveJobPrivate::start): Rename to startNow.
	* lang/qt/src/qgpgmesignencryptarchivejob.cpp (QGpgMESignEncryptArchiveJobPrivate::start): Rename to startNow.
	* lang/qt/src/qgpgmesignencryptjob.cpp (QGpgMESignEncryptJobPrivate::start): Rename to startNow.

	qt: Return const pointer to JobPrivate class for const pointer to Job.
	+ commit 6f6b35df505af108669bd6ff8c351c970130eb45
	* lang/qt/src/job.cpp, lang/qt/src/job_p.h (getJobPrivate): Replace with two overloads for non-const pointer and const pointer to Job.
	* lang/qt/src/job_p.h (jobPrivate): Replace with two template functions for non-const pointer and const pointer to Job.

2023-06-16  Andre Heinecke  <aheinecke@gnupg.org>

	qt, cpp: Support larger size-hint on 32 bit builds.
	+ commit 5811d069d3b391e9fd77c1062a2d96be41645422
	* NEWS: Mention this.
	* lang/cpp/src/data.h, lang/cpp/src/data.cpp (Data::setSizeHint): New.
	* lang/qt/src/qgpgmedecryptjob.cpp, lang/qt/src/qgpgmedecryptverifyarchivejob.cpp, lang/qt/src/qgpgmedecryptverifyjob.cpp, lang/qt/src/qgpgmeencryptjob.cpp, lang/qt/src/qgpgmesignencryptjob.cpp, lang/qt/src/qgpgmesignjob.cpp, lang/qt/src/qgpgmeverifydetachedjob.cpp, lang/qt/src/qgpgmeverifyopaquejob.cpp: Set size for input IODevice.

	cpp: Expose gpgme_data_set_flag through cpp API.
	+ commit cbcea4a09b1309a4bd822247a8dfcdcb73041f9c
	* lang/cpp/src/data.cpp (Data::setFlag): New.
	* lang/cpp/src/data.h: Update accordingly.
	* NEWS: Mention this.

2023-06-15  Werner Koch  <wk@gnupg.org>

	core: Send a input-size-hint for gpgsm.
	+ commit 91bbb1e482da783b4d1b9d5f663a1a0af77fc0a4
	* src/engine-gpgsm.c (send_input_size_hint): New. (gpgsm_decrypt): Send hint. (gpgsm_encrypt): Send hint. (gpgsm_sign): Send hint. (gpgsm_verify): Send hint.

	tests: Add option --cancel to run-encrypt.
	+ commit 8796456d235d2d7a8a1ce7337abc1d4d149bcf9a
	* tests/run-encrypt.c (cancel_after_progress): New. (progress_cb): Take care of it. (main): Add option --cancel.

	core: Use 64 bit instead of gpgme_off_t for some internal functions.
	+ commit eb68948c438814b99b81adf44b674738d0b1be34
	* src/conversion.c (_gpgme_string_to_off): Return an u64 value.
	* src/data.c (_gpgme_data_get_size_hint): Ditto. (gpgme_data_set_flag): Use u64 for io-buffer-size due to string_to_off change.
	* src/data.h (struct gpgme_data): Change size_hint to u64.
	* src/engine-gpg.c (add_input_size_hint): Replace gpgme_off_t by u64.

2023-06-13  Andre Heinecke  <aheinecke@gnupg.org>

	Fix definition of GPG_ERR_ENABLE_GETTEXT_MACROS.
	+ commit 7e6d51aa6fc97bed12486540167e9b710c9a3378
	* configure.ac: Add missing value.

2023-06-01  Ingo Klöcker  <dev@ingo-kloecker.de>

	doc,cpp: Treat GPG_ERR_FULLY_CANCELED as canceled.
	+ commit 7990f70107bc8487f954c6885436a7661e162929
	* doc/gpgme.texi (GPG_ERR_FULLY_CANCELED): New.
	* lang/cpp/src/context.cpp (Error::isCanceled): Also return true for GPG_ERR_FULLY_CANCELED.

2023-05-30  Biswapriyo Nath  <nathbappai@gmail.com>

	cpp,python: Respect --disable-gpg-test for tests.
	+ commit e2103be390764f62b21a4e5d4fa90a7b78326787 lang/cpp/Makefile.am (SUBDIRS): Depend tests in RUN_GPG_TESTS. lang/python/Makefile.am (SUBDIRS): Ditto.

2023-05-30  Werner Koch  <wk@gnupg.org>

	core: For key signing and uid revoking allow an empty user id.
	+ commit fbc3963d6229853fe9fb1fd599ef39ed0fe2eae6
	* src/engine-gpg.c (gpg_keysign): Required USERID to be non-empty.

2023-05-23  Werner Koch  <wk@gnupg.org>

	python: Fix wrong use of write.
	+ commit 36a68bc5308c0b4a541ca6adea5d3635217e8af2
	* lang/python/helpers.c (pyPassphraseCb): Use gpgme_io_writen. (_gpg_interact_cb): Ditto.
	* lang/python/helpers.h (write) [W32]: Remove bad write macro.

2023-05-16  NIIBE Yutaka  <gniibe@fsij.org>

	build: Sync to libtool from libgpg-error for 64-bit Windows.
	+ commit e622e36f1f32641c66b28a0de95c75ae35f6ca05
	* build-aux/ltmain.hs: Update from libgpg-error.

2023-04-26  NIIBE Yutaka  <gniibe@fsij.org>
	    Ingo Klöcker

	doc: Fix Python example code.
	+ commit d44a473e27160a35268789e14dccd0ad55af0690
	* lang/python/doc/src/gpgme-python-howto.org: Fix chmod race.
	* lang/python/examples/howto/export-secret-key.py: Likewise.
	* lang/python/examples/howto/export-secret-keys.py: Likewise.
	* lang/python/examples/howto/temp-homedir-config.py: Likewise.

2023-04-20  Werner Koch  <wk@gnupg.org>

	Release 1.20.0.
	+ commit 451ed47434c5ffd2916adae25e5a128606b5ef98

	core: Support the new macOS Homebrew location.
	+ commit 7351ef32ce7c04d20ee32fc9b645a1931b3b0aba
	* src/posix-util.c (find_executable): Extend the path.

2023-04-19  Ingo Klöcker  <dev@ingo-kloecker.de>

	build,qt: Simplify check for moc.
	+ commit a14155d2c1b2ddc167dbf278faf1d6b469575492 m4/qt6.m4: Remove alternative checks for moc that were taken over from Qt 5 and that are obsolete for Qt 6.

	Update NEWS.
	+ commit e80bf34bf86f6f183145c31d598dda41c0496a4d
	* NEWS: Add news for recent changes

2023-04-18  Ingo Klöcker  <dev@ingo-kloecker.de>

	cpp: Fix Key::canSign()
	+ commit 5bd84cfd3f092703bb4b9b993be7d89ca13b36b0
	* lang/cpp/src/key.h (canReallySign): Deprecate.
	* lang/cpp/src/key.cpp (canSign): Remove workaround. Use implementation of canReallySign. (canReallySign): Use canSign(). (operator<<): Use canSign().

2023-04-17  Werner Koch  <wk@gnupg.org>

	core: Avoid printf format warnings due to gpgme_ssize_t.
	+ commit 7d1159c1e99bb1bae0ab698c85105dcdcb95b7ea
	* src/debug.h (_trace_sysres_ssize_t): Cast arg.

	core,w32: Fix invocation of gpgtar.
	+ commit 0c29119e061cbdcb7342380938a25af91290f1a0
	* src/dirinfo.c (EXEEXT_S): New. (get_gpgconf_item): Append ".exe" to gpg-wks-client and gpgtar.

	* src/gpgme-w32spawn.c (mystderr): Add code to ease debugging.

2023-04-06  NIIBE Yutaka  <gniibe@fsij.org>

	build: Update gpg-error.m4.
	+ commit 806a5d18b988449fbaa3c2e6380acf3ae4580f4a
	* m4/gpg-error.m4: Update from libgpg-error master.

2023-04-04  Ingo Klöcker  <dev@ingo-kloecker.de>

	w32: Always use UTF-8 for localized texts.
	+ commit d256ba7cc57d9bfcfa05fb05cf66dc992efbb695
	* configure.ac: Define GPG_ERR_ENABLE_GETTEXT_MACROS.
	* src/version.c (do_subsystem_inits) [W32]: Switch gettext to UTF-8.

2023-03-27  Werner Koch  <wk@gnupg.org>

	core: Minor code cleanup.
	+ commit 34cc7daba12a2a6baa3cfa337762656c210686fa
	* src/engine-gpg.c (build_argv): Remove superfluous tes.

2023-03-27  Ingo Klöcker  <dev@ingo-kloecker.de>

	core: Initialize error variable.
	+ commit b608c084b9220d8ed288eb916e88a236abac0707
	* src/engine-gpg.c (build_argv): Initialize err.

2023-03-21  Werner Koch  <wk@gnupg.org>

	core,cpp: Add new key flags to gpgme_subkey_t.
	+ commit 6d21256c9220df05bf92a695a787dde13fe44ca7
	* src/gpgme.h.in (struct _gpgme_subkey): Add bit flags can_renc, can_timestamp, adn is_group_owned. Reduce size of _unused.
	* src/keylist.c (set_subkey_capability): Set them.
	* tests/run-keylist.c (main): Print them.

	* lang/cpp/src/key.h (Subkey::canRenc): New.
	(Subkey::canTimestamp): New.
	(Subkey::isGroupOwned): New.
	* lang/cpp/src/key.cpp: Implement new methods.
	(Subkey::isQualified): Print them.
	(std::ostream &operator<<): Print them.

2023-03-17  Werner Koch  <wk@gnupg.org>

	Release 1.19.0.
	+ commit 96a30fdf30626a7cefd9c9e620a60817ef44fde2

2023-03-17  Ben Greiner (bnavigator)  <unknown@dev.gnupg.org>

	python: Update python.m4 configure script.
	+ commit d086653cc346d5634bc742d5586e927fc9ee57cf
	* configure.ac: Unset PYTHON_LIBS.  Support python 3.10.
	* m4/python.m4: Find correct version string for python >= 3.10.

2023-03-17  Ingo Klöcker  <dev@ingo-kloecker.de>

	tests: Package the ownertrust file.
	+ commit e50724e1bbe55678dfcd2a1ea75157f6514fc58a tests/gpg/Makefile.am (EXTRA_DIST): Add ownertrust.txt.

2023-03-08  Werner Koch  <wk@gnupg.org>

	core: Also detect legacy X.509 v0 certificates.
	+ commit c1f6535f144dedfbf5507f850d4da5b61fd5ec74
	* src/data-identify.c (basic_detection): Loose the detection of X.509 certs.

	tests: Add option --binary to run-verify.
	+ commit 76351c4877d60799a35afccd87037d5dd0871262
	* tests/run-verify.c (main): Set encoding.

2023-02-14  Ingo Klöcker  <dev@ingo-kloecker.de>

	qt: Add signals for file-based and data-based progress.
	+ commit 73e46b34658c0130de5ab9e3f4ce1ac4ee35c5e2
	* lang/qt/src/decryptverifyarchivejob.h (DecryptVerifyArchiveJob): Add signals fileProgress and dataProgress.
	* lang/qt/src/encryptarchivejob.h (EncryptArchiveJob): Ditto.
	* lang/qt/src/signarchivejob.h (SignArchiveJob): Ditto.
	* lang/qt/src/signencryptarchivejob.h (SignEncryptArchiveJob): Ditto.
	* lang/qt/src/job_p.h (emitArchiveProgressSignals): New.
	* lang/qt/src/qgpgmedecryptverifyarchivejob.cpp (QGpgMEDecryptVerifyArchiveJob::QGpgMEDecryptVerifyArchiveJob): Emit appropriate signal when receiving Job::rawProgress signal.
	* lang/qt/src/qgpgmeencryptarchivejob.cpp (QGpgMEEncryptArchiveJob::QGpgMEEncryptArchiveJob): Ditto.
	* lang/qt/src/qgpgmesignarchivejob.cpp (QGpgMESignArchiveJob::QGpgMESignArchiveJob): Ditto.
	* lang/qt/src/qgpgmesignencryptarchivejob.cpp (QGpgMESignEncryptArchiveJob::QGpgMESignEncryptArchiveJob): Ditto.

	qt: Add simple and extended progress signals replacing old signal.
	+ commit ea6f15ed602eeb9fa87766ba88acc78361a14b38
	* lang/qt/src/job.h (Job): Add signals jobProgress and rawProgress. Deprecate signal progress.
	* lang/qt/src/multideletejob.cpp (MultiDeleteJob::slotResult): Emit new progress signals.
	* lang/qt/src/qgpgmerefreshsmimekeysjob.cpp (QGpgMERefreshSMIMEKeysJob::slotStatus): Ditto.
	* lang/qt/src/threadedjobmixin.h (ThreadedJobMixin::showProgress): Use modern overload of QMetaObject::invokeMethod to forward the progress signal and add the value of what. Add forwarding of progress to the new signals.

	* lang/qt/tests/t-encrypt.cpp (EncryptionTest::testProgress): Test the new signals instead of the deprecated one.

2023-02-10  Werner Koch  <wk@gnupg.org>

	core: Switch to logging via gpgrt.
	+ commit 9c5506fde701f637381614dcfe22e3f9dc82955d
	* src/debug.c (errfp): Remove. (debug_init): Factor some code out to ... (safe_to_use_debug_file): new. (tid_log_callback): New. (debug_init): Rewrite to make use of gpgrt logging. (_gpgme_debug): Ditto. (_gpgme_debug_end): Remove extra LF testing code.
	* src/dirinfo.c (get_gpgconf_item): Remove now unneeded LFs.  Realign output.

2023-02-10  Ingo Klöcker  <dev@ingo-kloecker.de>

	tests: Fix cleaning up at the end of the test.
	+ commit 21283dfd1be1e56bc174cf5f12461888af7ab8b5
	* tests/gpg/t-import.c (main): Unref key and release context.

	core: Allow finalization of signature verification of unencrypted data.
	+ commit 41dc3bd22a3e0001abec8f2bea79b40ee5ad00be
	* src/decrypt-verify.c (decrypt_verify_status_handler): Call _gpgme_verify_status_handler on EOF even if _gpgme_decrypt_status_handler returned NO DATA error.

	* tests/gpg/t-decrypt-verify.c (normal_signed_message): New.
	(main): Add test with signed, but not encrypted data.

2023-02-09  Ingo Klöcker  <dev@ingo-kloecker.de>

	cpp: Improve debug output of some enums.
	+ commit 3aaed9cfbfd6821b2e812fbdd24448953d6ca279
	* lang/cpp/src/verificationresult.cpp (operator<<): Fix output of Signature::PKAStatus which doesn't represent flags. Print corresponding name of enum value if Signature::Summary or Notation::Flags are 0.

	tests: Stop daemons after setting up test environment.
	+ commit 7098c14b231113055535abb14b4cde0c845f8728
	* lang/python/tests/Makefile.am, lang/qt/tests/Makefile.am, tests/gpg/Makefile.am, tests/json/Makefile.am (pubring-stamp): Call `gpgconf --kill all` after importing test keys.

2023-02-08  Ingo Klöcker  <dev@ingo-kloecker.de>

	tests: Extend tests with an ultimately trusted key.
	+ commit fcefc78f749a8f39cc587636647b24f8fa48efad
	* tests/gpg/Makefile.am (gpg-sample.stamp, pubring-stamp): Unify usage of tabs. (pubring-stamp): Import owner trust values.
	* tests/gpg/ownertrust.txt: New.
	* tests/gpg/t-decrypt-verify.c, tests/gpg/t-verify.c: Update expected values for signature summary and validity.
	* tests/gpg/t-keylist-secret-sig.c, tests/gpg/t-keylist-sig.c, tests/gpg/t-keylist.c: Update expected values of owner trust and uid validity.

	tests: Make t-edit-sign idempotent.
	+ commit 844e6cd3b923834727f042b92d6a9a2db86b3fed
	* tests/gpg/t-edit-sign.c (test_key, test_key_fpr, import_key, delete_key): New. (main): Remove key_fpr. Import test key to sign. Delete test key after test.

2023-02-02  Ingo Klöcker  <dev@ingo-kloecker.de>

	qt,tests: Add test for the previous commit.
	+ commit 52fd0bcde47a676ee1021c870b50e2add78d6973
	* lang/qt/tests/t-decryptverify.cpp: New.
	* lang/qt/tests/Makefile.am: Add new test.

	cpp: Return successful verification for signed but not encrypted data.
	+ commit 1698eec2ae3ec1a97c739e892d9cf288c0ec4ccd
	* lang/cpp/src/context.cpp (Context::decrypt): Use decryptionResult(). (Context::verifyDetachedSignature, Context::verifyOpaqueSignature): Use verificationResult(). (Context::verificationResult): Ignore "no data" error for signed but not encrypted data. (Context::decryptAndVerify): Use decryptionResult() and verificationResult().

	qt: Add job for extracting encrypted and signed archives.
	+ commit c407728064ca0c9b2f365437c6a7f2acc40e6d84
	* lang/qt/src/decryptverifyarchivejob.cpp, lang/qt/src/decryptverifyarchivejob.h, lang/qt/src/decryptverifyarchivejob_p.h, lang/qt/src/qgpgmedecryptverifyarchivejob.cpp, lang/qt/src/qgpgmedecryptverifyarchivejob.h: New.
	* lang/qt/src/protocol.h (class Protocol): Add pure virtual member function decryptVerifyArchiveJob
	* lang/qt/src/protocol_p.h (Protocol::decryptVerifyArchiveJob): ... and implement it.
	* lang/qt/src/Makefile.am: Update accordingly.

	* lang/qt/tests/run-decryptverifyarchivejob.cpp: New.
	* lang/qt/tests/Makefile.am: Add new test runner.

	core: Make usage of input size hint compatible with gpgtar.
	+ commit 7ad717f6ba00046a26a99d015d701a178ca30630
	* src/engine-gpg.c (add_input_size_hint): Use add_gpg_arg_with_value to add the --input-size-hint option.

	cpp: Update decryption flags.
	+ commit b3bdf14b37a313c21de61168e5e7545ab08fea13
	* lang/cpp/src/context.h (DecryptArchive): New flag.

	qt: Allow checking if the sign/encrypt archive jobs are supported.
	+ commit 55c948866fb8bf4adbf0c8f53edf51a4075b753e
	* lang/qt/src/encryptarchivejob.cpp, lang/qt/src/encryptarchivejob.h (isSupported): New.
	* lang/qt/src/signarchivejob.cpp, lang/qt/src/signarchivejob.h (isSupported): New.
	* lang/qt/src/signencryptarchivejob.cpp, lang/qt/src/signencryptarchivejob.h (isSupported): New.

	* lang/qt/tests/run-encryptarchivejob.cpp (main), lang/qt/tests/run-signarchivejob.cpp (main): Check if jobs are supported.

	cpp: Add const-overloads of version comparison operators.
	+ commit 84780646910cdd91555a368650e3d92cf52b86bd
	* lang/cpp/src/engineinfo.h (EngineInfo::Version): Add const-overloads of all comparison operators.

	core: Allow usage of gpgtar also for new enough gpg 2.2.
	+ commit 7f541547fc1783bb9ea119695fb76e2000bdfcf8
	* src/engine-gpg.c (have_usable_gpgtar): New. (start): Always pass --status-fd to the called process. (gpg_decrypt, gpg_encrypt, gpg_encrypt_sign, gpg_sign, gpg_verify): Use have_usable_gpgtar() to check for suitable gpg.

2023-02-01  Werner Koch  <wk@gnupg.org>

	core,w32: More robust detection of GnuPG Desktop dir layout.
	+ commit 5ab9c234d6b507f568fe1d2a2cbc82250a7828ee
	* src/w32-util.c (INST_TYPE_GPG4WIN, INST_TYPE_GPGDESK): New to replace the numeric constants. (find_version_file): New. (_gpgme_get_gpgconf_path): Guess a default for inst_type.

2023-01-31  Ingo Klöcker  <dev@ingo-kloecker.de>

	qt: Fix build without installed gpgme++ headers.
	+ commit 343fb33bf02bea74caf4e615483f1a00dc06f7b8
	* lang/qt/src/filelistdataprovider.cpp: Include error.h without folder prefix.

	qt: Remove unused and commented-out code.
	+ commit d3a8c2c8b68b290a642c83c53a5989ee7fdc6331
	* lang/qt/src/qgpgmeencryptarchivejob.cpp, lang/qt/src/qgpgmeencryptarchivejob.h (QGpgMEEncryptArchiveJob): Remove member function resultHook and member mResult.
	* lang/qt/src/qgpgmesignarchivejob.cpp, lang/qt/src/qgpgmesignarchivejob.h (QGpgMESignArchiveJob): Remove member function resultHook and member mResult.

	cpp: Fix debug output of SignatureMode.
	+ commit 41a30f6d9f59b08213ab2c307036be9bc9b6f876
	* lang/cpp/src/context.cpp (operator<<): Treat signature mode as combination of a 2-bit flag and a 1-bit flag.

	qt: Add job for creating encrypted signed archives.
	+ commit 8c4436e73af369f79f125f56d020d01b184cafc6
	* lang/qt/src/signencryptarchivejob.cpp, lang/qt/src/signencryptarchivejob.h, lang/qt/src/signencryptarchivejob_p.h, lang/qt/src/qgpgmesignencryptarchivejob.cpp, lang/qt/src/qgpgmesignencryptarchivejob.h: New.
	* lang/qt/src/protocol.h (class Protocol): Add pure virtual member function signEncryptArchiveJob
	* lang/qt/src/protocol_p.h (Protocol::signEncryptArchiveJob): ... and implement it.
	* lang/qt/src/Makefile.am: Update accordingly.

	* lang/qt/tests/run-encryptarchivejob.cpp (displayName): Remove. (CommandLineOptions): Initialize member armor. Add member sign. (parseCommandLine): Update application description. Add and parse option -s/--sign. (main): Use SignEncryptArchiveJob if sign option is set.

	qt,tests: Avoid leaking Context.
	+ commit 2b98585c89c1654aa736777eeb92ff79d5fdd72b
	* lang/qt/tests/t-import.cpp: Wrap Context*s in unique_ptr.

2023-01-31  Werner Koch  <wk@gnupg.org>

	json: New operation "identify" and convenience option --identify.
	+ commit 359378c5b3f3aaf274dfc33861978c3cf6ec60ca
	* src/gpgme-json.c (data_type_to_string): New. (op_identify): New. (process_request): Add to command list. (cmd_identify): New. (main): Add option --identify.

2023-01-30  Ingo Klöcker  <dev@ingo-kloecker.de>

	qt: Add job for creating signed archives.
	+ commit 8d672b3b7e5c5d487f20fb742a29fbee21236885
	* lang/qt/src/signarchivejob.cpp, lang/qt/src/signarchivejob.h, lang/qt/src/signarchivejob_p.h, lang/qt/src/qgpgmesignarchivejob.cpp, lang/qt/src/qgpgmesignarchivejob.h: New.
	* lang/qt/src/protocol.h (class Protocol): Add pure virtual member function signArchiveJob
	* lang/qt/src/protocol_p.h (Protocol::signArchiveJob): ... and implement it.
	* lang/qt/src/Makefile.am: Update accordingly.

	* lang/qt/tests/run-signarchivejob.cpp: New.
	* lang/qt/tests/Makefile.am: Add new test runner.

	cpp: Support new archive signing flag.
	+ commit 2faa031af24959d5093da430d5f10fe30d77a75d
	* lang/cpp/src/global.h (enum SignatureMode): Add constant SignArchive.
	* lang/cpp/src/context.cpp (sigmode2sigmode): Rename to sigflags2sigflags (sigflags2sigflags): ... and rename argument mode to flags and treat it as flags. Adjust the callers. (operator<<): Change local CHECK macro to handle flags. Add new flag to debug stream.
	* lang/cpp/src/signingresult.cpp (CreatedSignature::mode): Handle new flags (even if it cannot occur currently).

	core: Use signature modes as flags.
	+ commit 48b11f576260286bddef3833e25d0059638fe0bb
	* src/engine-backend.h (engine_ops.sign): Rename argument mode to flags.
	* src/engine-gpg.c (gpg_sign): Rename argument mode to flags. Check for invalid combination of flags.
	* src/engine-gpgsm.c (gpgsm_sign): Rename argument mode to flags. Check for unsupported flags.
	* src/engine-uiserver.c (gpgsm_sign): Rename argument mode to flags. Check for unsupported flags.
	* src/engine.c, src/engine.h (_gpgme_engine_op_sign): Rename argument mode to flags.
	* src/gpgme.h.in (GPGME_SIG_MODE_ARCHIVE): Change value to 4. (gpgme_op_sign_start, gpgme_op_sign): Rename argument mode to flags.
	* src/sign.c (sign_start): Rename argument mode to flags. Adjust check for invalid flags. (gpgme_op_sign_start, gpgme_op_sign): Rename argument mode to flags.

2023-01-27  Ingo Klöcker  <dev@ingo-kloecker.de>

	qt: Add job for creating encrypted archives.
	+ commit 7afd135ccec73585e06272f98b4a0895e3ee6579
	* lang/qt/src/encryptarchivejob.cpp, lang/qt/src/encryptarchivejob.h, lang/qt/src/encryptarchivejob_p.h, lang/qt/src/qgpgmeencryptarchivejob.cpp, lang/qt/src/qgpgmeencryptarchivejob.h: New.
	* lang/qt/src/protocol.h (class Protocol): Add pure virtual member function encryptArchiveJob
	* lang/qt/src/protocol_p.h (Protocol::encryptArchiveJob): ... and implement it.
	* lang/qt/src/Makefile.am: Update accordingly.

	* lang/qt/tests/run-encryptarchivejob.cpp: New.
	* lang/qt/tests/Makefile.am: Add new test runner.

	qt: Add data provider for list of file names.
	+ commit 275a3a2c16d27e5bc87f7d80af2ee703a92b6758
	* lang/qt/src/Makefile.am: Add new files and corresponding camel-case header.
	* lang/qt/src/dataprovider.h: Include interface from gpgme++ when not building.
	* lang/qt/src/filelistdataprovider.cpp, lang/qt/src/filelistdataprovider.h: New.

	cpp: Support new archive encryption flag.
	+ commit d28ea8c6b3db008150e2bae99a33e30b55c4bc10
	* lang/cpp/src/context.h (EncryptArchive): New flag.
	* lang/cpp/src/context.cpp (encryptflags2encryptflags): Convert EncryptArchive to corresponding gpgme encrypt flags. (operator<<): Add new flag to debug stream.

	cpp: Add convenience overload to set file name.
	+ commit 261245a2e0e76568607c79a0c80372cb6f46444e
	* lang/cpp/src/data.h, lang/cpp/src/data.cpp (setFileName): Add overload.

2023-01-26  Ingo Klöcker  <dev@ingo-kloecker.de>

	cpp: Support all encryption flags.
	+ commit 3e31f648e513bed0029b09104d416d25fca08868
	* lang/cpp/src/context.h (WantAddress): New flag.
	* lang/cpp/src/context.cpp (encryptflags2encryptflags): Convert WantAddress to corresponding gpgme encrypt flags. (operator<<): Add new flag to debug stream.

	cpp: Pass ThrowKeyIds and EncryptWrap flags to GpgME.
	+ commit 70aaf05a6a3eafd1ba96df71d03334337b1d071d
	* lang/cpp/src/context.cpp (encryptflags2encryptflags): Convert ThrowKeyIds and EncryptWrap to corresponding gpgme encrypt flags. (operator<<): Add flags to debug stream.

	core: Update required GnuPG version for new archive features.
	+ commit 3580bb139b2e41f6c2397e506ee66f4892ceec62
	* src/engine-gpg.c (gpg_decrypt, gpg_encrypt, gpg_encrypt_sign, gpg_sign, gpg_verify): Require gpg 2.4.1.

2023-01-25  Ingo Klöcker  <dev@ingo-kloecker.de>

	core: Support usage of gpgtar for verifying a signed archive.
	+ commit 5b79b323971cb0794c45791851d85f8a66f0a441
	* src/gpgme.h.in (gpgme_verify_flags_t): New enum. (GPGME_VERIFY_ARCHIVE): New const. (gpgme_op_verify_ext_start): New func. (gpgme_op_verify_ext): New func.
	* src/gpgme.def, src/libgpgme.vers: Add new functions.
	* src/verify.c (gpgme_op_verify_ext_start): New. (gpgme_op_verify_ext): New. (verify_start): Add arg FLAGS.  Pass the flags to _gpgme_engine_op_verify. (gpgme_op_verify_start): Call gpgme_op_verify_ext_start with 0 for FLAGS. (gpgme_op_verify): Call gpgme_op_verify_ext with 0 for FLAGS.
	* src/engine.c, src/engine.h (_gpgme_engine_op_verify): Add arg FLAGS.
	* src/engine-backend.h (struct engine_ops): Add FLAGS to 'verify'.
	* src/engine-gpg.c (gpg_verify): Add arg FLAGS. Set use_gpgtar engine flag if GPGME_VERIFY_ARCHIVE flag is set. Check for new enough gpg. Use add_gpg_arg for gpg-only options without a value. Set extra options for gpgtar and pass input data to stdin when using gpgtar.
	* src/engine-gpgsm.c (gpgsm_verify): Add arg FLAGS. Return error if GPGME_VERIFY_ARCHIVE flag is set.
	* src/engine-uiserver.c (uiserver_verify): Ditto.

	* tests/run-verify.c (show_usage): New options --archive, --directory, and --diagnostics. (main): Parse new options. Verify and extract with gpgtar if --archive is given. Set file name of output data to value of --directory option. Print stderr of gpg/gpgtar if --diagnostics is given.

2023-01-24  Ingo Klöcker  <dev@ingo-kloecker.de>

	core: Support usage of gpgtar for decrypting an encrypted archive.
	+ commit 95ea3bf831aeac201108876e73750692aa1ba3f5
	* src/gpgme.h.in (GPGME_DECRYPT_ARCHIVE): New decryption flag.
	* src/engine-gpg.c (gpg_decrypt): Set use_gpgtar engine flag if GPGME_DECRYPT_ARCHIVE flag is set. Check for new enough gpg and incompatible flags. Use add_gpg_arg_with_value for gpg-only options with a value and add_gpg_arg for gpg-only options without a value. Set extra options for gpgtar and pass input data to stdin when using gpgtar.

	* tests/run-decrypt.c (show_usage): New options --archive and --directory. (main): Parse new options. Decrypt with gpgtar if --archive is given. Set file name of output data to value of --directory option.

2023-01-23  Ingo Klöcker  <dev@ingo-kloecker.de>

	core: Allow setting the base directory when creating an archive.
	+ commit 419adf41afa40e5b34f646f2cb16d8aebda20048
	* src/engine-gpg.c (gpg_encrypt, gpg_encrypt_sign, gpg_sign): Pass file name set in data with --directory option to gpgtar.

	* tests/run-encrypt.c (show_usage): New option --directory.
	(main): Parse new option. Set file name of input data to option value.
	* tests/run-sign.c (show_usage): New option --directory.
	(main): Parse new option. Set file name of input data to option value.

2023-01-19  Ingo Klöcker  <dev@ingo-kloecker.de>

	core: Support usage of gpgtar for creating an encrypted signed archive.
	+ commit 29cfcd316d1bfc98ca663369a9503cc169dd3447
	* src/engine-gpg.c (gpg_encrypt_sign): Set use_gpgtar engine flag if GPGME_ENCRYPT_ARCHIVE mode is set. Check for new enough gpg. Use add_gpg_arg_with_value for gpg-only options with a value and add_gpg_arg for gpg-only options without a value. Set extra options for gpgtar and pass input data to stdin when using gpgtar.

	* tests/run-encrypt.c (print_result): Rename to print_encrypt_result. Print header. (print_sign_result): New. (show_usage): New option --sign. (main): Parse new option. Sign and encrypt --sign is given. Print results of signing additionally to results of encryption.

	core: Support usage of gpgtar for creating a signed archive.
	+ commit 0ca45e48b45af1978027e6fe26c7e406fd5ec74b
	* src/gpgme.h.in (GPGME_SIG_MODE_ARCHIVE): New signature mode.
	* src/engine-gpg.c (append_args_from_sender, append_args_from_sig_notations): Use add_gpg_arg_with_value for gpg-only options with a value. (gpg_sign): Set use_gpgtar engine flag if GPGME_SIG_MODE_ARCHIVE mode is set. Check for new enough gpg. Use add_gpg_arg_with_value for gpg-only options with a value and add_gpg_arg for gpg-only options without a value. Set extra options for gpgtar and pass input data to stdin when using gpgtar.
	* src/sign.c (sign_start): Add GPGME_SIG_MODE_ARCHIVE as valid mode.

	* tests/run-sign.c (show_usage): New options --archive and --diagnostics. (main): Parse new options. Sign with gpgtar if --archive is given. Print stderr of gpg/gpgtar if --diagnostics is given.

	core: Fix --set-filename argument.
	+ commit aa201b0bb63d703a3794826fac2e2013fb0c34e7
	* src/engine-gpg.c (gpg_encrypt): Append equal sign to argument name.

2023-01-18  Ingo Klöcker  <dev@ingo-kloecker.de>

	core: Support usage of gpgtar for encryption.
	+ commit 5d8316da1d3dd0ab73743898e76c51932d0f13e2
	* src/gpgme.h.in (GPGME_ENCRYPT_ARCHIVE): New encryption flag.
	* src/engine-gpg.c (arg_and_data_s): New field gpg_arg. (engine_gpg): New flag use_gpgtar. (_add_arg): Add argument gpg_arg and set it. (add_arg_ext, add_arg_with_locp, add_arg, add_arg_pfx, add_arg_len): Adjust call of _add_arg. (add_arg_with_locp): Add argument front. (add_gpg_arg, add_gpg_arg_with_value): New. (gpg_new): Use add_gpg_arg_with_value for gpg-only options with a value and add_gpg_arg for gpg-only options without. (build_argv): Consider usage of gpgtar when counting arguments to pass to gpg/gpgtar. Prepend "--gpg-args" to all gpg-only arguments if gpgtar is used. (start): Set program to use. Read diagnostics output from stderr when using gpgtar. Do not pass --status-fd to gpgtar for gpg < 2.4.1. Use add_gpg_arg_with_value for --lc-ctype and --lc-messages. (gpg_encrypt): Set use_gpgtar engine flag if GPGME_ENCRYPT_ARCHIVE flag is set. Check for new enough gpg and incompatible flags. Use add_gpg_arg_with_value for gpg-only options with a value and add_gpg_arg for gpg-only options without a value. Set extra options for gpgtar and pass input data to stdin when using gpgtar.
	* src/engine-gpgsm.c (gpgsm_encrypt): Return error if new flag is set.
	* src/engine-uiserver.c (uiserver_encrypt): Ditto.

	* tests/run-encrypt.c (show_usage): New options --archive and --diagnostics. (main): Parse new options. Encrypt with gpgtar if --archive is given. Print stderr of gpg/gpgtar if --diagnostics is given.

	core: Defer adding --status-fd and --logger-fd to argument list.
	+ commit d56b3bc1cfa128d0246cfac59411adaad2579bc4
	* src/engine-gpg.c (_append_to_arglist, _prepend_to_arglist): New. (_add_arg): Use _append_to_arglist and _prepend_to_arglist. (add_data_ext): New. Extends add_data. (add_data): Uses add_data_ext. (gpg_new): Do not add --status-fd and --logger-fd to argument list. (start): Prepend --logger-fd and --status-fd to the argument list.

	core: Extend gpgme_get_dirinfo to return the gpgtar name.
	+ commit 12e490d97f2e7064bc9b5bea0d197790d10db106
	* src/dirinfo.c (WANT_GPGTAR_NAME): New. (dirinfo): Add field gpgtar_name. (get_gpgconf_item): Build gpgtar_name on demand and return it. (_gpgme_get_default_gpgtar_name) : New. (gpgme_get_dirinfo): New value "gpgtar-name" for WHAT.
	* src/util.h (_gpgme_get_default_gpgtar_name): New.

	* tests/t-engine-info.c (main): Add gpgtar-name to the output.

2023-01-17  Ingo Klöcker  <dev@ingo-kloecker.de>

	core: Use "goto leave" pattern to clean up resources.
	+ commit fbce7deb3b68af900f692591d5d05fa5c1a83f5f
	* src/engine-gpg.c (build_argv): Initialize fd_data_map and argv. Goto leave on error. Free fd_data_map and argv on error.

2023-01-16  Ingo Klöcker  <dev@ingo-kloecker.de>

	core: Do not add obsolete --no-sk-comments to command line.
	+ commit 984ff7e3a2a9a261a0732cbdaf3b2f22d325b433
	* src/engine-gpg.c (build_argv): Don't add "--no-sk-comments" to argv.

2023-01-05  Ingo Klöcker  <dev@ingo-kloecker.de>

	qt: Fix comparisons of integer expressions of different signedness.
	+ commit 64da77620a451653e9b8c41bb0c9e58e22967123
	* lang/qt/tests/t-import.cpp (ImportTest::testImportWithImportFilter): Make integer literal unsigned.

	cpp: Fix comparisons of integer expressions of different signedness.
	+ commit 2e9d72a0be8579d6f1d3c74c64873a9c2f844272
	* lang/cpp/src/gpgrevokekeyeditinteractor.cpp (GpgRevokeKeyEditInteractor::Private::nextState): Cast signed nextLine value to std::size_t.

	cpp: Expliticly declare compiler generated copy constructors.
	+ commit dc9cc9aa0754d834388acabb5a68677f6512b960
	* lang/cpp/src/configuration.h (Component, Option), lang/cpp/src/data.h (Data), lang/cpp/src/decryptionresult.h (DecryptionResult, DecryptionResult::Recipient), lang/cpp/src/encryptionresult.h (EncryptionResult, InvalidRecipient), lang/cpp/src/engineinfo.h (EngineInfo), lang/cpp/src/importresult.h (ImportResult, Import), lang/cpp/src/key.h (Key, Subkey, UserID, UserID::Signature), lang/cpp/src/keygenerationresult.h (KeyGenerationResult), lang/cpp/src/keylistresult.h (KeyListResult), lang/cpp/src/notation.h (Notation), lang/cpp/src/signingresult.h (SigningResult, InvalidSigningKey, CreatedSignature), lang/cpp/src/swdbresult.h (SwdbResult), lang/cpp/src/tofuinfo.h (TofuInfo), lang/cpp/src/verificationresult.h (VerificationResult, Signature), lang/cpp/src/vfsmountresult.h (VfsMountResult): Explitily declare compiler generated copy constructor.

	qt: Replace Q_DECL_OVERRIDE with override.
	+ commit e16c368758e54b99d88529d3a10cecf36ed995b8
	* lang/qt/src/defaultkeygenerationjob.h, lang/qt/src/hierarchicalkeylistjob.h, lang/qt/src/multideletejob.h, lang/qt/src/protocol_p.h, lang/qt/src/qgpgmeadduseridjob.h, lang/qt/src/qgpgmechangeexpiryjob.h, lang/qt/src/qgpgmechangeownertrustjob.h, lang/qt/src/qgpgmechangepasswdjob.h, lang/qt/src/qgpgmedecryptjob.h, lang/qt/src/qgpgmedecryptverifyjob.h, lang/qt/src/qgpgmedeletejob.h, lang/qt/src/qgpgmedownloadjob.h, lang/qt/src/qgpgmeencryptjob.h, lang/qt/src/qgpgmeexportjob.h, lang/qt/src/qgpgmegpgcardjob.h, lang/qt/src/qgpgmeimportfromkeyserverjob.h, lang/qt/src/qgpgmeimportjob.h, lang/qt/src/qgpgmekeyformailboxjob.h, lang/qt/src/qgpgmekeygenerationjob.h, lang/qt/src/qgpgmekeylistjob.h, lang/qt/src/qgpgmelistallkeysjob.h, lang/qt/src/qgpgmenewcryptoconfig.h, lang/qt/src/qgpgmequickjob.h, lang/qt/src/qgpgmerefreshsmimekeysjob.h, lang/qt/src/qgpgmesignencryptjob.h, lang/qt/src/qgpgmesignjob.h, lang/qt/src/qgpgmesignkeyjob.h, lang/qt/src/qgpgmetofupolicyjob.h, lang/qt/src/qgpgmeverifydetachedjob.h, lang/qt/src/qgpgmeverifyopaquejob.h, lang/qt/src/qgpgmewkdlookupjob.h, lang/qt/src/qgpgmewkspublishjob.h, lang/qt/src/threadedjobmixin.h, lang/qt/tests/t-support.h: Replace Q_DECL_OVERRIDE with override

	qt: Allow deferred start of import job.
	+ commit 398375a0ab3b819694435c2e46b759d56b3735e0
	* lang/qt/src/importjob.h (ImportJob::startLater): New pure virtual method.
	* lang/qt/src/qgpgmeimportjob.cpp, lang/qt/src/qgpgmeimportjob.h (QGpgMEImportJob::startLater): New method.

	* lang/qt/tests/t-import.cpp (ImportTest::testDeferredStart): New.

2023-01-04  Ingo Klöcker  <dev@ingo-kloecker.de>

	qt: Support deferred start of jobs.
	+ commit 18c2c0b2509069951829bb0bdd9b39dc467f5e6e
	* lang/qt/src/job.cpp, lang/qt/src/job.h (Job::startNow): New method.
	* lang/qt/src/job_p.h (JobPrivate::start): New pure virtual method.
	* lang/qt/src/qgpgmechangeexpiryjob.cpp (QGpgMEChangeExpiryJobPrivate::start): New.
	* lang/qt/src/qgpgmeencryptjob.cpp (QGpgMEEncryptJobPrivate::start): New.
	* lang/qt/src/qgpgmeimportjob.cpp (QGpgMEImportJobPrivate::start): New.
	* lang/qt/src/qgpgmelistallkeysjob.cpp (QGpgMEListAllKeysJobPrivate::start): New.
	* lang/qt/src/qgpgmesignencryptjob.cpp (QGpgMESignEncryptJobPrivate::start): New.
	* lang/qt/src/threadedjobmixin.h (Thread::hasFunction): New method. (ThreadedJobMixin::run, ThreadedJobMixin::setWorkerFunction): New methods.

	qt: Explicitly instantiate private job classes.
	+ commit 270d7523001a57a59ea0be617d8e71d4363e0d50
	* lang/qt/src/Makefile.am: Add new files.
	* lang/qt/src/changeexpiryjob_p.h, lang/qt/src/encryptjob_p.h, lang/qt/src/importjob_p.h, lang/qt/src/listallkeysjob_p.h, lang/qt/src/signencryptjob_p.h: New.
	* lang/qt/src/changeexpiryjob.cpp, lang/qt/src/encryptjob.cpp, lang/qt/src/importjob.cpp, lang/qt/src/listallkeysjob.cpp, lang/qt/src/signencryptjob.cpp: Move JobPrivate subclasses to the new private header files.
	* lang/qt/src/job_p.h (jobPrivate): Remove lazy instantiation of private job classes.
	* lang/qt/src/qgpgmechangeexpiryjob.cpp (class QGpgMEChangeExpiryJobPrivate): New. (QGpgMEChangeExpiryJob::QGpgMEChangeExpiryJob): Instantiate private job class.
	* lang/qt/src/qgpgmeencryptjob.cpp (class QGpgMEEncryptJobPrivate): New. (QGpgMEEncryptJob::QGpgMEEncryptJob): Instantiate private job class.
	* lang/qt/src/qgpgmeimportjob.cpp (class QGpgMEImportJobPrivate): New. (QGpgMEImportJob::QGpgMEImportJob): Instantiate private job class.
	* lang/qt/src/qgpgmelistallkeysjob.cpp (class QGpgMEListAllKeysJobPrivate): New. (QGpgMEListAllKeysJob::QGpgMEListAllKeysJob): Instantiate private job class.
	* lang/qt/src/qgpgmesignencryptjob.cpp (class QGpgMESignEncryptJobPrivate): New. (QGpgMESignEncryptJob::QGpgMESignEncryptJob): Instantiate private job class.

2022-12-08  Ingo Klöcker  <dev@ingo-kloecker.de>

	cpp: Handle status errors in the base edit interactor.
	+ commit e7953dcf1376631719c73d9fa34bcb96752d3794
	* lang/cpp/src/editinteractor.cpp (edit_interactor_callback_impl): Handle status errors.
	* lang/cpp/src/gpgrevokekeyeditinteractor.cpp (GpgRevokeKeyEditInteractor::Private::nextState): Remove handling of status errors.

	cpp: Handle statuses that need no response in the base edit interactor.
	+ commit c419376b85ff4a489f3bf7ad97ed656495792523
	* lang/cpp/src/editinteractor.cpp (edit_interactor_callback_impl): Do not call nextState() if status needs no response.
	* lang/cpp/src/gpgaddexistingsubkeyeditinteractor.cpp (GpgAddExistingSubkeyEditInteractor::Private::nextState), lang/cpp/src/gpgadduserideditinteractor.cpp (GpgAddUserIDEditInteractor::nextState), lang/cpp/src/gpggencardkeyinteractor.cpp (GpgGenCardKeyInteractor::nextState), lang/cpp/src/gpgrevokekeyeditinteractor.cpp (GpgRevokeKeyEditInteractor::Private::nextState), lang/cpp/src/gpgsetexpirytimeeditinteractor.cpp (GpgSetExpiryTimeEditInteractor::nextState), lang/cpp/src/gpgsetownertrusteditinteractor.cpp (GpgSetOwnerTrustEditInteractor::nextState), lang/cpp/src/gpgsignkeyeditinteractor.cpp (GpgSignKeyEditInteractor::nextState): Remove handling of statuses that need no response.

2022-12-06  Ingo Klöcker  <dev@ingo-kloecker.de>

	qt: Write path values with Unix directory separators.
	+ commit d04d7b174fb7f27b7434cade22eafdd85b2d424e
	* lang/qt/src/qgpgmenewcryptoconfig.cpp (QGpgMENewCryptoConfigEntry::setURLValue): Remove conversion to native directory separators.

2022-11-25  NIIBE Yutaka  <gniibe@fsij.org>

	gpgme.m4: Fix AM_PATH_GPGME_PTHREAD.
	+ commit f9cbf2c8a839d2c3df20157cfe65b67a4b0bcb5a
	* src/gpgme.m4 (AM_PATH_GPGME_PTHREAD): It's deprecated, since gpgme supports threads and GNU C library has integrated pthread features.

2022-11-15  Ingo Klöcker  <dev@ingo-kloecker.de>

	core: Allow nullptr for key on card-edit.
	+ commit 5903fa454a47d788432192a7860b90b57efd6a10
	* src/edit.c (interact_start, edit_start): Return error if key is null on edit-key.

2022-11-15  NIIBE Yutaka  <gniibe@fsij.org>

	gpgme.m4: Include _AM_PATH_GPGRT_CONFIG implementation.
	+ commit abd51848bdc8a5ea5929f9cfb819a408dc53d463
	* src/gpgme.m4 (_AM_PATH_GPGRT_CONFIG): New. (_AM_PATH_GPGME_CONFIG): Require _AM_PATH_GPGRT_CONFIG.

	m4: Update gpg-error.m4.
	+ commit 2b7fcbf2f280ca88d76f8398138580155213552a
	* m4/gpg-error.m4: Update from libgpg-error master.

2022-11-11  Ingo Klöcker  <dev@ingo-kloecker.de>

	core: Check for nullptr.
	+ commit 6bcfbb3498f02dc86370cd4f2e3ccc5f9163d51a
	* src/edit.c (interact_start, edit_start): Return error if key is null.

2022-11-04  Ingo Klöcker  <dev@ingo-kloecker.de>

	qt: Allow disabling automatic trust database check on key listing.
	+ commit b6593bda1f7bfaf6cf3b869b8379cbb2b619e00a
	* lang/qt/src/Makefile.am (qgpgme_sources): Add listallkeysjob.cpp.
	* lang/qt/src/listallkeysjob.cpp: New.
	* lang/qt/src/listallkeysjob.h (enum ListAllKeysJob::Option, typedef ListAllKeysJob::Options, ListAllKeysJob::setOptions, ListAllKeysJob::options): New.
	* lang/qt/src/qgpgmelistallkeysjob.cpp (list_keys): Set context flag "no-auto-check-trustdb" if requested. (QGpgMEListAllKeysJob::start, QGpgMEListAllKeysJob::exec): Add options to call of list_keys.

	core: New context flag "no-auto-check-trustdb"
	+ commit 4f874ea431ba68ba70cf569741488502b1f61e66
	* src/context.h (gpgme_context): Add field no_auto_check_trustdb.
	* src/gpgme.c (gpgme_set_ctx_flag, gpgme_get_ctx_flag): Add flag "no-auto-check-trustdb".
	* src/engine-gpg.c (engine_gpg): Add flags.no_auto_check_trustdb. (gpg_set_engine_flags): Set the flag. (build_argv): Pass option to gpg.

	* tests/run-keylist.c (show_usage, main): Add option --no-trust-check.

2022-11-02  NIIBE Yutaka  <gniibe@fsij.org>

	build: Update libassuan.m4.
	+ commit 9f5e11729260b814c4903e2fbccfb3855073abd2
	* m4/libassuan.m4: Update from libassuan master.

	build: Prefer gpgrt-config when available.
	+ commit 9f55dceca0cf2926d14cb4a70bd0cdc454d89f03
	* src/gpgme.m4: Overriding the decision by --with-gpgme-prefix, use gpgrt-config gpgme when gpgrt-config is available.

2022-10-26  Werner Koch  <wk@gnupg.org>

	core: New global flags "inst-type".
	+ commit 1c9694f8d50b1236d2e4f2acbe23f972da36e437
	* src/gpgme.c (gpgme_set_global_flag): Add flag "inst-type".
	* src/w32-util.c (_gpgme_set_get_inst_type): New. (INST_TYPE_GPG4WIN_DIR): New. (INST_TYPE_GPGDESK_DIR): New. (_gpgme_get_gpgconf_path): Implement this flag.  Replace fixed strings by the macros.
	* src/posix-util.c (_gpgme_set_get_inst_type): New dummy.

2022-10-26  NIIBE Yutaka  <gniibe@fsij.org>

	python: Fix configure generating setup.py.
	+ commit f1802682c3c8794edaca37966405bd1f070f5e01
	* lang/python/setup.py.in: Handle the case, when substitutions may be empty.

2022-10-24  Werner Koch  <wk@gnupg.org>

	core: Protect against a theoretical integer overflow in parsetlv.c.
	+ commit 830e017e5d5f51d956d1188860302655f3e727e9
	* src/parsetlv.c (_gpgme_parse_tlv): Detect integer overflow.

2022-10-24  Ingo Klöcker  <dev@ingo-kloecker.de>

	cpp: Allow setting the curve to use when generating ECC keys.
	+ commit d9ac1385950217893be6f0d6fdb3324b8647d16b lang/cpp/src/gpggencardkeyinteractor.h (class GpgGenCardKeyInteractor): Add enum Curve. Add member function setCurve. lang/cpp/src/gpggencardkeyinteractor.cpp (class GpgGenCardKeyInteractor::Private): Initialize simple members in-class. Add member curve. (GpgGenCardKeyInteractor::~GpgGenCardKeyInteractor): Use default d'tor. (GpgGenCardKeyInteractor::setCurve): New. (GpgGenCardKeyInteractor::action): Return curve defaulting to Curve25519.

2022-10-24  NIIBE Yutaka  <gniibe@fsij.org>

	build: Update gpg-error.m4.
	+ commit d36905bb80c43987f2ca6980d3973d2111f89991
	* m4/gpg-error.m4: Update from libgpg-error 1.46.

2022-10-14  Ingo Klöcker  <dev@ingo-kloecker.de>

	build,qt: Check whether building with -fPIC is needed.
	+ commit 2ff09f474fb908dff83cce79c9d84b4fa21f5d7b m4/qt6.m4: Use build test to check whether -fPIC is needed for building a Qt application.

	build,qt: Fail check for Qt if moc wasn't found.
	+ commit 1792db58346cb39fd99332478d56dc190bae7836
	* m4/qt5.m4, m4/qt6.m4: Perform build test only if moc was found.

	build,qt: Always compile the Qt 6 test application with -fpic.
	+ commit f7a46714283bb8c107c68d0f1227abfe223b2365
	* m4/qt6.m4: Do not add -fpic to GPGME_QT6_CFLAGS. Add -fpic to CPPFLAGS used for build test of simple Qt 6 application.

2022-10-11  Ingo Klöcker  <dev@ingo-kloecker.de>

	build,qt: Clean up all generated files.
	+ commit e6a1b241b4e6a0a677ed8f0e4e287a5cc82d7fbb
	* lang/qt/src/Makefile.am (CLEANFILES): Add QGpgmeConfig-w32.cmake.in and QGpgmeQt6Config-w32.cmake.in.

	qt,tests: Port test to QRegularExpression.
	+ commit b2fb26baeada7b39331f71a30c654bfb8b53cb30
	* lang/qt/tests/t-trustsignatures.cpp: Use QRegularExpression instead of QRegExp.

	qt: Remove obsolete code.
	+ commit 4938c24a466bf05e707d3e6cbf759705adc7e8d6
	* lang/qt/src/qgpgmenewcryptoconfig.cpp (struct Select1St): Remove.

	build,qt: Allow building QGpgME for Qt 6.
	+ commit 8d019bbb8d40de2cbed7ad6d3367c6a46a561fab
	* configure.ac: Look for Qt 5 and/or Qt 6. Require C++17 if Qt 6 binding is built. Build cmake files QGpgmeConfig* for Qt 5 and QGpgmeQt6Config* for Qt 6. (available_languages): Add "qt5" and "qt6". (WANT_QT5, WANT_QT6): New conditionals.
	* lang/qt/src/Makefile.am: Keep building libqgpgme for Qt 5. Build libqgpgmeqt6 for Qt 6.
	* lang/qt/tests/Makefile.am: Build tests for Qt 5 or Qt 6.
	* lang/qt/src/QGpgmeQt6Config-w32.cmake.in.in, lang/qt/src/QGpgmeQt6Config.cmake.in.in, lang/qt/src/QGpgmeQt6ConfigVersion.cmake.in, m4/qt6.m4: New.

2022-10-10  Ingo Klöcker  <dev@ingo-kloecker.de>

	build,qt: Explicitly namespace a few Qt variables for Qt5.
	+ commit 8e908029ffa03d21662030d3111dcf556b722e1a m4/qt.m4: Rename to m4/qt5.m4: this. (FIND_QT): Rename to FIND_QT5. (GPGME_QT): Change variable prefix to GPGME_QT5. (GPGME_QTTEST: Change variable prefix to GPGME_QT5TEST. configure.ac, lang/qt/src/Makefile.am, lang/qt/tests/Makefile.am: Adjust accordingly.

2022-09-29  Werner Koch  <wk@gnupg.org>

	core: Fix SIG_CREATED status parsing for 0x1F sigs.
	+ commit b1e5f3b183104a58d71821b7dbe44244d1c3f87f
	* src/sign.c (parse_sig_created): Special case the rfc4880 "1F" status.

2022-09-15  NIIBE Yutaka  <gniibe@fsij.org>

	build:python: Don't use gpg-error-config/gpgme-config.
	+ commit ae9258fbf3b9d434495ef11fc184a91fe7c4ca57
	* lang/python/setup.py.in: Use @prefix@, @GPGME_CONFIG_LIBS@, @GPGME_CONFIG_CFLAGS@, and @GPG_ERROR_CFLAGS@ of configure.

	Fix for modern compiler.
	+ commit fbd94076461ec55603d741121fa2ff6a861ea803
	* src/argparse.c (show_version): It's no args.

2022-09-14  Ingo Klöcker  <dev@ingo-kloecker.de>

	cpp: Reject signing expired keys.
	+ commit eedaaf70167f5dd7d8438235139b57527d3a961b
	* lang/cpp/src/gpgsignkeyeditinteractor.cpp (enum SignKeyState): Add new state REJECT_SIGN_EXPIRED. (makeTable): Add entries for new state to transition map. (GpgSignKeyEditInteractor::action): Handle new state.

2022-09-07  NIIBE Yutaka  <gniibe@fsij.org>

	Fix parsing import status for invalid fingerprint.
	+ commit 80670f60ba971145dd6792e00d31c08c10cc8159
	* src/import.c (parse_import): Handle invalid fingerprint case.

2022-08-22  Ingo Klöcker  <dev@ingo-kloecker.de>

	build: Omit -I... and -L... for standard paths in pkgconfig file.
	+ commit 1522813888257aafb6d108b49fb7b24005d2693a
	* configure.ac (GPGME_CONFIG_CFLAGS): Prefix with -I${includedir} for non-standard include paths. (GPGME_CONFIG_LIBS): Prefix with -L${libdir} for non-standard library paths.
	* src/gpgme.pc.in (Cflags): Remove hard-coded -I${includedir}. (Libs): Remove hard-coded -L${libdir}.

	build: Update ax_cxx_compile_stdcxx macro.
	+ commit 73e96bfaa8176cf7b18bfa9edacaaf8d26989998
	* m4/ax_cxx_compile_stdcxx.m4: Replace with current version from the autoconf archive.

	qt: Fix building with C++11.
	+ commit 83176ad7d3e57ad7804d3c885e1b4fcd1d4d96f9
	* lang/qt/src/qgpgmerefreshsmimekeysjob.cpp (QGpgMERefreshSMIMEKeysJob::start): Replace 'auto' in lambda with the actual type.
	* lang/qt/src/qgpgmesignkeyjob.cpp (class TrustSignatureProperties): Add default c'tor and c'tor initializing all members.
	* lang/qt/src/util.cpp (toFingerprints): Replace 'auto' in lambda with the actual type.
	* lang/qt/tests/run-exportjob.cpp (createExportJob): Replace 'auto' return type with actual type.

	qt: Fix building with Qt6.
	+ commit 05661806848b8a6ef9005e4a420d8613ddc868f1
	* lang/qt/src/util.cpp, lang/qt/src/util.h: Replace forward declaration with include.

2022-08-19  Ingo Klöcker  <dev@ingo-kloecker.de>

	cpp: Fix building with C++11.
	+ commit f02c20cc9c5756690b07abfd02a43533547ba2ef
	* lang/cpp/src/importresult.cpp (ImportResult::mergeWith): Replace 'auto' in lambdas with the actual type.

2022-08-18  Ingo Klöcker  <dev@ingo-kloecker.de>

	qt,tests: Make test pass on 32-bit systems.
	+ commit 2e7a61b898fccc1c20000b79dee83cd980901fa9
	* lang/qt/tests/t-addexistingsubkey.cpp (AddExistingSubkeyJobTest::testAddExistingSubkeyWithExpiration): Handle negative expiration date.

	cpp: Fix handling of "no key" or "invalid time" situations.
	+ commit 2fa5c80aeba4528b3bdf41ec5740e7db5d4b6d2b
	* lang/cpp/src/gpgaddexistingsubkeyeditinteractor.cpp (GpgAddExistingSubkeyEditInteractor::Private::nextState): Fix inverted logic of string comparisons.

2022-08-17  Ingo Klöcker  <dev@ingo-kloecker.de>

	qt,tests: Make sure expiration time is interpreted as unsigned number.
	+ commit f2b48de26b8f8c48c293423eda712831544924f6
	* lang/qt/tests/t-addexistingsubkey.cpp, lang/qt/tests/t-changeexpiryjob.cpp: Convert expiration time to uint_least32_t.

	qt,tests: Log the actual error code if the assertion fails.
	+ commit 81d4b7f2d7077297d76af5728949d8f2bdff8cd5
	* lang/qt/tests/t-addexistingsubkey.cpp ( AddExistingSubkeyJobTest::testAddExistingSubkeyAsync, AddExistingSubkeyJobTest::testAddExistingSubkeySync, AddExistingSubkeyJobTest::testAddExistingSubkeyWithExpiration): Use QCOMPARE instead of QVERIFY for asserting equality.

	qt: Make sure expiration time is interpreted as unsigned number.
	+ commit c977424a1d39751fc5055131ad3f7819d421dcc8
	* lang/qt/src/qgpgmeaddexistingsubkeyjob.cpp (add_subkey): Convert expiration time to uint_least32_t.

2022-08-12  Andre Heinecke  <aheinecke@gnupg.org>

	w32: Add another fallback to look for gpgconf.exe.
	+ commit 5f51a9b4589200486b2833124cbd93455f6ce208
	* src/w32-util.c (_gpgme_get_gpgconf_path): Add fallback for GnuPG VS-Desktop install scheme.

2022-08-11  Andre Heinecke  <aheinecke@gnupg.org>

	Qt: Fix working with no gpgconf in CryptoConfig.
	+ commit 586846209b08ce5e9545f53f21de884eb4079115
	* lang/qt/src/cryptoconfig.cpp (CryptoConfig::entry): Add nullptr checks.
