### PR TITLE
micropython: fix stackctrl compilation for GCC 13

### DIFF
--- a/lang/python/micropython/patches/050-py-stackctrl-fix-gcc-13.patch
+++ b/lang/python/micropython/patches/050-py-stackctrl-fix-gcc-13.patch
@@ -1,0 +1,31 @@
+From f1c6cb7725960487195daa5c5c196fd8d3563811 Mon Sep 17 00:00:00 2001
+From: Damien George <damien@micropython.org>
+Date: Wed, 3 May 2023 15:23:24 +1000
+Subject: [PATCH] py/stackctrl: Add gcc pragmas to ignore dangling-pointer
+ warning.
+
+This warning became apparent in gcc 13.
+
+Signed-off-by: Damien George <damien@micropython.org>
+---
+ py/stackctrl.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+--- a/py/stackctrl.c
++++ b/py/stackctrl.c
+@@ -28,8 +28,15 @@
+ #include "py/stackctrl.h"
+ 
+ void mp_stack_ctrl_init(void) {
++    #if __GNUC__ >= 13
++    #pragma GCC diagnostic push
++    #pragma GCC diagnostic ignored "-Wdangling-pointer"
++    #endif
+     volatile int stack_dummy;
+     MP_STATE_THREAD(stack_top) = (char *)&stack_dummy;
++    #if __GNUC__ >= 13
++    #pragma GCC diagnostic pop
++    #endif
+ }
+ 
+ void mp_stack_set_top(void *top) {


### PR DESCRIPTION
Maintainer: @jefferyto jefferyto
Compile tested: arm, bcm27xx-bcm2708 (rpi), OpenWrt master
Run tested: N/A

Description:
On host PC using GCC 13, stackctrl.c fails to compile with the following error:
../py/stackctrl.c: In function 'mp_stack_ctrl_init': ../py/stackctrl.c:32:32: error: storing the address of
   local variable 'stack_dummy'
   in 'mp_state_ctx.thread.stack_top' [-Werror=dangling-pointer=]
   32 |     MP_STATE_THREAD(stack_top) = (char *)&stack_dummy;
../py/stackctrl.c:31:18: note: 'stack_dummy' declared here
   31 |     volatile int stack_dummy;
      |                  ^~~~~~~~~~~
In file included from ../py/runtime.h:29,
                 from ../py/stackctrl.c:27:
../py/mpstate.h:296:23: note: 'mp_state_ctx' declared here
  296 | extern mp_state_ctx_t mp_state_ctx;
      |                       ^~~~~~~~~~~~
cc1: all warnings being treated as errors

Fixed accordingly by ignoring -dangling-pointer warning inside mp_stack_ctrl_init function.

