### PR TITLE
file: fix libmagic compilation

### DIFF
--- a/libs/file/Makefile
+++ b/libs/file/Makefile
@@ -43,7 +43,7 @@ $(call Package/file/Default)
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE+= library
-  DEPENDS:=+zlib +liblzma +libbz2
+  DEPENDS:=+zlib +liblzma +libbz2 +libzstd
 endef
 
 TARGET_CFLAGS += $(FPIC)


### PR DESCRIPTION
Maintainer:  @ratkaj 
Compile tested: Compile tested: arm, bcm27xx-bcm2708 (rpi), OpenWrt master
Run tested: N/A

Description:
Upon compiling file package, observed that libmagic fails to complete its compilation complaining about missing libzstd.so.1 dependency as follows:

Package libmagic is missing dependencies for the following libraries: libzstd.so.1
make[2]: *** [Makefile:117:
/data/build/openwrt/bin/packages/arm_arm1176jzf-s_vfp/packages/ libmagic_5.44-1_arm_arm1176jzf-s_vfp.ipk] Error 1

make[2]: Leaving directory '/data/build/openwrt/feeds/packages/libs/file'
time: package/feeds/packages/file/compile#8.65#3.23#11.17
    ERROR: package/feeds/packages/file failed to build.

make[1]: *** [package/Makefile:120: package/feeds/packages/file/compile]
 Error 1
make[1]: Leaving directory '/data/build/openwrt'
make: *** [/data/build/openwrt/include/toplevel.mk:232:
 package/file/compile] Error 2

Fix by adding libzstd to libmagic dependencies


