### PR TITLE
v2fly-geodata: add package v2ray-geosite-ir

### DIFF
--- a/net/v2ray-geodata/Makefile
+++ b/net/v2ray-geodata/Makefile
@@ -30,6 +30,15 @@ define Download/geosite
   HASH:=3d335d493f168eace5414ca1ff54e4f255f8e5b1a90261d2debb1cbefa0666a0
 endef
 
+GEOSITE_IR_VER:=202307310028
+GEOSITE_IR_FILE:=iran.dat.$(GEOSITE_IR_VER)
+define Download/geosite-ir
+  URL:=https://github.com/bootmortis/iran-hosted-domains/releases/download/$(GEOSITE_IR_VER)/
+  URL_FILE:=iran.dat
+  FILE:=$(GEOSITE_IR_FILE)
+  HASH:=91788a5bdb7b103d3a7207a3b63351782ea5b8801aea5e1b579697590674c5cf
+endef
+
 define Package/v2ray-geodata/template
   SECTION:=net
   CATEGORY:=Network
@@ -54,6 +63,14 @@ define Package/v2ray-geosite
   LICENSE:=MIT
 endef
 
+define Package/v2ray-geosite-ir
+  $(call Package/v2ray-geodata/template)
+  TITLE:=Iran Geosite List for V2Ray
+  PROVIDES:=xray-geosite-ir
+  VERSION:=$(GEOSITE_IR_VER)-$(PKG_RELEASE)
+  LICENSE:=MIT
+endef
+
 define Build/Prepare
 	$(call Build/Prepare/Default)
 ifneq ($(CONFIG_PACKAGE_v2ray-geoip),)
@@ -61,6 +78,9 @@ ifneq ($(CONFIG_PACKAGE_v2ray-geoip),)
 endif
 ifneq ($(CONFIG_PACKAGE_v2ray-geosite),)
 	$(call Download,geosite)
+endif
+ifneq ($(CONFIG_PACKAGE_v2ray-geosite-ir),)
+	$(call Download,geosite-ir)
 endif
 endef
 
@@ -79,5 +99,12 @@ define Package/v2ray-geosite/install
 	$(LN) ../v2ray/geosite.dat $(1)/usr/share/xray/geosite.dat
 endef
 
+define Package/v2ray-geosite-ir/install
+	$(INSTALL_DIR) $(1)/usr/share/v2ray $(1)/usr/share/xray
+	$(INSTALL_DATA) $(DL_DIR)/$(GEOSITE_IR_FILE) $(1)/usr/share/v2ray/iran.dat
+	$(LN) ../v2ray/iran.dat $(1)/usr/share/xray/iran.dat
+endef
+
 $(eval $(call BuildPackage,v2ray-geoip))
 $(eval $(call BuildPackage,v2ray-geosite))
+$(eval $(call BuildPackage,v2ray-geosite-ir))


### PR DESCRIPTION
"Iran Hosted Domains" is a comprehensive list of Iranian domains and services that are hosted within the country.  
usage: ext:iran.dat:ir

Maintainer: @1715173329  
Compile tested: (x86,mediatek,ath79, 22.03.5,23.05.0-rc2, snapshot)
Run tested: (x86,mediatek,ath79, 22.03.5,23.05.0-rc2, snapshot)

Description:
"Iran Hosted Domains" is a comprehensive list of Iranian domains and services that are hosted within the country and and work similarly to the present geosite list.
