### PR TITLE
python-jmespath: Update to 1.0.1

### DIFF
--- a/lang/python/python-jmespath/Makefile
+++ b/lang/python/python-jmespath/Makefile
@@ -1,14 +1,15 @@
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=jmespath
-PKG_VERSION:=0.9.3
-PKG_RELEASE:=2
+PKG_NAME:=python-jmespath
+PKG_VERSION:=1.0.1
+PKG_RELEASE:=1
 
-PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64
+PYPI_NAME:=jmespath
+PKG_HASH:=90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe
 
 PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
 PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.txt
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -18,14 +19,14 @@ define Package/python3-jmespath
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  TITLE:=jmespath
+  TITLE:=JSON Matching Expressions
   URL:=https://github.com/jmespath/jmespath.py
-  DEPENDS:=+python3
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-jmespath/description
-  JMESPath (pronounced “james path”) allows you to declaratively specify how to extract
-  elements from a JSON document.
+JMESPath (pronounced “james path”) allows you to declaratively specify
+how to extract elements from a JSON document.
 endef
 
 $(eval $(call Py3Package,python3-jmespath))


### PR DESCRIPTION
Maintainer: @dddaniel
Compile tested: armsr-armv7, 2023-08-06 snapshot sdk
Run tested: armsr-armv7 (qemu), 2023-08-06 snapshot

Description:
This also updates the Python dependency from python3 to python3-light.