### PR TITLE
tunneldigger-broker updates

### DIFF
--- a/net/tunneldigger-broker/Makefile
+++ b/net/tunneldigger-broker/Makefile
@@ -5,14 +5,12 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://github.com/wlanslovenija/tunneldigger.git
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=4f72b30578ac3dbc5482f4a54054bf870355bdf5
-PKG_MIRROR_HASH:=e93b986b60475c16b0022ba4f5da981929cc3d6992c632f41264804912825473
+PKG_SOURCE_VERSION:=v0.4.0
+PKG_MIRROR_HASH:=c67a0e626cec571823085a7a28bc72fcaa077669cac52c441b0dde02d676e16c
 
 PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
 PKG_LICENSE:=AGPL-3.0
 PKG_LICENSE_FILES:=COPYING
-
-PKG_BUILD_DEPENDS:=python-cffi/host
 
 include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -22,22 +20,18 @@ define Package/tunneldigger-broker
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:= \
-	+ip-full \
+	+ip \
 	+kmod-l2tp \
-	+kmod-l2tp-ip \
 	+kmod-l2tp-eth \
 	+kmod-sched \
-	+libnetfilter-conntrack \
 	+libnfnetlink \
 	+libnl-tiny \
 	+libpthread \
 	+librt \
-	+python3-cffi \
 	+python3-ctypes \
 	+python3-light \
 	+python3-logging \
-	+python3-six \
-	+tc-full
+	+tc-tiny
   TITLE:=Broker for L2TPv3 tunnels using tunneldigger
   URL:=https://github.com/wlanslovenija/tunneldigger
 endef
@@ -48,7 +42,7 @@ support for L2TPv3 tunnels over UDP. This package contains the broker.
 endef
 
 PYTHON3_PKG_SETUP_DIR:=broker
-PYTHON3_PKG_WHEEL_VERSION:=0.4.0.dev1
+PYTHON3_PKG_WHEEL_VERSION:=0.4.0
 
 define Py3Package/tunneldigger-broker/install
 	$(INSTALL_DIR) $(1)/lib/functions
@@ -57,6 +51,7 @@ define Py3Package/tunneldigger-broker/install
 	$(INSTALL_BIN) ./files/hook-setup $(1)/usr/lib/tunneldigger-broker/hooks/setup
 	$(INSTALL_BIN) ./files/hook-teardown $(1)/usr/lib/tunneldigger-broker/hooks/teardown
 	$(INSTALL_BIN) ./files/hook-mtu-changed $(1)/usr/lib/tunneldigger-broker/hooks/mtu-changed
+	$(INSTALL_BIN) ./files/hook-connection-rate-limit $(1)/usr/lib/tunneldigger-broker/hooks/connection-rate-limit
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/tunneldigger-broker.init $(1)/etc/init.d/tunneldigger-broker
 	$(INSTALL_DIR) $(1)/etc/config

--- a/net/tunneldigger-broker/files/config.default
+++ b/net/tunneldigger-broker/files/config.default
@@ -3,16 +3,23 @@ config broker
 	list port '123'
 	list port '8942'
 	option interface 'loopback'
-	option max_cookies '1024'
 	option max_tunnels '1024'
-	option port_base '20000'
 	option tunnel_id_base '100'
-	option tunnel_timeout '60'
 	option pmtu '0'
-	option namespace 'production'
 	option connection_rate_limit '0.2'
+	option connection_rate_limit_per_ip_count '0'
+	option connection_rate_limit_per_ip_time '0'
 
 config log
-	option filename '/dev/null'
 	option verbosity 'INFO'
 	option log_ip_addresses '0'
+
+# To automatically put tunnel interfaces into pre-exitsing bridges
+# via the hook scripts, then create a bridge section for each 
+# supported mtu.  If pmtu is set to non-zero above, then only that 
+# bridge is needed.  To isolate the bridge ports, set isolate to '1'.
+# '0' is the default
+#config bridge
+#	option interface 'br-mybridge'
+#	option mtu '1446'
+#	option isolate '1'

--- a/net/tunneldigger-broker/files/hook-connection-rate-limit
+++ b/net/tunneldigger-broker/files/hook-connection-rate-limit
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+ENDPOINT_IP="$1"
+ENDPOINT_PORT="$2"
+UUID="$3"
+
+# This assumes that an ipset was created with something like
+# ```
+# ipset create create tunneldigger_blocked hash:ip family inet timeout 300
+# ```
+# and that a firewall rule like the following uses the ipset to block connections:
+# ```
+# -A INPUT -m set --match-set tunneldigger_blocked src -j DROP
+# ```
+
+#ipset add tunneldigger_blocked "$ENDPOINT_IP"

--- a/net/tunneldigger-broker/files/hook-mtu-changed
+++ b/net/tunneldigger-broker/files/hook-mtu-changed
@@ -21,10 +21,14 @@ if [ -z "$new_bridge" ]; then
   exit 1
 fi
 
+# Get the isolation option for this bridge
+tunneldigger_get_bridge_isolate isolate "${NEW_MTU}"
+
 # Remove interface from old bridge.
 ip link set dev ${INTERFACE} nomaster
 ip link set dev ${old_bridge} mtu ${OLD_MTU}
 
 # Change interface bridge and MTU.
 ip link set dev ${INTERFACE} master ${new_bridge} mtu ${NEW_MTU}
+echo $isolate > /sys/class/net/${INTERFACE}/brport/isolated
 ip link set dev ${new_bridge} mtu ${NEW_MTU}

--- a/net/tunneldigger-broker/files/hook-setup
+++ b/net/tunneldigger-broker/files/hook-setup
@@ -13,9 +13,14 @@ if [ -z "$bridge" ]; then
   exit 1
 fi
 
+# Get the isolation option for this bridge
+tunneldigger_get_bridge_isolate isolate "${MTU}"
+
 # Disable IPv6 on this interface as it will be bridged.
 echo 1 > /proc/sys/net/ipv6/conf/${INTERFACE}/disable_ipv6
 # Add the interface to the proper bridge and bring it up.
 ip link set dev ${INTERFACE} master ${bridge} mtu ${MTU} up
+# Isolate the bridge port, if so configured
+echo $isolate > /sys/class/net/${INTERFACE}/brport/isolated
 # Ensure bridge MTU.
 ip link set dev ${bridge} mtu ${MTU}

--- a/net/tunneldigger-broker/files/tunneldigger-broker.init
+++ b/net/tunneldigger-broker/files/tunneldigger-broker.init
@@ -54,7 +54,7 @@ parse_broker() {
 		cfg_append_kv address "${address}"
 	}
 
-	OPTIONS="max_cookies max_tunnels port_base tunnel_id_base tunnel_timeout namespace connection_rate_limit pmtu"
+	OPTIONS="max_tunnels tunnel_id_base connection_rate_limit connection_rate_limit_per_ip_count connection_rate_limit_per_ip_time pmtu"
 	for option in ${OPTIONS}; do
 		cfg_append_option "$section" "${option}" "${option}"
 	done
@@ -66,13 +66,14 @@ parse_broker() {
 	cfg_append_kv "session.up" "${HOOKPATH}/setup"
 	cfg_append_kv "session.pre-down" "${HOOKPATH}/teardown"
 	cfg_append_kv "session.mtu-changed" "${HOOKPATH}/mtu-changed"
+	cfg_append_kv "broker.connection-rate-limit" "${HOOKPATH}/connection-rate-limit"
 }
 
 parse_log() {
 	local section="$1"
 	cfg_append_section log
 	
-	OPTIONS="filename verbosity"
+	OPTIONS="verbosity"
 	for option in ${OPTIONS}; do
 		cfg_append_option "$section" "${option}" "${option}"
 	done
@@ -97,8 +98,25 @@ start_service() {
 	procd_set_param command "/usr/bin/python"
 	procd_append_param command -m tunneldigger_broker.main
 	procd_append_param command "${CONFIGFILE}"
+
+	# Set up a trigger when the interface changes state
+	local netdev
+	network_get_physdev netdev $(uci show "tunneldigger-broker.@broker[0].interface" | cut -d \' -f 2)
+	procd_set_param netdev $netdev
+
 	procd_set_param respawn
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_close_instance
 }
+
+reload_service() {
+	restart
+}
+
+service_triggers() {
+	local interface=$(uci show "tunneldigger-broker.@broker[0].interface" | cut -d \' -f 2)
+	procd_add_interface_trigger "interface.*.up" $interface /etc/init.d/tunneldigger-broker restart
+	procd_add_reload_trigger "tunneldigger-broker"
+}
+

--- a/net/tunneldigger-broker/files/tunneldigger.sh
+++ b/net/tunneldigger-broker/files/tunneldigger.sh
@@ -11,12 +11,8 @@ tunneldigger_get_bridge() {
 	# Discover the configured bridge.
 	unset _td_bridge
 	_td_bridge=""
-	config_cb() {
-		local cfg="$CONFIG_SECTION"
-		config_get configname "$cfg" TYPE
-		if [ "$configname" != "bridge" ]; then
-			return
-		fi
+	handle_bridge() {
+		local cfg="$1"
 
 		config_get cfg_mtu "$cfg" mtu
 		config_get interface "$cfg" interface
@@ -29,11 +25,12 @@ tunneldigger_get_bridge() {
 	}
 
 	config_load tunneldigger-broker
-	reset_cb
+	config_foreach handle_bridge bridge $mtu
 	if [ -z "$_td_bridge" ]; then
 		return
 	fi
 
-	eval $variable=$_td_bridge
-	# network_get_device $variable $_td_bridge
+	variable="$_td_bridge"
+	export ${NO_EXPORT:+-n} "$1=$variable"
 }
+

--- a/net/tunneldigger-broker/files/tunneldigger.sh
+++ b/net/tunneldigger-broker/files/tunneldigger.sh
@@ -34,3 +34,37 @@ tunneldigger_get_bridge() {
 	export ${NO_EXPORT:+-n} "$1=$variable"
 }
 
+# Get the isolation option for this bridge
+tunneldigger_get_bridge_isolate() {
+	local variable="$1"
+	local mtr="$2"
+
+        # Overwrite the destination variable.
+        unset $variable
+
+        # Discover the configured bridge.
+        unset _isolate_bridge
+        _isolate_bridge=""
+        handle_bridge() {
+                local cfg="$1"
+
+                config_get cfg_mtu "$cfg" mtu
+                config_get isolate "$cfg" isolate 0
+
+                if [ "$cfg_mtu" != "$mtu" ]; then
+                        return
+                fi
+
+                _isolate_bridge="$isolate"
+        }
+
+        config_load tunneldigger-broker
+        config_foreach handle_bridge bridge $mtu
+        if [ -z "$_isolate_bridge" ]; then
+                return
+        fi
+
+        variable="$_isolate_bridge"
+        export ${NO_EXPORT:+-n} "$1=$variable"
+
+}


### PR DESCRIPTION
Maintainer: @PolynomialDivision 
Compile tested: X86-64, KVM-VM  Snapshot with the SDK
Run tested: X86-64, KVM-VM Snapshot with the imagebuilder

Description:
Update /lib/functions/tunneldigger.sh to use config_foreach and add a new function to determine if bridge ports should be isolated (default 0, or not isolated).  Add functionality to the setup and mtu_changed hooks to incorporate the new bridge port isolation settings. Update the default config file to match new settings in v0.4.0. Add new hook function for rate limiting.

A config bridge section can now look like this:

config bridge
    option interface 'br-mybridge1446'
    option mtu '1466'
    option isolate '1' # default 0


 