### PR TITLE
openvpn: add missing script event options to be used in the openvpn config file

### DIFF
--- a/net/openvpn/files/etc/hotplug.d/openvpn/01-user
+++ b/net/openvpn/files/etc/hotplug.d/openvpn/01-user
@@ -7,10 +7,14 @@
 		$*
 }
 
-# Wrap user defined scripts on up/down events
+# Wrap user defined scripts on up/down/route-up/route-pre-down/ipchange events
+# Scriptp set with up/down/route-up/route-pre-down/ipchange in the openvpn config are also executed with the command=user_xxxx
 case "$ACTION" in
 	up) command=$user_up ;;
 	down) command=$user_down ;;
+	route-up) command=$user_route_up ;;
+	route-pre-down) command=$user_route_pre_down ;;
+	ipchange) command=$user_ipchange ;;
 	*) command= ;;
 esac
 

--- a/net/openvpn/files/openvpn.init
+++ b/net/openvpn/files/openvpn.init
@@ -144,6 +144,9 @@ openvpn_add_instance() {
 	local security="$4"
 	local up="$5"
 	local down="$6"
+	local route_up="$7"
+	local route_pre_down="$8"
+	local ipchange="$9"
 	local client=$(grep -qEx "client|tls-client" "$dir/$conf" && echo 1)
 
 	procd_open_instance "$name"
@@ -159,6 +162,9 @@ openvpn_add_instance() {
 		${client:+--ipchange "/usr/libexec/openvpn-hotplug ipchange $name"} \
 		${up:+--setenv user_up "$up"} \
 		${down:+--setenv user_down "$down"} \
+		${route_up:+--setenv user_route_up "$route_up"} \
+		${route_pre_down:+--setenv user_route_pre_down "$route_pre_down"} \
+		${client:+${ipchange:+--setenv user_ipchange "$ipchange"}} \
 		--script-security "${security:-2}" \
 		$(openvpn_get_dev "$name" "$conf") \
 		$(openvpn_get_credentials "$name" "$conf")
@@ -182,9 +188,12 @@ start_instance() {
 		return 1
 	}
 
-	local up down script_security
+	local up down route_up route_pre_down ipchange script_security
 	config_get up "$s" up
 	config_get down "$s" down
+	config_get route_up "$s" route_up
+	config_get route_pre_down "$s" route_pre_down
+	config_get ipchange "$s" ipchange
 	config_get script_security "$s" script_security
 
 	[ ! -d "/var/run" ] && mkdir -p "/var/run"
@@ -193,7 +202,10 @@ start_instance() {
 		append UCI_STARTED "$config" "$LIST_SEP"
 		[ -n "$up" ] || get_openvpn_option "$config" up up
 		[ -n "$down" ] || get_openvpn_option "$config" down down
-		openvpn_add_instance "$s" "${config%/*}" "$config" "$script_security" "$up" "$down"
+		[ -n "$route_up" ] || get_openvpn_option "$config" route_up route-up
+		[ -n "$route_pre_down" ] || get_openvpn_option "$config" route_pre_down route-pre-down
+		[ -n "$ipchange" ] || get_openvpn_option "$config" ipchange ipchange
+		openvpn_add_instance "$s" "${config%/*}" "$config" "$script_security" "$up" "$down" "$route_up" "$route_pre_down" "$ipchange"
 		return
 	fi
 
@@ -203,7 +215,7 @@ start_instance() {
 	append_params "$s" $OPENVPN_PARAMS
 	append_list "$s" $OPENVPN_LIST
 
-	openvpn_add_instance "$s" "/var/etc" "openvpn-$s.conf" "$script_security" "$up" "$down"
+	openvpn_add_instance "$s" "/var/etc" "openvpn-$s.conf" "$script_security" "$up" "$down" "$route_up" "$route_pre_down" "$ipchange"
 }
 
 start_service() {
@@ -230,7 +242,7 @@ start_service() {
 	else
 		config_foreach start_instance 'openvpn'
 
-		local path name up down
+		local path name up down route_up route_pre_down ipchange
 		for path in /etc/openvpn/*.conf; do
 			if [ -f "$path" ]; then
 				name="${path##*/}"; name="${name%.conf}"
@@ -247,7 +259,11 @@ start_service() {
 
 				get_openvpn_option "$path" up up || up=""
 				get_openvpn_option "$path" down down || down=""
-				openvpn_add_instance "$name" "${path%/*}" "$path" "" "$up" "$down"
+				get_openvpn_option "$path" route_up route-up || route_up=""
+				get_openvpn_option "$path" route_pre_down route-pre-down || route_pre_down=""
+				get_openvpn_option "$path" ipchange ipchange || ipchange=""
+				openvpn_add_instance "$name" "${path%/*}" "$path" "" "$up" "$down" "$route_up" "$route_pre_down" "$ipchange"
+
 			fi
 		done
 	fi


### PR DESCRIPTION
Maintainer: @neheb @AuthorReflex
Compile tested: aarch64, cortex-a53, OpenWRT 23.05
Run tested: Dynalink DL-WRX36

Description:
[A previous commit](https://github.com/openwrt/packages/commit/f8a8b71e26b9bdbf86fbb7d4d1482637af7f3ba4) has added more script event options.
However it looked like that commit was not complete as it stops the use of the script events route-up, route-pre-down, and ipchange when those are placed in the openvpn config file.

The purpose of this patch is to add these script event options so that those can be used again when set in the openvpn config file (openvpn.ovpn) 
Discussion in [this thread](https://forum.openwrt.org/t/openvpn-custom-route-up-script-in-23-05-rc2/167105/13)

[Previous Pull request](https://github.com/openwrt/packages/pull/21732 ) has been discussed and improved with the help of @AuthorReflex 

Signed-off-by: Erik Conijn <egc6774@gmail.com>

