### PR TITLE
openssh: add server config subdirectory

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
 PKG_VERSION:=9.3p2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
@@ -103,6 +103,7 @@ endef
 
 define Package/openssh-server/conffiles
 /etc/ssh/sshd_config
+/etc/ssh/sshd_config.d/
 /etc/ssh/ssh_host_ed25519_key
 /etc/ssh/ssh_host_ed25519_key.pub
 /etc/ssh/ssh_host_rsa_key
@@ -223,7 +224,7 @@ define Package/openssh-keygen/install
 endef
 
 define Package/openssh-server/install
-	install -d -m0700 $(1)/etc/ssh
+	install -d -m0700 $(1)/etc/ssh $(1)/etc/ssh/sshd_config.d
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/ssh/sshd_config $(1)/etc/ssh/
 	sed -r -i 's,^#(HostKey /etc/ssh/ssh_host_(rsa|ed25519)_key)$$$$,\1,' $(1)/etc/ssh/sshd_config
 	$(INSTALL_DIR) $(1)/etc/init.d

--- a/net/openssh/patches/900-sshd_config-include-dir.patch
+++ b/net/openssh/patches/900-sshd_config-include-dir.patch
@@ -1,0 +1,11 @@
+--- a/sshd_config
++++ b/sshd_config
+@@ -10,6 +10,8 @@
+ # possible, but leave them commented.  Uncommented options override the
+ # default value.
+ 
++Include /etc/ssh/sshd_config.d/*.conf
++
+ #Port 22
+ #AddressFamily any
+ #ListenAddress 0.0.0.0


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: x86_64, generic, HEAD (d54f3b2cfd)
Run tested: same, installed on production router

Description:

Most distros allow dropping site configuration files into `/etc/sshd_config.d/` so that you don't have to tweak the main server configuration file.

