### PR TITLE
gptfdisk: fix incorrect TARGET on non-linux host

### DIFF
--- a/utils/gptfdisk/Makefile
+++ b/utils/gptfdisk/Makefile
@@ -75,6 +75,7 @@ endef
 
 TARGET_CXXFLAGS += -std=c++11 -fno-rtti
 TARGET_LDFLAGS += -Wl,--as-needed
+MAKE_FLAGS += TARGET=linux
 
 define Package/gdisk/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Fixed by defining `TARGET=linux`, as suggested in the `README`.
By default `TARGET` is derived from the host using `uname -s`,
which produces build errors on a non-linux hosts:

```
TARGET is not set; trying to determine target based on host OS....
Detected OS is Darwin
Build target is macos
...
x86_64-openwrt-linux-musl-g++: error: unrecognized command-line option '-arch'
```

Compile tested: (target x64, OpenWrt master, host: macOS 13.5)

@neheb @1715173329 @aparcar @dhewg 