### PR TITLE
micropython: fix stackctrl compilation for GCC 13

### DIFF
--- a/lang/python/micropython/patches/050-py-stackctrl-fix-gcc-13.patch
+++ b/lang/python/micropython/patches/050-py-stackctrl-fix-gcc-13.patch
@@ -1,0 +1,31 @@
+From f1c6cb7725960487195daa5c5c196fd8d3563811 Mon Sep 17 00:00:00 2001
+From: Damien George <damien@micropython.org>
+Date: Wed, 3 May 2023 15:23:24 +1000
+Subject: [PATCH] py/stackctrl: Add gcc pragmas to ignore dangling-pointer
+ warning.
+
+This warning became apparent in gcc 13.
+
+Signed-off-by: Damien George <damien@micropython.org>
+---
+ py/stackctrl.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+--- a/py/stackctrl.c
++++ b/py/stackctrl.c
+@@ -28,8 +28,15 @@
+ #include "py/stackctrl.h"
+ 
+ void mp_stack_ctrl_init(void) {
++    #if __GNUC__ >= 13
++    #pragma GCC diagnostic push
++    #pragma GCC diagnostic ignored "-Wdangling-pointer"
++    #endif
+     volatile int stack_dummy;
+     MP_STATE_THREAD(stack_top) = (char *)&stack_dummy;
++    #if __GNUC__ >= 13
++    #pragma GCC diagnostic pop
++    #endif
+ }
+ 
+ void mp_stack_set_top(void *top) {


### PR DESCRIPTION
Maintainer: @jefferyto jefferyto
Compile tested: arm, bcm27xx-bcm2708 (rpi), OpenWrt master
Run tested: N/A

Description:
Signed-off-by: Jean-Paul Etienne <fractalclone@gmail.com>
(cherry picked from commit https://github.com/openwrt/packages/commit/4c1b74ede3a1d8c5b8b1594a01a2048325ee6c23)


