### PR TITLE
[openwrt-23.05] python-flask-socketio: Update to 5.3.5

### DIFF
--- a/lang/python/python-flask-socketio/Makefile
+++ b/lang/python/python-flask-socketio/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-flask-socketio
-PKG_VERSION:=5.3.1
+PKG_VERSION:=5.3.5
 PKG_RELEASE:=1
 
 PYPI_NAME:=Flask-SocketIO
-PKG_HASH:=fd0ed0fc1341671d92d5f5b2f5503916deb7aa7e2940e6636cfa2c087c828bf9
+PKG_HASH:=5f01158d10db71aa78c969b631ce3b9148b47ab0de1995158f9577f85b004d25
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @ja-pa
Compile tested: none (cherry picked from #21704)
Run tested: none

Description:
Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 58c9de9ede61a1a7b7c31cedc79140fd7a2c4344)