### PR TITLE
[22.03] node: August 2023 Security Releases

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v16.20.1
+PKG_VERSION:=v16.20.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=83e03381e271f1a5619188e7aea9d85d9b7e12f5be2a28ceb78d7249ed22b7f1
+PKG_HASH:=576f1a03c455e491a8d132b587eb6b3b84651fc8974bb3638433dd44d22c8f49
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: 22.03, aarch64, arm 
Run tested: (qemu 8.0.3) arm

Description:
Update to v16.20.2
This is a security release.

Notable Changes
The following CVEs are fixed in this release:
* CVE-2023-32002: Policies can be bypassed via Module._load (High)
* CVE-2023-32006: Policies can be bypassed by module.constructor.createRequire (Medium)
* CVE-2023-32559: Policies can be bypassed via process.binding (Medium)
* OpenSSL Security Releases  (Depends on shared library provided by OpenWrt)
  * OpenSSL security advisory 14th July.
  * OpenSSL security advisory 19th July.
  * OpenSSL security advisory 31st July