### PR TITLE
[23.05] node: August 2023 Security Releases

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v18.17.0
+PKG_VERSION:=v18.17.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=80c0faadf5ea39c213ccb9aa5c2432977a0f1b5a0b766852abd0de06f2770406
+PKG_HASH:=f215cf03d0f00f07ac0b674c6819f804c1542e16f152da04980022aeccf5e65a
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: 23.05, aarch64, arm 
Run tested: (qemu 8.0.3) arm

Description:
Update to v18.17.1
This is a security release.

Notable Changes
The following CVEs are fixed in this release:
* CVE-2023-32002: Policies can be bypassed via Module._load (High)
* CVE-2023-32006: Policies can be bypassed by module.constructor.createRequire (Medium)
* CVE-2023-32559: Policies can be bypassed via process.binding (Medium)
* OpenSSL Security Releases  (Depends on shared library provided by OpenWrt)
  * OpenSSL security advisory 14th July. 
  * OpenSSL security advisory 19th July. 
  * OpenSSL security advisory 31st July

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
(cherry picked from commit 153f0b3d83dcbab5e05f7c1b38067071e96a30aa)
