### PR TITLE
netifyd: Updated to v4.4.7

### DIFF
--- a/net/netifyd/Config.in
+++ b/net/netifyd/Config.in
@@ -1,0 +1,16 @@
+menu "Configuration"
+	depends on PACKAGE_netifyd
+
+config NETIFYD_BUILD_SHARED_LIBRARY
+	bool "Build the Agent as a shared library?"
+	default y
+	help
+		Build the Agent as a shared library when enabled, or statically link it otherwise.  Statically linking can make debugging easier.
+
+config NETIFYD_WITH_LOCAL_LIBGCRYPT
+	bool "Link nDPI with the local system libgcrypt?"
+	default y
+	help
+		Link the Agent (and nDPI) against the local system libgcrypt, or use the bundled gcrypt lite version.
+
+endmenu

--- a/net/netifyd/Makefile
+++ b/net/netifyd/Makefile
@@ -17,9 +17,13 @@ PKG_BUILD_FLAGS:=gc-sections
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.com/netify.ai/public/netify-agent.git
-PKG_SOURCE_DATE:=2023-03-03
-PKG_SOURCE_VERSION:=v4.4.1
-PKG_MIRROR_HASH:=aa3522b6d86e113943abacd50b235738e6452991a36864ec70f5db5b7bec6d13
+PKG_SOURCE_DATE:=2023-08-10
+PKG_SOURCE_VERSION:=v4.4.7
+PKG_MIRROR_HASH:=389fb77e4d6920e94ab9c6febd0049ecd3a34c6b073f3dfb7f204775f3389f07
+
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_NETIFYD_BUILD_SHARED_LIBRARY \
+	CONFIG_NETIFYD_WITH_LOCAL_LIBGCRYPT
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -28,11 +32,12 @@ define Package/netifyd
   CATEGORY:=Network
   TITLE:=Netify Agent
   URL:=http://www.netify.ai/
-  DEPENDS:=+ca-bundle +libcurl +libmnl +libnetfilter-conntrack +libpcap +zlib +libpthread @!USE_UCLIBC
+  DEPENDS:=+ca-bundle +libatomic +libcurl +libmnl +libnetfilter-conntrack +libpcap +zlib +libpthread @!USE_UCLIBC
   # Explicitly depend on libstdcpp rather than $(CXX_DEPENDS).  At the moment
   # std::unordered_map is only available via libstdcpp which is required for
   # performance reasons.
   DEPENDS+=+libstdcpp
+  DEPENDS+=+NETIFYD_WITH_LOCAL_LIBGCRYPT:libgcrypt
 endef
 
 define Package/netifyd/description
@@ -41,6 +46,10 @@ protocols and applications.  These detections can be saved locally, served over
 a UNIX or TCP socket, and/or "pushed" (via HTTP POSTs) to a remote third-party
 server.  Flow metadata, network statistics, and detection classifications are
 JSON encoded for easy consumption by third-party applications.
+endef
+
+define Package/netifyd/config
+	source "$(SOURCE)/Config.in"
 endef
 
 define Package/netifyd/conffiles
@@ -55,6 +64,8 @@ TARGET_CFLAGS+=-Wno-psabi
 TARGET_CXXFLAGS+=-std=c++11 -Wno-psabi
 
 CONFIGURE_ARGS+= \
+	$(if $(CONFIG_NETIFYD_BUILD_SHARED_LIBRARY),--enable-shared,--disable-shared) \
+	$(if $(CONFIG_NETIFYD_WITH_LOCAL_LIBGCRYPT),--with-local-libgcrypt,--without-local-libgcrypt) \
 	--sharedstatedir=/var/run \
 	--enable-lean-and-mean \
 	--disable-libtcmalloc \
@@ -72,7 +83,6 @@ CONFIGURE_ARGS+= \
 	--without-libcurl-zlib
 endif
 
-
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/netifyd
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/netifyd/*.h $(1)/usr/include/netifyd
@@ -85,7 +95,8 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/ndpi
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/ndpi/*.h $(1)/usr/include/ndpi
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetifyd.{a,so*} $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetifyd.a $(1)/usr/lib
+	$(if $(CONFIG_NETIFYD_BUILD_SHARED_LIBRARY),$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetifyd.so.* $(1)/usr/lib,)
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libnetifyd.pc $(1)/usr/lib/pkgconfig
 endef
@@ -100,7 +111,7 @@ define Package/netifyd/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/netifyd $(1)/usr/sbin
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetifyd.so.* $(1)/usr/lib
+	$(if $(CONFIG_NETIFYD_BUILD_SHARED_LIBRARY),$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetifyd.so.* $(1)/usr/lib,)
 	$(INSTALL_DIR) $(1)/etc/netify.d
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/deploy/netify-apps.conf $(1)/etc/netify.d
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/deploy/netify-categories.json $(1)/etc/netify.d


### PR DESCRIPTION
Maintainer: Darryl Sokoloski / @dsokoloski
Compile tested: arm_cortex-a15_neon-vfpv4, TP-Link Archer C2600, master
Run tested: TP-Link Archer C2600

## Bug Fixes

- Fixed mbedTLS crashes and TLS handshake errors when the nDPI-bundled libgcrypt "lite" version conflicts with the system version (via libcurl).
- Fixed linking order issue with libini.
- Fixed non-portable static linking warning with libndpi.
- Write flows to sockets regardless if "add_flows" is true.
- Fixed compilation error if _DIRENT_HAVE_D_RECLEN isn't defined.
- Fixed Agent path.
- [OpenWrt] Switch to "grep -E" as "egrep" is deprecated.
- Fixed possible ndAddr crash: return a const reference for cached strings.
