### PR TITLE
ruby: fix riscv64 build

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -12,7 +12,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
 PKG_VERSION:=3.2.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 # First two numbes
 PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VERSION))))

--- a/lang/ruby/patches/010-fix-riscv64-build.patch
+++ b/lang/ruby/patches/010-fix-riscv64-build.patch
@@ -1,0 +1,33 @@
+From dfb22e4d6662bf72879eda806eaa78c7b52b519e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 25 Jan 2022 20:29:14 -0800
+Subject: [PATCH] vm_dump.c: Define REG_S1 and REG_S2 for musl/riscv
+
+These defines are missing in musl, there is a possible
+patch to add them to musl, but we need a full list of
+these names for mcontext that can be added once for all
+
+Upstream-Status: Inappropriate [musl bug]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ vm_dump.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/vm_dump.c
++++ b/vm_dump.c
+@@ -39,6 +39,15 @@
+ 
+ #define MAX_POSBUF 128
+ 
++#ifdef __riscv
++#ifndef REG_S1
++#define REG_S1 9
++#endif
++#ifndef REG_S2
++#define REG_S2 18
++#endif
++#endif
++
+ #define VM_CFP_CNT(ec, cfp) \
+   ((rb_control_frame_t *)((ec)->vm_stack + (ec)->vm_stack_size) - \
+    (rb_control_frame_t *)(cfp))


### PR DESCRIPTION
Maintainer: @luizluca 
Compile tested: sifiveu/generic
Run tested: n/a

Description:
Fix build by adding missing macros.

The patch is taken from:
https://lists.openembedded.org/g/openembedded-core/message/161168

See also:
https://gitlab.alpinelinux.org/alpine/aports/-/issues/13667