### PR TITLE
reptyr: Update to 0.10.0

### DIFF
--- a/utils/reptyr/Makefile
+++ b/utils/reptyr/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=reptyr
-PKG_VERSION:=0.8.0
-PKG_RELEASE:=5
+PKG_VERSION:=0.10.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/nelhage/reptyr/archive/
-PKG_HASH:=4b470ed2a0d25fed591739fa9613ce7ad3d0377891eb56cbe914e3c85db46ca8
+PKG_HASH:=c6ffbc34a511ac00d072219bda30699e51f2f4eb483cbae9e32e981d49e8b380
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>


### PR DESCRIPTION
Maintainer: @BKPepe 
Compile tested: rockchip/armv8, sifiveu/generic
Run tested: nanopi-r2s (i dont have a riscv64 board to test, so only did it on arm64)

Description:
```
* 0.10.0 (Jun 04, 2023)
 - Add arm7 and aarch64 support for FreeBSD

* 0.9.0 (Jun 12, 2022)
 - Add RISCV64 support on Linux
 - Fix tty-stealing on PowerPC
```