### PR TITLE
smartmontools: update to 7.4

### DIFF
--- a/utils/smartmontools/Makefile
+++ b/utils/smartmontools/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=smartmontools
-PKG_VERSION:=7.3
-PKG_RELEASE:=2
+PKG_VERSION:=7.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/smartmontools
-PKG_HASH:=a544f8808d0c58cfb0e7424ca1841cb858a974922b035d505d4e4c248be3a22b
+PKG_HASH:=e9a61f641ff96ca95319edfb17948cd297d0cd3342736b2c49c99d4716fb993d
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/utils/smartmontools/patches/002-os_mailer-is-mailx.patch
+++ b/utils/smartmontools/patches/002-os_mailer-is-mailx.patch
@@ -1,6 +1,6 @@
 --- a/configure
 +++ b/configure
-@@ -7633,7 +7633,7 @@ releaseversion='${PACKAGE}-${VERSION}'
+@@ -7682,7 +7682,7 @@ fi
  # Set platform-specific modules and symbols
  os_libs=
  os_dltools='curl wget lynx svn'


### PR DESCRIPTION
Maintainer: me
Compile tested: ipq807x, r23300+3-86bc525d00
Run tested: ipq807x, r23300+3-86bc525d00, `smartctl --xall /dev/sda` works
Description:
- update to 7.4
- refresh patches
