### PR TITLE
ddns-scripts: allow IPv6 address in DNS charset

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -72,7 +72,7 @@ IPV6_REGEX="\(\([0-9A-Fa-f]\{1,4\}:\)\{1,\}\)\(\([0-9A-Fa-f]\{1,4\}\)\{0,1\}\)\(
 SHELL_ESCAPE="[\"\'\`\$\!();><{}?|\[\]\*\\\\]"
 
 # dns character set. "-" must be the last character
-DNS_CHARSET="[@a-zA-Z0-9._-]"
+DNS_CHARSET="[@a-zA-Z0-9._:-]"
 
 # domains can have * for wildcard. "-" must be the last character
 DNS_CHARSET_DOMAIN="[@a-zA-Z0-9._*-]"


### PR DESCRIPTION
Maintainer: @feckert 
Run tested: aarch64_cortex-a53, Qihoo 360T7, OpenWrt 23.05.0-rc2 r23228-cd17d8df2a

Description:

Recently, I was configuring IPv6 DDNS on my router at my home. When I wrote `option dns_server '2001:470:20::2'` to get the up-to-date DNS result from HE DNS since I use he.net DDNS service and restarted ths ddns service, the PID did not show in LuCI and neither is `ps`. I tried to execute `/bin/sh /usr/lib/ddns/dynamic_dns_updater.sh -v 0 -S myddns_ipv6 -- start` in shell, I got the error message ` 162830  CRIT : sanitize on dns_server found characters outside allowed subset - TERMINATE`.

After reviewing the code, I found that the `dns_server` will be sanitized in net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh:260`:

```sh
# File: net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh:260
# verify validity of variables
[ -n "$lookup_host" ] && sanitize_variable lookup_host "$DNS_CHARSET" ""
[ -n "$dns_server" ] && sanitize_variable dns_server "$DNS_CHARSET" ""
[ -n "$domain" ] && sanitize_variable domain "$DNS_CHARSET_DOMAIN" ""
```

However, the `DNS_CHARSET` in `net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh` is: `DNS_CHARSET="[@a-zA-Z0-9._-]"` which does not contain `:` for IPv6 address. Finally, I added `:` and tested all the DDNS update processes, and checked the log, and everything works.