### PR TITLE
qemu: enable host support for armsr/armv8

### DIFF
--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -29,7 +29,7 @@ include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/package.mk
 
 QEMU_DEPS_IN_GUEST := @(TARGET_x86_64||TARGET_armsr||TARGET_malta)
-QEMU_DEPS_IN_HOST := @(TARGET_x86_64||TARGET_sunxi)
+QEMU_DEPS_IN_HOST := @(TARGET_x86_64||TARGET_armsr_armv8||TARGET_sunxi)
 QEMU_DEPS_IN_HOST += +libstdcpp
 QEMU_DEPS_IN_HOST += $(ICONV_DEPENDS)
 
@@ -220,6 +220,7 @@ endef
 qemu-target-list :=	\
 	x86_64-softmmu	\
 	arm-softmmu	\
+	aarch64-softmmu \
 
 qemu-target-x86_64-softmmu-deps:= \
 	+qemu-firmware-pxe \


### PR DESCRIPTION
As of OpenWrt main branch commit [e505873e65f72 ](https://github.com/openwrt/openwrt/commit/e505873e65f72) ("armsr: armv8: enable KVM host") [merged 2023-08-15], armsr/armv8 has KVM host support. We can now enable QEMU host for this target.

For example, you can run OpenWrt armsr/armv8 as a guest like so:
```
qemu-system-aarch64 -nographic -M virt -cpu host --enable-kvm \
	-bios u-boot.bin -smp 1 -m 1024 \
	-drive file=openwrt-armsr-armv8-generic-ext4-combined.img,format=raw,index=0,media=disk
```
A compatible u-boot.bin can be obtained from u-boot-qemu_armv8/u-boot.bin that is built with the armsr target and available from downloads.openwrt.org.
(It would be nice to package EDK2 and u-boot for QEMU usage, sometime in the future)

Maintainer: @yousong 
Compile tested: armv8/armsr, OpenWrt main as of https://github.com/openwrt/openwrt/commit/46ed38adeb76b376e34056c755e0c8ffa5acf29f + x86_64 SDK snapshot 
Run tested: armv8/armsr, Traverse Technologies Ten64 (NXP LS1088A)

