### PR TITLE
dnscrypt-proxy2: update to 2.1.5

### DIFF
--- a/net/dnscrypt-proxy2/Makefile
+++ b/net/dnscrypt-proxy2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy2
-PKG_VERSION:=2.1.4
+PKG_VERSION:=2.1.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=dnscrypt-proxy-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/DNSCrypt/dnscrypt-proxy/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=05f0a3e8c8f489caf95919e2a75a1ec4598edd3428d2b9dd357caba6adb2607d
+PKG_HASH:=044c4db9a3c7bdcf886ff8f83c4b137d2fd37a65477a92bfe86bf69587ea7355
 PKG_BUILD_DIR:=$(BUILD_DIR)/dnscrypt-proxy-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>


### PR DESCRIPTION
Maintainer: @BKPepe
Compile tested: n/a
Run tested: n/a
Description:
https://github.com/DNSCrypt/dnscrypt-proxy/commit/1b65fe62b01965bfee3f7ed8ba852c15de1255eb