### PR TITLE
rust: fix host build on aarch64 darwin

### DIFF
--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -22,6 +22,12 @@ ifdef CONFIG_PKG_CC_STACKPROTECTOR_STRONG
 endif
 endif
 
+ifeq ($(HOST_OS),Darwin)
+  ifeq ($(HOST_ARCH),arm64)
+    RUSTC_TARGET_ARCH:=aarch64-apple-darwin
+  endif
+endif
+
 # mips64 openwrt has a specific targed in rustc
 ifeq ($(ARCH),mips64)
   RUSTC_TARGET_ARCH:=$(REAL_GNU_TARGET_NAME)


### PR DESCRIPTION
rust/host failed to compile on macOS running on Apple Silicon M1 Pro because the host target triple is autogenerated to be 'arm64-unknown-linux-'. Rust doesn't have such a target triple, thus the build failes because there are no pre-built artifacts for bootstrapping.

Fix this by setting RUSTC_HOST_ARCH to 'aarch64-apple-darwin' in case our host is HOST_ARCH=arm64 and HOST_OS=darwin.

Maintainer: @lu-zero 
Tested: macOS 14 on MacBook M1 Pro Apple Silicon, OpenWrt trunk

Description:

I just tried to compile OpenWrt with a Rust package that I included in my testing package feed. This package depends Rust/host, and it tries to bootstrap Rust environment for this. This bootstrapping failed due to an error in x.py with message:
```
src/stage0.json doesn't contain a checksum for dist/2023-06-01/rust-std-1.70.0-arm64-unknown-linux-.tar.xz
```
I did a bit debugging and saw, that the target triple 'arm64-unknown-linux-' isn't properly generated and doesn't come close to a matching Rust target triple. The proper target triple would be 'aarch64-apple-darwin'. Hard-specifying this in rust-values.mk is then working properly, the rust/host build and building the Rust package is working then.

I'm aware of that this fix only fixes build with Apple Silicon macOS. I guess, similar problems could occur on ARM64 based Linux because Rust target triples always use aarch64, but the auto-generated triples use 'uname -m' and end up with 'arm64'. Any thoughts how this could be extended to all aarch64 hosts?

cc @PolynomialDivision 