### PR TITLE
dnscrypt-proxy2: update to version 2.1.5

### DIFF
--- a/net/dnscrypt-proxy2/Makefile
+++ b/net/dnscrypt-proxy2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy2
-PKG_VERSION:=2.1.4
+PKG_VERSION:=2.1.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=dnscrypt-proxy-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/DNSCrypt/dnscrypt-proxy/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=05f0a3e8c8f489caf95919e2a75a1ec4598edd3428d2b9dd357caba6adb2607d
+PKG_HASH:=044c4db9a3c7bdcf886ff8f83c4b137d2fd37a65477a92bfe86bf69587ea7355
 PKG_BUILD_DIR:=$(BUILD_DIR)/dnscrypt-proxy-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>


### PR DESCRIPTION
Maintainer: me
Compile tested: Ramips - OpenWrt SNAPSHOT 2023-08-15
Run tested: Xiaomi Router 3G V1 - OpenWrt SNAPSHOT 2023-08-15

Description:
dnscrypt-proxy can be compiled with Go 1.21.0+
Responses to blocked queries now include extended error codes
Reliability of connections using HTTP/3 has been improved
New configuration directive: tls_key_log_file. When defined, this is the path to a file where TLS secret keys will be written to, so that DoH traffic can be locally inspected.
