### PR TITLE
frp: update to 0.51.3

### DIFF
--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=frp
-PKG_VERSION:=0.51.0
+PKG_VERSION:=0.51.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=80ccfa40c4e25309ddb48818f6342bc59f7639be83ab6ef59ffab5caeedc37e8
+PKG_HASH:=83032399773901348c660d41c967530e794ab58172ccd070db89d5e50d915fef
 
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: @ysc3839
Compile tested: (x86_64, OpenWrt snapshot)
Run tested: (x86_64, OpenWrt snapshot)

Description:
Includes some bug fixes and adds support for GO 1.21. Fix #21832.

Changelog:
https://github.com/fatedier/frp/releases/tag/v0.51.1
https://github.com/fatedier/frp/releases/tag/v0.51.2
https://github.com/fatedier/frp/releases/tag/v0.51.3