### PR TITLE
syncthing: update to 1.23.7

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -26,13 +26,13 @@ GO_PKG_BUILD_PKG:=\
 	$(if $(CONFIG_PACKAGE_strelaysrv),$(GO_PKG)/cmd/strelaysrv/)
 GO_PKG_INSTALL_EXTRA:=^gui/
 
+GO_PKG_TAGS:=noupgrade,noquic
 GO_PKG_LDFLAGS_X:=\
 	$(GO_PKG)/lib/build.Version=v$(PKG_VERSION) \
 	$(GO_PKG)/lib/build.Stamp=$(SOURCE_DATE_EPOCH) \
 	$(GO_PKG)/lib/build.User=openwrt \
 	$(GO_PKG)/lib/build.Host=openwrt \
-	$(GO_PKG)/lib/build.Tags=noupgrade
-GO_PKG_TAGS:=noupgrade
+	$(GO_PKG)/lib/build.Tags=$(GO_PKG_TAGS)
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk

--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.23.2
+PKG_VERSION:=1.23.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=3d0eca0e6f4eaaeba4879918b3f54f47d59fb5f4288a83af821d509271ada189
+PKG_HASH:=18d8dd74d8077f500a139752261b78217ef0b0a912a7c017192097a7196e21a1
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 


### PR DESCRIPTION
Maintainer: @aparcar
Compile tested: x86-64
Run tested: x86-64

Description:
Disable quic temporarily to support GO 1.21 https://github.com/syncthing/syncthing/issues/9034.
