### PR TITLE
rust: correct mistake in previous host-build fix

### DIFF
--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -24,7 +24,7 @@ endif
 
 ifeq ($(HOST_OS),Darwin)
   ifeq ($(HOST_ARCH),arm64)
-    RUSTC_TARGET_ARCH:=aarch64-apple-darwin
+    RUSTC_HOST_ARCH:=aarch64-apple-darwin
   endif
 endif
 


### PR DESCRIPTION
Fixes the commit 105fa3920e which was intended to make rust/host build on aarch64 darwin working again. However, the fix contains a mistake because it sets RUSTC_TARGET_ARCH instead of RUSTC_HOST_ARCH. Thus, the fix doesn't work.
This properly sets the correct variable RUSTC_HOST_ARCH.

Fixes: 105fa3920e ("rust: fix host build on aarch64 darwin")

Maintainer: @lu-zero 

Description:
I made a mistake while transferring my fix from my testing repo to the fork. I wasn't careful enough with the PR and just recognized this while backporting my fix to 23.05. Sorry for that.

In the fix before I used RUSTC_TARGET_ARCH but it must be RUSTC_HOST_ARCH to actually change the target triple used for compiling rust/host.

cc @PolynomialDivision 