### PR TITLE
openvpn: update to 2.6.6

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.6.5
+PKG_VERSION:=2.6.6
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=e34efdb9a3789a760cfc91d57349dfb1e31da169c98c06cb490c6a8a015638e2
+PKG_HASH:=3b074f392818b31aa529b84f76e8b5e4ad03fca764924f46d906bceaaf421034
 
 PKG_MAINTAINER:=Magnus Kroken <mkroken@gmail.com>
 
@@ -36,7 +36,8 @@ define Package/openvpn/Default
   URL:=http://openvpn.net
   SUBMENU:=VPN
   MENU:=1
-  DEPENDS:=+kmod-tun +libcap-ng +OPENVPN_$(1)_ENABLE_LZO:liblzo +OPENVPN_$(1)_ENABLE_LZ4:liblz4 +OPENVPN_$(1)_ENABLE_IPROUTE2:ip +OPENVPN_$(1)_ENABLE_DCO:libnl-genl $(3)
+  DEPENDS:=+kmod-tun +libcap-ng +OPENVPN_$(1)_ENABLE_LZO:liblzo +OPENVPN_$(1)_ENABLE_LZ4:liblz4 +OPENVPN_$(1)_ENABLE_IPROUTE2:ip \
+	+OPENVPN_$(1)_ENABLE_DCO:libnl-genl +OPENVPN_$(1)_ENABLE_DCO:kmod-ovpn-dco-v2 $(3)
   VARIANT:=$(1)
   PROVIDES:=openvpn openvpn-crypto
 endef

--- a/net/openvpn/patches/101-Fix-EVP_PKEY_CTX_-compilation-with-wolfSSL.patch
+++ b/net/openvpn/patches/101-Fix-EVP_PKEY_CTX_-compilation-with-wolfSSL.patch
@@ -9,7 +9,7 @@
  #include <openssl/kdf.h>
  #endif
  #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-@@ -1419,7 +1419,7 @@ engine_load_key(const char *file, SSL_CT
+@@ -1436,7 +1436,7 @@ engine_load_key(const char *file, SSL_CT
  #endif /* if HAVE_OPENSSL_ENGINE */
  }
  


### PR DESCRIPTION
Maintainer: @mkrkn 
Compile tested: ramips/mt7620, ramips/mt7621
Run tested: Xiaomi mi router 3 pro, Xiaomi mi-mini, Xiaomi miwifi-r3

Small bugfix release
For details refer to https://github.com/OpenVPN/openvpn/blob/v2.6.6/Changes.rst

Also, set depends on DCO kernel module when ENABLE_DCO flag is set.
