### PR TITLE
[openwrt-23.05] rust: fix host build on aarch64 darwin

### DIFF
--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -22,6 +22,12 @@ ifdef CONFIG_PKG_CC_STACKPROTECTOR_STRONG
 endif
 endif
 
+ifeq ($(HOST_OS),Darwin)
+  ifeq ($(HOST_ARCH),arm64)
+    RUSTC_HOST_ARCH:=aarch64-apple-darwin
+  endif
+endif
+
 # mips64 openwrt has a specific targed in rustc
 ifeq ($(ARCH),mips64)
   RUSTC_TARGET_ARCH:=$(REAL_GNU_TARGET_NAME)


### PR DESCRIPTION
Maintainer: @lu-zero 
Compile tested: yes

Description:
Backport of #21837 and #21845 to OpenWrt 23.05

I wasn't quite sure how to backport this because I had a mistake in the first PR, nevertheless it got merged and then submitted a second PR to fix that. Usually backporting seems to be done just by cherry-picking. Please tell me if that should be done in another way.

~~(cherry picked from 105fa3920e and c287e98af2)~~
(squashed 105fa3920e and c287e98af2)