### PR TITLE
Unbound: Silence SSL unexpected eof messages

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.17.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound

--- a/net/unbound/patches/200-remove-SSL-unexpected-eof-messages.patch
+++ b/net/unbound/patches/200-remove-SSL-unexpected-eof-messages.patch
@@ -1,0 +1,37 @@
+--- a/util/net_help.c
++++ b/util/net_help.c
+@@ -1005,6 +1005,16 @@ listen_sslctx_setup(void* ctxt)
+ 			log_crypto_err("could not set cipher list with SSL_CTX_set_cipher_list");
+ 	}
+ #endif
++#if defined(SSL_OP_IGNORE_UNEXPECTED_EOF)
++	/* ignore errors when peers do not send the mandatory close_notify
++	 * alert on shutdown.
++	 * Relevant for openssl >= 3 */
++	if((SSL_CTX_set_options(ctx, SSL_OP_IGNORE_UNEXPECTED_EOF) &
++		SSL_OP_IGNORE_UNEXPECTED_EOF) != SSL_OP_IGNORE_UNEXPECTED_EOF) {
++		log_crypto_err("could not set SSL_OP_IGNORE_UNEXPECTED_EOF");
++		return 0;
++	}
++#endif
+ 
+ 	if((SSL_CTX_set_options(ctx, SSL_OP_CIPHER_SERVER_PREFERENCE) &
+ 		SSL_OP_CIPHER_SERVER_PREFERENCE) !=
+@@ -1233,6 +1243,17 @@ void* connect_sslctx_create(char* key, c
+ 		SSL_CTX_free(ctx);
+ 		return 0;
+ 	}
++#endif
++#if defined(SSL_OP_IGNORE_UNEXPECTED_EOF)
++	/* ignore errors when peers do not send the mandatory close_notify
++	 * alert on shutdown.
++	 * Relevant for openssl >= 3 */
++	if((SSL_CTX_set_options(ctx, SSL_OP_IGNORE_UNEXPECTED_EOF) &
++		SSL_OP_IGNORE_UNEXPECTED_EOF) != SSL_OP_IGNORE_UNEXPECTED_EOF) {
++		log_crypto_err("could not set SSL_OP_IGNORE_UNEXPECTED_EOF");
++		SSL_CTX_free(ctx);
++		return 0;
++	}
+ #endif
+ 	if(key && key[0]) {
+ 		if(!SSL_CTX_use_certificate_chain_file(ctx, pem)) {


### PR DESCRIPTION
Maintainer: @EricLuehrsen 
Compile tested: aarch64, arm-cortex
Run tested: Linksys E8450/Netgear R7800, trunk

Description:
After OpenSSL update to v3+, Unbound log spamed with `SSL_read crypto error:0A000126:SSL routines::unexpected eof while reading` messages due to remote not sending disconnect.
Refs: https://github.com/NLnetLabs/unbound/issues/812 and https://github.com/NLnetLabs/unbound/issues/846

This is a backport of: https://github.com/NLnetLabs/unbound/commit/d7e776114114c16816570e48ab3a27eedc401a0e and can be removed with the next release/update of Unbound here.