### PR TITLE
[openwrt-23.05] python-py: Update to 1.11.0, update list of dependencies

### DIFF
--- a/lang/python/python-py/Makefile
+++ b/lang/python/python-py/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-py
-PKG_VERSION:=1.10.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.11.0
+PKG_RELEASE:=1
 
 PYPI_NAME:=py
-PKG_HASH:=21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3
+PKG_HASH:=51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=MIT
@@ -28,9 +28,9 @@ define Package/python3-py
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  TITLE:=py
+  TITLE:=Python development support library
   URL:=https://github.com/pytest-dev/py
-  DEPENDS:=+python3-light +python3-xml +python3-urllib
+  DEPENDS:=+python3-light +python3-xml +python3-urllib +python3-uuid
 endef
 
 define Package/python3-py/description


### PR DESCRIPTION
Maintainer: @ja-pa
Compile tested: none (cherry picked from #21858)
Run tested: none

Description:
Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit f9e3847599753f9489303ac21f74a1e724597ef8)