### PR TITLE
python-trio: Update to 0.22.2, update list of dependencies

### DIFF
--- a/lang/python/python-trio/Makefile
+++ b/lang/python/python-trio/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-trio
-PKG_VERSION:=0.22.0
+PKG_VERSION:=0.22.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=trio
-PKG_HASH:=ce68f1c5400a47b137c5a4de72c7c901bd4e7a24fbdebfe9b41de8c6c04eaacf
+PKG_HASH:=3887cf18c8bcc894433420305468388dac76932e9668afa1c49aa3806b6accb3
 
-PKG_LICENSE:=Apache-2.0|MIT
-PKG_LICENSE_FILES:=LICENSE.APACHE2|LICENSE.MIT
+PKG_LICENSE:=Apache-2.0 MIT
+PKG_LICENSE_FILES:=LICENSE.APACHE2 LICENSE.MIT
 PKG_MAINTAINER:=Julien Malik <julien.malik@paraiso.me>
 
 include ../pypi.mk
@@ -26,14 +26,11 @@ define Package/python3-trio
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  TITLE:=A friendly Python library for async concurrency and I/O
-  URL:=https://trio.readthedocs.io
+  TITLE:=Friendly library for async concurrency and I/O
+  URL:=https://github.com/python-trio/trio
   DEPENDS:= \
     +python3-light \
     +python3-attrs \
-    +python3-async-generator \
-    +python3-cffi \
-    +python3-exceptiongroup \
     +python3-idna \
     +python3-outcome \
     +python3-sniffio \
@@ -41,7 +38,8 @@ define Package/python3-trio
 endef
 
 define Package/python3-trio/description
-  The Trio project’s goal is to produce a production-quality, permissively licensed, async/await-native I/O library for Python
+The Trio project’s goal is to produce a production-quality, permissively
+licensed, async/await-native I/O library for Python.
 endef
 
 $(eval $(call Py3Package,python3-trio))


### PR DESCRIPTION
Maintainer: @julienmalik
Compile tested: armsr-armv7, 2023-08-20 snapshot sdk
Run tested: armsr-armv7 (qemu), 2023-08-20 snapshot sdk

Description:
