### PR TITLE
libssh: compile against MbedTLS instead of OpenSSL

### DIFF
--- a/libs/libssh/Makefile
+++ b/libs/libssh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libssh
 PKG_VERSION:=0.10.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.libssh.org/files/0.10/
@@ -32,7 +32,7 @@ define Package/libssh
   CATEGORY:=Libraries
   URL:=$(PKG_SOURCE_URL)
   TITLE:=SSH library
-  DEPENDS:=+libpthread +librt +zlib +libopenssl
+  DEPENDS:=+libpthread +librt +zlib +libmbedtls
 endef
 
 define Package/libssh/description
@@ -46,6 +46,7 @@ CMAKE_OPTIONS += \
 	-DHAVE_TERMIOS_H=1 \
 	-DWITH_EXAMPLES:BOOL=OFF \
 	-DWITH_GCRYPT:BOOL=OFF \
+	-DWITH_MBEDTLS:BOOL=ON \
 	-DWITH_GSSAPI:BOOL=OFF \
 	-DWITH_LIBZ:BOOL=ON \
 	-DWITH_NACL:BOOL=OFF \


### PR DESCRIPTION
Maintainer:  @neheb @PolynomialDivision 
Compile tested: librerouter-v1 ath79 OpenWrt main development branch
Run tested: librerouter-v1 ath79 OpenWrt, successfully run tmate which depends on libssh

Description:
Since 2017 libssh supports to be compiled against libmbedtls instead of libopessl, OpenWrt ships mbedtls by default, while depending on OpenSSL increase image size by almost 1.5MB unnecessarily.