### PR TITLE
tailscale: enable autodect of fw type

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
 PKG_VERSION:=1.48.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?

--- a/net/tailscale/files/tailscale.init
+++ b/net/tailscale/files/tailscale.init
@@ -23,6 +23,9 @@ start_service() {
   procd_open_instance
   procd_set_param command /usr/sbin/tailscaled
 
+  # starting with v1.48.1 ENV variable is required to enable autodetection of iptables / nftables
+  procd_set_param env TS_DEBUG_FIREWALL_MODE=auto
+
   # Set the port to listen on for incoming VPN packets.
   # Remote nodes will automatically be informed about the new port number,
   # but you might want to configure this in order to set external firewall


### PR DESCRIPTION
Maintainer: @ja-pa @oskarirauta
Compile tested: aarch64_cortex-a53 @ SNAPSHOT
Run tested: aarch64_cortex-a53 @ SNAPSHOT

Description: Starting with v1.48.1 tailscale reverted to using iptables as default. This change enables the TS_DEBUG_FIREWALL_MODE=auto to enable autodectect of nftables / iptables. Without this change, tailscale start up will fail because the iptable command cannot be found on systems using nftables.