### PR TITLE
dnsproxy: Update to 0.54.0; support multi instance

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # Copyright (C) 2021 ImmortalWrt.org
+# Copyright (C) 2023 Bruce Chen <a805899926@gmail.com>
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.52.0
-PKG_RELEASE:=1
+PKG_VERSION:=0.54.0
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
@@ -33,7 +34,6 @@ define Package/dnsproxy
   TITLE:=Simple DNS proxy with DoH, DoT, DoQ and DNSCrypt support
   URL:=https://github.com/AdguardTeam/dnsproxy
   DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
-  USERID:=dnsproxy=411:dnsproxy=411
 endef
 
 define Package/dnsproxy/description
@@ -53,6 +53,7 @@ endef
 
 define Package/dnsproxy/conffiles
 /etc/config/dnsproxy
+/etc/dnsproxy/
 endef
 
 $(eval $(call GoBinPackage,dnsproxy))

--- a/net/dnsproxy/files/dnsproxy.config
+++ b/net/dnsproxy/files/dnsproxy.config
@@ -1,41 +1,8 @@
-
 # For documents, please see https://github.com/AdguardTeam/dnsproxy#usage
 
-config dnsproxy 'global'
-	option enabled '0'
-	option listen_addr '127.0.0.1'
-	option listen_port '5353'
-	option log_file ''
-	option all_servers '0'
-	option fastest_addr '0'
-	option insecure '0'
-	option ipv6_disabled '0'
-	option max_go_routines ''
-	option rate_limit ''
-	option refuse_any '0'
-	option udp_buf_size ''
-	option verbose '0'
-
-config dnsproxy 'bogus_nxdomain'
-	list ip_addr ''
-
-config dnsproxy 'cache'
-	option enabled '0'
-	option cache_optimistic '0'
-	option size '65535'
-	option min_ttl ''
-	option max_ttl ''
-
-config dnsproxy 'dns64'
-	option enabled '0'
-	option dns64_prefix '64:ff9b::'
-
-config dnsproxy 'edns'
-	option enabled '0'
-	option edns_addr ''
-
-config dnsproxy 'servers'
-	list bootstrap 'tls://8.8.8.8'
-	list fallback 'tls://9.9.9.9'
-	list upstream 'tls://1.1.1.1'
-
+config dnsproxy 'example'
+         option enabled '0'
+         list port '53'
+		 list bootstrap 'tls://8.8.8.8'
+		 list upstream 'tls://1.1.1.1'
+		 list fallback 'tls://9.9.9.9'

--- a/net/dnsproxy/files/dnsproxy.init
+++ b/net/dnsproxy/files/dnsproxy.init
@@ -1,115 +1,85 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2021 Tianling Shen <cnsztl@immortalwrt.org>
+# Copyright (C) 2023 Bruce Chen <a805899926@gmail.com>
+
+START=90
+STOP=10
 
 USE_PROCD=1
-START=90
-
-CONF="dnsproxy"
 PROG="/usr/bin/dnsproxy"
 
-is_enabled() {
-	local enabled
-	config_get enabled "$1" "$2" "0"
-	if [ "$enabled" -eq "1" ]; then
-		return 0
-	else
-		return 1
-	fi
+section_enabled() {
+	config_get_bool enabled "$1" 'enabled' 0
+	[ $enabled -gt 0 ]
 }
 
-is_empty() {
-	local empty
-	config_get empty "$1" "$2" $3
-	if [ -z "$empty" ]; then
-		return 0
-	else
-		return 1
-	fi
-}
+add_instance() {
+	local name="$1"
+	
+	config_get_bool debug "$name" debug 0
 
-append_param() {
-	procd_append_param command "$1" $2
-}
+	procd_open_instance "$name"
+	procd_set_param command "$PROG"	--output "/var/log/dnsproxy.$name.log"
 
-append_param_arg() {
-	local value
-	config_get value "$1" "$2" $4
-	[ -n "$value" ] && append_param "$3" "$value"
-}
-
-append_param_bool() {
-	is_enabled "$1" "$2" && append_param "--${2//_/-}"
-}
-
-load_config_arg() {
-	append_param_bool "$1" "all_servers"
-	append_param_bool "$1" "fastest_addr"
-	append_param_bool "$1" "insecure"
-	append_param_bool "$1" "ipv6_disabled"
-	append_param_bool "$1" "refuse_any"
-	append_param_bool "$1" "verbose"
-}
-
-load_config_list() {
-	is_empty "bogus_nxdomain" "ip_addr" || config_list_foreach "bogus_nxdomain" "ip_addr" "append_param '--bogus-nxdomain'"
-
-	for i in "bootstrap" "fallback" "upstream"; do
-		is_empty "servers" "$i" || config_list_foreach "servers" "$i" "append_param '--$i'"
+	for i in "listen" "port" "bootstrap" "fallback" "upstream"; do
+		config_list_foreach "$name" $i "procd_append_param command --$i"
 	done
-}
 
-load_config_param() {
-	append_param_arg "global" "listen_addr" "--listen" "127.0.0.1"
-	append_param_arg "global" "listen_port" "--port" "5353"
-	append_param_arg "global" "log_file" "--output"
-	append_param_arg "global" "max_go_routines" "--max-go-routines"
-	append_param_arg "global" "rate_limit" "--ratelimit"
-	append_param_arg "global" "udp_buf_size" "--udp-buf-size"
+	config_list_foreach "$name" https_port "procd_append_param command --https-port"
+	config_list_foreach "$name" tls_port "procd_append_param command --tls-port"
+	config_list_foreach "$name" quic_port "procd_append_param command --quic-port"
+	config_list_foreach "$name" dnscrypt_port "procd_append_param command --dnscrypt-port"
 
-	is_enabled "cache" "enabled" && {
-		append_param "--cache"
-		append_param_bool "cache" "cache_optimistic"
-		append_param_arg "cache" "size" "--cache-size"
-		append_param_arg "cache" "min_ttl" "--cache-min-ttl"
-		append_param_arg "cache" "max_ttl" "--cache-max-ttl"
-	}
+	config_get tls_min_version "$name" tls_min_version
+	[ ! -z $tls_min_version ] && procd_append_param command --tls-min-version $tls_min_version
 
-	is_enabled "dns64" "enabled" && {
-		append_param "--dns64"
-		append_param_arg "dns64" "dns64_prefix" "--dns64-prefix"
-	}
+	config_get tls_max_version "$name" tls_max_version
+	[ ! -z $tls_max_version ] && procd_append_param command --tls-min-version $tls_max_version
 
-	is_enabled "edns" "enabled" && {
-		append_param "--edns"
-		append_param_arg "edns" "edns_addr" "--edns-addr"
-	}
-}
+	config_get_bool insecure "$name" insecure 0
+	[ "$insecure" -eq 1 ] && procd_append_param command --insecure
 
-start_service() {
-	config_load "$CONF"
-
-	is_enabled "global" "enabled" || return 1
-
-	procd_open_instance "$CONF"
-	procd_set_param command "$PROG"
-
-	load_config_arg "global"
-	load_config_list
-	load_config_param
-
-	procd_set_param respawn
-	procd_set_param stdout 1
-	procd_set_param stderr 1
-	procd_set_param user dnsproxy
-
+	[ "$debug" -eq 1 ] && procd_append_param command --verbose
+		
+    procd_set_param respawn
+	
 	procd_close_instance
 }
 
-reload_service() {
-	stop
-	start
+start_instance() {
+	local s="$1"
+    
+    section_enabled "$s" || {
+		return 1
+	}
+    [ ! -d "/var/run" ] && mkdir -p "/var/run"
+	add_instance "$s"
+}
+
+start_service() {
+	local instance="$1"
+	local instance_found=0
+	
+	config_cb() {
+		local type="$1"
+		local name="$2"
+		if [ "$type" = "dnsproxy" ]; then
+			if [ -n "$instance" -a "$instance" = "$name" ]; then
+				instance_found=1
+			fi
+		fi
+	}
+
+    config_load "dnsproxy"
+
+	if [ -n "$instance" ]; then
+		[ "$instance_found" -gt 0 ] || return
+		start_instance "$instance"
+	else
+    	config_foreach start_instance 'dnsproxy'
+	fi
 }
 
 service_triggers() {
-	procd_add_reload_trigger "$CONF"
+	procd_add_reload_trigger dnsproxy
 }


### PR DESCRIPTION
Maintainer: @czy21
Compile tested: x86_64, OpenWrt 22.03.5
Run tested: x86_64, OpenWrt 22.03.5, tests done

Description: dnsproxy upgrade to v.0.54.0; support multi instance
