### PR TITLE
knot: update to version 3.3.0

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.2.9
+PKG_VERSION:=3.3.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=bc1f9eb8c9f67f52805f3acfa2d0153190245fa145b007fafa9068d2da292506
+PKG_HASH:=cf12ab736c512eb719a221cd3f65bb94f93ff2b477803d9474d1334af73c1533
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8

--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -152,6 +152,7 @@ CONFIGURE_ARGS += 			\
 	--enable-cap-ng=no            	\
 	--enable-xdp=no                 \
 	--enable-maxminddb=no		\
+	--enable-quic			\
 	--disable-fastparser		\
 	--without-libidn		\
 	--with-libnghttp2=no		\


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 7.0.0 (hbl)
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 7.0.0 (hbl)

Description:

- Release upgrade (https://www.knot-dns.cz/2023-08-28-version-330.html)
- Enable QUIC support