### PR TITLE
ncdu: update to 1.18.1

### DIFF
--- a/utils/ncdu/Makefile
+++ b/utils/ncdu/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ncdu
-PKG_VERSION:=1.18
+PKG_VERSION:=1.18.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dev.yorhel.nl/download
-PKG_HASH:=3c37a1a96580c9c5d2cc352dc3c5eef0d909158c05f1cc29db4712544c8b9f95
+PKG_HASH:=7c0fa1eb29d85aaed4ba174164bdbb8f011b5c390d017c57d668fc7231332405
 
 PKG_MAINTAINER:=Charles E. Lehner <cel@celehner.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Upstream bump

Build system: x86_64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne

Description: @clehner