### PR TITLE
nginx: update nginx and brotli

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -215,9 +215,9 @@ endef
 
 
 define Download/nginx-mod-brotli
-  VERSION:=e505dce68acc190cc5a1e780a3b0275e39f160ca
+  VERSION:=25f86f0bac1101b6512135eac5f93c49c63609e3
   URL:=https://github.com/google/ngx_brotli.git
-  MIRROR_HASH:=04847f11ef808fed50f44b2af0ef3abf59ff0ffc06dfc7394d9ab51d53fef31f
+  MIRROR_HASH:=c85cdcfd76703c95aa4204ee4c2e619aa5b075cac18f428202f65552104add3b
   PROTO:=git
 endef
 

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
-PKG_VERSION:=1.25.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.25.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
-PKG_HASH:=f09071ac46e0ea3adc0008ef0baca229fc6b4be4533baef9bbbfba7de29a8602
+PKG_HASH:=05dd6d9356d66a74e61035f2a42162f8c754c97cf1ba64e7a801ba158d6c0711
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de> \
 				Ansuel Smith <ansuelsmth@gmail.com>


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Ansuel Smith <ansuelsmth@gmail.com>
Compile tested: Xiaomi AX3600 on the latest main
Run tested: Xiaomi AX3600 on the latest main

Description:
Update nginx to the latest version which brings mainly fixes to HTTP/3 (QUIC).

While at it update brotli to the latest version.