### PR TITLE
collectd-mod-ipstatistics: fix handling of long `/proc` lines

### DIFF
--- a/utils/collectd/patches/932-add-ipstatistics.patch
+++ b/utils/collectd/patches/932-add-ipstatistics.patch
@@ -41,7 +41,7 @@
 +
 +int ipstatistics_read() {
 +  FILE *fh;
-+  char buffer[1024];
++  char buffer[4096];
 +  char *fields[19];
 +  int numfields;
 +
@@ -56,7 +56,7 @@
 +    return -1;
 +  }
 +
-+  while (fgets(buffer, 1024, fh) != NULL) {
++  while (fgets(buffer, 4096, fh) != NULL) {
 +    numfields = strsplit(buffer, fields, 2);
 +
 +    if (numfields < 2)
@@ -80,7 +80,7 @@
 +  }
 +
 +  int count_ipext = 0;
-+  while (fgets(buffer, 1024, fh) != NULL) {
++  while (fgets(buffer, 4096, fh) != NULL) {
 +    numfields = strsplit(buffer, fields, 19);
 +
 +    if (numfields < 8)


### PR DESCRIPTION
`/proc/net/netstat` `TcpExt:` line is 2064 chars long on linux 6.1
