### PR TITLE
croc: new package

### DIFF
--- a/net/croc/Makefile
+++ b/net/croc/Makefile
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2023 Jonas Jelonek
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=croc
+PKG_VERSION:=9.6.5
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/schollz/croc/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=2d3ba7bae3c49e3870e2f8523c6be00e92fe6e46828269a8cea34d4034102cad
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/schollz/croc/v9
+GO_PKG_BUILD_PKG:=$(GO_PKG)
+GO_PKG_LDFLAGS_X:=$(GO_PKG)/src/cli.Version=v$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/croc
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=File Transfer
+  TITLE:=Easily and securely send things from one computer to another
+  URL:=https://github.com/schollz/croc
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/croc/description
+  croc is a tool that allows any two computers to simply and securely
+  transfer files and folders by using a relay.
+endef
+
+$(eval $(call GoBinPackage,croc))
+$(eval $(call BuildPackage,croc))


### PR DESCRIPTION
croc is a tool written in Go for sending files from one device to another over the internet using a relay. It runs on multiple platforms, provides end-to-end encryption and works without port forwarding and fixed IP/DynDNS.

Maintainer: me (@jonasjelonek)
Build system: x86_64 Linux
Compile tested: aarch64_cortex-a53, BananaPi R64
Run tested: aarch64_cortex-a53, BananaPi R64

Description:
The description above already summarizes quite well whats the purpose of this tool. A more detailed description can be found [here](https://schollz.com/tinker/croc6/), and there are several examples of its usage in the git [here](https://github.com/schollz/croc).
I use it quite a lot, e.g. when I build new images on my build server (which isn't in my LAN) to transfer it directly to the device to-be-sysupgraded.