### PR TITLE
[openwrt-23.05] python-rsa: Update to 4.9, update list of dependencies

### DIFF
--- a/lang/python/python-rsa/Makefile
+++ b/lang/python/python-rsa/Makefile
@@ -1,15 +1,18 @@
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=rsa
-PKG_VERSION:=4.6
+PKG_NAME:=python-rsa
+PKG_VERSION:=4.9
 PKG_RELEASE:=1
 
-PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=109ea5a66744dd859bf16fe904b8d8b627adafb9408753161e766a92e7d681fa
+PYPI_NAME:=rsa
+PKG_HASH:=e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21
 
 PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
-PKG_LICENSE:=MIT
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:python-rsa_project:python-rsa
+
+PKG_BUILD_DEPENDS:=python-poetry-core/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -19,15 +22,16 @@ define Package/python3-rsa
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  TITLE:=rsa
+  TITLE:=Pure-Python RSA implementation
   URL:=https://stuvel.eu/rsa
-  DEPENDS:=+python3 +python3-pyasn1
+  DEPENDS:=+python3-light +python3-multiprocessing +python3-pydoc +python3-pyasn1
 endef
 
 define Package/python3-rsa/description
-  Is a pure-Python RSA implementation. It supports encryption and decryption,
-  signing and verifying signatures, and key generation according to PKCS#1 version 1.5.
-  It can be used as a Python library as well as on the commandline. 
+Python-RSA is a pure-Python RSA implementation. It supports encryption
+and decryption, signing and verifying signatures, and key generation
+according to PKCS#1 version 1.5. It can be used as a Python library as
+well as on the commandline.
 endef
 
 $(eval $(call Py3Package,python3-rsa))


### PR DESCRIPTION
Maintainer: @dddaniel
Compile tested: none (cherry picked from #21908)
Run tested: none

Description:
The package changed to the poetry-core build backend.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit a694ed7b0c0c85108f37f7562e606a30d30638ac)