### PR TITLE
modemmanager: Fix Permission Denied error

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_SOURCE_VERSION:=1.20.6
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/10-report-down
+++ b/net/modemmanager/files/10-report-down
@@ -29,7 +29,12 @@ MODEM_DEVICE=$(modemmanager_get_field "${MODEM_STATUS}" "modem.generic.device")
 CFG=$(mm_get_modem_config "${MODEM_DEVICE}")
 [ -n "${CFG}" ] || exit 3
 
-logger -t "modemmanager" "interface ${CFG} (network device ${INTERFACE}) ${STATE}"
-proto_init_update $INTERFACE 0
-proto_send_update $CFG
+IFUP=$(ifstatus "${CFG}" | jsonfilter -e "@.up")
+
+[ "${IFUP}" = "true" ] && {
+	logger -t "modemmanager" "interface ${CFG} (network device ${INTERFACE}) ${STATE}"
+	proto_init_update $INTERFACE 0
+	proto_send_update $CFG
+}
+
 exit 0

--- a/net/modemmanager/files/modemmanager.proto
+++ b/net/modemmanager/files/modemmanager.proto
@@ -323,15 +323,6 @@ modemmanager_connected_method_static_ipv6() {
 	proto_send_update "${interface}"
 }
 
-modemmanager_disconnected_method_common() {
-	local interface="$1"
-
-	echo "running disconnection (common)"
-
-	proto_init_update "*" 0
-	proto_send_update "${interface}"
-}
-
 proto_modemmanager_init_config() {
 	available=1
 	no_device=1
@@ -628,7 +619,6 @@ proto_modemmanager_teardown() {
 
 	# disconnection handling only requires special treatment in IPv4/PPP
 	[ "${bearermethod_ipv4}" = "ppp" ] && modemmanager_disconnected_method_ppp_ipv4 "${interface}"
-	modemmanager_disconnected_method_common "${interface}"
 
 	# disconnect
 	mmcli --modem="${device}" --simple-disconnect ||
@@ -640,9 +630,6 @@ proto_modemmanager_teardown() {
 	# low power, only if requested
 	[ "${lowpower:-0}" -lt 1 ] ||
 		mmcli --modem="${device}" --set-power-state-low
-
-	proto_init_update "*" 0
-	proto_send_update "$interface"
 }
 
 [ -n "$INCLUDE_ONLY" ] || {


### PR DESCRIPTION
Maintainer: @mips171 , @aleksander0m
Compile tested: x86_64, APU3, latest openwrt master
Run tested: x86_64, APU3, latest openwrt master, test done = yes


Description:

The proto_send_update function is sending a notification to netifd during the teardown section.
However, netifd filters link-update-notifications executed during teardown, as indicated here: [Netifd-Code-Snippet]( https://git.openwrt.org/?p=project/netifd.git;a=blob;f=proto-shell.c;h=bc3c41dcba85ac46cff02db88b9d3ee8e9fc2a57;hb=HEAD#l515)
This was leading to a Permission Denied error due to its behavior, making proto_send_update ineffective during teardown.

To address the issue, the proto_send_update function has been removed from the teardown section.
This prevents the Permission Denied error while ensuring proper operation during teardown.

Additionally, in the 10-report-down helper script, a check has been implemented to determine if the interface is already down. This check is crucial to avoid triggering a Permission Denied error, especially in cases where netifd is already aware of a controlled ifdown operation.