### PR TITLE
ddns-scripts: desec.io - update url to https

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=38
+PKG_RELEASE:=39
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/desec.io.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/desec.io.json
@@ -1,11 +1,11 @@
 {
 	"name": "desec.io",
 	"ipv4": {
-		"url": "http://update.dedyn.io/update?username=[USERNAME]&password=[PASSWORD]&hostname=[DOMAIN]&myipv4=[IP]&myipv6=preserve",
+		"url": "https://update.dedyn.io/update?username=[USERNAME]&password=[PASSWORD]&hostname=[DOMAIN]&myipv4=[IP]&myipv6=preserve",
 		"answer": "good|nochg"
 	},
 	"ipv6": {
-		"url": "http://update.dedyn.io/update?username=[USERNAME]&password=[PASSWORD]&hostname=[DOMAIN]&myipv6=[IP]&myipv4=preserve",
+		"url": "https://update.dedyn.io/update?username=[USERNAME]&password=[PASSWORD]&hostname=[DOMAIN]&myipv6=[IP]&myipv4=preserve",
 		"answer": "good|nochg"
 	}
 }


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: OpenWrt 23.0.5
Run tested: Raspberry Pi 4B

Description:
desec.io ddns update is not working, after testing the endpoint I got a 301, after a bit of search I found out we are supposed to use https instead of http
more info here: https://talk.desec.io/t/301-from-update-dedyn-io/644/2