### PR TITLE
python-websocket-client: update to 1.6.2

### DIFF
--- a/lang/python/python-websocket-client/Makefile
+++ b/lang/python/python-websocket-client/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-websocket-client
-PKG_VERSION:=1.6.1
+PKG_VERSION:=1.6.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=websocket-client
-PKG_HASH:=c951af98631d24f8df89ab1019fc365f2227c0892f12fd150e935607c79dd0dd
+PKG_HASH:=53e95c826bf800c4c465f50093a8c4ff091c7327023b10bfaff40cf1ef170eaa
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream release.

 - Add support for SSLKEYLOGFILE environment variable
 - Add support for callable header arguments
 - Change handling of proxy environment variables, is_secure set to true now prevents http_proxy from getting used

