### PR TITLE
mhz: respect CC and CFLAGS passed by buildsystem

### DIFF
--- a/utils/mhz/Makefile
+++ b/utils/mhz/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mhz
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://github.com/wtarreau/mhz.git

--- a/utils/mhz/patches/0001-Makefile-allow-overriding-CC-and-CFLAGS.patch
+++ b/utils/mhz/patches/0001-Makefile-allow-overriding-CC-and-CFLAGS.patch
@@ -1,0 +1,29 @@
+From d55f7b578eb2126d2e4a7f045321f6ba7df3800a Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Wed, 30 Aug 2023 20:31:07 +0200
+Subject: [PATCH] Makefile: allow overriding CC and CFLAGS
+
+For OpenWrt and Buildroot which support really large amount of different
+architectures and cores it is sometimes required to pass our own CFLAGS.
+This is especially true if hardening options are to be respected.
+
+Also, for cross-compiling CC should be respected as currently it is
+working since both OpenWrt and Buildroot symlink gcc to the cross compiler.
+
+So, lets set the current values as defaults but allow them to be overriden.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,5 @@
+-CC         := gcc
+-CFLAGS     := -O3 -Wall -fomit-frame-pointer
++CC         ?= gcc
++CFLAGS     ?= -O3 -Wall -fomit-frame-pointer
+ 
+ all: mhz
+ 


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, a9/Turris Omnia and ipq807x/Qnap 301W
Run tested: ipq807x/Qnap 301W

Description:
It seems that the Makefile has both CC and CFLAGS hardcoded and does not allow overriding them by ones being passed by the buildsystem.

This works fine until CONFIG_PKG_ASLR_PIE_ALL is selected, then building will fail with:
```
arm-openwrt-linux-muslgnueabi/bin/ld.bfd: mhz.o: relocation R_ARM_MOVW_ABS_NC against `a local symbol' can not be used when making a shared object; recompile with -fPIC
arm-openwrt-linux-muslgnueabi/bin/ld.bfd: mhz.o(.text+0x75c): unresolvable R_ARM_CALL relocation against symbol `__aeabi_l2d@@GCC_3.5
```

So, lets add a patch pending upstream that allows both CC and CFLAGS to be overriden so that ones passed by the buildsystem are actually respected.

Fixes: 89123b308f98 ("mhz: add new package")
Fixes: #21956 