### PR TITLE
knot-resolver: update to version 5.7.0

### DIFF
--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -10,12 +10,12 @@ PKG_RELRO_FULL:=0
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot-resolver
-PKG_VERSION:=5.5.3
+PKG_VERSION:=5.7.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-resolver
-PKG_HASH:=a38f57c68b7d237d662784d8406e6098aad66a148f44dcf498d1e9664c5fed2d
+PKG_HASH:=383ef6db1cccabd2dd788ea9385f05e98a2bafdfeb7f0eda57ff9d572f4fad71
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=GPL-3.0-later

--- a/net/knot-resolver/patches/010-fix-lmdb.patch
+++ b/net/knot-resolver/patches/010-fix-lmdb.patch
@@ -17,4 +17,4 @@ which is now not propagated in OpenWrt meson host package.
 +##endif
  gnutls = dependency('gnutls')
  luajit = dependency('luajit')
- # NOTE avoid using link_args for luajit due to a macOS issue
+ message('------------------------------')


### PR DESCRIPTION
Maintainer: @ja-pa 
Compile tested: all Turris routers (Turris MOX - Marvell Armada 3720, Turris Omnia - Marvell Armada 385, Turris 1.0 and Turris 1.1 - PowerPC Freescale P2020), the latest changes from OpenWrt 21.02 and OpenWrt 22.03 branches
Run tested: same as above

Changelog:
https://www.knot-resolver.cz/2023-01-26-knot-resolver-5.6.0.html
https://www.knot-resolver.cz/2023-08-22-knot-resolver-5.7.0.html