### PR TITLE
syslog-ng: update to version 4.3.1

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
-PKG_VERSION:=4.2.0
+PKG_VERSION:=4.3.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
@@ -11,7 +11,7 @@ PKG_CPE_ID:=cpe:/a:balabit:syslog-ng
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syslog-ng/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
-PKG_HASH:=092bd17fd47002c988aebdf81d0ed3f3cfd0e82b388d2453bcaa5e67934f4dda
+PKG_HASH:=999dbab62982c3cffba02c0be22c596ee1ce81d6954689dc9b3a6afeb513cce3
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -33,7 +33,7 @@ define Package/syslog-ng
   CATEGORY:=Administration
   TITLE:=A powerful syslog daemon
   URL:=https://www.syslog-ng.com/products/open-source-log-management/
-  DEPENDS:=+libpcre +glib2 +libopenssl +libpthread +librt +zlib +libdbi +libjson-c +libcurl +libuuid +SYSLOGNG_LOGROTATE:logrotate
+  DEPENDS:=+libpcre2 +glib2 +libopenssl +libpthread +librt +zlib +libdbi +libjson-c +libcurl +libuuid +SYSLOGNG_LOGROTATE:logrotate
 endef
 
 define Package/syslog-ng/description
@@ -89,6 +89,7 @@ CONFIGURE_ARGS +=  \
 	--disable-sql \
 	--disable-linux-caps \
 	--with-jsonc=system \
+	--enable-cpp=no \
 	--enable-json=yes \
 	--enable-http=yes \
 	--disable-smtp \

--- a/admin/syslog-ng/files/syslog-ng.conf
+++ b/admin/syslog-ng/files/syslog-ng.conf
@@ -4,7 +4,7 @@
 # More details about these settings can be found here:
 # https://www.syslog-ng.com/technical-documents/list/syslog-ng-open-source-edition
 
-@version: 4.1
+@version: 4.3
 @include "scl.conf"
 
 options {


### PR DESCRIPTION
Maintainer: me
Compile tested: MacBook Pro, A1990, OpenWrt 22.03 for Turris Omnia, mvebu/cortexa9

Run tested: N/A, since I could not compile it for OpenWrt 21.02 due to Darwin platform, which resulted in cherry-picking a few commits to that branch, hopefully to be compiled, because the latest Turris OS version, which is now 6.3.1 still runs EoL, thus in the meantime, I prepared locally build env for OpenWrt 22.03, where it works.
Once, I confirm it that it works on the router, I will set my PR as ready instead of draft.

Description:
Makefile changes:
- Since version 4.3.0, there is required to use pcre2 instead of pcre 
Reference: https://github.com/syslog-ng/syslog-ng/pull/4537 (not mentioned in the release notes in tag :( )

- Disable c++ support by default to avoid picking and including libstdcpp dependency
Reference: https://github.com/syslog-ng/syslog-ng/pull/4484

Config changes:
- Bump version in config file