### PR TITLE
libmariadb: Fix async API by linking to libucontext

### DIFF
--- a/libs/libmariadb/Makefile
+++ b/libs/libmariadb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmariadb
 PKG_VERSION:=3.1.18
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=mariadb-connector-c-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL := \
@@ -35,7 +35,8 @@ MARIADB_CLIENT_PLUGINS := \
 	auth_gssapi_client \
 	remote_io
 
-PKG_BUILD_DEPENDS:=curl
+PKG_BUILD_DEPENDS:=curl USE_MUSL:libucontext
+
 PKG_CONFIG_DEPENDS := \
 	$(patsubst %,CONFIG_PACKAGE_$(PKG_NAME)-plugin-%,$(subst _,-,$(MARIADB_CLIENT_PLUGINS)))
 

--- a/libs/libmariadb/patches/010-link-to-libucontext.patch
+++ b/libs/libmariadb/patches/010-link-to-libucontext.patch
@@ -1,0 +1,61 @@
+libmariadb: Fix async api by linking to libucontext
+The asynchronous API of libmariadb uses cooperative multi threading
+by using the system calls
+  * makecontext
+  * swapcontext
+  * getcontext
+  * setcontext
+of the ucontext.h C-API.
+
+Thus additionally link libmariadb to libucontext which is a library
+providing these system calls on platforms not supporting them out of
+the box - like musl based platforms.
+--- a/libmariadb/CMakeLists.txt
++++ b/libmariadb/CMakeLists.txt
+@@ -417,7 +417,7 @@ ELSE()
+   SET_TARGET_PROPERTIES(libmariadb PROPERTIES LINKER_LANGUAGE C)
+ ENDIF()
+ 
+-TARGET_LINK_LIBRARIES(libmariadb LINK_PRIVATE ${SYSTEM_LIBS})
++TARGET_LINK_LIBRARIES(libmariadb LINK_PRIVATE ${SYSTEM_LIBS} ${LIBUCONTEXT_POSIX} ${LIBUCONTEXT})
+ 
+ SIGN_TARGET(libmariadb)
+ 
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -227,6 +227,14 @@ IF(UNIX)
+   SEARCH_LIBRARY(LIBPTHREAD pthread_getspecific "pthread;pthreads")
+   SEARCH_LIBRARY(LIBNSL gethostbyname_r "nsl_r;nsl")
+   SEARCH_LIBRARY(LIBSOCKET setsockopt socket)
++  SEARCH_LIBRARY(LIBUCONTEXT libucontext_swapcontext libucontext.a)
++  SEARCH_LIBRARY(LIBUCONTEXT_POSIX swapcontext libucontext_posix.a)
++  IF (NOT HAVE_LIBUCONTEXT_POSIX OR NOT HAVE_LIBUCONTEXT)
++    UNSET(HAVE_LIBUCONTEXT)
++    UNSET(LIBUCONTEXT)
++    UNSET(HAVE_LIBUCONTEXT_POSIX)
++    UNSET(LIBUCONTEXT_POSIX)
++  ENDIF()
+   FIND_PACKAGE(Threads)
+   SET(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${LIBNSL} ${LIBBIND} ${LIBICONV} ${LIBZ}
+     ${LIBSOCKET} ${CMAKE_DL_LIBS} ${LIBM} ${LIBPTHREAD})
+--- a/include/ma_config.h.in
++++ b/include/ma_config.h.in
+@@ -28,6 +28,7 @@
+ #cmakedefine HAVE_SYS_UN_H 1
+ #cmakedefine HAVE_UNISTD_H 1
+ #cmakedefine HAVE_UCONTEXT_H 1
++#cmakedefine HAVE_LIBUCONTEXT_POSIX 1
+ 
+ /*
+  * function definitions - processed in LibmysqlFunctions.txt 
+--- a/include/ma_context.h
++++ b/include/ma_context.h
+@@ -31,7 +31,7 @@
+ #define MY_CONTEXT_USE_X86_64_GCC_ASM
+ #elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__i386__)
+ #define MY_CONTEXT_USE_I386_GCC_ASM
+-#elif defined(HAVE_UCONTEXT_H)
++#elif defined(HAVE_UCONTEXT_H) || defined(HAVE_LIBUCONTEXT_POSIX)
+ #define MY_CONTEXT_USE_UCONTEXT
+ #else
+ #define MY_CONTEXT_DISABLE


### PR DESCRIPTION
Maintainer:  @miska

Description:
The asynchronous API of libmariadb uses cooperative multi threading by using the system calls
  * makecontext
  * swapcontext
  * getcontext
  * setcontext of the ucontext.h C-API.

Thus additionally link libmariadb to libucontext which is an library providing these system calls on platforms not supporting them out of the box - like musl based platforms.

Compile tested on:

- aarch64_cortex-a53
- aarch64_cortex-a72
- aarch64_generic
- arm_arm926ej-s
- arm_cortex-a15_neon-vfpv4
- arm_cortex-a7
- arm_cortex-a7_neon-vfpv4
- arm_cortex-a7_vfpv4
- arm_cortex-a9
- arm_cortex-a9_neon
- arm_cortex-a9_vfpv3-d16
- arm_fa526
- arm_mpcore
- arm_xscale
- i386_pentium-mmx
- mips_24kc
- mips64_octeonplus
- mipsel_24kc
- mipsel_24kc_24kf
- mipsel_74kc
- mipsel_mips32
- mips_mips32
- powerpc_464fp
- powerpc_8548
- riscv64_riscv64

Run tested:
- GL.iNet GL-A1300 (arm_cortex-a7_neon-vfpv4)
- GL.iNet GL-MT3000 (aarch64_cortex-a53)
- Linksys MR8300 (arm_cortex-a7_neon_vfpv4)
- Netgear R7800 (arm_cortex-a15_neon_vfpv4)
- TP-Link Archer A7v5 (mipsel_24kc)
