### PR TITLE
libedit: update to version 20230828-3.1

### DIFF
--- a/libs/libedit/Makefile
+++ b/libs/libedit/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libedit
-PKG_VERSION:=20221030-3.1
+PKG_VERSION:=20230828-3.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
@@ -16,7 +16,7 @@ PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://thrysoee.dk/editline/
-PKG_HASH:=f0925a5adf4b1bf116ee19766b7daa766917aec198747943b1c4edf67a4be2bb
+PKG_HASH:=4ee8182b6e569290e7d1f44f0f78dac8716b35f656b76528f699c69c98814dad
 
 PKG_INSTALL:=1
 


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan

Description:

- update of the library on which `knot` depends on