### PR TITLE
treewide: change my no longer used email

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -4,7 +4,7 @@ PKG_NAME:=syslog-ng
 PKG_VERSION:=4.2.0
 PKG_RELEASE:=1
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING LGPL.txt GPL.txt
 PKG_CPE_ID:=cpe:/a:balabit:syslog-ng

--- a/lang/python/python-astral/Makefile
+++ b/lang/python/python-astral/Makefile
@@ -16,7 +16,7 @@ PKG_HASH:=9b7c3b412e9e69d172cfb24be0e6addcc9f1bd01a28db8bebe66d75ccc533d88
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 
 PKG_BUILD_DEPENDS:=python-poetry-core/host
 

--- a/lang/python/python-awesomeversion/Makefile
+++ b/lang/python/python-awesomeversion/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=awesomeversion
 PKG_HASH:=a505558316010d2d10d487226f79c1157204af00fa462fdcf948e347011dd491
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENCE.md
 

--- a/lang/python/python-babel/Makefile
+++ b/lang/python/python-babel/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=Babel
 PKG_HASH:=cc2d99999cd01d44420ae725a21c9e3711b3aadc7976d6147f622d8581963455
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 

--- a/lang/python/python-cachetools/Makefile
+++ b/lang/python/python-cachetools/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=cachetools
 PKG_HASH:=dce83f2d9b4e1f732a8cd44af8e8fab2dbe46201467fc98b3ef8f269092bf62b
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 

--- a/lang/python/python-flask-babel/Makefile
+++ b/lang/python/python-flask-babel/Makefile
@@ -15,7 +15,7 @@ PYPI_NAME:=flask-babel
 PYPI_SOURCE_NAME:=flask_babel
 PKG_HASH:=be015772c5d7f046f3b99c508dcf618636eb93d21b713b356db79f3e79f69f39
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 

--- a/lang/python/python-flask-seasurf/Makefile
+++ b/lang/python/python-flask-seasurf/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=Flask-SeaSurf
 PKG_HASH:=54537008c769ac0ada8237877327c3e7ed74dcd8b01e74a9120ee0232c5951a9
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 

--- a/lang/python/python-flask-session/Makefile
+++ b/lang/python/python-flask-session/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=Flask-Session
 PKG_HASH:=0768e2bbf06f963ec1aa711bde7aa32dc39ff70f89b495d6db687d899eae4423
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 

--- a/lang/python/python-markdown/Makefile
+++ b/lang/python/python-markdown/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=Markdown
 PKG_HASH:=225c6123522495d4119a90b3a3ba31a1e87a70369e03f14799ea9c0d7183a3d6
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.md
 

--- a/lang/python/python-paho-mqtt/Makefile
+++ b/lang/python/python-paho-mqtt/Makefile
@@ -8,7 +8,7 @@ PKG_NAME:=python-paho-mqtt
 PKG_VERSION:=1.6.1
 PKG_RELEASE:=2
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>, Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=EPL-1.0 Eclipse Distribution License v1.0
 PKG_LICENSE_FILES:=epl-v10 edl-v10
 

--- a/lang/python/python-pyotp/Makefile
+++ b/lang/python/python-pyotp/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=pyotp
 PKG_HASH:=346b6642e0dbdde3b4ff5a930b664ca82abfa116356ed48cc42c7d6590d36f63
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 

--- a/lang/python/python-pyrsistent/Makefile
+++ b/lang/python/python-pyrsistent/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=pyrsistent
 PKG_HASH:=1a2994773706bbb4995c31a97bc94f1418314923bd1048c6d964837040376440
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.mit
 

--- a/lang/python/python-requests/Makefile
+++ b/lang/python/python-requests/Makefile
@@ -11,7 +11,7 @@ PKG_NAME:=python-requests
 PKG_VERSION:=2.31.0
 PKG_RELEASE:=1
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>, Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:python-requests:requests

--- a/lang/python/python-schedule/Makefile
+++ b/lang/python/python-schedule/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=schedule
 PKG_HASH:=b4ad697aafba7184c9eb6a1e2ebc41f781547242acde8ceae9a0a25b04c0922d
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
 

--- a/lang/python/python-sentry-sdk/Makefile
+++ b/lang/python/python-sentry-sdk/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=sentry-sdk
 PKG_HASH:=a99ee105384788c3f228726a88baf515fe7b5f1d2d0f215a03d194369f158df7
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 

--- a/lang/python/python-slugify/Makefile
+++ b/lang/python/python-slugify/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=ce0d46ddb668b3be82f4ed5e503dbc33dd815d83e2eb6824211310d3fb172a27
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 

--- a/lang/python/python-sqlalchemy/Makefile
+++ b/lang/python/python-sqlalchemy/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=SQLAlchemy
 PKG_HASH:=ca8a5ff2aa7f3ade6c498aaafce25b1eaeabe4e42b73e25519183e4566a16fc6
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:sqlalchemy:sqlalchemy

--- a/lang/python/python-tornado/Makefile
+++ b/lang/python/python-tornado/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=tornado
 PKG_HASH:=e7d8db41c0181c80d76c982aacc442c0783a2c54d6400fe028954201a2e032fe
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 

--- a/lang/python/python-uci/Makefile
+++ b/lang/python/python-uci/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=pyuci
 PKG_HASH:=865a45d48fb5d363f1230e94fa2c5b01ae6487f02f2180b0a6f78193a70166e2
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 

--- a/lang/python/python-unidecode/Makefile
+++ b/lang/python/python-unidecode/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=Unidecode
 PKG_HASH:=fed09cf0be8cf415b391642c2a5addfc72194407caee4f98719e40ec2a72b830
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 

--- a/lang/python/python-voluptuous-serialize/Makefile
+++ b/lang/python/python-voluptuous-serialize/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=5359f2e0a4f972ae03066e0777b4f0755c9226b2af099ca4fc55432efd1a447b
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=COPYING
 

--- a/lang/python/python-voluptuous/Makefile
+++ b/lang/python/python-voluptuous/Makefile
@@ -16,7 +16,7 @@ PKG_HASH:=663572419281ddfaf4b4197fd4942d181630120fb39b333e3adad70aeb56444b
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk

--- a/lang/python/python-yaml/Makefile
+++ b/lang/python/python-yaml/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=4
 PYPI_NAME:=PyYAML
 PKG_HASH:=68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:pyyaml_project:pyyaml

--- a/lang/python/python3-bottle/Makefile
+++ b/lang/python/python3-bottle/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=bottle
 PKG_HASH:=e1a9c94970ae6d710b3fb4526294dfeb86f2cb4a81eff3a4b98dc40fb0e5e021
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:bottlepy:bottle

--- a/lang/python/ruamel-yaml/Makefile
+++ b/lang/python/ruamel-yaml/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=ruamel.yaml
 PKG_HASH:=9751de4cbb57d4bfbf8fc394e125ed4a2f170fbff3dc3d78abf50be85924f8be
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 

--- a/lang/python/text-unidecode/Makefile
+++ b/lang/python/text-unidecode/Makefile
@@ -16,7 +16,7 @@ PKG_HASH:=bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93
 
 PKG_LICENSE:=Artistic-1.0-cl8
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk

--- a/net/dnscrypt-proxy2/Makefile
+++ b/net/dnscrypt-proxy2/Makefile
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=https://codeload.github.com/DNSCrypt/dnscrypt-proxy/tar.gz/$(PKG
 PKG_HASH:=05f0a3e8c8f489caf95919e2a75a1ec4598edd3428d2b9dd357caba6adb2607d
 PKG_BUILD_DIR:=$(BUILD_DIR)/dnscrypt-proxy-$(PKG_VERSION)
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=LICENSE
 

--- a/utils/reptyr/Makefile
+++ b/utils/reptyr/Makefile
@@ -9,7 +9,7 @@ PKG_SOURCE_URL:=https://github.com/nelhage/reptyr/archive/
 PKG_HASH:=c6ffbc34a511ac00d072219bda30699e51f2f4eb483cbae9e32e981d49e8b380
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION)
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
 

--- a/utils/sshpass/Makefile
+++ b/utils/sshpass/Makefile
@@ -8,7 +8,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/sshpass
 PKG_HASH:=71746e5e057ffe9b00b44ac40453bf47091930cba96bbea8dc48717dedc49fb7
 
-PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 


### PR DESCRIPTION
Since February 2023, I decided to no longer work with Turris, I mean CZ.NIC company due to some reasons how the development goes and since that day my work address is not available and not sure if there is some redirect to someone else, but if anyone wants to reach me, use my email address, where they can find me.

____

Also, it does not require to bump PKG_VERSION. My first thought of doing this was like, hey, I am not going to use these packages personally except syslog-ng and they are needed for Turris, so in the future, guys from Turris show up to take maintainership of these packages or there will be some alias, but... nope. That didn't happen and I haven't noticed that someone from Turris is active here as I was. Lets hope for brighter future now.