### PR TITLE
treewide: take maintainership from Karel

### DIFF
--- a/lang/python/python-appdirs/Makefile
+++ b/lang/python/python-appdirs/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=python-appdirs
 PKG_VERSION:=1.4.4
 PKG_RELEASE:=1
-PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com> 
 
 PYPI_NAME:=appdirs
 PKG_HASH:=7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41

--- a/lang/python/python-click-log/Makefile
+++ b/lang/python/python-click-log/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=python-click-log
 PKG_VERSION:=0.4.0
 PKG_RELEASE:=1
-PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com> 
 
 PYPI_NAME:=click-log
 PKG_HASH:=3970f8570ac54491237bcdb3d8ab5e3eef6c057df29f8c3d1151a51a9c23b975

--- a/lang/python/python-contextlib2/Makefile
+++ b/lang/python/python-contextlib2/Makefile
@@ -11,7 +11,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=contextlib2
 PKG_HASH:=ab1e2bfe1d01d968e1b7e8d9023bc51ef3509bba217bb730cee3827e1ee82869
 
-PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com> 
 PKG_LICENSE:=PSF-2.0 Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.txt
 

--- a/lang/python/python-decorator/Makefile
+++ b/lang/python/python-decorator/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=python-decorator
 PKG_VERSION:=4.4.2
 PKG_RELEASE:=1
-PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com> 
 PKG_CPE_ID:=cpe:/a:python:decorator
 
 PYPI_NAME:=decorator

--- a/lang/python/python-influxdb/Makefile
+++ b/lang/python/python-influxdb/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=python-influxdb
 PKG_VERSION:=5.3.1
 PKG_RELEASE:=1
-PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com> 
 
 PYPI_NAME:=influxdb
 PKG_HASH:=46f85e7b04ee4b3dee894672be6a295c94709003a7ddea8820deec2ac4d8b27a

--- a/lang/python/python-intelhex/Makefile
+++ b/lang/python/python-intelhex/Makefile
@@ -11,7 +11,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=intelhex
 PKG_HASH:=892b7361a719f4945237da8ccf754e9513db32f5628852785aea108dcd250093
 
-PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com> 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.txt
 

--- a/lang/python/python-jsonpath-ng/Makefile
+++ b/lang/python/python-jsonpath-ng/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=python-jsonpath-ng
 PKG_VERSION:=1.5.3
 PKG_RELEASE:=1
-PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com> 
 
 PYPI_NAME:=jsonpath-ng
 PKG_HASH:=a273b182a82c1256daab86a313b937059261b5c5f8c4fa3fc38b882b344dd567

--- a/lang/python/python-schema/Makefile
+++ b/lang/python/python-schema/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=python-schema
 PKG_VERSION:=0.7.5
 PKG_RELEASE:=1
-PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com> 
 
 PYPI_NAME:=schema
 PKG_HASH:=f06717112c61895cabc4707752b88716e8420a8819d71404501e114f91043197

--- a/utils/bigclown/bigclown-control-tool/Makefile
+++ b/utils/bigclown/bigclown-control-tool/Makefile
@@ -11,7 +11,7 @@ PKG_RELEASE:=3
 PYPI_NAME:=bch
 PKG_HASH:=4cd73b92757fce7275a4744baed411c867af2e671c521b90d6690b2320851d58
 
-PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com> 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 

--- a/utils/bigclown/bigclown-firmware-tool/Makefile
+++ b/utils/bigclown/bigclown-firmware-tool/Makefile
@@ -11,7 +11,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=bcf
 PKG_HASH:=8ad897586d02433d01a58b4978516621bea388cd230640eb0b8f8f9e40f10e6c
 
-PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com> 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 

--- a/utils/bigclown/bigclown-gateway/Makefile
+++ b/utils/bigclown/bigclown-gateway/Makefile
@@ -11,7 +11,7 @@ PKG_RELEASE:=3
 PYPI_NAME:=bcg
 PKG_HASH:=ce7f27f372551c0beb3f8929af2d779417d9dcd0feaa2fa2dc49e87b1416c536
 
-PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com> 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 

--- a/utils/bigclown/bigclown-mqtt2influxdb/Makefile
+++ b/utils/bigclown/bigclown-mqtt2influxdb/Makefile
@@ -11,7 +11,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=mqtt2influxdb
 PKG_HASH:=9fd98d2239c0b9a2482db8e55e3e5a310c5b644aa7d42c57d35ed775adb0101a
 
-PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com> 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 


### PR DESCRIPTION
Maintainer: @Cynerd 
Compile and run tested: NO

Description:

Both of us were working for Turris and using these devices on daily basis. A few of these packages are still required and used by Turris. It would be great if Turris people will take maintainership of these packages, but if they decide not to, I can step in and take them.

Since Karel switched from using OpenWrt to NixOS and hopefully, I didn't reveal some secret here, let's take maintainership of his packages.

_____

Hey @Cynerd ,

Thank you for all your work, which you need here and also mainly for Turris, it was great to see you and work with you!
Hopefully, someday, we will meet again. There is a plenty of things, which I can learn from you.

Oh, I forgot one thing, don't worry guys, ex Turris people sticks together, we are still in contact, which is nice. :-) We were not just colleagues working on one thing, but also become friends and from time to time, we are seeing each other and this is what we agreed on that I will take maintainership of these packages.
