### PR TITLE
python-pyserial: Update to 3.5, update list of dependencies

### DIFF
--- a/lang/python/python-pyserial/Makefile
+++ b/lang/python/python-pyserial/Makefile
@@ -8,13 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyserial
-PKG_VERSION:=3.4
-PKG_RELEASE:=2
+PKG_VERSION:=3.5
+PKG_RELEASE:=1
 
 PYPI_NAME:=pyserial
-PKG_HASH:=6e2d401fdee0eab996cf734e67773a0143b932772ca8b42451440cfed942c627
+PKG_HASH:=3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb
 
-PKG_LICENSE:=BSD
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE.txt
 PKG_MAINTAINER:=Micke Prag <micke.prag@telldus.se>
 
 include ../pypi.mk
@@ -22,19 +23,19 @@ include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
 define Package/python3-pyserial
-  SECTION:=lang-python
+  SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  TITLE:=python3-pyserial
+  TITLE:=Serial Port Extension
   URL:=https://github.com/pyserial/pyserial
-  DEPENDS:=+python3-light
+  DEPENDS:=+python3-light +python3-logging +python3-urllib
 endef
 
 define Package/python3-pyserial/description
-This module encapsulates the access for the serial port. It provides backends
-for Python running on Windows, OSX, Linux, BSD (possibly any POSIX compliant
-system) and IronPython. The module named "serial" automatically selects the
-appropriate backend.
+This module encapsulates the access for the serial port. It provides
+backends for Python running on Windows, OSX, Linux, BSD (possibly any
+POSIX compliant system) and IronPython. The module named "serial"
+automatically selects the appropriate backend.
 endef
 
 $(eval $(call Py3Package,python3-pyserial))


### PR DESCRIPTION
Maintainer: @mickeprag
Compile tested: armsr-armv7, 2023-09-03 snapshot sdk
Run tested: armsr-armv7 (qemu, basic module loading only), 2023-09-03 snapshot

Description:
