### PR TITLE
[openwrt-23.05] lua-eco: update to 2.5.1

### DIFF
--- a/lang/lua-eco/Makefile
+++ b/lang/lua-eco/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lua-eco
-PKG_VERSION:=2.5.0
+PKG_VERSION:=2.5.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://github.com/zhaojh329/lua-eco/releases/download/v$(PKG_VERSION)
-PKG_HASH:=d41668d137780f2655ebfec88276249bb9cd5c53f758c3e2103eb001ed9b5d02
+PKG_HASH:=436c09dd7dbc88ab651ae7696f2102b5635628ab420cc550bc237ecb04cade5d
 
 PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
(cherry picked from commit 4af428ec71af88470903d3459b720727714cde16)

Maintainer: me
Compile tested: x86, x86, master
Run tested: x86, x86, master, tests done

Description:
Release notes for 2.5.1: https://github.com/zhaojh329/lua-eco/releases/tag/v2.5.1
