### PR TITLE
SNode.C: Add package

### DIFF
--- a/net/snode.c/Config.in
+++ b/net/snode.c/Config.in
@@ -1,17 +1,13 @@
 menu "Configuration"
 	depends on PACKAGE_snode.c-utils
 
-	config SNODEC_GROUP_ID
-		int
-		prompt "Group id of group snodec"
-		default "1023"
+	config SNODEC_GROUP_NAME
+		string "Group name of unix group used for config/log/pid file management"
+		default snodec
 		help
-				The group id for unix group 'snodec'. This group is used for config/log/pid file
-				management.
-				(default: 1023)
-
-				https://github.com/VolkerChristian/snode.c
-				Volker Christian <me@vchrist.at>
+				The group name for unix group used for permission management of
+				config, log, and pid files.
+				(default: snodec)
 
 	choice
 		depends on PACKAGE_snode.c-core
@@ -24,18 +20,12 @@ menu "Configuration"
 				  * poll
 				  * select
 
-				https://github.com/VolkerChristian/snode.c
-				Volker Christian <me@vchrist.at>
-
 		config SNODEC_EPOLL
 			select PACKAGE_snode.c-core-mux-epoll
 			bool "epoll"
 			help
 					If choosen SNode.C will use 'epoll' as default I/O multiplexer.
 					(overrideable with LD_PRELOAD)
-
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
 
 		config SNODEC_POLL
 			select PACKAGE_snode.c-core-mux-poll
@@ -44,18 +34,12 @@ menu "Configuration"
 					If choosen SNode.C will use 'poll' as default I/O multiplexer.
 					(override with LD_PRELOAD)
 
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
-
 		config SNODEC_SELECT
 			select PACKAGE_snode.c-core-mux-select
 			bool "select"
 			help
 					If choosen SNode.C will use 'select' as default I/O multiplexer.
 					(override with LD_PRELOAD)
-
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
 	endchoice
 
 	menu "Socket connection behavior"
@@ -69,9 +53,6 @@ menu "Configuration"
 					Read block size in bytes.
 					(default: 16384)
 
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
-
 		config SNODEC_WRITE_BLOCKSIZE
 			int
 			prompt "Write block size in bytes"
@@ -80,30 +61,21 @@ menu "Configuration"
 					Write block size in bytes.
 					(default: 16384)
 
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
-
 		config SNODEC_READ_TIMEOUT
 			int
 			prompt "Read inactivity timeout in seconds"
 			default 60
 			help
-					Read inactivity timeout after which a connection is aborted
+					Read inactivity timeout after which a connection is aborted.
 					(default: 60, 0 = unlimited)
-
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
 
 		config SNODEC_WRITE_TIMEOUT
 			int
 			prompt "Write inactivity timeout in seconds"
 			default 60
 			help
-					Write inactivity timeout after which a connection is aborted
+					Write inactivity timeout after which a connection is aborted.
 					(default: 60, 0 = unlimited)
-
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
 	endmenu
 
 	menu "Server (stream) behavior"
@@ -117,9 +89,6 @@ menu "Configuration"
 					Listen backlog count.
 					(default: 5)
 
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
-
 		config SNODEC_ACCEPTS_PER_TICK
 			int
 			prompt "Accepts per tick"
@@ -127,9 +96,6 @@ menu "Configuration"
 			help
 					Maximum number of accepted connections per tick.
 					(default: 1)
-
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
 	endmenu
 
 	menu "Socket (stream) behavior"
@@ -144,9 +110,6 @@ menu "Configuration"
 					is taken offline.
 					(default: 0, 0 = unlimited)
 
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
-
 		config SNODEC_CONNECT_TIMEOUT
 			int
 			default 10
@@ -156,19 +119,13 @@ menu "Configuration"
 					connection can not be established.
 					(default: 10, 0 = unlimited)
 
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
-
 		config SNODEC_TERMINATE_TIMEOUT
 			int
 			prompt "Shutdown timeout in seconds"
 			default 1
 			help
-					Shutdown timeout after which a connection is aborted
+					Shutdown timeout after which a connection is aborted.
 					(default: 1)
-
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
 
 		menuconfig SNODEC_RECONNECT
 			bool
@@ -177,9 +134,6 @@ menu "Configuration"
 			help
 					Reconnect to a server if a previous connection was lost.
 					(default: n)
-
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
 
 		config SNODEC_RECONNECT_TIME
 		    depends on SNODEC_RECONNECT
@@ -190,9 +144,6 @@ menu "Configuration"
 					Duration after disconnecting bevore reconnecting.
 					(default: 1)
 
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
-
 		menuconfig SNODEC_RETRY
 			bool
 			default n
@@ -201,9 +152,6 @@ menu "Configuration"
 					Retry *listen* in case the socket address/port is already in use.
 					Retry *connect* in case the connection to the peer could not be established.
 					(default: n)
-
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
 
 		config SNODEC_RETRY_TIMEOUT
 		    depends on SNODEC_RETRY
@@ -215,9 +163,6 @@ menu "Configuration"
 					exponential increase.
 					(default: 1)
 
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
-
 		config SNODEC_RETRY_TRIES
 		    depends on SNODEC_RETRY
 			int
@@ -226,9 +171,6 @@ menu "Configuration"
 			help
 					The upper limit of retries to listen on an address or to connect to a peer.
 					(default: 0, 0 = unlimited)
-
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
 
 		config SNODEC_RETRY_BASE
 		    depends on SNODEC_RETRY
@@ -239,9 +181,6 @@ menu "Configuration"
 					The current retry timeout is multiplied by this value for each retry.
 					(default: 1.8)
 
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
-
 		config SNODEC_RETRY_JITTER
 		    depends on SNODEC_RETRY
 			int
@@ -251,9 +190,6 @@ menu "Configuration"
 					Maximum jitter in percent applied randomly to the calculated retry timeout.
 					(default: 0, 0 = disable)
 
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
-
 		config SNODEC_RETRY_LIMIT
 		    depends on SNODEC_RETRY
 			int
@@ -261,10 +197,7 @@ menu "Configuration"
 			prompt "Upper limit of retry timeout in seconds"
 			help
 					Upper limit for the retry timeout even if the calculated timeout is greater.
-					(default: 0, 0 = unlimited).
-
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
+					(default: 0, 0 = unlimited)
 
 		config SNODEC_REUSE_ADDRESS
 			bool
@@ -273,9 +206,6 @@ menu "Configuration"
 			help
 					Whether the socket address should be immediately reusable or not.
 					(default: n)
-
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
 
 		config SNODEC_REUSE_PORT
 			depends on PACKAGE_snode.c-net-in || PACKAGE_snode.c-net-in6
@@ -287,9 +217,6 @@ menu "Configuration"
 					Under Linux this makes it is possible to create a simple "multitasking" server.
 					(default: n)
 
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
-
 		config SNODEC_IPV6_ONLY
 			depends on PACKAGE_snode.c-net-in6
 			bool
@@ -300,9 +227,6 @@ menu "Configuration"
 					If not selected, IPv4 connections are also accepted (dual stack).
 					(default: n)
 
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
-
 		config SNODEC_IPV4_MAPPED
 			depends on PACKAGE_snode.c-net-in6
 			bool
@@ -311,9 +235,6 @@ menu "Configuration"
 			help
 					If selected, domain names can also be resolved to IPv4-mapped IPv6 addresses.
 					(default: n)
-
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
 	endmenu
 
 	menu "SSL/TLS behavior"
@@ -327,18 +248,12 @@ menu "Configuration"
 					Maximum duration of the initial SSL/TLS handshake befor a connection is aborted.
 					(default: 10)
 
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
-
 		config SNODEC_TLS_SHUTDOWN_TIMEOUT
 			int
 			prompt "SSL/TLS teardown timeout in seconds"
 			default 2
 			help
-					Maximum duration of SSL/TLS shutdown before a connection is aborted.
+					Maximum duration of the SSL/TLS shutdown before a connection is aborted.
 					(default: 2)
-
-					https://github.com/VolkerChristian/snode.c
-					Volker Christian <me@vchrist.at>
 	endmenu
 endmenu

--- a/net/snode.c/Config.in
+++ b/net/snode.c/Config.in
@@ -1,0 +1,344 @@
+menu "Configuration"
+	depends on PACKAGE_snode.c-utils
+
+	config SNODEC_GROUP_ID
+		int
+		prompt "Group id of group snodec"
+		default "1023"
+		help
+				The group id for unix group 'snodec'. This group is used for config/log/pid file
+				management.
+				(default: 1023)
+
+				https://github.com/VolkerChristian/snode.c
+				Volker Christian <me@vchrist.at>
+
+	choice
+		depends on PACKAGE_snode.c-core
+		prompt "I/O Multiplexer"
+		default SNODEC_EPOLL
+		help
+				The I/O multiplexer SNode.C will use by default.
+				Possible choices:
+				  * epoll (default)
+				  * poll
+				  * select
+
+				https://github.com/VolkerChristian/snode.c
+				Volker Christian <me@vchrist.at>
+
+		config SNODEC_EPOLL
+			select PACKAGE_snode.c-core-mux-epoll
+			bool "epoll"
+			help
+					If choosen SNode.C will use 'epoll' as default I/O multiplexer.
+					(overrideable with LD_PRELOAD)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_POLL
+			select PACKAGE_snode.c-core-mux-poll
+			bool "poll"
+			help
+					If choosen SNode.C will use 'poll' as default I/O multiplexer.
+					(override with LD_PRELOAD)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_SELECT
+			select PACKAGE_snode.c-core-mux-select
+			bool "select"
+			help
+					If choosen SNode.C will use 'select' as default I/O multiplexer.
+					(override with LD_PRELOAD)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+	endchoice
+
+	menu "Socket connection behavior"
+		depends on PACKAGE_snode.c-core-socket
+
+		config SNODEC_READ_BLOCKSIZE
+			int
+			prompt "Read block size in bytes"
+			default 16384
+			help
+					Read block size in bytes.
+					(default: 16384)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_WRITE_BLOCKSIZE
+			int
+			prompt "Write block size in bytes"
+			default 16384
+			help
+					Write block size in bytes.
+					(default: 16384)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_READ_TIMEOUT
+			int
+			prompt "Read inactivity timeout in seconds"
+			default 60
+			help
+					Read inactivity timeout after which a connection is aborted
+					(default: 60, 0 = unlimited)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_WRITE_TIMEOUT
+			int
+			prompt "Write inactivity timeout in seconds"
+			default 60
+			help
+					Write inactivity timeout after which a connection is aborted
+					(default: 60, 0 = unlimited)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+	endmenu
+
+	menu "Server (stream) behavior"
+		depends on PACKAGE_snode.c-core-socket-stream
+
+		config SNODEC_BACKLOG
+			int
+			default 5
+			prompt "Listen backlog"
+			help
+					Listen backlog count.
+					(default: 5)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_ACCEPTS_PER_TICK
+			int
+			prompt "Accepts per tick"
+			default 1
+			help
+					Maximum number of accepted connections per tick.
+					(default: 1)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+	endmenu
+
+	menu "Socket (stream) behavior"
+		depends on PACKAGE_snode.c-core-socket-stream
+
+		config SNODEC_ACCEPT_TIMEOUT
+			int
+			default 0
+			prompt "Accept inactivity timeout in seconds"
+			help
+					Accept inactivity (no new connection attempts) after which a server
+					is taken offline.
+					(default: 0, 0 = unlimited)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_CONNECT_TIMEOUT
+			int
+			default 10
+			prompt "Connect timeout in seconds"
+			help
+					Timeout in seconds after which a connect attempt will be aborted if the
+					connection can not be established.
+					(default: 10, 0 = unlimited)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_TERMINATE_TIMEOUT
+			int
+			prompt "Shutdown timeout in seconds"
+			default 1
+			help
+					Shutdown timeout after which a connection is aborted
+					(default: 1)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		menuconfig SNODEC_RECONNECT
+			bool
+			default n
+			prompt "Reconnect after disconnect"
+			help
+					Reconnect to a server if a previous connection was lost.
+					(default: n)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_RECONNECT_TIME
+		    depends on SNODEC_RECONNECT
+			string
+			default 1
+			prompt "Reconnect time in seconds"
+			help
+					Duration after disconnecting bevore reconnecting.
+					(default: 1)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		menuconfig SNODEC_RETRY
+			bool
+			default n
+			prompt "Retry listen and connect"
+			help
+					Retry *listen* in case the socket address/port is already in use.
+					Retry *connect* in case the connection to the peer could not be established.
+					(default: n)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_RETRY_TIMEOUT
+		    depends on SNODEC_RETRY
+			int
+			default 1
+			prompt "Retry interval in seconds"
+			help
+					The retry interval between two connect attempts, modified with jitter and
+					exponential increase.
+					(default: 1)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_RETRY_TRIES
+		    depends on SNODEC_RETRY
+			int
+			default 0
+			prompt "Upper limit of retry tries"
+			help
+					The upper limit of retries to listen on an address or to connect to a peer.
+					(default: 0, 0 = unlimited)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_RETRY_BASE
+		    depends on SNODEC_RETRY
+			string
+			default "1.8"
+			prompt "Base of exponential increase"
+			help
+					The current retry timeout is multiplied by this value for each retry.
+					(default: 1.8)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_RETRY_JITTER
+		    depends on SNODEC_RETRY
+			int
+			default 0
+			prompt "Jitter of retry timeout in percent"
+			help
+					Maximum jitter in percent applied randomly to the calculated retry timeout.
+					(default: 0, 0 = disable)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_RETRY_LIMIT
+		    depends on SNODEC_RETRY
+			int
+			default 0
+			prompt "Upper limit of retry timeout in seconds"
+			help
+					Upper limit for the retry timeout even if the calculated timeout is greater.
+					(default: 0, 0 = unlimited).
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_REUSE_ADDRESS
+			bool
+			default n
+			prompt "Reuse address"
+			help
+					Whether the socket address should be immediately reusable or not.
+					(default: n)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_REUSE_PORT
+			depends on PACKAGE_snode.c-net-in || PACKAGE_snode.c-net-in6
+			bool
+			default n
+			prompt "Reuse port (IPv4/IPv6)"
+			help
+					If selected, the port can be reused for further IPv4 or IPv6 servers.
+					Under Linux this makes it is possible to create a simple "multitasking" server.
+					(default: n)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_IPV6_ONLY
+			depends on PACKAGE_snode.c-net-in6
+			bool
+			default n
+			prompt "IPv6 only"
+			help
+					If selected, an IPv6 server only accepts IPv6 (single-stack) connections.
+					If not selected, IPv4 connections are also accepted (dual stack).
+					(default: n)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_IPV4_MAPPED
+			depends on PACKAGE_snode.c-net-in6
+			bool
+			default n
+			prompt "IPv4-mapped IPv6 addresses"
+			help
+					If selected, domain names can also be resolved to IPv4-mapped IPv6 addresses.
+					(default: n)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+	endmenu
+
+	menu "SSL/TLS behavior"
+		depends on PACKAGE_snode.c-core-socket-stream-tls
+
+		config SNODEC_TLS_INIT_TIMEOUT
+			int
+			prompt "SSL/TLS initial handshake timeout in seconds"
+			default 10
+			help
+					Maximum duration of the initial SSL/TLS handshake befor a connection is aborted.
+					(default: 10)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+
+		config SNODEC_TLS_SHUTDOWN_TIMEOUT
+			int
+			prompt "SSL/TLS teardown timeout in seconds"
+			default 2
+			help
+					Maximum duration of SSL/TLS shutdown before a connection is aborted.
+					(default: 2)
+
+					https://github.com/VolkerChristian/snode.c
+					Volker Christian <me@vchrist.at>
+	endmenu
+endmenu

--- a/net/snode.c/Makefile
+++ b/net/snode.c/Makefile
@@ -1,0 +1,275 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=snode.c
+PKG_VERSION:=0.90
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/SNodeC/snode.c/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=49c3629f302e7760edf08430c1d6787c181a835b1db136c2dcc30a68186134c7
+
+# PKG_SOURCE_URL:=https://api.github.com/repos/SNodeC/snode.c/tarball/v$(PKG_VERSION)?
+# PKG_HASH:=446e470b5f33291e75078d775308bc0efdd184b07e93d6a4f18022bb5afd60b1
+
+PKG_MAINTAINER:=Volker Christian <me@vchrist.at>
+PKG_LICENSE:=LGPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=nlohmannjson easyloggingpp
+PKG_BUILD_PARALLEL:=1
+
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+ifdef CONFIG_SNODEC_EPOLL
+  CONFIG_SNODEC_IO_MULTIPLEXER=epoll
+else ifdef CONFIG_SNODEC_POLL
+  CONFIG_SNODEC_IO_MULTIPLEXER=poll
+else ifdef CONFIG_SNODEC_SELECT
+  CONFIG_SNODEC_IO_MULTIPLEXER=select
+endif
+
+CMAKE_OPTIONS+=-DIO_MULTIPLEXER=$(CONFIG_SNODEC_IO_MULTIPLEXER) \
+               -DREAD_BLOCKSIZE=$(CONFIG_SNODEC_READ_BLOCKSIZE) \
+               -DWRITE_BLOCKSIZE=$(CONFIG_SNODEC_WRITE_BLOCKSIZE) \
+               -DREAD_TIMEOUT=$(CONFIG_SNODEC_READ_TIMEOUT) \
+               -DWRITE_TIMEOUT=$(CONFIG_SNODEC_WRITE_TIMEOUT) \
+               -DTERMINATE_TIMEOUT=$(CONFIG_SNODEC_TERMINATE_TIMEOUT) \
+               -DBACKLOG=$(CONFIG_SNODEC_BACKLOG) \
+               -DACCEPTS_PER_TICK=$(CONFIG_SNODEC_ACCEPTS_PER_TICK) \
+               -DREUSE_ADDRESS=$(CONFIG_SNODEC_REUSE_ADDRESS) \
+               -DREUSE_PORT=$(CONFIG_SNODEC_REUSE_PORT) \
+               -DIPV6_ONLY=$(CONFIG_SNODEC_IPV6_ONLY) \
+               -DIPV4_MAPPED=$(CONFIG_SNODEC_IPV4_MAPPED) \
+               -DACCEPT_TIMEOUT=$(CONFIG_SNODEC_ACCEPT_TIMEOUT) \
+               -DCONNECT_TIMEOUT=$(CONFIG_SNODEC_CONNECT_TIMEOUT) \
+               -DRECONNECT=$(CONFIG_SNODEC_RECONNECT) \
+               -DRECONNECT_TIME=$(CONFIG_SNODEC_RECONNECT_TIME) \
+               -DRETRY=$(CONFIG_SNODEC_RETRY) \
+               -DRETRY_TIMEOUT=$(CONFIG_SNODEC_RETRY_TIMEOUT) \
+               -DRETRY_TRIES=$(CONFIG_SNODEC_RETRY_TRIES) \
+               -DRETRY_BASE=$(CONFIG_SNODEC_RETRY_BASE) \
+               -DRETRY_JITTER=$(CONFIG_SNODEC_RETRY_JITTER) \
+               -DRETRY_LIMIT=$(CONFIG_SNODEC_RETRY_LIMIT) \
+               -DTLS_INIT_TIMEOUT=$(CONFIG_SNODEC_TLS_INIT_TIMEOUT) \
+               -DTLS_SHUTDOWN_TIMEOUT=$(CONFIG_SNODEC_TLS_SHUTDOWN_TIMEOUT) \
+               -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+               -DCMAKE_SKIP_RPATH=FALSE
+
+define Package/snode.c/Default
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=SNode.C
+  URL:=https://github.com/VolkerChristian/snode.c
+  Maintainer:=Volker Christian <me@vchrist.at>
+endef
+
+define Package/snode.c
+  $(call Package/snode.c/Default)
+  TITLE:=Easy to use lightwight layer based network framework for C++
+  DEPENDS:=+libstdcpp
+endef
+
+define Package/snode.c/description
+  SNode.C is a very simple to use lightweight highly extendable event
+driven layer-based framework for network applications in the spirit
+of node.js written entirely in C++.
+
+endef
+
+define Package/snode.c/config
+  source "$(SOURCE)/Config.in"
+endef
+
+define Package/snode.c/install
+	true
+endef
+
+SNODEC_GROUP_NAME=snodec
+SNODEC_GROUP_ID=$(call qstrip,$(CONFIG_SNODEC_GROUP_ID))
+
+define Package/snode.c/postinst
+#!/bin/sh
+
+GROUP_NAME=$(SNODEC_GROUP_NAME)
+GROUP_ID=$(SNODEC_GROUP_ID)
+
+if [ -z $$(grep "^$${GROUP_NAME}:" $${IPKG_INSTROOT}/etc/group) ]; then
+	echo "Adding group '$${GROUP_NAME}' with ID $${GROUP_ID} to /etc/group and assign user root to it"
+	echo "$${GROUP_NAME}:x:$${GROUP_ID}:root" >> $${IPKG_INSTROOT}/etc/group
+else
+	echo "Adding group '$${GROUP_NAME}' to /etc/group failed: group exists"
+fi
+endef
+
+define Package/snode.c/prerm
+#!/bin/sh
+
+GROUP_NAME=$(SNODEC_GROUP_NAME)
+GROUP_ID=$(SNODEC_GROUP_ID)
+
+if [ ! -z $$(grep "^$${GROUP_NAME}:.*:$${GROUP_ID}" $${IPKG_INSTROOT}/etc/group) ]; then
+	echo "Removing group '$${GROUP_NAME}' from /etc/group"
+	sed -i "/^$${GROUP_NAME}:/d" /etc/group
+else
+	echo "Removing group '$${GROUP_NAME}' from /etc/group failed: no such group"
+fi
+endef
+
+SO_VERSION=$(shell echo $(PKG_VERSION) | cut -d'.' -f1)
+
+define BuildSNodeCModule
+  define Package/snode.c-$(1)
+    $$(call Package/snode.c/Default)
+    TITLE:=$(1) module
+    DEPENDS:=$(2)
+  endef
+
+  define Package/snode.c-$(1)/description
+    This package contains the module '$(1)' of SNode.C
+
+  endef
+  
+  define Package/snode.c-$(1)/install
+	$(INSTALL_DIR) $$(1)$(3)
+	$(CP) $(PKG_INSTALL_DIR)$(3)/libsnodec-$(1).so.$(SO_VERSION) $$(1)$(3)/ 2> /dev/null || true
+  endef
+
+  $$(eval $$(call BuildPackage,snode.c-$(1)))
+endef
+
+define Package/snode.c-full
+  $(call Package/snode.c/Default)
+  TITLE:=install all modules (no apps)
+  DEPENDS:=+snode.c-core-mux-epoll \
+           +snode.c-core-mux-poll \
+           +snode.c-core-mux-select \
+           +snode.c-net-in-stream-legacy \
+           +snode.c-net-in-stream-tls \
+           +snode.c-net-in6-stream-legacy \
+           +snode.c-net-in6-stream-tls \
+           +snode.c-net-l2-stream-legacy \
+           +snode.c-net-l2-stream-tls \
+           +snode.c-net-rc-stream-legacy \
+           +snode.c-net-rc-stream-tls \
+           +snode.c-net-un-stream-legacy \
+           +snode.c-net-un-stream-tls \
+           +snode.c-net-un-dgram \
+           +snode.c-http-server-express \
+           +snode.c-http-client \
+           +snode.c-websocket-server \
+           +snode.c-websocket-client \
+           +snode.c-mqtt-server-websocket \
+           +snode.c-mqtt-client-websocket \
+           +snode.c-db-mariadb
+endef
+
+define Package/snode.c-full/description
+ This meta-package contains dependencies for all of the SNode.C modules.
+Note that the demo applications are not part of that dependency.
+
+endef
+
+define Package/snode.c-full/install
+	true
+endef
+
+define Package/snode.c-apps
+  $(call Package/snode.c/Default)
+  TITLE:=SNode.C demo applications
+  DEPENDS:=+snode.c-net-in-stream-legacy \
+           +snode.c-net-in-stream-tls \
+           +snode.c-net-in6-stream-legacy \
+           +snode.c-net-in6-stream-tls \
+           +snode.c-net-l2-stream-legacy \
+           +snode.c-net-l2-stream-tls \
+           +snode.c-net-rc-stream-legacy \
+           +snode.c-net-rc-stream-tls \
+           +snode.c-net-un-stream-legacy \
+           +snode.c-net-un-stream-tls \
+           +snode.c-http-server-express \
+           +snode.c-http-client \
+           +snode.c-websocket-server \
+           +snode.c-websocket-client \
+           +snode.c-mqtt-server \
+           +snode.c-mqtt-client \
+           +snode.c-db-mariadb
+endef
+
+define Package/snode.c-apps/description
+ This package contains all demo applications of SNode.C.
+
+endef
+
+define Package/snode.c-apps/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/lib/snode.c/web/http/upgrade/websocket
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/snode.c/web/http/upgrade/websocket/libsnodec-websocket-echo-server.so.$(SO_VERSION) $(1)/usr/lib/snode.c/web/http/upgrade/websocket/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/snode.c/web/http/upgrade/websocket/libsnodec-websocket-echo-client.so.$(SO_VERSION) $(1)/usr/lib/snode.c/web/http/upgrade/websocket/
+endef
+
+ifdef CONFIG_SNODEC_IO_MULTIPLEXER
+  CONFIG_SNODEC_IO_MULTIPLEXER_DEPENDENCY=+snode.c-core-mux-$(CONFIG_SNODEC_IO_MULTIPLEXER)
+endif
+
+$(eval $(call BuildPackage,snode.c))
+$(eval $(call BuildPackage,snode.c-apps))
+$(eval $(call BuildPackage,snode.c-full))
+$(eval $(call BuildSNodeCModule,logger,snode.c,/usr/lib))
+$(eval $(call BuildSNodeCModule,utils,+snode.c-logger,/usr/lib))
+$(eval $(call BuildSNodeCModule,core-mux-epoll,+snode.c-logger,/usr/lib))
+$(eval $(call BuildSNodeCModule,core-mux-poll,+snode.c-logger,/usr/lib))
+$(eval $(call BuildSNodeCModule,core-mux-select,+snode.c-logger,/usr/lib))
+$(eval $(call BuildSNodeCModule,core,+snode.c-utils $(CONFIG_SNODEC_IO_MULTIPLEXER_DEPENDENCY),/usr/lib))
+$(eval $(call BuildSNodeCModule,core-socket,+snode.c-core,/usr/lib))
+$(eval $(call BuildSNodeCModule,core-socket-stream,+snode.c-core-socket,/usr/lib))
+$(eval $(call BuildSNodeCModule,core-socket-stream-legacy,+snode.c-core-socket-stream,/usr/lib))
+$(eval $(call BuildSNodeCModule,core-socket-stream-tls,+snode.c-core-socket-stream +libopenssl,/usr/lib))
+$(eval $(call BuildSNodeCModule,db-mariadb,+snode.c-core +libmariadb,/usr/lib))
+$(eval $(call BuildSNodeCModule,net,+snode.c-utils,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-in,+snode.c-net,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-in-phy,+snode.c-net-in,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-in-phy-stream,+snode.c-net-in-phy,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-in-stream,+snode.c-net-in-phy-stream,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-in-stream-legacy,+snode.c-net-in-stream +snode.c-core-socket-stream-legacy,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-in-stream-tls,+snode.c-net-in-stream +snode.c-core-socket-stream-tls,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-in6,+snode.c-net,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-in6-phy,+snode.c-net-in6,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-in6-phy-stream,+snode.c-net-in6-phy,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-in6-stream,+snode.c-net-in6-phy-stream,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-in6-stream-legacy,+snode.c-net-in6-stream +snode.c-core-socket-stream-legacy,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-in6-stream-tls,+snode.c-net-in6-stream +snode.c-core-socket-stream-tls,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-l2,+snode.c-net,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-l2-phy,+snode.c-net-l2 +bluez-libs,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-l2-phy-stream,+snode.c-net-l2-phy,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-l2-stream,+snode.c-net-l2-phy-stream,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-l2-stream-legacy,+snode.c-net-l2-stream +snode.c-core-socket-stream-legacy,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-l2-stream-tls,+snode.c-net-l2-stream +snode.c-core-socket-stream-tls,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-rc,+snode.c-net,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-rc-phy,+snode.c-net-rc +bluez-libs,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-rc-phy-stream,+snode.c-net-rc-phy,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-rc-stream,+snode.c-net-rc-phy-stream,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-rc-stream-legacy,+snode.c-net-rc-stream +snode.c-core-socket-stream-legacy,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-rc-stream-tls,+snode.c-net-rc-stream +snode.c-core-socket-stream-tls,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-un,+snode.c-net,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-un-phy,+snode.c-net-un,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-un-phy-stream,+snode.c-net-un-phy,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-un-stream,+snode.c-net-un-phy-stream,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-un-stream-legacy,+snode.c-net-un-stream +snode.c-core-socket-stream-legacy,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-un-stream-tls,+snode.c-net-un-stream +snode.c-core-socket-stream-tls,/usr/lib))
+$(eval $(call BuildSNodeCModule,net-un-dgram,+snode.c-net-un,/usr/lib))
+$(eval $(call BuildSNodeCModule,http,+snode.c-core-socket-stream +libmagic,/usr/lib/snode.c/web/http))
+$(eval $(call BuildSNodeCModule,http-server,+snode.c-http,/usr/lib/snode.c/web/http))
+$(eval $(call BuildSNodeCModule,http-client,+snode.c-http,/usr/lib/snode.c/web/http))
+$(eval $(call BuildSNodeCModule,http-server-express,+snode.c-http-server,/usr/lib/snode.c/web/http))
+$(eval $(call BuildSNodeCModule,websocket,+snode.c-logger,/usr/lib/snode.c/web/http/upgrade))
+$(eval $(call BuildSNodeCModule,websocket-server,+snode.c-websocket +snode.c-http-server,/usr/lib/snode.c/web/http/upgrade))
+$(eval $(call BuildSNodeCModule,websocket-client,+snode.c-websocket +snode.c-http-client,/usr/lib/snode.c/web/http/upgrade))
+$(eval $(call BuildSNodeCModule,mqtt,+snode.c-core-socket-stream,/usr/lib/snode.c/iot/mqtt))
+$(eval $(call BuildSNodeCModule,mqtt-server,+snode.c-mqtt,/usr/lib/snode.c/iot/mqtt))
+$(eval $(call BuildSNodeCModule,mqtt-client,+snode.c-mqtt,/usr/lib/snode.c/iot/mqtt))
+$(eval $(call BuildSNodeCModule,mqtt-server-websocket,+snode.c-mqtt-server +snode.c-websocket-server,/usr/lib/snode.c/iot/mqtt))
+$(eval $(call BuildSNodeCModule,mqtt-client-websocket,+snode.c-mqtt-client +snode.c-websocket-client,/usr/lib/snode.c/iot/mqtt))

--- a/net/snode.c/Makefile
+++ b/net/snode.c/Makefile
@@ -6,10 +6,10 @@ PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SNodeC/snode.c/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=49c3629f302e7760edf08430c1d6787c181a835b1db136c2dcc30a68186134c7
+PKG_HASH:=dd26d3fb6232c19212b9bf5cc5e3fd9ab3a45a5142e0590771c8fe34568c16c3
 
 # PKG_SOURCE_URL:=https://api.github.com/repos/SNodeC/snode.c/tarball/v$(PKG_VERSION)?
-# PKG_HASH:=446e470b5f33291e75078d775308bc0efdd184b07e93d6a4f18022bb5afd60b1
+# PKG_HASH:=2df9a5086264a4f6034c18cd0fc9dfe3e6cfe7abb5a129c9a84793f23e528b5f
 
 PKG_MAINTAINER:=Volker Christian <me@vchrist.at>
 PKG_LICENSE:=LGPL-3.0-or-later
@@ -31,7 +31,8 @@ else ifdef CONFIG_SNODEC_SELECT
   CONFIG_SNODEC_IO_MULTIPLEXER=select
 endif
 
-CMAKE_OPTIONS+=-DIO_MULTIPLEXER=$(CONFIG_SNODEC_IO_MULTIPLEXER) \
+CMAKE_OPTIONS+=-DGROUP_NAME=$(patsubst "%",%,$(CONFIG_SNODEC_GROUP_NAME)) \
+               -DIO_MULTIPLEXER=$(CONFIG_SNODEC_IO_MULTIPLEXER) \
                -DREAD_BLOCKSIZE=$(CONFIG_SNODEC_READ_BLOCKSIZE) \
                -DWRITE_BLOCKSIZE=$(CONFIG_SNODEC_WRITE_BLOCKSIZE) \
                -DREAD_TIMEOUT=$(CONFIG_SNODEC_READ_TIMEOUT) \
@@ -62,14 +63,13 @@ define Package/snode.c/Default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=SNode.C
-  URL:=https://github.com/VolkerChristian/snode.c
-  Maintainer:=Volker Christian <me@vchrist.at>
 endef
 
 define Package/snode.c
   $(call Package/snode.c/Default)
   TITLE:=Easy to use lightwight layer based network framework for C++
   DEPENDS:=+libstdcpp
+  USERID:=$(patsubst "%",%,$(CONFIG_SNODEC_GROUP_NAME)):$(patsubst "%",%,$(CONFIG_SNODEC_GROUP_NAME))
 endef
 
 define Package/snode.c/description
@@ -85,37 +85,6 @@ endef
 
 define Package/snode.c/install
 	true
-endef
-
-SNODEC_GROUP_NAME=snodec
-SNODEC_GROUP_ID=$(call qstrip,$(CONFIG_SNODEC_GROUP_ID))
-
-define Package/snode.c/postinst
-#!/bin/sh
-
-GROUP_NAME=$(SNODEC_GROUP_NAME)
-GROUP_ID=$(SNODEC_GROUP_ID)
-
-if [ -z $$(grep "^$${GROUP_NAME}:" $${IPKG_INSTROOT}/etc/group) ]; then
-	echo "Adding group '$${GROUP_NAME}' with ID $${GROUP_ID} to /etc/group and assign user root to it"
-	echo "$${GROUP_NAME}:x:$${GROUP_ID}:root" >> $${IPKG_INSTROOT}/etc/group
-else
-	echo "Adding group '$${GROUP_NAME}' to /etc/group failed: group exists"
-fi
-endef
-
-define Package/snode.c/prerm
-#!/bin/sh
-
-GROUP_NAME=$(SNODEC_GROUP_NAME)
-GROUP_ID=$(SNODEC_GROUP_ID)
-
-if [ ! -z $$(grep "^$${GROUP_NAME}:.*:$${GROUP_ID}" $${IPKG_INSTROOT}/etc/group) ]; then
-	echo "Removing group '$${GROUP_NAME}' from /etc/group"
-	sed -i "/^$${GROUP_NAME}:/d" /etc/group
-else
-	echo "Removing group '$${GROUP_NAME}' from /etc/group failed: no such group"
-fi
 endef
 
 SO_VERSION=$(shell echo $(PKG_VERSION) | cut -d'.' -f1)
@@ -212,7 +181,7 @@ define Package/snode.c-apps/install
 endef
 
 ifdef CONFIG_SNODEC_IO_MULTIPLEXER
-  CONFIG_SNODEC_IO_MULTIPLEXER_DEPENDENCY=+snode.c-core-mux-$(CONFIG_SNODEC_IO_MULTIPLEXER)
+  CONFIG_SNODEC_IO_MULTIPLEXER_DEPENDENCY:=+snode.c-core-mux-$(CONFIG_SNODEC_IO_MULTIPLEXER)
 endif
 
 $(eval $(call BuildPackage,snode.c))


### PR DESCRIPTION
Maintainer: Volker Christian <me@vchrist.at>

Description: [SNode.C](https://github.com/VolkerChristian/snode.c) is a very simple to use lightweight highly extensible event driven layer-based framework for network applications in the spirit of node.js written entirely in C++.

Compile tested:
- aarch64_cortex-a53
- aarch64_cortex-a72
- aarch64_generic
- arm_arm926ej-s
- arm_cortex-a15_neon-vfpv4
- arm_cortex-a7
- arm_cortex-a7_neon-vfpv4
- arm_cortex-a7_vfpv4
- arm_cortex-a9
- arm_cortex-a9_neon
- arm_cortex-a9_vfpv3-d16
- arm_fa526
- arm_mpcore
- arm_xscale
- i386_pentium-mmx
- mips_24kc
- mips64_octeonplus
- mipsel_24kc
- mipsel_24kc_24kf
- mipsel_74kc
- mipsel_mips32
- mips_mips32
- powerpc_464fp
- powerpc_8548
- riscv64_riscv64

Run tested:
- GL.iNet GL-A1300 (arm_cortex-a7_neon-vfpv4)
- GL.iNet GL-MT3000 (aarch64_cortex-a53)
- Linksys MR8300 (arm_cortex-a7_neon_vfpv4)
- Netgear R7800 (arm_cortex-a15_neon_vfpv4)
- TP-Link Archer A7v5 (mipsel_24kc)
