### PR TITLE
ddns-scripts: suppress curl output for route53

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/update_route53_v1.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_route53_v1.sh
@@ -80,7 +80,7 @@ signature="$(sign "${signing_key}" "${sigmsg}")"
 
 authorization="AWS4-HMAC-SHA256 Credential=${AWS_ACCESS_KEY_ID}/${credential}, SignedHeaders=${signed_headers}, Signature=${signature}"
 
-ANSWER="$(flock /tmp/$(basename -s .sh "$0").lock curl \
+ANSWER="$(flock /tmp/$(basename -s .sh "$0").lock curl --silent --show-error \
     -X "POST" \
     -H "Host: route53.amazonaws.com" \
     -H "X-Amz-Date: ${fulldate}" \


### PR DESCRIPTION
When debugging and running update_route53_v1.sh interactively, curl progress bars are displayed, interrupting the output of the script. This change causes curl to suppress that progress bar on successful connections, but any errors will still come out on stderr.

Maintainer: me / @feckert (?)
Compile tested: ipq806x/generic OpenWrt 22.03.5 r20134-5f15225c1e / LuCI openwrt-22.03 branch git-23.093.57104-ce20b4a
Run tested: ipq806x/generic OpenWrt 22.03.5 r20134-5f15225c1e / LuCI openwrt-22.03 branch git-23.093.57104-ce20b4a

Thanks for your patience.