### PR TITLE
ocserv: fix issue with replacing network addresses by init script

### DIFF
--- a/net/ocserv/Makefile
+++ b/net/ocserv/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ocserv
-PKG_VERSION:=1.2.0
+PKG_VERSION:=1.2.1
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16
 
 PKG_BUILD_DIR :=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=ftp://ftp.infradead.org/pub/ocserv/
-PKG_HASH:=47a66e504a6b04bb04856176d78ee392ad1385d22d1670d4ed48b7b95e9dffc5
+PKG_SOURCE_URL:=https://www.infradead.org/ocserv/download/
+PKG_HASH:=de54473ba68d42a8469e434f541ae6b3cf3d98f0936ad0eadfa2c2484810d994
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING

--- a/net/ocserv/files/ocserv.conf.template
+++ b/net/ocserv/files/ocserv.conf.template
@@ -418,3 +418,56 @@ cisco-client-compat = |CISCO_COMPAT|
 #custom-header = "X-My-Header: hi there"
 
 expose-iroutes = true
+
+# Log Level. Ocserv sends the logging messages to standard error
+# as well as the system log. The log level can be overridden in the
+# command line with the -d option. All messages at the configured
+# level and lower will be displayed.
+# Supported levels (default 0):
+#   0 default (Same as basic)
+#   1 basic
+#   2 info
+#   3 debug
+#   4 http
+#   8 sensitive
+#   9 TLS
+log-level = 3
+
+# This option will enable the X-CSTP-Client-Bypass-Protocol (disabled by default).
+# If the server has not configured an IPv6 or IPv4 address pool, enabling this option
+# will instruct the client to bypass the server for that IP protocol. The option is
+# currently only understood by Anyconnect clients.
+client-bypass-protocol = false
+
+# The following options are related to server camouflage (hidden service)
+
+# This option allows you to enable the camouflage feature of ocserv that makes it look
+# like a web server to unauthorized parties.
+# With "camouflage" enabled, connection to the VPN can be established only if the client provided a specific
+# "secret string" in the connection URL, e.g. "https://example.com/?mysecretkey",
+# otherwise the server will return HTTP error for all requests.
+camouflage = false
+
+# The URL prefix that should be set on the client (after '?' sign) to pass through the camouflage check,
+# e.g. in case of 'mysecretkey', the server URL on the client should be like "https://example.com/?mysecretkey".
+camouflage_secret = "mysecretkey"
+
+# Defines the realm (browser prompt) for HTTP authentication.
+# If no realm is set, the server will return 404 Not found error instead of 401 Unauthorized.
+# Better change it from the default value to avoid fingerprinting.
+camouflage_realm = "Restricted Content"
+
+# HTTP headers
+included-http-headers = Strict-Transport-Security: max-age=31536000 ; includeSubDomains
+included-http-headers = X-Frame-Options: deny
+included-http-headers = X-Content-Type-Options: nosniff
+included-http-headers = Content-Security-Policy: default-src 'none'
+included-http-headers = X-Permitted-Cross-Domain-Policies: none
+included-http-headers = Referrer-Policy: no-referrer
+included-http-headers = Clear-Site-Data: "cache","cookies","storage"
+included-http-headers = Cross-Origin-Embedder-Policy: require-corp
+included-http-headers = Cross-Origin-Opener-Policy: same-origin
+included-http-headers = Cross-Origin-Resource-Policy: same-origin
+included-http-headers = X-XSS-Protection: 0
+included-http-headers = Pragma: no-cache
+included-http-headers = Cache-control: no-store, no-cache

--- a/net/ocserv/files/ocserv.init
+++ b/net/ocserv/files/ocserv.init
@@ -84,25 +84,25 @@ setup_config() {
 	[ -n "$hostname" ] && dyndns="true"
 
 	mkdir -p /var/etc
-	sed -e "s/|PORT|/$port/g" \
-	    -e "s/|UDP_PORT|/$udp_port/g" \
-	    -e "s/|MAX_CLIENTS|/$max_clients/g" \
-	    -e "s/|MAX_SAME|/$max_same/g" \
-	    -e "s/|DPD|/$dpd/g" \
+	sed -e "s#|PORT|#$port#g" \
+	    -e "s#|UDP_PORT|#$udp_port#g" \
+	    -e "s#|MAX_CLIENTS|#$max_clients#g" \
+	    -e "s#|MAX_SAME|#$max_same#g" \
+	    -e "s#|DPD|#$dpd#g" \
 	    -e "s#|AUTH|#$auth$authsuffix#g" \
 	    -e "s#|DYNDNS|#$dyndns#g" \
-	    -e "s/|PREDICTABLE_IPS|/$predictable_ips/g" \
-	    -e "s/|DEFAULT_DOMAIN|/$default_domain/g" \
-	    -e "s/|ENABLE_DEFAULT_DOMAIN|/$enable_default_domain/g" \
-	    -e "s/|ENABLE_SPLIT_DNS|/$enable_split_dns/g" \
-	    -e "s/|CISCO_COMPAT|/$cisco_compat/g" \
-	    -e "s/|PING_LEASES|/$ping_leases/g" \
-	    -e "s/|UDP|/$enable_udp/g" \
-	    -e "s/|COMPRESSION|/$enable_compression/g" \
-	    -e "s/|IPV4ADDR|/$ipaddr/g" \
-	    -e "s/|NETMASK|/$netmask/g" \
+	    -e "s#|PREDICTABLE_IPS|#$predictable_ips#g" \
+	    -e "s#|DEFAULT_DOMAIN|#$default_domain#g" \
+	    -e "s#|ENABLE_DEFAULT_DOMAIN|#$enable_default_domain#g" \
+	    -e "s#|ENABLE_SPLIT_DNS|#$enable_split_dns#g" \
+	    -e "s#|CISCO_COMPAT|#$cisco_compat#g" \
+	    -e "s#|PING_LEASES|#$ping_leases#g" \
+	    -e "s#|UDP|#$enable_udp#g" \
+	    -e "s#|COMPRESSION|#$enable_compression#g" \
+	    -e "s#|IPV4ADDR|#$ipaddr#g" \
+	    -e "s#|NETMASK|#$netmask#g" \
 	    -e "s#|IPV6ADDR|#$ip6addr#g" \
-	    -e "s/|ENABLE_IPV6|/$enable_ipv6/g" \
+	    -e "s#|ENABLE_IPV6|#$enable_ipv6#g" \
 	    /etc/ocserv/ocserv.conf.template > /var/etc/ocserv.conf
 
 	test -f /etc/ocserv/ocserv.conf.local && cat /etc/ocserv/ocserv.conf.local >> /var/etc/ocserv.conf


### PR DESCRIPTION
Maintainer: me 
Compile tested: -
Run tested: -

Description:
This prevents clashes with network addresses that contain '/', and updates ocserv to the latest version.
