### PR TITLE
[openwrt-23.05] ruamel-yaml: Update to 0.17.32, rename source package

### DIFF
--- a/lang/python/python-ruamel-yaml/Makefile
+++ b/lang/python/python-ruamel-yaml/Makefile
@@ -7,12 +7,12 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=ruamel-yaml
-PKG_VERSION:=0.17.17
+PKG_NAME:=python-ruamel-yaml
+PKG_VERSION:=0.17.32
 PKG_RELEASE:=1
 
 PYPI_NAME:=ruamel.yaml
-PKG_HASH:=9751de4cbb57d4bfbf8fc394e125ed4a2f170fbff3dc3d78abf50be85924f8be
+PKG_HASH:=ec939063761914e14542972a5cba6d33c23b0859ab6342f61cf070cfc600efc2
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=MIT
@@ -26,14 +26,15 @@ define Package/python3-ruamel-yaml
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  TITLE:=YAML 1.2 loader/dumper package for Python
-  URL:=https://bitbucket.org/ruamel/yaml
+  TITLE:=YAML 1.2 loader/dumper
+  URL:=https://sourceforge.net/p/ruamel-yaml/code/ci/default/tree
   DEPENDS:= \
       +python3-light
 endef
 
 define Package/python3-ruamel-yaml/description
-ruamel-yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order
+ruamel-yaml is a YAML parser/emitter that supports roundtrip
+preservation of comments, seq/map flow style, and map key order
 endef
 
 $(eval $(call Py3Package,python3-ruamel-yaml))


### PR DESCRIPTION
Maintainer: @BKPepe
Compile tested: none (cherry picked from #22038)
Run tested: none

Description:
This renames the source package to python-ruamel-yaml to match other Python packages.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit fdff92f0855d40d65a77d47e0e0db8e23f75a1f3)