### PR TITLE
[openwrt-23.05] xmltodict: Update to 0.13.0, rename source package

### DIFF
--- a/lang/python/python-xmltodict/Makefile
+++ b/lang/python/python-xmltodict/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-xmltodict
-PKG_VERSION:=0.12.0
-PKG_RELEASE:=2
+PKG_VERSION:=0.13.0
+PKG_RELEASE:=1
 
 PYPI_NAME:=xmltodict
-PKG_HASH:=50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21
+PKG_HASH:=341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
@@ -28,14 +28,12 @@ define Package/python3-xmltodict
   SUBMENU:=Python
   TITLE:=Work with XML like JSON
   URL:=https://github.com/martinblech/xmltodict
-  DEPENDS:= \
-	+python3-light \
-	+python3-xml \
-	+python3-urllib
+  DEPENDS:=+python3-light +python3-xml
 endef
 
 define Package/python3-xmltodict/description
-  xmltodict is a Python module that makes working with XML feel like you are working with JSON.
+xmltodict is a Python module that makes working with XML feel like you
+are working with JSON.
 endef
 
 $(eval $(call Py3Package,python3-xmltodict))


### PR DESCRIPTION
Maintainer: @BKPepe
Compile tested: none (cherry picked from #22039)
Run tested: none

Description:
This renames the source package to python-xmltodict to match other Python packages.

This also updates the list of dependencies.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 4872c325808357c0cb81a4367d053cc5b5468028)