### PR TITLE
[openwrt-23.05] python-cryptodome: Update to 3.18.0, refresh patches

### DIFF
--- a/lang/python/python-cryptodome/Makefile
+++ b/lang/python/python-cryptodome/Makefile
@@ -5,13 +5,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptodome
-PKG_VERSION:=3.9.7
-PKG_RELEASE:=4
+PKG_VERSION:=3.18.0
+PKG_RELEASE:=1
 
 PYPI_NAME:=pycryptodome
-PKG_HASH:=f1add21b6d179179b3c177c33d18a2186a09cc0d3af41ff5ed3f377360b869f2
+PKG_HASH:=c9adee653fc882d98956e33ca2c1fb582e23a8af7ac82fee75bd6113c55a0413
 
-PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE:=Public-Domain BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 PKG_CPE_ID:=cpe:/a:pycryptodome:pycryptodome
@@ -24,12 +24,12 @@ PYTHON3_PKG_BUILD_VARS:= \
   CONFIG_BIG_ENDIAN="$(CONFIG_BIG_ENDIAN)"
 
 define Package/python3-cryptodome
-  SECTION:=lang-python
+  SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  TITLE:=A self-contained cryptographic library for Python
+  TITLE:=Self-contained cryptographic library
   URL:=https://www.pycryptodome.org/
-  DEPENDS:=+libgmp +python3
+  DEPENDS:=+libgmp +python3-light +python3-cffi
   PROVIDES:=python3-crypto
 endef
 

--- a/lang/python/python-cryptodome/patches/001-fix-libgmp-loading.patch
+++ b/lang/python/python-cryptodome/patches/001-fix-libgmp-loading.patch
@@ -1,8 +1,8 @@
 --- a/lib/Crypto/Math/_IntegerGMP.py
 +++ b/lib/Crypto/Math/_IntegerGMP.py
-@@ -92,7 +92,7 @@ gmp_defs = """typedef unsigned long UNIX
-         int __gmpz_divisible_ui_p (const mpz_t n, UNIX_ULONG d);
-         """
+@@ -97,7 +97,7 @@ gmp_defs = """typedef unsigned long UNIX
+ if sys.platform == "win32":
+     raise ImportError("Not using GMP on Windows")
  
 -lib = load_lib("gmp", gmp_defs)
 +lib = load_lib("libgmp.so.10", gmp_defs)

--- a/lang/python/python-cryptodome/patches/002-omit-tests.patch
+++ b/lang/python/python-cryptodome/patches/002-omit-tests.patch
@@ -1,7 +1,7 @@
 --- a/setup.py
 +++ b/setup.py
-@@ -301,6 +301,9 @@ package_data = {
-     ],
+@@ -276,6 +276,9 @@ package_data = {
+     "Crypto.Util" : [ "*.pyi" ],
  }
  
 +packages = [i for i in packages if not i.startswith('Crypto.SelfTest')]


### PR DESCRIPTION
Maintainer: @ysc3839
Compile tested: none (cherry picked from #22040)
Run tested: none

Description:
This also updates the list of dependencies.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 03f1f4b9bb426670ddf4b870ed4dfbe354e19fcf)