### PR TITLE
[openwrt-23.05] python-cryptodomex: Update to 3.18.0, refresh patches

### DIFF
--- a/lang/python/python-cryptodomex/Makefile
+++ b/lang/python/python-cryptodomex/Makefile
@@ -5,13 +5,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptodomex
-PKG_VERSION:=3.10.1
-PKG_RELEASE:=2
+PKG_VERSION:=3.18.0
+PKG_RELEASE:=1
 
 PYPI_NAME:=pycryptodomex
-PKG_HASH:=541cd3e3e252fb19a7b48f420b798b53483302b7fe4d9954c947605d0a263d62
+PKG_HASH:=3e3ecb5fe979e7c1bb0027e518340acf7ee60415d79295e5251d13c68dde576e
 
-PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE:=Public-Domain BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 
@@ -23,12 +23,12 @@ PYTHON3_PKG_BUILD_VARS:= \
   CONFIG_BIG_ENDIAN="$(CONFIG_BIG_ENDIAN)"
 
 define Package/python3-cryptodomex
-  SECTION:=lang-python
+  SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  TITLE:=A self-contained cryptographic library for Python
+  TITLE:=Self-contained cryptographic library
   URL:=https://www.pycryptodome.org/
-  DEPENDS:=+libgmp +python3
+  DEPENDS:=+libgmp +python3-light +python3-cffi
 endef
 
 define Package/python3-cryptodomex/description

--- a/lang/python/python-cryptodomex/patches/001-fix-libgmp-loading.patch
+++ b/lang/python/python-cryptodomex/patches/001-fix-libgmp-loading.patch
@@ -1,6 +1,6 @@
 --- a/lib/Cryptodome/Math/_IntegerGMP.py
 +++ b/lib/Cryptodome/Math/_IntegerGMP.py
-@@ -95,7 +95,7 @@ gmp_defs = """typedef unsigned long UNIX
+@@ -97,7 +97,7 @@ gmp_defs = """typedef unsigned long UNIX
  if sys.platform == "win32":
      raise ImportError("Not using GMP on Windows")
  

--- a/lang/python/python-cryptodomex/patches/002-omit-tests.patch
+++ b/lang/python/python-cryptodomex/patches/002-omit-tests.patch
@@ -1,6 +1,6 @@
 --- a/setup.py
 +++ b/setup.py
-@@ -275,6 +275,9 @@ package_data = {
+@@ -276,6 +276,9 @@ package_data = {
      "Crypto.Util" : [ "*.pyi" ],
  }
  


### PR DESCRIPTION
Maintainer: @ysc3839
Compile tested: none (cherry picked from #22041)
Run tested: none

Description:
This also updates the list of dependencies.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit a1b3595550ebc6db9f21bce7a1a958bf7accedbe)