### PR TITLE
[openwrt-23.05] python-crcmod: Fix package section

### DIFF
--- a/lang/python/python-crcmod/Makefile
+++ b/lang/python/python-crcmod/Makefile
@@ -18,7 +18,7 @@ include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
 define Package/python3-crcmod
-  SECTION:=lang-python
+  SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=python3-crcmod


### PR DESCRIPTION
Maintainer: @blocktrron
Compile tested: N/A (cherry picked from #22043)
Run tested: N/A

Description:
Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 8e5ca3fc3e78d92a2e9cfa1ac1696f5151351816)