### PR TITLE
Tailscale: set nftables as default and update to 1.48.2

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.48.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.48.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6b3152cdd9ed915c01ce30f3967c0d4e04e2a81053eddeb93792d93088fe2d72
+PKG_HASH:=1c34c5c2c3b78e59ffb824b356418ff828653c62885b126d0d05f300218b36b5
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/tailscale/README.md
+++ b/net/tailscale/README.md
@@ -9,6 +9,9 @@ To install them run
 opkg install tailscale tailscaled
 ```
 
+> [!NOTE]
+> By default this package will use nftables. If you wish to use iptables, the config file `/etc/config/tailscale` can be modfied, changing the line `fw_mode 'nftables'` to `fw_mode 'iptables'`. You can then run `/etc/init.d/tailscale restart` to restart tailscale using your chosen method
+
 ## First setup
 
 First, enable and run daemon
@@ -25,9 +28,6 @@ Run command and finish device registration with the given URL.
 tailscale up
 ```
 
-If you are running with nftables, it is not supported by tailscale,
-so disable it and configure firewall by yourself and add argument
---netfilter-mode off
-to tailscale up command to disable iptables use.
+See the [OpenWrt wiki](https://openwrt.org/docs/guide-user/services/vpn/tailscale/start) for more detailed setup instructions
 
-After that, you should see your router in tailscale admin page.
+

--- a/net/tailscale/files/tailscale.conf
+++ b/net/tailscale/files/tailscale.conf
@@ -3,3 +3,5 @@ config settings 'settings'
 	option log_stdout '1'
 	option port '41641'
 	option state_file '/etc/tailscale/tailscaled.state'
+	# default to using nftables - change below to 'iptables' if still using iptable
+	option fw_mode 'nftables'

--- a/net/tailscale/files/tailscale.init
+++ b/net/tailscale/files/tailscale.init
@@ -17,14 +17,16 @@ start_service() {
   config_get_bool std_err "settings" log_stderr 1
   config_get port "settings" port 41641
   config_get state_file "settings" state_file /etc/tailscale/tailscaled.state
+  config_get fw_mode "settings" fw_mode nftables
 
   /usr/sbin/tailscaled --cleanup
 
   procd_open_instance
   procd_set_param command /usr/sbin/tailscaled
 
-  # starting with v1.48.1 ENV variable is required to enable autodetection of iptables / nftables
-  procd_set_param env TS_DEBUG_FIREWALL_MODE=auto
+  # Starting with v1.48.1 ENV variable is required to enable use of iptables / nftables.
+  # Use nftables by default - can be changed to 'iptables' in tailscale config
+  procd_set_param env TS_DEBUG_FIREWALL_MODE="$fw_mode"
 
   # Set the port to listen on for incoming VPN packets.
   # Remote nodes will automatically be informed about the new port number,


### PR DESCRIPTION
Maintainer: @ja-pa @oskarirauta
Compile tested: aarch64_cortex-a53 @ 22.03.5
                         mips_24kc @ SNAPSHOT
Run tested:        aarch64_cortex-a53 @ 22.03.5 on Linksys E8450 
                         mips_24kc @ SNAPSHOT on GL.iNet GL-AR750

Description: This changes the default firewall method used by Tailscale to nftables. The 'auto dection' mode is only [supported by arm64 and amd64](https://github.com/tailscale/tailscale/blob/dc7aa98b768bf82017aa5cc82a62dd4d685f811d/util/linuxfw/linuxfw_unsupported.go#L4C58-L4C58) for now. This causes mips devices to not do proper detection and default back to iptables ([thanks ](https://github.com/openwrt/packages/pull/21937#discussion_r1320620036)@alaviss).

I added a fw_mode variable to the tailscale.conf file that could be set to iptables for easy conversion for someone still using iptables. I was able to test on an older mips device and my current aarch64 without issues.

Also a few readme updates to bring it up to the current status.