### PR TITLE
snort3: update to 3.1.70.0

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
-PKG_VERSION:=3.1.69.0
+PKG_VERSION:=3.1.70.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
-PKG_HASH:=97083cd33a6ba33bdaa133bf19138a3f6a24ce93b2a9e285dcbd89858534cb72
+PKG_HASH:=4917f2631d033383ca553002f5688b61df507f5c809b9ba62abceca45a7554ad
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne
```
   ,,_     -*> Snort++ <*-
  o"  )~   Version 3.1.70.0
   ''''    By Martin Roesch & The Snort Team
           http://snort.org/contact#team
           Copyright (C) 2014-2023 Cisco and/or its affiliates. All rights reserved.
           Copyright (C) 1998-2013 Sourcefire, Inc., et al.
           Using DAQ version 3.0.12
           Using LuaJIT version 2.1.0-beta3
           Using OpenSSL 3.0.10 1 Aug 2023
           Using libpcap version 1.10.4 (with TPACKET_V3)
           Using PCRE version 8.45 2021-06-15
           Using ZLIB version 1.2.13
           Using Hyperscan version 5.4.2 2023-09-07
```
Maintainer: @flyn-org