### PR TITLE
rust: Move RUST_ARCH_DEPENDS into rust-values.mk

### DIFF
--- a/lang/rust/rust-package.mk
+++ b/lang/rust/rust-package.mk
@@ -15,9 +15,6 @@ ifeq ($(origin RUST_INCLUDE_DIR),undefined)
 endif
 include $(RUST_INCLUDE_DIR)/rust-values.mk
 
-# Support only a subset for now.
-RUST_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||mips||mipsel||mips64||mips64el||mipsel||powerpc64||riscv64||x86_64)
-
 # $(1) path to the package (optional)
 # $(2) additional arguments to cargo (optional)
 define Build/Compile/Cargo

--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -57,3 +57,6 @@ endif
 ifeq ($(ARCH),aarch64)
     RUST_CFLAGS:=-mno-outline-atomics
 endif
+
+# Support only a subset for now.
+RUST_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||mips||mipsel||mips64||mips64el||mipsel||powerpc64||riscv64||x86_64)


### PR DESCRIPTION
Maintainer: @lu-zero
Compile tested: armsr-armv7, 2023-09-09 snapshot sdk
Run tested: N/A

Description:
This allows other packages access to `RUST_ARCH_DEPENDS` by including rust-values.mk, instead of rust-package.mk which also sets `Build/Compile`.