### PR TITLE
ovpn-dco: fix package dependencies

### DIFF
--- a/kernel/ovpn-dco/Makefile
+++ b/kernel/ovpn-dco/Makefile
@@ -25,7 +25,7 @@ include $(INCLUDE_DIR)/package.mk
 define KernelPackage/ovpn-dco-v2
   SUBMENU:=Network Support
   TITLE:=OpenVPN data channel offload
-  DEPENDS:=+kmod-crypto-aead +kmod-udptunnel4 +kmod-udptunnel6
+  DEPENDS:=+kmod-crypto-aead +kmod-udptunnel4 +IPV6:kmod-udptunnel6
   FILES:=$(PKG_BUILD_DIR)/drivers/net/ovpn-dco/ovpn-dco-v2.ko
   AUTOLOAD:=$(call AutoLoad,30,ovpn-dco-v2)
 endef


### PR DESCRIPTION
Maintainer: @AuthorReflex
Compile tested: x86_64, latest master
Run tested: x86_64, latest master

Description:
We have to add an "IPV6:" in front of the kmod-udptunnel6 to fix redundant dependencies with the openvpn-* packages.
