### PR TITLE
tailscale: set nftables as default

### DIFF
--- a/net/tailscale/README.md
+++ b/net/tailscale/README.md
@@ -8,6 +8,8 @@ To install them run
 ```
 opkg install tailscale tailscaled
 ```
+> [!NOTE]
+> By default this package will use nftables. If you wish to use iptables, the config file `/etc/config/tailscale` can be modfied, changing the line `fw_mode 'nftables'` to `fw_mode 'iptables'`. You can then run `/etc/init.d/tailscale restart` to restart tailscale using your chosen method
 
 ## First setup
 
@@ -25,9 +27,4 @@ Run command and finish device registration with the given URL.
 tailscale up
 ```
 
-If you are running with nftables, it is not supported by tailscale,
-so disable it and configure firewall by yourself and add argument
---netfilter-mode off
-to tailscale up command to disable iptables use.
-
-After that, you should see your router in tailscale admin page.
+See the [OpenWrt wiki](https://openwrt.org/docs/guide-user/services/vpn/tailscale/start) for more detailed setup instructions

--- a/net/tailscale/files/tailscale.conf
+++ b/net/tailscale/files/tailscale.conf
@@ -3,3 +3,5 @@ config settings 'settings'
 	option log_stdout '1'
 	option port '41641'
 	option state_file '/etc/tailscale/tailscaled.state'
+	# default to using nftables - change below to 'iptables' if still using iptables
+	option fw_mode 'nftables'

--- a/net/tailscale/files/tailscale.init
+++ b/net/tailscale/files/tailscale.init
@@ -17,14 +17,16 @@ start_service() {
   config_get_bool std_err "settings" log_stderr 1
   config_get port "settings" port 41641
   config_get state_file "settings" state_file /etc/tailscale/tailscaled.state
+  config_get fw_mode "settings" fw_mode nftables
 
   /usr/sbin/tailscaled --cleanup
 
   procd_open_instance
   procd_set_param command /usr/sbin/tailscaled
 
-  # starting with v1.48.1 ENV variable is required to enable autodetection of iptables / nftables
-  procd_set_param env TS_DEBUG_FIREWALL_MODE=auto
+  # Starting with v1.48.1 ENV variable is required to enable use of iptables / nftables.
+  # Use nftables by default - can be changed to 'iptables' in tailscale config
+  procd_set_param env TS_DEBUG_FIREWALL_MODE="$fw_mode"
 
   # Set the port to listen on for incoming VPN packets.
   # Remote nodes will automatically be informed about the new port number,


### PR DESCRIPTION
Maintainer: @ja-pa @oskarirauta
Compile tested: `mips_24kc` @ SNAPSHOT
Run tested: `aarch64_cortex-a53` @ 22.03.5, `mips_24kc` @ SNAPSHOT

Description:
This changes the default firewall method used by Tailscale to nftables. The 'autodetection' mode is [only supported by arm64 and amd64](https://github.com/tailscale/tailscale/blob/dc7aa98b768bf82017aa5cc82a62dd4d685f811d/util/linuxfw/linuxfw_unsupported.go#L4C58-L4C58) for now. This causes mips devices to not do proper detection and incorrectly default back to iptables.

I added a fw_mode variable to the tailscale.conf file that could be set to iptables for easy conversion for someone still using iptables. I was able to test on an older mips device and my current aarch64 without issues.

Also a few readme updates to bring it up to the current status.