### PR TITLE
curl: update to version 8.3.0

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
-PKG_VERSION:=8.2.1
+PKG_VERSION:=8.3.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -17,7 +17,7 @@ PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,
 	https://dl.uxnr.de/mirror/curl/ \
 	https://curl.askapache.com/download/ \
 	https://curl.se/download/
-PKG_HASH:=dd322f6bd0a20e6cebdfd388f69e98c3d183bed792cf4713c8a7ef498cba4894
+PKG_HASH:=376d627767d6c4f05105ab6d497b0d9aba7111770dd9d995225478209c37ea63
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: @stangri 
Compile tested: MacBook A1990, MacOS Version 13.5.1 (22G90)
Run tested: Turris Omnia, OpenWrt 22.03, mvebu/cortexa9
```
root@turris:~# curl -V
curl 8.3.0 (arm-openwrt-linux-muslgnueabi) libcurl/8.3.0 OpenSSL/1.1.1v nghttp2/1.44.0
Release-Date: 2023-09-13
Protocols: file ftp ftps http https mqtt
Features: alt-svc HSTS HTTP2 HTTPS-proxy IPv6 Largefile SSL threadsafe
```


Fixes:
CVE-2023-38039 [1]

[1] https://curl.se/docs/CVE-2023-38039.html

