### PR TITLE
podman: update to 4.6.2

### DIFF
--- a/utils/podman/Makefile
+++ b/utils/podman/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=podman
-PKG_VERSION:=4.5.1
+PKG_VERSION:=4.6.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containers/podman/archive/v$(PKG_VERSION)
-PKG_HASH:=ee2c8b02b7fe301057f0382637b995a9c6c74e8d530692d6918e4c509ade6e39
+PKG_HASH:=2d8e04f0c3819c3f0ed1ca5d01da87e6d911571b96ae690448f7f75df41f2ad1
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -115,6 +115,7 @@ define Package/podman/install
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/lib/podman
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/{podman,podman-remote} $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/podman/{rootlessport,quadlet} $(1)/usr/lib/podman/
+	$(LN) podman $(1)/usr/bin/podmansh
 	$(INSTALL_DIR) $(1)/etc/containers
 	$(INSTALL_DATA) $(DL_DIR)/default-policy.json-362f70b056 $(1)/etc/containers/policy.json
 	$(INSTALL_DATA) $(DL_DIR)/registries.fedora-da9a9c8778 $(1)/etc/containers/registries.conf

--- a/utils/podman/patches/010-do-not-build-docs.patch
+++ b/utils/podman/patches/010-do-not-build-docs.patch
@@ -1,6 +1,6 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -209,7 +209,7 @@ GV_SHA=aab0ac9367fc5142f5857c36ac2352bcb
+@@ -211,7 +211,7 @@ GV_SHA=407efb5dcdb0f4445935f7360535800b6
  default: all
  
  .PHONY: all
@@ -9,7 +9,7 @@
  
  .PHONY: binaries
  ifeq ($(shell uname -s),FreeBSD)
-@@ -790,7 +790,7 @@ package-install: package  ## Install rpm
+@@ -798,7 +798,7 @@ rpm-install: package  ## Install rpm pac
  	/usr/bin/podman info  # will catch a broken conmon
  
  .PHONY: install


### PR DESCRIPTION
patch refreshed.

Changelog:

 - Fixed a performance issue when calculating diff sizes in overlay. The podman system df command should see a significant performance improvement.
 - Fixed a bug where containers in a pod would use the pod restart policy over the set container restart policy.
 - Fixed a bug in the Compat Build endpoint where the pull query parameter did not parse 0/1 as a boolean.
 - Updated the containers/storage library to v1.48.1

Maintainer: me
Compile tested: x86_64, latest git