### PR TITLE
netavark: update to 1.7.0

### DIFF
--- a/net/netavark/Makefile
+++ b/net/netavark/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netavark
-PKG_VERSION:=1.6.0
+PKG_VERSION:=1.7.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containers/netavark/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=3bec9e9b0f3f8f857370900010fb2125ead462d43998ad8f43e4387a5b06f9d6
+PKG_HASH:=b0ed7d80fd96ef2af88e7a001d91024919125e5842d9772de94648044630e116
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Changelog: https://github.com/containers/netavark/compare/v1.6.0...v1.7.0

Maintainer: me
Compile tested: x86_64, latest git