### PR TITLE
[23.05] adblock-fast: bugfix: remove domains on allow

### DIFF
--- a/net/adblock-fast/Makefile
+++ b/net/adblock-fast/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/adblock-fast/files/etc/init.d/adblock-fast
+++ b/net/adblock-fast/files/etc/init.d/adblock-fast
@@ -1124,7 +1124,7 @@ adb_allow() {
 			for c in $string; do
 				output 2 "  $c "
 				hf="$(echo "$c" | sed 's/\./\\./g')"
-				if sed -i "/(^|\.)${hf}$/d;" "$outputFile" && \
+				if sed -i "/\(^\|\.\)${hf}$/d;" "$outputFile" && \
 					uci_add_list_if_new "${packageName}" 'config' 'allowed_domain' "$c"; then
 						output_ok
 				else


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0-rc3
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0-rc2, allow domain

Description:
* fix sed command to properly remove allowed domains from block-file

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit bce310bfcd41a20b85fbe85fdcdf47ab1d5032bf)
