### PR TITLE
https-dns-proxy: improve boot up start

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2023-05-25
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/
@@ -45,8 +45,8 @@ define Package/https-dns-proxy/install
 	$(SED) "s|^\(readonly PKG_VERSION\).*|\1='$(PKG_VERSION)-$(PKG_RELEASE)'|" $(1)/etc/init.d/https-dns-proxy
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/etc/config/https-dns-proxy $(1)/etc/config/https-dns-proxy
-	$(INSTALL_DIR) $(1)/etc/hotplug.d/online
-	$(INSTALL_DATA) ./files/etc/hotplug.d/online/30-https-dns-proxy $(1)/etc/hotplug.d/online/30-https-dns-proxy
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
+	$(INSTALL_DATA) ./files/etc/hotplug.d/iface/90-https-dns-proxy $(1)/etc/hotplug.d/iface/90-https-dns-proxy
 	$(INSTALL_DIR) $(1)/etc/uci-defaults/
 	$(INSTALL_BIN) ./files/etc/uci-defaults/50-https-dns-proxy-migrate-options.sh $(1)/etc/uci-defaults/50-https-dns-proxy-migrate-options.sh
 endef

--- a/net/https-dns-proxy/files/etc/hotplug.d/iface/90-https-dns-proxy
+++ b/net/https-dns-proxy/files/etc/hotplug.d/iface/90-https-dns-proxy
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Copied from https://openwrt.org/docs/guide-user/advanced/hotplug_extras
+# shellcheck disable=SC1091
+. /lib/functions/network.sh
+network_flush_cache
+network_find_wan NET_IF
+network_find_wan6 NET_IF6
+[ "$INTERFACE" != "$NET_IF" ] && [ "$INTERFACE" != "$NET_IF6" ] && exit 0
+[ "$ACTION" != "ifup" ] && [ "$ACTION" != "ifupdate" ] && exit 0
+[ "$ACTION" = "ifupdate" ] && [ -z "$IFUPDATE_ADDRESSES" ] && \
+[ -z "$IFUPDATE_DATA" ] && exit 0
+
+sleep 10
+/etc/init.d/https-dns-proxy start 'on_hotplug'

--- a/net/https-dns-proxy/files/etc/hotplug.d/online/30-https-dns-proxy
+++ b/net/https-dns-proxy/files/etc/hotplug.d/online/30-https-dns-proxy
@@ -1,2 +1,0 @@
-#!/bin/sh
-/etc/init.d/https-dns-proxy start 'on_hotplug'


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0-rc3
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0-rc2, verify encrypted dns resolution on boot

Description:
* replace existing hotplug.d script with the new one