### PR TITLE
ariang: Update from 1.3.2 to 1.3.6

### DIFF
--- a/net/ariang/Makefile
+++ b/net/ariang/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ariang
-PKG_VERSION:=1.3.2
+PKG_VERSION:=1.3.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
 PKG_SOURCE_URL:=https://github.com/mayswind/AriaNg/releases/download/$(PKG_VERSION)
-PKG_HASH:=2186dacf57c9d1650e00084c0454f2227e910f3203d89c6190f547b40cac7243
+PKG_HASH:=2d36e1a39d95867b8e0cdb3cde96d04d40117bd37e8742d639da92496e07cc7b
 UNPACK_CMD=unzip -q -d $(1) $(DL_DIR)/$(PKG_SOURCE)
 
 PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>
@@ -56,6 +56,8 @@ define Package/ariang/install
 		$(PKG_BUILD_DIR)/LICENSE \
 		$(PKG_BUILD_DIR)/favicon.* \
 		$(PKG_BUILD_DIR)/robots.txt \
+		$(PKG_BUILD_DIR)/tileicon.png \
+		$(PKG_BUILD_DIR)/touchicon.png \
 		$(1)/www/ariang
 endef
 


### PR DESCRIPTION
Maintainer: @Ansuel 
Compile tested: AXT1800 (an qualcommax/ipq60xx) and x86
Run tested: AXT1800 (an qualcommax/ipq60xx) and x86

Description:

    Fix the problem that cannot create new task after clearing checksum option
    Other bug fix and user interface optimization

    Support overriding aria2 global settings with empty content when create new download task (#712)
    Other bug fix and user interface optimization

    Update Traditional Chinese translation (#705, thx @ChiaYen-Kan)
    Other bug fix and user interface optimization

    Add check-integrity to task settings tab (#693, thx @raytrap)
    Fix a spelling mistake (#696, thx @rusq)
   
    Some issues occuered and I have to re open a new Pull (old one is #22120 )