### PR TITLE
[23.05] Transmission backports from master

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=4.0.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/transmission/transmission/releases/download/$(PKG_VERSION)/

--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=4.0.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/transmission/transmission/releases/download/$(PKG_VERSION)/

--- a/net/transmission/files/transmission-daemon.json
+++ b/net/transmission/files/transmission-daemon.json
@@ -27,6 +27,7 @@
 				"fchmod",
 				"fcntl",
 				"fcntl64",
+				"ftruncate",
 				"ftruncate64",
 				"fstat",
 				"fstat64",

--- a/net/transmission/files/transmission-daemon.json
+++ b/net/transmission/files/transmission-daemon.json
@@ -14,6 +14,7 @@
 				"clone",
 				"close",
 				"connect",
+				"copy_file_range",
 				"epoll_create1",
 				"epoll_ctl",
 				"epoll_pwait",

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -158,8 +158,8 @@ transmission() {
 		logger -t transmission "Starting with $USE virt mem"
 	fi
 
-	[ -d "$web_home" ] && procd_set_param env TRANSMISSION_WEB_HOME="$web_home"
-	[ "$ca_bundle" -gt 0 ] && procd_set_param env CURL_CA_BUNDLE="$ca_bundle_file"
+	[ -d "$web_home" ] && procd_append_param env TRANSMISSION_WEB_HOME="$web_home"
+	[ "$ca_bundle" -gt 0 ] && procd_append_param env CURL_CA_BUNDLE="$ca_bundle_file"
 
 	procd_add_jail transmission log
 	procd_add_jail_mount "$config_file"


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: mediatek_filogic
Run tested: BananaPi R3

Description:
There are some important transmission fixes not applied to 23.05 branch. It was constantly crashing the service.
