### PR TITLE
ffmpeg: update to version 5.1.3

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
-PKG_VERSION:=5.1.2
+PKG_VERSION:=5.1.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
-PKG_HASH:=619e706d662c8420859832ddc259cd4d4096a48a2ce1eefd052db9e440eef3dc
+PKG_HASH:=1b113593ff907293be7aed95acdda5e785dd73616d7d4ec90a0f6adbc5a0312e
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Ian Leonard <antonlacon@gmail.com>
 


### PR DESCRIPTION
Maintainer: @thess , @antonlacon 
Compile tested: MacBook, macOS Ventura Version 13.5.2 (22G91), model A1990
Run tested: Will be shortly run tested on Turris Omnia, mvebu/cortexa9, OpenWrt 22.03.


Fixes CVEs:
CVE-2022-3964 [1]
CVE-2022-3965 [2]

[1] https://nvd.nist.gov/vuln/detail/CVE-2022-3964
[2] https://nvd.nist.gov/vuln/detail/CVE-2022-3965
