### PR TITLE
rust: Set rustflags by environment variable

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -3,16 +3,15 @@
 # Copyright (C) 2023 Luca Barbato and Donald Hoskins
 
 include $(TOPDIR)/rules.mk
-include ./rust-values.mk
 
 PKG_NAME:=rust
 PKG_VERSION:=1.72.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
 PKG_HASH:=ea9d61bbb51d76b6ea681156f69f0e0596b59722f04414b01c6e100b4b5be3a1
-HOST_BUILD_DIR:=$(BUILD_DIR)/host/rust-$(RUSTC_TARGET_ARCH)/rustc-$(PKG_VERSION)-src
+HOST_BUILD_DIR:=$(BUILD_DIR)/host/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>
 PKG_LICENSE:=Apache-2.0 MIT
@@ -23,6 +22,7 @@ PKG_HOST_ONLY:=1
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
+include ./rust-values.mk
 
 define Package/rust
   SECTION:=lang
@@ -31,6 +31,7 @@ define Package/rust
   TITLE:=Rust Programming Language Compiler
   URL:=https://www.rust-lang.org/
   DEPENDS:=$(RUST_ARCH_DEPENDS)
+  BUILDONLY:=1
 endef
 
 define Package/rust/description
@@ -95,8 +96,7 @@ define Host/Install
 		\
 		sed -e 's|@RUSTC_TARGET_ARCH@|$(RUSTC_TARGET_ARCH)|g' \
 		    -e 's|@TARGET_CC_NOCACHE@|$(TARGET_CC_NOCACHE)|g' \
-		    -e 's|@RUSTC_LDFLAGS@|$(RUSTC_LDFLAGS)|g' \
-			$(CURDIR)/files/cargo-config > $(CARGO_HOME)/config ; \
+			$(CURDIR)/files/cargo-config > $(CARGO_HOME)/config.toml ; \
 	)
 endef
 

--- a/lang/rust/files/cargo-config
+++ b/lang/rust/files/cargo-config
@@ -1,6 +1,5 @@
 [target.@RUSTC_TARGET_ARCH@]
 linker = "@TARGET_CC_NOCACHE@"
-rustflags = ["-Ctarget-feature=-crt-static", "-Clink-args=@RUSTC_LDFLAGS@"]
 
 [profile.stripped]
 inherits = "release"

--- a/lang/rust/rust-package.mk
+++ b/lang/rust/rust-package.mk
@@ -22,9 +22,10 @@ define Build/Compile/Cargo
 		cd $(PKG_BUILD_DIR) ; \
 		export PATH="$(CARGO_HOME)/bin:$(PATH)" ; \
 		CARGO_HOME=$(CARGO_HOME) \
-		TARGET_CFLAGS="$(TARGET_CFLAGS) $(RUST_CFLAGS)" \
+		TARGET_CFLAGS="$(TARGET_CFLAGS) $(RUSTC_CFLAGS)" \
 		TARGET_CC=$(TARGET_CC_NOCACHE) \
 		CC=$(HOSTCC_NOCACHE) \
+		RUSTFLAGS="$(CARGO_RUSTFLAGS)" \
 		$(CARGO_VARS) \
 		cargo install -v \
 			--profile stripped \


### PR DESCRIPTION
Maintainer: @lu-zero
Compile tested: x86-generic, 2023-09-09 snapshot sdk
Run tested: x86-generic (qemu, ran `ripgrep --version`), 2023-09-09 snapshot

Description:
In order to use `$(RUSTC_TARGET_ARCH)` in `HOST_BUILD_DIR`, the line to include rust-values.mk in the Rust makefile was moved in f489e019ac4a15e974518d9928ef913a157d135a, causing it to be included before package.mk is included.

This had the side effect of preventing "-lssp_nonshared" from being added to `RUSTC_LDFLAGS`, because `PKG_SSP` is indirectly set by package.mk (package.mk includes hardening.mk, hardening.mk sets `PKG_SSP`).

There is a deeper issue; it is the Rust package's `PKG_SSP` value that causes `RUSTC_LDFLAGS` to be set and written to the Cargo config file. For packages that use Rust to build, their `PKG_SSP` value does not affect the linker flag.

This sets rustflags with the `RUSTFLAGS` environment variable, instead of writing the value to the Cargo config file, allowing `PKG_SSP` from the package being built to be used and for the package being built to modify the rustflags used.

This also:

* Fix "-lssp_nonshared" being added to `TARGET_CFLAGS` instead of `RUSTC_LDFLAGS`, when `CONFIG_PKG_CC_STACKPROTECTOR_STRONG` is set.

* Remove the use of `$(RUSTC_TARGET_ARCH)` in `HOST_BUILD_DIR` and move the include line for rust-values.mk back to after package.mk.

  Since the host build directory was moved under the target build directory in efdbac38dc8b649ca26b49fac27abeb5cf76cd28, it is no longer necessary to separate build directories with `RUSTC_TARGET_ARCH`; `$(BUILD_DIR)` already separates build directories by target.

* Add `BUILDONLY:=1`, as the Rust package does not build a target package.

* Install the Cargo config file as "config.toml" instead of "config", as this is the [preferred form][1].

* Rename `RUST_CFLAGS` to `RUSTC_CFLAGS` and `CONFIG_HOST_SUFFIX` to `RUSTC_HOST_SUFFIX`, for consistency.

* Allow `CARGO_VARS` to be set before rust-values.mk is included.

[1]: https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure

Fixes: f489e019ac4a ("rust: compile host package per target")
Fixes: 83785a7ce016 ("rust-lang: Add the rust language support")
Fixes: https://github.com/openwrt/packages/issues/22133