### PR TITLE
collectd: remove target dependency from cpufreq plugin

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.12.0
-PKG_RELEASE:=48
+PKG_RELEASE:=49
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \
@@ -463,7 +463,7 @@ $(eval $(call BuildPlugin,chrony,chrony status input,chrony,))
 $(eval $(call BuildPlugin,conntrack,connection tracking table size input,conntrack,))
 $(eval $(call BuildPlugin,contextswitch,context switch input,contextswitch,))
 $(eval $(call BuildPlugin,cpu,CPU input,cpu,))
-$(eval $(call BuildPlugin,cpufreq,CPU Freq input,cpufreq,@(TARGET_x86||TARGET_x86_64||TARGET_mvebu||TARGET_ipq806x||TARGET_armsr||TARGET_ipq40xx||TARGET_bcm27xx_bcm2709||TARGET_rockchip||TARGET_mediatek||TARGET_qualcommax))) # Only enable on targets with CPUs supporting frequency scaling
+$(eval $(call BuildPlugin,cpufreq,CPU Freq input,cpufreq,))
 $(eval $(call BuildPlugin,csv,CSV output,csv,))
 $(eval $(call BuildPlugin,curl,cURL input,curl,+PACKAGE_collectd-mod-curl:libcurl))
 #$(eval $(call BuildPlugin,dbi,relational database input,dbi,+PACKAGE_collectd-mod-dbi:libdbi))


### PR DESCRIPTION
We currently have more package architectures supporting CPU frequency scaling than earlier, and the package architecture vs. CPU target SDK matching does not fully reflect that. (E.g. aarch64_cortex-a53 is currently using bcm27xx/bcm2710)

Simplify things by removing the target dependency and let the plugin be built for all architectures.

Maintainer: me 
Compile tested: CI testing via this PR
Run tested: -

Reference to issue [#12965 in OpenWrt bug tracker](https://github.com/openwrt/openwrt/issues/12965) and https://forum.openwrt.org/t/where-is-collectd-mod-cpufreq-gone/162459
