### PR TITLE
slirp4netns: update to 1.2.2

### DIFF
--- a/utils/slirp4netns/Makefile
+++ b/utils/slirp4netns/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=slirp4netns
-PKG_VERSION:=1.2.0
+PKG_VERSION:=1.2.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/rootless-containers/slirp4netns/archive/v$(PKG_VERSION)
-PKG_HASH:=b584edde686d3cfbac210cbdb93c4b0ba5d8cc0a6a4d92b9dfc3c5baec99c727
+PKG_HASH:=2450afb5730ee86a70f9c3f0d3fbc8981ab8e147246f4e0d354f0226a3a40b36
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
v1.2.2 changes:
 - Enabled reproducible builds

v1.2.1 changes:
 - sandbox: Add support for escaping resolv.conf symlinks. This fixes usage in WSL environments which symlinks /etc/resolv.conf under a shared location under /mnt.

Maintainer: me
Compile tested: x86_64, latest git