### PR TITLE
auc: preserve image's uci-defaults upon upgrade

### DIFF
--- a/utils/auc/Makefile
+++ b/utils/auc/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=auc
-PKG_VERSION:=0.3.2
+PKG_VERSION:=0.3.3
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0
 


### PR DESCRIPTION
uci-defaults scripts are essential for accessing device after firmware reset.

The device or user-facing PC might have no (easy accessible) Ethernet ports,
or wired LAN might not be accessible for any other reason.
In this case, uci-defaults script can contain code to setup WiFi AP on
the very first boot, thus granting the access.
Such uci-defaults script should survive the firmware upgrade with AUC,
if it was in the firmware image initially.
Otherwise, access to the device can be lost next time user performs firmware Reset.

This patch fixes it by passing the file
/rom/etc/uci-defaults/99-asu-defaults (the path used by ASU server)
for inclusion to a new firmware image using BuildRequest API's "defaults" member which allows specifying a content of that uci-defaults script:
https://sysupgrade.openwrt.org/ui/

fixes https://github.com/openwrt/asu/issues/575

@hauke @ynezz @aparcar 