### PR TITLE
bind: update to version 9.18.18

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.18.16
+PKG_VERSION:=9.18.18
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=c88234fe07ee75c3c8a9e59152fee64b714643de8e22cf98da3db4d0b57e0775
+PKG_HASH:=d735cdc127a6c5709bde475b5bf16fa2133f36fdba202f7c3c37d134e5192160
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: MacBook, macOS Ventura Version 13.5.2 (22G91), model A1990
Run tested: Turris Omnia, the latest changes from the OpenWrt 22.03 branches with one tweak - kernel 5.15 LTS known as Turris OS 7.0.0, which was not released to end-users so far, mvebu/cortex-a9
**Named works, dig works.**

Release notes:
https://downloads.isc.org/isc/bind9/9.18.18/doc/arm/html/notes.html#notes-for-bind-9-18-18 https://downloads.isc.org/isc/bind9/9.18.17/doc/arm/html/notes.html#notes-for-bind-9-18-17
