### PR TITLE
czmq: drop libpcre dependency

### DIFF
--- a/libs/czmq/Makefile
+++ b/libs/czmq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=czmq
 PKG_VERSION:=4.2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/zeromq/czmq/releases/download/v$(PKG_VERSION)/
@@ -30,7 +30,7 @@ define Package/czmq
   TITLE:=CZMQ High-level C binding for ZeroMQ
   URL:=http://czmq.zeromq.org
   ABI_VERSION:=4
-  DEPENDS:=+libzmq +libuuid +libpcre +libmicrohttpd +liblz4 +libcurl
+  DEPENDS:=+libzmq +libuuid +libmicrohttpd +liblz4 +libcurl
 endef
 
 define Package/czmq/description


### PR DESCRIPTION
Maintainer:  @ja-pa 
Compile tested: MacBook, macOS Ventura Version 13.5.2 (22G91), model A1990
Run tested: Turris Omnia, the latest changes from the OpenWrt 22.03 branches with one tweak - kernel 5.15 LTS known as Turris OS 7.0.0, which was not released to end-users so far, mvebu/cortex-a9

Description:
It seems like the libpcre dependency was added by mistake. While checking in the source code of czmq (Makefile.am, CMakeLists.txt), I see there are several dependencies, but there isn't PCRE.

Fixes: 936a48a ("czmq: add new package")
