### PR TITLE
tailscale: update to version 1.48.2

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.48.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.48.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6b3152cdd9ed915c01ce30f3967c0d4e04e2a81053eddeb93792d93088fe2d72
+PKG_HASH:=1c34c5c2c3b78e59ffb824b356418ff828653c62885b126d0d05f300218b36b5
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: @ja-pa @oskarirauta
Compile tested: mips_24kc @ SNAPSHOT
Run tested: aarch64_cortex-a53` @ 22.03.5 on Linksys E8450 & mips_24kc @ SNAPSHOT on GL.iNet GL-AR750

Description:
update to v1.48.2
Release notes:
https://github.com/tailscale/tailscale/releases/tag/v1.48.2