### PR TITLE
sshtunnel: support Dropbear

### DIFF
--- a/net/sshtunnel/Makefile
+++ b/net/sshtunnel/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sshtunnel
-PKG_VERSION:=4
-PKG_RELEASE:=5
+PKG_VERSION:=5
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0-or-later
 
 PKG_MAINTAINER:=Nuno Goncalves <nunojpg@gmail.com>
@@ -21,7 +21,7 @@ define Package/sshtunnel
   CATEGORY:=Network
   SUBMENU:=SSH
   TITLE:=Manages local and remote openssh ssh(1) tunnels
-  DEPENDS:=+openssh-client
+  DEPENDS:=@(DROPBEAR_DBCLIENT||PACKAGE_openssh-client)
   PKGARCH:=all
 endef
 

--- a/net/sshtunnel/files/sshtunnel.init
+++ b/net/sshtunnel/files/sshtunnel.init
@@ -57,6 +57,7 @@ validate_server_section() {
 
 validate_tunnelR_section() {
 	uci_load_validate sshtunnel tunnelR "$1" "$2" \
+		'enabled:bool:1' \
 		'remoteaddress:or(host, "*")' \
 		'remoteport:port' \
 		'localaddress:host' \
@@ -65,6 +66,7 @@ validate_tunnelR_section() {
 
 validate_tunnelL_section() {
 	uci_load_validate sshtunnel tunnelL "$1" "$2" \
+		'enabled:bool:1' \
 		'remoteaddress:host' \
 		'remoteport:port' \
 		'localaddress:or(host, "*")' \
@@ -73,12 +75,14 @@ validate_tunnelL_section() {
 
 validate_tunnelD_section() {
 	uci_load_validate sshtunnel tunnelD "$1" "$2" \
+		'enabled:bool:1' \
 		'localaddress:or(host, "*")' \
 		'localport:port'
 }
 
 validate_tunnelW_section() {
 	uci_load_validate sshtunnel tunnelW "$1" "$2" \
+		'enabled:bool:1' \
 		'vpntype:or("ethernet", "point-to-point"):point-to-point' \
 		'localdev:or("any", min(0))' \
 		'remotedev:or("any", min(0))'
@@ -86,6 +90,7 @@ validate_tunnelW_section() {
 
 load_tunnelR() {
 	config_get section_server "$1" "server"
+	[ "$enabled" = 0 ] && return 0
 
 	# continue to read next section if this is not for the current server
 	[ "$server" = "$section_server" ] || return 0
@@ -104,6 +109,7 @@ load_tunnelR() {
 
 load_tunnelL() {
 	config_get section_server "$1" "server"
+	[ "$enabled" = 0 ] && return 0
 
 	# continue to read next section if this is not for the current server
 	[ "$server" = "$section_server" ] || return 0
@@ -122,6 +128,7 @@ load_tunnelL() {
 
 load_tunnelD() {
 	config_get section_server "$1" "server"
+	[ "$enabled" = 0 ] && return 0
 
 	# continue to read next section if this is not for the current server
 	[ "$server" = "$section_server" ] || return 0
@@ -140,6 +147,7 @@ load_tunnelD() {
 
 load_tunnelW() {
 	config_get section_server "$1" "server"
+	[ "$enabled" = 0 ] && return 0
 
 	# continue to read next section if this is not for the current server
 	[ "$server" = "$section_server" ] || return 0

--- a/net/sshtunnel/files/sshtunnel.init
+++ b/net/sshtunnel/files/sshtunnel.init
@@ -174,10 +174,12 @@ load_server() {
 	config_foreach validate_tunnelW_section "tunnelW" load_tunnelW
 	[ "$count" -eq 0 ] && { _err "tunnels to $server not started - no tunnels defined"; return 1; }
 
-	append_params CheckHostIP Compression CompressionLevel IdentityFile \
+	append_params CheckHostIP Compression CompressionLevel \
 		LogLevel PKCS11Provider ServerAliveCountMax ServerAliveInterval \
 		StrictHostKeyChecking TCPKeepAlive VerifyHostKeyDNS
 
+	# dropbear doesn't support -o IdentityFile so use -i instead
+	[ -n "$IdentityFile" ] && ARGS_options="$ARGS_options -i $IdentityFile"
 	ARGS="$ARGS_options -o ExitOnForwardFailure=yes -o BatchMode=yes -nN $ARGS_tunnels -p $port $user@$hostname"
 
 	procd_open_instance "$server"

--- a/net/sshtunnel/files/sshtunnel.init
+++ b/net/sshtunnel/files/sshtunnel.init
@@ -191,7 +191,10 @@ load_server() {
 	# dbclient doesn't support StrictHostKeyChecking but it has the -y option that works same
 	[ "$StrictHostKeyChecking" = "accept-new" ] && ARGS_options="$ARGS_options -y"
 	[ "$StrictHostKeyChecking" = "no" ] && ARGS_options="$ARGS_options -yy"
-	ARGS="$ARGS_options -o ExitOnForwardFailure=yes -o BatchMode=yes -nN $ARGS_tunnels -p $port $user@$hostname"
+	ARGS="$ARGS_options -o ExitOnForwardFailure=yes -o BatchMode=yes -nN $ARGS_tunnels "
+	[ -n "$port" ] && ARGS="$ARGS -p $port "
+	[ -n "$user" ] && ARGS="$ARGS $user@"
+	ARGS="${ARGS}$hostname"
 
 	procd_open_instance "$server"
 	procd_set_param command "$PROG" $ARGS

--- a/net/sshtunnel/files/sshtunnel.init
+++ b/net/sshtunnel/files/sshtunnel.init
@@ -180,6 +180,9 @@ load_server() {
 
 	# dropbear doesn't support -o IdentityFile so use -i instead
 	[ -n "$IdentityFile" ] && ARGS_options="$ARGS_options -i $IdentityFile"
+	# dbclient doesn't support StrictHostKeyChecking but it has the -y option that works same
+	[ "$StrictHostKeyChecking" = "accept-new" ] && ARGS_options="$ARGS_options -y"
+	[ "$StrictHostKeyChecking" = "no" ] && ARGS_options="$ARGS_options -yy"
 	ARGS="$ARGS_options -o ExitOnForwardFailure=yes -o BatchMode=yes -nN $ARGS_tunnels -p $port $user@$hostname"
 
 	procd_open_instance "$server"

--- a/net/sshtunnel/files/sshtunnel.init
+++ b/net/sshtunnel/files/sshtunnel.init
@@ -47,10 +47,10 @@ validate_server_section() {
 		'Compression:or("yes", "no")' \
 		'CompressionLevel:range(1,9)' \
 		'IdentityFile:file' \
-		'LogLevel:or("QUIET", "FATAL", "ERROR", "INFO", "VERBOSE", "DEBUG", "DEBUG1", "DEBUG2", "DEBUG3"):INFO' \
+		'LogLevel:or("QUIET", "FATAL", "ERROR", "INFO", "VERBOSE", "DEBUG", "DEBUG1", "DEBUG2", "DEBUG3")' \
 		'ServerAliveCountMax:min(1)' \
 		'ServerAliveInterval:min(0)' \
-		'StrictHostKeyChecking:or("yes", "no", "accept-new")' \
+		'StrictHostKeyChecking:or("yes", "no", "accept-new"):accept-new' \
 		'TCPKeepAlive:or("yes", "no")' \
 		'VerifyHostKeyDNS:or("yes", "no")'
 }

--- a/net/sshtunnel/files/sshtunnel.init
+++ b/net/sshtunnel/files/sshtunnel.init
@@ -57,7 +57,7 @@ validate_server_section() {
 
 validate_tunnelR_section() {
 	uci_load_validate sshtunnel tunnelR "$1" "$2" \
-		'remoteaddress:or(host, "*"):*' \
+		'remoteaddress:or(host, "*")' \
 		'remoteport:port' \
 		'localaddress:host' \
 		'localport:port'
@@ -67,13 +67,13 @@ validate_tunnelL_section() {
 	uci_load_validate sshtunnel tunnelL "$1" "$2" \
 		'remoteaddress:host' \
 		'remoteport:port' \
-		'localaddress:or(host, "*"):*' \
+		'localaddress:or(host, "*")' \
 		'localport:port'
 }
 
 validate_tunnelD_section() {
 	uci_load_validate sshtunnel tunnelD "$1" "$2" \
-		'localaddress:or(host, "*"):*' \
+		'localaddress:or(host, "*")' \
 		'localport:port'
 }
 
@@ -93,7 +93,7 @@ load_tunnelR() {
 	# validate and load this remote tunnel config
 	[ "$2" = 0 ] || { _err "tunnelR $1: validation failed"; return 1; }
 
-	[ -n "$remoteport" -a -n "$localport" -a -n "$remoteaddress" ] || { _err "tunnelR $1: missing required options"; return 1; }
+	[ -n "$remoteport" -a -n "$localport" ] || { _err "tunnelR $1: missing required options"; return 1; }
 
 	# count nr of valid sections to make sure there are at least one
 	count=$((count+=1))
@@ -111,7 +111,7 @@ load_tunnelL() {
 	# validate and load this remote tunnel config
 	[ "$2" = 0 ] || { _err "tunnelL $1: validation failed"; return 1; }
 
-	[ -n "$remoteport" -a -n "$localport" -a -n "$remoteaddress" ] || { _err "tunnelL $1: missing required options"; return 1; }
+	[ -n "$remoteport" -a -n "$localport" ] || { _err "tunnelL $1: missing required options"; return 1; }
 
 	# count nr of valid sections to make sure there are at least one
 	count=$((count+=1))

--- a/net/sshtunnel/files/uci_sshtunnel
+++ b/net/sshtunnel/files/uci_sshtunnel
@@ -3,9 +3,9 @@
 # By default the OpenSSH client checks for /root/.ssh/id_rsa, /root/.ssh/id_ed25519 and /root/.ssh/id_ecdsa
 # See https://openwrt.org/docs/guide-user/services/ssh/sshtunnel
 
-#config server disney
-#	option user			mourinho
-#	option hostname			server.disney.com
+#config server example
+#	option user			root
+#	option hostname			server.example.com
 #	option port			22
 #	option retrydelay		1
 #	option CheckHostIP		yes
@@ -24,7 +24,7 @@
 # remoteaddress:remoteport and then forwarded to localaddress:localport
 #
 #config tunnelR http
-#	option server		disney
+#	option server		example
 #	option remoteaddress	*
 #	option remoteport	9009
 #	option localaddress	192.168.1.13
@@ -34,17 +34,17 @@
 # localaddress:localport and then forwarded to remoteaddress:remoteport
 #
 #config tunnelL test
-#	option server		disney
+#	option server		example
 #	option localaddress	*
 #	option localport	1022
-#	option remoteaddress	secretserver.disney.com
+#	option remoteaddress	secretserver.example.com
 #	option remoteport	22
 
 # tunnelD(ynamic) - when the connection will be initiated with the SOCKS4 or SOCKS5 protocol
 # to the local endpoint at localaddress:localport and then forwarded over the remote host
 #
 #config tunnelD proxy
-#	option server		disney
+#	option server		example
 #	option localaddress	*
 #	option localport	4055
 
@@ -54,7 +54,7 @@
 #  ethernet = TAP
 #
 #config tunnelW proxy
-#	option server           disney
+#	option server           example
 #	option vpntype		point-to-point|ethernet
 #	option localdev		any|0|1|2|...
 #	option remotedev	any|0|1|2|...

--- a/net/sshtunnel/files/uci_sshtunnel
+++ b/net/sshtunnel/files/uci_sshtunnel
@@ -1,19 +1,17 @@
-#
-# Password authentication is not possible, public key authentication must be used.
-# Set "option IdentityFile" to the file from which the identity (private key) for RSA or DSA authentication is read.
-# The default is ~/.ssh/identity for protocol version 1, and ~/.ssh/id_rsa and ~/.ssh/id_dsa for protocol version 2.
-# ssh will also try to load certificate information from the filename obtained by appending -cert.pub to identity filenames.
-#
+# Password auth is not possible so only Public Key auth must be used.
+# Set "option IdentityFile" to the file from which the identity (private key) is read.
+# By default the OpenSSH client checks for /root/.ssh/id_rsa, /root/.ssh/id_ed25519 and /root/.ssh/id_ecdsa
+# See https://openwrt.org/docs/guide-user/services/ssh/sshtunnel
 
 #config server disney
 #	option user			mourinho
 #	option hostname			server.disney.com
 #	option port			22
-#	option retrydelay		1	
+#	option retrydelay		1
 #	option CheckHostIP		yes
 #	option Compression		no
 #	option CompressionLevel		6
-#	option IdentityFile		~/.ssh/id_rsa
+#	option IdentityFile		/root/.ssh/id_rsa
 #	option LogLevel			INFO
 #	option PKCS11Provider		/lib/pteidpkcs11.so
 #	option ServerAliveCountMax	3


### PR DESCRIPTION
**Maintainer:** @nunojpg

**Compile tested:** OpenWrt 23
**Run tested:** tested in VirtualBox and Turris

**Description:**
This is the same PR as was in the #21263. 
I just removed the branch accidentally and now have to recreate the PR.

The only difference is that I changed dependency line: now it will depend ether on dbclient or openssh-client.
I copied the depends line from pppossh package but improved it to be more precise and depend on the dbclient and not just on the dropbear package.
The PR also contains update for the pppossh with the same depends change so @yousong please have a look.