### PR TITLE
mg: switch pcre to pcre2

### DIFF
--- a/utils/mg/Makefile
+++ b/utils/mg/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mg
 PKG_VERSION:=7.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ibara/mg/tar.gz/$(PKG_NAME)-$(PKG_VERSION)?
@@ -22,7 +22,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/mg
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libncurses +libpcre
+  DEPENDS:=+libncurses +libpcre2
   TITLE:=microscopic EMACS style editor
   URL:=https://github.com/ibara/mg
   SUBMENU:=Editors

--- a/utils/mg/patches/001-cross_compile_openwrt.patch
+++ b/utils/mg/patches/001-cross_compile_openwrt.patch
@@ -168,7 +168,7 @@
 -    ;;
 -esac
 +# OpenWrt
-+libs='-lncurses -lpcreposix -lutil'
++libs='-lncurses -lpcre2-posix -lutil'
 +cflags="$cflags -D_GNU_SOURCE -D__dead=\"__attribute__((__noreturn__))\" -Dst_mtimespec=st_mtim"
  
  cat << EOF > config.h

--- a/utils/mg/patches/901-use_pcre.patch
+++ b/utils/mg/patches/901-use_pcre.patch
@@ -5,7 +5,7 @@
  #include <sys/queue.h>
  #include <sys/types.h>
 -#include <regex.h>
-+#include <pcreposix.h>
++#include <pcre2posix.h>
  #include <signal.h>
  #include <stdio.h>
  #include <string.h>


### PR DESCRIPTION
Maintainer: me 
Compile tested: head, aarch64
Run tested: aarch64 (qemu-8.1.0)

Description:
Switch pcre to pcre2
https://github.com/openwrt/packages/issues/22006
