### PR TITLE
openvswitch: disable groff manpage check

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -251,6 +251,7 @@ CONFIGURE_ARGS+= \
 CONFIGURE_VARS += \
 	$(if $(CONFIG_OPENVSWITCH_WITH_LIBUNBOUND),,ac_cv_lib_unbound_ub_ctx_create=no) \
 	ovs_cv_flake8=no \
+	ovs_cv_groff=no \
 	ovs_cv_python3=$(PYTHON3) \
 	ovs_cv_python3_host=$(HOST_PYTHON3_BIN) \
 	SPHINXBUILD=none \


### PR DESCRIPTION
Maintainer: @yousong 
Compile tested: x86-64, OpenWrt master (d1521889066ce9698187ae56111cf591b09c10c5)
Run tested: Not run tested. This is a build fix that does not affect runtime.

Description:

The openvswitch build trips over a number of warnings during the manpage-check step if groff 1.23 is installed on the build host, resulting in a failed build.

As this check is optional, and we don't even install the manpages, simply override the groff configure check to never detect groff.

Supersedes #22161, as it turned out that several additional patches would've been necessary to make the groff check pass depending on the build host distro.

Closes #21991