### PR TITLE
treewide: add HAS_LUAJIT_ARCH dependency to luajit user

### DIFF
--- a/lang/luajit/Makefile
+++ b/lang/luajit/Makefile
@@ -24,12 +24,19 @@ define Package/luajit
  CATEGORY:=Languages
  TITLE:=LuaJIT
  URL:=https://www.luajit.org
- DEPENDS:=@(i386||x86_64||arm||armeb||aarch64||powerpc||mips||mipsel||mips64)
+ DEPENDS:=@HAS_LUAJIT_ARCH
 endef
 
 define Package/luajit/description
  LuaJIT is a Just-In-Time (JIT) compiler for the Lua programming language. *** Requires GCC Multilib on host system to build! ***
 endef
+
+define Package/luajit/config
+config HAS_LUAJIT_ARCH
+	bool
+	default y if i386||x86_64||arm||armeb||aarch64||powerpc||mips||mipsel||mips64
+endef
+
 ifeq ($(HOST_ARCH),$(filter $(HOST_ARCH), x86_64 mips64))
   ifeq ($(CONFIG_ARCH_64BIT),)
     HOST_BITS := -m32

--- a/lang/luajit2/Makefile
+++ b/lang/luajit2/Makefile
@@ -17,13 +17,17 @@ PKG_BUILD_FLAGS:=no-mips16
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 
+# HAS_LUAJIT_ARCH config is defined in luajit and is used to define
+# arch deoendency for luajit. Since luajit2 is an improved version of
+# luajit, they share the same arch dependency. Refer there to update
+# dependency for them.
 define Package/luajit2
  SECTION:=lang
  CATEGORY:=Languages
  SUBMENU:=Lua
  TITLE:=LuaJIT from OpenResty
  URL:=https://www.luajit.org
- DEPENDS:=@(i386||x86_64||arm||armeb||aarch64||powerpc||mips||mipsel||mips64)
+ DEPENDS:=@HAS_LUAJIT_ARCH
  PROVIDES:=luajit
 endef
 

--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -35,7 +35,7 @@ define Package/dnsdist/Default
 	  +libatomic \
 	  +libcap \
 	  +libstdcpp \
-	  +luajit
+	  @HAS_LUAJIT_ARCH +luajit
   URL:=https://dnsdist.org/
   VARIANT:=$(1)
   PROVIDES:=dnsdist

--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -34,7 +34,7 @@ define Package/knot-resolver
     +knot-libs \
     +knot-libzscanner \
     +libuv \
-    +luajit \
+    @HAS_LUAJIT_ARCH +luajit \
     +luasec \
     +luasocket \
     +libstdcpp \

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -210,7 +210,7 @@ endef
 
 define Package/nginx-mod-lua-resty-lrucache
   $(call Package/nginx/default)
-  DEPENDS:=+luajit2
+  DEPENDS:=@HAS_LUAJIT_ARCH +luajit2
   TITLE:=Nginx Lua OpenResty lrucache module
 endef
 

--- a/net/snort/Makefile
+++ b/net/snort/Makefile
@@ -31,7 +31,7 @@ define Package/snort
   SUBMENU:=Firewall
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libdaq +libdnet +libnghttp2 +libopenssl +libpcap +libpcre +libpthread +libtirpc +libuuid +zlib +luajit +SNORT_LZMA:liblzma
+  DEPENDS:=+libdaq +libdnet +libnghttp2 +libopenssl +libpcap +libpcre +libpthread +libtirpc +libuuid +zlib @HAS_LUAJIT_ARCH +luajit +SNORT_LZMA:liblzma
   TITLE:=Lightweight Network Intrusion Detection System
   URL:=http://www.snort.org/
   CONFLICTS:=snort3

--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -25,7 +25,7 @@ define Package/snort3
   SUBMENU:=Firewall
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre +libpthread +libuuid +zlib +libhwloc +libtirpc +luajit +libatomic
+  DEPENDS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic
   TITLE:=Lightweight Network Intrusion Detection System
   URL:=http://www.snort.org/
   MENU:=1


### PR DESCRIPTION
Add HAS_LUAJIT_ARCH dependency to any user of luajit to fix circular
dependency limitation.

Fixes: https://github.com/openwrt/packages/issues/22192

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>