### PR TITLE
[23.05] crowdsec: new upstream release version 1.5.4

### DIFF
--- a/net/crowdsec/Makefile
+++ b/net/crowdsec/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crowdsec
-PKG_VERSION:=1.5.2
+PKG_VERSION:=1.5.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/crowdsecurity/crowdsec/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=18de78572600166c3a7636e9cd4ea011d204211638810969d99cb65feb78c231
+PKG_HASH:=afa4021f77e9cb87d7fd11cd86146770836dc15cad1ae8a4edce1314b14be98a
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -29,7 +29,7 @@ CWD_BUILD_CODENAME:=alphaga
 CWD_BUILD_TIMESTAMP:=$(shell date +%F"_"%T)
 CWD_BUILD_TAG:=openwrt-$(PKG_VERSION)-$(PKG_RELEASE)
 
-CWD_VERSION_PKG:=github.com/crowdsecurity/crowdsec/pkg/cwversion
+CWD_VERSION_PKG:=github.com/crowdsecurity/go-cs-lib/version
 
 GO_PKG:=github.com/crowdsecurity/crowdsec
 GO_PKG_INSTALL_ALL:=1


### PR DESCRIPTION
Update crowdsec to latest upstream release version 1.5.4

Signed-off-by: S. Brusch <ne20002@gmx.ch>

Maintainer: Kerma Gérald <gandalf@gk2.net>
Build tested: package build checked, no run test due to limited space

Description: update to latest version of upstream
(cherry picked from commit 7528bf76821eb9234d4665752371c85496ca5b89)
