### PR TITLE
openthread-br: switch to avahi

### DIFF
--- a/net/openthread-br/Makefile
+++ b/net/openthread-br/Makefile
@@ -40,8 +40,7 @@ define Package/openthread-br
 	+libstdcpp \
 	+libubox \
 	+libubus \
-	+mdnsd \
-	+mdnsresponder
+	+libavahi-client
 endef
 
 define Package/openthread-br/description
@@ -67,7 +66,7 @@ CMAKE_OPTIONS += \
 	-DOTBR_BORDER_ROUTING:BOOL=ON \
 	-DOTBR_DNSSD_DISCOVERY_PROXY:BOOL=ON \
 	-DOTBR_DUA_ROUTING:BOOL=ON \
-	-DOTBR_MDNS=mDNSResponder \
+	-DOTBR_MDNS=avahi \
 	-DOTBR_OPENWRT:BOOL=ON \
 	-DOTBR_REST:BOOL=ON \
 	-DOTBR_SRP_ADVERTISING_PROXY:BOOL=ON \

--- a/net/openthread-br/Makefile
+++ b/net/openthread-br/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openthread-br
 PKG_SOURCE_DATE:=2023-08-01
 PKG_SOURCE_VERSION:=1738d8cd8b42106c2ef1262fbbac2f06beab83ba
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://github.com/openthread/ot-br-posix.git
@@ -93,10 +93,8 @@ endef
 
 define Package/openthread-br/install
 	$(INSTALL_DIR) \
-		$(1)/etc/init.d \
 		$(1)/lib/netifd/proto \
-		$(1)/usr/sbin \
-		$(1)/var/lib/thread
+		$(1)/usr/sbin
 	$(INSTALL_BIN) ./files/openthread-proto.sh $(1)/lib/netifd/proto/openthread.sh
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/* $(1)/usr/sbin
 endef

--- a/net/openthread-br/patches/100-rest-support-deleting-the-dataset.patch
+++ b/net/openthread-br/patches/100-rest-support-deleting-the-dataset.patch
@@ -16,8 +16,6 @@ otDatasetCreateNewNetwork).
  src/rest/resource.hpp |  1 +
  3 files changed, 57 insertions(+)
 
-diff --git a/src/rest/openapi.yaml b/src/rest/openapi.yaml
-index 2ba2a4dd56..2edc4af29a 100644
 --- a/src/rest/openapi.yaml
 +++ b/src/rest/openapi.yaml
 @@ -248,6 +248,18 @@ paths:
@@ -55,8 +53,6 @@ index 2ba2a4dd56..2edc4af29a 100644
  components:
    schemas:
      LeaderData:
-diff --git a/src/rest/resource.cpp b/src/rest/resource.cpp
-index a60e9d9483..829835341a 100644
 --- a/src/rest/resource.cpp
 +++ b/src/rest/resource.cpp
 @@ -767,12 +767,47 @@ exit:
@@ -107,8 +103,6 @@ index a60e9d9483..829835341a 100644
      case HttpMethod::kGet:
          GetDataset(aDatasetType, aRequest, aResponse);
          break;
-diff --git a/src/rest/resource.hpp b/src/rest/resource.hpp
-index d79085dbfc..362e501471 100644
 --- a/src/rest/resource.hpp
 +++ b/src/rest/resource.hpp
 @@ -150,6 +150,7 @@ private:
@@ -119,6 +113,3 @@ index d79085dbfc..362e501471 100644
  
      void DeleteOutDatedDiagnostic(void);
      void UpdateDiag(std::string aKey, std::vector<otNetworkDiagTlv> &aDiag);
--- 
-2.41.0
-


### PR DESCRIPTION
mDNSResponder links to dns_sd, which is also provided by avahi and does not include needed functions. Just avoid this mess.

Maintainer: @stintel 