### PR TITLE
adguardhome: wait for interfaces to be up at boot

### DIFF
--- a/net/adguardhome/files/adguardhome.init
+++ b/net/adguardhome/files/adguardhome.init
@@ -4,12 +4,22 @@ PROG=/usr/bin/AdGuardHome
 
 USE_PROCD=1
 
-# starts just after network starts to avoid some network race conditions
-START=25
+# matches dnsmasq
+START=19
 # stops before networking stops
 STOP=89
 
+boot() {
+  adguardhome_boot=1
+  start "$@"
+}
+
 start_service() {
+  if [ -n "$adguardhome_boot" ]; then
+    # Do not start yet, wait for triggers
+    return 0
+  fi
+
   config_load adguardhome
   config_get WORK_DIR config workdir
 
@@ -20,4 +30,12 @@ start_service() {
   procd_set_param stdout 1
   procd_set_param stderr 1
   procd_close_instance
+}
+
+service_triggers() {
+  if [ -n "$adguardhome_boot" ]; then
+    # Wait for interfaces to be up before starting AdGuard Home for real.
+    # Prevents issues like https://github.com/openwrt/packages/issues/21868.
+    procd_add_raw_trigger "interface.*.up" 5000 /etc/init.d/adguardhome restart
+  fi
 }


### PR DESCRIPTION
Maintainer: @dobo90 
Compile tested: n/a
Run tested: @iljah and @mangkoran 

Description:

This should allow the service to be activated even earlier during the boot process and also avoids race condition against network.

~~I've not tested this change yet since I'm not affected by this issue.
@iljah if you can compile your own packages, please test this.~~

Fixes #21868.