### PR TITLE
python-typing-extensions: Update to 4.8.0

### DIFF
--- a/lang/python/python-typing-extensions/Makefile
+++ b/lang/python/python-typing-extensions/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-typing-extensions
-PKG_VERSION:=4.7.1
+PKG_VERSION:=4.8.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=typing-extensions
 PYPI_SOURCE_NAME:=typing_extensions
-PKG_HASH:=b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2
+PKG_HASH:=df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>, Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=Python-2.0.1 0BSD

--- a/lang/python/python-typing-extensions/test.sh
+++ b/lang/python/python-typing-extensions/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ "$1" = python3-typing-extensions ] || exit 0
+
+python3 -c 'import typing_extensions'


### PR DESCRIPTION
Maintainer: me, @ja-pa
Compile tested: armsr-armv7, 2023-09-24 snapshot sdk
Run tested: armsr-armv7 (qemu, basic module loading only), 2023-09-24 snapshot

Description:
