### PR TITLE
stunnel: update version to 5.71

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.67
-PKG_RELEASE:=4
+PKG_VERSION:=5.71
+PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
@@ -23,7 +23,7 @@ PKG_SOURCE_URL:= \
 	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=3086939ee6407516c59b0ba3fbf555338f9d52f459bcab6337c0f00e91ea8456
+PKG_HASH:=f023aae837c2d32deb920831a5ee1081e11c78a5d57340f8e6f0829f031017f5
 
 PKG_FIXUP:=autoreconf
 PKG_FIXUP:=patch-libtool


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64 and lantiq_xrx200,
Run tested: x86_64, start without config

Description:
update version to 5.71
```
root@G3-10940 /root# stunnel
[ ] Initializing inetd mode confiroot@G3-10940 /sys/class/leds/khan:red:led8 # stunnel
[ ] Initializing inetd mode configuration
[ ] Clients allowed=500
[.] stunnel 5.71 on x86_64-openwrt-linux-gnu platform
[.] Compiled/running with OpenSSL 3.0.11 19 Sep 2023
[.] Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,OCSP,PSK,SNI
[ ] errno: (*__errno_location())
[ ] Initializing inetd mode configuration
[.] Reading configuration from file /etc/stunnel/stunnel.conf
[.] UTF-8 byte order mark not detected
[.] FIPS mode disabled
[ ] No PRNG seeding was required
[ ] Initializing service [dummy]
[ ] Initializing context [dummy]
[ ] stunnel default security level set: 2
[ ] Ciphers: HIGH:!aNULL:!SSLv2:!DH:!kDHEPSK
[ ] TLSv1.3 ciphersuites: TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256
[ ] TLS options: 0x2100000 (+0x0, -0x0)
[ ] Session resumption enabled
[ ] No certificate or private key specified
[ ] No trusted certificates found
[:] Service [dummy] needs authentication to prevent MITM attacks
[ ] OCSP: Client OCSP stapling enabled
[ ] DH initialization skipped: client section
[ ] ECDH initialization
[ ] ECDH initialized with curves X25519:P-256:X448:P-521:P-384
[.] Configuration successful
[ ] Deallocating deployed section defaults
[ ] Cleaning up context [stunnel]
[ ] Binding service [dummy]
[ ] Listening file descriptor created (FD=9)
[ ] Setting accept socket options (FD=9)
[ ] Option SO_REUSEADDR set on accept socket
[.] Binding service [dummy] to ::1:6000: Address in use (98)
[ ] Listening file descriptor created (FD=9)
[ ] Setting accept socket options (FD=9)
[ ] Option SO_REUSEADDR set on accept socket
[.] Binding service [dummy] to 127.0.0.1:6000: Address in use (98)
[!] Binding service [dummy] failed
[ ] Unbinding service [dummy]
[ ] Service [dummy] closed
[ ] Deallocating deployed section defaults
[ ] Cleaning up context [stunnel]
[ ] Deallocating section [dummy]
[ ] Cleaning up context [dummy]
[ ] Initializing inetd mode configurationguration
[ ] Clients allowed=500
[.] stunnel 5.71 on x86_64-openwrt-linux-gnu platform
[.] Compiled/running with OpenSSL 3.0.11 19 Sep 2023
[.] Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,OCSP,PSK,SNI
[ ] errno: (*__errno_location())
[ ] Initializing inetd mode configuration
[.] Reading configuration from file /etc/stunnel/stunnel.conf
[.] UTF-8 byte order mark not detected
[.] FIPS mode disabled
[ ] No PRNG seeding was required
[ ] Initializing service [dummy]
[ ] Initializing context [dummy]
[ ] stunnel default security level set: 2
[ ] Ciphers: HIGH:!aNULL:!SSLv2:!DH:!kDHEPSK
[ ] TLSv1.3 ciphersuites: TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256
[ ] TLS options: 0x2100000 (+0x0, -0x0)
[ ] Session resumption enabled
[ ] No certificate or private key specified
[ ] No trusted certificates found
[:] Service [dummy] needs authentication to prevent MITM attacks
[ ] OCSP: Client OCSP stapling enabled
[ ] DH initialization skipped: client section
[ ] ECDH initialization
[ ] ECDH initialized with curves X25519:P-256:X448:P-521:P-384
[.] Configuration successful
[ ] Deallocating deployed section defaults
[ ] Cleaning up context [stunnel]
[ ] Binding service [dummy]
[ ] Listening file descriptor created (FD=9)
[ ] Setting accept socket options (FD=9)
[ ] Option SO_REUSEADDR set on accept socket
[.] Binding service [dummy] to ::1:6000: Address in use (98)
[ ] Listening file descriptor created (FD=9)
[ ] Setting accept socket options (FD=9)
[ ] Option SO_REUSEADDR set on accept socket
[.] Binding service [dummy] to 127.0.0.1:6000: Address in use (98)
[!] Binding service [dummy] failed
[ ] Unbinding service [dummy]
[ ] Service [dummy] closed
[ ] Deallocating deployed section defaults
[ ] Cleaning up context [stunnel]
[ ] Deallocating section [dummy]
[ ] Cleaning up context [dummy]
[ ] Initializing inetd mode configuration
```
