### PR TITLE
libwebp: bump to version 1.3.2

### DIFF
--- a/libs/libwebp/Makefile
+++ b/libs/libwebp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libwebp
-PKG_VERSION:=1.3.1
+PKG_VERSION:=1.3.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://storage.googleapis.com/downloads.webmproject.org/releases/webp
-PKG_HASH:=b3779627c2dfd31e3d8c4485962c2efe17785ef975e2be5c8c0c9e6cd3c4ef66
+PKG_HASH:=2a499607df669e40258e53d0ade8035ba4ec0175244869d1025d460562aa09b4
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/ff95f859ebf710d2914472a3feeeb0d187d14459
Run tested:x86 https://github.com/openwrt/openwrt/commit/ff95f859ebf710d2914472a3feeeb0d187d14459

-----------------------------------------------------------_


From https://github.com/webmproject/libwebp/releases/tag/v1.3.2

- 9/13/2023: version 1.3.2 This is a binary compatible release.
  * security fix for lossless decoder (chromium: #1479274, CVE-2023-4863)