### PR TITLE
bind: bump to 9.18.19

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.18.18
+PKG_VERSION:=9.18.19
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=d735cdc127a6c5709bde475b5bf16fa2133f36fdba202f7c3c37d134e5192160
+PKG_HASH:=115e09c05439bebade1d272eda08fa88eb3b60129edef690588c87a4d27612cc
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
CVE fixes:

CVE-2023-3341 - Previously, sending a specially crafted message over the control channel could cause the packet-parsing code to run out of available stack memory, causing named to terminate unexpectedly.

CVE-2023-4236 - A flaw in the networking code handling DNS-over-TLS queries could cause named to terminate unexpectedly due to an assertion failure under significant DNS-over-TLS query load.

Maintainer: me
Compile tested: mvebu
Run tested: mvebu, openwrt 22.03. DNS secondary/slave service, DNSSEC, recursive validation, etc.

Description:

See https://ftp.isc.org/isc/bind9/cur/9.18/doc/arm/html/notes.html for the complete upstream changelog.