### PR TITLE
prometheus-node-exporter-lua: drop bmx6 package

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -59,17 +59,6 @@ endef
 
 # Additional optional exporters:
 
-define Package/prometheus-node-exporter-lua-bmx6
-  $(call Package/prometheus-node-exporter-lua/Default)
-  TITLE+= (bmx6 links collector)
-  DEPENDS:=prometheus-node-exporter-lua bmx6 +lua-cjson +bmx6-json
-endef
-
-define Package/prometheus-node-exporter-lua-bmx6/install
-	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/bmx6.lua $(1)/usr/lib/lua/prometheus-collectors/
-endef
-
 define Package/prometheus-node-exporter-lua-bmx7
   $(call Package/prometheus-node-exporter-lua/Default)
   TITLE+= (bmx7 links collector)
@@ -236,7 +225,6 @@ define Package/prometheus-node-exporter-lua-realtek-poe/install
 endef
 
 $(eval $(call BuildPackage,prometheus-node-exporter-lua))
-$(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx6))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx7))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-dawn))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-hostapd_stations))


### PR DESCRIPTION
Maintainer: @champtar 
Compile and run tested: NO

Description:

In the OpenWrt routing feed, package bmx6 and luci-app-bmx6 were removed because the LuCI app was vulnerable to several CVEs, as found by dependabot. It has been reporting it for a few months and has even created an issue. These two packages are not maintained in OpenWrt as well in upstream.

Users should switch to the bmx7 package.

Fixes: 9fb9d9343ea27d6dbb5008ece10c0c843dd2c781 ("bmx6: drop package") in the routing feed

See: https://github.com/openwrt/routing/pull/1021