### PR TITLE
Reaver: Patch channel changing to nl80211 from wireless-extensions

### DIFF
--- a/net/reaver/Makefile
+++ b/net/reaver/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=reaver
 PKG_VERSION:=1.6.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -30,6 +30,8 @@ CONFIGURE_PATH:=src
 MAKE_PATH:=src
 
 CONFIGURE_ARGS += --enable-savetocurrent
+TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include/libnl-tiny
+TARGET_LDFLAGS += -lnl-tiny
 
 define Package/reaver
   SECTION:=net
@@ -37,7 +39,7 @@ define Package/reaver
   SUBMENU:=Wireless
   TITLE:=Efficient brute force attack against Wifi Protected Setup
   URL:=https://github.com/t6x/reaver-wps-fork-t6x
-  DEPENDS:=+libpcap
+  DEPENDS:=+libpcap +libnl-tiny
 endef
 
 define Package/reaver/description

--- a/net/reaver/patches/100-nl80211-channel-switching.patch
+++ b/net/reaver/patches/100-nl80211-channel-switching.patch
@@ -1,0 +1,72 @@
+--- a/src/iface.c
++++ b/src/iface.c
+@@ -34,6 +34,10 @@
+ #include "iface.h"
+ #include "lwe/iwlib.h"
+ #include "globule.h"
++#include <libnl-tiny/netlink/netlink.h>
++#include <libnl-tiny/netlink/genl/genl.h>
++#include <libnl-tiny/netlink/genl/ctrl.h>
++#include <linux/nl80211.h>
+ #include <net/if.h>
+ #include <netinet/in.h>
+ #include <sys/ioctl.h>
+@@ -159,6 +163,16 @@ int change_channel(int channel)
+ 	return 0;
+ }
+ #else
++// taken from aircrack-ng source code
++static int ieee80211_channel_to_frequency(int chan)
++{
++	if (chan < 14) return 2407 + chan * 5;
++
++	if (chan == 14) return 2484;
++
++	/* FIXME: dot11ChannelStartingFactor (802.11-2007 17.3.8.3.2) */
++	return (chan + 1000) * 5;
++}
+ int change_channel(int channel)
+ {
+         int skfd = 0, ret_val = 0;
+@@ -180,14 +194,33 @@ int change_channel(int channel)
+                 wrq.u.freq.flags = IW_FREQ_FIXED;
+ 
+         	cprintf(VERBOSE, "[+] Switching %s to channel %d\n", get_iface(), channel);
+-
+-                /* Set frequency */
+-                if(iw_set_ext(skfd, get_iface(), SIOCSIWFREQ, &wrq) >= 0)
+-                {
+-			set_channel(channel);
+-                        ret_val = 1;
+-                }
+-
++            /** patch to use nl80211 **/
++            struct nl_sock* sk = nl_socket_alloc();
++            genl_connect(sk);
++
++            struct nl_msg *mesg = nlmsg_alloc();
++            enum nl80211_commands command = NL80211_CMD_SET_WIPHY;
++            genlmsg_put(mesg, 0, 0, genl_ctrl_resolve(sk, "nl80211"), 0, 0, command, 0);
++
++            int idx = if_nametoindex(get_iface());
++            int ret = 0;
++            if (idx > 0) {
++                struct nl_cb *cb = nl_cb_alloc(NL_CB_DEFAULT);
++                NLA_PUT_U32(mesg, NL80211_ATTR_IFINDEX, idx);
++                NLA_PUT_U32(mesg, NL80211_ATTR_WIPHY_FREQ, ieee80211_channel_to_frequency(channel));
++                NLA_PUT_U32(mesg, NL80211_ATTR_CHANNEL_WIDTH, NL80211_CHAN_WIDTH_20);
++                ret = nl_send_auto_complete(sk, mesg);
++                nl_recvmsgs(sk, cb);
++                nl_cb_put(cb);
++                nlmsg_free(mesg);
++                nl_socket_free(sk);
++                set_channel(channel);
++                return 1;
++            nla_put_failure:
++                nlmsg_free(mesg);
++                return 0;
++            }
++            /** end patch to use nl80211 **/
+                 iw_sockets_close(skfd);
+         }
+ 


### PR DESCRIPTION
Maintainer:  @yousong

Compile tested / Run tested:
```
DISTRIB_ID='OpenWrt'
DISTRIB_RELEASE='23.05.0-rc3'
DISTRIB_REVISION='r23389-5deed175a5'
DISTRIB_TARGET='ramips/mt7621'
DISTRIB_ARCH='mipsel_24kc'
DISTRIB_DESCRIPTION='OpenWrt 23.05.0-rc3 r23389-5deed175a5'
DISTRIB_TAINTS='no-all'
```

Description:
Reaver still uses an embedded version of `libiw`, which relies on wireless-extensions which no longer works on `23.05.0` for channel changing
Upstream code resolved their issue in 2020 for this without fixing, hence this patch. 

upstream ref: https://github.com/t6x/reaver-wps-fork-t6x/issues/324

This patch makes reaver and wash channel changing work again on 5GHz and 2GHz.

---
Reaver 5GHz:
```
reaver -i wlan1 -b 00:11:22:33:44:55 -vv -5

Reaver v1.6.6 WiFi Protected Setup Attack Tool
Copyright (c) 2011, Tactical Network Solutions, Craig Heffner <cheffner@tacnetsol.com>

[+] Waiting for beacon from 00:11:22:33:44:55
[+] Switching wlan1 to channel 34
[+] Switching wlan1 to channel 36
[+] Switching wlan1 to channel 38
[+] Switching wlan1 to channel 40
[+] Received beacon from 00:11:22:33:44:55
[+] Vendor: Broadcom
[+] Trying pin "12345670"
[+] Sending authentication request
[+] Sending association request
[+] Associated with 00:11:22:33:44:55 (ESSID: OpenWRT)
^C
[+] Nothing done, nothing to save.
```

Wash 5GHz
```
wash -i wlan1 -5
BSSID               Ch  dBm  WPS  Lck  Vendor    ESSID
--------------------------------------------------------------------------------
00:AA:AA:AA:AA:AA   40  -56  2.0  Yes  Unknown   OpenWRT
00:BB:BB:BB:BB:BB   40  -87  2.0  Yes  AtherosC  Example
00:CC:CC:CC:CC:CC   40  -83  2.0  Yes  AtherosC  Example2
```