### PR TITLE
crun: update to 1.9.2

### DIFF
--- a/utils/crun/Makefile
+++ b/utils/crun/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crun
-PKG_VERSION:=1.9
+PKG_VERSION:=1.9.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containers/crun/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=dfe15045953f6876fde273518ac2cafbabda7c0eebd3dcdba34c4e5dc8b46661
+PKG_HASH:=a5ed2984a9ebb3e0e5cba0781832f03931423097a56f48a948ab034b46726aef
 
 PKG_BUILD_DEPENDS:=argp-standalone
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
changelog 1.9.2:
 - cgroup: reset the inherited cpu affinity after moving to cgroup. Old kernels do that automatically, but new kernels remember the affinity that was set before the cgroup move, so we need to reset it in order to honor the cpuset configuration.

changelog 1.9.1:
 - utils: ignore ENOTSUP when chmod a symlink. It fixes a problem on Linux 6.6 that always refuses chmod on a symlink.
 - build: fix build on CentOS 7
 - linux: add new fallback when mount fails with EBUSY, so that there is not an additional tmpfs mount if not needed.
 - utils: improve error message when a directory cannot be created as a component of the path is already existing as a non directory.

Maintainer: me
Compile tested: x86_64, latest git