### PR TITLE
netavark: update to 1.8.0

### DIFF
--- a/net/netavark/Makefile
+++ b/net/netavark/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netavark
-PKG_VERSION:=1.7.0
+PKG_VERSION:=1.8.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containers/netavark/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=b0ed7d80fd96ef2af88e7a001d91024919125e5842d9772de94648044630e116
+PKG_HASH:=b1422ef6927458e9f80f7d322b751e29ab5d04d8ed6cb065baa82fa4291af10f
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
changelog:
 - iptables: improve error when ip6?tables commands are missing
 - docs: Convert markdown with go-md2man instead of mandown
 - iptables: drop invalid packages
 - bump rust edition to 2021
 - Add ACCEPT rules in firewall for bridge network with internal dns
 - Add vrf support for bridges

Maintainer: me 
Compile tested: x86_64, latest git