### PR TITLE
[23.05] libwebp: bump to version 1.3.2

### DIFF
--- a/libs/libwebp/Makefile
+++ b/libs/libwebp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libwebp
-PKG_VERSION:=1.3.0
+PKG_VERSION:=1.3.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://storage.googleapis.com/downloads.webmproject.org/releases/webp
-PKG_HASH:=64ac4614db292ae8c5aa26de0295bf1623dbb3985054cb656c55e67431def17c
+PKG_HASH:=2a499607df669e40258e53d0ade8035ba4ec0175244869d1025d460562aa09b4
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/libs/libwebp/patches/010-mips16.patch
+++ b/libs/libwebp/patches/010-mips16.patch
@@ -1,8 +1,8 @@
 --- a/src/dsp/cpu.h
 +++ b/src/dsp/cpu.h
-@@ -108,7 +108,7 @@
- #define WEBP_HAVE_NEON
- #endif
+@@ -124,7 +124,7 @@
+ //------------------------------------------------------------------------------
+ // MIPS defines.
  
 -#if defined(__mips__) && !defined(__mips64) && defined(__mips_isa_rev) && \
 +#if defined(__mips__) && !defined(__mips16) && !defined(__mips64) && defined(__mips_isa_rev) && \


### PR DESCRIPTION
Maintainer: me
Compile tested: n/a
Run tested: n/a


From https://github.com/webmproject/libwebp/releases/tag/v1.3.2

- 9/13/2023: version 1.3.2 This is a binary compatible release.
  * security fix for lossless decoder (chromium: #1479274, CVE-2023-4863)

Signed-off-by: Alexandru Ardelean <alex@shruggie.ro>
(cherry picked from commit 90c6cb239002b1581b249ed19c3d7475fa78e5f1)