### PR TITLE
crowdsec-firewall-bouncer: new upstream release version 0.0.28

### DIFF
--- a/net/crowdsec-firewall-bouncer/Makefile
+++ b/net/crowdsec-firewall-bouncer/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crowdsec-firewall-bouncer
-PKG_VERSION:=0.0.27
+PKG_VERSION:=0.0.28
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/crowdsecurity/cs-firewall-bouncer/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2516e700c88e46e6aa58100ff6f343257cc1befdb555d6ab9e124f217ec46ca0
+PKG_HASH:=1e0f4d3cd8bc73da21eafc9b965fda0c1c1b0a27a2acc038004602797e4fccf0
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Update crowdsec-firewall-bouncer to latest upstream release version 0.0.28

Signed-off-by: S. Brusch <ne20002@gmx.ch>

Maintainer: Kerma Gérald <gandalf@gk2.net>
Run tested: mediatek/filogic, BPI-R3, Openwrt 23.05.0-rc3
