### PR TITLE
vim: add empty defaults.vim

### DIFF
--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vim
 PKG_VERSION:=9.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 VIMVER:=90
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -207,6 +207,8 @@ define Package/vim/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/vim_tiny $(1)/usr/bin/vim
 	$(INSTALL_DIR) $(1)/usr/share/vim
 	$(INSTALL_CONF) ./files/vimrc $(1)/usr/share/vim/
+	mkdir -p $(1)/usr/share/vim/vim$(VIMVER)
+	touch $(1)/usr/share/vim/vim$(VIMVER)/defaults.vim
 endef
 
 define Package/vim-full/install
@@ -215,6 +217,8 @@ define Package/vim-full/install
 	$(INSTALL_DIR) $(1)/usr/share/vim
 	$(LN) vim $(1)/usr/bin/vimdiff
 	$(INSTALL_CONF) ./files/vimrc.full $(1)/usr/share/vim/vimrc
+	mkdir -p $(1)/usr/share/vim/vim$(VIMVER)
+	touch $(1)/usr/share/vim/vim$(VIMVER)/defaults.vim
 endef
 
 


### PR DESCRIPTION
**Description**:
When installing, `touch /usr/share/vim/vim90/defaults.vim` to eliminate the error message
```
E1187: Failed to source defaults.vim
```
that appears every run. The problem exists for `vim` and `vim-full`, but not for `vim-fuller`.

The fix was suggested here (last comment). https://bugs.launchpad.net/ubuntu/+source/vim/+bug/1968912
See also https://bugs.debian.org/1004118.

**Maintainer**: @ratkaj
**Compile and run tested**: bcm53xx/generic Linksys EA9200 snapshot (cafa8804a4c5fd)
