### PR TITLE
samba4: update smb.conf.template to disable guest logons by default

### DIFF
--- a/net/samba4/files/smb.conf.template
+++ b/net/samba4/files/smb.conf.template
@@ -19,7 +19,7 @@
 
 	## This parameter controls whether a remote client is allowed or required to use SMB encryption.
 	## It has different effects depending on whether the connection uses SMB1 or SMB2 and newer:
-    ## If the connection uses SMB1, then this option controls the use of a Samba-specific extension to the SMB protocol introduced in Samba 3.2 that makes use of the Unix extensions.
+	## If the connection uses SMB1, then this option controls the use of a Samba-specific extension to the SMB protocol introduced in Samba 3.2 that makes use of the Unix extensions.
 	## If the connection uses SMB2 or newer, then this option controls the use of the SMB-level encryption that is supported in SMB version 3.0 and above and available in Windows 8 and newer. 
 	## (default/auto,desired,required,off)
 	#smb encrypt = default
@@ -28,7 +28,7 @@
 	invalid users = root
 
 	## map unknow users to guest
-	map to guest = Bad User
+	map to guest = Never
 
 	## allow client access to accounts that have null passwords. 
 	null passwords = yes


### PR DESCRIPTION
Maintainer: @Gingernut1978
Compile tested: not tested
Run tested: ARM, Netgear R7800, OpenWrt 23.05.0-rc4

Description:
Insecure guest logons are on UpToDate Windows 10 1709 and later disabled by default. The option `map to guest` should be set to Samba default value = `Never`, because only then the Windows will ask to enter the password when accesing the share (when there are no valid user logged-in in Windows). If is the option `map to guest` is set to `Bad User` then Windows Client will not connect (when the user, which is logged-in in Windows is not also configured on OpenWrt) and fail with message, that insecure logons are disabled.

https://learn.microsoft.com/en-us/troubleshoot/windows-server/networking/guest-access-in-smb2-is-disabled-by-default

Typo also corrected.