### PR TITLE
ffmpeg: fix compilation error of ffmpeg-custom

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=5.1.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
@@ -534,6 +534,12 @@ ifeq ($(BUILD_VARIANT),custom)
 	--disable-swresample
   endif
 
+  ifneq ($(CONFIG_PACKAGE_ffmpeg-custom),n)
+      FFMPEG_CONFIGURE+= \
+	--enable-avfilter \
+	--enable-ffmpeg
+  endif
+
   FFMPEG_CONFIGURE+= \
 	--disable-swscale \
 	--disable-everything \
@@ -649,6 +655,11 @@ define Build/InstallDev/custom
 ifeq ($(CONFIG_FFMPEG_CUSTOM_PROGRAMS),y)
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avfilter,swresample}.{a,so*} $(1)/usr/lib/
 endif
+ifeq ($(BUILD_VARIANT),custom)
+  ifneq ($(CONFIG_PACKAGE_ffmpeg-custom),n)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libavfilter.{a,so*} $(1)/usr/lib/
+  endif
+endif
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/lib{avcodec,avdevice,avformat,avutil}.pc $(1)/usr/lib/pkgconfig/
 ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libx264),y)
@@ -730,6 +741,11 @@ ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libx264),y)
 endif
 ifeq ($(CONFIG_FFMPEG_CUSTOM_PROGRAMS),y)
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avfilter,swresample}.so.* $(1)/usr/lib/
+endif
+ifeq ($(BUILD_VARIANT),custom)
+  ifneq ($(CONFIG_PACKAGE_ffmpeg-custom),n)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libavfilter.so.* $(1)/usr/lib/
+  endif
 endif
 endef
 


### PR DESCRIPTION
Fixes: #12320

Maintainer: @graysky2
Compile tested: default arch, v22.03.5
Run tested: openwrt-22.03.5-ramips-mt7621-zbtlink_zbt-wg3526-32m
Description:

After plain enable of libffmpeg-custom and ffmpeg-custom which adds:
- CONFIG_PACKAGE_libbz2=m
- CONFIG_PACKAGE_libffmpeg-custom=m
- CONFIG_FFMPEG_CUSTOM_GPL=y
- CONFIG_PACKAGE_zlib=m
- CONFIG_PACKAGE_ffmpeg-custom=m

I get on v22.03.5 compilation error:
```
cp -fpR /.../openwrt-git/build_dir/target-mips_24kc_musl/ffmpeg-custom/ffmpeg-5.1/ipkg-install/usr/bin/ffmpeg /.../openwrt-git/build_dir/target-mips_24kc_musl/ffmpeg-custom/ffmpeg-5.1/ipkg-mips_24kc/ffmpeg-custom/usr/bin/
cp: cannot stat '/.../openwrt-git/build_dir/target-mips_24kc_musl/ffmpeg-custom/ffmpeg-5.1/ipkg-install/usr/bin/ffmpeg': No such file or directory
make[2]: *** [Makefile:756: /.../openwrt-git/bin/packages/mips_24kc/packages/ffmpeg-custom_5.1-1_mips_24kc.ipk] Error 1
```

It is because configure is missing `ffmpeg` in its `Programs:` section:
```
( cd /.../openwrt-git/build_dir/target-mips_24kc_musl/ffmpeg-custom/ffmpeg-5.1; CFLAGS="-Os -pipe -mno-branch-likely -mips32r2 -mtune=24kc -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -msoft-float -mips16 -minterlink-mips16 -fmacro-prefix-map=/.../openwrt-git/build_dir/target-mips_24kc_musl/ffmpeg-custom/ffmpeg-5.1=ffmpeg-5.1 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -I/.../openwrt-git/staging_dir/toolchain-mips_24kc_gcc-11.2.0_musl/usr/include -I/.../openwrt-git/staging_dir/toolchain-mips_24kc_gcc-11.2.0_musl/include/fortify -I/.../openwrt-git/staging_dir/toolchain-mips_24kc_gcc-11.2.0_musl/include -DPIC -fpic" LDFLAGS="-L/.../openwrt-git/staging_dir/toolchain-mips_24kc_gcc-11.2.0_musl/usr/lib -L/.../openwrt-git/staging_dir/toolchain-mips_24kc_gcc-11.2.0_musl/lib -znow -zrelro" ./configure --enable-cross-compile --cross-prefix="mips-openwrt-linux-musl-" --arch="mips" --cpu=24kc --target-os=linux --prefix="/usr" --pkg-config="pkg-config" --enable-shared --enable-static --enable-pthreads --enable-zlib --disable-doc --disable-debug --disable-lzma --disable-vaapi --disable-vdpau --disable-outdevs --disable-altivec --disable-vsx --disable-power8 --disable-armv5te --disable-armv6 --disable-armv6t2 --disable-fast-unaligned --disable-runtime-cpudetect --disable-x86asm --enable-small --enable-gpl --disable-programs --disable-avfilter --disable-swresample --disable-swscale --disable-everything                                                                                                                                                                                                                                                                                      --disable-postproc )
install prefix            /usr
source path               .
C compiler                mips-openwrt-linux-musl-gcc
C library
host C compiler           gcc
host C library            glibc
ARCH                      mips (24kc)
big-endian                yes
runtime cpu detection     no
MIPS FPU enabled          no
MIPS DSP R1 enabled       no
MIPS DSP R2 enabled       no
MIPS MSA enabled          no
LOONGSON MMI enabled      no
debug symbols             no
strip symbols             yes
optimize for size         yes
optimizations             yes
static                    yes
shared                    yes
postprocessing support    no
network support           yes
threading support         pthreads
safe bitstream reader     yes
texi2html enabled         no
perl enabled              yes
pod2man enabled           yes
makeinfo enabled          yes
makeinfo supports HTML    no
xmllint enabled           yes

External libraries:
alsa                    iconv
bzlib                   zlib

External libraries providing hardware acceleration:
cuda_llvm               v4l2_m2m

Libraries:
avcodec                 avformat
avdevice                avutil

Programs:

Enabled decoders:

Enabled encoders:

Enabled hwaccels:

Enabled parsers:

Enabled demuxers:

Enabled muxers:

Enabled protocols:

Enabled filters:

Enabled bsfs:

Enabled indevs:

Enabled outdevs:

License: GPL version 2 or later
```
