### PR TITLE
ffmpeg: Add avi muxer

### DIFF
--- a/multimedia/ffmpeg/Config.in
+++ b/multimedia/ffmpeg/Config.in
@@ -303,6 +303,9 @@ comment "Muxers"
 config FFMPEG_CUSTOM_MUXER_ac3
 	bool "AC3"
 
+config FFMPEG_CUSTOM_MUXER_avi
+	bool "AVI"
+
 config FFMPEG_CUSTOM_MUXER_h264
 	bool "H.264 Raw Video"
 	depends on FFMPEG_CUSTOM_PATENTED

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -69,6 +69,7 @@ FFMPEG_CUSTOM_DECODERS:= \
 
 FFMPEG_CUSTOM_MUXERS:= \
 	ac3 \
+	avi \
 	ffm \
 	h264 \
 	hevc \

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=5.1.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/


### PR DESCRIPTION
Otherwise one cannot produce *.avi containers needed for some H.264 camera codecs.

Maintainer: @graysky2 
Compile tested: default arch, v22.03.5
Run tested: openwrt-22.03.5-ramips-mt7621-zbtlink_zbt-wg3526-32m

Description:
I did not copy-paste the message but it will complain `-f avi` cannot produce AVI.