### PR TITLE
travelmate: Default VPN settings for auto-added STAs

### DIFF
--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -580,6 +580,13 @@ f_addsta() {
 			set travelmate."${uci_cfg}".con_end_expiry="0"
 			set travelmate."${uci_cfg}".enabled="1"
 		EOC
+  		if [ -n "${trm_default_vpnservice}" ] && [ -n "${trm_default_vpniface}" ]; then
+			uci -q batch <<-EOC
+				set travelmate."${uci_cfg}".vpnservice="${trm_default_vpnservice}"
+				set travelmate."${uci_cfg}".vpniface="${trm_default_vpniface}" 
+				set travelmate."${uci_cfg}".vpn="1"
+			EOC
+		fi
 		if [ -n "$(uci -q changes "travelmate")" ] || [ -n "$(uci -q changes "wireless")" ]; then
 			trm_opensta="$((trm_opensta + 1))"
 			uci_commit "travelmate"


### PR DESCRIPTION
Maintainer: @dibdot 
Compile tested: mips_24kc, ath79/generic, 22.03.5
Run tested: mips_24kc, ath79/generic, 22.03.5
- removed STA so that it would be auto-added again and confirm VPN connection came up without further configuration
- verified that newly added uplink had `vpn*` variables in the configuration

Description:
Add two new global configuration variables, trm_default_vpniface and trm_default_vpnservice to configure a VPNconnection on newly auto-added STAs.

Fixes: #22227