### PR TITLE
[openwrt-23.05] python-cffi: Update to 1.16.0

### DIFF
--- a/lang/python/python-cffi/Makefile
+++ b/lang/python/python-cffi/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cffi
-PKG_VERSION:=1.15.1
+PKG_VERSION:=1.16.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=cffi
-PKG_HASH:=d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9
+PKG_HASH:=bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -40,6 +40,7 @@ define Package/python3-cffi
   DEPENDS:= \
       +libffi \
       +python3-light \
+      +python3-ctypes \
       +python3-pycparser
 endef
 

--- a/lang/python/python-cffi/patches/001-unpin-setuptools.patch
+++ b/lang/python/python-cffi/patches/001-unpin-setuptools.patch
@@ -1,0 +1,10 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -2,6 +2,6 @@
+ requires = [
+     # first version that supports Python 3.12; older versions may work
+     # with previous Python versions, but are not tested
+-    "setuptools >= 66.1"
++    "setuptools"
+ ]
+ build-backend = "setuptools.build_meta"

--- a/lang/python/python-cffi/test.sh
+++ b/lang/python/python-cffi/test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+[ "$1" = python3-cffi ] || exit 0
+
+python3 - << EOF
+from cffi import FFI
+ffibuilder = FFI()
+EOF


### PR DESCRIPTION
Maintainer: me
Compile tested: none (cherry picked from #22283)
Run tested: none

Description:
This includes a patch to unpin the version of setuptools required for build; the required version is newer than the version bundled with Python 3.11. This patch should not be necessary when Python 3.12 is available.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit dd5af62695e2c0fcf421adfffbea92f37d1a652d)