### PR TITLE
keepalived: update to version 2.2.8

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
-PKG_VERSION:=2.2.7
-PKG_RELEASE:=10
+PKG_VERSION:=2.2.8
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software
-PKG_HASH:=c61940d874154a560a54627ecf7ef47adebdf832164368d10bf242a4d9b7d49d
+PKG_HASH:=85882eb62974f395d4c631be990a41a839594a7e62fbfebcb5649a937a7a1bb6
 
 PKG_CPE_ID:=cpe:/a:keepalived:keepalived
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.2.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software

--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.2.8
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software

--- a/net/keepalived/files/keepalived.init
+++ b/net/keepalived/files/keepalived.init
@@ -88,8 +88,11 @@ print_notify() {
 	shift
 	local name="$1"
 	shift
+	local indent="$1"
+	shift
+
 	for notify in "$@"; do
-		printf '%b%s' "${INDENT_1}" "$notify">> "$KEEPALIVED_CONF"
+		printf '%b%s' "${indent}" "$notify">> "$KEEPALIVED_CONF"
 		notify="$(echo "$notify" | tr 'a-z' 'A-Z')"
 		printf ' "/bin/busybox env -i ACTION=%s TYPE=%s NAME=%s /sbin/hotplug-call keepalived"\n' "$notify" "$type" "$name" >> "$KEEPALIVED_CONF"
 	done
@@ -320,7 +323,7 @@ vrrp_sync_group() {
 
 	print_elems_indent "$1" "$INDENT_1" no_val_smtp_alert no_val_global_tracking
 
-	print_notify "GROUP" "$name" notify_backup notify_master \
+	print_notify "GROUP" "$name" "$INDENT_1" notify_backup notify_master \
 		notify_fault notify
 
 	config_section_close
@@ -352,7 +355,7 @@ vrrp_instance() {
 		no_val_dont_track_primary no_val_smtp_alert no_val_nopreempt \
 		no_val_use_vmac
 
-	print_notify "INSTANCE" "$name" notify_backup notify_master \
+	print_notify "INSTANCE" "$name" "$INDENT_1" notify_backup notify_master \
 		notify_fault notify_stop
 
 	# Handle virtual_ipaddress & virtual_ipaddress_excluded lists
@@ -501,6 +504,7 @@ real_server() {
 	[ -n "$ipaddr" ] && [ -n "$port" ] && {
 		printf '%breal_server %s %d {\n' "${INDENT_1}" "$ipaddr" "$port" >> "$KEEPALIVED_CONF"
 		printf '%bweight %d\n' "${INDENT_2}" "$weight" >> "$KEEPALIVED_CONF"
+		print_notify "REAL_SERVER" "$name" "$INDENT_2" notify_up notify_down
 		case "$check" in
 			PING_CHECK)
 				printf '%b%s {\n' "${INDENT_2}" "$check" >> "$KEEPALIVED_CONF"

--- a/net/keepalived/files/keepalived.init
+++ b/net/keepalived/files/keepalived.init
@@ -502,6 +502,10 @@ real_server() {
 		printf '%breal_server %s %d {\n' "${INDENT_1}" "$ipaddr" "$port" >> "$KEEPALIVED_CONF"
 		printf '%bweight %d\n' "${INDENT_2}" "$weight" >> "$KEEPALIVED_CONF"
 		case "$check" in
+			PING_CHECK)
+				printf '%b%s {\n' "${INDENT_2}" "$check" >> "$KEEPALIVED_CONF"
+				printf '%b}\n' "${INDENT_2}" >> "$KEEPALIVED_CONF"
+				;;
 			TCP_CHECK)
 				printf '%b%s {\n' "${INDENT_2}" "$check" >> "$KEEPALIVED_CONF"
 				print_elems_indent "$1" "$INDENT_3" connect_timeout \


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, APU3, master
Run tested: x86_64, APU3, only `keepalived --version`
Description:

- Update to version 2.2.8 See release-notes https://www.keepalived.org/release-notes/Release-2.2.8.html
- Add PING_CHECK config via uci for real server
- Add notify_up and notify_down handling for virtual server

```
root@G3-10940 ~ # keepalived --version
Keepalived v2.2.8 (04/04,2023), git commit v2.2.7-154-g292b299e+

Copyright(C) 2001-2023 Alexandre Cassen, <acassen@gmail.com>

Built with kernel headers for Linux 5.15.132
Running on Linux 5.15.132 #0 SMP Mon Sep 25 13:22:59 2023
Distro: APOS master-Poochie-16-ga5d38f732

configure options: --target=x86_64-openwrt-linux --host=x86_64-openwrt-linux --build=x86_64-pc-linux-gnu --disable-dependency-tracking --program-prefix= --program-suffix= --prefix=/usr --exec-prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --libexecdir=/usr/lib --sysconfdir=/etc --datadir=/usr/share --localstatedir=/var --mandir=/usr/man --infodir=/usr/info --disable-nls --enable-json --with-init=SYSV --disable-track-process --runstatedir=/var/run --enable-sha1 --disable-libipset-dynamic build_alias=x86_64-pc-linux-gnu host_alias=x86_64-openwrt-linux target_alias=x86_64-openwrt-linux PKG_CONFIG=/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/host/bin/pkg-config PKG_CONFIG_PATH=/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/target-x86_64_musl/usr/lib/pkgconfig:/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/target-x86_64_musl/usr/share/pkgconfig PKG_CONFIG_LIBDIR=/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/target-x86_64_musl/usr/lib/pkgconfig:/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/target-x86_64_musl/usr/share/pkgconfig CC=x86_64-openwrt-linux-musl-gcc CFLAGS=-Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -ffile-prefix-map=/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/build_dir/target-x86_64_musl/keepalived-2.2.8=keepalived-2.2.8 -Wformat -Werror=format-security -DPIC -fpic -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -I/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/build_dir/target-x86_64_musl/linux-x86_64/linux-5.15.132  LDFLAGS=-L/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/usr/lib -L/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/lib -fuse-ld=bfd -DPIC -fpic -specs=/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/include/hardened-ld-pie.specs -znow -zrelro  CPPFLAGS=-I/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/usr/include -I/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/include/fortify -I/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/include

Config options:  LIBIPSET NFTABLES LVS VRRP VRRP_AUTH VRRP_VMAC JSON DISABLE_TRACK_PROCESS OLD_CHKSUM_COMPAT INIT=SYSV

System options:  VSYSLOG MEMFD_CREATE IPV6_MULTICAST_ALL LIBKMOD IPV4_DEVCONF LIBNL3 RTA_ENCAP RTA_EXPIRES RTA_NEWDST RTA_PREF FRA_SUPPRESS_PREFIXLEN FRA_SUPPRESS_IFGROUP FRA_TUN_ID RTAX_CC_ALGO RTAX_QUICKACK RTEXT_FILTER_SKIP_STATS FRA_L3MDEV FRA_UID_RANGE RTAX_FASTOPEN_NO_COOKIE RTA_VIA FRA_PROTOCOL FRA_IP_PROTO FRA_SPORT_RANGE FRA_DPORT_RANGE RTA_TTL_PROPAGATE IFA_FLAGS LWTUNNEL_ENCAP_MPLS LWTUNNEL_ENCAP_ILA IPTABLES NET_LINUX_IF_H_COLLISION NETINET_LINUX_IF_ETHER_H_COLLISION LIBIPVS_NETLINK IPVS_DEST_ATTR_ADDR_FAMILY IPVS_SYNCD_ATTRIBUTES IPVS_64BIT_STATS IPVS_TUN_TYPE IPVS_TUN_CSUM IPVS_TUN_GRE VRRP_IPVLAN IFLA_LINK_NETNSID INET6_ADDR_GEN_MODE VRF SO_MARK

```