### PR TITLE
[21.02] Knot DNS: update to version 3.2.10

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.2.6
+PKG_VERSION:=3.2.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=ac124fb17dbc4ac5310a30a396245a6ba304b3c89abed0f8a47d727462c8da4d
+PKG_HASH:=c2e3e267ace2d9d23d92fd64445d4735d974c698f5716ae505dc0867e56834f8
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8


### PR DESCRIPTION
Maintainer: @salzmdan @Payne-X6
Compiled on: MacBook A1990, Sonoma 14.0
Run tested: Turris 1.1, powerpc_8540, Turris OS 6.4.1 (based on OpenWrt 21.02)

Release notes:
https://www.knot-dns.cz/2023-09-10-version-3210.html
https://www.knot-dns.cz/2023-07-27-version-329.html
https://www.knot-dns.cz/2023-06-26-version-328.html
https://www.knot-dns.cz/2023-06-06-version-327.html

