### PR TITLE
python3: avoid unnecessary rebuilds

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -358,12 +358,6 @@ endef
 
 $(eval $(call HostBuild))
 
-$(foreach package, $(PYTHON3_PACKAGES),  \
-	$(eval $(call Py3Package,$(package))) \
-	$(eval $(call BuildPackage,$(package))) \
-	$(eval $(call BuildPackage,$(package)-src)) \
-)
-
 $(eval $(call BuildPackage,libpython3))
 $(eval $(call BuildPackage,python3))
 
@@ -375,3 +369,9 @@ $(eval $(call BuildPackage,python3-light))
 
 $(eval $(call BuildPackage,python3-base-src))
 $(eval $(call BuildPackage,python3-light-src))
+
+$(foreach package, $(PYTHON3_PACKAGES),  \
+	$(eval $(call Py3Package,$(package))) \
+	$(eval $(call BuildPackage,$(package))) \
+	$(eval $(call BuildPackage,$(package)-src)) \
+)


### PR DESCRIPTION
Maintainer: @jefferyto 
Compile tested: aarch64-cortex-a53
Run tested: N/A

Description:
Move the order in which BuildPackage is called, so that the libpython package is built ahead of the module packages, to avoid forcing a clean-build of the package when 'make package/python3/compile' is called a second time without changes.

The library must be built first, so that when the buildsystem checks for ABI version changes using libpython3.version, its timestamp should be older than the dependent package's STAMP_PREPARED file.

---

This can be debugged using the `check-compile.txt` log file.  Before this change, a second run will have something like:
```
 Considering target file 'bin/packages/aarch64_cortex-a53/packages/python3-asyncio_3.11.5-1_aarch64_cortex-a53.ipk'.
[...]
     Prerequisite 'staging_dir/target-aarch64_cortex-a53_musl/pkginfo/libpython3.version' is newer than target 'build_dir/target-aarch64_cortex-a53_musl/Python-3.11.5/.prepared_1703433c2b3604f017f04dd775678679_18f1e190c5d53547fed41a3eaa76e9e9'.
[...] repeat many times
    Must remake target 'build_dir/target-aarch64_cortex-a53_musl/Python-3.11.5/.prepared_1703433c2b3604f017f04dd775678679_18f1e190c5d53547fed41a3eaa76e9e9'.
```