### PR TITLE
[23.05] adblock-fast: bugfix: properly identify hosts-files

### DIFF
--- a/net/adblock-fast/Makefile
+++ b/net/adblock-fast/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/adblock-fast/files/etc/init.d/adblock-fast
+++ b/net/adblock-fast/files/etc/init.d/adblock-fast
@@ -282,7 +282,7 @@ append_url() {
  		echo 'dnsmasq2'
  	elif grep -q '^address=' "$file"; then
  		echo 'dnsmasq3'
- 	elif grep -q '^0.0.0.0' "$file" || grep -q '^127.0.0.1' "$file"; then
+ 	elif grep -q '^0\.0\.0\.0' "$file" || grep -q '^127\.0\.0\.1' "$file"; then
  		echo 'hosts'
  	elif [ -n "$(sed "$domainsFilter" "$file" | head -1)" ]; then
  		echo 'domains'
@@ -1536,6 +1536,7 @@ adb_start() {
 	json_close_array
 	procd_close_data
 	procd_close_instance
+	return 0
 }
 
 adb_status() {
@@ -1568,12 +1569,13 @@ adb_status() {
 			n=$((n+1))
 		done
 	fi
+	return 0
 }
 
 # shellcheck disable=SC2120
 adb_stop() {
 	local validation_result="$3"
-	load_environment "$validation_result" 'quiet' || return 1
+	load_environment "$validation_result" 'quiet' || return 0
 	if [ -s "$outputFile" ]; then
 		output "Stopping $serviceName... "
 		cache 'create'
@@ -1593,6 +1595,7 @@ adb_stop() {
 			output "${_ERROR_}: $(get_text 'errorStopping')!\\n"
 		fi
 	fi
+	return 0
 }
 
 adb_pause() {


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0-rc4
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0-rc4

Description:
* escape dots in grep command to properly identify hosts files

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 13a88d0b79142f385d77baaa390211673bf6b9c0)
