### PR TITLE
lighttpd: update to lighttpd 1.4.72 release hash

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
-PKG_VERSION:=1.4.71
+PKG_VERSION:=1.4.72
 PKG_RELEASE:=1
 # release candidate ~rcX testing; remove for release
 #PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x
-PKG_HASH:=b8b6915da20396fdc354df3324d5e440169b2e5ea7859e3a775213841325afac
+PKG_HASH:=f7cade4d69b754a0748c01463c33cd8b456ca9cc03bb09e85a71bcbcd54e55ec
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/lighttpd/patches/020-meson-mod_webdav_min.patch
+++ b/net/lighttpd/patches/020-meson-mod_webdav_min.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] [meson] mod_webdav_min w/o deps: xml2 sqlite3 uuid
 
 --- a/src/meson.build
 +++ b/src/meson.build
-@@ -876,6 +876,16 @@ if libsasl.found()
+@@ -877,6 +877,16 @@ if libsasl.found()
  	]
  endif
  


### PR DESCRIPTION
Maintainer: @flyn-org
Compile tested: arm_cortex-a9 OpenWrt master

Description:
* update to lighttpd 1.4.72 release hash