### PR TITLE
[openwrt-23.05] python-twisted: Update to 23.8.0, rework patches

### DIFF
--- a/lang/python/python-twisted/Makefile
+++ b/lang/python/python-twisted/Makefile
@@ -9,11 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-twisted
-PKG_VERSION:=22.10.0
+PKG_VERSION:=23.8.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=Twisted
-PKG_HASH:=32acbd40a94f5f46e7b42c109bfae2b302250945561783a8b7a059048f2d4d31
+PYPI_SOURCE_NAME:=twisted
+PKG_HASH:=3c73360add17336a622c0d811c2a2ce29866b6e59b1125fd6509b17252098a24
 
 PKG_BUILD_DEPENDS:=libtirpc
 
@@ -22,7 +23,7 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_CPE_ID:=cpe:/a:twistedmatrix:twisted
 
-PKG_BUILD_DEPENDS:=python-incremental/host
+PKG_BUILD_DEPENDS:=python-hatchling/host python-hatch-fancy-pypi-readme/host python-incremental/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -45,8 +46,6 @@ define Package/python3-twisted
       +python3-hyperlink \
       +python3-idna \
       +python3-incremental \
-      +python3-pkg-resources \
-      +python3-pyasn1 \
       +python3-pyopenssl \
       +python3-service-identity \
       +python3-typing-extensions \
@@ -55,12 +54,8 @@ endef
 
 define Package/python3-twisted/description
 Twisted is a networking engine written in Python, supporting numerous
-protocols. It contains a web server, numerous chat clients, chat servers,
-mail servers, and more.
-endef
-
-define Build/Configure
-	$(SED) 's/^version = attr: twisted.__version__$$$$/version = $(PKG_VERSION)/' $(PKG_BUILD_DIR)/setup.cfg
+protocols. It contains a web server, numerous chat clients, chat
+servers, mail servers, and more.
 endef
 
 define Py3Package/python3-twisted/filespec

--- a/lang/python/python-twisted/patches/001-omit-tkconch.patch
+++ b/lang/python/python-twisted/patches/001-omit-tkconch.patch
@@ -1,13 +1,13 @@
---- a/setup.cfg
-+++ b/setup.cfg
-@@ -115,7 +115,6 @@ console_scripts =
- 	conch = twisted.conch.scripts.conch:run
- 	mailmail = twisted.mail.scripts.mailmail:run
- 	pyhtmlizer = twisted.scripts.htmlizer:run
--	tkconch = twisted.conch.scripts.tkconch:run
- 	trial = twisted.scripts.trial:run
- 	twist = twisted.application.twist._twist:Twist.main
- 	twistd = twisted.scripts.twistd:run
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -150,7 +150,6 @@ ckeygen = "twisted.conch.scripts.ckeygen
+ conch = "twisted.conch.scripts.conch:run"
+ mailmail = "twisted.mail.scripts.mailmail:run"
+ pyhtmlizer = "twisted.scripts.htmlizer:run"
+-tkconch = "twisted.conch.scripts.tkconch:run"
+ trial = "twisted.scripts.trial:run"
+ twist = "twisted.application.twist._twist:Twist.main"
+ twistd = "twisted.scripts.twistd:run"
 --- a/src/twisted/python/twisted-completion.zsh
 +++ b/src/twisted/python/twisted-completion.zsh
 @@ -1,4 +1,4 @@

--- a/lang/python/python-twisted/patches/002-omit-tests.patch
+++ b/lang/python/python-twisted/patches/002-omit-tests.patch
@@ -1,20 +1,10 @@
---- a/setup.cfg
-+++ b/setup.cfg
-@@ -107,6 +107,9 @@ mypy =
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -194,6 +194,7 @@ exclude = [
+     "*.pxi",
+     "*.pyx",
+     "build.bat",
++    "test",
+ ]
  
- [options.packages.find]
- where = src
-+exclude = 
-+	*.test
-+	*.test.*
- 
- [options.entry_points]
- console_scripts = 
-@@ -126,6 +129,7 @@ console_scripts =
- 	*.pxi
- 	*.pyx
- 	build.bat
-+	test/*
- 
- [flake8]
- disable-noqa = True
+ [tool.hatch.build.targets.sdist]

--- a/lang/python/python-twisted/test.sh
+++ b/lang/python/python-twisted/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ "$1" = python3-twisted ] || exit 0
+
+python3 -c 'from twisted.internet import reactor'


### PR DESCRIPTION
Maintainer: me
Compile tested: none (cherry picked from #22291)
Run tested: none

Description:
The package changed to the hatchling build backend.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 00841f98731fe7599c7f2cae2bf4e08599833647)