### PR TITLE
libvpx: update to 1.13.1

### DIFF
--- a/libs/libvpx/Makefile
+++ b/libs/libvpx/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libvpx
-PKG_VERSION:=1.12.0
+PKG_VERSION:=1.13.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://chromium.googlesource.com/webm/libvpx
-PKG_MIRROR_HASH:=19d9bd55198f063875cc72bdfa5eb9fa7cc1ae8af33979f807d2c82b66349933
+PKG_MIRROR_HASH:=55d6880564e354b2d310047773ac211790421e0f3ea70a9280213f7e27fa5f3a
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>


### PR DESCRIPTION
v1.13.0

This release includes more Neon and AVX2 optimizations, adds a new codec control to set per frame QP, upgrades GoogleTest to v1.12.1, and includes numerous bug fixes.

v1.13.1

This release contains two security related fixes. One each for VP8 and VP9.

- https://crbug.com/1486441 (CVE-2023-5217)
- Fix bug with smaller width bigger size (CVE-2023-44488)

Fixes #22318

Maintainer: me
Compile tested: ath79_generic,mediatek_filogic,x86_64
Run tested: x86_64

```
root@OpenWrt:~# opkg update
root@OpenWrt:~# opkg install /tmp/libvpx*.ipk /tmp/gst1-mod-vpx*.ipk
root@OpenWrt:~# opkg install gstreamer1-utils gst1-mod-vpx gst1-mod-videotestsrc gst1-mod-matroska gst1-mod-hls uhttpd
root@OpenWrt:~# /etc/init.d/uhttpd start
root@OpenWrt:~# cd /www && gst-launch-1.0 videotestsrc is-live=true ! vp8enc deadline=1 cpu-used=4 lag-in-frames=0 ! webmmux streamable=true ! hlssink max-files=5 target-duration=5
root@OpenWrt:~# cd /www && gst-launch-1.0 videotestsrc is-live=true ! vp9enc deadline=1 cpu-used=4 lag-in-frames=0 ! webmmux streamable=true ! hlssink max-files=5 target-duration=5

PC ~$ gst-play-1.0 http://192.168.1.1/playlist.m3u8
PC ~$ ffplay http://192.168.1.1/playlist.m3u8
```

Description:
