### PR TITLE
pppossh: depend on dbclient

### DIFF
--- a/net/pppossh/Makefile
+++ b/net/pppossh/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pppossh
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 PKG_LICENSE:=GPLv2
 
@@ -18,7 +18,7 @@ define Package/pppossh
   SECTION:=net
   CATEGORY:=Network
   TITLE:=PPPoSSH (Point-to-Point Protocol over SSH)
-  DEPENDS:=+ppp +resolveip @(PACKAGE_dropbear||PACKAGE_openssh-client)
+  DEPENDS:=+ppp +resolveip @(DROPBEAR_DBCLIENT||PACKAGE_openssh-client)
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
Maintainer: @yousong
Compile tested: OpenWrt 23
Run tested: tested in VirtualBox and Turris

Description: The package should not only depend on a package dropbear but on the dbclient. Otherwise the dbclient may be disabled during compilation and the dependency will be not satisfied.

Same I did in the #22159 

