### PR TITLE
librespeed-go: Reload the daemon after modifying the tls certificate

### DIFF
--- a/net/librespeed-go/Makefile
+++ b/net/librespeed-go/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=librespeed-go
 PKG_VERSION:=1.1.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/librespeed/speedtest-go/tar.gz/v$(PKG_VERSION)?

--- a/net/librespeed-go/files/librespeed-go.init
+++ b/net/librespeed-go/files/librespeed-go.init
@@ -12,6 +12,7 @@ mount_jail_file() {
 	local cfg="$1"
 	local isdir="${2:-0}"
 	local rw="${3:-0}"
+	local reload="${4:-0}"
 
 	local value
 	config_get value "config" "$cfg"
@@ -31,6 +32,8 @@ mount_jail_file() {
 	else
 		procd_add_jail_mount "$value"
 	fi
+
+	[ "$reload" = "0" ] || procd_append_param file "$value"
 }
 
 start_service() {
@@ -74,8 +77,8 @@ start_service() {
 
 	mount_jail_file "assets_path" "1"
 	mount_jail_file "database_file" "0" "1"
-	mount_jail_file "tls_cert_file"
-	mount_jail_file "tls_key_file"
+	mount_jail_file "tls_cert_file" "0" "0" "1"
+	mount_jail_file "tls_key_file" "0" "0" "1"
 
 	procd_close_instance
 }


### PR DESCRIPTION
Maintainer: Tianling Shen cnsztl@immortalwrt.org @1715173329 
Compile tested: x86_64, x86/64, 22.03.5
Run tested: x86_64, x86/64, 22.03.5

Description:
Make the daemon reload after the tls certificate is updated