### PR TITLE
[22.03] samba4: Update to version 4.18.7

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.18.0
+PKG_VERSION:=4.18.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -13,7 +13,7 @@ PKG_SOURCE_URL:= \
 		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
-PKG_HASH:=70348656ef807be9c8be4465ca157cef4d99818e234253d2c684cc18b8408149
+PKG_HASH:=4fb87bceaeb01d832a59046c197a044b7e8e8000581548b5d577a6cda03344d1
 
 PKG_BUILD_FLAGS:=gc-sections
 


### PR DESCRIPTION
Maintainer: nobody
Compile tested: mvebu, Turris Omnia, Turris OS 7 = OpenWrt 22.03
Run tested: mvebu, Turris Omnia, Turris OS 7 = OpenWrt 22.03, runs, shares accessible

Description:
Update to the latest stable version in 4.18 series, for details, see

* https://www.samba.org/samba/history/samba-4.18.7.html
* https://www.samba.org/samba/history/samba-4.18.6.html
* https://www.samba.org/samba/history/samba-4.18.5.html
* https://www.samba.org/samba/history/samba-4.18.4.html
* https://www.samba.org/samba/history/samba-4.18.3.html
* https://www.samba.org/samba/history/samba-4.18.2.html
* https://www.samba.org/samba/history/samba-4.18.1.html

Backport of #22348