### PR TITLE
[23.05] samba4: Update to version 4.18.7

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.18.6
+PKG_VERSION:=4.18.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -13,7 +13,7 @@ PKG_SOURCE_URL:= \
 		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
-PKG_HASH:=284c8a994ce989c87cd6808c390fcb9d00c36b21a0dc1a8a75474b67c9e715e7
+PKG_HASH:=4fb87bceaeb01d832a59046c197a044b7e8e8000581548b5d577a6cda03344d1
 
 PKG_BUILD_FLAGS:=gc-sections
 


### PR DESCRIPTION
Maintainer: nobody
Compile tested: mvebu, Turris Omnia, Turris OS 7 = OpenWrt 22.03
Run tested: mvebu, Turris Omnia, Turris OS 7 = OpenWrt 22.03, runs, shares accessible

Description:
Update to the latest stable version in 4.18 series, for details, see
https://www.samba.org/samba/history/samba-4.18.7.html

Backport of https://github.com/openwrt/packages/pull/22348