### PR TITLE
swanmon: add package

### DIFF
--- a/libs/davici/Makefile
+++ b/libs/davici/Makefile
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2023 TDT AG <development@tdt.de>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See https://www.gnu.org/licenses/gpl-2.0.txt for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=davici
+PKG_VERSION:=1.4
+PKG_RELEASE=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/strongswan/davici/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=b03c5a1aad905e962271d70246d6af6c337ffd00449d990082ea02161327bde8
+
+PKG_MAINTAINER:=Lukas Voegl <lvoegl@tdt.de>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=COPYING
+
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/davici
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Decoupled Asynchronous VICI
+  URL:=https://github.com/strongswan/davici
+endef
+
+define Package/davici/description
+  The davici library provides a client implementation of the
+  strongSwan VICI protocol for integration into external applications.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdavici.so* $(1)/usr/lib/
+endef
+
+define Package/davici/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdavici.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,davici))

--- a/utils/swanmon/Makefile
+++ b/utils/swanmon/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2023 TDT AG <development@tdt.de>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See https://www.gnu.org/licenses/gpl-2.0.txt for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=swanmon
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/TDT-AG/swanmon
+PKG_SOURCE_VERSION:=296096e172005cae855c316f859265aba8b2e472
+PKG_MIRROR_HASH:=96b9c988cae8e2c34dc8b483e32b3c619fd3a027be33ece80c93972ab437e10a
+
+PKG_MAINTAINER:=Lukas Voegl <lvoegl@tdt.de>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/swanmon
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=strongSwan monitoring tool
+  DEPENDS:=+davici +glib2 +libjson-c
+endef
+
+define Package/swanmon/description
+  A command-line utility for serializing the strongSwan VICI output to JSON.
+endef
+
+define Package/swanmon/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/swanmon $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,swanmon))

--- a/utils/swanmon/test.sh
+++ b/utils/swanmon/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+swanmon help


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, lantiq_xrx200
Run tested: lantiq_xrx200, 22.03.5

Description:
swanmon is a tool for querying strongswan status information _in JSON, unlike swanctl_ via the [vici protocol](https://github.com/strongswan/strongswan/blob/master/src/libcharon/plugins/vici/README.md) using the added [davici](https://github.com/strongswan/davici) library package.

Example output:
```shell
~ swanmon help
Usage: swanmon [COMMAND]
commands:
  help              Shows swanmon help
  version           Returns daemon and system specific version information
  stats             Returns IKE daemon statistics and load information
  list-sas          Lists currently active IKE_SAs and associated CHILD_SAs
  get-conns         Return a list of connection names loaded exclusively over vici
  list-conns        List currently loaded connections. This call includes all connections known by the daemon, not only those loaded over vici
  get-authorities   Return a list of currently loaded certification authority names
  list-authorities  List currently loaded certification authority information
  list-policies     List currently installed trap, drop and bypass policies
  list-certs        List currently loaded certificates. This call includes all certificates known by the daemon, not only those loaded over vici
  get-keys          Return a list of identifiers of private keys loaded exclusively over vici
  get-shared        Return a list of unique identifiers of shared keys loaded exclusively over vici
  get-pools         List the currently loaded pools
  get-algorithms    List currently loaded algorithms and their implementation
  get-counters      List global or connection-specific counters for several IKE events
```

```shell
~ swanmon version
{"errors":[],"data":{"daemon":"charon","version":"5.9.8","sysname":"Linux","release":"5.15.132","machine":"mips"}}
```

_strongswan not started_
```shell
~ swanmon version
{"errors":[{"message":"Connecting failed: Connection refused"}]}
```