### PR TITLE
python-curl: fix missing curl-config path

### DIFF
--- a/lang/python/python-curl/Makefile
+++ b/lang/python/python-curl/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pycurl
 PKG_VERSION:=7.45.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=5730590be0271364a5bddd9e245c9cc0fb710c4cbacbdd95264a3122d23224ca
@@ -47,6 +47,9 @@ endif
 ifdef CONFIG_LIBCURL_WOLFSSL
   PYTHON3_PKG_BUILD_VARS:=PYCURL_SSL_LIBRARY=wolfssl
 endif
+
+PYTHON3_PKG_BUILD_VARS += \
+	PYCURL_CURL_CONFIG=$(STAGING_DIR)/usr/bin/curl-config
 
 $(eval $(call Py3Package,python3-curl))
 $(eval $(call BuildPackage,python3-curl))


### PR DESCRIPTION
python-curl wheel setup-tools failed to build because it wasn't able to find curl-config.

curl-config path is requested in setup.py, line 218: 
`curl_config = os.environ.get('PYCURL_CURL_CONFIG', "curl-config")`

and current Makefile did not set this variable. After adding it to build vars, package buils without issues.

curl-config can be found from 2 locations:
 - staging_dir/target/usr/bin/curl-config
 - staging_dir/target/host/bin/curl-config (which is link to first mentioned).

this commit uses first one. Could use either one.

Maintainer: @valdi74 
Compile tested: x86_64, latest git
Run tested: x86_64, latest git