### PR TITLE
[23.05] curl: Update to version 8.4.0

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -9,15 +9,15 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
-PKG_VERSION:=8.3.0
+PKG_VERSION:=8.4.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \
 	https://dl.uxnr.de/mirror/curl/ \
 	https://curl.askapache.com/download/ \
 	https://curl.se/download/
-PKG_HASH:=376d627767d6c4f05105ab6d497b0d9aba7111770dd9d995225478209c37ea63
+PKG_HASH:=e5250581a9c032b1b6ed3cf2f9c114c811fc41881069e9892d115cc73f9e88c6
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: @stangri
Compile tested: mvebu, Turris Omnia, Turris OS 6 = OpenWrt 21.02
Run tested: mvebu, Turris Omnia, Turris OS 6 = OpenWrt 21.02, can download a website

Description:
For detailed changes, see https://curl.se/changes.html#8_4_0
Switching to tar.bz2 for the time being as tar.xz is not yet available.
Fixes CVE-2023-38546 and CVE-2023-38545.
Backport of #22365 