### PR TITLE
openblas: bump to version 0.3.24

### DIFF
--- a/libs/openblas/Makefile
+++ b/libs/openblas/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=OpenBLAS
-PKG_VERSION:=0.3.23
+PKG_VERSION:=0.3.24
 PKG_RELEASE:=1
 
 PKG_SOURCE:=OpenBLAS-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/xianyi/OpenBLAS/releases/download/v$(PKG_VERSION)/
-PKG_HASH:=5d9491d07168a5d00116cdc068a40022c3455bf9293c7cb86a65b1054d7e5114
+PKG_HASH:=ceadc5065da97bd92404cac7254da66cc6eb192679cf1002098688978d4d5132
 PKG_LICENSE:=BSD 3-Clause
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/e66eed033f9f9d27fc839d81d3a03d4fad1b9b5b
Run tested: x86 https://github.com/openwrt/openwrt/commit/e66eed033f9f9d27fc839d81d3a03d4fad1b9b5b

