### PR TITLE
node: bump to v18.18.1

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v18.18.0
+PKG_VERSION:=v18.18.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=e4d4dbac3634d99f892f00db47da78f98493c339582e8a95fb2dd59f5cfe0f90
+PKG_HASH:=c3c95047ec0c2b2063a5ea4b4f71ee807f6075d1dbeae4f3207cda4b9ae782f6
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: head, aarch64, arm, i386, x86_64
Run tested: (qemu 8.1.0) aarch64

Description:
Update to v18.18.1

Notable Changes

 This release addresses some regressions that appeared in Node.js 18.18.0:

-  (Windows) FS can not handle certain characters in file name nodejs/node#48673
-  18 and 20 node images give error - Text file busy (after re-build images) nodejs/docker-node#1968
-  libuv update in 18.18.0 breaks webpack's thread-loader nodejs/node#49911