### PR TITLE
[openwrt-23.05] python-zope-interface: Update to 6.1, refresh patch

### DIFF
--- a/lang/python/python-zope-interface/Makefile
+++ b/lang/python/python-zope-interface/Makefile
@@ -9,11 +9,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-zope-interface
-PKG_VERSION:=6.0
+PKG_VERSION:=6.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=zope.interface
-PKG_HASH:=aab584725afd10c710b8f1e6e208dbee2d0ad009f57d674cb9d1b3964037275d
+PKG_HASH:=2fdc7ccbd6eb6b7df5353012fbed6c3c5d04ceaca0038f75e601060e95345309
 
 PKG_LICENSE:=ZPL-2.1
 PKG_LICENSE_FILES:=LICENSE.txt
@@ -29,7 +29,7 @@ define Package/python3-zope-interface
   SUBMENU:=Python
   TITLE:=Interfaces for Python
   URL:=https://github.com/zopefoundation/zope.interface
-  DEPENDS:=+python3-light
+  DEPENDS:=+python3-light +python3-logging
 endef
 
 define Package/python3-zope-interface/description

--- a/lang/python/python-zope-interface/patches/001-omit-tests.patch
+++ b/lang/python/python-zope-interface/patches/001-omit-tests.patch
@@ -1,6 +1,6 @@
 --- a/setup.py
 +++ b/setup.py
-@@ -124,7 +124,7 @@ setup(name='zope.interface',
+@@ -125,7 +125,7 @@ setup(name='zope.interface',
            "Framework :: Zope :: 3",
            "Topic :: Software Development :: Libraries :: Python Modules",
        ],
@@ -9,7 +9,7 @@
        package_dir={'': 'src'},
        namespace_packages=["zope"],
        cmdclass={
-@@ -132,6 +132,7 @@ setup(name='zope.interface',
+@@ -133,6 +133,7 @@ setup(name='zope.interface',
        },
        test_suite='zope.interface.tests',
        include_package_data=True,

--- a/lang/python/python-zope-interface/test.sh
+++ b/lang/python/python-zope-interface/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ "$1" = python3-zope-interface ] || exit 0
+
+python3 -c 'import zope.interface'


### PR DESCRIPTION
Maintainer: me
Compile tested: none (cherry picked from #22344)
Run tested: none

Description:
This also updates the list of dependencies and adds a test.sh script for the packages feed CI.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 7e8f7b28d74ca2044309dff9c789dec055ee43c5)