### PR TITLE
rust: update to 1.73.0

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
-PKG_VERSION:=1.72.0
-PKG_RELEASE:=3
+PKG_VERSION:=1.73.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
-PKG_HASH:=ea9d61bbb51d76b6ea681156f69f0e0596b59722f04414b01c6e100b4b5be3a1
+PKG_HASH:=96d62e6d1f2d21df7ac8acb3b9882411f9e7c7036173f7f2ede9e1f1f6b1bb3a
 HOST_BUILD_DIR:=$(BUILD_DIR)/host/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>
@@ -52,6 +52,7 @@ TARGET_CONFIGURE_ARGS = \
 	--set=target.$(RUSTC_TARGET_ARCH).cxx=$(TARGET_CXX_NOCACHE) \
 	--set=target.$(RUSTC_TARGET_ARCH).linker=$(TARGET_CC_NOCACHE) \
 	--set=target.$(RUSTC_TARGET_ARCH).ranlib=$(TARGET_RANLIB) \
+	--set=target.$(RUSTC_TARGET_ARCH).crt-static=false \
 	$(if $(CONFIG_USE_MUSL),--set=target.$(RUSTC_TARGET_ARCH).musl-root=$(TOOLCHAIN_DIR))
 
 # CARGO_HOME is an environmental

--- a/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
+++ b/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
@@ -11,7 +11,7 @@ Subject: [PATCH] Update xz2 and use it static
 
 --- a/src/bootstrap/Cargo.lock
 +++ b/src/bootstrap/Cargo.lock
-@@ -430,9 +430,9 @@ dependencies = [
+@@ -434,9 +434,9 @@ dependencies = [
  
  [[package]]
  name = "lzma-sys"
@@ -23,7 +23,7 @@ Subject: [PATCH] Update xz2 and use it static
  dependencies = [
   "cc",
   "libc",
-@@ -899,9 +899,9 @@ dependencies = [
+@@ -903,9 +903,9 @@ dependencies = [
  
  [[package]]
  name = "xz2"

--- a/lang/rust/patches/0002-rustc-bootstrap-cache.patch
+++ b/lang/rust/patches/0002-rustc-bootstrap-cache.patch
@@ -1,6 +1,6 @@
 --- a/src/bootstrap/bootstrap.py
 +++ b/src/bootstrap/bootstrap.py
-@@ -543,7 +543,7 @@ class RustBuild(object):
+@@ -546,7 +546,7 @@ class RustBuild(object):
                  shutil.rmtree(bin_root)
  
              key = self.stage0_compiler.date
@@ -11,7 +11,7 @@
                  os.makedirs(rustc_cache)
 --- a/src/bootstrap/download.rs
 +++ b/src/bootstrap/download.rs
-@@ -507,7 +507,10 @@ impl Config {
+@@ -520,7 +520,10 @@ impl Config {
          key: &str,
          destination: &str,
      ) {
@@ -23,10 +23,10 @@
          let cache_dir = cache_dst.join(key);
          if !cache_dir.exists() {
              t!(fs::create_dir_all(&cache_dir));
-@@ -627,7 +630,10 @@ download-rustc = false
+@@ -647,7 +650,10 @@ download-rustc = false
          let llvm_assertions = self.llvm_assertions;
  
-         let cache_prefix = format!("llvm-{}-{}", llvm_sha, llvm_assertions);
+         let cache_prefix = format!("llvm-{llvm_sha}-{llvm_assertions}");
 -        let cache_dst = self.out.join("cache");
 +        let cache_dst = match env::var_os("OPENWRT_RUSTC_BOOTSTRAP_CACHE") {
 +            Some(v) => PathBuf::from(v),

--- a/lang/rust/patches/0003-bump-libc-deps-to-0.2.146.patch
+++ b/lang/rust/patches/0003-bump-libc-deps-to-0.2.146.patch
@@ -1,0 +1,156 @@
+This patch bumps all libc dependencies and checksums to 0.2.146, which includes the fix for musl 1.2.4.
+
+--- a/vendor/addr2line-0.20.0/Cargo.lock
++++ b/vendor/addr2line-0.20.0/Cargo.lock
+@@ -246,9 +246,9 @@ checksum = "e2abad23fbc42b3700f2f279844d
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.141"
++version = "0.2.146"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
++checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+ 
+ [[package]]
+ name = "libtest-mimic"
+--- a/vendor/backtrace-0.3.67/Cargo.lock
++++ b/vendor/backtrace-0.3.67/Cargo.lock
+@@ -64,9 +64,9 @@ checksum = "dec7af912d60cdbd3677c1af9352
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.138"
++version = "0.2.146"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
++checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+ 
+ [[package]]
+ name = "libloading"
+--- a/vendor/bstr/Cargo.lock
++++ b/vendor/bstr/Cargo.lock
+@@ -34,9 +34,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.138"
++version = "0.2.146"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
++checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+ 
+ [[package]]
+ name = "memchr"
+--- a/vendor/cranelift-jit/Cargo.lock
++++ b/vendor/cranelift-jit/Cargo.lock
+@@ -224,9 +224,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.141"
++version = "0.2.146"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
++checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+ 
+ [[package]]
+ name = "log"
+--- a/vendor/crossbeam-channel/Cargo.lock
++++ b/vendor/crossbeam-channel/Cargo.lock
+@@ -50,9 +50,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.141"
++version = "0.2.146"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
++checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+ 
+ [[package]]
+ name = "num_cpus"
+--- a/vendor/elasticlunr-rs/Cargo.lock
++++ b/vendor/elasticlunr-rs/Cargo.lock
+@@ -555,9 +555,9 @@ checksum = "e2abad23fbc42b3700f2f279844d
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.140"
++version = "0.2.146"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
++checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+ 
+ [[package]]
+ name = "lindera"
+--- a/vendor/handlebars/Cargo.lock
++++ b/vendor/handlebars/Cargo.lock
+@@ -550,9 +550,9 @@ checksum = "e2abad23fbc42b3700f2f279844d
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.140"
++version = "0.2.146"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
++checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+ 
+ [[package]]
+ name = "lock_api"
+--- a/vendor/icu_locid/Cargo.lock
++++ b/vendor/icu_locid/Cargo.lock
+@@ -318,9 +318,9 @@ checksum = "e2abad23fbc42b3700f2f279844d
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.141"
++version = "0.2.146"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
++checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+ 
+ [[package]]
+ name = "litemap"
+--- a/vendor/libffi/Cargo.lock
++++ b/vendor/libffi/Cargo.lock
+@@ -10,9 +10,9 @@ checksum = "50d30906286121d95be3d479533b
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.140"
++version = "0.2.146"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
++checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+ 
+ [[package]]
+ name = "libffi"
+--- a/vendor/terminal_size/Cargo.lock
++++ b/vendor/terminal_size/Cargo.lock
+@@ -47,9 +47,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.140"
++version = "0.2.146"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
++checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+ 
+ [[package]]
+ name = "linux-raw-sys"
+--- a/vendor/tracing-tree/Cargo.lock
++++ b/vendor/tracing-tree/Cargo.lock
+@@ -100,9 +100,9 @@ checksum = "e2abad23fbc42b3700f2f279844d
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.141"
++version = "0.2.146"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
++checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+ 
+ [[package]]
+ name = "log"


### PR DESCRIPTION
changelog at https://github.com/rust-lang/rust/releases/tag/1.73.0

Maintainer: @lu-zero 
Compile tested: x86_64, latest git
Run tested: x86_64, latest git