### PR TITLE
rust: fix build with glibc, ARM and hard floats

### DIFF
--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -53,6 +53,7 @@ ifeq ($(ARCH),arm)
 
   ifeq ($(CONFIG_HAS_FPU),y)
     RUSTC_TARGET_ARCH:=$(subst musleabi,musleabihf,$(RUSTC_TARGET_ARCH))
+    RUSTC_TARGET_ARCH:=$(subst gnueabi,gnueabihf,$(RUSTC_TARGET_ARCH))
   endif
 endif
 


### PR DESCRIPTION
Maintainer: @lu-zero 
Compile tested: NXP i.MX6 Cortex-A9, master as of 66f6c20e45aa0eb2649d1e0552eab9e138e38601 and ac8ca9c86a4af19b24704cae7881094a09520e0e
Run tested: NXP i.MX6 Cortex-A9, master as of ac8ca9c86a4af19b24704cae7881094a09520e0e

Description:

Patch the target triple for Rust with glibc to include hard floating point support.

The GNU target triple used elsewhere does not include hard float support, instead `-mfloat-abi=hard` is passed separately. For Rust it must be included in the target triple. This was already being done for musl, this commit adds the same patching for glibc.

Without this patch Rust compilation fails with an error like this (abbreviated to fit the line length):

    ld: error: libstd.so uses VFP register arguments, ... does not
    ld: failed to merge target specific data of file ...

<details><summary>Unabbreviated logs</summary>

	openwrt/staging_dir/toolchain-arm_cortex-a9+neon_gcc-12.3.0_glibc_eabi/lib/gcc/arm-openwrt-linux-gnueabi/12.3.0/../../../../arm-openwrt-linux-gnueabi/bin/ld: error: openwrt/build_dir/target-arm_cortex-a9+neon_glibc_eabi/host/rustc-1.72.0-src/build/x86_64-unknown-linux-gnu/stage2-std/armv7-unknown-linux-gnueabi/release/deps/libstd-5a8d47e92604592e.so uses VFP register arguments, openwrt/build_dir/target-arm_cortex-a9+neon_glibc_eabi/host/rustc-1.72.0-src/build/x86_64-unknown-linux-gnu/stage2-std/armv7-unknown-linux-gnueabi/release/deps/libcompiler_builtins-31b99788d3a02979.rlib(compiler_builtins-31b99788d3a02979.compiler_builtins.a070c9823d55f24a-cgu.007.rcgu.o) does not
	openwrt/staging_dir/toolchain-arm_cortex-a9+neon_gcc-12.3.0_glibc_eabi/lib/gcc/arm-openwrt-linux-gnueabi/12.3.0/../../../../arm-openwrt-linux-gnueabi/bin/ld: failed to merge target specific data of file openwrt/build_dir/target-arm_cortex-a9+neon_glibc_eabi/host/rustc-1.72.0-src/build/x86_64-unknown-linux-gnu/stage2-std/armv7-unknown-linux-gnueabi/release/deps/libcompiler_builtins-31b99788d3a02979.rlib(compiler_builtins-31b99788d3a02979.compiler_builtins.a070c9823d55f24a-cgu.007.rcgu.o)

</details>