### PR TITLE
maturin: Update to 1.3.0, build as Python (host-only) package

### DIFF
--- a/lang/python/python-maturin/Makefile
+++ b/lang/python/python-maturin/Makefile
@@ -4,40 +4,48 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=maturin
-PKG_VERSION:=0.14.15
+PKG_NAME:=python-maturin
+PKG_VERSION:=1.3.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/PyO3/maturin/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=60cbf8ff73a36333c3f5483ca679a52169839db381f06683d8e61a6c00c28cf7
+PYPI_NAME:=maturin
+PKG_HASH:=f6c69bc7ae147a5effd55587447b35cab1ceb726ba244d08698bc7518b8688ac
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>
 PKG_LICENSE:=Apache-2.0 MIT
 PKG_LICENSE_FILES:=license-apache license-mit
 
-HOST_BUILD_DEPENDS:=rust/host
+HOST_BUILD_DEPENDS:= \
+	python3/host \
+	python-build/host \
+	python-installer/host \
+	python-wheel/host \
+	python-setuptools-rust/host
 HOST_BUILD_PARALLEL:=1
 PKG_HOST_ONLY:=1
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
-include ../rust/rust-host-build.mk
+include ../python3-package.mk
+include ../python3-host-build.mk
 
-define Package/maturin
+define Package/python3-maturin
   SECTION:=lang
   CATEGORY:=Languages
-  SUBMENU:=Rust
+  SUBMENU:=Python
   TITLE:=Build and publish crates as python packages
   DEPENDS:=$(RUST_ARCH_DEPENDS)
   URL:=https://maturin.rs
+  BUILDONLY:=1
 endef
 
-define Package/maturin/description
+define Package/python3-maturin/description
   Build and publish crates with pyo3, rust-cpython, cffi and uniffi
   bindings as well as rust binaries as python packages.
 endef
 
-$(eval $(call RustBinHostBuild))
 $(eval $(call HostBuild))
-$(eval $(call BuildPackage,maturin))
+$(eval $(call Py3Package,python3-maturin))
+$(eval $(call BuildPackage,python3-maturin))
+$(eval $(call BuildPackage,python3-maturin-src))


### PR DESCRIPTION
Maintainer: @lu-zero
Compile tested: armsr-armv7, 2023-10-07 snapshot sdk
Run tested: N/A

Description:
Python packages that use maturin to build do not call the maturin program directly; they use the [maturin build backend][1]. This build backend is a Python library provided with maturin that interfaces with the maturin program.

This changes the maturin package to use the Python build process so that the build backend is installed correctly.

This also renames the source package to python-maturin and moves it into the lang/python directory.

[1]: https://www.maturin.rs/#source-distribution