### PR TITLE
[openwrt-23.05] conmon: update to 2.1.8

### DIFF
--- a/utils/conmon/Makefile
+++ b/utils/conmon/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=conmon
-PKG_VERSION:=2.1.7
+PKG_VERSION:=2.1.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containers/$(PKG_NAME)/archive/v$(PKG_VERSION)
-PKG_HASH:=7d0f9a2f7cb8a76c51990128ac837aaf0cc89950b6ef9972e94417aa9cf901fe
+PKG_HASH:=e72c090210a03ca3b43a0fad53f15bca90bbee65105c412468009cf3a5988325
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Backport conmon update 2.1.8 to openwrt 23.05

I have received several issue reports on difficulties and problems with podman containers with stable release version of openwrt. So I am backporting up to date versions to be able help solve these issues.

Maintainer: me
Compile tested: x86_64
Run tested: x86_64