### PR TITLE
[openwrt-23.05] netavark: update to 1.8.0

### DIFF
--- a/net/netavark/Makefile
+++ b/net/netavark/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netavark
-PKG_VERSION:=1.6.0
+PKG_VERSION:=1.8.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containers/netavark/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=3bec9e9b0f3f8f857370900010fb2125ead462d43998ad8f43e4387a5b06f9d6
+PKG_HASH:=b1422ef6927458e9f80f7d322b751e29ab5d04d8ed6cb065baa82fa4291af10f
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
backport netavark 1.8.0 update to openwrt-23.05

I have received several issue reports on difficulties and problems with podman containers with stable release version of openwrt. So I am backporting up to date versions to be able help solve these issues.

Maintainer: me
Compile tested: x86_64