### PR TITLE
[openwrt-23.05] cni-protocol: update to 20231008

### DIFF
--- a/net/cni-protocol/Makefile
+++ b/net/cni-protocol/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cni-protocol
-PKG_VERSION:=20230217
+PKG_VERSION:=20231008
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
@@ -16,25 +16,44 @@ define Package/cni-protocol
 endef
 
 define Package/cni-protocol/description
-  protocol support for cni networks for netifd
-  makes defining network for podman and other similar
-  systems using cni networking much easier and simpler.
+  protocol support for netavark/cni networks for netifd
+  makes defining networks for podman and other similar
+  systems easier and simple.
 
-  with cni protocol support, on a network, where firewall
-  and portmapper management is disabled, you may control
-  firewalling with openwrt's default firewall configuration.
+  with protocol, a network where firewall and portmapper
+  management is disabled, control of firewalling, whether
+  it was exposing ports, and forwarding to them from wan,
+  or limiting/accepting access to other networks such
+  as lan can made through openwrt's own firewalling
+  configuration.
 
-  for example, create a container that hosts web content on
-  port 80 with static ip on your cni network, if your
-  network is 10.88.0.0/16, use for eg. 10.88.0.101 as
-  your containers static ip address. Create a zone, cni
-  to your firewall and add your interface to it.
+  example configuration could be as following:
+    - lan network: 10.0.0.0/16 (255.255.0.0)
+    - container network: 10.129.0.1/24 (255.255.255.0)
 
-  Now you can easily set up redirectiong to 10.88.0.101:80
-  to expose it's port 80 to wan for serving your website.
+  Add a network configuration for your container network
+  using cni protocol. Then create firewall zone for it.
 
-  Protocol has one setting: device, on podman this often
-  is cni-podman0.
+  You could create a new container/pod with static ip
+  address 10.129.0.2 (as 10.129.0.1 as container network's
+  gateway).
+
+  Easily define permissions so that local networks can
+  connect to cni network, but not the other way around.
+  Also you want to allow forwarding from/to wan.
+
+  Now, as cni cannot access local dns, make a rule for
+  your firewall to accept connections from cni network
+  to port 53 (dns).
+
+  Now all you have to do, is make redirects to your firewall
+  and point them to 10.129.0.2 and connections from wan are
+  redirectered to containers/pods.
+
+  Protocol has 2 settings: device and delay. Sometimes polling
+  interfaces takes some time, and in that case you might want
+  to add few seconds to delay. Otherwise, it can be excluded
+  from configuration.
 endef
 
 define Build/Configure

--- a/net/cni-protocol/files/cni.sh
+++ b/net/cni-protocol/files/cni.sh
@@ -9,33 +9,50 @@
 proto_cni_init_config() {
 	no_device=0
 	available=0
-	no_proto_task=1
-	teardown_on_l3_link_down=1
 
 	proto_config_add_string "device:device"
+	proto_config_add_int "delay"
 }
 
 proto_cni_setup() {
-
 	local cfg="$1"
-	local device ipaddr netmask broadcast route routemask routesrc
+	local iface="$2"
+	local device delay
 
-	json_get_var device device
+	json_get_vars device delay
 
-	ipaddr=$(ip -4 -o a show "$device" | awk '{ print $4 }' | cut -d '/' -f1)
-	netmask=$(ip -4 -o a show "$device" | awk '{ print $4 }' | cut -d '/' -f2)
-	broadcast=$(ip -4 -o a show "$device" | awk '{ print $6 }')
-	route=$(ip -4 -o r show dev "$device" | awk '{ print $1 }' | cut -d '/' -f1)
-	routemask=$(ip -4 -o r show dev "$device" | awk '{ print $1 }' | cut -d '/' -f2)
-	routesrc=$(ip -4 -o r show dev "$device" | awk '{ print $7 }')
+	[ -n "$device" ] || {
+		echo "No cni interface specified"
+		proto_notify_error "$cfg" NO_DEVICE
+		proto_set_available "$cfg" 0
+		return 1
+	}
+
+	[ -n "$delay" ] && sleep "$delay"
+
+	[ -L "/sys/class/net/${iface}" ] || {
+		echo "The specified interface $iface is not present"
+		proto_notify_error "$cfg" NO_DEVICE
+		proto_set_available "$cfg" 0
+		return 1
+	}
+
+	local ipaddr netmask broadcast route routemask routesrc
+
+	ipaddr=$(ip -4 -o a show "$iface" | awk '{ print $4 }' | cut -d '/' -f1)
+	netmask=$(ip -4 -o a show "$iface" | awk '{ print $4 }' | cut -d '/' -f2)
+	broadcast=$(ip -4 -o a show "$iface" | awk '{ print $6 }')
+	route=$(ip -4 -o r show dev "$iface" | awk '{ print $1 }' | cut -d '/' -f1)
+	routemask=$(ip -4 -o r show dev "$iface" | awk '{ print $1 }' | cut -d '/' -f2)
+	routesrc=$(ip -4 -o r show dev "$iface" | awk '{ print $7 }')
 
 	[ -z "$ipaddr" ] && {
-		echo "cni network $cfg does not have ip address"
+		echo "interface $iface does not have ip address"
 		proto_notify_error "$cfg" NO_IPADDRESS
 		return 1
 	}
 
-	proto_init_update "$device" 1
+	proto_init_update "$iface" 1
 	[ -n "$ipaddr" ] && proto_add_ipv4_address "$ipaddr" "$netmask" "$broadcast" ""
 	[ -n "$route" ] && proto_add_ipv4_route "$route" "$routemask" "" "$routesrc" ""
 	proto_send_update "$cfg"
@@ -43,7 +60,6 @@ proto_cni_setup() {
 
 proto_cni_teardown() {
 	local cfg="$1"
-	#proto_set_available "$cfg" 0
 	return 0
 }
 


### PR DESCRIPTION
backport update cni-protocol package to 20231008 for openwrt-23.05

I have received several issue reports on difficulties and problems with podman containers with stable release version of openwrt. So I am backporting up to date versions to be able help solve these issues.

Maintainer: me
Compile tested: x86_64