### PR TITLE
openconnect: add support for option --pfs

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=9.01
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://ftp.infradead.org/pub/openconnect/

--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -20,6 +20,7 @@ proto_openconnect_init_config() {
 	proto_config_add_int "juniper"
 	proto_config_add_int "reconnect_timeout"
 	proto_config_add_string "vpn_protocol"
+	proto_config_add_boolean "pfs"
 	proto_config_add_boolean "no_dtls"
 	proto_config_add_string "interface"
 	proto_config_add_string "username"
@@ -58,6 +59,7 @@ proto_openconnect_setup() {
 		os \
 		password \
 		password2 \
+		pfs \
 		port \
 		proxy \
 		reconnect_timeout \
@@ -84,6 +86,7 @@ proto_openconnect_setup() {
 	[ -n "$port" ] && port=":$port"
 
 	append_args "$server$port" -i "$ifname" --non-inter --syslog --script /lib/netifd/vpnc-script
+	[ "$pfs" = 1 ] && append_args --pfs
 	[ "$no_dtls" = 1 ] && append_args --no-dtls
 	[ -n "$mtu" ] && append_args --mtu "$mtu"
 


### PR DESCRIPTION
Add support for the OpenConnect option `--pfs`.
Designed to require perfect forward secrecy.

Maintainer: @nmav