### PR TITLE
Fixed the AWS Route53 resolver

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/update_route53_v1.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_route53_v1.sh
@@ -13,7 +13,7 @@ RECORD_TTL=300
 RECORD_NAME="${lookup_host}."
 [ ${use_ipv6} -eq 0 ] && RECORD_TYPE="A"
 [ ${use_ipv6} -eq 1 ] && RECORD_TYPE="AAAA"
-RECORD_VALUE="${LOCAL_IP}"
+RECORD_VALUE="${__IP}"
 HOSTED_ZONE_ID="${domain}"
 API_PATH="/2013-04-01/hostedzone/${HOSTED_ZONE_ID}/rrset/"
 


### PR DESCRIPTION
Maintainer: unknown
Compile tested: ARMv8 on Linksys E8450 (UBI) running OpenWrt 23.05.0-rc4 r23482-7fe85ce1f2
Run tested: ARMv8 on Linksys E8450 (UBI) running OpenWrt 23.05.0-rc4 r23482-7fe85ce1f2. Ran ddns updater with new code.

Description:
Previously, the scripts for this resolver used the wrong local variable `LOCAL_IP` instead of the correct `__IP`. This fixes that.

