### PR TITLE
isc-dhcp: refuse to add empty DHCP ranges 

### DIFF
--- a/net/isc-dhcp/files/dhcpd.init
+++ b/net/isc-dhcp/files/dhcpd.init
@@ -374,7 +374,9 @@ gen_dhcp_subnet() {
 		echo " range $START $END;"
 	fi
 	echo " option subnet-mask $netmask;"
-	if [ "$BROADCAST" != "0.0.0.0" ] ; then
+	# check for 0.0.0.0 until all active releases of ipcalc.sh omit it
+	# for small networks:
+	if [ -n "$BROADCAST" ] && [ "$BROADCAST" != "0.0.0.0" ] ; then
 		echo " option broadcast-address $BROADCAST;"
 	fi
 	if [ "$dynamicdhcp" -eq 0 ] ; then
@@ -443,7 +445,7 @@ dhcpd_add() {
 
 	dhcp_ifs="$dhcp_ifs $ifname"
 
-	eval "$(ipcalc.sh $subnet $start $limit)"
+	ipcalc $subnet $start $limit
 
 	config_get netmask "$cfg" "netmask" "$NETMASK"
 	config_get leasetime "$cfg" "leasetime"

--- a/net/isc-dhcp/files/dhcpd.init
+++ b/net/isc-dhcp/files/dhcpd.init
@@ -445,7 +445,10 @@ dhcpd_add() {
 
 	dhcp_ifs="$dhcp_ifs $ifname"
 
-	ipcalc $subnet $start $limit
+	if ! ipcalc "$subnet" "$start" "$limit"; then
+		echo "invalid range params: $subnet start: $start limit $limit" >&2
+		return 1
+	fi
 
 	config_get netmask "$cfg" "netmask" "$NETMASK"
 	config_get leasetime "$cfg" "leasetime"


### PR DESCRIPTION
Maintainer: me
Compile tested: no
Run tested: no

Description:

With https://github.com/openwrt/openwrt/pull/12925, 'BROADCAST' will no longer be set if there is no local broadcast address (instead of setting the global broadcast address). Prepare for the merger but stay compatible with the old version of ipcalc.