### PR TITLE
[23.05] https-dns-proxy: bugfix: logging crashing instances on ath79

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2023-05-25
-PKG_RELEASE:=5
+PKG_RELEASE:=7
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/
@@ -24,6 +24,8 @@ define Package/https-dns-proxy
 	TITLE:=DNS Over HTTPS Proxy
 	URL:=https://docs.openwrt.melmac.net/https-dns-proxy/
 	DEPENDS:=+libcares +libcurl +libev +ca-bundle +jsonfilter
+	DEPENDS+=+!BUSYBOX_DEFAULT_GREP:grep
+	DEPENDS+=+!BUSYBOX_DEFAULT_SED:sed
 	CONFLICTS:=https_dns_proxy
 endef
 
@@ -45,8 +47,6 @@ define Package/https-dns-proxy/install
 	$(SED) "s|^\(readonly PKG_VERSION\).*|\1='$(PKG_VERSION)-$(PKG_RELEASE)'|" $(1)/etc/init.d/https-dns-proxy
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/etc/config/https-dns-proxy $(1)/etc/config/https-dns-proxy
-	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
-	$(INSTALL_DATA) ./files/etc/hotplug.d/iface/90-https-dns-proxy $(1)/etc/hotplug.d/iface/90-https-dns-proxy
 	$(INSTALL_DIR) $(1)/etc/uci-defaults/
 	$(INSTALL_BIN) ./files/etc/uci-defaults/50-https-dns-proxy-migrate-options.sh $(1)/etc/uci-defaults/50-https-dns-proxy-migrate-options.sh
 endef

--- a/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
+++ b/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
@@ -5,6 +5,8 @@
 # shellcheck disable=SC2034
 START=90
 # shellcheck disable=SC2034
+STOP=15
+# shellcheck disable=SC2034
 USE_PROCD=1
 
 if type extra_command 1>/dev/null 2>&1; then
@@ -250,20 +252,21 @@ start_service() {
 		output "Updating dnsmasq config "
 		if uci_commit 'dhcp'; then
 			output_okn
-		else
-			output_failn
-		fi
-		param='dnsmasq_restart'
-	fi
-	if [ "$param" = 'on_hotplug' ] || [ "$param" = 'on_boot' ] || \
-		[ "$param" = 'dnsmasq_restart' ] ; then
-		output "Restarting dnsmasq "
-		if dnsmasq_restart; then
-			output_okn
+			param='on_config_update'
 		else
 			output_failn
 		fi
 	fi
+	case "$param" in
+		on_boot|on_config_update|on_hotplug)
+			output "Restarting dnsmasq ${param:+$param }"
+			if dnsmasq_restart; then
+				output_okn
+			else
+				output_failn
+			fi
+		;;
+	esac
 }
 
 stop_service() {
@@ -291,29 +294,13 @@ stop_service() {
 	[ "$s" = '0' ] && output_okn || output_failn
 }
 
-# shellcheck disable=SC1091
 service_triggers() {
-	local wan wan6 i
-	local procd_trigger_wan6
-	config_load "$packageName"
-	config_get_bool procd_trigger_wan6 'config' 'procd_trigger_wan6' '0'
-	. /lib/functions/network.sh
-	network_flush_cache
-	network_find_wan wan
-	wan="${wan:-wan}"
-	if [ "$procd_trigger_wan6" -ne 0 ]; then
-		network_find_wan6 wan6
-		wan6="${wan6:-wan6}"
-	fi
-	for i in "$wan" "$wan6"; do
-		[ -n "$i" ] && procd_add_interface_trigger "interface.*" "$i" "/etc/init.d/${packageName}" restart
-	done
-	procd_add_config_trigger "config.change" "$packageName" "/etc/init.d/${packageName}" reload
+	procd_add_raw_trigger "interface.*.up" 3000 "/etc/init.d/${packageName}" restart 'on_interface_up'
+	procd_add_config_trigger "config.change" "$packageName" "/etc/init.d/${packageName}" reload 'on_config_change'
 }
-
 service_started() { procd_set_config_changed firewall; }
 service_stopped() { procd_set_config_changed firewall; }
-restart() { procd_send_signal "$packageName"; rc_procd start_service; }
+restart() { procd_send_signal "$packageName"; rc_procd start_service "$*"; }
 
 dnsmasq_doh_server() {
 	local cfg="$1" param="$2" address="${3:-127.0.0.1}" port="$4" i

--- a/net/https-dns-proxy/patches/030-src-logging.c-fix-crash.patch
+++ b/net/https-dns-proxy/patches/030-src-logging.c-fix-crash.patch
@@ -1,0 +1,11 @@
+--- a/src/logging.c
++++ b/src/logging.c
+@@ -78,7 +78,7 @@ void _log(const char *file, int line, in
+ 
+   struct timeval tv;
+   gettimeofday(&tv, NULL);
+-  fprintf(logf, "%s %8lu.%06lu %s:%d ", SeverityStr[severity],
++  fprintf(logf, "%s %8llu.%06llu %s:%d ", SeverityStr[severity],
+           (uint64_t)tv.tv_sec,
+           (uint64_t)tv.tv_usec, file, line);
+ 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0

Description:
* finally fixes https://github.com/openwrt/packages/issues/19366
* simplify service_triggers
* improve output for dnsmasq restart
* improve grep/sed dependencies
* remove interface hotplug

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 38c026250f2bdae36fbd5bba6a9d529fb7082ed1)
