### PR TITLE
apinger.init: fixed bug in append_alarm_loss(), percent_high was set …

### DIFF
--- a/net/apinger/files/apinger.init
+++ b/net/apinger/files/apinger.init
@@ -54,10 +54,15 @@ append_target() {
 	config_get_bool rrd               "$target" rrd 0
 
 	[ -z "$address" ] && return 0
-
-	srcip=$(uci_get network "$interface" ipaddr)
-	[ -z "$srcip" ] && network_get_ipaddr srcip "$interface"
-	srcip="${srcip:-0.0.0.0}"
+	if [ -z $(echo "$address"|sed "/:/d") ]; then
+		srcip=$(uci_get network "$interface" ip6addr)
+		[ -z "$srcip"] && network_get_ipaddr6 srcip "$interface"
+		srcip="${srcip:-::}"
+	else
+		srcip=$(uci_get network "$interface" ipaddr)
+		[ -z "$srcip"] && network_get_ipaddr srcip "$interface"
+		srcip="${srcip:-0.0.0.0}"
+	fi
 
 	alarms=${alarm_down:+\"${alarm_down}\"}
 	alarms=${alarm_delay:+${alarms:+${alarms}, }}${alarm_delay:+\"${alarm_delay}\"}
@@ -115,7 +120,7 @@ append_alarm_loss() {
 	local percent_low percent_high
 
 	config_get percent_low  "$alarm" percent_low
-	config_get percent_high "$alarm" percent_low
+	config_get percent_high "$alarm" percent_high
 
 	if [ -z "$percent_low" ] || [ -z "$percent_high" ]; then
 		return
@@ -132,9 +137,9 @@ init_apinger_config() {
 	local debug status_interval rrd_interval instance
 	instance=$1
 
-	config_get_bool debug             apinger debug 0
-	config_get      status_interval   apinger status_interval 1
-	config_get      rrd_interval      apinger rrd_interval 30
+	config_get_bool debug             "$instance" debug 0
+	config_get      status_interval   "$instance" status_interval 1
+	config_get      rrd_interval      "$instance" rrd_interval 30
 
 	[ "$debug" = "1" ] && debug=on || debug=off
 

--- a/net/apinger/files/apinger.rpc
+++ b/net/apinger/files/apinger.rpc
@@ -38,7 +38,7 @@ apinger_status() {
 		if [ -f "$status_file" ]; then
 			_IFS="$IFS"
 			IFS="|"
-			while read -r address srcip target received sent timestamp latency loss alarm; do
+			while read -r address srcip target sent received timestamp latency loss alarm; do
 				json_add_object targets
 				json_add_string interface "$iface"
 				json_add_string target "$target"


### PR DESCRIPTION
apinger.init: fixed bug in init_apinger_config - debug/status_interval/rrd_interval were never set correctly
apinger.init: added ability to use ipv6 on wan6 (has to be fixed in luci-app-apinger as well)
apinger.rpc: fixed bug in apinger_status(), send and receive were swapped

Maintainer: @hnyman @samm-git
Compile tested: ARMv8 Processor rev 4, FriendlyElec NanoPi R4S, OpenWrt 22.03.3
Run tested: ARMv8 Processor rev 4, FriendlyElec NanoPi R4S, OpenWrt 22.03.3
