### PR TITLE
[23.05] node: Friday October 13 2023 Security Releases

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v18.18.1
+PKG_VERSION:=v18.18.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=c3c95047ec0c2b2063a5ea4b4f71ee807f6075d1dbeae4f3207cda4b9ae782f6
+PKG_HASH:=7249e2f0af943ec38599504f4b2a2bd31fb938787291b6ccca6c8badf01e3b56
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: 23.05, aarch64, arm 
Run tested: (qemu 8.1.2) aarch64

Description:

This is a security release.
Notable Changes
The following CVEs are fixed in this release:
* CVE-2023-44487: nghttp2 Security Release (High) (Depends on shared library provided by OpenWrt)
* CVE-2023-45143: undici Security Release (High)
* CVE-2023-38552: Integrity checks according to policies can be circumvented (Medium)
* CVE-2023-39333: Code injection via WebAssembly export names (Low)
 
More detailed information on each of the vulnerabilities can be found in October 2023 Security Releases blog post.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
(cherry picked from commit 9101a21e535d2247b3fb85e0660f7bb0dd4a4290)
