### PR TITLE
net-snmp: backport patch fixing memory leak for PCRE2

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.9.1
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp

--- a/net/net-snmp/patches/203-if-mib-data_access-interface.c-plug-a-leak-with-pcre.patch
+++ b/net/net-snmp/patches/203-if-mib-data_access-interface.c-plug-a-leak-with-pcre.patch
@@ -1,0 +1,30 @@
+From e5aadf1e78c624a8e4147d4b70a7795497a50e73 Mon Sep 17 00:00:00 2001
+From: Niels Baggesen <nba@users.sourceforge.net>
+Date: Mon, 22 May 2023 18:44:36 +0200
+Subject: [PATCH] if-mib/data_access/interface.c: plug a leak with pcre2
+
+---
+ agent/mibgroup/if-mib/data_access/interface.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/agent/mibgroup/if-mib/data_access/interface.c
++++ b/agent/mibgroup/if-mib/data_access/interface.c
+@@ -845,7 +845,7 @@ int netsnmp_access_interface_include(con
+ {
+     netsnmp_include_if_list *if_ptr;
+ #if defined(HAVE_PCRE2_H)
+-    pcre2_match_data *ndx_match = pcre2_match_data_create(3, NULL);
++    pcre2_match_data *ndx_match;
+ #elif defined(HAVE_PCRE_H)
+     int                      found_ndx[3];
+ #endif
+@@ -860,6 +860,9 @@ int netsnmp_access_interface_include(con
+          */
+         return TRUE;
+ 
++#if defined(HAVE_PCRE2_H)
++    ndx_match = pcre2_match_data_create(3, NULL);
++#endif
+ 
+     for (if_ptr = include_list; if_ptr; if_ptr = if_ptr->next) {
+ #if defined(HAVE_PCRE2_H)


### PR DESCRIPTION
Backport patch fixing memory leak for PCRE2 present upstream.

Fixes: #22428

---

@stintel 