### PR TITLE
iperf3: Fix dependecy conflict with iperf3-ssl

### DIFF
--- a/net/iperf3/Makefile
+++ b/net/iperf3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
 PKG_VERSION:=3.15
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.es.net/pub/iperf
@@ -46,6 +46,7 @@ $(call Package/iperf3/default)
   TITLE+= with iperf_auth support
   VARIANT:=ssl
   DEPENDS:=+libopenssl
+  CONFLICTS:=iperf3
 endef
 
 define Package/libiperf3


### PR DESCRIPTION
When selecting both iperf3 and iperf3 ssl, there is a problem that both packages install same binary file.
This patch fixes this issue by adding conflict between those packages.

Maintainer: Felix Fietkau @nbd168 
Compile tested: aarch64 / 2023-10-18 snapshot
Run tested: aarch64, raspberry Pi 4, 2023-10-18 snapshot

Description:
This fixes conflict when building Iperf3 by adding appropriate dependencies/conflicts.