### PR TITLE
statserial: Add package

### DIFF
--- a/utils/statserial/Makefile
+++ b/utils/statserial/Makefile
@@ -1,0 +1,39 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=statserial
+PKG_VERSION:=1.1-25
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://salsa.debian.org/debian/statserial.git
+PKG_SOURCE_VERSION:=debian/$(PKG_VERSION)
+PKG_MIRROR_HASH:=d493fd3154de4e52811e1d4f2ee68d573b1bcc24b58089b3b3dc41461357920e
+
+PKG_MAINTAINER:=Jakub Raczynski <myszsoda@gmail.com>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/statserial
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=statserial
+  URL:=https://salsa.debian.org/debian/statserial
+  DEPENDS:=+libncurses
+endef
+
+define Package/statserial/description
+ Display serial port modem status lines.
+
+ Statserial displays a table of the signals on a standard 9-pin or
+ 25-pin serial port, and indicates the status of the handshaking lines.
+ It can be useful for debugging problems with serial ports or modems.
+endef
+
+define Package/statserial/install
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/statserial $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,statserial))

--- a/utils/statserial/patches/001-fix_compilation.patch
+++ b/utils/statserial/patches/001-fix_compilation.patch
@@ -1,0 +1,22 @@
+--- a/Makefile
++++ b/Makefile
+@@ -1,16 +1,11 @@
+-CC	= gcc
+-LD	= gcc
+-
+ # for debug
+-#CFLAGS	= -Wall -g
+-#LDFLAGS = -N
++#CFLAGS	= -Wall -O0 -g
+ 
+ # for production code
+-CFLAGS	= -Wall -O3 -fomit-frame-pointer
+-LDFLAGS = -s -N
++CFLAGS	+= -Wall -O3 -fomit-frame-pointer
+ 
+ statserial:	statserial.o
+-	$(LD) $(LDFLAGS) -o statserial statserial.o -lcurses
++	$(CC) $(LDFLAGS) -o statserial statserial.o -lncurses
+ 
+ statserial.o: statserial.c
+ 	$(CC) $(CFLAGS) -c statserial.c


### PR DESCRIPTION
Description (from https://linux.die.net/man/1/statserial):
 Statserial displays a table of the signals on a standard 9-pin or
 25-pin serial port, and indicates the status of the handshaking lines.
 It can be useful for debugging problems with serial ports or modems.

 The optional device-name parameter is the full name of the device file for
 the serial port in question. If not specified, the default is taken from
 the environment variable MODEM if set, otherwise /dev/cua1.

This package is fork of https://salsa.debian.org/debian/statserial

Maintainer: me
Compile tested: aarch64 / 2023-10-18 snapshot
Run tested: aarch64, raspberry Pi 4, 2023-10-18 snapshot

Description:
This pull request does add statserial package available on debian/Ubuntu. 