### PR TITLE
ngtcp2: add new package

### DIFF
--- a/libs/ngtcp2/Makefile
+++ b/libs/ngtcp2/Makefile
@@ -1,0 +1,39 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ngtcp2
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/ngtcp2/ngtcp2/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=a40b18af654baaebee3431af9bb4e347f40080bf1189d658ad53f8e66bf39da3
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
+
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/libngtcp2
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Implementation of QUIC protocol
+  URL:=https://nghttp2.org/ngtcp2
+  DEPENDS:=+libnghttp3 +libopenssl
+endef
+
+define Package/libngtcp2/description
+ ngtcp2 project is an effort to implement QUIC protocol which is now being discussed in IETF QUICWG for its standardization.
+endef
+
+CMAKE_OPTIONS += -DENABLE_LIB_ONLY=ON
+
+define Package/libngtcp2/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libngtcp2*.so* $(1)/usr/lib
+endef
+
+$(eval $(call BuildPackage,libngtcp2))


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0

Description:
* add new package to allow building of curl with HTTP/3 support

PS. I'd like to solicit feedback on cherry-picking it for 23.05 as well.