### PR TITLE
conntrack-tools: update to 1.4.8

### DIFF
--- a/net/conntrack-tools/Makefile
+++ b/net/conntrack-tools/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=conntrack-tools
-PKG_VERSION:=1.4.7
+PKG_VERSION:=1.4.8
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.netfilter.org/projects/conntrack-tools/files
-PKG_HASH:=099debcf57e81690ced57f516b493588a73518f48c14d656f823b29b4fc24b5d
+PKG_HASH:=067677f4c5f6564819e78ed3a9d4a8980935ea9273f3abb22a420ea30ab5ded6
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Release Notes:
https://marc.info/?l=netfilter&m=169598613909790&w=2

Furthermore, switch to "tar.xz".

Maintainer: @jow
Compile tested: mt7622
Run tested: tbd
