### PR TITLE
xtables-addons: fix broken compile with external Toolchain

### DIFF
--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -41,15 +41,6 @@ CONFIGURE_ARGS+= \
 	--with-kbuild="$(LINUX_DIR)" \
 	--with-xtlibdir="/usr/lib/iptables"
 
-ifdef CONFIG_EXTERNAL_TOOLCHAIN
-MAKE_FLAGS:= \
-	$(patsubst ARCH=%,ARCH=$(LINUX_KARCH),$(MAKE_FLAGS)) \
-	DEPMOD="/bin/true"
-
-MAKE_INSTALL_FLAGS:= \
-	$(patsubst ARCH=%,ARCH=$(LINUX_KARCH),$(MAKE_FLAGS)) \
-	DEPMOD="/bin/true"
-else
 define Build/Compile
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
 		$(KERNEL_MAKE_FLAGS) \
@@ -65,7 +56,6 @@ define Build/Install
 		DEPMOD="/bin/true" \
 		install
 endef
-endif
 
 # 1: extension/module suffix used in package name
 # 2: extension/module display name used in package title/description


### PR DESCRIPTION
Fix broken compile with external Toolchain.

Commit 32aaaaa7d379 ("xtables-addons: pass correct flags to compile and install") simplified and dropped the custom Compile/Install in favor of the default one. Problem is that it dropped DESTDIR resulting in the package having problem on finishing install.

The commit then was reworked with c83b8787a5f8 ("xtables-addons: adapt build to EXTERNAL_TOOLCHAIN" that reintroduced DESTDIR and also introduced a useless custom flag to fix wrong ARCH.

ARCH is fixed by kernel.mk and doesn't depend on external Toolchain or not. For ARCH that require fixing, kernel.mk should be fixed instead of adding custom function to packages Makefile.

The real problem was overwriting the MAKE_FLAGS and MAKE_INSTALL_FLAGS
instead of simply appending the additional required options.

Drop the custom Compile/Install and add the missing DESTDIR to the MAKE flags.

Fixes: 32aaaaa7d379 ("xtables-addons: pass correct flags to compile and install")
Fixes: c83b8787a5f8 ("xtables-addons: adapt build to EXTERNAL_TOOLCHAIN")

---

@cotequeiroz @ptpt52 @swg0101 can you test
