### PR TITLE
rust: Allow to specify a separate download folder for rust packages

### DIFF
--- a/lang/rust/Config.in
+++ b/lang/rust/Config.in
@@ -12,4 +12,19 @@ config RUST_SCCACHE_DIR
 	  Store sccache in this directory.
 	  If not set, uses './.sccache'
 
+config RUST_DOWNLOAD_SEPARATE
+	bool "Use separate download folder"
+	help
+	  By default, the rust downloads are stored in the rustc
+	  subdirectory of the openwrt download folder. However, this can
+	  cause problems if the download directory is not local but is an
+	  nfs mount.
+
+config RUST_DOWNLOAD_FOLDER
+	string "Rust download folder" if RUST_DOWNLOAD_SEPARATE
+	default ""
+	help
+	  Please specify a folder if the download folder for rust packages
+	  should be different than for openwrt packages.
+
 endmenu

--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -86,7 +86,7 @@ endef
 define Host/Compile
 	$(RUST_SCCACHE_VARS) \
 	CARGO_HOME=$(CARGO_HOME) \
-	OPENWRT_RUSTC_BOOTSTRAP_CACHE=$(DL_DIR)/rustc \
+	OPENWRT_RUSTC_BOOTSTRAP_CACHE=$(RUST_DOWNLOAD_FOLDER)/rustc \
 	$(PYTHON) $(HOST_BUILD_DIR)/x.py \
 		--build-dir $(HOST_BUILD_DIR)/build \
 		--config $(HOST_BUILD_DIR)/config.toml \

--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -5,7 +5,14 @@
 # Rust Environmental Vars
 RUSTC_HOST_SUFFIX:=$(word 4, $(subst -, ,$(GNU_HOST_NAME)))
 RUSTC_HOST_ARCH:=$(HOST_ARCH)-unknown-linux-$(RUSTC_HOST_SUFFIX)
-CARGO_HOME:=$(DL_DIR)/cargo
+
+ifeq ($(CONFIG_RUST_DOWNLOAD_FOLDER),)
+  RUST_DOWNLOAD_FOLDER:=$(DL_DIR)/rustc
+else
+  RUST_DOWNLOAD_FOLDER:=$(call qstrip,$(CONFIG_RUST_DOWNLOAD_FOLDER))
+endif
+
+CARGO_HOME:=$(RUST_DOWNLOAD_FOLDER)/cargo
 
 ifeq ($(CONFIG_USE_MUSL),y)
   # Force linking of the SSP library for musl


### PR DESCRIPTION
Maintainer: @jefferyto 
Compile tested: x86_64, -- , OpenWrt master
Run tested: not needed only build changes

Description:
By default, the rust downloads are stored in the rustc/cargo subdirectory of the openwrt default download folder. However, this can cause problems if the download directory is not local but is an nfs mount.

Fix this by adding a new configuration option to openwrt to change the default download folder for rust packages.

My [research](https://stackoverflow.com/questions/42392600/oserror-errno-18-invalid-cross-device-link) has shown that the problem is the nfs mount.


Build error if dl ist on a ntfs mount:
````
   Compiling xz2 v0.1.7
   Compiling build_helper v0.1.0 (/home/bbworker/bbworker/owrt_dev_x86_64/System6/build/openwrt/build_dir/target-x86_64_musl/host/rustc-1.73.0-src/src/tools/build_helper)
    Finished dev [unoptimized] target(s) in 17.44s
downloading https://ci-artifacts.rust-lang.org/rustc-builds/cc66ad468955717ab92600c770da8c1601a4ff33/rust-dev-1.73.0-x86_64-unknown-linux-gnu.tar.xz
#=#=#                                                                         
##                                                                         3.7%
#####                                                                      8.1%
#########                                                                 12.6%
############                                                              17.0%
###############                                                           21.7%
##################                                                        26.2%
######################                                                    30.6%
#########################                                                 35.1%
############################                                              39.5%
###############################                                           44.0%
##################################                                        48.4%
#####################################                                     52.5%
########################################                                  56.7%
###########################################                               61.1%
###############################################                           65.3%
##################################################                        69.7%
#####################################################                     74.0%
########################################################                  78.3%
###########################################################               82.7%
##############################################################            87.1%
#################################################################         91.3%
####################################################################      95.6%
#######################################################################   99.8%
######################################################################## 100.0%
thread 'main' panicked at 'std::fs::rename(&tempfile, dest_path) failed with Invalid cross-device link (os error 18)', download.rs:205:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Build completed unsuccessfully in 0:00:27
make[4]: *** [Makefile:108: /home/bbworker/bbworker/owrt_dev_x86_64/System6/build/openwrt/build_dir/target-x86_64_musl/host/rustc-1.73.0-src/.built] Error 1
time: package/feeds/packages/rust/host-compile#65.55#10.02#35.76
````