### PR TITLE
crowdsec-firewall-bouncer: add ujail

### DIFF
--- a/net/crowdsec-firewall-bouncer/Makefile
+++ b/net/crowdsec-firewall-bouncer/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crowdsec-firewall-bouncer
 PKG_VERSION:=0.0.28
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/crowdsecurity/cs-firewall-bouncer/tar.gz/v$(PKG_VERSION)?

--- a/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.initd
+++ b/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.initd
@@ -210,6 +210,13 @@ run_bouncer() {
 		procd_set_param command "$PROG" -c "$VARCONFIG"
 		procd_set_param stdout 1
 		procd_set_param stderr 1
+		procd_set_param nice 10
+		if [ -x "/sbin/ujail" ]; then
+			procd_add_jail cs-bouncer log
+			procd_add_jail_mount $VARCONFIG
+			procd_add_jail_mount_rw /var/log/
+			procd_set_param no_new_privs 1
+		fi
 		procd_close_instance
 	fi
 }


### PR DESCRIPTION
Updated initd script

Signed-off-by: S. Brusch <ne20002@gmx.ch>

Maintainer: Kerma Gérald <gandalf@gk2.net>
Run tested: mediatek/filogic, BPI-R3, Openwrt 23.05.0

Description:
* added ujail for crowdsec-firewall-bouncer
* set nice to reduce priority for process

