### PR TITLE
strongswan: add eap-dynamic plugin

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/
@@ -41,6 +41,7 @@ PKG_MOD_AVAILABLE:= \
 	dnskey \
 	drbg \
 	duplicheck \
+	eap-dynamic \
 	eap-identity \
 	eap-md5 \
 	eap-mschapv2 \
@@ -183,6 +184,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-dnskey \
 	+strongswan-mod-drbg \
 	+strongswan-mod-duplicheck \
+	+strongswan-mod-eap-dynamic \
 	+strongswan-mod-eap-identity \
 	+strongswan-mod-eap-md5 \
 	+strongswan-mod-eap-mschapv2 \
@@ -681,6 +683,7 @@ $(eval $(call BuildPlugin,dhcp,DHCP based attribute provider,))
 $(eval $(call BuildPlugin,dnskey,DNS RR key decoding,))
 $(eval $(call BuildPlugin,drbg,Deterministic random bit generator,,))
 $(eval $(call BuildPlugin,duplicheck,advanced duplicate checking,))
+$(eval $(call BuildPlugin,eap-dynamic,EAP dynamic selector,))
 $(eval $(call BuildPlugin,eap-identity,EAP identity helper,))
 $(eval $(call BuildPlugin,eap-md5,EAP MD5 (CHAP) EAP auth,))
 $(eval $(call BuildPlugin,eap-mschapv2,EAP MS-CHAPv2 EAP auth,+strongswan-mod-md4 +strongswan-mod-des))


### PR DESCRIPTION
Maintainer: @pprindeville @Thermi
Compile tested: x86_64, 23.05.0
Run tested: x86_64, 23.05.0, configured the `eap-dynamic` as authentication method for a connection. MacOS Sonoma native VPN client connected using `eap-tls`, while Android phone native VPN client is using `eap-mschapv2`.

```
# swanctl --stats
uptime: 2 hours, since Oct 22 09:03:55 2023
worker threads: 16 total, 11 idle, working: 4/0/1/0
job queues: 0/0/0/0
jobs scheduled: 0
IKE_SAs: 0 total, 0 half-open
loaded plugins: charon aes des rc2 sha2 sha1 md4 md5 mgf1 random nonce x509 revocation constraints pubkey pkcs1 pgp dnskey sshkey pem openssl fips-prf gmp xcbc hmac attr kernel-netlink resolve socket-default connmark vici updown eap-identity eap-mschapv2 eap-dynamic eap-tls xauth-generic
```

Description:

This plugin acts as a proxy that dynamically selects an EAP method that is supported/preferred by the client. If the original EAP method initiated by the plugin is rejected with an EAP-NAK message, it will select a different method that is supported/requested by the client.

For example it is possible to configure eap-tls as preferred authentication method for your connection while still allow eap-mschapv2.