### PR TITLE
shadowsocks-rust: add new package

### DIFF
--- a/net/shadowsocks-rust/Makefile
+++ b/net/shadowsocks-rust/Makefile
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2017-2020 Yousong Zhou <yszhou4tech@gmail.com>
+# Copyright (C) 2021-2023 ImmortalWrt.org
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=shadowsocks-rust
+PKG_VERSION:=1.17.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/shadowsocks/shadowsocks-rust/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=ef964ac60a499a0c8313d48284a7542c085f9c7672eb121a796b70d49163f35a
+
+PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=rust/host
+PKG_BUILD_PARALLEL:=1
+
+RUST_PKG_FEATURES:=aead-cipher-2022,local-http,local-redir,local-tun,local-tunnel
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/shadowsocks-rust/Default
+  define Package/shadowsocks-rust-$(1)
+    SECTION:=net
+    CATEGORY:=Network
+    SUBMENU:=Web Servers/Proxies
+    TITLE:=shadowsocks-rust $(1)
+    URL:=https://shadowsocks.org/
+    DEPENDS:=$$(RUST_ARCH_DEPENDS)
+  endef
+
+  define Package/shadowsocks-rust-$(1)/description
+    Shadowsocks is a fast tunnel proxy that helps you bypass firewalls.
+
+    This package contains the $(1).
+  endef
+
+  define Package/shadowsocks-rust-$(1)/install
+	$$(INSTALL_DIR) $$(1)/usr/bin
+	$$(INSTALL_BIN) $$(PKG_INSTALL_DIR)/bin/$(1) $$(1)/usr/bin/
+  endef
+endef
+
+SHADOWSOCKS_COMPONENTS:=sslocal ssmanager ssserver ssurl ssservice
+define shadowsocks-rust/templates
+  $(foreach component,$(SHADOWSOCKS_COMPONENTS),
+    $(call Package/shadowsocks-rust/Default,$(component))
+  )
+endef
+$(eval $(call shadowsocks-rust/templates))
+
+$(foreach component,$(SHADOWSOCKS_COMPONENTS), \
+  $(eval $(call BuildPackage,shadowsocks-rust-$(component))) \
+)


### PR DESCRIPTION
Maintainer: me
Compile tested: all targets
Run tested: ipq40xx/generic, mediatek/filogic, rockchip/armv8, x86/64 etc.

Description:
The rust port of shadowsocks, designed to replace the old libev implementation.

Ref: #22356