### PR TITLE
exim: update to version 4.96.2

### DIFF
--- a/mail/exim/Makefile
+++ b/mail/exim/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=exim
-PKG_VERSION:=4.96.1
+PKG_VERSION:=4.96.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ftp.exim.org/pub/exim/exim4/
-PKG_HASH:=93ac0755c317e1fdbbea8ccb70a868876bdf3148692891c72ad0fe816767033d
+PKG_HASH:=038e327e8d1e93d005bac9bb06fd22aec44d5028930d6dbe8817ad44bbfc1de6
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 
 PKG_LICENSE:=GPL-2.0-or-later

--- a/mail/exim/patches/100-localscan_dlopen.patch
+++ b/mail/exim/patches/100-localscan_dlopen.patch
@@ -287,7 +287,7 @@ Last-Update: 2021-07-28
  #endif
 --- a/src/string.c
 +++ b/src/string.c
-@@ -418,6 +418,7 @@ return ss;
+@@ -428,6 +428,7 @@ return ss;
  
  #if (defined(HAVE_LOCAL_SCAN) || defined(EXPAND_DLFUNC)) \
  	&& !defined(MACRO_PREDEF) && !defined(COMPILE_UTILITY)
@@ -295,7 +295,7 @@ Last-Update: 2021-07-28
  /*************************************************
  *            Copy and save string                *
  *************************************************/
-@@ -463,6 +464,7 @@ string_copyn_function(const uschar * s,
+@@ -473,6 +474,7 @@ string_copyn_function(const uschar * s,
  {
  return string_copyn(s, n);
  }


### PR DESCRIPTION
Maintainer: me
Compile tested: -
Run tested: -

Description:
Fixes vulnerabilities:
 - Improper Neutralization of Special Elements (CVE-2023-42117)
 - dnsdb Out-Of-Bounds Read (CVE-2023-42119)
