### PR TITLE
Modemmanager fix race condition

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_SOURCE_VERSION:=1.22.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_SOURCE_VERSION:=1.22.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/modemmanager.common
+++ b/net/modemmanager/files/modemmanager.common
@@ -319,9 +319,6 @@ mm_report_event_from_cache_line() {
 }
 
 mm_report_events_from_cache() {
-	# Remove the sysfs cache
-	rm -f "${MODEMMANAGER_SYSFS_CACHE}"
-
 	local n=60
 	local step=1
 	local mmrunning=0
@@ -345,6 +342,9 @@ mm_report_events_from_cache() {
 		mm_log "error" "couldn't report initial kernel events: ModemManager not running"
 		return
 	}
+
+	# Remove the sysfs cache
+	rm -f "${MODEMMANAGER_SYSFS_CACHE}"
 
 	# Report cached kernel events
 	while IFS= read -r event_line; do

--- a/net/modemmanager/files/modemmanager.common
+++ b/net/modemmanager/files/modemmanager.common
@@ -277,7 +277,7 @@ mm_report_event() {
 	local sysfspath="$4"
 
 	# Do not save virtual devices
-	local virtual
+	local virtual result
 	virtual="$(echo "$sysfspath" | cut -d'/' -f4)"
 	[ "$virtual" = "virtual" ] && {
 		mm_log "debug" "sysfspath is a virtual device ($sysfspath)"
@@ -298,11 +298,15 @@ mm_report_event() {
 	esac
 
 	# Report the event
-	mm_log "debug" "event reported: action=${action}, name=${name}, subsystem=${subsystem}"
-	mmcli --report-kernel-event="action=${action},name=${name},subsystem=${subsystem}" 1>/dev/null 2>&1 &
+	mm_log "debug" "Report event: action=${action}, name=${name}, subsystem=${subsystem}"
+	result=$(mmcli --report-kernel-event="action=${action},name=${name},subsystem=${subsystem}" 2>&1)
+	if [ "$?" -eq "0" ]; then
+		# Wait for added modem if a sysfspath is given
+		[ -n "${sysfspath}" ] && [ "$action" = "add" ] && mm_report_modem_wait "${sysfspath}"
+	else
+		mm_log "error" "Couldn't report kernel event: ${result}"
+	fi
 
-	# Wait for added modem if a sysfspath is given
-	[ -n "${sysfspath}" ] && [ "$action" = "add" ] && mm_report_modem_wait "${sysfspath}"
 }
 
 mm_report_event_from_cache_line() {


### PR DESCRIPTION
Maintainer: @mips171. Please also have a look at this change @aleksander0m
Compile tested: x86_64, lantiq_xrx200 latest openwrt master
Run tested:  x86_64, lantiq_xrx200 latest openwrt master, test done = yes

On slower targets, it can happen that modems are not recognized correctly. During startup, the sysfs_cache is cleared, and then it waits for mmcli -L to complete. If a hotplug event occurs during this waiting time, the device attempts to report itself. However, the mmcli --report-kernel-event command fails, but it is still marked as "processed" in the sysfs cache. As a result, the modem is never further processed.
To address this issue, I propose two commits:

1. [remove sysfscache after dbus ready](https://github.com/openwrt/packages/commit/4125f74085dadc8bbc8a9133eda5246ab0a82d62)
2. [check status of report-kernel-event](https://github.com/openwrt/packages/commit/04e5ecbd7f0dff191a118d6653e021a439b9b8f6)