### PR TITLE
modemmanager improve cleanup

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_SOURCE_VERSION:=1.22.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_SOURCE_VERSION:=1.22.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/modemmanager.common
+++ b/net/modemmanager/files/modemmanager.common
@@ -235,24 +235,20 @@ mm_report_modem_wait() {
 # Cleanup interfaces
 
 mm_cleanup_interfaces() {
-	local modemlist modemlength idx modeminfo modemsysfspath
+	local sysfs_path status
 
-	modemlist=$(mmcli --list-modems --output-keyvalue)
-	[ -n "${modemlist}" ] || return 0
+	# Do nothing if there is no sysfs cache
+	[ -f "${MODEMMANAGER_SYSFS_CACHE}" ] || return
 
-	modemlength=$(modemmanager_get_field "${modemlist}" "modem-list.length")
+	while IFS= read -r sysfs_cache_line; do
+		sysfs_path=$(echo "${sysfs_cache_line}" | awk '{print $1}')
+		status=$(echo "${sysfs_cache_line}" | awk '{print $2}')
 
-	# do nothing if no modem reported
-	[ -n "${modemlength}" ] && [ "${modemlength}" -ge 1 ] && {
-		idx=1
-		while [ $idx -le "$modemlength" ]; do
-			modempath=$(modemmanager_get_field "${modemlist}" "modem-list.value\[$idx\]")
-			modeminfo=$(mmcli --modem "${modempath}" --output-keyvalue)
-			modemsysfspath=$(modemmanager_get_field "${modeminfo}" "modem.generic.device")
-			mm_cleanup_interface_by_sysfspath "${modemsysfspath}"
-			idx=$((idx + 1))
-		done
-	}
+		if [ "${status}" = "processed" ]; then
+			mm_log "debug" "call cleanup for: ${sysfs_path}"
+			mm_cleanup_interface_by_sysfspath "${sysfs_path}"
+		fi
+	done < ${MODEMMANAGER_SYSFS_CACHE}
 }
 
 mm_cleanup_interface_by_sysfspath() {

--- a/net/modemmanager/files/modemmanager.init
+++ b/net/modemmanager/files/modemmanager.init
@@ -6,13 +6,6 @@ START=70
 
 LOG_LEVEL="INFO"
 
-stop_service() {
-	# Load common utils
-	. /usr/share/ModemManager/modemmanager.common
-	# Set all configured interfaces as unavailable
-	mm_cleanup_interfaces
-}
-
 start_service() {
 	# Setup ModemManager service
 	#

--- a/net/modemmanager/files/usr/sbin/ModemManager-wrapper
+++ b/net/modemmanager/files/usr/sbin/ModemManager-wrapper
@@ -20,7 +20,6 @@ main() {
 
 	mkdir -p "${MODEMMANAGER_RUNDIR}"
 	chmod 0755 "${MODEMMANAGER_RUNDIR}"
-	mm_cleanup_interfaces
 
 	/usr/sbin/ModemManager "$@" 1>/dev/null 2>/dev/null &
 	CHILD="$!"
@@ -28,6 +27,9 @@ main() {
 	mm_report_events_from_cache
 
 	wait "$CHILD"
+
+	# Set all configured interfaces as unavailable
+	mm_cleanup_interfaces
 }
 
 main "$@"


### PR DESCRIPTION
Maintainer: @mips171. Please also have a look at this change @aleksander0m
Compile tested: x86_64, lantiq_xrx200 latest openwrt master
Run tested: x86_64, lantiq_xrx200 latest openwrt master, test done = yes

There are situations where the cleanup of interfaces doesn't work as expected. For instance, when ModemManager crashes, cleanup is not triggered. Even if cleanup were to be triggered, the interfaces cannot be queried because the mmcli command is no longer available after a crash. To address this issue, I propose two commits:
1. [ improve cleanup of ifaces](https://github.com/openwrt/packages/commit/0d7a557462702617f73cb17b34aa2e2149ed3151)
2. [move iface cleanup to wrapper script](https://github.com/openwrt/packages/commit/c49aff8595dfaa765f8049dc59bee597eff64d56)