### PR TITLE
restic-rest-server: update to 0.12.1

### DIFF
--- a/net/restic-rest-server/Makefile
+++ b/net/restic-rest-server/Makefile
@@ -1,13 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=restic-rest-server
-PKG_VERSION:=0.11.0
-PKG_RELEASE:=2
+PKG_VERSION:=0.12.1
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/rest-server-$(PKG_VERSION)
 PKG_SOURCE:=rest-server-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/restic/rest-server/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=cd9b35ad2224244207a967ebbc78d84f4298d725e95c1fa9341ed95a350ea68f
+PKG_HASH:=cfbeb4a66cac6fc36b1cb11256f06c6e4fcc7a28c2ef590550adf1c199b9aa4b
 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: Tom Stöveken <tom@naaa.de>
Compile tested: Ubuntu 23.04 x64 / OpenWrt SNAPSHOT @ 6cf27094e9209250dbd45f8b042530c3b23f0a42
Run tested: Linksys WRT32X / OpenWrt SNAPSHOT r24002-e3559fb445

Description:

update to [0.12.1](https://github.com/restic/rest-server/compare/v0.11.0...v0.12.1)

cc: @Torxgewinde 