### PR TITLE
rust: Fix compile error if build dir and DL_DIR on separate filesystems, compile error for mipsel_24kc+24kf

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
 PKG_VERSION:=1.73.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
@@ -18,6 +18,7 @@ PKG_LICENSE:=Apache-2.0 MIT
 PKG_LICENSE_FILES:=LICENSE-APACHE LICENSE-MIT
 
 PKG_HOST_ONLY:=1
+PKG_BUILD_FLAGS:=no-mips16
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
@@ -86,6 +87,7 @@ endef
 define Host/Compile
 	$(RUST_SCCACHE_VARS) \
 	CARGO_HOME=$(CARGO_HOME) \
+	TARGET_CFLAGS="$(TARGET_CFLAGS)" \
 	OPENWRT_RUSTC_BOOTSTRAP_CACHE=$(DL_DIR)/rustc \
 	$(PYTHON) $(HOST_BUILD_DIR)/x.py \
 		--build-dir $(HOST_BUILD_DIR)/build \

--- a/lang/rust/patches/0002-rustc-bootstrap-cache.patch
+++ b/lang/rust/patches/0002-rustc-bootstrap-cache.patch
@@ -11,7 +11,22 @@
                  os.makedirs(rustc_cache)
 --- a/src/bootstrap/download.rs
 +++ b/src/bootstrap/download.rs
-@@ -520,7 +520,10 @@ impl Config {
+@@ -202,7 +202,13 @@ impl Config {
+             Some(other) => panic!("unsupported protocol {other} in {url}"),
+             None => panic!("no protocol in {url}"),
+         }
+-        t!(std::fs::rename(&tempfile, dest_path));
++        match std::fs::rename(&tempfile, dest_path) {
++            Ok(v) => v,
++            Err(_) => {
++                t!(std::fs::copy(&tempfile, dest_path));
++                t!(std::fs::remove_file(&tempfile));
++            }
++        }
+     }
+ 
+     fn download_http_with_retries(&self, tempfile: &Path, url: &str, help_on_error: &str) {
+@@ -520,7 +526,10 @@ impl Config {
          key: &str,
          destination: &str,
      ) {
@@ -23,7 +38,7 @@
          let cache_dir = cache_dst.join(key);
          if !cache_dir.exists() {
              t!(fs::create_dir_all(&cache_dir));
-@@ -647,7 +650,10 @@ download-rustc = false
+@@ -647,7 +656,10 @@ download-rustc = false
          let llvm_assertions = self.llvm_assertions;
  
          let cache_prefix = format!("llvm-{llvm_sha}-{llvm_assertions}");


### PR DESCRIPTION
Maintainer: @lu-zero
Compile tested: armsr-armv7/armsr-armv8/ath79-generic/malta-be/octeon-generic/pistachio-generic/ramips-mt7620/sifiveu-generic/x86-64/x86-generic, 2023-10-23 snapshot sdks
Run tested: armsr-armv7/armsr-armv8/malta-be/x86-64/x86-generic (qemu, basic ripgrep run test), 2023-10-23 snapshot

Description:
Please see the individual commit messages for details.

For the compile error if build dir and `DL_DIR` are on separate filesystems, the issue was first described in https://github.com/openwrt/packages/pull/22457.

For the compile error on mipsel_24kc+24kf, the [mipsel_24kc_24kf faillogs](https://downloads.openwrt.org/snapshots/faillogs/mipsel_24kc_24kf/packages/) show that all Rust packages do not build. Building locally, this is the error for rust/host (from the host-compile.txt log file):

```
running: "mipsel-openwrt-linux-musl-gcc" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-I" "/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/include" "-fstrict-aliasing" "-funwind-tables" "-fvisibility=hidden" "-std=c99" "-D_LIBUNWIND_DISABLE_VISIBILITY_ANNOTATIONS" "-o" "/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/build/mipsel-unknown-linux-musl/native/libunwind/UnwindRegistersRestore.o" "-c" "/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S"
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S: Assembler messages:
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:945: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f0,(4*36+8*0)($4)'
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:946: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f2,(4*36+8*2)($4)'
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:947: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f4,(4*36+8*4)($4)'
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:948: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f6,(4*36+8*6)($4)'
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:949: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f8,(4*36+8*8)($4)'
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:950: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f10,(4*36+8*10)($4)'
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:951: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f12,(4*36+8*12)($4)'
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:952: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f14,(4*36+8*14)($4)'
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:953: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f16,(4*36+8*16)($4)'
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:954: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f18,(4*36+8*18)($4)'
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:955: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f20,(4*36+8*20)($4)'
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:956: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f22,(4*36+8*22)($4)'
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:957: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f24,(4*36+8*24)($4)'
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:958: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f26,(4*36+8*26)($4)'
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:959: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f28,(4*36+8*28)($4)'
cargo:warning=/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S:960: Error: opcode not supported on this processor: mips1 (mips1) `ldc1 $f30,(4*36+8*30)($4)'
exit status: 1


error occurred: Command "mipsel-openwrt-linux-musl-gcc" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-I" "/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/include" "-fstrict-aliasing" "-funwind-tables" "-fvisibility=hidden" "-std=c99" "-D_LIBUNWIND_DISABLE_VISIBILITY_ANNOTATIONS" "-o" "/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/build/mipsel-unknown-linux-musl/native/libunwind/UnwindRegistersRestore.o" "-c" "/home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/src/llvm-project/libunwind/src/UnwindRegistersRestore.S" with args "mipsel-openwrt-linux-musl-gcc" did not execute successfully (status code exit status: 1).


Build completed unsuccessfully in 1:04:07
make[2]: *** [Makefile:108: /home/temp/downloads/openwrt/testing/pistachio-generic/build_dir/target-mipsel_24kc+24kf_musl/host/rustc-1.73.0-src/.built] Error 1
make[2]: Leaving directory '/home/jeff/Code/personal/openwrt/packages/master/lang/rust'
time: package/feeds/packages/rust/host-compile#509.62#119.39#3950.89
```