### PR TITLE
knot: update to version 3.3.2

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.3.1
+PKG_VERSION:=3.3.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=f3f4b1d49ec9b81113b14a38354b823bd4a470356ed7e8e555595b6fd1ac80c9
+PKG_HASH:=0d65d4b59f5df69b78c6295ade0a2ea7931831de7ef5eeee3e00f8a20af679e4
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8

--- a/net/knot/patches/03_libdnssec_pkcs11_support.patch
+++ b/net/knot/patches/03_libdnssec_pkcs11_support.patch
@@ -1,0 +1,17 @@
+--- a/src/libdnssec/key/key.c
++++ b/src/libdnssec/key/key.c
+@@ -146,10 +146,14 @@ dnssec_key_t *dnssec_key_dup(const dnsse
+ 
+ 		gnutls_privkey_type_t type = gnutls_privkey_get_type(key->private_key);
+ 		if (type == GNUTLS_PRIVKEY_PKCS11) {
++#ifdef ENABLE_PKCS11
+ 			gnutls_pkcs11_privkey_t tmp;
+ 			gnutls_privkey_export_pkcs11(key->private_key, &tmp);
+ 			gnutls_privkey_import_pkcs11(dup->private_key, tmp,
+ 			                             GNUTLS_PRIVKEY_IMPORT_AUTO_RELEASE);
++#else
++			assert(0);
++#endif
+ 		} else {
+ 			assert(type == GNUTLS_PRIVKEY_X509);
+ 			gnutls_x509_privkey_t tmp;


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 6.4.4 (hbk)
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 6.4.4 (hbk)

Description:

- Release upgrade (https://www.knot-dns.cz/2023-10-20-version-332.html)
