### PR TITLE
[23.05] curl: prepare for HTTP/3 support

### DIFF
--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -105,6 +105,16 @@ config LIBCURL_NGHTTP2
 	bool "HTTP2 protocol"
 	default y
 
+config LIBCURL_NGHTTP3
+	bool "HTTP/3 protocol"
+	depends on LIBCURL_OPENSSL
+	default n
+
+config LIBCURL_NGTCP2
+	bool "QUIC protocol"
+	depends on LIBCURL_OPENSSL
+	default n
+
 comment "Miscellaneous"
 
 config LIBCURL_PROXY

--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=8.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \
@@ -58,6 +58,8 @@ PKG_CONFIG_DEPENDS:= \
   CONFIG_LIBCURL_TELNET \
   CONFIG_LIBCURL_TFTP \
   CONFIG_LIBCURL_NGHTTP2 \
+  CONFIG_LIBCURL_NGHTTP3 \
+  CONFIG_LIBCURL_NGTCP2 \
   \
   CONFIG_LIBCURL_COOKIES \
   CONFIG_LIBCURL_CRYPTO_AUTH \
@@ -95,7 +97,7 @@ define Package/libcurl
   CATEGORY:=Libraries
   DEPENDS:= +LIBCURL_WOLFSSL:libwolfssl +LIBCURL_OPENSSL:libopenssl +LIBCURL_GNUTLS:libgnutls +LIBCURL_MBEDTLS:libmbedtls
   DEPENDS += +LIBCURL_ZLIB:zlib +LIBCURL_ZSTD:libzstd +LIBCURL_THREADED_RESOLVER:libpthread +LIBCURL_LDAP:libopenldap
-  DEPENDS += +LIBCURL_LIBIDN2:libidn2 +LIBCURL_SSH2:libssh2 +LIBCURL_NGHTTP2:libnghttp2 +ca-bundle
+  DEPENDS += +LIBCURL_LIBIDN2:libidn2 +LIBCURL_SSH2:libssh2 +LIBCURL_NGHTTP2:libnghttp2 +LIBCURL_NGHTTP3:libnghttp3 +LIBCURL_NGTCP2:libngtcp2 +ca-bundle
   TITLE:=A client-side URL transfer library
   MENU:=1
   ABI_VERSION:=4
@@ -135,6 +137,8 @@ CONFIGURE_ARGS += \
 	$(if $(CONFIG_LIBCURL_ZLIB),--with-zlib="$(STAGING_DIR)/usr",--without-zlib) \
 	$(if $(CONFIG_LIBCURL_ZSTD),--with-zstd="$(STAGING_DIR)/usr",--without-zstd) \
 	$(if $(CONFIG_LIBCURL_NGHTTP2),--with-nghttp2="$(STAGING_DIR)/usr",--without-nghttp2) \
+	$(if $(CONFIG_LIBCURL_NGHTTP3),--with-nghttp3="$(STAGING_DIR)/usr",--without-nghttp3) \
+	$(if $(CONFIG_LIBCURL_NGTCP2),--with-ngtcp2="$(STAGING_DIR)/usr",--without-ngtcp2) \
 	\
 	$(call autoconf_bool,CONFIG_LIBCURL_DICT,dict) \
 	$(call autoconf_bool,CONFIG_LIBCURL_FILE,file) \


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0

Description:
* these changes along with 2 PRs below and using non-standard openssl library allow for building curl with HTTP/3 support
* https://github.com/openwrt/packages/pull/22443
* https://github.com/openwrt/packages/pull/22444

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 6bd2b89d839026c3365da7205359b1568f955e6b)
