### PR TITLE
snort3: update to 3.1.73.0

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
-PKG_VERSION:=3.1.71.0
+PKG_VERSION:=3.1.73.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
-PKG_HASH:=b5dd52b46ca2570986d7c12750bbf9db00ee3c294983ce272b3ca321aee8fb73
+PKG_HASH:=d04edf07e9b695fb22de73f0987537d35b4c8466119940e39a056d1a13888b27
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Upstream bump

Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne
```
   ,,_     -*> Snort++ <*-
  o"  )~   Version 3.1.73.0
   ''''    By Martin Roesch & The Snort Team
           http://snort.org/contact#team
           Copyright (C) 2014-2023 Cisco and/or its affiliates. All rights reserved.
           Copyright (C) 1998-2013 Sourcefire, Inc., et al.
           Using DAQ version 3.0.12
           Using LuaJIT version 2.1.0-beta3
           Using OpenSSL 3.0.11 19 Sep 2023
           Using libpcap version 1.10.4 (with TPACKET_V3)
           Using PCRE version 8.45 2021-06-15
           Using ZLIB version 1.3
           Using Hyperscan version 5.4.2 2023-10-26
```
Maintainer: @flyn-org