### PR TITLE
qemu: update to 8.1.2

### DIFF
--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -9,10 +9,10 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qemu
-PKG_VERSION:=8.0.2
+PKG_VERSION:=8.1.2
 PKG_RELEASE:=1
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=f060abd435fbe6794125e2c398568ffc3cfa540042596907a8b18edca34cf6a5
+PKG_HASH:=541526a764576eb494d2ff5ec46aeb253e62ea29035d1c23c0a8af4e6cd4f087
 PKG_SOURCE_URL:=http://download.qemu.org/
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=LICENSE tcg/LICENSE
@@ -392,7 +392,7 @@ CONFIGURE_ARGS +=			\
 	--disable-docs			\
 	--disable-fuse			\
 	--disable-gcrypt		\
-	--with-git-submodules=ignore	\
+	--disable-download		\
 	--disable-glusterfs		\
 	--disable-gnutls		\
 	--disable-guest-agent-msi	\

--- a/utils/qemu/patches/0001-configure-allow-disable-fortify_source.patch
+++ b/utils/qemu/patches/0001-configure-allow-disable-fortify_source.patch
@@ -11,9 +11,9 @@ OpenWrt base build system decide flavor of fortify_source to use
 
 --- a/configure
 +++ b/configure
-@@ -896,6 +896,8 @@ for opt do
+@@ -823,6 +823,8 @@ for opt do
    ;;
-   --disable-vfio-user-server) vfio_user_server="disabled"
+   --gdb=*) gdb_bin="$optarg"
    ;;
 +  --disable-fortify-source) fortify_source="no"
 +  ;;

--- a/utils/qemu/patches/0006-util-mmap-alloc-fix-missing-MAP_SYNC.patch
+++ b/utils/qemu/patches/0006-util-mmap-alloc-fix-missing-MAP_SYNC.patch
@@ -32,9 +32,9 @@ Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
  #endif /* CONFIG_LINUX */
  
  #include "qemu/osdep.h"
-@@ -29,6 +26,13 @@
- #include <sys/vfs.h>
+@@ -57,6 +54,13 @@ QemuFsType qemu_fd_getfs(int fd)
  #endif
+ }
  
 +#ifndef MAP_SYNC
 +#define MAP_SYNC              0x0

--- a/utils/qemu/patches/0010-no-tests.patch
+++ b/utils/qemu/patches/0010-no-tests.patch
@@ -1,6 +1,6 @@
 --- a/meson.build
 +++ b/meson.build
-@@ -3192,10 +3192,6 @@ subdir('common-user')
+@@ -3451,10 +3451,6 @@ subdir('common-user')
  subdir('bsd-user')
  subdir('linux-user')
  
@@ -11,7 +11,7 @@
  # accel modules
  tcg_real_module_ss = ss.source_set()
  tcg_real_module_ss.add_all(when: 'CONFIG_TCG_MODULAR', if_true: tcg_module_ss)
-@@ -3687,10 +3683,6 @@ subdir('scripts')
+@@ -3945,10 +3941,6 @@ subdir('scripts')
  subdir('tools')
  subdir('pc-bios')
  subdir('docs')


### PR DESCRIPTION
Maintainer: @yousong
Compile tested: x86_64, OpenWrt master (https://github.com/openwrt/openwrt/commit/75aeb7ed627ba5ea6f10f365b232bed21e40b502)
Run tested: x86_64 host, KVM for qemu-x86_64-softmmu + Bios VM.

Description:

    Version updated to 8.1.2