### PR TITLE
WIP: yggdrasil: bump to v0.5.1

### DIFF
--- a/net/yggdrasil/Makefile
+++ b/net/yggdrasil/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yggdrasil
-PKG_VERSION:=0.4.7
+PKG_VERSION:=0.5.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=47429f75b87d9b2450108471991e84c90d748606642e8778e9f578485b05a56f
+PKG_HASH:=74cf3d4dc925ea424cb8ae5e171c64344d62dde16e23c42108ecd463d48d5277
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-go-$(PKG_VERSION)
 
 PKG_MAINTAINER:=William Fleurant <meshnet@protonmail.com>


### PR DESCRIPTION
Maintainer: @wfleurant 
Compile tested: rpi4 aarch64-a72x, trunk
Run tested: work in progress
Description: https://yggdrasil-network.github.io/2023/10/22/upcoming-v05-release.html 

testing required:
- current openwrt package and luci package support
- next openwrt and luci #20626
- changes in memory and blob footprint (please document)

extras requested:
- build and package genkeys/main.go
- compatibility fixes (if any) between openwrt and luci package changes against ygg-0.5