### PR TITLE
freeradius3: switch to pcre2

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
 PKG_VERSION:=3.0.26
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=freeradius-server-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/releases/download/release_$(subst .,_,$(PKG_VERSION))/
@@ -63,7 +63,7 @@ endef
 define Package/freeradius3-common
   $(call Package/freeradius3/Default)
   TITLE:=common files
-  DEPENDS:=+USE_GLIBC:libpthread +USE_GLIBC:libbsd +FREERADIUS3_OPENSSL:libopenssl +libcap +libpcap +libncurses +libpcre +libreadline +libtalloc +libatomic
+  DEPENDS:=+USE_GLIBC:libpthread +USE_GLIBC:libbsd +FREERADIUS3_OPENSSL:libopenssl +libcap +libpcap +libncurses +libpcre2 +libreadline +libtalloc +libatomic
 endef
 
 define Package/freeradius3-default


### PR DESCRIPTION
switch to PCRE2 implementation https://github.com/openwrt/packages/issues/22006

Maintainer: @odmdas / @neheb
Compile tested: tested on mediatek unifi-6-lr-v1 with musl openwrt 23.05
Run tested: tested on mediatek unifi-6-lr-v1 with musl openwrt-23.05 with sample configuration (& internal setup ...)

Description:
libpcre is EOL with no further (security) fixes.
use libpcre2 instead