### PR TITLE
tvheadend: drop support for PCRE

### DIFF
--- a/multimedia/tvheadend/Config.in
+++ b/multimedia/tvheadend/Config.in
@@ -36,11 +36,6 @@ choice
     help
       Use internal POSIX Regular Expressions.
       Note that not all EPG parsers will work with POSIX RegEx.
-  config TVHEADEND_REGEX_PCRE
-    bool "PCRE (libpcre)"
-    select PACKAGE_libpcre
-    help
-      Use more advanced Perl-Compatible Regular Expressions, provided by libpcre.
   config TVHEADEND_REGEX_PCRE2
     bool "PCRE2 (libpcre2)"
     select PACKAGE_libpcre2

--- a/multimedia/tvheadend/Makefile
+++ b/multimedia/tvheadend/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tvheadend
 PKG_VERSION:=2023-06-05
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/tvheadend/tvheadend.git
@@ -36,7 +36,6 @@ define Package/tvheadend
 	$(ICONV_DEPENDS) \
 	+zlib \
 	+TVHEADEND_AVAHI_SUPPORT:libavahi-client \
-	+TVHEADEND_REGEX_PCRE:libpcre \
 	+TVHEADEND_REGEX_PCRE2:libpcre2 \
 	+BUILD_PATENTED&&TVHEADEND_CSA:libdvbcsa
 
@@ -77,15 +76,12 @@ ifeq ($(CONFIG_TVHEADEND_TRACE),)
 	CONFIGURE_ARGS += --disable-trace
 endif
 
+CONFIGURE_ARGS += --disable-pcre
 ifneq ($(CONFIG_TVHEADEND_REGEX_PCRE2),)
-	CONFIGURE_ARGS += --disable-pcre --enable-pcre2
-else
-ifneq ($(CONFIG_TVHEADEND_REGEX_PCRE),)
-	CONFIGURE_ARGS += --enable-pcre --disable-pcre2
+	CONFIGURE_ARGS += --enable-pcre2
 else
 ifneq ($(CONFIG_TVHEADEND_REGEX_POSIX),)
-	CONFIGURE_ARGS += --disable-pcre --disable-pcre2
-endif
+	CONFIGURE_ARGS += --disable-pcre2
 endif
 endif
 


### PR DESCRIPTION
Drop support for PCRE as it's now EOL and won't receive any security updates anymore.