### PR TITLE
pulseaudio: disable compiling against libwrap (was Include +libwrap dependency)

### DIFF
--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pulseaudio
 PKG_VERSION:=16.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://freedesktop.org/software/pulseaudio/releases
@@ -122,7 +122,9 @@ MESON_ARGS += \
 	-Dx11=disabled \
 	-Dadrian-aec=true \
 	-Dwebrtc-aec=disabled \
-        -Ddoxygen=false
+        -Ddoxygen=false \
+        -Dtcpwrap=disabled \
+        -Dbluez5-gstreamer=disabled 
 
 ifeq ($(BUILD_VARIANT),avahi)
 MESON_ARGS += \


### PR DESCRIPTION
Reportedly was inadvertendly being compiled against libwrap per https://github.com/openwrt/packages/commit/aafc57c1ded5450419b9690056163acf3d19d51f#comments

Maintainer: @neheb

If libraries/libwrap (tcp wrapper library) was built before pulseaudio, 
Libwrap was detected at the meson configuration stage of pulseaudio and used since this commit:
https://github.com/pulseaudio/pulseaudio/commit/156e16f941789c5d53cdb0c46be480c64e3149f1
However, pulseaudio can not find libwrap.so.0 during the openwrt building process at some stage. 
Therefor, compilation against libwrap is disabled.