### PR TITLE
glib2: Split package into separate library packages, to cut down on size

### DIFF
--- a/admin/gkrellmd/Makefile
+++ b/admin/gkrellmd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gkrellmd
 PKG_VERSION:=2.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=gkrellm-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://gkrellm.srcbox.net/releases
@@ -26,7 +26,7 @@ include $(INCLUDE_DIR)/nls.mk
 define Package/gkrellmd
   SECTION:=admin
   CATEGORY:=Administration
-  DEPENDS:=+glib2
+  DEPENDS:=+glib2-core +glib2-gmodule +glib2-gthread
   TITLE:=The GNU Krell Monitors Server
   URL:=http://gkrellm.net/
 endef

--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.82.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/$(basename $(PKG_VERSION))
@@ -33,12 +33,66 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/meson.mk
 
-define Package/glib2
+define Package/glib2/default
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=$(ICONV_DEPENDS) $(INTL_DEPENDS) +zlib +libpthread +libffi +libattr +libpcre2
-  TITLE:=glib 2.0
   URL:=http://www.gtk.org/
+endef
+
+define Package/glib2-core
+$(call Package/glib2/default)
+  TITLE:=GLib 2.0 core library
+  DEPENDS:=$(ICONV_DEPENDS) $(INTL_DEPENDS) +libattr +libpcre2
+endef
+
+define Package/glib2-gmodule
+$(call Package/glib2/default)
+  TITLE:=GLib 2.0 gmodule library
+  DEPENDS:=+glib2-core
+endef
+
+define Package/glib2-gthread
+$(call Package/glib2/default)
+  TITLE:=GLib 2.0 gthread library
+  DEPENDS:=+glib2-core
+endef
+
+define Package/glib2-gobject
+$(call Package/glib2/default)
+  TITLE:=GLib 2.0 gobject library
+  DEPENDS:=+glib2-core +libffi
+endef
+
+define Package/glib2-gio
+$(call Package/glib2/default)
+  TITLE:=GLib 2.0 gio library
+  DEPENDS:=+glib2-core +glib2-gobject +glib2-gmodule +zlib +libffi
+endef
+
+define Package/glib2
+$(call Package/glib2/default)
+  TITLE:=Full GLib 2.0 library
+  DEPENDS:+glib2-gthread +glib2-gio
+endef
+
+define Package/glib2-core/description
+  Common code and core library for GLib library of C routines
+endef
+
+define Package/glib2-gmodule/description
+  GLib library module functions
+endef
+
+define Package/glib2-gthread/description
+  GLib library thread functions
+endef
+
+define Package/glib2-gobject/description
+  GLib library object functions
+endef
+
+define Package/glib2-gio/description
+  GLib library io functions
 endef
 
 define Package/glib2/description
@@ -119,12 +173,44 @@ define Build/InstallDev
 		$(1)/usr/share/glib-2.0/
 endef
 
-define Package/glib2/install
+define Package/glib2-core/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/*.so* \
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libglib-2.0.so* \
 		$(1)/usr/lib/
 endef
 
+define Package/glib2-gmodule/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgmodule-2.0.so* \
+		$(1)/usr/lib
+endef
+
+define Package/glib2-gthread/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgthread-2.0.so* \
+		$(1)/usr/lib
+endef
+
+define Package/glib2-gobject/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgobject-2.0.so* \
+		$(1)/usr/lib
+endef
+
+define Package/glib2-gio/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgio-2.0.so* \
+		$(1)/usr/lib
+endef
+
+define Package/glib2/install
+	:
+endef
+
 $(eval $(call HostBuild))
+$(eval $(call BuildPackage,glib2-core))
+$(eval $(call BuildPackage,glib2-gmodule))
+$(eval $(call BuildPackage,glib2-gthread))
+$(eval $(call BuildPackage,glib2-gobject))
+$(eval $(call BuildPackage,glib2-gio))
 $(eval $(call BuildPackage,glib2))


### PR DESCRIPTION
Maintainer: Peter Wagner <tripolar@gmx.at>
Compile tested: ath79, TPlink TL-WDR3600, r24166+6-53039bf7f5
Run tested: ath79, TPlink TL-WDR3600, r24166+6-53039bf7f5, tested by installation and the fact that the gkrellmd package pulls in fewer libraries and the image is smaller
Description: In order to be able to reduce the installed size of anything that depends of GLib2.0, which has 5 component libraries, split the package into 5 separate packages, and a full version which depends on on the others to pull in all five. Also test the split by altering gkrellmd to only pull in the specific libraries that it actually depends on
