### PR TITLE
keepalived: add script call feature and missing option

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.2.8
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software

--- a/net/keepalived/files/keepalived.init
+++ b/net/keepalived/files/keepalived.init
@@ -358,7 +358,7 @@ vrrp_instance() {
 		garp_master_repeat garp_master_refresh_repeat \
 		no_val_vmac_xmit_base no_val_native_ipv6 no_val_accept \
 		no_val_dont_track_primary no_val_smtp_alert no_val_nopreempt \
-		no_val_use_vmac
+		no_val_use_vmac no_val_no_accept
 
 	print_notify "INSTANCE" "$name" "$INDENT_1" notify_backup notify_master \
 		notify_fault notify_stop


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64 and lantiq_xrx200
Run tested: Only verified if the script changes generate a valid keepalived config file.

Description:
[keepalived: add startup and shutdown script handling](https://github.com/openwrt/packages/commit/eb2ed206454ac72c73f0af0f5386cb7f5d79672d)
[eepalived: add missing no_accept option](https://github.com/openwrt/packages/commit/f9ed5a9f3af0c587b29e12f85fd9b82b8394be71)