### PR TITLE
zabbix: update to version 6.4.7

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=6.2.3
-PKG_RELEASE:=4
+PKG_VERSION:=6.4.7
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
 	https://cdn.zabbix.com/zabbix/sources/oldstable/$(basename $(PKG_VERSION))/
-PKG_HASH:=2be7e57fb33a55fee71480598e317ffa6a8ee5a39639a7e1b42b2ea6872107b5
+PKG_HASH:=6b4e81f07de4c82c7994871bea51be4d6427683fa9a7fbe112fd7559b3670e49
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=GPL-2.0
@@ -157,6 +157,7 @@ define Package/zabbix-server/Default
     +ZABBIX_MYSQL:libmariadbclient \
     @(!ZABBIX_SQLITE) \
     +libevent2 \
+    +libevent2-pthreads \
     +fping
 endef
 
@@ -209,6 +210,7 @@ define Package/zabbix-proxy/Default
     +ZABBIX_MYSQL:libmariadbclient \
     +ZABBIX_SQLITE:libsqlite3 \
     +libevent2 \
+    +libevent2-pthreads \
     +fping
 endef
 
@@ -262,7 +264,7 @@ CONFIGURE_ARGS+= \
 	$(if $(CONFIG_ZABBIX_MYSQL),--with-mysql) \
 	$(if $(CONFIG_ZABBIX_POSTGRESQL),--with-postgresql) \
 	$(if $(CONFIG_ZABBIX_SQLITE),--with-sqlite3=$(STAGING_DIR)/usr) \
-	--with-libevent=$(STAGING_DIR)/usr/include/libevent \
+	--with-libevent=$(STAGING_DIR)/usr/include \
 	--with-libpcre2=$(STAGING_DIR)/usr/include \
 	--with-zlib=$(STAGING_DIR)/usr/include
 

--- a/admin/zabbix/patches/110-reproducible-builds.patch
+++ b/admin/zabbix/patches/110-reproducible-builds.patch
@@ -1,6 +1,6 @@
---- a/src/libs/zbxcommon/str.c
-+++ b/src/libs/zbxcommon/str.c
-@@ -49,7 +49,7 @@ static const char	help_message_footer[]
+--- a/src/libs/zbxcommon/misc.c
++++ b/src/libs/zbxcommon/misc.c
+@@ -329,7 +329,7 @@ void	zbx_help(void)
  void	zbx_version(void)
  {
  	printf("%s (Zabbix) %s\n", title_message, ZABBIX_VERSION);


### PR DESCRIPTION
Maintainer:  @champtar 
Compile tested: x86_64 and lantiq_xrx200
Run tested: lantiq_xrx200 only starting zabbix-agentd

Description:
Switch to current stabl version 6.4.7.
See release notes: https://www.zabbix.com/rn/rn6.4.7

So that the new version builds cleanly. The 'libevent2-pthreads' must be added as dependency.

Test:
```
root@VR2-106149 ~ # zabbix_agentd --version
zabbix_agentd (daemon) (Zabbix) 6.4.7
Revision 4e555c6d64d 26 September 2023

Copyright (C) 2023 Zabbix SIA
License GPLv2+: GNU GPL version 2 or later <https://www.gnu.org/licenses/>.
This is free software: you are free to change and redistribute it according to
the license. There is NO WARRANTY, to the extent permitted by law.

This product includes software developed by the OpenSSL Project
for use in the OpenSSL Toolkit (http://www.openssl.org/).

Compiled with OpenSSL 3.0.11 19 Sep 2023
Running with OpenSSL 3.0.11 19 Sep 2023
```