### PR TITLE
wsdd2: #46 from upstream to fix interface selection

### DIFF
--- a/net/wsdd2/Makefile
+++ b/net/wsdd2/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wsdd2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/Netgear/wsdd2.git

--- a/net/wsdd2/patches/010-wsdd-upstream-pr46.patch
+++ b/net/wsdd2/patches/010-wsdd-upstream-pr46.patch
@@ -1,0 +1,21 @@
+Index: wsdd2-2022-04-25-e37443ac/wsdd2.c
+From 50f97a909d2c0d8e2c20d87c055531151223600b Mon Sep 17 00:00:00 2001
+From: Lev <lev.shutov@gmail.com>
+Date: Sun, 12 Mar 2023 08:53:52 +0300
+Subject: [PATCH] Fix interface selection
+
+Fix selection of new/modified interface when running in single interface mode with -i key
+
+Backport from Netgear/wsdd2#46
+===================================================================
+--- wsdd2-2022-04-25-e37443ac.orig/wsdd2.c
++++ wsdd2-2022-04-25-e37443ac/wsdd2.c
+@@ -520,7 +520,7 @@ static bool is_new_addr(struct nlmsghdr
+ 
+ 	if (ifindex && ifam->ifa_index != ifindex) {
+ 		char buf[IFNAMSIZ];
+-		if (!if_indextoname(ifindex, buf) || strcmp(buf, ifname) != 0)
++		if (!if_indextoname(ifam->ifa_index, buf) || strcmp(buf, ifname) != 0)
+ 			return false;
+ 		ifindex = ifam->ifa_index;
+ 	}


### PR DESCRIPTION
Fixes Netgear/wsdd2#36

Maintainer: @rikka0w0
Compile tested: ARMv7, Linksys wrt1900ac v2, OpenWrt 23.05.0
Run tested: ARMv7, Linksys wrt1900ac v2, OpenWrt 23.05.0, run for 3 hours to see if the server still becomes invisible.

Description:
In a ksmbd+wsdd2 configuration, the server becomes invisible to Windows 11 clients after a few minutes to a few hours.

This PR merges a pending PR Netgear/wsdd2#46 from the upstream repository to address this issue.