### PR TITLE
ddns-scripts: Fix Route53 provider

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=41
+PKG_RELEASE:=42
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_route53_v1.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_route53_v1.sh
@@ -11,9 +11,10 @@
 ENDPOINT="route53.amazonaws.com"
 RECORD_TTL=300
 RECORD_NAME="${lookup_host}."
+RECORD_VALUE="${__IP}"
 [ ${use_ipv6} -eq 0 ] && RECORD_TYPE="A"
 [ ${use_ipv6} -eq 1 ] && RECORD_TYPE="AAAA"
-RECORD_VALUE="${LOCAL_IP}"
+
 HOSTED_ZONE_ID="${domain}"
 API_PATH="/2013-04-01/hostedzone/${HOSTED_ZONE_ID}/rrset/"
 


### PR DESCRIPTION
Maintainer: @chris5560, @maxberger, @dibdot
Compile tested: : N/A
Run tested:  OpenWrt 23.05.0, r23497-6637af95aa, amd64 

Description:
This fixes the Invalid Resource Record: FATAL problem: ARRDATAIllegalIPv4Address error message described in https://forum.openwrt.org/t/route53v1-script-error/160068

Signed-off-by: Max Berger <max@berger.name>