### PR TITLE
python-cryptography: Update to 41.0.5

### DIFF
--- a/lang/python/python-cryptography/Makefile
+++ b/lang/python/python-cryptography/Makefile
@@ -8,15 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptography
-PKG_VERSION:=41.0.4
+PKG_VERSION:=41.0.5
 PKG_RELEASE:=1
 
 PYPI_NAME:=cryptography
-PKG_HASH:=7febc3094125fc126a7f6fb1f420d0da639f3f32cb15c8ff0dc3997c4549f51a
+PKG_HASH:=392cb88b597247177172e02da6b7a63deeff1937fa6fec3bbf902ebd75d97ec7
 
 PKG_LICENSE:=Apache-2.0 BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.APACHE LICENSE.BSD
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+PKG_CPE_ID:=cpe:/a:cryptography_project:cryptography
 
 PKG_BUILD_DEPENDS:=libffi/host python-cffi/host python-setuptools-rust/host
 

--- a/lang/python/python-cryptography/test.sh
+++ b/lang/python/python-cryptography/test.sh
@@ -2,11 +2,13 @@
 
 [ "$1" = python3-cryptography ] || exit 0
 
-python3 - << EOF
-import sys
+python3 - << 'EOF'
+
 from cryptography.fernet import Fernet
 key = Fernet.generate_key()
 f = Fernet(key)
-token = f.encrypt(b"my deep dark secret")
-sys.exit(0 if f.decrypt(token) == b"my deep dark secret" else 1)
+msg = b"my deep dark secret"
+token = f.encrypt(msg)
+assert f.decrypt(token) == msg
+
 EOF


### PR DESCRIPTION
Maintainer: me
Compile tested: armsr-armv7, 2023-10-28 snapshot sdk
Run tested: armsr-armv7 (qemu), 2023-10-28 snapshot

Description:
This also adds a CPE ID for the package and updates the test.sh script to use an assert.