### PR TITLE
[openwrt-23.05] rust: Fix compile error if build dir and DL_DIR on separate filesystems, compile error for mipsel_24kc+24kf

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
 PKG_VERSION:=1.73.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
@@ -18,6 +18,7 @@ PKG_LICENSE:=Apache-2.0 MIT
 PKG_LICENSE_FILES:=LICENSE-APACHE LICENSE-MIT
 
 PKG_HOST_ONLY:=1
+PKG_BUILD_FLAGS:=no-mips16
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
@@ -86,6 +87,7 @@ endef
 define Host/Compile
 	$(RUST_SCCACHE_VARS) \
 	CARGO_HOME=$(CARGO_HOME) \
+	TARGET_CFLAGS="$(TARGET_CFLAGS)" \
 	OPENWRT_RUSTC_BOOTSTRAP_CACHE=$(DL_DIR)/rustc \
 	$(PYTHON) $(HOST_BUILD_DIR)/x.py \
 		--build-dir $(HOST_BUILD_DIR)/build \

--- a/lang/rust/patches/0002-rustc-bootstrap-cache.patch
+++ b/lang/rust/patches/0002-rustc-bootstrap-cache.patch
@@ -11,7 +11,22 @@
                  os.makedirs(rustc_cache)
 --- a/src/bootstrap/download.rs
 +++ b/src/bootstrap/download.rs
-@@ -520,7 +520,10 @@ impl Config {
+@@ -202,7 +202,13 @@ impl Config {
+             Some(other) => panic!("unsupported protocol {other} in {url}"),
+             None => panic!("no protocol in {url}"),
+         }
+-        t!(std::fs::rename(&tempfile, dest_path));
++        match std::fs::rename(&tempfile, dest_path) {
++            Ok(v) => v,
++            Err(_) => {
++                t!(std::fs::copy(&tempfile, dest_path));
++                t!(std::fs::remove_file(&tempfile));
++            }
++        }
+     }
+ 
+     fn download_http_with_retries(&self, tempfile: &Path, url: &str, help_on_error: &str) {
+@@ -520,7 +526,10 @@ impl Config {
          key: &str,
          destination: &str,
      ) {
@@ -23,7 +38,7 @@
          let cache_dir = cache_dst.join(key);
          if !cache_dir.exists() {
              t!(fs::create_dir_all(&cache_dir));
-@@ -647,7 +650,10 @@ download-rustc = false
+@@ -647,7 +656,10 @@ download-rustc = false
          let llvm_assertions = self.llvm_assertions;
  
          let cache_prefix = format!("llvm-{llvm_sha}-{llvm_assertions}");


### PR DESCRIPTION
Maintainer: @lu-zero
Compile tested: none (cherry picked from #22504)
Run tested: none

Description:
Please see #22504 for details.