### PR TITLE
newt: Update to 0.52.24, add test.sh script for packages feed CI

### DIFF
--- a/libs/newt/Makefile
+++ b/libs/newt/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=newt
-PKG_VERSION:=0.52.23
+PKG_VERSION:=0.52.24
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://releases.pagure.org/newt
-PKG_HASH:=caa372907b14ececfe298f0d512a62f41d33b290610244a58aed07bbc5ada12a
+PKG_HASH:=5ded7e221f85f642521c49b1826c8de19845aa372baf5d630a51774b544fbdbb
 
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=LGPL-2.0-only

--- a/libs/newt/test.sh
+++ b/libs/newt/test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+case "$1" in
+
+python3-newt)
+	python3 -c 'import snack'
+	;;
+
+whiptail)
+	whiptail --version | grep -Fx "whiptail (newt): $PKG_VERSION"
+	;;
+
+esac


### PR DESCRIPTION
Maintainer: me
Compile tested: armsr-armv7, 2023-10-28 snapshot sdk
Run tested: armsr-armv7 (qemu, basic loading tests only), 2023-10-28 snapshot

Description:
