### PR TITLE
[openwrt-23.05] Armsr target support for dmidecode/efivar/efibootmgr

### DIFF
--- a/libs/efivar/Makefile
+++ b/libs/efivar/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=efivar
 PKG_VERSION:=38
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/rhboot/efivar/releases/download/$(PKG_VERSION)
@@ -25,7 +25,7 @@ define Package/efivar
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Tools and libraries to work with EFI variables
-  DEPENDS:=@TARGET_x86_64
+  DEPENDS:=@(TARGET_x86_64||TARGET_armsr_armv8)
   URL:=https://github.com/rhboot/efibootmgr
 endef
 

--- a/libs/efivar/patches/006-build-util-c-separately-for-makeguids.patch
+++ b/libs/efivar/patches/006-build-util-c-separately-for-makeguids.patch
@@ -1,0 +1,32 @@
+From ca48d3964d26f5e3b38d73655f19b1836b16bd2d Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex@linutronix.de>
+Date: Tue, 18 Jan 2022 11:53:41 +0100
+Subject: [PATCH] src/Makefile: build util.c separately for makeguids
+
+util.c needs to be built twice when cross-compiling:
+for the build machine to be able to link with
+makeguids which then runs during the same build,
+and then for the actual target.
+
+Signed-off-by: Alexander Kanavin <alex@linutronix.de>
+---
+ src/Makefile | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -28,10 +28,13 @@ EFIVAR_OBJECTS = $(patsubst %.S,%.o,$(pa
+ EFISECDB_SOURCES = efisecdb.c guid-symbols.c secdb-dump.c util.c
+ EFISECDB_OBJECTS = $(patsubst %.S,%.o,$(patsubst %.c,%.o,$(EFISECDB_SOURCES)))
+ GENERATED_SOURCES = include/efivar/efivar-guids.h guid-symbols.c
+-MAKEGUIDS_SOURCES = makeguids.c util.c
++MAKEGUIDS_SOURCES = makeguids.c util-makeguids.c
+ MAKEGUIDS_OBJECTS = $(patsubst %.S,%.o,$(patsubst %.c,%.o,$(MAKEGUIDS_SOURCES)))
+ MAKEGUIDS_OUTPUT = $(GENERATED_SOURCES) guids.lds
+ 
++util-makeguids.c : util.c
++	cp util.c util-makeguids.c
++
+ ALL_SOURCES=$(LIBEFISEC_SOURCES) $(LIBEFIBOOT_SOURCES) $(LIBEFIVAR_SOURCES) \
+ 	    $(MAKEGUIDS_SOURCES) $(GENERATED_SOURCES) $(EFIVAR_SOURCES) \
+ 	    $(sort $(wildcard include/efivar/*.h))

--- a/utils/dmidecode/Makefile
+++ b/utils/dmidecode/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dmidecode
 PKG_VERSION:=3.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SAVANNAH/$(PKG_NAME)
@@ -26,7 +26,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/dmidecode
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=@(TARGET_x86||TARGET_x86_64)
+  DEPENDS:=@(TARGET_x86||TARGET_x86_64||TARGET_armsr_armv8)
   TITLE:=Displays BIOS informations.
   URL:=https://www.nongnu.org/dmidecode/
 endef

--- a/utils/efibootmgr/Makefile
+++ b/utils/efibootmgr/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=efibootmgr
 PKG_VERSION:=18
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/rhboot/efibootmgr.git
@@ -23,7 +23,7 @@ define Package/efibootmgr
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Application to modify the EFI Boot Manager
-  DEPENDS:=@TARGET_x86_64 +efivar +libpopt
+  DEPENDS:=@(TARGET_x86_64||TARGET_armsr_armv8) +efivar +libpopt
   URL:=https://github.com/rhboot/efibootmgr
 endef
 


### PR DESCRIPTION

Maintainer: @Noltari @jefferyto @oskarirauta  @1715173329
Compile tested: armsr-armv8
Run tested: armsr-armv8 (NXP i.MX8plus, Kontron Box)

Description:
These packages can be used on Arm SystemReady platforms

Cherry picked from master branch
