### PR TITLE
freeradius3: drop libpcre2 dependency + bump 3.2.3

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -63,7 +63,7 @@ endef
 define Package/freeradius3-common
   $(call Package/freeradius3/Default)
   TITLE:=common files
-  DEPENDS:=+USE_GLIBC:libpthread +USE_GLIBC:libbsd +FREERADIUS3_OPENSSL:libopenssl +libcap +libpcap +libncurses +libpcre2 +libreadline +libtalloc +libatomic
+  DEPENDS:=+USE_GLIBC:libpthread +USE_GLIBC:libbsd +FREERADIUS3_OPENSSL:libopenssl +libcap +libpcap +libncurses +libreadline +libtalloc +libatomic
 endef
 
 define Package/freeradius3-default
@@ -482,11 +482,13 @@ endef
 # needed in a future release.
 EXTRA_CFLAGS+= -DHAVE_OPENSSL_RAND_H
 
+# Enable PCRE2 support again if ever backported or we switch to release 4.0.0
 CONFIGURE_ARGS+= \
 	--libdir=/usr/lib/freeradius3 \
 	--libexecdir=/usr/lib/freeradius3 \
 	--disable-developer \
 	--with-threads \
+	--with-pcre=no \
 	$(if $(CONFIG_FREERADIUS3_OPENSSL),--with,--without)-openssl \
 	$(if $(CONFIG_FREERADIUS3_OPENSSL),--with-openssl-includes="$(STAGING_DIR)/usr/include",) \
 	$(if $(CONFIG_FREERADIUS3_OPENSSL),--with-openssl-libraries="$(STAGING_DIR)/usr/lib",) \

--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
-PKG_VERSION:=3.0.26
-PKG_RELEASE:=2
+PKG_VERSION:=3.2.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=freeradius-server-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/releases/download/release_$(subst .,_,$(PKG_VERSION))/
-PKG_HASH:=9a65314c462da4d4c4204df72c45f210de671f89317299b01f78549ac4503f59
+PKG_HASH:=4a16aeffbfa1424e1f317fdf71d17e5523a4fd9564d87c747a60595ef93c5d1f
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0

--- a/net/freeradius3/patches/002-disable-session-cache-CVE-2017-9148.patch
+++ b/net/freeradius3/patches/002-disable-session-cache-CVE-2017-9148.patch
@@ -9,7 +9,7 @@ Last-Update: 2020-04-28
 
 --- a/src/main/tls.c
 +++ b/src/main/tls.c
-@@ -934,7 +934,7 @@ after_chain:
+@@ -947,7 +947,7 @@ after_chain:
  	}
  	if (vp) vp->vp_integer = state->mtu;
  
@@ -18,7 +18,7 @@ Last-Update: 2020-04-28
  
  	return state;
  }
-@@ -4389,7 +4389,7 @@ post_ca:
+@@ -4488,7 +4488,7 @@ post_ca:
  	/*
  	 *	Callbacks, etc. for session resumption.
  	 */
@@ -27,7 +27,7 @@ Last-Update: 2020-04-28
  		/*
  		 *	Cache sessions on disk if requested.
  		 */
-@@ -4469,7 +4469,7 @@ post_ca:
+@@ -4568,7 +4568,7 @@ post_ca:
  	/*
  	 *	Setup session caching
  	 */
@@ -36,7 +36,7 @@ Last-Update: 2020-04-28
  		/*
  		 *	Create a unique context Id per EAP-TLS configuration.
  		 */
-@@ -4757,7 +4757,7 @@ fr_tls_server_conf_t *tls_server_conf_pa
+@@ -4856,7 +4856,7 @@ fr_tls_server_conf_t *tls_server_conf_pa
  		goto error;
  	}
  

--- a/net/freeradius3/patches/003-freeradius-fix-error-for-expansion-of-macro.patch
+++ b/net/freeradius3/patches/003-freeradius-fix-error-for-expansion-of-macro.patch
@@ -1,6 +1,6 @@
 --- a/src/include/threads.h
 +++ b/src/include/threads.h
-@@ -89,7 +89,7 @@ static _t __fr_thread_local_init_##_n(pt
+@@ -92,7 +92,7 @@ static _t __fr_thread_local_init_##_n(pt
  #  define fr_thread_local_get(_n) _n
  #elif defined(HAVE_PTHREAD_H)
  #  include <pthread.h>
@@ -9,7 +9,7 @@
  static pthread_key_t __fr_thread_local_key_##_n;\
  static pthread_once_t __fr_thread_local_once_##_n = PTHREAD_ONCE_INIT;\
  static pthread_destructor_t __fr_thread_local_destructor_##_n = NULL;\
-@@ -100,17 +100,17 @@ static void __fr_thread_local_destroy_##
+@@ -103,17 +103,17 @@ static void __fr_thread_local_destroy_##
  static void __fr_thread_local_key_init_##_n(void)\
  {\
  	(void) pthread_key_create(&__fr_thread_local_key_##_n, __fr_thread_local_destroy_##_n);\

--- a/net/freeradius3/patches/004-get-hostname-from-proc-in-radtest.patch
+++ b/net/freeradius3/patches/004-get-hostname-from-proc-in-radtest.patch
@@ -4,7 +4,7 @@
  then
  	nas=$7
  else
--	nas=`hostname`
+-	nas=`(hostname || uname -n) 2>/dev/null | sed 1q`
 +	nas=$(cat /proc/sys/kernel/hostname)
  fi
  

--- a/net/freeradius3/patches/010-openssl-deprecated.patch
+++ b/net/freeradius3/patches/010-openssl-deprecated.patch
@@ -1,17 +1,17 @@
 --- a/src/main/threads.c
 +++ b/src/main/threads.c
-@@ -298,6 +298,7 @@ static void ssl_locking_function(int mod
+@@ -265,6 +265,7 @@ static void ssl_locking_function(int mod
   */
  int tls_mutexes_init(void)
  {
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
- 	int i;
+ 	int i, num;
  
- 	ssl_mutexes = rad_malloc(CRYPTO_num_locks() * sizeof(pthread_mutex_t));
-@@ -316,6 +317,7 @@ int tls_mutexes_init(void)
- #ifdef HAVE_CRYPTO_SET_LOCKING_CALLBACK
+ 	rad_assert(ssl_mutexes == NULL);
+@@ -282,6 +283,7 @@ int tls_mutexes_init(void)
+ 	}
+ 
  	CRYPTO_set_locking_callback(ssl_locking_function);
- #endif
 +#endif
  
  	return 0;
@@ -26,7 +26,7 @@
  
  #if OPENSSL_VERSION_NUMBER >= 0x30000000L
  #  include <openssl/provider.h>
-@@ -2954,7 +2955,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
+@@ -2981,7 +2982,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
  	int		my_ok = ok;
  
  	ASN1_INTEGER	*sn = NULL;
@@ -35,7 +35,7 @@
  	VALUE_PAIR	**certs;
  	char **identity;
  #ifdef HAVE_OPENSSL_OCSP_H
-@@ -3028,7 +3029,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
+@@ -3072,7 +3073,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
  	 *	Get the Expiration Date
  	 */
  	buf[0] = '\0';
@@ -44,7 +44,7 @@
  	if (certs && (lookup <= 1) && asn_time &&
  	    (asn_time->length < (int) sizeof(buf))) {
  		memcpy(buf, (char*) asn_time->data, asn_time->length);
-@@ -3041,7 +3042,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
+@@ -3085,7 +3086,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
  	 *	Get the Valid Since Date
  	 */
  	buf[0] = '\0';
@@ -53,9 +53,9 @@
  	if (certs && (lookup <= 1) && asn_time &&
  	    (asn_time->length < (int) sizeof(buf))) {
  		memcpy(buf, (char*) asn_time->data, asn_time->length);
-@@ -3592,10 +3593,12 @@ static int set_ecdh_curve(SSL_CTX *ctx,
+@@ -3647,10 +3648,12 @@ static int set_ecdh_curve(SSL_CTX *ctx,
   */
- int tls_global_init(bool spawn_flag, bool check)
+ int tls_global_init(TLS_UNUSED bool spawn_flag, TLS_UNUSED bool check)
  {
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L
  	SSL_load_error_strings();	/* readable error messages (examples show call before library_init) */
@@ -66,7 +66,7 @@
  
  	/*
  	 *	Initialize the index for the certificates.
-@@ -3693,6 +3696,7 @@ int tls_global_version_check(char const
+@@ -3750,6 +3753,7 @@ int tls_global_version_check(char const
   */
  void tls_global_cleanup(void)
  {
@@ -74,7 +74,7 @@
  #if OPENSSL_VERSION_NUMBER < 0x10000000L
  	ERR_remove_state(0);
  #elif OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-@@ -3718,6 +3722,7 @@ void tls_global_cleanup(void)
+@@ -3775,6 +3779,7 @@ void tls_global_cleanup(void)
  	ERR_free_strings();
  	EVP_cleanup();
  	CRYPTO_cleanup_all_ex_data();


### PR DESCRIPTION
Commit https://github.com/openwrt/packages/commit/19ec30255f1379cb2d25f7ace22523039cc8aa67 ("freeradius3: switch to pcre2") was entirely wrong.
Freeradius3 have support for PCRE2 from release 4.0.0 alpha and won't be
backport to 3.x. The CI test were successful just because libpcre2 was
set as a dependency so libpcre header were never included in staging_dir
and autoconfig disabled pcre support silently.

On buildbot or other buildroot with mixed libpcre and libpcre2,
freeradius will find the pcre header and enable it.

Freeradius3 team said that if pcre library is not found the posix
variant is used. To actually enforce this cause, we need to configre
freeradius to explicily disable libpcre support even if found.

Fixes: https://github.com/openwrt/packages/commit/19ec30255f1379cb2d25f7ace22523039cc8aa67 ("freeradius3: switch to pcre2")
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

Bump freeradius3 to release 3.2.3.

Refresh patches and manually rebase the openssl support one and the
hostname patch.