### PR TITLE
[openwrt-23.05] pyodbc: Fix segmentation fault

### DIFF
--- a/lang/python/pyodbc/Makefile
+++ b/lang/python/pyodbc/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pyodbc
 PKG_VERSION:=4.0.39
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=e528bb70dd6d6299ee429868925df0866e3e919c772b9eff79c8e17920d8f116
@@ -27,7 +27,7 @@ define Package/python3-pyodbc
   SUBMENU:=Python
   TITLE:=python3-pyodbc
   URL:=https://github.com/mkleehammer/pyodbc
-  DEPENDS:=+unixodbc +python3-light +libstdcpp
+  DEPENDS:=+unixodbc +python3-light +python3-decimal +python3-uuid +libstdcpp
 endef
 
 define Package/python3-pyodbc/description


### PR DESCRIPTION
Maintainer: me
Compile tested: none (cherry picked from #22561)
Run tested: none

Description:
4.0.36 included a change to [decimal parsing][1] that requires the decimal module. Trying to load the pyodbc module without python3-decimal installed would lead to a segmentation fault.

This adds python3-decimal as a dependency.

This also adds python3-uuid as a dependency as the module can [accept and return uuid objects][2].

[1]: https://github.com/mkleehammer/pyodbc/commit/6b107a2bcaf7379e5ba182007b6ecae1bc2fc931
[2]: https://github.com/mkleehammer/pyodbc/commit/2ad7a9ced7c9c33232c173668c0830a484cc92f3

Fixes: f02f3ee8c768 ("pyodbc: Update to 4.0.39")

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 668a0f9dd8baa2fb6275ff0e022b6f1bf390b7c2)