### PR TITLE
psqlodbc: Fix build

### DIFF
--- a/libs/psqlodbc/Makefile
+++ b/libs/psqlodbc/Makefile
@@ -23,7 +23,7 @@ PKG_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 
 CONFIGURE_ARGS += \
-	--with-unixodbc=$(STAGING_DIR_HOST)/bin/odbc_config \
+	--with-unixodbc=$(STAGING_DIR)/host/bin/odbc_config \
 	--with-libpq=$(STAGING_DIR)/usr
 
 define Package/psqlodbc/Default


### PR DESCRIPTION
Maintainer: none
Compile tested: armsr-arm7, 2023-10-28 snapshot sdk
Run tested: none

Description:
This updates the path for odbc_config as it was moved from `$(STAGING_DIR_HOST)/bin` to `$(STAGING_DIR)/host/bin` (in commit 61de50de5f787b08e06de9425ec409c8fd1ffcbf).