### PR TITLE
pptpd: use boolean options

### DIFF
--- a/net/pptpd/Makefile
+++ b/net/pptpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pptpd
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/poptop

--- a/net/pptpd/files/pptpd.init
+++ b/net/pptpd/files/pptpd.init
@@ -18,11 +18,11 @@ validate_login_section() {
 
 validate_pptpd_section() {
 	uci_load_validate pptpd service "$1" "$2" \
-		'enabled:uinteger' \
+		'enabled:bool:1' \
 		'localip:string' \
 		'remoteip:string' \
 		'mppe:list(string):required no40 no56 stateless' \
-		'logwtmp:uinteger'
+		'logwtmp:bool:0'
 }
 
 setup_login() {


### PR DESCRIPTION
Run tested: OpenWrt 23.05.0 x86/64

Description:
Use boolean options and fix the relevant init error.