### PR TITLE
wgsd: add package

### DIFF
--- a/net/wgsd/Makefile
+++ b/net/wgsd/Makefile
@@ -1,0 +1,87 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=wgsd
+PKG_VERSION:=0.3.6
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/jwhited/wgsd/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=b64e7c93a98e444e6ef46871fb73349c485c501469758e459e10188d7abfec28
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Vladimir Ermakov <vooon341@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/jwhited/wgsd
+GO_PKG_EXCLUDES:=test
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/wgsd/Default
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=VPN
+  TITLE:=WireGuard Service Discovery
+  URL:=https://github.com/jwhited/wgsd
+  DEPENDS:=+kmod-wireguard
+endef
+
+define Package/wgsd-coredns
+  $(call Package/wgsd/Default)
+  TITLE+= DNS-SD server
+endef
+
+define Package/wgsd-client
+  $(call Package/wgsd/Default)
+  TITLE+= Client
+endef
+
+define Package/wgsd/Default/description
+  wgsd is a CoreDNS plugin that serves WireGuard peer information via DNS-SD (RFC6763) semantics.
+  This enables use cases such as:
+
+  - Building a mesh of WireGuard peers from a central registry
+  - Dynamic discovery of WireGuard Endpoint addressing (both IP address and port number)
+  - NAT-to-NAT WireGuard connectivity where UDP hole punching is supported.
+endef
+
+define Package/wgsd-coredns/description
+  $(call Package/wgsd/Default/description)
+
+  CoreDNS binary.
+endef
+
+define Package/wgsd-client/description
+  $(call Package/wgsd/Default/description)
+
+  Client binary.
+endef
+
+define Package/wgsd-coredns/conffiles
+/etc/Corefile
+endef
+
+define Package/wgsd-coredns/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/coredns $(1)/usr/bin/wgsd-coredns
+
+	$(INSTALL_DIR) $(1)/etc/
+	$(INSTALL_CONF) $(CURDIR)/files/Corefile $(1)/etc/Corefile
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) $(CURDIR)/files/wgsd-coredns.init $(1)/etc/init.d/wgsd-coredns
+endef
+
+define Package/wgsd-client/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/wgsd-client $(1)/usr/bin/wgsd-client
+endef
+
+$(eval $(call BuildPackage,wgsd-coredns))
+$(eval $(call BuildPackage,wgsd-client))

--- a/net/wgsd/README.md
+++ b/net/wgsd/README.md
@@ -1,0 +1,30 @@
+## Wireguard Service Discovery (Mesh)
+
+This tool allows you to build a mesh from wireguard tunnels and also traversal NAT.
+
+See this article: https://www.jordanwhited.com/posts/wireguard-endpoint-discovery-nat-traversal/
+Also see project on github: https://github.com/jwhited/wgsd
+
+
+## Usage
+
+On server edit /etc/Corefile to select on which port DNS-SD should be serving and also which interface to use.
+
+Here is the example, where port `5353` will be used by coredns, `coredns.lan.` zone be used for discovery and `vpn_wg` interface be used to gather peers information.
+
+    .:5353 {
+      log
+      #whoami
+      wgsd coredns.lan. vpn_wg
+    }
+
+On a client you should put to the cron line like that:
+
+    1,6,11,16,21,26,31,36,41,46,51,56 * * * * /usr/bin/wgsd-client -device vpn_wg -dns your.central.node:5353 -zone coredns.lan
+
+
+### Note
+
+All peers that should connect to each other should know other peers.
+So you should setup your central node as a first peer followed with peers.
+E.g. let's say we have a Cloud-Router (CR), Alice and the Bob. Then you should configure peers for CR (with the address) and Bob on Alice's side and CR and Alice on Bob's.

--- a/net/wgsd/files/Corefile
+++ b/net/wgsd/files/Corefile
@@ -1,0 +1,5 @@
+.:5353 {
+  log
+  #whoami
+  wgsd coredns.lan. vpn_wg
+}

--- a/net/wgsd/files/wgsd-coredns.init
+++ b/net/wgsd/files/wgsd-coredns.init
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+
+USE_PROCD=1
+PROG=/usr/bin/wgsd-coredns
+
+start_service() {
+	procd_open_instance
+	procd_set_param command "$PROG" -conf /etc/Corefile
+	procd_close_instance
+}


### PR DESCRIPTION
Maintainer: me / @vooon
Compile tested: ramips / Asus ax53u / OpenWrt master, 
Run tested: ramips / Asus ax53u / OpenWrt master - client, x64_64 - coredns

Description:

Adds [WGSD](https://github.com/jwhited/wgsd), a service that enables use cases such as:

- Building a mesh of WireGuard peers from a central registry
- Dynamic discovery of WireGuard Endpoint addressing (both IP address and port number)
- NAT-to-NAT WireGuard connectivity where [UDP hole punching](https://en.wikipedia.org/wiki/UDP_hole_punching) is supported.

Provides two packages:
- wgsd-coredns - a DNS-SD server
- wgsd-client - a client, which query DNS server and update wireguard peers