### PR TITLE
nmap: backport fix to be able to compile it with OpenSSL 1.1

### DIFF
--- a/net/nmap/Makefile
+++ b/net/nmap/Makefile
@@ -14,7 +14,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nmap
 PKG_VERSION:=7.93
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Nuno Gonçalves <nunojpg@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/net/nmap/patches/010-Build-based-on-OpenSSL-version.patch
+++ b/net/nmap/patches/010-Build-based-on-OpenSSL-version.patch
@@ -1,0 +1,295 @@
+From d6bea8dcdee36a3902cece14097993350306f1b6 Mon Sep 17 00:00:00 2001
+From: dmiller <dmiller@e0a8ed71-7df4-0310-8962-fdc924857419>
+Date: Tue, 6 Sep 2022 22:39:34 +0000
+Subject: [PATCH] Build based on OpenSSL version, not API level. Fixes #2516
+
+---
+ ncat/http_digest.c        |  2 +-
+ ncat/ncat_connect.c       |  4 ++--
+ ncat/ncat_ssl.c           |  6 +++---
+ ncat/ncat_ssl.h           | 12 ------------
+ ncat/test/test-wildcard.c |  4 ++--
+ nse_openssl.cc            | 28 +++++++---------------------
+ nse_ssl_cert.cc           | 24 ++++++------------------
+ nsock/src/nsock_ssl.c     |  4 ++--
+ nsock/src/nsock_ssl.h     | 15 +--------------
+ 9 files changed, 24 insertions(+), 75 deletions(-)
+
+--- a/ncat/http_digest.c
++++ b/ncat/http_digest.c
+@@ -133,7 +133,7 @@ int http_digest_init_secret(void)
+     return 0;
+ }
+ 
+-#if OPENSSL_API_LEVEL < 10100
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ #define EVP_MD_CTX_new EVP_MD_CTX_create
+ #define EVP_MD_CTX_free EVP_MD_CTX_destroy
+ #endif
+--- a/ncat/ncat_connect.c
++++ b/ncat/ncat_connect.c
+@@ -82,8 +82,8 @@
+ #include <openssl/err.h>
+ 
+ /* Deprecated in OpenSSL 3.0 */
+-#if OPENSSL_API_LEVEL >= 30000
+-#define SSL_get_peer_certificate SSL_get1_peer_certificate
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
++# define SSL_get_peer_certificate SSL_get1_peer_certificate
+ #endif
+ #endif
+ 
+--- a/ncat/ncat_ssl.c
++++ b/ncat/ncat_ssl.c
+@@ -80,7 +80,7 @@
+ #define FUNC_ASN1_STRING_data ASN1_STRING_data
+ #endif
+ 
+-#if OPENSSL_API_LEVEL >= 30000
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+ #include <openssl/provider.h>
+ /* Deprecated in OpenSSL 3.0 */
+ #define SSL_get_peer_certificate SSL_get1_peer_certificate
+@@ -117,7 +117,7 @@ SSL_CTX *setup_ssl_listen(void)
+     OpenSSL_add_all_algorithms();
+     ERR_load_crypto_strings();
+     SSL_load_error_strings();
+-#elif OPENSSL_API_LEVEL >= 30000
++#elif OPENSSL_VERSION_NUMBER >= 0x30000000L
+   if (NULL == OSSL_PROVIDER_load(NULL, "legacy"))
+   {
+     loguser("OpenSSL legacy provider failed to load.\n");
+@@ -477,7 +477,7 @@ static int ssl_gen_cert(X509 **cert, EVP
+     const char *commonName = "localhost";
+     char dNSName[128];
+     int rc;
+-#if OPENSSL_API_LEVEL < 30000
++#if OPENSSL_VERSION_NUMBER < 0x30000000L
+     int ret = 0;
+     RSA *rsa = NULL;
+     BIGNUM *bne = NULL;
+--- a/ncat/ncat_ssl.h
++++ b/ncat/ncat_ssl.h
+@@ -67,18 +67,6 @@
+ #include <openssl/ssl.h>
+ #include <openssl/err.h>
+ 
+-/* OPENSSL_API_LEVEL per OpenSSL 3.0: decimal MMmmpp */
+-#ifndef OPENSSL_API_LEVEL
+-# if OPENSSL_API_COMPAT < 0x900000L
+-#  define OPENSSL_API_LEVEL (OPENSSL_API_COMPAT)
+-# else
+-#  define OPENSSL_API_LEVEL \
+-     (((OPENSSL_API_COMPAT >> 28) & 0xF) * 10000  \
+-      + ((OPENSSL_API_COMPAT >> 20) & 0xFF) * 100 \
+-      + ((OPENSSL_API_COMPAT >> 12) & 0xFF))
+-# endif
+-#endif
+-
+ #define NCAT_CA_CERTS_FILE "ca-bundle.crt"
+ 
+ enum {
+--- a/ncat/test/test-wildcard.c
++++ b/ncat/test/test-wildcard.c
+@@ -20,7 +20,7 @@ are rejected. The SSL transactions happe
+ 
+ #include "ncat_core.h"
+ #include "ncat_ssl.h"
+-#if OPENSSL_API_LEVEL < 30000
++#if OPENSSL_VERSION_NUMBER < 0x30000000L
+ #include <openssl/bn.h>
+ #endif
+ 
+@@ -294,7 +294,7 @@ stack_err:
+ static int gen_cert(X509 **cert, EVP_PKEY **key,
+     const struct lstr commonNames[], const struct lstr dNSNames[])
+ {
+-#if OPENSSL_API_LEVEL < 30000
++#if OPENSSL_VERSION_NUMBER < 0x30000000L
+     int rc, ret=0;
+     RSA *rsa = NULL;
+     BIGNUM *bne = NULL;
+--- a/nse_openssl.cc
++++ b/nse_openssl.cc
+@@ -20,6 +20,9 @@
+ #define FUNC_EVP_CIPHER_CTX_init EVP_CIPHER_CTX_reset
+ #define FUNC_EVP_CIPHER_CTX_cleanup EVP_CIPHER_CTX_reset
+ #define PASS_EVP_CTX(ctx) (ctx)
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
++# include <openssl/provider.h>
++#endif
+ #else
+ #define FUNC_EVP_MD_CTX_init EVP_MD_CTX_init
+ #define FUNC_EVP_MD_CTX_cleanup EVP_MD_CTX_cleanup
+@@ -37,23 +40,6 @@ extern NmapOps o;
+ 
+ #include "nse_openssl.h"
+ 
+-/* OPENSSL_API_LEVEL per OpenSSL 3.0: decimal MMmmpp */
+-#ifndef OPENSSL_API_LEVEL
+-# if OPENSSL_API_COMPAT < 0x900000L
+-#  define OPENSSL_API_LEVEL (OPENSSL_API_COMPAT)
+-# else
+-#  define OPENSSL_API_LEVEL \
+-     (((OPENSSL_API_COMPAT >> 28) & 0xF) * 10000  \
+-      + ((OPENSSL_API_COMPAT >> 20) & 0xFF) * 100 \
+-      + ((OPENSSL_API_COMPAT >> 12) & 0xFF))
+-# endif
+-#endif
+-
+-
+-#if OPENSSL_API_LEVEL >= 30000
+-#include <openssl/provider.h>
+-#endif
+-
+ #define NSE_SSL_LUA_ERR(_L) \
+     luaL_error(_L, "OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))
+ 
+@@ -184,7 +170,7 @@ static int l_bignum_is_prime( lua_State
+   bignum_data_t * p = (bignum_data_t *) luaL_checkudata( L, 1, "BIGNUM" );
+   BN_CTX * ctx = BN_CTX_new();
+   int is_prime =
+-#if OPENSSL_API_LEVEL < 30000
++#if OPENSSL_VERSION_NUMBER < 0x30000000L
+     BN_is_prime_ex( p->bn, BN_prime_checks, ctx, NULL );
+ #else
+     BN_check_prime( p->bn, ctx, NULL );
+@@ -199,7 +185,7 @@ static int l_bignum_is_safe_prime( lua_S
+   bignum_data_t * p = (bignum_data_t *) luaL_checkudata( L, 1, "BIGNUM" );
+   BN_CTX * ctx = BN_CTX_new();
+   int is_prime =
+-#if OPENSSL_API_LEVEL < 30000
++#if OPENSSL_VERSION_NUMBER < 0x30000000L
+     BN_is_prime_ex( p->bn, BN_prime_checks, ctx, NULL );
+ #else
+     BN_check_prime( p->bn, ctx, NULL );
+@@ -210,7 +196,7 @@ static int l_bignum_is_safe_prime( lua_S
+     BN_sub_word( n, (BN_ULONG)1 );
+     BN_div_word( n, (BN_ULONG)2 );
+     is_safe =
+-#if OPENSSL_API_LEVEL < 30000
++#if OPENSSL_VERSION_NUMBER < 0x30000000L
+       BN_is_prime_ex( n, BN_prime_checks, ctx, NULL );
+ #else
+       BN_check_prime( n, ctx, NULL );
+@@ -582,7 +568,7 @@ LUALIB_API int luaopen_openssl(lua_State
+ #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined LIBRESSL_VERSION_NUMBER
+   OpenSSL_add_all_algorithms();
+   ERR_load_crypto_strings();
+-#elif OPENSSL_API_LEVEL >= 30000
++#elif OPENSSL_VERSION_NUMBER >= 0x30000000L
+   if (NULL == OSSL_PROVIDER_load(NULL, "legacy") && o.debugging > 1)
+   {
+     // Legacy provider may not be available.
+--- a/nse_ssl_cert.cc
++++ b/nse_ssl_cert.cc
+@@ -89,19 +89,7 @@
+ #define X509_get0_notAfter X509_get_notAfter
+ #endif
+ 
+-/* OPENSSL_API_LEVEL per OpenSSL 3.0: decimal MMmmpp */
+-#ifndef OPENSSL_API_LEVEL
+-# if OPENSSL_API_COMPAT < 0x900000L
+-#  define OPENSSL_API_LEVEL (OPENSSL_API_COMPAT)
+-# else
+-#  define OPENSSL_API_LEVEL \
+-     (((OPENSSL_API_COMPAT >> 28) & 0xF) * 10000  \
+-      + ((OPENSSL_API_COMPAT >> 20) & 0xFF) * 100 \
+-      + ((OPENSSL_API_COMPAT >> 12) & 0xFF))
+-# endif
+-#endif
+-
+-#if OPENSSL_API_LEVEL >= 30000
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+ #include <openssl/core_names.h>
+ /* Deprecated in OpenSSL 3.0 */
+ #define SSL_get_peer_certificate SSL_get1_peer_certificate
+@@ -459,7 +447,7 @@ static const char *pkey_type_to_string(i
+ }
+ 
+ int lua_push_ecdhparams(lua_State *L, EVP_PKEY *pubkey) {
+-#if OPENSSL_API_LEVEL >= 30000
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+   char tmp[64] = {0};
+   size_t len = 0;
+   /* This structure (ecdhparams.curve_params) comes from tls.lua */
+@@ -634,7 +622,7 @@ static int parse_ssl_cert(lua_State *L,
+   else
+ #endif
+   if (pkey_type == EVP_PKEY_RSA) {
+-#if OPENSSL_API_LEVEL < 30000
++#if OPENSSL_VERSION_NUMBER < 0x30000000L
+     RSA *rsa = EVP_PKEY_get1_RSA(pubkey);
+     if (rsa) {
+ #endif
+@@ -643,7 +631,7 @@ static int parse_ssl_cert(lua_State *L,
+       luaL_getmetatable( L, "BIGNUM" );
+       lua_setmetatable( L, -2 );
+ #if HAVE_OPAQUE_STRUCTS
+-#if OPENSSL_API_LEVEL < 30000
++#if OPENSSL_VERSION_NUMBER < 0x30000000L
+       const BIGNUM *n = NULL, *e = NULL;
+       data->should_free = false;
+       RSA_get0_key(rsa, &n, &e, NULL);
+@@ -663,7 +651,7 @@ static int parse_ssl_cert(lua_State *L,
+       luaL_getmetatable( L, "BIGNUM" );
+       lua_setmetatable( L, -2 );
+ #if HAVE_OPAQUE_STRUCTS
+-#if OPENSSL_API_LEVEL < 30000
++#if OPENSSL_VERSION_NUMBER < 0x30000000L
+       data->should_free = false;
+ #else
+       data->should_free = true;
+@@ -673,7 +661,7 @@ static int parse_ssl_cert(lua_State *L,
+       data->bn = rsa->n;
+ #endif
+       lua_setfield(L, -2, "modulus");
+-#if OPENSSL_API_LEVEL < 30000
++#if OPENSSL_VERSION_NUMBER < 0x30000000L
+       RSA_free(rsa);
+     }
+ #endif
+--- a/nsock/src/nsock_ssl.c
++++ b/nsock/src/nsock_ssl.c
+@@ -64,7 +64,7 @@
+ #include "netutils.h"
+ 
+ #if HAVE_OPENSSL
+-#if OPENSSL_API_LEVEL >= 30000
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+ #include <openssl/provider.h>
+ #endif
+ 
+@@ -120,7 +120,7 @@ static SSL_CTX *ssl_init_helper(const SS
+     SSL_library_init();
+ #else
+     OPENSSL_atexit(nsock_ssl_atexit);
+-#if OPENSSL_API_LEVEL >= 30000
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+     if (NULL == OSSL_PROVIDER_load(NULL, "legacy"))
+     {
+       nsock_log_error("OpenSSL legacy provider failed to load.\n");
+--- a/nsock/src/nsock_ssl.h
++++ b/nsock/src/nsock_ssl.h
+@@ -69,20 +69,7 @@
+ #include <openssl/err.h>
+ #include <openssl/rand.h>
+ 
+-/* OPENSSL_API_LEVEL per OpenSSL 3.0: decimal MMmmpp */
+-#ifndef OPENSSL_API_LEVEL
+-# if OPENSSL_API_COMPAT < 0x900000L
+-#  define OPENSSL_API_LEVEL (OPENSSL_API_COMPAT)
+-# else
+-#  define OPENSSL_API_LEVEL \
+-     (((OPENSSL_API_COMPAT >> 28) & 0xF) * 10000  \
+-      + ((OPENSSL_API_COMPAT >> 20) & 0xFF) * 100 \
+-      + ((OPENSSL_API_COMPAT >> 12) & 0xFF))
+-# endif
+-#endif
+-
+-
+-#if OPENSSL_API_LEVEL >= 30000
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+ /* Deprecated in OpenSSL 3.0 */
+ #define SSL_get_peer_certificate SSL_get1_peer_certificate
+ #endif


### PR DESCRIPTION
Maintainer: @nunojpg 
Compile tested: nmap with OpenSSL 1.1 on OpenWrt 22.03 for Turris Omnia, mvebu/cortex-a9

Description:
The latest nmap version 7.9.3 currently fails to compile with OpenSSL 1.1 [1], it required to backport upstream patch to fix the compilation. [2]

[1] https://github.com/nmap/nmap/issues/2516
[2] https://github.com/nmap/nmap/commit/d6bea8dcdee36a3902cece14097993350306f1b6

**This is required for OpenWrt 22.03, but it does not mind to have it on OpenWrt master and thus backport it to OpenWrt 23.05 and OpenWrt 22.03.**
