### PR TITLE
pulseaudio: disable new optional library

### DIFF
--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pulseaudio
 PKG_VERSION:=16.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://freedesktop.org/software/pulseaudio/releases
@@ -122,13 +122,15 @@ MESON_ARGS += \
 	-Dx11=disabled \
 	-Dadrian-aec=true \
 	-Dwebrtc-aec=disabled \
-        -Ddoxygen=false
+        -Ddoxygen=false \
+        -Dtcpwrap=false
 
 ifeq ($(BUILD_VARIANT),avahi)
 MESON_ARGS += \
 	-Davahi=enabled \
 	-Dbluez5=enabled \
-	-Ddbus=enabled
+	-Ddbus=enabled \
+	-Dgstreamer=false
 endif
 
 ifeq ($(BUILD_VARIANT),noavahi)


### PR DESCRIPTION
Disable new optional library for pulseaudio added from package bump.