### PR TITLE
[ddns] fix Route53 script bug

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/update_route53_v1.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_route53_v1.sh
@@ -13,7 +13,7 @@ RECORD_TTL=300
 RECORD_NAME="${lookup_host}."
 [ ${use_ipv6} -eq 0 ] && RECORD_TYPE="A"
 [ ${use_ipv6} -eq 1 ] && RECORD_TYPE="AAAA"
-RECORD_VALUE="${LOCAL_IP}"
+RECORD_VALUE="${__IP}"
 HOSTED_ZONE_ID="${domain}"
 API_PATH="/2013-04-01/hostedzone/${HOSTED_ZONE_ID}/rrset/"
 


### PR DESCRIPTION
The Route53 DDNS script is looking for the curent IP in a variable called $LOCAL_IP however this is no longer valid the IP is now passed to the script in a variable called $__IP Unsure when this change occured but it is currently broken in 23.05. 

Signed-off-by: Seb Belcher s.d.j.belcher@gmail.com

Maintainer: Unknown
Compile tested: x86 23.05
Run tested: x86 23.05 - tested updates to several Route53 DNS records
Description:
The Route53 script is currently broken as it sends a blank IP to the endpoint.  The cause is that the script is looking at the variable $LOCAL_IP to get the current IP.  At some point (unknown) a change was made and this $LOCAL_IP variable is no longer populated (though this script seemed to work fine in 22.03).  Other DDNS client scripts have used the variable $__IP for the current IP for many years - so it would seem to be something upstream of the script has changed.  Applying this variable name change to the Route53 script gets it working again.  See here for commentary: https://forum.openwrt.org/t/route53v1-script-error/160068