### PR TITLE
libsodium: Update to 1.0.19 and fix patches

### DIFF
--- a/libs/libsodium/Makefile
+++ b/libs/libsodium/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsodium
-PKG_VERSION:=1.0.18
-PKG_RELEASE:=4
+PKG_VERSION:=1.0.19
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.libsodium.org/libsodium/releases \
 		https://github.com/jedisct1/libsodium/releases/download/$(PKG_VERSION)
-PKG_HASH:=6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1
+PKG_HASH:=018d79fe0a045cca07331d37bd0cb57b2e838c51bc48fd837a1472e50068bbea
 
 PKG_MAINTAINER:=Damiano Renfer <x9w2n7xnu@relay.firefox.com>
 PKG_LICENSE:=ISC
@@ -26,6 +26,9 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
+
+TAR_OPTIONS+= --strip-components 1
+TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 
 define Package/libsodium
   SECTION:=libs

--- a/libs/libsodium/patches/001-revert-f5076db5f8ef27.patch
+++ b/libs/libsodium/patches/001-revert-f5076db5f8ef27.patch
@@ -1,6 +1,6 @@
 --- a/src/libsodium/Makefile.am
 +++ b/src/libsodium/Makefile.am
-@@ -59,6 +59,7 @@ libsodium_la_SOURCES = \
+@@ -73,6 +73,7 @@ libsodium_la_SOURCES = \
  	crypto_scalarmult/curve25519/ref10/x25519_ref10.h \
  	crypto_scalarmult/curve25519/scalarmult_curve25519.c \
  	crypto_scalarmult/curve25519/scalarmult_curve25519.h \
@@ -8,7 +8,7 @@
  	crypto_secretbox/crypto_secretbox.c \
  	crypto_secretbox/crypto_secretbox_easy.c \
  	crypto_secretbox/xsalsa20poly1305/secretbox_xsalsa20poly1305.c \
-@@ -160,7 +161,6 @@ libsodium_la_SOURCES += \
+@@ -173,7 +174,6 @@ libsodium_la_SOURCES += \
  	crypto_pwhash/scryptsalsa208sha256/pbkdf2-sha256.h \
  	crypto_pwhash/scryptsalsa208sha256/pwhash_scryptsalsa208sha256.c \
  	crypto_pwhash/scryptsalsa208sha256/nosse/pwhash_scryptsalsa208sha256_nosse.c \
@@ -18,7 +18,7 @@
  	crypto_shorthash/siphash24/shorthash_siphashx24.c \
 --- a/src/libsodium/include/sodium.h
 +++ b/src/libsodium/include/sodium.h
-@@ -33,6 +33,7 @@
+@@ -39,6 +39,7 @@
  #include "sodium/crypto_pwhash_argon2i.h"
  #include "sodium/crypto_scalarmult.h"
  #include "sodium/crypto_scalarmult_curve25519.h"
@@ -26,11 +26,11 @@
  #include "sodium/crypto_secretbox.h"
  #include "sodium/crypto_secretbox_xsalsa20poly1305.h"
  #include "sodium/crypto_secretstream_xchacha20poly1305.h"
-@@ -57,7 +58,6 @@
- # include "sodium/crypto_box_curve25519xchacha20poly1305.h"
- # include "sodium/crypto_core_ed25519.h"
- # include "sodium/crypto_core_ristretto255.h"
--# include "sodium/crypto_scalarmult_ed25519.h"
- # include "sodium/crypto_scalarmult_ristretto255.h"
- # include "sodium/crypto_secretbox_xchacha20poly1305.h"
- # include "sodium/crypto_pwhash_scryptsalsa208sha256.h"
+@@ -64,7 +65,6 @@
+ #include "sodium/crypto_core_ed25519.h"
+ #include "sodium/crypto_core_ristretto255.h"
+ #include "sodium/crypto_pwhash_scryptsalsa208sha256.h"
+-#include "sodium/crypto_scalarmult_ed25519.h"
+ #include "sodium/crypto_scalarmult_ristretto255.h"
+ #include "sodium/crypto_secretbox_xchacha20poly1305.h"
+ #include "sodium/crypto_stream_salsa2012.h"

--- a/libs/libsodium/patches/100-minimal-build-with-ed25519-core.patch
+++ b/libs/libsodium/patches/100-minimal-build-with-ed25519-core.patch
@@ -1,6 +1,6 @@
 --- a/src/libsodium/Makefile.am
 +++ b/src/libsodium/Makefile.am
-@@ -12,6 +12,7 @@ libsodium_la_SOURCES = \
+@@ -23,6 +23,7 @@ libsodium_la_SOURCES = \
  	crypto_box/crypto_box_easy.c \
  	crypto_box/crypto_box_seal.c \
  	crypto_box/curve25519xsalsa20poly1305/box_curve25519xsalsa20poly1305.c \
@@ -8,7 +8,7 @@
  	crypto_core/ed25519/ref10/ed25519_ref10.c \
  	crypto_core/hchacha20/core_hchacha20.c \
  	crypto_core/hsalsa20/ref2/core_hsalsa20_ref2.c \
-@@ -152,7 +153,6 @@ if !MINIMAL
+@@ -165,7 +166,6 @@ if !MINIMAL
  libsodium_la_SOURCES += \
  	crypto_box/curve25519xchacha20poly1305/box_curve25519xchacha20poly1305.c \
  	crypto_box/curve25519xchacha20poly1305/box_seal_curve25519xchacha20poly1305.c \
@@ -18,19 +18,19 @@
  	crypto_pwhash/scryptsalsa208sha256/crypto_scrypt.h \
 --- a/src/libsodium/include/sodium.h
 +++ b/src/libsodium/include/sodium.h
-@@ -14,6 +14,7 @@
+@@ -16,6 +16,7 @@
  #include "sodium/crypto_auth_hmacsha512256.h"
  #include "sodium/crypto_box.h"
  #include "sodium/crypto_box_curve25519xsalsa20poly1305.h"
 +#include "sodium/crypto_core_ed25519.h"
- #include "sodium/crypto_core_hsalsa20.h"
  #include "sodium/crypto_core_hchacha20.h"
+ #include "sodium/crypto_core_hsalsa20.h"
  #include "sodium/crypto_core_salsa20.h"
-@@ -56,7 +57,6 @@
+@@ -62,7 +63,6 @@
  
  #ifndef SODIUM_LIBRARY_MINIMAL
- # include "sodium/crypto_box_curve25519xchacha20poly1305.h"
--# include "sodium/crypto_core_ed25519.h"
- # include "sodium/crypto_core_ristretto255.h"
- # include "sodium/crypto_scalarmult_ristretto255.h"
- # include "sodium/crypto_secretbox_xchacha20poly1305.h"
+ #include "sodium/crypto_box_curve25519xchacha20poly1305.h"
+-#include "sodium/crypto_core_ed25519.h"
+ #include "sodium/crypto_core_ristretto255.h"
+ #include "sodium/crypto_pwhash_scryptsalsa208sha256.h"
+ #include "sodium/crypto_scalarmult_ristretto255.h"


### PR DESCRIPTION
Maintainer: @damianorenfer 
Compile and run-tested: bcm2711 (rpi4), mt7622 (Linksys E8450), ath79 (TP-Link Archer C7 v5)

Fixes https://github.com/openwrt/packages/issues/22171.

Unfortunately, latest libsodium-1.0.19.tar.gz extracts to libsodium-stable. That's why I had to update PKG_BUILD_DIR, maybe (hopefully) this can be reverted on next libsodium release.