### PR TITLE
Added python-fnv-hash-fast, python-lru-dict, and python-orjson

### DIFF
--- a/lang/python/python-fnv-hash-fast/Makefile
+++ b/lang/python/python-fnv-hash-fast/Makefile
@@ -1,0 +1,38 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-fnv-hash-fast
+PKG_VERSION:=0.5.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=fnv-hash-fast
+PYPI_SOURCE_NAME:=fnv_hash_fast
+PKG_HASH:=a84d658952776a186418f4158fc8e55ff3c576ac32cc9ef7f8077efdf2d0b89f
+
+PKG_MAINTAINER:=Timothy Ace <openwrt@timothyace.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=python-cython/host python-poetry-core/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-fnv-hash-fast
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=A fast version of fnv1a
+  URL:=https://github.com/bdraco/fnv-hash-fast
+  DEPENDS:=+libstdcpp +python3-light +python3-fnvhash
+endef
+
+define Package/python3-fnv-hash-fast/description
+A fast version of fnv1a. This library will use a CPP implementation of fnv1a
+(32) if cython is available, and will fallback to pure python from the fnvhash
+package if it is not.
+endef
+
+$(eval $(call Py3Package,python3-fnv-hash-fast))
+$(eval $(call BuildPackage,python3-fnv-hash-fast))
+$(eval $(call BuildPackage,python3-fnv-hash-fast-src))

--- a/lang/python/python-fnvhash/Makefile
+++ b/lang/python/python-fnvhash/Makefile
@@ -1,0 +1,33 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-fnvhash
+PKG_VERSION:=0.1.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=fnvhash
+PKG_HASH:=3e82d505054f9f3987b2b5b649f7e7b6f48349f6af8a1b8e4d66779699c85a8e
+
+PKG_MAINTAINER:=Timothy Ace <openwrt@timothyace.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-fnvhash
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Pure Python FNV hash implementation
+  URL:=https://github.com/znerol/py-fnvhash
+  DEPENDS:=+python3-light
+endef
+
+define Package/python3-fnvhash/description
+Pure Python implementation of the FNV hash family with 100% test coverage.
+endef
+
+$(eval $(call Py3Package,python3-fnvhash))
+$(eval $(call BuildPackage,python3-fnvhash))
+$(eval $(call BuildPackage,python3-fnvhash-src))

--- a/lang/python/python-lru-dict/Makefile
+++ b/lang/python/python-lru-dict/Makefile
@@ -1,0 +1,37 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-lru-dict
+PKG_VERSION:=1.3.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=lru-dict
+PKG_HASH:=54fd1966d6bd1fcde781596cb86068214edeebff1db13a2cea11079e3fd07b6b
+
+PKG_MAINTAINER:=Timothy Ace <openwrt@timothyace.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-lru-dict
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=An Dict like LRU container
+  URL:=https://github.com/amitdev/lru-dict
+  DEPENDS:=+python3-light
+endef
+
+define Package/python3-lru-dict/description
+A fixed size dict like container which evicts Least Recently Used (LRU) items
+once size limit is exceeded. There are many python implementations available
+which does similar things. This is a fast and efficient C implementation. LRU
+maximum capacity can be modified at run-time. If you are looking for pure
+python version, look elsewhere.
+endef
+
+$(eval $(call Py3Package,python3-lru-dict))
+$(eval $(call BuildPackage,python3-lru-dict))
+$(eval $(call BuildPackage,python3-lru-dict-src))

--- a/lang/python/python-orjson/Makefile
+++ b/lang/python/python-orjson/Makefile
@@ -1,0 +1,37 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-orjson
+PKG_VERSION:=3.9.10
+PKG_RELEASE:=1
+
+PYPI_NAME:=orjson
+PKG_HASH:=9ebbdbd6a046c304b1845e96fbcc5559cd296b4dfd3ad2509e33c4d9ce07d6a1
+
+PKG_MAINTAINER:=Timothy Ace <openwrt@timothyace.com>
+PKG_LICENSE:=Apache-2.0 MIT
+PKG_LICENSE_FILES:=LICENSE-APACHE LICENSE-MIT
+
+PKG_BUILD_DEPENDS:=python-maturin/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-orjson
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Fast, correct Python JSON library
+  URL:=https://github.com/ijl/orjson
+  DEPENDS:= \
+	+python3-light \
+	$(RUST_ARCH_DEPENDS)
+endef
+
+define Package/python3-orjson/description
+Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy
+endef
+
+$(eval $(call Py3Package,python3-orjson))
+$(eval $(call BuildPackage,python3-orjson))
+$(eval $(call BuildPackage,python3-orjson-src))


### PR DESCRIPTION
Specific module versions added:
- python-fnvhash v0.1.0
- python-fnv-hash-fast v0.5.0
- python-lru-dict v1.3.0
- python-orjson v3.9.10

Maintainer: me
Compile tested:
- arch: arm_cortex-a9_vfpv3-d16
- model: Linksys WRT1900ACS
- OpenWRT versions:
-- 23.05.0 r23497-6637af95aa (note: had to back-port python-maturin from master)
-- master
Run tested:
- arch: arm_cortex-a9_vfpv3-d16
- model: Linksys WRT1900ACS
- OpenWRT version: 23.05.0 r23497-6637af95aa
- successful install and run of HomeAssistant v2023.11.1

Description:
These three compiled modules are required by the latest release (2023.11.1) for the HomeAssistant project. While HomeAssistant is not yet supported on openwrt, I was able to get 2023.11.1 working and may at some point add a package to openwrt. For now, these modules may be useful to some people for other projects.

Note: There was a specific issue I was having with python-orjson that necessitated the line `PATH:=$(TARGET_PATH_PKG)` be added to the Makefile. This was because `$(STAGING_DIR_HOSTPKG)` was not being added to the PATH for some reason, but rather `staging_dir/host/bin` was being added to the PATH twice. This could either be form a bug in the build system or simply my lack of expertise with it. This was using the `openwrt/sdk:mvebu-cortexa9-openwrt-23.05` docker image. If adding this PATH override should cause any issues or if there is a proper way to get `$(STAGING_DIR_HOSTPKG)` added to the path, please suggest an alternative.