### PR TITLE
tang: set the right permissions to keys

### DIFF
--- a/utils/tang/Makefile
+++ b/utils/tang/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tang
 PKG_VERSION:=14
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/latchset/$(PKG_NAME)/releases/download/v$(PKG_VERSION)/

--- a/utils/tang/Makefile
+++ b/utils/tang/Makefile
@@ -15,7 +15,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/latchset/$(PKG_NAME)/releases/download/v$(PKG_VERSION)/
 PKG_HASH:=04263ed1cc98d60cab29fe47f908921b7b1aa4d6da5f9de2fcbe543773b75886
 
-PKG_MAINTAINER:=Tibor Dudlák <tibor.dudlak@gmail.com>
+PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING
 

--- a/utils/tang/files/tang.init
+++ b/utils/tang/files/tang.init
@@ -8,6 +8,7 @@ start_service() {
 	if [ -z "${KEYS}" ] || [ "${KEYS}" = "0" ]; then # if db is empty generate new key pair
 		mkdir -p /usr/share/tang/db
 		/usr/sbin/tangd-keygen /usr/share/tang/db
+		chown -R tang /usr/share/tang/db
 	fi
 
 	config_load "tang"


### PR DESCRIPTION
Maintainer: me
Compile tested: -
Run tested: -

Description:
This corrects the permissions of generated files and sets the right maintainer.

Resolves: #22632
