### PR TITLE
tailscale: Update to 1.52.1

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.50.1
+PKG_VERSION:=1.52.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=183a7d559590a759dd77aa9c2b65486ab6e13c26f3c07fad0b536e318ad5e233
+PKG_HASH:=297d01584104dde7d1e5d2e99ee57c6a60579dc4f494ed9d2306716e031af19a
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: @ja-pa @oskarirauta
<!-- (commented until I really tested)
Compile tested: `aarch64_cortex-a53` @ SNAPSHOT
Run tested: `aarch64_cortex-a53` @ SNAPSHOT
-->

Signed-off-by: Zephyr Lykos <git@mochaa.ws>
