### PR TITLE
sstp-client: bump to 1.0.19

### DIFF
--- a/net/sstp-client/Makefile
+++ b/net/sstp-client/Makefile
@@ -8,16 +8,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sstp-client
-PKG_VERSION:=1.0.15
+PKG_VERSION:=1.0.19
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SF/sstp-client/$(PKG_VERSION)
-PKG_HASH:=8484aa51fbfbe418a0ebad58ad20a8ee1c46ed71f800be18bcd23b42e6baad64
+PKG_SOURCE_URL:=https://gitlab.com/sstp-project/sstp-client/-/archive/1.0.19/
+PKG_HASH:=e2652365f69f5037102e78f4e115ff764a390b27bb3fd513a8a50b10a61bb613
 
 PKG_MAINTAINER:=Federico Di Marco <fededim@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
+
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/sstp-client/patches/200-openssl-deprecated.patch
+++ b/net/sstp-client/patches/200-openssl-deprecated.patch
@@ -1,6 +1,6 @@
 --- a/src/sstp-client.c
 +++ b/src/sstp-client.c
-@@ -542,6 +542,7 @@ static status_t sstp_init_ssl(sstp_clien
+@@ -546,6 +546,7 @@ static status_t sstp_init_ssl(sstp_clien
      int retval = SSTP_FAIL;
      int status = 0;
  
@@ -8,7 +8,7 @@
      /* Initialize the OpenSSL library */
      status = SSL_library_init();
      if (status != 1)
-@@ -555,6 +556,9 @@ static status_t sstp_init_ssl(sstp_clien
+@@ -575,6 +576,9 @@ static status_t sstp_init_ssl(sstp_clien
  
      /* Create a new crypto context */
      client->ssl_ctx = SSL_CTX_new(SSLv23_client_method());


### PR DESCRIPTION
Maintainer: @neheb 
Compile tested: OpenWrt master
Run tested: ipq40xx

Description:

After 1.0.18, this project moved from SourceForge to gitlab
Also, since 1.0.19, the configure script is not present by default anymore, so we need to add autoreconf to generate it

Release notes:
https://gitlab.com/sstp-project/sstp-client/-/releases
