### PR TITLE
unbound: update to 1.19.0

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.18.0
+PKG_VERSION:=1.19.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound
-PKG_HASH:=3da95490a85cff6420f26fae0b84a49f5112df1bf1b7fc34f8724f02082cb712
+PKG_HASH:=a97532468854c61c2de48ca4170de854fd3bc95c8043bb0cfb0fe26605966624
 
 PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/unbound/patches/010-configure-uname.patch
+++ b/net/unbound/patches/010-configure-uname.patch
@@ -3,7 +3,7 @@ Fix cross compile errors by inserting an environment variable for the
 target. Use "uname" on host only if "UNAME" variable is empty.
 --- a/configure.ac
 +++ b/configure.ac
-@@ -840,7 +840,7 @@ if test x_$ub_test_python != x_no; then
+@@ -842,7 +842,7 @@ if test x_$ub_test_python != x_no; then
     fi
  fi
  


### PR DESCRIPTION
Maintainer: me
Tested: Linksys WRT3200ACM
Description: update to 1.19.0 and bring PR \22594 along
Fixes: #22594
Fixes: #22593
