### PR TITLE
gensio: prevent accidental use of dns_sd

### DIFF
--- a/net/gensio/Makefile
+++ b/net/gensio/Makefile
@@ -49,6 +49,7 @@ CONFIGURE_ARGS += \
 	--without-afskmdm \
 	--without-ax25 \
 	--without-alsa \
+	--without-dnssd \
 	--without-go \
 	--without-ipmisol \
 	--without-kiss \


### PR DESCRIPTION
Maintainer: @WereCatf 
Compile tested: mxs
Run tested: no

Description:

Buildbots spottet this error that when dns_sd library is available, then gensio's configure will pick it up. This is not desired since we already link to libavahi for the mdns stuff, so let's disable dnssd lookup explicitly.
