### PR TITLE
gensio: disable cm108gpio gensio and prevent using libudev

### DIFF
--- a/net/gensio/Makefile
+++ b/net/gensio/Makefile
@@ -47,8 +47,9 @@ CONFIGURE_ARGS += \
 	--$(if $(CONFIG_GENSIO_GLIB),with,without)-glib \
 	--$(if $(CONFIG_GENSIO_TCL),with,without)-tcl \
 	--without-afskmdm \
-	--without-ax25 \
 	--without-alsa \
+	--without-ax25 \
+	--without-cm108gpio \
 	--without-dnssd \
 	--without-go \
 	--without-ipmisol \
@@ -56,6 +57,7 @@ CONFIGURE_ARGS += \
 	--without-openipmi \
 	--without-portaudio \
 	--without-sound \
+	--without-udev \
 	--with-cplusplus \
 	--with-flock-locking \
 	--with-uucp-locking \


### PR DESCRIPTION
Maintainer: @WereCatf 
Compile tested: mxs
Run tested: -

Description:

libudev seems to be required only for cm108gpio gensio which is a relatively special one. Let's disable it and also the libudev lookup, so that there is no need to link/use libudev.
(While at, sort the without arguments alphabetically.)