### PR TITLE
freeradius3: Fix build when pcre is present

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
 PKG_VERSION:=3.0.26
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=freeradius-server-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/releases/download/release_$(subst .,_,$(PKG_VERSION))/
@@ -63,7 +63,7 @@ endef
 define Package/freeradius3-common
   $(call Package/freeradius3/Default)
   TITLE:=common files
-  DEPENDS:=+USE_GLIBC:libpthread +USE_GLIBC:libbsd +FREERADIUS3_OPENSSL:libopenssl +libcap +libpcap +libncurses +libpcre2 +libreadline +libtalloc +libatomic
+  DEPENDS:=+USE_GLIBC:libpthread +USE_GLIBC:libbsd +FREERADIUS3_OPENSSL:libopenssl +libcap +libpcap +libncurses +libreadline +libtalloc +libatomic
 endef
 
 define Package/freeradius3-default
@@ -499,6 +499,7 @@ CONFIGURE_ARGS+= \
 	--with-radacctdir=/var/db/radacct \
 	--with-logdir=/var/log \
 	--without-edir \
+	--without-pcre \
 	--without-snmp \
 	--without-rlm_cache \
 	--without-rlm_cache_memcached \


### PR DESCRIPTION
Maintainer: none
Compile tested: armsr-armv7, 2023-11-10 snapshot sdk
Run tested: none

Description:
If pcre is built before freeradius, then freeradius' configure will detect pcre and freeradius will be built with pcre functionality enabled. This causes a "missing dependencies" error at the end of package build.

This passes `--without-pcre` to configure to disable this autodetection.

This also removes the dependency on libpcre2 as freeradius v3 does not have support for pcre2.

Fixes: 19ec30255f13 ("freeradius3: switch to pcre2")
Fixes: https://github.com/openwrt/packages/issues/22574