### PR TITLE
snort3: fix compilation with gcc13

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.1.74.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/

--- a/net/snort3/patches/010-gcc13.patch
+++ b/net/snort3/patches/010-gcc13.patch
@@ -1,0 +1,14 @@
+--- a/src/network_inspectors/packet_capture/packet_capture.h
++++ b/src/network_inspectors/packet_capture/packet_capture.h
+@@ -20,9 +20,10 @@
+ #ifndef PACKET_CAPTURE_H
+ #define PACKET_CAPTURE_H
+ 
++#include <cstdint>
+ #include <string>
+ 
+-void packet_capture_enable(const std::string&, const int16_t g = -1);
++void packet_capture_enable(const std::string&, const std::int16_t g = -1);
+ void packet_capture_disable();
+ 
+ #endif


### PR DESCRIPTION
Missing header.

Maintainer: @flyn-org 