### PR TITLE
openvpn: update to 2.6.8

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.6.6
+PKG_VERSION:=2.6.8
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=3b074f392818b31aa529b84f76e8b5e4ad03fca764924f46d906bceaaf421034
+PKG_HASH:=5ede1565c8a6d880100f7f235317a7ee9eea83d5052db5547f13a9e76af7805d
 
 PKG_MAINTAINER:=Magnus Kroken <mkroken@gmail.com>
 

--- a/net/openvpn/patches/100-mbedtls-disable-runtime-version-check.patch
+++ b/net/openvpn/patches/100-mbedtls-disable-runtime-version-check.patch
@@ -1,6 +1,6 @@
 --- a/src/openvpn/ssl_mbedtls.c
 +++ b/src/openvpn/ssl_mbedtls.c
-@@ -1535,7 +1535,7 @@ const char *
+@@ -1533,7 +1533,7 @@ const char *
  get_ssl_library_version(void)
  {
      static char mbedtls_version[30];

--- a/net/openvpn/patches/101-Fix-EVP_PKEY_CTX_-compilation-with-wolfSSL.patch
+++ b/net/openvpn/patches/101-Fix-EVP_PKEY_CTX_-compilation-with-wolfSSL.patch
@@ -1,6 +1,6 @@
 --- a/src/openvpn/crypto_openssl.c
 +++ b/src/openvpn/crypto_openssl.c
-@@ -51,7 +51,7 @@
+@@ -49,7 +49,7 @@
  #include <openssl/rand.h>
  #include <openssl/ssl.h>
  
@@ -9,8 +9,8 @@
  #include <openssl/kdf.h>
  #endif
  #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-@@ -1436,7 +1436,7 @@ engine_load_key(const char *file, SSL_CT
- #endif /* if HAVE_OPENSSL_ENGINE */
+@@ -1374,7 +1374,7 @@ memcmp_constant_time(const void *a, cons
+     return CRYPTO_memcmp(a, b, size);
  }
  
 -#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)

--- a/net/openvpn/patches/102-Disable-external-ec-key-support-when-building-with-wolfSSL.patch
+++ b/net/openvpn/patches/102-Disable-external-ec-key-support-when-building-with-wolfSSL.patch
@@ -1,6 +1,6 @@
 --- a/src/openvpn/ssl_openssl.c
 +++ b/src/openvpn/ssl_openssl.c
-@@ -1351,7 +1351,7 @@ err:
+@@ -1347,7 +1347,7 @@ err:
      return 0;
  }
  
@@ -9,7 +9,7 @@
  
  /* called when EC_KEY is destroyed */
  static void
-@@ -1512,7 +1512,7 @@ tls_ctx_use_management_external_key(stru
+@@ -1508,7 +1508,7 @@ tls_ctx_use_management_external_key(stru
              goto cleanup;
          }
      }

--- a/net/openvpn/patches/103-define-LN_serialNumber-for-wolfSSL.patch
+++ b/net/openvpn/patches/103-define-LN_serialNumber-for-wolfSSL.patch
@@ -1,6 +1,6 @@
 --- a/src/openvpn/ssl_verify_openssl.c
 +++ b/src/openvpn/ssl_verify_openssl.c
-@@ -269,6 +269,9 @@ backend_x509_get_username(char *common_n
+@@ -267,6 +267,9 @@ backend_x509_get_username(char *common_n
              return FAILURE;
          }
      }


### PR DESCRIPTION
Maintainer: @mkrkn
Compile tested: ramips/mt7620, ramips/mt7621
Run tested: Xiaomi mi router 3 pro, Xiaomi mi-mini, Xiaomi miwifi-r3

Is a regression fix release for previous release that containing bugfixes and security fixes.

Security Fixes (included in 2.6.7):

CVE-2023-46850 OpenVPN versions between 2.6.0 and 2.6.6 incorrectly use a send buffer after it has been free()d in some circumstances, causing some free()d memory to be sent to the peer. All configurations using TLS (e.g. not using --secret) are affected by this issue.

CVE-2023-46849 OpenVPN versions between 2.6.0 and 2.6.6 incorrectly restore --fragment configuration in some circumstances, leading to a division by zero when --fragment is used. On platforms where division by zero is fatal, this will cause an OpenVPN crash.

For details refer to https://github.com/OpenVPN/openvpn/blob/v2.6.8/Changes.rst

