### PR TITLE
dhtd: update to 0.2.4

### DIFF
--- a/net/dhtd/Makefile
+++ b/net/dhtd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dhtd
-PKG_VERSION:=0.2.1
+PKG_VERSION:=0.2.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mwarning/dhtd/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=65d2e0d6a3648fe3619d9fa4bef34a76c22577b7fe3fe460f96ac10510c3f06a
+PKG_HASH:=0f35cd0016689682b277f9769ec1e95c3c1321479cedc9727abc0bc91a0427d5
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
 PKG_LICENSE:=MIT

--- a/net/dhtd/files/dhtd.config
+++ b/net/dhtd/files/dhtd.config
@@ -15,6 +15,9 @@ config dhtd
 	list peer 'bttracker.debian.org:6881'
 	list peer 'router.bittorrent.com:6881'
 
+## Execute a script for each result
+#	option execute '/root/on_result.sh'
+
 ## Bind the DHT to this port.
 #	option port '6881'
 

--- a/net/dhtd/files/dhtd.init
+++ b/net/dhtd/files/dhtd.init
@@ -54,7 +54,7 @@ start_instance() {
 
 	OPTS=""
 
-	append_opts "$cfg" verbosity peerfile port
+	append_opts "$cfg" verbosity peerfile port execute
 
 	config_get ifname "$cfg" "ifname"
 	if network_get_device IFNAME "$ifname";then


### PR DESCRIPTION
Signed-off-by: Moritz Warning <moritzwarning@web.de>
(cherry picked from commit 819cf67a338611681d2bee7ee37eec5864110fc3)

Maintainer: me
Compile tested: ramips/mt7620, Nexx wt3020, OpenWrt master ([255d5c9bf8430bea8ee342b0132be0787b509634](https://github.com/openwrt/openwrt/commit/255d5c9bf8430bea8ee342b0132be0787b509634))
Run tested: same as compile version, tested: bootstrap, search and print results, execute script on result
