### PR TITLE
sockread: cleanup code and allow arguments

### DIFF
--- a/utils/sockread/Makefile
+++ b/utils/sockread/Makefile
@@ -4,8 +4,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sockread
-PKG_VERSION:=1.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.1
+PKG_RELEASE:=1
 PKG_LICENSE:=CC0-1.0
 
 include $(INCLUDE_DIR)/package.mk
@@ -13,13 +13,12 @@ include $(INCLUDE_DIR)/package.mk
 define Package/sockread
 	SECTION:=utils
 	CATEGORY:=Utilities
-	TITLE:=sockread
+	TITLE:=Unix domain sockets utility
 	MAINTAINER:=Moritz Warning <moritzwarning@web.de>
 endef
 
 define Package/sockread/description
-	sockread writes and reads data from a Unix domain socket
-	represented as a special file on the file system.
+	Command line utility to read and write to Unix domain sockets.
 endef
 
 define Build/Prepare

--- a/utils/sockread/src/main.c
+++ b/utils/sockread/src/main.c
@@ -7,57 +7,65 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
-int main(int argc, char *argv[]) {
-	char buf[1024];
-	ssize_t r;
+const char *usage =
+    "Write to and read from a Unix domain socket.\n"
+    "Add commands to send as arguments or pass by pipe.\n"
+    "\n"
+    "Usage: sockread <path> [<commands>]\n";
 
-	if (argc != 2) {
-		fprintf(stderr, "Write to and read from a Unix domain socket.\n\nUsage: %s <socket>\n", argv[0]);
-		return 1;
-	}
+int main(int argc, char *argv[])
+{
+    char buffer[1024];
+    ssize_t r;
 
-	size_t addrlen = strlen(argv[1]);
+    if (argc < 2) {
+        fprintf(stderr, "%s", usage);
+        return EXIT_FAILURE;
+    }
 
-	/* Allocate enough space for arbitrary-length paths */
-	char addrbuf[offsetof(struct sockaddr_un, sun_path) + addrlen + 1];
-	memset(addrbuf, 0, sizeof(addrbuf));
+    struct sockaddr_un address = {0};
+    address.sun_family = AF_UNIX;
+    strcpy((char*) &address.sun_path, argv[1]);
 
-	struct sockaddr_un *addr = (struct sockaddr_un *)addrbuf;
-	addr->sun_family = AF_UNIX;
-	memcpy(addr->sun_path, argv[1], addrlen+1);
+    int sock = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (sock < 0) {
+        fprintf(stderr, "socket() %s\n", strerror(errno));
+        return EXIT_FAILURE;
+    }
 
-	int fd = socket(AF_UNIX, SOCK_STREAM, 0);
-	if (fd < 0) {
-		fprintf(stderr, "Failed to create socket: %s\n", strerror(errno));
-		return 1;
-	}
+    if (connect(sock, (struct sockaddr*)&address, sizeof(address)) < 0) {
+        fprintf(stderr, "connect() %s\n", strerror(errno));
+        return EXIT_FAILURE;
+    }
 
-	if (connect(fd, (struct sockaddr*)addr, sizeof(addrbuf)) < 0) {
-		fprintf(stderr, "Can't connect to `%s': %s\n", argv[1], strerror(errno));
-		return 1;
-	}
+    /* Check if stdin refers to a terminal */
+    if (!isatty(fileno(stdin))) {
+        /* Read from stdin and write to socket */
+        while (0 < (r = fread(buffer, 1, sizeof(buffer), stdin))) {
+            send(sock, buffer, r, 0);
+        }
+    } else {
+        for (size_t i = 2; i < argc; i++) {
+            if (i > 2) {
+                send(sock, " ", 1, 0);
+            }
+            send(sock, argv[i], strlen(argv[i]), 0);
+        }
+    }
 
-	/* Check if stdin refers to a terminal */
-	if (!isatty(fileno(stdin))) {
-		/* Read from stdin and write to socket */
-		while (0 < (r = fread(buf, 1, sizeof(buf), stdin))) {
-			send(fd, buf, r, 0);
-		}
-	}
+    /* Read from socket and write to stdout */
+    while (1) {
+        r = recv(sock, buffer, sizeof(buffer), 0);
+        if (r < 0) {
+            fprintf(stderr, "recv() %s\n", strerror(errno));
+            return EXIT_FAILURE;
+        }
 
-	/* Read from socket and write to stdout */
-	while (1) {
-		r = recv(fd, buf, sizeof(buf), 0);
-		if (r < 0) {
-			fprintf(stderr, "read: %s\n", strerror(errno));
-			return 1;
-		}
+        if (r == 0)
+            break;
 
-		if (r == 0)
-			return 0;
+        fwrite(buffer, r, 1, stdout);
+    }
 
-		fwrite(buf, r, 1, stdout);
-	}
-
-	return 0;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
* cleanup code style
* allow arguments to be passed from the command line

Maintainer: me
Compile tested: ramips/mt7620, Nexx wt3020, OpenWrt master ([0f283ab4c9d9b7971a19172ca5d15035c801cb24](https://github.com/openwrt/openwrt/commit/0f283ab4c9d9b7971a19172ca5d15035c801cb24))
Run tested: (put here arch, model, OpenWrt version, tests done)
