### PR TITLE
strongswan: support /var/swanctl/conf.d/*.conf

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -573,6 +573,7 @@ define Package/strongswan-swanctl/install
 	$(INSTALL_DIR) $(1)/etc/swanctl/x509{,aa,ac,ca,crl,ocsp}
 	$(CP) $(PKG_INSTALL_DIR)/etc/swanctl/swanctl.conf $(1)/etc/swanctl/
 	echo "include /var/swanctl/swanctl.conf" >> $(1)/etc/swanctl/swanctl.conf
+	echo "include /var/swanctl/conf.d/*.conf" >> $(1)/etc/swanctl/swanctl.conf
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/swanctl $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/swanctl.init $(1)/etc/init.d/swanctl

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -712,7 +712,7 @@ do_postamble() {
 }
 
 prepare_env() {
-	mkdir -p /var/ipsec /var/swanctl
+	mkdir -p /var/ipsec /var/swanctl/conf.d
 
 	swan_reset
 	swanctl_reset


### PR DESCRIPTION
Maintainer: @pprindeville @Thermi 
Compile tested: x86 master
Run tested: x86 master

Description:

Sometimes, users might want to generate dynamic conf files. One example would be creating a IPv6 pool using WAN PD that might change. Currently, only /etc/swanctl/conf.d/*.conf is supported for user conf files, but it's not a good fit for dynamic ones, since upon rebooting the device, the conf can become stale.

With this change, users, for example, can use hotplug to create the conf in /var/swanctl/conf.d and have swanctl correctly load it.

They could of course add the include directive in
/etc/swanctl/swanctl.conf, but then they have to also remember creating the /var/swanctl/conf.d directory before every generation of the dynamic conf, which can be cumbersome. Given OpenWrt's popularity in home network, direct support for dynamic user conf files should be desirable.