### PR TITLE
rust: Update to 1.74.0

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
-PKG_VERSION:=1.73.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.74.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
-PKG_HASH:=96d62e6d1f2d21df7ac8acb3b9882411f9e7c7036173f7f2ede9e1f1f6b1bb3a
+PKG_HASH:=882b584bc321c5dcfe77cdaa69f277906b936255ef7808fcd5c7492925cf1049
 HOST_BUILD_DIR:=$(BUILD_DIR)/host/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>

--- a/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
+++ b/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
@@ -11,7 +11,7 @@ Subject: [PATCH] Update xz2 and use it static
 
 --- a/src/bootstrap/Cargo.lock
 +++ b/src/bootstrap/Cargo.lock
-@@ -434,9 +434,9 @@ dependencies = [
+@@ -424,9 +424,9 @@ dependencies = [
  
  [[package]]
  name = "lzma-sys"
@@ -23,7 +23,7 @@ Subject: [PATCH] Update xz2 and use it static
  dependencies = [
   "cc",
   "libc",
-@@ -903,9 +903,9 @@ dependencies = [
+@@ -871,9 +871,9 @@ dependencies = [
  
  [[package]]
  name = "xz2"

--- a/lang/rust/patches/0002-rustc-bootstrap-cache.patch
+++ b/lang/rust/patches/0002-rustc-bootstrap-cache.patch
@@ -1,6 +1,6 @@
 --- a/src/bootstrap/bootstrap.py
 +++ b/src/bootstrap/bootstrap.py
-@@ -546,7 +546,7 @@ class RustBuild(object):
+@@ -557,7 +557,7 @@ class RustBuild(object):
                  shutil.rmtree(bin_root)
  
              key = self.stage0_compiler.date
@@ -11,7 +11,7 @@
                  os.makedirs(rustc_cache)
 --- a/src/bootstrap/download.rs
 +++ b/src/bootstrap/download.rs
-@@ -202,7 +202,13 @@ impl Config {
+@@ -211,7 +211,13 @@ impl Config {
              Some(other) => panic!("unsupported protocol {other} in {url}"),
              None => panic!("no protocol in {url}"),
          }
@@ -26,7 +26,7 @@
      }
  
      fn download_http_with_retries(&self, tempfile: &Path, url: &str, help_on_error: &str) {
-@@ -520,7 +526,10 @@ impl Config {
+@@ -529,7 +535,10 @@ impl Config {
          key: &str,
          destination: &str,
      ) {
@@ -38,7 +38,7 @@
          let cache_dir = cache_dst.join(key);
          if !cache_dir.exists() {
              t!(fs::create_dir_all(&cache_dir));
-@@ -647,7 +656,10 @@ download-rustc = false
+@@ -656,7 +665,10 @@ download-rustc = false
          let llvm_assertions = self.llvm_assertions;
  
          let cache_prefix = format!("llvm-{llvm_sha}-{llvm_assertions}");

--- a/lang/rust/patches/0003-bump-libc-deps-to-0.2.146.patch
+++ b/lang/rust/patches/0003-bump-libc-deps-to-0.2.146.patch
@@ -1,19 +1,19 @@
-This patch bumps all libc dependencies and checksums to 0.2.146, which includes the fix for musl 1.2.4.
+This patch bumps all libc dependencies and checksums to 0.2.147, which includes the fix for musl 1.2.4.
 
---- a/vendor/addr2line-0.20.0/Cargo.lock
-+++ b/vendor/addr2line-0.20.0/Cargo.lock
-@@ -246,9 +246,9 @@ checksum = "e2abad23fbc42b3700f2f279844d
+--- a/vendor/addr2line-0.19.0/Cargo.lock
++++ b/vendor/addr2line-0.19.0/Cargo.lock
+@@ -235,9 +235,9 @@ checksum = "e2abad23fbc42b3700f2f279844d
  
  [[package]]
  name = "libc"
--version = "0.2.141"
-+version = "0.2.146"
+-version = "0.2.126"
++version = "0.2.147"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
-+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
++checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
  
  [[package]]
- name = "libtest-mimic"
+ name = "memchr"
 --- a/vendor/backtrace-0.3.67/Cargo.lock
 +++ b/vendor/backtrace-0.3.67/Cargo.lock
 @@ -64,9 +64,9 @@ checksum = "dec7af912d60cdbd3677c1af9352
@@ -21,27 +21,13 @@ This patch bumps all libc dependencies and checksums to 0.2.146, which includes 
  [[package]]
  name = "libc"
 -version = "0.2.138"
-+version = "0.2.146"
++version = "0.2.147"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
-+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
++checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
  
  [[package]]
  name = "libloading"
---- a/vendor/bstr/Cargo.lock
-+++ b/vendor/bstr/Cargo.lock
-@@ -34,9 +34,9 @@ dependencies = [
- 
- [[package]]
- name = "libc"
--version = "0.2.138"
-+version = "0.2.146"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
-+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
- 
- [[package]]
- name = "memchr"
 --- a/vendor/cranelift-jit/Cargo.lock
 +++ b/vendor/cranelift-jit/Cargo.lock
 @@ -224,9 +224,9 @@ dependencies = [
@@ -49,10 +35,10 @@ This patch bumps all libc dependencies and checksums to 0.2.146, which includes 
  [[package]]
  name = "libc"
 -version = "0.2.141"
-+version = "0.2.146"
++version = "0.2.147"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
-+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
++checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
  
  [[package]]
  name = "log"
@@ -63,10 +49,10 @@ This patch bumps all libc dependencies and checksums to 0.2.146, which includes 
  [[package]]
  name = "libc"
 -version = "0.2.141"
-+version = "0.2.146"
++version = "0.2.147"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
-+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
++checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
  
  [[package]]
  name = "num_cpus"
@@ -77,10 +63,10 @@ This patch bumps all libc dependencies and checksums to 0.2.146, which includes 
  [[package]]
  name = "libc"
 -version = "0.2.140"
-+version = "0.2.146"
++version = "0.2.147"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
-+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
++checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
  
  [[package]]
  name = "lindera"
@@ -91,10 +77,10 @@ This patch bumps all libc dependencies and checksums to 0.2.146, which includes 
  [[package]]
  name = "libc"
 -version = "0.2.140"
-+version = "0.2.146"
++version = "0.2.147"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
-+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
++checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
  
  [[package]]
  name = "lock_api"
@@ -105,10 +91,10 @@ This patch bumps all libc dependencies and checksums to 0.2.146, which includes 
  [[package]]
  name = "libc"
 -version = "0.2.141"
-+version = "0.2.146"
++version = "0.2.147"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
-+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
++checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
  
  [[package]]
  name = "litemap"
@@ -119,38 +105,24 @@ This patch bumps all libc dependencies and checksums to 0.2.146, which includes 
  [[package]]
  name = "libc"
 -version = "0.2.140"
-+version = "0.2.146"
++version = "0.2.147"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
-+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
++checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
  
  [[package]]
  name = "libffi"
---- a/vendor/terminal_size/Cargo.lock
-+++ b/vendor/terminal_size/Cargo.lock
-@@ -47,9 +47,9 @@ dependencies = [
- 
- [[package]]
- name = "libc"
--version = "0.2.140"
-+version = "0.2.146"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
-+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
- 
- [[package]]
- name = "linux-raw-sys"
 --- a/vendor/tracing-tree/Cargo.lock
 +++ b/vendor/tracing-tree/Cargo.lock
-@@ -100,9 +100,9 @@ checksum = "e2abad23fbc42b3700f2f279844d
+@@ -296,9 +296,9 @@ checksum = "e2abad23fbc42b3700f2f279844d
  
  [[package]]
  name = "libc"
 -version = "0.2.141"
-+version = "0.2.146"
++version = "0.2.147"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
-+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
++checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
  
  [[package]]
- name = "log"
+ name = "linux-raw-sys"


### PR DESCRIPTION
Maintainer: @lu-zero 
Compile tested: mediatek/filogic
Run tested: n/a

Description:
- Bumped libc to 0.2.147 to align deps.
- Refreshed patches.

Release note: https://releases.rs/docs/1.74.0/