### PR TITLE
unbound: fix `create_host_record_from_host` error when `dns` is not set

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.19.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound

--- a/net/unbound/files/dnsmasq.sh
+++ b/net/unbound/files/dnsmasq.sh
@@ -107,7 +107,7 @@ create_host_record_from_host() {
   local dns ip name
 
   # basefiles dhcp "host" clause which means host A and PTR records
-  config_get dns  "$cfg" dns
+  config_get dns  "$cfg" dns 0
   config_get ip   "$cfg" ip
   config_get name "$cfg" name
 


### PR DESCRIPTION
Maintainer: @EricLuehrsen
Compile tested: n/a
Run tested: OpenWrt 23.05.0 r23497-6637af95aa / LuCI openwrt-23.05 branch git-23.236.53405-fc638c8

Description:
The function `create_host_record_from_host` fails if the `dns` option is not set in the host entry.
This sets a default to the `dns` variable in order to fix this error.

Fixes: #22691