### PR TITLE
lua5.4: Add new lua version

### DIFF
--- a/lang/lua5.4/Makefile
+++ b/lang/lua5.4/Makefile
@@ -1,0 +1,165 @@
+#
+# Copyright (C) 2006-2023 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=lua
+PKG_VERSION:=5.4.6
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://www.lua.org/ftp/ \
+	https://www.tecgraf.puc-rio.br/lua/ftp/
+PKG_HASH:=7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88
+PKG_BUILD_PARALLEL:=1
+
+PKG_MAINTAINER:=Christian Marangi <ansuelsmth@gmail.com>
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=COPYRIGHT
+PKG_CPE_ID:=cpe:/a:lua:lua
+
+HOST_PATCH_DIR := ./patches-host
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+
+define Package/lua5.4/Default
+  SUBMENU:=Lua
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Lua programming language (version 5.4)
+  URL:=https://www.lua.org/
+endef
+
+define Package/lua5.4/Default/description
+  Lua is a powerful, efficient, lightweight, embeddable scripting language. It
+  supports procedural programming, object-oriented programming, functional
+  programming, data-driven programming, and data description.
+endef
+
+define Package/liblua5.4
+$(call Package/lua5.4/Default)
+  SUBMENU:=
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE+= (libraries)
+  ABI_VERSION:=5.4
+endef
+
+define Package/liblua5.4/description
+$(call Package/lua5.4/Default/description)
+ This package contains the Lua shared libraries, needed by other programs.
+endef
+
+define Package/lua5.4
+$(call Package/lua5.4/Default)
+  DEPENDS:=+liblua5.4
+  TITLE+= (interpreter)
+endef
+
+define Package/lua5.4/description
+$(call Package/lua5.4/Default/description)
+  This package contains the Lua language interpreter.
+endef
+
+define Package/luac5.4
+$(call Package/lua5.4/Default)
+  DEPENDS:=+liblua5.4
+  TITLE+= (compiler)
+endef
+
+define Package/luac5.4/description
+$(call Package/lua5.4/Default/description)
+  This package contains the Lua language compiler.
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	mv $(PKG_BUILD_DIR)/doc/lua.1 $(PKG_BUILD_DIR)/doc/lua5.4.1
+	mv $(PKG_BUILD_DIR)/doc/luac.1 $(PKG_BUILD_DIR)/doc/luac5.4.1
+endef
+
+TARGET_CFLAGS += -DLUA_USE_LINUX $(FPIC) -std=gnu99
+
+define Build/Compile
+	$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+		CC="$(TARGET_CROSS)gcc" \
+		AR="$(TARGET_CROSS)ar rcu" \
+		RANLIB="$(TARGET_CROSS)ranlib" \
+		INSTALL_ROOT=/usr \
+		CFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS)" \
+		PKG_VERSION=$(PKG_VERSION) \
+		linux
+	rm -rf $(PKG_INSTALL_DIR)
+	mkdir -p $(PKG_INSTALL_DIR)
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		INSTALL_TOP="$(PKG_INSTALL_DIR)/usr" \
+		install
+endef
+
+define Host/Prepare
+	$(call Host/Prepare/Default)
+	mv $(HOST_BUILD_DIR)/doc/lua.1 $(HOST_BUILD_DIR)/doc/lua5.4.1
+	mv $(HOST_BUILD_DIR)/doc/luac.1 $(HOST_BUILD_DIR)/doc/luac5.4.1
+endef
+
+define Host/Configure
+	$(SED) 's,"/usr/local/","$(STAGING_DIR_HOSTPKG)/",' $(HOST_BUILD_DIR)/src/luaconf.h
+endef
+
+ifeq ($(HOST_OS),Darwin)
+	LUA_OS:=macosx
+else
+	ifeq ($(HOST_OS),FreeBSD)
+		LUA_OS:=freebsd
+	else
+		LUA_OS:=linux
+	endif
+endif
+
+define Host/Compile
+	$(MAKE) -C $(HOST_BUILD_DIR) \
+		CC="$(HOSTCC) $(HOST_FPIC) -std=gnu99" \
+		$(LUA_OS)
+endef
+
+define Host/Install
+	$(MAKE) -C $(HOST_BUILD_DIR) \
+		INSTALL_TOP="$(STAGING_DIR_HOSTPKG)" \
+		install
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/lua5.4 $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/lua5.4/lua{,lib,conf}.h $(1)/usr/include/lua5.4/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/lua5.4/lua.hpp $(1)/usr/include/lua5.4/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/lua5.4/lauxlib.h $(1)/usr/include/lua5.4/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liblua5.4.{a,so*} $(1)/usr/lib/
+	$(LN) liblua5.4.so.0.0.0 $(1)/usr/lib/liblualib5.4.so
+endef
+
+define Package/liblua5.4/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liblua5.4.so* $(1)/usr/lib/
+endef
+
+define Package/lua5.4/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/lua5.4 $(1)/usr/bin/
+endef
+
+define Package/luac5.4/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/luac5.4 $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,liblua5.4))
+$(eval $(call BuildPackage,lua5.4))
+$(eval $(call BuildPackage,luac5.4))
+$(eval $(call HostBuild))

--- a/lang/lua5.4/patches-host/001-include-version-number.patch
+++ b/lang/lua5.4/patches-host/001-include-version-number.patch
@@ -1,0 +1,65 @@
+From 96576b44a1b368bd6590eb0778ae45cc9ccede3f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rafa=C5=82=20Mi=C5=82ecki?= <rafal@milecki.pl>
+Date: Fri, 21 Jun 2019 14:08:38 +0200
+Subject: [PATCH] include version number
+
+Including it allows multiple lua versions to coexist.
+
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
+---
+
+--- a/Makefile
++++ b/Makefile
+@@ -12,7 +12,7 @@ PLAT= guess
+ # LUA_ROOT, LUA_LDIR, and LUA_CDIR in luaconf.h.
+ INSTALL_TOP= /usr/local
+ INSTALL_BIN= $(INSTALL_TOP)/bin
+-INSTALL_INC= $(INSTALL_TOP)/include
++INSTALL_INC= $(INSTALL_TOP)/include/lua$V
+ INSTALL_LIB= $(INSTALL_TOP)/lib
+ INSTALL_MAN= $(INSTALL_TOP)/man/man1
+ INSTALL_LMOD= $(INSTALL_TOP)/share/lua/$V
+@@ -39,10 +39,10 @@ RM= rm -f
+ PLATS= guess aix bsd c89 freebsd generic ios linux linux-readline macosx mingw posix solaris
+ 
+ # What to install.
+-TO_BIN= lua luac
++TO_BIN= lua$V luac$V
+ TO_INC= lua.h luaconf.h lualib.h lauxlib.h lua.hpp
+-TO_LIB= liblua.a
+-TO_MAN= lua.1 luac.1
++TO_LIB= liblua$V.a
++TO_MAN= lua$V.1 luac$V.1
+ 
+ # Lua version and release.
+ V= 5.4
+@@ -52,7 +52,7 @@ R= $V.6
+ all:	$(PLAT)
+ 
+ $(PLATS) help test clean:
+-	@cd src && $(MAKE) $@
++	@cd src && $(MAKE) $@ V=$V
+ 
+ install: dummy
+ 	cd src && $(MKDIR) $(INSTALL_BIN) $(INSTALL_INC) $(INSTALL_LIB) $(INSTALL_MAN) $(INSTALL_LMOD) $(INSTALL_CMOD)
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -32,15 +32,15 @@ CMCFLAGS=
+ 
+ PLATS= guess aix bsd c89 freebsd generic ios linux linux-readline macosx mingw posix solaris
+ 
+-LUA_A=	liblua.a
++LUA_A=	liblua$V.a
+ CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o
+ LIB_O=	lauxlib.o lbaselib.o lcorolib.o ldblib.o liolib.o lmathlib.o loadlib.o loslib.o lstrlib.o ltablib.o lutf8lib.o linit.o
+ BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
+ 
+-LUA_T=	lua
++LUA_T=	lua$V
+ LUA_O=	lua.o
+ 
+-LUAC_T=	luac
++LUAC_T=	luac$V
+ LUAC_O=	luac.o
+ 
+ ALL_O= $(BASE_O) $(LUA_O) $(LUAC_O)

--- a/lang/lua5.4/patches-host/100-no_readline.patch
+++ b/lang/lua5.4/patches-host/100-no_readline.patch
@@ -1,0 +1,27 @@
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -126,7 +126,7 @@ c89:
+ 	@echo ''
+ 
+ FreeBSD NetBSD OpenBSD freebsd:
+-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX -DLUA_USE_READLINE -I/usr/include/edit" SYSLIBS="-Wl,-E -ledit" CC="cc"
++	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX $(if $(USE_READLINE), -DLUA_USE_READLINE) -I/usr/include/edit" SYSLIBS="-Wl,-E -ledit" CC="cc"
+ 
+ generic: $(ALL)
+ 
+@@ -136,13 +136,13 @@ ios:
+ Linux linux:	linux-noreadline
+ 
+ linux-noreadline:
+-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -ldl"
++	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX $(if $(USE_READLINE), -DLUA_USE_READLINE)" SYSLIBS="-Wl,-E -ldl $(if $(USE_READLINE), -lreadline)"
+ 
+ linux-readline:
+ 	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX -DLUA_USE_READLINE" SYSLIBS="-Wl,-E -ldl -lreadline"
+ 
+ Darwin macos macosx:
+-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX -DLUA_USE_READLINE" SYSLIBS="-lreadline"
++	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX $(if $(USE_READLINE), -DLUA_USE_READLINE)" SYSLIBS="$(if $(USE_READLINE), -lreadline)"
+ 
+ mingw:
+ 	$(MAKE) "LUA_A=lua54.dll" "LUA_T=lua.exe" \

--- a/lang/lua5.4/patches/001-include-version-number.patch
+++ b/lang/lua5.4/patches/001-include-version-number.patch
@@ -1,0 +1,65 @@
+From 96576b44a1b368bd6590eb0778ae45cc9ccede3f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rafa=C5=82=20Mi=C5=82ecki?= <rafal@milecki.pl>
+Date: Fri, 21 Jun 2019 14:08:38 +0200
+Subject: [PATCH] include version number
+
+Including it allows multiple lua versions to coexist.
+
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
+---
+
+--- a/Makefile
++++ b/Makefile
+@@ -12,7 +12,7 @@ PLAT= guess
+ # LUA_ROOT, LUA_LDIR, and LUA_CDIR in luaconf.h.
+ INSTALL_TOP= /usr/local
+ INSTALL_BIN= $(INSTALL_TOP)/bin
+-INSTALL_INC= $(INSTALL_TOP)/include
++INSTALL_INC= $(INSTALL_TOP)/include/lua$V
+ INSTALL_LIB= $(INSTALL_TOP)/lib
+ INSTALL_MAN= $(INSTALL_TOP)/man/man1
+ INSTALL_LMOD= $(INSTALL_TOP)/share/lua/$V
+@@ -39,10 +39,10 @@ RM= rm -f
+ PLATS= guess aix bsd c89 freebsd generic ios linux linux-readline macosx mingw posix solaris
+ 
+ # What to install.
+-TO_BIN= lua luac
++TO_BIN= lua$V luac$V
+ TO_INC= lua.h luaconf.h lualib.h lauxlib.h lua.hpp
+-TO_LIB= liblua.a
+-TO_MAN= lua.1 luac.1
++TO_LIB= liblua$V.a
++TO_MAN= lua$V.1 luac$V.1
+ 
+ # Lua version and release.
+ V= 5.4
+@@ -52,7 +52,7 @@ R= $V.6
+ all:	$(PLAT)
+ 
+ $(PLATS) help test clean:
+-	@cd src && $(MAKE) $@
++	@cd src && $(MAKE) $@ V=$V
+ 
+ install: dummy
+ 	cd src && $(MKDIR) $(INSTALL_BIN) $(INSTALL_INC) $(INSTALL_LIB) $(INSTALL_MAN) $(INSTALL_LMOD) $(INSTALL_CMOD)
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -32,15 +32,15 @@ CMCFLAGS=
+ 
+ PLATS= guess aix bsd c89 freebsd generic ios linux linux-readline macosx mingw posix solaris
+ 
+-LUA_A=	liblua.a
++LUA_A=	liblua$V.a
+ CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o
+ LIB_O=	lauxlib.o lbaselib.o lcorolib.o ldblib.o liolib.o lmathlib.o loadlib.o loslib.o lstrlib.o ltablib.o lutf8lib.o linit.o
+ BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
+ 
+-LUA_T=	lua
++LUA_T=	lua$V
+ LUA_O=	lua.o
+ 
+-LUAC_T=	luac
++LUAC_T=	luac$V
+ LUAC_O=	luac.o
+ 
+ ALL_O= $(BASE_O) $(LUA_O) $(LUAC_O)

--- a/lang/lua5.4/patches/020-shared_liblua.patch
+++ b/lang/lua5.4/patches/020-shared_liblua.patch
@@ -1,0 +1,115 @@
+--- a/Makefile
++++ b/Makefile
+@@ -41,7 +41,7 @@ PLATS= guess aix bsd c89 freebsd generic
+ # What to install.
+ TO_BIN= lua$V luac$V
+ TO_INC= lua.h luaconf.h lualib.h lauxlib.h lua.hpp
+-TO_LIB= liblua$V.a
++TO_LIB= liblua$V.a liblua$V.so.0.0.0
+ TO_MAN= lua$V.1 luac$V.1
+ 
+ # Lua version and release.
+@@ -59,6 +59,9 @@ install: dummy
+ 	cd src && $(INSTALL_EXEC) $(TO_BIN) $(INSTALL_BIN)
+ 	cd src && $(INSTALL_DATA) $(TO_INC) $(INSTALL_INC)
+ 	cd src && $(INSTALL_DATA) $(TO_LIB) $(INSTALL_LIB)
++	ln -s liblua$V.so.0.0.0 $(INSTALL_LIB)/liblua$V.so.0.0
++	ln -s liblua$V.so.0.0.0 $(INSTALL_LIB)/liblua$V.so.0
++	ln -s liblua$V.so.0.0.0 $(INSTALL_LIB)/liblua$V.so
+ 	cd doc && $(INSTALL_DATA) $(TO_MAN) $(INSTALL_MAN)
+ 
+ uninstall:
+--- a/src/ldebug.h
++++ b/src/ldebug.h
+@@ -36,7 +36,7 @@
+ #endif
+ 
+ 
+-LUAI_FUNC int luaG_getfuncline (const Proto *f, int pc);
++LUA_API int luaG_getfuncline (const Proto *f, int pc);
+ LUAI_FUNC const char *luaG_findlocal (lua_State *L, CallInfo *ci, int n,
+                                                     StkId *pos);
+ LUAI_FUNC l_noret luaG_typeerror (lua_State *L, const TValue *o,
+--- a/src/lstring.h
++++ b/src/lstring.h
+@@ -50,7 +50,7 @@ LUAI_FUNC void luaS_init (lua_State *L);
+ LUAI_FUNC void luaS_remove (lua_State *L, TString *ts);
+ LUAI_FUNC Udata *luaS_newudata (lua_State *L, size_t s, int nuvalue);
+ LUAI_FUNC TString *luaS_newlstr (lua_State *L, const char *str, size_t l);
+-LUAI_FUNC TString *luaS_new (lua_State *L, const char *str);
++LUA_API TString *luaS_new (lua_State *L, const char *str);
+ LUAI_FUNC TString *luaS_createlngstrobj (lua_State *L, size_t l);
+ 
+ 
+--- a/src/lundump.h
++++ b/src/lundump.h
+@@ -30,7 +30,7 @@
+ LUAI_FUNC LClosure* luaU_undump (lua_State* L, ZIO* Z, const char* name);
+ 
+ /* dump one chunk; from ldump.c */
+-LUAI_FUNC int luaU_dump (lua_State* L, const Proto* f, lua_Writer w,
++LUA_API int luaU_dump (lua_State* L, const Proto* f, lua_Writer w,
+                          void* data, int strip);
+ 
+ #endif
+--- a/src/lzio.h
++++ b/src/lzio.h
+@@ -44,7 +44,7 @@ typedef struct Mbuffer {
+ #define luaZ_freebuffer(L, buff)	luaZ_resizebuffer(L, buff, 0)
+ 
+ 
+-LUAI_FUNC void luaZ_init (lua_State *L, ZIO *z, lua_Reader reader,
++LUA_API void luaZ_init (lua_State *L, ZIO *z, lua_Reader reader,
+                                         void *data);
+ LUAI_FUNC size_t luaZ_read (ZIO* z, void *b, size_t n);	/* read next n bytes */
+ 
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -33,6 +33,7 @@ CMCFLAGS=
+ PLATS= guess aix bsd c89 freebsd generic ios linux linux-readline macosx mingw posix solaris
+ 
+ LUA_A=	liblua$V.a
++LUA_SO=	liblua$V.so.0.0.0
+ CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o
+ LIB_O=	lauxlib.o lbaselib.o lcorolib.o ldblib.o liolib.o lmathlib.o loadlib.o loslib.o lstrlib.o ltablib.o lutf8lib.o linit.o
+ BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
+@@ -44,8 +45,9 @@ LUAC_T=	luac$V
+ LUAC_O=	luac.o
+ 
+ ALL_O= $(BASE_O) $(LUA_O) $(LUAC_O)
+-ALL_T= $(LUA_A) $(LUA_T) $(LUAC_T)
++ALL_T= $(LUA_A) $(LUA_SO) $(LUA_T) $(LUAC_T)
+ ALL_A= $(LUA_A)
++ALL_SO= $(LUA_SO)
+ 
+ # Targets start here.
+ default: $(PLAT)
+@@ -56,14 +58,25 @@ o:	$(ALL_O)
+ 
+ a:	$(ALL_A)
+ 
++so:	$(ALL_SO)
++
+ $(LUA_A): $(BASE_O)
+ 	$(AR) $@ $(BASE_O)
+ 	$(RANLIB) $@
+ 
+-$(LUA_T): $(LUA_O) $(LUA_A)
+-	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
++$(LUA_SO): $(CORE_O) $(LIB_O)
++	$(CC) -o $@ -Wl,-Bsymbolic-functions -shared -Wl,-soname="$@" $?
++	ln -fs $@ liblua$V.so.0.0
++	ln -fs $@ liblua$V.so.0
++	ln -fs $@ liblua$V.so
++
++$(LUA_T): $(LUA_O) $(LUA_SO)
++	$(CC) -o $@ -L. -llua$V $(MYLDFLAGS) $(LUA_O) $(LIBS)
++
++$(LUAC_T): $(LUAC_O) $(LUA_SO)
++	$(CC) -o $@ -L. -llua$V $(MYLDFLAGS) $(LUAC_O) $(LIBS)
+ 
+-$(LUAC_T): $(LUAC_O) $(LUA_A)
++$(LUAC_T)-host: $(LUAC_O) $(LUA_A)
+ 	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
+ 
+ test:

--- a/lang/lua5.4/patches/100-no_readline.patch
+++ b/lang/lua5.4/patches/100-no_readline.patch
@@ -1,0 +1,27 @@
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -126,7 +126,7 @@ c89:
+ 	@echo ''
+ 
+ FreeBSD NetBSD OpenBSD freebsd:
+-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX -DLUA_USE_READLINE -I/usr/include/edit" SYSLIBS="-Wl,-E -ledit" CC="cc"
++	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX $(if $(USE_READLINE), -DLUA_USE_READLINE) -I/usr/include/edit" SYSLIBS="-Wl,-E -ledit" CC="cc"
+ 
+ generic: $(ALL)
+ 
+@@ -136,13 +136,13 @@ ios:
+ Linux linux:	linux-noreadline
+ 
+ linux-noreadline:
+-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -ldl"
++	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX $(if $(USE_READLINE), -DLUA_USE_READLINE)" SYSLIBS="-Wl,-E -ldl $(if $(USE_READLINE), -lreadline)"
+ 
+ linux-readline:
+ 	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX -DLUA_USE_READLINE" SYSLIBS="-Wl,-E -ldl -lreadline"
+ 
+ Darwin macos macosx:
+-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX -DLUA_USE_READLINE" SYSLIBS="-lreadline"
++	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX $(if $(USE_READLINE), -DLUA_USE_READLINE)" SYSLIBS="$(if $(USE_READLINE), -lreadline)"
+ 
+ mingw:
+ 	$(MAKE) "LUA_A=lua54.dll" "LUA_T=lua.exe" \


### PR DESCRIPTION
Add new lua version 5.4 required by new version of nmap.

Patch copied from lua 5.3. Readline patch has to be reworked as lua 5.4 now supports no readline for linux but still needs some tweaks for macos and bsd systems.

Patch shared lib required some rework.

---

@BKPepe is this ok? Required for nmap bump