### PR TITLE
gensio: add patches/fixes to workaround swig and python detection

### DIFF
--- a/net/gensio/Makefile
+++ b/net/gensio/Makefile
@@ -77,6 +77,9 @@ CONFIGURE_VARS += \
 	PYTHON_LIBS="$(shell $(STAGING_DIR)/host/bin/$(PYTHON3)-config --ldflags) -l${PYTHON3}" \
 	PYTHON_CPPFLAGS="$(shell $(STAGING_DIR)/host/bin/$(PYTHON3)-config --includes)" \
 	PYTHON="$(STAGING_DIR_HOSTPKG)/bin/$(PYTHON3)"
+
+MAKE_VARS += \
+	PYTHON_LIBS="$(shell $(STAGING_DIR)/host/bin/$(PYTHON3)-config --ldflags) -l${PYTHON3}"
 else
 CONFIGURE_ARGS += \
 	--without-python \

--- a/net/gensio/patches/0001-Ensure-that-ax_python_devel_found-is-defined.patch
+++ b/net/gensio/patches/0001-Ensure-that-ax_python_devel_found-is-defined.patch
@@ -13,15 +13,16 @@ checking consistency of all components of python development environment... yes
 
 Signed-off-by: Michael Heimpold <mhei@heimpold.de>
 ---
- configure.ac | 2 ++
- 1 file changed, 2 insertions(+)
+ configure.ac | 3 +++
+ 1 file changed, 3 insertions(+)
 
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1997,6 +1997,8 @@ if test "x$trypython" = "xyes"; then
+@@ -1997,6 +1997,9 @@ if test "x$trypython" = "xyes"; then
        PYTHON_CPPFLAGS="$pythoncflags"
     fi
     AX_PYTHON_DEVEL([], [true])
++   ax_python_devel_found=yes
 +else
 +   ax_python_devel_found=no
  fi

--- a/net/gensio/patches/0002_ax_python_devel-fix-serial.patch
+++ b/net/gensio/patches/0002_ax_python_devel-fix-serial.patch
@@ -1,0 +1,11 @@
+--- a/m4/ax_python_devel.m4
++++ b/m4/ax_python_devel.m4
+@@ -72,7 +72,7 @@
+ #   modified version of the Autoconf Macro, you may extend this special
+ #   exception to the GPL to apply to your modified version as well.
+ 
+-#serial 34
++#serial 35
+ 
+ AU_ALIAS([AC_PYTHON_DEVEL], [AX_PYTHON_DEVEL])
+ AC_DEFUN([AX_PYTHON_DEVEL],[

--- a/net/gensio/patches/0003-Revert-ax_pkg_swig.m4-to-latest-vanilla-version.patch
+++ b/net/gensio/patches/0003-Revert-ax_pkg_swig.m4-to-latest-vanilla-version.patch
@@ -1,0 +1,144 @@
+From f53fc85ee9734dd21447ea3438b7ba1edcd1bcf8 Mon Sep 17 00:00:00 2001
+From: Michael Heimpold <mhei@heimpold.de>
+Date: Tue, 21 Nov 2023 23:27:45 +0100
+Subject: [PATCH] Revert ax_pkg_swig.m4 to latest vanilla version
+
+And instead of extending the macro, we can use the already
+create variable 'available_swig_vernum' to compare the
+required version number.
+
+Signed-off-by: Michael Heimpold <mhei@heimpold.de>
+---
+ configure.ac      | 26 ++++++++++++--------------
+ m4/ax_pkg_swig.m4 | 20 +++++++++-----------
+ 2 files changed, 21 insertions(+), 25 deletions(-)
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -1956,21 +1956,19 @@ AC_CHECK_LIB(nsl, main, [HAVE_LIBNSL=1;
+ SWIG_DIR=
+ SWIG_CPP_DIR=
+ SWIG=
+-SWIG_NUMVERSION=0
++available_swig_vernum=0
+ if test "x$tryswig" = "xyes"; then
+    if test "x$swigprog" != "x"; then
+       SWIG="$swigprog"
+    fi
+-   AX_PKG_SWIG([1.3.21])
+-   if test "x$SWIG" != "x"; then
+-      AC_DEFINE([HAVE_SWIG], [], [Have swig installed])
+-      SWIG_DIR=swig
+-      if test $SWIG_NUMVERSION -ge 40100; then
+-          SWIG_CPP_DIR=swig
+-      else
+-          AC_MSG_WARN([SWIG version >= 4.1.0 is required for C++ swig.])
+-      fi
+-   fi
++   AX_PKG_SWIG(4.1.0,
++        [
++            AC_DEFINE([HAVE_SWIG], [], [Have swig installed])
++            SWIG_DIR=swig
++            SWIG_CPP_DIR=swig
++        ], [
++            AC_MSG_WARN([SWIG version >= 4.1.0 is required for C++ swig.])
++        ])
+ fi
+ AC_SUBST(SWIG_DIR)
+ AC_SUBST(SWIG_CPP_DIR)
+@@ -2055,7 +2053,7 @@ AC_SUBST(PYTHON_UNDEF_LIBS)
+ PYTHON_EXECUTABLE="${PYTHON}"
+ AC_SUBST(PYTHON_EXECUTABLE)
+ 
+-if test $SWIG_NUMVERSION -ge 40100 -a "${enable_shared}" = yes; then
++if test $available_swig_vernum -ge 40100 -a "${enable_shared}" = yes; then
+    trygo=yes
+ else
+    trygo=no
+@@ -2076,7 +2074,7 @@ AC_ARG_WITH(go,
+    fi,
+ )
+ 
+-if test $trygo = yes -a $SWIG_NUMVERSION -lt 40100; then
++if test $trygo = yes -a $available_swig_vernum -lt 40100; then
+    AC_MSG_ERROR([Go enabled, but swig version must be >= 4.1.0 for that])
+ fi
+ GODIR=
+@@ -2363,7 +2361,7 @@ pr_op  "  shared libraries:	" $enable_sh
+ pr_op  "  sctp sendv:		" $ac_cv_lib_sctp_sctp_sendv
+ pr_vop "  python:		" "$ax_python_version"
+ if test "$SWIG_CPP_DIR" = "swig"; then
+-  prrw "  swig:			" "$SWIG_NUMVERSION"
++  prrw "  swig:			" "$available_swig_vernum"
+ else
+   prrw "  swig:			" "no"
+ fi
+--- a/m4/ax_pkg_swig.m4
++++ b/m4/ax_pkg_swig.m4
+@@ -19,11 +19,6 @@
+ #   1.3.17), AX_PKG_SWIG checks that the swig package is this version number
+ #   or higher.
+ #
+-#   If successful, SWIG_NUMVERSION is set to a numeric value for the
+-#   version found in the format NNnnpp where NN is the major version,
+-#   nn is the minor version, and pp is the patch version.  This is
+-#   easy to directly compare with a number.
+-#
+ #   As usual, action-if-found is executed if SWIG is found, otherwise
+ #   action-if-not-found is executed.
+ #
+@@ -41,6 +36,8 @@
+ #   Copyright (c) 2008 Rafael Laboissiere <rafael@laboissiere.net>
+ #   Copyright (c) 2008 Andrew Collier
+ #   Copyright (c) 2011 Murray Cumming <murrayc@openismus.com>
++#   Copyright (c) 2018 Reini Urban <rurban@cpan.org>
++#   Copyright (c) 2021 Vincent Danjean <Vincent.Danjean@ens-lyon.org>
+ #
+ #   This program is free software; you can redistribute it and/or modify it
+ #   under the terms of the GNU General Public License as published by the
+@@ -68,14 +65,16 @@
+ #   modified version of the Autoconf Macro, you may extend this special
+ #   exception to the GPL to apply to your modified version as well.
+ 
+-#serial 13
++#serial 15
+ 
+ AC_DEFUN([AX_PKG_SWIG],[
+         # Find path to the "swig" executable.
+         AC_PATH_PROGS([SWIG],[swig swig3.0 swig2.0])
+         if test -z "$SWIG" ; then
+                 m4_ifval([$3],[$3],[:])
+-        elif test -n "$1" ; then
++        elif test -z "$1" ; then
++                m4_ifval([$2],[$2],[:])
++	else
+                 AC_MSG_CHECKING([SWIG version])
+                 [swig_version=`$SWIG -version 2>&1 | grep 'SWIG Version' | sed 's/.*\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/g'`]
+                 AC_MSG_RESULT([$swig_version])
+@@ -86,12 +85,12 @@ AC_DEFUN([AX_PKG_SWIG],[
+                         if test -z "$required_major" ; then
+                                 [required_major=0]
+                         fi
+-                        [required=`echo $required | sed 's/[0-9]*[^0-9]//'`]
++                        [required=`echo $required. | sed 's/[0-9]*[^0-9]//'`]
+                         [required_minor=`echo $required | sed 's/[^0-9].*//'`]
+                         if test -z "$required_minor" ; then
+                                 [required_minor=0]
+                         fi
+-                        [required=`echo $required | sed 's/[0-9]*[^0-9]//'`]
++                        [required=`echo $required. | sed 's/[0-9]*[^0-9]//'`]
+                         [required_patch=`echo $required | sed 's/[^0-9].*//'`]
+                         if test -z "$required_patch" ; then
+                                 [required_patch=0]
+@@ -126,10 +125,9 @@ AC_DEFUN([AX_PKG_SWIG],[
+                                 m4_ifval([$3],[$3],[])
+                         else
+                                 AC_MSG_CHECKING([for SWIG library])
+-                                SWIG_LIB=`$SWIG -swiglib | tail -1`
++                                SWIG_LIB=`$SWIG -swiglib | tr '\r\n' '  '`
+                                 AC_MSG_RESULT([$SWIG_LIB])
+                                 m4_ifval([$2],[$2],[])
+-                                SWIG_NUMVERSION=$available_swig_vernum
+                         fi
+                 else
+                         AC_MSG_WARN([cannot determine SWIG version])


### PR DESCRIPTION
Maintainer: @WereCatf 
Compile tested: mxs
Run tested: -

Description:

The built-in swig/python detection does not works well when system-wide m4 macros are available with same name but different content.
So make the configure stuff compatible, resp. workaround a little bit.
Upstream PRs are pending for review.

It seems also necessary to pass the PYTHON_LIBS environment during the compile phase.
