### PR TITLE
snort3: update to 3.1.75.0

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
-PKG_VERSION:=3.1.74.0
-PKG_RELEASE:=2
+PKG_VERSION:=3.1.75.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
-PKG_HASH:=4a4529e74bc202303c0330ae8b2317f0bef3ac92ae7216df8cfedfce24ddd129
+PKG_HASH:=c1a1b7d00df5ab45df968f0fb0125eba95bad27c181018b8d68a41e1bb6fc111
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Upstream bump
```
   ,,_     -*> Snort++ <*-
  o"  )~   Version 3.1.75.0
   ''''    By Martin Roesch & The Snort Team
           http://snort.org/contact#team
           Copyright (C) 2014-2023 Cisco and/or its affiliates. All rights reserved.
           Copyright (C) 1998-2013 Sourcefire, Inc., et al.
           Using DAQ version 3.0.13
           Using LuaJIT version 2.1.0-beta3
           Using OpenSSL 3.0.12 24 Oct 2023
           Using libpcap version 1.10.4 (with TPACKET_V3)
           Using PCRE version 8.45 2021-06-15
           Using ZLIB version 1.3
           Using Hyperscan version 5.4.2 2023-11-20
```
Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne

Maintainer: @flyn-org