### PR TITLE
[22.03] https-dns-proxy: fix unintentional call of service_stopped in boot()

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2023-10-25
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/

--- a/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
+++ b/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
@@ -134,7 +134,7 @@ boot() {
 	ubus -t 30 wait_for network.interface 2>/dev/null
 	on_boot_trigger=1
 	rc_procd start_service 'on_boot' && service_started 'on_boot'
-	is_resolver_working || rc_procd stop_service 'on_boot' && service_stopped 'on_boot'
+	is_resolver_working || { rc_procd stop_service 'on_boot' && service_stopped 'on_boot'; }
 }
 
 start_instance() {

--- a/net/https-dns-proxy/patches/020-src-options.c-add-version.patch
+++ b/net/https-dns-proxy/patches/020-src-options.c-add-version.patch
@@ -5,7 +5,7 @@
    return SW_VERSION;
  #else
 -  return "2023.10.10-atLeast";  // update date sometimes, like 1-2 times a year
-+  return "2023-10-25-3";  // update date sometimes, like 1-2 times a year
++  return "2023-10-25-4";  // update date sometimes, like 1-2 times a year
  #endif
  }
  


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 2e9f6c44460a48876cd85cde3557ce373693df6b)
