### PR TITLE
mc: bump to release 4.8.30

### DIFF
--- a/utils/mc/Makefile
+++ b/utils/mc/Makefile
@@ -6,15 +6,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mc
-PKG_VERSION:=4.8.27
-PKG_RELEASE:=3
+PKG_VERSION:=4.8.30
+PKG_RELEASE:=1
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_CPE_ID:=cpe:/a:midnight_commander:midnight_commander
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://ftp.midnight-commander.org/
-PKG_HASH:=31be59225ffa9920816e9a8b3be0ab225a16d19e4faf46890f25bdffa02a4ff4
+PKG_HASH:=5ebc3cb2144b970c5149fda556c4ad50b78780494696cdf2d14a53204c95c7df
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf gettext-version
 PKG_BUILD_DEPENDS:=MC_VFS:libtirpc
@@ -57,7 +57,6 @@ CONFIGURE_ARGS += \
 	--enable-silent-rules \
 	--disable-tests \
 	--disable-doxygen-doc \
-	--with-homedir=/etc/mc \
 	--with-screen=ncurses \
 	--without-x \
 
@@ -99,7 +98,7 @@ define Package/mc/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/mc $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/etc/mc
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/misc/mc.charsets $(1)/etc/mc
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/misc/mc.ext $(1)/etc/mc
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/misc/mc.ext.ini $(1)/etc/mc
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/misc/mc.default.keymap $(1)/etc/mc/mc.keymap
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/misc/filehighlight.ini $(1)/etc/mc
 	$(INSTALL_DIR) $(1)/usr/share/mc/help

--- a/utils/mc/patches/010-subshell.patch
+++ b/utils/mc/patches/010-subshell.patch
@@ -1,6 +1,6 @@
 --- a/src/subshell/common.c
 +++ b/src/subshell/common.c
-@@ -1140,7 +1140,7 @@ init_subshell_precmd (char *precmd, size
+@@ -1143,7 +1143,7 @@ init_subshell_precmd (char *precmd, size
                      "else "
                      "[ \"${PWD##$HOME/}\" = \"$PWD\" ] && MC_PWD=\"$PWD\" || MC_PWD=\"~/${PWD##$HOME/}\"; "
                      "fi; "

--- a/utils/mc/patches/020-fix-mouse-handling-newer-terminfo.patch
+++ b/utils/mc/patches/020-fix-mouse-handling-newer-terminfo.patch
@@ -1,6 +1,6 @@
 --- a/lib/tty/tty.c
 +++ b/lib/tty/tty.c
-@@ -402,7 +402,7 @@ tty_init_xterm_support (gboolean is_xter
+@@ -407,7 +407,7 @@ tty_init_xterm_support (gboolean is_xter
      if (xmouse_seq != NULL)
      {
          if (strcmp (xmouse_seq, ESC_STR "[<") == 0)

--- a/utils/mc/patches/030-mc-mksh-subshell-v2.patch
+++ b/utils/mc/patches/030-mc-mksh-subshell-v2.patch
@@ -1,6 +1,6 @@
 --- a/lib/shell.c
 +++ b/lib/shell.c
-@@ -68,6 +68,8 @@ mc_shell_get_installed_in_system (void)
+@@ -70,6 +70,8 @@ mc_shell_get_installed_in_system (void)
          mc_shell->path = g_strdup ("/bin/bash");
      else if (access ("/bin/ash", X_OK) == 0)
          mc_shell->path = g_strdup ("/bin/ash");
@@ -9,7 +9,7 @@
      else if (access ("/bin/dash", X_OK) == 0)
          mc_shell->path = g_strdup ("/bin/dash");
      else if (access ("/bin/busybox", X_OK) == 0)
-@@ -149,6 +151,12 @@ mc_shell_recognize_real_path (mc_shell_t
+@@ -151,6 +153,12 @@ mc_shell_recognize_real_path (mc_shell_t
          mc_shell->type = SHELL_ZSH;
          mc_shell->name = "zsh";
      }
@@ -34,7 +34,7 @@
      SHELL_FISH
 --- a/src/subshell/common.c
 +++ b/src/subshell/common.c
-@@ -378,6 +378,11 @@ init_subshell_child (const char *pty_nam
+@@ -380,6 +380,11 @@ init_subshell_child (const char *pty_nam
          }
          break;
  
@@ -46,7 +46,7 @@
          /* TODO: Find a way to pass initfile to TCSH and FISH */
      case SHELL_TCSH:
      case SHELL_FISH:
-@@ -427,6 +432,7 @@ init_subshell_child (const char *pty_nam
+@@ -429,6 +434,7 @@ init_subshell_child (const char *pty_nam
  
      case SHELL_ASH_BUSYBOX:
      case SHELL_DASH:
@@ -54,7 +54,7 @@
      case SHELL_TCSH:
      case SHELL_FISH:
          execl (mc_global.shell->path, mc_global.shell->path, (char *) NULL);
-@@ -1091,6 +1097,10 @@ init_subshell_precmd (char *precmd, size
+@@ -1094,6 +1100,10 @@ init_subshell_precmd (char *precmd, size
                      "PS1='\\u@\\h:\\w\\$ '\n", command_buffer_pipe[WRITE],
                      command_buffer_pipe[WRITE], subshell_pipe[WRITE]);
          break;


### PR DESCRIPTION
Description:
* News: http://midnight-commander.org/wiki/NEWS-4.8.30
* refresh patches
* remove obsolete / adapt changed options

Maintainer: n/a
Compile tested: x86_64, APU1
Run tested: x86_64, APU1

Signed-off-by: Dirk Brenken <dev@brenken.org>