### PR TITLE
[23.05] adblock-fast: bugfix: call to missing function

### DIFF
--- a/net/adblock-fast/Makefile
+++ b/net/adblock-fast/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/adblock-fast/files/etc/init.d/adblock-fast
+++ b/net/adblock-fast/files/etc/init.d/adblock-fast
@@ -1764,7 +1764,7 @@ adb_pause() {
 	local validation_result="$3"
 	adb_stop 'on_pause' '' "$validation_result"
 	output "Sleeping for $timeout seconds... "
-	if is_number "$timeout" && sleep "$timeout"; then
+	if is_integer "$timeout" && sleep "$timeout"; then
 		output_okn
 	else
 		output_failn
@@ -1779,8 +1779,8 @@ boot() {
 	config_load "$packageName"
 	config_get procd_boot_delay 'config' 'procd_boot_delay' '0'
 # shellcheck disable=SC2154
-	{ is_integer "$procd_boot_delay" && sleep "$procd_boot_delay" || true; } && \
-		rc_procd start_service 'on_boot' && service_started 'on_boot' &
+	{ is_integer "$procd_boot_delay" && sleep "$procd_boot_delay"; \
+		rc_procd start_service 'on_boot' && service_started 'on_boot'; } &
 }
 check() { load_validate_config 'config' adb_check "'$*'"; }
 check_lists() { load_validate_config 'config' adb_check_lists "'$*'"; }


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2

Description:
* fix call to is_number to is_integer
* improve boot()

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit ffb396bca93ba5675ec0f999cf2dc9397b28e138)
