### PR TITLE
dhtd: update to 0.2.5

### DIFF
--- a/net/dhtd/Makefile
+++ b/net/dhtd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dhtd
-PKG_VERSION:=0.2.4
+PKG_VERSION:=0.2.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mwarning/dhtd/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=0f35cd0016689682b277f9769ec1e95c3c1321479cedc9727abc0bc91a0427d5
+PKG_HASH:=0e239c969400537fda549b74f0555bddc2f1fe4ab3c00abe539970dfefab6599
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested:  ramips/mt7620, OpenWrt master
Run tested: minimal changes
