### PR TITLE
syncthing: fix duplicate command line parameters on service

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)

--- a/utils/syncthing/files/syncthing.init
+++ b/utils/syncthing/files/syncthing.init
@@ -14,7 +14,7 @@ config_cb() {
 		local option="$1"
 		local value="$2"
 		case $option in
-		enabled|macprocs|nice|user|logfile)
+		enabled|gui_address|home|logfile|macprocs|nice|user)
 			eval $option=$value
 			;;
 		debug)


### PR DESCRIPTION
Maintainer: @BKPepe 
Compile tested: none
Run tested: linksys_e8450-ubi aarch64_cortex-a53

Description:
Fixes issue #22760, duplicate command line options at service startup.