### PR TITLE
[23.05] nghttp3: update to 1.1.0

### DIFF
--- a/libs/nghttp3/Makefile
+++ b/libs/nghttp3/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nghttp3
-PKG_VERSION:=1.0.0
+PKG_VERSION:=1.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/ngtcp2/nghttp3/releases/download/v$(PKG_VERSION)/
-PKG_HASH:=2e5b5a39415b9a0d160bbcb90b37bef7d8aee44ae504e8c0ddcb31aa92435988
+PKG_SOURCE_URL:=https://codeload.github.com/ngtcp2/nghttp3/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=b3ffb23a90442a0eafe8bfbefbc8b4ffb5179d68a7c0b8a416a34cf04b28d7c5
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
@@ -25,7 +25,7 @@ define Package/libnghttp3
 endef
 
 define Package/libnghttp3/description
- nghttp3 is a thin HTTP/3 layer over an underlying QUIC stack.
+nghttp3 is a thin HTTP/3 layer over an underlying QUIC stack.
 endef
 
 CMAKE_OPTIONS += -DENABLE_LIB_ONLY=ON


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2

Description:
* Changelog: https://github.com/ngtcp2/nghttp3/releases/tag/v1.1.0

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 353bdb9cf08d3921bcae90d75a84665a329501db)
