### PR TITLE
ngtcp2: update to 1.1.0

### DIFF
--- a/libs/ngtcp2/Makefile
+++ b/libs/ngtcp2/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ngtcp2
-PKG_VERSION:=1.0.1
+PKG_VERSION:=1.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/ngtcp2/ngtcp2/releases/download/v$(PKG_VERSION)/
-PKG_HASH:=df03e7e91110fcbb165ae048fa671f1dd39f77b841df3a14aef076a1c192cc27
+PKG_SOURCE_URL:=https://codeload.github.com/ngtcp2/ngtcp2/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=987d784643edea4f2859c405f7dfbc53871a9f7ae5fcddf5fb12ec5dfce1ef22
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
@@ -26,7 +26,8 @@ define Package/libngtcp2
 endef
 
 define Package/libngtcp2/description
- ngtcp2 project is an effort to implement QUIC protocol which is now being discussed in IETF QUICWG for its standardization.
+ngtcp2 project is an effort to implement QUIC protocol which is now being
+discussed in IETF QUICWG for its standardization.
 endef
 
 CMAKE_OPTIONS += -DENABLE_LIB_ONLY=ON


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2

Description:
* Changelog: https://github.com/ngtcp2/ngtcp2/releases/tag/v1.1.0
