### PR TITLE
wifischedule: updated to 1.0.5-1

### DIFF
--- a/net/wifischedule/Makefile
+++ b/net/wifischedule/Makefile
@@ -15,8 +15,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifischedule
-PKG_VERSION:=1
-PKG_RELEASE:=3
+PKG_VERSION:=1.0.5
+PKG_RELEASE:=1
 PKG_LICENSE:=PRPL
 
 PKG_MAINTAINER:=Nils Koenig <openwrt@newk.it> 
@@ -53,6 +53,18 @@ define Package/wifischedule/install
 	$(INSTALL_BIN) ./net/usr/bin/wifi_schedule.sh $(1)/usr/bin/wifi_schedule.sh
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DATA) ./net/etc/config/wifi_schedule $(1)/etc/config/wifi_schedule
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_DATA) ./net/etc/init.d/wifi_schedule $(1)/etc/init.d/wifi_schedule
+endef
+
+define Package/wifischedule/postinst
+#!/bin/sh
+# check if we are on real system
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	echo "Enabling rc.d symlink for wifischedule"
+	/etc/init.d/wifi_schedule enable
+fi
+exit 0
 endef
 
 $(eval $(call BuildPackage,wifischedule))

--- a/net/wifischedule/README.md
+++ b/net/wifischedule/README.md
@@ -74,10 +74,11 @@ Then call the script as follows in order to get the necessary cron jobs created:
 All commands:
  
 ```
-wifi_schedule.sh cron|start|stop|forcestop|recheck|getmodules|savemodules|help
+wifi_schedule.sh cron|start|startup|stop|forcestop|recheck|getmodules|savemodules|help
 
     cron: Create cronjob entries.
     start: Start wifi.
+    startup: Checks current timewindow and enables/disables WIFI accordingly.
     stop: Stop wifi gracefully, i.e. check if there are stations associated and if so keep retrying.
     forcestop: Stop wifi immediately.
     recheck: Recheck if wifi can be disabled now.
@@ -85,3 +86,6 @@ wifi_schedule.sh cron|start|stop|forcestop|recheck|getmodules|savemodules|help
     savemodules: Saves a list of automatic determined modules to UCI
     help: This description.
 ```
+
+## Startup Script: `/etc/init.d/wifi_schedule`
+Makes sure time window is checked and WIFI is enabled or disabled accordingly when powering on the router.

--- a/net/wifischedule/net/etc/init.d/wifi_schedule
+++ b/net/wifischedule/net/etc/init.d/wifi_schedule
@@ -1,0 +1,8 @@
+#!/bin/sh /etc/rc.common
+# Startup Script for wifi_schedule
+
+START=100
+
+start() {
+    /usr/bin/wifi_schedule.sh startup
+}

--- a/net/wifischedule/net/usr/bin/wifi_schedule.sh
+++ b/net/wifischedule/net/usr/bin/wifi_schedule.sh
@@ -14,6 +14,8 @@
 #
 # Author: Nils Koenig <openwrt@newk.it>
 
+set -o pipefail
+
 SCRIPT=$0
 LOCKFILE=/tmp/wifi_schedule.lock
 LOGFILE=/tmp/log/wifi_schedule.log
@@ -122,10 +124,46 @@ _enable_wifi_schedule()
     return 0
 }
 
+_is_earlier()
+{
+    local hhmm=$1
+    local ret=1
+    if [[ $(date +%H) -lt ${hhmm:0:2} ]]
+    then
+        ret=0
+    fi
+    if [[ $(date +%H) -eq ${hhmm:0:2} && $(date +%M) -lt ${hhmm:3:4} ]]
+    then
+        ret=0
+    fi
+    echo $ret
+}
+
+# returns 0 if now() is in $entry
+_check_startup_timewindow()
+{
+    local entry=$1
+    local starttime
+    local stoptime
+    local dow
+    starttime=$(_get_uci_value ${PACKAGE}.${entry}.starttime) || _exit 1
+    stoptime=$(_get_uci_value ${PACKAGE}.${entry}.stoptime) || _exit 1
+    dow=$(_get_uci_value_raw ${PACKAGE}.${entry}.daysofweek) || _exit 1
+
+    echo $dow | grep $(date +%A) > /dev/null 2>&1
+    rc=$?
+
+    if [[ $rc -eq 0 && $(date +%H) -ge ${starttime:0:2}  && $(date +%M) -ge ${starttime:3:4}  && $(_is_earlier $stoptime) -eq 0  ]]
+    then
+        echo 0
+    else
+        echo 1
+    fi
+}
+
 _get_wireless_interfaces()
 {
-    local n=$(cat /proc/net/wireless | wc -l)
-    cat /proc/net/wireless | tail -n $(($n - 2))|awk -F':' '{print $1}'| sed  's/ //' 
+    iwinfo | grep ESSID | cut -f 1 -s -d" "
 }
 
 
@@ -218,6 +256,38 @@ _create_cron_entries()
     done
 }
 
+_should_wifi_enabled() 
+{
+
+    local enable_wifi=0
+    local entries=$(uci show ${PACKAGE} 2> /dev/null | awk -F'.' '{print $2}' | grep -v '=' | grep -v '@global\[0\]' | uniq | sort)
+    local _entry
+    for _entry in ${entries}
+    do
+        local status
+        status=$(_get_uci_value ${PACKAGE}.${_entry}.enabled) || _exit 1
+        if [ ${status} -eq 1 ]
+        then
+            enable_wifi=$(_check_startup_timewindow $_entry)
+        fi
+    done
+    echo ${enable_wifi}
+}
+
+startup()
+{
+    _log "startup"
+    local _enable_wifi=$(_should_wifi_enabled)
+    if [[ ${_enable_wifi} -eq 0 ]]
+    then
+        _log "enable wifi"
+        enable_wifi
+    else 
+        _log "disable wifi"
+        disable_wifi
+    fi
+}
+
 check_cron_status()
 {
     local global_enabled
@@ -231,7 +301,7 @@ check_cron_status()
 disable_wifi()
 {
     _rm_cron_script "${SCRIPT} recheck"
-    /sbin/wifi down
+    _set_status_wifi_uci 1
     local unload_modules
     unload_modules=$(_get_uci_value_raw ${GLOBAL}.unload_modules) || _exit 1
     if [[ "${unload_modules}" == "1" ]]; then
@@ -241,7 +311,7 @@ disable_wifi()
 
 soft_disable_wifi()
 {
-    local _disable_wifi=1
+    local _disable_wifi=0 #0: disable wifi, 1: do not disable wifi
     local iwinfo=/usr/bin/iwinfo
     if [ ! -e ${iwinfo} ]; then
         _log "${iwinfo} not available, skipping"
@@ -261,19 +331,34 @@ soft_disable_wifi()
         fi
 
         if [ -n "${stations}" ]; then
-            _disable_wifi=0
+            _disable_wifi=1
             _log "Station(s) $(echo ${stations}) associated on ${_if}"
         fi
     done
 
-    if [ ${_disable_wifi} -eq 1 ]; then
+    local _wifi_enabled=$(_should_wifi_enabled)
+    if [[ ${_disable_wifi} -eq 0 && ${_wifi_enabled} -eq 1 ]]; then
         _log "No stations associated, disable wifi."
         disable_wifi
+    elif [[ ${_disable_wifi} -eq 0 && ${_wifi_enabled} -eq 0 ]]; then
+        _log "Do not disable wifi since there is an allow timeframe, skip rechecking."
+        _rm_cron_script "${SCRIPT} recheck"
     else
         _log "Could not disable wifi due to associated stations, retrying..."
         local recheck_interval=$(_get_uci_value ${GLOBAL}.recheck_interval)
         _add_cron_script "*/${recheck_interval} * * * * ${SCRIPT} recheck"
     fi
+}
+
+_set_status_wifi_uci()
+{
+    local status=$1
+    local radios=$(uci show wireless | grep radio | awk -F'.' '{print $2}' | grep -v '[=|@]' | sort | uniq)
+    for radio in ${radios}
+    do
+        uci set wireless.${radio}.disabled=${status}
+    done
+    uci commit
 }
 
 enable_wifi()
@@ -284,18 +369,20 @@ enable_wifi()
     if [[ "${unload_modules}" == "1" ]]; then
         _load_modules
     fi
+    _set_status_wifi_uci 0
     /sbin/wifi
 }
 
 usage()
 {
     echo ""
-    echo "$0 cron|start|stop|forcestop|recheck|getmodules|savemodules|help"
+    echo "$0 cron|start|startup|stop|forcestop|recheck|getmodules|savemodules|help"
     echo ""
     echo "    UCI Config File: /etc/config/${PACKAGE}"
     echo ""
     echo "    cron: Create cronjob entries."
     echo "    start: Start wifi."
+    echo "    startup: Checks current timewindow and enables/disables WIFI accordingly."
     echo "    stop: Stop wifi gracefully, i.e. check if there are stations associated and if so keep retrying."
     echo "    forcestop: Stop wifi immediately."
     echo "    recheck: Recheck if wifi can be disabled now."
@@ -305,16 +392,28 @@ usage()
     echo ""
 }
 
+_cleanup()
+{
+    lock -u ${LOCKFILE}
+    rm ${LOCKFILE}
+}
+
 ###############################################################################
 # MAIN
 ###############################################################################
+trap _cleanup EXIT
+
 LOGGING=$(_get_uci_value ${GLOBAL}.logging) || _exit 1
 _log ${SCRIPT} $1 $2
 lock ${LOCKFILE}
 
 case "$1" in
-    cron) check_cron_status ;;
+    cron) 
+        check_cron_status
+        startup
+    ;;
     start) enable_wifi ;;
+    startup) startup ;;
     forcestop) disable_wifi ;;
     stop) soft_disable_wifi ;;
     recheck) soft_disable_wifi ;;


### PR DESCRIPTION
- Fixed _get_wireless_interfaces, thanks to @Trekky12
- Check schedule during router startup

Fixes: https://github.com/newkit/wifischedule/pull/9
Maintainer: @newkit
Tested: TP-Link WDR3600 with OpenWRT 23.05

Signed-off-by: Nils Koenig openwrt@newk.it
