### PR TITLE
CI: Fix CI_HELPER

### DIFF
--- a/.github/workflows/entrypoint.sh
+++ b/.github/workflows/entrypoint.sh
@@ -13,7 +13,7 @@ mkdir -p /var/lock/
 
 opkg update
 
-[ -n "${CI_HELPER:=''}" ] || CI_HELPER="/ci/.github/workflows/ci_helpers.sh"
+export CI_HELPER="/ci/.github/workflows/ci_helpers.sh"
 
 for PKG in /ci/*.ipk; do
 	tar -xzOf "$PKG" ./control.tar.gz | tar xzf - ./control
@@ -42,7 +42,7 @@ for PKG in /ci/*.ipk; do
 		continue
 	fi
 
-	export PKG_NAME PKG_VERSION CI_HELPER
+	export PKG_NAME PKG_VERSION
 
 	if [ -f "$PRE_TEST_SCRIPT" ]; then
 		echo "Use package specific pre-test.sh"


### PR DESCRIPTION
Maintainer: @aparcar
Compile tested: tested in https://github.com/jefferyto/openwrt-packages/pull/18 ([GA run](https://github.com/jefferyto/openwrt-packages/actions/runs/7014564500/job/19082480680?pr=18))
Run tested: N/A

Description:
Commit 18d3c529fa4ab8dafcf6c147cf3cb55792d8ca10 caused `CI_HELPER` to be set to `''` (two single quotes), leading to an error when test.sh tries to source `$CI_HELPER`.

`CI_HELPER` is not set anywhere else and not passed into the container environment, so there is no need to test if it has a value.

This fixes the value of `CI_HELPER`.

Fixes: 18d3c529fa4a ("github-ci: error on any shell errors")