### PR TITLE
podman: update to version 4.8.0

### DIFF
--- a/utils/podman/Makefile
+++ b/utils/podman/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=podman
-PKG_VERSION:=4.7.1
+PKG_VERSION:=4.8.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containers/podman/archive/v$(PKG_VERSION)
-PKG_HASH:=b785fe69041a0f222a8e1f8165816d767cb9bff5418f3f559547da82c0c279cc
+PKG_HASH:=cd0afd1fb493b0c099fd8634525f318f35e4e84c1d7735d8426a722a4d5c8409
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -39,7 +39,7 @@ define Package/podman
   CATEGORY:=Utilities
   TITLE:=Podman
   URL:=https://podman.io
-  DEPENDS:=$(GO_ARCH_DEPENDS) +conmon +libgpgme +libseccomp +nsenter +zoneinfo-simple +kmod-veth +slirp4netns +netavark +aardvark-dns +catatonit +PODMAN_SELINUX_SUPPORT:libselinux
+  DEPENDS:=$(GO_ARCH_DEPENDS) +conmon +libgpgme +libseccomp +nsenter +zoneinfo-simple +kmod-veth +slirp4netns +netavark +aardvark-dns +catatonit +crun +PODMAN_SELINUX_SUPPORT:libselinux
 endef
 
 define Package/podman/description

--- a/utils/podman/files/containers.conf
+++ b/utils/podman/files/containers.conf
@@ -3,11 +3,14 @@
 [containers]
 #annotations = []
 #apparmor_profile = "container-default"
+#base_hosts_file = ""
+#cgroup_conf = []
 cgroupns = "private"
 cgroups = "enabled"
 netns = "private"
 #pidns = "private"
-#rootless_networking = "slirp4netns"
+#userns = "host"
+#utsns = "private"
 #seccomp_profile = "/usr/share/containers/seccomp.json"
 #shm_size = "65536k"
 
@@ -29,30 +32,116 @@ default_sysctls = [
   "net.ipv4.ping_group_range=0 0",
 ]
 
+#devices = []
+#dns_options = []
+#dns_searches = []
+#dns_servers = []
+#env = [
+#  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+#]
+
+#env_host = false
+#host_containers_internal_ip = ""
+#http_proxy = true
+#init = false
+#ipcns = "shareable"
+#keyring = true
+#label = true
+#label_users = false
+#log_driver = "k8s-file"
+#log_size_max = -1
+#log_tag = ""
+#mounts = []
+#prepare_volume_on_create = false
+#privileged = false
+#read_only = false
+#seccomp_profile = "/usr/share/containers/seccomp.json"
+#tz = ""
+#umask = "0022"
+#volumes = []
+
+[secrets]
+#driver = "file"
+
+[secrets.opts]
+#root = "/example/directory"
+
 [network]
 network_backend = "netavark"
+#netavark_plugin_dirs = [
+#  "/usr/local/libexec/netavark",
+#  "/usr/libexec/netavark",
+#  "/usr/local/lib/netavark",
+#  "/usr/lib/netavark",
+#]
+#firewall_driver = "none"
 network_config_dir = "/etc/containers/networks/"
 default_network = "podman"
+#default_subnet = "10.88.0.0/16"
+#default_subnet_pools = [
+#  {"base" = "10.89.0.0/16", "size" = 24},
+#  {"base" = "10.90.0.0/15", "size" = 24},
+#  {"base" = "10.92.0.0/14", "size" = 24},
+#  {"base" = "10.96.0.0/11", "size" = 24},
+#  {"base" = "10.128.0.0/9", "size" = 24},
+#]
+
+default_rootless_network_cmd = "slirp4netns"
+#dns_bind_port = 53
+
 
 [engine]
+#add_compression = ["gzip", "zstd", "zstd:chunked"]
+#compat_api_enforce_docker_hub = true
+#compose_providers=[]
+#compose_warning_logs = true
+#compression_format = "gzip"
+#compression_level = 5
 cgroup_manager = "cgroupfs"
+
+conmon_path = [ "/usr/bin/conmon" ]
+#conmon_env_vars = [
+#  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+#]
+
+#database_backend = ""
+#detach_keys = "ctrl-p,ctrl-q"
+#enable_port_reservation = true
+#env = []
+#events_logfile_path=""
+#events_logfile_max_size = "1m"
 events_logger = "none"
+#events_container_create_inspect_data = false
+#image_default_format = ""
 #image_default_transport = "docker://"
 #image_parallel_copies = 0
+#image_volume_mode = ""
 #infra_command = "/pause"
-#infra_image = "k8s.gcr.io/pause:3.4.1"
-#lock_type** = "shm"
+#infra_image = ""
+#lock_type = "shm"
+#multi_image_archive = false
 #namespace = ""
-#network_cmd_path = ""
+network_cmd_path = "/usr/bin/slirp4netns"
+#network_cmd_options = []
+#no_pivot_root = false
+#num_locks = 2048
+#pod_exit_policy = "continue"
+#pull_policy = "missing"
+#remote = false
 
 runtime = "crun"
-# runtime = "runc"
-# runtime = "uxc"
 
-runtime_supports_json = ["crun", "runc", "kata", "uxc"]
+runtime_supports_json = ["crun", "runc", "kata", "runsc", "youki", "krun", "uxc"]
 #runtime_supports_kvm = ["kata", "krun"]
 #runtime_supports_nocgroups = ["crun", "krun", "uxc"]
+#service_timeout = 5
+#stop_timeout = 10
+#exit_command_delay = 300
 #static_dir = "/var/lib/containers/storage/libpod"
+tmp_dir = "/var/run/libpod"
+#volume_path = "/var/lib/containers/storage/volumes"
+#volume_plugin_timeout = 5
+#podmansh_timeout = 30
 
 [engine.runtimes]
 crun = [
@@ -67,8 +156,19 @@ uxc = [
        "/sbin/uxc",
 ]
 
+[engine.volume_plugins]
+#testplugin = "/run/podman/plugins/test.sock"
+
 [machine]
 #cpus = 1
 #disk_size = 10
 #image = "testing"
 #memory = 2048
+#user = "core"
+#volumes = [
+#  "$HOME:$HOME",
+#]
+#provider = ""
+
+[farms]
+#[farms.list]

--- a/utils/podman/patches/010-do-not-build-docs.patch
+++ b/utils/podman/patches/010-do-not-build-docs.patch
@@ -1,6 +1,6 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -219,7 +219,7 @@ GV_SHA=db608827124caa71ba411cec8ea959bb9
+@@ -224,7 +224,7 @@ GV_VERSION=v0.7.1
  default: all
  
  .PHONY: all
@@ -9,7 +9,7 @@
  
  .PHONY: binaries
  ifeq ($(shell uname -s),FreeBSD)
-@@ -804,7 +804,7 @@ rpm-install: package  ## Install rpm pac
+@@ -803,7 +803,7 @@ rpm-install: package  ## Install rpm pac
  	/usr/bin/podman info  # will catch a broken conmon
  
  .PHONY: install


### PR DESCRIPTION
Changelog: https://github.com/containers/podman/releases

I also updated containers.conf - it has gotten quite a many new options. I added crun to depends, every other distribution seems to ship it with podman, and after all it is a default OCI Container Runtime for podman anyway and has a super low footprint, so shouldn't be a problem for anyone running containers, after all you need some storage for that anyway.

Maintainer: me
Compile tested: x86_64, latest git
Run tested: x86_64, latest git