### PR TITLE
libs/libsocketcan: remove double line

### DIFF
--- a/libs/libsocketcan/Makefile
+++ b/libs/libsocketcan/Makefile
@@ -19,8 +19,6 @@ PKG_MAINTAINER:=Yegor Yefremov <yegorslists@googlemail.com>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=LICENSE
 
-include $(INCLUDE_DIR)/package.mk
-
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Maintainer: @yegorich 
Compile tested: ARMv7, TI Sitara AM335x, OpenWrt v23.05.2
Run tested: ARMv7, TI Sitara AM335x, OpenWrt v23.05.2, tested with internal software

Description:

The following line appeared twice:

include $(INCLUDE_DIR)/package.mk
