### PR TITLE
[23.05] postfix: Fix enabling PCRE support

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postfix
 PKG_VERSION:=3.8.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -172,7 +172,7 @@ ifdef CONFIG_POSTFIX_PGSQL
 endif
 
 ifdef CONFIG_POSTFIX_PCRE
-  CCARGS+=-DHAS_PCRE2 -I$(STAGING_DIR)/usr/include/
+  CCARGS+=-DHAS_PCRE=2 -I$(STAGING_DIR)/usr/include/
   AUXLIBS+=-L$(STAGING_DIR)/usr/lib -lpcre2-8
 else
   CCARGS+=-DNO_PCRE


### PR DESCRIPTION
Backport of https://github.com/openwrt/packages/pull/22765 to `openwrt-23.05`.

After the change from PCRE to PCRE2 when enabling POSTFIX_PCRE the resulting postfix build no longer reports pcre as an available module. (postfconf -m). This is caused by using the wrong syntax for the HAS_PCRE build flag (HAS_PCRE2 vs HAS_PCRE=2). This fixes the build flag to use the correct syntax.

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)
