### PR TITLE
[23.05] node: bump to v18.19.0

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v18.18.2
+PKG_VERSION:=v18.19.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=7249e2f0af943ec38599504f4b2a2bd31fb938787291b6ccca6c8badf01e3b56
+PKG_HASH:=f52b41af20596a9abd8ed75241837ec43945468221448bbf841361e2091819b6
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,6 +1,6 @@
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1391,7 +1391,8 @@ Module._initPaths = function() {
+@@ -1516,7 +1516,8 @@ Module._initPaths = function() {
      path.resolve(process.execPath, '..') :
      path.resolve(process.execPath, '..', '..');
  

--- a/lang/node/patches/004-musl_support.patch
+++ b/lang/node/patches/004-musl_support.patch
@@ -20,7 +20,7 @@
    result = clock_gettime(CLOCK_MONOTONIC, &ts);
 --- a/deps/v8/src/base/platform/platform-posix.cc
 +++ b/deps/v8/src/base/platform/platform-posix.cc
-@@ -1066,7 +1066,7 @@ bool Thread::Start() {
+@@ -1072,7 +1072,7 @@ bool Thread::Start() {
  #if V8_OS_DARWIN
      // Default on Mac OS X is 512kB -- bump up to 1MB
      stack_size = 1 * 1024 * 1024;


### PR DESCRIPTION
Maintainer: me @ianchi
 Compile tested: 23.05, aarch64, arm 
Run tested: (qemu 8.1.3) aarch64

Description:
Notable Changes
* npm updated to v10
* ESM and customization hook changes
* New node:module API register for module customization hooks; new initialize hook
* import.meta.resolve unflagged
* --experimental-default-type flag to flip module defaults