### PR TITLE
[openwrt-23.05] fail2ban: Fix compatibility with Python 3.11

### DIFF
--- a/net/fail2ban/Makefile
+++ b/net/fail2ban/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fail2ban
 PKG_VERSION:=0.11.2
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fail2ban/fail2ban/tar.gz/$(PKG_VERSION)?

--- a/net/fail2ban/patches/101-move-global-groups-to-start-of-expression-python-3.11-compat.patch
+++ b/net/fail2ban/patches/101-move-global-groups-to-start-of-expression-python-3.11-compat.patch
@@ -1,0 +1,44 @@
+From 7e2ab36d86998575853150c0a57de5e22518cf66 Mon Sep 17 00:00:00 2001
+From: sebres <info@sebres.de>
+Date: Tue, 21 Jun 2022 16:55:57 +0200
+Subject: [PATCH] move global groups to start of expression (python 3.11
+ compat)
+
+[remove change to regex not in 0.11.2]
+Signed-off-by: Jeffery To <jeffery.to@gmail.com>
+---
+ fail2ban/client/fail2banregex.py | 2 +-
+ fail2ban/server/datetemplate.py  | 8 ++++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+--- a/fail2ban/server/datetemplate.py
++++ b/fail2ban/server/datetemplate.py
+@@ -35,6 +35,7 @@ logSys = getLogger(__name__)
+ # check already grouped contains "(", but ignores char "\(" and conditional "(?(id)...)":
+ RE_GROUPED = re.compile(r'(?<!(?:\(\?))(?<!\\)\((?!\?)')
+ RE_GROUP = ( re.compile(r'^((?:\(\?\w+\))?\^?(?:\(\?\w+\))?)(.*?)(\$?)$'), r"\1(\2)\3" )
++RE_GLOBALFLAGS = re.compile(r'((?:^|(?!<\\))\(\?[a-z]+\))')
+ 
+ RE_EXLINE_NO_BOUNDS = re.compile(r'^\{UNB\}')
+ RE_EXLINE_BOUND_BEG = re.compile(r'^\{\^LN-BEG\}')
+@@ -110,6 +111,11 @@ class DateTemplate(object):
+ 		# because it may be very slow in negative case (by long log-lines not matching pattern)
+ 
+ 		regex = regex.strip()
++		# cut global flags like (?iu) from RE in order to pre-set it after processing:
++		gf = RE_GLOBALFLAGS.search(regex)
++		if gf:
++			regex = RE_GLOBALFLAGS.sub('', regex, count=1)
++		# check word boundaries needed:
+ 		boundBegin = wordBegin and not RE_NO_WRD_BOUND_BEG.search(regex)
+ 		boundEnd = wordEnd and not RE_NO_WRD_BOUND_END.search(regex)
+ 		# if no group add it now, should always have a group(1):
+@@ -135,6 +141,8 @@ class DateTemplate(object):
+ 			self.flags |= DateTemplate.LINE_END
+ 		# remove possible special pattern "**" in front and end of regex:
+ 		regex = RE_DEL_WRD_BOUNDS[0].sub(RE_DEL_WRD_BOUNDS[1], regex)
++		if gf: # restore global flags:
++			regex = gf.group(1) + regex
+ 		self._regex = regex
+ 		logSys.log(7, '  constructed regex %s', regex)
+ 		self._cRegex = None

--- a/net/fail2ban/patches/102-wrap-global-flags-to-local-flags-if-supported-by-RE-engine-in-the-python-version.patch
+++ b/net/fail2ban/patches/102-wrap-global-flags-to-local-flags-if-supported-by-RE-engine-in-the-python-version.patch
@@ -1,0 +1,36 @@
+From 4337e366163278815ea9fc6c952bffb579e885a0 Mon Sep 17 00:00:00 2001
+From: sebres <info@sebres.de>
+Date: Tue, 21 Jun 2022 16:56:57 +0200
+Subject: [PATCH] wrap global flags like ((?i)xxx) or (?:(?i)xxx) to local
+ flags (?i:xxx) if supported by RE-engine in the python version
+
+---
+ fail2ban/server/failregex.py | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+--- a/fail2ban/server/failregex.py
++++ b/fail2ban/server/failregex.py
+@@ -91,6 +91,13 @@ R_MAP = {
+ 	"port": "fport",
+ }
+ 
++# map global flags like ((?i)xxx) or (?:(?i)xxx) to local flags (?i:xxx) if supported by RE-engine in this python version:
++try:
++	re.search("^re(?i:val)$", "reVAL")
++	R_GLOB2LOCFLAGS = ( re.compile(r"(?<!\\)\((?:\?:)?(\(\?[a-z]+)\)"), r"\1:" )
++except:
++	R_GLOB2LOCFLAGS = ()
++
+ def mapTag2Opt(tag):
+ 	tag = tag.lower()
+ 	return R_MAP.get(tag, tag)
+@@ -128,6 +135,9 @@ class Regex:
+ 		#
+ 		if regex.lstrip() == '':
+ 			raise RegexException("Cannot add empty regex")
++		# special handling wrapping global flags to local flags:
++		if R_GLOB2LOCFLAGS:
++			regex = R_GLOB2LOCFLAGS[0].sub(R_GLOB2LOCFLAGS[1], regex)
+ 		try:
+ 			self._regexObj = re.compile(regex, re.MULTILINE if multiline else 0)
+ 			self._regex = regex


### PR DESCRIPTION
Maintainer: @erdoukki
Compile tested: none (cherry picked from #22742)
Run tested: none

Description:
This backports 2 commits from [upstream][1]; the other 3 are not strictly necessary. One of the patches has been updated to remove a change to a regex that does not exist in 0.11.2.

[1]: https://github.com/fail2ban/fail2ban/pull/3267

Fixes: https://github.com/openwrt/packages/issues/22736

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit 0d9cc4aed202c9126966f7a9e73eaa7f48d51b6b)