### PR TITLE
[openwrt-23.05] dhtd: udpate to 0.2.6

### DIFF
--- a/net/dhtd/Makefile
+++ b/net/dhtd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dhtd
-PKG_VERSION:=0.2.5
+PKG_VERSION:=0.2.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mwarning/dhtd/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=0e239c969400537fda549b74f0555bddc2f1fe4ab3c00abe539970dfefab6599
+PKG_HASH:=4d9d88dc9cb035742a86c451c6bd40a7e44161709cd962933516ef6c5170683d
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
(cherry picked from commit 3c011d8aa190bc5d9b2eb5552bba14f7de072734)

Maintainer: me
