### PR TITLE
[openwrt-23.05] iperf3: update to 3.16

### DIFF
--- a/net/iperf3/Makefile
+++ b/net/iperf3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
-PKG_VERSION:=3.15
+PKG_VERSION:=3.16
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.es.net/pub/iperf
-PKG_HASH:=bdb77c11f72bce90214883159577fa24412013e62b2083cf5f54391d79b1d8ff
+PKG_HASH:=cc740c6bbea104398cc3e466befc515a25896ec85e44a662d5f4a767b9cf713e
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=BSD-3-Clause
@@ -44,7 +44,8 @@ define Package/iperf3-ssl
 $(call Package/iperf3/default)
   TITLE+= with iperf_auth support
   VARIANT:=ssl
-  DEPENDS:=+libopenssl
+  DEPENDS:=+libopenssl +libatomic
+  CONFLICTS:=iperf3
 endef
 
 define Package/libiperf3
@@ -52,9 +53,11 @@ define Package/libiperf3
   CATEGORY:=Libraries
   TITLE:=Internet Protocol bandwidth measuring library
   URL:=https://github.com/esnet/iperf
+  DEPENDS+=+libatomic
 endef
 
 TARGET_CFLAGS += -D_GNU_SOURCE
+TARGET_LDFLAGS += -latomic
 
 ifeq ($(BUILD_VARIANT),ssl)
 	CONFIGURE_ARGS += --with-openssl="$(STAGING_DIR)/usr" --disable-shared


### PR DESCRIPTION
notable changes:
- multithreading support

changelog: https://github.com/esnet/iperf/releases/tag/3.16

Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
(cherry picked from bdb6d2a37f)

Maintainer: @nbd168 
Compile tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt 23.05 snapshot
Run tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt 23.05 snapshot

Description:
see changelog for all changes. Most notably, the developers already included the multithreading support in this mainline version.