### PR TITLE
freeradius3: update where to download freeradius-3.0.26

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -8,19 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
-PKG_VERSION:=3_0_26
-PKG_RELEASE:=4
+PKG_VERSION:=3.0.26
+PKG_RELEASE:=1
 
-PKG_SOURCE:=release_$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/FreeRADIUS/freeradius-server/tar.gz/release_$(PKG_VERSION)?
-PKG_HASH:=6aea98d6126035e7ccca483d8b3faea447030169639807017ec98985b78fb2ca
+PKG_SOURCE:=freeradius-server-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=ftp://ftp.freeradius.org/pub/freeradius/
+PKG_HASH:=9a65314c462da4d4c4204df72c45f210de671f89317299b01f78549ac4503f59
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYRIGHT LICENSE
 PKG_CPE_ID:=cpe:/a:freeradius:freeradius
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/freeradius-server-release_$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/freeradius-server-$(PKG_VERSION)
 PKG_FIXUP:=autoreconf
 PYTHON3_PKG_BUILD:=0
 
@@ -136,6 +136,23 @@ define Package/freeradius3-mod-attr-filter/conffiles
 /etc/freeradius3/mods-config/attr_filter/pre-proxy
 endef
 
+define Package/freeradius3-mod-cache
+  $(call Package/freeradius3/Default)
+  DEPENDS:=freeradius3
+  TITLE:=Cache module
+endef
+
+define Package/freeradius3-mod-cache/conffiles
+/etc/freeradius3/mods-available/cache
+/etc/freeradius3/mods-available/cache_auth
+endef
+
+define Package/freeradius3-mod-cache-rbtree
+  $(call Package/freeradius3/Default)
+  DEPENDS:=freeradius3 +freeradius3-mod-cache
+  TITLE:=Cache Drivers rbtree
+endef
+
 define Package/freeradius3-mod-chap
   $(call Package/freeradius3/Default)
   DEPENDS:=freeradius3
@@ -248,6 +265,12 @@ define Package/freeradius3-mod-eap-pwd
   $(call Package/freeradius3/Default)
   DEPENDS:=freeradius3-mod-eap @FREERADIUS3_OPENSSL
   TITLE:=EAP/PWD module
+endef
+
+define Package/freeradius3-mod-eap-sim
+  $(call Package/freeradius3/Default)
+  DEPENDS:=freeradius3-mod-eap
+  TITLE:=EAP/SIM module
 endef
 
 define Package/freeradius3-mod-eap-tls
@@ -567,6 +590,12 @@ define Package/freeradius3-mod-sql-sqlite/conffiles
 /etc/freeradius3/mods-config/sql/main/sqlite
 endef
 
+define Package/freeradius3-mod-sql-unixodbc
+  $(call Package/freeradius3/Default)
+  DEPENDS:=freeradius3-mod-sql +unixodbc
+  TITLE:=Radius unixODBC back-end drivers
+endef
+
 define Package/freeradius3-mod-sqlcounter
   $(call Package/freeradius3/Default)
   DEPENDS:=+freeradius3-mod-sql
@@ -589,6 +618,17 @@ define Package/freeradius3-mod-sqlippool/conffiles
 /etc/freeradius3/mods-config/sql/ippool-dhcp
 /etc/freeradius3/mods-available/dhcp_sqlippool
 /etc/freeradius3/mods-available/sqlippool
+endef
+
+define Package/freeradius3-mod-totp
+  $(call Package/freeradius3/Default)
+  DEPENDS:=freeradius3
+  TITLE:=Totp module
+endef
+
+define Package/freeradius3-mod-totp/conffiles
+/etc/freeradius3/mods-available/totp
+/etc/freeradius3/sites-available/totp
 endef
 
 define Package/freeradius3-mod-unix
@@ -672,11 +712,8 @@ CONFIGURE_ARGS+= \
 	--with-radacctdir=/var/db/radacct \
 	--with-logdir=/var/log \
 	--without-pcre \
-	--without-rlm_cache \
 	--without-rlm_cache_memcached \
-	--without-rlm_couchbase \
 	--without-rlm_eap_ikev2 \
-	--without-rlm_eap_sim \
 	--without-rlm_eap_tnc \
 	--without-rlm_perl \
 	--without-rlm_python \
@@ -685,7 +722,6 @@ CONFIGURE_ARGS+= \
 	--without-rlm_sql_freetds \
 	--without-rlm_sql_iodbc \
 	--without-rlm_sql_oracle \
-	--without-rlm_sql_unixodbc \
 
 CONFIGURE_LIBS+= -latomic
 
@@ -828,6 +864,15 @@ else
   CONFIGURE_ARGS+= --without-rlm_sql_sqlite
 endif
 
+ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-unixodbc),)
+  CONFIGURE_ARGS+= \
+		--with-rlm_sql_unixodbc \
+		--with-rlm_sql_unixodbc-include-dir="$(STAGING_DIR)/usr/include" \
+		--with-rlm_sql_unixodbc-lib-dir="$(STAGING_DIR)/usr/lib"
+else
+  CONFIGURE_ARGS+= --without-rlm_sql_unixodbc
+endif
+
 ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-sqlcounter),)
   CONFIGURE_ARGS+= --with-rlm_sqlcounter
 else
@@ -965,6 +1010,8 @@ $(eval $(call BuildPackage,freeradius3-default))
 $(eval $(call BuildPackage,freeradius3-democerts))
 $(eval $(call BuildPlugin,freeradius3-mod-always,rlm_always,))
 $(eval $(call BuildPlugin,freeradius3-mod-attr-filter,rlm_attr_filter,))
+$(eval $(call BuildPlugin,freeradius3-mod-cache,rlm_cache,))
+$(eval $(call BuildPlugin,freeradius3-mod-cache-rbtree,rlm_cache_rbtree,))
 $(eval $(call BuildPlugin,freeradius3-mod-chap,rlm_chap,))
 $(eval $(call BuildPlugin,freeradius3-mod-counter,rlm_counter,))
 $(eval $(call BuildPlugin,freeradius3-mod-date,rlm_date,))
@@ -978,6 +1025,7 @@ $(eval $(call BuildPlugin,freeradius3-mod-eap-md5,rlm_eap_md5,))
 $(eval $(call BuildPlugin,freeradius3-mod-eap-mschapv2,rlm_eap_mschapv2,))
 $(eval $(call BuildPlugin,freeradius3-mod-eap-peap,rlm_eap_peap,))
 $(eval $(call BuildPlugin,freeradius3-mod-eap-pwd,rlm_eap_pwd,))
+$(eval $(call BuildPlugin,freeradius3-mod-eap-sim,rlm_eap_sim,))
 $(eval $(call BuildPlugin,freeradius3-mod-eap-tls,rlm_eap_tls,))
 $(eval $(call BuildPlugin,freeradius3-mod-eap-ttls,rlm_eap_ttls,))
 $(eval $(call BuildPlugin,freeradius3-mod-exec,rlm_exec,))
@@ -1009,8 +1057,10 @@ $(eval $(call BuildPlugin,freeradius3-mod-sql-mysql,rlm_sql_mysql,))
 $(eval $(call BuildPlugin,freeradius3-mod-sql-null,rlm_sql_null,))
 $(eval $(call BuildPlugin,freeradius3-mod-sql-postgresql,rlm_sql_postgresql,))
 $(eval $(call BuildPlugin,freeradius3-mod-sql-sqlite,rlm_sql_sqlite,))
+$(eval $(call BuildPlugin,freeradius3-mod-sql-unixodbc,rlm_sql_unixodbc,))
 $(eval $(call BuildPlugin,freeradius3-mod-sqlcounter,rlm_sqlcounter,))
 $(eval $(call BuildPlugin,freeradius3-mod-sqlippool,rlm_sqlippool,))
+$(eval $(call BuildPlugin,freeradius3-mod-totp,rlm_totp,))
 $(eval $(call BuildPlugin,freeradius3-mod-unix,rlm_unix,))
 $(eval $(call BuildPlugin,freeradius3-mod-unpack,rlm_unpack,))
 $(eval $(call BuildPlugin,freeradius3-mod-utf8,rlm_utf8,))


### PR DESCRIPTION
Maintainer:
Compile tested: armsr
Run tested: armv8

Description:

update where to download freeradius3

add modules

freeradius3-mod-totp
freeradius3-mod-sql-unixodbc
freeradius3-mod-eap-sim
freeradius3-mod-cache
freeradius3-mod-cache-rbtree