### PR TITLE
lvm2: remove dependency on libreadline by default

### DIFF
--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=LVM2
 PKG_VERSION:=2.03.25
 PKG_VERSION_DM:=1.02.199
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://sourceware.org/pub/lvm2
@@ -66,7 +66,7 @@ define Package/lvm2/default
   SUBMENU:=Disc
   TITLE:=The Linux Logical Volume Manager
   URL:=https://sourceware.org/lvm2/
-  DEPENDS:=+libreadline +libncurses +libaio
+  DEPENDS:=+libncurses +libaio
 endef
 
 define Package/lvm2
@@ -101,6 +101,7 @@ CONFIGURE_ARGS += \
 	--with-default-dm-run-dir=/var/run \
 	--with-default-run-dir=/var/run/lvm \
 	--with-default-locking-dir=/var/lock/lvm \
+	--disable-readline \
 	--$(if $(findstring selinux,$(BUILD_VARIANT)),en,dis)able-selinux
 
 ifneq ($(shell /bin/sh -c "echo -n 'X'"),X)


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: arm/aarch64 / OpenWrt 22.05
Run tested: arm/aarch64 / OpenWrt 22.05

Description:
Remove dependency on GPLv3 package.