### PR TITLE
tgt: update to 1.0.89

### DIFF
--- a/net/tgt/Makefile
+++ b/net/tgt/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tgt
-PKG_VERSION:=1.0.87
+PKG_VERSION:=1.0.89
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fujita/tgt/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=975bb23b4762f2e2a8e787b79afa7fb44442c5afabaea0e469fca0169826077a
+PKG_HASH:=cd09daffacc00a6641a7b95d31c43441656ce0b01af8d512359bc91bac3c6d99
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_cortex-a53, qualcommax/ipq807x, r24583+3-5fec4d6cd5
Run tested: aarch64_cortex-a53, qualcommax/ipq807x, r24583+3-5fec4d6cd5, running in a chroot at r23300+3-86bc525d00. I/O on a file as a backing store works

Description:
