### PR TITLE
[23.05] irqbalance: Fix log spam and correct meson version

### DIFF
--- a/utils/irqbalance/Makefile
+++ b/utils/irqbalance/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=irqbalance
 PKG_VERSION:=1.9.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/Irqbalance/irqbalance.git

--- a/utils/irqbalance/patches/010-meson.patch
+++ b/utils/irqbalance/patches/010-meson.patch
@@ -4,6 +4,9 @@ Date: Fri, 10 Jun 2022 23:14:27 -0700
 Subject: [PATCH] add meson
 
 Signed-off-by: Rosen Penev <rosenp@gmail.com>
+
+[update version string to 1.9.3]
+
 ---
  meson.build       | 43 +++++++++++++++++++++++++++++++++++++++++++
  meson_options.txt | 11 +++++++++++
@@ -15,7 +18,7 @@ Signed-off-by: Rosen Penev <rosenp@gmail.com>
 +++ b/meson.build
 @@ -0,0 +1,43 @@
 +project('irqbalance', 'c',
-+  version : '1.9.0',
++  version : '1.9.3',
 +  default_options : ['warning_level=1']
 +)
 +

--- a/utils/irqbalance/patches/020-mark-EINVAL-error-permanent.patch
+++ b/utils/irqbalance/patches/020-mark-EINVAL-error-permanent.patch
@@ -1,0 +1,15 @@
+--- a/activate.c
++++ b/activate.c
+@@ -98,11 +98,11 @@ error:
+ 	case ENOSPC: /* Specified CPU APIC is full. */
+ 	case EAGAIN: /* Interrupted by signal. */
+ 	case EBUSY: /* Affinity change already in progress. */
+-	case EINVAL: /* IRQ would be bound to no CPU. */
+ 	case ERANGE: /* CPU in mask is offline. */
+ 	case ENOMEM: /* Kernel cannot allocate CPU mask. */
+ 		/* Do not blacklist the IRQ on transient errors. */
+ 		break;
++	case EINVAL: /* IRQ would be bound to no CPU. */
+ 	default:
+ 		/* Any other error is considered permanent. */
+ 		info->flags |= IRQ_FLAG_AFFINITY_UNMANAGED;


### PR DESCRIPTION
Irqbalance 1.9.3 changed the handling of certain errors. Specifically EINVAL, trying to set an invalid CPU core, was changed to be a temporary error, causing log spam from repeated balancing runs in some devices. See log and strace below. Mark EINVAL as permanent.

This errors seems to surface on 23.05 only on some devices, but not all. 
And when I briefly tested, the unpatched 1.9.3 seemed to work in R7800 main/master build (with kernel 6.1) but fail with 23.05.  So I initially author this fix just for 23.05 

Also correct the version in our own meson.build patch.

Log and strace:

```
Sat Dec  9 10:17:27 2023 daemon.warn irqbalance: Cannot change IRQ 48 affinity: Invalid argument

open("/proc/irq/48/smp_affinity", O_WRONLY|O_CREAT|O_TRUNC|O_LARGEFILE, 0666) = 6 mmap2(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0xb6ed9000
ioctl(6, TIOCGWINSZ, 0xbeb134e8)        = -1 ENOTTY (Not a tty)
writev(6, [{iov_base="00000001", iov_len=8}, {iov_base=NULL, iov_len=0}], 2) = -1 EINVAL (Invalid argument)
close(6)                                = 0
munmap(0xb6ed9000, 4096)                = 0
clock_gettime64(CLOCK_REALTIME, {tv_sec=1702109847, tv_nsec=340549081}) = 0
sendto(5, "<28>Dec  9 08:17:27 irqbalance: "..., 80, 0, NULL, 0) = 80
writev(1, [{iov_base="Cannot change IRQ 48 affinity: I"..., iov_len=47}, {iov_base="\n", iov_len=1}], 2Cannot change IRQ 48 affinity: Invalid argument
) = 48

```
Maintainer: me 
Run tested: ipq806x/R7800

I wrote a comment upstream. Interesting to see their views.
https://github.com/Irqbalance/irqbalance/pull/269#issuecomment-1848331750
