### PR TITLE
[23.05] curl: update to 8.5.0

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -9,15 +9,15 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
-PKG_VERSION:=8.4.0
-PKG_RELEASE:=2
+PKG_VERSION:=8.5.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \
 	https://dl.uxnr.de/mirror/curl/ \
 	https://curl.askapache.com/download/ \
 	https://curl.se/download/
-PKG_HASH:=e5250581a9c032b1b6ed3cf2f9c114c811fc41881069e9892d115cc73f9e88c6
+PKG_HASH:=ce4b6a6655431147624aaf582632a36fe1ade262d5fab385c60f78942dd8d87b
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING

--- a/net/curl/patches/200-no_docs_tests.patch
+++ b/net/curl/patches/200-no_docs_tests.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -159,7 +159,7 @@ CLEANFILES = $(VC10_LIBVCXPROJ) $(VC10_S
+@@ -134,7 +134,7 @@ CLEANFILES = $(VC14_LIBVCXPROJ) \
  bin_SCRIPTS = curl-config
  
  SUBDIRS = lib src
@@ -9,7 +9,7 @@
  
  pkgconfigdir = $(libdir)/pkgconfig
  pkgconfig_DATA = libcurl.pc
-@@ -273,8 +273,6 @@ cygwinbin:
+@@ -248,8 +248,6 @@ cygwinbin:
  # We extend the standard install with a custom hook:
  install-data-hook:
  	(cd include && $(MAKE) install)


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2, test https-dns-proxy works.

Description:
* https://curl.se/changes.html#8_5_0

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 6501290c17fb2c65e0fb589da94d121ff89e7d5e)
