### PR TITLE
gpgme: Fix license

### DIFF
--- a/libs/gpgme/Makefile
+++ b/libs/gpgme/Makefile
@@ -9,7 +9,7 @@ PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
 PKG_HASH:=416e174e165734d84806253f8c96bda2993fd07f258c3aad5f053a6efd463e88
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
-PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
gpgme license is wrong since the addition of the package in commit https://git.openwrt.org/?p=feed/packages.git;a=commit;h=3e39633b75e7d26f3666bce9c2e97d268f0fd068

Indeed, gpgme has been licensed under LPGL-2.1+ since version 1.0.2 back in 2004 [1]:

```
Noteworthy changes in version 1.0.2 (2004-12-28)
------------------------------------------------

 * Changed the license of the library to the GNU Lesser General Public License (LGPL), version 2.1 or later.
```

[1] https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=blob;f=NEWS;h=2475a877a40817f575accd22a386bfd5f0a66aad;hb=HEAD

Maintainer: @dangowrt
Compile tested: Not needed
Run tested: Not needed
