### PR TITLE
[23.05] syncthing: fix duplicate command line parameters on service

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)

--- a/utils/syncthing/files/syncthing.init
+++ b/utils/syncthing/files/syncthing.init
@@ -14,7 +14,7 @@ config_cb() {
 		local option="$1"
 		local value="$2"
 		case $option in
-		enabled|macprocs|nice|user|logfile)
+		enabled|gui_address|home|logfile|macprocs|nice|user)
 			eval $option=$value
 			;;
 		debug)


### PR DESCRIPTION
  - This patch fixes 9d17ba1 and #22760

Signed-off-by: Eric Fahlgren <ericfahlgren@gmail.com>
(cherry picked from commit 6849a9df90d8c9c99dd50356b8f969d64026c16d)

Maintainer: @aparcar 

Description:
Backport fix to 23.05