### PR TITLE
perlbase-extutils: Adding required perlbase-version dependency.

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -11,7 +11,7 @@ include perlver.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=$(PERL_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://www.cpan.org/src/5.0
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz

--- a/lang/perl/perlbase.mk
+++ b/lang/perl/perlbase.mk
@@ -567,7 +567,7 @@ $(eval $(call BuildPackage,perlbase-experimental))
 define Package/perlbase-extutils
 $(call Package/perlbase-template)
 TITLE:=ExtUtils perl module
-DEPENDS+=+perlbase-autosplit +perlbase-base +perlbase-config +perlbase-cwd +perlbase-dirhandle +perlbase-encode +perlbase-essential +perlbase-file +perlbase-io +perlbase-ipc +perlbase-ostype +perlbase-symbol +perlbase-text
+DEPENDS+=+perlbase-autosplit +perlbase-base +perlbase-config +perlbase-cwd +perlbase-dirhandle +perlbase-encode +perlbase-essential +perlbase-file +perlbase-io +perlbase-ipc +perlbase-ostype +perlbase-symbol +perlbase-text +perlbase-version
 endef
 
 define Package/perlbase-extutils/install


### PR DESCRIPTION
Maintainer: @pprindeville, @Naoir
Compile tested: mvebu-cortexa9, arm_cortex-a9_vfpv3-d16, master: c399f7b94a9ddf98100542157b25df1d5cfe533b
Run tested: mvebu-cortexa9, arm_cortex-a9_vfpv3-d16, 23.05.0

Description:

Attempting to use  `ExtUtils::MakeMaker` after Installing `perlbase-extutils` results in an error:

```
root@storage:~# perl -MExtUtils::MakeMaker -e '1;'
Can't locate ExtUtils/MakeMaker/version/vpp.pm in @INC (you may need to install the ExtUtils::MakeMaker::version::vpp module) (@INC contains: /usr/lib/perl5/5.28) at (eval 4) line 1.
BEGIN failed--compilation aborted at (eval 4) line 1.
Compilation failed in require at /usr/lib/perl5/5.28/ExtUtils/MakeMaker.pm line 9.
BEGIN failed--compilation aborted at /usr/lib/perl5/5.28/ExtUtils/MakeMaker.pm line 9.
Compilation failed in require.
BEGIN failed--compilation aborted.
```

Installing `perlbase-version` fixes this, so it should be a required dependency of `perlbase-extutils`

```
root@storage:~# opkg install perlbase-version
Installing perlbase-version (5.28.1-9) to root...
Downloading https://downloads.openwrt.org/releases/23.05.0/packages/arm_cortex-a9_vfpv3-d16/packages/perlbase-version_5.28.1-9_arm_cortex-a9_vfpv3-d16.ipk
Configuring perlbase-version.
root@storage:~# perl -MExtUtils::MakeMaker -e '1;'
root@storage:~#
```
