### PR TITLE
mosh: Move section net/Network/SSH

### DIFF
--- a/net/mosh/Makefile
+++ b/net/mosh/Makefile
@@ -27,8 +27,9 @@ PKG_BUILD_FLAGS:=gc-sections lto
 include $(INCLUDE_DIR)/package.mk
 
 define Package/mosh/Default
-  SECTION:=utils
-  CATEGORY:=Utilities
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=SSH
   TITLE:=Mosh mobile shell
   DEPENDS:=+libncursesw +libopenssl +protobuf
   URL:=https://mosh.org/


### PR DESCRIPTION
The mosh-server and mosh-client packages are related to SSH.

Maintainer: @neheb @tymmej

Compile tested: OpenWrt master
Run tested: VirtulBox amd64

Description:
The mosh package is located in `net` folder while its makefile section is set to `utils`.
I didn't found it in the menuconfig because expected to see it in net/SSH section.
The PR moves it to the more appropriate section.