### PR TITLE
snort3: compile with lzma support

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -25,7 +25,7 @@ define Package/snort3
   SUBMENU:=Firewall
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic +kmod-nft-queue
+  DEPENDS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic +kmod-nft-queue +liblzma
   TITLE:=Lightweight Network Intrusion Detection System
   URL:=http://www.snort.org/
   MENU:=1
@@ -52,7 +52,7 @@ CMAKE_OPTIONS += \
 	-DMAKE_PDF_DOC:BOOL=NO \
 	-DMAKE_TEXT_DOC:BOOL=NO \
 	-DHAVE_LIBUNWIND=OFF \
-	-DHAVE_LZMA=OFF
+	-DHAVE_LZMA=ON
 
 TARGET_CFLAGS  += -I$(STAGING_DIR)/usr/include/daq3 -I$(STAGING_DIR)/usr/include/tirpc
 TARGET_LDFLAGS += -L$(STAGING_DIR)/usr/lib/daq3 -ltirpc


### PR DESCRIPTION
This PR adds the ability of snort to process rules that target swf and pdf files requiring lzma decompression to look for
malicious payloads therein.  This change only increases the size of the snort3 executable by a fraction of a KB and the added
dependency of liblzma (based on currently offered 5.4.4-1) is only a 169 KB shared object.  Based on CPU requirements of snort,
x86 users likely represent the majority user-base and space their rootfs is not an issue as it may be for lower-powered SoCs.

Size of snort3-3.1.76.0-2: 7354403 bytes
Size of snort3-3.1.76.0-3: 7354435 bytes

Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne

Maintainer: me and @flyn-org 