### PR TITLE
snort3: add missing action-override option

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.1.77.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/

--- a/net/snort3/files/main.uc
+++ b/net/snort3/files/main.uc
@@ -90,7 +90,7 @@ const snort_config = {
 
 	mode:            config_item("enum",  [ "ids", "ips" ]),
 	method:          config_item("enum",  [ "pcap", "afpacket", "nfq" ]),
-	action:          config_item("enum",  [ "alert", "block", "drop", "reject" ]),
+	action:          config_item("enum",  [ "default", "alert", "block", "drop", "reject" ]),
 	interface:       config_item("str",   [ uci.get("network", "wan", "device") ]),
 	snaplen:         config_item("range", [ 1518, 65535 ]),     // int daq.snaplen = 1518: set snap length (same as -s) { 0:65535 }
 
@@ -137,7 +137,9 @@ snort
                       PID file (why?).  Default /var/log
     openappid       - Enabled inspection using the 'openappid' package
                       See 'opkg info openappid'
-    action          - 'alert', 'block', 'reject' or 'drop'
+    action          - Override the specified action of your rules.  One of 'default',
+                      'alert', 'block', 'reject' or 'drop', where 'default' means use
+                      the rule as defined and don't override.
     method          - 'pcap', 'afpacket' or 'nfq'
     snaplen         - int daq.snaplen = 1518: set snap length (same as -s) { 0:65535 }
     include         - User-defined snort configuration, applied at end of generated snort.lua

--- a/net/snort3/files/snort.config
+++ b/net/snort3/files/snort.config
@@ -25,7 +25,9 @@
 #                       PID file (why?).  Default /var/log
 #     openappid       - Enabled inspection using the 'openappid' package
 #                       See 'opkg info openappid'
-#     action          - 'alert', 'block', 'reject' or 'drop'
+#     action          - Override the specified action of your rules.  One of 'default',
+#                       'alert', 'block', 'reject' or 'drop', where 'default' means use
+#                       the rule as defined and don't override.
 #     method          - 'pcap', 'afpacket' or 'nfq'
 #     snaplen         - int daq.snaplen = 1518: set snap length (same as -s) { 0:65535 }
 #     include         - User-defined snort configuration, applied at end of generated snort.lua
@@ -59,7 +61,7 @@ config snort 'snort'
 	option openappid       '0'              # one of [0, 1]
 	option mode            'ids'            # one of [ids, ips]
 	option method          'pcap'           # one of [pcap, afpacket, nfq]
-	option action          'alert'          # one of [alert, block, drop, reject]
+	option action          'default'        # one of [default, alert, block, drop, reject]
 	option interface       'eth0'           # a string
 	option snaplen         '1518'           # 1518 <= x <= 65535
 	option include         ''               # a path string

--- a/net/snort3/files/snort.uc
+++ b/net/snort3/files/snort.uc
@@ -52,7 +52,9 @@ snort  = {
 ips = {
   mode            = '{{ line_mode }}',
   variables       = default_variables,
+{% if (snort.action != 'default'): %}
   action_override = '{{ snort.action }}',
+{% endif %}
 {% if (getenv("_SNORT_WITHOUT_RULES") == "1"): %}
   -- WARNING: THIS IS A TEST-ONLY CONFIGURATION WITHOUT ANY RULES.
 {% else %}


### PR DESCRIPTION
Allow use of rules as-defined, and don't override their actions.  This is generally the best way to use the ruleset, and overriding their actions should only be undertaken when you fully understand how it affects their use.

Maintainer: @flyn-org @graysky2 
Run tested: x86/64
