### PR TITLE
 boost: Updates package to version 1.84.0

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -11,13 +11,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=boost
-PKG_VERSION:=1.83.0
-PKG_SOURCE_VERSION:=1_83_0
+PKG_VERSION:=1.84.0
+PKG_SOURCE_VERSION:=1_84_0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://boostorg.jfrog.io/artifactory/main/release/$(PKG_VERSION)/source/
-PKG_HASH:=6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e
+PKG_HASH:=cc4b893acf645c9d4b698e9a0f08ca8846aa5d6c68275c14c3e7949c24109454
 
 PKG_MAINTAINER:=Carlos M. Ferreira <carlosmf.pt@gmail.com>
 PKG_LICENSE:=BSL-1.0
@@ -42,12 +42,13 @@ define Package/boost/Default
 endef
 
 define Package/boost/description
-This package provides the Boost v1.83.0 libraries.
+This package provides the Boost v1.84.0 libraries.
 Boost is a set of free, peer-reviewed, portable C++ source libraries.
 
 This package provides the following run-time libraries:
  - atomic
  - chrono
+ - cobalt (new)
  - container
  - context
  - contract
@@ -78,7 +79,7 @@ This package provides the following run-time libraries:
  - wave
 
 There are many more header-only libraries supported by Boost.
-See more at http://www.boost.org/doc/libs/1_83_0/
+See more at http://www.boost.org/doc/libs/1_84_0/
 endef
 
 PKG_BUILD_DEPENDS:=boost/host
@@ -336,6 +337,7 @@ endef
 
 $(eval $(call DefineBoostLibrary,atomic,system))
 $(eval $(call DefineBoostLibrary,chrono,system))
+$(eval $(call DefineBoostLibrary,cobalt,system container))
 $(eval $(call DefineBoostLibrary,container))
 $(eval $(call DefineBoostLibrary,context,chrono system,,!boost-context-exclude))
 $(eval $(call DefineBoostLibrary,contract,system))
@@ -384,12 +386,10 @@ TARGET_LDFLAGS += -pthread -lrt -lstdc++ -Wl,--as-needed,--print-gc-sections
 TARGET_CFLAGS += \
 	$(if $(CONFIG_SOFT_FLOAT),-DBOOST_NO_FENV_H) -fPIC
 
-ifeq ($(word 1,$(subst ., ,$(call qstrip,$(CONFIG_GCC_VERSION)))),5)
-    EXTRA_CXXFLAGS += -std=gnu++14
-else ifneq ($(filter-out 6 7 8 9,$(word 1,$(subst ., ,$(call qstrip,$(CONFIG_GCC_VERSION))))),)
-    EXTRA_CXXFLAGS += -std=gnu++17
-else
+ifeq ($(word 1,$(subst ., ,$(call qstrip,$(CONFIG_GCC_VERSION)))),11)
     EXTRA_CXXFLAGS += -std=gnu++20
+else
+    EXTRA_CXXFLAGS += -std=gnu++23
 endif
 
 ifneq ($(findstring mips,$(ARCH)),)


### PR DESCRIPTION
Maintainer: @ClaymorePT 
Compile tested: ramips/mt7621 
Run tested: N/A

Description:
This commit updates boost to version 1.84.0

New available libraries:
* [Cobalt](https://www.boost.org/libs/cobalt/): Basic algorithms and types for C++20 coroutines, from Klemens Morgenstern.
* [Redis](https://www.boost.org/libs/redis/): Redis async client library built on top of Boost.Asio, from Marcelo Zimbres Silva.

More info about Boost 1.84.0 can be found [at the usual place](https://www.boost.org/users/history/version_1_84_0.html).
