### PR TITLE
libtorrent-rasterbar: Update to 2.0.9

### DIFF
--- a/libs/libtorrent-rasterbar/Makefile
+++ b/libs/libtorrent-rasterbar/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtorrent-rasterbar
-PKG_VERSION:=2.0.8
+PKG_VERSION:=2.0.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/arvidn/libtorrent/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=29e5c5395de8126ed1b24d0540a9477fbb158b536021cd65aaf9de34d0aadb46
+PKG_SOURCE_URL:=https://github.com/arvidn/libtorrent/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=90cd92b6061c5b664840c3d5e151d43fedb24f5b2b24e14425ffbb884ef1798e
 
 PKG_MAINTAINER:=David Yang <mmyangfl@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -45,24 +45,6 @@ endef
 #	$(call Package/libtorrent-rasterbar/description)
 #	This package contains Python 3 bindings for the libtorrent-rasterbar library.
 #endef
-
-define Download/try_signal
-	VERSION:=105cce59972f925a33aa6b1c3109e4cd3caf583d
-	SUBDIR:=deps/try_signal
-	FILE:=$(PKG_NAME)-try_signal-$$(VERSION).tar.xz
-	URL:=https://github.com/arvidn/try_signal.git
-	MIRROR_HASH:=da81da67d52b7a731c21148573b68bf8dc7863616d6ae1f81845b7afb29e8f00
-	PROTO:=git
-endef
-$(eval $(call Download,try_signal))
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-
-define Build/Prepare
-	$(Build/Prepare/Default)
-	$(eval $(Download/try_signal))
-	xzcat $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
-endef
 
 #CMAKE_OPTIONS += \
 #	-Dpython-bindings=ON \


### PR DESCRIPTION
Maintainer: @yangfl
Compile tested: rockchip/armv8, x86/64
Run tested: -

Description:
Switch to use release tarball to avoid try_signal hack.
Release note: https://github.com/arvidn/libtorrent/releases/tag/v2.0.9
