### PR TITLE
chrony: update to 4.5 and add ntp hotplug

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
-PKG_VERSION:=4.4
+PKG_VERSION:=4.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://chrony-project.org/releases/
-PKG_HASH:=eafb07e6daf92b142200f478856dfed6efc9ea2d146eeded5edcb09b93127088
+PKG_HASH:=19fe1d9f4664d445a69a96c71e8fdb60bcd8df24c73d1386e02287f7366ad422
 
 PKG_MAINTAINER:=Miroslav Lichvar <mlichvar0@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -85,6 +85,7 @@ define Package/chrony/install
 	$(INSTALL_DIR) $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/chronyd $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/chronyc $(1)/usr/bin
+	$(INSTALL_BIN) ./files/chrony.ntp-hotplug $(1)/usr/sbin/chrony-hotplug
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DIR) $(1)/etc/chrony

--- a/net/chrony/files/chrony.ntp-hotplug
+++ b/net/chrony/files/chrony.ntp-hotplug
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Wait for sync for up to 5 minutes and notify other services
+
+/usr/bin/chronyc waitsync 300 1 0.0 1 || exit 0
+
+ubus call hotplug.ntp call '{ "env": [ "ACTION=stratum" ] }'

--- a/net/chrony/files/chronyd.init
+++ b/net/chrony/files/chronyd.init
@@ -4,6 +4,7 @@
 START=15
 USE_PROCD=1
 PROG=/usr/sbin/chronyd
+HOTPLUG=/usr/sbin/chrony-hotplug
 CONFIGFILE=/etc/chrony/chrony.conf
 INCLUDEFILE=/var/etc/chrony.d/10-uci.conf
 RTCDEVICE=/dev/rtc0
@@ -77,6 +78,10 @@ start_service() {
 	procd_set_param command $PROG -n
 	procd_set_param file $CONFIGFILE
 	procd_set_param file $INCLUDEFILE
+	procd_close_instance
+
+	procd_open_instance
+	procd_set_param command $HOTPLUG
 	procd_close_instance
 
 	config_load chrony


### PR DESCRIPTION
Maintainer: me
Compile tested: (mips, Archer C5v1, 23.05)
Run tested: (mips, Archer C5v1, 23.05, NTP client+server)

Description:
Update to latest release and add an ntp hotplug provider script.