### PR TITLE
shairport-sync: pipe audio backend support enabled

### DIFF
--- a/sound/shairport-sync/Makefile
+++ b/sound/shairport-sync/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shairport-sync
 PKG_VERSION:=4.3.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikebrady/shairport-sync/tar.gz/$(PKG_VERSION)?
@@ -79,6 +79,7 @@ CONFIGURE_ARGS += \
 	--with-alsa \
 	--with-libdaemon \
 	--with-airplay-2 \
+	--with-pipe \
 	--with-metadata
 
 ifeq ($(BUILD_VARIANT),openssl)


### PR DESCRIPTION
Maintainer: @mikebrady  / @thess 

**Compile tested:** 
- arch: armv8
- model: NanoPi R4S
- OpenWRT version: 23.05

**Run tested:** 
- arch: armv8
- model: NanoPi R4S
- OpenWRT version: OpenWrt 23.05.2 r23630-842932a63d / LuCI openwrt-23.05 branch git-23.306.39416-c86c256
- tests:

-- [x] shairport-sync 4.3.2 installed on NanoPi R4S
-- [x] shairport-sync -V reports 'pipe' support

```
root@test-router-hw1:~# /usr/bin/shairport-sync -V
4.3.2-libdaemon-OpenSSL-Avahi-ALSA-pipe-soxr-metadata-sysconfdir:/etc
```

-- [x] shairport-sync to write to default pipe on NanoPi R4S with UCI's shairport-sync's 'pipe-name' set to /etc/shairport-sync-audio

0.

```
root@test-router-hw1:~# ls -alh /tmp/shairport-sync-*
prw-rw-rw-    1 root     root           0 Dec 20 11:58 /tmp/shairport-sync-audio
prw-rw-rw-    1 root     root           0 Dec 20 11:58 /tmp/shairport-sync-metadata
-rw-------    1 root     root      108.9K Dec 20 11:58 /tmp/shairport-sync-openssl_4.3.2-0_aarch64_generic.ipk
```

1. Play audio on phone connected to shairport-sync's server instance
2. 

```
cat /tmp/shairport-sync-audio
**** full of gibberish symbol, as I expected :-) ****
```

**Description:**
- Enable pipe audio backend at compile time:
  - UCI's shairport-sync's pipe conf block is defined but has no effect without shairport-sync's pipe support.
  - On SBC with no sound card available (built-in or external) and without ALSA plugins support on OpenwRT (no package) to reroute a stream from shairport-sync's ALSA default output to a PulseAudio controlled Bluetooth sink , then  pipe support is required to enable the following flow: `shairport-sync -> named pipe -> owntone`. See https://github.com/openwrt/packages/pull/22942
  - diff: +746 bytes   
    - shairport-sync-openssl_4.3.2-0_aarch64_generic.ipk without --pipe: 110806 bytes
    - shairport-sync-openssl_4.3.2-0_aarch64_generic.ipk with --pipe: 111552 bytes