### PR TITLE
syncthing: fix group in syncthing.init

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
 PKG_VERSION:=1.27.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)

--- a/utils/syncthing/files/syncthing.init
+++ b/utils/syncthing/files/syncthing.init
@@ -55,6 +55,8 @@ start_service() {
 
 	config_load "syncthing"
 
+	local group=$(id -gn $user)
+
 	# Some of the default values below might not match the defaults
 	#   in /etc/config/syncthing: the reason is to remain backwards
 	#   compatible with the older versions of this service as it
@@ -67,12 +69,12 @@ start_service() {
 		[ -d "$IDX_DB" ] || mkdir -p "$IDX_DB"
 
 		# A separate step to handle an upgrade use case
-		[ -d "$IDX_DB" ] && chown -R $user:$user "$IDX_DB"
+		[ -d "$IDX_DB" ] && chown -R $user:$group "$IDX_DB"
 	fi
 
 	[ -d "$home" ] || mkdir -p "$home"
 	# A separate step to handle an upgrade use case
-	[ -d "$home" ] && chown -R $user:$user "$home"
+	[ -d "$home" ] && chown -R $user:$group "$home"
 
 	# Changes to "niceness"/macprocs are not picked up by "reload_config"
 	#   nor by "restart": the service has to be stopped/started


### PR DESCRIPTION
The goup does not always have the same name as user, and when I try to run syncthing with nobody I get an error. Since nobody belongs to the group nogroup, I added some code to find out which group user belongs to.

Maintainer:  @aparcar @brvphoenix
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
