### PR TITLE
ccid: update to version 1.5.4

### DIFF
--- a/utils/ccid/Makefile
+++ b/utils/ccid/Makefile
@@ -8,18 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ccid
-PKG_VERSION:=1.5.1
+PKG_VERSION:=1.5.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://ccid.apdu.fr/files/
-PKG_HASH:=e7a78c398ec0d617a4f98bac70d5b64f78689284dd0ae87d4692e2857f117377
+PKG_HASH:=6e832adc172ecdcfdee2b56f33144684882cbe972daff1938e7a9c73a64f88bf
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=libtool
 PKG_INSTALL:=1
+PKG_BUILD_DEPENDS:=zlib
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/utils/ccid/patches/010-macos.patch
+++ b/utils/ccid/patches/010-macos.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -79,7 +79,7 @@ AC_CHECK_FUNCS(select strerror strncpy m
+@@ -83,7 +83,7 @@ AC_CHECK_FUNCS(select strerror strncpy m
  # Select OS specific versions of source files.
  AC_SUBST(BUNDLE_HOST)
  AC_SUBST(DYN_LIB_EXT)


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: -

Description:
1.5.4 - 29 October 2023, Ludovic Rousseau
   - fix a regression introduced in 1.5.3

1.5.3 - 25 October 2023, Ludovic Rousseau
   - Add support of - ACS ACR1552 1S CL Reader - ACS ACR1552 CL Reader - ACS ACR1581 - ACS ACR40T ICC Reader - ACS ACR40U ICC Reader - ACS WalletMate 1S CL Reader - Aktiv Rutoken SCR 3101 NFC Reader - CIRIGHT ONE PASS U2F - Dexon Tecnologias Digitais LTDA eSmartDX - Excelsecu Card reader - GHI NC001 - Identiv uTrust Token Flex - SpringCard M519 with idProduct: 0x6212 - SpringCard M519 with idProduct: 0x621A - WCMi SD5931
   - parse: create output.bin file
   - udev: Disable USB-persist for CCID devices
   - configure: fail if flex is not found
   - Some other minor improvements

1.5.2 - 31 January 2023, Ludovic Rousseau
   - Add support of - KAPELSE KAP-LINK - LDU LANDI - Sensyl SSC-HV Reader - TOKEN2 MFA NFC Reader - TOKEN2 Molto2 - Thales RF Reader
   - Alcor Micro AU9560: Remove high speeds since they are not supported
   - Hack for AlcorMicro AU9560 and Acos-ID card
   - configure.ac: disable the use of --disable-usbdropdir