### PR TITLE
base16384: bump to version 2.2.5

### DIFF
--- a/utils/base16384/Makefile
+++ b/utils/base16384/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=base16384
-PKG_VERSION:=2.2.4
+PKG_VERSION:=2.2.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fumiama/base16384/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=5701519bd07a58019bc5204ca93194026f2869969cb8bc2563cbcb450f2e80bf
+PKG_HASH:=f1a7d18f96ce06085911f224f61ce490e5e02c3b179667befef01adaaf7bc659
 
 PKG_MAINTAINER:=源 文雨 <fumiama@foxmail.com>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: x86/64, Generic PC, OpenWrt 22.03.2 r19803-9a599fee93
Run tested: x86/64, Generic PC, OpenWrt 22.03.2 r19803-9a599fee93

Signed-off-by: 源 文雨 <fumiama@foxmail.com>