### PR TITLE
pcsc-lite: update to version 2.0.1

### DIFF
--- a/utils/pcsc-lite/Makefile
+++ b/utils/pcsc-lite/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pcsc-lite
-PKG_VERSION:=1.9.9
+PKG_VERSION:=2.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://pcsclite.apdu.fr/files/
-PKG_HASH:=cbcc3b34c61f53291cecc0d831423c94d437b188eb2b97b7febc08de1c914e8a
+PKG_HASH:=5edcaf5d4544403bdab6ee2b5d6c02c6f97ea64eebf0825b8d0fa61ba417dada
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
@@ -70,6 +70,7 @@ CONFIGURE_ARGS += \
 	--disable-libudev \
 	--disable-libsystemd \
 	--enable-libusb \
+	--disable-polkit \
 	--enable-static \
 	--enable-ipcdir=/var/run/pcscd \
 	--enable-usbdropdir=/usr/lib/pcsc/drivers


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: -

Description:
Add configure argument to keep polkit disabled as per before 2.0.1.

2.0.1: Ludovic Rousseau
24 November 2023
- SCardConnect(): return SCARD_W_SECURITY_VIOLATION when needed (polkit)
- SCardCancel(): return SCARD_S_SUCCESS even if the client already finished
- polkit is enabled by default
- libpcscspy: fix a crash with NULL pointers
- Doxygen: fix SCardBeginTransaction() documentation
- fix pcscd internal thread safety issues (clang -fsanitize=thread)
- Some other minor improvements

9 June 2023
2.0.0: Ludovic Rousseau
9 June 2023
- Adjust USB drivers path at run-time via environment variable PCSCLITE_HP_DROPDIR
- Add '--disable-polkit' option
- Reset eventCounter when a reader is removed
- Add "polkit" in "pcscd -v" output if enabled
- Doxygen: document SCARD_E_INVALID_VALUE for some functions
- use secure_getenv(3) if available
- Some other minor improvements