### PR TITLE
pcsc-tools: update to version 1.7.0

### DIFF
--- a/utils/pcsc-tools/Makefile
+++ b/utils/pcsc-tools/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pcsc-tools
-PKG_VERSION:=1.6.1
+PKG_VERSION:=1.7.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://ludovic.rousseau.free.fr/softwares/pcsc-tools
-PKG_HASH:=86fb756adfd18958d05af61e53c7503d4c46f0700677e6d0688dd4360eb53150
+PKG_HASH:=3466e60f975573168e9880505c7b44a4d51eb507a8a7dda9e68b672071c20da6
 
-PKG_MAINTAINER:=
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
@@ -29,7 +29,7 @@ define Package/pcsc-tools
   CATEGORY:=Utilities
   DEPENDS:=+libpcsclite
   TITLE:=pcsc-tools
-  URL:=http://ludovic.rousseau.free.fr/softwares/pcsc-tools/
+  URL:=https://pcsc-tools.apdu.fr/
 endef
 
 define Package/pcsc-tools/description

--- a/utils/pcsc-tools/patches/001-disable-atr.patch
+++ b/utils/pcsc-tools/patches/001-disable-atr.patch
@@ -3,12 +3,21 @@ as a dependency.
 
 --- a/pcsc_scan.c
 +++ b/pcsc_scan.c
-@@ -294,7 +294,7 @@ static void initialize_options(options_t
- #if defined(WIN32) || defined(__APPLE__)
- 	options->analyse_atr = False;
+@@ -283,7 +283,7 @@ static void initialize_options(options_t
+ {
+ 	options->pname = pname;
+ #if defined(ATR_PARSER)
+-	options->analyse_atr = true;
++	options->analyse_atr = false;
  #else
--	options->analyse_atr = True;
-+	options->analyse_atr = False;
+ 	options->analyse_atr = false;
+ #define ATR_PARSER ""
+@@ -302,7 +302,7 @@ static void initialize_options(options_t
+ #ifdef WIN32
+ #define OPTIONS OPTIONS_BASE
+ #else
+-#define OPTIONS OPTIONS_BASE "n"
++#define OPTIONS OPTIONS_BASE
  #endif
- 	options->stress_card = False;
- 	options->maxtime = 0;
+ 
+ static void print_version(void)


### PR DESCRIPTION
Maintainer: -
Compile tested: aarch64/cortex-a53
Run tested: -

Description:
See https://pcsc-tools.apdu.fr/Changelog for details.