### PR TITLE
libcurl-gnutls: update to version 8.5.0

### DIFF
--- a/net/libcurl-gnutls/Makefile
+++ b/net/libcurl-gnutls/Makefile
@@ -10,14 +10,14 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=libcurl-gnutls
 
 PKG_SOURCE_NAME:=curl
-PKG_VERSION:=8.2.1
+PKG_VERSION:=8.5.0
 PKG_RELEASE:=1
-PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \
 	https://dl.uxnr.de/mirror/curl/ \
 	https://curl.askapache.com/download/ \
 	https://curl.se/download/
-PKG_HASH:=dd322f6bd0a20e6cebdfd388f69e98c3d183bed792cf4713c8a7ef498cba4894
+PKG_HASH:=ce4b6a6655431147624aaf582632a36fe1ade262d5fab385c60f78942dd8d87b
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT

--- a/net/libcurl-gnutls/patches/0001-gnutls-fix-build-with-disable-verbose.patch
+++ b/net/libcurl-gnutls/patches/0001-gnutls-fix-build-with-disable-verbose.patch
@@ -1,0 +1,54 @@
+From af520ac9fec7d88e942f05fdcd90704adb9fa566 Mon Sep 17 00:00:00 2001
+From: Baruch Siach <baruch@tkos.co.il>
+Date: Mon, 11 Dec 2023 20:45:01 +0200
+Subject: [PATCH] gnutls: fix build with --disable-verbose
+
+infof() parameters must be defined event with --disable-verbose since
+commit dac293cfb702 ("lib: apache style infof and trace
+macros/functions").
+
+Move also 'ptr' definition under !CURL_DISABLE_VERBOSE_STRINGS.
+
+Fixes the following build failure:
+
+In file included from ../lib/sendf.h:29,
+                 from vtls/gtls.c:44:
+vtls/gtls.c: In function 'Curl_gtls_verifyserver':
+vtls/gtls.c:841:34: error: 'version' undeclared (first use in this function); did you mean 'session'?
+  841 |         gnutls_protocol_get_name(version), ptr);
+      |                                  ^~~~~~~
+
+Closes #12505
+---
+ lib/vtls/gtls.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/lib/vtls/gtls.c
++++ b/lib/vtls/gtls.c
+@@ -822,16 +822,17 @@ Curl_gtls_verifyserver(struct Curl_easy
+   char certname[65] = ""; /* limited to 64 chars by ASN.1 */
+   size_t size;
+   time_t certclock;
+-  const char *ptr;
+   int rc;
+   CURLcode result = CURLE_OK;
+ #ifndef CURL_DISABLE_VERBOSE_STRINGS
++  const char *ptr;
+   unsigned int algo;
+   unsigned int bits;
+   gnutls_protocol_t version = gnutls_protocol_get_version(session);
+ #endif
+   long * const certverifyresult = &ssl_config->certverifyresult;
+ 
++#ifndef CURL_DISABLE_VERBOSE_STRINGS
+   /* the name of the cipher suite used, e.g. ECDHE_RSA_AES_256_GCM_SHA384. */
+   ptr = gnutls_cipher_suite_get_name(gnutls_kx_get(session),
+                                      gnutls_cipher_get(session),
+@@ -839,6 +840,7 @@ Curl_gtls_verifyserver(struct Curl_easy
+ 
+   infof(data, "SSL connection using %s / %s",
+         gnutls_protocol_get_name(version), ptr);
++#endif
+ 
+   /* This function will return the peer's raw certificate (chain) as sent by
+      the peer. These certificates are in raw format (DER encoded for


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: -

Description:
https://curl.se/changes.html#8_5_0

Pick upstream patch to fix build with gnuTLS and verbose strings removed. The patch should be removed with the next version bump.

