### PR TITLE
openvpn: start openvpn connection located under '/etc/openvpn' not only on system start

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.6.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/openvpn.init
+++ b/net/openvpn/files/openvpn.init
@@ -171,7 +171,7 @@ openvpn_add_instance() {
 	procd_close_instance
 }
 
-start_instance() {
+start_uci_instance() {
 	local s="$1"
 
 	config_get config "$s" config
@@ -226,9 +226,9 @@ start_service() {
 
 	if [ -n "$instance" ]; then
 		[ "$instance_found" -gt 0 ] || return
-		start_instance "$instance"
+		start_uci_instance "$instance"
 	else
-		config_foreach start_instance 'openvpn'
+		config_foreach start_uci_instance 'openvpn'
 
 		local path name up down
 		for path in /etc/openvpn/*.conf; do

--- a/net/openvpn/files/openvpn.init
+++ b/net/openvpn/files/openvpn.init
@@ -271,7 +271,12 @@ start_service() {
 	else
 		config_foreach start_uci_instance 'openvpn'
 
-		start_path_instances
+		auto="$(uci_get openvpn globals autostart 1)"
+		if [ "$auto" = "1" ]; then
+			start_path_instances
+		else
+			logger -t openvpn "Autostart for configs in '$PATH_INSTANCE_DIR/*.conf' disabled"
+		fi
 	fi
 }
 

--- a/net/openvpn/files/openvpn.init
+++ b/net/openvpn/files/openvpn.init
@@ -206,6 +206,29 @@ start_uci_instance() {
 	openvpn_add_instance "$s" "/var/etc" "openvpn-$s.conf" "$script_security" "$up" "$down"
 }
 
+start_path_instances() {
+	local path name up down
+
+	for path in /etc/openvpn/*.conf; do
+		if [ -f "$path" ]; then
+			name="${path##*/}"; name="${name%.conf}"
+
+			# don't start configs again that are already started by uci
+			if echo "$UCI_STARTED" | grep -qxF "$path"; then
+				continue
+				# don't start configs which are set to disabled in uci
+			elif echo "$UCI_DISABLED" | grep -qxF "$path"; then
+				logger -t openvpn "$name.conf is disabled in /etc/config/openvpn"
+				continue
+			fi
+
+			get_openvpn_option "$path" up up || up=""
+			get_openvpn_option "$path" down down || down=""
+			openvpn_add_instance "$name" "${path%/*}" "$path" "" "$up" "$down"
+		fi
+	done
+}
+
 start_service() {
 	local instance="$1"
 	local instance_found=0
@@ -230,26 +253,7 @@ start_service() {
 	else
 		config_foreach start_uci_instance 'openvpn'
 
-		local path name up down
-		for path in /etc/openvpn/*.conf; do
-			if [ -f "$path" ]; then
-				name="${path##*/}"; name="${name%.conf}"
-
-				# don't start configs again that are already started by uci
-				if echo "$UCI_STARTED" | grep -qxF "$path"; then
-					continue
-
-				# don't start configs which are set to disabled in uci
-				elif echo "$UCI_DISABLED" | grep -qxF "$path"; then
-					logger -t openvpn "$name.conf is disabled in /etc/config/openvpn"
-					continue
-				fi
-
-				get_openvpn_option "$path" up up || up=""
-				get_openvpn_option "$path" down down || down=""
-				openvpn_add_instance "$name" "${path%/*}" "$path" "" "$up" "$down"
-			fi
-		done
+		start_path_instances
 	fi
 }
 

--- a/net/openvpn/files/openvpn.init
+++ b/net/openvpn/files/openvpn.init
@@ -263,8 +263,11 @@ start_service() {
 	config_load 'openvpn'
 
 	if [ -n "$instance" ]; then
-		[ "$instance_found" -gt 0 ] || return
-		start_uci_instance "$instance"
+		if [ "$instance_found" -gt 0 ]; then
+			start_uci_instance "$instance"
+		else
+			start_path_instance "$instance"
+		fi
 	else
 		config_foreach start_uci_instance 'openvpn'
 

--- a/net/openvpn/files/openvpn.init
+++ b/net/openvpn/files/openvpn.init
@@ -10,6 +10,7 @@ STOP=10
 USE_PROCD=1
 PROG=/usr/sbin/openvpn
 
+PATH_INSTANCE_DIR="/etc/openvpn"
 LIST_SEP="
 "
 
@@ -207,26 +208,40 @@ start_uci_instance() {
 }
 
 start_path_instances() {
-	local path name up down
+	local path name
 
-	for path in /etc/openvpn/*.conf; do
-		if [ -f "$path" ]; then
-			name="${path##*/}"; name="${name%.conf}"
-
-			# don't start configs again that are already started by uci
-			if echo "$UCI_STARTED" | grep -qxF "$path"; then
-				continue
-				# don't start configs which are set to disabled in uci
-			elif echo "$UCI_DISABLED" | grep -qxF "$path"; then
-				logger -t openvpn "$name.conf is disabled in /etc/config/openvpn"
-				continue
-			fi
-
-			get_openvpn_option "$path" up up || up=""
-			get_openvpn_option "$path" down down || down=""
-			openvpn_add_instance "$name" "${path%/*}" "$path" "" "$up" "$down"
-		fi
+	for path in ${PATH_INSTANCE_DIR}/*.conf; do
+		[ -f "$path" ] && {
+			name="${path##*/}"
+			name="${name%.conf}"
+			start_path_instance "$name"
+		}
 	done
+}
+
+start_path_instance() {
+	local name="$1"
+
+	local path up down
+
+	path="${PATH_INSTANCE_DIR}/${name}.conf"
+
+	# don't start configs again that are already started by uci
+	if echo "$UCI_STARTED" | grep -qxF "$path"; then
+		logger -t openvpn "$name.conf already started"
+		return
+	fi
+
+	# don't start configs which are set to disabled in uci
+	if echo "$UCI_DISABLED" | grep -qxF "$path"; then
+		logger -t openvpn "$name.conf is disabled in /etc/config/openvpn"
+		return
+	fi
+
+	get_openvpn_option "$path" up up || up=""
+	get_openvpn_option "$path" down down || down=""
+
+	openvpn_add_instance "$name" "${path%/*}" "$path" "" "$up" "$down"
 }
 
 start_service() {


### PR DESCRIPTION
Maintainer: @jow- @AuthorReflex 
Compile tested: only script changes
Run tested: x86_64, APU3, latest openwrt master

Description:

OpenVPN configurations that have a uci entry, the enable/enabled option can be used to control whether the OpenVPN connection should be started at system startup or not.

OpenVPN configurations that are located under `/etc/openvpn/` are always started at system boot. To ensure that these connections can also be started later, they must **not** be started automatically during system boot. This can be prevented with the following new uci section entry in the OpenVPN configuration.

```
config globals 'globals'
    option autostart '0'
```

These OpenVPN configurations can then be started later with the command `/etc/init.d/openvpn start <name>`.
