### PR TITLE
python-dbus-fast: update version 2.21.0

### DIFF
--- a/lang/python/python-dbus-fast/Makefile
+++ b/lang/python/python-dbus-fast/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dbus-fast
-PKG_VERSION:=2.20.0
+PKG_VERSION:=2.21.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=dbus-fast
 PYPI_SOURCE_NAME:=dbus_fast
-PKG_HASH:=a38e837c5a8d0a1745ec8390f68ff57986ed2167b0aa2e4a79738a51dd6dfcc3
+PKG_HASH:=f582f6f16791ced6067dab325fae444edf7ce0704315b90c2a473090636a6fe0
 
 PKG_MAINTAINER:=Quintin Hill <stuff@quintin.me.uk>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer:Quintin Hill <stuff@quintin.me.uk>
Compile tested: armsr
Run tested: armv8

Description:

python-dbus-fast update version 2.21.0