### PR TITLE
python-greenlet: update version 3.0.2

### DIFF
--- a/lang/python/python-greenlet/Makefile
+++ b/lang/python/python-greenlet/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-greenlet
-PKG_VERSION:=2.0.2
+PKG_VERSION:=3.0.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=greenlet
-PKG_HASH:=e7c8dc13af7db097bed64a051d2dd49e9f0af495c26995c00a9ee842690d34c0
+PKG_HASH:=1c1129bc47266d83444c85a8e990ae22688cf05fb20d7951fd2866007c2ba9bc
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=MIT
@@ -20,9 +20,13 @@ PKG_LICENSE_FILES:=LICENSE
 # FIXME: remove when GCC10 is the oldest supported compiler, or the issue goes away
 PKG_BUILD_FLAGS:=no-mips16
 
+HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-wheel/host
+
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-greenlet
   SUBMENU:=Python
@@ -51,3 +55,4 @@ endif
 $(eval $(call Py3Package,python3-greenlet))
 $(eval $(call BuildPackage,python3-greenlet))
 $(eval $(call BuildPackage,python3-greenlet-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: @ja-pa 
Compile tested: armsr
Run tested: armv8

Description:

updates and add the host that python-gevent needs 