### PR TITLE
wifischedule: fix startup problems

### DIFF
--- a/net/wifischedule/Makefile
+++ b/net/wifischedule/Makefile
@@ -16,7 +16,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifischedule
 PKG_VERSION:=1.0.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=PRPL
 
 PKG_MAINTAINER:=Nils Koenig <openwrt@newk.it> 
@@ -54,7 +54,7 @@ define Package/wifischedule/install
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DATA) ./net/etc/config/wifi_schedule $(1)/etc/config/wifi_schedule
 	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_DATA) ./net/etc/init.d/wifi_schedule $(1)/etc/init.d/wifi_schedule
+	$(INSTALL_BIN) ./net/etc/init.d/wifi_schedule $(1)/etc/init.d/wifi_schedule
 endef
 
 define Package/wifischedule/postinst

--- a/net/wifischedule/net/usr/bin/wifi_schedule.sh
+++ b/net/wifischedule/net/usr/bin/wifi_schedule.sh
@@ -277,14 +277,16 @@ _should_wifi_enabled()
 startup()
 {
     _log "startup"
-    local _enable_wifi=$(_should_wifi_enabled)
-    if [[ ${_enable_wifi} -eq 0 ]]
-    then
-        _log "enable wifi"
-        enable_wifi
-    else 
-        _log "disable wifi"
-        disable_wifi
+    local global_enabled=$(_get_uci_value ${GLOBAL}.enabled) || _exit 1
+    if [ ${global_enabled} -eq 1 ]; then
+        local _enable_wifi=$(_should_wifi_enabled)
+        if [ ${_enable_wifi} -eq 0 ]; then
+            _log "enable wifi"
+            enable_wifi
+        else
+            _log "disable wifi"
+            disable_wifi
+        fi
     fi
 }
 


### PR DESCRIPTION
Maintainer: @newkit
Compile tested: mediatek/fiilogic Sinovoip Banana Pi R3, snapshot kernel 6.1.69
Run tested: mediatek/fiilogic Sinovoip Banana Pi R3, snapshot kernel 6.1.69

Description:
1. Make the new `startup()` function in `/usr/bin/wifi_schedule.sh`
    respect the global `enabled` config flag; in particular, make no
    changes to `/etc/config/wireless` when wifi_schedule is disabled.
2. Make the new `/etc/init.d/wifi_schedule` service script executable.

Fixes: e0d7181a6
Closes: #22973
Closes: #22988