### PR TITLE
zoneinfo: Updated to 2023d release.

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2023c
-PKG_RELEASE:=2
+PKG_VERSION:=2023d
+PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
 #as referense to http://www.iana.org/time-zones/repository/tz-link.html
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=3f510b5d1b4ae9bb38e485aa302a776b317fb3637bdb6404c4adf7b6cadd965c
+PKG_HASH:=dbca21970b0a8b8c0ceceec1d7b91fa903be0f6eca5ae732b5329672232a08f3
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=46d17f2bb19ad73290f03a203006152e0fa0d7b11e5b71467c4a823811b214e7
+   HASH:=e9a5f9e118886d2de92b62bb05510a28cc6c058d791c93bd6b84d3292c3c161e
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT master
Run tested: n/a

Description:

The 2023d release of the tz code and data is available.

This release contains the following changes:

   Briefly:

     Ittoqqortoormiit, Greenland changes time zones on 2024-03-31.
     Vostok, Antarctica changed time zones on 2023-12-18.
     Casey, Antarctica changed time zones five times since 2020.
     Code and data fixes for Palestine timestamps starting in 2072.
     A new data file zonenow.tab for timestamps starting now.

   Changes to future timestamps

     Ittoqqortoormiit, Greenland (America/Scoresbysund) joins most of
     the rest of Greenland's timekeeping practice on 2024-03-31, by
     changing its time zone from -01/+00 to -02/-01 at the same moment
     as the spring-forward transition.  Its clocks will therefore not
     spring forward as previously scheduled.  The time zone change
     reverts to its common practice before 1981.

     Fix predictions for DST transitions in Palestine in 2072-2075,
     correcting a typo introduced in 2023a.

   Changes to past and future timestamps

     Vostok, Antarctica changed to +05 on 2023-12-18.  It had been at
     +07 (not +06) for years.  (Thanks to Zakhary V. Akulov.)

     Change data for Casey, Antarctica to agree with [timeanddate.com](http://timeanddate.com/),
     by adding five time zone changes since 2020.  Casey is now at +08
     instead of +11.

   Changes to past tm_isdst flags

     Much of Greenland, represented by America/Nuuk, changed its
     standard time from -03 to -02 on 2023-03-25, not on 2023-10-28.
     This does not affect UTC offsets, only the tm_isdst flag.
     (Thanks to Thomas M. Steenholdt.)

   New data file

     A new data file zonenow.tab helps configure applications that use
     timestamps dated from now on.  This simplifies configuration,
     since users choose from a smaller Zone set.  The file's format is
     experimental and subject to change.

   Changes to code

     localtime.c no longer mishandles TZif files that contain a single
     transition into a DST regime.  Previously, it incorrectly assumed
     DST was in effect before the transition too.  (Thanks to Alois
     Treindl for debugging help.)

     localtime.c's timeoff no longer collides with OpenBSD 7.4.

     The C code now uses _Generic only if __STDC_VERSION__ says the
     compiler is C11 or later.

     tzselect now optionally reads zonenow.tab, to simplify when
     configuring only for timestamps dated from now on.

     tzselect no longer creates temporary files.

     tzselect no longer mishandles the following:

       Spaces and most other special characters in BUGEMAIL, PACKAGE,
       TZDIR, and VERSION.

       TZ strings when using mawk 1.4.3, which mishandles regular
       expressions of the form /X{2,}/.

       ISO 6709 coordinates when using an awk that lacks the GNU
       extension of newlines in -v option-arguments.

       Non UTF-8 locales when using an iconv command that lacks the GNU
       //TRANSLIT extension.

     zic no longer mishandles data for Palestine after the year 2075.
     Previously, it incorrectly omitted post-2075 transitions that are
     predicted for just before and just after Ramadan.  (Thanks to Ken
     Murchison for debugging help.)

     zic now works again on Linux 2.6.16 and 2.6.17 (2006).
     (Problem reported by Rune Torgersen.)

   Changes to build procedure

     The Makefile is now more compatible with POSIX:
      * It no longer defines AR, CC, CFLAGS, LDFLAGS, and SHELL.
      * It no longer uses its own 'cc' in place of CC.
      * It now uses ARFLAGS, with default specified by POSIX.
      * It does not use LFLAGS incompatibly with POSIX.
      * It uses the special .POSIX target.
      * It quotes special characters more carefully.
      * It no longer mishandles builds in an ISO 8859 locale.
     Due to the CC changes, TZDIR is now #defined in a file tzfile.h
     built by 'make', not in a $(CC) -D option.  Also, TZDEFAULT is
     now treated like TZDIR as they have similar roles.

   Changes to commentary

      Limitations and hazards of the optional support for obsolescent
      C89 platforms are documented better, along with a tentative
      schedule for removing this support.

