### PR TITLE
[22.03] nebula: update to 1.8.1

### DIFF
--- a/net/nebula/Makefile
+++ b/net/nebula/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nebula
-PKG_VERSION:=1.6.1
+PKG_VERSION:=1.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/slackhq/nebula/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=9c343d998d2eab9473c3bf73d434b8a382d90b1f73095dd1114ecaf2e1c0970f
+PKG_HASH:=85c048b6d39296eeb8cf2d3324124d834011121383d0550662018190494d433e
 
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2

Description:
* https://github.com/slackhq/nebula/releases/tag/v1.8.1

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 731d594ee31df8c0fadf980f29939461d13bc395)
