### PR TITLE
strongswan: trigger reload when interfaces are specified

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -702,6 +702,16 @@ stop_service() {
 service_triggers() {
 	procd_add_reload_trigger "ipsec"
 	config load "ipsec"
+
+	config_foreach service_trigger_ipsec ipsec
+}
+
+service_trigger_ipsec() {
+	local interface interface_list
+	config_list_foreach "$1" interface append_var interface_list
+	for interface in $interface_list; do
+		procd_add_reload_interface_trigger $interface
+	done
 }
 
 start_service() {


### PR DESCRIPTION
Maintainer: @pprindeville @Thermi
Compile tested: na
Run tested: aarch64/mt7622 Linksys E8450

Description:

Add interface triggers if interfaces to listen to are specified in /etc/config/ipsec. This fixes the "running with no instances" scenario after rebooting a router.

I've been running this for a month to good effect.

Cherry-picked from #22898 for OpenWrt 23.05.
