### PR TITLE
exfatprogs: Update to 1.2.2

### DIFF
--- a/utils/exfatprogs/Makefile
+++ b/utils/exfatprogs/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=exfatprogs
-PKG_VERSION:=1.2.1
+PKG_VERSION:=1.2.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/$(PKG_NAME)/$(PKG_NAME)/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=14dabb9ae1c7dbfc29aaf6871b93cf4bde688b8d4b29aec1188c6dd92fb9e86f
+PKG_HASH:=16b28c9130b4dfab0b571dce6d2959d2ee93fce27aa0f4b2c1bb30700f371393
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: rockchip/armv8
Run tested: nanopi-r5c

Description:
```
exfatprogs 1.2.2 - released 2023-10-26
======================================

CHANGES :
 * exfat2img: Allow dumps for read-only devices.
 * fsck.exfat: Revert Repairing zero size directory.

NEW FEATURES :
 * fsck.exfat: Repair duplicated filename.
 * mkfs.exfat: Add the option "q" to print only error messages.
 * mkfs.exfat: Add the option "U" to set volume GUID.
 * tune.exfat: Add the option "U" / "-u" to set or print volume GUID.

BUG FIXES:
 * fsck.exfat: Fix some out-of-bounds memory accesses.
 * fsck.exfat: Change not to delete volume GUID directory entry.
```