### PR TITLE
collectd: minor dsl lua script changes

### DIFF
--- a/utils/collectd/files/lua-scripts/dsl.lua
+++ b/utils/collectd/files/lua-scripts/dsl.lua
@@ -113,11 +113,17 @@ end
 local function get_values(hostname, variables, metrics, direction)
 	for _, information in pairs(variables) do
 		local name = information["name"]
+		local type = information["type"]
 
 		if metrics and metrics[name] ~= nil then
 			local value = metrics[name]
-			local metric = build_metric(name, direction)
-			if information["type"] == "bool" then
+
+			if name = type then
+				local metric = direction
+			else
+				local metric = build_metric(name, direction)
+			end
+			if type == "bool" then
 				if metrics[name] == true then
 					value = 1
 				else
@@ -128,7 +134,7 @@ local function get_values(hostname, variables, metrics, direction)
 			local t = {
 				host = host,
 				plugin = 'dsl',
-				type = information["type"],
+				type = type,
 				type_instance = metric,
 				values = {value}
 			}

--- a/utils/collectd/files/lua-scripts/dsl.lua
+++ b/utils/collectd/files/lua-scripts/dsl.lua
@@ -25,11 +25,11 @@ local line_vars = {
 	},
 	{
 		name = "satn",
-		type = "snr"
+		type = "gauge"
 	},
 	{
 		name = "latn",
-		type = "snr"
+		type = "gauge"
 	},
 	{
 		name = "attndr",
@@ -64,6 +64,14 @@ local errors = {
 	},
 	{
 		name = "tx_retransmitted",
+		type = "errors"
+	},
+	{
+		name = "crc_p",
+		type = "errors"
+	},
+	{
+		name = "crcp_p",
 		type = "errors"
 	}
 }

--- a/utils/collectd/files/lua-scripts/dsl.lua
+++ b/utils/collectd/files/lua-scripts/dsl.lua
@@ -126,11 +126,7 @@ local function get_values(hostname, variables, metrics, direction)
 		if metrics and metrics[name] ~= nil then
 			local value = metrics[name]
 
-			if name = type then
-				local metric = direction
-			else
-				local metric = build_metric(name, direction)
-			end
+			local metric = build_metric(name, direction)
 			if type == "bool" then
 				if metrics[name] == true then
 					value = 1

--- a/utils/collectd/files/lua-scripts/dsl.lua
+++ b/utils/collectd/files/lua-scripts/dsl.lua
@@ -59,7 +59,15 @@ local errors = {
 		type = "errors"
 	},
 	{
+		name = "rx_uncorrected_protected",
+		type = "errors"
+	},
+	{
 		name = "rx_retransmitted",
+		type = "errors"
+	},
+	{
+		name = "rx_corrected",
 		type = "errors"
 	},
 	{


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
- Change attenuation types from snr to gauge. Not sure if this is really the best option, just wanted to differentiate it from the already existing snr margin, because it really isnt to do with snr
- Add `rx_corrected`, `rx_uncorrected_protected`, `crc_p` and `crcp_p` errors
- ~~If name and type are identical (currently only relevant for snr), the name will be ignored. Ie. `snr-snr_down` becomes `snr-down`. I think this looks neater, but maybe that's just me.~~

Open to criticism.

Primarily for https://github.com/openwrt/luci/pull/6798