### PR TITLE
rust: Update to 1.75.0

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
 PKG_VERSION:=1.74.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/

--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
-PKG_VERSION:=1.74.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.75.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
-PKG_HASH:=882b584bc321c5dcfe77cdaa69f277906b936255ef7808fcd5c7492925cf1049
+PKG_HASH:=5b739f45bc9d341e2d1c570d65d2375591e22c2d23ef5b8a37711a0386abc088
 HOST_BUILD_DIR:=$(BUILD_DIR)/host/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>

--- a/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
+++ b/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
@@ -11,7 +11,7 @@ Subject: [PATCH] Update xz2 and use it static
 
 --- a/src/bootstrap/Cargo.lock
 +++ b/src/bootstrap/Cargo.lock
-@@ -424,9 +424,9 @@ dependencies = [
+@@ -391,9 +391,9 @@ dependencies = [
  
  [[package]]
  name = "lzma-sys"
@@ -23,7 +23,7 @@ Subject: [PATCH] Update xz2 and use it static
  dependencies = [
   "cc",
   "libc",
-@@ -871,9 +871,9 @@ dependencies = [
+@@ -834,9 +834,9 @@ dependencies = [
  
  [[package]]
  name = "xz2"
@@ -37,12 +37,12 @@ Subject: [PATCH] Update xz2 and use it static
  ]
 --- a/src/bootstrap/Cargo.toml
 +++ b/src/bootstrap/Cargo.toml
-@@ -49,7 +49,7 @@ toml = "0.5"
- ignore = "0.4.10"
- opener = "0.5"
- once_cell = "1.7.2"
+@@ -57,7 +57,7 @@ tar = "0.4"
+ termcolor = "1.2.0"
+ toml = "0.5"
+ walkdir = "2"
 -xz2 = "0.1"
 +xz2 = { version = "0.1", features = ["static"] }
- walkdir = "2"
  
  # Dependencies needed by the build-metrics feature
+ sysinfo = { version = "0.26.0", optional = true }

--- a/lang/rust/patches/0002-rustc-bootstrap-cache.patch
+++ b/lang/rust/patches/0002-rustc-bootstrap-cache.patch
@@ -9,9 +9,9 @@
              rustc_cache = os.path.join(cache_dst, key)
              if not os.path.exists(rustc_cache):
                  os.makedirs(rustc_cache)
---- a/src/bootstrap/download.rs
-+++ b/src/bootstrap/download.rs
-@@ -211,7 +211,13 @@ impl Config {
+--- a/src/bootstrap/src/core/download.rs
++++ b/src/bootstrap/src/core/download.rs
+@@ -208,7 +208,13 @@ impl Config {
              Some(other) => panic!("unsupported protocol {other} in {url}"),
              None => panic!("no protocol in {url}"),
          }
@@ -26,7 +26,7 @@
      }
  
      fn download_http_with_retries(&self, tempfile: &Path, url: &str, help_on_error: &str) {
-@@ -529,7 +535,10 @@ impl Config {
+@@ -544,7 +550,10 @@ impl Config {
          key: &str,
          destination: &str,
      ) {
@@ -38,7 +38,7 @@
          let cache_dir = cache_dst.join(key);
          if !cache_dir.exists() {
              t!(fs::create_dir_all(&cache_dir));
-@@ -656,7 +665,10 @@ download-rustc = false
+@@ -671,7 +680,10 @@ download-rustc = false
          let llvm_assertions = self.llvm_assertions;
  
          let cache_prefix = format!("llvm-{llvm_sha}-{llvm_assertions}");

--- a/lang/rust/patches/0003-bump-libc-deps-to-0.2.146.patch
+++ b/lang/rust/patches/0003-bump-libc-deps-to-0.2.146.patch
@@ -28,20 +28,6 @@ This patch bumps all libc dependencies and checksums to 0.2.147, which includes 
  
  [[package]]
  name = "libloading"
---- a/vendor/cranelift-jit/Cargo.lock
-+++ b/vendor/cranelift-jit/Cargo.lock
-@@ -224,9 +224,9 @@ dependencies = [
- 
- [[package]]
- name = "libc"
--version = "0.2.141"
-+version = "0.2.147"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
-+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
- 
- [[package]]
- name = "log"
 --- a/vendor/crossbeam-channel/Cargo.lock
 +++ b/vendor/crossbeam-channel/Cargo.lock
 @@ -50,9 +50,9 @@ dependencies = [
@@ -84,20 +70,6 @@ This patch bumps all libc dependencies and checksums to 0.2.147, which includes 
  
  [[package]]
  name = "lock_api"
---- a/vendor/icu_locid/Cargo.lock
-+++ b/vendor/icu_locid/Cargo.lock
-@@ -318,9 +318,9 @@ checksum = "e2abad23fbc42b3700f2f279844d
- 
- [[package]]
- name = "libc"
--version = "0.2.141"
-+version = "0.2.147"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
-+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
- 
- [[package]]
- name = "litemap"
 --- a/vendor/libffi/Cargo.lock
 +++ b/vendor/libffi/Cargo.lock
 @@ -10,9 +10,9 @@ checksum = "50d30906286121d95be3d479533b

--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -2,6 +2,12 @@
 #
 # Copyright (C) 2023 Luca Barbato and Donald Hoskins
 
+# Clear environment variables which should be handled internally,
+# as users might configure their own env on the host
+
+# CCache
+unexport RUSTC_WRAPPER
+
 # Rust Environmental Vars
 RUSTC_HOST_SUFFIX:=$(word 4, $(subst -, ,$(GNU_HOST_NAME)))
 RUSTC_HOST_ARCH:=$(HOST_ARCH)-unknown-linux-$(RUSTC_HOST_SUFFIX)


### PR DESCRIPTION
Maintainer: @lu-zero 
Compile tested: rockchip/armv8
Run tested: n/a

Description:
- unexport host sccache env variable
- update to 1.75.0
   changelog: https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html
