### PR TITLE
v4l2camera: Update Makefile to fix mips build

### DIFF
--- a/multimedia/v4l2camera/Makefile
+++ b/multimedia/v4l2camera/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v4l2camera
 PKG_VERSION:=0.1.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/mpromonet/v4l2camera
@@ -23,6 +23,8 @@ LIVE555_FILE:=live.$(LIVE555_VERSION).tar.gz
 PKG_MAINTAINER:=Michel Promonet<michel.promonet@free.fr>
 PKG_LICENSE:=Unlicense
 PKG_LICENSE_FILES:=LICENCE
+
+PKG_BUILD_FLAGS:=gc-sections lto
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION
Maintainer: @mpromonet 
Compile tested: allwinner H3, nanopi neo air, openwrt latest
Run tested: allwinner H3, nanopi neo air, openwrt latest

Description:
fix build for [mipsel_24kc_24kf/packages/v4l2camera/compile.txt](https://downloads.openwrt.org/snapshots/faillogs/mipsel_24kc_24kf/packages/v4l2camera/compile.txt)