### PR TITLE
fuse-overlayfs: update to 1.13

### DIFF
--- a/utils/fuse-overlayfs/Makefile
+++ b/utils/fuse-overlayfs/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fuse-overlayfs
-PKG_VERSION:=1.7.1
+PKG_VERSION:=1.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containers/fuse-overlayfs/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=fe2c076aed7b8669e7970301a99c0b197759b611035d8199de4c0add7d2fb2b4
+PKG_HASH:=96d10344921d5796bcba7a38580ae14a53c4e60399bb90b238ac5a10b3bb65b2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64
