### PR TITLE
openssh: bump to 9.6p1

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
-PKG_VERSION:=9.5p1
+PKG_VERSION:=9.6p1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
 		https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/
-PKG_HASH:=f026e7b79ba7fb540f75182af96dc8a8f1db395f922bbc9f6ca603672686086b
+PKG_HASH:=910211c07255a8c5ad654391b40ee59800710dd8119dd5362de09385aa7a777c
 
 PKG_LICENSE:=BSD ISC
 PKG_LICENSE_FILES:=LICENCE

--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -20,6 +20,8 @@ PKG_LICENSE:=BSD ISC
 PKG_LICENSE_FILES:=LICENCE
 PKG_CPE_ID:=cpe:/a:openssh:openssh
 
+#While bumping new version, make sure that it works without it, so it can be removed.
+PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=
 PKG_CONFIG_DEPENDS := \
 	CONFIG_OPENSSH_LIBFIDO2

--- a/net/openssh/patches/010-better_fzero-call-detection.patch
+++ b/net/openssh/patches/010-better_fzero-call-detection.patch
@@ -1,0 +1,52 @@
+From 1036d77b34a5fa15e56f516b81b9928006848cbd Mon Sep 17 00:00:00 2001
+From: Damien Miller <djm@mindrot.org>
+Date: Fri, 22 Dec 2023 17:56:26 +1100
+Subject: [PATCH] better detection of broken -fzero-call-used-regs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+gcc 13.2.0 on ppc64le refuses to compile some function, including
+cipher.c:compression_alg_list() with an error:
+
+> sorry, unimplemented: argument ‘used’ is not supportedcw
+> for ‘-fzero-call-used-regs’ on this target
+
+This extends the autoconf will-it-work test with a similarly-
+structured function that seems to catch this.
+
+Spotted/tested by Colin Watson; bz3645
+---
+ m4/openssh.m4 | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+--- a/m4/openssh.m4
++++ b/m4/openssh.m4
+@@ -20,18 +20,24 @@ char *f2(char *s, ...) {
+ 	va_end(args);
+ 	return strdup(ret);
+ }
++const char *f3(int s) {
++	return s ? "good" : "gooder";
++}
+ int main(int argc, char **argv) {
+-	(void)argv;
+ 	char b[256], *cp;
++	const char *s;
+ 	/* Some math to catch -ftrapv problems in the toolchain */
+ 	int i = 123 * argc, j = 456 + argc, k = 789 - argc;
+ 	float l = i * 2.1;
+ 	double m = l / 0.5;
+ 	long long int n = argc * 12345LL, o = 12345LL * (long long int)argc;
++	(void)argv;
+ 	f(1);
+-	snprintf(b, sizeof b, "%d %d %d %f %f %lld %lld\n", i,j,k,l,m,n,o);
++	s = f3(f(2));
++	snprintf(b, sizeof b, "%d %d %d %f %f %lld %lld %s\n", i,j,k,l,m,n,o,s);
+ 	if (write(1, b, 0) == -1) exit(0);
+-	cp = f2("%d %d %d %f %f %lld %lld\n", i,j,k,l,m,n,o);
++	cp = f2("%d %d %d %f %f %lld %lld %s\n", i,j,k,l,m,n,o,s);
++	if (write(1, cp, 0) == -1) exit(0);
+ 	free(cp);
+ 	/*
+ 	 * Test fallthrough behaviour.  clang 10's -Wimplicit-fallthrough does


### PR DESCRIPTION
Release notes: https://www.openssh.com/txt/release-9.6

Maintainer:  @SibrenVasse, @tripolar 
Compile tested: bcm2711, rpi4, master
Run tested: bcm2711, rpi4, master
