### PR TITLE
[23.05] Add missing python3-bleak dependency

### DIFF
--- a/lang/python/python-bleak/Makefile
+++ b/lang/python/python-bleak/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-bleak
 PKG_VERSION:=0.21.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=bleak
 PKG_HASH:=ec4a1a2772fb315b992cbaa1153070c7e26968a52b0e2727035f443a1af5c18f
@@ -30,7 +30,7 @@ define Package/python3-bleak
   TITLE:=Bluetooth Low Energy platform Agnostic Klient
   URL:=https://github.com/hbldh/bleak
   DEPENDS:=+python3-light +python3-async-timeout +python3-asyncio \
-	+python3-dbus-fast +python3-ctypes +python3-logging
+	+python3-dbus-fast +python3-ctypes +python3-typing-extensions +python3-logging
 endef
 
 define Package/python3-bleak/description

--- a/lang/python/python-dbus-fast/Makefile
+++ b/lang/python/python-dbus-fast/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dbus-fast
-PKG_VERSION:=2.20.0
+PKG_VERSION:=2.21.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=dbus-fast
 PYPI_SOURCE_NAME:=dbus_fast
-PKG_HASH:=a38e837c5a8d0a1745ec8390f68ff57986ed2167b0aa2e4a79738a51dd6dfcc3
+PKG_HASH:=f582f6f16791ced6067dab325fae444edf7ce0704315b90c2a473090636a6fe0
 
 PKG_MAINTAINER:=Quintin Hill <stuff@quintin.me.uk>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: None for backport
Run tested: None for backport

Description: https://github.com/openwrt/packages/pull/22919 and https://github.com/openwrt/packages/pull/22965 backports to 23.05.

CC: @predators46
