### PR TITLE
snort3: build against hyperscan

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.1.78.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
@@ -25,8 +25,11 @@ define Package/snort3
   SUBMENU:=Firewall
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic +kmod-nft-queue +liblzma \
-	+ucode +ucode-mod-fs +ucode-mod-uci
+  DEPENDS:= \
+	    +(TARGET_x86||TARGET_x86_64):hyperscan-runtime \
+	    +libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre +libpthread \
+	    +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic \
+	    +kmod-nft-queue +liblzma +ucode +ucode-mod-fs +ucode-mod-uci
   TITLE:=Lightweight Network Intrusion Detection System
   URL:=http://www.snort.org/
   MENU:=1
@@ -39,6 +42,11 @@ define Package/snort3/description
   analysis and pattern matching in order to detect anomalies, misuse and
   attacks.
 endef
+
+# Hyperscan and gperftools only builds for x86
+ifdef CONFIG_TARGET_x86_64
+	CMAKE_OPTIONS += -DHS_INCLUDE_DIRS=$(STAGING_DIR)/usr/include/hs
+endif
 
 CMAKE_OPTIONS += \
 	-DUSE_TIRPC:BOOL=YES \

--- a/net/snort3/patches/100-remove-HAVE_HS_COMPILE_LIT-to-work-around-upstream-b.patch
+++ b/net/snort3/patches/100-remove-HAVE_HS_COMPILE_LIT-to-work-around-upstream-b.patch
@@ -1,0 +1,34 @@
+From bf87399e720ec5e5adf9d74a17d86781b1e41428 Mon Sep 17 00:00:00 2001
+From: graysky <therealgraysky@proton.me>
+Date: Mon, 8 Jan 2024 13:00:28 -0500
+Subject: [PATCH] Hack: fix build with hyperscan
+
+Workaround to build until upstream bug is fixed[1].
+
+1. https://github.com/intel/hyperscan/issues/388
+
+---
+ cmake/sanity_checks.cmake | 1 -
+ config.cmake.h.in         | 1 -
+ 2 files changed, 2 deletions(-)
+
+--- a/cmake/sanity_checks.cmake
++++ b/cmake/sanity_checks.cmake
+@@ -136,7 +136,6 @@ if (HS_FOUND)
+         cmake_push_check_state(RESET)
+         set(CMAKE_REQUIRED_INCLUDES ${HS_INCLUDE_DIRS})
+         set(CMAKE_REQUIRED_LIBRARIES ${HS_LIBRARIES})
+-        check_function_exists(hs_compile_lit HAVE_HS_COMPILE_LIT)
+         cmake_pop_check_state()
+     endif()
+ endif()
+--- a/config.cmake.h.in
++++ b/config.cmake.h.in
+@@ -124,7 +124,6 @@
+ 
+ /* hyperscan available */
+ #cmakedefine HAVE_HYPERSCAN 1
+-#cmakedefine HAVE_HS_COMPILE_LIT 1
+ 
+ /* iconv available */
+ #cmakedefine HAVE_ICONV 1


### PR DESCRIPTION
Increases snort's IPS fast pattern matching by 2x (compared to the ac_full engine) and 3x (compared to ac_bfna).  This is most noticeable for users of large rules sets and when doing deep flow inspection.

For more see: https://blog.snort.org/2020/09/snort-3-hyperscan-.html

Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne

Maintainer: me @flyn-org 