### PR TITLE
mwan3: use network_get_preferred_ipaddr6

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.11.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/lib/mwan3/common.sh
+++ b/net/mwan3/files/lib/mwan3/common.sh
@@ -61,18 +61,20 @@ mwan3_get_src_ip()
 	unset "$1"
 	config_get family "$interface" family ipv4
 	if [ "$family" = "ipv4" ]; then
-		addr_cmd='network_get_ipaddr'
+		addr_cmd_1='network_get_ipaddr'
+		addr_cmd_2='false'
 		default_ip="0.0.0.0"
 		sed_str='s/ *inet \([^ \/]*\).*/\1/;T; pq'
 		IP="$IP4"
 	elif [ "$family" = "ipv6" ]; then
-		addr_cmd='network_get_ipaddr6'
+		addr_cmd_1='network_get_preferred_ipaddr6'
+		addr_cmd_2='network_get_ipaddr6'
 		default_ip="::"
 		sed_str='s/ *inet6 \([^ \/]*\).* scope.*/\1/;T; pq'
 		IP="$IP6"
 	fi
 
-	$addr_cmd _src_ip "$true_iface"
+	$addr_cmd_1 _src_ip "$true_iface" 2>&1 || $addr_cmd_2 _src_ip "$true_iface"
 	if [ -z "$_src_ip" ]; then
 		network_get_device device $true_iface
 		_src_ip=$($IP address ls dev $device 2>/dev/null | sed -ne "$sed_str")


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: -
Run tested: x86

Description: This updates mwan3 to use network_get_preferred_ipaddr6 instead of network_get_ipaddr6 if possible to determine a source ip for the connectivity checks. This avoids issues where the first ip address that is returned from network_get_ipaddr6 does not work anymore while the preferred one returned from network_get_preferred_ipaddr6 works.

This partially fixes <https://github.com/openwrt/packages/issues/21782>.

Important: This is useless without <https://github.com/openwrt/openwrt/pull/14333>