### PR TITLE
mwan3: Check removed route before removal

### DIFF
--- a/net/mwan3/files/usr/sbin/mwan3rtmon
+++ b/net/mwan3/files/usr/sbin/mwan3rtmon
@@ -95,6 +95,13 @@ mwan3_rtmon_route_handle()
 	fi
 	route_line=$(echo "$route_line" | sed -ne "$MWAN3_ROUTE_LINE_EXP")
 
+	if [ "$action" = "del" ]; then
+		if mwan3_get_routes | grep -qxF "$route_line"; then
+			LOG debug "deleted but route still exists - $route_line"
+			return
+		fi
+	fi
+
 	handle_route() {
 		local error
 		local iface=$1


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: -
Run tested: OpenWrt 23.05.2 x86

Description: This makes mwan3rtmon check if mwan3_get_routes returns a route before removing it. This helps with IPv6 routes with source address selector removal where multiple original routes are transformed to the same mwan3 route if one of the source routes is removed while the others are kept.

This fixes <https://github.com/openwrt/packages/issues/21364>