### PR TITLE
Sendmail: Enable IPV6 Milter support, Enable missing functions in MUSL that are…

### DIFF
--- a/mail/sendmail/Makefile
+++ b/mail/sendmail/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sendmail
 PKG_VERSION:=8.16.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://ftp.sendmail.org/pub/sendmail
@@ -90,7 +90,7 @@ programs access to mail messages as they are being processed in order to
 filter meta-information and content.
 endef
 
-TARGET_CFLAGS += $(FPIC)
+TARGET_CFLAGS += $(FPIC) -DNETINET6 -DNEEDSGETIPNODE
 
 define Build/Prepare
 	$(Build/Prepare/Default)


### PR DESCRIPTION
… avail in glibc, bump PKG_RELEASE

RE: #https://github.com/openwrt/packages/pull/20544

I'm really not on github as much as I should be, my apologies for taking so long to fix the commit title and bump the PKG_RELEASE version. Got the email today about the other request and had some time.

----------- Old desc: 

This compiles libmilter with ipv6 support, allowing clamav, opendkim, and whatever else to work with ipv6 in their milters.

Maintainer: Don't think there is one anymore
Compile tested: cross-compile from ubuntu x64 vm to aarch64_cortex-a72 , 22.03.3
Run tested: Ras pi, 22.03, aarch64_cortex-a72, etc

Description:
Without this, clamav and opendkim running as milters on postfix seem to work fine on ipv4, but when they receive any mail to filter from an ipv6 source they error out with an error containing the string "Unknown family 54", which when searching google reveals libmilter not being compiled with ipv6 support.

adding -DNETINET6 enables IP6 support, however, it uses three functions that are deprecated in glibc and completely not available in musl, adding -DNEEDSGETIPNODE causes the the functions and corresponding structure to be built.

After compiling and installing, the errors are gone and opendkim still pops the message saying it validated and all appears good with the world of mail for a day.. now for that slight issue with spamassassin lol

