### PR TITLE
kmod: add host build

### DIFF
--- a/utils/kmod/Makefile
+++ b/utils/kmod/Makefile
@@ -47,6 +47,25 @@ define Host/Clean
 	rm -f $(STAGING_DIR_HOST)/bin/modinfo
 endef
 
+HOST_CONFIGURE_VARS += ./configure --with-zlib
+
+define Host/Compile
+	$(MAKE) -C $(HOST_BUILD_DIR) tools/kmod
+endef
+
+define Host/Install
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/tools/kmod $(STAGING_DIR_HOST)/bin/kmod
+	ln -sf kmod $(STAGING_DIR_HOST)/bin/depmod
+	ln -sf kmod $(STAGING_DIR_HOST)/bin/modinfo
+endef
+
+define Host/Clean
+	$(Host/Clean/Default)
+	rm -f $(STAGING_DIR_HOST)/bin/kmod
+	rm -f $(STAGING_DIR_HOST)/bin/depmod
+	rm -f $(STAGING_DIR_HOST)/bin/modinfo
+endef
+
 define Package/kmod/Default
   SECTION:=utils
   CATEGORY:=Utilities

--- a/utils/kmod/Makefile
+++ b/utils/kmod/Makefile
@@ -23,16 +23,36 @@ PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 
-CONFIGURE_ARGS += --with-zlib
+CONFIGURE_ARGS += --with-zlib --with-zstd
+
+HOST_CONFIGURE_VARS += ./configure --with-zlib --with-zstd
+
+define Host/Compile
+	$(MAKE) -C $(HOST_BUILD_DIR) tools/kmod
+endef
+
+define Host/Install
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/tools/kmod $(STAGING_DIR_HOST)/bin/kmod
+	ln -sf kmod $(STAGING_DIR_HOST)/bin/depmod
+	ln -sf kmod $(STAGING_DIR_HOST)/bin/modinfo
+endef
+
+define Host/Clean
+	$(Host/Clean/Default)
+	rm -f $(STAGING_DIR_HOST)/bin/kmod
+	rm -f $(STAGING_DIR_HOST)/bin/depmod
+	rm -f $(STAGING_DIR_HOST)/bin/modinfo
+endef
 
 define Package/kmod/Default
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Linux kernel module handling
   URL:=https://www.kernel.org/pub/linux/utils/kernel/kmod/
-  DEPENDS:=+zlib
+  DEPENDS:=+zlib +libzstd
 endef
 
 
@@ -87,5 +107,6 @@ define Build/InstallDev
 endef
 
 
+$(eval $(call HostBuild))
 $(eval $(call BuildPackage,kmod))
 $(eval $(call BuildPackage,libkmod))


### PR DESCRIPTION
Maintainer: @jdub 
Compile tested: (armsr, armv8, OpenWrt ce4ee14a46)
Run tested: (armsr, armv8, OpenWrt ce4ee14a46, tests done in Qemu and RockPi4)

Description:

Target armsr requires the depmod host binary to generate module dependency data for several Linux kernel modules that are installed in the initrd image.

It installs two files: kmod and depmod, the latter as a symlink to kmod. There is no need to build a host package.

It's a dependency for https://github.com/openwrt/openwrt/pull/13684