### PR TITLE
adblock-fast: bugfix: pause command

### DIFF
--- a/net/adblock-fast/Makefile
+++ b/net/adblock-fast/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/adblock-fast/files/etc/init.d/adblock-fast
+++ b/net/adblock-fast/files/etc/init.d/adblock-fast
@@ -1728,7 +1728,7 @@ adb_start() {
 	action="$(config_cache get 'trigger_service')"
 	fw4_restart_flag="$(config_cache get 'trigger_fw4')"
 
-	if [ "$action" = 'on_boot' ] || [ "$param" = 'on_boot' ]; then
+	if [ "$action" = 'on_boot' ] || [ "$param" = 'on_boot' ] || [ "$param" = 'on_pause' ]; then
 		if cache 'test_gzip' || cache 'test'; then
 			action='restore'
 		else


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2

Description:
* the pause command used to incorrectly cause block-lists reload, this has been fixed in this version
