### PR TITLE
uspot: update to Git HEAD (2024-01-09)

### DIFF
--- a/net/uspot/Makefile
+++ b/net/uspot/Makefile
@@ -8,9 +8,9 @@ PKG_MAINTAINER:=Thibaut VARÈNE <hacks@slashdirt.org>
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/f00b4r0/uspot.git
-PKG_SOURCE_DATE:=2023-11-30
-PKG_SOURCE_VERSION:=7e1e21b0f8425205d719b99a392fa893b3e512e6
-PKG_MIRROR_HASH:=494c616159b16d978fe00348ebe50c77a48f1db98d624ed613f3cca2d39e3a6e
+PKG_SOURCE_DATE:=2024-01-09
+PKG_SOURCE_VERSION:=c4b6f2f0bb1e9d2da4adc8cb3523cd7e440d7584
+PKG_MIRROR_HASH:=fa6be10e0479a9dc71b8c21e57b07aac09c8938e8e7120045816a5cd4b949343
 
 CMAKE_SOURCE_SUBDIR:=src
 
@@ -25,7 +25,7 @@ define Package/uspot
   DEPENDS:=+conntrack \
 	   +libblobmsg-json +liblucihttp-ucode +libradcli +libubox +libubus +libuci \
 	   +spotfilter \
-	   +ucode +ucode-mod-math +ucode-mod-nl80211 +ucode-mod-rtnl +uhttpd-mod-ucode +ucode-mod-uloop
+	   +ucode +ucode-mod-log +ucode-mod-math +ucode-mod-nl80211 +ucode-mod-rtnl +uhttpd-mod-ucode +ucode-mod-uloop
 
 endef
 
@@ -49,6 +49,7 @@ define Package/uspot-www
   CATEGORY:=Network
   TITLE:=uspot default user interface files
   DEPENDS:=+uspot
+  PKGARCH:=all
 endef
 
 define Package/uspot-www/description
@@ -63,6 +64,7 @@ define Package/uspotfilter
   PROVIDES:=spotfilter
   CONFLICTS:=spotfilter
   DEPENDS:=+conntrack +nftables-json +ucode +ucode-mod-rtnl +ucode-mod-uloop
+  PKGARCH:=all
 endef
 
 define Package/uspotfilter/description


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79/generic, ramips/mt7621, x86/64
Run tested: ath79/generic, ramips/mt7621, x86/64 - OpenWrt 23.05

Description: uspot update to Git HEAD (2024-01-09)

**Please cherry-pick into 23.05 once merged :)**
