### PR TITLE
node: bump to v20.11.0

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v20.10.0
+PKG_VERSION:=v20.11.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=32eb256eebd8cacd5574e6631e54b42be7ec8ebe25ad47a8ca685403bad15535
+PKG_HASH:=31807ebeeeb049c53f1765e4a95aed69476a4b696dd100cb539ab668d7950b40
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/007-fix_host_build_on_macos.patch
+++ b/lang/node/patches/007-fix_host_build_on_macos.patch
@@ -1,6 +1,6 @@
 --- a/tools/gyp/pylib/gyp/generator/make.py
 +++ b/tools/gyp/pylib/gyp/generator/make.py
-@@ -206,7 +206,7 @@ cmd_solink_module = $(LINK.$(TOOLSET)) -
+@@ -207,7 +207,7 @@ cmd_solink_module = $(LINK.$(TOOLSET)) -
  
  LINK_COMMANDS_MAC = """\
  quiet_cmd_alink = LIBTOOL-STATIC $@

--- a/lang/node/patches/204-v8_gyp.patch
+++ b/lang/node/patches/204-v8_gyp.patch
@@ -44,7 +44,7 @@
        ],
        'sources': [
          '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_initializers.*?sources = ")',
-@@ -689,6 +695,7 @@
+@@ -694,6 +700,7 @@
        'toolsets': ['host', 'target'],
        'direct_dependent_settings': {
          'sources': ['<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_compiler_sources = ")'],
@@ -52,7 +52,7 @@
          'conditions': [
            ['v8_target_arch=="ia32"', {
              'sources': [
-@@ -797,6 +804,8 @@
+@@ -802,6 +809,8 @@
        'target_name': 'v8_turboshaft',
        'type': 'static_library',
        'toolsets': ['host', 'target'],
@@ -61,7 +61,7 @@
        'dependencies': [
          'generate_bytecode_builtins_list',
          'run_torque',
-@@ -821,6 +830,7 @@
+@@ -826,6 +835,7 @@
          'run_torque',
          'v8_maybe_icu',
        ],
@@ -69,7 +69,7 @@
        'conditions': [
          ['(is_component_build and not v8_optimized_debug and v8_enable_fast_mksnapshot) or v8_enable_turbofan==0', {
            'dependencies': [
-@@ -861,6 +871,7 @@
+@@ -866,6 +876,7 @@
        ],
        'includes': ['inspector.gypi'],
        'direct_dependent_settings': {
@@ -77,7 +77,7 @@
          'include_dirs': [
            '<(generate_bytecode_output_root)',
            '<(SHARED_INTERMEDIATE_DIR)',
-@@ -1474,6 +1485,7 @@
+@@ -1484,6 +1495,7 @@
          }],
        ],
        'direct_dependent_settings': {
@@ -85,7 +85,7 @@
          'include_dirs': [
            '<(V8_ROOT)/include',
          ],
-@@ -1494,6 +1506,7 @@
+@@ -1504,6 +1516,7 @@
      {
        'target_name': 'bytecode_builtins_list_generator',
        'type': 'executable',
@@ -93,7 +93,7 @@
        'conditions': [
          ['want_separate_host_toolset', {
            'toolsets': ['host'],
-@@ -1522,6 +1535,9 @@
+@@ -1532,6 +1545,9 @@
      {
        'target_name': 'mksnapshot',
        'type': 'executable',
@@ -103,7 +103,7 @@
        'dependencies': [
          'v8_base_without_compiler',
          'v8_compiler_for_mksnapshot',
-@@ -1549,6 +1565,7 @@
+@@ -1559,6 +1575,7 @@
      {
        'target_name': 'torque',
        'type': 'executable',
@@ -111,7 +111,7 @@
        'dependencies': [
          'torque_base',
          # "build/win:default_exe_manifest",
-@@ -1591,6 +1608,7 @@
+@@ -1601,6 +1618,7 @@
      {
        'target_name': 'torque-language-server',
        'type': 'executable',
@@ -119,7 +119,7 @@
        'conditions': [
          ['want_separate_host_toolset', {
            'toolsets': ['host'],
-@@ -1622,6 +1640,8 @@
+@@ -1632,6 +1650,8 @@
      {
        'target_name': 'gen-regexp-special-case',
        'type': 'executable',
@@ -128,7 +128,7 @@
        'dependencies': [
          'v8_libbase',
          # "build/win:default_exe_manifest",
-@@ -1840,6 +1860,7 @@
+@@ -1850,6 +1870,7 @@
           }],
        ],
        'direct_dependent_settings': {
@@ -136,7 +136,7 @@
          'include_dirs': [
            '<(V8_ROOT)/include',
          ],
-@@ -1961,15 +1982,19 @@
+@@ -1971,15 +1992,19 @@
          }],
        ],
        'direct_dependent_settings': {

--- a/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
+++ b/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
@@ -1,6 +1,6 @@
 --- a/configure.py
 +++ b/configure.py
-@@ -1270,7 +1270,6 @@ def configure_node(o):
+@@ -1275,7 +1275,6 @@ def configure_node(o):
  
    # Enable branch protection for arm64
    if target_arch == 'arm64':


### PR DESCRIPTION
Maintainer: me @ianchi
Compile tested: head, aarch64, arm, i386, x86_64
Run tested: (qemu 8.2.0) aarch64

Description:
Notable Changes
* crypto: update root certificates to NSS 3.95 (Node.js GitHub Bot)
* doc: add MrJithil to collaborators (Jithil P Ponnan)
* doc: add Ethan-Arrowood as a collaborator (Ethan Arrowood)
* (SEMVER-MINOR) esm: add import.meta.dirname and import.meta.filename (James Sumners)
* fs: add c++ fast path for writeFileSync utf8 (CanadaHonk)
* (SEMVER-MINOR) module: remove useCustomLoadersIfPresent flag (Chengzhong Wu)
* (SEMVER-MINOR) module: bootstrap module loaders in shadow realm (Chengzhong Wu)
* (SEMVER-MINOR) src: add --disable-warning option (Ethan Arrowood)
* [SEMVER-MINOR) src: create per isolate proxy env template (Chengzhong Wu)
* (SEMVER-MINOR) src: make process binding data weak (Chengzhong Wu)
* stream: use Array for Readable buffer (Robert Nagy)
* stream: optimize creation (Robert Nagy)
* (SEMVER-MINOR) test_runner: adds built in lcov reporter (Phil Nash)
* (SEMVER-MINOR) test_runner: add Date to the supported mock APIs (Lucas Santos)
* (SEMVER-MINOR) test_runner, cli: add --test-timeout flag (Shubham Pandey)