### PR TITLE
netclient: initial commit

### DIFF
--- a/net/netclient/Makefile
+++ b/net/netclient/Makefile
@@ -1,0 +1,53 @@
+# Copyright 2024 Stan Grishin (stangri@melmac.ca)
+# This is free software, licensed under the Apache-2.0 License.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=netclient
+PKG_VERSION:=0.22.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/gravitl/netclient/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=010e7ee72f8cf8ae4cc91b19010b85875d75e70faabd248c992af2487629211d
+
+PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE.txt
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/gravitl/netclient
+GO_PKG_BUILD_PKG:=github.com/gravitl/netclient
+GO_PKG_LDFLAGS_X:=main.version=v$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/netclient
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=netclient
+  URL:=https://docs.openwrt.melmac.net/netclient/
+  DEPENDS:=$(GO_ARCH_DEPENDS) +wireguard-tools
+endef
+
+define Package/netclient/description
+  This is the client for Netmaker networks. Netmaker automates fast, secure, and
+  distributed virtual networks with Wireguard. To learn more about Netmaker, see:
+  https://github.com/gravitl/netmaker
+endef
+
+define Package/netclient/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/netclient.init $(1)/etc/init.d/netclient
+	$(SED) "s|^\(readonly PKG_VERSION\).*|\1='$(PKG_VERSION)-$(PKG_RELEASE)'|" $(1)/etc/init.d/netclient
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/netclient $(1)/usr/sbin/
+endef
+
+$(eval $(call GoBinPackage,netclient))
+$(eval $(call BuildPackage,netclient))

--- a/net/netclient/files/netclient.init
+++ b/net/netclient/files/netclient.init
@@ -1,0 +1,25 @@
+#!/bin/sh /etc/rc.common
+# Copyright 2024 Stan Grishin (stangri@melmac.ca)
+# shellcheck disable=SC3043,SC3060
+
+# shellcheck disable=SC2034
+START=95
+STOP=95
+# shellcheck disable=SC2034
+USE_PROCD=1
+
+readonly PKG_VERSION='dev-test'
+readonly PROG=/usr/sbin/netclient
+
+extra_command 'version' 'Show version information'
+
+version() { echo "Version: $PKG_VERSION"; }
+
+start_service() {
+	procd_open_instance
+	procd_set_param command ${PROG} daemon
+	procd_set_param stderr 1
+	procd_set_param stdout 1
+	procd_set_param respawn 3600 1 0
+	procd_close_instance
+}

--- a/net/netclient/patches/010-install-initd-fix.patch
+++ b/net/netclient/patches/010-install-initd-fix.patch
@@ -1,0 +1,59 @@
+--- a/daemon/initd_linux.go
++++ b/daemon/initd_linux.go
+@@ -1,37 +1,12 @@
+ package daemon
+ 
+ import (
+-	"errors"
+-	"os"
+-
+ 	"github.com/gravitl/netclient/ncutils"
+ 	"golang.org/x/exp/slog"
+ )
+ 
+ // setupInitd - sets up initd daemon
+ func setupInitd() error {
+-	service := `#!/bin/sh /etc/rc.common
+-	START=99
+-	STOP=99
+-	USE_PROCD=1
+-	
+-	start_service() {
+-        procd_open_instance
+-        procd_set_param command /sbin/netclient daemon
+-        procd_set_param stdout 1
+-        procd_set_param stderr 1
+-        procd_close_instance
+-}
+-`
+-	bytes := []byte(service)
+-	if err := os.WriteFile("/etc/init.d/netclient", bytes, 0755); err != nil {
+-		slog.Debug("error writing initd service file", "error", err)
+-		return err
+-	}
+-	if _, err := ncutils.RunCmd("/etc/init.d/netclient enable", false); err != nil {
+-		slog.Debug("error enabling initd service", "error", err)
+-		return err
+-	}
+ 	return nil
+ }
+ 
+@@ -58,18 +33,5 @@ func restartInitd() error {
+ 
+ // removeInitd - removes initd daemon
+ func removeInitd() error {
+-	var faults string
+-	if _, err := ncutils.RunCmd("/etc/init.d/netclient disable", true); err != nil {
+-		faults = faults + err.Error()
+-	}
+-	if ncutils.FileExists("/etc/init.d/netclient") {
+-		if err := os.Remove("/etc/init.d/netclient"); err != nil {
+-			slog.Info("Error removing /etc/init.d/netclient. Please investigate.")
+-			faults = faults + err.Error()
+-		}
+-	}
+-	if faults != "" {
+-		return errors.New(faults)
+-	}
+ 	return nil
+ }

--- a/net/netclient/test.sh
+++ b/net/netclient/test.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+"/usr/sbin/${1}" version 2>&1 | grep "$2" || "/etc/init.d/${1}" version 2>&1 | grep "$2"


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2

Description:
* initial commit of netclient, the client for Netmaker networks.
