### PR TITLE
autossh: make forwarding optional

### DIFF
--- a/net/autossh/Makefile
+++ b/net/autossh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=autossh
 PKG_VERSION:=1.4g
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://www.harding.motd.ca/autossh/

--- a/net/autossh/files/autossh.init
+++ b/net/autossh/files/autossh.init
@@ -34,15 +34,15 @@ start_instance() {
 	config_get path            "$section" path
 	config_get pidfile         "$section" pidfile
 
-	if [ -z "$localport" ]; then
-		echo "autossh: localport option is required"
+	if [ -n "$localport" ] && [ -n "$remoteport" ]; then
+		if [ -n "$remotehost" ]; then
+			forwarding="-L ${localport}:${remotehost}:${remoteport}"
+		else
+			forwarding="-R ${remoteport}:${localhost}:${localport}"
+		fi
+	elif [ -n "$localport" ] || [ -n "$remoteport" ]; then
+		echo "autossh: both localport and remoteport options are required"
 		return 1
-	fi
-
-	if [ -n "$remotehost" ]; then
-		forwarding="-L ${localport}:${remotehost}:${remoteport}"
-	else
-		forwarding="-R ${remoteport}:${localhost}:${localport}"
 	fi
 
 	procd_open_instance "$section"


### PR DESCRIPTION
Maintainer: @jempatel / @neheb 

Compile tested: x86_64 b7f9742da8
Run tested: Netgear R6220, OpenWrt 23.05.2, r23630-842932a63d 

Description:
Previous change made localport option required, which broke older configs and was not documented in any tutorials regarding autossh package (e.g. https://openwrt.org/docs/guide-user/services/ssh/autossh).
This change makes in-config forwarding only optional, restoring original configuration template valid.
New localport & remoteport options are still accepted, however extra test is performed to ensure both of these options are provided as expected by ssh command.
