### PR TITLE
bcm27xx-eeprom: update and split into bcm2711/bcm2712

### DIFF
--- a/utils/bcm27xx-eeprom/Makefile
+++ b/utils/bcm27xx-eeprom/Makefile
@@ -18,15 +18,39 @@ include $(INCLUDE_DIR)/package.mk
 TAR_OPTIONS:=--strip-components 1 $(TAR_OPTIONS)
 TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 
-define Package/bcm27xx-eeprom
+define Package/bcm27xx-eeprom/Default
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=bcm27xx-userland +blkid +coreutils +coreutils-od +mount-utils +pciutils +python3-light
+endef
+
+define Package/bcm27xx-eeprom
+$(call Package/bcm27xx-eeprom/Default)
   TITLE:=BCM27xx EEPROM tools
+  DEPENDS:=bcm27xx-userland +blkid +coreutils +coreutils-od +mount-utils +pciutils +python3-light
+endef
+
+define Package/bcm2711-eeprom
+$(call Package/bcm27xx-eeprom/Default)
+  TITLE:=BCM2711 EEPROM tools
+  DEPENDS:=+bcm27xx-eeprom
+endef
+
+define Package/bcm2712-eeprom
+$(call Package/bcm27xx-eeprom/Default)
+  TITLE:=BCM2712 EEPROM tools
+  DEPENDS:=+bcm27xx-eeprom
 endef
 
 define Package/bcm27xx-eeprom/description
-  BCM27xx EEPROM tools.
+  BCM27xx EEPROM config and update tools.
+endef
+
+define Package/bcm2711-eeprom/description
+  BCM2711 EEPROM config and update tools.
+endef
+
+define Package/bcm2712-eeprom/description
+  BCM2712 EEPROM config and update tools.
 endef
 
 define Build/Compile
@@ -45,7 +69,9 @@ define Package/bcm27xx-eeprom/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/rpi-eeprom-config $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/rpi-eeprom-digest $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/rpi-eeprom-update $(1)/usr/bin
+endef
 
+define Package/bcm2711-eeprom/install
 	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2711
 	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2711/default
 	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
@@ -55,4 +81,16 @@ define Package/bcm27xx-eeprom/install
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest $(1)/lib/firmware/raspberrypi/bootloader-2711
 endef
 
+define Package/bcm2712-eeprom/install
+	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2712
+	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2712/default
+	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
+
+	$(CP) $(PKG_BUILD_DIR)/firmware-2712/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader-2712
+	$(CP) $(PKG_BUILD_DIR)/firmware-2712/default $(1)/lib/firmware/raspberrypi/bootloader-2712
+	$(CP) $(PKG_BUILD_DIR)/firmware-2712/latest $(1)/lib/firmware/raspberrypi/bootloader-2712
+endef
+
 $(eval $(call BuildPackage,bcm27xx-eeprom))
+$(eval $(call BuildPackage,bcm2711-eeprom))
+$(eval $(call BuildPackage,bcm2712-eeprom))

--- a/utils/bcm27xx-eeprom/Makefile
+++ b/utils/bcm27xx-eeprom/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcm27xx-eeprom
-PKG_VERSION:=v2022.04.26-138a1
+PKG_VERSION:=v.2024.01.05-2712
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/raspberrypi/rpi-eeprom/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=7c54839e68f226c5853fb63c8a1539b729d84b2e6bac311a51766c601d10a413
+PKG_HASH:=ae1d9f10e4383ee39b291b4b3be1be583f6f32f806f65a1431da65ca4ccffe39
 
 PKG_LICENSE:=BSD-3-Clause Custom
 PKG_LICENSE_FILES:=LICENSE
@@ -21,7 +21,7 @@ TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 define Package/bcm27xx-eeprom
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=bcm27xx-userland +blkid +coreutils +coreutils-od +pciutils +python3-light
+  DEPENDS:=bcm27xx-userland +blkid +coreutils +coreutils-od +mount-utils +pciutils +python3-light
   TITLE:=BCM27xx EEPROM tools
 endef
 
@@ -46,14 +46,13 @@ define Package/bcm27xx-eeprom/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/rpi-eeprom-digest $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/rpi-eeprom-update $(1)/usr/bin
 
-	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader
-	$(CP) $(PKG_BUILD_DIR)/firmware/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader
+	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2711
+	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2711/default
+	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 
-	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader/critical
-	$(CP) $(PKG_BUILD_DIR)/firmware/critical/ $(1)/lib/firmware/raspberrypi/bootloader/
-
-	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader/stable
-	$(CP) $(PKG_BUILD_DIR)/firmware/stable/ $(1)/lib/firmware/raspberrypi/bootloader/
+	$(CP) $(PKG_BUILD_DIR)/firmware-2711/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader-2711
+	$(CP) $(PKG_BUILD_DIR)/firmware-2711/default $(1)/lib/firmware/raspberrypi/bootloader-2711
+	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest $(1)/lib/firmware/raspberrypi/bootloader-2711
 endef
 
 $(eval $(call BuildPackage,bcm27xx-eeprom))

--- a/utils/bcm27xx-eeprom/patches/0001-rpi-eeprom-update-OpenWrt-defaults.patch
+++ b/utils/bcm27xx-eeprom/patches/0001-rpi-eeprom-update-OpenWrt-defaults.patch
@@ -1,4 +1,4 @@
-From da37f7b051fe6833e25e78184cc9217dd4379187 Mon Sep 17 00:00:00 2001
+From a7c4e8f246dc58b4c83293b11f6443528065dc70 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
 Date: Mon, 23 Mar 2020 10:10:55 +0100
 Subject: [PATCH] rpi-eeprom-update: OpenWrt defaults
@@ -8,34 +8,29 @@ Content-Transfer-Encoding: 8bit
 
 Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 ---
- rpi-eeprom-update         | 6 +++---
- rpi-eeprom-update-default | 5 +++--
- 2 files changed, 6 insertions(+), 5 deletions(-)
+ rpi-eeprom-update         | 4 ++--
+ rpi-eeprom-update-default | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
 
 --- a/rpi-eeprom-update
 +++ b/rpi-eeprom-update
-@@ -24,9 +24,9 @@ else
- fi
+@@ -25,7 +25,7 @@ fi
  
  # Selects the release sub-directory
--FIRMWARE_RELEASE_STATUS=${FIRMWARE_RELEASE_STATUS:-default}
-+FIRMWARE_RELEASE_STATUS=${FIRMWARE_RELEASE_STATUS:-stable}
- FIRMWARE_IMAGE_DIR=${FIRMWARE_IMAGE_DIR:-${FIRMWARE_ROOT}/${FIRMWARE_RELEASE_STATUS}}
+ FIRMWARE_RELEASE_STATUS=${FIRMWARE_RELEASE_STATUS:-default}
 -FIRMWARE_BACKUP_DIR=${FIRMWARE_BACKUP_DIR:-/var/lib/raspberrypi/bootloader/backup}
 +FIRMWARE_BACKUP_DIR=${FIRMWARE_BACKUP_DIR:-${FIRMWARE_ROOT}/backup}
  ENABLE_VL805_UPDATES=${ENABLE_VL805_UPDATES:-1}
- RECOVERY_BIN=${RECOVERY_BIN:-${FIRMWARE_ROOT}/${FIRMWARE_RELEASE_STATUS}/recovery.bin}
- BOOTFS=${BOOTFS:-/boot}
+ CM4_ENABLE_RPI_EEPROM_UPDATE=${CM4_ENABLE_RPI_EEPROM_UPDATE:-0}
+ RPI_EEPROM_UPDATE_CONFIG_TOOL="${RPI_EEPROM_UPDATE_CONFIG_TOOL:-raspi-config}"
 --- a/rpi-eeprom-update-default
 +++ b/rpi-eeprom-update-default
-@@ -1,8 +1,8 @@
+@@ -1,7 +1,7 @@
  
  FIRMWARE_ROOT=/lib/firmware/raspberrypi/bootloader
--FIRMWARE_RELEASE_STATUS="critical"
-+FIRMWARE_RELEASE_STATUS="stable"
- FIRMWARE_IMAGE_DIR="${FIRMWARE_ROOT}/${FIRMWARE_RELEASE_STATUS}"
+ FIRMWARE_RELEASE_STATUS="default"
 -FIRMWARE_BACKUP_DIR="/var/lib/raspberrypi/bootloader/backup"
 +FIRMWARE_BACKUP_DIR="${FIRMWARE_ROOT}/backup"
- BOOTFS=/boot
- USE_FLASHROM=0
  EEPROM_CONFIG_HOOK=
+ 
+ # BOOTFS can be set here to override auto-detection in rpi-eeprom-update

--- a/utils/bcm27xx-eeprom/patches/0002-rpi-eeprom-update-change-default-include-path.patch
+++ b/utils/bcm27xx-eeprom/patches/0002-rpi-eeprom-update-change-default-include-path.patch
@@ -1,4 +1,4 @@
-From 6674d49dea0104031b3f54df4c7a356dc4307bb2 Mon Sep 17 00:00:00 2001
+From fc552b1e5c503c530763e40d2b83df55c5c2e9a3 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
 Date: Wed, 25 Mar 2020 20:58:35 +0100
 Subject: [PATCH] rpi-eeprom-update: change default include path
@@ -8,8 +8,8 @@ Content-Transfer-Encoding: 8bit
 
 Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 ---
- rpi-eeprom-update | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
+ rpi-eeprom-update | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
 
 --- a/rpi-eeprom-update
 +++ b/rpi-eeprom-update
@@ -24,7 +24,16 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  fi
  
  LOCAL_MODE=0
-@@ -380,7 +380,7 @@ The system should then boot normally.
+@@ -423,7 +423,7 @@ checkDependencies() {
+       echo "Run with -h for more information."
+       echo
+       echo "To enable flashrom programming of the EEPROM"
+-      echo "Add these the following entries to /etc/default/rpi-eeprom-update"
++      echo "Add these the following entries to /etc/bcm27xx-eeprom.conf"
+       echo "RPI_EEPROM_USE_FLASHROM=1"
+       echo "CM4_ENABLE_RPI_EEPROM_UPDATE=1"
+       echo 
+@@ -514,7 +514,7 @@ The system should then boot normally.
  
  If /boot does not correspond to the boot partition and this
  is not a NOOBS system, then the mount point for BOOTFS should be defined
@@ -33,7 +42,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  
  A backup of the current EEPROM config file is written to ${FIRMWARE_BACKUP_DIR}
  before applying the update.
-@@ -413,7 +413,7 @@ Options:
+@@ -546,7 +546,7 @@ Options:
     -u Install the specified VL805 (USB EEPROM) image file.
  
  Environment:
@@ -42,3 +51,12 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  
  EEPROM_CONFIG_HOOK
  
+@@ -618,7 +618,7 @@ must first be enabled by removing ENABLE
+ via usbboot.
+ 
+ After enabling self-update set the CM4_ENABLE_RPI_EEPROM_UPDATE=1 environment
+-variable or define it in /etc/default/rpi-eeprom-update.
++variable or define it in /etc/bcm27xx-eeprom.conf.
+ 
+ N.B. If there is a power failure during SELF_UPDATE the EEPROM write may fail and
+ usbboot must be used to flash the bootloader EEPROM. SELF_UPDATE is not recommended

--- a/utils/bcm27xx-eeprom/patches/0003-rpi-eeprom-update-chmod-silent-f-is-not-supported.patch
+++ b/utils/bcm27xx-eeprom/patches/0003-rpi-eeprom-update-chmod-silent-f-is-not-supported.patch
@@ -1,4 +1,4 @@
-From 8376ac74390af0ad736c88615e128b82a75eebc0 Mon Sep 17 00:00:00 2001
+From 62ec3384358bda60269c131d3880795bc8cdc3ce Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
 Date: Fri, 19 Feb 2021 10:54:23 +0100
 Subject: [PATCH] rpi-eeprom-update: chmod silent (-f) is not supported
@@ -13,7 +13,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 
 --- a/rpi-eeprom-update
 +++ b/rpi-eeprom-update
-@@ -200,7 +200,7 @@ applyRecoveryUpdate()
+@@ -216,7 +216,7 @@ applyRecoveryUpdate()
                  || die "Failed to copy ${TMP_EEPROM_IMAGE} to ${BOOTFS}"
  
          # For NFS mounts ensure that the files are readable to the TFTP user
@@ -22,7 +22,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
                  || die "Failed to set permissions on eeprom update files"
     fi
  
-@@ -211,7 +211,7 @@ applyRecoveryUpdate()
+@@ -227,7 +227,7 @@ applyRecoveryUpdate()
                  || die "Failed to copy ${VL805_UPDATE_IMAGE} to ${BOOTFS}/vl805.bin"
  
          # For NFS mounts ensure that the files are readable to the TFTP user

--- a/utils/bcm27xx-eeprom/patches/0004-rpi-eeprom-config-replace-nano-with-vi-as-default-ed.patch
+++ b/utils/bcm27xx-eeprom/patches/0004-rpi-eeprom-config-replace-nano-with-vi-as-default-ed.patch
@@ -1,6 +1,19 @@
+From 8d1e47c956ae10d1146114f7fcd4eb0d33187d08 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
+Date: Tue, 16 Jan 2024 16:25:40 +0100
+Subject: [PATCH] rpi-eeprom-config: replace nano with vi as default editor
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+---
+ rpi-eeprom-config | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
 --- a/rpi-eeprom-config
 +++ b/rpi-eeprom-config
-@@ -166,8 +166,8 @@ def edit_config(eeprom=None):
+@@ -184,8 +184,8 @@ def edit_config(eeprom=None):
      """
      Implements something like 'git commit' for editing EEPROM configs.
      """
@@ -11,7 +24,7 @@
      if 'EDITOR' in os.environ:
          editor = os.environ['EDITOR']
  
-@@ -428,7 +428,7 @@ Operating modes:
+@@ -484,7 +484,7 @@ Operating modes:
  
     To cancel the pending update run 'sudo rpi-eeprom-update -r'
  


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm27xx/bcm2711
Run tested: bcm27xx/bcm2711

Description: Updates Raspberry Pi 4 EEPROM and adds Raspberry Pi 5 EEPROM support.
Adds separate packages for Raspberry Pi 4 (bcm2711-eeprom) and Raspberry Pi 5 (bcm2712-eeprom).