### PR TITLE
openvpn: add missing script-security

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.6.8
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/openvpn.init
+++ b/net/openvpn/files/openvpn.init
@@ -201,6 +201,7 @@ start_uci_instance() {
 
 	if [ ! -z "$config" ]; then
 		append UCI_STARTED "$config" "$LIST_SEP"
+		[ -n "$script_security" ] || get_openvpn_option "$config" script_security script-security
 		[ -n "$up" ] || get_openvpn_option "$config" up up
 		[ -n "$down" ] || get_openvpn_option "$config" down down
 		[ -n "$route_up" ] || get_openvpn_option "$config" route_up route-up


### PR DESCRIPTION
Maintainer: @mkrkn  @neheb

Compile tested: armv7, cortexA15, OpenWRT 23.05
Run tested: Linksys EA8500

Compile tested: armv8, cortexA53, OpenWRT main
Run tested: Dynalink DL-WRX36

Description:
Script-security is always 2 and cannot be changed from the openvpn config file due to a missing rule in openvpn.init.

This is discussed in issue #23014

This patch adds the missing rule in openvpn.init to parse script-security from the openvpn config file.

Signed-off-by: Erik Conijn <egc112@msn.com> 