### PR TITLE
snort3: update to 3.1.78.0

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
-PKG_VERSION:=3.1.77.0
-PKG_RELEASE:=2
+PKG_VERSION:=3.1.78.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
-PKG_HASH:=cb98c0d15caa7c84da24995e8521f42f4e86a860b9748418154d8649b6a0db2d
+PKG_HASH:=08a51223c22aa3196e6dc959d3b52df03da9a458877ff7e77fa9c4ee8eb8947c
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>, John Audia <therealgraysky@proton.me>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Upstream bump
```
   ,,_     -*> Snort++ <*-
  o"  )~   Version 3.1.78.0
   ''''    By Martin Roesch & The Snort Team
           http://snort.org/contact#team
           Copyright (C) 2014-2024 Cisco and/or its affiliates. All rights reserved.
           Copyright (C) 1998-2013 Sourcefire, Inc., et al.
           Using DAQ version 3.0.14
           Using LuaJIT version 2.1.0-beta3
           Using OpenSSL 3.0.12 24 Oct 2023
           Using libpcap version 1.10.4 (with TPACKET_V3)
           Using PCRE version 8.45 2021-06-15
           Using ZLIB version 1.3
           Using Hyperscan version 5.4.2 2024-01-15
           Using LZMA version 5.4.4
```
Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne

Maintainer: me