### PR TITLE
libdaq3: update to 3.0.14

### DIFF
--- a/libs/libdaq3/Makefile
+++ b/libs/libdaq3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdaq3
-PKG_VERSION:=3.0.13
+PKG_VERSION:=3.0.14
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -17,7 +17,7 @@ PKG_LICENSE:=GPL-2.0-only
 
 PKG_SOURCE:=libdaq-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/snort3/libdaq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=3a48b934bc45a1fe44b3887185d33a76a042c1d10aa177e3e7c417d83da67213
+PKG_HASH:=521364d69f8b764281ce39924d2e4c4c43348c7679768c41246adea9c7a31cc3
 PKG_BUILD_DIR:=$(BUILD_DIR)/libdaq-$(PKG_VERSION)
 
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Update to latest version.

Changelog: https://github.com/snort3/libdaq/releases/tag/v3.0.14

Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne

Maintainer: @flyn-org
