### PR TITLE
python-jsonschema: Update to 4.21.1

### DIFF
--- a/lang/python/python-jsonschema/Makefile
+++ b/lang/python/python-jsonschema/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-jsonschema
-PKG_VERSION:=4.21.0
+PKG_VERSION:=4.21.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=jsonschema
-PKG_HASH:=3ba18e27f7491ea4a1b22edce00fb820eec968d397feb3f9cb61d5894bb38167
+PKG_HASH:=85727c00279f5fa6bedbe6238d2aa6403bedd8b4864ab11207d07df3cc1b2ee5
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream release