### PR TITLE
python-orjson: update to version 3.9.12

### DIFF
--- a/lang/python/python-orjson/Makefile
+++ b/lang/python/python-orjson/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-orjson
-PKG_VERSION:=3.9.10
+PKG_VERSION:=3.9.12
 PKG_RELEASE:=1
 
 PYPI_NAME:=orjson
-PKG_HASH:=9ebbdbd6a046c304b1845e96fbcc5559cd296b4dfd3ad2509e33c4d9ce07d6a1
+PKG_HASH:=da908d23a3b3243632b523344403b128722a5f45e278a8343c2bb67538dff0e4
 
 PKG_MAINTAINER:=Timothy Ace <openwrt@timothyace.com>
 PKG_LICENSE:=Apache-2.0 MIT


### PR DESCRIPTION
Relevant changes since 3.9.10:
- Improve performance of serializing. str is significantly faster. Documents using dict, list, and tuple are somewhat faster.
- FIXED: Minimal musllinux_1_1 build due to sporadic CI failure.

Maintainer: me
Compile tested: arm_cortex-a9_vfpv3-d16, Linksys WRT1900ACS, master
Run tested: arm_cortex-a9_vfpv3-d16, Linksys WRT1900ACS, 23.05.0 r23497-6637af95aa

Description:
Updates python-orjson from 3.9.10 -> 3.9.12. Fixes from upstream include:
- Improve performance of serializing. str is significantly faster. Documents using dict, list, and tuple are somewhat faster.
- FIXED: Minimal musllinux_1_1 build due to sporadic CI failure.