### PR TITLE
libs/libvpx: fix PKG_CPE_ID

### DIFF
--- a/libs/libvpx/Makefile
+++ b/libs/libvpx/Makefile
@@ -20,7 +20,7 @@ PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
-PKG_CPE_ID:=cpe:/a:john_koleszar:libvpx
+PKG_CPE_ID:=cpe:/a:webmproject:libvpx
 PKG_BUILD_PARALLEL:=1
 
 PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VERSION))))


### PR DESCRIPTION
There is not a single CVEs under cpe:/a:john_koleszar:libvpx so use cpe:/a:webmproject:libvpx:
https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Awebmproject%3Alibvpx

Maintainer: @luizluca
Compile tested: Not needed
Run tested: Not needed