### PR TITLE
libs/apr: fix PKG_CPE_ID

### DIFF
--- a/libs/apr/Makefile
+++ b/libs/apr/Makefile
@@ -20,7 +20,7 @@ PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_CPE_ID:=cpe:/a:apache:apr
+PKG_CPE_ID:=cpe:/a:apache:portable_runtime
 
 PKG_BUILD_PARALLEL:=1
 


### PR DESCRIPTION
There is not a single CVE under cpe:/a:apache:apr
so use cpe:/a:apache:portable_runtime:
https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Aapache%3Aportable_runtime

Maintainer: @neheb
Compile tested: Not needed
Run tested: Not needed