### PR TITLE
net/tcpreplay: fix PKG_CPE_ID

### DIFF
--- a/net/tcpreplay/Makefile
+++ b/net/tcpreplay/Makefile
@@ -17,7 +17,7 @@ PKG_HASH:=3ff9753cc43bb15e77832cee657e3030dbcdd957fa247e6abacc605689e24051
 
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=docs/LICENSE
-PKG_CPE_ID:=cpe:/a:appneta:tcpreplay
+PKG_CPE_ID:=cpe:/a:broadcom:tcpreplay
 
 PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
There is not a single CVE under cpe:/a:appneta:tcpreplay so use cpe:/a:broadcom:tcpreplay:
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:broadcom:tcpreplay

Maintainer: @commodo 
Compile tested: Not needed
Run tested: Not needed
