### PR TITLE
utils/cgroupfs-mount: assign PKG_CPE_ID

### DIFF
--- a/utils/cgroupfs-mount/Makefile
+++ b/utils/cgroupfs-mount/Makefile
@@ -10,6 +10,7 @@ PKG_SOURCE_DATE:=2020-06-26
 PKG_MIRROR_HASH:=ca217ffff5aa938149d2d8adfe15d800903d2fec180acb2400c36d62905988ea
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
+PKG_CPE_ID:=cpe:/a:cgroupfs-mount_project:cgroupfs-mount
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:cgroupfs-mount_project:cgroupfs-mount

Maintainer: @G-M0N3Y-2503
Compile tested: Not needed
Run tested: Not needed