### PR TITLE
utils/cryptsetup: assign PKG_CPE_ID

### DIFF
--- a/utils/cryptsetup/Makefile
+++ b/utils/cryptsetup/Makefile
@@ -18,6 +18,7 @@ PKG_HASH:=410ded65a1072ab9c8e41added37b9729c087fef4d2db02bb4ef529ad6da4693
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING COPYING.LGPL
+PKG_CPE_ID:=cpe:/a:cryptsetup_project:cryptsetup
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:cryptsetup_project:cryptsetup

Maintainer: @dangowrt 
Compile tested: Not needed
Run tested: Not needed
