### PR TITLE
lang/python/python-docker: assign PKG_CPE_ID

### DIFF
--- a/lang/python/python-docker/Makefile
+++ b/lang/python/python-docker/Makefile
@@ -10,6 +10,7 @@ PKG_HASH:=323736fb92cd9418fc5e7133bc953e11a9da04f4483f828b527db553f1e7e5a3
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:docker:docker-py
 
 PKG_BUILD_DEPENDS:=python-setuptools-scm/host
 


### PR DESCRIPTION
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:docker:docker-py

Maintainer: @neheb
Compile tested: Not needed
Run tested: Not needed