### PR TITLE
net/fail2ban: assign PKG_CPE_ID

### DIFF
--- a/net/fail2ban/Makefile
+++ b/net/fail2ban/Makefile
@@ -16,6 +16,7 @@ PKG_HASH:=383108e5f8644cefb288537950923b7520f642e7e114efb843f6e7ea9268b1e0
 PKG_MAINTAINER:=Gerald Kerma <gandalf@gk2.net>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:fail2ban:fail2ban
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk


### PR DESCRIPTION
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:fail2ban:fail2ban

Maintainer: @1715173329
Compile tested: Not needed
Run tested: Not needed
