### PR TITLE
libs/freetype: fix PKG_CPE_ID

### DIFF
--- a/libs/freetype/Makefile
+++ b/libs/freetype/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=3333ae7cfda88429c97a7ae63b7d01ab398076c3b67182e960e5684050f2c5c8
 PKG_MAINTAINER:=Val Kulkov <val.kulkov@gmail.com>
 PKG_LICENSE:=FTL GPL-2.0-only MIT ZLIB GPL-3.0-or-later
 PKG_LICENSE_FILES:=docs/LICENSE.TXT docs/FTL.TXT docs/GPLv2.TXT src/bdf/README src/pcf/README src/gzip/zlib.h builds/unix/config.sub builds/unix/config.guess builds/unix/libtool 
-PKG_CPE_ID:=cpe:/a:freetype:freetype2
+PKG_CPE_ID:=cpe:/a:freetype:freetype
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/meson.mk


### PR DESCRIPTION
There is not a single CVE under cpe:/a:freetype:freetype2 so use cpe:/a:freetype:freetype:
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:freetype:freetype

Maintainer: @neheb
Compile tested: Not needed
Run tested: Not needed
