### PR TITLE
bcm27xx-eeprom: switch to bcm27xx-utils

### DIFF
--- a/utils/bcm27xx-eeprom/Makefile
+++ b/utils/bcm27xx-eeprom/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcm27xx-eeprom
 PKG_VERSION:=v.2024.01.05-2712
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/raspberrypi/rpi-eeprom/tar.gz/$(PKG_VERSION)?
@@ -26,7 +26,7 @@ endef
 define Package/bcm27xx-eeprom
 $(call Package/bcm27xx-eeprom/Default)
   TITLE:=BCM27xx EEPROM tools
-  DEPENDS:=bcm27xx-userland +blkid +coreutils +coreutils-od +mount-utils +pciutils +python3-light
+  DEPENDS:=bcm27xx-utils +blkid +coreutils +coreutils-od +mount-utils +pciutils +python3-light
 endef
 
 define Package/bcm2711-eeprom


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm2711, bcm2712
Run tested: bcm2711/RPi4, bcm2712/RPi5

Description: bcm27xx-userland is now deprecated and utils should be used instead.
https://github.com/raspberrypi/userland/commit/96a7334ae9d5fc9db7ac92e59852377df63f1848
