### PR TITLE
[23.05] sing-box: update to 1.8.4

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.8.0
+PKG_VERSION:=1.8.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=80ae2a860fc77d961c578999e5fcfe964f969c81d9ccac156b2fef1340eca12f
+PKG_HASH:=949feec1da2bc9d43b6c766c1dfb6f71f737a221e5ce4220616a3900dfb40c82
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: me
Compile tested: (x86_64, OpenWrt snapshot)
Run tested: (x86_64, OpenWrt snapshot, tests done)

Description:
Cherry picked from commit 49ab3e0018948ebcbad676f5640c3ca7e3984db5.
