### PR TITLE
ci: bump checkout/upload-artifact to v4

### DIFF
--- a/.github/workflows/check-autorelease-deprecation.yml
+++ b/.github/workflows/check-autorelease-deprecation.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -56,7 +56,7 @@ jobs:
             runtime_test: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -153,7 +153,7 @@ jobs:
 
       - name: Store packages
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.ARCHIVE_NAME}}-packages
           path: |
@@ -164,7 +164,7 @@ jobs:
 
       - name: Store logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.ARCHIVE_NAME}}-logs
           path: |


### PR DESCRIPTION
Maintainer: @aparcar 
Compile tested: n/a
Run tested: n/a

Description:
Fix Node.js 16 deprecation warning.
Ref: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/