### PR TITLE
udpxy: workaround bug introduced by SSM.

### DIFF
--- a/net/udpxy/patches/001-fix_uninitialized_source_address.patch
+++ b/net/udpxy/patches/001-fix_uninitialized_source_address.patch
@@ -1,0 +1,20 @@
+--- a/chipmunk/udpxrec.c
++++ b/chipmunk/udpxrec.c
+@@ -283,6 +283,7 @@ subscribe( int* sockfd, struct in_addr*
+ 
+     assert( sockfd && mcast_inaddr && s_address );
+ 
++    memset( s_address, 0, sizeof(struct sockaddr_in) );
+     if (strlen(source_ipaddr) != 0 && 1 != inet_aton( source_ipaddr, &s_address->sin_addr)) {
+         mperror( g_flog, errno,
+                 "%s: Invalid source address (SSM) [%s]: inet_aton",
+--- a/chipmunk/udpxy.c
++++ b/chipmunk/udpxy.c
+@@ -693,6 +693,7 @@ udp_relay( int sockfd, struct server_ctx
+             break;
+         }
+ 
++	memset( &src_addr, 0, sizeof(src_addr) );
+         /* If the source IP exists, store the IP in the src_addr which is a sockaddr_in struct */
+         if( strlen(src_addr) != 0 && 1 != inet_pton(AF_INET, src_addr, &s_addr.sin_addr) ) {
+             (void) tmfprintf( g_flog, "Invalid  address: [%s]\n", src_addr );


### PR DESCRIPTION
There is a bug introduced by SSM support, the source address
is uninitialized if it's not specified in command line argument.
It will cause UDP socket waiting for packet from random address,
and result in timeout in that case.

This patch is trying to workaround the bug in OpenWrt.

Signed-off-by: Gang Chen <11877522+cgang@users.noreply.github.com>

Maintainer: @neheb 
Compile tested: Linksys E8450 mediatek/mt7622 OpenWrt 23.05.2
Run tested: Linksys E8450 mediatek/mt7622 OpenWrt 23.05.2

Description:
This bug can be reproduced with Linksys E8450 mediatek/mt7622 OpenWrt 23.05.2.
