### PR TITLE
utils/vim: add license info

### DIFF
--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -16,6 +16,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://ftp.vim.org/pub/vim/unix
 PKG_HASH:=a6456bc154999d83d0c20d968ac7ba6e7df0d02f3cb6427fb248660bacfb336e
 PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
+PKG_LICENSE:=Vim
+PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:vim:vim
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)$(VIMVER)


### PR DESCRIPTION
vim is licensed under its own Vim license:
https://spdx.org/licenses/Vim.html

Maintainer: @ratkaj
Compile tested: Not needed
Run tested: Not needed