### PR TITLE
devel/automake: fix license

### DIFF
--- a/devel/automake/Makefile
+++ b/devel/automake/Makefile
@@ -16,7 +16,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_HASH:=ff2bf7656c4d1c6fdda3b8bebb21f09153a736bcba169aaf65eab25fa113bf3a
 
 PKG_MAINTAINER:=Heinrich Schuchardt <xypron.glpk@gmx.de>
-PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:gnu:automake
 
 PKG_INSTALL:=1


### PR DESCRIPTION
automake is licensed under GPL-2.0-or-later, not GPL-3.0-or-later: https://git.savannah.gnu.org/cgit/automake.git/tree/COPYING indeed switch to GPL-3.0-or-later was reverted a long time ago (i.e. before its addition to openwrt) by
https://git.savannah.gnu.org/cgit/automake.git/commit/?id=fcf2f56062e384455ec8b1aed943af33f20c27c7

While at it, add the license file

Fixes: c6ac1e3f76ecd92d02d82c5729bbd1f2bd64922b

Maintainer: @xypron 
Compile tested: Not needed
Run tested: Not needed
