### PR TITLE
net/tor: add license

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -17,6 +17,7 @@ PKG_SOURCE_URL:=https://dist.torproject.org/ \
 PKG_HASH:=b20d2b9c74db28a00c07f090ee5b0241b2b684f3afdecccc6b8008931c557491
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
+PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:torproject:tor
 


### PR DESCRIPTION
tor is licensed under BSD-3-Clause

Maintainer: @hauke 
Compile tested: Not needed
Run tested: Not needed
