### PR TITLE
 [23.05] python-ble2mqtt: update to 0.2.2

### DIFF
--- a/lang/python/python-ble2mqtt/Makefile
+++ b/lang/python/python-ble2mqtt/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-ble2mqtt
-PKG_VERSION:=0.2.1
+PKG_VERSION:=0.2.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=ble2mqtt
-PKG_HASH:=b02a2cb61ae7a2ba6e4d9d5c2bd95bba80cd6ee8b7d8704a6a55ee56d5ecb196
+PKG_HASH:=6c8abb4fe3d8ba77e42f23e4acdfbb99e337ed5bdea05db4e1b92d455186c8e6
 
 PKG_MAINTAINER:=Quintin Hill <stuff@quintin.me.uk>
 PKG_LICENSE:=MIT

--- a/lang/python/python-dbus-fast/Makefile
+++ b/lang/python/python-dbus-fast/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dbus-fast
-PKG_VERSION:=2.21.0
+PKG_VERSION:=2.21.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=dbus-fast
 PYPI_SOURCE_NAME:=dbus_fast
-PKG_HASH:=f582f6f16791ced6067dab325fae444edf7ce0704315b90c2a473090636a6fe0
+PKG_HASH:=87b852d2005f1d59399ca51c5f3538f28a4742d739d7abe82b7ae8d01d8a5d02
 
 PKG_MAINTAINER:=Quintin Hill <stuff@quintin.me.uk>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: none
Run tested: none

Description: minor version bumps of two packages (https://github.com/openwrt/packages/pull/23173) backported to 23.05.
