### PR TITLE
Nmap: adjust SSL dependencies

### DIFF
--- a/net/nmap/Makefile
+++ b/net/nmap/Makefile
@@ -14,7 +14,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nmap
 PKG_VERSION:=7.93
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_MAINTAINER:=Nuno Gonçalves <nunojpg@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/net/nmap/Makefile
+++ b/net/nmap/Makefile
@@ -73,14 +73,14 @@ endef
 
 define Package/ncat-ssl
 $(call Package/nmap/default)
-  DEPENDS:=$(NCAT_DEPENDS) +libopenssl
+  DEPENDS:=$(NCAT_DEPENDS) +libopenssl +ca-bundle
   VARIANT:=ssl
   TITLE:=Ncat (with OpenSSL support)
 endef
 
 define Package/ncat-full
 $(call Package/nmap/default)
-  DEPENDS:=$(NCAT_DEPENDS) +libopenssl +liblua5.3
+  DEPENDS:=$(NCAT_DEPENDS) +libopenssl +ca-bundle +liblua5.3
   VARIANT:=full
   TITLE:=Ncat (with OpenSSL and scripting support)
 endef
@@ -179,7 +179,6 @@ endef
 define Package/ncat-ssl/install
 	$(call Package/ncat/install,$(1))
 	$(INSTALL_DIR) $(1)/usr/share/ncat
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/ncat/ca-bundle.crt $(1)/usr/share/ncat/
 endef
 
 Package/ncat-full/install=$(Package/ncat-ssl/install)

--- a/net/nmap/Makefile
+++ b/net/nmap/Makefile
@@ -35,6 +35,7 @@ include ../../lang/python/python3-package.mk
 NMAP_DEPENDS:=+libpcap +libstdcpp +zlib +libpcre
 NCAT_DEPENDS:=+libpcap
 NPING_DEPENDS:=+libpcap +libpthread +libstdcpp
+SSL_DEPENDS:=+libopenssl +ca-certs
 
 define Package/nmap/default
   SUBMENU:=NMAP Suite
@@ -52,14 +53,14 @@ endef
 
 define Package/nmap-ssl
 $(call Package/nmap/default)
-  DEPENDS:=$(NMAP_DEPENDS) +libopenssl
+  DEPENDS:=$(NMAP_DEPENDS) $(SSL_DEPENDS)
   VARIANT:=ssl
   TITLE:=Nmap (with OpenSSL support)
 endef
 
 define Package/nmap-full
 $(call Package/nmap/default)
-  DEPENDS:=$(NMAP_DEPENDS) +libopenssl +liblua5.3 +libssh2
+  DEPENDS:=$(NMAP_DEPENDS) $(SSL_DEPENDS) +liblua5.3 +libssh2
   VARIANT:=full
   TITLE:=Nmap (with OpenSSL and scripting support)
 endef
@@ -73,14 +74,14 @@ endef
 
 define Package/ncat-ssl
 $(call Package/nmap/default)
-  DEPENDS:=$(NCAT_DEPENDS) +libopenssl +ca-bundle
+  DEPENDS:=$(NCAT_DEPENDS) $(SSL_DEPENDS)
   VARIANT:=ssl
   TITLE:=Ncat (with OpenSSL support)
 endef
 
 define Package/ncat-full
 $(call Package/nmap/default)
-  DEPENDS:=$(NCAT_DEPENDS) +libopenssl +ca-bundle +liblua5.3
+  DEPENDS:=$(NCAT_DEPENDS) $(SSL_DEPENDS) +liblua5.3
   VARIANT:=full
   TITLE:=Ncat (with OpenSSL and scripting support)
 endef
@@ -94,7 +95,7 @@ endef
 
 define Package/nping-ssl
 $(call Package/nmap/default)
-  DEPENDS:=$(NPING_DEPENDS) +libopenssl
+  DEPENDS:=$(NPING_DEPENDS) $(SSL_DEPENDS)
   VARIANT:=ssl
   TITLE:=Nping (with OpenSSL support)
 endef

--- a/net/nmap/patches/030-ncat-drop-ca-bundle.patch
+++ b/net/nmap/patches/030-ncat-drop-ca-bundle.patch
@@ -1,0 +1,66 @@
+Author: Konstantin Demin <rockdrilla@gmail.com>
+Title: ncat: avoid shipping/using internal ca-bundle.crt
+
+1. ca-bundle.crt may provide outdated trusted CAs.
+2. maintain trusted CAs in one place.
+
+Also remove references to NCAT_CA_CERTS_FILE and NCAT_CA_CERTS_PATH in order to catch future errors early (i.e. at compile-time).
+
+ ncat/Makefile.in  |  1 -
+ ncat/ncat_posix.c | 13 +------------
+ ncat/ncat_ssl.h   |  2 --
+ 3 files changed, 1 insertion(+), 15 deletions(-)
+
+--- a/ncat/Makefile.in
++++ b/ncat/Makefile.in
+@@ -80,7 +80,6 @@ DATAFILES =
+ ifneq ($(HAVE_OPENSSL),)
+ SRCS += http_digest.c
+ OBJS += http_digest.o
+-DATAFILES = certs/ca-bundle.crt
+ endif
+ 
+ ifneq ($(NOLUA),yes)
+--- a/ncat/ncat_posix.c
++++ b/ncat/ncat_posix.c
+@@ -347,28 +347,17 @@ void set_lf_mode(void)
+ 
+ #ifdef HAVE_OPENSSL
+ 
+-#define NCAT_CA_CERTS_PATH (NCAT_DATADIR "/" NCAT_CA_CERTS_FILE)
+-
+ int ssl_load_default_ca_certs(SSL_CTX *ctx)
+ {
+     int rc;
+ 
+     if (o.debug)
+-        logdebug("Using system default trusted CA certificates and those in %s.\n", NCAT_CA_CERTS_PATH);
++        logdebug("Using system default trusted CA certificates.\n");
+ 
+     /* Load distribution-provided defaults, if any. */
+     rc = SSL_CTX_set_default_verify_paths(ctx);
+     ncat_assert(rc > 0);
+ 
+-    /* Also load the trusted certificates we ship. */
+-    rc = SSL_CTX_load_verify_locations(ctx, NCAT_CA_CERTS_PATH, NULL);
+-    if (rc != 1) {
+-        if (o.debug)
+-            logdebug("Unable to load trusted CA certificates from %s: %s\n",
+-                NCAT_CA_CERTS_PATH, ERR_error_string(ERR_get_error(), NULL));
+-        return -1;
+-    }
+-
+     return 0;
+ }
+ #endif
+--- a/ncat/ncat_ssl.h
++++ b/ncat/ncat_ssl.h
+@@ -67,8 +67,6 @@
+ #include <openssl/ssl.h>
+ #include <openssl/err.h>
+ 
+-#define NCAT_CA_CERTS_FILE "ca-bundle.crt"
+-
+ enum {
+     SHA1_BYTES = 160 / 8,
+     /* 40 bytes for hex digits and 9 bytes for ' '. */


### PR DESCRIPTION
Maintainer: @nunojpg
Compile-tested: ath79/generic (TP-Link Archer C7 v2), mediatek/filogic (GL.iNet GL-MT6000)
Run-tested: mediatek/filogic (GL.iNet GL-MT6000)

Description:
- nmap: ncat: use default CA bundle
- nmap: unify SSL dependencies