### PR TITLE
libjpeg-trubo: update to 3.0.2

### DIFF
--- a/libs/libjpeg-turbo/Makefile
+++ b/libs/libjpeg-turbo/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libjpeg-turbo
-PKG_VERSION:=2.1.4
-PKG_RELEASE:=2
+PKG_VERSION:=3.0.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SF/$(PKG_NAME)
-PKG_HASH:=d3ed26a1131a13686dfca4935e520eb7c90ae76fbc45d98bb50a8dc86230342b
+PKG_SOURCE_URL:=https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/$(PKG_VERSION)
+PKG_HASH:=c2ce515a78d91b09023773ef2770d6b0df77d674e144de80d63e0389b3a15ca6
 
 PKG_MAINTAINER:=Rosen Penev <rosenp@gmail.com>
 PKG_LICENSE:=BSD-3-Clause IJG zlib
@@ -50,16 +50,6 @@ define Package/libjpeg-turbo-utils/description
 endef
 
 CMAKE_OPTIONS += \
-	-DENABLE_SHARED=ON \
-	-DENABLE_STATIC=ON \
-	-DREQUIRE_SIMD=OFF \
-	-DWITH_12BIT=OFF \
-	-DWITH_ARITH_DEC=OFF \
-	-DWITH_ARITH_ENC=OFF \
-	-DWITH_JAVA=OFF \
-	-DWITH_JPEG7=OFF \
-	-DWITH_JPEG8=OFF \
-	-DWITH_MEM_SRCDST=ON \
 	-DWITH_SIMD=O$(if $(findstring mips,$(CONFIG_ARCH)),FF,N) \
 	-DWITH_TURBOJPEG=OFF
 


### PR DESCRIPTION
Maintainer: @neheb 
Compile tested: ARMv7, Linksys WRT3200ACM, master branch

Description:
- Switch source URL to Github since upstream migrated there
- Remove CMake options which are obsolete or match default values
- Don't disable arithmetic encoding/decoding since it's the standard
