### PR TITLE
libsndfile: update to 1.2.2

### DIFF
--- a/libs/libsndfile/Makefile
+++ b/libs/libsndfile/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsndfile
+PKG_VERSION:=1.2.2
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/erikd/libsndfile.git
-PKG_SOURCE_DATE:=2019-04-21
-PKG_SOURCE_VERSION:=25824cb914fb3b79e18f31fb861e218c84be7d34
-PKG_MIRROR_HASH:=9b3beef70003456ff297ce50ecd5cb1d066ca98f10f6363562431d773b3fcb3d
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/libsndfile/libsndfile/releases/download/$(PKG_VERSION)
+PKG_HASH:=3799ca9924d3125038880367bf1468e53a1b7e3686a934f098b7e1d286cdb80e
 
+PKG_MAINTAINER:=Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE:=LGPLv2.1
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:libsndfile_project:libsndfile
@@ -27,8 +27,8 @@ define Package/libsndfile
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Library for reading/writing audio files
-  URL:=http://www.mega-nerd.com/libsndfile/
-  MAINTAINER:=Peter Wagner <tripolar@gmx.at>
+  URL:=https://libsndfile.github.io/libsndfile/
+  DEPENDS:=+lame-lib +libmpg123
 endef
 
 define Package/libsndfile/description
@@ -37,15 +37,17 @@ define Package/libsndfile/description
 endef
 
 CMAKE_OPTIONS += \
-	-DBUILD_SHARED_LIBS:BOOL=ON \
-	-DENABLE_EXTERNAL_LIBS:BOOL=FALSE \
-	-DBUILD_REGTEST:BOOL=FALSE
+	-DENABLE_MPEG=ON \
+	-DBUILD_SHARED_LIBS=ON \
+	-DENABLE_EXTERNAL_LIBS=OFF
 
 TARGET_CFLAGS += $(FPIC)
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)
 	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/sndfile.pc
+	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/sndfile.pc
 endef
 
 define Package/libsndfile/install


### PR DESCRIPTION
Maintainer: @tripolar 
Run tested: ARMv7, Linksys WRT3200ACM, master branch

Description:
- Update package URL to the official one
- Update source URL to the official one
- Modernize CMake options
- Fixup pkgconfig file
- Enable mpg123 support per users request (+7kB)