### PR TITLE
zstd: update to 1.5.5

### DIFF
--- a/utils/zstd/Makefile
+++ b/utils/zstd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zstd
-PKG_VERSION:=1.5.2
-PKG_RELEASE:=2
+PKG_VERSION:=1.5.5
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/facebook/zstd/releases/download/v$(PKG_VERSION)
-PKG_HASH:=7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0
+PKG_HASH:=9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0-or-later
@@ -64,12 +64,6 @@ endif
 MESON_ARGS += \
 	-Dlegacy_level=7 \
 	-Ddebug_level=0 \
-	-Dbacktrace=false \
-	-Dstatic_runtime=false \
-	-Dbin_programs=true \
-	-Dbin_tests=false \
-	-Dbin_contrib=false \
-	-Dmulti_thread=enabled \
 	-Dzlib=disabled \
 	-Dlzma=disabled \
 	-Dlz4=disabled \


### PR DESCRIPTION
Maintainer: N/A
Run tested: ARMv7, Linksys WRT3200ACM, master branch

Description:
- Don't set Meson options which are matching defaults
