### PR TITLE
[23.05] nebula: update to 1.8.2-2

### DIFF
--- a/net/nebula/Makefile
+++ b/net/nebula/Makefile
@@ -1,19 +1,20 @@
-# Copyright 2023 Stan Grishin (stangri@melmac.ca)
-# This is free software, licensed under the MIT License.
+# Copyright 2021-2023 Stan Grishin (stangri@melmac.ca)
+# This is free software, licensed under the Apache 2.0 License.
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nebula
 PKG_VERSION:=1.8.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/slackhq/nebula/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=203713c58d0ec8a10df2f605af791a77a33f825454911ac3a5313ced591547fd
 
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_LICENSE:=MIT
+PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:slack:nebula
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
@@ -29,27 +30,27 @@ GO_PKG_LDFLAGS_X:=\
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
-define Package/nebula
+define Package/nebula/Default
   SECTION:=net
   CATEGORY:=Network
-  TITLE:=nebula
   URL:=https://docs.openwrt.melmac.net/nebula/
+endef
+
+define Package/nebula
+  $(call Package/nebula/Default)
+  TITLE:=nebula
   DEPENDS:=$(GO_ARCH_DEPENDS) +kmod-tun
 endef
 
 define Package/nebula-cert
-  SECTION:=net
-  CATEGORY:=Network
+  $(call Package/nebula/Default)
   TITLE:=nebula-cert
-  URL:=https://docs.openwrt.melmac.net/nebula/
   DEPENDS:=$(GO_ARCH_DEPENDS)
 endef
 
 define Package/nebula-proto
-  SECTION:=net
-  CATEGORY:=Network
+  $(call Package/nebula/Default)
   TITLE:=nebula-proto
-  URL:=https://docs.openwrt.melmac.net/nebula/
   DEPENDS:=nebula
 	DEPENDS+=+!BUSYBOX_DEFAULT_AWK:gawk
 	DEPENDS+=+!BUSYBOX_DEFAULT_GREP:grep
@@ -58,10 +59,8 @@ define Package/nebula-proto
 endef
 
 define Package/nebula-service
-  SECTION:=net
-  CATEGORY:=Network
+  $(call Package/nebula/Default)
   TITLE:=nebula-service
-  URL:=https://docs.openwrt.melmac.net/nebula/
   DEPENDS:=nebula
 	DEPENDS+=+!BUSYBOX_DEFAULT_AWK:gawk
 	DEPENDS+=+!BUSYBOX_DEFAULT_SED:sed
@@ -69,53 +68,48 @@ define Package/nebula-service
   PKGARCH:=all
 endef
 
-define Build/Compile
-  $(call GoPackage/Build/Compile)
+define Package/nebula/description/Default
+  Nebula is a scalable overlay networking tool with a focus on performance, simplicity
+  and security. It lets you seamlessly connect computers anywhere in the world.
 endef
 
 define Package/nebula/description
-Nebula is a scalable overlay networking tool with a focus on performance, simplicity
-and security. It lets you seamlessly connect computers anywhere in the world.
-This package contains only nebula binary. Unless you want to start nebula manually,
-you may want to also install *either* 'nebula-service' *or* 'nebula-proto' package.
+  $(call Package/nebula/description/Default)
+  This package contains only nebula binary. Unless you want to start nebula manually,
+  you may want to also install *either* 'nebula-service' *or* 'nebula-proto' package.
 endef
 
 define Package/nebula-cert/description
-Nebula is a scalable overlay networking tool with a focus on performance, simplicity
-and security. It lets you seamlessly connect computers anywhere in the world.
-This package contains only nebula-cert binary.
+  $(call Package/nebula/description/Default)
+  This package contains only nebula-cert binary.
 endef
 
 define Package/nebula-proto/description
-Nebula is a scalable overlay networking tool with a focus on performance, simplicity
-and security. It lets you seamlessly connect computers anywhere in the world.
-This package contains only OpenWrt protocol/interface support for nebula.
+  $(call Package/nebula/description/Default)
+  This package contains only OpenWrt protocol/interface support for nebula.
 endef
 
 define Package/nebula-service/description
-Nebula is a scalable overlay networking tool with a focus on performance, simplicity
-and security. It lets you seamlessly connect computers anywhere in the world.
-This package contains only OpenWrt-specific init.d script for nebula.
+  $(call Package/nebula/description/Default)
+  This package contains only OpenWrt-specific init.d script for nebula.
 endef
+
+define Package/nebula/conffiles
+/etc/nebula/
+endef
+
+Package/nebula-cert/conffiles = $(Package/nebula/conffiles)
 
 define Package/nebula/install
 	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
-	$(INSTALL_DIR) $(1)/usr/share/doc/nebula
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nebula $(1)/usr/sbin/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/LICENSE $(1)/usr/share/doc/nebula/LICENSE
-	$(INSTALL_DATA) ./files/nebula.upgrade $(1)/lib/upgrade/keep.d/nebula
 endef
 
 define Package/nebula-cert/install
 	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
-	$(INSTALL_DIR) $(1)/usr/share/doc/nebula-cert
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nebula-cert $(1)/usr/sbin/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/LICENSE $(1)/usr/share/doc/nebula-cert/LICENSE
-	$(INSTALL_DATA) ./files/nebula.upgrade $(1)/lib/upgrade/keep.d/nebula-cert
 endef
 
 define Package/nebula-proto/install

--- a/net/nebula/files/README.md
+++ b/net/nebula/files/README.md
@@ -1,0 +1,3 @@
+# README
+
+README is available at [https://docs.openwrt.melmac.net/nebula/](https://docs.openwrt.melmac.net/nebula/).

--- a/net/nebula/files/nebula.upgrade
+++ b/net/nebula/files/nebula.upgrade
@@ -1,1 +1,0 @@
-/etc/nebula/


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2

Description:
The following fixes have been applied to Makefile:
* fix the nebula license type
* add PKG_CPE_ID
* remove unneeded call to Build/Compile
* add leading spaces to descriptions
* add Package/nebula/conffiles definition
* remove unneeded /lib/upgrade/keep.d files
* no longer install actual license file
* add the README file

Kudos to @BKPepe and @1715173329 for feedback which lead to these fixes

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit ae22bea8ddda7dd4409ea436e34c39073c954d8d)
