### PR TITLE
libs/vips: fix PKG_CPE_ID

### DIFF
--- a/libs/vips/Makefile
+++ b/libs/vips/Makefile
@@ -16,7 +16,7 @@ PKG_HASH:=06811f5aed3e7bc03e63d05537ff4b501de5283108c8ee79396c60601a00830c
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:vips:vips
+PKG_CPE_ID:=cpe:/a:libvips:libvips
 
 PKG_BUILD_DEPENDS:=glib2/host
 


### PR DESCRIPTION
libvips:libvips is a better CPE ID than vips:vips as this CPE ID has the latest CVEs (whereas vips only has an old CVE from 2010):

  https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:libvips:libvips

Fix: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36

Maintainer: @flyn-org
Compile tested: Not needed
Run tested: Not needed