### PR TITLE
libs/expat: fix PKG_CPE_ID

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -17,7 +17,7 @@ PKG_HASH:=ef2420f0232c087801abf705e89ae65f6257df6b7931d37846a193ef2e8cdcbe
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:libexpat:expat
+PKG_CPE_ID:=cpe:/a:libexpat_project:libexpat
 
 CMAKE_INSTALL:=1
 


### PR DESCRIPTION
There is not a single CVE linked to libexpat:expat so use libexpat_project:libexpat instead:

https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:libexpat_project:libexpat

Fixes: 70c62ef2d77aef5d8a27ccca2b147bc2a69dc7f8 (expat: update to version 2.2.7 (security fix))

Maintainer: @thess 
Compile tested: Not needed
Run tested: Not needed
