### PR TITLE
libs/libidn2: fix PKG_CPE_ID

### DIFF
--- a/libs/libidn2/Makefile
+++ b/libs/libidn2/Makefile
@@ -16,7 +16,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=93caba72b4e051d1f8d4f5a076ab63c99b77faee019b72b9783b267986dbb45f
 
 PKG_MAINTAINER:=
-PKG_CPE_ID:=cpe:/a:libidn2_project:libidn2
+PKG_CPE_ID:=cpe:/a:gnu:libidn2
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
There is not a single CVE linked to libidn2_project:libidn2 so use gnu:libidn2 instead:
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:gnu:libidn2

Fixes: ceadbcbb64de727c3a974e552d9a723d532e4e40 (treewide: add PKG_CPE_ID for cvescanner)

Maintainer:
Compile tested: Not needed
Run tested: Not needed
