### PR TITLE
perl-time-moment: new module for Time::Moment v0.44

### DIFF
--- a/lang/perl-time-moment/Makefile
+++ b/lang/perl-time-moment/Makefile
@@ -1,0 +1,56 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-time-moment
+PKG_VERSION:=0.44
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=Time-Moment
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/C/CH/CHANSEN
+PKG_HASH:=64acfa042f634fcef8dadf55e7f42ba4eaab8aaeb7d5212eb89815a31f78f6fd
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Timothy Ace <openwrt@timothyace.com>
+PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
+HOST_BUILD_DEPENDS:=perl/host
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include ../perl/perlmod.mk
+
+define Package/perl-time-moment
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Time::Moment Represents a date and time of day with an offset from UTC
+  URL:=https://github.com/chansen/p5-time-moment
+  DEPENDS:=perl +perlbase-essential +perlbase-time +perlbase-xsloader
+endef
+
+define Build/Configure
+        $(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+        $(call perlmod/Compile,,)
+endef
+
+define Package/perl-time-moment/install
+        $(call perlmod/Install,$(1),Time auto/Time)
+endef
+
+define Host/Configure
+        $(call perlmod/host/Configure,,,)
+endef
+
+define Host/Compile
+        $(call perlmod/host/Compile,,)
+endef
+
+define Host/Install
+        $(call perlmod/host/Install,$(1),)
+endef
+
+$(eval $(call BuildPackage,perl-time-moment))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: me
Compile tested: arm_cortex-a9_vfpv3-d16, Linksys WRT1900ACS, OpenWrt 23.05.0
Run tested: arm_cortex-a9_vfpv3-d16, Linksys WRT1900ACS, OpenWrt 23.05.0
Tests:
- Loaded module:
```
root@storage:/tmp# perl -MTime::Moment -e '1'
root@storage:/tmp# 
```
- Executed test file from module: `https://raw.githubusercontent.com/chansen/p5-time-moment/master/eg/us_federal_holidays.pl`. NOTE: This script (not the module) requires the "enum" module, which is pure perl, so can be via CPAN through `perl -MCPAN -e 'install enum'` for the purposes of testing this script.
```
root@storage:/tmp# perl us_federal_holidays.pl 
ok 1 - U.S. federal holidays for year 1997
ok 2 - U.S. federal holidays for year 1998
ok 3 - U.S. federal holidays for year 1999
ok 4 - U.S. federal holidays for year 2000
ok 5 - U.S. federal holidays for year 2001
ok 6 - U.S. federal holidays for year 2002
ok 7 - U.S. federal holidays for year 2003
ok 8 - U.S. federal holidays for year 2004
ok 9 - U.S. federal holidays for year 2005
ok 10 - U.S. federal holidays for year 2006
ok 11 - U.S. federal holidays for year 2007
ok 12 - U.S. federal holidays for year 2008
ok 13 - U.S. federal holidays for year 2009
ok 14 - U.S. federal holidays for year 2010
ok 15 - U.S. federal holidays for year 2011
ok 16 - U.S. federal holidays for year 2012
ok 17 - U.S. federal holidays for year 2013
ok 18 - U.S. federal holidays for year 2014
ok 19 - U.S. federal holidays for year 2015
ok 20 - U.S. federal holidays for year 2016
ok 21 - U.S. federal holidays for year 2017
ok 22 - U.S. federal holidays for year 2018
ok 23 - U.S. federal holidays for year 2019
ok 24 - U.S. federal holidays for year 2020
1..24
root@storage:/tmp# 
```

Description: This adds the compiled perl module Time::Moment at v0.44
