### PR TITLE
libmariadb: update to 3.1.23

### DIFF
--- a/libs/libmariadb/Makefile
+++ b/libs/libmariadb/Makefile
@@ -8,16 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmariadb
-PKG_VERSION:=3.1.18
-PKG_RELEASE:=2
+PKG_VERSION:=3.1.23
+PKG_RELEASE:=1
 
 PKG_SOURCE:=mariadb-connector-c-$(PKG_VERSION)-src.tar.gz
-PKG_SOURCE_URL := \
+PKG_SOURCE_URL:=\
 	https://mirror.netcologne.de/mariadb/connector-c-$(PKG_VERSION) \
 	https://mirror.lstn.net/mariadb/connector-c-$(PKG_VERSION) \
 	https://ftp.yz.yamagata-u.ac.jp/pub/dbms/mariadb/connector-c-$(PKG_VERSION) \
-	https://downloads.mariadb.org/interstitial/connector-c-$(PKG_VERSION)
-PKG_HASH:=b01ecacf7531c2f36d90708845488e66462bf63627c58cb5986bd1c0833e4d9c
+	https://dlm.mariadb.com/3677044/Connectors/c/connector-c-$(PKG_VERSION)
+PKG_HASH:=43642ff0f104a1f79ec530ac81716bab52040016f6ad7cdec56f4ce30be19f6a
 PKG_BUILD_DIR:=$(BUILD_DIR)/mariadb-connector-c-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Michal Hrusecky <Michal@Hrusecky.net>
@@ -47,8 +47,7 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-# Pass CPPFLAGS in the CFLAGS as otherwise the build system will
-# ignore them.
+# Pass CPPFLAGS in the CFLAGS as otherwise the build system will ignore them.
 TARGET_CFLAGS+=$(TARGET_CPPFLAGS)
 
 define Package/$(PKG_NAME)/install/plugin
@@ -87,9 +86,6 @@ endef
 
 # We won't need unit tests
 CMAKE_OPTIONS += -DWITH_UNIT_TESTS=0
-
-# Make it explicit that we are cross-compiling
-CMAKE_OPTIONS += -DCMAKE_CROSSCOMPILING=1
 
 CMAKE_OPTIONS += \
 	-DDEFAULT_CHARSET=utf8 \

--- a/libs/libmariadb/patches/010-link-to-libucontext.patch
+++ b/libs/libmariadb/patches/010-link-to-libucontext.patch
@@ -23,7 +23,7 @@ the box - like musl based platforms.
  
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -227,6 +227,14 @@ IF(UNIX)
+@@ -230,6 +230,14 @@ IF(UNIX)
    SEARCH_LIBRARY(LIBPTHREAD pthread_getspecific "pthread;pthreads")
    SEARCH_LIBRARY(LIBNSL gethostbyname_r "nsl_r;nsl")
    SEARCH_LIBRARY(LIBSOCKET setsockopt socket)


### PR DESCRIPTION
Maintainer: @miska 
Run tested: ARMv7, Linksys WRT3200ACM, master branch

Description:
- Use single official source URL
- Rebase the patch
