### PR TITLE
libpsl: update to 0.21.5

### DIFF
--- a/libs/libpsl/Makefile
+++ b/libs/libpsl/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpsl
-PKG_VERSION:=0.21.2
+PKG_VERSION:=0.21.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/rockdaboot/libpsl/releases/download/$(PKG_VERSION)
-PKG_HASH:=e35991b6e17001afa2c0ca3b10c357650602b92596209b7492802f3768a6285f
+PKG_HASH:=1dcc9ceae8b128f3c0b3f654decd0e1e891afc6ff81098f227ef260449dae208
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @flyn-org 
Run tested: ARMv7, Linksys WRT3200ACM, master branch
