### PR TITLE
libs/libpam: fix PKG_CPE_ID

### DIFF
--- a/libs/libpam/Makefile
+++ b/libs/libpam/Makefile
@@ -19,7 +19,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/Linux-PAM-$(PKG_VERSION)
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
 PKG_LICENSE:=BSD-3c GPL
 PKG_LICENSE_FILES:=COPYING Copyright
-PKG_CPE_ID:=cpe:/a:kernel:linux-pam
+PKG_CPE_ID:=cpe:/a:linux-pam:linux-pam
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
linux-pam:linux-pam is a better CPE ID than kernel:linux-pam as this CPE ID has the latest CVEs (whereas kernel:linux-pam only has a SUSE-specific CVE): https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:linux-pam:linux-pam

Fix: 6f74b0c4f15a095b1069a8aaeb19a32dfbc7539a

Maintainer: @nmav
Compile tested: Not needed
Run tested: Not needed
