### PR TITLE
utils/lrzsz: fix PKG_CPE_ID

### DIFF
--- a/utils/lrzsz/Makefile
+++ b/utils/lrzsz/Makefile
@@ -19,7 +19,7 @@ PKG_BUILD_DIR=$(BUILD_DIR)/lrzsz-990823
 PKG_MAINTAINER:=Hsing-Wang Liao <kuoruan@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:lrzsz_project
+PKG_CPE_ID:=cpe:/a:lrzsz_project:lrzsz
 
 PKG_INSTALL:=1
 


### PR DESCRIPTION
PKG_CPE_ID was missing ":lrzsz"

Fixes: 6d6c4b21b5e22a9f1058db5b61521a298e00a5f0 (lrzsz: update to v0.12.21rc and fix a CVE)

Maintainer: @kuoruan
Compile tested: Not needed
Run tested: Not needed