### PR TITLE
net/miniupnpc: fix PKG_CPE_ID

### DIFF
--- a/net/miniupnpc/Makefile
+++ b/net/miniupnpc/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=dce41b4a4f08521c53a0ab163ad2007d18b5e1aa173ea5803bd47a1be3159c24
 PKG_MAINTAINER:=
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
-PKG_CPE_ID:=cpe:/a:miniupnp_project:miniupnp
+PKG_CPE_ID:=cpe:/a:miniupnp_project:miniupnpc
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION
cpe:/a:miniupnp_project:miniupnpc is the correct CPE ID for miniupnpc: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:miniupnp_project:miniupnpc

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

Maintainer:
Compile tested: Not needed
Run tested: Not needed
