### PR TITLE
net/krb5: fix PKG_CPE_ID

### DIFF
--- a/net/krb5/Makefile
+++ b/net/krb5/Makefile
@@ -15,7 +15,7 @@ PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=NOTICE
-PKG_CPE_ID:=cpe:/a:mit:kerberos
+PKG_CPE_ID:=cpe:/a:mit:kerberos_5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://web.mit.edu/kerberos/dist/krb5/1.21


### PR DESCRIPTION
mit:kerberos_5 is a better CPE ID than mit:kerberos as this CPE ID has the latest CVEs (whereas mit:kerberos only has CVEs until 2018): https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:mit:kerberos_5

Fix: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36

Maintainer: @flyn-org
Compile tested: Not needed
Run tested: Not needed
