### PR TITLE
multimedia/motion: fix PKG_CPE_ID

### DIFF
--- a/multimedia/motion/Makefile
+++ b/multimedia/motion/Makefile
@@ -19,7 +19,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-release-$(PKG_VERSION)
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:lavrsen:motion
+PKG_CPE_ID:=cpe:/a:motion_project:motion
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
motion_project:motion is a better CPE ID than lavrsen:motion as this CPE ID has the latest CVE (whereas lavrsen:motion only a CVE from 2008): https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:motion_project:motion

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

Maintainer: @roger- 
Compile tested: Not needed
Run tested: Not needed
