### PR TITLE
lang/python/python-urllib3: fix PKG_CPE_ID

### DIFF
--- a/lang/python/python-urllib3/Makefile
+++ b/lang/python/python-urllib3/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
-PKG_CPE_ID:=cpe:/a:urllib3_project:urllib3
+PKG_CPE_ID:=cpe:/a:python:urllib3
 
 PYPI_NAME:=urllib3
 PKG_HASH:=8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11


### PR DESCRIPTION
There is not a single CVE linked to urllib3_project:urllib3 so use python:urllib3 instead:
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:python:urllib3

Fixes: 6dcaa769d8ce8921dc3bfaf78ab9a8c1cef4a9b9 (python-urllib3: update to version 1.25)

Maintainer: @BKPepe
Compile tested: Not needed
Run tested: Not needed