### PR TITLE
lang/python/python-requests: fix PKG_CPE_ID

### DIFF
--- a/lang/python/python-requests/Makefile
+++ b/lang/python/python-requests/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
-PKG_CPE_ID:=cpe:/a:python-requests:requests
+PKG_CPE_ID:=cpe:/a:python:requests
 
 PYPI_NAME:=requests
 PKG_HASH:=942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1


### PR DESCRIPTION
There is not a single CVE linked to python-requests:requests so use python:requests instead:
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:python:requests

Fixes: ceadbcbb64de727c3a974e552d9a723d532e4e40 (treewide: add PKG_CPE_ID for cvescanner)

Maintainer: @BKPepe 
Compile tested: Not needed
Run tested: Not needed
