### PR TITLE
lang/python/python-pip: fix PKG_CPE_ID

### DIFF
--- a/lang/python/python-pip/Makefile
+++ b/lang/python/python-pip/Makefile
@@ -17,7 +17,7 @@ PKG_HASH:=1fcaa041308d01f14575f6d0d2ea4b75a3e2871fe4f9c694976f908768e14174
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
-CPE_ID:=cpe:/a:python:pip
+PKG_CPE_ID:=cpe:/a:pypa:pip
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
There is not a single CVE linked to python:pip so use pypa:pip instead: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:pypa:pip

Moreover, CPE_ID missed PKG_ prefix

Fixes: eee273507b868ad5f6f7e744d513c85330967906 (python3: Split pip into separate source package)

Maintainer: @jefferyto
Compile tested: Not needed
Run tested: Not needed
