### PR TITLE
net/nbd: fix PKG_CPE_ID

### DIFF
--- a/net/nbd/Makefile
+++ b/net/nbd/Makefile
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=@SF/nbd
 PKG_HASH:=b4466412f13e057659f25d35e1e8e181afd62c7179bff22a6add81445ecb8690
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_MAINTAINER:=Marcin Jurkowski <marcin1j@gmail.com>
-PKG_CPE_ID:=cpe:/a:network_block_device:nbd
+PKG_CPE_ID:=cpe:/a:network_block_device_project:network_block_device
 
 PKG_INSTALL:=1
 


### PR DESCRIPTION
There is not a single CVE linked to network_block_device:nbd so use network_block_device_project:network_block_device instead: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:network_block_device_project:network_block_device

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

Maintainer: @marcin1j
Compile tested: Not needed
Run tested: Not needed
