### PR TITLE
lang/python/python-yaml: fix PKG_CPE_ID

### DIFF
--- a/lang/python/python-yaml/Makefile
+++ b/lang/python/python-yaml/Makefile
@@ -17,7 +17,7 @@ PKG_HASH:=bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
-PKG_CPE_ID:=cpe:/a:pyyaml_project:pyyaml
+PKG_CPE_ID:=cpe:/a:pyyaml:pyyaml
 
 PKG_BUILD_DEPENDS:=python-cython/host
 


### PR DESCRIPTION
There is not a single CVE linked to pyyaml_project:pyyaml so use pyyaml:pyyaml instead:
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:pyyaml:pyyaml

Fixes: c06a04c754bdcfdb2ea0bd1d654128863a2b6738 (python-yaml: update to version 5.1)

Maintainer: @BKPepe
Compile tested: Not needed
Run tested: Not needed
