### PR TITLE
libs/redis: fix PKG_CPE_ID

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -11,7 +11,7 @@ PKG_HASH:=5b2b8b7a50111ef395bf1c1d5be11e6e167ac018125055daa8b5c2317ae131ab
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:pivotal_software:redis
+PKG_CPE_ID:=cpe:/a:redis:redis
 
 PKG_INSTALL:=1
 


### PR DESCRIPTION
There is not a single CVE linked to pivotal_software:redis so use redis:redis instead:
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:redis:redis

Fixes: ceadbcbb64de727c3a974e552d9a723d532e4e40 (treewide: add PKG_CPE_ID for cvescanner)

Maintainer: @ja-pa
Compile tested: Not needed
Run tested: Not needed
