### PR TITLE
net/boinc: fix PKG_CPE_ID

### DIFF
--- a/net/boinc/Makefile
+++ b/net/boinc/Makefile
@@ -19,7 +19,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-client_release-$(PKG_VERSION_SHORT)-$(PK
 PKG_MAINTAINER:=Christian Dreihsig <christian.dreihsig@t-online.de>, Steffen Moeller <moeller@debian.org>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:boinc_project:boinc
+PKG_CPE_ID:=cpe:/a:rom_walton:boinc
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=0


### PR DESCRIPTION
boinc_project:boinc has never been a valid CPE ID so use rom_walton:boinc instead:
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:rom_walton:boinc

Fixes: 9c2bd865c715cad8646157d6bbfb669d9970c322 (boinc: new package for distributed computing/data acquisition)

Maintainer: @N30dG 
Compile tested: Not needed
Run tested: Not needed
