### PR TITLE
utils/squashfs-tools: fix PKG_CPE_ID

### DIFF
--- a/utils/squashfs-tools/Makefile
+++ b/utils/squashfs-tools/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
-PKG_CPE_ID:=cpe:/a:phillip_lougher:squashfs
+PKG_CPE_ID:=cpe:/a:squashfs-tools_project:squashfs-tools
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/plougher/squashfs-tools/tar.gz/${PKG_VERSION}?


### PR DESCRIPTION
There is not a single CVE linked to phillip_lougher:squashfs so use squashfs-tools_project:squashfs-tools instead:
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:squashfs-tools_project:squashfs-tools

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

Maintainer: @commodo
Compile tested: Not needed
Run tested: Not needed
