### PR TITLE
admin/sudo: fix PKG_CPE_ID

### DIFF
--- a/admin/sudo/Makefile
+++ b/admin/sudo/Makefile
@@ -19,7 +19,7 @@ PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=doc/LICENSE
-PKG_CPE_ID:=cpe:/a:todd_miller:sudo
+PKG_CPE_ID:=cpe:/a:sudo_project:sudo
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
sudo_project:sudo is a better CPE ID than todd_miller:sudo as this CPE ID has the latest CVEs (whereas todd_miller:sudo only has CVEs up to 2016): https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:sudo_project:sudo

Fixes: 8ce9f30c421255c514b1b2e41fc92eafd7976583 (sudo: Update to 1.8.24)

Maintainer: @commodo
Compile tested: Not needed
Run tested: Not needed