### PR TITLE
net/tinc: fix PKG_CPE_ID

### DIFF
--- a/net/tinc/Makefile
+++ b/net/tinc/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=2757ddc62cf64b411f569db2fa85c25ec846c0db110023f6befb33691f078986
 PKG_MAINTAINER:=Erwan Mas <erwan@mas.nom.fr>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:tinc:tinc
+PKG_CPE_ID:=cpe:/a:tinc-vpn:tinc
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
tinc-vpn:tinc is a better CPE ID than tinc:tinc as this CPE ID has the latest CVEs (whereas tinc:tinc only has CVEs up to 2002): https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:tinc-vpn:tinc

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

Maintainer: @ErwanMAS
Compile tested: Not needed
Run tested: Not needed
