### PR TITLE
net/tinyproxy: fix PKG_CPE_ID

### DIFF
--- a/net/tinyproxy/Makefile
+++ b/net/tinyproxy/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=d66388448215d0aeb90d0afdd58ed00386fb81abc23ebac9d80e194fceb40f7c
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:banu:tinyproxy
+PKG_CPE_ID:=cpe:/a:tinyproxy_project:tinyproxy
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
tinyproxy_project:tinyproxy is a better CPE ID than banu:tinyproxy as this CPE ID has the latest CVEs (whereas banu:tinyproxy only has CVEs up to 2012):
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:tinyproxy_project:tinyproxy

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

Maintainer: @jow-
Compile tested: Not needed
Run tested: Not needed
