### PR TITLE
utils/gpsd: fix PKG_CPE_ID

### DIFF
--- a/utils/gpsd/Makefile
+++ b/utils/gpsd/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=7e5e53e5ab157dce560a2f22e20322ef1136d3ebde99162def833a3306de01e5
 PKG_MAINTAINER:=Pushpal Sidhu <psidhu.devel@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:berlios:gps_daemon
+PKG_CPE_ID:=cpe:/a:gpsd_project:gpsd
 
 PKG_BUILD_DEPENDS:=scons/host
 


### PR DESCRIPTION
gpsd_project:gpsd is a better CPE ID than berlios:gps_daemon as this CPE ID has the latest CVEs (whereas berlios:gps_daemon only has one CVE from 2004):
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:gpsd_project:gpsd

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

Maintainer: @psidhu
Compile tested: Not needed
Run tested: Not needed
