### PR TITLE
utils/zsh: fix PKG_CPE_ID

### DIFF
--- a/utils/zsh/Makefile
+++ b/utils/zsh/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=9b8d1ecedd5b5e81fbf1918e876752a7dd948e05c1a0dba10ab863842d45acd5
 PKG_MAINTAINER:=Vadim A. Misbakh-Soloviov <openwrt-zsh@mva.name>
 PKG_LICENSE:=ZSH
 PKG_LICENSE_FILES:=LICENCE
-PKG_CPE_ID:=cpe:/a:zsh_project:zsh
+PKG_CPE_ID:=cpe:/a:zsh:zsh
 
 PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
zsh:zsh is a better CPE ID than zsh_project:zsh as this CPE ID has the latest CVEs (whereas zsh_project:zsh only has CVEs up to 2017): https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:zsh:zsh

Fixes: ff056fcffcacf2632505bb108bf8e8c2a3cef09c (zsh: Update to 5.6.2)

Maintainer: @msva
Compile tested: Not needed
Run tested: Not needed