### PR TITLE
utils/ntfs-3g: fix PKG_CPE_ID

### DIFF
--- a/utils/ntfs-3g/Makefile
+++ b/utils/ntfs-3g/Makefile
@@ -16,7 +16,7 @@ PKG_HASH:=0489fbb6972581e1b417ab578d543f6ae522e7fa648c3c9b49c789510fd5eb93
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=GPL-2.0-only LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING COPYING.LIB
-PKG_CPE_ID:=cpe:/a:ntfs-3g:ntfs-3g
+PKG_CPE_ID:=cpe:/a:tuxera:ntfs-3g
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
tuxera:ntfs-3g is a better CPE ID than ntfs-3g:ntfs-3g as this CPE ID has the latest CVEs (whereas ntfs-3g:ntfs-3g only has one CVE from 2007): https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:tuxera:ntfs-3g

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

Maintainer: @thess
Compile tested: Not needed
Run tested: Not needed
