### PR TITLE
utils/tmux: fix PKG_CPE_ID

### DIFF
--- a/utils/tmux/Makefile
+++ b/utils/tmux/Makefile
@@ -12,7 +12,7 @@ PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:nicholas_marriott:tmux
+PKG_CPE_ID:=cpe:/a:tmux_project:tmux
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1


### PR DESCRIPTION
tmux_project:tmux is a better CPE ID than nicholas_marriott:tmux as this CPE ID has the latest CVE (whereas nicholas_marriott:tmux only has a CVE from 2011):
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:tmux_project:tmux

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

Maintainer: @mstorchak
Compile tested: Not needed
Run tested: Not needed
