### PR TITLE
net/vsftpd: fix PKG_CPE_ID

### DIFF
--- a/net/vsftpd/Makefile
+++ b/net/vsftpd/Makefile
@@ -17,7 +17,7 @@ PKG_HASH:=26b602ae454b0ba6d99ef44a09b6b9e0dfa7f67228106736df1f278c70bc91d3
 
 PKG_MAINTAINER:=Cezary Jackiewicz <cezary@eko.one.pl>
 PKG_LICENSE:=GPLv2
-PKG_CPE_ID:=cpe:/a:beasts:vsftpd
+PKG_CPE_ID:=cpe:/a:vsftpd_project:vsftpd
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
vsftpd_project:vsftpd is a better CPE ID than beasts:vsftpd as this CPE ID has the latest CVEs (whereas beasts:vsftpd only has CVEs up to 2015): https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:vsftpd_project:vsftpd

Fixes: 1371b7be878382b8b52cd73ff72a3a41d28013c4 (vsftpd: Fix compilation without ECC or deprecated APIs)

Maintainer:
Compile tested: Not needed
Run tested: Not needed
