### PR TITLE
cloudflared: refine config.yml

### DIFF
--- a/net/cloudflared/files/cloudflared.config
+++ b/net/cloudflared/files/cloudflared.config
@@ -1,6 +1,7 @@
 
 config cloudflared 'config'
 	option enabled '0'
+	option token ''
 	option config '/etc/cloudflared/config.yml'
 	option origincert '/etc/cloudflared/cert.pem'
 	option region ''

--- a/net/cloudflared/files/sample_config.yml
+++ b/net/cloudflared/files/sample_config.yml
@@ -1,3 +1,9 @@
-url: http://localhost:8000
-tunnel: <Tunnel-UUID>
-credentials-file: /etc/cloudflared/<Tunnel-UUID>.json
+#tunnel: <Tunnel-UUID>
+#credentials-file: /etc/cloudflared/<Tunnel-UUID>.json
+#
+#ingress:
+#  - hostname: luci.example.com
+#    service: http://localhost:80
+#  - hostname: ssh.example.com
+#    service: ssh://localhost:22
+#  - service: http_status:404


### PR DESCRIPTION
The config.yml is an example of a tunnel local configuration. But the cloudlfared treat it as a real config and fails to start. So to avoid problems let's comment all the statements.

The `url: http://localhost:8000` is not a valid config option.

Additionally add a smale of configuring ingres rules.

The cloudflared.config has missing option token.

Maintainer: @1715173329 
Compile tested: not needed
Run tested: VBox
