### PR TITLE
lang/python/python-aiohttp: fix PKG_CPE_ID

### DIFF
--- a/lang/python/python-aiohttp/Makefile
+++ b/lang/python/python-aiohttp/Makefile
@@ -17,7 +17,7 @@ PKG_HASH:=b9552ec52cc147dbf1944ac7ac98af7602e51ea2dcd076ed194ca3c0d1c7d0bc
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.txt
-PKG_CPE_ID:=cpe:/a:aio-libs_project:aiohttp
+PKG_CPE_ID:=cpe:/a:aiohttp:aiohttp
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
aiohttp:aiohttp is a better CPE ID than aio-libs_projet:aiohttp as this CPE ID has the latest CVEs (whereas aio-libs_project:aiohttp only has one CVE from 2018):
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:aiohttp:aiohttp

Fixes: 2edf5034f1c09fe60af52087abe7b6fcef9433fc (python-aiohttp: add a new package)

Maintainer: @BKPepe
Compile tested: Not needed
Run tested: Not needed
