### PR TITLE
libs/libgd: fix license

### DIFF
--- a/libs/libgd/Makefile
+++ b/libs/libgd/Makefile
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/gd-
 PKG_HASH:=3fe822ece20796060af63b7c60acb151e5844204d289da0ce08f8fdf131e5a61
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
-PKG_LICENSE:=MIT
+PKG_LICENSE:=GD
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:libgd:libgd
 


### PR DESCRIPTION
libgd is licensed under its own "GD" license and not MIT

Fixes: 60feea09c9d343f648045e5e85e7788e75d4e039 (libgd: import from oldpackages, add myself as maintainer, add license...)

Maintainer: @jow-
Compile tested: Not needed
Run tested: Not needed