### PR TITLE
zoneinfo: Updated to 2024a release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2023 OpenWrt.org
+# Copyright (C) 2007-2024 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2023d
+PKG_VERSION:=2024a
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public-Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=dbca21970b0a8b8c0ceceec1d7b91fa903be0f6eca5ae732b5329672232a08f3
+PKG_HASH:=0d0434459acbd2059a7a8da1f3304a84a86591f6ed69c6248fffa502b6edffe3
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=e9a5f9e118886d2de92b62bb05510a28cc6c058d791c93bd6b84d3292c3c161e
+   HASH:=80072894adff5a458f1d143e16e4ca1d8b2a122c9c5399da482cb68cba6a1ff8
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT master
Run tested: n/a

Description:

The 2024a release of the tz code and data is available.

This release contains the following changes:

   Briefly:

     Kazakhstan unifies on UTC+5 beginning 2024-03-01.
     Palestine springs forward a week later after Ramadan.
     zic no longer pretends to support indefinite-past DST.
     localtime no longer mishandles Ciudad Ju?rez in 2422.

   Changes to future timestamps

     Kazakhstan unifies on UTC+5.  This affects Asia/Almaty and
     Asia/Qostanay which together represent the eastern portion of the
     country that will transition from UTC+6 on 2024-03-01 at 00:00 to
     join the western portion.  (Thanks to Zhanbolat Raimbekov.)

     Palestine springs forward a week later than previously predicted
     in 2024 and 2025.  (Thanks to Heba Hamad.)  Change spring-forward
     predictions to the second Saturday after Ramadan, not the first;
     this also affects other predictions starting in 2039.

   Changes to past timestamps

     Asia/Ho_Chi_Minh's 1955-07-01 transition occurred at 01:00
     not 00:00.  (Thanks to ?o?n Tr?n C?ng Danh.)

     From 1947 through 1949, Toronto's transitions occurred at 02:00
     not 00:00.  (Thanks to Chris Walton.)

     In 1911 Miquelon adopted standard time on June 15, not May 15.

   Changes to code

     The FROM and TO columns of Rule lines can no longer be "minimum"
     or an abbreviation of "minimum", because TZif files do not support
     DST rules that extend into the indefinite past - although these
     rules were supported when TZif files had only 32-bit data, this
     stopped working when 64-bit TZif files were introduced in 1995.
     This should not be a problem for realistic data, since DST was
     first used in the 20th century.  As a transition aid, FROM columns
     like "minimum" are now diagnosed and then treated as if they were
     the year 1900; this should suffice for TZif files on old systems
     with only 32-bit time_t, and it is more compatible with bugs in
     2023c-and-earlier localtime.c.  (Problem reported by Yoshito
     Umaoka.)

     localtime and related functions no longer mishandle some
     timestamps that occur about 400 years after a switch to a time
     zone with a DST schedule.  In 2023d data this problem was visible
     for some timestamps in November 2422, November 2822, etc. in
     America/Ciudad_Juarez.  (Problem reported by Gilmore Davidson.)

     strftime %s now uses tm_gmtoff if available.  (Problem and draft
     patch reported by Dag-Erling Sm?rgrav.)

   Changes to build procedure

     The leap-seconds.list file is now copied from the IERS instead of
     from its downstream counterpart at NIST, as the IERS version is
     now in the public domain too and tends to be more up-to-date.
     (Thanks to Martin Burnicki for liaisoning with the IERS.)

   Changes to documentation

     The strftime man page documents which struct tm members affect
     which conversion specs, and that tzset is called.  (Problems
     reported by Robert Elz and Steve Summit.)