### PR TITLE
lang/python/python-paho-mqtt: fix license

### DIFF
--- a/lang/python/python-paho-mqtt/Makefile
+++ b/lang/python/python-paho-mqtt/Makefile
@@ -9,8 +9,8 @@ PKG_VERSION:=1.6.1
 PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
-PKG_LICENSE:=EPL-1.0 Eclipse Distribution License v1.0
-PKG_LICENSE_FILES:=epl-v10 edl-v10
+PKG_LICENSE:=EPL-2.0 Eclipse Distribution License v1.0
+PKG_LICENSE_FILES:=epl-v20 edl-v10 LICENSE.txt
 
 PYPI_NAME:=paho-mqtt
 PKG_HASH:=2a8291c81623aec00372b5a85558a372c747cbca8e9934dfe218638b8eefc26f


### PR DESCRIPTION
python-paho-mqtt is licensed under EPL-2.0, not EPL-1.0, since version 1.6.0 and
https://github.com/eclipse/paho.mqtt.python/commit/fabe7500fb6fde31fd98c619e0117d1c651fd18d

While at it, add LICENSE.txt to PKG_LICENSE_FILES

Fixes: 784f2a519bb8cdfaa973070f65ff9a3a481e5cd1 (python-paho-mqtt: bump to version 1.6.1)

Maintainer: @BKPepe
Compile tested: Not needed
Run tested: Not needed
