### PR TITLE
libs/tiff: fix license

### DIFF
--- a/libs/tiff/Makefile
+++ b/libs/tiff/Makefile
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=https://download.osgeo.org/libtiff
 PKG_HASH:=88b3979e6d5c7e32b50d7ec72fb15af724f6ab2cbf7e10880c360a77e4b5d99a
 
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
-PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE:=libtiff
 PKG_LICENSE_FILES:=COPYRIGHT
 PKG_CPE_ID:=cpe:/a:libtiff:libtiff
 


### PR DESCRIPTION
tiff is licensed under its own "libtiff" license and not BSD-3-Clause

Fixes: 364de5bc3f16eba42f93d36e848b998b3579e39e (tiff: add licensing information)

Maintainer: @jslachta
Compile tested: Not needed
Run tested: Not needed