### PR TITLE
net/ntpd: fix license

### DIFF
--- a/net/ntpd/Makefile
+++ b/net/ntpd/Makefile
@@ -15,7 +15,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/
 PKG_HASH:=f65840deab68614d5d7ceb2d0bb9304ff70dcdedd09abb79754a87536b849c19
 
-PKG_LICENSE:=Unique
+PKG_LICENSE:=NTP
 PKG_LICENSE_FILES:=COPYRIGHT html/copyright.html
 PKG_CPE_ID:=cpe:/a:ntp:ntp
 


### PR DESCRIPTION
Replace "Unique" by the standard SPDX identifier for NTP license: https://spdx.org/licenses/NTP.html

Fixes: 1aff45c6dd36f2a5875eadaeae2ed93da8ff6d45 (ntpd: add SPDX license information)

Maintainer:
Compile tested: Not needed
Run tested: Not needed
