### PR TITLE
python-orjson: update to version 3.9.13

### DIFF
--- a/lang/python/python-orjson/Makefile
+++ b/lang/python/python-orjson/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-orjson
-PKG_VERSION:=3.9.12
+PKG_VERSION:=3.9.13
 PKG_RELEASE:=1
 
 PYPI_NAME:=orjson
-PKG_HASH:=da908d23a3b3243632b523344403b128722a5f45e278a8343c2bb67538dff0e4
+PKG_HASH:=fc6bc65b0cf524ee042e0bc2912b9206ef242edfba7426cf95763e4af01f527a
 
 PKG_MAINTAINER:=Timothy Ace <openwrt@timothyace.com>
 PKG_LICENSE:=Apache-2.0 MIT


### PR DESCRIPTION
Relevant changes since 3.9.12:
- FIXED: Serialization str escape uses only 128-bit SIMD.
- FIXED: Fix compatibility with CPython 3.13 alpha 3.
- Publish musllinux_1_2 instead of musllinux_1_1 wheels.
- Serialization uses small integer optimization in CPython 3.12 or later.

Maintainer: me
Compile tested: arm_cortex-a9_vfpv3-d16, Linksys WRT1900ACS, master
Run tested: arm_cortex-a9_vfpv3-d16, Linksys WRT1900ACS, 23.05.0 r23497-6637af95aa

Description:
Updates python-orjson from 3.9.12 -> 3.9.13. Fixes from upstream include:
- FIXED: Serialization str escape uses only 128-bit SIMD.
- FIXED: Fix compatibility with CPython 3.13 alpha 3.
- Publish musllinux_1_2 instead of musllinux_1_1 wheels.
- Serialization uses small integer optimization in CPython 3.12 or later.