### PR TITLE
oniguruma: bump to 6.9.9

### DIFF
--- a/libs/oniguruma/Makefile
+++ b/libs/oniguruma/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=oniguruma
-PKG_VERSION:=6.9.7.1
+PKG_VERSION:=6.9.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=onig-v$(subst _,-,$(PKG_VERSION)).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/kkos/oniguruma/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8f9a75b7d90dde0942c30a8b3c17889b2fecf190690988cc381c4e525cbbd22b
+PKG_HASH:=001aa1202e78448f4c0bf1a48c76e556876b36f16d92ce3207eccfd61d99f2a0
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=BSD-2-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: r25004-b463737826, mediatek, aarch64_cortex-a53
Run tested: none, just checked that soname did not change.

Description:
Featured changes:
- Update Unicode version 15.1.0
- NEW API: ONIG_OPTION_MATCH_WHOLE_STRING
- Fixed: (?I) option was not enabled for character classes (Issue #264).
- Changed specification to check for incorrect POSIX bracket (Issue #253).
- Changed [[:punct:]] in Unicode encodings to be compatible with POSIX definition. (Issue #268)
- Fixed: ONIG_OPTION_FIND_LONGEST behavior --- 6.9.8
- Whole options
  - (?C) : ONIG_OPTION_DONT_CAPTURE_GROUP
  - (?I) : ONIG_OPTION_IGNORECASE_IS_ASCII
  - (?L) : ONIG_OPTION_FIND_LONGEST
- Fixed some problems found by OSS-Fuzz


