### PR TITLE
xmlrpc-c: install dev files only with 1st variant

### DIFF
--- a/libs/xmlrpc-c/Makefile
+++ b/libs/xmlrpc-c/Makefile
@@ -114,7 +114,9 @@ define Build/Compile
 	$(call Build/Compile/Default)
 endef
 
-define Build/InstallDev
+TARGET_VARIANT=$(if $(ALL_VARIANTS),$(if $(VARIANT),$(VARIANT),$(firstword $(ALL_VARIANTS))))
+ifeq ($(if $(TARGET_VARIANT),$(BUILD_VARIANT)),$(TARGET_VARIANT))
+  define Build/InstallDev
 	$(INSTALL_DIR) \
 		$(1)/usr/include \
 		$(1)/usr/lib \
@@ -140,7 +142,8 @@ define Build/InstallDev
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc \
 		$(1)/usr/lib/pkgconfig/
-endef
+  endef
+endif
 
 define Package/xmlrpc-c-libxml2/install
 	$(INSTALL_DIR) \


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: r25004-b463737826, mediatek, aarch64_cortex-a53
Run tested: none

Description:
This adds a variant check to run InstallDev only when the first variant is built.  Otherwise, a dependent package may install the default version, even though the second variant ends up in the staging dir, causing downstream packages to miss library dependencies, such as:

Package rtorrent-rpc is missing dependencies for the following libraries: libxmlrpc_xmlparse.so.3
libxmlrpc_xmltok.so.3

