### PR TITLE
prometheus-node-exporter-ucode: fix sporadic wifi errors and warnings

### DIFF
--- a/utils/prometheus-node-exporter-ucode/Makefile
+++ b/utils/prometheus-node-exporter-ucode/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-ucode
-PKG_VERSION:=2022.12.02
+PKG_VERSION:=2024.02.07
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Andre Heider <a.heider@gmail.com>

--- a/utils/prometheus-node-exporter-ucode/files/extra/wifi.uc
+++ b/utils/prometheus-node-exporter-ucode/files/extra/wifi.uc
@@ -110,9 +110,12 @@ for (let radio in x) {
 			m_station_rx_packets(labels, info["rx_packets"]);
 			m_station_tx_packets(labels, info["tx_packets"]);
 			m_station_signal(labels, info["signal"]);
-			m_station_rx_bitrate(labels, info["rx_bitrate"]["bitrate32"] * 100);
-			m_station_tx_bitrate(labels, info["tx_bitrate"]["bitrate32"] * 100);
-			m_station_exp_tp(labels, info["expected_throughput"]);
+			if (info["rx_bitrate"] && info["rx_bitrate"]["bitrate32"])
+				m_station_rx_bitrate(labels, info["rx_bitrate"]["bitrate32"] * 100);
+			if (info["tx_bitrate"] && info["tx_bitrate"]["bitrate32"])
+				m_station_tx_bitrate(labels, info["tx_bitrate"]["bitrate32"] * 100);
+			if (info["expected_throughput"])
+				m_station_exp_tp(labels, info["expected_throughput"]);
 		}
 	}
 }


### PR DESCRIPTION
Some properties may not yet be available, properly guard them.

Fixes error like:
```
daemon.err uhttpd[2116]: error running collector 'wifi':
daemon.err uhttpd[2116]: left-hand side expression is null
```

Maintainer: me
Compile tested: ipq40xx_generic, ramips_mt7621, mediatek_filogic
Run tested: ipq40xx_generic, ramips_mt7621, mediatek_filogic