### PR TITLE
libffi: update to 3.4.4

### DIFF
--- a/libs/libffi/Makefile
+++ b/libs/libffi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libffi
-PKG_VERSION:=3.4.2
-PKG_RELEASE:=2
+PKG_VERSION:=3.4.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/libffi/libffi/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=0acbca9fd9c0eeed7e5d9460ae2ea945d3f1f3d48e13a4c54da12c7e0d23c313
+PKG_SOURCE_URL:=https://github.com/libffi/libffi/releases/download/v$(PKG_VERSION)
+PKG_HASH:=d66c56ad259a82cf2a9dfc408b32bf5da52371500b84745f7fb8b645712df676
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -31,7 +31,7 @@ define Package/libffi
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Foreign Function Interface (FFI) library
-  URL:=http://sourceware.org/libffi/
+  URL:=https://sourceware.org/libffi/
   MAINTAINER:=Peter Wagner <tripolar@gmx.at>
 endef
 
@@ -50,7 +50,6 @@ endef
 
 HOST_CONFIGURE_ARGS += \
 	--disable-shared \
-	--disable-debug \
 	--disable-docs \
 	--disable-multi-os-directory \
 	--disable-raw-api \
@@ -58,7 +57,6 @@ HOST_CONFIGURE_ARGS += \
 	--with-pic
 
 CONFIGURE_ARGS += \
-	--disable-debug \
 	--disable-docs \
 	--disable-multi-os-directory \
 	--disable-raw-api \


### PR DESCRIPTION
Maintainer: @tripolar 
Run tested: ARMv7, Linksys WRT3200ACM, master branch

Description:
- Use proper tarball URL
- Use HTTPS for package URL
- Don't set default configure option
