### PR TITLE
libfastjson: update to 1.2304.0

### DIFF
--- a/libs/libfastjson/Makefile
+++ b/libs/libfastjson/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libfastjson
-PKG_VERSION:=0.99.8
+PKG_VERSION:=1.2304.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://download.rsyslog.com/libfastjson
-PKG_HASH:=3544c757668b4a257825b3cbc26f800f59ef3c1ff2a260f40f96b48ab1d59e07
+PKG_SOURCE_URL:=https://download.rsyslog.com/libfastjson
+PKG_HASH:=ef30d1e57a18ec770f90056aaac77300270c6203bbe476f4181cc83a2d5dc80c
 
 PKG_MAINTAINER:=Dov Murik <dmurik@us.ibm.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @dubek 
Run tested: ARMv7, Linksys WRT3200ACM, master branch

Description:
- Use HTTPS for source URL
