### PR TITLE
squid: update to 6.7

### DIFF
--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squid
-PKG_VERSION:=5.7
+PKG_VERSION:=6.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://www2.pl.squid-cache.org/Versions/v5/ \
-	http://www.squid-cache.org/Versions/v5/
-PKG_HASH:=6b0753aaba4c9c4efd333e67124caecf7ad6cc2d38581f19d2f0321f5b7ecd81
+PKG_SOURCE_URL:=http://www2.pl.squid-cache.org/Versions/v6/ \
+	http://www.squid-cache.org/Versions/v6/
+PKG_HASH:=e14daa4eae41925d1ae3f08e64439a6aaa3011bdced686628b8de697d5ab8428
 
 PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -30,7 +30,7 @@ define Package/squid/Default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
-  URL:=http://www.squid-cache.org/
+  URL:=https://www.squid-cache.org/
 endef
 
 define Package/squid
@@ -69,30 +69,22 @@ endef
 
 CONFIGURE_ARGS += \
 	BUILDCXX=$(HOSTCXX_NOCACHE) \
-	--config-cache \
 	--datadir=/usr/share/squid \
 	--libexecdir=/usr/lib/squid \
 	--sysconfdir=/etc/squid \
-	--enable-shared \
 	--disable-static \
 	--enable-delay-pools \
-	--enable-kill-parent-hack \
-	--enable-ssl \
 	--enable-cache-digests \
 	--enable-linux-netfilter \
 	--disable-unlinkd \
 	--enable-x-accelerator-vary \
-	--disable-translation \
 	--disable-auto-locale \
-	--with-dl \
-	--with-pthreads \
 	--enable-epoll \
-	--with-maxfd=2048 \
-	--disable-ecap \
+	--with-filedescriptors=2048 \
 	--disable-external-acl-helpers \
 	--disable-arch-native \
-	--with-krb5-config=no \
 	--without-mit-krb5 \
+	--without-heimdal-krb5 \
 	--without-netfilter-conntrack \
 	--disable-ident-lookups \
 	$(if $(CONFIG_SQUID_auth-basic),--enable,--disable)-auth-basic \

--- a/net/squid/patches/010-no-buildcxxflags.patch
+++ b/net/squid/patches/010-no-buildcxxflags.patch
@@ -1,11 +1,11 @@
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
-@@ -761,7 +761,7 @@ cache_cf.o: cf_parser.cci
+@@ -626,7 +626,7 @@ cache_cf.o: cf_parser.cci
  
  # cf_gen builds the configuration files.
  cf_gen$(EXEEXT): $(cf_gen_SOURCES) $(cf_gen_DEPENDENCIES) cf_gen_defines.cci
 -	$(BUILDCXX) $(BUILDCXXFLAGS) -o $@ $(srcdir)/cf_gen.cc -I$(srcdir) -I$(top_builddir)/include/ -I$(top_builddir)/src
-+	$(BUILDCXX) -o $@ $(srcdir)/cf_gen.cc -I$(srcdir) -I$(top_builddir)/include/ -I$(top_builddir)/src
++	$(BUILDCXX) -std=c++17 -o $@ $(srcdir)/cf_gen.cc -I$(srcdir) -I$(top_builddir)/include/ -I$(top_builddir)/src
  
  # squid.conf.default is built by cf_gen when making cf_parser.cci
  squid.conf.default squid.conf.documented: cf_parser.cci


### PR DESCRIPTION
Maintainer: @ratkaj 
Run tested: ARMv7, Linksys WRT3200ACM, master branch

Description:
- Switch URL to HTTPS
- Remove default/obsolete configure options
- Fix and refresh the patch
