### PR TITLE
Updated tailscale version to 1.58.2

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.32.3
+PKG_VERSION:=1.58.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=tailscale-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=4cf88a1d754240ce71b29d3a65ca480091ad9c614ac99c541cef6fdaf0585dd4
+PKG_HASH:=452f355408e4e2179872387a863387e06346fc8a6f9887821f9b8a072c6a5b0a
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Updated tailscale to version 1.58.2

Maintainer: @ja-pa  @mochaaP @BKPepe
Compile tested: aarch64_cortex-a53 @ SNAPSHOT
Run tested: aarch64_cortex-a53 @ SNAPSHOT

Description:
I have updated the tailscale package to the latest stable release v. 1.58.2
![Bildschirmfoto 2024-02-07 um 19 36 58](https://github.com/openwrt/packages/assets/22558802/d6748bca-451f-4290-ab4e-5966fe5f2ecb)
