### PR TITLE
Updated tailscale version to 1.58.2

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.56.1
+PKG_VERSION:=1.58.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=56b7d25c704e3c22e9e20dcb55695cd9c816878d2c172a73c64aac42e460fd41
+PKG_HASH:=452f355408e4e2179872387a863387e06346fc8a6f9887821f9b8a072c6a5b0a
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Updated tailscale to version 1.58.2

Maintainer: @ja-pa @mochaaP @BKPepe
Compile tested: aarch64_cortex-a53 @ SNAPSHOT
Run tested: aarch64_cortex-a53 @ SNAPSHOT

Description:
I have updated the tailscale package to the latest stable release v. 1.58.2