### PR TITLE
snort3: clean up ucode usage

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.1.78.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
@@ -25,7 +25,8 @@ define Package/snort3
   SUBMENU:=Firewall
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic +kmod-nft-queue +liblzma
+  DEPENDS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic +kmod-nft-queue +liblzma \
+	+ucode +ucode-mod-fs +ucode-mod-uci
   TITLE:=Lightweight Network Intrusion Detection System
   URL:=http://www.snort.org/
   MENU:=1

--- a/net/snort3/files/main.uc
+++ b/net/snort3/files/main.uc
@@ -30,14 +30,45 @@ function wrn(fmt, ...args) {
 
 function rpad(str, fill, len)
 {
-    str = rtrim(str) + ' ';
-    while (length(str) < len) {
-        str += fill;
-    }
-    return str;
+	str = rtrim(str) + ' ';
+	while (length(str) < len) {
+		str += fill;
+	}
+	return str;
 }
 
 //------------------------------------------------------------------------------
+
+const ConfigItem = {
+	contains: function(value) {
+		// Check if the value is contained in the listed values,
+		// depending on the item type.
+		switch (this.type) {
+		case "enum":
+			return value in this.values;
+		case "range":
+			return value >= this.values[0] && value <= this.values[1];
+		default:
+			return true;
+		}
+	},
+
+	allowed: function() {
+		// Show a pretty version of the possible values, for error messages.
+		switch (this.type) {
+		case "enum":
+			return "one of [" + join(", ", this.values) + "]";
+		case "range":
+			return `${this.values[0]} <= x <= ${this.values[1]}`;
+		case "path":
+			return "a path string";
+		case "str":
+			return "a string";
+		default:
+			return "???";
+		}
+	},
+};
 
 function config_item(type, values, def) {
 	// If no default value is provided explicity, then values[0] is used as default.
@@ -49,42 +80,13 @@ function config_item(type, values, def) {
 		wrn(`A 'range' type item must have exactly 2 values in ascending order.`);
 		return;
 	}
-	// Maybe check paths for existence???
+	// Maybe check 'path' values for existence???
 		
-	return {
+	return proto({
 		type:     type,
 		values:   values,
 		default:  def ?? values[0],
-
-		contains: function(value) {
-			// Check if the value is contained in the listed values,
-			// depending on the item type.
-			switch (this.type) {
-			case "enum":
-				return value in this.values;
-			case "range":
-				return value >= this.values[0] && value <= this.values[1];
-			default:
-				return true;
-			}
-		},
-
-		allowed: function() {
-			// Show a pretty version of the possible values, for error messages.
-			switch (this.type) {
-			case "enum":
-				return "one of [" + join(", ", this.values) + "]";
-			case "range":
-				return `${this.values[0]} <= x <= ${this.values[1]}`;
-			case "path":
-				return "a path string";
-			case "str":
-				return "a string";
-			default:
-				return "???";
-			}
-		},
-	}
+	}, ConfigItem);
 };
 
 const snort_config = {


### PR DESCRIPTION
 - Add missing 'ucode' package dependencies in Makefile
 - Proto-ify the ConfigItem objects
 - Fix indentation and tab usage
 - Add modelines to enforce proper formatting

Maintainer: @flyn-org @graysky2
Run tested: x86