### PR TITLE
lyncx: fix wrongful include of 'bsd/stdlib.h' is some environments

### DIFF
--- a/net/lynx/Makefile
+++ b/net/lynx/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lynx
 PKG_VERSION:=2.9.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Leonid Esman <leonid.esman@gmail.com>
@@ -56,8 +56,10 @@ CONFIGURE_ARGS += \
 	--disable-idna \
 	--without-bzlib
 
-CONFIGURE_VARS += cf_cv_ncurses_header="ncursesw/curses.h" \
-		  ac_cv_path_NCURSES_CONFIG=""
+CONFIGURE_VARS += \
+	ac_cv_lib_bsd_arc4random=no \
+	cf_cv_ncurses_header="ncursesw/curses.h" \
+	ac_cv_path_NCURSES_CONFIG=""
 
 define Package/lynx/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Maintainer: @LLE8 
Run tested: ARMv7, Linksys WRT3200ACM, master branch

Description:

Latest update had some broken faillogs, e.g. https://downloads.openwrt.org/snapshots/faillogs/aarch64_cortex-a72/packages/lynx/compile.txt (while CI and local builds were all right):
```
In file included from ../../WWW/Library/Implementation/UCDefs.h:11,
                 from ./makeuctb.c:31:
../../WWW/Library/Implementation/HTUtils.h:801:10: fatal error: bsd/stdlib.h: No such file or directory
  801 | #include <bsd/stdlib.h>  /* prototype for arc4random.h */
```
Hopefully this fix will eliminate those fails.