### PR TITLE
squid: fix configure options

### DIFF
--- a/net/squid/Config.in
+++ b/net/squid/Config.in
@@ -18,10 +18,6 @@ if PACKAGE_squid
 		bool "Enable ICAP client support"
 		default n
 
-	config SQUID_enable-dlmalloc
-		bool "Compile & use the malloc package by Doug Lea"
-		default y
-
 	config SQUID_enable-ssl-crtd
 		bool "Enable dynamic SSL certificate generation"
 		depends on !SQUID_use-gnutls
@@ -92,4 +88,3 @@ if PACKAGE_squid
 	comment "Additional tools"
 
 endif
-

--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squid
 PKG_VERSION:=6.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www2.pl.squid-cache.org/Versions/v6/ \
@@ -91,7 +91,6 @@ CONFIGURE_ARGS += \
 	$(if $(CONFIG_SQUID_auth-digest),--enable,--disable)-auth-digest \
 	$(if $(CONFIG_SQUID_auth-ntlm),--enable,--disable)-auth-ntlm \
 	$(if $(CONFIG_SQUID_auth-negotiate),--enable,--disable)-auth-negotiate \
-	$(if $(CONFIG_SQUID_enable-ipv6),--enable,--disable)-dlmalloc \
 	$(if $(CONFIG_SQUID_enable-ipv6),--enable,--disable)-ipv6 \
 	$(if $(CONFIG_SQUID_enable-ssl-crtd),--enable-ssl-crtd) \
 	$(if $(CONFIG_SQUID_use-gnutls),--with,--without)-gnutls \
@@ -100,10 +99,10 @@ CONFIGURE_ARGS += \
 	$(if $(CONFIG_SQUID_enable-icmp),--enable,--disable)-icmp \
 	$(if $(CONFIG_SQUID_enable-icap-client),--enable,--disable)-icap-client \
 	$(if $(CONFIG_SQUID_enable-snmp),--enable,--disable)-snmp \
-	$(if $(CONFIG_SQUID_with-libcap),--with,--without)-libcap \
+	$(if $(CONFIG_SQUID_with-libcap),--with,--without)-cap \
 	$(if $(CONFIG_SQUID_with-nettle),--with,--without)-nettle \
 	$(if $(CONFIG_SQUID_with-expat),--with,--without)-expat \
-	$(if $(CONFIG_SQUID_with-libxml2),--with,--without)-libxml2
+	$(if $(CONFIG_SQUID_with-libxml2),--with,--without)-xml2
 
 CONFIGURE_VARS += \
 	ac_cv_header_linux_netfilter_ipv4_h=yes \

--- a/net/squid/patches/020-fix-nettle-configure.patch
+++ b/net/squid/patches/020-fix-nettle-configure.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -1043,7 +1043,7 @@ AC_MSG_NOTICE([HTCP support enabled: $en
+ 
+ # Cryptograhic libraries
+ SQUID_AUTO_LIB(nettle,[Nettle crypto],[LIBNETTLE])
+-AS_IF(test "x$with_nettle" != "xno"],[
++AS_IF([test "x$with_nettle" != "xno"],[
+   SQUID_STATE_SAVE(squid_nettle_state)
+   PKG_CHECK_MODULES([LIBNETTLE],[nettle >= 3.4],[],[
+     CPPFLAGS="$LIBNETTLE_CFLAGS $CPPFLAGS"


### PR DESCRIPTION
Maintainer: @ratkaj
Run tested: ARMv7, Linksys WRT3200ACM, master branch

Description:
- Remove non-existing 'dlmalloc' option
- Use 'with-cap' instead of 'with-libcap'
- Use 'with-xml2' instead of 'with-libxml2'
- Patch configure.ac to properly handle 'with-nettle'

Fixes faillogs error:
```
Package squid is missing dependencies for the following libraries:
libcap.so.2
libnettle.so.8
libxml2.so.2
```