### PR TITLE
net-snmp: update to 5.9.4

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
-PKG_VERSION:=5.9.1
-PKG_RELEASE:=7
+PKG_VERSION:=5.9.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp
-PKG_HASH:=eb7fd4a44de6cddbffd9a92a85ad1309e5c1054fb9d5a7dd93079c8953f48c3f
+PKG_HASH:=8b4de01391e74e3c7014beb43961a2d6d6fa03acc34280b9585f4930745b0544
 PKG_MAINTAINER:=Stijn Tintel <stijn@linux-ipv6.be>
 PKG_LICENSE:=MIT BSD-3-Clause-Clear
 PKG_CPE_ID:=cpe:/a:net-snmp:net-snmp
@@ -148,7 +148,7 @@ SNMP_MIB_MODULES_INCLUDED = \
 	snmpv3/usmStats \
 	snmpv3/usmUser \
 	tunnel \
-	ucd-snmp/disk \
+	ucd-snmp/disk_hw \
 	ucd-snmp/dlmod \
 	ucd-snmp/extensible \
 	ucd-snmp/loadave \

--- a/net/net-snmp/patches/000-cross-compile.patch
+++ b/net/net-snmp/patches/000-cross-compile.patch
@@ -15,11 +15,11 @@ link tests to fail due to a stray "no" word getting passed to the linker.
 Signed-off-by: Jo-Philipp Wich <jo@mein.io>
 --- a/configure.d/config_os_libs2
 +++ b/configure.d/config_os_libs2
-@@ -247,14 +247,22 @@ if test "x$with_nl" != "xno"; then
-         )
- 
+@@ -252,14 +252,22 @@ if test "x$with_nl" != "xno"; then
+     case $target_os in
+     linux*) # Check for libnl (linux)
          netsnmp_save_CPPFLAGS="$CPPFLAGS"
--        CPPFLAGS="${LIBNL3_CFLAGS} $CPPFLAGS"
+-        CPPFLAGS="${LIBNL3_CFLAGS} ${LIBNLROUTE3_CFLAGS} $CPPFLAGS"
 -        NETSNMP_SEARCH_LIBS(nl_connect, nl-3,
 -            [AC_CHECK_HEADERS(netlink/netlink.h)
 -            EXTERNAL_MIBGROUP_INCLUDES="$EXTERNAL_MIBGROUP_INCLUDES ${LIBNL3_CFLAGS}"],

--- a/net/net-snmp/patches/010-HOST-MIB-hr_filesys-fix-compile-error.patch
+++ b/net/net-snmp/patches/010-HOST-MIB-hr_filesys-fix-compile-error.patch
@@ -29,6 +29,6 @@ Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>
  {
 -next:
 +next: ;
- #if HAVE_GETFSSTAT
+ #ifdef HAVE_GETFSSTAT
      if (HRFS_index >= fscount)
          return -1;

--- a/net/net-snmp/patches/100-debian-statistics.patch
+++ b/net/net-snmp/patches/100-debian-statistics.patch
@@ -1,22 +1,13 @@
 --- a/agent/mibgroup/mibII/interfaces.c
 +++ b/agent/mibgroup/mibII/interfaces.c
-@@ -1579,6 +1579,10 @@ Interface_Scan_Init(void)
-         struct ifnet   *nnew;
+@@ -1586,6 +1586,10 @@ Interface_Scan_Init(void)
          char           *stats, *ifstart = line;
+         size_t          len;
  
 +	/* Ignore interfaces with no statistics. */
 +	if (strstr(line, "No statistics available."))
-+	    continue;
++	continue;
 +
-         if (line[strlen(line) - 1] == '\n')
-             line[strlen(line) - 1] = '\0';
- 
-@@ -1611,7 +1615,7 @@ Interface_Scan_Init(void)
-                                                &coll) != 5)) {
-             if ((scan_line_to_use == scan_line_2_2)
-                 && !strstr(line, "No statistics available"))
--                snmp_log(LOG_ERR,
-+                snmp_log(LOG_DEBUG,
-                          "/proc/net/dev data format error, line ==|%s|",
-                          line);
-             continue;
+         len = strlen(line);
+         if (len && line[len - 1] == '\n')
+             line[len - 1] = '\0';

--- a/net/net-snmp/patches/160-no_ldconfig.patch
+++ b/net/net-snmp/patches/160-no_ldconfig.patch
@@ -1,6 +1,6 @@
 --- a/configure
 +++ b/configure
-@@ -15602,7 +15602,7 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu
+@@ -16599,7 +16599,7 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu
    need_version=no
    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
    soname_spec='$libname$release$shared_ext$major'

--- a/net/net-snmp/patches/161-project_types.patch
+++ b/net/net-snmp/patches/161-project_types.patch
@@ -1,0 +1,11 @@
+--- a/configure.d/config_project_types
++++ b/configure.d/config_project_types
+@@ -66,7 +66,7 @@ netsnmp_save_CFLAGS=$CFLAGS
+ CFLAGS="$CFLAGS -Werror"
+ 
+ AC_MSG_CHECKING([for the type of fd_set::fds_bits])
+-for type in __fd_mask __int32_t unknown; do
++for type in __fd_mask __int32_t u_int32_t; do
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+ #include <sys/select.h>
+ #include <stddef.h>

--- a/net/net-snmp/patches/170-ldflags.patch
+++ b/net/net-snmp/patches/170-ldflags.patch
@@ -1,11 +1,11 @@
 --- a/Makefile.top
 +++ b/Makefile.top
-@@ -87,7 +87,7 @@ LIBCURRENT  = 41
- LIBAGE      = 1
- LIBREVISION = 0
+@@ -87,7 +87,7 @@ LIBCURRENT  = 42
+ LIBAGE      = 2
+ LIBREVISION = 1
  
--LIB_LD_CMD      = $(LIBTOOL) --mode=link $(LINKCC) $(CFLAGS) -rpath $(libdir) -version-info $(LIBCURRENT):$(LIBREVISION):$(LIBAGE) -o
-+LIB_LD_CMD      = $(LIBTOOL) --mode=link $(LINKCC) $(CFLAGS) -rpath $(libdir) $(LDFLAGS) -version-info $(LIBCURRENT):$(LIBREVISION):$(LIBAGE) -o
+-LIB_LD_CMD      = $(LIBTOOL) --mode=link $(LINKCC) $(CFLAGS) -rpath $(libdir) -version-info $(LIBCURRENT):$(LIBREVISION):$(LIBAGE) @LD_NO_UNDEFINED@ -o
++LIB_LD_CMD      = $(LIBTOOL) --mode=link $(LINKCC) $(CFLAGS) -rpath $(libdir) $(LDFLAGS) -version-info $(LIBCURRENT):$(LIBREVISION):$(LIBAGE) @LD_NO_UNDEFINED@ -o
  LIB_EXTENSION   = la
  LIB_VERSION     =
  LIB_LDCONFIG_CMD = $(LIBTOOL) --mode=finish $(INSTALL_PREFIX)$(libdir)

--- a/net/net-snmp/patches/200-add-pcre2-support.patch
+++ b/net/net-snmp/patches/200-add-pcre2-support.patch
@@ -22,7 +22,7 @@ Subject: [PATCH] add pcre2 support
  #include "swrun.h"
  #include "swrun_private.h"
  
--#if HAVE_PCRE_H
+-#ifdef HAVE_PCRE_H
 +#if defined(HAVE_PCRE2_H)
 +#define PCRE2_CODE_UNIT_WIDTH 8
 +#include <pcre2.h>
@@ -34,7 +34,7 @@ Subject: [PATCH] add pcre2 support
  #endif /* NETSNMP_FEATURE_REMOVE_SWRUN_MAX_PROCESSES */
  
  #ifndef NETSNMP_FEATURE_REMOVE_SWRUN_COUNT_PROCESSES_BY_REGEX
--#if HAVE_PCRE_H
+-#ifdef HAVE_PCRE_H
 +#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
  int
  swrun_count_processes_by_regex( char *name, netsnmp_regex_ptr regexp )
@@ -47,7 +47,7 @@ Subject: [PATCH] add pcre2 support
 +    int *found_ndx;
 +    ndx_match = pcre2_match_data_create(30, NULL);
 +    found_ndx = pcre2_get_ovector_pointer(ndx_match);
-+#elif HAVE_PCRE_H
++#elif defined(HAVE_PCRE_H)
      int found_ndx[30];
 +#endif
      int found;
@@ -91,20 +91,20 @@ Subject: [PATCH] add pcre2 support
  #include "if-mib/ifTable/ifTable.h"
  #include "if-mib/data_access/interface.h"
  #include "interface_private.h"
--#if HAVE_PCRE_H
+-#if defined(HAVE_PCRE_H)
 +
 +#if defined(HAVE_PCRE2_H)
 +#define PCRE2_CODE_UNIT_WIDTH 8
 +#include <pcre2.h>
 +#elif defined(HAVE_PCRE_H)
  #include <pcre.h>
- #elif HAVE_REGEX_H
+ #elif defined(HAVE_REGEX_H)
  #include <sys/types.h>
-@@ -840,7 +844,13 @@ int netsnmp_access_interface_max_reached
+@@ -824,7 +828,13 @@ int netsnmp_access_interface_max_reached
  int netsnmp_access_interface_include(const char *name)
  {
      netsnmp_include_if_list *if_ptr;
--#if HAVE_PCRE_H
+-#ifdef HAVE_PCRE_H
 +#if defined(HAVE_PCRE2_H) 
 +    //pcre_exec->pcre2_match
 +    //ovector->pcre2_match_data
@@ -115,11 +115,11 @@ Subject: [PATCH] add pcre2 support
      int                      found_ndx[3];
  #endif
  
-@@ -856,7 +866,13 @@ int netsnmp_access_interface_include(con
+@@ -840,7 +850,13 @@ int netsnmp_access_interface_include(con
  
  
      for (if_ptr = include_list; if_ptr; if_ptr = if_ptr->next) {
--#if HAVE_PCRE_H
+-#if defined(HAVE_PCRE_H)
 +#if defined(HAVE_PCRE2_H)
 +        if (pcre2_match(if_ptr->regex_ptr, name, strlen(name), 0, 0, 
 +                                ndx_match, NULL) >= 0)  {
@@ -130,7 +130,7 @@ Subject: [PATCH] add pcre2 support
          if (pcre_exec(if_ptr->regex_ptr, NULL, name, strlen(name), 0, 0,
                        found_ndx, 3) >= 0)
              return TRUE;
-@@ -869,6 +885,9 @@ int netsnmp_access_interface_include(con
+@@ -853,6 +869,9 @@ int netsnmp_access_interface_include(con
  #endif
      }
  
@@ -140,11 +140,11 @@ Subject: [PATCH] add pcre2 support
      return FALSE;
  }
  
-@@ -980,7 +999,13 @@ _parse_include_if_config(const char *tok
+@@ -964,7 +983,13 @@ _parse_include_if_config(const char *tok
  {
      netsnmp_include_if_list *if_ptr, *if_new;
      char                    *name, *st;
--#if HAVE_PCRE_H
+-#if defined(HAVE_PCRE_H)
 +#if defined(HAVE_PCRE2_H)
 +    //we can only get the message upon calling pcre2_error_message.
 +    // so an additional variable is required.
@@ -154,12 +154,12 @@ Subject: [PATCH] add pcre2 support
 +#elif defined(HAVE_PCRE_H)
      const char              *pcre_error;
      int                     pcre_error_offset;
- #elif HAVE_REGEX_H
-@@ -1012,7 +1037,15 @@ _parse_include_if_config(const char *tok
+ #elif defined(HAVE_REGEX_H)
+@@ -996,7 +1021,15 @@ _parse_include_if_config(const char *tok
              config_perror("Out of memory");
              goto err;
          }
--#if HAVE_PCRE_H
+-#if defined(HAVE_PCRE_H)
 +#if defined(HAVE_PCRE2_H)
 +        if_new->regex_ptr = pcre2_compile(if_new->name, PCRE2_ZERO_TERMINATED, 0,
 +                         &pcre2_err_code, &pcre2_error_offset, NULL);
@@ -172,7 +172,7 @@ Subject: [PATCH] add pcre2 support
          if_new->regex_ptr = pcre_compile(if_new->name, 0,  &pcre_error,
                                           &pcre_error_offset, NULL);
          if (!if_new->regex_ptr) {
-@@ -1048,7 +1081,7 @@ _parse_include_if_config(const char *tok
+@@ -1032,7 +1065,7 @@ _parse_include_if_config(const char *tok
  
  err:
      if (if_new) {
@@ -181,14 +181,14 @@ Subject: [PATCH] add pcre2 support
          free(if_new->regex_ptr);
  #endif
          free(if_new->name);
-@@ -1063,7 +1096,7 @@ _free_include_if_config(void)
+@@ -1047,7 +1080,7 @@ _free_include_if_config(void)
  
      while (if_ptr) {
          if_next = if_ptr->next;
--#if HAVE_PCRE_H
+-#if defined(HAVE_PCRE_H)
 +#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
          free(if_ptr->regex_ptr);
- #elif HAVE_REGEX_H
+ #elif defined(HAVE_REGEX_H)
          regfree(if_ptr->regex_ptr);
 --- a/agent/mibgroup/struct.h
 +++ b/agent/mibgroup/struct.h
@@ -196,7 +196,7 @@ Subject: [PATCH] add pcre2 support
  
  struct myproc {
      char            name[STRMAX];
--#if HAVE_PCRE_H
+-#ifdef HAVE_PCRE_H
 +#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
      netsnmp_regex_ptr regexp;
  #endif
@@ -207,11 +207,11 @@ Subject: [PATCH] add pcre2 support
  #  include <time.h>
  # endif
  #endif
--#if HAVE_PCRE_H
+-#ifdef HAVE_PCRE_H
 +#ifdef HAVE_PCRE2_H
 +#define PCRE2_CODE_UNIT_WIDTH 8
 +#include <pcre2.h>
-+#elif HAVE_PCRE_H
++#elifdef HAVE_PCRE_H
  #include <pcre.h>
  #endif
  
@@ -228,7 +228,7 @@ Subject: [PATCH] add pcre2 support
      for (ptmp = procwatch; ptmp != NULL;) {
          ptmp2 = ptmp;
          ptmp = ptmp->next;
--#if HAVE_PCRE_H
+-#ifdef HAVE_PCRE_H
 +#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
          free(ptmp2->regexp.regex_ptr);
  #endif
@@ -237,7 +237,7 @@ Subject: [PATCH] add pcre2 support
      if (*procp == NULL)
          return;                 /* memory alloc error */
      numprocs++;
--#if HAVE_PCRE_H
+-#ifdef HAVE_PCRE_H
 +#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
      (*procp)->regexp.regex_ptr = NULL;
  #endif
@@ -246,7 +246,7 @@ Subject: [PATCH] add pcre2 support
          cptr = skip_not_white(cptr);
          if ((cptr = skip_white(cptr))) {
              (*procp)->min = atoi(cptr);
--#if HAVE_PCRE_H
+-#ifdef HAVE_PCRE_H
 +#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
              cptr = skip_not_white(cptr);
              if ((cptr = skip_white(cptr))) {
@@ -262,7 +262,7 @@ Subject: [PATCH] add pcre2 support
 +                if ((*procp)->regexp.regex_ptr == NULL) {
 +                    config_perror(pcre2_error_msg);
 +                }
-+#elif HAVE_PCRE_H
++#elifdef HAVE_PCRE_H
                  const char *pcre_error;
                  int pcre_error_offset;
  
@@ -289,14 +289,14 @@ Subject: [PATCH] add pcre2 support
    return swrun_count_processes_by_name( procname );
  }
  
--#if HAVE_PCRE_H
+-#ifdef HAVE_PCRE_H
 +#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
  netsnmp_feature_require(swrun_count_processes_by_regex);
  int
  sh_count_procs_by_regex(char *procname, netsnmp_regex_ptr regexp)
 --- a/agent/mibgroup/ucd-snmp/proc.h
 +++ b/agent/mibgroup/ucd-snmp/proc.h
-@@ -12,7 +12,7 @@ config_require(util_funcs)
+@@ -12,7 +12,7 @@ config_require(util_funcs);
       extern WriteMethod fixProcError;
       int sh_count_myprocs(struct myproc *);
       int             sh_count_procs(char *);
@@ -340,10 +340,10 @@ Subject: [PATCH] add pcre2 support
  if test "x$with_pcre" != "xno"; then
    AC_CHECK_HEADER([pcre.h], [
        AC_DEFINE([HAVE_PCRE_H], [1], [Define to 1 if you have <pcre.h>.])
-@@ -121,3 +147,4 @@ NETSNMP_SEARCH_LIBS([pcre_exec], [pcre],
-   ],,, LAGENTLIBS)
- AC_SUBST(LAGENTLIBS)
- AC_SUBST(LMIBLIBS)
+@@ -123,3 +149,4 @@ if test "x$with_pcre" != "xno"; then
+   AC_SUBST(LAGENTLIBS)
+   AC_SUBST(LMIBLIBS)
+ fi
 +fi
 --- a/configure.d/config_project_with_enable
 +++ b/configure.d/config_project_with_enable
@@ -364,24 +364,24 @@ Subject: [PATCH] add pcre2 support
  extern          "C" {
  #endif
  
--#if HAVE_PCRE_H
+-#if defined(HAVE_PCRE_H)
 +#if defined(HAVE_PCRE2_H)
 +#define PCRE2_CODE_UNIT_WIDTH 8
 +#include <pcre2.h>
 +#elif defined(HAVE_PCRE_H)
  #include <pcre.h>
- #elif HAVE_REGEX_H
+ #elif defined(HAVE_REGEX_H)
  #include <regex.h>
 @@ -211,7 +214,9 @@ typedef struct _conf_if_list {
      typedef netsnmp_conf_if_list conf_if_list; /* backwards compat */
  
  typedef struct _include_if_list {
--#if HAVE_PCRE_H
+-#if defined(HAVE_PCRE_H)
 +#if defined(HAVE_PCRE2_H)
 +    pcre2_code              *regex_ptr;
 +#elif defined(HAVE_PCRE_H)
      pcre                    *regex_ptr;
- #elif HAVE_REGEX_H
+ #elif defined(HAVE_REGEX_H)
      regex_t                 *regex_ptr;
 --- a/include/net-snmp/data_access/swrun.h
 +++ b/include/net-snmp/data_access/swrun.h

--- a/net/net-snmp/patches/201-Run-autoreconf.patch
+++ b/net/net-snmp/patches/201-Run-autoreconf.patch
@@ -10,7 +10,7 @@ Subject: [PATCH] Run autoreconf
 
 --- a/configure
 +++ b/configure
-@@ -898,6 +898,8 @@ with_dnssec
+@@ -928,6 +928,8 @@ with_dnssec
  enable_dnssec
  with_rpm
  enable_rpm
@@ -19,7 +19,7 @@ Subject: [PATCH] Run autoreconf
  with_pcre
  enable_pcre
  with_install_prefix
-@@ -1810,6 +1812,8 @@ Compiler Options:
+@@ -1851,6 +1853,8 @@ Compiler Options:
    --without-rpm                   Don't include support for the RPM package
                                    management system when building the host MIB
                                    module.
@@ -28,7 +28,7 @@ Subject: [PATCH] Run autoreconf
    --without-pcre                  Don't include pcre process searching
                                    support in the agent.
    --with-install-prefix=PATH      Just for installing, prefix all
-@@ -4907,6 +4911,21 @@ fi
+@@ -5259,6 +5263,21 @@ fi
  
  
  
@@ -49,8 +49,8 @@ Subject: [PATCH] Run autoreconf
 +
  
  # Check whether --with-pcre was given.
- if test "${with_pcre+set}" = set; then :
-@@ -22321,6 +22340,112 @@ LIBS="$netsnmp_save_LIBS"
+ if test ${with_pcre+y}
+@@ -26477,6 +26496,112 @@ LIBS="$netsnmp_save_LIBS"
  #
  #   regex in process table
  #
@@ -161,9 +161,9 @@ Subject: [PATCH] Run autoreconf
 +if test "x$with_pcre2" != "xyes"; then
 +
  if test "x$with_pcre" != "xno"; then
-   ac_fn_c_check_header_mongrel "$LINENO" "pcre.h" "ac_cv_header_pcre_h" "$ac_includes_default"
- if test "x$ac_cv_header_pcre_h" = xyes; then :
-@@ -25886,6 +26011,7 @@ done
+   ac_fn_c_check_header_compile "$LINENO" "pcre.h" "ac_cv_header_pcre_h" "$ac_includes_default"
+ if test "x$ac_cv_header_pcre_h" = xyes
+@@ -31486,6 +31611,7 @@ printf "%s\n" "#define pid_t $ac_pid_typ
  
  
  fi
@@ -173,7 +173,7 @@ Subject: [PATCH] Run autoreconf
  
 --- a/include/net-snmp/net-snmp-config.h.in
 +++ b/include/net-snmp/net-snmp-config.h.in
-@@ -722,6 +722,9 @@
+@@ -727,6 +727,9 @@
  /* Define to 1 if you have the <pci/pci.h> header file. */
  #undef HAVE_PCI_PCI_H
  

--- a/net/net-snmp/patches/202-Improve-pcre2-support.patch
+++ b/net/net-snmp/patches/202-Improve-pcre2-support.patch
@@ -22,7 +22,7 @@ declarations occur before statements.
 -    ndx_match = pcre2_match_data_create(30, NULL);
 -    found_ndx = pcre2_get_ovector_pointer(ndx_match);
 +    pcre2_match_data *ndx_match = pcre2_match_data_create(30, NULL);
- #elif HAVE_PCRE_H
+ #elif defined(HAVE_PCRE_H)
      int found_ndx[30];
  #endif
 @@ -122,22 +119,20 @@ swrun_count_processes_by_regex( char *na
@@ -55,7 +55,7 @@ declarations occur before statements.
  #endif
 --- a/agent/mibgroup/if-mib/data_access/interface.c
 +++ b/agent/mibgroup/if-mib/data_access/interface.c
-@@ -844,12 +844,8 @@ int netsnmp_access_interface_max_reached
+@@ -828,12 +828,8 @@ int netsnmp_access_interface_max_reached
  int netsnmp_access_interface_include(const char *name)
  {
      netsnmp_include_if_list *if_ptr;
@@ -70,7 +70,7 @@ declarations occur before statements.
  #elif defined(HAVE_PCRE_H)
      int                      found_ndx[3];
  #endif
-@@ -867,8 +863,8 @@ int netsnmp_access_interface_include(con
+@@ -851,8 +847,8 @@ int netsnmp_access_interface_include(con
  
      for (if_ptr = include_list; if_ptr; if_ptr = if_ptr->next) {
  #if defined(HAVE_PCRE2_H)
@@ -81,7 +81,7 @@ declarations occur before statements.
                  pcre2_match_data_free(ndx_match);
                  return TRUE;
          }
-@@ -1000,11 +996,13 @@ _parse_include_if_config(const char *tok
+@@ -984,11 +980,13 @@ _parse_include_if_config(const char *tok
      netsnmp_include_if_list *if_ptr, *if_new;
      char                    *name, *st;
  #if defined(HAVE_PCRE2_H)
@@ -99,7 +99,7 @@ declarations occur before statements.
  #elif defined(HAVE_PCRE_H)
      const char              *pcre_error;
      int                     pcre_error_offset;
-@@ -1038,10 +1036,14 @@ _parse_include_if_config(const char *tok
+@@ -1022,10 +1020,14 @@ _parse_include_if_config(const char *tok
              goto err;
          }
  #if defined(HAVE_PCRE2_H)

--- a/net/net-snmp/patches/203-if-mib-data_access-interface.c-plug-a-leak-with-pcre.patch
+++ b/net/net-snmp/patches/203-if-mib-data_access-interface.c-plug-a-leak-with-pcre.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] if-mib/data_access/interface.c: plug a leak with pcre2
 
 --- a/agent/mibgroup/if-mib/data_access/interface.c
 +++ b/agent/mibgroup/if-mib/data_access/interface.c
-@@ -845,7 +845,7 @@ int netsnmp_access_interface_include(con
+@@ -829,7 +829,7 @@ int netsnmp_access_interface_include(con
  {
      netsnmp_include_if_list *if_ptr;
  #if defined(HAVE_PCRE2_H)
@@ -18,7 +18,7 @@ Subject: [PATCH] if-mib/data_access/interface.c: plug a leak with pcre2
  #elif defined(HAVE_PCRE_H)
      int                      found_ndx[3];
  #endif
-@@ -860,6 +860,9 @@ int netsnmp_access_interface_include(con
+@@ -844,6 +844,9 @@ int netsnmp_access_interface_include(con
           */
          return TRUE;
  

--- a/net/net-snmp/patches/990-remove-semicolon-check-in-macros.patch
+++ b/net/net-snmp/patches/990-remove-semicolon-check-in-macros.patch
@@ -1,0 +1,130 @@
+--- a/configure.d/config_modules_agent
++++ b/configure.d/config_modules_agent
+@@ -27,8 +27,6 @@ done
+ #
+ AC_MSG_CHECKING([for and configuring mib modules to use])
+ 
+-AH_TOP([#define NETSNMP_REQUIRE_SEMICOLON extern void netsnmp_unused_function(void)])
+-
+ # set up the CPP command
+ MODULECPP="$CPP $PARTIALTARGETFLAGS $CPPFLAGS -DNETSNMP_FEATURE_CHECKING -I${srcdir}/include -I${srcdir}/agent/mibgroup"
+ if test "x$enable_mfd_rewrites" = "xyes"; then
+@@ -194,7 +192,7 @@ while test "x$new_module_list" != "x"; d
+     #     - mib_module   => libnetsnmpmibs   (default)
+     #     - agent_module => libnetsnmpagent
+     #
+-    AH_TOP([#define config_belongs_in(x) NETSNMP_REQUIRE_SEMICOLON])
++    AH_TOP([#define config_belongs_in(x)])
+     module_type=mib_module
+     if test -f $srcdir/$mibdir/$i.h; then
+       changequote(, )
+@@ -279,7 +277,7 @@ while test "x$new_module_list" != "x"; d
+       	#
+         # check if $i has any conflicts
+         #
+-        AH_TOP([#define config_exclude(x) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_exclude(x)])
+         new_list_excl=`$MODULECPP module_tmp_header.h | \
+                        $SED -n 's/.*config_exclude(\(.*\)).*/\1/p'`
+ 	if test "x$new_list_excl" != "x"; then
+@@ -308,7 +306,7 @@ while test "x$new_module_list" != "x"; d
+         #
+         # check if $i has any architecture specific requirements
+         #
+-        AH_TOP([#define config_arch_require(x,y) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_arch_require(x,y)])
+         changequote(, )
+         new_list_arch=`$MODULECPP module_tmp_header.h | \
+                        $SED -n 's/.*config_arch_require( *\([^ ]*\) *, *\([^ ]*\) *).*/\1-xarchx-\2/p'`
+@@ -330,7 +328,7 @@ while test "x$new_module_list" != "x"; d
+       	# macro: config_version_require((base, version, version-modules, ...))
+       	#  - lists alternative modules used from different versions.
+         #
+-        AH_TOP([#define config_version_require(x) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_version_require(x)])
+         [new_list_alt3=`$MODULECPP module_tmp_header.h | \
+             $AWK '
+                 BEGIN {
+@@ -372,7 +370,7 @@ while test "x$new_module_list" != "x"; d
+         #
+         # check if $i has any other required modules
+         #
+-        AH_TOP([#define config_require(x) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_require(x)])
+         new_list="$new_list `$MODULECPP module_tmp_header.h | \
+                   $SED -n 's/.*config_require(\(.*\)).*/\1/p'`"
+         AC_MSG_MODULE_DBG(" $i will test: $new_list")
+@@ -409,7 +407,7 @@ while test "x$new_module_list" != "x"; d
+         #
+         # check if $i has any mibs to add
+         #
+-        AH_TOP([#define config_add_mib(x) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_add_mib(x)])
+         new_mibs=`$MODULECPP module_tmp_header.h | \
+                   $SED -n 's/.*config_add_mib(\(.*\)).*/\1/p'`
+ 	if test "x$new_mibs" != "x"; then
+@@ -456,7 +454,7 @@ while test "x$new_module_list" != "x"; d
+         # check for config_parse_dot_conf
+         #  (generally not used any longer; old auto-load a .conf token)
+         #
+-        AH_TOP([#define config_parse_dot_conf(w,x,y,z) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_parse_dot_conf(w,x,y,z)])
+         changequote(, )
+         $MODULECPP module_tmp_header.h | \
+         $SED -n 's@.*config_parse_dot_conf(\([^)]*\), *\([^),]*\), *\([^),]*\), *\([^),]*\)).*@register_config_handler("snmpd",\1, \2, \3, \4);@p' >> $mibdir/mib_module_dot_conf.h
+@@ -468,7 +466,7 @@ while test "x$new_module_list" != "x"; d
+         #
+         # check if $i has any errors, or warnings
+         #
+-        AH_TOP([#define config_error(x) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_error(x)])
+         error=`$MODULECPP module_tmp_header.h | \
+                $SED -n 's/.*config_error(\(.*\)).*/\1/p'`
+ 	if test "x$error" != "x"; then
+@@ -481,7 +479,7 @@ while test "x$new_module_list" != "x"; d
+       	# macro: config_warning(warning text)
+       	#  - used to signal a configuration "warning" to be printed to the user
+         #
+-        AH_TOP([#define config_warning(x) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_warning(x)])
+         warning=`$MODULECPP module_tmp_header.h | \
+                  $SED -n 's/.*config_warning(\(.*\)).*/\1/p'`
+ 	if test "x$warning" != "x"; then
+--- a/include/net-snmp/net-snmp-config.h.in
++++ b/include/net-snmp/net-snmp-config.h.in
+@@ -36,25 +36,25 @@
+ 
+ /* definitions added by configure on-the-fly */
+ 
+-#define config_parse_dot_conf(w,x,y,z) NETSNMP_REQUIRE_SEMICOLON
++#define config_parse_dot_conf(w,x,y,z)
+ 
+-#define config_error(x) NETSNMP_REQUIRE_SEMICOLON
++#define config_error(x)
+ 
+-#define config_warning(x) NETSNMP_REQUIRE_SEMICOLON
++#define config_warning(x)
+ 
+-#define NETSNMP_REQUIRE_SEMICOLON extern void netsnmp_unused_function(void)
++#define extern void netsnmp_unused_function(void)
+ 
+-#define config_belongs_in(x) NETSNMP_REQUIRE_SEMICOLON
++#define config_belongs_in(x)
+ 
+-#define config_exclude(x) NETSNMP_REQUIRE_SEMICOLON
++#define config_exclude(x)
+ 
+-#define config_arch_require(x,y) NETSNMP_REQUIRE_SEMICOLON
++#define config_arch_require(x,y)
+ 
+-#define config_version_require(x) NETSNMP_REQUIRE_SEMICOLON
++#define config_version_require(x)
+ 
+-#define config_require(x) NETSNMP_REQUIRE_SEMICOLON
++#define config_require(x)
+ 
+-#define config_add_mib(x) NETSNMP_REQUIRE_SEMICOLON
++#define config_add_mib(x)
+ 
+ /* Define to 1 if using 'alloca.c'. */
+ #undef C_ALLOCA


### PR DESCRIPTION
Maintainer: @stintel 
Compile tested: ramips/mt7621, ramips/mt76x8, ath79
Run tested: xiaomi mi router 3 pro, keenetic extra II, tp-link tl-wdr4300

Adjust patches for current version changes
Module "disk" renamed to "disk_hw"
Internal type "unknown" changed to "u_int32_t"
Add patch with removing macro syntax checking for successful build
