### PR TITLE
openconnect: make host dependency more resilient

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=9.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.infradead.org/openconnect/download


### PR DESCRIPTION
Retry when resolveip fails as it seems to be causing issues on startup depending on various unpredictable parameters.

Resolves: 23185

Maintainer: me
Compile tested: N/A
Run tested: N/A

Description:
Retry when resolveip fails as it seems to be causing issues on startup depending on various unpredictable parameters.
