### PR TITLE
Bump iodine 0.8.0

### DIFF
--- a/net/iodine/Makefile
+++ b/net/iodine/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iodine
-PKG_VERSION:=0.7.0
+PKG_VERSION:=0.8.0
 PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://code.kryo.se/iodine/
-PKG_HASH:=ad2b40acf1421316ec15800dcde0f587ab31d7d6f891fa8b9967c4ded93c013e
+PKG_HASH:=546e92cf8617f7970ea81c850b1063eb189c68c406d0c6a67e02c55e72e714c6
 
 PKG_MAINTAINER:=Uwe Kleine-König <uwe+openwrt@kleine-koenig.org>
 PKG_LICENSE:=ISC

--- a/net/iodine/patches/010-cross-compile.patch
+++ b/net/iodine/patches/010-cross-compile.patch
@@ -1,24 +1,26 @@
 --- a/src/osflags
 +++ b/src/osflags
-@@ -16,12 +16,6 @@ link)
+@@ -18,13 +18,6 @@ link)
  		windows32)
  			echo '-lws2_32 -liphlpapi';
  		;;
 -		Linux)
 -			FLAGS="";
 -			[ -e /usr/include/selinux/selinux.h ] && FLAGS="$FLAGS -lselinux";
--			[ -e /usr/include/systemd/sd-daemon.h ] && FLAGS="$FLAGS -lsystemd-daemon";
+-			"$PKG_CONFIG" --exists libsystemd-daemon && FLAGS="$FLAGS $($PKG_CONFIG --libs libsystemd-daemon)";
+-			"$PKG_CONFIG" --exists libsystemd && FLAGS="$FLAGS $($PKG_CONFIG --libs libsystemd)";
 -			echo $FLAGS;
 -		;;
  	esac
  	;;
  cflags)
-@@ -34,8 +28,6 @@ cflags)
+@@ -40,9 +33,6 @@ cflags)
  		;;
  		Linux)
  			FLAGS="-D_GNU_SOURCE"
 -			[ -e /usr/include/selinux/selinux.h ] && FLAGS="$FLAGS -DHAVE_SETCON";
--			[ -e /usr/include/systemd/sd-daemon.h ] && FLAGS="$FLAGS -DHAVE_SYSTEMD";
+-			"$PKG_CONFIG" --exists libsystemd-daemon && FLAGS="$FLAGS -DHAVE_SYSTEMD";
+-			"$PKG_CONFIG" --exists libsystemd && FLAGS="$FLAGS -DHAVE_SYSTEMD";
  			echo $FLAGS;
  		;;
- 	esac
+ 		GNU/kFreeBSD|GNU)

--- a/net/iodine/patches/101-musl-workaround-incomplete-nameser-h.patch
+++ b/net/iodine/patches/101-musl-workaround-incomplete-nameser-h.patch
@@ -16,12 +16,12 @@ http://www.openwall.com/lists/musl/2017/12/04/3
 
 --- a/src/osflags
 +++ b/src/osflags
-@@ -27,7 +27,7 @@ cflags)
- 			echo '-Dsocklen_t=int';
+@@ -32,7 +32,7 @@ cflags)
+ 			echo '-D__APPLE_USE_RFC_3542';
  		;;
  		Linux)
 -			FLAGS="-D_GNU_SOURCE"
 +			FLAGS="-D_GNU_SOURCE -include endian.h"
  			echo $FLAGS;
  		;;
- 	esac
+ 		GNU/kFreeBSD|GNU)


### PR DESCRIPTION
Maintainer: me / @jow- / @svlobanov / @neheb / @ja-pa / @champtar / @mstorchak
Compile tested: `IPQ40XX` `AVM FRITZ!Box 7520/7530` `23.05.2`
Run tested: `IPQ40XX` `AVM FRITZ!Box 7520/7530` `23.05.2` `server start`+`client connect`

Description:
`v0.8.0` release [implements IPv6 support](https://github.com/yarrick/iodine/compare/v0.7.0...v0.8.0).

