### PR TITLE
tgt: update to 1.0.90

### DIFF
--- a/net/tgt/Makefile
+++ b/net/tgt/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tgt
-PKG_VERSION:=1.0.89
+PKG_VERSION:=1.0.90
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fujita/tgt/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=cd09daffacc00a6641a7b95d31c43441656ce0b01af8d512359bc91bac3c6d99
+PKG_HASH:=e832a19c2831bde83e7078cd7a8d2fc8fe5c5f38ddd51130f5123013416d4cff
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-2.0-only

--- a/net/tgt/patches/100-musl-compat.patch
+++ b/net/tgt/patches/100-musl-compat.patch
@@ -13,9 +13,9 @@
  #define NR_SCSI_OPCODES		256
 --- a/usr/util.h
 +++ b/usr/util.h
-@@ -16,6 +16,10 @@
- #include <limits.h>
- #include <linux/types.h>
+@@ -20,6 +20,10 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
  
 +#ifndef __WORDSIZE
 +#include <sys/reg.h>


### PR DESCRIPTION
Maintainer: me
Compile tested: r25115+3-7181eb9f81, qualcommax/ipq807x
Run tested: r25115+3-7181eb9f81, qualcommax/ipq807x in a chroot on r23300+3-86bc525d00, exporting a file as a lun works

Description:
- update to 1.0.90
- refresh patches