### PR TITLE
attr: update to 2.5.2

### DIFF
--- a/utils/attr/Makefile
+++ b/utils/attr/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=attr
-PKG_VERSION:=2.5.1
+PKG_VERSION:=2.5.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://git.savannah.nongnu.org/cgit/attr.git/snapshot
-PKG_HASH:=69991b2fc5fe7917d996b05d5d4fe3c44d074c9d806dd263b14a42fab57bfc2f
+PKG_HASH:=b266cf45e2256b4d85a86554b42c0218abce40356f5c3026f88e15dcf73df775
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_CPE_ID:=cpe:/a:attr_project:attr

--- a/utils/attr/patches/100-no-gettext_configure.patch
+++ b/utils/attr/patches/100-no-gettext_configure.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -35,9 +35,6 @@ AC_SYS_LARGEFILE
+@@ -37,9 +37,6 @@ AC_SYS_LARGEFILE
  AM_PROG_AR
  LT_INIT
  
@@ -10,7 +10,7 @@
  AC_ARG_ENABLE([debug],
  	[AS_HELP_STRING([--enable-debug], [Enable extra debugging])])
  AS_IF([test "x$enable_debug" = "xyes"],
-@@ -61,6 +58,5 @@ AC_CONFIG_COMMANDS([include/attr],
+@@ -65,6 +62,5 @@ AC_CONFIG_COMMANDS([include/attr],
  AC_CONFIG_FILES([
  	libattr.pc
  	Makefile

--- a/utils/attr/patches/101-no-gettext_autogen.patch
+++ b/utils/attr/patches/101-no-gettext_autogen.patch
@@ -1,7 +1,9 @@
 --- a/autogen.sh
 +++ b/autogen.sh
-@@ -1,4 +1,2 @@
+@@ -1,6 +1,4 @@
  #!/bin/sh -ex
 -po/update-potfiles
 -autopoint --force
+ am_libdir=$(automake --print-libdir)
+ cp "${am_libdir}/INSTALL" doc/
  exec autoreconf -f -i


### PR DESCRIPTION
Maintainer: me
Compile tested: r25115+3-7181eb9f81, qualcommax/ipq807x
Run tested: r25115+3-7181eb9f81, qualcommax/ipq807x in a chroot on r23300+3-86bc525d00, setfattr/getfattr works, rsync can copy xattrs

Description:
- update to 2.5.2
- refresh patches

