### PR TITLE
python-aiohttp: update to 3.9.3

### DIFF
--- a/lang/python/python-aiohttp/Makefile
+++ b/lang/python/python-aiohttp/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-aiohttp
-PKG_VERSION:=3.8.5
+PKG_VERSION:=3.9.3
 PKG_RELEASE:=1
 
 PYPI_NAME:=aiohttp
-PKG_HASH:=b9552ec52cc147dbf1944ac7ac98af7602e51ea2dcd076ed194ca3c0d1c7d0bc
+PKG_HASH:=90842933e5d1ff760fae6caca4b2b3edba53ba8f4b71e95dacf2818a2aca06f7
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Fixes CVE-2023-47627

Maintainer: @BKPepe 