### PR TITLE
python3: add python3-webbrowser package from python3-light

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 include ../python3-version.mk
 
 PKG_NAME:=python3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=$(PYTHON3_VERSION).$(PYTHON3_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -262,7 +262,6 @@ define Py3Package/python3-light/filespec
 -|/usr/lib/python$(PYTHON3_VERSION)/idlelib
 -|/usr/lib/python$(PYTHON3_VERSION)/tkinter
 -|/usr/lib/python$(PYTHON3_VERSION)/turtledemo
--|/usr/lib/python$(PYTHON3_VERSION)/webbrowser.py
 -|/usr/lib/python$(PYTHON3_VERSION)/_osx_support.py
 $(foreach lib_file,$(filter /usr/lib/python$(PYTHON3_VERSION)/%,$(PYTHON3_LIB_FILES_DEL)),
   -|$(lib_file)

--- a/lang/python/python3/files/python3-package-webbrowser.mk
+++ b/lang/python/python3/files/python3-package-webbrowser.mk
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2006-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Package/python3-webbrowser
+$(call Package/python3/Default)
+  TITLE:=Python $(PYTHON3_VERSION) Web-browser controller
+  DEPENDS:=+python3-light
+endef
+
+$(eval $(call Py3BasePackage,python3-webbrowser, \
+	/usr/lib/python$(PYTHON3_VERSION)/webbrowser.py \
+))


### PR DESCRIPTION
Maintainer: @jefferyto 
Compile tested: Ubuntu 23.04 x64 / OpenWrt SNAPSHOT @ 622340f6c10a492c03e6d0c0ee004da1c43270bc
Run tested: Linksys WRT32X / OpenWrt SNAPSHOT r24778-49e8f53298

Description:

python3: add python3-webbrowser package from python3-light so this can be installed if required as home assistant dependency

I attempted to revive #14198 before submitting this PR