### PR TITLE
redis: update to 6.2.14

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
-PKG_VERSION:=6.2.6
+PKG_VERSION:=6.2.14
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=http://download.redis.io/releases/
+PKG_SOURCE_URL:=https://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=5b2b8b7a50111ef395bf1c1d5be11e6e167ac018125055daa8b5c2317ae131ab
+PKG_HASH:=34e74856cbd66fdb3a684fb349d93961d8c7aa668b06f81fd93ff267d09bc277
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Fixes CVE-2022-24735 and CVE-2022-24736

Maintainer: @ja-pa 