### PR TITLE
zlog: update to 1.2.17

### DIFF
--- a/libs/zlog/Makefile
+++ b/libs/zlog/Makefile
@@ -1,31 +1,27 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zlog
-PKG_VERSION:=1.2.15
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/HardySimpson/$(PKG_NAME)/archive/refs/tags/$(PKG_VERSION).tar.gz?
-PKG_HASH:=00037ab8d52772a95d645f1dcfd2c292b7cea326b54e63e219a5b7fdcb7e6508
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/HardySimpson/zlog
+PKG_SOURCE_VERSION:=1.2.17
+PKG_MIRROR_HASH:=fcad107b91aa251c61b7409dfbae0421662154c4dc158c7a34ee2f69cde8f9a2
+
 PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:zlog_project:zlog
 
-PKG_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
-
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/zlog
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Pure C logging library
   URL:=http://hardysimpson.github.io/zlog/
-  LICENSE:=LGPL-2.1-or-later
-  LICENSE_FILES:=COPYING
 endef
-
-MAKE_FLAGS+= \
-	PREFIX="$(PKG_INSTALL_DIR)/usr"
 
 define Package/zlog/description
   zlog is a reliable, high-performance, thread safe, flexible, clear-model, pure C logging library.

--- a/libs/zlog/patches/010-cmake.patch
+++ b/libs/zlog/patches/010-cmake.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -25,7 +25,6 @@ SET(zlog_so_ver ${CPACK_PACKAGE_VERSION_
+ message(STATUS "plateform : ${CMAKE_SYSTEM}")
+ 
+ add_definitions("-g -Wall -Wstrict-prototypes")
+-set(CMAKE_C_FLAGS "-std=c99 -pedantic -D_DEFAULT_SOURCE")
+ set(CMAKE_C_FLAGS_DEBUG "-ggdb3 -DDEBUG")
+ set(CMAKE_C_FLAGS_RELEASE "-O2")
+ 


### PR DESCRIPTION
Rework to use local tarballs. Smaller and more stable.

Build with cmake. Faster and simpler. Needs a small patch though.

License was updated.

Fixes CVE-2021-43521

Maintainer: @ratkaj 