### PR TITLE
tio: update to 2.7

### DIFF
--- a/utils/tio/Makefile
+++ b/utils/tio/Makefile
@@ -8,27 +8,27 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tio
-PKG_VERSION:=1.32
-PKG_RELEASE:=2
+PKG_VERSION:=2.7
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/tio/tio/releases/download/v$(PKG_VERSION)
-PKG_HASH:=a8f5ed6994cacb96780baa416b19e5a6d7d67e8c162a8ea4fd9eccd64984ae44
+PKG_HASH:=bf8fe434848c2c1b6540af0b42503c986068176ddc1a988cf02e521e7de5daa5
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0-or-later
-PKG_LICENSE_FILES:=COPYING
-
-PKG_FIXUP:=autoreconf
+PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/meson.mk
 
 define Package/tio
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Terminal
   TITLE:=A simple TTY terminal I/O application
   URL:=https://tio.github.io/
-  SUBMENU:=Terminal
+  DEPENDS:=+libinih
 endef
 
 define Package/tio/description
@@ -37,7 +37,7 @@ endef
 
 define Package/tio/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/tio $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/tio $(1)/usr/sbin/
 endef
 
 $(eval $(call BuildPackage,tio))


### PR DESCRIPTION
Maintainer: N/A
Run tested: ARMv7, Linksys WRT3200ACM, master branch

Description:
- Switch to Meson build
- Fix license file name
- Add libinih dependency
