### PR TITLE
coova-chilli: fix libxt-coova not loading properly from iptables ( openwrt/packages#23092 )

### DIFF
--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coova-chilli
 PKG_VERSION:=1.6
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/coova/coova-chilli/tar.gz/$(PKG_VERSION)?

--- a/net/coova-chilli/patches/020-libxt_coova-Use-constructor-instead-of-_init.patch
+++ b/net/coova-chilli/patches/020-libxt_coova-Use-constructor-instead-of-_init.patch
@@ -26,7 +26,7 @@ Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
  };
  
 -void _init(void)
-+void __attribute__ ((constructor)) xtables_init(void)
++void __attribute__ ((constructor)) libxt_coova_init(void)
  {
  	xtables_register_match(&coova_mt_reg);
  	xtables_register_match(&coova_mt6_reg);


### PR DESCRIPTION
**Compile tested:**

 rockchip/armv8/friendlyarm_nanopi-r5c-squashfs

**Run tested:** 

on rockchip/armv8/friendlyarm_nanopi-r5c-squashfs
Loading the libxt-coova module, and using coova-chilli

**Description:**

Before this commit Trying to load the libxt-coova module would result into an error:

```
root@OpenWRT:~# iptables -m coova -h
iptables v1.8.8 (nf_tables): Couldn't load match `coova':No such file or directory

Try `iptables -h' or 'iptables --help' for more information.
```

After this commit it loads correctly:

```
iptables -m coova -h
iptables v1.8.8 (legacy)

Usage: iptables -[ACD] chain rule-specification [options]
     [...]
coova match options:
    --name name                 Name of the table to be used. 'chilli' used if none given.
    --source                    Indicates the source direction (lookup by source MAC/IP)
    --dest                      Indicates the reply (lookup by dest address).
xt_coova by: David Bird (Coova Technologies) <support@coova.com>.  http://coova.github.io/CoovaChilli
```

And coova-chilli is usable with libxt-coova module.
