### PR TITLE
python-yaml: create /host target

### DIFF
--- a/lang/python/python-yaml/Makefile
+++ b/lang/python/python-yaml/Makefile
@@ -20,10 +20,13 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:pyyaml:pyyaml
 
 PKG_BUILD_DEPENDS:=python-cython/host
+HOST_BUILD_DEPENDS:=python-cython/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-yaml
   SECTION:=lang
@@ -43,3 +46,4 @@ PYTHON3_PKG_BUILD_VARS:=PYYAML_FORCE_LIBYAML=1
 $(eval $(call Py3Package,python3-yaml))
 $(eval $(call BuildPackage,python3-yaml))
 $(eval $(call BuildPackage,python3-yaml-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Make the python-yaml/host target available for the build environment to be used with e.g. the PKG_BUILD_DEPENDS list.

Maintainer: @BKPepe 
Compile tested: x86_64, ARM

Description:
Create host target for the python-yaml package. This is needed for an upcoming package (libcamera).

