### PR TITLE
python-jinja2: create /host target

### DIFF
--- a/lang/python/python-jinja2/Makefile
+++ b/lang/python/python-jinja2/Makefile
@@ -15,10 +15,13 @@ PKG_MAINTAINER:=Michal Vasilek <michal.vasilek@nic.cz>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
 PKG_CPE_ID:=cpe:/a:pocoo:jinja2
+HOST_BUILD_DEPENDS:= python-markupsafe/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-jinja2
   SECTION:=lang
@@ -43,3 +46,4 @@ endef
 $(eval $(call Py3Package,python3-jinja2))
 $(eval $(call BuildPackage,python3-jinja2))
 $(eval $(call BuildPackage,python3-jinja2-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Make the python-jinja2/host target available for the build environment to be used with e.g. the PKG_BUILD_DEPENDS list.

Maintainer:  Michal Vasilek <michal.vasilek@nic.cz>
Compile tested: x86_64, ARM

Description:
Create host target for the python-jinja2 package. This is needed for an upcoming package (libcamera).

