### PR TITLE
syslog-ng: Install logread to /usr/sbin

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -123,7 +123,7 @@ define Package/syslog-ng/install
 	touch $(1)/etc/syslog-ng.d/.keep
 
 	$(INSTALL_DIR) $(1)/sbin
-	$(INSTALL_BIN) ./files/logread $(1)/sbin
+	$(INSTALL_BIN) ./files/logread $(1)/usr/sbin
 
 	$(INSTALL_DIR) $(1)/usr/share/syslog-ng/include/
 	$(CP) -r ./files/scl $(1)/usr/share/syslog-ng/include/


### PR DESCRIPTION
Maintainer: @BKPepe 
Compile tested: x86 / 64 / master
Run tested: x86 / 64 / master

Description:

Instead of into /sbin/ install logread into /usr/sbin/logread. This works around a conflict with the logd package.

Closes: https://github.com/openwrt/packages/issues/11535
Closes: https://github.com/openwrt/packages/issues/22451