### PR TITLE
crowdsec-firewall-bouncer: add `retry_initial_connect` option support

### DIFF
--- a/net/crowdsec-firewall-bouncer/Makefile
+++ b/net/crowdsec-firewall-bouncer/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crowdsec-firewall-bouncer
 PKG_VERSION:=0.0.28
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/crowdsecurity/cs-firewall-bouncer/tar.gz/v$(PKG_VERSION)?

--- a/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.initd
+++ b/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.initd
@@ -37,6 +37,7 @@ init_yaml() {
 	local ipv4
 	local input_chain_name
 	local input6_chain_name
+	local retry_initial_connect
 
 	config_get update_frequency $section update_frequency '10s'
 	config_get log_level $section log_level 'info'
@@ -52,6 +53,7 @@ init_yaml() {
 	config_get_bool ipv4 $section ipv4 '1'
 	config_get input_chain_name $section input_chain_name "input"
 	config_get input6_chain_name $section input6_chain_name "input"
+	config_get_bool retry_initial_connect $section retry_initial_connect '1'
 
 	# Create tmp dir & permissions if needed
 	if [ ! -d "${VARCONFIGDIR}" ]; then
@@ -72,6 +74,7 @@ init_yaml() {
 	log_max_age: $log_max_age
 	api_url: $api_url
 	api_key: $api_key
+	retry_initial_connect: bool($retry_initial_connect)
 	insecure_skip_verify: true
 	disable_ipv6: boolnot($ipv6)
 	deny_action: $deny_action

--- a/net/crowdsec-firewall-bouncer/files/crowdsec.config
+++ b/net/crowdsec-firewall-bouncer/files/crowdsec.config
@@ -12,4 +12,7 @@ config bouncer
 	option filter_input '1'
 	option filter_forward '1'
 	list interface 'eth1'
-
+	option retry_initial_connect '1'
+	# set to 1 to retry connection with LAPI during startup
+	# can be useful if LAPI is ready later than the bouncer
+	


### PR DESCRIPTION
Maintainer: Gerald Kerma @erdoukki
Compile tested: n/a
Run tested: 23.05.2 r23630-842932a63d, x86_64, I made those changes on my device and all config settings were correctly parsed and used by crowdsec-firewall-bouncer

Description:

This PR introduces support for `retry_initial_connect` config option in crowdsec-firewall-bouncer. The `.initd` file simply sources the option from package config and adds it to the generated `config.yaml` that is used by the bouncer.

In some cases Crowdsec firewall bouncer is running before Crowdsec engine finished initialization and LAIP started. In such case the bouncer will fatal, even though everything is configured correctly. In OpenWRT this issue can arise for example when engine and bouncer are running on the same device - during startup bouncer starts (and fatals) before LAPI is active.

Crowdsec firewall bouncer developers mitigated this problem by [adding retry functionality](https://github.com/crowdsecurity/go-cs-bouncer/pull/1) to the bouncer and [introducing the `retry_initial_connect`](https://github.com/crowdsecurity/go-cs-bouncer/pull/27) option in config. Both changes are present in v0.0.13 used in OpenWRT.

However, this option right now cannot be used in crowdsec-firewall-bouncer package because the `initd` script overwrites `config.yaml` every time the service is started (to account for changes made with UCI). Proposed changes make the service use `retry_initial_connect` option and allow user to configure it from uci.

I have also added a short comment about the use of this option in config file, as I have no idea how to change OpenWRT documentation and because this option is not straightforward to wind in Crowdsec documentation.
