### PR TITLE
proxychains-ng: update to version 4.17

### DIFF
--- a/net/proxychains-ng/Makefile
+++ b/net/proxychains-ng/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019-2022 Daniel Bermond
+# Copyright (C) 2019-2024 Daniel Bermond
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=proxychains-ng
-PKG_VERSION:=4.16
+PKG_VERSION:=4.17
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/rofl0r/proxychains-ng/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=5f66908044cc0c504f4a7e618ae390c9a78d108d3f713d7839e440693f43b5e7
+PKG_HASH:=1a2dc68fcbcb2546a07a915343c1ffc75845f5d9cc3ea5eb3bf0b62a66c0196f
 
 PKG_MAINTAINER:=Daniel Bermond <dbermond@archlinux.org>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer   : myself
Build system : Arch Linux x86_64
Build tested : r7800 OpenWrt git master (r25151-2a2abed0be)
Run tested   : r7800 OpenWrt git master (r25151-2a2abed0be)

Regular update to upstream proxychains-ng 4.17.

