### PR TITLE
unbound: update to latest upstream release version 1.19.1

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.19.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.19.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound
-PKG_HASH:=a97532468854c61c2de48ca4170de854fd3bc95c8043bb0cfb0fe26605966624
+PKG_HASH:=bc1d576f3dd846a0739adc41ffaa702404c6767d2b6082deb9f2f97cbb24a3a9
 
 PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/unbound/patches/010-configure-uname.patch
+++ b/net/unbound/patches/010-configure-uname.patch
@@ -3,7 +3,7 @@ Fix cross compile errors by inserting an environment variable for the
 target. Use "uname" on host only if "UNAME" variable is empty.
 --- a/configure.ac
 +++ b/configure.ac
-@@ -842,7 +842,7 @@ if test x_$ub_test_python != x_no; then
+@@ -843,7 +843,7 @@ if test x_$ub_test_python != x_no; then
     fi
  fi
  


### PR DESCRIPTION
Maintainer: @EricLuehrsen
Fixes: CVE-2023-50387, CVE-2023-50868
Release notes: https://nlnetlabs.nl/news/2024/Feb/13/unbound-1.19.1-released/
Run tested: BPi-R3, mediatek/filogic, OpenWrt 23.05.2
Signed-off-by: S. Brusch <ne20002@gmx.ch>
