### PR TITLE
libv4l: update to 1.26.1

### DIFF
--- a/libs/libv4l/Makefile
+++ b/libs/libv4l/Makefile
@@ -6,22 +6,24 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v4l-utils
-PKG_VERSION:=1.22.1
+PKG_VERSION:=1.26.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.linuxtv.org/downloads/v4l-utils
-PKG_HASH:=65c6fbe830a44ca105c443b027182c1b2c9053a91d1e72ad849dfab388b94e31
+PKG_HASH:=4a71608c0ef7df2931176989e6d32b445c0bdc1030a2376d929c8ca6e550ec4e
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 
-PKG_BUILD_FLAGS:=no-mips16 lto
-PKG_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
 
 PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_BUILD_NLS \
+	CONFIG_PACKAGE_v4l-utils
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/meson.mk
 include $(INCLUDE_DIR)/nls.mk
 
 define Package/libv4l/Default
@@ -49,7 +51,7 @@ define Package/libv4l
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE+= wrapper libraries
-  DEPENDS := +libpthread +librt $(ICONV_DEPENDS)
+  DEPENDS:=$(ICONV_DEPENDS)
   LICENSE:=LGPL-2.1-or-later
   LICENSE_FILES:=COPYING.libv4l
 endef
@@ -63,7 +65,7 @@ define Package/v4l-utils
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE+= utilities
-  DEPENDS:= +libudev +libv4l +libstdcpp $(ICONV_DEPENDS) $(INTL_DEPENDS)
+  DEPENDS:=+libudev +libv4l +libstdcpp $(ICONV_DEPENDS) $(INTL_DEPENDS)
   LICENSE:=GPL-2.0-or-later
   LICENSE_FILES:=COPYING
 endef
@@ -73,17 +75,19 @@ define Package/v4l-utils/description
   This package contains the video4linux utilities.
 endef
 
-TARGET_LDFLAGS += \
-	$(if $(CONFIG_USE_GLIBC),,-largp) \
-	-Wl,--gc-sections,--as-needed
+MESON_ARGS += \
+	-Db_lto=true \
+	-Ddefault_library=both \
+	-Dbpf=disabled \
+	-Dgconv=disabled \
+	-Djpeg=disabled \
+	-Dlibdvbv5=disabled \
+	-Dqv4l2=disabled \
+	-Dqvidcap=disabled \
+	-Dv4l-utils=$(if $(CONFIG_PACKAGE_v4l-utils),true,false) \
+	-Ddoxygen-doc=disabled
 
-CONFIGURE_ARGS+= \
-	--disable-bpf \
-	--disable-doxygen-doc \
-	--disable-libdvbv5 \
-	--disable-qv4l2 \
-	--disable-qvidcap \
-	--without-jpeg
+TARGET_LDFLAGS += -Wl,--gc-sections
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include

--- a/libs/libv4l/patches/010-intl.patch
+++ b/libs/libv4l/patches/010-intl.patch
@@ -1,0 +1,50 @@
+--- a/lib/libdvbv5/meson.build
++++ b/lib/libdvbv5/meson.build
+@@ -124,6 +124,7 @@ install_headers(libdvbv5_api, subdir: 'l
+ 
+ libdvbv5_deps = [
+     dep_iconv,
++    dep_intl,
+     dep_libm,
+     dep_librt,
+     dep_libudev,
+--- a/meson.build
++++ b/meson.build
+@@ -178,6 +178,8 @@ size_t iconv (iconv_t cd, char * *inbuf,
+     endif
+ endif
+ 
++dep_intl = dependency('intl')
++
+ have_gconv = cc.has_header('gconv.h', required : get_option('gconv'))
+ 
+ # Detect system gconv directory
+--- a/utils/dvb/meson.build
++++ b/utils/dvb/meson.build
+@@ -1,5 +1,6 @@
+ dvb_common_deps =  [
+     dep_argp,
++    dep_intl,
+     dep_libdvbv5,
+     dep_libudev,
+     dep_threads,
+--- a/utils/ir-ctl/meson.build
++++ b/utils/ir-ctl/meson.build
+@@ -12,6 +12,7 @@ ir_ctl_sources = files(
+ 
+ ir_ctl_deps =  [
+     dep_argp,
++    dep_intl,
+ ]
+ 
+ ir_ctl = executable('ir-ctl',
+--- a/utils/keytable/meson.build
++++ b/utils/keytable/meson.build
+@@ -11,6 +11,7 @@ ir_keytable_sources = files(
+ 
+ ir_keytable_deps = [
+     dep_argp,
++    dep_intl,
+ ]
+ 
+ ir_keytable_system_dir = udevdir

--- a/libs/libv4l/patches/020-musl.patch
+++ b/libs/libv4l/patches/020-musl.patch
@@ -1,0 +1,50 @@
+--- a/utils/v4l2-tracer/retrace.cpp
++++ b/utils/v4l2-tracer/retrace.cpp
+@@ -10,10 +10,7 @@ extern struct retrace_context ctx_retrac
+ void retrace_mmap(json_object *mmap_obj, bool is_mmap64)
+ {
+ 	json_object *mmap_args_obj;
+-	if (is_mmap64)
+-		json_object_object_get_ex(mmap_obj, "mmap64", &mmap_args_obj);
+-	else
+-		json_object_object_get_ex(mmap_obj, "mmap", &mmap_args_obj);
++	json_object_object_get_ex(mmap_obj, "mmap", &mmap_args_obj);
+ 
+ 	json_object *len_obj;
+ 	json_object_object_get_ex(mmap_args_obj, "len", &len_obj);
+@@ -46,10 +43,7 @@ void retrace_mmap(json_object *mmap_obj,
+ 		return;
+ 
+ 	void *buf_address_retrace_pointer = nullptr;
+-	if (is_mmap64)
+-		buf_address_retrace_pointer = mmap64(0, len, prot, flags, fd_retrace, off);
+-	else
+-		buf_address_retrace_pointer = mmap(0, len, prot, flags, fd_retrace, off);
++	buf_address_retrace_pointer = mmap(0, len, prot, flags, fd_retrace, off);
+ 
+ 	if (buf_address_retrace_pointer == MAP_FAILED) {
+ 		if (is_mmap64)
+@@ -116,10 +110,7 @@ void retrace_open(json_object *jobj, boo
+ 	int fd_trace = json_object_get_int(fd_trace_obj);
+ 
+ 	json_object *open_args_obj;
+-	if (is_open64)
+-		json_object_object_get_ex(jobj, "open64", &open_args_obj);
+-	else
+-		json_object_object_get_ex(jobj, "open", &open_args_obj);
++	json_object_object_get_ex(jobj, "open", &open_args_obj);
+ 
+ 	json_object *path_obj;
+ 	std::string path_trace;
+@@ -148,10 +139,7 @@ void retrace_open(json_object *jobj, boo
+ 		mode = s2number(json_object_get_string(mode_obj));
+ 
+ 	int fd_retrace = 0;
+-	if (is_open64)
+-		fd_retrace = open64(path_retrace.c_str(), oflag, mode);
+-	else
+-		fd_retrace = open(path_retrace.c_str(), oflag, mode);
++	fd_retrace = open(path_retrace.c_str(), oflag, mode);
+ 
+ 	if (fd_retrace <= 0) {
+ 		line_info("\n\tCan't open: %s", path_retrace.c_str());


### PR DESCRIPTION
meson now available.

Added 2 patches to fix missing intl dependency and musl support.

Maintainer: @thess 