### PR TITLE
Add metanoia mt5311 vdsl modem tools

### DIFF
--- a/lang/lua-struct/Makefile
+++ b/lang/lua-struct/Makefile
@@ -1,0 +1,42 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=lua-struct
+PKG_VERSION:=0.9.2
+PKG_RELEASE:=1
+
+PKG_VERSION_TAG:=$(PKG_VERSION)-1
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION_TAG).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/iryont/$(PKG_NAME)/tar.gz/$(PKG_VERSION_TAG)?
+PKG_HASH:=30d4e3584e27caa504745fdf5e191f2469ae284dc51271292654856905a4603d
+
+PKG_MAINTAINER:=jasle <jasle@riseup.net>
+PKG_LICENSE:=MIT/X11
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION_TAG)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/lua-struct
+  SUBMENU:=Lua
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Implementation of binary packing/unpacking in pure lua
+  URL:=https://github.com/iryont/lua-struct
+endef
+
+define Package/lua-struct/desription
+	lua-struct is a pure lua Implementation for packing and unpacking 
+	binary data. 
+endef
+
+define Build/Compile
+	echo "Nothing to compile, pure lua package"
+endef
+
+define Package/lua-struct/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/src/struct.lua $(1)/usr/lib/lua/
+endef
+
+$(eval $(call BuildPackage,lua-struct))
+

--- a/utils/mt5311/Makefile
+++ b/utils/mt5311/Makefile
@@ -37,6 +37,7 @@ define Package/mt5311/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/ebm.lua $(1)/usr/lib/lua/mt5311/
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/register.lua $(1)/usr/lib/lua/mt5311/
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/register.map $(1)/usr/lib/lua/mt5311/
+	$(INSTALL_DATA) ./files/init.lua $(1)/usr/lib/lua/mt5311/
 
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) ./files/ebm-read $(1)/usr/bin/

--- a/utils/mt5311/Makefile
+++ b/utils/mt5311/Makefile
@@ -1,0 +1,46 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mt5311
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/jimdigriz/mt5311.git
+PKG_SOURCE_VERSION:=2cb13045cd82474416e7f454b36f3a07b0de49d7
+PKG_MIRROR_HASH:=a1e1e9354fe9b9d6aa5da6b38ff6ef84458761533f9dbc55758dd403868c42ed
+
+PKG_MAINTAINER:=jasle <jasle@riseup.net>
+PKG_LICENSE:=AGPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/mt5311
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Utilities for working with Metanoia/Proscend VDSL2 SFP Modems
+  URL:=https://github.com/jimdigriz/mt5311
+  DEPENDS:=+lua +luaposix +lua-struct
+endef
+
+define Package/mt5311/description
+	mt5311 is a tool to read status informationen from Metanoia/Proscend 
+	VDSL2/Proscend VDSL2 SFP Modems.
+endef
+
+define Build/Compile
+	echo "Nothing to compile, pure lua package"
+endef
+
+define Package/mt5311/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/mt5311
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/ebm-read.lua $(1)/usr/lib/lua/mt5311/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/ebm.lua $(1)/usr/lib/lua/mt5311/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/register.lua $(1)/usr/lib/lua/mt5311/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/register.map $(1)/usr/lib/lua/mt5311/
+
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) ./files/ebm-read $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,mt5311))
+

--- a/utils/mt5311/files/ebm-read
+++ b/utils/mt5311/files/ebm-read
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+exec lua /usr/lib/lua/mt5311/ebm-read.lua "$@"
+

--- a/utils/mt5311/files/init.lua
+++ b/utils/mt5311/files/init.lua
@@ -1,0 +1,11 @@
+-- mt5311 init file, makes mt5311 importable as module 
+
+local dir = '/usr/lib/lua/mt5311/'
+local file = dir .. 'ebm.lua'
+arg={}
+arg[0] = file
+
+mt5311 = assert(loadfile(file))(arg)
+
+return mt5311
+


### PR DESCRIPTION
Maintainer: me, @jasle 
Compile tested:  mediatek filogic MT7986 bpi-r3
Run tested: mediatek filogic MT7986 bpi-r3

Description:
Utilities for working with Metanoia/Proscend VDSL2 SFP Modems from @jimdigriz.
This Package only contain the parts needed for using it from shell or lua, not the snmp part, because it is currently mentioned as work in progress.

Also contains new package `lua-struct`, a dependency for the mt5311 utilities.