### PR TITLE
conserver: free correct addrinfo to prevent crash.

### DIFF
--- a/net/conserver/Makefile
+++ b/net/conserver/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=conserver
 PKG_VERSION:=8.2.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/conserver/conserver/tar.gz/v$(PKG_VERSION)?

--- a/net/conserver/patches/002-addrsmatch-freeaddrinfo.patch
+++ b/net/conserver/patches/002-addrsmatch-freeaddrinfo.patch
@@ -1,0 +1,36 @@
+--- a/conserver/consent.c
++++ b/conserver/consent.c
+@@ -1269,7 +1269,7 @@ AddrsMatch(char *addr1, char *addr2)
+ {
+ #if USE_IPV6
+     int error, ret = 0;
+-    struct addrinfo *ai1, *ai2, hints;
++    struct addrinfo *ai1, *ai2, *rp1, *rp2, hints;
+ #else
+     /* so, since we might use inet_addr, we're going to use
+      * (in_addr_t)(-1) as a sign of an invalid ip address.
+@@ -1307,17 +1307,19 @@ AddrsMatch(char *addr1, char *addr2)
+ 	goto done;
+     }
+ 
+-    for (; ai1 != NULL; ai1 = ai1->ai_next) {
+-	for (; ai2 != NULL; ai2 = ai2->ai_next) {
+-	    if (ai1->ai_addr->sa_family != ai2->ai_addr->sa_family)
++    rp1 = ai1;
++    rp2 = ai2;
++    for (; rp1 != NULL; rp1 = rp1->ai_next) {
++	for (; rp2 != NULL; rp2 = rp2->ai_next) {
++	    if (rp1->ai_addr->sa_family != rp2->ai_addr->sa_family)
+ 		continue;
+ 
+ 	    if (
+ # if HAVE_MEMCMP
+-		   memcmp(&ai1->ai_addr, &ai2->ai_addr,
++		   memcmp(&rp1->ai_addr, &rp2->ai_addr,
+ 			  sizeof(struct sockaddr_storage))
+ # else
+-		   bcmp(&ai1->ai_addr, &ai2->ai_addr,
++		   bcmp(&rp1->ai_addr, &rp2->ai_addr,
+ 			sizeof(struct sockaddr_storage))
+ # endif
+ 		   == 0) {


### PR DESCRIPTION
When looping through addrinfo lists in AddrsMatch, keep a copy of the original addrinfo pointers to free instead of ending up at the terminating NULLs and trying to free those.

OpenWRT uses musl in which freeaddrinfo(NULL) is not safe (which is fine, it's not required by the spec) so this fixes a segfault.

Maintainer: @BKPepe 
Compile tested: mips_24kc,  gl.inet 6416, master
Run tested: mips_24kc, gl.inet 6416, OpenWrt SNAPSHOT, r25153-869df9ecdf with tests below, plus running in "production" on a gl.inet gl-ar150 on 23.05.2.

Description:
This was submitted and accepted upstream as https://github.com/bstansell/conserver/pull/98.
Tests:
root# uname -a
Linux glinet6416 5.15.148 #0 Wed Feb 14 15:22:53 2024 mips GNU/Linux

root# cat /etc/conserver/conserver.cf
config * { }
default full { rw *; }
default * { master google.com; type device; baud 115200; parity none; }
console test1 { master google.com;  device /dev/ttyUSB0; }
console test2 { master www.google.com; device /dev/ttyUSB1; }
access * { trusted 127.0.0.1; }

root# /usr/sbin/conserver 
[Thu Feb 15 19:41:03 2024] conserver (2162): conserver.com version 8.2.6
[Thu Feb 15 19:41:03 2024] conserver (2162): started as `root' by `root'
Segmentation fault

root# opkg remove conserver
Removing package conserver from root...
Not deleting modified conffile /etc/conserver/conserver.cf.

root# opkg install /tmp/conserver_8.2.6-3_mips_24kc.ipk 
Installing conserver (8.2.6-3) to root...
Configuring conserver.
Collected errors:
 * resolve_conffiles: Existing conffile /etc/conserver/conserver.cf is different from the conffile in the new package. The new conffile will be placed at /etc/conserver/conserver.cf-opkg.

root# /usr/sbin/conserver 
[Thu Feb 15 19:42:52 2024] conserver (2323): conserver.com version 8.2.6
[Thu Feb 15 19:42:52 2024] conserver (2323): started as `root' by `root'
[Thu Feb 15 19:42:54 2024] conserver (2323): compare www.google.com and google.com returns 0
[Thu Feb 15 19:42:54 2024] conserver (2323): ERROR: Master(): listen(): Bad file descriptor
[Thu Feb 15 19:42:54 2024] conserver (2323): terminated
(note lack of segfault)