### PR TITLE
bind: bump to 9.18.24

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.18.19
+PKG_VERSION:=9.18.24
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=115e09c05439bebade1d272eda08fa88eb3b60129edef690588c87a4d27612cc
+PKG_HASH:=709d73023c9115ddad3bab65b6c8c79a590196d0d114f5d0ca2533dbd52ddf66
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Fixes CVEs:

- CVE-2023-50387: Validating DNS messages containing a lot of DNSSEC signatures could cause excessive CPU load, leading to a denial-of-service condition.
- CVE-2023-50868: Preparing an NSEC3 closest encloser proof could cause excessive CPU load, leading to a denial-of-service condition.
- CVE-2023-4408: Parsing DNS messages with many different names could cause excessive CPU load.
- CVE-2023-5517: Specific queries could cause named to crash with an assertion failure when nxdomain-redirect was enabled.
- CVE-2023-5679: A bad interaction between DNS64 and serve-stale could cause named to crash with an assertion failure, when both of these features were enabled.

Maintainer: me 
Compile tested: x86_64
Run tested:  _pending_

