### PR TITLE
pdns-recursor: update to 4.8.6 (fixes CVE-2023-50387, CVE-2023-50868)

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
-PKG_VERSION:=4.7.4
+PKG_VERSION:=4.8.6
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=17b5c7c881e3f400bb3b527dd866e5cf2cd62d5d33566b1b70b58c608d9968d5
+PKG_HASH:=1ff4087ef12e6fc68fccd22c97215fd7f01038d7ad46715e9ffe7494e9926d95
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>
 PKG_LICENCE:=GPL-2.0-only

--- a/net/pdns-recursor/patches/100-disable-recursor.conf-dist.patch
+++ b/net/pdns-recursor/patches/100-disable-recursor.conf-dist.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -492,12 +492,6 @@ $(srcdir)/effective_tld_names.dat:
+@@ -503,12 +503,6 @@ $(srcdir)/effective_tld_names.dat:
  pubsuffix.cc: $(srcdir)/effective_tld_names.dat
  	$(AM_V_GEN)./mkpubsuffixcc
  
@@ -8,7 +8,7 @@
 -sysconf_DATA = recursor.conf-dist
 -
 -recursor.conf-dist: pdns_recursor
--	$(AM_V_GEN)./pdns_recursor --config > $@
+-	$(AM_V_GEN)./pdns_recursor --config=default > $@
 -
  ## Manpages
  MANPAGES=pdns_recursor.1 \


### PR DESCRIPTION
Maintainer: me
Compile tested: github actions
Run tested: docker x86_64 openwrt/rootfs:x86_64-openwrt-22.03

Description:
this bumps to a new major because no patches are available for the 4.7 series, which is [EOL](https://doc.powerdns.com/recursor/appendices/EOL.html)
