### PR TITLE
slirp4netns: update to 1.2.3

### DIFF
--- a/net/slirp4netns/Makefile
+++ b/net/slirp4netns/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=slirp4netns
-PKG_VERSION:=1.2.2
+PKG_VERSION:=1.2.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/rootless-containers/slirp4netns/archive/v$(PKG_VERSION)
-PKG_HASH:=2450afb5730ee86a70f9c3f0d3fbc8981ab8e147246f4e0d354f0226a3a40b36
+PKG_HASH:=acce648fab8fe5f113c41a8fd6d20177708519b4ddaa60f845e1998a17b22ca5
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
changelog:
 - Fix some FD leaks (#334, thanks to @giuseppe)

As package belongs to network category, I moved it from utils to network folder

Maintainer: me
Compile tested: x86_64, recent git
Run tested: x86_64, recent git