### PR TITLE
conmon: update to 2.1.10

### DIFF
--- a/utils/conmon/Makefile
+++ b/utils/conmon/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=conmon
-PKG_VERSION:=2.1.8
+PKG_VERSION:=2.1.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containers/$(PKG_NAME)/archive/v$(PKG_VERSION)
-PKG_HASH:=e72c090210a03ca3b43a0fad53f15bca90bbee65105c412468009cf3a5988325
+PKG_HASH:=455fabcbd4a5a5dc5e05374a71b62dc0b08ee865c2ba398e9dc9acac1ea1836a
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
bug fixes:
 - Fix incorrect free in conn_sock
 - logging: Respect log-size-max immediately after open
 - fix some issues flagged by SAST scan
 - src: fix write after end of buffer
 - src: open all files with O_CLOEXEC
 - oom-score: restore oom score before running exit command

new features:
 - Forward more messages on the sd-notify socket
 - logging: -l passthrough accepts TTYs

Maintainer: me
Compile tested: x86_64, recent git
Run tested: x86_64, recent git