### PR TITLE
micropython: disable mold

### DIFF
--- a/lang/python/micropython/Makefile
+++ b/lang/python/micropython/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=micropython
 PKG_VERSION:=1.21.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/micropython/micropython/releases/download/v$(PKG_VERSION)
@@ -21,7 +21,7 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:micropython:micropython
 
 PKG_BUILD_DEPENDS:=python3/host
-PKG_BUILD_FLAGS:=no-mips16
+PKG_BUILD_FLAGS:=no-mips16 no-mold
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/host-build.mk


### PR DESCRIPTION
package fails to build with mold linker due to unregocnized flag.

Maintainer: @jefferyto 
Compile tested: x86_64, recent git
Run tested: x86_64, recent git