### PR TITLE
libuv: fix CVE-2024-24806

### DIFF
--- a/libs/libuv/Makefile
+++ b/libs/libuv/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuv
-PKG_VERSION:=1.45.0
+PKG_VERSION:=1.48.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://dist.libuv.org/dist/v$(PKG_VERSION)/
-PKG_HASH:=f5b07f65a1e8166e47983a7ed1f42fae0bee08f7458142170c37332fc676a748
+PKG_SOURCE_URL:=https://dist.libuv.org/dist/v$(PKG_VERSION)/
+PKG_HASH:=7f1db8ac368d89d1baf163bac1ea5fe5120697a73910c8ae6b2fffb3551d59fb
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>


### PR DESCRIPTION
Maintainer: @ratkaj
Compile tested: head aarch64, arm
 Run tested: aarch64 (qemu 8.2.1)

Description:
Update to 1.48.0
CVE-2024-24806 : Improper Domain Lookup that potentially leads to SSRF attacks

Vulnerabilities fixed
* CVE-2024-24806 / GHSA-f74f-cvh7-c6q6

Notable Changes
* linux: disable io_uring on ppc64 and ppc64le
* linux: disable io_uring on hppa below kernel 6.1.51
* win/spawn: optionally run executable paths with no file extension (We recommend that most users consider setting this by default) Important Bugs Fixed
* unix,win: fix busy loop with zero timeout timers