### PR TITLE
glib2: revert latest changes to get back to working version 2.74.0

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.74.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/$(basename $(PKG_VERSION))
@@ -45,23 +45,27 @@ define Package/glib2/description
   The GLib library of C routines
 endef
 
-COMP_ARGS= \
-	-Dselinux=disabled \
-	-Dlibmount=disabled \
-	-Dman=false \
-	-Ddtrace=false \
-	-Dsystemtap=false \
-	-Dsysprof=disabled \
-	-Dgtk_doc=false \
-	-Dbsymbolic_functions=true \
-	-Dforce_posix_threads=true \
-	-Dtests=false \
-	-Dinstalled_tests=false \
-	-Doss_fuzz=disabled \
-	-Dglib_debug=disabled \
-	-Dglib_assert=false \
-	-Dglib_checks=true \
-	-Dlibelf=disabled
+COMP_ARGS:=
+
+# default feature=auto see meson_options.txt
+COMP_ARGS+=-Dglib_debug=disabled
+
+# default feature=auto see meson_options.txt
+COMP_ARGS+=-Dlibmount=disabled
+
+# default feature=auto see meson_options.txt
+COMP_ARGS+=-Dselinux=disabled
+
+
+# default boolean=false see meson_options.txt
+COMP_ARGS+=-Dforce_posix_threads=true
+
+# default boolean=true see meson_options.txt
+COMP_ARGS+=-Dglib_assert=false
+
+# default boolean=true see meson_options.txt
+COMP_ARGS+=-Dtests=false
+
 
 MESON_HOST_ARGS += $(COMP_ARGS) -Dxattr=false -Ddefault_library=static -Dnls=disabled
 MESON_ARGS += $(COMP_ARGS) -Dxattr=true -Db_lto=true -Ddefault_library=both -Dnls=$(if $(CONFIG_BUILD_NLS),en,dis)abled

--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
-PKG_VERSION:=2.74.0
-PKG_RELEASE:=6
+PKG_VERSION:=2.74.7
+PKG_RELEASE:=1
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/$(basename $(PKG_VERSION))
-PKG_HASH:=3652c7f072d7b031a6b5edd623f77ebc5dcd2ae698598abcc89ff39ca75add30
+PKG_HASH:=196ab86c27127a61b7a70c3ba6af7b97bdc01c07cd3b21abd5e778b955eccb1b
 
 PKG_MAINTAINER:=Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
-PKG_VERSION:=2.78.4
-PKG_RELEASE:=1
+PKG_VERSION:=2.74.0
+PKG_RELEASE:=5
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/$(basename $(PKG_VERSION))
-PKG_HASH:=24b8e0672dca120cc32d394bccb85844e732e04fe75d18bb0573b2dbc7548f63
+PKG_HASH:=3652c7f072d7b031a6b5edd623f77ebc5dcd2ae698598abcc89ff39ca75add30
 
 PKG_MAINTAINER:=Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE:=LGPL-2.1-or-later
@@ -38,7 +38,7 @@ define Package/glib2
   CATEGORY:=Libraries
   DEPENDS:=$(ICONV_DEPENDS) $(INTL_DEPENDS) +zlib +libpthread +libffi +libattr +libpcre2
   TITLE:=glib 2.0
-  URL:=https://www.gtk.org/
+  URL:=http://www.gtk.org/
 endef
 
 define Package/glib2/description
@@ -48,8 +48,16 @@ endef
 COMP_ARGS= \
 	-Dselinux=disabled \
 	-Dlibmount=disabled \
+	-Dman=false \
+	-Ddtrace=false \
+	-Dsystemtap=false \
+	-Dsysprof=disabled \
+	-Dgtk_doc=false \
+	-Dbsymbolic_functions=true \
 	-Dforce_posix_threads=true \
 	-Dtests=false \
+	-Dinstalled_tests=false \
+	-Doss_fuzz=disabled \
 	-Dglib_debug=disabled \
 	-Dglib_assert=false \
 	-Dglib_checks=true \

--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.78.4
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/$(basename $(PKG_VERSION))
@@ -55,7 +55,7 @@ COMP_ARGS= \
 	-Dglib_checks=true \
 	-Dlibelf=disabled
 
-MESON_HOST_ARGS += $(COMP_ARGS) -Dxattr=false -Ddefault_library=static -Dnls=disabled -Dforce_fallback_for=libpcre2-8
+MESON_HOST_ARGS += $(COMP_ARGS) -Dxattr=false -Ddefault_library=static -Dnls=disabled
 MESON_ARGS += $(COMP_ARGS) -Dxattr=true -Db_lto=true -Ddefault_library=both -Dnls=$(if $(CONFIG_BUILD_NLS),en,dis)abled
 
 define Build/InstallDev

--- a/libs/glib2/patches/006-c99.patch
+++ b/libs/glib2/patches/006-c99.patch
@@ -1,6 +1,6 @@
 --- a/meson.build
 +++ b/meson.build
-@@ -1045,7 +1045,7 @@ if host_system == 'windows' and (cc.get_
+@@ -1062,7 +1062,7 @@ if host_system == 'windows' and (cc.get_
    glib_conf.set('HAVE_C99_SNPRINTF', false)
    glib_conf.set('HAVE_C99_VSNPRINTF', false)
    glib_conf.set('HAVE_UNIX98_PRINTF', false)

--- a/libs/glib2/patches/006-c99.patch
+++ b/libs/glib2/patches/006-c99.patch
@@ -1,6 +1,6 @@
 --- a/meson.build
 +++ b/meson.build
-@@ -1118,7 +1118,7 @@ if host_system == 'windows' and (cc.get_
+@@ -1045,7 +1045,7 @@ if host_system == 'windows' and (cc.get_
    glib_conf.set('HAVE_C99_SNPRINTF', false)
    glib_conf.set('HAVE_C99_VSNPRINTF', false)
    glib_conf.set('HAVE_UNIX98_PRINTF', false)

--- a/libs/glib2/patches/010-pcre.patch
+++ b/libs/glib2/patches/010-pcre.patch
@@ -1,6 +1,6 @@
 --- a/glib/meson.build
 +++ b/glib/meson.build
-@@ -365,6 +365,7 @@ pcre2_static_args = []
+@@ -366,6 +366,7 @@ pcre2_static_args = []
  
  if use_pcre2_static_flag
    pcre2_static_args = ['-DPCRE2_STATIC']

--- a/libs/glib2/patches/010-pcre.patch
+++ b/libs/glib2/patches/010-pcre.patch
@@ -1,11 +1,8 @@
 --- a/glib/meson.build
 +++ b/glib/meson.build
-@@ -400,8 +400,9 @@ endif
+@@ -402,6 +402,7 @@ pcre2_static_args = []
  
- pcre2_static_args = []
- 
--if use_pcre2_static_flag
-+if pcre2.type_name() == 'internal'
+ if use_pcre2_static_flag
    pcre2_static_args = ['-DPCRE2_STATIC']
 +  pcre2 = pcre2.as_link_whole()
  endif

--- a/libs/glib2/patches/010-pcre.patch
+++ b/libs/glib2/patches/010-pcre.patch
@@ -1,10 +1,10 @@
 --- a/glib/meson.build
 +++ b/glib/meson.build
-@@ -402,6 +402,7 @@ pcre2_static_args = []
+@@ -365,6 +365,7 @@ pcre2_static_args = []
  
  if use_pcre2_static_flag
    pcre2_static_args = ['-DPCRE2_STATIC']
 +  pcre2 = pcre2.as_link_whole()
  endif
  
- glib_c_args = ['-DG_LOG_DOMAIN="GLib"'] + glib_c_args_internal + pcre2_static_args
+ glib_c_args = ['-DG_LOG_DOMAIN="GLib"', '-DGLIB_COMPILATION'] + pcre2_static_args + glib_hidden_visibility_args

--- a/libs/glib2/patches/020-locale.patch
+++ b/libs/glib2/patches/020-locale.patch
@@ -1,0 +1,24 @@
+From ebcc3c01db27b79af38b42c3c52a79d0225f744c Mon Sep 17 00:00:00 2001
+From: Seungha Yang <seungha@centricular.com>
+Date: Sun, 14 Aug 2022 04:56:20 +0900
+Subject: [PATCH] glib-mkenums: Specify output encoding as UTF-8 explicitly for
+ non-English locale
+
+Fixup regression introduced by
+https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2797
+---
+ gobject/glib-mkenums.in | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/gobject/glib-mkenums.in
++++ b/gobject/glib-mkenums.in
+@@ -19,6 +19,9 @@ import errno
+ import codecs
+ import locale
+ 
++# Non-english locale systems might complain to unrecognized character
++sys.stdout = io.TextIOWrapper(sys.stdout.detach(), encoding='utf-8')
++
+ VERSION_STR = '''glib-mkenums version @VERSION@
+ glib-mkenums comes with ABSOLUTELY NO WARRANTY.
+ You may redistribute copies of glib-mkenums under the terms of

--- a/libs/glib2/patches/020-locale.patch
+++ b/libs/glib2/patches/020-locale.patch
@@ -12,9 +12,9 @@ https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2797
 
 --- a/gobject/glib-mkenums.in
 +++ b/gobject/glib-mkenums.in
-@@ -19,6 +19,9 @@ import errno
- import codecs
- import locale
+@@ -22,6 +22,9 @@ import locale
+ # Non-english locale systems might complain to unrecognized character
+ sys.stdout = io.TextIOWrapper(sys.stdout.detach(), encoding='utf-8')
  
 +# Non-english locale systems might complain to unrecognized character
 +sys.stdout = io.TextIOWrapper(sys.stdout.detach(), encoding='utf-8')


### PR DESCRIPTION
Maintainer:  @neheb
Compile tested: lantiq_xrx200 and x86_64
Run tested: x86_64, APU3 with modemmanager

Description:
* revert latest changes to get back to working version 2.74.0
* do not set default meson options
* Update to  latest version 2.74.7 in series 2.74.x and refresh patches