### PR TITLE
openvpn: fix init errors

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.6.8
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/lib/functions/openvpn.sh
+++ b/net/openvpn/files/lib/functions/openvpn.sh
@@ -1,13 +1,11 @@
 #!/bin/sh
 
 get_openvpn_option() {
-	local config="$1"
-	local variable="$2"
-	local option="$3"
+	local value config="$1" variable="$2" option="$3"
 
-	local value="$(sed -rne 's/^[ \t]*'"$option"'[ \t]+'"'([^']+)'"'[ \t]*$/\1/p' "$config" | tail -n1)"
-	[ -n "$value" ] || value="$(sed -rne 's/^[ \t]*'"$option"'[ \t]+"(([^"\\]|\\.)+)"[ \t]*$/\1/p' "$config" | tail -n1 | sed -re 's/\\(.)/\1/g')"
-	[ -n "$value" ] || value="$(sed -rne 's/^[ \t]*'"$option"'[ \t]+(([^ \t\\]|\\.)+)[ \t]*$/\1/p' "$config" | tail -n1 | sed -re 's/\\(.)/\1/g')"
+	value="$(sed -rne 's/^[ \t]*'"$option"'[ \t]+'"'([^']+)'"'[ \t]*$/\1/p' "$config" 2>/dev/null | tail -n1 2>/dev/null)"
+	[ -n "$value" ] || value="$(sed -rne 's/^[ \t]*'"$option"'[ \t]+"(([^"\\]|\\.)+)"[ \t]*$/\1/p' "$config" 2>/dev/null | tail -n1 2>/dev/null | sed -re 's/\\(.)/\1/g' 2>/dev/null)"
+	[ -n "$value" ] || value="$(sed -rne 's/^[ \t]*'"$option"'[ \t]+(([^ \t\\]|\\.)+)[ \t]*$/\1/p' "$config" 2>/dev/null | tail -n1 2>/dev/null | sed -re 's/\\(.)/\1/g' 2>/dev/null)"
 	[ -n "$value" ] || return 1
 
 	export -n "$variable=$value"

--- a/net/openvpn/files/openvpn.init
+++ b/net/openvpn/files/openvpn.init
@@ -281,7 +281,7 @@ start_service() {
 	if [ -n "$instance" ]; then
 		if [ "$instance_found" -gt 0 ]; then
 			start_uci_instance "$instance"
-		else
+		elif [ -f "${PATH_INSTANCE_DIR}/${instance}.conf" ]; then
 			start_path_instance "$instance"
 		fi
 	else
@@ -299,4 +299,3 @@ start_service() {
 service_triggers() {
 	procd_add_reload_trigger openvpn
 }
-


### PR DESCRIPTION
Maintainer: n/a
Compile tested: n/a
Run tested: GL.iNet GL-MT3000, OpenWrt SNAPSHOT r25153-869df9ecdf

Description:
- mute possible sed, tail etc. errors in the 'get_openvpn_option' function, to make sense of the value check
- check the conffile existance (with .conf extension), before starting the 'start_path_instance' function. This fixes errors with 
  non-existing (e.g. wrong spelling) instances and with opvn configurations as well.
