### PR TITLE
apr/subversion: fix subversion build and apache-mod-php8 build regres…

### DIFF
--- a/libs/apr/Makefile
+++ b/libs/apr/Makefile
@@ -88,7 +88,7 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/build-1/* $(1)/usr/share/build-1
 	$(SED) '/^prefix=\|^exec_prefix=/s|/usr|$(STAGING_DIR)/usr|' \
 					$(1)/usr/bin/apr-1-config
-	$(SED) '/^bindir=/s|/usr/bin|$(STAGING_DIR)|' $(1)/usr/bin/apr-1-config
+	$(SED) '/^bindir=/s|/usr|$$$${prefix}|' $(1)/usr/bin/apr-1-config
 	$(SED) '/^datadir=/s|/usr|$$$${prefix}|' $(1)/usr/bin/apr-1-config
 	$(SED) '/^datarootdir=/s|/usr|$$$${prefix}|' $(1)/usr/bin/apr-1-config
 	$(SED) 's,/usr/share/build-1,$(STAGING_DIR)/usr/share/build-1,g' \

--- a/net/subversion/Makefile
+++ b/net/subversion/Makefile
@@ -80,6 +80,8 @@ define Package/subversion-server/conffiles
 endef
 
 CONFIGURE_ARGS += \
+	--with-apr=$(STAGING_DIR)/usr/bin/apr-1-config \
+	--with-apr-util=$(STAGING_DIR)/usr/bin/apu-1-config \
 	--without-swig \
 	--without-berkeley-db \
 	--without-apxs \


### PR DESCRIPTION
…sion (fixes #23460)

The recent upgrade of apr included a change with should fix the subversion build.

Unfortunately, this fix resulted in a build regression of apache-mod-php8.

The new approach is to pass the locations of the apr config helpers to configure via parameter.

Fixes: 68dd7b7cf632 ("apr: update to 1.7.4")

Maintainer: @heil
Compile tested: x86-64
Run tested: -
