### PR TITLE
imagemagick: add missing libzip dependency

### DIFF
--- a/multimedia/imagemagick/Makefile
+++ b/multimedia/imagemagick/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=imagemagick
 PKG_VERSION:=7.1.1
 PKG_REVISION:=28
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Aleksey Vasilenko <aleksey.vasilenko@gmail.com>
 
 PKG_SOURCE:=ImageMagick-$(PKG_VERSION)-$(PKG_REVISION).tar.xz
@@ -35,7 +35,7 @@ endef
 
 define Package/imagemagick
   $(call Package/imagemagick/Default)
-  DEPENDS:=+libltdl +libpthread +zlib +libfreetype +libpng +libjpeg +libtiff +libstdcpp
+  DEPENDS:=+libltdl +libpthread +zlib +libfreetype +libpng +libjpeg +libtiff +libstdcpp +libzip
 endef
 
 define Package/imagemagick/description


### PR DESCRIPTION
Package imagemagick is missing dependencies for the following libraries: libzip.so.5.

Fixes: 7b697342e9fc ("imagemagick: update to 7.1.1-28")

Maintainer: @krant
Compile tested: Netgear XR700 ARMv7 Processor rev 4 (v7l), OpenWrt SNAPSHOT r25160-388cb43b8773
Run tested: Netgear XR700 ARMv7 Processor rev 4 (v7l), OpenWrt SNAPSHOT r25160-388cb43b8773