### PR TITLE
[22.03] strongswan: backport fixes from 23.05

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.5
-PKG_RELEASE:=13.1
+PKG_RELEASE:=13.2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -331,10 +331,10 @@ config_child() {
 	[ -n "$local_subnet" ] && swanctl_xappend4 "local_ts = $local_subnet"
 	[ -n "$remote_subnet" ] && swanctl_xappend4 "remote_ts = $remote_subnet"
 
-	[ -n "$hw_offload" ] && swanctl_append4 "hw_offload = $hw_offload"
+	[ -n "$hw_offload" ] && swanctl_xappend4 "hw_offload = $hw_offload"
 	[ $ipcomp -eq 1 ] && swanctl_xappend4 "ipcomp = 1"
-	[ -n "$interface" ] && swanctl_append4 "interface = $interface"
-	[ -n "$priority" ] && swanctl_append4 "priority = $priority"
+	[ -n "$interface" ] && swanctl_xappend4 "interface = $interface"
+	[ -n "$priority" ] && swanctl_xappend4 "priority = $priority"
 	[ -n "$if_id" ] && { swanctl_xappend4 "if_id_in = $if_id" ; swanctl_xappend4 "if_id_out = $if_id" ; }
 	[ -n "$startaction" -a "$startaction" != "none" ] && swanctl_xappend4 "start_action = $startaction"
 	[ -n "$closeaction" -a "$closeaction" != "none" ] && swanctl_xappend4 "close_action = $closeaction"

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -544,12 +544,12 @@ config_connection() {
 		swanctl_xappend0 ""
 
 		swanctl_xappend0 "secrets {"
-		swanctl_xappend1 "ike {"
+		swanctl_xappend1 "ike-$config_name {"
 		swanctl_xappend2 "secret = $pre_shared_key"
-		if [ -n "$local_id" ]; then
-			swanctl_xappend2 "id1 = $local_id"
-			if [ -n "$remote_id" ]; then
-				swanctl_xappend2 "id2 = $remote_id"
+		if [ -n "$local_identifier" ]; then
+			swanctl_xappend2 "id1 = $local_identifier"
+			if [ -n "$remote_identifier" ]; then
+				swanctl_xappend2 "id2 = $remote_identifier"
 			fi
 		fi
 		swanctl_xappend1 "}"

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -383,7 +383,9 @@ config_connection() {
 	local local_gateway
 	local local_sourceip
 	local local_ip
+	local local_identifier
 	local remote_gateway
+	local remote_identifier
 	local pre_shared_key
 	local auth_method
 	local keyingtries


### PR DESCRIPTION
Maintainer: @pprindeville
Compile tested: mvebu, Turris Omnia, Turris OS 7 = OpenWrt 22.03
Run tested: mvebu, Turris Omnia, Turris OS 7 = OpenWrt 22.03, it runs

Description:
User complained about the error caused by non-existing reference to swanctl_append4. I was able to reproduce it and after noticing the second fix I reproduced also managed to reproduce it. After applying the fixes from 23.05 everything worked. 
Reference to our forum:
- https://forum.turris.cz/t/turris-os-7-0-is-in-rc/19755/20
