### PR TITLE
libiio: fix pkgconfig paths

### DIFF
--- a/libs/libiio/Makefile
+++ b/libs/libiio/Makefile
@@ -128,6 +128,8 @@ define Build/InstallDev
 
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libiio.pc $(1)/usr/lib/pkgconfig/
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/libiio.pc
+	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/libiio.pc
 endef
 
 define Package/libiio/install


### PR DESCRIPTION
CMake build is passing host paths in pkgconfig file.

Maintainer: @mhei 