### PR TITLE
ripgrep: update to 14.1.0

### DIFF
--- a/utils/ripgrep/Makefile
+++ b/utils/ripgrep/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ripgrep
-PKG_VERSION:=13.0.0
-PKG_RELEASE:=2
+PKG_VERSION:=14.1.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/BurntSushi/ripgrep/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=0fb17aaf285b3eee8ddab17b833af1e190d73de317ff9648751ab0660d763ed2
+PKG_HASH:=33c6169596a6bbfdc81415910008f26e0809422fda2d849562637996553b2ab6
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>
 PKG_LICENSE:=MIT Unlicense
@@ -24,6 +24,11 @@ RUST_PKG_FEATURES:=pcre2
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/rust/rust-package.mk
+
+## Force pcre2-sys crate to link dynamically with libpcre2
+export PCRE2_SYS_STATIC=0
+## Most optimized profile
+CARGO_PKG_PROFILE:=release-lto
 
 define Package/ripgrep
   SECTION:=utils


### PR DESCRIPTION
Maintainer: @lu-zero 
Run tested: ARMv7, Linksys WRT3200ACM, master branch

Description:
- Link pcre2 dynamically
  - it was linked statically and libpcre2 dependency was useless
  - it magically fixes build error when global LTO is enabled
  - it reduces resulting binary size
- Use 'release-lto' cargo profile to further reduce binary size

'rg' binary sizes comparision (arm_cortex-a9+neon):
- 4293KB: unmodified
- 4018KB: dynamic libpcre2
- 3521KB: dynamic libpcre2 + release-lto
