### PR TITLE
sysstat: add missing xz-utils dependency

### DIFF
--- a/utils/sysstat/Makefile
+++ b/utils/sysstat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sysstat
 PKG_VERSION:=12.7.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://sysstat.github.io/sysstat-packages
@@ -32,7 +32,7 @@ define Package/sysstat
   CATEGORY:=Utilities
   TITLE:=Sysstat performance monitoring tools
   URL:=https://sysstat.github.io/
-  DEPENDS:=$(INTL_DEPENDS) +xz
+  DEPENDS:=$(INTL_DEPENDS) +xz-utils +xz
 endef
 
 define Package/sysstat/description


### PR DESCRIPTION
Depending only on 'xz' hides the package when 'xz-utils' is not selected.

Last update in #23494 introduced 'xz' dependency incorrectly. Thanks to @nxhack for spotting the issue.
