### PR TITLE
rust: update to 1.76.0

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
-PKG_VERSION:=1.75.0
+PKG_VERSION:=1.76.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
+PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.xz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
-PKG_HASH:=5b739f45bc9d341e2d1c570d65d2375591e22c2d23ef5b8a37711a0386abc088
+PKG_HASH:=805482b436442a6786d270cacbab8f00529e06141b27b7fb01909b97ce4f3464
 HOST_BUILD_DIR:=$(BUILD_DIR)/host/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>

--- a/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
+++ b/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
@@ -11,7 +11,7 @@ Subject: [PATCH] Update xz2 and use it static
 
 --- a/src/bootstrap/Cargo.lock
 +++ b/src/bootstrap/Cargo.lock
-@@ -391,9 +391,9 @@ dependencies = [
+@@ -384,9 +384,9 @@ dependencies = [
  
  [[package]]
  name = "lzma-sys"
@@ -23,7 +23,7 @@ Subject: [PATCH] Update xz2 and use it static
  dependencies = [
   "cc",
   "libc",
-@@ -834,9 +834,9 @@ dependencies = [
+@@ -827,9 +827,9 @@ dependencies = [
  
  [[package]]
  name = "xz2"
@@ -37,7 +37,7 @@ Subject: [PATCH] Update xz2 and use it static
  ]
 --- a/src/bootstrap/Cargo.toml
 +++ b/src/bootstrap/Cargo.toml
-@@ -57,7 +57,7 @@ tar = "0.4"
+@@ -56,7 +56,7 @@ tar = "0.4"
  termcolor = "1.2.0"
  toml = "0.5"
  walkdir = "2"

--- a/lang/rust/patches/0002-rustc-bootstrap-cache.patch
+++ b/lang/rust/patches/0002-rustc-bootstrap-cache.patch
@@ -11,25 +11,28 @@
                  os.makedirs(rustc_cache)
 --- a/src/bootstrap/src/core/download.rs
 +++ b/src/bootstrap/src/core/download.rs
-@@ -208,7 +208,13 @@ impl Config {
+@@ -208,10 +208,13 @@ impl Config {
              Some(other) => panic!("unsupported protocol {other} in {url}"),
              None => panic!("no protocol in {url}"),
          }
--        t!(std::fs::rename(&tempfile, dest_path));
+-        t!(
+-            std::fs::rename(&tempfile, dest_path),
+-            format!("failed to rename {tempfile:?} to {dest_path:?}")
+-        );
 +        match std::fs::rename(&tempfile, dest_path) {
 +            Ok(v) => v,
 +            Err(_) => {
 +                t!(std::fs::copy(&tempfile, dest_path));
 +                t!(std::fs::remove_file(&tempfile));
 +            }
-+        }
++        };
      }
  
      fn download_http_with_retries(&self, tempfile: &Path, url: &str, help_on_error: &str) {
-@@ -544,7 +550,10 @@ impl Config {
-         key: &str,
-         destination: &str,
-     ) {
+@@ -577,7 +580,10 @@ impl Config {
+             return;
+         }
+ 
 -        let cache_dst = self.out.join("cache");
 +        let cache_dst = match env::var_os("OPENWRT_RUSTC_BOOTSTRAP_CACHE") {
 +            Some(v) => PathBuf::from(v),
@@ -38,15 +41,3 @@
          let cache_dir = cache_dst.join(key);
          if !cache_dir.exists() {
              t!(fs::create_dir_all(&cache_dir));
-@@ -671,7 +680,10 @@ download-rustc = false
-         let llvm_assertions = self.llvm_assertions;
- 
-         let cache_prefix = format!("llvm-{llvm_sha}-{llvm_assertions}");
--        let cache_dst = self.out.join("cache");
-+        let cache_dst = match env::var_os("OPENWRT_RUSTC_BOOTSTRAP_CACHE") {
-+            Some(v) => PathBuf::from(v),
-+            None => self.out.join("cache"),
-+        };
-         let rustc_cache = cache_dst.join(cache_prefix);
-         if !rustc_cache.exists() {
-             t!(fs::create_dir_all(&rustc_cache));

--- a/lang/rust/patches/0003-bump-libc-deps-to-0.2.146.patch
+++ b/lang/rust/patches/0003-bump-libc-deps-to-0.2.146.patch
@@ -84,17 +84,3 @@ This patch bumps all libc dependencies and checksums to 0.2.147, which includes 
  
  [[package]]
  name = "libffi"
---- a/vendor/tracing-tree/Cargo.lock
-+++ b/vendor/tracing-tree/Cargo.lock
-@@ -296,9 +296,9 @@ checksum = "e2abad23fbc42b3700f2f279844d
- 
- [[package]]
- name = "libc"
--version = "0.2.141"
-+version = "0.2.147"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
-+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
- 
- [[package]]
- name = "linux-raw-sys"


### PR DESCRIPTION
Maintainer: @lu-zero 
Run tested: ARMv7, Linksys WRT3200ACM - build and run ripgrep package

Description:
- Use .xz for source archive
- Refresh patches
