### PR TITLE
tmux: update to 3.4

### DIFF
--- a/utils/tmux/Makefile
+++ b/utils/tmux/Makefile
@@ -2,12 +2,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tmux
-PKG_VERSION:=3.3a
+PKG_VERSION:=3.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tmux/tmux/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=f9687493203f86d346791a9327cde9148b9b4be959381b1effc575a9364a043f
+PKG_HASH:=ec7ddf021a0a1d3778862feb845fd0c02759dcdb37ba5380ba4e0038164f7187
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 
 PKG_LICENSE:=ISC


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_cortex-a53, Dynalink DL-WRX36, r25309+3-c378927ef8
Run tested: aarch64_cortex-a53, Dynalink DL-WRX36, r25309+3-c378927ef8 in a chroot running on r23300+3-86bc525d00 in a chroot. tmux works as expected

Description: