### PR TITLE
[23.05] c-ares: update to 1.27.0

### DIFF
--- a/libs/c-ares/Makefile
+++ b/libs/c-ares/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=c-ares
-PKG_VERSION:=1.19.1
+PKG_VERSION:=1.27.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://c-ares.org/download
-PKG_HASH:=321700399b72ed0e037d0074c629e7741f6b2ec2dda92956abe3e9671d3e268e
+PKG_HASH:=0a72be66959955c43e2af2fbd03418e82a2bd5464604ec9a62147e37aceb420b
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.md
@@ -29,7 +29,7 @@ define Package/libcares
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Library for asyncronous DNS Requests (including name resolves)
-  URL:=http://c-ares.haxx.se/
+  URL:=https://c-ares.org/
   MAINTAINER:=Karl Palsson <karlp@etactica.com>
 endef
 
@@ -42,10 +42,7 @@ Netware, Android and many more operating systems.
 endef
 
 CMAKE_OPTIONS += \
-	-DCARES_STATIC=OFF \
-	-DCARES_SHARED=ON \
 	-DCARES_STATIC_PIC=ON \
-	-DCARES_BUILD_TESTS=OFF \
 	-DCARES_BUILD_TOOLS=OFF
 
 define Build/InstallDev


### PR DESCRIPTION
- Update package URL
- Don't set default CMake options

Signed-off-by: krant <aleksey.vasilenko@gmail.com>
(cherry picked from commit 0858accfda87e09df019c2e8ba4ab51f6323f17e)

^^^ @krant original commit message ^^^

Maintainer: @karlp
Compile tested: 23.05, aarch64, arm, i386, x86_64
Run tested: aarch64 (qemu 8.2.1) node.js, mosquitto-client working

Description:
This is a security, feature, and bugfix release.

Security:

    Moderate. CVE-2024-25629. Reading malformatted /etc/resolv.conf,
    /etc/nsswitch.conf or the HOSTALIASES file could result in a crash.
    [GHSA-mg26-v6qh-x48q](https://github.com/c-ares/c-ares/security/advisories/GHSA-mg26-v6qh-x48q)

Features:

    New function ares_queue_active_queries() to retrieve number of in-flight
    queries. https://github.com/c-ares/c-ares/pull/712
    New function ares_queue_wait_empty() to wait for the number of in-flight
    queries to reach zero. https://github.com/c-ares/c-ares/pull/710
    New ARES_FLAG_NO_DEFLT_SVR for ares_init_options() to return a failure if
    no DNS servers can be found rather than attempting to use 127.0.0.1. This
    also introduces a new ares status code of ARES_ENOSERVER. https://github.com/c-ares/c-ares/pull/713

Changes:

    EDNS Packet size should be 1232 as per DNS Flag Day. https://github.com/c-ares/c-ares/pull/705

Bugfixes:

    Windows DNS suffix search list memory leak. https://github.com/c-ares/c-ares/pull/711
    Fix warning due to ignoring return code of write(). https://github.com/c-ares/c-ares/pull/709
    CMake: don't override target output locations if not top-level. https://github.com/c-ares/c-ares/issues/708
    Fix building c-ares without thread support. https://github.com/c-ares/c-ares/pull/700
