### PR TITLE
tor: add /etc/torrc.d/ to conffiles

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -114,6 +114,7 @@ endef
 
 define Package/tor/conffiles
 /etc/tor/torrc
+/etc/tor/torrc.d/*
 /var/lib/tor/fingerprint
 /var/lib/tor/keys/*
 /etc/config/tor


### PR DESCRIPTION
The /etc/tor/torrc may contain the line:

    %include /etc/torrc.d/*.conf

So users may put their own config files there.
We should preserve the files during an upgrade.

Maintainer: @hauke
Compile tested: Not needed
Run tested: Not needed

CC: @rsalvaterra
