### PR TITLE
dnsdist: disable XSK to fix the build

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsdist
 PKG_VERSION:=1.9.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
@@ -149,6 +149,7 @@ CONFIGURE_ARGS+= \
 	--with-pic \
 	--with-lua=luajit \
 	--with-libcap \
+	--without-xsk \
 	$(if $(call IsEnabled,DNSDIST_PIE),,--disable-hardening) \
 	$(if $(call IsEnabled,DNSDIST_SODIUM),--enable-dnscrypt --with-libsodium,--disable-dnscrypt --without-libsodium) \
 	$(if $(call IsEnabled,DNSDIST_DNSTAP),--enable-dnstap=yes,--enable-dnstap=no) \


### PR DESCRIPTION
Maintainer: @Habbie 

XSK support is set to `auto` by default and on some hosts it is detected as `on` and leads to (from [faillog](https://downloads.openwrt.org/snapshots/faillogs/arm_cortex-a5_vfpv4/packages/dnsdist/full/compile.txt)):
```
In file included from dnsdist-backend.cc:32:
xsk.hh:28:10: fatal error: bits/types/struct_timespec.h: No such file or directory
   28 | #include <bits/types/struct_timespec.h>
```
Here we disable XSK so configure will behave more deterministically and hopefully fix the builders.