### PR TITLE
mc: depend on libe2p

### DIFF
--- a/utils/mc/Makefile
+++ b/utils/mc/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mc
 PKG_VERSION:=4.8.30
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_CPE_ID:=cpe:/a:midnight_commander:midnight_commander
@@ -35,7 +35,7 @@ include $(INCLUDE_DIR)/nls.mk
 define Package/mc
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+glib2 +libncurses +libmount +MC_VFS:libssh2 $(ICONV_DEPENDS)
+  DEPENDS:=+glib2 +libncurses +libmount +libe2p +MC_VFS:libssh2 $(ICONV_DEPENDS)
   TITLE:=Midnight Commander - a powerful visual file manager
   URL:=https://www.midnight-commander.org/
   MENU:=1


### PR DESCRIPTION
Now that libe2p is separated from e2fsprogs;
midnight commander needs it added to depends.

Maintainer: unknown
Compile tested: x86_64, latest git
Run tested: x86_64, latest git

Description:
I recently requested libe2p package separation from e2fsprogs; it had impact on a single package: midnight commander.
This PR adds libe2p to depends, nothing more.