### PR TITLE
modemmanager: report events for virtual netdevices

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_SOURCE_VERSION:=1.22.0
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/usr/share/ModemManager/modemmanager.common
+++ b/net/modemmanager/files/usr/share/ModemManager/modemmanager.common
@@ -130,7 +130,20 @@ mm_report_event() {
 	virtual="$(echo "$sysfspath" | cut -d'/' -f4)"
 	[ "$virtual" = "virtual" ] && {
 		mm_log "debug" "sysfspath is a virtual device ($sysfspath)"
-		return
+		case "$name" in
+			"qmapmux"*)
+				mm_log "debug" "rmnet netdevice $name"
+				;;
+			"qmimux"*)
+				mm_log "debug" "qmi_wwan qmap netdevice $name"
+				;;
+			"mbimmux"*)
+				mm_log "debug" "mbim vlan netdevice $name"
+				;;
+			*)
+				return
+				;;
+		esac
 	}
 
 	# Track/untrack events in cache


### PR DESCRIPTION
Virtual netdevices created for multiplexing should not be skipped when reporting events, otherwise it is not possible to setup the data connection.

Add these exceptions in mm_report_event function.

Maintainer: @feckert 
Compile tested: none
Run tested: 23.05.0-rc1 r23069-e2701e0f33 imx/imx8

Tested with data connection:

mmcli -m 0 --create-bearer="apn=default,ip-type=ipv4,multiplex=requested"
mmcli -m 0 -b 1 --connect

fixes #23550 

Not very proficient in scripting, apologize if the change is wrong.