### PR TITLE
libwebsockets: update to 4.3.3, support wolfssl

### DIFF
--- a/libs/libwebsockets/Makefile
+++ b/libs/libwebsockets/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libwebsockets
-PKG_VERSION:=4.3.2
-PKG_RELEASE:=2
+PKG_VERSION:=4.3.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.github.com/warmcat/libwebsockets/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6a85a1bccf25acc7e8e5383e4934c9b32a102880d1e4c37c70b27ae2a42406e1
+PKG_HASH:=6fd33527b410a37ebc91bb64ca51bdabab12b076bc99d153d7c5dd405e4bdf90
 
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 
@@ -67,6 +67,15 @@ define Package/libwebsockets-mbedtls
 	CONFLICTS:=libwebsockets-openssl
 endef
 
+define Package/libwebsockets-wolfssl
+	$(call Package/$(PKG_NAME)/Default)
+	TITLE += (wolfSSL)
+	DEPENDS += +libwolfssl
+	VARIANT:=wolfssl
+	PROVIDES:=libwebsockets
+	CONFLICTS:=libwebsockets-openssl
+endef
+
 define Package/libwebsockets-full
 	$(call Package/libwebsockets/Default)
 	TITLE += (Full - OpenSSL, libuv, plugins, CGI)
@@ -82,6 +91,12 @@ endif
 
 ifeq ($(BUILD_VARIANT),mbedtls)
     CMAKE_OPTIONS += -DLWS_WITH_MBEDTLS=1
+endif
+
+ifeq ($(BUILD_VARIANT),wolfssl)
+    CMAKE_OPTIONS += -DLWS_WITH_WOLFSSL=ON
+    CMAKE_OPTIONS += -DLWS_WOLFSSL_INCLUDE_DIRS=$(STAGING_DIR)/usr/include
+    CMAKE_OPTIONS += -DLWS_WOLFSSL_LIBRARIES=$(STAGING_DIR)/usr/lib/libwolfssl.so
 endif
 
 ifeq ($(BUILD_VARIANT),full)
@@ -101,6 +116,7 @@ define Package/libwebsockets/install
 endef
 
 Package/libwebsockets-mbedtls/install = $(Package/libwebsockets/install)
+Package/libwebsockets-wolfssl/install = $(Package/libwebsockets/install)
 Package/libwebsockets-openssl/install = $(Package/libwebsockets/install)
 
 define Package/libwebsockets-full/install
@@ -110,4 +126,5 @@ endef
 
 $(eval $(call BuildPackage,libwebsockets-openssl))
 $(eval $(call BuildPackage,libwebsockets-mbedtls))
+$(eval $(call BuildPackage,libwebsockets-wolfssl))
 $(eval $(call BuildPackage,libwebsockets-full))

--- a/libs/libwebsockets/patches/101-fix-wolfssl-server.patch
+++ b/libs/libwebsockets/patches/101-fix-wolfssl-server.patch
@@ -1,0 +1,21 @@
+--- a/lib/tls/openssl/openssl-server.c
++++ b/lib/tls/openssl/openssl-server.c
+@@ -308,7 +308,7 @@ lws_tls_server_certs_load(struct lws_vho
+ 						  flen);
+ 	}
+ #else
+-	ret = wolfSSL_CTX_use_PrivateKey_buffer(vhost->tls.ssl_ctx, p, flen,
++	ret = wolfSSL_CTX_use_PrivateKey_buffer(vhost->tls.ssl_ctx, p, (long) flen,
+ 						WOLFSSL_FILETYPE_ASN1);
+ #endif
+ 	lws_free_set_NULL(p);
+@@ -441,7 +441,9 @@ check_key:
+ 	/* Get X509 certificate from ssl context */
+ #if !defined(LWS_WITH_BORINGSSL)
+ #if !defined(LWS_HAVE_SSL_EXTRA_CHAIN_CERTS)
++#if !defined(USE_WOLFSSL)
+ 	x = sk_X509_value(vhost->tls.ssl_ctx->extra_certs, 0);
++#endif
+ #else
+ 	SSL_CTX_get_extra_chain_certs_only(vhost->tls.ssl_ctx, &extra_certs);
+ 	if (extra_certs)

--- a/libs/libwebsockets/patches/200-fix-mbedtls-verson.patch
+++ b/libs/libwebsockets/patches/200-fix-mbedtls-verson.patch
@@ -1,0 +1,14 @@
+--- a/lib/core/context.c
++++ b/lib/core/context.c
+@@ -788,7 +788,11 @@ lws_create_context(const struct lws_cont
+ #endif /* network */
+ 
+ #if defined(LWS_WITH_MBEDTLS)
++#if defined(MBEDTLS_VERSION_C)
+ 	mbedtls_version_get_string(mbedtls_version);
++#else
++	strcpy(mbedtls_version, MBEDTLS_VERSION_STRING);
++#endif
+ #endif
+ 
+ #if defined(LWS_WITH_MBEDTLS)


### PR DESCRIPTION
Maintainer: OpenWrt.org
Compile tested: ath79-generic-openwrt-23.05 (docker sdk tag)
Run tested: ath79/generic, OpenWrt 23.05.2, Netgear WNDR3800

Description: Update libwebsockets to latest 4.3.3, and provide wolfssl variant.