### PR TITLE
irqbalance: Update init script to remove duplicate spaces

### DIFF
--- a/utils/irqbalance/Makefile
+++ b/utils/irqbalance/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=irqbalance
 PKG_VERSION:=1.9.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/Irqbalance/irqbalance.git

--- a/utils/irqbalance/files/irqbalance.init
+++ b/utils/irqbalance/files/irqbalance.init
@@ -16,28 +16,36 @@ start_service() {
 	config_get_bool enabled irqbalance enabled 0
 	[ "$enabled" -gt 0 ] || return 0
 
-	# 2 is the default
 	config_get deepestcache irqbalance deepestcache 2
-
-	# 10 is the default
 	config_get interval irqbalance interval 10
-
-	# empty is the default
 	config_get banned_cpulist irqbalance banned_cpulist ''
-
-	# A list of IRQ's to ignore
-	banirq=""
-	handle_banirq_value()
-	{
-		banirq="$banirq -i $1"
-	}
-	config_list_foreach irqbalance banirq handle_banirq_value
+	config_get debug irqbalance debug 0
 
 	procd_open_instance "irqbalance"
 	if [ -n "$banned_cpulist" ]; then
 		procd_set_param env IRQBALANCE_BANNED_CPULIST="$banned_cpulist"
 	fi
-	procd_set_param command /usr/sbin/irqbalance -f -c "$deepestcache" -t "$interval" "$banirq"
+
+	procd_add_jail_mount_rw /proc
+	procd_set_param command /usr/sbin/irqbalance
+	procd_append_param command -f
+	procd_append_param command "-c $deepestcache"
+	procd_append_param command "-t $interval"
+
+	# add banned IRQs
+	handle_banirq_value()
+	{
+		procd_append_param command "-i $1"
+	}
+	config_list_foreach irqbalance banirq handle_banirq_value
+
+	# debug
+	if [ "$debug" -gt 0 ]; then
+		procd_append_param command -d
+		procd_set_param stdout 1
+	fi
+	procd_set_param stderr 1
+
 	procd_set_param respawn
 	procd_close_instance
 }


### PR DESCRIPTION
I have some strange issues with irqbalance sometimes overwriting smp_affinity values for banned/ignored IRQs. The issue is reproduceable and is mitigated when I change theway how the irqbalance command line is built. The only difference between the resulting command is that there is only one space between the -t parameter and the first -i parameter value.
