### PR TITLE
eza: add new package

### DIFF
--- a/utils/eza/Makefile
+++ b/utils/eza/Makefile
@@ -1,0 +1,46 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=eza
+PKG_VERSION:=0.18.5
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/eza-community/eza/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=9229b2111063577a0cb8650db270d0ae6bcc1b437dbacf814786f77c67b1003d
+
+PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=rust/host
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/eza
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=A modern, maintained replacement for ls
+  DEPENDS:=$(RUST_ARCH_DEPENDS) +zlib
+  URL:=https://eza.rocks
+endef
+
+define Package/eza/description
+ eza is a modern, maintained replacement for the venerable
+ file-listing command-line program ls that ships with Unix
+ and Linux operating systems, giving it more features and
+ better defaults. It uses colours to distinguish file types
+ and metadata. It knows about symlinks, extended attributes,
+ and Git.
+
+ And it’s small, fast, and just one single binary.
+endef
+
+define Package/eza/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/eza $(1)/usr/bin
+endef
+
+$(eval $(call RustBinPackage,eza))
+$(eval $(call BuildPackage,eza))


### PR DESCRIPTION
eza is a substitute for ls command with icons and colors and more. Common for those who use ohmyzsh or similar shell stylers.

Maintainer: Jonas Jelonek / @jonasjelonek 
Compile tested: x86_64, latest git
Run tested: x86_64, latest git