### PR TITLE
https-dns-proxy: update to upstream 2023-11-19

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
-PKG_VERSION:=2023-10-25
-PKG_RELEASE:=5
+PKG_VERSION:=2023-11-19
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/
 PKG_SOURCE_DATE:=$(PKG_VERSION)
-PKG_SOURCE_VERSION:=977341a4e35a37ee454e97e82caf4276b1b4961a
-PKG_MIRROR_HASH:=8622846f1038ac05436a48d9b36a07c516cbb6504ce68e7ee8c5529788fac39b
+PKG_SOURCE_VERSION:=489c57efd46983e688579974a2ab7aeaa7df8d83
+PKG_MIRROR_HASH:=6c8e0e158dfbfde29b1c22f1a1c90a7deae540111c26daac13c8fbb5a49081a5
 
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=MIT
@@ -24,7 +24,7 @@ define Package/https-dns-proxy
 	CATEGORY:=Network
 	TITLE:=DNS Over HTTPS Proxy
 	URL:=https://docs.openwrt.melmac.net/https-dns-proxy/
-	DEPENDS:=+libcares +libcurl +libev +ca-bundle +jsonfilter
+	DEPENDS:=+libcares +libcurl +libev +ca-bundle +jsonfilter +resolveip
 	DEPENDS+=+!BUSYBOX_DEFAULT_GREP:grep
 	DEPENDS+=+!BUSYBOX_DEFAULT_SED:sed
 	CONFLICTS:=https_dns_proxy

--- a/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
+++ b/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
@@ -135,7 +135,7 @@ boot() {
 	ubus -t 30 wait_for network.interface 2>/dev/null
 	on_boot_trigger=1
 	rc_procd start_service 'on_boot' && service_started 'on_boot'
-	is_resolver_working || { rc_procd stop_service 'on_boot' && service_stopped 'on_boot'; }
+	is_resolver_working || { rc_procd stop_service 'on_failed_health_check' && service_stopped 'on_failed_health_check'; }
 }
 
 start_instance() {

--- a/net/https-dns-proxy/patches/020-src-options.c-add-version.patch
+++ b/net/https-dns-proxy/patches/020-src-options.c-add-version.patch
@@ -5,7 +5,7 @@
    return SW_VERSION;
  #else
 -  return "2023.10.10-atLeast";  // update date sometimes, like 1-2 times a year
-+  return "2023-10-25-5";  // update date sometimes, like 1-2 times a year
++  return "2023-11-19-1";  // update date sometimes, like 1-2 times a year
  #endif
  }
  


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2, start/stop/name resolution

Description:
* update to upstream 2023-11-19 (changes: https://github.com/aarond10/https_dns_proxy/commit/489c57efd46983e688579974a2ab7aeaa7df8d83)
* bugfix: include resolveip dependency in Makefile (fixes https://github.com/openwrt/packages/issues/23567)
* minor update for failed healthcheck logging
