### PR TITLE
natmap: update to 20240303

### DIFF
--- a/net/natmap/Makefile
+++ b/net/natmap/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=natmap
-PKG_VERSION:=20240126
+PKG_VERSION:=20240303
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/heiher/natmap/releases/download/$(PKG_VERSION)
-PKG_HASH:=7d8b3fe5c29dfe30271197b8ea1f78af292830483aefb1ccc21a3ec05f74627b
+PKG_HASH:=d7b7a1ba2fc8dbd471ed88757fa6fc7c7e2d83f9f44c8f62661e9809d386d163
 
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>, Ray Wang <r@hev.cc>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @ysc3839 @heiher
Compile tested: armsr-armv8, snapshot; ramips-mt7621, 23.05
Run tested: ramips-mt7621, 23.05

Description:

1. Update to 20240303.