### PR TITLE
rust: restore mis-deleted patch hunk

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
 PKG_VERSION:=1.76.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.xz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/

--- a/lang/rust/patches/0002-rustc-bootstrap-cache.patch
+++ b/lang/rust/patches/0002-rustc-bootstrap-cache.patch
@@ -41,3 +41,15 @@
          let cache_dir = cache_dst.join(key);
          if !cache_dir.exists() {
              t!(fs::create_dir_all(&cache_dir));
+@@ -704,7 +710,10 @@ download-rustc = false
+         let llvm_assertions = self.llvm_assertions;
+ 
+         let cache_prefix = format!("llvm-{llvm_sha}-{llvm_assertions}");
+-        let cache_dst = self.out.join("cache");
++        let cache_dst = match env::var_os("OPENWRT_RUSTC_BOOTSTRAP_CACHE") {
++            Some(v) => PathBuf::from(v),
++            None => self.out.join("cache"),
++        };
+         let rustc_cache = cache_dst.join(cache_prefix);
+         if !rustc_cache.exists() {
+             t!(fs::create_dir_all(&rustc_cache));


### PR DESCRIPTION
Maintainer: @lu-zero 
Compile tested: Atheros ATH79

Description:
Those lines were erroneously deleted in commit dccb910 during manual rebase.
Thanks to @1715173329 for finding it out.
