### PR TITLE
xtables-addons: fix compilation error on kernel 6.6

### DIFF
--- a/net/xtables-addons/patches/211-fix-build-with-kernel-6.6.patch
+++ b/net/xtables-addons/patches/211-fix-build-with-kernel-6.6.patch
@@ -1,0 +1,53 @@
+From 03ec7e6466fc73f3278f9c4775348e9739c4abda Mon Sep 17 00:00:00 2001
+From: W_Y_CPP <383152993@qq.com>
+Date: Thu, 25 Jan 2024 22:38:58 -0500
+Subject: [PATCH] 1
+
+---
+ extensions/LUA/prot_buf_ip.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/extensions/LUA/prot_buf_ip.c b/extensions/LUA/prot_buf_ip.c
+index 9c1004f..f0e28cc 100644
+--- a/extensions/LUA/prot_buf_ip.c
++++ b/extensions/LUA/prot_buf_ip.c
+@@ -17,7 +17,11 @@
+  */
+ 
+ #if defined(__KERNEL__)
++#include <linux/version.h>
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
++	#include <linux/bitops.h>
++#endif
+ 	#include <net/checksum.h>
+ 	#include <net/tcp.h>
+ #endif
+ 
+--- a/extensions/LUA/prot_buf_tcp.c
++++ b/extensions/LUA/prot_buf_tcp.c
+@@ -17,6 +17,10 @@
+  */
+ 
+ #if defined(__KERNEL__)
++#include <linux/version.h>
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
++	#include <linux/bitops.h>
++#endif
+ 	#include <net/checksum.h>
+ 	#include <net/tcp.h>
+ #endif
+--- a/extensions/LUA/prot_buf_udp.c
++++ b/extensions/LUA/prot_buf_udp.c
+@@ -17,6 +17,10 @@
+  */
+ 
+ #if defined(__KERNEL__)
++#include <linux/version.h>
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
++	#include <linux/bitops.h>
++#endif
+ 	#include <net/checksum.h>
+ #endif
+ 
+-- 
+2.17.1


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: x86_64, OpenWRT Snapshot / PR https://github.com/openwrt/openwrt/pull/14751
Run tested: x86_64, OpenWRT Snapshot / PR https://github.com/openwrt/openwrt/pull/14751 System booted, with internet and routing running fine, no packet loss observed

Description: Needs this patch to compile against Kernel 6.6.x based from coolsnowwolf commit on his fork https://github.com/coolsnowwolf/packages/commit/1257305f200b2467fbeff88d005a5ded46b4e4ef or else the following compile error occurs

<details>
  <summary>xtables-addons compile error</summary>
  
  ```sh
# CC [M]  /home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/extensions/LUA/prot_buf_ip.o
  x86_64-openwrt-linux-musl-gcc -Wp,-MMD,/home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/extensions/LUA/.prot_buf_ip.o.d -nostdinc -I./arch/x86/include -I./arch/x86/include/generated  -I./include -I./arch/x86/include/uapi -I./arch/x86/include/generated/uapi -I./include/uapi -I./include/generated/uapi -include ./include/linux/compiler-version.h -include ./include/linux/kconfig.h -include ./include/linux/compiler_types.h -D__KERNEL__ -fmacro-prefix-map=./= -std=gnu11 -fshort-wchar -funsigned-char -fno-common -fno-PIE -fno-strict-aliasing -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx -fcf-protection=none -m64 -falign-jumps=1 -falign-loops=1 -mno-80387 -mno-fp-ret-in-387 -mpreferred-stack-boundary=3 -mskip-rax-setup -mtune=generic -mno-red-zone -mcmodel=kernel -Wno-sign-compare -fno-asynchronous-unwind-tables -mindirect-branch=thunk-extern -mindirect-branch-register -mindirect-branch-cs-prefix -fno-jump-tables -fno-delete-null-pointer-checks -O2 -fno-allow-store-data-races -fstack-protector -fno-omit-frame-pointer -fno-optimize-sibling-calls -fno-stack-clash-protection -falign-functions=16 -fno-strict-overflow -fno-stack-check -fconserve-stack -Wall -Wundef -Werror=implicit-function-declaration -Werror=implicit-int -Werror=return-type -Werror=strict-prototypes -Wno-format-security -Wno-trigraphs -Wno-frame-address -Wno-address-of-packed-member -Wframe-larger-than=2048 -Wno-main -Wno-unused-but-set-variable -Wno-unused-const-variable -Wvla -Wno-pointer-sign -Wcast-function-type -Wno-array-bounds -Wno-alloc-size-larger-than -Wimplicit-fallthrough=5 -Werror=date-time -Werror=incompatible-pointer-types -Werror=designated-init -Wenum-conversion -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-restrict -Wno-packed-not-aligned -Wno-format-overflow -Wno-format-truncation -Wno-stringop-overflow -Wno-stringop-truncation -Wno-missing-field-initializers -Wno-type-limits -Wno-shift-negative-value -Wno-maybe-uninitialized -Wno-sign-compare -g -fno-var-tracking -femit-struct-debug-baseonly -fmacro-prefix-map=/home/builder/lede_x86/build_dir/target-x86_64_musl=target-x86_64_musl -fno-caller-saves -DDEBUG -I/home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/extensions/LUA/prot_buf_new -I/home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/extensions/LUA/lua -I/home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/extensions/LUA/lua/include  -DMODULE  -DKBUILD_BASENAME='"prot_buf_ip"' -DKBUILD_MODNAME='"xt_LUA"' -D__KBUILD_MODNAME=kmod_xt_LUA -c -o /home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/extensions/LUA/prot_buf_ip.o /home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/extensions/LUA/prot_buf_ip.c   ; ./tools/objtool/objtool --hacks=jump_label --hacks=noinstr --retpoline --stackval --static-call --uaccess   --module /home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/extensions/LUA/prot_buf_ip.o
In file included from /home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/extensions/LUA/prot_buf_ip.c:20:
./include/net/checksum.h: In function 'csum_shift':
./include/net/checksum.h:90:40: error: implicit declaration of function 'ror32' [-Werror=implicit-function-declaration]
   90 |                 return (__force __wsum)ror32((__force u32)sum, 8);
      |                                        ^~~~~
In file included from ./include/linux/kernel.h:22,
                 from ./include/linux/skbuff.h:13,
                 from ./include/linux/tcp.h:17,
                 from ./include/net/tcp.h:20,
                 from /home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/extensions/LUA/prot_buf_ip.c:21:
./include/linux/bitops.h: At top level:
./include/linux/bitops.h:134:21: error: conflicting types for 'ror32'; have '__u32(__u32,  unsigned int)' {aka 'unsigned int(unsigned int,  unsigned int)'}
  134 | static inline __u32 ror32(__u32 word, unsigned int shift)
      |                     ^~~~~
In file included from /home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/extensions/LUA/prot_buf_ip.c:20:
./include/net/checksum.h:90:40: note: previous implicit declaration of 'ror32' with type 'int()'
   90 |                 return (__force __wsum)ror32((__force u32)sum, 8);
      |                                        ^~~~~
cc1: some warnings being treated as errors
make[10]: *** [scripts/Makefile.build:243: /home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/extensions/LUA/prot_buf_ip.o] Error 1
make[9]: *** [scripts/Makefile.build:480: /home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/extensions/LUA] Error 2
make[8]: *** [/home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/linux-6.6.18/Makefile:1913: /home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/extensions] Error 2
make[7]: *** [Makefile:234: __sub-make] Error 2
make[7]: Leaving directory '/home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/linux-6.6.18'
make[6]: *** [Makefile:461: modules] Error 2
make[6]: Leaving directory '/home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/extensions'
make[5]: *** [Makefile:621: all-recursive] Error 1
make[5]: Leaving directory '/home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22'
make[4]: *** [Makefile:393: all] Error 2
make[4]: Leaving directory '/home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22'
make[3]: *** [Makefile:177: /home/builder/lede_x86/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.22/.built] Error 2
make[3]: Leaving directory '/home/builder/lede_x86/feeds/packages/net/xtables-addons'
  ```
</details>