### PR TITLE
modemmanager: reconnect interface if the modemmanager detects a disconnect

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_SOURCE_VERSION:=1.22.0
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/usr/lib/ModemManager/connection.d/10-report-down
+++ b/net/modemmanager/files/usr/lib/ModemManager/connection.d/10-report-down
@@ -31,9 +31,9 @@ CFG=$(mm_get_modem_config "${MODEM_DEVICE}")
 IFUP=$(ifstatus "${CFG}" | jsonfilter -e "@.up")
 
 [ "${IFUP}" = "true" ] && {
-	logger -t "modemmanager" "interface ${CFG} (network device ${INTERFACE}) ${STATE}"
-	proto_init_update $INTERFACE 0
-	proto_send_update $CFG
+	mm_log "info" "Reconnecting '${CFG}' on '${STATE}' event"
+	ubus call network.interface down "{ 'interface': '${CFG}'}"
+	ubus call network.interface up "{ 'interface': '${CFG}'}"
 }
 
 exit 0


### PR DESCRIPTION
Maintainer: me / @aleksander0m 
Compile tested: not needed only script changes
Run tested: x86_64, APU3

Description:

There are situation for mobile routers, that the ModemManager can not stay connected to the mobile network in OpenWrt. There can have various reasons. In order for the system to reconnect automatically, the netifd must be informed that it must re-establish the connection.

The modem manager already does have a script callback handling which is already used by the modemmanager in openwrt. Currently the modem is marked as not unavailable when a disconnected event is detected.

The behavior was changed with this commit, so that a reconnect of the interface is now triggerd via the netifd if the modem disconnects.

Testcases:
* Start a connection via netifd modemmanager proto
* Execute the command `mmcli -m 0 --simple-disconnect`
* With this change the netifd should start a reconnection
* After the reconnection execute `ifdown wwan`
* The interface does not reconnect

Therefor, all use case should be covered.
A ModemManager disconnect starts a reconnection via netifd
A User disconnect does not start a reconnection.
