### PR TITLE
syslog-ng: update to version 4.6.0

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
-PKG_VERSION:=4.4.0
+PKG_VERSION:=4.6.0
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
@@ -11,7 +11,7 @@ PKG_CPE_ID:=cpe:/a:balabit:syslog-ng
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syslog-ng/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
-PKG_HASH:=583b147f3ec17fbc2dbbf31aafb1e3966237d7541313de5b41ea885dc16d932e
+PKG_HASH:=b69e3360dfb96a754a4e1cbead4daef37128b1152a23572356db4ab64a475d4f
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1

--- a/admin/syslog-ng/files/syslog-ng.conf
+++ b/admin/syslog-ng/files/syslog-ng.conf
@@ -4,7 +4,7 @@
 # More details about these settings can be found here:
 # https://www.syslog-ng.com/technical-documents/list/syslog-ng-open-source-edition
 
-@version: 4.4
+@version: 4.6
 @include "scl.conf"
 
 options {


### PR DESCRIPTION
Maintainer: me
Compile tested: MacBook A1990, Sonoma 14.3.1 for Turris Omnia router
Run tested: Turris Omnia, mvebu/cortexa9, OpenWrt 22.03

Description:

1. Updated to version 4.6.0
- https://github.com/syslog-ng/syslog-ng/releases/tag/syslog-ng-4.6.0
- https://github.com/syslog-ng/syslog-ng/releases/tag/syslog-ng-4.5.0

2. Bump config file