### PR TITLE
syslog-ng: enable http module based on zlib support in curl

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=4.6.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later
@@ -21,6 +21,7 @@ PKG_BUILD_DEPENDS:= \
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_IPV6 \
+	CONFIG_LIBCURL_ZLIB
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -33,7 +34,7 @@ define Package/syslog-ng
   CATEGORY:=Administration
   TITLE:=A powerful syslog daemon
   URL:=https://www.syslog-ng.com/products/open-source-log-management/
-  DEPENDS:=+libpcre2 +glib2 +libopenssl +libpthread +librt +zlib +libdbi +libjson-c +libcurl +libuuid +SYSLOGNG_LOGROTATE:logrotate
+  DEPENDS:=+libpcre2 +glib2 +libopenssl +libpthread +librt +libdbi +libjson-c +libcurl +libuuid +SYSLOGNG_LOGROTATE:logrotate +LIBCURL_ZLIB:zlib
 endef
 
 define Package/syslog-ng/description
@@ -91,7 +92,7 @@ CONFIGURE_ARGS +=  \
 	--with-jsonc=system \
 	--enable-cpp=no \
 	--enable-json=yes \
-	--enable-http=yes \
+	$(if $(CONFIG_LIBCURL_ZLIB),--enable-http=yes,--enable-http=no) \
 	--disable-smtp \
 	--disable-mqtt \
 	--disable-redis \


### PR DESCRIPTION
Maintainer: me
Compile tested: MacBook A1990, Sonoma 14.3.1 for Turris Omnia router
Run tested: Turris Omnia, mvebu/cortexa9, OpenWrt 22.03

Description:
Since version 4.4.0, syslog-ng added compression to http() destination using zlib from curl. [1] However, zlib is currently disabled in curl [2] and it prevented syslog-ng to start.

This commit changes the configuration opinion to enable http module only if zlib support is enabled for curl and as well it adds dependency for zlib (in that case). If the zlib is disabled, then it disables http module, so syslog-ng can start and thus zlib dependency is not required.

[1] https://gitlab.nic.cz/turris/os/packages/-/issues/932
[2] https://github.com/openwrt/packages/blob/93cbaacbfb13048ad378520a7afea7c9027dd1d6/net/curl/Config.in#L134
Fixes: 4dd49d7c3cd571107958154f1ed1ec8d8dba7464 ("syslog-ng: update to version 4.4.0")

Proof of run testing:


Enabled HTTP, but without curl zlib support (before this commit):
```
root@turris:~# syslog-ng -V
syslog-ng 4 (4.4.0)
Config version: 4.2
Installer-Version: 4.4.0
Revision:
Compile-Date: Oct  9 2023 18:03:02
Module-Directory: /usr/lib/syslog-ng
Module-Path: /usr/lib/syslog-ng
Include-Path: /usr/share/syslog-ng/include
Error opening plugin module; module='http', error='Error relocating /usr/lib/syslog-ng/libhttp.so: deflateEnd: symbol not found'
Available-Modules: kvformat,json-plugin,timestamp,rate-limit-filter,correlation,hook-commands,map-value-pairs,cryptofuncs,basicfuncs,disk-buffer,syslogformat,metrics-probe,secure-logging,cef,system-source,afprog,afstomp,afuser,add-contextual-data,linux-kmsg-format,azure-auth-header,xml,afsocket,tfgetent,pseudofile,regexp-parser,tags-parser,csvparser,confgen,affile,appmodel,graphite,stardate,examples
Enable-Debug: off
Enable-GProf: off
Enable-Memtrace: off
Enable-IPv6: on
Enable-Spoof-Source: off
Enable-TCP-Wrapper: off
Enable-Linux-Caps: off
Enable-Systemd: off
```

**With this commit**

without HTTP support:
```
root@turris:~# syslog-ng -V
syslog-ng 4 (4.6.0)
Config version: 4.2
Installer-Version: 4.6.0
Revision:
Compile-Date: Mar  1 2024 01:19:33
Module-Directory: /usr/lib/syslog-ng
Module-Path: /usr/lib/syslog-ng
Include-Path: /usr/share/syslog-ng/include
Available-Modules: add-contextual-data,affile,afprog,afsocket,afstomp,afuser,appmodel,azure-auth-header,basicfuncs,cef,confgen,correlation,cryptofuncs,csvparser,disk-buffer,examples,graphite,hook-commands,json-plugin,kvformat,linux-kmsg-format,map-value-pairs,metrics-probe,pseudofile,rate-limit-filter,regexp-parser,secure-logging,stardate,syslogformat,system-source,tags-parser,tfgetent,timestamp,xml
Enable-Debug: off
Enable-GProf: off
Enable-Memtrace: off
Enable-IPv6: on
Enable-Spoof-Source: off
Enable-TCP-Wrapper: off
Enable-Linux-Caps: off
Enable-Systemd: off
```

with HTTP support:
```
root@turris:~# syslog-ng -V
syslog-ng 4 (4.6.0)
Config version: 4.2
Installer-Version: 4.6.0
Revision:
Compile-Date: Mar  1 2024 01:19:33
Module-Directory: /usr/lib/syslog-ng
Module-Path: /usr/lib/syslog-ng
Include-Path: /usr/share/syslog-ng/include
Available-Modules: add-contextual-data,affile,afprog,afsocket,afstomp,afuser,appmodel,azure-auth-header,basicfuncs,cef,confgen,correlation,cryptofuncs,csvparser,disk-buffer,examples,graphite,hook-commands,**http**,json-plugin,kvformat,linux-kmsg-format,map-value-pairs,metrics-probe,pseudofile,rate-limit-filter,regexp-parser,secure-logging,stardate,syslogformat,system-source,tags-parser,tfgetent,timestamp,xml
Enable-Debug: off
Enable-GProf: off
Enable-Memtrace: off
Enable-IPv6: on
Enable-Spoof-Source: off
Enable-TCP-Wrapper: off
Enable-Linux-Caps: off
Enable-Systemd: off
```