### PR TITLE
nnn: update to version 4.9

### DIFF
--- a/utils/nnn/Makefile
+++ b/utils/nnn/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nnn
-PKG_VERSION:=4.4
+PKG_VERSION:=4.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jarun/nnn/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=e04a3f0f0c2af1e18cb6f005d18267c7703644274d21bb93f03b30e4fd3d1653
+PKG_HASH:=9e25465a856d3ba626d6163046669c0d4010d520f2fb848b0d611e1ec6af1b22
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=BSD-2-Clause

--- a/utils/nnn/patches/musl-fts.patch
+++ b/utils/nnn/patches/musl-fts.patch
@@ -1,6 +1,6 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -135,7 +135,7 @@ CFLAGS += -std=c11 -Wall -Wextra -Wshado
+@@ -152,7 +152,7 @@ CFLAGS += -std=c11 -Wall -Wextra -Wshado
  CFLAGS += $(CFLAGS_OPTIMIZATION)
  CFLAGS += $(CFLAGS_CURSES)
  


### PR DESCRIPTION
Maintainer: me
Compile tested: MacBook A1990, Sonoma 14.3.1 for Turris Omnia router
Run tested: Turris Omnia, mvebu/cortexa9, OpenWrt 22.03.6 and perfomed basics tests that the applications runs

Description:
Release notes:
https://github.com/jarun/nnn/compare/v4.4...v4.9

and refresh patch