### PR TITLE
eza: update to 0.18.6

### DIFF
--- a/utils/eza/Makefile
+++ b/utils/eza/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=eza
-PKG_VERSION:=0.18.5
+PKG_VERSION:=0.18.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eza-community/eza/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=9229b2111063577a0cb8650db270d0ae6bcc1b437dbacf814786f77c67b1003d
+PKG_HASH:=4cbca009d8ddc817d9ffda34bd1cada4278896e63051c645f0821605a6497faa
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=MIT
@@ -34,7 +34,7 @@ define Package/eza/description
  and metadata. It knows about symlinks, extended attributes,
  and Git.
 
- And it’s small, fast, and just one single binary.
+ And it's small, fast, and just one single binary.
 endef
 
 define Package/eza/install


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64 mediatek/filogic (BananaPi R3), OpenWrt snapshot
Run tested: aarch64 mediatek/filogic (BananaPi R3), OpenWrt snapshot

Description:
- Release notes: https://github.com/eza-community/eza/releases/tag/v0.18.6
- fix typo in description in Makefile (caused weird output in make menuconfig)