### PR TITLE
zabbix: zabbix_helper_mac80211.c: add <libgen.h> header

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=6.4.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \

--- a/admin/zabbix/files/zabbix_helper_mac80211.c
+++ b/admin/zabbix/files/zabbix_helper_mac80211.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <string.h>
+#include <libgen.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <dirent.h>


### PR DESCRIPTION
### Maintainer: @champtar 
Description
---
The musl libc only implements POSIX basename() but provided a GNU header kludge in <string.h>, which is removed in musl 1.2.5 [1]. Use the standard <libgen.h> header to avoid compilation warnings like:
```
zabbix-6.4.7/zabbix-extra-mac80211/zabbix_helper_mac80211.c:37:11: warning: implicit declaration of function 'basename' [-Wimplicit-function-declaration]
   37 |     phy = basename(phy);
      |           ^~~~~~~~
zabbix-6.4.7/zabbix-extra-mac80211/zabbix_helper_mac80211.c:37:9: warning: assignment to 'char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
   37 |     phy = basename(phy);
      |         ^
zabbix-6.4.7/zabbix-extra-mac80211/zabbix_helper_mac80211.c:38:10: warning: assignment to 'char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
   38 |     stat = basename(stat);
      |          ^
```
Link 1: https://git.musl-libc.org/cgit/musl/log/?qt=grep&q=basename

This change is motivated by the `musl 1.25` update in https://github.com/openwrt/openwrt/pull/14802, and has been tested together with that PR.


Testing
---
Build and run tested using QEMU against master with malta/le64 and arm/32 arches.

Review
---
Also pinging @feckert and @Ansuel who are recent contributors to this package.