### PR TITLE
gping: new package

### DIFF
--- a/net/gping/Makefile
+++ b/net/gping/Makefile
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2024 Jonas Jelonek
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gping
+PKG_VERSION:=1.16.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/orf/gping/tar.gz/$(PKG_NAME)-v$(PKG_VERSION)?
+PKG_HASH:=557dad6e54b5dd23f88224ea7914776b7636672f237d9cbbea59972235ca89a8
+
+PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_NAME)-v$(PKG_VERSION)
+PKG_BUILD_DEPENDS:=rust/host
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/gping
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Ping but with a graph
+  DEPENDS:=$(RUST_ARCH_DEPENDS)
+  URL:=https://github.com/orf/gping
+endef
+
+define Package/gping/description
+  gping graphically plots ping results over time in terminal, allows
+  multiple hosts to ping in parallel, uses coloured output and can
+  also plot the execution time of arbitrary commands.
+endef
+
+Build/Compile = $(call Build/Compile/Cargo,gping)
+
+$(eval $(call RustBinPackage,gping))
+$(eval $(call BuildPackage,gping))


### PR DESCRIPTION
gping is ping but with a graph. It graphically plots ping results over time in terminal, allows multiple hosts to ping in parallel, uses coloured output and can also plot the execution time of arbitrary commands.

Maintainer: me
Compile tested: aarch64 mediatek/filogic (BananaPi R3), OpenWrt snapshot
Run tested: aarch64 mediatek/filogic (BananaPi R3), OpenWrt snapshot

Description: see package description above or in the commit message.
This is more of a nice-to-have package, but I find it quite useful to have the ping plotted, to see how it fluctuates, and also to plot exec time of any other command.

PS: The `Build/Compile` needs to be overwritten in the Makefile since gping uses Cargo Workspaces.
