### PR TITLE
zabbix: update to 7.0.0

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -63,6 +63,7 @@ endef
 define Package/zabbix-agentd
   $(call Package/zabbix/Default)
   TITLE+= agentd
+  DEPENDS+= +libevent2-pthreads
   PROVIDES:=zabbix-agentd
   VARIANT:=nossl
   DEFAULT_VARIANT:=1
@@ -71,7 +72,7 @@ endef
 define Package/zabbix-agentd-openssl
   $(call Package/zabbix/Default)
   TITLE+= agentd (with OpenSSL)
-  DEPENDS+= +libopenssl
+  DEPENDS+= +libevent2-pthreads +libopenssl
   PROVIDES:=zabbix-agentd
   VARIANT:=openssl
 endef
@@ -79,7 +80,7 @@ endef
 define Package/zabbix-agentd-gnutls
   $(call Package/zabbix/Default)
   TITLE+= agentd (with GnuTLS)
-  DEPENDS+= +libgnutls
+  DEPENDS+= +libevent2-pthreads +libgnutls
   PROVIDES:=zabbix-agentd
   VARIANT:=gnutls
 endef

--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=6.4.7
-PKG_RELEASE:=2
+PKG_VERSION:=6.4.12
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
 	https://cdn.zabbix.com/zabbix/sources/oldstable/$(basename $(PKG_VERSION))/
-PKG_HASH:=6b4e81f07de4c82c7994871bea51be4d6427683fa9a7fbe112fd7559b3670e49
+PKG_HASH:=b64f3cfc6ca3951d49b024a092d0b20555dd153a9f90c2754caed6600baa13a8
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=6.4.13
+PKG_VERSION:=6.4.14
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
 	https://cdn.zabbix.com/zabbix/sources/oldstable/$(basename $(PKG_VERSION))/
-PKG_HASH:=a92ba21b0679e3abb3a8bfa0b6e16f2b5363bd50460eafec6da4d7050f32b092
+PKG_HASH:=044a4b8828882824f522269df48674fa08506212c7a8a624a0a592d898833841
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=6.4.12
+PKG_VERSION:=6.4.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
 	https://cdn.zabbix.com/zabbix/sources/oldstable/$(basename $(PKG_VERSION))/
-PKG_HASH:=b64f3cfc6ca3951d49b024a092d0b20555dd153a9f90c2754caed6600baa13a8
+PKG_HASH:=a92ba21b0679e3abb3a8bfa0b6e16f2b5363bd50460eafec6da4d7050f32b092
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,16 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=6.4.15
+PKG_VERSION:=7.0.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
 	https://cdn.zabbix.com/zabbix/sources/oldstable/$(basename $(PKG_VERSION))/
-PKG_HASH:=0ad98d0aecc355c8628e29d6728a779465135464b625b89009b9aeb325c142f6
+PKG_HASH:=520641483223f680ef6e685284b556ba34a496d886a38dc3bca085cde21031b1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
-PKG_LICENSE:=GPL-2.0
+PKG_LICENSE:=AGPL-3.0-only
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:zabbix:zabbix
 

--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=6.4.14
+PKG_VERSION:=6.4.15
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
 	https://cdn.zabbix.com/zabbix/sources/oldstable/$(basename $(PKG_VERSION))/
-PKG_HASH:=044a4b8828882824f522269df48674fa08506212c7a8a624a0a592d898833841
+PKG_HASH:=0ad98d0aecc355c8628e29d6728a779465135464b625b89009b9aeb325c142f6
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/admin/zabbix/patches/010-change-agentd-config.patch
+++ b/admin/zabbix/patches/010-change-agentd-config.patch
@@ -30,7 +30,7 @@
 @@ -136,6 +133,7 @@ Server=127.0.0.1
  # Range: 0-100
  # Default:
- # StartAgents=3
+ # StartAgents=10
 +StartAgents=1
  
  ##### Active checks related

--- a/admin/zabbix/patches/110-reproducible-builds.patch
+++ b/admin/zabbix/patches/110-reproducible-builds.patch
@@ -1,7 +1,7 @@
 --- a/src/libs/zbxcommon/misc.c
 +++ b/src/libs/zbxcommon/misc.c
-@@ -329,7 +329,7 @@ void	zbx_help(void)
- void	zbx_version(void)
+@@ -223,7 +223,7 @@ static const char	copyright_message[] =
+ void	zbx_print_version(const char *title_message)
  {
  	printf("%s (Zabbix) %s\n", title_message, ZABBIX_VERSION);
 -	printf("Revision %s %s, compilation time: %s %s\n\n", ZABBIX_REVISION, ZABBIX_REVDATE, __DATE__, __TIME__);


### PR DESCRIPTION
Maintainer: @champtar
Compile tested: ipq806x/wg2600hp3, ramips/wn-ax2033gr
Run tested: ipq806x/wg2600hp3, ramips/wn-ax2033gr

Description:
- Update to latest stable version.
- Fix agentd build error.