### PR TITLE
nginx: Fix compilation with LTO

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.25.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
@@ -23,7 +23,7 @@ PKG_CPE_ID:=cpe:/a:nginx:nginx
 PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
-PKG_BUILD_FLAGS:=gc-sections
+PKG_BUILD_FLAGS:=gc-sections lto
 
 # 3rd-party modules
 PKG_MOD_EXTRA := \

--- a/net/nginx/patches/nginx/102-sizeof_test_fix.patch
+++ b/net/nginx/patches/nginx/102-sizeof_test_fix.patch
@@ -4,7 +4,7 @@
  $NGX_INCLUDE_INTTYPES_H
  $NGX_INCLUDE_AUTO_CONFIG_H
  
-+char object_code_block[] = {
++volatile char object_code_block[] = {
 +	'\n', 'e', '4', 'V', 'A',
 +	'0', 'x', ('0' + sizeof($ngx_type)),
 +	'Y', '3', 'p', 'M', '\n'


### PR DESCRIPTION
Maintainer: @Ansuel 
Compile tested: x86, x86_64 QEMU, master
Run tested: x86, x86_64 QEMU, master, `wget --no-check-certificate https://localhost`

Description:
When CONFIG_USE_LTO=y, the int-size detection script will fail because a variable gets optimised out. Mark it as volatile to fix the issue.