### PR TITLE
gnunet: update to version v0.21.0

### DIFF
--- a/net/gnunet/Makefile
+++ b/net/gnunet/Makefile
@@ -2,11 +2,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnunet
 
-PKG_VERSION:=0.20.0
+PKG_VERSION:=0.21.0
 PKG_RELEASE:=1
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/gnunet
-PKG_HASH:=56029e78a99c04d52b1358094ae5074e4cd8ea9b98cf6855f57ad9af27ac9518
+PKG_HASH:=a846eb9f64b5602c6e518badfa32a9ee18d9e66042ad4765e40a936041ca74ad
 
 PKG_LICENSE:=AGPL-3.0
 PKG_LICENSE_FILES:=COPYING
@@ -28,7 +28,6 @@ CONFIGURE_ARGS+= \
 	--with-libiconv-prefix="$(ICONV_PREFIX)" \
 	--with-libintl-prefix="$(INTL_PREFIX)" \
 	--with-ltdl \
-	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-mysql),--with-mysql="$(STAGING_DIR)/usr",--without-mysql) \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-pgsql),--with-postgresql="$(STAGING_DIR)/usr/bin/pg_config",--without-postgresql) \
 	--with-sqlite3="$(STAGING_DIR)/usr" \
 	--disable-testruns \
@@ -36,7 +35,6 @@ CONFIGURE_ARGS+= \
 	--enable-experimental \
 	--with-extractor=$(STAGING_DIR)/usr \
 	--with-gnutls=$(STAGING_DIR)/usr \
-	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-transport-bluetooth),--with-bluetooth="$(STAGING_DIR)/usr",--without-bluetooth) \
 	--with-jose=$(STAGING_DIR)/usr \
 	--with-libcurl=$(STAGING_DIR)/usr \
 	--with-ogg=$(STAGING_DIR)/usr \
@@ -44,7 +42,6 @@ CONFIGURE_ARGS+= \
 	--with-pabc=$(STAGING_DIR)/usr \
 	--with-png=$(STAGING_DIR)/usr \
 	--with-pulse=$(STAGING_DIR)/usr \
-	--with-libunistring-prefix=$(STAGING_DIR)/usr \
 	--with-microhttpd=$(STAGING_DIR)/usr
 
 # upstream now provides --with-pulseaudio but doesn't detect rpath
@@ -60,8 +57,8 @@ endef
 define Package/gnunet
 $(call Package/gnunet/Default)
   TITLE+= - a peer-to-peer framework focusing on security
-  DEPENDS:=+libatomic +libgcrypt +libgpg-error +libidn2 +libltdl +libsodium \
-           +libunistring +librt +zlib $(ICONV_DEPENDS) $(INTL_DEPENDS)
+  DEPENDS:=+libatomic +libgcrypt +libgmp +libgpg-error +libidn2 +libltdl \
+           +libsodium +libunistring +librt +zlib $(ICONV_DEPENDS) $(INTL_DEPENDS)
   USERID:=gnunet=958:gnunet=958
   MENU:=1
   FILE_MODES:=/usr/lib/gnunet/libexec/gnunet-helper-nat-server:root:gnunet:4750 \
@@ -151,35 +148,35 @@ define Package/gnunet/install
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/lib/gnunet/libexec
 	$(INSTALL_DIR) $(1)/usr/share/gnunet/config.d $(1)/usr/share/gnunet/hellos
 
-	( for bin in arm ats cadet core config ecc identity nat nat-auto nat-server nse \
-	    peerinfo revocation scalarproduct scrypt statistics transport uri; do \
+	( for bin in arm cadet core config ecc identity nat nat-auto nat-server nse \
+	    scalarproduct scrypt statistics uri; do \
 		$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gnunet-$$$$bin $(1)/usr/bin/ || exit 1; \
 	done )
 
-	( for lib in arm ats block blockgroup cadet \
-	    core datacache dht dns fragmentation friends hello \
-	    identity natauto natnew nse nt peerinfo peerstore regexblock regex revocation \
-	    scalarproduct set seti setu statistics transport transportapplication \
+	( for lib in arm block blockgroup cadet \
+	    core datacache dht dns hello \
+	    identity natauto natnew nse peerstore regexblock regex \
+	    scalarproduct set seti setu statistics transportapplication \
 	    transportcommunicator transportcore transportmonitor util; do \
 		$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgnunet$$$$lib.so* $(1)/usr/lib/ || exit 1; \
 	done )
 
-	( for plug in ats_proportional block_dht block_regex block_revocation dhtu_gnunet dhtu_ip transport_unix; do \
+	( for plug in block_dht block_regex; do \
 		$(CP) $(PKG_INSTALL_DIR)/usr/lib/gnunet/libgnunet_plugin_$$$$plug*.so $(1)/usr/lib/gnunet || exit 1; \
 	done )
 
 	( for lex in communicator-unix daemon-topology helper-nat-client \
-	    helper-nat-server service-arm service-ats service-cadet service-core \
+	    helper-nat-server service-arm service-cadet service-core \
 	    service-dht service-identity service-nat service-nat-auto service-nse \
-	    service-peerinfo service-peerstore service-regex service-revocation \
+	    service-peerstore service-regex \
 	    service-scalarproduct-alice service-scalarproduct-bob service-scalarproduct-ecc-alice \
 	    service-scalarproduct-ecc-bob service-set service-seti service-setu service-statistics \
-	    service-tng service-transport timeout; do \
+	    service-transport timeout; do \
 		$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/gnunet/libexec/gnunet-$$$$lex $(1)/usr/lib/gnunet/libexec || exit 1; \
 	done )
 
-	( for conf in arm ats cadet communicator-unix core datacache dht dhtu identity \
-	    nat nat-auto nse peerinfo peerstore regex revocation \
+	( for conf in arm cadet core datacache dht dhtu identity \
+	    nat nat-auto nse peerstore regex \
 	    scalarproduct set seti setu statistics tlds topology transport util; do \
 		$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/gnunet/config.d/$$$$conf.conf $(1)/usr/share/gnunet/config.d || exit 1; \
 	done )
@@ -234,11 +231,6 @@ CONF_hostlist:=hostlist
 LIBEXEC_communicator-udp:=communicator-udp
 LIBEXEC_communicator-tcp:=communicator-tcp
 
-DEPENDS_transport-bluetooth:=+bluez-libs
-PLUGIN_transport-bluetooth:=transport_bluetooth
-LIBEXEC_transport-bluetooth:=helper-transport-bluetooth
-FILE_MODES_transport-bluetooth:=/usr/lib/gnunet/libexec/gnunet-helper-transport-bluetooth:root:gnunet:4750
-
 DEPENDS_transport-http_client:=+gnunet-curl +ca-bundle
 PLUGIN_transport-http_client:=transport_http_client transport_https_client
 
@@ -253,12 +245,6 @@ PLUGIN_transport-wlan:=transport_wlan
 LIBEXEC_transport-wlan:=helper-transport-wlan
 FILE_MODES_transport-wlan:=/usr/lib/gnunet/libexec/gnunet-helper-transport-wlan:root:gnunet:4750
 
-# BIN_dv:=dv
-LIB_dv:=dv
-PLUGIN_dv:=transport_dv
-LIBEXEC_dv:=service-dv
-CONF_dv:=dv
-
 DEPENDS_fs:=+gnunet-datastore +libextractor
 BIN_fs:=auto-share directory download fs publish unindex search
 LIB_fs:=fs
@@ -268,15 +254,12 @@ CONF_fs:=fs
 
 DEPENDS_gns:=+gnunet-vpn +iptables-mod-extra
 USERID_gns:=:gnunetdns=452
-BIN_gns:=gns namecache namestore namestore-dbtool namestore-zonefile resolver zoneimport
-LIB_gns:=gns gnsrecord namecache namestore
-PLUGIN_gns:=block_dns block_gns gnsrecord_conversation gnsrecord_dns gnsrecord_gns namecache_flat
-LIBEXEC_gns:=dns2gns helper-dns service-dns service-gns service-namecache service-namestore service-resolver service-zonemaster
-CONF_gns:=dns gns namecache namestore resolver zonemaster
+BIN_gns:=gns namecache namestore namestore-dbtool namestore-zonefile resolver revocation zoneimport
+LIB_gns:=gns gnsrecord namecache namestore revocation
+PLUGIN_gns:=block_dns block_gns block_revocation gnsrecord_conversation gnsrecord_dns gnsrecord_gns namecache_flat
+LIBEXEC_gns:=dns2gns helper-dns service-dns service-gns service-namecache service-namestore service-resolver service-revocation service-zonemaster
+CONF_gns:=dns gns namecache namestore resolver revocation zonemaster
 FILE_MODES_gns:=/usr/lib/gnunet/libexec/gnunet-helper-dns:root:gnunetdns:4750 /usr/lib/gnunet/libexec/gnunet-service-dns:gnunet:gnunetdns:2750
-
-DEPENDS_namestore-fcfsd:=+gnunet-rest +libmicrohttpd-ssl
-LIBEXEC_namestore-fcfsd:=namestore-fcfsd
 
 DEPENDS_gns-proxy:=+gnunet-gns +gnunet-curl +libmicrohttpd-ssl +PACKAGE_libgnutls-dane:libgnutls-dane
 LIBEXEC_gns-proxy:=gns-proxy
@@ -302,7 +285,7 @@ PLUGIN_reclaim:=block_consensus gnsrecord_reclaim reclaim_credential_jwt reclaim
 
 DEPENDS_rest:=+gnunet-gns +gnunet-reclaim +libmicrohttpd-ssl +jansson +libjose
 LIB_rest:=rest json gnsrecordjson
-PLUGIN_rest:=rest_config rest_copying rest_gns rest_identity rest_namestore rest_peerinfo rest_openid_connect rest_reclaim
+# PLUGIN_rest:=rest_config rest_copying rest_gns rest_identity rest_namestore rest_openid_connect rest_reclaim
 LIBEXEC_rest:=rest-server
 CONF_rest:=rest
 
@@ -314,19 +297,9 @@ CONF_rps:=rps
 PLUGIN_dhtcache-heap:=datacache_heap
 CONFLICTS_dhtcache-heap:=gnunet-dhtcache-pgsql gnunet-dhtcache-sqlite
 
-PLUGIN_peerstore-flat:=peerstore_flat
-
 DEPENDS_fs-heap:=+gnunet-datastore
 PLUGIN_fs-heap:=datastore_heap
-CONFLICTS_fs-heap:=gnunet-fs-mysql gnunet-fs-pgsql gnunet-fs-sqlite
-
-DEPENDS_mysql:=+libmysqlclient
-LIB_mysql:=mysql my
-
-
-DEPENDS_fs-mysql:=+gnunet-mysql +gnunet-datastore
-PLUGIN_fs-mysql:=datastore_mysql
-CONFLICTS_fs-mysql:=gnunet-fs-pgsql gnunet-fs-sqlite
+CONFLICTS_fs-heap:=gnunet-fs-pgsql gnunet-fs-sqlite
 
 DEPENDS_pgsql:=+libpq +pgsql-server
 LIB_pgsql:=pq
@@ -414,8 +387,6 @@ endef
 
 $(eval $(call PostInstFixSUIDPerms,gnunet))
 $(eval $(call PostInstFixSUIDPerms,gnunet-gns))
-$(eval $(call PostInstFixSUIDPerms,gnunet-transport-bluetooth))
-$(eval $(call PostInstFixSUIDPerms,gnunet-transport-wlan))
 $(eval $(call PostInstFixSUIDPerms,gnunet-vpn))
 
 $(eval $(call BuildPackage,gnunet))
@@ -425,7 +396,6 @@ $(eval $(call BuildComponent,conversation,conversation component,))
 $(eval $(call BuildComponent,curl,cURL wrapper component,))
 $(eval $(call BuildComponent,datastore,data storage components,))
 $(eval $(call BuildComponent,dht-cli,DHT command line clients,))
-# $(eval $(call BuildComponent,dv,distance-vector routing component,y))
 $(eval $(call BuildComponent,fs,file-sharing components,))
 $(eval $(call BuildComponent,gns,name resolution components,y))
 $(eval $(call BuildComponent,gns-proxy,gns-proxy component,))
@@ -434,12 +404,8 @@ $(eval $(call BuildComponent,messenger,group chat messenger,))
 $(eval $(call BuildComponent,reclaim,reclaim identity-provider subsystem,))
 $(eval $(call BuildComponent,rest,REST interface,))
 $(eval $(call BuildComponent,rps,RPS routing component,y))
-$(eval $(call BuildComponent,namestore-fcfsd,first-come-first-serve registration server,))
 $(eval $(call BuildComponent,dhtcache-heap,heap-based dhtcache plugin,y))
 $(eval $(call BuildComponent,fs-heap,heap-based filesharing plugin,))
-$(eval $(call BuildComponent,peerstore-flat,flat storage peerstore plugin,))
-$(eval $(call BuildComponent,mysql,mySQL backend,))
-$(eval $(call BuildComponent,fs-mysql,mySQL filesharing plugins,))
 $(eval $(call BuildComponent,pgsql,PostgreSQL backend,))
 $(eval $(call BuildComponent,dhtcache-pgsql,PostgreSQL dhtcache plugin,))
 $(eval $(call BuildComponent,fs-pgsql,PostgreSQL filesharing plugin,))
@@ -451,11 +417,5 @@ $(eval $(call BuildComponent,gns-sqlite,libsqlite3 gns plugins,))
 $(eval $(call BuildComponent,peerstore-sqlite,libsqlite3 peerstore plugin,))
 $(eval $(call BuildComponent,communicator-tcp,tng transport TCP communicator,y))
 $(eval $(call BuildComponent,communicator-udp,tng transport UDP communicator,y))
-$(eval $(call BuildComponent,transport-bluetooth,bluetooth transport,))
-$(eval $(call BuildComponent,transport-http_client,HTTP/HTTPS client transport,y))
-$(eval $(call BuildComponent,transport-http_server,HTTP/HTTPS server transport,))
-$(eval $(call BuildComponent,transport-tcp,TCP transport,y))
-$(eval $(call BuildComponent,transport-udp,UDP transport,y))
-$(eval $(call BuildComponent,transport-wlan,WLAN transport,y))
 $(eval $(call BuildComponent,utils,administration utililties,))
 $(eval $(call BuildComponent,vpn,vpn components,y))

--- a/net/gnunet/patches/010-DHTU-ship-dhtu-conf.patch
+++ b/net/gnunet/patches/010-DHTU-ship-dhtu-conf.patch
@@ -1,0 +1,37 @@
+From 79b58e8a0c4155134bdf680899fab22a7c01f35a Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sat, 9 Mar 2024 00:46:18 +0000
+Subject: [PATCH] DHTU: ship dhtu.conf
+To: gnunet-developers@gnu.org
+
+Without dhtu.conf GNUnet will create infinite loglines
+ERROR No DHT underlays configured!
+
+Ship the new config file to fix that.
+---
+ src/service/dht/Makefile.am | 3 +++
+ src/service/dht/meson.build | 6 ++++++
+ 2 files changed, 9 insertions(+)
+
+--- a/src/service/dht/Makefile.am
++++ b/src/service/dht/Makefile.am
+@@ -10,6 +10,9 @@ libexecdir= $(pkglibdir)/libexec/
+ pkgcfg_DATA = \
+   dht.conf
+ 
++dist_pkgcfg_DATA = \
++  dhtu.conf
++
+ if USE_COVERAGE
+   AM_CFLAGS = --coverage -O0
+   XLIB = -lgcov
+--- /dev/null
++++ b/src/service/dht/dhtu.conf
+@@ -0,0 +1,7 @@
++[dhtu-gnunet]
++ENABLED = YES
++
++[dhtu-ip]
++ENABLED = NO
++NSE = 4
++UDP_PORT = 6666

--- a/net/gnunet/patches/020-curl-no-runtime-test.patch
+++ b/net/gnunet/patches/020-curl-no-runtime-test.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -727,12 +727,7 @@ LIBCURL_CHECK_CONFIG([], [7.34.0], [],
+@@ -727,12 +727,7 @@ LIBCURL_CHECK_CONFIG([], [7.85.0], [],
  
  OLD_LIBS=$LIBS
  LIBS="$LIBS $LIBCURL"


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_cortex-a53
Run tested: -
Description:
This release marks a noteworthy milestone in that it includes a completely new transport layer. It lays the groundwork for fixing some major design issues and may also already alleviate a variety of issues seen in previous releases related to connectivity. This change also deprecates our testbed and ATS subsystem.

This is a new major release. It breaks protocol compatibility with the 0.20.x versions. Please be aware that Git master is thus henceforth (and has been for a while) INCOMPATIBLE with the 0.20.x GNUnet network, and interactions between old and new peers will result in issues. In terms of usability, users should be aware that there are still a number of known open issues in particular with respect to ease of use, but also some critical privacy issues especially for mobile users. Also, the nascent network is tiny and thus unlikely to provide good anonymity or extensive amounts of interesting information. As a result, the 0.21.0 release is still only suitable for early adopters with some reasonable pain tolerance.

v0.21.0:

- Reworked PEERSTORE API

- Added record flag for maintenance records

- ensure traits can be generated with subsystem-specific prefixes for the symbols

- libgnunettesting first major testing NG refactor towards getting dependency structure streamlined

- Remove single-use API macro `GNUNET_VA_ARG_ENUM`

- major revision of blind signature API

- Introduced closure to hold store context when calling function to add hello in peerstore.

- Added DDLs for handling `GNUNET_PEERSTORE_StoreHelloContext`

- Removed old hello functionality.

- Refactoring components under `src/` into `lib/`, `plugin/`, `cli/` and `service/`

- add support for encoding/decoding double values as part of JSON to libgnunetjson

- Changed method `GNUNET_HELLO_builder_get_expiration_time` to not need parameter `GNUNET_HELLO_Builder`.

- Code moved to the core package to get rid of circular dependencies.

- Moved code to testing to have more generic test setup, which can be used not only from within transport.

- The old hello design replaced by the new hello design.

- Added api to get notified when hellos are stored with peerstore service.

- Added api to store hellos with peerstore service.

- Changed new hello uri api to allow to change the expiration time

- Moved start peer command to testing subsystem.

- Removed all usage of old transport api, beside peerinfo tool, gnunet-transport cli and usage in transport layer itself.

- Added `__attribute__((deprecated))` to the old transport API