### PR TITLE
espeak: remove libstdcpp dependency

### DIFF
--- a/sound/espeak/Makefile
+++ b/sound/espeak/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=espeak
 PKG_VERSION:=1.48.04
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-source.zip
 PKG_SOURCE_URL:=@SF/espeak
@@ -27,7 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/espeak
   SECTION:=sound
   CATEGORY:=Sound
-  DEPENDS:=+libstdcpp +portaudio
+  DEPENDS:=+portaudio
   TITLE:=Speech synthesizer
   URL:=http://espeak.sourceforge.net/
 endef
@@ -52,7 +52,7 @@ MAKE_FLAGS+= \
 MAKE_PATH:=./src
 
 TARGET_CXXFLAGS += -std=c++14
-TARGET_LDFLAGS += $(FPIC) $(if $(CONFIG_USE_GLIBC),-lm) -Wl,--as-needed
+TARGET_LDFLAGS += $(FPIC) -Wl,--as-needed
 
 define Package/espeak/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Apparently it goes away when passing --as-needed.

Maintainer: nobody