### PR TITLE
microsocks: update to 1.0.4

### DIFF
--- a/net/microsocks/Makefile
+++ b/net/microsocks/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=microsocks
-PKG_VERSION:=1.0.3
+PKG_VERSION:=1.0.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/rofl0r/microsocks/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6801559b6f8e17240ed8eef17a36eea8643412b5a7476980fd4e24b02a021b82
+PKG_HASH:=130127a87f55870f18fbe47a64d9b9533020e2900802d36a0f6fd2b074313deb
 
 PKG_MAINTAINER:=Mateusz Korniak <matkorgithubcom@ant.gliwice.pl>
 PKG_LICENSE:=MIT

--- a/net/microsocks/files/microsocks.config
+++ b/net/microsocks/files/microsocks.config
@@ -7,3 +7,4 @@ config microsocks 'config'
 	option user ''
 	option password ''
 	option auth_once '0' # Boolean, must be used together with user/pass
+	option quiet '1'

--- a/net/microsocks/files/microsocks.init
+++ b/net/microsocks/files/microsocks.init
@@ -18,6 +18,7 @@ start_service() {
 	local _user
 	local _format
 	local _auth_once
+	local _quiet
 
 	config_get _port "config" "port"
 	config_get _listenip "config" "listenip"
@@ -25,6 +26,7 @@ start_service() {
 	config_get _user "config" "user"
 	config_get _password "config" "password"
 	config_get_bool _auth_once "config" "auth_once" 0
+	config_get_bool _quiet "config" "quiet" 0
     
 	procd_open_instance "$CONF"
 	procd_set_param command /usr/bin/microsocks
@@ -34,6 +36,7 @@ start_service() {
 	[ -z "$_user" ] || procd_append_param command -u "${_user}"
 	[ -z "$_password" ] || procd_append_param command -P "${_password}"
 	[ "$_auth_once" -eq "0" ] || procd_append_param command -1
+	[ "$_quiet" -eq "0" ] || procd_append_param command -q
 	
 	procd_set_param respawn
 	procd_set_param stderr 1


### PR DESCRIPTION
Maintainer: Mateusz Korniak / @matkor
Compile tested: ipq806x, Netgear Nighthawk X4S R7800
Run tested: ipq806x, Netgear Nighthawk X4S R7800, OpenWrt 23.05-SNAPSHOT r23786-2f2eceab13 / LuCI openwrt-23.05 branch git-24.067.02086-146a8f1

Have been using a custom build of microsocks on the latest commit of the 1.0.4 release, for over 2 months. 

Description:
Updated package microsocks to version 1.0.4. Added configuration flag for the newly added quiet mode. 

Setup the config file so that quiet mode is enabled by default. On frequent use of the proxy, the per-site-visit logging quickly fills up the limited log history, therefore it makes sense from a usability perspective for it to be turned off by default. 