### PR TITLE
Update etherwake-nfqueue to version 4

### DIFF
--- a/net/etherwake-nfqueue/Makefile
+++ b/net/etherwake-nfqueue/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=etherwake-nfqueue
-PKG_RELEASE:=3
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/mister-benjamin/etherwake-nfqueue.git
-PKG_SOURCE_DATE:=2019-09-28
-PKG_SOURCE_VERSION:=f71c269b58585e93575fa3e9fcc1793806fb3080
-PKG_MIRROR_HASH:=4960dc592abc4ca06504c92ca09fc736c678353df0dcc32d4081e17b137a9164
+PKG_SOURCE_DATE:=2023-06-20
+PKG_SOURCE_VERSION:=857c8714c4aec2b54ae70655c6d0e13f3c70ed0a
+PKG_MIRROR_HASH:=5685537c0a904bd27d07810a782d8ab500f1aa117d0fe41631a7b13dc48cb054
 
 PKG_MAINTAINER:=Mister Benjamin <144dbspl@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -25,7 +25,7 @@ include $(INCLUDE_DIR)/cmake.mk
 define Package/etherwake-nfqueue
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libnetfilter-queue +nftables +kmod-nft-queue
+  DEPENDS:=+libnetfilter-queue +nftables +kmod-nft-queue +libmnl
   TITLE:=Wake up computers on netfilter match
   URL:=https://github.com/mister-benjamin/etherwake-nfqueue
 endef

--- a/net/etherwake-nfqueue/README.md
+++ b/net/etherwake-nfqueue/README.md
@@ -146,6 +146,7 @@ The full list of options for a target is:
 | interface   | no       | The interface used for sending the magic packet, default is interface=eth0 |
 | broadcast   | no       | Send magic packet to broadcast address, default is broadcast=off |
 | password    | no       | Set a password (required by some adapters), e.g. password=00:22:44:66:88:aa or 192.168.1.1 |
+| defer       | no       | Defer delivery of matched packets until host with specified IP address responds to a ping i.e. has woken up |
 | enabled     | no       | Optionally disable the target, default is enabled=true |
 
 After committing your changes, the settings are persisted to
@@ -172,6 +173,7 @@ config target
         option nfqueue_num '2'
         option interface 'eth0.3'
         option broadcast 'on'
+        option defer '192.168.3.2'
         option password '00:25:90:00:d5:fb'
 ```
 

--- a/net/etherwake-nfqueue/files/etherwake-nfqueue.config
+++ b/net/etherwake-nfqueue/files/etherwake-nfqueue.config
@@ -14,6 +14,9 @@ config etherwake-nfqueue 'setup'
 # # uci set etherwake-nfqueue.@target[-1].interface=eth0
 # Configure if it should be sent to broadcast address, defaults to off
 # # uci set etherwake-nfqueue.@target[-1].broadcast=off
+# Optionally enable defer delivery mechanism and provide an IP address of the host to be woken up
+# e.g. 192.168.1.1
+# # uci set etherwake-nfqueue.@target[-1].defer=192.168.1.1
 # Optionally provide a password (required by some adapters)
 # e.g. 00:22:44:66:88:aa or 192.168.1.1
 # # uci set etherwake-nfqueue.@target[-1].password=00:22:44:66:88:aa

--- a/net/etherwake-nfqueue/files/etherwake-nfqueue.init
+++ b/net/etherwake-nfqueue/files/etherwake-nfqueue.init
@@ -60,6 +60,9 @@ start_instance()
     config_get value "${section}" password
     [ -n "${value}" ] && procd_append_param command -p "${value}"
 
+    config_get value "${section}" defer
+    [ -n "${value}" ] && procd_append_param command -d "${value}"
+
     config_get value "${section}" nfqueue_num 0
     procd_append_param command -q "${value}"
 


### PR DESCRIPTION
Maintainer: Mister Benjamin / @mister-benjamin
Compile tested: x86, Manjaro Linux, OpenWRT 23.05 for ipq40xx
Run tested: ARMv7, ipq40xx, AVM FRITZ!Box 7530, OpenWRT 23.05.2, casual test with and without new mechanism

Description:
Update rewrites deprecated functions. Furthermore a defer mechanism was added which holds packets in queue until host responds, i.e., has woken up. This should prevent packets from being lost.