### PR TITLE
fx: update to 32.0.0

### DIFF
--- a/utils/fx/Makefile
+++ b/utils/fx/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fx
-PKG_VERSION:=31.0.0
+PKG_VERSION:=32.0.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/antonmedv/fx/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=8408047ef42506aac44aa805de209dd64ae4fc084e76bee8e24112ffbdc2d5dc
+PKG_HASH:=584c7f1178bedec605a2487abe3f7909b05a9d13eff878edca2be4dab8f489f4
 
 PKG_MAINTAINER:=Fabian Lipken <dynasticorpheus@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @dynasticorpheus 
Compile tested: Ubuntu 23.04 x64 / OpenWrt SNAPSHOT @ 36b1dd75fd9da1ea13f1ce1ee679c6b3c9c402cc
Run tested: Linksys WRT32X / OpenWrt SNAPSHOT r24315-ae500e62e2

Description: Update to [32.0.0](https://github.com/antonmedv/fx/compare/31.0.0...32.0.0)

Fx is a dual-purpose command-line tool tailored for JSON, providing both a terminal-based JSON viewer and a JSON processing utility.


