### PR TITLE
chore(net/knot-resolver): Correct build flags so that dnstap option works again.

### DIFF
--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -59,7 +59,6 @@ MESON_ARGS+= \
 	-Dcapng=disabled \
 	-Dclient=disabled \
 	-Dconfig_tests=disabled \
-	-Ddnstap=disabled \
 	-Ddoc=disabled \
 	-Dinstall_kresd_conf=disabled \
 	-Dinstall_root_keys=disabled \


### PR DESCRIPTION
Maintainer: Jan Pavlinec <jan.pavlinec1@gmail.com>
Compile tested: octeon/generic, EdgeRouter-4, openwrt-23.05, main.
Run tested:  octeon/generic, EdgeRouter-4, tests: setup dnstap in knot-resolver and used dnstap package to ship to go-dnscollector.
Description:
Previously this didn't respect the dnstap option. It does now.
