### PR TITLE
shairport-sync:  mqtt support

### DIFF
--- a/sound/shairport-sync/Makefile
+++ b/sound/shairport-sync/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shairport-sync
 PKG_VERSION:=4.3.2
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikebrady/shairport-sync/tar.gz/$(PKG_VERSION)?
@@ -29,7 +29,7 @@ define Package/shairport-sync/default
   SECTION:=sound
   CATEGORY:=Sound
   TITLE:=AirPlay compatible audio player
-  DEPENDS:=@AUDIO_SUPPORT +libpthread +alsa-lib +libconfig +libdaemon +libpopt +libplist +libsodium +libgcrypt +libffmpeg-full +libuuid +nqptp
+  DEPENDS:=@AUDIO_SUPPORT +libpthread +alsa-lib +libconfig +libdaemon +libpopt +libplist +libsodium +libgcrypt +libffmpeg-full +libuuid +nqptp +libmosquitto
   PROVIDES:=shairport-sync
   URL:=https://github.com/mikebrady/shairport-sync
 endef
@@ -80,6 +80,7 @@ CONFIGURE_ARGS += \
 	--with-libdaemon \
 	--with-airplay-2 \
 	--with-pipe \
+	--with-mqtt-client \
 	--with-metadata
 
 ifeq ($(BUILD_VARIANT),openssl)

--- a/sound/shairport-sync/files/shairport-sync.config
+++ b/sound/shairport-sync/files/shairport-sync.config
@@ -60,6 +60,17 @@ config shairport-sync 'shairport_sync'
 	# Stdout
 	option stdout_latency_offset '' # 0
 	option stdout_buffer_length '' # 44100
+	# MQTT: https://github.com/mikebrady/shairport-sync/blob/master/MQTT.md
+	option mqtt_enabled 'no'
+	option mqtt_hostname '127.0.0.1'
+	option mqtt_port '1883'
+	option mqtt_username '' # empty = no authentication
+	option mqtt_password '' # empty = no authentication
+	option mqtt_topic 'shairport'
+	option mqtt_publish_raw 'no'
+	option mqtt_publish_parsed 'no'
+	option mqtt_publish_cover 'no'
+	option mqtt_enable_remote 'no'
 	# AO
 	option ao_latency_offset '' # 0
 	option ao_buffer_length '' # 44100

--- a/sound/shairport-sync/files/shairport-sync.init
+++ b/sound/shairport-sync/files/shairport-sync.init
@@ -120,6 +120,21 @@ start_instance() {
 		append_num "$cfg" stdout_buffer_length "audio_backend_buffer_desired_length"
 		printf "};\n\n"
 
+		# MQTT
+		printf "mqtt =\n"
+		printf "{\n"
+		append_str "$cfg" mqtt_enabled "enabled"
+		append_str "$cfg" mqtt_hostname "hostname"
+		append_num "$cfg" mqtt_port "port"
+		append_str "$cfg" mqtt_username "username"
+		append_str "$cfg" mqtt_password "password"
+		append_str "$cfg" mqtt_topic "topic"
+		append_str "$cfg" mqtt_publish_raw "publish_raw"
+		append_str "$cfg" mqtt_publish_parsed "publish_parsed"
+		append_str "$cfg" mqtt_publish_cover "publish_cover"
+		append_str "$cfg" mqtt_enable_remote "enable_remote"
+		printf "};\n\n"
+
 		# AO audio back end
 		printf "ao =\n"
 		printf "{\n"


### PR DESCRIPTION
Maintainer: @mikebrady 
Compile tested: NanoPi R4s SNAPSHOT
Run tested: NanoPi R4s SNAPSHOT

Description:
- Enable compile time MQTT support in shairport-sync
- Support all shairport-sync related MQTT config in UCI 

Why ?

shairport-sync is remote control capable over MQTT. This, along with a custom script outside the scope of this PR, is needed to stop shairport sync when for instance a mpd / other audio servers are playing 