### PR TITLE
httping: add license informations

### DIFF
--- a/net/httping/Makefile
+++ b/net/httping/Makefile
@@ -10,6 +10,8 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=httping
 PKG_VERSION:=3.5
 PKG_RELEASE:=1
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/folkertvanheusden/HTTPing


### PR DESCRIPTION
Maintainer: @jefferyto @krant 
Compile tested: not needed only Makefile change
Run tested: not needed only Makefile change

Description:
Add missing license information.
https://github.com/folkertvanheusden/HTTPing/blob/master/LICENSE
