### PR TITLE
ci: set correct arch for rootfs tests

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -196,11 +196,11 @@ jobs:
       - name: Build Docker container
         if: ${{ matrix.runtime_test && fromJSON(env.HAVE_IPKS) }}
         run: |
-          docker build -t test-container --build-arg ARCH .github/workflows/
+          docker build --platform linux/${{ matrix.arch }} -t test-container --build-arg ARCH .github/workflows/
         env:
           ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
 
       - name: Test via Docker container
         if: ${{ matrix.runtime_test && fromJSON(env.HAVE_IPKS) }}
         run: |
-          docker run --rm -v $GITHUB_WORKSPACE:/ci test-container
+          docker run --platform linux/${{ matrix.arch }} --rm -v $GITHUB_WORKSPACE:/ci test-container


### PR DESCRIPTION
With the commit 01e5cfc "CI: Add target/arch tags (no suffix) for snapshot images"[1] the os/platform is set for all images, which is usually different from what the GitHub action runner uses (x86). The Docker deamon still tries to fetch the x86 version and fails.

This commit explicitly sets the fitting arch.

[1]: https://github.com/openwrt/docker/commit/01e5cfccd73a72ecab730496607c7c22b904f366

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
