### PR TITLE
libdeflate: update to 1.19

### DIFF
--- a/libs/libdeflate/Makefile
+++ b/libs/libdeflate/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdeflate
-PKG_VERSION:=1.18
+PKG_VERSION:=1.19
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/ebiggers/libdeflate/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=225d982bcaf553221c76726358d2ea139bb34913180b20823c782cede060affd
+PKG_SOURCE_URL:=https://github.com/ebiggers/libdeflate/releases/download/v$(PKG_VERSION)
+PKG_HASH:=d9bb9bdd8cc5a8c1f7f6226fa0053dd72861e15f366e7ff7d0d191eac16d66f3
 
 PKG_LICENSE:=COPYING
 PKG_LICENSE_FILES:=MIT


### PR DESCRIPTION
Maintainer: @dangowrt 
Run tested: ARMv7, Linksys WRT3200ACM, master branch

Description:
  - Use proper tarball URL.
