### PR TITLE
eza: update to 0.18.7

### DIFF
--- a/utils/eza/Makefile
+++ b/utils/eza/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=eza
-PKG_VERSION:=0.18.6
+PKG_VERSION:=0.18.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eza-community/eza/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=4cbca009d8ddc817d9ffda34bd1cada4278896e63051c645f0821605a6497faa
+PKG_HASH:=e712e3ae97ca7ee28e411b8537e20b1efb88b3e052c8053c13d70ae97bae9b61
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64 mediatek/filogic (BananaPi R3), OpenWrt snapshot
Run tested: aarch64 mediatek/filogic (BananaPi R3), OpenWrt snapshot

Description:
- Release notes: https://github.com/eza-community/eza/releases/tag/v0.18.7
