### PR TITLE
tgt: update to 1.0.91

### DIFF
--- a/net/tgt/Makefile
+++ b/net/tgt/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tgt
-PKG_VERSION:=1.0.90
+PKG_VERSION:=1.0.91
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fujita/tgt/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=e832a19c2831bde83e7078cd7a8d2fc8fe5c5f38ddd51130f5123013416d4cff
+PKG_HASH:=3bfd50e19f308e9d197e2f6877fb5d13e4777e5bbb61716a7409b3735b481d8f
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-2.0-only

--- a/net/tgt/patches/100-musl-compat.patch
+++ b/net/tgt/patches/100-musl-compat.patch
@@ -13,9 +13,9 @@
  #define NR_SCSI_OPCODES		256
 --- a/usr/util.h
 +++ b/usr/util.h
-@@ -20,6 +20,10 @@
- #include <sys/types.h>
+@@ -21,6 +21,10 @@
  #include <sys/stat.h>
+ #include <sys/types.h>
  
 +#ifndef __WORDSIZE
 +#include <sys/reg.h>


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_cortex-a53, r25557+3-8fb23465ca
Run tested: aarch64_cortex-a53, ipq807x, Dynalink DL-WRX36, r25557+3-8fb23465ca in a chroot on r23300+3-86bc525d00. Exporting a file as a iSCSI target works.

Description:
- update to 1.0.91
- refresh patches
