### PR TITLE
ddns-scripts: Add servercow.de as DDNS provider

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=42
+PKG_RELEASE:=43
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/servercow.de.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/servercow.de.json
@@ -1,0 +1,11 @@
+{
+	"name": "servercow.de",
+	"ipv4": {
+		"url": "http://www.servercow.de/dnsupdate/update.php?username=[USERNAME]&pass=[PASSWORD]&hostname=[DOMAIN]&ipaddr=[IP]",
+		"answer": "OKv4"
+	},
+	"ipv6": {
+		"url": "http://www.servercow.de/dnsupdate/update.php?username=[USERNAME]&pass=[PASSWORD]&hostname=[DOMAIN]&ip6addr=[IP]",
+		"answer": "OKv6"
+	}
+}

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -54,6 +54,7 @@ ovh.com
 regfish.de
 schokokeks.org
 selfhost.de
+servercow.de
 simply.com
 sitelutions.com
 spdyn.de


### PR DESCRIPTION
Run tested: x86-64 22.03

Description:
Add ddns provider servercow.de.
Description of usage at https://cp.servercow.de/plugin/support_manager/knowledgebase/view/46/dns-update-through-fritzbox-router/