### PR TITLE
minisatip: Fix configure option for openssl

### DIFF
--- a/multimedia/minisatip/Makefile
+++ b/multimedia/minisatip/Makefile
@@ -48,7 +48,7 @@ endef
 
 CONFIGURE_ARGS += \
 	--$(if $(CONFIG_BUILD_PATENTED),en,dis)able-dvbcsa \
-	--$(if $(CONFIG_MINISATIP_AES),en,dis)able-dvbaes \
+	--$(if $(CONFIG_MINISATIP_AES),en,dis)able-dvbca \
 	--$(if $(CONFIG_MINISATIP_CLIENT),en,dis)able-satipc
 
 define Package/minisatip/install


### PR DESCRIPTION
The configure option which depends on openSSL is named --disable-dvbca and not --disable-dvbaes

This fixes the following warning:
configure: WARNING: unrecognized options: --disable-dependency-tracking, --disable-nls, --disable-dvbaes

When the option is not set configure will check if openssl is available and compile against openssl if it find openssl. This breaks the build because openssl is not defined as a package dependency.

Maintainer: @danielkucera 
Compile tested: malta/be
Run tested: no