### PR TITLE
prometheus-node-exporter-lua-hostapd_stations: fix hostapd exporter not reporting metrics

### DIFF
--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/hostapd_stations.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/hostapd_stations.lua
@@ -33,10 +33,10 @@ local function get_wifi_interface_labels()
     for _, intf in ipairs(dev_table['interfaces']) do
       local cfg = intf['config']
 
-      if is_ubus_interface(ubus_interfaces, cfg['ifname']) then
+      if is_ubus_interface(ubus_interfaces, intf['ifname']) then
 
         -- Migrate this to ubus interface once it exposes all interesting labels
-        local handle = io.popen("hostapd_cli -i " .. cfg['ifname'] .." status")
+        local handle = io.popen("hostapd_cli -i " .. intf['ifname'] .." status")
         local hostapd_status = handle:read("*a")
         handle:close()
 
@@ -50,7 +50,7 @@ local function get_wifi_interface_labels()
             hostapd["channel"] = value
           -- hostapd gives us all bss on the relevant phy, find the one we're interested in
           elseif string.match(name, "bss%[%d%]") then
-            if value == cfg['ifname'] then
+            if value == intf['ifname'] then
               bss_idx = tonumber(string.match(name, "bss%[(%d)%]"))
             end
           elseif bss_idx >= 0 then
@@ -63,7 +63,7 @@ local function get_wifi_interface_labels()
         end
 
         local labels = {
-          vif = cfg['ifname'],
+          vif = intf['ifname'],
           ssid = hostapd['ssid'],
           bssid = hostapd['bssid'],
           encryption = cfg['encryption'], -- In a mixed scenario it would be good to know if A or B was used


### PR DESCRIPTION
Maintainer: @champtar 
Compile tested: -
Run tested: (put here arch, model, OpenWrt version, tests done)
- xRX200 rev 1.2, BT Home Hub 5A, OpenWrt 22.03.5 r20134-5f15225c1e
- Qualcomm Atheros QCA9558 ver 1 rev 0, TP-Link TL-WR1043ND v2, OpenWrt 23.05.2 r23630-842932a63d
- MediaTek MT7621 ver:1 eco:3, D-Team Newifi D2, OpenWrt 23.05.2 r23630-842932a63d
- Atheros AR9132 rev 2, TP-Link TL-WR1043ND v1, OpenWrt 22.03.6 r20265-f85a79bcb4

I've overwritten lua file on all devices and after restarting the `prometheus-node-exporter-lua` service, the metrics appeared on the metrics endpont correctly.

Description:
Due to a bug in hostapd_stations.lua, hostapd exporter skips all interfaces and does not provide any metrics.

Metrics before the fix:
```
# TYPE hostapd_station_receive_packets_total counter
# TYPE hostapd_station_receive_bytes_total counter
# TYPE hostapd_station_transmit_packets_total counter
# TYPE hostapd_station_transmit_bytes_total counter
# TYPE hostapd_station_signal_dbm gauge
# TYPE hostapd_station_connected_seconds_total counter
# TYPE hostapd_station_inactive_seconds gauge
# TYPE hostapd_station_flag_auth gauge
# TYPE hostapd_station_flag_assoc gauge
# TYPE hostapd_station_flag_short_preamble gauge
# TYPE hostapd_station_flag_ht gauge
# TYPE hostapd_station_flag_vht gauge
# TYPE hostapd_station_flag_he gauge
# TYPE hostapd_station_flag_mfp gauge
# TYPE hostapd_station_flag_wmm gauge
# TYPE hostapd_station_sae_group gauge
# TYPE hostapd_station_vht_capb_su_beamformee gauge
# TYPE hostapd_station_vht_capb_mu_beamformee gauge
node_scrape_collector_duration_seconds{collector="hostapd_stations"} 0.0054290294647217
node_scrape_collector_success{collector="hostapd_stations"} 1
```

Metrics after the fix:
```
# TYPE hostapd_station_receive_packets_total counter
# TYPE hostapd_station_receive_bytes_total counter
# TYPE hostapd_station_transmit_packets_total counter
# TYPE hostapd_station_transmit_bytes_total counter
# TYPE hostapd_station_signal_dbm gauge
# TYPE hostapd_station_connected_seconds_total counter
# TYPE hostapd_station_inactive_seconds gauge
# TYPE hostapd_station_flag_auth gauge
# TYPE hostapd_station_flag_assoc gauge
# TYPE hostapd_station_flag_short_preamble gauge
# TYPE hostapd_station_flag_ht gauge
# TYPE hostapd_station_flag_vht gauge
# TYPE hostapd_station_flag_he gauge
# TYPE hostapd_station_flag_mfp gauge
# TYPE hostapd_station_flag_wmm gauge
# TYPE hostapd_station_sae_group gauge
# TYPE hostapd_station_vht_capb_su_beamformee gauge
# TYPE hostapd_station_vht_capb_mu_beamformee gauge
hostapd_station_flag_auth{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 1
hostapd_station_flag_assoc{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 1
hostapd_station_flag_short_preamble{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 0
hostapd_station_flag_ht{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 1
hostapd_station_flag_vht{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 1
hostapd_station_flag_he{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 0
hostapd_station_flag_wmm{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 1
hostapd_station_flag_mfp{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 0
hostapd_station_receive_packets_total{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 31
hostapd_station_receive_bytes_total{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 4911
hostapd_station_transmit_packets_total{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 22
hostapd_station_transmit_bytes_total{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 4299
hostapd_station_inactive_seconds{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 0.14
hostapd_station_signal_dbm{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} -45
hostapd_station_connected_seconds_total{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 1
hostapd_station_vht_capb_su_beamformee{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 1
hostapd_station_vht_capb_mu_beamformee{ssid="ssid",vif="wlan0",encryption="psk2+ccmp",channel="132",bssid="xx:xx:xx:xx:xx:xx",station="yy:yy:yy:yy:yy:yy",frequency="5660"} 1
node_scrape_collector_duration_seconds{collector="hostapd_stations"} 0.061378002166748
node_scrape_collector_success{collector="hostapd_stations"} 1
```

Related issue: https://github.com/openwrt/packages/issues/16692