### PR TITLE
nginx: update to 1.25.4

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
-PKG_VERSION:=1.25.3
-PKG_RELEASE:=2
+PKG_VERSION:=1.25.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
-PKG_HASH:=64c5b975ca287939e828303fa857d22f142b251f17808dfe41733512d9cded86
+PKG_HASH:=760729901acbaa517996e681ee6ea259032985e37c2768beef80df3a877deed9
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de> \
 				Christian Marangi <ansuelsmth@gmail.com>


### PR DESCRIPTION
Maintainer: @heil @Ansuel
Compile tested: compiled for Turris Omnia
Run tested: running flawlessly for weeks on Turris Omnia (compiled from master)

Description:
Update NGINX to 1.25.4. Maybe worth backporting to stable branch(es) as there are some major CVE fixes (for HTTP3, which is turned off by default in OpenWrt, however).