### PR TITLE
unbound: update to 1.19.3

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.19.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.19.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound
-PKG_HASH:=bc1d576f3dd846a0739adc41ffaa702404c6767d2b6082deb9f2f97cbb24a3a9
+PKG_HASH:=3ae322be7dc2f831603e4b0391435533ad5861c2322e34a76006a9fb65eb56b9
 
 PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/unbound/patches/010-configure-uname.patch
+++ b/net/unbound/patches/010-configure-uname.patch
@@ -3,7 +3,7 @@ Fix cross compile errors by inserting an environment variable for the
 target. Use "uname" on host only if "UNAME" variable is empty.
 --- a/configure.ac
 +++ b/configure.ac
-@@ -843,7 +843,7 @@ if test x_$ub_test_python != x_no; then
+@@ -845,7 +845,7 @@ if test x_$ub_test_python != x_no; then
     fi
  fi
  


### PR DESCRIPTION
Maintainer: @EricLuehrsen
Compile tested: Turris Omnia (mvebu/armv7) on self-compiled OpenWrt master
Run tested: Turris Omnia (mvebu/armv7) on self-compiled OpenWrt master, using as a home network DNS server (and using the dnsmasq script for local device names)

Description:
Update from 1.19.1 to 1.19.3 (1.19.2 fixes CVE-2024-1931 only, 1.19.3 is a general bugfix release). Maybe worth backporting to stable due to the security fix?