### PR TITLE
flashrom: strip leading whitespace from PROGRAMMER_ARGS

### DIFF
--- a/utils/flashrom/Makefile
+++ b/utils/flashrom/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=flashrom
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.flashrom.org/releases

--- a/utils/flashrom/flashrom.mk
+++ b/utils/flashrom/flashrom.mk
@@ -96,9 +96,8 @@ else
   $(eval $(call Programmer,satamv,$(FLASHROM_PCI)))
 endif
 
-comma := ,
 MESON_ARGS += \
 	-Ddefault_programmer_name=$(DEFAULT_PROGRAMMER_NAME) \
-	-Dprogrammer=$(subst $() $(),$(comma),$(PROGRAMMER_ARGS)) \
+	-Dprogrammer=$(subst $(space),$(comma),$(strip $(PROGRAMMER_ARGS))) \
 	-Dwerror=false \
 	-Dtests=disabled


### PR DESCRIPTION
Maintainer: @Noltari 
Compile tested: qualcommax-ipq807x
Run tested: edgecore_eap102

Description:

I can't compile the current OpenWrt master branch without this change. I'm not 100% sure if this is the best way to fix it, but I hope it may be useful to somebody who may encounter the same issue.

It seems that newer version of meson do not allow empty arguments but `PROGRAMMER_ARGS` begin with a comma, which is considered as an empty argument.