### PR TITLE
add packages lpac

### DIFF
--- a/utils/lpac/Makefile
+++ b/utils/lpac/Makefile
@@ -1,0 +1,48 @@
+# This software is in the public domain, furnished "as is", without technical
+# support, and with no warranty, express or implied, as to its usefulness for
+# any purpose.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=lpac
+PKG_VERSION:=1.0.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/estkme-group/lpac/tar.gz/refs/tags/v$(PKG_VERSION)?
+PKG_HASH:=a0736bd70eb1dc0504a06b24b0e7a86afd5187ca6a2a5812022a9b017cbc8e99
+
+PKG_MAINTAINER:=estkme-group (https://github.com/estkme-group)
+PKG_LICENSE:=AGPL-3.0-only
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/lpac
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=eUICC eSIM LPA written in C
+  URL:=https://github.com/estkme-group/lpac
+  DEPENDS:=+libopenssl +pcscd +libpcsclite +libcurl
+endef
+
+define Package/lpac/description
+    lpac is a eUICC eSIM LPA manager written in C. It allows to
+    manage eSIM profiles on eUICC SIM cards or modules using multiple
+    backends.
+endef
+
+define Package/lpac/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/output/libapduinterface_at.so $(1)/usr/lib/lpac
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/output/libapduinterface_pcsc.so $(1)/usr/lib/lpac
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/output/libapduinterface_stdio.so $(1)/usr/lib/lpac
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/output/libhttpinterface_curl.so $(1)/usr/lib/lpac
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/output/libhttpinterface_stdio.so $(1)/usr/lib/lpac
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/output/lpac $(1)/usr/bin
+endef
+
+
+$(eval $(call BuildPackage,lpac))
+

--- a/utils/lpac/README.md
+++ b/utils/lpac/README.md
@@ -1,0 +1,9 @@
+# lpac of openwrt
+## 介绍 Presentation
+### lpac 是一个用 C 语言编写的 eUICC eSIM LPA 管理器。它允许使用多个后端管理 eUICC SIM 卡或模块上的 eSIM 配置文件。
+### lpac is a eUICC eSIM LPA manager written in C. It allows to manage eSIM profiles on eUICC SIM cards or modules using multiple backends.
+## 安装 Install
+### 在 Utilities 选择 lpac 即可
+### Select lpac in Utilities.
+## 项目代码地址 Project Code Address
+[点击即可跳转 Click to go](https://github.com/estkme-group/lpac)。

--- a/utils/lpac/patches/001-add-fPIC.patch
+++ b/utils/lpac/patches/001-add-fPIC.patch
@@ -1,0 +1,62 @@
+From f206904999175a8d10f8c2ec7245af06c4a4d371 Mon Sep 17 00:00:00 2001
+From: ghhccghk <2137610394@qq.com>
+Date: Mon, 18 Mar 2024 12:51:11 +0800
+Subject: [PATCH] add add_compile_options(-fPIC)
+
+Signed-off-by: ghhccghk <2137610394@qq.com>
+---
+ CMakeLists.txt             | 1 +
+ cjson/CMakeLists.txt       | 1 +
+ dlfcn-win32/CMakeLists.txt | 1 +
+ euicc/CMakeLists.txt       | 1 +
+ src/CMakeLists.txt         | 1 +
+ 5 files changed, 5 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 40b422d..02aa3a7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -48,3 +48,4 @@ add_subdirectory(cjson)
+ add_subdirectory(euicc)
+ add_subdirectory(interface)
+ add_subdirectory(src)
++add_compile_options(-fPIC)
+diff --git a/cjson/CMakeLists.txt b/cjson/CMakeLists.txt
+index 29e3531..73718f4 100644
+--- a/cjson/CMakeLists.txt
++++ b/cjson/CMakeLists.txt
+@@ -1,3 +1,4 @@
+ aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} LIB_CJSON_SRCS)
+ add_library(cjson-static STATIC ${LIB_CJSON_SRCS})
++set_target_properties(cjson-static PROPERTIES POSITION_INDEPENDENT_CODE ON)
+ target_include_directories(cjson-static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
+diff --git a/dlfcn-win32/CMakeLists.txt b/dlfcn-win32/CMakeLists.txt
+index 0a8ad47..4fa1716 100644
+--- a/dlfcn-win32/CMakeLists.txt
++++ b/dlfcn-win32/CMakeLists.txt
+@@ -1,3 +1,4 @@
+ aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} LIB_DLFCN_SRCS)
+ add_library(dlfcn-win32 STATIC ${LIB_DLFCN_SRCS})
+ target_include_directories(dlfcn-win32 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
++add_compile_options(-fPIC)
+diff --git a/euicc/CMakeLists.txt b/euicc/CMakeLists.txt
+index 76f3715..faeb80e 100644
+--- a/euicc/CMakeLists.txt
++++ b/euicc/CMakeLists.txt
+@@ -2,3 +2,4 @@ aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} LIB_EUICC_SRCS)
+ add_library(euicc STATIC ${LIB_EUICC_SRCS})
+ target_link_libraries(euicc cjson-static)
+ target_include_directories(euicc PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
++add_compile_options(-fPIC)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index f93bfad..3ddc3ef 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -30,3 +30,4 @@ add_dependencies(lpac version)
+ if(UNIX)
+     install(TARGETS lpac RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+ endif()
++add_compile_options(-fPIC)
+--
+2.44.0
+


### PR DESCRIPTION
Maintainer: me
Compile tested: (aarch64_cortex-a53 Banana pi R3 , OpenWrt R24.2.2)
Run tested: (aarch64_cortex-a53 Banana pi R3 , OpenWrt R24.2.2, tests done)

Description:
lpac is a eUICC eSIM LPA manager written in C. It allows to manage eSIM profiles on eUICC SIM cards or modules using multiple backends.