### PR TITLE
htop: build with CONFIG_HTOP_LMSENSORS=y

### DIFF
--- a/admin/htop/Makefile
+++ b/admin/htop/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=htop
 PKG_VERSION:=3.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/htop-dev/htop/tar.gz/$(PKG_VERSION)?
@@ -48,11 +48,12 @@ define Package/htop/config
 	config HTOP_LMSENSORS
 		bool "Compile Htop with lm-sensors support"
 		depends on PACKAGE_htop
-		default y if TARGET_x86
+		default y
 		help
 			Build htop with lm-sensors support.
-			This doesn't add lm-sensors as dependency,
-			if present it'll loaded using dlopen().
+			This increases the binary by approx 5 kB.
+			Users wanting this functionality need to
+			install libsensors.
 endef
 
 CONFIGURE_ARGS += \


### PR DESCRIPTION
Default CONFIG_HTOP_LMSENSORS to y so users just need to install libsensors, no need to build your own, but no need to pay the size price when you don't use it.  Closes #23700.

Maintainer: @champtar