### PR TITLE
etherwake: add missing lincense information

### DIFF
--- a/net/etherwake/Makefile
+++ b/net/etherwake/Makefile
@@ -10,6 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=etherwake
 PKG_VERSION:=1.09
 PKG_RELEASE:=5
+PKG_LICENSE:=GPL-2.0-or-later
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.gz
 PKG_SOURCE_URL:=http://ftp.debian.org/debian/pool/main/e/etherwake


### PR DESCRIPTION
Maintainer: @neheb @tripolar 
Compile tested: not needed
Run tested: not needed

Description:

In the source there is a note that it is under `GPL`.
But it is not clear which version of the `GPL` (GPL-1.0, GPL-2.0, GPL-3.0).

At the time the source file was created, `GPL-2.0` was the latest GPL.
Also, in debian the package refers to `GPL` which is a symlink to `GPL-3.0`.

Therefore the `PKG_LICENSE` variable is set to `GPL-2.0-or-later`.
