### PR TITLE
openvpn: update to 2.6.10

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.6.9
+PKG_VERSION:=2.6.10
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=e08d147e15b4508dfcd1d6618a1f21f1495f9817a8dadc1eddf0532fa116d7e3
+PKG_HASH:=1993bbb7b9edb430626eaa24573f881fd3df642f427fcb824b1aed1fca1bcc9b
 
 PKG_MAINTAINER:=
 


### PR DESCRIPTION
Maintainer: @neheb @AuthorReflex
Compile tested: ramips/mt7621, ramips/mt7620, ramips/mt76x8
Run tested: Xiaomi Mi Router 3 Pro, Xiaomi Mi Router R3, Asus RT-AC1200

Description:
This is a bugfix release containing several security fixes specific to the Windows platform.

Bug fixes
---------
- Windows: if the win-dco driver is used (default) and the GUI requests use of a proxy server, the connection would fail.  Disable DCO in this case.

- Compression: minor bugfix in checking option consistency vs. compiled-in algorithm support

- systemd unit files: remove obsolete syslog.target

Security fixes
--------------
- CVE-2024-27459: Windows: fix a possible stack overflow in the interactive service component which might lead to a local privilege escalation.

- CVE-2024-24974: Windows: disallow access to the interactive service pipe from remote computers.

- CVE-2024-27903: Windows: disallow loading of plugins from untrusted installation paths, which could be used to attack openvpn.exe via a malicious plugin.

For details refer to https://github.com/OpenVPN/openvpn/blob/v2.6.10/Changes.rst
