### PR TITLE
[23.05] nebula: prepare migration to APK

### DIFF
--- a/net/nebula/Makefile
+++ b/net/nebula/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nebula
 PKG_VERSION:=1.8.2
-PKG_RELEASE:=2
+PKG_RELEASE:=r2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/slackhq/nebula/tar.gz/v$(PKG_VERSION)?


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 9cb2dbd23ce740fb6f03a190327dc60ab7c6884d)
