### PR TITLE
[23.05] https-dns-proxy: prepare migration to APK

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
-PKG_VERSION:=2023-11-19
-PKG_RELEASE:=1
+PKG_VERSION:=2023.11.19
+PKG_RELEASE:=r1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/

--- a/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
+++ b/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
@@ -300,7 +300,9 @@ service_triggers() {
 	local wan wan6 i
 	local procd_trigger_wan6
 	if [ "$on_boot_trigger" = '1' ]; then
+		output "Setting $serviceName raw_trigger for 'interface.*.up'"
 		procd_add_raw_trigger "interface.*.up" 3000 "/etc/init.d/${packageName}" restart 'on_interface_up'
+		output_okn
 	else
 		config_load "$packageName"
 		config_get_bool procd_trigger_wan6 'config' 'procd_trigger_wan6' '0'

--- a/net/https-dns-proxy/patches/020-src-options.c-add-version.patch
+++ b/net/https-dns-proxy/patches/020-src-options.c-add-version.patch
@@ -5,7 +5,7 @@
    return SW_VERSION;
  #else
 -  return "2023.10.10-atLeast";  // update date sometimes, like 1-2 times a year
-+  return "2023-11-19-1";  // update date sometimes, like 1-2 times a year
++  return "2023.11.19-r1";  // update date sometimes, like 1-2 times a year
  #endif
  }
  


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit dae56fd2a5d4ac579dff5d151cefe45b8d873bd6)
