### PR TITLE
gost_engine: Update to version 3.0.3

### DIFF
--- a/libs/gost_engine/Makefile
+++ b/libs/gost_engine/Makefile
@@ -2,8 +2,8 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/openssl-module.mk
 
 PKG_NAME:=gost_engine
-PKG_VERSION:=3.0.1
-PKG_HASH:=bfeac85883724cfbe0ecc6d942ac0524b908143e019ab3d3b6abe47a3466a628
+PKG_VERSION:=3.0.3
+PKG_HASH:=8cf888333d08b8bbcc12e4e8c0d8b258c74dbd67941286ffbcc648c6d3d66735
 PKG_LICENSE:=Apache-2.0
 PKG_RELEASE:=9
 

--- a/libs/gost_engine/patches/030-dont-build-provider.patch
+++ b/libs/gost_engine/patches/030-dont-build-provider.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -357,9 +357,11 @@ set_target_properties(lib_gost_engine PR
+@@ -367,9 +367,11 @@ set_target_properties(lib_gost_engine PR
    COMPILE_DEFINITIONS "BUILDING_ENGINE_AS_LIBRARY"
    PUBLIC_HEADER gost-engine.h
    OUTPUT_NAME "gost")
@@ -13,7 +13,7 @@
  # The GOST provider uses this
  add_subdirectory(libprov)
  
-@@ -384,6 +386,7 @@ set_target_properties(lib_gost_prov PROP
+@@ -394,6 +396,7 @@ set_target_properties(lib_gost_prov PROP
    )
  target_link_libraries(lib_gost_prov PRIVATE gost_core libprov)
  endif()
@@ -21,7 +21,7 @@
  
  set(GOST_SUM_SOURCE_FILES
          gostsum.c
-@@ -424,15 +427,15 @@ install(FILES gostsum.1 gost12sum.1 DEST
+@@ -434,15 +437,15 @@ install(FILES gostsum.1 gost12sum.1 DEST
  install(TARGETS gost_engine EXPORT GostEngineConfig
          LIBRARY  DESTINATION ${OPENSSL_ENGINES_DIR}
          RUNTIME  DESTINATION ${OPENSSL_ENGINES_DIR})
@@ -42,7 +42,7 @@
  endif()
  
  if (MSVC)
-@@ -440,8 +443,8 @@ if (MSVC)
+@@ -450,8 +453,8 @@ if (MSVC)
      EXPORT GostEngineConfig DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)
    install(FILES $<TARGET_PDB_FILE:gost_engine>
      EXPORT GostEngineConfig DESTINATION ${OPENSSL_ENGINES_DIR} OPTIONAL)
@@ -51,6 +51,6 @@
 +#  install(FILES $<TARGET_PDB_FILE:gost_prov>
 +#    EXPORT GostProviderConfig DESTINATION ${OPENSSL_MODULES_DIR} OPTIONAL)
  endif()
- install(EXPORT GostEngineConfig DESTINATION GostEngine/share/cmake/GostEngine)
--install(EXPORT GostProviderConfig DESTINATION GostEngine/share/cmake/GostProvider)
-+#install(EXPORT GostProviderConfig DESTINATION GostEngine/share/cmake/GostProvider)
+ install(EXPORT GostEngineConfig DESTINATION share/cmake/GostEngine)
+-install(EXPORT GostProviderConfig DESTINATION share/cmake/GostProvider)
++#install(EXPORT GostProviderConfig DESTINATION share/cmake/GostProvider)

--- a/libs/gost_engine/patches/040-dont-build-tests.patch
+++ b/libs/gost_engine/patches/040-dont-build-tests.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -213,128 +213,6 @@ set(GOST_PROV_SOURCE_FILES
+@@ -213,138 +213,6 @@ set(GOST_PROV_SOURCE_FILES
          gost_prov_mac.c
          )
  
@@ -90,6 +90,15 @@
 -target_link_libraries(test_gost89 gost_core gost_err)
 -add_test(NAME gost89 COMMAND test_gost89)
 -
+-add_executable(test_mgm test_mgm.c)
+-target_link_libraries(test_mgm OpenSSL::Crypto)
+-add_test(NAME mgm-with-engine COMMAND test_mgm)
+-set_tests_properties(mgm-with-engine
+-  PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT_ENGINE}")
+-add_test(NAME mgm-with-provider COMMAND test_mgm)
+-set_tests_properties(mgm-with-provider
+-  PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT_PROVIDER}")
+-
 -if(NOT SKIP_PERL_TESTS)
 -    execute_process(COMMAND perl -MTest2::V0 -e ""
 -       ERROR_QUIET RESULT_VARIABLE MISSING_TEST2_V0)
@@ -123,6 +132,7 @@
 -        test_keyexpimp
 -        test_gost89
 -        test_tls
+-        test_mgm
 -        )
 -set_property(TARGET ${BINARY_TESTS_TARGETS} APPEND PROPERTY COMPILE_DEFINITIONS ENGINE_DIR="${OUTPUT_DIRECTORY}")
 -


### PR DESCRIPTION
This version contains minor bugfixes.
It fixes a compile problem with GCC 13.

Changes: https://github.com/gost-engine/engine/compare/v3.0.1...v3.0.3

Maintainer: Artur Petrov <github@phpchain.ru>
Compile tested: aarch64
Run tested: none

Description:
