### PR TITLE
snort3: Fix compilation with GCC 13

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.1.82.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/

--- a/net/snort3/patches/110-packet_capture-Fix-compilation-with-GCC-13.patch
+++ b/net/snort3/patches/110-packet_capture-Fix-compilation-with-GCC-13.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Sat, 23 Mar 2024 19:11:15 +0100
+Subject: packet_capture: Fix compilation with GCC 13
+
+Fix the following compile problem with GCC 13:
+src/network_inspectors/packet_capture/packet_capture.h:25:54: error: 'int16_t' does not name a type
+   25 | void packet_capture_enable(const std::string&, const int16_t g = -1, const std::string& t = "");
+---
+ src/network_inspectors/packet_capture/packet_capture.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/src/network_inspectors/packet_capture/packet_capture.h
++++ b/src/network_inspectors/packet_capture/packet_capture.h
+@@ -21,6 +21,7 @@
+ #define PACKET_CAPTURE_H
+ 
+ #include <string>
++#include <cstdint>
+ 
+ void packet_capture_enable(const std::string&, const int16_t g = -1, const std::string& t = "");
+ void packet_capture_disable();


### PR DESCRIPTION
This fixes a compile problem with GCC 13.

Maintainer: @flyn-org, @graysky2
Compile tested: aarch64 + gcc 13
Run tested: none

Description:

Upstream PR: https://github.com/snort3/snort3/pull/352