### PR TITLE
lsd: update to v1.1.1

### DIFF
--- a/utils/lsd/Makefile
+++ b/utils/lsd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lsd
-PKG_VERSION:=1.0.0
+PKG_VERSION:=1.1.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/lsd-rs/lsd/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=ab34e9c85bc77cfa42b43bfb54414200433a37419f3b1947d0e8cfbb4b7a6325
+PKG_HASH:=7933e196bf7b164ea8879078f8a8e87381e0c49f71867e0036c82916199aba61
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Changes:
 - hex color parser for themes
 - adds truncate option
 - adds --literal flag
 - adds disable option for permission
 - upgrades many included sub modules/crates
 - Fixes literal flags not regocnized
 - adds and improves icons

Full changelogs since v1.0.0:
 - v1.1.0: https://github.com/lsd-rs/lsd/releases/tag/v1.1.0
 - v1.1.1: https://github.com/lsd-rs/lsd/releases/tag/v1.1.1

Maintainer: me / @oskarirauta
Compile tested: x86_64, latest git
Run tested: x86_64, latest git