### PR TITLE
ngtcp2: update to 1.4.0

### DIFF
--- a/libs/ngtcp2/Makefile
+++ b/libs/ngtcp2/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ngtcp2
-PKG_VERSION:=1.1.0
-PKG_RELEASE:=1
+PKG_VERSION:=1.4.0
+PKG_RELEASE:=r1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/ngtcp2/ngtcp2/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=987d784643edea4f2859c405f7dfbc53871a9f7ae5fcddf5fb12ec5dfce1ef22
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/ngtcp2/$(PKG_NAME)/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=b5d1433b9f5c06ce249e1e390e97dcfa49bf7ada5cb7c8bed8e6cd4feaf1ca4a
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
@@ -22,7 +22,7 @@ define Package/libngtcp2
   CATEGORY:=Libraries
   TITLE:=Implementation of QUIC protocol
   URL:=https://nghttp2.org/ngtcp2
-  DEPENDS:=+libnghttp3 +libopenssl
+  DEPENDS:=+libnghttp3
 endef
 
 define Package/libngtcp2/description


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2

Description:
* update PKG_RELEASE to be apk-compatible
* update PKG_SOURCE/PKG_SOURCE_URL so that it builds
* drop dependency on libopenssl as other SSL libs start to support HTTP/3
