### PR TITLE
update init scripts to use procd and announce services on mdns

### DIFF
--- a/net/atftp/files/atftpd.init
+++ b/net/atftp/files/atftpd.init
@@ -2,24 +2,18 @@
 # Copyright (C) 2020 OpenWrt.org
 
 START=95
-PIDFILE=/tmp/run/atftpd.pid
 
-start() {
-	local enable
-	local srv
-	local port
+USE_PROCD=1
+BIN=atftpd
 
+start_service() {
 	config_load atftpd
+	config_get SRV service path "/srv/tftp"
+	config_get PORT service port 69
 
-	config_get enable service enable 0
-	[ "$enable" -eq "0" ] && return 0
-
-	config_get srv service path "/srv/tftp"
-	config_get port service port 69
-
-	atftpd --pidfile $PIDFILE --user root.root --port $port --daemon $srv
-}
-
-stop() {
-	kill $(cat $PIDFILE)
+	procd_open_instance
+	procd_add_mdns "tftp" "udp" "$PORT" "daemon=atftpd"
+	procd_set_param command $BIN "--no-fork" "--daemon" "--user" "root.root" "--port" "$PORT" "$SRV"
+	procd_set_param respawn
+	procd_close_instance
 }

--- a/net/nginx/files/nginx.init
+++ b/net/nginx/files/nginx.init
@@ -75,6 +75,40 @@ nginx_init() {
 	logger -t "nginx_init" -p "daemon.info" "using ${CONF} (the test is ok)"
 }
 
+add_mdns() {
+        local cfg="$1"
+        local port enabled mdns service
+
+        config_get enabled "$cfg" enabled
+        config_get mdns "$cfg" mdns
+        config_get port "$cfg" listen
+
+        port=$(echo "$port" | head -n1 | awk '{print $1;}')
+
+        if [ "${mdns}" == "0" ] || [ "${mdns}" == "false" ]; then
+                return
+        fi
+
+        if [ "${enabled}" != "0" ] && [ "${enabled}" != "false" ] && [ -n "${port}" ]; then
+		[ "${port}" == "80" ] && service="http"
+		[ "${port}" == "8080" ] && service="http-alt"
+		[ "${port}" == "443" ] && service="https"
+		[ "${port}" == "8443" ] && service="pcsync-https"
+
+		procd_add_mdns_service "$service" "tcp" "$port" "daemon=nginx"
+        fi
+}
+
+configure_mdns() {
+	procd_open_data
+	json_add_object "mdns"
+
+	config_load nginx
+	config_foreach add_mdns server
+
+	json_close_object
+	procd_close_data
+}
 
 start_service() {
 	nginx_init
@@ -86,6 +120,9 @@ start_service() {
 	procd_set_param file "${CONF}" "${CONF_DIR}*.crt" "${CONF_DIR}*.key" \
 		"${CONF_DIR}*.conf" "${CONF_DIR}*.locations"
 	procd_set_param respawn
+
+	configure_mdns
+
 	procd_close_instance
 }
 

--- a/net/vsftpd/files/vsftpd.conf
+++ b/net/vsftpd/files/vsftpd.conf
@@ -1,4 +1,4 @@
-background=YES
+background=NO
 listen=YES
 anonymous_enable=NO
 local_enable=YES

--- a/net/vsftpd/files/vsftpd.init
+++ b/net/vsftpd/files/vsftpd.init
@@ -2,12 +2,15 @@
 # Copyright (C) 2006-2011 OpenWrt.org
 
 START=50
+USE_PROCD=1
+BIN=vsftpd
 
-start() {
-	mkdir -m 0755 -p /var/run/vsftpd
-	service_start /usr/sbin/vsftpd
-}
+start_service() {
+	procd_open_instance
 
-stop() {
-	service_stop /usr/sbin/vsftpd
+	procd_add_mdns "ftp" "tcp" "21" "daemon=vsftpd"
+
+	procd_set_param command $BIN
+	procd_set_param respawn
+	procd_close_instance
 }

--- a/net/xl2tpd/files/xl2tpd.init
+++ b/net/xl2tpd/files/xl2tpd.init
@@ -13,6 +13,7 @@ start_service() {
 	mkdir -p "$RUN_D"
 
 	procd_open_instance
+	procd_add_mdns "l2tp" "udp" "1701" "daemon=xl2tpd"
 	procd_set_param command $BIN -D -l -p "$PID_F"
 	procd_set_param respawn
 	procd_close_instance


### PR DESCRIPTION
The following init scripts have been modified to use procd:
* atftpd
* vsftpd

The following services are being advertised:

* atftpd: tftp
* nginx: http, https, http-alt, pcsync-https
* vsftpd: ftp
* xl2tpd: l2tp

Signed-off-by: Mohd Husaam Mehdi <husaam.mehdi@iopsys.eu>
