### PR TITLE
net-snmp: include ipv6 address & route mibs

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.9.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp
@@ -130,7 +130,10 @@ SNMP_MIB_MODULES_INCLUDED = \
 	host/hr_system \
 	ieee802dot11 \
 	if-mib/ifXTable \
+	ip-mib/ipAddressTable \
 	ip-mib/inetNetToMediaTable \
+	ip-forward-mib/inetCidrRouteTable \
+	ip-forward-mib/ipCidrRouteTable \
 	mibII/at \
 	mibII/icmp \
 	mibII/ifTable \


### PR DESCRIPTION
Description: 
  Since IPv6 is present in everyday use, we need to include
  information about IPv6 addresses & routes in SNMP

Example:
  IP-MIB::ipAddressOrigin.ipv6

  IP-MIB::ipAddressOrigin[ipv6]["00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:01"] = manual
  IP-MIB::ipAddressOrigin[ipv6]["fd:00:00:09:02:55:00:00:00:00:00:00:00:00:01:01"] = manual
  IP-MIB::ipAddressOrigin[ipv6]["fe:80:00:00:00:00:00:00:0c:00:09:ff:fe:06:01:01"] = linklayer
  IP-MIB::ipAddressOrigin[ipv6]["fe:80:00:00:00:00:00:00:0c:02:09:ff:fe:00:01:01"] = linklayer
  IP-MIB::ipAddressOrigin[ipv6]["fe:80:00:00:00:00:00:00:ae:84:c6:ff:fe:25:8c:ce"] = linklayer

Tested:
  23.05-snapshot
  master snapshot
  with LibreNMS, OpenWRT device IPv6 Addresses & Routes are properly recognized
