### PR TITLE
python-{pydantic, pydantic-core, annotated-types}: add new packages

### DIFF
--- a/lang/python/python-annotated-types/Makefile
+++ b/lang/python/python-annotated-types/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2024, Clouder Oy
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-annotated-types
+PKG_VERSION:=0.7.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=annotated_types
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Ilkka Ollakka <ilkka.ollakka@cloudersolutions.com>
+PKG_HASH:=aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-annotated-types
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Annotated-types
+  URL:=https://github.com/annotated-types/annotated-types
+  DEPENDS:= \
+      +python3-light \
+      +python3-typing-extensions
+endef
+
+define Package/python3-annotated-types/description
+PEP-593 added typing.Annotated as a way of adding context-specific metadata to existing types, and specifies that Annotated[T, x] should be treated as T by any tool or library without special logic for x.
+
+This package provides metadata objects which can be used to represent common constraints such as upper and lower bounds on scalar values and collection sizes, a Predicate marker for runtime checks, and descriptions of how we intend these metadata to be interpreted. In some cases, we also note alternative representations which do not require this package.
+endef
+
+$(eval $(call Py3Package,python3-annotated-types))
+$(eval $(call BuildPackage,python3-annotated-types))
+$(eval $(call BuildPackage,python3-annotated-types-src))

--- a/lang/python/python-pydantic-core/Makefile
+++ b/lang/python/python-pydantic-core/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2024, Clouder Oy
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pydantic-core
+PKG_VERSION:=2.20.1
+PKG_RELEASE:=1
+
+PYPI_NAME:=pydantic_core
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Ilkka Ollakka <ilkka.ollakka@cloudersolutions.com>
+PKG_HASH:=26ca695eeee5f9f1aeeb211ffc12f10bcb6f71e2989988fda61dabd65db878d4
+
+PKG_BUILD_DEPENDS:=python-maturin/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-pydantic-core
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Pydantic-core
+  URL:=https://github.com/pydantic/pydantic-core
+  DEPENDS:= \
+      +python3-light \
+      $(RUST_ARCH_DEPENDS)
+endef
+
+define Package/python3-pydantic-core/description
+This package provides the core functionality for pydantic validation and serialization.
+endef
+
+$(eval $(call Py3Package,python3-pydantic-core))
+$(eval $(call BuildPackage,python3-pydantic-core))
+$(eval $(call BuildPackage,python3-pydantic-core-src))

--- a/lang/python/python-pydantic/Makefile
+++ b/lang/python/python-pydantic/Makefile
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2024, Clouder Oy
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pydantic
+PKG_VERSION:=2.8.2
+PKG_RELEASE:=1
+
+PYPI_NAME:=pydantic
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Ilkka Ollakka <ilkka.ollakka@cloudersolutions.com>
+PKG_HASH:=6f62c13d067b0755ad1c21a34bdd06c0c12625a22b0fc09c6b149816604f7c2a
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-pydantic
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Pydantic
+  URL:=https://github.com/pydantic/pydantic
+  DEPENDS:= \
+      +python3-light \
+      +python3-typing-extensions \
+      +python3-annotated-types \
+      +python3-pydantic-core
+endef
+
+define Package/python3-pydantic/description
+Data validation using Python type hints.
+
+Fast and extensible, Pydantic plays nicely with your linters/IDE/brain.
+Define how data should be in pure, canonical Python 3.8+;
+validate it with Pydantic.
+endef
+
+$(eval $(call Py3Package,python3-pydantic))
+$(eval $(call BuildPackage,python3-pydantic))
+$(eval $(call BuildPackage,python3-pydantic-src))

--- a/lang/python/python-pydantic/test.sh
+++ b/lang/python/python-pydantic/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ "$1" = python3-pydantic ] || exit 0
+
+python3 -c 'from pydantic import (BaseModel, Field, Json, TypeAdapter)'


### PR DESCRIPTION
Maintainer: me
Compile tested: mips64_octeonplus, OpenWRT 23.05
Run tested: mips64_octeonplus, OpenWRT 23.05, tested by using pydantic library in python code

Description:

Add Pydantic 2.8.2 to packages, as it requires pydantic-core that uses rust code to be compiled in pydantic-core side, it is not trivial to install directly from pypi repository to openwrt device.

Pydantic is library to validate and parse data in python code. https://pypi.org/project/pydantic/

PR adds following packages:
- python-annotated-types 0.7.0
- python-pydantic-core 2.20.1
- python-pydantic 2.8.2
