### PR TITLE
[23.05] ksmbd-tools: update to 3.5.1 and swap to tagged as master

### DIFF
--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
-PKG_RELEASE:=1
+PKG_VERSION:=3.5.1
+PKG_RELEASE:=2
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/cifsd-team/ksmbd-tools
-PKG_SOURCE_VERSION:=3.4.8
-PKG_MIRROR_HASH:=e374c6e5053e82bc321e13927dbf3baf0d636205516564324686d002c084c5d6
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/cifsd-team/ksmbd-tools/releases/download/$(PKG_VERSION)
+PKG_HASH:=ab377b3044c48382303f3f7ec95f2e1a17592c774d70b2a11f32952099dbb214
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING

--- a/net/ksmbd-tools/patches/030-glib.patch
+++ b/net/ksmbd-tools/patches/030-glib.patch
@@ -3,7 +3,7 @@
 @@ -21,6 +21,7 @@ include_dirs = include_directories(
  glib_dep = dependency(
    'glib-2.0',
-   version: '>= 2.40',
+   version: '>= 2.44',
 +  static: true,
  )
  libnl_dep = dependency(


### PR DESCRIPTION
update ksmbd-tools to 3.5.1 and update download link to prepare for apk

Maintainer: nobody
Should fix https://github.com/openwrt/packages/issues/23771