### PR TITLE
tor: update to 0.4.8.10 stable

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.8.7
+PKG_VERSION:=0.4.8.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=b20d2b9c74db28a00c07f090ee5b0241b2b684f3afdecccc6b8008931c557491
+PKG_HASH:=e628b4fab70edb4727715b23cf2931375a9f7685ac08f2c59ea498a178463a86
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Bugfix release, see the changelog [1] for what's new.

[1] https://gitlab.torproject.org/tpo/core/tor/-/raw/tor-0.4.8.10/ChangeLog

Run tested (tor-basic): mediatek/filogic, mediatek/mt7622, ramips/mt7621

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>