### PR TITLE
dnsdist: add config options for --uid and --gid

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsdist
 PKG_VERSION:=1.9.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/

--- a/net/dnsdist/files/dnsdist.config
+++ b/net/dnsdist/files/dnsdist.config
@@ -1,2 +1,4 @@
 config 'dnsdist' 'general'
         option enabled '0'
+        option user 'root'
+        option group 'root'

--- a/net/dnsdist/files/dnsdist.init
+++ b/net/dnsdist/files/dnsdist.init
@@ -7,13 +7,19 @@ start_service() {
 	config_load dnsdist
 	local cfg=general
 	local enabled
+	local user
+	local group
 
 	config_get_bool enabled "$cfg" 'enabled' 1
+	config_get user "$cfg" user root
+	config_get group "$cfg" group root
 
 	[ $enabled -gt 0 ] || return 1
 
 	procd_open_instance
 	procd_set_param command dnsdist --supervised -C /etc/dnsdist.conf
+	[ "$user" != root ] && procd_append_param command -u "$user"
+	[ "$group" != root ] && procd_append_param command -g "$group"
 	procd_set_param file /etc/dnsdist.conf
 	procd_set_param respawn
 	procd_close_instance


### PR DESCRIPTION
Maintainer: @Habbie @rgacogne
Compile tested: no
Run tested: x86_64, OpenWrt 23.05.2

These options allow running dnsdist as a non-root user.

Further notes/points for discussion:
* I noted that the dnsdist package creates a `dnsdist` user/group, which seems like a good candidate for the default of `uid` and `gid`. However, I left it at the current implicit default of `root`, since the change might break existing setups.
* The options might be more aptly named `user` and `group`, since dnsdist accepts names as well as IDs. But I decided to stick with the wording dnsdist uses for its parameters.