### PR TITLE
python-orjson: update to version 3.10.0

### DIFF
--- a/lang/python/python-orjson/Makefile
+++ b/lang/python/python-orjson/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-orjson
-PKG_VERSION:=3.9.13
+PKG_VERSION:=3.10.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=orjson
-PKG_HASH:=fc6bc65b0cf524ee042e0bc2912b9206ef242edfba7426cf95763e4af01f527a
+PKG_HASH:=ba4d8cac5f2e2cff36bea6b6481cdb92b38c202bcec603d6f5ff91960595a1ed
 
 PKG_MAINTAINER:=Timothy Ace <openwrt@timothyace.com>
 PKG_LICENSE:=Apache-2.0 MIT


### PR DESCRIPTION
Relevant changes since previous 3.9.13:
- FIXED: Fix crash serializing str introduced in 3.9.11
- FIXED: Implement recursion limit of 1024 on orjson.loads()
- FIXED: Use byte-exact read on str formatting SIMD path to avoid crash
- Build now depends on Rust 1.72 or later
- Support serializing numpy.float16 (numpy.half)
- sdist uses metadata 2.3 instead of 2.1
- Improve Windows PyPI builds

Maintainer: me
Compile tested: arm_cortex-a9_vfpv3-d16, Linksys WRT1900ACS, master
Run tested: arm_cortex-a9_vfpv3-d16, Linksys WRT1900ACS, 23.05.0 r23497-6637af95aa

Description:
Updates python-orjson from 3.9.13 -> 3.10.0. Fixes from upstream (from v3.9.14, v3.9.15, and v3.10.0) include:

- FIXED: Fix crash serializing str introduced in 3.9.11
- FIXED: Implement recursion limit of 1024 on orjson.loads()
- FIXED: Use byte-exact read on str formatting SIMD path to avoid crash
- Build now depends on Rust 1.72 or later
- Support serializing numpy.float16 (numpy.half)
- sdist uses metadata 2.3 instead of 2.1
- Improve Windows PyPI builds