### PR TITLE
mwan3: Fix awk expression in mwan3_delete_iface_rules

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.11.13
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -549,7 +549,7 @@ mwan3_delete_iface_rules()
 		return
 	fi
 
-	for rule_id in $(ip rule list | awk '$1 % 1000 == '$id' && $1 > 1000 && $1 < 4000 {print substr($1,0,4)}'); do
+	for rule_id in $(ip rule list | awk -F : '$1 % 1000 == '$id' && $1 > 1000 && $1 < 4000 {print $1}'); do
 		$IP rule del pref $rule_id
 	done
 }


### PR DESCRIPTION
Maintainer: @feckert
Run tested: armv7l, Netgear R7800, r23853-560965d582, tested by `mwan3 restart`

Description:

The awk expression in mwan3_delete_iface_rules splits the `ip rule list` output by spaces, therefore $1 contains the trailing colon (e.g., "1:", "1000:"). The < and > operators compare such values as strings instead of numbers, producing unexpected results (for example, "1:" > "1000").

Change the field separator to ":" for correct number comparison, so that the right rules are removed.

An example error message that may appear before the fix:

    Error: argument "1:" is wrong: preference value is invalid

It happens because `substr($1,0,4)` selects short numbers along with the colon. In other cases wrong rules may be removed, for example, if there is rule 10051, then rule 1005 will be removed.