### PR TITLE
mdio-tools: use commit hash as the source version

### DIFF
--- a/kernel/mdio-netlink/Makefile
+++ b/kernel/mdio-netlink/Makefile
@@ -2,11 +2,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=mdio-netlink
-PKG_RELEASE:=1
+PKG_VERSION:=1.3.1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://github.com/wkz/mdio-tools
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=1.3.1
+PKG_SOURCE_VERSION:=f74eaf38dbda441df4fcaeb21ca4465957953a2f
 PKG_MIRROR_HASH:=97dfd25d8cdf5994eeb8cb0a5862c993b8aef373b280bca567d41d4113f494a9
 
 PKG_LICENSE:=GPL-2.0-only

--- a/net/mdio-tools/Makefile
+++ b/net/mdio-tools/Makefile
@@ -1,11 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mdio-tools
-PKG_RELEASE:=1
+PKG_VERSION:=1.3.1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://github.com/wkz/mdio-tools
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=1.3.1
+PKG_SOURCE_VERSION:=f74eaf38dbda441df4fcaeb21ca4465957953a2f
 PKG_MIRROR_HASH:=b7973284dc3dffef4bd2a904e3f7aa7fd3caab4aecf85ac57488f5acbf341aba
 
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Maintainer: me
Compile tested: qualcommax, Dynalink WRX-36, main
Run tested: qualcommax, Dynalink WRX-36, main

Description:
In light of the recent XZ events, it seems that using the tag as the source version reference is not ideal as it can be updated by the upstream lets switch to using the full commit hash as the source.

This also should fix the APK semantic versioning by setting PKG_VERSION as well updating the PKG_MIRROR_HASH which got broken by recent APK changes.