### PR TITLE
shairport-sync: Fix diagnostics setting generation in shairport-sync's native conf file

### DIFF
--- a/sound/shairport-sync/files/shairport-sync.config
+++ b/sound/shairport-sync/files/shairport-sync.config
@@ -18,10 +18,8 @@ config shairport-sync 'shairport_sync'
 	option port '' # 5000
 	option udp_port_base '' # 6001
 	option udp_port_range '' # 100
-	option statistics '' # no/yes
 	option drift '' # 88
 	option resync_threshold '' # 2205
-	option log_verbosity '' # 0/1/2/3
 	option ignore_volume_control '' # no/yes
 	option volume_range_db '' # 30 to 150
 	option regtype '' # _raop._tcp
@@ -59,3 +57,7 @@ config shairport-sync 'shairport_sync'
 	# AO
 	option ao_latency_offset '' # 0
 	option ao_buffer_length '' # 44100
+	# Diagnostics
+	option diagnostics_statistics '' # no/yes
+	option diagnostics_log_output_to '' # syslog/stderr/stdout
+	option diagnostics_log_verbosity '' # 0/1/2/3

--- a/sound/shairport-sync/files/shairport-sync.init
+++ b/sound/shairport-sync/files/shairport-sync.init
@@ -56,10 +56,8 @@ start_instance() {
 		append_num "$cfg" port "port"
 		append_num "$cfg" udp_port_base "udp_port_base"
 		append_num "$cfg" udp_port_range "udp_port_range"
-		append_str "$cfg" statistics "statistics"
 		append_num "$cfg" drift "drift"
 		append_num "$cfg" resync_threshold "resync_threshold"
-		append_num "$cfg" log_verbosity "log_verbosity"
 		append_str "$cfg" ignore_volume_control "ignore_volume_control"
 		append_num "$cfg" volume_range_db "volume_range_db"
 		append_str "$cfg" regtype "regtype"
@@ -121,6 +119,14 @@ start_instance() {
 		printf "{\n"
 		append_num "$cfg" ao_latency_offset "audio_backend_latency_offset"
 		append_num "$cfg" ao_buffer_length "audio_backend_buffer_desired_length"
+		printf "};\n\n"
+
+		# Diagnostics
+		printf "diagnostics =\n"
+		printf "{\n"
+		append_str "$cfg" diagnostics_statistics "statistics"
+		append_str "$cfg" diagnostics_log_output_to "log_output_to"
+		append_num "$cfg" diagnostics_log_verbosity "log_verbosity"
 		printf "};\n\n"
 	} > "$conf_file"
 


### PR DESCRIPTION
Maintainer: @mikebrady
Compile tested: NanoPi R4s / SNAPSHOTS
Run tested: NanoPi R4s / SNAPSHOTS

Description:
shairport-sync expects `statistics`/`log_verbosity`/`log_output_to` settings
to be in the diagnostics section of shairport-sync's native config.

Prior to this commit, these settings were either missing (log_output_to)
or generated in the incorrect (general) native config section bloc.
