### PR TITLE
hcxdumptool: Update to 6.3.4

### DIFF
--- a/net/hcxdumptool/Makefile
+++ b/net/hcxdumptool/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hcxdumptool
-PKG_VERSION:=6.3.2
+PKG_VERSION:=6.3.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerbea/hcxdumptool/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=1f6fe2b4757a5f20adeb6cc469693b4d0e8c49ba290450e10a37699d9f9a2a42
+PKG_HASH:=a45140960bd5de28085d549e1a9ccf2c08af143984a138c28ac4092c6a52a5d2
 
 PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
hcxdumptool: Update to 6.3.4
Version 6.3.4 has some important fixes for the OpenWrt community. This version properly supports Big-Endian systems (which are many); the previous OpenWrt packaged version crashed on such systems.

Maintainer: Andreas Nilsen <adde88@gmail.com>
Compile tested: (put here arch, model, OpenWrt version) Compiled for GL.iNet E750 running OpenWrt 23.05.2, MIPS Big-Endian
Run tested: Tested working on OpenWrt 23.05.2, MIPS Big-Endian

Description:
 - Adds BE support
 - Adds internal BPF compilation
