### PR TITLE
apcupsd: fix gcc 13 compliation error

### DIFF
--- a/net/apcupsd/Makefile
+++ b/net/apcupsd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apcupsd
 PKG_VERSION:=3.14.14
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0
@@ -27,7 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/apcupsd
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libpthread +libusb-compat
+  DEPENDS:=+libpthread +libusb-compat +libstdcpp
   TITLE:=UPS control software
   URL:=http://www.apcupsd.org/
 endef
@@ -35,7 +35,7 @@ endef
 define Package/apcupsd-cgi
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libpthread +libgd
+  DEPENDS:=+libpthread +libgd +libstdcpp
   TITLE:=UPS control software CGI module
   URL:=http://www.apcupsd.org/
 endef
@@ -57,7 +57,7 @@ endef
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		DESTDIR="$(PKG_INSTALL_DIR)" \
-		LD="$(TARGET_CC)" \
+		LD="$(TARGET_CXX)" \
 		all install
 endef
 


### PR DESCRIPTION
Maintainer: @tru7
Compile tested: ramips/mt7620
Run tested: Xiaomi Mi router 3,  Back-UPS XS 800CI (usb-hid connection)

Description:
On GCC13 build fails:

toolchain-mipsel_24kc_gcc-13.2.0_musl/lib/libsupc++.a(eh_alloc.o): in function `std::__sv_check(unsigned int, unsigned int, char const*)': toolchain-mipsel_24kc_gcc-13.2.0_musl/gcc-13.2.0-final/mipsel-openwrt-linux-musl/libstdc++-v3/include/string_view:73: undefined reference to `std::__throw_out_of_range_fmt(char const*, ...)' collect2: error: ld returned 1 exit status
make[5]: *** [Makefile:33: apcupsd] Error 1

Workaround found at https://lore.kernel.org/buildroot/87wmsbk386.fsf@48ers.dk/T/