### PR TITLE
dmx_usb_module: fix 6.6 kernel compile

### DIFF
--- a/libs/dmx_usb_module/Makefile
+++ b/libs/dmx_usb_module/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=dmx_usb_module
 PKG_VERSION:=19.12.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/lowlander/dmx_usb_module/tar.gz/V$(PKG_VERSION)?

--- a/libs/dmx_usb_module/patches/101-fix-kernel-6.6-builds.patch
+++ b/libs/dmx_usb_module/patches/101-fix-kernel-6.6-builds.patch
@@ -1,0 +1,14 @@
+--- a/dmx_usb.c
++++ b/dmx_usb.c
+@@ -97,7 +97,11 @@ struct dmx_usb_device {
+ 
+ 
+ /* prevent races between open() and disconnect() */
++#if(LINUX_VERSION_CODE < KERNEL_VERSION(6,5,3))
+ 	static DEFINE_SEMAPHORE(disconnect_sem);
++#else
++	static DEFINE_SEMAPHORE(disconnect_sem, 1);
++#endif
+ 
+ /* local function prototypes */
+ static ssize_t dmx_usb_write	(struct file *file, const char *buffer, size_t count, loff_t *ppos);


### PR DESCRIPTION
Maintainer: @FriedZombie
Compile tested: cortexa53,ti-k3,master branch
Run tested: no

Description:
Fix compiling the dmx_usb_module module against kernel 6.6.

