### PR TITLE
cryptsetup: update to version 2.7.1

### DIFF
--- a/utils/cryptsetup/Makefile
+++ b/utils/cryptsetup/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cryptsetup
-PKG_VERSION:=2.6.1
+PKG_VERSION:=2.7.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=@KERNEL/linux/utils/cryptsetup/v2.6
-PKG_HASH:=410ded65a1072ab9c8e41added37b9729c087fef4d2db02bb4ef529ad6da4693
+PKG_SOURCE_URL:=@KERNEL/linux/utils/cryptsetup/v$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VERSION))))
+PKG_HASH:=da5d1419e2a86e01aa32fd79582cd54d208857cb541bca2fd426a5ff1aaabbc3
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_cortex-a53
Run tested: -

Description:
The most notable change is the introduction of (optional) support for hardware OPAL disk encryption. However, as this requires Linux 6.4 or later, support for OPAL is implicitely disabled until targets used for the package build have been updated to Linux 6.6.

See release notes for 2.7.0 and 2.7.1 for more details:

https://cdn.kernel.org/pub/linux/utils/cryptsetup/v2.7/v2.7.0-ReleaseNotes

https://cdn.kernel.org/pub/linux/utils/cryptsetup/v2.7/v2.7.1-ReleaseNotes
