### PR TITLE
exim: update to 4.97.1

### DIFF
--- a/mail/exim/Makefile
+++ b/mail/exim/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=exim
-PKG_VERSION:=4.96.2
+PKG_VERSION:=4.97.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ftp.exim.org/pub/exim/exim4/
-PKG_HASH:=038e327e8d1e93d005bac9bb06fd22aec44d5028930d6dbe8817ad44bbfc1de6
+PKG_HASH:=bd782057509a793593508528590626d185ea160ce32cb34beda262e99cefdfa9
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 
 PKG_LICENSE:=GPL-2.0-or-later
@@ -138,7 +138,7 @@ define Package/exim/conffiles
 endef
 
 HOST_CFLAGS += -std=c99
-TARGET_CFLAGS += $(FPIC) -DNO_IP_OPTIONS -D_FILE_OFFSET_BITS=64
+TARGET_CFLAGS += $(FPIC) -DNO_IP_OPTIONS -D_FILE_OFFSET_BITS=64 -DNO_EXECINFO
 
 MAKE_VARS += build=Linux-$$(ARCH)
 MAKE_FLAGS += AR="$$(TARGET_AR) r"
@@ -152,7 +152,7 @@ define Build/Configure
 	$(SED) 's%# EXIM_GROUP=.*%EXIM_GROUP=42%' $(PKG_BUILD_DIR)/Local/Makefile
 	$(SED) 's%# EXIM_USER=.*%EXIM_USER=42%' $(PKG_BUILD_DIR)/Local/Makefile
 	$(SED) 's%# INCLUDE=.*%INCLUDE=-I$(STAGING_DIR)/usr/include -I$(STAGING_DIR)/usr/include%' $(PKG_BUILD_DIR)/Local/Makefile
-	$(SED) 's%# HAVE_IPV6=YES%HAVE_IPV6=YES%' $(PKG_BUILD_DIR)/Local/Makefile
+	$(SED) 's%# HAVE_IPV6=yes%HAVE_IPV6=yes%' $(PKG_BUILD_DIR)/Local/Makefile
 	$(SED) 's%# WITH_CONTENT_SCAN=yes%WITH_CONTENT_SCAN=yes%' $(PKG_BUILD_DIR)/Local/Makefile
 	$(SED) 's%# SUPPORT_MAILDIR=yes%SUPPORT_MAILDIR=yes%' $(PKG_BUILD_DIR)/Local/Makefile
 	$(SED) 's%# SUPPORT_MAILSTORE=yes%SUPPORT_MAILSTORE=yes%' $(PKG_BUILD_DIR)/Local/Makefile

--- a/mail/exim/patches/010-allow-json-dynamic-lookup.patch
+++ b/mail/exim/patches/010-allow-json-dynamic-lookup.patch
@@ -1,6 +1,6 @@
 --- a/src/drtables.c
 +++ b/src/drtables.c
-@@ -662,7 +662,7 @@ addlookupmodule(NULL, &ibase_lookup_modu
+@@ -663,7 +663,7 @@ addlookupmodule(NULL, &ibase_lookup_modu
  addlookupmodule(NULL, &ldap_lookup_module_info);
  #endif
  

--- a/mail/exim/patches/030-openssl-deprecated.patch
+++ b/mail/exim/patches/030-openssl-deprecated.patch
@@ -13,7 +13,7 @@
    }
 --- a/src/pdkim/signing.c
 +++ b/src/pdkim/signing.c
-@@ -703,7 +703,6 @@ return NULL;
+@@ -704,7 +704,6 @@ return NULL;
  void
  exim_dkim_init(void)
  {
@@ -23,7 +23,7 @@
  
 --- a/src/tls-openssl.c
 +++ b/src/tls-openssl.c
-@@ -22,7 +22,10 @@ functions from the OpenSSL library. */
+@@ -23,7 +23,10 @@ functions from the OpenSSL library. */
  #include <openssl/lhash.h>
  #include <openssl/ssl.h>
  #include <openssl/err.h>
@@ -34,7 +34,7 @@
  #ifndef OPENSSL_NO_ECDH
  # include <openssl/ec.h>
  #endif
-@@ -885,8 +888,9 @@ pkey = EVP_RSA_gen(2048);
+@@ -944,8 +947,9 @@ pkey = EVP_RSA_gen(2048);
  
  X509_set_version(x509, 2);				/* N+1 - version 3 */
  ASN1_INTEGER_set(X509_get_serialNumber(x509), 1);
@@ -46,7 +46,7 @@
  X509_set_pubkey(x509, pkey);
  
  name = X509_get_subject_name(x509);
-@@ -4670,8 +4674,8 @@ return string_fmt_append(g,
+@@ -4979,8 +4983,8 @@ return string_fmt_append(g,
      "                          Runtime: %s\n"
      "                                 : %s\n",
  	     OPENSSL_VERSION_TEXT,
@@ -57,7 +57,7 @@
    /* third line is 38 characters for the %s and the line is 73 chars long;
    the OpenSSL output includes a "built on: " prefix already. */
  }
-@@ -4713,8 +4717,6 @@ if (pidnow != pidlast)
+@@ -5022,8 +5026,6 @@ if (pidnow != pidlast)
    is unique for each thread", this doesn't apparently apply across processes,
    so our own warning from vaguely_random_number_fallback() applies here too.
    Fix per PostgreSQL. */
@@ -68,7 +68,7 @@
  
 --- a/src/tlscert-openssl.c
 +++ b/src/tlscert-openssl.c
-@@ -218,13 +218,13 @@ return mod ? tls_field_from_dn(cp, mod)
+@@ -219,13 +219,13 @@ return mod ? tls_field_from_dn(cp, mod)
  uschar *
  tls_cert_not_before(void * cert, uschar * mod)
  {

--- a/mail/exim/patches/100-localscan_dlopen.patch
+++ b/mail/exim/patches/100-localscan_dlopen.patch
@@ -10,7 +10,7 @@ Last-Update: 2021-07-28
 
 --- a/src/EDITME
 +++ b/src/EDITME
-@@ -873,6 +873,21 @@ HEADERS_CHARSET="ISO-8859-1"
+@@ -904,6 +904,21 @@ HEADERS_CHARSET="ISO-8859-1"
  
  
  #------------------------------------------------------------------------------
@@ -45,7 +45,7 @@ Last-Update: 2021-07-28
  #define CONFIGURE_FILE
 --- a/src/globals.c
 +++ b/src/globals.c
-@@ -117,6 +117,10 @@ int     dsn_ret                = 0;
+@@ -118,6 +118,10 @@ int     dsn_ret                = 0;
  const pcre2_code  *regex_DSN         = NULL;
  uschar *dsn_advertise_hosts    = NULL;
  
@@ -58,7 +58,7 @@ Last-Update: 2021-07-28
  BOOL    gnutls_allow_auto_pkcs11 = FALSE;
 --- a/src/globals.h
 +++ b/src/globals.h
-@@ -155,6 +155,9 @@ extern int      dsn_ret;               /
+@@ -157,6 +157,9 @@ extern int      dsn_ret;               /
  extern const pcre2_code  *regex_DSN;         /* For recognizing DSN settings */
  extern uschar  *dsn_advertise_hosts;   /* host for which TLS is advertised */
  
@@ -70,8 +70,8 @@ Last-Update: 2021-07-28
  
 --- a/src/local_scan.c
 +++ b/src/local_scan.c
-@@ -7,58 +7,133 @@
- /* See the file NOTICE for conditions of use and distribution. */
+@@ -8,58 +8,133 @@
+ /* SPDX-License-Identifier: GPL-2.0-or-later */
  
  
 -/******************************************************************************
@@ -248,7 +248,7 @@ Last-Update: 2021-07-28
  /* End of local_scan.c */
 --- a/src/local_scan.h
 +++ b/src/local_scan.h
-@@ -27,6 +27,7 @@ settings, and the store functions. */
+@@ -28,6 +28,7 @@ settings, and the store functions. */
  
  #include <stdarg.h>
  #include <sys/types.h>
@@ -256,7 +256,7 @@ Last-Update: 2021-07-28
  #include "config.h"
  #include "mytypes.h"
  #include "store.h"
-@@ -166,6 +167,9 @@ extern header_line *header_list;       /
+@@ -177,6 +178,9 @@ extern header_line *header_list;       /
  extern BOOL    host_checking;          /* Set when checking a host */
  extern uschar *interface_address;      /* Interface for incoming call */
  extern int     interface_port;         /* Port number for incoming call */
@@ -266,7 +266,7 @@ Last-Update: 2021-07-28
  extern uschar *message_id;             /* Internal id of message being handled */
  extern uschar *received_protocol;      /* Name of incoming protocol */
  extern int     recipients_count;       /* Number of recipients */
-@@ -236,4 +240,6 @@ extern pid_t    child_open_exim2_functio
+@@ -247,4 +251,6 @@ extern pid_t    child_open_exim2_functio
  extern pid_t    child_open_function(uschar **, uschar **, int, int *, int *, BOOL, const uschar *);
  #endif
  
@@ -275,7 +275,7 @@ Last-Update: 2021-07-28
  /* End of local_scan.h */
 --- a/src/readconf.c
 +++ b/src/readconf.c
-@@ -212,6 +212,9 @@ static optionlist optionlist_config[] =
+@@ -216,6 +216,9 @@ static optionlist optionlist_config[] =
    { "local_from_prefix",        opt_stringptr,   {&local_from_prefix} },
    { "local_from_suffix",        opt_stringptr,   {&local_from_suffix} },
    { "local_interfaces",         opt_stringptr,   {&local_interfaces} },
@@ -287,7 +287,7 @@ Last-Update: 2021-07-28
  #endif
 --- a/src/string.c
 +++ b/src/string.c
-@@ -428,6 +428,7 @@ return ss;
+@@ -453,6 +453,7 @@ return ss;
  
  #if (defined(HAVE_LOCAL_SCAN) || defined(EXPAND_DLFUNC)) \
  	&& !defined(MACRO_PREDEF) && !defined(COMPILE_UTILITY)
@@ -295,7 +295,7 @@ Last-Update: 2021-07-28
  /*************************************************
  *            Copy and save string                *
  *************************************************/
-@@ -473,6 +474,7 @@ string_copyn_function(const uschar * s,
+@@ -498,6 +499,7 @@ string_copyn_function(const uschar * s,
  {
  return string_copyn(s, n);
  }

--- a/mail/exim/patches/200-fix-build.patch
+++ b/mail/exim/patches/200-fix-build.patch
@@ -1,17 +1,6 @@
---- a/src/drtables.c
-+++ b/src/drtables.c
-@@ -736,7 +736,7 @@ else
-     {
-     char * name = ent->d_name;
-     int len = (int)strlen(name);
--    if (regex_match(regex_islookupmod, US name, len, NUL))
-+    if (regex_match(regex_islookupmod, US name, len, NULL))
-       {
-       int pathnamelen = len + (int)strlen(LOOKUP_MODULE_DIR) + 2;
-       void *dl;
 --- a/src/exim.c
 +++ b/src/exim.c
-@@ -636,13 +636,15 @@ exim_nullstd(void)
+@@ -642,13 +642,15 @@ exim_nullstd(void)
  {
  int devnull = -1;
  struct stat statbuf;
@@ -31,7 +20,7 @@
    }
 --- a/src/local_scan.h
 +++ b/src/local_scan.h
-@@ -26,6 +26,7 @@ store.c
+@@ -27,6 +27,7 @@ store.c
  settings, and the store functions. */
  
  #include <stdarg.h>

--- a/mail/exim/patches/210-no-exim_id_update.patch
+++ b/mail/exim/patches/210-no-exim_id_update.patch
@@ -1,0 +1,11 @@
+--- a/OS/Makefile-Base
++++ b/OS/Makefile-Base
+@@ -253,7 +253,7 @@ utils: $(EXIM_MONITOR) exicyclog exinext
+         transport-filter.pl convert4r3 convert4r4 \
+         exim_checkaccess \
+         exim_dbmbuild exim_dumpdb exim_fixdb exim_tidydb \
+-	exim_lock exim_msgdate exim_id_update
++	exim_lock exim_msgdate
+ 
+ 
+ # Targets for special-purpose configuration header builders

--- a/mail/exim/patches/300-avoid-time-printf.patch
+++ b/mail/exim/patches/300-avoid-time-printf.patch
@@ -1,0 +1,11 @@
+--- a/src/transports/smtp.c
++++ b/src/transports/smtp.c
+@@ -938,7 +938,7 @@ if (  sx->early_pipe_active
+     if (!(er = dbfn_read_enforce_length(dbm_file, ehlo_resp_key, sizeof(dbdata_ehlo_resp))))
+       debug_printf("no ehlo-resp record!\n");
+     else
+-      debug_printf("ehlo-resp record is %d seconds old\n", time(NULL) - er->time_stamp);
++      debug_printf("ehlo-resp record is %.0f seconds old\n", difftime(time(NULL), er->time_stamp));
+     }
+ 
+   dbfn_delete(dbm_file, ehlo_resp_key);


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_cortex-a53
Run tested: -

Description:

**IPv6 has accidentally been disabled in all Exim builds since the package was introduced in OpenWrt due to a faulty `sed` script. This has now been fixed, so beware that IPv6 is now enabled when updating from previous releases.**

Since Exim version 4.97
-----------------------

JH/s1 Refuse to accept a line "dot, LF" as end-of-DATA unless operating in
      LF-only mode (as detected from the first header line).  Previously we did
      accept that in (normal) CRLF mode; this has been raised as a possible
      attack scenario (under the name "smtp smuggling", CVE-2023-51766).

Exim version 4.97
-----------------

JH/01 The hosts_connection_nolog main option now also controls "no MAIL in
      SMTP connection" log lines.

JH/02 Option default value updates:
	- queue_fast_ramp (main)	true (was false)
	- remote_max_parallel (main)	4 (was 2)

JH/03 Cache static regex pattern compilations, for use by ACLs.

JH/04 Bug 2903: avoid exit on an attempt to rewrite a malformed address.
      Make the rewrite never match and keep the logging.  Trust the
      admin to be using verify=header-syntax (to actually reject the message).

JH/05 Follow symlinks for placing a watch on TLS creds files.  This means
      (under Linux) we watch the dir containing the final file; previously
      it would be the dir with the first symlink.  We still do not monitor
      the entire path.

JH/06 Check for bad chars in rDNS for sender_host_name.  The OpenBSD (at least)
      dn_expand() is happy to pass them through.

JH/07 OpenSSL Fix auto-reload of changed server OCSP proof.  Previously, if
      the file with the proof had an unchanged name, the new proof(s) were
      loaded on top of the old ones (and nover used; the old ones were stapled).

JH/08 Bug 2915: Fix use-after-free for $regex<n> variables. Previously when
      more than one message arrived in a single connection a reference from
      the earlier message could be re-used.  Often a sigsegv resulted.
      These variables were introduced in Exim 4.87.
      Debug help from Graeme Fowler.

JH/09 Fix ${filter } for conditions that modify $value.  Previously the
      modified version would be used in construction the result, and a memory
      error would occur.

JH/10 GnuTLS: fix for (IOT?) clients offering no TLS extensions at all.
      Find and fix by Jasen Betts.

JH/11 OpenSSL: fix for ancient clients needing TLS support for versions earlier
      than TLSv1,2,  Previously, more-recent versions of OpenSSL were permitting
      the systemwide configuration to override the Exim config.

HS/01 Bug 2728: Introduce EDITME option "DMARC_API" to work around incompatible
      API changes in libopendmarc.

JH/12 Bug 2930: Fix daemon startup.  When started from any process apart from
      pid 1, in the normal "background daemon" mode, having to drop process-
      group leadership also lost track of needing to create listener sockets.

JH/13 Bug 2929: Fix using $recipients after ${run...}.  A change made for 4.96
      resulted in the variable appearing empty.  Find and fix by Ruben Jenster.

JH/14 Bug 2933: Fix regex substring match variables for null matches. Since 4.96
      a capture group which obtained no text (eg. "(abc)*" matching zero
      occurrences) could cause a segfault if the corresponding $<n> was
      expanded.

JH/15 Fix argument parsing for ${run } expansion. Previously, when an argument
      included a close-brace character (eg. it itself used an expansion) an
      error occurred.

JH/16 Move running the smtp connect ACL to before, for TLS-on-connect ports,
      starting TLS.  Previously it was after, meaning that attackers on such
      ports had to be screened using the host_reject_connection main config
      option. The new sequence aligns better with the STARTTLS behaviour, and
      permits defences against crypto-processing load attacks, even though it
      is strictly an incompatible change.
      Also, avoid sending any SMTP fail response for either the connect ACL
      or host_reject_connection, for TLS-on-connect ports.

JH/17 Permit the ACL "encrypted" condition to be used in a HELO/EHLO ACL,
      Previously this was not permitted, but it makes reasonable sense.
      While there, restore a restriction on using it from a connect ACL; given
      the change JH/16 it could only return false (and before 4.91 was not
      permitted).

JH/18 Fix a fencepost error in logging.  Previously (since 4.92) when a log line
      was exactly sized compared to the log buffer, a crash occurred with the
      misleading message "bad memory reference; pool not found".
      Found and traced by Jasen Betts.

JH/19 Bug 2911: Fix a recursion in DNS lookups.  Previously, if the main option
      dns_again_means_nonexist included an element causing a DNS lookup which
      itself returned DNS_AGAIN, unbounded recursion occurred.  Possible results
      included (though probably not limited to) a process crash from stack
      memory limit, or from excessive open files.  Replace this with a paniclog
      whine (as this is likely a configuration error), and returning
      DNS_NOMATCH.

JH/20 Bug 2954: (OpenSSL) Fix setting of explicit EC curve/group.  Previously
      this always failed, probably leading to the usual downgrade to in-clear
      connections.

JH/21 Fix TLSA lookups.  Previously dns_again_means_nonexist would affect
      SERVFAIL results, which breaks the downgrade resistance of DANE.  Change
      to not checking that list for these lookups.

JH/22 Bug 2434: Add connection-elapsed "D=" element to more connection
      closure log lines.

JH/23 Fix crash in string expansions. Previously, if an empty variable was
      immediately followed by an expansion operator, a null-indirection read
      was done, killing the process.

JH/24 Bug 2997: When built with EXPERIMENTAL_DSN_INFO, bounce messages can
      include an SMTP response string which is longer than that supported
      by the delivering transport.  Alleviate by wrapping such lines before
      column 80.

JH/25 Bug 2827: Restrict size of References: header in bounce messages to 998
      chars (RFC limit).  Previously a limit of 12 items was made, which with
      a not-impossible References: in the message being bounced could still
      be over-large and get stopped in the transport.

JH/26 For a ${readsocket } in TLS mode, send a TLS Close Alert before the TCP
      close.  Previously a bare socket close was done.

JH/27 Fix ${srs_encode ..}.  Previously it would give a bad result for one day
      every 1024 days.

JH/28 Bug 2996: Fix a crash in the smtp transport.  When finding that the
      message being considered for delivery was already being handled by
      another process, and having an SMTP connection already open, the function
      to close it tried to use an uninitialized variable.  This would afftect
      high-volume sites more, especially when running mailing-list-style loads.
      Pollution of logs was the major effect, as the other process delivered
      the message.  Found and partly investigated by Graeme Fowler.

JH/29 Change format of the internal ID used for message identification. The old
      version only supported 31 bits for a PID element; the new 64 (on systems
      which can use Base-62 encoding, which is all currently supported ones
      but not Darwin (MacOS) or Cygwin, which have case-insensitive filesystems
      and must use Base-36).  The new ID is 23 characters rather than 16, and is
      visible in various places - notably logs, message headers, and spool file
      names.  Various of the ancillary utilities also have to know the format.
	As well as the expanded PID portion, the sub-second part of the time
      recorded in the ID is expanded to support finer precision.  Theoretically
      this permits a receive rate from a single comms channel of better than the
      previous 2000/sec.
        The major timestamp part of the ID is not changed; at 6 characters it is
      usable until about year 3700.
        Updating from previously releases is fully supported: old-format spool
      files are still usable, and the utilities support both formats.  New
      message will use the new format.  The one hints-DB file type which uses
      message-IDs (the transport wait- DB) will be discarded if an old-format ID
      is seen; new ones will be built with only new-format IDs.
      Optionally, a utility can be used to convert spool files from old to new,
      but this is only an efficiency measure not a requirement for operation
        Downgrading from new to old requires running a provided utility, having
      first stopped all operations.  This will convert any spool files from new
      back to old (losing time-precision and PID information) and remove any
      wait- hints databases.

JH/30 Bug 3006: Fix handling of JSON strings having embedded commas. Previously
      we treated them as item separators when parsing for a list item, but they
      need to be protected by the doublequotes.  While there, add handling for
      backslashes.

JH/31 Bug 2998: Fix ${utf8clean:...} to disallow UTF-16 surrogate codepoints.
      Found and fixed by Jasen Betts. No testcase for this as my usual text
      editor insists on emitting only valid UTF-8.

JH/32 Fix "tls_dhparam = none" under GnuTLS.  At least with 3.7.9 this gave
      a null-indirection SIGSEGV for the receive process.

JH/33 Fix free for live variable $value created by a ${run ...} expansion during
      -bh use.  Internal checking would spot this and take a panic.

JH/34 Bug 3013: Fix use of $recipients within arguments for ${run...}.
      In 4.96 this would expand to empty.

JH/35 Bug 3014: GnuTLS: fix expiry date for an auto-generated server
      certificate.  Find and fix by Andreas Metzler.

JH/36 Add ARC info to DMARC hostory records.

JH/37 Bug 3016: Avoid sending DSN when message was accepted under fakereject
      or fakedefer.  Previously the sender could discover that the message
      had in fact been accepted.

JH/38 Taint-track intermediate values from the peer in multi-stage authentation
      sequences.  Previously the input was not noted as being tainted; notably
      this resulted in behaviour of LOGIN vs. PLAIN being inconsistent under
      bad coding of authenticators.

JH/39 Bug 3023: Fix crash induced by some combinations of zero-length strings
      and ${tr...}.  Found and diagnosed by Heiko Schlichting.

JH/40 Bug 2999: Fix a possible OOB write in the external authenticator, which
      CVE-2023-42115

JH/41 Bug 3000: Fix a possible OOB write in the SPA authenticator, which could
      be triggered by externally-controlled input.  Found by Trend Micro.
      CVE-2023-42116

JH/42 Bug 3001: Fix a possible OOB read in the SPA authenticator, which could
      be triggered by externally-controlled input.  Found by Trend Micro.
      CVE-2023-42114

JH/43 Bug 2903: avoid exit on an attempt to rewrite a malformed address.
      Make the rewrite never match and keep the logging.  Trust the
      admin to be using verify=header-syntax (to actually reject the message).

JH/44 Bug 3033: Harden dnsdb lookups against crafted DNS responses.
      CVE-2023-42219
      could be triggered by externally-supplied input.  Found by Trend Micro.
      CVE-2023-42115

JH/41 Bug 3000: Fix a possible OOB write in the SPA authenticator, which could
      be triggered by externally-controlled input.  Found by Trend Micro.
      CVE-2023-42116

JH/42 Bug 3001: Fix a possible OOB read in the SPA authenticator, which could
      be triggered by externally-controlled input.  Found by Trend Micro.
      CVE-2023-42114

JH/43 Bug 2903: avoid exit on an attempt to rewrite a malformed address.
      Make the rewrite never match and keep the logging.  Trust the
      admin to be using verify=header-syntax (to actually reject the message).