### PR TITLE
fx: update to 34.0.0

### DIFF
--- a/utils/fx/Makefile
+++ b/utils/fx/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fx
-PKG_VERSION:=33.0.0
+PKG_VERSION:=34.0.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/antonmedv/fx/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=b619c18a3cbc7566be1c7fecfc802d469402cf8eae6a70911359c4de7eab07ba
+PKG_HASH:=a1d436a8951a753488adda02fe9fb1091fabfe928eafce73f3b1e690a9dccbee
 
 PKG_MAINTAINER:=Fabian Lipken <dynasticorpheus@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @dynasticorpheus  
Compile tested: Ubuntu 23.04 x64 / OpenWrt SNAPSHOT @ 36b1dd75fd9da1ea13f1ce1ee679c6b3c9c402cc
Run tested: Linksys WRT32X / OpenWrt SNAPSHOT r24315-ae500e62e2

Description: Update to [34.0.0](https://github.com/antonmedv/fx/compare/33.0.0...34.0.0)

Fx is a dual-purpose command-line tool tailored for JSON, providing both a terminal-based JSON viewer and a JSON processing utility.