### PR TITLE
[23.05] curl: update to 8.7.1

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -9,15 +9,15 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
-PKG_VERSION:=8.6.0
-PKG_RELEASE:=1
+PKG_VERSION:=8.7.1
+PKG_RELEASE:=r1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \
 	https://dl.uxnr.de/mirror/curl/ \
 	https://curl.askapache.com/download/ \
 	https://curl.se/download/
-PKG_HASH:=b4785f2d8877fa92c0e45d7155cf8cc6750dbda961f4b1a45bcbec990cf2fa9b
+PKG_HASH:=05bbd2b698e9cfbab477c33aa5e99b4975501835a41b7ca6ca71de03d8849e76
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
@@ -113,6 +113,7 @@ TARGET_LDFLAGS += -Wl,--gc-sections
 
 CONFIGURE_ARGS += \
 	--disable-debug \
+	--disable-docs \
 	--disable-ares \
 	--enable-shared \
 	--enable-static \

--- a/net/curl/patches/200-no_docs_tests.patch
+++ b/net/curl/patches/200-no_docs_tests.patch
@@ -3,18 +3,22 @@
 @@ -135,7 +135,7 @@ CLEANFILES = $(VC14_LIBVCXPROJ) $(VC14_S
  bin_SCRIPTS = curl-config
  
- SUBDIRS = lib src
+ SUBDIRS = lib docs src scripts
 -DIST_SUBDIRS = $(SUBDIRS) tests packages scripts include docs
 +DIST_SUBDIRS = $(SUBDIRS) packages include
  
  pkgconfigdir = $(libdir)/pkgconfig
  pkgconfig_DATA = libcurl.pc
-@@ -243,8 +243,6 @@ cygwinbin:
- # We extend the standard install with a custom hook:
+@@ -244,12 +244,9 @@ cygwinbin:
+ if BUILD_DOCS
  install-data-hook:
  	(cd include && $(MAKE) install)
 -	(cd docs && $(MAKE) install)
 -	(cd docs/libcurl && $(MAKE) install)
+ else
+ install-data-hook:
+ 	(cd include && $(MAKE) install)
+-	(cd docs && $(MAKE) install)
+ endif
  
  # We extend the standard uninstall with a custom hook:
- uninstall-hook:


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2

Description:
* update to 8.7.1: https://curl.se/changes.html#8_7_1
* use the new --disable-docs flag for configure
* update 200-no_docs_tests.patch
* switch to APK-compatible revision

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 227c8daa159acdc84aad9e06a6a33f7d07263130)
