### PR TITLE
ovpn-dco: bump version to 0.2.20240320

### DIFF
--- a/kernel/ovpn-dco/Makefile
+++ b/kernel/ovpn-dco/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ovpn-dco
-PKG_VERSION:=0.2.20230426
+PKG_VERSION:=0.2.20240320
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://codeload.github.com/OpenVPN/ovpn-dco/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=f8ba335026d7d0d73e9ee121fd1a3b4b6f5e8ad5b604d4cc16f943ae46784a85
+PKG_HASH:=83a02dc3e6e40b0ef128cd32ce7f47da7fccd759af68657f44925d64a88db37b
 
 PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
 PKG_LICENSE:=GPL-2.0-only
@@ -38,6 +38,7 @@ endef
 NOSTDINC_FLAGS += \
 	$(KERNEL_NOSTDINC_FLAGS) \
 	-I$(PKG_BUILD_DIR)/include \
+	-I$(PKG_BUILD_DIR)/compat-include \
 	-include $(PKG_BUILD_DIR)/linux-compat.h
 
 EXTRA_KCONFIG:= \


### PR DESCRIPTION
Fixes builds against kernel 6.6

Maintainer:
Compile tested: AArch64 kernel 6.6
Run tested: no