### PR TITLE
nano: fix syntax highlighting for raw ucode scripts

### DIFF
--- a/utils/nano/Makefile
+++ b/utils/nano/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nano
 PKG_VERSION:=7.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/nano

--- a/utils/nano/files/ucode.nanorc
+++ b/utils/nano/files/ucode.nanorc
@@ -43,7 +43,7 @@ color ,green "[[:space:]]+$"
 
 # Text outside template directives
 color slate start="[}%#]\}" end="\{[{%#]"
-color slate start="^#!" end="\{[{%#]"
+color slate start="^#!.*(\<utpl\>|[[:space:]]-[[:alnum:]]*T[[:alnum:]]*\>)" end="\{[{%#]"
 color slate "^([^{%#}]|\{[^{%#]|[%#}][^}])+\{[{%#]"
 
 # Template tags


### PR DESCRIPTION
Maintainer: @hnyman 
Compile tested: n/a
Run tested: n/a

Description:

Text between interpreter line and start of first directive should only highlighted as uninterpreted when running in template mode, so adjust the match rule accordingly.

Fixes: #23761 