### PR TITLE
libopenldap: Add missing Config.in hook

### DIFF
--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -53,6 +53,10 @@ define Package/libopenldap
   TITLE+= (libraries)
 endef
 
+define Package/libopenldap/config
+  source "$(SOURCE)/Config.in"
+endef
+
 define Package/openldap/config
   source "$(SOURCE)/Config.in"
 endef


### PR DESCRIPTION
Package has a consistent Config.in file, but it isn't added to all parts of the file.

libopenldap is unable to be built with `--enable-debug` because the Config.in is never attached to `Package/libopenldap/Config`

