### PR TITLE
ksmbd-tools: update to version 3.5.2

### DIFF
--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
-PKG_VERSION:=3.5.1
-PKG_RELEASE:=2
+PKG_VERSION:=3.5.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/cifsd-team/ksmbd-tools/releases/download/$(PKG_VERSION)
-PKG_HASH:=ab377b3044c48382303f3f7ec95f2e1a17592c774d70b2a11f32952099dbb214
+PKG_HASH:=5da7fb4cb4368f9abf56f6f9fbc17b25e387876bed9ff7ee0d6f1140ef07c8d7
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Major changes are:
 - Add durable handles parameter to ksmbd.conf.
 - Add payload_sz in ksmbd_share_config_response to validate ipc response.
 - Fix UAF and cleanups.

Maintainer: nobody
Compile tested: mediatek/filogic GL.iNet GL-MT6000 OpenWRT snapshot r25843-4d69e130c6

Run tested: mediatek/filogic GL.iNet GL-MT6000 OpenWRT snapshot r25843-4d69e130c6

Tested
-add new user
-mod existing user

please cherry-pick to 23.05, thanks a lot