### PR TITLE
glib2: link libiconv when building host pkg

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.74.7
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/$(basename $(PKG_VERSION))
@@ -26,7 +26,7 @@ PKG_FORTIFY_SOURCE:=0
 PKG_BUILD_FLAGS:=gc-sections
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/glib-$(PKG_VERSION)
-HOST_BUILD_DEPENDS:=pcre2/host libffi/host
+HOST_BUILD_DEPENDS:=pcre2/host libffi/host libiconv-full/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
some compile error happens when building.
Linking to libiconv-full fixes this.
refer to: https://github.com/openwrt/openwrt/commit/63dd14b906e9eb27bc878b95ac6777a3624b1135

fix this error: 
```
ninja: Entering directory `/home/nasbdh9/openwrt/build_dir/hostpkg/glib-2.74.7/openwrt-build'
[1/240] Linking target glib/gtester
FAILED: glib/gtester
/home/nasbdh9/openwrt/staging_dir/host/bin/gcc  -o glib/gtester glib/gtester.p/gtester.c.o -L/home/nasbdh9/openwrt/staging_dir/host/lib -L/home/nasbdh9/openwrt/staging_dir/hostpkg/lib -L/home/nasbdh9/openwrt/staging_dir/target-x86_64_musl/host/lib -Wl,--as-needed -Wl,--no-undefined -Wl,--start-group glib/libglib-2.0.a -pthread -lm -Wl,--end-group
/usr/bin/ld: glib/libglib-2.0.a(gconvert.c.o): in function `try_conversion':
/home/nasbdh9/openwrt/build_dir/hostpkg/glib-2.74.7/openwrt-build/../glib/gconvert.c:172: undefined reference to `libiconv_open'
/usr/bin/ld: /home/nasbdh9/openwrt/build_dir/hostpkg/glib-2.74.7/openwrt-build/../glib/gconvert.c:172: undefined reference to `libiconv_open'
/usr/bin/ld: /home/nasbdh9/openwrt/build_dir/hostpkg/glib-2.74.7/openwrt-build/../glib/gconvert.c:172: undefined reference to `libiconv_open'
/usr/bin/ld: /home/nasbdh9/openwrt/build_dir/hostpkg/glib-2.74.7/openwrt-build/../glib/gconvert.c:172: undefined reference to `libiconv_open'
/usr/bin/ld: glib/libglib-2.0.a(gconvert.c.o): in function `g_iconv':
/home/nasbdh9/openwrt/build_dir/hostpkg/glib-2.74.7/openwrt-build/../glib/gconvert.c:282: undefined reference to `libiconv'
/usr/bin/ld: glib/libglib-2.0.a(gconvert.c.o): in function `g_iconv_close':
/home/nasbdh9/openwrt/build_dir/hostpkg/glib-2.74.7/openwrt-build/../glib/gconvert.c:305: undefined reference to `libiconv_close'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```
