### PR TITLE
softflowd: add '-b' option to config

### DIFF
--- a/net/softflowd/Makefile
+++ b/net/softflowd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=softflowd
 PKG_VERSION:=1.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/irino/softflowd/tar.gz/softflowd-v$(PKG_VERSION)?

--- a/net/softflowd/files/softflowd.config
+++ b/net/softflowd/files/softflowd.config
@@ -11,5 +11,6 @@ config softflowd
 	option hoplimit       ''
 	option tracking_level 'full'
 	option track_ipv6     '0'
+	option bidirectional  '0'
 	option sampling_rate  '100'
 	option filter         ''

--- a/net/softflowd/files/softflowd.init
+++ b/net/softflowd/files/softflowd.init
@@ -44,6 +44,7 @@ start_instance() {
 	append_string "$section" 'tracking_level' '-T'
 	append_string "$section" 'sampling_rate' '-s'
 	append_bool "$section" track_ipv6 '-6'
+	append_bool "$section" bidirectional '-b'
 
 	procd_open_instance
 	procd_set_param command /usr/sbin/softflowd -d $args${pid_file:+ -p $pid_file} "$filter"


### PR DESCRIPTION
- add '-b' option to enable bidirectional flow probing

Maintainer: @rvandegrift (Makefile) or @stintel (Git history)
Compile tested: cross-compiled on Linux/x86_64 for ramips/mt7621
Run tested: ramips/mt7621, Asus RT-AX53U running OpenWRT 23.05.0

Test procedure:
* download stock config from downloads.openwrt.org
* set router model and `CONFIG_PACKAGE_softflowd=m`
* compile toolchain, softflowd
* upload package to target, install with `opkg`, update config
* `service softflowd restart`
* verify `-b` arg present with `ps | grep softflowd`