### PR TITLE
node: April 3, 2024 Security Releases

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v20.11.1
+PKG_VERSION:=v20.12.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=77813edbf3f7f16d2d35d3353443dee4e61d5ee84d9e3138c7538a3c0ca5209e
+PKG_HASH:=b9bef0314e12773ef004368ee56a2db509a948d4170b9efb07441bac1f1407a0
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,6 +1,6 @@
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1537,7 +1537,8 @@ Module._initPaths = function() {
+@@ -1529,7 +1529,8 @@ Module._initPaths = function() {
      path.resolve(process.execPath, '..') :
      path.resolve(process.execPath, '..', '..');
  

--- a/lang/node/patches/202-node_gyp.patch
+++ b/lang/node/patches/202-node_gyp.patch
@@ -1,10 +1,10 @@
 --- a/node.gyp
 +++ b/node.gyp
-@@ -1193,6 +1193,7 @@
+@@ -1197,6 +1197,7 @@
        'dependencies': [
          'deps/simdutf/simdutf.gyp:simdutf#host',
        ],
 +      'libraries!':[ '-licui18n', '-licuuc', '-licudata', '-lcrypto', '-lssl', '-lz', '-lhttp_parser', '-luv', '-lnghttp2', '-lcares' ],
        'include_dirs': [
-         'tools'
-       ],
+         'tools',
+         'src',

--- a/lang/node/patches/204-v8_gyp.patch
+++ b/lang/node/patches/204-v8_gyp.patch
@@ -77,7 +77,7 @@
          'include_dirs': [
            '<(generate_bytecode_output_root)',
            '<(SHARED_INTERMEDIATE_DIR)',
-@@ -1484,6 +1495,7 @@
+@@ -1495,6 +1506,7 @@
          }],
        ],
        'direct_dependent_settings': {
@@ -85,7 +85,7 @@
          'include_dirs': [
            '<(V8_ROOT)/include',
          ],
-@@ -1504,6 +1516,7 @@
+@@ -1515,6 +1527,7 @@
      {
        'target_name': 'bytecode_builtins_list_generator',
        'type': 'executable',
@@ -93,7 +93,7 @@
        'conditions': [
          ['want_separate_host_toolset', {
            'toolsets': ['host'],
-@@ -1532,6 +1545,9 @@
+@@ -1543,6 +1556,9 @@
      {
        'target_name': 'mksnapshot',
        'type': 'executable',
@@ -103,7 +103,7 @@
        'dependencies': [
          'v8_base_without_compiler',
          'v8_compiler_for_mksnapshot',
-@@ -1559,6 +1575,7 @@
+@@ -1570,6 +1586,7 @@
      {
        'target_name': 'torque',
        'type': 'executable',
@@ -111,7 +111,7 @@
        'dependencies': [
          'torque_base',
          # "build/win:default_exe_manifest",
-@@ -1601,6 +1618,7 @@
+@@ -1612,6 +1629,7 @@
      {
        'target_name': 'torque-language-server',
        'type': 'executable',
@@ -119,7 +119,7 @@
        'conditions': [
          ['want_separate_host_toolset', {
            'toolsets': ['host'],
-@@ -1632,6 +1650,8 @@
+@@ -1643,6 +1661,8 @@
      {
        'target_name': 'gen-regexp-special-case',
        'type': 'executable',
@@ -128,7 +128,7 @@
        'dependencies': [
          'v8_libbase',
          # "build/win:default_exe_manifest",
-@@ -1850,6 +1870,7 @@
+@@ -1861,6 +1881,7 @@
           }],
        ],
        'direct_dependent_settings': {
@@ -136,9 +136,9 @@
          'include_dirs': [
            '<(V8_ROOT)/include',
          ],
-@@ -1971,15 +1992,19 @@
-         }],
-       ],
+@@ -1988,15 +2009,19 @@
+         'WARNING_CFLAGS!': ['-Wno-invalid-offsetof']
+       },
        'direct_dependent_settings': {
 +        'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
          'include_dirs': [

--- a/lang/node/patches/999-localhost-no-addrconfig.patch
+++ b/lang/node/patches/999-localhost-no-addrconfig.patch
@@ -13,7 +13,7 @@ Forwarded: https://github.com/nodejs/node/issues/33816
  //
  // Permission is hereby granted, free of charge, to any person obtaining a
  // copy of this software and associated documentation files (the
-@@ -1330,13 +1331,6 @@ function lookupAndConnect(self, options)
+@@ -1337,13 +1338,6 @@ function lookupAndConnect(self, options)
      hints: options.hints || 0,
    };
  

--- a/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
+++ b/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
@@ -1,6 +1,6 @@
 --- a/configure.py
 +++ b/configure.py
-@@ -1275,7 +1275,6 @@ def configure_node(o):
+@@ -1282,7 +1282,6 @@ def configure_node(o):
  
    # Enable branch protection for arm64
    if target_arch == 'arm64':


### PR DESCRIPTION
Maintainer: me @ianchi
Compile tested: head, aarch64, arm, i386, x86_64
Run tested: (qemu 8.2.1) aarch64

Description:
Update to v20.12.1

This is a security release
Notable Changes
* CVE-2024-27983 - Assertion failed in node::http2::Http2Session::~Http2Session() leads to HTTP/2 server crash- (High)
* CVE-2024-27982 - HTTP Request Smuggling via Content Length Obfuscation - (Medium)
* llhttp version 9.2.1
* undici version 5.28.4

Changed to use gz according to main-snapshot