### PR TITLE
[23.05] node: April 3, 2024 Security Releases

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v18.19.1
+PKG_VERSION:=v18.20.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=090f96a2ecde080b6b382c6d642bca5d0be4702a78cb555be7bf02b20bd16ded
+PKG_HASH:=7fb430d0b1256c22f26dd321070182ab943005bdb7b738facc6d9a82b1e04ed7
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,6 +1,6 @@
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1516,7 +1516,8 @@ Module._initPaths = function() {
+@@ -1524,7 +1524,8 @@ Module._initPaths = function() {
      path.resolve(process.execPath, '..') :
      path.resolve(process.execPath, '..', '..');
  


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: 23.05, aarch64, arm 
Run tested: (qemu 8.2.1) aarch64

Description:
Update to v18.20.1

Notable Changes
* CVE-2024-27983 - Assertion failed in node::http2::Http2Session::~Http2Session() leads to HTTP/2 server crash- (High)
* CVE-2024-27982 - HTTP Request Smuggling via Content Length Obfuscation - (Medium)
* llhttp version 9.2.1
* undici version 5.28.4

Changed to use gz according to main-snapshot
