### PR TITLE
shairport-sync: fixed diagnostics setting generation in shairport-sync's native conf file

### DIFF
--- a/sound/shairport-sync/Makefile
+++ b/sound/shairport-sync/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shairport-sync
 PKG_VERSION:=4.3.2
-PKG_RELEASE:=3
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikebrady/shairport-sync/tar.gz/$(PKG_VERSION)?

--- a/sound/shairport-sync/files/shairport-sync.config
+++ b/sound/shairport-sync/files/shairport-sync.config
@@ -18,10 +18,10 @@ config shairport-sync 'shairport_sync'
 	option port '' # 5000
 	option udp_port_base '' # 6001
 	option udp_port_range '' # 100
-	option statistics '' # no/yes
+	option statistics '' # no/yes - DEPRECATED: This option will be removed in a future release. Use 'diagnostics_statistics' instead
 	option drift '' # 88
 	option resync_threshold '' # 2205
-	option log_verbosity '' # 0/1/2/3
+	option log_verbosity '' # 0/1/2/3 - DEPRECATED: This option will be removed in a future release. Use 'diagnostics_log_verbosity' instead
 	option ignore_volume_control '' # no/yes
 	option volume_range_db '' # 30 to 150
 	option regtype '' # _raop._tcp
@@ -59,3 +59,7 @@ config shairport-sync 'shairport_sync'
 	# AO
 	option ao_latency_offset '' # 0
 	option ao_buffer_length '' # 44100
+	# Diagnostics
+	option diagnostics_statistics '' # no/yes
+	option diagnostics_log_output_to '' # syslog/stderr/stdout
+	option diagnostics_log_verbosity '' # 0/1/2/3

--- a/sound/shairport-sync/files/shairport-sync.init
+++ b/sound/shairport-sync/files/shairport-sync.init
@@ -56,10 +56,8 @@ start_instance() {
 		append_num "$cfg" port "port"
 		append_num "$cfg" udp_port_base "udp_port_base"
 		append_num "$cfg" udp_port_range "udp_port_range"
-		append_str "$cfg" statistics "statistics"
 		append_num "$cfg" drift "drift"
 		append_num "$cfg" resync_threshold "resync_threshold"
-		append_num "$cfg" log_verbosity "log_verbosity"
 		append_str "$cfg" ignore_volume_control "ignore_volume_control"
 		append_num "$cfg" volume_range_db "volume_range_db"
 		append_str "$cfg" regtype "regtype"
@@ -121,6 +119,17 @@ start_instance() {
 		printf "{\n"
 		append_num "$cfg" ao_latency_offset "audio_backend_latency_offset"
 		append_num "$cfg" ao_buffer_length "audio_backend_buffer_desired_length"
+		printf "};\n\n"
+
+		# Diagnostics
+		config_get log_verbosity "$cfg" log_verbosity
+		config_get statistics "$cfg" statistics
+
+		printf "diagnostics =\n"
+		printf "{\n"
+		append_str "$cfg" diagnostics_statistics "statistics" "${statistics}"
+		append_str "$cfg" diagnostics_log_output_to "log_output_to"
+		append_num "$cfg" diagnostics_log_verbosity "log_verbosity" "${log_verbosity}"
 		printf "};\n\n"
 	} > "$conf_file"
 


### PR DESCRIPTION
The original PR was closed by mistake: https://github.com/openwrt/packages/pull/23800 - This new PR supersedes it.

Maintainer: @mikebrady
Compile tested: NanoPi R4s / SNAPSHOTS
Run tested: NanoPi R4s / SNAPSHOTS

Description:
shairport-sync expects statistics/log_verbosity/log_output_to settings
to be in the diagnostics section of shairport-sync's native config.

Prior to this commit, these settings were either missing (log_output_to)
or generated in the incorrect (general) native config section bloc.
