### PR TITLE
rsync: update to 3.3.0

### DIFF
--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsync
-PKG_VERSION:=3.2.7
+PKG_VERSION:=3.3.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.samba.org/pub/$(PKG_NAME)/src
-PKG_HASH:=4e7d9d3f6ed10878c58c5fb724a67dacf4b6aac7340b13e488fb2dc41346f2bb
+PKG_HASH:=7399e9a6708c32d678a72a63219e96f23be0be2336e50fd1348498d07041df90
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
Changelog: https://download.samba.org/pub/rsync/NEWS#3.3.0
```
# rsync --version
rsync  version 3.3.0  protocol version 31
Copyright (C) 1996-2024 by Andrew Tridgell, Wayne Davison, and others. Web site: https://rsync.samba.org/
Capabilities:
    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
    no socketpairs, symlinks, symtimes, hardlinks, no hardlink-specials,
    no hardlink-symlinks, IPv6, atimes, batchfiles, inplace, append, no ACLs,
    no xattrs, optional secluded-args, no iconv, prealloc, stop-at,
    no crtimes
Optimizations:
    no SIMD-roll, no asm-roll, no openssl-crypto, asm-MD5
Checksum list:
    md5 md4 none
Compress list:
    zlibx zlib none
Daemon auth list:
    md5 md4
```
Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne

Maintainer: @mstorchak