### PR TITLE
speedtest-go: add new package

### DIFF
--- a/net/speedtest-go/Makefile
+++ b/net/speedtest-go/Makefile
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# Copyright (C) 2021 ImmortalWrt.org
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=speedtest-go
+PKG_VERSION:=1.6.11
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/showwin/speedtest-go/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=e09e1532bf3d1d78cad6546e8614e72e818fb14c3a7c11d609905c9ae7337930
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=TeleostNaCl Dai <teleostnacl@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/showwin/speedtest-go
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/speedtest-go
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Test Internet Speed
+  URL:=https://github.com/showwin/speedtest-go
+  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+endef
+
+define Package/speedtest-go/description
+  Command Line Interface and pure Go API to
+  Test Internet Speed using speedtest.net
+endef
+
+$(eval $(call GoBinPackage,speedtest-go))
+$(eval $(call BuildPackage,speedtest-go))


### PR DESCRIPTION
This is a Command Line Interface (CLI) and pure Go API to test internet speed using speedtest.net. Its upstream is https://github.com/showwin/speedtest-go

Maintainer: TeleostNaCl [teleostnacl@gmail.com](mailto:teleostnacl@gmail.com)
Compile tested: MediaTek Ralink MIPS MT7621 based boards Phicomm K2P Powered by LuCI Master (git-24.096.15376-b029f06)
Run tested: MediaTek Ralink MIPS MT7621 based boards Phicomm K2P Powered by LuCI Master (git-24.096.15376-b029f06)

Description: Add new package, a CLI with go to test internet speed
