### PR TITLE
pppossh: add option peer_pppd_options

### DIFF
--- a/net/pppossh/Makefile
+++ b/net/pppossh/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pppossh
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 PKG_LICENSE:=GPLv2
 

--- a/net/pppossh/README.md
+++ b/net/pppossh/README.md
@@ -1,6 +1,6 @@
 This package will add the so-called `pppossh` protocol support to OpenWrt.  The idea is mainly from [`pvpn` project](https://github.com/halhen/pvpn) (poor man's VPN over SSH).
 
-PPPoSSH is generally not considered a network setup for production use mainly due to the TCP-over-TCP styles of traffic transport, but it can be quite handy for personal use.  And with what's already in OpenWrt, it is really easy and takes little extra space to configure it up running.
+PPPoSSH is generally not considered a network setup for production use mainly due to the TCP-over-TCP styles of traffic transport, but it can be quite handy for personal use.  And with what's already in OpenWrt, it is really easy and takes little extra space to configure it up and running.
 
 ## Prerequisites and dependency.
 
@@ -32,6 +32,7 @@ The protocol name to use in `/etc/config/network` is `pppossh`.  Options are as 
 - `ipaddr`, local ip address to be assigned.
 - `peeraddr`, peer ip address to be assigned.
 - `ssh_options`, extra options for the ssh client.
+- `peer_pppd_options`, extra options for the pppd command run on the peer side.
 - `use_hostdep`, set it to `0` to disable the use of `proto_add_host_dependency`.  This is mainly for the case that the appropriate route to `server` is not registered to `netifd` and thus causing a incorrect route being setup.
 
 ## Tips
@@ -63,6 +64,6 @@ It's possible that pppd may output protocol negotiation incompatibilities issues
 
 To debug such problems, we can try adding `option pppd_optinos debug` to the interface config.  In the above case, it's a LCP CCP configure rej (the CCP options struct is exactly 6 octets in size as indicated in source code `pppd/ccp.h`) and since the internet fee is not charged on the bytes transferred, I will just use `noccp` to disable the negotiation altogether.
 
-Also to optimize bulk transfer performance, you can try tweaking the ciphers.  OpenSSH client does not support `none` cipher by default and you have to patch and install it for by yourself.  Another option is to try ciphers like `arcfour` and `blowfish-cbc`.  In my case, `arcfour` has the best throughput.
+Also to optimize bulk transfer performance, you can try tweaking the ciphers.  OpenSSH client does not support `none` cipher by default and you have to patch and install it by yourself.  Another option is to try ciphers like `arcfour` and `blowfish-cbc`.  In my case, `arcfour` has the best throughput.
 
 	option ssh_options '-o "Ciphers arcfour"'

--- a/net/pppossh/files/pppossh.sh
+++ b/net/pppossh/files/pppossh.sh
@@ -16,7 +16,7 @@ INCLUDE_ONLY=1
 
 proto_pppossh_init_config() {
 	ppp_generic_init_config
-	config_add_string server sshuser ipaddr peeraddr ssh_options
+	config_add_string server sshuser ipaddr peeraddr ssh_options peer_pppd_options
 	config_add_array 'identity:list(string)'
 	config_add_int port use_hostdep
 	available=1
@@ -28,10 +28,10 @@ proto_pppossh_setup() {
 	local iface="$2"
 	local user="$(id -nu)"
 	local home=$(sh -c "echo ~$user")
-	local server port sshuser ipaddr peeraddr ssh_options identity use_hostdep
+	local server port sshuser ipaddr peeraddr ssh_options peer_pppd_options identity use_hostdep
 	local ip fn errmsg opts pty
 
-	json_get_vars port sshuser ipaddr peeraddr ssh_options use_hostdep
+	json_get_vars port sshuser ipaddr peeraddr ssh_options peer_pppd_options use_hostdep
 	json_get_var server server && {
 		[ -z "$use_hostdep" ] && use_hostdep=1
 		for ip in $(resolveip -t 5 "$server"); do
@@ -60,7 +60,7 @@ proto_pppossh_setup() {
 	opts="$opts ${port:+-p $port}"
 	opts="$opts ${ssh_options}"
 	opts="$opts $sshuser@$server"
-	pty="exec env 'HOME=$home' $SSH $opts pppd nodetach notty noauth"
+	pty="exec env 'HOME=$home' $SSH $opts pppd nodetach notty noauth $peer_pppd_options"
 
 	ppp_generic_setup "$config" noauth pty "$pty" "$ipaddr:$peeraddr"
 }


### PR DESCRIPTION

Maintainer: me
Compile tested: N/A
Run tested: x86_64 on qemu kvm, OpenWrt 22.03.5, ifup/down

Description:

This can be useful for things like making the interface on the peer side fixed with value like `ifname xx`
