### PR TITLE
snort3: fix bug with unset variable

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.1.84.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/

--- a/net/snort3/files/snort-mgr
+++ b/net/snort3/files/snort-mgr
@@ -54,7 +54,7 @@ nft_rm_table() {
 
 nft_add_table() {
 	if [ "$(uci -q get snort.snort.method)" = "nfq" ]; then
-		local options
+		local options=''
 		$VERBOSE && options='-e'
 		print nftables | nft $options -f $STDIN
 		$VERBOSE && nft list table inet snort
@@ -118,7 +118,7 @@ check() {
 	fi
 
 	if [ "$(uci -q get snort.snort.method)" = "nfq" ]; then
-		local options
+		local options=''
 		local test_nft="${CONF_DIR}/test_conf.nft"
 		print nftables > "${test_nft}" || die "Errors during generation of nftables config"
 		$VERBOSE && options='-e'


### PR DESCRIPTION
Parameter not set in two places: /usr/bin/snort-mgr: eval: line 125: options: parameter not set

Reported-by: @klingon888

Maintainer: @flyn-org @graysky2 
Compile tested: NA
Run tested: x86-64

Description:
`snort-mgr` fails due to unset variable in two places.