### PR TITLE
libarchive: update to 3.7.3

### DIFF
--- a/libs/libarchive/Makefile
+++ b/libs/libarchive/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libarchive
-PKG_VERSION:=3.7.2
+PKG_VERSION:=3.7.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.libarchive.org/downloads
-PKG_HASH:=04357661e6717b6941682cde02ad741ae4819c67a260593dfb2431861b251acb
+PKG_HASH:=63e7a7174638fc7d6b79b4c8b0ad954e0f4f45abe7239c1ecb200232aa9a43d2
 
 PKG_MAINTAINER:=Johannes Morgenroth <morgenroth@ibr.cs.tu-bs.de>
 PKG_LICENSE:=BSD-2-Clause


### PR DESCRIPTION
Maintainer: @morgenroth 
Run tested: ARMv7, Linksys WRT3200ACM, master branch, tesseract package depening from this works all right
