### PR TITLE
netbird: update to 0.27.3

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.26.6
+PKG_VERSION:=0.27.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=009656248dba9b0e9969c7658178c50ebef7866e96de75b79b9b15d8c2ba1a47
+PKG_HASH:=f172798f164b7484b231adc656eaf1090b6f7d9e7d7c3753f1e611bdf82ae738
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: Oskari Rauta / @oskarirauta
Compile tested: [mips_24kc](https://openwrt.org/docs/techref/instructionset/mips_24kc), [ar71xx-ath79](https://openwrt.org/docs/techref/targets/ar71xx-ath79), generic, TP-Link, [Archer C7](https://openwrt.org/toh/tp-link/archer_c7), v4, OpenWrt SNAPSHOT r25888-ae192c042c
Run tested: [mips_24kc](https://openwrt.org/docs/techref/instructionset/mips_24kc), [ar71xx-ath79](https://openwrt.org/docs/techref/targets/ar71xx-ath79), generic, TP-Link, [Archer C7](https://openwrt.org/toh/tp-link/archer_c7), v4, OpenWrt SNAPSHOT r25888-ae192c042c

~~Compile tested: [mips_24kc](https://openwrt.org/docs/techref/instructionset/mips_24kc), [ar71xx-ath79](https://openwrt.org/docs/techref/targets/ar71xx-ath79), generic, TP-Link, [Archer C7](https://openwrt.org/toh/tp-link/archer_c7), v4, OpenWrt SNAPSHOT r25877-076f945dfb
Run tested: [mips_24kc](https://openwrt.org/docs/techref/instructionset/mips_24kc), [ar71xx-ath79](https://openwrt.org/docs/techref/targets/ar71xx-ath79), generic, TP-Link, [Archer C7](https://openwrt.org/toh/tp-link/archer_c7), v4, OpenWrt SNAPSHOT r25877-076f945dfb~~

~~Compile tested: [mips_24kc](https://openwrt.org/docs/techref/instructionset/mips_24kc), [ar71xx-ath79](https://openwrt.org/docs/techref/targets/ar71xx-ath79), generic, TP-Link, [Archer C7](https://openwrt.org/toh/tp-link/archer_c7), v4, OpenWrt SNAPSHOT r25874-98f9154316
Run tested: [mips_24kc](https://openwrt.org/docs/techref/instructionset/mips_24kc), [ar71xx-ath79](https://openwrt.org/docs/techref/targets/ar71xx-ath79), generic, TP-Link, [Archer C7](https://openwrt.org/toh/tp-link/archer_c7), v4, OpenWrt SNAPSHOT r25874-98f9154316~~

Description:
- Changelog:
  - [v0.27.3](https://github.com/netbirdio/netbird/releases/tag/v0.27.3)
  - [v0.27.2](https://github.com/netbirdio/netbird/releases/tag/v0.27.2)
  - [v0.27.1](https://github.com/netbirdio/netbird/releases/tag/v0.27.1)
  - [v0.27.0](https://github.com/netbirdio/netbird/releases/tag/v0.27.0)
  - [v0.26.7](https://github.com/netbirdio/netbird/releases/tag/v0.26.7)
- Full changelog: https://github.com/netbirdio/netbird/compare/v0.26.6...v0.27.3

Edit:
- bump version v0.27.2 to v0.27.3
- rebase
- add Signed-off-by 