### PR TITLE
macremapper: drop VERSION definition in Makefile

### DIFF
--- a/kernel/macremapper/Makefile
+++ b/kernel/macremapper/Makefile
@@ -25,7 +25,6 @@ include $(INCLUDE_DIR)/package.mk
 define KernelPackage/macremapper
   SUBMENU:=Network Support
   URL:=https://www.edgewaterwireless.com
-  VERSION:=$(LINUX_VERSION)-$(BOARD)-$(PKG_RELEASE)
   TITLE:=Dual Channel Wi-Fi macremapper Module
   DEPENDS:= +kmod-cfg80211 +kmod-br-netfilter
   FILES:=$(PKG_BUILD_DIR)/kernelmod/$(PKG_NAME).$(LINUX_KMOD_SUFFIX)


### PR DESCRIPTION
By defualt Kernel modules follow the version schema from openwrt.git, which happens to be APK compatible. Instead of defining a entirely custom format, use what's already out there.

This patch drops the individual VERSION definition.

Right now, the version becomes 6.1.82.1.1.0-r2

Maintainer: Carey Sonsino <careys@edgewaterwireless.com>
Compile tested: arm64