### PR TITLE
libs: glib2: fix provided pkg-config and always use host tools

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -100,6 +100,12 @@ define Build/InstallDev
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc \
 		$(1)/usr/lib/pkgconfig
+	$(foreach BIN,glib_genmarshal glib_mkenums,
+		$(SED) 's/^$(BIN)=$$$${bindir}\/\(.*\)/$(BIN)=$$$${prefix_hostpkg}\/bin\/\1/' $(1)/usr/lib/pkgconfig/glib-2.0.pc
+	)
+	$(foreach BIN,glib_compile_resources gdbus_codegen,
+		$(SED) 's/^$(BIN)=$$$${bindir}\/\(.*\)/$(BIN)=$$$${prefix_hostpkg}\/bin\/\1/' $(1)/usr/lib/pkgconfig/gio-2.0.pc
+	)
 
 	$(INSTALL_DIR) $(2)/share/aclocal/
 	$(INSTALL_DATA) \


### PR DESCRIPTION
For the InstallDev target, the pkg-config should point to the glib2 host tools for glib_compile_resources, gdbus_codegen, glib_genmarshal and glib_mkenums instead of pointing to the targets ones as they are unusable by the host machine (due to crosscompiling)

Fix the pkg-config to reference the host tools by replaying the entry and use the prefix_hostpkg variable provided by our pkg-config.

---

This fix the recent error with grilo-plugins trying to use target glib_compile_resources instead of the host one.