### PR TITLE
mtd-rw: drop PKG_VERSION definition in Makefile

### DIFF
--- a/kernel/mtd-rw/Makefile
+++ b/kernel/mtd-rw/Makefile
@@ -9,7 +9,6 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=mtd-rw
-PKG_VERSION:=git-20160214
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz


### PR DESCRIPTION
Maintainer: Joseph C. Lehner <joseph.c.lehner@gmail.com>
Compile tested: arm64
Run tested: -

Description:

By default Kernel modules follow the version schema from openwrt.git, which happens to be APK compatible. Instead of defining a entirely custom format, use what's already out there.

This patch drops the individual PKG_VERSION definition.

Right now, the version becomes 6.1.82.0~7e856206-r2.
