### PR TITLE
snort3: update to 3.1.84.0

### DIFF
--- a/libs/vectorscan/Makefile
+++ b/libs/vectorscan/Makefile
@@ -1,0 +1,85 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=vectorscan
+PKG_VERSION:=5.4.9
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/VectorCamp/vectorscan/tar.gz/$(PKG_NAME)/$(PKG_VERSION)?
+PKG_HASH:=e61c78f26a9d04ccffab0df1159885c4503fc501172402c57f7357a2126ea3c6
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=John Audia <therealgraysky@proton.me>
+PKG_LICENSE:=BSD-3-Clause BSD-2-Clause BSL-1.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_BUILD_PARALLEL:=1
+CMAKE_INSTALL:=1
+
+PKG_BUILD_DEPENDS:=ragel/host python3/host boost/host
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+CMAKE_OPTIONS += \
+	-DCMAKE_INSTALL_LIBDIR=lib \
+	-DBUILD_SHARED_LIBS=ON \
+	-Wno-dev
+
+define Package/vectorscan-headers
+  CATEGORY:=Libraries
+  SECTION:=libs
+  TITLE:=Vectorscan Headers
+  URL:=https://github.com/VectorCamp/vectorscan
+  DEPENDS:=@(aarch64||arm||i386||i686||x86_64)
+endef
+
+define Package/vectorscan-runtime
+  CATEGORY:=Libraries
+  SECTION:=libs
+  TITLE:=Vectorscan Runtime
+  URL:=https://github.com/VectorCamp/vectorscan
+  DEPENDS:=@(aarch64||arm||i386||i686||x86_64)
+endef
+
+define Package/vectorscan-headers/description
+  This package contains the headers for Vectorscan.
+  A fork of Intel's Hyperscan, modified to run on more platforms.
+endef
+
+define Package/vectorscan-runtime/description
+  This package contains the shared objects for Vectorscan.
+  A fork of Intel's Hyperscan, modified to run on more platforms.
+endef
+
+define Package/vectorscan-runtime/install
+endef
+
+# This installs files into ./staging_dir/. so that you can cross compile from the host
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/hs
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/hs* $(1)/usr/include/hs/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libhs.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/usr/lib/pkgconfig/libhs.pc $(1)/usr/lib/pkgconfig/libhs.pc
+endef
+
+# This installs files on the target.  Compare with Build/InstallDev
+define Package/vectorscan-headers/install
+	$(INSTALL_DIR) $(1)/usr/include/hs
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/hs* $(1)/usr/include/hs/
+endef
+
+define Package/vectorscan-runtime/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libhs.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,vectorscan-headers))
+$(eval $(call BuildPackage,vectorscan-runtime))

--- a/libs/vectorscan/patches/0001-CMakeLists.txt-dirty-hack.patch
+++ b/libs/vectorscan/patches/0001-CMakeLists.txt-dirty-hack.patch
@@ -1,0 +1,19 @@
+From 5ce0e124f04d7b69f3257b57a71873d14a00c9e4 Mon Sep 17 00:00:00 2001
+Date: Tue, 23 May 2023 06:52:19 -0400
+Subject: [PATCH] CMakeLists.txt: dirty hack
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -172,7 +172,7 @@ if (CMAKE_COMPILER_IS_GNUCC AND NOT CROS
+ 
+     # arg1 might exist if using ccache
+     string (STRIP "${CMAKE_C_COMPILER_ARG1}" CC_ARG1)
+-    set (EXEC_ARGS ${CC_ARG1} -c -Q --help=target -${ARCH_FLAG}=native -${TUNE_FLAG}=native)
++    set (EXEC_ARGS ${CC_ARG1} -c -Q --help=target -${ARCH_FLAG}=armv8-a -${TUNE_FLAG}=cortex-a72)
+     execute_process(COMMAND ${CMAKE_C_COMPILER} ${EXEC_ARGS}
+         OUTPUT_VARIABLE _GCC_OUTPUT)
+     set(_GCC_OUTPUT_TUNE ${_GCC_OUTPUT})


### PR DESCRIPTION
Changelog: https://github.com/snort3/snort3/releases/tag/3.1.84.0
```
   ,,_     -*> Snort++ <*-
  o"  )~   Version 3.1.84.0
   ''''    By Martin Roesch & The Snort Team
           http://snort.org/contact#team
           Copyright (C) 2014-2024 Cisco and/or its affiliates. All rights reserved.
           Copyright (C) 1998-2013 Sourcefire, Inc., et al.
           Using DAQ version 3.0.14
           Using LuaJIT version 2.1.0-beta3
           Using OpenSSL 3.0.13 30 Jan 2024
           Using libpcap version 1.10.4 (with TPACKET_V3)
           Using PCRE version 8.45 2021-06-15
           Using ZLIB version 1.3.1
           Using Hyperscan version 5.4.2 2024-04-10
           Using LZMA version 5.4.6
```
Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne