### PR TITLE
curl: fix release number

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=8.7.1
-PKG_RELEASE:=r1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \


### PR DESCRIPTION
With the recent change in how release numbers are derived, there can't be any letters in the $PKG_RELEASE. That is automatically calculated.

Otherwise the following problem occurs:

```
➤ opkg list-upgradable
curl - 8.7.1-r1 - 8.7.1-rr1
libcurl4 - 8.7.1-r1 - 8.7.1-rr1
```

Maintainer: stangri@melmac.ca
Run tested: aarch64, Dynalink DL-WRX36, Master Branch
