### PR TITLE
stress-ng: update to 0.17.07

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.17.05
+PKG_VERSION:=0.17.07
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ColinIanKing/stress-ng/tar.gz/refs/tags/V$(PKG_VERSION)?
-PKG_HASH:=48964a0de5838acfed5c78d78d5f4a1d86974883d5537ccc55df019a0186a1b5
+PKG_HASH:=b0bc1495adce6c7a1f82d53f363682b243d6d7e93a06be7f94c9559c0a311a6f
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only

--- a/utils/stress-ng/patches/001-disable-extra-stressors.patch
+++ b/utils/stress-ng/patches/001-disable-extra-stressors.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.config
 +++ b/Makefile.config
-@@ -327,10 +327,10 @@ clean:
+@@ -351,10 +351,10 @@ clean:
  .PHONY: libraries
  libraries: \
  	configdir \


### PR DESCRIPTION
Maintainer: @commodo 
Run tested: ARMv7, Linksys WRT3200ACM, master branch

Description:
- Refresh the patch

