### PR TITLE
rclone: fix configuration saving

### DIFF
--- a/net/rclone/Makefile
+++ b/net/rclone/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rclone
 PKG_VERSION:=1.66.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/rclone/rclone/tar.gz/v$(PKG_VERSION)?

--- a/net/rclone/files/rclone.init
+++ b/net/rclone/files/rclone.init
@@ -58,7 +58,7 @@ start_service() {
 	local config_dir="${config_path%/*}"
 	[ -d "$config_dir" ] || mkdir -p "$config_dir"
 	touch "${config_path}"
-	chown rclone "${config_path}"
+	chown rclone "${config_path}" "${config_dir}"
 
 	[ -d "/lib/upgrade/keep.d" ] || mkdir -p "/lib/upgrade/keep.d/"
 	echo "$config_path" > "/lib/upgrade/keep.d/luci-app-rclone"


### PR DESCRIPTION
Maintainer: none
Compile tested: none
Run tested: x86_64, openwrt 22.03

Description:

The following error occurs when creating storage configuration in WEBUI:
```
Failed to save config after 10 tries: failed to create temp file for new config: open /etc/rclone/rclone.conf4258227003: permission denied
```

we should set the owner of the parent directory of the configuration file to rclone

