### PR TITLE
minicom: update to 2.9

### DIFF
--- a/utils/minicom/Makefile
+++ b/utils/minicom/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=minicom
-PKG_VERSION:=2.8
-PKG_RELEASE:=2
+PKG_VERSION:=2.9
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://salsa.debian.org/minicom-team/minicom/-/archive/$(PKG_VERSION)
-PKG_HASH:=38cea30913a20349326ff3f1763ee1512b7b41601c24f065f365e18e9db0beba
+PKG_HASH:=9efbb6458140e5a0de445613f0e76bcf12cbf7a9892b2f53e075c2e7beaba86c
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 
 PKG_LICENSE:=GPL-2.0-or-later

--- a/utils/minicom/patches/110-reproducible-builds.patch
+++ b/utils/minicom/patches/110-reproducible-builds.patch
@@ -1,6 +1,6 @@
 --- a/src/minicom.c
 +++ b/src/minicom.c
-@@ -1248,7 +1248,7 @@ int main(int argc, char **argv)
+@@ -1323,7 +1323,7 @@ int main(int argc, char **argv)
        switch(c) {
          case 'v':
            printf(_("%s version %s"), PACKAGE, VERSION);
@@ -9,7 +9,7 @@
            printf(_(" (compiled %s)"), __DATE__);
  #endif
            printf("\n");
-@@ -1580,7 +1580,7 @@ int main(int argc, char **argv)
+@@ -1659,7 +1659,7 @@ int main(int argc, char **argv)
  
    mc_wprintf(us, "\n%s %s\r\n", _("Welcome to minicom"), VERSION);
    mc_wprintf(us, "\n%s: %s\r\n", _("OPTIONS"), option_string);


### PR DESCRIPTION
Maintainer: @Noltari 
Run tested: ARMv7, Linksys WRT3200ACM, master branch

Description:
- Refresh the patch
