### PR TITLE
mosquitto: bump PKG_RELEASE since missing in PR #23863

### DIFF
--- a/net/mosquitto/Makefile
+++ b/net/mosquitto/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mosquitto
 PKG_VERSION:=2.0.18
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://mosquitto.org/files/source/


### PR DESCRIPTION
Maintainer: @karlp
Compile tested: NanoPi R4s / SNAPSHOTS
Run tested: NanoPi R4s / SNAPSHOTS

Description:
Bump PKG_RELEASE for existing OpenWRT instances to pick changes in #23863 during the next software update. 