### PR TITLE
snort3: update to 3.1.84.0

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
-PKG_VERSION:=3.1.82.0
-PKG_RELEASE:=3
+PKG_VERSION:=3.1.84.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
-PKG_HASH:=64304315e1c172b80cb9fef8c27fa457357329ecf02ee27a6604a79fd6cfa10f
+PKG_HASH:=dca1707a66f6ca56ddd526163b2d951cefdb168bddc162c791adc74c0d226c7f
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>, John Audia <therealgraysky@proton.me>
 PKG_LICENSE:=GPL-2.0-only
@@ -43,11 +43,6 @@ define Package/snort3/description
   analysis and pattern matching in order to detect anomalies, misuse and
   attacks.
 endef
-
-# Hyperscan and gperftools only builds for x86
-ifdef CONFIG_TARGET_x86_64
-	CMAKE_OPTIONS += -DHS_INCLUDE_DIRS=$(STAGING_DIR)/usr/include/hs
-endif
 
 # Hyperscan and gperftools only builds for x86
 ifdef CONFIG_TARGET_x86_64

--- a/net/snort3/patches/110-packet_capture-Fix-compilation-with-GCC-13.patch
+++ b/net/snort3/patches/110-packet_capture-Fix-compilation-with-GCC-13.patch
@@ -12,9 +12,9 @@ src/network_inspectors/packet_capture/packet_capture.h:25:54: error: 'int16_t' d
 
 --- a/src/network_inspectors/packet_capture/packet_capture.h
 +++ b/src/network_inspectors/packet_capture/packet_capture.h
-@@ -21,6 +21,7 @@
- #define PACKET_CAPTURE_H
+@@ -22,6 +22,7 @@
  
+ #include <cstdint>
  #include <string>
 +#include <cstdint>
  


### PR DESCRIPTION
1. Update to latest version
2. Remove redundant section in Makefile

Changelog: https://github.com/snort3/snort3/releases/tag/3.1.84.0
```
   ,,_     -*> Snort++ <*-
  o"  )~   Version 3.1.84.0
   ''''    By Martin Roesch & The Snort Team
           http://snort.org/contact#team
           Copyright (C) 2014-2024 Cisco and/or its affiliates. All rights reserved.
           Copyright (C) 1998-2013 Sourcefire, Inc., et al.
           Using DAQ version 3.0.14
           Using LuaJIT version 2.1.0-beta3
           Using OpenSSL 3.0.13 30 Jan 2024
           Using libpcap version 1.10.4 (with TPACKET_V3)
           Using PCRE version 8.45 2021-06-15
           Using ZLIB version 1.3.1
           Using Hyperscan version 5.4.2 2024-04-10
           Using LZMA version 5.4.6
```
Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne