### PR TITLE
collectd: add module nftables

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -175,6 +175,7 @@ COLLECTD_PLUGINS_SELECTED:= \
 	mysql \
 	netlink \
 	network \
+	nftables \
 	nginx \
 	ntpd \
 	nut \
@@ -498,6 +499,7 @@ $(eval $(call BuildPlugin,modbus,read variables through libmodbus,modbus,+PACKAG
 $(eval $(call BuildPlugin,mqtt,transmit data with MQTT,mqtt,+PACKAGE_collectd-mod-mqtt:libmosquitto))
 $(eval $(call BuildPlugin,netlink,netlink input,netlink,+PACKAGE_collectd-mod-netlink:libmnl))
 $(eval $(call BuildPlugin,network,network input/output,network,+PACKAGE_COLLECTD_ENCRYPTED_NETWORK:libgcrypt))
+$(eval $(call BuildPlugin,nftables,nftables named counters,nftables,+PACKAGE_collectd-mod-nftables:libmnl))
 $(eval $(call BuildPlugin,nginx,nginx status input,nginx,+PACKAGE_collectd-mod-nginx:libcurl))
 $(eval $(call BuildPlugin,ntpd,NTP daemon status input,ntpd,))
 $(eval $(call BuildPlugin,nut,UPS monitoring input,nut,+PACKAGE_collectd-mod-nut:nut-common))

--- a/utils/collectd/patches/950-add-nftables-plugin.patch
+++ b/utils/collectd/patches/950-add-nftables-plugin.patch
@@ -1,0 +1,362 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1582,6 +1582,14 @@ nfs_la_SOURCES = src/nfs.c
+ nfs_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+ endif
+ 
++if BUILD_PLUGIN_NFTABLES
++pkglib_LTLIBRARIES += nftables.la
++nftables_la_SOURCES = src/nftables.c
++nftables_la_CFLAGS = $(AM_CFLAGS) $(BUILD_WITH_LIBMNL_CFLAGS)
++nftables_la_LDFLAGS = $(PLUGIN_LDFLAGS)
++nftables_la_LIBADD = $(BUILD_WITH_LIBMNL_LIBS)
++endif
++
+ if BUILD_PLUGIN_NGINX
+ pkglib_LTLIBRARIES += nginx.la
+ nginx_la_SOURCES = src/nginx.c
+--- a/configure.ac
++++ b/configure.ac
+@@ -6633,6 +6633,7 @@ plugin_memory="no"
+ plugin_multimeter="no"
+ plugin_netstat_udp="no"
+ plugin_nfs="no"
++plugin_nftables="no"
+ plugin_numa="no"
+ plugin_ovs_events="no"
+ plugin_ovs_stats="no"
+@@ -7125,6 +7126,7 @@ AC_PLUGIN([netlink],             [$with_
+ AC_PLUGIN([netstat_udp],         [$plugin_netstat_udp],       [UDP network statistics])
+ AC_PLUGIN([network],             [yes],                       [Network communication plugin])
+ AC_PLUGIN([nfs],                 [$plugin_nfs],               [NFS statistics])
++AC_PLUGIN([nftables],            [$with_libmnl],              [nftables named counters statistics])
+ AC_PLUGIN([nginx],               [$with_libcurl],             [nginx statistics])
+ AC_PLUGIN([notify_desktop],      [$with_libnotify],           [Desktop notifications])
+ AC_PLUGIN([notify_email],        [$with_libesmtp],            [Email notifier])
+@@ -7577,6 +7579,7 @@ AC_MSG_RESULT([    netlink . . . . . . .
+ AC_MSG_RESULT([    netstat_udp . . . . . $enable_netstat_udp])
+ AC_MSG_RESULT([    network . . . . . . . $enable_network])
+ AC_MSG_RESULT([    nfs . . . . . . . . . $enable_nfs])
++AC_MSG_RESULT([    nftables. . . . . . . $enable_nftables])
+ AC_MSG_RESULT([    nginx . . . . . . . . $enable_nginx])
+ AC_MSG_RESULT([    notify_desktop  . . . $enable_notify_desktop])
+ AC_MSG_RESULT([    notify_email  . . . . $enable_notify_email])
+--- a/src/collectd.conf.in
++++ b/src/collectd.conf.in
+@@ -172,6 +172,7 @@
+ #@BUILD_PLUGIN_NETLINK_TRUE@LoadPlugin netlink
+ @LOAD_PLUGIN_NETWORK@LoadPlugin network
+ #@BUILD_PLUGIN_NFS_TRUE@LoadPlugin nfs
++#@BUILD_PLUGIN_NFTABLES_TRUE@LoadPlugin nftables
+ #@BUILD_PLUGIN_NGINX_TRUE@LoadPlugin nginx
+ #@BUILD_PLUGIN_NOTIFY_DESKTOP_TRUE@LoadPlugin notify_desktop
+ #@BUILD_PLUGIN_NOTIFY_EMAIL_TRUE@LoadPlugin notify_email
+@@ -1245,6 +1246,14 @@
+ #	#ReportV4 false
+ #</Plugin>
+ 
++#<Plugin nftables>
++#	<Instance Protocol>
++#		Counter cnt_reject_from_wan_udp UDP
++#		Counter cnt_reject_from_wan_tcp TCP
++#		Counter cnt_reject_from_wan_total Total
++#	</Instance>
++#</Plugin>
++
+ #<Plugin nginx>
+ #	URL "http://localhost/status?auto"
+ #	User "www-user"
+--- /dev/null
++++ b/src/nftables.c
+@@ -0,0 +1,267 @@
++/**
++ * collectd - src/nftables.c
++ * Copyright (C) 2024 Tobias Waldvogel
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License as published by the
++ * Free Software Foundation; either version 2 of the License, or (at your
++ * option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful, but
++ * WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License along
++ * with this program; if not, write to the Free Software Foundation, Inc.,
++ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
++ **/
++
++#include "collectd.h"
++
++#include "plugin.h"
++#include "utils/common/common.h"
++
++#include <netinet/in.h>
++
++#include <linux/netfilter.h>
++#include <linux/netfilter/nf_tables.h>
++
++#include <libmnl/libmnl.h>
++#include <libnftnl/object.h>
++
++#ifdef HAVE_SYS_CAPABILITY_H
++#include <sys/capability.h>
++#endif
++
++#define PLUGIN_NAME "nftables"
++
++/*
++ * (Module-)Global variables
++ */
++uint32_t seq;
++uint32_t portid;
++
++/*
++ * Socket for communication with mnl
++ */
++struct mnl_socket *nl = NULL;
++struct nlmsghdr *nlh = NULL;
++char *nlh_buf = NULL;
++
++#ifndef MAXNAMELEN
++#define MAXNAMELEN 32
++#endif
++typedef struct {
++  char counter[MAXNAMELEN];
++  char display[MAXNAMELEN];
++  char instance[MAXNAMELEN];
++} ctr_t;
++
++static ctr_t *ctr_list = NULL;
++static int ctr_num = 0;
++
++static int nftables_config_counter(oconfig_item_t *ci, const char *instance) {
++  ctr_t *list = realloc(ctr_list, (ctr_num + 1) * sizeof(*list));
++  if (list == NULL) {
++    ERROR("realloc failed: %s", STRERRNO);
++    return -1;
++  }
++
++  if ((ci->values_num == 0) || (ci->values[0].type != OCONFIG_TYPE_STRING)) {
++    ERROR("The `%s' option requires at least one string argument.", ci->key);
++    return -1;
++  }
++
++  size_t display = ci->values_num == 1 ? 0 : 1;
++
++  if (ci->values[display].type != OCONFIG_TYPE_STRING) {
++    ERROR("The `%s' option requires a string as argument %d", ci->key, (int)display + 1);
++    return -1;
++  }
++
++  ctr_list = list;
++  ctr_t *counter = ctr_list + ctr_num;
++
++  sstrncpy(counter->counter, ci->values[0].value.string, sizeof(counter->counter));
++  sstrncpy(counter->display, ci->values[display].value.string, sizeof(counter->display));
++  sstrncpy(counter->instance, instance, sizeof(counter->instance));
++
++  ctr_num++;
++  return 0;
++}
++
++static int nftables_config(oconfig_item_t *ci) {
++  for (int i = 0; i < ci->children_num; i++) {
++    oconfig_item_t *child = ci->children + i;
++
++    /* Instance definition */
++    if (strcasecmp("Instance", child->key) == 0 && child->children_num) {
++      if ((child->values_num == 0) || (child->values[0].type != OCONFIG_TYPE_STRING)) {
++        ERROR("Section '%s' cannot be anonymous.", child->key);
++        return -1;
++      }
++
++      const char *instance = child->values[0].value.string;
++
++      for (int c = 0; c < child->children_num; c++)
++        if (nftables_config_counter(child->children + c, instance))
++          return -1;
++
++    } else  if (strcasecmp("Counter", child->key) == 0) {
++      if (nftables_config_counter(child, ""))
++        return -1;
++
++    } else {
++      ERROR("%s plugin: Unknown config option: %s", PLUGIN_NAME, child->key);
++      return 1;
++
++    }
++  }
++
++  return 0;
++}
++
++static void nftables_dispatch_counter(const char *plugin_instance,
++                                     const char *type_instance,
++                                     uint64_t bytes, uint64_t packets) {
++  value_list_t vl = VALUE_LIST_INIT;
++  vl.values_len = 1;
++
++  sstrncpy(vl.plugin, PLUGIN_NAME, sizeof(vl.plugin));
++  sstrncpy(vl.plugin_instance, plugin_instance, sizeof(vl.plugin_instance));
++  sstrncpy(vl.type_instance, type_instance, sizeof(vl.type_instance));
++
++  sstrncpy(vl.type, "total_bytes", sizeof(vl.type));
++  vl.values = &(value_t){.derive = (derive_t)bytes};
++  plugin_dispatch_values(&vl);
++
++  sstrncpy(vl.type, "packets", sizeof(vl.type));
++  vl.values = &(value_t){.derive = (derive_t)packets};
++  plugin_dispatch_values(&vl);
++}
++
++
++static int nftables_read_counter_cb(const struct nlmsghdr *nlh, void *data) {
++  struct nftnl_obj *nftnl_counter;
++
++  nftnl_counter = nftnl_obj_alloc();
++  if (nftnl_counter == NULL) {
++    ERROR("%s plugin: Out of memory", PLUGIN_NAME);
++    return MNL_CB_ERROR ;
++  }
++
++  if (nftnl_obj_nlmsg_parse(nlh, nftnl_counter) < 0) {
++    ERROR("nftables plugin: nftnl_obj_nlmsg_parse failed");
++  } else {
++    const char *name = nftnl_obj_get_str(nftnl_counter, NFTNL_OBJ_NAME);
++    uint64_t bytes = nftnl_obj_get_u64(nftnl_counter, NFTNL_OBJ_CTR_BYTES);
++    uint64_t packets = nftnl_obj_get_u64(nftnl_counter, NFTNL_OBJ_CTR_PKTS);
++
++    if (!ctr_num)
++      nftables_dispatch_counter("", name, bytes, packets);
++    else
++      for (ssize_t i = 0; i < ctr_num; i++)
++        if (strcasecmp(name, ctr_list[i].counter) == 0)
++          nftables_dispatch_counter(ctr_list[i].instance, ctr_list[i].display, bytes, packets);
++  }
++
++  nftnl_obj_free(nftnl_counter);
++  return MNL_CB_OK;
++}
++
++static int nftables_read(void) {
++  int ret;
++  char buf[MNL_SOCKET_BUFFER_SIZE];
++
++  if (!nlh) {
++    struct nftnl_obj *nftnl_ctr_template = nftnl_obj_alloc();
++    if (nftnl_ctr_template == NULL) {
++      ERROR("nftables plugin: Out of memory");
++      return 1;
++    }
++
++    nlh_buf = malloc(MNL_SOCKET_BUFFER_SIZE);
++    nlh = nftnl_nlmsg_build_hdr(nlh_buf, NFT_MSG_GETOBJ, NFPROTO_UNSPEC, NLM_F_MATCH | NLM_F_ACK, seq);
++    nftnl_obj_set_u32(nftnl_ctr_template, NFTNL_OBJ_TYPE, NFT_OBJECT_COUNTER);
++    nftnl_obj_nlmsg_build_payload(nlh, nftnl_ctr_template);
++    nftnl_obj_free(nftnl_ctr_template);
++  }
++
++  if (!nl) {
++    nl = mnl_socket_open(NETLINK_NETFILTER);
++    if (nl == NULL) {
++      ERROR("nftables plugin: mnl_socket_open failed");
++      return -1;
++    }
++
++    if (mnl_socket_bind(nl, 0, MNL_SOCKET_AUTOPID) < 0) {
++      ERROR("nftables plugin: mnl_socket_bind failed");
++      return -1;
++    }
++
++    portid = mnl_socket_get_portid(nl);
++  }
++
++  if (mnl_socket_sendto(nl, nlh, nlh->nlmsg_len) < 0) {
++    ERROR("nftables plugin: mnl_socket_send failed");
++    mnl_socket_close(nl);
++    nl = NULL;
++    return -1;
++  }
++
++  ret = mnl_socket_recvfrom(nl, buf, sizeof(buf));
++  while (ret > 0) {
++    ret = mnl_cb_run(buf, ret, seq, portid, nftables_read_counter_cb, 0);
++    if (ret <= 0)
++      break;
++    ret = mnl_socket_recvfrom(nl, buf, sizeof(buf));
++  }
++
++  if (ret == -1) {
++    ERROR("nftables plugin: mnl_socket_recv failed");
++    mnl_socket_close(nl);
++    nl = NULL;
++    return -1;
++  }
++
++  return 0;
++} /* int nftables_read */
++
++static int nftables_shutdown(void) {
++  if (ctr_list)
++    free(ctr_list);
++
++  if (nl)
++    mnl_socket_close(nl);
++
++  return 0;
++} /* int nftables_shutdown */
++
++static int nftables_init(void) {
++#if defined(HAVE_SYS_CAPABILITY_H) && defined(CAP_NET_ADMIN)
++  if (check_capability(CAP_NET_ADMIN) != 0) {
++    if (getuid() == 0)
++      WARNING("%s plugin: Running collectd as root, but the "
++              "CAP_NET_ADMIN capability is missing. The plugin's read "
++              "function will probably fail. Is your init system dropping "
++              "capabilities?",
++              PLUGIN_NAME);
++    else
++      WARNING("%s plugin: collectd doesn't have the CAP_NET_ADMIN "
++              "capability. If you don't want to run collectd as root, try "
++              "running \"setcap cap_net_admin=ep\" on the collectd binary.",
++              PLUGIN_NAME);
++  }
++#endif
++
++  seq = time(NULL);
++  return 0;
++} /* int nftables_init */
++
++void module_register(void) {
++  plugin_register_complex_config(PLUGIN_NAME, nftables_config);
++  plugin_register_init(PLUGIN_NAME, nftables_init);
++  plugin_register_read(PLUGIN_NAME, nftables_read);
++  plugin_register_shutdown(PLUGIN_NAME, nftables_shutdown);
++}
+--- a/src/collectd.conf.pod
++++ b/src/collectd.conf.pod
+@@ -6498,6 +6498,21 @@ more of the following options to B<false
+ 
+ =back
+ 
++=head2 Plugin C<nftables>
++
++The I<nftables plugin> collects named counters from nftables.
++By default all named counters will be collected.
++
++=over 4
++
++=item B<Counter> B<name> B<display name>
++
++You can use the B<Counter>-option to pick individual counters and configure
++a display name. It is also possible to create several instance for
++grouping the counters together.
++
++=back
++
+ =head2 Plugin C<nginx>
+ 
+ This plugin collects the number of connections and requests handled by the


### PR DESCRIPTION
Signed-off-by: Tobias Waldvogel <tobias.waldvogel@gmail.com>

Maintainer: me / Jo-Philipp Wich <jo@mein.io>, Hannu Nyman <hannu.nyman@iki.fi>
Compile tested: rockhchip, NanoPi R4S, aarch64,  r25874
Run tested: rockhchip, NanoPi R4S, aarch64,  r25874

Description: As fw4 is now nftables based the old iptables module for collecting firewall
statistics does not work anymore. This module collects packet and bytes statistics from
named nftables counters. Anonymous counters are not supported as this would require
looking up the corresponding rule by comment, which would have a huge performance
overhead.
For reporting on these statistics I have prepared an extension for luci-app-statistics,
which I will provide in a different pull request.

Tests performed: Monitoring collect with the processes plugin over two weeks to ensure
that it does not have any performance impact or memory leak.



