### PR TITLE
ngtcp2: Use APK style release number

### DIFF
--- a/libs/ngtcp2/Makefile
+++ b/libs/ngtcp2/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ngtcp2
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=r1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/ngtcp2/$(PKG_NAME)/releases/download/v$(PKG_VERSION)/


### PR DESCRIPTION
Maintainer: Tianling Shen <cnsztl@immortalwrt.org>
Run tested: aarch64, Dynalink DL-WRX36, Master Branch