### PR TITLE
adblock-fast: Use APK style release number

### DIFF
--- a/net/adblock-fast/Makefile
+++ b/net/adblock-fast/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=r7
+PKG_RELEASE:=7
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 


### PR DESCRIPTION
Maintainer: Tianling Shen <cnsztl@immortalwrt.org>
Run tested: aarch64, Dynalink DL-WRX36, Master Branch