### PR TITLE
https-dns-proxy: Use APK style release number

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2023.11.19
-PKG_RELEASE:=r1
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/


### PR DESCRIPTION
Maintainer: Tianling Shen <cnsztl@immortalwrt.org>
Run tested: aarch64, Dynalink DL-WRX36, Master Branch