### PR TITLE
snort3: fix issue caused by ucode semantics change

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.1.82.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/

--- a/net/snort3/files/main.uc
+++ b/net/snort3/files/main.uc
@@ -76,6 +76,10 @@ function config_item(type, values, def) {
 		wrn(`Invalid item type '${type}', must be one of "enum", "range", "path" or "str".`);
 		return;
 	}
+	if (type == "enum") {
+		// Convert values to strings, so 'in' works in 'contains'.
+		values = map(values, function(i) { return "" + i; });
+	}
 	if (type == "range" && (length(values) != 2 || values[0] > values[1])) {
 		wrn(`A 'range' type item must have exactly 2 values in ascending order.`);
 		return;


### PR DESCRIPTION
A recent change in the ucode interpeter caused a failure when using the 'in' operator.
https://github.com/jow-/ucode/commit/be767ae197babd656d4f5d9c2d5013e39ddbe656

Reported in a forum post by @graysky2.
https://forum.openwrt.org/t/194218/28

Maintainer: @flyn-org @graysky2 
Compile tested: NA
Run tested: x86