### PR TITLE
nginx: autoload dynamic modules

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.25.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
@@ -195,6 +195,15 @@ define Package/nginx-mod-luci/description
  Support file for LuCI in nginx. Include custom nginx configuration, autostart script for uwsgi.
 endef
 
+define Package/nginx-mod-luci/preinst
+#!/bin/sh
+grep -r -l ngx_http_ubus_module.so /etc/nginx/module.d | grep -v ngx_http_ubus.module | while read file; do
+  echo "Removing old LuCI module load file for 'ngx_http_ubus.so' in $$file."
+  rm -f $$file
+done
+exit 0
+endef
+
 define Package/nginx-mod-luci/install
 	$(INSTALL_DIR) $(1)/etc/nginx/conf.d
 	$(INSTALL_CONF) ./files-luci-support/luci.locations $(1)/etc/nginx/conf.d/
@@ -375,8 +384,10 @@ define BuildModule
 
   define Package/nginx-mod-$(1)/install
 	$(INSTALL_DIR) $$(1)/usr/lib/nginx/modules
+	$(INSTALL_DIR) $$(1)/etc/nginx/module.d
 	$(foreach m,$(3),
-	  $(CP) $$(PKG_INSTALL_DIR)/usr/lib/nginx/modules/$(m)_module.so $$(1)/usr/lib/nginx/modules
+	  $(CP) $$(PKG_INSTALL_DIR)/usr/lib/nginx/modules/$(m)_module.so $$(1)/usr/lib/nginx/modules && \
+	  echo "load_module /usr/lib/nginx/modules/$(m)_module.so;" > $$(1)/etc/nginx/module.d/$(m).module
 	)
 	$(call Module/nginx-mod-$(1)/install,$$(1))
   endef

--- a/net/nginx/files-luci-support/60_nginx-luci-support
+++ b/net/nginx/files-luci-support/60_nginx-luci-support
@@ -12,8 +12,8 @@ location /ubus {
 EOT
 	fi
 
-        if [ ! -f "/etc/nginx/module.d/luci.module" ]; then
-		cat <<EOT >> /etc/nginx/module.d/luci.module
+        if [ ! -f "/etc/nginx/module.d/ngx_http_ubus.module" ]; then
+		cat <<EOT > /etc/nginx/module.d/ngx_http_ubus.module
 load_module /usr/lib/nginx/modules/ngx_http_ubus_module.so;
 EOT
 	fi


### PR DESCRIPTION
In current setup, dynamic modules are not autoloaded, requiring users to create and load additional config files.

We should assume that if a user installs additional modules, they want them 'on' by default.

This commit does the following:

1. generates a module load config in `'/etc/nginx/modules.d'` with the

    format `'${module_name}'.module`
    (i.e. `/etc/nginx/modules.d/ngx_http_geoip2.module`)
2. deletes previous module conf for `'luci'`
    `/etc/nginx/modules.d/luci.module` if it exists, this will prevent
    `'module already loaded'` errors.

The following is a portion of the final output when using the default uci template `/etc/nginx/uci.conf.template` (via nginx-util):

```
nginx -T -c '/etc/nginx/uci.conf' | grep load_module
nginx: the configuration file /etc/nginx/uci.conf syntax is ok
nginx: configuration file /etc/nginx/uci.conf test is successful
load_module /usr/lib/nginx/modules/ngx_http_brotli_filter_module.so;
load_module /usr/lib/nginx/modules/ngx_http_brotli_static_module.so;
load_module /usr/lib/nginx/modules/ngx_http_dav_ext_module.so;
load_module /usr/lib/nginx/modules/ngx_http_geoip2_module.so;
load_module /usr/lib/nginx/modules/ngx_http_headers_more_filter_module.so;
load_module /usr/lib/nginx/modules/ngx_http_lua_module.so;
load_module /usr/lib/nginx/modules/ngx_http_naxsi_module.so;
load_module /usr/lib/nginx/modules/ngx_http_ts_module.so;
load_module /usr/lib/nginx/modules/ngx_http_ubus_module.so;
load_module /usr/lib/nginx/modules/ngx_rtmp_module.so;
load_module /usr/lib/nginx/modules/ngx_stream_module.so;
load_module /usr/lib/nginx/modules/ngx_stream_geoip2_module.so;
```

Maintainer: Thomas Heil <heil@terminal-consulting.de>, Christian Marangi <ansuelsmth@gmail.com>
Compile tested: aarch64, qualcommax, Master Branch
Run tested: aarch64, Dynalink DL-WRX36, Master Branch