### PR TITLE
nginx: fix geoip2 dependency on mod ngx_stream

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -477,7 +477,7 @@ $(eval $(call BuildModule,brotli,,ngx_http_brotli_filter ngx_http_brotli_static,
 	Add support for brotli compression module.))
 $(eval $(call BuildModule,naxsi,,ngx_http_naxsi, \
 	Enable NAXSI module.))
-$(eval $(call BuildModule,geoip2,+@NGINX_STREAM_CORE_MODULE +libmaxminddb,ngx_http_geoip2 ngx_stream_geoip2, \
+$(eval $(call BuildModule,geoip2,+@NGINX_STREAM_CORE_MODULE +nginx-mod-stream +libmaxminddb,ngx_http_geoip2 ngx_stream_geoip2, \
 	Enable MaxMind GeoIP2 module.))
 
 # TODO: remove after a transition period (together with pkg nginx-util):


### PR DESCRIPTION
Since the geoip2 package contains both `http` and `stream` versions. It requires the module `ngx_stream` be installed and loaded and produces the error:

```
2024/04/12 18:38:18 [emerg] 4402#0: dlopen() 
"/usr/lib/nginx/modules/ngx_stream_geoip2_module.so" failed 
(Error relocating /usr/lib/nginx/modules/ngx_stream_geoip2_module.so: ngx_stream_complex_value: symbol not found) in /etc/nginx/module.d/ngx_stream_geoip2.module:1
nginx: configuration file /etc/nginx/uci.conf test failed
```

Add dependency so it gets built and installed automatically.

**Run tested**: aarch64, Dynalink DL-WRX36, Master Branch
**Compile tested**: aarch64, qualcommax, Master Branch
**Compile produces follows**:
```
nginx-ssl_1.25.4-r3_aarch64_cortex-a53.ipk
nginx-mod-ubus_1.25.4-r3_aarch64_cortex-a53.ipk
nginx-mod-luci_1.25.4-r3_aarch64_cortex-a53.ipk
nginx-mod-lua-resty-lrucache_1.25.4-r3_aarch64_cortex-a53.ipk
nginx-mod-lua-resty-core_1.25.4-r3_aarch64_cortex-a53.ipk
nginx-mod-stream_1.25.4-r3_aarch64_cortex-a53.ipk
nginx-mod-lua_1.25.4-r3_aarch64_cortex-a53.ipk
nginx-mod-dav-ext_1.25.4-r3_aarch64_cortex-a53.ipk
nginx-mod-headers-more_1.25.4-r3_aarch64_cortex-a53.ipk
nginx-mod-rtmp_1.25.4-r3_aarch64_cortex-a53.ipk
nginx-mod-ts_1.25.4-r3_aarch64_cortex-a53.ipk
nginx-mod-brotli_1.25.4-r3_aarch64_cortex-a53.ipk
nginx-mod-naxsi_1.25.4-r3_aarch64_cortex-a53.ipk
nginx-mod-geoip2_1.25.4-r3_aarch64_cortex-a53.ipk
nginx-mod-luci-ssl_1.25.4-r3_all.ipk
```

Maintainer: Thomas Heil [heil@terminal-consulting.de](mailto:heil@terminal-consulting.de), Christian Marangi [ansuelsmth@gmail.com](mailto:ansuelsmth@gmail.com)