### PR TITLE
netbird: add kmod-wireguard dependency

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
 PKG_VERSION:=0.28.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
@@ -29,7 +29,7 @@ define Package/netbird
   SUBMENU:=VPN
   TITLE:=Connect your devices into a single secure private WireGuard®-based mesh network
   URL:=https://netbird.io
-  DEPENDS:=$(GO_ARCH_DEPENDS)
+  DEPENDS:=$(GO_ARCH_DEPENDS) +kmod-wireguard
 endef
 
 define Package/netbird/description


### PR DESCRIPTION
Maintainer: Oskari Rauta / @oskarirauta
Compile tested: [mips_24kc](https://openwrt.org/docs/techref/instructionset/mips_24kc), [ar71xx-ath79](https://openwrt.org/docs/techref/targets/ar71xx-ath79), generic, TP-Link, [Archer C7](https://openwrt.org/toh/tp-link/archer_c7), v4, OpenWrt SNAPSHOT r25907-ab9a29a320
Run tested: [mips_24kc](https://openwrt.org/docs/techref/instructionset/mips_24kc), [ar71xx-ath79](https://openwrt.org/docs/techref/targets/ar71xx-ath79), generic, TP-Link, [Archer C7](https://openwrt.org/toh/tp-link/archer_c7), v4, OpenWrt SNAPSHOT r25907-ab9a29a320

Description:
- `netbird` supports the `wireguard` kernel module, but it can work without it in user mode, losing some performance, but we know in advance that `netbird` will run as root, therefore supporting the `wireguard` kernel mode with better performance.

Edit:
- Rebase and resolve conflicts
- Made requested changes
- Rebase
- I thought maybe on some really limited space devices this might be a problem, but from openwrt [packages](https://downloads.openwrt.org/snapshots/packages/mips_24kc/packages) repo [`netbird_0.26.6-r1_mips_24kc.ipk`](https://mirror-03.infra.openwrt.org/snapshots/packages/mips_24kc/packages/netbird_0.26.6-r1_mips_24kc.ipk) it is 9922.5 KB and from openwrt [kmods](https://downloads.openwrt.org/snapshots/targets/ath79/generic/kmods/6.1.82-1-8a2a779f879a106de68f6c7335a5db52) repo [`kmod-wireguard_6.1.82-r1_mips_24kc.ipk`](https://mirror-03.infra.openwrt.org/snapshots/targets/ath79/generic/kmods/6.1.82-1-8a2a779f879a106de68f6c7335a5db52/kmod-wireguard_6.1.82-r1_mips_24kc.ipk) it is 37.7 KB and my compiled locally `netbird_0.27.3-r1_mips_24kc.ipk` is 9977 KB, nah, if kmod-wireguard can't be installed, netbird probably can't either.