### PR TITLE
rsync: enable xxhash and lz4

### DIFF
--- a/net/rsync/Config.in
+++ b/net/rsync/Config.in
@@ -17,4 +17,14 @@ if PACKAGE_rsync
 		prompt "Enable zstd stream compression"
 		default n
 
+	config RSYNC_lz4
+		bool
+		prompt "Enable lz4, extremely fast compression"
+		default n
+
+	config RSYNC_xxhash
+		bool
+		prompt "Enable xxhash, extremely fast hash"
+		default n
+
 endif

--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsync
 PKG_VERSION:=3.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.samba.org/pub/$(PKG_NAME)/src
@@ -30,8 +30,8 @@ define Package/rsync
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=File Transfer
-  TITLE:=Fast remote file copy program (like rcp)
-  DEPENDS:=+libpopt +zlib +RSYNC_xattr:libattr +RSYNC_acl:libacl +RSYNC_zstd:libzstd $(ICONV_DEPENDS)
+  TITLE:=an open source utility that provides fast incremental file transfer
+  DEPENDS:=+libpopt +zlib +RSYNC_xattr:libattr +RSYNC_acl:libacl +RSYNC_zstd:libzstd +RSYNC_xxhash:libxxhash +RSYNC_lz4:liblz4 $(ICONV_DEPENDS)
   URL:=https://rsync.samba.org/
   MENU:=1
 endef
@@ -47,18 +47,18 @@ CONFIGURE_ARGS += \
 	--without-included-zlib \
 	--disable-debug \
 	--disable-asm \
-	--disable-lz4 \
 	--disable-locale \
 	--disable-md2man \
 	--disable-openssl \
 	--disable-simd \
 	--disable-roll-simd \
-	--disable-xxhash \
 	--$(if $(CONFIG_BUILD_NLS),en,dis)able-iconv \
 	--$(if $(CONFIG_BUILD_NLS),en,dis)able-iconv-open \
 	--$(if $(CONFIG_RSYNC_zstd),en,dis)able-zstd \
+	--$(if $(CONFIG_RSYNC_lz4),en,dis)able-lz4 \
 	--$(if $(CONFIG_RSYNC_xattr),en,dis)able-xattr-support \
 	--$(if $(CONFIG_RSYNC_acl),en,dis)able-acl-support \
+	--$(if $(CONFIG_RSYNC_xxhash),en,dis)able-xxhash \
 	$(if $(CONFIG_IPV6),,--disable-ipv6)
 
 define Package/rsyncd


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_cortex-a53, Dynalink DL-WRX36, r25915+3-c2f52e42b1
Run tested: aarch64_cortex-a53, Dynalink DL-WRX36, r25915+3-c2f52e42b1, copy a file from the router to the build host with --zc={zstd, lz4, zlibx, zlib} and --checksum-choice={xxh128, xxh3, xxh64, xxhash, md5, md4} works

Description:
- add support for xxhash
- add support for lz4
 
All options are off by default, but taking into account the size change, maybe it makes sense to enable xxhash?
```
$ ls -lna *.ipk
-rw-r--r--    1 500      100          53872 Apr 14 10:54 liblz4-1_1.9.4-r1_aarch64_cortex-a53.ipk
-rw-r--r--    1 500      100          10498 Apr 14 10:48 libxxhash_0.8.2-r1_aarch64_cortex-a53.ipk
-rw-r--r--    1 500      100         332652 Apr 14 10:48 libzstd_1.5.5-r1_aarch64_cortex-a53.ipk
-rw-r--r--    1 500      100         206759 Apr 14 10:55 rsync_3.3.0-r1_aarch64_cortex-a53.ipk
```

@graysky2 , thank you for updating rsync to 3.3.0!