### PR TITLE
lua-eco: Fix compilation with musl libc 1.2.5

### DIFF
--- a/lang/lua-eco/patches/0001-Support-POSIX-basename-from-musl-libc.patch
+++ b/lang/lua-eco/patches/0001-Support-POSIX-basename-from-musl-libc.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Sun, 14 Apr 2024 17:13:17 +0200
+Subject: Support POSIX basename() from musl libc
+
+Musl libc 1.2.5 removed the definition of the basename() function from
+string.h and only provides it in libgen.h as the POSIX standard
+defines it.
+
+This change fixes compilation with musl libc 1.2.5.
+````
+/build_dir/target-mips_24kc_musl/lua-eco-3.3.0/log/log.c: In function '___log':
+/build_dir/target-mips_24kc_musl/lua-eco-3.3.0/log/log.c:76:24: error: implicit declaration of function 'basename' [-Werror=implicit-function-declaration]
+   76 |             filename = basename(filename);
+      |                        ^~~~~~~~
+/build_dir/target-mips_24kc_musl/lua-eco-3.3.0/log/log.c:76:22: error: assignment to 'const char *' from 'int' makes pointer from integer without a cast [-Werror=int-conversion]
+   76 |             filename = basename(filename);
+      |                      ^
+````
+
+basename() modifies the input string, copy it first with strdup(), If
+strdup() returns NULL the code will handle it.
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ log/log.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+--- a/log/log.c
++++ b/log/log.c
+@@ -9,6 +9,7 @@
+ #include <stdlib.h>
+ #include <unistd.h>
+ #include <string.h>
++#include <libgen.h>
+ 
+ #include "log.h"
+ 
+@@ -65,6 +66,7 @@ void ___log(const char *filename, int li
+ {
+     char new_fmt[256];
+     va_list ap;
++    char *dirc = NULL;
+ 
+     priority = LOG_PRI(priority);
+ 
+@@ -72,9 +74,13 @@ void ___log(const char *filename, int li
+         return;
+ 
+     if (__log_flags__ & LOG_FLAG_FILE || __log_flags__ & LOG_FLAG_PATH) {
+-        if (!(__log_flags__ & LOG_FLAG_PATH))
+-            filename = basename(filename);
++        if (!(__log_flags__ & LOG_FLAG_PATH)) {
++            dirc = strdup(filename);
++            filename = basename(dirc);
++        }
+         snprintf(new_fmt, sizeof(new_fmt), "(%s:%3d) %s", filename, line, fmt);
++        if (!(__log_flags__ & LOG_FLAG_PATH))
++            free(dirc);
+     } else {
+         snprintf(new_fmt, sizeof(new_fmt), "%s", fmt);
+     }


### PR DESCRIPTION
Support POSIX basename used in musl libc 1.2.5.

Maintainer: @zhaojh329
Compile tested: mips BE
Run tested: no

Upstream PR: https://github.com/zhaojh329/log/pull/2
