### PR TITLE
libmraa: Fix compilation with musl libc 1.2.5

### DIFF
--- a/libs/libmraa/patches/001-mraa-Use-posix-basename.patch
+++ b/libs/libmraa/patches/001-mraa-Use-posix-basename.patch
@@ -1,0 +1,40 @@
+From 47c3850cddd63cebd9dc48e411963314449118f1 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 31 Dec 2023 19:16:35 -0800
+Subject: [PATCH] mraa: Use posix basename
+
+Musl has removed the declaration from string.h [1] which exposes the
+problem especially with clang-17+ compiler where implicit function
+declaration is flagged as error. Use posix basename and make a copy of
+string to operate on to emulate GNU basename behaviour.
+
+[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/mraa.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/src/mraa.c
++++ b/src/mraa.c
+@@ -12,6 +12,7 @@
+ #endif
+ 
+ #include <dlfcn.h>
++#include <libgen.h>
+ #include <pwd.h>
+ #include <sched.h>
+ #include <stddef.h>
+@@ -338,9 +339,11 @@ static int
+ mraa_count_iio_devices(const char* path, const struct stat* sb, int flag, struct FTW* ftwb)
+ {
+     // we are only interested in files with specific names
+-    if (fnmatch(IIO_DEVICE_WILDCARD, basename(path), 0) == 0) {
++    char* tmp = strdup(path);
++    if (fnmatch(IIO_DEVICE_WILDCARD, basename(tmp), 0) == 0) {
+         num_iio_devices++;
+     }
++    free(tmp);
+     return 0;
+ }
+ 


### PR DESCRIPTION
Support POSIX basename used in musl libc 1.2.5.

This backports a patch from upstream git.

Maintainer: @blogic @nxhack 
Compile tested: Mips BE
Run tested: No

Upstream commit: https://github.com/eclipse/mraa/commit/47c3850cddd63cebd9dc48e411963314449118f1
