### PR TITLE
udpxy:fix service not tracking interface change

### DIFF
--- a/net/udpxy/Makefile
+++ b/net/udpxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=udpxy
 PKG_VERSION:=1.0-25.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/pcherenkov/udpxy/tar.gz/$(PKG_VERSION)?

--- a/net/udpxy/files/udpxy.init
+++ b/net/udpxy/files/udpxy.init
@@ -29,6 +29,7 @@ append_bool() {
 start_instance() {
 	local cfg="$1"
 	local aux
+	local dev
 
 	config_get_bool aux "$cfg" 'disabled' '0'
 	[ "$aux" = 1 ] && return 1
@@ -54,11 +55,21 @@ start_instance() {
 	config_get_bool aux "$cfg" 'respawn' '0'
 	[ "$aux" = 1 ] && procd_set_param respawn
 
+	config_get dev "$cfg" "source"
+	[ -n "$dev" ] && procd_set_param netdev $dev
+
 	procd_close_instance
 }
 
-service_triggers() { 
-	procd_add_reload_trigger "udpxy" 
+service_triggers() {
+	local cfg
+	local dev
+	local ifname
+	procd_add_reload_trigger "udpxy"
+	cfg=$(config_foreach echo $1 udpxy)
+	config_get dev "$cfg" "source"
+	[ -n "$dev" ] && ifname=$(uci show network | grep $dev | awk '{split($0,arr,".");print arr[2]}')
+	[ -n "$ifname" ] && procd_add_interface_trigger "interface.*" $ifname /etc/init.d/udpxy restart
 }
 
 start_service() {


### PR DESCRIPTION
Maintainer: @Meano
Compile tested: (x86/64, VMware, OpenWrt 23.05.3)
Run tested: (x86/64, VMware, OpenWrt 23.05.3, tests done)

Description:
udpxy service  can not keep track with the change of the corresponding interface.