### PR TITLE
[22.03] php8: update to 8.1.28

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.1.27
+PKG_VERSION:=8.1.28
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -15,8 +15,8 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=479e65c3f05714d4aace1370e617d78e49e996ec7a7579a5be47535be61f0658
+PKG_SOURCE_URL:=https://www.php.net/distributions/
+PKG_HASH:=95d0b2e9466108fd750dab5c30a09e5c67f5ad2cb3b1ffb3625a038a755ad080
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
This fixes:
  - CVE-2024-1874
  - CVE-2024-2756
  - CVE-2024-3096

Maintainer: me
Compile tested: mxs
Run tested: -
