### PR TITLE
ddns-scripts: fix parsing of parameters

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=70
+PKG_RELEASE:=71
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
@@ -42,10 +42,13 @@ __DOMAIN=$(printf %s "$domain" | cut -d@ -f2)
 # __HOST   = the FQDN of record to modify
 # i.e. example.com for the "domain record" or host.sub.example.com for "host record"
 
+if [ -z "$__HOST" ]; then
 # handling domain record then set __HOST = __DOMAIN
-[ -z "$__HOST" ] && __HOST=$__DOMAIN
+	__HOST=$__DOMAIN
+else
 # handling host record then rebuild fqdn host@domain.tld => host.domain.tld
-[ "$__HOST" != "$__DOMAIN" ] && __HOST="${__HOST}.${__DOMAIN}"
+	__HOST="${__HOST}.${__DOMAIN}"
+fi
 
 # set record type
 [ $use_ipv6 -eq 0 ] && __TYPE="A" || __TYPE="AAAA"


### PR DESCRIPTION
Maintainer: Florian Eckert <fe@dev.tdt.de>
Compile tested: none
Run tested: none

Description:
There is an obvious bug here:
if we want to update example.com.example.com in zone example.com, so `domain=example.com@example.com`, after parsing, the `__HOST` will be `example.com`, not expected `example.com.example.com`.
