### PR TITLE
tor: update to 0.4.8.11 stable

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.8.10
+PKG_VERSION:=0.4.8.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=e628b4fab70edb4727715b23cf2931375a9f7685ac08f2c59ea498a178463a86
+PKG_HASH:=8f2bdf90e63380781235aa7d604e159570f283ecee674670873d8bb7052c8e07
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Minor release, see the changelog [1] for what's new.

[1] https://gitlab.torproject.org/tpo/core/tor/-/raw/tor-0.4.8.11/ChangeLog

Maintainer: @hauke
Run tested: mediatek/filogic (tor-basic)

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>