### PR TITLE
curl: call mbedtls_ssl_setup() after RNG callback is set

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=8.7.1
-PKG_RELEASE:=r1
+PKG_RELEASE:=r2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \

--- a/net/curl/patches/300-setup_after_rng.patch
+++ b/net/curl/patches/300-setup_after_rng.patch
@@ -1,0 +1,29 @@
+--- a/lib/vtls/mbedtls.c
++++ b/lib/vtls/mbedtls.c
+@@ -602,10 +602,6 @@ mbed_connect_step1(struct Curl_cfilter *
+   }
+ 
+   mbedtls_ssl_init(&backend->ssl);
+-  if(mbedtls_ssl_setup(&backend->ssl, &backend->config)) {
+-    failf(data, "mbedTLS: ssl_init failed");
+-    return CURLE_SSL_CONNECT_ERROR;
+-  }
+ 
+   /* new profile with RSA min key len = 1024 ... */
+   mbedtls_ssl_conf_cert_profile(&backend->config,
+@@ -639,6 +635,15 @@ mbed_connect_step1(struct Curl_cfilter *
+ 
+   mbedtls_ssl_conf_rng(&backend->config, mbedtls_ctr_drbg_random,
+                        &backend->ctr_drbg);
++
++  ret = mbedtls_ssl_setup(&backend->ssl, &backend->config);
++  if(ret) {
++    mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));
++    failf(data, "ssl_setup failed - mbedTLS: (-0x%04X) %s",
++          -ret, errorbuf);
++    return CURLE_SSL_CONNECT_ERROR;
++  }
++
+   mbedtls_ssl_set_bio(&backend->ssl, cf,
+                       mbedtls_bio_cf_write,
+                       mbedtls_bio_cf_read,


### PR DESCRIPTION
Maintainer: @stangri (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version) x86-64, hyper-v
Run tested: (put here arch, model, OpenWrt version, tests done) https://github.com/openwrt/openwrt/pull/15092 , x86-64, hyper-v

Description:

Since mbedTLS v3.6.0, the RNG check added in ssl_conf_check() will fail if no RNG is provided when calling mbedtls_ssl_setup(). Therefore, mbedtls_ssl_conf_rng() needs to be called before the SSL context is passed to mbedtls_ssl_setup().
