### PR TITLE
ddns-scripts: fix duplication of processes when reloading

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=43
+PKG_RELEASE:=44
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
@@ -89,7 +89,7 @@ case "$1" in
 		exit 1
 		;;
 	reload)
-		killall -1 dynamic_dns_updater.sh 2>/dev/null
+		killall dynamic_dns_updater.sh 2>/dev/null
 		exit $?
 		;;
 	*)	usage_err "unknown command - $1";;


### PR DESCRIPTION
When a "service ddns reload" is issued, the ddns processes are being duplicated. It seems the culprit is the -1 in the 'killall' command, and removing it fixes the issue, so this commit removes the -1 as workaround of the problem.

Fixes https://github.com/openwrt/packages/issues/23135 and there is more information in the issue. @maxberger wanted to look at it deeply but until then, this code fixes the issue and it seems not to break anything.

Maintainer: @chris5560, @maxberger, @dibdot
Compile tested: qualcommax/ipq807x, Xiaomi AX3600, OpenWrt snapshot
Run tested: qualcommax/ipq807x, Xiaomi AX3600, OpenWrt snapshot, test reload the service and look at the ps processes to confirm all is as expected.