### PR TITLE
sftp-server: add package

### DIFF
--- a/net/sftp-server/Makefile
+++ b/net/sftp-server/Makefile
@@ -1,0 +1,44 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=sftp-server
+PKG_VERSION:=2
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/ewxrjk/sftpserver.git
+PKG_SOURCE_DATE:=2024-04-17
+PKG_SOURCE_VERSION:=454309adcd99e3253f106f1f634e800e4d098b18
+PKG_MIRROR_HASH:=9590f6c0d4defe820eed8f359f5f782cd87801ca40c2c2f0d160e521bc80dc3b
+
+PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/sftp-server
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=SSH
+  TITLE:=Green End SFTP Server
+  CONFLICTS:=openssh-sftp-server
+  URL:=http://www.greenend.org.uk/rjk/sftpserver/
+endef
+
+define Package/sftp-server/description
+ This is an SFTP server supporting up to protocol version 6.
+ It is possible to use it as a drop-in replacement
+ for the OpenSSH server.
+endef
+
+CONFIGURE_ARGS += --libexecdir=/usr/libexec
+
+define Package/sftp-server/install
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/libexec/gesftpserver $(1)/usr/libexec/sftp-server
+endef
+
+$(eval $(call BuildPackage,sftp-server))

--- a/net/sftp-server/patches/110-fix-autoconf-warnings.patch
+++ b/net/sftp-server/patches/110-fix-autoconf-warnings.patch
@@ -1,0 +1,83 @@
+From 234709884c84896511d5d5d52f5f7926b44ca6ad Mon Sep 17 00:00:00 2001
+From: Andy Pan <andypan@ntuosc.org>
+Date: Wed, 6 Sep 2023 14:12:03 +0800
+Subject: [PATCH] Eliminate autoconf warnings
+
+---
+ acinclude.m4 | 20 ++++++++++----------
+ configure.ac |  6 +++---
+ 2 files changed, 13 insertions(+), 13 deletions(-)
+
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -120,10 +120,10 @@ $suppress \
+   fi
+   AC_CACHE_CHECK([whether <inttypes.h> macros produce warnings],
+                  [rjk_cv_inttypeswarnings],[
+-    AC_TRY_COMPILE([#include <stddef.h>
++    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stddef.h>
+ #include <stdio.h>
+-#include <inttypes.h>],
+-                   [uint64_t x=0;size_t sz=0;printf("%"PRIu64" %zu\n", x, sz);],
++#include <inttypes.h>]],[
++                   [uint64_t x=0;size_t sz=0;printf("%"PRIu64" %zu\n", x, sz);]])],
+                    [rjk_cv_inttypeswarnings=no],
+                    [rjk_cv_inttypeswarnings=yes])
+   ])
+@@ -144,16 +144,16 @@ AC_DEFUN([RJK_GTKFLAGS],[
+ AC_DEFUN([RJK_STAT_TIMESPEC],[
+   AC_CACHE_CHECK([for timespec style in struct stat],[rjk_cv_stat_timespec],[
+     rjk_cv_stat_timespec=none
+-    AC_TRY_COMPILE([#include <sys/stat.h>],[
++    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/stat.h>]],[[
+       struct stat sb;
+       sb.st_atim.tv_sec = 0;
+       (void)sb;
+-    ],[rjk_cv_stat_timespec=POSIX])
+-    AC_TRY_COMPILE([#include <sys/stat.h>],[
++    ]])],[rjk_cv_stat_timespec=POSIX],[])
++    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/stat.h>]],[[
+       struct stat sb;
+       sb.st_atimespec.tv_sec = 0;
+       (void)sb;
+-    ],[rjk_cv_stat_timespec=BSD])
++    ]])],[rjk_cv_stat_timespec=BSD],[])
+   ])
+   case "$rjk_cv_stat_timespec" in
+   BSD )
+@@ -243,12 +243,12 @@ AC_DEFUN([RJK_SIZE_MAX],[
+   AC_CHECK_SIZEOF([size_t])
+   AC_CHECK_HEADERS([stdint.h])
+   AC_CACHE_CHECK([for SIZE_MAX],[rjk_cv_size_max],[
+-    AC_TRY_COMPILE([#include <limits.h>
++    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <limits.h>
+                     #include <stddef.h>
+                     #if HAVE_STDINT_H
+                     # include <stdint.h>
+-                    #endif],
+-                   [size_t x = SIZE_MAX;++x;],
++                    #endif]],
++                   [[size_t x = SIZE_MAX;++x;]])],
+                    [rjk_cv_size_max=yes],
+                    [rjk_cv_size_max=no])
+   ])
+--- a/configure.ac
++++ b/configure.ac
+@@ -17,14 +17,14 @@
+ # USA
+ 
+ # Process this file with autoconf to produce a configure script.
+-AC_INIT(sftpserver, 2, rjk@greenend.org.uk)
++AC_INIT([sftpserver],[2],[rjk@greenend.org.uk])
+ AC_CONFIG_AUX_DIR([config.aux])
+ AM_INIT_AUTOMAKE([foreign])
+ AC_CONFIG_SRCDIR([alloc.c])
+-AM_CONFIG_HEADER([config.h])
++AC_CONFIG_HEADERS([config.h])
+ 
+ AC_PROG_CC
+-AC_SET_MAKE
++AC_PROG_MAKE_SET
+ 
+ #AC_PROG_LIBTOOL
+ #AC_LIBTOOL_DLOPEN

--- a/net/sftp-server/patches/120-fix-for-old-libedit.patch
+++ b/net/sftp-server/patches/120-fix-for-old-libedit.patch
@@ -1,0 +1,21 @@
+From b5113a1a3fd72dca5d358ce8c8c7f387f7f9356b Mon Sep 17 00:00:00 2001
+From: Andy Pan <andy0130tw@yahoo.com.tw>
+Date: Mon, 13 Nov 2023 01:09:56 +0800
+Subject: [PATCH] Fix config script where rl_copy_text is not found in old
+ libedit.
+
+ref. https://github.com/gphoto/gphoto2/issues/381
+---
+ configure.ac | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -41,6 +41,7 @@ AC_CHECK_LIB([socket],[socket])
+ AC_CHECK_LIB([readline],[readline],
+              [AC_SUBST([LIBREADLINE],[-lreadline])
+               AC_DEFINE([HAVE_READLINE],[1],[define if you have a readline library])])
++AC_CHECK_LIB([readline],[rl_copy_text])
+ RJK_ICONV
+ AC_DEFINE([_GNU_SOURCE], [1], [required for e.g. strsignal])
+ AC_C_INLINE

--- a/net/sftp-server/patches/130-fix-locale-issue.patch
+++ b/net/sftp-server/patches/130-fix-locale-issue.patch
@@ -1,0 +1,21 @@
+From 5b944c94527555457ee76815351d50a662892929 Mon Sep 17 00:00:00 2001
+From: Andy Pan <andy0130tw@yahoo.com.tw>
+Date: Mon, 13 Nov 2023 01:13:35 +0800
+Subject: [PATCH] Do not print char >= 0x7f even if isprint returns nonzero
+
+... which is seemingly caused by `setlocale(LC_CTYPE, "");`
+---
+ debug.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/debug.c
++++ b/debug.c
+@@ -75,7 +75,7 @@ void sftp_debug_hexdump(const void *ptr,
+     output += 2;
+     for(j = 0; j < 16; ++j)
+       if(i + j < n)
+-        *output++ = isprint(p[i + j]) ? p[i + j] : '.';
++        *output++ = (isprint(p[i + j]) && p[i + j] < 0x7f) ? p[i + j] : '.';
+     *output++ = '\n';
+     *output = 0;
+     fputs(buffer, debugfp);

--- a/net/sftp-server/patches/140-add-websocat-support.patch
+++ b/net/sftp-server/patches/140-add-websocat-support.patch
@@ -1,0 +1,127 @@
+From 1c589910e6726bfc2d01ec01092ae744174f7219 Mon Sep 17 00:00:00 2001
+From: Andy Pan <andy0130tw@yahoo.com.tw>
+Date: Thu, 16 Nov 2023 03:25:04 +0800
+Subject: [PATCH] Add an option --websocat in SFTP server
+
+---
+ configure.ac |  2 +-
+ send.c       |  8 ++++++++
+ sftpclient.c |  3 +++
+ sftpserver.c | 19 +++++++++++++++++++
+ sftpserver.h |  7 +++++++
+ 5 files changed, 38 insertions(+), 1 deletion(-)
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -41,7 +41,7 @@ AC_CHECK_LIB([socket],[socket])
+ AC_CHECK_LIB([readline],[readline],
+              [AC_SUBST([LIBREADLINE],[-lreadline])
+               AC_DEFINE([HAVE_READLINE],[1],[define if you have a readline library])])
+-AC_CHECK_LIB([readline],[rl_copy_text])
++AC_CHECK_LIB([readline],[rl_copy_text],[true])
+ RJK_ICONV
+ AC_DEFINE([_GNU_SOURCE], [1], [required for e.g. strsignal])
+ AC_C_INLINE
+--- a/send.c
++++ b/send.c
+@@ -93,6 +93,14 @@ void sftp_send_end(struct worker *w) {
+     D(("%s:", sendtype));
+     sftp_debug_hexdump(w->buffer + 4, w->bufused - 4);
+   }
++
++  if (websocat_compatible) {
++    uint32_t buf_prefix = htonl(w->bufused);
++    if ((n = write(sftpout, &buf_prefix, 4)) != 4) {
++      sftp_fatal("error sending response prefix: %s", strerror(errno));
++    }
++  }
++
+   /* Write the whole buffer, coping with short writes */
+   written = 0;
+   while((size_t)written < w->bufused)
+--- a/sftpclient.c
++++ b/sftpclient.c
+@@ -132,6 +132,9 @@ static int forceversion;
+ 
+ static char *sftp_realpath(const char *path);
+ 
++/* used in server; unused in client. */
++int websocat_compatible;
++
+ enum {
+   OPT_QUIRK_REVERSE_SYMLINK = 256,
+   OPT_STOP_ON_ERROR,
+--- a/sftpserver.c
++++ b/sftpserver.c
+@@ -82,8 +82,14 @@ static const struct queuedetails workque
+ const struct sftpprotocol *protocol = &sftp_preinit;
+ const char sendtype[] = "response";
+ 
++int websocat_compatible;
++
+ /* Options */
+ 
++enum {
++  OPT_WEBSOCAT_COMPATIBLE = 256,
++};
++
+ static const struct option options[] = {
+     {"help", no_argument, 0, 'h'},
+     {"version", no_argument, 0, 'V'},
+@@ -99,6 +105,7 @@ static const struct option options[] = {
+     {"ipv4", no_argument, 0, '4'},
+     {"ipv6", no_argument, 0, '6'},
+ #endif
++    {"websocat", no_argument, 0, OPT_WEBSOCAT_COMPATIBLE},
+     {"readonly", no_argument, 0, 'R'},
+     {0, 0, 0, 0}};
+ 
+@@ -121,6 +128,7 @@ static void attribute((noreturn)) help(v
+                "  -4|-6                    Force IPv4 or IPv6 for --listen\n"
+                "  --background, -b         Daemonize\n"
+ #endif
++               "  --websocat               Transmit length-prefixed messages\n"
+                "  --readonly, -R           Read-only mode\n");
+   exit(0);
+ }
+@@ -498,6 +506,9 @@ int main(int argc, char **argv) {
+     case 'C':
+       config = optarg;
+       break;
++    case OPT_WEBSOCAT_COMPATIBLE:
++      websocat_compatible = 1;
++      break;
+     default:
+       exit(1);
+     }
+@@ -664,6 +675,14 @@ static void sftp_service(void) {
+   umask(0);
+   while(sftp_state_get() != sftp_state_stop &&
+         !sftp_xread(0, &len, sizeof len)) {
++
++    if (websocat_compatible) {
++      /* discard the prefix and read again */
++      if (sftp_xread(0, &len, sizeof len)) {
++        break;
++      }
++    }
++
+     job = sftp_xmalloc(sizeof *job);
+     job->len = ntohl(len);
+     if(!job->len || job->len > MAXREQUEST)
+--- a/sftpserver.h
++++ b/sftpserver.h
+@@ -57,6 +57,13 @@
+ #    define NTHREADS 4
+ #  endif
+ 
++/* If true, operate in websocat-compatible mode.
++   For use in conjunction with "lengthprefix:" overlay in websocat.
++   See websocat's doc for detail.
++   Prefix all outgoing messages with their length in uint32BE.
++   Also expect incoming messages to be formatted in the same way. */
++extern int websocat_compatible;
++
+ /** @brief Send an @ref SSH_FXP_STATUS message
+  * @param job Job
+  * @param status Status code


### PR DESCRIPTION
sftp-server is a lightweight sftp-server which can be used if user wants to avoid -O when using scp and installing openssh-sftp-server. sftp-server can be used as a drop-in replacement for openssh-sftp-server while it isn't as feature rich.

sftp-server is also known as Green End sftpserver.

Package uses git instead of release/tag because tagged versions were quite out-dated. I also added some patches from forked repositories which either provide small fixes, for example, to autoconf script - or add features, such as socat support.

sftp-server is minimal comparing disk space needed by openssh-sftp-server. And it does not have depencies.

Maintainer: me
Compile tested: x86_64, latest git
Run tested: x86_64, latest git