### PR TITLE
tailscale: Update to 1.64.1

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.62.1
+PKG_VERSION:=1.64.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=22737fae37e971fecdf49d6b741b99988868aa3f1e683e67e14b872a2c49ca1c
+PKG_HASH:=df6009abb4800a7e7681063c9d3f62da6850060e4949ca0bd1edad60781e9f03
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: @ja-pa @oskarirauta

<https://github.com/tailscale/tailscale/releases/v1.64.1>

Signed-off-by: Zephyr Lykos \<git@mochaa.ws>
