### PR TITLE
socat: fix compile error when ccache is enabled

### DIFF
--- a/net/socat/Makefile
+++ b/net/socat/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=socat
 PKG_VERSION:=1.8.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.dest-unreach.org/socat/download
@@ -57,6 +57,9 @@ CONFIGURE_ARGS += \
 	--disable-libwrap \
 	--disable-readline \
 	--enable-termios
+
+## procan.c fails to compile when ccache is enabled
+MAKE_FLAGS += CC="$(TARGET_CC_NOCACHE)"
 
 ifneq ($(CONFIG_SOCAT_SSL),y)
   CONFIGURE_ARGS+= --disable-openssl


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: arm_cortex-a9_neon, master branch

Fixes an error reported in https://github.com/openwrt/packages/commit/5a06e3471ba0a4a49130b22f936c823142680fe1#comments.