### PR TITLE
acme: fix script standalone error

### DIFF
--- a/net/acme-common/Makefile
+++ b/net/acme-common/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-common
-PKG_VERSION:=1.1.1
+PKG_VERSION:=1.1.2
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/acme-common/files/acme.init
+++ b/net/acme-common/files/acme.init
@@ -57,6 +57,7 @@ load_options() {
 	config_get days "$section" days
 	export days
 	config_get standalone "$section" standalone
+	export standalone
 	[ -n "$standalone" ] && log warn "Option \"standalone\" is deprecated."
 	config_get dns_wait "$section" dns_wait
 	export dns_wait
@@ -126,7 +127,7 @@ load_globals() {
 		log warn "Option \"state_dir\" is deprecated, please remove it. Certificates now exist in $CERT_DIR."
 		mkdir -p "$state_dir"
 	else
-		state_dir=/etc/acme
+		state_dir=$CERT_DIR
 	fi
 	export state_dir
 


### PR DESCRIPTION
Maintainers: @tohojo, @stokito
Run tested: OpenWrt 23.05.3

Description:

Fix issue with `acme.sh`:

```
acme-acmesh: Running ACME for ****
/usr/lib/acme/hook: line 123: standalone: parameter not set
```

Here is few reported issues: 
https://github.com/openwrt/packages/issues/23756

Finally solution found here:
https://forum.openwrt.org/t/acme-not-working-on-openwrt-23-05-2/190724/3

And moved to this PR:
problem is that `hook` requres ` `standalone` variabe. So it is worth to be exported, to avoid script fail, even if the standalone already deprecated.

And the second issue is that comment about deprecated `state_dir` used `$CERT_DIR` that points to `/etc/ssl/acme`.
While actual default value is `/etc/acme`, so fixed it to use `$CERT_DIR`.


