### PR TITLE
banip: release 0.9.5-1

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -5,8 +5,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
-PKG_VERSION:=0.9.4
-PKG_RELEASE:=3
+PKG_VERSION:=0.9.5
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/banip/files/README.md
+++ b/net/banip/files/README.md
@@ -17,12 +17,12 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 | antipopads          | antipopads IPs                 |         |         |    x    | tcp: 80, 443 | [Link](https://github.com/dibdot/banIP-IP-blocklists)        |
 | asn                 | ASN segments                   |         |         |    x    | tcp: 80, 443 | [Link](https://asn.ipinfo.app)                               |
 | backscatterer       | backscatterer IPs              |    x    |    x    |         |              | [Link](https://www.uceprotect.net/en/index.php)              |
+| becyber             | malicious attacker IPs         |    x    |    x    |         |              | [Link](https://github.com/duggytuxy/malicious_ip_addresses)  |
 | binarydefense       | binary defense banlist         |    x    |    x    |         |              | [Link](https://iplists.firehol.org/?ipset=bds_atif)          |
 | bogon               | bogon prefixes                 |    x    |    x    |         |              | [Link](https://team-cymru.com)                               |
 | bruteforceblock     | bruteforceblocker IPs          |    x    |    x    |         |              | [Link](https://danger.rulez.sk/index.php/bruteforceblocker/) |
 | country             | country blocks                 |    x    |    x    |         |              | [Link](https://www.ipdeny.com/ipblocks)                      |
 | cinsscore           | suspicious attacker IPs        |    x    |    x    |         |              | [Link](https://cinsscore.com/#list)                          |
-| darklist            | blocks suspicious attacker IPs |    x    |    x    |         |              | [Link](https://darklist.de)                                  |
 | debl                | fail2ban IP blacklist          |    x    |    x    |         |              | [Link](https://www.blocklist.de)                             |
 | doh                 | public DoH-Provider            |         |         |    x    | tcp: 80, 443 | [Link](https://github.com/dibdot/DoH-IP-blocklists)          |
 | drop                | spamhaus drop compilation      |    x    |    x    |         |              | [Link](https://www.spamhaus.org)                             |
@@ -37,14 +37,15 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 | greensnow           | suspicious server IPs          |    x    |    x    |         |              | [Link](https://greensnow.co)                                 |
 | iblockads           | Advertising IPs                |         |         |    x    | tcp: 80, 443 | [Link](https://www.iblocklist.com)                           |
 | iblockspy           | Malicious spyware IPs          |         |         |    x    | tcp: 80, 443 | [Link](https://www.iblocklist.com)                           |
-| ipblackhole         | blackhole IPs                  |    x    |    x    |         |              | [Link](https://ip.blackhole.monster)                         |
+| ipsum               | malicious IPs                  |    x    |    x    |         |              | [Link](https://github.com/stamparm/ipsum)                    |
 | ipthreat            | hacker and botnet TPs          |    x    |    x    |         |              | [Link](https://ipthreat.net)                                 |
 | myip                | real-time IP blocklist         |    x    |    x    |         |              | [Link](https://myip.ms)                                      |
 | nixspam             | iX spam protection             |    x    |    x    |         |              | [Link](http://www.nixspam.org)                               |
 | oisdbig             | OISD-big IPs                   |         |         |    x    | tcp: 80, 443 | [Link](https://github.com/dibdot/banIP-IP-blocklists)        |
 | oisdnsfw            | OISD-nsfw IPs                  |         |         |    x    | tcp: 80, 443 | [Link](https://github.com/dibdot/banIP-IP-blocklists)        |
 | oisdsmall           | OISD-small IPs                 |         |         |    x    | tcp: 80, 443 | [Link](https://github.com/dibdot/banIP-IP-blocklists)        |
-| proxy               | open proxies                   |    x    |         |         |              | [Link](https://iplists.firehol.org/?ipset=proxylists)        |
+| pallebone           | curated IP blocklist           |    x    |    x    |         |              | [Link](https://github.com/pallebone/StrictBlockPAllebone)    |
+| proxy               | open proxies                   |    x    |    x    |         |              | [Link](https://iplists.firehol.org/?ipset=proxylists)        |
 | ssbl                | SSL botnet IPs                 |    x    |    x    |         |              | [Link](https://sslbl.abuse.ch)                               |
 | stevenblack         | stevenblack IPs                |         |         |    x    | tcp: 80, 443 | [Link](https://github.com/dibdot/banIP-IP-blocklists)        |
 | talos               | talos IPs                      |    x    |    x    |         |              | [Link](https://talosintelligence.com/reputation_center)      |
@@ -66,10 +67,12 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 * Full IPv4 and IPv6 support
 * Supports nft atomic Set loading
 * Supports blocking by ASN numbers and by iso country codes
+* Block countries dynamically by Regional Internet Registry (RIR), e.g. all countries related to ARIN. Supported service regions are: AFRINIC, ARIN, APNIC, LACNIC and RIPE
 * Supports local allow- and blocklist with MAC/IPv4/IPv6 addresses or domain names
 * Supports concatenation of local MAC addresses with IPv4/IPv6 addresses, e.g. to enforce dhcp assignments
 * All local input types support ranges in CIDR notation
 * Auto-add the uplink subnet or uplink IP to the local allowlist
+* Prevent common ICMP, UDP and SYN flood attacks and drop spoofed tcp flags & invalid conntrack packets (DDoS attacks) in an additional prerouting chain
 * Provides a small background log monitor to ban unsuccessful login attempts in real-time (like fail2ban, crowdsec etc.)
 * Auto-add unsuccessful LuCI, nginx, Asterisk or ssh login attempts to the local blocklist
 * Auto-add entire subnets to the blocklist Sets based on an additional RDAP request with the monitored suspicious IP
@@ -80,6 +83,7 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 * Provides HTTP ETag support to download only ressources that have been updated on the server side, to speed up banIP reloads and to save bandwith
 * Supports an 'allowlist only' mode, this option skips all blocklists and restricts the internet access only to specific, explicitly allowed IP segments
 * Supports external allowlist URLs to reference additional IPv4/IPv6 feeds
+* Optionally always allow certain protocols/destination ports in wan-input and wan-forward chains
 * Deduplicate IPs accross all Sets (single IPs only, no intervals)
 * Provides comprehensive runtime information
 * Provides a detailed Set report
@@ -149,14 +153,19 @@ Available commands:
 | ban_logreadfile         | option | /var/log/messages             | alternative location for parsing the log file, e.g. via syslog-ng, to deactivate the standard parsing via logread |
 | ban_autodetect          | option | 1                             | auto-detect wan interfaces, devices and subnets                                                                   |
 | ban_debug               | option | 0                             | enable banIP related debug logging                                                                                |
-| ban_loginput            | option | 1                             | log drops in the wan-input chain                                                                                  |
-| ban_logforwardwan       | option | 1                             | log drops in the wan-forward chain                                                                                |
-| ban_logforwardlan       | option | 0                             | log rejects in the lan-forward chain                                                                              |
+| ban_icmplimit           | option | 10                            | treshold in number of packets to detect icmp DDoS in prerouting chain                                             |
+| ban_synlimit            | option | 10                            | treshold in number of packets to detect syn DDoS in prerouting chain                                              |
+| ban_udplimit            | option | 100                           | treshold in number of packets to detect udp DDoS in prerouting chain                                              |
+| ban_logprerouting       | option | 0                             | log supsicious packets in the prerouting chain                                                                    |
+| ban_loginput            | option | 0                             | log supsicious packets in the wan-input chain                                                                     |
+| ban_logforwardwan       | option | 0                             | log supsicious packets in the wan-forward chain                                                                   |
+| ban_logforwardlan       | option | 0                             | log supsicious packets in the lan-forward chain                                                                   |
 | ban_autoallowlist       | option | 1                             | add wan IPs/subnets and resolved domains automatically to the local allowlist (not only to the Sets)              |
 | ban_autoblocklist       | option | 1                             | add suspicious attacker IPs and resolved domains automatically to the local blocklist (not only to the Sets)      |
 | ban_autoblocksubnet     | option | 0                             | add entire subnets to the blocklist Sets based on an additional RDAP request with the suspicious IP               |
 | ban_autoallowuplink     | option | subnet                        | limit the uplink autoallow function to: 'subnet', 'ip' or 'disable' it at all                                     |
 | ban_allowlistonly       | option | 0                             | skip all blocklists and restrict the internet access only to specific, explicitly allowed IP segments             |
+| ban_allowflag           | option | -                             | always allow certain protocols(tcp or udp) plus destination ports or port ranges, e.g.: 'tcp 80 443-445'          |
 | ban_allowurl            | list   | -                             | external allowlist feed URLs, one or more references to simple remote IP lists                                    |
 | ban_basedir             | option | /tmp                          | base working directory while banIP processing                                                                     |
 | ban_reportdir           | option | /tmp/banIP-report             | directory where banIP stores the report files                                                                     |
@@ -174,11 +183,12 @@ Available commands:
 | ban_splitsize           | option | 0                             | split ext. Sets after every n lines/members (saves RAM)                                                           |
 | ban_cores               | option | - / autodetect                | limit the cpu cores used by banIP (saves RAM)                                                                     |
 | ban_nftloglevel         | option | warn                          | nft loglevel, values: emerg, alert, crit, err, warn, notice, info, debug                                          |
-| ban_nftpriority         | option | -200                          | nft priority for the banIP table (default is the prerouting table priority)                                       |
+| ban_nftpriority         | option | -100                          | nft priority for the banIP table (the prerouting table is fixed to priority -150)                                 |
 | ban_nftpolicy           | option | memory                        | nft policy for banIP-related Sets, values: memory, performance                                                    |
 | ban_nftexpiry           | option | -                             | expiry time for auto added blocklist members, e.g. '5m', '2h' or '1d'                                             |
 | ban_feed                | list   | -                             | external download feeds, e.g. 'yoyo', 'doh', 'country' or 'talos' (see feed table)                                |
 | ban_asn                 | list   | -                             | ASNs for the 'asn' feed, e.g.'32934'                                                                              |
+| ban_region              | list   | -                             | Regional Internet Registry (RIR) country selection. Supported regions are: AFRINIC, ARIN, APNIC, LACNIC and RIPE  |
 | ban_country             | list   | -                             | country iso codes for the 'country' feed, e.g. 'ru'                                                               |
 | ban_blockpolicy         | option | -                             | limit the default block policy to a certain chain, e.g. 'input', 'forwardwan' or 'forwardlan'                     |
 | ban_blocktype           | option | drop                          | 'drop' packets silently on input and forwardwan chains or actively 'reject' the traffic                           |
@@ -206,39 +216,46 @@ Available commands:
 :::
 ::: banIP Set Statistics
 :::
-    Timestamp: 2024-03-02 07:38:28
+    Timestamp: 2024-04-17 23:02:15
     ------------------------------
-    auto-added to allowlist today: 0
-    auto-added to blocklist today: 0
+    blocked syn-flood packets in prerouting  : 5
+    blocked udp-flood packets in prerouting  : 11
+    blocked icmp-flood packets in prerouting : 6
+    blocked invalid ct packets in prerouting : 277
+    blocked invalid tcp packets in prerouting: 0
+    ----------
+    auto-added IPs to allowlist today: 0
+    auto-added IPs to blocklist today: 0
 
     Set                  | Elements     | WAN-Input (packets)   | WAN-Forward (packets) | LAN-Forward (packets) | Port/Protocol Limit
     ---------------------+--------------+-----------------------+-----------------------+-----------------------+------------------------
-    allowlistv4MAC       | 0            | -                     | -                     | OK: 0                 | -                     
-    allowlistv6MAC       | 0            | -                     | -                     | OK: 0                 | -                     
-    allowlistv4          | 1            | OK: 0                 | OK: 0                 | OK: 0                 | -                     
-    allowlistv6          | 2            | OK: 0                 | OK: 0                 | OK: 0                 | -                     
-    adguardtrackersv6    | 74           | -                     | -                     | OK: 0                 | tcp: 80, 443          
-    adguardtrackersv4    | 883          | -                     | -                     | OK: 0                 | tcp: 80, 443          
-    cinsscorev4          | 12053        | OK: 25                | OK: 0                 | -                     | -                     
-    countryv4            | 37026        | OK: 14                | OK: 0                 | -                     | -                     
-    deblv4               | 13592        | OK: 0                 | OK: 0                 | -                     | -                     
-    countryv6            | 38139        | OK: 0                 | OK: 0                 | -                     | -                     
-    deblv6               | 82           | OK: 0                 | OK: 0                 | -                     | -                     
-    dohv6                | 837          | -                     | -                     | OK: 0                 | tcp: 80, 443          
-    dohv4                | 1240         | -                     | -                     | OK: 0                 | tcp: 80, 443          
-    dropv6               | 51           | OK: 0                 | OK: 0                 | -                     | -                     
-    dropv4               | 592          | OK: 0                 | OK: 0                 | -                     | -                     
-    firehol1v4           | 906          | OK: 1                 | OK: 0                 | -                     | -                     
-    firehol2v4           | 2105         | OK: 0                 | OK: 0                 | OK: 0                 | -                     
-    threatv4             | 55           | OK: 0                 | OK: 0                 | -                     | -                     
-    ipthreatv4           | 2042         | OK: 0                 | OK: 0                 | -                     | -                     
-    turrisv4             | 6433         | OK: 0                 | OK: 0                 | -                     | -                     
-    blocklistv4MAC       | 0            | -                     | -                     | OK: 0                 | -                     
-    blocklistv6MAC       | 0            | -                     | -                     | OK: 0                 | -                     
-    blocklistv4          | 0            | OK: 0                 | OK: 0                 | OK: 0                 | -                     
-    blocklistv6          | 0            | OK: 0                 | OK: 0                 | OK: 0                 | -                     
+    allowlistv4MAC       | 0            | -                     | -                     | ON: 0                 | -                     
+    allowlistv6MAC       | 0            | -                     | -                     | ON: 0                 | -                     
+    allowlistv4          | 1            | ON: 0                 | ON: 0                 | ON: 0                 | -                     
+    allowlistv6          | 2            | ON: 0                 | ON: 0                 | ON: 0                 | -                     
+    adguardtrackersv6    | 105          | -                     | -                     | ON: 0                 | tcp: 80, 443          
+    adguardtrackersv4    | 816          | -                     | -                     | ON: 0                 | tcp: 80, 443          
+    becyberv4            | 229006       | ON: 2254              | ON: 0                 | -                     | -                     
+    cinsscorev4          | 7135         | ON: 1630              | ON: 2                 | -                     | -                     
+    deblv4               | 10191        | ON: 23                | ON: 0                 | -                     | -                     
+    countryv6            | 38233        | ON: 7                 | ON: 0                 | -                     | -                     
+    countryv4            | 37169        | ON: 2323              | ON: 0                 | -                     | -                     
+    deblv6               | 65           | ON: 0                 | ON: 0                 | -                     | -                     
+    dropv6               | 66           | ON: 0                 | ON: 0                 | -                     | -                     
+    dohv4                | 1219         | -                     | -                     | ON: 0                 | tcp: 80, 443          
+    dropv4               | 895          | ON: 75                | ON: 0                 | -                     | -                     
+    dohv6                | 832          | -                     | -                     | ON: 0                 | tcp: 80, 443          
+    threatv4             | 20           | ON: 0                 | ON: 0                 | -                     | -                     
+    firehol1v4           | 753          | ON: 1                 | ON: 0                 | -                     | -                     
+    ipthreatv4           | 1369         | ON: 20                | ON: 0                 | -                     | -                     
+    firehol2v4           | 2216         | ON: 1                 | ON: 0                 | -                     | -                     
+    turrisv4             | 5613         | ON: 179               | ON: 0                 | -                     | -                     
+    blocklistv4MAC       | 0            | -                     | -                     | ON: 0                 | -                     
+    blocklistv6MAC       | 0            | -                     | -                     | ON: 0                 | -                     
+    blocklistv4          | 0            | ON: 0                 | ON: 0                 | ON: 0                 | -                     
+    blocklistv6          | 0            | ON: 0                 | ON: 0                 | ON: 0                 | -                     
     ---------------------+--------------+-----------------------+-----------------------+-----------------------+------------------------
-    24                   | 116113       | 16 (40)               | 16 (0)                | 13 (0)
+    25                   | 335706       | 17 (6513)             | 17 (2)                | 12 (0)
 ```
 
 **banIP runtime information**  
@@ -246,16 +263,16 @@ Available commands:
 ~# /etc/init.d/banip status
 ::: banIP runtime information
   + status            : active (nft: ✔, monitor: ✔)
-  + version           : 0.9.4-1
-  + element_count     : 116113
-  + active_feeds      : allowlistv4MAC, allowlistv6MAC, allowlistv4, allowlistv6, adguardtrackersv6, adguardtrackersv4, cinsscorev4, countryv4, deblv4, countryv6, deblv6, dohv6, dohv4, dropv6, dropv4, firehol1v4, firehol2v4, threatv4, ipthreatv4, turrisv4, blocklistv4MAC, blocklistv6MAC, blocklistv4, blocklistv6
+  + version           : 0.9.5-r1
+  + element_count     : 335706
+  + active_feeds      : allowlistv4MAC, allowlistv6MAC, allowlistv4, allowlistv6, adguardtrackersv6, adguardtrackersv4, becyberv4, cinsscorev4, deblv4, countryv6, countryv4, deblv6, dropv6, dohv4, dropv4, dohv6, threatv4, firehol1v4, ipthreatv4, firehol2v4, turrisv4, blocklistv4MAC, blocklistv6MAC, blocklistv4, blocklistv6
   + active_devices    : wan: pppoe-wan / wan-if: wan, wan_6 / vlan-allow: - / vlan-block: -
-  + active_uplink     : 217.89.211.113, fe80::2c35:fb80:e78c:cf71, 2003:ed:b5ff:2338:2c15:fb80:e78c:cf71
-  + nft_info          : priority: -200, policy: performance, loglevel: warn, expiry: 2h
+  + active_uplink     : 217.83.205.130, fe80::9cd6:12e9:c4df:75d3, 2003:ed:b5ff:43bd:9cd5:12e7:c3ef:75d8
+  + nft_info          : priority: 0, policy: performance, loglevel: warn, expiry: 2h
   + run_info          : base: /mnt/data/banIP, backup: /mnt/data/banIP/backup, report: /mnt/data/banIP/report
-  + run_flags         : auto: ✔, proto (4/6): ✔/✔, log (wan-inp/wan-fwd/lan-fwd): ✔/✔/✔, dedup: ✔, split: ✘, custom feed: ✘, allowed only: ✘
-  + last_run          : action: reload, log: logread, fetch: curl, duration: 0m 50s, date: 2024-03-02 07:35:01
-  + system_info       : cores: 4, memory: 1685, device: Bananapi BPI-R3, OpenWrt SNAPSHOT r25356-09be63de70
+  + run_flags         : auto: ✔, proto (4/6): ✔/✔, log (pre/inp/fwd/lan): ✔/✘/✘/✘, dedup: ✔, split: ✘, custom feed: ✘, allowed only: ✘
+  + last_run          : action: reload, log: logread, fetch: curl, duration: 2m 33s, date: 2024-04-17 05:57:56
+  + system_info       : cores: 4, memory: 1573, device: Bananapi BPI-R3, OpenWrt SNAPSHOT r25932-338b463e1e
 ```
 
 **banIP search information**  
@@ -315,10 +332,13 @@ Both local lists also accept domain names as input to allow IP filtering based o
 banIP supports an "allowlist only" mode. This option skips all blocklists and restricts the internet access only to specific, explicitly allowed IP segments - and block access to the rest of the internet. All IPs which are _not_ listed in the allowlist (plus the external Allowlist URLs) are blocked.
 
 **MAC/IP-binding**
-banIP supports concatenation of local MAC addresses with IPv4/IPv6 addresses, e.g. to enforce dhcp assignments. Following notations in the local allow and block lists are allowed:
+banIP supports concatenation of local MAC addresses/ranges with IPv4/IPv6 addresses, e.g. to enforce dhcp assignments. Following notations in the local allow and block lists are allowed:
 ```
 MAC-address only:
 C8:C2:9B:F7:80:12                                  => this will be populated to the v4MAC- and v6MAC-Sets with the IP-wildcards 0.0.0.0/0 and ::/0
+
+MAC-address range:
+C8:C2:9B:F7:80:12/24                               => this populate the MAC-range C8:C2:9B:00:00:00", "C8:C2:9B:FF:FF:FF to the v4MAC- and v6MAC-Sets with the IP-wildcards 0.0.0.0/0 and ::/0
 
 MAC-address with IPv4 concatenation:
 C8:C2:9B:F7:80:12 192.168.1.10                     => this will be populated only to v4MAC-Set with the certain IP, no entry in the v6MAC-Set
@@ -334,6 +354,7 @@ MAC-address with IPv4 and IPv6 wildcard concatenation:
 C8:C2:9B:F7:80:12 192.168.1.10                     => this will be populated to v4MAC-Set with the certain IP
 C8:C2:9B:F7:80:12                                  => this will be populated to v6MAC-Set with the IP-wildcard ::/0
 ```
+
 **enable the cgi interface to receive remote logging events**  
 banIP ships a basic cgi interface in '/www/cgi-bin/banip' to receive remote logging events (disabled by default). The cgi interface evaluates logging events via GET or POST request (see examples below). To enable the cgi interface set the following options:  
 
@@ -407,12 +428,12 @@ A valid JSON source object contains the following information, e.g.:
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)$/{printf \"%s,\\n\",$1}",
 		"descr": "tor exit nodes",
-		"flag": "80-89 443 tcp"
+		"flag": "tcp 80-89 443"
 	},
 	[...]
 ```
 Add an unique feed name (no spaces, no special chars) and make the required changes: adapt at least the URL, the regex and the description for a new feed.  
-Please note: the flag field is optional, it's a space separated list of options: supported are 'gz' as an archive format, port numbers (plus ranges) for destination port limitations with 'tcp' (default) or 'udp' as protocol variants.  
+Please note: the flag field is optional, it's a space separated list of options: supported are 'gz' as an archive format, protocols 'tcp' or 'udp' with port numbers/port ranges for destination port limitations.  
 
 ## Support
 Please join the banIP discussion in this [forum thread](https://forum.openwrt.org/t/banip-support-thread/16985) or contact me by mail <dev@brenken.org>

--- a/net/banip/files/banip-functions.sh
+++ b/net/banip/files/banip-functions.sh
@@ -16,6 +16,7 @@ ban_basedir="/tmp"
 ban_backupdir="/tmp/banIP-backup"
 ban_reportdir="/tmp/banIP-report"
 ban_feedfile="/etc/banip/banip.feeds"
+ban_countryfile="/etc/banip/banip.countries"
 ban_customfeedfile="/etc/banip/banip.custom.feeds"
 ban_allowlist="/etc/banip/banip.allowlist"
 ban_blocklist="/etc/banip/banip.blocklist"
@@ -36,18 +37,24 @@ ban_reportelements="1"
 ban_remotelog="0"
 ban_remotetoken=""
 ban_nftloglevel="warn"
-ban_nftpriority="-200"
+ban_nftpriority="-100"
 ban_nftpolicy="memory"
 ban_nftexpiry=""
 ban_loglimit="100"
+ban_icmplimit="10"
+ban_synlimit="10"
+ban_udplimit="100"
 ban_logcount="1"
 ban_logterm=""
+ban_region=""
 ban_country=""
 ban_asn=""
-ban_loginput="1"
-ban_logforwardwan="1"
+ban_logprerouting="0"
+ban_loginput="0"
+ban_logforwardwan="0"
 ban_logforwardlan="0"
 ban_allowurl=""
+ban_allowflag=""
 ban_allowlistonly="0"
 ban_autoallowlist="1"
 ban_autoallowuplink="subnet"
@@ -104,6 +111,7 @@ f_system() {
 		[ "${cpu}" = "0" ] && cpu="1"
 		[ "${core}" = "0" ] && core="1"
 		ban_cores="$((cpu * core))"
+		[ "${ban_cores}" -gt "16" ] && ban_cores="16"
 	fi
 }
 
@@ -211,8 +219,7 @@ f_rmpid() {
 			kill -INT "${pid}" >/dev/null 2>&1
 		done
 	fi
-	: >"${ban_rdapfile}"
-	: >"${ban_pidfile}"
+	: >"${ban_rdapfile}" >"${ban_pidfile}"
 }
 
 # write log messages
@@ -247,7 +254,9 @@ f_log() {
 # load config
 #
 f_conf() {
-	unset ban_dev ban_vlanallow ban_vlanblock ban_ifv4 ban_ifv6 ban_feed ban_allowurl ban_blockinput ban_blockforwardwan ban_blockforwardlan ban_logterm ban_country ban_asn
+	local rir ccode region country
+
+	unset ban_dev ban_vlanallow ban_vlanblock ban_ifv4 ban_ifv6 ban_feed ban_allowurl ban_blockinput ban_blockforwardwan ban_blockforwardlan ban_logterm ban_region ban_country ban_asn
 	config_cb() {
 		option_cb() {
 			local option="${1}"
@@ -294,6 +303,9 @@ f_conf() {
 				"ban_logterm")
 					eval "${option}=\"$(printf "%s" "${ban_logterm}")${value}\\|\""
 					;;
+				"ban_region")
+					eval "${option}=\"$(printf "%s" "${ban_region}")${value} \""
+					;;
 				"ban_country")
 					eval "${option}=\"$(printf "%s" "${ban_country}")${value} \""
 					;;
@@ -305,6 +317,14 @@ f_conf() {
 	}
 	config_load banip
 	[ -f "${ban_logreadfile}" ] && ban_logreadcmd="$(command -v tail)" || ban_logreadcmd="$(command -v logread)"
+
+	for rir in ${ban_region}; do
+		while read -r ccode region country; do
+			if [ "${rir}" = "${region}" ] && ! printf "%s" "${ban_country}" | "${ban_grepcmd}" -qw "${ccode}"; then
+				ban_country="${ban_country} ${ccode}"
+			fi
+		done < "${ban_countryfile}"
+	done
 }
 
 # get nft/monitor actuals
@@ -575,11 +595,32 @@ f_etag() {
 # build initial nft file with base table, chains and rules
 #
 f_nftinit() {
-	local wan_dev vlan_allow vlan_block feed_log feed_rc file="${1}"
+	local wan_dev vlan_allow vlan_block log_ct log_icmp log_syn log_udp log_tcp feed_log feed_rc allow_proto allow_dport flag file="${1}"
 
 	wan_dev="$(printf "%s" "${ban_dev}" | "${ban_sedcmd}" 's/^/\"/;s/$/\"/;s/ /\", \"/g')"
 	[ -n "${ban_vlanallow}" ] && vlan_allow="$(printf "%s" "${ban_vlanallow%%?}" | "${ban_sedcmd}" 's/^/\"/;s/$/\"/;s/ /\", \"/g')"
 	[ -n "${ban_vlanblock}" ] && vlan_block="$(printf "%s" "${ban_vlanblock%%?}" | "${ban_sedcmd}" 's/^/\"/;s/$/\"/;s/ /\", \"/g')"
+
+	for flag in ${ban_allowflag}; do
+		if [ -z "${allow_proto}" ] && { [ "${flag}" = "tcp" ] || [ "${flag}" = "udp" ]; }; then
+			allow_proto="${flag}"
+		elif [ -n "${allow_proto}" ] && [ -n "${flag//[![:digit]-]/}" ] && ! printf "%s" "${allow_dport}" | "${ban_grepcmd}" -qw "${flag}"; then
+			if [ -z "${allow_dport}" ]; then
+				allow_dport="${flag}"
+			else
+				allow_dport="${allow_dport}, ${flag}"
+			fi
+		fi
+	done
+	[ -n "${allow_dport}" ] && allow_dport="${allow_proto} dport { ${allow_dport} }"
+
+	if [ "${ban_logprerouting}" = "1" ]; then
+		log_icmp="log level ${ban_nftloglevel} prefix \"banIP/pre-icmp/drop: \""
+		log_syn="log level ${ban_nftloglevel} prefix \"banIP/pre-syn/drop: \""
+		log_udp="log level ${ban_nftloglevel} prefix \"banIP/pre-udp/drop: \""
+		log_tcp="log level ${ban_nftloglevel} prefix \"banIP/pre-tcp/drop: \""
+		log_ct="log level ${ban_nftloglevel} prefix \"banIP/pre-ct/drop: \""
+	fi
 
 	{
 		# nft header (tables and chains)
@@ -589,36 +630,55 @@ f_nftinit() {
 			printf "%s\n" "delete table inet banIP"
 		fi
 		printf "%s\n" "add table inet banIP"
+		printf "%s\n" "add counter inet banIP cnt-icmpflood"
+		printf "%s\n" "add counter inet banIP cnt-udpflood"
+		printf "%s\n" "add counter inet banIP cnt-synflood"
+		printf "%s\n" "add counter inet banIP cnt-tcpinvalid"
+		printf "%s\n" "add counter inet banIP cnt-ctinvalid"
+		printf "%s\n" "add chain inet banIP pre-routing { type filter hook prerouting priority -150; policy accept; }"
 		printf "%s\n" "add chain inet banIP wan-input { type filter hook input priority ${ban_nftpriority}; policy accept; }"
 		printf "%s\n" "add chain inet banIP wan-forward { type filter hook forward priority ${ban_nftpriority}; policy accept; }"
 		printf "%s\n" "add chain inet banIP lan-forward { type filter hook forward priority ${ban_nftpriority}; policy accept; }"
 		printf "%s\n" "add chain inet banIP reject-chain"
 
-		# default reject rules
+		# default reject chain rules
 		#
 		printf "%s\n" "add rule inet banIP reject-chain meta l4proto tcp reject with tcp reset"
 		printf "%s\n" "add rule inet banIP reject-chain reject"
 
+		# default pre-routing rules
+		#
+		printf "%s\n" "add rule inet banIP pre-routing iifname != { ${wan_dev} } counter accept"
+		printf "%s\n" "add rule inet banIP pre-routing ct state invalid ${log_ct} counter name cnt-ctinvalid drop"
+		printf "%s\n" "add rule inet banIP pre-routing ip protocol icmp limit rate over ${ban_icmplimit}/second ${log_icmp} counter name cnt-icmpflood drop"
+		printf "%s\n" "add rule inet banIP pre-routing ip6 nexthdr icmpv6 limit rate over ${ban_icmplimit}/second ${log_icmp} counter name cnt-icmpflood drop"
+		printf "%s\n" "add rule inet banIP pre-routing meta l4proto udp ct state new limit rate over ${ban_udplimit}/second ${log_udp} counter name cnt-udpflood drop"
+		printf "%s\n" "add rule inet banIP pre-routing tcp flags & (fin|syn|rst|ack) == syn limit rate over ${ban_synlimit}/second ${log_syn} counter name cnt-synflood drop"
+		printf "%s\n" "add rule inet banIP pre-routing tcp flags & (fin|syn) == (fin|syn) ${log_tcp} counter name cnt-tcpinvalid drop"
+		printf "%s\n" "add rule inet banIP pre-routing tcp flags & (syn|rst) == (syn|rst) ${log_tcp} counter name cnt-tcpinvalid drop"
+		printf "%s\n" "add rule inet banIP pre-routing tcp flags & (fin|syn|rst|psh|ack|urg) < (fin) ${log_tcp} counter name cnt-tcpinvalid drop"
+		printf "%s\n" "add rule inet banIP pre-routing tcp flags & (fin|syn|rst|psh|ack|urg) == (fin|psh|urg) ${log_tcp} counter name cnt-tcpinvalid drop"
+
 		# default wan-input rules
 		#
-		printf "%s\n" "add rule inet banIP wan-input ct state established,related counter accept"
 		printf "%s\n" "add rule inet banIP wan-input iifname != { ${wan_dev} } counter accept"
+		printf "%s\n" "add rule inet banIP wan-input ct state established,related counter accept"
 		printf "%s\n" "add rule inet banIP wan-input meta nfproto ipv4 udp sport 67-68 udp dport 67-68 counter accept"
 		printf "%s\n" "add rule inet banIP wan-input meta nfproto ipv6 udp sport 547 udp dport 546 counter accept"
-		printf "%s\n" "add rule inet banIP wan-input meta nfproto ipv4 icmp type { echo-request } limit rate 1000/second counter accept"
-		printf "%s\n" "add rule inet banIP wan-input meta nfproto ipv6 icmpv6 type { echo-request } limit rate 1000/second counter accept"
-		printf "%s\n" "add rule inet banIP wan-input meta nfproto ipv6 icmpv6 type { nd-neighbor-advert, nd-neighbor-solicit, nd-router-advert} limit rate 1000/second ip6 hoplimit 1 counter accept"
-		printf "%s\n" "add rule inet banIP wan-input meta nfproto ipv6 icmpv6 type { nd-neighbor-advert, nd-neighbor-solicit, nd-router-advert} limit rate 1000/second ip6 hoplimit 255 counter accept"
+		printf "%s\n" "add rule inet banIP wan-input meta nfproto ipv6 icmpv6 type { nd-neighbor-advert, nd-neighbor-solicit, nd-router-advert} ip6 hoplimit 1 counter accept"
+		printf "%s\n" "add rule inet banIP wan-input meta nfproto ipv6 icmpv6 type { nd-neighbor-advert, nd-neighbor-solicit, nd-router-advert} ip6 hoplimit 255 counter accept"
+		[ -n "${allow_dport}" ] && printf "%s\n" "add rule inet banIP wan-input ${allow_dport} counter accept"
 
 		# default wan-forward rules
 		#
-		printf "%s\n" "add rule inet banIP wan-forward ct state established,related counter accept"
 		printf "%s\n" "add rule inet banIP wan-forward iifname != { ${wan_dev} } counter accept"
+		printf "%s\n" "add rule inet banIP wan-forward ct state established,related counter accept"
+		[ -n "${allow_dport}" ] && printf "%s\n" "add rule inet banIP wan-forward ${allow_dport} counter accept"
 
 		# default lan-forward rules
 		#
-		printf "%s\n" "add rule inet banIP lan-forward ct state established,related counter accept"
 		printf "%s\n" "add rule inet banIP lan-forward oifname != { ${wan_dev} } counter accept"
+		printf "%s\n" "add rule inet banIP lan-forward ct state established,related counter accept"
 		[ -n "${vlan_allow}" ] && printf "%s\n" "add rule inet banIP lan-forward iifname { ${vlan_allow} } counter accept"
 		[ -n "${vlan_block}" ] && printf "%s\n" "add rule inet banIP lan-forward iifname { ${vlan_block} } counter goto reject-chain"
 	} >"${file}"
@@ -628,7 +688,8 @@ f_nftinit() {
 	feed_log="$("${ban_nftcmd}" -f "${file}" 2>&1)"
 	feed_rc="${?}"
 
-	f_log "debug" "f_nftinit   ::: wan_dev: ${wan_dev}, vlan_allow: ${vlan_allow:-"-"}, vlan_block: ${vlan_block:-"-"}, priority: ${ban_nftpriority}, policy: ${ban_nftpolicy}, loglevel: ${ban_nftloglevel}, rc: ${feed_rc:-"-"}, log: ${feed_log:-"-"}"
+	f_log "debug" "f_nftinit   ::: wan_dev: ${wan_dev}, vlan_allow: ${vlan_allow:-"-"}, vlan_block: ${vlan_block:-"-"}, allowed_dports: ${allow_dport:-"-"}, priority: ${ban_nftpriority}, policy: ${ban_nftpolicy}, loglevel: ${ban_nftloglevel}, rc: ${feed_rc:-"-"}, log: ${feed_log:-"-"}"
+	: >"${file}"
 	return "${feed_rc}"
 }
 
@@ -636,7 +697,7 @@ f_nftinit() {
 #
 f_down() {
 	local log_input log_forwardwan log_forwardlan start_ts end_ts tmp_raw tmp_load tmp_file split_file ruleset_raw handle rc etag_rc
-	local expr cnt_set cnt_dl restore_rc feed_direction feed_rc feed_log feed_comp feed_proto feed_dport flag
+	local expr cnt_set cnt_dl restore_rc feed_direction feed_rc feed_log feed_comp feed_proto feed_dport feed_target
 	local feed="${1}" proto="${2}" feed_url="${3}" feed_rule="${4}" feed_flag="${5}"
 
 	start_ts="$(date +%s)"
@@ -652,6 +713,14 @@ f_down() {
 	[ "${ban_loginput}" = "1" ] && log_input="log level ${ban_nftloglevel} prefix \"banIP/inp-wan/${ban_blocktype}/${feed}: \""
 	[ "${ban_logforwardwan}" = "1" ] && log_forwardwan="log level ${ban_nftloglevel} prefix \"banIP/fwd-wan/${ban_blocktype}/${feed}: \""
 	[ "${ban_logforwardlan}" = "1" ] && log_forwardlan="log level ${ban_nftloglevel} prefix \"banIP/fwd-lan/reject/${feed}: \""
+
+	# set feed target
+	#
+	if [ "${ban_blocktype}" = "reject" ]; then
+		feed_target="goto reject-chain"
+	else
+		feed_target="drop"
+	fi
 
 	# set feed block direction
 	#
@@ -689,9 +758,9 @@ f_down() {
 	for flag in ${feed_flag}; do
 		if [ "${flag}" = "gz" ] && ! printf "%s" "${feed_comp}" | "${ban_grepcmd}" -qw "${flag}"; then
 			feed_comp="${flag}"
-		elif { [ "${flag}" = "tcp" ] || [ "${flag}" = "udp" ]; } && ! printf "%s" "${feed_proto}" | "${ban_grepcmd}" -qw "${flag}"; then
+		elif [ -z "${feed_proto}" ] && { [ "${flag}" = "tcp" ] || [ "${flag}" = "udp" ]; }; then
 			feed_proto="${flag}"
-		elif [ -n "${flag//[![:digit]]/}" ] && ! printf "%s" "${feed_dport}" | "${ban_grepcmd}" -qw "${flag}"; then
+		elif [ -n "${feed_proto}" ] && [ -n "${flag//[![:digit]-]/}" ] && ! printf "%s" "${feed_dport}" | "${ban_grepcmd}" -qw "${flag}"; then
 			if [ -z "${feed_dport}" ]; then
 				feed_dport="${flag}"
 			else
@@ -699,7 +768,7 @@ f_down() {
 			fi
 		fi
 	done
-	[ -n "${feed_dport}" ] && feed_dport="${feed_proto:-"tcp"} dport { ${feed_dport} }"
+	[ -n "${feed_dport}" ] && feed_dport="${feed_proto} dport { ${feed_dport} }"
 
 	# chain/rule maintenance
 	#
@@ -732,7 +801,7 @@ f_down() {
 				done
 			elif [ "${feed%v*}" = "asn" ]; then
 				for asn in ${ban_asn}; do
-					f_etag "${feed}" "${feed_url}AS${asn}" ".{asn}"
+					f_etag "${feed}" "${feed_url}AS${asn}" ".${asn}"
 					rc="${?}"
 					[ "${rc}" = "4" ] && break
 					etag_rc="$((etag_rc + rc))"
@@ -768,6 +837,7 @@ f_down() {
 				break
 			fi
 		done
+
 		if [ "${feed_rc}" = "0" ]; then
 			f_backup "allowlist" "${tmp_allow}"
 		elif [ -z "${restore_rc}" ] && [ "${feed_rc}" != "0" ]; then
@@ -795,22 +865,14 @@ f_down() {
 				printf "%s\n" "add set inet banIP ${feed} { type ipv4_addr; flags interval; auto-merge; policy ${ban_nftpolicy}; $(f_getelements "${tmp_file}") }"
 				if [ -z "${feed_direction##*input*}" ]; then
 					if [ "${ban_allowlistonly}" = "1" ]; then
-						if [ "${ban_blocktype}" = "reject" ]; then
-							printf "%s\n" "add rule inet banIP wan-input ip saddr != @${feed} ${log_input} counter goto reject-chain"
-						else
-							printf "%s\n" "add rule inet banIP wan-input ip saddr != @${feed} ${log_input} counter drop"
-						fi
+						printf "%s\n" "add rule inet banIP wan-input ip saddr != @${feed} ${log_input} counter ${feed_target}"
 					else
 						printf "%s\n" "add rule inet banIP wan-input ip saddr @${feed} counter accept"
 					fi
 				fi
 				if [ -z "${feed_direction##*forwardwan*}" ]; then
 					if [ "${ban_allowlistonly}" = "1" ]; then
-						if [ "${ban_blocktype}" = "reject" ]; then
-							printf "%s\n" "add rule inet banIP wan-forward ip saddr != @${feed} ${log_forwardwan} counter goto reject-chain"
-						else
-							printf "%s\n" "add rule inet banIP wan-forward ip saddr != @${feed} ${log_forwardwan} counter drop"
-						fi
+						printf "%s\n" "add rule inet banIP wan-forward ip saddr != @${feed} ${log_forwardwan} counter ${feed_target}"
 					else
 						printf "%s\n" "add rule inet banIP wan-forward ip saddr @${feed} counter accept"
 					fi
@@ -828,35 +890,28 @@ f_down() {
 				printf "%s\n" "add set inet banIP ${feed} { type ipv6_addr; flags interval; auto-merge; policy ${ban_nftpolicy}; $(f_getelements "${tmp_file}") }"
 				if [ -z "${feed_direction##*input*}" ]; then
 					if [ "${ban_allowlistonly}" = "1" ]; then
-						if [ "${ban_blocktype}" = "reject" ]; then
-							printf "%s\n" "add rule inet banIP wan-input ip6 saddr != @${feed} ${log_input} counter goto reject-chain"
-						else
-							printf "%s\n" "add rule inet banIP wan-input ip6 saddr != @${feed} ${log_input} counter drop"
-						fi
+						printf "%s\n" "add rule inet banIP wan-input ip6 saddr != @${feed} ${log_input} counter ${feed_target}"
 					else
 						printf "%s\n" "add rule inet banIP wan-input ip6 saddr @${feed} counter accept"
 					fi
 				fi
 				if [ -z "${feed_direction##*forwardwan*}" ]; then
 					if [ "${ban_allowlistonly}" = "1" ]; then
-						if [ "${ban_blocktype}" = "reject" ]; then
-							printf "%s\n" "add rule inet banIP wan-forward ip6 saddr != @${feed} ${log_forwardwan} counter goto reject-chain"
-						else
-							printf "%s\n" "add rule inet banIP wan-forward ip6 saddr != @${feed} ${log_forwardwan} counter drop"
-						fi
+						printf "%s\n" "add rule inet banIP wan-forward ip6 saddr != @${feed} ${log_forwardwan} counter ${feed_target}"
 					else
 						printf "%s\n" "add rule inet banIP wan-forward ip6 saddr @${feed} counter accept"
 					fi
 				fi
 				if [ -z "${feed_direction##*forwardlan*}" ]; then
 					if [ "${ban_allowlistonly}" = "1" ]; then
-						printf "%s\n" "add rule inet banIP lan-forward ip6 daddr != @${feed} ${log_forwardlan} counter goto reject-chain"
+						printf "%s\n" "add rule inet banIP lan-forward ip6 daddr != @${feed} ${log_forwardlan} counter ${feed_target}"
 					else
 						printf "%s\n" "add rule inet banIP lan-forward ip6 daddr @${feed} counter accept"
 					fi
 				fi
 			fi
 		} >"${tmp_nft}"
+		: >"${tmp_flush}" >"${tmp_raw}" >"${tmp_file}"
 		feed_rc="0"
 	elif [ "${feed%v*}" = "blocklist" ]; then
 		{
@@ -881,13 +936,8 @@ f_down() {
 				fi
 				"${ban_awkcmd}" '{ORS=" ";print}' "${tmp_split}" 2>/dev/null >"${tmp_file}"
 				printf "%s\n" "add set inet banIP ${feed} { type ipv4_addr; flags interval, timeout; auto-merge; policy ${ban_nftpolicy}; $(f_getelements "${tmp_file}") }"
-				if [ "${ban_blocktype}" = "reject" ]; then
-					[ -z "${feed_direction##*input*}" ] && printf "%s\n" "add rule inet banIP wan-input ip saddr @${feed} ${log_input} counter goto reject-chain"
-					[ -z "${feed_direction##*forwardwan*}" ] && printf "%s\n" "add rule inet banIP wan-forward ip saddr @${feed} ${log_forwardwan} counter goto reject-chain"
-				else
-					[ -z "${feed_direction##*input*}" ] && printf "%s\n" "add rule inet banIP wan-input ip saddr @${feed} ${log_input} counter drop"
-					[ -z "${feed_direction##*forwardwan*}" ] && printf "%s\n" "add rule inet banIP wan-forward ip saddr @${feed} ${log_forwardwan} counter drop"
-				fi
+				[ -z "${feed_direction##*input*}" ] && printf "%s\n" "add rule inet banIP wan-input ip saddr @${feed} ${log_input} counter ${feed_target}"
+				[ -z "${feed_direction##*forwardwan*}" ] && printf "%s\n" "add rule inet banIP wan-forward ip saddr @${feed} ${log_forwardwan} counter ${feed_target}"
 				[ -z "${feed_direction##*forwardlan*}" ] && printf "%s\n" "add rule inet banIP lan-forward ip daddr @${feed} ${log_forwardlan} counter goto reject-chain"
 			elif [ "${proto}" = "6" ]; then
 				if [ "${ban_deduplicate}" = "1" ]; then
@@ -902,16 +952,12 @@ f_down() {
 				fi
 				"${ban_awkcmd}" '{ORS=" ";print}' "${tmp_split}" 2>/dev/null >"${tmp_file}"
 				printf "%s\n" "add set inet banIP ${feed} { type ipv6_addr; flags interval, timeout; auto-merge; policy ${ban_nftpolicy}; $(f_getelements "${tmp_file}") }"
-				if [ "${ban_blocktype}" = "reject" ]; then
-					[ -z "${feed_direction##*input*}" ] && printf "%s\n" "add rule inet banIP wan-input ip6 saddr @${feed} ${log_input} counter goto reject-chain"
-					[ -z "${feed_direction##*forwardwan*}" ] && printf "%s\n" "add rule inet banIP wan-forward ip6 saddr @${feed} ${log_forwardwan} counter goto reject-chain"
-				else
-					[ -z "${feed_direction##*input*}" ] && printf "%s\n" "add rule inet banIP wan-input ip6 saddr @${feed} ${log_input} counter drop"
-					[ -z "${feed_direction##*forwardwan*}" ] && printf "%s\n" "add rule inet banIP wan-forward ip6 saddr @${feed} ${log_forwardwan} counter drop"
-				fi
+				[ -z "${feed_direction##*input*}" ] && printf "%s\n" "add rule inet banIP wan-input ip6 saddr @${feed} ${log_input} counter ${feed_target}"
+				[ -z "${feed_direction##*forwardwan*}" ] && printf "%s\n" "add rule inet banIP wan-forward ip6 saddr @${feed} ${log_forwardwan} counter ${feed_target}"
 				[ -z "${feed_direction##*forwardlan*}" ] && printf "%s\n" "add rule inet banIP lan-forward ip6 daddr @${feed} ${log_forwardlan} counter goto reject-chain"
 			fi
 		} >"${tmp_nft}"
+		: >"${tmp_flush}" >"${tmp_raw}" >"${tmp_file}"
 		feed_rc="0"
 
 	# handle external feeds
@@ -925,7 +971,7 @@ f_down() {
 				feed_rc="${?}"
 				[ "${feed_rc}" = "0" ] && "${ban_catcmd}" "${tmp_raw}" 2>/dev/null >>"${tmp_load}"
 			done
-			rm -f "${tmp_raw}"
+			: >"${tmp_raw}"
 
 		# handle asn downloads
 		#
@@ -935,7 +981,7 @@ f_down() {
 				feed_rc="${?}"
 				[ "${feed_rc}" = "0" ] && "${ban_catcmd}" "${tmp_raw}" 2>/dev/null >>"${tmp_load}"
 			done
-			rm -f "${tmp_raw}"
+			: >"${tmp_raw}"
 
 		# handle compressed downloads
 		#
@@ -943,7 +989,7 @@ f_down() {
 			feed_log="$("${ban_fetchcmd}" ${ban_fetchparm} "${tmp_raw}" "${feed_url}" 2>&1)"
 			feed_rc="${?}"
 			[ "${feed_rc}" = "0" ] && "${ban_zcatcmd}" "${tmp_raw}" 2>/dev/null >"${tmp_load}"
-			rm -f "${tmp_raw}"
+			: >"${tmp_raw}"
 
 		# handle normal downloads
 		#
@@ -970,27 +1016,28 @@ f_down() {
 		# deduplicate Sets
 		#
 		if [ "${ban_deduplicate}" = "1" ] && [ "${feed_url}" != "local" ]; then
-			"${ban_awkcmd}" "${feed_rule}" "${tmp_load}" 2>/dev/null >"${tmp_raw}"
+			"${ban_awkcmd}" '{sub("\r$", ""); print}' "${tmp_load}" 2>/dev/null | "${ban_awkcmd}" "${feed_rule}" 2>/dev/null >"${tmp_raw}"
 			"${ban_awkcmd}" 'NR==FNR{member[$0];next}!($0 in member)' "${ban_tmpfile}.deduplicate" "${tmp_raw}" 2>/dev/null | tee -a "${ban_tmpfile}.deduplicate" >"${tmp_split}"
 		else
-			"${ban_awkcmd}" "${feed_rule}" "${tmp_load}" 2>/dev/null >"${tmp_split}"
+			"${ban_awkcmd}" '{sub("\r$", ""); print}' "${tmp_load}" 2>/dev/null | "${ban_awkcmd}" "${feed_rule}" 2>/dev/null >"${tmp_split}"
 		fi
 		feed_rc="${?}"
 
 		# split Sets
 		#
 		if [ "${feed_rc}" = "0" ]; then
-			if [ -n "${ban_splitsize//[![:digit]]/}" ] && [ "${ban_splitsize//[![:digit]]/}" -gt "0" ]; then
+			if [ -n "${ban_splitsize//[![:digit]]/}" ] && [ "${ban_splitsize//[![:digit]]/}" -gt "512" ]; then
 				if ! "${ban_awkcmd}" "NR%${ban_splitsize//[![:digit]]/}==1{file=\"${tmp_file}.\"++i;}{ORS=\" \";print > file}" "${tmp_split}" 2>/dev/null; then
-					rm -f "${tmp_file}".*
 					f_log "info" "can't split Set '${feed}' to size '${ban_splitsize//[![:digit]]/}'"
+					rm -f "${tmp_file}".*
 				fi
 			else
 				"${ban_awkcmd}" '{ORS=" ";print}' "${tmp_split}" 2>/dev/null >"${tmp_file}.1"
 			fi
 			feed_rc="${?}"
 		fi
-		rm -f "${tmp_raw}" "${tmp_load}"
+		: >"${tmp_raw}" >"${tmp_load}"
+
 		if [ "${feed_rc}" = "0" ] && [ "${proto}" = "4" ]; then
 			{
 				# nft header (IPv4 Set)
@@ -1001,13 +1048,8 @@ f_down() {
 
 				# input and forward rules
 				#
-				if [ "${ban_blocktype}" = "reject" ]; then
-					[ -z "${feed_direction##*input*}" ] && printf "%s\n" "add rule inet banIP wan-input ${feed_dport} ip saddr @${feed} ${log_input} counter goto reject-chain"
-					[ -z "${feed_direction##*forwardwan*}" ] && printf "%s\n" "add rule inet banIP wan-forward ${feed_dport} ip saddr @${feed} ${log_forwardwan} counter goto reject-chain"
-				else
-					[ -z "${feed_direction##*input*}" ] && printf "%s\n" "add rule inet banIP wan-input ${feed_dport} ip saddr @${feed} ${log_input} counter drop"
-					[ -z "${feed_direction##*forwardwan*}" ] && printf "%s\n" "add rule inet banIP wan-forward ${feed_dport} ip saddr @${feed} ${log_forwardwan} counter drop"
-				fi
+				[ -z "${feed_direction##*input*}" ] && printf "%s\n" "add rule inet banIP wan-input ${feed_dport} ip saddr @${feed} ${log_input} counter ${feed_target}"
+				[ -z "${feed_direction##*forwardwan*}" ] && printf "%s\n" "add rule inet banIP wan-forward ${feed_dport} ip saddr @${feed} ${log_forwardwan} counter ${feed_target}"
 				[ -z "${feed_direction##*forwardlan*}" ] && printf "%s\n" "add rule inet banIP lan-forward ${feed_dport} ip daddr @${feed} ${log_forwardlan} counter goto reject-chain"
 			} >"${tmp_nft}"
 		elif [ "${feed_rc}" = "0" ] && [ "${proto}" = "6" ]; then
@@ -1020,16 +1062,12 @@ f_down() {
 
 				# input and forward rules
 				#
-				if [ "${ban_blocktype}" = "reject" ]; then
-					[ -z "${feed_direction##*input*}" ] && printf "%s\n" "add rule inet banIP wan-input ${feed_dport} ip6 saddr @${feed} ${log_input} counter goto reject-chain"
-					[ -z "${feed_direction##*forwardwan*}" ] && printf "%s\n" "add rule inet banIP wan-forward ${feed_dport} ip6 saddr @${feed} ${log_forwardwan} counter goto reject-chain"
-				else
-					[ -z "${feed_direction##*input*}" ] && printf "%s\n" "add rule inet banIP wan-input ${feed_dport} ip6 saddr @${feed} ${log_input} counter drop"
-					[ -z "${feed_direction##*forwardwan*}" ] && printf "%s\n" "add rule inet banIP wan-forward ${feed_dport} ip6 saddr @${feed} ${log_forwardwan} counter drop"
-				fi
+				[ -z "${feed_direction##*input*}" ] && printf "%s\n" "add rule inet banIP wan-input ${feed_dport} ip6 saddr @${feed} ${log_input} counter ${feed_target}"
+				[ -z "${feed_direction##*forwardwan*}" ] && printf "%s\n" "add rule inet banIP wan-forward ${feed_dport} ip6 saddr @${feed} ${log_forwardwan} counter ${feed_target}"
 				[ -z "${feed_direction##*forwardlan*}" ] && printf "%s\n" "add rule inet banIP lan-forward ${feed_dport} ip6 daddr @${feed} ${log_forwardlan} counter goto reject-chain"
 			} >"${tmp_nft}"
 		fi
+		: >"${tmp_flush}" >"${tmp_file}.1"
 	fi
 
 	# load generated nft file in banIP table
@@ -1039,6 +1077,7 @@ f_down() {
 			cnt_dl="$("${ban_awkcmd}" 'END{printf "%d",NR}' "${tmp_allow}" 2>/dev/null)"
 		else
 			cnt_dl="$("${ban_awkcmd}" 'END{printf "%d",NR}' "${tmp_split}" 2>/dev/null)"
+			: >"${tmp_split}"
 		fi
 		if [ "${cnt_dl:-"0"}" -gt "0" ] || [ "${feed_url}" = "local" ] || [ "${feed%v*}" = "allowlist" ] || [ "${feed%v*}" = "blocklist" ]; then
 			feed_log="$("${ban_nftcmd}" -f "${tmp_nft}" 2>&1)"
@@ -1048,15 +1087,13 @@ f_down() {
 			#
 			if [ "${feed_rc}" = "0" ]; then
 				for split_file in "${tmp_file}".*; do
-					[ ! -f "${split_file}" ] && break
-					if [ "${split_file##*.}" = "1" ]; then
-						rm -f "${split_file}"
-						continue
-					fi
-					if ! "${ban_nftcmd}" add element inet banIP "${feed}" "{ $("${ban_catcmd}" "${split_file}") }" >/dev/null 2>&1; then
+					[ ! -s "${split_file}" ] && continue
+					"${ban_sedcmd}" -i "1 i #!/usr/sbin/nft -f\nadd element inet banIP "${feed}" { " "${split_file}"
+					printf "%s\n" "}" >> "${split_file}"
+					if ! "${ban_nftcmd}" -f "${split_file}" >/dev/null 2>&1; then
 						f_log "info" "can't add split file '${split_file##*.}' to Set '${feed}'"
 					fi
-					rm -f "${split_file}"
+					: >"${split_file}"
 				done
 				if [ "${ban_debug}" = "1" ] && [ "${ban_reportelements}" = "1" ]; then
 					cnt_set="$("${ban_nftcmd}" -j list set inet banIP "${feed}" 2>/dev/null | "${ban_jsoncmd}" -qe '@.nftables[*].set.elem[*]' | wc -l 2>/dev/null)"
@@ -1066,7 +1103,7 @@ f_down() {
 			f_log "info" "skip empty feed '${feed}'"
 		fi
 	fi
-	rm -f "${tmp_split}" "${tmp_nft}"
+	: >"${tmp_nft}"
 	end_ts="$(date +%s)"
 
 	f_log "debug" "f_down      ::: feed: ${feed}, cnt_dl: ${cnt_dl:-"-"}, cnt_set: ${cnt_set:-"-"}, split_size: ${ban_splitsize:-"-"}, time: $((end_ts - start_ts)), rc: ${feed_rc:-"-"}, log: ${feed_log:-"-"}"
@@ -1110,7 +1147,7 @@ f_rmset() {
 	json_get_keys feedlist
 	tmp_del="${ban_tmpfile}.final.delete"
 	ruleset_raw="$("${ban_nftcmd}" -tj list ruleset 2>/dev/null)"
-	table_sets="$(printf "%s\n" "${ruleset_raw}" | "${ban_jsoncmd}" -qe '@.nftables[@.set.table="banIP"].set.name')"
+	table_sets="$(printf "%s\n" "${ruleset_raw}" | "${ban_jsoncmd}" -qe '@.nftables[@.set.table="banIP"&&@.set.family="inet"].set.name')"
 	{
 		printf "%s\n\n" "#!/usr/sbin/nft -f"
 		for item in ${table_sets}; do
@@ -1137,7 +1174,7 @@ f_rmset() {
 		feed_log="$("${ban_nftcmd}" -f "${tmp_del}" 2>&1)"
 		feed_rc="${?}"
 	fi
-	rm -f "${tmp_del}"
+	: >"${tmp_del}"
 
 	f_log "debug" "f_rmset     ::: sets: ${del_set:-"-"}, rc: ${feed_rc:-"-"}, log: ${feed_log:-"-"}"
 }
@@ -1153,7 +1190,7 @@ f_genstatus() {
 			end_time="$(date "+%s")"
 			duration="$(((end_time - ban_starttime) / 60))m $(((end_time - ban_starttime) % 60))s"
 		fi
-		table_sets="$("${ban_nftcmd}" -tj list ruleset 2>/dev/null | "${ban_jsoncmd}" -qe '@.nftables[@.set.table="banIP"].set.name')"
+		table_sets="$("${ban_nftcmd}" -tj list ruleset 2>/dev/null | "${ban_jsoncmd}" -qe '@.nftables[@.set.table="banIP"&&@.set.family="inet"].set.name')"
 		if [ "${ban_reportelements}" = "1" ]; then
 			for object in ${table_sets}; do
 				cnt_elements="$((cnt_elements + $("${ban_nftcmd}" -j list set inet banIP "${object}" 2>/dev/null | "${ban_jsoncmd}" -qe '@.nftables[*].set.elem[*]' | wc -l 2>/dev/null)))"
@@ -1202,7 +1239,7 @@ f_genstatus() {
 	json_close_array
 	json_add_string "nft_info" "priority: ${ban_nftpriority}, policy: ${ban_nftpolicy}, loglevel: ${ban_nftloglevel}, expiry: ${ban_nftexpiry:-"-"}"
 	json_add_string "run_info" "base: ${ban_basedir}, backup: ${ban_backupdir}, report: ${ban_reportdir}"
-	json_add_string "run_flags" "auto: $(f_char ${ban_autodetect}), proto (4/6): $(f_char ${ban_protov4})/$(f_char ${ban_protov6}), log (wan-inp/wan-fwd/lan-fwd): $(f_char ${ban_loginput})/$(f_char ${ban_logforwardwan})/$(f_char ${ban_logforwardlan}), dedup: $(f_char ${ban_deduplicate}), split: $(f_char ${split}), custom feed: $(f_char ${custom_feed}), allowed only: $(f_char ${ban_allowlistonly})"
+	json_add_string "run_flags" "auto: $(f_char ${ban_autodetect}), proto (4/6): $(f_char ${ban_protov4})/$(f_char ${ban_protov6}), log (pre/inp/fwd/lan): $(f_char ${ban_logprerouting})/$(f_char ${ban_loginput})/$(f_char ${ban_logforwardwan})/$(f_char ${ban_logforwardlan}), dedup: $(f_char ${ban_deduplicate}), split: $(f_char ${split}), custom feed: $(f_char ${custom_feed}), allowed only: $(f_char ${ban_allowlistonly})"
 	json_add_string "last_run" "${runtime:-"-"}"
 	json_add_string "system_info" "cores: ${ban_cores}, memory: ${ban_memory}, device: ${ban_sysver}"
 	json_dump >"${ban_rtfile}"
@@ -1284,12 +1321,12 @@ f_lookup() {
 		cnt_domain="$((cnt_domain + 1))"
 	done
 	if [ -n "${elementsv4}" ]; then
-		if ! "${ban_nftcmd}" add element inet banIP "${feed}v4" "{ ${elementsv4} }" >/dev/null 2>&1; then
+		if ! "${ban_nftcmd}" add element inet banIP "${feed}v4" { ${elementsv4} } >/dev/null 2>&1; then
 			f_log "info" "can't add lookup file to Set '${feed}v4'"
 		fi
 	fi
 	if [ -n "${elementsv6}" ]; then
-		if ! "${ban_nftcmd}" add element inet banIP "${feed}v6" "{ ${elementsv6} }" >/dev/null 2>&1; then
+		if ! "${ban_nftcmd}" add element inet banIP "${feed}v6" { ${elementsv6} } >/dev/null 2>&1; then
 			f_log "info" "can't add lookup file to Set '${feed}v6'"
 		fi
 	fi
@@ -1303,8 +1340,8 @@ f_lookup() {
 #
 f_report() {
 	local report_jsn report_txt tmp_val ruleset_raw item table_sets set_cnt set_input set_forwardwan set_forwardlan set_cntinput set_cntforwardwan set_cntforwardlan set_proto set_dport set_details
-	local expr detail jsnval timestamp autoadd_allow autoadd_block sum_sets sum_setinput sum_setforwardwan sum_setforwardlan sum_setelements sum_cntinput sum_cntforwardwan sum_cntforwardlan output="${1}"
-
+	local expr detail jsnval timestamp autoadd_allow autoadd_block sum_sets sum_setinput sum_setforwardwan sum_setforwardlan sum_setelements sum_cntinput sum_cntforwardwan sum_cntforwardlan
+	local sum_synflood sum_udpflood sum_icmpflood sum_ctinvalid sum_tcpinvalid output="${1}"
 	[ -z "${ban_dev}" ] && f_conf
 	f_mkdir "${ban_reportdir}"
 	report_jsn="${ban_reportdir}/ban_report.jsn"
@@ -1313,7 +1350,7 @@ f_report() {
 	# json output preparation
 	#
 	ruleset_raw="$("${ban_nftcmd}" -tj list ruleset 2>/dev/null)"
-	table_sets="$(printf "%s" "${ruleset_raw}" | "${ban_jsoncmd}" -qe '@.nftables[@.set.table="banIP"].set.name')"
+	table_sets="$(printf "%s" "${ruleset_raw}" | "${ban_jsoncmd}" -qe '@.nftables[@.set.table="banIP"&&@.set.family="inet"].set.name')"
 	sum_sets="0"
 	sum_setinput="0"
 	sum_setforwardwan="0"
@@ -1322,6 +1359,11 @@ f_report() {
 	sum_cntinput="0"
 	sum_cntforwardwan="0"
 	sum_cntforwardlan="0"
+	sum_synflood="$(printf "%s" "${ruleset_raw}" | "${ban_jsoncmd}" -qe '@.nftables[@.counter.name="cnt-synflood"].*.packets')"
+	sum_udpflood="$(printf "%s" "${ruleset_raw}" | "${ban_jsoncmd}" -qe '@.nftables[@.counter.name="cnt-udpflood"].*.packets')"
+	sum_icmpflood="$(printf "%s" "${ruleset_raw}" | "${ban_jsoncmd}" -qe '@.nftables[@.counter.name="cnt-icmpflood"].*.packets')"
+	sum_ctinvalid="$(printf "%s" "${ruleset_raw}" | "${ban_jsoncmd}" -qe '@.nftables[@.counter.name="cnt-ctinvalid"].*.packets')"
+	sum_tcpinvalid="$(printf "%s" "${ruleset_raw}" | "${ban_jsoncmd}" -qe '@.nftables[@.counter.name="cnt-tcpinvalid"].*.packets')"
 	timestamp="$(date "+%Y-%m-%d %H:%M:%S")"
 	: >"${report_jsn}"
 	{
@@ -1344,12 +1386,6 @@ f_report() {
 				[ "${expr}" = "1" ] && [ -z "${set_dport}" ] && set_dport="$(printf "%s" "${ruleset_raw}" | "${ban_jsoncmd}" -ql1 -e "@.nftables[@.rule.table=\"banIP\"&&@.rule.chain=\"lan-forward\"][@.expr[${expr}].match.right=\"@${item}\"].expr[*].match.right.set")"
 				[ "${expr}" = "1" ] && [ -z "${set_proto}" ] && set_proto="$(printf "%s" "${ruleset_raw}" | "${ban_jsoncmd}" -ql1 -e "@.nftables[@.rule.table=\"banIP\"&&@.rule.chain=\"lan-forward\"][@.expr[${expr}].match.right=\"@${item}\"].expr[*].match.left.payload.protocol")"
 			done
-			if [ -n "${set_dport}" ]; then
-				set_dport="${set_dport//[\{\}\":]/}"
-				set_dport="${set_dport#\[ *}"
-				set_dport="${set_dport%* \]}"
-				set_dport="${set_proto}: $(f_trim "${set_dport}")"
-			fi
 			if [ "${ban_reportelements}" = "1" ]; then
 				set_cnt="$("${ban_nftcmd}" -j list set inet banIP "${item}" 2>/dev/null | "${ban_jsoncmd}" -qe '@.nftables[*].set.elem[*]' | wc -l 2>/dev/null)"
 				sum_setelements="$((sum_setelements + set_cnt))"
@@ -1357,8 +1393,14 @@ f_report() {
 				set_cnt=""
 				sum_setelements="n/a"
 			fi
+			if [ -n "${set_dport}" ]; then
+				set_dport="${set_dport//[\{\}\":]/}"
+				set_dport="${set_dport#\[ *}"
+				set_dport="${set_dport%* \]}"
+				set_dport="${set_proto}: $(f_trim "${set_dport}")"
+			fi
 			if [ -n "${set_cntinput}" ]; then
-				set_input="OK"
+				set_input="ON"
 				sum_setinput="$((sum_setinput + 1))"
 				sum_cntinput="$((sum_cntinput + set_cntinput))"
 			else
@@ -1366,7 +1408,7 @@ f_report() {
 				set_cntinput=""
 			fi
 			if [ -n "${set_cntforwardwan}" ]; then
-				set_forwardwan="OK"
+				set_forwardwan="ON"
 				sum_setforwardwan="$((sum_setforwardwan + 1))"
 				sum_cntforwardwan="$((sum_cntforwardwan + set_cntforwardwan))"
 			else
@@ -1374,7 +1416,7 @@ f_report() {
 				set_cntforwardwan=""
 			fi
 			if [ -n "${set_cntforwardlan}" ]; then
-				set_forwardlan="OK"
+				set_forwardlan="ON"
 				sum_setforwardlan="$((sum_setforwardlan + 1))"
 				sum_cntforwardlan="$((sum_cntforwardlan + set_cntforwardlan))"
 			else
@@ -1398,6 +1440,11 @@ f_report() {
 		printf "\t%s\n" "\"timestamp\": \"${timestamp}\","
 		printf "\t%s\n" "\"autoadd_allow\": \"$("${ban_grepcmd}" -c "added on ${timestamp% *}" "${ban_allowlist}")\","
 		printf "\t%s\n" "\"autoadd_block\": \"$("${ban_grepcmd}" -c "added on ${timestamp% *}" "${ban_blocklist}")\","
+		printf "\t%s\n" "\"sum_synflood\": \"${sum_synflood}\","
+		printf "\t%s\n" "\"sum_udpflood\": \"${sum_udpflood}\","
+		printf "\t%s\n" "\"sum_icmpflood\": \"${sum_icmpflood}\","
+		printf "\t%s\n" "\"sum_ctinvalid\": \"${sum_ctinvalid}\","
+		printf "\t%s\n" "\"sum_tcpinvalid\": \"${sum_tcpinvalid}\","
 		printf "\t%s\n" "\"sum_sets\": \"${sum_sets}\","
 		printf "\t%s\n" "\"sum_setinput\": \"${sum_setinput}\","
 		printf "\t%s\n" "\"sum_setforwardwan\": \"${sum_setforwardwan}\","
@@ -1418,6 +1465,11 @@ f_report() {
 			json_get_var timestamp "timestamp" >/dev/null 2>&1
 			json_get_var autoadd_allow "autoadd_allow" >/dev/null 2>&1
 			json_get_var autoadd_block "autoadd_block" >/dev/null 2>&1
+			json_get_var sum_synflood "sum_synflood" >/dev/null 2>&1
+			json_get_var sum_udpflood "sum_udpflood" >/dev/null 2>&1
+			json_get_var sum_icmpflood "sum_icmpflood" >/dev/null 2>&1
+			json_get_var sum_ctinvalid "sum_ctinvalid" >/dev/null 2>&1
+			json_get_var sum_tcpinvalid "sum_tcpinvalid" >/dev/null 2>&1
 			json_get_var sum_sets "sum_sets" >/dev/null 2>&1
 			json_get_var sum_setinput "sum_setinput" >/dev/null 2>&1
 			json_get_var sum_setforwardwan "sum_setforwardwan" >/dev/null 2>&1
@@ -1430,8 +1482,14 @@ f_report() {
 				printf "%s\n%s\n%s\n" ":::" "::: banIP Set Statistics" ":::"
 				printf "%s\n" "    Timestamp: ${timestamp}"
 				printf "%s\n" "    ------------------------------"
-				printf "%s\n" "    auto-added to allowlist today: ${autoadd_allow}"
-				printf "%s\n\n" "    auto-added to blocklist today: ${autoadd_block}"
+				printf "%s\n" "    blocked syn-flood packets  : ${sum_synflood}"
+				printf "%s\n" "    blocked udp-flood packets  : ${sum_udpflood}"
+				printf "%s\n" "    blocked icmp-flood packets : ${sum_icmpflood}"
+				printf "%s\n" "    blocked invalid ct packets : ${sum_ctinvalid}"
+				printf "%s\n" "    blocked invalid tcp packets: ${sum_tcpinvalid}"
+				printf "%s\n" "    ----------"
+				printf "%s\n" "    auto-added IPs to allowlist: ${autoadd_allow}"
+				printf "%s\n\n" "    auto-added IPs to blocklist: ${autoadd_block}"
 				json_select "sets" >/dev/null 2>&1
 				json_get_keys table_sets >/dev/null 2>&1
 				if [ -n "${table_sets}" ]; then
@@ -1488,10 +1546,10 @@ f_search() {
 	local item table_sets ip proto hold cnt result_flag="/var/run/banIP.search" input="${1}"
 
 	if [ -n "${input}" ]; then
-		ip="$(printf "%s" "${input}" | "${ban_awkcmd}" 'BEGIN{RS="(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\/(1?[0-9]|2?[0-9]|3?[0-2]))?[[:space:]]*$)"}{printf "%s",RT}')"
+		ip="$(printf "%s" "${input}" | "${ban_awkcmd}" 'BEGIN{RS="(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?[[:space:]]*$)"}{printf "%s",RT}')"
 		[ -n "${ip}" ] && proto="v4"
 		if [ -z "${proto}" ]; then
-			ip="$(printf "%s" "${input}" | "${ban_awkcmd}" 'BEGIN{RS="(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\/(1?[0-2][0-8]|[0-9][0-9]))?)([[:space:]].*|$)"}{printf "%s",RT}')"
+			ip="$(printf "%s" "${input}" | "${ban_awkcmd}" 'BEGIN{RS="(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)([[:space:]].*|$)"}{printf "%s",RT}')"
 			[ -n "${ip}" ] && proto="v6"
 		fi
 	fi
@@ -1564,7 +1622,7 @@ f_mail() {
 # log monitor
 #
 f_monitor() {
-	local daemon logread_cmd loglimit_cmd nft_expiry line proto ip log_raw log_count rdap_log rdap_rc rdap_elements rdap_info
+	local daemon logread_cmd loglimit_cmd nft_expiry line proto ip log_raw log_count rdap_log rdap_rc rdap_prefix rdap_length rdap_info
 
 	if [ -f "${ban_logreadfile}" ]; then
 		logread_cmd="${ban_logreadcmd} -qf ${ban_logreadfile} 2>/dev/null | ${ban_grepcmd} -e \"${ban_logterm%%??}\" 2>/dev/null"
@@ -1609,19 +1667,22 @@ f_monitor() {
 							rdap_log="$("${ban_fetchcmd}" ${ban_rdapparm} "${ban_rdapfile}" "${ban_rdapurl}${ip}" 2>&1)"
 							rdap_rc="${?}"
 							if [ "${rdap_rc}" = "0" ] && [ -s "${ban_rdapfile}" ]; then
-								rdap_elements="$(jsonfilter -i "${ban_rdapfile}" -qe '@.cidr0_cidrs.*' | awk 'BEGIN{FS="[\" ]"}{printf "%s/%s, ",$6,$11}')"
-								rdap_info="$(jsonfilter -i "${ban_rdapfile}" -qe '@.country' -qe '@.notices[@.title="Source"].description[1]' | awk 'BEGIN{RS="";FS="\n"}{printf "%s, %s",$1,$2}')"
-								if [ -n "${rdap_elements//\/*/}" ]; then
-									if "${ban_nftcmd}" add element inet banIP "blocklist${proto}" "{ ${rdap_elements%%??} ${nft_expiry} }" >/dev/null 2>&1; then
-										f_log "info" "add IP range '${rdap_elements%%??}' (source: ${rdap_info:-"-"} ::: expiry: ${ban_nftexpiry:-"-"}) to blocklist${proto} set"
+								[ "${proto}" = "v4" ] && rdap_prefix="$(jsonfilter -l1 -i "${ban_rdapfile}" -qe '@.cidr0_cidrs.*.v4prefix')"
+								[ "${proto}" = "v6" ] && rdap_prefix="$(jsonfilter -l1 -i "${ban_rdapfile}" -qe '@.cidr0_cidrs.*.v6prefix')"
+								rdap_length="$(jsonfilter -l1 -i "${ban_rdapfile}" -qe '@.cidr0_cidrs.*.length')"
+								rdap_info="$(jsonfilter -l1 -i "${ban_rdapfile}" -qe '@.country' -qe '@.notices[@.title="Source"].description[1]' | awk 'BEGIN{RS="";FS="\n"}{printf "%s, %s",$1,$2}')"
+								[ -z "${rdap_info}" ] && rdap_info="$(jsonfilter -l1 -i "${ban_rdapfile}" -qe '@.notices[0].links[0].value' | awk 'BEGIN{FS="[/.]"}{printf"%s, %s","n/a",toupper($4)}')"
+								if [ -n "${rdap_prefix}" ] && [ -n "${rdap_length}" ]; then
+									if "${ban_nftcmd}" add element inet banIP "blocklist${proto}" { ${rdap_prefix}/${rdap_length} ${nft_expiry} } >/dev/null 2>&1; then
+										f_log "info" "add IP range '${rdap_prefix}/${rdap_length}' (source: ${rdap_info:-"n/a"} ::: expiry: ${ban_nftexpiry:-"-"}) to blocklist${proto} set"
 									fi
 								fi
 							else
 								f_log "info" "rdap request failed (rc: ${rdap_rc:-"-"}/log: ${rdap_log})"
 							fi
 						fi
-						if [ "${ban_autoblocksubnet}" = "0" ] || [ "${rdap_rc}" != "0" ] || [ ! -s "${ban_rdapfile}" ] || [ -z "${rdap_elements//\/*/}" ]; then
-							if "${ban_nftcmd}" add element inet banIP "blocklist${proto}" "{ ${ip} ${nft_expiry} }" >/dev/null 2>&1; then
+						if [ "${ban_autoblocksubnet}" = "0" ] || [ "${rdap_rc}" != "0" ] || [ ! -s "${ban_rdapfile}" ] || [ -z "${rdap_prefix}" ] || [ -z "${rdap_length}" ]; then
+							if "${ban_nftcmd}" add element inet banIP "blocklist${proto}" { ${ip} ${nft_expiry} } >/dev/null 2>&1; then
 								f_log "info" "add IP '${ip}' (expiry: ${ban_nftexpiry:-"-"}) to blocklist${proto} set"
 							fi
 						fi

--- a/net/banip/files/banip-service.sh
+++ b/net/banip/files/banip-service.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # banIP main service script - ban incoming and outgoing IPs via named nftables Sets
-# Copyright (c) 2018-2023 Dirk Brenken (dev@brenken.org)
+# Copyright (c) 2018-2024 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 
 # (s)hellcheck exceptions
@@ -24,8 +24,8 @@ f_getif
 f_getdev
 f_getuplink
 f_mkdir "${ban_backupdir}"
-f_mkfile "${ban_blocklist}"
 f_mkfile "${ban_allowlist}"
+f_mkfile "${ban_blocklist}"
 
 # firewall check
 #
@@ -44,13 +44,13 @@ if [ "${ban_action}" != "reload" ]; then
 	fi
 fi
 
-# init nft namespace
+# init banIP nftables namespace
 #
 if [ "${ban_action}" != "reload" ] || ! "${ban_nftcmd}" -t list set inet banIP allowlistv4MAC >/dev/null 2>&1; then
 	if f_nftinit "${ban_tmpfile}".init.nft; then
-		f_log "info" "initialize nft namespace"
+		f_log "info" "initialize banIP nftables namespace"
 	else
-		f_log "err" "can't initialize nft namespace"
+		f_log "err" "can't initialize banIP nftables namespace"
 	fi
 fi
 
@@ -99,7 +99,7 @@ for feed in allowlist ${ban_feed} blocklist; do
 		continue
 	fi
 
-	# handle IPv4/IPv6 feeds with the same/single download URL
+	# handle IPv4/IPv6 feeds with a single download URL
 	#
 	if [ "${feed_url_4}" = "${feed_url_6}" ]; then
 		if [ "${ban_protov4}" = "1" ] && [ -n "${feed_url_4}" ] && [ -n "${feed_rule_4}" ]; then
@@ -115,7 +115,8 @@ for feed in allowlist ${ban_feed} blocklist; do
 		fi
 		continue
 	fi
-	# handle IPv4/IPv6 feeds with separated download URLs
+
+	# handle IPv4/IPv6 feeds with separate download URLs
 	#
 	if [ "${ban_protov4}" = "1" ] && [ -n "${feed_url_4}" ] && [ -n "${feed_rule_4}" ]; then
 		(f_down "${feed}" "4" "${feed_url_4}" "${feed_rule_4}" "${feed_flag}") &

--- a/net/banip/files/banip.countries
+++ b/net/banip/files/banip.countries
@@ -1,249 +1,249 @@
-af;Afghanistan
-ax;Åland Islands
-al;Albania
-dz;Algeria
-as;American Samoa
-ad;Andorra
-ao;Angola
-ai;Anguilla
-aq;Antarctica
-ag;Antigua & Barbuda
-ar;Argentina
-am;Armenia
-aw;Aruba
-au;Australia
-at;Austria
-az;Azerbaijan
-bs;Bahamas
-bh;Bahrain
-bd;Bangladesh
-bb;Barbados
-by;Belarus
-be;Belgium
-bz;Belize
-bj;Benin
-bm;Bermuda
-bt;Bhutan
-bo;Bolivia
-ba;Bosnia
-bw;Botswana
-bv;Bouvet Island
-br;Brazil
-io;British Indian Ocean Territory
-vg;British Virgin Islands
-bn;Brunei
-bg;Bulgaria
-bf;Burkina Faso
-bi;Burundi
-kh;Cambodia
-cm;Cameroon
-ca;Canada
-cv;Cape Verde
-bq;Caribbean Netherlands
-ky;Cayman Islands
-cf;Central African Republic
-td;Chad
-cl;Chile
-cn;China
-cx;Christmas Island
-cc;Cocos (Keeling) Islands
-co;Colombia
-km;Comoros
-cg;Congo - Brazzaville
-cd;Congo - Kinshasa
-ck;Cook Islands
-cr;Costa Rica
-ci;Côte d’Ivoire
-hr;Croatia
-cu;Cuba
-cw;Curaçao
-cy;Cyprus
-cz;Czechia
-dk;Denmark
-dj;Djibouti
-dm;Dominica
-do;Dominican Republic
-ec;Ecuador
-eg;Egypt
-sv;El Salvador
-gq;Equatorial Guinea
-er;Eritrea
-ee;Estonia
-sz;Eswatini
-et;Ethiopia
-fk;Falkland Islands
-fo;Faroe Islands
-fj;Fiji
-fi;Finland
-fr;France
-gf;French Guiana
-pf;French Polynesia
-tf;French Southern Territories
-ga;Gabon
-gm;Gambia
-ge;Georgia
-de;Germany
-gh;Ghana
-gi;Gibraltar
-gr;Greece
-gl;Greenland
-gd;Grenada
-gp;Guadeloupe
-gu;Guam
-gt;Guatemala
-gg;Guernsey
-gn;Guinea
-gw;Guinea-Bissau
-gy;Guyana
-ht;Haiti
-hm;Heard & McDonald Islands
-hn;Honduras
-hk;Hong Kong
-hu;Hungary
-is;Iceland
-in;India
-id;Indonesia
-ir;Iran
-iq;Iraq
-ie;Ireland
-im;Isle of Man
-il;Israel
-it;Italy
-jm;Jamaica
-jp;Japan
-je;Jersey
-jo;Jordan
-kz;Kazakhstan
-ke;Kenya
-ki;Kiribati
-kw;Kuwait
-kg;Kyrgyzstan
-la;Laos
-lv;Latvia
-lb;Lebanon
-ls;Lesotho
-lr;Liberia
-ly;Libya
-li;Liechtenstein
-lt;Lithuania
-lu;Luxembourg
-mo;Macau
-mg;Madagascar
-mw;Malawi
-my;Malaysia
-mv;Maldives
-ml;Mali
-mt;Malta
-mh;Marshall Islands
-mq;Martinique
-mr;Mauritania
-mu;Mauritius
-yt;Mayotte
-mx;Mexico
-fm;Micronesia
-md;Moldova
-mc;Monaco
-mn;Mongolia
-me;Montenegro
-ms;Montserrat
-ma;Morocco
-mz;Mozambique
-mm;Myanmar
-na;Namibia
-nr;Nauru
-np;Nepal
-nl;Netherlands
-nc;New Caledonia
-nz;New Zealand
-ni;Nicaragua
-ne;Niger
-ng;Nigeria
-nu;Niue
-nf;Norfolk Island
-mp;Northern Mariana Islands
-kp;North Korea
-mk;North Macedonia
-no;Norway
-om;Oman
-pk;Pakistan
-pw;Palau
-ps;Palestine
-pa;Panama
-pg;Papua New Guinea
-py;Paraguay
-pe;Peru
-ph;Philippines
-pn;Pitcairn Islands
-pl;Poland
-pt;Portugal
-pr;Puerto Rico
-qa;Qatar
-re;Réunion
-ro;Romania
-ru;Russia
-rw;Rwanda
-ws;Samoa
-sm;San Marino
-st;São Tomé & Príncipe
-sa;Saudi Arabia
-sn;Senegal
-rs;Serbia
-sc;Seychelles
-sl;Sierra Leone
-sg;Singapore
-sx;Sint Maarten
-sk;Slovakia
-si;Slovenia
-sb;Solomon Islands
-so;Somalia
-za;South Africa
-gs;South Georgia & South Sandwich Islands
-kr;South Korea
-ss;South Sudan
-es;Spain
-lk;Sri Lanka
-bl;St. Barthélemy
-sh;St. Helena
-kn;St. Kitts & Nevis
-lc;St. Lucia
-mf;St. Martin
-pm;St. Pierre & Miquelon
-vc;St. Vincent & Grenadines
-sd;Sudan
-sr;Suriname
-sj;Svalbard & Jan Mayen
-se;Sweden
-ch;Switzerland
-sy;Syria
-tw;Taiwan
-tj;Tajikistan
-tz;Tanzania
-th;Thailand
-tl;Timor-Leste
-tg;Togo
-tk;Tokelau
-to;Tonga
-tt;Trinidad & Tobago
-tn;Tunisia
-tr;Turkey
-tm;Turkmenistan
-tc;Turks & Caicos Islands
-tv;Tuvalu
-ug;Uganda
-ua;Ukraine
-ae;United Arab Emirates
-gb;United Kingdom
-us;United States
-uy;Uruguay
-um;U.S. Outlying Islands
-vi;U.S. Virgin Islands
-uz;Uzbekistan
-vu;Vanuatu
-va;Vatican City
-ve;Venezuela
-vn;Vietnam
-wf;Wallis & Futuna
-eh;Western Sahara
-ye;Yemen
-zm;Zambia
-zw;Zimbabwe
+af	APNIC	Afghanistan
+ax	RIPE	Åland Islands
+al	RIPE	Albania
+dz	AFRINIC	Algeria
+as	APNIC	American Samoa
+ad	RIPE	Andorra
+ao	AFRINIC	Angola
+ai	ARIN	Anguilla
+aq	ARIN	Antarctica
+ag	ARIN	Antigua & Barbuda
+ar	LACNIC	Argentina
+am	RIPE	Armenia
+aw	LACNIC	Aruba
+au	APNIC	Australia
+at	RIPE	Austria
+az	RIPE	Azerbaijan
+bs	ARIN	Bahamas
+bh	RIPE	Bahrain
+bd	APNIC	Bangladesh
+bb	ARIN	Barbados
+by	RIPE	Belarus
+be	RIPE	Belgium
+bz	LACNIC	Belize
+bj	AFRINIC	Benin
+bm	ARIN	Bermuda
+bt	APNIC	Bhutan
+bo	LACNIC	Bolivia
+bq	LACNIC	Bonaire
+ba	RIPE	Bosnia & Herzegowina
+bw	AFRINIC	Botswana
+bv	ARIN	Bouvet Island
+br	LACNIC	Brazil
+io	APNIC	British Indian Ocean Territory
+bn	APNIC	Brunei
+bg	RIPE	Bulgaria
+bf	AFRINIC	Burkina Faso
+bi	AFRINIC	Burundi
+kh	APNIC	Cambodia
+cm	AFRINIC	Cameroon
+ca	ARIN	Canada
+cv	AFRINIC	Cape Verde
+ky	ARIN	Cayman Islands
+cf	AFRINIC	Central African Republic
+td	AFRINIC	Chad
+cl	LACNIC	Chile
+cn	APNIC	China
+cx	APNIC	Christmas Island
+cc	APNIC	Cocos Islands
+co	LACNIC	Colombia
+km	AFRINIC	Comoros
+cg	AFRINIC	Congo - Brazzaville
+cd	AFRINIC	Congo - Kinshasa
+ck	APNIC	Cook Islands
+cr	LACNIC	Costa Rica
+ci	AFRINIC	Côte D'ivoire
+hr	RIPE	Croatia
+cu	LACNIC	Cuba
+cw	LACNIC	Curaçao
+cy	RIPE	Cyprus
+cz	RIPE	Czechia
+dk	RIPE	Denmark
+dj	AFRINIC	Djibouti
+dm	ARIN	Dominica
+do	LACNIC	Dominican Republic
+ec	LACNIC	Ecuador
+eg	AFRINIC	Egypt
+sv	LACNIC	El Salvador
+gq	AFRINIC	Equatorial Guinea
+er	AFRINIC	Eritrea
+ee	RIPE	Estonia
+sz	AFRINIC	Eswatini
+et	AFRINIC	Ethiopia
+fk	LACNIC	Falkland Islands
+fo	RIPE	Faroe Islands
+fj	APNIC	Fiji
+fi	RIPE	Finland
+fr	RIPE	France
+gf	LACNIC	French Guiana
+pf	APNIC	French Polynesia
+tf	APNIC	French Southern Territories
+ga	AFRINIC	Gabon
+gm	AFRINIC	Gambia
+ge	RIPE	Georgia
+de	RIPE	Germany
+gh	AFRINIC	Ghana
+gi	RIPE	Gibraltar
+gr	RIPE	Greece
+gl	RIPE	Greenland
+gd	ARIN	Grenada
+gp	ARIN	Guadeloupe
+gu	APNIC	Guam
+gt	LACNIC	Guatemala
+gg	RIPE	Guernsey
+gn	AFRINIC	Guinea
+gw	AFRINIC	Guinea-Bissau
+gy	LACNIC	Guyana
+ht	LACNIC	Haiti
+hm	ARIN	Heard & McDonald Islands
+hn	LACNIC	Honduras
+hk	APNIC	Hong Kong
+hu	RIPE	Hungary
+is	RIPE	Iceland
+in	APNIC	India
+id	APNIC	Indonesia
+ir	RIPE	Iran
+iq	RIPE	Iraq
+ie	RIPE	Ireland
+im	RIPE	Isle of Man
+il	RIPE	Israel
+it	RIPE	Italy
+jm	ARIN	Jamaica
+jp	APNIC	Japan
+je	RIPE	Jersey
+jo	RIPE	Jordan
+kz	RIPE	Kazakhstan
+ke	AFRINIC	Kenya
+ki	APNIC	Kiribati
+kw	RIPE	Kuwait
+kg	RIPE	Kyrgyzstan
+la	APNIC	Lao
+lv	RIPE	Latvia
+lb	RIPE	Lebanon
+ls	AFRINIC	Lesotho
+lr	AFRINIC	Liberia
+ly	AFRINIC	Libya
+li	RIPE	Liechtenstein
+lt	RIPE	Lithuania
+lu	RIPE	Luxembourg
+mo	APNIC	Macao
+mg	AFRINIC	Madagascar
+mw	AFRINIC	Malawi
+my	APNIC	Malaysia
+mv	APNIC	Maldives
+ml	AFRINIC	Mali
+mt	RIPE	Malta
+mh	APNIC	Marshall Islands
+ma	AFRINIC	Marocco
+mq	ARIN	Martinique
+mr	AFRINIC	Mauritania
+mu	AFRINIC	Mauritius
+yt	AFRINIC	Mayotte
+mx	LACNIC	Mexico
+fm	APNIC	Micronesia
+md	RIPE	Moldova
+mc	RIPE	Monaco
+mn	APNIC	Mongolia
+me	RIPE	Montenegro
+ms	ARIN	Montserrat
+mz	AFRINIC	Mozambique
+mm	APNIC	Myanmar
+na	AFRINIC	Namibia
+nr	APNIC	Nauru
+np	APNIC	Nepal
+nl	RIPE	Netherlands
+nc	APNIC	New Caledonia
+nz	APNIC	New Zealand
+ni	LACNIC	Nicaragua
+ne	AFRINIC	Niger
+ng	AFRINIC	Nigeria
+nu	APNIC	Niue
+nf	APNIC	Norfolk Island
+kp	APNIC	North Korea
+mk	RIPE	North Macedonia
+mp	APNIC	Northern Mariana Islands
+no	RIPE	Norway
+om	RIPE	Oman
+pk	APNIC	Pakistan
+pw	APNIC	Palau
+ps	RIPE	Palestine
+pa	LACNIC	Panama
+pg	APNIC	Papua New Guinea
+py	LACNIC	Paraguay
+pe	LACNIC	Peru
+ph	APNIC	Philippines
+pn	APNIC	Pitcairn
+pl	RIPE	Poland
+pt	RIPE	Portugal
+pr	ARIN	Puerto Rico
+qa	RIPE	Qatar
+re	AFRINIC	Reunion
+ro	RIPE	Romania
+ru	RIPE	Russian Federation
+rw	AFRINIC	Rwanda
+sh	ARIN	Saint Helena
+bl	ARIN	Saint Barthélemy
+kn	ARIN	Saint Kitts & Nevis
+lc	ARIN	Saint Lucia
+mf	ARIN	Saint Martin
+pm	ARIN	Saint Pierre & Miquelon
+vc	ARIN	Saint Vincent & the Grenadines
+ws	APNIC	Samoa
+sm	RIPE	San Marino
+st	AFRINIC	Sao Tome & Principe
+sa	RIPE	Saudi Arabia
+sn	AFRINIC	Senegal
+rs	RIPE	Serbia
+sc	AFRINIC	Seychelles
+sl	AFRINIC	Sierra Leone
+sg	APNIC	Singapore
+sx	LACNIC	Sint Maarten
+sk	RIPE	Slovakia
+si	RIPE	Slovenia
+sb	APNIC	Solomon Islands
+so	AFRINIC	Somalia
+za	AFRINIC	South Africa
+gs	LACNIC	South Georgia
+kr	APNIC	South Korea
+ss	AFRINIC	South Sudan
+es	RIPE	Spain
+lk	APNIC	Sri Lanka
+sd	AFRINIC	Sudan
+sr	LACNIC	Suriname
+sj	RIPE	Svalbard & Jan Mayen Islands
+se	RIPE	Sweden
+ch	RIPE	Switzerland
+sy	RIPE	Syrian
+tw	APNIC	Taiwan
+tj	RIPE	Tajikistan
+tz	AFRINIC	Tanzania
+th	APNIC	Thailand
+tl	APNIC	Timor-Leste
+tg	AFRINIC	Togo
+tk	APNIC	Tokelau
+to	APNIC	Tonga
+tt	LACNIC	Trinidad & Tobago
+tn	AFRINIC	Tunisia
+tr	RIPE	Türkey
+tm	RIPE	Turkmenistan
+tc	ARIN	Turks & Caicos Islands
+tv	APNIC	Tuvalu
+ug	AFRINIC	Uganda
+ua	RIPE	Ukraine
+ae	RIPE	United Arab Emirates
+gb	RIPE	United Kingdom
+us	ARIN	United States
+um	ARIN	United States Minor Outlying Islands
+uy	LACNIC	Uruguay
+uz	RIPE	Uzbekistan
+vu	APNIC	Vanuatu
+va	RIPE	Vatikan City
+ve	LACNIC	Venezuela
+vn	APNIC	Vietnam
+vg	ARIN	Virgin Islands (British)
+vi	ARIN	Virgin Islands (U.S.)
+wf	APNIC	Wallis & Futuna Islands
+eh	AFRINIC	Western Sahara
+ye	RIPE	Yemen
+zm	AFRINIC	Zambia
+zw	AFRINIC	Zimbabwe

--- a/net/banip/files/banip.feeds
+++ b/net/banip/files/banip.feeds
@@ -5,7 +5,7 @@
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"descr": "adaway IPs",
-		"flag": "80 443"
+		"flag": "tcp 80 443"
 	},
 	"adguard":{
 		"url_4": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/adguard-ipv4.txt",
@@ -13,7 +13,7 @@
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"descr": "adguard IPs",
-		"flag": "80 443"
+		"flag": "tcp 80 443"
 	},
 	"adguardtrackers":{
 		"url_4": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/adguardtrackers-ipv4.txt",
@@ -21,7 +21,7 @@
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"descr": "adguardtracker IPs",
-		"flag": "80 443"
+		"flag": "tcp 80 443"
 	},
 	"antipopads":{
 		"url_4": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/antipopads-ipv4.txt",
@@ -29,7 +29,7 @@
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"descr": "antipopads IPs",
-		"flag": "80 443"
+		"flag": "tcp 80 443"
 	},
 	"asn":{
 		"url_4": "https://asn.ipinfo.app/api/text/list/",
@@ -37,13 +37,20 @@
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)$/{printf \"%s,\\n\",$1}",
 		"descr": "ASN IP segments",
-		"flag": "80 443"
+		"flag": "tcp 80 443"
 	},
 	"backscatterer":{
 		"url_4": "http://wget-mirrors.uceprotect.net/rbldnsd-all/ips.backscatterer.org.gz",
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
 		"descr": "backscatterer IPs",
 		"flag": "gz"
+	},
+	"becyber":{
+		"url_4": "https://raw.githubusercontent.com/duggytuxy/malicious_ip_addresses/main/botnets_zombies_scanner_spam_ips.txt",
+		"url_6": "https://raw.githubusercontent.com/duggytuxy/malicious_ip_addresses/main/botnets_zombies_scanner_spam_ips_ipv6.txt",
+		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)$/{printf \"%s,\\n\",$1}",
+		"descr": "malicious attacker IPs"
 	},
 	"binarydefense":{
 		"url_4": "https://iplists.firehol.org/files/bds_atif.ipset",
@@ -74,14 +81,9 @@
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)$/{printf \"%s,\\n\",$1}",
 		"descr": "country blocks"
 	},
-	"darklist":{
-		"url_4": "https://darklist.de/raw.php",
-		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
-		"descr": "suspicious attacker IPs"
-	},
 	"debl":{
-		"url_4": "https://www.blocklist.de/downloads/export-ips_all.txt",
-		"url_6": "https://www.blocklist.de/downloads/export-ips_all.txt",
+		"url_4": "https://lists.blocklist.de/lists/all.txt",
+		"url_6": "https://lists.blocklist.de/lists/all.txt",
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)$/{printf \"%s,\\n\",$1}",
 		"descr": "fail2ban IP blocklist"
@@ -92,7 +94,7 @@
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"descr": "public DoH-Provider",
-		"flag": "80 443"
+		"flag": "tcp 80 443"
 	},
 	"drop":{
 		"url_4": "https://www.spamhaus.org/drop/drop.txt",
@@ -150,18 +152,18 @@
 		"url_4": "https://list.iblocklist.com/?list=dgxtneitpuvgqqcpfulq&fileformat=cidr&archiveformat=gz",
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
 		"descr": "advertising IPs",
-		"flag": "gz 80 443"
+		"flag": "gz tcp 80 443"
 	},
 	"iblockspy":{
 		"url_4": "https://list.iblocklist.com/?list=llvtlsjyoyiczbkjsxpf&fileformat=cidr&archiveformat=gz",
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
 		"descr": "malicious spyware IPs",
-		"flag": "gz 80 443"
+		"flag": "gz tcp 80 443"
 	},
-	"ipblackhole":{
-		"url_4": "https://ip.blackhole.monster/blackhole-today",
-		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
-		"descr": "blackhole IP blocklist"
+	"ipsum":{
+		"url_4": "https://raw.githubusercontent.com/stamparm/ipsum/master/levels/3.txt",
+		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[-[:space:]]?/{printf \"%s,\\n\",$1}",
+		"descr": "malicious IPs"
 	},
 	"ipthreat":{
 		"url_4": "https://lists.ipthreat.net/file/ipthreat-lists/threat/threat-30.txt.gz",
@@ -188,7 +190,7 @@
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"descr": "OISD-big IPs",
-		"flag": "80 443"
+		"flag": "tcp 80 443"
 	},
 	"oisdnsfw":{
 		"url_4": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/oisdnsfw-ipv4.txt",
@@ -196,7 +198,7 @@
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"descr": "OISD-nsfw IPs",
-		"flag": "80 443"
+		"flag": "tcp 80 443"
 	},
 	"oisdsmall":{
 		"url_4": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/oisdsmall-ipv4.txt",
@@ -204,7 +206,12 @@
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"descr": "OISD-small IPs",
-		"flag": "80 443"
+		"flag": "tcp 80 443"
+	},
+	"pallebone":{
+		"url_4": "https://raw.githubusercontent.com/pallebone/StrictBlockPAllebone/master/BlockIP.txt",
+		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"descr": "curated IP blocklist"
 	},
 	"proxy":{
 		"url_4": "https://iplists.firehol.org/files/proxylists.ipset",
@@ -222,7 +229,7 @@
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"descr": "stevenblack IPs",
-		"flag": "80 443"
+		"flag": "tcp 80 443"
 	},
 	"talos":{
 		"url_4": "https://www.talosintelligence.com/documents/ip-blacklist",
@@ -295,6 +302,6 @@
 		"rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"descr": "yoyo IPs",
-		"flag": "80 443"
+		"flag": "tcp 80 443"
 	}
 }


### PR DESCRIPTION
Maintainer: me / @dibdot 
Compile tested: n/a
Run tested: Bananapi BPI-R3, OpenWrt SNAPSHOT r25932-338b463e1e

Description:
* added a DDoS protection rules in a new pre-routing chain to prevent common ICMP, UDP and SYN flood attacks and drop spoofed tcp flags & invalid conntrack packets, flood tresholds are configured via 'ban_icmplimit' (default 10/s), 'ban_synlimit' (default 10/s) and 'ban_udplimit' (default 100/s)
* the new pre-routing rules are tracked via named nft counters and are part of the standard reporting, set 'ban_logprerouting' accordingly
* block countries dynamically by Regional Internet Registry (RIR)/regions, e.g. all countries related to ARIN. Supported service regions are: AFRINIC, ARIN, APNIC, LACNIC and RIPE, set 'ban_region' accordingly
* it's now possible to always allow certain protocols/destination ports in wan-input and wan-forward chains, set 'ban_allowflag' accordingly - e.g. ' tcp 80 443-445'
* filter/convert possible windows line endings of external feeds during processing
* the cpu core autodetection is now limited to max. 16 cores in parallel, set 'ban_cores' manually to overrule this limitation
* set the default nft priority to -100 for banIP input/forward chains (pre-routing is set to -150)
* update readme
* a couple of bugfixes & performance improvements
* removed abandoned feeds: darklist, ipblackhole
* added new feeds: becyber, ipsum, pallebone, debl (changed URL)
* requires a LuCI frontend update as well (separate PR/commit)
