### PR TITLE
ibrcommon: remove basename

### DIFF
--- a/libs/ibrcommon/Makefile
+++ b/libs/ibrcommon/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ibrcommon
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.ibr.cs.tu-bs.de/projects/ibr-dtn/releases

--- a/libs/ibrcommon/patches/001-fix-build-with-musl.patch
+++ b/libs/ibrcommon/patches/001-fix-build-with-musl.patch
@@ -1,21 +1,33 @@
 --- a/ibrcommon/data/File.cpp
 +++ b/ibrcommon/data/File.cpp
-@@ -35,9 +35,7 @@
+@@ -35,10 +35,6 @@
  #include <cerrno>
  #include <fstream>
  
 -#if !defined(HAVE_FEATURES_H) || defined(ANDROID)
- #include <libgen.h>
+-#include <libgen.h>
 -#endif
- 
+-
  #ifdef __WIN32__
  #include <io.h>
-@@ -226,7 +224,7 @@ namespace ibrcommon
+ #define FILE_DELIMITER_CHAR '\\'
+@@ -225,14 +221,11 @@ namespace ibrcommon
+ 
  	std::string File::getBasename() const
  	{
- #if !defined(ANDROID) && defined(HAVE_FEATURES_H)
+-#if !defined(ANDROID) && defined(HAVE_FEATURES_H)
 -		return std::string(basename(_path.c_str()));
-+		return std::string(basename((char *)_path.c_str()));
- #else
- 		char path[_path.length()+1];
- 		::memcpy(&path, _path.c_str(), _path.length()+1);
+-#else
+-		char path[_path.length()+1];
+-		::memcpy(&path, _path.c_str(), _path.length()+1);
+-
+-		return std::string(basename(path));
+-#endif
++		size_t found = _path.find_last_of('/');
++		if (found != std::string::npos)
++			return _path.substr(found + 1);
++		else
++			return _path;
+ 	}
+ 
+ 	File File::get(const std::string &filename) const


### PR DESCRIPTION
Can be replaced with regular C++.

Maintainer: @morgenroth 