### PR TITLE
curl: fix/bump PKG_RELEASE, remove maintainer

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=8.7.1
-PKG_RELEASE:=r1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \
@@ -81,7 +81,7 @@ define Package/curl/Default
   SECTION:=net
   CATEGORY:=Network
   URL:=http://curl.se/
-  MAINTAINER:=Stan Grishin <stangri@melmac.ca>
+  MAINTAINER:=
 endef
 
 define Package/curl


### PR DESCRIPTION
Maintainer: n/a
Compile tested: n/a
Run tested: n/a - only package formalities changed

Description:
* make PKG_RELEASE numeric again
* made a release bump due to  a newly added patch (see https://github.com/openwrt/packages/commit/de4ef9d169a182350796afca778742bf68052af4 for details)
* remove maintainer (as requested in #23890

