### PR TITLE
tini: fix missing basename

### DIFF
--- a/utils/tini/Makefile
+++ b/utils/tini/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tini
 PKG_VERSION:=0.19.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/krallin/tini/tar.gz/v${PKG_VERSION}?

--- a/utils/tini/patches/002-fix_missing_basename.patch
+++ b/utils/tini/patches/002-fix_missing_basename.patch
@@ -1,0 +1,11 @@
+--- a/src/tini.c
++++ b/src/tini.c
+@@ -18,6 +18,8 @@
+ #include "tiniConfig.h"
+ #include "tiniLicense.h"
+ 
++#define basename(name) (strrchr((name),'/') ? strrchr((name),'/')+1 : (name))
++
+ #if TINI_MINIMAL
+ #define PRINT_FATAL(...)                         fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n");
+ #define PRINT_WARNING(...)  if (verbosity > 0) { fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); }


### PR DESCRIPTION
I know that a pull request is already opened https://github.com/openwrt/packages/pull/23929 please, if ok, merge one, this or other, thank you and sorry for double.

Fix issue: https://github.com/openwrt/packages/issues/23934
Patch from: https://git.alpinelinux.org/aports/tree/community/tini/fix-missing-basename.patch

It solves the error: implicit declaration of function 'basename' with musl libc 1.2.5

Maintainer: @G-M0N3Y-2503 
Compile tested: MT6000 latest master
Run tested: MT6000

Thank you

Andrea
