### PR TITLE
eza: update to 0.18.11

### DIFF
--- a/utils/eza/Makefile
+++ b/utils/eza/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=eza
-PKG_VERSION:=0.18.9
+PKG_VERSION:=0.18.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eza-community/eza/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=917736591429813ef4cfce47bb2d3d87e9f1e142b2a6ebf74a345c3a15894918
+PKG_HASH:=92d810c36ac67038e2ed3c421087de8793eb0b9de332c9239096df9d52eb30e3
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64 mediatek/filogic (BananaPi R3), OpenWrt snapshot
Run tested: aarch64 mediatek/filogic (BananaPi R3), OpenWrt snapshot

Description:
Release notes:
0.18.10: https://github.com/eza-community/eza/releases/tag/v0.18.10
0.18.11: https://github.com/eza-community/eza/releases/tag/v0.18.11