### PR TITLE
hyperscan: fix broken build w/ external toolchain

### DIFF
--- a/libs/hyperscan/Makefile
+++ b/libs/hyperscan/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hyperscan
 PKG_VERSION:=5.4.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/intel/hyperscan/tar.gz/v$(PKG_VERSION)?

--- a/libs/hyperscan/patches/0001-CMakeLists.txt-hack-for-our-build-system.patch
+++ b/libs/hyperscan/patches/0001-CMakeLists.txt-hack-for-our-build-system.patch
@@ -1,0 +1,56 @@
+From c5a983652a2bbbc029961affd2996459e45b5336 Mon Sep 17 00:00:00 2001
+From: John Audia <therealgraysky@proton.me>
+Date: Sat, 20 Apr 2024 13:29:49 -0400
+Subject: [PATCH] CMakeLists.txt: hack for our build system
+
+If building with the project external toolchain, the gcc check
+fails to set the correct value for TUNE_FLAG to allow the min
+supported SSSE3 compiler support test to pass.  This patch hacks
+the file to set to the correct value.
+
+Links to upstream bug reports:
+https://github.com/openwrt/openwrt/issues/15216
+https://github.com/intel/hyperscan/issues/431
+
+---
+ CMakeLists.txt | 29 +----------------------------
+ 1 file changed, 1 insertion(+), 28 deletions(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -183,34 +183,7 @@ else()
+     endforeach ()
+ 
+     if (CMAKE_COMPILER_IS_GNUCC)
+-        message(STATUS "gcc version ${CMAKE_C_COMPILER_VERSION}")
+-        # If gcc doesn't recognise the host cpu, then mtune=native becomes
+-        # generic, which isn't very good in some cases. march=native looks at
+-        # cpuid info and then chooses the best microarch it can (and replaces
+-        # the flag), so use that for tune.
+-
+-        # arg1 might exist if using ccache
+-        string (STRIP "${CMAKE_C_COMPILER_ARG1}" CC_ARG1)
+-        set (EXEC_ARGS ${CC_ARG1} -c -Q --help=target -march=native -mtune=native)
+-        execute_process(COMMAND ${CMAKE_C_COMPILER} ${EXEC_ARGS}
+-            OUTPUT_VARIABLE _GCC_OUTPUT)
+-        string(FIND "${_GCC_OUTPUT}" "march" POS)
+-        string(SUBSTRING "${_GCC_OUTPUT}" ${POS} -1 _GCC_OUTPUT)
+-        string(REGEX REPLACE "march=[ \t]*([^ \n]*)[ \n].*" "\\1"
+-            GNUCC_ARCH "${_GCC_OUTPUT}")
+-
+-        # test the parsed flag
+-        set (EXEC_ARGS ${CC_ARG1} -E - -mtune=${GNUCC_ARCH})
+-        execute_process(COMMAND ${CMAKE_C_COMPILER} ${EXEC_ARGS}
+-            OUTPUT_QUIET ERROR_QUIET
+-            INPUT_FILE /dev/null
+-            RESULT_VARIABLE GNUCC_TUNE_TEST)
+-        if (NOT GNUCC_TUNE_TEST EQUAL 0)
+-            message(SEND_ERROR "Something went wrong determining gcc tune: -mtune=${GNUCC_ARCH} not valid")
+-        endif()
+-        set(TUNE_FLAG ${GNUCC_ARCH})
+-    else ()
+-        set(TUNE_FLAG native)
++        set(TUNE_FLAG x86-64-v2)
+     endif()
+ 
+     # compiler version checks TODO: test more compilers


### PR DESCRIPTION
Maintainer: me

If building with the project external toolchain, the gcc check fails to set the correct value for TUNE_FLAG to allow the min supported SSSE3 compiler support test to pass.  This patch hacks the file to set to the correct value.

Links to upstream bug reports:
https://github.com/openwrt/openwrt/issues/15216
https://github.com/intel/hyperscan/issues/431

Build system: x86/64 (build system toolchain and x86/64 w/ external toolchain (18-Apr-2024 snapshot)
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne