### PR TITLE
usbmuxd: fix tethering not working after iPhone restart

### DIFF
--- a/utils/usbmuxd/Makefile
+++ b/utils/usbmuxd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=usbmuxd
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.libimobiledevice.org/downloads
@@ -31,7 +31,7 @@ define Package/usbmuxd
   SUBMENU:=libimobiledevice
   TITLE:=USB multiplexing daemon
   URL:=https://www.libimobiledevice.org/
-  DEPENDS:=+librt +libusb-1.0 +libusbmuxd +libopenssl +libimobiledevice
+  DEPENDS:=+libusb-1.0 +libusbmuxd +libopenssl +libimobiledevice +usbutils
 endef
 
 define Package/usbmuxd/description
@@ -50,7 +50,9 @@ endef
 CONFIGURE_ARGS += --with-systemd
 
 define Package/usbmuxd/install
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/usb
 	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/usbmuxd.hotplug $(1)/etc/hotplug.d/usb/40-usbmuxd
 	$(INSTALL_BIN) ./files/usbmuxd.init $(1)/etc/init.d/usbmuxd
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/usbmuxd $(1)/usr/sbin/

--- a/utils/usbmuxd/files/usbmuxd.hotplug
+++ b/utils/usbmuxd/files/usbmuxd.hotplug
@@ -1,0 +1,24 @@
+case "$ACTION" in
+	bind)
+		dev=/sys$DEVPATH
+
+		[ ! -f /tmp/iPhone.lock ] && [ -d ${dev}/net ] &&
+		{
+			readlink ${dev}/driver | grep -q ipheth &&
+			{
+				sleep 5
+				carrier_path=${dev}/net/*/carrier
+				carrier=`cat ${carrier_path}`
+
+				[ "${carrier}" = "0" ] &&
+				{
+					touch /tmp/iPhone.lock
+					logger -p daemon.error -t iPhone ${carrier_path} = ${carrier}
+					logger -p daemon.error -t iPhone `/usr/bin/usbreset iPhone`
+					/etc/init.d/usbmuxd restart
+					sleep 5 && rm -f /tmp/iPhone.lock &
+				}
+			}
+		}
+		;;
+esac


### PR DESCRIPTION
If the iPhone restarts while the USB cable is still connected, tethering does not work. This can be fixed by reconnecting.

Fix: if the `hotplug.d` script detects that carrier is disabled (no communication), the USB link is reset, and then the `usbmuxd` service is restarted. Tethering starts even before the iPhone is unlocked. As a side effect, if tethering is not enabled, the iPhone will ding a second time after 5 seconds.

[1] https://github.com/libimobiledevice/usbmuxd/issues/218
[2] https://github.com/openwrt/openwrt/issues/12566#issuecomment-2066305622

Maintainer: @neheb 
Compile and run tested:
- Marvell EBU Armada, Marvell Armada 37x/38x/XP, Linksys WRT3200ACM, [main](https://github.com/openwrt/openwrt/commit/66019e456f60f5ef71a9af0d73502e20b874d114)
- Atheros ATH79, Generic, TP-Link TL-WR1043N/ND v4, main
