### PR TITLE
cni-plugins-nft: use local tarballs

### DIFF
--- a/utils/cni-plugins-nft/Makefile
+++ b/utils/cni-plugins-nft/Makefile
@@ -2,11 +2,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cni-plugins-nft
 PKG_VERSION:=1.0.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/greenpau/cni-plugins/archive/v$(PKG_VERSION)
-PKG_HASH:=51c4b41c61f46c7dfc691d52dba301e7d8189589e1a625772f761ea3ae804fb3
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/greenpau/cni-plugins
+PKG_MIRROR_HASH:=3bb778c8f48261eaaee8b14b9219f1730967ef16158b5b540d45da54ef580e53
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -22,8 +23,6 @@ GO_PKG_BUILD_PKG:=github.com/greenpau/cni-plugins/cmd/cni-nftables-portmap \
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C "$(PKG_BUILD_DIR)" --strip-components=1 -xzf "$(DL_DIR)/$(PKG_SOURCE)"
 
 define Package/cni-plugins-nft
   SECTION:=utils


### PR DESCRIPTION
Avoids having to override PKG_UNPACK.

Maintainer: @dangowrt 