### PR TITLE
unbound: pull in adblock-fast generated adb_list

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.19.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound

--- a/net/unbound/files/unbound.sh
+++ b/net/unbound/files/unbound.sh
@@ -1477,14 +1477,16 @@ unbound_include() {
   fi
 
 
-  if [ -z "$adb_files" ] || [  ! -x /usr/bin/adblock.sh ] \
-  || [ ! -x /etc/init.d/adblock ] ; then
+  if [ -z "$adb_files" ]; then
     adb_enabled=0
 
-  elif /etc/init.d/adblock enabled ; then
+  elif { [ -x /etc/init.d/adblock-fast ] && /etc/init.d/adblock-fast enabled; } \
+  || { [ -x /usr/bin/adblock.sh ] && [ -x /etc/init.d/adblock ] \
+  &&  /etc/init.d/adblock enabled; }; then
     adb_enabled=1
     {
-      # Pull in your selected openwrt/pacakges/net/adblock generated lists
+      # Pull in your selected openwrt/pacakges/net/adblock or
+      # openwrt/pacakges/net/adblock-fast generated lists
       echo "include: $UB_VARDIR/adb_list.*"
       echo
     } >> $UB_TOTAL_CONF


### PR DESCRIPTION
Maintainer: @EricLuehrsen 
Compile tested: no, trivial change
Run tested: no, I only tested the new elif expression in shell

Description:
* adblock-fast can generate the compatible adb_list-file, but it's only pulled if net/adblock installed, this patch also pulls in the adb_list file if net/adblock-fast is installed.
* also bump PKG_RELEASE
