### PR TITLE
modemmanager: add sourcefilter option support

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.22.0
-PKG_RELEASE:=15
+PKG_RELEASE:=16
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -208,6 +208,7 @@ modemmanager_connected_method_dhcp_ipv6() {
 	json_add_string proto "dhcpv6"
 	proto_add_dynamic_defaults
 	json_add_string extendprefix 1 # RFC 7278: Extend an IPv6 /64 Prefix to LAN
+	[ "$sourcefilter" = "0" ] && json_add_boolean sourcefilter "0"
 	[ -n "$metric" ] && json_add_int metric "${metric}"
 	json_close_object
 	ubus call network add_dynamic "$(json_dump)"
@@ -270,6 +271,7 @@ proto_modemmanager_init_config() {
 	proto_config_add_string preferredmode
 	proto_config_add_string pincode
 	proto_config_add_string iptype
+	proto_config_add_boolean sourcefilter
 	proto_config_add_string plmn
 	proto_config_add_int signalrate
 	proto_config_add_boolean lowpower
@@ -431,7 +433,7 @@ proto_modemmanager_setup() {
 	local address prefix gateway mtu dns1 dns2
 
 	json_get_vars device apn allowedauth username password
-	json_get_vars pincode iptype plmn metric signalrate allow_roaming
+	json_get_vars pincode iptype sourcefilter plmn metric signalrate allow_roaming
 	json_get_vars allowedmode preferredmode force_connection
 
 	json_get_vars init_epsbearer


### PR DESCRIPTION
This make source based IPv6 routing option available for modemmanager case dhcpv6

cc @feckert 

I post here without test. I am not really clear how the modemmanager work

