### PR TITLE
snort3: use local tarballs

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -9,9 +9,10 @@ PKG_NAME:=snort3
 PKG_VERSION:=3.1.84.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/snort3/snort3/archive/refs/tags/
-PKG_HASH:=dca1707a66f6ca56ddd526163b2d951cefdb168bddc162c791adc74c0d226c7f
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/snort3/snort3
+PKG_MIRROR_HASH:=ffa69fdd95c55a943ab4dd782923caf31937dd8ad29e202d7fe781373ed84444
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>, John Audia <therealgraysky@proton.me>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Avoids having a bad tarball name with just the version.

Maintainer: @flyn-org 