### PR TITLE
treewide: exclude mips64

### DIFF
--- a/libs/gperftools/Makefile
+++ b/libs/gperftools/Makefile
@@ -26,7 +26,7 @@ define Package/gperftools-headers
   SECTION:=libs
   TITLE:=Gperftools Headers
   URL:=https://github.com/gperftools/gperftools
-  DEPENDS:= @!mips @!mipsel @!powerpc
+  DEPENDS:= @!(mips||mips64||mipsel||powerpc)
 endef
 
 define Package/gperftools-runtime
@@ -34,7 +34,7 @@ define Package/gperftools-runtime
   CATEGORY:=Libraries
   TITLE:=Gperftools Runtime
   URL:=https://github.com/gperftools/gperftools
-  DEPENDS:= +libunwind +libstdcpp @!mips @!mipsel @!powerpc
+  DEPENDS:= +libunwind +libstdcpp @!(mips||mips64||mipsel||powerpc)
 endef
 
 define Package/gperftools-headers/description

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -47,7 +47,7 @@ define Package/dockerd
     +kmod-veth \
     +tini \
     +uci-firewall \
-    @!(mips||mipsel)
+    @!(mips||mips64||mipsel)
   USERID:=docker:docker
   MENU:=1
 endef

--- a/utils/mstflint/Makefile
+++ b/utils/mstflint/Makefile
@@ -31,7 +31,7 @@ define Package/mstflint
   CATEGORY:=Utilities
   TITLE:=Mellanox Firmware Burning and Diagnostics Tools
   URL:=https://github.com/Mellanox/mstflint
-  DEPENDS:=@!(mips||mipsel) \
+  DEPENDS:=@!(mips||mips64||mipsel) \
     +libcurl +liblzma +libopenssl +libsqlite3 \
     +libstdcpp +libxml2 +python3-ctypes \
     +python3-urllib +python3-xml +zlib


### PR DESCRIPTION
These packages exclude mips but forget to exclude mips64.
