### PR TITLE
[23.05] node: bump to v18.20.2

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v18.20.1
+PKG_VERSION:=v18.20.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=7fb430d0b1256c22f26dd321070182ab943005bdb7b738facc6d9a82b1e04ed7
+PKG_HASH:=68c165b9ceb7bc69dcdc75c6099723edb5ff0509215959af0775ed426174c404
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: 23.05, aarch64, arm 
Run tested: (qemu 8.2.2) aarch64

Description:
This is a security release.

Notable Changes
* CVE-2024-27980 - Command injection via args parameter of child_process.spawn without shell option enabled on Windows