### PR TITLE
[23.05] natmap: add log_std{out,err} options

### DIFF
--- a/net/natmap/Makefile
+++ b/net/natmap/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=natmap
 PKG_VERSION:=20240303
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/heiher/natmap/releases/download/$(PKG_VERSION)

--- a/net/natmap/files/natmap.config
+++ b/net/natmap/files/natmap.config
@@ -10,4 +10,6 @@ config natmap
 	option forward_target ''
 	option forward_port ''
 	option notify_script ''
+	option log_stdout '1'
+	option log_stderr '1'
 

--- a/net/natmap/files/natmap.init
+++ b/net/natmap/files/natmap.init
@@ -27,7 +27,9 @@ validate_section_natmap() {
 		'port:port' \
 		'forward_target:host' \
 		'forward_port:port' \
-		'notify_script:file'
+		'notify_script:file' \
+		'log_stdout:bool:1' \
+		'log_stderr:bool:1'
 }
 
 natmap_instance() {
@@ -63,8 +65,8 @@ natmap_instance() {
 	procd_append_param command -e /usr/lib/natmap/update.sh
 
 	procd_set_param respawn
-	procd_set_param stdout 1
-	procd_set_param stderr 1
+	procd_set_param stdout "${log_stdout}"
+	procd_set_param stderr "${log_stderr}"
 
 	procd_close_instance
 }


### PR DESCRIPTION
Maintainer: @ysc3839 @heiher
Compile tested: x86-generic, 23.05
Run tested: x86-generic, 23.05

Description:

Introduce `log_stdout` and `log_stderr` options for managing logging output.