### PR TITLE
nginx: QUIC: Fix SSL 3.0 deprecated function

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.25.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/

--- a/net/nginx/patches/nginx/300-fix-deprecated-openssl-3_0.patch
+++ b/net/nginx/patches/nginx/300-fix-deprecated-openssl-3_0.patch
@@ -1,0 +1,12 @@
+--- a/src/event/quic/ngx_event_quic_protection.c
++++ b/src/event/quic/ngx_event_quic_protection.c
+@@ -510,7 +510,7 @@ ngx_quic_crypto_common(ngx_quic_secret_t
+         }
+     }
+ 
+-    if (EVP_CIPHER_mode(EVP_CIPHER_CTX_cipher(ctx)) == EVP_CIPH_CCM_MODE
++    if (EVP_CIPHER_mode(EVP_CIPHER_CTX_get0_cipher(ctx)) == EVP_CIPH_CCM_MODE
+         && EVP_CipherUpdate(ctx, NULL, &len, NULL, in->len) != 1)
+     {
+         ngx_ssl_error(NGX_LOG_INFO, log, 0, "EVP_CipherUpdate() failed");
+


### PR DESCRIPTION
`EVP_CIPHER_CTX_cipher()` function was deprecated in OpenSSL 3.0. As per OpenSSL's recommendation (https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_CTX_get0_cipher.html) switch to using `EVP_CIPHER_CTX_get0_cipher()` instead.

This would remedy the following:
```
  -L/data/code/openwrt/ipq/staging_dir/target-aarch64_cortex-a53_musl/usr/lib -L/data/code/openwrt/ipq/staging_dir/toolchain-aarch64_cortex-a53_gcc-13.2.0_musl/usr/lib -L/data/code/openwr  t/ipq/staging_dir/toolchain-aarch64_cortex-a53_gcc-13.2.0_musl/lib -fuse-ld=mold -Wl,--gc-sections -flto=auto -fuse-linker-plugin -zrelro \
  -shared
  mold: error: undefined symbol: EVP_CIPHER_CTX_cipher
  >>> referenced by <artificial>
  >>>               /data/code/openwrt/ipq/tmp/ccBL6cZK.ltrans24.ltrans.o:(ngx_quic_crypto_common.isra.0)>>> referenced by <artificial>
  >>>               /data/code/openwrt/ipq/tmp/ccBL6cZK.ltrans24.ltrans.o:(ngx_quic_crypto_common.isra.0)
  collect2: error: ld returned 1 exit status
  make[4]: *** [objs/Makefile:325: objs/nginx] Error 1
```

With this change and recent commit to nginx-util #23935. We should now be able to build `nginx` + `modules` with fully compliant calls to OpenSSL 3.0+, with legacy features disabled.

Run tested: aarch64, Dynalink DL-WRX36, Master Branch
Maintainer: Thomas Heil [heil@terminal-consulting.de](mailto:heil@terminal-consulting.de), Christian Marangi [ansuelsmth@gmail.com](mailto:ansuelsmth@gmail.com)