### PR TITLE
tinyproxy: fix upstream config generation

### DIFF
--- a/net/tinyproxy/Makefile
+++ b/net/tinyproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tinyproxy
 PKG_VERSION:=1.11.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/tinyproxy/tinyproxy/releases/download/$(PKG_VERSION)

--- a/net/tinyproxy/files/tinyproxy.init
+++ b/net/tinyproxy/files/tinyproxy.init
@@ -24,10 +24,10 @@ write_upstream() {
 	[ -n "$target" ] && target=' "'"$target"'"'
 
 	[ "$type" = "proxy" ] && [ -n "$via" ] && \
-		echo "upstream $via$target"
+		echo "upstream http $via$target"
 
 	[ "$type" = "reject" ] && [ -n "$target" ] && \
-		echo "no upstream$target"
+		echo "upstream none$target"
 }
 
 proxy_atom() {


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: N/A
Run tested: Xiaomi Mi Router 3G, OpenWrt 22.03.5, r20134-5f15225c1e

Description:
Fixes generation of upstream record as reported in #19942
