### PR TITLE
ibrespeed-go: config improvements

### DIFF
--- a/net/librespeed-go/Makefile
+++ b/net/librespeed-go/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=librespeed-go
 PKG_VERSION:=1.1.5
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/librespeed/speedtest-go/tar.gz/v$(PKG_VERSION)?
@@ -39,10 +39,10 @@ define Package/librespeed-go
 endef
 
 define Package/librespeed-go/description
-  No Flash, No Java, No WebSocket, No Bullshit.
-
   This is a very lightweight speed test implemented in JavaScript,
   using XMLHttpRequest and Web Workers.
+
+  No Flash, No Java, No WebSocket, No Bullshit.
 endef
 
 define Package/librespeed-go/conffiles


### PR DESCRIPTION
Maintainer: @1715173329
Compile tested: no
Run tested: no

Description: This softens a couple of [rough edges that I ran into when trying to use this package.](https://forum.openwrt.org/t/how-do-i-use-the-librespeed-go-package/195804) 

* The first change reorders the description so that the one line you get in the LuCI Software page should read "This is a very lightweight speed test implemented in JavaScript,..." instead of what it currently shows:
  <img width="949" alt="Screenshot 2024-04-24 at 11 28 57 AM" src="https://github.com/nfriedly/openwrt-packages/assets/114976/c3345f59-1b6a-47df-8895-a520dcbbf919">


* ~~The second is a configuration change to enable it by default, which should allow it to be managed via the Startup page in LuCI. (Without this change, it appears there, but none of the buttons actually work.)~~ dropped now.
  <img width="957" alt="Screenshot 2024-04-25 at 11 19 18 AM" src="https://github.com/nfriedly/openwrt-packages/assets/114976/ebd4f4b0-f47e-463e-8d0f-aa8db26510f5">

I put both of these into the same PR, but I can split them into two if desired.

Neither change was tested locally. I initially checked out the code and attempted to run the Makefile, but quickly realized that it's a lot more involved than that. I may be able to figure it out if necessary, but I'd appreciate it if someone else who already has a working buildroot setup would test it for me instead.