### PR TITLE
net/nut: Build nut-driver-snmp-ups by default

### DIFF
--- a/net/nut/Config.in
+++ b/net/nut/Config.in
@@ -22,7 +22,7 @@
 		bool "Build with support for SNMP drivers"
 		help
 			If you have a UPS you can connect to via SNMP, select this.
-		default n
+		default y
 
 	config NUT_DRIVER_SERIAL
 		depends on PACKAGE_nut

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -97,9 +97,6 @@ define Package/nut-common
 	$(call Package/nut/Default)
 	TITLE+= (common)
 	DEPENDS:= nut \
-		+NUT_DRIVER_SNMP:libnetsnmp \
-		+NUT_DRIVER_USB:libusb-compat \
-		+NUT_DRIVER_NEON:libneon \
 		+NUT_SSL:libopenssl
 endef
 
@@ -368,10 +365,9 @@ define DriverPackage
 		$(call Package/nut/Default)
 		TITLE:=$(2) (NUT $(1) driver)
 		DEPENDS:=nut +nut-server
-		$(if $(filter $(1),snmp),DEPENDS+= @NUT_DRIVER_SNMP)
-		$(if $(filter $(1),usb),DEPENDS+= @NUT_DRIVER_USB)
-		$(if $(filter $(1),serial),DEPENDS+= @NUT_DRIVER_SERIAL)
-                $(if $(filter $(1),neon),DEPENDS+= @NUT_DRIVER_NEON)
+		$(if $(filter $(1),snmp),DEPENDS+= +libnetsnmp)
+		$(if $(filter $(1),usb),DEPENDS+= +libusb-compat)
+                $(if $(filter $(1),neon),DEPENDS+= +libneon)
         endef
 	# Deliberately empty description in order to trigger a build failure.
 	# It should be overridden by the list below, and when updating to a


### PR DESCRIPTION
Maintainer: @neheb 
Compile tested: no
Run tested: no

Description:

net/nut: Build nut-driver-snmp-ups by default

Also removes library dependencies from nut-common package:

These deps aren't actually common to all drivers and we don't want to pull in libnetsnmp for all installations so with this change the respective lib dep is specified on the driver packages only.