### PR TITLE
[23.05] adblock-fast: bugfix: unbound-related fixes

### DIFF
--- a/net/adblock-fast/Makefile
+++ b/net/adblock-fast/Makefile
@@ -1,14 +1,14 @@
-# Copyright 2023 MOSSDeF, Stan Grishin (stangri@melmac.ca)
-# TLD optimization written by Dirk Brenken (dev@brenken.org)
-# This is free software, licensed under the GNU General Public License v3.
+# Copyright 2023-2024 MOSSDeF, Stan Grishin (stangri@melmac.ca).
+# TLD optimization written by Dirk Brenken (dev@brenken.org).
+# This is free software, licensed under AGPL-3.0-or-later.
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=r8
+PKG_RELEASE:=11
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE:=AGPL-3.0-or-later
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/adblock-fast/files/etc/init.d/adblock-fast
+++ b/net/adblock-fast/files/etc/init.d/adblock-fast
@@ -52,7 +52,7 @@ readonly smartdnsNftsetFilter=';'
 readonly unboundFile="/var/lib/unbound/adb_list.${packageName}"
 readonly unboundCache="/var/run/${packageName}/unbound.cache"
 readonly unboundGzip="${packageName}.unbound.gz"
-readonly unboundFilter='s|^|local-zone: "|;s|$|" static|'
+readonly unboundFilter='s|^|local-zone: "|;s|$|." always_nxdomain|'
 readonly A_TMP="/var/${packageName}.a.tmp"
 readonly B_TMP="/var/${packageName}.b.tmp"
 readonly SED_TMP="/var/${packageName}.sed.tmp"
@@ -267,7 +267,7 @@ dns_set_output_values() {
 			outputFilter="$unboundFilter"
 			outputFile="$unboundFile"
 			outputCache="$unboundCache"
-			outputGzip="$unboundGzip"
+			outputGzip="${compressed_cache_dir}/${unboundGzip}"
 		;;
 	esac
 }
@@ -757,7 +757,7 @@ load_environment() {
 	[ "$dns" = 'smartdns.domainset' ] || rm -f "$smartdnsDomainSetFile" "$smartdnsDomainSetCache" "${compressed_cache_dir}/${smartdnsDomainSetGzip}" "$smartdnsDomainSetConfig"
 	[ "$dns" = 'smartdns.ipset' ]     || rm -f "$smartdnsIpsetFile" "$smartdnsIpsetCache" "${compressed_cache_dir}/${smartdnsIpsetGzip}" "$smartdnsIpsetConfig"
 	[ "$dns" = 'smartdns.nftset' ]    || rm -f "$smartdnsNftsetFile" "$smartdnsNftsetCache" "${compressed_cache_dir}/${smartdnsNftsetGzip}" "$smartdnsNftsetConfig"
-	[ "$dns" = 'unbound.adb_list' ]   || rm -f "$unboundFile" "$unboundCache" "$unboundGzip"
+	[ "$dns" = 'unbound.adb_list' ]   || rm -f "$unboundFile" "$unboundCache" "${compressed_cache_dir}/${unboundGzip}"
 
 	for i in "$runningConfigFile" "$runningErrorFile" "$runningStatusFile" "$outputFile" "$outputCache" "$outputGzip" "$outputConfig"; do
 		[ -n "$i" ] || continue
@@ -892,7 +892,7 @@ resolver() {
 			rm -f "$smartdnsDomainSetFile" "$smartdnsDomainSetCache" "${compressed_cache_dir}/${smartdnsDomainSetGzip}" "$smartdnsDomainSetConfig"
 			rm -f "$smartdnsIpsetFile" "$smartdnsIpsetCache" "${compressed_cache_dir}/${smartdnsIpsetGzip}" "$smartdnsIpsetConfig"
 			rm -f "$smartdnsNftsetFile" "$smartdnsNftsetCache" "${compressed_cache_dir}/${smartdnsNftsetGzip}" "$smartdnsNftsetConfig"
-			rm -f "$unboundFile" "$unboundCache" "$unboundGzip"
+			rm -f "$unboundFile" "$unboundCache" "${compressed_cache_dir}/${unboundGzip}"
 			if [ -s "/etc/config/dhcp" ]; then
 				config_load 'dhcp'
 				config_foreach _dnsmasq_instance_config 'dnsmasq' 'cleanup'
@@ -932,19 +932,19 @@ resolver() {
 			case "$dns" in
 				dnsmasq.*)
 					chmod 660 "$outputFile"
-					chown root:dnsmasq "$outputFile"
+					chown root:dnsmasq "$outputFile" >/dev/null 2>/dev/null
 					param='dnsmasq_restart'
 					output_text='Restarting dnsmasq'
 				;;
 				smartdns.*)
 					chmod 660 "$outputFile" "$outputConfig"
-					chown root:root "$outputFile" "$outputConfig"
+					chown root:root "$outputFile" "$outputConfig" >/dev/null 2>/dev/null
 					param='smartdns_restart'
 					output_text='Restarting SmartDNS'
 				;;
 				unbound.*)
 					chmod 660 "$outputFile"
-					chown root:unbound "$outputFile"
+					chown root:unbound "$outputFile" >/dev/null 2>/dev/null
 					param='unbound_restart'
 					output_text='Restarting Unbound'
 				;;
@@ -1036,7 +1036,7 @@ cache() {
 			return $?
 		;;
 		test_gzip)
-			[ -s "$outputGzip" ] && gzip -t -c "$outputGzip"
+			[ -s "$outputGzip" ] && gzip -t -c "$outputGzip" >/dev/null 2>/dev/null
 			return $?
 		;;
 		create_gzip)
@@ -1412,6 +1412,11 @@ $(sed '/^[[:space:]]*$/d' "$A_TMP")"
 		output_failn
 		json add error 'errorMovingDataFile'
 	fi
+	case "$dns" in
+		unbound.adb_list)
+			sed -i '1 i\server:' "$outputFile"
+		;;
+	esac
 	if [ "$compressed_cache" -gt 0 ]; then
 		output 2 'Creating compressed cache '
 		json set message "$(get_text 'statusProcessing'): creating compressed cache"
@@ -1596,7 +1601,7 @@ adb_check() {
 					smartdns.*)
 						grep "$string" "$outputFile";;
 					unbound.adb_list)
-						grep "$string" "$outputFile" | sed 's|^local-zone: "||;s|" static$||;';;
+						grep "$string" "$outputFile" | sed 's|^local-zone: "||;s|." always_nxdomain$||;';;
 				esac
 			fi
 		else


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.3
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.3

Description:
* include `server:` directive at the top of unbound file
* update unbound-related outputGzip variable to include full path
* return always_nxdomain for blocked domains
* also update copyright stamp/license

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 474587a1f44db8b66caca8bdde9c2dd64b480638)
