### PR TITLE
transmission: update to version 4.0.5

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
-PKG_VERSION:=4.0.4
+PKG_VERSION:=4.0.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/transmission/transmission/releases/download/$(PKG_VERSION)/
-PKG_HASH:=15f7b4318fdfbffb19aa8d9a6b0fd89348e6ef1e86baa21a0806ffd1893bd5a6
+PKG_HASH:=fd68ff114a479200043c30c7e69dba4c1932f7af36ca4c5b5d2edcb5866e6357
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile and run tested: Turris Omnia, mvebu/cortex-a9, Marvell Armada 385, OpenWrt master

Release notes:
https://github.com/transmission/transmission/releases/tag/4.0.5

