### PR TITLE
msmtp: update to version 1.8.25

### DIFF
--- a/mail/msmtp/Makefile
+++ b/mail/msmtp/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=msmtp
-PKG_VERSION:=1.8.24
+PKG_VERSION:=1.8.25
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://marlam.de/msmtp/releases
-PKG_HASH:=bd6644b1aaab17d61b86647993e3efad860b23c54283b00ddc579c1f5110aa59
+PKG_HASH:=2dfe1dbbb397d26fe0b0b6b2e9cd2efdf9d72dd42d18e70d7f363ada2652d738
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
Maintainer: no one
Host env: MacBook A1990, Sonoma 14.4.1
Run tested: Turris Omnia, mvebu/cortexa9, OpenWrt 22.03.6

Release notes:
https://marlam.de/msmtp/news/msmtp-1-8-25/
