### PR TITLE
boost: Updates package to version 1.85.0

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -11,13 +11,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=boost
-PKG_VERSION:=1.84.0
-PKG_SOURCE_VERSION:=1_84_0
+PKG_VERSION:=1.85.0
+PKG_SOURCE_VERSION:=1_85_0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://boostorg.jfrog.io/artifactory/main/release/$(PKG_VERSION)/source/
-PKG_HASH:=cc4b893acf645c9d4b698e9a0f08ca8846aa5d6c68275c14c3e7949c24109454
+PKG_HASH:=7009fe1faa1697476bdc7027703a2badb84e849b7b0baad5086b087b971f8617
 
 PKG_MAINTAINER:=Carlos M. Ferreira <carlosmf.pt@gmail.com>
 PKG_LICENSE:=BSL-1.0
@@ -42,13 +42,14 @@ define Package/boost/Default
 endef
 
 define Package/boost/description
-This package provides the Boost v1.84.0 libraries.
+This package provides the Boost v1.85.0 libraries.
 Boost is a set of free, peer-reviewed, portable C++ source libraries.
 
 This package provides the following run-time libraries:
  - atomic
+ - charconv (new)
  - chrono
- - cobalt (new)
+ - cobalt
  - container
  - context
  - contract
@@ -79,7 +80,7 @@ This package provides the following run-time libraries:
  - wave
 
 There are many more header-only libraries supported by Boost.
-See more at http://www.boost.org/doc/libs/1_84_0/
+See more at http://www.boost.org/doc/libs/1_85_0/
 endef
 
 PKG_BUILD_DEPENDS:=boost/host
@@ -336,6 +337,7 @@ define DefineBoostLibrary
 endef
 
 $(eval $(call DefineBoostLibrary,atomic,system))
+$(eval $(call DefineBoostLibrary,charconv,,,,libquadmath))
 $(eval $(call DefineBoostLibrary,chrono,system))
 $(eval $(call DefineBoostLibrary,cobalt,system container))
 $(eval $(call DefineBoostLibrary,container))


### PR DESCRIPTION
Maintainer: @ClaymorePT 
Compile tested: bcm27xx (bcm2712) and x86_64 - used development snapshot from the 27th of April. 
Run tested: N/A

Description:
This commit updates boost to version 1.85.0

New available libraries:
* *Charconv:* A high quality implementation of \<charconv\> in C++11, from Matt Borland. [2]
* *Scope:* A collection of scope guard utilities and a unique_resource wrapper, from Andrey Semashev. [3]

More info about Boost 1.85.0 can be found at the usual place [1].

[1]: https://www.boost.org/users/history/version_1_85_0.html
[2]: https://www.boost.org/libs/charconv/
[3]: https://www.boost.org/libs/scope/