### PR TITLE
[WIP] natmap: add dynamic firewall rules support

### DIFF
--- a/net/natmap/files/natmap-update.sh
+++ b/net/natmap/files/natmap-update.sh
@@ -1,17 +1,20 @@
 #!/bin/sh
 
-. /usr/share/libubox/jshn.sh
+[ -z "${CONFIG_SECTION_ID}" ] && exit 1
+export -n CONFIG_SECTION_ID
 
 (
+	. /usr/share/libubox/jshn.sh
+
 	json_init
 	json_add_string ip "$1"
 	json_add_int port "$2"
 	json_add_int inner_port "$4"
 	json_add_string protocol "$5"
-	json_dump > /var/run/natmap/$PPID.json
+	json_dump > "/var/run/natmap/${CONFIG_SECTION_ID}.json"
 )
 
-[ -n "${NOTIFY_SCRIPT}" ] && {
-	export -n NOTIFY_SCRIPT
-	exec "${NOTIFY_SCRIPT}" "$@"
-}
+. /lib/functions.sh
+
+NOTIFY_SCRIPT="$(uci_get natmap "${CONFIG_SECTION_ID}" notify_script)"
+[ "$?" -eq 0 ] && [ -n "${NOTIFY_SCRIPT}" ] && exec "${NOTIFY_SCRIPT}" "$@"

--- a/net/natmap/files/natmap.init
+++ b/net/natmap/files/natmap.init
@@ -61,7 +61,7 @@ natmap_instance() {
 
 	[ -n "${forward_target}" ] && procd_append_param command -t "$forward_target" -p "$forward_port"
 
-	[ -n "${notify_script}" ] && procd_set_param env "NOTIFY_SCRIPT=${notify_script}"
+	procd_set_param env "CONFIG_SECTION_ID=$1"
 	procd_append_param command -e /usr/lib/natmap/update.sh
 
 	procd_set_param respawn


### PR DESCRIPTION
Maintainer: me and @heiher
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
This PR is working in progress.

I have some questions about dynamic firewall rules.
`fw4` can read dynamic rules from service data ([link](https://github.com/openwrt/firewall4/blob/698a53354fd280aae097efe08803c0c9a10c14c2/root/usr/share/ucode/fw4.uc#L573)).
But setting `data` of a `service` would override other parameters ([link](https://github.com/openwrt/procd/blob/946552a7b598a0b88db6101e864679554ec4f221/service/service.c#L123-L141)).
So the `data` of a `service` should be set when service starting? No after service started?
If so, is there another way to add non-persistent firewall rules?