### PR TITLE
keepalived: remove not supported notify script handling

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.2.8
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software

--- a/net/keepalived/files/keepalived.config
+++ b/net/keepalived/files/keepalived.config
@@ -78,10 +78,6 @@ config global_defs
 #	list group		"VI_1"
 #	list group		"VI_2"
 #	option smtp_alert	"1"
-#	option notify_backup	"<switch-backup-state-script>"
-#	option notify_master	"<switch-master-state-script>"
-#	option notify_fault	"<switch-fault-state-script>"
-#	option notify		"<switch-any-state-script>"
 #	option global_tracking	1
 
 #config track_interface
@@ -131,11 +127,6 @@ config global_defs
 #	option nopreempt		"1"
 #	option preempt_delay		"500"
 #	option debug			"2"
-#	option notify_backup		"<switch-backup-state-script>"
-#	option notify_master		"<switch-master-state-script>"
-#	option notify_fault		"<switch-fault-state-script>"
-#	option notify_stop		"<switch-stop-state-script>"
-#	option notify			"<switch-any-state-script>"
 #	option smtp_alert		"1"
 #	option accept			"1"
 


### PR DESCRIPTION
Maintainer: me
Compile tested: no
Run tested: no

Description:
fixes #24021 
This is not supported by keepalived uci configuration handling.
If a script should be called by a notify event, then the script must be placed under the directory '/etc/hotplug.d/keepalived'.