### PR TITLE
speedtest-netperf Update  to replace egrep with grep -E

### DIFF
--- a/net/speedtest-netperf/files/speedtest-netperf.sh
+++ b/net/speedtest-netperf/files/speedtest-netperf.sh
@@ -163,7 +163,7 @@ sample_load() {
 	cat /proc/$$/stat
 	while : ; do
 		sleep 1s
-		egrep "^cpu[0-9]*" /proc/stat
+		grep -E "^cpu[0-9]*" /proc/stat
 		for c in $cpus; do
 			[ -r $c/$f ] && echo "cpufreq $(basename $c) $(cat $c/$f)"
 		done


### PR DESCRIPTION
egrep is bash dependent and also obsolete.

Maintainer: me / @guidosarducci  (find it by checking history of the package Makefile)

Run tested: (put here arch, model, OpenWrt version, tests done)

Linux OpenWrt 5.15.150 #0 SMP Fri Mar 22 22:09:42 2024 armv7l GNU/Linux
linksys wrt1200
openwrt OpenWrt 23.05.3, r23809-234f1a2efa

Description:
fixed a bug (egrep is obsolete) 
