### PR TITLE
transmission: fix compile with mbedtls3.X

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=4.0.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/transmission/transmission/releases/download/$(PKG_VERSION)/

--- a/net/transmission/patches/010-temp-mbedtls3-compile.patch
+++ b/net/transmission/patches/010-temp-mbedtls3-compile.patch
@@ -1,0 +1,70 @@
+From da7d6fe0e1b162eac6cc048153ff7f201975b6c4 Mon Sep 17 00:00:00 2001
+From: Seo Suchan <tjtncks@gmail.com>
+Date: Thu, 2 May 2024 03:34:12 +0900
+Subject: [PATCH] fix compile with mbedtls 3.x
+
+Signed-off-by: Seo Suchan <tjtncks@gmail.com>
+---
+ libtransmission/crypto-utils-mbedtls.cc | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+--- a/libtransmission/crypto-utils-mbedtls.cc
++++ b/libtransmission/crypto-utils-mbedtls.cc
+@@ -117,7 +117,7 @@ public:
+     {
+         mbedtls_sha1_init(&handle_);
+ 
+-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
++#if MBEDTLS_VERSION_NUMBER < 0x03000000 && MBEDTLS_VERSION_NUMBER >= 0x02070000
+         mbedtls_sha1_starts_ret(&handle_);
+ #else
+         mbedtls_sha1_starts(&handle_);
+@@ -128,7 +128,7 @@ public:
+     {
+         if (data_length > 0U)
+         {
+-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
++#if MBEDTLS_VERSION_NUMBER < 0x03000000 && MBEDTLS_VERSION_NUMBER >= 0x02070000
+             mbedtls_sha1_update_ret(&handle_, static_cast<unsigned char const*>(data), data_length);
+ #else
+             mbedtls_sha1_update(&handle_, static_cast<unsigned char const*>(data), data_length);
+@@ -140,7 +140,7 @@ public:
+     {
+         auto digest = tr_sha1_digest_t{};
+         auto* const digest_as_uchar = reinterpret_cast<unsigned char*>(std::data(digest));
+-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
++#if MBEDTLS_VERSION_NUMBER < 0x03000000 && MBEDTLS_VERSION_NUMBER >= 0x02070000
+         mbedtls_sha1_finish_ret(&handle_, digest_as_uchar);
+ #else
+         mbedtls_sha1_finish(&handle_, digest_as_uchar);
+@@ -168,10 +168,10 @@ public:
+     {
+         mbedtls_sha256_init(&handle_);
+ 
+-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
++#if MBEDTLS_VERSION_NUMBER < 0x03000000 && MBEDTLS_VERSION_NUMBER >= 0x02070000
+         mbedtls_sha256_starts_ret(&handle_, 0);
+ #else
+-        mbedtls_sha256_starts(&handle_);
++        mbedtls_sha256_starts(&handle_, 0);
+ #endif
+     }
+ 
+@@ -179,7 +179,7 @@ public:
+     {
+         if (data_length > 0U)
+         {
+-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
++#if MBEDTLS_VERSION_NUMBER < 0x03000000 && MBEDTLS_VERSION_NUMBER >= 0x02070000
+             mbedtls_sha256_update_ret(&handle_, static_cast<unsigned char const*>(data), data_length);
+ #else
+             mbedtls_sha256_update(&handle_, static_cast<unsigned char const*>(data), data_length);
+@@ -191,7 +191,7 @@ public:
+     {
+         auto digest = tr_sha256_digest_t{};
+         auto* const digest_as_uchar = reinterpret_cast<unsigned char*>(std::data(digest));
+-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
++#if MBEDTLS_VERSION_NUMBER < 0x03000000 && MBEDTLS_VERSION_NUMBER >= 0x02070000
+         mbedtls_sha256_finish_ret(&handle_, digest_as_uchar);
+ #else
+         mbedtls_sha256_finish(&handle_, digest_as_uchar);


### PR DESCRIPTION
Signed-off-by: Seo Suchan <tjtncks@gmail.com>

Maintainer: Daniel Golle <daniel@makrotopia.org> / @dangowrt (find it by checking history of the package Makefile)
Compile tested: x64, libvirt, master
Run tested:  x64, libvirt, master, downloading a torrent

Description: insert a patch to make it use renamed function names when complied againest  mbedtls3.x, while update to most resent version too.

Fixes: https://github.com/openwrt/packages/issues/24120

