### PR TITLE
snort3: build against gperftools for more than x86

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.1.84.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
@@ -28,9 +28,8 @@ define Package/snort3
   CATEGORY:=Network
   DEPENDS:= \
 	    +(TARGET_x86||TARGET_x86_64):hyperscan-runtime \
-	    +(TARGET_x86||TARGET_x86_64):gperftools-runtime \
-	    +libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre2 +libpthread \
-	    +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic \
+	    +gperftools-runtime +libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre2 \
+	    +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic \
 	    +kmod-nft-queue +liblzma +ucode +ucode-mod-fs +ucode-mod-uci
   TITLE:=Lightweight Network Intrusion Detection System
   URL:=http://www.snort.org/
@@ -45,11 +44,9 @@ define Package/snort3/description
   attacks.
 endef
 
-# Hyperscan and gperftools only builds for x86
+# Hyperscan only builds for x86
 ifdef CONFIG_TARGET_x86_64
-	CMAKE_OPTIONS += -DHS_INCLUDE_DIRS=$(STAGING_DIR)/usr/include/hs \
-			 -DENABLE_TCMALLOC=ON \
-			 -DTCMALLOC_LIBRARIES=$(STAGING_DIR)/usr/lib/libtcmalloc.so
+	CMAKE_OPTIONS += -DHS_INCLUDE_DIRS=$(STAGING_DIR)/usr/include/hs
 endif
 
 CMAKE_OPTIONS += \
@@ -65,6 +62,8 @@ CMAKE_OPTIONS += \
 	-DMAKE_PDF_DOC:BOOL=NO \
 	-DMAKE_TEXT_DOC:BOOL=NO \
 	-DHAVE_LIBUNWIND=OFF \
+	-DENABLE_TCMALLOC=ON \
+	-DTCMALLOC_LIBRARIES=$(STAGING_DIR)/usr/lib/libtcmalloc.so \
 	-DHAVE_LZMA=ON
 
 TARGET_CFLAGS  += -I$(STAGING_DIR)/usr/include/daq3 -I$(STAGING_DIR)/usr/include/tirpc


### PR DESCRIPTION
Other targets should be able to build against gperftools and realize speed and efficiency gains.

Build system: x86/64
Build-tested: bcm27xx/bcm2712
Run-tested: bcm27xx/bcm2712

Maintainer: me @flyn-org 