### PR TITLE
knot-resolver: fix make config

### DIFF
--- a/net/knot-resolver/Config.in
+++ b/net/knot-resolver/Config.in
@@ -1,12 +1,15 @@
 menu "Configuration"
-	config PACKAGE_knot-resolver_dnstap
-		bool "Build with dnstap support"
-		default y
-		help
-			knot-resolver dnstap module supports logging DNS responses
-			to a unix socket in dnstap format using fstrm framing library.
-			This logging is useful if you need effectivelly log all
-			DNS traffic.
-			The unix socket and the socket reader must be present before
-			starting resolver instances.
+	depends on PACKAGE_knot-resolver
+
+config PACKAGE_knot-resolver_dnstap
+	bool "Build with dnstap support"
+	default n
+	help
+		knot-resolver dnstap module supports logging DNS responses
+		to a unix socket in dnstap format using fstrm framing library.
+		This logging is useful if you need effectivelly log all
+		DNS traffic.
+		The unix socket and the socket reader must be present before
+		starting resolver instances.
+
 endmenu

--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -21,6 +21,9 @@ PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=GPL-3.0-later
 PKG_LICENSE_FILES:=COPYING
 
+PKG_CONFIG_DEPENDS:= \
+        CONFIG_PACKAGE_knot-resolver_dnstap
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/meson.mk
 
@@ -40,8 +43,8 @@ define Package/knot-resolver
     +libstdcpp \
     +libnghttp2 \
     +lmdb \
-    PACKAGE_knot-resolver_dnstap:libfstrm \
-    PACKAGE_knot-resolver_dnstap:libprotobuf-c
+    +PACKAGE_knot-resolver_dnstap:libfstrm \
+    +PACKAGE_knot-resolver_dnstap:libprotobuf-c
   USERID:=kresd=3536:kresd=3536
 endef
 


### PR DESCRIPTION
* Fix errors in make config preventing e.g. `menuconfig` from working, and `knot-resolver` from being included in builds

Maintainer: @miska

Build system: x86/64
Compile tested: rockchip/armv8, nanopi-r4s, be37ab6e51 snapshot build
Run tested: rockchip/armv8, nanopi-r4s, be37ab6e51 snapshot build, running on my main router
