### PR TITLE
gnutls: Update to version 3.8.5

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
-PKG_VERSION:=3.8.3
+PKG_VERSION:=3.8.5
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.8
-PKG_HASH:=f74fc5954b27d4ec6dfbb11dea987888b5b124289a3703afcada0ee520f4173e
+PKG_HASH:=66269a2cfe0e1c2dabec87bdbbd8ab656f396edd9a40dd006978e003cfa52bfc
 
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <nmav@gnutls.org>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/libs/gnutls/patches/010-m4.patch
+++ b/libs/gnutls/patches/010-m4.patch
@@ -62,7 +62,7 @@
      [AC_COMPILE_IFELSE(
 --- a/src/gl/m4/gnulib-comp.m4
 +++ b/src/gl/m4/gnulib-comp.m4
-@@ -1252,7 +1252,7 @@ changequote([, ])dnl
+@@ -1268,7 +1268,7 @@ changequote([, ])dnl
    gl_UNISTD_MODULE_INDICATOR([sleep])
    AC_CHECK_DECLS_ONCE([alarm])
    AC_REQUIRE([gt_TYPE_WCHAR_T])

--- a/libs/gnutls/patches/030-unistring-optional.patch
+++ b/libs/gnutls/patches/030-unistring-optional.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -471,6 +471,8 @@ DEFAULT_VALGRINDFLAGS='-q --error-exitco
+@@ -508,6 +508,8 @@ DEFAULT_VALGRINDFLAGS='-q --error-exitco
  
  gl_VALGRIND_TESTS_DEFAULT_NO
  


### PR DESCRIPTION
All patches automatically refreshed.

The most important changes are two "medium" CVEs fixed in GnuTLS 3.8.4:

- CVE-2024-28834 / GNUTLS-SA-2023-12-04
  A vulnerability was found that the deterministic ECDSA code leaks
  bit-length of random nonce which allows for full recovery of the
  private key used after observing a few hundreds to a few thousands of
  signatures on known messages, due to the application of lattice
  techniques.
  The issue was reported in the issue tracker as [#1516](https://gitlab.com/gnutls/gnutls/-/issues/1516).
- CVE-2024-28835 / GNUTLS-SA-2024-01-23
  When validating a certificate chain with more then 16 certificates
  GnuTLS applications crash with an assertion failure.
  The issue was reported in the issue tracker as [#1527](https://gitlab.com/gnutls/gnutls/-/issues/1527) and [#1525](https://gitlab.com/gnutls/gnutls/-/issues/1525).

Augmented copy/extract from upstream's NEWS file since GnuTLS 3.8.3:

- Version 3.8.5 (released 2024-04-04)
  - libgnutls: Due to majority of usages and implementations of
    RSA decryption with PKCS#1 v1.5 padding being incorrect,
    leaving them vulnerable to Marvin attack, the RSAES-PKCS1-v1_5
    is being deprecated (encryption and decryption) and will be
    disabled in the future. A new option `allow-rsa-pkcs1-encrypt`
    has been added into the system-wide library configuration which
    allows to enable/disable the RSAES-PKCS1-v1_5. Currently, the
    RSAES-PKCS1-v1_5 is enabled by default.
  - libgnutls: Added support for RIPEMD160 and PBES1-DES-SHA1 for
    backward compatibility with GCR.
  - libgnutls: A couple of memory related issues have been fixed in RSA PKCS#1
    v1.5 decryption error handling and deterministic ECDSA with earlier
    versions of GMP.  These were a regression introduced in the 3.8.4
    release. See [#1535](https://gitlab.com/gnutls/gnutls/-/issues/1535) and [!1827](https://gitlab.com/gnutls/gnutls/-/merge_requests/1827).
  - build: Fixed a bug where building gnutls statically failed due
    to a duplicate definition of `nettle_rsa_compute_root_tr()`.
  - API and ABI modifications:
    - `GNUTLS_PKCS_PBES1_DES_SHA1`: New enum member of `gnutls_pkcs_encrypt_flags_t`.
- Version 3.8.4 (released 2024-03-18)
  - libgnutls: RSA-OAEP encryption scheme is now supported
    To use it with an unrestricted RSA private key, one would need to
    initialize a `gnutls_x509_spki_t` object with necessary parameters
    for RSA-OAEP and attach it to the private key. It is also possible
    to import restricted private keys if they are stored in PKCS#8
    format.
  - libgnutls: Fix side-channel in the deterministic ECDSA.
    Reported by George Pantelakis ([#1516](https://gitlab.com/gnutls/gnutls/-/issues/1516)).
    [GNUTLS-SA-2023-12-04, CVSS: medium] [CVE-2024-28834]
  - libgnutls: Fixed a bug where certtool crashed when verifying a certificate
    chain with more than 16 certificates. Reported by William Woodruff ([#1525](https://gitlab.com/gnutls/gnutls/-/issues/1525))
    and yixiangzhike ([#1527](https://gitlab.com/gnutls/gnutls/-/issues/1527)).
    [GNUTLS-SA-2024-01-23, CVSS: medium] [CVE-2024-28835]
  - libgnutls: Compression libraries are now loaded dynamically as needed
    instead of all being loaded during gnutls library initialization.
    As a result, the library initialization should be faster.
  - build: The gnutls library can now be linked with the static library
    of GMP.  Note that in order for this to work libgmp.a needs to be
    compiled with -fPIC and libhogweed in Nettle also has to be linked
    to the static library of GMP.  This can be used to prevent custom
    memory allocators from being overriden by other applications.
  - API and ABI modifications:
    - `gnutls_x509_spki_get_rsa_oaep_params`: New function.
    - `gnutls_x509_spki_set_rsa_oaep_params`: New function.
    - `GNUTLS_PK_RSA_OAEP`: New enum member of `gnutls_pk_algorithm_t`.

Signed-off-by: Pascal Ernster <git@hardfalcon.net>