### PR TITLE
nghttp3: drop maintainership

### DIFF
--- a/libs/nghttp3/Makefile
+++ b/libs/nghttp3/Makefile
@@ -4,13 +4,13 @@ PKG_NAME:=nghttp3
 PKG_VERSION:=1.2.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://github.com/ngtcp2/$(PKG_NAME)/releases/download/v$(PKG_VERSION)/
-PKG_HASH:=d2e216bae7bd7362f850922e4237a5caa204853b3594b22adccab4c1e1c1d1aa
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/ngtcp2/nghttp3/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=0cc9b943f61a135e08b80bdcc4c1181f695df18fbb5fa93509a58d7d971dca75
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
+PKG_MAINTAINER:=
 
 CMAKE_INSTALL:=1
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.3
Run tested: n/a

Description:
* switch back to using tar.gz archives, switch to xz was probably unnecessary and the previous problem building from the tagged release gz was probably cache-related
* drop maintainership
