### PR TITLE
ngtcp2: drop maintainership

### DIFF
--- a/libs/ngtcp2/Makefile
+++ b/libs/ngtcp2/Makefile
@@ -4,13 +4,13 @@ PKG_NAME:=ngtcp2
 PKG_VERSION:=1.4.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://github.com/ngtcp2/$(PKG_NAME)/releases/download/v$(PKG_VERSION)/
-PKG_HASH:=b5d1433b9f5c06ce249e1e390e97dcfa49bf7ada5cb7c8bed8e6cd4feaf1ca4a
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/ngtcp2/ngtcp2/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=163e26e6e7531b8bbcd7ec53d2c6b4ff3cb7d3654fde37b091e3174d37a8acd7
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
+PKG_MAINTAINER:=
 
 CMAKE_INSTALL:=1
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.3
Run tested: n/a

Description:
* switch back to using tar.gz archives, switch to xz was probably unnecessary and the previous problem building from the tagged release gz was probably cache-related
* drop maintainership
