### PR TITLE
gensio: add patch with workaround for buildbots (refs #24047)

### DIFF
--- a/net/gensio/patches/0001-Ensure-that-ax_python_devel_found_is_defined.patch
+++ b/net/gensio/patches/0001-Ensure-that-ax_python_devel_found_is_defined.patch
@@ -1,0 +1,10 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -2002,6 +2002,7 @@ if test "x$trypython" = "xyes"; then
+       PYTHON_CPPFLAGS="$pythoncflags"
+    fi
+    AX_PYTHON_DEVEL([], [true])
++   ax_python_devel_found=yes
+ else
+    ax_python_devel_found=no
+ fi


### PR DESCRIPTION
Maintainer: @WereCatf 
Compile tested: Raspberry Pi
Run tested: -

Description:

This should solve the issue found on the buildbots:

-snip-
...
checking consistency of all components of python development environment... yes ./configure: line 24172: test: =: unary operator expected checking for pam_start in -lpam... (cached) no
...
-snap-

For still unknown reason, AX_PYTHON_DEVEL from the included m4 file is not used which would set the variable the correct way.
