### PR TITLE
ply: add new package

### DIFF
--- a/utils/ply/Makefile
+++ b/utils/ply/Makefile
@@ -1,0 +1,46 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ply
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://github.com/iovisor/ply
+PKG_MIRROR_HASH:=88b13091060c304ea7ecd3471d3889cf9daf6c0e524f6f810e56502fe46a4803
+PKG_SOURCE_DATE:=2023-05-19
+PKG_SOURCE_VERSION:=1b57943db56692924bccb61c271de24a8264d8df
+
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+PKG_FIXUP:=autoreconf
+PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ply
+  SECTION:=base
+  CATEGORY:=Base system
+  TITLE:=A dynamic tracer for Linux
+  DEPENDS:=@(aarch64||arm||powerpc||x86_64||riscv64) +@KERNEL_BPF_EVENTS +@KERNEL_FTRACE_SYSCALLS \
+			+@KERNEL_ENABLE_DEFAULT_TRACERS +@KERNEL_FUNCTION_TRACER +@KERNEL_FUNCTION_GRAPH_TRACER \
+			+@KERNEL_DYNAMIC_FTRACE +@KERNEL_FUNCTION_PROFILER +@KERNEL_IRQSOFF_TRACER \
+			+@KERNEL_PREEMPT_TRACER
+  URL:=https://github.com/iovisor/ply
+endef
+
+define Package/ply/description
+  A light-weight dynamic tracer for Linux that leverages the
+  kernel's BPF VM in concert with kprobes and tracepoints to
+  attach probes to arbitrary points in the kernel.
+endef
+
+define Package/ply/install
+	$(call Build/Install/Default)
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libply.so* $(1)/usr/lib
+
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/ply $(1)/usr/sbin
+endef
+
+$(eval $(call BuildPackage,ply))

--- a/utils/ply/patches/001-fix-autoconf.patch
+++ b/utils/ply/patches/001-fix-autoconf.patch
@@ -1,0 +1,9 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -1,5 +1,5 @@
+ AC_PREREQ(2.61)
+-AC_INIT(ply, [m4_esyscmd_s(git describe --always --dirty)],
++AC_INIT(ply, [2.3.0-9-g1b57943],
+ 	     https://github.com/wkz/ply/issues)
+ 
+ AC_GNU_SOURCE

--- a/utils/ply/patches/002-use-BPF_FUNC_probe_read_str.patch
+++ b/utils/ply/patches/002-use-BPF_FUNC_probe_read_str.patch
@@ -1,0 +1,11 @@
+--- a/src/libply/built-in/memory.c
++++ b/src/libply/built-in/memory.c
+@@ -140,7 +140,7 @@ static int str_ir_post(const struct func
+ 	ir_emit_ldbp(pb->ir, BPF_REG_1, n->sym->irs.stack);
+ 	ir_emit_insn(ir, MOV_IMM((int32_t)type_sizeof(n->sym->type)), BPF_REG_2, 0);
+ 	ir_emit_sym_to_reg(ir, BPF_REG_3, ptr->sym);
+-	ir_emit_insn(ir, CALL(BPF_FUNC_probe_read_kernel_str), 0, 0);
++	ir_emit_insn(ir, CALL(BPF_FUNC_probe_read_str), 0, 0);
+ 	return 0;
+ }
+ 

--- a/utils/ply/patches/003-canonical-tracepoint-path.patch
+++ b/utils/ply/patches/003-canonical-tracepoint-path.patch
@@ -1,0 +1,25 @@
+--- a/src/libply/provider/tracepoint.c
++++ b/src/libply/provider/tracepoint.c
+@@ -350,6 +350,13 @@ static int tracepoint_detach(struct ply_
+ 	return 0;
+ }
+ 
++static void canonical_path(char *path)
++{
++	char *p = strchr(path, ':');
++	if (p)
++		*p = '/';
++}
++
+ static int tracepoint_probe(struct ply_probe *pb)
+ {
+ 	struct tracepoint *tp;
+@@ -370,6 +377,8 @@ static int tracepoint_probe(struct ply_p
+ 	fprintf(fp, TRACEPATH "events/%s", name);
+ 	fclose(fp);
+ 
++	canonical_path(tp->path);
++
+ 	tp->data_func = tracepoint_data_func;
+ 
+ 	data_t  = xcalloc(1, sizeof(*data_t));


### PR DESCRIPTION
A light-weight dynamic tracer for Linux that leverages the kernel's BPF VM in concert with kprobes and tracepoints to attach probes to arbitrary points in the kernel.

Maintainer: me
Compile tested: (aarch64, GL-MT6000, master)
Run tested: (aarch64, GL-MT6000, master, tests done)

Description:
    https://github.com/iovisor/ply