### PR TITLE
speedtest-netperf: add idle latency measurement

### DIFF
--- a/net/speedtest-netperf/Makefile
+++ b/net/speedtest-netperf/Makefile
@@ -1,12 +1,12 @@
 #
-# Copyright (c) 2018 Tony Ambardar
+# Copyright (c) 2018-2024 Tony Ambardar
 # This is free software, licensed under the GNU General Public License v2.
 #
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=speedtest-netperf
-PKG_VERSION:=1.0.0
+PKG_VERSION:=1.1.0
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Tony Ambardar <itugrok@yahoo.com>

--- a/net/speedtest-netperf/files/README.md
+++ b/net/speedtest-netperf/files/README.md
@@ -11,7 +11,7 @@ The `speedtest-netperf` package provides a convenient means of on-device network
 
 3. **CPU Usage:**  Observing CPU usage under network load gives insight into whether the router is CPU-bound, or if there is CPU "headroom" to support even higher network throughput. In addition to managing network traffic, a router actively running a speed test will also use CPU cycles to generate network load, and measuring this distinct CPU usage also helps gauge its impact.
 
-**Note:** _The `speedtest-netperf.sh` script uses servers and network bandwidth that are provided by generous volunteers (not some wealthy "big company"). Feel free to use the script to test your SQM configuration or troubleshoot network and latency problems. Continuous or high rate use of this script may result in denied access. Happy testing!_
+**Note:** _The `speedtest-netperf.sh` script uses servers and network bandwidth that are provided by generous volunteers. Feel free to use the script to test your SQM configuration or troubleshoot network and latency problems, but be warned that continuous or high-rate use of the servers may result in denied access. Happy testing!_
 
 
 ## Theory of Operation
@@ -23,6 +23,8 @@ The script operates in two distict modes for network loading: *sequential* and *
 Sequential mode is preferred when measuring peak upload and download speeds for SQM configuration or testing ISP speed claims, because the measurements are unimpacted by traffic in the opposite direction.
 
 Concurrent mode places greater stress on the network, and can expose additional latency problems. It provides a more realistic estimate of expected bidirectional throughput. However, the download and upload speeds reported may be considerably lower than your line's rated speed. This is not a bug, nor is it a problem with your internet connection. It's because the ACK (acknowledge) messages sent back to the sender may consume a significant fraction of a link's capacity (as much as 50% with highly asymmetric links, e.g 15:1 or 20:1).
+
+The script also supports measuring latency when idle as a baseline prior to measuring under network load. This allows better determination of induced latency under load, a critical bufferbloat parameter. The CPU details can also be used to verify idle conditions or examine CPU frequency against ping variations and jitter (e.g. tracing high jitter to occasional low CPU frequency operation).
 
 After running `speedtest-netperf.sh`, if latency is seen to increase much during the data transfers, then other network activity, such as voice or video chat, gaming, and general interactive usage will likely suffer. Gamers will see this as frustrating lag when someone else uses the network, Skype and FaceTime users will see dropouts or freezes, and VOIP service may be unusable.
 
@@ -42,9 +44,9 @@ opkg install speedtest-netperf_1.0.0-1_all.ipk
 
 ## Usage
 
-The speedtest-netperf.sh script measures throughput, latency and CPU usage during file transfers. To invoke it:
+The speedtest-netperf.sh script measures throughput, latency and CPU usage during file transfers and when idle. To invoke it:
 
-    speedtest-netperf.sh [-4 | -6] [-H netperf-server] [-t duration] [-p host-to-ping] [-n simultaneous-streams ] [-s | -c]
+    speedtest-netperf.sh [-4 | -6] [-H netperf-server] [-t duration] [-p host-to-ping] [-n simultaneous-streams ] [-s | -c [duration] ] [ -i [duration] ]
 
 Options, if present, are:
 
@@ -52,11 +54,12 @@ Options, if present, are:
     -H | --host:       DNS or Address of a netperf server (default - netperf.bufferbloat.net)
                        Alternate servers are netperf-east (US, east coast),
                        netperf-west (US, California), and netperf-eu (Denmark).
-    -t | --time:       Duration for how long each direction's test should run - (default - 60 seconds)
-    -p | --ping:       Host to ping to measure latency (default - gstatic.com)
+    -t | --time:       Duration for how long each direction's test should run - (default - 30 seconds)
+    -p | --ping:       Host to ping to measure latency (default - one.one.one.one)
     -n | --number:     Number of simultaneous sessions (default - 5 sessions)
-    -s | --sequential: Sequential download/upload (default - sequential)
-    -c | --concurrent: Concurrent download/upload
+    -s | --sequential: Sequential download/upload (default - disabled)
+    -c | --concurrent: Concurrent download/upload (default - disabled)
+    -i | --idle:       Measure idle latency before speed test (default - disabled)
 
 The primary script output shows download and upload speeds, together with the percent packet loss, and a summary of latencies, including min, max, average, median, and 10th and 90th percentiles so you can get a sense of the distribution.
 
@@ -69,7 +72,7 @@ Notice also that the activation of SQM requires greater CPU, but that in both ca
 
 ```
 [Sequential Test: NO SQM, POOR LATENCY]                       [Sequential Test: WITH SQM, GOOD LATENCY]
-# speedtest-netperf.sh                                        # speedtest-netperf.sh
+# speedtest-netperf.sh --sequential                           # speedtest-netperf.sh --sequential
 [date/time] Starting speedtest for 60 seconds per transfer    [date/time] Starting speedtest for 60 seconds per transfer
 session. Measure speed to netperf.bufferbloat.net (IPv4)      session. Measure speed to netperf.bufferbloat.net (IPv4)
 while pinging gstatic.com. Download and upload sessions are   while pinging gstatic.com. Download and upload sessions are


### PR DESCRIPTION
**Author/ Maintainer**: me
**Compile tested**: against `openwrt/master` for `malta/mips` (package is arch-independent) 
**Run tested**: EA6350v3 (ipq40xx/generic), PC (x86_64)

**Description**:

Support measuring ping latency and CPU details at idle as a baseline before measuring under data transfer loading. This allows better determination of Latency Under Load, a critical bufferbloat parameter. The CPU details can also be used to verify idle conditions or examine CPU frequency against ping variations and jitter.

Change the default test duration to 30 seconds, which is adequate for SQM tuning while reducing bandwidth consumption for upstream netperf servers.

Change the default ping host from gstatic.com to one.one.one.one, which is widely available and generally shows lower latency.

When warning of internal netperf errors, suggest running netperf directly (with example command) to view error details.

Other minor updates include:
  - clear tmp file names for safety in case of traps
  - simplify ping code, argument parsing and number validation
  - fix cases of wrong protocol usage with hostname as ping target
  - drop unneeded egrep usage

Also update README accordingly, with clearer usage text and terminology.

**Usage Example**:
```
root@openwrt:/tmp# ./speedtest-netperf.sh -H netperf-west.bufferbloat.net -t 30 -i -c
2024-05-05 21:52:02 Begin test with 30-second ping, 30-second transfer sessions.
Measure idle latency by pinging one.one.one.one (IPv4).
..............................
  Latency: [in msec, 29 pings, 0.00% packet loss]
      Min:   7.641
    10pct:   7.703
   Median:   7.972
      Avg:   8.308
    90pct:   8.121
      Max:  18.098
 CPU Load: [in % busy (avg +/- std dev) @ avg frequency, 27 samples]
     cpu0:   4.0 +/-  2.8  @  716 MHz
     cpu1:   3.1 +/-  1.6  @  716 MHz
     cpu2:   3.1 +/-  1.7  @  716 MHz
     cpu3:   3.8 +/-  1.8  @  716 MHz
 Overhead: [in % used of total CPU available]
  netperf:   1.3

Measure speed to netperf-west.bufferbloat.net (IPv4) while pinging one.one.one.one.
Download and upload sessions are concurrent, each with 5 simultaneous streams.
................................
 Download:  31.22 Mbps
   Upload:   4.35 Mbps
  Latency: [in msec, 32 pings, 0.00% packet loss]
      Min:   8.759
    10pct:  10.416
   Median:  13.630
      Avg:  15.090
    90pct:  16.799
      Max:  35.210
 CPU Load: [in % busy (avg +/- std dev) @ avg frequency, 28 samples]
     cpu0:  15.7 +/-  5.0  @  716 MHz
     cpu1:  15.2 +/-  4.1  @  716 MHz
     cpu2:  15.7 +/-  4.8  @  716 MHz
     cpu3:  16.8 +/-  4.8  @  716 MHz
 Overhead: [in % used of total CPU available]
  netperf:   5.7
root@openwrt:/tmp#
```

**CC**: @hnyman (reviewed/merged original PR) @richb-hanover @PolynomialDivision 