### PR TITLE
mwan3: "use" action: run process via `exec` and handle whitespace

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.11.13
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -220,7 +220,6 @@ use() {
 	# firewall rules
 
 	local interface device src_ip family
-	mwan3_init
 
 	interface=$1 ; shift
 	[ -z "$*" ] && echo "no command specified for mwan3 use" && return
@@ -234,16 +233,17 @@ use() {
 	[ -z "$family" ] && echo "could not find family for $interface. Using ipv4." && family='ipv4'
 
 	echo "Running '$*' with DEVICE=$device SRCIP=$src_ip FWMARK=$MMX_DEFAULT FAMILY=$family"
-	# shellcheck disable=SC2048
-	FAMILY=$family DEVICE=$device SRCIP=$src_ip FWMARK=$MMX_DEFAULT LD_PRELOAD=/lib/mwan3/libwrap_mwan3_sockopt.so.1.0 $*
-
+	# if a program (not a shell builtin) is run: use "exec" for allowing direct process control
+	if [ -x "$(command -v "$1")" ]; then
+		set -- exec "$@"
+	fi
+	FAMILY=$family DEVICE=$device SRCIP=$src_ip FWMARK=$MMX_DEFAULT LD_PRELOAD=/lib/mwan3/libwrap_mwan3_sockopt.so.1.0 "$@"
 }
 
 case "$1" in
 	ifup|ifdown|interfaces|policies|connected|rules|status|start|stop|restart|use|internal)
 		mwan3_init
-		# shellcheck disable=SC2048
-		$*
+		"$@"
 	;;
 	*)
 		help


### PR DESCRIPTION
Maintainer:  @feckert
Compile tested: APU, 23.05.2
Run tested: APU, 23.05.2, execution of programs or shell builtins via `mwan3 use`

Previously the "use" command had the following shortcomings:
* a subprocess was created instead of replacing the shell process
* whitespace in arguments was not handled correctly

Implementation detail:
In shell context the `"$@"` expression should be used (instead of `$*`). This allows the safe handling of arguments containing whitespace.

Closes: #20001