### PR TITLE
net-tools: add netstat utiltiy

### DIFF
--- a/net/net-tools/Makefile
+++ b/net/net-tools/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-tools
 PKG_VERSION:=2.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://sourceforge.net/projects/net-tools/files/
@@ -53,6 +53,22 @@ define Package/net-tools-route/description
 	functionality of the net-tools variant (e.g. AF_X25).
 endef
 
+define Package/net-tools-netstat
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=net-tools - netstat utility
+  URL:=http://net-tools.sourceforge.net/
+  PROVIDES:=route
+  ALTERNATIVES:=300:/bin/netstat:/usr/libexec/net-tools-netstat
+endef
+
+define Package/net-tools-netstat/description
+	Replace busybox version of the netstat command with the full net-tools
+	version. This is normally not needed as busybox is smaller and provides
+	sufficient functionality, but some users may want or need the full
+	functionality of the net-tools variant.
+endef
+
 define Build/Configure
 	# Failed configure.sh leaves stub config.h around.
 	rm -f $(PKG_BUILD_DIR)/config.h
@@ -69,5 +85,11 @@ define Package/net-tools-route/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/route $(1)/usr/libexec/net-tools-route
 endef
 
+define Package/net-tools-netstat/install
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/netstat $(1)/usr/libexec/net-tools-netstat
+endef
+
 $(eval $(call BuildPackage,mii-tool))
 $(eval $(call BuildPackage,net-tools-route))
+$(eval $(call BuildPackage,net-tools-netstat))


### PR DESCRIPTION
Maintainer: @Borromini (?)
Compile tested: x86_64, APU3 , OpenWrt latest
Run tested: x86_64, APU3, OpenWrt latest, tests done

Description:
Some user may want or need the full fuctionality of the netstat tool.
