### PR TITLE
stunnel: update to version 5.72

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.71
+PKG_VERSION:=5.72
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0-or-later
@@ -23,7 +23,7 @@ PKG_SOURCE_URL:= \
 	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=f023aae837c2d32deb920831a5ee1081e11c78a5d57340f8e6f0829f031017f5
+PKG_HASH:=3d532941281ae353319735144e4adb9ae489a10b7e309c58a48157f08f42e949
 
 PKG_FIXUP:=autoreconf
 PKG_FIXUP:=patch-libtool


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64/lantiq_xrx200, APU3, OpenWrt latest
Run tested: x86_64, APU3, OpenWrt latest, tests done)

Description:

```
[ ] Initializing inetd mode configuration
[ ] Clients allowed=500
[.] stunnel 5.72 on x86_64-openwrt-linux-gnu platform
[.] Compiled/running with OpenSSL 3.0.13 30 Jan 2024
[.] Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,OCSP,PSK,SNI
[ ] errno: (*__errno_location())
[!] Invalid configuration file name "-v"
[!] realpath: No such file or directory (2)
```
