### PR TITLE
keepalived: add patch to remove log message on json output

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.2.8
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software

--- a/net/keepalived/patches/0001-vrrp-remove-logging-on-status-output.patch
+++ b/net/keepalived/patches/0001-vrrp-remove-logging-on-status-output.patch
@@ -1,0 +1,24 @@
+From 6cce75f4eb65551a61d2e4ba775637b288c1d592 Mon Sep 17 00:00:00 2001
+From: Florian Eckert <fe@dev.tdt.de>
+Date: Mon, 6 May 2024 13:10:55 +0200
+Subject: [PATCH] vrrp: remove logging on status output
+
+A message is output to the log each time the status is queried. This is
+not necessary and can therefore be omitted.
+
+Signed-off-by: Florian Eckert <fe@dev.tdt.de>
+---
+ keepalived/vrrp/vrrp_daemon.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+--- a/keepalived/vrrp/vrrp_daemon.c
++++ b/keepalived/vrrp/vrrp_daemon.c
+@@ -755,8 +755,6 @@ sigusr2_vrrp(__attribute__((unused)) voi
+ static void
+ sigjson_vrrp(__attribute__((unused)) void *v, __attribute__((unused)) int sig)
+ {
+-	log_message(LOG_INFO, "Printing VRRP as json for process(%d) on signal",
+-		getpid());
+ 	thread_add_event(master, print_vrrp_json, NULL, 0);
+ }
+ #endif


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, APU3, OpenWrt latest
Run tested: x86_64, APU3, OpenWrt latest, tests done

Description:
The 'luci-app-keepalived' uses the status json output to parse this information for the status page. The problem is that when the LuCI status page is open in the browser, the query is logged every 3 second into the syslog. This is not needed and can therefore be removed.

This patch was already merged upstream:
https://github.com/acassen/keepalived/commit/6cce75f4eb65551a61d2e4ba775637b288c1d592