### PR TITLE
modemmanager: add missing ubus status backend via mmcli

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.22.0
-PKG_RELEASE:=16
+PKG_RELEASE:=17
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git
@@ -43,6 +43,7 @@ define Package/modemmanager
 	+glib2 \
 	+dbus \
 	+ppp \
+	+lua-cjson \
 	+MODEMMANAGER_WITH_MBIM:libmbim \
 	+MODEMMANAGER_WITH_QMI:libqmi \
 	+MODEMMANAGER_WITH_QRTR:libqrtr-glib
@@ -94,6 +95,10 @@ define Package/modemmanager/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/ModemManager $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/usr/sbin/ModemManager-wrapper $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/usr/sbin/ModemManager-monitor $(1)/usr/sbin
+
+	$(INSTALL_DIR) $(1)/usr/libexec/rpcd
+	$(INSTALL_BIN) ./files/usr/libexec/rpcd/modemmanager \
+		$(1)/usr/libexec/rpcd/
 
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mmcli $(1)/usr/bin

--- a/net/modemmanager/files/usr/libexec/rpcd/modemmanager
+++ b/net/modemmanager/files/usr/libexec/rpcd/modemmanager
@@ -1,0 +1,216 @@
+#!/usr/bin/env lua
+
+local json = require "cjson"
+
+local status = {}
+local bearers = {}
+local sim = {}
+local signal = {}
+local location = {}
+
+local info = {}
+
+function mm_get_modem_bearer(index)
+
+	local command = string.format("/usr/bin/mmcli --bearer=%s --output-json 2>/dev/null", index)
+
+	local handle = io.popen(command)
+	local output = handle:read("*a")
+	handle:close()
+
+	local ok, status = pcall(function()
+		return json.decode(string.format(output))
+	end)
+
+	if not ok then
+		return
+	end
+
+	table.insert(bearers, status["bearer"])
+end
+
+function mm_get_modem_sim(index)
+
+	local command = string.format("/usr/bin/mmcli --sim=%s --output-json 2>/dev/null", index)
+
+	local handle = io.popen(command)
+	local output = handle:read("*a")
+	handle:close()
+
+	local ok, status = pcall(function()
+		return json.decode(string.format(output))
+	end)
+
+	if not ok then
+		return
+	end
+
+	sim = status["sim"]
+end
+
+function mm_get_modem_signal(modem)
+
+	local command = string.format("/usr/bin/mmcli --modem=%s --signal-get --output-json 2>/dev/null", modem)
+
+	local handle = io.popen(command)
+	local output = handle:read("*a")
+	handle:close()
+
+	local ok, status = pcall(function()
+		return json.decode(string.format(output))
+	end)
+
+	if ok == false then
+		return
+	end
+
+	signal = status["modem"]["signal"]
+end
+
+function mm_get_modem_location(modem)
+
+	local command = string.format("/usr/bin/mmcli --modem=%s --location-get --output-json 2>/dev/null", modem)
+
+	local handle = io.popen(command)
+	local output = handle:read("*a")
+	handle:close()
+
+	local ok, status = pcall(function()
+		return json.decode(string.format(output))
+	end)
+
+	if ok == false then
+		return
+	end
+
+	location = status["modem"]["location"]
+end
+
+function mm_get_modem_status(modem)
+
+	local command = string.format("/usr/bin/mmcli --modem=%s --output-json 2>/dev/null", modem)
+
+	local handle = io.popen(command)
+	local output = handle:read("*a")
+	handle:close()
+
+	local ok, mstatus = pcall(function()
+		return json.decode(string.format(output))
+	end)
+
+	if ok == false then
+		return
+	end
+
+	if mstatus["modem"]["generic"]["bearers"] ~= nil then
+		bearers = {}
+		for k, v in ipairs(mstatus["modem"]["generic"]["bearers"]) do
+			mm_get_modem_bearer(v)
+		end
+		if (next(bearers) ~= nil) then
+			mstatus["modem"]["generic"]["bearers"] = bearers
+		end
+	end
+
+	if mstatus["modem"]["generic"]["sim"] ~= "--" then
+		sim = {}
+		mm_get_modem_sim(mstatus["modem"]["generic"]["sim"])
+		if (next(sim) ~= nil) then
+			mstatus["modem"]["generic"]["sim"] = sim
+		end
+	else
+		mstatus["modem"]["generic"]["sim"] = {}
+	end
+
+	signal = {}
+	mm_get_modem_signal(modem)
+	if (next(signal) ~= nil) then
+		mstatus["modem"]["signal"] = signal
+	else
+		mstatus["modem"]["signal"] = {}
+	end
+
+	location = {}
+	mm_get_modem_location(modem)
+	if (next(location) ~= nil) then
+		mstatus["modem"]["location"] = location
+	else
+		mstatus["modem"]["location"] = {}
+	end
+
+	mstatus["modem"]["device"] = mstatus["modem"]["generic"]["device"]
+
+	table.insert(status["modem"], mstatus["modem"])
+end
+
+function aquire_data_modemmanager()
+
+	local command = string.format("/usr/bin/mmcli --list-modems --output-json 2>/dev/null")
+
+	local handle = io.popen(command)
+	local output = handle:read("*a")
+	handle:close()
+
+	local ok, modems = pcall(function()
+		return json.decode(output)
+	end)
+
+	if not ok then
+		return
+	end
+
+	entry_cache = {}
+	status = {}
+	status["modem"] = {}
+	for k, v in ipairs(modems["modem-list"]) do
+		mm_get_modem_status(modems["modem-list"][k])
+	end
+end
+
+function aquire_data_info()
+	aquire_data_modemmanager()
+
+	-- check if modemmanger is available and is using a modem
+	if status['modem'] == nil then
+		return
+	end
+
+	info['modem'] = {}
+
+	for k, v in ipairs(status['modem']) do
+		local element = {}
+
+		element['imei'] = status['modem'][k]['3gpp']['imei']
+		element['signal'] = status['modem'][k]['generic']['signal-quality']['value']
+		element['technology'] = status['modem'][k]['generic']['access-technologies'][1]
+		if status['modem'][k]['3gpp']['operator-name'] ~= '--' then
+			element['operator'] = status['modem'][k]['3gpp']['operator-name']
+		end
+		if status['modem'][k]['generic']['sim']['properties'] ~= nil then
+			element['iccid'] = status['modem'][k]['generic']['sim']['properties']['iccid']
+			element['imsi'] = status['modem'][k]['generic']['sim']['properties']['imsi']
+		end
+		element['device'] = status['modem'][k]['device']
+
+		table.insert(info['modem'], element)
+	end
+end
+
+function main(cmd, call)
+	if cmd == "list" then
+		print(json.encode({
+			dump = {},
+			info = {}
+		}))
+	elseif cmd == "call" then
+		if call == "dump" then
+			aquire_data_modemmanager()
+			print(json.encode(status))
+		elseif call == "info" then
+			aquire_data_info()
+			print(json.encode(info))
+		end
+	end
+end
+
+main(arg[1], arg[2])


### PR DESCRIPTION
Maintainer: me @mips171 @aleksander0m 
Compile tested: not needed only script changes
Run tested: x86_64, APU3, OpenWrt latest, tests done)

Description:
The 'modemmanager' uses the 'dbus'. Status information can be retrieved with the 'mmcli' command, this can also be output in json format.

This commit adds a new 'ubus' backend with which this information can be easily accessed via ubus.

```
root@G3-10940 ~ # ubus call modemmanager info
{
        "modem": [
                {
                        "imsi": "262029915879434",
                        "operator": "Vodafone.de",
                        "technology": "lte",
                        "device": "Modem1",
                        "iccid": "89492099166029838939",
                        "imei": "861107037891430",
                        "signal": "47"
                }
        ]
}
```
```
root@G3-10940 ~ # ubus call modemmanager dump
{
	"modem": [
		{
			"cdma": {
				"evdo-registration-state": "--",
				"cdma1x-registration-state": "--",
				"activation-state": "--",
				"esn": "--",
				"meid": "--",
				"nid": "--",
				"sid": "--"
			},
			"generic": {
				"current-bands": [
					"egsm",
					"dcs",
					"utran-1",
					"utran-5",
					"utran-8",
					"eutran-1",
					"eutran-3",
					"eutran-5",
					"eutran-7",
					"eutran-8",
					"eutran-20",
					"eutran-38",
					"eutran-40",
					"eutran-41"
				],
				"signal-quality": {
					"recent": "yes",
					"value": "0"
				},
				"primary-port": "cdc-wdm0",
				"equipment-identifier": "861107037891430",
				"manufacturer": "QUALCOMM INCORPORATED",
				"drivers": [
					"qmi_wwan",
					"option1"
				],
				"revision": "EC25EFAR02A08M4G",
				"physdev": "/sys/devices/pci0000:00/0000:00:13.0/usb2/2-1/2-1.3",
				"device": "Modem1",
				"supported-modes": [
					"allowed: 2g; preferred: none",
					"allowed: 3g; preferred: none",
					"allowed: 4g; preferred: none",
					"allowed: 2g, 3g; preferred: 3g",
					"allowed: 2g, 3g; preferred: 2g",
					"allowed: 2g, 4g; preferred: 4g",
					"allowed: 2g, 4g; preferred: 2g",
					"allowed: 3g, 4g; preferred: 4g",
					"allowed: 3g, 4g; preferred: 3g",
					"allowed: 2g, 3g, 4g; preferred: 4g",
					"allowed: 2g, 3g, 4g; preferred: 3g",
					"allowed: 2g, 3g, 4g; preferred: 2g"
				],
				"plugin": "quectel",
				"model": "QUECTEL Mobile Broadband Module",
				"primary-sim-slot": "--",
				"unlock-required": "--",
				"state-failed-reason": "sim-missing",
				"device-identifier": "a1e87e7fec94ad3d4cb750b434dc9ffc8a3699b3",
				"current-capabilities": [
					"gsm-umts, lte"
				],
				"carrier-configuration": "default",
				"power-state": "on",
				"bearers": {
					
				},
				"unlock-retries": {
					
				},
				"ports": [
					"cdc-wdm0 (qmi)",
					"ttyUSB0 (ignored)",
					"ttyUSB1 (gps)",
					"ttyUSB2 (at)",
					"ttyUSB3 (at)",
					"wwan0 (net)"
				],
				"own-numbers": {
					
				},
				"sim": {
					
				},
				"access-technologies": {
					
				},
				"supported-ip-families": [
					"ipv4",
					"ipv6",
					"ipv4v6"
				],
				"sim-slots": {
					
				},
				"carrier-configuration-revision": "--",
				"supported-capabilities": [
					"gsm-umts, lte"
				],
				"supported-bands": [
					"egsm",
					"dcs",
					"utran-1",
					"utran-5",
					"utran-8",
					"eutran-1",
					"eutran-3",
					"eutran-5",
					"eutran-7",
					"eutran-8",
					"eutran-20",
					"eutran-38",
					"eutran-40",
					"eutran-41"
				],
				"state": "failed",
				"hardware-revision": "10000",
				"current-modes": "allowed: 2g, 3g, 4g; preferred: 4g"
			},
			"3gpp": {
				"operator-name": "--",
				"registration-state": "--",
				"eps": {
					"initial-bearer": {
						"dbus-path": "--",
						"settings": {
							"password": "--",
							"user": "--",
							"apn": "--",
							"ip-type": "--"
						}
					},
					"ue-mode-operation": "--"
				},
				"operator-code": "--",
				"enabled-locks": {
					
				},
				"pco": "--",
				"5gnr": {
					"registration-settings": {
						"drx-cycle": "--",
						"mico-mode": "--"
					}
				},
				"imei": "861107037891430",
				"packet-service-state": "--"
			},
			"dbus-path": "/org/freedesktop/ModemManager1/Modem/0",
			"device": "Modem1",
			"location": {
				
			},
			"signal": {
				
			}
		}
	]
}
```