### PR TITLE
ocserv: set ipcalc explicitly

### DIFF
--- a/net/ocserv/Makefile
+++ b/net/ocserv/Makefile
@@ -56,7 +56,8 @@ EXTRA_CPPFLAGS+=-I$(STAGING_DIR)/usr/include/readline/
 EXTRA_LDFLAGS+=-lncurses
 
 CONFIGURE_VARS += \
-	ac_cv_file__proc_self_exe=yes
+	ac_cv_file__proc_self_exe=yes \
+	ac_cv_prog_IPCALC=/bin/true
 
 CONFIGURE_ARGS+= \
 	--with-pager="" \


### PR DESCRIPTION
Maintainer: me\
Compile tested: -
Run tested: -

Description:
ipcalc is a mandatory tool for the test suite, but we do not run it. This patch fixes compilation.
