### PR TITLE
strongswan: Add missing declarations in swanctl

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.14
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -428,7 +428,9 @@ config_remote() {
 	local gateway
 	local local_sourceip
 	local local_ip
+	local local_identifier
 	local remote_gateway
+	local remote_identifier
 	local pre_shared_key
 	local auth_method
 	local keyingtries


### PR DESCRIPTION
Maintainer: me, @Thermi 
Compile tested: x86_64, generic, HEAD (187d704e3b)
Run tested: same, installed on production router

Description:
