### PR TITLE
bluez: fix the build with GCC 14

### DIFF
--- a/utils/bluez/Makefile
+++ b/utils/bluez/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bluez
 PKG_VERSION:=5.72
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/bluetooth/

--- a/utils/bluez/patches/000-fix-gcc-14-build.patch
+++ b/utils/bluez/patches/000-fix-gcc-14-build.patch
@@ -1,0 +1,12 @@
+Index: bluez-5.72/tools/hex2hcd.c
+===================================================================
+--- bluez-5.72.orig/tools/hex2hcd.c
++++ bluez-5.72/tools/hex2hcd.c
+@@ -24,6 +24,7 @@
+ #include <stdlib.h>
+ #include <stdbool.h>
+ #include <sys/stat.h>
++#include <libgen.h>
+ 
+ static ssize_t process_record(int fd, const char *line, uint16_t *upper_addr)
+ {


### PR DESCRIPTION
Bluez fails to build with GCC 14.1, add a trivial patch to fix it.

Compile tested: mediatek/filogic (Banana Pi R3)

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>