### PR TITLE
php8: Support for icu 75

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=8.3.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=PHP-3.01
@@ -299,7 +299,6 @@ endif
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-intl),)
   CONFIGURE_ARGS+= --enable-intl=shared
-  TARGET_CXXFLAGS+= -std=c++0x
 else
   CONFIGURE_ARGS+= --disable-intl
 endif

--- a/lang/php8/patches/1020-php-intl_unbreak_build_with_ICU_75.patch
+++ b/lang/php8/patches/1020-php-intl_unbreak_build_with_ICU_75.patch
@@ -1,0 +1,50 @@
+From e680bd98d34a86302db434c5be23d0cf9d23df23 Mon Sep 17 00:00:00 2001
+From: Jan Beich <jbeich@FreeBSD.org>
+Date: Sat, 20 Apr 2024 23:49:22 +0200
+Subject: devel/php*-intl: unbreak build with ICU 75
+
+In file included from ext/intl/intl_convertcpp.cpp:17:
+In file included from ./intl_convertcpp.h:22:
+In file included from /usr/local/include/unicode/unistr.h:39:
+/usr/local/include/unicode/stringpiece.h:133:29: error: no template named 'enable_if_t' in namespace 'std'
+            typename = std::enable_if_t<
+                       ~~~~~^
+/usr/local/include/unicode/stringpiece.h:134:23: error: no template named 'is_same_v' in namespace 'std'; did you mean 'is_same'?
+                (std::is_same_v<decltype(T().data()), const char*>
+                 ~~~~~^
+/usr/include/c++/v1/__type_traits/is_same.h:22:29: note: 'is_same' declared here
+struct _LIBCPP_TEMPLATE_VIS is_same : _BoolConstant<__is_same(_Tp, _Up)> { };
+                            ^
+In file included from ext/intl/intl_convertcpp.cpp:17:
+In file included from ./intl_convertcpp.h:22:
+In file included from /usr/local/include/unicode/unistr.h:39:
+/usr/local/include/unicode/stringpiece.h:139:17: error: use of address-of-label extension outside of a function body
+                std::is_same_v<decltype(T().size()), size_t>>>
+                ^
+/usr/local/include/unicode/stringpiece.h:139:62: error: expected member name or ';' after declaration specifiers
+                std::is_same_v<decltype(T().size()), size_t>>>
+                                                             ^
+PR:		278420
+Reported by:	antoine (via exp-run)
+---
+
+--- a/ext/intl/config.m4
++++ b/ext/intl/config.m4
+@@ -80,7 +80,16 @@ if test "$PHP_INTL" != "no"; then
+     breakiterator/codepointiterator_methods.cpp"
+ 
+   PHP_REQUIRE_CXX()
+-  PHP_CXX_COMPILE_STDCXX(11, mandatory, PHP_INTL_STDCXX)
++
++  AC_MSG_CHECKING([if intl requires -std=gnu++17])
++  AS_IF([test "$PKG_CONFIG icu-uc --atleast-version=74"],[
++    AC_MSG_RESULT([yes])
++    PHP_CXX_COMPILE_STDCXX(17, mandatory, PHP_INTL_STDCXX)
++  ],[
++    AC_MSG_RESULT([no])
++    PHP_CXX_COMPILE_STDCXX(11, mandatory, PHP_INTL_STDCXX)
++  ])
++
+   PHP_INTL_CXX_FLAGS="$INTL_COMMON_FLAGS $PHP_INTL_STDCXX $ICU_CXXFLAGS"
+   case $host_alias in
+   *cygwin*) PHP_INTL_CXX_FLAGS="$PHP_INTL_CXX_FLAGS -D_POSIX_C_SOURCE=200809L"


### PR DESCRIPTION
Maintainer: @mhei 
Compile tested: aarch64, arm, x86_64 
Run tested: (qemu-9.0.0) aarch64

Description:
Preparing to update icu4c to 75.
Created a patch for build errors in php-intl.
```
In file included from /mnt/node/openwrt/staging_dir/target-aarch64_generic_musl/usr/include/unicode/unistr.h:39,
                 from ext/intl/intl_convertcpp.h:22,
                 from ext/intl/intl_convertcpp.cpp:17:
/mnt/node/openwrt/staging_dir/target-aarch64_generic_musl/usr/include/unicode/stringpiece.h:133:29: error: 'enable_if_t' in namespace 'std' does not name a template type
  133 |             typename = std::enable_if_t<
      |                             ^~~~~~~~~~~
/mnt/node/openwrt/staging_dir/target-aarch64_generic_musl/usr/include/unicode/stringpiece.h:133:24: note: 'std::enable_if_t' is only available from C++14 onwards
  133 |             typename = std::enable_if_t<
      |                        ^~~
/mnt/node/openwrt/staging_dir/target-aarch64_generic_musl/usr/include/unicode/stringpiece.h:133:40: error: expected '>' before '<' token
  133 |             typename = std::enable_if_t<
      |                                        ^
```
The FreeBSD ports patch was used as a reference.
https://github.com/freebsd/freebsd-ports/commit/e680bd98d34a86302db434c5be23d0cf9d23df23
