### PR TITLE
Shairport-sync: patch to use mbedtls3

### DIFF
--- a/sound/shairport-sync/Makefile
+++ b/sound/shairport-sync/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shairport-sync
 PKG_VERSION:=4.3.2
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikebrady/shairport-sync/tar.gz/$(PKG_VERSION)?

--- a/sound/shairport-sync/patches/100-mbedtls3fix.patch
+++ b/sound/shairport-sync/patches/100-mbedtls3fix.patch
@@ -1,0 +1,94 @@
+From d73b585c6f6d9136ae7a04243a54d734fa57d779 Mon Sep 17 00:00:00 2001
+From: Seo Suchan <tjtncks@gmail.com>
+Date: Thu, 9 May 2024 19:10:59 +0900
+Subject: [PATCH] mbedtls: add support to mbedtls3
+
+Signed-off-by: Seo Suchan <tjtncks@gmail.com>
+---
+ common.c | 30 ++++++++++++++++++++++++++----
+ player.c |  1 -
+ player.h |  1 -
+ 3 files changed, 26 insertions(+), 6 deletions(-)
+
+--- a/common.c
++++ b/common.c
+@@ -100,6 +100,12 @@
+ #include <mbedtls/md.h>
+ #include <mbedtls/version.h>
+ #include <mbedtls/x509.h>
++
++#if MBEDTLS_VERSION_MAJOR == 3
++#define MBEDTLS_PRIVATE_V3_ONLY(_q) MBEDTLS_PRIVATE(_q)
++#else
++#define MBEDTLS_PRIVATE_V3_ONLY(_q) _q
++#endif
+ #endif
+ 
+ #ifdef CONFIG_LIBDAEMON
+@@ -910,8 +916,14 @@ uint8_t *rsa_apply(uint8_t *input, int i
+ 
+   mbedtls_pk_init(&pkctx);
+ 
++#if MBEDTLS_VERSION_MAJOR == 3
++  rc = mbedtls_pk_parse_key(&pkctx, (unsigned char *)super_secret_key, sizeof(super_secret_key),
++                            NULL, 0, mbedtls_ctr_drbg_random, &ctr_drbg);
++#else
+   rc = mbedtls_pk_parse_key(&pkctx, (unsigned char *)super_secret_key, sizeof(super_secret_key),
+                             NULL, 0);
++
++#endif
+   if (rc != 0)
+     debug(1, "Error %d reading the private key.", rc);
+ 
+@@ -921,18 +933,28 @@ uint8_t *rsa_apply(uint8_t *input, int i
+   switch (mode) {
+   case RSA_MODE_AUTH:
+     mbedtls_rsa_set_padding(trsa, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_NONE);
+-    outbuf = malloc(trsa->len);
++    outbuf = malloc(trsa->MBEDTLS_PRIVATE_V3_ONLY(len));
++#if MBEDTLS_VERSION_MAJOR == 3
++    rc = mbedtls_rsa_pkcs1_encrypt(trsa, mbedtls_ctr_drbg_random, &ctr_drbg,
++                                   inlen, input, outbuf);
++#else
+     rc = mbedtls_rsa_pkcs1_encrypt(trsa, mbedtls_ctr_drbg_random, &ctr_drbg, MBEDTLS_RSA_PRIVATE,
+                                    inlen, input, outbuf);
++#endif
+     if (rc != 0)
+       debug(1, "mbedtls_pk_encrypt error %d.", rc);
+-    *outlen = trsa->len;
++    *outlen = trsa->MBEDTLS_PRIVATE_V3_ONLY(len);
+     break;
+   case RSA_MODE_KEY:
+     mbedtls_rsa_set_padding(trsa, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA1);
+-    outbuf = malloc(trsa->len);
++    outbuf = malloc(trsa->MBEDTLS_PRIVATE_V3_ONLY(len));
++#if MBEDTLS_VERSION_MAJOR == 3
++    rc = mbedtls_rsa_pkcs1_decrypt(trsa, mbedtls_ctr_drbg_random, &ctr_drbg,
++                                   &olen, input, outbuf, trsa->MBEDTLS_PRIVATE_V3_ONLY(len));
++#else
+     rc = mbedtls_rsa_pkcs1_decrypt(trsa, mbedtls_ctr_drbg_random, &ctr_drbg, MBEDTLS_RSA_PRIVATE,
+                                    &olen, input, outbuf, trsa->len);
++#endif
+     if (rc != 0)
+       debug(1, "mbedtls_pk_decrypt error %d.", rc);
+     *outlen = olen;
+--- a/player.c
++++ b/player.c
+@@ -48,7 +48,6 @@
+ 
+ #ifdef CONFIG_MBEDTLS
+ #include <mbedtls/aes.h>
+-#include <mbedtls/havege.h>
+ #endif
+ 
+ #ifdef CONFIG_POLARSSL
+--- a/player.h
++++ b/player.h
+@@ -9,7 +9,6 @@
+ 
+ #ifdef CONFIG_MBEDTLS
+ #include <mbedtls/aes.h>
+-#include <mbedtls/havege.h>
+ #endif
+ 
+ #ifdef CONFIG_POLARSSL


### PR DESCRIPTION
Maintainer: @mikebrady
Compile tested: x86_64, generic, main
Run tested: (put here arch, model, OpenWrt version, tests done)

Description: updated to compatible with mbedtls 3.X as https://github.com/Mbed-TLS/mbedtls/blob/development/docs/3.0-migration-guide.md , and tested it complies without error, but I don't have any apple sound device to test this: @davidandreoletti  could you test if this works? it doesn't use tls as-is so PSA should not be a problem