### PR TITLE
openconnect: backport fix for anyconnect compatibility

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=9.12
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.infradead.org/openconnect/download

--- a/net/openconnect/patches/020-anyconnect.patch
+++ b/net/openconnect/patches/020-anyconnect.patch
@@ -1,0 +1,11 @@
+--- a/main.c
++++ b/main.c
+@@ -1774,7 +1774,7 @@ int main(int argc, char **argv)
+ 
+ 	openconnect_init_ssl();
+ 
+-	vpninfo = openconnect_vpninfo_new("Open AnyConnect VPN Agent",
++	vpninfo = openconnect_vpninfo_new("AnyConnect-compatible OpenConnect VPN Agent",
+ 		validate_peer_cert, NULL, process_auth_form_cb, write_progress, NULL);
+ 	if (!vpninfo) {
+ 		fprintf(stderr, _("Failed to allocate vpninfo structure\n"));


### PR DESCRIPTION
Fixes: #21135

Maintainer: me
Compile tested: arm_cortex-a9+vfpv3-d16_musl_eabi
Run tested: -

Description:
Backport fix for AnyConnect protocol compatibility.