### PR TITLE
netbird: update to 0.27.6

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.27.3
+PKG_VERSION:=0.27.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=f172798f164b7484b231adc656eaf1090b6f7d9e7d7c3753f1e611bdf82ae738
+PKG_HASH:=87abb18ad73cab77e5b3cb1b51e49c28a922672163bb7f45a3619fd991a8bc9f
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
# Compile and run tested

Maintainer: Oskari Rauta / @oskarirauta

| Package architecture                                                       | Target                                                                | Subtarget | Brand    | Model                                                  | Hardware Version | OpenWrt version                    |
|----------------------------------------------------------------------------|-----------------------------------------------------------------------|-----------|----------|--------------------------------------------------------|------------------|------------------------------------|
| [mips_24kc](https://openwrt.org/docs/techref/instructionset/mips_24kc)     | [ar71xx-ath79](https://openwrt.org/docs/techref/targets/ar71xx-ath79) | generic   | TP-Link  | [Archer C7](https://openwrt.org/toh/tp-link/archer_c7) | v4               | OpenWrt SNAPSHOT r26308-4341901f05 |
| [mipsel_24kc](https://openwrt.org/docs/techref/instructionset/mipsel_24kc) | [ramips](https://openwrt.org/docs/techref/targets/ramips)             | mt7621    | TOTOLINK | [x5000r](https://openwrt.org/toh/totolink/x5000r)      | n/a              | OpenWrt SNAPSHOT r26308-4341901f05 |
| ~[mips_24kc](https://openwrt.org/docs/techref/instructionset/mips_24kc)~     | ~[ar71xx-ath79](https://openwrt.org/docs/techref/targets/ar71xx-ath79)~ | ~generic~   | ~TP-Link~  | ~[Archer C7](https://openwrt.org/toh/tp-link/archer_c7)~ | ~v4~               | ~OpenWrt SNAPSHOT r26300-da0cd9d764~ |
| ~[mipsel_24kc](https://openwrt.org/docs/techref/instructionset/mipsel_24kc)~ | ~[ramips](https://openwrt.org/docs/techref/targets/ramips)~             | ~mt7621~    | ~TOTOLINK~ | ~[x5000r](https://openwrt.org/toh/totolink/x5000r)~      | ~n/a~              | ~OpenWrt SNAPSHOT r26300-da0cd9d764~ |

## Description

- Changelog:
  - [v0.27.6](https://github.com/netbirdio/netbird/releases/tag/v0.27.6)
  - [v0.27.5](https://github.com/netbirdio/netbird/releases/tag/v0.27.5)
  - [v0.27.4](https://github.com/netbirdio/netbird/releases/tag/v0.27.4)
- Full changelog: https://github.com/netbirdio/netbird/compare/v0.27.3...v0.27.6

## Edit

- rebase, bump version v0.27.5 to v0.27.6
- Format text