### PR TITLE
pianod: fix mbedtls 3.6 compilation

### DIFF
--- a/sound/pianod/Makefile
+++ b/sound/pianod/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pianod
 PKG_VERSION:=174.09
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://github.com/thess/pianod-sc/releases/download/$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz

--- a/sound/pianod/patches/010-mbedtls36.patch
+++ b/sound/pianod/patches/010-mbedtls36.patch
@@ -1,0 +1,10 @@
+--- a/src/libwaitress/waitress.c
++++ b/src/libwaitress/waitress.c
+@@ -46,6 +46,7 @@ THE SOFTWARE.
+ 
+ #if defined(USE_MBEDTLS)
+ 
++#include <mbedtls/compat-2.x.h>
+ #include <mbedtls/ssl.h>
+ #include <mbedtls/entropy.h>
+ #include <mbedtls/ctr_drbg.h>


### PR DESCRIPTION
Just a header is needed.

Maintainer: @thess 