### PR TITLE
stlink: fix compilation with GCC 14

### DIFF
--- a/utils/stlink/Makefile
+++ b/utils/stlink/Makefile
@@ -2,11 +2,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stlink
 PKG_VERSION:=1.8.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/stlink-org/$(PKG_NAME)/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=cff760b5c212c2cc480f705b9ca7f3828d6b9c267950c6a547002cd0a1f5f6ac
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/stlink-org/stlink
+PKG_MIRROR_HASH:=6211ce88fe699d5e810f6bb1dc7baaa7c66e8e0dcbd773f03f2d4524f1961512
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause

--- a/utils/stlink/patches/010-poll.patch
+++ b/utils/stlink/patches/010-poll.patch
@@ -1,0 +1,23 @@
+From 9f84dcdef89e8950bc631ba15b286530547bec72 Mon Sep 17 00:00:00 2001
+From: murray <murray.calavera@protonmail.com>
+Date: Thu, 15 Feb 2024 10:33:25 +0000
+Subject: [PATCH] Fix poll.h include path
+
+The correct include path for poll(2) is poll.h not sys/poll.h.
+sys/poll.h may not be available on some libcs or may issue a
+warning. In particular this fixes a warning on musl systems.
+---
+ src/st-util/gdb-remote.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/st-util/gdb-remote.c
++++ b/src/st-util/gdb-remote.c
+@@ -12,7 +12,7 @@
+ #include <win32_socket.h>
+ #else
+ #include <unistd.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #endif
+ 
+ #include "gdb-remote.h"

--- a/utils/stlink/patches/020-calloc.patch
+++ b/utils/stlink/patches/020-calloc.patch
@@ -1,0 +1,11 @@
+--- a/src/stlink-lib/chipid.c
++++ b/src/stlink-lib/chipid.c
+@@ -65,7 +65,7 @@ void process_chipfile(char *fname) {
+     return;
+   }
+ 
+-  ts = calloc(sizeof(struct stlink_chipid_params), 1);
++  ts = calloc(1, sizeof(struct stlink_chipid_params));
+ 
+   while (fgets(buf, sizeof(buf), fp) != NULL) {
+ 


### PR DESCRIPTION
Switch to local git tarballs. Smaller.

Upstream backport and a local patch.

Maintainer: @dangowrt 