### PR TITLE
bwm-ng: fix compilation with GCC 14

### DIFF
--- a/net/bwm-ng/Makefile
+++ b/net/bwm-ng/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bwm-ng
 PKG_VERSION:=0.6.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.gropp.org/bwm-ng

--- a/net/bwm-ng/patches/010-gcc14.patch
+++ b/net/bwm-ng/patches/010-gcc14.patch
@@ -1,0 +1,10 @@
+--- a/src/defines.h
++++ b/src/defines.h
+@@ -22,6 +22,7 @@
+ #ifndef __HAVE_DEFINE_H
+ #define __HAVE_DEFINE_H
+ 
++#include <ctype.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <unistd.h>


### PR DESCRIPTION
Header is missing.

Maintainer: @Zokormazo 