### PR TITLE
dump1090: fix compilation with GCC14

### DIFF
--- a/utils/dump1090/Makefile
+++ b/utils/dump1090/Makefile
@@ -9,11 +9,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dump1090
 PKG_VERSION:=9.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/flightaware/dump1090/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=6190622c3625713ec9cff882a9d6f6a51b6d2f83ef20e6e1905a3902c7b08483
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/flightaware/dump1090
+PKG_MIRROR_HASH:=5acbfd0afbed020fc8328b44ade406c855cf617a54a9049b309586e181242ec8
 
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/utils/dump1090/patches/010-gcc14.patch
+++ b/utils/dump1090/patches/010-gcc14.patch
@@ -1,0 +1,38 @@
+From f3b92b89dcd6311f15c777ee1ab7c4469880c7df Mon Sep 17 00:00:00 2001
+From: Ralf Ertzinger <ralf@skytale.net>
+Date: Sun, 28 Jan 2024 18:28:05 +0100
+Subject: [PATCH] Fix incorrect `calloc()` parameter order
+
+In two instances, the paramter order for `calloc()` calls are reversed,
+with the element size in the first parameter and the count in the
+second. When building under Fedora rawhide with gcc 14, this is flagged
+as an error.
+
+Signed-off-by: Ralf Ertzinger <ralf@skytale.net>
+---
+ adaptive.c | 2 +-
+ net_io.c   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+--- a/adaptive.c
++++ b/adaptive.c
+@@ -195,7 +195,7 @@ void adaptive_init()
+     adaptive_burst_window_remaining = adaptive_samples_per_window;
+     adaptive_burst_window_counter = 0;
+ 
+-    adaptive_range_radix = calloc(sizeof(unsigned), 65536);
++    adaptive_range_radix = calloc(65536, sizeof(unsigned));
+     adaptive_range_state = RANGE_RESCAN_UP;
+ 
+     // select and enforce gain limits
+--- a/net_io.c
++++ b/net_io.c
+@@ -104,7 +104,7 @@ struct net_service *serviceInit(const ch
+ {
+     struct net_service *service;
+ 
+-    if (!(service = calloc(sizeof(*service), 1))) {
++    if (!(service = calloc(1, sizeof(*service)))) {
+         fprintf(stderr, "Out of memory allocating service %s\n", descr);
+         exit(1);
+     }


### PR DESCRIPTION
Upstream backport.

Switch to local tarballs. Smaller.

Maintainer: @Noltari 