### PR TITLE
uwsgi: fix compilation with GCC14

### DIFF
--- a/net/uwsgi/Makefile
+++ b/net/uwsgi/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uwsgi
 PKG_VERSION:=2.0.25.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=uWSGI
 PYPI_SOURCE_NAME:=uwsgi

--- a/net/uwsgi/patches/040-gcc14.patch
+++ b/net/uwsgi/patches/040-gcc14.patch
@@ -1,0 +1,11 @@
+--- a/core/regexp.c
++++ b/core/regexp.c
+@@ -23,7 +23,7 @@ int uwsgi_regexp_build(char *re, uwsgi_p
+ 
+ #ifdef UWSGI_PCRE2
+ 	int errnbr;
+-	long unsigned int erroff;
++	size_t erroff;
+ 
+ 	*pattern = pcre2_compile((const unsigned char *) re, PCRE2_ZERO_TERMINATED, 0, &errnbr, &erroff, NULL);
+ #else


### PR DESCRIPTION
Wrong pointer type is used.

Maintainer: @Ansuel 

Fixes: https://github.com/openwrt/packages/issues/24160