### PR TITLE
remserial: fix compilation with GCC14

### DIFF
--- a/net/remserial/Makefile
+++ b/net/remserial/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=remserial
 PKG_VERSION:=1.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPL-2.0-or-later
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/remserial/patches/010-gcc14.patch
+++ b/net/remserial/patches/010-gcc14.patch
@@ -1,0 +1,10 @@
+--- a/remserial.c
++++ b/remserial.c
+@@ -54,6 +54,7 @@ void sighandler(int sig);
+ int connect_to(struct sockaddr_in *addr);
+ void usage(char *progname);
+ void link_slave(int fd);
++void set_tty(int fd,char *settings);
+ 
+ int main(int argc, char *argv[])
+ {


### PR DESCRIPTION
Missing function declaration.

Maintainer: @nunojpg 