### PR TITLE
nsutils: fix compilation with GCC14

### DIFF
--- a/utils/nsutils/Makefile
+++ b/utils/nsutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nsutils
 BASE_VERSION:=0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/rd235/nsutils.git

--- a/utils/nsutils/patches/010-gcc14.patch
+++ b/utils/nsutils/patches/010-gcc14.patch
@@ -1,0 +1,10 @@
+--- a/nslist.c
++++ b/nslist.c
+@@ -25,6 +25,7 @@
+ #include <stdint.h>
+ #include <string.h>
+ #include <ctype.h>
++#include <libgen.h>
+ #include <limits.h>
+ #include <dirent.h>
+ #include <getopt.h>


### PR DESCRIPTION
Missing header.

Maintainer: @oskarirauta 