### PR TITLE
cyrus-sasl: fix compilation with GCC14

### DIFF
--- a/libs/cyrus-sasl/Makefile
+++ b/libs/cyrus-sasl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cyrus-sasl
 PKG_VERSION:=2.1.28
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 

--- a/libs/cyrus-sasl/patches/010-gcc14.patch
+++ b/libs/cyrus-sasl/patches/010-gcc14.patch
@@ -1,0 +1,32 @@
+--- a/lib/saslutil.c
++++ b/lib/saslutil.c
+@@ -59,9 +59,7 @@
+ #ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+-#ifdef HAVE_TIME_H
+ #include <time.h>
+-#endif
+ #include "saslint.h"
+ #include <saslutil.h>
+ 
+--- a/plugins/cram.c
++++ b/plugins/cram.c
+@@ -48,6 +48,7 @@
+ #include <string.h>
+ #include <stdlib.h>
+ #include <stdio.h>
++#include <time.h>
+ #ifndef macintosh
+ #include <sys/stat.h>
+ #endif
+--- a/plugins/digestmd5.c
++++ b/plugins/digestmd5.c
+@@ -50,6 +50,7 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <string.h>
++#include <time.h>
+ #ifndef macintosh
+ #include <sys/types.h>
+ #include <sys/stat.h>


### PR DESCRIPTION
Missing time.h header.

Maintainer: @flyn-org 