### PR TITLE
openldap: fix compilation with GCC14

### DIFF
--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
 PKG_VERSION:=2.6.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://mirror.eu.oneandone.net/software/openldap/openldap-release/ \

--- a/libs/openldap/patches/030-gcc14.patch
+++ b/libs/openldap/patches/030-gcc14.patch
@@ -1,0 +1,11 @@
+--- a/servers/slapd/config.c
++++ b/servers/slapd/config.c
+@@ -151,7 +151,7 @@ int config_check_vals(ConfigTable *Conf,
+ 	int rc, arg_user, arg_type, arg_syn, iarg;
+ 	unsigned uiarg;
+ 	long larg;
+-	size_t ularg;
++	unsigned long ularg;
+ 	ber_len_t barg;
+ 	
+ 	if(Conf->arg_type == ARG_IGNORED) {


### PR DESCRIPTION
Wrong pointer type.

Maintainer: @flyn-org 