### PR TITLE
ddns-scripts: do not verify DNS server on start

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=44
+PKG_RELEASE:=45
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
@@ -322,9 +322,6 @@ else
 	write_log 7 "last update: $(eval $EPOCH_TIME)"
 fi
 
-# verify DNS server
-[ -n "$dns_server" ] && verify_dns "$dns_server"
-
 # verify Proxy server and set environment
 [ -n "$proxy" ] && {
 	verify_proxy "$proxy" && {


### PR DESCRIPTION
Maintainer: me
Compile tested: no only script changes
Run tested: x86_64, APU3, OpenWrt latest

Description:
Can any of @McGiverGim @jummo @maxberger  check that the change does not generate regressions? 
I had problem with my ddns update and debugged it and the problem is the DNS server check. 

When the ddns update script is started, the system checks whether the configured DNS server can be reached. This is checked with the 'netcat' tool. The tool tries to establish a TCP connection on port 53 of the configured DNS server.

The problem with this implementation is, that this call blocks the ddns update script until 'netcat' returns from the call.

Verfification failed:
If the IP and the port cannot be reached, the netcat call returns immediately.

Verfification successfull:
If the IP and the port of the DNS server can be reached, the connection remains established and so the ddns update scripts blocks until the configured TCP session timeout of the DNS server resets the connection.

The behavior in the event of an successfull verificataion is a problem for the ddns update script if it is called via the hotplug. Since the ddns update script runs too long! This blocking behavior also depends on the TCP session timeout setting of the DNS server.

> time netcat 1.1.1.1 53
netcat 1.1.1.1 53  0.00s user 0.00s system 0% cpu 10.016 total

> time netcat 8.8.8.8 53
netcat 8.8.8.8 53  0.00s user 0.00s system 0% cpu 2.012 total

The TCP session timeout is for 1.1.1.1 10 seconds and for 8.8.8.8 2 seconds.

The '--wait' option of necat or the additional integration of the 'timeout' function of busybox was implemented for this behavior. But the used '--wait' function of netcat of the busybox shows no effect here.

Since the used implementation is not clean, the question arise why this is necessary for the ddns update script at all? As the nslookup throws an error anyway if it cannot resolve the IP. This check is only informative. The check does not affect the script behavior.

The check is therefore removed on ddns update.


