### PR TITLE
modemmanager: do not disable modem on reconnect

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.22.0
-PKG_RELEASE:=13
+PKG_RELEASE:=14
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -710,8 +710,17 @@ proto_modemmanager_teardown() {
 	mmcli --modem="${device}" --simple-disconnect ||
 		proto_notify_error "${interface}" DISCONNECT_FAILED
 
-	# disable
-	mmcli --modem="${device}" --disable
+	# reading variable from var state which was set in
+	# '/usr/lib/ModemManager/connection.d/10-report-down'
+	# because of a reconnect event.
+	# The modem therefore does not need to be disabled.
+	local disable="$(uci_get_state network "$interface" disable_modem "1")"
+	if [ "${disable}" -eq 0 ]; then
+		echo "Modem remains enabled"
+		uci_revert_state network "${interface}" disable_modem
+	else
+		mmcli --modem="${device}" --disable
+	fi
 
 	# low power, only if requested
 	[ "${lowpower:-0}" -lt 1 ] ||

--- a/net/modemmanager/files/usr/lib/ModemManager/connection.d/10-report-down
+++ b/net/modemmanager/files/usr/lib/ModemManager/connection.d/10-report-down
@@ -32,6 +32,8 @@ IFUP=$(ifstatus "${CFG}" | jsonfilter -e "@.up")
 
 [ "${IFUP}" = "true" ] && {
 	mm_log "info" "Reconnecting '${CFG}' on '${STATE}' event"
+
+	uci_toggle_state network "${CFG}" disable_modem "0"
 	ubus call network.interface down "{ 'interface': '${CFG}'}"
 	ubus call network.interface up "{ 'interface': '${CFG}'}"
 }


### PR DESCRIPTION
Description:
If the modem loses the connection, an attempt is made to re-establish the connection via the report-down script.

Until now, the modem was disabled when the modem processed the teardown of the modemmanager protohandler. The immediate up events of netifd renables the modem right away. This takes time, which is not necessary.

This commit changes the behavior so that the modem is not disabled when the modemmanager is disconnected via the report-down script.

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

