### PR TITLE
sslh: update to v1.23.1

### DIFF
--- a/net/sslh/Makefile
+++ b/net/sslh/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sslh
-PKG_VERSION:=v1.22c
+PKG_VERSION:=v1.23.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://rutschle.net/tech/sslh/
-PKG_HASH:=8e3742d14edf4119350cfdc7bb96b89134d9218eb6d2a6e1f70891ca18a649b1
+PKG_HASH:=2aac006b40e5ae90e3b0fccb44acc994174e24e64457f25041b06aa2433ae637
 
 PKG_MAINTAINER:=Jonathan McCrohan <jmccrohan@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -47,6 +47,16 @@ endef
 
 MAKE_FLAGS += \
   USELIBCAP=1
+
+define Build/Compile
+
+ifeq ($(CONFIG_SSLH_SELECT),y)
+	$(call Build/Compile/Default,sslh-select)
+else
+	$(call Build/Compile/Default,sslh-fork)
+endif
+
+endef
 
 define Package/sslh/install
 	$(INSTALL_DIR) $(1)/usr/sbin

--- a/net/sslh/patches/001-configfile-fix.patch
+++ b/net/sslh/patches/001-configfile-fix.patch
@@ -8,23 +8,3 @@
  # This is a basic configuration file that should provide
  # sensible values for "standard" setup.
  
-@@ -15,15 +19,16 @@ chroot: "/var/empty";
- # Change hostname with your external address name.
- listen:
- (
--    { host: "thelonious"; port: "443"; }
-+    { host: "0.0.0.0"; port: "443"; },
-+    { host: "[::]"; port: "443"; }
- );
- 
- protocols:
- (
-      { name: "ssh"; service: "ssh"; host: "localhost"; port: "22"; fork: true; },
-      { name: "openvpn"; host: "localhost"; port: "1194"; },
--     { name: "xmpp"; host: "localhost"; port: "5222"; },
--     { name: "http"; host: "localhost"; port: "80"; },
-+#     { name: "xmpp"; host: "localhost"; port: "5222"; },
-+#     { name: "http"; host: "localhost"; port: "80"; },
-      { name: "tls"; host: "localhost"; port: "443"; log_level: 0; },
-      { name: "anyprot"; host: "localhost"; port: "443"; }
- );


### PR DESCRIPTION
Maintainer: @jmccrohan
Compile tested: x86 32bit, model, OpenWrt master
Run tested: VirtualBox

Description:
The sslh Makefile's default target "all" now also tries to compile a new version sslh-ev. To disable its compilation the Build/Compile is overridden and to call directly "make sslh-select" or "make sslh-fork" depending on CONFIG_SSLH_SELECT.

Some changes from 001-configfile-fix.patch were applied to the upstream and we can remove them. The only left is a notice "sslh command line arguments override the config".

