### PR TITLE
speedtest-go: update to 1.7.7

### DIFF
--- a/net/speedtest-go/Makefile
+++ b/net/speedtest-go/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=speedtest-go
-PKG_VERSION:=1.7.5
+PKG_VERSION:=1.7.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/showwin/speedtest-go/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c18d7e74171b739a10e6b00e426f9f5fbf4d1dde345f3e20d14df9bbe2dc1aaf
+PKG_HASH:=68609998d91e6ac159b41cf85c758058805527044e1af3d557fd67bb4fabd9de
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Update speedtest-go version to 1.7.7

Maintainer: TeleostNaCl [teleostnacl@gmail.com](mailto:teleostnacl@gmail.com)
Compile tested: MediaTek Ralink MIPS MT7621 based boards Phicomm K2P Powered by LuCI Master (git-24.130.56871-0191870)
Run tested: MediaTek Ralink MIPS MT7621 based boards Phicomm K2P Powered by LuCI Master (git-24.130.56871-0191870)

Description: Add new package, a CLI with go to test internet speed