### PR TITLE
[23.05] sing-box: update to 1.8.14

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.8.12
+PKG_VERSION:=1.8.14
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=802eb5e202ac1dd846b1f529b3df9e5d69452182fd5d70f7c8f2a819c9e86162
+PKG_HASH:=2ba7cfa097f5963ba304d47606e7a6b61bf881eb86cbed78fa6e4efae44a0a5f
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: me
Compile tested: (x86_64, OpenWrt-23.05)
Run tested: (x86_64, OpenWrt-23.05, tests done)

Description:
Cherry picked from #24193.