### PR TITLE
nft-qos remove unnecessary log to avoid log spam 

### DIFF
--- a/net/nft-qos/files/nft-qos-dynamic.hotplug
+++ b/net/nft-qos/files/nft-qos-dynamic.hotplug
@@ -18,7 +18,6 @@ qosdef_check_if_dynamic() {
 }
 
 
-logger -t nft-qos-dynamic "ACTION=$ACTION, MACADDR=$MACADDR, IPADDR=$IPADDR, HOSTNAME=$HOSTNAME"
 
 case "$ACTION" in
 	add | update | remove)

--- a/net/nft-qos/files/nft-qos-dynamic.hotplug
+++ b/net/nft-qos/files/nft-qos-dynamic.hotplug
@@ -18,7 +18,6 @@ qosdef_check_if_dynamic() {
 }
 
 
-
 case "$ACTION" in
 	add | update | remove)
 		qosdef_validate_dynamic default qosdef_check_if_dynamic

--- a/net/nft-qos/files/nft-qos-monitor.hotplug
+++ b/net/nft-qos/files/nft-qos-monitor.hotplug
@@ -7,7 +7,6 @@ export initscript="nft-qos-monitor"
 
 . /lib/nft-qos/monitor.sh
 
-logger -t nft-qos-monitor "ACTION=$ACTION, MACADDR=$MACADDR, IPADDR=$IPADDR, HOSTNAME=$HOSTNAME"
 
 case "$ACTION" in
 	add | update)


### PR DESCRIPTION
Maintainer: @neheb @wulfy23 @champtar @lzto @ldir-EDB0 @rosysong

Compile tested: I think it’s don’t needed.

Run tested: 

I comment out this logger line in 2 files at `/etc/hotplug.d/dhcp/` on my OpenWrt, and it’s works normally.

Description:

Log DHCP info to system log is obviously unnecessary. I found some users in community also complaining about this because sometimes it leads to log spam.
See: https://www.right.com.cn/forum/thread-4091545-1-1.html