### PR TITLE
libqmi, lpac: bump versions to support eSIM

### DIFF
--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_VERSION:=1.34.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.35.4-dev
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/libqmi.git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
-PKG_MIRROR_HASH:=65ee91b81c6f68d908cc94a0b5d670eefa29d550ecf8ef94cb836981fbfa4c2a
+PKG_MIRROR_HASH:=074cd6cae2f4b314d6ac1058cd24da36021fb701e7ed187275b7f37cd1582f45
 
 PKG_BUILD_FLAGS:=gc-sections
 

--- a/utils/lpac/Makefile
+++ b/utils/lpac/Makefile
@@ -3,12 +3,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lpac
-PKG_VERSION:=2.0.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/estkme-group/lpac/tar.gz/refs/tags/v$(PKG_VERSION)?
-PKG_HASH:=6afa88ed7d38ba5973a540d818c800083368ac82b3b09ac6fd18f7929b830b0a
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/estkme-group/lpac.git
+PKG_SOURCE_DATE:=2024-05-29
+PKG_SOURCE_VERSION:=d41c2f84461f19f01fe0cebeadebacd0c3e009dc
+PKG_MIRROR_HASH:=010f68ae93c07f279c71f80b819fa1003d93b768feb747125f29356970226961
 
 PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
 PKG_LICENSE:=AGPL-3.0-only LGPL-2.0-only


### PR DESCRIPTION
the new version includes changes needed for e-SIM functionality

@mips171 @blocktrron 