### PR TITLE
msmtp: update to version 1.8.26

### DIFF
--- a/mail/msmtp/Makefile
+++ b/mail/msmtp/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=msmtp
-PKG_VERSION:=1.8.25
+PKG_VERSION:=1.8.26
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://marlam.de/msmtp/releases
-PKG_HASH:=2dfe1dbbb397d26fe0b0b6b2e9cd2efdf9d72dd42d18e70d7f363ada2652d738
+PKG_HASH:=6cfc488344cef189267e60aea481f00d4c7e2a59b53c6c659c520a4d121f66d8
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-3.0-or-later

--- a/mail/msmtp/test.sh
+++ b/mail/msmtp/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+case "$1" in
+        msmtp)
+                msmtp --version | grep "$2"
+                ;;
+esac


### PR DESCRIPTION
Maintainer: me
Compile tested and run tested: inside GitHub actions

Release notes:
https://marlam.de/msmtp/news/msmtp-1-8-26/