### PR TITLE
netbird: update to 0.27.10

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.27.7
+PKG_VERSION:=0.27.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8b93ea80bc8f6a69447c2ad00448c29b91f13822377136c1ea15b9ec45c23d9d
+PKG_HASH:=d5a0f2af7e340a8df334906850401caf2d5498df832dc82a3153b2031f2ed897
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## Compile and run tested

Maintainer: Oskari Rauta / @oskarirauta

| Package architecture | Target | Subtarget | Brand | Model | Hardware Version | OpenWrt version |
|----------------------|--------|-----------|-------|-------|------------------|-----------------|
| [mips_24kc](https://openwrt.org/docs/techref/instructionset/mips_24kc) | [ar71xx-ath79](https://openwrt.org/docs/techref/targets/ar71xx-ath79) | generic | TP-Link | [Archer C7](https://openwrt.org/toh/tp-link/archer_c7) | v4 | OpenWrt SNAPSHOT r26435-f7f8099aa3 |
| ~[mips_24kc](https://openwrt.org/docs/techref/instructionset/mips_24kc)~ | ~[ar71xx-ath79](https://openwrt.org/docs/techref/targets/ar71xx-ath79)~ | ~generic~ | ~TP-Link~ | ~[Archer C7](https://openwrt.org/toh/tp-link/archer_c7)~ | ~v4~ | ~OpenWrt SNAPSHOT r26390-e83a5618d4~ |
| ~[mipsel_24kc](https://openwrt.org/docs/techref/instructionset/mipsel_24kc)~ | ~[ramips](https://openwrt.org/docs/techref/targets/ramips)~ | ~mt7621~ | ~TOTOLINK~ | ~[x5000r](https://openwrt.org/toh/totolink/x5000r)~ | ~n/a~ | ~OpenWrt SNAPSHOT r26387-9a11bc3682~ |

## Description

- Changelog:
  - [v0.27.10](https://github.com/netbirdio/netbird/releases/tag/v0.27.10)
  - [v0.27.9](https://github.com/netbirdio/netbird/releases/tag/v0.27.9)
  - [v0.27.8](https://github.com/netbirdio/netbird/releases/tag/v0.27.8)
- Full changelog: https://github.com/netbirdio/netbird/compare/v0.27.7...v0.27.10

## Additional information

Compiled package with container [`sdk`](https://github.com/openwrt/docker), and build `openwrt` image with container [`imagebuilder`](https://github.com/openwrt/docker)

My repo with my automated build can be see here:
- https://github.com/wehagy/openwrt-builder

And my artifacts here:
- https://github.com/wehagy/openwrt-builder/actions/runs/9259257007
- ~https://github.com/wehagy/openwrt-builder/actions/runs/9215712155~

### Edit
 - rebase, bump version v0.27.9 to v0.27.10
 - Add totolink device
