### PR TITLE
github: Improve Pull Request template

### DIFF
--- a/.github/pull_request_template
+++ b/.github/pull_request_template
@@ -1,5 +1,18 @@
-Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
-Compile tested: (put here arch, model, OpenWrt version)
-Run tested: (put here arch, model, OpenWrt version, tests done)
+**Package details**
 
-Description:
+    Maintainer: @\<github-user> (find it by checking the history of the package Makefile)
+    Description:
+
+**Indication of run testing**
+
+     OpenWrt version:
+     OpenWrt target/subtarget:
+     OpenWrt device:
+
+**Formalities**
+
+     [ ] Review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
+
+     If your PR contains a patch
+     [ ] Make sure that it can be applied by git am
+     [ ] It must be in a way that it is potentially upstreamable (subject, commit description, etc.), and we must try to upstream it so we have fewer patches and fewer.


### PR DESCRIPTION
By updating pull request template, this ensures that all newly patches will be hopefully submitted to upstream, which help us that we dont need to maintain these patches for ages. Also, all patches should be applied by git am. This is important, because this follows OpenWrt main repo contribution policy and we will know, who is the author of the patch and what it does (= commit subject, commit description).

Also, we don't need to know on which host env, we compiled package. If there is something host related, we can request details. This details is not requested in OpenWrt main repo.
