### PR TITLE
iperf3: update to 3.17.1

### DIFF
--- a/net/iperf3/Makefile
+++ b/net/iperf3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
-PKG_VERSION:=3.16
+PKG_VERSION:=3.17.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.es.net/pub/iperf
-PKG_HASH:=cc740c6bbea104398cc3e466befc515a25896ec85e44a662d5f4a767b9cf713e
+PKG_HASH:=84404ca8431b595e86c473d8f23d8bb102810001f15feaf610effd3b318788aa
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Changelogs since last release:
	https://github.com/esnet/iperf/releases/tag/3.17
	https://github.com/esnet/iperf/releases/tag/3.17.1

Maintainer: @nbd168 