### PR TITLE
lighttpd: trigger reload on ACME cert renewal

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.76
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 # release candidate ~rcX testing; remove for release
 #PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 

--- a/net/lighttpd/files/lighttpd.init
+++ b/net/lighttpd/files/lighttpd.init
@@ -33,6 +33,7 @@ start_service() {
 service_triggers() {
 	procd_add_reload_interface_trigger loopback
 	procd_add_reload_interface_trigger lan
+	procd_add_raw_trigger acme.renew 5000 /etc/init.d/lighttpd reload
 }
 
 reload_service() {


### PR DESCRIPTION
Maintainer: @gstrauss
Compile tested: main branch OpenWrt
Run tested: VirtualBox

Description:
When the acme service issued a new cert it will call a hotplug and send UBUS event `acme.renew`. All services that _may_ use the certs issued by acme should re-read the certs if they were changed.
The triggers was already [added](https://github.com/openwrt/packages/commit/7f04710579ef9466bc429403624fed71f112d6c9#diff-dc08870b7ffa81c14c116dcd370cbea271ef3ef728731d1c40046952f90b9a0fR69) for uhttpd, nginx and haproxy. But not for the Lighttpd and Apache. For the Apache it would be more difficult because it doesn't use procd but for the Lighty it's simple.

Fixes #15610
