### PR TITLE
acme-common: fallback to deprecated use_staging if the staging option is not set

### DIFF
--- a/net/acme-common/files/acme.init
+++ b/net/acme-common/files/acme.init
@@ -25,10 +25,10 @@ cleanup() {
 load_options() {
 	section=$1
 
+	config_get staging "$section" staging
 	# compatibility for old option name
-	config_get_bool staging "$section" use_staging
 	if [ -z "$staging" ]; then
-		config_get_bool staging "$section" staging 0
+		config_get_bool staging "$section" use_staging 0
 	fi
 	export staging
 	config_get calias "$section" calias
@@ -130,7 +130,7 @@ load_globals() {
 	fi
 	export state_dir
 
-	config_get debug "$section" debug 0
+	config_get_bool debug "$section" debug 0
 	export debug
 
 	# only look for the first acme section


### PR DESCRIPTION
Maintainer: @tohojo
Description:

The use_staging option was deprecated in 9d2d8787cafdfb49339766a00ced422fa75cb883. But it still has a bigger priority than the staging option. This happens because config_get_bool returns 0 when the use_staging option wasn't set. So the next check for the staging var emptiness is always false.

As the simplest fix, use the config_get staging that returns a plain string when the option is not set and if it's empty then fallback to the use_staging.

Once the use_staging option is removed we should get back to the config_get_bool staging.

Also use config_get_bool debug.

The luci-app-acme uses the `use_staging` option. I'll send a PR to fix this.
