### PR TITLE
mg: fix compilation with GCC 14

### DIFF
--- a/utils/mg/Makefile
+++ b/utils/mg/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mg
 PKG_VERSION:=7.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ibara/mg/tar.gz/$(PKG_NAME)-$(PKG_VERSION)?

--- a/utils/mg/patches/902-fix_for_gcc14.patch
+++ b/utils/mg/patches/902-fix_for_gcc14.patch
@@ -1,0 +1,10 @@
+--- a/main.c
++++ b/main.c
+@@ -18,6 +18,7 @@
+ #include <unistd.h>
+ #if defined(__linux__) || defined(__CYGWIN__)
+ #include <pty.h>
++#include <utmp.h>
+ #elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+ #include <util.h>
+ #else


### PR DESCRIPTION
Maintainer: me
Compile tested: head, aarch64
Run tested: aarch64 (qemu-9.0.0)

Description:
Addressing compile errors with gcc-14
