### PR TITLE
pciutils: fix compilation with GCC14

### DIFF
--- a/utils/pciutils/Makefile
+++ b/utils/pciutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pciutils
 PKG_VERSION:=3.12.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/utils/pciutils

--- a/utils/pciutils/patches/210-gcc-14-compatibility.patch
+++ b/utils/pciutils/patches/210-gcc-14-compatibility.patch
@@ -1,0 +1,10 @@
+--- a/lib/sysfs.c
++++ b/lib/sysfs.c
+@@ -19,6 +19,7 @@
+ #include <errno.h>
+ #include <dirent.h>
+ #include <fcntl.h>
++#include <libgen.h>
+ #include <sys/types.h>
+ 
+ #include "internal.h"


### PR DESCRIPTION
Fixes:
``` C
sysfs.c:457:53: error: implicit declaration of function 'basename' [-Wimplicit-function-declaration]
  457 |           pci_set_property(d, PCI_FILL_IOMMU_GROUP, basename(group_link));
      |                                                     ^~~~~~~~
```

Maintainer: @lucize
Compile tested: WRT3200ACM

@neheb @PolynomialDivision @1715173329 @hauke @Ansuel 