### PR TITLE
croc: update to 10.0.5

### DIFF
--- a/net/croc/Makefile
+++ b/net/croc/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=croc
-PKG_VERSION:=9.6.15
+PKG_VERSION:=10.0.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/schollz/croc/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=ca118155cdf3ceb7496928b1c76387ba74f39b774372d30543e6cbd23d2c0a97
+PKG_HASH:=a5d1dc841d01a15e7ccec4280aa0905c69d4076236e1dd53513cde90097688a7
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -20,7 +20,7 @@ PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
-GO_PKG:=github.com/schollz/croc/v9
+GO_PKG:=github.com/schollz/croc/v10
 GO_PKG_BUILD_PKG:=$(GO_PKG)
 GO_PKG_LDFLAGS_X:=$(GO_PKG)/src/cli.Version=v$(PKG_VERSION)
 


### PR DESCRIPTION
breaking changes to fix several CVEs. croc v10.x.x cannot be used with with previous croc versions.

release notes:
https://github.com/schollz/croc/releases/tag/v9.6.16
https://github.com/schollz/croc/releases/tag/v9.6.17
(9.6.16 + .17 were later rereleased as 10.0.0)
https://github.com/schollz/croc/releases/tag/v10.0.0
https://github.com/schollz/croc/releases/tag/v10.0.1
https://github.com/schollz/croc/releases/tag/v10.0.2
https://github.com/schollz/croc/releases/tag/v10.0.3
https://github.com/schollz/croc/releases/tag/v10.0.4
https://github.com/schollz/croc/releases/tag/v10.0.5

Maintainer: me
Compile tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt snapshot
Run tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt snapshot

Description:
(Please tell me if there are to many links as reference in the commit message. Unfortunately, the author of the tool has a horrible way of releasing new versions.)

croc v10 release fixes several CVEs which can be found in the first release note link. This requires breaking behavior with previous croc versions before 10, they won't work together anymore.
As a consequence of these changes, there is a usage change since the user cannot simply provide the secret as a CLI argument anymore but needs to pass it via an environment variable or on the prompt after croc has been run without any secret.