### PR TITLE
acme-common: create a symlink to webroot

### DIFF
--- a/net/acme-common/Makefile
+++ b/net/acme-common/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-common
-PKG_VERSION:=1.2.0
+PKG_VERSION:=1.3.0
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/acme-common/files/acme.uci-defaults
+++ b/net/acme-common/files/acme.uci-defaults
@@ -1,4 +1,9 @@
 #!/bin/sh
+# Create a symlink to webroot
+if [ -d /www/ ] && [ ! -L /www/.well-known/acme-challenge ] && [ ! -d /www/.well-known/acme-challenge/ ]; then
+	mkdir -p /www/.well-known/
+	ln -s /var/run/acme/challenge/ /www/.well-known/acme-challenge
+fi
 
 grep -q '/etc/init.d/acme' /etc/crontabs/root 2>/dev/null && exit 0
 echo "0 0 * * * /etc/init.d/acme start" >>/etc/crontabs/root


### PR DESCRIPTION
Maintainer: @tohojo CC @hgl
Compile tested: OpenWrt main branch
Run tested: VirtualBox

Description:

The `webroot` option was deprecated and users should use the /var/run/acme/challenge by default. The folder itself should be exposed to web.
The simplest way to do this is to create a symlink from /www. This is a default web location for most routers and should cover most cases.

Here I extended the acme.uci-defaults script to create the symlink.
If a user doesn't have the /www folder or it's in other place then the symlink creation will be skipped.
Ideally we should send a PR to all web servers to make them unconditionally serve the folder themselves. But that would be a change that is difficult to push. So as a quick solution this should help just today. 


As an additional topic I tried to make the `acme.sh` command to be runned without the specifying a full path `/usr/lib/acme/client/acme.sh`. This should help users to just copy-paste commands from the acme.sh wiki. It's relatively easy to create a symlink from the `/usr/lib/acme/client/acme.sh` to `/usr/bin/` but the acme.sh also looking for the `dnsapi` folder that should be placed to the same folder as the script. Having the `/usr/bin/dnsapi/` folder is unacceptable so leaved the idea. We may try to override the `_SUB_FOLDER_DNSAPI` var.

Still maybe this is something that you considered to do, here is patch:
```diff
===================================================================
diff --git a/net/acme-acmesh/Makefile b/net/acme-acmesh/Makefile
--- a/net/acme-acmesh/Makefile	(revision a694a0277574985cd67dacc19d6e869f8e4d8d86)
+++ b/net/acme-acmesh/Makefile	(date 1716923256716)
@@ -45,6 +45,8 @@
 define Package/acme-acmesh/install
 	$(INSTALL_DIR) $(1)/usr/lib/acme/client
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/acme.sh $(1)/usr/lib/acme/client
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(LN) ../../usr/lib/acme/client/acme.sh $(1)/usr/bin/
 	$(INSTALL_BIN) ./files/hook.sh $(1)/usr/lib/acme/hook
 endef
```

