### PR TITLE
netatalk: update to 3.2.0

### DIFF
--- a/net/netatalk/Makefile
+++ b/net/netatalk/Makefile
@@ -1,0 +1,99 @@
+#
+# Copyright (C) 2009-2013 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=netatalk
+PKG_VERSION:=3.2.0
+PKG_RELEASE:=1
+
+#PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=@SF/netatalk
+PKG_HASH:=0c2b4b47450bc7ac95a268d1033471f572a3e06b64131fcef9b66e73663b6d08
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
+
+PKG_CPE_ID:=cpe:/a:netatalk:netatalk
+
+PKG_BUILD_DEPENDS:=libevent2
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/netatalk
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Filesystem
+  DEPENDS:=+libattr +libdb47 +libgcrypt +libopenssl +libevent2
+  TITLE:=netatalk
+  URL:=http://netatalk.sourceforge.net
+  MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+endef
+
+define Package/netatalk/decription
+  Netatalk is a freely-available Open Source AFP fileserver.
+  It also provides a kernel level implementation of the AppleTalk
+  Protocol Suite.
+endef
+
+TARGET_CFLAGS += -std=gnu99
+
+CONFIGURE_ARGS += \
+	--disable-afs \
+	--disable-hfs \
+	--enable-debugging \
+	--disable-shell-check \
+	--disable-timelord \
+	--disable-a2boot \
+	--disable-cups \
+	--disable-tcp-wrappers \
+	--with-cnid-default-backend=dbd \
+	--with-bdb="$(STAGING_DIR)/usr/" \
+	--with-libevent=no \
+	--with-libgcrypt-dir="$(STAGING_DIR)/usr" \
+	--with-ssl-dir="$(STAGING_DIR)/usr" \
+	--with-uams-path="/usr/lib/uams" \
+	--without-acls \
+	--without-kerberos \
+	--without-mysql \
+	--with-mysql-config=false \
+	--without-pam \
+	--disable-admin-group \
+	--disable-srvloc \
+	--disable-zeroconf \
+	$(if $(CONFIG_SHADOW_PASSWORDS),--with-shadow,--without-shadow) \
+	--without-dtrace \
+	--without-ldap
+
+define Package/netatalk/conffiles
+/etc/afp.conf
+/etc/extmap.conf
+/etc/netatalk/
+endef
+
+define Package/netatalk/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/usr/lib/uams
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libatalk.so* $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/dbd $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ad $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/afppasswd $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/afpd $(1)/usr/sbin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/cnid_dbd $(1)/usr/sbin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/cnid_metad $(1)/usr/sbin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/uams/*.so $(1)/usr/lib/uams/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/afp.conf $(1)/etc/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/extmap.conf $(1)/etc/
+	$(INSTALL_BIN) ./files/afpd.init $(1)/etc/init.d/afpd
+endef
+
+$(eval $(call BuildPackage,netatalk))

--- a/net/netatalk/files/afpd.init
+++ b/net/netatalk/files/afpd.init
@@ -1,0 +1,23 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2010-2012 OpenWrt.org
+
+START=80
+STOP=10
+
+USE_PROCD=1
+
+start_service() {
+        mkdir -p /var/netatalk/CNID/
+
+	procd_open_instance
+	procd_set_param command /usr/sbin/afpd -d -F /etc/afp.conf
+	procd_set_param file /etc/afp.conf
+	procd_set_param respawn
+	procd_close_instance
+
+	procd_open_instance
+	procd_set_param command /usr/sbin/cnid_metad -d
+	procd_set_param respawn
+	procd_close_instance
+}
+


### PR DESCRIPTION
Maintainer: @APCCV / Antonio Pastor

Commit restores package after it was removed from OpenWrt 21.02.

Compile tested: ipq806x - OpenWrt 23.05.3, r23809
- Compiled using SDK for 23.05.3.

Run tested: ipq806x - OpenWrt 23.05.3, r23809. Tests included:
- opkg install of package
- edit config file to create network shares
- connect to shares from MacOS (both vintage 10.13 and 14.4)
- stored, modify and delete files in share from Finder
- check and update file Information (properties) from Finder
- configured share to be used for TimeMachine backup
- create a backup (full backup - initial backup)
- create incremental backups
- enter Time Machine and browse backups

Description:
Netatalk package was removed in 2023 as it was stale and used old 3.1.13 version from 2018.
This commit uses the latest stable netatalk version.
A separate PR will be created to take the package out of packages-abandoned.
