### PR TITLE
ngtcp2: fix bad pkgconfig paths

### DIFF
--- a/libs/ngtcp2/Makefile
+++ b/libs/ngtcp2/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ngtcp2
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/ngtcp2/$(PKG_NAME)/releases/download/v$(PKG_VERSION)/
@@ -31,6 +31,12 @@ discussed in IETF QUICWG for its standardization.
 endef
 
 CMAKE_OPTIONS += -DENABLE_LIB_ONLY=ON
+
+define Build/InstallDev
+	$(call Build/InstallDev/cmake,$(1))
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/libngtcp2.pc
+	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/libngtcp2.pc
+endef
 
 define Package/libngtcp2/install
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
Avoids leaking host paths.

Maintainer: @stangri 