### PR TITLE
ffmpeg: fix compilation with gcc14

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=5.1.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
@@ -385,7 +385,7 @@ REAL_CPU_TYPE:=$(firstword $(subst +, ,$(CONFIG_CPU_TYPE)))
 REAL_CPU_TYPE:=$(subst octeonplus,octeon+,$(REAL_CPU_TYPE))
 
 FFMPEG_CONFIGURE:= \
-	CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS) $(FPIC)" \
+	CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS) $(FPIC) -Wno-error=incompatible-pointer-types" \
 	LDFLAGS="$(TARGET_LDFLAGS)" \
 	./configure \
 	--enable-cross-compile \

--- a/multimedia/ffmpeg/patches/020-ioctl.patch
+++ b/multimedia/ffmpeg/patches/020-ioctl.patch
@@ -1,0 +1,35 @@
+From 9e674b31606c805dd31b4bb754364a72a5877238 Mon Sep 17 00:00:00 2001
+From: Brad Smith <brad-at-comstyle.com@ffmpeg.org>
+Date: Sun, 5 May 2024 23:59:47 -0400
+Subject: [PATCH] lavd/v4l2: Use proper field type for second parameter of
+ ioctl() with BSD's
+
+The proper type was used until 73251678c83cbe24d08264da693411b166239bc7.
+
+This covers all of the OS's that currently have V4L2 support, permutations
+of Linux glibc/musl, Android bionic, FreeBSD, NetBSD, OpenBSD, Solaris.
+
+Copied from FreeBSD ports patch.
+
+Signed-off-by: Brad Smith <brad@comstyle.com>
+Signed-off-by: Marton Balint <cus@passwd.hu>
+---
+ libavdevice/v4l2.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/libavdevice/v4l2.c
++++ b/libavdevice/v4l2.c
+@@ -106,10 +106,10 @@ struct video_data {
+     int (*open_f)(const char *file, int oflag, ...);
+     int (*close_f)(int fd);
+     int (*dup_f)(int fd);
+-#ifdef __GLIBC__
+-    int (*ioctl_f)(int fd, unsigned long int request, ...);
+-#else
++#if defined(__sun) || defined(__BIONIC__) || defined(__musl__) /* POSIX-like */
+     int (*ioctl_f)(int fd, int request, ...);
++#else
++    int (*ioctl_f)(int fd, unsigned long int request, ...);
+ #endif
+     ssize_t (*read_f)(int fd, void *buffer, size_t n);
+     void *(*mmap_f)(void *start, size_t length, int prot, int flags, int fd, int64_t offset);


### PR DESCRIPTION
Requires disabling a warning as there's an incompatibility between musl ioctl and v4l2_ioctl.

Maintainer: @thess @antonlacon 