### PR TITLE
libgpiod: update to 2.1.2

### DIFF
--- a/libs/libgpiod/Makefile
+++ b/libs/libgpiod/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgpiod
-PKG_VERSION:=2.1.1
+PKG_VERSION:=2.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/libs/libgpiod/
-PKG_HASH:=b21913f469d3135680d5516f00fdf9f81d5e564e19ffb690927ea7f1d7e312cb
+PKG_HASH:=7a148a5a7d1c97a1abb40474b9a392b6edd7a42fe077dfd7ff42cfba24308548
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: Michael Heimpold / @mhei 
Compile tested: ath79, buffalo,wzr-600dhp, r26434-0a861a0c0f
Run tested: ath79, buffalo,wzr-600dhp, r26434-0a861a0c0f

Description:

From NEWS:

libgpiod v2.1.2
===============

Bug fixes:
- fix C++ bindings build using slibtool
- accept the new style automatic GPIO chip labels from gpio-sim in bash tests

Misc:
- relicense C++ bindings under LGPL-2.1-or-later