### PR TITLE
acme-common: migrate deprecated options

### DIFF
--- a/net/acme-common/Makefile
+++ b/net/acme-common/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-common
-PKG_VERSION:=1.3.0
+PKG_VERSION:=1.4.0
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/acme-common/files/acme.init
+++ b/net/acme-common/files/acme.init
@@ -37,8 +37,8 @@ load_options() {
 	export dalias
 	config_get domains "$section" domains
 	export domains
-	export main_domain
 	main_domain="$(first_arg $domains)"
+	export main_domain
 	config_get keylength "$section" keylength
 	if [ "$keylength" ]; then
 		log warn "Option \"keylength\" is deprecated, please use key_type (e.g., ec256, rsa2048) instead."

--- a/net/acme-common/files/acme.uci-defaults
+++ b/net/acme-common/files/acme.uci-defaults
@@ -1,9 +1,57 @@
 #!/bin/sh
+. /lib/functions.sh
+
 # Create a symlink to webroot
 if [ -d /www/ ] && [ ! -L /www/.well-known/acme-challenge ] && [ ! -d /www/.well-known/acme-challenge/ ]; then
 	mkdir -p /www/.well-known/
 	ln -s /var/run/acme/challenge/ /www/.well-known/acme-challenge
 fi
+
+# migrate deprecated opts
+# shellcheck disable=SC2155
+handle_cert() {
+	local section="$1"
+	local use_staging=$(uci_get acme "$section" use_staging)
+	if [ -n "$use_staging" ]; then
+		uci_remove acme "$section" use_staging
+		local staging=$(uci_get acme "$section" staging)
+		if [ -z "$staging" ]; then
+			uci_set acme "$section" staging "$use_staging"
+		fi
+	fi
+
+	local keylength=$(uci_get acme "$section" keylength)
+	if [ -n "$keylength" ]; then
+		uci_remove acme "$section" keylength
+		local key_type=$(uci_get acme "$section" key_type)
+		if [ -z "$key_type" ]; then
+			case $keylength in
+			ec-*) key_type=${keylength/-/} ;;
+			*) key_type=rsa$keylength ;;
+			esac
+			uci_set acme "$section" key_type "$key_type"
+		fi
+	fi
+
+	local standalone=$(uci_get acme "$section" standalone)
+	[ -n "$standalone" ] && uci_remove acme "$section" standalone
+	local dns=$(uci_get acme "$section" dns)
+	local validation_method=$(uci_get acme "$section" validation_method)
+	if [ -z "$validation_method" ]; then
+		if [ -n "$dns" ]; then
+			validation_method="dns"
+		elif [ "$standalone" = 1 ]; then
+			validation_method="standalone"
+		else
+			validation_method="webroot"
+		fi
+		uci_set acme "$section" validation_method "$validation_method"
+	fi
+}
+
+config_load acme
+config_foreach handle_cert cert
+uci_commit
 
 grep -q '/etc/init.d/acme' /etc/crontabs/root 2>/dev/null && exit 0
 echo "0 0 * * * /etc/init.d/acme start" >>/etc/crontabs/root


### PR DESCRIPTION
Maintainer: @tohojo
Compile tested: OpenWrt main branch, x86
Run tested: VBox

Description:
Add to uci-defaults script a migration from old deprecated options to new:
  use_staging to staging
  keylength to key_type
  remove standalone
  add missing validation_method

We still support the old options in the acme.init if old config was copied after installing of the newer version of the acme-common.

So in a year or two we should remove them with the patch:

```patch
diff --git a/net/acme-common/files/acme.init b/net/acme-common/files/acme.init
--- a/net/acme-common/files/acme.init	(revision de3f1b5c4cf22b1ee06e533c8ace619ff75885ac)
+++ b/net/acme-common/files/acme.init	(date 1717240095041)
@@ -25,11 +25,7 @@
 load_options() {
 	section=$1
 
-	config_get staging "$section" staging
-	# compatibility for old option name
-	if [ -z "$staging" ]; then
-		config_get_bool staging "$section" use_staging 0
-	fi
+	config_get_bool staging "$section" use_staging 0
 	export staging
 	config_get calias "$section" calias
 	export calias
@@ -39,16 +35,7 @@
 	export domains
 	export main_domain
 	main_domain="$(first_arg $domains)"
-	config_get keylength "$section" keylength
-	if [ "$keylength" ]; then
-		log warn "Option \"keylength\" is deprecated, please use key_type (e.g., ec256, rsa2048) instead."
-		case $keylength in
-		ec-*) key_type=${keylength/-/} ;;
-		*) key_type=rsa$keylength ;;
-		esac
-	else
-		config_get key_type "$section" key_type ec256
-	fi
+	config_get key_type "$section" key_type ec256
 	export key_type
 	config_get dns "$section" dns
 	export dns
@@ -56,8 +43,6 @@
 	export acme_server
 	config_get days "$section" days
 	export days
-	config_get standalone "$section" standalone
-	[ -n "$standalone" ] && log warn "Option \"standalone\" is deprecated."
 	config_get dns_wait "$section" dns_wait
 	export dns_wait
 	config_get webroot "$section" webroot
@@ -67,17 +52,6 @@
 	fi
 
 	config_get validation_method "$section" validation_method
-	# if validation_method isn't set then guess it
-	if [ -z "$validation_method" ]; then
-		if [ -n "$dns" ]; then
-			validation_method="dns"
-		elif [ "$standalone" = 1 ]; then
-			validation_method="standalone"
-		else
-			validation_method="webroot"
-		fi
-		log warn "Please set \"option validation_method $validation_method\"."
-	fi
 	export validation_method
 }
 
```


Additionally I noticed a strange place:
```sh
export main_domain
main_domain="$(first_arg $domains)"
```

It works correctly but confusing. So I changed it to:

```sh
main_domain="$(first_arg $domains)"
export main_domain
```
