### PR TITLE
wsdd2: fix compilation with GCC14 and 64-bit

### DIFF
--- a/net/wsdd2/Makefile
+++ b/net/wsdd2/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wsdd2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/Netgear/wsdd2.git

--- a/net/wsdd2/patches/010-gcc14.patch
+++ b/net/wsdd2/patches/010-gcc14.patch
@@ -1,0 +1,19 @@
+--- a/wsdd2.c
++++ b/wsdd2.c
+@@ -543,7 +543,15 @@ static int netlink_recv(struct endpoint
+ 	char buf[PAGE_SIZE];
+ 	struct sockaddr_nl sa;
+ 	struct iovec iov = { buf, sizeof buf };
+-	struct msghdr msg = { &sa, sizeof sa, &iov, 1, NULL, 0, 0 };
++	struct msghdr msg = {
++		.msg_name = &sa,
++		.msg_namelen = sizeof(sa),
++		.msg_iov = &iov,
++		.msg_iovlen = 1,
++		.msg_control = NULL,
++		.msg_controllen = 0,
++		.msg_flags = 0,
++	};
+ 	ssize_t msglen = recvmsg(ep->sock, &msg, 0);
+ 
+ 	DEBUG(2, W, "%s: %zd bytes", __func__, msglen);


### PR DESCRIPTION
struct msghdr under musl uses padding ints for 64-bit, which means we can't direct initialize like this. Switch to initializing each member explicitly.

Maintainer: 