### PR TITLE
nghttp2: update 1.62.1

### DIFF
--- a/libs/nghttp2/Makefile
+++ b/libs/nghttp2/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nghttp2
-PKG_VERSION:=1.61.0
+PKG_VERSION:=1.62.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/nghttp2/nghttp2/releases/download/v$(PKG_VERSION)
-PKG_HASH:=aa7594c846e56a22fbf3d6e260e472268808d3b49d5e0ed339f589e9cc9d484c
+PKG_HASH:=2345d4dc136fda28ce243e0bb21f2e7e8ef6293d62c799abbf6f633a6887af72
 
 PKG_MAINTAINER:=Hans Dedecker <dedeckeh@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @dedeckeh 
Run tested: WRT3200ACM, arm_cortex-a9_neon, GCC 14, LTO

Description:
- Switch source back to .xz according to CONTRIBUTING.md
