### PR TITLE
node: bump to v20.14.0

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v20.13.1
+PKG_VERSION:=v20.14.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=a85ee53aa0a5c2f5ca94fa414cdbceb91eb7d18a77fc498358512c14cc6c6991
+PKG_HASH:=f01109d3102754ac360fcf25aa588f3bef5c090a8eed3fb1d0be194149c46cf2
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi
Compile tested: head, aarch64, arm, i386, x86_64
Run tested: (qemu 9.0.0) aarch64

Description:
Update to v20.14.0

Notable Changes
* src,permission: throw async errors on async APIs (Rafael Gonzaga)
* (SEMVER-MINOR) test_runner: support forced exit (Colin Ihrig)
