### PR TITLE
[23.05] node: bump to v18.20.3

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v18.20.2
+PKG_VERSION:=v18.20.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=68c165b9ceb7bc69dcdc75c6099723edb5ff0509215959af0775ed426174c404
+PKG_HASH:=f35c9b9923c7b2e9243e7e2d10cd9ae61fbd5b925df3debbb72d5a70dbff555d
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi 
Compile tested: 23.05, aarch64, arm 
Run tested: (qemu 9.0.0) aarch64

Description:
Update to v18.20.3

Notable changes
This release fixes a regression introduced in Node.js 18.19.0 where http.server.close() was incorrectly closing idle connections. A fix has also been included for compiling Node.js from source with newer versions of Clang. The list of keys used to sign releases has been synchronized with the current list from the main branch.

Updated dependencies
* acorn updated to 8.11.3.
* acorn-walk updated to 8.3.2.
* ada updated to 2.7.8.
* c-ares updated to 1.28.1.
* corepack updated to 0.28.0.
* nghttp2 updated to 1.61.0.
* ngtcp2 updated to 1.3.0.
* npm updated to 10.7.0. Includes a fix from npm@10.5.1 to limit the number of open connections npm/cli#7324.
* simdutf updated to 5.2.4.
* zlib updated to 1.3.0.1-motley-7d77fb7.

