### PR TITLE
stress-ng: bump to version 0.17.08

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.17.07
+PKG_VERSION:=0.17.08
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ColinIanKing/stress-ng/tar.gz/refs/tags/V$(PKG_VERSION)?
-PKG_HASH:=b0bc1495adce6c7a1f82d53f363682b243d6d7e93a06be7f94c9559c0a311a6f
+PKG_HASH:=e4982d2a1c57139dad1741d6248b00a30935f746c1f665ec5b9d53c010c8dc08
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/5b1d6d4607e4a062319225dd8930541cd1974ebe
Run tested: x86 https://github.com/openwrt/openwrt/commit/5b1d6d4607e4a062319225dd8930541cd1974ebe
