### PR TITLE
prometheus-node-exporter-lua: fix netclass duplicate TYPE lines

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,8 +4,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2024.06.02
-PKG_RELEASE:=2
+PKG_VERSION:=2024.06.03
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Fixes a315c40b7232bbc83582685c98e41466d84d7a35

[initial fix]
Signed-off-by: René Treffer <treffer@measite.de>
[fixup René version]
Signed-off-by: PichetGoulu <pichet@nosuid.be>
[actual commit]
Signed-off-by: Etienne Champetier <champetier.etienne@gmail.com>

Maintainer: me

Fixes #19508 