### PR TITLE
Revert "ci: no longer require real name"

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -34,6 +34,14 @@ jobs:
               RET=1
             fi
 
+            author="$(git show -s --format=%aN $commit)"
+            if echo $author | grep -q '\S\+\s\+\S\+'; then
+              success "Author name ($author) seems ok"
+            else
+              err "Author name ($author) need to be your real name 'firstname lastname'"
+              RET=1
+            fi
+
             subject="$(git show -s --format=%s $commit)"
             if echo "$subject" | grep -q -e '^[0-9A-Za-z,+/_-]\+: ' -e '^Revert ' -e '^CONTRIBUTING.md' -e '^README.md'; then
               success "Commit subject line seems ok ($subject)"


### PR DESCRIPTION
It was decided that we should require to use real name once again. There was discussion about it on the mailing list [1], which was based on the commit in different OpenWrt repo [2]

This reverts commit 7e6cd98ad481184b1a620a9862aa3713d1ab85cc.

[1] https://lists.openwrt.org/pipermail/openwrt-devel/2024-April/042711.html
[2] https://github.com/openwrt/actions-shared-workflows/commit/12d9551f2d07ec34ac813da8612c8014fb393af6

Recent discussion about this was here: https://github.com/openwrt/packages/pull/23072#issuecomment-2018331887 and here: https://github.com/openwrt/packages/pull/23072#issuecomment-2018331887