### PR TITLE
prometheus-node-exporter-lua: remove duplicated nat samples

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2024.06.03
+PKG_VERSION:=2024.06.15
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/nat_traffic.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/nat_traffic.lua
@@ -1,7 +1,20 @@
 local function scrape()
   -- documetation about nf_conntrack:
   -- https://www.frozentux.net/iptables-tutorial/chunkyhtml/x1309.html
-  nat_metric =  metric("node_nat_traffic", "gauge" )
+
+  -- two dimesional table to sum bytes for the pair (src/dest)
+  local nat = {}
+  -- default constructor to init unknow pairs
+  setmetatable(nat, {
+    __index = function (t, addr)
+      t[addr] = {}
+      setmetatable(t[addr], {
+        __index = function () return 0 end
+      })
+      return t[addr]
+    end
+  })
+
   for e in io.lines("/proc/net/nf_conntrack") do
     -- output(string.format("%s\n",e  ))
     local fields = space_split(e)
@@ -22,9 +35,16 @@ local function scrape()
     -- local src, dest, bytes = string.match(natstat[i], "src=([^ ]+) dst=([^ ]+) .- bytes=([^ ]+)");
     -- local src, dest, bytes = string.match(natstat[i], "src=([^ ]+) dst=([^ ]+) sport=[^ ]+ dport=[^ ]+ packets=[^ ]+ bytes=([^ ]+)")
 
-    local labels = { src = src, dest = dest }
     -- output(string.format("src=|%s| dest=|%s| bytes=|%s|", src, dest, bytes  ))
-    nat_metric(labels, bytes )
+    nat[src][dest] = nat[src][dest] + bytes
+  end
+
+  nat_metric =  metric("node_nat_traffic", "gauge" )
+  for src, values in next, nat do
+    for dest, bytes in next, values do
+      local labels = { src = src, dest = dest }
+      nat_metric(labels, bytes )
+    end
   end
 end
 


### PR DESCRIPTION
Maintainer: @champtar 
Compile tested:  -
Run tested: `arm_cortex-a15_neon-vfpv4/ipq806x/generic/22.03.5 r20134-5f15225c1e`

Fixes duplicates samples for NAT gauge

Fixes #24166

_Disclaimer: this is my first time writing Lua._

I've patched my device manually and will monitor the behaviour during the next few hours. 
