### PR TITLE
libdaq3: update to 3.0.15

### DIFF
--- a/libs/libdaq3/Makefile
+++ b/libs/libdaq3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdaq3
-PKG_VERSION:=3.0.14
+PKG_VERSION:=3.0.15
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -18,7 +18,7 @@ PKG_LICENSE_FILES:=COPYING LICENSE
 
 PKG_SOURCE:=libdaq-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/snort3/libdaq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=521364d69f8b764281ce39924d2e4c4c43348c7679768c41246adea9c7a31cc3
+PKG_HASH:=174c639d59f7bda84d71bda50257febbb2646138aa7bbf948bb4d4a8be60f2d8
 PKG_BUILD_DIR:=$(BUILD_DIR)/libdaq-$(PKG_VERSION)
 
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Update to latest version.

Changelog: https://github.com/snort3/libdaq/releases/tag/v3.0.15
```
   ,,_     -*> Snort++ <*-
  o"  )~   Version 3.1.84.0
   ''''    By Martin Roesch & The Snort Team
           http://snort.org/contact#team
           Copyright (C) 2014-2024 Cisco and/or its affiliates. All rights reserved.
           Copyright (C) 1998-2013 Sourcefire, Inc., et al.
           Using DAQ version 3.0.15
           Using LuaJIT version 2.1.0-beta3
           Using OpenSSL 3.0.13 30 Jan 2024
           Using libpcap version 1.10.4 (with TPACKET_V3)
           Using PCRE version 10.42 2022-12-11
           Using ZLIB version 1.3.1
           Using Hyperscan version 5.4.2 2024-05-26
           Using LZMA version 5.4.6
```
Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne

Maintainer: @flyn-org