### PR TITLE
php8: update to 8.3.8

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.3.7
+PKG_VERSION:=8.3.8
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.php.net/distributions/
-PKG_HASH:=d53433c1ca6b2c8741afa7c524272e6806c1e895e5912a058494fea89988570a
+PKG_HASH:=aea358b56186f943c2bbd350c9005b9359133d47e954cfc561385319ae5bb8d7
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16

--- a/lang/php8/patches/0025-php-5.4.9-fixheader.patch
+++ b/lang/php8/patches/0025-php-5.4.9-fixheader.patch
@@ -9,7 +9,7 @@ Make generated php_config.h constant across rebuilds.
 
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1490,7 +1490,7 @@ PHP_REMOVE_USR_LIB(LDFLAGS)
+@@ -1493,7 +1493,7 @@ PHP_REMOVE_USR_LIB(LDFLAGS)
  EXTRA_LDFLAGS="$EXTRA_LDFLAGS $PHP_LDFLAGS"
  EXTRA_LDFLAGS_PROGRAM="$EXTRA_LDFLAGS_PROGRAM $PHP_LDFLAGS"
  

--- a/lang/php8/patches/1004-disable-phar-command.patch
+++ b/lang/php8/patches/1004-disable-phar-command.patch
@@ -11,7 +11,7 @@
  
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1686,13 +1686,13 @@ CFLAGS_CLEAN="$CFLAGS \$(PROF_FLAGS)"
+@@ -1689,13 +1689,13 @@ CFLAGS_CLEAN="$CFLAGS \$(PROF_FLAGS)"
  CFLAGS="\$(CFLAGS_CLEAN) $standard_libtool_flag"
  CXXFLAGS="$CXXFLAGS $standard_libtool_flag \$(PROF_FLAGS)"
  


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs, bcm27xx
Run tested: Raspberry Pi

Description:

This fixes:
    - CVE-2024-4577
    - CVE-2024-5458
    - CVE-2024-5585

Changelog: https://www.php.net/ChangeLog-8.php#8.3.8
