### PR TITLE
[23.05] php8: update to 8.2.20

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.2.18
+PKG_VERSION:=8.2.20
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.php.net/distributions/
-PKG_HASH:=44b306fc021e56441f691da6c3108788bd9e450f293b3bc70fcd64b08dd41a50
+PKG_HASH:=4474cc430febef6de7be958f2c37253e5524d5c5331a7e1765cd2d2234881e50
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16

--- a/lang/php8/patches/0025-php-5.4.9-fixheader.patch
+++ b/lang/php8/patches/0025-php-5.4.9-fixheader.patch
@@ -9,7 +9,7 @@ Make generated php_config.h constant across rebuilds.
 
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1451,7 +1451,7 @@ PHP_REMOVE_USR_LIB(LDFLAGS)
+@@ -1454,7 +1454,7 @@ PHP_REMOVE_USR_LIB(LDFLAGS)
  EXTRA_LDFLAGS="$EXTRA_LDFLAGS $PHP_LDFLAGS"
  EXTRA_LDFLAGS_PROGRAM="$EXTRA_LDFLAGS_PROGRAM $PHP_LDFLAGS"
  

--- a/lang/php8/patches/1004-disable-phar-command.patch
+++ b/lang/php8/patches/1004-disable-phar-command.patch
@@ -11,7 +11,7 @@
  
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1647,13 +1647,13 @@ CFLAGS_CLEAN="$CFLAGS \$(PROF_FLAGS)"
+@@ -1650,13 +1650,13 @@ CFLAGS_CLEAN="$CFLAGS \$(PROF_FLAGS)"
  CFLAGS="\$(CFLAGS_CLEAN) $standard_libtool_flag"
  CXXFLAGS="$CXXFLAGS $standard_libtool_flag \$(PROF_FLAGS)"
  


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs (Duckbill)

Description:

This fixes:
    - CVE-2024-4577
    - CVE-2024-5458
    - CVE-2024-5585

Changelog: https://www.php.net/ChangeLog-8.php#8.2.20
