### PR TITLE
iperf3: fix usage with big endian

### DIFF
--- a/net/iperf3/Makefile
+++ b/net/iperf3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
 PKG_VERSION:=3.17.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.es.net/pub/iperf

--- a/net/iperf3/patches/010-y2k.patch
+++ b/net/iperf3/patches/010-y2k.patch
@@ -1,0 +1,21 @@
+From 4c7629f590bb18855e478a826833adb05d2a128b Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sat, 8 Jun 2024 15:35:47 -0700
+Subject: [PATCH] fix -Wformat-y2k error
+
+%c potentially prints a 2 digit year. Just use a normal format.
+---
+ src/iperf_error.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/iperf_error.c
++++ b/src/iperf_error.c
+@@ -99,7 +99,7 @@ iperf_errexit(struct iperf_test *test, c
+     if (test != NULL && test->timestamps) {
+ 	time(&now);
+ 	ltm = localtime(&now);
+-	strftime(iperf_timestrerr, sizeof(iperf_timestrerr), "%c ", ltm);
++	strftime(iperf_timestrerr, sizeof(iperf_timestrerr), "%Y-%m-%d %H:%M:%S", ltm);
+ 	ct = iperf_timestrerr;
+     }
+ 

--- a/net/iperf3/patches/020-big-endian.patch
+++ b/net/iperf3/patches/020-big-endian.patch
@@ -1,0 +1,21 @@
+From fe09305eb6f907e4eb637b8edd0c8a986187d1dd Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sat, 8 Jun 2024 15:23:51 -0700
+Subject: [PATCH] fix crash under big endian musl
+
+iperf_printf is using an int format here but an int64_t variable. The format only needs the first 3 digits. Cast to int to fix it.
+---
+ src/iperf_api.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/iperf_api.c
++++ b/src/iperf_api.c
+@@ -4056,7 +4056,7 @@ iperf_print_results(struct iperf_test *t
+                                 iperf_printf(test, report_sender_not_available_summary_format, "SUM");
+                         }
+                         else {
+-                          iperf_printf(test, report_sum_bw_retrans_format, mbuf, start_time, sender_time, ubuf, nbuf, total_retransmits, report_sender);
++                          iperf_printf(test, report_sum_bw_retrans_format, mbuf, start_time, sender_time, ubuf, nbuf, (int)total_retransmits, report_sender);
+                         }
+                 } else {
+                     /* Summary sum, TCP without retransmits. */


### PR DESCRIPTION
Upstream submissions.

Maintainer: @nbd168 