### PR TITLE
sing-box: update to 1.9.2

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.9.1
+PKG_VERSION:=1.9.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=ba5c0773dfed932c60c449a910d76d3157648e920defd75a8ccf24c20be50bb4
+PKG_HASH:=c187867e7dc42dc5913acc791cfff209126b6bfccf658106a97d78ea4b4bee2c
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @brvphoenix
Compile tested: armv8, snapshot/23.05
Run tested: armv8, snapshot/23.05

Description:
sing-box: update to 1.9.2