### PR TITLE
sing-box: update to 1.9.3

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.9.2
+PKG_VERSION:=1.9.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c187867e7dc42dc5913acc791cfff209126b6bfccf658106a97d78ea4b4bee2c
+PKG_HASH:=ab3d321860f973151e773c0c4a1478ab31ed63d89e17c7ac618cf50b232dd1c4
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @brvphoenix
Compile tested: armv8, snapshot/23.05
Run tested: armv8, snapshot/23.05

Description:
sing-box: update to 1.9.3