### PR TITLE
php8: workaround libgd capability detection (refs #23846)

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=8.3.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=PHP-3.01

--- a/lang/php8/patches/1020_workaround-external-libgd-feature-detection.patch
+++ b/lang/php8/patches/1020_workaround-external-libgd-feature-detection.patch
@@ -1,0 +1,45 @@
+--- a/ext/gd/config.m4
++++ b/ext/gd/config.m4
+@@ -152,7 +152,7 @@ AC_DEFUN([PHP_GD_CHECK_FORMAT],[
+   LIBS="${LIBS} ${GD_SHARED_LIBADD}"
+   old_CFLAGS="${CFLAGS}"
+   CFLAGS="${CFLAGS} ${GDLIB_CFLAGS}"
+-  AC_MSG_CHECKING([for working gdImageCreateFrom$1 in libgd])
++  AC_MSG_CHECKING([for gdImageCreateFrom$1 in libgd (OpenWrt build config based)])
+   AC_LANG_PUSH([C])
+   AC_RUN_IFELSE([AC_LANG_SOURCE([
+ #include <stdio.h>
+@@ -179,7 +179,10 @@ int main(int argc, char** argv) {
+   ],[
+     AC_MSG_RESULT([no])
+   ],[
+-    AC_MSG_RESULT([no])
++    AC_MSG_RESULT([$3])
++    m4_if([$3],[yes],[
++      AC_DEFINE($2, 1, [Does gdImageCreateFrom$1 work?])
++    ])
+   ])
+   AC_LANG_POP([C])
+   CFLAGS="${old_CFLAGS}"
+@@ -187,13 +190,14 @@ int main(int argc, char** argv) {
+ ])
+ 
+ AC_DEFUN([PHP_GD_CHECK_VERSION],[
+-  PHP_GD_CHECK_FORMAT([Png],  [HAVE_GD_PNG])
+-  PHP_GD_CHECK_FORMAT([Avif], [HAVE_GD_AVIF])
+-  PHP_GD_CHECK_FORMAT([Webp], [HAVE_GD_WEBP])
+-  PHP_GD_CHECK_FORMAT([Jpeg], [HAVE_GD_JPG])
+-  PHP_GD_CHECK_FORMAT([Xpm],  [HAVE_GD_XPM])
+-  PHP_GD_CHECK_FORMAT([Bmp],  [HAVE_GD_BMP])
+-  PHP_GD_CHECK_FORMAT([Tga],  [HAVE_GD_TGA])
++  dnl The 3rd parameter is OpenWrt specific default derived from libgd build
++  PHP_GD_CHECK_FORMAT([Png],  [HAVE_GD_PNG],  [yes])
++  PHP_GD_CHECK_FORMAT([Avif], [HAVE_GD_AVIF], [no])
++  PHP_GD_CHECK_FORMAT([Webp], [HAVE_GD_WEBP], [yes])
++  PHP_GD_CHECK_FORMAT([Jpeg], [HAVE_GD_JPG],  [yes])
++  PHP_GD_CHECK_FORMAT([Xpm],  [HAVE_GD_XPM],  [no])
++  PHP_GD_CHECK_FORMAT([Bmp],  [HAVE_GD_BMP],  [no])
++  PHP_GD_CHECK_FORMAT([Tga],  [HAVE_GD_TGA],  [no])
+   PHP_CHECK_LIBRARY(gd, gdFontCacheShutdown,           [AC_DEFINE(HAVE_GD_FREETYPE,          1, [ ])], [], [ $GD_SHARED_LIBADD ])
+   PHP_CHECK_LIBRARY(gd, gdVersionString,               [AC_DEFINE(HAVE_GD_LIBVERSION,        1, [ ])], [], [ $GD_SHARED_LIBADD ])
+   PHP_CHECK_LIBRARY(gd, gdImageGetInterpolationMethod, [AC_DEFINE(HAVE_GD_GET_INTERPOLATION, 1, [ ])], [], [ $GD_SHARED_LIBADD ])


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs, bcm27xx
Run tested: Raspberry Pi

Description:
This is an alternative approach to #24209. Instead of switching to bundled/internal libgd, workaround the capability detection by giving the information to the build system directly.

PHP's original approach does not work when cross-compiling, but since it is known which features are enabled in OpenWrt's build, we can directly enable these features here, too.

This is not that future prove, but should do the job for the moment until a proper solution was discussed with upstream.
