### PR TITLE
modemmanager: improve reconnect handling

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.22.0
-PKG_RELEASE:=13
+PKG_RELEASE:=14
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.22.0
-PKG_RELEASE:=14
+PKG_RELEASE:=15
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/README.md
+++ b/net/modemmanager/README.md
@@ -26,6 +26,7 @@ Once installed, you can configure the 2G/3G/4G modem connections directly in
         option lowpower    '1'
         option signalrate  '30'
         option allow_roaming '1'
+        option force_connection '1'
         option init_epsbearer '<none|default|custom>'
 
 Only 'device' and 'proto' are mandatory options, the remaining ones are all
@@ -43,6 +44,10 @@ The 'plmn' option allows to set the network operator MCCMNC.
 
 The 'signalrate' option set's the signal refresh rate (in seconds) for the device.
 You can call signal info with command: mmcli -m 0 --signal-get
+
+The 'force_connection' option is designed to ensure that the modem automatically
+attempts to reconnect regardless of any errors encountered during the
+connection process.
 
 If there is no Circuit switch network available, then an initial EPS
 bearer must be set, so this could be used during the network registration

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -274,6 +274,7 @@ proto_modemmanager_init_config() {
 	proto_config_add_int signalrate
 	proto_config_add_boolean lowpower
 	proto_config_add_boolean allow_roaming
+	proto_config_add_boolean force_connection
 	proto_config_add_string init_epsbearer
 	proto_config_add_string init_iptype
 	proto_config_add_string 'init_allowedauth:list(string)'
@@ -421,6 +422,7 @@ proto_modemmanager_setup() {
 
 	local device apn allowedauth username password pincode
 	local iptype plmn metric signalrate allow_roaming
+	local force_connection
 
 	local init_epsbearer
 	local init_iptype init_allowedauth
@@ -430,7 +432,7 @@ proto_modemmanager_setup() {
 
 	json_get_vars device apn allowedauth username password
 	json_get_vars pincode iptype plmn metric signalrate allow_roaming
-	json_get_vars allowedmode preferredmode
+	json_get_vars allowedmode preferredmode force_connection
 
 	json_get_vars init_epsbearer
 	json_get_vars init_iptype init_allowedauth
@@ -471,8 +473,14 @@ proto_modemmanager_setup() {
 		mmcli --modem="${device}" \
 			--timeout 120 \
 			--3gpp-register-in-operator="${plmn}" || {
-			proto_notify_error "${interface}" MM_3GPP_OPERATOR_REGISTRATION_FAILED
-			proto_block_restart "${interface}"
+
+			if [ -n "${force_connection}" ] && [ "${force_connection}" -eq 1 ]; then
+				echo "3GPP operator registration failed -> attempting restart"
+				proto_notify_error "${interface}" MM_INTERFACE_RESTART
+			else
+				proto_notify_error "${interface}" MM_3GPP_OPERATOR_REGISTRATION_FAILED
+				proto_block_restart "${interface}"
+			fi
 			return 1
 		}
 	}
@@ -574,8 +582,13 @@ proto_modemmanager_setup() {
 	append_param "${password:+password=${password}}"
 
 	mmcli --modem="${device}" --timeout 120 --simple-connect="${connectargs}" || {
-		proto_notify_error "${interface}" MM_CONNECT_FAILED
-		proto_block_restart "${interface}"
+		if [ -n "${force_connection}" ] && [ "${force_connection}" -eq 1 ]; then
+			echo "Connection failed -> attempting restart"
+			proto_notify_error "${interface}" MM_INTERFACE_RESTART
+		else
+			proto_notify_error "${interface}" MM_CONNECT_FAILED
+			proto_block_restart "${interface}"
+		fi
 		return 1
 	}
 

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -557,7 +557,6 @@ proto_modemmanager_setup() {
 
 	# setup connect args; APN mandatory (even if it may be empty)
 	echo "starting connection with apn '${apn}'..."
-	proto_notify_error "${interface}" MM_CONNECT_IN_PROGRESS
 
 	# setup allow-roaming parameter
 	if [ -n "${allow_roaming}" ] && [ "${allow_roaming}" -eq 0 ];then


### PR DESCRIPTION
Maintainer: @feckert  / @aleksander0m
Compile tested: not needed only script changes
Run tested: lantiq_xrx200

Description:
Currently, the proto handler stops if a connection cannot be established during setup. There are scenarios where the user does not want the connection to be re-established (for example, with an incorrect username/password). On the other hand, there are also scenarios where the user wants the connection to be established at all costs. For this, I have added a new option that covers such scenarios.