### PR TITLE
qbee-agent: new package qbee-agent 2024.23

### DIFF
--- a/admin/qbee-agent/Makefile
+++ b/admin/qbee-agent/Makefile
@@ -1,0 +1,53 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=qbee-agent
+PKG_VERSION:=2024.23
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/qbee-io/qbee-agent.git
+PKG_SOURCE_VERSION:=3219c17730eab4c80598494732b4bed4c4c18b51
+PKG_MIRROR_HASH:=ab109061103afdbefb1b6e1c4c38050f6dcd726c0a326cfecce1eac4e217b950
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jon Henrik Bjørnstad <jonhenrik@qbee.io>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_FLAGS:=no-mips16
+PKG_BUILD_PARALLEL:=1
+
+GO_PKG:=go.qbee.io/agent
+GO_PKG_LDFLAGS_X:= \
+	$(GO_PKG)/app.Version=$(PKG_VERSION) \
+	$(GO_PKG)/app.Commit=$(PKG_SOURCE_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/qbee-agent
+  SECTION:=admin
+  CATEGORY:=Administration
+  TITLE:=qbee.io fleet management agent
+  URL:=https://qbee.io
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/qbee-agent/description
+  qbee.io is a SaaS provided fleet management solution. This package
+  provides the agent that runs on the device and communicates with
+  the qbee.io server.
+endef
+
+define Package/qbee-agent/install
+	$(INSTALL_DIR) $(1)/etc/qbee/ppkeys
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/package/share/ssl/ca.cert $(1)/etc/qbee/ppkeys/ca.cert
+
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/agent $(1)/usr/bin/qbee-agent
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/qbee-agent.init $(1)/etc/init.d/qbee-agent
+endef
+
+$(eval $(call BuildPackage,qbee-agent))

--- a/admin/qbee-agent/files/qbee-agent.init
+++ b/admin/qbee-agent/files/qbee-agent.init
@@ -1,0 +1,23 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=11
+USE_PROCD=1
+
+ARGS="start"
+
+start_service() {
+	if [ ! -f /etc/qbee/qbee-agent.json ]; then
+		echo "Device seems to not have been bootstrapped. Please run 'qbee-agent bootstrap -k <bootstrap-key>' as root to bootstrap."
+		return 0
+	fi
+
+	procd_open_instance qbee-agent
+	procd_set_param command /usr/bin/qbee-agent $ARGS
+	procd_set_param respawn 3600 60 0
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param pidfile /var/run/qbee-agent.pid
+	procd_set_param term_timeout 600
+	procd_close_instance
+}


### PR DESCRIPTION
Maintainer: @jonhenrik13
Compile tested: mipsel_24kc, x86_64, mips_24kc
Run tested: mipsel_24kc, x86_64, mips_24kc

Description:
qbee-agent is the fleet management agent from qbee.io released under Apache-2.0 license. It provides configuration management capabilities, inventory information, remote access, metrics and more. In version 2024.23 it also has support for the opkg package manager.