### PR TITLE
eza: update to 0.18.18

### DIFF
--- a/utils/eza/Makefile
+++ b/utils/eza/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=eza
-PKG_VERSION:=0.18.15
+PKG_VERSION:=0.18.18
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eza-community/eza/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=53c6ea67804dbaa330918f6ce62a1cff866a145b2395c606903c0d128dd8564f
+PKG_HASH:=437ea76838fea2464b9592f1adef7df0412e27c9fc2a3e7ff47efcdfb17457f5
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
release notes:
0.18.16: https://github.com/eza-community/eza/releases/tag/v0.18.16
0.18.17: https://github.com/eza-community/eza/releases/tag/v0.18.17
0.18.18: https://github.com/eza-community/eza/releases/tag/v0.18.18

Maintainer: me
Compile tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt snapshot
Run tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt snapshot
