### PR TITLE
libfido2: fix license info in Makefile

### DIFF
--- a/libs/libfido2/Makefile
+++ b/libs/libfido2/Makefile
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=https://codeload.github.com/Yubico/libfido2/tar.gz/$(PKG_VERSION
 PKG_HASH:=3601792e320032d428002c4cce8499a4c7b803319051a25a0c9f1f138ffee45a
 
 PKG_MAINTAINER:=Linos Giannopoulos <linosgian00+openwrt@gmail.com>
-PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING
 
 PKG_FORTIFY_SOURCE:=0


### PR DESCRIPTION
Maintainer: @linosgian 
Compile tested: NA
Run tested: NA

Description: libfido2 is licensed under the BSD 2-clause license as per: https://github.com/Yubico/libfido2/
Update package Makefile to correctly reflect this.