### PR TITLE
[23.05] ruby: update to 3.2.4

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,15 +11,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=3.2.2
-PKG_RELEASE:=2
+PKG_VERSION:=3.2.4
+PKG_RELEASE:=1
 
 # First two numbes
 PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VERSION))))
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=4b352d0f7ec384e332e3e44cdbfdcd5ff2d594af3c8296b5636c710975149e23
+PKG_HASH:=e7f1653d653232ec433472489a91afbc7433c9f760cc822defe7437c9d95791b
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
The 3.2.3 release includes many bug-fixes. This release also includes the update of uri.gem to 0.12.2 which contains the security fix.

- CVE-2023-36617: ReDoS vulnerability in URI

See: https://www.ruby-lang.org/en/news/2024/01/18/ruby-3-2-3-released/

The 3.2.4 release includes security fixes. Please check the topics below for details.

- CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search
- CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc
- CVE-2024-27280: Buffer overread vulnerability in StringIO

See: https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-2-4-released/

Maintainer: me
Compile tested: x86
Run tested: none

Description:
