### PR TITLE
libvpx: update to 1.14.1

### DIFF
--- a/libs/libvpx/Makefile
+++ b/libs/libvpx/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libvpx
-PKG_VERSION:=1.14.0
+PKG_VERSION:=1.14.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://chromium.googlesource.com/webm/libvpx
-PKG_MIRROR_HASH:=00c35f3101a55ac8f899174bacc27bb45fabfc2dd47ccfaa69eaab65d88e89cd
+PKG_MIRROR_HASH:=a9737eadde24611fbbf080f28c792d804ea0970dadbc9421b427e18bb8f14820
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>


### PR DESCRIPTION
This release includes enhancements and bug fixes.
This release is ABI compatible with the previous release.

See: https://github.com/webmproject/libvpx/releases/tag/v1.14.1

Maintainer: me
Compile tested: ath79
Run tested: none

Description:
