### PR TITLE
knxd: bump to new release 0.14.62

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -11,12 +11,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
-PKG_VERSION:=0.14.61
+PKG_VERSION:=0.14.62
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/knxd/knxd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=b5284c89a55a2c53e0ff769ec4f736fc1ad4b55afdd2a18b9258fa95f708d798
+PKG_HASH:=4941cf1260fc6017ded74816f1312283801cccd277124a59b3176e112c72c4f5
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/knxd/patches/0100-version.patch
+++ b/net/knxd/patches/0100-version.patch
@@ -7,4 +7,4 @@
 -test -d .git || exit
 -# git describe --tags
 -git log --format=format:%D | perl -ne 'next unless s#.*tag: ##; s#,.*##; next if m#/#; print; exit;'
-+echo -n "0.14.61"
++echo -n "0.14.62"


### PR DESCRIPTION
Maintainer: me
Compile tested: mpc85xx, tl-wdr4900-v1, trunk
Compile tested: ath79, tplink_archer-c7-v4, trunk
Compile tested: ramips, mt7620a, trunk
Run tested: ath79, tp-link Archer C7 v4, trunk, compiled with knxd package

Description:
new upstream release 0.14.62
