### PR TITLE
xray-core: update to 1.8.15

### DIFF
--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-core
-PKG_VERSION:=1.8.13
+PKG_VERSION:=1.8.15
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/XTLS/Xray-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=9e63fbeb4667c19e286389c370d30e9e904f4421784adcbe6cf4d6e172a2ac29
+PKG_HASH:=4e0ac5170668033fd55544688a1d56938de91bc00c5ebc7d8c5211fd97cbca65
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MPL-2.0


### PR DESCRIPTION
Maintainer: @1715173329
Compile tested: armv8, snapshot/23.05
Run tested: armv8, snapshot/23.05

Description:
xray-core: Update to 1.8.15
For more information, visit https://github.com/XTLS/Xray-core/compare/v1.8.13...v1.8.15
