### PR TITLE
dnslookup: update to 1.11.0

### DIFF
--- a/net/dnslookup/Makefile
+++ b/net/dnslookup/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnslookup
-PKG_VERSION:=1.10.1
+PKG_VERSION:=1.11.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ameshkov/dnslookup/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=f7b6ffb70136210ee321dee3e30a4c2b97958f7286cc7f0979aab3d8ed8ea723
+PKG_HASH:=c9464093b76ba593fae3629ae54f5738251de48d8fc3bbdc08a9d6644416dfa0
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @1715173329
Compile tested: armv8, snapshot/23.05
Run tested: armv8, snapshot/23.05

Description:
dnslookup: update to 1.11.0
For more information, visit https://github.com/ameshkov/dnslookup/compare/v1.10.1...v1.11.0