### PR TITLE
frr: link zlib in host build

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -164,6 +164,9 @@ HOST_CPPFLAGS += -I$(STAGING_DIR_HOST)/include/libelf
 HOST_CONFIGURE_ARGS+= \
 	--enable-clippy-only
 
+HOST_MAKE_FLAGS = \
+        LIBS+='-lz'
+
 define Host/Install
 	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/bin
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/lib/clippy $(STAGING_DIR_HOSTPKG)/bin/


### PR DESCRIPTION
(refer to openwrt/openwrt#15690)

Due to changes in elfutils in order to
simplify the build for static libraries only,
the zlib functions that libelf depends on
are no longer linked within the static libelf library.

If frr were to use pkg-config, no change would be necessary,
however, the AC_CHECK_LIB macro is used, so add the link manually.

Maintainer: @lucize 
Compile tested: host build
Run tested: no
