### PR TITLE
keyutils: Package into the right directories

### DIFF
--- a/libs/keyutils/Makefile
+++ b/libs/keyutils/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keyutils
 PKG_VERSION:=1.6.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git/snapshot/
@@ -54,14 +54,15 @@ define Package/keyutils/description
 endef
 
 MAKE_FLAGS += \
-	BINDIR=/usr/bin \
+	BINDIR=/bin \
 	LIBDIR=/usr/lib \
-	SBINDIR=/usr/sbin \
+	SBINDIR=/sbin \
 	CFLAGS="$(TARGET_CFLAGS) $(FPIC)"
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+
 	$(INSTALL_DIR) $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libkeyutils.a $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libkeyutils.so.$(ABI_VERSION)* $(1)/usr/lib/
@@ -73,15 +74,17 @@ define Package/libkeyutils/install
 endef
 
 define Package/keyutils/install
-	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/keyutils $(1)/etc/request-key.d
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/request-key $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/key.dns_resolver $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/sbin/request-key $(1)/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/sbin/key.dns_resolver $(1)/sbin/
+
+	$(INSTALL_DIR) $(1)/etc/keyutils $(1)/etc/request-key.d
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/request-key.conf $(1)/etc/
 endef
 
 define Package/keyctl/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/keyctl $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/keyctl $(1)/bin
 endef
 
 $(eval $(call BuildPackage,libkeyutils))


### PR DESCRIPTION
Maintainer: @dangowrt / @neheb
Compile tested: x86-generic OpenWRT 7ccd7dac7e
Run tested: as above
Description:

The kernel knows about /sbin/request-key *at that path*, and the shipped configuration file presumes that /sbin/key.dns_resolver and /bin/keyctl are the correct paths.