### PR TITLE
[23.05]dnslookup: update to 1.11.0

### DIFF
--- a/net/dnslookup/Makefile
+++ b/net/dnslookup/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnslookup
-PKG_VERSION:=1.10.1
+PKG_VERSION:=1.11.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ameshkov/dnslookup/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=f7b6ffb70136210ee321dee3e30a4c2b97958f7286cc7f0979aab3d8ed8ea723
+PKG_HASH:=c9464093b76ba593fae3629ae54f5738251de48d8fc3bbdc08a9d6644416dfa0
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT

--- a/net/dnslookup/Makefile
+++ b/net/dnslookup/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnslookup
-PKG_VERSION:=1.10.0
+PKG_VERSION:=1.10.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ameshkov/dnslookup/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6001fa5b54ba3a1b29f68eed4d12b026a1b716b1578342621f398fd4d569d199
+PKG_HASH:=f7b6ffb70136210ee321dee3e30a4c2b97958f7286cc7f0979aab3d8ed8ea723
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT

--- a/net/dnslookup/Makefile
+++ b/net/dnslookup/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnslookup
-PKG_VERSION:=1.9.2
+PKG_VERSION:=1.10.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ameshkov/dnslookup/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=0f9b19f57c0d2fbae03e6ba2f652af017e3ceb8f8ed2a3efb3f983e48bc304fe
+PKG_HASH:=6001fa5b54ba3a1b29f68eed4d12b026a1b716b1578342621f398fd4d569d199
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @1715173329
Compile tested: armv8, snapshot/23.05
Run tested: armv8, snapshot/23.05

Description:
dnslookup: Update to 1.10.0
(cherry picked from commit https://github.com/openwrt/packages/commit/eb711e2eb2ab896018751bf3c7a66cbff6a43317)
dnslookup: Update to 1.10.1(cherry picked from commit https://github.com/openwrt/packages/commit/5ba2fed3582ae318a083c2bf3971aaeec288664b)
dnslookup: Update to 1.11.0(cherry picked from commit https://github.com/openwrt/packages/commit/0764fe31f8c18ded48d9644ffa0978b1be0913a5)

For more information, visit https://github.com/ameshkov/dnslookup/compare/v1.9.2...v1.11.0