### PR TITLE
natmap: reset PKG_RELEASE to 1

### DIFF
--- a/net/natmap/Makefile
+++ b/net/natmap/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=natmap
 PKG_VERSION:=20240603
-PKG_RELEASE:=3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/heiher/natmap/releases/download/$(PKG_VERSION)


### PR DESCRIPTION
Maintainer: @ysc3839,@heiher
Compile tested: N/A
Run tested: N/A

Description:
Fix the issue of not resetting PKG_RELEASE to 1 in https://github.com/openwrt/packages/pull/24318
Sorry for this oversight.