### PR TITLE
openvpn: update to 2.6.11

### DIFF
--- a/net/openvpn/Config-wolfssl.in
+++ b/net/openvpn/Config-wolfssl.in
@@ -45,6 +45,7 @@ config OPENVPN_wolfssl_ENABLE_DCO
 	depends on !OPENVPN_wolfssl_ENABLE_IPROUTE2
 	bool "Enable support for data channel offload"
 	default n if OPENVPN_openssl_ENABLE_IPROUTE2
+	select WOLFSSL_HAS_OPENVPN
 	help
 	  enable data channel offload support
 	  using the ovpn-dco-v2 kernel module

--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.6.10
+PKG_VERSION:=2.6.11
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=1993bbb7b9edb430626eaa24573f881fd3df642f427fcb824b1aed1fca1bcc9b
+PKG_HASH:=d60adf413d37e11e6e63531cacf2655906756046b4edffe88a13b9e2fec40d5e
 
 PKG_MAINTAINER:=
 

--- a/net/openvpn/patches/100-mbedtls-disable-runtime-version-check.patch
+++ b/net/openvpn/patches/100-mbedtls-disable-runtime-version-check.patch
@@ -6,6 +6,6 @@
      static char mbedtls_version[30];
 -    unsigned int pv = mbedtls_version_get_number();
 +    unsigned int pv = MBEDTLS_VERSION_NUMBER;
-     sprintf( mbedtls_version, "mbed TLS %d.%d.%d",
+     snprintf(mbedtls_version, sizeof(mbedtls_version), "mbed TLS %d.%d.%d",
               (pv>>24)&0xff, (pv>>16)&0xff, (pv>>8)&0xff );
      return mbedtls_version;

--- a/net/openvpn/patches/101-Fix-EVP_PKEY_CTX_-compilation-with-wolfSSL.patch
+++ b/net/openvpn/patches/101-Fix-EVP_PKEY_CTX_-compilation-with-wolfSSL.patch
@@ -9,7 +9,7 @@
  #include <openssl/kdf.h>
  #endif
  #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-@@ -1374,7 +1374,7 @@ memcmp_constant_time(const void *a, cons
+@@ -1398,7 +1398,7 @@ memcmp_constant_time(const void *a, cons
      return CRYPTO_memcmp(a, b, size);
  }
  


### PR DESCRIPTION
Maintainer: @neheb @AuthorReflex
Compile tested: ramips/mt7621, ramips/mt7620, ramips/mt76x8
Run tested: Xiaomi Mi Router 3 Pro, Xiaomi Mi Router R3, Asus RT-AC1200

Description:
This is a bugfix release containing several security fixes.

Security fixes
--------------
 - CVE-2024-4877: Windows: harden interactive service pipe. Security scope: a malicious process with "some" elevated privileges could open the pipe a second time, tricking openvn GUI into providing user credentials (tokens),  getting full access to the account openvpn-gui.exe runs as.

 - CVE-2024-5594: control channel: refuse control channel messages with nonprintable characters in them. Security scope: a malicious openvpn peer can send garbage to openvpn log, or cause high CPU load.

 - CVE-2024-28882: only call schedule_exit() once (on a given peer). Security scope: an authenticated client can make the server "keep the session" even when the server has been told to disconnect this client

Bug fixes
---------
 - fix connect timeout when using SOCKS proxies

 - work around LibreSSL crashing on OpenBSD 7.5 when enumerating ciphers

 - Add bracket in fingerprint message and do not warn about missing verification

For details refer to https://github.com/OpenVPN/openvpn/blob/v2.6.11/Changes.rst