### PR TITLE
strongswan: comma separated list for {left,right}subnet

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.14
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/ipsec.init
+++ b/net/strongswan/files/ipsec.init
@@ -146,7 +146,7 @@ config_conn() {
 	ipsec_xappend "  right=$remote_gateway"
 
 	[ -n "$local_sourceip" ] && ipsec_xappend "  leftsourceip=$local_sourceip"
-	[ -n "$local_subnet" ] && ipsec_xappend "  leftsubnet=$local_subnet"
+	[ -n "$local_subnet" ] && ipsec_xappend "  leftsubnet=${local_subnet// /,}"
 
 	[ -n "$local_firewall" ] && ipsec_xappend "  leftfirewall=$local_firewall"
 	[ -n "$remote_firewall" ] && ipsec_xappend "  rightfirewall=$remote_firewall"
@@ -166,7 +166,7 @@ config_conn() {
 		ipsec_xappend "  rightauth=psk"
 
 		[ "$remote_sourceip" != "" ] && ipsec_xappend "  rightsourceip=$remote_sourceip"
-		[ "$remote_subnet" != "" ] && ipsec_xappend "  rightsubnet=$remote_subnet"
+		[ "$remote_subnet" != "" ] && ipsec_xappend "  rightsubnet=${remote_subnet// /,}"
 
 		ipsec_xappend "  auto=$mode"
 	else


### PR DESCRIPTION
Maintainer: Stephen Baker / @prmam
Run tested: Intel(R) Xeon(R) CPU E5-2630 v3 @ 2.40GHz, QEMU Standard PC (Q35 + ICH9, 2009), OpenWrt 23.05.2 r23630-842932a63d / LuCI openwrt-23.05 branch git-24.086.45142-09d5a38

Description:
Translate local_subnet and remote_subnet in /etc/config/ipsec into a comma separated list for leftsubnet and rightsubnet in /var/ipsec/ipsec.conf

Resolves #24435