### PR TITLE
kafs-client: introduce package

### DIFF
--- a/net/kafs-client/Makefile
+++ b/net/kafs-client/Makefile
@@ -1,0 +1,73 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=kafs-client
+PKG_VERSION:=0.5-9957339e
+PKG_RELEASE:=2
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://gitlab.com/linux-afs/kafs-client.git
+PKG_SOURCE_VERSION:=99573359e25c1e31b84b23592ff72ae40c8756f5
+PKG_MIRROR_HASH:=69436e5e8760be7bf2fd50a316a6596ee910e3dfd888bdea8a2ee506a0a5c5f2
+
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/kafs-client
+	SECTION:=net
+	CATEGORY:=Network
+	SUBMENU:=Filesystem
+	DEPENDS:=+keyutils +krb5-libs +kmod-fs-afs +kmod-crypto-user
+	TITLE:=kafs client library
+	URL:=http://git.infradead.org/users/dhowells/kafs-client.git
+endef
+
+define Package/kafs-client/description
+kAFS utilities
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR)/src \
+		$(TARGET_CONFIGURE_OPTS) \
+		CFLAGS="$(TARGET_CFLAGS)"
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/kafs
+	$(CP) $(PKG_BUILD_DIR)/src/include/kafs/*.h $(1)/usr/include/kafs/
+endef
+
+define Package/kafs-client/install
+	$(INSTALL_DIR) $(1)/afs
+
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_DIR) $(1)/etc/kafs
+	$(INSTALL_DIR) $(1)/etc/kafs/client.d
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/conf/client.conf $(1)/etc/kafs/
+
+	$(INSTALL_DIR) $(1)/etc/request-key.d
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/conf/kafs_dns.conf \
+	    $(1)/etc/request-key.d/
+
+	$(INSTALL_DIR) $(1)/usr/share/kafs
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/conf/cellservdb.conf \
+	    $(1)/usr/share/kafs/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/lib*.so* $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/aklog-kafs $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/kafs-check-config $(1)/usr/sbin/
+
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/kafs-preload $(1)/usr/libexec/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/kafs-dns $(1)/usr/libexec/
+endef
+
+$(eval $(call BuildPackage,kafs-client))

--- a/net/kafs-client/patches/res_query.patch
+++ b/net/kafs-client/patches/res_query.patch
@@ -1,0 +1,64 @@
+Hackishly cut out res_nquery for res_query.  Surely there's a better way.
+
+--- a/src/lib_dns_lookup.c
++++ b/src/lib_dns_lookup.c
+@@ -312,13 +312,13 @@ static int dns_query_AFSDB(struct kafs_s
+ 	ns_msg	handle;			/* handle for response message */
+ 	union {
+ 		HEADER hdr;
+-		u_char buf[NS_PACKETSZ];
++		unsigned char buf[NS_PACKETSZ];
+ 	} response;		/* response buffers */
+ 
+ 	verbose("Get AFSDB RR for cell name:'%s'", cell_name);
+ 
+ 	/* query the dns for an AFSDB resource record */
+-	response_len = res_nquery(&ctx->res,
++	response_len = res_query( // &ctx->res,
+ 				  cell_name,
+ 				  ns_c_in,
+ 				  ns_t_afsdb,
+@@ -473,7 +473,7 @@ static int dns_query_SRV(struct kafs_ser
+ 	ns_msg	handle;			/* handle for response message */
+ 	union {
+ 		HEADER hdr;
+-		u_char buf[NS_PACKETSZ];
++		unsigned char buf[NS_PACKETSZ];
+ 	} response;
+ 	enum dns_payload_protocol_type protocol;
+ 	char name[1024];
+@@ -483,7 +483,7 @@ static int dns_query_SRV(struct kafs_ser
+ 
+ 	verbose("Get SRV RR for name:'%s'", name);
+ 
+-	response_len = res_nquery(&ctx->res,
++	response_len = res_query( // &ctx->res,
+ 				  name,
+ 				  ns_c_in,
+ 				  ns_t_srv,
+--- a/src/lib_object.c
++++ b/src/lib_object.c
+@@ -23,11 +23,13 @@
+ int kafs_init_lookup_context(struct kafs_lookup_context *ctx)
+ {
+ 	memset(&ctx->res, 0, sizeof(ctx->res));
++#if 0
+ 	if (res_ninit(&ctx->res) < 0) {
+ 		ctx->report.bad_error = true;
+ 		ctx->report.error("%m");
+ 		return -1;
+ 	}
++#endif
+ 	return 0;
+ }
+ 
+@@ -36,7 +38,9 @@ int kafs_init_lookup_context(struct kafs
+  */
+ void kafs_clear_lookup_context(struct kafs_lookup_context *ctx)
+ {
++#if 0
+ 	res_nclose(&ctx->res);
++#endif
+ }
+ 
+ /*


### PR DESCRIPTION
Maintainer: me / @nwf
Compile tested: x86/generic dcc4307205
Run tested: x86/generic dcc4307205

Description:

[kAFS](https://docs.kernel.org/filesystems/afs.html) is the Linux in-kernel implementation of the Andrew File System client / "cache manager".  [kafs-client](https://gitlab.com/linux-afs/kafs-client) is a small collection of user-space programs that support it, including:
- Loading lists of known AFS cells ("CellServDB")
- Providing dynamic cell and server discovery using DNS via `request-key`
- Feeding the kernel AFS authentication tokens derived from users' Kerberos tickets (`aklog-kafs`)

Please note:
- some functionality in this package is not expected to work correctly until #24421 lands.

- As per @robimarko's request on https://github.com/openwrt/openwrt/pull/15761, this package depends on `kmod-crypto-user` rather than relying on it being a transitive dependency of `kmod-fs-afs`. 

- The directory `/afs` is created as part of this package but no automatic mounting is (yet) done; users will need to arrange their own, flavored to taste.

Tests performed included
- mounting kafs with dynamic root (`mount -t afs -o dyn none /afs`)
- accessing a cell via DNS lookup (`ls /afs/andrew.cmu.edu`)
- getting Kerberos tickets (`kinit`) and using `aklog-kafs` to install AFS tokens, validating access to non-public parts of the namespace
- installing the shipped CellServDB with `/usr/libexec/kafs-preload`