### PR TITLE
node: bump to v20.15.0

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v20.14.0
+PKG_VERSION:=v20.15.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=f01109d3102754ac360fcf25aa588f3bef5c090a8eed3fb1d0be194149c46cf2
+PKG_HASH:=01e2c034467a324a33e778c81f2808dff13d289eaa9307d3e9b06c171e4d932d
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/202-node_gyp.patch
+++ b/lang/node/patches/202-node_gyp.patch
@@ -1,6 +1,6 @@
 --- a/node.gyp
 +++ b/node.gyp
-@@ -1214,6 +1214,7 @@
+@@ -1302,6 +1302,7 @@
        'dependencies': [
          'deps/simdutf/simdutf.gyp:simdutf#host',
        ],

--- a/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
+++ b/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
@@ -1,6 +1,6 @@
 --- a/node.gyp
 +++ b/node.gyp
-@@ -1215,6 +1215,7 @@
+@@ -1303,6 +1303,7 @@
          'deps/simdutf/simdutf.gyp:simdutf#host',
        ],
        'libraries!':[ '-licui18n', '-licuuc', '-licudata', '-lcrypto', '-lssl', '-lz', '-lhttp_parser', '-luv', '-lnghttp2', '-lcares' ],


### PR DESCRIPTION
Maintainer: me @ianchi
Compile tested: head, aarch64, arm, i386, x86_64
Run tested: (qemu 9.0.1) aarch64

Description:
Update to v20.15.0

Notable Changes
* test_runner: support test plans
* inspector: introduce the --inspect-wait flag
* zlib: expose zlib.crc32()
* cli: allow running wasm in limited vmem with --disable-wasm-trap-handler