### PR TITLE
containerd: Update to 1.7.18

### DIFF
--- a/utils/containerd/Makefile
+++ b/utils/containerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=containerd
-PKG_VERSION:=1.7.15
+PKG_VERSION:=1.7.18
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -9,7 +9,7 @@ PKG_CPE_ID:=cpe:/a:linuxfoundation:containerd
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containerd/containerd/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=2dc491434b182334b51350f810ed68ace3624c8a2d6e1eac490d93c653498a33
+PKG_HASH:=91685cebd50e3f353a402adadf61e2a6aeda3f63754fa0fcc978a043e00acac4
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: all supported targets
Run tested: N/A

Description:
Update Go version to 1.21.11 (https://github.com/containerd/containerd/pull/10298)
Remove uses of alias (https://github.com/containerd/containerd/pull/10277platforms.Platform)
Migrate log imports to (https://github.com/containerd/containerd/pull/10269github.com/containerd/log)
Migrate errdefs package to (https://github.com/containerd/containerd/pull/10266github.com/containerd/errdefs)
Fix usage of "unknown" platform (https://github.com/containerd/containerd/pull/10261)
For more information, visit https://github.com/containerd/containerd/compare/v1.7.15...v1.7.18