### PR TITLE
dockerd: Update to 26.1.4

### DIFF
--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=26.1.0
+PKG_VERSION:=26.1.4
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=7a59781fe9e1d74d1ada53624f0bde909de503964b729dc9dfb21e56c3a9b8ae
-PKG_GIT_SHORT_COMMIT:=c8af8eb # SHA1 used within the docker executables
+PKG_HASH:=74d3f38f2b88399012e0b889e6408d81e2d198437deda71da6d1da72dcc8afcc
+PKG_GIT_SHORT_COMMIT:=de5c9cf # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: all supported targets
Run tested: N/A

Description:
dockerd: Update to 26.1.4
For more information, visit https://github.com/moby/moby/compare/v26.1.0...v26.1.4

Dependent on:
https://github.com/openwrt/packages/pull/24452
