### PR TITLE
tinc: fix regression bring by commit fd61f2d

### DIFF
--- a/net/tinc/Makefile
+++ b/net/tinc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tinc
 PKG_VERSION:=1.1pre18
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://tinc-vpn.org/packages

--- a/net/tinc/files/tinc.init
+++ b/net/tinc/files/tinc.init
@@ -249,7 +249,10 @@ start_instance() {
 	append_params "$s" logfile debug
 
 	SERVICE_PID_FILE="/var/run/tinc.$s.pid"
-	service_start $BIN -c "$TMP_TINC/$s" $ARGS --pidfile="$SERVICE_PID_FILE"
+	# consequences of option -n "%s"
+	# tinc will display this warning Both netname and configuration directory given, using the latter...
+	# BUT the exported variable NETNAME will be set with the right value when run tinc-up script
+	service_start $BIN -c "$TMP_TINC/$s" -n "$s" $ARGS --pidfile="$SERVICE_PID_FILE"
 }
 
 stop_instance() {


### PR DESCRIPTION
Maintainer: me

Run tested: mvebu/cortexa9/linksys_wrt1900acs   snapshot 

Description:
   the variable NETNAME that is exported in tinc-up , was not set correctly

