### PR TITLE
dnslookup: Update to 1.11.1

### DIFF
--- a/net/dnslookup/Makefile
+++ b/net/dnslookup/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnslookup
-PKG_VERSION:=1.11.0
+PKG_VERSION:=1.11.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ameshkov/dnslookup/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c9464093b76ba593fae3629ae54f5738251de48d8fc3bbdc08a9d6644416dfa0
+PKG_HASH:=31967c89406aa6da5f69c563815e58478b530c8e55f0d995065a363f68d5e535
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Fixed unnecessary error when running with no arguments.

Maintainer: @1715173329
Compile tested: all supported targets
Run tested: armv8, snapshot

Description:
Fixed unnecessary error when running with no arguments: https://github.com/ameshkov/dnslookup/pull/72