### PR TITLE
[22.03] mhz: backport build fix

### DIFF
--- a/utils/mhz/Makefile
+++ b/utils/mhz/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mhz
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://github.com/wtarreau/mhz.git

--- a/utils/mhz/patches/0001-Makefile-allow-overriding-CC-and-CFLAGS.patch
+++ b/utils/mhz/patches/0001-Makefile-allow-overriding-CC-and-CFLAGS.patch
@@ -1,0 +1,29 @@
+From d55f7b578eb2126d2e4a7f045321f6ba7df3800a Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Wed, 30 Aug 2023 20:31:07 +0200
+Subject: [PATCH] Makefile: allow overriding CC and CFLAGS
+
+For OpenWrt and Buildroot which support really large amount of different
+architectures and cores it is sometimes required to pass our own CFLAGS.
+This is especially true if hardening options are to be respected.
+
+Also, for cross-compiling CC should be respected as currently it is
+working since both OpenWrt and Buildroot symlink gcc to the cross compiler.
+
+So, lets set the current values as defaults but allow them to be overriden.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,5 @@
+-CC         := gcc
+-CFLAGS     := -O3 -Wall -fomit-frame-pointer
++CC         ?= gcc
++CFLAGS     ?= -O3 -Wall -fomit-frame-pointer
+ 
+ all: mhz
+ 


### PR DESCRIPTION
Maintainer: @robimarko 
Compile tested: mvebu, Turris Omnia, Turris OS 7 = OpenWrt 22.03
Run tested: mvebu, Turris Omnia, Turris OS 7 = OpenWrt 22.03, it compiles

Description:
The package repeatedly fails to compile with the errors mentioned in the commit message. On our newer branch, tracking OpenWrt 23.05, the build does not fail. Backporting this patch fixed the problem on the current branch, tracking OpenWrt 22.03.