### PR TITLE
[23.05] libjwt: add package

### DIFF
--- a/libs/libjwt/Makefile
+++ b/libs/libjwt/Makefile
@@ -1,0 +1,43 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libjwt
+PKG_VERSION:=1.17.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/benmcollins/libjwt/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=568cb5c272622e6ae045708594f1eded64fbfc101112d20de51875fce7653c83
+
+PKG_LICENSE:=MPL-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+
+CMAKE_OPTIONS += \
+        -DBUILD_SHARED_LIBS=ON
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/libjwt
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=libjwt
+  URL:=https://github.com/benmcollins/libjwt
+  DEPENDS:=+libopenssl +jansson
+  ABI_VERSION:=0
+endef
+
+define Package/libjwt/description
+ JSON Web Tokens are an open, industry standard RFC 7519 method for representing claims securely between two parties.
+ libjwt seems to be the most popular implementation written in C.
+endef
+
+
+define Package/libjwt/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libjwt.so $(1)/usr/lib/libjwt.so.0
+	$(LN) libjwt.so.0 $(1)/usr/lib/libjwt.so
+endef
+
+$(eval $(call BuildPackage,libjwt))


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, mips_24kc
Run tested: x86/64
Description:
Add package for JWT C Library built against OpenSSL.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>
(cherry picked from commit 57fdc5d2b98e6bdd96f8f0f6f0448579bc3ddbad)

This package is needed to update asterisk in telephony feed to version 20.8.1 which no longer comes with a built-in JWT implementation.