### PR TITLE
schroot: add boost-1.85 compatibility patch

### DIFF
--- a/admin/schroot/patches/030-boost-1.85.patch
+++ b/admin/schroot/patches/030-boost-1.85.patch
@@ -1,0 +1,31 @@
+--- a/sbuild/sbuild-chroot-config.cc
++++ b/sbuild/sbuild-chroot-config.cc
+@@ -31,6 +31,7 @@
+ #include <cstdlib>
+ #include <cstring>
+ 
++#include <boost/filesystem/directory.hpp>
+ #include <boost/filesystem/operations.hpp>
+ 
+ #include <sys/types.h>
+--- a/sbuild/sbuild-run-parts.cc
++++ b/sbuild/sbuild-run-parts.cc
+@@ -29,6 +29,7 @@
+ #include <syslog.h>
+ 
+ #include <boost/format.hpp>
++#include <boost/filesystem/directory.hpp>
+ #include <boost/filesystem/operations.hpp>
+ 
+ using boost::format;
+--- a/sbuild/sbuild-util.cc
++++ b/sbuild/sbuild-util.cc
+@@ -35,8 +35,6 @@
+ #include <time.h>
+ #endif
+ 
+-#include <boost/filesystem/convenience.hpp>
+-
+ using namespace sbuild;
+ 
+ namespace


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
Fix build failures with `boost 1.85`, merged on Sunday.

```sh
../sbuild/sbuild-run-parts.cc: In constructor 'sbuild::run_parts::run_parts(const std::string&, bool, bool, mode_t)':
../sbuild/sbuild-run-parts.cc:79:22: error: 'directory_iterator' is not a member of 'boost::filesystem'; did you mean 'directory_entry'?
79 |   boost::filesystem::directory_iterator end_iter;
|                      ^~~~~~~~~~~~~~~~~~
|                      directory_entry
../sbuild/sbuild-run-parts.cc:80:27: error: 'directory_iterator' is not a member of 'boost::filesystem'; did you mean 'directory_entry'?
80 |   for (boost::filesystem::directory_iterator dirent(dirpath);
|                           ^~~~~~~~~~~~~~~~~~
|                           directory_entry
../sbuild/sbuild-run-parts.cc:81:8: error: 'dirent' was not declared in this scope
81 |        dirent != end_iter;
|        ^~~~~~
../sbuild/sbuild-run-parts.cc:81:18: error: 'end_iter' was not declared in this scope
81 |        dirent != end_iter;
|                  ^~~~~~~~
ninja: build stopped: subcommand failed.
```

```sh
../sbuild/sbuild-chroot-config.cc: In member function 'void sbuild::chroot_config::add_config_directory(const std::string&, const std::string&)':
../sbuild/sbuild-chroot-config.cc:152:22: error: 'directory_iterator' is not a member of 'boost::filesystem'; did you mean 'directory_entry'?
152 |   boost::filesystem::directory_iterator end_iter;
|                      ^~~~~~~~~~~~~~~~~~
|                      directory_entry
../sbuild/sbuild-chroot-config.cc:153:27: error: 'directory_iterator' is not a member of 'boost::filesystem'; did you mean 'directory_entry'?
153 |   for (boost::filesystem::directory_iterator dirent(dirpath);
|                           ^~~~~~~~~~~~~~~~~~
|                           directory_entry
../sbuild/sbuild-chroot-config.cc:154:8: error: 'dirent' was not declared in this scope
154 |        dirent != end_iter;
|        ^~~~~~
../sbuild/sbuild-chroot-config.cc:154:18: error: 'end_iter' was not declared in this scope
154 |        dirent != end_iter;
|                  ^~~~~~~~
ninja: build stopped: subcommand failed.
```

```sh
./build_dir/target-x86_64_musl/reschroot-1.6.13/reschroot/sbuild/sbuild-util.cc:38:10: fatal error: boost/filesystem/convenience.hpp: No such file or directory
38 | #include <boost/filesystem/convenience.hpp>
|          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.
```
