### PR TITLE
freeradius3: add PKG_BUILD_PARALLEL:=0

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
 PKG_VERSION:=3.2.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=freeradius-server-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://freeradius.org/ftp/pub/freeradius
@@ -21,6 +21,7 @@ PKG_LICENSE_FILES:=COPYRIGHT LICENSE
 PKG_CPE_ID:=cpe:/a:freeradius:freeradius
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/freeradius-server-$(PKG_VERSION)
+PKG_BUILD_PARALLEL:=0
 PKG_FIXUP:=autoreconf
 PYTHON3_PKG_BUILD:=0
 


### PR DESCRIPTION
Maintainer:
Compile tested:
Run tested:

Description:

freeradius-3.2.4 had a build failure in the snapshoot release but it builds successfully when doing a pull request

https://downloads.openwrt.org/snapshots/faillogs/aarch64_generic/packages/freeradius3/compile.txt

https://github.com/openwrt/packages/pull/24417

as a solution we need to add

```
PKG_BUILD_PARALLEL:=0
```

to prevent freeradius3 from doing the build in parallel