### PR TITLE
git: Force use -O2 when lto enabled

### DIFF
--- a/net/git/Makefile
+++ b/net/git/Makefile
@@ -81,6 +81,10 @@ define Package/git-gitweb/conffiles
 /etc/gitweb.conf
 endef
 
+ifeq ($(CONFIG_USE_LTO),y)
+  TARGET_CPPFLAGS := $(filter-out -O%,$(TARGET_CFLAGS)) -O2
+endif
+
 MAKE_FLAGS := \
 	CC="$(TARGET_CC)" \
 	CFLAGS="$(TARGET_CFLAGS)" \


### PR DESCRIPTION
Git doen't support lto with gcc flag -O3 and -Ofast. This is discussed in openwrt/packages#24366.
If CONFIG_USE_LTO=y, filter -O% from CPPFLAGS and set to -O2.

Maintainer: @krant @neheb 
Compile tested: aarch64 f637cf5ef73bbecaf6183e5c416e3043a5f1e202
Run tested: aarch64 f637cf5ef73bbecaf6183e5c416e3043a5f1e202 looks good

Description:
