### PR TITLE
docker: Update to 27.0.2

### DIFF
--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker
-PKG_VERSION:=26.1.4
+PKG_VERSION:=27.0.2
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/docker/cli
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=73f914421db873d1a19d4d15e8ae21bebc35079f3034f574dfc6cd0449edcf89
-PKG_GIT_SHORT_COMMIT:=5650f9b # SHA1 used within the docker executables
+PKG_HASH:=a2b31d4c8143c8b126e98a359639f51727fc83fc1e61670efbdeaa7dea92fd5a
+PKG_GIT_SHORT_COMMIT:=912c1dd # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=26.1.4
+PKG_VERSION:=27.0.2
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=74d3f38f2b88399012e0b889e6408d81e2d198437deda71da6d1da72dcc8afcc
-PKG_GIT_SHORT_COMMIT:=de5c9cf # SHA1 used within the docker executables
+PKG_HASH:=2705abdd7a8a47ec88c0d2f0f31eede01ba4aa5ae8b5ab0e2c4ee25e7c314521
+PKG_GIT_SHORT_COMMIT:=e953d76 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 

--- a/utils/runc/Makefile
+++ b/utils/runc/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=runc
-PKG_VERSION:=1.1.12
+PKG_VERSION:=1.1.13
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -9,7 +9,7 @@ PKG_CPE_ID:=cpe:/a:linuxfoundation:runc
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opencontainers/runc/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=be31b07d6a54a8f234016501c300ad04b6c428c56588e7eca8c3b663308db208
+PKG_HASH:=789d5749a08ef1fbe5d1999b67883206a68a4e58e6ca0151c411d678f3480b25
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: all supported targets
Run tested: N/A

Description:
runc: Update to 1.1.13
This is the thirteenth patch release in the 1.1.z release branch of runc. It
brings in Go 1.22.x compatibility and fixes a few issues, including an
occasional wrong nofile rlimit in runc exec, and a race between runc list and
runc delete.
For more information, visit https://github.com/opencontainers/runc/releases/tag/v1.1.13

docker: Update to 27.0.2
For more information, visit https://github.com/docker/cli/compare/v26.1.4...v27.0.2

dockerd: Update to 27.0.2
For more information, visit https://github.com/moby/moby/compare/v26.1.4...v27.0.2