### PR TITLE
lxc: update to 6.0.1

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
-PKG_VERSION:=5.0.3
+PKG_VERSION:=6.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/
-PKG_HASH:=2693a4c654dcfdafb3aa95c262051d8122afa1b6f5cef1920221ebbdee934d07
+PKG_HASH:=ccb38fbcdb86a82ee8192ccc85bba47edaf824439e9a7f12ab178d51ff1f77e0
 
 PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later BSD-2-Clause GPL-2.0
@@ -137,7 +137,7 @@ define Package/liblxc
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=LXC userspace library
-  DEPENDS+= +libcap +libpthread +LXC_SECCOMP:libseccomp +libopenssl
+  DEPENDS+= +libcap +libpthread +LXC_SECCOMP:libseccomp +libopenssl +libdbus
 endef
 
 define Package/lxc-init

--- a/utils/lxc/patches/020-lxc-checkconfig.patch
+++ b/utils/lxc/patches/020-lxc-checkconfig.patch
@@ -1,20 +1,19 @@
 --- a/src/lxc/cmd/lxc-checkconfig.in
 +++ b/src/lxc/cmd/lxc-checkconfig.in
-@@ -4,6 +4,17 @@
+@@ -7,6 +7,16 @@ export LANGUAGE=en
  # Allow environment variables to override config
- : ${CONFIG:=/proc/config.gz}
- : ${MODNAME:=configs}
+ : "${CONFIG:=/proc/config.gz}"
+ : "${MODNAME:=configs}"
 +: ${ZGREP:=zgrep}
 +: ${GUNZIP:=gunzip}
 +
 +if [ -z $(command -v $ZGREP) ] && ! [ -z $(command -v $GUNZIP) ] && [ -x $(command -v $GUNZIP) ] &&  [ -f $CONFIG ] && [ "$CONFIG" == "/proc/config.gz" ] ; then
++  CONFIG_NEW="/tmp/config-$(uname -r)"
++  $GUNZIP -c $CONFIG > $CONFIG_NEW
++  CONFIG=$CONFIG_NEW
 +
-+	CONFIG_NEW="/tmp/config-$(uname -r)"
-+	$GUNZIP -c $CONFIG > $CONFIG_NEW
-+	CONFIG=$CONFIG_NEW
-+
-+	GREP=grep
++  GREP=grep
 +fi
  
- CAT="cat"
+ GREP="grep"
  

--- a/utils/lxc/patches/025-remove-unsupported-option.patch
+++ b/utils/lxc/patches/025-remove-unsupported-option.patch
@@ -1,13 +1,16 @@
 --- a/templates/lxc-download.in
 +++ b/templates/lxc-download.in
-@@ -384,20 +384,7 @@ fi
- # Unpack the rootfs
- echo "Unpacking the rootfs"
+@@ -380,26 +380,10 @@ if tar --version | grep -sq "bsdtar"; th
+     IS_BSD_TAR="true"
+ fi
  
 -EXCLUDES=""
 -excludelist=$(relevant_file excludes)
 -if [ -f "${excludelist}" ]; then
 -  while read -r line; do
+-    if [ ${IS_BSD_TAR} = "true" ]; then
+-      line="^${line}"
+-    fi
 -    EXCLUDES="${EXCLUDES} --exclude=${line}"
 -  done < "${excludelist}"
 -fi
@@ -17,8 +20,12 @@
 -# is to use a function wrapper, but the latter can't be used here as the args
 -# are dynamic. We thus need to ignore the warning brought by shellcheck.
 -# shellcheck disable=SC2086
--tar  --anchored ${EXCLUDES} --numeric-owner -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
-+tar --numeric-owner -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
+ if [ "${IS_BSD_TAR}" = "true" ]; then
+-  tar ${EXCLUDES} --numeric-owner -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
++  tar --numeric-owner -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
+ else
+-  tar --anchored ${EXCLUDES} --numeric-owner --xattrs-include='*' -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
++  tar --numeric-owner --xattrs-include='*' -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
+ fi
  
  mkdir -p "${LXC_ROOTFS}/dev/pts/"
- 


### PR DESCRIPTION
Changelog: https://discuss.linuxcontainers.org/t/lxc-6-0-lts-has-been-released/19567

Required libdbus as a depends for liblxc.  I verified that both lxc-create and lxc-checkconfig work with the rebases to the following patches but do please review:

- 020-lxc-checkconfig.patch
- 025-remove-unsupported-option.patch

Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne

Maintainer: @ratkaj