### PR TITLE
unixobdc: fix compilation with GCC14 again

### DIFF
--- a/libs/unixodbc/Makefile
+++ b/libs/unixodbc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unixodbc
 PKG_VERSION:=2.3.12
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=unixODBC-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.unixodbc.org
@@ -23,9 +23,8 @@ PKG_CPE_ID:=cpe:/a:unixodbc:unixodbc
 PKG_BUILD_DIR:=$(BUILD_DIR)/unixODBC-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR)/host/unixODBC-$(PKG_VERSION)
 
-PKG_BUILD_PARALLEL:=1
-PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 HOST_BUILD_DEPENDS:=unixodbc
 HOST_BUILD_PARALLEL:=1

--- a/libs/unixodbc/patches/010-gcc14.patch
+++ b/libs/unixodbc/patches/010-gcc14.patch
@@ -1,6 +1,29 @@
+From 45f501e1be2db6b017cc242c79bfb9de32b332a1 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Mon, 29 Jan 2024 08:27:29 +0100
+Subject: [PATCH] PostgreSQL driver: Fix incompatible pointer-to-integer types
+
+These result in out-of-bounds stack writes on 64-bit architectures
+(caller has 4 bytes, callee writes 8 bytes), and seem to have gone
+unnoticed on little-endian architectures (although big-endian
+architectures must be broken).
+
+This change is required to avoid a build failure with GCC 14.
+---
+ Drivers/Postgre7.1/info.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
 --- a/Drivers/Postgre7.1/info.c
 +++ b/Drivers/Postgre7.1/info.c
-@@ -1786,7 +1786,7 @@ HSTMT hcol_stmt;
+@@ -1779,14 +1779,14 @@ char *table_name;
+ char index_name[MAX_INFO_STRING];
+ short fields_vector[8];
+ char isunique[10], isclustered[10];
+-SDWORD index_name_len, fields_vector_len;
++SQLLEN index_name_len, fields_vector_len;
+ TupleNode *row;
+ int i;
+ HSTMT hcol_stmt;
  StatementClass *col_stmt, *indx_stmt;
  char column_name[MAX_INFO_STRING], relhasrules[MAX_INFO_STRING];
  char **column_names = 0;
@@ -9,3 +32,12 @@
  int total_columns = 0;
  char error = TRUE;
  ConnInfo *ci;
+@@ -2136,7 +2136,7 @@ HSTMT htbl_stmt;
+ StatementClass *tbl_stmt;
+ char tables_query[STD_STATEMENT_LEN];
+ char attname[MAX_INFO_STRING];
+-SDWORD attname_len;
++SQLLEN attname_len;
+ char pktab[MAX_TABLE_LEN + 1];
+ Int2 result_cols;
+ 


### PR DESCRIPTION
Wrong pointer type. This time found on 64-bit.

Maintainer: @heil