### PR TITLE
p11-kit: update to 0.25.3

### DIFF
--- a/libs/p11-kit/Makefile
+++ b/libs/p11-kit/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=p11-kit
-PKG_VERSION:=0.24.1
-PKG_RELEASE:=2
+PKG_VERSION:=0.25.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/p11-glue/p11-kit/releases/download/$(PKG_VERSION)
-PKG_HASH:=d8be783efd5cd4ae534cee4132338e3f40f182c3205d23b200094ec85faaaef8
+PKG_HASH:=d8ddce1bb7e898986f9d250ccae7c09ce14d82f1009046d202a0eb1b428b2adc
 
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/libs/p11-kit/patches/010-format.patch
+++ b/libs/p11-kit/patches/010-format.patch
@@ -1,0 +1,29 @@
+From c203931e32040f2ffb41461f3e3a5ebf3829ef63 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Fri, 28 Jun 2024 13:07:07 -0700
+Subject: [PATCH] fix format warning with 32-bit platforms on musl
+
+musl uses 64-bit time_t, even on 32-bit platforms. Cast to avoid the warning.
+---
+ p11-kit/server.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/p11-kit/server.c
++++ b/p11-kit/server.c
+@@ -45,6 +45,7 @@
+ #include <assert.h>
+ #include <errno.h>
+ #include <fcntl.h>
++#include <inttypes.h>
+ #include <limits.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+@@ -558,7 +559,7 @@ server_loop (Server *server,
+ 
+ 		/* timeout */
+ 		if (ret == 0 && children_avail == 0 && timeout != NULL) {
+-			p11_message (_("no connections to %s for %lu secs, exiting"), server->socket_name, timeout->tv_sec);
++			p11_message (_("no connections to %s for %" PRIu64 " secs, exiting"), server->socket_name, (uint64_t)timeout->tv_sec);
+ 			break;
+ 		}
+ 


### PR DESCRIPTION
Upstream backport fixing 32-bit -Wformat warning.

Maintainer: @nmav 