### PR TITLE
apinger: fix time_t format

### DIFF
--- a/net/apinger/Makefile
+++ b/net/apinger/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=apinger
 PKG_SOURCE_DATE:=2015-04-09
 PKG_SOURCE_VERSION:=78eb328721ba1a10571c19df95acddcb5f0c17c8
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/Jajcus/apinger

--- a/net/apinger/patches/050-statusformat.patch
+++ b/net/apinger/patches/050-statusformat.patch
@@ -14,8 +14,8 @@
 -			ctime(&t->last_received_tv.tv_sec));
 -		fprintf(f,"Average delay: %0.3fms\n",AVG_DELAY(t));
 +		if(config->status_format){
-+			fprintf(f,"%s|%s|%s|%i|%i|%u|",t->name, t->config->srcip, t->description, t->last_sent+1,
-+				 t->received, t->last_received_tv.tv_sec);
++			fprintf(f,"%s|%s|%s|%i|%i|%" PRIu64 "|",t->name, t->config->srcip, t->description, t->last_sent+1,
++				 t->received, (uint64_t)t->last_received_tv.tv_sec);
 +			fprintf(f,"%0.3fms|", AVG_DELAY(t));
 +		}
 +		else{


### PR DESCRIPTION
Needs to be 64-bit.

Maintainer: @samm-git 