### PR TITLE
docker: Update to 27.0.3

### DIFF
--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker
-PKG_VERSION:=27.0.2
+PKG_VERSION:=27.0.3
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/docker/cli
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=a2b31d4c8143c8b126e98a359639f51727fc83fc1e61670efbdeaa7dea92fd5a
-PKG_GIT_SHORT_COMMIT:=912c1dd # SHA1 used within the docker executables
+PKG_HASH:=f992e895c949852686abef9a6fa9efd622826c4f4d70b83876569a4641c4c8fc
+PKG_GIT_SHORT_COMMIT:=7d4bcd8 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=27.0.2
+PKG_VERSION:=27.0.3
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=2705abdd7a8a47ec88c0d2f0f31eede01ba4aa5ae8b5ab0e2c4ee25e7c314521
-PKG_GIT_SHORT_COMMIT:=e953d76 # SHA1 used within the docker executables
+PKG_HASH:=db02d9b5d98e85284538d6ead43b549c025acf937e98c09d18395bb331c1e607
+PKG_GIT_SHORT_COMMIT:=662f78c # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: all supported targets
Run tested: N/A

Description:
docker: Update to 27.0.3
For more information, visit https://github.com/docker/cli/compare/v27.0.2...v27.0.3

dockerd: Update to 27.0.3
Fix a regression that incorrectly reported a port mapping from a host IPv6 address to an IPv4-only container as an error. https://github.com/moby/moby/pull/48090
Fix a regression that caused duplicate subnet allocations when creating networks. https://github.com/moby/moby/pull/48089
Fix a regression resulting in "fail to register layer: failed to Lchown" errors when trying to pull an image with rootless enabled on a system that supports native overlay with user-namespaces. https://github.com/moby/moby/pull/48086
For more information, visit https://github.com/moby/moby/compare/v27.0.2...v27.0.3