### PR TITLE
miniupnpc: Update to 2.2.8

### DIFF
--- a/net/miniupnpc/Makefile
+++ b/net/miniupnpc/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpc
-PKG_VERSION:=2.2.3
+PKG_VERSION:=2.2.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
-PKG_HASH:=dce41b4a4f08521c53a0ab163ad2007d18b5e1aa173ea5803bd47a1be3159c24
+PKG_HASH:=05b929679091b9921b6b6c1f25e39e4c8d1f4d46c8feb55a412aa697aee03a93
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=BSD-3-Clause
@@ -58,8 +58,8 @@ endef
 
 define Package/miniupnpc/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/upnpc-shared $(1)/usr/bin/upnpc
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/listdevices $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/upnpc-shared $(1)/usr/bin/upnpc
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/upnp-listdevices-shared $(1)/usr/bin/upnp-listdevices
 endef
 
 define Package/libminiupnpc/install

--- a/net/miniupnpc/patches/100-no-fPIC.patch
+++ b/net/miniupnpc/patches/100-no-fPIC.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -41,12 +41,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+@@ -51,12 +51,6 @@ if (APPLE)
    target_compile_definitions(miniupnpc-private INTERFACE _DARWIN_C_SOURCE)
  endif ()
  
@@ -12,31 +12,4 @@
 -
  # Suppress noise warnings
  if (MSVC)
-   target_compile_definitions(miniupnpc-private INTERFACE _CRT_SECURE_NO_WARNINGS)
-@@ -221,16 +215,16 @@ endif ()
- 
- if (NOT UPNPC_NO_INSTALL)
-   install (FILES
--    miniupnpc.h
--    miniwget.h
--    upnpcommands.h
--    igd_desc_parse.h
--    upnpreplyparse.h
--    upnperrors.h
--    upnpdev.h
--    miniupnpctypes.h
--    portlistingparse.h
--    miniupnpc_declspec.h
-+    include/miniupnpc.h
-+    include/miniwget.h
-+    include/upnpcommands.h
-+    include/igd_desc_parse.h
-+    include/upnpreplyparse.h
-+    include/upnperrors.h
-+    include/upnpdev.h
-+    include/miniupnpctypes.h
-+    include/portlistingparse.h
-+    include/miniupnpc_declspec.h
-     DESTINATION include/miniupnpc
-   )
- 
+   target_compile_definitions(miniupnpc-private INTERFACE _CRT_SECURE_NO_WARNINGS _WINSOCK_DEPRECATED_NO_WARNINGS)


### PR DESCRIPTION
Maintainer: n/a
Compile tested: sunxi/cortexa53
Run tested: n/a

Description:
Updated binary path, rebased patches.
