### PR TITLE
rust: select correct architecture for armv5

### DIFF
--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -52,7 +52,9 @@ endif
 
 # ARM Logic
 ifeq ($(ARCH),arm)
-  ifeq ($(CONFIG_arm_v7),y)
+  ifeq ($(CONFIG_arm_v6)$(CONFIG_arm_v7),)
+    RUSTC_TARGET_ARCH:=$(subst arm,armv5te,$(RUSTC_TARGET_ARCH))
+  else ifeq ($(CONFIG_arm_v7),y)
     RUSTC_TARGET_ARCH:=$(subst arm,armv7,$(RUSTC_TARGET_ARCH))
   endif
 


### PR DESCRIPTION
Maintainer: @lu-zero 
Compile tested: armv5te, kirkwood, latest snapshot
Run tested: armv5te, kirkwood, latest snapshot, rust program run test

Description:
Currently, armv5 and armv6 targets are both using armv6 rustc. Without this patch, rust programs in armv5 targets throw illegal instruction error.

This pull request depends on https://github.com/openwrt/openwrt/pull/15855