### PR TITLE
openvpn: fix startup with script-security lower than 2

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.6.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/openvpn.init
+++ b/net/openvpn/files/openvpn.init
@@ -155,17 +155,24 @@ openvpn_add_instance() {
 		--syslog "openvpn($name)" \
 		--status "/var/run/openvpn.$name.status" \
 		--cd "$dir" \
-		--config "$conf" \
-		--up "/usr/libexec/openvpn-hotplug up $name" \
-		--down "/usr/libexec/openvpn-hotplug down $name" \
-		--route-up "/usr/libexec/openvpn-hotplug route-up $name" \
-		--route-pre-down "/usr/libexec/openvpn-hotplug route-pre-down $name" \
-		${client:+--ipchange "/usr/libexec/openvpn-hotplug ipchange $name"} \
-		${up:+--setenv user_up "$up"} \
-		${down:+--setenv user_down "$down"} \
-		${route_up:+--setenv user_route_up "$route_up"} \
-		${route_pre_down:+--setenv user_route_pre_down "$route_pre_down"} \
-		${client:+${ipchange:+--setenv user_ipchange "$ipchange"}} \
+		--config "$conf"
+	# external scripts can only be called on script-security 2 or higher
+	if [ "${security:-2}" -lt 2 ]; then
+		logger -t "openvpn(${name})" "not adding hotplug scripts due to script-security ${security:-2}"
+	else
+		procd_append_param command \
+			--up "/usr/libexec/openvpn-hotplug up $name" \
+			--down "/usr/libexec/openvpn-hotplug down $name" \
+			--route-up "/usr/libexec/openvpn-hotplug route-up $name" \
+			--route-pre-down "/usr/libexec/openvpn-hotplug route-pre-down $name" \
+			${client:+--ipchange "/usr/libexec/openvpn-hotplug ipchange $name"} \
+			${up:+--setenv user_up "$up"} \
+			${down:+--setenv user_down "$down"} \
+			${route_up:+--setenv user_route_up "$route_up"} \
+			${route_pre_down:+--setenv user_route_pre_down "$route_pre_down"} \
+			${client:+${ipchange:+--setenv user_ipchange "$ipchange"}}
+	fi
+	procd_append_param command \
 		--script-security "${security:-2}" \
 		$(openvpn_get_dev "$name" "$conf") \
 		$(openvpn_get_credentials "$name" "$conf")


### PR DESCRIPTION
_Maintainer:_  @neheb @BKPepe
_Run tested:_ OpenWRT x86-64 snapshot with custom .ovpn config and `script-security 0` setting, see below.

_Description:_
External scripts may only be specified for OpenVPN with `script-security 2` or higher, otherwise OpenVPN fails at tunnel startup with an error.
In some circumstances where the remote OpenVPN server is not fully trusted, setting `script-security` to `0` or `1` might still be a good practice and should be allowed. This changes the previously hardcoded hotplug scripts to only be added if `script-security 2` or higher is used.



logread from a current OpenWRT x86-64 snapshot failing on a custom config with `script-security 0`:
```
Tue Jul  2 20:25:54 2024 daemon.notice openvpn(custom_config)[4720]: TUN/TAP device tap0 opened
Tue Jul  2 20:25:54 2024 daemon.notice openvpn(custom_config)[4720]: /usr/libexec/openvpn-hotplug up custom_config tap0 1500 0   init
Tue Jul  2 20:25:54 2024 daemon.err openvpn(custom_config)[4720]: WARNING: Failed running command (--up/--down): disallowed by script-security setting
Tue Jul  2 20:25:54 2024 daemon.notice openvpn(custom_config)[4720]: Exiting due to fatal error
```
Updated init file with `script-security 0`:
```
Tue Jul  2 20:25:59 2024 user.notice openvpn(custom_config): not adding hotplug scripts due to script-security 0
Tue Jul  2 20:25:59 2024 daemon.notice openvpn(custom_config)[4864]: TUN/TAP device tap0 opened
Tue Jul  2 20:25:59 2024 daemon.notice openvpn(custom_config)[4864]: Initialization Sequence Completed
```
Updated init file with `script-security 2`:
```
Tue Jul  2 21:01:53 2024 daemon.notice openvpn(custom_config)[2861]: TUN/TAP device tap0 opened
Tue Jul  2 21:01:53 2024 daemon.notice openvpn(custom_config)[2861]: /usr/libexec/openvpn-hotplug up custom_config tap0 1500 0   init
Tue Jul  2 21:01:53 2024 daemon.notice openvpn(custom_config)[2861]: Initialization Sequence Completed
```