### PR TITLE
utils: lpac: fix passing CMAKE options

### DIFF
--- a/utils/lpac/Makefile
+++ b/utils/lpac/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lpac
 PKG_VERSION:=2.0.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/estkme-group/lpac/tar.gz/refs/tags/v$(PKG_VERSION)?
@@ -45,10 +45,10 @@ endef
 
 TARGET_CFLAGS += $(FPIC)
 
+# libqmi 1.35.4 or newer is required for QMI over QRTR
 CMAKE_OPTIONS += \
   -DLPAC_WITH_APDU_PCSC=$(if $(CONFIG_LPAC_WITH_PCSC),ON,OFF) \
   -DLPAC_WITH_APDU_AT=$(if $(CONFIG_LPAC_WITH_AT),ON,OFF) \
-  # libqmi 1.35.4 or newer is required for this
   -DLPAC_WITH_APDU_QMI_QRTR=OFF
 
 define Package/lpac/install


### PR DESCRIPTION
Maintainer: @blocktrron 
Compile tested: qualcommax/ipq60xx, main
Run tested: qualcommax/ipq60xx, main

Description:
Turns out that having a comment for QMI over QRTR in the CMAKE_OPTIONS will drop anything after it, so lets move the comment above CMAKE_OPTIONS.

Fixes: 34f9d96b4cc3 ("lpac: make APDU backends configurable")