### PR TITLE
tailscale: Update to 1.68.2

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.68.1
+PKG_VERSION:=1.68.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=d7fe30282d2f5eabdc76a5a89f11d935ed3a5d93d55f5fd5b40f9a9f49e19490
+PKG_HASH:=9d34bd153c485dd0d88d3d76f187b5032046c0807a411ca97f38c8039a9ac659
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: @ja-pa
Compile tested: rockchip/armv8
Run tested: N/A

Description:
tailscale: Update to 1.68.2
Fixed: [Tailnet lock](https://tailscale.com/kb/1226/tailnet-lock) validation of rotation signatures now permits multiple nodes signed by the same pre-signed reusable auth key.
For more information, visit https://github.com/tailscale/tailscale/compare/v1.68.1...v1.68.2