### PR TITLE
eza: update to 0.18.21

### DIFF
--- a/utils/eza/Makefile
+++ b/utils/eza/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=eza
-PKG_VERSION:=0.18.18
+PKG_VERSION:=0.18.21
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eza-community/eza/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=437ea76838fea2464b9592f1adef7df0412e27c9fc2a3e7ff47efcdfb17457f5
+PKG_HASH:=53cee12706be2b5bedcf40b97e077a18b254f0f53f1aee52d1d74136466045bc
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: x86-64, APU board, OpenWrt snapshot
Run tested: x86-64, APU board, OpenWrt snapshot

Release notes:
0.18.19: https://github.com/eza-community/eza/releases/tag/v0.18.19
0.18.20: https://github.com/eza-community/eza/releases/tag/v0.18.20
0.18.21: https://github.com/eza-community/eza/releases/tag/v0.18.21

