### PR TITLE
openssh: fix incompatible ptr type error GCC 14.1

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
 PKG_VERSION:=9.8p1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \

--- a/net/openssh/patches/100-fix-incompatible-ptr-GCC-14.1.patch
+++ b/net/openssh/patches/100-fix-incompatible-ptr-GCC-14.1.patch
@@ -1,0 +1,11 @@
+--- a/openbsd-compat/port-linux.c
++++ b/openbsd-compat/port-linux.c
+@@ -366,7 +366,7 @@ ssh_systemd_notify(const char *fmt, ...)
+ 		error_f("socket \"%s\": %s", path, strerror(errno));
+ 		goto out;
+ 	}
+-	if (connect(fd, &addr, sizeof(addr)) != 0) {
++	if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+ 		error_f("socket \"%s\" connect: %s", path, strerror(errno));
+ 		goto out;
+ 	}


### PR DESCRIPTION
The `ssh_systemd_notify` function is causing compilation errors when built against GCC 14.1. This is due to an incompatible pointer type being passed to the `connect` function.

`connect` function expects a pointer to `struct sockaddr`, but was receiving a pointer to `struct sockaddr_un`.

Maintainer: Peter Wagner <tripolar@gmx.at>
Run tested: aarch64, Dynalink DL-WRX36, Master Branch

Related issue: https://github.com/openwrt/packages/issues/24514