### PR TITLE
Enable serial moduls for luasockets

### DIFF
--- a/lang/luasocket/Makefile
+++ b/lang/luasocket/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luasocket
 PKG_VERSION:=3.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
@@ -83,6 +83,7 @@ define Package/luasocket/install
 	$(INSTALL_DIR) $(1)/usr/lib/lua/socket
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/src/{ftp,http,smtp,tp,url,headers}.lua $(1)/usr/lib/lua/socket
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/unix.so $(1)/usr/lib/lua/socket
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/serial.so $(1)/usr/lib/lua/socket
 	ln -sf ../socket-3.0.0.so $(1)/usr/lib/lua/socket/core.so
 endef
 


### PR DESCRIPTION
Maintainer: @flyn-org
Compile tested: ath79/generic OpenWRT 23.05.3
Run tested: ath79/generic OpenWRT 23.05.3
Description: Includes the serial module for luasockets (which is already being built) in the final package.  This allows using socket.select() on a serial port (eg /dev/ttyACM0) which is the easiest way to use a serial-port with coroutines.  For instance copas can now be used via:
```
local copas = require("copas")
local serial = require("socket.serial")

copas.addthread(function()
        tty = copas.wrap(serial("/dev/ttyACM0"))
        l, e = tty:receivepartial()
        while not e do
                print(">" .. l)
                l, e = tty:receivepartial()
        end
end)
copas()
```
