### PR TITLE
pcsc-lite: install libpcsclite_real.{a,so*}, too

### DIFF
--- a/utils/pcsc-lite/Makefile
+++ b/utils/pcsc-lite/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pcsc-lite
 PKG_VERSION:=2.2.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://pcsclite.apdu.fr/files/
@@ -79,6 +79,7 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/PCSC/* $(1)/usr/include/PCSC/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcsclite.{a,so*} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcsclite_real.{a,so*} $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpcsclite.pc $(1)/usr/lib/pkgconfig/
 endef
@@ -86,6 +87,7 @@ endef
 define Package/libpcsclite/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcsclite.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcsclite_real.so.* $(1)/usr/lib/
 endef
 
 define Package/pcscd/conffiles


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: HEAD (e74ead224), mips64-octeon
Run tested: As above.  OpenVPN using pkcs11-helper doesn't work without, does with file installed.

Description:
74ee2fa4899 failed to notice that libpcsclite now supports redirection, as of https://salsa.debian.org/rousseau/PCSC/-/commit/1faab672aa1f926cf943d8b814ae15636dddd22c (first present in upstream release 2.1.0).  It's important to include the real implementation, even if redirection permits loading others.