### PR TITLE
lolcat: bump to 1.5

### DIFF
--- a/utils/lolcat/Makefile
+++ b/utils/lolcat/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lolcat
-PKG_VERSION:=1.4
+PKG_VERSION:=1.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jaseg/lolcat/tar.gz/refs/tags/v$(PKG_VERSION)?
-PKG_HASH:=6ea43ee2b2bb2f15fc91812b72ebcdaa883052853ed8f055b6f8b38637bda909
+PKG_HASH:=2af79bed90e0bda52ae500d16e7e7022037fad10c487c317e7f0ff17ec4b14f5
 
 PKG_MAINTAINER:=Rui Salvaterra <rsalvaterra@gmail.com>
 PKG_LICENSE:=WTFPL


### PR DESCRIPTION
No changelog, but only a single commit since last version, fixing uncoloured stderr interleaved with coloured stdout.

Maintainer: me
Run tested: octeon

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>