### PR TITLE
[23.05] node: July 8, 2024 Security Releases

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v18.20.3
+PKG_VERSION:=v18.20.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=f35c9b9923c7b2e9243e7e2d10cd9ae61fbd5b925df3debbb72d5a70dbff555d
+PKG_HASH:=349259af6821f730bc4ca3a0e6576efc75ba86e546d118629a5b75eb8ebc3a0b
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi
Compile tested: 23.05, aarch64, arm
Run tested: (qemu 9.0.1) aarch64

Description:
This is a security release.

Notable Changes

    CVE-2024-36138 - Bypass incomplete fix of CVE-2024-27980 (High)
    CVE-2024-22020 - Bypass network import restriction via data URL (Medium)