### PR TITLE
[23.05] backport openvpn: fix startup with script-security lower than 2

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.5.8
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/openvpn.init
+++ b/net/openvpn/files/openvpn.init
@@ -154,17 +154,24 @@ openvpn_add_instance() {
 		--syslog "openvpn($name)" \
 		--status "/var/run/openvpn.$name.status" \
 		--cd "$dir" \
-		--config "$conf" \
-		--up "/usr/libexec/openvpn-hotplug up $name" \
-		--down "/usr/libexec/openvpn-hotplug down $name" \
-		--route-up "/usr/libexec/openvpn-hotplug route-up $name" \
-		--route-pre-down "/usr/libexec/openvpn-hotplug route-pre-down $name" \
-		${client:+--ipchange "/usr/libexec/openvpn-hotplug ipchange $name"} \
-		${up:+--setenv user_up "$up"} \
-		${down:+--setenv user_down "$down"} \
-		${route_up:+--setenv user_route_up "$route_up"} \
-		${route_pre_down:+--setenv user_route_pre_down "$route_pre_down"} \
-		${client:+${ipchange:+--setenv user_ipchange "$ipchange"}} \
+		--config "$conf"
+	# external scripts can only be called on script-security 2 or higher
+	if [ "${security:-2}" -lt 2 ]; then
+		logger -t "openvpn(${name})" "not adding hotplug scripts due to script-security ${security:-2}"
+	else
+		procd_append_param command \
+			--up "/usr/libexec/openvpn-hotplug up $name" \
+			--down "/usr/libexec/openvpn-hotplug down $name" \
+			--route-up "/usr/libexec/openvpn-hotplug route-up $name" \
+			--route-pre-down "/usr/libexec/openvpn-hotplug route-pre-down $name" \
+			${client:+--ipchange "/usr/libexec/openvpn-hotplug ipchange $name"} \
+			${up:+--setenv user_up "$up"} \
+			${down:+--setenv user_down "$down"} \
+			${route_up:+--setenv user_route_up "$route_up"} \
+			${route_pre_down:+--setenv user_route_pre_down "$route_pre_down"} \
+			${client:+${ipchange:+--setenv user_ipchange "$ipchange"}}
+	fi
+	procd_append_param command \
 		--script-security "${security:-2}" \
 		$(openvpn_get_dev "$name" "$conf") \
 		$(openvpn_get_credentials "$name" "$conf")


### PR DESCRIPTION
Maintainer:  @neheb @BKPepe
Compile tested: N/A
Run tested: OpenWRT x86-64 23.05

Backport of https://github.com/openwrt/packages/pull/24504