### PR TITLE
xr_usb_serial_common: fix 32-bit compilation

### DIFF
--- a/libs/xr_usb_serial_common/Makefile
+++ b/libs/xr_usb_serial_common/Makefile
@@ -4,7 +4,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=usb-serial-xr_usb_serial_common
 PKG_SOURCE_DATE:=2023-03-21
 PKG_SOURCE_VERSION:=90ad530166f096347a5a57b6f9eb21c422a40fd9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/kasbert/epsolar-tracer

--- a/libs/xr_usb_serial_common/patches/0001-fix-kernel-6.6-builds.patch
+++ b/libs/xr_usb_serial_common/patches/0001-fix-kernel-6.6-builds.patch
@@ -31,7 +31,7 @@ Signed-off-by: Adam Duskett <adam.duskett@amarulasolutions.com>
  		return 0;
  
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
-+	dev_vdbg(&xr_usb_serial->data->dev, "%s - count %ld\n", __func__, count);
++	dev_vdbg(&xr_usb_serial->data->dev, "%s - count %zd\n", __func__, count);
 +#else
  	dev_vdbg(&xr_usb_serial->data->dev, "%s - count %d\n", __func__, count);
 +#endif
@@ -43,7 +43,7 @@ Signed-off-by: Adam Duskett <adam.duskett@amarulasolutions.com>
  
  	count = (count > xr_usb_serial->writesize) ? xr_usb_serial->writesize : count;
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
-+	dev_vdbg(&xr_usb_serial->data->dev, "%s - write %ld\n", __func__, count);
++	dev_vdbg(&xr_usb_serial->data->dev, "%s - write %zd\n", __func__, count);
 +#else
  	dev_vdbg(&xr_usb_serial->data->dev, "%s - write %d\n", __func__, count);
 +#endif


### PR DESCRIPTION
Format needs to be %zd, not %ld for size_t.

Maintainer: @dangowrt 

ping @aduskett @john-tho 