### PR TITLE
lxc: fix lxc-download

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -50,7 +50,7 @@ LXC_SCRIPTS += \
 
 DEPENDS_APPLETS = +libpthread +libcap +liblxc
 
-DEPENDS_create = +lxc-configs +lxc-hooks +lxc-templates +flock +getopt
+DEPENDS_create = +lxc-configs +lxc-hooks +lxc-templates +flock +getopt +tar
 
 define Package/lxc/Default
   SECTION:=utils

--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=6.0.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/

--- a/utils/lxc/patches/025-remove-unsupported-option.patch
+++ b/utils/lxc/patches/025-remove-unsupported-option.patch
@@ -1,9 +1,14 @@
 --- a/templates/lxc-download.in
 +++ b/templates/lxc-download.in
-@@ -380,26 +380,10 @@ if tar --version | grep -sq "bsdtar"; th
-     IS_BSD_TAR="true"
- fi
+@@ -375,32 +375,7 @@ fi
+ # Unpack the rootfs
+ echo "Unpacking the rootfs"
  
+-IS_BSD_TAR="false"
+-if tar --version | grep -sq "bsdtar"; then
+-    IS_BSD_TAR="true"
+-fi
+-
 -EXCLUDES=""
 -excludelist=$(relevant_file excludes)
 -if [ -f "${excludelist}" ]; then
@@ -20,12 +25,12 @@
 -# is to use a function wrapper, but the latter can't be used here as the args
 -# are dynamic. We thus need to ignore the warning brought by shellcheck.
 -# shellcheck disable=SC2086
- if [ "${IS_BSD_TAR}" = "true" ]; then
+-if [ "${IS_BSD_TAR}" = "true" ]; then
 -  tar ${EXCLUDES} --numeric-owner -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
-+  tar --numeric-owner -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
- else
+-else
 -  tar --anchored ${EXCLUDES} --numeric-owner --xattrs-include='*' -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
-+  tar --numeric-owner --xattrs-include='*' -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
- fi
+-fi
++tar --absolute-names --numeric-owner --xattrs-include='*' -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
  
  mkdir -p "${LXC_ROOTFS}/dev/pts/"
+ 


### PR DESCRIPTION
This commit contains two fixes.

The first add gnu-tar as a dependency for lxc-create which is needed to properly extract the root file system tarball. Without it, symlink target of /bin/tar is busybox and it lacks proper support to extract with xattrs.  The default gnu-tar is actually built without this support as well, but it is able to extract the rootfs tarballs with a warning not an error which is not the case with busybox which ends in an error.

The second is a fix to 025-remove-unsupported-option.patch which both removes bsdtar command as it ends in errors, see below, and circumvents an error when extracting to overlayfs[1].

Error when extracting rootfs tarball with bsdtar:
```
tar --absolute-names --numeric-owner '--xattrs-include=*' -xpJf /var/cache/lxc//download/archlinux/current/amd64//default/rootfs.tar.xz -C /mnt/data/lxc/test/rootfs
./usr/bin/newgidmap: Cannot restore extended attributes on this system: Illegal byte sequence lxc-create: test: 
../src/lxc/lxccontainer.c: create_run_template: 1589 Failed to create container from template lxc-create: test: 
../src/lxc/tools/lxc_create.c: lxc_create_main: 318 Failed to create container test
```
1. https://github.com/openwrt/openwrt/issues/15888

Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne

Maintainer: @ratkaj @neheb 
