### PR TITLE
[23.05]xray-core: update to 1.8.17

### DIFF
--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-core
-PKG_VERSION:=1.8.16
+PKG_VERSION:=1.8.17
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/XTLS/Xray-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=61a96fba9ae18e91ea163f317a3641bca21fa744c214fb912270a3e6b7a8da6d
+PKG_HASH:=390745e9f8afbd1cd584344a34709f13b9465bb887c7a4f993696ee8cf706b83
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MPL-2.0


### PR DESCRIPTION
Maintainer: @1715173329
Compile tested: all supported targets
Run tested: rockchip/armv8

Description:
xray-core: Update to 1.8.17(cherry picked from commit https://github.com/openwrt/packages/commit/48ea7d33e169dee3513d4b3f22203b0b78df304c)
For more information, visit https://github.com/XTLS/Xray-core/compare/v1.8.16...v1.8.17