### PR TITLE
mpd: fix build with libfmt v11

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpd
 PKG_VERSION:=0.23.15
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.musicpd.org/download/mpd/0.23

--- a/sound/mpd/patches/040-lib-fmt-support-build-with-libfmt-11.0.0.patch
+++ b/sound/mpd/patches/040-lib-fmt-support-build-with-libfmt-11.0.0.patch
@@ -1,0 +1,72 @@
+From 1402869715e3efca87942d79c3173a6b21a6925d Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Fri, 5 Jul 2024 14:27:45 +0000
+Subject: [PATCH 1/1] lib/fmt: support build with libfmt-11.0.0
+
+Upstream libfmt commit fmtlib/fmt@d707292
+now requires the format function to be const.
+
+Adjust the function prototype so it is const and can compile.
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>
+---
+ src/lib/ffmpeg/LibFmt.hxx            | 2 +-
+ src/lib/fmt/AudioFormatFormatter.hxx | 4 ++--
+ src/lib/fmt/ExceptionFormatter.hxx   | 2 +-
+ src/lib/fmt/PathFormatter.hxx        | 2 +-
+ 4 files changed, 5 insertions(+), 5 deletions(-)
+
+--- a/src/lib/ffmpeg/LibFmt.hxx
++++ b/src/lib/ffmpeg/LibFmt.hxx
+@@ -29,7 +29,7 @@ template<>
+ struct fmt::formatter<AVSampleFormat> : formatter<string_view>
+ {
+ 	template<typename FormatContext>
+-	auto format(const AVSampleFormat format, FormatContext &ctx) {
++	auto format(const AVSampleFormat format, FormatContext &ctx) const {
+ 		const char *name = av_get_sample_fmt_name(format);
+ 		if (name == nullptr)
+ 			name = "?";
+--- a/src/lib/fmt/AudioFormatFormatter.hxx
++++ b/src/lib/fmt/AudioFormatFormatter.hxx
+@@ -39,7 +39,7 @@ template<>
+ struct fmt::formatter<SampleFormat> : formatter<string_view>
+ {
+ 	template<typename FormatContext>
+-	auto format(const SampleFormat format, FormatContext &ctx) {
++	auto format(const SampleFormat format, FormatContext &ctx) const {
+ 		return formatter<string_view>::format(sample_format_to_string(format),
+ 						      ctx);
+ 	}
+@@ -49,7 +49,7 @@ template<>
+ struct fmt::formatter<AudioFormat> : formatter<string_view>
+ {
+ 	template<typename FormatContext>
+-	auto format(const AudioFormat &af, FormatContext &ctx) {
++	auto format(const AudioFormat &af, FormatContext &ctx) const {
+ 		return formatter<string_view>::format(ToString(af).c_str(),
+ 						      ctx);
+ 	}
+--- a/src/lib/fmt/ExceptionFormatter.hxx
++++ b/src/lib/fmt/ExceptionFormatter.hxx
+@@ -38,7 +38,7 @@ template<>
+ struct fmt::formatter<std::exception_ptr> : formatter<string_view>
+ {
+ 	template<typename FormatContext>
+-	auto format(std::exception_ptr e, FormatContext &ctx) {
++	auto format(std::exception_ptr e, FormatContext &ctx) const {
+ 		return formatter<string_view>::format(GetFullMessage(e), ctx);
+ 	}
+ };
+--- a/src/lib/fmt/PathFormatter.hxx
++++ b/src/lib/fmt/PathFormatter.hxx
+@@ -29,7 +29,7 @@ template<>
+ struct fmt::formatter<Path> : formatter<string_view>
+ {
+ 	template<typename FormatContext>
+-	auto format(Path path, FormatContext &ctx) {
++	auto format(Path path, FormatContext &ctx) const {
+ 		return formatter<string_view>::format(path.ToUTF8(), ctx);
+ 	}
+ };


### PR DESCRIPTION
mpd fails to compile with libfmt v11 because of minor API changes in the library.

https://github.com/MusicPlayerDaemon/MPD/issues/2068

Maintainer: @neheb 
Compile tested: ARMv7 Processor rev 4 (v7l)
Run tested: ARMv7 Processor rev 4 (v7l)
