### PR TITLE
tailscale: Update to 1.68.2

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.58.2
+PKG_VERSION:=1.68.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=452f355408e4e2179872387a863387e06346fc8a6f9887821f9b8a072c6a5b0a
+PKG_HASH:=9d34bd153c485dd0d88d3d76f187b5032046c0807a411ca97f38c8039a9ac659
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Signed-off-by: Milinda Brantini <C_A_T_T_E_R_Y@outlook.com>
(cherry picked from commit bdae046c88e7017d9e92acd7b387a290a9b0d3af)

Maintainer: me

Description: Backported from master. Should fix #24570 and two CVEs.
