### PR TITLE
[23.05]dnsproxy: Update to 0.67.0

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.66.0
-PKG_RELEASE:=2
+PKG_VERSION:=0.67.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6928b109fb1080fec2aadc0cad20d0c08d13b5ff5db1a7c82ecfe200eec21326
+PKG_HASH:=885fc754fb3d204b51e1e069dad559ea1f771c855902803175387f2c0d5f0a82
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: @1715173329
Compile tested: all supported targets
Run tested: rockchip/armv8

Description:
dnsproxy: Update to 0.67.0(The last version supported by [go 1.21](https://github.com/AdguardTeam/dnsproxy/blob/v0.67.0/go.mod))

For more information, visit https://github.com/AdguardTeam/dnsproxy/compare/v0.66.0...v0.67.0