### PR TITLE
tree: bump to 2.1.3

### DIFF
--- a/utils/tree/Makefile
+++ b/utils/tree/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tree
-PKG_VERSION:=2.1.1
+PKG_VERSION:=2.1.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/Old-Man-Programmer/$(PKG_NAME)/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=1b70253994dca48a59d6ed99390132f4d55c486bf0658468f8520e7e63666a06
+PKG_HASH:=3ffe2c8bb21194b088ad1e723f0cf340dd434453c5ff9af6a38e0d47e0c2723b
 
 PKG_MAINTAINER:=Banglang Huang <banglang.huang@foxmail.com>
 


### PR DESCRIPTION
Changelog: version 2.1.3 (07/09/2024)
  - Mostly a brown-paper bag release to fix the below regression and add a feature I forgot to add.
  - Fix regression in search() function that broke --fromfile (Florian Ernst) (caused by removing too much code while fixing premature sort for --fromfile)
  - Allow the -L option to accept its parameter immediately (with no space) instead of requiring it be the next option word. (Trevor Gross)

Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne

Maintainer: @hbl0307106015
