### PR TITLE
perl-cgi: Update to 4.66

### DIFF
--- a/lang/perl-cgi/Makefile
+++ b/lang/perl-cgi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-cgi
-PKG_VERSION:=4.64
+PKG_VERSION:=4.66
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://www.cpan.org/authors/id/L/LE/LEEJO
 PKG_SOURCE:=CGI-$(PKG_VERSION).tar.gz
-PKG_HASH:=39bd8e40ce00cdab39e0a2bc71abd2bbe451d1d97bc7e54e41a2e199eb6226e7
+PKG_HASH:=4697437688a193e3f02556e1d223015590c1f2800b40becf83dc12d5cc5ed8e1
 PKG_BUILD_DIR:=$(BUILD_DIR)/perl/CGI-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>, \


### PR DESCRIPTION
Maintainer: me, @Naoir 
Compile tested: x86_64, generic, HEAD (5bf463bd9)
Run tested: same, installed on production router

Description:
