### PR TITLE
xray-core: update to 1.8.18

### DIFF
--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-core
-PKG_VERSION:=1.8.17
+PKG_VERSION:=1.8.18
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/XTLS/Xray-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=390745e9f8afbd1cd584344a34709f13b9465bb887c7a4f993696ee8cf706b83
+PKG_HASH:=088248fe9d06c0a8964b8815edc6099cb50a7fe2b36633681829097903470ac1
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MPL-2.0


### PR DESCRIPTION
Maintainer: @1715173329
Compile tested: all supported targets
Run tested: rockchip/armv8

Description:
Fixed Log_X_Inner functions, which had incorrect log severity.
Minimum required Golang version  downgraded to 1.21.4

For more information, visit https://github.com/XTLS/Xray-core/compare/v1.8.17...v1.8.18