### PR TITLE
lm-sensors: add fancontrol and pwmconfig scripts

### DIFF
--- a/utils/lm-sensors/Makefile
+++ b/utils/lm-sensors/Makefile
@@ -51,6 +51,14 @@ define Package/lm-sensors-detect
 	+PACKAGE_lm-sensors-detect:perlbase-xsloader
 endef
 
+define Package/fancontrol
+  $(call Package/lm-sensors/Default)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=fancontrol
+  DEPENDS+=+bash
+endef
+
 define Package/libsensors
   $(call Package/lm-sensors/Default)
   SECTION:=libs
@@ -65,6 +73,10 @@ endef
 
 define Package/lm-sensors-detect/description
  script to autodetect sensor hardware
+endef
+
+define Package/fancontrol/description
+ automated software based fan speed regulation
 endef
 
 define Package/libsensors/description
@@ -118,6 +130,18 @@ define Package/lm-sensors-detect/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/prog/detect/sensors-detect $(1)/usr/sbin
 endef
 
+define Package/fancontrol/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/prog/pwm/fancontrol $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/prog/pwm/pwmconfig  $(1)/usr/sbin
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/fancontrol.init $(1)/etc/init.d/fancontrol
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/fancontrol.config $(1)/etc/config/fancontrol
+endef
+
 define Package/libsensors/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_BUILD_DIR)/lib/libsensors.so* $(1)/usr/lib
@@ -126,3 +150,4 @@ endef
 $(eval $(call BuildPackage,libsensors))
 $(eval $(call BuildPackage,lm-sensors))
 $(eval $(call BuildPackage,lm-sensors-detect))
+$(eval $(call BuildPackage,fancontrol))

--- a/utils/lm-sensors/files/fancontrol.config
+++ b/utils/lm-sensors/files/fancontrol.config
@@ -1,0 +1,57 @@
+
+config fancontrol 'common'
+	# Defines at which interval in seconds fancontrol should wake up
+	option interval		'10'
+
+	# Optional, fancontrol won't start if set to 1 (default: 0)
+	option disabled		'1'
+
+
+# fancontrol uses this to check that the configuration is still up-to-date
+config device 'hwmon0'
+	# Can be retrieved via "cat /sys/class/hwmon/hwmon*/name"
+	option name		'coretemp'
+
+	# Can be retrieved via "readlink -f /sys/class/hwmon/hwmon*/device | sed -e 's/^\/sys\///'"
+	option path		'devices/platform/coretemp.0'
+
+config device 'hwmon4'
+	option name		'mlxsw'
+	option path		'devices/pci0000:00/0000:00:01.0/0000:01:00.0'
+
+
+config control
+	# The fan's PWM output file
+	option pwm		'hwmon4/pwm1'
+
+	# The sensor's temperature input file
+	option temp		'hwmon0/temp2_input'
+
+	# The temperature below which the fan gets switched to minimum speed
+	option min_temp 	'20'
+
+	# The temperature over which the fan gets switched to maximum speed
+	option max_temp 	'60'
+
+	# The minimum PWM value at which the fan begins spinning
+	option min_start 	'150'
+
+	# The minimum PWM value at which the fan still spins
+	option min_stop 	'100'
+
+	# Optional, the fan's speed input file
+	# fancontrol can check the fan speed and restart it if it stops unexpectedly
+	option fan		'hwmon4/fan4_input'
+
+	# Optional, the PWM value to use when the temperature is below min_temp (default: 0)
+	option min_pwm		'0'
+
+	# Optional, the PWM value to use when the temperature is over max_temp (default: 255)
+	option max_pwm		'255'
+
+	# Optional, how many last temperature readings are used to average the temperature (default: 1 -> no averaging)
+	option average		'1'
+
+	# Optional, disables this section (default: 0)
+	option disabled		'0'
+

--- a/utils/lm-sensors/files/fancontrol.init
+++ b/utils/lm-sensors/files/fancontrol.init
@@ -1,0 +1,160 @@
+#!/bin/sh /etc/rc.common
+
+START=97
+USE_PROCD=1
+
+NAME=fancontrol
+PROG=/usr/sbin/$NAME
+
+CONF_DIR=/var/etc
+CONF_FILE=$CONF_DIR/$NAME
+
+create_config() {
+	echo "INTERVAL=$INTERVAL"
+	echo "DEVPATH=$DEVPATH"
+	echo "DEVNAME=$DEVNAME"
+	echo "FCTEMPS=$FCTEMPS"
+
+	[ -n "$FCFANS" ] && \
+		echo "FCFANS=$FCFANS"
+
+	echo "MINTEMP=$MINTEMP"
+	echo "MAXTEMP=$MAXTEMP"
+	echo "MINSTART=$MINSTART"
+	echo "MINSTOP=$MINSTOP"
+
+	[ -n "$MINPWM" ] && \
+		echo "MINPWM=$MINPWM"
+
+	[ -n "$MAXPWM" ] && \
+		echo "MAXPWM=$MAXPWM"
+
+	[ -n "$AVERAGE" ] && \
+		echo "AVERAGE=$AVERAGE"
+
+	return 0
+}
+
+parse_device() {
+	local config="$1"
+	local name path
+
+	config_get name "$config" "name"
+	if [ -z "$name" ]; then
+		echo "Missing device name for $config"
+		return
+	fi
+
+	config_get path "$config" "path"
+	if [ -z "$path" ]; then
+		echo "Missing device path for $name"
+		return
+	fi
+
+	append DEVNAME "$config=$name"
+	append DEVPATH "$config=$path"
+}
+
+parse_control() {
+	local config="$1"
+	local pwm temp fan
+	local min_temp max_temp
+	local min_start min_stop
+	local min_pwm max_pwm
+	local average disabled
+
+	config_get_bool disabled "$config" "disabled" 0
+	[ $disabled -eq 1 ] && return
+
+	config_get pwm "$config" "pwm"
+	if [ -z "$pwm" ]; then
+		echo "Missing PWM file for $config"
+		return
+	fi
+
+	config_get temp "$config" "temp"
+	if [ -z "$temp" ]; then
+		echo "Missing temperature file for $pwm"
+		return
+	fi
+
+	config_get min_temp "$config" "min_temp"
+	if [ -z "$min_temp" ]; then
+		echo "Missing minimum temperature for $pwm"
+		return
+	fi
+
+	config_get max_temp "$config" "max_temp"
+	if [ -z "$max_temp" ]; then
+		echo "Missing maximum temperature for $pwm"
+		return
+	fi
+
+	config_get min_start "$config" "min_start"
+	if [ -z "$min_start" ]; then
+		echo "Missing PWM fan start value for $pwm"
+		return
+	fi
+
+	config_get min_stop "$config" "min_stop"
+	if [ -z "$min_stop" ]; then
+		echo "Missing PWM fan stop value for $pwm"
+		return
+	fi
+
+	config_get fan "$config" "fan"
+	config_get min_pwm "$config" "min_pwm"
+	config_get max_pwm "$config" "max_pwm"
+	config_get average "$config" "average"
+
+	append FCTEMPS  "$pwm=$temp"
+	append MINTEMP  "$pwm=$min_temp"
+	append MAXTEMP  "$pwm=$max_temp"
+	append MINSTART "$pwm=$min_start"
+	append MINSTOP  "$pwm=$min_stop"
+
+	[ -n "$fan" ]     && append FCFANS  "$pwm=$fan"
+	[ -n "$min_pwm" ] && append MINPWM  "$pwm=$min_pwm"
+	[ -n "$max_pwm" ] && append MAXPWM  "$pwm=$max_pwm"
+	[ -n "$average" ] && append AVERAGE "$pwm=$average"
+}
+
+parse_config() {
+	config_get INTERVAL "common" "interval"
+	if [ -z "$INTERVAL" ]; then
+		echo "Missing interval in common section"
+		return 1
+	fi
+
+	config_foreach parse_device "device"
+	if [ -z "$DEVNAME" ]; then
+		echo "At least one device section is required"
+		return 1
+	fi
+
+	config_foreach parse_control "control"
+	if [ -z "$FCTEMPS" ]; then
+		echo "At least one control section is required"
+		return 1
+	fi
+
+	mkdir -p $CONF_DIR
+	create_config > $CONF_FILE || return 1
+
+	return 0
+}
+
+start_service() {
+	local disabled
+	config_load $NAME
+
+	config_get_bool disabled "common" "disabled" 0
+	[ $disabled -eq 1 ] && return 0
+
+	parse_config || return 1
+
+	procd_open_instance
+	procd_set_param command $PROG $CONF_FILE
+	procd_set_param file $CONF_FILE
+	procd_close_instance
+}


### PR DESCRIPTION
Maintainer: @jow-
Compile tested: x86_64, OpenWrt trunk
Run tested: x86_64, OpenWrt trunk, tests done

<br>
Description:
<br><br>

This PR adds:
- The `fancontrol` bash script from `lm-sensors`, which automatically regulates the system's fan speeds
- The `pwmconfig` bash script from `lm-sensors`, which lets you interactively create a configuration file for `fancontrol`
- A procd init script to parse the UCI configuration file, convert it to the `fancontrol` configuration file, and manage the `fancontrol` service
- An example UCI configuration file for `fancontrol`
<br>

It would be nice if the configuration file created by `pwmconfig` is automatically converted into a UCI configuration. But I am currently unsure which is the best way to do so (maybe writing a script or an init script for `pwmconfig`?).