### PR TITLE
tailscale: Update to 1.70.0

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.68.2
+PKG_VERSION:=1.70.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=9d34bd153c485dd0d88d3d76f187b5032046c0807a411ca97f38c8039a9ac659
+PKG_HASH:=8429728708f9694534489daa0a30af58be67f25742597940e7613793275c738f
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: @ja-pa
Compile tested: rockchip/armv8
Run tested: N/A

Description:
New: Restrict [recommended](https://tailscale.com/kb/1392/auto-exit-nodes) and automatically selected exit nodes using the new AllowedSuggestedExitNodes [system policy](https://tailscale.com/kb/1315/mdm-keys). Applies only to platforms that support [system policies](https://tailscale.com/kb/1315/mdm-keys).
Changed: Improved [NAT traversal](https://tailscale.com/blog/how-nat-traversal-works) for some uncommon scenarios.
Changed: Optimized [sending firewall rules to clients](https://tailscale.com/kb/1018/acls) more efficiently.
Fixed: [Exit node suggestion](https://tailscale.com/kb/1392/auto-exit-nodes) CLI command now prints the hostname (which you can use with the [tailscale set](https://tailscale.com/kb/1080/cli#set) command).
Fixed: [Taildrive](https://tailscale.com/kb/1369/taildrive) share paths configured through the CLI resolve relative to where you run the tailscale command.
Fixed: Switching from unstable to stable tracks using the [tailscale update](https://github.com/tailscale.com/kb/1080/cli#update) command now works correctly.

For more information, visit https://github.com/tailscale/tailscale/compare/v1.68.2...v1.70.0