### PR TITLE
stress-ng: bump to version 0.18.01

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.17.08
+PKG_VERSION:=0.18.01
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ColinIanKing/stress-ng/tar.gz/refs/tags/V$(PKG_VERSION)?
-PKG_HASH:=e4982d2a1c57139dad1741d6248b00a30935f746c1f665ec5b9d53c010c8dc08
+PKG_HASH:=30465ee60a32d9018d0de8a78cfeaa576e869b6e6db87e3628d0704dbe61b561
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: x86  https://github.com/openwrt/openwrt/commit/d92c42f46990db232c163e20a05c7443d9efd2e1
Run tested:  x86  https://github.com/openwrt/openwrt/commit/d92c42f46990db232c163e20a05c7443d9efd2e1