### PR TITLE
openvpn: update to 2.6.12

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.6.11
-PKG_RELEASE:=2
+PKG_VERSION:=2.6.12
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=d60adf413d37e11e6e63531cacf2655906756046b4edffe88a13b9e2fec40d5e
+PKG_HASH:=1c610fddeb686e34f1367c347e027e418e07523a10f4d8ce4a2c2af2f61a1929
 
 PKG_MAINTAINER:=
 


### PR DESCRIPTION
Maintainer: @neheb @AuthorReflex
Compile tested: ramips/mt7621, ramips/mt7620,  ramips/mt76x8
Run tested: Xiaomi Mi router 3 pro, Xiaomi Mi router R3, TP-Link MR-3020 v3

Buugfix release. Bug fixes:

 - the fix for CVE-2024-5594 (refuse control channel messages with nonprintable characters) was too strict, breaking user configurations with AUTH_FAIL messages having trailing CR/NL characters. This often happens if the AUTH_FAIL reason is set by a script.

 - Http-proxy: fix bug preventing proxy credentials caching

For details refer to https://github.com/OpenVPN/openvpn/blob/v2.6.12/Changes.rst