### PR TITLE
[23.05]automake: update to 1.16.5

### DIFF
--- a/devel/automake/Makefile
+++ b/devel/automake/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=automake
-PKG_VERSION:=1.16.3
+PKG_VERSION:=1.16.5
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@GNU/automake
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=ff2bf7656c4d1c6fdda3b8bebb21f09153a736bcba169aaf65eab25fa113bf3a
+PKG_HASH:=f01d58cd6d9d77fbdca9eb4bbd5ead1988228fdb73d6f7a201f5f8d6b118b469
 
 PKG_MAINTAINER:=Heinrich Schuchardt <xypron.glpk@gmx.de>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: @xypron
Compile tested: all supported targets
Run tested: N/A

Description:
automake: update to 1.16.5(cherry picked from commit https://github.com/openwrt/packages/commit/2bcd9a4cd7d8d5fd2c2a25fb18f5e0ec605c335c)