### PR TITLE
[23.05]autoconf: update to 2.72

### DIFF
--- a/devel/autoconf/Makefile
+++ b/devel/autoconf/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=autoconf
-PKG_VERSION:=2.70
-PKG_RELEASE:=2
+PKG_VERSION:=2.72
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@GNU/autoconf
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=fa9e227860d9d845c0a07f63b88c8d7a2ae1aa2345fb619384bb8accc19fecc6
+PKG_HASH:=ba885c1319578d6c94d46e9b0dceb4014caafe2490e437a0dbca3f270a223f5a
 
 PKG_MAINTAINER:=Heinrich Schuchardt <xypron.glpk@gmx.de>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
Maintainer: @xypron
Compile tested: all supported targets
Run tested: N/A

Description:
autoconf: update to 2.72(cherry picked from commit https://github.com/openwrt/packages/commit/90d316b4286986192fc38bd064e138c336d8960c)