### PR TITLE
netbird: update to 0.28.6

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.28.4
+PKG_VERSION:=0.28.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=f2133123f364c23ed53a1316e7bf493aa71f36d31838c1ec71b91d863065b667
+PKG_HASH:=d5693c18641e5446c546ac53cecba5d12b33cc7eb56adac90a3c0fbe34b5762c
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## Compile and run tested

Maintainer: Oskari Rauta / @oskarirauta

| Package architecture | Target | Subtarget | Brand | Model | Hardware Version | OpenWrt version |
|----------------------|--------|-----------|-------|-------|------------------|-----------------|
| [x86_64](https://openwrt.org/docs/techref/instructionset/x86_64) | [x86](https://openwrt.org/docs/techref/targets/x86) | 64 | [Duex](https://duex.com.br/) | [DX B75ZG M.2 Intel LGA 1155 DDR3](https://duex.com.br/produto/placa-mae-dx-b75zg-m-2-intel-lga-1155-ddr3/) | n/a | OpenWrt SNAPSHOT r26990-06b37a5856<br/> ~OpenWrt SNAPSHOT r26969-715634e6d1~ |

## Description

- Changelog:
  - [v0.28.6](https://github.com/netbirdio/netbird/releases/tag/v0.28.6)
  - [v0.28.5](https://github.com/netbirdio/netbird/releases/tag/v0.28.5)
- Full changelog: https://github.com/netbirdio/netbird/compare/v0.28.4...v0.28.6

## Additional information

`x86_64` running as container with [`incus`](https://github.com/lxc/incus).
Compiled package with container [`sdk`](https://github.com/openwrt/docker), and build `openwrt` image with container [`imagebuilder`](https://github.com/openwrt/docker).

My repo with my automated build can be see here:
- https://github.com/wehagy/openwrt-builder

And my artifacts here:
- https://github.com/wehagy/openwrt-builder/actions/runs/10053678191