### PR TITLE
[23.05] boost: fix GCC options in Makefile

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -384,12 +384,10 @@ TARGET_LDFLAGS += -pthread -lrt -lstdc++ -Wl,--as-needed,--print-gc-sections
 TARGET_CFLAGS += \
 	$(if $(CONFIG_SOFT_FLOAT),-DBOOST_NO_FENV_H) -fPIC
 
-ifeq ($(word 1,$(subst ., ,$(call qstrip,$(CONFIG_GCC_VERSION)))),5)
-    EXTRA_CXXFLAGS += -std=gnu++14
-else ifneq ($(filter-out 6 7 8 9,$(word 1,$(subst ., ,$(call qstrip,$(CONFIG_GCC_VERSION))))),)
-    EXTRA_CXXFLAGS += -std=gnu++17
-else
+ifeq ($(word 1,$(subst ., ,$(call qstrip,$(CONFIG_GCC_VERSION)))),11)
     EXTRA_CXXFLAGS += -std=gnu++20
+else
+    EXTRA_CXXFLAGS += -std=gnu++23
 endif
 
 ifneq ($(findstring mips,$(ARCH)),)


### PR DESCRIPTION
Maintainer: @ClaymorePT 
Compile tested: mvebu, Turris Omnia, Turris OS 8 = OpenWrt 23.05
Run tested: mvebu, Turris Omnia, Turris OS 8 = OpenWrt 23.05, it runs

Description:
Using the filter-out function in the Makefile, the GCC version 6,7,8 and 9 fell to `-std=gnu++20` even though this option can be used just with GCC >=10. The GCC version 8 and 9 do support C++20, but needs to be used as `-std=gnu++2a`.

Ref:
- https://gcc.gnu.org/projects/cxx-status.html#cxx20