### PR TITLE
ddns-scripts: fix reload logic to avoid duplicate updater instances

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=46
+PKG_RELEASE:=47
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -1244,7 +1244,7 @@ trap_handler() {
 			fi ;;
 		 1)	write_log 6 "PID '$$' received 'SIGHUP' at $(eval $DATE_PROG)"
 			# reload config via starting the script again
-			/usr/lib/ddns/dynamic_dns_updater.sh -v "0" -S "$__SECTIONID" -- start || true
+			/usr/lib/ddns/dynamic_dns_updater.sh -v "0" -S "$SECTION_ID" -- start &
 			exit 0 ;;	# and leave this one
 		 2)	write_log 5 "PID '$$' terminated by 'SIGINT' at $(eval $DATE_PROG)${N}";;
 		 3)	write_log 5 "PID '$$' terminated by 'SIGQUIT' at $(eval $DATE_PROG)${N}";;

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
@@ -89,7 +89,7 @@ case "$1" in
 		exit 1
 		;;
 	reload)
-		killall dynamic_dns_updater.sh 2>/dev/null
+		killall -1 dynamic_dns_updater.sh 2>/dev/null
 		exit $?
 		;;
 	*)	usage_err "unknown command - $1";;


### PR DESCRIPTION
I believe this is the correct fix to #23135. I am not sure if there is a particularly good reason why the updater has separate reload logic, rather than just restarting - possibly to preserve settings passed on the command line?

Anyway: when starting new instance as a result of reload
-  use global variable to get section ID, as there is no access to locals from the trap handler
-  start the new instance in the background so the old one can exit

**Explanation**: The cause of the #23135 seems to have been that passing a blank section ID when respawning the script caused it start a new instance for every section. Given the original reload action would have sent a HUP to multiple running instances, I think this causes a slow but exponential explosion in running processes, which may be why I've been seeing my router crash! There's also in some circumstances stuck original processes caused by not backgrounding the new ones.

Seems to work here, where I have three ddns sections.

This PR reverts the previous fix in a separate commit, and also bumps the version. Feel free to hack it about into whatever form is most appropriate for OpenWRT PRs!

Fixes: #23135.