### PR TITLE
docker: Update to 27.1.0

### DIFF
--- a/utils/containerd/Makefile
+++ b/utils/containerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=containerd
-PKG_VERSION:=1.7.18
+PKG_VERSION:=1.7.20
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -9,7 +9,7 @@ PKG_CPE_ID:=cpe:/a:linuxfoundation:containerd
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containerd/containerd/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=91685cebd50e3f353a402adadf61e2a6aeda3f63754fa0fcc978a043e00acac4
+PKG_HASH:=c4268561e514a2e8322bc8cdd39113d5e164fb31c2cef76f479d683395ea9bd6
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker
-PKG_VERSION:=27.0.3
+PKG_VERSION:=27.1.0
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/docker/cli
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=f992e895c949852686abef9a6fa9efd622826c4f4d70b83876569a4641c4c8fc
-PKG_GIT_SHORT_COMMIT:=7d4bcd8 # SHA1 used within the docker executables
+PKG_HASH:=8e58a2e419ba91ce1a27831c394bf214f7076758f55eccc6762b5265bec58b9f
+PKG_GIT_SHORT_COMMIT:=6312585 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=27.0.3
-PKG_RELEASE:=2
+PKG_VERSION:=27.1.0
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=db02d9b5d98e85284538d6ead43b549c025acf937e98c09d18395bb331c1e607
-PKG_GIT_SHORT_COMMIT:=662f78c # SHA1 used within the docker executables
+PKG_HASH:=8bb11443dc86c712daeb37135f2db54bfede368a84ebdf950d6adffd90c162d7
+PKG_GIT_SHORT_COMMIT:=a21b1a2 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: all supported targets
Run tested: N/A

Description:
**containerd: Update to 1.7.20**
Fix support for OTLP config
Add API go module
Remove overlayfs volatile option on temp mounts
Update runc binary to v1.1.13
Migrate platforms package to github.com/containerd/platforms
Migrate reference/docker package to github.com/distribution/reference
Fix panic in NRI from nil CRI reference
Support for dropping inheritable capabilities
Make PodSandboxStatus friendlier to shim crashes
Handle empty DNSConfig differently than unspecified
Fix for [cri] ttrpc: closed during ListPodSandboxStats
_For more information, visit https://github.com/containerd/containerd/compare/v1.7.18...v1.7.20_

**docker: Update to 27.1.0**
_For more information, visit https://github.com/docker/cli/compare/v27.0.3...v27.1.0_

**dockerd: Update to 27.1.0**
rootless: add Requires=dbus.socket to prevent errors when starting the daemon on a cgroup v2 host with systemd
containerd integration: image tag event is now properly emitted when building images with Buildkit
cli: add OOMScoreAdj to docker service create and docker stack
cli: add support for DOCKER_CUSTOM_HEADERS env-var (experimental)
cli: containerd-integration: Fix docker push defaulting the --platform flag to a value of DOCKER_DEFAULT_PLATFORM environment variable on unsupported API versions
cli: fix: ctx cancellation on login prompt
cli: fix: wait for the container to exit before closing the stream when sending a termination request to the CLI while attached to a container
_For more information, visit https://github.com/moby/moby/compare/v27.0.3...v27.1.0_