### PR TITLE
atlas-sw-probe: tweak SSH key permissions

### DIFF
--- a/net/atlas-sw-probe/Makefile
+++ b/net/atlas-sw-probe/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=atlas-sw-probe
 PKG_VERSION:=5080
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/RIPE-NCC/ripe-atlas-software-probe.git

--- a/net/atlas-sw-probe/files/atlas.init
+++ b/net/atlas-sw-probe/files/atlas.init
@@ -102,10 +102,9 @@ create_key() {
 	[ -f $PRIV_KEY_FILE ] || ln -s $probe_key $PRIV_KEY_FILE
 	[ -f $PUB_KEY_FILE ] || ln -s $probe_pub_key $PUB_KEY_FILE
 
-	#Fix permission
-	chown atlas $probe_key $probe_pub_key
-	chgrp atlas $probe_key $probe_pub_key
-	chmod 644 $probe_key $probe_pub_key
+	#Fix permissions in case keys were generated using dropbearkey/dropbearconvert
+	chmod 600 $probe_key
+	chmod 644 $probe_pub_key
 
 	print_msg "Key generated successfully. Use the get_key command to show the public key and get instruction on how to register your probe."
 }


### PR DESCRIPTION
Do not run `chown` or `chgrp` for probe key files since the probe scripts are run as root anyway.

Do not run `chmod 644` for `/etc/atlas/probe_key` since an SSH private key should not be readable by any user except the owner.

Maintainer: @ja-pa
Cc: @Ansuel (author of 0afe371babf851d1ce239c75525e99bcef3626d0, see #15488)

---

Perhaps I am missing something obvious, but the efforts that the init script makes to `chown atlas:atlas` various files is puzzling to me, given that upstream scripts do not seem to be designed for running as any user other than root (there are e.g. [writes to hard-coded paths that are only writable by root](https://github.com/RIPE-NCC/ripe-atlas-software-probe/blob/5090/bin/arch/openwrt-sw-probe/openwrt-sw-probe-common.sh#L17).  (The `atlas` user is created by the `atlas-probe` package.)

In fact, if the SSH key files were owned by root in the first place, `ssh` itself would [detect](https://github.com/openssh/openssh-portable/blob/V_9_8/authfile.c#L104-L113) that the permissions set for them by the init script are too open.  However, that check is only triggered if the user that `ssh` is run as is the same as the user owning the key file.  (In this case, that's `root` vs. `atlas`, so the 644 mode set for the private key does not prevent `ssh` from working.)

This PR attempts to ensure that file modes are set identical no matter whether `ssh-keygen` or `dropbearkey`/`dropbearconvert` are used for generating the probe keys.
