### PR TITLE
knot: update to version 3.3.8

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.3.7
+PKG_VERSION:=3.3.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=18ceb398578342e9a3d5b75f2423945a2f8d1d7c730f24f4d2aa4a24b50e831d
+PKG_HASH:=498de8338489a625673797f7ecc921fa4490c826afbfa42fa66922b525089e6a
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8

--- a/net/knot/patches/01_zscanner_tests.patch
+++ b/net/knot/patches/01_zscanner_tests.patch
@@ -19,5 +19,5 @@
 -ZSCANNER_TOOL="$BUILD"/zscanner-tool
 +ZSCANNER_TOOL="$SOURCE"/zscanner-tool
  
- plan 86
+ plan 87
  


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 	8.0.0 (hbd)
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 	8.0.0 (hbd)

Description:

- Release upgrade (https://www.knot-dns.cz/2024-07-22-version-338.html)