### PR TITLE
net-snmp: set hostname as sysname

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.9.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp

--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -24,12 +24,15 @@ snmpd_agentx_add() {
 
 snmpd_system_add() {
 	local cfg="$1"
+	local hostname
+
 	config_get syslocation "$cfg" sysLocation
 	[ -n "$syslocation" ] && echo "sysLocation $syslocation" >> $CONFIGFILE
 	config_get syscontact "$cfg" sysContact
 	[ -n "$syscontact" ] && echo "sysContact $syscontact" >> $CONFIGFILE
 	config_get sysname "$cfg" sysName
 	[ -n "$sysname" ] && echo "sysName $sysname" >> $CONFIGFILE
+	[ -z "$sysname" ] && hostname=$(uci_get system.@system[0].hostname) && echo "sysName $hostname" >> $CONFIGFILE
 	config_get sysservice "$cfg" sysService
 	[ -n "$sysservice" ] && echo "sysService $sysservice" >> $CONFIGFILE
 	config_get sysdescr "$cfg" sysDescr


### PR DESCRIPTION
Maintainer: @stintel 
Compile tested: x86_64, OpenWrt = 23.05
Run tested: x86_64, OpenWrt = 23.05

Description:

This commit writes the option `hostname` obtained via `uci_get system.@system[0].hostname`  to the `snmpd.conf` file if  `sysName` is not defined in `/etc/config/snmpd`.