### PR TITLE
packages/v4l2rtspserver: Update Makefile to support ALSA by default

### DIFF
--- a/multimedia/v4l2rtspserver/Makefile
+++ b/multimedia/v4l2rtspserver/Makefile
@@ -33,7 +33,7 @@ define Package/v4l2rtspserver
 	SECTION:=multimedia
 	CATEGORY:=Multimedia
 	TITLE:=v4l2rtspserver
-	DEPENDS:=+libstdcpp
+	DEPENDS:=+libstdcpp +alsa-lib
 	URL:=https://github.com/mpromonet/v4l2rtspserver
 endef
 
@@ -54,7 +54,7 @@ endef
 TARGET_LDFLAGS += -Wl,--as-needed
 
 CMAKE_OPTIONS += \
-	-DALSA=OFF \
+	-DALSA=ON \
 	-DSTATICSTDCPP=OFF \
 	-DWITH_SSL=OFF \
 	-DLIVE555CFLAGS="SOCKLEN_T=socklen_t;_LARGEFILE_SOURCE=1;_FILE_OFFSET_BITS=64;LOCALE_NOT_USED;NO_SSTREAM=1;ALLOW_RTSP_SERVER_PORT_REUSE=1;NO_STD_LIB=1;VERSION=\"$(PKG_VERSION)\""


### PR DESCRIPTION
Description:
Added default ALSA support, as (I believe) most folks that are streaming RTSP video would probably appreciate the audio stream as well.  Added +alsa-lib to the DEPENDS
Changed CMAKE_OPTIONS [-DALSA] to ON

Tested on a local build environment and deployed to a Marvell device; working fine.

Maintainer: me / @mpromonet
Compile tested: (armv5, marvell-kirkwood-popoplugv4, OpenWrt 23.05.3)
Run tested: (armv5, marvell-kirkwood-generic, OpenWrt 23.05.3, ran with various ALSA input devices and verified audio with a remote VLC RTSP stream)