### PR TITLE
[23.05]xray-core: update to 1.8.21

### DIFF
--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-core
-PKG_VERSION:=1.8.20
+PKG_VERSION:=1.8.21
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/XTLS/Xray-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=602b04dc305086c3a1206395858e4eff6ccdffc799556521f1d830b3bc715fbc
+PKG_HASH:=464636c323c20cd17a6e10d6fdf0120f0a84096f1c66c0ab4851141d238a1a0b
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MPL-2.0


### PR DESCRIPTION
Maintainer: @1715173329
Compile tested: all supported targets
Run tested: rockchip/armv8

Description:
xray-core: update to 1.8.21(cherry picked from commit https://github.com/openwrt/packages/commit/ebeeafb99630ea54bd9a14ab0484f213218028aa)

For more information, visit https://github.com/XTLS/Xray-core/compare/v1.8.20...v1.8.21