### PR TITLE
docker: Update to 27.1.1

### DIFF
--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker
-PKG_VERSION:=27.1.0
+PKG_VERSION:=27.1.1
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,7 +10,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/docker/cli
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=8e58a2e419ba91ce1a27831c394bf214f7076758f55eccc6762b5265bec58b9f
+PKG_HASH:=84db222b6d65695f3d8ae02acf8f21d90fb3f2169754bb94d314864c37bac7f3
 PKG_GIT_SHORT_COMMIT:=6312585 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=27.1.0
+PKG_VERSION:=27.1.1
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=8bb11443dc86c712daeb37135f2db54bfede368a84ebdf950d6adffd90c162d7
-PKG_GIT_SHORT_COMMIT:=a21b1a2 # SHA1 used within the docker executables
+PKG_HASH:=d8afaa4513d324db5841ced641daeee9090802c765b78f1c583bc171e9b0a6fd
+PKG_GIT_SHORT_COMMIT:=cc13f95 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: all supported targets
Run tested: N/A

Description:
**docker: Update to 27.1.1**
_For more information, visit https://github.com/docker/cli/compare/v27.1.0...v27.1.1_

**dockerd: Update to 27.1.1**
This release contains a fix for [CVE-2024-41110](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-41110) / [GHSA-v23v-6jw2-98fq](https://github.com/moby/moby/security/advisories/GHSA-v23v-6jw2-98fq)
that impacted setups using [authorization plugins (AuthZ)](https://docs.docker.com/engine/extend/plugins_authorization/)
for access control. No other changes are included in this release, and this
release is otherwise identical for users not using AuthZ plugins.
_For more information, visit https://github.com/moby/moby/compare/v27.1.0...v27.1.1_