### PR TITLE
[22.03] openssh: fix build for older GCC versions

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -179,9 +179,13 @@ CONFIGURE_ARGS += \
 	--without-kerberos5 \
 	--with-stackprotect \
 	--with$(if $(CONFIG_OPENSSL_ENGINE),,out)-ssl-engine \
-	--with$(if $(CONFIG_OPENSSH_LIBFIDO2),,out)-security-key-builtin \
+	--with$(if $(CONFIG_OPENSSH_LIBFIDO2),,out)-security-key-builtin
+
+ifeq ($(CONFIG_GCC_USE_VERSION_11),y)
+CONFIGURE_ARGS += \
 	--with-cflags-after=-fzero-call-used-regs=skip
-	
+endif
+
 ifeq ($(BUILD_VARIANT),with-pam)
 CONFIGURE_ARGS += \
 	--with-pam


### PR DESCRIPTION
Maintainer: @neheb 
Compile tested: mvebu, Turris Omnia, Turris OS 7 = OpenWrt 22.03
Run tested: mvebu, Turris Omnia, Turris OS 7 = OpenWrt 22.03, it runs

Description:
Recently added option is not available in older versions of GCC causing the following error during the build:

- error: unrecognized command line option '-fzero-call-used-regs=skip'

The error arose with GCC 8 and 10. With this fix compilation ended successfully.