### PR TITLE
c-ares: update to 1.32.3

### DIFF
--- a/libs/c-ares/Makefile
+++ b/libs/c-ares/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=c-ares
-PKG_VERSION:=1.29.0
+PKG_VERSION:=1.32.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://c-ares.org/download
-PKG_HASH:=0b89fa425b825c4c7bc708494f374ae69340e4d1fdc64523bdbb2750bfc02ea7
+PKG_SOURCE_URL:=https://github.com/c-ares/c-ares/releases/download/v$(PKG_VERSION)
+PKG_HASH:=5f02cc809aac3f6cc5edc1fac6c4423fd5616d7406ce47b904c24adf0ff2cd0f
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.md


### PR DESCRIPTION
Maintainer: @karlp 
Compile tested: arm_cortex-a9_neon, GCC 14, LTO
Run tested: WRT3200ACM

Description:
- Use up-to-date source URL

