### PR TITLE
ruby: update to 3.3.4

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=3.3.3
+PKG_VERSION:=3.3.4
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=83c05b2177ee9c335b631b29b8c077b4770166d02fa527f3a9f6a40d13f3cce2
+PKG_HASH:=fe6a30f97d54e029768f2ddf4923699c416cdbc3a6e96db3e2d5716c7db96a34
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Ruby 3.3.4 fixes a regression in Ruby 3.3.3 that dependencies are missing in the gemspec of some bundled gems: net-pop, net-ftp, net-imap, and prime. The fix allows Bundler to successfully install those gems on platforms like Heroku. If your bundle install runs correctly now, you may not have this issue. Other changes are mostly minor bug fixes.

See: https://www.ruby-lang.org/en/news/2024/07/09/ruby-3-3-4-released/

Maintainer: me
Compile tested: current main in x86/64
Run tested: current main in x86/64 checking dependencies