### PR TITLE
rsyslog: update to 8.2406.0

### DIFF
--- a/admin/rsyslog/Makefile
+++ b/admin/rsyslog/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsyslog
-PKG_VERSION:=8.2312.0
+PKG_VERSION:=8.2406.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	https://fossies.org/linux/misc \
 	https://www.rsyslog.com/files/download/rsyslog
-PKG_HASH:=774032006128a896437f5913e132aa27dbfb937cd8847e449522d5a12d63d03e
+PKG_HASH:=1343e0269dd32166ffde04d7ceebfa0e7146cf1dbc6962c56bf428c61f01a7df
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
Maintainer: N/A
Compile tested: arm_cortex-a9_neon, GCC 14, LTO
Run tested: WRT3200ACM