### PR TITLE
swig: update to 4.2.1

### DIFF
--- a/utils/swig/Makefile
+++ b/utils/swig/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=swig
-PKG_VERSION:=4.2.0
+PKG_VERSION:=4.2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
-PKG_HASH:=261ca2d7589e260762817b912c075831572b72ff2717942f75b3e51244829c97
+PKG_HASH:=fa045354e2d048b2cddc69579e4256245d4676894858fcf0bab2290ecf59b7d8
 
 PKG_MAINTAINER:=John Crispin <blogic@openwrt.org>, Hirokazu MORIKAWA <morikw2@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -29,7 +29,7 @@ define Package/swig
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=swig binding generator
-  URL:=http://swig.org/
+  URL:=https://swig.org/
   BUILDONLY:=1
 endef
 


### PR DESCRIPTION
Maintainer: @blogic @nxhack 
Compile tested: arm_cortex-a9_neon, GCC 14 - python-selinux builds all right

Description:
- Switch package URL to HTTPS
