### PR TITLE
[23.05]docker: Update to 27.1.1

### DIFF
--- a/utils/containerd/Makefile
+++ b/utils/containerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=containerd
-PKG_VERSION:=1.7.18
+PKG_VERSION:=1.7.20
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -9,7 +9,7 @@ PKG_CPE_ID:=cpe:/a:linuxfoundation:containerd
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containerd/containerd/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=91685cebd50e3f353a402adadf61e2a6aeda3f63754fa0fcc978a043e00acac4
+PKG_HASH:=c4268561e514a2e8322bc8cdd39113d5e164fb31c2cef76f479d683395ea9bd6
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker
-PKG_VERSION:=27.0.3
+PKG_VERSION:=27.1.0
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/docker/cli
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=f992e895c949852686abef9a6fa9efd622826c4f4d70b83876569a4641c4c8fc
-PKG_GIT_SHORT_COMMIT:=7d4bcd8 # SHA1 used within the docker executables
+PKG_HASH:=8e58a2e419ba91ce1a27831c394bf214f7076758f55eccc6762b5265bec58b9f
+PKG_GIT_SHORT_COMMIT:=6312585 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker
-PKG_VERSION:=27.1.0
+PKG_VERSION:=27.1.1
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,7 +10,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/docker/cli
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=8e58a2e419ba91ce1a27831c394bf214f7076758f55eccc6762b5265bec58b9f
+PKG_HASH:=84db222b6d65695f3d8ae02acf8f21d90fb3f2169754bb94d314864c37bac7f3
 PKG_GIT_SHORT_COMMIT:=6312585 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=27.0.3
-PKG_RELEASE:=2
+PKG_VERSION:=27.1.0
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=db02d9b5d98e85284538d6ead43b549c025acf937e98c09d18395bb331c1e607
-PKG_GIT_SHORT_COMMIT:=662f78c # SHA1 used within the docker executables
+PKG_HASH:=8bb11443dc86c712daeb37135f2db54bfede368a84ebdf950d6adffd90c162d7
+PKG_GIT_SHORT_COMMIT:=a21b1a2 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=27.1.0
+PKG_VERSION:=27.1.1
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=8bb11443dc86c712daeb37135f2db54bfede368a84ebdf950d6adffd90c162d7
-PKG_GIT_SHORT_COMMIT:=a21b1a2 # SHA1 used within the docker executables
+PKG_HASH:=d8afaa4513d324db5841ced641daeee9090802c765b78f1c583bc171e9b0a6fd
+PKG_GIT_SHORT_COMMIT:=cc13f95 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: all supported targets
Run tested: N/A

Description:
docker: Update to 27.1.0(cherry picked from commit https://github.com/openwrt/packages/commit/c8d63383add0ec11e53f4f05d15ece6118b1cf41)
dockerd: Update to 27.1.0(cherry picked from commit https://github.com/openwrt/packages/commit/79fac95444e4874a411c1a135ad01b12a8e36007)
containerd: Update to 1.7.20(cherry picked from commit https://github.com/openwrt/packages/commit/79fac95444e4874a411c1a135ad01b12a8e36007)
docker: Update to 27.1.1(cherry picked from commit https://github.com/openwrt/packages/commit/a14185ce28d2b37722b6fe5930ea2b430a4e0494)
dockerd: Update to 27.1.1(cherry picked from commit https://github.com/openwrt/packages/commit/84f20279113d05284de92bc246a1cf9149108ed9)

For more information, visit:
https://github.com/containerd/containerd/compare/v1.7.18...v1.7.20
https://github.com/docker/cli/compare/v27.0.3...v27.1.1
https://github.com/moby/moby/compare/v27.0.3...v27.1.1