### PR TITLE
mwan3: close flock fd when starting mwan3.user scripts

### DIFF
--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
@@ -20,7 +20,7 @@
 	}
 
 	[ -x /etc/mwan3.user ] || chmod 755 /etc/mwan3.user
-	env -i ACTION="$ACTION" INTERFACE="$INTERFACE" DEVICE="$DEVICE" /etc/mwan3.user
+	env -i ACTION="$ACTION" INTERFACE="$INTERFACE" DEVICE="$DEVICE" /etc/mwan3.user 1000>&-
 }
 
 exit 0


### PR DESCRIPTION

Maintainer: me
Compile tested: no
Run tested: no

Description:
Fixes deadlock with multiple init script calls.
Fixes https://github.com/openwrt/openwrt/issues/15994
