### PR TITLE
xray-core: update to 1.8.23

### DIFF
--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-core
-PKG_VERSION:=1.8.21
+PKG_VERSION:=1.8.23
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/XTLS/Xray-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=464636c323c20cd17a6e10d6fdf0120f0a84096f1c66c0ab4851141d238a1a0b
+PKG_HASH:=c3731f11efae32296be75774cb4e86667fbc6e685cae4a891a0bc567b839ac7f
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MPL-2.0


### PR DESCRIPTION
Maintainer: @1715173329
Compile tested: all supported targets
Run tested: rockchip/armv8

Description:
SplitHTTP: Rename three options & Reduce server defaults
SplitHTTP: Fix wrong config deserialization
Docker: Add multi-arch builds and Loyalsoldier flavor
CertificateObject: Enable auto-reload for cacert & Add buildChain & Fixes
Fix a nil pointer in Wireguard client logging
SplitHTTP server: Add noSSEHeader
SplitHTTP: More range options, change defaults, enforce maxUploadSize, fix querystring behavior
SplitHTTP client: Add minUploadInterval
WS, HU: Remove unnecessary sleep from test
SplitHTTP server: Fix panic during concurrent Close and Push
Freedom: Don't do raw/splice copy in case of MITM
Fix SplitHTTP Unix domain socket

For more information, visit https://github.com/XTLS/Xray-core/compare/v1.8.21...v1.8.23