### PR TITLE
gping: update to 1.17.3

### DIFF
--- a/net/gping/Makefile
+++ b/net/gping/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gping
-PKG_VERSION:=1.16.1
+PKG_VERSION:=1.17.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/orf/gping/tar.gz/$(PKG_NAME)-v$(PKG_VERSION)?
-PKG_HASH:=557dad6e54b5dd23f88224ea7914776b7636672f237d9cbbea59972235ca89a8
+PKG_HASH:=bed3e1d46c2311ae15cad114700458a138e7d29fd45322cb9dd2c1108eb5a68e
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64 mediatek/filogic (BananaPi R3 Mini), OpenWrt snapshot
Run tested: aarch64 mediatek/filogic (BananaPi R3 Mini), OpenWrt snapshot

Description:
no release notes or diff provided by upstream repository