### PR TITLE
eza: update to 0.18.23

### DIFF
--- a/utils/eza/Makefile
+++ b/utils/eza/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=eza
-PKG_VERSION:=0.18.21
+PKG_VERSION:=0.18.23
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eza-community/eza/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=53cee12706be2b5bedcf40b97e077a18b254f0f53f1aee52d1d74136466045bc
+PKG_HASH:=34b0e8a699ac1a8a308448f417f0c0137a67ea34e261fd6f106e8be9fd5bb54c
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64 mediatek/filogic (BananaPi R3 Mini), OpenWrt snapshot
Run tested: aarch64 mediatek/filogic (BananaPi R3 Mini), OpenWrt snapshot

Release notes:
0.18.22: https://github.com/eza-community/eza/releases/tag/v0.18.22
0.18.23: https://github.com/eza-community/eza/releases/tag/v0.18.23