### PR TITLE
dnsproxy: Update to 0.72.2

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.72.1
+PKG_VERSION:=0.72.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=482787733a980a862361c069c0f71b5f9bb765ae51c07d6a6c195f44e98189f6
+PKG_HASH:=066f1c7ae5055817a968af9ccf2360de495540e818b683263cc3e0b872ca4097
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: @1715173329
Compile tested: all supported targets
Run tested: rockchip/armv8

Description:

Fixed: General memory performance improvements.

For more information, visit https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.72.2
