### PR TITLE
tinyproxy: change the `Bind` type to list

### DIFF
--- a/net/tinyproxy/files/tinyproxy.config
+++ b/net/tinyproxy/files/tinyproxy.config
@@ -25,9 +25,9 @@ option Port 8888
 
 #
 # The Bind directive allows you to bind the outgoing connections to a
-# particular IP address.
+# particular IP addresses.
 #
-#option Bind 192.168.0.1
+#list Bind 192.168.0.1
 
 #
 # Timeout: The number of seconds of inactivity a connection is allowed to

--- a/net/tinyproxy/files/tinyproxy.init
+++ b/net/tinyproxy/files/tinyproxy.init
@@ -102,7 +102,7 @@ start_proxy() {
 	proxy_atom "$1" Group
 	proxy_atom "$1" Port 8888
 	proxy_atom "$1" Listen
-	proxy_atom "$1" Bind
+	proxy_list "$1" Bind
 	proxy_atom "$1" Timeout
 
 	proxy_string "$1" ErrorFile_400 "ErrorFile 400"


### PR DESCRIPTION
Maintainer: @jow-
Compile tested:  x86, 64, openwrt-23.05.4
Run tested: x86, 64, openwrt-23.05.4, (1) using a list consisting of a single IPv4 IP address, (2) using a list consisting of two IP addresses - one IPv4, the other IPv6.

Description: tinyproxy supports several `Bind` options, that can be used to create a proxy that (1) supports both IPv4 and IPv6 and (2) uses specific addresses (in my case VPN addresses. It is very important to bind to specific addresses to avoid traffic leaks).