### PR TITLE
adblock: Add hagezi/dns-blocklists Pro List

### DIFF
--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -26,6 +26,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 | easyprivacy         |         | M    | tracking         | [Link](https://easylist.to)                                                       |
 | firetv_tracking     |         | S    | tracking         | [Link](https://github.com/Perflyst/PiHoleBlocklist)                               |
 | games_tracking      |         | S    | tracking         | [Link](https://www.gameindustry.eu)                                               |
+| hagezi_pro          |         | XL   | compilation      | [Link](https://github.com/hagezi/dns-blocklists)                                  |
 | hblock              |         | XL   | compilation      | [Link](https://hblock.molinero.dev)                                               |
 | lightswitch05       |         | XL   | compilation      | [Link](https://github.com/lightswitch05/hosts)                                    |
 | notracking          |         | XL   | tracking         | [Link](https://github.com/notracking/hosts-blocklists)                            |

--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -111,6 +111,13 @@
 		"focus": "tracking",
 		"descurl": "https://www.gameindustry.eu"
 	},
+	"hagezi_pro": {
+			"url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro-onlydomains.txt",
+			"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
+			"size": "XL",
+			"focus": "compilation",
+			"descurl": "https://github.com/hagezi/dns-blocklists"
+	},
 	"hblock": {
 		"url": "https://hblock.molinero.dev/hosts_domains.txt",
 		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",


### PR DESCRIPTION
Maintainer: @dibdot 
Compile tested: N/A
Run tested: OpenWrt 23.05.4, adblock 4.1.5-11, tested by modifying adblock sources.

Description:
Add the popular [hagezi](https://github.com/hagezi/dns-blocklists) blocklist, which is used by [adblock-lean](https://github.com/lynxthecat/adblock-lean) and has been come up a few times in the adblock support thread (such as [this](https://forum.openwrt.org/t/adblock-support-thread/507/2378)). I just picked the recommended pro list here.