### PR TITLE
mariadb: fix compilation with fmt 10.2

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
 PKG_VERSION:=10.9.8
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := https://archive.mariadb.org/$(PKG_NAME)-$(PKG_VERSION)/source

--- a/utils/mariadb/patches/120-fmt10.patch
+++ b/utils/mariadb/patches/120-fmt10.patch
@@ -1,0 +1,25 @@
+From 4375245d5d9f01cabb6e3fd6c637535e724eae38 Mon Sep 17 00:00:00 2001
+From: Daniel Black <daniel@mariadb.org>
+Date: Wed, 22 May 2024 17:43:17 +1000
+Subject: [PATCH] MDEV-34206 compile failure: fmt use incompatible with
+ libfmt-10.2.[2]+
+
+Upstream libfmt commit https://github.com/fmtlib/fmt/commit/d70729215fba1d54862e407b626abf86ddf409bf
+now requires the format function to be const.
+
+Adjust the function prototype so it is const and can compile.
+---
+ sql/item_strfunc.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/sql/item_strfunc.cc
++++ b/sql/item_strfunc.cc
+@@ -1367,7 +1367,7 @@ bool Item_func_sformat::fix_length_and_d
+ namespace fmt {
+   template <> struct formatter<String>: formatter<string_view> {
+     template <typename FormatContext>
+-    auto format(String c, FormatContext& ctx) -> decltype(ctx.out()) {
++    auto format(String c, FormatContext& ctx) const -> decltype(ctx.out()) {
+       string_view name = { c.ptr(), c.length() };
+       return formatter<string_view>::format(name, ctx);
+     };


### PR DESCRIPTION
Upstream backport.

Maintainer: @miska 

Fixes: https://github.com/openwrt/packages/issues/24721