### PR TITLE
mjpg-streamer: fix option enabled check in init.d

### DIFF
--- a/multimedia/mjpg-streamer/Makefile
+++ b/multimedia/mjpg-streamer/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mjpg-streamer
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jacksonliam/mjpg-streamer/tar.gz/v$(PKG_VERSION)?

--- a/multimedia/mjpg-streamer/files/mjpg-streamer.init
+++ b/multimedia/mjpg-streamer/files/mjpg-streamer.init
@@ -16,7 +16,7 @@ start_instance() {
 
 	local enabled
 	config_get_bool enabled "$1" 'enabled' 0
-	[ "$enabled" ] || return
+	[ "$enabled" -gt 0 ] || return
 
 	local input
 	config_get input "$s" 'input'


### PR DESCRIPTION
[ "$enabled" ] returns true whatever non-empty value enabled has, including 0.

Maintainer: @thess @roger- 
Compile tested: main
Run tested: 23.05 manually copying the fixed file

Description:

23.05 also needs this fix