### PR TITLE
netbird: update to 0.28.7

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.28.6
+PKG_VERSION:=0.28.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=d5693c18641e5446c546ac53cecba5d12b33cc7eb56adac90a3c0fbe34b5762c
+PKG_HASH:=2e51ea86c2c127b0e5c2d459a1d598f95d731e167cf557018b5a97d63117835a
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## Compile and run tested

Maintainer: Oskari Rauta / @oskarirauta

| Package architecture | Target | Subtarget | Brand | Model | Hardware Version | OpenWrt version |
|----------------------|--------|-----------|-------|-------|------------------|-----------------|
| [x86_64](https://openwrt.org/docs/techref/instructionset/x86_64) | [x86](https://openwrt.org/docs/techref/targets/x86) | 64 | [Duex](https://duex.com.br/) | [DX B75ZG M.2 Intel LGA 1155 DDR3](https://duex.com.br/produto/placa-mae-dx-b75zg-m-2-intel-lga-1155-ddr3/) | n/a | OpenWrt SNAPSHOT r27065-ca4469045f |

## Description

- Changelog:
  - [v0.28.7](https://github.com/netbirdio/netbird/releases/tag/v0.28.7)
- Full changelog: https://github.com/netbirdio/netbird/compare/v0.28.6...v0.28.7

## Additional information

`x86_64` running as container with [`incus`](https://github.com/lxc/incus).
Compiled package with container [`sdk`](https://github.com/openwrt/docker), and build `openwrt` image with container [`imagebuilder`](https://github.com/openwrt/docker).

My repo with my automated build can be see here:
- https://github.com/wehagy/openwrt-builder

And my artifacts here:
- https://github.com/wehagy/openwrt-builder/actions/runs/10224098527
