### PR TITLE
wgsd: add missing dependency

### DIFF
--- a/net/wgsd/Makefile
+++ b/net/wgsd/Makefile
@@ -28,7 +28,7 @@ define Package/wgsd/Default
   SUBMENU:=VPN
   TITLE:=WireGuard Service Discovery
   URL:=https://github.com/jwhited/wgsd
-  DEPENDS:=+kmod-wireguard
+  DEPENDS:=$(GO_ARCH_DEPENDS) +kmod-wireguard
 endef
 
 define Package/wgsd-coredns


### PR DESCRIPTION
Maintainer: @vooon
Compile tested: n/a
Run tested: n/a

Description:
wgsd is written in Go, add $(GO_ARCH_DEPENDS) to dependencies to avoid building on unsupported architectures.
