### PR TITLE
modemmanager: make rpcd integration optional

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.22.0
-PKG_RELEASE:=17
+PKG_RELEASE:=18
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git
@@ -43,7 +43,6 @@ define Package/modemmanager
 	+glib2 \
 	+dbus \
 	+ppp \
-	+lua-cjson \
 	+MODEMMANAGER_WITH_MBIM:libmbim \
 	+MODEMMANAGER_WITH_QMI:libqmi \
 	+MODEMMANAGER_WITH_QRTR:libqrtr-glib
@@ -53,6 +52,24 @@ define Package/modemmanager/description
   ModemManager is a D-Bus-activated service which allows controlling mobile
   broadband modems. Add kernel modules for your modems as needed.
   Select Utilities/usb-modeswitch if needed.
+endef
+
+define Package/modemmanager-rpcd
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=RPC interface for ModemManager for rpcd
+  URL:=https://www.freedesktop.org/wiki/Software/ModemManager
+  DEPENDS:= \
+	modemmanager \
+	+lua-cjson
+endef
+
+define Package/modemmanager-rpcd/description
+  ModemManager is a D-Bus-activated service which allows controlling mobile
+  broadband modems.
+
+  This package enables an rpcd interface for getting information from
+  ModemManager using e.g. ubus.
 endef
 
 MESON_ARGS += \
@@ -95,10 +112,6 @@ define Package/modemmanager/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/ModemManager $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/usr/sbin/ModemManager-wrapper $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/usr/sbin/ModemManager-monitor $(1)/usr/sbin
-
-	$(INSTALL_DIR) $(1)/usr/libexec/rpcd
-	$(INSTALL_BIN) ./files/usr/libexec/rpcd/modemmanager \
-		$(1)/usr/libexec/rpcd/
 
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mmcli $(1)/usr/bin
@@ -145,4 +158,11 @@ define Package/modemmanager/install
 		$(1)/lib/netifd/proto
 endef
 
+define Package/modemmanager-rpcd/install
+	$(INSTALL_DIR) $(1)/usr/libexec/rpcd
+	$(INSTALL_BIN) ./files/usr/libexec/rpcd/modemmanager \
+		$(1)/usr/libexec/rpcd/
+endef
+
 $(eval $(call BuildPackage,modemmanager))
+$(eval $(call BuildPackage,modemmanager-rpcd))


### PR DESCRIPTION
ModemManager does not depend on Lua by its own, and it should not be a requirement to have Lua to run ModemManager.

@feckert What do you think?

Maintainer: @feckert @aleksander0m 
Compile tested: master OpenWrt, mips64 octeon
Run tested: master OpenWrt, mips64 octeon

Description:
We try to keep our OpenWrt builds slim and this seemed like a low hanging fruit to remove a new, for us, dependency on lua.