### PR TITLE
gawk: set gawk as an alternative to awk

### DIFF
--- a/utils/gawk/Makefile
+++ b/utils/gawk/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gawk
 PKG_VERSION:=5.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/gawk
@@ -27,6 +27,7 @@ define Package/gawk
   URL:=https://www.gnu.org/software/gawk/
   TITLE:=GNU awk
   DEPENDS:=+libncursesw +libreadline
+  ALTERNATIVES:=200:/usr/bin/awk:/usr/bin/gawk
 endef
 
 CONFIGURE_ARGS+= --disable-mpfr


### PR DESCRIPTION
This makes it possible to build without busybox awk.

Maintainer: @dangowrt
Compile tested: OpenWrt master, mips64 octeon
Run tested: OpenWrt master, mips64 octeon

Description:
I had an issue when compiling without BusyBox awk and having gawk, where some scripts in an integration for ModemManager used `awk` and not depending on it. Fair enough, but as `gawk` is an implementation of `awk` we should probably install it as `/usr/bin/awk` like many other tools do.