### PR TITLE
[23.05] adblock-fast: update to 1.1.2-3

### DIFF
--- a/net/adblock-fast/Makefile
+++ b/net/adblock-fast/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.1.2
-PKG_RELEASE:=1
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=AGPL-3.0-or-later
 
@@ -16,7 +16,7 @@ define Package/adblock-fast
   SECTION:=net
   CATEGORY:=Network
   TITLE:=AdBlock Fast Service
-  URL:=https://docs.openwrt.melmac.net/adblock-fast/
+  URL:=https://github.com/stangri/adblock-fast/
   DEPENDS:=+jshn +curl
 	DEPENDS+=+!BUSYBOX_DEFAULT_AWK:gawk
 	DEPENDS+=+!BUSYBOX_DEFAULT_GREP:grep
@@ -49,17 +49,14 @@ define Package/adblock-fast/install
 	$(SED) "s|^\(readonly PKG_VERSION\).*|\1='$(PKG_VERSION)-$(PKG_RELEASE)'|" $(1)/etc/init.d/adblock-fast
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/etc/config/adblock-fast $(1)/etc/config/adblock-fast
-	$(INSTALL_DIR) $(1)/tmp
-	$(INSTALL_DATA) ./files/adblock-fast.config.update $(1)/tmp/adblock-fast.config.update
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
-	$(INSTALL_BIN)  ./files/etc/uci-defaults/90-adblock-fast $(1)/etc/uci-defaults/90-adblock-fast
+	$(INSTALL_BIN) ./files/etc/uci-defaults/90-adblock-fast $(1)/etc/uci-defaults/90-adblock-fast
 endef
 
 define Package/adblock-fast/postinst
 	#!/bin/sh
 	# check if we are on real system
 	if [ -z "$${IPKG_INSTROOT}" ]; then
-		sed -f /tmp/adblock-fast.config.update -i /etc/config/adblock-fast || true
 		/etc/init.d/adblock-fast enable
 	fi
 	exit 0

--- a/net/adblock-fast/README.md
+++ b/net/adblock-fast/README.md
@@ -1,0 +1,4 @@
+# README
+
+Documentation for this project is available at [https://docs.openwrt.melmac.net/adblock-fast/](https://docs.openwrt.melmac.net/adblock-fast/).
+

--- a/net/adblock-fast/files/adblock-fast.config.update
+++ b/net/adblock-fast/files/adblock-fast.config.update
@@ -13,3 +13,4 @@ s|list blocked_hosts_url 'https://hosts.oisd.nl/'|list blocked_adblockplus_url '
 \|dnsmasq.oisd.nl|d
 \|dnsmasq2.oisd.nl|d
 \|https://cdn.jsdelivr.net/gh/AdguardTeam/cname-trackers@master/combined_disguised_trackers_justdomains.txt|d
+\|sysctl.org/cameleon/hosts|d

--- a/net/adblock-fast/files/etc/config/adblock-fast
+++ b/net/adblock-fast/files/etc/config/adblock-fast
@@ -14,7 +14,7 @@ config adblock-fast 'config'
 	option debug '0'
 	option dns 'dnsmasq.servers'
 	list dnsmasq_instance '*'
-#	option dnsmasq_config_file_url 'https://big.oisd.nl/dnsmasq2'
+#	option dnsmasq_config_file_url 'https://small.oisd.nl/dnsmasq2'
 	option download_timeout '10'
 	option force_dns '1'
 	list force_dns_port '53'
@@ -36,84 +36,105 @@ config adblock-fast 'config'
 	option verbosity '2'
 
 config file_url
-	option url 'https://cdn.jsdelivr.net/gh/StevenBlack/hosts/hosts'
-	option size '6770929'
+	option name 'Hagezi - Pro'
+	option url 'https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/domains/pro.txt'
+	option size '12522070'
 	option action 'block'
 	option enabled '0'
 
 config file_url
+	option name 'AdguardTeam - CNAME Trackers'
 	option url 'https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/combined_disguised_trackers_justdomains.txt'
 	option size '6241707'
 	option action 'block'
 	option enabled '0'
 
 config file_url
+	option name 'OISD - Big'
 	option url 'https://big.oisd.nl/'
 	option size '6163363'
 	option action 'block'
 	option enabled '0'
 
 config file_url
+	option name 'StevenBlack - Unified hosts'
+	option url 'https://cdn.jsdelivr.net/gh/StevenBlack/hosts/hosts'
+	option size '4790642'
+	option action 'block'
+	option enabled '0'
+
+config file_url
+	option name '1Hosts - Lite'
+	option url 'https://o0.pages.dev/Lite/domains.txt'
+	option size '2786010'
+	option action 'block'
+	option enabled '0'
+
+config file_url
+	option name 'Bongochong - Combined Privacy Block Lists (TLD Optimized)'
 	option url 'https://cdn.jsdelivr.net/gh/bongochong/CombinedPrivacyBlockLists/NoFormatting/cpbl-ctld.txt'
 	option size '2608152'
 	option action 'block'
 	option enabled '0'
 
 config file_url
-	option url 'http://sysctl.org/cameleon/hosts'
-	option size '638545'
-	option action 'block'
-	option enabled '0'
-
-config file_url
+	option name 'Kboghdady - YouTube Ads DNS'
 	option url 'https://cdn.jsdelivr.net/gh/kboghdady/youTube_ads_4_pi-hole/black.list'
 	option size '553006'
 	option action 'block'
 	option enabled '0'
 
 config file_url
+	option name 'AdguardTeam - CNAME Clickthroughs'
 	option url 'https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/combined_disguised_clickthroughs_justdomains.txt'
 	option size '362170'
 	option action 'block'
 	option enabled '0'
 
 config file_url
+	option name 'SomeoneWhoCares - Hosts'
 	option url 'https://someonewhocares.org/hosts/hosts'
 	option size '347410'
 	option action 'block'
 	option enabled '0'
 
 config file_url
+	option name 'WinHelp2002 MVPS - Hosts'
 	option url 'https://winhelp2002.mvps.org/hosts.txt'
 	option size '334861'
 	option action 'block'
 	option enabled '0'
 
 config file_url
+	option name 'AdAway - Hosts'
 	option url 'https://adaway.org/hosts.txt'
 	option size '243454'
 	option action 'block'
 	option enabled '0'
 
 config file_url
+	option name 'AdguardTeam - CNAME Ads'
 	option url 'https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/combined_disguised_ads_justdomains.txt'
 	option size '222595'
 	option action 'block'
 	option enabled '0'
 
 config file_url
+	option name 'AdguardTeam - CNAME Microsites'
 	option url 'https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/combined_disguised_microsites_justdomains.txt'
 	option size '123275'
 	option action 'block'
 	option enabled '0'
 
 config file_url
+	option name 'Yoyo.org - Hosts'
 	option url 'https://pgl.yoyo.org/as/serverlist.php?hostformat=hosts&showintro=1&mimetype=plaintext'
 	option size '99588'
 	option action 'block'
 	option enabled '0'
 
 config file_url
+	option name 'Hoshsadiq - NoCoin Adblock List'
 	option url 'https://cdn.jsdelivr.net/gh/hoshsadiq/adblock-nocoin-list/hosts.txt'
 	option size '11149'
 	option action 'block'

--- a/net/adblock-fast/files/etc/init.d/adblock-fast
+++ b/net/adblock-fast/files/etc/init.d/adblock-fast
@@ -8,6 +8,8 @@ START=94
 USE_PROCD=1
 LC_ALL=C
 
+[ -n "${IPKG_INSTROOT}" ] && return 0
+
 if type extra_command 1>/dev/null 2>&1; then
 	extra_command 'allow' 'Allows domain in current block-list and config'
 	extra_command 'check' 'Checks if specified domain is found in current block-list'
@@ -34,7 +36,7 @@ fi
 
 readonly packageName='adblock-fast'
 readonly PKG_VERSION='dev-test'
-readonly packageCompat='1'
+readonly packageCompat='2'
 readonly serviceName="$packageName $PKG_VERSION"
 readonly packageConfigFile="/etc/config/${packageName}"
 readonly dnsmasqAddnhostsFile="/var/run/${packageName}/dnsmasq.addnhosts"
@@ -1111,7 +1113,8 @@ process_file_url() {
 
 	label="${url##*//}"
 	label="${label%%/*}"
-	label="File: $label"
+	label="${name:-$label}"
+	label="List: $label"
 	case "$action" in
 		allow) type='Allowed'; D_TMP="$A_TMP"
 		;;
@@ -1668,6 +1671,13 @@ adb_check_lists() {
 }
 
 adb_config_update() {
+	_cleanup_missing_urls() {
+		local cfg="$1" url size
+		config_get url "$cfg" url
+		if [ -z "$url" ]; then
+			uci_delete "$packageName" "$cfg"
+		fi
+	}
 	local R_TMP label
 	local param validation_result="$3"
 	case "$1" in
@@ -1703,6 +1713,9 @@ adb_config_update() {
 		fi
 	fi
 	rm -f "$R_TMP"
+	config_load "$packageName"
+	config_foreach _cleanup_missing_urls 'file_url'
+	[ -n "$(uci_changes "$packageName")" ] && uci_commit "$packageName"
 	return 0
 }
 
@@ -1714,10 +1727,11 @@ adb_show_blocklist() {
 
 adb_sizes() {
 	_config_add_url_size() {
-		local cfg="$1" url size
+		local cfg="$1" url name size
 		config_get url "$cfg" url
+		config_get name "$cfg" name
 		size="$(get_url_filesize "$url")"
-		output "$url${size:+: $size} "
+		output "${name:-$url}${size:+: $size} "
 		if [ -n "$size" ]; then
 			uci_set "$packageName" "$cfg" 'size' "$size"
 			output_okn
@@ -1730,7 +1744,7 @@ adb_sizes() {
 	load_environment "$validation_result" 'quiet' || return 1
 	config_load "$packageName"
 	config_foreach _config_add_url_size 'file_url'
-	uci_commit "$packageName"
+	[ -n "$(uci_changes "$packageName")" ] && uci_commit "$packageName"
 }
 
 # shellcheck disable=SC2120
@@ -2105,6 +2119,7 @@ load_validate_file_url_section() {
 		'enabled:bool:1' \
 		'action:or("allow", "block"):block' \
 		'size:or(uinteger, "")' \
+		'name:string' \
 		'url:string'
 }
 

--- a/net/adblock-fast/files/etc/uci-defaults/90-adblock-fast
+++ b/net/adblock-fast/files/etc/uci-defaults/90-adblock-fast
@@ -125,4 +125,37 @@ if [ -s '/etc/config/simple-adblock' ] \
 	output_okn
 fi
 
+# Transition to list names
+_find_name() { grep -B1 "$1" "/etc/config/${packageName}-opkg" | head -1 | cut -d "'" -f2; }
+
+add_name() {
+	local cfg="$1"
+	local url name label
+	config_get url "$cfg" 'url'
+	config_get name "$cfg" 'name'
+	if [ -z "$name" ]; then
+		label="${url##*//}"
+		label="${label%%/*}";
+		output "Finding name for ${label}: "
+		name="$(_find_name "$url")"
+		if [ -n "$name" ]; then
+			uci_set "$packageName" "$cfg" 'name' "$name"
+			output "$name "
+			output_okn
+		else
+			output "Unknown "
+			output_failn
+		fi
+	else
+		output "Name for ${label} already set to ${name} "
+		output_okn
+	fi
+}
+
+if [ -s "/etc/config/${packageName}-opkg" ] && ! grep -q 'option name' "/etc/config/${packageName}"; then
+	config_load "$packageName"
+	config_foreach add_name 'file_url'
+	[ -n "$(uci_changes "$packageName")" ] && uci_commit "$packageName"
+fi
+
 exit 0


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 23.05.4
Run tested: x86_64, Dell EMC Edge620, OpenWrt 23.05.4

Description:

This version brings two significant updates:
* support for text labels/names for the external lists
* better processing of the config update files, which cleans up entries with missing URLs

Also:
* new config file contains names for all lists
* it tries to match existing URLs with the names from the new config file and update user config as part of uci-defaults script
* contains minor updates to copyright/license/upstream URL/README
* updates the config update script to remove sysctl.org list as it's outdated
* adds two new remote lists: Hagezi and 1Hosts

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 50e85ed27f0999c8c43ed43675f9b702944ee3e8)
