### PR TITLE
dhtd: udpate to 1.0.2

### DIFF
--- a/net/dhtd/Makefile
+++ b/net/dhtd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dhtd
-PKG_VERSION:=1.0.1
+PKG_VERSION:=1.0.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mwarning/dhtd/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=7b1338059dfb9ed2300bb6b005d7cd677d99df8c74846eaed1b0cb97641b7297
+PKG_HASH:=15c10eec45800e8bc11489a8e4b6e36610b523a534f921b785b95dedca358b20
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: ramips/mt76x8, WR902AC, OpenWrt master
Run tested: startup and peering with other instances on the Internet

Description: Fixes a potential segmentation fault.