### PR TITLE
dnsproxy: Update to 0.72.3

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.72.2
+PKG_VERSION:=0.72.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=066f1c7ae5055817a968af9ccf2360de495540e818b683263cc3e0b872ca4097
+PKG_HASH:=40910c1b8a24d2beb4835fc42dd9d38f35cd7e6239f813015a36e0c64f0c12aa
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: @1715173329
Compile tested: all supported targets
Run tested: rockchip/armv8

Description:
Changed: Updated [golibs](https://github.com/AdguardTeam/golibs) dependency.

For more information, visit https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.72.3
