### PR TITLE
[23.05] php8: update to 8.2.22

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.2.21
+PKG_VERSION:=8.2.22
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.php.net/distributions/
-PKG_HASH:=8cc44d51bb2506399ec176f70fe110f0c9e1f7d852a5303a2cd1403402199707
+PKG_HASH:=8566229bc88ad1f4aadc10700ab5fbcec81587c748999d985f11cf3b745462df
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs, bcm2708
Run tested: bcm2708, Raspi

Description:

Upstream changelog:
https://www.php.net/ChangeLog-8.php#8.2.22
