### PR TITLE
bash-completion: Add new package version 2.14.0

### DIFF
--- a/utils/bash-completion/Makefile
+++ b/utils/bash-completion/Makefile
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2024 CZ.NIC, z.s.p.o.
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bash-completion
+PKG_VERSION:=2.14.0
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://www.github.com/scop/bash-completion/releases/download/${PKG_VERSION}
+PKG_HASH:=5c7494f968280832d6adb5aa19f745a56f1a79df311e59338c5efa6f7285e168
+
+PKG_MAINTAINER:=Michal Hrusecky <michal.hrusecky@turris.com>
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/bash-completion
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Shells
+  TITLE:=Collection of command line command completions for Bash shell
+  DEPENDS:=+bash
+  URL:=https://github.com/scop/bash-completion
+endef
+
+define Package/bash-completion/install
+	$(INSTALL_DIR) $(1)/etc/profile.d
+	$(CP) $(PKG_INSTALL_DIR)/etc/profile.d/* $(1)/etc/profile.d/
+	$(INSTALL_DIR) $(1)/usr/share/bash-completion
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/bash-completion/bash_completion $(1)/usr/share/bash-completion
+	$(INSTALL_DIR) $(1)/usr/share/bash-completion/completions
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/bash-completion/completions/* $(1)/usr/share/bash-completion/completions/
+	$(CP) ./files/* $(PKG_INSTALL_DIR)/usr/share/bash-completion/* $(1)/usr/share/bash-completion/completions/
+	$(INSTALL_DIR) $(1)/usr/share/bash-completion/helpers
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/bash-completion/helpers/* $(1)/usr/share/bash-completion/helpers
+endef
+
+define Package/bash-completion/description
+  bash-completion is a collection of command line command completions for the
+  Bash shell, collection of helper functions to assist in creating new
+  completions, and set of facilities for loading completions automatically on
+  demand, as well as installing them.
+endef
+
+$(eval $(call BuildPackage,bash-completion))

--- a/utils/bash-completion/files/uci
+++ b/utils/bash-completion/files/uci
@@ -1,0 +1,77 @@
+_uci_command_complete() {
+    local i
+    for i in batch export import changes commit add add_list del_list show get set delete rename revert reorder; do
+        if [[ "$i" =~ ^${COMP_WORDS[COMP_CWORD]} ]] || [[ -z "${COMP_WORDS[COMP_CWORD]}" ]]; then
+            COMPREPLY+=("$i")
+        fi
+    done
+}
+
+_uci_config_complete() {
+    local i
+    for i in $(cd /etc/config; echo "${COMP_WORDS[COMP_CWORD]}"*); do
+        if [[ ! "$i" =~ .*-opkg$ ]]; then
+            COMPREPLY+=("$i")
+        fi
+    done
+}
+
+_uci_section_complete() {
+    local i
+    for i in $(uci -q show | grep "^${COMP_WORDS[COMP_CWORD]}" | grep -v '.-opkg\.' | sed 's|=.*||' | sort -u); do
+        COMPREPLY+=("$i")
+    done
+}
+
+_uci_global_options_complete() {
+    local i
+    for i in -c -d -m -n -N -p -P -t -q -s -S -X; do
+        if [[ "x$i" =~ ^x${COMP_WORDS[COMP_CWORD]} ]] || [[ -z "${COMP_WORDS[COMP_CWORD]}" ]]; then
+            COMPREPLY+=("$i")
+        fi
+    done
+}
+
+_uci_completition() {
+    if [[ "${#COMP_WORDS[@]}" -eq "2" ]]; then
+        _uci_global_options_complete
+        _uci_command_complete
+        return
+    fi
+    if [[ "${#COMP_WORDS[@]}" -gt "3" ]]; then
+        case "${COMP_WORDS[$((COMP_CWORD - 2))]}" in
+            -*c|-*p|-*P|-*t|-*d|-*f)
+                _uci_global_options_complete
+                _uci_command_complete
+                return
+                ;;
+        esac
+    fi
+    if [[ "${#COMP_WORDS[@]}" -gt "2" ]]; then
+        case "${COMP_WORDS[$((COMP_CWORD - 1))]}" in
+            -*c|-*p|-*P|-*t)
+                COMPREPLY=($(compgen -d "${COMP_WORDS[$COMP_CWORD]}"))
+                return
+                ;;
+            -*f)
+                COMPREPLY=($(compgen -f "${COMP_WORDS[$COMP_CWORD]}"))
+                return
+                ;;
+            -*m*|-*n*|-*N*|-*q*|-*s*|-*S*|-*X*)
+                _uci_global_options_complete
+                _uci_command_complete
+                return
+                ;;
+            export|import|changes|commit|add)
+                _uci_config_complete
+                return
+                ;;
+            add_list|del_list|show|get|set|delete|rename|revert|reorder)
+                _uci_section_complete
+                return
+                ;;
+        esac
+    fi
+}
+
+complete -F _uci_completition uci


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, Turris Omnia, Turris OS 7.1 ~ OpenWrt 22.03
Run tested: mvebu, Turris Omnia, Turris OS 7.1 ~ OpenWrt 22.03, completion works

Description:
Adding new package containing collection of command line command completions for the Bash shell, collection of helper functions to assist in creating new completions, and set of facilities for loading completions automatically on demand, as well as installing them. Makes Bash much more user-friendly.