### PR TITLE
node: bump to v20.16.0

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v20.15.1
+PKG_VERSION:=v20.16.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=da228a0c27922f02001d9a781793696432096ab2da658eb77d7fc21693f4c5cb
+PKG_HASH:=8f24bf9abe455a09ab30f9ae8edda1e945ed678a4b1c3b07ee0f901fdc0ff4fd
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/202-node_gyp.patch
+++ b/lang/node/patches/202-node_gyp.patch
@@ -1,6 +1,6 @@
 --- a/node.gyp
 +++ b/node.gyp
-@@ -1302,6 +1302,7 @@
+@@ -1305,6 +1305,7 @@
        'dependencies': [
          'deps/simdutf/simdutf.gyp:simdutf#host',
        ],

--- a/lang/node/patches/999-localhost-no-addrconfig.patch
+++ b/lang/node/patches/999-localhost-no-addrconfig.patch
@@ -13,7 +13,7 @@ Forwarded: https://github.com/nodejs/node/issues/33816
  //
  // Permission is hereby granted, free of charge, to any person obtaining a
  // copy of this software and associated documentation files (the
-@@ -1338,13 +1339,6 @@ function lookupAndConnect(self, options)
+@@ -1339,13 +1340,6 @@ function lookupAndConnect(self, options)
      hints: options.hints || 0,
    };
  

--- a/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
+++ b/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
@@ -1,6 +1,6 @@
 --- a/node.gyp
 +++ b/node.gyp
-@@ -1303,6 +1303,7 @@
+@@ -1306,6 +1306,7 @@
          'deps/simdutf/simdutf.gyp:simdutf#host',
        ],
        'libraries!':[ '-licui18n', '-licuuc', '-licudata', '-lcrypto', '-lssl', '-lz', '-lhttp_parser', '-luv', '-lnghttp2', '-lcares' ],


### PR DESCRIPTION
Maintainer: me @ianchi
Compile tested: head, aarch64, arm, i386, x86_64
Run tested: (qemu 9.0.2) aarch64

Description:
Update to v20.16.0

Notable Changes
- 	process: add process.getBuiltinModule(id)
- 	doc: doc-only deprecate OpenSSL engine-based APIs
- 	inspector: fix disable async hooks on Debugger.setAsyncCallStackDepth