### PR TITLE
unbound: fix gawk incompatibility

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.20.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound

--- a/net/unbound/files/iptools.sh
+++ b/net/unbound/files/iptools.sh
@@ -44,7 +44,7 @@ domain_ptr_ip6() {
   y = $0 ;
   ct_start = length(y) - 32 + CIDR ;
   for(i=ct_start; i>0; i--) { x = (x substr(y,i,1)) ; } ;
-  gsub(/./,"&\.",x) ;
+  gsub(/./,"&.",x) ;
   x = (x "ip6.arpa") ;
   print x }'
 }
@@ -65,7 +65,7 @@ host_ptr_ip6() {
   ct_start = length(y);
   for(i=ct_start; i>0; i--) { x = (x substr(y,i,1)) ; } ;
   sub(/[0-9]+\//,"",x) ;
-  gsub(/./,"&\.",x) ;
+  gsub(/./,"&.",x) ;
   x = (x "ip6.arpa") ;
   print x }'
 }
@@ -80,8 +80,8 @@ domain_ptr_ip4() {
   CIDR = (CIDR / 8) ;
   dtxt = $0 ;
   sub(/\/.*/,"",dtxt) ;
-  split(dtxt, dtxt, ".") ;
-  for(i=1; i<=CIDR; i++) { x = (dtxt[i] "." x) ; }
+  split(dtxt, dtxtarr, ".") ;
+  for(i=1; i<=CIDR; i++) { x = (dtxtarr[i] "." x) ; }
   x = (x "in-addr.arpa") ;
   print x }'
 }

--- a/net/unbound/files/odhcpd.awk
+++ b/net/unbound/files/odhcpd.awk
@@ -62,7 +62,7 @@
   if ((cls == "ipv4") && (hst != "-") && (cdr == 32) && (NF == 9)) {
     # IPV4 ; only for provided hostnames and full /32 assignments
     # NF=9 ; odhcpd errata in field format without host name
-    ptr = adr ; qpr = "" ; split( ptr, ptr, "." ) ;
+    ptr = adr ; qpr = "" ; split( ptr, ptrarr, "." ) ;
     slaac = slaac_eui64( id ) ;
 
 
@@ -74,7 +74,7 @@
 
 
     # always create the pipe file
-    for( i=1; i<=4; i++ ) { qpr = ( ptr[i] "." qpr) ; }
+    for( i=1; i<=4; i++ ) { qpr = ( ptrarr[i] "." qpr) ; }
     x = ( fqdn ". 300 IN A " adr ) ;
     y = ( qpr "in-addr.arpa. 300 IN PTR " fqdn ) ;
     print ( x "\n" y ) > pipefile ;
@@ -160,27 +160,27 @@
 
 ##############################################################################
 
-function ipv6_ptr( ipv6,    arpa, ary, end, i, j, new6, sz, start ) {
+function ipv6_ptr( ipv6, arpa, ary, end, m, n, new6, sz, start ) {
   # IPV6 colon flexibility is a challenge when creating [ptr].ip6.arpa.
   sz = split( ipv6, ary, ":" ) ; end = 9 - sz ;
 
 
-  for( i=1; i<=sz; i++ ) {
-    if( length(ary[i]) == 0 ) {
-      for( j=1; j<=end; j++ ) { ary[i] = ( ary[i] "0000" ) ; }
+  for( m=1; m<=sz; m++ ) {
+    if( length(ary[m]) == 0 ) {
+      for( n=1; n<=end; n++ ) { ary[m] = ( ary[m] "0000" ) ; }
     }
 
     else {
-      ary[i] = substr( ( "0000" ary[i] ), length( ary[i] )+5-4 ) ;
+      ary[m] = substr( ( "0000" ary[m] ), length( ary[m] )+5-4 ) ;
     }
   }
 
 
   new6 = ary[1] ;
-  for( i = 2; i <= sz; i++ ) { new6 = ( new6 ary[i] ) ; }
+  for( m = 2; m <= sz; m++ ) { new6 = ( new6 ary[m] ) ; }
   start = length( new6 ) ;
-  for( i=start; i>0; i-- ) { arpa = ( arpa substr( new6, i, 1 ) ) ; } ;
-  gsub( /./, "&\.", arpa ) ; arpa = ( arpa "ip6.arpa" ) ;
+  for( m=start; m>0; m-- ) { arpa = ( arpa substr( new6, m, 1 ) ) ; } ;
+  gsub( /./, "&.", arpa ) ; arpa = ( arpa "ip6.arpa" ) ;
 
   return arpa ;
 }


### PR DESCRIPTION
Maintainer: @EricLuehrsen 
Compile tested: SNAPSHOT, r27106-74553537f1
Run tested: SNAPSHOT, r27106-74553537f1

Description:
* fix gawk incompatibility in iptools.sh

Since commit 2664e85a640244e6792df5b9c4edfc69669edf19 "/usr/bin/awk" points to gawk (if installed) and no longer to busybox awk. This reveals a long standing gawk incompatibility in iptools.sh, e.g.
```
root@blackhole:~# /etc/init.d/unbound restart
10542
awk: cmd. line:12: warning: escape sequence `\.' treated as plain `.'
awk: cmd. line:12: warning: escape sequence `\.' treated as plain `.'
awk: cmd. line:6: (FILENAME=- FNR=1) fatal: split: second argument is not an array
awk: cmd. line:14: warning: escape sequence `\.' treated as plain `.'
awk: cmd. line:14: warning: escape sequence `\.' treated as plain `.'
awk: cmd. line:6: (FILENAME=- FNR=1) fatal: split: second argument is not an array
awk: cmd. line:6: (FILENAME=- FNR=1) fatal: split: second argument is not an array
awk: cmd. line:6: (FILENAME=- FNR=1) fatal: split: second argument is not an array
awk: cmd. line:14: warning: escape sequence `\.' treated as plain `.'
awk: cmd. line:14: warning: escape sequence `\.' treated as plain `.'
awk: cmd. line:6: (FILENAME=- FNR=1) fatal: split: second argument is not an array
awk: cmd. line:14: warning: escape sequence `\.' treated as plain `.'
awk: cmd. line:14: warning: escape sequence `\.' treated as plain `.'
awk: cmd. line:6: (FILENAME=- FNR=1) fatal: split: second argument is not an array
awk: cmd. line:6: (FILENAME=- FNR=1) fatal: split: second argument is not an array
```

Signed-off-by: Dirk Brenken <dev@brenken.org>
