### PR TITLE
squeezelite: add uci option squeezelite.options.unmute to init script

### DIFF
--- a/sound/squeezelite/files/squeezelite.init
+++ b/sound/squeezelite/files/squeezelite.init
@@ -102,6 +102,10 @@ make_cmdline() {
 	local dop
 	config_get dop options dsd_over_pcm 0
 	[ "$dop" -eq 1 ] && cmdline="$cmdline -D"
+
+	local unmute
+	config_get unmute options unmute ""
+	[ -n "$unmute" ] && cmdline="$cmdline -U $unmute"
 }
 
 start_service() {


### PR DESCRIPTION
Add an uci option squeezelite.options.unmute to init script allowing specification of cmdline option -U <control> (e.g. -U Headphone)

Signed-off-by: Kel Modderman kelvmod@gmail.com

Maintainer: @thess
Run tested: SNAPSHOT r27032-274b18d105
