### PR TITLE
add respawn to mdns-repeater init

### DIFF
--- a/net/mdns-repeater/Makefile
+++ b/net/mdns-repeater/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mdns-repeater
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://github.com/kennylevinsen/mdns-repeater.git
 PKG_SOURCE_PROTO=git

--- a/net/mdns-repeater/files/mdns-repeater.init
+++ b/net/mdns-repeater/files/mdns-repeater.init
@@ -11,6 +11,7 @@ start_service() {
 	local interfaces
 	config_get interfaces main interface
 	procd_open_instance
+	procd_set_param respawn
 	procd_set_param command $PROG -f $interfaces
 	# -f generates a lot of debug output
 	# no forwarding of stderr to logs


### PR DESCRIPTION
Maintainer: @axkg
Compile tested: aarch64_cortex-a53, Xiaomi AX6S, snapshot, 23.05.4
Run tested: 23.05.4, snapshot, ramips (Xiaomi Mi Router 4A Gigabit Edition), aarch64_cortex-a53 (AX6S)

Description:
Added `respawn` to procd parameters with default options.

Sometimes `mdns-repeater` quits or crashes, leaving service stopped, requiring manual (re)start. This commit should fix that – and I use this patch this on all my openwrt routers for nearly a year.