### PR TITLE
lua-eco: update to 3.6.0

### DIFF
--- a/lang/lua-eco/Makefile
+++ b/lang/lua-eco/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lua-eco
-PKG_VERSION:=3.5.3
+PKG_VERSION:=3.6.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://github.com/zhaojh329/lua-eco/releases/download/v$(PKG_VERSION)
-PKG_HASH:=38e55cfa796115c548e6a0b014fc016fad67e3e57579fbcc5a60999bc6341fd5
+PKG_HASH:=0fdcd8eb9e93f2d1f0ff2132298faae2e13a8bfd676bd91db4d53e48917d6a74
 
 PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
 PKG_LICENSE:=MIT
@@ -62,6 +62,7 @@ Package/lua-eco-netlink=$(call Package/lua-eco/Module,netlink,+lua-eco-socket)
 Package/lua-eco-ip=$(call Package/lua-eco/Module,ip utils,+lua-eco-netlink)
 Package/lua-eco-nl80211=$(call Package/lua-eco/Module,nl80211,+lua-eco-netlink)
 Package/lua-eco-ssh=$(call Package/lua-eco/Module,ssh,+lua-eco-socket +libssh2)
+Package/lua-eco-packet=$(call Package/lua-eco/Module,packet,+lua-eco-nl80211)
 
 define Package/lua-eco-ssl/config
 	choice
@@ -191,6 +192,11 @@ define Package/lua-eco-ssh/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ssh.so $(1)/usr/local/lib/lua/5.3/eco/core
 endef
 
+define Package/lua-eco-packet/install
+	$(INSTALL_DIR) $(1)/usr/local/lib/lua/5.3/eco
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/packet.lua $(1)/usr/local/lib/lua/5.3/eco
+endef
+
 $(eval $(call BuildPackage,lua-eco))
 $(eval $(call BuildPackage,lua-eco-log))
 $(eval $(call BuildPackage,lua-eco-base64))
@@ -208,3 +214,4 @@ $(eval $(call BuildPackage,lua-eco-netlink))
 $(eval $(call BuildPackage,lua-eco-ip))
 $(eval $(call BuildPackage,lua-eco-nl80211))
 $(eval $(call BuildPackage,lua-eco-ssh))
+$(eval $(call BuildPackage,lua-eco-packet))


### PR DESCRIPTION
A new package lua-eco-packet added since 3.6.0.

Maintainer: me
Compile tested: x86, x86, master
Run tested: x86, x86, master, tests done

Description:
Release notes for 3.6.0: https://github.com/zhaojh329/lua-eco/releases/tag/v3.6.0
