### PR TITLE
freeradius3: fix cannot find @LIBREADLINE@: No such file or directory

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -982,9 +982,12 @@ CONFIGURE_VARS+= \
 	LDFLAGS="$$$$LDFLAGS" \
 	LIBS="$(CONFIGURE_LIBS)" \
 	MYSQL_CONFIG="no" \
-	vl_cv_lib_readline=no \
+	ac_cv_header_readline_h=no \
+	ac_cv_header_readline_readline_h=no \
+	ac_cv_header_readline_history_h=no \
 	ax_cv_cc_builtin_choose_expr=yes \
-	ax_cv_cc_builtin_types_compatible_p=yes ax_cv_cc_builtin_bswap64=yes \
+	ax_cv_cc_builtin_types_compatible_p=yes \
+	ax_cv_cc_builtin_bswap64=yes \
 	ax_cv_cc_bounded_attribute=no \
 	ac_cv_lib_collectdclient_lcc_connect=no \
 	ac_cv_lib_execinfo_backtrace_symbols=no


### PR DESCRIPTION
Maintainer:
Compile tested: aarch64
Run tested: aarch64/ master

Description:

this problem occurs on freeradius-3.2.4 and continues on freeradius-3.2.5 I have made several attempts but all failed.

and strangely this happens while building on the snapshots release.

and in the end I found this problem occurs in freeradius4 when I try to build in openwrt and finally found a solution for now
