### PR TITLE
openwisp-monitoring: add missing PKG_VERSION for APK

### DIFF
--- a/admin/openwisp-monitoring/Makefile
+++ b/admin/openwisp-monitoring/Makefile
@@ -5,16 +5,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openwisp-monitoring
-PKG_RELEASE:=2
+PKG_VERSION:=0.1.1
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Federico Capoano <support@openwisp.io>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE_URL:=https://github.com/openwisp/openwrt-openwisp-monitoring.git
-PKG_MIRROR_HASH:=b09f2b6ac1a41b6abab3d85917c02b16a94bfec3876c6062108ce600a4a25d98
+PKG_MIRROR_HASH:=97ae00b37518919079d894622c664d330bbf0cb0ee1b68c84991b459c1a087ee
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=0.1.1
+PKG_SOURCE_VERSION:=$(PKG_VERSION)
 PKGARCH:=all
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
The 'PKG_VERSION' string was missing and only 'PKG_SOURCE_VERSION' string was used.

Maintainer: @nemesifier 
ping @aparcar