### PR TITLE
[23.05] natmap: update to 20240813

### DIFF
--- a/net/natmap/Makefile
+++ b/net/natmap/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=natmap
-PKG_VERSION:=20240603
+PKG_VERSION:=20240813
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/heiher/natmap/releases/download/$(PKG_VERSION)
-PKG_HASH:=4754833b95b6687de6c07d02ff92798232f6a3bf5ec1cbf20e8bc26057d0ef20
+PKG_HASH:=2fd89d286b19b9235d5e3477699c3752911bc5e80840ea1ed6930bfe98f47248
 
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>, Ray Wang <r@hev.cc>
 PKG_LICENSE:=MIT

--- a/net/natmap/files/natmap.init
+++ b/net/natmap/files/natmap.init
@@ -24,7 +24,7 @@ validate_section_natmap() {
 		'interval:uinteger' \
 		'stun_server:host' \
 		'http_server:host' \
-		'port:port' \
+		'port:portrange' \
 		'forward_target:host' \
 		'forward_port:port' \
 		'notify_script:file' \


### PR DESCRIPTION
Maintainer: @ysc3839 @heiher
Compile tested: armsr-armv8, snapshot; ramips-mt7621, 23.05
Run tested: ramips-mt7621, 23.05

Description:

1. Update to 20240813.