### PR TITLE
uacme: adapted run.sh script to get it working with step CA

### DIFF
--- a/net/uacme/files/acme.config
+++ b/net/uacme/files/acme.config
@@ -2,11 +2,15 @@ config acme
        option state_dir '/etc/acme'
        option account_email 'email@example.org'
        option debug 0
+       # option acme_url 'https://example.org/acme/acme/directory' # the URL to your ACME service
+       # option acme_interface 'wan' # set to interface name, when ACME server is on another network as 'wan'
 
 config cert 'example'
        option enabled 0
        option use_staging 1
        option keylength 2048
+       # option dns 0
+       # option tls 1 # this enables 'tls-alpn-01' challenge
        option update_uhttpd 1
        option update_nginx 1
        option update_haproxy 1


### PR DESCRIPTION
Maintainer: @lucize
Compile tested: OpenWrt 23.05.03
Run tested: OpenWrt 23.05.03

Description:

Current uacme package has no support for using private CA (like step CA). The tool supports that, but the wrapper script responsible for handling the ACME challenge is missing additional settings required for that (see this [thread](https://forum.openwrt.org/t/custom-ca-for-ssl-certificates/160156)).

On top of that, the wrapper script was initially forked from acme.sh package and contains code snippets which suggest wrapper is same when uacme and acme.sh are installed. This makes no sense, so I've decided to fix the wrapper script (run.sh) to support only uacme package.

Added support for `tls-alpn-01` and tested `http-01` and `tls-alpn-01` ACME challenge types using [step CA](https://smallstep.com/docs/step-ca/) as ACME service. Also fixed and improved the pre_check() and post_check() functions of the wrapper. Added also option for setting which interface should listen on the ACME challenge.