### PR TITLE
basicstation: fix compilation for new mbedtls version 3.x

### DIFF
--- a/net/basicstation/Makefile
+++ b/net/basicstation/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=basicstation
 PKG_VERSION:=2.0.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/lorabasics/basicstation/tar.gz/v$(PKG_VERSION)?

--- a/net/basicstation/patches/001-build-with-mbedtls-3.x.patch
+++ b/net/basicstation/patches/001-build-with-mbedtls-3.x.patch
@@ -1,0 +1,82 @@
+From 120c5817c0fb89aeb1641d86322e5168ceaa08cc Mon Sep 17 00:00:00 2001
+From: Glenn Strauss <gstrauss@gluelogic.com>
+Date: Fri, 19 Jul 2024 11:26:39 -0400
+Subject: [PATCH] build with mbedtls 3.x
+
+Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
+---
+ src/cups.c | 15 +++++++++------
+ src/tls.c  |  8 ++++++--
+ src/tls.h  |  6 +++++-
+ 3 files changed, 20 insertions(+), 9 deletions(-)
+
+--- a/src/cups.c
++++ b/src/cups.c
+@@ -38,6 +38,9 @@
+ #include "mbedtls/sha512.h"
+ #include "mbedtls/bignum.h"
+ 
++#ifndef MBEDTLS_PRIVATE
++#define MBEDTLS_PRIVATE(x) x
++#endif
+ 
+ #define FAIL_CNT_THRES 6
+ #define SIGCRC_LEN 4
+@@ -72,12 +75,12 @@ static int cups_verifySig (cups_sig_t* s
+         mbedtls_ecdsa_context ecdsa;
+         mbedtls_ecdsa_init(&ecdsa);
+         int ret;
+-        if ((ret = mbedtls_ecp_group_load        (&k.grp, MBEDTLS_ECP_DP_SECP256R1) ) ||
+-            (ret = mbedtls_mpi_read_binary       (&k.Q.X, (u1_t*)key.buf, 32)       ) ||
+-            (ret = mbedtls_mpi_read_binary       (&k.Q.Y, (u1_t*)key.buf+32, 32)    ) ||
+-            (ret = mbedtls_mpi_lset              (&k.Q.Z, 1)                        ) ||
+-            (ret = mbedtls_ecp_check_pubkey      (&k.grp, &k.Q)                     ) ||
+-            (ret = mbedtls_ecdsa_from_keypair    (&ecdsa, &k)                       ) ||
++        if ((ret = mbedtls_ecp_group_load        (&k.MBEDTLS_PRIVATE(grp), MBEDTLS_ECP_DP_SECP256R1)               ) ||
++            (ret = mbedtls_mpi_read_binary       (&k.MBEDTLS_PRIVATE(Q).MBEDTLS_PRIVATE(X), (u1_t*)key.buf, 32)    ) ||
++            (ret = mbedtls_mpi_read_binary       (&k.MBEDTLS_PRIVATE(Q).MBEDTLS_PRIVATE(Y), (u1_t*)key.buf+32, 32) ) ||
++            (ret = mbedtls_mpi_lset              (&k.MBEDTLS_PRIVATE(Q).MBEDTLS_PRIVATE(Z), 1)                     ) ||
++            (ret = mbedtls_ecp_check_pubkey      (&k.MBEDTLS_PRIVATE(grp), &k.MBEDTLS_PRIVATE(Q))                  ) ||
++            (ret = mbedtls_ecdsa_from_keypair    (&ecdsa, &k)                                                      ) ||
+             (ret = mbedtls_ecdsa_read_signature  (&ecdsa, sig->hash, sizeof(sig->hash), sig->signature, sig->len ))
+          ) {
+             verified = 0;
+--- a/src/tls.c
++++ b/src/tls.c
+@@ -28,7 +28,6 @@
+ 
+ #include "mbedtls/net_sockets.h"
+ #include "mbedtls/ssl.h"
+-#include "mbedtls/certs.h"
+ #include "mbedtls/entropy.h"
+ #include "mbedtls/ctr_drbg.h"
+ #include "mbedtls/error.h"
+@@ -230,7 +229,12 @@ int tls_setMyCert (tlsconf_t* conf, cons
+         keyb = (u1_t*)dbuf.buf;
+         keyl = dbuf.bufsize+1;
+     }
+-    if( (ret = mbedtls_pk_parse_key(mykey, keyb, keyl, (const u1_t*)pwd, pwd?strlen(pwd):0)) != 0 ) {
++    ret = mbedtls_pk_parse_key(mykey, keyb, keyl, (const u1_t*)pwd, pwd?strlen(pwd):0
++#if MBEDTLS_VERSION_NUMBER >= 0x03000000 /* mbedtls 3.0.0 */
++                               , mbedtls_ctr_drbg_random, assertDBRG()
++#endif
++                              );
++    if( ret != 0 ) {
+         log_mbedError(ERROR, ret, "Parsing key");
+         goto errexit;
+     }
+--- a/src/tls.h
++++ b/src/tls.h
+@@ -30,7 +30,11 @@
+ #define _tls_h_
+ 
+ #include "mbedtls/ssl.h"
+-#include "mbedtls/net.h"
++#if MBEDTLS_VERSION_NUMBER < 0x02040000L
++#include <mbedtls/net.h>
++#else
++#include "mbedtls/net_sockets.h"
++#endif
+ 
+ typedef struct tlsconf tlsconf_t;
+ typedef struct mbedtls_ssl_context* tlsctx_p;


### PR DESCRIPTION
Maintainer:  @mars642 
Compile tested: x86_64
Run tested: no

Description:
The basicstation build fails since the change to the new major version 3.x of mbedtls, because of API changes in the new mbedtls version.

To fix the compilation for new mbedtls version, the waiting pullrequest is backported as a patch.

Thanks to 'Glenn Strauss' to create this PR:
https://github.com/lorabasics/basicstation/pull/198