### PR TITLE
ci: fix APK version detection

### DIFF
--- a/.github/workflows/check-apk-valid-version.yml
+++ b/.github/workflows/check-apk-valid-version.yml
@@ -48,14 +48,16 @@ jobs:
                 PKG_RELEASE=$(grep -E '^PKG_RELEASE' "$ROOT/Makefile" | cut -f 2 -d '=')
                 if [ -n "$PKG_RELEASE" ]; then
                   if [[ "$PKG_RELEASE" == '^[0-9]+$' ]]; then
-                    INCOMPATIBLE_VERSION+="$ROOT"
+                    echo "PKG_RELEASE is not an integer"
+                    INCOMPATIBLE_VERSION+=" $ROOT"
                     break
                   fi
                 fi
                 PKG_VERSION=$(grep -E '^PKG_VERSION' "$ROOT/Makefile" | cut -f 2 -d '=')
                 if [ -n "$PKG_VERSION" ]; then
-                  if $GITHUB_WORKSPACE/apk version --check "$PKG_VERSION"; then
-                    INCOMPATIBLE_VERSION+="$ROOT"
+                  if [[ $($GITHUB_WORKSPACE/apk version --check "$PKG_VERSION") -ne "" ]]; then
+                    echo "PKG_VERSION is not compatible"
+                    INCOMPATIBLE_VERSION+=" $ROOT"
                   fi
                 fi
               fi


### PR DESCRIPTION
This action was mostly based on the autorelease CI job and somehow there is an error that if multiple packages are affected, the path is concatenated instead of adding a space.

Secondly the APK return code 0 wasn't good enough for the if condition and caused it to trigger even on valid versions.