### PR TITLE
natmap: allow binding to a port or port range

### DIFF
--- a/net/natmap/Makefile
+++ b/net/natmap/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=natmap
 PKG_VERSION:=20240813
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/heiher/natmap/releases/download/$(PKG_VERSION)

--- a/net/natmap/files/natmap.init
+++ b/net/natmap/files/natmap.init
@@ -24,7 +24,7 @@ validate_section_natmap() {
 		'interval:uinteger' \
 		'stun_server:host' \
 		'http_server:host' \
-		'port:portrange' \
+		'port:or(port,portrange)' \
 		'forward_target:host' \
 		'forward_port:port' \
 		'notify_script:file' \


### PR DESCRIPTION
Maintainer: @ysc3839 @heiher
Compile tested: armsr-armv8, snapshot; ramips-mt7621, 23.05
Run tested: ramips-mt7621, 23.05

Description:

1. Allow binding to a port or port range.