### PR TITLE
docker: Update to 27.1.2

### DIFF
--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker
-PKG_VERSION:=27.1.1
+PKG_VERSION:=27.1.2
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/docker/cli
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=84db222b6d65695f3d8ae02acf8f21d90fb3f2169754bb94d314864c37bac7f3
-PKG_GIT_SHORT_COMMIT:=6312585 # SHA1 used within the docker executables
+PKG_HASH:=e60fddb2bd2b4e19790d26b786c930e70fa935168373ef08055f74bbc450bce8
+PKG_GIT_SHORT_COMMIT:=d01f264 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=27.1.1
+PKG_VERSION:=27.1.2
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=d8afaa4513d324db5841ced641daeee9090802c765b78f1c583bc171e9b0a6fd
-PKG_GIT_SHORT_COMMIT:=cc13f95 # SHA1 used within the docker executables
+PKG_HASH:=8c9b5fa44f0272726484c925d4d05f0aa189053ed8be9b27447bc116df1e99c9
+PKG_GIT_SHORT_COMMIT:=f9522e5 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: all supported targets
Run tested: N/A

Description:
**docker: Update to 27.1.2**
_For more information, visit https://github.com/docker/cli/compare/v27.1.1...v27.1.2_

**dockerd: Update to 27.1.2**
Fix a regression that could result in a ResourceExhausted desc = grpc: received message larger than max error when building from a large Dockerfile.
CLI: Fix docker attach exiting on SIGINT instead of forwarding the signal to the container and waiting for it to exit.
CLI: Fix --device-read-bps and --device-write-bps options not taking effect.
CLI: Fix a panic happening in some cases while running a plugin.
Update BuildKit to v0.15.1.
Update Buildx to v0.16.2.
Update Go runtime to 1.21.13.
_For more information, visit https://github.com/moby/moby/compare/v27.1.1...v27.1.2_