### PR TITLE
bcm27xx-eeprom: update to latest version

### DIFF
--- a/utils/bcm27xx-eeprom/Makefile
+++ b/utils/bcm27xx-eeprom/Makefile
@@ -1,17 +1,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcm27xx-eeprom
-PKG_VERSION:=v2024.04.20-2712
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/raspberrypi/rpi-eeprom/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=83ea92e64d9a620376ef081d69f3cdde5a8b376b4a56aeb685f8a56dd10e7b14
-
-PKG_LICENSE:=BSD-3-Clause Custom
-PKG_LICENSE_FILES:=LICENSE
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/raspberrypi/rpi-eeprom
+PKG_SOURCE_DATE:=2024-06-05
+PKG_SOURCE_VERSION:=e430a41e7323a1e28fb42b53cf79e5ba9b5ee975
+PKG_MIRROR_HASH:=6c9a45d4ea0f33a9dc18f11b6cdeb425f0682dc41099df3a1f350939aecce353
 
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
+PKG_LICENSE:=BSD-3-Clause Custom
+PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -76,7 +76,7 @@ define Package/bcm2711-eeprom/install
 	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2711/default
 
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader-2711
-	$(CP) $(PKG_BUILD_DIR)/firmware-2711/default/pieeprom-2024-04-15.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/default
+	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/pieeprom-2024-05-17.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/default
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/default/recovery.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/default
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/default/vl805-000138c0.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/default
 endef
@@ -86,7 +86,7 @@ define Package/bcm2712-eeprom/install
 	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2712/default
 
 	$(CP) $(PKG_BUILD_DIR)/firmware-2712/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader-2712
-	$(CP) $(PKG_BUILD_DIR)/firmware-2712/default/pieeprom-2024-04-20.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/default
+	$(CP) $(PKG_BUILD_DIR)/firmware-2712/default/pieeprom-2024-06-05.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/default
 	$(CP) $(PKG_BUILD_DIR)/firmware-2712/default/recovery.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/default
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm27xx/bcm2712
Run tested: RPi 5

Description:
New eeprom firmwares for BCM2711 (RPi 4) and BCM2712 (RPi 5).
Full changelog: https://github.com/raspberrypi/rpi-eeprom/compare/v2024.04.20-2712...v2024.06.05-2712

Also makes PKG_VERSION compatible with APK (https://github.com/openwrt/packages/issues/23706).