### PR TITLE
bind: bump to 9.18.28

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.18.27
+PKG_VERSION:=9.18.28
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=ea3f3d8cfa2f6ae78c8722751d008f54bc17a3aed2be3f7399eb7bf5f4cda8f1
+PKG_HASH:=e7cce9a165f7b619eefc4832f0a8dc16b005d29e3890aed6008c506ea286a5e7
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Fixes CVEs:
- CVE-2024-1975: remove sig 0 support
- CVE-2024-4076: qctx-zversion was not being cleared when it should have been leading to an assertion failure if it needed to be reused.
- CVE-2024-1737: An excessively large number of rrtypes per owner can slow down database query processing, so a limit has been placed on the number of rrtypes that can be stored per owner (node) in a cache or zone database. This is configured with the new "max-rrtypes-per-name" option, and defaults to 100.
- CVE-2024-1737: Excessively large rdatasets can slow down database query processing, so a limit has been placed on the number of records that can be stored per rdataset in a cache or zone database. This is configured with the new "max-records-per-type" option, and defaults to 100.
- CVE-2024-0760: Malicious DNS client that sends many queries over TCP but never reads responses can cause server to respond slowly or not respond at all for other clients.

Maintainer: me 
Compile tested: mvebu/openwrt-23.05
Run tested: mvebu/openwrt-23.05 running in production
