### PR TITLE
squeezelite: handle option to unmute ALSA control

### DIFF
--- a/sound/squeezelite/Makefile
+++ b/sound/squeezelite/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squeezelite
 PKG_VERSION:=1.9.9-1432
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/ralph-irving/squeezelite

--- a/sound/squeezelite/files/squeezelite.init
+++ b/sound/squeezelite/files/squeezelite.init
@@ -102,6 +102,10 @@ make_cmdline() {
 	local dop
 	config_get dop options dsd_over_pcm 0
 	[ "$dop" -eq 1 ] && cmdline="$cmdline -D"
+
+	local unmute
+	config_get unmute options unmute ""
+	[ -n "$unmute" ] && cmdline="$cmdline -U $unmute"
 }
 
 start_service() {


### PR DESCRIPTION
Add logic in squeezelite.init to handle -U <control> cmdline option and squeezelite.options.unmute=<control> uci option.

Maintainer: @thess 
Run tested: SNAPSHOT r27140-ccc06f6716