### PR TITLE
-- Add New Packages

### DIFF
--- a/libs/kasalua/Makefile
+++ b/libs/kasalua/Makefile
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=kasalua
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL=https://github.com/TheRootED24/kasalua.git
+PKG-BRANCH=main
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2024-07-28
+
+PKG_SOURCE_VERSION:=8b8c3ef4ba7904a59ad93ad176dbad2244a1c94b
+PKG_MIRROR_HASH:=6bb74ecad467044c12cb364c067aebc2f857f40b1d94259ce89dd4187e85d911
+
+PKG_MAINTAINER:=Scott Mercrer <TheRootED24@gmail.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENCE
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/kasalua
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=OpenWrt kasalua provides high level lua binding to the Kasa C interface library with minimal overhead
+  DEPENDS:=+liblua
+endef
+
+TARGET_CFLAGS += -std=gnu99 -I$(STAGING_DIR)/usr/include/kasalua/
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/kasalua
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/*.h \
+		$(1)/usr/include/kasalua/
+
+	$(INSTALL_DIR) $(1)/usr/lib/lua/kasalua
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/kasa.so* \
+		$(1)/usr/lib/lua/kasalua/
+	
+endef
+
+define Package/kasalua/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/kasalua
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ipkg-install/usr/lib/lua/kasa/kasa.so* $(1)/usr/lib/lua/kasalua/
+endef
+
+$(eval $(call BuildPackage,kasalua))

--- a/libs/mgjson/Makefile
+++ b/libs/mgjson/Makefile
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mgjson
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL=https://github.com/TheRootED24/mgjson.git
+PKG-BRANCH=openwrt
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2024-08-17
+			
+PKG_SOURCE_VERSION:=9793e7ba97f1197909dda8fa3002673e4dd7266b
+
+PKG_MIRROR_HASH:=fcd329401b06734f1e4ca30b34dafcbcafa09dda3d42232dac5363d61cde0871
+
+PKG_MAINTAINER:=Scott Mercer <TheRootED24@gmail.com>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=LICENSE
+
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/mgjson
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=A Stripped down OpenWrt version of Mongoose C Networking. mgjson Provides only the mg_json, mg_str, and mg_iobuf functionilty from the Mongoose Library.
+endef
+
+TARGET_CFLAGS += -std=gnu99 -I$(STAGING_DIR)/usr/include/mgjson/
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/mgjson
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/*.h \
+		$(1)/usr/include/mgjson/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/libmgjson.so \
+		$(1)/usr/lib/
+	
+endef
+
+define Package/mgjson/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ipkg-install/usr/lib/libmgjson.so $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,mgjson))

--- a/libs/mongoose/Makefile
+++ b/libs/mongoose/Makefile
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mongoose
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL=https://github.com/TheRootED24/libmongoose.git
+PKG-BRANCH=main
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2024-08-17
+			
+PKG_SOURCE_VERSION:=7ed296cba65a1a02f1f686ed1c8858d0c7eea114
+PKG_MIRROR_HASH:=cb99d6b4a80d85e05fa30be9d0c0182579eff3e9ba0b72dd212a5bc4eaf506e1
+
+PKG_MAINTAINER:=Scott Mercer <TheRootED24@gmail.com>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/mongoose
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=OpenWrt Mongoose C Networking shared Library
+  DEPENDS:=+libopenssl
+endef
+
+TARGET_CFLAGS += -std=gnu99 -I$(STAGING_DIR)/usr/include/mongoose/
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/mongoose
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/*.h \
+		$(1)/usr/include/mongoose/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/libmongoose.so* \
+		$(1)/usr/lib/
+	
+endef
+
+define Package/mongoose/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ipkg-install/usr/lib/libmongoose.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,mongoose))

--- a/utils/jsonmg/Makefile
+++ b/utils/jsonmg/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=jsonmg
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL=https://github.com/TheRootED24/jsonmg.git
+PKG-BRANCH=main
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2024-08-15
+			
+PKG_SOURCE_VERSION:=6a1d6b78bc736ac680c9b0bb4b0a873ef92ba70d
+
+PKG_MIRROR_HASH:=bc63690b7e63f27ca73ea9e3802a9b57226bf632f5000b37ce8c7b0f26008698
+
+PKG_MAINTAINER:=Scott Mercer <TheRootED24@gmail.com>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_FLAGS:=lto
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/jsonmg
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:= A basic JSON parsing and serialization library. 
+  DEPENDS:=+mgjson +liblua
+endef
+
+TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include/mgjson/
+
+define Package/jsonmg/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/jsonmg
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ipkg-install/usr/lib/lua/jsonmg/jsonmg.so $(1)/usr/lib/lua/jsonmg
+endef
+
+$(eval $(call BuildPackage,jsonmg))


### PR DESCRIPTION
--mongoose - Makefile to compile, The Mongoose C Networking Library, as a share>

--mgjson - A stripped down version of the Mongoose Library, provide just the mg>

--kasalua -  A high level lua binding to the KasaC library, for interacting wit>

-- jsonmg - A high level lua binding to the mgjson library. Provides a JSON parser and stringifyer, much like the luci.jsonc bindings.

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
