### PR TITLE
libuwsc: bump PKG_RELEASE for APK

### DIFF
--- a/libs/libuwsc/Makefile
+++ b/libs/libuwsc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuwsc
 PKG_VERSION:=3.3.5
-PKG_RELEASE:=5.1
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://github.com/zhaojh329/libuwsc/releases/download/v$(PKG_VERSION)


### PR DESCRIPTION
PKG_RELEASE must be an integer.

Maintainer: @zhaojh329 