### PR TITLE
ntfs-3g: Bump to 2022.10.3

### DIFF
--- a/utils/ntfs-3g/Makefile
+++ b/utils/ntfs-3g/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntfs-3g
-PKG_VERSION:=2022.5.17
+PKG_VERSION:=2022.10.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)_ntfsprogs-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://www.tuxera.com/opensource/
-PKG_HASH:=0489fbb6972581e1b417ab578d543f6ae522e7fa648c3c9b49c789510fd5eb93
+PKG_HASH:=f20e36ee68074b845e3629e6bced4706ad053804cbaf062fbae60738f854170c
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=GPL-2.0-only LGPL-2.1-or-later


### PR DESCRIPTION

Maintainer: @thess / @neheb
Compile tested:x86_64
Run tested: QEMU x86_64, master

Description:

This fixes CVE-2022-40284.

Security release 2022.10.3 (Oct 31, 2022)

 * Rejected zero-sized runs
 * Avoided merging runlists with no runs
