### PR TITLE
Add package jsonmg

### DIFF
--- a/libs/kasalua/Makefile
+++ b/libs/kasalua/Makefile
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=kasalua
+PKG_RELEASE:=1
+
+PKG-BRANCH=main
+PKG_SOURCE_URL=https://github.com/TheRootED24/kasalua.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2024-07-28
+
+PKG_SOURCE_VERSION:=8b8c3ef4ba7904a59ad93ad176dbad2244a1c94b
+PKG_MIRROR_HASH:=0a8aaae89e9b3d6a1db7768b6388d8fecb8da146e5c1a679343ee3bfd1b77b9a
+
+PKG_MAINTAINER:=Scott Mercrer <TheRootED24@gmail.com>
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENCE
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/kasalua
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=OpenWrt kasalua provides high level lua binding to the Kasa C interface library with minimal overhead
+  DEPENDS:=+liblua
+endef
+
+TARGET_CFLAGS += -std=gnu99 -I$(STAGING_DIR)/usr/include/kasalua/
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/kasalua
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/*.h \
+		$(1)/usr/include/kasalua/
+
+	$(INSTALL_DIR) $(1)/usr/lib/lua/kasalua
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/kasa.so* \
+		$(1)/usr/lib/lua/kasalua/
+	
+endef
+
+define Package/kasalua/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/kasalua
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ipkg-install/usr/lib/lua/kasa/kasa.so* $(1)/usr/lib/lua/kasalua/
+endef
+
+$(eval $(call BuildPackage,kasalua))

--- a/libs/mgjson/Makefile
+++ b/libs/mgjson/Makefile
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mgjson
+PKG_RELEASE:=1
+
+PKG-BRANCH=main
+PKG_SOURCE_URL=https://github.com/TheRootED24/mgjson.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2024-08-17
+
+PKG_SOURCE_VERSION:=9793e7ba97f1197909dda8fa3002673e4dd7266b
+PKG_MIRROR_HASH:=85c5b3c3704e0b834f4d315b345baadd79a5e972bf688f46269d2887d4ae6acd
+
+PKG_MAINTAINER:=Scott Mercer <TheRootED24@gmail.com>
+
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/mgjson
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=A Stripped down OpenWrt version of Mongoose C Networking. mgjson provides only the mg_json, mg_str, and mg_iobuf, functionilty of the Mongoose Library.
+endef
+
+TARGET_CFLAGS += -std=gnu99 -I$(STAGING_DIR)/usr/include/mgjson/
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/mgjson
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/*.h \
+		$(1)/usr/include/mgjson/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/libmgjson.so \
+		$(1)/usr/lib/
+	
+endef
+
+define Package/mgjson/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ipkg-install/usr/lib/libmgjson.so $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,mgjson))


### PR DESCRIPTION
Maintainer: Scott Mercer / @\TheRootED24(find it by checking history of the package Makefile)
Compile tested: (ATH79, gl-inet, OpenWrt version r27160-b72c4b5386)
Run tested: (ATH79, gl-inet, OpenWrt version r27160-b72c4b5386, tests done Basic Functionality, valgrind 0 errors 0 bytes in use at exit)

Description:
jsonmg: A basic JSON parsing and serialization library. Provides high level Lua binding to the Mongoose C Neworking library to allow reading and writing JSON data with minimal overhead.

