### PR TITLE
dnsproxy: Update to 0.73.0

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.72.3
+PKG_VERSION:=0.73.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=40910c1b8a24d2beb4835fc42dd9d38f35cd7e6239f813015a36e0c64f0c12aa
+PKG_HASH:=e735faf47b066d348d70ecddabd1c37e3f06050c5a7e83ff932c552f0775b375
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: @1715173329
Compile tested: all supported targets
Run tested: rockchip/armv8

Description:
**_dnsproxy: Update to 0.73.0_**
Added
The and the options, which control the preliminary resolving , and requests from hosts (5) files before using the upstream servers.--hosts-file-enabled--hosts-filesAAAAAPTR

Note
The functionality is enabled and uses the OS-specific hosts files by default. To disable it, use option.--hosts-file-enabled=false

Changed
The upstream.AddressToUpstream now validates the host as a domain name, as opposed to the hostname validation used before. The same also applies to the proxy.ParseUpstreamConfig function.
The proxy.MessageConstructor interface has been changed to include one additional method .NewMsgNODATA

Removed
proxy.CheckDisabledAAAARequest function, use proxy.RequestHandler to halt AAAA requests.
proxy.GenEmptyMessage function.
**_For more information, visit https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.73.0_**