### PR TITLE
ddns-scripts: Add IPv6 and https for OVH

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=46
+PKG_RELEASE:=47
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/ovh.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/ovh.com.json
@@ -1,7 +1,11 @@
 {
 	"name": "ovh.com",
 	"ipv4": {
-		"url": "http://[USERNAME]:[PASSWORD]@www.ovh.com/nic/update?system=dyndns&hostname=[DOMAIN]&myip=[IP]",
+		"url": "https://[USERNAME]:[PASSWORD]@dns.eu.ovhapis.com/nic/update?system=dyndns&hostname=[DOMAIN]&myip=[IP]",
+		"answer": "good|nochg"
+	},
+	"ipv6": {
+		"url": "https://[USERNAME]:[PASSWORD]@dns.eu.ovhapis.com/nic/update?system=dyndns&hostname=[DOMAIN]&myip=[IP]",
 		"answer": "good|nochg"
 	}
 }


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: -
Run tested: x86 on 23.05.4

Description:
ovh.com supports https and IPv6 since March 2024:
https://github.com/ovh/manager/pull/11307/commits/08893f66dcbd040be1125a7003c2c538b98a32b2

New API operates under domain dns.eu.ovhapis.com:
https://help.ovhcloud.com/csm/en-gb-dns-dynhost?id=kb_article_view&sysparm_article=KB0051640

Add IPv6 support, use https and updated domain for ovh.com.