### PR TITLE
dnsproxy: Update to 0.73.1

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.73.0
+PKG_VERSION:=0.73.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=e735faf47b066d348d70ecddabd1c37e3f06050c5a7e83ff932c552f0775b375
+PKG_HASH:=189462fe1255b4f58d39d4ea3c1696200fa65596fcb58e1a35c0545ba6b80618
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: @1715173329
Compile tested: all supported targets
Run tested: rockchip/armv8

Description:
**_dnsproxy: Update to 0.73.1_**
Fixed: The hosts-file-enabled field of the YAML configuration could not be parsed.

**_For more information, visit https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.73.1_**