### PR TITLE
stubby: update domain names and change cipher preferences

### DIFF
--- a/net/stubby/Makefile
+++ b/net/stubby/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stubby
 PKG_VERSION:=0.4.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/getdnsapi/$(PKG_NAME)

--- a/net/stubby/Makefile
+++ b/net/stubby/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stubby
 PKG_VERSION:=0.4.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/getdnsapi/$(PKG_NAME)

--- a/net/stubby/files/README.md
+++ b/net/stubby/files/README.md
@@ -378,13 +378,23 @@ stubby daemon. By default, this is an empty string.
 If set, this specifies the acceptable ciphers for DNS over TLS. With OpenSSL
 1.1.1 this list is for TLS1.2 and older only. Ciphers for TLS1.3 should be set
 with the `tls_ciphersuites` option. This option can also be given per upstream
-resolver. By default, this option is not set.
+resolver. The default value is `'EECDH+CHACHA20:EECDH+AESGCM'`. Set to
+`'EECDH+AESGCM:EECDH+CHACHA20'` to prefer AES over ChaCha, if the CPU of the
+OpenWRT device has the [AES instruction
+set](https://en.wikipedia.org/wiki/AES_instruction_set).
 
 #### `option tls_ciphersuites`
 
 If set, this specifies the acceptable cipher for DNS over TLS1.3. OpenSSL
 version 1.1.1 or greater is required for this option. This option can also be
-given per upstream resolver. By default, this option is not set.
+given per upstream resolver. The default value is
+`'TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384'`.
+Set to
+`'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256'`
+or
+`'TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256'`
+to prefer AES over ChaCha, if the CPU of the OpenWRT device has the [AES
+instruction set](https://en.wikipedia.org/wiki/AES_instruction_set).
 
 #### `option tls_min_version`
 

--- a/net/stubby/files/stubby.conf
+++ b/net/stubby/files/stubby.conf
@@ -19,8 +19,8 @@ config stubby 'global'
        list listen_address '0::1@5453'
        # option log_level '7'
        # option command_line_arguments ''
-       # option tls_cipher_list 'EECDH+AESGCM:EECDH+CHACHA20'
-       # option tls_ciphersuites 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256'
+       option tls_cipher_list 'EECDH+CHACHA20:EECDH+AESGCM'
+       option tls_ciphersuites 'TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384'
        # option tls_min_version '1.2'
        # option tls_max_version '1.3'
 
@@ -30,8 +30,8 @@ config resolver
        option tls_auth_name 'one.one.one.one'
        # option tls_port 853
        # list spki 'sha256/yioEpqeR4WtDwE9YxNVnCEkTxIjx6EEIwFSQW+lJsbc='
-       # option tls_cipher_list 'EECDH+AESGCM:EECDH+CHACHA20'
-       # option tls_ciphersuites 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256'
+       # option tls_cipher_list 'EECDH+CHACHA20:EECDH+AESGCM'
+       # option tls_ciphersuites 'TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384'
        # option tls_min_version '1.2'
        # option tls_max_version '1.3'
 
@@ -40,8 +40,8 @@ config resolver
        option tls_auth_name 'one.one.one.one'
        # option tls_port 853
        # list spki 'sha256/yioEpqeR4WtDwE9YxNVnCEkTxIjx6EEIwFSQW+lJsbc='
-       # option tls_cipher_list 'EECDH+AESGCM:EECDH+CHACHA20'
-       # option tls_ciphersuites 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256'
+       # option tls_cipher_list 'EECDH+CHACHA20:EECDH+AESGCM'
+       # option tls_ciphersuites 'TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384'
        # option tls_min_version '1.2'
        # option tls_max_version '1.3'
 
@@ -50,8 +50,8 @@ config resolver
        option tls_auth_name 'one.one.one.one'
        # option tls_port 853
        # list spki 'sha256/yioEpqeR4WtDwE9YxNVnCEkTxIjx6EEIwFSQW+lJsbc='
-       # option tls_cipher_list 'EECDH+AESGCM:EECDH+CHACHA20'
-       # option tls_ciphersuites 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256'
+       # option tls_cipher_list 'EECDH+CHACHA20:EECDH+AESGCM'
+       # option tls_ciphersuites 'TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384'
        # option tls_min_version '1.2'
        # option tls_max_version '1.3'
 
@@ -60,7 +60,7 @@ config resolver
        option tls_auth_name 'one.one.one.one'
        # option tls_port 853
        # list spki 'sha256/yioEpqeR4WtDwE9YxNVnCEkTxIjx6EEIwFSQW+lJsbc='
-       # option tls_cipher_list 'EECDH+AESGCM:EECDH+CHACHA20'
-       # option tls_ciphersuites 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256'
+       # option tls_cipher_list 'EECDH+CHACHA20:EECDH+AESGCM'
+       # option tls_ciphersuites 'TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384'
        # option tls_min_version '1.2'
        # option tls_max_version '1.3'

--- a/net/stubby/files/stubby.conf
+++ b/net/stubby/files/stubby.conf
@@ -27,7 +27,7 @@ config stubby 'global'
 # Upstream resolvers are specified using 'resolver' sections.
 config resolver
        option address '2606:4700:4700::1111'
-       option tls_auth_name 'cloudflare-dns.com'
+       option tls_auth_name 'one.one.one.one'
        # option tls_port 853
        # list spki 'sha256/yioEpqeR4WtDwE9YxNVnCEkTxIjx6EEIwFSQW+lJsbc='
        # option tls_cipher_list 'EECDH+AESGCM:EECDH+CHACHA20'
@@ -37,7 +37,7 @@ config resolver
 
 config resolver
        option address '2606:4700:4700::1001'
-       option tls_auth_name 'cloudflare-dns.com'
+       option tls_auth_name 'one.one.one.one'
        # option tls_port 853
        # list spki 'sha256/yioEpqeR4WtDwE9YxNVnCEkTxIjx6EEIwFSQW+lJsbc='
        # option tls_cipher_list 'EECDH+AESGCM:EECDH+CHACHA20'
@@ -47,7 +47,7 @@ config resolver
 
 config resolver
        option address '1.1.1.1'
-       option tls_auth_name 'cloudflare-dns.com'
+       option tls_auth_name 'one.one.one.one'
        # option tls_port 853
        # list spki 'sha256/yioEpqeR4WtDwE9YxNVnCEkTxIjx6EEIwFSQW+lJsbc='
        # option tls_cipher_list 'EECDH+AESGCM:EECDH+CHACHA20'
@@ -57,7 +57,7 @@ config resolver
 
 config resolver
        option address '1.0.0.1'
-       option tls_auth_name 'cloudflare-dns.com'
+       option tls_auth_name 'one.one.one.one'
        # option tls_port 853
        # list spki 'sha256/yioEpqeR4WtDwE9YxNVnCEkTxIjx6EEIwFSQW+lJsbc='
        # option tls_cipher_list 'EECDH+AESGCM:EECDH+CHACHA20'

--- a/net/stubby/files/stubby.yml
+++ b/net/stubby/files/stubby.yml
@@ -14,6 +14,8 @@ listen_addresses:
   - 0::1@5453
 dns_transport_list:
   - GETDNS_TRANSPORT_TLS
+tls_cipher_list: "EECDH+CHACHA20:EECDH+AESGCM"
+tls_ciphersuites: "TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384"
 upstream_recursive_servers:
   - address_data: 2606:4700:4700::1111
     tls_auth_name: "one.one.one.one"

--- a/net/stubby/files/stubby.yml
+++ b/net/stubby/files/stubby.yml
@@ -16,10 +16,10 @@ dns_transport_list:
   - GETDNS_TRANSPORT_TLS
 upstream_recursive_servers:
   - address_data: 2606:4700:4700::1111
-    tls_auth_name: "cloudflare-dns.com"
+    tls_auth_name: "one.one.one.one"
   - address_data: 2606:4700:4700::1001
-    tls_auth_name: "cloudflare-dns.com"
+    tls_auth_name: "one.one.one.one"
   - address_data: 1.1.1.1
-    tls_auth_name: "cloudflare-dns.com"
+    tls_auth_name: "one.one.one.one"
   - address_data: 1.0.0.1
-    tls_auth_name: "cloudflare-dns.com"
+    tls_auth_name: "one.one.one.one"


### PR DESCRIPTION
Maintainer: n/a
Compile tested: mipsel_24kc, Xiaomi Mi Router AC2100, v23.05.4
Run tested: mipsel_24kc, Xiaomi Mi Router AC2100, v23.05.4

Description:
1. Update domain names of default resolvers based on official docs (https://developers.cloudflare.com/1.1.1.1/encryption/dns-over-tls/).
2. Most embedded devices do not have processors that support AES instructions. Using ChaCha is faster than using AES-related ciphers for such devices. Adjust default preferences of ciphers to have better performance.