### PR TITLE
netbird: update to 0.28.9 and add test

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.28.7
-PKG_RELEASE:=2
+PKG_VERSION:=0.28.9
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2e51ea86c2c127b0e5c2d459a1d598f95d731e167cf557018b5a97d63117835a
+PKG_HASH:=c3cc721330cbe8341665e982f8e7c77e0a37f0fedaee07f44fc78b5e200eb1c3
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/test.sh
+++ b/net/netbird/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+"${PKG_NAME}" version | grep "${PKG_VERSION}"


### PR DESCRIPTION
## Compile and run tested

Maintainer: Oskari Rauta / @oskarirauta

| Package architecture | Target | Subtarget | Brand | Model | Hardware Version | OpenWrt version |
|----------------------|--------|-----------|-------|-------|------------------|-----------------|
| [x86_64](https://openwrt.org/docs/techref/instructionset/x86_64) | [x86](https://openwrt.org/docs/techref/targets/x86) | 64 | [Duex](https://duex.com.br/) | [DX B75ZG M.2 Intel LGA 1155 DDR3](https://duex.com.br/produto/placa-mae-dx-b75zg-m-2-intel-lga-1155-ddr3/) | n/a | OpenWrt SNAPSHOT r27195-cddda1d44d ~r27195-cddda1d44d~ |

## Description

- Changelog:
  - [v0.28.9](https://github.com/netbirdio/netbird/releases/tag/v0.28.9)
  - [v0.28.8](https://github.com/netbirdio/netbird/releases/tag/v0.28.8)
- Full changelog: https://github.com/netbirdio/netbird/compare/v0.28.7...v0.28.9
- Add simple test to check package version.

## Additional information

`x86_64` running as container with [`incus`](https://github.com/lxc/incus).
Compiled package with container [`sdk`](https://github.com/openwrt/docker), and build `openwrt` image with container [`imagebuilder`](https://github.com/openwrt/docker).

My repo with my automated build can be see here:
- https://github.com/wehagy/openwrt-builder

And my artifacts here:
- https://github.com/wehagy/openwrt-builder/actions/runs/10533390853
- ~https://github.com/wehagy/openwrt-builder/actions/runs/10495737537~
