### PR TITLE
mstflint: update to 4.29.0

### DIFF
--- a/utils/mstflint/Makefile
+++ b/utils/mstflint/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mstflint
-PKG_VERSION:=4.28.0
+PKG_VERSION:=4.29.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-1.tar.gz
 PKG_SOURCE_URL:=https://github.com/Mellanox/$(PKG_NAME)/releases/download/v$(PKG_VERSION)-1
-PKG_SOURCE_DATE:=2024-05-06
-PKG_HASH:=cef08373ff7002a4f75c123d03990ea6b9e79b9d8493ca067b625eddd287b62d
+PKG_SOURCE_DATE:=2024-08-13
+PKG_HASH:=1bd048146f1fe0493d4770b244b02e32981b49caed068fd96a22700103220654
 
 PKG_MAINTAINER:=Til Kaiser <mail@tk154.de>
 PKG_LICENSE:=GPL-2.0-only
@@ -32,7 +32,7 @@ define Package/mstflint
   TITLE:=Mellanox Firmware Burning and Diagnostics Tools
   URL:=https://github.com/Mellanox/mstflint
   DEPENDS:=@!(mips||mips64||mipsel) \
-    +libcurl +liblzma +libopenssl \
+    +libcurl +libexpat +liblzma +libopenssl \
     +libsqlite3 +libstdcpp +libxml2 +zlib
 endef
 
@@ -90,7 +90,8 @@ endef
 
 CONFIGURE_ARGS += \
 	--enable-fw-mgr \
-	--disable-inband
+	--disable-inband \
+	--enable-adb-generic-tools
 
 TARGET_CFLAGS += \
 	-D_GNU_SOURCE \
@@ -110,11 +111,14 @@ define Package/mstflint/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstconfig $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstcongestion $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstflint $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstfwctrl $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstfwmanager $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstlink $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstmcra $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstmread $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstmtserver $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstmwrite $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstreg $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstregdump $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstvpd $(1)/usr/bin/
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Mellanox Spectrum, OpenWrt trunk
Run tested: x86_64, Mellanox Spectrum, OpenWrt trunk, tests done

Description:
This commit updates the `mstflint` package to the latest `4.29.0` release, including the new binaries `mstfwctrl`, `mstlink`, `mstreg`, and `libexpat` as a new dependency.