### PR TITLE
tailscale: Update to 1.72.1

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.70.0
+PKG_VERSION:=1.72.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8429728708f9694534489daa0a30af58be67f25742597940e7613793275c738f
+PKG_HASH:=21b529e85144f526b61e0998c8b7885d53f17cba21252e5c7252c4014f5f507b
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: @ja-pa
Compile tested: rockchip/armv8
Run tested: N/A

Description:
**_tailscale: Update to 1.72.1_**
[Captive portal detection](https://tailscale.com/kb/1457/captive-portals) is now supported.
The [tailscale cert](https://tailscale.com/kb/1080/cli/#cert) command now contains the --min-validity flag. Use this flag to request a specified minimum remaining validity on the returned certificate. This flag is intended for automation, like cron jobs, that periodically refreshes certificates.
The [tailscale lock](https://tailscale.com/kb/1243/tailscale-lock) command now supports passing keys as files. To pass a key as a file, use the prefix file: followed by the path to the file: file:<path-to-key-file>.
A health warning is now raised if Tailscale is unable to forward DNS queries to the configured resolvers.
An increase in send and receive buffer sizes for userspace mode TCP improves throughput over high latency paths.
The addition of TCP generic segmentation offload (GSO) support to userspace mode improves throughput.
DNS over TCP failures when querying the Tailscale-internal resolver are fixed.

**_For more information, visit https://github.com/tailscale/tailscale/compare/v1.70.0...v1.72.1 https://tailscale.com/changelog_**