### PR TITLE
hv-tools: add new package: hyper-v guest tools

### DIFF
--- a/utils/hv-tools/Makefile
+++ b/utils/hv-tools/Makefile
@@ -1,0 +1,52 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=hv-tools
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/NikulovE/hv-tools/
+PKG_SOURCE_VERSION:=089a8d7376404eb873860b6fcb85b409a5d385fe
+PKG_MIRROR_HASH:=0e08eea3dbb00180eb738583f6c28f95921ffcbc3ba7f7217637777e62678493
+
+PKG_MAINTAINER:=Evgeniy Nikulov <nikulov@live.ru>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+define Package/hv-tools
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Virtualization
+  TITLE:=Hyper-V Guest Tools
+  DEPENDS:=+procd +libpthread @(TARGET_x86||TARGET_x86_64)
+endef
+
+define Package/hv-tools/description
+  This package contains Hyper-V Guest Tools for OpenWrt, including various utilities and daemons.
+endef
+
+define Build/Compile
+	$(MAKE_VARS) $(MAKE) $(MAKE_FLAGS) all -C $(PKG_BUILD_DIR)/files/tools/hv
+endef
+
+define Package/hv-tools/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/tools/hv/hv_kvp_daemon $(1)/usr/sbin/hv_kvp_daemon
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/tools/hv/hv_vss_daemon $(1)/usr/sbin/hv_vss_daemon
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/tools/hv/hv_fcopy_daemon $(1)/usr/sbin/hv_fcopy_daemon
+	
+	$(INSTALL_DIR) $(1)/usr/libexec/hypervkvpd 
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/libexec/hypervkvpd/hv_get_dhcp_info.sh $(1)/usr/libexec/hypervkvpd/hv_get_dhcp_info
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/libexec/hypervkvpd/hv_get_dns_info.sh $(1)/usr/libexec/hypervkvpd/hv_get_dns_info
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/libexec/hypervkvpd/hv_set_ifconfig.sh $(1)/usr/libexec/hypervkvpd/hv_set_ifconfig
+	
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/etc/init.d/hv_fcopy_daemon $(1)/etc/init.d/hv_fcopy_daemon
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/etc/init.d/hv_kvp_daemon $(1)/etc/init.d/hv_kvp_daemon
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/etc/init.d/hv_vss_daemon $(1)/etc/init.d/hv_vss_daemon
+endef
+
+$(eval $(call BuildPackage,hv-tools))


### PR DESCRIPTION
Maintainer: me
Compile tested: (x86_64, OpenWrt SNAPSHOT r27084-16959ebf5f version)
Run tested: (x86_64, OpenWrt SNAPSHOT r27084-16959ebf5f version)

Description:
Main purpose of this new package is better integration with Hyper-V via hyper-v guest tools. Hyper-V guest tools are already in Linux kernel in /tools/hv but not included any OpenWRT builds. This PR is pack to bring it back. 
Other function is turned back VSS (shadow copy) integration.
Also realized hv_set_ifconfig.sh that can be useful in cloud environment and other

Without this package:
![image](https://github.com/user-attachments/assets/6d51b712-7ff8-4940-a3b7-3eddda62df9c)
after manual installation:
![image](https://github.com/user-attachments/assets/ac4513fb-6a7f-425b-aaac-93b6e6da2b66)

