### PR TITLE
fwupd: add package

### DIFF
--- a/libs/libgudev/Makefile
+++ b/libs/libgudev/Makefile
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2024 TDT AG <development@tdt.de>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See https://www.gnu.org/licenses/gpl-2.0.txt for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libgudev
+PKG_VERSION:=238
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=@GNOME/libgudev/$(basename $(PKG_VERSION))
+PKG_HASH:=61266ab1afc9d73dbc60a8b2af73e99d2fdff47d99544d085760e4fa667b5dd1
+
+PKG_MAINTAINER:=Lukas Voegl <lvoegl@tdt.de>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=COPYING
+
+PKG_BUILD_DEPENDS:=glib2/host
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+include $(INCLUDE_DIR)/meson.mk
+
+define Package/libgudev
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=libgudev
+  URL:=https://gitlab.gnome.org/GNOME/libgudev
+  DEPENDS:= \
+  	+glib2 \
+  	+libudev
+endef
+
+define Package/libgusb/description
+  libgudev is a GObject-based wrapper library providing bindings for libudev.
+endef
+
+MESON_ARGS+= \
+	-Db_lto=true \
+	-Dtests=disabled \
+	-Dintrospection=disabled \
+	-Dvapi=disabled \
+	-Dgtk_doc=false
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/gudev-1.0/gudev
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/gudev-1.0/gudev/*.h $(1)/usr/include/gudev-1.0/gudev
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgudev-1.0.so* $(1)/usr/lib
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/gudev-1.0.pc $(1)/usr/lib/pkgconfig
+endef
+
+define Package/libgudev/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgudev-1.0.so* $(1)/usr/lib
+endef
+
+$(eval $(call BuildPackage,libgudev))

--- a/libs/libjcat/Config.in
+++ b/libs/libjcat/Config.in
@@ -1,0 +1,22 @@
+menu "Select libjcat options"
+	depends on PACKAGE_libjcat
+
+config LIBJCAT_GPG
+	bool "GPG"
+	default y
+	help
+	  Compile libjcat with GPG support
+
+config LIBJCAT_PKCS7
+	bool "PKCS #7"
+	default y
+	help
+	  Compile libjcat with PKCS #7 support
+
+config LIBJCAT_ED25519
+	bool "ed25519"
+	default n
+	help
+	  Compile libjcat with ed25519 support
+
+endmenu

--- a/libs/libjcat/Makefile
+++ b/libs/libjcat/Makefile
@@ -1,0 +1,83 @@
+#
+# Copyright (C) 2024 TDT AG <development@tdt.de>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See https://www.gnu.org/licenses/gpl-2.0.txt for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libjcat
+PKG_VERSION:=0.2.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/hughsie/libjcat/releases/download/$(PKG_VERSION)
+PKG_HASH:=a6232aeca3c3fab6dbb3bed06ec3832088b49a4b278a7119558d72be60ce921f
+
+PKG_MAINTAINER:=Lukas Voegl <lvoegl@tdt.de>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=glib2/host
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+include $(INCLUDE_DIR)/meson.mk
+
+define Package/libjcat
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=libjcat
+  URL:=https://github.com/hughsie/libjcat
+  DEPENDS:= \
+	+glib2 \
+	+json-glib \
+	+LIBJCAT_GPG:libgpgme \
+	+LIBJCAT_GPG:libgpg-error \
+	+LIBJCAT_PKCS7:libgnutls \
+	+LIBJCAT_ED25519:libgnutls \
+	+LIBJCAT_ED25519:libnettle
+endef
+
+define Package/libjcat/description
+  libjcat allows reading and writing gzip-compressed JSON catalog files,
+  which can be used to store GPG, PKCS-7 and SHA-256 checksums for each file.
+endef
+
+define Package/libjcat/config
+	source "$(SOURCE)/Config.in"
+endef
+
+MESON_ARGS += \
+	-Db_lto=true \
+	-Dgtkdoc=false \
+	-Dintrospection=false \
+	-Dvapi=false \
+	-Dtests=false \
+	-Dman=false \
+	-Dcli=false \
+	-Dgpg=$(if $(CONFIG_LIBJCAT_GPG),true,false) \
+	-Dpkcs7=$(if $(CONFIG_LIBJCAT_PKCS7),true,false) \
+	-Ded25519=$(if $(CONFIG_LIBJCAT_ED25519),true,false)
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/libjcat-1
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libjcat-1/jcat.h $(1)/usr/include/libjcat-1/jcat.h
+
+	$(INSTALL_DIR) $(1)/usr/include/libjcat-1/libjcat
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libjcat-1/libjcat/*.h $(1)/usr/include/libjcat-1/libjcat
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libjcat.so* $(1)/usr/lib
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/jcat.pc $(1)/usr/lib/pkgconfig
+endef
+
+define Package/libjcat/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libjcat.so* $(1)/usr/lib
+endef
+
+$(eval $(call BuildPackage,libjcat))

--- a/libs/libqmi/Config.in
+++ b/libs/libqmi/Config.in
@@ -19,9 +19,11 @@ choice
 
 	config LIBQMI_COLLECTION_MINIMAL
 		depends on !MODEMMANAGER_WITH_QMI
+		depends on !FWUPD_PLUGIN_MODEMMANAGER
 		bool "minimal"
 
 	config LIBQMI_COLLECTION_BASIC
+		depends on !FWUPD_PLUGIN_MODEMMANAGER
 		bool "basic (default)"
 
 	config LIBQMI_COLLECTION_FULL

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -21,6 +21,11 @@ PKG_BUILD_FLAGS:=gc-sections
 PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 PKG_CPE_ID:=cpe:/a:libqmi_project:libqmi
 
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_LIBQMI_COLLECTION_FULL \
+	CONFIG_LIBQMI_COLLECTION_BASIC \
+	CONFIG_LIBQMI_COLLECTION_MINIMAL
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/meson.mk

--- a/libs/libxmlb/Config.in
+++ b/libs/libxmlb/Config.in
@@ -1,0 +1,16 @@
+menu "Select libxmlb options"
+	depends on PACKAGE_libxmlb
+
+config LIBXMLB_LZMA
+	bool "LZMA"
+	default n
+	help
+	  Compile libxmlb with LZMA support
+
+config LIBXMLB_ZSTD
+	bool "zstd"
+	default n
+	help
+	  Compile libxmlb with zstd support
+
+endmenu

--- a/libs/libxmlb/Makefile
+++ b/libs/libxmlb/Makefile
@@ -1,0 +1,76 @@
+#
+# Copyright (C) 2024 TDT AG <development@tdt.de>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See https://www.gnu.org/licenses/gpl-2.0.txt for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libxmlb
+PKG_VERSION:=0.3.19
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/hughsie/libxmlb/releases/download/$(PKG_VERSION)
+PKG_HASH:=0a3ec258b12dbf10e5fe840b2421c84137eb7cc1b09c3de6210f3f7d51733733
+
+PKG_MAINTAINER:=Lukas Voegl <lvoegl@tdt.de>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=glib2/host
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+include $(INCLUDE_DIR)/meson.mk
+
+define Package/libxmlb
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=libxmlb
+  URL:=https://github.com/hughsie/libxmlb
+  DEPENDS:= \
+	+glib2 \
+	+LIBXMLB_LZMA:liblzma \
+	+LIBXMLB_ZSTD:libzstd
+endef
+
+define Package/libxmlb/description
+  Library to help create and query binary XML blobs.
+endef
+
+define Package/libxmlb/config
+	source "$(SOURCE)/Config.in"
+endef
+
+MESON_ARGS += \
+	-Db_lto=true \
+	-Dgtkdoc=false \
+	-Dintrospection=false \
+	-Dtests=false \
+	-Dcli=false \
+	-Dstemmer=false \
+	-Dlzma=$(if $(CONFIG_LIBXMLB_LZMA),enabled,disabled) \
+	-Dzstd=$(if $(CONFIG_LIBXMLB_ZSTD),enabled,disabled)
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/libxmlb-2
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libxmlb-2/xmlb.h $(1)/usr/include/libxmlb-2
+
+	$(INSTALL_DIR) $(1)/usr/include/libxmlb-2/libxmlb
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libxmlb-2/libxmlb/*.h $(1)/usr/include/libxmlb-2/libxmlb
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libxmlb.so* $(1)/usr/lib
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/xmlb.pc $(1)/usr/lib/pkgconfig
+endef
+
+define Package/libxmlb/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libxmlb.so* $(1)/usr/lib
+endef
+
+$(eval $(call BuildPackage,libxmlb))

--- a/utils/fwupd/Config.in
+++ b/utils/fwupd/Config.in
@@ -1,0 +1,65 @@
+menu "Select fwupd options"
+	depends on PACKAGE_fwupd-libs
+
+config FWUPD_FIRMWARE_PACKAGER
+	bool "firmware packager"
+	default n
+	help
+	  Compile fwupd with firmware packager
+
+config FWUPD_HSI
+	bool "Host Security ID"
+	default n
+	help
+	  Compile fwupd with HSI support
+
+config FWUPD_LVFS
+	bool "LVFS remote"
+	default y
+	help
+	  Compile and install LVFS remote
+
+config FWUPD_CBOR
+	bool "CBOR"
+	default n
+	help
+	  Compile fwupd with cbor protocol support
+
+config FWUPD_LZMA
+	bool "LZMA"
+	default n
+	help
+	  Compile fwupd with LZMA support
+
+config FWUPD_CURL
+	bool "curl"
+	default n
+	help
+	  Compile fwupd with curl support
+
+config FWUPD_SQLITE
+	bool "sqlite"
+	default n
+	help
+	  Compile fwupd with sqlite support
+
+config FWUPD_LIBARCHIVE
+	bool "libarchive"
+	default y
+	help
+	  Compile fwupd with libarchive support
+
+config FWUPD_GUDEV
+	bool "GUdev"
+	default n
+	help
+	  Compile fwupd with GUdev support
+
+config FWUPD_PLUGIN_MODEMMANAGER
+	bool "ModemManager plugin"
+	default y
+	select FWUPD_GUDEV
+	help
+	  Compile fwupd with ModemManager plugin
+
+endmenu

--- a/utils/fwupd/Makefile
+++ b/utils/fwupd/Makefile
@@ -1,0 +1,233 @@
+#
+# Copyright (C) 2024 TDT AG <development@tdt.de>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See https://www.gnu.org/licenses/gpl-2.0.txt for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=fwupd
+PKG_VERSION:=1.9.24
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/fwupd/fwupd/releases/download/$(PKG_VERSION)
+PKG_HASH:=12f560b35dbed981fde8cf774c6d1f2e658a157d3a63d6c439bf418dbcc44b4c
+
+PKG_MAINTAINER:=Lukas Voegl <lvoegl@tdt.de>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:fwupd:fwupd
+
+PKG_BUILD_DEPENDS:= \
+	glib2/host \
+	python3/host \
+	python-packaging/host \
+	python-jinja2/host
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+include $(INCLUDE_DIR)/meson.mk
+include ../../lang/python/python3-host.mk
+
+define Package/fwupd/Default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=fwupd
+  URL:=https://fwupd.org
+  DEPENDS:= \
+	+glib2 \
+	+dbus \
+	+libxmlb \
+	+libjcat \
+	+libprotobuf-c \
+	+FWUPD_LIBARCHIVE:libarchive \
+	+FWUPD_CBOR:libcbor \
+	+FWUPD_LZMA:liblzma \
+	+FWUPD_CURL:libcurl \
+	+FWUPD_SQLITE:libsqlite3 \
+	+FWUPD_GUDEV:libgudev \
+	+FWUPD_PLUGIN_MODEMMANAGER:modemmanager \
+	+FWUPD_PLUGIN_MODEMMANAGER:libqmi \
+	+FWUPD_PLUGIN_MODEMMANAGER:libmbim
+endef
+
+define Package/fwupd/Default/description
+  A simple system daemon to allow session software to easily update firmware on
+  your local machine.
+endef
+
+define Package/fwupd-libs
+  $(call Package/fwupd/Default)
+  TITLE:=fwupd-libs
+endef
+
+define Package/fwupd-libs/description
+  $(call Package/fwupd/Default/description)
+  This package contains the fwupd libraries.
+endef
+
+define Package/fwupd-libs/config
+  source "$(SOURCE)/Config.in"
+endef
+
+define Package/fwupd-tools
+  $(call Package/fwupd/Default)
+  DEPENDS:=+fwupd-libs
+  TITLE:=fwupd-tools
+endef
+
+define Package/fwupd-tools/description
+  $(call Package/fwupd/Default/description)
+  This package contains the fwupd cli tools.
+endef
+
+define Package/fwupd-daemon
+  $(call Package/fwupd/Default)
+  DEPENDS:=+fwupd-libs
+  TITLE:=fwupd-daemon
+endef
+
+define Package/fwupd-daemon/description
+  $(call Package/fwupd/Default/description)
+  This package contains the fwupd daemon.
+endef
+
+MESON_ARGS += \
+	-Db_lto=true \
+	-Dbuild=all \
+	-Dpython=$(HOST_PYTHON3_BIN) \
+	-Dudevdir=/lib/udev \
+	-Dsupported_build=enabled \
+	-Dstatic_analysis=false \
+	-Dtests=false \
+	-Dmetainfo=false \
+	-Dbash_completion=false \
+	-Dfish_completion=false \
+	-Dman=false \
+	-Dthinklmi_compat=false \
+	-Dconsolekit=disabled \
+	-Ddocs=disabled \
+	-Dintrospection=disabled \
+	-Dbluez=disabled \
+	-Dpolkit=disabled \
+	-Dgnutls=disabled \
+	-Dpassim=disabled \
+	-Dplugin_acpi_phat=disabled \
+	-Dplugin_amdgpu=disabled \
+	-Dplugin_android_boot=disabled \
+	-Dplugin_bcm57xx=disabled \
+	-Dplugin_cfu=disabled \
+	-Dplugin_cpu=disabled \
+	-Dplugin_emmc=disabled \
+	-Dplugin_ep963x=disabled \
+	-Dplugin_gpio=disabled \
+	-Dplugin_igsc=disabled \
+	-Dplugin_kinetic_dp=disabled \
+	-Dplugin_logitech_bulkcontroller=disabled \
+	-Dplugin_logitech_scribe=disabled \
+	-Dplugin_logitech_tap=disabled \
+	-Dplugin_parade_lspcon=disabled \
+	-Dplugin_pixart_rf=disabled \
+	-Dplugin_realtek_mst=disabled \
+	-Dplugin_synaptics_mst=disabled \
+	-Dplugin_mediatek_scaler=disabled \
+	-Dplugin_synaptics_rmi=disabled \
+	-Dplugin_scsi=disabled \
+	-Dplugin_tpm=disabled \
+	-Dplugin_redfish=disabled \
+	-Dplugin_uefi_capsule=disabled \
+	-Dplugin_uefi_pk=disabled \
+	-Dplugin_nitrokey=disabled \
+	-Dplugin_nvme=disabled \
+	-Dplugin_msr=disabled \
+	-Dplugin_mtd=disabled \
+	-Dplugin_flashrom=disabled \
+	-Dplugin_intel_me=disabled \
+	-Dplugin_uf2=disabled \
+	-Dplugin_upower=disabled \
+	-Dplugin_powerd=disabled \
+	-Dplugin_fastboot=disabled \
+	-Dgusb=disabled \
+	-Dsystemd=disabled \
+	-Dlaunchd=disabled \
+	-Delogind=disabled \
+	-Dfirmware-packager=$(if $(CONFIG_FWUPD_FIRMWARE_PACKAGER),true,false) \
+	-Dhsi=$(if $(CONFIG_FWUPD_HSI),enabled,disabled) \
+	-Dlvfs=$(if $(CONFIG_FWUPD_LVFS),true,false) \
+	-Dcbor=$(if $(CONFIG_FWUPD_CBOR),enabled,disabled) \
+	-Dlzma=$(if $(CONFIG_FWUPD_LZMA),enabled,disabled) \
+	-Dcurl=$(if $(CONFIG_FWUPD_CURL),enabled,disabled) \
+	-Dsqlite=$(if $(CONFIG_FWUPD_SQLITE),enabled,disabled) \
+	-Dlibarchive=$(if $(CONFIG_FWUPD_LIBARCHIVE),enabled,disabled) \
+	-Dgudev=$(if $(CONFIG_FWUPD_GUDEV),enabled,disabled) \
+	-Dplugin_modem_manager=$(if $(CONFIG_FWUPD_PLUGIN_MODEMMANAGER),enabled,disabled)
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/fwupd-1
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/fwupd-1/fwupd.h $(1)/usr/include/fwupd-1
+
+	$(INSTALL_DIR) $(1)/usr/include/fwupd-1/libfwupd
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/fwupd-1/libfwupd/*.h $(1)/usr/include/fwupd-1/libfwupd
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfwupd.so* $(1)/usr/lib
+
+	$(INSTALL_DIR) $(1)/usr/lib/fwupd-$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/fwupd-$(PKG_VERSION)/*.so* $(1)/usr/lib/fwupd-$(PKG_VERSION)
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/fwupd.pc $(1)/usr/lib/pkgconfig
+
+	$(INSTALL_DIR) $(1)/usr/share/dbus-1/interfaces
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/dbus-1/interfaces/*.xml $(1)/usr/share/dbus-1/interfaces
+endef
+
+define Package/fwupd-libs/install
+	$(INSTALL_DIR) $(1)/etc/fwupd
+	$(CP) $(PKG_INSTALL_DIR)/etc/fwupd/fwupd.conf $(1)/etc/fwupd
+
+	$(INSTALL_DIR) $(1)/etc/fwupd/remotes.d
+	$(CP) $(PKG_INSTALL_DIR)/etc/fwupd/remotes.d/*.conf $(1)/etc/fwupd/remotes.d
+
+	$(INSTALL_DIR) $(1)/etc/pki
+	$(CP) $(PKG_INSTALL_DIR)/etc/pki/fwupd $(1)/etc/pki
+	$(CP) $(PKG_INSTALL_DIR)/etc/pki/fwupd-metadata $(1)/etc/pki
+
+	$(if $(CONFIG_FWUPD_GUDEV), \
+		$(INSTALL_DIR) $(1)/lib/udev/rules.d; \
+		$(INSTALL_DATA) $(PKG_INSTALL_DIR)/lib/udev/rules.d/*.rules $(1)/lib/udev/rules.d)
+
+	$(INSTALL_DIR) $(1)/usr/share/dbus-1/system.d
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/dbus-1/system.d/org.freedesktop.fwupd.conf $(1)/usr/share/dbus-1/system.d
+
+	$(INSTALL_DIR) $(1)/usr/share/fwupd
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/fwupd/quirks.d $(1)/usr/share/fwupd
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfwupd.so* $(1)/usr/lib
+
+	$(INSTALL_DIR) $(1)/usr/lib/fwupd-$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/fwupd-$(PKG_VERSION)/*.so* $(1)/usr/lib/fwupd-$(PKG_VERSION)
+endef
+
+define Package/fwupd-tools/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fwupdtool $(1)/usr/bin
+endef
+
+define Package/fwupd-daemon/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fwupdmgr $(1)/usr/bin
+
+	$(INSTALL_DIR) $(1)/usr/libexec/fwupd
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/libexec/fwupd/fwupd $(1)/usr/libexec/fwupd
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/etc/init.d/fwupd $(1)/etc/init.d/fwupd
+endef
+
+$(eval $(call BuildPackage,fwupd-libs))
+$(eval $(call BuildPackage,fwupd-tools))
+$(eval $(call BuildPackage,fwupd-daemon))

--- a/utils/fwupd/files/etc/init.d/fwupd
+++ b/utils/fwupd/files/etc/init.d/fwupd
@@ -1,0 +1,15 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=80
+VERBOSE=0
+
+start_service() {
+	procd_open_instance
+	procd_set_param command /usr/libexec/fwupd/fwupd
+	[ "$VERBOSE" = 1 ] && procd_append_param command --verbose
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
+	procd_close_instance
+}

--- a/utils/fwupd/test.sh
+++ b/utils/fwupd/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+case "$1" in
+	fwupdmgr|fwupdtool) "$1" --version 2>&1 | grep "runtime\s*org.freedesktop.fwupd\s*$2" ;;
+esac


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, lantiq_xrx200
Run tested: lantiq_xrx200, 23.05

Description:
Adds [fwupd](https://github.com/fwupd/fwupd) and its four required dependecies [libjcat](https://github.com/hughsie/libjcat), [libxmlb](https://github.com/hughsie/libxmlb), [libgusb](https://github.com/hughsie/libgusb) and [libgudev](https://gitlab.gnome.org/GNOME/libgudev).

fwupd allows firmware upgrades for various devices, including many modems via the modem-manager and fastboot options. The package includes a daemon `/usr/libexec/fwupd/fwupd` started by `/etc/init.d/fwupd` and controlled by `/usr/bin/fwupdmgr`, as well as  `/usr/bin/fwupdtool` that can be used without the daemon.