### PR TITLE
nut: specify pid path during build

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.8.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.8/
@@ -546,6 +546,7 @@ CONFIGURE_ARGS += \
 	--without-libltdl \
 	--without-macosx_ups \
 	--with-statepath=/var/run/nut \
+	--with-pidpath=/var/run \
 	--with-drvpath=/lib/nut \
 	--with-user=root \
 	--with-group=root \


### PR DESCRIPTION
Maintainer: @ruralroots (no MAINTAINER in Makefile, but from latest change)
Compile tested: x86-64 / master @ 2024-08-17
Run tested: x86-64 / master @ 2024-08-17

Description:
nut was recently upgraded to 2.8.1 which includes a change in
configure.ac that uses /run for the pidfile if it exists during build.

Explicitly specify --with-pidpath to use the path that was used with
2.8.0 and prior.

The symptom here was that there'd be leftover processes when nut-monitor
was restarted.

Fixes: 82f36e0c781d ("nut: update to 2.8.1")
Fixes: https://github.com/openwrt/packages/issues/24106