### PR TITLE
liburing: update to 2.7

### DIFF
--- a/libs/liburing/Makefile
+++ b/libs/liburing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=liburing
-PKG_VERSION:=2.6
+PKG_VERSION:=2.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://git.kernel.dk/cgit/liburing/snapshot
-PKG_HASH:=78bcc0dc0d004a238d8b5f597adbb4ec74926352a3983b872db7f0efdb72565d
+PKG_HASH:=cc5268f97d089bc21d3d5848959e6620b2dfc85023b92479dad0496b2c51df06
 
 PKG_MAINTAINER:=Christian Lachner <gladiac@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @gladiac 
Compile tested: arm_cortex-a9_neon, GCC 14

MariaDB and Samba builds okay with uring enabled.