### PR TITLE
graphicsmagick: update to 1.3.44

### DIFF
--- a/multimedia/graphicsmagick/Makefile
+++ b/multimedia/graphicsmagick/Makefile
@@ -5,13 +5,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=graphicsmagick
-PKG_VERSION:=1.3.43
+PKG_VERSION:=1.3.44
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/GraphicsMagick-$(PKG_VERSION)
 PKG_SOURCE:=GraphicsMagick-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/graphicsmagick
-PKG_HASH:=2b88580732cd7e409d9e22c6116238bef4ae06fcda11451bf33d259f9cbf399f
+PKG_HASH:=6ac28470d2fbd3d5f60859dd43f3cee2585e955e32896f892b4dc61dda101ea0
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=Copyright.txt
@@ -57,11 +57,13 @@ CONFIGURE_ARGS += \
 	--without-bzlib \
 	--without-dps \
 	--without-fpx \
+	--without-gs \
 	--without-jbig \
 	--without-webp \
 	--with-jpeg \
 	--without-jp2 \
 	--without-lcms2 \
+	--without-libzip \
 	--without-lzma \
 	--with-png \
 	--with-tiff \


### PR DESCRIPTION
Maintainer: me
Compile tested: arm_cortex-a9_neon, GCC 14
Run tested: WRT3200ACM

Description:
Explicitly disable gs and libzip in configure to prevent host dependencies leakage.
