### PR TITLE
tayga: add options for static mapping

### DIFF
--- a/ipv6/tayga/Makefile
+++ b/ipv6/tayga/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tayga
 PKG_VERSION:=0.9.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=tayga-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.litech.org/tayga/

--- a/ipv6/tayga/files/tayga-proto.sh
+++ b/ipv6/tayga/files/tayga-proto.sh
@@ -14,8 +14,8 @@ proto_tayga_setup() {
 	local iface="$2"
 	local link="tayga-$cfg"
 
-	local ipv4_addr ipv6_addr prefix dynamic_pool ipaddr ip6addr noroutes
-	json_get_vars ipv4_addr ipv6_addr prefix dynamic_pool ipaddr ip6addr noroutes
+	local ipv4_addr ipv6_addr prefix dynamic_pool map_ipv4 map_ipv6 ipaddr ip6addr noroutes
+	json_get_vars ipv4_addr ipv6_addr prefix dynamic_pool map_ipv4 map_ipv6 ipaddr ip6addr noroutes
 	[ -z "$ipv4_addr" -o -z "$prefix" ] && {
 		proto_notify_error "$cfg" "REQUIRED_PARAMETERS_MISSING"
 		proto_block_restart "$cfg"
@@ -34,8 +34,10 @@ proto_tayga_setup() {
 		echo "prefix $prefix" >>$tmpconf
 	[ -n "$dynamic_pool" ] &&
 		echo "dynamic-pool $dynamic_pool" >>$tmpconf
+	# TODO: Allow setting multiple static mapping
+	[ -n "$map_ipv4" ] &&
+		echo "map $map_ipv4 $map_ipv6" >>$tmpconf
 	echo "data-dir /var/run/tayga/$cfg" >>$tmpconf
-	#TODO: Support static mapping of IPv4 <-> IPv6
 
 	# here we create TUN device and check configuration
 	tayga -c $tmpconf --mktun
@@ -63,6 +65,7 @@ proto_tayga_setup() {
 			proto_add_ipv6_route "$prefix6" "$mask6"
 		}
 	}
+	# TODO: Set up routes and firewall rules for clat/nat46 automatically?
 
 	proto_send_update "$cfg"
 
@@ -86,6 +89,8 @@ proto_tayga_init_config() {
 	proto_config_add_string "ipv6_addr"
 	proto_config_add_string "prefix"
 	proto_config_add_string "dynamic_pool"
+	proto_config_add_string "map_ipv4"
+	proto_config_add_string "map_ipv6"
 	proto_config_add_string "ipaddr"
 	proto_config_add_string "ip6addr:ip6addr"
 	proto_config_add_boolean "noroutes"


### PR DESCRIPTION
The commit adds options for static mapping, which is essential for 464xlat(clat) usage. 

But routes and firewall rules have to be configured manually.

To use tayga as clat/nat46:

0. specify $ipv4_addr, $prefix, $map_{ipv4,ipv6} properly, and set $noroutes to 1 to prevent creating routes for nat64
1. add custom IPv4 routes to tayga, possibly with a reasonable metric for default route
2. add a SNAT firewall rule for processing IPv4 traffic destined for tayga
3. add firewall rules to allow FORWARD traffic between tayga and WAN6
4. add a $map_ipv6 route to tayga for guiding return traffic

Maintainer: @oskar456
Compile tested: N/A
Run tested: aarch64, CMCC RAX3000M, OpenWrt 23.05.4

Description:
See above.