### PR TITLE
cloudflared: reload service if wan inferface has (re)connected

### DIFF
--- a/net/cloudflared/Makefile
+++ b/net/cloudflared/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cloudflared
 PKG_VERSION:=2024.8.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cloudflare/cloudflared/tar.gz/$(PKG_VERSION)?

--- a/net/cloudflared/files/cloudflared.init
+++ b/net/cloudflared/files/cloudflared.init
@@ -53,4 +53,5 @@ reload_service() {
 
 service_triggers() {
 	procd_add_reload_trigger "$CONF"
+	procd_add_interface_trigger "interface.*.up" "wan" /etc/init.d/cloudflared restart
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: n/a
Run tested: nanopi-r5c

Description:
Sometimes the wan connection needs time to be established (e.g. cold boot after power loss) and the service may crash as the internet is yet available. Add a trigger to reload the service once the wan interface is up.
