### PR TITLE
uhubctl: update to 2.6.0

### DIFF
--- a/utils/uhubctl/Makefile
+++ b/utils/uhubctl/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uhubctl
-PKG_VERSION:=2.5.0
+PKG_VERSION:=2.6.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mvp/uhubctl/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=d4452252f7862f7a45dd9c62f2ea7cd3a57ab5f5ab0e54a857d4c695699bbba3
+PKG_HASH:=56ca15ddf96d39ab0bf8ee12d3daca13cea45af01bcd5a9732ffcc01664fdfa2
 
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=COPYING LICENSE


### PR DESCRIPTION
Maintainer: @snh
Compile tested: OpenWrt master, mips64 octeon
Run tested: OpenWrt master, mips64 octeon

Description:
New release containing among other things the patches mentioned in https://github.com/openwrt/packages/pull/24734.

Testing:
```
root@oob-lab-sw1:~# uhubctl -v
2.6.0
root@oob-lab-sw1:~# uhubctl
Current status for hub 4 [1d6b:0003 Linux 6.6.39 xhci-hcd xHCI Host Controller 0000:01:00.0, USB 3.00, 2 ports, ppps]
  Port 1: 02a0 power 5gbps Rx.Detect
  Port 2: 02a0 power 5gbps Rx.Detect
Current status for hub 3 [1d6b:0002 Linux 6.6.39 xhci-hcd xHCI Host Controller 0000:01:00.0, USB 2.00, 2 ports, ppps]
  Port 1: 0503 power highspeed enable connect [0403:6011 FTDI USB <-> Serial Cable FTYICQ95]
  Port 2: 0503 power highspeed enable connect [0bda:b812 Realtek 802.11ac NIC 123456]
root@oob-lab-sw1:~# uhubctl --help 2>&1 | grep sysfs
--nosysfs,  -S - do not use the Linux sysfs port disable interface.
root@oob-lab-sw1:~# 
```