### PR TITLE
knot: update to version 3.4.0

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.3.8
+PKG_VERSION:=3.4.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=498de8338489a625673797f7ecc921fa4490c826afbfa42fa66922b525089e6a
+PKG_HASH:=2730b11398944faa5151c51b0655cf26631090343c303597814f2a57df424736
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8
@@ -56,7 +56,7 @@ endef
 define Package/knot
 	$(call Package/knot/Default)
 	TITLE+= server with control utility
-	DEPENDS+=+libedit +liburcu +knot-libs +knot-libzscanner
+	DEPENDS+=+libedit +liburcu +libdbus +knot-libs +knot-libzscanner
 	EXTRA_DEPENDS:=knot-libs (=$(PKG_VERSION)-r$(PKG_RELEASE)), \
 	               knot-libzscanner (=$(PKG_VERSION)-r$(PKG_RELEASE))
 	USERID:=knot=5353:knot=5353
@@ -87,7 +87,7 @@ endef
 define Package/knot-zonecheck
 	$(call Package/knot/Default)
 	TITLE+= zonefile check utility
-	DEPENDS+=+libedit +liburcu +knot-libs +knot-libzscanner
+	DEPENDS+=+libedit +liburcu +libdbus +knot-libs +knot-libzscanner
 	EXTRA_DEPENDS:=knot-libs (=$(PKG_VERSION)-r$(PKG_RELEASE)), \
 	               knot-libzscanner (=$(PKG_VERSION)-r$(PKG_RELEASE))
 endef
@@ -95,7 +95,7 @@ endef
 define Package/knot-keymgr
 	$(call Package/knot/Default)
 	TITLE+= DNSSEC key management utility
-	DEPENDS+=+libedit +liburcu +knot-libs +knot-libzscanner
+	DEPENDS+=+libedit +liburcu +libdbus +knot-libs +knot-libzscanner
 	EXTRA_DEPENDS:=knot-libs (=$(PKG_VERSION)-r$(PKG_RELEASE)), \
 	               knot-libzscanner (=$(PKG_VERSION)-r$(PKG_RELEASE))
 endef
@@ -103,7 +103,7 @@ endef
 define Package/knot-tests
 	$(call Package/knot/Default)
 	TITLE+= tests
-	DEPENDS+=+libedit +liburcu +knot-libs +knot-libzscanner
+	DEPENDS+=+libedit +liburcu +libdbus +knot-libs +knot-libzscanner
 	EXTRA_DEPENDS:=knot-libs (=$(PKG_VERSION)-r$(PKG_RELEASE)), \
 	               knot-libzscanner (=$(PKG_VERSION)-r$(PKG_RELEASE))
 endef
@@ -152,6 +152,7 @@ CONFIGURE_ARGS += 			\
 	--enable-cap-ng=no            	\
 	--enable-xdp=no                 \
 	--enable-maxminddb=no		\
+	--enable-dbus=libdbus           \
 	--enable-quic			\
 	--disable-fastparser		\
 	--without-libidn		\


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 8.0.0 (hbd)
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 8.0.0 (hbd)

Description:
- Release upgrade (https://www.knot-dns.cz/2024-09-02-version-340.html)
- Enabled D-Bus support with libdbus-1 library