### PR TITLE
apr: update to 1.7.5

### DIFF
--- a/libs/apr/Makefile
+++ b/libs/apr/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apr
-PKG_VERSION:=1.7.4
+PKG_VERSION:=1.7.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@APACHE/apr/
-PKG_HASH:=fc648de983f3a2a6c9e78dea1f180639bd2fad6c06d556d4367a701fe5c35577
+PKG_HASH:=cd0f5d52b9ab1704c72160c5ee3ed5d3d4ca2df4a7f8ab564e3cb352b67232f2
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 


### PR DESCRIPTION
Maintainer: @heil
Compile tested: arm_cortex-a9_neon, GCC 14

apache web server builds all right.