### PR TITLE
ntpd: disable autoreconf fixup

### DIFF
--- a/net/ntpd/Makefile
+++ b/net/ntpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntp
 PKG_VERSION:=4.2.8p17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/
@@ -19,7 +19,6 @@ PKG_LICENSE:=NTP
 PKG_LICENSE_FILES:=COPYRIGHT html/copyright.html
 PKG_CPE_ID:=cpe:/a:ntp:ntp
 
-PKG_FIXUP:=autoreconf
 PKG_LIBTOOL_PATHS:=. sntp
 PKG_CHECK_FORMAT_SECURITY:=0
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Maintainer: @ffontaine @hauke @knthm
Compile tested: x86_64 & octeon, master
Run tested: x86_64 & octeon, master

Description:

Fixes #24918 which got introduced with openwrt c364cb8.
 
Credit for the fix goes to Hirokazu MORIKAWA.


Test:

```
bluecmd@oob-lab-sw3:~$ ntpq -p localhost
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 129.151.196.70  .STEP.          16 u    -   64    0    0.000   +0.000   0.000
 ntp.netnod.se   .STEP.          16 u   19   64    0    0.000   +0.000   0.000
 time.cloudflare .STEP.          16 u   78   64    0    0.000   +0.000   0.000
*ntp7.flashdance 194.58.202.148   2 u    6   64    1    1.080   -0.252   0.079
```