### PR TITLE
dockerd: add config options for http proxy

### DIFF
--- a/utils/dockerd/files/dockerd.init
+++ b/utils/dockerd/files/dockerd.init
@@ -185,6 +185,10 @@ process_config() {
 	config_get ip globals ip ""
 	config_get fixed_cidr globals fixed_cidr ""
 	config_get fixed_cidr_v6 globals fixed_cidr_v6 ""
+	# Use the *_proxy environment variable as the default value
+	config_get http_proxy proxies http_proxy "${http_proxy}"
+	config_get https_proxy proxies https_proxy "${https_proxy}"
+	config_get no_proxy proxies no_proxy "${no_proxy}"
 
 	. /usr/share/libubox/jshn.sh
 	json_init
@@ -207,6 +211,13 @@ process_config() {
 	[ -z "${ip}" ] || json_add_string "ip" "${ip}"
 	[ -z "${fixed_cidr}" ] || json_add_string "fixed-cidr" "${fixed_cidr}"
 	[ -z "${fixed_cidr_v6}" ] || json_add_string "fixed-cidr-v6" "${fixed_cidr_v6}"
+	if [ -n "${http_proxy}" ] || [ -n "${https_proxy}" ] || [ -n "${no_proxy}" ]; then
+		json_add_object "proxies"
+		[ -z "${http_proxy}" ] || json_add_string "http-proxy" "${http_proxy}"
+		[ -z "${https_proxy}" ] || json_add_string "https-proxy" "${https_proxy}"
+		[ -z "${no_proxy}" ] || json_add_string "no-proxy" "${no_proxy}"
+		json_close_object
+	fi
 	json_dump > "${DOCKERD_CONF}"
 
 	[ "${iptables}" -eq "1" ] && config_foreach iptables_add_blocking_rule firewall

--- a/utils/dockerd/files/etc/config/dockerd
+++ b/utils/dockerd/files/etc/config/dockerd
@@ -21,6 +21,13 @@ config globals 'globals'
 #	list registry_mirrors 'https://<my-docker-mirror-host>'
 #	list registry_mirrors 'https://hub.docker.com'
 
+# If your organization uses a proxy server to connect to the internet, you may need to configure the proxy.
+# See https://docs.docker.com/engine/daemon/proxy/ for more details
+config proxies 'proxies'
+#	option http_proxy 'http://proxy.example.com:3128'
+#	option https_proxy 'https://proxy.example.com:3129'
+#	option http_proxy '*.test.example.com,.example.org,127.0.0.0/8'
+
 # Docker doesn't work well out of the box with fw4. This is because Docker relies on a compatibility layer that
 # naively translates iptables rules. For the best compatibility replace the following dependencies:
 # `firewall4` -> `firewall`


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503 @p-w-p 
Compile tested: x86_64 / master @ 2024-09-07
Run tested: x86_64 / master @ 2024-09-07

Description:
add config options to set http porxy for dockerd, refer to https://docs.docker.com/engine/daemon/proxy/ for details