### PR TITLE
libmariadb: update to 3.4.1

### DIFF
--- a/libs/libmariadb/Makefile
+++ b/libs/libmariadb/Makefile
@@ -8,16 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmariadb
-PKG_VERSION:=3.1.23
+PKG_VERSION:=3.4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=mariadb-connector-c-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=\
 	https://mirror.netcologne.de/mariadb/connector-c-$(PKG_VERSION) \
-	https://mirror.lstn.net/mariadb/connector-c-$(PKG_VERSION) \
 	https://ftp.yz.yamagata-u.ac.jp/pub/dbms/mariadb/connector-c-$(PKG_VERSION) \
-	https://dlm.mariadb.com/3677044/Connectors/c/connector-c-$(PKG_VERSION)
-PKG_HASH:=43642ff0f104a1f79ec530ac81716bab52040016f6ad7cdec56f4ce30be19f6a
+	https://dlm.mariadb.com/3907132/Connectors/c/connector-c-$(PKG_VERSION)
+PKG_HASH:=0a7f2522a44a7369c1dda89676e43485037596a7b1534898448175178aedeb4d
 PKG_BUILD_DIR:=$(BUILD_DIR)/mariadb-connector-c-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Michal Hrusecky <Michal@Hrusecky.net>

--- a/libs/libmariadb/patches/010-link-to-libucontext.patch
+++ b/libs/libmariadb/patches/010-link-to-libucontext.patch
@@ -12,18 +12,18 @@ providing these system calls on platforms not supporting them out of
 the box - like musl based platforms.
 --- a/libmariadb/CMakeLists.txt
 +++ b/libmariadb/CMakeLists.txt
-@@ -417,7 +417,7 @@ ELSE()
+@@ -458,7 +458,7 @@ ELSE()
    SET_TARGET_PROPERTIES(libmariadb PROPERTIES LINKER_LANGUAGE C)
  ENDIF()
  
--TARGET_LINK_LIBRARIES(libmariadb LINK_PRIVATE ${SYSTEM_LIBS})
-+TARGET_LINK_LIBRARIES(libmariadb LINK_PRIVATE ${SYSTEM_LIBS} ${LIBUCONTEXT_POSIX} ${LIBUCONTEXT})
+-TARGET_LINK_LIBRARIES(libmariadb LINK_PRIVATE ${SYSTEM_LIBS} ${CRYPTO_LIBS})
++TARGET_LINK_LIBRARIES(libmariadb LINK_PRIVATE ${SYSTEM_LIBS} ${CRYPTO_LIBS} ${LIBUCONTEXT_POSIX} ${LIBUCONTEXT})
  
  SIGN_TARGET(libmariadb)
  
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -230,6 +230,14 @@ IF(UNIX)
+@@ -251,6 +251,14 @@ IF(UNIX)
    SEARCH_LIBRARY(LIBPTHREAD pthread_getspecific "pthread;pthreads")
    SEARCH_LIBRARY(LIBNSL gethostbyname_r "nsl_r;nsl")
    SEARCH_LIBRARY(LIBSOCKET setsockopt socket)
@@ -36,8 +36,8 @@ the box - like musl based platforms.
 +    UNSET(LIBUCONTEXT_POSIX)
 +  ENDIF()
    FIND_PACKAGE(Threads)
-   SET(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${LIBNSL} ${LIBBIND} ${LIBICONV} ${LIBZ}
-     ${LIBSOCKET} ${CMAKE_DL_LIBS} ${LIBM} ${LIBPTHREAD})
+   SET(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${LIBNSL} ${LIBBIND} ${LIBICONV} ${ZLIB_LIBRARY} 
+       ${LIBSOCKET} ${CMAKE_DL_LIBS} ${LIBM} ${LIBPTHREAD})
 --- a/include/ma_config.h.in
 +++ b/include/ma_config.h.in
 @@ -28,6 +28,7 @@
@@ -50,7 +50,7 @@ the box - like musl based platforms.
   * function definitions - processed in LibmysqlFunctions.txt 
 --- a/include/ma_context.h
 +++ b/include/ma_context.h
-@@ -31,7 +31,7 @@
+@@ -32,7 +32,7 @@
  #define MY_CONTEXT_USE_X86_64_GCC_ASM
  #elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__i386__)
  #define MY_CONTEXT_USE_I386_GCC_ASM

--- a/libs/libmariadb/patches/020-fix-ucontext-maybe-uninitialized.patch
+++ b/libs/libmariadb/patches/020-fix-ucontext-maybe-uninitialized.patch
@@ -1,0 +1,12 @@
+--- a/libmariadb/ma_context.c
++++ b/libmariadb/ma_context.c
+@@ -92,6 +92,9 @@ my_context_spawn(struct my_context *c, v
+ {
+   int err;
+   union pass_void_ptr_as_2_int u;
++  // Avoid 'may be used uninitialized' error on 32-bit systems
++  // upstream issue: https://jira.mariadb.org/browse/CONC-725
++  u.a[1] = 0;
+ 
+   err= getcontext(&c->spawned_context);
+   if (err)


### PR DESCRIPTION
Maintainer: @miska 
Compile tested: arm_cortex-a9_neon, GCC 14
Run tested: WRT3200ACM - addrwatch_mysql runs fine

Description:
- Remove a mirror with invalid certificate
- Manually rebase 010-link-to-libucontext.patch
- Add new 020-fix-ucontext-maybe-uninitialized.patch
