### PR TITLE
eza: update to 0.19.2

### DIFF
--- a/utils/eza/Makefile
+++ b/utils/eza/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=eza
-PKG_VERSION:=0.18.23
+PKG_VERSION:=0.19.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eza-community/eza/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=34b0e8a699ac1a8a308448f417f0c0137a67ea34e261fd6f106e8be9fd5bb54c
+PKG_HASH:=db4897ef7f58d0802620180e0b13bb35563e03c9de66624206b35dcad21007f8
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
release notes:
0.18.24: https://github.com/eza-community/eza/releases/tag/v0.18.24
0.19.0: https://github.com/eza-community/eza/releases/tag/v0.19.0
0.19.1: https://github.com/eza-community/eza/releases/tag/v0.19.1
0.19.2: https://github.com/eza-community/eza/releases/tag/v0.19.2

Maintainer: me
Compile tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt snapshot
Run tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt snapshot

Description:
(skipped several versions before updating because there were only little changes, mostly related to the upstream repository's CI)