### PR TITLE
zoneinfo: Updated to 2024b release.

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2024a
+PKG_VERSION:=2024b
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public-Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=0d0434459acbd2059a7a8da1f3304a84a86591f6ed69c6248fffa502b6edffe3
+PKG_HASH:=70e754db126a8d0db3d16d6b4cb5f7ec1e04d5f261255e4558a67fe92d39e550
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=80072894adff5a458f1d143e16e4ca1d8b2a122c9c5399da482cb68cba6a1ff8
+   HASH:=5e438fc449624906af16a18ff4573739f0cda9862e5ec28d3bcb19cbaed0f672
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT master
Run tested: n/a

Description:

This release contains the following changes:

   Briefly:

     Improve historical data for Mexico, Mongolia, and Portugal.
     System V names are now obsolescent.
     The main data form now uses %z.
     The code now conforms to RFC 8536 for early timestamps.
     Support POSIX.1-2024, which removes asctime_r and ctime_r.
     Assume POSIX.2-1992 or later for shell scripts.
     SUPPORT_C89 now defaults to 1.

   Changes to past timestamps

     Asia/Choibalsan is now an alias for Asia/Ulaanbaatar rather than
     being a separate Zone with differing behavior before April 2008.
     This seems better given our wildly conflicting information about
     Mongolia's time zone history.  (Thanks to Heitor David Pinto.)

     Historical transitions for Mexico have been updated based on
     official Mexican decrees.  The affected timestamps occur during
     the years 1921-1927, 1931, 1945, 1949-1970, and 1981-1997.
     The affected zones are America/Bahia_Banderas, America/Cancun,
     America/Chihuahua, America/Ciudad_Juarez, America/Hermosillo,
     America/Mazatlan, America/Merida, America/Mexico_City,
     America/Monterrey, America/Ojinaga, and America/Tijuana.
     (Thanks to Heitor David Pinto.)

     Historical transitions for Portugal, represented by Europe/Lisbon,
     Atlantic/Azores, and Atlantic/Madeira, have been updated based on a
     close reading of old Portuguese legislation, replacing previous data
     mainly originating from Whitman and Shanks & Pottenger.  These
     changes affect a few transitions in 1917-1921, 1924, and 1940
     throughout these regions by a few hours or days, and various
     timestamps between 1977 and 1993 depending on the region.  In
     particular, the Azores and Madeira did not observe DST from 1977 to
     1981.  Additionally, the adoption of standard zonal time in former
     Portuguese colonies have been adjusted: Africa/Maputo in 1909, and
     Asia/Dili by 22 minutes at the start of 1912.
     (Thanks to Tim Parenti.)

   Changes to past tm_isdst flags

     The period from 1966-04-03 through 1966-10-02 in Portugal is now
     modeled as DST, to more closely reflect how contemporaneous changes
     in law entered into force.

   Changes to data

     Names present only for compatibility with UNIX System V
     (last released in the 1990s) have been moved to 'backward'.
     These names, which for post-1970 timestamps mostly just duplicate
     data of geographical names, were confusing downstream uses.
     Names moved to 'backward' are now links to geographical names.
     This affects behavior for TZ='EET' for some pre-1981 timestamps,
     for TZ='CET' for some pre-1947 timestamps, and for TZ='WET' for
     some pre-1996 timestamps.  Also, TZ='MET' now behaves like
     TZ='CET' and so uses the abbreviation "CET" rather than "MET".
     Those needing the previous TZDB behavior, which does not match any
     real-world clocks, can find the old entries in 'backzone'.
     (Problem reported by Justin Grant.)

     The main source files' time zone abbreviations now use %z,
     supported by zic since release 2015f and used in vanguard form
     since release 2022b.  For example, America/Sao_Paulo now contains
     the zone continuation line "-3:00 Brazil %z", which is less error
     prone than the old "-3:00 Brazil -03/-02".  This does not change
     the represented data: the generated TZif files are unchanged.
     Rearguard form still avoids %z, to support obsolescent parsers.

     Asia/Almaty has been removed from zonenow.tab as it now agrees
     with Asia/Tashkent for future timestamps, due to Kazakhstan's
     2024-02-29 time zone change.  Similarly, America/Scoresbysund
     has been removed, as it now agrees with America/Nuuk due to
     its 2024-03-31 time zone change.

   Changes to code

     localtime.c now always uses a TZif file's time type 0 to handle
     timestamps before the file's first transition.  Formerly,
     localtime.c sometimes inferred a different time type, in order to
     handle problematic data generated by zic 2018e or earlier.  As it
     is now safe to assume more recent versions of zic, there is no
     longer a pressing need to fail to conform RFC 8536 section 3.2,
     which requires using time type 0 in this situation.  This change
     does not affect behavior when reading TZif files generated by zic
     2018f and later.

     POSIX.1-2024 removes asctime_r and ctime_r and does not let
     libraries define them, so remove them except when needed to
     conform to earlier POSIX.  These functions are dangerous as they
     can overrun user buffers.  If you still need them, add
     -DSUPPORT_POSIX2008 to CFLAGS.

     The SUPPORT_C89 option now defaults to 1 instead of 0, fixing a
     POSIX-conformance bug introduced in 2023a.

     tzselect now supports POSIX.1-2024 proleptic TZ strings.  Also, it
     assumes POSIX.2-1992 or later, as practical porting targets now
     all support that, and it uses some features from POSIX.1-2024 if
     available.

   Changes to build procedure

     'make check' no longer requires curl and Internet access.

     The build procedure now assumes POSIX.2-1992 or later, to simplify
     maintenance.  To build on Solaris 10, the only extant system still
     defaulting to pre-POSIX, prepend /usr/xpg4/bin to PATH.

   Changes to documentation

     The documentation now reflects POSIX.1-2024.

   Changes to commentary

     Commentary about historical transitions in Portugal and her former
     colonies has been expanded with links to many relevant legislation.
     (Thanks to Tim Parenti.)