### PR TITLE
nerdctl: update to 1.7.7

### DIFF
--- a/utils/nerdctl/Makefile
+++ b/utils/nerdctl/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nerdctl
-PKG_VERSION:=1.7.6
+PKG_VERSION:=1.7.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containerd/nerdctl/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=9a204b15ab4a0c260a9615a0254fb91ec2ccd9815be85b0890130ef1f3920717
+PKG_HASH:=bcddf2ee3ad2bc84adc5e207f97157998fe973912c7d1dd9540bd4bb4a07698d
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -17,6 +17,7 @@ PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/containerd/nerdctl
+GO_PKG_LDFLAGS_X:=$(GO_PKG)/pkg/version.Version=v$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk


### PR DESCRIPTION
Maintainer: @lu-zero
Compile tested: Ubuntu 23.04 x64 / OpenWrt SNAPSHOT @ https://github.com/openwrt/packages/commit/36b1dd75fd9da1ea13f1ce1ee679c6b3c9c402cc
Run tested: Linksys WRT32X / OpenWrt SNAPSHOT r24315-ae500e62e2

Description: nerdctl: Docker-compatible CLI for containerd

- Update to [1.7.7](https://github.com/containerd/nerdctl/compare/v1.7.6...v1.7.7)
- Set version information with ldflag