### PR TITLE
[Security] expat: update to 2.6.3

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -6,13 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
-PKG_VERSION:=2.6.2
+PKG_VERSION:=2.6.3
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=@SF/expat \
-	https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$(PKG_VERSION))
-PKG_HASH:=ee14b4c5d8908b1bec37ad937607eab183d4d9806a08adee472c3c3121d27364
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$(PKG_VERSION))
+PKG_HASH:=17aa6cfc5c4c219c09287abfc10bc13f0c06f30bb654b28bfe6f567ca646eb79
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=MIT
@@ -36,7 +35,6 @@ define Package/libexpat/description
 endef
 
 CMAKE_OPTIONS += \
-	-DDOCBOOK_TO_MAN=OFF \
 	-DEXPAT_BUILD_TOOLS=OFF \
 	-DEXPAT_BUILD_EXAMPLES=OFF \
 	-DEXPAT_BUILD_TESTS=OFF \


### PR DESCRIPTION
Maintainer: @thess
Compile tested: mvebu/FG-50E, snapshot
Run tested: N/A

- This release contains fixes for CVE-2024-45490, CVE-2024-45491, CVE-2024-45492.
- Since official place for expat development moved from SourceForge to GitHub, SourceForge was removed from PKG_SOURCE_URL.
- Use gzip archive to avoid xz usage.
- Remove DOCBOOK_TO_MAN=OFF from CMAKE_OPTIONS because we already have EXPAT_BUILD_DOCS=OFF, which has same effect.
