### PR TITLE
mwan3: add check_quality for httping

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.11.15
+PKG_VERSION:=2.11.16
 PKG_RELEASE:=4
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -294,14 +294,32 @@ main() {
 						result=$?
 					;;
 					httping)
-						if [ "$httping_ssl" -eq 1 ]; then
-							WRAP httping -c $count -t $timeout -q "https://$track_ip" &> /dev/null &
+						if [ $check_quality -eq 0 ]; then
+							if [ "$httping_ssl" -eq 1 ]; then
+								WRAP httping -c $count -t $timeout -q "https://$track_ip" &> /dev/null &
+							else
+								WRAP httping -c $count -t $timeout -q "http://$track_ip" &> /dev/null &
+							fi
+							TRACK_PID=$!
+							wait $TRACK_PID
+							result=$?
 						else
-							WRAP httping -c $count -t $timeout -q "http://$track_ip" &> /dev/null &
+							if [ "$httping_ssl" -eq 1 ]; then
+								WRAP httping -c $count -t $timeout "https://$track_ip" 2> /dev/null > $TRACK_OUTPUT &
+							else
+								WRAP httping -c $count -t $timeout "http://$track_ip" 2> /dev/null > $TRACK_OUTPUT &
+							fi
+							TRACK_PID=$!
+							wait $TRACK_PID
+							ping_status=$?
+							loss="$(sed $TRACK_OUTPUT -ne 's/.* \([0-9]\+\).*% failed.*/\1/p')"
+							if [ "$ping_status" -ne 0 ] || [ "$loss" -eq 100 ]; then
+								latency=999999
+								loss=100
+							else
+								latency="$(sed $TRACK_OUTPUT -ne 's%\(rtt\|round-trip\).* = [^/]*/\([0-9]\+\).*%\2%p')"
+							fi
 						fi
-						TRACK_PID=$!
-						wait $TRACK_PID
-						result=$?
 					;;
 					nping-*)
 						WRAP nping -c $count $track_ip --${FAMILY#nping-} > $TRACK_OUTPUT &


### PR DESCRIPTION
Run tested: RUTX12 Router, OpenWrt distribution release 21.02.0

Description: Currently, `check_quality` option is only available for track method `ping`. This PR adds `check_quality` option for track method `httping`.
