### PR TITLE
CONTRIBUTING.md: remove incorrect info about `PKG_VERSION`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,9 +200,7 @@ created packages and runs a script called `test.sh` located next to the package
 Makefile. The script is executed with the two arguments `PKG_NAME` and
 `PKG_VERSION`. The `PKG_NAME` can be used to distinguish package variants, e.g.
 `foobar` vs. `foobar-full`. The `PKG_VERSION` can be used for a trivial test
-checking if `foobar --version` prints the correct version. `PKG_VERSION` is the
-OpenWrt version and therefore includes the `PKG_RELEASE`, which isn't usually
-part of the running programs version.
+checking if `foobar --version` prints the correct version.
 
 The following snippet shows a script that tests different binaries depending on
 what IPK package was installed. The `gpsd` Makefile produces both a `gpsd` and


### PR DESCRIPTION
### Description

The documentation stated that `PKG_VERSION` is the OpenWrt version and therefore includes the `PKG_RELEASE`, but this statement was incorrect and has been removed to avoid confusion.

### Motivation and Context

Recently I have done a test commit https://github.com/openwrt/packages/commit/22e430ce78695cab17310066417d8033154300b0# for netbird package, to write this I see others examples and read:

https://github.com/openwrt/packages/blob/86ad54b482fbd987a5fca47cf591a85f9f7b9c58/CONTRIBUTING.md?plain=1#L200-L205

The confusion is, the user can use `PKG_VERSION` to test the version of program, but at same time `PKG_VERSION` includes `PKG_RELEASE` and can't be used to test version?

Let's see how the contributors write their tests:

https://github.com/openwrt/packages/blob/86ad54b482fbd987a5fca47cf591a85f9f7b9c58/utils/yq/test.sh#L3

https://github.com/openwrt/packages/blob/86ad54b482fbd987a5fca47cf591a85f9f7b9c58/net/sscep/test.sh#L3

https://github.com/openwrt/packages/blob/86ad54b482fbd987a5fca47cf591a85f9f7b9c58/net/v2raya/test.sh#L3

To be sure I dive in a little bit and see this:

https://github.com/openwrt/packages/blob/86ad54b482fbd987a5fca47cf591a85f9f7b9c58/.github/workflows/entrypoint.sh#L22-L24