### PR TITLE
netbird: send logs to syslog

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
 PKG_VERSION:=0.29.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?

--- a/net/netbird/files/netbird.init
+++ b/net/netbird/files/netbird.init
@@ -17,6 +17,9 @@ start_service() {
 	procd_open_instance
 	procd_set_param command /usr/bin/netbird
 	procd_append_param command service run
+	procd_append_param command --log-file console
+	procd_set_param stdout 1
+	procd_set_param stderr 1
 	procd_set_param pidfile /var/run/netbird.pid
 	procd_close_instance
 }


### PR DESCRIPTION
Netbird writes logs to persistent storage by default on /var/log/netbird/client.log. This change aligns the behavior of logs to other services in OpenWrt, whose logs are sent to syslog.

Maintainer: @oskarirauta 
Compile tested: Confiabits MT7981, SNAPSHOT r27350-c4a9265160
Run tested: Confiabits MT7981, SNAPSHOT r27350-c4a9265160
