### PR TITLE
wfb-ng: Add wfb-ng package

### DIFF
--- a/net/wfb-ng/Makefile
+++ b/net/wfb-ng/Makefile
@@ -1,0 +1,49 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=wfb-ng
+PKG_VERSION:=24.09.23
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/svpcom/wfb-ng/tar.gz/$(PKG_NAME)-$(PKG_VERSION)?
+PKG_HASH:=c6cf669090952f6e430166a23b2fd787c6f7d4fd2d8d1996e8e3713f5cc4f8d9
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION)
+
+PKG_LICENSE:=GPL-3.0-only
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Vasily Evseenko <svpcom@p2ptech.org>
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+MAKE_FLAGS += VERSION=$(PKG_VERSION)-$(PKG_RELEASE) COMMIT=openwrt all_bin
+
+define Package/wfb-ng
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Wireless
+  TITLE:=Long-range packet radio link using raw WiFi
+  URL:=https://github.com/svpcom/wfb-ng
+  DEPENDS:=+libpcap +libsodium +libstdcpp
+endef
+
+define Package/wfb-ng/description
+  The next generation of long-range packet radio link using raw WiFi
+  This is a base version that have only binaries and can act as cluster node,
+  standalone receiver or transmitter without diversity.
+endef
+
+define Package/wfb-ng/conffiles
+/usr/sbin/wfb-ng.sh
+endef
+
+define Package/wfb-ng/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wfb_rx $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wfb_tx $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/wfb-ng.init $(1)/etc/init.d/wfb-ng
+endef
+
+$(eval $(call BuildPackage,wfb-ng))

--- a/net/wfb-ng/files/wfb-ng.init
+++ b/net/wfb-ng/files/wfb-ng.init
@@ -1,0 +1,18 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=10
+
+USE_PROCD=1
+WFB_INIT="/usr/sbin/wfb-ng.sh"
+
+start_service() {
+        if [ -x $WFB_INIT ]; then
+                procd_open_instance wfb-ng
+                procd_set_param command $WFB_INIT
+                procd_set_param respawn
+                procd_set_param stdout 1
+                procd_set_param stderr 1
+                procd_close_instance
+        fi
+}


### PR DESCRIPTION
Maintainer: me
Compile tested: (MIPS 74Kc, TP-Link CPE510, openwrt-23.05)
Run tested: (MIPS 74Kc, TP-Link CPE510, tests done)

Description:
WFB-ng is long-range packet radio link based on raw WiFi radio.
 
Adding it to openwrt base packages will help a lot of it users to use cheap wifi routers (supporting minitoring mode) instead of build custom hardware yourself.