### PR TITLE
dnsproxy: Update to 0.73.2

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.73.1
-PKG_RELEASE:=2
+PKG_VERSION:=0.73.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=189462fe1255b4f58d39d4ea3c1696200fa65596fcb58e1a35c0545ba6b80618
+PKG_HASH:=9ab32251344f8353f3d3b02092fff887c30eaa1109839ec632bfe69d9fea25ab
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: @1715173329
Compile tested: all supported targets
Run tested: rockchip/armv8

Description:
**_dnsproxy: Update to 0.73.1_**
Fixed: Get rid of github.com/jessevdk/go-flags dependency.
**_For more information, visit_** https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.73.2