### PR TITLE
knot-resolver: update to version 5.7.4

### DIFF
--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015-2021 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+# Copyright (C) 2015-2024 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -10,12 +10,12 @@ PKG_RELRO_FULL:=0
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot-resolver
-PKG_VERSION:=5.7.1
+PKG_VERSION:=5.7.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-resolver
-PKG_HASH:=da14b415c61d53747a991f12d6209367ef826a13dc6bf4eeaf5d88760294c3a2
+PKG_HASH:=6b6da6ecf06828041afad44dfa227781f0ae34ad183a667008509355d18bd9c8
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=GPL-3.0-later


### PR DESCRIPTION
Maintainer: @ja-pa
Compile tested: TBD
Run tested: TBD

Knot Resolver 5.7.4 (2024-07-23)
================================

Security
--------
- reduce buffering of transmitted data, especially TCP-based in userspace Also expose some of the new tweaks in lua: (require 'ffi').C.the_worker.engine.net.tcp.user_timeout = 1000 (require 'ffi').C.the_worker.engine.net.listen_{tcp,udp}_buflens.{snd,rcv}

Improvements
------------
- add the fresh DNSSEC root key KSK-2024 already, Key ID 38696

Incompatible changes
--------------------
- libknot 3.0.x support is dropped Upstream last maintained 3.0.x in spring 2022.

Knot Resolver 5.7.3 (2024-05-30)
================================

Improvements
------------
- stats: add separate metrics for IPv6 and IPv4

Bugfixes
--------
- fix NSEC3 records missing in answer for positive wildcard expansion with the NSEC3 having over-limit iteration count

Knot Resolver 5.7.2 (2024-03-27)
================================

Bugfixes
--------
- fix on 32-bit systems with 64-bit time_t

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
