### PR TITLE
pbr: update to 1.1.7-10

### DIFF
--- a/net/pbr/Makefile
+++ b/net/pbr/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.1.7
-PKG_RELEASE:=7
+PKG_RELEASE:=10
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 
@@ -135,6 +135,9 @@ define Package/pbr-netifd/postinst
 	#!/bin/sh
 	# check if we are on real system
 	if [ -z "$${IPKG_INSTROOT}" ]; then
+		chmod -x /etc/init.d/pbr || true
+		fw4 -q reload || true
+		chmod +x /etc/init.d/pbr || true
 		echo -n "Installing rc.d symlink for pbr-netifd... "
 		/etc/init.d/pbr enable && echo "OK" || echo "FAIL"
 	fi

--- a/net/pbr/files/etc/init.d/pbr
+++ b/net/pbr/files/etc/init.d/pbr
@@ -465,7 +465,7 @@ get_text() {
 		errorResolverNotSupported) r="Resolver set (${resolver_set}) is not supported on this system!";;
 		errorServiceDisabled) r="The ${packageName} service is currently disabled!";;
 		errorNoWanGateway) r="The ${serviceName} service failed to discover WAN gateway!";;
-		errorNoWanInterface) r="The %s inteface not found, you need to set the 'pbr.config.procd_wan_interface' option!";;
+		errorNoWanInterface) r="The %s interface not found, you need to set the 'pbr.config.procd_wan_interface' option!";;
 		errorNoWanInterfaceHint) r="Refer to https://docs.openwrt.melmac.net/pbr/#procd_wan_interface.";;
 		errorNftsetNameTooLong) r="The nft set name '%s' is longer than allowed 255 characters!";;
 		errorUnexpectedExit) r="Unexpected exit or service termination: '%s'!";;
@@ -723,7 +723,7 @@ nft_file() {
 	case "$1" in
 		add|add_command)
 			shift
-			grep -q "$*" "$nftTempFile" || echo "$*" >> "$nftTempFile"
+			echo "$*" >> "$nftTempFile"
 		;;
 		create)
 			rm -f "$nftTempFile" "$nftPermFile"
@@ -754,7 +754,7 @@ nft_file() {
 		;;
 	esac
 }
-nft() { [ -x "$nft" ] && [ -n "$*" ] && { nft_file 'add_command' "$@" || "$nft" "$@" >/dev/null 2>&1;} }
+nft() { [ -x "$nft" ] && [ -n "$*" ] && nft_file 'add_command' "$@"; }
 nft4() { nft "$@"; }
 nft6() { [ -n "$ipv6_enabled" ] || return 0; nft "$@"; }
 nftset() {
@@ -1846,7 +1846,7 @@ interface_process() {
 				fi
 			;;
 		esac
-		return 0
+		str_contains_word "$supported_interface" "$iface" || return 0
 	fi
 
 	is_supported_interface "$iface" || return 0
@@ -2153,17 +2153,24 @@ start_service() {
 				config_foreach load_validate_dns_policy 'dns_policy' dns_policy_process
 				output 1 '\n'
 			fi
-			if is_config_enabled 'include'; then
+			if is_config_enabled 'include' || [ -d "/etc/${packageName}.d/" ]; then
 				interface_process 'all' 'prepare'
 				config_foreach interface_process 'interface' 'create_user_set'
 				output 1 'Processing user file(s) '
 				config_load "$packageName"
 				config_foreach load_validate_include 'include' user_file_process
+				if [ -d "/etc/${packageName}.d/" ]; then
+					local i
+					for i in "/etc/${packageName}.d/"*; do
+						local enabled='1' path="$i"
+						[ -f "$i" ] && user_file_process
+					done
+				fi
 				output 1 '\n'
 			fi
 			nft_file 'install'
 			resolver 'init_end'
-			! nft_file 'exists' && resolver 'compare_hash' && resolver 'restart'
+			resolver 'compare_hash' && resolver 'restart'
 		;;
 	esac
 
@@ -2186,7 +2193,6 @@ service_started() {
 	if nft_file 'exists'; then
 		procd_set_config_changed firewall
 		if nft_file 'exists'; then
-			resolver 'compare_hash' && resolver 'restart'
 			[ -n "$gatewaySummary" ] && output "$serviceName (fw4 nft file mode) started with gateways:\\n${gatewaySummary}"
 		else
 			output "$serviceName FAILED TO START in fw4 nft file mode!!!"

--- a/net/pbr/files/etc/uci-defaults/90-pbr
+++ b/net/pbr/files/etc/uci-defaults/90-pbr
@@ -57,6 +57,7 @@ EOT
 fi
 
 # Transition from pre-1.1.7 versions
+# shellcheck disable=SC2317
 _remove_wg_server_client() {
 	local path
 	config_get path "$1" 'path'


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 23.05.4
Run tested: x86_64, Dell EMC Edge620, OpenWrt 23.05.4

Description:
* allow using WG servers as gateways if explicitly set in supported_interface
* automatically execute user scripts in /etc/pbr.d/
* change the dnsmasq restart logic on start/reload/restart
* further nft file atomic mode-related code cleanup
* fix spelling in error message
