### PR TITLE
stress-ng: bump to version 0.18.04

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.18.01
+PKG_VERSION:=0.18.04
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ColinIanKing/stress-ng/tar.gz/refs/tags/V$(PKG_VERSION)?
-PKG_HASH:=30465ee60a32d9018d0de8a78cfeaa576e869b6e6db87e3628d0704dbe61b561
+PKG_HASH:=c76cf067e582fb8a066d47207bbccc6d0d4175ba700b5d122909132d79e7f6ea
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only

--- a/utils/stress-ng/patches/001-disable-extra-stressors.patch
+++ b/utils/stress-ng/patches/001-disable-extra-stressors.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.config
 +++ b/Makefile.config
-@@ -351,10 +351,10 @@ clean:
+@@ -362,10 +362,10 @@ clean:
  .PHONY: libraries
  libraries: \
  	configdir \


### PR DESCRIPTION
Patch needed a refresh

Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne

Maintainer: @commodo