### PR TITLE
dnsproxy: fix set hosts options

### DIFF
--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
 PKG_VERSION:=0.73.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?

--- a/net/dnsproxy/files/dnsproxy.init
+++ b/net/dnsproxy/files/dnsproxy.init
@@ -64,10 +64,6 @@ load_config_list() {
 
 	is_empty "bogus_nxdomain" "ip_addr" || config_list_foreach "bogus_nxdomain" "ip_addr" "append_param '--bogus-nxdomain'"
 
-	is_enabled "hosts" "enabled" && {
-		config_list_foreach "hosts" "hosts_files" "append_param '--hosts-files'"
-	}
-
 	is_enabled "private_rdns" "enabled" && {
 		append_param "--use-private-rdns"
 		config_list_foreach "private_rdns" "upstream" "append_param '--private-rdns-upstream'"
@@ -85,8 +81,6 @@ load_config_param() {
 	append_param_arg "global" "timeout" "--timeout"
 	append_param_arg "global" "udp_buf_size" "--udp-buf-size"
 	append_param_arg "global" "upstream_mode" "--upstream-mode"
-
-	append_param_arg "hosts" "enabled" "--hosts-file-enabled" "0"
 
 	is_enabled "cache" "enabled" && {
 		append_param "--cache"
@@ -132,6 +126,12 @@ start_service() {
 	load_config_list
 	load_config_param
 
+	# This must be set at last, all other options set after this will be ignored
+	is_enabled "hosts" "enabled" && {
+		append_param "--hosts-file-enabled" "true"
+		config_list_foreach "hosts" "hosts_files" "append_param '--hosts-files'"
+	} || append_param "--hosts-file-enabled" "false"
+
 	procd_set_param respawn
 	procd_set_param stdout 1
 	procd_set_param stderr 1
@@ -139,17 +139,14 @@ start_service() {
 
 	procd_add_jail dnsproxy ronly log
 	procd_set_param capabilities "/etc/capabilities/dnsproxy.json"
+	procd_add_jail_mount "/etc/hosts"
 	procd_add_jail_mount "/etc/ssl/certs/ca-certificates.crt"
 	[ -z "$log_file" ] || procd_add_jail_mount_rw "$log_file"
 	[ -z "$tls_crt" ] || procd_add_jail_mount "$tls_crt"
 	[ -z "$tls_key" ] || procd_add_jail_mount "$tls_key"
+	is_enabled "hosts" "enabled" && config_list_foreach "hosts" "hosts_files" "procd_add_jail_mount"
 
 	procd_close_instance
-}
-
-reload_service() {
-	stop
-	start
 }
 
 service_triggers() {


### PR DESCRIPTION
Maintainer: me
Run tested: nanopi-r5c

Description:
1. Mount hosts files since the daemon is in ujail
2. Set hosts options at last as all other options set after it will be ignored

Drop redundant reload_service func while at it.

Fixes: #25010