### PR TITLE
iperf3: explicitly disable SCTP

### DIFF
--- a/net/iperf3/Makefile
+++ b/net/iperf3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
 PKG_VERSION:=3.17.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.es.net/pub/iperf
@@ -65,6 +65,8 @@ ifeq ($(BUILD_VARIANT),ssl)
 else
 	CONFIGURE_ARGS += --without-openssl
 endif
+
+CONFIGURE_ARGS += --without-sctp
 
 MAKE_FLAGS += noinst_PROGRAMS=
 


### PR DESCRIPTION
Maintainer: @nbd168 
Compile tested: arm_cortex-a9_neon, GCC 14

Description:
Since https://github.com/openwrt/openwrt/commit/3fa5ee0b28b736c5d06af34ed5c3e80f78235fe8 OpenWrt no longer disables SCTP support by default (to unblock its enablement for other packages). It caused the leak of libsctp dependency to iperf3. Here we disable it explicitly to fix the build.

Fixes https://github.com/openwrt/packages/issues/25014.
