### PR TITLE
conserver: backport support for high baud rates.

### DIFF
--- a/net/conserver/Makefile
+++ b/net/conserver/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=conserver
 PKG_VERSION:=8.2.6
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/conserver/conserver/tar.gz/v$(PKG_VERSION)?

--- a/net/conserver/patches/003-backport-high-baud-rates.patch
+++ b/net/conserver/patches/003-backport-high-baud-rates.patch
@@ -1,0 +1,64 @@
+From e7ca230c2239735d1b4c05747da8efbbae2fb547 Mon Sep 17 00:00:00 2001
+From: Peter Chubb <Peter.Chubb@data61.csiro.au>
+Date: Tue, 16 Mar 2021 10:31:27 +1100
+Subject: [PATCH] Conserver-server: Add high baud rates
+
+Linux (and others) allow higher baud rates than POSIX.
+Add the definitions so that baud rates up to 4Mb/s are recognised
+and can be used.
+
+Signed-off-by: Peter Chubb <peter.chubb@data61.csiro.au>
+---
+ conserver/consent.c | 39 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 39 insertions(+)
+
+diff --git a/conserver/consent.c b/conserver/consent.c
+index 8ef7199..ca50473 100644
+--- a/conserver/consent.c
++++ b/conserver/consent.c
+@@ -86,6 +86,45 @@ BAUD baud[] = {
+     {"3500000", 32},
+     {"4000000", 33},
+ #else /* FOR_CYCLADES_TS */
++# if defined(B4000000)
++    {"4000000", B4000000},
++# endif
++# if defined(B3500000)
++    {"3500000", B3500000},
++# endif
++# if defined(B3000000)
++    {"3000000", B3000000},
++# endif
++# if defined(B2500000)
++    {"2500000", B2500000},
++# endif
++# if defined(B2000000)
++    {"2000000", B2000000},
++# endif
++# if defined(B1500000)
++    {"1500000", B1500000},
++# endif
++# if defined(B1152000)
++    {"1152000", B1152000},
++# endif
++# if defined(B1000000)
++    {"1000000", B1000000},
++# endif
++# if defined(B921600)
++    {"921600", B921600},
++# endif
++# if defined(B576000)
++    {"576000", B576000},
++# endif
++# if defined(B500000)
++    {"500000", B500000},
++# endif
++# if defined(B460800)
++    {"460800", B460800},
++# endif
++# if defined(B230400)
++    {"230400", B230400},
++# endif
+ # if defined(B115200)
+     {"115200", B115200},
+ # endif

--- a/net/conserver/patches/004-backport-high-baud-digits.patch
+++ b/net/conserver/patches/004-backport-high-baud-digits.patch
@@ -1,0 +1,40 @@
+From 1a961cdf18e2de6240c78f127029f76b147226fc Mon Sep 17 00:00:00 2001
+From: "Bjoern A. Zeeb" <patch@zabbadoz.net>
+Date: Fri, 16 Jul 2021 16:28:15 +0000
+Subject: [PATCH] conserver: reflect that baud values have increased to 7
+ digits
+
+When having "examine" print baud/parity increase the maximum string
+width from 6 to 7 digits.  And while here try to indicate more baud
+values in the manual going up to 4000000.
+---
+ conserver.cf/conserver.cf.man.in | 2 +-
+ conserver/group.c                | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/conserver.cf/conserver.cf.man.in b/conserver.cf/conserver.cf.man.in
+index fd89f20..addaf52 100644
+--- a/conserver.cf/conserver.cf.man.in
++++ b/conserver.cf/conserver.cf.man.in
+@@ -468,7 +468,7 @@ all consoles have an implicit ``include "*";'' at the beginning
+ of their definition).
+ .RS
+ .TP
+-\f3baud\fP \f3300\fP|\f3600\fP|\f31800\fP|\f32400\fP|\f34800\fP|\f39600\fP|\f319200\fP|\f338400\fP|\f357600\fP|\f3115200\fP
++\f3baud\fP \f3300\fP|\f3600\fP|\f31800\fP|\f32400\fP|\f34800\fP|\f39600\fP|\f319200\fP|\f338400\fP|\f357600\fP|\f3115200\fP|..|\f34000000\fP
+ .br
+ Assign the baud rate to the console.
+ Only consoles of type ``device'' will use this value.
+diff --git a/conserver/group.c b/conserver/group.c
+index cfdc80e..27c102b 100644
+--- a/conserver/group.c
++++ b/conserver/group.c
+@@ -2210,7 +2210,7 @@ CommandExamine(GRPENT *pGE, CONSCLIENT *pCLServing, CONSENT *pCEServing,
+ 		break;
+ 	}
+ 	FilePrint(pCLServing->fd, FLAGFALSE,
+-		  " %-24.24s on %-32.32s at %6.6s%c\r\n", pCE->server, d,
++		  " %-24.24s on %-32.32s at %7.7s%c\r\n", pCE->server, d,
+ 		  b, p);
+ 	if (args != (char *)0)
+ 	    break;


### PR DESCRIPTION
Backport upstream support for high baud rates (230.4k up to 4M baud).

Maintainer: @neheb 
Compile tested: mips_24kc, gl.inet 6416, openwrt current
Run tested: mips_24kc, gl.inet 6416, openwrt current, tested at 1.5Mbit with a USB ch341-uart

Description:
This backports e7ca230c2239735d1b4c05747da8efbbae2fb547 (which adds support for baud rates above 115.2k) and 1a961cdf18e2de6240c78f127029f76b147226fc (which fixes a bug displaying those speeds) which was added upstream after the 8.2.6 release/