### PR TITLE
lpac: don't override env vars in the wrapper

### DIFF
--- a/utils/lpac/files/lpac.sh
+++ b/utils/lpac/files/lpac.sh
@@ -2,32 +2,18 @@
 
 . /lib/config/uci.sh
 
-APDU_BACKEND="$(uci_get lpac global apdu_backend uqmi)"
-APDU_DEBUG="$(uci_get lpac global apdu_debug 0)"
+: "${LPAC_APDU=$(uci_get lpac global apdu_backend)}"; export LPAC_APDU
+LIBEUICC_DEBUG_APDU="$(uci_get lpac global apdu_debug)" && export LIBEUICC_DEBUG_APDU
 
-HTTP_BACKEND="$(uci_get lpac global http_backend curl)"
-HTTP_DEBUG="$(uci_get lpac global http_debug 0)"
-
-export LPAC_HTTP="$HTTP_BACKEND"
-if [ "$HTTP_DEBUG" -eq 1 ]; then
-    export LIBEUICC_DEBUG_HTTP="1"
+if [ "$LPAC_APDU" = "at" ]; then
+    export AT_DEVICE="$(uci_get lpac at device)"
+    AT_DEBUG="$(uci_get lpac at debug)" && export AT_DEBUG
+elif [ "$LPAC_APDU" = "uqmi" ]; then
+    export LPAC_QMI_DEV="$(uci_get lpac uqmi device)"
+    LPAC_QMI_DEBUG="$(uci_get lpac uqmi debug)" && export LPAC_QMI_DEBUG
 fi
 
-export LPAC_APDU="$APDU_BACKEND"
-if [ "$APDU_DEBUG" -eq 1 ]; then
-    export LIBEUICC_DEBUG_APDU="1"
-fi
+export LPAC_HTTP="$(uci_get lpac global http_backend)"
+LIBEUICC_DEBUG_HTTP="$(uci_get lpac global http_debug)" && export LIBEUICC_DEBUG_HTTP
 
-if [ "$APDU_BACKEND" = "at" ]; then
-    AT_DEVICE="$(uci_get lpac at device /dev/ttyUSB2)"
-    AT_DEBUG="$(uci_get lpac at debug 0)"
-    export AT_DEVICE="$AT_DEVICE"
-    export AT_DEBUG="$AT_DEBUG"
-elif [ "$APDU_BACKEND" = "uqmi" ]; then
-    UQMI_DEV="$(uci_get lpac uqmi device /dev/cdc-wdm0)"
-    UQMI_DEBUG="$(uci_get lpac uqmi debug 0)"
-    export LPAC_QMI_DEV="$UQMI_DEV"
-    export LPAC_QMI_DEBUG="$UQMI_DEBUG"
-fi
-
-/usr/lib/lpac "$@"
+exec /usr/lib/lpac "$@"

--- a/utils/lpac/files/lpac.uci
+++ b/utils/lpac/files/lpac.uci
@@ -1,13 +1,13 @@
 config global global
 	option		apdu_backend	'uqmi'
 	option		http_backend	'curl'
-	option		apdu_debug	'0'
-	option		http_debug	'0'
+#	option		apdu_debug	'1'
+#	option		http_debug	'1'
 
 config at at
 	option		device		'/dev/ttyUSB2'
-	option		debug		'0'
+#	option		debug		'1'
 
 config uqmi uqmi
 	option		device		'/dev/cdc-wdm0'
-	option		debug		'0'
+#	option		debug		'1'		# value matters


### PR DESCRIPTION
Some env variables sensitive for proper lpac functioning are set by upper lpac wrappers such as [lpac-libmbim-wrapper](https://github.com/stich86/lpac-libmbim-wrapper/).
If that's the case, we shouldn't override them, otherwise the wrapper won't work.

Also fixes problem with AT ADPU backend where debug is always on due AT_DEBUG is always exported.

Also, we shouldn't interpret values of the debug env
variables. Instead, we just pass them as is if the
corresponding uci optioins exist.

fixes #25035

Maintainer: @blocktrron

Description:
alternative to #25036