### PR TITLE
go2rtc: add package

### DIFF
--- a/multimedia/go2rtc/Makefile
+++ b/multimedia/go2rtc/Makefile
@@ -1,0 +1,50 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=go2rtc
+PKG_VERSION:=1.9.4
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/AlexxIT/go2rtc/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=90c1273c84d8f538d573cf638493ab30981d4445ff8451b485ab26c60353ed48
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Vladimir Ermakov <vooon341@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/AlexxIT/go2rtc
+GO_PKG_EXCLUDES:=test
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/go2rtc
+  SECTION:=multimedia
+  CATEGORY:=Multimedia
+  TITLE:=go2rtc camera streaming
+  URL:=https://github.com/AlexxIT/go2rtc
+  DEPENDS:=$(GO_ARCH_DEPENDS) +ffmpeg
+endef
+
+define Package/go2rtc/description
+  Ultimate camera streaming application with support RTSP, WebRTC, HomeKit, FFmpeg, RTMP, etc.
+endef
+
+define Package/go2rtc/conffiles
+/etc/go2rtc.yaml
+endef
+
+define Package/go2rtc/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+
+	$(INSTALL_DIR) $(1)/etc/
+	$(INSTALL_CONF) $(CURDIR)/files/go2rtc.yaml $(1)/etc/go2rtc.yaml
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) $(CURDIR)/files/go2rtc.init $(1)/etc/init.d/go2rtc
+endef
+
+$(eval $(call BuildPackage,go2rtc))

--- a/multimedia/go2rtc/files/go2rtc.init
+++ b/multimedia/go2rtc/files/go2rtc.init
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+
+USE_PROCD=1
+PROG=/usr/bin/go2rtc
+
+start_service() {
+	procd_open_instance
+	procd_set_param command "$PROG" -config /etc/go2rtc.yaml
+	procd_close_instance
+}

--- a/multimedia/go2rtc/files/go2rtc.yaml
+++ b/multimedia/go2rtc/files/go2rtc.yaml
@@ -1,0 +1,25 @@
+# See also: https://github.com/AlexxIT/go2rtc/blob/master/README.md
+---
+
+log:
+  level: info  # default level
+  # api: trace
+  # exec: debug
+  # ngrok: info
+  # rtsp: warn
+  # streams: error
+  # webrtc: fatal
+
+api:
+  listen: "127.0.0.1:1984"
+
+rtsp:
+  listen: "127.0.0.1:8554"
+
+webrtc:
+  listen: ":8555"  # external TCP/UDP port
+
+ffmpeg:
+  bin: /usr/bin/ffmpeg  # path to ffmpeg binary
+
+streams: {}


### PR DESCRIPTION
Maintainer: me / @vooon
Compile tested: OpenWrt master,
Run tested: OpenWrt master, x64_64 / gl-b2200 ARMv7

Description:

Adds [go2rtc](https://github.com/AlexxIT/go2rtc), a service that re-streams camera to many other protocols.

WebRTC can use TURN (like coturn) to establish connection in case of dual SNAT.