### PR TITLE
ddns-scripts: add colon char in DNS_CHARSET

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -72,7 +72,7 @@ IPV6_REGEX="\(\([0-9A-Fa-f]\{1,4\}:\)\{1,\}\)\(\([0-9A-Fa-f]\{1,4\}\)\{0,1\}\)\(
 SHELL_ESCAPE="[\"\'\`\$\!();><{}?|\[\]\*\\\\]"
 
 # dns character set. "-" must be the last character
-DNS_CHARSET="[@a-zA-Z0-9._-]"
+DNS_CHARSET="[@a-zA-Z0-9.:_-]"
 
 # domains can have * for wildcard. "-" must be the last character
 DNS_CHARSET_DOMAIN="[@a-zA-Z0-9._*-]"


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: N/A. (Runtime package script only)
Run tested: (amd64, ibm comp PC, OpenWrt 23.04, tests done)

Description:
IPv6 is separated by `:` instead of `.`, so we need to add `:` in DNS_CHARSET to fix issue https://github.com/openwrt/packages/issues/25051 or #25051

Signed-off-by: Xiaolong Zhang <xliilQwQ@outlook.com>