### PR TITLE
utils/xz: fix license

### DIFF
--- a/utils/xz/Makefile
+++ b/utils/xz/Makefile
@@ -17,7 +17,7 @@ PKG_SOURCE_URL:=@SF/lzmautils
 PKG_HASH:=e12aa03cbd200597bd4ce11d97be2d09a6e6d39a9311ce72c91ac7deacde3171
 
 PKG_MAINTAINER:=
-PKG_LICENSE:=Public-Domain LGPL-2.1-or-later GPL-2.0-or-later GPL-3.0-or-later
+PKG_LICENSE:=Public-Domain LGPL-2.1-or-later 0BSD
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:tukaani:xz
 


### PR DESCRIPTION
Remove GPL-2.0+ and GPL-3.0+ from `PKG_LICENSE` as GNU GPLv2+ and GPLv3+ are only used for the build system as  stated in [1]( https://github.com/tukaani-project/xz/commit/02ddf09bc3079b3e17297729b9e43f14d407b8fc):

>  The build system contains public domain files, and files that
>  are under GNU GPLv2+ or GNU GPLv3+. None of these files end up
>  in the binaries being built.

Moreover, add 0BSD which is used since version 5.6.0 [2](https://github.com/tukaani-project/xz/commit/689e0228baeb95232430e90d628379db89583d71)

Fixes: b9e87eeb7deb8b3890415b835c9c69764893c023 (xz: import from old packages feed)

Maintainer: @1715173329
Compile tested: Not needed
Run tested: Not needed