### PR TITLE
Add support for SRT streaming within gstreamer

### DIFF
--- a/libs/srt/Config.in
+++ b/libs/srt/Config.in
@@ -1,0 +1,33 @@
+if PACKAGE_srt
+
+comment "Encryption support"
+
+choice
+	prompt "Selected Encryption library"
+	default SRT_OPENSSL
+
+	config SRT_OPENSSL
+		bool "OpenSSL"
+
+	config SRT_MBEDTLS
+		bool "mbed TLS"
+
+	config SRT_GNUTLS
+		bool "GNUTLS"
+
+	config SRT_NOENCRYPTION
+		bool "No encryption support"
+
+endchoice
+
+comment "Options"
+
+config SRT_MONOTONIC_CLOCK
+	bool "Monotonic clock"
+	default y
+
+config SRT_BONDING
+	bool "Bonding"
+	default n
+
+endif

--- a/libs/srt/Makefile
+++ b/libs/srt/Makefile
@@ -1,0 +1,79 @@
+#
+# Copyright (C) 2024 Koen Vandeputte <koen.vandeputte@citymesh.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=srt
+PKG_VERSION:=1.5.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/haivision/srt/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=befaeb16f628c46387b898df02bc6fba84868e86a6f6d8294755375b9932d777
+PKG_MAINTAINER:=Koen Vandeputte <koen.vandeputte@citymesh.com>
+
+PKG_LICENSE:=MPL-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+CMAKE_INSTALL:=1
+
+PKG_CONFIG_DEPENDS:= \
+  \
+  CONFIG_SRT_OPENSSL \
+  CONFIG_SRT_MBEDTLS \
+  CONFIG_SRT_GNUTLS \
+  CONFIG_SRT_NOENCRYPTION \
+  \
+  CONFIG_SRT_MONOTONIC_CLOCK \
+  CONFIG_SRT_BONDING
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/srt
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:= +libstdcpp +libatomic
+  DEPENDS += +SRT_OPENSSL:libopenssl +SRT_MBEDTLS:libmbedtls +SRT_GNUTLS:libgnutls
+  TITLE:=secure reliable transport
+  URL:=https://github.com/Haivision/srt
+  MENU:=1
+endef
+
+define Package/srt/description
+  This package provides the Secure Reliable Transport library which
+  is mostly used by the gstreamer srt sink plugin
+endef
+
+define Package/srt/config
+  source "$(SOURCE)/Config.in"
+endef
+
+TARGET_LDFLAGS += -Wl,--gc-sections
+
+CMAKE_OPTIONS += \
+	-DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DENABLE_APPS=OFF \
+        -DENABLE_PKTINFO=OFF \
+        -DENABLE_SHARED=ON \
+        -DENABLE_STATIC=OFF \
+        -DENABLE_TESTING=OFF \
+        -DENABLE_UNITTESTS=OFF \
+        -DUSE_BUSY_WAITING=OFF \
+        -DENABLE_BONDING=$(if $(CONFIG_SRT_BONDING),ON,OFF) \
+        -DENABLE_MONOTONIC_CLOCK=$(if $(CONFIG_SRT_MONOTONIC_CLOCK),ON,OFF) \
+        -DENABLE_ENCRYPTION=$(if $(CONFIG_SRT_OPENSSL)$(CONFIG_SRT_MBEDTLS)$(CONFIG_SRT_GNUTLS),ON,OFF) \
+        $(if $(CONFIG_SRT_OPENSSL),-DUSE_ENCLIB=openssl-evp) \
+        $(if $(CONFIG_SRT_MBEDTLS),-DUSE_ENCLIB=mbedtls) \
+        $(if $(CONFIG_SRT_GNUTLS),-DUSE_ENCLIB=gnutls)
+
+define Package/srt/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsrt.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,srt))

--- a/multimedia/gst1-plugins-bad/Makefile
+++ b/multimedia/gst1-plugins-bad/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-bad
 PKG_VERSION:=1.24.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=gst-plugins-bad-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://gstreamer.freedesktop.org/src/gst-plugins-bad/
@@ -228,7 +228,7 @@ MESON_ARGS += \
 	$(call GST_COND_SELECT,sndfile) \
 	-Dsoundtouch=disabled \
 	-Dspandsp=disabled \
-	-Dsrt=disabled \
+	$(call GST_COND_SELECT,srt) \
 	-Dsrtp=disabled \
 	-Dteletext=disabled \
 	-Dtinyalsa=disabled \
@@ -415,6 +415,7 @@ $(eval $(call GstBuildPlugin,opusparse,OPUS streams library,pbutils,,+libopus))
 $(eval $(call GstBuildPlugin,sbc,sbc support,audio,,+sbc))
 $(eval $(call GstBuildPlugin,shm,POSIX shared memory source and sink,,,+librt))
 $(eval $(call GstBuildPlugin,sndfile,sndfile support,audio,,+libsndfile))
+$(eval $(call GstBuildPlugin,srt,srt support,,,+srt))
 #$(eval $(call GstBuildPlugin,srtp,srtp support,rtp,,+libsrtp))
 $(eval $(call GstBuildPlugin,webp,webp support,,,+libwebp))
 #$(eval $(call GstBuildPlugin,yadif,yadif support,,,))


### PR DESCRIPTION
Maintainer: @neheb @flyn-org 
Compile tested: imx6 (all 3 encryption settings + unencrypted)
Run tested: imx6 (all 3 encryption settings + unencrypted - tested using Nimble streamer as receiver)

Description:
This series adds full support for SRT streaming (Secure Reliable Transport)
- The 1st commit adds the lib as a new package
- The 2nd commit enables it within gstreamer (plugins-bad)

Encryption support is present for:
- OpenSSL (using modern EVP mechanism)
- mbedtls
- gnutls