### PR TITLE
lsof: update to 4.99.3

### DIFF
--- a/utils/lsof/Makefile
+++ b/utils/lsof/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=lsof
-PKG_VERSION:=4.99.0
+PKG_VERSION:=4.99.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lsof-org/lsof/releases/download/$(PKG_VERSION)
-PKG_HASH:=180e6284aff184d94d273e34f7264edc2af849c07b1c5d6a4183d4d402734245
+PKG_HASH:=86428a8881b0d1147a52058e853c775b83d794f0da685d549b2bfd07063ed1cd
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>

--- a/utils/lsof/patches/000-disable-man.patch
+++ b/utils/lsof/patches/000-disable-man.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -208,13 +208,8 @@ EXTRA_DIST += 00.README.FIRST 00CREDITS
+@@ -212,11 +212,6 @@ EXTRA_DIST += 00.README.FIRST 00CREDITS
  # Testing
  EXTRA_DIST += tests/00README tests/TestDB tests/CkTestDB tests/Makefile tests/LsofTest.h check.bash
  
@@ -12,7 +12,3 @@
  # Fix distcheck error
  clean-local:
  	rm -rf lsof.man
- distclean-local:
--	rm -rf lockf_owner.h lockf.h
-\ No newline at end of file
-+	rm -rf lockf_owner.h lockf.h


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_cortex-a53, qualcommax/ipq807x, r27617+3-a9540a4e33
Run tested: aarch64_cortex-a53, qualcommax/ipq807x, r27617+3-a9540a4e33, works as expected

Description:
- update to 4.99.3
- refresh the patch