### PR TITLE
netbird: update to 0.29.4

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.29.3
+PKG_VERSION:=0.29.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=14bedb946a27e989896c53a13a93457e5c17f7f171da3a69f6d10e1ead142fc0
+PKG_HASH:=a3ad5dd3deda26e7888706af99c2e093cc03c6db2d47cf3569c28b8306d23c2f
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.29.2
+PKG_VERSION:=0.29.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=1a9b52f620d1b9e7215898c0a9f857f0d2cc49b3ca29f3565a3768239df20c20
+PKG_HASH:=14bedb946a27e989896c53a13a93457e5c17f7f171da3a69f6d10e1ead142fc0
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.29.1
+PKG_VERSION:=0.29.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=9072d16845de49ce395b150564b82f97a33defe007276b6b46d733306b6760ee
+PKG_HASH:=1a9b52f620d1b9e7215898c0a9f857f0d2cc49b3ca29f3565a3768239df20c20
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## Compile and run tested

Maintainer: Oskari Rauta / @oskarirauta

| Package architecture | Target | Subtarget | Brand | Model | Hardware Version | OpenWrt version |
|----------------------|--------|-----------|-------|-------|------------------|-----------------|
| [x86_64](https://openwrt.org/docs/techref/instructionset/x86_64) | [x86](https://openwrt.org/docs/techref/targets/x86) | 64 | [Duex](https://duex.com.br/) | [DX B75ZG M.2 Intel LGA 1155 DDR3](https://duex.com.br/produto/placa-mae-dx-b75zg-m-2-intel-lga-1155-ddr3/) | n/a | OpenWrt SNAPSHOT r27644-d03f3dcf3b |

## Description

- Changelog:
  - [v0.29.4](https://github.com/netbirdio/netbird/releases/tag/v0.29.4)
  - [v0.29.3](https://github.com/netbirdio/netbird/releases/tag/v0.29.3)
  - [v0.29.2](https://github.com/netbirdio/netbird/releases/tag/v0.29.2)
- Full changelog: https://github.com/netbirdio/netbird/compare/v0.29.1...v0.29.4

## Additional information
`x86_64` running as container with [`incus`](https://github.com/lxc/incus).
Compiled package with container [`sdk`](https://github.com/openwrt/docker), and build `openwrt` image with container [`imagebuilder`](https://github.com/openwrt/docker).

My repo with my automated build can be see here:
- https://github.com/wehagy/openwrt-builder/tree/netbird

And my artifacts here:
- https://github.com/wehagy/openwrt-builder/actions/runs/11156121780