### PR TITLE
digital ocean ddns requires "type" field

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/update_digitalocean_com_v2.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_digitalocean_com_v2.sh
@@ -24,6 +24,7 @@
 json_init
 json_add_string name "$username"
 json_add_string data "$__IP"
+[ $use_ipv6 -ne 0 ] && json_add_string type "AAAA" || json_add_string type "A"
 
 __STATUS=$(curl -Ss -X PUT "https://api.digitalocean.com/v2/domains/${domain}/records/${param_opt}" \
 	-H "Authorization: Bearer ${password}" \


### PR DESCRIPTION
Maintainer: @giannoug
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
digital ocean ddns requires "type" field