### PR TITLE
xray-core: update to 24.9.30

### DIFF
--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-core
-PKG_VERSION:=1.8.24
+PKG_VERSION:=24.9.30
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/XTLS/Xray-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=86e3e388c77cda4d8457a607356416c201c1f18bbed53f0a9e76a228508ff298
+PKG_HASH:=0771120ddbf866fba44f2e8978bcc20f3843663f5726bd8db9e03e1a27e1212a
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MPL-2.0


### PR DESCRIPTION
Maintainer: @1715173329
Compile tested: all supported targets
Run tested: rockchip/armv8

Description:
**_xray-core: update to 24.9.30_**
> [!NOTE]  
> SplitHTTP is now only compatible with v1.8.24. Removed QUIC and DomainSocket transport layers, and eliminated compatibility code for legacy configurations.

**_For more information, visit https://github.com/XTLS/Xray-core/releases/tag/v24.9.30 https://github.com/XTLS/Xray-core/compare/v1.8.24...v24.9.30_**