### PR TITLE
nginx: Add support for NJS module

### DIFF
--- a/libs/libxslt/Makefile
+++ b/libs/libxslt/Makefile
@@ -132,7 +132,7 @@ define Build/InstallDev/Exslt
 endef
 
 define Build/InstallDev
-	 $(if $(CONFIG_PACKAGE_libxslt),$(call Build/InstallDev/Xslt,$(1),$(2)))
+	 $(call Build/InstallDev/Xslt,$(1),$(2))
 	 $(if $(CONFIG_PACKAGE_libexslt),$(call Build/InstallDev/Exslt,$(1),$(2)))
 endef
 

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -37,7 +37,8 @@ PKG_MOD_EXTRA := \
 	brotli \
 	headers-more \
 	ts \
-	ubus
+	ubus \
+	njs
 # official and 3rd-party modules
 PKG_MOD_ALL := \
 	$(PKG_MOD_EXTRA) \
@@ -254,7 +255,6 @@ define Download/nginx-mod-headers-more
   PROTO:=git
 endef
 
-
 define Download/nginx-mod-brotli
   SOURCE_DATE:=2020-04-23
   VERSION:=25f86f0bac1101b6512135eac5f93c49c63609e3
@@ -324,6 +324,14 @@ define Download/nginx-mod-ubus
   VERSION:=b2d7260dcb428b2fb65540edb28d7538602b4a26
   URL:=https://github.com/Ansuel/nginx-ubus-module.git
   MIRROR_HASH:=515bb9d355ad80916f594046a45c190a68fb6554d6795a54ca15cab8bdd12fda
+  PROTO:=git
+endef
+
+define Download/nginx-mod-njs
+  SOURCE_DATE:=2024-10-03
+  VERSION:=c5a29a7af8894ee1ec44ebda71ef0ea1f2a31af6
+  URL:=https://github.com/nginx/njs.git
+  MIRROR_HASH:=69bc424d4bfd8b7a0a70feeb4787ff8b503ac893fb730f07f3244e35fde876e4
   PROTO:=git
 endef
 
@@ -473,7 +481,8 @@ CONFIGURE_ARGS += \
 	$(if $(CONFIG_PACKAGE_nginx-mod-stream),--with-stream=dynamic --with-stream_ssl_module --with-stream_ssl_preread_module) \
 	$(if $(call IsEnabled,NGINX_STREAM_REAL_IP),--with-stream_realip_module) \
 	$(if $(CONFIG_PACKAGE_nginx-mod-naxsi),--add-dynamic-module=$(PKG_BUILD_DIR)/nginx-mod-naxsi/naxsi_src) \
-	$(foreach m,$(filter-out lua-resty-core lua-resty-lrucache naxsi,$(PKG_MOD_EXTRA)), \
+	$(if $(CONFIG_PACKAGE_nginx-mod-njs),--add-dynamic-module=$(PKG_BUILD_DIR)/nginx-mod-njs/nginx) \
+	$(foreach m,$(filter-out lua-resty-core lua-resty-lrucache naxsi njs,$(PKG_MOD_EXTRA)), \
 		$(if $(CONFIG_PACKAGE_nginx-mod-$(m)),--add-dynamic-module=$(PKG_BUILD_DIR)/nginx-mod-$(m)))
 
 $(eval $(call BuildPackage,nginx-ssl))
@@ -501,6 +510,8 @@ $(eval $(call BuildModule,naxsi,,ngx_http_naxsi, \
 	Enable NAXSI module.))
 $(eval $(call BuildModule,geoip2,+@NGINX_STREAM_CORE_MODULE +nginx-mod-stream +libmaxminddb,ngx_http_geoip2 ngx_stream_geoip2, \
 	Enable MaxMind GeoIP2 module.))
+$(eval $(call BuildModule,njs,+zlib +libxml2 +libxslt +libpcre2,ngx_http_js, \
+	Enable NJS module.))
 
 # TODO: remove after a transition period (together with pkg nginx-util):
 # It is for smoothly substituting nginx and nginx-mod-luci-ssl (by nginx-ssl

--- a/net/nginx/patches/nginx-mod-njs/101-feature_test_fix.patch
+++ b/net/nginx/patches/nginx-mod-njs/101-feature_test_fix.patch
@@ -1,0 +1,61 @@
+--- a/nginx-mod-njs/auto/explicit_bzero
++++ b/nginx-mod-njs/auto/explicit_bzero
+@@ -7,7 +7,7 @@
+ 
+ njs_feature="explicit_bzero()"
+ njs_feature_name=NJS_HAVE_EXPLICIT_BZERO
+-njs_feature_run=yes
++njs_feature_run=no
+ njs_feature_incs=
+ njs_feature_libs=
+ njs_feature_test="#include <strings.h>
+--- a/nginx-mod-njs/auto/getrandom
++++ b/nginx-mod-njs/auto/getrandom
+@@ -7,7 +7,7 @@
+ 
+ njs_feature="getrandom()"
+ njs_feature_name=NJS_HAVE_GETRANDOM
+-njs_feature_run=yes
++njs_feature_run=no
+ njs_feature_incs=
+ njs_feature_libs=
+ njs_feature_test="#include <unistd.h>
+@@ -76,6 +76,7 @@ if [ $njs_found = no ]; then
+ 
+     njs_feature="getentropy()"
+     njs_feature_name=NJS_HAVE_GETENTROPY
++    njs_feature_run=no
+     njs_feature_test="#include <unistd.h>
+ 
+                       int main(void) {
+--- a/nginx-mod-njs/auto/memalign
++++ b/nginx-mod-njs/auto/memalign
+@@ -8,7 +8,7 @@
+ 
+ njs_feature="posix_memalign()"
+ njs_feature_name=NJS_HAVE_POSIX_MEMALIGN
+-njs_feature_run=yes
++njs_feature_run=no
+ njs_feature_incs=
+ njs_feature_libs=
+ njs_feature_test="#include <stdlib.h>
+@@ -31,7 +31,7 @@ if [ $njs_found = no ]; then
+ 
+     njs_feature="memalign()"
+     njs_feature_name=NJS_HAVE_MEMALIGN
+-    njs_feature_run=yes
++    njs_feature_run=no
+     njs_feature_incs=
+     njs_feature_libs=
+     njs_feature_test="#include <stdlib.h>
+--- a/nginx-mod-njs/auto/time
++++ b/nginx-mod-njs/auto/time
+@@ -5,7 +5,7 @@
+ 
+ njs_feature="clock_gettime(CLOCK_MONOTONIC)"
+ njs_feature_name=NJS_HAVE_CLOCK_MONOTONIC
+-njs_feature_run=yes
++njs_feature_run=no
+ njs_feature_incs=
+ njs_feature_libs=
+ njs_feature_test="#include <time.h>

--- a/net/nginx/patches/nginx-mod-njs/102-sizeof_test_fix.patch
+++ b/net/nginx/patches/nginx-mod-njs/102-sizeof_test_fix.patch
@@ -1,0 +1,236 @@
+--- a/nginx-mod-njs/auto/types
++++ b/nginx-mod-njs/auto/types
+@@ -11,113 +11,37 @@
+ #     printf("%d", (int) sizeof(TYPE));
+ 
+ 
+-njs_feature="sizeof(int)"
+-njs_feature_name=NJS_INT_SIZE
+-njs_feature_run=value
+-njs_feature_incs=
+-njs_feature_libs=
+-njs_feature_test="#include <stdio.h>
+-
+-                  int main() {
+-                      printf(\"%d\", (int) sizeof(int));
+-                      return 0;
+-                  }"
+-. auto/feature
+-
+-
+-njs_feature="sizeof(u_int)"
+-njs_feature_name=NJS_UINT_SIZE
+-njs_feature_run=value
+-njs_feature_incs=
+-njs_feature_libs=
+-njs_feature_test="#include <sys/types.h>
+-                  #include <stdio.h>
+-
+-                  int main() {
+-                      printf(\"%d\", (int) sizeof(u_int));
+-                      return 0;
+-                  }"
+-. auto/feature
+-
+-
+-njs_feature="sizeof(void *)"
+-njs_feature_name=NJS_PTR_SIZE
+-njs_feature_run=value
+-njs_feature_incs=
+-njs_feature_libs=
+-njs_feature_test="#include <stdio.h>
+-
+-                  int main() {
+-                      printf(\"%d\", (int) sizeof(void *));
+-                      return 0;
+-                  }"
+-. auto/feature
+-
+-
+-njs_feature="sizeof(uintptr_t)"
+-njs_feature_name=NJS_UINTPTR_T_SIZE
+-njs_feature_run=value
+-njs_feature_incs=
+-njs_feature_libs=
+-njs_feature_test="#include <stdint.h>
+-                  #include <stdio.h>
+-
+-                  int main() {
+-                      printf(\"%d\", (int) sizeof(uintptr_t));
+-                      return 0;
+-                  }"
+-. auto/feature
++njs_type="int"; . auto/types_util/sizeof
++njs_param=NJS_INT_SIZE; njs_value=$njs_size; . auto/types_util/value
+ 
+ 
+-case "$njs_feature_value" in
++njs_type="u_int"; . auto/types_util/sizeof
++njs_param=NJS_UINT_SIZE; njs_value=$njs_size; . auto/types_util/value
++
++
++njs_type="void *"; . auto/types_util/sizeof
++njs_param=NJS_PTR_SIZE; njs_value=$njs_size; . auto/types_util/value
++
++
++njs_type="uintptr_t"; . auto/types_util/sizeof
++njs_param=NJS_UINTPTR_T_SIZE; njs_value=$njs_size; . auto/types_util/value
++
++case "$njs_value" in
+     8) NJS_64BIT=1 ;;
+     *) NJS_64BIT=0 ;;
+ esac
+ 
+ 
+-njs_feature="sizeof(size_t)"
+-njs_feature_name=NJS_SIZE_T_SIZE
+-njs_feature_run=value
+-njs_feature_incs=
+-njs_feature_libs=
+-njs_feature_test="#include <stdio.h>
+-
+-                  int main() {
+-                      printf(\"%d\", (int) sizeof(size_t));
+-                      return 0;
+-                  }"
+-. auto/feature
+-
+-
+-njs_feature="sizeof(off_t)"
+-njs_feature_name=NJS_OFF_T_SIZE
+-njs_feature_run=value
+-njs_feature_incs=
+-njs_feature_libs=
+-njs_feature_test="#define _FILE_OFFSET_BITS  64
+-                  #include <unistd.h>
+-                  #include <stdio.h>
+-
+-                  int main() {
+-                      printf(\"%d\", (int) sizeof(off_t));
+-                      return 0;
+-                  }"
+-. auto/feature
+-
+-
+-njs_feature="sizeof(time_t)"
+-njs_feature_name=NJS_TIME_T_SIZE
+-njs_feature_run=value
+-njs_feature_incs=
+-njs_feature_libs=
+-njs_feature_test="#include <time.h>
+-                  #include <stdio.h>
+-
+-                  int main(void) {
+-                      printf(\"%d\", (int) sizeof(time_t));
+-                      return 0;
+-                  }"
+-. auto/feature
++njs_type="size_t"; . auto/types_util/sizeof
++njs_param=NJS_SIZE_T_SIZE; njs_value=$njs_size; . auto/types_util/value
++
++
++njs_type="off_t"; . auto/types_util/sizeof
++njs_param=NJS_OFF_T_SIZE; njs_value=$njs_size; . auto/types_util/value
++
++
++njs_type="time_t"; . auto/types_util/sizeof
++njs_param=NJS_TIME_T_SIZE; njs_value=$njs_size; . auto/types_util/value
+ 
+ 
+ # Ensuring that double type is always evaluated at standard
+--- /dev/null
++++ b/nginx-mod-njs/auto/types_util/sizeof
+@@ -0,0 +1,78 @@
++
++# Copyright (C) Igor Sysoev
++# Copyright (C) Nginx, Inc.
++
++
++printf "checking for sizeof($njs_type) ..."
++
++cat << END >> $NJS_AUTOCONF_ERR
++
++----------------------------------------
++checking for sizeof($njs_type)
++
++END
++
++njs_size=
++
++cat << END > $NJS_AUTOTEST.c
++
++#include <sys/types.h>
++#include <time.h>
++#include <stdio.h>
++#include <stdint.h>
++
++volatile char object_code_block[] = {
++	'\n', 'e', '4', 'V', 'A',
++	'0', 'x', ('0' + sizeof($njs_type)),
++	'Y', '3', 'p', 'M', '\n'
++};
++
++int main(void) {
++    printf("dummy use of object_code_block to avoid gc-section: %c", object_code_block[0]);
++    return 0;
++}
++
++END
++
++
++njs_test="$CC $CFLAGS $NJS_CFLAGS $NJS_CC_OPT $NJS_TEST_CFLAGS \
++          -o $NJS_AUTOTEST $NJS_AUTOTEST.c \
++          $NJS_LD_OPT $NJS_TEST_LIBS"
++
++eval "$njs_test >> $NJS_AUTOCONF_ERR 2>&1"
++
++
++if [ -x $NJS_AUTOTEST ]; then
++    njs_size=`sed -ne 's/^e4VA0x\(.\)Y3pM$/\1/p' < $NJS_AUTOTEST`
++    echo " $njs_size"
++fi
++
++
++case $njs_size in
++    4)
++        njs_max_value=2147483647
++        njs_max_len='(sizeof("-2147483648") - 1)'
++    ;;
++
++    8)
++        njs_max_value=9223372036854775807LL
++        njs_max_len='(sizeof("-9223372036854775808") - 1)'
++    ;;
++
++    *)
++        echo
++        echo "$0: error: can not detect $njs_type size"
++
++        echo "----------"    >> $NJS_AUTOCONF_ERR
++        cat $NJS_AUTOTEST.c  >> $NJS_AUTOCONF_ERR
++        echo "----------"    >> $NJS_AUTOCONF_ERR
++        echo $njs_test       >> $NJS_AUTOCONF_ERR
++        echo "----------"    >> $NJS_AUTOCONF_ERR
++
++        rm -rf $NJS_AUTOTEST*
++
++        exit 1
++esac
++
++
++rm -rf $NJS_AUTOTEST*
+--- /dev/null
++++ b/nginx-mod-njs/auto/types_util/value
+@@ -0,0 +1,12 @@
++
++# Copyright (C) Igor Sysoev
++# Copyright (C) Nginx, Inc.
++
++
++cat << END >> $NJS_AUTO_CONFIG_H
++
++#ifndef $njs_param
++#define $njs_param  $njs_value
++#endif
++
++END

--- a/net/nginx/patches/nginx-mod-njs/104-endianness_fix.patch
+++ b/net/nginx/patches/nginx-mod-njs/104-endianness_fix.patch
@@ -1,0 +1,51 @@
+--- a/nginx-mod-njs/auto/endianness
++++ b/nginx-mod-njs/auto/endianness
+@@ -2,6 +2,15 @@
+ # Copyright (C) Dmitry Volyntsev
+ # Copyright (C) NGINX, Inc.
+ 
++if [ "${CONFIG_BIG_ENDIAN}" != "y" ]; then
++    njs_define=NJS_HAVE_BIG_ENDIAN . auto/define
++
++else
++    njs_define=NJS_HAVE_LITTLE_ENDIAN . auto/define
++fi
++
++return
++
+ njs_found=no
+ 
+ njs_feature="system byte ordering"
+@@ -26,10 +35,4 @@ if [ $njs_found = no ]; then
+     exit 1;
+ fi
+ 
+-if [ $njs_feature_value = big ]; then
+-    njs_define=NJS_HAVE_BIG_ENDIAN . auto/define
+-
+-else
+-    njs_define=NJS_HAVE_LITTLE_ENDIAN . auto/define
+ 
+-fi
+--- a/nginx-mod-njs/nginx/config.make
++++ b/nginx-mod-njs/nginx/config.make
+@@ -3,15 +3,15 @@ cat << END
+ $ngx_addon_dir/../build/libnjs.a: $NGX_MAKEFILE
+ 	cd $ngx_addon_dir/.. \\
+ 	&& if [ -f build/Makefile ]; then \$(MAKE) clean; fi \\
+-	&& CFLAGS="\$(CFLAGS)" CC="\$(CC)" ./configure --no-openssl \\
+-		--no-libxml2 --no-zlib --no-pcre --no-quickjs \\
++	&& CFLAGS="\$(CFLAGS)" CC="\$(CC)" CONFIG_BIG_ENDIAN=\$(CONFIG_BIG_ENDIAN) \\
++		./configure --no-openssl --no-libxml2 --no-zlib --no-pcre --no-quickjs \\
+ 	&& \$(MAKE) libnjs
+ 
+ $ngx_addon_dir/../build/libqjs.a: $NGX_MAKEFILE
+ 	cd $ngx_addon_dir/.. \\
+ 	&& if [ -f build/Makefile ]; then \$(MAKE) clean; fi \\
+-	&& CFLAGS="\$(CFLAGS)" CC="\$(CC)" ./configure --no-openssl \\
+-		--no-libxml2 --no-zlib --no-pcre \\
++	&& CFLAGS="\$(CFLAGS)" CC="\$(CC)" CONFIG_BIG_ENDIAN=\$(CONFIG_BIG_ENDIAN) \\
++		./configure --no-openssl --no-libxml2 --no-zlib --no-pcre \\
+ 	&& \$(MAKE) libnjs libqjs
+ 
+ END

--- a/net/nginx/patches/nginx/101-feature_test_fix.patch
+++ b/net/nginx/patches/nginx/101-feature_test_fix.patch
@@ -5,7 +5,7 @@
      ngx_feature="C compiler"
      ngx_feature_name=
 -    ngx_feature_run=yes
-+    ngx_feature_run=
++    ngx_feature_run=no
      ngx_feature_incs=
      ngx_feature_path=
      ngx_feature_libs=
@@ -71,6 +71,15 @@
  
  ngx_feature="prctl(PR_SET_DUMPABLE)"
  ngx_feature_name="NGX_HAVE_PR_SET_DUMPABLE"
+-ngx_feature_run=yes
++ngx_feature_run=no
+ ngx_feature_incs="#include <sys/prctl.h>"
+ ngx_feature_path=
+ ngx_feature_libs=
+@@ -186,7 +186,7 @@ ngx_feature_test="if (prctl(PR_SET_DUMPA
+ 
+ ngx_feature="prctl(PR_SET_KEEPCAPS)"
+ ngx_feature_name="NGX_HAVE_PR_SET_KEEPCAPS"
 -ngx_feature_run=yes
 +ngx_feature_run=no
  ngx_feature_incs="#include <sys/prctl.h>"

--- a/net/nginx/patches/nginx/105-optional-libexslt.patch
+++ b/net/nginx/patches/nginx/105-optional-libexslt.patch
@@ -1,0 +1,29 @@
+--- a/auto/options
++++ b/auto/options
+@@ -165,6 +165,7 @@ USE_PERL=NO
+ NGX_PERL=perl
+ 
+ USE_LIBXSLT=NO
++USE_LIBEXSLT=NO
+ USE_LIBGD=NO
+ USE_GEOIP=NO
+ 
+@@ -370,6 +371,7 @@ use the \"--with-mail_ssl_module\" optio
+         --with-pcre-opt=*)               PCRE_OPT="$value"          ;;
+         --with-pcre-jit)                 PCRE_JIT=YES               ;;
+         --without-pcre2)                 PCRE2=DISABLED             ;;
++        --with-libexslt)                 USE_LIBEXSLT=YES           ;;
+ 
+         --with-openssl=*)                OPENSSL="$value"           ;;
+         --with-openssl-opt=*)            OPENSSL_OPT="$value"       ;;
+--- a/auto/lib/libxslt/conf
++++ b/auto/lib/libxslt/conf
+@@ -156,7 +156,7 @@ if [ $ngx_found = no ]; then
+ fi
+ 
+ 
+-if [ $ngx_found = yes ]; then
++if [ $ngx_found = yes ] && [ $USE_LIBEXSLT = "YES" ]; then
+     if [ $USE_LIBXSLT = YES ]; then
+         CORE_LIBS="$CORE_LIBS -lexslt"
+     fi

--- a/net/nginx/patches/nginx/201-ignore-invalid-options.patch
+++ b/net/nginx/patches/nginx/201-ignore-invalid-options.patch
@@ -1,6 +1,6 @@
 --- a/auto/options
 +++ b/auto/options
-@@ -413,8 +413,7 @@ $0: warning: the \"--with-sha1-asm\" opt
+@@ -415,8 +415,7 @@ $0: warning: the \"--with-sha1-asm\" opt
          --test-build-solaris-sendfilev)  NGX_TEST_BUILD_SOLARIS_SENDFILEV=YES ;;
  
          *)

--- a/net/nginx/patches/nginx/300-fix-deprecated-openssl-3_0.patch
+++ b/net/nginx/patches/nginx/300-fix-deprecated-openssl-3_0.patch
@@ -9,4 +9,3 @@
          && EVP_CipherUpdate(ctx, NULL, &len, NULL, in->len) != 1)
      {
          ngx_ssl_error(NGX_LOG_INFO, log, 0, "EVP_CipherUpdate() failed");
-


### PR DESCRIPTION
Add support for NJS module. Various patch are required to make this
module correctly compile with the required library mainly related on
detecting config flags.

In doing this, improve feature patch on nginx core.

It's not needed to bump PKG_RELEASE as we are not changing anything in the main package and just introducing a new module.