### PR TITLE
pdns-recursor: update to 5.1.2

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
-PKG_VERSION:=5.1.1
+PKG_VERSION:=5.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=5b7ab793ace822294a3f38092fe72ee64748ff0cbb8a5283dc77f40780605ae9
+PKG_HASH:=b3a37ebb20285ab9acbbb0e1370e623bb398ed3087f0e678f23ffa3b0063983d
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>, Remi Gacogne <remi.gacogne@powerdns.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
fixes CVE-2024-25590

Maintainer: me + @rgacogne 
Compile tested: github actions
Run tested: docker openwrt/rootfs x86_64

Description:
