### PR TITLE
tgt: enable support for thin_provisioning

### DIFF
--- a/net/tgt/Makefile
+++ b/net/tgt/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tgt
 PKG_VERSION:=1.0.93
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fujita/tgt/tar.gz/v$(PKG_VERSION)?

--- a/net/tgt/files/tgt.config
+++ b/net/tgt/files/tgt.config
@@ -47,6 +47,10 @@ config target 1
 #	option 'sense_format' '0'
 # Rotaion rate: 0: not reported, 1: non-rotational medium (SSD), 2-1024: reserverd, 1025+: "Nominal rotation rate"
 #	option 'rotation_rate' '0'
+# A thin-provisioned LUN is represented as a sparse file.
+# When initiators use the SCSI UNMAP command TGTD will release the affected areas back to the filesystem using FALLOC_FL_PUNCH_HOLE.
+# This option applies to the disk type and rdwr bstype
+#	option 'thin_provisioning' '1'
 
 #config lun 2_1
 #	option device /mnt/iscsi.img

--- a/net/tgt/files/tgt.init
+++ b/net/tgt/files/tgt.init
@@ -28,7 +28,8 @@ validate_lun_section() {
 		'scsi_sn:string' \
 		'sense_format:range(0, 1)' \
 		'vendor_id:string' \
-		'rotation_rate:uinteger'
+		'rotation_rate:uinteger' \
+		'thin_provisioning:bool:0'
 }
 
 handle_lun() {
@@ -55,9 +56,20 @@ handle_lun() {
 		bsoflags="--bsoflags $bsoflags"
 	fi
 
+	if [ "$thin_provisioning" -eq 1 ]; then
+		[ "$type" = disk ] || {
+			$logger "Thin provisioning is supported only for the 'disk' type" 
+			return 1
+		}
+		[ "$bstype" = rdwr ] || {
+			$logger "Thin provisioning is supported onfy for the 'rdwr' bstype"
+			return 1
+		}
+	fi
+
 	blocksize=${blocksize+--blocksize=$blocksize}
 	local params='' i
-	for i in mode_page product_id product_rev readonly removable scsi_id scsi_sn sense_format vendor_id rotation_rate; do
+	for i in mode_page product_id product_rev readonly removable scsi_id scsi_sn sense_format vendor_id rotation_rate thin_provisioning; do
 		eval params=\${$i+$i=\$$i,}\$params
 	done
 


### PR DESCRIPTION
Maintainer: me
Compile tested: N/A
Run tested: aarch64_cortex-a53, qualcommax/ipq807x, r27617+3-a9540a4e33, thin provisioning works: `du -h` on the backing store file shows the decrease in size on `rm` and `fstrim` at the initiator side. The init script reports and rejects the unsupported combinations.

Description:
enable the `thin_provisioning` option for the rdwr disk targets

Fixes #25065