### PR TITLE
[23.05] php8: update to 8.2.24

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.2.23
+PKG_VERSION:=8.2.24
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.php.net/distributions/
-PKG_HASH:=81c5ae6ba44e262a076349ee54a2e468638a4571085d80bff37f6fd308e1d8d5
+PKG_HASH:=80a5225746a9eb484475b312d4c626c63a88a037d8e56d214f30205e1ba1411a
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16

--- a/lang/php8/patches/0025-php-5.4.9-fixheader.patch
+++ b/lang/php8/patches/0025-php-5.4.9-fixheader.patch
@@ -9,7 +9,7 @@ Make generated php_config.h constant across rebuilds.
 
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1454,7 +1454,7 @@ PHP_REMOVE_USR_LIB(LDFLAGS)
+@@ -1468,7 +1468,7 @@ PHP_REMOVE_USR_LIB(LDFLAGS)
  EXTRA_LDFLAGS="$EXTRA_LDFLAGS $PHP_LDFLAGS"
  EXTRA_LDFLAGS_PROGRAM="$EXTRA_LDFLAGS_PROGRAM $PHP_LDFLAGS"
  

--- a/lang/php8/patches/1004-disable-phar-command.patch
+++ b/lang/php8/patches/1004-disable-phar-command.patch
@@ -11,7 +11,7 @@
  
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1650,13 +1650,13 @@ CFLAGS_CLEAN="$CFLAGS \$(PROF_FLAGS)"
+@@ -1664,13 +1664,13 @@ CFLAGS_CLEAN="$CFLAGS \$(PROF_FLAGS)"
  CFLAGS="\$(CFLAGS_CLEAN) $standard_libtool_flag"
  CXXFLAGS="$CXXFLAGS $standard_libtool_flag \$(PROF_FLAGS)"
  


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs & bcm2708
Run tested: Raspberry Pi

Description:

This fixes:
    - CVE-2024-8925
    - CVE-2024-8926
    - CVE-2024-8927
    - CVE-2024-9026

Upstream changelog:
https://www.php.net/ChangeLog-8.php#8.2.24
