### PR TITLE
libpng: fix compilation with loongarch64

### DIFF
--- a/libs/libpng/Makefile
+++ b/libs/libpng/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpng
 PKG_VERSION:=1.6.44
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/libpng
@@ -36,8 +36,12 @@ CMAKE_OPTIONS += \
 	-DPNG_TOOLS=OFF \
 	-DPNG_TESTS=OFF \
 	-DPNG_FRAMEWORK=OFF \
-	-DPNG_HARDWARE_OPTIMIZATIONS=O$(if $(findstring powerpc,$(CONFIG_ARCH))$(findstring mips,$(CONFIG_ARCH)),FF,N) \
+	-DPNG_HARDWARE_OPTIMIZATIONS=ON \
 	-DPNG_ARM_NEON=$(if $(or $(findstring aarch64,$(CONFIG_ARCH)),$(findstring neon,$(CONFIG_CPU_TYPE))),on,off) \
+	-DPNG_LOONGARCH_LSX=off \
+	-DPNG_MIPS_MMI=off \
+	-DPNG_MIPS_MSA=off \
+	-DPNG_POWERPC_VSX=off \
 	-Dld-version-script=OFF
 
 define Build/InstallDev


### PR DESCRIPTION
Explicitly disable unsupported hardware acceleration instead of trying to match against targets.

Maintainer: @jow- 