### PR TITLE
tmux: update to 3.5a

### DIFF
--- a/utils/tmux/Makefile
+++ b/utils/tmux/Makefile
@@ -2,12 +2,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tmux
-PKG_VERSION:=3.5
+PKG_VERSION:=3.5a
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tmux/tmux/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=74460f85bd81d73661356f777cdada121033ba8b0bc9119991d9fb0b5381c35e
+PKG_HASH:=49e68b41dec0bf408990160ee12fa29b06dee8f74c1f0b4b71c9d2a1477dd910
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 
 PKG_LICENSE:=ISC


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_cortex-a53, qualcommax/ipq807x, r27697+4-d51353db26
Run tested: aarch64_cortex-a53, qualcommax/ipq807x, r27697+4-d51353db26, works, no issues so far
 
Description:
