### PR TITLE
qemu: 9.1.0-2: fix guest agent patch

### DIFF
--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qemu
 PKG_VERSION:=9.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_HASH:=816b7022a8ba7c2ac30e2e0cf973e826f6bcc8505339603212c5ede8e94d7834
 PKG_SOURCE_URL:=https://download.qemu.org/

--- a/utils/qemu/patches/0007-qga-invoke-separate-applets-for-guest-shutdown-modes.patch
+++ b/utils/qemu/patches/0007-qga-invoke-separate-applets-for-guest-shutdown-modes.patch
@@ -41,7 +41,7 @@ https://gitlab.alpinelinux.org/alpine/aports/commit/76b81b486480fd9c3294cd420bcf
      if (local_err) {
 -        error_propagate(errp, local_err);
 -        return;
-+        const char fallback_argv[] = {fallback_cmd, (char *) NULL};
++        const char *fallback_argv[] = {fallback_cmd, (char *) NULL};
 +        ga_run_command(fallback_argv, NULL, fallback_cmd, &local_err);
 +        if (local_err) {
 +            error_propagate(errp, local_err);


### PR DESCRIPTION
Maintainer: @yousong
Compile tested: x86_64, OpenWrt master
Run tested: x86_64 host, KVM for qemu-x86_64-softmmu + Bios VM.

Description:

I've used wrong type in qemu guest agent patch, found by: @curtdept
Fixes https://github.com/vooon/openwrt-packages/commit/d9da6e792a25e8b34c271d4c3752c7185c77878d#r147673510