### PR TITLE
age: Add package for age

### DIFF
--- a/utils/age/Makefile
+++ b/utils/age/Makefile
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=age
+PKG_VERSION:=1.2.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/FiloSottile/age/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=cefe9e956401939ad86a9c9d7dcf843a43b6bcdf4ee7d8e4508864f227a3f6f0
+
+PKG_MAINTAINER:=Arnau Valls <vallsfustearnau@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/FiloSottile/age
+GO_PKG_BUILD_PKG:=filippo.io/age/cmd/...
+GO_PKG_LDFLAGS_X:=$(GO_PKG)/cmd.Version=$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/age
+	SECTION:=utils
+	CATEGORY:=Utilities
+	TITLE:=age file encryption
+	URL:=https://docs.gitlab.com/runner
+	DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/age/description
+age is a simple, modern and secure file encryption tool, format, and Go library.
+
+It features small explicit keys, no config options, and UNIX-style composability.
+endef
+
+$(eval $(call GoBinPackage,age))
+$(eval $(call BuildPackage,age))
+


### PR DESCRIPTION
https://github.com/FiloSottile/age

Maintainer: me
Compile tested: 
amd64 for mipsel_24kc on commit https://github.com/openwrt/openwrt/commit/084665698b113811c8c9017631068dc3e452efa4
Run tested: 
Unielec U7621-01 16MB, mipsel_24kc on version 23.05.5.

I tested encrypting a file and decrypting a file using the ssh host key with success.

Description:
A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability.

It is useful in this case to encrypt and decrypt files using the host ssh key (it has to be converted with dropbearconvert).

This package provides the age and age-keygen binaries, but I would like to make separate packages for each. What's the best way?