### PR TITLE
mwan3: add rules for router initiated traffic

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.11.16
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -77,7 +77,7 @@ stop_service() {
 			$IP route flush table $tid &> /dev/null
 		done
 
-		for rule in $($IP rule list | grep -E '^[1-3][0-9]{3}\:' | cut -d ':' -f 1); do
+		for rule in $($IP rule list | grep -E '^[1-3][0-9]{3}:' | cut -d ':' -f 1); do
 			$IP rule del pref $rule &> /dev/null
 		done
 		table="$($IPT -S)"

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -527,7 +527,10 @@ mwan3_create_iface_rules()
 
 	mwan3_delete_iface_rules "$1"
 
+	network_get_ipaddr wan_addr "${1}"
+
 	$IP rule add pref $((id+1000)) iif "$2" lookup "$id"
+	$IP rule add pref $((id+1500)) from ${wan_addr} lookup "$id"
 	$IP rule add pref $((id+2000)) fwmark "$(mwan3_id2mask id MMX_MASK)/$MMX_MASK" lookup "$id"
 	$IP rule add pref $((id+3000)) fwmark "$(mwan3_id2mask id MMX_MASK)/$MMX_MASK" unreachable
 }


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: x86-64, snapshot
Run tested: x86-64, 23.05.4

Description:
Router-initiated traffic can select the uplink to use via the `mwan3 use` command or the socket wrapper.
This PR adds ip rules to enable route selection using the uplink's source IP address.

Additional information:
Given that eth0.1 is the backup wan, the `ping -c 1 -I eth0.1 www.google.com` command used by the [documentation](https://openwrt.org/docs/guide-user/network/wan/multiwan/mwan3#verify_outbound_traffic_on_each_wan_interface) now only works before mwan3 is configured. With this patch, it will work even after mwan3 has been configured.
See [this forum thread](https://forum.openwrt.org/t/mwan3-router-initiated-traffic/212629) for discussion.
