### PR TITLE
fluent-bit: Deactivate sasl2, zlib and zstd

### DIFF
--- a/admin/fluent-bit/Makefile
+++ b/admin/fluent-bit/Makefile
@@ -41,7 +41,10 @@ CMAKE_OPTIONS+= \
 	-DFLB_CHUNK_TRACE=No \
 	-DFLB_BACKTRACE=No \
 	-DFLB_WASM=No \
-	-DFLB_LUAJIT=No
+	-DFLB_LUAJIT=No \
+	-DWITH_SASL=No \
+	-DWITH_ZLIB=No \
+	-DWITH_ZSTD=No
 
 define Package/fluent-bit/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
Maintainer: @rthakur33 
Compile tested: MIPS malta BE 32
Run tested: None

Description:

Deactivate the dependencies to libsals2, libzlib and libzstd.
This fixes the build of fluent-bit.

This fixes the following problem:
```
Package fluent-bit is missing dependencies for the following libraries:
libsasl2.so.3
libz.so.1
libzstd.so.1
```