### PR TITLE
ruby: Fix ruby 3.3.4 build error using github action

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -40,6 +40,7 @@ HOST_CONFIGURE_ARGS += \
 	--disable-install-capi \
 	--without-gmp \
 	--with-static-linked-ext \
+        --disable-yjit \
 	--with-out-ext=-test-/*,bigdecimal,cgi/escape,continuation,coverage,etc,fcntl,fiddle,io/console,json,json/generator,json/parser,mathn/complex,mathn/rational,nkf,objspace,pty,racc/cparse,rbconfig/sizeof,readline,rubyvm,syslog,win32,win32ole,win32/resolv
 
 HOST_BUILD_DEPENDS:=yaml/host
@@ -53,7 +54,8 @@ CONFIGURE_ARGS += \
 	--disable-install-capi \
 	--with-ruby-version=minor \
 	--with-iconv-dir=$(ICONV_PREFIX) \
-	--with-out-ext=win32,win32ole
+	--with-out-ext=win32,win32ole \
+        --disable-yjit
 
 ifndef CONFIG_RUBY_DIGEST_USE_OPENSSL
 CONFIGURE_ARGS += \


### PR DESCRIPTION
Maintainer: Luiz Angelo Daros de Luca <luizluca@gmail.com>
Compile tested: (put here arch, model, OpenWrt version)
Run tested: master

Description:
Fix ruby build error using github action:
"linking static-library libruby-static.a
LLVM ERROR: Invalid encoding"

fix ruby build error 3.3.4 using github action
https://github.com/openwrt/packages/issues/25052

reference from:
https://lore.kernel.org/all/20240205183308.2120022-1-james.hilliard1@gmail.com/T/
