### PR TITLE
libmaxminddb: fixup lib and include dirs in pkg-config

### DIFF
--- a/libs/libmaxminddb/Makefile
+++ b/libs/libmaxminddb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmaxminddb
 PKG_VERSION:=1.11.0
-PKG_RELEASE=1
+PKG_RELEASE=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/maxmind/libmaxminddb/releases/download/$(PKG_VERSION)
@@ -45,6 +45,8 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmaxminddb.so* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libmaxminddb.pc $(1)/usr/lib/pkgconfig
+	$(SED) 's,libdir=lib,libdir=$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/libmaxminddb.pc
+	$(SED) 's,includedir=include,includedir=$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/libmaxminddb.pc
 endef
 
 define Package/libmaxminddb/install


### PR DESCRIPTION
Maintainer: @ja-pa, @krant
Compile tested: qualcommax,ipq807x ,main
Run tested: NO

Description:
libmaxminddb has switched to using `CMAKE_INSTALL_PREFIX`, `CMAKE_INSTALL_LIBDIR` and `CMAKE_INSTALL_INCLUDEDIR` for generating the pkg-config in upstream commit [1] and thus broke pkg-config file generation in openwrt.
```

It would generate:
prefix=/usr
exec_prefix=/usr
libdir=lib
includedir=include
```

Obviously libdir and includedirs are incorrect for OpenWrt and this would then cause pdns compilation to fail if geoip backend was enabled since it uses pkg-config to get the required flags and passing just lib for LDFLAGS would cause libtool to error out since that path is not valid.

So, lets use SED magic to replace `libdir` and `includedir` with the correct paths, so now pkg-config looks like:
```
prefix=/usr
exec_prefix=/usr
libdir=${exec_prefix}/lib
includedir=${prefix}/include
```

[1] https://github.com/maxmind/libmaxminddb/commit/8b4bf0dec99bc248c36e49e0837efb749e7d46f6

Fixes: 9f7357880f64 ("libmaxminddb: update to 1.11.0")