### PR TITLE
ddns-scripts: porkbun bugfix to not delete subdomain on A/AAAA record

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=49
+PKG_RELEASE:=50
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_porkbun_v3.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_porkbun_v3.sh
@@ -130,6 +130,7 @@ function edit_record() {
 	local request response
 	json_init
 	json_authenticate
+	json_add_string "name" "$__SUBDOMAIN"
 	json_add_string "type" "$__TYPE"
 	json_add_string "content" "$__ADDR"
 	request=$(json_dump)


### PR DESCRIPTION
I noticed that the porkbun updater is changing my wildcard domain A and AAAA records from `*.<domain>.<tld>` to just `<domain>.<tld>` after the first run.

It would appear that Porkbun's API considers a missing `name` key to mean you want to drop the subdomain from the record (see [here](https://porkbun.com/api/json/v3/documentation#DNS%20Edit%20Record%20by%20Domain%20and%20ID)), which is probably not the intended behavior here.

This PR simply adds one line to correct that.