### PR TITLE
[22.03] pdns-recursor: update to 4.9.9

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
-PKG_VERSION:=4.8.6
+PKG_VERSION:=4.9.9
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=1ff4087ef12e6fc68fccd22c97215fd7f01038d7ad46715e9ffe7494e9926d95
+PKG_HASH:=cda5c7d077b90bd3ef9d6989e9bcf824609a32201093961e62eb6e40c3ef7a48
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>
 PKG_LICENCE:=GPL-2.0-only

--- a/net/pdns-recursor/patches/100-disable-recursor.conf-dist.patch
+++ b/net/pdns-recursor/patches/100-disable-recursor.conf-dist.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -503,12 +503,6 @@ $(srcdir)/effective_tld_names.dat:
+@@ -508,12 +508,6 @@ $(srcdir)/effective_tld_names.dat:
  pubsuffix.cc: $(srcdir)/effective_tld_names.dat
  	$(AM_V_GEN)./mkpubsuffixcc
  


### PR DESCRIPTION
Maintainer: me + @rgacogne 
Compile tested: github actions
Run tested: docker openwrt/rootfs:x86-64-22.03.7

Description:

fixes CVE-2024-25590

as there is no fix for 4.8.x, this bumps to the latest 4.9.x
