### PR TITLE
openconnect: introduced script parameter

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=9.12
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.infradead.org/openconnect/download

--- a/net/openconnect/README
+++ b/net/openconnect/README
@@ -18,6 +18,9 @@ config interface 'MYVPN'
 	# Reconnect after a temporary network down time (in seconds)
 	#option reconnect_timeout '30'
 
+	# Shell command line for using a vpnc-compatible config script (default: "/lib/netifd/vpnc-script")
+	# option script '/lib/netifd/vpnc-script'
+
 	# For second factor auth:
 
 	# when a fixed 2FA password can be used

--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -37,6 +37,7 @@ proto_openconnect_init_config() {
 	proto_config_add_string "csd_wrapper"
 	proto_config_add_string "proxy"
 	proto_config_add_array 'form_entry:regex("[^:]+:[^=]+=.*")'
+	proto_config_add_string "script"
 	no_device=1
 	available=1
 }
@@ -73,6 +74,7 @@ proto_openconnect_setup() {
 		token_secret \
 		usergroup \
 		username \
+		script \
 
 	ifname="vpn-$config"
 
@@ -101,7 +103,8 @@ proto_openconnect_setup() {
 	[ -n "$port" ] && port=":$port"
 	[ -z "$uri" ] && uri="$server$port"
 
-	append_args "$uri" -i "$ifname" --non-inter --syslog --script /lib/netifd/vpnc-script
+	append_args "$uri" -i "$ifname" --non-inter --syslog
+	[ -n "$script" ] && append_args --script "$script"
 	[ "$pfs" = 1 ] && append_args --pfs
 	[ "$no_dtls" = 1 ] && append_args --no-dtls
 	[ -n "$mtu" ] && append_args --mtu "$mtu"


### PR DESCRIPTION
This allows specifying a custom vpnc-compatible config script.

Maintainer: me
Compile tested: n/a (runtime only)
Run tested: OpenWRT 23.05.5 (Routerich AX3000) with and without set option

Description:
This allows specifying a custom vpnc-compatible config script.