### PR TITLE
igmpproxy: add config parameter to enable ssdp

### DIFF
--- a/net/igmpproxy/Makefile
+++ b/net/igmpproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=igmpproxy
 PKG_VERSION:=0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/pali/igmpproxy/releases/download/${PKG_VERSION}/

--- a/net/igmpproxy/files/igmpproxy.config
+++ b/net/igmpproxy/files/igmpproxy.config
@@ -12,3 +12,4 @@ config phyint
 	option network lan
 	option zone lan
 	option direction downstream
+#	option ssdp [0|1]

--- a/net/igmpproxy/files/igmpproxy.init
+++ b/net/igmpproxy/files/igmpproxy.init
@@ -79,7 +79,7 @@ igmp_add_firewall_routing() {
 	config_get_bool ssdp $1 ssdp 0
 
 	if [ $ssdp -gt 0 ]; then
-		local ssdp_target="ACCEPT"
+		ssdp_target="ACCEPT"
 	fi
 
 	json_add_object ""

--- a/net/igmpproxy/files/igmpproxy.init
+++ b/net/igmpproxy/files/igmpproxy.init
@@ -63,6 +63,9 @@ igmp_add_network() {
 }
 
 igmp_add_firewall_routing() {
+	local direction zone ssdp
+	local ssdp_target="DROP"
+
 	config_get direction $1 direction
 	config_get zone $1 zone
 
@@ -70,7 +73,14 @@ igmp_add_firewall_routing() {
 		return 0
 	fi
 
-# First drop SSDP packets then accept all other multicast
+	# Old logic to drop SSDP in any case removed. Added new config option to enable SSDP in case needed.
+	# However, default behaviour is unchanged.
+
+	config_get_bool ssdp $1 ssdp 0
+
+	if [ $ssdp -gt 0 ]; then
+		local ssdp_target="ACCEPT"
+	fi
 
 	json_add_object ""
 	json_add_string type rule
@@ -79,7 +89,7 @@ igmp_add_firewall_routing() {
 	json_add_string family ipv4
 	json_add_string proto udp
 	json_add_string dest_ip "239.255.255.250"
-	json_add_string target DROP
+	json_add_string target "$ssdp_target"
 	json_close_object
 
 	json_add_object ""


### PR DESCRIPTION
* Adde a config parameter to enable SSDP
* Keep existing default behavior
* Bump release version

Maintainer: @nbd168
Compile tested: openwrt/sdk:x86-64-openwrt-23.05 & openwrt/sdk:ramips-mt7621-23.05
Run tested: ramips/mt7621, TP-Link Archer C6 v3, OpenWrt 23.05.5 r24106-10cc5fcd00, tested with default config, disabled option & enabled option

Description:
The previous implementation of the init script always disabled SSDP. The new implementation adds a config flag bearing the option not to disable SSDP. However, the default behavior will not change and SSDP will stay disabled by default.
Especially Sonos users, who want to use SSDP forwarding, will benefit from having the choice whether to DROP or ACCEPT.
