### PR TITLE
modemmanager: apply EPS initial bearer before modem enable

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.22.0
-PKG_RELEASE:=19
+PKG_RELEASE:=20
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: qualcommax/ipq60xx,main
Run tested: qualcommax/ipq60xx,main

Description:
Currently, the EPS initial bearer is getting applied only after the modem has been enabled, but that means that its already registered to the network and might have been using the network provided APN to do so instead of the APN we provided and want to use.

So, in order for the desired APN to always be used to register to the network we need to apply the initial EPS bearer configuration before the modem has been enabled.