### PR TITLE
[23.05] i2pd: update to 2.54.0

### DIFF
--- a/net/i2pd/Makefile
+++ b/net/i2pd/Makefile
@@ -1,7 +1,7 @@
 #
 # Copyright (C) 2015, 2016 gxcreator
 # Copyright (C) 2017 OpenWrt.org
-# Copyright (C) 2021-2023 PurpleI2P team
+# Copyright (C) 2021-2024 PurpleI2P team
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -10,13 +10,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=i2pd
-PKG_VERSION:=2.48.0
+PKG_VERSION:=2.54.0
 PKG_RELEASE:=1
 PKG_BUILD_PARALLEL:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/PurpleI2P/i2pd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=ccf417aa66ce37f72ea15b7fbcff4c71e823566ea74bda696b9c1e19aae08739
+PKG_HASH:=5c3f703417bb5f3e5dda642d39c5d30593a5dcf69d5a5ecfe82d5e8a7d454aaf
 
 PKG_MAINTAINER:=David Yang <mmyangfl@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -28,8 +28,8 @@ include $(INCLUDE_DIR)/package.mk
 define Package/i2pd
 	SECTION:=net
 	CATEGORY:=Network
-	DEPENDS:=+libopenssl +boost +boost-system +boost-filesystem \
-	         +boost-program_options +boost-date_time +libatomic +zlib
+	DEPENDS:=+libopenssl +boost +boost-system \
+	         +boost-program_options +libatomic +zlib
 	TITLE:=full-featured C++ implementation of I2P client
 	URL:=https://github.com/PurpleI2P/i2pd
 	USERID:=i2pd:i2pd
@@ -51,8 +51,8 @@ define Package/i2pd/conffiles
 endef
 
 define Package/i2pd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/i2pd $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/i2pd $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/i2pd.init $(1)/etc/init.d/i2pd
 	$(INSTALL_DIR) $(1)/usr/share/i2pd

--- a/net/i2pd/files/i2pd.init
+++ b/net/i2pd/files/i2pd.init
@@ -8,7 +8,7 @@ START=90
 STOP=10
 
 # default params
-PROG=/usr/sbin/i2pd
+PROG=/usr/bin/i2pd
 USER="i2pd"
 GROUP="i2pd"
 PIDFILE=/var/run/i2pd.pid


### PR DESCRIPTION
Maintainer: @yangfl
Compile tested: 23.05.5 x86-64
Run tested: 23.05.5 x86-64

Description:
* Updating package to 2.54.0
* Changed Makefile to install binary to /usr/bin (as in upstream)
* Updated init.rc script with new path