### PR TITLE
Fix typos in NAT traffic Prometheus collector

### DIFF
--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/nat_traffic.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/nat_traffic.lua
@@ -1,10 +1,10 @@
 local function scrape()
-  -- documetation about nf_conntrack:
+  -- documentation about nf_conntrack:
   -- https://www.frozentux.net/iptables-tutorial/chunkyhtml/x1309.html
 
-  -- two dimesional table to sum bytes for the pair (src/dest)
+  -- two dimensional table to sum bytes for the pair (src/dest)
   local nat = {}
-  -- default constructor to init unknow pairs
+  -- default constructor to initialize unknown pairs
   setmetatable(nat, {
     __index = function (t, addr)
       t[addr] = {}


### PR DESCRIPTION
Maintainer: [@champtar](https://github.com/jdbaldry/packages/blob/171f68ffb3f10c023ff0358f0325a041b64ef3fc/utils/prometheus-node-exporter-lua/Makefile#L10)
Compile tested: None
Run tested: None

Note the broken CI is present in the previous change to this package: https://github.com/openwrt/packages/pull/24328
