### PR TITLE
netbird: update to 0.30.2

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.30.1
+PKG_VERSION:=0.30.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=46014fb96e5320715efef5d1e767278e4f13dbe11eb18df7cdfb2bd06b12eabf
+PKG_HASH:=4d27fed679da342b3f50c3aa5feda3342de761cb038a31b9337c4db7f50445d3
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## Compile and run tested

Maintainer: Oskari Rauta / @oskarirauta

| Package architecture | Target | Subtarget | Brand | Model | Hardware Version | OpenWrt version |
|----------------------|--------|-----------|-------|-------|------------------|-----------------|
| [x86_64](https://openwrt.org/docs/techref/instructionset/x86_64) | [x86](https://openwrt.org/docs/techref/targets/x86) | 64 | [Duex](https://duex.com.br/) | [DX B75ZG M.2 Intel LGA 1155 DDR3](https://duex.com.br/produto/placa-mae-dx-b75zg-m-2-intel-lga-1155-ddr3/) | n/a | OpenWrt SNAPSHOT r27798-dbc2923cbe |

## Description

- Changelog:
  - [v0.30.2](https://github.com/netbirdio/netbird/releases/tag/v0.30.2)
- Full changelog: https://github.com/netbirdio/netbird/compare/v0.30.1...v0.30.2

## Additional information

`x86_64` running as container with [`incus`](https://github.com/lxc/incus).
Compiled package with container [`sdk`](https://github.com/openwrt/docker), and build `openwrt` image with container [`imagebuilder`](https://github.com/openwrt/docker).

My repo with my automated build can be see here:
- https://github.com/wehagy/openwrt-builder/tree/update/netbird

And my artifacts here:
- https://github.com/wehagy/openwrt-builder/actions/runs/11419054995