### PR TITLE
keepalived: fixes in hotplug script

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.2.8
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software

--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.2.8
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software

--- a/net/keepalived/files/etc/hotplug.d/keepalived/511-firewall
+++ b/net/keepalived/files/etc/hotplug.d/keepalived/511-firewall
@@ -5,6 +5,7 @@
 
 set_service_name firewall
 
+set_skip_running_check
 set_reload_if_sync
 
 add_sync_file /etc/config/firewall

--- a/net/keepalived/files/etc/hotplug.d/keepalived/551-dnsmasq
+++ b/net/keepalived/files/etc/hotplug.d/keepalived/551-dnsmasq
@@ -7,7 +7,6 @@ set_service_name dnsmasq
 
 set_restart_if_master
 set_stop_if_backup
-set_reload_if_sync
 
 add_sync_file /etc/config/dhcp
 add_sync_file /tmp/dhcp.leases

--- a/net/keepalived/files/lib/functions/keepalived/hotplug.sh
+++ b/net/keepalived/files/lib/functions/keepalived/hotplug.sh
@@ -82,7 +82,7 @@ is_sync_file() {
 	list_contains SYNC_FILES_LIST "$1"
 }
 
-set_update_target() {
+_set_update_target() {
 	set_var UPDATE_TARGET "${1:-1}"
 }
 
@@ -90,8 +90,8 @@ get_update_target() {
 	get_var UPDATE_TARGET
 }
 
-unset_update_target() {
-	set_var UPDATE_TARGET
+set_disable_update_target() {
+	_set_update_target 0
 }
 
 is_update_target() {
@@ -170,8 +170,12 @@ skip_running_check() {
 	get_var_flag NOTIFY_SKIP_RUNNING
 }
 
+_set_reload_if_sync() {
+	set_var NOTIFY_SYNC_RELOAD "${1:-0}"
+}
+
 set_reload_if_sync() {
-	set_var NOTIFY_SYNC_RELOAD "${1:-1}"
+	_set_reload_if_sync 1
 }
 
 get_reload_if_sync() {
@@ -257,8 +261,8 @@ keepalived_hotplug() {
 	[ -z "$(get_fault_cb)" ] && set_fault_cb _notify_fault
 	[ -z "$(get_sync_cb)" ] && set_sync_cb _notify_sync
 
-	[ -z "$(get_update_target)" ] && set_update_target "$@"
-	[ -z "$(get_reload_if_sync)" ] && set_reload_if_sync "$@"
+	[ -z "$(get_update_target)" ] && _set_update_target "$@"
+	[ -z "$(get_reload_if_sync)" ] && _set_reload_if_sync "$@"
 
 	case $ACTION in
 		NOTIFY_MASTER) call_cb "$(get_master_cb)" ;;

--- a/net/keepalived/files/lib/functions/keepalived/hotplug.sh
+++ b/net/keepalived/files/lib/functions/keepalived/hotplug.sh
@@ -31,23 +31,27 @@ _service() {
 	[ ! -x "$rc" ] && return
 
 	case $1 in
-		start) $rc running || $rc start ;;
-		stop) $rc running && $rc stop ;;
+		start) _service_running_check "$rc" || $rc start ;;
+		stop) _service_running_check "$rc" && $rc stop ;;
 		reload)
-			if $rc running; then
+			if _service_running_check "$rc"; then
 				$rc reload
 			else
 				$rc start
 			fi
 			;;
 		restart)
-			if $rc running; then
+			if _service_running_check "$rc"; then
 				$rc restart
 			else
 				$rc start
 			fi
 			;;
 	esac
+}
+
+_service_running_check() {
+	skip_running_check || "$1" running
 }
 
 _start_service() {
@@ -156,6 +160,14 @@ set_stop_if_backup() {
 
 backup_and_stop() {
 	get_var_flag NOTIFY_BACKUP_STOP 1
+}
+
+set_skip_running_check() {
+	set_var NOTIFY_SKIP_RUNNING 1
+}
+
+skip_running_check() {
+	get_var_flag NOTIFY_SKIP_RUNNING
 }
 
 set_reload_if_sync() {


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: not yet compiled
Run tested: only tested on v23.05.5 with manually modified files

Description:
I've found some issues in hotpulg.sh called during sync, master/backup switch... and in dnsmasq hotplug handler

I report the commit descriptions:

for **hotpulg.sh**

- some init.d scripts like firewall and sqm do not return the actual state of the service if called with "running" parameter. This result in the init script called with "start" parameter and the service may not load the new configuration. firewall init script is one of this
An option is added in order to skip the "running" check for the service

- when "set_reload_if_sync" is not set in the hotplug script, the service is not expected to reload. That is not true because even if not set, the value is set to the default 1 (reload active) or equals the parameter set when "keepalived_hotplug" is called.
The default behavior should be:
    - reload if set_reload_if_sync is called
    - NOT reload if set_reload_if_sync is NOT called
A similar fix is ported to "set_update_target"

for **dnsmasq**

- when "set_reload_if_sync" is set, the service is reloaded when the configuration changes. For dnsmasq this means that the service, if stopped, is started, and we don't want this in the backup node