### PR TITLE
net-snmp: add SNMPv3 options and logging

### DIFF
--- a/net/net-snmp/Config.in
+++ b/net/net-snmp/Config.in
@@ -1,0 +1,10 @@
+if PACKAGE_net-snmp-ssl
+	menu "Configuration"
+		depends on PACKAGE_net-snmp-ssl
+
+		config NETSNMP_WITH_OPENSSL
+			bool
+			default y
+			prompt "Enable compilation with OPENSSL"
+	endmenu
+endif

--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.9.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp
@@ -36,14 +36,42 @@ define Package/net-snmp/Default/description
  IPv4 and IPv6.
 endef
 
+define Package/net-snmp-ssl
+$(call Package/net-snmp/Default)
+  TITLE:=net-snmp with Openssl
+  CONFLICTS:=net-snmp-nossl
+  VARIANT:=with-openssl
+  DEPENDS:= \
+  	    +snmp-mibs \
+  	    +snmp-utils \
+  	    +snmpd-ssl \
+  	    +snmpd-static \
+  	    +snmptrapd
+endef
+
+define Package/net-snmp-nossl
+$(call Package/net-snmp/Default)
+  TITLE:=net-snmp without Openssl
+  CONFLICTS:=net-snmp-ssl
+  VARIANT:=without-openssl
+  DEFAULT_VARIANT:=1
+  DEPENDS:= \
+  	    +snmp-mibs \
+  	    +snmp-utils \
+  	    +snmpd \
+  	    +snmpd-static \
+  	    +snmptrapd
+endef
+
 
 define Package/libnetsnmp
 $(call Package/net-snmp/Default)
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libnl-tiny +libpci +libpcre2
+  DEPENDS:=+libnl-tiny +libpci +libpcre2 +NETSNMP_WITH_OPENSSL:libopenssl
   TITLE:=Open source SNMP implementation (libraries)
 endef
+
 
 define Package/libnetsnmp/description
 $(call Package/net-snmp/Default/description)
@@ -51,6 +79,9 @@ $(call Package/net-snmp/Default/description)
  This package contains shared libraries, needed by other programs.
 endef
 
+define Package/libnetsnmp/config
+	source "$(SOURCE)/Config.in"
+endef
 
 define Package/snmp-mibs
 $(call Package/net-snmp/Default)
@@ -86,6 +117,7 @@ endef
 define Package/snmpd
 $(call Package/net-snmp/Default)
   DEPENDS:=+libnetsnmp
+  CONFLICTS:=snmpd-ssl
   TITLE:=Open source SNMP implementation (daemon)
 endef
 
@@ -96,9 +128,23 @@ $(call Package/net-snmp/Default/description)
 endef
 
 
+define Package/snmpd-ssl
+$(call Package/net-snmp/Default)
+  DEPENDS:=+libnetsnmp
+  CONFLICTS:=snmpd
+  TITLE:=Open source SNMP implementation (daemon) with Openssl encryption
+endef
+
+define Package/snmpd-ssl/description
+$(call Package/net-snmp/Default/description)
+ .
+ This package contains the SNMP agent, dynamically linked.
+endef
+
+
 define Package/snmpd-static
 $(call Package/net-snmp/Default)
-  DEPENDS:=+snmpd
+DEPENDS:=+NETSNMP_WITH_OPENSSL:snmpd-ssl +(!NETSNMP_WITH_OPENSSL):snmpd
   TITLE:=Open source SNMP implementation (daemon)
   BUILDONLY:=1
 endef
@@ -206,7 +252,6 @@ CONFIGURE_ARGS += \
 	--with-mib-modules="$(SNMP_MIB_MODULES_INCLUDED)" \
 	--with-out-transports="$(SNMP_TRANSPORTS_EXCLUDED)" \
 	--with-transports="$(SNMP_TRANSPORTS_INCLUDED)" \
-	--without-openssl \
 	--without-libwrap \
 	--without-mysql \
 	--without-rpm \
@@ -216,7 +261,7 @@ CONFIGURE_ARGS += \
 	 $(call autoconf_bool,CONFIG_IPV6,ipv6) \
 	--disable-perl-cc-checks \
 	--disable-embedded-perl \
-	--without-perl-modules
+	--without-perl-modules \
 
 CONFIGURE_VARS += \
 	ac_cv_header_netlink_netlink_h=yes \
@@ -224,6 +269,14 @@ CONFIGURE_VARS += \
 
 ifeq ($(CONFIG_IPV6),y)
 SNMP_TRANSPORTS_INCLUDED+= UDPIPv6
+endif
+
+ifeq ($(BUILD_VARIANT),with-openssl)
+CONFIGURE_ARGS += \
+--with-openssl="$(STAGING_DIR)/usr"
+else
+CONFIGURE_ARGS += \
+--without-openssl
 endif
 
 define Build/Compile
@@ -261,11 +314,14 @@ define Package/snmp-utils/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/snmp{get,set,status,test,trap,walk} $(1)/usr/bin/
 endef
 
-define Package/snmpd/conffiles
+define Package/snmpd/conffiles/Default
 /etc/config/snmpd
 endef
 
-define Package/snmpd/install
+Package/snmpd-ssl/conffiles = $(Packag/snmpd/conffiles/Default)
+Package/snmpd-nossl/conffiles = $(Packag/snmpd/conffiles/Default)
+
+define Package/snmpd/install/Default
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DATA) ./files/snmpd.conf $(1)/etc/config/snmpd
 	$(INSTALL_DIR) $(1)/etc/snmp
@@ -274,7 +330,15 @@ define Package/snmpd/install
 	$(INSTALL_BIN) ./files/snmpd.init $(1)/etc/init.d/snmpd
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/snmpd $(1)/usr/sbin/snmpd
+
+	ifeq ($(CONFIG_NETSNMP_WITH_OPENSSL),y)
+		sed -i -e 's/CONFIG_NETSNMP_WITH_OPENSSL=n/CONFIG_NETSNMP_WITH_OPENSSL=y/g' $(1)/etc/init.d/snmpd
+	endif
+
 endef
+
+Package/snmpd-ssl/install = $(Package/snmpd/install/Default)
+Package/snmpd/install = $(Package/snmpd/install/Default)
 
 define Package/snmptrapd/install
 	$(INSTALL_DIR) $(1)/etc/init.d
@@ -288,6 +352,9 @@ endef
 $(eval $(call BuildPackage,libnetsnmp))
 $(eval $(call BuildPackage,snmp-mibs))
 $(eval $(call BuildPackage,snmp-utils))
+$(eval $(call BuildPackage,snmpd-ssl))
 $(eval $(call BuildPackage,snmpd))
 $(eval $(call BuildPackage,snmpd-static))
 $(eval $(call BuildPackage,snmptrapd))
+$(eval $(call BuildPackage,net-snmp-nossl))
+$(eval $(call BuildPackage,net-snmp-ssl))

--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -385,6 +385,7 @@ start_service() {
 	append_authtrapenable authtrapenable enable authtrapenable
 	append_parm v1trapaddress host v1trapaddress
 	append_parm trapsess trapsess trapsess
+	config_foreach snmpd_snmpv3_add v3 general
 
 	procd_set_param command $PROG -Lf /dev/null -f -r
 	procd_set_param file $CONFIGFILE

--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -2,6 +2,8 @@
 # Copyright (C) 2008 OpenWrt.org
 START=99
 
+CONFIG_NETSNMP_WITH_OPENSSL=n
+
 USE_PROCD=1
 PROG="/usr/sbin/snmpd"
 
@@ -240,6 +242,70 @@ snmpd_sink_add() {
 	config_get port "$cfg" port
 	port=${port:+:$port}
 	echo "$section $host$port $community" >> $CONFIGFILE
+}
+
+snmpd_snmpv3_add() {
+	local cfg="$1"
+	local cfg2="$2"
+
+	local version
+	local username
+	local auth_type
+	local auth_pass
+	local privacy_type
+	local privacy_pass
+	local allow_write
+	local oid
+
+	config_get version "$cfg2" snmp_version
+	if [ "$version" != "v1/v2c/v3" ] && [ "$version" != "v3" ]; then
+		return 0
+	fi
+
+	if [ "$CONFIG_NETSNMP_WITH_OPENSSL" = "n" ]; then
+		return 0
+	fi
+
+	config_get username "$cfg" username
+	[ -n "$username" ] || return 0
+
+	config_get auth_type "$cfg" auth_type
+	[ -n "$auth_type" ] || return 0
+
+	config_get auth_pass "$cfg" auth_pass
+	config_get privacy_type "$cfg" privacy_type
+	config_get privacy_pass "$cfg" privacy_pass
+	config_get oid "$cfg" RestrictedOID
+
+	config_get_bool allow_write "$cfg" allow_write
+	local useraccess="Rouser"
+	[ $allow_write -eq 1 ] && useraccess="Rwuser"
+
+	if [ -n "$privacy_type" ] && [ -n "$auth_pass" ] && [ -n "$privacy_pass" ]; then
+		echo "createUser $username $auth_type \"$auth_pass\" $privacy_type \"$privacy_pass\"" >> $CONFIGFILE
+		if [ -n "$oid" ]; then
+			echo "$useraccess $username priv $oid" >> $CONFIGFILE
+		else
+			echo "$useraccess $username priv" >> $CONFIGFILE
+		fi
+		return
+	fi
+
+	if [ -n "$auth_type" ]; then
+		echo "createUser $username $auth_type \"$auth_pass\"" >> $CONFIGFILE
+		if [ -n "$oid" ]; then
+			echo "$useraccess $username auth $oid" >> $CONFIGFILE
+		else
+			echo "$useraccess $username auth" >> $CONFIGFILE
+		fi
+	else
+		echo "createUser $username" >> $CONFIGFILE
+		if [ -n "$oid" ]; then
+			echo "$useraccess $username noauth $oid" >> $CONFIGFILE
+		else
+			echo "$useraccess $username noauth" >> $CONFIGFILE
+		fi
+	fi
 }
 
 append_parm() {

--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -350,6 +350,64 @@ snmpd_setup_fw_rules() {
 	HANDLED_SNMP_ZONES="$HANDLED_SNMP_ZONES $zone"
 }
 
+snmpd_configure_logging() {
+	local cfg="$1"
+	local log_syslog
+	local log_syslog_facility
+	local log_syslog_priority
+	local log_file
+	local log_file_path
+	local log_file_priority
+
+	config_get_bool log_syslog "$cfg" log_syslog 0
+
+	# d - LOG_DAEMON,
+	# u - LOG_USER,
+	# 0-7 - LOG_LOCAL0 through LOG_LOCAL7.
+
+	# 0 or ! - LOG_EMERG
+	# 1 or a - LOG_ALERT
+	# 2 or c - LOG_CRIT
+	# 3 or e - LOG_ERR
+	# 4 or w - LOG_WARN
+	# 5 or n - LOG_NOTICE
+	# 6 or i - LOG_INFO
+	# 7 or d - LOG_DEBUG
+
+	if [ "$log_syslog" -eq 1 ]; then
+		config_get log_syslog_facility "$cfg" log_syslog_facility "daemon"
+		config_get log_syslog_priority "$cfg" log_syslog_priority "info"
+
+		if [ "$log_syslog_facility" = "daemon" ] ||
+			[ "$log_syslog_facility" = "user" ]; then
+				log_syslog_facility=$(echo "$log_syslog_facility" |
+				cut -c 1)
+		else
+			log_syslog_facility=$(echo "$log_syslog_facility" |
+				cut -c 6)
+		fi
+
+		[ "$log_syslog_priority" = "emerg" ] && log_syslog_priority="!"
+		log_syslog_priority=$(echo "$log_syslog_priority" |
+			cut -c 1)
+
+		procd_append_param command "-LS ${log_syslog_priority} ${log_syslog_facility}"
+	fi
+
+	config_get_bool log_file "$cfg" log_file 0
+
+	if [ "$log_file" -eq 1 ]; then
+		config_get log_file_path "$cfg" log_file_path "/var/log/snmpd.log"
+		config_get log_file_priority "$cfg" log_file_priority "info"
+
+		[ "$log_file_priority" = "emerg" ] && log_file_priority="!"
+		log_file_priority=$(echo "$log_file_priority" | cut -c 1)
+
+		mkdir -p "$(dirname "${log_file_path}")"
+		procd_append_param command "-LF ${log_file_priority} ${log_file_path}"
+	fi
+}
+
 start_service() {
 	[ -f "$CONFIGFILE" ] && rm -f "$CONFIGFILE"
 
@@ -387,8 +445,9 @@ start_service() {
 	append_parm trapsess trapsess trapsess
 	config_foreach snmpd_snmpv3_add v3 general
 
-	procd_set_param command $PROG -Lf /dev/null -f -r
-	procd_set_param file $CONFIGFILE
+	procd_set_param command $PROG -f -r -p "$pid_file"
+	config_foreach snmpd_configure_logging log
+	procd_append_param command -C -c $CONFIGFILE
 	procd_set_param respawn
 
 	for iface in $(ls /sys/class/net 2>/dev/null); do


### PR DESCRIPTION
Maintainer: @stintel
Compile tested: x86_64, Openwrt 23.05
Run tested: x86_64, Openwrt 23.05

Description:
Openssl is needed to implement encryption and authentification  for SNMPv3,
therefore the Makefile is modified for that purpose.
Also snmpV3 prerequisites are added to snmpd.init file and the possibility
to log messages to syslog or a log file.

At last the deprecated option to specifiy a port  at `
snmpd_trap_hostname_add()` 
and `snmpd_trap_ip_add()` is removed.