### PR TITLE
libuhttpd: add support with MbedTLS 3.0

### DIFF
--- a/libs/libuhttpd/Makefile
+++ b/libs/libuhttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuhttpd
 PKG_VERSION:=3.14.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://github.com/zhaojh329/libuhttpd/releases/download/v$(PKG_VERSION)

--- a/libs/libuhttpd/patches/001-Add-compatibility-with-Mbed-TLS-3.0.0.patch
+++ b/libs/libuhttpd/patches/001-Add-compatibility-with-Mbed-TLS-3.0.0.patch
@@ -1,0 +1,55 @@
+From 28cc9b5d98179d161673d20e79333ae5a4864228 Mon Sep 17 00:00:00 2001
+From: Jianhui Zhao <zhaojh329@gmail.com>
+Date: Sat, 4 May 2024 19:40:07 +0800
+Subject: [PATCH 1/2] Add compatibility with Mbed TLS 3.0.0
+
+Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
+---
+ src/ssl/mbedtls.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+--- a/src/ssl/mbedtls.c
++++ b/src/ssl/mbedtls.c
+@@ -49,7 +49,6 @@
+ #include "ssl.h"
+ 
+ #include <mbedtls/ssl.h>
+-#include <mbedtls/certs.h>
+ #include <mbedtls/x509.h>
+ #include <mbedtls/rsa.h>
+ #include <mbedtls/error.h>
+@@ -136,9 +135,13 @@ static const int default_ciphersuites_cl
+     AES_CBC_CIPHERS(ECDHE_ECDSA),
+     AES_CBC_CIPHERS(ECDHE_RSA),
+     AES_CBC_CIPHERS(DHE_RSA),
++#ifdef MBEDTLS_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
+     MBEDTLS_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA,
++#endif
+     AES_CIPHERS(RSA),
++#ifdef MBEDTLS_TLS_RSA_WITH_3DES_EDE_CBC_SHA
+     MBEDTLS_TLS_RSA_WITH_3DES_EDE_CBC_SHA,
++#endif
+     0
+ };
+ 
+@@ -218,7 +221,7 @@ static void ssl_update_own_cert(struct s
+     if (!ctx->cert.version)
+         return;
+ 
+-    if (!ctx->key.pk_info)
++    if (mbedtls_pk_get_type(&ctx->key) == MBEDTLS_PK_NONE)
+         return;
+ 
+     mbedtls_ssl_conf_own_cert(&ctx->conf, &ctx->cert, &ctx->key);
+@@ -255,7 +258,11 @@ int ssl_load_key_file(struct ssl_context
+ {
+     int ret;
+ 
++#if (MBEDTLS_VERSION_NUMBER >= 0x03000000)
++    ret = mbedtls_pk_parse_keyfile(&ctx->key, file, NULL, _urandom, NULL);
++#else
+     ret = mbedtls_pk_parse_keyfile(&ctx->key, file, NULL);
++#endif
+     if (ret)
+         return -1;
+ 

--- a/libs/libuhttpd/patches/002-if-MBEDTLS_PSA_CRYPTO_CLIENT-defined-PSA-is-enabled-.patch
+++ b/libs/libuhttpd/patches/002-if-MBEDTLS_PSA_CRYPTO_CLIENT-defined-PSA-is-enabled-.patch
@@ -1,0 +1,23 @@
+From e7236faafd2a45605455cdd50f8c918ddf8a3510 Mon Sep 17 00:00:00 2001
+From: "shegaoyuan@aliyun.com" <shegaoyuan@aliyun.com>
+Date: Tue, 14 May 2024 09:51:27 +0800
+Subject: [PATCH 2/2] if MBEDTLS_PSA_CRYPTO_CLIENT defined, PSA is enabled,
+ must call psa_crypto_init() first
+
+---
+ src/ssl/mbedtls.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/src/ssl/mbedtls.c
++++ b/src/ssl/mbedtls.c
+@@ -164,6 +164,10 @@ struct ssl_context *ssl_context_new(bool
+     if (!ctx)
+         return NULL;
+ 
++#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
++    psa_crypto_init();
++#endif
++
+     ctx->server = server;
+     mbedtls_pk_init(&ctx->key);
+     mbedtls_x509_crt_init(&ctx->cert);


### PR DESCRIPTION
Backport patch from ssl submodule to fix compilation error and add support with MbedTLS 3.0.

Minor modification to backported patch to apply on a full clone and to use the old _urandom function.
