### PR TITLE
sstp-client: bump to 1.0.20 release

### DIFF
--- a/net/sstp-client/Makefile
+++ b/net/sstp-client/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sstp-client
-PKG_VERSION:=1.0.19
-PKG_RELEASE:=2
+PKG_VERSION:=1.0.20
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://gitlab.com/sstp-project/sstp-client/-/archive/1.0.19/
-PKG_HASH:=e2652365f69f5037102e78f4e115ff764a390b27bb3fd513a8a50b10a61bb613
+PKG_SOURCE_URL:=https://gitlab.com/sstp-project/sstp-client/-/archive/1.0.20/
+PKG_HASH:=9150c96c61c71aa3fd0ac7c2b95f60cecb8bf761febb07e00e34794c47eac9fa
 
 PKG_MAINTAINER:=Federico Di Marco <fededim@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/sstp-client/patches/100-musl-compat.patch
+++ b/net/sstp-client/patches/100-musl-compat.patch
@@ -13,7 +13,7 @@
 +#endif /* net/ppp_defs.h */
 --- a/src/libsstp-log/sstp-log-syslog.c
 +++ b/src/libsstp-log/sstp-log-syslog.c
-@@ -32,6 +32,7 @@
+@@ -18,6 +18,7 @@
  #include <sys/uio.h>
  #include <sys/un.h>
  #include <sys/socket.h>
@@ -23,7 +23,7 @@
  #include <sstp-common.h>
 --- a/src/libsstp-log/sstp-log-std.c
 +++ b/src/libsstp-log/sstp-log-std.c
-@@ -25,6 +25,7 @@
+@@ -11,6 +11,7 @@
  #include <stdio.h>
  #include <stdint.h>
  #include <string.h>

--- a/net/sstp-client/patches/200-openssl-deprecated.patch
+++ b/net/sstp-client/patches/200-openssl-deprecated.patch
@@ -1,6 +1,6 @@
 --- a/src/sstp-client.c
 +++ b/src/sstp-client.c
-@@ -546,6 +546,7 @@ static status_t sstp_init_ssl(sstp_clien
+@@ -532,6 +532,7 @@ static status_t sstp_init_ssl(sstp_clien
      int retval = SSTP_FAIL;
      int status = 0;
  
@@ -8,7 +8,7 @@
      /* Initialize the OpenSSL library */
      status = SSL_library_init();
      if (status != 1)
-@@ -575,6 +576,9 @@ static status_t sstp_init_ssl(sstp_clien
+@@ -561,6 +562,9 @@ static status_t sstp_init_ssl(sstp_clien
  
      /* Create a new crypto context */
      client->ssl_ctx = SSL_CTX_new(SSLv23_client_method());


### PR DESCRIPTION
Bump sstp-client to 1.0.20 release. This fix compilation error with new PPPd version 2.5.0 as some API changed.

Patch automatically refreshed.

---

Notice: CI might fail as a fix for this has been pushed in openwrt main and maybe the SDK needs to be refreshed.