### PR TITLE
AriaNg: Update to 1.3.7

### DIFF
--- a/net/ariang/Makefile
+++ b/net/ariang/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ariang
-PKG_VERSION:=1.3.6
+PKG_VERSION:=1.3.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
 PKG_SOURCE_URL:=https://github.com/mayswind/AriaNg/releases/download/$(PKG_VERSION)
-PKG_HASH:=2d36e1a39d95867b8e0cdb3cde96d04d40117bd37e8742d639da92496e07cc7b
+PKG_HASH:=60023dce3e02d4811b76cfdccf5953fe616006bceff90b5291872be8239dcedf
 UNPACK_CMD=unzip -q -d $(1) $(DL_DIR)/$(PKG_SOURCE)
 
 PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>


### PR DESCRIPTION
Maintainer: @Ansuel (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
https://github.com/mayswind/AriaNg/releases

AriaNg 1.3.7 Change Log

1. Each task list page supports independent display order
2. Rpc dropdown list on larger screen would be shown larger
3. Other bug fix and user interface optimization

This version works well on my aarch64_generic platform router.
This upgrade has not changed much, the file names and quantities have not changed.

![379956614-84603ba7-4df7-467f-b78c-9221dd067fdf](https://github.com/user-attachments/assets/9be245fb-3db3-45f3-80c6-c791e40a0e42)

