### PR TITLE
libdeflate: update to 1.22 (backport)

### DIFF
--- a/libs/libdeflate/Makefile
+++ b/libs/libdeflate/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdeflate
-PKG_VERSION:=1.18
+PKG_VERSION:=1.22
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ebiggers/libdeflate/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=225d982bcaf553221c76726358d2ea139bb34913180b20823c782cede060affd
+PKG_HASH:=7834d9adbc9a809e0fb0d7b486060a9ae5f7819eb7f55bb8c22b10d7b3bed8da
 
 PKG_LICENSE:=COPYING
 PKG_LICENSE_FILES:=MIT


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: kirkwood, ZyXEL NSA-310b and NSA-325v2, OpenWrt v20.05.5
Run tested: kirkwood, ZyXEL NSA-310b and NSA-325v2, OpenWrt v20.05.5, tests done

Description: fixes complie issues under kirkwood platform.
`libdeflate` is a dependency of the `transmission` package, so it was broken on the platform until this update.
Reference: #23626