### PR TITLE
knxd: bump to new version 0.14.66

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -11,12 +11,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
-PKG_VERSION:=0.14.65
+PKG_VERSION:=0.14.66
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/knxd/knxd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=b9d98898004fc19803077c821f8b73dea94825843845d6edd29b73590cfdcc4c
+PKG_HASH:=aec3887a69a07a764fedf48f295e39887255f69a3c6e05987bbf0b9bcde6c7a1
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/knxd/patches/0100-version.patch
+++ b/net/knxd/patches/0100-version.patch
@@ -7,4 +7,4 @@
 -test -d .git || exit
 -# git describe --tags
 -git log --format=format:%D | perl -ne 'next unless s#.*tag: ##; s#,.*##; next if m#/#; print; exit;'
-+echo -n "0.14.65"
++echo -n "0.14.66"


### PR DESCRIPTION
Maintainer: me
Compile tested: mpc85xx, tl-wdr4900-v1, trunk
Compile tested: ath79, tplink_archer-c7-v4, trunk
Compile tested: ramips, mt7620a, trunk
Run tested: ath79, tp-link Archer C7 v4, trunk

Description:
new upstream release 0.14.66

