### PR TITLE
bcm27xx-eeprom: update to latest version

### DIFF
--- a/utils/bcm27xx-eeprom/Makefile
+++ b/utils/bcm27xx-eeprom/Makefile
@@ -5,9 +5,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/raspberrypi/rpi-eeprom
-PKG_SOURCE_DATE:=2024-06-05
-PKG_SOURCE_VERSION:=e430a41e7323a1e28fb42b53cf79e5ba9b5ee975
-PKG_MIRROR_HASH:=6c9a45d4ea0f33a9dc18f11b6cdeb425f0682dc41099df3a1f350939aecce353
+PKG_SOURCE_DATE:=2024-09-23
+PKG_SOURCE_VERSION:=c8fffcda5ae0f923857a73fedbeb07e81d2eb813
+PKG_MIRROR_HASH:=68d0eedd1aff573c2ea7071f89a5898292061ced96d7f98ea4a347dc16c8102c
 
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 PKG_LICENSE:=BSD-3-Clause Custom
@@ -73,21 +73,21 @@ endef
 
 define Package/bcm2711-eeprom/install
 	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2711
-	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2711/default
+	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader-2711
-	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/pieeprom-2024-05-17.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/default
-	$(CP) $(PKG_BUILD_DIR)/firmware-2711/default/recovery.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/default
-	$(CP) $(PKG_BUILD_DIR)/firmware-2711/default/vl805-000138c0.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/default
+	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/pieeprom-2024-09-05.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
+	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/recovery.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
+	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/vl805-000138c0.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 endef
 
 define Package/bcm2712-eeprom/install
 	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2712
-	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2712/default
+	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
 
 	$(CP) $(PKG_BUILD_DIR)/firmware-2712/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader-2712
-	$(CP) $(PKG_BUILD_DIR)/firmware-2712/default/pieeprom-2024-06-05.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/default
-	$(CP) $(PKG_BUILD_DIR)/firmware-2712/default/recovery.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/default
+	$(CP) $(PKG_BUILD_DIR)/firmware-2712/latest/pieeprom-2024-09-23.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
+	$(CP) $(PKG_BUILD_DIR)/firmware-2712/latest/recovery.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
 endef
 
 $(eval $(call BuildPackage,bcm27xx-eeprom))

--- a/utils/bcm27xx-eeprom/patches/0001-rpi-eeprom-update-OpenWrt-defaults.patch
+++ b/utils/bcm27xx-eeprom/patches/0001-rpi-eeprom-update-OpenWrt-defaults.patch
@@ -28,8 +28,9 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 @@ -1,7 +1,7 @@
  
  FIRMWARE_ROOT=/lib/firmware/raspberrypi/bootloader
- FIRMWARE_RELEASE_STATUS="default"
+-FIRMWARE_RELEASE_STATUS="default"
 -FIRMWARE_BACKUP_DIR="/var/lib/raspberrypi/bootloader/backup"
++FIRMWARE_RELEASE_STATUS="latest"
 +FIRMWARE_BACKUP_DIR="${FIRMWARE_ROOT}/backup"
  EEPROM_CONFIG_HOOK=
  

--- a/utils/bcm27xx-eeprom/patches/0002-rpi-eeprom-update-change-default-include-path.patch
+++ b/utils/bcm27xx-eeprom/patches/0002-rpi-eeprom-update-change-default-include-path.patch
@@ -24,7 +24,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  fi
  
  LOCAL_MODE=0
-@@ -436,7 +436,7 @@ checkDependencies() {
+@@ -439,7 +439,7 @@ checkDependencies() {
        echo "Run with -h for more information."
        echo
        echo "To enable flashrom programming of the EEPROM"
@@ -33,7 +33,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
        echo "RPI_EEPROM_USE_FLASHROM=1"
        echo "CM4_ENABLE_RPI_EEPROM_UPDATE=1"
        echo 
-@@ -523,7 +523,7 @@ The system should then boot normally.
+@@ -526,7 +526,7 @@ The system should then boot normally.
  
  If /boot does not correspond to the boot partition and this
  is not a NOOBS system, then the mount point for BOOTFS should be defined
@@ -42,7 +42,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  
  A backup of the current EEPROM config file is written to ${FIRMWARE_BACKUP_DIR}
  before applying the update.
-@@ -555,7 +555,7 @@ Options:
+@@ -558,7 +558,7 @@ Options:
     -u Install the specified VL805 (USB EEPROM) image file.
  
  Environment:
@@ -51,7 +51,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  
  EEPROM_CONFIG_HOOK
  
-@@ -627,7 +627,7 @@ must first be enabled by removing ENABLE
+@@ -630,7 +630,7 @@ must first be enabled by removing ENABLE
  via usbboot.
  
  After enabling self-update set the CM4_ENABLE_RPI_EEPROM_UPDATE=1 environment


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm27xx/bcm2712
Run tested: bcm27xx/bcm2712

Description:
This update contains multiple improvements for BCM2711 and BCM2712. Switch from default (critical) to stable firmwares.

Full changelog: https://github.com/raspberrypi/rpi-eeprom/compare/v2024.06.05-2712...v2024.09.23-2712