### PR TITLE
attendedsysupgrade-common: give the uci-defaults script a run level

### DIFF
--- a/utils/attendedsysupgrade-common/Makefile
+++ b/utils/attendedsysupgrade-common/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=attendedsysupgrade-common
-PKG_VERSION:=8
+PKG_VERSION:=9
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk
@@ -49,7 +49,7 @@ endef
 
 define Package/attendedsysupgrade-common/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults/
-	$(INSTALL_DATA) ./files/attendedsysupgrade.defaults $(1)/etc/uci-defaults/attendedsysupgrade
+	$(INSTALL_DATA) ./files/attendedsysupgrade.defaults $(1)/etc/uci-defaults/50-attendedsysupgrade
 
 	$(INSTALL_DIR) $(1)/etc/opkg/keys/
 	$(INSTALL_DATA) ./files/8a11255d14aef6c8 $(1)/etc/opkg/keys/8a11255d14aef6c8


### PR DESCRIPTION
Maintainer: @aparcar 
Compile tested: x86/64 snapshot
Run tested: x86/64 snapshot

Description:
Move the init script to '50-attendedsysupgrade', so it is run in the middle of the init sequence, rather than after all the explicitly ordered ones.  This allows later scripts, specifically the 99-level ones, to modify the contents of the attendedsysupgrade configuration.


A user reported issues with setting values in their ASU-generated custom init script `99-asu-defaults`, and it turned out that the attendedsysupgrade-common script was run after everything else.  Since it's not really important where it runs, I just chose to put it at 50, seems as good a place as any as long as it's after the custom 99- ones.

Ref: https://forum.openwrt.org/t/owut-openwrt-upgrade-tool/200035/191
Our solution there was to rewrite their custom script to source the file, which seems sort of hacky:
```
...
. /rom/etc/uci-defaults/attendedsysupgrade
uci set attendedsysupgrade.blah=blah     <<< throws an error unless you've sourced the file above
```