### PR TITLE
owut: fix order of uci-defaults

### DIFF
--- a/utils/owut/Makefile
+++ b/utils/owut/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=owut
 PKG_SOURCE_DATE:=2024-10-25
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=8c8907c6360ae5248b898e1f8ad87ed797e733e6
@@ -53,7 +53,7 @@ endef
 
 define Package/owut/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/files/owut.defaults $(1)/etc/uci-defaults/attendedsysupgrade-owut
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/files/owut.defaults $(1)/etc/uci-defaults/51-attendedsysupgrade-owut
 
 	$(INSTALL_DIR) $(1)/etc/owut.d
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/pre-install.sh $(1)/etc/owut.d/pre-install.sh


### PR DESCRIPTION
Maintainer: me
Compile tested: x86/64 snapshot
Run tested: x86/64 snapshot

Description:
Move uci-defaults file to run level 51, so it is executed immediately after the attendedsysupgrade-common package's uci-defaults script.

Depends on the already merged https://github.com/openwrt/packages/pull/25234