### PR TITLE
prometheus-node-expoter-lua: Add optout for metrics of unused interfaces

### DIFF
--- a/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
@@ -11,12 +11,13 @@ _log() {
 start_service() {
 	. /lib/functions/network.sh
 
-	local interface port bind4 bind6
+	local interface port bind4 bind6 skip_unused_interfaces
 
 	config_load prometheus-node-exporter-lua.main
 	config_get keepalive "main" http_keepalive 70
 	config_get interface "main" listen_interface "loopback"
 	config_get port "main" listen_port 9100
+	config_get skip_unused_interfaces "main" skip_unused_interfaces 0
 
 	[ "$interface" = "*" ] || {
 		network_get_ipaddr  bind4 "$interface"
@@ -28,6 +29,8 @@ start_service() {
     }
 
 	procd_open_instance
+
+	[ "$skip_unused_interfaces" -eq 1 ] && procd_set_param env PNEL_SKIP_UNUSED_INTERFACES=1
 
 	procd_set_param command /usr/sbin/uhttpd -f -c /dev/null -l / -L /usr/bin/prometheus-node-exporter-lua
 	[ $keepalive -gt 0 ] && procd_append_param command -k $keepalive

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/netdev.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/netdev.lua
@@ -19,12 +19,16 @@ local netdevsubstat = {
 }
 
 local pattern = "([^%s:]+):%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)"
+local pattern_unused = "([^%s:]+):%s+0%s+0%s+0%s+0%s+0%s+0%s+0%s+0%s+0%s+0%s+0%s+0%s+0%s+0%s+0%s+0$"
+
+local skip_unused_interfaces = os.getenv("PNEL_SKIP_UNUSED_INTERFACES") == "1"
 
 local function scrape()
   local nds_table = {}
   for line in io.lines("/proc/net/dev") do
     local t = {string.match(line, pattern)}
-    if #t == 17 then
+    local skip = skip_unused_interfaces and string.match(line, pattern_unused)
+    if #t == 17 and not skip then
       nds_table[t[1]] = t
     end
   end


### PR DESCRIPTION
Maintainer: @champtar
Compile tested: mips/MediaTek MT7621, Xiaomi Redmi Router AC2100, OpenWrt 23.05.0 
Run tested: mips/MediaTek MT7621, Xiaomi Redmi Router AC2100, OpenWrt 23.05.0 (run with enabled and disable opt-out, checked absence of impact on scrape duration)

Description:
Added option `skip_unused_interfaces` to configuration of prometheus-node-expoter-lua. By default disabled.
When enabled `netdev.lua` collector skips interfaces with all counters at 0.