### PR TITLE
Unbound: fix file lock race in odhcpd.sh

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.21.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound

--- a/net/unbound/files/odhcpd.sh
+++ b/net/unbound/files/odhcpd.sh
@@ -78,7 +78,6 @@ odhcpd_zonedata() {
       fi
     fi
 
-
     case $longconf in
     freshstart)
       awk -v conffile=$UB_DHCP_CONF -v pipefile=$dns_ls_new \
@@ -129,22 +128,11 @@ odhcpd_zonedata() {
 
 ##############################################################################
 
-UB_ODHPCD_LOCK=/tmp/unbound_odhcpd.lock
+UB_ODHCPD_LOCK=/var/lock/unbound_odhcpd.lock
 
-if [ ! -f $UB_ODHPCD_LOCK ] ; then
-  # imperfect but it should avoid collisions
-  touch $UB_ODHPCD_LOCK
+exec 1000>$UB_ODHCPD_LOCK
+if flock -x -n 1000 ; then
   odhcpd_zonedata
-  rm -f $UB_ODHPCD_LOCK
-
-else
-  UB_ODHCPD_LOCK_AGE=$(( $( date +%s ) - $( date -r $UB_ODHPCD_LOCK +%s ) ))
-
-  if [ $UB_ODHCPD_LOCK_AGE -gt 100 ] ; then
-    # unlock because something likely broke but do not write this time through
-    rm -f $UB_ODHPCD_LOCK
-  fi
 fi
 
 ##############################################################################
-


### PR DESCRIPTION
Maintainer: @EricLuehrsen 
Compile tested: aarch64_cortex-a53, trunk
Run tested: aarch64, Linksys E8450 (UBI), trunk build

Description:

Several system hangs observed due to file lock failure resulting in multiple instances of `odphcd.sh` executing causing corruption to `unbound` config data. Current scheme does not provide *atomic* locking. Using `flock` for serialization simplifies the process.