### PR TITLE
atop: add missing nls.mk include

### DIFF
--- a/admin/atop/Makefile
+++ b/admin/atop/Makefile
@@ -4,6 +4,7 @@
 #
 
 include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=atop
 PKG_RELEASE:=1


### PR DESCRIPTION
Maintainer: @utoni @krant 
Compile tested: qualcommax/ipq807x, main
Run tested: Just compile time tested

Description:
If `nls.mk` is not included and `BUILD_NLS` is set compilation will fail with:
```
aarch64-openwrt-linux-musl-gcc atop.o version.o various.o  deviate.o   procdbase.o acctproc.o photoproc.o photosyst.o cgroups.o rawlog.o ifprop.o parseable.o showgeneric.o drawbar.o showlinux.o  showsys.o showprocs.o atopsar.o  netatopif.o netatopbpfif.o gpucom.o  json.o utsnames.o -o atop -lncursesw -lz -lm -lrt -Lstaging_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/usr/lib -Lstaging_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/lib -fuse-ld=bfd -znow -zrelro  -Lstaging_dir/target-aarch64_cortex-a53_musl/usr/lib -lglib-2.0 -lintl
staging_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/lib/gcc/aarch64-openwrt-linux-musl/13.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld.bfd: cannot find -lintl: No such file or directory
collect2: error: ld returned 1 exit status
```

So make sure to include `nls.mk`.

Fixes: #25231