### PR TITLE
netatalk: Update to 4.0.4 (backport)

### DIFF
--- a/net/netatalk/Makefile
+++ b/net/netatalk/Makefile
@@ -8,30 +8,27 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netatalk
-PKG_VERSION:=3.2.5
+PKG_VERSION:=4.0.4
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0-or-later
 
-#PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/netatalk
-PKG_HASH:=57de9a7ed411029d6176e429a14ef314460251d8aebe7139aeadc35633d9584b
-
-PKG_BUILD_PARALLEL:=1
-PKG_INSTALL:=1
-PKG_FIXUP:=autoreconf
+PKG_HASH:=3234ed4aee2dff05319544eec53eda232ecc94742c5cbee39376899551351219
 
 PKG_CPE_ID:=cpe:/a:netatalk:netatalk
 
 PKG_BUILD_DEPENDS:=libevent2
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+include $(INCLUDE_DIR)/meson.mk
 
 define Package/netatalk
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Filesystem
-  DEPENDS:=+libattr +libdb47 +libgcrypt +libopenssl +libevent2
+  DEPENDS:=+libevent2 +libdb47 +libgcrypt
   TITLE:=netatalk
   URL:=http://netatalk.sourceforge.net
   MAINTAINER:=An Pa <apccv@outlook.com>
@@ -43,34 +40,35 @@ define Package/netatalk/decription
   Protocol Suite.
 endef
 
-TARGET_CFLAGS += -std=gnu99
-
-CONFIGURE_ARGS += \
-	--disable-afs \
-	--disable-hfs \
-	--enable-debugging \
-	--disable-shell-check \
-	--disable-timelord \
-	--disable-a2boot \
-	--disable-cups \
-	--disable-tcp-wrappers \
-	--with-cnid-default-backend=dbd \
-	--with-bdb="$(STAGING_DIR)/usr/" \
-	--with-libevent=no \
-	--with-libgcrypt-dir="$(STAGING_DIR)/usr" \
-	--with-ssl-dir="$(STAGING_DIR)/usr" \
-	--with-uams-path="/usr/lib/uams" \
-	--without-acls \
-	--without-kerberos \
-	--without-mysql \
-	--with-mysql-config=false \
-	--without-pam \
-	--disable-admin-group \
-	--disable-srvloc \
-	--disable-zeroconf \
-	$(if $(CONFIG_SHADOW_PASSWORDS),--with-shadow,--without-shadow) \
-	--without-dtrace \
-	--without-ldap
+MESON_ARGS += \
+	-Dwith-appletalk=false \
+	-Dwith-zeroconf=false \
+	-Dwith-cups=false \
+	-Dwith-quota=false \
+	-Dwith-afpstats=false \
+	-Dwith-acls=false \
+	-Dwith-ldap=false \
+	-Dwith-cnid-default-backend=dbd \
+	-Dwith-cnid-dbd-backend=true \
+	-Dwith-cnid-mysql-backend=false \
+	-Dwith-pam=false \
+	-Dwith-tests=false \
+	-Dwith-testsuite=false \
+	-Dwith-bdb-path="$(STAGING_DIR)/usr/" \
+	-Dwith-unicode-data-path="$(STAGING_DIR_HOST)/share/gnulib/tests/uniname/" \
+	-Dwith-libgcrypt-path="$(STAGING_DIR)/usr/" \
+	-Dwith-kerberos=false \
+	-Dwith-krbV-uam=false \
+	-Dwith-libiconv=false \
+	-Dwith-spotlight=false \
+	$(if $(CONFIG_SHADOW_PASSWORDS),-Dwith-shadow=true,-Dwith-shadow=false) \
+	-Dwith-dtrace=false \
+	-Dwith-tcp-wrappers=false \
+	-Dwith-debug=false \
+	-Dwith-shell-check=false \
+	-Dwith-readmes=false \
+	-Dwith-manual=none \
+	-Dwith-init-style=none \
 
 define Package/netatalk/conffiles
 /etc/afp.conf
@@ -81,17 +79,13 @@ endef
 define Package/netatalk/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/lib/netatalk
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_DIR) $(1)/usr/lib/uams
 	$(INSTALL_DIR) $(1)/etc/init.d
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libatalk.so* $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/dbd $(1)/usr/bin/
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ad $(1)/usr/bin/
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/afppasswd $(1)/usr/bin/
-	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/afpd $(1)/usr/sbin/
-	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/cnid_dbd $(1)/usr/sbin/
-	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/cnid_metad $(1)/usr/sbin/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/uams/*.so $(1)/usr/lib/uams/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libatalk.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/netatalk/*.so $(1)/usr/lib/netatalk/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/* $(1)/usr/sbin/
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/afp.conf $(1)/etc/
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/extmap.conf $(1)/etc/
 	$(INSTALL_BIN) ./files/afpd.init $(1)/etc/init.d/afpd

--- a/net/netatalk/Makefile
+++ b/net/netatalk/Makefile
@@ -39,15 +39,15 @@ define Package/netatalk/decription
   and Time Machine backups. Modern MacOS prefers Samba network shares
   but AFP has shown superior throughput. High Sierra and older MacOS
   only support AFP for Time Machine backups.
-  Does not support old AppleTalk protocols to talk to non OSX Macs.
+  Includes support of AppleTalk protocols to network with pre-OSX Macs.
 endef
 
 MESON_ARGS += \
-	-Dwith-appletalk=false \
+	-Dwith-appletalk=true \
 	-Dwith-zeroconf=false \
 	-Dwith-cups=false \
 	-Dwith-quota=false \
-	-Dwith-afpstats=false \
+	-Dwith-afpstats=true \
 	-Dwith-acls=false \
 	-Dwith-ldap=false \
 	-Dwith-cnid-default-backend=dbd \
@@ -76,6 +76,8 @@ define Package/netatalk/conffiles
 /etc/afp.conf
 /etc/extmap.conf
 /etc/netatalk/
+/etc/atalkd.conf
+/etc/papd.conf
 endef
 
 define Package/netatalk/install
@@ -90,6 +92,8 @@ define Package/netatalk/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/* $(1)/usr/sbin/
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/afp.conf $(1)/etc/
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/extmap.conf $(1)/etc/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/papd.conf $(1)/etc/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/atalkd.conf $(1)/etc/
 	$(INSTALL_BIN) ./files/afpd.init $(1)/etc/init.d/afpd
 endef
 

--- a/net/netatalk/Makefile
+++ b/net/netatalk/Makefile
@@ -10,15 +10,15 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=netatalk
 PKG_VERSION:=4.0.4
 PKG_RELEASE:=1
-PKG_LICENSE:=GPL-2.0-or-later
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/netatalk
 PKG_HASH:=3234ed4aee2dff05319544eec53eda232ecc94742c5cbee39376899551351219
 
+PKG_MAINTAINER:=Antonio Pastor <antonio.pastor@gmail.com>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:netatalk:netatalk
-
-PKG_BUILD_DEPENDS:=libevent2
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -28,16 +28,18 @@ define Package/netatalk
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Filesystem
-  DEPENDS:=+libevent2 +libdb47 +libgcrypt
-  TITLE:=netatalk
+  TITLE:=Netatalk - Apple Filing Protocol (AFP) file server.
   URL:=http://netatalk.sourceforge.net
-  MAINTAINER:=An Pa <apccv@outlook.com>
+  DEPENDS:=+libevent2 +libdb47 +libgcrypt
 endef
 
 define Package/netatalk/decription
-  Netatalk is a freely-available Open Source AFP fileserver.
-  It also provides a kernel level implementation of the AppleTalk
-  Protocol Suite.
+  Netatalk is an Open Source Apple Filing Protocol (AFP) fileserver.
+  Implements a service that allows Macintosh file sharing
+  and Time Machine backups. Modern MacOS prefers Samba network shares
+  but AFP has shown superior throughput. High Sierra and older MacOS
+  only support AFP for Time Machine backups.
+  Does not support old AppleTalk protocols to talk to non OSX Macs.
 endef
 
 MESON_ARGS += \


### PR DESCRIPTION
Maintainer: Antonio Pastor / @APCCV
Compile tested: ipq806x (23.05.3, snapshot)
Run tested: ipq806x - C2600: start server, connect from MacOS, read/write files to home share, create/update TimeMachine backups. File sharing from MacOS 9.2.

Description:
Backport of Netatalk 4.0.4 (missed 24.10 cutoff by 3h).  Includes:
- bump to 4.0.4 using meson build
- Makefile cleanup
- AppleTalk feature
