### PR TITLE
glib2: fix pkg-config path for glib_compile_schemas

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -104,7 +104,7 @@ define Build/InstallDev
 	$(foreach BIN,glib_genmarshal glib_mkenums,
 		$(SED) 's/^$(BIN)=$$$${bindir}\/\(.*\)/$(BIN)=$$$${prefix_hostpkg}\/bin\/\1/' $(1)/usr/lib/pkgconfig/glib-2.0.pc
 	)
-	$(foreach BIN,glib_compile_resources gdbus_codegen,
+	$(foreach BIN,glib_compile_resources glib_compile_schemas gdbus_codegen,
 		$(SED) 's/^$(BIN)=$$$${bindir}\/\(.*\)/$(BIN)=$$$${prefix_hostpkg}\/bin\/\1/' $(1)/usr/lib/pkgconfig/gio-2.0.pc
 	)
 


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: aarch64/cortex-a53
Run tested: mediatek/filogic (BananaPi R4)

Description:
Some applications using Glib2 require using glib_compile_schemas during build and deduct the path of that executable via pkg-config. This currently fails as the path is not fixed in gio.pc. Fix that by adding glib_compile_schemas to the sed expression taking care of applying prefix_hostpkg.

(This change is required to build GTK+ in video feed)