### PR TITLE
gstreamer additions required to build GTK+

### DIFF
--- a/libs/libgudev/Makefile
+++ b/libs/libgudev/Makefile
@@ -1,0 +1,54 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libgudev
+PKG_VERSION:=238
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=@GNOME/$(PKG_NAME)/$(PKG_VERSION)
+PKG_HASH:=61266ab1afc9d73dbc60a8b2af73e99d2fdff47d99544d085760e4fa667b5dd1
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=LGPL-2.1
+PKG_LICENSE_FILES:=COPYING
+
+PKG_BUILD_DEPENDS:=glib2/host
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/meson.mk
+
+define Package/libgudev
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=GObject udev library
+  URL:=https://gitlab.gnome.org/GNOME/libgudev
+  DEPENDS:=+glib2 +libudev
+endef
+
+define Package/libgudev/description
+ This is libgudev, a library providing GObject bindings for libudev.
+ It used to be part of udev, then merged into systemd. It's now a project
+ on its own.
+endef
+
+MESON_ARGS += \
+	-Dtests=disabled \
+	-Dintrospection=disabled \
+	-Dvapi=disabled \
+	-Dgtk_doc=false
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/gudev-1.0/gudev
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/gudev-1.0/gudev/*.h $(1)/usr/include/gudev-1.0/gudev
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc $(1)/usr/lib/pkgconfig
+endef
+
+define Package/libgudev/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib
+endef
+
+$(eval $(call BuildPackage,libgudev))

--- a/multimedia/gst1-plugins-bad/Makefile
+++ b/multimedia/gst1-plugins-bad/Makefile
@@ -264,6 +264,32 @@ MESON_ARGS += \
 	-Dextra-checks=disabled \
 	-Ddoc=disabled
 
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/gstreamer-$(GST_VERSION)
+	( cd $(PKG_INSTALL_DIR); $(CP) \
+		./usr/include/gstreamer-$(GST_VERSION)/* \
+		$(1)/usr/include/gstreamer-$(GST_VERSION)/ \
+	)
+	$(INSTALL_DIR) $(1)/usr/lib
+	( cd $(PKG_INSTALL_DIR); $(CP) \
+		./usr/lib/libgst*-$(GST_VERSION).so* \
+		$(1)/usr/lib/ \
+	)
+	if [ -d $(PKG_INSTALL_DIR)/usr/lib/gstreamer-$(GST_VERSION)/ ]; then \
+		$(INSTALL_DIR) $(1)/usr/lib/gstreamer-$(GST_VERSION); \
+		( cd $(PKG_INSTALL_DIR); $(FIND) \
+			./usr/lib/gstreamer-$(GST_VERSION)/ -name libgst*.so -print0 | \
+			xargs --null --no-run-if-empty $(CP) \
+			--target-directory=$(1)/usr/lib/gstreamer-$(GST_VERSION)/ \
+		) \
+	fi
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	( cd $(PKG_INSTALL_DIR); $(CP) \
+		./usr/lib/pkgconfig/gstreamer*-$(GST_VERSION).pc \
+		$(1)/usr/lib/pkgconfig/ \
+	)
+endef
+
 define Package/gst1-plugins-bad/install
 	/bin/true
 endef
@@ -303,10 +329,13 @@ endef
 
 $(eval $(call GstBuildLibrary,adaptivedemux,adaptivedemux,app uridownloader,))
 $(eval $(call GstBuildLibrary,photography,photography,,))
+$(eval $(call GstBuildLibrary,play,play,,))
+$(eval $(call GstBuildLibrary,player,player,play,))
 $(eval $(call GstBuildLibrary,basecamerabinsrc,basecamerabinsrc,app,))
 $(eval $(call GstBuildLibrary,uridownloader,uridownloader,,))
 $(eval $(call GstBuildLibrary,codecparsers,codecparsers,,))
 $(eval $(call GstBuildLibrary,mpegts,mpegts,,))
+$(eval $(call GstBuildLibrary,transcoder,transcoder,,))
 
 # 1: short name
 # 2: description

--- a/multimedia/gst1-plugins-base/Makefile
+++ b/multimedia/gst1-plugins-base/Makefile
@@ -36,6 +36,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_gst1-mod-playback \
 	CONFIG_PACKAGE_gst1-mod-gio \
 	CONFIG_PACKAGE_gst1-mod-ogg \
+	CONFIG_PACKAGE_gst1-mod-opengl \
 	CONFIG_PACKAGE_gst1-mod-opus \
 	CONFIG_PACKAGE_gst1-mod-tcp \
 	CONFIG_PACKAGE_gst1-mod-theora \
@@ -95,16 +96,24 @@ define Package/gstreamer1-plugins-base/config
     comment "Modules"
 
    $(foreach mod,$(GST_BASE_MODULES), \
-    config PACKAGE_gst1-mod-$(mod)
-      prompt "GStreamer $(mod) module"
+    config PACKAGE_gst1-mod-$(firstword $(subst :, ,$(mod)))
+      prompt "GStreamer $(firstword $(subst :, ,$(mod))) module"
+    $(if $(wordlist 2,$(words $(subst :, ,$(mod))),$(subst :, ,$(mod))),\
+    $(foreach confdep,$(wordlist 2,$(words $(subst :, ,$(mod))),$(subst :, ,$(mod))),\
+      depends on $(confdep)
+    ))
 
    )
 
     comment "Libraries"
 
    $(foreach lib,$(GST_BASE_LIBS), \
-    config PACKAGE_libgst1$(lib)
-      prompt "GStreamer $(lib) library"
+    config PACKAGE_libgst1$(firstword $(subst :, ,$(lib)))
+      prompt "GStreamer $(firstword $(subst :, ,$(lib))) library"
+    $(if $(wordlist 2,$(words $(subst :, ,$(lib))),$(subst :, ,$(lib))),\
+    $(foreach confdep,$(wordlist 2,$(words $(subst :, ,$(lib))),$(subst :, ,$(lib))),\
+      depends on $(confdep)
+    ))
 
    )
 
@@ -118,7 +127,6 @@ GST_VERSION:=1.0
 
 MESON_ARGS += \
 	-Daudioresample_format=int \
-	-Dgl=disabled \
 	\
 	$(call GST_COND_SELECT,adder) \
 	$(call GST_COND_SELECT,app) \
@@ -130,6 +138,7 @@ MESON_ARGS += \
 	$(call GST_COND_SELECT,compositor) \
 	$(call GST_COND_SELECT,encoding) \
 	$(call GST_COND_SELECT,gio) \
+	-Dgl=$(if $(CONFIG_PACKAGE_libgst1gl),en,dis)abled \
 	$(call GST_COND_SELECT,overlaycomposition) \
 	$(call GST_COND_SELECT,pbtypes) \
 	$(call GST_COND_SELECT,playback) \
@@ -186,6 +195,14 @@ define Build/InstallDev
 			--target-directory=$(1)/usr/lib/gstreamer-$(GST_VERSION)/ \
 		) \
 	fi
+	if [ -d $(PKG_INSTALL_DIR)/usr/lib/gstreamer-$(GST_VERSION)/include/gst/gl ]; then \
+		$(INSTALL_DIR) $(1)/usr/lib/gstreamer-$(GST_VERSION)/include/gst/gl; \
+		( cd $(PKG_INSTALL_DIR); $(FIND) \
+			./usr/lib/gstreamer-$(GST_VERSION)/include/gst/gl -name *.h -print0 | \
+			xargs --null --no-run-if-empty $(CP) \
+			--target-directory=$(1)/usr/lib/gstreamer-$(GST_VERSION)/include/gst/gl \
+		) \
+	fi
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	( cd $(PKG_INSTALL_DIR); $(CP) \
 		./usr/lib/pkgconfig/gstreamer*-$(GST_VERSION).pc \
@@ -210,7 +227,7 @@ define GstBuildLibrary
 
   GST_DEPENDS += +libgst1$(1)
 
-  GST_BASE_LIBS+= $(1)
+  GST_BASE_LIBS+= $(1)$(if $(5),:$(subst $(space),:,$(5)))
 
   define Package/libgst1$(1)
     $(call Package/gstreamer1-base/Default)
@@ -240,6 +257,7 @@ $(eval $(call GstBuildLibrary,allocators,allocators,,+libdrm))
 $(eval $(call GstBuildLibrary,app,app,,))
 $(eval $(call GstBuildLibrary,audio,audio,tag,))
 $(eval $(call GstBuildLibrary,fft,FFT,,))
+$(eval $(call GstBuildLibrary,gl,gl,allocators video,+libmesa +libwayland +libgudev,HAVE_MESA))
 $(eval $(call GstBuildLibrary,pbutils,utils,audio tag video,))
 $(eval $(call GstBuildLibrary,riff,RIFF media,audio tag,,))
 $(eval $(call GstBuildLibrary,rtp,RTP,,))
@@ -257,7 +275,7 @@ define GstBuildPlugin
 
   GST_DEPENDS += +gst1-mod-$(1)
 
-  GST_BASE_MODULES+= $(1)
+  GST_BASE_MODULES+= $(1)$(if $(6),:$(subst $(space),:,$(6)))
 
   define Package/gst1-mod-$(1)
     $(call Package/gstreamer1-base/Default)
@@ -293,6 +311,7 @@ $(eval $(call GstBuildPlugin,audiotestsrc,audio test,audio tag controller,,))
 $(eval $(call GstBuildPlugin,compositor,video compositor,video,,))
 $(eval $(call GstBuildPlugin,encoding,encoding plugin,pbutils video,,))
 $(eval $(call GstBuildPlugin,gio,GIO,,,))
+$(eval $(call GstBuildPlugin,opengl,GL,gl controller,,+libgraphene +libjpeg +libpng,HAVE_MESA))
 $(eval $(call GstBuildPlugin,overlaycomposition,overlay composition,video,,))
 $(eval $(call GstBuildPlugin,pbtypes,pbtypes,video,,))
 $(eval $(call GstBuildPlugin,playback,playback,pbutils,,))


### PR DESCRIPTION
Maintainer: @flyn-org @thess 
Compile tested: aarch64/cortex-a53
Run tested: mediatek/filogic (BananaPi R4)

Description:
Package `gl`, `play` and `player` libraries as well as the `opengl` plugin.

Required to build GTK+