### PR TITLE
netbird: update to 0.31.0

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.30.3
+PKG_VERSION:=0.31.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=21cd8ed88ac0f284be11deb70cfe8afbafcba9d888e50bda9fa8f45d87b28dba
+PKG_HASH:=7da075c5e1962b9118d2d17500bf9b22e6f70c595a356ed290b4f7b1d1b84919
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## Compile and run tested

Maintainer: Oskari Rauta / @oskarirauta

| Package architecture | Target | Subtarget | Brand | Model | Hardware Version | OpenWrt version |
|----------------------|--------|-----------|-------|-------|------------------|-----------------|
| [x86_64](https://openwrt.org/docs/techref/instructionset/x86_64) | [x86](https://openwrt.org/docs/techref/targets/x86) | 64 | [Duex](https://duex.com.br/) | [DX B75ZG M.2 Intel LGA 1155 DDR3](https://duex.com.br/produto/placa-mae-dx-b75zg-m-2-intel-lga-1155-ddr3/) | n/a | OpenWrt SNAPSHOT r27897-b27075e12b |

## Description

- Changelog:
  - [v0.31.0](https://github.com/netbirdio/netbird/releases/tag/v0.31.0)
- Full changelog: https://github.com/netbirdio/netbird/compare/v0.30.3...v0.31.0

## Additional information

`x86_64` running as container with [`incus`](https://github.com/lxc/incus).
Compiled package with container [`sdk`](https://github.com/openwrt/docker), and build `openwrt` image with container [`imagebuilder`](https://github.com/openwrt/docker).

My repo with my automated build can be see here:
- https://github.com/wehagy/openwrt-builder

And my artifacts here:
- ~https://github.com/wehagy/openwrt-builder/actions/runs/11674459476~
- https://github.com/wehagy/openwrt-builder/actions/runs/11725604958

\
~My automated build and locally, is failing to build the `x86_64` architecture with the errors:~

```shell
 make[1] package/netbird/compile~
 make[2] -C feeds/packages/lang/golang/golang host-compile
 make[2] -C package/toolchain clean-build
 make[2] -C package/toolchain compile
    ERROR: package/toolchain failed to build.
 make[2] -C package/kernel/linux clean-build
 make[2] -C package/kernel/linux compile
    ERROR: package/kernel/linux failed to build.
make -r package/netbird/compile: build failed. Please re-run make with -j1 V=s or V=sc for a higher verbosity level to see what's going on
make: *** [/builder/include/toplevel.mk:241: package/netbird/compile] Error 1
```

~From what I've [observed](https://github.com/openwrt/packages/pull/25247#issuecomment-2454090827), this error seems to stem from an incompatibility between the Debian 11 and 12 versions in the `buildbots`.~

~For me, this is a blocker. Once this error is resolved, I will test and update this PR. In the meantime, if someone else tests it, please add your `Tested-by` here along with any other relevant information.~