### PR TITLE
lpac: don't overwrite env variables

### DIFF
--- a/utils/lpac/files/lpac.sh
+++ b/utils/lpac/files/lpac.sh
@@ -8,26 +8,29 @@ APDU_DEBUG="$(uci_get lpac global apdu_debug 0)"
 HTTP_BACKEND="$(uci_get lpac global http_backend curl)"
 HTTP_DEBUG="$(uci_get lpac global http_debug 0)"
 
-export LPAC_HTTP="$HTTP_BACKEND"
+function export_if_not_in_env {
+    eval "value=\${$1}"
+    if [ -z "$value" ]; then
+        export "$1=$2"
+    fi
+}
+
+export_if_not_in_env LPAC_HTTP "$HTTP_BACKEND"
 if [ "$HTTP_DEBUG" -eq 1 ]; then
-    export LIBEUICC_DEBUG_HTTP="1"
+    export_if_not_in_env LIBEUICC_DEBUG_HTTP "1"
 fi
 
-export LPAC_APDU="$APDU_BACKEND"
+export_if_not_in_env LPAC_APDU "$APDU_BACKEND"
 if [ "$APDU_DEBUG" -eq 1 ]; then
-    export LIBEUICC_DEBUG_APDU="1"
+    export_if_not_in_env LIBEUICC_DEBUG_APDU "1"
 fi
 
 if [ "$APDU_BACKEND" = "at" ]; then
-    AT_DEVICE="$(uci_get lpac at device /dev/ttyUSB2)"
-    AT_DEBUG="$(uci_get lpac at debug 0)"
-    export AT_DEVICE="$AT_DEVICE"
-    export AT_DEBUG="$AT_DEBUG"
+    export_if_not_in_env AT_DEVICE "$(uci_get lpac at device /dev/ttyUSB2)"
+    export_if_not_in_env AT_DEBUG "$(uci_get lpac at debug 0)"
 elif [ "$APDU_BACKEND" = "uqmi" ]; then
-    UQMI_DEV="$(uci_get lpac uqmi device /dev/cdc-wdm0)"
-    UQMI_DEBUG="$(uci_get lpac uqmi debug 0)"
-    export LPAC_QMI_DEV="$UQMI_DEV"
-    export LPAC_QMI_DEBUG="$UQMI_DEBUG"
+    export_if_not_in_env LPAC_QMI_DEV "$(uci_get lpac uqmi device /dev/cdc-wdm0)"
+    export_if_not_in_env LPAC_QMI_DEBUG "$(uci_get lpac uqmi debug 0)"
 fi
 
 /usr/lib/lpac "$@"


### PR DESCRIPTION
Maintainer: me
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:

Don't override env variables which are already set when execuring the wrapper script. This makes it possible to override the options set by UCI in the calling programm.