### PR TITLE
Remove maintainer

### DIFF
--- a/libs/json-glib/Makefile
+++ b/libs/json-glib/Makefile
@@ -1,6 +1,4 @@
 #
-# Copyright (C) 2020 Sebastian Kemper <sebastian_ml@gmx.net>
-#
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
@@ -17,7 +15,7 @@ PKG_HASH:=97ef5eb92ca811039ad50a65f06633f1aae64792789307be7170795d8b319454
 
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
+PKG_MAINTAINER:=
 
 PKG_BUILD_DEPENDS:=glib2/host
 

--- a/libs/libmariadb/Makefile
+++ b/libs/libmariadb/Makefile
@@ -1,6 +1,4 @@
 #
-# Copyright (C) 2019 Sebastian Kemper <sebastian_ml@gmx.net>
-#
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #

--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2018 Sebastian Kemper <sebastian_ml@gmx.net>
 # Copyright (C) 2021 Michal Hrusecky <michal@hrusecky.net>
 #
 # This is free software, licensed under the GNU General Public License v2.


### PR DESCRIPTION
As requested on openwrt-devel in October 2024 [1], remove maintainer, including any copyright lines.

[1] https://lists.openwrt.org/pipermail/openwrt-devel/2024-October/043323.html

Maintainer:
Compile tested: 
Run tested: 

Description:
Thanks for all the support over the years. All the best!