### PR TITLE
containerd: update to 2.0.0

### DIFF
--- a/utils/containerd/Makefile
+++ b/utils/containerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=containerd
-PKG_VERSION:=1.7.22
+PKG_VERSION:=2.0.0
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -9,7 +9,7 @@ PKG_CPE_ID:=cpe:/a:linuxfoundation:containerd
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containerd/containerd/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=8c5edde741b7596af63c021429a1212bd616350ed65a7b741eeffc47e27ee9a9
+PKG_HASH:=346d644e1b96e1f4a39bfe9d1eb0eb01ca676f806c12d95e5dbe35325bbc1780
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: Ubuntu 23.04 x64 / OpenWrt SNAPSHOT @ https://github.com/openwrt/packages/commit/36b1dd75fd9da1ea13f1ce1ee679c6b3c9c402cc
Run tested: Linksys WRT32X / OpenWrt SNAPSHOT r24315-ae500e62e2

Description: containerd: update to 2.0.0

- Update to [2.0.0](https://github.com/containerd/containerd/compare/v1.7.23...v2.0.0)