### PR TITLE
umurmur: add pending patch fixing support for MbedTLS 3.x

### DIFF
--- a/net/umurmur/patches/100-Add-support-for-mbedtls-3.x.patch
+++ b/net/umurmur/patches/100-Add-support-for-mbedtls-3.x.patch
@@ -1,0 +1,177 @@
+From fa75e4ca000fc41af0eefd60ac06223c573e0ae4 Mon Sep 17 00:00:00 2001
+From: Glenn Strauss <gstrauss@gluelogic.com>
+Date: Thu, 24 Oct 2024 10:07:10 -0400
+Subject: [PATCH] Add support for mbedtls-3.x
+
+Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
+---
+ src/crypt.h        |  1 -
+ src/ssl.h          |  4 +++
+ src/ssli_mbedtls.c | 65 +++++++++++++++++++++++++++++++++++++++++++---
+ 3 files changed, 66 insertions(+), 4 deletions(-)
+
+--- a/src/crypt.h
++++ b/src/crypt.h
+@@ -36,7 +36,6 @@
+ 
+ #if defined(USE_MBEDTLS)
+ 
+-#include <mbedtls/havege.h>
+ #include <mbedtls/aes.h>
+ 
+ #define CRYPT_AES_KEY mbedtls_aes_context
+--- a/src/ssl.h
++++ b/src/ssl.h
+@@ -53,6 +53,10 @@
+ #include <mbedtls/net.h>
+ #endif
+ 
++#if (MBEDTLS_VERSION_MAJOR >= 3)
++#undef USE_MBEDTLS_HAVEGE
++#endif
++
+ #if defined(USE_MBEDTLS_HAVEGE)
+ #include <mbedtls/havege.h>
+ #define HAVEGE_RAND (mbedtls_havege_random)
+--- a/src/ssli_mbedtls.c
++++ b/src/ssli_mbedtls.c
+@@ -37,10 +37,16 @@
+ #include <stdlib.h>
+ #include <fcntl.h>
+ 
+-#include <mbedtls/config.h>
+ #include <mbedtls/version.h>
+-#include <mbedtls/havege.h>
++#if defined(MBEDTLS_USE_PSA_CRYPTO)
++#include <mbedtls/psa_util.h>
++#else
++#include <mbedtls/ctr_drbg.h>
++#include <mbedtls/entropy.h>
++#endif
++#if MBEDTLS_VERSION_MAJOR < 3
+ #include <mbedtls/certs.h>
++#endif
+ #include <mbedtls/x509.h>
+ #include <mbedtls/ssl.h>
+ 
+@@ -64,13 +70,32 @@ const int ciphers[] =
+     0
+ };
+ 
++#if MBEDTLS_VERSION_NUMBER >= 0x03000000
++#if !defined(MBEDTLS_USE_PSA_CRYPTO)
++#ifdef MBEDTLS_ENTROPY_C
++static mbedtls_entropy_context entropy;
++#ifdef MBEDTLS_CTR_DRBG_C
++static mbedtls_ctr_drbg_context ctr_drbg;
++#endif
++#endif
++#endif
++#endif
++
+ static mbedtls_x509_crt certificate;
+ static inline int x509parse_keyfile(mbedtls_pk_context *pk, const char *path, const char *pwd)
+ {
+     int ret;
+ 
+     mbedtls_pk_init(pk);
++#if MBEDTLS_VERSION_NUMBER >= 0x03000000
++#if defined(MBEDTLS_USE_PSA_CRYPTO)
++    ret = mbedtls_pk_parse_keyfile(pk, path, pwd, mbedtls_psa_get_random, MBEDTLS_PSA_RANDOM_STATE);
++#else
++    ret = mbedtls_pk_parse_keyfile(pk, path, pwd, mbedtls_ctr_drbg_random, &ctr_drbg);
++#endif
++#else
+     ret = mbedtls_pk_parse_keyfile(pk, path, pwd);
++#endif
+     if (ret == 0 && !mbedtls_pk_can_do(pk, MBEDTLS_PK_ECDSA) && !mbedtls_pk_can_do(pk, MBEDTLS_PK_RSA))
+ 	{
+         ret = MBEDTLS_ERR_PK_TYPE_MISMATCH;
+@@ -127,6 +152,13 @@ static void initKey()
+ #ifndef USE_MBEDTLS_HAVEGE
+ int urandom_bytes(void *ctx, unsigned char *dest, size_t len)
+ {
++#if (MBEDTLS_VERSION_MAJOR >= 3)
++#if defined(MBEDTLS_USE_PSA_CRYPTO)
++	mbedtls_psa_get_random(MBEDTLS_PSA_RANDOM_STATE, dest, len);
++#else
++	mbedtls_ctr_drbg_random(&ctr_drbg, dest, len);
++#endif
++#else
+ 	int cur;
+ 
+ 	while (len) {
+@@ -135,6 +167,7 @@ int urandom_bytes(void *ctx, unsigned ch
+ 			continue;
+ 		len -= cur;
+ 	}
++#endif
+ 	return 0;
+ }
+ #endif
+@@ -160,10 +193,20 @@ void SSLi_init(void)
+ #ifdef USE_MBEDTLS_HAVEGE
+ 	mbedtls_havege_init(&hs);
+ #else
++#if MBEDTLS_VERSION_NUMBER >= 0x03000000
++#if defined(MBEDTLS_USE_PSA_CRYPTO)
++	psa_crypto_init();
++#else
++	mbedtls_ctr_drbg_init(&ctr_drbg);
++	mbedtls_entropy_init(&entropy);
++	mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy, NULL, 0);
++#endif
++#else
+ 	urandom_fd = open("/dev/urandom", O_RDONLY);
+ 	if (urandom_fd < 0)
+ 		Log_fatal("Cannot open /dev/urandom");
+ #endif
++#endif
+ 
+ 	/* Initialize config */
+ 	conf = Memory_safeCalloc(1, sizeof(mbedtls_ssl_config));
+@@ -187,7 +230,11 @@ void SSLi_init(void)
+ #endif
+ 	mbedtls_ssl_conf_dbg(conf, pssl_debug, NULL);
+ 
++#if MBEDTLS_VERSION_NUMBER >= 0x03000000
++	mbedtls_ssl_conf_min_version(conf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3);
++#else
+ 	mbedtls_ssl_conf_min_version(conf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_1);
++#endif
+ 
+ 	mbedtls_ssl_conf_ciphersuites(conf, (const int*)&ciphers);
+ 
+@@ -209,8 +256,15 @@ void SSLi_deinit(void)
+ #ifdef USE_MBEDTLS_HAVEGE
+ 	mbedtls_havege_free(&hs);
+ #else
++#if MBEDTLS_VERSION_NUMBER >= 0x03000000
++#if !defined(MBEDTLS_USE_PSA_CRYPTO)
++	mbedtls_ctr_drbg_free(&ctr_drbg);
++	mbedtls_entropy_free(&entropy);
++#endif
++#else
+ 	close(urandom_fd);
+ #endif
++#endif
+ }
+ 
+ bool_t SSLi_getSHA1Hash(SSL_handle_t *ssl, uint8_t *hash)
+@@ -223,8 +277,15 @@ bool_t SSLi_getSHA1Hash(SSL_handle_t *ss
+ 	}
+ #if MBEDTLS_VERSION_NUMBER < 0x02070000L
+ 	mbedtls_sha1(cert->raw.p, cert->raw.len, hash);
+-#else
++#elif MBEDTLS_VERSION_NUMBER < 0x03000000L
+ 	mbedtls_sha1_ret(cert->raw.p, cert->raw.len, hash);
++#elif !defined(MBEDTLS_USE_PSA_CRYPTO)
++	mbedtls_sha1(cert->raw.p, cert->raw.len, hash);
++#else
++	size_t hash_length;
++	mbedtls_psa_hash_compute(
++		PSA_ALG_SHA_1, cert->raw.p, cert->raw.len, hash,
++		20 /* client_t member uint8_t hash[20] */, &hash_length);
+ #endif
+ 	return true;
+ }


### PR DESCRIPTION
Add pending patch fixing support for MbedTLS 3.x.

Small variation to the provided PR from [0] to remove the dropped mbedtls/certs.h header.

[0] https://github.com/umurmur/umurmur/pull/190