### PR TITLE
node: Preparing to update ICU to 76

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
 PKG_VERSION:=20.18.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nodejs.org/dist/v$(PKG_VERSION)

--- a/lang/node/patches/999-fix_building_with_system_icu_76.patch
+++ b/lang/node/patches/999-fix_building_with_system_icu_76.patch
@@ -1,0 +1,25 @@
+From 54299ac3a3d4e4520b8604dce43c2584092ccde2 Mon Sep 17 00:00:00 2001
+From: Michael Cho <michael@michaelcho.dev>
+Date: Sun, 27 Oct 2024 10:08:07 -0400
+Subject: [PATCH] build: fix building with system icu 76
+
+ICU 76 decided to reduce overlinking[^1] thus `icu-i18n` will no longer
+add `icu-uc` when linking to shared libraries. This results in undefined
+symbols/references when trying to build with system ICU 76.
+
+[^1]: unicode-org/icu@199bc82
+---
+ configure.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/configure.py
++++ b/configure.py
+@@ -1829,7 +1829,7 @@ def configure_intl(o):
+   elif with_intl == 'system-icu':
+     # ICU from pkg-config.
+     o['variables']['v8_enable_i18n_support'] = 1
+-    pkgicu = pkg_config('icu-i18n')
++    pkgicu = pkg_config(['icu-i18n', 'icu-uc'])
+     if not pkgicu[0]:
+       error('''Could not load pkg-config data for "icu-i18n".
+        See above errors or the README.md.''')


### PR DESCRIPTION
Maintainer: me @ianchi
Compile tested: head, aarch64, arm, i386, x86_64
Run tested: (qemu 9.1.1) aarch64

Description:
fix building with system icu 76

ICU 76 decided to reduce overlinking[^1] thus `icu-i18n` will no longer add `icu-uc` when linking to shared libraries. This results in undefined symbols/references when trying to build with system ICU 76.
[^1]: unicode-org/icu@199bc82

ref: https://github.com/nodejs/node/pull/55563
