### PR TITLE
libxmp: package XMP sound module renderer

### DIFF
--- a/sound/libxmp/Makefile
+++ b/sound/libxmp/Makefile
@@ -1,0 +1,38 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libxmp
+PKG_VERSION:=4.6.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/$(PKG_NAME)-$(PKG_VERSION)
+PKG_HASH:=2d3c45fe523b50907e89e60f9a3b7f4cc9aab83ec9dbba7743eaffbcdcb35ea6
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=README
+
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/libxmp
+  SECTION:=sound
+  CATEGORY:=Sound
+  TITLE:=Extended Module Player Library
+  URL:=https://github.com/libxmp/libxmp
+endef
+
+define Package/libxmp/description
+  Libxmp is a library that renders module files to PCM data. It supports
+  over 90 mainstream and obscure module formats including Protracker (MOD),
+  Scream Tracker 3 (S3M), Fast Tracker II (XM), and Impulse Tracker (IT).
+endef
+
+define Package/libxmp/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libxmp))


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: aarch64/cortex-a53
Run tested: mediatek/filogic (BPi-R4)

Description:
XMP is a library for handling playback of most sound module formats such as MOD, XM, S3M, IT, ...

