### PR TITLE
hwdata: package pnp.ids and add InstallDev section

### DIFF
--- a/utils/hwdata/Makefile
+++ b/utils/hwdata/Makefile
@@ -17,6 +17,8 @@ PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0-or-later  XFree86-1.0
 PKG_LICENSE_FILES:=LICENSE
 
+PKG_INSTALL:=1
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/pciids
@@ -33,15 +35,35 @@ define Package/usbids
   URL:=https://github.com/vcrhonek/hwdata
 endef
 
+define Package/pnpids
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=PnP ID list
+  URL:=https://github.com/vcrhonek/hwdata
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/share/hwdata
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/hwdata/* $(1)/usr/share/hwdata
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/*/pkgconfig/hwdata.pc $(1)/usr/lib/pkgconfig
+endef
+
 define Package/pciids/install
 	$(INSTALL_DIR) $(1)/usr/share/hwdata
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/pci.ids $(1)/usr/share/hwdata
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/hwdata/pci.ids $(1)/usr/share/hwdata
+endef
+
+define Package/pnpids/install
+	$(INSTALL_DIR) $(1)/usr/share/hwdata
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/hwdata/pnp.ids $(1)/usr/share/hwdata
 endef
 
 define Package/usbids/install
 	$(INSTALL_DIR) $(1)/usr/share/hwdata
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/usb.ids $(1)/usr/share/hwdata
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/hwdata/usb.ids $(1)/usr/share/hwdata
 endef
 
 $(eval $(call BuildPackage,pciids))
+$(eval $(call BuildPackage,pnpids))
 $(eval $(call BuildPackage,usbids))


### PR DESCRIPTION
Maintainer: @krant ?
Compile tested: aarch64/cortex-a53
Run tested: -

Description:
Make sure hwdata can be used by other packages during build by adding InstallDev section which includes pkgconfig as well as all types of IDs.
