### PR TITLE
btrfs-progs: add "btrfs device scan" before overlay/extroot

### DIFF
--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btrfs-progs
 PKG_VERSION:=6.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/kdave/btrfs-progs
@@ -67,6 +67,7 @@ CONFIGURE_ARGS += \
 	--disable-documentation \
 	--disable-libudev \
 	--disable-python
+
 ifneq ($(CONFIG_BTRFS_PROGS_ZSTD),y)
 CONFIGURE_ARGS += --disable-zstd
 endif
@@ -90,7 +91,8 @@ define Package/btrfs-progs/install
 	$(foreach prog,$(boxprogs),$(LN) btrfs $(1)/usr/bin/$(prog);)
 	$(foreach prog,$(progs),$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(prog) $(1)/usr/bin/;)
 	$(INSTALL_DIR) $(1)/lib/preinit
-	$(INSTALL_BIN) ./files/btrfs-scan.init $(1)/lib/preinit/85_btrfs_scan
+	$(INSTALL_BIN) ./files/btrfs-scan.init $(1)/lib/preinit/85_btrfs_scan_post
+	$(LN) ./85_btrfs_scan_post $(1)/lib/preinit/78_btrfs_scan_pre
 endef
 
 $(eval $(call BuildPackage,btrfs-progs))

--- a/utils/btrfs-progs/files/btrfs-scan.init
+++ b/utils/btrfs-progs/files/btrfs-scan.init
@@ -2,7 +2,7 @@
 
 preinit_btrfs_scan() {
 	if grep -q btrfs /proc/filesystems; then
-		 btrfs device scan
+		btrfs device scan -d > /dev/kmsg
 	fi
 }
 


### PR DESCRIPTION
Maintainer: @Cynerd
Compile tested: x86-64 Gentoo Linux, OpenWrt git main branch
Run tested: mvebu Linksys WRT-1900ACv1, Turris Omnia, OpenWrt git main branch r27964
Overlay on btrfs RAID works. Extroot on btrfs RAID not tested.

Description:
If users choose to build OpenWrt with btrfs-progs included and want to use a btrfs RAID for overlay/extroot,
then devices need to be scanned *before* mounting overlay/extroot. If not, btrfs won't find all RAID drives and fail to mount.

This commit:
- creates a duplicate (symlink) of the btrfs scan script so that it runs both before and after overlay/extroot mount,
- changes the scan command to not depend on blkid (-d),
- outputs the scan results to kernel log to show what's being detected, as the system logger is not yet running.