### PR TITLE
ddns-scripts: Adjust descriptions in Makefile for apk (no parentheses inside double quotes)

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=51
+PKG_RELEASE:=52
 
 PKG_LICENSE:=GPL-2.0
 
@@ -109,7 +109,7 @@ define Package/ddns-scripts-freedns
 endef
 
 define Package/ddns-scripts-freedns/description
-  Dynamic DNS Client scripts extension for "freedns.42.pl".
+  Dynamic DNS Client scripts extension for 'freedns.42.pl'.
 endef
 
 
@@ -121,7 +121,7 @@ define Package/ddns-scripts-godaddy
 endef
 
 define Package/ddns-scripts-godaddy/description
-  Dynamic DNS Client scripts extension for "godaddy.com API v1".
+  Dynamic DNS Client scripts extension for 'godaddy.com API v1'.
 endef
 
 
@@ -133,14 +133,14 @@ define Package/ddns-scripts-digitalocean
 endef
 
 define Package/ddns-scripts-digitalocean/description
-  Dynamic DNS Client scripts extension for "digitalocean.com API v2".
+  Dynamic DNS Client scripts extension for digitalocean.com API v2.
   The script directly updates a DNS record using the DO API.
   It requires:
-  "option dns_server" to be set to the server to be used by nsupdate.
-  "option domain" the dns domain to update the record for (eg. A-record: home.<example.com>)
-  "option username" the dns record name to update (eg. A-record: <home>.example.com)
-  "option param_opt" the id of the dns record to update (check using chrome inspector in the DO dns tab)
-  "option password" the api token generated in the DO panel
+  'option dns_server' to be set to the server to be used by nsupdate.
+  'option domain' the dns domain to update the record for (eg. A-record: home.<example.com>)
+  'option username' the dns record name to update (eg. A-record: <home>.example.com)
+  'option param_opt' the id of the dns record to update (check using chrome inspector in the DO dns tab)
+  'option password' the api token generated in the DO panel
 endef
 
 
@@ -163,7 +163,7 @@ define Package/ddns-scripts-noip
 endef
 
 define Package/ddns-scripts-noip/description
-  Dynamic DNS Client scripts extension for "no-ip.com".
+  Dynamic DNS Client scripts extension for 'no-ip.com'.
 endef
 
 define Package/ddns-scripts-ns1
@@ -173,10 +173,10 @@ define Package/ddns-scripts-ns1
 endef
 
 define Package/ddns-scripts-ns1/description
-  Dynamic DNS Client scripts extension for "ns1.com".
+  Dynamic DNS Client scripts extension for 'ns1.com'.
   It requires:
-  "option username" to be a valid zone for ns1.com
-  "option password" to be a valid API key for ns1.com
+  'option username' to be a valid zone for ns1.com
+  'option password' to be a valid API key for ns1.com
 endef
 
 
@@ -192,9 +192,9 @@ define Package/ddns-scripts-nsupdate/description
   The script directly updates a PowerDNS (or maybe bind server) via nsupdate
   from bind-client package.
   It requires:
-  "option dns_server" to be set to the server to be used by nsupdate.
-  "option username" should be set to the key name and
-  "option password" to the base64 encoded shared secret.
+  'option dns_server' to be set to the server to be used by nsupdate.
+  'option username' should be set to the key name and
+  'option password' to the base64 encoded shared secret.
 endef
 
 
@@ -206,12 +206,12 @@ define Package/ddns-scripts-route53
 endef
 
 define Package/ddns-scripts-route53/description
-  Dynamic DNS Client scripts extension for Amazon AWS "route53 API v1".
+  Dynamic DNS Client scripts extension for Amazon AWS 'route53 API v1'.
   Note: You must also install ca-certificate or ca-bundle.
   It requires:
-  "option username" to be a valid AWS access key id
-  "option password" to be the matching AWS secret key id
-  "option domain" to contain the hosted zone ID
+  'option username' to be a valid AWS access key id
+  'option password' to be the matching AWS secret key id
+  'option domain' to contain the hosted zone ID
 endef
 
 
@@ -223,11 +223,11 @@ define Package/ddns-scripts-cnkuai
 endef
 
 define Package/ddns-scripts-cnkuai/description
-  Dynamic DNS Client scripts extension for "cnkuai.cn".
+  Dynamic DNS Client scripts extension for 'cnkuai.cn'.
   It requires:
-  "option username" to be a valid CnKuai control panel id
-  "option password" to be the matching CnKuai control panel password
-  "option domain" to contain the domain
+  'option username' to be a valid CnKuai control panel id
+  'option password' to be the matching CnKuai control panel password
+  'option domain' to contain the domain
 endef
 
 
@@ -238,10 +238,10 @@ define Package/ddns-scripts-gandi
 endef
 
 define Package/ddns-scripts-gandi/description
-  Dynamic DNS Client scripts extension for "gandi.net".
+  Dynamic DNS Client scripts extension for 'gandi.net'.
   It requires:
-  "option username" to be a valid subdomain for gandi.net
-  "option password" to be a valid API key for gandi.net
+  'option username' to be a valid subdomain for gandi.net
+  'option password' to be a valid API key for gandi.net
 endef
 
 
@@ -252,11 +252,11 @@ define Package/ddns-scripts-pdns
 endef
 
 define Package/ddns-scripts-pdns/description
-  Dynamic DNS Client scripts extension for "PowerDNS" via API.
+  Dynamic DNS Client scripts extension for 'PowerDNS' via API.
   It requires:
-  "option param_opt(Optional Parameter)" to be a valid root URL for the PowerDNS webserver
-  "option username" to be a valid subdomain for the PowerDNS domain
-  "option password" to be a valid API key for the PowerDNS webserver
+  'option param_opt(Optional Parameter)' to be a valid root URL for the PowerDNS webserver
+  'option username' to be a valid subdomain for the PowerDNS domain
+  'option password' to be a valid API key for the PowerDNS webserver
 endef
 
 
@@ -267,14 +267,14 @@ define Package/ddns-scripts-transip
 endef
 
 define Package/ddns-scripts-transip/description
-  Dynamic DNS Client scripts extension for "transip.nl".
+  Dynamic DNS Client scripts extension for 'transip.nl'.
   Note: You must also install ca-certificate or ca-bundle.
   It requires:
-  "option username" to be a valid username for transip.nl
-  "option password" to be a valid matching private key
-  "option domain" to contain the base domain
-  "option param_enc" to contain the name of the DNS record to update
-  "option param_opt" to contain the TTL of the DNS record to update
+  'option username' to be a valid username for transip.nl
+  'option password' to be a valid matching private key
+  'option domain' to contain the base domain
+  'option param_enc' to contain the name of the DNS record to update
+  'option param_opt' to contain the TTL of the DNS record to update
 endef
 
 define Package/ddns-scripts-one
@@ -284,11 +284,11 @@ define Package/ddns-scripts-one
 endef
 
 define Package/ddns-scrtips-one/description
-	Dynamic DNS Client scripts extension for "one.com".
+	Dynamic DNS Client scripts extension for 'one.com'.
 	It requires:
-	"option username" to be a valid Email for one.com Control Panel
-	"option password" to be the matching one.com Control Panel password
-	"option domain" to contain the domain / subdomain
+	'option username' to be a valid Email for one.com Control Panel
+	'option password' to be the matching one.com Control Panel password
+	'option domain' to contain the domain / subdomain
 endef
 
 
@@ -302,9 +302,9 @@ endef
 define Package/ddns-scripts-porkbun/description
 	Dynamic DNS Client scripts extension for porkbun.com API v3 (require curl)
 	It requires:
-	"option username" to be a Porkbun API key
-	"option password" to be the corresponding Porkbun API secret key
-	"option domain" to be the FQDN for which to configure DDNS
+	'option username' to be a Porkbun API key
+	'option password' to be the corresponding Porkbun API secret key
+	'option domain' to be the FQDN for which to configure DDNS
 endef
 
 define Package/ddns-scripts-huaweicloud


### PR DESCRIPTION
Having both double quotes and parentheses in package description may lead into trouble with apk, if parentheses are located so that they get passed "outside" the quoted parameter, and get interpreted as a token for shell. 

Example, where quoted text containing parentheses `"option param_opt(Optional Parameter)"` gets handled wrong, as the 'opening quote' is actually the closing quote from shell perspective and thus ( is seen as a shell delimiter:

```
 ash: -c: line 1: syntax error near unexpected token `('
 bash: -c: line 1: `/OpenWrt/e8450/staging_dir/host/bin/fakeroot
 /OpenWrt/e8450/staging_dir/host/bin/apk mkpkg --info "name:ddns
 -scripts-pdns" --info "version:2.8.2-r51" --info "description:D
 ynamic DNS Client scripts extension for "PowerDNS" via API. It
 requires: "option param_opt(Optional Parameter)" to be a valid
```

Avoid that by using single quotes in the detailed descriptions in Makefile.

I am doing this change as a PR to document this behavior better for future.
