### PR TITLE
lftp: fix expat under GCC14

### DIFF
--- a/net/lftp/Makefile
+++ b/net/lftp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lftp
 PKG_VERSION:=4.9.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://lftp.tech/ftp/ \
@@ -50,6 +50,7 @@ CONFIGURE_ARGS += \
 	--without-gnutls \
 	--without-libidn2 \
 	--without-libresolv \
+	--with-expat="$(STAGING_DIR)/usr" \
 	--with-openssl="$(STAGING_DIR)/usr" \
 	--with-readline="$(STAGING_DIR)/usr" \
 	--with-zlib="$(STAGING_DIR)/usr" \


### PR DESCRIPTION
For some weird reason, it tries to use OS directories. Override.

Maintainer: @fededim 