### PR TITLE
libdrm: update to 2.4.123

### DIFF
--- a/libs/libdrm/Makefile
+++ b/libs/libdrm/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdrm
-PKG_VERSION:=2.4.120
+PKG_VERSION:=2.4.123
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://dri.freedesktop.org/libdrm
-PKG_HASH:=3bf55363f76c7250946441ab51d3a6cc0ae518055c0ff017324ab76cdefb327a
+PKG_HASH:=a2b98567a149a74b0f50e91e825f9c0315d86e7be9b74394dae8b298caadb79e
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer :@krant
Compile tested: aarch64/cortex-a53
Run tested: mediatek/filogic (BananaPi R4 with panel-mipi-dbi-spi, running weston and glroots based cage)

Description:
Changes since 2.4.120:
ad750dc6 amdgpu: add marketing names from Adrenalin 23.11.1 64144740 amdgpu: add marketing names from PRO Edition for W7700 fb13af43 amdgpu: add marketing names from Windows Steam Deck OLED APU driver dfb8111e amdgpu: add marketing names from amd-6.0
9d9498f4 amdgpu: add marketing name for Radeon RX 6550M 14094328 amdgpu: add marketing names from amd-6.0.1 7ab1cdac xf86drm: ignore symlinks in process_device() 1aa800d4 Revert "xf86drm: ignore symlinks in process_device()" 7c5c742d xf86drm: Don't consider node names longer than the maximum allowed 01f91aa7 meson: make build system happy by replacing deprecated feature 1b4e04ba tests/util: add tidss driver
c8f327ce amdgpu: Make amdgpu_device_deinitialize thread-safe 43768487 amdgpu: add amdgpu_va_manager
96fe43a0 amdgpu: expose amdgpu_va_manager publicly 6978f999 amdgpu: add amdgpu_va_range_alloc2
7275ef8e amdgpu: add amdgpu_device_initialize2
525e8044 symbols-check: Add _GLOBAL_OFFSET_TABLE_
c45ffb1e symbols-check: Add _fbss, _fdata, _ftext
c7c3c14b amdgpu: fix deinit logic
fbb83f74 meson: Replace usages of deprecated ExternalProgram.path() 764ed8b9 meson: Fix broken str.format usage
5a9cfb3c ci: build with meson --fatal-meson-warnings f94a79a7 ci: use "meson setup" sub-command
1179edb4 include poll.h instead of sys/poll.h
362b5b0a xf86drm: document drmDevicesEqual()
4df91735 amdgpu: Make amdgpu_cs_signal_semaphore() thread-safe 058a04de tests/amdgpu: fix compile warning with the guard enum value cee441f3 tests/amdgpu: fix compile error with gcc7.5 37265ab0 tests/amdgpu: fix compile error with gcc14 93d037cd amdgpu: sync amdgpu_drm.h
70c4f836 Bump version to 2.4.121
7f20912b Remove libm in libdrm dependencies
0cd18d0d OpenBSD: fix FTBS on misspelled and missing variables 90c1a35f fix FTBS on FreeBSD (or non-Linux in general) b7338fc8 freedreno: fix FTBS on non-Linux platforms (unused header) 589f8e86 etnaviv: fix FTBS on undefined linux/* headers on non-Linux platforms. d096affb ci: upgrade debian container to bookworm
a97bd7b4 ci: upgrade FreeBSD VM to 14.1
998d2a2e Sync headers with drm-next
ad78bb59 build: bump version to 2.4.122
b065dbc5 Fix FTBS on undefined clock_gettime() and asprintf() 5e1e7c4d amdgpu: add new marketing names
11cafdd8 amdgpu: add new marketing names
21ac1816 Convert to Android.bp
aefb5fa9 Delete all Makefile.sources files
aef24b66 readdir_r is deprecated.
c2b5759a Android.bp: Add include exports for android dir 6aa6411c Make libdrm recovery_available
dcb14fe0 Makes libdrm available on host
460f7907 Export include dirs with -isystem
f22956a4 Adds libdrm_headers
d9043a25 add crosvm to com.android.virt
4bd09d78 Enable GPU in crosvm
b0815faa libs: Tie DSO minor versions to libdrm version 88db6114 tests: Make modetest and proptest cc_binary in Android.bp f3f56f41 Disable ioctl signed overload for Bionic libc 25dec5b9 build: bump version to 2.4.123