### PR TITLE
[openwrt-23.05] rust: update to 1.81.0

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
-PKG_VERSION:=1.80.1
+PKG_VERSION:=1.81.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
-PKG_HASH:=2c0b8f643942dcb810cbcc50f292564b1b6e44db5d5f45091153996df95d2dc4
+PKG_HASH:=872448febdff32e50c3c90a7e15f9bb2db131d13c588fe9071b0ed88837ccfa7
 HOST_BUILD_DIR:=$(BUILD_DIR)/host/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>

--- a/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
+++ b/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Update xz2 and use it static
 
 --- a/src/bootstrap/Cargo.toml
 +++ b/src/bootstrap/Cargo.toml
-@@ -62,7 +62,7 @@ tar = "0.4"
+@@ -60,7 +60,7 @@ tar = "0.4"
  termcolor = "1.4"
  toml = "0.5"
  walkdir = "2.4"


### PR DESCRIPTION
Maintainer: @lu-zero 
Compile tested: rockchip/armv8
Run tested: n/a

Description:
backport rust 1.81.0 update to 23.05 branch.