### PR TITLE
openvpn-easy-rsa: Bump to 3.2.1 release

### DIFF
--- a/net/openvpn-easy-rsa/Makefile
+++ b/net/openvpn-easy-rsa/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn-easy-rsa
 
-PKG_VERSION:=3.1.3
+PKG_VERSION:=3.2.1
 PKG_RELEASE:=1
 PKG_SOURCE_URL:=https://codeload.github.com/OpenVPN/easy-rsa/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=f2967aa598cb603dd20791002e767d0ce58e300b04c9cff1b6d6b14fedae6a80
+PKG_HASH:=9b01dba67d811cea1b918ed1a0f146dead31beabc85b96abe4b09ffc75129099
 
 # For git snapshots
 #PKG_SOURCE_PROTO:=git

--- a/net/openvpn-easy-rsa/patches/100-Make-package-reproducible.patch
+++ b/net/openvpn-easy-rsa/patches/100-Make-package-reproducible.patch
@@ -10,7 +10,7 @@ Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
 
 --- a/build/build-dist.sh
 +++ b/build/build-dist.sh
-@@ -86,7 +86,7 @@ stage_unix() {
+@@ -118,7 +118,7 @@ stage_unix() {
  
  	# FreeBSD does not accept -i without argument in a way also acceptable by GNU sed
  	sed -i.tmp -e "s/~VER~/$VERSION/" \
@@ -19,7 +19,7 @@ Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
  		   -e "s/~HOST~/$(hostname -s)/" \
  		   -e "s/~GITHEAD~/$(git rev-parse HEAD)/" \
  		   "$DIST_ROOT/unix/$PV/easyrsa" || die "Cannot update easyrsa version data"
-@@ -128,7 +128,7 @@ stage_win() {
+@@ -160,7 +160,7 @@ stage_win() {
  		done
  
  		sed -i.tmp -e "s/~VER~/$VERSION/" \


### PR DESCRIPTION
Bump openvpn-easy-rsa to 3.2.1 release. All patch automatically refreshed.

---

#25248