### PR TITLE
[24.10] openwisp-monitoring: fix Makefile for 0.2.0

### DIFF
--- a/admin/openwisp-monitoring/Config.in
+++ b/admin/openwisp-monitoring/Config.in
@@ -1,0 +1,9 @@
+menu "netjson-monitoring Configuration"
+
+config NETJSON_MONITORING_IWINFO
+	bool "Enable rpcd-mod-iwinfo"
+	default y
+	help
+	  Whether to include the rpcd-mod-iwinfo dependency (enabled by default).
+
+endmenu

--- a/admin/openwisp-monitoring/Makefile
+++ b/admin/openwisp-monitoring/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openwisp-monitoring
 PKG_VERSION:=0.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Federico Capoano <support@openwisp.io>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -34,8 +34,13 @@ define Package/netjson-monitoring
   CATEGORY:=Administration
   SECTION:=admin
   SUBMENU:=openwisp
-  DEPENDS:=+libubus-lua +lua-cjson +rpcd +rpcd-mod-iwinfo
+  DEPENDS:=+libubus-lua +lua-cjson +rpcd
+  DEPENDS+=+NETJSON_MONITORING_IWINFO:rpcd-mod-iwinfo
   URL:=http://openwisp.org
+endef
+
+define Package/netjson-monitoring/config
+  source "$(SOURCE)/Config.in"
 endef
 
 define Build/Compile
@@ -87,6 +92,11 @@ define Package/netjson-monitoring/install
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/openwisp-monitoring/files/lib/openwisp-monitoring/wifi.lua \
 		$(1)/usr/lib/lua/openwisp-monitoring/wifi.lua
+
+# Iwinfo is enabled by default unless specified otherwise
+ifeq ($(CONFIG_NETJSON_MONITORING_IWINFO), y)
+	$(CP) $(PKG_BUILD_DIR)/openwisp-monitoring/files/lib/openwisp-monitoring/iwinfo.lua $(1)/usr/lib/lua/openwisp-monitoring/iwinfo.lua
+endif
 
 	$(CP) $(PKG_BUILD_DIR)/VERSION $(1)/usr/lib/openwisp-monitoring/
 

--- a/admin/openwisp-monitoring/Makefile
+++ b/admin/openwisp-monitoring/Makefile
@@ -30,7 +30,7 @@ define Package/openwisp-monitoring
 endef
 
 define Package/netjson-monitoring
-  TITLE:=NetJson Monitoring
+  TITLE:=NetJSON Monitoring
   CATEGORY:=Administration
   SECTION:=admin
   SUBMENU:=openwisp
@@ -50,7 +50,7 @@ define Package/netjson-monitoring/install
 		$(1)/usr/sbin \
 		$(1)/usr/libexec \
 		$(1)/usr/lib/lua/openwisp-monitoring \
-		$(1)/etc/openwisp-monitoring
+		$(1)/usr/lib/openwisp-monitoring
 
 	$(INSTALL_BIN) \
 		$(PKG_BUILD_DIR)/openwisp-monitoring/files/sbin/netjson-monitoring.lua \
@@ -88,7 +88,7 @@ define Package/netjson-monitoring/install
 		$(PKG_BUILD_DIR)/openwisp-monitoring/files/lib/openwisp-monitoring/wifi.lua \
 		$(1)/usr/lib/lua/openwisp-monitoring/wifi.lua
 
-	$(CP) $(PKG_BUILD_DIR)/VERSION $(1)/etc/openwisp-monitoring/
+	$(CP) $(PKG_BUILD_DIR)/VERSION $(1)/usr/lib/openwisp-monitoring/
 
 endef
 
@@ -97,7 +97,8 @@ define Package/openwisp-monitoring/install
 		$(1)/usr/sbin \
 		$(1)/etc/init.d \
 		$(1)/etc/config \
-		$(1)/etc/openwisp-monitoring
+		$(1)/usr/lib/openwisp-monitoring \
+		$(1)/etc/hotplug.d/openwisp
 
 	$(INSTALL_BIN) \
 		$(PKG_BUILD_DIR)/openwisp-monitoring/files/monitoring.agent \
@@ -106,6 +107,10 @@ define Package/openwisp-monitoring/install
 	$(INSTALL_BIN) \
 		$(PKG_BUILD_DIR)/openwisp-monitoring/files/monitoring.init \
 		$(1)/etc/init.d/openwisp-monitoring
+
+	$(INSTALL_BIN) \
+		$(PKG_BUILD_DIR)/openwisp-monitoring/files/openwisp-monitoring.hotplug \
+		$(1)/etc/hotplug.d/openwisp/openwisp-monitoring
 
 	$(INSTALL_CONF) \
 		$(PKG_BUILD_DIR)/openwisp-monitoring/files/monitoring.config \


### PR DESCRIPTION
Maintainer: @nemesifier
Compile tested: ramips
Run tested: ramips

Description: 

Cherry picked  886b3fa36d0b82071b10d0169d6950b0aaa6f16c and ca503cc4054d9a13558c7b552886a6dba359a0eb