### PR TITLE
ruby: include JSON modules in host build

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -49,7 +49,7 @@ HOST_CONFIGURE_ARGS += \
 	--disable-yjit \
 	--without-gmp \
 	--with-static-linked-ext \
-	--with-out-ext=-test-/*,bigdecimal,cgi/escape,continuation,coverage,etc,fcntl,fiddle,io/console,json,json/generator,json/parser,mathn/complex,mathn/rational,nkf,objspace,pty,racc/cparse,rbconfig/sizeof,readline,rubyvm,syslog,win32,win32ole,win32/resolv
+	--with-out-ext=-test-/*,bigdecimal,cgi/escape,continuation,coverage,etc,fcntl,fiddle,io/console,mathn/complex,mathn/rational,nkf,objspace,pty,racc/cparse,rbconfig/sizeof,readline,rubyvm,syslog,win32,win32ole,win32/resolv
 
 HOST_BUILD_DEPENDS:=yaml/host
 


### PR DESCRIPTION
Maintainer: @luizluca
Compile tested: host
Run tested: host (to build WebKit)

Description:
Ruby JSON modules are used to build WebKitGTK.
Include them in the host build.