### PR TITLE
libpng: add symlink to debug library

### DIFF
--- a/libs/libpng/Makefile
+++ b/libs/libpng/Makefile
@@ -46,6 +46,9 @@ CMAKE_OPTIONS += \
 
 define Build/InstallDev
 	$(call Build/InstallDev/cmake,$(1))
+ifdef CONFIG_DEBUG
+	$(LN) libpng16d.so $(1)/usr/lib/libpng16.so
+endif
 	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' $(1)/usr/bin/libpng{,16}-config
 	$(SED) '/^includedir=/s|/usr|$$$${prefix}|' $(1)/usr/bin/libpng{,16}-config
 	$(SED) '/^libdir=/s|/usr|$$$${prefix}|' $(1)/usr/bin/libpng{,16}-config
@@ -59,7 +62,10 @@ endef
 
 define Package/libpng/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpng16.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpng16$(if $(CONFIG_DEBUG),d).so* $(1)/usr/lib/
+ifdef CONFIG_DEBUG
+	$(LN) libpng16d.so $(1)/usr/lib/libpng16.so
+endif
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpng.so $(1)/usr/lib/
 endef
 


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: aarch64/cortex-a53
Run tested: mediatek/filogic (BananaPi R4)

Description:
Add convenience symlink when building with CONFIG_DEBUG.

Reported by @hnyman in https://github.com/openwrt/openwrt/pull/16899#issuecomment-2471281135