### PR TITLE
privoxy: adjust version for apk

### DIFF
--- a/net/privoxy/Makefile
+++ b/net/privoxy/Makefile
@@ -9,12 +9,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=privoxy
 PKG_VERSION:=3.0.34
+PKG_REAL_VERSION:=$(PKG_VERSION)-stable
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-stable-src.tar.gz
 PKG_SOURCE_URL:=@SF/ijbswa
 PKG_HASH:=e6ccbca1656f4e616b4657f8514e33a70f6697e9d7294356577839322a3c5d2c
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)-stable
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_REAL_VERSION)
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
@@ -71,9 +72,9 @@ define Package/privoxy/config
 	help
 		Privoxy is a web proxy with advanced filtering capabilities for protecting
 		privacy, modifying web page content, managing cookies, controlling access,
-		and removing ads, banners, pop-ups and other obnoxious Internet junk. 
+		and removing ads, banners, pop-ups and other obnoxious Internet junk.
 		Privoxy has a very flexible configuration and can be customized to suit
-		individual needs and tastes. 
+		individual needs and tastes.
 		Privoxy has application for both stand-alone systems and multi-user networks.
 		Run as : $(USERID)
 		Version: $(PKG_VERSION)-$(PKG_RELEASE)
@@ -123,7 +124,7 @@ define Package/privoxy/preinst
 
 # stop service if PKG_UPGRADE
 [ "$${PKG_UPGRADE}" = "1" ] && /etc/init.d/privoxy stop >/dev/null 2>&1
-	
+
 exit 0	# suppress errors from stop command
 endef
 


### PR DESCRIPTION
Adjust privoxy version for apk by removing the "-stable"
from the OpenWrt version, although it is still needed for
upstream download archive name.

Signed-off-by: xiao bo [peterwillcn@gmail.com](mailto:peterwillcn@gmail.com)