### PR TITLE
git: Set PKG_FORTIFY_SOURCE to 0 when lto enabled

### DIFF
--- a/net/git/Makefile
+++ b/net/git/Makefile
@@ -23,6 +23,10 @@ PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
+ifeq ($(CONFIG_USE_LTO),y)
+	PKG_FORTIFY_SOURCE:=0
+endif
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/git/Default


### PR DESCRIPTION
If PKG_FORTIFY_SOURCE is not 0 and lto is enabled for package git, git will fail to compile with the following example error:

/openwrt/staging_dir/toolchain-aarch64_generic_gcc-14.1.0_musl/include/stdio.h: In function 'process_curl_messages': /openwrt/staging_dir/toolchain-aarch64_generic_gcc-14.1.0_musl/include/stdio.h:90:8: error: inlining failed in call to 'always_inline' 'fwrite': function body can be overwritten at link time
   90 | size_t fwrite(const void *__restrict, size_t, size_t, FILE *__restrict);
      |        ^
http.c:355:33: note: called from here
  355 |                                 fprintf(stderr, "Received DONE message for unknown request!\n");
      |                                 ^

A related issue is openwrt/openwrt#13016 .
This commit set PKG_FORTIFY_SOURCE to 0 if CONFIG_USE_LTO is y.

Close: #24366
Link: https://lore.kernel.org/git/CAHfWF5mjquES-nocQaK+CAEsqWgdy-_OYdGtN82heYs0eJP3eQ@mail.gmail.com/T/#t
Link: https://github.com/openwrt/openwrt/issues/13016
Link: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110834

Maintainer: @krant @neheb
Compile tested: bcm2711 4f8ad90a9de0c63df2520ce0b7023b7a0fbfbf8d
Run tested: not yet

Description:
This is a rework of #24470