### PR TITLE
luajit: fix built for apk naming requirements

### DIFF
--- a/lang/luajit/Makefile
+++ b/lang/luajit/Makefile
@@ -1,13 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luajit
-PKG_VERSION:=2.1.0-beta3
-PKG_RELEASE:=7
+PKG_VERSION:=2.1.0
+PKG_REAL_VERSION:=$(PKG_VERSION)-beta3
+PKG_RELEASE:=8
 
-PKG_SOURCE:=LuaJIT-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=LuaJIT-$(PKG_REAL_VERSION).tar.gz
 PKG_SOURCE_URL:=https://luajit.org/download
 PKG_HASH:=1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3
-PKG_BUILD_DIR:=$(BUILD_DIR)/LuaJIT-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/LuaJIT-$(PKG_REAL_VERSION)
 
 PKG_MAINTAINER:=Morteza Milani <milani@pichak.co>
 PKG_LICENSE:=MIT
@@ -69,14 +70,14 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*so* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/luajit.pc $(1)/usr/lib/pkgconfig/
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/luajit-$(PKG_VERSION) $(PKG_INSTALL_DIR)/usr/bin/$(PKG_NAME)
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/luajit-$(PKG_REAL_VERSION) $(PKG_INSTALL_DIR)/usr/bin/$(PKG_NAME)
 endef
 
 define Package/luajit/install
 	$(INSTALL_DIR) $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/luajit-$(PKG_VERSION) $(1)/usr/bin/$(PKG_NAME)
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/luajit-$(PKG_REAL_VERSION) $(1)/usr/bin/$(PKG_NAME)
 endef
 
 define Host/Compile
@@ -90,7 +91,7 @@ define Host/Install
 	$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR) \
 		DPREFIX=$(STAGING_DIR_HOSTPKG) \
 		install
-	$(CP) $(STAGING_DIR_HOSTPKG)/bin/luajit-$(PKG_VERSION) $(STAGING_DIR_HOSTPKG)/bin/$(PKG_NAME)
+	$(CP) $(STAGING_DIR_HOSTPKG)/bin/luajit-$(PKG_REAL_VERSION) $(STAGING_DIR_HOSTPKG)/bin/$(PKG_NAME)
 endef
 
 $(eval $(call HostBuild,luajit))


### PR DESCRIPTION
Like wolfssl[1], adjust version for apk by removing the hyphen.

1. https://git.openwrt.org/?p=openwrt/openwrt.git;a=commitdiff;h=be952e98bc1d768a0da5b84e59a6e7c04a1cdab8

Build system: x86/64
Build-tested: x86/64/AMD Cezanne
Run-tested: x86/64/AMD Cezanne

Maintainer: @milani