### PR TITLE
git: use symbolic link

### DIFF
--- a/net/git/Makefile
+++ b/net/git/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=git
 PKG_VERSION:=2.46.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/scm/git/
@@ -137,8 +137,8 @@ define Package/git/install
 		usr/lib/git-core \
 		usr/share/git-core/templates \
 	) | ( cd $(1); $(TAR) -xf - )
-	ln $(1)/usr/lib/git-core/git $(1)/usr/bin/git
-	ln $(1)/usr/lib/git-core/git-shell $(1)/usr/bin/git-shell
+	$(LN) ../lib/git-core/git $(1)/usr/bin/git
+	$(LN) ../lib/git-core/git-shell $(1)/usr/bin/git-shell
 endef
 
 define Package/git-http/install


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: head,aarch64, 
Run tested: aarch64 (mediatek/filogic)

Description:
The following error occurs when CONFIG_USE_APK is set.
```
ln /mnt/gl-mt6000-main/openwrt/build_dir/target-aarch64_cortex-a53_musl/git-2.46.2/.pkgdir/git/usr/lib/git-core/git /mnt/gl-mt6000-main/openwrt/build_dir/target-aarch64_cortex-a53_musl/git-2.46.2/.pkgdir/git/usr/bin/git
ln /mnt/gl-mt6000-main/openwrt/build_dir/target-aarch64_cortex-a53_musl/git-2.46.2/.pkgdir/git/usr/lib/git-core/git-shell /mnt/gl-mt6000-main/openwrt/build_dir/target-aarch64_cortex-a53_musl/git-2.46.2/.pkgdir/git/usr/bin/git-shell
touch /mnt/gl-mt6000-main/openwrt/build_dir/target-aarch64_cortex-a53_musl/git-2.46.2/.pkgdir/git.installed
mkdir -p /mnt/gl-mt6000-main/openwrt/staging_dir/target-aarch64_cortex-a53_musl/root-mediatek/stamp
SHELL= flock /mnt/gl-mt6000-main/openwrt/tmp/.root-copy.flock -c 'cp -fpR /mnt/gl-mt6000-main/openwrt/build_dir/target-aarch64_cortex-a53_musl/git-2.46.2/.pkgdir/git/. /mnt/gl-mt6000-main/openwrt/staging_dir/target-aarch64_cortex-a53_musl/root-mediatek/'
cp: '/mnt/gl-mt6000-main/openwrt/build_dir/target-aarch64_cortex-a53_musl/git-2.46.2/.pkgdir/git/./usr/bin/git' and '/mnt/gl-mt6000-main/openwrt/staging_dir/target-aarch64_cortex-a53_musl/root-mediatek/./usr/bin/git' are the same file
cp: '/mnt/gl-mt6000-main/openwrt/build_dir/target-aarch64_cortex-a53_musl/git-2.46.2/.pkgdir/git/./usr/bin/git-shell' and '/mnt/gl-mt6000-main/openwrt/staging_dir/target-aarch64_cortex-a53_musl/root-mediatek/./usr/bin/git-shell' are the same file
make[2]: *** [Makefile:167: /mnt/gl-mt6000-main/openwrt/staging_dir/target-aarch64_cortex-a53_musl/root-mediatek/stamp/.git_installed] Error 1
```
Use $(LN) instead of 'ln' and use relative path.