### PR TITLE
ocserv: Use default value for log-level in conf

### DIFF
--- a/net/ocserv/files/ocserv.conf.template
+++ b/net/ocserv/files/ocserv.conf.template
@@ -431,7 +431,7 @@ expose-iroutes = true
 #   4 http
 #   8 sensitive
 #   9 TLS
-log-level = 3
+#log-level = 2
 
 # This option will enable the X-CSTP-Client-Bypass-Protocol (disabled by default).
 # If the server has not configured an IPv6 or IPv4 address pool, enabling this option


### PR DESCRIPTION
This commit comments out the `log-level` line in the template config file to use default value from upstream, default should be 2.

Maintainer: @nmav 
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
