### PR TITLE
gphoto2: fix compilation with GCC14

### DIFF
--- a/multimedia/gphoto2/Makefile
+++ b/multimedia/gphoto2/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gphoto2
 PKG_VERSION:=2.5.28
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/gphoto

--- a/multimedia/gphoto2/patches/010-pthread.patch
+++ b/multimedia/gphoto2/patches/010-pthread.patch
@@ -1,0 +1,33 @@
+From ccc4c1f092bd21ebc713f4d7b9be85be49f92f1e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 2 Sep 2022 12:59:46 -0700
+Subject: [PATCH] gphoto2: Use pthread_t abstract type for thead IDs
+
+This is not a plain old datatype in every libc, e.g. with musl this
+would fail in type conversion
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ gphoto2/main.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/gphoto2/main.c
++++ b/gphoto2/main.c
+@@ -1198,7 +1198,7 @@ thread_func (void *data)
+ 	pthread_cleanup_pop (1);
+ }
+ 
+-static unsigned int
++static pthread_t
+ start_timeout_func (Camera *camera, unsigned int timeout,
+ 		    CameraTimeoutFunc func, void __unused__ *data)
+ {
+@@ -1219,7 +1219,7 @@ start_timeout_func (Camera *camera, unsi
+ }
+ 
+ static void
+-stop_timeout_func (Camera __unused__ *camera, unsigned int id,
++stop_timeout_func (Camera __unused__ *camera, pthread_t id,
+ 		   void __unused__ *data)
+ {
+ 	pthread_t tid = id;

--- a/multimedia/gphoto2/patches/020-gcc14.patch
+++ b/multimedia/gphoto2/patches/020-gcc14.patch
@@ -1,0 +1,44 @@
+From 366930ccc1a261c3eb883da2bf3c655162ccd75f Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 1 Mar 2023 22:58:37 -0800
+Subject: [PATCH] Match prototypes of callbacks with libgphoto
+
+In https://github.com/gphoto/gphoto2/pull/535/commits/ccc4c1f092bd21ebc713f4d7b9be85be49f92f1e
+we tried to fix by using pthread_t but it also needs to make changes in
+libgphoto and these changes can be invasive, therefore lets revert to
+older types and to fix musl problem fix it via type casts
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ gphoto2/main.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+--- a/gphoto2/main.c
++++ b/gphoto2/main.c
+@@ -1198,7 +1198,7 @@ thread_func (void *data)
+ 	pthread_cleanup_pop (1);
+ }
+ 
+-static pthread_t
++static unsigned int
+ start_timeout_func (Camera *camera, unsigned int timeout,
+ 		    CameraTimeoutFunc func, void __unused__ *data)
+ {
+@@ -1215,14 +1215,14 @@ start_timeout_func (Camera *camera, unsi
+ 
+ 	pthread_create (&tid, NULL, thread_func, td);
+ 
+-	return (tid);
++	return (unsigned int)tid;
+ }
+ 
+ static void
+-stop_timeout_func (Camera __unused__ *camera, pthread_t id,
++stop_timeout_func (Camera __unused__ *camera, unsigned int id,
+ 		   void __unused__ *data)
+ {
+-	pthread_t tid = id;
++	pthread_t tid = (pthread_t)id;
+ 
+ 	pthread_cancel (tid);
+ 	pthread_join (tid, NULL);


### PR DESCRIPTION
Upstream backports.

Maintainer: @DocLM 