### PR TITLE
libdbi-drivers: fix compilation with GCC14

### DIFF
--- a/libs/libdbi-drivers/Makefile
+++ b/libs/libdbi-drivers/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdbi-drivers
 PKG_VERSION:=0.9.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/libdbi-drivers

--- a/libs/libdbi-drivers/patches/010-gcc14.patch
+++ b/libs/libdbi-drivers/patches/010-gcc14.patch
@@ -1,0 +1,49 @@
+Patch-Source-1: https://sourceforge.net/p/libdbi-drivers/bugs/27/attachment/libdbi-drivers-sys-wait.patch
+Patch-Source-2: https://sourceforge.net/p/libdbi-drivers/bugs/28/attachment/libdbi-drivers-c99.patch
+--
+--- a/tests/cgreen/src/unit.c
++++ b/tests/cgreen/src/unit.c
+@@ -9,6 +9,7 @@
+ #include <stdarg.h>
+ #include <unistd.h>
+ #include <signal.h>
++#include <sys/wait.h>
+ 
+ enum {test_function, test_suite};
+ 
+--- a/tests/cgreen/src/constraint.c
++++ b/tests/cgreen/src/constraint.c
+@@ -22,8 +22,7 @@ static double unbox_double(intptr_t box)
+ static double as_double(intptr_t box);
+ 
+ static int compare_using_matcher(Constraint *constraint, intptr_t actual);
+-static void test_with_matcher(Constraint *constraint, const char *function, const char* matcher_name, intptr_t actual, const char *test_file, int test_line, TestReporter *reporter);
+-
++static void test_with_matcher(Constraint *constraint, const char *function, intptr_t matcher_function, const char *test_file, int test_line, TestReporter *reporter);
+ 
+ void destroy_constraint(void *abstract) {
+     Constraint *constraint = (Constraint *)abstract;
+@@ -164,11 +163,11 @@ static void test_want_double(Constraint
+ }
+ 
+ static int compare_using_matcher(Constraint *constraint, intptr_t actual) {
+-	int (*matches)(const void*) = constraint->expected;
+-    return matches(actual);
++	int (*matches)(const void*) = (int (*)(const void*)) constraint->expected;
++    return matches((const void *)actual);
+ }
+ 
+-static void test_with_matcher(Constraint *constraint, const char *function, const char* matcher_name, intptr_t matcher_function, const char *test_file, int test_line, TestReporter *reporter) {
++static void test_with_matcher(Constraint *constraint, const char *function, intptr_t matcher_function, const char *test_file, int test_line, TestReporter *reporter) {
+     (*reporter->assert_true)(
+             reporter,
+             test_file,
+@@ -176,7 +175,7 @@ static void test_with_matcher(Constraint
+             (*constraint->compare)(constraint, matcher_function),
+             "Wanted parameter [%s] to match [%s] in function [%s]",
+             constraint->parameter,
+-            matcher_name,
++            constraint->name,
+             function);
+ }
+ 


### PR DESCRIPTION
Patch from Alpine Linux.

Maintainer: 