### PR TITLE
libesmtp: fix compilation with GCC14

### DIFF
--- a/libs/libesmtp/Makefile
+++ b/libs/libesmtp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libesmtp
 PKG_VERSION:=1.1.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=LGPL-2.0-or-later
@@ -28,7 +28,7 @@ define Package/libesmtp
   CATEGORY:=Libraries
   TITLE:=A Library for Posting Electronic Mail
   URL:=https://libesmtp.github.io/
-  DEPENDS:=+libpthread +libopenssl
+  DEPENDS:=+libopenssl
 endef
 
 define Build/InstallDev

--- a/libs/libesmtp/patches/010-gcc14.patch
+++ b/libs/libesmtp/patches/010-gcc14.patch
@@ -1,0 +1,27 @@
+--- a/smtp-api.c
++++ b/smtp-api.c
+@@ -22,6 +22,10 @@
+ 
+ #include <config.h>
+ 
++#ifndef _GNU_SOURCE
++#define _GNU_SOURCE
++#endif
++
+ #include <stdarg.h>
+ #include <string.h>
+ #include <stdlib.h>
+--- a/smtp-tls.c
++++ b/smtp-tls.c
+@@ -47,6 +47,11 @@
+ 
+ /* This stuff doesn't belong here */
+ /* vvvvvvvvvvv */
++
++#ifndef _GNU_SOURCE
++#define _GNU_SOURCE
++#endif
++
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <unistd.h>


### PR DESCRIPTION
_GNU_SOURCE is needed for some functions.

Removed now pointless libpthread depedency.

Maintainer: @tru7 