### PR TITLE
libgudev: fix compilation with full NLS

### DIFF
--- a/libs/libgudev/Makefile
+++ b/libs/libgudev/Makefile
@@ -16,6 +16,7 @@ PKG_BUILD_DEPENDS:=glib2/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/meson.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/libgudev
   SECTION:=libs


### PR DESCRIPTION
nls.mk is needed.

Maintainer: @dangowrt 