### PR TITLE
svox: Make version apk compatible

### DIFF
--- a/sound/svox/Makefile
+++ b/sound/svox/Makefile
@@ -8,12 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=svox
-PKG_VERSION:=1.0+git20130326
+PKG_REAL_VERSION:=1.0+git20130326
+PKG_VERSION:=$(subst +git,.,$(PKG_REAL_VERSION))
 PKG_RELEASE:=3
 
-PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.gz
+PKG_SOURCE:=$(PKG_NAME)_$(PKG_REAL_VERSION).orig.tar.gz
 PKG_SOURCE_URL:=http://ftp.debian.org/debian/pool/non-free/s/svox
 PKG_HASH:=337b25e6ccb3764f0df1e176470b883c90e40e98840d4133340fcc89eb3cea0c
+
+PKG_BUILD_DIR :=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_REAL_VERSION)
 
 PKG_MAINTAINER:=Alessandro Di Marco <dmr@ethzero.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Adjust PKG_VERSION to be compatible with apk's semantic rules.

Maintainer:  @dmrlsn 

Compile tested: mediatek/mt7622 RT3200