### PR TITLE
network: Add SUBMENU variable for some packages

### DIFF
--- a/net/cifs-utils/Makefile
+++ b/net/cifs-utils/Makefile
@@ -30,6 +30,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/cifsmount
   SECTION:=net
   CATEGORY:=Network
+  SUBMENU:=Filesystem
   DEPENDS:=+kmod-fs-cifs
   TITLE:=CIFS mount
   URL:=https://wiki.samba.org/index.php/LinuxCIFS_utils

--- a/net/dawn/Makefile
+++ b/net/dawn/Makefile
@@ -25,6 +25,7 @@ include $(INCLUDE_DIR)/cmake.mk
 define Package/dawn
   SECTION:=net
   CATEGORY:=Network
+  SUBMENU:=Wireless
   TITLE:=Decentralized wifi controller
   URL:=https://github.com/berlin-open-wireless-lab/DAWN.git
   DEPENDS:=$(DRV_DEPENDS) +libubus +libubox +libblobmsg-json +libuci +libgcrypt +libiwinfo +umdns

--- a/net/dnscrypt-proxy/Makefile
+++ b/net/dnscrypt-proxy/Makefile
@@ -33,6 +33,7 @@ define Package/dnscrypt-proxy/Default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=IP Addresses and Names
+  TITLE:=DNSCrypt-Proxy by Dyne, not actively maintained
   URL:=https://github.com/dyne/dnscrypt-proxy
 endef
 

--- a/net/dnscrypt-proxy2/Makefile
+++ b/net/dnscrypt-proxy2/Makefile
@@ -36,6 +36,7 @@ define Package/dnscrypt-proxy2
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Flexible DNS proxy with encrypted DNS protocols
+  SUBMENU:=IP Addresses and Names
   URL:=https://github.com/DNSCrypt/dnscrypt-proxy
   DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
   CONFLICTS:=dnscrypt-proxy

--- a/net/family-dns/Makefile
+++ b/net/family-dns/Makefile
@@ -17,6 +17,7 @@ define Package/family-dns
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=Family DNS
+	SUBMENU:=IP Addresses and Names
 	PKGARCH:=all
 endef
 

--- a/net/git-lfs/Makefile
+++ b/net/git-lfs/Makefile
@@ -32,6 +32,7 @@ define Package/git-lfs
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Git Large File Storage
+  SUBMENU:=Version Control Systems
   URL:=https://git-lfs.com
   DEPENDS:=$(GO_ARCH_DEPENDS) +git
 endef

--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -30,6 +30,7 @@ define Package/https-dns-proxy
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=DNS Over HTTPS Proxy
+	SUBMENU:=IP Addresses and Names
 	URL:=https://github.com/stangri/https-dns-proxy/
 	DEPENDS:=+libcares +libcurl +libev +ca-bundle +jsonfilter +resolveip
 	DEPENDS+=+!BUSYBOX_DEFAULT_GREP:grep

--- a/net/mdns-repeater/Makefile
+++ b/net/mdns-repeater/Makefile
@@ -24,6 +24,7 @@ define Package/mdns-repeater
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Multicast DNS repeater for Linux
+  SUBMENU:=IP Addresses and Names
   URL:=https://github.com/kennylevinsen/mdns-repeater
 endef
 

--- a/net/nextdns/Makefile
+++ b/net/nextdns/Makefile
@@ -34,6 +34,7 @@ define Package/nextdns
   SECTION:=net
   CATEGORY:=Network
   TITLE:=NextDNS DNS over HTTPS Proxy
+  SUBMENU:=IP Addresses and Names
   URL:=https://github.com/nextdns/nextdns
   DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
 endef

--- a/net/onionshare-cli/Makefile
+++ b/net/onionshare-cli/Makefile
@@ -31,6 +31,7 @@ define Package/onionshare-cli
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Secure chat, web and file sharing
+  SUBMENU:=File Transfer
   URL:=https://onionshare.org/
   DEPENDS:= \
     +python3-light \

--- a/net/smartdns/Makefile
+++ b/net/smartdns/Makefile
@@ -29,6 +29,7 @@ define Package/smartdns
   SECTION:=net
   CATEGORY:=Network
   TITLE:=smartdns server
+  SUBMENU:=IP Addresses and Names
   DEPENDS:=+libpthread +libopenssl
   URL:=https://www.github.com/pymumu/smartdns/
 endef

--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -27,7 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
 define Package/xray/template
-  TITLE:=A platform for building proxies to bypass network restrictions
+  TITLE:=A proxy platform to bypass network restrictions
   SECTION:=net
   CATEGORY:=Network
   URL:=https://xtls.github.io


### PR DESCRIPTION
Add SUBMENU variable for some packages in Network category. Add title for `dnscrypt-proxy` package.

Filesystem:
- cifs-utils

File Transfer:
- onionshare-cli

IP Addresses and Names:
- dnscrypt-proxy2
- family-dns
- https-dns-proxy
- mdns-repeater
- nextdns
- smartdns

Version Control Systems:
- git-lfs

Web Servers/Proxies:
- xray-core

Wireless:
- dawn

Maintainer: Should I ping all maintainers for these packages?
Compile tested: no, simple commit
Run tested: no

Description:
