### PR TITLE
v2ray-core: Bump to 5.22.0

### DIFF
--- a/net/v2ray-core/Makefile
+++ b/net/v2ray-core/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v2ray-core
-PKG_VERSION:=5.21.0
+PKG_VERSION:=5.22.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/v2fly/v2ray-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=880a929caff7b72ef9d3b9a3262cec0dff6566c2481989822a6b27fdaaeed975
+PKG_HASH:=df25a873c8f7fb30f44cb6d26b18db264dfa209df5aeb6116fc43df7157fb4b8
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -30,7 +30,7 @@ include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
 define Package/v2ray/template
-  TITLE:=A platform for building proxies to bypass network restrictions
+  TITLE:=A proxy platform to bypass network restrictions
   SECTION:=net
   CATEGORY:=Network
   URL:=https://www.v2fly.org


### PR DESCRIPTION
Shorten TITLE variable to fix missing title in ncurses menu. Add SUBMENU variable to make this package appear in `Web Server/Proxies` menu.
Release notes and changes logs in the link below.

Link: https://github.com/v2fly/v2ray-core/releases/tag/v5.22.0
Link: https://github.com/v2fly/v2ray-core/compare/v5.21.0...v5.22.0

Maintainer: @1715173329 :smiling_face_with_three_hearts:   
Compile tested: bcm2711 afffcd09e5f15be53f327a80ee87d391312eb805
Run tested: no, theoretically it should work as is 

Description:
