### PR TITLE
hev-socks5-tunnel: update to 2.7.5

### DIFF
--- a/net/hev-socks5-tunnel/Makefile
+++ b/net/hev-socks5-tunnel/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hev-socks5-tunnel
-PKG_VERSION:=2.7.3
+PKG_VERSION:=2.7.5
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/heiher/hev-socks5-tunnel/releases/download/$(PKG_VERSION)
-PKG_HASH:=613c4132cfed26ccd6e9f59a3e8590723f07969ac677f4957cbe000b13737fea
+PKG_HASH:=a6dffa86d1a4f95025386a666628781415fb15e3d8e846d777e5a06086e5c769
 
 PKG_MAINTAINER:=Ray Wang <r@hev.cc>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: armsr, arm64, snapshot/23.05
Run tested: arms4, arm64, 23.05, tests done

Description: update to 2.7.5