### PR TITLE
acme-common: Create challenge directory on boot

### DIFF
--- a/net/acme-common/Makefile
+++ b/net/acme-common/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-common
-PKG_VERSION:=1.4.0
+PKG_VERSION:=1.4.1
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/acme-common/files/acme.init
+++ b/net/acme-common/files/acme.init
@@ -1,5 +1,6 @@
 #!/bin/sh /etc/rc.common
 
+START=20
 USE_PROCD=1
 run_dir=/var/run/acme
 export CHALLENGE_DIR=$run_dir/challenge
@@ -156,4 +157,9 @@ start_service() {
 service_triggers() {
 	procd_add_config_trigger config.change acme \
 		/etc/init.d/acme start
+}
+
+boot() {
+        mkdir -p "$CHALLENGE_DIR"
+        return 0
 }


### PR DESCRIPTION
The challenge directory (for webroot challenges) is on a tmpfs, which means it
doesn't exist on boot. @mipopa reported that some web servers (uhttpd in
particular) don't like being configured to serve files from a non-existent
directory. So add a boot() section to the ACME init script that just creates the
challenge directory, and make sure it runs relatively early. That should take
care of the non-existent directory issue, while still keeping the actual
certificate renewal controlled by cron.

-------

Maintainer: me
Compile tested: No
Run tested: No