### PR TITLE
alist: Bump to 3.39.4, web-dist to 3.39.2

### DIFF
--- a/net/alist/Makefile
+++ b/net/alist/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alist
-PKG_VERSION:=3.39.1
+PKG_VERSION:=3.39.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/alist-org/alist/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=f211a3b35b6c600a94dbee9041cb5e167284613be383c5944afef6b0b86ab330
+PKG_SOURCE_URL:=https://codeload.github.com/AlistGo/alist/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=c455b3fc14f4fd2b81ce1a590113027e3cb278a66a77fd5d21f3a295eb3ea987
 
 PKG_LICENSE:=AGPL-3.0-only
 PKG_LICENSE_FILES:=LICENSE
@@ -49,13 +49,13 @@ define Package/alist/conffiles
 /etc/config/alist
 endef
 
-WEB_VERSION:=3.39.0
+WEB_VERSION:=3.39.2
 WEB_FILE:=$(PKG_NAME)-web-$(WEB_VERSION).tar.gz
 define Download/alist-web
-	URL:=https://github.com/alist-org/alist-web/releases/download/$(WEB_VERSION)/
+	URL:=https://github.com/AlistGo/alist-web/releases/download/$(WEB_VERSION)/
 	URL_FILE:=dist.tar.gz
 	FILE:=$(WEB_FILE)
-	HASH:=59f5dae6fed76ca708b12a7a6323ef85cdee48861ffafb8864c785b7d7c36e89
+	HASH:=d998315aff5544e7d7248214d02a3b04a92366bf0ac50fb4791b23833e8b543a
 endef
 
 define Build/Prepare


### PR DESCRIPTION
alist 3.39.4:
- release: Missing installation of zig
  -  by @xhofe (0ba75)
web-dist 3.39.2:
- No significant changes.

No release notes available, providing diff in link below instead.

Close: #25405
Link: https://github.com/AlistGo/alist/compare/v3.39.3...v3.39.4
Link: https://github.com/AlistGo/alist-web/compare/3.39.0...3.39.2

Maintainer: @1715173329 
Compile tested: bcm2711
Run tested: not
Description:
