### PR TITLE
iperf3: fix crashing with musl

### DIFF
--- a/net/iperf3/Makefile
+++ b/net/iperf3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
 PKG_VERSION:=3.17.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.es.net/pub/iperf

--- a/net/iperf3/patches/030-musl-crash.patch
+++ b/net/iperf3/patches/030-musl-crash.patch
@@ -1,0 +1,19 @@
+From 3da07ae96f5b40f76b75e1ccd4b20267f6a5988e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jakub=20Kul=C3=ADk?= <kulikjak@gmail.com>
+Date: Wed, 28 Aug 2024 09:43:04 +0200
+Subject: [PATCH] remove incorrect freeaddrinfo call
+
+---
+ src/net.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+--- a/src/net.c
++++ b/src/net.c
+@@ -145,7 +145,6 @@ create_socket(int domain, int proto, con
+     if ((gerror = getaddrinfo(server, portstr, &hints, &server_res)) != 0) {
+ 	if (local)
+ 	    freeaddrinfo(local_res);
+-        freeaddrinfo(server_res);
+         return -1;
+     }
+ 


### PR DESCRIPTION
Upstream backport.

Maintainer: @nbd168 