### PR TITLE
[23.05] openwisp-monitoring: align PKG_SOURCE_VERSION with PKG_VERSION

### DIFF
--- a/admin/openwisp-monitoring/Makefile
+++ b/admin/openwisp-monitoring/Makefile
@@ -6,16 +6,16 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openwisp-monitoring
 PKG_VERSION:=0.2.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Federico Capoano <support@openwisp.io>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE_URL:=https://github.com/openwisp/openwrt-openwisp-monitoring.git
-PKG_MIRROR_HASH:=86990e9c09b3917dd1e335f3152e0508838ad2632701c33a407d06c5dcad92d0
+PKG_MIRROR_HASH:=aad91b9a1cd08e23782a4f55e27c6af5502f1dff1e91cf10bcd6d99d939641f0
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=0.1.1
+PKG_SOURCE_VERSION:=$(PKG_VERSION)
 PKGARCH:=all
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: @nemesifier
Compile tested: ramips
Run tested: ramips


Description:
Previously, `PKG_SOURCE_VERSION` in the Makefile was incorrectly set to `0.1.1` instead of tracking `PKG_VERSION`. This mismatch caused compilation issues for the package.

This fix ensures `PKG_SOURCE_VERSION` dynamically aligns with `PKG_VERSION` to prevent future discrepancies.



