### PR TITLE
rtty: update to 8.1.3

### DIFF
--- a/utils/rtty/Makefile
+++ b/utils/rtty/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtty
-PKG_VERSION:=8.1.2
+PKG_VERSION:=8.1.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://github.com/zhaojh329/rtty/releases/download/v$(PKG_VERSION)
-PKG_HASH:=522b0fc5e032c3b84ac707abce8ac4ff5609900011f8f300ce4f4246abac0acc
+PKG_HASH:=d31596cb601d88b2cf651ee5497e22000b7a855f80c872ac2b411fc272c83d13
 
 PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: x86, x86, master
Run tested: x86, x86, master, tests done

Description:
Release notes for 8.1.3: https://github.com/zhaojh329/rtty/releases/tag/v8.1.3