### PR TITLE
ncdu: update to 1.21

### DIFF
--- a/utils/ncdu/Makefile
+++ b/utils/ncdu/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ncdu
-PKG_VERSION:=1.20
+PKG_VERSION:=1.21
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dev.yorhel.nl/download
-PKG_HASH:=5fe2bb841abe72374bb242dbb93293c4ae053078432d896a7481b2ff10be9572
+PKG_HASH:=a894d3a9b46bce578a6039bef48f54533ec402fb589b0769bfbb1d1edf9601a6
 
 PKG_MAINTAINER:=Charles E. Lehner <cel@celehner.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Release history:
```
* Perform tilde expansion on paths in the config file (from 2.7)
* Fix JSON import of escaped UTF-16 surrogate pairs (from 2.7)
* Fix displaying and exporting zero values when extended info is not available (from 2.6)
* Fix JSON export and import of the “other filesystem” flag (from 2.5)
```
Maintainer: @clehner