### PR TITLE
node: upgrade to 22.11.0 LTS

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=20.18.0
-PKG_RELEASE:=2
+PKG_VERSION:=22.11.0
+PKG_RELEASE:=1
+NODE_MODULE_VERSION:=127
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nodejs.org/dist/v$(PKG_VERSION)
-PKG_HASH:=c0819f8fc5038584d24c22002aeffd23f2d4a6fd6b337b30c502cbe4a659720c
+PKG_HASH:=24e5130fa7bc1eaab218a0c9cb05e03168fa381bb9e3babddc6a11f655799222
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)-v$(PKG_VERSION)
 
@@ -42,6 +43,7 @@ define Package/node
   DEPENDS:=@HAS_FPU @(i386||x86_64||arm||aarch64) \
 	   +libstdcpp +libopenssl +zlib +libnghttp2 \
 	   +libcares +libatomic +NODEJS_ICU_SYSTEM:icu +NODEJS_ICU_SYSTEM:icu-full-data
+  ABI_VERSION:=$(NODE_MODULE_VERSION)
 endef
 
 define Package/node/description

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,6 +1,6 @@
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1650,7 +1650,8 @@ Module._initPaths = function() {
+@@ -1779,7 +1779,8 @@ Module._initPaths = function() {
      path.resolve(process.execPath, '..') :
      path.resolve(process.execPath, '..', '..');
  

--- a/lang/node/patches/004-musl_support.patch
+++ b/lang/node/patches/004-musl_support.patch
@@ -20,7 +20,7 @@
    result = clock_gettime(CLOCK_MONOTONIC, &ts);
 --- a/deps/v8/src/base/platform/platform-posix.cc
 +++ b/deps/v8/src/base/platform/platform-posix.cc
-@@ -1147,7 +1147,7 @@ bool Thread::Start() {
+@@ -1207,7 +1207,7 @@ bool Thread::Start() {
  #if V8_OS_DARWIN
      // Default on Mac OS X is 512kB -- bump up to 1MB
      stack_size = 1 * 1024 * 1024;

--- a/lang/node/patches/007-fix_host_build_on_macos.patch
+++ b/lang/node/patches/007-fix_host_build_on_macos.patch
@@ -1,11 +1,11 @@
 --- a/tools/gyp/pylib/gyp/generator/make.py
 +++ b/tools/gyp/pylib/gyp/generator/make.py
-@@ -207,7 +207,7 @@ cmd_solink_module = $(LINK.$(TOOLSET)) -
+@@ -208,7 +208,7 @@ cmd_solink_module = $(LINK.$(TOOLSET)) -
  
  LINK_COMMANDS_MAC = """\
  quiet_cmd_alink = LIBTOOL-STATIC $@
--cmd_alink = rm -f $@ && ./gyp-mac-tool filter-libtool libtool $(GYP_LIBTOOLFLAGS) -static -o $@ $(filter %.o,$^)
-+cmd_alink = rm -f $@ && ./gyp-mac-tool filter-libtool /usr/bin/libtool $(GYP_LIBTOOLFLAGS) -static -o $@ $(filter %.o,$^)
+-cmd_alink = rm -f $@ && %(python)s gyp-mac-tool filter-libtool libtool $(GYP_LIBTOOLFLAGS) -static -o $@ $(filter %%.o,$^)
++cmd_alink = rm -f $@ && %(python)s gyp-mac-tool filter-libtool /usr/bin/libtool $(GYP_LIBTOOLFLAGS) -static -o $@ $(filter %%.o,$^)
  
  quiet_cmd_link = LINK($(TOOLSET)) $@
  cmd_link = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o "$@" $(LD_INPUTS) $(LIBS)

--- a/lang/node/patches/202-node_gyp.patch
+++ b/lang/node/patches/202-node_gyp.patch
@@ -1,6 +1,6 @@
 --- a/node.gyp
 +++ b/node.gyp
-@@ -1305,6 +1305,7 @@
+@@ -1350,6 +1350,7 @@
        'dependencies': [
          'deps/simdutf/simdutf.gyp:simdutf#host',
        ],

--- a/lang/node/patches/203-icu-generic_gyp.patch
+++ b/lang/node/patches/203-icu-generic_gyp.patch
@@ -16,7 +16,7 @@
              'include_dirs': [
                '<(icu_path)/source/i18n',
              ],
-@@ -200,6 +202,7 @@
+@@ -223,6 +225,7 @@
                # full data - no trim needed
                'sources': [ '<(SHARED_INTERMEDIATE_DIR)/icudt<(icu_ver_major)_dat.<(icu_asm_ext)' ],
                'dependencies': [ 'genccode#host', 'icupkg#host', 'icu_implementation#host', 'icu_uconfig' ],
@@ -24,7 +24,7 @@
                'include_dirs': [
                  '<(icu_path)/source/common',
                ],
-@@ -284,6 +287,7 @@
+@@ -307,6 +310,7 @@
                # This file contains the small ICU data
                'sources': [ '<(SHARED_INTERMEDIATE_DIR)/icusmdt<(icu_ver_major)_dat.<(icu_asm_ext)' ],
                # for umachine.h
@@ -32,7 +32,7 @@
                'include_dirs': [
                  '<(icu_path)/source/common',
                ],
-@@ -300,6 +304,7 @@
+@@ -323,6 +327,7 @@
        'sources': [
          '<@(icu_src_stubdata)'
        ],
@@ -40,7 +40,7 @@
        'include_dirs': [
          '<(icu_path)/source/common',
        ],
-@@ -339,6 +344,7 @@
+@@ -362,6 +367,7 @@
            '_XOPEN_SOURCE_EXTENDED=0',
          ]}],
        ],
@@ -48,7 +48,7 @@
        'include_dirs': [
          '<(icu_path)/source/common',
        ],
-@@ -348,6 +354,7 @@
+@@ -371,6 +377,7 @@
        'cflags_c': ['-std=c99'],
        'export_dependent_settings': [ 'icu_uconfig', 'icu_uconfig_target' ],
        'direct_dependent_settings': {
@@ -56,7 +56,7 @@
          'include_dirs': [
            '<(icu_path)/source/common',
          ],
-@@ -378,6 +385,7 @@
+@@ -401,6 +408,7 @@
          '<(icu_path)/source/tools/toolutil/dbgutil.cpp',
          '<(icu_path)/source/tools/toolutil/dbgutil.h',
        ],
@@ -64,7 +64,7 @@
        'include_dirs': [
          '<(icu_path)/source/common',
          '<(icu_path)/source/i18n',
-@@ -397,6 +405,7 @@
+@@ -420,6 +428,7 @@
          }]
        ],
        'direct_dependent_settings': {
@@ -72,7 +72,7 @@
          'include_dirs': [
            '<(icu_path)/source/common',
            '<(icu_path)/source/i18n',
-@@ -418,6 +427,7 @@
+@@ -441,6 +450,7 @@
        'target_name': 'genrb',
        'type': 'executable',
        'toolsets': [ 'host' ],
@@ -80,7 +80,7 @@
        'dependencies': [ 'icutools', 'icu_implementation' ],
        'sources': [
          '<@(icu_src_genrb)'
-@@ -440,6 +450,7 @@
+@@ -463,6 +473,7 @@
        'target_name': 'iculslocs',
        'toolsets': [ 'host' ],
        'type': 'executable',
@@ -88,7 +88,7 @@
        'dependencies': [ 'icutools' ],
        'sources': [
          'iculslocs.cc',
-@@ -458,6 +469,7 @@
+@@ -481,6 +492,7 @@
        'target_name': 'icupkg',
        'toolsets': [ 'host' ],
        'type': 'executable',
@@ -96,7 +96,7 @@
        'dependencies': [ 'icutools' ],
        'sources': [
          '<@(icu_src_icupkg)',
-@@ -475,6 +487,7 @@
+@@ -498,6 +510,7 @@
        'target_name': 'genccode',
        'toolsets': [ 'host' ],
        'type': 'executable',

--- a/lang/node/patches/204-v8_gyp.patch
+++ b/lang/node/patches/204-v8_gyp.patch
@@ -24,17 +24,17 @@
          'include_dirs': [
            '<(generate_bytecode_output_root)',
            '<(SHARED_INTERMEDIATE_DIR)',
-@@ -252,6 +255,7 @@
+@@ -253,6 +256,7 @@
        'sources': [
          '<(V8_ROOT)/src/init/setup-isolate-full.cc',
        ],
 +      'include_dirs': [ '<!@(echo "$STAGING_DIR"/usr/../usr/include)' ],
      },  # v8_init
      {
-       'target_name': 'v8_initializers',
-@@ -263,9 +267,11 @@
-         'v8_shared_internal_headers',
+       # This target is used to work around a GCC issue that causes the
+@@ -294,9 +298,11 @@
          'v8_pch',
+         'v8_abseil',
        ],
 +      'include_dirs!': [ '<!@(echo "$STAGING_DIR"/usr/include)' ],
        'include_dirs': [
@@ -44,7 +44,7 @@
        ],
        'sources': [
          '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_initializers.*?sources = ")',
-@@ -694,6 +700,7 @@
+@@ -820,6 +826,7 @@
        'toolsets': ['host', 'target'],
        'direct_dependent_settings': {
          'sources': ['<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_compiler_sources = ")'],
@@ -52,7 +52,7 @@
          'conditions': [
            ['v8_target_arch=="ia32"', {
              'sources': [
-@@ -802,6 +809,8 @@
+@@ -929,6 +936,8 @@
        'target_name': 'v8_turboshaft',
        'type': 'static_library',
        'toolsets': ['host', 'target'],
@@ -61,7 +61,7 @@
        'dependencies': [
          'generate_bytecode_builtins_list',
          'run_torque',
-@@ -826,6 +835,7 @@
+@@ -968,6 +977,7 @@
          'run_torque',
          'v8_maybe_icu',
        ],
@@ -69,7 +69,7 @@
        'conditions': [
          ['(is_component_build and not v8_optimized_debug and v8_enable_fast_mksnapshot) or v8_enable_turbofan==0', {
            'dependencies': [
-@@ -866,6 +876,7 @@
+@@ -1010,6 +1020,7 @@
        ],
        'includes': ['inspector.gypi'],
        'direct_dependent_settings': {
@@ -77,7 +77,7 @@
          'include_dirs': [
            '<(generate_bytecode_output_root)',
            '<(SHARED_INTERMEDIATE_DIR)',
-@@ -1495,6 +1506,7 @@
+@@ -1647,6 +1658,7 @@
          }],
        ],
        'direct_dependent_settings': {
@@ -85,7 +85,7 @@
          'include_dirs': [
            '<(V8_ROOT)/include',
          ],
-@@ -1515,6 +1527,7 @@
+@@ -1667,6 +1679,7 @@
      {
        'target_name': 'bytecode_builtins_list_generator',
        'type': 'executable',
@@ -93,7 +93,7 @@
        'conditions': [
          ['want_separate_host_toolset', {
            'toolsets': ['host'],
-@@ -1543,6 +1556,9 @@
+@@ -1695,6 +1708,9 @@
      {
        'target_name': 'mksnapshot',
        'type': 'executable',
@@ -103,7 +103,7 @@
        'dependencies': [
          'v8_base_without_compiler',
          'v8_compiler_for_mksnapshot',
-@@ -1570,6 +1586,7 @@
+@@ -1723,6 +1739,7 @@
      {
        'target_name': 'torque',
        'type': 'executable',
@@ -111,7 +111,7 @@
        'dependencies': [
          'torque_base',
          # "build/win:default_exe_manifest",
-@@ -1612,6 +1629,7 @@
+@@ -1765,6 +1782,7 @@
      {
        'target_name': 'torque-language-server',
        'type': 'executable',
@@ -119,7 +119,7 @@
        'conditions': [
          ['want_separate_host_toolset', {
            'toolsets': ['host'],
-@@ -1643,6 +1661,8 @@
+@@ -1796,6 +1814,8 @@
      {
        'target_name': 'gen-regexp-special-case',
        'type': 'executable',
@@ -128,7 +128,7 @@
        'dependencies': [
          'v8_libbase',
          # "build/win:default_exe_manifest",
-@@ -1861,6 +1881,7 @@
+@@ -2036,6 +2056,7 @@
           }],
        ],
        'direct_dependent_settings': {
@@ -136,7 +136,7 @@
          'include_dirs': [
            '<(V8_ROOT)/include',
          ],
-@@ -1982,15 +2003,19 @@
+@@ -2175,15 +2196,19 @@
          }],
        ],
        'direct_dependent_settings': {

--- a/lang/node/patches/999-fix_building_with_system_icu_76.patch
+++ b/lang/node/patches/999-fix_building_with_system_icu_76.patch
@@ -14,7 +14,7 @@ symbols/references when trying to build with system ICU 76.
 
 --- a/configure.py
 +++ b/configure.py
-@@ -1829,7 +1829,7 @@ def configure_intl(o):
+@@ -1876,7 +1876,7 @@ def configure_intl(o):
    elif with_intl == 'system-icu':
      # ICU from pkg-config.
      o['variables']['v8_enable_i18n_support'] = 1

--- a/lang/node/patches/999-localhost-no-addrconfig.patch
+++ b/lang/node/patches/999-localhost-no-addrconfig.patch
@@ -13,7 +13,7 @@ Forwarded: https://github.com/nodejs/node/issues/33816
  //
  // Permission is hereby granted, free of charge, to any person obtaining a
  // copy of this software and associated documentation files (the
-@@ -1339,13 +1340,6 @@ function lookupAndConnect(self, options)
+@@ -1342,13 +1343,6 @@ function lookupAndConnect(self, options)
      hints: options.hints || 0,
    };
  

--- a/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
+++ b/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
@@ -1,6 +1,6 @@
 --- a/node.gyp
 +++ b/node.gyp
-@@ -1306,6 +1306,7 @@
+@@ -1351,6 +1351,7 @@
          'deps/simdutf/simdutf.gyp:simdutf#host',
        ],
        'libraries!':[ '-licui18n', '-licuuc', '-licudata', '-lcrypto', '-lssl', '-lz', '-lhttp_parser', '-luv', '-lnghttp2', '-lcares' ],


### PR DESCRIPTION
Maintainer: me @ianchi
Compile tested: head, aarch64, arm, i386, x86_64
Run tested: (qemu 9.1.1) aarch64

Description:
Upgrade Version 22.11.0 'Jod' (LTS)

Notable Changes

This release marks the transition of Node.js 22.x into Long Term Support (LTS) with the codename 'Jod'. The 22.x release line now moves into "Active LTS" and will remain so until October 2025. After that time, it will move into "Maintenance" until end of life in April 2027.