### PR TITLE
Reduce python dependencies

### DIFF
--- a/lang/python/python-cryptography/Makefile
+++ b/lang/python/python-cryptography/Makefile
@@ -35,7 +35,6 @@ define Package/python3-cryptography
       +libopenssl \
       +libopenssl-legacy \
       +python3-light \
-      +python3-email \
       +python3-urllib \
       +python3-cffi \
       $(RUST_ARCH_DEPENDS)

--- a/lang/python/python-urllib3/Makefile
+++ b/lang/python/python-urllib3/Makefile
@@ -34,7 +34,7 @@ define Package/python3-urllib3
   CATEGORY:=Languages
   TITLE:=Sanity-friendly HTTP client
   URL:=https://urllib3.readthedocs.io/
-  DEPENDS:=+python3
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-urllib3/description


### PR DESCRIPTION
Maintainer: grosjo
Compile tested: ath79, 24.10
Run tested: ath79, 24.10

Description:
Purpose is to reduce the number of libraries and related size that are useless for some modules