### PR TITLE
net-snmp: refactor Makefile for optional variant with openssl and logging

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -37,6 +37,20 @@ define Package/net-snmp/Default/description
 endef
 
 
+define Package/net-snmp-ssl
+$(call Package/net-snmp/Default)
+  TITLE:= Open source SNMP package - with Openssl
+  DEPENDS:= \
+	    +libnetsnmp-ssl \
+	    +snmpd-ssl \
+	    +snmp-mibs \
+	    +snmptrapd-ssl \
+	    +snmp-utils-ssl
+  VARIANT:=ssl
+  CONFLICTS:=net-snmp
+endef
+
+
 define Package/net-snmp
 $(call Package/net-snmp/Default)
   TITLE:= Open source SNMP package - without Openssl
@@ -65,10 +79,24 @@ $(call Package/libnetsnmp/Default)
   VARIANT:=nossl
 endef
 
+define Package/libnetsnmp-ssl
+$(call Package/libnetsnmp)
+  DEPENDS+=+libopenssl
+  TITLE+= - with openssl
+  VARIANT:=ssl
+  CONFLICTS:=libnetsnmp
+endef
+
+
 define Package/libnetsnmp/description
 $(call Package/net-snmp/Default/description)
  .
  This package contains shared libraries, needed by other programs.
+endef
+
+define Package/libnetsnmp-ssl/description
+$(call Package/libnetsnmp/description)
+ This package is built with SSL support.
 endef
 
 
@@ -76,6 +104,7 @@ define Package/snmp-mibs
 $(call Package/net-snmp/Default)
   TITLE:=Open source SNMP implementation (MIB-files)
 endef
+
 
 define Package/snmp-mibs/description
 $(call Package/net-snmp/Default/description)
@@ -88,6 +117,16 @@ define Package/snmp-utils/Default
 $(call Package/net-snmp/Default)
   TITLE:=Open source SNMP implementation (utilities)
 endef
+
+
+define Package/snmp-utils-ssl
+$(call Package/snmp-utils/Default)
+  DEPENDS:=+libnetsnmp-ssl
+  VARIANT:=ssl
+  TITLE+= - with Openssl
+  CONFLICTS:=snmp-utils
+endef
+
 
 define Package/snmp-utils
 $(call Package/snmp-utils/Default)
@@ -109,6 +148,7 @@ $(call Package/net-snmp/Default/description)
    - snmpwalk
 endef
 
+Package/snmp-utils-ssl/description = $(Package/snmp-utils/descripition/Default)
 Package/snmp-utils/description = $(Package/snmp-utils/descripition/Default)
 
 
@@ -127,6 +167,18 @@ $(call Package/net-snmp/Default/description)
 endef
 
 
+define Package/snmpd-ssl
+$(call Package/net-snmp/Default)
+  DEPENDS:=+libnetsnmp-ssl
+  VARIANT:=ssl
+  TITLE:=Open source SNMP implementation (daemon) with Openssl encryption
+  CONFLICTS:=snmpd
+endef
+
+
+Package/snmpd-ssl/description = $(Package/snmpd/description)
+
+
 define Package/snmpd-static
 $(call Package/net-snmp/Default)
   DEPENDS:=+snmpd
@@ -138,6 +190,14 @@ endef
 define Package/snmptrapd/Default
 $(call Package/net-snmp/Default)
   TITLE:=Open source SNMP implementation (notification receiver)
+endef
+
+define Package/snmptrapd-ssl
+$(call Package/snmptrapd/Default)
+  DEPENDS:=+libnetsnmp-ssl
+  VARIANT:=ssl
+  TITLE+= - with Openssl
+  CONFLICTS:=snmptrapd
 endef
 
 define Package/snmptrapd
@@ -155,6 +215,7 @@ $(call Package/net-snmp/Default/description)
 endef
 
 
+Package/snmptrapd-ssl/description = $(Package/snmpdtrapd/description/Default)
 Package/snmptrapd/description = $(Package/snmpdtrapd/description/Default)
 
 
@@ -247,7 +308,6 @@ CONFIGURE_ARGS += \
 	--with-mib-modules="$(SNMP_MIB_MODULES_INCLUDED)" \
 	--with-out-transports="$(SNMP_TRANSPORTS_EXCLUDED)" \
 	--with-transports="$(SNMP_TRANSPORTS_INCLUDED)" \
-	--without-openssl \
 	--without-libwrap \
 	--without-mysql \
 	--without-rpm \
@@ -265,6 +325,12 @@ CONFIGURE_VARS += \
 
 ifeq ($(CONFIG_IPV6),y)
 SNMP_TRANSPORTS_INCLUDED+= UDPIPv6
+endif
+
+ifeq ($(BUILD_VARIANT),ssl)
+ CONFIGURE_ARGS+= --with-openssl="$(STAGING_DIR)/usr"
+else
+ CONFIGURE_ARGS+= --without-openssl
 endif
 
 define Build/Compile
@@ -292,6 +358,11 @@ define Package/libnetsnmp/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetsnmp{,agent,helpers,mibs}.so.* $(1)/usr/lib/
 endef
 
+
+define Package/libnetsnmp-ssl/install
+$(call Package/libnetsnmp/install,$(1))
+endef
+
 define Package/snmp-mibs/install
 	$(INSTALL_DIR) $(1)/usr/share/snmp/mibs
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/snmp/mibs/* $(1)/usr/share/snmp/mibs/
@@ -302,6 +373,7 @@ define Package/snmp-utils/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/snmp{get,set,status,test,trap,walk} $(1)/usr/bin/
 endef
 
+define Package/snmp-utils-ssl/install
 $(call Package/snmp-utils/install,$(1))
 endef
 
@@ -309,6 +381,7 @@ define Package/snmpd/conffiles/Default
 /etc/config/snmpd
 endef
 
+Package/snmpd-ssl/conffiles = $(Package/snmpd/conffiles/Default)
 Package/snmpd/conffiles = $(Package/snmpd/conffiles/Default)
 
 define Package/snmpd/install
@@ -322,6 +395,11 @@ define Package/snmpd/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/snmpd $(1)/usr/sbin/snmpd
 endef
 
+
+define Package/snmpd-ssl/install
+$(call Package/snmpd/install,$(1))
+endef
+
 define Package/snmptrapd/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/snmptrapd.init $(1)/etc/init.d/snmptrapd
@@ -331,10 +409,21 @@ define Package/snmptrapd/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/snmptrapd $(1)/usr/sbin/
 endef
 
+
+define Package/snmptrapd-ssl/install
+$(call Package/snmptrapd/install,$(1))
+endef
+
+
 $(eval $(call BuildPackage,libnetsnmp))
+$(eval $(call BuildPackage,libnetsnmp-ssl))
 $(eval $(call BuildPackage,snmp-mibs))
 $(eval $(call BuildPackage,snmp-utils))
+$(eval $(call BuildPackage,snmp-utils-ssl))
 $(eval $(call BuildPackage,snmpd))
+$(eval $(call BuildPackage,snmpd-ssl))
 $(eval $(call BuildPackage,snmpd-static))
 $(eval $(call BuildPackage,snmptrapd))
+$(eval $(call BuildPackage,snmptrapd-ssl))
 $(eval $(call BuildPackage,net-snmp))
+$(eval $(call BuildPackage,net-snmp-ssl))

--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.9.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp
@@ -37,12 +37,32 @@ define Package/net-snmp/Default/description
 endef
 
 
-define Package/libnetsnmp
+define Package/net-snmp
 $(call Package/net-snmp/Default)
+  TITLE:= Open source SNMP package - without Openssl
+  DEPENDS:= \
+	    +libnetsnmp \
+	    +snmpd \
+	    +snmp-mibs \
+	    +snmptrapd \
+	    +snmp-utils
+  VARIANT:=nossl
+  DEFAULT_VARIANT:=1
+  PROVIDES:=net-snmp
+endef
+
+define Package/libnetsnmp/Default
+$(call Package/net-snmp/Default)
+  TITLE:=Open source SNMP implementation (libraries)
   SECTION:=libs
   CATEGORY:=Libraries
   DEPENDS:=+libnl-tiny +libpci +libpcre2
-  TITLE:=Open source SNMP implementation (libraries)
+endef
+
+define Package/libnetsnmp
+$(call Package/libnetsnmp/Default)
+  PROVIDES:=libnetsnmp
+  VARIANT:=nossl
 endef
 
 define Package/libnetsnmp/description
@@ -64,13 +84,20 @@ $(call Package/net-snmp/Default/description)
 endef
 
 
-define Package/snmp-utils
+define Package/snmp-utils/Default
 $(call Package/net-snmp/Default)
-  DEPENDS:=+libnetsnmp
   TITLE:=Open source SNMP implementation (utilities)
 endef
 
-define Package/snmp-utils/description
+define Package/snmp-utils
+$(call Package/snmp-utils/Default)
+  DEPENDS:=+libnetsnmp
+  VARIANT:=nossl
+  TITLE+= - without Openssl
+endef
+
+
+define Package/snmp-utils/description/Default
 $(call Package/net-snmp/Default/description)
  .
  This package contains SNMP client utilities:
@@ -82,11 +109,15 @@ $(call Package/net-snmp/Default/description)
    - snmpwalk
 endef
 
+Package/snmp-utils/description = $(Package/snmp-utils/descripition/Default)
+
 
 define Package/snmpd
 $(call Package/net-snmp/Default)
   DEPENDS:=+libnetsnmp
+  VARIANT:=nossl
   TITLE:=Open source SNMP implementation (daemon)
+  PROVIDES:=snmpd
 endef
 
 define Package/snmpd/description
@@ -104,17 +135,27 @@ $(call Package/net-snmp/Default)
 endef
 
 
-define Package/snmptrapd
+define Package/snmptrapd/Default
 $(call Package/net-snmp/Default)
-  DEPENDS:=+libnetsnmp
   TITLE:=Open source SNMP implementation (notification receiver)
 endef
 
-define Package/snmptrapd/description
+define Package/snmptrapd
+$(call Package/snmptrapd/Default)
+  DEPENDS:=+libnetsnmp
+  VARIANT:=nossl
+  TITLE+= - without Openssl
+endef
+
+
+define Package/snmptrapd/description/Default
 $(call Package/net-snmp/Default/description)
  .
  This package contains the SNMP notification receiver.
 endef
+
+
+Package/snmptrapd/description = $(Package/snmpdtrapd/description/Default)
 
 
 SNMP_MIB_MODULES_INCLUDED = \
@@ -261,9 +302,14 @@ define Package/snmp-utils/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/snmp{get,set,status,test,trap,walk} $(1)/usr/bin/
 endef
 
-define Package/snmpd/conffiles
+$(call Package/snmp-utils/install,$(1))
+endef
+
+define Package/snmpd/conffiles/Default
 /etc/config/snmpd
 endef
+
+Package/snmpd/conffiles = $(Package/snmpd/conffiles/Default)
 
 define Package/snmpd/install
 	$(INSTALL_DIR) $(1)/etc/config
@@ -291,3 +337,4 @@ $(eval $(call BuildPackage,snmp-utils))
 $(eval $(call BuildPackage,snmpd))
 $(eval $(call BuildPackage,snmpd-static))
 $(eval $(call BuildPackage,snmptrapd))
+$(eval $(call BuildPackage,net-snmp))

--- a/net/net-snmp/files/snmpd.conf
+++ b/net/net-snmp/files/snmpd.conf
@@ -128,3 +128,21 @@ config engineid
 config snmpd general
 	option enabled '1'
 #	list network 'wan'
+#
+#config logging
+#	option log_file '0'
+#	option log_file_path '/var/log/snmpd.log'
+#	option log_file_priority 'info'
+#	option log_syslog '0'
+#	option log_syslog_facility 'daemon'
+#	option log_syslog_priority 'info'
+#
+#config v3
+#	option username 'John'
+#	option allow_write '0'
+#	option auth_type 'SHA|MD5'
+#	option auth_pass 'passphrase'
+#	option privacy_type 'AES|DES'
+#	option privacy_pass 'passphrase'
+#	option RestrictOID 'yes|no'
+#	option RestrictedOID '1.3.6.1.2.1.1.1'

--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -242,6 +242,66 @@ snmpd_sink_add() {
 	echo "$section $host$port $community" >> $CONFIGFILE
 }
 
+snmpd_snmpv3_add() {
+	local cfg="$1"
+	local cfg2="$2"
+
+	local version
+	local username
+	local auth_type
+	local auth_pass
+	local privacy_type
+	local privacy_pass
+	local allow_write
+	local oid
+
+	config_get version "$cfg2" snmp_version
+	if [ "$version" != "v1/v2c/v3" ] && [ "$version" != "v3" ]; then
+		return 0
+	fi
+
+	config_get username "$cfg" username
+	[ -n "$username" ] || return 0
+
+	config_get auth_type "$cfg" auth_type
+	[ -n "$auth_type" ] || return 0
+
+	config_get auth_pass "$cfg" auth_pass
+	config_get privacy_type "$cfg" privacy_type
+	config_get privacy_pass "$cfg" privacy_pass
+	config_get oid "$cfg" RestrictedOID
+
+	config_get_bool allow_write "$cfg" allow_write
+	local useraccess="Rouser"
+	[ $allow_write -eq 1 ] && useraccess="Rwuser"
+
+	if [ -n "$privacy_type" ] && [ -n "$auth_pass" ] && [ -n "$privacy_pass" ]; then
+		echo "createUser $username $auth_type \"$auth_pass\" $privacy_type \"$privacy_pass\"" >> $CONFIGFILE
+		if [ -n "$oid" ]; then
+			echo "$useraccess $username priv $oid" >> $CONFIGFILE
+		else
+			echo "$useraccess $username priv" >> $CONFIGFILE
+		fi
+		return
+	fi
+
+	if [ -n "$auth_type" ]; then
+		echo "createUser $username $auth_type \"$auth_pass\"" >> $CONFIGFILE
+		if [ -n "$oid" ]; then
+			echo "$useraccess $username auth $oid" >> $CONFIGFILE
+		else
+			echo "$useraccess $username auth" >> $CONFIGFILE
+		fi
+	else
+		echo "createUser $username" >> $CONFIGFILE
+		if [ -n "$oid" ]; then
+			echo "$useraccess $username noauth $oid" >> $CONFIGFILE
+		else
+			echo "$useraccess $username noauth" >> $CONFIGFILE
+		fi
+	fi
+}
+
 append_parm() {
 	local section="$1"
 	local option="$2"
@@ -284,6 +344,64 @@ snmpd_setup_fw_rules() {
 	HANDLED_SNMP_ZONES="$HANDLED_SNMP_ZONES $zone"
 }
 
+snmpd_configure_logging() {
+	local cfg="$1"
+	local log_syslog
+	local log_syslog_facility
+	local log_syslog_priority
+	local log_file
+	local log_file_path
+	local log_file_priority
+
+	config_get_bool log_syslog "$cfg" log_syslog 0
+
+	# d - LOG_DAEMON,
+	# u - LOG_USER,
+	# 0-7 - LOG_LOCAL0 through LOG_LOCAL7.
+
+	# 0 or ! - LOG_EMERG
+	# 1 or a - LOG_ALERT
+	# 2 or c - LOG_CRIT
+	# 3 or e - LOG_ERR
+	# 4 or w - LOG_WARN
+	# 5 or n - LOG_NOTICE
+	# 6 or i - LOG_INFO
+	# 7 or d - LOG_DEBUG
+
+	if [ "$log_syslog" -eq 1 ]; then
+		config_get log_syslog_facility "$cfg" log_syslog_facility "daemon"
+		config_get log_syslog_priority "$cfg" log_syslog_priority "info"
+
+		if [ "$log_syslog_facility" = "daemon" ] ||
+			[ "$log_syslog_facility" = "user" ]; then
+				log_syslog_facility=$(echo "$log_syslog_facility" |
+				cut -c 1)
+		else
+			log_syslog_facility=$(echo "$log_syslog_facility" |
+				cut -c 6)
+		fi
+
+		[ "$log_syslog_priority" = "emerg" ] && log_syslog_priority="!"
+		log_syslog_priority=$(echo "$log_syslog_priority" |
+			cut -c 1)
+
+		procd_append_param command "-LS ${log_syslog_priority} ${log_syslog_facility}"
+	fi
+
+	config_get_bool log_file "$cfg" log_file 0
+
+	if [ "$log_file" -eq 1 ]; then
+		config_get log_file_path "$cfg" log_file_path "/var/log/snmpd.log"
+		config_get log_file_priority "$cfg" log_file_priority "info"
+
+		[ "$log_file_priority" = "emerg" ] && log_file_priority="!"
+		log_file_priority=$(echo "$log_file_priority" | cut -c 1)
+
+		mkdir -p "$(dirname "${log_file_path}")"
+		procd_append_param command "-LF ${log_file_priority} ${log_file_path}"
+	fi
+}
+
 start_service() {
 	[ -f "$CONFIGFILE" ] && rm -f "$CONFIGFILE"
 
@@ -319,9 +437,11 @@ start_service() {
 	append_authtrapenable authtrapenable enable authtrapenable
 	append_parm v1trapaddress host v1trapaddress
 	append_parm trapsess trapsess trapsess
+	config_foreach snmpd_snmpv3_add v3 general
 
-	procd_set_param command $PROG -Lf /dev/null -f -r
-	procd_set_param file $CONFIGFILE
+	procd_set_param command $PROG -f -r -p "$pid_file"
+	config_foreach snmpd_configure_logging log
+	procd_append_param command -C -c $CONFIGFILE
 	procd_set_param respawn
 
 	for iface in $(ls /sys/class/net 2>/dev/null); do


### PR DESCRIPTION
Maintainer: @stintel 
Compile tested: x86_64, Openwrt 24.10
Run tested: x86_64, Openwrt 24.10

Description:
Openssl is needed to implement encryption and authentification for SNMPv3.
As discussed in PR #25178 , I added a variant for net-snmp that compiles libnetsnmp 
with libopenssl (for SNMPv3). The default compilation is with the former variant.

The features for SNMPv3 are added to snmpd.init file and the possibility
to log messages to syslog or a log file..