### PR TITLE
libinput: update and add support for libwacom

### DIFF
--- a/libs/libinput/Makefile
+++ b/libs/libinput/Makefile
@@ -5,13 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libinput
-PKG_VERSION:=1.25.0
+PKG_VERSION:=1.26.2
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://gitlab.freedesktop.org/libinput/libinput.git
-PKG_SOURCE_VERSION:=$(PKG_VERSION)
-PKG_MIRROR_HASH:=e2c4a46292a17d2e037ba4eb439c135e9834041993ac641e23c71fd5ddfceb72
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://gitlab.freedesktop.org/$(PKG_NAME)/$(PKG_NAME)/-/archive/$(PKG_VERSION)
+PKG_HASH:=5c1c4150f217fea1db2d1fd88e2607b2f1928cfde65c34da65a9f24dcfd69464
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT
@@ -26,7 +25,7 @@ define Package/libinput
   CATEGORY:=Libraries
   TITLE:=a library to handle input devices
   URL:=https://freedesktop.org/wiki/Software/libinput/
-  DEPENDS:=+libevdev +mtdev +libudev
+  DEPENDS:=+libevdev +mtdev +libudev +libwacom
 endef
 
 define Package/libinput/description
@@ -39,7 +38,7 @@ endef
 
 MESON_ARGS += \
 	-Depoll-dir=no \
-	-Dlibwacom=false \
+	-Dlibwacom=true \
 	-Ddebug-gui=false \
 	-Dtests=false \
 	-Dzshcompletiondir=no

--- a/libs/libwacom/Makefile
+++ b/libs/libwacom/Makefile
@@ -1,0 +1,63 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libwacom
+PKG_VERSION:=2.13.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/linuxwacom/$(PKG_NAME)/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
+PKG_HASH:=acd18121441bbc00fc5c881fca08a33319ab814b798eac8d0be6354923f8fb08
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+include $(INCLUDE_DIR)/meson.mk
+
+define Package/libwacom
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=a tablet description library
+  URL:=https://github.com/linuxwacom/libwacom
+  DEPENDS:=+glib2 +libevdev +libgudev
+endef
+
+define Package/libwacom/description
+libwacom is a library to identify graphics tablets and their model-specific
+features. It provides easy access to information such as "is this a built-in
+on-screen tablet", "what is the size of this model", etc.
+
+The name libwacom is historical - it was originally developed for Wacom devices
+only but now supports any graphics tablet from any vendor.
+endef
+
+MESON_ARGS += \
+	-Ddocumentation=disabled \
+	-Dtests=disabled
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/libwacom-1.0/libwacom
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libwacom-1.0/libwacom/*.h \
+		$(1)/usr/include/libwacom-1.0/libwacom
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc $(1)/usr/lib/pkgconfig
+endef
+
+define Package/libwacom/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/{udev,*.so*} $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/share/libwacom
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/libwacom/* $(1)/usr/share/libwacom
+endef
+
+$(eval $(call BuildPackage,libwacom))


### PR DESCRIPTION
Maintainer: me
Compile tested: mediatek/filogic, x86/64
Run tested: BananaPi R4 with USB keyboard, x86/64 laptop

Description:
Update libinput and build with support for tablets using libwacom.