### PR TITLE
[23.05] node: bump to v18.20.5

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v18.20.4
+PKG_VERSION:=v18.20.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=349259af6821f730bc4ca3a0e6576efc75ba86e546d118629a5b75eb8ebc3a0b
+PKG_HASH:=938735364745b7d4cd650b9325df6f2d2ec4240c56f9318e38638af910a820c6
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/007-fix_host_build_on_macos.patch
+++ b/lang/node/patches/007-fix_host_build_on_macos.patch
@@ -1,6 +1,6 @@
 --- a/tools/gyp/pylib/gyp/generator/make.py
 +++ b/tools/gyp/pylib/gyp/generator/make.py
-@@ -206,7 +206,7 @@ cmd_solink_module = $(LINK.$(TOOLSET)) -
+@@ -207,7 +207,7 @@ cmd_solink_module = $(LINK.$(TOOLSET)) -
  
  LINK_COMMANDS_MAC = """\
  quiet_cmd_alink = LIBTOOL-STATIC $@

--- a/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
+++ b/lang/node/patches/999-revert_enable_pointer_authentication_on_arm64.patch
@@ -1,6 +1,6 @@
 --- a/configure.py
 +++ b/configure.py
-@@ -1291,7 +1291,6 @@ def configure_node(o):
+@@ -1290,7 +1290,6 @@ def configure_node(o):
  
    # Enable branch protection for arm64
    if target_arch == 'arm64':


### PR DESCRIPTION
Maintainer: me @ianchi
Compile tested: 23.05, aarch64, arm
Run tested: (qemu 9.1.1) aarch64

Description:

Notable Changes
  esm: mark import attributes and JSON module as stable (Nicolò Ribaudo)