### PR TITLE
ffmpeg: add hls demuxer and https, crypto select

### DIFF
--- a/multimedia/ffmpeg/Config.in
+++ b/multimedia/ffmpeg/Config.in
@@ -382,6 +382,9 @@ config FFMPEG_CUSTOM_DEMUXER_mpegps
 config FFMPEG_CUSTOM_DEMUXER_mpegts
 	bool "MPEG-2 (TS)"
 
+config FFMPEG_CUSTOM_DEMUXER_hls
+	bool "hls"
+
 config FFMPEG_CUSTOM_DEMUXER_mpc
 	bool "Musepack"
 
@@ -464,6 +467,12 @@ config FFMPEG_CUSTOM_PROTOCOL_file
 
 config FFMPEG_CUSTOM_PROTOCOL_http
 	bool "http:"
+
+config FFMPEG_CUSTOM_PROTOCOL_https
+	bool "https:"
+
+config FFMPEG_CUSTOM_PROTOCOL_crypto
+	bool "crypto:"
 
 config FFMPEG_CUSTOM_PROTOCOL_icecast
 	bool "icecast:"

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=6.1.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
@@ -96,6 +96,7 @@ FFMPEG_CUSTOM_DEMUXERS:= \
 	mp3 \
 	mpegps \
 	mpegts \
+	hls \
 	mpegvideo \
 	mpc \
 	mpc8 \
@@ -121,7 +122,7 @@ FFMPEG_CUSTOM_PARSERS:= \
 	vc1 \
 
 FFMPEG_CUSTOM_PROTOCOLS:= \
-	file http icecast pipe rtp tcp udp
+	file http icecast pipe rtp tcp udp https crypto
 
 FFMPEG_MINI_DECODERS:= \
 	ac3 \
@@ -315,7 +316,8 @@ $(call Package/libffmpeg/Default)
            +FFMPEG_CUSTOM_SELECT_libopus:libopus \
            +PACKAGE_libx264:libx264 +PACKAGE_lame-lib:lame-lib \
            +FFMPEG_CUSTOM_SELECT_libshine:shine \
-           +PACKAGE_fdk-aac:fdk-aac
+           +PACKAGE_fdk-aac:fdk-aac \
+           +FFMPEG_CUSTOM_PROTOCOL_https:libgnutls
  VARIANT:=custom
  MENU:=1
 endef
@@ -509,6 +511,9 @@ ifeq ($(BUILD_VARIANT),custom)
 	$(foreach c, $(2), \
 		$(if $($(3)_$(c)),--enable-$(1)="$(c)") \
 	)
+  ifeq ($(CONFIG_FFMPEG_CUSTOM_PROTOCOL_https),y)
+	FFMPEG_CONFIGURE+=--enable-gnutls
+  endif
 
   ifeq ($(CONFIG_FFMPEG_CUSTOM_LARGE),y)
 	FFMPEG_CONFIGURE+= \


### PR DESCRIPTION
enable ffmpeg to handle input file in the format of https://xxx.m3u8 
crypto protocol is used to decrypt AES-encrypted HLS streams (.m3u8 files)

Maintainer: @thess @antonlacon 
Compile tested: (x86qemu/onecloud,OpenWrt version-24.10/master)
Run tested: (x86qemu/onecloud,OpenWrt version-24.10/master)