### PR TITLE
django: bump to 4.2.16 [23.05]

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=4.2.11
+PKG_VERSION:=4.2.16
 PKG_RELEASE:=1
 
 PYPI_NAME:=Django
-PKG_HASH:=6e6ff3db2d8dd0c986b4eec8554c8e4f919b5c1ff62a5b4390c17aff2ed6e5c4
+PKG_HASH:=6f1616c2786c408ce86ab7e10f792b8f15742f7b7b7460243929cb371e7f1dad
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Peter Stadler <peter.stadler@student.uibk.ac.at>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Fixes a bunch of CVEs.
CVE-2024-45230
  https://nvd.nist.gov/vuln/detail/CVE-2024-45230

CVE-2024-45231
  https://nvd.nist.gov/vuln/detail/CVE-2024-45231

(And maybe a few more).

Maintainer: me, @peter-stadler 
Compile tested: n/a
Run tested: n/a
