### PR TITLE
numpy,django,python-pytz: bump versions

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=5.1
+PKG_VERSION:=5.1.3
 PKG_RELEASE:=1
 
 PYPI_NAME:=Django
-PKG_HASH:=848a5980e8efb76eea70872fb0e4bc5e371619c70fffbe48e3e1b50b2c09455d
+PKG_HASH:=c0fa0e619c39325a169208caef234f90baa925227032ad3f44842ba14d75234a
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Peter Stadler <peter.stadler@student.uibk.ac.at>
 PKG_LICENSE:=BSD-3-Clause

--- a/lang/python/numpy/Makefile
+++ b/lang/python/numpy/Makefile
@@ -6,11 +6,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=numpy
-PKG_VERSION:=2.1.0
+PKG_VERSION:=2.1.3
 PKG_RELEASE:=1
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=7dc90da0081f7e1da49ec4e398ede6a8e9cc4f5ebe5f9e06b443ed889ee9aaa2
+PKG_HASH:=aa08e04e08aaf974d4458def539dece0d28146d866a39da5639596f4921fd761
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 

--- a/lang/python/python-pytz/Makefile
+++ b/lang/python/python-pytz/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pytz
-PKG_VERSION:=2024.1
+PKG_VERSION:=2024.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=pytz
-PKG_HASH:=2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812
+PKG_HASH:=2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me, @peter-stadler (as co-maintainer for Django)
Compile tested: https://https://github.com/openwrt/openwrt/commit/1bdb6d84046ec1c47f28c57651358470ed212ec3  x86
Run tested: https://https://github.com/openwrt/openwrt/commit/1bdb6d84046ec1c47f28c57651358470ed212ec3    x86
