### PR TITLE
keepalived: add ubus status

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.3.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software
@@ -236,10 +236,16 @@ endif
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/keepalived
 	$(INSTALL_DATA) ./files/hotplug-user \
 		$(1)/etc/hotplug.d/keepalived/01-user
+	$(INSTALL_DATA) ./files/etc/hotplug.d/keepalived/01-ubus \
+		$(1)/etc/hotplug.d/keepalived/01-ubus
 
 	$(INSTALL_DIR) $(1)/usr/libexec/rpcd
 	$(INSTALL_BIN) ./files/usr/libexec/rpcd/keepalived \
 		$(1)/usr/libexec/rpcd/keepalived
+
+	$(INSTALL_DIR) $(1)/usr/libexec/keepalived/rpc
+	$(INSTALL_DATA) ./files/usr/libexec/keepalived/rpc/status.sh \
+		$(1)/usr/libexec/keepalived/rpc/status.sh
 
 ifneq ($(CONFIG_KEEPALIVED_SNMP_VRRP)$(CONFIG_KEEPALIVED_SNMP_CHECKER)$(CONFIG_KEEPALIVED_SNMP_RFC2)$(CONFIG_KEEPALIVED_SNMP_RFC3),)
 	$(INSTALL_DIR) $(1)/usr/share/snmp/mibs
@@ -318,7 +324,21 @@ define Package/keepalived-sync/install
 		$(1)/usr/libexec/keepalived/rpc/sync.sh
 
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/keepalived
-	$(CP) ./files/etc/hotplug.d/keepalived/* \
+	$(CP) ./files/etc/hotplug.d/keepalived/501-rpcd \
+		$(1)/etc/hotplug.d/keepalived
+	$(CP) ./files/etc/hotplug.d/keepalived/505-system \
+		$(1)/etc/hotplug.d/keepalived
+	$(CP) ./files/etc/hotplug.d/keepalived/511-firewall \
+		$(1)/etc/hotplug.d/keepalived
+	$(CP) ./files/etc/hotplug.d/keepalived/551-dnsmasq \
+		$(1)/etc/hotplug.d/keepalived
+	$(CP) ./files/etc/hotplug.d/keepalived/555-dropbear \
+		$(1)/etc/hotplug.d/keepalived
+	$(CP) ./files/etc/hotplug.d/keepalived/600-uhttpd \
+		$(1)/etc/hotplug.d/keepalived
+	$(CP) ./files/etc/hotplug.d/keepalived/700-luci \
+		$(1)/etc/hotplug.d/keepalived
+	$(CP) ./files/etc/hotplug.d/keepalived/810-files \
 		$(1)/etc/hotplug.d/keepalived
 endef
 

--- a/net/keepalived/files/etc/hotplug.d/keepalived/01-ubus
+++ b/net/keepalived/files/etc/hotplug.d/keepalived/01-ubus
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+KEEPALIVED_STATUS_DIR="/var/run/keepalived"
+
+# Add a TAG for configured INSTANCE/GROUP
+tag_config() {
+	local cfg="$1"
+	local type="$2"
+	local name
+
+	config_get name "$cfg" name
+	mkdir -p "${KEEPALIVED_STATUS_DIR}/${name}_${type}"
+	touch "${KEEPALIVED_STATUS_DIR}/${name}_${type}/TAG"
+}
+
+main() {
+	# Remove TAG flag
+	for dir in ${KEEPALIVED_STATUS_DIR}/*; do
+		rm -rf "$dir/TAG"
+	done
+
+	config_load keepalived
+	config_foreach tag_config vrrp_instance INSTANCE
+	config_foreach tag_config vrrp_sync_group GROUP
+
+	# Delete run time directories which are not configured anymore
+	for dir in ${KEEPALIVED_STATUS_DIR}/*; do
+		if [ ! -e "$dir/TAG" ]; then
+			rm -rf "$dir"
+		fi
+	done
+
+	# Do not update 'GROUP' status if action is 'NOTIFY'
+	[ "$ACTION" = "NOTIFY" ] && [ "$TYPE" = "GROUP" ] && return
+
+	if [ -n "${NAME}" ] && [ -n "${TYPE}" ]; then
+		mkdir -p "${KEEPALIVED_STATUS_DIR}/${NAME}_${TYPE}"
+		[ -n "$ACTION" ] || ACTION="NOTIFY_UNKNOWN"
+		echo "$ACTION" > "${KEEPALIVED_STATUS_DIR}/${NAME}_${TYPE}/STATUS"
+		date +'%s' > "${KEEPALIVED_STATUS_DIR}/${NAME}_${TYPE}/TIME"
+	fi
+}
+
+main

--- a/net/keepalived/files/usr/libexec/keepalived/rpc/status.sh
+++ b/net/keepalived/files/usr/libexec/keepalived/rpc/status.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+. /usr/share/libubox/jshn.sh
+
+KEEPALIVED_STATUS_DIR="/var/run/keepalived"
+
+dump() {
+	local type="${1}"
+	local value name time status
+
+	json_add_array "$(echo "$type" | tr A-Z a-z)"
+	for dir in ${KEEPALIVED_STATUS_DIR}/*; do
+		value="${dir##*_}"
+		name="${dir%_*}"
+		name="${name##*/}"
+		[ -f "${dir}/TIME" ] && time=$(cat "${dir}/TIME")
+		[ -f "${dir}/STATUS" ] && status=$(cat "${dir}/STATUS")
+		if [ "${value}" = "${type}" ]; then
+			json_add_object
+			json_add_string "name" "${name}"
+			json_add_int "event" "${time}"
+			json_add_string "status" "${status}"
+			json_close_object
+		fi
+	done
+	json_close_array
+}
+
+status() {
+	json_init
+	dump "INSTANCE"
+	dump "GROUP"
+	json_dump
+}


### PR DESCRIPTION
Maintainer: me
Compile tested: only script changes
Run tested: x86_64, APU3, OpenWrt master

Description:
The hotplug scripts are called with every state change. When called, the scripts are processed under '/etc/hotplug.d/keepalived'. This change adds the functionality that the last state change of the keepalived can be queried via the ubus.