### PR TITLE
mpd: remove no-lto

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpd
 PKG_VERSION:=0.23.15
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.musicpd.org/download/mpd/0.23
@@ -22,7 +22,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_BUILD_PATENTED \
 	CONFIG_IPV6 \
 
-PKG_BUILD_FLAGS:=no-mips16 no-lto
+PKG_BUILD_FLAGS:=no-mips16
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -101,6 +101,7 @@ define Package/mpd-avahi-service/conffiles
 endef
 
 MESON_ARGS += \
+	-Db_lto=true \
 	-Ddocumentation=disabled \
 	-Dhtml_manual=false \
 	-Dmanpages=false \


### PR DESCRIPTION
This seems to no longer fail compilation.

Use meson's b_lto to turn it on always.

ping @dhewg 