### PR TITLE
[22.03] php8: update to 8.1.31

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.1.30
+PKG_VERSION:=8.1.31
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.php.net/distributions/
-PKG_HASH:=f24a6007f0b25a53cb7fbaee69c85017e0345b62089c2425a0afb7e177192ed1
+PKG_HASH:=c4f244d46ba51c72f7d13d4f66ce6a9e9a8d6b669c51be35e01765ba58e7afca
 
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
Maintainer: me
Compile tested: 
Run tested: mxs, Duckbill

Description:

This fixes:
    - CVE-2024-8929
    - CVE-2024-8932
    - CVE-2024-11233
    - CVE-2024-11234
    - CVE-2024-11236

Upstream changelog:
https://www.php.net/ChangeLog-8.php#8.1.31