### PR TITLE
ddns-scripts: refactoring phase 1 scripting

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
 PKG_RELEASE:=67
+PKG_RELEASE:=68
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -220,16 +220,14 @@ stop_section_processes() {
 # and by /etc/init.d/ddns stop
 # needed because we also need to kill "sleep" child processes
 stop_daemon_for_all_ddns_sections() {
-	local __EVENTIF="$1"
-	local __SECTIONS=""
-	local __SECTIONID=""
-	local __IFACE=""
+	local event_if sections section_id configured_if
+	event_if="$1"
 
-	load_all_service_sections __SECTIONS
-	for __SECTIONID in $__SECTIONS;	do
-		config_get __IFACE "$__SECTIONID" interface "wan"
-		[ -z "$__EVENTIF" -o "$__IFACE" = "$__EVENTIF" ] || continue
-		stop_section_processes "$__SECTIONID"
+	load_all_service_sections sections
+	for section_id in $sections;	do
+		config_get configured_if "$section_id" interface "wan"
+		[ -z "$event_if" ] || [ "$configured_if" = "$event_if" ] || continue
+		stop_section_processes "$section_id"
 	done
 }
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -1210,9 +1210,9 @@ get_registered_ip() {
 
 get_uptime() {
 	# $1	Variable to store result in
-	[ $# -ne 1 ] && write_log 12 "Error calling 'verify_host_port()' - wrong number of parameters"
-	local __UPTIME=$(cat /proc/uptime)
-	eval "$1=\"${__UPTIME%%.*}\""
+	[ $# -ne 1 ] && write_log 12 "Error calling 'get_uptime()' - requires exactly 1 argument."
+	read -r uptime < /proc/uptime
+	eval "$1=\"${uptime%%.*}\""
 }
 
 trap_handler() {

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -204,15 +204,14 @@ start_daemon_for_all_ddns_sections()
 # stop sections process incl. childs (sleeps)
 # $1 = section
 stop_section_processes() {
-	local __PID=0
-	local __PIDFILE="$ddns_rundir/$1.pid"
-	[ $# -ne 1 ] && write_log 12 "Error calling 'stop_section_processes()' - wrong number of parameters"
+	local pid_file
+	pid_file="$ddns_rundir/$1.pid"
+	[ $# -ne 1 ] && write_log 12 "Error: 'stop_section_processes()' requires exactly one parameter"
 
-	[ -e "$__PIDFILE" ] && {
-		__PID=$(cat $__PIDFILE)
-		busybox ps | grep "^[\t ]*$__PID" >/dev/null 2>&1 && kill $__PID || __PID=0	# terminate it
+	[ -e "$pid_file" ] && {
+		xargs kill < "$pid_file" 2>/dev/null && return 1
 	}
-	[ $__PID -eq 0 ] # report if process was running
+	return 0 # nothing killed
 }
 
 # stop updater script for all defines sections or only for one given

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -184,20 +184,14 @@ load_all_service_sections() {
 # and by /etc/init.d/ddns start
 start_daemon_for_all_ddns_sections()
 {
-	local __EVENTIF="$1"
-	local __SECTIONS=""
-	local __SECTIONID=""
-	local __IFACE=""
+	local event_if sections section_id configured_if
+	event_if="$1"
 
-	load_all_service_sections __SECTIONS
-	for __SECTIONID in $__SECTIONS; do
-		config_get __IFACE "$__SECTIONID" interface "wan"
-		[ -z "$__EVENTIF" -o "$__IFACE" = "$__EVENTIF" ] || continue
-		if [ $VERBOSE -eq 0 ]; then	# start in background
-			/usr/lib/ddns/dynamic_dns_updater.sh -v 0 -S "$__SECTIONID" -- start &
-		else
-			/usr/lib/ddns/dynamic_dns_updater.sh -v "$VERBOSE" -S "$__SECTIONID" -- start
-		fi
+	load_all_service_sections sections
+	for section_id in $sections; do
+		config_get configured_if "$section_id" interface "wan"
+		[ -z "$event_if" ] || [ "$configured_if" = "$event_if" ] || continue
+		/usr/lib/ddns/dynamic_dns_updater.sh -v "$VERBOSE" -S "$section_id" -- start
 	done
 }
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -129,35 +129,34 @@ USE_CURL=$(uci -q get ddns.global.use_curl) || USE_CURL=0	# read config
 # $1 = ddns, $2 = SECTION_ID
 load_all_config_options()
 {
-	local __PKGNAME="$1"
-	local __SECTIONID="$2"
-	local __VAR
-	local __ALL_OPTION_VARIABLES=""
+	local pkg_name section_id tmp_var all_opt_vars
+	pkg_name="$1"
+	section_id="$2"
 
-	# this callback loads all the variables in the __SECTIONID section when we do
+	# this callback loads all the variables in the $section_id section when we do
 	# config_load. We need to redefine the option_cb for different sections
 	# so that the active one isn't still active after we're done with it.  For reference
 	# the $1 variable is the name of the option and $2 is the name of the section
 	config_cb()
 	{
-		if [ ."$2" = ."$__SECTIONID" ]; then
+		if [ ."$2" = ."$section_id" ]; then
 			option_cb()
 			{
-				__ALL_OPTION_VARIABLES="$__ALL_OPTION_VARIABLES $1"
+				all_opt_vars="$all_opt_vars $1"
 			}
 		else
 			option_cb() { return 0; }
 		fi
 	}
 
-	config_load "$__PKGNAME"
+	config_load "$pkg_name"
 
 	# Given SECTION_ID not found so no data, so return 1
-	[ -z "$__ALL_OPTION_VARIABLES" ] && return 1
+	[ -z "$all_opt_vars" ] && return 1
 
-	for __VAR in $__ALL_OPTION_VARIABLES
+	for tmp_var in $all_opt_vars
 	do
-		config_get "$__VAR" "$__SECTIONID" "$__VAR"
+		config_get "$tmp_var" "$section_id" "$tmp_var"
 	done
 	return 0
 }

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_lucihelper.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_lucihelper.sh
@@ -147,19 +147,19 @@ case "$1" in
 		;;
 	start)
 		[ -z "$SECTION" ] &&  usage_err "command 'start': 'SECTION' not set"
-		if [ $VERBOSE -eq 0 ]; then	# start in background
-			$DDNSPRG -v 0 -S $SECTION -- start &
+		if [ "$VERBOSE" -eq 0 ]; then	# start in background
+			"$DDNSPRG" -v 0 -S "$SECTION" -- start &
 		else
-			$DDNSPRG -v $VERBOSE -S $SECTION -- start
+			"$DDNSPRG" -v "$VERBOSE" -S "$SECTION" -- start
 		fi
 		;;
 	reload)
-		$DDNSPRG -- reload
+		"$DDNSPRG" -- reload
 		;;
 	restart)
-		$DDNSPRG -- stop
+		"$DDNSPRG" -- stop
 		sleep 1
-		$DDNSPRG -- start
+		"$DDNSPRG" -- start
 		;;
 	*)
 		__RET=255
@@ -167,6 +167,6 @@ case "$1" in
 esac
 
 # remove out and err file
-[ -f $DATFILE ] && rm -f $DATFILE
-[ -f $ERRFILE ] && rm -f $ERRFILE
+[ -f "$DATFILE" ] && rm -f "$DATFILE"
+[ -f "$ERRFILE" ] && rm -f "$ERRFILE"
 return $__RET

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_lucihelper.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_lucihelper.sh
@@ -26,6 +26,7 @@ Commands:
  start               start given SECTION
  reload              force running ddns processes to reload changed configuration
  restart             restart all ddns processes
+ stop                stop given SECTION
 
 Parameters:
  -6                  => use_ipv6=1          (default 0)
@@ -39,7 +40,7 @@ Parameters:
  -s SCRIPT           => ip_script=SCRIPT; ip_source="script"
  -t                  => force_dnstcp=1      (default 0)
  -u URL              => ip_url=URL; ip_source="web"
- -S SECTION          SECTION to start
+ -S SECTION          SECTION to [start|stop]
 
  -h                  => show this help and exit
  -L                  => use_logfile=1    (default 0)
@@ -160,6 +161,15 @@ case "$1" in
 		"$DDNSPRG" -- stop
 		sleep 1
 		"$DDNSPRG" -- start
+		;;
+	stop)
+		if [ -n "$SECTION" ]; then
+			# section stop
+			"$DDNSPRG" -S "$SECTION" -- stop
+		else
+			# global stop
+			"$DDNSPRG" -- stop
+		fi
 		;;
 	*)
 		__RET=255

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
@@ -79,7 +79,11 @@ case "$1" in
 		fi
 		;;
 	stop)
-		if [ -n "$INTERFACE" ]; then
+		if [ -n "$SECTION_ID" ]; then
+			stop_section_processes "$SECTION_ID"
+			exit 0
+		fi
+		if [ -n "$NETWORK" ]; then
 			stop_daemon_for_all_ddns_sections "$NETWORK"
 			exit 0
 		else

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
@@ -266,16 +266,16 @@ esac
 
 [ -n "$update_url" ] && {
 	# only check if update_url is given, update_scripts have to check themselves
-	[ -z "$domain" ] && $(echo "$update_url" | grep "\[DOMAIN\]" >/dev/null 2>&1) && \
-		write_log 14 "Service section not configured correctly! Missing 'domain'"
-	[ -z "$username" ] && $(echo "$update_url" | grep "\[USERNAME\]" >/dev/null 2>&1) && \
-		write_log 14 "Service section not configured correctly! Missing 'username'"
-	[ -z "$password" ] && $(echo "$update_url" | grep "\[PASSWORD\]" >/dev/null 2>&1) && \
-		write_log 14 "Service section not configured correctly! Missing 'password'"
-	[ -z "$param_enc" ] && $(echo "$update_url" | grep "\[PARAMENC\]" >/dev/null 2>&1) && \
-		write_log 14 "Service section not configured correctly! Missing 'param_enc'"
-	[ -z "$param_opt" ] && $(echo "$update_url" | grep "\[PARAMOPT\]" >/dev/null 2>&1) && \
-		write_log 14 "Service section not configured correctly! Missing 'param_opt'"
+	[ -z "$domain" ] && [ "${update_url##*'[DOMAIN]'}" != "$update_url" ] && \
+		write_log 14 "Service section missing 'domain'"
+	[ -z "$username" ] && [ "${update_url##*'[USERNAME]'}" != "$update_url" ] && \
+		write_log 14 "Service section missing 'username'"
+	[ -z "$password" ] && [ "${update_url##*'[PASSWORD]'}" != "$update_url" ] && \
+		write_log 14 "Service section missing 'password'"
+	[ -z "$param_enc" ] && [ "${update_url##*'[PARAMENC]'}" != "$update_url" ] && \
+		write_log 14 "Service section missing 'param_enc'"
+	[ -z "$param_opt" ] && [ "${update_url##*'[PARAMOPT]'}" != "$update_url" ] && \
+		write_log 14 "Service section missing 'param_opt'"
 }
 
 # verify ip_source 'script' if script is configured and executable


### PR DESCRIPTION
Maintainer: @chris5560 (?)

Phase 1 of a refactor of the DDNS scripts. Goal: scripts no longer open *many* sub-shells or call a number of external utilities like `sed` and `grep` or similar piped chains where the equivalent is available in pure script functionality. (The `url_update` checks found within this change-set avoid spawning six potential sub-shells at every run.)

Refactors make code less shouty and 'stabby'.

I've tested these changes on my system (23.05.5) for a while now and they show an improvement. Otherwise, the refactor achieves synonymous functionality. 

This change-set introduces the ability to stop individual sections (previously missing). 