### PR TITLE
strongswan: swanctl: Add support for encap

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.14
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -450,6 +450,7 @@ config_remote() {
 	local auth_method
 	local keyingtries
 	local dpddelay
+	local encap
 	local inactivity
 	local keyexchange
 	local fragmentation
@@ -473,6 +474,7 @@ config_remote() {
 	config_get local_ip "$conf" local_ip "%any"
 	config_get keyingtries "$conf" keyingtries "3"
 	config_get dpddelay "$conf" dpddelay "30s"
+	config_get_bool encap "$conf" encap 0
 	config_get inactivity "$conf" inactivity
 	config_get keyexchange "$conf" keyexchange "ikev2"
 	config_get fragmentation "$conf" fragmentation "yes"
@@ -597,6 +599,7 @@ config_remote() {
 
 	swanctl_xappend2 "proposals = $ike_proposal"
 	[ -n "$dpddelay" ] && swanctl_xappend2 "dpd_delay = $dpddelay"
+	[ $encap -eq 1 ] && swanctl_xappend2 "encap = yes" || swanctl_xappend2 "encap = no"
 	[ "$keyingtries" = "%forever" ] && swanctl_xappend2 "keyingtries = 0" || swanctl_xappend2 "keyingtries = $keyingtries"
 
 	swanctl_xappend1 "}"


### PR DESCRIPTION
Maintainer:  @pprindeville @Thermi
Compile tested: None.  Script only change.
Run tested: aarch64, Linksys E8450 mediatek/mt7622, OpenWrt 23.05.5, checked generated `swanctl.conf` and operation

Description:
Support the [encap] connection configuration option to force UDP encapsulation of ESP packets to work around connectivity issues with middleboxes which block ESP packets.

This work is based on a patch by @aleks-mariusz in https://forum.openwrt.org/t/confusion-regarding-setting-up-ikev2-vpn-service-with-strongswan-using-ipsec-and-swanctl/169587/9 This PR uses `encap` for the option name instead of `force_encapsulation` for consistency with [swanctl.conf](https://docs.strongswan.org/docs/latest/swanctl/swanctlConf.html#:~:text=encap).

Thanks for considering,
Kevin

[encap]: https://docs.strongswan.org/docs/latest/swanctl/swanctlConf.html#_connections