### PR TITLE
strongswan: swanctl: Add support for send_certreq

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.14
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -461,6 +461,7 @@ config_remote() {
 	local rekeytime
 	local overtime
 	local send_cert
+	local send_certreq
 	local remote_ca_certs
 	local pools
 	local eap_id
@@ -487,6 +488,7 @@ config_remote() {
 	config_get rekeytime "$conf" rekeytime
 	config_get overtime "$conf" overtime
 	config_get send_cert "$conf" send_cert
+	config_get_bool send_certreq "$conf" send_certreq 1
 	config_get eap_id "$conf" eap_id "%any"
 
 	config_list_foreach "$conf" local_sourceip append_var local_sourceip ","
@@ -587,6 +589,7 @@ config_remote() {
 	esac
 
 	[ -n "$send_cert" ] && swanctl_xappend2 "send_cert = $send_cert"
+	[ $send_certreq -eq 1 ] && swanctl_xappend2 "send_certreq = yes" || swanctl_xappend2 "send_certreq = no"
 
 	[ $mobike -eq 1 ] && swanctl_xappend2 "mobike = yes" || swanctl_xappend2 "mobike = no"
 


### PR DESCRIPTION
Maintainer:  @pprindeville @Thermi
Compile tested: None.  Script only change.
Run tested: aarch64, Linksys E8450 mediatek/mt7622, OpenWrt 23.05.5, checked generated `swanctl.conf` and operation

Description:
Support the [send_certreq] connection configuration option to disable offering trusted root CA certificates and reduce the size of the initial IKE packets.

This work is based on a patch by @aleks-mariusz in https://forum.openwrt.org/t/confusion-regarding-setting-up-ikev2-vpn-service-with-strongswan-using-ipsec-and-swanctl/169587/9  This PR uses `send_certreq` for the option name instead of `remote_sendcert` for consistency with [swanctl.conf](https://docs.strongswan.org/docs/latest/swanctl/swanctlConf.html#:~:text=send_certreq).

Thanks for considering,
Kevin

[send_certreq]: https://docs.strongswan.org/docs/latest/swanctl/swanctlConf.html#_connections