### PR TITLE
strongswan: swanctl: make overtime and send_cert vars local

### DIFF
--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -458,6 +458,7 @@ config_remote() {
 	local local_key
 	local ca_cert
 	local rekeytime
+	local send_cert
 	local remote_ca_certs
 	local pools
 	local eap_id

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -458,6 +458,7 @@ config_remote() {
 	local local_key
 	local ca_cert
 	local rekeytime
+	local overtime
 	local send_cert
 	local remote_ca_certs
 	local pools


### PR DESCRIPTION
Maintainer:  @pprindeville @Thermi
Compile tested: None.  Script only change.
Run tested: aarch64, Linksys E8450 mediatek/mt7622, OpenWrt 23.05.5, checked generated `swanctl.conf` and operation

Description:
Both `$overtime` and `$send_cert` are only used in `config_remote()` in `swanctl.init`.  However, unlike the other local option variables, they are not declared local.  This PR does so for consistency, to avoid global namespace pollution, and make the code easier to reason about.

For reference, `$overtime` was added in f9d91f1f47, `$send_cert` in 4b9453b9a4.

Thanks for considering,
Kevin