### PR TITLE
eza: update to 0.20.10

### DIFF
--- a/utils/eza/Makefile
+++ b/utils/eza/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=eza
-PKG_VERSION:=0.20.5
+PKG_VERSION:=0.20.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eza-community/eza/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=3455907abddd72ab405613588f82e2b5f6771facf215e5bcd92bca1a82520819
+PKG_HASH:=dbeba82ed85c18776aac20a4f91429bd3ab7e1bd3734344cd247e8f646516a13
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=EUPL-1.2


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64 mediatek/filogic (BananaPi R4), OpenWrt snapshot
Run tested: aarch64 mediatek/filogic (BananaPi R4), OpenWrt snapshot

Release notes:
0.20.6: https://github.com/eza-community/eza/releases/tag/v0.20.6
0.20.7: https://github.com/eza-community/eza/releases/tag/v0.20.7
0.20.8: https://github.com/eza-community/eza/releases/tag/v0.20.8
0.20.9: https://github.com/eza-community/eza/releases/tag/v0.20.9
0.20.10: https://github.com/eza-community/eza/releases/tag/v0.20.10