### PR TITLE
net-snmp: add uci section to include additional conf files

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.9.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp

--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -284,6 +284,14 @@ snmpd_setup_fw_rules() {
 	HANDLED_SNMP_ZONES="$HANDLED_SNMP_ZONES $zone"
 }
 
+snmpd_include_file() {
+	local section="$1"
+	local file_name=""
+
+	config_get file_name "$section" path
+	[ -n "$file_name" ] && echo "includeFile $file_name" >> $CONFIGFILE
+}
+
 start_service() {
 	[ -f "$CONFIGFILE" ] && rm -f "$CONFIGFILE"
 
@@ -316,6 +324,7 @@ start_service() {
 	config_foreach snmpd_sink_add trapsink trapsink
 	config_foreach snmpd_sink_add trap2sink trap2sink
 	config_foreach snmpd_sink_add informsink informsink
+	config_foreach snmpd_include_file include
 	append_authtrapenable authtrapenable enable authtrapenable
 	append_parm v1trapaddress host v1trapaddress
 	append_parm trapsess trapsess trapsess


### PR DESCRIPTION
net-snmp allows including additional conf files by specifying then with the includeFile token in the snmpd.conf, this commits adds a uci section that translates to includeFile in snmpd.conf files and hence allows including additional conf files.

the syntax introduced is as follows:

config include 'custom-file'
    option path '/tmp/mysnmpd.conf'