### PR TITLE
[23.05] ruby: update to 3.2.6

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=3.2.5
+PKG_VERSION:=3.2.6
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=7780d91130139406d39b29ed8fe16bba350d8fa00e510c76bef9b8ec1340903c
+PKG_HASH:=671134022238c2c4a9d79dc7d1e58c909634197617901d25863642f735a27ecb
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Ruby 3.2.6 is a minor bug fix release.

Link: https://github.com/ruby/ruby/releases/tag/v3_2_6

Maintainer: me
Compile tested: built on ath79_generic,mediatek_filogic,ramips_mt7620,x86_64
Run tested: none (minor update)