### PR TITLE
ruby: update to 3.3.6

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=3.3.5
+PKG_VERSION:=3.3.6
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=3781a3504222c2f26cb4b9eb9c1a12dbf4944d366ce24a9ff8cf99ecbce75196
+PKG_HASH:=8dc48fffaf270f86f1019053f28e51e4da4cce32a36760a0603a9aee67d7fd8d
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Ruby 3.3.6 is a routine update that includes minor bug fixes. It also stops warning missing default gem dependencies that will be bundled gems in Ruby 3.5.

Link: https://github.com/ruby/ruby/releases/tag/v3_3_6

Maintainer: me
Compile tested: built on ath79_generic,mediatek_filogic,ramips_mt7620,x86_64
Run tested: none (minor update)