### PR TITLE
keepalived: fix name of globals section in default config

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.3.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software

--- a/net/keepalived/files/keepalived.config
+++ b/net/keepalived/files/keepalived.config
@@ -1,4 +1,4 @@
-config global_defs
+config globals 'globals'
 #	option alt_config_file		"/etc/keepalived/keepalived.conf"
 #	list notification_email		"acassen@firewall.loc"
 #	list notification_email		"failover@firewall.loc"


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: lantiq_xrx200, latest master
Run tested: lantiq_xrx200, latest master

Description:
This section was renamed some time ago. Although this would be fixed by the uci-default migration script, we should set this correctly in the example config file right away.

Please also backport this change to the branches openwrt-23.05 and openwrt-24.10.