### PR TITLE
python-click: add hostbuild

### DIFF
--- a/lang/python/python-click/Makefile
+++ b/lang/python/python-click/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-click
 PKG_VERSION:=8.1.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=click
 PKG_HASH:=ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de
@@ -15,9 +15,13 @@ PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
 
+HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-wheel/host
+
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-click
   SECTION:=lang
@@ -38,3 +42,4 @@ endef
 $(eval $(call Py3Package,python3-click))
 $(eval $(call BuildPackage,python3-click))
 $(eval $(call BuildPackage,python3-click-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: @jefferyto 
Compile tested: OpenWRT One master/snapshot

Description:
Add hostbuild directives for `python-click`.

This package is a host-requirement for building projects with PlatformIO, including the [openwrt-meshtastic](https://github.com/openwrt-meshtastic/openwrt-meshtastic) project.