### PR TITLE
netbird: update to 0.34.1

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.31.0
+PKG_VERSION:=0.34.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=7da075c5e1962b9118d2d17500bf9b22e6f70c595a356ed290b4f7b1d1b84919
+PKG_HASH:=5eb78e815c73b197f36141dbc071520171cd660a1f64a010c5ec5c4db4d006e4
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## Compile and run tested

Maintainer: Oskari Rauta / @oskarirauta

| Package architecture | Target | Subtarget | Brand | Model | Hardware Version | OpenWrt version |
|----------------------|--------|-----------|-------|-------|------------------|-----------------|
| [x86_64](https://openwrt.org/docs/techref/instructionset/x86_64) | [x86](https://openwrt.org/docs/techref/targets/x86) | 64 | WOVIBO | B75 M.2 Intel LGA 1155 DDR3 | n/a | OpenWrt SNAPSHOT ~r28146-52b6c92479~ r28146-52b6c92479 |

## Description

- Supersedes: https://github.com/openwrt/packages/pull/25425
- Changelog:
  - [v0.34.0](https://github.com/netbirdio/netbird/releases/tag/v0.34.0)
  - [v0.34.1](https://github.com/netbirdio/netbird/releases/tag/v0.34.1)
- Full changelog: https://github.com/netbirdio/netbird/compare/v0.31.0...v0.34.1

## Additional information

`x86_64` running as container with [`incus`](https://github.com/lxc/incus).
Compiled package with container [`sdk`](https://github.com/openwrt/docker), and build `openwrt` image with container [`imagebuilder`](https://github.com/openwrt/docker).

My repo with my automated build can be see here:
- https://github.com/wehagy/openwrt-builder/tree/update/netbird

And my artifacts here:
- ~https://github.com/wehagy/openwrt-builder/actions/runs/12171924545~
- https://github.com/wehagy/openwrt-builder/actions/runs/12192519259

~Some of my automated builds failed with the error below, but is unrelated to the `netbird` package.~

```shell
Building package index...

Installing packages...
ERROR: unable to select packages:
  hostapd-common (no such package):
    required by: wpad-basic-mbedtls-2024.09.15~5ace39b0-r1[hostapd-common=2024.09.15~5ace39b0-r1]
                 kmod-mac80211-6.6.63.6.11.2-r1[hostapd-common]
make[2]: *** [Makefile:225: package_install] Error 6
make[1]: *** [Makefile:156: _call_image] Error 2
make: *** [Makefile:328: image] Error 2
```

Everything is fine now.