### PR TITLE
python-chardet: add hostbuild

### DIFF
--- a/lang/python/python-chardet/Makefile
+++ b/lang/python/python-chardet/Makefile
@@ -9,15 +9,19 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-chardet
 PKG_VERSION:=5.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=LGPL-2.1
 
 PYPI_NAME:=chardet
 PKG_HASH:=1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7
 
+HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-wheel/host
+
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-chardet
   SUBMENU:=Python
@@ -45,3 +49,4 @@ endef
 $(eval $(call Py3Package,python3-chardet))
 $(eval $(call BuildPackage,python3-chardet))
 $(eval $(call BuildPackage,python3-chardet-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: OpenWRT One master/snapshot

Description:
Add hostbuild directives for `python-chardet`.

This package is a required when building a `python-requests` host package (PR inbound).

This will ultimately be consumed by the `python-platformio` host package (build system) that I am working on at the [openwrt-meshtastic](https://github.com/openwrt-meshtastic/openwrt-meshtastic) project.