### PR TITLE
python-certifi: add hostbuild

### DIFF
--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
 PKG_VERSION:=2024.2.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=MPL-2.0
@@ -16,9 +16,13 @@ PKG_LICENSE_FILES:=LICENSE
 PYPI_NAME:=certifi
 PKG_HASH:=0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f
 
+HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-wheel/host
+
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-certifi
   SUBMENU:=Python
@@ -38,3 +42,4 @@ endef
 $(eval $(call Py3Package,python3-certifi))
 $(eval $(call BuildPackage,python3-certifi))
 $(eval $(call BuildPackage,python3-certifi-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: @cotequeiroz @jefferyto @BKPepe
Compile tested: OpenWRT One master/snapshot

Description:
Add hostbuild directives for `python-certifi`.

This package is a required when building a `python-requests` host package (PR inbound).

This will ultimately be consumed by the `python-platformio` host package (build system) that I am working on at the [openwrt-meshtastic](https://github.com/openwrt-meshtastic/openwrt-meshtastic) project.