### PR TITLE
python-requests: add hostbuild

### DIFF
--- a/lang/python/python-requests/Makefile
+++ b/lang/python/python-requests/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-requests
 PKG_VERSION:=2.32.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -19,9 +19,17 @@ PKG_CPE_ID:=cpe:/a:python:requests
 PYPI_NAME:=requests
 PKG_HASH:=55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760
 
+HOST_BUILD_DEPENDS:= \
+  python-chardet/host \
+  python-idna/host \
+  python-urllib3/host \
+  python-certifi/host
+
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-requests
   SUBMENU:=Python
@@ -44,3 +52,4 @@ endef
 $(eval $(call Py3Package,python3-requests))
 $(eval $(call BuildPackage,python3-requests))
 $(eval $(call BuildPackage,python3-requests-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: @commodo @BKPepe 
Compile tested: OpenWRT One master/snapshot

Description:
Add hostbuild directives for `python-requests`.

~Draft for now~, requisite upon #25495 #25496 #25497 #25498 

This package is a host-requirement for PlatformIO and projects which depend on PlatformIO, including the [openwrt-meshtastic](https://github.com/openwrt-meshtastic/openwrt-meshtastic) project.