### PR TITLE
python-dateutil: "downgrade" to version 2.9.0

### DIFF
--- a/lang/python/python-dateutil/Makefile
+++ b/lang/python/python-dateutil/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dateutil
-PKG_VERSION:=2.9.0.post0
+PKG_VERSION:=2.9.0
 PKG_RELEASE:=1
 PKG_LICENSE:=BSD-2-Clause
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3
+PKG_HASH:=78e73e19c63f5b20ffa567001531680d939dc042bf7850431877645523c66709
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 
 PKG_BUILD_DEPENDS:=python-setuptools-scm/host


### PR DESCRIPTION
Maintainer: me
Compile tested: n/a
Run tested: n/a

------------------------------------------------------------

This backport is mostly to align with master, since the version in 24.10 is slightly ahead.

------------------------------------------------------------

Fixes:
  https://github.com/openwrt/packages/pull/23648#issuecomment-2495371925

As weird as this sounds, the only different between the current version (2.9.0.post0) and 2.9.0 is the pinning of `setuptools_scm` to `< 8`. See:  https://github.com/dateutil/dateutil/releases/tag/2.9.0.post0

Also, the APK build doesn't seem to like the 'post0' suffix.

Signed-off-by: Alexandru Ardelean <alex@shruggie.ro>
(cherry picked from commit 40cfff8fe9594c4507db705111461973a9bbb0f0)