### PR TITLE
ksmbd-tools: update to version 3.5.3

### DIFF
--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
-PKG_VERSION:=3.5.2
+PKG_VERSION:=3.5.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/cifsd-team/ksmbd-tools/releases/download/$(PKG_VERSION)
-PKG_HASH:=5da7fb4cb4368f9abf56f6f9fbc17b25e387876bed9ff7ee0d6f1140ef07c8d7
+PKG_HASH:=e8d55cc53825170d7e5213d48a92b8251dc0d1351601283f6d0995cfd789b4d0
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING

--- a/net/ksmbd-tools/patches/030-glib.patch
+++ b/net/ksmbd-tools/patches/030-glib.patch
@@ -3,7 +3,7 @@
 @@ -21,6 +21,7 @@ include_dirs = include_directories(
  glib_dep = dependency(
    'glib-2.0',
-   version: '>= 2.44',
+   version: '>= 2.58',
 +  static: true,
  )
  libnl_dep = dependency(


### PR DESCRIPTION
Maintainer: nobody
Compile tested: meditek/filogic MT6000
Run tested: meditek/filogic MT6000

Description: 

- manually refresh patch 030-glib.patch

Major changes are:
    fix adduser / addshare prompting on musl libc
    fix use of veto files as global share parameter
    lookup primary group and don't recurse in ksmbd.conf `@group` handling
    fix a leak and an intermittent auth failure in Kerberos 5
    add global parameter kerberos support

detailed changelog here: https://github.com/cifsd-team/ksmbd-tools/releases/tag/3.5.3
