### PR TITLE
dhtd: update to 1.0.5

### DIFF
--- a/net/dhtd/Makefile
+++ b/net/dhtd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dhtd
-PKG_VERSION:=1.0.4
+PKG_VERSION:=1.0.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mwarning/dhtd/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=77b106fb05a2b7c5bb777513cf47a8f2b729672520d9772ffe82b86036b45d0f
+PKG_HASH:=2b88977c474f35b611124bed226648dfc7fb98fd0e922360e8b8d42443028fa5
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: yes, ramips/mt76x8
Run tested: no, trivial changes
