### PR TITLE
ksmbd-tools: adjust smb2 max read/write/trans and cache

### DIFF
--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
 PKG_VERSION:=3.5.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/cifsd-team/ksmbd-tools/releases/download/$(PKG_VERSION)

--- a/net/ksmbd-tools/files/ksmbd.conf.template
+++ b/net/ksmbd-tools/files/ksmbd.conf.template
@@ -7,8 +7,3 @@
 	ipc timeout = 20
 	deadtime = 15
 	map to guest = Bad User
-	smb2 max read = 64K
-	smb2 max write = 64K
-	smb2 max trans = 64K
-	cache read buffers = no
-	cache trans buffers = no

--- a/net/ksmbd-tools/files/ksmbd.init
+++ b/net/ksmbd-tools/files/ksmbd.init
@@ -12,6 +12,28 @@ config_get_sane()
 	set -- "$(echo "$1" | tr -d '<>[]{};%?=#\n')"
 }
 
+config_get_ram()
+{
+	ramsize=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+	if [ "$ramsize" -lt 65537 ];then
+		printf "\tsmb2 max read = 64K\n"
+		printf "\tsmb2 max write = 64K\n"
+		printf "\tsmb2 max trans = 64K\n"
+		printf "\tcache read buffers = no\n"
+		printf "\tcache trans buffers = no\n"
+	elif [ "$ramsize" -lt 134073 ];then
+		printf "\tsmb2 max read = 128K\n"
+		printf "\tsmb2 max write = 128K\n"
+		printf "\tsmb2 max trans = 128K\n"
+		printf "\tcache read buffers = no\n"
+		printf "\tcache trans buffers = no\n"
+	elif [ "$ramsize" -lt 262146 ];then
+		printf "\tsmb2 max read = 1M\n"
+		printf "\tsmb2 max write = 1M\n"
+		printf "\tsmb2 max trans = 1M\n"
+	fi
+}
+
 smb_header()
 {
 	config_get_sane SMBD_IFACE "$1" interface "lan"
@@ -41,6 +63,8 @@ smb_header()
 	    /etc/ksmbd/ksmbd.conf.template > /var/etc/ksmbd/ksmbd.conf
 		
 	{
+		config_get_ram
+		
 		printf "\n######### Dynamic written config options #########\n"
 
 		if [ "$ALLOW_LEGACY_PROTOCOLS" -eq 1 ]; then


### PR DESCRIPTION
Maintainer: nobody
Compile tested: mediatek/filogic MT6000
Run tested: mediatek/filogic MT6000

Description of pull request:

Now for all devices with every size of RAM it is set to: `smb2 max read = 64K`
`smb2 max write = 64K`
`smb2 max trans = 64K`

Instead of fixed value to 64K is better to check RAM size and adjust to:

32 ~ 64MB RAM, set the value to 64K
64 ~ 128MB, set it to 128KB
128 ~ 256MB, set it to 1MB
More than 256MB leave default size to 4MB

With 64MB and 128MB is better also to disable the read/write cache `cache read buffers = no`
`cache write buffers = no`

