### PR TITLE
liborcania: Install library on target

### DIFF
--- a/libs/liborcania/Makefile
+++ b/libs/liborcania/Makefile
@@ -7,13 +7,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=liborcania
 PKG_VERSION:=2.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/babelouest/orcania/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=b1b5550523164eca0f59099e843177684c5017c6088284123880cffd4c6dbbde
 
-PKG_MAINTAINER:=Toni Uhlig <matzeton@googlemail.com>
+PKG_MAINTAINER:=Toni Uhlig <matzeton@googlemail.com>, Austin Lane <vidplace7@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=LICENSE
 
@@ -33,6 +33,11 @@ endef
 
 define Package/liborcania/description
   Potluck with different functions for different purposes that can be shared among C programs.
+endef
+
+define Package/liborcania/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liborcania.so* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,liborcania))


### PR DESCRIPTION
Maintainer: @utoni -- adding myself as a maintainer as well.
Compile tested: OpenWRT One master/snapshot

Description:
The current liborcania / libulfius packages do not install to the target, resulting in messages like:
```
Package meshtasticd is missing dependencies for the following libraries:
liborcania.so.2.3
libulfius.so.2.7
```
This change corrects the issue by installing the library `.so`s to the target.