### PR TITLE
python-platformio: Add package (build system)

### DIFF
--- a/lang/python/python-platformio/Makefile
+++ b/lang/python/python-platformio/Makefile
@@ -1,0 +1,59 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-platformio
+PKG_VERSION:=6.1.16
+PKG_RELEASE:=1
+
+PYPI_NAME:=platformio
+PYPI_SOURCE_NAME:=platformio
+PKG_HASH:=79387b45ca7df9c0c51cae82b3b0a40ba78d11d87cea385db47e1033d781e959
+
+PKG_MAINTAINER:=Austin Lane <vidplace7@gmail.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_HOST_ONLY:=1
+HOST_BUILD_DEPENDS:= \
+	python3/host \
+	python-build/host \
+	python-installer/host \
+	python-pyserial/host \
+	python-click/host \
+	python-semantic-version/host \
+	python-requests/host \
+	python-tabulate/host \
+	python-pyelftools/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include ../python3-package.mk
+include ../python3-host-build.mk
+
+define Package/python3-platformio
+  SECTION:=meshtastic
+  CATEGORY:=Meshtastic
+  TITLE:=PlatformIO Host Tools
+  URL:=https://github.com/platformio/platformio-core
+  BUILDONLY:=1
+  DEPENDS:= \
+	+python3-light \
+	+python3-pyserial \
+	+python3-click \
+	+python3-semantic-version \
+	+python3-requests \
+	+python3-tabulate \
+	+python3-pyelftools
+endef
+
+define Package/python3-platformio/description
+PlatformIO IDE
+endef
+
+$(eval $(call Py3Package,python3-platformio))
+$(eval $(call BuildPackage,python3-platformio))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: me
Compile tested: OpenWRT One master/snapshot

Description:
Add PlatformIO build system, required for compiling [`meshtasticd`](https://github.com/openwrt-meshtastic/openwrt-meshtastic) and other Platformio-based projects.

PlatformIO is a Python-based IDE / build system for embedded development, including Linux-based targets (among many others).

Requires PRs for dependencies:
- #25492
- #25494
- #25499
- #25501
- #25502
