### PR TITLE
python-orjson: update to version 3.10.12

### DIFF
--- a/lang/python/python-orjson/Makefile
+++ b/lang/python/python-orjson/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-orjson
-PKG_VERSION:=3.10.0
+PKG_VERSION:=3.10.12
 PKG_RELEASE:=1
 
 PYPI_NAME:=orjson
-PKG_HASH:=ba4d8cac5f2e2cff36bea6b6481cdb92b38c202bcec603d6f5ff91960595a1ed
+PKG_HASH:=0a78bbda3aea0f9f079057ee1ee8a1ecf790d4f1af88dd67493c6b8ee52506ff
 
 PKG_MAINTAINER:=Timothy Ace <openwrt@timothyace.com>
 PKG_LICENSE:=Apache-2.0 MIT


### PR DESCRIPTION
Relevant changes since previous 3.10.0:
Fixed:
- Serializing numpy.ndarray with non-native endianness raises orjson.JSONEncodeError.
- Fix int serialization on 32-bit Python 3.8, 3.9, 3.10. This was introduced in 3.10.8.
Changed:
- Improve performance of serializing.
- Drop [testing workflow] support for arm7.
- int serialization no longer chains OverflowError to the the __cause__ attribute of orjson.JSONEncodeError when range exceeded.

Maintainer: me
Compile tested:  arm_cortex-a9_vfpv3-d16, Linksys WRT1900ACS, master and aarch64_cortex-a72 just to make sure arm7 worked.
Run tested: arm_cortex-a9_vfpv3-d16, Linksys WRT1900ACS, 23.05.0 r23497-6637af95aa

Description:
Updates python-orjson from 3.10.0 -> 3.10.12