### PR TITLE
netbird: change maintainer

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -8,7 +8,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=5eb78e815c73b197f36141dbc071520171cd660a1f64a010c5ec5c4db4d006e4
 
-PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
+PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 


### PR DESCRIPTION
Maintainer: Oskari Rauta / @oskarirauta
Compile tested: N/A
Run tested: N/A

### Description

- Add myself as maintainer
- Remove `Oskari Rauta <oskari.rauta@gmail.com>`

### Motivation and a bit of background

For the past few months, I have been updating, testing, and occasionally assisting people (both publicly, as seen in at https://github.com/netbirdio/netbird/issues/2268, and privately) with `netbird`. Unfortunately, the original maintainer, @oskarirauta, has been absent for several months, and @hnyman has commented on this here: https://github.com/openwrt/packages/pull/25425#issuecomment-2496006348.

To be honest, I am not an expert in Go or OpenWrt code, but I believe it's better to have someone involved than no one at all. With time and more experience, I have plans for `netbird`, which needs more love, such as UCI integration.