### PR TITLE
[24.10] python-requests (and deps): add hostbuild

### DIFF
--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
 PKG_VERSION:=2024.2.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=MPL-2.0
@@ -16,9 +16,13 @@ PKG_LICENSE_FILES:=LICENSE
 PYPI_NAME:=certifi
 PKG_HASH:=0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f
 
+HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-wheel/host
+
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-certifi
   SUBMENU:=Python
@@ -38,3 +42,4 @@ endef
 $(eval $(call Py3Package,python3-certifi))
 $(eval $(call BuildPackage,python3-certifi))
 $(eval $(call BuildPackage,python3-certifi-src))
+$(eval $(call HostBuild))

--- a/lang/python/python-chardet/Makefile
+++ b/lang/python/python-chardet/Makefile
@@ -9,15 +9,19 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-chardet
 PKG_VERSION:=5.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=LGPL-2.1
 
 PYPI_NAME:=chardet
 PKG_HASH:=1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7
 
+HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-wheel/host
+
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-chardet
   SUBMENU:=Python
@@ -45,3 +49,4 @@ endef
 $(eval $(call Py3Package,python3-chardet))
 $(eval $(call BuildPackage,python3-chardet))
 $(eval $(call BuildPackage,python3-chardet-src))
+$(eval $(call HostBuild))

--- a/lang/python/python-idna/Makefile
+++ b/lang/python/python-idna/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-idna
 PKG_VERSION:=3.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=idna
 PKG_HASH:=9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca
@@ -19,10 +19,13 @@ PKG_LICENSE_FILES:=LICENSE.md
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
 PKG_BUILD_DEPENDS:=python-flit-core/host
+HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-flit-core/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-idna
   SECTION:=lang
@@ -43,3 +46,4 @@ endef
 $(eval $(call Py3Package,python3-idna))
 $(eval $(call BuildPackage,python3-idna))
 $(eval $(call BuildPackage,python3-idna-src))
+$(eval $(call HostBuild))

--- a/lang/python/python-requests/Makefile
+++ b/lang/python/python-requests/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-requests
 PKG_VERSION:=2.32.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -19,9 +19,17 @@ PKG_CPE_ID:=cpe:/a:python:requests
 PYPI_NAME:=requests
 PKG_HASH:=55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760
 
+HOST_BUILD_DEPENDS:= \
+  python-chardet/host \
+  python-idna/host \
+  python-urllib3/host \
+  python-certifi/host
+
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-requests
   SUBMENU:=Python
@@ -44,3 +52,4 @@ endef
 $(eval $(call Py3Package,python3-requests))
 $(eval $(call BuildPackage,python3-requests))
 $(eval $(call BuildPackage,python3-requests-src))
+$(eval $(call HostBuild))

--- a/lang/python/python-urllib3/Makefile
+++ b/lang/python/python-urllib3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-urllib3
 PKG_VERSION:=2.0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
@@ -20,10 +20,13 @@ PYPI_NAME:=urllib3
 PKG_HASH:=8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11
 
 PKG_BUILD_DEPENDS:=python-hatchling/host
+HOST_BUILD_DEPENDS:=python-hatchling/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-urllib3
   SUBMENU:=Python
@@ -41,3 +44,4 @@ endef
 $(eval $(call Py3Package,python3-urllib3))
 $(eval $(call BuildPackage,python3-urllib3))
 $(eval $(call BuildPackage,python3-urllib3-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: @commodo @BKPepe 
Compile tested: OpenWRT One 24.10 branch

Description:
Add hostbuild directives for python-requests and it's dependencies. Required for PlatformIO 24.10 backport.

Backport to `24.10`

Cherry-picked PRs:
- #25499
- #25498
- #25497
- #25496
- #25495

Related PRs:
- #26743