### PR TITLE
gst1-plugins-bad: build Intel QuickSync plugin only on x86

### DIFF
--- a/multimedia/gst1-plugins-bad/Makefile
+++ b/multimedia/gst1-plugins-bad/Makefile
@@ -218,6 +218,7 @@ MESON_ARGS += \
 	-Dopenni2=disabled \
 	-Dopensles=disabled \
 	-Dopus=$(if $(CONFIG_PACKAGE_gst1-mod-opusparse),en,dis)abled \
+	-Dqsv=$(if $(CONFIG_i386)$(CONFIG_i686)$(CONFIG_x86_64),en,dis)abled \
 	-Dresindvd=disabled \
 	-Drsvg=disabled \
 	-Drtmp=disabled \


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: x86/64, mipsel
Run tested: -

Description:
Intel Media SDK lacks support for many architectures and leads to build failing. As the QuickSync hardware feature is anyway only supported on x86 CPUs simply don't build the plugin on other platforms.