### PR TITLE
realtek-poe: build default config from board.json

### DIFF
--- a/utils/realtek-poe/Makefile
+++ b/utils/realtek-poe/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=realtek-poe
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Martin Kennedy <hurricos@gmail.com>
 
@@ -27,9 +27,10 @@ define Package/realtek-poe/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/realtek-poe $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/etc/init.d/poe $(1)/etc/init.d/
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/files/etc/config/poe $(1)/etc/config/
+	$(INSTALL_BIN) ./files/etc/uci-defaults/30-poe $(1)/etc/uci-defaults/30-poe
 endef
 
 $(eval $(call BuildPackage,realtek-poe))

--- a/utils/realtek-poe/files/etc/uci-defaults/30-poe
+++ b/utils/realtek-poe/files/etc/uci-defaults/30-poe
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+[ -e /etc/config/poe ] && exit 0
+
+. /lib/functions.sh
+. /usr/share/libubox/jshn.sh
+
+CFG=/etc/board.json
+
+json_init
+json_load_file "${CFG}"
+
+json_is_a poe object || exit 0
+
+umask 055
+touch /etc/config/poe
+
+json_select poe
+	json_get_vars budget
+
+	uci add poe global
+	uci set poe.@global[-1].budget="$budget"
+
+	if json_is_a ports array; then
+		json_get_values ports ports
+		id='1'
+
+		for port in $ports; do
+			uci -q batch <<-EOF
+				add poe port
+				set poe.@port[-1].name='$port'
+				set poe.@port[-1].id='$id'
+				set poe.@port[-1].enable='1'
+			EOF
+			let id=id+1
+		done
+	fi
+json_select ..
+
+uci commit
+
+exit 0


### PR DESCRIPTION
Maintainer: me
Compile tested: (not yet)
Run tested: (not yet)

This adjustment makes a compromise between those that would prefer not to complicate the realtek-poe.git source repository and those who want to have PoE work out-of-the-box on Realtek switches -- see realtek-poe.git, commit 2df137ee457155 ("realtek-poe/openwrt: Generate config from board.json")

Switches previously booted with OpenWrt will have an /etc/config/poe file already present, and thus the uci-default shall not take effect.
