### PR TITLE
knxd: bump to version 0.14.68

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -11,12 +11,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
-PKG_VERSION:=0.14.67
+PKG_VERSION:=0.14.68
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/knxd/knxd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=1d6290e576b079d9e751b63bd8fe9c627820d2b6a04ec811ff0b5fcc2c688abf
+PKG_HASH:=49de6adddab53b73302560fe1c2bdacc0b71ffe980bd8fdc94dbff97e15ce2e1
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/knxd/patches/0100-version.patch
+++ b/net/knxd/patches/0100-version.patch
@@ -7,4 +7,4 @@
 -test -d .git || exit
 -# git describe --tags
 -git log --format=format:%D | perl -ne 'next unless s#.*tag: ##; s#,.*##; next if m#/#; print; exit;'
-+echo -n "0.14.67"
++echo -n "0.14.68"

--- a/net/knxd/patches/0110-tcptunserver.patch
+++ b/net/knxd/patches/0110-tcptunserver.patch
@@ -1,0 +1,10 @@
+--- a/src/libserver/tcptunserver.cpp
++++ b/src/libserver/tcptunserver.cpp
+@@ -21,6 +21,7 @@
+ #include "config.h"
+ #include "tunchannel.h"
+ 
++#include <unistd.h>
+ #include <netinet/tcp.h>
+ #include <sys/un.h>
+ #include <arpa/inet.h>


### PR DESCRIPTION
Maintainer: me
Compile tested: mpc85xx, tl-wdr4900-v1, trunk
Compile tested: ath79, tplink_archer-c7-v4, trunk
Compile tested: ramips, mt7620a, trunk
Run tested: ath79, tp-link Archer C7 v4, trunk

Description:
new upstream release 0.14.68
