### PR TITLE
[24.10] lrzsz: fix random build failures by really disabling autofoo

### DIFF
--- a/utils/lrzsz/Makefile
+++ b/utils/lrzsz/Makefile
@@ -41,13 +41,6 @@ define Package/lrzsz/description
   from a variety of programs running under various operating systems.
 endef
 
-# to stop automake from running, the bundled autohell crap is too old
-define Build/Configure
-	touch $(PKG_BUILD_DIR)/*
-	touch $(PKG_BUILD_DIR)/*/*
-	$(call Build/Configure/Default)
-endef
-
 define Package/lrzsz/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/lrz $(1)/usr/bin/

--- a/utils/lrzsz/patches/300-neutralize-autofoo.patch
+++ b/utils/lrzsz/patches/300-neutralize-autofoo.patch
@@ -1,0 +1,72 @@
+autofoo stuff is really ancient, so lets make sure, that its never called.
+
+Fixes: openwrt/packages/issues/25543
+Signed-off-by: Petr Štetiar <ynezz@true.cz>
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -92,7 +92,7 @@ USE_NLS = @USE_NLS@
+ VERSION = @VERSION@
+ l = @l@
+ 
+-SUBDIRS = lib intl src po man testsuite
++SUBDIRS = lib intl src po
+ EXTRA_DIST = check.lrzsz COMPATABILITY README.cvs README.isdn4linux 	README.gettext rpmrc buildrpm systype.in fastcheck.sh README.tests 	beos-runpiped.c fastcheck.beos
+ 
+ noinst_SCRIPTS = systype
+@@ -117,19 +117,16 @@ GZIP_ENV = --best
+ all: all-redirect
+ .SUFFIXES:
+ $(srcdir)/Makefile.in: Makefile.am $(top_srcdir)/configure.in $(ACLOCAL_M4) 
+-	cd $(top_srcdir) && $(AUTOMAKE) --gnu Makefile
+ 
+ Makefile: $(srcdir)/Makefile.in  $(top_builddir)/config.status $(BUILT_SOURCES)
+ 	cd $(top_builddir) \
+ 	  && CONFIG_FILES=$@ CONFIG_HEADERS= $(SHELL) ./config.status
+ 
+ $(ACLOCAL_M4):  configure.in  acinclude.m4
+-	cd $(srcdir) && $(ACLOCAL)
+ 
+ config.status: $(srcdir)/configure $(CONFIG_STATUS_DEPENDENCIES)
+ 	$(SHELL) ./config.status --recheck
+ $(srcdir)/configure: $(srcdir)/configure.in $(ACLOCAL_M4) $(CONFIGURE_DEPENDENCIES)
+-	cd $(srcdir) && $(AUTOCONF)
+ 
+ config.h: stamp-h
+ 	@if test ! -f $@; then \
+@@ -147,7 +144,6 @@ $(srcdir)/config.h.in: $(srcdir)/stamp-h
+ 		$(MAKE) $(srcdir)/stamp-h.in; \
+ 	else :; fi
+ $(srcdir)/stamp-h.in: $(top_srcdir)/configure.in $(ACLOCAL_M4) acconfig.h
+-	cd $(top_srcdir) && $(AUTOHEADER)
+ 	@echo timestamp > $(srcdir)/stamp-h.in 2> /dev/null
+ 
+ mostlyclean-hdr:
+--- a/lib/Makefile.in
++++ b/lib/Makefile.in
+@@ -141,7 +141,6 @@ all: all-redirect
+ .SUFFIXES:
+ .SUFFIXES: .S .c .o .s
+ $(srcdir)/Makefile.in: Makefile.am $(top_srcdir)/configure.in $(ACLOCAL_M4) 
+-	cd $(top_srcdir) && $(AUTOMAKE) --gnu lib/Makefile
+ 
+ Makefile: $(srcdir)/Makefile.in  $(top_builddir)/config.status $(BUILT_SOURCES)
+ 	cd $(top_builddir) \
+--- a/man/Makefile.in
++++ b/man/Makefile.in
+@@ -111,7 +111,6 @@ GZIP_ENV = --best
+ all: all-redirect
+ .SUFFIXES:
+ $(srcdir)/Makefile.in: Makefile.am $(top_srcdir)/configure.in $(ACLOCAL_M4) 
+-	cd $(top_srcdir) && $(AUTOMAKE) --gnu man/Makefile
+ 
+ Makefile: $(srcdir)/Makefile.in  $(top_builddir)/config.status $(BUILT_SOURCES)
+ 	cd $(top_builddir) \
+@@ -168,8 +167,6 @@ distdir: $(DISTFILES)
+ 	here=`cd $(top_builddir) && pwd`; \
+ 	top_distdir=`cd $(top_distdir) && pwd`; \
+ 	distdir=`cd $(distdir) && pwd`; \
+-	cd $(top_srcdir) \
+-	  && $(AUTOMAKE) --include-deps --build-dir=$$here --srcdir-name=$(top_srcdir) --output-dir=$$top_distdir --gnu man/Makefile
+ 	@for file in $(DISTFILES); do \
+ 	  d=$(srcdir); \
+ 	  if test -d $$d/$$file; then \


### PR DESCRIPTION
(cherry picked from commit https://github.com/openwrt/packages/commit/3e612586041d40ebfafadb65eaa6fc34b2061ee8)

Maintainer: @kuoruan, Cc: @dhewg 
Compile tested: x86_64
Run tested: Not yet

Description:

Currently we're seeing random build failures, caused by autofoo being called on very ancient bundled autofoo:

```shell
  cd . && aclocal
  aclocal.real: warning: autoconf input should be named 'configure.ac', not 'configure.in'
  acinclude.m4:2: warning: underquoted definition of AC_REPLACE_GNU_GETOPT
  acinclude.m4:2:   run info Automake 'Extending aclocal'
  acinclude.m4:2:   or see https://www.gnu.org/software/automake/manual/automake.html#Extending-aclocal
  configure.in:106: error: automatic de-ANSI-fication support has been removed
```

For some reason that `touch` based neutralization introduced in commit 6d6c4b21b5e2 ("lrzsz: update to v0.12.21rc and fix a CVE") doesn't always work.

So lets fix it by removing the autofoo bits from the bundled Makefile.in and while at it remove processing of man and testsuite subdirs to save some computing cycles.

Fixes: #25543
Fixes: 6d6c4b21b5e2 ("lrzsz: update to v0.12.21rc and fix a CVE")

### Impact

#### 24.10
https://downloads.openwrt.org/releases/faillogs-24.10/arm_cortex-a9/packages/lrzsz/compile.txt
```shell
cd . && automake --gnu Makefile
automake: warning: autoconf input should be named 'configure.ac', not 'configure.in'
configure.in:3: warning: AM_INIT_AUTOMAKE: two- and three-arguments forms are deprecated.  For more info, see:
configure.in:3: https://www.gnu.org/software/automake/manual/automake.html#Modernize-AM_005fINIT_005fAUTOMAKE-invocation
configure.in:3: error: your implementation of AM_INIT_AUTOMAKE comes from an
```