### PR TITLE
abseil-cpp: Add package

### DIFF
--- a/libs/abseil-cpp/Makefile
+++ b/libs/abseil-cpp/Makefile
@@ -1,0 +1,56 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=abseil-cpp
+PKG_VERSION:=20240722.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/abseil/abseil-cpp/releases/download/$(PKG_VERSION)
+PKG_HASH:=f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3
+
+PKG_MAINTAINER:=Austin Lane <vidplace7@gmail.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/abseil-cpp
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Collection of C++ code designed to augment the C++ standard library
+  URL:=https://github.com/abseil/abseil-cpp
+  DEPENDS:=+libpthread +libstdcpp
+endef
+
+define Package/abseil-cpp/description
+Abseil is an open-source collection of C++ code (compliant to C++14) designed to augment the C++ standard library.
+endef
+
+CMAKE_INSTALL:=1
+
+CMAKE_HOST_OPTIONS += \
+	-DCMAKE_CXX_STANDARD=14 \
+	-DABSL_ENABLE_INSTALL=ON \
+	-DABSL_USE_GOOGLETEST_HEAD=OFF
+
+CMAKE_OPTIONS += \
+	-DCMAKE_CXX_STANDARD=14 \
+	-DABSL_ENABLE_INSTALL=ON \
+	-DABSL_USE_GOOGLETEST_HEAD=OFF
+
+TARGET_CFLAGS += $(FPIC)
+
+define Build/InstallDev
+	$(call Build/InstallDev/cmake,$(1))
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/absl_*.pc
+	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/absl_*.pc
+endef
+
+$(eval $(call BuildPackage,abseil-cpp))
+$(eval $(call HostBuild))

--- a/libs/abseil-cpp/patches/001-absl-always-use-asm-sgidefs.h.patch
+++ b/libs/abseil-cpp/patches/001-absl-always-use-asm-sgidefs.h.patch
@@ -1,0 +1,34 @@
+# From https://git.openembedded.org/meta-openembedded/tree/meta-oe/recipes-devtools/abseil-cpp
+From 11faa06436fdeb0c9948080a11f9a99d3b5ba16c Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 9 Apr 2020 13:06:27 -0700
+Subject: [PATCH] absl: always use <asm/sgidefs.h>
+
+Fixes mips/musl build, since sgidefs.h is not present on all C libraries
+but on linux asm/sgidefs.h is there and contains same definitions, using
+that makes it portable.
+
+Upstream-Status: Pending
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ absl/base/internal/direct_mmap.h | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+--- a/absl/base/internal/direct_mmap.h
++++ b/absl/base/internal/direct_mmap.h
+@@ -41,13 +41,9 @@
+ 
+ #ifdef __mips__
+ // Include definitions of the ABI currently in use.
+-#if defined(__BIONIC__) || !defined(__GLIBC__)
+-// Android doesn't have sgidefs.h, but does have asm/sgidefs.h, which has the
++// bionic/musl C libs don't have sgidefs.h, but do have asm/sgidefs.h, which has the
+ // definitions we need.
+ #include <asm/sgidefs.h>
+-#else
+-#include <sgidefs.h>
+-#endif  // __BIONIC__ || !__GLIBC__
+ #endif  // __mips__
+ 
+ // SYS_mmap and SYS_munmap are not defined in Android.

--- a/libs/abseil-cpp/patches/002-Remove-maes-option-from-cross-compilation.patch
+++ b/libs/abseil-cpp/patches/002-Remove-maes-option-from-cross-compilation.patch
@@ -1,0 +1,32 @@
+# From https://git.openembedded.org/meta-openembedded/tree/meta-oe/recipes-devtools/abseil-cpp
+From a573ccd57e713486e7d8e782d6b3b34fde01ff9e Mon Sep 17 00:00:00 2001
+From: Sinan Kaya <sinan.kaya@microsoft.com>
+Date: Mon, 3 Feb 2020 03:25:57 +0000
+Subject: [PATCH] Remove maes option from cross-compilation
+
+Upstream-Status: Pending
+---
+ absl/copts/GENERATED_AbseilCopts.cmake | 4 ----
+ absl/copts/GENERATED_copts.bzl         | 4 ----
+ 2 files changed, 8 deletions(-)
+
+--- a/absl/copts/GENERATED_AbseilCopts.cmake
++++ b/absl/copts/GENERATED_AbseilCopts.cmake
+@@ -229,7 +229,3 @@ list(APPEND ABSL_RANDOM_HWAES_ARM64_FLAG
+ list(APPEND ABSL_RANDOM_HWAES_MSVC_X64_FLAGS
+ )
+ 
+-list(APPEND ABSL_RANDOM_HWAES_X64_FLAGS
+-    "-maes"
+-    "-msse4.1"
+-)
+--- a/absl/copts/GENERATED_copts.bzl
++++ b/absl/copts/GENERATED_copts.bzl
+@@ -230,7 +230,3 @@ ABSL_RANDOM_HWAES_ARM64_FLAGS = [
+ ABSL_RANDOM_HWAES_MSVC_X64_FLAGS = [
+ ]
+ 
+-ABSL_RANDOM_HWAES_X64_FLAGS = [
+-    "-maes",
+-    "-msse4.1",
+-]

--- a/libs/abseil-cpp/patches/003-Remove-neon-option-from-cross-compilation.patch
+++ b/libs/abseil-cpp/patches/003-Remove-neon-option-from-cross-compilation.patch
@@ -1,0 +1,43 @@
+# From https://git.openembedded.org/meta-openembedded/tree/meta-oe/recipes-devtools/abseil-cpp
+From 632632508daf8bb3a5800dac937ffc33c6d85973 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Thu, 16 Jun 2022 11:46:31 +0000
+Subject: [PATCH] Remove neon option from cross compilation
+
+Not every arm platform supports neon instructions, so do not enforce
+them.
+
+Upstream-Status: Pending
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ absl/copts/GENERATED_AbseilCopts.cmake | 4 ----
+ absl/copts/GENERATED_copts.bzl         | 4 ----
+ 2 files changed, 8 deletions(-)
+
+--- a/absl/copts/GENERATED_AbseilCopts.cmake
++++ b/absl/copts/GENERATED_AbseilCopts.cmake
+@@ -218,10 +218,6 @@ list(APPEND ABSL_MSVC_TEST_FLAGS
+     "/DNOMINMAX"
+ )
+ 
+-list(APPEND ABSL_RANDOM_HWAES_ARM32_FLAGS
+-    "-mfpu=neon"
+-)
+-
+ list(APPEND ABSL_RANDOM_HWAES_ARM64_FLAGS
+     "-march=armv8-a+crypto"
+ )
+--- a/absl/copts/GENERATED_copts.bzl
++++ b/absl/copts/GENERATED_copts.bzl
+@@ -219,10 +219,6 @@ ABSL_MSVC_TEST_FLAGS = [
+     "/DNOMINMAX",
+ ]
+ 
+-ABSL_RANDOM_HWAES_ARM32_FLAGS = [
+-    "-mfpu=neon",
+-]
+-
+ ABSL_RANDOM_HWAES_ARM64_FLAGS = [
+     "-march=armv8-a+crypto",
+ ]

--- a/libs/abseil-cpp/patches/004-abseil-ppc-fixes.patch
+++ b/libs/abseil-cpp/patches/004-abseil-ppc-fixes.patch
@@ -1,0 +1,93 @@
+# From https://git.openembedded.org/meta-openembedded/tree/meta-oe/recipes-devtools/abseil-cpp
+From f9607924225ca59fb6c60222e6424b84e6f70029 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 21 Sep 2024 20:53:06 +0800
+Subject: [PATCH] abseil: ppc fixes
+
+An all-in-one patch that fixes several issues:
+
+1) UnscaledCycleClock not fully implemented for ppc*-musl (disabled on musl)
+2) powerpc stacktrace implementation only works on glibc (disabled on musl)
+3) powerpc stacktrace implementation has ppc64 assumptions (fixed)
+4) examine_stack.cpp makes glibc assumptions on powerpc (fixed)
+
+Sourced from void linux
+
+Upstream-Status: Pending
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ absl/base/internal/unscaledcycleclock.cc       | 4 ++--
+ absl/base/internal/unscaledcycleclock_config.h | 3 ++-
+ absl/debugging/internal/examine_stack.cc       | 8 +++++++-
+ absl/debugging/internal/stacktrace_config.h    | 2 +-
+ 4 files changed, 12 insertions(+), 5 deletions(-)
+
+--- a/absl/base/internal/unscaledcycleclock.cc
++++ b/absl/base/internal/unscaledcycleclock.cc
+@@ -20,7 +20,7 @@
+ #include <intrin.h>
+ #endif
+ 
+-#if defined(__powerpc__) || defined(__ppc__)
++#if (defined(__powerpc__) || defined(__ppc__)) && defined(__GLIBC__)
+ #ifdef __GLIBC__
+ #include <sys/platform/ppc.h>
+ #elif defined(__FreeBSD__)
+@@ -58,7 +58,7 @@ double UnscaledCycleClock::Frequency() {
+   return base_internal::NominalCPUFrequency();
+ }
+ 
+-#elif defined(__powerpc__) || defined(__ppc__)
++#elif (defined(__powerpc__) || defined(__ppc__)) && defined(__GLIBC__)
+ 
+ int64_t UnscaledCycleClock::Now() {
+ #ifdef __GLIBC__
+--- a/absl/base/internal/unscaledcycleclock_config.h
++++ b/absl/base/internal/unscaledcycleclock_config.h
+@@ -21,7 +21,8 @@
+ 
+ // The following platforms have an implementation of a hardware counter.
+ #if defined(__i386__) || defined(__x86_64__) || defined(__aarch64__) || \
+-    defined(__powerpc__) || defined(__ppc__) || defined(_M_IX86) ||     \
++    ((defined(__powerpc__) || defined(__ppc__)) && defined(__GLIBC__)) || \
++    defined(_M_IX86) ||     \
+     (defined(_M_X64) && !defined(_M_ARM64EC))
+ #define ABSL_HAVE_UNSCALED_CYCLECLOCK_IMPLEMENTATION 1
+ #else
+--- a/absl/debugging/internal/examine_stack.cc
++++ b/absl/debugging/internal/examine_stack.cc
+@@ -36,6 +36,10 @@
+ #include <csignal>
+ #include <cstdio>
+ 
++#if defined(__powerpc__)
++#include <asm/ptrace.h>
++#endif
++
+ #include "absl/base/attributes.h"
+ #include "absl/base/internal/raw_logging.h"
+ #include "absl/base/macros.h"
+@@ -177,8 +181,10 @@ void* GetProgramCounter(void* const vuc)
+     return reinterpret_cast<void*>(context->uc_mcontext.pc);
+ #elif defined(__powerpc64__)
+     return reinterpret_cast<void*>(context->uc_mcontext.gp_regs[32]);
+-#elif defined(__powerpc__)
++#elif defined(__powerpc__) && defined(__GLIBC__)
+     return reinterpret_cast<void*>(context->uc_mcontext.uc_regs->gregs[32]);
++#elif defined(__powerpc__)
++    return reinterpret_cast<void*>((context->uc_regs)->gregs[32]);
+ #elif defined(__riscv)
+     return reinterpret_cast<void*>(context->uc_mcontext.__gregs[REG_PC]);
+ #elif defined(__s390__) && !defined(__s390x__)
+--- a/absl/debugging/internal/stacktrace_config.h
++++ b/absl/debugging/internal/stacktrace_config.h
+@@ -60,7 +60,7 @@
+ #elif defined(__i386__) || defined(__x86_64__)
+ #define ABSL_STACKTRACE_INL_HEADER \
+   "absl/debugging/internal/stacktrace_x86-inl.inc"
+-#elif defined(__ppc__) || defined(__PPC__)
++#elif (defined(__ppc__) || defined(__PPC__)) && defined(__GLIBC__)
+ #define ABSL_STACKTRACE_INL_HEADER \
+   "absl/debugging/internal/stacktrace_powerpc-inl.inc"
+ #elif defined(__aarch64__)

--- a/libs/abseil-cpp/patches/005-Don-t-match-Wnon-virtual-dtor-in-the-flags-are-neede.patch
+++ b/libs/abseil-cpp/patches/005-Don-t-match-Wnon-virtual-dtor-in-the-flags-are-neede.patch
@@ -1,0 +1,29 @@
+# From https://git.openembedded.org/meta-openembedded/tree/meta-oe/recipes-devtools/abseil-cpp
+From 9cb5e5d15c142e5cc43a2c1db87c8e4e5b6d38a5 Mon Sep 17 00:00:00 2001
+From: Derek Mauro <dmauro@google.com>
+Date: Mon, 5 Aug 2024 07:35:05 -0700
+Subject: [PATCH] Don't match -Wnon-virtual-dtor in the "flags are needed to
+ suppress warnings in headers". It should fall through to the "don't impose
+ our warnings on others" case. Do this by matching on "-Wno-*" instead of
+ "-Wno*".
+
+Fixes #1737
+
+PiperOrigin-RevId: 659548798
+Change-Id: I49d7ba7ddcd7be30f946fca90ba9be467181e854
+Upstream-Status: Backport [https://github.com/abseil/abseil-cpp/commit/9cb5e5d15c142e5cc43a2c1db87c8e4e5b6d38a5]
+---
+ CMake/AbseilHelpers.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/CMake/AbseilHelpers.cmake
++++ b/CMake/AbseilHelpers.cmake
+@@ -195,7 +195,7 @@ function(absl_cc_library)
+         # specified platform. Filter both of them out before the successor
+         # reaches the "^-m" filter.
+         set(skip_next_cflag ON)
+-      elseif(${cflag} MATCHES "^(-Wno|/wd)")
++      elseif(${cflag} MATCHES "^(-Wno-|/wd)")
+         # These flags are needed to suppress warnings that might fire in our headers.
+         set(PC_CFLAGS "${PC_CFLAGS} ${cflag}")
+       elseif(${cflag} MATCHES "^(-W|/w[1234eo])")


### PR DESCRIPTION
Maintainer: me
Compile tested:
- OpenWRT One master/snapshot (local)
- CI at [openwrt-meshtastic](https://github.com/openwrt-meshtastic/openwrt-meshtastic/actions/runs/12367901614)

Description:
Adds new package `abseil-cpp`. This is a dependency for many Google C libraries / projects. Notably `protobuf` >= 22.x, but also: gRPC, tensorflow, and many others.

Pre-requisite in order to update the `protobuf` package.
https://protobuf.dev/support/migration/#abseil