### PR TITLE
coremark: fix error when it was built in the second run

### DIFF
--- a/utils/coremark/Makefile
+++ b/utils/coremark/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=coremark
 PKG_SOURCE_DATE:=2023-01-25
 PKG_SOURCE_VERSION:=d5fad6bd094899101a4e5fd53af7298160ced6ab
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_DATE).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eembc/coremark/tar.gz/$(PKG_SOURCE_VERSION)?
@@ -70,8 +70,8 @@ endif
 
 define Build/Compile
 	$(SED) 's|EXE = .exe|EXE =|' $(PKG_BUILD_DIR)/posix/core_portme.mak
-	mkdir $(PKG_BUILD_DIR)/$(ARCH)
-	$(CP) -r $(PKG_BUILD_DIR)/linux/* $(PKG_BUILD_DIR)/$(ARCH)
+	mkdir -p $(PKG_BUILD_DIR)/$(ARCH)
+	$(CP) $(PKG_BUILD_DIR)/linux/* $(PKG_BUILD_DIR)/$(ARCH)/
 	$(MAKE) -C $(PKG_BUILD_DIR) PORT_DIR=$(ARCH) $(MAKE_FLAGS) \
 		PORT_CFLAGS="$(TARGET_CFLAGS)" XCFLAGS="$(EXTRA_CFLAGS)" compile
 endef


### PR DESCRIPTION
**Maintainer**: @abajk
**Compile tested**: (aarch64, qualcommax, SNAPSHOT)
**Run tested**: (aarch64, qualcommax, SNAPSHOT, tests done)

**Description**:
when there is an error building packages(other than coremark), and re-run with make -j1 V=s, the coremark package will report error

```
mkdir: cannot create directory '.../coremark-d5fad6bd094899101a4e5fd53af7298160ced6ab/aarch64': File exists
```

so, add a check to see if that dir is already there;

the root cause is that, in the second run, that folder is already created in the first run, and not removed before the second run.

also, add a '/' to the destination folder of the cp command, otherwise it will also report a "file exist" error.

the '-r' is also removed, since $(CP) already have -r

fixes https://github.com/immortalwrt/packages/issues/1380

P.S. I'm not sure if this can be done by move the "mkdir" to `Build/Prepare` or `Build/Configure`, cause I'm not quite familiar with the Openwrt build system, so any comment is warmly welcome.
