### PR TITLE
[ddns] Support IPv6 for joker.com

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=52
+PKG_RELEASE:=53
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/joker.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/joker.com.json
@@ -3,5 +3,9 @@
 	"ipv4": {
 		"url": "http://svc.joker.com/nic/update?username=[USERNAME]&password=[PASSWORD]&myip=[IP]&hostname=[DOMAIN]",
 		"answer": "good|nochg"
+	},
+	"ipv6": {
+		"url": "http://svc.joker.com/nic/update?username=[USERNAME]&password=[PASSWORD]&myip=[IP]&hostname=[DOMAIN]",
+		"answer": "good|nochg"
 	}
 }


### PR DESCRIPTION
The existing endpoint can handle IPv6 addresses as well.
I am currently using a `custom` configuration with the settings from this PR to update my IPv6 address.