### PR TITLE
net-snmp: support compilation with GCC 11 permissively

### DIFF
--- a/net/net-snmp/patches/200-add-pcre2-support.patch
+++ b/net/net-snmp/patches/200-add-pcre2-support.patch
@@ -211,7 +211,7 @@ Subject: [PATCH] add pcre2 support
 +#ifdef HAVE_PCRE2_H
 +#define PCRE2_CODE_UNIT_WIDTH 8
 +#include <pcre2.h>
-+#elifdef HAVE_PCRE_H
++#elif defined(HAVE_PCRE_H)
  #include <pcre.h>
  #endif
  
@@ -262,7 +262,7 @@ Subject: [PATCH] add pcre2 support
 +                if ((*procp)->regexp.regex_ptr == NULL) {
 +                    config_perror(pcre2_error_msg);
 +                }
-+#elifdef HAVE_PCRE_H
++#elif defined(HAVE_PCRE_H)
                  const char *pcre_error;
                  int pcre_error_offset;
  


### PR DESCRIPTION
Maintainer: @stintel

Compile tested: armv7, imx/cortexa7, OpenWrt 23.05

Description:
200-add-pcre2-support.patch uses `#elif defined` 9 times and `#elifdef` twice.
Maybe we can change those two `#elifdef` to `#elif defined` so that it is more consistent and more permissive to GCC 11?