### PR TITLE
lxc: update to 6.0.3

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
-PKG_VERSION:=6.0.2
+PKG_VERSION:=6.0.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/
-PKG_HASH:=1930aa10d892db8531d1353d15f7ebf5913e74a19e134423e4d074c07f2d6e8b
+PKG_HASH:=adac0837d2abfd2903916eaf56f60756f131327311f4f25ad917f6a71f73f98c
 
 PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later BSD-2-Clause GPL-2.0


### PR DESCRIPTION
No patches needed to be rebased/simple version bump.

Build system: x86/64
Build-tested: x86/64
Run-tested: x86/64

Maintainer: @ratkaj