### PR TITLE
vpnc: update version and add nossl variant

### DIFF
--- a/net/vpnc/Makefile
+++ b/net/vpnc/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vpnc
-PKG_SOURCE_DATE:=2022-05-17
-PKG_SOURCE_VERSION:=5c0ea6a3ba77f889063abfc43ac3b688ad8d6f86
+PKG_SOURCE_DATE:=2024-12-20
+PKG_SOURCE_VERSION:=d58afaaafb6a43cb21bb08282b54480d7b2cc6ab
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/streambinder/vpnc
-PKG_MIRROR_HASH:=228dae3ec92316e7f0870b137bb4dc659c3dbdbd566990d5ecdaa878e63571eb
+PKG_MIRROR_HASH:=1058679c951db0f53de4cd22942bb6d2c80647bb13fb62a70d71316ce7544fc4
 
 PKG_MAINTAINER:=Daniel Gimpelevich <daniel@gimpelevich.san-francisco.ca.us>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -31,24 +31,37 @@ define Package/vpnc/config
 	source "$(SOURCE)/Config.in"
 endef
 
-define Package/vpnc
+define Package/vpnc/default
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=\
 	  +libgpg-error \
 	  +libgcrypt \
 	  +kmod-tun \
-	  +VPNC_OPENSSL:libopenssl \
-	  +VPNC_GNUTLS:libgnutls \
 	  +vpnc-scripts \
 	  +resolveip \
 
   TITLE:=VPN client for Cisco EasyVPN
   URL:=https://davidepucci.it/doc/vpnc/
   SUBMENU:=VPN
+  PROVIDES:=vpnc
 endef
 
-define Package/vpnc/description
+define Package/vpnc-nossl
+  $(call Package/vpnc/default)
+  TITLE+= (without SSL)
+  VARIANT:=nossl
+endef
+
+define Package/vpnc
+  $(call Package/vpnc/default)
+  TITLE+= (with SSL)
+  DEPENDS+= +VPNC_OPENSSL:libopenssl \
+            +VPNC_GNUTLS:libgnutls
+  VARIANT:=ssl
+endef
+
+define Package/vpnc/default/description
 	A VPN client compatible with Cisco's EasyVPN equipment.
 
 	Supports IPSec (ESP) with Mode Configuration and Xauth.  Supports only
@@ -56,11 +69,39 @@ define Package/vpnc/description
 	3DES, 1DES, MD5, SHA1, DH1/2/5/14/15/16/17/18 and IP tunneling.
 endef
 
-define Package/vpnc/conffiles
+define Package/vpnc/description
+	$(call Package/vpnc/default/description)
+	This package is built with SSL support.
+	This is needed for VPN connections which rely on SSL certificates.
+	(It supports all types of connections vpnc handles.)
+	If your router does not have space available for a TLS library
+	and your endpoint is using a pre-shared group key, you can install
+	the vpnc-nossl package instead. This will not affect the security
+	of your connection.
+endef
+
+define Package/vpnc-nossl/description
+	$(call Package/vpnc/default/description)
+	This package is built without SSL support.
+	It will only support connections with a pre-shared group key.
+	(For example it allows connectiong to an AVM FRITZ!Box.)
+	If this package allows you to connect to your remote endpoint,
+	it means your endpoint is not using SSL and the regular package
+	would only take up more space. If your endpoint uses SSL, this
+	version will refuse to connect.
+endef
+
+define Package/vpnc-default/conffiles
 /etc/vpnc/default.conf
 endef
 
-OPENSSL-y:=OPENSSL_GPL_VIOLATION=yes
+ifeq ($(BUILD_VARIANT),ssl)
+  OPENSSL-y:=OPENSSL_GPL_VIOLATION=yes
+endif
+
+ifeq ($(BUILD_VARIANT),nossl)
+  CRYPTO_NONE_MAKEFLAG:=CRYPTO_NONE=yes
+endif
 
 define Build/Compile
 	mkdir $(PKG_BUILD_DIR)/bin
@@ -69,7 +110,8 @@ define Build/Compile
 		OS="Linux" \
 		VERSION="$(PKG_VERSION)" \
 		$(OPENSSL-$(CONFIG_VPNC_OPENSSL)) \
-		vpnc \
+                $(CRYPTO_NONE_MAKEFLAG) \
+		$(PKG_BUILD_DIR)/bin/vpnc \
 	)
 endef
 
@@ -86,4 +128,7 @@ define Package/vpnc/install
 	$(INSTALL_DATA) ./files/vpnc.upgrade $(1)/lib/upgrade/keep.d/vpnc
 endef
 
+Package/vpnc-nossl/install=$(Package/vpnc/install)
+
 $(eval $(call BuildPackage,vpnc))
+$(eval $(call BuildPackage,vpnc-nossl))

--- a/net/vpnc/Makefile
+++ b/net/vpnc/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vpnc
-PKG_SOURCE_DATE:=2022-05-17
-PKG_SOURCE_VERSION:=5c0ea6a3ba77f889063abfc43ac3b688ad8d6f86
+PKG_SOURCE_DATE:=2024-12-20
+PKG_SOURCE_VERSION:=d58afaaafb6a43cb21bb08282b54480d7b2cc6ab
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/streambinder/vpnc
-PKG_MIRROR_HASH:=228dae3ec92316e7f0870b137bb4dc659c3dbdbd566990d5ecdaa878e63571eb
+PKG_MIRROR_HASH:=2ed427c2689f2089a36b22406b4aa731c37fff59a45254a35f087ef6615eb8e6
 
 PKG_MAINTAINER:=Daniel Gimpelevich <daniel@gimpelevich.san-francisco.ca.us>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -31,36 +31,81 @@ define Package/vpnc/config
 	source "$(SOURCE)/Config.in"
 endef
 
-define Package/vpnc
+define Package/vpnc/default
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=\
 	  +libgpg-error \
 	  +libgcrypt \
 	  +kmod-tun \
-	  +VPNC_OPENSSL:libopenssl \
-	  +VPNC_GNUTLS:libgnutls \
 	  +vpnc-scripts \
 	  +resolveip \
 
   TITLE:=VPN client for Cisco EasyVPN
   URL:=https://davidepucci.it/doc/vpnc/
   SUBMENU:=VPN
+  PROVIDES:=vpnc
+endef
+
+define Package/vpnc-nossl
+  $(call Package/vpnc/default)
+  TITLE+= (without SSL)
+  CONFLICTS:=vpnc
+  VARIANT:=nossl
+endef
+
+define Package/vpnc
+  $(call Package/vpnc/default)
+  TITLE+= (with SSL)
+  DEPENDS+= +VPNC_OPENSSL:libopenssl \
+            +VPNC_GNUTLS:libgnutls
+  CONFLICTS:=vpnc-nossl
+  VARIANT:=ssl
+endef
+
+define Package/vpnc/default/description
+  A VPN client compatible with Cisco's EasyVPN equipment.
+
+  Supports IPSec (ESP) with Mode Configuration and Xauth.  Supports only
+  shared-secret IPSec authentication with Xauth, AES (256, 192, 128),
+  3DES, 1DES, MD5, SHA1, DH1/2/5/14/15/16/17/18 and IP tunneling.
 endef
 
 define Package/vpnc/description
-	A VPN client compatible with Cisco's EasyVPN equipment.
+  $(call Package/vpnc/default/description)
+  This package is built with SSL support.
+  This is needed for VPN connections which rely on SSL certificates.
+  (It supports all types of connections vpnc handles.)
+  If your router does not have space available for a TLS library
+  and your endpoint is using a pre-shared group key, you can install
+  the vpnc-nossl package instead. This will not affect the security
+  of your connection.
+endef
 
-	Supports IPSec (ESP) with Mode Configuration and Xauth.  Supports only
-	shared-secret IPSec authentication with Xauth, AES (256, 192, 128),
-	3DES, 1DES, MD5, SHA1, DH1/2/5/14/15/16/17/18 and IP tunneling.
+define Package/vpnc-nossl/description
+  $(call Package/vpnc/default/description)
+  This package is built without SSL support.
+  It will only support connections with a pre-shared group key.
+  (For example it allows connectiong to an AVM FRITZ!Box.)
+  If this package allows you to connect to your remote endpoint,
+  it means your endpoint is not using SSL and the regular package
+  would only take up more space. If your endpoint uses SSL, this
+  version will refuse to connect.
 endef
 
 define Package/vpnc/conffiles
 /etc/vpnc/default.conf
 endef
 
-OPENSSL-y:=OPENSSL_GPL_VIOLATION=yes
+Package/vpnc-nossl/conffiles=$(Package/vpnc/conffiles)
+
+ifeq ($(BUILD_VARIANT),ssl)
+  OPENSSL-y:=OPENSSL_GPL_VIOLATION=yes
+endif
+
+ifeq ($(BUILD_VARIANT),nossl)
+  CRYPTO_NONE_MAKEFLAG:=CRYPTO_NONE=yes
+endif
 
 define Build/Compile
 	mkdir $(PKG_BUILD_DIR)/bin
@@ -69,7 +114,8 @@ define Build/Compile
 		OS="Linux" \
 		VERSION="$(PKG_VERSION)" \
 		$(OPENSSL-$(CONFIG_VPNC_OPENSSL)) \
-		vpnc \
+		$(CRYPTO_NONE_MAKEFLAG) \
+		$(PKG_BUILD_DIR)/bin/vpnc \
 	)
 endef
 
@@ -86,4 +132,7 @@ define Package/vpnc/install
 	$(INSTALL_DATA) ./files/vpnc.upgrade $(1)/lib/upgrade/keep.d/vpnc
 endef
 
+Package/vpnc-nossl/install=$(Package/vpnc/install)
+
 $(eval $(call BuildPackage,vpnc))
+$(eval $(call BuildPackage,vpnc-nossl))

--- a/net/vpnc/patches/110-openssl-deprecated.patch
+++ b/net/vpnc/patches/110-openssl-deprecated.patch
@@ -1,6 +1,17 @@
+From 37a37bab0b6a632461f484de298c52f872842774 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 1 Jan 2019 23:55:24 -0800
+Subject: [PATCH] Fix compilation without deprecated OpenSSL 1.x APIs
+
+---
+ src/crypto-openssl.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/crypto-openssl.c b/src/crypto-openssl.c
+index d5a6a0b..427838b 100644
 --- a/src/crypto-openssl.c
 +++ b/src/crypto-openssl.c
-@@ -20,6 +20,7 @@
+@@ -11,6 +11,7 @@
  #include <string.h>
  #include <errno.h>
  #include <openssl/pem.h>
@@ -8,7 +19,7 @@
  #include "config.h"
  #include "sysdep.h"
  #include "crypto.h"
-@@ -35,10 +36,12 @@ crypto_ctx *crypto_ctx_new(crypto_error
+@@ -26,10 +27,12 @@ crypto_ctx *crypto_ctx_new(crypto_error **error)
  		return NULL;
  	}
  
@@ -21,3 +32,6 @@
  
  	memset(ctx, 0, sizeof(crypto_ctx));
  	ctx->stack = sk_X509_new_null();
+-- 
+2.43.0
+


### PR DESCRIPTION
Maintainer: @danielg4
Compile tested: (mipsel_24kc_musl, TP-Link Archer C50v6, f10ee1e20966bdb86cb61a87338f953de1d86cc6)
Compile tested: (arm_arm1176jzf-s_vfp, Raspberry Pi Model B Rev 2, 24.10.0-rc7)
Run tested: (arm_arm1176jzf-s_vfp, Raspberry Pi Model B Rev 2, 24.10.0-rc7)

Description:
Updated vpnc to the latest version. I submitted a patch that allows compilation without an SSL library. When using a pre-shared group key, vpnc doesn't use its SSL library, so for many cases this is not needed while it allows vpnc to be used on devices with little space where an SSL library does not fit. See also: https://github.com/streambinder/vpnc/pull/55

Note that I still need to test the newer version and will report back. Many thanks in advance for any feedback you might have!