### PR TITLE
python-installer: patch behavior for when script file exists

### DIFF
--- a/lang/python/python-installer/Makefile
+++ b/lang/python/python-installer/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-installer
 PKG_VERSION:=0.7.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=installer
 PKG_HASH:=a26d3e3116289bb08216e0d0f7d925fcef0b0194eedfa0c944bcaaa106c4b631

--- a/lang/python/python-installer/patches/001-don-t-raise-error-if-file-exists.patch
+++ b/lang/python/python-installer/patches/001-don-t-raise-error-if-file-exists.patch
@@ -1,0 +1,13 @@
+diff --git a/src/installer/destinations.py b/src/installer/destinations.py
+index a3c1967..9f733c8 100644
+--- a/src/installer/destinations.py
++++ b/src/installer/destinations.py
+@@ -164,7 +164,7 @@ class SchemeDictionaryDestination(WheelDestination):
+         target_path = self._path_with_destdir(scheme, path)
+         if os.path.exists(target_path):
+             message = f"File already exists: {target_path}"
+-            raise FileExistsError(message)
++            os.remove(target_path)
+ 
+         parent_folder = os.path.dirname(target_path)
+         if not os.path.exists(parent_folder):


### PR DESCRIPTION
Maintainer: @jefferyto 
Compile tested: x86 https://github.com/openwrt/commit/d1e9c50d06a8cb618cb85ab489cbcccaec220636
Run tested:  x86 https://github.com/openwrt/commit/d1e9c50d06a8cb618cb85ab489cbcccaec220636


This seems to happen when re-triggering a build.
The destination path is already there, so this exception gets raised.

Another approach is to do 'make package/<python-package>/clean' and re-trigger the build.
But that becomes annoying.