### PR TITLE
stress-ng: bump to version 0.18.07

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.18.05
+PKG_VERSION:=0.18.07
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ColinIanKing/stress-ng/tar.gz/refs/tags/V$(PKG_VERSION)?
-PKG_HASH:=b0ac75b68bb804fd3276fcb235f1b0a9567090ebd887b2ed0f8a3203f9545e11
+PKG_HASH:=e2adaab67a70f4f98863d88d92e5805a31adce4559de52419e4f556e2ddeada6
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/commit/d1e9c50d06a8cb618cb85ab489cbcccaec220636
Run tested:  x86 https://github.com/openwrt/commit/d1e9c50d06a8cb618cb85ab489cbcccaec220636
