### PR TITLE
ddns-scripts: add support for ipv64.net

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=53
+PKG_RELEASE:=54
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/ipv64.net.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/ipv64.net.json
@@ -1,0 +1,11 @@
+{
+	"name": "duckdns.org",
+	"ipv4": {
+		"url": "http://ipv64.net/nic/update?domain=[DOMAIN]&key=[PASSWORD]&ip=[IP]",
+		"answer": "good|nochg"
+	},
+	"ipv6": {
+		"url": "http://ipv64.net/nic/update?domain=[DOMAIN]&key=[PASSWORD]&ipv6=[IP]",
+		"answer": "good|nochg"
+	}
+}

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -35,6 +35,7 @@ he.net
 hosting.de
 infomaniak.com
 ipnodns.ru
+ipv64.net
 inwx.de
 joker.com
 loopia.se


### PR DESCRIPTION
Adds ipv64.net service as DDNS provider

Docs: https://ipv64.net/dyndns_updater_api