### PR TITLE
bcm27xx-eeprom: update to v2024.11.12-2712

### DIFF
--- a/utils/bcm27xx-eeprom/Makefile
+++ b/utils/bcm27xx-eeprom/Makefile
@@ -5,9 +5,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/raspberrypi/rpi-eeprom
-PKG_SOURCE_DATE:=2024-09-23
-PKG_SOURCE_VERSION:=c8fffcda5ae0f923857a73fedbeb07e81d2eb813
-PKG_MIRROR_HASH:=68d0eedd1aff573c2ea7071f89a5898292061ced96d7f98ea4a347dc16c8102c
+PKG_SOURCE_DATE:=2024-11-12
+PKG_SOURCE_VERSION:=eefb7b83bc9b602455d9eaf34a51149a6e9cca96
+PKG_MIRROR_HASH:=336aba0c35cc5644a45510aff161b08c4400c1345486b44bc526c8b37a81463c
 
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 PKG_LICENSE:=BSD-3-Clause Custom
@@ -76,7 +76,7 @@ define Package/bcm2711-eeprom/install
 	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader-2711
-	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/pieeprom-2024-09-05.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
+	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/pieeprom-2024-10-21.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/recovery.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/vl805-000138c0.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 endef
@@ -86,7 +86,7 @@ define Package/bcm2712-eeprom/install
 	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
 
 	$(CP) $(PKG_BUILD_DIR)/firmware-2712/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader-2712
-	$(CP) $(PKG_BUILD_DIR)/firmware-2712/latest/pieeprom-2024-09-23.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
+	$(CP) $(PKG_BUILD_DIR)/firmware-2712/latest/pieeprom-2024-11-12.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
 	$(CP) $(PKG_BUILD_DIR)/firmware-2712/latest/recovery.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64
Run tested: bcm27xx/bcm2712 (RPi 5)

Description:
Update bcm27xx-eeprom to v2024.11.12-2712

bcm2711:
https://github.com/raspberrypi/rpi-eeprom/blob/v2024.11.12-2712/firmware-2711/release-notes.md#2024-10-10-use-soft-reset-to-preseve-sdram-contents-after-ramoops-latest
https://github.com/raspberrypi/rpi-eeprom/blob/v2024.11.12-2712/firmware-2711/release-notes.md#2024-10-21-fix-pcie-bar-issue-for-some-switches--latest

bcm2712:
https://github.com/raspberrypi/rpi-eeprom/blob/v2024.11.12-2712/firmware-2712/release-notes.md#2024-10-10-add-support-to-override-the-boot-mode-at-power-on-latest
https://github.com/raspberrypi/rpi-eeprom/blob/v2024.11.12-2712/firmware-2712/release-notes.md#2024-10-21-fix-pcie-bar-issue-for-some-switches--latest
https://github.com/raspberrypi/rpi-eeprom/blob/v2024.11.12-2712/firmware-2712/release-notes.md#2024-11-05-numa---add-system_heapmax_order0-when-needed-latest
https://github.com/raspberrypi/rpi-eeprom/blob/v2024.11.12-2712/firmware-2712/release-notes.md#2024-11-12-enable-initial_turbo60-by-default-latest

Full changelog: https://github.com/raspberrypi/rpi-eeprom/compare/v2024.09.23-2712...v2024.11.12-2712