### PR TITLE
wget: update alternative priority

### DIFF
--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wget
 PKG_VERSION:=1.24.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -49,7 +49,7 @@ $(call Package/wget/Default)
   DEPENDS+= +libopenssl +librt
   TITLE+= (with SSL support)
   VARIANT:=ssl
-  ALTERNATIVES:=300:/usr/bin/wget:/usr/libexec/wget-ssl
+  ALTERNATIVES:=400:/usr/bin/wget:/usr/libexec/wget-ssl
 endef
 
 define Package/wget-ssl/description


### PR DESCRIPTION
Maintainer: me
Compile tested: mediatek/filogic
Run tested: Openwrt One

Description:
Fix #25625. Update wget-ssl and wget-nossl using differet alternative priorities for /usr/bin/wget. 
