### PR TITLE
nano: set default shell editor to nano

### DIFF
--- a/utils/nano/Makefile
+++ b/utils/nano/Makefile
@@ -129,6 +129,8 @@ endef
 define Package/nano/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/$(PKG_NAME) $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/profile.d
+	printf "export EDITOR=/usr/bin/$(PKG_NAME)\n" >$(1)/etc/profile.d/$(PKG_NAME).sh
 endef
 
 define Package/nano-plus/install


### PR DESCRIPTION
The default editor for the system is vi this exports the EDITOR shell variable as nano. Utilities like crontab that respect EDITOR will use nano by default.

Maintainer: Hannu Nyman <hannu.nyman@iki.fi>
Compile tested: ipq40xx, generic, asus_map-ac2200
Run tested: 24.10-rc2

Description:
Simple change that creates an`/etc/profile.d/nano.sh` file with `export EDITOR=/usr/bin/nano`.
