### PR TITLE
openvpn: enable DCO by default

### DIFF
--- a/net/openvpn/Config-mbedtls.in
+++ b/net/openvpn/Config-mbedtls.in
@@ -35,7 +35,7 @@ config OPENVPN_mbedtls_ENABLE_IPROUTE2
 config OPENVPN_mbedtls_ENABLE_DCO
 	depends on !OPENVPN_mbedtls_ENABLE_IPROUTE2
 	bool "Enable support for data channel offload"
-	default n if OPENVPN_mbedtls_ENABLE_IPROUTE2
+	default y if !OPENVPN_mbedtls_ENABLE_IPROUTE2
 	help
 	  enable data channel offload support
 	  using the ovpn-dco-v2 kernel module

--- a/net/openvpn/Config-openssl.in
+++ b/net/openvpn/Config-openssl.in
@@ -39,7 +39,7 @@ config OPENVPN_openssl_ENABLE_IPROUTE2
 config OPENVPN_openssl_ENABLE_DCO
 	depends on !OPENVPN_openssl_ENABLE_IPROUTE2
 	bool "Enable support for data channel offload"
-	default n if OPENVPN_openssl_ENABLE_IPROUTE2
+	default y if !OPENVPN_openssl_ENABLE_IPROUTE2
 	help
 	  enable data channel offload support
 	  using the ovpn-dco-v2 kernel module

--- a/net/openvpn/Config-wolfssl.in
+++ b/net/openvpn/Config-wolfssl.in
@@ -44,7 +44,7 @@ config OPENVPN_wolfssl_ENABLE_IPROUTE2
 config OPENVPN_wolfssl_ENABLE_DCO
 	depends on !OPENVPN_wolfssl_ENABLE_IPROUTE2
 	bool "Enable support for data channel offload"
-	default n if OPENVPN_openssl_ENABLE_IPROUTE2
+	default y if !OPENVPN_wolfssl_ENABLE_IPROUTE2
 	select WOLFSSL_HAS_OPENVPN
 	help
 	  enable data channel offload support


### PR DESCRIPTION
Description:

Enable DCO by default in the `openvpn` package to allow for better performance and have a use case for `kmod-ovpn-dco-v2`. :slightly_smiling_face: 
