### PR TITLE
natmap: update to 20250101

### DIFF
--- a/net/natmap/Makefile
+++ b/net/natmap/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=natmap
-PKG_VERSION:=20240813
-PKG_RELEASE:=2
+PKG_VERSION:=20250101
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/heiher/natmap/releases/download/$(PKG_VERSION)
-PKG_HASH:=2fd89d286b19b9235d5e3477699c3752911bc5e80840ea1ed6930bfe98f47248
+PKG_HASH:=7cd18e495b3d163a39b0a52866e6bad9b121ade504d6477f5ea36dc0d0040cac
 
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>, Ray Wang <r@hev.cc>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @ysc3839 @heiher
Compile tested: x86_64, snapshot; ramips-mt7621, 23.05
Run tested: ramips-mt7621, 23.05

Description:

1. Update to 20250101.