### PR TITLE
muninlite: add /etc/munin to conffiles and install muninlite.conf

### DIFF
--- a/admin/muninlite/Makefile
+++ b/admin/muninlite/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=muninlite
 PKG_VERSION:=2.1.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/munin-monitoring/$(PKG_NAME)/releases/download/$(PKG_VERSION)/
@@ -37,12 +37,14 @@ endef
 define Package/muninlite/install
 	$(INSTALL_DIR) $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/muninlite $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/munin/plugins
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/muninlite.conf $(1)/etc/munin/
 	$(INSTALL_DIR) $(1)/etc/xinetd.d
 	$(INSTALL_DATA) ./files/etc/xinetd.d/muninlite $(1)/etc/xinetd.d/
-	$(INSTALL_DIR) $(1)/etc/munin/plugins
 endef
 
 define Package/muninlite/conffiles
+/etc/munin/
 /etc/xinetd.d/muninlite
 endef
 

--- a/admin/muninlite/Makefile
+++ b/admin/muninlite/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=muninlite
 PKG_VERSION:=2.1.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/munin-monitoring/$(PKG_NAME)/releases/download/$(PKG_VERSION)/

--- a/admin/muninlite/patches/001-ntpdate-fix-typo-on-graph-title.patch
+++ b/admin/muninlite/patches/001-ntpdate-fix-typo-on-graph-title.patch
@@ -1,0 +1,18 @@
+From 74927fc6e7d2b5475d4b8d4bc426b55d23c67be9 Mon Sep 17 00:00:00 2001
+From: "Kim B. Heino" <b@bbbs.net>
+Date: Sun, 22 Aug 2021 19:37:40 +0300
+Subject: [PATCH 1/5] ntpdate: fix typo on graph title
+
+---
+ plugins/ntpdate | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/plugins/ntpdate
++++ b/plugins/ntpdate
+@@ -1,5 +1,5 @@
+ config_ntpdate() {
+-  echo "graph_title NTP offset and dealy to peer $NTP_PEER"
++  echo "graph_title NTP offset and delay to peer $NTP_PEER"
+   echo "graph_args --base 1000 --vertical-label msec"
+   echo "graph_category time"
+   echo "offset.label Offset"

--- a/admin/muninlite/patches/002-plugin-ntpdate-tolerate-multiple-NTP-servers-e.g.-in.patch
+++ b/admin/muninlite/patches/002-plugin-ntpdate-tolerate-multiple-NTP-servers-e.g.-in.patch
@@ -1,0 +1,30 @@
+From a2f1745477e480f91bb68102308217eb95a063c7 Mon Sep 17 00:00:00 2001
+From: Lars Kruse <devel@sumpfralle.de>
+Date: Wed, 4 May 2022 14:52:44 +0200
+Subject: [PATCH 2/5] plugin ntpdate: tolerate multiple NTP servers (e.g. in a
+ pool)
+
+Previously multiple "server" lines were consumed, but the output of the
+awk filter lacked the line ending.  Thus the last numeric value of the
+previous "server" line was concatenated with the first numeric value of
+the following "server" line.  Thus multiple dots occurred in a single
+numeric value and parsing just failed.
+
+Thanks, glyndon!
+
+Closes: #16
+---
+ plugins/ntpdate | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/plugins/ntpdate
++++ b/plugins/ntpdate
+@@ -11,7 +11,7 @@ fetch_ntpdate() {
+   OFFSET=0
+   DELAY=0
+   if [ -n "$NTP_PEER" ] && [ -x "$NTPDATE" ]; then
+-    DATA=$("$NTPDATE" -q "$NTP_PEER" | awk '/^server.*offset/{gsub(/,/,""); printf "%s %s", ($6*1000), ($8*1000);}')
++    DATA=$("$NTPDATE" -q "$NTP_PEER" | awk '/^server.*offset/{gsub(/,/,""); printf "%s %s", ($6*1000), ($8*1000); exit;}')
+     OFFSET=$(echo "$DATA" | cut -d " " -f 1)
+     DELAY=$(echo "$DATA" | cut -d " " -f 2)
+   fi

--- a/admin/muninlite/patches/003-Improve-df.patch
+++ b/admin/muninlite/patches/003-Improve-df.patch
@@ -1,0 +1,45 @@
+From f55b83fdbda8bbe65f27395fe55d75f6e9e845f2 Mon Sep 17 00:00:00 2001
+From: Daniel Alder <daald@users.noreply.github.com>
+Date: Wed, 13 Dec 2023 00:59:12 +0100
+Subject: [PATCH 3/5] Improve df
+
+Before, there were 1+n calls of df where n is the number of output values. I introduced some script magic to use the values from the
+first call. Motivation was, there was a very complex sed call which failed to process some of my df output lines. The new code is much
+safer.
+
+Actually, the original problem obviously was that the sed regex didn't cover capital letters which I had in my mountpoints.
+---
+ plugins/df | 16 +++++++---------
+ 1 file changed, 7 insertions(+), 9 deletions(-)
+
+--- a/plugins/df
++++ b/plugins/df
+@@ -4,21 +4,19 @@ graph_args --upper-limit 100 -l 0
+ graph_vlabel %
+ graph_category disk
+ graph_info This graph shows disk usage on the machine."
+-  for PART in $(df -PT | grep '^/' | grep -vwE "$DF_IGNORE_FILESYSTEM_REGEX" | sed '/\/[a-z0-9]*$/!d;s/.* \([a-z0-9\/]\{1,\}\)$/\1/g')
++  df -PT | grep '^/' | grep -vwE "$DF_IGNORE_FILESYSTEM_REGEX" | while read dev type blocks used avail pct mp
+   do
+-    PINFO=$(df -P "$PART" | tail -1);
+-    PNAME=$(clean_fieldname "$(echo "$PINFO" | cut -d " " -f 1)")
+-    echo "$PNAME.label $PART"
+-    echo "$PNAME.info $PNAME -> $PART"
++    PNAME=$(clean_fieldname "$dev")
++    echo "$PNAME.label $mp"
++    echo "$PNAME.info $dev -> $mp"
+     echo "$PNAME.warning 92"
+     echo "$PNAME.critical 98"
+   done
+ }
+ fetch_df() {
+-  for PART in $(df -PT | grep '^/' | grep -vwE "$DF_IGNORE_FILESYSTEM_REGEX" | sed '/\/[a-z0-9]*$/!d;s/.* \([a-z0-9\/]\{1,\}\)$/\1/g')
++  df -PT | grep '^/' | grep -vwE "$DF_IGNORE_FILESYSTEM_REGEX" | while read dev type blocks used avail pct mp
+   do
+-    PINFO=$(df -P "$PART" | tail -1);
+-    PNAME=$(clean_fieldname "$(echo "$PINFO" | cut -d " " -f 1)")
+-    echo "$PNAME.value" "$(echo "$PINFO" | sed -e 's/\%//g' -e 's/  */ /g' | cut -d " " -f 5)"
++    PNAME=$(clean_fieldname "$dev")
++    echo "$PNAME.value" "${pct%\%}"
+   done
+ }

--- a/admin/muninlite/patches/004-Fix-previous-change.-The-key-for-config-and-values-w.patch
+++ b/admin/muninlite/patches/004-Fix-previous-change.-The-key-for-config-and-values-w.patch
@@ -1,0 +1,31 @@
+From c2b8d7315d9c9c466537ef60dcdb5bd6733ea809 Mon Sep 17 00:00:00 2001
+From: Daniel Alder <daald@users.noreply.github.com>
+Date: Thu, 14 Dec 2023 13:26:47 +0100
+Subject: [PATCH 4/5] Fix previous change. The key for config and values was
+ the mountpoint
+
+I accidently changed this to dev. This also works but breaks existing history
+---
+ plugins/df | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/plugins/df
++++ b/plugins/df
+@@ -6,7 +6,7 @@ graph_category disk
+ graph_info This graph shows disk usage on the machine."
+   df -PT | grep '^/' | grep -vwE "$DF_IGNORE_FILESYSTEM_REGEX" | while read dev type blocks used avail pct mp
+   do
+-    PNAME=$(clean_fieldname "$dev")
++    PNAME=$(clean_fieldname "$mp")
+     echo "$PNAME.label $mp"
+     echo "$PNAME.info $dev -> $mp"
+     echo "$PNAME.warning 92"
+@@ -16,7 +16,7 @@ graph_info This graph shows disk usage o
+ fetch_df() {
+   df -PT | grep '^/' | grep -vwE "$DF_IGNORE_FILESYSTEM_REGEX" | while read dev type blocks used avail pct mp
+   do
+-    PNAME=$(clean_fieldname "$dev")
++    PNAME=$(clean_fieldname "$mp")
+     echo "$PNAME.value" "${pct%\%}"
+   done
+ }

--- a/admin/muninlite/patches/100-netstat-drop-netstat-s-dep-by-using-proc-net-snmp-da.patch
+++ b/admin/muninlite/patches/100-netstat-drop-netstat-s-dep-by-using-proc-net-snmp-da.patch
@@ -1,0 +1,88 @@
+From cd0d4478916ff203db1d3e403b99a58d60d7c5ec Mon Sep 17 00:00:00 2001
+From: Rany Hany <rany_hany@riseup.net>
+Date: Thu, 2 Jan 2025 14:26:07 +0200
+Subject: [PATCH 5/5] netstat: drop `netstat -s` dep by using `/proc/net/snmp`
+ data directly
+
+This allows the plugin to work under OpenWRT as the busybox netstat
+does not support `netstat -s`.
+
+Fixes: https://github.com/munin-monitoring/muninlite/issues/14
+Signed-off-by: Rany Hany <rany_hany@riseup.net>
+---
+ muninlite.in    |  2 +-
+ plugins/netstat | 54 +++++++++++++++++++++++++++++++++++++++++++------
+ 2 files changed, 49 insertions(+), 7 deletions(-)
+
+--- a/muninlite.in
++++ b/muninlite.in
+@@ -87,7 +87,7 @@ for PLUG in $PLUGINS; do
+       done
+       ;;
+     netstat)
+-      if netstat -s >/dev/null 2>&1; then
++      if [ -f /proc/net/snmp ]; then
+         RES="$RES netstat"
+       fi
+       ;;
+--- a/plugins/netstat
++++ b/plugins/netstat
+@@ -31,10 +31,52 @@ config_netstat() {
+   echo "established.info The number of currently open connections."
+ }
+ fetch_netstat() {
+-  NINFO=$(netstat -s | sed 's/ \{1,\}/ /g')
+-  echo "active.value" "$(echo "$NINFO" | grep "active connection" | cut -d " " -f 2)"
+-  echo "passive.value" "$(echo "$NINFO" | grep "passive connection" | cut -d " " -f 2)"
+-  echo "failed.value" "$(echo "$NINFO" | grep "failed connection" | cut -d " " -f 2)"
+-  echo "resets.value" "$(echo "$NINFO" | grep "connection resets" | cut -d " " -f 2)"
+-  echo "established.value" "$(echo "$NINFO" | grep "connections established" | cut -d " " -f 2)"
++  awk '
++    BEGIN {
++      TcpNR = -1
++      ActiveOpens = -1
++      PassiveOpens = -1
++      AttemptFails = -1
++      EstabResets = -1
++      CurrEstab = -1
++    }
++
++    /^Tcp: / {
++      if (++TcpNR == 0) {
++        for (i = 1; i <= NF; i++) {
++          if ($i == "ActiveOpens") {
++            ActiveOpens = i
++          } else if ($i == "PassiveOpens") {
++            PassiveOpens = i
++          } else if ($i == "AttemptFails") {
++            AttemptFails = i
++          } else if ($i == "EstabResets") {
++            EstabResets = i
++          } else if ($i == "CurrEstab") {
++            CurrEstab = i
++          }
++        }
++      } else if (TcpNR == 1) {
++        if (ActiveOpens < 1 || PassiveOpens < 1 || AttemptFails < 1 || EstabResets < 1 || CurrEstab < 1) {
++          TcpNR = -1
++        } else {
++          print "active.value " $ActiveOpens
++          print "passive.value " $PassiveOpens
++          print "failed.value " $AttemptFails
++          print "resets.value " $EstabResets
++          print "established.value " $CurrEstab
++        }
++      }
++    }
++
++    END {
++      if (TcpNR < 1) {
++        print "active.value 0"
++        print "passive.value 0"
++        print "failed.value 0"
++        print "resets.value 0"
++        print "established.value 0"
++      }
++    }
++  ' /proc/net/snmp
+ }

--- a/admin/muninlite/patches/200-Allow-customizing-the-list-of-monitored-network-inte.patch
+++ b/admin/muninlite/patches/200-Allow-customizing-the-list-of-monitored-network-inte.patch
@@ -1,0 +1,29 @@
+From c14b6ccaecba0a85fee0261774d31187a6c66f71 Mon Sep 17 00:00:00 2001
+From: Daniel Alder <daald@users.noreply.github.com>
+Date: Wed, 13 Dec 2023 15:16:20 +0100
+Subject: [PATCH 200/204] Allow customizing the list of monitored network
+ interfaces
+
+This is a simple way to customize the selection of network interfaces. If INTERFACE_NAMES_OVERRIDE is set in muninlite.conf, that list is used instead of auto-detection. As muninlite.conf
+itself is also a script, it is even possible to write a custom command.
+This feature is helpful in environments with virtual machines or containers, like docker or lxc where there are lots of br-*, veth*, lxcbr* etc interfaces where monitoring doesn't make much
+sense. I didn't find a way to reliably filter physical interfaces.
+---
+ muninlite.in | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+--- a/muninlite.in
++++ b/muninlite.in
+@@ -78,7 +78,11 @@ RES=""
+ for PLUG in $PLUGINS; do
+   case "$PLUG" in
+     if_|if_err_)
+-      interface_names=$(sed 's/^ *//; s/:.*$//; / /d; /^lo$/d' /proc/net/dev)
++      if [ -z "$INTERFACE_NAMES_OVERRIDE" ]; then
++        interface_names=$(sed 's/^ *//; s/:.*$//; / /d; /^lo$/d' /proc/net/dev)
++      else
++        interface_names="$INTERFACE_NAMES_OVERRIDE"
++      fi
+       for INTER in $interface_names; do
+         INTERRES=$(echo "$INTER" | sed -e 's/\./VLAN/' -e 's/\-/_/g')
+         RES="$RES ${PLUG}${INTERRES}"

--- a/admin/muninlite/patches/201-Add-examples-for-config-with-INTERFACE_NAMES_OVERRID.patch
+++ b/admin/muninlite/patches/201-Add-examples-for-config-with-INTERFACE_NAMES_OVERRID.patch
@@ -1,0 +1,18 @@
+From 71cc9a81106dc2199e5686a54fcff7c0aff6ef5e Mon Sep 17 00:00:00 2001
+From: Daniel Alder <daald@users.noreply.github.com>
+Date: Wed, 13 Dec 2023 17:35:57 +0100
+Subject: [PATCH 201/204] Add examples for config with INTERFACE_NAMES_OVERRIDE
+
+---
+ muninlite.conf | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/muninlite.conf
++++ b/muninlite.conf
+@@ -1,3 +1,6 @@
+ # the following variables are added to the top of the assembled muninlite script
+ NTP_PEER="pool.ntp.org"
+ DF_IGNORE_FILESYSTEM_REGEX="(none|unknown|rootfs|iso9660|squashfs|udf|romfs|ramfs|debugfs|cgroup_root|devtmpfs)"
++
++#INTERFACE_NAMES_OVERRIDE="eth0"
++#INTERFACE_NAMES_OVERRIDE="$(sed 's/^ *//; s/:.*$//; / /d' /proc/net/dev | grep -P '^(eth|wlan|en)')"

--- a/admin/muninlite/patches/202-Fix-parameter-not-set-error.patch
+++ b/admin/muninlite/patches/202-Fix-parameter-not-set-error.patch
@@ -1,0 +1,21 @@
+From 903869d10cd58891c77e9a633ab1fc5eb2710abb Mon Sep 17 00:00:00 2001
+From: Daniel Alder <daald@users.noreply.github.com>
+Date: Wed, 13 Dec 2023 17:43:24 +0100
+Subject: [PATCH 202/204] Fix "parameter not set" error
+
+./muninlite: 651: INTERFACE_NAMES_OVERRIDE: parameter not set
+---
+ muninlite.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/muninlite.in
++++ b/muninlite.in
+@@ -78,7 +78,7 @@ RES=""
+ for PLUG in $PLUGINS; do
+   case "$PLUG" in
+     if_|if_err_)
+-      if [ -z "$INTERFACE_NAMES_OVERRIDE" ]; then
++      if [ -z "${INTERFACE_NAMES_OVERRIDE:-}" ]; then
+         interface_names=$(sed 's/^ *//; s/:.*$//; / /d; /^lo$/d' /proc/net/dev)
+       else
+         interface_names="$INTERFACE_NAMES_OVERRIDE"

--- a/admin/muninlite/patches/203-Make-example-more-portable.patch
+++ b/admin/muninlite/patches/203-Make-example-more-portable.patch
@@ -1,0 +1,18 @@
+From e0f0687247958a19911d0f874fd8bff3b50fbede Mon Sep 17 00:00:00 2001
+From: daald <daald@users.noreply.github.com>
+Date: Thu, 14 Dec 2023 02:29:15 +0100
+Subject: [PATCH 203/204] Make example more portable
+
+Co-authored-by: Kenyon Ralph <kenyon@kenyonralph.com>
+---
+ muninlite.conf | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/muninlite.conf
++++ b/muninlite.conf
+@@ -3,4 +3,4 @@ NTP_PEER="pool.ntp.org"
+ DF_IGNORE_FILESYSTEM_REGEX="(none|unknown|rootfs|iso9660|squashfs|udf|romfs|ramfs|debugfs|cgroup_root|devtmpfs)"
+ 
+ #INTERFACE_NAMES_OVERRIDE="eth0"
+-#INTERFACE_NAMES_OVERRIDE="$(sed 's/^ *//; s/:.*$//; / /d' /proc/net/dev | grep -P '^(eth|wlan|en)')"
++#INTERFACE_NAMES_OVERRIDE="$(sed 's/^ *//; s/:.*$//; / /d' /proc/net/dev | grep -E '^(eth|wlan|en)')"

--- a/admin/muninlite/patches/204-Remove-example-code-as-requested.patch
+++ b/admin/muninlite/patches/204-Remove-example-code-as-requested.patch
@@ -1,0 +1,16 @@
+From 6f27355dc64ddc1ad9588f1402a21ad112bfbc01 Mon Sep 17 00:00:00 2001
+From: Daniel Alder <daald@users.noreply.github.com>
+Date: Fri, 15 Dec 2023 22:42:18 +0100
+Subject: [PATCH 204/204] Remove example code as requested
+
+---
+ muninlite.conf | 1 -
+ 1 file changed, 1 deletion(-)
+
+--- a/muninlite.conf
++++ b/muninlite.conf
+@@ -3,4 +3,3 @@ NTP_PEER="pool.ntp.org"
+ DF_IGNORE_FILESYSTEM_REGEX="(none|unknown|rootfs|iso9660|squashfs|udf|romfs|ramfs|debugfs|cgroup_root|devtmpfs)"
+ 
+ #INTERFACE_NAMES_OVERRIDE="eth0"
+-#INTERFACE_NAMES_OVERRIDE="$(sed 's/^ *//; s/:.*$//; / /d' /proc/net/dev | grep -E '^(eth|wlan|en)')"


### PR DESCRIPTION
Maintainer: Jonathan McCrohan (@jmccrohan)
Compile tested: ramips_mt7621/netgear_wac124
Run tested: ramips_mt7621/netgear_wac124

Description:

The entire /etc/munin should be backed up as it includes user configuration for custom plugins and the muninlite.conf config file which is useful to override the default NTP server.

Also we install muninlite.conf to /etc/munin/.