### PR TITLE
curl: add LIBCURL_WEBSOCKETS flag

### DIFF
--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -45,6 +45,10 @@ config LIBCURL_HTTP
 	bool "HTTP / HTTPS protocol"
 	default y
 
+config LIBCURL_WEBSOCKETS
+	bool "WebSockets protocol"
+	default n
+
 config LIBCURL_COOKIES
 	bool "Enable Cookies support"
 	depends on LIBCURL_HTTP

--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -44,6 +44,7 @@ PKG_CONFIG_DEPENDS:= \
   CONFIG_LIBCURL_FTP \
   CONFIG_LIBCURL_GOPHER \
   CONFIG_LIBCURL_HTTP \
+  CONFIG_LIBCURL_WEBSOCKETS \
   CONFIG_LIBCURL_IMAP \
   CONFIG_LIBCURL_LDAP \
   CONFIG_LIBCURL_LDAPS \
@@ -153,6 +154,7 @@ CONFIGURE_ARGS += \
 	$(call autoconf_bool,CONFIG_LIBCURL_SMTP,smtp) \
 	$(call autoconf_bool,CONFIG_LIBCURL_TELNET,telnet) \
 	$(call autoconf_bool,CONFIG_LIBCURL_TFTP,tftp) \
+	$(call autoconf_bool,CONFIG_LIBCURL_WEBSOCKETS,websockets) \
 	\
 	$(call autoconf_bool,CONFIG_LIBCURL_COOKIES,cookies) \
 	$(call autoconf_bool,CONFIG_LIBCURL_CRYPTO_AUTH,crypto-auth) \


### PR DESCRIPTION
Maintainer: @krant
Compile tested: armv5 (mxs target), built using openwrt master on Oracle Linux 8
Run tested: on a non-openwrt armv5 system

Description:
