### PR TITLE
tgt: update to 1.0.94

### DIFF
--- a/net/tgt/Makefile
+++ b/net/tgt/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tgt
-PKG_VERSION:=1.0.93
-PKG_RELEASE:=2
+PKG_VERSION:=1.0.94
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fujita/tgt/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=587e4a160a46851d049dbf07b0fae7e269ed1c3f58ad3fbbdbe45c9bb36093db
+PKG_HASH:=bb2a49130dd83310268af2eaa435f43be61d92a5bd22b9d360f7c751947f37b9
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_cortex-a53, qualcommax/ipq807x r28451+3-e0eca57b6e
Run tested: aarch64_cortex-a53, qualcommax/ipq807x r28451+3-e0eca57b6e in a chroot on r27697+4-d51353db26; an ext4 filesystem on a file-backed LUN works fine

Description: