### PR TITLE
owipcalc: fix integer overflow in func howmany

### DIFF
--- a/net/owipcalc/Makefile
+++ b/net/owipcalc/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=owipcalc
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
 PKG_LICENSE:=Apache-2.0

--- a/net/owipcalc/src/owipcalc.c
+++ b/net/owipcalc/src/owipcalc.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <math.h>
 
 #include <arpa/inet.h>
 
@@ -616,13 +617,15 @@ struct cidr * cidr_parse(const char *op, const char *s, int af_hint)
 
 bool cidr_howmany(struct cidr *a, struct cidr *b)
 {
+	int prefix_diff;
 	if (printed)
 		qprintf(" ");
 
-	if (b->prefix < a->prefix)
+	prefix_diff = (b->prefix - a->prefix);
+	if (prefix_diff < 1)
 		qprintf("0");
 	else
-		qprintf("%u", 1 << (b->prefix - a->prefix));
+		qprintf("%.0LF", powl(2, prefix_diff));
 
 	return true;
 }


### PR DESCRIPTION
Maintainer: Nick Hainke <vincent@systemli.org> (@PolynomialDivision)
Compile tested: ath79, wdr4300, OpenWrt 23.05.5
Run tested: ath79, wdr4300, OpenWrt 23.05.5, tests done

Description:
This only works with numbers smaller than 2 to the power of 64, but the maximum is 2 to the power of 128. Replace bit shift with pow() form math.h
