### PR TITLE
mwan3: Add support for nslookup track method

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.11.16
+PKG_VERSION:=2.11.17
 PKG_RELEASE:=5
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -91,6 +91,12 @@ validate_track_method() {
 				return 1
 			}
 			;;
+		nslookup)
+			command -v nslookup 1>/dev/null 2>&1 || {
+				LOG warn "Missing nslookup. Please install busybox package."
+				return 1
+			}
+			;;
 		*)
 			LOG warn "Unsupported tracking method: $track_method"
 			return 2
@@ -326,6 +332,12 @@ main() {
 						TRACK_PID=$!
 						wait $TRACK_PID
 						result=$(grep Lost $TRACK_OUTPUT | awk '{print $12}')
+					;;
+					nslookup)
+						WRAP nslookup www.google.com $track_ip > $TRACK_OUTPUT &
+						TRACK_PID=$!
+						wait $TRACK_PID
+						result=$?
 					;;
 				esac
 				do_log=""

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -322,7 +322,7 @@ main() {
 						fi
 					;;
 					nping-*)
-						WRAP nping -c $count $track_ip --${FAMILY#nping-} > $TRACK_OUTPUT &
+						WRAP nping -${FAMILY#ipv} -c $count $track_ip --${track_method#nping-} > $TRACK_OUTPUT &
 						TRACK_PID=$!
 						wait $TRACK_PID
 						result=$(grep Lost $TRACK_OUTPUT | awk '{print $12}')


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: x86_64, 23.05.5

Description:
In cases where ICMP ECHO is blocked by the ISP or perhaps even just de-prioritized, there can be a lot of ping failures when the link is perfectly fine.  In such cases, doing a DNS query is much more reliable so add a link-test method to use nslookup to do a DNS query.

Also, fix a couple of small bugs in the nping method.
