### PR TITLE
mediatek: filogic: Enable QEMU (24.10 backport)

### DIFF
--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -31,7 +31,7 @@ include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-host.mk
 
 QEMU_DEPS_IN_GUEST := @(TARGET_x86||TARGET_x86_64||TARGET_armsr||TARGET_malta)
-QEMU_DEPS_IN_HOST := @(TARGET_x86_64||TARGET_armsr_armv8||TARGET_sunxi)
+QEMU_DEPS_IN_HOST := @(TARGET_x86_64||TARGET_armsr_armv8||TARGET_sunxi||TARGET_mediatek_filogic)
 QEMU_DEPS_IN_HOST += +libstdcpp
 QEMU_DEPS_IN_HOST += $(ICONV_DEPENDS)
 


### PR DESCRIPTION
The Filogic devices are capable of running KVM machines, enable QEMU to make it easy.

Maintainer: @yousong
Compile tested: 24.10.0-rc4
Run tested: Banana BPI R3 Mini

References:
- https://github.com/openwrt/openwrt/pull/17495
- https://github.com/openwrt/openwrt/pull/17496
- https://github.com/openwrt/packages/pull/25679
