### PR TITLE
eza: update to 0.20.15

### DIFF
--- a/utils/eza/Makefile
+++ b/utils/eza/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=eza
-PKG_VERSION:=0.20.10
+PKG_VERSION:=0.20.15
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eza-community/eza/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=dbeba82ed85c18776aac20a4f91429bd3ab7e1bd3734344cd247e8f646516a13
+PKG_HASH:=cbb50e61b35b06ccf487ee6cc88d3b624931093546194dd5a2bbd509ed1786d6
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=EUPL-1.2


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt snapshot
Run tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt snapshot, simple run test with basic options

Release notes:
0.20.11: https://github.com/eza-community/eza/releases/tag/v0.20.11
0.20.12: https://github.com/eza-community/eza/releases/tag/v0.20.12
0.20.13: https://github.com/eza-community/eza/releases/tag/v0.20.13
0.20.14: https://github.com/eza-community/eza/releases/tag/v0.20.14
0.20.15: https://github.com/eza-community/eza/releases/tag/v0.20.15
