### PR TITLE
gping: update to 1.19.0

### DIFF
--- a/net/gping/Makefile
+++ b/net/gping/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gping
-PKG_VERSION:=1.18.0
+PKG_VERSION:=1.19.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/orf/gping/tar.gz/$(PKG_NAME)-v$(PKG_VERSION)?
-PKG_HASH:=a76e09619831c0f2bb95f505a92c1332de89c3c43383b4d832a69afcb0fafd4c
+PKG_HASH:=a979c9a8c7a1a540bb48a1e90bb7ad294560bddc16ca977bc8475fb14f20155d
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt snapshot
Run tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt snapshot, ping test

**Description:**

**compile-test: fine, run-test: fails for ping**
Due to the rewrite of the internal pinger library, gping now uses a default interval of 0.2 seconds for ping. Before, no specific interval was used. While this works fine for Alpines BusyBox, which upstream explicitly supports, it doesn't on OpenWrt because the BusyBox option `FRACTIONAL_DURATION` is disabled by default.

Not sure how to fix this, I can think of three solutions:
- downstream patch to change default interval to 1s
- PR in OpenWrt repository to change the default of `FLOAT_DURATION` to `yes`
- add `+@BUSYBOX_CUSTOM +@BUSYBOX_CONFIG_FLOAT_DURATION` to package DEPENDS. works, but requires `BUSYBOX_CUSTOM`. However, this doesn't seem to me like a good solution.

No proper release notes available.
changes:
- rewrite of internal pinger library
- dependency updates