### PR TITLE
cpupower: fix category 'utils' -> 'utilities'

### DIFF
--- a/utils/cpupower/Makefile
+++ b/utils/cpupower/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define Package/cpupower
   SECTION:=utils
-  CATEGORY:=Utils
+  CATEGORY:=Utilities
   TITLE:=Shows and sets processor power related values
   URL:=https://www.kernel.org
   DEPENDS:=+libpci


### PR DESCRIPTION
Maintainer: @graysky2 
Compile tested: -
Run tested: -

Description:

The initial idea was to have the new package in the existing category, not to create a new one.
Thanks @anomeome for spotting this.
