### PR TITLE
opendkim: fix compilation with GCC14

### DIFF
--- a/mail/opendkim/Makefile
+++ b/mail/opendkim/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opendkim
 PKG_VERSION:=2.10.3
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)

--- a/mail/opendkim/patches/030-gcc14.patch
+++ b/mail/opendkim/patches/030-gcc14.patch
@@ -1,0 +1,10 @@
+--- a/libopendkim/util.c
++++ b/libopendkim/util.c
+@@ -22,6 +22,7 @@
+ #include <netdb.h>
+ #include <resolv.h>
+ #include <stdlib.h>
++#include <stdio.h>
+ 
+ /* libopendkim includes */
+ #include "dkim-internal.h"


### PR DESCRIPTION
Missing header.

Maintainer: @val-kulkov 