### PR TITLE
fscrypt: add new package

### DIFF
--- a/utils/fscrypt/Makefile
+++ b/utils/fscrypt/Makefile
@@ -1,0 +1,56 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=fscrypt
+PKG_VERSION:=0.3.5
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/google/fscrypt/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=368119b5e67c64bdc5f7872ffc7beed425e1401778003f4c7ae7c1062a45ebaf
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:google:fscrypt
+PKG_MAINTAINER:=John Audia <therealgraysky@proton.me>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/google/fscrypt
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/fscrypt
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Encryption
+  TITLE:=A tool for managing Linux filesystem encryption
+  URL:=https://github.com/google/fscrypt
+  DEPENDS:=$(GO_ARCH_DEPENDS) +libpam +@KERNEL_FS_ENCRYPTION
+  KCONFIG:=CONFIG_FS_ENCRYPTION=y
+endef
+
+define Package/fscrypt/description
+  Fscrypt is a high-level tool for the management of Linux native filesystem
+  encryption. Fscrypt manages metadata, key generation, key wrapping, PAM integration,
+  and provides a uniform interface for creating and modifying encrypted directories.
+endef
+
+define Package/fscrypt/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/usr/lib/security
+	$(INSTALL_DIR) $(1)/etc/pam.d
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/fscrypt $(1)/usr/bin/fscrypt
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/pam_fscrypt $(1)/usr/lib/security/pam_fscrypt.so
+	$(INSTALL_DATA) ./files/pam_config $(1)/etc/pam.d/fscrypt
+endef
+
+define Package/fscrypt/conffiles
+/etc/fscrypt.conf
+endef
+
+$(eval $(call GoBinPackage,fscrypt))
+$(eval $(call BuildPackage,fscrypt))

--- a/utils/fscrypt/files/pam_config
+++ b/utils/fscrypt/files/pam_config
@@ -1,0 +1,2 @@
+# Allow fscrypt to check your login passphrase when you create a login protector
+auth		required	pam_unix.so


### PR DESCRIPTION
Fscrypt is a high-level tool for the management of Linux native filesystem encryption. fscrypt manages metadata, key generation, key wrapping, PAM integration, and provides a uniform interface for creating and modifying encrypted directories.

Upstream url: https://github.com/google/fscrypt/blob/master/README.md

Build system: x86/64
Build-tested: bcm27xx/bcm2712
Run-tested: bcm27xx/bcm2712

Maintainer: me