### PR TITLE
ddns-scripts: cloudflare: use PATCH method, minimize changes

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=55
+PKG_RELEASE:=56
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
@@ -27,9 +27,8 @@
 [ $use_https -eq 0 ] && use_https=1	# force HTTPS
 
 # used variables
-local __HOST __DOMAIN __TYPE __URLBASE __PRGBASE __RUNPROG __DATA __IPV6 __ZONEID __RECID __PROXIED
+local __HOST __DOMAIN __TYPE __URLBASE __PRGBASE __RUNPROG __DATA __IPV6 __ZONEID __RECID
 local __URLBASE="https://api.cloudflare.com/client/v4"
-local __TTL=120
 
 # split __HOST __DOMAIN from $domain
 # given data:
@@ -186,16 +185,14 @@ __DATA=$(grep -o '"content":\s*"[^"]*' $DATFILE | grep -o '[^"]*$' | head -1)
 
 # update is needed
 # let's build data to send
-# set proxied parameter
-__PROXIED=$(grep -o '"proxied":\s*[^",]*' $DATFILE | grep -o '[^:]*$')
 
 # use file to work around " needed for json
 cat > $DATFILE << EOF
-{"id":"$__ZONEID","type":"$__TYPE","name":"$__HOST","content":"$__IP","ttl":$__TTL,"proxied":$__PROXIED}
+{"content":"$__IP"}
 EOF
 
 # let's complete transfer command
-__RUNPROG="$__PRGBASE --request PUT --data @$DATFILE '$__URLBASE/zones/$__ZONEID/dns_records/$__RECID'"
+__RUNPROG="$__PRGBASE --request PATCH --data @$DATFILE '$__URLBASE/zones/$__ZONEID/dns_records/$__RECID'"
 cloudflare_transfer || return 1
 
 return 0

--- a/net/ddns-scripts/files/usr/share/ddns/default/ipv64.net.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/ipv64.net.json
@@ -1,5 +1,5 @@
 {
-	"name": "duckdns.org",
+	"name": "ipv64.net",
 	"ipv4": {
 		"url": "http://ipv64.net/nic/update?domain=[DOMAIN]&key=[PASSWORD]&ip=[IP]",
 		"answer": "good|nochg"


### PR DESCRIPTION
Maintainer: me
Compile tested: none, shell-only
Run tested: mediatek/mt7622, aarch64_cortex-a53, Linksys E8450 (UBI), SNAPSHOT r0-285bdd2, tested updating A record to the current IPv4 address

Description:

Use the PATCH method which is the intended way to update an existing record with the cloudflare API, and update the "content" (rdata) only, that is, the IP address, leaving any other existing details intact.

In particular this removes the hard-coded 120 second TTL overriding the existing value set at cloudflare.
