### PR TITLE
transmissision: remove build dependency on nodejs

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -21,7 +21,7 @@ PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:transmissionbt:transmission
 
 PKG_INSTALL:=1
-PKG_BUILD_DEPENDS:=libb64 node/host
+PKG_BUILD_DEPENDS:=libb64
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=gc-sections lto
 PKG_CONFIG_DEPENDS:= \


### PR DESCRIPTION
Have no idea why such dependency was added.
No documentation from transmission that they need
such dependency on build time. On the other hand
saves vast of time during build

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
