### PR TITLE
nginx: 302 the "/" path to "/cgi-bin/luci/"

### DIFF
--- a/net/nginx/files-luci-support/luci.locations
+++ b/net/nginx/files-luci-support/luci.locations
@@ -1,3 +1,6 @@
+location =/ {
+	return 302 /cgi-bin/luci/;
+}
 location /cgi-bin/luci {
 		index  index.html;
 		include uwsgi_params;


### PR DESCRIPTION
This change will prevent the blank
"LuCI - Lua Configuration Interface" screen
 from being displayed for the first time
 when accessing luci via a url like 192.168.1.1

Maintainer: @Ansuel
Compile tested: (x86/64, 24.10.0-rc4, Edge) 
Run tested: (x86/64, 24.10.0-rc4, Edge) 

Description:

When using nginx instead of uhttpd, accessing the root url such as "192.168.1.1" or "my-router.lan" will display a blank page and then jump to the luci page like this.
![2025-01-10_09-40-08](https://github.com/user-attachments/assets/66dcd880-92a5-45c7-b15a-2008e2cfb9c4)

Just add the following lines to `luci.locations`:

```
location =/ {
  return 302 /cgi-bin/luci/;  // Use 302 to avoid permanent redirect caching by browsers
}
```

by this way, the blank page will no longer be displayed, and nginx can handle the redirect by itself.
~~Because it is a 301 response, the browser will automatically jump to /cgi-bin/luci/ the next time you visit.~~
Because it is a 302 response, the browser will automatically jump to /cgi-bin/luci/ the next time you visit. Use `302` to prevent browsers from caching the redirect permanently.

If you still see a blank page when accessing the root url after applying this patch, you need to open the browser console page when accessing, find the Network tab, check Disable Cache, and then access the root url