### PR TITLE
cargo-c: Version bump

### DIFF
--- a/devel/cargo-c/Makefile
+++ b/devel/cargo-c/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cargo-c
-PKG_VERSION:=0.9.32
+PKG_VERSION:=0.10.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/lu-zero/cargo-c/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=a96f3cc6c63d9901c9583083338d50b0132504bb067f68accc17f4116ed01f72
+PKG_HASH:=2c7bfff50e9c11801c92280f34f7d308857652b0c3875d0fd0906167623414ac
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me 
Compile tested: aarch64, main
Run tested: N/A

Description: Version bump to keep it in sync with cargo so packages using the new resolver would work fine.
