### PR TITLE
acme-acmesh: Bump to v3.1.0

### DIFF
--- a/net/acme-acmesh/Makefile
+++ b/net/acme-acmesh/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-acmesh
-PKG_VERSION:=3.0.7
-PKG_RELEASE:=2
+PKG_VERSION:=3.1.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/acmesh-official/acme.sh/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=abd446d6bd45d0b44dca1dcbd931348797a3f82d1ed6fb171472eaf851a8d849
+PKG_HASH:=5bc8a72095e16a1a177d1a516728bbd3436abf8060232d5d36b462fce74447aa
 PKG_BUILD_DIR:=$(BUILD_DIR)/acme.sh-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>


### PR DESCRIPTION
New upstream release with mostly minor fixes.

Maintainer: me 

Fixes https://github.com/openwrt/packages/issues/24262