### PR TITLE
liburcu: update to version 0.15.0

### DIFF
--- a/libs/liburcu/Makefile
+++ b/libs/liburcu/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=liburcu
-PKG_VERSION:=0.14.1
+PKG_VERSION:=0.15.0
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
@@ -18,7 +18,7 @@ PKG_LICENSE_FILES:=lgpl-2.1.txt gpl-2.0.txt lgpl-relicensing.txt
 
 PKG_SOURCE:=userspace-rcu-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://lttng.org/files/urcu/
-PKG_HASH:=231acb13dc6ec023e836a0f0666f6aab47dc621ecb1d2cd9d9c22f922678abc0
+PKG_HASH:=4f2d839af67905ad396d6d53ba5649b66113d90840dcbc89941e0da64bccd38c
 PKG_BUILD_DIR:=$(BUILD_DIR)/userspace-rcu-$(PKG_VERSION)
 
 PKG_FIXUP:=autoreconf

--- a/libs/liburcu/patches/010-no-tests.patch
+++ b/libs/liburcu/patches/010-no-tests.patch
@@ -1,10 +1,11 @@
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -1,6 +1,6 @@
+@@ -4,7 +4,7 @@
+ 
  ACLOCAL_AMFLAGS=-I m4
  
 -SUBDIRS = include src doc tests extras
 +SUBDIRS = include src
  
- dist_doc_DATA = LICENSE \
- 		README.md
+ dist_doc_DATA = \
+ 	LICENSE.md \


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan

Description:

- update of the library `knot` depends on