### PR TITLE
prosody: update to 0.12.5

### DIFF
--- a/net/prosody/Makefile
+++ b/net/prosody/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prosody
-PKG_VERSION:=0.11.13
+PKG_VERSION:=0.12.15
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://prosody.im/downloads/source
-PKG_HASH:=39c61b346a09b5125b604cb969e14206cbbcb86c81156ffc6ba2d62527cf0432
+PKG_HASH:=778fb7707a0f10399595ba7ab9c66dd2a2288c0ae3a7fe4ab78f97d462bd399f
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=MIT/X11


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>
Compile tested: x86-64, virtual, snapshot
Run tested: x86-64, virtual, snapshot

Description:
With this PR i propose to update Prosody to v0.12.5.

Fixes: https://github.com/openwrt/packages/issues/25464