### PR TITLE
adblock: Add cert.pl list

### DIFF
--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -362,5 +362,12 @@
 		"size": "S",
 		"focus": "general",
 		"descurl": "https://pgl.yoyo.org/as"
+	},
+	"cert": {
+		"url": "https://hole.cert.pl/domains/v2/domains.txt",
+		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
+		"size": "XXL",
+		"focus": "general",
+		"descurl": "https://cert.pl"
 	}
 }


### PR DESCRIPTION
Maintainer: Janusz Kostorz <janusz.kostorz@gmail.com>
Compile tested: MediaTek MT7621 ver:1 eco:3, Ubiquiti EdgeRouter X, 23.05.5
Run tested: MediaTek MT7621 ver:1 eco:3, Ubiquiti EdgeRouter X, 23.05.5

Description: Add "Dangerous websites Warning List" from Cert Polska (https://hole.cert.pl/domains/v2/domains.txt) to adblock package.

More about CERT Polska: https://cert.pl/en/about-us/