### PR TITLE
vsftpd: fix bug related to option conf_file

### DIFF
--- a/net/vsftpd/Makefile
+++ b/net/vsftpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vsftpd
 PKG_VERSION:=3.0.5
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://security.appspot.com/downloads/

--- a/net/vsftpd/files/vsftpd.init
+++ b/net/vsftpd/files/vsftpd.init
@@ -141,7 +141,7 @@ start_service() {
 	mkdir -m 0755 -p "$DEFAULT_SECURE_CHROOT"
 	chown root:root "$DEFAULT_SECURE_CHROOT"
 
-	config_get_bool conf_file global conf_file ""
+	config_get conf_file global conf_file ""
 	if [ -n "$conf_file" ]; then 
 		# use user defined conf file instead of UCI
 		OUTPUT_CONF="$conf_file"


### PR DESCRIPTION
* I had wrongly used config_get_bool for the option, so fixed it
* this also fixes the issue of /etc/init.d/vsftpd stop not working

Signed-off-by: Mohd Husaam Mehdi <husaam.mehdi@iopsys.eu>
