### PR TITLE
openssh: fix killing of active sessions on shutdown

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openssh
 PKG_REALVERSION:=9.9p1
 PKG_VERSION:=9.9_p1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_REALVERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
@@ -184,7 +184,7 @@ CONFIGURE_ARGS += \
 	--with$(if $(CONFIG_OPENSSL_ENGINE),,out)-ssl-engine \
 	--with$(if $(CONFIG_OPENSSH_LIBFIDO2),,out)-security-key-builtin \
 	--with-cflags-after=-fzero-call-used-regs=skip
-	
+
 ifeq ($(BUILD_VARIANT),with-pam)
 CONFIGURE_ARGS += \
 	--with-pam

--- a/net/openssh/files/sshd.init
+++ b/net/openssh/files/sshd.init
@@ -41,7 +41,7 @@ shutdown() {
 	stop
 
 	# kill active clients
-	for pid in $(pidof sshd)
+	for pid in $(pidof sshd-session)
 	do
 		[ "$pid" = "$$" ] && continue
 		[ -e "/proc/$pid/stat" ] && kill $pid


### PR DESCRIPTION
Starting with OpenSSH 9.8 sessions are handled by a separate binary called sshd-session

Maintainer: @graysky2 
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
Without this fix open sessions are not killed on shutdown since the name of the binary has changed.