### PR TITLE
ddns-scripts: get l3 device for bind network using curl

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=58
+PKG_RELEASE:=59
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
@@ -96,8 +96,8 @@ __PRGBASE="$CURL -RsS -o $DATFILE --stderr $ERRFILE"
 # force network/interface-device to use for communication
 if [ -n "$bind_network" ]; then
 	local __DEVICE
-	network_get_physdev __DEVICE $bind_network || \
-		write_log 13 "Can not detect local device using 'network_get_physdev $bind_network' - Error: '$?'"
+	network_get_device __DEVICE $bind_network || \
+		write_log 13 "Can not detect local device using 'network_get_device $bind_network' - Error: '$?'"
 	write_log 7 "Force communication via device '$__DEVICE'"
 	__PRGBASE="$__PRGBASE --interface $__DEVICE"
 fi

--- a/net/ddns-scripts/files/usr/lib/ddns/update_dnspod_cn.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_dnspod_cn.sh
@@ -28,7 +28,7 @@ build_command() {
 	# bind host/IP
 	if [ -n "$bind_network" ]; then
 		local __DEVICE
-		network_get_physdev __DEVICE $bind_network || write_log 13 "Can not detect local device using 'network_get_physdev $bind_network' - Error: '$?'"
+		network_get_device __DEVICE $bind_network || write_log 13 "Can not detect local device using 'network_get_device $bind_network' - Error: '$?'"
 		write_log 7 "Force communication via device '$__DEVICE'"
 		__CMDBASE="$__CMDBASE --interface $__DEVICE"
 	fi

--- a/net/ddns-scripts/files/usr/lib/ddns/update_dnspod_cn_v3.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_dnspod_cn_v3.sh
@@ -120,8 +120,8 @@ tencentcloud_transfer() {
 # force network/interface-device to use for communication
 if [ -n "$bind_network" ]; then
 	local __DEVICE
-	network_get_physdev __DEVICE $bind_network ||
-		write_log 13 "Can not detect local device using 'network_get_physdev $bind_network' - Error: '$?'"
+	network_get_device __DEVICE $bind_network ||
+		write_log 13 "Can not detect local device using 'network_get_device $bind_network' - Error: '$?'"
 	write_log 7 "Force communication via device '$__DEVICE'"
 	__PRGBASE="$__PRGBASE --interface $__DEVICE"
 fi

--- a/net/ddns-scripts/files/usr/lib/ddns/update_godaddy_com_v1.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_godaddy_com_v1.sh
@@ -93,8 +93,8 @@ __PRGBASE="$CURL -RsS -w '%{http_code}' -o $DATFILE --stderr $ERRFILE"
 # force network/interface-device to use for communication
 if [ -n "$bind_network" ]; then
 	local __DEVICE
-	network_get_physdev __DEVICE $bind_network || \
-		write_log 13 "Can not detect local device using 'network_get_physdev $bind_network' - Error: '$?'"
+	network_get_device __DEVICE $bind_network || \
+		write_log 13 "Can not detect local device using 'network_get_device $bind_network' - Error: '$?'"
 	write_log 7 "Force communication via device '$__DEVICE'"
 	__PRGBASE="$__PRGBASE --interface $__DEVICE"
 fi

--- a/net/ddns-scripts/files/usr/lib/ddns/update_luadns_v1.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_luadns_v1.sh
@@ -76,8 +76,8 @@ __PRGBASE="$CURL -RsS -w '%{http_code}' -o $DATFILE --stderr $ERRFILE"
 # force network/interface-device to use for communication
 if [ -n "$bind_network" ]; then
 	local __DEVICE
-	network_get_physdev __DEVICE $bind_network || \
-		write_log 13 "Can not detect local device using 'network_get_physdev $bind_network' - Error: '$?'"
+	network_get_device __DEVICE $bind_network || \
+		write_log 13 "Can not detect local device using 'network_get_device $bind_network' - Error: '$?'"
 	write_log 7 "Force communication via device '$__DEVICE'"
 	__PRGBASE="$__PRGBASE --interface $__DEVICE"
 fi


### PR DESCRIPTION
If pppoe is used for wan access. script set 'eth1' as interface for curl call. The correct interface is however 'pppoe-wan'.

These scripts use 'network_get_physdev' function to get real device for bind_network but this is wrong. We need instead the l3_device of the the logical interface.

In case if we don't use pppoe connection - 'l3_device' is equal to real device.

Follow P/R:
 #14431

And please backport to current stable version.