### PR TITLE
rng-tools: bumped version, requested maintainer

### DIFF
--- a/utils/rng-tools/Makefile
+++ b/utils/rng-tools/Makefile
@@ -8,15 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rng-tools
-PKG_VERSION:=6.15
-PKG_RELEASE:=2
+PKG_VERSION:=6.17
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/nhorman/rng-tools
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_MIRROR_HASH:=ed3b07062ab6d89ffd145a4df495534b9d529bebb64bc2c2e4dc266acdde181b
 
-PKG_MAINTAINER:=Nathaniel Wesley Filardo <nwfilardo@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:rng-tools_project:rng-tools


### PR DESCRIPTION
Maintainer: nobody
Compile tested: x86-64
Run tested: x86-64

Description:
Removal of maintainer as requested in https://github.com/openwrt/packages/issues/14492 by the maintainer.
Also bumped version.