### PR TITLE
openssh: Validate keys and regenerate if needed.

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openssh
 PKG_REALVERSION:=9.9p1
 PKG_VERSION:=9.9_p1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_REALVERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \

--- a/net/openssh/files/sshd.init
+++ b/net/openssh/files/sshd.init
@@ -12,6 +12,13 @@ start_service() {
 	do
 		# check for keys
 		key=/etc/ssh/ssh_host_${type}_key
+		[ -f $key ] && {
+			[ -x /usr/bin/ssh-keygen ] && {
+				if ! /usr/bin/ssh-keygen -y -f $key > /dev/null 2>&1; then
+					rm -rf $key
+				fi
+			}
+		}
 		[ ! -f $key ] && {
 			# generate missing keys
 			[ -x /usr/bin/ssh-keygen ] && {


### PR DESCRIPTION
Imitate dropbear init.d-script and make sure we
don't end up with corrupt keys.

This can happen if we use a caching filesystem,
like 'ubifs', and the DUT is powered off during
boot-up.
