### PR TITLE
lpac: update to 2.2.1, add support for custom ISD-R AID

### DIFF
--- a/utils/lpac/Makefile
+++ b/utils/lpac/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lpac
-PKG_VERSION:=2.1.0
-PKG_RELEASE:=2
+PKG_VERSION:=2.2.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/estkme-group/lpac/tar.gz/refs/tags/v$(PKG_VERSION)?
-PKG_HASH:=532c5daef6888fe91b0838e8e23bf23ea2f5f39cbb755c008676b9cdfbd833fb
+PKG_HASH:=3d87080a625b10430eebb82f89e2d24e16a84a8435a9c40b3718fd88c82028ba
 
 PKG_MAINTAINER:=David Bauer <david.bauer@uniberg.com>
 PKG_LICENSE:=AGPL-3.0-only LGPL-2.0-only

--- a/utils/lpac/files/lpac.sh
+++ b/utils/lpac/files/lpac.sh
@@ -8,6 +8,8 @@ APDU_DEBUG="$(uci_get lpac global apdu_debug 0)"
 HTTP_BACKEND="$(uci_get lpac global http_backend curl)"
 HTTP_DEBUG="$(uci_get lpac global http_debug 0)"
 
+CUSTOM_ISD_R_AID="$(uci_get lpac global custom_isd_r_aid A0000005591010FFFFFFFF8900000100)"
+
 export LPAC_HTTP="$HTTP_BACKEND"
 if [ "$HTTP_DEBUG" -eq 1 ]; then
     export LIBEUICC_DEBUG_HTTP="1"
@@ -29,5 +31,7 @@ elif [ "$APDU_BACKEND" = "uqmi" ]; then
     export LPAC_QMI_DEV="$UQMI_DEV"
     export LPAC_QMI_DEBUG="$UQMI_DEBUG"
 fi
+
+export LPAC_CUSTOM_ISD_R_AID="$CUSTOM_ISD_R_AID"
 
 /usr/lib/lpac "$@"

--- a/utils/lpac/files/lpac.uci
+++ b/utils/lpac/files/lpac.uci
@@ -3,6 +3,7 @@ config global global
 	option		http_backend	'curl'
 	option		apdu_debug	'0'
 	option		http_debug	'0'
+	option		custom_isd_r_aid	'A0000005591010FFFFFFFF8900000100'
 
 config at at
 	option		device		'/dev/ttyUSB2'


### PR DESCRIPTION
Updated lpac to 2.2.1 and added support for custom ISD-R AIDs. This allows for a broader range of esim cards with non standard AIDs to be supported. See https://github.com/estkme-group/lpac/pull/181 for additional info.

Maintainer: @blocktrron 
Compile tested: ramips/mt7621 TP-Link MR600 v2 (EU) (24.10-rc5, snapshot)
Run tested: ramips/mt7621 TP-Link MR600 v2 (EU) (24.10-rc5, snapshot) Verified esim profile management with standard and non-standard AID cards
