### PR TITLE
[24.10] openvpn: update to 2.6.13

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.6.12
+PKG_VERSION:=2.6.13
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=1c610fddeb686e34f1367c347e027e418e07523a10f4d8ce4a2c2af2f61a1929
+PKG_HASH:=1af10b86922bd7c99827cc0f151dfe9684337b8e5ebdb397539172841ac24a6a
 
 PKG_MAINTAINER:=
 


### PR DESCRIPTION
Maintainer: @neheb @AuthorReflex
Compile tested: ramips/mt7620
Run tested: Xiaomi Mi-mini

Feature changes:
 - on non-windows clients (MacOS, Linux, Unix) send "release" string from uname() call as IV_PLAT_VER to server
 - Windows: protect cached username, password and token in client memory
 - Windows: use new API to get dco-win driver version from driver
 - Linux: pass --timeout=0 argument to systemd-ask-password, to avoid default timeout of 90 seconds

Security fixes:
 - improve server-side handling of clients sending usernames or passwords longer than USER_PASS_LEN

Notable bug fixes:
 - FreeBSD DCO: fix memory leaks in nvlist handling
 - purge proxy authentication credentials from memory after use

For details refer to https://github.com/OpenVPN/openvpn/blob/v2.6.13/Changes.rst
(cherry-picked from https://github.com/openwrt/packages/pull/25765)

