### PR TITLE
[23.05]sing-box: Update to 1.10.7

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.9.7
+PKG_VERSION:=1.10.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=5b015352f3434bb780af01a6b1f6c0fe706166d6c44a69547e29892f0920b944
+PKG_HASH:=402b618148b58f5ff6c1bee4f4fdcf7cdcb88a2df6a8bd682ea742a89b5be9ec
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @brvphoenix
Compile tested: all supported targets
Run tested: N/A

Description:
sing-box: update to 1.10.7(cherry picked from commit https://github.com/openwrt/packages/commit/996c1819e3c68e27783bc7ac081cfcd3dc75ea3b)

Fixes and improvements

For more information, visit https://github.com/SagerNet/sing-box/compare/v1.9.7...v1.10.7