### PR TITLE
adblock: add oisd nsfw small blacklist source

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
 PKG_VERSION:=4.2.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -33,6 +33,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 | notracking          |         | XL   | tracking         | [Link](https://github.com/notracking/hosts-blocklists)                            |
 | oisd_big            |         | XXL  | general          | [Link](https://oisd.nl)                                                           |
 | oisd_nsfw           |         | XXL  | porn             | [Link](https://oisd.nl)                                                           |
+| oisd_nsfw_small     |         | M    | porn             | [Link](https://oisd.nl)                                                           |
 | oisd_small          |         | L    | general          | [Link](https://oisd.nl)                                                           |
 | openphish           |         | S    | phishing         | [Link](https://openphish.com)                                                     |
 | phishing_army       |         | S    | phishing         | [Link](https://phishing.army)                                                     |

--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -167,6 +167,13 @@
 		"focus": "general",
 		"descurl": "https://oisd.nl"
 	},
+	"oisd_nsfw_small": {
+		"url": "https://nsfw-small.oisd.nl/domainswild2",
+		"rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
+		"size": "M",
+		"focus": "porn",
+		"descurl": "https://oisd.nl"
+	},
 	"openphish": {
 		"url": "https://openphish.com/feed.txt",
 		"rule": "BEGIN{FS=\"\/\"}/^http[s]?:\\/\\/([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+(\\/|$)/{print tolower($3)}",


### PR DESCRIPTION
Maintainer: me
Compile tested: all supported targets
Run tested: N/A
Description: Added [OISD](https://oisd.nl)'s new NSFW small variant as a blacklist source.