### PR TITLE
htop: support show core temperature on rockchip rk3566/3588

### DIFF
--- a/admin/htop/Makefile
+++ b/admin/htop/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=htop
 PKG_VERSION:=3.3.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/htop-dev/htop/tar.gz/$(PKG_VERSION)?

--- a/admin/htop/patches/001-Show-core-temperatures-of-Rockchip-RK3588-SoC.patch
+++ b/admin/htop/patches/001-Show-core-temperatures-of-Rockchip-RK3588-SoC.patch
@@ -1,0 +1,71 @@
+From ba5738813d27e67057d55af970eba3374a5e288f Mon Sep 17 00:00:00 2001
+From: Gabor SEBESTYEN <segabor@gmail.com>
+Date: Mon, 11 Mar 2024 07:59:41 +0100
+Subject: [PATCH] Show core temperatures of Rockchip RK3588 SoC
+
+---
+ linux/LibSensors.c | 45 +++++++++++++++++++++++++++++++++++++++------
+ 1 file changed, 39 insertions(+), 6 deletions(-)
+
+--- a/linux/LibSensors.c
++++ b/linux/LibSensors.c
+@@ -133,13 +133,17 @@ static int tempDriverPriority(const sens
+       const char* prefix;
+       int priority;
+    } tempDrivers[] =  {
+-      { "coretemp",    0 },
+-      { "via_cputemp", 0 },
+-      { "cpu_thermal", 0 },
+-      { "k10temp",     0 },
+-      { "zenpower",    0 },
++      { "coretemp",           0 },
++      { "via_cputemp",        0 },
++      { "cpu_thermal",        0 },
++      { "k10temp",            0 },
++      { "zenpower",           0 },
++      /* Rockchip RK3588 */
++      { "littlecore_thermal", 0 },
++      { "bigcore0_thermal",   0 },
++      { "bigcore1_thermal",   0 },
+       /* Low priority drivers */
+-      { "acpitz",      1 },
++      { "acpitz",             1 },
+    };
+ 
+    for (size_t i = 0; i < ARRAYSIZE(tempDrivers); i++)
+@@ -208,6 +212,35 @@ void LibSensors_getCPUTemperatures(CPUDa
+          if (r != 0)
+             continue;
+ 
++         /* Map temperature values to Rockchip cores
++          *
++          *   littlecore -> cores 1..4
++          *   bigcore0   -> cores 5,6
++          *   bigcore1   -> cores 7,8
++          */
++         if (existingCPUs == 8) {
++            if (String_eq(chip->prefix, "littlecore_thermal")) {
++               data[1] = temp;
++               data[2] = temp;
++               data[3] = temp;
++               data[4] = temp;
++               coreTempCount += 4;
++               continue;
++            }
++            if (String_eq(chip->prefix, "bigcore0_thermal")) {
++               data[5] = temp;
++               data[6] = temp;
++               coreTempCount += 2;
++               continue;
++            }
++            if (String_eq(chip->prefix, "bigcore1_thermal")) {
++               data[7] = temp;
++               data[8] = temp;
++               coreTempCount += 2;
++               continue;
++            }
++         }
++
+          /* If already set, e.g. Ryzen reporting platform temperature for each die, use the bigger one */
+          if (isNaN(data[tempID])) {
+             data[tempID] = temp;

--- a/admin/htop/patches/002-Be-less-strict-about-thermal-zones-for-RockChip-RK35.patch
+++ b/admin/htop/patches/002-Be-less-strict-about-thermal-zones-for-RockChip-RK35.patch
@@ -1,0 +1,28 @@
+From f2f724b6414d9f49c087e6c177e8a1c2eb80a0c8 Mon Sep 17 00:00:00 2001
+From: Benny Baumann <BenBE@geshi.org>
+Date: Fri, 30 Aug 2024 21:56:18 +0200
+Subject: [PATCH] Be less strict about thermal zones for RockChip RK3588 SoC
+
+---
+ linux/LibSensors.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/linux/LibSensors.c
++++ b/linux/LibSensors.c
+@@ -142,6 +142,7 @@ static int tempDriverPriority(const sens
+       { "littlecore_thermal", 0 },
+       { "bigcore0_thermal",   0 },
+       { "bigcore1_thermal",   0 },
++      { "bigcore2_thermal",   0 },
+       /* Low priority drivers */
+       { "acpitz",             1 },
+    };
+@@ -233,7 +234,7 @@ void LibSensors_getCPUTemperatures(CPUDa
+                coreTempCount += 2;
+                continue;
+             }
+-            if (String_eq(chip->prefix, "bigcore1_thermal")) {
++            if (String_eq(chip->prefix, "bigcore1_thermal") || String_eq(chip->prefix, "bigcore2_thermal")) {
+                data[7] = temp;
+                data[8] = temp;
+                coreTempCount += 2;

--- a/admin/htop/patches/003-feat-add-sensors-for-Rockchip-RK3566.patch
+++ b/admin/htop/patches/003-feat-add-sensors-for-Rockchip-RK3566.patch
@@ -1,0 +1,39 @@
+From 1eab0a5b1f58ed893a44e87243cc5d9a236f639f Mon Sep 17 00:00:00 2001
+From: KholkinDmitrii <62114481+KholkinDmitrii@users.noreply.github.com>
+Date: Wed, 9 Oct 2024 12:46:51 +0200
+Subject: [PATCH] feat: add sensors for Rockchip RK3566
+
+---
+ linux/LibSensors.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+--- a/linux/LibSensors.c
++++ b/linux/LibSensors.c
+@@ -143,6 +143,8 @@ static int tempDriverPriority(const sens
+       { "bigcore0_thermal",   0 },
+       { "bigcore1_thermal",   0 },
+       { "bigcore2_thermal",   0 },
++      /* Rockchip RK3566 */
++      { "soc_thermal",        0 },
+       /* Low priority drivers */
+       { "acpitz",             1 },
+    };
+@@ -241,6 +243,18 @@ void LibSensors_getCPUTemperatures(CPUDa
+                continue;
+             }
+          }
++
++         /* Rockchip RK3566 */
++         if (existingCPUs == 4) {
++            if (String_eq(chip->prefix, "soc_thermal")) {
++               data[1] = temp;
++               data[2] = temp;
++               data[3] = temp;
++               data[4] = temp;
++               coreTempCount += 4;
++               continue;
++            }
++         }
+ 
+          /* If already set, e.g. Ryzen reporting platform temperature for each die, use the bigger one */
+          if (isNaN(data[tempID])) {


### PR DESCRIPTION
Backport support to show core temperature on rockchip rk3566/3588 SoC

Maintainer: @champtar
Compile tested: arm64, OpenWrt main
Run tested: rockchip, NanoPi R6C
