### PR TITLE
[24.10] netbird: update to 0.36.3, revert fix to build with musl >1.2.4 and change maintainer

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -44,12 +44,6 @@ define Package/netbird/conffiles
 /etc/netbird/config.json
 endef
 
-# Workaround for musl 1.2.4 compability in mattn/go-sqlite3
-# https://github.com/mattn/go-sqlite3/issues/1164
-ifneq ($(CONFIG_USE_MUSL),)
-	TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
-endif
-
 define Package/netbird/install
 	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/etc/init.d

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.30.3
+PKG_VERSION:=0.36.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=21cd8ed88ac0f284be11deb70cfe8afbafcba9d888e50bda9fa8f45d87b28dba
+PKG_HASH:=71d0e7c342bdcd1b74b9b4e99d2c87f898ed54f780b4adf6bbda77900b842ec8
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -8,7 +8,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=21cd8ed88ac0f284be11deb70cfe8afbafcba9d888e50bda9fa8f45d87b28dba
 
-PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
+PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 


### PR DESCRIPTION
## ~Draft PR, need testing and PR #25782 merge~
## Compile and run tested

**Maintainer:** Me

| Package architecture | Target | Subtarget | Brand | Model | Hardware Version | OpenWrt version |
|----------------------|--------|-----------|-------|-------|------------------|-----------------|
| [x86_64](https://openwrt.org/docs/techref/instructionset/x86_64) | [x86](https://openwrt.org/docs/techref/targets/x86) | 64 | QEMU (x86_64) | qemu-system-x86_64 | qemu-9.1.2-2.fc41 | OpenWrt 24.10-SNAPSHOT r28361-3207fe6636 |

**Tests Performed:**
- [x] Connection to the NetBird Cloud Dashboard (not self-hosted).
- [x] Firewall configured with nftables.
- [x] Connection established in P2P mode.
- [x] `wireguard` kernel mode active.
- [x] Routes configured between my homelab and my cloud server.
- [x] `netbird` DNS server functioning correctly.
- [ ] NAT operational (not needed by me at this time, may consider testing in the future).
- [ ] Permissions rules is enforced (not needed by me at this time, may consider testing in the future).

## Description

- Changelog:
  - Change maintainer:
    - Add myself as maintainer
    - Remove `Oskari Rauta <oskari.rauta@gmail.com>`
      - Cherry picked from 2594fc3e2ebdba785dca3ac3ccf944359c8eb5b1
      - PR #25540
  - Partially revert: 7b3d033ab651dd11e0db5fb099d106c9e09a2dc6
    - Revert: Also fixes issue of not being able to build with musl >1.2.4,
      The issue has been resolved as of March 2024. For more details, see:
      https://github.com/mattn/go-sqlite3/issues/1164#issuecomment-1975022901
      - Cherry picked from 851386dc67bddcd7b1c4fbd85d4576335d703c48
      - PR #25637
  - Update to [0.36.3](https://github.com/netbirdio/netbird/releases/tag/v0.36.3)
    - Full changelog: https://github.com/netbirdio/netbird/compare/v0.30.3...v0.36.3
      - Cherry picked from 8628bd16bbe6521e36ebe591356a319792eae505
      - PR #25782

## Additional information

`x86_64` running as virtual machine with [`incus`](https://github.com/lxc/incus).
Compiled package with container [`sdk`](https://github.com/openwrt/docker), and build `openwrt` image with container [`imagebuilder`](https://github.com/openwrt/docker).

My repo with my automated build can be see here:
- https://github.com/wehagy/openwrt-builder/tree/update/netbird

And my artifacts here:
- https://github.com/wehagy/openwrt-builder/actions/runs/12874269178