### PR TITLE
syncthing: Update to 1.29.2 and Change logfile path

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.27.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.29.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=5c7b0456e50c8a2e4c9767727c4139558ba95573a276273a1730a903e0a73834
+PKG_HASH:=c7b6bc36af1af6f1cb304f4ec4c16743760ef6e8b3586f31dc11439d5d5fd427
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 

--- a/utils/syncthing/files/syncthing.conf
+++ b/utils/syncthing/files/syncthing.conf
@@ -24,7 +24,7 @@ config syncthing 'syncthing'
 	# Running as 'root' is possible, but not recommended
 	option user 'syncthing'
 
-	option logfile '/etc/syncthing/syncthing.log'
+	option logfile '/var/log/syncthing.log'
 	option log_max_old_files 7
 	# Size in bytes
 	option log_max_size 1048576

--- a/utils/syncthing/files/syncthing.init
+++ b/utils/syncthing/files/syncthing.init
@@ -48,7 +48,7 @@ start_service() {
 	local enabled=0
 	local gui_address="http://0.0.0.0:8384"
 	local home="/etc/syncthing"
-	local logfile="/etc/syncthing/syncthing.log"
+	local logfile="/var/log/syncthing.log"
 	local macprocs=0
 	local nice=0
 	local user="syncthing"


### PR DESCRIPTION
Update to 1.29.2 and Change logfile path from /etc/syncthing/syncthing log to /var/log/syncthing.log.
This utilizes tmpfs (memory-based storage) to prevent disk usage growth caused by log file accumulation during extended operation.

Benefits:
- Avoids storage saturation from excessive log growth.
- Aligns with best practices for temporary log management.
- For systems using flash storage (e.g., SSDs or eMMC), storing logs in tmpfs avoids flash memory wear caused by frequent writes to /etc/syncthing.

Maintainer: Paul Spooren [mail@aparcar.org](mailto:mail@aparcar.org), Van Waholtz [brvphoenix@gmail.com](mailto:brvphoenix@gmail.com)
Compile tested: x86-64（Ubuntu 24）, master(24.10-rc5)
Run tested: x86-64, master(24.10-rc5), it's running normally.
Description:
The current version is two years old, and the default log path is under /etc/syncthing, which does not automatically clean up after restarting the machine or program, resulting in wasted storage space (especially for small embedded devices).


Because the repository was forked again, the previous PR cannot be reopened.  
Regarding the previously mentioned [`make -j` compilation error](https://github.com/openwrt/packages/pull/25753#issuecomment-2599505564), it seems that it's due to the lack of support for `make -j` compilation when building Go in the OpenWRT SDK, and it doesn't affect the normal source code compilation process. The rest of the test results are all normal.