### PR TITLE
zoneinfo: Updated to 2025a release.

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2024 OpenWrt.org
+# Copyright (C) 2007-2025 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2024b
+PKG_VERSION:=2025a
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public-Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=70e754db126a8d0db3d16d6b4cb5f7ec1e04d5f261255e4558a67fe92d39e550
+PKG_HASH:=4d5fcbc72c7c450ebfe0b659bd0f1c02fbf52fd7f517a9ea13fe71c21eb5f0d0
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=5e438fc449624906af16a18ff4573739f0cda9862e5ec28d3bcb19cbaed0f672
+   HASH:=119679d59f76481eb5e03d3d2a47d7870d592f3999549af189dbd31f2ebf5061
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT master
Run tested: n/a

Description:

This release contains the following changes:

   Briefly:

     Paraguay adopts permanent -03 starting spring 2024.
     Improve pre-1991 data for the Philippines.
     Etc/Unknown is now reserved.

   Changes to future timestamps

     Paraguay will stop changing its clocks after the spring-forward
     transition on 2024-10-06, so it is now permanently at -03.
     (Thanks to Heitor David Pinto and Even Scharning.)
     This affects timestamps starting 2025-03-22, as well as the
     obsolescent tm_isdst flags starting 2024-10-15.

   Changes to past timestamps

     Correct timestamps for the Philippines before 1900, and from 1937
     through 1990.  (Thanks to P Chan for the heads-up and citations.)
     This includes adjusting local mean time before 1899; fixing
     transitions in September 1899, January 1937, and June 1954; adding
     transitions in December 1941, November 1945, March and September
     1977, and May and July 1990; and removing incorrect transitions in
     March and September 1978.

   Changes to data

     Add zone1970.tab lines for the Concordia and Eyre Bird Observatory
     research stations.  (Thanks to Derick Rethans and Jule Dabars.)

   Changes to code

     strftime %s now generates the correct numeric string even when the
     represented number does not fit into time_t.  This is better than
     generating the numeric equivalent of (time_t) -1, as strftime did
     in TZDB releases 96a (when %s was introduced) through 2020a and in
     releases 2022b through 2024b.  It is also better than failing and
     returning 0, as strftime did in releases 2020b through 2022a.

     strftime now outputs an invalid conversion specifier as-is,
     instead of eliding the leading '%', which confused debugging.

     An invalid TZ now generates the time zone abbreviation "-00", not
     "UTC", to help the user see that an error has occurred.  (Thanks
     to Arthur David Olson for suggesting a "wrong result".)

     mktime and timeoff no longer incorrectly fail merely because a
     struct tm component near INT_MIN or INT_MAX overflows when a
     lower-order component carries into it.

     TZNAME_MAXIMUM, the maximum number of bytes in a proleptic TZ
     string's time zone abbreviation, now defaults to 254 not 255.
     This helps reduce the size of internal state from 25480 to 21384
     on common platforms.  This change should not be a problem, as
     nobody uses such long "abbreviations" and the longstanding tzcode
     maximum was 16 until release 2023a.  For those who prefer no
     arbitrary limits, you can now specify TZNAME_MAXIMUM values up to
     PTRDIFF_MAX, a limit forced by C anyway; formerly tzcode silently
     misbehaved unless TZNAME_MAXIMUM was less than INT_MAX.

     tzset and related functions no longer leak a file descriptor if
     another thread forks or execs at about the same time and if the
     platform has O_CLOFORK and O_CLOEXEC respectively.  Also, the
     functions no longer let a TZif file become a controlling terminal.

     'zdump -' now reads TZif data from /dev/stdin.
     (From a question by Arthur David Olson.)

   Changes to documentation

     The name Etc/Unknown is now reserved: it will not be used by TZDB.
     This is for compatibility with CLDR, which uses the string
     "Etc/Unknown" for an unknown or invalid timezone.  (Thanks to
     Justin Grant, Mark Davis, and Guy Harris.)

     Cite Internet RFC 9636, which obsoletes RFC 8536 for TZif format.
