### PR TITLE
[23.05] node: January 21, 2025 Security Releases

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v18.20.5
+PKG_VERSION:=v18.20.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=938735364745b7d4cd650b9325df6f2d2ec4240c56f9318e38638af910a820c6
+PKG_HASH:=e7ddfeabea3d1f7cc622cc9861d2fb0955b9e60940dbbedbed6f2f821ab3e4c7
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me @ianchi
Compile tested: 23.05, aarch64, arm
Run tested: (qemu 9.2.0) aarch64

Description:
Update to 18.20.6

Notable Changes

    CVE-2025-23085 - src: fix HTTP2 mem leak on premature close and ERR_PROTO (Medium)
    CVE-2025-23084 - path: fix path traversal in normalize() on Windows (Medium)

Dependency update:

    CVE-2025-22150 - Use of Insufficiently Random Values in undici fetch() (Medium)