### PR TITLE
acme-common: Resolve problem with webroot symlink

### DIFF
--- a/net/acme-common/Makefile
+++ b/net/acme-common/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-common
-PKG_VERSION:=1.4.1
+PKG_VERSION:=1.4.2
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/acme-common/files/acme.uci-defaults
+++ b/net/acme-common/files/acme.uci-defaults
@@ -4,7 +4,7 @@
 # Create a symlink to webroot
 if [ -d /www/ ] && [ ! -L /www/.well-known/acme-challenge ] && [ ! -d /www/.well-known/acme-challenge/ ]; then
 	mkdir -p /www/.well-known/
-	ln -s /var/run/acme/challenge/ /www/.well-known/acme-challenge
+	ln -s /var/run/acme/challenge/.well-known/acme-challenge /www/.well-known/acme-challenge
 fi
 
 # migrate deprecated opts


### PR DESCRIPTION
acme.sh uses `/var/run/acme/challenge/` as a root of webserver, and automaticly create there `.well-known/acme-challenge` while acme request is in progress.
Now webroot method should works with no need of any additional config.
