### PR TITLE
nut: add --without-nut_monitor to configure args

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.8.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.8/
@@ -545,6 +545,7 @@ CONFIGURE_ARGS += \
 	--$(if $(CONFIG_NUT_SSL),with,without)-ssl $(if $(CONFIG_NUT_SSL),--with-openssl) \
 	--without-libltdl \
 	--without-macosx_ups \
+	--without-nut_monitor \
 	--with-statepath=/var/run/nut \
 	--with-pidpath=/var/run \
 	--with-drvpath=/lib/nut \


### PR DESCRIPTION
Maintainer: @neheb (last pr/commit merger)
Compile tested: master branch / Turris Omnia (mvebu)
Run tested: Turris Omnia (mvebu)

Description:
I think the fact that nut_monitor is built by default might be a bug in NUT's configure. Anyway: nut_monitor is not used at all and is being needlessly built. Even worse, the build uses host system's python (not hostpkg python) and if that python is version 3.13, it breaks the build due to removed telnetlib.