### PR TITLE
openssh: fix recursive key file removal

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openssh
 PKG_REALVERSION:=9.9p1
 PKG_VERSION:=9.9_p1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_REALVERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \

--- a/net/openssh/files/sshd.init
+++ b/net/openssh/files/sshd.init
@@ -15,7 +15,7 @@ start_service() {
 		[ -f $key ] && {
 			[ -x /usr/bin/ssh-keygen ] && {
 				if ! /usr/bin/ssh-keygen -y -f $key > /dev/null 2>&1; then
-					rm -rf $key
+					rm -f $key
 				fi
 			}
 		}


### PR DESCRIPTION
Maintainer: @tripolar
Compile tested: -
Run tested: -

Description:

The -r option is not required here but should also not hurt, since it was already tested, that $key is a file.
However, to express the intent of the command more clearly, let's drop it.

Suggested-by: @SibrenVasse in https://github.com/openwrt/packages/pull/25759#issuecomment-2613928718