### PR TITLE
[23.05] coova-chilli: Fix WolfSSL support

### DIFF
--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coova-chilli
 PKG_VERSION:=1.6
-PKG_RELEASE:=9.1
+PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/coova/coova-chilli/tar.gz/$(PKG_VERSION)?

--- a/net/coova-chilli/patches/030-cyassl-renamed-to-wolfssl.patch
+++ b/net/coova-chilli/patches/030-cyassl-renamed-to-wolfssl.patch
@@ -1,0 +1,34 @@
+--- a/src/md5.h
++++ b/src/md5.h
+@@ -29,7 +29,7 @@
+ #define MD5Final MD5_Final
+ 
+ #elif HAVE_CYASSL
+-#include <cyassl/openssl/md5.h>
++#include <wolfssl/openssl/md5.h>
+ 
+ #define MD5Init MD5_Init
+ #define MD5Update MD5_Update
+--- a/src/ssl.h
++++ b/src/ssl.h
+@@ -49,13 +49,13 @@ typedef struct {
+ #include <string.h>
+ 
+ #define OPENSSL_NO_ENGINE
+-#include <cyassl/options.h>
+-#include <cyassl/ssl.h>
+-#include <cyassl/openssl/bio.h>
+-#include <cyassl/openssl/crypto.h>
+-#include <cyassl/openssl/x509.h>
+-#include <cyassl/openssl/ssl.h>
+-#include <cyassl/openssl/pem.h>
++#include <wolfssl/options.h>
++#include <wolfssl/ssl.h>
++#include <wolfssl/openssl/bio.h>
++#include <wolfssl/openssl/crypto.h>
++#include <wolfssl/openssl/x509.h>
++#include <wolfssl/openssl/ssl.h>
++#include <wolfssl/openssl/pem.h>
+ #endif
+ 
+ #define OPENSSL_TMPKEY_MAX      4


### PR DESCRIPTION
Signed-off-by: Federico Capoano <f.capoano@openwisp.io>
(cherry picked from commit bf3333594a8add333e3d7192107aa7be8bc39a33)

Backporting https://github.com/openwrt/packages/pull/25821.