### PR TITLE
DDns Scripts: Rename 'retry_count' to 'retry_max_count' in custom scripts and sample config

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=61
+PKG_RELEASE:=62
 
 PKG_LICENSE:=GPL-2.0
 
@@ -362,6 +362,10 @@ define Package/ddns-scripts/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) ./files/usr/bin/ddns.sh \
 		$(1)/usr/bin/ddns
+
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DATA) ./files/etc/uci-defaults/50-ddns-migrate-retry-count \
+		$(1)/etc/uci-defaults/
 endef
 
 define Package/ddns-scripts/postinst

--- a/net/ddns-scripts/files/etc/uci-defaults/50-ddns-migrate-retry-count
+++ b/net/ddns-scripts/files/etc/uci-defaults/50-ddns-migrate-retry-count
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+upgrade_to_retry_max_count() {
+	local service=$1
+	local retry_count retry_max_count
+
+	config_get retry_max_count $service retry_max_count
+	config_get retry_count $service retry_count
+	if [ -z "$retry_max_count" ] && [ -n "$retry_count" ]; then
+		uci_set ddns $service retry_max_count $retry_count
+		uci_commit ddns
+	fi
+}
+
+config_load ddns
+config_foreach upgrade_to_retry_max_count service
+
+exit 0

--- a/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
@@ -72,11 +72,11 @@ cloudflare_transfer() {
 		}
 
 		__CNT=$(( $__CNT + 1 ))	# increment error counter
-		# if error count > retry_count leave here
-		[ $retry_count -gt 0 -a $__CNT -gt $retry_count ] && \
-			write_log 14 "Transfer failed after $retry_count retries"
+		# if error count > retry_max_count leave here
+		[ $retry_max_count -gt 0 -a $__CNT -gt $retry_max_count ] && \
+			write_log 14 "Transfer failed after $retry_max_count retries"
 
-		write_log 4 "Transfer failed - retry $__CNT/$retry_count in $RETRY_SECONDS seconds"
+		write_log 4 "Transfer failed - retry $__CNT/$retry_max_count in $RETRY_SECONDS seconds"
 		sleep $RETRY_SECONDS &
 		PID_SLEEP=$!
 		wait $PID_SLEEP	# enable trap-handler

--- a/net/ddns-scripts/files/usr/lib/ddns/update_dnspod_cn.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_dnspod_cn.sh
@@ -70,7 +70,7 @@ dnspod_transfer() {
 			return 1
 		fi
 		__CNT=$(($__CNT + 1))
-		[ $retry_count -gt 0 -a $__CNT -gt $retry_count ] && write_log 14 "Transfer failed after $retry_count retries"
+		[ $retry_max_count -gt 0 -a $__CNT -gt $retry_max_count ] && write_log 14 "Transfer failed after $retry_max_count retries"
 		write_log 4 "Transfer failed - $__CNT Try again in $RETRY_SECONDS seconds"
 		sleep $RETRY_SECONDS &
 		PID_SLEEP=$!

--- a/net/ddns-scripts/files/usr/lib/ddns/update_godaddy_com_v1.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_godaddy_com_v1.sh
@@ -68,11 +68,11 @@ godaddy_transfer() {
 		}
 
 		__CNT=$(( $__CNT + 1 ))	# increment error counter
-		# if error count > retry_count leave here
-		[ $retry_count -gt 0 -a $__CNT -gt $retry_count ] && \
-			write_log 14 "Transfer failed after $retry_count retries"
+		# if error count > retry_max_count leave here
+		[ $retry_max_count -gt 0 -a $__CNT -gt $retry_max_count ] && \
+			write_log 14 "Transfer failed after $retry_max_count retries"
 
-		write_log 4 "Transfer failed - retry $__CNT/$retry_count in $RETRY_SECONDS seconds"
+		write_log 4 "Transfer failed - retry $__CNT/$retry_max_count in $RETRY_SECONDS seconds"
 		sleep $RETRY_SECONDS &
 		PID_SLEEP=$!
 		wait $PID_SLEEP	# enable trap-handler

--- a/net/ddns-scripts/files/usr/lib/ddns/update_luadns_v1.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_luadns_v1.sh
@@ -51,11 +51,11 @@ luadns_transfer() {
 		}
 
 		__CNT=$(( $__CNT + 1 ))	# increment error counter
-		# if error count > retry_count leave here
-		[ $retry_count -gt 0 -a $__CNT -gt $retry_count ] && \
-			write_log 14 "Transfer failed after $retry_count retries"
+		# if error count > retry_max_count leave here
+		[ $retry_max_count -gt 0 -a $__CNT -gt $retry_max_count ] && \
+			write_log 14 "Transfer failed after $retry_max_count retries"
 
-		write_log 4 "Transfer failed - retry $__CNT/$retry_count in $RETRY_SECONDS seconds"
+		write_log 4 "Transfer failed - retry $__CNT/$retry_max_count in $RETRY_SECONDS seconds"
 		sleep $RETRY_SECONDS &
 		PID_SLEEP=$!
 		wait $PID_SLEEP	# enable trap-handler
@@ -112,7 +112,7 @@ if [ -n "$zone_id" ]; then
 else
 	# read zone id for registered domain.TLD
 	__RUNPROG="$__PRGBASE --request GET '$__URLBASE/zones'"
-	luadns_transfer || return 1	
+	luadns_transfer || return 1
 	# extract zone id
 	i=1
 	while : ; do

--- a/net/ddns-scripts/samples/ddns.config_sample
+++ b/net/ddns-scripts/samples/ddns.config_sample
@@ -271,7 +271,7 @@ config service "myddns"
 	# a network to use for communication.
 	# should use option ip_source "web" (see above)
 	# Needs GNU Wget (with SSL support) or cURL to be installed.
-	# GNU Wget will use IP address and cURL the physical device 
+	# GNU Wget will use IP address and cURL the physical device
 	# of the given network
 	# default: none
 #	option bind_network "wan7"
@@ -304,10 +304,10 @@ config service "myddns"
 
 	###########
 	# if error happen on detecting, sending or updating the
-	# script will retry the relevant action for retry_count times
+	# script will retry the relevant action for retry_max_count times
 	# before stopping script execution.
 	# default: 5
-	option retry_count '5'
+	option retry_max_count '5'
 
 	###########
 	# if error happen on detecting, sending or updating the


### PR DESCRIPTION
Maintainer: FriesI23 Qin / @FriesI23
Compile tested: should be universal, Debian 12, OpenWrt 23.05.05
Run tested: i386_pentium4, vm on proxmox 8.3 using [openwrt.sh](https://github.com/tteck/Proxmox/raw/main/vm/openwrt.sh), OpenWrt 23.05

> I don’t have accounts for these providers, so only tested whether scripts listed below can read new var (`retry_max_count`).

Description:

Finish work from "e3292e4" by change remaining `retry_count` to `retry_max_count`. 

[ddns-scripts: rename variable: s/retry_count/retry_max_count/](https://github.com/openwrt/packages/commit/e3292e4c9766e823ed38160390248dbc61f69c82)

- [x] ddns.config_sample
- [x] cloudflare.com v4
- [x] dnspod.cn
- [x] godaddy.com v1
- [x] luadns.com v1

---

- [x] `uci-default` migrate script