### PR TITLE
coova-chilli: enable SSL by default

### DIFF
--- a/net/coova-chilli/Config.in
+++ b/net/coova-chilli/Config.in
@@ -32,7 +32,7 @@ config COOVACHILLI_JSONINTERFACE
 
 choice
 	prompt "SSL library"
-	default COOVACHILLI_NOSSL
+	default COOVACHILLI_WOLFSSL
 
 config COOVACHILLI_NOSSL
 	bool "No SSL support"

--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coova-chilli
 PKG_VERSION:=1.6
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/coova/coova-chilli/tar.gz/$(PKG_VERSION)?


### PR DESCRIPTION
Maintainer: @teslamint
Compile tested: (ramips, yuncore AX820, OpenWrt 24.10)
Run tested: (ramips, yuncore AX820, OpenWrt 24.10)

**Description:**

The current defaults in coova-chilli make the
package in the official OpenWrt repositories
nearly useless: it can't redirect users to
the login HTML page and doesn't support HTTPS.

Without HTTPS, browsers display security
warnings, discouraging users and making the
package impractical in modern environments.

Without redirects, the user would have to
open the login HTML page manually, which
is extremely bad UX.

Updating these defaults will make the package
published in the official OpenWrt feeds
usable out of the box, lowering the barrier
to entry for users exploring coova-chilli's
hotspot features.
