### PR TITLE
chronyd: add `prefer` and `maxsources` options

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
 PKG_VERSION:=4.6.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://chrony-project.org/releases/

--- a/net/chrony/files/chronyd.init
+++ b/net/chrony/files/chronyd.init
@@ -10,7 +10,7 @@ INCLUDEFILE=/var/etc/chrony.d/10-uci.conf
 RTCDEVICE=/dev/rtc0
 
 handle_source() {
-	local cfg=$1 sourcetype=$2 disabled hostname minpoll maxpoll iburst nts
+	local cfg=$1 sourcetype=$2 disabled hostname minpoll maxpoll iburst nts prefer maxsources
 
 	config_get_bool disabled "$cfg" disabled 0
 	[ "$disabled" = "1" ] && return
@@ -21,12 +21,16 @@ handle_source() {
 	config_get maxpoll "$cfg" maxpoll
 	config_get_bool iburst "$cfg" iburst 0
 	config_get_bool nts "$cfg" nts 0
+	config_get_bool prefer "$cfg" prefer 0
+    [ "$sourcetype" = "pool" ] && config_get maxsources "$cfg" maxsources
 	echo $(
 		echo $sourcetype $hostname
 		[ -n "$minpoll" ] && echo minpoll $minpoll
 		[ -n "$maxpoll" ] && echo maxpoll $maxpoll
 		[ "$iburst" = "1" ] && echo iburst
 		[ "$nts" = "1" ] && echo nts
+		[ "$prefer" = "1" ] && echo prefer
+		if [ "$sourcetype" = "pool" ] && [ -n "$maxsources" ]; then echo maxsources $maxsources; fi 
 	)
 }
 


### PR DESCRIPTION
Maintainer: Miroslav Lichvar <mlichvar0@gmail.com>
Compile tested: n/a
Run tested: (arch, model, OpenWrt version) Intel(R) Core(TM) i3-4150T CPU @ 3.00GHz, LENOVO INVALID, OpenWrt 23.05.2 r23630-842932a63d; I have implemented the changes on my machine and tested if chrony config file is generated correctly,


Description:

Added support for specifying two options in sources definitions - `prefer` (applicable for server, pool and peer) and `maxsources` (applicable only for pool).

Per chrony docs, `prefer` makes chrony prefer given source over other selectable sources without the prefer option.
I find it useful to not use pool.ntp.org if possible (as their website suggests) and to use servers with better stratum when possible.

Per chrony docs, `maxsources` sets the desired number of sources to be used from the pool. chronyd will repeatedly try to resolve the name until it gets this number of sources responding to requests. The default value is 4 and the maximum value is 16.
This can be specified to not overuse (or overuse) pools as needed