### PR TITLE
bind: bump to 9.20.5

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.20.4
+PKG_VERSION:=9.20.5
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=3a8e1a05e00e3e9bc02bdffded7862faf7726ba76ba997f42ab487777bd8210b
+PKG_HASH:=19274fd739c023772b4212a0b6c201cf4364855fa7e6a7d3db49693f55db1ab8
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: me
Compile tested: n/a
Run tested: n/a

Description:
Fixes CVEs:
- CVE-2024-12705: DNS-over-HTTPS flooding
- CVE-2024-11187: Limit additional section processing for large RDATA sets
