### PR TITLE
bind: bump to 9.18.33

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.18.32
+PKG_VERSION:=9.18.33
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=dc840cdf9d54578d98400f2edf7008b1b33a1721be6e490eb1e42d0d11d9cff4
+PKG_HASH:=fb373fac5ebbc41c645160afd5a9fb451918f6c0e69ab1d9474154e2b515de40
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: me
Compile tested: n/a
Run tested: n/a

Description:
Fixes CVEs:
- CVE-2024-12705: DNS-over-HTTPS flooding
- CVE-2024-11187: Limit additional section processing for large RDATA sets