### PR TITLE
cryptsetup: update to version 2.7.5

### DIFF
--- a/utils/cryptsetup/Makefile
+++ b/utils/cryptsetup/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cryptsetup
-PKG_VERSION:=2.7.4
+PKG_VERSION:=2.7.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/cryptsetup/v$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VERSION))))
-PKG_HASH:=dce29903a58f7b774fe61191e7e6de955de0f40d9e27b0028ffcf3438c0e9480
+PKG_HASH:=d2be4395b8f503b0ebf4b2d81db90c35a97050a358ee21fe62a0dfb66e5d5522
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.1-or-later
@@ -56,13 +56,36 @@ define Package/cryptsetup-ssh/description
   Experimental SSH token support for cryptsetup.
 endef
 
+define Package/integritysetup
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Encryption
+  TITLE:=integritysetup
+  DEPENDS:=+cryptsetup
+  URL:=https://gitlab.com/cryptsetup/cryptsetup/
+endef
+
+define Package/integritysetup/description
+  Manage dm-integrity (block level integrity) volumes
+endef
+
+define Package/veritysetup
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Encryption
+  TITLE:=veritysetup
+  DEPENDS:=+cryptsetup
+  URL:=https://gitlab.com/cryptsetup/cryptsetup/
+endef
+
+define Package/veritysetup/description
+  Manage dm-verity (block level verification) volumes
+endef
+
 CONFIGURE_ARGS += \
 	--disable-asciidoc \
-	--disable-cryptsetup-reencrypt \
-	--disable-integritysetup \
 	--disable-selinux \
 	--disable-rpath \
-	--disable-veritysetup \
 	--disable-udev \
 	--with-default-luks-format=LUKS2 \
 	--with-luks2-lock-path=/var/run/cryptsetup \
@@ -102,5 +125,17 @@ define Package/cryptsetup-ssh/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/cryptsetup-ssh $(1)/usr/sbin
 endef
 
+define Package/integritysetup/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/integritysetup $(1)/usr/sbin
+endef
+
+define Package/veritysetup/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/veritysetup $(1)/usr/sbin
+endef
+
 $(eval $(call BuildPackage,cryptsetup))
 $(eval $(call BuildPackage,cryptsetup-ssh))
+$(eval $(call BuildPackage,integritysetup))
+$(eval $(call BuildPackage,veritysetup))


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: -
Description:

Enable building cryptsetup-reencrypt, integritysetup and veritysetup, add new binary packages for integritysetup and veritysetup.

Changes since version 2.7.4
=================
* Fix possible online reencryption data corruption (only in 2.7.x).

  In some situations (initializing a suspended device-mapper device), cryptsetup disabled direct-io device access. This caused unsafe online reencryption operations that could lead to data corruption. The code now adds strict checks (and aborts the operation) and changes direct-io detection code to prevent data corruption.

* Fix a clang compilation error in SSH token plugin.

  As clang linker treats missing symbols as errors, the linker phase for the SSH token failed as the optional cryptsetup_token_buffer_free was not defined.

* Fix crypto backend initialization in crypt_format_luks2_opal API call.
