### PR TITLE
tailscale: update to 1.80.0

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.78.1
+PKG_VERSION:=1.80.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=dbc25cc241bb233f183475f003d5508af7b45add1ca548b35a6a6fea91fb91af
+PKG_HASH:=3dc0e5f903912ba5ada04c807501550b2d434111d1080b11099672d3dfd5c3f3
 
 PKG_MAINTAINER:=Zephyr Lykos <self@mochaa.ws>, \
 		Sandro Jäckel <sandro.jaeckel@gmail.com>


### PR DESCRIPTION
Maintainer: me / @mochaaP 
Compile tested: arm_cortex-a7_neon-vfpv4 OpenWrt 24.10.0
Run tested: arm_cortex-a7_neon-vfpv4 OpenWrt 23.05.5, connected to my tailscale net and things continued to work

Description:
