### PR TITLE
Compile dnsdist with liblua on aarch64 as luajit does not work

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -35,7 +35,7 @@ define Package/dnsdist/Default
 	  +libatomic \
 	  +libcap \
 	  +libstdcpp \
-	  @HAS_LUAJIT_ARCH +luajit
+	  $(if $(filter aarch64,$(ARCH)),+liblua,+luajit)
   URL:=https://dnsdist.org/
   VARIANT:=$(1)
   PROVIDES:=dnsdist
@@ -147,7 +147,7 @@ TARGET_CXXFLAGS+=-Os -fvisibility=hidden -flto -fno-ipa-cp -DNDEBUG \
 
 CONFIGURE_ARGS+= \
 	--with-pic \
-	--with-lua=luajit \
+	$(if $(filter aarch64,$(ARCH)),--with-lua,--with-lua=luajit) \
 	--with-libcap \
 	--without-xsk \
 	$(if $(call IsEnabled,DNSDIST_PIE),,--disable-hardening) \


### PR DESCRIPTION
Maintainer: @Habbie
Run tested: aarch64, NanoPi R5C, OpenWrt 24.10.0-rc6

Description:
The current version of dnsdist-full on OpenWrt 24.10.0-rc can't start and fails with a SIGILL in luajit. 
Switching to liblua fixes the issue.