### PR TITLE
Backport strongswan patch for wolfssl

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.14
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/patches/0905-wolfssl-parse_error.patch
+++ b/net/strongswan/patches/0905-wolfssl-parse_error.patch
@@ -1,0 +1,19 @@
+From 60336ceecbd1cda73aa26dd44cfdaf2e31a046e1 Mon Sep 17 00:00:00 2001
+From: Tobias Brunner <tobias@strongswan.org>
+Date: Fri, 4 Oct 2024 11:23:28 +0200
+Subject: [PATCH] wolfssl: Don't undef PARSE_ERROR as headers included later
+ might refer to it
+
+---
+ src/libstrongswan/plugins/wolfssl/wolfssl_common.h | 2 --
+ 1 file changed, 2 deletions(-)
+
+--- a/src/libstrongswan/plugins/wolfssl/wolfssl_common.h
++++ b/src/libstrongswan/plugins/wolfssl/wolfssl_common.h
+@@ -78,6 +78,4 @@ typedef union {
+ } wolfssl_ed_key;
+ #endif /* HAVE_ED25519 || HAVE_ED448 */
+ 
+-#undef PARSE_ERROR
+-
+ #endif /* WOLFSSL_PLUGIN_COMMON_H_ */


### PR DESCRIPTION
Maintainer: @pprindeville
Compile tested: aarch_64_generic rockchip_armv6_friendlyarm_nanopi-r4s 24.10.0-rc7
Run tested: None

Description: Backport https://github.com/strongswan/strongswan/commit/60336ceecbd1cda73aa26dd44cfdaf2e31a046e1 in order to address compile failure in 24.10.0-rc7 which was caused by wolfssl update. Closes #25877.

https://github.com/openwrt/openwrt/issues/17768


