### PR TITLE
keepalived: add support for directory sync

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.3.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software

--- a/net/keepalived/files/etc/hotplug.d/keepalived/810-files
+++ b/net/keepalived/files/etc/hotplug.d/keepalived/810-files
@@ -15,4 +15,7 @@ add_sync_file /etc/shinit
 add_sync_file /etc/sysctl.conf
 add_sync_file /tmp/dhcp.leases
 
+# uncomment the following line and add /etc/hotplug.d/keepalived to sysupgrade.conf or keepalived configuration in order to enable hotplug scripts sync
+# add_sync_file /etc/hotplug.d/keepalived
+
 keepalived_hotplug

--- a/net/keepalived/files/lib/functions/keepalived/hotplug.sh
+++ b/net/keepalived/files/lib/functions/keepalived/hotplug.sh
@@ -82,6 +82,17 @@ is_sync_file() {
 	list_contains SYNC_FILES_LIST "$1"
 }
 
+is_sync_file_in_folder() {
+ 	local f="$1"
+	while [ "$f" != "" ]; do
+		f="${f%/*}"
+		if list_contains SYNC_FILES_LIST "$f"; then
+			return 0
+		fi
+	done
+	return 1
+}
+
 _set_update_target() {
 	set_var UPDATE_TARGET "${1:-1}"
 }
@@ -227,7 +238,7 @@ _notify_sync() {
 		return
 	fi
 
-	is_sync_file "$RSYNC_TARGET" || return
+	is_sync_file "$RSYNC_TARGET" || is_sync_file_in_folder "$RSYNC_TARGET" || return
 
 	if ! cp -a "$RSYNC_SOURCE" "$RSYNC_TARGET"; then
 		log_err "can not copy $RSYNC_SOURCE => $RSYNC_TARGET"

--- a/net/keepalived/files/usr/share/keepalived/scripts/rsync.sh
+++ b/net/keepalived/files/usr/share/keepalived/scripts/rsync.sh
@@ -44,11 +44,10 @@ ha_sync_send() {
 	config_get sync_list "$cfg" sync_list
 
 	for sync_file in $sync_list $(sysupgrade -l); do
-		[ -f "$sync_file" ] && {
-			dir="${sync_file%/*}"
-			list_contains files_list "${sync_file}" || append files_list "${sync_file}"
-		}
+		[ -f "$sync_file" ] && dir="${sync_file%/*}"
 		[ -d "$sync_file" ] && dir="${sync_file}"
+
+		list_contains files_list "${sync_file}" || append files_list "${sync_file}"
 		list_contains dirs_list "${sync_dir}${dir}" || append dirs_list "${sync_dir}${dir}"
 	done
 


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: not yet compiled
Run tested: only tested on v23.05.5 with manually modified files

Description:
This pull request adds support for folder synchronization
An example is in the 810-files file where it is explained how to synchronize all hotplug files of keepalived. Personally, I am currently using the scirpt for this exact purpose