### PR TITLE
igmpproxy: add support for ACL (whitelist/blacklist) in UCI

### DIFF
--- a/net/igmpproxy/Makefile
+++ b/net/igmpproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=igmpproxy
 PKG_VERSION:=0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/pali/igmpproxy/releases/download/${PKG_VERSION}/

--- a/net/igmpproxy/files/igmpproxy.config
+++ b/net/igmpproxy/files/igmpproxy.config
@@ -7,6 +7,8 @@ config phyint
 	option zone wan
 	option direction upstream
 	list altnet 192.168.1.0/24
+#	list acl 233.252.0.0/24
+#	list acl !233.252.0.1/32
 
 config phyint
 	option network lan

--- a/net/igmpproxy/files/igmpproxy.init
+++ b/net/igmpproxy/files/igmpproxy.init
@@ -23,11 +23,12 @@ igmp_header() {
 }
 
 igmp_add_phyint() {
-	local network direction altnets device up
+	local network direction altnets acl_items device up
 
 	config_get network $1 network
 	config_get direction $1 direction
 	config_get altnets $1 altnet
+	config_get acl_items $1 acl
 
 	local status="$(ubus -S call "network.interface.$network" status)"
 	[ -n "$status" ] || return
@@ -51,6 +52,20 @@ igmp_add_phyint() {
 		local altnet
 		for altnet in $altnets; do
 			echo -e "\taltnet $altnet" >> /var/etc/igmpproxy.conf
+		done
+	fi
+
+	if [ -n "$acl_items" ]; then
+		local acl_item
+		for acl_item in $acl_items; do
+			case "$acl_item" in
+				!*)
+					echo -e "\tblacklist ${acl_item#!}" >> /var/etc/igmpproxy.conf
+					;;
+				*)
+					echo -e "\twhitelist ${acl_item}" >> /var/etc/igmpproxy.conf
+					;;
+			esac
 		done
 	fi
 }


### PR DESCRIPTION
This permits allowing/denying specific multicast networks to be proxied.

* "whitelist" was added in 0.2 (pali/igmpproxy@65f777e7f66b55239d935c1cf81bb5abc0f6c89f)
* "blacklist" was added in 0.4 (pali/igmpproxy@cfad33001fc5031399bdd073048ca86889378678)

Maintainer: @nbd168
Compile tested: mediatek/filogic / Banana Pi R4 / openwrt/openwrt@69890e16b37d59b55ba64633522c727f957cb2fd
Run tested:
* mediatek/filogic / Banana Pi R4 / openwrt/openwrt@d1e9c50d06a8cb618cb85ab489cbcccaec220636
* armsr/armv8 / Docker / openwrt/openwrt@6cbfbb18531e9e283ee4e50b14d53a27625fe518 (v24.10.0-rc7)

Supersedes #20497.