### PR TITLE
prometheus-node-exporter-ucode: fix missing .so mounts in jail

### DIFF
--- a/utils/prometheus-node-exporter-ucode/Makefile
+++ b/utils/prometheus-node-exporter-ucode/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-ucode
 PKG_VERSION:=2024.02.07
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Andre Heider <a.heider@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-ucode/files/init
+++ b/utils/prometheus-node-exporter-ucode/files/init
@@ -42,7 +42,7 @@ start_service() {
 	procd_add_jail prometheus-node-exporter-ucode log procfs sysfs ubus
 	procd_add_jail_mount "/usr/lib/uhttpd_ucode.so"
 	procd_add_jail_mount "/lib/libubus.so*"
-	procd_add_jail_mount "/lib/libuci.so"
+	procd_add_jail_mount "/lib/libuci.so*"
 	procd_add_jail_mount "/usr/lib/ucode"
 	procd_add_jail_mount "/usr/lib/libnl*.so*"
 	procd_add_jail_mount "/usr/share/ucode/node-exporter"


### PR DESCRIPTION
Maintainer: @dhewg
Compile tested: N/A
Run tested: OpenWrt 24.10.0-rc7, aarch64, mediatek/filogic, BPI-R4

Description:
There is a bug with this package currently where it fails to launch with this error
```
Sun Feb  2 23:35:49 2025 daemon.info uhttpd[4199]: jail: exec-ing /usr/sbin/uhttpd
Sun Feb  2 23:35:49 2025 daemon.err uhttpd[4199]: Runtime error: Unable to dlopen file '/usr/lib/ucode/uci.so': Error loading shared library libuci.so.20250120: No such file or directory (needed by /usr/lib/ucode/uci.so)
Sun Feb  2 23:35:49 2025 daemon.err uhttpd[4199]: In /usr/share/ucode/node-exporter/metrics.uc, line 2, byte 1:
Sun Feb  2 23:35:49 2025 daemon.err uhttpd[4199]:
Sun Feb  2 23:35:49 2025 daemon.err uhttpd[4199]:  `{%`
Sun Feb  2 23:35:49 2025 daemon.err uhttpd[4199]:     ^-- Near here
Sun Feb  2 23:35:49 2025 daemon.err uhttpd[4199]:
Sun Feb  2 23:35:49 2025 daemon.err uhttpd[4199]:
Sun Feb  2 23:35:49 2025 daemon.err uhttpd[4199]: Error: Runtime error while executing ucode handler
Sun Feb  2 23:35:49 2025 daemon.info uhttpd[4199]: jail: jail (4224) exited with exit: 2
```

I was able to fix this with this small change, adding a wildcard to the libuci.so files mounted into the jail. I did not try recompiling, just edited this file on my device, and reloaded/restarted the service. It works fine with this change
