### PR TITLE
ddns-scripts: add type field for digitalocean API

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=59
+PKG_RELEASE:=60
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_digitalocean_com_v2.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_digitalocean_com_v2.sh
@@ -24,6 +24,7 @@
 json_init
 json_add_string name "$username"
 json_add_string data "$__IP"
+[ $use_ipv6 -ne 0 ] && json_add_string type "AAAA" || json_add_string type "A"
 
 __STATUS=$(curl -Ss -X PUT "https://api.digitalocean.com/v2/domains/${domain}/records/${param_opt}" \
 	-H "Authorization: Bearer ${password}" \


### PR DESCRIPTION
Maintainer: me
Compile tested: Compile not tested
Run tested: Architecture: ARMv7 Processor rev 0 (v7l), Platform: ipq806x/generic, Model: Netgear Nighthawk XR500

Description:
DigitalOcean API requires a "type" JSON field to update a DNS record. This adds that while checking for IPv6 to change which record type to use. Without it, the API call fails, making the script unable to update the DNS records for DigitalOcean.

Fixes #25061 