### PR TITLE
[23.05]sing-box: Update to 1.11.0

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.10.7
+PKG_VERSION:=1.11.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=402b618148b58f5ff6c1bee4f4fdcf7cdcb88a2df6a8bd682ea742a89b5be9ec
+PKG_HASH:=d4a48b2fe450041fea2d25955ddc092a62afc8da7bb442b49cb12575123b2edb
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @brvphoenix
Compile tested: all supported targets
Run tested: N/A

Description:
sing-box: update to 1.11.0(cherry picked from commit https://github.com/openwrt/packages/commit/2c7b8ef5a2deb42089674dba2177e4bc8ccb88d6)

For more information, visit https://github.com/SagerNet/sing-box/compare/v1.10.7...v1.11.0