### PR TITLE
keepalived: add new uci section config interface_up_down_delays

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.3.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software

--- a/net/keepalived/files/keepalived.init
+++ b/net/keepalived/files/keepalived.init
@@ -287,6 +287,25 @@ static_routes() {
 	done
 }
 
+interface_up_down_delays() {
+	local device
+	local down_delay
+	local up_delay
+	local line
+
+	config_get device "$1" device
+	config_get down_delay "$1" down_delay
+	config_get up_delay "$1" up_delay
+
+	[ -z "$device" ] && return
+	[ -z "$down_delay" ] && return
+
+	line="${device} ${down_delay}"
+	[ -z "$up_delay" ] || line="${line} ${up_delay}"
+
+	printf '%b%s\n' "$INDENT_1" "$line" >> "$KEEPALIVED_CONF"
+}
+
 # Count 'vrrp_instance' with the given name ; called by vrrp_instance_check()
 vrrp_instance_name_count() {
 	local name
@@ -611,6 +630,10 @@ process_config() {
 
 	config_section_open "static_routes"
 	config_foreach_wrapper static_routes
+	config_section_close
+
+	config_section_open "interface_up_down_delays"
+	config_foreach_wrapper interface_up_down_delays
 	config_section_close
 
 	config_foreach_wrapper vrrp_script


### PR DESCRIPTION
Maintainer: me 
Compile tested: only script changes
Run tested: only generation of new section

refs https://github.com/openwrt/luci/issues/7475

Description:
If an interface that is being used (or tracked) by a VRRP instance goes to down state, the VRRP instance(s) will, by default, immediately transition to FAULT state, and when all relevant interfaces are back up again the VRRP instance(s) will immediately transition to BACKUP state.

This can cause problems if interfaces are bouncing, and so delays can be specified between the interface state change and the transition to FAULT/BACKUP state. If the interface returns to its original state before the delay expires, no associated VRRP instance state transition will occur.

New uci section 'interface_up_down_delay':
```

config interface_up_down_delays
	option device <device>
	option down_delay <number in seconds>
	option up_delay <number in seconds>
```