### PR TITLE
strongswan: backport the latest changes from master to openwrt-24.10 to fix compilation issue with wolfssl

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.14
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.14
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -610,10 +610,6 @@ config_remote() {
 		fatal "AuthenticationMode $auth_mode not supported"
 	fi
 
-	swanctl_xappend0 "pools {"
-	config_list_foreach "$conf" pools config_pool
-	swanctl_xappend0 "}"
-
 	swanctl_xappend0 ""
 }
 
@@ -689,6 +685,10 @@ prepare_env() {
 	config_load ipsec
 	config_foreach config_ipsec ipsec
 	config_foreach config_remote remote
+	
+	swanctl_xappend0 "pools {"
+	config_foreach config_pool pools
+	swanctl_xappend0 "}"
 
 	do_postamble
 }

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -466,6 +466,7 @@ config_remote() {
 	config_get ca_cert "$conf" ca_cert ""
 	config_get rekeytime "$conf" rekeytime
 	config_get overtime "$conf" overtime
+	config_get send_cert "$conf" send_cert
 
 	config_list_foreach "$conf" local_sourceip append_var local_sourceip ","
 	config_list_foreach "$conf" remote_ca_certs append_var remote_ca_certs ","
@@ -559,6 +560,8 @@ config_remote() {
 		keyexchange=
 		;;
 	esac
+
+	[ -n "$send_cert" ] && swanctl_xappend2 "send_cert = $send_cert"
 
 	[ $mobike -eq 1 ] && swanctl_xappend2 "mobike = yes" || swanctl_xappend2 "mobike = no"
 

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -421,6 +421,21 @@ config_pool() {
 	swanctl_xappend1 "}"
 }
 
+config_mschapv2_secret() {
+	local conf="$1"
+
+	local id
+	local secret
+
+	config_get id "$conf" id
+	config_get secret "$conf" secret
+
+	swanctl_xappend1 "eap-${conf} {"
+	swanctl_xappend2 "id = $id"
+	swanctl_xappend2 "secret = $secret"
+	swanctl_xappend1 "}"
+}
+
 config_remote() {
 	local conf="$1"
 
@@ -445,6 +460,7 @@ config_remote() {
 	local rekeytime
 	local remote_ca_certs
 	local pools
+	local eap_id
 
 	config_get_bool enabled "$conf" enabled 0
 	[ $enabled -eq 0 ] && return
@@ -467,6 +483,7 @@ config_remote() {
 	config_get rekeytime "$conf" rekeytime
 	config_get overtime "$conf" overtime
 	config_get send_cert "$conf" send_cert
+	config_get eap_id "$conf" eap_id "%any"
 
 	config_list_foreach "$conf" local_sourceip append_var local_sourceip ","
 	config_list_foreach "$conf" remote_ca_certs append_var remote_ca_certs ","
@@ -526,11 +543,14 @@ config_remote() {
 	[ -n "$fragmentation" ] && swanctl_xappend2 "fragmentation = $fragmentation"
 	[ -n "$pools" ] && swanctl_xappend2 "pools = $pools"
 
+	local local_auth_method="$auth_method"
+	[ "$auth_method" = "eap-mschapv2" ] && local_auth_method="pubkey"
+
 	swanctl_xappend2 "local {"
-	swanctl_xappend3 "auth = $auth_method"
+	swanctl_xappend3 "auth = $local_auth_method"
 
 	[ -n "$local_identifier" ] && swanctl_xappend3 "id = \"$local_identifier\""
-	[ "$auth_method" = pubkey ] && [ -n "$local_cert" ] && \
+	[ "$local_auth_method" = pubkey ] && [ -n "$local_cert" ] && \
 	    swanctl_xappend3 "certs = $local_cert"
 	swanctl_xappend2 "}"
 
@@ -538,6 +558,7 @@ config_remote() {
 	swanctl_xappend3 "auth = $auth_method"
 	[ -n "$remote_identifier" ] && swanctl_xappend3 "id = \"$remote_identifier\""
 	[ -n "$remote_ca_certs" ] && swanctl_xappend3 "cacerts = \"$remote_ca_certs\""
+	[ "$auth_method" = eap-mschapv2 ] && swanctl_xappend3 "eap_id = $eap_id"
 	swanctl_xappend2 "}"
 
 	swanctl_xappend2 "children {"
@@ -606,6 +627,9 @@ config_remote() {
 		fi
 		swanctl_xappend1 "}"
 		swanctl_xappend0 "}"
+	elif [ "$auth_method" = eap-mschapv2 ]; then
+		# EAP-MSCHAPv2 secrets are handled in config_mschapv2_secrets globally
+		:  # empty command
 	else
 		fatal "AuthenticationMode $auth_mode not supported"
 	fi
@@ -686,8 +710,15 @@ prepare_env() {
 	config_foreach config_ipsec ipsec
 	config_foreach config_remote remote
 	
+	swanctl_xappend0 "# Global config"
+	swanctl_xappend0 ""
+	
 	swanctl_xappend0 "pools {"
 	config_foreach config_pool pools
+	swanctl_xappend0 "}"
+
+	swanctl_xappend0 "secrets {"
+	config_foreach config_mschapv2_secret mschapv2_secrets
 	swanctl_xappend0 "}"
 
 	do_postamble

--- a/net/strongswan/patches/0905-wolfssl-parse_error.patch
+++ b/net/strongswan/patches/0905-wolfssl-parse_error.patch
@@ -1,0 +1,19 @@
+From 60336ceecbd1cda73aa26dd44cfdaf2e31a046e1 Mon Sep 17 00:00:00 2001
+From: Tobias Brunner <tobias@strongswan.org>
+Date: Fri, 4 Oct 2024 11:23:28 +0200
+Subject: [PATCH] wolfssl: Don't undef PARSE_ERROR as headers included later
+ might refer to it
+
+---
+ src/libstrongswan/plugins/wolfssl/wolfssl_common.h | 2 --
+ 1 file changed, 2 deletions(-)
+
+--- a/src/libstrongswan/plugins/wolfssl/wolfssl_common.h
++++ b/src/libstrongswan/plugins/wolfssl/wolfssl_common.h
+@@ -78,6 +78,4 @@ typedef union {
+ } wolfssl_ed_key;
+ #endif /* HAVE_ED25519 || HAVE_ED448 */
+ 
+-#undef PARSE_ERROR
+-
+ #endif /* WOLFSSL_PLUGIN_COMMON_H_ */


### PR DESCRIPTION
Maintainer: @pprindeville 
Compile tested: x86_64m APU3, openwrt-24.10
Run tested: no

Description:
This PR backports the latest changes for strongswan from the main branch.
https://github.com/openwrt/packages/commit/4b9453b9a4c865f5eb722761a1f7120d954a1b57
https://github.com/openwrt/packages/commit/6b824ee7d71f6c4e001a8ec41aa47d97860c9fae
https://github.com/openwrt/packages/commit/88d1876f382f3fad99502679abb9914c429c7a7d
The following commit is related to #25877 
https://github.com/openwrt/packages/commit/1cc7069c6437fc92e394fa4b675c074f98f52ff0
