### PR TITLE
ddns-scripts: add ydns.io provider

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=60
+PKG_RELEASE:=61
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/ydns.io.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/ydns.io.json
@@ -1,0 +1,11 @@
+{
+	"name": "ydns.io",
+	"ipv4": {
+		"url": "https://[USERNAME]:[PASSWORD]@ydns.io/api/v1/update/?host=[DOMAIN]&ip=[IP]",
+		"answer": "good"
+	},
+	"ipv6": {
+		"url": "https://[USERNAME]:[PASSWORD]@ydns.io/api/v1/update/?host=[DOMAIN]&ip=[IP]",
+		"answer": "good"
+	}
+}

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -67,4 +67,5 @@ twodns.de
 udmedia.de
 variomedia.de
 xlhost.de
+ydns.io
 zoneedit.com


### PR DESCRIPTION
Maintainer: @ACI0419

Description:
Add ydns.io provider.  
YDNS is a free and open-source DDNS service provider, with its project available on GitHub at https://github.com/ydns
