### PR TITLE
i2c-tools: remove PKG_INSTALL_DIR before installing content

### DIFF
--- a/utils/i2c-tools/Makefile
+++ b/utils/i2c-tools/Makefile
@@ -90,6 +90,7 @@ define Build/InstallDev
 endef
 
 define Build/Install
+	$(RM) -rf $(PKG_INSTALL_DIR)
 	$(call Py3Build/Install)
 endef
 


### PR DESCRIPTION
When building the i2c-tools package for a second time, the following issue is observed:

```
cd "/openwrt/build_dir/target-aarch64-unknown-linux-gnu_musl/i2c-tools-4.3" && CC="ccache aarch64-openwrt-linux-musl-gcc" CCSHARED="ccache aarch64-openwrt-linux-musl-gcc -DPIC -fPIC" CXX="ccache aarch64-openwrt-linux-musl-g++" LD="ccache aarch64-openwrt-linux-musl-gcc" LDSHARED="ccache aarch64-openwrt-linux-musl-gcc -shared" CFLAGS="-Os -pipe -fno-caller-saves -fno-plt -Wformat -Werror=format-security -DPIC -fPIC -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wl,-z,now -Wl,-z,relro" CPPFLAGS="-I/opt/softathome/toolchain/ipq95xx-aarch64-linux-6.1-gcc-12.3.0-musl-1.2.4/include/fortify -I/opt/softathome/toolchain/ipq95xx-aarch64-linux-6.1-gcc-12.3.0-musl-1.2.4/include -I/openwrt/staging_dir/target-aarch64-unknown-linux-gnu_musl/usr/include/python3.11" LDFLAGS="-L/opt/softathome/toolchain/ipq95xx-aarch64-linux-6.1-gcc-12.3.0-musl-1.2.4/lib -DPIC -fPIC -specs=/openwrt/include/hardened-ld-pie.specs -znow -zrelro -lpython3.11" _PYTHON_HOST_PLATFORM="linux-aarch64" _PYTHON_SYSCONFIGDATA_NAME="_sysconfigdata__linux_aarch64-linux-musl" PYTHONPATH="/openwrt/staging_dir/target-aarch64-unknown-linux-gnu_musl/usr/lib/python3.11:/openwrt/staging_dir/target-aarch64-unknown-linux-gnu_musl//usr/lib/python3.11/site-packages:/openwrt/build_dir/target-aarch64-unknown-linux-gnu_musl/i2c-tools-4.3/ipkg-install//usr/lib/python3.11/site-packages" PYTHONDONTWRITEBYTECODE=1 _python_sysroot="/openwrt/staging_dir/target-aarch64-unknown-linux-gnu_musl" _python_prefix="/usr" _python_exec_prefix="/usr"  CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu CARGO_HOME=/openwrt/dl/cargo CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 CARGO_PROFILE_RELEASE_DEBUG=false CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=false CARGO_PROFILE_RELEASE_LTO=true CARGO_PROFILE_RELEASE_OPT_LEVEL=z CARGO_PROFILE_RELEASE_OVERFLOW_CHECKS=true CARGO_PROFILE_RELEASE_PANIC=unwind CARGO_PROFILE_RELEASE_RPATH=false CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-openwrt-linux-musl-gcc RUSTFLAGS="-Ctarget-feature=-crt-static -lssp_nonshared" TARGET_CC=aarch64-openwrt-linux-musl-gcc TARGET_CFLAGS="-Os -pipe -fno-caller-saves -fno-plt -Wformat -Werror=format-security -DPIC -fPIC -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wl,-z,now -Wl,-z,relro -mno-outline-atomics" PYO3_CROSS_LIB_DIR="/openwrt/staging_dir/target-aarch64-unknown-linux-gnu_musl/usr/lib/python3.11" SETUPTOOLS_RUST_CARGO_PROFILE="release"    /openwrt/staging_dir/hostpkg/bin/python3.11  -m installer --destdir "/openwrt/build_dir/target-aarch64-unknown-linux-gnu_musl/i2c-tools-4.3/ipkg-install" --no-compile-bytecode --prefix /usr "/openwrt/build_dir/target-aarch64-unknown-linux-gnu_musl/i2c-tools-4.3/py-smbus"/openwrt-build/smbus-1.1-*.whl
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/openwrt/staging_dir/hostpkg/lib/python3.11/site-packages/installer/__main__.py", line 98, in <module>
    _main(sys.argv[1:], "python -m installer")
  File "/openwrt/staging_dir/hostpkg/lib/python3.11/site-packages/installer/__main__.py", line 94, in _main
    installer.install(source, destination, {})
  File "/openwrt/staging_dir/hostpkg/lib/python3.11/site-packages/installer/_core.py", line 109, in install
    record = destination.write_file(
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/openwrt/staging_dir/hostpkg/lib/python3.11/site-packages/installer/destinations.py", line 207, in write_file
    return self.write_to_fs(scheme, path_, stream, is_executable)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openwrt/staging_dir/hostpkg/lib/python3.11/site-packages/installer/destinations.py", line 167, in write_to_fs
    raise FileExistsError(message)
FileExistsError: File already exists: /openwrt/build_dir/target-aarch64-unknown-linux-gnu_musl/i2c-tools-4.3/ipkg-install/usr/lib/python3.11/site-packages/smbus.cpython-311-aarch64-linux-musl.so
```

By removing the content of PKG_INSTALL_DIR before installing again in this directory we can solve this problem.

Maintainer: me / @dangowrt @jefferyto 
Compile tested: openwrt master
Run tested: NA

Description:
