### PR TITLE
strongswan: preserve changed configuration files

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -462,6 +462,10 @@ define BuildPlugin
 	$(call Plugin/$(1)/install,$$(1))
   endef
 
+  define Package/strongswan-mod-$(1)/conffiles
+/etc/strongswan.d/charon/$(1).conf
+endef
+
   $$(eval $$(call BuildPackage,strongswan-mod-$(1)))
 endef
 
@@ -523,6 +527,11 @@ define Package/strongswan-charon/install
 	$(INSTALL_DIR) $(1)/usr/lib/ipsec
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/ipsec/charon $(1)/usr/lib/ipsec/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ipsec/libcharon.so.* $(1)/usr/lib/ipsec/
+endef
+
+define Package/strongswan-charon/conffiles
+/etc/strongswan.d/charon.conf
+/etc/strongswan.d/charon-logging.conf
 endef
 
 define Package/strongswan-charon-cmd/install


### PR DESCRIPTION
After reinstalling the packages with the preserved configuration files after a sysupgrade, the reinstalled package config files overwrite what is on disk rather than being placed as conf-opkg. Defining these config files will preserve them appropriately.

Maintainer: @pprindeville @Thermi 
Compile tested: aarch64, Linksys E8450, OpenWrt 24.10.0
Run tested: aarch64, Linksys E8450, OpenWrt 24.10.0

Description:
This adds the config files to the `conffiles` target which should signal to opkg (and apk in future) the config files to be left alone if they exist.

I have checked that the resulting opkg package's control.tar.gz has a new `conffiles` metadata file. Installing the package now shows this message:

```bash
# opkg install /tmp/strongswan-mod-dhcp_5.9.14-r7_aarch64_cortex-a53.ipk
Upgrading strongswan-mod-dhcp on root from 5.9.14-r6 to 5.9.14-r7...
Configuring strongswan-mod-dhcp.
Collected errors:
 * resolve_conffiles: Existing conffile /etc/strongswan.d/charon/dhcp.conf is different from the conffile in the new package. The new conffile will be placed at /etc/strongswan.d/charon/dhcp.conf-opkg.
```