### PR TITLE
eza: update to 0.20.20

### DIFF
--- a/utils/eza/Makefile
+++ b/utils/eza/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=eza
-PKG_VERSION:=0.20.15
+PKG_VERSION:=0.20.20
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eza-community/eza/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=cbb50e61b35b06ccf487ee6cc88d3b624931093546194dd5a2bbd509ed1786d6
+PKG_HASH:=8731184ff1b1d3dbd6bb8fda8f750780a58ccac682fd6344d92160dc518937de
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=EUPL-1.2


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt snapshot
Run tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt snapshot, simple base function test

changelogs:
0.20.16: https://github.com/eza-community/eza/releases/tag/v0.20.16
0.20.17: https://github.com/eza-community/eza/releases/tag/v0.20.17
0.20.18: https://github.com/eza-community/eza/releases/tag/v0.20.18
0.20.19: https://github.com/eza-community/eza/releases/tag/v0.20.19
0.20.20: https://github.com/eza-community/eza/releases/tag/v0.20.20
