### PR TITLE
nerdctl: update to 2.0.3

### DIFF
--- a/utils/nerdctl/Makefile
+++ b/utils/nerdctl/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nerdctl
-PKG_VERSION:=1.7.7
+PKG_VERSION:=2.0.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containerd/nerdctl/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=bcddf2ee3ad2bc84adc5e207f97157998fe973912c7d1dd9540bd4bb4a07698d
+PKG_HASH:=50118ed245f814ac39fe4598ba0cc5e401f820ba7260d706d544daea6d1c9d56
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @lu-zero
Compile tested: Ubuntu 23.04 x64 / OpenWrt SNAPSHOT @ https://github.com/openwrt/packages/commit/36b1dd75fd9da1ea13f1ce1ee679c6b3c9c402cc
Run tested: Linksys WRT32X / OpenWrt SNAPSHOT r24315-ae500e62e2

Description: nerdctl: Docker-compatible CLI for containerd

- Update to [2.0.3](https://github.com/containerd/nerdctl/compare/v1.7.7...v2.0.3)