### PR TITLE
Create Makefile Usteer-ng

### DIFF
--- a/net/usteer-ng/Makefile
+++ b/net/usteer-ng/Makefile
@@ -1,0 +1,46 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=usteer-ng
+PKG_VERSION:=1.0.0
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/NilsRo/usteer-ng/tar.gz/$(PKG_NAME)-$(PKG_VERSION)?
+PKG_HASH:=3d87ce13ba55de92dfbd51867021f5b690ddf1a6be9eff5b303286529d8be57c
+
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Nils Hendrik Rottgardt <n.rottgardt@gmail.com>
+PKG_LICENSE:=GPL-2.0-only
+
+PKG_BUILD_DEPENDS:=libpcap
+PKG_BUILD_PARALLEL:=1
+
+PKG_FILE_DEPENDS:=$(CURDIR)/../..
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+	ln -s $(CURDIR)/../../.git $(PKG_BUILD_DIR)/.git
+	cd $(PKG_BUILD_DIR) && git checkout .
+endef
+
+define Package/usteer-ng
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Wireless
+  DEPENDS:=+libubox +libubus +libblobmsg-json +libnl-tiny
+  TITLE:=Usteer - Next Generation OpenWrt AP roaming assist daemon
+  URL:=https://github.com/NilsRo/usteer-ng/
+endef
+
+define Package/usteer-ng/conffiles
+/etc/config/usteer
+endef
+
+define Package/usteer-ng/install
+	$(INSTALL_DIR) $(1)/sbin $(1)/etc/init.d $(1)/etc/config
+	$(CP) ./files/* $(1)/
+	$(CP) $(PKG_BUILD_DIR)/usteerd $(1)/sbin/
+endef
+
+$(eval $(call BuildPackage,usteer-ng))


### PR DESCRIPTION
New package Usteer-ng. Initial Makefile.

Maintainer: me / @Nilsro (find it by checking history of the package Makefile)
Compile tested: ARMv7, ZyXEL NBG6817, SNAPSHOT r28197-5695267847
Run tested: ARMv7, ZyXEL NBG6817, SNAPSHOT r28197-5695267847

Description: Providing the next generation version of Usteer with new and improved functionality
