### PR TITLE
lighttpd: patches for mbedtls,wolfssl curve config

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.77
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 # release candidate ~rcX testing; remove for release
 #PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 

--- a/net/lighttpd/patches/030-mod_mbedtls-crl.patch
+++ b/net/lighttpd/patches/030-mod_mbedtls-crl.patch
@@ -1,0 +1,20 @@
+From 639af8a3829045f54860fabe2c4268394b7f6b42 Mon Sep 17 00:00:00 2001
+From: Glenn Strauss <gstrauss@gluelogic.com>
+Date: Fri, 31 Jan 2025 01:40:03 -0500
+Subject: [PATCH] [mod_mbedtls] fix ssl.verifyclient.ca-crl-file
+
+---
+ src/mod_mbedtls.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/mod_mbedtls.c
++++ b/src/mod_mbedtls.c
+@@ -557,7 +557,7 @@ mod_mbedtls_merge_config_cpv (plugin_con
+         break;
+       case 4: /* ssl.ca-crl-file */
+         if (cpv->vtype == T_CONFIG_LOCAL)
+-            pconf->ssl_ca_dn_file = cpv->v.v;
++            pconf->ssl_ca_crl_file = cpv->v.v;
+         break;
+       case 5: /* ssl.read-ahead */
+         pconf->ssl_read_ahead = (0 != cpv->v.u);

--- a/net/lighttpd/patches/030-mod_mbedtls-curve.patch
+++ b/net/lighttpd/patches/030-mod_mbedtls-curve.patch
@@ -1,0 +1,79 @@
+From 9a57bd133c54a1c30724c7cadb2995c049a8775f Mon Sep 17 00:00:00 2001
+From: Glenn Strauss <gstrauss@gluelogic.com>
+Date: Wed, 12 Feb 2025 01:00:47 -0500
+Subject: [PATCH] [mod_mbedtls] limit default curves to avail curves
+
+---
+ src/mod_mbedtls.c | 54 +++++++++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 52 insertions(+), 2 deletions(-)
+
+--- a/src/mod_mbedtls.c
++++ b/src/mod_mbedtls.c
+@@ -4103,7 +4103,32 @@ mod_mbedtls_ssl_conf_curves(server *srv,
+ 
+     const char *groups = curvelist && !buffer_is_blank(curvelist)
+       ? curvelist->ptr
+-      : "x25519:secp256r1:secp384r1:x448";
++      :
++       #if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED)
++        "x25519"
++       #endif
++       #if defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED)
++        #if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED)
++        ":"
++        #endif
++        "secp256r1"
++       #endif
++       #if defined(MBEDTLS_ECP_DP_SECP384R1_ENABLED)
++        #if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED) \
++         || defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED)
++        ":"
++        #endif
++        "secp384r1"
++       #endif
++       #if defined(MBEDTLS_ECP_DP_CURVE448_ENABLED)
++        #if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED) \
++         || defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED)  \
++         || defined(MBEDTLS_ECP_DP_SECP384R1_ENABLED)
++        ":"
++        #endif
++        "x448"
++       #endif
++        ;
+     for (const char *e; groups; groups = e ? e+1 : NULL) {
+         const char * const n = groups;
+         e = strchr(n, ':');
+@@ -4163,7 +4188,32 @@ mod_mbedtls_ssl_conf_curves(server *srv,
+ 
+     const char *groups = curvelist && !buffer_is_blank(curvelist)
+       ? curvelist->ptr
+-      : "x25519:secp256r1:secp384r1:x448";
++      :
++       #if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED)
++        "x25519"
++       #endif
++       #if defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED)
++        #if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED)
++        ":"
++        #endif
++        "secp256r1"
++       #endif
++       #if defined(MBEDTLS_ECP_DP_SECP384R1_ENABLED)
++        #if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED) \
++         || defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED)
++        ":"
++        #endif
++        "secp384r1"
++       #endif
++       #if defined(MBEDTLS_ECP_DP_CURVE448_ENABLED)
++        #if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED) \
++         || defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED)  \
++         || defined(MBEDTLS_ECP_DP_SECP384R1_ENABLED)
++        ":"
++        #endif
++        "x448"
++       #endif
++        ;
+     for (const char *e; groups; groups = e ? e+1 : NULL) {
+         const char * const n = groups;
+         e = strchr(n, ':');

--- a/net/lighttpd/patches/030-mod_wolfssl-curve.patch
+++ b/net/lighttpd/patches/030-mod_wolfssl-curve.patch
@@ -1,0 +1,36 @@
+From fac530682b68bc8fbc44a5e5b106aa39abd2fe87 Mon Sep 17 00:00:00 2001
+From: Glenn Strauss <gstrauss@gluelogic.com>
+Date: Wed, 12 Feb 2025 00:44:42 -0500
+Subject: [PATCH] [mod_wolfssl] limit default curves to avail curves
+
+---
+ src/mod_wolfssl.c | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+--- a/src/mod_wolfssl.c
++++ b/src/mod_wolfssl.c
+@@ -2022,7 +2022,23 @@ mod_openssl_ssl_conf_curves(server *srv,
+      */
+     const char *groups = ssl_ec_curve && !buffer_is_blank(ssl_ec_curve)
+       ? ssl_ec_curve->ptr
+-      : "X25519:P-256:P-384:X448";
++      :
++       #ifdef HAVE_CURVE25519
++        "X25519"
++       #endif
++       #ifdef HAVE_ECC
++        #if defined(HAVE_CURVE25519)
++        ":"
++        #endif
++        "P-256:P-384"
++       #endif
++       #ifdef HAVE_CURVE448
++        #if defined(HAVE_CURVE25519) || defined(HAVE_ECC)
++        ":"
++        #endif
++        "X448"
++       #endif
++        ;
+     if (WOLFSSL_SUCCESS != wolfSSL_CTX_set1_curves_list(s->ssl_ctx, groups)) {
+         log_error(srv->errh, __FILE__, __LINE__,
+           "SSL: Unknown to set groups %s", groups);


### PR DESCRIPTION
Maintainer: @gstrauss
Compile tested: arm_cortex-a9 OpenWrt master

Description:

lighttpd: patches for mbedtls,wolfssl curve config

openwrt by default does not compile mbedtls or wolfssl with X448 curve

lighttpd mod_mbedtls issues a warning about missing x448.  lighttpd mod_wolfssl exits with an error for missing X448.  Patches included adjust lighttpd curve defaults to available curves in mbedtls and wolfssl, respectively.

Note: I will be requesting backport of this to 24.10 after this PR is accepted to master branch.