### PR TITLE
ffmpeg: restore and rebase 030-h264-mips patch

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=6.1.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/

--- a/multimedia/ffmpeg/patches/030-h264-mips.patch
+++ b/multimedia/ffmpeg/patches/030-h264-mips.patch
@@ -1,0 +1,18 @@
+--- a/libavcodec/mips/cabac.h
++++ b/libavcodec/mips/cabac.h
+@@ -30,7 +30,7 @@
+ #include "libavutil/mips/mmiutils.h"
+ #include "config.h"
+ 
+-#if !HAVE_MIPS32R6 && !HAVE_MIPS64R6
++#if !defined(__mips16) && !HAVE_MIPS32R6 && !HAVE_MIPS64R6
+ #define get_cabac_inline get_cabac_inline_mips
+ static av_always_inline int get_cabac_inline_mips(CABACContext *c,
+                                                   uint8_t * const state){
+@@ -226,5 +226,5 @@ static av_always_inline int get_cabac_by
+ 
+     return res;
+ }
+-#endif /* !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
++#endif /* !defined(__mips16) && !HAVE_MIPS32R6 && !HAVE_MIPS64R6 */
+ #endif /* AVCODEC_MIPS_CABAC_H */


### PR DESCRIPTION
Maintainer: @thess @antonlacon
CC: @krant @neheb 
Compile tested: ramips/mt7621
Run tested: Beeline SmartBox PRO

Description: Follow-up of #24746, after that build fails on some MIPS targets with `CONFIG_BUILD_PATENTED=y`:

```
mipsel-openwrt-linux-musl-gcc -I. -I./ -EL -D_ISOC99_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -DPIC -DZLIB_CONST -DHAVE_AV_CONFIG_H -DBUILDING_avcodec -Os -pipe -mno-branch-likely -mips32r2 -mtune=24kc -fno-caller-saves -fno-plt -fhonour-copts -msoft-float -ffile-prefix-map=/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/build_dir/target-mipsel_24kc_musl/ffmpeg-full/ffmpeg-6.1.2=ffmpeg-6.1.2 -mips16 -minterlink-mips16 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -I/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/usr/include -I/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/include -I/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/include/fortify -DPIC -fpic -Wno-error=incompatible-pointer-types   -march=24kc -std=c11 -fomit-frame-pointer -fPIC -pthread -I/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/staging_dir/target-mipsel_24kc_musl/usr/include -I/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/staging_dir/target-mipsel_24kc_musl/usr/include -I/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/staging_dir/target-mipsel_24kc_musl/usr/include/opus -I/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/staging_dir/target-mipsel_24kc_musl/usr/include/opus -I/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/staging_dir/target-mipsel_24kc_musl/usr/include -I/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/staging_dir/target-mipsel_24kc_musl/usr/include -I/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/staging_dir/target-mipsel_24kc_musl/usr/include -DX264_API_IMPORTS -I/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/staging_dir/target-mipsel_24kc_musl/usr/include -Wdeclaration-after-statement -Wall -Wdisabled-optimization -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wtype-limits -Wundef -Wmissing-prototypes -Wstrict-prototypes -Wempty-body -Wno-parentheses -Wno-switch -Wno-format-zero-length -Wno-pointer-sign -Wno-unused-const-variable -Wno-bool-operation -Wno-char-subscripts -Os -fno-math-errno -fno-signed-zeros -fno-tree-vectorize -Werror=format-security -Werror=implicit-function-declaration -Werror=missing-prototypes -Werror=return-type -Werror=vla -Wformat -fdiagnostics-color=auto -Wno-maybe-uninitialized   -MMD -MF libavcodec/h264_cabac.d -MT libavcodec/h264_cabac.o -c -o libavcodec/h264_cabac.o libavcodec/h264_cabac.c
{standard input}: Assembler messages:
{standard input}:138: Error: invalid operands `and $24,$7,0xC0'
{standard input}:139: Error: invalid operands `sll $24,$24,0x01'
{standard input}:140: Error: invalid operands `addu $24,$24,$17'
{standard input}:141: Error: invalid operands `addu $24,$24,$2'
{standard input}:142: Error: invalid operands `lbu $25,512($24)'
{standard input}:143: Error: operand 3 must be an immediate expression `subu $7,$7,$25'
...
about 500 similar lines skipped
...
{standard input}:4885: Error: opcode not supported on this processor: mips32r2 (mips32r2) `movz $7,$16,$6'
{standard input}:4886: Error: opcode not supported on this processor: mips32r2 (mips32r2) `movz $4,$25,$6'
make[3]: *** [ffbuild/common.mak:81: libavcodec/h264_cabac.o] Error 1
make[3]: Leaving directory '/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/build_dir/target-mipsel_24kc_musl/ffmpeg-full/ffmpeg-6.1.2'
make[2]: *** [Makefile:773: /home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/build_dir/target-mipsel_24kc_musl/ffmpeg-full/ffmpeg-6.1.2/.built] Error 2
make[2]: Leaving directory '/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/feeds/packages/multimedia/ffmpeg'
time: package/feeds/packages/ffmpeg/full/compile#6.43#0.93#7.30
    ERROR: package/feeds/packages/ffmpeg failed to build (build variant: full).
make[1]: *** [package/Makefile:179: package/feeds/packages/ffmpeg/compile] Error 1
make[1]: Leaving directory '/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64'
make: *** [/home/openwrt/openwrt-sdk-24.10.0-ramips-mt7621_gcc-13.3.0_musl.Linux-x86_64/include/toplevel.mk:226: package/ffmpeg/compile] Error 2
```