### PR TITLE
[24.10] adguardhome: Update to 0.107.56 (backport)

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
-PKG_VERSION:=0.107.53
+PKG_VERSION:=0.107.56
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=v$(PKG_VERSION)
-PKG_SOURCE_URL:=https://github.com/AdguardTeam/AdGuardHome
-PKG_MIRROR_HASH:=d74702bc4f8b82bda64a0a937a98e73ee602c21b9361c0c683671212e03e9316
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/AdGuardHome/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=e4285c8d7611fe677e45dad469fbc0237ebeea57094148a059edd5aa32ab8fce
+PKG_BUILD_DIR:=$(BUILD_DIR)/AdGuardHome-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILES:=LICENSE.txt
@@ -28,7 +28,7 @@ GO_PKG_BUILD_PKG:=github.com/AdguardTeam/AdGuardHome
 AGH_BUILD_TIME:=$(shell date -d @$(SOURCE_DATE_EPOCH) +%FT%TZ%z)
 AGH_VERSION_PKG:=github.com/AdguardTeam/AdGuardHome/internal/version
 GO_PKG_LDFLAGS_X:=$(AGH_VERSION_PKG).channel=release \
-	$(AGH_VERSION_PKG).version=$(PKG_SOURCE_VERSION) \
+	$(AGH_VERSION_PKG).version=$(PKG_VERSION) \
 	$(AGH_VERSION_PKG).buildtime=$(AGH_BUILD_TIME) \
 	$(AGH_VERSION_PKG).goarm=$(GO_ARM) \
 	$(AGH_VERSION_PKG).gomips=$(GO_MIPS)

--- a/net/adguardhome/files/adguardhome.config
+++ b/net/adguardhome/files/adguardhome.config
@@ -1,4 +1,5 @@
 config adguardhome config
-	# Where to store persistent data by AdGuard Home
-	option workdir /var/adguardhome
 	option config /etc/adguardhome.yaml
+	# Where to store persistent data by AdGuard Home
+	option workdir /var/lib/adguardhome
+	option pidfile /run/adguardhome.pid

--- a/net/adguardhome/files/adguardhome.init
+++ b/net/adguardhome/files/adguardhome.init
@@ -21,13 +21,14 @@ start_service() {
   fi
 
   config_load adguardhome
-  config_get WORK_DIR config workdir
   config_get CONFIG_FILE config config "/etc/adguardhome.yaml"
+  config_get PID_FILE config pidfile "/run/adguardhome.pid"
+  config_get WORK_DIR config workdir "/var/lib/adguardhome"
 
   [ -d "$WORK_DIR" ] || mkdir -m 0755 -p "$WORK_DIR"
 
   procd_open_instance
-  procd_set_param command "$PROG" -c "$CONFIG_FILE" -w "$WORK_DIR" --no-check-update
+  procd_set_param command "$PROG" -c "$CONFIG_FILE" -w "$WORK_DIR" --pidfile "$PID_FILE" --no-check-update
   procd_set_param stdout 1
   procd_set_param stderr 1
   procd_close_instance


### PR DESCRIPTION
Maintainer: @dobo90 @1715173329
Compile tested: NanoPi R6S 24.10.0
Run tested: NanoPi R6S 24.10.0
Description: Backport/cherry-pick of PR#25521 authored by @Ra2-IFV (Bump last AdGuard Home and go-lang) (resubmitting using "-x" in the cherry-pick).