### PR TITLE
mwan3: propagate mwan3 use command exit code

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.11.17
+PKG_VERSION:=2.11.18
 PKG_RELEASE:=5
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -241,9 +241,15 @@ use() {
 }
 
 case "$1" in
-	ifup|ifdown|interfaces|policies|connected|rules|status|start|stop|restart|use|internal)
+	ifup|ifdown|interfaces|policies|connected|rules|status|start|stop|restart|internal)
 		mwan3_init
 		"$@"
+	;;
+	use)
+		mwan3_init
+		"$@"
+		# Propagate mwan3 use command exit code
+		exit "$?"
 	;;
 	*)
 		help


### PR DESCRIPTION
Maintainer: @feckert @aaronjg

Compile tested: OpenWrt 24.10.0, r28427-6df0e3d02a - turris
Run tested: OpenWrt 24.10.0, r28427-6df0e3d02a - turris

Description:

This simply propagates the exit code of the command wrapped by `mwan3 use`.

Before:

```shell
mwan3 use wan false >/dev/null && echo ok || echo fail
# ok
```

After:

```shell
mwan3 use wan false >/dev/null && echo ok || echo fail
# fail
```

This allows for example to use `mwan3 use` for monitoring purposes.
