### PR TITLE
mwan3: write `mwan3 use` error/debug messages to stderr instead of stdout

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.11.18
+PKG_VERSION:=2.11.19
 PKG_RELEASE:=5
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -222,17 +222,17 @@ use() {
 	local interface device src_ip family
 
 	interface=$1 ; shift
-	[ -z "$*" ] && echo "no command specified for mwan3 use" && return
+	[ -z "$*" ] && echo "no command specified for mwan3 use" >&2 && return
 	network_get_device device $interface
-	[ -z "$device" ] && echo "could not find device for $interface" && return
+	[ -z "$device" ] && echo "could not find device for $interface" >&2 && return
 
 	mwan3_get_src_ip src_ip $interface
-	[ -z "$src_ip" ] && echo "could not find src_ip for $interface" && return
+	[ -z "$src_ip" ] && echo "could not find src_ip for $interface" >&2 && return
 
 	config_get family $interface family
-	[ -z "$family" ] && echo "could not find family for $interface. Using ipv4." && family='ipv4'
+	[ -z "$family" ] && echo "could not find family for $interface. Using ipv4." >&2 && family='ipv4'
 
-	echo "Running '$*' with DEVICE=$device SRCIP=$src_ip FWMARK=$MMX_DEFAULT FAMILY=$family"
+	echo "Running '$*' with DEVICE=$device SRCIP=$src_ip FWMARK=$MMX_DEFAULT FAMILY=$family" >&2
 	# if a program (not a shell builtin) is run: use "exec" for allowing direct process control
 	if [ -x "$(command -v "$1")" ]; then
 		set -- exec "$@"


### PR DESCRIPTION
Maintainer: @feckert @aaronjg

Compile tested: OpenWrt 24.10.0, r28427-6df0e3d02a - turris
Run tested: OpenWrt 24.10.0, r28427-6df0e3d02a - turris

Description:

This redirects the debug output to stderr, allowing `mwan3 use` to be used in
scripts without polluting stdout.

Before:

```shell
mwan3 use wan6 curl -fsSL myip.wtf/json | jq -er '.YourFuckingCountryCode'
jq: parse error: Invalid numeric literal at line 1, column 8
curl: (23) Failure writing output to destination, passed 389 returned 0
```

After:

```shell
mwan3 use wan6 curl -fsSL myip.wtf/json | jq -er '.YourFuckingCountryCode'
Running 'curl -fsSL myip.wtf/json' with DEVICE=eth2 SRCIP=2a02:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx FWMARK=0x3f00 FAMILY=ipv6
DE
```
