### PR TITLE
arp-scan-database: Relocate mac-vendor.txt to /etc/arp-scan

### DIFF
--- a/net/arp-scan/Makefile
+++ b/net/arp-scan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=arp-scan
 PKG_VERSION:=1.10.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/royhills/arp-scan/tar.gz/$(PKG_VERSION)?
@@ -74,11 +74,13 @@ endef
 define Package/arp-scan-database/install
 	$(INSTALL_DIR) $(1)/usr/share/arp-scan
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/ieee-oui.txt $(1)/usr/share/arp-scan/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/mac-vendor.txt $(1)/usr/share/arp-scan/
+	$(INSTALL_DIR) $(1)/etc/arp-scan
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/mac-vendor.txt $(1)/etc/arp-scan/
 endef
 
 define Package/arp-scan-database/postrm
 	$(RM) -rf $(1)/usr/share/arp-scan
+	$(RM) -rf $(1)/etc/arp-scan
 endef
 
 $(eval $(call BuildPackage,arp-scan-database))


### PR DESCRIPTION
Maintainer: @urusha (recent changes have been made by @PolynomialDivision)
Compile tested: arch: x86, model: 64, OpenWrt version: 24.10.0
```sh
wget https://downloads.openwrt.org/releases/24.10.0/targets/x86/64/openwrt-sdk-24.10.0-x86-64_gcc-13.3.0_musl.Linux-x86_64.tar.zst
tar -xvf openwrt-sdk-24.10.0-x86-64_gcc-13.3.0_musl.Linux-x86_64.tar.zst
cd openwrt-sdk-24.10.0-x86-64_gcc-13.3.0_musl.Linux-x86_64/
cp feeds.conf.default feeds.conf
sed -i 2d feeds.conf
echo 'src-link packages /home/chris/git/github.com/cpswan/OpenWrt-packages' >> feeds.conf
./scripts/feeds update -a
./scripts/feeds install arp-scan
make V=s package/arp-scan/compile
find . -name *.ipk
python3 -m http.server
```
Run tested: arch: x86, model: 64, OpenWrt version: 24.10.0
```sh
opkg update
opkg install arp-scan
wget http://openwrt.swos.local:8000/bin/packages/x86_64/packages/arp-scan-database_1.10.0-r3_x86_64.ipk
opkg install arp-scan-database_1.10.0-r3_x86_64.ipk
```
The logged into LuCI, navigated to Network->Diagnostics and pressed `Arp-scan` button. Output was:

```log
Interface: br-lan, type: EN10MB, MAC: 00:0c:29:56:f3:7a, IPv4: 192.168.138.24
Starting arp-scan 1.10.0 with 256 hosts (https://github.com/royhills/arp-scan)
192.168.138.1	00:50:56:c0:00:01	VMware, Inc.
192.168.138.23	00:0c:29:76:33:3c	VMware, Inc.
192.168.138.254	00:50:56:f8:88:15	VMware, Inc.

4 packets received by filter, 0 packets dropped by kernel
Ending arp-scan 1.10.0: 256 hosts scanned in 2.082 seconds (122.96 hosts/sec). 3 responded
```

Description: fixes #26014 where arp-scan expects to find `mac-vendor.txt` in `/etc/arp-scan/` since the 1.10.0 release
