### PR TITLE
ddns-scripts: Add option 'myip=no' to Dynu IPv6 update URL

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=63
+PKG_RELEASE:=64
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/dynu.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/dynu.com.json
@@ -4,6 +4,6 @@
 		"url": "http://api.dynu.com/nic/update?hostname=[DOMAIN]&myip=[IP]&username=[USERNAME]&password=[PASSWORD]"
 	},
 	"ipv6": {
-		"url": "http://api.dynu.com/nic/update?hostname=[DOMAIN]&myipv6=[IP]&username=[USERNAME]&password=[PASSWORD]"
+		"url": "http://api.dynu.com/nic/update?hostname=[DOMAIN]&myip=no&myipv6=[IP]&username=[USERNAME]&password=[PASSWORD]"
 	}
 }


### PR DESCRIPTION
Prevents IPv6 updates to also update IPv4 (undesirable when behind a CGNAT)

Maintainer: @feckert
Compile tested: NanoPI R6S, OpenWrt 24.10.0
Run tested: NanoPI R6S, OpenWrt 24.10.0. Confirmed that after this change only IPv6 is updated in DynuDDNS.
Description: Prevents IPv6 updates to also update IPv4 (undesirable when behind a CGNAT)