### PR TITLE
nginx: update repository of maintained naxsi module

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -290,10 +290,10 @@ define Download/nginx-mod-ts
 endef
 
 define Download/nginx-mod-naxsi
-  SOURCE_DATE:=2022-09-14
-  SOURCE_VERSION:=d714f1636ea49a9a9f4f06dba14aee003e970834
-  URL:=https://github.com/nbs-system/naxsi.git
-  MIRROR_HASH:=b0cef5fbf842f283eb5f0686ddd1afcd07d83abd7027c8cfb3e84a2223a34797
+  SOURCE_DATE:=2025-01-05
+  SOURCE_VERSION:=b61ba37b3666b386c7a6d83fbcdf6ca3377395a1
+  URL:=https://github.com/wargio/naxsi.git
+  MIRROR_HASH:=2b8bf06f8e4cee95e287158c193c4930deab097bf1491c03a95dd8b0c2682d4c
   PROTO:=git
 endef
 
@@ -356,7 +356,11 @@ $(foreach m,$(PKG_MOD_EXTRA),$(eval $(call Module/Download,$(m))))
 
 define Module/nginx-mod-naxsi/install
 	$(INSTALL_DIR) $(1)/etc/nginx
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/nginx-mod-naxsi/naxsi_config/naxsi_core.rules $(1)/etc/nginx
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/nginx-mod-naxsi/naxsi_rules/naxsi_core.rules $(1)/etc/nginx
+endef
+
+define Package/nginx-mod-naxsi/conffiles
+/etc/nginx/naxsi_core.rules
 endef
 
 define Quilt/Refresh/Package


### PR DESCRIPTION
nginx: update repository of maintained naxsi moduleMaintainer: @mhusaam @Ansuel  
Compile tested: 
mediatek/filogic / Bananapi BPI-R3 / openwrt/openwrt@1fad1b4 (v24.10.0)  

Run tested: 
mediatek/filogic / Bananapi BPI-R3 / openwrt/openwrt@1fad1b4 (v24.10.0)  

Description:  
This improvement switches the naxsi-module repository to an actively maintained fork [recomanded](https://github.com/nbs-system/naxsi?tab=readme-ov-file#project-status) by nbs-system due to the original project is officially abandoned (archived in 2023.11.08). The current version causes syntax error when reading the default `naxsi_core.rules` and other blocking and whitelist rules file as below:    
```  
Naxsi-Config : Incorrect line MainRule rx:select|union|update|delete|insert|table|from|ascii|hex|unhex|drop|load_file|substr|group_concat|dumpfile (nginx-1.26.1/nginx-mod-naxsi/naxsi_src/naxsi_skeleton.c/973)... in /etc/nginx/naxsi_core.rules:23
```  