### PR TITLE
[24.10] ddns-scripts: backport updates to 24.10 branch

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=52
+PKG_RELEASE:=53
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=60
+PKG_RELEASE:=61
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=58
+PKG_RELEASE:=59
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=59
+PKG_RELEASE:=60
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=61
+PKG_RELEASE:=62
 
 PKG_LICENSE:=GPL-2.0
 
@@ -362,6 +362,10 @@ define Package/ddns-scripts/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) ./files/usr/bin/ddns.sh \
 		$(1)/usr/bin/ddns
+
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DATA) ./files/etc/uci-defaults/50-ddns-migrate-retry-count \
+		$(1)/etc/uci-defaults/
 endef
 
 define Package/ddns-scripts/postinst

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=63
+PKG_RELEASE:=64
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=62
+PKG_RELEASE:=63
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=53
+PKG_RELEASE:=54
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=57
+PKG_RELEASE:=58
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=54
+PKG_RELEASE:=55
 
 PKG_LICENSE:=GPL-2.0
 
@@ -152,6 +152,17 @@ endef
 
 define Package/ddns-scripts-dnspod/description
   Dynamic DNS Client scripts extension for dnspod.cn API (require curl)
+endef
+
+
+define Package/ddns-scripts-dnspod-v3
+  $(call Package/ddns-scripts/Default)
+  TITLE:=Extension for dnspod.tencentcloudapi.com (aka: dnspod.cn) API v3
+  DEPENDS:=ddns-scripts +curl +openssl-util
+endef
+
+define Package/ddns-scripts-dnspod-v3/description
+  Dynamic DNS Client scripts extension for dnspod.tencentcloudapi.com API v3 (require curl)
 endef
 
 
@@ -385,6 +396,7 @@ define Package/ddns-scripts-services/install
 	rm $(1)/usr/share/ddns/default/godaddy.com-v1.json
 	rm $(1)/usr/share/ddns/default/digitalocean.com-v2.json
 	rm $(1)/usr/share/ddns/default/dnspod.cn.json
+	rm $(1)/usr/share/ddns/default/dnspod.cn-v3.json
 	rm $(1)/usr/share/ddns/default/no-ip.com.json
 	rm $(1)/usr/share/ddns/default/bind-nsupdate.json
 	rm $(1)/usr/share/ddns/default/route53-v1.json
@@ -533,6 +545,25 @@ define Package/ddns-scripts-dnspod/install
 endef
 
 define Package/ddns-scripts-dnspod/prerm
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	/etc/init.d/ddns stop
+fi
+exit 0
+endef
+
+
+define Package/ddns-scripts-dnspod-v3/install
+	$(INSTALL_DIR) $(1)/usr/lib/ddns
+	$(INSTALL_BIN) ./files/usr/lib/ddns/update_dnspod_cn_v3.sh \
+		$(1)/usr/lib/ddns
+
+	$(INSTALL_DIR) $(1)/usr/share/ddns/default
+	$(INSTALL_DATA) ./files/usr/share/ddns/default/dnspod.cn-v3.json \
+		$(1)/usr/share/ddns/default/
+endef
+
+define Package/ddns-scripts-dnspod-v3/prerm
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
 	/etc/init.d/ddns stop
@@ -760,6 +791,7 @@ $(eval $(call BuildPackage,ddns-scripts-freedns))
 $(eval $(call BuildPackage,ddns-scripts-godaddy))
 $(eval $(call BuildPackage,ddns-scripts-digitalocean))
 $(eval $(call BuildPackage,ddns-scripts-dnspod))
+$(eval $(call BuildPackage,ddns-scripts-dnspod-v3))
 $(eval $(call BuildPackage,ddns-scripts-noip))
 $(eval $(call BuildPackage,ddns-scripts-nsupdate))
 $(eval $(call BuildPackage,ddns-scripts-route53))

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=55
+PKG_RELEASE:=56
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=56
+PKG_RELEASE:=57
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/etc/uci-defaults/50-ddns-migrate-retry-count
+++ b/net/ddns-scripts/files/etc/uci-defaults/50-ddns-migrate-retry-count
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+upgrade_to_retry_max_count() {
+	local service=$1
+	local retry_count retry_max_count
+
+	config_get retry_max_count $service retry_max_count
+	config_get retry_count $service retry_count
+	if [ -z "$retry_max_count" ] && [ -n "$retry_count" ]; then
+		uci_set ddns $service retry_max_count $retry_count
+		uci_commit ddns
+	fi
+}
+
+config_load ddns
+config_foreach upgrade_to_retry_max_count service
+
+exit 0

--- a/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
@@ -27,9 +27,8 @@
 [ $use_https -eq 0 ] && use_https=1	# force HTTPS
 
 # used variables
-local __HOST __DOMAIN __TYPE __URLBASE __PRGBASE __RUNPROG __DATA __IPV6 __ZONEID __RECID __PROXIED
+local __HOST __DOMAIN __TYPE __URLBASE __PRGBASE __RUNPROG __DATA __IPV6 __ZONEID __RECID
 local __URLBASE="https://api.cloudflare.com/client/v4"
-local __TTL=120
 
 # split __HOST __DOMAIN from $domain
 # given data:
@@ -186,16 +185,14 @@ __DATA=$(grep -o '"content":\s*"[^"]*' $DATFILE | grep -o '[^"]*$' | head -1)
 
 # update is needed
 # let's build data to send
-# set proxied parameter
-__PROXIED=$(grep -o '"proxied":\s*[^",]*' $DATFILE | grep -o '[^:]*$')
 
 # use file to work around " needed for json
 cat > $DATFILE << EOF
-{"id":"$__ZONEID","type":"$__TYPE","name":"$__HOST","content":"$__IP","ttl":$__TTL,"proxied":$__PROXIED}
+{"content":"$__IP"}
 EOF
 
 # let's complete transfer command
-__RUNPROG="$__PRGBASE --request PUT --data @$DATFILE '$__URLBASE/zones/$__ZONEID/dns_records/$__RECID'"
+__RUNPROG="$__PRGBASE --request PATCH --data @$DATFILE '$__URLBASE/zones/$__ZONEID/dns_records/$__RECID'"
 cloudflare_transfer || return 1
 
 return 0

--- a/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
@@ -96,8 +96,8 @@ __PRGBASE="$CURL -RsS -o $DATFILE --stderr $ERRFILE"
 # force network/interface-device to use for communication
 if [ -n "$bind_network" ]; then
 	local __DEVICE
-	network_get_physdev __DEVICE $bind_network || \
-		write_log 13 "Can not detect local device using 'network_get_physdev $bind_network' - Error: '$?'"
+	network_get_device __DEVICE $bind_network || \
+		write_log 13 "Can not detect local device using 'network_get_device $bind_network' - Error: '$?'"
 	write_log 7 "Force communication via device '$__DEVICE'"
 	__PRGBASE="$__PRGBASE --interface $__DEVICE"
 fi

--- a/net/ddns-scripts/files/usr/lib/ddns/update_digitalocean_com_v2.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_digitalocean_com_v2.sh
@@ -24,6 +24,7 @@
 json_init
 json_add_string name "$username"
 json_add_string data "$__IP"
+[ $use_ipv6 -ne 0 ] && json_add_string type "AAAA" || json_add_string type "A"
 
 __STATUS=$(curl -Ss -X PUT "https://api.digitalocean.com/v2/domains/${domain}/records/${param_opt}" \
 	-H "Authorization: Bearer ${password}" \

--- a/net/ddns-scripts/files/usr/lib/ddns/update_dnspod_cn.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_dnspod_cn.sh
@@ -28,7 +28,7 @@ build_command() {
 	# bind host/IP
 	if [ -n "$bind_network" ]; then
 		local __DEVICE
-		network_get_physdev __DEVICE $bind_network || write_log 13 "Can not detect local device using 'network_get_physdev $bind_network' - Error: '$?'"
+		network_get_device __DEVICE $bind_network || write_log 13 "Can not detect local device using 'network_get_device $bind_network' - Error: '$?'"
 		write_log 7 "Force communication via device '$__DEVICE'"
 		__CMDBASE="$__CMDBASE --interface $__DEVICE"
 	fi

--- a/net/ddns-scripts/files/usr/lib/ddns/update_dnspod_cn_v3.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_dnspod_cn_v3.sh
@@ -120,8 +120,8 @@ tencentcloud_transfer() {
 # force network/interface-device to use for communication
 if [ -n "$bind_network" ]; then
 	local __DEVICE
-	network_get_physdev __DEVICE $bind_network ||
-		write_log 13 "Can not detect local device using 'network_get_physdev $bind_network' - Error: '$?'"
+	network_get_device __DEVICE $bind_network ||
+		write_log 13 "Can not detect local device using 'network_get_device $bind_network' - Error: '$?'"
 	write_log 7 "Force communication via device '$__DEVICE'"
 	__PRGBASE="$__PRGBASE --interface $__DEVICE"
 fi

--- a/net/ddns-scripts/files/usr/lib/ddns/update_dnspod_cn_v3.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_dnspod_cn_v3.sh
@@ -1,0 +1,345 @@
+#!/bin/sh
+#
+# Script for sending updates to cloud.tencent.com, modified based on
+# "update_cloudflare_com_v4.sh" and "update_dnspod_cn.sh".
+#
+# You can found them from:
+# - github.com/openwrt/packages for "update_cloudflare_com_v4.sh"
+#	- at: net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
+# - github.com/nixonli/ddns-scripts_dnspod for "update_dnspod_cn.sh"
+#
+# 2024 FriesI23 <FriesI23@outlook.com>
+#
+# API documentation at https://cloud.tencent.com/document/api/1427/84627
+# API signature documentation at https://cloud.tencent.com/document/api/1427/56189
+#
+# This script is parsed by dynamic_dns_functions.sh inside send_update() function
+#
+# using following options from /etc/config/ddns
+# you can get your own secret values from console.cloud.tencent.com/cam/capi
+# option username  - api secretId
+# option password  - api secretKey
+# option domain    - "hostname@yourdomain.TLD"
+# option record_id - record id for special record
+#
+# variable __IP already defined with the ip-address to use for update
+#
+
+local OPENSSL=$(command -v openssl)
+
+# check parameters
+[ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing key as 'username'"
+[ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing secret as 'password'"
+[ -z "$CURL_SSL" ] && write_log 13 "Dnspod communication require cURL with SSL support. Please install"
+[ -z "$OPENSSL" ] && write_log 13 "Dnspod communication require openssl. Please install"
+[ $use_https -eq 0 ] && use_https=1
+
+# variables
+local __HOST __DOMAIN __TYPE
+local __RUNPROG
+local __RECID __RECLINE __DATA __IPV6
+local __URLHOST="dnspod.tencentcloudapi.com"
+local __URLBASE="https://$__URLHOST"
+local __METHOD="POST"
+local __CONTENT_TYPE="application/json"
+
+# split __HOST __DOMAIN from $domain
+# given data:
+# @example.com for "domain record"
+# host.sub@example.com for a "host record"
+__HOST=$(printf %s "$domain" | cut -d@ -f1)
+__DOMAIN=$(printf %s "$domain" | cut -d@ -f2)
+
+# set record type
+[ $use_ipv6 -eq 0 ] && __TYPE="A" || __TYPE="AAAA"
+
+tencentcloud_transfer() {
+	local __CNT=0
+	local __ERR __CODE
+
+	while :; do
+		write_log 7 "#> $__RUNPROG"
+		eval "$__RUNPROG"
+		__ERR=$? # save communication error
+
+		if [ $__ERR -eq 0 ]; then
+			if grep -q '"Error"' "$DATFILE"; then
+				__CODE=$(grep -o '"Code":\s*"[^"]*' $DATFILE | grep -o '[^"]*$' | head -1)
+				[[ $__CODE == "ResourceNotFound.NoDataOfRecord" ]] && break
+				write_log 3 "cURL Response Error: '$__CODE'"
+				write_log 7 "$(cat $DATFILE)" # report error
+			else
+				break
+			fi
+		else
+			write_log 3 "cURL Error: '$__ERR'"
+			write_log 7 "$(cat $ERRFILE)" # report error
+		fi
+
+		[ $VERBOSE -gt 1 ] && {
+			# VERBOSE > 1 then NO retry
+			write_log 4 "Transfer failed - Verbose Mode: $VERBOSE - NO retry on error"
+			break
+		}
+
+		__CNT=$(($__CNT + 1)) # increment error counter
+		# if error count > retry_count leave here
+		[ $retry_count -gt 0 -a $__CNT -gt $retry_count ] &&
+			write_log 14 "Transfer failed after $retry_count retries"
+
+		write_log 4 "Transfer failed - retry $__CNT/$retry_count in $RETRY_SECONDS seconds"
+		sleep $RETRY_SECONDS &
+		PID_SLEEP=$!
+		wait $PID_SLEEP # enable trap-handler
+		PID_SLEEP=0
+	done
+
+	# check for error
+	if grep -q '"Error":' $DATFILE; then
+		__CODE=$(grep -o '"Code":\s*"[^"]*' $DATFILE | grep -o '[^"]*$' | head -1)
+		[[ $__CODE == "ResourceNotFound.NoDataOfRecord" ]] && return 0
+		write_log 4 "TecentCloud reported an error:"
+		write_log 7 "$(cat $DATFILE)" # report error
+		return 1
+	fi
+
+	return 0
+}
+
+# Build base command to use
+__PRGBASE="$CURL -RsS -o $DATFILE --stderr $ERRFILE"
+
+# force network/interface-device to use for communication
+if [ -n "$bind_network" ]; then
+	local __DEVICE
+	network_get_physdev __DEVICE $bind_network ||
+		write_log 13 "Can not detect local device using 'network_get_physdev $bind_network' - Error: '$?'"
+	write_log 7 "Force communication via device '$__DEVICE'"
+	__PRGBASE="$__PRGBASE --interface $__DEVICE"
+fi
+
+# force ip version to use
+if [ $force_ipversion -eq 1 ]; then
+	[ $use_ipv6 -eq 0 ] && __PRGBASE="$__PRGBASE -4" || __PRGBASE="$__PRGBASE -6" # force IPv4/IPv6
+fi
+
+# set certificate parameters
+if [ "$cacert" = "IGNORE" ]; then     # idea from Ticket #15327 to ignore server cert
+	__PRGBASE="$__PRGBASE --insecure" # but not empty better to use "IGNORE"
+elif [ -f "$cacert" ]; then
+	__PRGBASE="$__PRGBASE --cacert $cacert"
+elif [ -d "$cacert" ]; then
+	__PRGBASE="$__PRGBASE --capath $cacert"
+elif [ -n "$cacert" ]; then # it's not a file and not a directory but given
+	write_log 14 "No valid certificate(s) found at '$cacert' for HTTPS communication"
+fi
+
+# disable proxy if not set (there might be .wgetrc or .curlrc or wrong environment set)
+# or check if libcurl compiled with proxy support
+if [ -z "$proxy" ]; then
+	__PRGBASE="$__PRGBASE --noproxy '*'"
+elif [ -z "$CURL_PROXY" ]; then
+	# if libcurl has no proxy support and proxy should be used then force ERROR
+	write_log 13 "cURL: libcurl compiled without Proxy support"
+fi
+
+# Signature Method v3
+# get more information from github.com/TencentCloud/signature-process-demo,
+# at signature-v3/bash/signv3_no_xdd.sh
+# usage: build_authorization <action> <version> <timestamp> <payload>
+build_authorization() {
+	local __SECRET_ID=$username
+	local __SECRET_KEY=$password
+
+	local __SERVICE=$(printf %s "$__URLHOST" | cut -d '.' -f1)
+	local __REGION=""
+	local __ACTION=$1
+	local __VERSION=$2
+	local __ALGORITHM="TC3-HMAC-SHA256"
+	local __TIMESTAMP=$3
+	local __DATE=$(date -u -d @$__TIMESTAMP +"%Y-%m-%d")
+	local __PAYLOAD=$4
+
+	# Step 1: Concatenate request string
+	local __CANONICAL_URI="/"
+	local __CANONICAL_QUERYSTRING=""
+	local __CANONICAL_HEADERS=$(
+		cat <<EOF
+content-type:$__CONTENT_TYPE
+host:$__URLHOST
+x-tc-action:$(echo $__ACTION | awk '{print tolower($0)}')
+EOF
+	)
+	local __SIGNED_HEADERS="content-type;host;x-tc-action"
+	local __HASHED_REQUEST_PAYLOAD=$(echo -n "$__PAYLOAD" | $OPENSSL sha256 -hex | awk '{print $2}')
+	local __CANONICAL_REQEUST=$(
+		cat <<EOF
+$__METHOD
+$__CANONICAL_URI
+$__CANONICAL_QUERYSTRING
+$__CANONICAL_HEADERS
+
+$__SIGNED_HEADERS
+$__HASHED_REQUEST_PAYLOAD
+EOF
+	)
+
+	# Step 2: Concatenate signed string
+	local __CREDENTIAL_SCOPE="$__DATE/$__SERVICE/tc3_request"
+	local __HASHED_CANONICAL_REQUEST=$(printf "$__CANONICAL_REQEUST" |
+		$OPENSSL sha256 -hex | awk '{print $2}')
+	local __STRING_TO_SIGN=$(
+		cat <<EOF
+$__ALGORITHM
+$__TIMESTAMP
+$__CREDENTIAL_SCOPE
+$__HASHED_CANONICAL_REQUEST
+EOF
+	)
+
+	# Step 3: Calculate signature
+	local __SECRET_DATE=$(printf "$__DATE" |
+		$OPENSSL sha256 -hmac "TC3$__SECRET_KEY" | awk '{print $2}')
+	local __SECRET_SERVICE=$(printf $__SERVICE |
+		$OPENSSL dgst -sha256 -mac hmac -macopt hexkey:"$__SECRET_DATE" | awk '{print $2}')
+	local __SECRET_SIGNING=$(printf "tc3_request" |
+		$OPENSSL dgst -sha256 -mac hmac -macopt hexkey:"$__SECRET_SERVICE" | awk '{print $2}')
+	local __SIGNATURE=$(printf "$__STRING_TO_SIGN" |
+		$OPENSSL dgst -sha256 -mac hmac -macopt hexkey:"$__SECRET_SIGNING" | awk '{print $2}')
+
+	# Step 4: Concatenate Authorization
+	local __AUTHORIZATION="$__ALGORITHM Credential=$__SECRET_ID/$__CREDENTIAL_SCOPE, \
+SignedHeaders=$__SIGNED_HEADERS, Signature=$__SIGNATURE"
+
+	printf '%s' "$__AUTHORIZATION"
+}
+
+# Common Parameters for Signature Method v3
+# usage: build_header <action> <version> <payload>
+build_header() {
+	local __ACTION=$1
+	local __VERSION=$2
+	local __TIMESTAMP=$(date +%s)
+	local __PAYLOAD=$3
+
+	local __AUTHORIZATION=$(build_authorization $__ACTION $__VERSION $__TIMESTAMP $__PAYLOAD)
+
+	printf '%s' "--header 'HOST: $__URLHOST' "
+	printf '%s' "--header 'Content-Type: $__CONTENT_TYPE' "
+	printf '%s' "--header 'X-TC-Action: $__ACTION' "
+	printf '%s' "--header 'X-TC-Version: $__VERSION' "
+	printf '%s' "--header 'X-TC-Timestamp: $__TIMESTAMP' "
+	printf '%s' "--header 'Authorization: $__AUTHORIZATION' "
+}
+
+# API: DescribeRecordList。
+# https://cloud.tencent.com/document/api/1427/56166
+build_describe_record_list_request_param() {
+	local __PAYLOAD="{\"Domain\":\"$__DOMAIN\""
+	__PAYLOAD="$__PAYLOAD,\"Offset\":0"
+	__PAYLOAD="$__PAYLOAD,\"Limit\":1"
+	__PAYLOAD="$__PAYLOAD,\"RecordType\":\"$__TYPE\""
+	if [[ -n "$__HOST" ]]; then
+		__PAYLOAD="$__PAYLOAD,\"Subdomain\":\"$__HOST\""
+	fi
+	__PAYLOAD="$__PAYLOAD}"
+
+	printf '%s' "--request POST "
+	printf '%s' "$__URLBASE "
+	printf '%s' "--data '$__PAYLOAD' "
+	build_header "DescribeRecordList" "2021-03-23" $__PAYLOAD
+}
+
+# API: CreateRecord
+# https://cloud.tencent.com/document/api/1427/56180
+build_create_record_request_param() {
+	local __VALUE=$1
+	local __RECLINE=${2:-默认}
+
+	local __PAYLOAD="{\"Domain\":\"$__DOMAIN\""
+	__PAYLOAD="$__PAYLOAD,\"RecordType\":\"$__TYPE\""
+	__PAYLOAD="$__PAYLOAD,\"RecordLine\":\"$__RECLINE\""
+	__PAYLOAD="$__PAYLOAD,\"Value\":\"$__VALUE\""
+	if [[ -n "$__HOST" ]]; then
+		__PAYLOAD="$__PAYLOAD,\"SubDomain\":\"$__HOST\""
+	fi
+	__PAYLOAD="$__PAYLOAD}"
+
+	printf '%s' "--request POST "
+	printf '%s' "$__URLBASE "
+	printf '%s' "--data '$__PAYLOAD' "
+	build_header "CreateRecord" "2021-03-23" $__PAYLOAD
+}
+
+# API: ModifyRecord
+# https://cloud.tencent.com/document/api/1427/56157
+build_modify_record_request_param() {
+	local __VALUE=$1
+	local __RECLINE=${2:-默认}
+	local __RECID=$3
+
+	local __PAYLOAD="{\"Domain\":\"$__DOMAIN\""
+	__PAYLOAD="$__PAYLOAD,\"RecordType\":\"$__TYPE\""
+	__PAYLOAD="$__PAYLOAD,\"RecordLine\":\"$__RECLINE\""
+	__PAYLOAD="$__PAYLOAD,\"RecordId\":$__RECID"
+	__PAYLOAD="$__PAYLOAD,\"Value\":\"$__VALUE\""
+	if [[ -n "$__HOST" ]]; then
+		__PAYLOAD="$__PAYLOAD,\"SubDomain\":\"$__HOST\""
+	fi
+	__PAYLOAD="$__PAYLOAD}"
+
+	printf '%s' "--request POST "
+	printf '%s' "$__URLBASE "
+	printf '%s' "--data '$__PAYLOAD' "
+	build_header "ModifyRecord" "2021-03-23" $__PAYLOAD
+}
+
+if [ -n "$record_id" ]; then
+	__RECID="$record_id"
+else
+	# read record id for A or AAAA record of host.domain.TLD
+	__RUNPROG="$__PRGBASE $(build_describe_record_list_request_param)"
+	# extract zone id
+	tencentcloud_transfer || return 1
+	__RECID=$(grep -o '"RecordId":[[:space:]]*[0-9]*' $DATFILE | grep -o '[0-9]*' | head -1)
+fi
+
+[ $VERBOSE -gt 1 ] && write_log 7 "Got record id: $__RECID"
+
+# extract current stored IP
+__RECLINE=$(grep -o '"Line":\s*"[^"]*' $DATFILE | grep -o '[^"]*$' | head -1)
+__DATA=$(grep -o '"Value":\s*"[^"]*' $DATFILE | grep -o '[^"]*$' | head -1)
+
+# check data
+[ $use_ipv6 -eq 0 ] &&
+	__DATA=$(printf "%s" "$__DATA" | grep -m 1 -o "$IPV4_REGEX") ||
+	__DATA=$(printf "%s" "$__DATA" | grep -m 1 -o "$IPV6_REGEX")
+
+# we got data so verify
+[ -n "$__DATA" ] && {
+	# expand IPv6 for compare
+	if [ $use_ipv6 -eq 1 ]; then
+		expand_ipv6 $__IP __IPV6
+		expand_ipv6 $__DATA __DATA
+		[ "$__DATA" = "$__IPV6" ] && { # IPv6 no update needed
+			write_log 7 "IPv6 at cloud.tencent.com already up to date"
+			return 0
+		}
+	else
+		[ "$__DATA" = "$__IP" ] && { # IPv4 no update needed
+			write_log 7 "IPv4 at cloud.tencent.com already up to date"
+			return 0
+		}
+	fi
+}
+
+if [ -z "$__RECID" ]; then
+	# create new record if record id not found
+	__RUNPROG="$__PRGBASE $(build_create_record_request_param $__IP $__RECLINE)"
+	tencentcloud_transfer || return 1
+	return 0
+fi
+
+__RUNPROG="$__PRGBASE $(build_modify_record_request_param $__IP $__RECLINE $__RECID)"
+tencentcloud_transfer || return 1
+return

--- a/net/ddns-scripts/files/usr/lib/ddns/update_dnspod_cn_v3.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_dnspod_cn_v3.sh
@@ -8,6 +8,8 @@
 #	- at: net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
 # - github.com/nixonli/ddns-scripts_dnspod for "update_dnspod_cn.sh"
 #
+# v1.1.0: Publish script
+#
 # 2024 FriesI23 <FriesI23@outlook.com>
 #
 # API documentation at https://cloud.tencent.com/document/api/1427/84627
@@ -43,6 +45,10 @@ local __URLBASE="https://$__URLHOST"
 local __METHOD="POST"
 local __CONTENT_TYPE="application/json"
 
+# Build base command to use
+local __PRGBASE="$CURL -RsS -o $DATFILE --stderr $ERRFILE"
+local __PRGEXTA=""
+
 # split __HOST __DOMAIN from $domain
 # given data:
 # @example.com for "domain record"
@@ -58,6 +64,7 @@ tencentcloud_transfer() {
 	local __ERR __CODE
 
 	while :; do
+		__RUNPROG="$__PRGBASE $($__PRGEXTA)"
 		write_log 7 "#> $__RUNPROG"
 		eval "$__RUNPROG"
 		__ERR=$? # save communication error
@@ -105,9 +112,6 @@ tencentcloud_transfer() {
 
 	return 0
 }
-
-# Build base command to use
-__PRGBASE="$CURL -RsS -o $DATFILE --stderr $ERRFILE"
 
 # force network/interface-device to use for communication
 if [ -n "$bind_network" ]; then
@@ -298,7 +302,7 @@ if [ -n "$record_id" ]; then
 	__RECID="$record_id"
 else
 	# read record id for A or AAAA record of host.domain.TLD
-	__RUNPROG="$__PRGBASE $(build_describe_record_list_request_param)"
+	__PRGEXTA="build_describe_record_list_request_param"
 	# extract zone id
 	tencentcloud_transfer || return 1
 	__RECID=$(grep -o '"RecordId":[[:space:]]*[0-9]*' $DATFILE | grep -o '[0-9]*' | head -1)
@@ -335,11 +339,11 @@ __DATA=$(grep -o '"Value":\s*"[^"]*' $DATFILE | grep -o '[^"]*$' | head -1)
 
 if [ -z "$__RECID" ]; then
 	# create new record if record id not found
-	__RUNPROG="$__PRGBASE $(build_create_record_request_param $__IP $__RECLINE)"
+	__PRGEXTA="build_create_record_request_param $__IP $__RECLINE"
 	tencentcloud_transfer || return 1
 	return 0
 fi
 
-__RUNPROG="$__PRGBASE $(build_modify_record_request_param $__IP $__RECLINE $__RECID)"
+__PRGEXTA="build_modify_record_request_param $__IP $__RECLINE $__RECID"
 tencentcloud_transfer || return 1
 return

--- a/net/ddns-scripts/files/usr/lib/ddns/update_godaddy_com_v1.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_godaddy_com_v1.sh
@@ -93,8 +93,8 @@ __PRGBASE="$CURL -RsS -w '%{http_code}' -o $DATFILE --stderr $ERRFILE"
 # force network/interface-device to use for communication
 if [ -n "$bind_network" ]; then
 	local __DEVICE
-	network_get_physdev __DEVICE $bind_network || \
-		write_log 13 "Can not detect local device using 'network_get_physdev $bind_network' - Error: '$?'"
+	network_get_device __DEVICE $bind_network || \
+		write_log 13 "Can not detect local device using 'network_get_device $bind_network' - Error: '$?'"
 	write_log 7 "Force communication via device '$__DEVICE'"
 	__PRGBASE="$__PRGBASE --interface $__DEVICE"
 fi

--- a/net/ddns-scripts/files/usr/lib/ddns/update_luadns_v1.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_luadns_v1.sh
@@ -76,8 +76,8 @@ __PRGBASE="$CURL -RsS -w '%{http_code}' -o $DATFILE --stderr $ERRFILE"
 # force network/interface-device to use for communication
 if [ -n "$bind_network" ]; then
 	local __DEVICE
-	network_get_physdev __DEVICE $bind_network || \
-		write_log 13 "Can not detect local device using 'network_get_physdev $bind_network' - Error: '$?'"
+	network_get_device __DEVICE $bind_network || \
+		write_log 13 "Can not detect local device using 'network_get_device $bind_network' - Error: '$?'"
 	write_log 7 "Force communication via device '$__DEVICE'"
 	__PRGBASE="$__PRGBASE --interface $__DEVICE"
 fi

--- a/net/ddns-scripts/files/usr/share/ddns/default/dnspod.cn-v3.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/dnspod.cn-v3.json
@@ -1,0 +1,9 @@
+{
+	"name": "dnspod.cn-v3",
+	"ipv4": {
+		"url": "update_dnspod_cn_v3.sh"
+	},
+	"ipv6": {
+		"url": "update_dnspod_cn_v3.sh"
+	}
+}

--- a/net/ddns-scripts/files/usr/share/ddns/default/dynu.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/dynu.com.json
@@ -4,6 +4,6 @@
 		"url": "http://api.dynu.com/nic/update?hostname=[DOMAIN]&myip=[IP]&username=[USERNAME]&password=[PASSWORD]"
 	},
 	"ipv6": {
-		"url": "http://api.dynu.com/nic/update?hostname=[DOMAIN]&myipv6=[IP]&username=[USERNAME]&password=[PASSWORD]"
+		"url": "http://api.dynu.com/nic/update?hostname=[DOMAIN]&myip=no&myipv6=[IP]&username=[USERNAME]&password=[PASSWORD]"
 	}
 }

--- a/net/ddns-scripts/files/usr/share/ddns/default/ipv64.net.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/ipv64.net.json
@@ -1,0 +1,11 @@
+{
+	"name": "duckdns.org",
+	"ipv4": {
+		"url": "http://ipv64.net/nic/update?domain=[DOMAIN]&key=[PASSWORD]&ip=[IP]",
+		"answer": "good|nochg"
+	},
+	"ipv6": {
+		"url": "http://ipv64.net/nic/update?domain=[DOMAIN]&key=[PASSWORD]&ipv6=[IP]",
+		"answer": "good|nochg"
+	}
+}

--- a/net/ddns-scripts/files/usr/share/ddns/default/joker.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/joker.com.json
@@ -3,5 +3,9 @@
 	"ipv4": {
 		"url": "http://svc.joker.com/nic/update?username=[USERNAME]&password=[PASSWORD]&myip=[IP]&hostname=[DOMAIN]",
 		"answer": "good|nochg"
+	},
+	"ipv6": {
+		"url": "http://svc.joker.com/nic/update?username=[USERNAME]&password=[PASSWORD]&myip=[IP]&hostname=[DOMAIN]",
+		"answer": "good|nochg"
 	}
 }

--- a/net/ddns-scripts/files/usr/share/ddns/default/ydns.io.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/ydns.io.json
@@ -2,10 +2,10 @@
 	"name": "ydns.io",
 	"ipv4": {
 		"url": "https://[USERNAME]:[PASSWORD]@ydns.io/api/v1/update/?host=[DOMAIN]&ip=[IP]",
-		"answer": "good"
+		"answer": "good|nochg"
 	},
 	"ipv6": {
 		"url": "https://[USERNAME]:[PASSWORD]@ydns.io/api/v1/update/?host=[DOMAIN]&ip=[IP]",
-		"answer": "good"
+		"answer": "good|nochg"
 	}
 }

--- a/net/ddns-scripts/files/usr/share/ddns/default/ydns.io.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/ydns.io.json
@@ -1,0 +1,11 @@
+{
+	"name": "ydns.io",
+	"ipv4": {
+		"url": "https://[USERNAME]:[PASSWORD]@ydns.io/api/v1/update/?host=[DOMAIN]&ip=[IP]",
+		"answer": "good"
+	},
+	"ipv6": {
+		"url": "https://[USERNAME]:[PASSWORD]@ydns.io/api/v1/update/?host=[DOMAIN]&ip=[IP]",
+		"answer": "good"
+	}
+}

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -67,4 +67,5 @@ twodns.de
 udmedia.de
 variomedia.de
 xlhost.de
+ydns.io
 zoneedit.com

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -35,6 +35,7 @@ he.net
 hosting.de
 infomaniak.com
 ipnodns.ru
+ipv64.net
 inwx.de
 joker.com
 loopia.se


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: NanoPI R6S, OpenWrt 24.10.0
Run tested: NanoPI R6S, OpenWrt 24.10.0.
Description: backport/chery pick latest ddns-scripts commits to 24.10 branch

Test environment (24.10.0 updated with 24.10 packages built with this PR):
```
 -----------------------------------------------------
 OpenWrt 24.10.0, r28427-6df0e3d02a
 -----------------------------------------------------
root@router:~# opkg list-installed | grep ddns
ddns-scripts - 2.8.2-r64
ddns-scripts-services - 2.8.2-r64
luci-app-ddns - 25.049.66344~2b8e93c
```