### PR TITLE
docker-compose: Update to version 2.33.1

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.33.0
+PKG_VERSION:=2.33.1
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=6543bc9876688d021310df2b910a7f93b5710464660fab9a63e0c6cb1f2ac48d
+PKG_HASH:=6e7365e84041cd696a0ad5542a83df37e3e29524a238e353e3771ae52871ae1f
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86_64
Run tested: master x86_64

Description:
New upstream release. [Changelog](https://github.com/docker/compose/releases/tag/v2.33.1)