### PR TITLE
netbird: update to 0.37.0

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.36.7
+PKG_VERSION:=0.37.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=03b0581ef19fa839fca9172aac3cdadda39a89df42761c497bc81709081574a4
+PKG_HASH:=e920e7036c16954e6c3d768633851c4db8d256013a48ec363af68287d970acca
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## Compile and run tested

**Maintainer:** Me

| Package architecture | Target | Subtarget | Brand | Model | Hardware Version | OpenWrt version |
|----------------------|--------|-----------|-------|-------|------------------|-----------------|
| [x86_64](https://openwrt.org/docs/techref/instructionset/x86_64) | [x86](https://openwrt.org/docs/techref/targets/x86) | 64 | WOVIBO | B75 M.2 Intel LGA 1155 DDR3 | N/A | OpenWrt SNAPSHOT r28863-ab80e6c684 |

Used a 'dirty' installation of the `OpenWrt` image instead of starting with a clean state:
```
# apk update
# apk upgrade
# apk add --allow-untrusted <package_name>.apk
# reboot
```

**Tests checklist:**
- [x] Connection to the NetBird Cloud Dashboard (not self-hosted).
- [x] Firewall configured with nftables.
- [x] Connection established in P2P mode.
- [x] `wireguard` kernel mode active.
- [x] Routes configured between my homelab and my cloud server.
- [x] `netbird` DNS server functioning correctly.
- [ ] NAT operational (not needed by me at this time, may consider testing in the future).
- [ ] Permissions rules is enforced (not needed by me at this time, may consider testing in the future).

## Description

- Changelog:
  - Update to [0.37.0](https://github.com/netbirdio/netbird/releases/tag/v0.37.0)
    - Full changelog: https://github.com/netbirdio/netbird/compare/v0.36.7...v0.37.0
    - Breaking change:
      - N/A

---

### Additional information

`x86_64` is running in a container using [`incus`](https://github.com/lxc/incus).
The package(s) was compiled with the container [`sdk`](https://github.com/openwrt/docker).
The `OpenWrt` image(s) was built using the container [`imagebuilder`](https://github.com/openwrt/docker) or [`distrobuilder`](https://github.com/lxc/distrobuilder).

You can view my repository with the patch applied and the automated build here:
`This repository is temporary and will be removed or modified after the merge.`
- https://github.com/wehagy/owpib/tree/netbird/update

You can find my artifacts here:
- https://github.com/wehagy/owpib/actions/runs/13465241504

I have encountered some unrelated errors during my build:
- https://github.com/wehagy/owpib/actions/runs/13465241504/job/37656826649#step:5:25421
```
#21 2.206 Installing packages...
#21 2.267 ERROR: unable to select packages:
#21 2.267   f2fsck (no such package):
#21 2.267     required by: world[f2fsck]
#21 2.267   mkf2fs (no such package):
#21 2.267     required by: world[mkf2fs]
#21 2.267   nftables (no such package):
#21 2.267     required by: world[nftables]
#21 2.267   ppp (no such package):
#21 2.267     required by: world[ppp]
#21 2.267   ppp-mod-pppoe (no such package):
#21 2.267     required by: world[ppp-mod-pppoe]
#21 2.267   nftables-json (no such package):
#21 2.267     required by: firewall4-2024.12.18~18fc0ead-r1[nftables-json]
#21 2.269 make[2]: *** [Makefile:226: package_install] Error 11
#21 2.269 make[1]: *** [Makefile:157: _call_image] Error 2
#21 2.270 make: *** [Makefile:332: image] Error 2
#21 ERROR: process "/bin/sh -c /dev/pipes/EOF" did not complete successfully: exit code: 2
```