### PR TITLE
rust: update to 1.85.0

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
-PKG_VERSION:=1.84.0
+PKG_VERSION:=1.85.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
-PKG_HASH:=15cee7395b07ffde022060455b3140366ec3a12cbbea8f1ef2ff371a9cca51bf
+PKG_HASH:=2f4f3142ffb7c8402139cfa0796e24baaac8b9fd3f96b2deec3b94b4045c6a8a
 HOST_BUILD_DIR:=$(BUILD_DIR)/host/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>


### PR DESCRIPTION
Fixes podman build breakage which was caused by podman depending on netavark, which in turn depends on rust-iptables.

rust-iptables requires rust 1.85.0 since commit 75825cd https://github.com/yaa110/rust-iptables/commit/75825cd9c13db91f697461e6fa91f78c5e927008

Maintainer: @lu-zero 
Compile tested: rockchip, snapshot
