### PR TITLE
net/aria2: fix PKG_CPE_ID

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -21,7 +21,7 @@ PKG_MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>, \
 	Hsing-Wang Liao <kuoruan@gmail.com>
 PKG_LICENSE:=GPLv2
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:tatsuhiro_tsujikawa:aria2
+PKG_CPE_ID:=cpe:/a:aria2_project:aria2
 
 PKG_CONFIG_DEPENDS := \
 	CONFIG_ARIA2_NOSSL \


### PR DESCRIPTION
aria2_project:aria2 is a better CPE ID than tatsuhiro_tsujikawa:aria2 as this CPE ID has the latest CVE (whereas tatsuhiro_tsujikawa:aria2 only has CVEs up to 2010):
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:aria2_project:aria2

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

Maintainer: 
Compile tested: Not needed
Run tested: Not needed