### PR TITLE
libs/libupnp: fix PKG_CPE_ID

### DIFF
--- a/libs/libupnp/Makefile
+++ b/libs/libupnp/Makefile
@@ -11,7 +11,7 @@ PKG_HASH:=16a7cee93ce2868ae63ab1a8164dc7de43577c59983b9f61293a310d6888dceb
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:libupnp_project:libupnp
+PKG_CPE_ID:=cpe:/a:pupnp_project:pupnp
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_libupnp-sample \


### PR DESCRIPTION
pupnp_project:pupnp is a better CPE ID than libupnp_project:libupnp as this CPE ID has the latest CVEs from 2021 (whereas libupnp_project:libupnp only has CVEs up to 2020): https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:pupnp_project:pupnp

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

Maintainer: @neheb
Compile tested: Not needed
Run tested: Not needed
