### PR TITLE
lang/tcl: fix PKG_CPE_ID

### DIFF
--- a/lang/tcl/Makefile
+++ b/lang/tcl/Makefile
@@ -21,7 +21,7 @@ HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)$(PKG_VERSION)
 PKG_MAINTAINER:=Joe Mistachkin <joe@mistachkin.com>
 PKG_LICENSE:=TCL
 PKG_LICENSE_FILES:=license.terms
-PKG_CPE_ID:=cpe:/a:tcl_tk:tcl_tk
+PKG_CPE_ID:=cpe:/a:tcl:tcl
 
 PKG_BUILD_DEPENDS:=HOST_OS_MACOS:fakeuname/host
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
tcl:tcl is a better CPE ID than tcl_tk:tcl_tk as this CPE ID has the latest CVE (whereas tcl_tk:tcl_tk only has CVEs up to 2008): https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:tcl:tcl

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

Maintainer: @neheb
Compile tested: Not needed
Run tested: Not needed
