### PR TITLE
admin/syslog-ng: fix PKG_CPE_ID

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -7,7 +7,7 @@ PKG_RELEASE:=2
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING LGPL.txt GPL.txt
-PKG_CPE_ID:=cpe:/a:balabit:syslog-ng
+PKG_CPE_ID:=cpe:/a:oneidentity:syslog-ng
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syslog-ng/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/


### PR DESCRIPTION
oneidentity:syslog-ng is a better CPE ID than balabit:syslog-ng as this CPE ID has the latest CVEs (whereas balabit:syslog-ng only has a CVE from 2000):
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:oneidentity:syslog-ng

Fixes: 5f07bb10948f6ebdf83470c3437c3072aab982e3 (syslog-ng: update to version 3.19.1)

Maintainer: @BKPepe
Compile tested: Not needed
Run tested: Not needed
