### PR TITLE
utils/logrotate: fix PKG_CPE_ID

### DIFF
--- a/utils/logrotate/Makefile
+++ b/utils/logrotate/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=42b4080ee99c9fb6a7d12d8e787637d057a635194e25971997eebbe8d5e57618
 PKG_MAINTAINER:=Christian Beier <cb@shoutrlabs.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:gentoo:logrotate
+PKG_CPE_ID:=cpe:/a:logrotate_project:logrotate
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
logrotate_project:logrotate is a better CPE ID than gentoo:logrotate as this CPE ID has the latest CVE (whereas gentoo:logrotate only has CVEs up to 2011):
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:logrotate_project:logrotate

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

Maintainer: @neheb
Compile tested: Not needed
Run tested: Not needed
