### PR TITLE
net/openssh: fix PKG_CPE_ID

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -20,7 +20,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(if $(BUILD_VARIANT),$(PKG_NAME)-$(BUILD_VARIANT)/)
 
 PKG_LICENSE:=BSD ISC
 PKG_LICENSE_FILES:=LICENCE
-PKG_CPE_ID:=cpe:/a:openssh:openssh
+PKG_CPE_ID:=cpe:/a:openbsd:openssh
 
 #While bumping new version, make sure that it works without it, so it can be removed.
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
openbsd:openssh is a better CPE ID than openssh:openssh as this CPE ID has the latest CVEs (whereas openssh:openssh has no CVEs): https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:openbsd:openssh

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

Maintainer:
Compile tested: Not needed
Run tested: Not needed