### PR TITLE
libs/libuv: fix PKG_CPE_ID

### DIFF
--- a/libs/libuv/Makefile
+++ b/libs/libuv/Makefile
@@ -19,7 +19,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
-PKG_CPE_ID:=cpe:/a:libuv_project:libuv
+PKG_CPE_ID:=cpe:/a:libuv:libuv
 
 CMAKE_BINARY_SUBDIR:=out/cmake
 


### PR DESCRIPTION
libuv:libuv is a better CPE ID than libuv_project:libuv as this CPE ID has the latest CVEs (whereas libuv_project:libuv only has a CVE from 2015):
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:libuv:libuv

Fixes: f8ecbf529bad57970e4ff8f90484ba58d06b4a39 (libuv: update to 1.32.0)

Maintainer:
Compile tested: Not needed
Run tested: Not needed
