### PR TITLE
nginx-mod-njs: fix endianess patch

### DIFF
--- a/net/nginx/patches/nginx-mod-njs/104-endianness_fix.patch
+++ b/net/nginx/patches/nginx-mod-njs/104-endianness_fix.patch
@@ -34,18 +34,18 @@
  	cd $ngx_addon_dir/.. \\
  	&& if [ -f build/Makefile ]; then \$(MAKE) clean; fi \\
 -	&& CFLAGS="\$(CFLAGS)" CC="\$(CC)" ./configure --no-openssl \\
--		--no-libxml2 --no-zlib --no-pcre --no-quickjs \\
+-		--no-libxml2 --no-zlib --no-pcre --no-quickjs --ld-opt="$NGX_LD_OPT" \\
 +	&& CFLAGS="\$(CFLAGS)" CC="\$(CC)" CONFIG_BIG_ENDIAN=\$(CONFIG_BIG_ENDIAN) \\
-+		./configure --no-openssl --no-libxml2 --no-zlib --no-pcre --no-quickjs \\
++	./configure --no-openssl --no-libxml2 --no-zlib --no-pcre --no-quickjs --ld-opt="$NGX_LD_OPT" \\
  	&& \$(MAKE) libnjs
  
  $ngx_addon_dir/../build/libqjs.a: $NGX_MAKEFILE
  	cd $ngx_addon_dir/.. \\
  	&& if [ -f build/Makefile ]; then \$(MAKE) clean; fi \\
 -	&& CFLAGS="\$(CFLAGS)" CC="\$(CC)" ./configure --no-openssl \\
--		--no-libxml2 --no-zlib --no-pcre \\
+-		--no-libxml2 --no-zlib --no-pcre --ld-opt="$NGX_LD_OPT" \\
 +	&& CFLAGS="\$(CFLAGS)" CC="\$(CC)" CONFIG_BIG_ENDIAN=\$(CONFIG_BIG_ENDIAN) \\
-+		./configure --no-openssl --no-libxml2 --no-zlib --no-pcre \\
++	./configure --no-openssl --no-libxml2 --no-zlib --no-pcre --ld-opt="$NGX_LD_OPT" \\
  	&& \$(MAKE) libnjs libqjs
  
  END


### PR DESCRIPTION
Maintainer: @Ansuel 
Compile tested: x86_64, main
Run tested: None

Description:
Currently, the 104-endianness_fix.patch does not apply, so let's manually refresh it to apply and thus fix buildbot nginx builds.