### PR TITLE
tgt: update to 1.0.95

### DIFF
--- a/net/tgt/Makefile
+++ b/net/tgt/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tgt
-PKG_VERSION:=1.0.94
+PKG_VERSION:=1.0.95
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fujita/tgt/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=bb2a49130dd83310268af2eaa435f43be61d92a5bd22b9d360f7c751947f37b9
+PKG_HASH:=3584370a7e983404cac7782c6d35f36c75f01498fd2c5d01b3b5f74e66928b90
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_cortex-a53, Dynalink DL-WRX36, r28926+3-9a7192c08e
Run tested: aarch64_cortex-a53, Dynalink DL-WRX36, r28926+3-9a7192c08e in a chroot on r27697+4-d51353db26, exporting an image with ext4 fs works
Description:
