### PR TITLE
Fix for #25578: Ignore empty string from device metrics

### DIFF
--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/netclass.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/netclass.lua
@@ -33,7 +33,7 @@ local function get_metric(device, metric_node_network)
   local ifalias = load(device, "ifalias")
   metric_node_network.info({device = device, address = address, broadcast = broadcast, duplex = duplex, operstate = operstate, ifalias = ifalias}, 1)
   local speed = load(device, "speed")
-  if speed ~= nil and tonumber(speed) >= 0 then
+  if speed ~= nil and #speed > 0 and tonumber(speed) >= 0 then
     metric_node_network.speed_bytes({device = device}, tonumber(speed)*1000*1000/8)
   end
   local file_to_metric = {
@@ -56,7 +56,7 @@ local function get_metric(device, metric_node_network)
   }
   for file, metric in pairs(file_to_metric) do
     local value = load(device, file)
-    if value ~= nil then
+    if value ~= nil and #speed > 0 then
       metric_node_network[metric]({device = device}, tonumber(value))
     end
   end


### PR DESCRIPTION
Maintainer: @champtar 
Compile tested: RTL8382/RTL8380, D-Link DGS-1210-16 & DGS-1210-10MP F, OpenWrt 23.05.4 r24012-d8dd03c46f & 23.05.5 r24106-10cc5fcd00
Run tested: RTL8382/RTL8380, D-Link DGS-1210-16 & DGS-1210-10MP F, OpenWrt 23.05.4 r24012-d8dd03c46f & 23.05.5 r24106-10cc5fcd00, applied code changes directly to device and no longer experience errors.

Description:

Fix for issue #25578

Some devices return an empty string, which `tonumber` converts to `nil`, and which subsequently can't be rendered with `format` back to a string.

Originally `nil` caused a termination at /usr/lib/lua/prometheus-collectors/netclass.lua:36, but fixing that led to many failures at /usr/bin/prometheus-node-exporter-lua:42.

The fix was to prevent those empty values the same as preventing `nil` values.

