### PR TITLE
 zerotier: add patch to support miniupnpc 2.2.8

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
 PKG_VERSION:=1.14.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?

--- a/net/zerotier/patches/0006-add-support-for-miniupnpc-2.2.8.patch
+++ b/net/zerotier/patches/0006-add-support-for-miniupnpc-2.2.8.patch
@@ -1,0 +1,25 @@
+From a8cb9d188fabe750821661b5e34e9be467846283 Mon Sep 17 00:00:00 2001
+From: Moritz Warning <moritzwarning@web.de>
+Date: Mon, 3 Mar 2025 23:26:42 +0100
+Subject: [PATCH] add support for miniupnpc 2.2.8
+
+Signed-off-by: Moritz Warning <moritzwarning@web.de>
+---
+ osdep/PortMapper.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/osdep/PortMapper.cpp
++++ b/osdep/PortMapper.cpp
+@@ -230,7 +230,12 @@ public:
+ 					OSUtils::ztsnprintf(inport,sizeof(inport),"%d",localPort);
+ 
+ 					int foundValidIGD = 0;
++#if MINIUPNPC_API_VERSION < 18
+ 					if ((foundValidIGD = UPNP_GetValidIGD(devlist,&urls,&data,lanaddr,sizeof(lanaddr)))&&(lanaddr[0])) {
++#else
++					if ((foundValidIGD = UPNP_GetValidIGD(devlist,&urls,&data,lanaddr,sizeof(lanaddr),NULL,0))&&(lanaddr[0])) {
++#endif
++
+ #ifdef ZT_PORTMAPPER_TRACE
+                         PM_TRACE("PortMapper: UPnP: my LAN IP address: %s" ZT_EOL_S,lanaddr);
+ #endif


### PR DESCRIPTION
Maintainer: me
Compile tested: ramips/mt7620

Description: This hopefully fixes https://github.com/openwrt/openwrt/issues/18019, but I was not able to reproduce the problem myself.
