### PR TITLE
adblock: Fix initscript startup logic inversion

### DIFF
--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -20,7 +20,7 @@ adb_script="/usr/bin/adblock.sh"
 adb_pidfile="/var/run/adblock.pid"
 
 [ "${action}" = "boot" ] && "${adb_init}" running && exit 0
-[ -s "${adb_pidfile}" ] && { [ "${action}" = "start" ] || [ "${action}" = "stop" ] || [ "${action}" = "restart" ] || [ "${action}" = "reload" ] || [ "${action}" = "report" ] || [ "${action}" = "suspend" ] || [ "${action}" = "resume" ] || [ "${action}" = "query" ] || { [ "${action}" = "list" ] && [ -n "${1}" ]; }; } && exit 1
+[ -s "${adb_pidfile}" ] && ! { [ "${action}" = "start" ] || [ "${action}" = "stop" ] || [ "${action}" = "restart" ] || [ "${action}" = "reload" ] || [ "${action}" = "report" ] || [ "${action}" = "suspend" ] || [ "${action}" = "resume" ] || [ "${action}" = "query" ] || { [ "${action}" = "list" ] && [ -n "${1}" ]; }; } && exit 1
 
 boot() {
 	: >"${adb_pidfile}"


### PR DESCRIPTION
Maintainer: @dibdot
Compile tested: N/A
Run tested: mips_24kc, glinet,gl-ar750, 24.10.0 r28427-6df0e3d02a, ran `/etc/init.d/adblock restart`

Description:
It seems that a few (6) years back in bc299d0 the logic of testing the initscript invocation for a valid action got partially inverted. But the individual tests in a group were inverted without also inverting the result of the group to maintain the original logic.

Fixes: #26090