### PR TITLE
hev-socks5-tunnel: update to 2.9.1

### DIFF
--- a/net/hev-socks5-tunnel/Makefile
+++ b/net/hev-socks5-tunnel/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hev-socks5-tunnel
-PKG_VERSION:=2.7.5
+PKG_VERSION:=2.9.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/heiher/hev-socks5-tunnel/releases/download/$(PKG_VERSION)
-PKG_HASH:=a6dffa86d1a4f95025386a666628781415fb15e3d8e846d777e5a06086e5c769
+PKG_HASH:=60f029e1776caa5e8cf3d64d2f7448d034703a8d38a65cc6d14fad2face2b7ff
 
 PKG_MAINTAINER:=Ray Wang <r@hev.cc>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: armv8, 24.10
Run tested: armv8, 24.10, tests done

Description: update to 2.9.1