### PR TITLE
treewide: update to use SOURCE_VERSION for submodule download 

### DIFF
--- a/net/znc/Makefile
+++ b/net/znc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=znc
 PKG_VERSION:=1.9.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://znc.in/releases \
@@ -159,9 +159,9 @@ define playback
 endef
 
 define Download/znc-playback
-  VERSION:=8dd128bfe2b24b2cc6a9ea2e2d28bfaa28d2a833
+  SOURCE_VERSION:=8dd128bfe2b24b2cc6a9ea2e2d28bfaa28d2a833
   SUBDIR:=znc-mod-playback
-  FILE:=znc-playback-$$(VERSION).tar.xz
+  FILE:=znc-playback-$$(SOURCE_VERSION).tar.xz
   URL:=https://github.com/jpnurmi/znc-playback.git
   MIRROR_HASH:=ac89d69048d62c5b15f39cc0d357a111ce4053816062e7bc1e553392b36fbd71
   PROTO:=git
@@ -195,9 +195,9 @@ define push
 endef
 
 define Download/znc-push
-  VERSION:=23d84678de2696e0b1f51aa5074764d29a98d37b
+  SOURCE_VERSION:=23d84678de2696e0b1f51aa5074764d29a98d37b
   SUBDIR:=znc-mod-push
-  FILE:=znc-push-$$(VERSION).tar.xz
+  FILE:=znc-push-$$(SOURCE_VERSION).tar.xz
   URL:=https://github.com/amyreese/znc-push.git
   MIRROR_HASH:=b1ec076ee8a37b8ff8cb530852d7639fbfce3df4a963cae29375056382020394
   PROTO:=git

--- a/utils/crun/Makefile
+++ b/utils/crun/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crun
 PKG_VERSION:=1.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containers/crun/tar.gz/$(PKG_VERSION)?
@@ -37,7 +37,7 @@ LIBOCISPEC_COMMIT:=68211ccc41201c45ad276b04c7f67d61e80b1f7a
 define Download/libocispec
   PROTO:=git
   URL:=https://github.com/containers/libocispec.git
-  VERSION:=$(LIBOCISPEC_COMMIT)
+  SOURCE_VERSION:=$(LIBOCISPEC_COMMIT)
   MIRROR_HASH:=688d00600dbdf46d4b52acc8e43313b14471026ccff8c3cc5983e2f5dfd15571
   FILE:=libocispec-$(LIBOCISPEC_COMMIT).tar.xz
   SUBDIR:=libocispec


### PR DESCRIPTION
Commit https://github.com/openwrt/packages/commit/9fc79e2e262270470397f907704689915ec368b6 ("download: don't overwrite VERSION variable")
changed the variable for direct download call from VERSION to
SOURCE_VERSION.

This cause the dl_github_archive script to pass empty value for
--version arg making it always clone HEAD.

Correctly update the variable to SOURCE_VERSION to actually clone the
expected commit HASH.