### PR TITLE
sshtunnel.init support disable option

### DIFF
--- a/net/sshtunnel/files/sshtunnel.init
+++ b/net/sshtunnel/files/sshtunnel.init
@@ -42,7 +42,8 @@ validate_server_section() {
 		'StrictHostKeyChecking:or("yes", "no", "accept-new"):accept-new' \
 		'TCPKeepAlive:or("yes", "no")' \
 		'VerifyHostKeyDNS:or("yes", "no")' \
-		'ProxyCommand:string(1)'
+		'ProxyCommand:string(1)' \
+		'disable:or("yes", "no")'
 }
 
 validate_tunnelR_section() {
@@ -196,6 +197,10 @@ load_server() {
 	procd_set_param command "$PROG" $ARGS
 	# ProxyCommand must be quoted
 	[ -n "$ProxyCommand" ] && procd_append_param command -o "ProxyCommand=$ProxyCommand"
+
+	if [ "$disable" == "yes" ]; then
+		return 1
+	fi
 
 	procd_set_param stdout 1
 	procd_set_param stderr 1


### PR DESCRIPTION
Add in the configuration of the SSHTUNNEL package the support for disable option.

Maintainer: @nunojpg 
Compile tested: mips, x86_64
Run tested: TP-Link TL-WR802N v4, OpenWrt 24.10.0

Description:
Adds support for `option disable=yes` (or `option disable=no`). Useful when you have a lot of different tunnels.

Signed-off-by: Lars Theorin [lars18th@users.noreply.github.com](mailto:lars18th@users.noreply.github.com)
