### PR TITLE
chrony: enable support for non-MD5 keys in nts variant

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
 PKG_VERSION:=4.6.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://chrony-project.org/releases/
@@ -78,10 +78,10 @@ CONFIGURE_ARGS+= \
 	--sysconfdir=/etc/chrony \
 	--prefix=/usr \
 	--chronyrundir=/var/run/chrony \
-	$(if $(findstring normal,$(BUILD_VARIANT)),--disable-nts,--enable,nts) \
+	$(if $(findstring normal,$(BUILD_VARIANT)),--disable-nts) \
 	--disable-readline \
 	--disable-rtc \
-	--disable-sechash \
+	$(if $(findstring normal,$(BUILD_VARIANT)),--disable-sechash) \
 	--with-user=chrony
 
 CONFIGURE_VARS+=CPPFLAGS=-DNDEBUG


### PR DESCRIPTION
Maintainer: me
Compile tested: mipsel, Cudy WR1300, 24.10
Run tested: mipsel, Cudy WR1300, 24.10, configuration with AES128 key

Description:
gnutls and nettle are already required for NTS. Enable their use for authentication with non-MD5 symmetric keys as the SECHASH feature printed by the configure script.

Also drop the --enable,nts (typo) configure option. It's enabled by default.
