### PR TITLE
nginx: update to 1.26.3

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
-PKG_VERSION:=1.26.1
-PKG_RELEASE:=4
+PKG_VERSION:=1.26.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
-PKG_HASH:=f9187468ff2eb159260bfd53867c25ff8e334726237acf227b9e870e53d3e36b
+PKG_HASH:=69ee2b237744036e61d24b836668aad3040dda461fe6f570f1787eab570c75aa
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de> \
 				Christian Marangi <ansuelsmth@gmail.com>


### PR DESCRIPTION
Maintainer: @heil @Ansuel
Compile tested: compiled for Turris Omnia (compiled from current master as of creating this PR)
Run tested: Turris Omnia

Description:
Update NGINX to 1.26.3. Fixes [CVE-2025-23419](https://www.cve.org/CVERecord?id=CVE-2025-23419), so possibly worth backporting?