### PR TITLE
dockerd: fix build issue with custom core.abbrev value in .gitconfig

### DIFF
--- a/utils/dockerd/git-short-commit.sh
+++ b/utils/dockerd/git-short-commit.sh
@@ -39,7 +39,7 @@ git init --quiet "${GIT_DIR}"
 
 		if git fetch --depth 1 origin "${GIT_REF}"; then
 			git checkout --detach FETCH_HEAD --
-			git rev-parse --short HEAD
+			git rev-parse --short=7 HEAD
 			break
 		fi
 


### PR DESCRIPTION
As documented by "man git-rev-parse", the "--short" option shortens commit sha1sums to at least "length" characters, equal to core.abbrev if that is specified in ~/.gitconfig.

The development processes of some other open source projects require having a

[core]
	abbrev = 12

in the .gitconfig, which is incompatible with the way in which docker wants PKG_GIT_SHORT_COMMIT.

On my system, I get these errors:

```
  make[3]: Entering directory 'feeds/packages/utils/dockerd'
  (...)
  # Verify CLI is the same version
  ( CLI_MAKEFILE="../docker/Makefile"; CLI_VERSION=$( grep --only-matching --perl-regexp '(?<=PKG_VERSION:=)(.*)' "${CLI_MAKEFILE}" ); if [ "${CLI_VERSION}" != "27.3.1" ]; then echo "ERROR: Expected 'PKG_VERSION:=27.3.1' in '${CLI_MAKEFILE}', found 'PKG_VERSION:=${CLI_VERSION}'"; exit 1; fi )
  # Verify PKG_GIT_SHORT_COMMIT
  ( EXPECTED_PKG_GIT_SHORT_COMMIT=$( feeds/packages/utils/dockerd/git-short-commit.sh 'github.com/moby/moby' 'v27.3.1' 'tmp/git-short-commit/dockerd-27.3.1' ); if [ "${EXPECTED_PKG_GIT_SHORT_COMMIT}" != "41ca978" ]; then echo "ERROR: Expected 'PKG_GIT_SHORT_COMMIT:=${EXPECTED_PKG_GIT_SHORT_COMMIT}', found 'PKG_GIT_SHORT_COMMIT:=41ca978'"; exit 1; fi )
  Trying remote 'github.com/moby/moby'
  fatal: 'github.com/moby/moby' does not appear to be a git repository
  fatal: Could not read from remote repository.

  Please make sure you have the correct access rights
  and the repository exists.
  Trying remote 'https://github.com/moby/moby'
  remote: Enumerating objects: 11117, done.
  From https://github.com/moby/moby
   * tag                         v27.3.1    -> FETCH_HEAD
  HEAD is now at 41ca978a0a54 Merge pull request #48525 from thaJeztah/27.x_backport_govulncheck_permissions
  ERROR: Expected 'PKG_GIT_SHORT_COMMIT:=41ca978a0a54', found 'PKG_GIT_SHORT_COMMIT:=41ca978'
  make[3]: *** [Makefile:198: build_dir/target-aarch64_generic_glibc/dockerd-27.3.1/.prepared_d76b59f2eb81424899b1fbb9e44f77e2_6664517399ebbbc92a37c5bb081b5c53] Error 1
  make[3]: Leaving directory 'feeds/packages/utils/dockerd'
  time: package/feeds/packages/dockerd/compile#1.71#1.18#5.38
      ERROR: package/feeds/packages/dockerd failed to build.
```

Since --short supports a length argument, use that to break the dependency on the system .gitconfig.