### PR TITLE
[openwrt-23.05] rust: disable download ci llvm

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -75,7 +75,6 @@ HOST_CONFIGURE_ARGS = \
 	--release-channel=stable \
 	--enable-cargo-native-static \
 	--bootstrap-cache-path=$(DL_DIR)/rustc \
-	--set=llvm.download-ci-llvm=true \
 	$(TARGET_CONFIGURE_ARGS)
 
 define Host/Uninstall


### PR DESCRIPTION
Maintainer: @lu-zero 
Compile tested: rockchip/armv8
Run tested: n/a

Description:
Upstream removed CI builds for this (outdated) version.