### PR TITLE
ipmitool: disable FreeIPMI support

### DIFF
--- a/admin/ipmitool/Makefile
+++ b/admin/ipmitool/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ipmitool
 PKG_VERSION:=1.8.19
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://codeberg.org/IPMITool/ipmitool
@@ -50,7 +50,7 @@ CONFIGURE_ARGS += \
 	--enable-intf-lan \
 	--enable-intf-lanplus \
 	--enable-intf-serial \
-	--enable-intf-free \
+	--disable-intf-free \
 	--enable-intf-open \
 	--enable-intf-imb \
 	--enable-ipmishell


### PR DESCRIPTION
Maintainer: @neheb @ffontaine 
Compile tested: qualcommax/ipq807x, main
Run tested: None

Description:
Now that we are building FreeIPMI library ipmitool will detect it and since we are already passing --enable-intf-free it will build support for FreeIPMI as well.

However, --enable-intf-free was previously no-op since it would just fail to detect FreeIPMI and disable support for it but now it seems that buildbots build FreeIPMI first and then ipmitool will fail with missing dependency on FreeIPMI library.

Since FreeIPMI is quite big and previously ipmitool was built without support for it anyway lets disable support for FreeIPMI in ipmitool and if its required it can be made optional or as a package variant later.

This fixes building ipmitool via buildbots again.