### PR TITLE
htop: fix executable

### DIFF
--- a/admin/htop/Makefile
+++ b/admin/htop/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=htop
 PKG_VERSION:=3.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/htop-dev/htop/tar.gz/$(PKG_VERSION)?
@@ -55,6 +55,8 @@ define Package/htop/config
 			Users wanting this functionality need to
 			install libsensors.
 endef
+
+export CURSES_LIBS=-lncurses
 
 CONFIGURE_ARGS += \
 	--$(if $(CONFIG_HTOP_LMSENSORS),en,dis)able-sensors \


### PR DESCRIPTION
Upstream changes causes configure to miss setup from the ncurses6-config utility. The new configure picks up the ncurses6-config information and somehow the new linker flags breaks htop execution. Bug observed on x86/64 and might affect others as well.

Example executing htop-3.4.0-r1:
```
% htop
Error opening terminal: xterm-256color.
```
This commit overrides CURSES_LIBS when running configure. This ignores the two additional library search directories from the build machine.

Reference: https://github.com/htop-dev/htop/issues/1636

Build system: x86/64
Build-tested: x86/64
Run-tested: x86/64

Maintainer: @champtar