### PR TITLE
lxc: add two files to default backup list

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -103,6 +103,11 @@ define Package/lxc-unprivileged/install
 	$(INSTALL_DATA) ./files/lxc-unprivileged.defaults $(1)/etc/uci-defaults/lxc-unprivileged
 endef
 
+define Package/lxc-unprivileged/conffiles
+/etc/subgid
+/etc/subuid
+endef
+
 define Package/lxc/config
   source "$(SOURCE)/Config.in"
 endef


### PR DESCRIPTION
Users running unprivileged containers will need to create /etc/subgid and /etc/subuid and want to have them preserved across updates. This commit adds them to the default backup set.

Maintainer: @ratkaj