### PR TITLE
bcm27xx-eeprom: update to v2025-02-12-2712

### DIFF
--- a/utils/bcm27xx-eeprom/Makefile
+++ b/utils/bcm27xx-eeprom/Makefile
@@ -5,9 +5,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/raspberrypi/rpi-eeprom
-PKG_SOURCE_DATE:=2024-11-12
-PKG_SOURCE_VERSION:=eefb7b83bc9b602455d9eaf34a51149a6e9cca96
-PKG_MIRROR_HASH:=336aba0c35cc5644a45510aff161b08c4400c1345486b44bc526c8b37a81463c
+PKG_SOURCE_DATE:=2025-02-12
+PKG_SOURCE_VERSION:=c954a72f6301b8ac0fc4b0fe252e1c5024d2862b
+PKG_MIRROR_HASH:=fb45c5d65c70dc7b68c8b63ab2641706e44a54042c6817d7a9167c55d51f3794
 
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 PKG_LICENSE:=BSD-3-Clause Custom
@@ -76,7 +76,7 @@ define Package/bcm2711-eeprom/install
 	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader-2711
-	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/pieeprom-2024-10-21.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
+	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/pieeprom-2025-02-11.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/recovery.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/vl805-000138c0.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 endef
@@ -86,7 +86,7 @@ define Package/bcm2712-eeprom/install
 	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
 
 	$(CP) $(PKG_BUILD_DIR)/firmware-2712/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader-2712
-	$(CP) $(PKG_BUILD_DIR)/firmware-2712/latest/pieeprom-2024-11-12.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
+	$(CP) $(PKG_BUILD_DIR)/firmware-2712/latest/pieeprom-2025-02-12.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
 	$(CP) $(PKG_BUILD_DIR)/firmware-2712/latest/recovery.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
 endef
 

--- a/utils/bcm27xx-eeprom/patches/0001-rpi-eeprom-update-OpenWrt-defaults.patch
+++ b/utils/bcm27xx-eeprom/patches/0001-rpi-eeprom-update-OpenWrt-defaults.patch
@@ -14,7 +14,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 
 --- a/rpi-eeprom-update
 +++ b/rpi-eeprom-update
-@@ -25,7 +25,7 @@ fi
+@@ -27,7 +27,7 @@ fi
  
  # Selects the release sub-directory
  FIRMWARE_RELEASE_STATUS=${FIRMWARE_RELEASE_STATUS:-default}
@@ -27,9 +27,10 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 +++ b/rpi-eeprom-update-default
 @@ -1,7 +1,7 @@
  
- FIRMWARE_ROOT=/lib/firmware/raspberrypi/bootloader
+-FIRMWARE_ROOT=/usr/lib/firmware/raspberrypi/bootloader
 -FIRMWARE_RELEASE_STATUS="default"
 -FIRMWARE_BACKUP_DIR="/var/lib/raspberrypi/bootloader/backup"
++FIRMWARE_ROOT=/lib/firmware/raspberrypi/bootloader
 +FIRMWARE_RELEASE_STATUS="latest"
 +FIRMWARE_BACKUP_DIR="${FIRMWARE_ROOT}/backup"
  EEPROM_CONFIG_HOOK=

--- a/utils/bcm27xx-eeprom/patches/0002-rpi-eeprom-update-change-default-include-path.patch
+++ b/utils/bcm27xx-eeprom/patches/0002-rpi-eeprom-update-change-default-include-path.patch
@@ -24,7 +24,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  fi
  
  LOCAL_MODE=0
-@@ -439,7 +439,7 @@ checkDependencies() {
+@@ -466,7 +466,7 @@ checkDependencies() {
        echo "Run with -h for more information."
        echo
        echo "To enable flashrom programming of the EEPROM"
@@ -33,7 +33,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
        echo "RPI_EEPROM_USE_FLASHROM=1"
        echo "CM4_ENABLE_RPI_EEPROM_UPDATE=1"
        echo 
-@@ -526,7 +526,7 @@ The system should then boot normally.
+@@ -553,7 +553,7 @@ The system should then boot normally.
  
  If /boot does not correspond to the boot partition and this
  is not a NOOBS system, then the mount point for BOOTFS should be defined
@@ -42,7 +42,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  
  A backup of the current EEPROM config file is written to ${FIRMWARE_BACKUP_DIR}
  before applying the update.
-@@ -558,7 +558,7 @@ Options:
+@@ -585,7 +585,7 @@ Options:
     -u Install the specified VL805 (USB EEPROM) image file.
  
  Environment:
@@ -51,7 +51,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  
  EEPROM_CONFIG_HOOK
  
-@@ -630,7 +630,7 @@ must first be enabled by removing ENABLE
+@@ -657,7 +657,7 @@ must first be enabled by removing ENABLE
  via usbboot.
  
  After enabling self-update set the CM4_ENABLE_RPI_EEPROM_UPDATE=1 environment

--- a/utils/bcm27xx-eeprom/patches/0003-rpi-eeprom-update-chmod-silent-f-is-not-supported.patch
+++ b/utils/bcm27xx-eeprom/patches/0003-rpi-eeprom-update-chmod-silent-f-is-not-supported.patch
@@ -13,7 +13,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 
 --- a/rpi-eeprom-update
 +++ b/rpi-eeprom-update
-@@ -220,7 +220,7 @@ applyRecoveryUpdate()
+@@ -248,7 +248,7 @@ applyRecoveryUpdate()
                  || die "Failed to copy ${TMP_EEPROM_IMAGE} to ${BOOTFS}"
  
          # For NFS mounts ensure that the files are readable to the TFTP user
@@ -22,7 +22,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
                  || die "Failed to set permissions on eeprom update files"
     fi
  
-@@ -231,7 +231,7 @@ applyRecoveryUpdate()
+@@ -259,7 +259,7 @@ applyRecoveryUpdate()
                  || die "Failed to copy ${VL805_UPDATE_IMAGE} to ${BOOTFS}/vl805.bin"
  
          # For NFS mounts ensure that the files are readable to the TFTP user

--- a/utils/bcm27xx-eeprom/patches/0004-rpi-eeprom-config-replace-nano-with-vi-as-default-ed.patch
+++ b/utils/bcm27xx-eeprom/patches/0004-rpi-eeprom-config-replace-nano-with-vi-as-default-ed.patch
@@ -13,7 +13,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 
 --- a/rpi-eeprom-config
 +++ b/rpi-eeprom-config
-@@ -186,8 +186,8 @@ def edit_config(eeprom=None):
+@@ -184,8 +184,8 @@ def edit_config(eeprom=None):
      """
      Implements something like 'git commit' for editing EEPROM configs.
      """
@@ -24,7 +24,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
      if 'EDITOR' in os.environ:
          editor = os.environ['EDITOR']
  
-@@ -517,7 +517,7 @@ Operating modes:
+@@ -515,7 +515,7 @@ Operating modes:
  
     To cancel the pending update run 'sudo rpi-eeprom-update -r'
  


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64
Run tested: bcm27xx/bcm2712

Description: Update bcm27xx-eeprom to v2025-02-12-2712

bcm2711:
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2711/release-notes.md#2024-12-07-enable-banklow-and-so-numa-by-default-latest
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2711/release-notes.md#2024-12-07-enable-banklow-and-so-numa-by-default-latest
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2711/release-notes.md#2025-02-11-recovery-walk-partitions-to-delete-recoverybin-latest

bcm2712:
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2712/release-notes.md#2024-11-27-rp1fw-add-fifo_state--drain_tx-fix-can_add_program-default
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2712/release-notes.md#2024-12-07-enable-banklow-and-so-numa-by-default-latest
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2712/release-notes.md#2024-12-15-add-net-install-to-boot-menu-latest
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2712/release-notes.md#2024-12-19-disable-fan-pwm-before-shutdown-latest
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2712/release-notes.md#2025-01-06-stop-the-fan-after-after-fan-probe-latest
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2712/release-notes.md#2025-01-07-fixup-m2-hat-detection-latest
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2712/release-notes.md#2025-01-08-update-sdram-refresh-timings-for-bcm2712d0-products-latest
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2712/release-notes.md#2025-01-13-improved-sdram-refresh-timings-for-pi5-16gb-latest
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2712/release-notes.md#2025-01-14-add-set_reboot_order-api-latest
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2712/release-notes.md#2025-01-22-add-dt-chosen-property-signed-boot-bootimg-hash-latest
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2712/release-notes.md#2025-01-27-walk-the-partition-table-if-the-requested-partition-is-not-bootable-latest
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2712/release-notes.md#2025-02-11-cm5-no-wifi-stability-improvements-latest
- https://github.com/raspberrypi/rpi-eeprom/blob/v2025.02.12-2712/firmware-2712/release-notes.md#2025-02-12-fixup-change-to-disable-37v-pmic-output-on-cm5-no-wifi-latest

Full changelog: https://github.com/raspberrypi/rpi-eeprom/compare/v2024.11.12-2712...v2025.02.12-2712