### PR TITLE
libdaq3: update to 3.0.19

### DIFF
--- a/libs/libdaq3/Makefile
+++ b/libs/libdaq3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdaq3
-PKG_VERSION:=3.0.18
+PKG_VERSION:=3.0.19
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -18,7 +18,7 @@ PKG_LICENSE_FILES:=COPYING LICENSE
 
 PKG_SOURCE:=libdaq-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/snort3/libdaq/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=301db00d33ccd7be546ffb40cd9f4fc41031a5d67196b48bd8b76ae36e10f078
+PKG_HASH:=28d026de46f8206b1a74dd6bf7de10ca19d7a7c95a463744b9f79e51958e5889
 PKG_BUILD_DIR:=$(BUILD_DIR)/libdaq-$(PKG_VERSION)
 
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Update to latest version.

Changelog: https://github.com/snort3/libdaq/releases/tag/v3.0.19

Maintainer: @flyn-org 