### PR TITLE
adguardhome: backport updates to 24.10 branch

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -18,7 +18,7 @@ PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_MAINTAINER:=Dobroslaw Kijowski <dobo90@gmail.com>
 
-PKG_BUILD_DEPENDS:=golang/host node/host node-yarn/host
+PKG_BUILD_DEPENDS:=golang/host node/host
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
@@ -56,7 +56,7 @@ endef
 define Build/Compile
 	( \
 		pushd $(PKG_BUILD_DIR) ; \
-		NODE_OPTIONS=--openssl-legacy-provider make js-deps js-build ; \
+		make js-deps js-build ; \
 		popd ; \
 		$(call GoPackage/Build/Compile) ; \
 	)

--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
-PKG_VERSION:=0.107.56
+PKG_VERSION:=0.107.57
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/AdGuardHome/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=e4285c8d7611fe677e45dad469fbc0237ebeea57094148a059edd5aa32ab8fce
+PKG_HASH:=9df951486dab0e83485b596c0393f91d4ff2994de26101b43af8344efb7c1536
 PKG_BUILD_DIR:=$(BUILD_DIR)/AdGuardHome-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-3.0-only


### PR DESCRIPTION
Maintainer: @dobo90 @1715173329 @Ra2-IFV @p-w-p
Compile tested: mediatek/filogic 24.10.0

- Tested both with and without #26116 

Run tested: mediatek/filogic, 24.10.0, Zyxel EX5601-T0 ubootmod (T-56)

- all files are installed correctly
- service starts
- web UI loads with the existing config and displays the updated version
- DNS keeps resolving

Description:

This is a backport of #26131 from master to 24.10 branch (commits marked as cherry-picked)

- bump Adguard Home version to 0.107.57
- remove unnecessary `node-yarn/host` (replaced with npm upstream) as per [AdguardTeam/AdGuardHome@1afe226](https://github.com/AdguardTeam/AdGuardHome/commit/1afe226ce8f8af179e1eacccf4cdd63823f0c358#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R210-L211)
- remove unnecessary `NODE_OPTIONS=--openssl-legacy-provider` (since Node.js 18.x) as per [AdguardTeam/AdGuardHome@1afe226](https://github.com/AdguardTeam/AdGuardHome/commit/1afe226ce8f8af179e1eacccf4cdd63823f0c358#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L223-L230)