### PR TITLE
net/arp-scan: Disable promiscuous mode

### DIFF
--- a/net/arp-scan/Makefile
+++ b/net/arp-scan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=arp-scan
 PKG_VERSION:=1.10.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/royhills/arp-scan/tar.gz/$(PKG_VERSION)?

--- a/net/arp-scan/patches/001-Disable-promiscuous-mode.patch
+++ b/net/arp-scan/patches/001-Disable-promiscuous-mode.patch
@@ -1,0 +1,52 @@
+From 51311e645e3deb9917cafcaac3a430c614769ad4 Mon Sep 17 00:00:00 2001
+From: Roy Hills <royhills@hotmail.com>
+Date: Sat, 4 Feb 2023 12:21:40 +0000
+Subject: [PATCH] Disable promiscuous mode (#142)
+
+* Disable promiscuous mode
+
+* Update ChangeLog and NEWS.md
+---
+ ChangeLog  | 6 ++++++
+ NEWS.md    | 1 +
+ arp-scan.h | 2 +-
+ 3 files changed, 8 insertions(+), 1 deletion(-)
+
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,9 @@
++2023-02-04 Roy Hills <royhills@hotmail.com>
++
++	* arp-scan.h: Disable promiscuous mode on the network interface.
++	  Promiscuous mode is not required to receive ARP response packets
++	  because they are unicast packets directed to the scanning host.
++
+ 2022-12-10 Roy Hills <royhills@hotmail.com>
+ 
+ 	* configure.ac: Set version to 1.10.0.
+--- a/NEWS.md
++++ b/NEWS.md
+@@ -1,6 +1,12 @@
+ **This file gives a brief overview of the major changes between each arp-scan
+ release.  For more details please read the ChangeLog file.**
+ 
++# 2023-02-26 arp-scan 1.10.1-git (in development)
++
++* Fixed Bugs:
++
++  - Do not enable promiscuous mode on the network interface as it is not needed.
++
+ # 2022-12-10 arp-scan 1.10.0 (git tag 1.10.0)
+ 
+ ## New Features
+--- a/arp-scan.h
++++ b/arp-scan.h
+@@ -144,7 +144,7 @@
+ #define DEFAULT_RETRY 2                 /* Default number of retries */
+ #define DEFAULT_TIMEOUT 500             /* Default per-host timeout in ms */
+ #define SNAPLEN 64			/* 14 (ether) + 28 (ARP) + extra */
+-#define PROMISC 1			/* Enable promiscuous mode */
++#define PROMISC 0			/* Promiscuous mode 0=off, 1=on */
+ #define TO_MS 1000			/* Timeout for pcap_set_timeout() */
+ #define OPTIMISE 1			/* Optimise pcap filter */
+ #define ARPHRD_ETHER 1			/* Ethernet ARP type */


### PR DESCRIPTION
Maintainer: @PolynomialDivision @neheb @feckert 
Compile tested: mediatek/filogic, latest master
Run tested: mediatek/filogic, latest master

Description:
If you run the arp-scan tool cyclically, the kernel messages for promiscuous mode are very annoying.

This backports an upstream patch to disable the unnecessary promiscuous mode in arp-scan.
