### PR TITLE
stress-ng: bump to version 0.18.11

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.18.07
+PKG_VERSION:=0.18.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ColinIanKing/stress-ng/tar.gz/refs/tags/V$(PKG_VERSION)?
-PKG_HASH:=e2adaab67a70f4f98863d88d92e5805a31adce4559de52419e4f556e2ddeada6
+PKG_HASH:=f4388c4d4d53172431cd77e029139ddd0dacb249ef59053dbc1f0c42188e3e35
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only
@@ -19,6 +19,8 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+# For MIPS there is some inline assembly, and this won't compile without '-mno-mips16'
+PKG_BUILD_FLAGS:=no-mips16
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Maintainer: me
Compile tested: master, x86
Run tested: : master, x86
