### PR TITLE
coreutils: Repair package definition MENU:=1 is not effective

### DIFF
--- a/utils/coreutils/Makefile
+++ b/utils/coreutils/Makefile
@@ -82,7 +82,6 @@ endef
 
 define Package/coreutils
   $(call Package/coreutils/Default)
-  TITLE:=The GNU core utilities
   MENU:=1
 endef
 


### PR DESCRIPTION
Package definition MENU:=1 is not effective

![not work now](https://github.com/user-attachments/assets/2096097c-d954-49f0-8872-88a8c30252fc)
![work1](https://github.com/user-attachments/assets/1b8920a0-ce99-4edb-b958-d61e27a9d6e7)
![work2](https://github.com/user-attachments/assets/951e3d05-3458-4f12-83ed-1c6e04d6eea2)

