### PR TITLE
htop: tell which variant of ncurses to look for

### DIFF
--- a/admin/htop/Makefile
+++ b/admin/htop/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=htop
 PKG_VERSION:=3.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/htop-dev/htop/tar.gz/$(PKG_VERSION)?
@@ -63,7 +63,8 @@ CONFIGURE_ARGS += \
 	--disable-delayacct \
 	--disable-unicode \
 	--disable-unwind \
-	--disable-hwloc
+	--disable-hwloc \
+	--with-curses=ncursesw
 
 CONFIGURE_VARS += \
 	ac_cv_file__proc_stat=yes \


### PR DESCRIPTION
Maintainer: @champtar 
Compile tested: qualcommax/ipq807x, DL-WRX36, r28979+3-9a79cdc7ee
Run tested: qualcommax/ipq807x, DL-WRX36, r28979+3-9a79cdc7ee, htop starts, no more complaints on the terminal type

Description:
Without this hint it finds hostpkg version of ncurses and compiles it in statically
Cc: @graysky2 @Explorer09
This is an alternative to #26137, I'm posting it mostly to verify it with GH build checks.