### PR TITLE
protobuf: Set tar flags --no-same-owner

### DIFF
--- a/libs/protobuf/Makefile
+++ b/libs/protobuf/Makefile
@@ -26,6 +26,8 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk
 
+TAR_OPTIONS+= --no-same-owner
+
 define Package/protobuf/Default
   SECTION:=libs
   CATEGORY:=Libraries


### PR DESCRIPTION
Maintainer: Ken Keys / @kenkeys (find it by checking history of the package Makefile)
Compile tested:  x86_64 / master on 3/19/2025
Run tested: /
Description:
When building OpenWRT as root (occurs when building in docker) tar tries to preserve file permissions when extracting the source. Protobuf source is owned by its publishers, trying to change its ownership ended up failing the build. 
```
tar: protobuf-3.17.3/WORKSPACE: Cannot change ownership to uid 576694, gid 89939: Invalid argument
...
```
This commit mitigates the issue by not retaining original file permission when extracting the source.
