### PR TITLE
curl: add new option HTTP AUTH

### DIFF
--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -175,4 +175,7 @@ config LIBCURL_NTLM
 	depends on LIBCURL_CRYPTO_AUTH && !LIBCURL_NOSSL
 	default n
 
+config LIBCURL_HTTP_AUTH
+	bool "Enable HTTP authentication support"
+	default n
 endif

--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=8.12.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \
@@ -62,6 +62,7 @@ PKG_CONFIG_DEPENDS:= \
   \
   CONFIG_LIBCURL_COOKIES \
   CONFIG_LIBCURL_CRYPTO_AUTH \
+  CONFIG_LIBCURL_HTTP_AUTH \
   CONFIG_LIBCURL_LIBCURL_OPTION \
   CONFIG_LIBCURL_PROXY \
   CONFIG_LIBCURL_THREADED_RESOLVER \
@@ -158,6 +159,7 @@ CONFIGURE_ARGS += \
 	\
 	$(call autoconf_bool,CONFIG_LIBCURL_COOKIES,cookies) \
 	$(call autoconf_bool,CONFIG_LIBCURL_CRYPTO_AUTH,crypto-auth) \
+	$(call autoconf_bool,CONFIG_LIBCURL_HTTP_AUTH,http-auth) \
 	$(call autoconf_bool,CONFIG_LIBCURL_LIBCURL_OPTION,libcurl-option) \
 	$(call autoconf_bool,CONFIG_LIBCURL_PROXY,proxy) \
 	$(call autoconf_bool,CONFIG_LIBCURL_THREADED_RESOLVER,threaded-resolver) \


### PR DESCRIPTION
Maintainer: @1715173329 @hnyman 
Compile tested: x86_64, APU3, latest version
Run tested: x86_64 and lantiq_xrx200, APU3, connect to a server with digest auth requirements

Description:

The '--enable-http-auth' compile option in cURL is used to enable support for HTTP authentication methods. This option allows cURL to handle various authentication schemes, such as Basic, Digest, NTLM, and others, which are commonly used in HTTP requests to secure access to resources.

This cURL compile option is default disabled. This should at least be enabled as a compile option in OpenWrt so that it can be switched on if needed.
