### PR TITLE
knot: update to version 3.4.5

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.4.4
+PKG_VERSION:=3.4.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=e7d9d6de97f21bf33e907bd986a4038025f394879af0a5fd19787203ac3b2131
+PKG_HASH:=359af70afafa7ccaa18439a7c1eb35270ff9eece81d0756ae4ca716b1433cb4b
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 8.0.0 (hbl)
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 8.0.0 (hbl)

Description:

- Release upgrade (https://www.knot-dns.cz/2025-03-18-version-345.html)