### PR TITLE
[23.05] pptpd: Fix secrets update

### DIFF
--- a/net/pptpd/Makefile
+++ b/net/pptpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pptpd
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/poptop

--- a/net/pptpd/files/pptpd.init
+++ b/net/pptpd/files/pptpd.init
@@ -62,6 +62,7 @@ setup_config() {
 start_service() {
 	config_load pptpd
 	validate_pptpd_section pptpd setup_config || return
+	sed -i -E "/^\w+\s+pptp-server\s+.+$/d" $CHAP_SECRETS
 	config_foreach validate_login_section login setup_login
 
 	ln -sfn $CHAP_SECRETS /etc/ppp/chap-secrets


### PR DESCRIPTION
Backported from master

Clear pptp-server existing logins from CHAP_SECRETS file before adding new login data.

Maintainer: None
Compile tested: mipsel_24kc, ramips/mt7621,mikrotik,routerboard-760igs, MikroTik RouterBOARD 760iGS, OpenWrt 22.03.6 r20265-f85a79bcb4
Run tested: mipsel_24kc, ramips/mt7621,mikrotik,routerboard-760igs, MikroTik RouterBOARD 760iGS, OpenWrt 22.03.6 r20265-f85a79bcb4

Description:
The init script only adds information to the CHAP_SECRETS file. When reloading/restarting the pptpd service the CHAP_SECRETS init script duplicates existing and kept logins and does not delete the removed data because the CHAP_SECRETS file is never cleaned.
This change add a sed line that cleans only all "pptp-server" entries from CHAP_SECRETS before adding the current logins, therefore removing the bad behavior.
