### PR TITLE
acme-common: fix service startup on boot

### DIFF
--- a/net/acme-common/Makefile
+++ b/net/acme-common/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-common
-PKG_VERSION:=1.4.2
+PKG_VERSION:=1.4.3
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/acme-common/files/acme.init
+++ b/net/acme-common/files/acme.init
@@ -160,6 +160,6 @@ service_triggers() {
 }
 
 boot() {
-        mkdir -p "$CHALLENGE_DIR"
-        return 0
+	mkdir -p "$CHALLENGE_DIR"
+	start "$@"
 }


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: no (script change)
Run tested: yes

Description:
The return 0 in the boot section prevented the service from starting, even when enabled. This fix ensures the service starts properly on boot.