### PR TITLE
coreutils: Add PKG_FIXUP:=autoreconf and bump PKG_RELEASE

### DIFF
--- a/utils/coreutils/Makefile
+++ b/utils/coreutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coreutils
 PKG_VERSION:=9.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/coreutils
@@ -22,6 +22,7 @@ PKG_CPE_ID:=cpe:/a:gnu:coreutils
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
This fixes the build on GCC 14 and solves issue https://github.com/openwrt/packages/issues/26175

Maintainer: @hnyman
Compile tested: x86/64, QEMU Standard PC (Q35 + ICH9, 2009), r29064-696ad7b1aa09
Compile tested: ath79/generic, TP-Link Archer C7 v4, r29064-696ad7b1aa09
Compile tested: realtek/rtl838x, Netgear GS108T v3, r29064-696ad7b1aa09
Run tested: x86/64, QEMU Standard PC (Q35 + ICH9, 2009), r29064-696ad7b1aa09, booted and used for 7h without issues
Run tested: ath79/generic, TP-Link Archer C7 v4, r29064-696ad7b1aa09, booted and used for 7h without issues
Run tested: realtek/rtl838x, Netgear GS108T v3, r29064-696ad7b1aa09, booted and used for 7h without issues

Signed-off-by: Pascal Ernster <git@hardfalcon.net>