### PR TITLE
gnutls: Update to version 3.8.9

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
-PKG_VERSION:=3.8.5
+PKG_VERSION:=3.8.9
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.8
-PKG_HASH:=66269a2cfe0e1c2dabec87bdbbd8ab656f396edd9a40dd006978e003cfa52bfc
+PKG_HASH:=69e113d802d1670c4d5ac1b99040b1f2d5c7c05daec5003813c049b5184820ed
 
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <nmav@gnutls.org>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/libs/gnutls/patches/010-m4.patch
+++ b/libs/gnutls/patches/010-m4.patch
@@ -1,6 +1,6 @@
 --- a/m4/stdint.m4
 +++ b/m4/stdint.m4
-@@ -15,7 +15,7 @@ AC_DEFUN_ONCE([gl_STDINT_H],
+@@ -17,7 +17,7 @@ AC_DEFUN_ONCE([gl_STDINT_H],
    AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
  
    AC_REQUIRE([gl_LIMITS_H])
@@ -11,47 +11,47 @@
    dnl macros.
 --- a/m4/vasnprintf.m4
 +++ b/m4/vasnprintf.m4
-@@ -33,7 +33,7 @@ AC_DEFUN([gl_REPLACE_VASNPRINTF],
+@@ -75,7 +75,7 @@ AC_DEFUN([gl_FUNC_VASNWPRINTF],
+ # Prerequisites of lib/printf-args.h, lib/printf-args.c.
  AC_DEFUN([gl_PREREQ_PRINTF_ARGS],
  [
-   AC_REQUIRE([gt_TYPE_WCHAR_T])
 -  AC_REQUIRE([gt_TYPE_WINT_T])
 +  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
  ])
  
  # Prerequisites of lib/printf-parse.h, lib/printf-parse.c.
-@@ -41,7 +41,7 @@ AC_DEFUN([gl_PREREQ_PRINTF_PARSE],
+@@ -83,7 +83,7 @@ AC_DEFUN([gl_PREREQ_PRINTF_ARGS],
+ AC_DEFUN([gl_PREREQ_PRINTF_PARSE],
  [
    AC_REQUIRE([gl_FEATURES_H])
-   AC_REQUIRE([gt_TYPE_WCHAR_T])
 -  AC_REQUIRE([gt_TYPE_WINT_T])
 +  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
    AC_REQUIRE([AC_TYPE_SIZE_T])
    AC_CHECK_TYPE([ptrdiff_t], ,
      [AC_DEFINE([ptrdiff_t], [long],
-@@ -55,7 +55,7 @@ AC_DEFUN_ONCE([gl_PREREQ_VASNPRINTF],
+@@ -216,7 +216,7 @@ int main()
+ AC_DEFUN_ONCE([gl_PREREQ_VASNXPRINTF],
  [
    AC_REQUIRE([AC_FUNC_ALLOCA])
-   AC_REQUIRE([gt_TYPE_WCHAR_T])
 -  AC_REQUIRE([gt_TYPE_WINT_T])
 +  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
-   AC_CHECK_FUNCS([snprintf strnlen wcslen wcsnlen mbrtowc wcrtomb])
-   dnl Use the _snprintf function only if it is declared (because on NetBSD it
-   dnl is defined as a weak alias of snprintf; we prefer to use the latter).
---- a/m4/wchar_t.m4
-+++ b/m4/wchar_t.m4
-@@ -8,7 +8,7 @@ dnl From Bruno Haible.
- dnl Test whether <stddef.h> has the 'wchar_t' type.
- dnl Prerequisite: AC_PROG_CC
+   AC_CHECK_FUNCS([wcslen])
+   dnl Knowing DBL_EXPBIT0_WORD and DBL_EXPBIT0_BIT enables an optimization
+   dnl in the code for NEED_PRINTF_LONG_DOUBLE || NEED_PRINTF_DOUBLE.
+--- a/m4/wchar_h.m4
++++ b/m4/wchar_h.m4
+@@ -28,7 +28,7 @@ AC_DEFUN_ONCE([gl_WCHAR_H],
  
--AC_DEFUN([gt_TYPE_WCHAR_T],
-+AC_DEFUN([gt_TYPE_WCHAR_T_GNUTLS],
- [
-   AC_CACHE_CHECK([for wchar_t], [gt_cv_c_wchar_t],
-     [AC_COMPILE_IFELSE(
+   AC_REQUIRE([gl_FEATURES_H])
+ 
+-  AC_REQUIRE([gt_TYPE_WINT_T])
++  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
+   if test $gt_cv_c_wint_t = yes; then
+     HAVE_WINT_T=1
+   else
 --- a/m4/wint_t.m4
 +++ b/m4/wint_t.m4
-@@ -9,7 +9,7 @@ dnl Test whether <wchar.h> has the 'wint
+@@ -11,7 +11,7 @@ dnl Test whether <wchar.h> has the 'wint
  dnl <wchar.h> or <wctype.h> would, if present, override 'wint_t'.
  dnl Prerequisite: AC_PROG_CC
  
@@ -62,12 +62,12 @@
      [AC_COMPILE_IFELSE(
 --- a/src/gl/m4/gnulib-comp.m4
 +++ b/src/gl/m4/gnulib-comp.m4
-@@ -1268,7 +1268,7 @@ changequote([, ])dnl
-   gl_UNISTD_MODULE_INDICATOR([sleep])
+@@ -1440,7 +1440,7 @@ changequote([, ])dnl
    AC_CHECK_DECLS_ONCE([alarm])
-   AC_REQUIRE([gt_TYPE_WCHAR_T])
+   gl_SNAN
+   gl_NAN_MIPS
 -  AC_REQUIRE([gt_TYPE_WINT_T])
 +  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
-   gl_FUNC_STRERROR_R
-   AS_IF([test $HAVE_DECL_STRERROR_R = 0 || test $REPLACE_STRERROR_R = 1], [
-     AC_LIBOBJ([strerror_r])
+   gl_DOUBLE_EXPONENT_LOCATION
+   gl_STRING_MODULE_INDICATOR([str_endswith])
+   gl_STRING_MODULE_INDICATOR([str_startswith])

--- a/libs/gnutls/patches/020-dont-install-m4-files.patch
+++ b/libs/gnutls/patches/020-dont-install-m4-files.patch
@@ -21,5 +21,5 @@ Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
 -ACLOCAL_AMFLAGS = -I m4 -I src/gl/m4 -I lib/unistring/m4 --install
 +ACLOCAL_AMFLAGS = -I m4 -I src/gl/m4 -I lib/unistring/m4
  
- EXTRA_DIST = cfg.mk maint.mk CONTRIBUTING.md README.md LICENSE AUTHORS NEWS \
+ EXTRA_DIST = cfg.mk maint.mk CONTRIBUTING.md README.md COPYING.LESSERv2 COPYING AUTHORS NEWS \
  	ChangeLog THANKS INSTALL.md RELEASES.md .mailmap

--- a/libs/gnutls/patches/030-unistring-optional.patch
+++ b/libs/gnutls/patches/030-unistring-optional.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -508,6 +508,8 @@ DEFAULT_VALGRINDFLAGS='-q --error-exitco
+@@ -540,6 +540,8 @@ DEFAULT_VALGRINDFLAGS='-q --error-exitco
  
  gl_VALGRIND_TESTS_DEFAULT_NO
  


### PR DESCRIPTION
All patches refreshed.

Verbatim copy from upstream's NEWS file:

* Version 3.8.9 (released 2025-02-07)

** libgnutls: leancrypto was added as an interim option for PQC
   The library can now be built with leancrypto instead of liboqs for
   post-quantum cryptography (PQC), when configured with
   --with-leancrypto option instead of --with-liboqs.

** libgnutls: Experimental support for ML-DSA signature algorithm
   The library and certtool now support ML-DSA signature algorithm as
   defined in FIPS 204 and based on
   draft-ietf-lamps-dilithium-certificates-04. This feature is
   currently marked as experimental and can only be enabled when
   compiled with --with-leancrypto or --with-liboqs.
   Contributed by David Dudas.

** libgnutls: Support for ML-KEM-1024 key encapsulation mechanism
   The support for ML-KEM post-quantum key encapsulation mechanisms
   has been extended to cover ML-KEM-1024, in addition to ML-KEM-768.
   MLKEM1024 is only offered as SecP384r1MLKEM1024 hybrid as per
   draft-kwiatkowski-tls-ecdhe-mlkem-03.

** libgnutls: Fix potential DoS in handling certificates with numerous name
   constraints, as a follow-up of CVE-2024-12133 in libtasn1. The
   bundled copy of libtasn1 has also been updated to the latest 4.20.0
   release to complete the fix.  Reported by Bing Shi (#1553).
   [GNUTLS-SA-2025-02-07, CVSS: medium] [CVE-2024-12243]

** API and ABI modifications:
GNUTLS_PK_MLDSA44: New enum member of gnutls_pk_algorithm_t GNUTLS_PK_MLDSA65: New enum member of gnutls_pk_algorithm_t GNUTLS_PK_MLDSA87: New enum member of gnutls_pk_algorithm_t GNUTLS_SIGN_MLDSA44: New enum member of gnutls_sign_algorithm_t GNUTLS_SIGN_MLDSA65: New enum member of gnutls_sign_algorithm_t GNUTLS_SIGN_MLDSA87: New enum member of gnutls_sign_algorithm_t

* Version 3.8.8 (released 2024-11-05)

** libgnutls: Experimental support for X25519MLKEM768 and SecP256r1MLKEM768 key exchange in TLS 1.3
   The support for post-quantum key exchanges has been extended to
   cover the final standard of ML-KEM, following
   draft-kwiatkowski-tls-ecdhe-mlkem. The minimum supported version of
   liboqs is bumped to 0.11.0.

** libgnutls: All records included in an OCSP response are now checked in TLS
   Previously, when multiple records are provided in a single OCSP
   response, only the first record was considered; now all those
   records are examined until the server certificate matches.

** libgnutls: Handling of malformed compress_certificate extension is now more standard compliant
   The server behavior of receiving a malformed compress_certificate
   extension now more strictly follows RFC 8879; return
   illegal_parameter alert instead of bad_certificate, as well as
   overlong extension data is properly rejected.

** build: More flexible library linking options for compression libraries, TPM, and liboqs support
   The configure options, --with-zstd, --with-brotli, --with-zlib,
   --with-tpm2, and --with-liboqs now take 4 states:
   yes/link/dlopen/no, to specify how the libraries are linked or
   loaded.

** API and ABI modifications:
No changes since last version.

* Version 3.8.7 (released 2024-08-15)

** libgnutls: New configure option to compile out DSA support
   The --disable-dsa configure option has been added to completely disable DSA
   algorithm support.

** libgnutls: Experimental support for X25519Kyber768Draft00 key exchange in TLS
   For testing purposes, the hybrid post-quantum key exchange defined
   in draft-tls-westerbaan-xyber768d00 has been implemented using
   liboqs. Since the algorithm is still not finalized, the support of
   this key exchange is disabled by default and can be enabled with
   the --with-liboqs configure option.

** API and ABI modifications:
GNUTLS_PK_MLKEM768: New enum member of gnutls_pk_algorithm_t

* Version 3.8.6 (released 2024-07-03)

** libgnutls: PBMAC1 is now supported as a MAC mechanism for PKCS#12
   To be compliant with FIPS 140-3, PKCS#12 files with MAC based on
   PBKDF2 (PBMAC1) is now supported, according to the specification
   proposed in draft-ietf-lamps-pkcs12-pbmac1.

** libgnutls: SHA3 extendable output functions (XOF) are now supported
   SHA3 XOF, SHAKE128 and SHAKE256, are now usable through a new
   public API gnutls_hash_squeeze.

** API and ABI modifications:
gnutls_pkcs12_generate_mac3: New function
gnutls_pkcs12_flags_t: New enum
gnutls_hash_squeeze: New function

Compile tested: x86/64, QEMU Standard PC (Q35 + ICH9, 2009), r29064-696ad7b1aa09
Compile tested: ath79/generic, TP-Link Archer C7 v4, r29064-696ad7b1aa09
Compile tested: realtek/rtl838x, Netgear GS108T v3, r29064-696ad7b1aa09
Run tested: x86/64, QEMU Standard PC (Q35 + ICH9, 2009), r29064-696ad7b1aa09, booted and used for 7h without issues
Run tested: ath79/generic, TP-Link Archer C7 v4, r29064-696ad7b1aa09, booted and used for 7h without issues
Run tested: realtek/rtl838x, Netgear GS108T v3, r29064-696ad7b1aa09, booted and used for 7h without issues

Signed-off-by: Pascal Ernster <git@hardfalcon.net>