### PR TITLE
bind: bump to 9.20.7

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.20.5
+PKG_VERSION:=9.20.7
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=19274fd739c023772b4212a0b6c201cf4364855fa7e6a7d3db49693f55db1ab8
+PKG_HASH:=43323c8d22d2144282c37b4060ec11e98c24835e225688876fad08ba7b95dca6
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Verbatim copy from upstream's release notes:

Notes for BIND 9.20.7

- New Features
  - Implement the min-transfer-rate-in configuration option.
  - A new option min-transfer-rate-in has been added to the view and zone configurations. It can abort incoming zone transfers that run very slowly due to network-related issues, for example. The default value is 10240 bytes in five minutes. [GL #3914]
  - Add HTTPS record query to host command line tool.
  - The host command was extended to also query for the HTTPS RR type by default.
  - Implement sig0key-checks-limit and sig0message-checks-limit.
  - Previously, a hard-coded limitation of a maximum of two key or message verification checks was introduced when checking a message’s SIG(0) signature, to protect against possible DoS attacks. Two as a maximum was chosen so that more than a single key should only be required during key rotations, and in that case two keys are enough. It later became apparent that there are other use cases where even more keys are required; see the related GitLab issue for examples.
  - This change introduces two new configuration options for the views: sig0key-checks-limit and sig0message-checks-limit. They define how many keys can be checked to find a matching key, and how many message verifications are allowed to take place once a matching key has been found. The former provides slightly less “expensive” key parsing operations and defaults to 16. The latter protects against expensive cryptographic operations when there are keys with colliding tags and algorithm numbers; the default is 2. [GL #5050]
- Bug Fixes
  - Fix dual-stack-servers configuration option.
  - The dual-stack-servers configuration option was not working as expected; the specified servers were not being used when they should have been, leading to resolution failures. This has been fixed. [GL #5019]
  - Fix a data race causing a permanent active client increase.
  - Previously, a data race could cause a newly created fetch context for a new client to be used before it had been fully initialized, which would cause the query to become stuck; queries for the same data would be either paused indefinitely or dropped because of the clients-per-query limit. This has been fixed. [GL #5053]
  - Fix deferred validation of unsigned DS and DNSKEY records.
  - When processing a query with the “checking disabled” bit set (CD=1), named stores the invalidated result in the cache, marked “pending”. When the same query is sent with CD=0, the cached data is validated and either accepted as an answer, or ejected from the cache as invalid. This deferred validation was not attempted for DS and DNSKEY records if they had no cached signatures, causing spurious validation failures. The deferred validation is now completed in this scenario.
  - Also, if deferred validation fails, the data is now re-queried to find out whether the zone has been corrected since the invalid data was cached. [GL #5066]
  - Fix RPZ race condition during a reconfiguration.
  - With RPZ in use, named could terminate unexpectedly because of a race condition when a reconfiguration command was received using rndc. This has been fixed. [GL #5146]
  - “CNAME and other data check” not applied to all types.
  - An incorrect optimization caused “CNAME and other data” errors not to be detected if certain types were at the same node as a CNAME. This has been fixed. [GL #5150]
  - Relax private DNSKEY and RRSIG constraints.
  - DNSKEY, KEY, RRSIG, and SIG constraints have been relaxed to allow empty key and signature material after the algorithm identifier for PRIVATEOID and PRIVATEDNS. It is arguable whether this falls within the expected use of these types, as no key material is shared and the signatures are ineffective, but these are private algorithms and they can be totally insecure. [GL #5167]
  - Remove NSEC/DS/NSEC3 RRSIG check from dns_message_parse().
  - Previously, when parsing responses, named incorrectly rejected responses without matching RRSIG records for NSEC/DS/NSEC3 records in the authority section. This rejection, if appropriate, should have been left for the validator to determine and has been fixed. [GL #5185]
  - Fix TTL issue with ANY queries processed through RPZ “passthru”.
  - Answers to an “ANY” query which were processed by the RPZ “passthru” policy had the response-policy’s max-policy-ttl value unexpectedly applied. This has been fixed. [GL #5187]
  - dnssec-signzone needs to check for a NULL key when setting offline.
  - dnssec-signzone could dereference a NULL key pointer when resigning a zone. This has been fixed. [GL #5192]
  - Fix a bug in the statistics channel when querying zone transfer information.
  - When querying zone transfer information from the statistics channel, there was a rare possibility that named could terminate unexpectedly if a zone transfer was in a state when transferring from all the available primary servers had failed earlier. This has been fixed. [GL #5198]
  - Fix assertion failure when dumping recursing clients.
  - Previously, if a new counter was added to the hash table while dumping recursing clients via the rndc recursing command, and fetches-per-zone was enabled, an assertion failure could occur. This has been fixed. [GL #5200]
  - Dump the active resolver fetches from dns_resolver_dumpfetches()
  - Previously, active resolver fetches were only dumped when the fetches-per-zone configuration option was enabled. Now, active resolver fetches are dumped along with the number of clients-per-query counters per resolver fetch.

Notes for BIND 9.20.6

- New Features
  - Adds support for EDE code 1 and 2.
  - Support was added for EDE codes 1 and 2, which might occur during DNSSEC validation in the case of an unsupported RRSIG algorithm or DNSKEY digest. [GL #2715]
  - Add an rndc command to toggle jemalloc profiling.
  - The new command is rndc memprof; the memory profiling status is also reported inside rndc status. The status shows whether named can toggle memory profiling, and whether the server is built with jemalloc. [GL #4759]
  - Add support for multiple extended DNS errors.
  - The Extended DNS Error (EDE) mechanism may raise errors during a DNS resolution. named is now able to add up to three EDE codes in a DNS response. If there are duplicate error codes, only the first one is part of the DNS response. [GL #5085]
  - Print the expiration time of stale records.
  - BIND now prints the expiration time of any stale RRsets in the cache dump.
- Bug Fixes
  - Recently expired records could be returned with a timestamp in future.
  - Under rare circumstances, an RRSet that expired at the time of the query could be returned with a TTL in the future. This has been fixed.
  - As a side effect, the expiration time of expired RRSets is no longer returned in a cache dump. [GL #5094]
  - YAML string not terminated in negative response in delv.
  - [GL #5098]
  - Fix a bug in dnssec-signzone related to keys being offline.
  - When dnssec-signzone was called on an already-signed zone and the private key file was unavailable, a signature that needed to be refreshed was dropped without being able to generate a replacement. This has been fixed. [GL #5126]
  - Apply the memory limit only to ADB database items.
  - Under heavy load, a resolver could exhaust the memory available for storing the information in the Address Database (ADB), effectively discarding previously stored information in the ADB. The memory used to retrieve and provide information from the ADB is no longer subject to the same memory limits that are applied to the Address Database. [GL #5127]
  - Avoid unnecessary locking in the zone/cache database.
  - Lock contention among many worker threads referring to the same database node at the same time is now prevented. This improves zone and cache database performance for any heavily contended database nodes. [GL #5130]
  - Fix reporting of Extended DNS Error 22 (No Reachable Authority).
  - This error code was previously not reported in some applicable situations. This has been fixed. [GL #5137]

Compile tested: x86/64, QEMU Standard PC (Q35 + ICH9, 2009), r29064-696ad7b1aa09
Compile tested: ath79/generic, TP-Link Archer C7 v4, r29064-696ad7b1aa09
Compile tested: realtek/rtl838x, Netgear GS108T v3, r29064-696ad7b1aa09
Run tested: x86/64, QEMU Standard PC (Q35 + ICH9, 2009), r29064-696ad7b1aa09, booted and used for 7h without issues
Run tested: ath79/generic, TP-Link Archer C7 v4, r29064-696ad7b1aa09, booted and used for 7h without issues
Run tested: realtek/rtl838x, Netgear GS108T v3, r29064-696ad7b1aa09, booted and used for 7h without issues

Signed-off-by: Pascal Ernster <git@hardfalcon.net>