### PR TITLE
go2rtc: update to 1.9.9

### DIFF
--- a/multimedia/go2rtc/Makefile
+++ b/multimedia/go2rtc/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=go2rtc
-PKG_VERSION:=1.9.8
+PKG_VERSION:=1.9.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AlexxIT/go2rtc/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=86940520f50b9e4ca6e1e4f7f408e21ff5e9e74cde5ade8008124ccab5cd7352
+PKG_HASH:=0afb5a9f0cdbd696193288197cfb5ebf44d085f631e7326cc0465026fe3b9196
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -17,7 +17,7 @@ PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/AlexxIT/go2rtc
-GO_PKG_EXCLUDES:=test
+GO_PKG_EXCLUDES:=examples/
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk

--- a/multimedia/go2rtc/patches/0001-v4l2-drop-codegen-file-to-be-able-to-build-with-CGO-.patch
+++ b/multimedia/go2rtc/patches/0001-v4l2-drop-codegen-file-to-be-able-to-build-with-CGO-.patch
@@ -1,0 +1,178 @@
+From bb8b2d421a971fadd6bf08a1656d212e0103a583 Mon Sep 17 00:00:00 2001
+From: Vladimir Ermakov <vooon341@gmail.com>
+Date: Fri, 30 May 2025 16:57:51 +0200
+Subject: [PATCH 1/6] v4l2: drop codegen file to be able to build with CGO=0
+
+Signed-off-by: Vladimir Ermakov <vooon341@gmail.com>
+---
+ pkg/v4l2/device/videodev2_arch.c | 163 -------------------------------
+ 1 file changed, 163 deletions(-)
+ delete mode 100644 pkg/v4l2/device/videodev2_arch.c
+
+--- a/pkg/v4l2/device/videodev2_arch.c
++++ /dev/null
+@@ -1,163 +0,0 @@
+-#include <stdio.h>
+-#include <stddef.h>
+-#include <linux/videodev2.h>
+-
+-#define printconst1(con) printf("\t%s = 0x%08lx\n", #con, con)
+-#define printconst2(con) printf("\t%s = %d\n", #con, con)
+-#define printstruct(str) printf("type %s struct { // size %lu\n", #str, sizeof(struct str))
+-#define printmember(str, mem, typ) printf("\t%s %s // offset %lu, size %lu\n", #mem == "type" ? "typ" : #mem, typ, offsetof(struct str, mem), sizeof((struct str){0}.mem))
+-#define printunimem(str, uni, mem, typ) printf("\t%s %s // offset %lu, size %lu\n", #mem, typ, offsetof(struct str, uni.mem), sizeof((struct str){0}.uni.mem))
+-#define printalign1(str, mem2, mem1) printf("\t_ [%lu]byte // align\n", offsetof(struct str, mem2) - offsetof(struct str, mem1) - sizeof((struct str){0}.mem1))
+-#define printfiller(str, mem) printf("\t_ [%lu]byte // filler\n", sizeof(struct str) - offsetof(struct str, mem) - sizeof((struct str){0}.mem))
+-
+-int main() {
+-	printf("const (\n");
+-	printconst1(VIDIOC_QUERYCAP);
+-	printconst1(VIDIOC_ENUM_FMT);
+-	printconst1(VIDIOC_G_FMT);
+-	printconst1(VIDIOC_S_FMT);
+-	printconst1(VIDIOC_REQBUFS);
+-	printconst1(VIDIOC_QUERYBUF);
+-	printf("\n");
+-	printconst1(VIDIOC_QBUF);
+-	printconst1(VIDIOC_DQBUF);
+-	printconst1(VIDIOC_STREAMON);
+-	printconst1(VIDIOC_STREAMOFF);
+-	printconst1(VIDIOC_G_PARM);
+-	printconst1(VIDIOC_S_PARM);
+-	printf("\n");
+-	printconst1(VIDIOC_ENUM_FRAMESIZES);
+-	printconst1(VIDIOC_ENUM_FRAMEINTERVALS);
+-	printf(")\n\n");
+-
+-	printf("const (\n");
+-	printconst2(V4L2_BUF_TYPE_VIDEO_CAPTURE);
+-	printconst2(V4L2_COLORSPACE_DEFAULT);
+-	printconst2(V4L2_FIELD_NONE);
+-	printconst2(V4L2_FRMIVAL_TYPE_DISCRETE);
+-	printconst2(V4L2_FRMSIZE_TYPE_DISCRETE);
+-	printconst2(V4L2_MEMORY_MMAP);
+-	printf(")\n\n");
+-
+-	printstruct(v4l2_capability);
+-	printmember(v4l2_capability, driver, "[16]byte");
+-	printmember(v4l2_capability, card, "[32]byte");
+-	printmember(v4l2_capability, bus_info, "[32]byte");
+-	printmember(v4l2_capability, version, "uint32");
+-	printmember(v4l2_capability, capabilities, "uint32");
+-	printmember(v4l2_capability, device_caps, "uint32");
+-	printmember(v4l2_capability, reserved, "[3]uint32");
+-	printf("}\n\n");
+-
+-	printstruct(v4l2_format);
+-	printmember(v4l2_format, type, "uint32");
+-	printalign1(v4l2_format, fmt, type);
+-	printunimem(v4l2_format, fmt, pix, "v4l2_pix_format");
+-	printfiller(v4l2_format, fmt.pix);
+-	printf("}\n\n");
+-
+-	printstruct(v4l2_pix_format);
+-	printmember(v4l2_pix_format, width, "uint32");
+-	printmember(v4l2_pix_format, height, "uint32");
+-	printmember(v4l2_pix_format, pixelformat, "uint32");
+-	printmember(v4l2_pix_format, field, "uint32");
+-	printmember(v4l2_pix_format, bytesperline, "uint32");
+-	printmember(v4l2_pix_format, sizeimage, "uint32");
+-	printmember(v4l2_pix_format, colorspace, "uint32");
+-	printmember(v4l2_pix_format, priv, "uint32");
+-	printmember(v4l2_pix_format, flags, "uint32");
+-	printmember(v4l2_pix_format, ycbcr_enc, "uint32");
+-	printmember(v4l2_pix_format, quantization, "uint32");
+-	printmember(v4l2_pix_format, xfer_func, "uint32");
+-	printf("}\n\n");
+-
+-	printstruct(v4l2_streamparm);
+-	printmember(v4l2_streamparm, type, "uint32");
+-	printunimem(v4l2_streamparm, parm, capture, "v4l2_captureparm");
+-	printfiller(v4l2_streamparm, parm.capture);
+-	printf("}\n\n");
+-
+-	printstruct(v4l2_captureparm);
+-	printmember(v4l2_captureparm, capability, "uint32");
+-	printmember(v4l2_captureparm, capturemode, "uint32");
+-	printmember(v4l2_captureparm, timeperframe, "v4l2_fract");
+-	printmember(v4l2_captureparm, extendedmode, "uint32");
+-	printmember(v4l2_captureparm, readbuffers, "uint32");
+-	printmember(v4l2_captureparm, reserved, "[4]uint32");
+-	printf("}\n\n");
+-
+-	printstruct(v4l2_fract);
+-	printmember(v4l2_fract, numerator, "uint32");
+-	printmember(v4l2_fract, denominator, "uint32");
+-	printf("}\n\n");
+-
+-	printstruct(v4l2_requestbuffers);
+-	printmember(v4l2_requestbuffers, count, "uint32");
+-	printmember(v4l2_requestbuffers, type, "uint32");
+-	printmember(v4l2_requestbuffers, memory, "uint32");
+-	printmember(v4l2_requestbuffers, capabilities, "uint32");
+-	printmember(v4l2_requestbuffers, flags, "uint8");
+-	printmember(v4l2_requestbuffers, reserved, "[3]uint8");
+-	printf("}\n\n");
+-
+-	printstruct(v4l2_buffer);
+-	printmember(v4l2_buffer, index, "uint32");
+-	printmember(v4l2_buffer, type, "uint32");
+-	printmember(v4l2_buffer, bytesused, "uint32");
+-	printmember(v4l2_buffer, flags, "uint32");
+-	printmember(v4l2_buffer, field, "uint32");
+-	printalign1(v4l2_buffer, timecode, field);
+-	printmember(v4l2_buffer, timecode, "v4l2_timecode");
+-	printmember(v4l2_buffer, sequence, "uint32");
+-	printmember(v4l2_buffer, memory, "uint32");
+-	printunimem(v4l2_buffer, m, offset, "uint32");
+-	printalign1(v4l2_buffer, length, m.offset);
+-	printmember(v4l2_buffer, length, "uint32");
+-	printfiller(v4l2_buffer, length);
+-	printf("}\n\n");
+-
+-	printstruct(v4l2_timecode);
+-	printmember(v4l2_timecode, type, "uint32");
+-	printmember(v4l2_timecode, flags, "uint32");
+-	printmember(v4l2_timecode, frames, "uint8");
+-	printmember(v4l2_timecode, seconds, "uint8");
+-	printmember(v4l2_timecode, minutes, "uint8");
+-	printmember(v4l2_timecode, hours, "uint8");
+-	printmember(v4l2_timecode, userbits, "[4]uint8");
+-	printf("}\n\n");
+-
+-	printstruct(v4l2_fmtdesc);
+-	printmember(v4l2_fmtdesc, index, "uint32");
+-	printmember(v4l2_fmtdesc, type, "uint32");
+-	printmember(v4l2_fmtdesc, flags, "uint32");
+-	printmember(v4l2_fmtdesc, description, "[32]byte");
+-	printmember(v4l2_fmtdesc, pixelformat, "uint32");
+-	printmember(v4l2_fmtdesc, mbus_code, "uint32");
+-	printmember(v4l2_fmtdesc, reserved, "[3]uint32");
+-	printf("}\n\n");
+-
+-	printstruct(v4l2_frmsizeenum);
+-	printmember(v4l2_frmsizeenum, index, "uint32");
+-	printmember(v4l2_frmsizeenum, pixel_format, "uint32");
+-	printmember(v4l2_frmsizeenum, type, "uint32");
+-	printmember(v4l2_frmsizeenum, discrete, "v4l2_frmsize_discrete");
+-	printfiller(v4l2_frmsizeenum, discrete);
+-	printf("}\n\n");
+-
+-	printstruct(v4l2_frmsize_discrete);
+-	printmember(v4l2_frmsize_discrete, width, "uint32");
+-	printmember(v4l2_frmsize_discrete, height, "uint32");
+-	printf("}\n\n");
+-
+-	printstruct(v4l2_frmivalenum);
+-	printmember(v4l2_frmivalenum, index, "uint32");
+-	printmember(v4l2_frmivalenum, pixel_format, "uint32");
+-	printmember(v4l2_frmivalenum, width, "uint32");
+-	printmember(v4l2_frmivalenum, height, "uint32");
+-	printmember(v4l2_frmivalenum, type, "uint32");
+-	printmember(v4l2_frmivalenum, discrete, "v4l2_fract");
+-	printfiller(v4l2_frmivalenum, discrete);
+-	printf("}\n\n");
+-
+-	return 0;
+-}
+\ No newline at end of file

--- a/multimedia/go2rtc/patches/0002-Fix-support-linux-riscv64-1639.patch
+++ b/multimedia/go2rtc/patches/0002-Fix-support-linux-riscv64-1639.patch
@@ -1,0 +1,26 @@
+From c6b1584b5fdcbf0a7d5b0a00defcc2d1ce71e803 Mon Sep 17 00:00:00 2001
+From: Alex X <alexey.khit@gmail.com>
+Date: Thu, 13 Mar 2025 15:33:23 +0300
+Subject: [PATCH 2/6] Fix support linux + riscv64 #1639
+
+---
+ internal/v4l2/v4l2.go       | 2 +-
+ internal/v4l2/v4l2_linux.go | 2 ++
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+--- a/internal/v4l2/v4l2.go
++++ b/internal/v4l2/v4l2.go
+@@ -1,4 +1,4 @@
+-//go:build !linux
++//go:build !(linux && (386 || arm || mipsle || amd64 || arm64))
+ 
+ package v4l2
+ 
+--- a/internal/v4l2/v4l2_linux.go
++++ b/internal/v4l2/v4l2_linux.go
+@@ -1,3 +1,5 @@
++//go:build linux && (386 || arm || mipsle || amd64 || arm64)
++
+ package v4l2
+ 
+ import (

--- a/multimedia/go2rtc/patches/0003-add-riscv64-platform-for-v4l2-package.patch
+++ b/multimedia/go2rtc/patches/0003-add-riscv64-platform-for-v4l2-package.patch
@@ -1,0 +1,162 @@
+From f83445984f2865d219095288c8dde548bd2020ed Mon Sep 17 00:00:00 2001
+From: nakata5321 <makar5321@gmail.com>
+Date: Thu, 13 Mar 2025 15:13:50 +0200
+Subject: [PATCH 3/6] add riscv64 platform for v4l2 package
+
+PR: https://github.com/AlexxIT/go2rtc/pull/1651
+---
+ pkg/v4l2/device/videodev2_riscv64.go | 148 +++++++++++++++++++++++++++
+ 1 file changed, 148 insertions(+)
+ create mode 100644 pkg/v4l2/device/videodev2_riscv64.go
+
+--- /dev/null
++++ b/pkg/v4l2/device/videodev2_riscv64.go
+@@ -0,0 +1,148 @@
++const (
++	VIDIOC_QUERYCAP = 0x80685600
++	VIDIOC_ENUM_FMT = 0xc0405602
++	VIDIOC_G_FMT = 0xc0d05604
++	VIDIOC_S_FMT = 0xc0d05605
++	VIDIOC_REQBUFS = 0xc0145608
++	VIDIOC_QUERYBUF = 0xc0585609
++
++	VIDIOC_QBUF = 0xc058560f
++	VIDIOC_DQBUF = 0xc0585611
++	VIDIOC_STREAMON = 0x40045612
++	VIDIOC_STREAMOFF = 0x40045613
++	VIDIOC_G_PARM = 0xc0cc5615
++	VIDIOC_S_PARM = 0xc0cc5616
++
++	VIDIOC_ENUM_FRAMESIZES = 0xc02c564a
++	VIDIOC_ENUM_FRAMEINTERVALS = 0xc034564b
++)
++
++const (
++	V4L2_BUF_TYPE_VIDEO_CAPTURE = 1
++	V4L2_COLORSPACE_DEFAULT = 0
++	V4L2_FIELD_NONE = 1
++	V4L2_FRMIVAL_TYPE_DISCRETE = 1
++	V4L2_FRMSIZE_TYPE_DISCRETE = 1
++	V4L2_MEMORY_MMAP = 1
++)
++
++type v4l2_capability struct { // size 104
++	driver [16]byte // offset 0, size 16
++	card [32]byte // offset 16, size 32
++	bus_info [32]byte // offset 48, size 32
++	version uint32 // offset 80, size 4
++	capabilities uint32 // offset 84, size 4
++	device_caps uint32 // offset 88, size 4
++	reserved [3]uint32 // offset 92, size 12
++}
++
++type v4l2_format struct { // size 208
++	typ uint32 // offset 0, size 4
++	_ [4]byte // align
++	pix v4l2_pix_format // offset 8, size 48
++	_ [152]byte // filler
++}
++
++type v4l2_pix_format struct { // size 48
++	width uint32 // offset 0, size 4
++	height uint32 // offset 4, size 4
++	pixelformat uint32 // offset 8, size 4
++	field uint32 // offset 12, size 4
++	bytesperline uint32 // offset 16, size 4
++	sizeimage uint32 // offset 20, size 4
++	colorspace uint32 // offset 24, size 4
++	priv uint32 // offset 28, size 4
++	flags uint32 // offset 32, size 4
++	ycbcr_enc uint32 // offset 36, size 4
++	quantization uint32 // offset 40, size 4
++	xfer_func uint32 // offset 44, size 4
++}
++
++type v4l2_streamparm struct { // size 204
++	typ uint32 // offset 0, size 4
++	capture v4l2_captureparm // offset 4, size 40
++	_ [160]byte // filler
++}
++
++type v4l2_captureparm struct { // size 40
++	capability uint32 // offset 0, size 4
++	capturemode uint32 // offset 4, size 4
++	timeperframe v4l2_fract // offset 8, size 8
++	extendedmode uint32 // offset 16, size 4
++	readbuffers uint32 // offset 20, size 4
++	reserved [4]uint32 // offset 24, size 16
++}
++
++type v4l2_fract struct { // size 8
++	numerator uint32 // offset 0, size 4
++	denominator uint32 // offset 4, size 4
++}
++
++type v4l2_requestbuffers struct { // size 20
++	count uint32 // offset 0, size 4
++	typ uint32 // offset 4, size 4
++	memory uint32 // offset 8, size 4
++	capabilities uint32 // offset 12, size 4
++	flags uint8 // offset 16, size 1
++	reserved [3]uint8 // offset 17, size 3
++}
++
++type v4l2_buffer struct { // size 88
++	index uint32 // offset 0, size 4
++	typ uint32 // offset 4, size 4
++	bytesused uint32 // offset 8, size 4
++	flags uint32 // offset 12, size 4
++	field uint32 // offset 16, size 4
++	_ [20]byte // align
++	timecode v4l2_timecode // offset 40, size 16
++	sequence uint32 // offset 56, size 4
++	memory uint32 // offset 60, size 4
++	offset uint32 // offset 64, size 4
++	_ [4]byte // align
++	length uint32 // offset 72, size 4
++	_ [12]byte // filler
++}
++
++type v4l2_timecode struct { // size 16
++	typ uint32 // offset 0, size 4
++	flags uint32 // offset 4, size 4
++	frames uint8 // offset 8, size 1
++	seconds uint8 // offset 9, size 1
++	minutes uint8 // offset 10, size 1
++	hours uint8 // offset 11, size 1
++	userbits [4]uint8 // offset 12, size 4
++}
++
++type v4l2_fmtdesc struct { // size 64
++	index uint32 // offset 0, size 4
++	typ uint32 // offset 4, size 4
++	flags uint32 // offset 8, size 4
++	description [32]byte // offset 12, size 32
++	pixelformat uint32 // offset 44, size 4
++	mbus_code uint32 // offset 48, size 4
++	reserved [3]uint32 // offset 52, size 12
++}
++
++type v4l2_frmsizeenum struct { // size 44
++	index uint32 // offset 0, size 4
++	pixel_format uint32 // offset 4, size 4
++	typ uint32 // offset 8, size 4
++	discrete v4l2_frmsize_discrete // offset 12, size 8
++	_ [24]byte // filler
++}
++
++type v4l2_frmsize_discrete struct { // size 8
++	width uint32 // offset 0, size 4
++	height uint32 // offset 4, size 4
++}
++
++type v4l2_frmivalenum struct { // size 52
++	index uint32 // offset 0, size 4
++	pixel_format uint32 // offset 4, size 4
++	width uint32 // offset 8, size 4
++	height uint32 // offset 12, size 4
++	typ uint32 // offset 16, size 4
++	discrete v4l2_fract // offset 20, size 8
++	_ [24]byte // filler
++}
++

--- a/multimedia/go2rtc/patches/0004-v4l2-eanble-risc-v-64-support.patch
+++ b/multimedia/go2rtc/patches/0004-v4l2-eanble-risc-v-64-support.patch
@@ -1,0 +1,27 @@
+From 0343f6378994b9c45f851847062f1a1fef1bee92 Mon Sep 17 00:00:00 2001
+From: Vladimir Ermakov <vooon341@gmail.com>
+Date: Sun, 1 Jun 2025 18:24:41 +0200
+Subject: [PATCH 4/6] v4l2: eanble risc-v 64 support
+
+Signed-off-by: Vladimir Ermakov <vooon341@gmail.com>
+---
+ internal/v4l2/v4l2.go       | 2 +-
+ internal/v4l2/v4l2_linux.go | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+--- a/internal/v4l2/v4l2.go
++++ b/internal/v4l2/v4l2.go
+@@ -1,4 +1,4 @@
+-//go:build !(linux && (386 || arm || mipsle || amd64 || arm64))
++//go:build !(linux && (386 || arm || mipsle || amd64 || arm64 || riscv64))
+ 
+ package v4l2
+ 
+--- a/internal/v4l2/v4l2_linux.go
++++ b/internal/v4l2/v4l2_linux.go
+@@ -1,4 +1,4 @@
+-//go:build linux && (386 || arm || mipsle || amd64 || arm64)
++//go:build linux && (386 || arm || mipsle || amd64 || arm64 || riscv64)
+ 
+ package v4l2
+ 

--- a/multimedia/go2rtc/patches/0005-v4l2-fix-riscv64-build-and-go-fmt.patch
+++ b/multimedia/go2rtc/patches/0005-v4l2-fix-riscv64-build-and-go-fmt.patch
@@ -1,0 +1,250 @@
+From 92640089b2fcc233e3d5b12283e019a40762afbd Mon Sep 17 00:00:00 2001
+From: Vladimir Ermakov <vooon341@gmail.com>
+Date: Sun, 1 Jun 2025 18:52:17 +0200
+Subject: [PATCH 5/6] v4l2: fix riscv64 build and go-fmt
+
+Signed-off-by: Vladimir Ermakov <vooon341@gmail.com>
+---
+ pkg/v4l2/device/videodev2_riscv64.go | 177 ++++++++++++++-------------
+ 1 file changed, 89 insertions(+), 88 deletions(-)
+
+--- a/pkg/v4l2/device/videodev2_riscv64.go
++++ b/pkg/v4l2/device/videodev2_riscv64.go
+@@ -1,148 +1,149 @@
++package device
++
+ const (
+ 	VIDIOC_QUERYCAP = 0x80685600
+ 	VIDIOC_ENUM_FMT = 0xc0405602
+-	VIDIOC_G_FMT = 0xc0d05604
+-	VIDIOC_S_FMT = 0xc0d05605
+-	VIDIOC_REQBUFS = 0xc0145608
++	VIDIOC_G_FMT    = 0xc0d05604
++	VIDIOC_S_FMT    = 0xc0d05605
++	VIDIOC_REQBUFS  = 0xc0145608
+ 	VIDIOC_QUERYBUF = 0xc0585609
+ 
+-	VIDIOC_QBUF = 0xc058560f
+-	VIDIOC_DQBUF = 0xc0585611
+-	VIDIOC_STREAMON = 0x40045612
++	VIDIOC_QBUF      = 0xc058560f
++	VIDIOC_DQBUF     = 0xc0585611
++	VIDIOC_STREAMON  = 0x40045612
+ 	VIDIOC_STREAMOFF = 0x40045613
+-	VIDIOC_G_PARM = 0xc0cc5615
+-	VIDIOC_S_PARM = 0xc0cc5616
++	VIDIOC_G_PARM    = 0xc0cc5615
++	VIDIOC_S_PARM    = 0xc0cc5616
+ 
+-	VIDIOC_ENUM_FRAMESIZES = 0xc02c564a
++	VIDIOC_ENUM_FRAMESIZES     = 0xc02c564a
+ 	VIDIOC_ENUM_FRAMEINTERVALS = 0xc034564b
+ )
+ 
+ const (
+ 	V4L2_BUF_TYPE_VIDEO_CAPTURE = 1
+-	V4L2_COLORSPACE_DEFAULT = 0
+-	V4L2_FIELD_NONE = 1
+-	V4L2_FRMIVAL_TYPE_DISCRETE = 1
+-	V4L2_FRMSIZE_TYPE_DISCRETE = 1
+-	V4L2_MEMORY_MMAP = 1
++	V4L2_COLORSPACE_DEFAULT     = 0
++	V4L2_FIELD_NONE             = 1
++	V4L2_FRMIVAL_TYPE_DISCRETE  = 1
++	V4L2_FRMSIZE_TYPE_DISCRETE  = 1
++	V4L2_MEMORY_MMAP            = 1
+ )
+ 
+ type v4l2_capability struct { // size 104
+-	driver [16]byte // offset 0, size 16
+-	card [32]byte // offset 16, size 32
+-	bus_info [32]byte // offset 48, size 32
+-	version uint32 // offset 80, size 4
+-	capabilities uint32 // offset 84, size 4
+-	device_caps uint32 // offset 88, size 4
+-	reserved [3]uint32 // offset 92, size 12
++	driver       [16]byte  // offset 0, size 16
++	card         [32]byte  // offset 16, size 32
++	bus_info     [32]byte  // offset 48, size 32
++	version      uint32    // offset 80, size 4
++	capabilities uint32    // offset 84, size 4
++	device_caps  uint32    // offset 88, size 4
++	reserved     [3]uint32 // offset 92, size 12
+ }
+ 
+ type v4l2_format struct { // size 208
+-	typ uint32 // offset 0, size 4
+-	_ [4]byte // align
++	typ uint32          // offset 0, size 4
++	_   [4]byte         // align
+ 	pix v4l2_pix_format // offset 8, size 48
+-	_ [152]byte // filler
++	_   [152]byte       // filler
+ }
+ 
+ type v4l2_pix_format struct { // size 48
+-	width uint32 // offset 0, size 4
+-	height uint32 // offset 4, size 4
+-	pixelformat uint32 // offset 8, size 4
+-	field uint32 // offset 12, size 4
++	width        uint32 // offset 0, size 4
++	height       uint32 // offset 4, size 4
++	pixelformat  uint32 // offset 8, size 4
++	field        uint32 // offset 12, size 4
+ 	bytesperline uint32 // offset 16, size 4
+-	sizeimage uint32 // offset 20, size 4
+-	colorspace uint32 // offset 24, size 4
+-	priv uint32 // offset 28, size 4
+-	flags uint32 // offset 32, size 4
+-	ycbcr_enc uint32 // offset 36, size 4
++	sizeimage    uint32 // offset 20, size 4
++	colorspace   uint32 // offset 24, size 4
++	priv         uint32 // offset 28, size 4
++	flags        uint32 // offset 32, size 4
++	ycbcr_enc    uint32 // offset 36, size 4
+ 	quantization uint32 // offset 40, size 4
+-	xfer_func uint32 // offset 44, size 4
++	xfer_func    uint32 // offset 44, size 4
+ }
+ 
+ type v4l2_streamparm struct { // size 204
+-	typ uint32 // offset 0, size 4
++	typ     uint32           // offset 0, size 4
+ 	capture v4l2_captureparm // offset 4, size 40
+-	_ [160]byte // filler
++	_       [160]byte        // filler
+ }
+ 
+ type v4l2_captureparm struct { // size 40
+-	capability uint32 // offset 0, size 4
+-	capturemode uint32 // offset 4, size 4
++	capability   uint32     // offset 0, size 4
++	capturemode  uint32     // offset 4, size 4
+ 	timeperframe v4l2_fract // offset 8, size 8
+-	extendedmode uint32 // offset 16, size 4
+-	readbuffers uint32 // offset 20, size 4
+-	reserved [4]uint32 // offset 24, size 16
++	extendedmode uint32     // offset 16, size 4
++	readbuffers  uint32     // offset 20, size 4
++	reserved     [4]uint32  // offset 24, size 16
+ }
+ 
+ type v4l2_fract struct { // size 8
+-	numerator uint32 // offset 0, size 4
++	numerator   uint32 // offset 0, size 4
+ 	denominator uint32 // offset 4, size 4
+ }
+ 
+ type v4l2_requestbuffers struct { // size 20
+-	count uint32 // offset 0, size 4
+-	typ uint32 // offset 4, size 4
+-	memory uint32 // offset 8, size 4
+-	capabilities uint32 // offset 12, size 4
+-	flags uint8 // offset 16, size 1
+-	reserved [3]uint8 // offset 17, size 3
++	count        uint32   // offset 0, size 4
++	typ          uint32   // offset 4, size 4
++	memory       uint32   // offset 8, size 4
++	capabilities uint32   // offset 12, size 4
++	flags        uint8    // offset 16, size 1
++	reserved     [3]uint8 // offset 17, size 3
+ }
+ 
+ type v4l2_buffer struct { // size 88
+-	index uint32 // offset 0, size 4
+-	typ uint32 // offset 4, size 4
+-	bytesused uint32 // offset 8, size 4
+-	flags uint32 // offset 12, size 4
+-	field uint32 // offset 16, size 4
+-	_ [20]byte // align
+-	timecode v4l2_timecode // offset 40, size 16
+-	sequence uint32 // offset 56, size 4
+-	memory uint32 // offset 60, size 4
+-	offset uint32 // offset 64, size 4
+-	_ [4]byte // align
+-	length uint32 // offset 72, size 4
+-	_ [12]byte // filler
++	index     uint32        // offset 0, size 4
++	typ       uint32        // offset 4, size 4
++	bytesused uint32        // offset 8, size 4
++	flags     uint32        // offset 12, size 4
++	field     uint32        // offset 16, size 4
++	_         [20]byte      // align
++	timecode  v4l2_timecode // offset 40, size 16
++	sequence  uint32        // offset 56, size 4
++	memory    uint32        // offset 60, size 4
++	offset    uint32        // offset 64, size 4
++	_         [4]byte       // align
++	length    uint32        // offset 72, size 4
++	_         [12]byte      // filler
+ }
+ 
+ type v4l2_timecode struct { // size 16
+-	typ uint32 // offset 0, size 4
+-	flags uint32 // offset 4, size 4
+-	frames uint8 // offset 8, size 1
+-	seconds uint8 // offset 9, size 1
+-	minutes uint8 // offset 10, size 1
+-	hours uint8 // offset 11, size 1
++	typ      uint32   // offset 0, size 4
++	flags    uint32   // offset 4, size 4
++	frames   uint8    // offset 8, size 1
++	seconds  uint8    // offset 9, size 1
++	minutes  uint8    // offset 10, size 1
++	hours    uint8    // offset 11, size 1
+ 	userbits [4]uint8 // offset 12, size 4
+ }
+ 
+ type v4l2_fmtdesc struct { // size 64
+-	index uint32 // offset 0, size 4
+-	typ uint32 // offset 4, size 4
+-	flags uint32 // offset 8, size 4
+-	description [32]byte // offset 12, size 32
+-	pixelformat uint32 // offset 44, size 4
+-	mbus_code uint32 // offset 48, size 4
+-	reserved [3]uint32 // offset 52, size 12
++	index       uint32    // offset 0, size 4
++	typ         uint32    // offset 4, size 4
++	flags       uint32    // offset 8, size 4
++	description [32]byte  // offset 12, size 32
++	pixelformat uint32    // offset 44, size 4
++	mbus_code   uint32    // offset 48, size 4
++	reserved    [3]uint32 // offset 52, size 12
+ }
+ 
+ type v4l2_frmsizeenum struct { // size 44
+-	index uint32 // offset 0, size 4
+-	pixel_format uint32 // offset 4, size 4
+-	typ uint32 // offset 8, size 4
+-	discrete v4l2_frmsize_discrete // offset 12, size 8
+-	_ [24]byte // filler
++	index        uint32                // offset 0, size 4
++	pixel_format uint32                // offset 4, size 4
++	typ          uint32                // offset 8, size 4
++	discrete     v4l2_frmsize_discrete // offset 12, size 8
++	_            [24]byte              // filler
+ }
+ 
+ type v4l2_frmsize_discrete struct { // size 8
+-	width uint32 // offset 0, size 4
++	width  uint32 // offset 0, size 4
+ 	height uint32 // offset 4, size 4
+ }
+ 
+ type v4l2_frmivalenum struct { // size 52
+-	index uint32 // offset 0, size 4
+-	pixel_format uint32 // offset 4, size 4
+-	width uint32 // offset 8, size 4
+-	height uint32 // offset 12, size 4
+-	typ uint32 // offset 16, size 4
+-	discrete v4l2_fract // offset 20, size 8
+-	_ [24]byte // filler
++	index        uint32     // offset 0, size 4
++	pixel_format uint32     // offset 4, size 4
++	width        uint32     // offset 8, size 4
++	height       uint32     // offset 12, size 4
++	typ          uint32     // offset 16, size 4
++	discrete     v4l2_fract // offset 20, size 8
++	_            [24]byte   // filler
+ }
+-

--- a/multimedia/go2rtc/patches/0006-v4l2-fix-compile-on-unsupported-arch-mips.patch
+++ b/multimedia/go2rtc/patches/0006-v4l2-fix-compile-on-unsupported-arch-mips.patch
@@ -1,0 +1,27 @@
+From bb9f4b303a982089cafaaa5e4080d82160df8a6c Mon Sep 17 00:00:00 2001
+From: Vladimir Ermakov <vooon341@gmail.com>
+Date: Sun, 1 Jun 2025 20:23:29 +0200
+Subject: [PATCH 6/6] v4l2: fix compile on unsupported arch (mips)
+
+Signed-off-by: Vladimir Ermakov <vooon341@gmail.com>
+---
+ pkg/v4l2/device/device.go | 2 +-
+ pkg/v4l2/producer.go      | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+--- a/pkg/v4l2/device/device.go
++++ b/pkg/v4l2/device/device.go
+@@ -1,4 +1,4 @@
+-//go:build linux
++//go:build linux && (386 || arm || mipsle || amd64 || arm64 || riscv64)
+ 
+ package device
+ 
+--- a/pkg/v4l2/producer.go
++++ b/pkg/v4l2/producer.go
+@@ -1,4 +1,4 @@
+-//go:build linux
++//go:build linux && (386 || arm || mipsle || amd64 || arm64 || riscv64)
+ 
+ package v4l2
+ 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, OpenWrt master d63663601d
Run tested: x86_64, Master, camera's continue to work

Description:

- Update version to 1.9.9
- Add patches to fix build with CGO=0
- Fix excludes to drop example binaries
