### PR TITLE
coreutils: apply PKG_FIXUP conditionally

### DIFF
--- a/utils/coreutils/Makefile
+++ b/utils/coreutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coreutils
 PKG_VERSION:=9.6
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/coreutils
@@ -22,7 +22,9 @@ PKG_CPE_ID:=cpe:/a:gnu:coreutils
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_FIXUP:=autoreconf
+ifeq ($(CONFIG_GCC_VERSION_14),y)
+	PKG_FIXUP:=autoreconf
+endif
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
PKG_FIXUP:=autoreconf introduced in this commit[1] to fix builds with GCC 14 does not play well with GCC 13. Apply it conditionally.

I build some coreutils packages under GCC 13 and again under GCC 14 and both completed successfully.

Build system: x86/64
Build-tested: x86/64

Fixes https://github.com/openwrt/packages/issues/26175

Maintainer: @hnyman