### PR TITLE
golang: support multiple host versions in parallel, defined per-package

### DIFF
--- a/lang/golang/golang-values.mk
+++ b/lang/golang/golang-values.mk
@@ -146,6 +146,7 @@ GO_HOST_ARCH:=$(call go_arch,$(subst \
   armv7l,arm,$(subst \
   i686,i386,$(HOST_ARCH)))))
 GO_HOST_OS_ARCH:=$(GO_HOST_OS)_$(GO_HOST_ARCH)
+GO_BIN_OS_ARCH:=$(GO_HOST_OS)-$(GO_HOST_ARCH)
 
 ifeq ($(GO_OS_ARCH),$(GO_HOST_OS_ARCH))
   GO_HOST_TARGET_SAME:=1
@@ -270,3 +271,21 @@ define Go/CacheCleanup
 	$(GO_GENERAL_BUILD_CONFIG_VARS) \
 	$(SHELL) $(GO_INCLUDE_DIR)/golang-build.sh cache_cleanup
 endef
+
+GO_BIN_SOURCE_URL:=https://go.dev/ \
+                   https://dl.google.com/go/ \
+                   https://golang.google.cn/dl/ \
+                   https://mirrors.nju.edu.cn/golang/ \
+                   https://mirrors.ustc.edu.cn/golang/
+
+# Only one patch version per MAJOR.MINOR and platform combination should be
+# defined. Last matching version-platform key will be used in case multiple
+# match on MAJOR.MINOR prefix.
+#
+# SHA256 hashes can be looked up at https://go.dev/dl/
+GO_BIN_HASHES:=1.22.12.linux-amd64=4fa4f869b0f7fc6bb1eb2660e74657fbf04cdd290b5aef905585c86051b34d43 \
+               1.22.12.linux-arm64=fd017e647ec28525e86ae8203236e0653242722a7436929b1f775744e26278e7 \
+               1.23.9.linux-amd64=de03e45d7a076c06baaa9618d42b3b6a0561125b87f6041c6397680a71e5bb26 \
+               1.23.9.linux-arm64=3dc4dd64bdb0275e3ec65a55ecfc2597009c7c46a1b256eefab2f2172a53a602 \
+               1.24.3.linux-amd64=3333f6ea53afa971e9078895eaa4ac7204a8c6b5c68c10e6bc9a33e8e391bdd8 \
+               1.24.3.linux-arm64=a463cb59382bd7ae7d8f4c68846e73c4d589f223c589ac76871b66811ded7836

--- a/lang/golang/golang/Makefile
+++ b/lang/golang/golang/Makefile
@@ -7,12 +7,13 @@
 
 include $(TOPDIR)/rules.mk
 
+# Don't forget to add the new version to GO_BIN_HASHES in golang-values.mk
 GO_VERSION_MAJOR_MINOR:=1.24
 GO_VERSION_PATCH:=3
 
 PKG_NAME:=golang
 PKG_VERSION:=$(GO_VERSION_MAJOR_MINOR)$(if $(GO_VERSION_PATCH),.$(GO_VERSION_PATCH))
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 GO_SOURCE_URLS:=https://dl.google.com/go/ \
                 https://mirrors.ustc.edu.cn/golang/ \

--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -23,12 +23,13 @@ PKG_LICENSE_FILES:=LICENSE.txt
 PKG_CPE_ID:=cpe:/a:adguard:adguardhome
 PKG_MAINTAINER:=Dobroslaw Kijowski <dobo90@gmail.com>, George Sapkin <george@sapk.in>
 
-PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_DEPENDS:=
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/AdguardTeam/AdGuardHome
 GO_PKG_BUILD_PKG:=github.com/AdguardTeam/AdGuardHome
+GO_BIN_VERSION:=1.24
 
 AGH_VERSION_PKG:=github.com/AdguardTeam/AdGuardHome/internal/version
 GO_PKG_LDFLAGS_X:=$(AGH_VERSION_PKG).channel=release \

--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -22,7 +22,7 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:tailscale:tailscale
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/tailscale-$(PKG_VERSION)
-PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_DEPENDS:=
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
@@ -31,6 +31,7 @@ GO_PKG:=\
 GO_PKG_LDFLAGS:=-X 'tailscale.com/version.longStamp=$(PKG_VERSION)-$(PKG_RELEASE) (OpenWrt)'
 GO_PKG_LDFLAGS_X:=tailscale.com/version.shortStamp=$(PKG_VERSION)
 GO_PKG_TAGS:=ts_include_cli,ts_omit_aws,ts_omit_bird,ts_omit_tap,ts_omit_kube,ts_omit_completion
+GO_BIN_VERSION:=1.24
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk

--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -15,7 +15,7 @@ PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:syncthing:syncthing
 
-PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_DEPENDS:=
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
@@ -25,6 +25,7 @@ GO_PKG_BUILD_PKG:=\
 	$(if $(CONFIG_PACKAGE_stdiscosrv),$(GO_PKG)/cmd/stdiscosrv/) \
 	$(if $(CONFIG_PACKAGE_strelaysrv),$(GO_PKG)/cmd/strelaysrv/)
 GO_PKG_INSTALL_EXTRA:=^gui/
+GO_BIN_VERSION:=1.23
 
 GO_PKG_TAGS:=noupgrade
 GO_PKG_LDFLAGS_X:=\


### PR DESCRIPTION
Maintainer: @jefferyto @1715173329
Compile tested: mediatek/filogic; 24.10, x86/64, 23.05.5; x86/64, HEAD

- Tested building AdGuard Home, Syncthing and Tailscale from the example commits with and without `GO_BIN_VERSION` specified
- Tested setting invalid `GO_BIN_VERSION` not available in `GO_BIN_HASHES`.
- Tested upgrading go in staging between different patch levels, e.g. 1.24.1 to 1.24.2.

Run tested: mediatek/filogic on 24.10, QEMU x86/64 on 24.10

---

Some Go-based packages require up-to-date versions of Go, that are newer than the one in the stable branch. For example AdGuard Home and Tailscale. This prevents these packages from being updated in stable and leaves them potentially vulnerable. The concern of backporting Go to stable branches is that it might break other packages.

Following the recent example of Node.js switching to binary distribution #26116, this PR introduces a setup to use a binary distribution of Go, and allows each package to specify their own version, without interfering with the host Go package and potentially breaking other packages that depend on it, or other versions.

---

Per-project Go version is defined in the format of `MAJOR.MINOR` using `GO_BIN_VERSION` package variable. The actual version is looked up based on `GO_BIN_VERSION` and current platform from `GO_BIN_HASHES` and stored in `GO_BIN_FULL_VERSION`. The binaries for that version are fetched by `GoPackage/GoBin/Install`, installed into `staging_dir/hostpkg/lib/gobin-$GO_BIN_VERSION` and symlinked into `staging_dir/hostpkg/bin/go$GO_BIN_VERSION`.

`gobin-` directory prefix is used to avoid collision with host go that uses `go-` prefix when bootstrapping in `golang-compiler.mk`.
    
`golang-build.sh` uses `GO_BIN_VERSION` if specified, and defaults to `golang/host` version otherwise.

There are some checks in `golang-build.sh` to prevent `go${GO_BIN_VERSION}` from leading to a command injection, the script is called from within a Makefile and all the previous checks like finding a matching version from `GO_BIN_HASHES` would need to pass for that to happen.
    
Only one patch version per `MAJOR.MINOR` and platform combination should be defined in `GO_BIN_HASHES`.
    
`golang/host` must be unset from `PKG_BUILD_DEPENDS`.
    
Supported Go version hashes (per host arch, thus supporting theoretical SDKs for other platforms, like `arm64`) are defined in `golang-values.mk` using `GO_BIN_HASHES` and can be looked up in https://go.dev/dl/

`golang/host` must be unset from `PKG_BUILD_DEPENDS` package variable when `GO_BIN_VERSION` is used.

Hence multiple versions, including global SDK host package, can co-exists in the same SDK setup:

```bash
# ls -lh staging_dir/hostpkg/bin
lrwxrwxrwx. 1 buildbot buildbot 22 Apr  6 23:22 go -> ../lib/go-cross/bin/go
lrwxrwxrwx. 1 buildbot buildbot 50 Apr  6 22:58 go1.23 -> ../lib/gobin-1.23/bin/go
lrwxrwxrwx. 1 buildbot buildbot 50 Apr  6 22:32 go1.24 -> ../lib/gobin-1.24/bin/go
lrwxrwxrwx. 1 buildbot buildbot 25 Apr  6 23:22 gofmt -> ../lib/go-cross/bin/gofmt
lrwxrwxrwx. 1 buildbot buildbot 53 Apr  6 22:58 gofmt1.23 -> ../lib/gobin-1.23/bin/gofmt
lrwxrwxrwx. 1 buildbot buildbot 53 Apr  6 22:32 gofmt1.24 -> ../lib/gobin-1.24/bin/gofmt
```

I added some additional logging:

```bash
# to show the selected version of go
syncthing requested go 1.23, matched to go 1.23.8.

# or exit when no match was found:
../../lang/golang/golang-package.mk:381: *** adguardhome requested go 2.24, but no matching version found..  Stop.

# and further to show the selected binary:
Using go version go1.23.8 linux/amd64 from /builder/staging_dir/hostpkg/bin/go1.23

# or when using host go:
Using host go version go1.24.2 linux/amd64 from /builder/staging_dir/hostpkg/bin/go
```

---

The three commits for AdGuard Home, Syncthing and Tailscale show examples of packages using different Go versions in the same setup. The Syncthing one is illustrative and is not meant to be merged.

This is a more complicated alternative to #26310 that _doesn't_ require an existing bootstrapped host go, and functions independently. Thus mimicking the new binary-only host node behavior, but with support for multiple parallel versions.

Related discussions wrt Tailscale #25062, #24741
