### PR TITLE
netbird: update to 0.38.2

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.38.0
+PKG_VERSION:=0.38.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=5683a4f507e142597222ac481d2e91115a13329dc2d5a612d74ede6410e82301
+PKG_HASH:=2f6de5427b098d97c72446475a7a780fee06f474b97935ef5599a13fc8de4c38
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## Compile and run tested

**Maintainer:** Me

| Package architecture | Target | Subtarget | Brand | Model | Hardware Version | OpenWrt version |
|----------------------|--------|-----------|-------|-------|------------------|-----------------|
| [x86_64](https://openwrt.org/docs/techref/instructionset/x86_64) | [x86](https://openwrt.org/docs/techref/targets/x86) | 64 | WOVIBO | B75 M.2 Intel LGA 1155 DDR3 | N/A | OpenWrt SNAPSHOT r29070-8d1fe32c2c |

Used a 'dirty' installation of the `OpenWrt` image instead of starting with a clean state:
```
# apk update
# apk upgrade
# apk add --allow-untrusted <package_name>.apk
# reboot
```

**Tests checklist:**
- [x] Connection to the NetBird Cloud Dashboard (not self-hosted).
- [x] Firewall configured with nftables.
- [x] Connection established in P2P mode.
- [x] `wireguard` kernel mode active.
- [x] Routes configured between my homelab and my cloud server.
- [x] `netbird` DNS server functioning correctly.
- [ ] NAT operational (not needed by me at this time, may consider testing in the future).
- [ ] Permissions rules is enforced (not needed by me at this time, may consider testing in the future).

## Description

- Changelog:
  - Update to [0.38.2](https://github.com/netbirdio/netbird/releases/tag/v0.38.2)
    - Full changelog: https://github.com/netbirdio/netbird/compare/v0.38.0...v0.38.2
    - Breaking change:
      - N/A

---

### Additional information

`x86_64` is running in a container using [`incus`](https://github.com/lxc/incus).
The package(s) was compiled with the container [`sdk`](https://github.com/openwrt/docker).
The `OpenWrt` image(s) was built using the container [`imagebuilder`](https://github.com/openwrt/docker) or [`distrobuilder`](https://github.com/lxc/distrobuilder).

You can view my repository with the patch applied and the automated build here:
`This repository is temporary and will be removed or modified after the merge.`
- https://github.com/wehagy/owpib/tree/netbird/update

You can find my artifacts here:
- https://github.com/wehagy/owpib/actions/runs/14022245718