### PR TITLE
tinyproxy: Update version to 1.11.2

### DIFF
--- a/net/tinyproxy/Makefile
+++ b/net/tinyproxy/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tinyproxy
-PKG_VERSION:=1.11.1
-PKG_RELEASE:=3
+PKG_VERSION:=1.11.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/tinyproxy/tinyproxy/releases/download/$(PKG_VERSION)
-PKG_HASH:=d66388448215d0aeb90d0afdd58ed00386fb81abc23ebac9d80e194fceb40f7c
+PKG_HASH:=6a126880706691c987e2957b1c99b522efb1964a75eb767af4b30aac0b88a26a
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/tinyproxy/files/tinyproxy.config
+++ b/net/tinyproxy/files/tinyproxy.config
@@ -207,18 +207,18 @@ list ConnectPort 563
 #  # connection to test domain goes through testproxy
 #
 #config upstream
-#	option type proxy
+#	option type proxy  # type "proxy" == "http"
 #	option via testproxy:8008
 #	option target ".test.domain.invalid"
 #
 #config upstream
-#	option type proxy
-#	option via testproxy:8008
+#	option type socks4
+#	option via testproxy:1080
 #	option target ".our_testbed.example.com"
 #
 #config upstream
-#	option type proxy
-#	option via testproxy:8008
+#	option type socks5
+#	option via testproxy:1080
 #	option target "192.168.128.0/255.255.254.0"
 #
 #  # no upstream proxy for internal websites and unqualified hosts

--- a/net/tinyproxy/files/tinyproxy.init
+++ b/net/tinyproxy/files/tinyproxy.init
@@ -23,6 +23,12 @@ write_upstream() {
 	config_get target "$1" target
 	[ -n "$target" ] && target=' "'"$target"'"'
 
+	[ "$type" = "socks4" ] && [ -n "$via" ] && \
+		echo "upstream socks4 $via$target"
+
+	[ "$type" = "socks5" ] && [ -n "$via" ] && \
+		echo "upstream socks5 $via$target"
+
 	[ "$type" = "proxy" ] && [ -n "$via" ] && \
 		echo "upstream http $via$target"
 


### PR DESCRIPTION
Maintainer: @jow-
Compile tested: x86_64
Run tested: X86-PC, OpenWrt 24.10.0

Description:

The package is updated to the latest version. In addition, support for Socks4/5 upstream proxies is added because the new version of the package supports it.

Signed-off-by: Lars The <lars18th@users.noreply.github.com>
