### PR TITLE
keepalived: bump to 2.3.2

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
-PKG_VERSION:=2.3.1
-PKG_RELEASE:=3
+PKG_VERSION:=2.3.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software
-PKG_HASH:=92f4b69bfd998e2306d1995ad16fdad1b59e70be694c883385c5f55e02c62aa3
+PKG_HASH:=77f4a22e5a23fa8e49b8916acdfb584c864e72905a2f1de2a7f62ed40a896160
 
 PKG_CPE_ID:=cpe:/a:keepalived:keepalived
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/keepalived/patches/001-vrrp-Don-t-include-linux-if_ether.h-if-not-needed.patch
+++ b/net/keepalived/patches/001-vrrp-Don-t-include-linux-if_ether.h-if-not-needed.patch
@@ -1,0 +1,31 @@
+From f129c588f7c8a66e595d8ae96a43d585018e79cd Mon Sep 17 00:00:00 2001
+From: Quentin Armitage <quentin@armitage.org.uk>
+Date: Thu, 7 Nov 2024 11:09:43 +0000
+Subject: [PATCH] vrrp: Don't include <linux/if_ether.h> if not needed
+
+The musl headers do not allow including both <linux/if_ether.h> and
+<net/ethernet.h> since they both define struct ethhdr.
+
+It is likely that we do not need to include <linux/if_ether.h> at all
+since with both glibc and musl including  <net/ethernet.h> is sufficient,
+but removing <linux/if_ether.h> is for another day.
+
+Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>
+---
+ keepalived/vrrp/vrrp.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/keepalived/vrrp/vrrp.c
++++ b/keepalived/vrrp/vrrp.c
+@@ -40,8 +40,10 @@
+ #include <netinet/ip6.h>
+ #include <stdint.h>
+ #include <net/if_arp.h>
+-#include <linux/if_ether.h>
+ #include <net/ethernet.h>
++#if !defined ETH_HLEN || !defined ETH_ZLEN
++#include <linux/if_ether.h>		/* This may not be needed at all - try removing and see if any issues raised */
++#endif
+ #ifdef _NETWORK_TIMESTAMP_
+ #include <linux/net_tstamp.h>
+ #endif

--- a/net/keepalived/patches/002-vrrp-fix-reading-of-iproute2-conf-files-when-directo.patch
+++ b/net/keepalived/patches/002-vrrp-fix-reading-of-iproute2-conf-files-when-directo.patch
@@ -1,0 +1,35 @@
+From 042dc49f8781cbc914c06e99f15de94bd153d4e2 Mon Sep 17 00:00:00 2001
+From: Quentin Armitage <quentin@armitage.org.uk>
+Date: Sun, 10 Nov 2024 11:31:40 +0000
+Subject: [PATCH] vrrp: fix reading of iproute2 conf files when directories
+ don't exist
+
+Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>
+---
+ lib/rttables.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+--- a/lib/rttables.c
++++ b/lib/rttables.c
+@@ -412,8 +412,9 @@ initialise_list(list_head_t *l, const ch
+ 
+ 			read_file(path, l, max);
+ 		}
++
++		closedir(dir);
+ 	}
+-	closedir(dir);
+ #endif
+ 
+ 	/* Now read the entries in the IPROUTE_ETC_DIR subdirectory */
+@@ -425,8 +426,9 @@ initialise_list(list_head_t *l, const ch
+ 
+ 			read_file(path, l, max);
+ 		}
++
++		closedir(dir);
+ 	}
+-	closedir(dir);
+ 
+ 	FREE_PTR(path);
+ #ifdef IPROUTE_USR_DIR


### PR DESCRIPTION
Maintainer: @feckert @scrpi 
Compile tested: OpenWrt master r29070-8d1fe32c2c on x86/64
Run tested: OpenWrt master r29070-8d1fe32c2c on qoriq

Description:
Bump keepalived to the current latest release, 2.3.2.

This requires backporting two upstream commits to avoid a segfault due to the /etc/iproute2/rt_addrprotos.d and
/usr/share/iproute2/rt_addrprotos.d directories not existing on OpenWrt, and the following compile error:

In file included from /home/stijn/Development/OpenWrt/openwrt/staging_dir/toolchain-powerpc64_e5500_gcc-13.3.0_musl/include/net/ethernet.h:10,
                 from vrrp.c:44:
/home/stijn/Development/OpenWrt/openwrt/staging_dir/toolchain-powerpc64_e5500_gcc-13.3.0_musl/include/netinet/if_ether.h:115:8: error: redefinition of 'struct ethhdr'
  115 | struct ethhdr {
      |        ^~~~~~
In file included from vrrp.c:43:
/home/stijn/Development/OpenWrt/openwrt/staging_dir/toolchain-powerpc64_e5500_gcc-13.3.0_musl/include/linux/if_ether.h:173:8: note: originally defined here
  173 | struct ethhdr {
      |        ^~~~~~
