### PR TITLE
zoneinfo: Updated to 2025b release.

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2025a
+PKG_VERSION:=2025b
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public-Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=4d5fcbc72c7c450ebfe0b659bd0f1c02fbf52fd7f517a9ea13fe71c21eb5f0d0
+PKG_HASH:=11810413345fc7805017e27ea9fa4885fd74cd61b2911711ad038f5d28d71474
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=119679d59f76481eb5e03d3d2a47d7870d592f3999549af189dbd31f2ebf5061
+   HASH:=05f8fedb3525ee70d49c87d3fae78a8a0dbae4fe87aa565c65cda9948ae135ec
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT master
Run tested: n/a

Description:

This release contains the following changes:

   Briefly:

     New zone for Aysén Region in Chile which moves from -04/-03 to -03.

   Changes to future timestamps

     Chile's Aysén Region moves from -04/-03 to -03 year-round, joining
     Magallanes Region.  The region will not change its clocks on
     2025-04-05 at 24:00, diverging from America/Santiago and creating a
     new zone America/Coyhaique.  (Thanks to Yonathan Dossow.)  Model
     this as a change to standard offset effective 2025-03-20.

   Changes to past timestamps

     Iran switched from +04 to +0330 on 1978-11-10 at 24:00, not at
     year end.  (Thanks to Roozbeh Pournader.)

   Changes to code

     'zic -l TIMEZONE -d . -l /some/other/file/system' no longer
     attempts to create an incorrect symlink, and no longer has a
     read buffer underflow.  (Problem reported by Evgeniy Gorbanev.)
