### PR TITLE
modemmanager: various fixes

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.22.0
-PKG_RELEASE:=21
+PKG_RELEASE:=22
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.22.0
-PKG_RELEASE:=22
+PKG_RELEASE:=23
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/usr/libexec/rpcd/modemmanager
+++ b/net/modemmanager/files/usr/libexec/rpcd/modemmanager
@@ -12,7 +12,7 @@ local info = {}
 
 function mm_get_modem_bearer(index)
 
-	local command = string.format("/usr/bin/mmcli --bearer=%s --output-json 2>/dev/null", index)
+	local command = string.format("/usr/bin/mmcli --bearer=%s --timeout=10 --output-json 2>/dev/null", index)
 
 	local handle = io.popen(command)
 	local output = handle:read("*a")
@@ -31,7 +31,7 @@ end
 
 function mm_get_modem_sim(index)
 
-	local command = string.format("/usr/bin/mmcli --sim=%s --output-json 2>/dev/null", index)
+	local command = string.format("/usr/bin/mmcli --sim=%s --timeout=10 --output-json 2>/dev/null", index)
 
 	local handle = io.popen(command)
 	local output = handle:read("*a")
@@ -50,7 +50,7 @@ end
 
 function mm_get_modem_signal(modem)
 
-	local command = string.format("/usr/bin/mmcli --modem=%s --signal-get --output-json 2>/dev/null", modem)
+	local command = string.format("/usr/bin/mmcli --modem=%s --signal-get --timeout=10 --output-json 2>/dev/null", modem)
 
 	local handle = io.popen(command)
 	local output = handle:read("*a")
@@ -69,7 +69,7 @@ end
 
 function mm_get_modem_location(modem)
 
-	local command = string.format("/usr/bin/mmcli --modem=%s --location-get --output-json 2>/dev/null", modem)
+	local command = string.format("/usr/bin/mmcli --modem=%s --location-get --timeout=10 --output-json 2>/dev/null", modem)
 
 	local handle = io.popen(command)
 	local output = handle:read("*a")
@@ -88,7 +88,7 @@ end
 
 function mm_get_modem_status(modem)
 
-	local command = string.format("/usr/bin/mmcli --modem=%s --output-json 2>/dev/null", modem)
+	local command = string.format("/usr/bin/mmcli --modem=%s --timeout=10 --output-json 2>/dev/null", modem)
 
 	local handle = io.popen(command)
 	local output = handle:read("*a")
@@ -145,7 +145,7 @@ end
 
 function aquire_data_modemmanager()
 
-	local command = string.format("/usr/bin/mmcli --list-modems --output-json 2>/dev/null")
+	local command = string.format("/usr/bin/mmcli --list-modems --timeout=10 --output-json 2>/dev/null")
 
 	local handle = io.popen(command)
 	local output = handle:read("*a")

--- a/net/modemmanager/files/usr/sbin/ModemManager-monitor
+++ b/net/modemmanager/files/usr/sbin/ModemManager-monitor
@@ -6,9 +6,10 @@
 
 trap_with_arg() {
 	func="$1" ; shift
+	pid="$1" ; shift
 	for sig ; do
 		# shellcheck disable=SC2064
-		trap "$func $sig" "$sig"
+		trap "$func $sig $pid" "$sig"
 	done
 }
 
@@ -23,7 +24,7 @@ func_trap() {
 		mm_monitor_cache_remove "$object"
 	done < ${MODEMMANAGER_MONITOR_CACHE}
 
-	kill "-${1}" "$CHILD" 2>/dev/null
+	kill "-${1}" "$2" 2>/dev/null
 }
 
 mm_monitor_get_sysfspath() {
@@ -116,8 +117,6 @@ main() {
 	local step=1
 	local mmrunning=0
 
-	trap_with_arg func_trap INT TERM KILL
-
 	mkdir -p "${MODEMMANAGER_RUNDIR}"
 	chmod 0755 "${MODEMMANAGER_RUNDIR}"
 
@@ -140,16 +139,18 @@ main() {
 		return
 	}
 
-	/usr/bin/mmcli -M | {
+	sh -c "echo \$\$; exec /usr/bin/mmcli -M" | {
+		read -r monitor_pid
+		trap_with_arg func_trap "$monitor_pid" SIGINT SIGTERM SIGKILL
 		local line
 		while read -r line; do
 			mm_log "debug" "Monitor cache line: ${line}"
 			mm_monitor_cache "$line"
 		done
 	} &
-	CHILD="$!"
-
-	wait $CHILD
+	child="$!"
+	trap_with_arg func_trap "$child" SIGINT SIGTERM SIGKILL
+	wait $child
 }
 
 main "$@"


### PR DESCRIPTION
Maintainer: me
Compile tested: not needed only script changes
Run tested: x86_64, APU3, OpenWrt version

Description:
```
modemmanager: add missing mmcli timeout option during ubus call
The default 'timeout' value is 30 seconds when calling an mmcli action. That
is too long. For this reason, the mmcli 'timeout' option is specified for
calls and the value is set to 10 seconds.
```

```
modemmanager: fix pending mmcli calls for ModemManager-monitor script
If the ModemManager is stopped via '/etc/init.d/modemmanager', mmcli calls
always remain in the process list. This is because the ModemManager-monitor
call is not terminated properly, as the kill signals are not handled
correctly in the startup script for mmcli. To fix this, the signal handling is refactored.
```