### PR TITLE
wfb-ng: Update to release 25.01

### DIFF
--- a/net/wfb-ng/Makefile
+++ b/net/wfb-ng/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wfb-ng
-PKG_VERSION:=24.09.23
+PKG_VERSION:=25.01
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/svpcom/wfb-ng/tar.gz/$(PKG_NAME)-$(PKG_VERSION)?
-PKG_HASH:=c6cf669090952f6e430166a23b2fd787c6f7d4fd2d8d1996e8e3713f5cc4f8d9
+PKG_HASH:=0179542732c094a3383c7447dc7930e28b9d6684cc67dde64b8ea146a55ef962
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-3.0-only
@@ -14,6 +14,7 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Vasily Evseenko <svpcom@p2ptech.org>
 
 PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DEPENDS:=libevent2
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -38,12 +39,25 @@ define Package/wfb-ng/conffiles
 /usr/sbin/wfb-ng.sh
 endef
 
+define Package/wfb-ng-tun
+$(call Package/wfb-ng)
+  TITLE:=Long-range packet radio link using raw WiFi (tunnel)
+  DEPENDS:=+libevent2-core +kmod-tun
+endef
+
 define Package/wfb-ng/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wfb_rx $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wfb_tx $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wfb_tx_cmd $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/wfb-ng.init $(1)/etc/init.d/wfb-ng
 endef
 
+define Package/wfb-ng-tun/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wfb_tun $(1)/usr/bin/
+endef
+
 $(eval $(call BuildPackage,wfb-ng))
+$(eval $(call BuildPackage,wfb-ng-tun))


### PR DESCRIPTION
Changes:

1) FEC optimizations
2) Added tunnel daemon
3) Added wfb_tx_cmd utility

Maintainer: me
Compile tested: (ath79_generic, TP-Link CPE510, OpenWrt 24.10)
Run tested: (ath79_generic, TP-Link CPE510, OpenWrt 24.10)

Description:
This is update of wfb-ng to latest release 25.01. In includes three major changes described above and multiple minor improvements.  Also please backport this commit to 24.10 packages branch if possible.