### PR TITLE
adguardhome: increase UDP send/receive buffers

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
 PKG_VERSION:=0.107.59
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/AdGuardHome/tar.gz/v$(PKG_VERSION)?
@@ -78,6 +78,9 @@ define Package/adguardhome/install
 
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DATA) ./files/adguardhome.config $(1)/etc/config/adguardhome
+
+	$(INSTALL_DIR) $(1)/etc/sysctl.d
+	$(INSTALL_CONF) ./files/adguardhome.sysctl $(1)/etc/sysctl.d/50-adguardhome.conf
 endef
 
 $(eval $(call Download,adguardhome-frontend))

--- a/net/adguardhome/files/adguardhome.sysctl
+++ b/net/adguardhome/files/adguardhome.sysctl
@@ -1,0 +1,3 @@
+# quic-go expects larger UDP send/receive buffers
+net.core.rmem_max = 7500000
+net.core.wmem_max = 7500000


### PR DESCRIPTION
Maintainer: @dobo90 @1715173329 
Compile tested: mediatek/filogic on 24.10
Run tested: mediatek/filogic on 24.10, Zyxel EX5601-T0 ubootmod (T-56)

- all files are installed correctly
- version check returns the correct version
- service starts without quic-go warnings
- web UI loads
- DNS keeps resolving

Description:

Addresses the low buffers warning from quic-go:

> Experiments have shown that QUIC transfers on high-bandwidth connections can be limited by the size of the UDP receive and send buffer. The receive buffer holds packets that have been received by the kernel, but not yet read by the application (quic-go in this case). The send buffer holds packets that have been sent by quic-go, but not sent out by the kernel. In both cases, once these buffers fill up, the kernel will drop any new incoming packet.

The sysctl config is numbered to go _after_ a similar Transmission one (which this PR doesn't conflict with), that sets lower values.

More info: https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes