### PR TITLE
snort3: update to 3.8.1.0

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
-PKG_VERSION:=3.7.1.0
+PKG_VERSION:=3.8.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
 PKG_SOURCE_URL:=https://github.com/snort3/snort3
-PKG_MIRROR_HASH:=e70af1a4fc97260094a5ef44d6133c12e3da8e82769788e2677d4fdb020f0c44
+PKG_MIRROR_HASH:=ab6d5c4b433b5f1abc23299ec4c4efd8048f479a2ae1c45203699a5f998cb960
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>, John Audia <therealgraysky@proton.me>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Removed upstreamed and bumped to latest release:
      110-packet_capture-Fix-compilation-with-GCC-13.patch

Changelog: https://github.com/snort3/snort3/releases/tag/3.8.1.0
```
       ,,_     -*> Snort++ <*-
      o"  )~   Version 3.8.1.0
       ''''    By Martin Roesch & The Snort Team
               http://snort.org/contact#team
               Copyright (C) 2014-2025 Cisco and/or its affiliates. All rights reserved.
               Copyright (C) 1998-2013 Sourcefire, Inc., et al.
               Using DAQ version 3.0.19
               Using Hyperscan version 5.4.2 2025-05-27
               Using libpcap version 1.10.5 (with TPACKET_V3)
               Using LuaJIT version 2.1.0-beta3
               Using LZMA version 5.6.2
               Using OpenSSL 3.5.0 8 Apr 2025
               Using PCRE2 version 10.42 2022-12-11
               Using ZLIB version 1.3.1
``` 
Build system: x86/64
Build-tested: x86/64
Run-tested: x86/64

Maintainer: me