### PR TITLE
ddns-scripts: always use the 'ps' output from busybox

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=66
+PKG_RELEASE:=67
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -210,7 +210,7 @@ stop_section_processes() {
 
 	[ -e "$__PIDFILE" ] && {
 		__PID=$(cat $__PIDFILE)
-		ps | grep "^[\t ]*$__PID" >/dev/null 2>&1 && kill $__PID || __PID=0	# terminate it
+		busybox ps | grep "^[\t ]*$__PID" >/dev/null 2>&1 && kill $__PID || __PID=0	# terminate it
 	}
 	[ $__PID -eq 0 ] # report if process was running
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: no
Run tested: no

Description:

Fixes #26067 

The 'ps' command from 'procps-ng' is used in favour of 'ps' from 'busybox' when 'procps-ng' is installed. The problem is that the outputs are not compatible and the ‘grep’ is different for further processing. To fix this, always use the 'ps' command from 'busybox'.

