### PR TITLE
ddns-scripts: fix ddns-scripts-scaleway description

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -276,7 +276,7 @@ define Package/ddns-scripts-scaleway
   DEPENDS:=ddns-scripts +curl
 endef
 
-define Package/ddns-scripts-scaleway
+define Package/ddns-scripts-scaleway/description
   Dynamic DNS Client scripts extension for Scaleway.
   Parameters:
   'option username'  The zone in which the RR is to be set


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: None
Run tested: None

Description:
ddns-scripts-scaleway description section was not defined as such and was overriding the package definition leading to:
Makefile:839: *** missing separator.  Stop.

Fixes: a7867016c84c ("ddns-scripts: add support for Scaleway DNS")