### PR TITLE
[24.10] antiblock: Update to 2.1.2

### DIFF
--- a/net/antiblock/Makefile
+++ b/net/antiblock/Makefile
@@ -1,13 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=antiblock
-PKG_VERSION:=2.0.2
+PKG_VERSION:=2.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/karen07/antiblock
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
-PKG_MIRROR_HASH:=00d9d50d12bdb3d3ec6ddefe0b3ea254433a1d58867b0fae87a12dd24ec1ba87
+PKG_MIRROR_HASH:=d9e86dea43ab19b5ca6887a8c444bac0fa7b3a6e4c9976ac50817cdd11dd9d4b
 
 PKG_MAINTAINER:=Khachatryan Karen <karen0734@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -19,15 +19,15 @@ include $(INCLUDE_DIR)/cmake.mk
 define Package/antiblock
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libcurl
+  DEPENDS:=+libcurl +libpcap
   TITLE:=AntiBlock
   URL:=https://github.com/karen07/antiblock
 endef
 
 define Package/antiblock/description
-  AntiBlock program proxies DNS requests.
-  The IP addresses of the specified domains are added to
-  the routing table for routing through the specified interface.
+  AntiBlock sniffer DNS requests. The IP addresses of the
+  specified domains are added to the routing table for
+  routing through the specified interfaces.
 endef
 
 define Package/antiblock/conffiles

--- a/net/antiblock/files/etc/config/antiblock
+++ b/net/antiblock/files/etc/config/antiblock
@@ -1,14 +1,26 @@
 
-#config antiblock 'config'
-	#option enabled '0'
-	#At least one parameters needs to be filled:
-		#option url 'https://antifilter.download/list/domains.lst'
-		#option file '/root/domains'
-	#Required parameters:
-		#option listen '192.168.1.1:5053'
-		#option DNS '1.1.1.1:53'
-		#option VPN_name 'VPN'
-	#Optional parameters:
-		#option log '1'
-		#option stat '1'
-		#option output '/tmp/antiblock'
+#config main 'config'
+#Required parameters:
+	#option enabled       '0'
+#Optional parameters:
+	#option log			  '1'
+	#option stat		  '1'
+	#list blacklist 	  'x.x.x.x/xx'
+	#list blacklist 	  'x.x.x.x/xx'
+
+#It is necessary to enter from 1 to 32 values:
+#config route
+	#option gateway       'gateway1'
+	#option domains_path  'https://test1.com'
+
+#config route
+	#option gateway       'gateway2'
+	#option domains_path  '/test1.txt'
+
+#config route
+	#option gateway       'gateway2'
+	#option domains_path  '/test2.txt'
+
+#config route
+	#option gateway       'gateway1'
+	#option domains_path  'https://test2.com'

--- a/net/antiblock/files/etc/init.d/antiblock
+++ b/net/antiblock/files/etc/init.d/antiblock
@@ -3,10 +3,30 @@
 USE_PROCD=1
 START=99
 
-CONF="antiblock"
+prog_name="antiblock"
+tmp_folder="/tmp/$prog_name"
+blacklist_file="$tmp_folder/blacklist"
+
+routes_parse() {
+	local _config="$1"
+
+	local _gateway
+	local _domains_path
+
+	config_get _gateway "${_config}" gateway
+	config_get _domains_path "${_config}" domains_path
+
+	procd_append_param command -r "${_gateway} ${_domains_path}"
+}
+
+blacklist_parse() {
+	[ "${_blacklist_count}" -eq "0" ] && mkdir -p $tmp_folder && >$blacklist_file
+	_blacklist_count=$(expr "${_blacklist_count}" + 1)
+	echo "$1" >>$blacklist_file
+}
 
 start_service() {
-	config_load "$CONF"
+	config_load "$prog_name"
 
 	local _enabled
 	config_get_bool _enabled "config" "enabled" "0"
@@ -14,70 +34,40 @@ start_service() {
 
 	echo "AntiBlock start"
 
-	local _url
-	local _file
-	local _listen
-	local _DNS
-	local _VPN_name
 	local _log
 	local _stat
-	local _output
-
-	config_get _url "config" "url"
-	config_get _file "config" "file"
-
-	config_get _listen "config" "listen"
-	config_get _DNS "config" "DNS"
-	config_get _VPN_name "config" "VPN_name"
+	local _test
 
 	config_get_bool _log "config" "log" "0"
 	config_get_bool _stat "config" "stat" "0"
-	config_get _output "config" "output"
+	config_get_bool _test "config" "test" "0"
 
-	procd_open_instance "$CONF"
+	_blacklist_count=0
+	config_list_foreach "config" blacklist blacklist_parse
 
-	procd_set_param command "/usr/bin/antiblock"
+	procd_open_instance "$prog_name"
+
+	procd_set_param command "/usr/bin/$prog_name"
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 
-	[ -n "${_url}" ] && procd_append_param command -url "${_url}"
-	[ -n "${_file}" ] && procd_append_param command -file "${_file}"
+	config_foreach routes_parse route
 
-	if [ -n "${_listen}" ]; then
-		local listen_IP="$(echo "${_listen}" | cut -d ':' -f1)"
-		local listen_port="$(echo "${_listen}" | cut -d ':' -f2)"
-		uci -q set dhcp.@dnsmasq[0].noresolv="1"
-		uci -q delete dhcp.@dnsmasq[0].server
-		uci -q add_list dhcp.@dnsmasq[0].server="$listen_IP#$listen_port"
+	local _listen
+	_listen="$(uci -q get network.lan.ipaddr):53"
+	procd_append_param command -l "${_listen}"
 
-		procd_append_param command -listen "${_listen}"
-	fi
-	[ -n "${_DNS}" ] && procd_append_param command -DNS "${_DNS}"
-	if [ -n "${_VPN_name}" ]; then
-		local gateway="$(ip r | grep -v via | grep "dev ${_VPN_name} " | grep src | awk '{print $NF}')"
-		procd_append_param command -gateway "$gateway"
-	fi
-
-	[ "${_log}" -ne "0" ] && procd_append_param command -log
-	[ "${_stat}" -ne "0" ] && procd_append_param command -stat
-	if [ -n "${_output}" ]; then
-		mkdir -p "${_output}"
-		procd_append_param command -output "${_output}"
-	fi
+	procd_append_param command -o "$tmp_folder"
+	[ "${_blacklist_count}" -ne "0" ] && procd_append_param command -b "$blacklist_file"
+	[ "${_log}" -ne "0" ] && mkdir -p $tmp_folder && procd_append_param command --log
+	[ "${_stat}" -ne "0" ] && mkdir -p $tmp_folder && procd_append_param command --stat
+	[ "${_test}" -ne "0" ] && procd_append_param command --test
 
 	procd_close_instance
 
 	/etc/init.d/dnsmasq restart >/dev/null 2>&1
 }
 
-stop_service() {
-	echo "AntiBlock stop"
-
-	uci -q revert dhcp.@dnsmasq[0]
-
-	/etc/init.d/dnsmasq restart >/dev/null 2>&1
-}
-
 service_triggers() {
-	procd_add_reload_trigger "$CONF"
+	procd_add_reload_trigger "$prog_name"
 }

--- a/net/antiblock/test.sh
+++ b/net/antiblock/test.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-antiblock | grep "AntiBlock started $PKG_VERSION"
+antiblock | grep "AntiBlock $PKG_VERSION"


### PR DESCRIPTION
1) Added the ability to route different domains through different gateways, up to 32 routes.
2) The program has been switched from proxying mode to sniffer mode.
3) Blacklist has been added so that the specified subnets are not added to the routing table.
4) Log updated.
5) The "output" option has been removed from the service, it is now /tmp/antiblock