### PR TITLE
eza: update to 0.21.0

### DIFF
--- a/utils/eza/Makefile
+++ b/utils/eza/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=eza
-PKG_VERSION:=0.20.20
+PKG_VERSION:=0.21.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eza-community/eza/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8731184ff1b1d3dbd6bb8fda8f750780a58ccac682fd6344d92160dc518937de
+PKG_HASH:=885ae7a12c7ed68dd3a7cca76d4e8beaa100c9e9d6b7ad136b5bb6785e16b28b
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=EUPL-1.2


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt snapshot
Run tested: aarch64_cortex-a53 (BananaPi R64), OpenWrt snapshot, simple function test

[release notes]
0.20.21: https://github.com/eza-community/eza/releases/tag/v0.20.21
0.20.22: https://github.com/eza-community/eza/releases/tag/v0.20.22
0.20.23: https://github.com/eza-community/eza/releases/tag/v0.20.23
0.20.24: https://github.com/eza-community/eza/releases/tag/v0.20.24
