### PR TITLE
[24.10] openvpn: update to 2.6.14

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.6.13
+PKG_VERSION:=2.6.14
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=1af10b86922bd7c99827cc0f151dfe9684337b8e5ebdb397539172841ac24a6a
+PKG_HASH:=9eb6a6618352f9e7b771a9d38ae1631b5edfeed6d40233e243e602ddf2195e7a
 
 PKG_MAINTAINER:=
 

--- a/net/openvpn/patches/100-mbedtls-disable-runtime-version-check.patch
+++ b/net/openvpn/patches/100-mbedtls-disable-runtime-version-check.patch
@@ -1,6 +1,6 @@
 --- a/src/openvpn/ssl_mbedtls.c
 +++ b/src/openvpn/ssl_mbedtls.c
-@@ -1612,7 +1612,7 @@ const char *
+@@ -1616,7 +1616,7 @@ const char *
  get_ssl_library_version(void)
  {
      static char mbedtls_version[30];


### PR DESCRIPTION
Maintainer: @neheb @AuthorReflex
Compile tested: ramips/mt7620
Run tested: Xiaomi Mi-mini

Security fixes:

​CVE-2025-2704: fix possible ASSERT() on OpenVPN servers using --tls-crypt-v2
 Security scope: OpenVPN servers between 2.6.1 and 2.6.13 using --tls-crypt-v2 can be made
 to abort with an ASSERT() message by sending a particular combination of authenticated and
 malformed packets. No crypto integrity is violated, no data is leaked, and no remote code
 execution is possible. This bug does not affect OpenVPN clients.

For details refer to https://github.com/OpenVPN/openvpn/blob/v2.6.14/Changes.rst

cherry-picked from https://github.com/openwrt/packages/pull/26260