### PR TITLE
openfortivpn: bump to 1.23.1; add saml login support

### DIFF
--- a/net/openfortivpn/Makefile
+++ b/net/openfortivpn/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openfortivpn
-PKG_VERSION:=1.22.1
+PKG_VERSION:=1.23.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/adrienverge/openfortivpn/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=9aaaae2229f01b35bf79dcc9e1c0a4363cec75084a30fd46df58c20d52bff809
+PKG_HASH:=ecacfc7f18d87f4ff503198177e51a83316b59b4646f31caa8140fdbfaa40389
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later OpenSSL

--- a/net/openfortivpn/files/openfortivpn.sh
+++ b/net/openfortivpn/files/openfortivpn.sh
@@ -22,6 +22,8 @@ proto_openfortivpn_init_config() {
 	proto_config_add_int "persist_int"
 	proto_config_add_string "trusted_cert"
 	proto_config_add_string "remote_status_check"
+	proto_config_add_boolean "saml_login"
+	proto_config_add_int "saml_login_port"
 	no_device=1
 	available=1
 }
@@ -32,9 +34,9 @@ proto_openfortivpn_setup() {
 	local msg ifname ip server_ips pwfile callfile
 
 	local peeraddr port tunlink local_ip username password persist_int \
-	      trusted_cert remote_status_check
+	      trusted_cert remote_status_check saml_login saml_login_port
 	json_get_vars host peeraddr port tunlink local_ip username password persist_int \
-		      trusted_cert remote_status_check
+		      trusted_cert remote_status_check saml_login saml_login_port
 
 	ifname="vpn-$config"
 
@@ -137,6 +139,14 @@ proto_openfortivpn_setup() {
 	[ -f /etc/openfortivpn/user-cert-$config.pem ] && append_args "--user-cert=/etc/openfortivpn/user-cert-$config.pem"
 	[ -f /etc/openfortivpn/user-key-$config.pem ] && append_args "--user-key=/etc/openfortivpn/user-key-$config.pem"
 	[ -f /etc/openfortivpn/ca-$config.pem ] && append_args "--ca-file=/etc/openfortivpn/ca-$config.pem"
+
+	[ "$saml_login" = 1 ]  && {
+		if [ -n "$saml_login_port" ]; then
+			append_args "--saml-login=$saml_login_port"
+		else
+			append_args "--saml-login"
+		fi
+	}
 
 	callfile="/var/etc/openfortivpn/peers/$config"
 	echo "115200


### PR DESCRIPTION
Maintainer: Aaron Goodman
Compile tested: MIPS, MT761; OpenWrt 24.10.0
Run tested: MIPS, MT761; OpenWrt 24.10.0; tested: connect to VPN server