### PR TITLE
cpu-load-mon: Initial commit

### DIFF
--- a/utils/cpu-load-mon/Makefile
+++ b/utils/cpu-load-mon/Makefile
@@ -1,0 +1,53 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cpu-load-mon
+PKG_VERSION=1.0
+PKG_RELEASE:=1
+MAINTAINER:=Nikita Kuchinsky <nik.owrt@serenity-island.net>
+
+PKG_SOURCE=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeberg.org/sie-foss/cpu-load-mon/archive/$(PKG_VERSION).tar.gz?
+PKG_HASH:=d43b47dbe2436e50554e16da87d50fdba5d7bba6fe78ad62ef5d12fdd7962d65
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/cpu-load-mon
+	SECTION:=utils
+	CATEGORY:=Utilities
+	TITLE:=CPU Load Monitor
+	URL:=https://codeberg.org/sie-foss/cpu-load-mon
+	PKGARCH:=all
+	PROVIDES:=cpu-load-avg
+endef
+
+define Package/cpu-load-mon/description
+CPU Load Monitor service written in awk (mawk).
+Gathers CPU utilization data over time in the background and displays
+averages over the last 1 min, 5 min, 15 min and overall (since boot).
+endef
+
+UNPACK_CMD=tar -xaf "$(DL_DIR)/$(PKG_SOURCE)" --directory $(PKG_BUILD_DIR)
+SRC_DIR:=$(PKG_BUILD_DIR)/$(PKG_NAME)
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	sed -f ./files/strip-comments.sed $(SRC_DIR)/cpu-load-avg.awk       > $(PKG_BUILD_DIR)/cpu-load-avg.awk
+	sed -f ./files/strip-comments.sed $(SRC_DIR)/cpu-load-stats-log.awk > $(PKG_BUILD_DIR)/cpu-load-stats-log.awk
+	sed -f ./files/strip-comments.sed ./files/cpu-load-mon.init         > $(PKG_BUILD_DIR)/cpu-load-mon.init
+	$(Build/Patch)
+endef
+
+define Build/Configure
+endef
+define Build/Compile
+endef
+
+define Package/cpu-load-mon/install
+	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/libexec $(1)/etc/init.d $(1)/etc/config
+	$(INSTALL_DATA) ./files/cpu-load-mon.conf $(1)/etc/config/$(PKG_NAME)
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/cpu-load-avg.awk $(1)/usr/bin/cpu-load-avg
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/cpu-load-stats-log.awk $(1)/usr/libexec/cpu-load-stats-log.awk
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/cpu-load-mon.init $(1)/etc/init.d/$(PKG_NAME)
+endef
+
+$(eval $(call BuildPackage,cpu-load-mon))
+

--- a/utils/cpu-load-mon/files/cpu-load-mon.conf
+++ b/utils/cpu-load-mon/files/cpu-load-mon.conf
@@ -1,0 +1,3 @@
+config cpu-load-mon
+#    option stats_path '/run/cpu-load-data.log'
+#    option stats_interval_sec '60'

--- a/utils/cpu-load-mon/files/cpu-load-mon.init
+++ b/utils/cpu-load-mon/files/cpu-load-mon.init
@@ -1,0 +1,21 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=01
+USE_PROCD=1
+
+start_service() {
+	procd_open_instance
+	config_load "cpu-load-mon"
+	local val
+	config_get val "stats_path" ""
+	if [ -n "$val" ]; then procd_set_param env CPU_LOAD_STATS_PATH="$val"; fi
+	if [ ! -d /var/run ]; then mkdir -p /var/run; fi
+	if [ ! -x /run ]; then ln -s /var/run /run; fi
+	config_get val "stats_interval_sec" "60"
+	procd_set_param command /bin/sh -ec "while true; do awk -f /usr/libexec/cpu-load-stats-log.awk; sleep ${val}; done"
+	procd_set_param term_timeout 1
+	procd_set_param respawn 180 10 10
+	procd_close_instance
+}
+

--- a/utils/cpu-load-mon/files/strip-comments.sed
+++ b/utils/cpu-load-mon/files/strip-comments.sed
@@ -1,0 +1,3 @@
+#!/bin/sed -f
+
+1{/^#!/ {p}}; /^[\t\ ]*#/d;/\.*#.*/ {/[\x22\x27].*#.*[\x22\x27]/ !{:regular_loop s/[\t ]*[^\]#.*//;t regular_loop}; /[\x22\x27].*#.*[\x22\x27]/ {:special_loop s/\([\x22\x27].*#.*[^\x22\x27]\)#.*/\1/;t special_loop}; /\\#/ {:second_special_loop s/\(.*\\#.*[^\]\)#.*/\1/;t second_special_loop}}


### PR DESCRIPTION
### Maintainer:
- Nikita Kuchinsky <nik.owrt@serenity-island.net>

### Compile tested:
- arch: `MediaTek MT7621 ver:1 eco:3`, model: `MikroTik RouterBOARD 760iGS (hEX S)`, OpenWrt version: `OpenWrt 24.10.0`

### Run tested: 
- arch: `MediaTek MT7621 ver:1 eco:3`, model: `MikroTik RouterBOARD 760iGS (hEX S)`, OpenWrt version: `OpenWrt 24.10.0`
- arch: `Atheros AR7161 rev 2`, model: `Aruba AP-105`, OpenWrt version: `OpenWrt 24.10.0`
- arch: `ARMv8 Processor rev 4`, model: `Routerich AX3000`, OpenWrt version: `OpenWrt 23.05.5`

### Tests done:
- service starts automatically, runs stably
- front-end command executes without any errors

### Description:
Initial commit that adds `cpu-load-mon` architecture-independent utility, which might be useful/convenient tool when aggregating various hardware utilization statistics.

If possible, please grant me commit access to let me maintain this utility.