### PR TITLE
ipmitool: disable download of IANA enterprise numbers

### DIFF
--- a/admin/ipmitool/Makefile
+++ b/admin/ipmitool/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ipmitool
 PKG_VERSION:=1.8.19
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://codeberg.org/IPMITool/ipmitool
@@ -53,6 +53,7 @@ CONFIGURE_ARGS += \
 	--disable-intf-free \
 	--enable-intf-open \
 	--enable-intf-imb \
-	--enable-ipmishell
+	--enable-ipmishell \
+	--disable-registry-download
 
 $(eval $(call BuildPackage,ipmitool))

--- a/admin/ipmitool/patches/0001-Do-not-require-the-IANA-PEN-registry-file.patch
+++ b/admin/ipmitool/patches/0001-Do-not-require-the-IANA-PEN-registry-file.patch
@@ -1,0 +1,103 @@
+From 26b088193a55624df4cbe2a0d33c7bba5bca108d Mon Sep 17 00:00:00 2001
+From: Vincent Fazio <vfazio@gmail.com>
+Date: Sat, 7 Jan 2023 21:02:48 -0600
+Subject: [PATCH] Do not require the IANA PEN registry file
+
+Previously, ipmitool would fail to run if the local copy of the IANA PEN
+registry could not be parsed.
+
+When the registry is not available the manufacturer will be "Unknown" but
+ipmitool will otherwise function so should not be considered fatal.
+
+Also, fix an issue with improperly handling the `oem_info_list_load`
+return value. Previously, in `ipmi_oem_info_init`, if `oem_info_list_load`
+returned a negative value due to the registry file not existing, an
+improper count would cause `oem_info_init_from_list` to aallocate a list
+that didn't encompass the full header/tail list.
+
+  IANA PEN registry open failed: No such file or directory
+    Allocating      3 entries
+    [     1] 16777214 | A Debug Assisting Company, Ltd.
+    [     0]  1048575 | Unspecified
+
+Now, use a signed int and ensure a valid count of loaded OEMs is used.
+
+Signed-off-by: Vincent Fazio <vfazio@gmail.com>
+---
+ include/ipmitool/ipmi_strings.h |  2 +-
+ lib/ipmi_main.c                 |  5 +----
+ lib/ipmi_strings.c              | 19 +++++--------------
+ 3 files changed, 7 insertions(+), 19 deletions(-)
+
+--- a/include/ipmitool/ipmi_strings.h
++++ b/include/ipmitool/ipmi_strings.h
+@@ -55,7 +55,7 @@ extern const struct valstr ipmi_integrit
+ extern const struct valstr ipmi_encryption_algorithms[];
+ extern const struct valstr ipmi_user_enable_status_vals[];
+ extern const struct valstr *ipmi_oem_info;
+-int ipmi_oem_info_init();
++void ipmi_oem_info_init();
+ void ipmi_oem_info_free();
+ 
+ extern const struct valstr picmg_frucontrol_vals[];
+--- a/lib/ipmi_main.c
++++ b/lib/ipmi_main.c
+@@ -853,10 +853,7 @@ ipmi_main(int argc, char ** argv,
+ 	}
+ 
+ 	/* load the IANA PEN registry */
+-	if (ipmi_oem_info_init()) {
+-		lprintf(LOG_ERR, "Failed to initialize the OEM info dictionary");
+-		goto out_free;
+-	}
++	ipmi_oem_info_init();
+ 
+ 	/* run OEM setup if found */
+ 	if (oemtype &&
+--- a/lib/ipmi_strings.c
++++ b/lib/ipmi_strings.c
+@@ -1719,39 +1719,30 @@ out:
+ 	return rc;
+ }
+ 
+-int ipmi_oem_info_init()
++void ipmi_oem_info_init()
+ {
+ 	oem_valstr_list_t terminator = { { -1, NULL}, NULL }; /* Terminator */
+ 	oem_valstr_list_t *oemlist = &terminator;
+ 	bool free_strings = true;
+-	size_t count;
+-	int rc = -4;
++	int count;
+ 
+ 	lprintf(LOG_INFO, "Loading IANA PEN Registry...");
+ 
+ 	if (ipmi_oem_info) {
+ 		lprintf(LOG_INFO, "IANA PEN Registry is already loaded");
+-		rc = 0;
+ 		goto out;
+ 	}
+ 
+-	if (!(count = oem_info_list_load(&oemlist))) {
+-		/*
+-		 * We can't identify OEMs without a loaded registry.
+-		 * Set the pointer to dummy and return.
+-		 */
+-		ipmi_oem_info = ipmi_oem_info_dummy;
+-		goto out;
++	if ((count = oem_info_list_load(&oemlist)) < 1) {
++		lprintf(LOG_WARN, "Failed to load entries from IANA PEN Registry");
++		count = 0;
+ 	}
+ 
+ 	/* In the array was allocated, don't free the strings at cleanup */
+ 	free_strings = !oem_info_init_from_list(oemlist, count);
+ 
+-	rc = IPMI_CC_OK;
+-
+ out:
+ 	oem_info_list_free(&oemlist, free_strings);
+-	return rc;
+ }
+ 
+ void ipmi_oem_info_free()

--- a/admin/ipmitool/patches/0002-configure.ac-allow-disabling-registry-downloads.patch
+++ b/admin/ipmitool/patches/0002-configure.ac-allow-disabling-registry-downloads.patch
@@ -1,0 +1,67 @@
+From be11d948f89b10be094e28d8a0a5e8fb532c7b60 Mon Sep 17 00:00:00 2001
+From: Vincent Fazio <vfazio@gmail.com>
+Date: Wed, 11 Jan 2023 22:55:51 -0600
+Subject: [PATCH] configure.ac: allow disabling registry downloads
+
+Some environments require reproducible builds. Since the IANA PEN
+registry is constantly updating and there is no snapshot available,
+installing ipmitool via `make install` is not reproducible.
+
+Provide a configure mechanism to disable the registry download/install..
+---
+ configure.ac | 30 ++++++++++++++++++++----------
+ 1 file changed, 20 insertions(+), 10 deletions(-)
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -18,8 +18,6 @@ AC_PROG_LN_S
+ AC_PROG_MAKE_SET
+ AC_CHECK_PROG([RPMBUILD], [rpmbuild], [rpmbuild], [rpm])
+ AC_CHECK_PROG([SED], [sed], [sed])
+-AC_CHECK_PROG([WGET], [wget], [wget])
+-AC_CHECK_PROG([CURL], [curl], [curl])
+ 
+ AC_HEADER_STDC
+ AC_CHECK_HEADERS([stdlib.h string.h sys/ioctl.h sys/stat.h unistd.h paths.h])
+@@ -56,21 +54,33 @@ if test "x$exec_prefix" = "xNONE"; then
+ 	exec_prefix="$prefix"
+ fi
+ 
+-if test "x$WGET" = "x"; then
+-	if test "x$CURL" = "x"; then
++dnl allow enabling/disabling the fetching of the IANA PEN registry
++AC_ARG_ENABLE([registry-download],
++	[AC_HELP_STRING([--enable-registry-download],
++			[download/install the IANA PEN registry [default=yes]])],
++	[xenable_registry_download=$enableval],
++	[xenable_registry_download=yes])
++
++AM_CONDITIONAL([DOWNLOAD], [false])
++
++if test "x$xenable_registry_download" = "xyes"; then
++	AC_CHECK_PROG([WGET], [wget], [wget])
++	AC_CHECK_PROG([CURL], [curl], [curl])
++
++	if test "x$WGET" = "x" && test "x$CURL" = "x"; then
+ 		AC_MSG_WARN([** Neither wget nor curl could be found.])
+ 		AC_MSG_WARN([** IANA PEN database will not be installed by `make install` !])
+ 	else
+-		DOWNLOAD="$CURL --location --progress-bar"
+ 		AM_CONDITIONAL([DOWNLOAD], [true])
++		if test "x$WGET" != "x"; then
++			DOWNLOAD="$WGET -c -nd -O -"
++		else
++			DOWNLOAD="$CURL --location --progress-bar"
++		fi
+ 	fi
+-else
+-	DOWNLOAD="$WGET -c -nd -O -"
+-	AM_CONDITIONAL([DOWNLOAD], [true])
+ fi
+ 
+-AC_MSG_WARN([** Download is:])
+-AC_MSG_WARN($DOWNLOAD)
++AC_MSG_WARN([** Download is: $DOWNLOAD])
+ AC_SUBST(DOWNLOAD, $DOWNLOAD)
+ 
+ dnl


### PR DESCRIPTION
Maintainer: @lynxis 
Compile tested: x86/64 (APU3)
Run tested: x86/64 (APU3)

Description:
Backport upstream commits to disable the download of IANA PEN registry during the build process.