### PR TITLE
ttyd: bump to 1.7.7

### DIFF
--- a/utils/ttyd/Makefile
+++ b/utils/ttyd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ttyd
-PKG_VERSION:=1.7.3
+PKG_VERSION:=1.7.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tsl0922/ttyd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=c9cf5eece52d27c5d728000f11315d36cb400c6948d1964a34a7eae74b454099
+PKG_HASH:=039dd995229377caee919898b7bd54484accec3bba49c118e2d5cd6ec51e3650
 
 PKG_MAINTAINER:=Shuanglei Tao <tsl0922@gmail.com>
 PKG_LICENSE:=MIT

--- a/utils/ttyd/files/ttyd.init
+++ b/utils/ttyd/files/ttyd.init
@@ -18,7 +18,7 @@ validate_section_ttyd()
 		'gid:uinteger' \
 		'signal:uinteger' \
 		'url_arg:bool' \
-		'readonly:bool' \
+		'readonly:bool:0' \
 		'client_option:list(string)' \
 		'terminal_type:string' \
 		'check_origin:bool' \
@@ -53,7 +53,7 @@ ttyd_instance()
 	}
 
 	[ "$url_arg" = 0 ] && url_arg=""
-	[ "$readonly" = 0 ] && readonly=""
+	[ "$readonly" = 0 ] && readonly="-W"
 	[ "$check_origin" = 0 ] && check_origin=""
 	[ "$once" = 0 ] && once=""
 	[ "$ipv6" = 0 ] && ipv6=""
@@ -68,7 +68,7 @@ ttyd_instance()
 		${gid:+-g $gid} \
 		${signal:+-s $signal} \
 		${url_arg:+-a} \
-		${readonly:+-R} \
+		${readonly:-} \
 		${terminal_type:+-T $terminal_type} \
 		${check_origin:+-O} \
 		${max_clients:+-m $max_clients} \

--- a/utils/ttyd/patches/100-log-to-syslog.patch
+++ b/utils/ttyd/patches/100-log-to-syslog.patch
@@ -8,7 +8,7 @@
  
  #include "utils.h"
  
-@@ -509,7 +510,8 @@ int main(int argc, char **argv) {
+@@ -520,7 +521,8 @@ int main(int argc, char **argv) {
      return -1;
    }
  


### PR DESCRIPTION
Breaking Changes

    The web terminal is readonly by default now, to make it writable,
    use -W option.

Changelog 1.7.7

    Bump to 1.7.7
    cmake: add static version back

Changelog 1.7.6

    workflow: update actions packages
    cmake: get version from git ref

Changelog 1.7.5

    html: allow overriding client options with URL query
    server: add --exit-no-conn option
    html: add safari mobile full screen support
    html: Add Unicode 11 xterm.js addon
    html: upgrade to xterm 5.4.0
    add trzszDragInitTimeout option

Changelog 1.7.4

    Leverage Docker Layer System
    html: update dependencies
    build(deps): update zlib version 1.2.13 to 1.3 in cross-build.sh
    server: print working directory on start
    server: replace --readonly with --writable
    server: fix -U option not work
    server: do not expose port to public by default
    Add -y flag for easier installation
    improve support for trzsz
    info.max_http_header_data = 65535;
    Add Docker pulls badge
    fix flow control
    Fix typo, OPTOINS -> OPTIONS
    Bump CMake version to 2.8.12

Maintainer: @tsl0922 (?)
Compile tested: x86_64
