### PR TITLE
modemmanager: add missing any option to allowedmode

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.22.0
-PKG_RELEASE:=23
+PKG_RELEASE:=24
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -684,6 +684,10 @@ proto_modemmanager_setup() {
 				modemmanager_set_allowed_mode "$device" \
 					"$interface" "5g"
 				;;
+			"any")
+				modemmanager_set_allowed_mode "$device" \
+					"$interface" "any"
+				;;
 			*)
 				modemmanager_set_preferred_mode "$device" \
 					"$interface" "${allowedmode}" "${preferredmode}"


### PR DESCRIPTION
Maintainer: me
Compile tested: no only script changes
Run tested: x86_64, APU3, OpenWrt master

Description:

The 'mmcli' also understands the option 'any'.