### PR TITLE
knot: update to version 3.4.6

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.4.5
+PKG_VERSION:=3.4.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=359af70afafa7ccaa18439a7c1eb35270ff9eece81d0756ae4ca716b1433cb4b
+PKG_HASH:=d19c5a1ff94b4f26027d635de108dbfc88f5652be86ccb3ba9a44ee9be0e5839
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8


### PR DESCRIPTION
Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 8.0.0 (hbl)
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 8.0.0 (hbl)

Description:

Release upgrade (https://www.knot-dns.cz/2025-04-10-version-346.html)