### PR TITLE
ddns-scripts: correct bump release

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,6 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=67
 PKG_RELEASE:=68
 
 PKG_LICENSE:=GPL-2.0


### PR DESCRIPTION
Oops. 

Should be harmless anyway: the value is simply reassigned. But let's remove any margin for error.