### PR TITLE
lxc: update to 6.0.4

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
-PKG_VERSION:=6.0.3
-PKG_RELEASE:=4
+PKG_VERSION:=6.0.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/
-PKG_HASH:=adac0837d2abfd2903916eaf56f60756f131327311f4f25ad917f6a71f73f98c
+PKG_HASH:=872d26ce8512b9f993d194816e336bf9f3ad8326f22dc24ef0f01f85599fa8b9
 
 PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later BSD-2-Clause GPL-2.0

--- a/utils/lxc/patches/030-start-re-introduce-first-SET_DUMPABLE-call.patch
+++ b/utils/lxc/patches/030-start-re-introduce-first-SET_DUMPABLE-call.patch
@@ -1,0 +1,29 @@
+From 2663712e8fa8f37e0bb873185e2d4526dc644764 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?St=C3=A9phane=20Graber?= <stgraber@stgraber.org>
+Date: Sat, 5 Apr 2025 01:11:18 -0400
+Subject: [PATCH] start: Re-introduce first SET_DUMPABLE call
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Without it, we're running into issues with complex hooks like nvidia.
+
+Signed-off-by: Stéphane Graber <stgraber@stgraber.org>
+---
+ src/lxc/start.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/src/lxc/start.c
++++ b/src/lxc/start.c
+@@ -1125,6 +1125,11 @@ static int do_start(void *data)
+ 		if (!lxc_switch_uid_gid(nsuid, nsgid))
+ 			goto out_warn_father;
+ 
++		ret = prctl(PR_SET_DUMPABLE, prctl_arg(1), prctl_arg(0),
++			    prctl_arg(0), prctl_arg(0));
++		if (ret < 0)
++			goto out_warn_father;
++
+ 		/* set{g,u}id() clears deathsignal */
+ 		ret = lxc_set_death_signal(SIGKILL, handler->monitor_pid, status_fd);
+ 		if (ret < 0) {


### PR DESCRIPTION
Added upstream patch to fix starting containers with complex hooks.
No existing patches needed to be rebased/simple version bump to 6.0.4.

Build system: x86/64
Build-tested: x86/64
Run-tested: x86/64

Maintainer: @ratkaj