### PR TITLE
ddns-scripts: fix daemon start and reload

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=68
+PKG_RELEASE:=69
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/etc/init.d/ddns
+++ b/net/ddns-scripts/files/etc/init.d/ddns
@@ -6,9 +6,13 @@ boot() {
 	return 0
 }
 
-reload() {
-	/usr/lib/ddns/dynamic_dns_updater.sh -- reload
+kill() {
+	/usr/lib/ddns/dynamic_dns_updater.sh -- kill
 	return 0
+}
+
+reload() {
+	restart
 }
 
 restart() {

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -190,7 +190,7 @@ start_daemon_for_all_ddns_sections()
 	for section_id in $sections; do
 		config_get configured_if "$section_id" interface "wan"
 		[ -z "$event_if" ] || [ "$configured_if" = "$event_if" ] || continue
-		/usr/lib/ddns/dynamic_dns_updater.sh -v "$VERBOSE" -S "$section_id" -- start
+		/usr/lib/ddns/dynamic_dns_updater.sh -v "$VERBOSE" -S "$section_id" -- start &
 	done
 }
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
@@ -23,7 +23,7 @@ Usage:
 
 Commands:
 start                Start SECTION or NETWORK or all
-stop                 Stop NETWORK or all
+stop                 Stop SECTION or NETWORK or all
 
 Parameters:
  -n NETWORK          Start/Stop sections in background monitoring NETWORK, force VERBOSE=0
@@ -92,7 +92,7 @@ case "$1" in
 		fi
 		exit 1
 		;;
-	reload)
+	kill)
 		killall dynamic_dns_updater.sh 2>/dev/null
 		exit $?
 		;;


### PR DESCRIPTION
Fix daemon start (backgrounding) and the reload alias in the init script. 