### PR TITLE
netbird: update to 0.40.1

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.40.0
+PKG_VERSION:=0.40.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2bf6dd2a9aa7d0c77c7c2a70b215f137e24f08f958c7efcf2ae863afb080fc53
+PKG_HASH:=373d1797fdbfb9df22d4a9064af62cdc7b25f314a934ea5d442d3e57c8a263b1
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## Compile and run tested

**Maintainer:** Me

| Package architecture | Target | Subtarget | Brand | Model | Hardware Version | OpenWrt version |
|----------------------|--------|-----------|-------|-------|------------------|-----------------|
| [x86_64](https://openwrt.org/docs/techref/instructionset/x86_64) | [x86](https://openwrt.org/docs/techref/targets/x86) | 64 | QEMU (x86_64) | qemu-system-x86_64 | qemu-9.1.3-2.fc41 | OpenWrt SNAPSHOT r29172-eec11fbbb6 |

**Tests checklist:**
- [x] Connection to the NetBird Cloud Dashboard (not self-hosted).
- [x] Firewall configured with nftables.
- [x] Connection established in P2P mode.
- [x] `wireguard` kernel mode active.
- [x] Routes configured between my homelab and my cloud server.
- [x] `netbird` DNS server functioning correctly.
- [ ] NAT operational (not needed by me at this time, may consider testing in the future).
- [ ] Permissions rules is enforced (not needed by me at this time, may consider testing in the future).

## Description

- Changelog:
  - Update to [0.40.1](https://github.com/netbirdio/netbird/releases/tag/v0.40.1)
    - Full changelog: https://github.com/netbirdio/netbird/compare/v0.40.0...v0.40.1
    - Breaking change:
      - N/A

---

### Additional information

The package(s) was compiled with the container [`sdk`](https://github.com/openwrt/docker).
The `OpenWrt` image(s) was built using the container [`imagebuilder`](https://github.com/openwrt/docker) or [`distrobuilder`](https://github.com/lxc/distrobuilder).

You can view my repository with the patch applied and the automated build here:
`This repository is temporary and will be removed or modified after the merge.`
- https://github.com/wehagy/owpib/tree/netbird/update

You can find my artifacts here:
- https://github.com/wehagy/owpib/actions/runs/14383160157