### PR TITLE
collectd-mod-sensors: add UseLabels option

### DIFF
--- a/utils/collectd/files/usr/share/collectd/plugin/sensors.json
+++ b/utils/collectd/files/usr/share/collectd/plugin/sensors.json
@@ -1,6 +1,7 @@
 {
 	"bool": [
-		"IgnoreSelected"
+		"IgnoreSelected",
+		"UseLabels"
 	],
 	"list": [
 		"Sensor"


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: didnt make any change to build script
Run tested: on 24.10 . by editing /usr/share/collectd/plugin/sensors.json directly

Description:
add a new option from upstream. this may useful when sensor have multiple input on a same type (eg. sfp have both tx/rx power)