### PR TITLE
golang:  allow overriding GOTOOLCHAIN per package

### DIFF
--- a/lang/golang/golang-package.mk
+++ b/lang/golang/golang-package.mk
@@ -119,6 +119,16 @@ include $(GO_INCLUDE_DIR)/golang-values.mk
 #   '$(call GoPackage/Package/Install/Bin,dest_dir)'.
 #
 #   e.g. GO_PKG_INSTALL_BIN_PATH:=/sbin
+#
+#
+# GOTOOLCHAIN - use a specific go toolchain version, default local
+#
+#   Force the use of a specific go toolchain version. Setting this to
+#   version+auto means to use the specified version by default but allow
+#   upgrades to newer versions as well. Lets host go automatically download the
+#   missing versions.
+#
+#   e.g. GOTOOLCHAIN=go1.24.2
 
 # Credit for this package build process (GoPackage/Build/Configure and
 # GoPackage/Build/Compile) belong to Debian's dh-golang completely.
@@ -211,12 +221,13 @@ GO_PKG_TARGET_VARS= \
 	CGO_CXXFLAGS="$(filter-out $(GO_CFLAGS_TO_REMOVE),$(TARGET_CXXFLAGS))" \
 	CGO_LDFLAGS="$(TARGET_LDFLAGS)"
 
+GOTOOLCHAIN?=local
 GO_PKG_BUILD_VARS= \
 	GOPATH="$(GO_PKG_BUILD_DIR)" \
 	GOCACHE="$(GO_BUILD_CACHE_DIR)" \
 	GOMODCACHE="$(GO_MOD_CACHE_DIR)" \
 	GOENV=off \
-	GOTOOLCHAIN=local
+	GOTOOLCHAIN=$(GOTOOLCHAIN)
 
 GO_PKG_VARS= \
 	$(GO_PKG_TARGET_VARS) \

--- a/lang/golang/golang-values.mk
+++ b/lang/golang/golang-values.mk
@@ -29,7 +29,6 @@ unexport \
   GOOS \
   GOPATH \
   GOROOT \
-  GOTOOLCHAIN \
   GOTMPDIR \
   GOWORK
 # Unmodified:
@@ -38,6 +37,7 @@ unexport \
 #   GOPROXY
 #   GONOPROXY
 #   GOSUMDB
+#   GOTOOLCHAIN
 #   GONOSUMDB
 #   GOVCS
 

--- a/lang/golang/golang/Makefile
+++ b/lang/golang/golang/Makefile
@@ -12,7 +12,7 @@ GO_VERSION_PATCH:=3
 
 PKG_NAME:=golang
 PKG_VERSION:=$(GO_VERSION_MAJOR_MINOR)$(if $(GO_VERSION_PATCH),.$(GO_VERSION_PATCH))
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 GO_SOURCE_URLS:=https://dl.google.com/go/ \
                 https://mirrors.ustc.edu.cn/golang/ \


### PR DESCRIPTION
Maintainer: @jefferyto @1715173329
Compile tested: mediatek/filogic, 24.10; x86/64, HEAD

- Tested building AdGuard Home and Tailscale versions from master, that require newer versions of go, with `GOTOOLCHAIN` specified
- Tested building Syncthing without `GOTOOLCHAIN` specified

Run tested: mediatek/filogic on 24.10.0

Some Go-based packages require up-to-date versions of Go, that are newer than the one in the stable branch, e.g. AdGuard Home and Tailscale. Which prevents these packages from being updated in stable and leaves them potentially vulnerable.

`GOTOOLCHAIN` forces the use of a specific go toolchain version per package. Setting this to `version+auto` means to use the specified version by default but allow upgrades to newer versions as well. This lets host go automatically download the missing versions.

The default behavior is still the same: use bootstrapped host go when `GOTOOLCHAIN` is not specified.
    
Example: `GOTOOLCHAIN=go1.24.2+auto`
    
More info: https://go.dev/doc/toolchain

This is a simpler alternative to #26201 that depends on the existing bootstrapped host go.

Related discussions wrt Tailscale #25062, #24741
