### PR TITLE
external-protocol: add missing ip dependency

### DIFF
--- a/net/external-protocol/Makefile
+++ b/net/external-protocol/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=external-protocol
 PKG_VERSION:=20231119
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 
@@ -12,6 +12,7 @@ define Package/external-protocol
   SECTION:=net
   CATEGORY:=Network
   TITLE:=externally managed protocol
+  DEPENDS:=+ip
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
Maintainer: @oskarirauta 
Compile tested: mediatek/filogic, 24.10
Run tested: mediatek/filogic, 24.10.0, Zyxel EX5601-T0 ubootmod (T-56)

Description:

`external.sh` requires `ip` with `-json` flag that is not supported by the BusyBox `ip`.

```bash
$ ls -lh /sbin/ip
lrwxrwxrwx    1 root     root          14 Feb  4 01:09 /sbin/ip -> ../bin/busybox

$ ip --json ad
BusyBox v1.36.1 (2025-02-26 22:32:40 UTC) multi-call binary.

Usage: ip [OPTIONS] address|route|link|neigh|rule [ARGS]

OPTIONS := -f[amily] inet|inet6|link | -o[neline]

ip addr add|del IFADDR dev IFACE | show|flush [dev IFACE] [to PREFIX]
ip route list|flush|add|del|change|append|replace|test ROUTE
ip link set IFACE [up|down] [arp on|off] [multicast on|off]
	[promisc on|off] [mtu NUM] [name NAME] [qlen NUM] [address MAC]
	[master IFACE | nomaster] [netns PID]
ip neigh show|flush [to PREFIX] [dev DEV] [nud STATE]
ip rule [list] | add|del SELECTOR ACTION
```

Fixes: https://github.com/openwrt/packages/issues/26302
