### PR TITLE
libarchive: bump to 3.7.9 fixing CVE-2025-25724, CVE-2025-1632, CVE-2024-57970

### DIFF
--- a/libs/libarchive/Makefile
+++ b/libs/libarchive/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libarchive
-PKG_VERSION:=3.7.7
+PKG_VERSION:=3.7.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.libarchive.org/downloads
-PKG_HASH:=879acd83c3399c7caaee73fe5f7418e06087ab2aaf40af3e99b9e29beb29faee
+PKG_HASH:=ed8b5732e4cd6e30fae909fb945cad8ff9cb7be5c6cdaa3944ec96e4a200c04c
 
 PKG_MAINTAINER:=Johannes Morgenroth <morgenroth@ibr.cs.tu-bs.de>
 PKG_LICENSE:=BSD-2-Clause


### PR DESCRIPTION
Maintainer: @morgenroth
Compile tested: N/A
Run tested: N/A

Description:

Libarchive 3.7.9 is a bugfix release, fixing a regression in libarchive 3.7.8 regarding GNU sparse entries was fixed.

Libarchive 3.7.8 is a bugfix and security release:

  Security fixes:

    * tar reader: Handle truncation in the middle of a GNU long linkname (CVE-2024-57970)
    * unzip: fix null pointer dereference (CVE-2025-1632)
    * tar reader: fix unchecked return value in list_item_verbose() (CVE-2025-25724)

  Important bugfixes:

    * 7zip reader: add SPARC and POWERPC filter support for non-LZMA compressors
    * tar reader: Ignore ustar size when pax size is present
    * tar writer: Fix bug when -s/a/b/ used more than once with b flag
    * cpio: Fix a Y2038 bug on Windows
    * libarchive: Handle ARCHIVE_FILTER_LZOP in archive_read_append_filter
    * libarchive: Adding missing seeker function to archive_read_open_FILE()

Full Changelog: https://github.com/libarchive/libarchive/compare/v3.7.7...v3.7.8