### PR TITLE
libcbor: disable sanitize by default

### DIFF
--- a/libs/libcbor/Makefile
+++ b/libs/libcbor/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libcbor
 PKG_VERSION:=0.11.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/PJK/libcbor/tar.gz/v$(PKG_VERSION)?
@@ -19,8 +19,6 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Linos Giannopoulos <linosgian00+openwrt@gmail.com>
 
-CMAKE_OPTIONS += \
-        -DBUILD_SHARED_LIBS=ON
 CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -38,6 +36,9 @@ define Package/libcbor/description
  libcbor is a C library for parsing and generating CBOR, the general-purpose schema-less binary data format.
 endef
 
+CMAKE_OPTIONS += \
+	-DBUILD_SHARED_LIBS=ON \
+	-DSANITIZE=OFF
 
 define Package/libcbor/install
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
Maintainer: @linosgian
Compile tested: rockchip/armv8
Run tested: n/a

Description:
musl libc does not support this feature, and for glibc, additional
library libasan is required. Disable it explicitly to avoid build issue
when CONFIG_DEBUG is selected.

Fixes: #25348
Cc: @hnyman @pwned-pixel
