### PR TITLE
syncthing: bump to 1.29.5

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.29.4
+PKG_VERSION:=1.29.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=d17699e3233127dd7f1315b41bec3926fdac42b6beeca4fcb6f05b1e25ed9941
+PKG_HASH:=17f60258af1043db93f1df3609222cdd40b4fdcccae5c60dce46c557e0796098
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 

--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.29.3
+PKG_VERSION:=1.29.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=cfbe9cc3a37deca1405e0cf92f12e57ca8767d50f193d52d00360522ae02d417
+PKG_HASH:=d17699e3233127dd7f1315b41bec3926fdac42b6beeca4fcb6f05b1e25ed9941
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 

--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.29.2
+PKG_VERSION:=1.29.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=c7b6bc36af1af6f1cb304f4ec4c16743760ef6e8b3586f31dc11439d5d5fd427
+PKG_HASH:=cfbe9cc3a37deca1405e0cf92f12e57ca8767d50f193d52d00360522ae02d417
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 


### PR DESCRIPTION
Maintainer: @aparcar, @brvphoenix 
Compile tested: mediatek/filogic, master and 24.10

- also tested with #26201 and #26310
- all intermediate versions compile as well

Run tested: mediatek/filogic, 24.10.0, Zyxel EX5601-T0 ubootmod (T-56)

- all files are installed correctly
- version checks return the updated version
- service starts
- web UI loads with the existing config and displays the updated version
- synchronization works
- all intermediate versions work as well (I've been using them since their releases)

Description:

- bump Syncthing to 1.29.5

Changelogs:

- https://github.com/syncthing/syncthing/releases/tag/v1.29.3
- https://github.com/syncthing/syncthing/releases/tag/v1.29.4
- https://github.com/syncthing/syncthing/releases/tag/v1.29.5