### PR TITLE
expat: backport 2.7.1 to 24.10 to fix several CVEs

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
-PKG_VERSION:=2.6.3
+PKG_VERSION:=2.7.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$(PKG_VERSION))
-PKG_HASH:=17aa6cfc5c4c219c09287abfc10bc13f0c06f30bb654b28bfe6f567ca646eb79
+PKG_HASH:=0cce2e6e69b327fc607b8ff264f4b66bdf71ead55a87ffd5f3143f535f15cfa2
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: mediatek/filogic, 24.10

Run tested: mediatek/filogic on 24.10.0, Zyxel EX5601-T0 ubootmod (T-56)

- this is a library, individual dependent projects need to be tested
- I used unbound-anchor to generate a root key based on anchor XML

Description:

This is a backport of #26264 from master to 24.10

Addresses CVE-2024-8176 and CVE-2024-50602.

Changelog: https://github.com/libexpat/libexpat/blob/R_2_7_1/expat/Changes
Fixes: https://github.com/openwrt/packages/issues/26255