### PR TITLE
prometheus-node-exporter-lua: add nftables named counters collector

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
 PKG_VERSION:=2025.06.23
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -268,6 +268,17 @@ define Package/prometheus-node-exporter-lua-ethtool/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/ethtool.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
+define Package/prometheus-node-exporter-lua-nft-counters
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (nftables counters collector)
+  DEPENDS:=prometheus-node-exporter-lua +nftables-json +lua-cjson
+endef
+
+define Package/prometheus-node-exporter-lua-nft-counters/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/nft_counters.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
 $(eval $(call BuildPackage,prometheus-node-exporter-lua))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx7))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-dawn))
@@ -288,3 +299,4 @@ $(eval $(call BuildPackage,prometheus-node-exporter-lua-snmp6))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-realtek-poe))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-mwan3))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-ethtool))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-nft-counters))

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/nft_counters.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/nft_counters.lua
@@ -1,0 +1,26 @@
+local json = require "cjson"
+
+local function scrape()
+  local handle = io.popen("nft --json list counters")
+  local result = handle:read("*a")
+  handle:close()
+  local nft_data = json.decode(result).nftables
+
+  local metric_packets = metric("nft_counter_packets", "counter")
+  local metric_bytes = metric("nft_counter_bytes", "counter")
+
+  for _, data in pairs(nft_data) do
+    if (data.counter ~= nil) then
+      local labels = {
+        family = data.counter.family,
+        table = data.counter.table,
+        name = data.counter.name,
+        comment = data.counter.comment
+      }
+      metric_packets(labels, data.counter.packets)
+      metric_bytes(labels, data.counter.bytes)
+    end
+  end
+end
+
+return { scrape = scrape }


### PR DESCRIPTION
Maintainer: me / @Prototik
Compile tested: QEMU x86_64 VM, OpenWrt master branch
Run tested: QEMU x86_64 VM, OpenWrt master branch

Description:
Allows to export named counters statistics from nftables, thus making a more precise tracking to be possible.
![image](https://github.com/user-attachments/assets/736f193b-f364-4cc7-8c2e-5f8c5b6eaa0d)
