### PR TITLE
[24.10] netbird: update to 0.39.2

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.36.7
+PKG_VERSION:=0.39.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=03b0581ef19fa839fca9172aac3cdadda39a89df42761c497bc81709081574a4
+PKG_HASH:=79553c2555e3cd03d0386e23f17ba3dd0e4437fecc9ffd82d6b5a557af7bffc0
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## Compile and run tested

**Maintainer:** Me

| Package architecture | Target | Subtarget | Brand | Model | Hardware Version | OpenWrt version |
|----------------------|--------|-----------|-------|-------|------------------|-----------------|
| [x86_64](https://openwrt.org/docs/techref/instructionset/x86_64) | [x86](https://openwrt.org/docs/techref/targets/x86) | 64 | QEMU (x86_64) | qemu-system-x86_64 | qemu-9.1.3-2.fc41 | OpenWrt 24.10-SNAPSHOT r28575-ba66273943 |

**Tests checklist:**
- [x] Connection to the NetBird Cloud Dashboard (not self-hosted).
- [x] Firewall configured with nftables.
- [x] Connection established in P2P mode.
- [x] `wireguard` kernel mode active.
- [x] Routes configured between my homelab and my cloud server.
- [x] `netbird` DNS server functioning correctly.
- [ ] NAT operational (not needed by me at this time, may consider testing in the future).
- [ ] Permissions rules is enforced (not needed by me at this time, may consider testing in the future).

## Description

- Changelog:
  - Update to [0.39.2](https://github.com/netbirdio/netbird/releases/tag/v0.39.2)
    - Full changelog: https://github.com/netbirdio/netbird/compare/v0.36.7...v0.39.2
      - Cherry picked from: https://github.com/openwrt/packages/commit/8efe42d86c9bb08e55454dc7d51d14a8e2167f06
      - PR: https://github.com/openwrt/packages/pull/26247
    - Breaking change:
      - N/A

While I ideally want to backport to the latest version, `0.41.2`, the `netbird` package is being updated so rapidly that it becomes challenging to test and backport, and for now, it’s better to wait a bit until a fix for the memory leak affecting version `>=0.40.0` is released, as mentioned here: https://github.com/netbirdio/netbird/issues/3678#issuecomment-2804619297.

---

### Additional information

The package(s) was compiled with the container [`sdk`](https://github.com/openwrt/docker).
The `OpenWrt` image(s) was built using the container [`imagebuilder`](https://github.com/openwrt/docker) or [`distrobuilder`](https://github.com/lxc/distrobuilder).

You can view my repository with the patch applied and the automated build here:
`This repository is temporary and will be removed or modified after the merge.`
- https://github.com/wehagy/owpib/tree/openwrt-24.10/netbird/update

You can find my artifacts here:
- https://github.com/wehagy/owpib/actions/runs/14237952425