### PR TITLE
syncthing: backport 1.29.5 to 24.10

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.27.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.29.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=5c7b0456e50c8a2e4c9767727c4139558ba95573a276273a1730a903e0a73834
+PKG_HASH:=c7b6bc36af1af6f1cb304f4ec4c16743760ef6e8b3586f31dc11439d5d5fd427
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 

--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.29.4
+PKG_VERSION:=1.29.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=d17699e3233127dd7f1315b41bec3926fdac42b6beeca4fcb6f05b1e25ed9941
+PKG_HASH:=17f60258af1043db93f1df3609222cdd40b4fdcccae5c60dce46c557e0796098
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 

--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.29.3
+PKG_VERSION:=1.29.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=cfbe9cc3a37deca1405e0cf92f12e57ca8767d50f193d52d00360522ae02d417
+PKG_HASH:=d17699e3233127dd7f1315b41bec3926fdac42b6beeca4fcb6f05b1e25ed9941
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 

--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.29.2
+PKG_VERSION:=1.29.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=c7b6bc36af1af6f1cb304f4ec4c16743760ef6e8b3586f31dc11439d5d5fd427
+PKG_HASH:=cfbe9cc3a37deca1405e0cf92f12e57ca8767d50f193d52d00360522ae02d417
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 

--- a/utils/syncthing/files/syncthing.conf
+++ b/utils/syncthing/files/syncthing.conf
@@ -24,7 +24,7 @@ config syncthing 'syncthing'
 	# Running as 'root' is possible, but not recommended
 	option user 'syncthing'
 
-	option logfile '/etc/syncthing/syncthing.log'
+	option logfile '/var/log/syncthing.log'
 	option log_max_old_files 7
 	# Size in bytes
 	option log_max_size 1048576

--- a/utils/syncthing/files/syncthing.init
+++ b/utils/syncthing/files/syncthing.init
@@ -48,7 +48,7 @@ start_service() {
 	local enabled=0
 	local gui_address="http://0.0.0.0:8384"
 	local home="/etc/syncthing"
-	local logfile="/etc/syncthing/syncthing.log"
+	local logfile="/var/log/syncthing.log"
 	local macprocs=0
 	local nice=0
 	local user="syncthing"


### PR DESCRIPTION
Maintainer: @aparcar, @brvphoenix 
Compile tested: mediatek/filogic, 24.10.1 SDK

- also tested with #26201 and #26310
- all intermediate versions compile as well

Run tested: mediatek/filogic, 24.10.1, Zyxel EX5601-T0 ubootmod (T-56)

- all files are installed correctly
- version checks return the updated version
- service starts
- web UI loads with the existing config and displays the updated version
- synchronization works
- all intermediate versions work as well (I've been using them since their releases)

Description:

This is a backport of #25790 and #26320 to 24.10.

- bump Syncthing to 1.29.5

Changelogs:

- https://github.com/syncthing/syncthing/releases/tag/v1.29.2
- https://github.com/syncthing/syncthing/releases/tag/v1.29.3
- https://github.com/syncthing/syncthing/releases/tag/v1.29.4
- https://github.com/syncthing/syncthing/releases/tag/v1.29.5