### PR TITLE
external-protocol: backport add missing ip dependency to 24.10

### DIFF
--- a/net/external-protocol/Makefile
+++ b/net/external-protocol/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=external-protocol
 PKG_VERSION:=20231119
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 
@@ -12,6 +12,7 @@ define Package/external-protocol
   SECTION:=net
   CATEGORY:=Network
   TITLE:=externally managed protocol
+  DEPENDS:=+ip
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
Maintainer: @oskarirauta 
Compile tested: mediatek/filogic, 24.10.1 SDK
Run tested: mediatek/filogic, 24.10.1, Zyxel EX5601-T0 ubootmod (T-56)

Description:

This is a backport of #26311 to 24.10.

`external.sh` requires `ip` with `-json` flag that is not supported by the BusyBox `ip`.

Fixes: https://github.com/openwrt/packages/issues/26302