### PR TITLE
libqmi: bump to 1.36.0

### DIFF
--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_VERSION:=1.34.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.36.0
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/libqmi.git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
-PKG_MIRROR_HASH:=65ee91b81c6f68d908cc94a0b5d670eefa29d550ecf8ef94cb836981fbfa4c2a
+PKG_MIRROR_HASH:=8745d3d116301a7197e95c924072170ba53a9ecf592217af4ba22ea79876ffab
 
 PKG_BUILD_FLAGS:=gc-sections
 


### PR DESCRIPTION
Maintainer: Nicholas Smith <nicholas@nbembedded.com>
Compile tested: aarch64, Banana Pi-R4, snapshot 4-16-2025
Run tested: aarch64, Banana Pi-R4, snapshot 4-16-2025, ModemManager connects and is working with my RM502Q-AE modem.

Description:
Bump libqmi to 1.36.0 for modemmanager 1.24.0 dependency
Needed for https://github.com/openwrt/packages/pull/26334
