### PR TITLE
libmbim: bump to 1.32.0

### DIFF
--- a/libs/libmbim/Makefile
+++ b/libs/libmbim/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmbim
-PKG_VERSION:=1.30.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.32.0
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/libmbim.git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
-PKG_MIRROR_HASH:=0ff9212138eb68c2e33ad9220aa64df2e9a0da86f03dd02bf6d4cf02bcd95a68
+PKG_MIRROR_HASH:=75720195b8beb8bfaf75495dd54ef9b9674aa5152c749ae52ca426b315a5c191
 
 PKG_BUILD_FLAGS:=gc-sections
 


### PR DESCRIPTION
Maintainer: Nicholas Smith [nicholas@nbembedded.com](mailto:nicholas@nbembedded.com)
Compile tested: aarch64, Banana Pi-R4, snapshot 4-16-2025
Run tested: aarch64, Banana Pi-R4, snapshot 4-16-2025, ModemManager connects and is working with my RM502Q-AE modem.

Description:
Bump libmbim to 1.32.0 for modemmanager 1.24.0 dependency