### PR TITLE
sqlite3: bump to 3.47.2

### DIFF
--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqlite
-PKG_VERSION:=3460100
+PKG_VERSION:=3470200
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-autoconf-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.sqlite.org/2024/
-PKG_HASH:=67d3fe6d268e6eaddcae3727fce58fcc8e9c53869bdd07a0c61e38ddf2965071
+PKG_HASH:=f1b2ee412c28d7472bc95ba996368d6f0cdcf00362affdadb27ed286c179540b
 
 PKG_CPE_ID:=cpe:/a:sqlite:sqlite
 PKG_LICENSE:=PUBLICDOMAIN


### PR DESCRIPTION
build: x86_64
run tested: x86_64

```
# sqlite3 --version
3.47.2 2024-12-07 20:39:59 2aabe05e2e8cae4847a802ee2daddc1d7413d8fc560254d93ee3e72c14685b6c (64-bit)
```


A note to future devs: >= 3.48 includes a change:

====
Refactor the "configure" script used to help build SQLite from [canonical sources](https://sqlite.org/amalg-v-canon.html#canon), to fix bugs, improve performance, and make the code more maintainable.

- This does not affect the "configure" script in the sqlite3-autoconf-NNNNNNN.tar.gz "amalgamation tarball", only the [canonical sources](https://sqlite.org/amalg-v-canon.html#canon). The build system for the amalgamation tarball is unchanged. If you are using the amalgamation tarball, nothing about this change log entry applies to you.
- The key innovation here is that [Autosetup](https://msteveb.github.io/autosetup/) is now used instead of [GNU Autoconf](https://www.gnu.org/software/autoconf/). That seems like a big change, but it is really just an implementation detail. The ./configure script is coded very differently, but should work the same as before.
==== 

But attempting to compile 3.49.1 from exactly that tarball results in:

```
Build C compiler...cc
Checking for stdlib.h...ok
Error: Unknown option --target
Try: 'configure --help' for options
make[2]: *** [Makefile:145: /builder/build_dir/target-x86_64_musl/sqlite-autoconf-3490100/.configured_5cc4a1d1f3803d62da0f17a1838839ee] Error 1
```

Nice.