### PR TITLE
freeradius3: bump to 3.2.7

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -8,12 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
-PKG_VERSION:=3.2.5
-PKG_RELEASE:=3
+PKG_VERSION:=3.2.7
+PKG_VERSION_UNDERSCORE:=$(subst .,_,${PKG_VERSION})
+PKG_RELEASE:=1
 
 PKG_SOURCE:=freeradius-server-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://www.freeradius.org/ftp/pub/freeradius/
-PKG_HASH:=1e75f5fc1961d9854d1cb3c6921612fbe2b9edb8ee508a5a7cbd69f1e7607115
+PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/releases/download/release_$(PKG_VERSION_UNDERSCORE)/
+PKG_HASH:=3fd3b7725faa8b5e6c5a331a395e392ea9f7eceb3c0d42e82e82c32f2ff5b098
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0

--- a/net/freeradius3/patches/002-disable-session-cache-CVE-2017-9148.patch
+++ b/net/freeradius3/patches/002-disable-session-cache-CVE-2017-9148.patch
@@ -9,7 +9,7 @@ Last-Update: 2020-04-28
 
 --- a/src/main/tls.c
 +++ b/src/main/tls.c
-@@ -956,7 +956,7 @@ after_chain:
+@@ -848,7 +848,7 @@ after_chain:
  	}
  	if (vp) vp->vp_integer = state->mtu;
  
@@ -18,7 +18,7 @@ Last-Update: 2020-04-28
  
  	return state;
  }
-@@ -4515,7 +4515,7 @@ post_ca:
+@@ -4496,7 +4496,7 @@ post_ca:
  	/*
  	 *	Callbacks, etc. for session resumption.
  	 */
@@ -27,7 +27,7 @@ Last-Update: 2020-04-28
  		/*
  		 *	Cache sessions on disk if requested.
  		 */
-@@ -4595,7 +4595,7 @@ post_ca:
+@@ -4576,7 +4576,7 @@ post_ca:
  	/*
  	 *	Setup session caching
  	 */
@@ -36,7 +36,7 @@ Last-Update: 2020-04-28
  		/*
  		 *	Create a unique context Id per EAP-TLS configuration.
  		 */
-@@ -4883,7 +4883,7 @@ fr_tls_server_conf_t *tls_server_conf_pa
+@@ -4864,7 +4864,7 @@ fr_tls_server_conf_t *tls_server_conf_pa
  		goto error;
  	}
  

--- a/net/freeradius3/patches/010-openssl-deprecated.patch
+++ b/net/freeradius3/patches/010-openssl-deprecated.patch
@@ -1,6 +1,6 @@
 --- a/src/main/threads.c
 +++ b/src/main/threads.c
-@@ -265,6 +265,7 @@ static void ssl_locking_function(int mod
+@@ -275,6 +275,7 @@ static void ssl_locking_function(int mod
   */
  int tls_mutexes_init(void)
  {
@@ -8,7 +8,7 @@
  	int i, num;
  
  	rad_assert(ssl_mutexes == NULL);
-@@ -282,6 +283,7 @@ int tls_mutexes_init(void)
+@@ -292,6 +293,7 @@ int tls_mutexes_init(void)
  	}
  
  	CRYPTO_set_locking_callback(ssl_locking_function);
@@ -18,7 +18,7 @@
  }
 --- a/src/main/tls.c
 +++ b/src/main/tls.c
-@@ -60,6 +60,7 @@ USES_APPLE_DEPRECATED_API	/* OpenSSL API
+@@ -59,6 +59,7 @@ USES_APPLE_DEPRECATED_API	/* OpenSSL API
  #    include <openssl/evp.h>
  #  endif
  #  include <openssl/ssl.h>
@@ -26,7 +26,7 @@
  
  #if OPENSSL_VERSION_NUMBER >= 0x30000000L
  #  include <openssl/provider.h>
-@@ -2996,7 +2997,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
+@@ -2929,7 +2930,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
  	int		my_ok = ok;
  
  	ASN1_INTEGER	*sn = NULL;
@@ -35,7 +35,7 @@
  	VALUE_PAIR	**certs;
  	char **identity;
  #ifdef HAVE_OPENSSL_OCSP_H
-@@ -3087,7 +3088,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
+@@ -3021,7 +3022,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
  	 *	Get the Expiration Date
  	 */
  	buf[0] = '\0';
@@ -44,7 +44,7 @@
  	if (certs && (lookup <= 1) && asn_time &&
  	    (asn_time->length < (int) sizeof(buf))) {
  		memcpy(buf, (char*) asn_time->data, asn_time->length);
-@@ -3100,7 +3101,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
+@@ -3034,7 +3035,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
  	 *	Get the Valid Since Date
  	 */
  	buf[0] = '\0';
@@ -53,7 +53,7 @@
  	if (certs && (lookup <= 1) && asn_time &&
  	    (asn_time->length < (int) sizeof(buf))) {
  		memcpy(buf, (char*) asn_time->data, asn_time->length);
-@@ -3664,10 +3665,12 @@ static int set_ecdh_curve(SSL_CTX *ctx,
+@@ -3638,10 +3639,12 @@ static int set_ecdh_curve(SSL_CTX *ctx,
   */
  int tls_global_init(TLS_UNUSED bool spawn_flag, TLS_UNUSED bool check)
  {
@@ -64,9 +64,9 @@
  	CONF_modules_load_file(NULL, NULL, 0);
 +#endif
  
- 	/*
- 	 *	Initialize the index for the certificates.
-@@ -3767,6 +3770,7 @@ int tls_global_version_check(char const
+ #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+ 	EVP_set_default_properties(NULL, "fips=no");
+@@ -3745,6 +3748,7 @@ int tls_global_version_check(char const
   */
  void tls_global_cleanup(void)
  {
@@ -74,7 +74,7 @@
  #if OPENSSL_VERSION_NUMBER < 0x10000000L
  	ERR_remove_state(0);
  #elif OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-@@ -3792,6 +3796,7 @@ void tls_global_cleanup(void)
+@@ -3770,6 +3774,7 @@ void tls_global_cleanup(void)
  	ERR_free_strings();
  	EVP_cleanup();
  	CRYPTO_cleanup_all_ex_data();
@@ -92,8 +92,8 @@
 +	ssl_linked = OpenSSL_version_num();
  
  	/*
- 	 *	Major and minor versions mismatch, that's bad.
-@@ -152,7 +152,7 @@ char const *ssl_version_num(void)
+ 	 *	Major mismatch, that's bad.
+@@ -165,7 +165,7 @@ char const *ssl_version_num(void)
  {
  	long ssl_linked;
  
@@ -102,7 +102,7 @@
  	return ssl_version_by_num((uint32_t)ssl_linked);
  }
  
-@@ -188,10 +188,10 @@ char const *ssl_version(void)
+@@ -201,10 +201,10 @@ char const *ssl_version(void)
  {
  	static char buffer[256];
  


### PR DESCRIPTION
changed to github download URL

build: x86_64
run tested: x86_64

```
 # radiusd -v
radiusd: FreeRADIUS Version 3.2.7, for host x86_64-openwrt-linux-gnu, built on Apr 18 2025 at 00:10:48
FreeRADIUS Version 3.2.7
```
