### PR TITLE
samba4: disable null passwords (deprecated)

### DIFF
--- a/net/samba4/files/smb.conf.template
+++ b/net/samba4/files/smb.conf.template
@@ -30,9 +30,6 @@
 	## map unknow users to guest
 	map to guest = Bad User
 
-	## allow client access to accounts that have null passwords. 
-	null passwords = yes
-
 	## The old plaintext passdb backend. Some Samba features will not work if this passdb backend is used. (NOTE: enabled for size reasons)
 	## (tdbsam,smbpasswd,ldapsam)
 	passdb backend = smbpasswd


### PR DESCRIPTION
The option "null passwords" is marked by samba4 as deprecated.

Maintainer: none
Compile tested: not needed
Run tested: config file tested on OpenWrt 24.10.0

Description:
The option `null passwords` is marked as deprecated in Samba. See log file in https://github.com/openwrt/packages/issues/25605

Also Insecure Guest Logins (SMB shares without passwords) are disabled by default in Windows 11 24H2. 
https://learn.microsoft.com/en-us/answers/questions/2189515/windows-11-24h2-and-insecure-guest-logins-settings?forum=windowsclient-all&referrer=answers
https://learn.microsoft.com/en-us/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3?tabs=group-policy