### PR TITLE
changeip.com: use HTTPS for update URL

### DIFF
--- a/net/ddns-scripts/files/usr/share/ddns/default/changeip.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/changeip.com.json
@@ -1,7 +1,7 @@
 {
 	"name": "changeip.com",
 	"ipv4": {
-		"url": "http://[USERNAME]:[PASSWORD]@nic.changeip.com/nic/update?u=[USERNAME]&p=[PASSWORD]&cmd=update&hostname=[DOMAIN]&ip=[IP]",
+		"url": "https://[USERNAME]:[PASSWORD]@nic.changeip.com/nic/update?u=[USERNAME]&p=[PASSWORD]&cmd=update&hostname=[DOMAIN]&ip=[IP]",
 		"answer": "Successful"
 	}
 }


### PR DESCRIPTION
### Description

This pull request updates the dynamic DNS configuration for `changeip.com` by switching the update URL scheme from **HTTP** to **HTTPS** in `changeip.com.json` to ensure credentials are encrypted in transit.
This improves security without affecting functionality.

### Testing

- Confirmed that the updated URL successfully performs DDNS updates with valid credentials.
- No functional regressions observed.

### API DOCs for `changeip.com`
https://www.changeip.com/accounts/index.php?rp=/knowledgebase/34/DDNS-API-Information.html
