### PR TITLE
xtables-addons: bump to 3.27

### DIFF
--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -7,9 +7,9 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=xtables-addons
-PKG_VERSION:=3.26
+PKG_VERSION:=3.27
 PKG_RELEASE:=1
-PKG_HASH:=0b52df2117bacf2e32d1d3f98d09dbf88b274390733d3955699b108acaf9f2a6
+PKG_HASH:=e47ea8febe73c12ecab09d2c93578c5dc72d76f17fdf673397758f519cce6828
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://inai.de/files/xtables-addons/


### PR DESCRIPTION
Updated for compatibility with kernel 6.12.

Fix build error: 
```
make[5]: Entering directory '/Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions'
-n Xtables-addons 3.26 - Linux 
6.12.23
if [ -n "/Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/linux-6.12.23" ]; then make -C /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/linux-6.12.23 M=/Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions modules; fi;
make[6]: Entering directory '/Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/linux-6.12.23'
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/compat_xtables.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_CHAOS.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_DELUDE.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_DHCPMAC.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_DNETMAP.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_ECHO.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_IPMARK.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_LOGMARK.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_PROTO.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_SYSRQ.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_TARPIT.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_condition.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_fuzzy.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_geoip.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_asn.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_iface.o
  CC [M]  /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_ipp2p.o
/Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.26/extensions/xt_ipp2p.c:9:10: fatal error: asm/unaligned.h: No such file or directory
    9 | #include <asm/unaligned.h>
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
```

