### PR TITLE
[24.10] aria2: fix openssl legacy load failed

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
 PKG_VERSION:=1.37.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/aria2/aria2/releases/download/release-$(PKG_VERSION)/
@@ -43,6 +43,15 @@ PKG_CONFIG_DEPENDS := \
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
+define Package/aria2-openssl
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=File Transfer
+  TITLE:=lightweight download utility (OpenSSL dependencies)
+  DEPENDS:=+libopenssl +libopenssl-legacy
+  HIDDEN:=1
+endef
+
 define Package/aria2/config
   source "$(SOURCE)/Config.in"
 endef
@@ -53,7 +62,7 @@ define Package/aria2
   SUBMENU:=File Transfer
   TITLE:=lightweight download utility
   URL:=https://aria2.github.io/
-  DEPENDS:=+zlib +libstdcpp +ARIA2_OPENSSL:libopenssl +ARIA2_GNUTLS:libgnutls \
+  DEPENDS:=+zlib +libstdcpp +ARIA2_OPENSSL:aria2-openssl +ARIA2_GNUTLS:libgnutls \
 	+ARIA2_NETTLE:libnettle +ARIA2_LIBGCRYPT:libgcrypt +ARIA2_GMP:libgmp \
 	+ARIA2_LIBXML2:libxml2 +ARIA2_EXPAT:libexpat +ARIA2_SFTP:libssh2 \
 	+ARIA2_ASYNC_DNS:libcares +ARIA2_COOKIE:libsqlite3
@@ -100,3 +109,4 @@ define Package/aria2/install
 endef
 
 $(eval $(call BuildPackage,aria2))
+$(eval $(call BuildPackage,aria2-openssl))

--- a/net/aria2/files/aria2.init
+++ b/net/aria2/files/aria2.init
@@ -341,6 +341,7 @@ aria2_start() {
 		procd_set_param user "$user"
 
 	procd_add_jail "$NAME.$section" log
+	procd_add_jail_mount "/usr/lib/ossl-modules"
 	procd_add_jail_mount "$ca_certificate" "$certificate" "$rpc_certificate" "$rpc_private_key"
 	procd_add_jail_mount_rw "$dir" "$config_dir" "$log"
 	procd_close_instance


### PR DESCRIPTION
```
Mon Apr 21 13:30:56 2025 daemon.info aria2c[13301]: jail: exec-ing /usr/bin/aria2c
Mon Apr 21 13:30:56 2025 daemon.err aria2c[13301]: Exception caught
Mon Apr 21 13:30:56 2025 daemon.err aria2c[13301]: Exception: [Platform.cc:125] errorCode=1 OSSL_PROVIDER_load 'legacy' failed.
Mon Apr 21 13:30:56 2025 daemon.err aria2c[13301]:
Mon Apr 21 13:30:56 2025 daemon.info procd: Instance aria2::aria2.main s in a crash loop 6 crashes, 0 seconds since last crash
Mon Apr 21 13:30:56 2025 daemon.info aria2c[13301]: jail: jail (13302) exited with exit: 1

```

Links:
- https://github.com/aria2/aria2/issues/2152

Maintainer: @egorenar @kuoruan 
Compile tested: x86_64, openwrt 24.10.0
Run tested: same

Description:
This is a improved version of https://github.com/openwrt/packages/pull/22956 , mount `/usr/lib/ossl-modules` instead of `/usr/lib`, and fix recursive dependency

Related PR https://github.com/openwrt/packages/pull/26361

