### PR TITLE
wifi-presence: mqttID error

### DIFF
--- a/net/wifi-presence/files/wifi-presence.init
+++ b/net/wifi-presence/files/wifi-presence.init
@@ -35,7 +35,7 @@ start_service() {
         config_get hassPrefix main hassPrefix
         config_get hostapdSocks main hostapdSocks
         config_get mqttAddr main mqttAddr
-        config_get mqttID main mqttId
+        config_get mqttID main mqttID
         config_get mqttUsername main mqttUsername
         config_get mqttPassword main mqttPassword
         config_get mqttPrefix main mqttPrefix


### PR DESCRIPTION
Fixed mqttID not taken into account (typo error)

Maintainer: @awilliams / @jmccrohan
Compile tested: mvebu/cortexa9 / r24106-10cc5fcd00
Run tested: mvebu/cortexa9 / r24106-10cc5fcd00

Description:
In `wifi-presence.init` only, `mqttID` variable was written `mqttId`, preventing it from being taken into account.