### PR TITLE
libtorrent-rasterbar: Update to 2.0.11 and enable python package

### DIFF
--- a/libs/libtorrent-rasterbar/Makefile
+++ b/libs/libtorrent-rasterbar/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtorrent-rasterbar
-PKG_VERSION:=2.0.10
+PKG_VERSION:=2.0.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/arvidn/libtorrent/releases/download/v$(PKG_VERSION)/
-PKG_HASH:=fc935b8c1daca5c0a4d304bff59e64e532be16bb877c012aea4bda73d9ca885d
+PKG_HASH:=f0db58580f4f29ade6cc40fa4ba80e2c9a70c90265cd77332d3cdec37ecf1e6d
 
 PKG_MAINTAINER:=David Yang <mmyangfl@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/libs/libtorrent-rasterbar/Makefile
+++ b/libs/libtorrent-rasterbar/Makefile
@@ -12,51 +12,72 @@ PKG_MAINTAINER:=David Yang <mmyangfl@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
 
+PKG_CONFIG_DEPENDS:=CONFIG_PACKAGE_python3-libtorrent
+
+CMAKE_INSTALL:=1
+PYTHON3_PKG_BUILD:=0
+PYTHON3_PKG_WHEEL_NAME:=libtorrent
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
+include ../../lang/python/python3-package.mk
 
 define Package/libtorrent-rasterbar/Default
-	TITLE:=Rasterbar BitTorrent library
-	URL:=https://libtorrent.org/
+  TITLE:=Rasterbar BitTorrent library
+  URL:=https://libtorrent.org/
 endef
 
 define Package/libtorrent-rasterbar
-	$(call Package/libtorrent-rasterbar/Default)
-	SECTION:=libs
-	CATEGORY:=Libraries
-	DEPENDS:=+boost-system +libopenssl +libatomic +libstdcpp
+  $(call Package/libtorrent-rasterbar/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+boost-system +libopenssl +libatomic +libstdcpp
 endef
 
-#define Package/python3-libtorrent
-#	$(call Package/libtorrent-rasterbar/Default)
-#	SECTION:=lang
-#	CATEGORY:=Languages
-#	SUBMENU:=Python
-#	TITLE+= (Python 3)
-#	DEPENDS:=+libtorrent-rasterbar +boost-python
-#endef
+define Package/python3-libtorrent
+  $(call Package/libtorrent-rasterbar/Default)
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE+= (Python 3)
+  DEPENDS:=+libtorrent-rasterbar +boost-python3
+endef
 
 define Package/libtorrent-rasterbar/description
-	Rasterbar libtorrent is a C++ library that aims to be a good alternative to
-	all the other bittorrent implementations around.
+  Rasterbar libtorrent is a C++ library that aims to be a good alternative to
+  all the other bittorrent implementations around.
 endef
 
-#define Package/python3-libtorrent/description
-#	$(call Package/libtorrent-rasterbar/description)
-#	This package contains Python 3 bindings for the libtorrent-rasterbar library.
-#endef
+define Package/python3-libtorrent/description
+  $(call Package/libtorrent-rasterbar/description)
+  This package contains Python 3 bindings for the libtorrent-rasterbar library.
+endef
 
-#CMAKE_OPTIONS += \
-#	-Dpython-bindings=ON \
-#	-Dpython-egg-info=ON
+ifneq ($(CONFIG_PACKAGE_python3-libtorrent),)
+CMAKE_OPTIONS += \
+	-Dpython-bindings=ON \
+	-Dpython-egg-info=ON
+endif
 
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/libtorrent $(1)/usr/include/
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libtorrent-rasterbar.so* $(1)/usr/lib/
-	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libtorrent-rasterbar.pc $(1)/usr/lib/pkgconfig/
+define Build/Configure
+	$(call Build/Configure/Default)
+ifneq ($(CONFIG_PACKAGE_python3-libtorrent),)
+	$(call Py3Build/Configure)
+endif
+endef
+
+define Build/Compile
+	$(call Build/Compile/Default)
+ifneq ($(CONFIG_PACKAGE_python3-libtorrent),)
+	$(call Py3Build/Compile)
+endif
+endef
+
+define Build/Install
+	$(call Build/Install/Default)
+ifneq ($(CONFIG_PACKAGE_python3-libtorrent),)
+	$(call Py3Build/Install/Default)
+endif
 endef
 
 define Package/libtorrent-rasterbar/install
@@ -64,10 +85,6 @@ define Package/libtorrent-rasterbar/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libtorrent-rasterbar.so.* $(1)/usr/lib/
 endef
 
-#define Package/python3-libtorrent/install
-#	$(INSTALL_DIR) $(1)/usr/lib/python2.7/site-packages
-#	$(CP) $(PKG_INSTALL_DIR)/usr/lib/python2.7/site-packages/*.so* $(1)/usr/lib/python2.7/site-packages/
-#endef
-
 $(eval $(call BuildPackage,libtorrent-rasterbar))
-#$(eval $(call BuildPackage,python3-libtorrent))
+$(eval $(call Py3Package,python3-libtorrent))
+$(eval $(call BuildPackage,python3-libtorrent))


### PR DESCRIPTION
Maintainer: @yangfl
Compile tested: rockchip/armv8
Run tested: n/a

Description:
- Update to 2.0.11
- enable python package

The python package now works with Python 3.11.
Also simplify Build/InstallDev with CMAKE_INSTALL.
