### PR TITLE
xtables-addons: remove not needed iptables install dependency for RTSP helpers

### DIFF
--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -8,7 +8,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=xtables-addons
 PKG_VERSION:=3.27
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_HASH:=e47ea8febe73c12ecab09d2c93578c5dc72d76f17fdf673397758f519cce6828
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -195,10 +195,20 @@ define Package/iptgeoip/install
 endef
 
 
+define KernelPackage/nf-nathelper-rtsp
+  SUBMENU:=Netfilter Extensions
+  TITLE:=Conntrack and NAT for rtsp
+  DEPENDS:=+kmod-nf-conntrack +kmod-nf-nat
+  FILES:=$(PKG_BUILD_DIR)/extensions/rtsp/nf_conntrack_rtsp.$(LINUX_KMOD_SUFFIX) \
+    $(PKG_BUILD_DIR)/extensions/rtsp/nf_nat_rtsp.$(LINUX_KMOD_SUFFIX)
+  AUTOLOAD:=$(call AutoProbe,nf_conntrack_rtsp nf_nat_rtsp)
+  PROVIDES:=kmod-ipt-nathelper-rtsp
+endef
+
+
 #$(eval $(call BuildTemplate,SUFFIX,DESCRIPTION,EXTENSION,MODULE,PRIORITY,DEPENDS))
 
 $(eval $(call BuildTemplate,compat-xtables,API compatibilty layer,,compat_xtables,+IPV6:kmod-ip6tables))
-$(eval $(call BuildTemplate,nathelper-rtsp,RTSP Conntrack and NAT,,rtsp/nf_conntrack_rtsp rtsp/nf_nat_rtsp,+kmod-ipt-conntrack-extra +kmod-ipt-nat))
 
 $(eval $(call BuildTemplate,account,ACCOUNT,xt_ACCOUNT,ACCOUNT/xt_ACCOUNT,+kmod-ipt-compat-xtables))
 $(eval $(call BuildTemplate,asn,asn,xt_asn,xt_asn,))
@@ -226,3 +236,4 @@ $(eval $(call BuildTemplate,tarpit,TARPIT,xt_TARPIT,xt_TARPIT,+kmod-ipt-compat-x
 $(eval $(call BuildPackage,iptaccount))
 $(eval $(call BuildPackage,iptasn))
 $(eval $(call BuildPackage,iptgeoip))
+$(eval $(call KernelPackage,nf-nathelper-rtsp))


### PR DESCRIPTION
Maintainer: @namiltd 
Compile tested: x86_64, APU3, master
Run tested: x86_64, APU3, only module load

Description:

The RTSP conntrack and nat does not dependent on iptables, but only on nf_conntrack and nf_nat. The RTSP conntrack module is used as a helper in [firewall4](https://github.com/openwrt/firewall4/blob/master/root/usr/share/firewall4/helpers#L89). Previously, it was not possible to install RTSP kernel module without also installing the not needed iptables modules. However, as firewall4 is based on nftables and not on iptables, this dependency is not necessary.

I did never get an answer from the [mailinglist](https://lists.openwrt.org/pipermail/openwrt-devel/2024-August/043112.html). But from my point of view it made no sense to have a dependency on iptables here. And since it's being [rebased](https://github.com/openwrt/packages/pull/26368/) anyway, it wouldn't be bad if we could fix this too.

Test:
```
root@LUKE-C-P094 ~ # opkg  install /tmp/kmod-nf-nathelper-rtsp_5.15.180-3.24-1_x86_64.ipk
root@LUKE-C-P094 ~ # lsmod | grep nf_nat 
asn1_decoder           16384  1 nf_nat_snmp_basic
nf_conntrack           90112 42 nf_nat_rtsp,nf_conntrack_rtsp,xt_connlimit,nf_conncount,xt_state,xt_nat,xt_helper,xt_conntrack,xt_connmark,xt_connbytes,xt_REDIRECT,xt_NETMAP,xt_MASQUERADE,ppa_drv_stack_al,nft_redir,nft_nat,nft_masq,nft_flow_offload,nft_ct,nf_nat_tftp,nf_nat_snmp_basic,nf_nat_sip,nf_nat_pptp,nf_nat_irc,nf_nat_h323,nf_nat_ftp,nf_nat_amanda,nf_nat,nf_flow_table,nf_conntrack_tftp,nf_conntrack_snmp,nf_conntrack_sip,nf_conntrack_sane,nf_conntrack_pptp,nf_conntrack_netlink,nf_conntrack_netbios_ns,nf_conntrack_irc,nf_conntrack_h323,nf_conntrack_ftp,nf_conntrack_broadcast,nf_conntrack_bridge,nf_conntrack_amanda
nf_conntrack_amanda    16384  3 nf_nat_amanda
nf_conntrack_ftp       16384  3 nf_nat_ftp
nf_conntrack_h323      49152  5 nf_nat_h323
nf_conntrack_irc       16384  2 nf_nat_irc
nf_conntrack_pptp      16384  2 nf_nat_pptp
nf_conntrack_rtsp      20480  1 nf_nat_rtsp  <----
nf_conntrack_sip       28672  3 nf_nat_sip
nf_conntrack_snmp      16384  2 nf_nat_snmp_basic
nf_conntrack_tftp      16384  3 nf_nat_tftp
nf_nat                 40960 17 nf_nat_rtsp,iptable_nat,xt_nat,xt_REDIRECT,xt_NETMAP,xt_MASQUERADE,nft_redir,nft_nat,nft_masq,nft_chain_nat,nf_nat_tftp,nf_nat_sip,nf_nat_pptp,nf_nat_irc,nf_nat_h323,nf_nat_ftp,nf_nat_amanda
nf_nat_amanda          16384  0 
nf_nat_ftp             16384  0 
nf_nat_h323            20480  0 
nf_nat_irc             16384  0 
nf_nat_pptp            16384  0 
nf_nat_rtsp            16384  0  <-----
nf_nat_sip             20480  0 
nf_nat_snmp_basic      16384  0 
nf_nat_tftp            16384  0
```