### PR TITLE
modemmanager: additional backport fixes for version 1.24.0

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/patches/0002-modem-helpers-cinterion-allow-spaces-in-SXRAT-test-r.patch
+++ b/net/modemmanager/patches/0002-modem-helpers-cinterion-allow-spaces-in-SXRAT-test-r.patch
@@ -1,0 +1,75 @@
+From 6b6997362b5530708725c16c80ef36cd21609f20 Mon Sep 17 00:00:00 2001
+From: Dan Williams <dan@ioncontrol.co>
+Date: Sun, 13 Apr 2025 19:56:56 -0500
+Subject: [PATCH] modem-helpers-cinterion: allow spaces in ^SXRAT test response
+
+^SXRAT: (0-6), (0,2,3), (0,2,3)
+
+Fixes: https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/issues/974
+
+Signed-off-by: Dan Williams <dan@ioncontrol.co>
+---
+ .../cinterion/mm-modem-helpers-cinterion.c    |  2 +-
+ .../tests/test-modem-helpers-cinterion.c      | 33 +++++++++++++++++++
+ 2 files changed, 34 insertions(+), 1 deletion(-)
+
+--- a/src/plugins/cinterion/mm-modem-helpers-cinterion.c
++++ b/src/plugins/cinterion/mm-modem-helpers-cinterion.c
+@@ -794,7 +794,7 @@ mm_cinterion_parse_sxrat_test (const gch
+         return FALSE;
+     }
+ 
+-    r = g_regex_new ("\\^SXRAT:\\s*\\(([^\\)]*)\\),\\(([^\\)]*)\\)(,\\(([^\\)]*)\\))?(?:\\r\\n)?",
++    r = g_regex_new ("\\^SXRAT:\\s*\\(([^\\)]*)\\),\\s*\\(([^\\)]*)\\)(,\\s*\\(([^\\)]*)\\))?(?:\\r\\n)?",
+                      G_REGEX_DOLLAR_ENDONLY | G_REGEX_RAW,
+                      0, NULL);
+ 
+--- a/src/plugins/cinterion/tests/test-modem-helpers-cinterion.c
++++ b/src/plugins/cinterion/tests/test-modem-helpers-cinterion.c
+@@ -1827,6 +1827,38 @@ test_sxrat_response_els61 (void)
+ }
+ 
+ static void
++test_sxrat_response_pls63_w (void)
++{
++    GArray *expected_rat;
++    GArray *expected_pref1;
++    GArray *expected_pref2;
++    const guint vals[] = { 0, 2, 3 };
++    guint val;
++    const gchar *response =
++        "^SXRAT: (0-6), (0,2,3), (0,2,3)\r\n"
++        "\r\n";
++
++    expected_rat = g_array_sized_new (FALSE, FALSE, sizeof (guint), 7);
++    for (val = 0; val < 7; val++)
++        g_array_append_val (expected_rat, val);
++
++    expected_pref1 = g_array_sized_new (FALSE, FALSE, sizeof (guint), 3);
++    g_array_append_vals (expected_pref1, &vals, 3);
++
++    expected_pref2 = g_array_sized_new (FALSE, FALSE, sizeof (guint), 3);
++    g_array_append_vals (expected_pref2, &vals, 3);
++
++    common_test_sxrat (response,
++                       expected_rat,
++                       expected_pref1,
++                       expected_pref2);
++
++    g_array_unref (expected_rat);
++    g_array_unref (expected_pref1);
++    g_array_unref (expected_pref2);
++}
++
++static void
+ test_sxrat_response_other (void)
+ {
+     GArray *expected_rat;
+@@ -2177,6 +2209,7 @@ int main (int argc, char **argv)
+     g_test_add_func ("/MM/cinterion/sgauth",                  test_sgauth_response);
+     g_test_add_func ("/MM/cinterion/sxrat",                   test_sxrat);
+     g_test_add_func ("/MM/cinterion/sxrat/response/els61",    test_sxrat_response_els61);
++    g_test_add_func ("/MM/cinterion/sxrat/response/pls63w",   test_sxrat_response_pls63_w);
+     g_test_add_func ("/MM/cinterion/sxrat/response/other",    test_sxrat_response_other);
+     g_test_add_func ("/MM/cinterion/cops/only-mode-2g",       test_cops_only_mode_2g);
+     g_test_add_func ("/MM/cinterion/cops/only-mode-3g",       test_cops_only_mode_3g);

--- a/net/modemmanager/patches/0003-modem-helpers-fix-checking-of-CDMA-EVDO-access-techn.patch
+++ b/net/modemmanager/patches/0003-modem-helpers-fix-checking-of-CDMA-EVDO-access-techn.patch
@@ -1,0 +1,73 @@
+From 9e205f47847ab9ef5887b79c077ef8468d769af0 Mon Sep 17 00:00:00 2001
+From: Dan Williams <dan@ioncontrol.co>
+Date: Sat, 12 Apr 2025 23:17:45 -0500
+Subject: [PATCH] modem-helpers: fix checking of CDMA/EVDO access technology
+
+Missing ! for strncmp() meant the test was backwards and would
+erroneously report 1xRTT and EVDOr0 when those access technologies
+were not in use.
+
+Signed-off-by: Dan Williams <dan@ioncontrol.co>
+---
+ src/mm-modem-helpers.c         |  6 +++---
+ src/tests/test-modem-helpers.c | 25 +++++++++++++++++++++++++
+ 2 files changed, 28 insertions(+), 3 deletions(-)
+
+--- a/src/mm-modem-helpers.c
++++ b/src/mm-modem-helpers.c
+@@ -4160,11 +4160,11 @@ mm_string_to_access_tech (const gchar *s
+      * are included in other strings too.
+      */
+     len = strlen (string);
+-    if (strncmp (string, "EVDO", 4) && (len >= 4 && !isalnum (string[4])))
++    if (!strncmp (string, "EVDO", 4) && (len >= 4 && !isalnum (string[4])))
+         act |= MM_MODEM_ACCESS_TECHNOLOGY_EVDO0;
+-    if (strncmp (string, "CDMA", 4) && (len >= 4 && !isalnum (string[4])))
++    if (!strncmp (string, "CDMA", 4) && (len >= 4 && !isalnum (string[4])))
+         act |= MM_MODEM_ACCESS_TECHNOLOGY_1XRTT;
+-    if (strncmp (string, "CDMA-EVDO", 9) && (len >= 9 && !isalnum (string[9])))
++    if (!strncmp (string, "CDMA-EVDO", 9) && (len >= 9 && !isalnum (string[9])))
+         act |= MM_MODEM_ACCESS_TECHNOLOGY_1XRTT | MM_MODEM_ACCESS_TECHNOLOGY_EVDO0;
+ 
+     return act;
+--- a/src/tests/test-modem-helpers.c
++++ b/src/tests/test-modem-helpers.c
+@@ -4866,6 +4866,29 @@ test_mnc_length (void)
+ 
+ /*****************************************************************************/
+ 
++typedef struct {
++    const gchar                   *str;
++    const MMModemAccessTechnology  act;
++} TestActData;
++
++static const TestActData test_act_data[] = {
++    { "EDGE",      MM_MODEM_ACCESS_TECHNOLOGY_EDGE },
++    /* Ensure WCDMA does not get counted as 3GPP2 CDMA */
++    { "WCDMA",     MM_MODEM_ACCESS_TECHNOLOGY_UMTS },
++    { "CDMA-EVDO", MM_MODEM_ACCESS_TECHNOLOGY_1XRTT | MM_MODEM_ACCESS_TECHNOLOGY_EVDO0 },
++};
++
++static void
++test_string_to_access_tech (void)
++{
++    guint i;
++
++    for (i = 0; i < G_N_ELEMENTS (test_act_data); i++)
++        g_assert_cmpint (mm_string_to_access_tech (test_act_data[i].str), ==, test_act_data[i].act);
++}
++
++/*****************************************************************************/
++
+ #define TESTCASE(t, d) g_test_create_case (#t, 0, d, NULL, (GTestFixtureFunc) t, NULL)
+ 
+ int main (int argc, char **argv)
+@@ -5111,6 +5134,8 @@ int main (int argc, char **argv)
+     g_test_suite_add (suite, TESTCASE (test_spn_to_utf8, NULL));
+     g_test_suite_add (suite, TESTCASE (test_mnc_length, NULL));
+ 
++    g_test_suite_add (suite, TESTCASE (test_string_to_access_tech, NULL));
++
+     result = g_test_run ();
+ 
+     reg_test_data_free (reg_data);

--- a/net/modemmanager/patches/0004-iface-modem-voice-recheck-call-state-polling-when-ca.patch
+++ b/net/modemmanager/patches/0004-iface-modem-voice-recheck-call-state-polling-when-ca.patch
@@ -1,0 +1,54 @@
+From 92e666e1c92c205e896552604e717d5b39528ae3 Mon Sep 17 00:00:00 2001
+From: Dan Williams <dan@ioncontrol.co>
+Date: Sat, 12 Apr 2025 23:04:38 -0500
+Subject: [PATCH] iface-modem-voice: recheck call state polling when call is
+ started
+
+When an outgoing call is created and added to the call list its state
+is UNKNOWN. The call list emits the ADDED signal which MMIfaceModemVoice
+listens for to check whether to begin polling call state.
+
+But since UNKNOWN is not an in-progress call state polling isn't started.
+And nothing was rechecking whether to start polling when the call state
+changed to something other than UNKNOWN.
+
+Do that so that we can track call progress as it dials out and is
+answered.
+
+Signed-off-by: Dan Williams <dan@ioncontrol.co>
+---
+ src/mm-iface-modem-voice.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+--- a/src/mm-iface-modem-voice.c
++++ b/src/mm-iface-modem-voice.c
+@@ -32,6 +32,10 @@ static GQuark in_call_event_context_quar
+ 
+ G_DEFINE_INTERFACE (MMIfaceModemVoice, mm_iface_modem_voice, MM_TYPE_IFACE_MODEM)
+ 
++static void setup_call_list_polling (MMCallList        *call_list,
++                                     const gchar       *call_path_added,
++                                     MMIfaceModemVoice *self);
++
+ /*****************************************************************************/
+ 
+ void
+@@ -1781,6 +1785,7 @@ typedef enum {
+     IN_CALL_SETUP_STEP_FIRST,
+     IN_CALL_SETUP_STEP_UNSOLICITED_EVENTS,
+     IN_CALL_SETUP_STEP_AUDIO_CHANNEL,
++    IN_CALL_SETUP_STEP_CHECK_POLLING,
+     IN_CALL_SETUP_STEP_LAST,
+ } InCallSetupStep;
+ 
+@@ -1908,6 +1913,10 @@ in_call_setup_context_step (GTask *task)
+         }
+         ctx->step++;
+         /* fall-through */
++    case IN_CALL_SETUP_STEP_CHECK_POLLING:
++        setup_call_list_polling (NULL, NULL, self);
++        ctx->step++;
++        /* fall-through */
+     case IN_CALL_SETUP_STEP_LAST:
+         g_task_return_boolean (task, TRUE);
+         g_object_unref (task);


### PR DESCRIPTION


Maintainer: me
Compile tested: x86_64, APU3, OpenWrt master
Run tested: no

Description:
Based on the discussion refs #26349 also backport the latest changes. The following commits were added shortly after the release of Modemmanager version '1.24.0'.

Patch: 0002-modem-helpers-cinterion-allow-spaces-in-SXRAT-test-r.patch
Backport: https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/commit/6b6997362b5530708725c16c80ef36cd21609f20
Issue: https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/issues/974

Patch: 0003-modem-helpers-fix-checking-of-CDMA-EVDO-access-techn.patch
Backport: https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/commit/9e205f47847ab9ef5887b79c077ef8468d769af0
Issue: no

Patch: 0004-iface-modem-voice-recheck-call-state-polling-when-ca.patch
Backport: https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/commit/92e666e1c92c205e896552604e717d5b39528ae3
Issue: no
