### PR TITLE
[24.10] realtek-poe: Builds for all targets

### DIFF
--- a/utils/realtek-poe/Makefile
+++ b/utils/realtek-poe/Makefile
@@ -20,7 +20,7 @@ define Package/realtek-poe
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Realtek PoE Switch Port daemon
-  DEPENDS:=@TARGET_realtek +libubox +libubus +libuci
+  DEPENDS:=+libubox +libubus +libuci
 endef
 
 define Package/realtek-poe/install


### PR DESCRIPTION
Backport of https://github.com/openwrt/packages/pull/26341

Maintainer: @mrnuke @Hurricos
Compile tested: realtek/rtl839x (hpe_1920-48g-poe 5d26507a73b166e6a47522478455bb95bc73672b
Run tested: realtek/rtl839x (hpe_1920-48g-poe 5d26507a73b166e6a47522478455bb95bc73672b

Description:

Currently realtek-poe is built for mips-4kec with the realtek/rtl838x target but not built for mips-24kc with the realtek/rtl839x target. The package builds ok but buildbot is not triggering the extra build and the package is missing from mips-24kc repos.

This flag should instruct build systems to build the package for all targets.

