### PR TITLE
glib2: Fix ipkg packaging error

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.82.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/$(basename $(PKG_VERSION))
@@ -95,7 +95,7 @@ define Build/InstallDev
 
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/*.{so*,a} \
-		$(1)/usr/lib/
+		$(1)/usr/lib/ || :
 
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(INSTALL_DATA) \


### PR DESCRIPTION
fix this error:
```
mkdir -p /home/nasbdh9/openwrt/tmp/stage-glib2/host /home/nasbdh9/openwrt/staging_dir/target-aarch64_generic_musl/packages
install -d -m0755 /home/nasbdh9/openwrt/tmp/stage-glib2/usr/bin
cp -fpR /home/nasbdh9/openwrt/build_dir/target-aarch64_generic_musl/glib-2.82.0/ipkg-install/usr/bin/* /home/nasbdh9/openwrt/tmp/stage-glib2/usr/bin/
install -d -m0755 /home/nasbdh9/openwrt/tmp/stage-glib2/usr/include
cp -fpR /home/nasbdh9/openwrt/build_dir/target-aarch64_generic_musl/glib-2.82.0/ipkg-install/usr/include/glib-2.0 /home/nasbdh9/openwrt/tmp/stage-glib2/usr/include/
cp -fpR /home/nasbdh9/openwrt/build_dir/target-aarch64_generic_musl/glib-2.82.0/ipkg-install/usr/lib/glib-2.0/include/*.h /home/nasbdh9/openwrt/tmp/stage-glib2/usr/include/glib-2.0/
cp -fpR /home/nasbdh9/openwrt/build_dir/target-aarch64_generic_musl/glib-2.82.0/ipkg-install/usr/include/gio-unix-2.0 /home/nasbdh9/openwrt/tmp/stage-glib2/usr/include/
install -d -m0755 /home/nasbdh9/openwrt/tmp/stage-glib2/usr/lib
cp -fpR /home/nasbdh9/openwrt/build_dir/target-aarch64_generic_musl/glib-2.82.0/ipkg-install/usr/lib/glib-2.0 /home/nasbdh9/openwrt/tmp/stage-glib2/usr/lib/
cp -fpR /home/nasbdh9/openwrt/build_dir/target-aarch64_generic_musl/glib-2.82.0/ipkg-install/usr/lib/*.{so*,a} /home/nasbdh9/openwrt/tmp/stage-glib2/usr/lib/
cp: cannot stat '/home/nasbdh9/openwrt/build_dir/target-aarch64_generic_musl/glib-2.82.0/ipkg-install/usr/lib/*.a': No such file or directory
make[2]: *** [Makefile:141: /home/nasbdh9/openwrt/staging_dir/target-aarch64_generic_musl/stamp/.glib2_installed] Error 1
make[2]: Leaving directory '/home/nasbdh9/openwrt/feeds/packages/libs/glib2'
time: package/feeds/packages/glib2/compile#111.16#10.95#70.99
    ERROR: package/feeds/packages/glib2 failed to build.
make[1]: *** [package/Makefile:120: package/feeds/packages/glib2/compile] Error 1
make[1]: Leaving directory '/home/nasbdh9/openwrt'
```
