### PR TITLE
libowfat: update to version 0.34

### DIFF
--- a/libs/libowfat/Makefile
+++ b/libs/libowfat/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libowfat
-PKG_VERSION:=0.33
+PKG_VERSION:=0.34
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.fefe.de/libowfat
-PKG_HASH:=311ec8b3f4b72bb442e323fb013a98f956fa745547f2bc9456287b20d027cd7d
+PKG_HASH:=d4330d373ac9581b397bc24a22ad1f7f5d58a7fe36d9d239fe352ceffc5d304b
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
@@ -19,9 +19,6 @@ PKG_BUILD_DEPENDS += libowfat/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
-
-# set to 1 to enable debugging
-DEBUG=
 
 define Package/libowfat
   SECTION:=libs
@@ -40,7 +37,7 @@ LOWFAT_MAKEOPTS = $(TARGET_CONFIGURE_OPTS) \
 	CFLAGS="$(TARGET_CFLAGS) -I$(PKG_BUILD_DIR) -I$(STAGING_DIR)/usr/include" \
 	CCC="$(TARGET_CC)" \
 	CROSS="$(TARGET_CROSS)" \
-	DEBUG="$(DEBUG)" \
+	DEBUG="$(if $(CONFIG_DEBUG),1,)" \
 	VERSION="$(PKG_VERSION)" \
 	OS="Linux"
 
@@ -55,13 +52,13 @@ define Build/Compile
 endef
 
 define Host/Compile
-	$(LN) . $(HOST_BUILD_DIR)/libowfat
-	$(MAKE) -C $(HOST_BUILD_DIR) $(LOWFAT_HOST_MAKEOPTS) ent
+	$(MAKE) -C $(HOST_BUILD_DIR) $(LOWFAT_HOST_MAKEOPTS) ent json
 endef
 
 define Host/Install
 	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/bin
 	$(CP) $(HOST_BUILD_DIR)/ent $(STAGING_DIR_HOSTPKG)/bin/libowfat-ent
+	$(CP) $(HOST_BUILD_DIR)/json $(STAGING_DIR_HOSTPKG)/bin/libowfat-json
 endef
 
 define Build/InstallDev

--- a/libs/libowfat/patches/001-fixbuild.patch
+++ b/libs/libowfat/patches/001-fixbuild.patch
@@ -1,6 +1,33 @@
 --- a/GNUmakefile
 +++ b/GNUmakefile
-@@ -368,6 +368,8 @@ socket_accept4.o socket_accept6.o socket
+@@ -25,7 +25,7 @@ CROSS=
+ #CROSS=i686-mingw-
+ CC?=gcc
+ AR?=ar
+-RANLIB?=ranlib
++RANLIB?=$(CROSS)ranlib
+ CCC=$(CROSS)$(CC)
+ WERROR=
+ WARN=-W -Wall -Wextra $(WERROR)
+@@ -1174,7 +1174,7 @@ $(IO_OBJS) $(CDB_OBJS) $(CRITBIT_OBJS)
+ 
+ libowfat.a: $(ALL_OBJS)
+ 	$(CROSS)$(AR) cru $@ $(ALL_OBJS)
+-	-$(CROSS)$(RANLIB) $@
++	-$(RANLIB) $@
+ 
+ CFLAGS+=-I.
+ CFLAGS_OPT+=-I.
+@@ -1187,7 +1187,7 @@ CFLAGS_OPT+=-I.
+ 
+ %.a:
+ 	$(CROSS)$(AR) cru $@ $^
+-	-$(CROSS)$(RANLIB) $@
++	-$(RANLIB) $@
+ 
+ t: t.o libowfat.a libsocket
+ 	$(DIET) $(CCC) -g -o $@ t.o libowfat.a `cat libsocket` -lpthread $(LDFLAGS)
+@@ -1366,6 +1366,8 @@ socket_accept4.o socket_accept6.o socket
  socket_local6.o socket_recv4.o socket_recv6.o socket_remote4.o \
  socket_remote6.o socket_accept4_flags.o socket_accept6_flags.o: havesl.h
  
@@ -9,8 +36,19 @@
  dns_nd6.o fmt_xlong.o scan_xlong.o fmt_ip6_flat.o $(TEXTCODE_OBJS): haveinline.h
  
  iob_send.o scan_ip6if.o: havealloca.h
-@@ -397,7 +399,7 @@ update:
- 	dl -n http://www.w3.org/TR/html5/entities.json
+@@ -1390,8 +1392,8 @@ Makefile: GNUmakefile dep libdep
+ srcdirs=$(subst :, ,$(VPATH))
+ srcfiles=$(foreach dir,$(srcdirs),$(wildcard $(dir)/*.c))
+ 
+-compile_commands.json.tmpl: json
+-	./json $(srcfiles) > $@
++compile_commands.json.tmpl:
++	libowfat-json $(srcfiles) > $@
+ 
+ compile_commands.json: compile_commands.json.tmpl
+ 	sed -e 's#"@"#"$(PWD)"#' < $< > $@
+@@ -1410,7 +1412,7 @@ update:
+ 	dl -n https://html.spec.whatwg.org/entities.json
  
  entities.h: entities.json ent
 -	./ent


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: -
Description:

changes since 0.33:
 * be more C99 compliant (Florian Weimer)
 * add C++ convenience overloads to uint*.h
 * remove unaligned memory access behind #ifdef i386 from uint*.h (compilers are now smart enough so they are no longer needed and they were technically undefined behavior so the sanitizer complained)

OpenWrt package changes:
 * The newly introduced 'json' build tool is added to the host build and staged as 'libowfat-json'.
 * DEBUG option is now set by global CONFIG_DEBUG option
 * fixed duplicate CROSS prefix of RANLIB
