### PR TITLE
gnupg2: update to 2.4.7 (and related libraries)

### DIFF
--- a/libs/gpgme/Makefile
+++ b/libs/gpgme/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gpgme
-PKG_VERSION:=1.21.0
+PKG_VERSION:=1.24.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
-PKG_HASH:=416e174e165734d84806253f8c96bda2993fd07f258c3aad5f053a6efd463e88
+PKG_HASH:=e11b1a0e361777e9e55f48a03d89096e2abf08c63d84b7017cfe1dce06639581
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/libs/libassuan/Makefile
+++ b/libs/libassuan/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libassuan
-PKG_VERSION:=2.5.6
+PKG_VERSION:=3.0.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
-PKG_HASH:=e9fd27218d5394904e4e39788f9b1742711c3e6b41689a31aa3380bd5aa4f426
+PKG_HASH:=d2931cdad266e633510f9970e1a2f346055e351bb19f9b78912475b8074c36f6
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1-or-later
@@ -17,6 +17,8 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
+
+CONFIGURE_VARS += ac_cv_path_GPGRT_CONFIG="$(STAGING_DIR)/usr/bin/gpgrt-config"
 
 define Package/libassuan
   SECTION:=libs

--- a/libs/libksba/Makefile
+++ b/libs/libksba/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libksba
-PKG_VERSION:=1.6.4
+PKG_VERSION:=1.6.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
-PKG_HASH:=bbb43f032b9164d86c781ffe42213a83bf4f2fee91455edfa4654521b8b03b6b
+PKG_HASH:=cf72510b8ebb4eb6693eef765749d83677a03c79291a311040a5bfd79baab763
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-3.0-or-later GPL-2.0-or-later

--- a/libs/npth/Makefile
+++ b/libs/npth/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=npth
-PKG_VERSION:=1.6
+PKG_VERSION:=1.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
-PKG_HASH:=1393abd9adcf0762d34798dc34fdcf4d0d22a8410721e76f1e3afcd1daa4e2d1
+PKG_HASH:=8bd24b4f23a3065d6e5b26e98aba9ce783ea4fd781069c1b35d149694e90ca3e
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1-or-later
@@ -30,15 +30,32 @@ define Package/libnpth/description
 nPth is a library to provide the GNU Pth API and thus a non-preemptive threads implementation. 
 endef
 
+CONFIGURE_ARGS = \
+		--target=$(REAL_GNU_TARGET_NAME) \
+		--host=$(REAL_GNU_TARGET_NAME) \
+		--build=$(GNU_HOST_NAME) \
+		--disable-dependency-tracking \
+		--program-prefix="" \
+		--program-suffix="" \
+		--prefix=$(CONFIGURE_PREFIX) \
+		--exec-prefix=$(CONFIGURE_PREFIX) \
+		--bindir=$(CONFIGURE_PREFIX)/bin \
+		--sbindir=$(CONFIGURE_PREFIX)/sbin \
+		--libexecdir=$(CONFIGURE_PREFIX)/lib \
+		--sysconfdir=/etc \
+		--datadir=$(CONFIGURE_PREFIX)/share \
+		--localstatedir=/var \
+		--mandir=$(CONFIGURE_PREFIX)/man \
+		--infodir=$(CONFIGURE_PREFIX)/info
+
 define Build/InstallDev
-	$(INSTALL_DIR) $(2)/bin $(1)/usr/bin
-	$(INSTALL_BIN) \
-		$(PKG_INSTALL_DIR)/usr/bin/npth-config \
-		$(2)/bin/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/npth.pc \
+		$(1)/usr/lib/pkgconfig
 	$(SED) \
 		's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' \
-		$(2)/bin/npth-config
-	ln -sf $(STAGING_DIR)/host/bin/npth-config $(1)/usr/bin/npth-config
+		$(1)/usr/lib/pkgconfig/npth.pc \
 
 	$(INSTALL_DIR) $(1)/usr/include
 	$(INSTALL_DATA) \

--- a/utils/gnupg2/Makefile
+++ b/utils/gnupg2/Makefile
@@ -8,13 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnupg
-PKG_VERSION:=2.2.39
+PKG_VERSION:=2.4.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/gnupg
-PKG_HASH:=ab74db6685f026d7c0a10b527ecddecd608606a1691d15fda5d0a7f7d27e4c2f
+PKG_HASH:=7b24706e4da7e0e3b06ca068231027401f238102c41c909631349dcc3b85eb46
 
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING COPYING.CC0 COPYING.GPL2 COPYING.LGPL21 COPYING.LGPL3 COPYING.other
 PKG_CPE_ID:=cpe:/a:gnupg:gnupg
@@ -24,6 +25,8 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
+
+CONFIGURE_VARS += ac_cv_path_GPGRT_CONFIG="$(STAGING_DIR)/usr/bin/gpgrt-config"
 
 define Package/gnupg2/Default
   SECTION:=utils
@@ -49,6 +52,7 @@ endef
 define Package/gnupg2-dirmngr
   $(call Package/gnupg2/Default)
   TITLE:=Keyserver, CRL, and OCSP access for GnuPG (version 2)
+  DEPENDS+=+libgnutls
 endef
 
 define Package/gnupg2-utils
@@ -92,11 +96,10 @@ CONFIGURE_ARGS += \
 	--with-libassuan-prefix="$(STAGING_DIR)/usr/" \
 	--with-ksba-prefix="$(STAGING_DIR)/usr/" \
 	--with-npth-prefix="$(STAGING_DIR)/usr/" \
-	--enable-dirmngr \
+	--disable-doc \
 	--disable-bzip2 \
 	--disable-card-support \
 	--disable-ccid-driver \
-	--disable-gnutls \
 	--disable-ldap \
 	--disable-ntbtls \
 	--disable-rpath \


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: -
Description:
Update GnuPG and project-related libraries.