### PR TITLE
i2c-tools: update to version 4.4

### DIFF
--- a/utils/i2c-tools/Makefile
+++ b/utils/i2c-tools/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=i2c-tools
-PKG_VERSION:=4.3
-PKG_RELEASE:=3
+PKG_VERSION:=4.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/utils/i2c-tools
-PKG_HASH:=1f899e43603184fac32f34d72498fc737952dbc9c97a8dd9467fadfdf4600cf9
+PKG_HASH:=8b15f0a880ab87280c40cfd7235cfff28134bf14d5646c07518b1ff6642a2473
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: -
Description:

4.4 (2024-10-10)
-------------------
  tools: Use getopt
         Implement and document option -h
  eeprog: Use force option when data comes from a pipe
  i2cdetect: Display more functionality bits with option -F
  i2cdump: Remove support for SMBus block mode
  i2cget: Document SMBus block mode
          Fix the return code of option -h
  i2cset: Fix the return code of option -h
  i2ctransfer: Sort command line options and add to help text
               Add an option to print binary data
               Drop redundant variable arg_idx
  py-smbus: Install in the defined prefix
            Use setuptools instead of distutils
