### PR TITLE
glib-networking: update to version 2.80.1

### DIFF
--- a/libs/glib-networking/Makefile
+++ b/libs/glib-networking/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib-networking
-PKG_VERSION:=2.80.0
+PKG_VERSION:=2.80.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/$(PKG_NAME)/$(basename $(PKG_VERSION))
-PKG_HASH:=d8f4f1aab213179ae3351617b59dab5de6bcc9e785021eee178998ebd4bb3acf
+PKG_HASH:=b80e2874157cd55071f1b6710fa0b911d5ac5de106a9ee2a4c9c7bee61782f8e
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: -
Description:

2.80.1 - January 8, 2025
========================

 - OpenSSL: fix crash in complete_handshake (!251, Dario Saccavino)
 - OpenSSL: fix invalid free in openssl_get_binding_tls_server_end_point() (!255)
 - TLS test should handle G_IO_ERROR_WOULD_BLOCK (!253, Richard Purdie and Alexander Kanavin)
 - Updated translations
