### PR TITLE
lvm2: update to version 2.03.31 and libdm version 1.02.205

### DIFF
--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -9,13 +9,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=LVM2
-PKG_VERSION:=2.03.25
-PKG_VERSION_DM:=1.02.199
+PKG_VERSION:=2.03.31
+PKG_VERSION_DM:=1.02.205
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
-PKG_SOURCE_URL:=https://sourceware.org/pub/lvm2
-PKG_HASH:=4bea6fd2e5af9cdb3e27b48b4efa8d89210d9bfa13df900e092e404720a59b1d
+PKG_SOURCE_URL:=https://sourceware.org/pub/lvm2 \
+                https://www.mirrorservice.org/sites/sourceware.org/pub/lvm2
+
+PKG_HASH:=5db2956a00fbf87d92274cccc92436387ec0c3faadece7413ece1ba1c10c98ff
 PKG_BUILD_DIR:=$(BUILD_DIR)/lvm2-$(BUILD_VARIANT)/$(PKG_NAME).$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>

--- a/utils/lvm2/patches/002-const-stdio.patch
+++ b/utils/lvm2/patches/002-const-stdio.patch
@@ -1,6 +1,6 @@
 --- a/lib/commands/toolcontext.c
 +++ b/lib/commands/toolcontext.c
-@@ -1660,6 +1660,7 @@ struct cmd_context *create_toolcontext(u
+@@ -1669,6 +1669,7 @@ struct cmd_context *create_toolcontext(u
  	/* FIXME Make this configurable? */
  	reset_lvm_errno(1);
  
@@ -8,7 +8,7 @@
  	/* Set in/out stream buffering before glibc */
  	if (set_buffering
  	    && !cmd->running_on_valgrind /* Skipping within valgrind execution. */
-@@ -1704,6 +1705,7 @@ struct cmd_context *create_toolcontext(u
+@@ -1713,6 +1714,7 @@ struct cmd_context *create_toolcontext(u
  	} else if (!set_buffering)
  		/* Without buffering, must not use stdin/stdout */
  		init_silent(1);
@@ -16,7 +16,7 @@
  
  	/*
  	 * Environment variable LVM_SYSTEM_DIR overrides this below.
-@@ -2038,6 +2040,7 @@ void destroy_toolcontext(struct cmd_cont
+@@ -2047,6 +2049,7 @@ void destroy_toolcontext(struct cmd_cont
  	if (cmd->cft_def_hash)
  		dm_hash_destroy(cmd->cft_def_hash);
  
@@ -24,7 +24,7 @@
  	if (!cmd->running_on_valgrind && cmd->linebuffer) {
  		int flags;
  		/* Reset stream buffering to defaults */
-@@ -2061,6 +2064,7 @@ void destroy_toolcontext(struct cmd_cont
+@@ -2070,6 +2073,7 @@ void destroy_toolcontext(struct cmd_cont
  
  		free(cmd->linebuffer);
  	}
@@ -34,7 +34,7 @@
  
 --- a/tools/lvmcmdline.c
 +++ b/tools/lvmcmdline.c
-@@ -3375,6 +3375,7 @@ int lvm_split(char *str, int *argc, char
+@@ -3386,6 +3386,7 @@ int lvm_split(char *str, int *argc, char
  /* Make sure we have always valid filedescriptors 0,1,2 */
  static int _check_standard_fds(void)
  {
@@ -42,7 +42,7 @@
  	int err = is_valid_fd(STDERR_FILENO);
  
  	if (!is_valid_fd(STDIN_FILENO) &&
-@@ -3401,6 +3402,12 @@ static int _check_standard_fds(void)
+@@ -3412,6 +3413,12 @@ static int _check_standard_fds(void)
  		       strerror(errno));
  		return 0;
  	}

--- a/utils/lvm2/patches/003-no-mallinfo.patch
+++ b/utils/lvm2/patches/003-no-mallinfo.patch
@@ -1,6 +1,6 @@
 --- a/lib/mm/memlock.c
 +++ b/lib/mm/memlock.c
-@@ -195,12 +195,15 @@ static void _allocate_memory(void)
+@@ -199,12 +199,15 @@ static void _allocate_memory(void)
  	 *  memory on free(), this is good enough for our purposes.
  	 */
  	while (missing > 0) {
@@ -16,7 +16,7 @@
  		inf = MALLINFO();
  
  		if (hblks < inf.hblks) {
-@@ -210,9 +213,12 @@ static void _allocate_memory(void)
+@@ -214,9 +217,12 @@ static void _allocate_memory(void)
  			free(areas[area]);
  			_size_malloc_tmp /= 2;
  		} else {
@@ -29,7 +29,7 @@
  
  		if (area == max_areas && missing > 0) {
  			/* Too bad. Warn the user and proceed, as things are
-@@ -529,8 +535,13 @@ static void _lock_mem(struct cmd_context
+@@ -540,8 +546,13 @@ static void _lock_mem(struct cmd_context
  	 * will not block memory locked thread
  	 * Note: assuming _memlock_count_daemon is updated before _memlock_count
  	 */


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: -

Description:

Version 2.03.31 - 27th February 2025
====================================
  Reduce 'mandoc -T lint' reported issues for man pages.
  Restore support for LVM_SUPPRESS_FD_WARNINGS (2.03.24).
  Fix uncache and split cache restoring original state of volume.
  Extend use of lockopt skip to more scenarios.
  Enhance error path resolving in polling code.
  Disallow shared activation of LV with CoW snapshot.
  Fix lvmlockd use in lvremove of CoW snapshot, VDO pool, and uncache.
  Improve mirror split with opened temporary volumes.
  Improve pvmove finish with opened temporary volumes.
  Fix backup limit for devices file, handle over 10,000 files.
  Ignore reported optimal_io_size not divisible by 4096.
  Fix busy-loop in config reading when read returned 0.
  Fix DM cache preserving logic (2.03.28).
  Improve use of lvmlockd for usecases involving thin volumes and pools.

Version 2.03.30 - 14th January 2025
===================================
  Lvresize reports origin vdo volume cannot be resized.
  Support setting reserved_memory|stack of --config cmdline.
  Fix support for disabling memory locking (2.03.27).
  Do not extend an LV if FS resize unsupported and '--fs resize' used.
  Prevent leftover temporary device when converting in use volume to a pool.
  lvconvert detects early volume in use when converting it to a pool.
  Handle NVMe with quirk changed WWID not matching WWID in devices file.

Version 2.03.29 - 09th December 2024
====================================
  Configure --enable/disable-sd-notify to control lvmlockd build with sd-notify.
  Allow test mode when lvmlockd is built without dlm support.
  Add a note about RAID + integrity synchronization to lvmraid(7) man page.
  Add a function for running lvconvert --repair on RAID LVs to lvmdbusd.
  Improve option section of man pages for listing commands ({pv,lv,vg}{s,display}).
  Fix renaming of raid sub LVs when converting a volume to raid (2.03.28).
  Fix segfault/VG write error for raid LV lvextend -i|--stripes -I|--stripesize.
  Revert ignore -i|--stripes, -I|--stripesize for lvextend on raid0 LV (2.03.27).

Version 2.03.28 - 04th November 2024
====================================
  Use radix_tree to lookup for UUID within committed metadata.
  Use radix_tree to lookup LV list entry within VG struct.
  Introduce setting config/validate_metadata = full | none.
  Restore fs resize call for lvresize -r on the same size LV (2.03.17).
  Correct off-by-one devicesfile backup counting.
  Replace use of dm_hash with radix_tree for lv names and uuids.
  Refactor vg_validate with uniq_insert and better use of CPU caches.
  Add radix_tree_uniq_insert.
  Update DM cache when taking next VG lock instead of dropping it.
  Generate json string id only for json reporting.
  For vgsummary use new API call dm_config_parse_only_section().
  Use radix_tree for PV names mapping.
  Split check_lv_segment into separate _in/complete_vg variant.
  Use find_lv instead of find_lv_in_vg when possible.
  Do a mirror fixup only when mirrors with logs are imported.
  Add faster crc32 calculation from zlib code for x86_64.
  Fall back to direct zeroing if BLKZEROOUT fails during new LV initialization.

Version 2.03.27 - 02nd October 2024
===================================
  Fix swap device size detection using blkid for lvresize/lvreduce/lvextend.

  Detect GPT partition table and pass partition filter if no partitions defined.
  Add global/sanlock_align_size option to configure sanlock lease size.
  Disable mem locking when activation/reserved_stack or reserved_memory is 0.
  Fix locking issues in lvmlockd leaving thin pool locked.
  Deprecate vdo settings vdo_write_policy and vdo_write_policy.
  Lots of typo fixes across lvm2 code base (codespell).
  Corrected integrity parameter interleave_sectors for DM table line.
  Ignore -i|--stripes, -I|--stripesize for lvextend on raid0 LV, like raid10.
  Do not accept duplicate device names for pvcreate.

Version 2.03.26 - 23rd August 2024
==================================
  Fix internal error reported by pvmove on a VG with single PV.
  Also accept --mknodes --refresh for vgscan.
  Fix vgmknodes --refresh to wait for udev before checking /dev content.
  Use log/report_command_log=1 config setting by default for JSON output format.
  Fix unreleased memory pools on RAID lvextend.
  Add --integritysettings option to manipulate dm-integrity settings.
