### PR TITLE
libinput: update to 1.28.1 (and related libraries)

### DIFF
--- a/libs/libinput/Makefile
+++ b/libs/libinput/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libinput
-PKG_VERSION:=1.26.2
+PKG_VERSION:=1.28.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/$(PKG_NAME)/$(PKG_NAME)/-/archive/$(PKG_VERSION)
-PKG_HASH:=5c1c4150f217fea1db2d1fd88e2607b2f1928cfde65c34da65a9f24dcfd69464
+PKG_HASH:=a13f8c9a7d93df3c85c66afd135f0296701d8d32f911991b7aa4273fdd6a42a3
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT

--- a/libs/libmanette/Makefile
+++ b/libs/libmanette/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmanette
-PKG_VERSION:=0.2.9
+PKG_VERSION:=0.2.12
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/$(PKG_NAME)/$(basename $(PKG_VERSION))
-PKG_HASH:=29366be5452f60a74c65fc64ffe2d74eddd4e6e6824c2cefa567a43bd92b688f
+PKG_HASH:=48b349267180f1dc34d405a9e1e90ba16f054a19ce907930e679493d911ea1d8
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT
@@ -21,7 +21,7 @@ define Package/libmanette
   CATEGORY:=Libraries
   TITLE:=The simple GObject game controller library.
   URL:=https://gitlab.gnome.org/GNOME/libmanette
-  DEPENDS:=+glib2 +libgudev
+  DEPENDS:=+glib2 +libgudev +hidapi
 endef
 
 define Package/libmanette/description

--- a/libs/libwacom/Makefile
+++ b/libs/libwacom/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libwacom
-PKG_VERSION:=2.13.0
+PKG_VERSION:=2.15.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/linuxwacom/$(PKG_NAME)/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
-PKG_HASH:=acd18121441bbc00fc5c881fca08a33319ab814b798eac8d0be6354923f8fb08
+PKG_HASH:=20cd65b1693129c3a6c003db0fe7fff7eccaf19fb04e89aaad9c20eb2151515a
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: -

Description:

Update libinput, libwacom and libmanette.