### PR TITLE
exfatprogs: update to version 1.2.8

### DIFF
--- a/utils/exfatprogs/Makefile
+++ b/utils/exfatprogs/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=exfatprogs
-PKG_VERSION:=1.2.5
+PKG_VERSION:=1.2.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/exfatprogs/exfatprogs/releases/download/$(PKG_VERSION)
-PKG_HASH:=f27160dcc1ddd17c96cd41a6ceef7037adc2796ab5c5633d3d85cf532c3ee2f0
+PKG_HASH:=d742b17af7b09370b9334deff167222f21720577c6eea3f9b3c51770ac544516
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: aarch64/cortex-a53
Run tested: -

Description:

exfatprogs 1.2.8 - released 2025-03-04
======================================

BUG FIXES :
 * dump.exfat: fix an incorrect output of an entry position in 32-bit system.
 * mkfs.exfat: fill an oem sector with zero instead of one.
 * exfatprogs: fix compilation on musl based systems due to loff_t type. And update the Github action to validate builds on the system.

exfatprogs 1.2.7 - released 2025-02-03
======================================

NEW FEATURES :
 * fsck.exfat: support repairing the upcase table.

CHANGES :
 * exfatprogs: make sure to load the tbl preprocessor for man pages.

BUG FIXES :
 * exfatprogs: fix a double free memory error.
 * dump.exfat: fix a constraint that volume label, bitmap, upcase table must be located at the beginning of a root directory.

exfatprogs 1.2.6 - released 2024-11-20
======================================

CHANGES :
 * exfatprogs: replace obsolete autoconf and libtool macros.
 * mkfs.exfat: prefer the physical block size over the logical block size for the exFAT sector size.
 * mkfs.exfat: add notes about the format of the volume GUID to the man page.
 * mkfs.exfat: fix an incorrect calculation of the number of used clusters.

BUG FIXES :
 * exfatlabel: fix an user input error when setting a volume serial or label.
