### PR TITLE
[24.10] lua: lua5.4 update to 5.4.7

### DIFF
--- a/lang/lua5.4/Makefile
+++ b/lang/lua5.4/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lua
-PKG_VERSION:=5.4.6
+PKG_VERSION:=5.4.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.lua.org/ftp/ \
 	https://www.tecgraf.puc-rio.br/lua/ftp/
-PKG_HASH:=7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88
+PKG_HASH:=9fbf5e28ef86c69858f6d3d34eccc32e911c1a28b4120ff3e84aaa70cfbf1e30
 PKG_BUILD_PARALLEL:=1
 
 PKG_MAINTAINER:=Christian Marangi <ansuelsmth@gmail.com>

--- a/lang/lua5.4/patches-host/001-include-version-number.patch
+++ b/lang/lua5.4/patches-host/001-include-version-number.patch
@@ -33,7 +33,7 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
  
  # Lua version and release.
  V= 5.4
-@@ -52,7 +52,7 @@ R= $V.6
+@@ -52,7 +52,7 @@ R= $V.7
  all:	$(PLAT)
  
  $(PLATS) help test clean:

--- a/lang/lua5.4/patches/001-include-version-number.patch
+++ b/lang/lua5.4/patches/001-include-version-number.patch
@@ -33,7 +33,7 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
  
  # Lua version and release.
  V= 5.4
-@@ -52,7 +52,7 @@ R= $V.6
+@@ -52,7 +52,7 @@ R= $V.7
  all:	$(PLAT)
  
  $(PLATS) help test clean:

--- a/lang/lua5.4/patches/020-shared_liblua.patch
+++ b/lang/lua5.4/patches/020-shared_liblua.patch
@@ -43,7 +43,7 @@
  
 --- a/src/lundump.h
 +++ b/src/lundump.h
-@@ -30,7 +30,7 @@
+@@ -29,7 +29,7 @@
  LUAI_FUNC LClosure* luaU_undump (lua_State* L, ZIO* Z, const char* name);
  
  /* dump one chunk; from ldump.c */


### PR DESCRIPTION
1ab3208a1fceb12fca8f24ba57d6e13c5bff15e3 'lua.h' back to redundancy in version definitions 21ff8de33a5aca9c3c907592b894e4b9ab036d3e Bug: Tricky _PROMPT may trigger undefined behavior 7eb1ed21b7057ab5f1b921f8271eddcf13659737 More permissive use of 'errno' 2db966fcbf757775c842bc66449d7e697826aa1d Bug: luaL_traceback may need more than 5 stack slots ae9a0cbbb446499e759acae47664d1d136d7ba90 Bug: overlapping assignments d5212c13b081ed62d8e1ae436779e79c79edf564 More disciplined use of 'errno' e0efebdbe4e4053c6fb78588c546f1dc23aa964a Detail in the manual e84f7bf19852c35ad0a1e9a1654a7b99a211e17c Details
dfbde4c7d540f81f2cc539741a2c1f4c00f91c10 Bug: Active-lines for stripped vararg functions de794a6527058e75b674118b35f39dcbb13e88b1 Towards release 5.4.7 8b83417de982d068bd92e0428a42ca0cdd909789 Avoids a warning when lua_Number is 'float' e288c5a91883793d14ed9e9d93464f6ee0b08915 Bug: Yielding in a hook stops in the wrong instruction 5853c37a83ec66ccb45094f9aeac23dfdbcde671 Bug: Buffer overflow in string concatenation 842a83f09caa2ebd4bc03e0076420148ac07c808 Panic functions should not raise errors 7923dbbf72da303ca1cca17efd24725668992f15 Bug: Recursion in 'getobjname' can stack overflow 81e4fce5303fdb274bc5572fb168dd766fb8208e Simpler test in 'luaH_getint' 6baee9ef9d5657ab582c8a4b9f885ec58ed502d0 Removed test for "corrupted binary dump" edd8589f478e784bb8d1a8e9a3bb2bb3ca51738c Avoid casts from unsigned long to floating-point 07a9eab23ac073362f231ddc7215688cf221ff45 Cannot use 'getshrstr' before setting 'shrlen' 9363a8b9901a5643c9da061ea8dda8a86cdc7ef1 Documentation for "LUA_NOENV" 5ab6a5756b3c50c99f1388885e9a48a7da8cbe2d Bug: Wrong line number for function calls 9b4f39ab14fb2e55345c3d23537d129dac23b091 More disciplined use of 'getstr' and 'tsslen' f4211a5ea4e235ccfa8b8dfa46031c23e9e839e2 More control over encoding of test files 1b3f507f620d996ffb69da7476a19251acfb89ca Bug: Call hook may be called twice when count hook yields 6b51133a988587f34ee9581d799ea9913581afd3 Thread stacks resized in the atomic phase cbae01620278f9b568805db16a96d0631ced473d Details
ea39042e13645f63713425c05cc9ee4cfdcf0a40 Removed redundancy in definitions of version/release 05ec55f16b389a4377adab84efe374437da8dbd2 Avoid inclusion loop in 'ltm.h' f623b969325be736297bc1dff48e763c08778243 Bug: read overflow in 'l_strcmp' 9be74ccc214eb6f4d9d0b9496fd973542c7377d9 Several functions turned 'static' 09f3c2372f5dbeaec9f50614a26c1b5761726a88 Option '-l' discards version sufix from file name c197885cb00b85251c35cffdc4057efaee2d7a88 Small improvements in tests 934e77a286aeb97ca02badf56956ccc78217e9d0 Details


(cherry picked from commit 769e8f9d2d724e725bdfec4fa02ebd651e72e711)