### PR TITLE
grep: fix that egrep and fgrep workaround doesn't work

### DIFF
--- a/utils/grep/Makefile
+++ b/utils/grep/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grep
 PKG_VERSION:=3.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/grep
@@ -23,9 +23,9 @@ PKG_CPE_ID:=cpe:/a:gnu:grep
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
-MAKE_FLAGS += SHELL="/bin/sh"
-
 include $(INCLUDE_DIR)/package.mk
+
+MAKE_FLAGS += SHELL="/bin/sh"
 
 define Package/grep
   SECTION:=utils


### PR DESCRIPTION
Maintainer: Julen Landa Alustiza / @Zokormazo
Compile tested: (rockchip, NanoPi R2S, master branch)
Run tested: the same as above.

Description:

Commit 07b6eec21f57c3cb391b0daf89240b7632b2a49f doesn't work at least now, because `package.mk` initializes the variables to the default values.  You have to modify the variable after including `package.mk` as @zhanhb [commented](https://github.com/openwrt/packages/pull/16551#issuecomment-1073797207).
Fixes: #17826
Related: #16548, #17803, #23778, #16551