### PR TITLE
tailscale: add more parameters and firewall zone config

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
 PKG_VERSION:=1.82.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
@@ -56,11 +56,13 @@ define Package/tailscale/conffiles
 endef
 
 define Package/tailscale/install
-	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/init.d $(1)/etc/config
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/init.d $(1)/etc/config $(1)/etc/hotplug.d/iface
 	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/tailscaled $(1)/usr/sbin
 	$(LN) tailscaled $(1)/usr/sbin/tailscale
 	$(INSTALL_BIN) ./files//tailscale.init $(1)/etc/init.d/tailscale
 	$(INSTALL_DATA) ./files//tailscale.conf $(1)/etc/config/tailscale
+	$(INSTALL_BIN) ./files//tailscale.helper $(1)/usr/sbin/tailscale_helper
+	$(INSTALL_BIN) ./files//tailscale.iface $(1)/etc/hotplug.d/iface/40-tailscale
 endef
 
 $(eval $(call BuildPackage,tailscale))

--- a/net/tailscale/files/tailscale.conf
+++ b/net/tailscale/files/tailscale.conf
@@ -1,7 +1,43 @@
-config settings 'settings'
-	option log_stderr '1'
-	option log_stdout '1'
+config tailscale 'settings'
+	# Set whether Tailcale is enabled or not
+	option enabled '0'
+	# Set the port to listen on for incoming Tailscale packets (default 41641)
 	option port '41641'
-	option state_file '/etc/tailscale/tailscaled.state'
-	# default to using nftables - change below to 'iptables' if still using iptables
+	# Path to config file
+	option config_path '/etc/tailscale'
+	# Default to using nftables - change below to 'iptables' if still using iptables
 	option fw_mode 'nftables'
+	# Enable stdout log
+	option log_stdout '1'
+	# Enable stderr log
+	option log_stderr '1'
+	# Accept subnet routes that other nodes advertise
+	#option accept_routes '1'
+	# Provide a hostname to use for the device instead of the one provided by the OS
+	#option hostname ''
+	# Accept DNS configuration from the admin console. (default accept)
+	option accept_dns '1'
+	# Offer to be an exit node for outbound internet traffic from the Tailscale network
+	#option advertise_exit_node '1'
+	# Provide a Tailscale IP or machine name to use as an exit node
+	#option exit_node ''
+	# Expose physical subnet routes to your entire Tailscale network (e.g. 10.0.0.0/24)
+	#list advertise_routes ''
+	# Set to '1' to disable subnet route masquerading
+	#option disable_snat_subnet_routes '1'
+	# To connect subnets within your tailnet (e.g. 192.168.1.0/24)
+	# Documentation https://tailscale.com/kb/1214/site-to-site
+	#list subnet_routes ''
+	# Set firewall zone (ts_ac_lan: Tailscale access LAN, ts_ac_wan: Tailscale access WAN:, lan_ac_ts: LAN access Tailscale, wan_ac_ts: WAN access Tailscale)
+	# Documentation https://openwrt.org/docs/guide-user/services/vpn/tailscale/start
+	#list access 'ts_ac_lan'
+	#list access 'ts_ac_wan'
+	#list access 'lan_ac_ts'
+	#list access 'wan_ac_ts'
+	# Set extra flags for enabling settings upon the initiation of Tailscale
+	# Documentation https://tailscale.com/kb/1241/tailscale-up
+	#list flags ''
+	# Provide the base URL of a custom server instead of https://controlplane.tailscale.com
+	#option login_server ''
+	# Set auth Key of custom server
+	#option authkey ''

--- a/net/tailscale/files/tailscale.helper
+++ b/net/tailscale/files/tailscale.helper
@@ -1,0 +1,147 @@
+#!/bin/sh
+
+# Copyright (C) 2025 asvow
+# SPDX-License-Identifier: GPL-3.0-only
+
+# Error handling function
+revert_exit() {
+	logger -p daemon.err -t tailscale_helper "$(date '+%Y/%m/%d %H:%M:%S') $1"
+	uci revert dhcp && uci revert network && uci revert firewall
+	/etc/init.d/tailscale stop
+	exit 1
+}
+
+# Execute tailscale up command
+/usr/sbin/tailscale up --reset "$@" || revert_exit "tailscale up failed."
+
+# Use flock to acquire an exclusive lock
+LOCK_FILE="/var/lock/tailscale.lock"
+exec 9> "$LOCK_FILE"
+flock -xn 9 || { revert_exit "Failed to acquire lock on $LOCK_FILE"; }
+trap 'rm -f "$LOCK_FILE"; exit' INT TERM EXIT
+
+# Wait for Tailscale IPv4 address
+count=0
+while [ -z "$(ifconfig | grep 'tailscale' | awk '{print $1}')" ] || [ -z "$(tailscale ip -4)" ]; do
+	sleep 2
+	count=$((count + 1))
+	[ "${count}" -ge 5 ] && revert_exit "Failed to get Tailscale IPv4 address after 5 attempts."
+done
+
+# Configure Tailscale MagicDNS
+if [ "$ACCEPT_DNS" = "1" ]; then
+	MagicDNSSuffix=$(tailscale status --json | awk -F'"' '/"MagicDNSSuffix"/ {last=$(NF-1)} END {print last}')
+	target_address="/$MagicDNSSuffix/100.100.100.100"
+	index=$(uci show dhcp | grep 'dhcp.@dnsmasq\[[0-9]\+\]=dnsmasq' | grep -o '[0-9]\+')
+	for i in $index; do
+		if ! uci get dhcp.@dnsmasq[$i].address 2>/dev/null | grep -qxF "$target_address"; then
+			uci add_list "dhcp.@dnsmasq[$i].address=$target_address" || revert_exit "Failed to add DNS address."
+		fi
+	done
+fi
+
+# Configure network interface for Tailscale
+ts0=$(ifconfig | grep 'tailscale' | awk '{print $1}')
+if [ -z "$(uci -q get network.tailscale)" ]; then
+	uci set network.tailscale='interface'
+	if [ "$ts0" = *$'\n'* ]; then
+		[ -n "$(uci batch <<-EOF 2>&1
+			set network.ts_lan='device'
+			set network.ts_lan.type='bridge'
+			set network.ts_lan.name='ts-lan'
+			set network.tailscale.proto='none'
+			set network.tailscale.device='ts-lan'
+		EOF
+		)" ] && revert_exit "Failed to configure network interface for Tailscale."
+		for port in "${ts0}"; do
+			uci add_list network.ts_lan.ports=$port || revert_exit "Failed to add port $port."
+		done
+	else
+		[ -n "$(uci batch <<-EOF 2>&1
+			set network.tailscale.proto='static'
+			set network.tailscale.ipaddr=$(tailscale ip -4)
+			add_list network.tailscale.ip6addr=$(tailscale ip -6)
+			set network.tailscale.netmask='255.0.0.0'
+			set network.tailscale.device=$ts0
+		EOF
+		)" ] && revert_exit "Failed to configure network interface for Tailscale."
+	fi
+fi
+
+# Configure exit node firewall rules
+if [ -n "$EXIT_NODE" ]; then
+	uci set firewall.@defaults[0].forward='REJECT' || revert_exit "Failed to set default forward policy to REJECT."
+	# Find the LAN to WAN forwarding rule index
+	index=$(uci show firewall | grep "firewall.@forwarding\[[0-9]\+\]\.src='lan'" -B 1 -A 1 | grep "firewall.@forwarding\[[0-9]\+\]\.dest='wan'" | grep -o '[0-9]\+')
+	[ -n "$index" ] && uci set firewall.@forwarding[$index].enabled='0' || revert_exit "Failed to disable forwarding rule."
+fi
+
+# Configure subnet routes for site to site
+if [ -n "$SUBNET_ROUTES" ]; then
+	i=1
+	ts_ip=$(tailscale ip -4)
+	for route in $SUBNET_ROUTES; do
+		[ -n "$(uci batch <<-EOF 2>&1
+			set network.ts_subnet$i='route'
+			set network.ts_subnet$i.interface='tailscale'
+			set network.ts_subnet$i.target=$route
+			set network.ts_subnet$i.gateway=$ts_ip
+		EOF
+		)" ] && revert_exit "Failed to configure subnet routes for site to site."
+		let i++
+	done
+fi
+
+# Configure firewall zone and rules
+if [ -n "$ACCESS" ]; then
+	[ -n "$(uci batch <<-EOF 2>&1
+		set firewall.tszone='zone'
+		set firewall.tszone.input='ACCEPT'
+		set firewall.tszone.output='ACCEPT'
+		set firewall.tszone.forward='ACCEPT'
+		set firewall.tszone.masq='1'
+		set firewall.tszone.mtu_fix='1'
+		set firewall.tszone.name='tailscale'
+		set firewall.tszone.network='tailscale'
+	EOF
+	)" ] && revert_exit "Failed to create firewall zone and forwarding rules for Tailscale."
+fi
+
+# Configure specific firewall forwarding rules between Tailscale, LAN, and WAN
+if [ "${ACCESS//ts_ac_lan/}" != "$ACCESS" ]; then
+	[ -n "$(uci batch <<-EOF 2>&1
+		set firewall.ts_ac_lan=forwarding
+		set firewall.ts_ac_lan.dest='lan'
+		set firewall.ts_ac_lan.src='tailscale'
+	EOF
+	)" ] && revert_exit "Failed to configure ts_ac_lan firewall forwarding rules."
+fi
+if [ "${ACCESS//ts_ac_wan/}" != "$ACCESS" ]; then
+	[ -n "$(uci batch <<-EOF 2>&1
+		set firewall.ts_ac_wan=forwarding
+		set firewall.ts_ac_wan.dest='wan'
+		set firewall.ts_ac_wan.src='tailscale'
+	EOF
+	)" ] && revert_exit "Failed to configure ts_ac_wan firewall forwarding rules."
+fi
+if [ "${ACCESS//lan_ac_ts/}" != "$ACCESS" ]; then
+	[ -n "$(uci batch <<-EOF 2>&1
+		set firewall.lan_ac_ts=forwarding
+		set firewall.lan_ac_ts.dest='tailscale'
+		set firewall.lan_ac_ts.src='lan'
+	EOF
+	)" ] && revert_exit "Failed to configure lan_ac_ts firewall forwarding rules."
+fi
+if [ "${ACCESS//wan_ac_ts/}" != "$ACCESS" ]; then
+	[ -n "$(uci batch <<-EOF 2>&1
+		set firewall.wan_ac_ts=forwarding
+		set firewall.wan_ac_ts.dest='tailscale'
+		set firewall.wan_ac_ts.src='wan'
+	EOF
+	)" ] && revert_exit "Failed to configure wan_ac_ts firewall forwarding rules."
+fi
+
+# Commit configuration changes and reload service
+[ -n "$(uci changes dhcp)" ] && uci commit dhcp && /etc/init.d/dnsmasq reload
+[ -n "$(uci changes network)" ] && uci commit network && /etc/init.d/network reload
+[ -n "$(uci changes firewall)" ] && uci commit firewall && /etc/init.d/firewall reload

--- a/net/tailscale/files/tailscale.iface
+++ b/net/tailscale/files/tailscale.iface
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+tailscale_enable="$(uci get tailscale.settings.enabled)"
+
+[ "$ACTION" = ifup -o "$ACTION" = ifupdate ] || exit 0
+[ "$ACTION" = ifupdate -a -z "$IFUPDATE_ADDRESSES" -a -z "$IFUPDATE_DATA" ] && exit 0
+[ "$tailscale_enable" -eq "1" ] || exit 0
+/etc/init.d/tailscale start > /tmp/tailscale.log 2>&1 &

--- a/net/tailscale/files/tailscale.init
+++ b/net/tailscale/files/tailscale.init
@@ -4,44 +4,156 @@
 # Copyright (C) 2021 CZ.NIC z.s.p.o. (https://www.nic.cz/)
 # SPDX-License-Identifier: Apache-2.0
 
+START=90
+
 USE_PROCD=1
-START=80
+
+PROG=/usr/sbin/tailscale_helper
+PROGD=/usr/sbin/tailscaled
+CONFIG_PATH=/var/lib/tailscale
+
+service_triggers() {
+	procd_add_reload_trigger "tailscale"
+	procd_add_interface_trigger "interface.*.up" wan /etc/init.d/tailscale reload
+}
+
+section_enabled() {
+	config_get_bool enabled "$1" 'enabled' 0
+	[ $enabled -gt 0 ]
+}
+
+configure_service() {
+	local cfg="$1"
+	local accept_routes hostname accept_dns advertise_exit_node exit_node advertise_routes disable_snat_subnet_routes subnet_routes access flags login_server authkey std_out std_err
+
+	config_get_bool accept_routes $cfg 'accept_routes'
+	config_get hostname $cfg 'hostname'
+	config_get_bool accept_dns $cfg 'accept_dns'
+	config_get_bool advertise_exit_node $cfg 'advertise_exit_node'
+	config_get exit_node $cfg 'exit_node'
+	config_get advertise_routes $cfg 'advertise_routes'
+	config_get_bool disable_snat_subnet_routes $cfg 'disable_snat_subnet_routes'
+	config_get subnet_routes $cfg 'subnet_routes'
+	config_get access $cfg 'access'
+	config_get flags $cfg 'flags'
+	config_get login_server $cfg 'login_server'
+	config_get authkey $cfg 'authkey'
+	config_get_bool std_out $cfg 'log_stdout'
+	config_get_bool std_err $cfg 'log_stderr'
+
+	procd_open_instance
+	procd_set_param command $PROG
+
+	[ "$accept_routes" = "1" ] && procd_append_param command --accept-routes=true
+	[ -n "$hostname" ] && procd_append_param command --hostname="$hostname"
+	[ "$accept_dns" = "0" ] && procd_append_param command --accept-dns=false
+	[ "$advertise_exit_node" = "1" ] && procd_append_param command --advertise-exit-node
+	[ -n "$exit_node" ] && {
+		procd_append_param command --exit-node="$exit_node"
+		procd_append_param command --exit-node-allow-lan-access=true
+	}
+	[ -n "$advertise_routes" ] && procd_append_param command --advertise-routes="$(echo $advertise_routes | tr ' ' ',')"
+	[ "$disable_snat_subnet_routes" = "1" ] && procd_append_param command --snat-subnet-routes=false
+	[ -n "$flags" ] && procd_append_param command $flags
+	[ -n "$login_server" ] && procd_append_param command --login-server="$login_server"
+	[ -n "$authkey" ] && procd_append_param command --authkey="$authkey"
+
+	procd_set_param env \
+		ACCEPT_DNS="$accept_dns" \
+		EXIT_NODE="$exit_node" \
+		SUBNET_ROUTES="$subnet_routes" \
+		ACCESS="$access"
+
+	procd_set_param respawn
+	procd_set_param stdout "$std_out"
+	procd_set_param stderr "$std_err"
+	procd_close_instance
+}
+
+start_instance() {
+	local cfg="$1"
+	local port config_path fw_mode std_out std_err state_file
+
+	if ! section_enabled "$cfg"; then
+		echo "disabled in /etc/config/tailscale"
+		return 1
+	fi
+
+	config_get port $cfg 'port'
+	config_get config_path $cfg 'config_path'
+	config_get fw_mode $cfg 'fw_mode'
+	config_get_bool std_out $cfg 'log_stdout'
+	config_get_bool std_err $cfg 'log_stderr'
+
+	[ -d $config_path ] || mkdir -p $config_path
+	[ -d $CONFIG_PATH ] || mkdir -p $CONFIG_PATH
+	state_file="$config_path/tailscaled.state"
+	
+	/usr/sbin/tailscaled --cleanup
+
+	procd_open_instance
+	procd_set_param command $PROGD
+
+	[ -n "$port" ] && procd_append_param command --port "$port"
+	[ -n "$state_file" ] && procd_append_param command --state "$state_file"
+
+	procd_set_param env TS_DEBUG_FIREWALL_MODE="$fw_mode"
+	
+	procd_set_param respawn
+	procd_set_param stdout "$std_out"
+	procd_set_param stderr "$std_err"
+	procd_close_instance
+
+	configure_service "$cfg"
+}
 
 start_service() {
-  local state_file
-  local port
-  local std_err std_out
+	config_load 'tailscale'
+	config_foreach start_instance 'tailscale'
+}
 
-  config_load tailscale
-  config_get_bool std_out "settings" log_stdout 1
-  config_get_bool std_err "settings" log_stderr 1
-  config_get port "settings" port 41641
-  config_get state_file "settings" state_file /etc/tailscale/tailscaled.state
-  config_get fw_mode "settings" fw_mode nftables
+stop_instance() {
+	local cfg="$1"
 
-  /usr/sbin/tailscaled --cleanup
+	# Remove dnsmasq settings
+	MagicDNSSuffix=$(tailscale status --json | awk -F'"' '/"MagicDNSSuffix"/ {last=$(NF-1)} END {print last}')
+	for suffix in $(uci show dhcp | grep -E "address=.*/${MagicDNSSuffix}/" | sed "s/'//g"); do
+		uci -q del_list $suffix
+	done
+ 
+	# Remove network settings
+	uci -q delete network.tailscale
+	uci -q delete network.ts_lan
+	for route in $(uci show network | grep 'network.ts_subnet[0-9]\+=route' | grep -o 'network.ts_subnet[0-9]\+'); do
+		uci -q delete $route
+	done
+	
+	# Remove firewall settings
+	index=$(uci show firewall | grep "firewall.@forwarding\[[0-9]\+\]\.src='lan'" -B 1 -A 1 | grep "firewall.@forwarding\[[0-9]\+\]\.dest='wan'" | grep -o '[0-9]\+')
+	uci -q delete firewall.@forwarding[$index].enabled
+	uci -q delete firewall.tszone
+	uci -q delete firewall.ts_ac_lan
+	uci -q delete firewall.ts_ac_wan
+	uci -q delete firewall.lan_ac_ts
+	uci -q delete firewall.wan_ac_ts
+	
+	# Commit configuration changes and reload service
+	[ -n "$(uci changes dhcp)" ] && uci commit dhcp && /etc/init.d/dnsmasq reload
+	[ -n "$(uci changes network)" ] && uci commit network && /etc/init.d/network reload
+	[ -n "$(uci changes firewall)" ] && uci commit firewall && /etc/init.d/firewall reload
 
-  procd_open_instance
-  procd_set_param command /usr/sbin/tailscaled
+	/usr/sbin/tailscaled --cleanup
 
-  # Starting with v1.48.1 ENV variable is required to enable use of iptables / nftables.
-  # Use nftables by default - can be changed to 'iptables' in tailscale config
-  procd_set_param env TS_DEBUG_FIREWALL_MODE="$fw_mode"
-
-  # Set the port to listen on for incoming VPN packets.
-  # Remote nodes will automatically be informed about the new port number,
-  # but you might want to configure this in order to set external firewall
-  # settings.
-  procd_append_param command --port "$port"
-  procd_append_param command --state "$state_file"
-
-  procd_set_param respawn
-  procd_set_param stdout "$std_out"
-  procd_set_param stderr "$std_err"
-
-  procd_close_instance
+	# Remove existing link or folder
+	rm -rf "$CONFIG_PATH"
 }
 
 stop_service() {
-  /usr/sbin/tailscaled --cleanup
+	config_load 'tailscale'
+	config_foreach stop_instance 'tailscale'
+}
+
+reload_service() {
+	stop
+	start
 }


### PR DESCRIPTION
Maintainer: me / @mochaaP @SuperSandro2000 @ja-pa @oskarirauta
Compile tested: 24.10.1 & Snapshot
Run tested: x86-64
Description:

Based on the official documentation, introduce support for most tailscale up parameters and OpenWrt firewall zone configuration to simplify and improve the Tailscale configuration. Meanwhile, provide the corresponding luci-app-tailscale (openwrt/luci#7735).

Add:
- --accept-routes
- --hostname
- --accept-dns
- --advertise-exit-node
- --exit-node
- --exit-node-allow-lan-access
- --advertise-routes
- --snat-subnet-routes
- --login-server
- --authkey
- other extra flags for enabling settings upon the initiation of Tailscale
- Set OpenWrt firewall zone for tailscale


Reference:
1. https://openwrt.org/docs/guide-user/services/vpn/tailscale/start
2. https://tailscale.com/kb/1241/tailscale-up
3. https://tailscale.com/kb/1214/site-to-site
