### PR TITLE
lvm2: add missing dependency

### DIFF
--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=LVM2
 PKG_VERSION:=2.03.31
 PKG_VERSION_DM:=1.02.205
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://sourceware.org/pub/lvm2 \
@@ -68,7 +68,7 @@ define Package/lvm2/default
   SUBMENU:=Disc
   TITLE:=The Linux Logical Volume Manager
   URL:=https://sourceware.org/lvm2/
-  DEPENDS:=+libreadline +libncurses +libaio
+  DEPENDS:=+libreadline +libncurses +libaio +libnvme
 endef
 
 define Package/lvm2


### PR DESCRIPTION
This package fails to build without defining libmvme as a DEPENDS.
```
Package lvm2 is missing dependencies for the following libraries: libnvme.so.1
```
Build system: x86/64
Build-tested: x86/64
Run-tested: x86/64

Maintainer: @dangowrt 
