### PR TITLE
sing-box: Update to 1.11.9

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -1,13 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.11.3
+PKG_VERSION:=1.11.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=51b189549395c132dce781e1c70315e4bb8386c207e171c07124759b45481d97
-
+PKG_HASH:=ee0c183ed9c431a2b6b5f12cad0cfb1d2bccb83147b641d50a619a381fa9d449
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Van Waholtz <brvphoenix@gmail.com>


### PR DESCRIPTION
Maintainer: @brvphoenix
Compile tested: mediatek/filogic Xiaomi Redmi ax6000 24.10.0
Run tested: mediatek/filogic Xiaomi Redmi ax6000 24.10.0

Description:
📝 Release Notes
- Fixes and improvements

https://github.com/SagerNet/sing-box/releases/tag/v1.11.9
