### PR TITLE
coreutils: Fix gcc14 compilation via std=c17  (or c23)

### DIFF
--- a/utils/coreutils/Makefile
+++ b/utils/coreutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coreutils
 PKG_VERSION:=9.6
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/coreutils
@@ -22,9 +22,6 @@ PKG_CPE_ID:=cpe:/a:gnu:coreutils
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-ifeq ($(CONFIG_GCC_VERSION_14),y)
-	PKG_FIXUP:=autoreconf
-endif
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -133,6 +130,8 @@ CONFIGURE_ARGS += \
 	--$(if $(CONFIG_USE_MUSL),with,without)-included-regex \
 	--without-selinux \
 	--with-gmp
+
+TARGET_CFLAGS += -std=c17
 
 define Package/coreutils/install
 	true


### PR DESCRIPTION
Fix compilation with gcc 14 by applying the `-std=c23` flag, as suggested by @lededev in https://github.com/openwrt/packages/commit/2d3f68cc8c165b1fa01308f566394cbd7d06766f#commitcomment-153809841

Remove the previous autoreconf fix attempt.

Maintainer: @jow- 
cc @graysky2 
Compile tested: qualcommax/DL-WRX36

Description:
GCC 14 was applied as the default for main/master today. So, aim to fix the issue more permanently.

Related: #26175 , #26195 , #26200

Ps. I am curious to see how the PR goes through CI, as 1/3 of that targets have already got the gcc14 defaults in SDK from buildbot, while 2/3 are still with the old gcc13 SDK.

Pps. As gcc14 has today been set as the default, there can possibly be wider breakage of packages compilation, although @neheb did last year a major effort last year in fixing packages for gcc14.