### PR TITLE
adblock-fast: Remove non-printable characters from curl results

### DIFF
--- a/net/adblock-fast/Makefile
+++ b/net/adblock-fast/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.1.3
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=AGPL-3.0-or-later
 

--- a/net/adblock-fast/files/etc/init.d/adblock-fast
+++ b/net/adblock-fast/files/etc/init.d/adblock-fast
@@ -469,7 +469,8 @@ get_url_filesize() {
 	is_present 'curl' || return 0
 	size_command='curl --silent --insecure --fail --head --request GET'
 #	size="$($size_command "$url" | grep -Po '^[cC]ontent-[lL]ength: \K\w+')"
-	size="$($size_command "$url" | grep -Eo '^[cC]ontent-[lL]ength: (.*)' | awk '{print $2}')"
+# shellcheck disable=SC1017
+	size="$($size_command "$url" | awk -F": " '{IGNORECASE=1}/content-length/ {gsub(/\r/, ""); print $2}' )"
 # shellcheck disable=SC3037
 	echo -en "$size"
 }


### PR DESCRIPTION
Maintainer: @stangri
Compile tested: MediaTek MT7621 ver:1 eco:3, OpenWrt 24.10.0 r28427-6df0e3d02a
Run tested: MediaTek MT7621 ver:1 eco:3, OpenWrt 24.10.0 r28427-6df0e3d02a

Description:

- Removing hidden carriage return '^M' from curl results
- Removing "grep" command and only "awk" is used to filter the results

Signed-off-by: Nikolay Manev (just.ops@proton.me)
