### PR TITLE
net-snmp: add system to trigger

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.9.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp

--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -353,7 +353,7 @@ service_triggers(){
 	procd_add_raw_trigger "interface.*" 2000 /etc/init.d/$name reload
 	procd_close_trigger
 
-	procd_add_reload_trigger 'snmpd'
+	procd_add_reload_trigger 'snmpd' 'system'
 }
 
 service_started() {


### PR DESCRIPTION
Maintainer: @stintel 
Compile tested: (x86_64, OpenWrt 24.10)
Run tested: (x86_64, OpenWrt 24.10)

Description:

In a previous commit (0b12bee6) hostname was added to snmpd.init. 
To track changes in system, the init file needs to add 'system' to the trigger.
Therefore it is added in this commit.
