### PR TITLE
aria2: fix aira2-openssl install failed

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
 PKG_VERSION:=1.37.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/aria2/aria2/releases/download/release-$(PKG_VERSION)/
@@ -106,6 +106,10 @@ define Package/aria2/install
 
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/aria2.conf $(1)/etc/config/aria2
+endef
+
+define Package/aria2-openssl/install
+	true
 endef
 
 $(eval $(call BuildPackage,aria2))


### PR DESCRIPTION
Maintainer: @kuoruan 
cc：@1715173329
Compile tested: (aarch, rax3000m, OpenWrt version 24.10, tests done)
Run tested: (aarch, rax3000m, OpenWrt version 24.10, tests done)

Description: fix in full compile a firmware 
* pkg_hash_check_unresolved: cannot find dependency aria2-openssl for aria2
 * pkg_hash_fetch_best_installation_candidate: Packages for aria2 found, but incompatible with the architectures configured
 * satisfy_dependencies_for: Cannot satisfy the following dependencies for luci-app-aria2:
 * 	aria2-openssl
 * opkg_install_cmd: Cannot install package luci-app-aria2.
 fix:https://github.com/openwrt/packages/commit/dfa01855b37255f3582ed80b33db7fa7be482aef