### PR TITLE
lrzsz: fix compilation with GCC14

### DIFF
--- a/utils/lrzsz/patches/400-configure-gcc14.patch
+++ b/utils/lrzsz/patches/400-configure-gcc14.patch
@@ -1,0 +1,23 @@
+Trying to compile with GCC14 will fail on compiler sanity check with:
+configure:1056:1: error: return type defaults to 'int' [-Wimplicit-int]
+ 1056 | main(){return(0);}
+      | ^~~~
+
+This is due to GCC14 not allowing implicit integer types anymore[1].
+
+So, patch configure to avoid this and make it compile with GCC14.
+
+[1] https://gcc.gnu.org/gcc-14/porting_to.html#implicit-int
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+--- a/configure
++++ b/configure
+@@ -1053,7 +1053,7 @@ cat > conftest.$ac_ext << EOF
+ #line 1054 "configure"
+ #include "confdefs.h"
+ 
+-main(){return(0);}
++int main(){return(0);}
+ EOF
+ if { (eval echo configure:1059: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext}; then
+   ac_cv_prog_cc_works=yes


### PR DESCRIPTION
Maintainer: @ynezz @neheb 
Compile tested: qualcommax/ipq807x (Cortex-A53), main
Run tested: None

Description:
```
Trying to compile with GCC14 will fail on compiler sanity check with: configure:1056:1: error: return type defaults to 'int' [-Wimplicit-int]
 1056 | main(){return(0);}
      | ^~~~
```

This is due to GCC14 not allowing implicit integer types anymore[1].

So, patch configure to avoid this and make it compile with GCC14.

Proper fix would be to use autoreconf to rebuild configure but configure.in is completely outdated and would likely be more broken when regenerated.

[1] https://gcc.gnu.org/gcc-14/porting_to.html#implicit-int