### PR TITLE
icecast: fix compilation with GCC14

### DIFF
--- a/multimedia/icecast/Makefile
+++ b/multimedia/icecast/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=icecast
 PKG_VERSION:=2.4.4
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.xiph.org/releases/icecast/

--- a/multimedia/icecast/patches/030-stdlib.patch
+++ b/multimedia/icecast/patches/030-stdlib.patch
@@ -1,0 +1,30 @@
+From 33a0595d1085d2acde65f3418da806e50d7c5ad7 Mon Sep 17 00:00:00 2001
+From: Philipp Schafft <phschafft@de.loewenfelsen.net>
+Date: Tue, 30 Jul 2024 22:33:28 +0000
+Subject: [PATCH] Fix: Added a number of missing includes to <stdlib.h>
+
+---
+ src/main.c              | 1 +
+ src/xslt.c              | 1 +
+ 2 files changed, 2 insertions(+)
+
+--- a/src/main.c
++++ b/src/main.c
+@@ -18,6 +18,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <string.h>
+ #include <errno.h>
+ 
+--- a/src/xslt.c
++++ b/src/xslt.c
+@@ -14,6 +14,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <stdlib.h>
+ #include <string.h>
+ #include <libxml/xmlmemory.h>
+ #include <libxml/debugXML.h>


### PR DESCRIPTION
Upstream backport.

Maintainer: @thess 