### PR TITLE
[24.10] sing-box: Update to 1.11.9

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.11.1
+PKG_VERSION:=1.11.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2bdc5bbc12e43d56f558458b22394d285bec5d0c98e0ab31dc3d74fa2ed6a195
+PKG_HASH:=ee0c183ed9c431a2b6b5f12cad0cfb1d2bccb83147b641d50a619a381fa9d449
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @brvphoenix
Compile tested: mediatek/filogic Xiaomi Redmi ax6000 24.10.0
Run tested: mediatek/filogic Xiaomi Redmi ax6000 24.10.0

Description:
📝 Release Notes

    Fixes and improvements

https://github.com/SagerNet/sing-box/releases/tag/v1.11.9

(cherry picked from commit https://github.com/openwrt/packages/commit/c0a996ddd9ee8a16fb79f5495e6fc0196eebf493)
