### PR TITLE
[24.10] sqlite3: backport 3.49.1

### DIFF
--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqlite
-PKG_VERSION:=3460100
+PKG_VERSION:=3470200
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-autoconf-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.sqlite.org/2024/
-PKG_HASH:=67d3fe6d268e6eaddcae3727fce58fcc8e9c53869bdd07a0c61e38ddf2965071
+PKG_HASH:=f1b2ee412c28d7472bc95ba996368d6f0cdcf00362affdadb27ed286c179540b
 
 PKG_CPE_ID:=cpe:/a:sqlite:sqlite
 PKG_LICENSE:=PUBLICDOMAIN

--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqlite
-PKG_VERSION:=3470200
+PKG_VERSION:=3490100
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-autoconf-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://www.sqlite.org/2024/
-PKG_HASH:=f1b2ee412c28d7472bc95ba996368d6f0cdcf00362affdadb27ed286c179540b
+PKG_SOURCE_URL:=https://www.sqlite.org/2025/
+PKG_HASH:=106642d8ccb36c5f7323b64e4152e9b719f7c0215acf5bfeac3d5e7f97b59254
 
 PKG_CPE_ID:=cpe:/a:sqlite:sqlite
 PKG_LICENSE:=PUBLICDOMAIN
@@ -99,13 +99,14 @@ TARGET_CFLAGS += \
 	$(if $(CONFIG_SQLITE3_BATCH_ATOMIC_WRITE),-DSQLITE_ENABLE_BATCH_ATOMIC_WRITE) \
 	$(if $(CONFIG_SQLITE3_COLUMN_METADATA),-DSQLITE_ENABLE_COLUMN_METADATA)
 
-CONFIGURE_ARGS += \
+CONFIGURE_ARGS := \
+	$(filter-out --target=% $(DISABLE_IPV6) $(DISABLE_NLS),$(CONFIGURE_ARGS)) \
 	--disable-debug \
 	--disable-static-shell \
 	--enable-shared \
 	--enable-static \
 	--enable-threadsafe \
-	$(if $(CONFIG_SQLITE3_DYNAMIC_EXTENSIONS),--enable-dynamic-extensions,--disable-dynamic-extensions) \
+	$(if $(CONFIG_SQLITE3_DYNAMIC_EXTENSIONS),--enable-load-extension,--disable-load-extension) \
 	$(if $(CONFIG_SQLITE3_FTS3),--enable-fts3,--disable-fts3) \
 	$(if $(CONFIG_SQLITE3_FTS4),--enable-fts4,--disable-fts4) \
 	$(if $(CONFIG_SQLITE3_FTS5),--enable-fts5,--disable-fts5) \
@@ -130,7 +131,7 @@ endef
 
 define Package/libsqlite3/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsqlite3.so.$(ABI_VERSION)* $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsqlite3.so* $(1)/usr/lib
 endef
 
 define Package/sqlite3-cli/install


### PR DESCRIPTION
Maintainer: no maintainer specified, @systemcrash, @1715173329
Compile tested: x86/64, 24.10.1 SDK
Run tested: x86/64, 24.10, QEMU

- library is correctly installed and loaded by CLI
- CLI starts and reports the correct version

Description:

This is a backport of #26344 and #26373 _without_ switching to the upstream version format, so any future backports will not be able to be cherry-picked from master, and will need to be done separately. Commits marked as cherry-picked.

Changelogs:
https://sqlite.org/releaselog/3_47_0.html
https://sqlite.org/releaselog/3_47_1.html
https://sqlite.org/releaselog/3_47_2.html
https://sqlite.org/releaselog/3_48_0.html
https://sqlite.org/releaselog/3_49_0.html
https://sqlite.org/releaselog/3_49_1.html