### PR TITLE
prometheus-node-exporter-lua: Fixes #26442; Add DHCP Collector

### DIFF
--- a/utils/lrzsz/patches/400-configure-gcc14.patch
+++ b/utils/lrzsz/patches/400-configure-gcc14.patch
@@ -1,0 +1,23 @@
+Trying to compile with GCC14 will fail on compiler sanity check with:
+configure:1056:1: error: return type defaults to 'int' [-Wimplicit-int]
+ 1056 | main(){return(0);}
+      | ^~~~
+
+This is due to GCC14 not allowing implicit integer types anymore[1].
+
+So, patch configure to avoid this and make it compile with GCC14.
+
+[1] https://gcc.gnu.org/gcc-14/porting_to.html#implicit-int
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+--- a/configure
++++ b/configure
+@@ -1053,7 +1053,7 @@ cat > conftest.$ac_ext << EOF
+ #line 1054 "configure"
+ #include "confdefs.h"
+ 
+-main(){return(0);}
++int main(){return(0);}
+ EOF
+ if { (eval echo configure:1059: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext}; then
+   ac_cv_prog_cc_works=yes

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/dhcp_clients.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/dhcp_clients.lua
@@ -1,0 +1,34 @@
+-- DHCP clients collector
+
+local function get_contents(path)
+    local file = io.open(path, "r")
+    if not file then return nil end
+    local content = file:read("*a")
+    file:close()
+    return content
+  end
+  
+  local function scrape()
+    local log = get_contents("/var/dhcp.leases")
+    if not log then return end
+  
+    -- Define the metric
+    local dhcp_metric = metric("dhcp_client", "gauge")
+
+    -- DHCP entry format:
+    -- 1746223910 18:56:80:88:00:5e 192.168.1.236 13172BAM 01:18:56:80:88:00:5e
+    -- timestamp mac ip hostname extra_mac
+    
+    for line in log:gmatch("[^\r\n]+") do
+      local timestamp, mac, ip, hostname, extra_mac = line:match("^(%d+)%s+(%S+)%s+(%S+)%s+(%S+)%s+(%S+)$")
+      if timestamp and mac and ip and hostname and extra_mac then
+        dhcp_metric({
+          mac = string.upper(mac),
+          ip = ip,
+          hostname = hostname ~= "*" and hostname or "unknown"
+        }, 1)
+      end
+    end
+  end
+  
+  return { scrape = scrape }


### PR DESCRIPTION
Compile tested: not applicable
Run tested: tested on 24.10.0 MediaTek MT7621 ver:1 eco:3
Description: Adding dhcp client exporter for prometheus

Signed-off-by: Cer Berus <cer@be.rus>
