### PR TITLE
sqlite3: add legacy SONAME

### DIFF
--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=sqlite
 PKG_VERSION:=3.49.1
 PKG_SRC_VERSION:=3490100
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-autoconf-$(PKG_SRC_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.sqlite.org/2025/
@@ -107,6 +107,7 @@ CONFIGURE_ARGS := \
 	--enable-shared \
 	--enable-static \
 	--enable-threadsafe \
+	--soname=legacy \
 	$(if $(CONFIG_SQLITE3_DYNAMIC_EXTENSIONS),--enable-load-extension,--disable-load-extension) \
 	$(if $(CONFIG_SQLITE3_FTS3),--enable-fts3,--disable-fts3) \
 	$(if $(CONFIG_SQLITE3_FTS4),--enable-fts4,--disable-fts4) \


### PR DESCRIPTION
Maintainer: no maintainer set, @systemcrash @1715173329 
Compile tested: HEAD, x86/64, gcc 14.2
Run tested: HEAD, x86/64, QEMU

- library is correctly installed and loaded by CLI
- CLI starts and reports the correct version
- libraries that link against libsqlite3 show correct local path #26449

Description:

With no SONAME set, when linking against the full library path, that path will be used, i.e. the full path in the build environment. But if SONAME is set, it will be used instead.

Set `--soname=legacy` to add a SONAME to the library to allow projects that use full path to link correctly.

Link: https://sqlite.org/src/forumpost/5a3b44f510df8ded
Fixes: https://github.com/openwrt/packages/issues/26449
