### PR TITLE
dnscrypt-proxy2: update to version 2.1.12

### DIFF
--- a/net/dnscrypt-proxy2/Makefile
+++ b/net/dnscrypt-proxy2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy2
-PKG_VERSION:=2.1.5
+PKG_VERSION:=2.1.12
 PKG_RELEASE:=1
 
 PKG_SOURCE:=dnscrypt-proxy-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/DNSCrypt/dnscrypt-proxy/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=044c4db9a3c7bdcf886ff8f83c4b137d2fd37a65477a92bfe86bf69587ea7355
+PKG_HASH:=95fe29ed03dad0cdd34d47316ecb15c25f7ef5fab21d9ec52cbfc4743bcf5198
 PKG_BUILD_DIR:=$(BUILD_DIR)/dnscrypt-proxy-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
@@ -30,7 +30,15 @@ include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
 GO_MOD_ARGS:=
+GO_PKG_LDFLAGS_X:=$(GO_PKG)/constant.Version=$(PKG_VERSION)
 GO_PKG_BUILD_VARS+= GO111MODULE=off
+
+# Add the new MIPS-specific flags here, before the package definition
+ifeq ($(ARCH),mips)
+    GO_PKG_GCFLAGS += -N
+    GO_PKG_LDFLAGS += -linkmode external
+    GO_PKG_LDFLAGS_X += main.version=$(PKG_VERSION)
+endif
 
 define Package/dnscrypt-proxy2
   SECTION:=net
@@ -40,6 +48,16 @@ define Package/dnscrypt-proxy2
   URL:=https://github.com/DNSCrypt/dnscrypt-proxy
   DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
   CONFLICTS:=dnscrypt-proxy
+endef
+
+define Build/Prepare
+        $(call Build/Prepare/Default)
+
+        # Create static directory in the build directory
+	$(INSTALL_DIR) $(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/dnscrypt-proxy/static
+
+	# Copy static files from the package build directory to the Go package build directory
+	$(CP) -r $(PKG_BUILD_DIR)/dnscrypt-proxy/static/* $(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/dnscrypt-proxy/static/
 endef
 
 define Package/dnscrypt-proxy2/install

--- a/net/dnscrypt-proxy2/files/dnscrypt-proxy.init
+++ b/net/dnscrypt-proxy2/files/dnscrypt-proxy.init
@@ -7,6 +7,15 @@ START=18
 # stops before networking stops
 STOP=89
 
+[ -n "${IPKG_INSTROOT}" ] && return 0
+
+if type extra_command 1>/dev/null 2>&1; then
+        extra_command 'version' 'Show version information'
+else
+# shellcheck disable=SC2034
+        EXTRA_COMMANDS='version'
+fi
+
 PROG=/usr/sbin/dnscrypt-proxy
 CONFIGFILE=/etc/dnscrypt-proxy2/dnscrypt-proxy.toml
 
@@ -19,3 +28,5 @@ start_service() {
         procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
         procd_close_instance
 }
+
+version() { exec "$PROG" -version; }

--- a/net/dnscrypt-proxy2/test.sh
+++ b/net/dnscrypt-proxy2/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ "$1" = dnscrypt-proxy2 ] || exit 0
+
+dnscrypt-proxy -version | grep "$PKG_VERSION"


### PR DESCRIPTION
Maintainer: @BKPepe
Compile tested: OpenWrt 24.10.1 r28597-0425664679
Run tested: OpenWrt 24.10.1 r28597-0425664679

Description:

- update dnscrypt-proxy2 to version 2.1.12
- added new option 'version' to the init file
- added test.sh file for ci testing

Fixes #26354 

