### PR TITLE
syncthing: bump to 1.29.6

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.29.5
+PKG_VERSION:=1.29.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=17f60258af1043db93f1df3609222cdd40b4fdcccae5c60dce46c557e0796098
+PKG_HASH:=28e7f4984a6a34fb4697448141ce2611a6510f5a4369c1669d4e766eb75cd878
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 

--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -83,11 +83,17 @@ define Package/syncthing/description
 endef
 
 define Package/stdiscosrv/description
-  Relay server for syncthing
+  Syncthing relies on a discovery server to find peers on the internet.
+  Anyone can run a discovery server and point Syncthing installations to
+  it. The Syncthing project also maintains a global cluster for public
+  use.
 endef
 
 define Package/strelaysrv/description
-  Relay server for syncthing
+  Syncthing relies on a network of community-contributed relay servers.
+  Anyone can run a relay server, and it will automatically join the relay
+  pool and be available to Syncthing users. The current list of relays can
+  be found at https://relays.syncthing.net/.
 endef
 
 define SyncthingInstall


### PR DESCRIPTION
Maintainer: @aparcar, @brvphoenix
Compile tested: HEAD, x86/64

- also tested with #26201 and #26310

Run tested: snapshot, x86/64, QEMU

- all files are installed correctly
- version checks return the updated version
- service starts
- web UI loads with the existing config and displays the updated version
- synchronization works

Description:

> - chore(lib): expose model methods to obtain progress
> - feat(gui): explanation to options enabled or disabled per folder type
> - fix(gui): validate device ID in canonical form
> - fix(config): remove discontinued primary STUN server
> - fix(stun): better error handling
> - chore(config): remove discontinued secondary STUN servers
> - chore(fs): speed up case normalization
> - build(deps): update dependencies
> - feat(fs, config): add support for custom filesystem type construction
> - build: replace underscore in Debian version
> - chore(model): add metric for total number of conflicts
> - fix(config): properly apply defaults when reading folder configuration
> - fix(config): zero filesystemtype is "basic"
> - build: push artifacts to Azure
> - chore(config): resolve primary STUN servers via SRV record
> - chore(fs): changes to allow Filesystem to be implemented externally
> - fix(strings): differentiate setup(n) and set(v) up
> - fix(gui): mark unseen disconnected devices as inactive
> - fix(syncthing): use separate lock file instead of locking the
>   certificate
> - feat(api, gui): allow authentication bypass for metrics
> - chore: add missing copyright in new files from infra branch
> - fix(osutil): give threads same I/O priority on Linux
> - chore(syncthing): remove support for TLS 1.2 sync connections
> - chore(gui): update dependency copyrights, add script for periodic
>   maintenance
> - chore(api): log X-Forwarded-For
> - feat(config): add option for audit file
> - chore(gui): use go list --deps for dependency list
> - fix(strelaysrv): make the session limiter session-dependent

- Add discovery and relay server descriptions.

Changelog: https://github.com/syncthing/syncthing/compare/v1.29.5...v1.29.6