### PR TITLE
[24.10] dnsdist: update to 1.9.9

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsdist
-PKG_VERSION:=1.9.7
+PKG_VERSION:=1.9.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=285111c2b7dff6bc8a2407106a51c365cc5bf5e6287fe459a29b396c74620332
+PKG_HASH:=e86bc636d4d2dc8bac180ec8cdafbfe5f35229b6005ec15d7510fb6f58b49f5a
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>, Remi Gacogne <remi.gacogne@powerdns.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me + @rgacogne 
Compile tested: github actions
Run tested: docker x86_64

Description:
fixes CVE-2025-30194