### PR TITLE
stress-ng: bump to version 0.19.00

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.18.11
+PKG_VERSION:=0.19.00
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ColinIanKing/stress-ng/tar.gz/refs/tags/V$(PKG_VERSION)?
-PKG_HASH:=f4388c4d4d53172431cd77e029139ddd0dacb249ef59053dbc1f0c42188e3e35
+PKG_HASH:=7d0be69dcdad655145026f499863de01d317e87ff87acd48c3343d451540d172
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only

--- a/utils/stress-ng/patches/001-disable-extra-stressors.patch
+++ b/utils/stress-ng/patches/001-disable-extra-stressors.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.config
 +++ b/Makefile.config
-@@ -362,10 +362,10 @@ clean:
+@@ -363,10 +363,10 @@ clean:
  .PHONY: libraries
  libraries: \
  	configdir \

--- a/utils/stress-ng/patches/002-disable-atomics-mips-and-ppc.patch
+++ b/utils/stress-ng/patches/002-disable-atomics-mips-and-ppc.patch
@@ -1,0 +1,26 @@
+--- a/stress-fractal.c
++++ b/stress-fractal.c
+@@ -90,6 +90,10 @@ static void stress_fractal_deinit(void)
+ 	}
+ }
+ 
++#if (defined(STRESS_ARCH_MIPS) || defined(STRESS_ARCH_PPC64) || defined(STRESS_ARCH_PPC))
++#undef HAVE_ATOMIC_FETCH_ADD
++#endif
++
+ /*
+  *  stress_fractal_get_row()
+  *	get next row to be computed, will wrap around. Wrap arounds
+--- a/stress-misaligned.c
++++ b/stress-misaligned.c
+@@ -49,6 +49,10 @@
+ #undef HAVE_ATOMIC
+ #endif
+ 
++#if (defined(STRESS_ARCH_MIPS) || defined(STRESS_ARCH_PPC64) || defined(STRESS_ARCH_PPC))
++#undef HAVE_ATOMIC
++#endif
++
+ #if defined(HAVE_LIB_RT) &&		\
+     defined(HAVE_TIMER_CREATE) &&	\
+     defined(HAVE_TIMER_DELETE) &&	\


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 http://github.com/openwrt/openwrt/commit/b5fba2035180b7892f33516aa65851051d32c719
Run tested: x86 http://github.com/openwrt/openwrt/commit/b5fba2035180b7892f33516aa65851051d32c719
