### PR TITLE
xtables-addons: rtpsp-conntrack support 6.12

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.4.7
+PKG_VERSION:=8.4.6
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.php.net/distributions/
-PKG_HASH:=e29f4c23be2816ed005aa3f06bbb8eae0f22cc133863862e893515fc841e65e3
+PKG_HASH:=089b08a5efef02313483325f3bacd8c4fe311cf1e1e56749d5cc7d059e225631
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16

--- a/lang/php8/test.sh
+++ b/lang/php8/test.sh
@@ -14,11 +14,7 @@ case "$1" in
 		PHP_MOD="${1#php8-mod-}"
 		PHP_MOD="${PHP_MOD//-/_}"
 
-		if command -v opkg >/dev/null 2>&1; then
-			opkg install php8-cli
-		else
-			apk add php8-cli
-		fi
+		opkg install php8-cli
 
 		php8-cli -m | grep -i "$PHP_MOD"
 		;;

--- a/libs/tcp_wrappers/patches/001-debian_subset.patch
+++ b/libs/tcp_wrappers/patches/001-debian_subset.patch
@@ -724,13 +724,16 @@
  #endif
 --- a/fix_options.c
 +++ b/fix_options.c
-@@ -35,7 +35,8 @@ struct request_info *request;
+@@ -35,7 +35,12 @@ struct request_info *request;
  #ifdef IP_OPTIONS
      unsigned char optbuf[BUFFER_SIZE / 3], *cp;
      char    lbuf[BUFFER_SIZE], *lp;
--    int     optsize = sizeof(optbuf), ipproto;
-+    socklen_t  optsize = sizeof(optbuf);
++#if !defined(__GLIBC__)
+     int     optsize = sizeof(optbuf), ipproto;
++#else /* __GLIBC__ */
++    size_t  optsize = sizeof(optbuf);
 +    int     ipproto;
++#endif /* __GLIBC__ */
      struct protoent *ip;
      int     fd = request->fd;
      unsigned int opt;
@@ -750,21 +753,27 @@
      struct sockaddr_in *sin = (struct sockaddr_in *) sa;
 --- a/socket.c
 +++ b/socket.c
-@@ -76,7 +76,7 @@ struct request_info *request;
+@@ -76,7 +76,11 @@ struct request_info *request;
  {
      static struct sockaddr_in client;
      static struct sockaddr_in server;
--    int     len;
-+    socklen_t  len;
++#if !defined (__GLIBC__)
+     int     len;
++#else /* __GLIBC__ */
++    size_t  len;
++#endif /* __GLIBC__ */
      char    buf[BUFSIZ];
      int     fd = request->fd;
  
-@@ -224,7 +224,7 @@ int     fd;
+@@ -224,7 +228,11 @@ int     fd;
  {
      char    buf[BUFSIZ];
      struct sockaddr_in sin;
--    int     size = sizeof(sin);
-+    socklen_t  size = sizeof(sin);
++#if !defined(__GLIBC__)
+     int     size = sizeof(sin);
++#else /* __GLIBC__ */
++    size_t  size = sizeof(sin);
++#endif /* __GLIBC__ */
  
      /*
       * Eat up the not-yet received datagram. Some systems insist on a

--- a/libs/tcp_wrappers/patches/006-compilation-warnings.patch
+++ b/libs/tcp_wrappers/patches/006-compilation-warnings.patch
@@ -93,15 +93,24 @@
  #endif
  
  #include <sys/types.h>
-@@ -29,7 +29,7 @@ static char sccsid[] = "@(#) fix_options
+@@ -29,14 +29,14 @@ static char sccsid[] = "@(#) fix_options
  
  /* fix_options - get rid of IP-level socket options */
  
 -fix_options(request)
-+void fix_options(request)
- struct request_info *request;
+-struct request_info *request;
++void    fix_options(request)
++struct  request_info *request;
  {
  #ifdef IP_OPTIONS
+     unsigned char optbuf[BUFFER_SIZE / 3], *cp;
+     char    lbuf[BUFFER_SIZE], *lp;
+ #if !defined(__GLIBC__)
+-    int     optsize = sizeof(optbuf), ipproto;
++    unsigned int  optsize = sizeof(optbuf), ipproto;
+ #else /* __GLIBC__ */
+     size_t  optsize = sizeof(optbuf);
+     int     ipproto;
 --- a/fromhost.c
 +++ b/fromhost.c
 @@ -11,7 +11,7 @@
@@ -536,6 +545,24 @@
  #endif
  
  /* System libraries. */
+@@ -77,7 +77,7 @@ struct request_info *request;
+     static struct sockaddr_in client;
+     static struct sockaddr_in server;
+ #if !defined (__GLIBC__)
+-    int     len;
++    unsigned int  len;
+ #else /* __GLIBC__ */
+     size_t  len;
+ #endif /* __GLIBC__ */
+@@ -229,7 +229,7 @@ int     fd;
+     char    buf[BUFSIZ];
+     struct sockaddr_in sin;
+ #if !defined(__GLIBC__)
+-    int     size = sizeof(sin);
++    unsigned int  size = sizeof(sin);
+ #else /* __GLIBC__ */
+     size_t  size = sizeof(sin);
+ #endif /* __GLIBC__ */
 --- a/tcpd.c
 +++ b/tcpd.c
 @@ -11,7 +11,7 @@

--- a/net/cloudflared/Makefile
+++ b/net/cloudflared/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cloudflared
-PKG_VERSION:=2025.5.0
+PKG_VERSION:=2025.4.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cloudflare/cloudflared/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=956e9cf01b5f3735a7f032eb1c7f1977345b4bca5997ce6c8fb7daf5f15d8fe8
+PKG_HASH:=2ed887aff0f14cdaba3b35bb47343f25cbfe23c7e1f5ceb94c2fc005ccc23666
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE

--- a/net/dnsproxy/Makefile
+++ b/net/dnsproxy/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsproxy
-PKG_VERSION:=0.75.5
+PKG_VERSION:=0.75.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/dnsproxy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=a01b436cf9a6f94f7dc69536bfd3065bef358ab1be3d52508f697417999aad68
+PKG_HASH:=e280193753770de7273eefd26c8aa6a91df85258d4e0b63a392260a24e99331a
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=Apache-2.0
@@ -53,8 +53,6 @@ define Package/dnsproxy/install
 	$(INSTALL_BIN) $(CURDIR)/files/dnsproxy.init $(1)/etc/init.d/dnsproxy
 	$(INSTALL_DIR) $(1)/etc/uci-defaults/
 	$(INSTALL_BIN) $(CURDIR)/files/dnsproxy.defaults $(1)/etc/uci-defaults/80-dnsproxy-migration
-	$(INSTALL_DIR) $(1)/etc/sysctl.d/
-	$(INSTALL_CONF) ./files/dnsproxy.sysctl $(1)/etc/sysctl.d/50-dnsproxy.conf
 endef
 
 define Package/dnsproxy/conffiles

--- a/net/dnsproxy/files/dnsproxy.sysctl
+++ b/net/dnsproxy/files/dnsproxy.sysctl
@@ -1,3 +1,0 @@
-# quic-go expects larger UDP send/receive buffers
-net.core.rmem_max = 7500000
-net.core.wmem_max = 7500000

--- a/net/wifi-presence/files/wifi-presence.init
+++ b/net/wifi-presence/files/wifi-presence.init
@@ -35,7 +35,7 @@ start_service() {
         config_get hassPrefix main hassPrefix
         config_get hostapdSocks main hostapdSocks
         config_get mqttAddr main mqttAddr
-        config_get mqttID main mqttID
+        config_get mqttID main mqttId
         config_get mqttUsername main mqttUsername
         config_get mqttPassword main mqttPassword
         config_get mqttPrefix main mqttPrefix

--- a/net/xtables-addons/patches/100-add-rtsp-conntrack.patch
+++ b/net/xtables-addons/patches/100-add-rtsp-conntrack.patch
@@ -983,10 +983,11 @@
 +			sprintf(tmpname, "rtsp-%d", i);
 +		}
 +
-+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0)
 +		strlcpy(hlpr->name, tmpname, sizeof(hlpr->name));
 +#else
-+		hlpr->name = tmpname;
++		strncpy(hlpr->name, tmpname, sizeof(hlpr->name) - 1);
++		hlpr->name[sizeof(hlpr->name) - 1] = '\0'; // Ensure null-termination
 +#endif
 +		pr_debug("port #%d: %d\n", i, ports[i]);
 +

--- a/utils/owut/Makefile
+++ b/utils/owut/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=owut
-PKG_SOURCE_DATE:=2025-05-12
+PKG_SOURCE_DATE:=2025-04-08
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=8353c4e9e2557509be7226c1d06c3b4d679aa3d0
+PKG_SOURCE_VERSION:=ef2bfb4d4cb561c499600f6a0cb017b8c762eed5
 PKG_SOURCE_URL:=https://github.com/efahl/owut.git
-PKG_MIRROR_HASH:=3406d663c350e94da085a9dc689c89faa996de97e53c8704c9a71e7c98ffe080
+PKG_MIRROR_HASH:=24ee8a1067003c15c4e06db3d6182cfde873df1c60baf7803bf4b756df3f4029
 
 PKG_MAINTAINER:=Eric Fahlgren <ericfahlgren@gmail.com>
 PKG_LICENSE:=GPL-2.0-only
@@ -65,7 +65,6 @@ define Package/owut/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/owut $(1)/usr/bin
 
 	sed -i -e "s/%%VERSION%%/$(PKG_VERSION)-r$(PKG_RELEASE)/" $(1)/usr/bin/owut
-	sed -i -e "s/%%VERSION%%/$(PKG_VERSION)-r$(PKG_RELEASE)/" $(1)/usr/share/ucode/utils/argparse.uc
 endef
 
 $(eval $(call BuildPackage,owut))


### PR DESCRIPTION
xtables-addons rtpsp-conntrack support 6.12

strlcpy has been dropped in kernel 6.12 - replace it with strncpy ensuring null termination

amend patch 100-add-rtsp-conntrack.patch

Signed-off-by: Rudy Andram <rmandrad@gmail.com>
