### PR TITLE
libpng: Revert "libpng: add symlink to debug library" as unnecessary, update to 1.6.48

### DIFF
--- a/libs/libpng/Makefile
+++ b/libs/libpng/Makefile
@@ -46,9 +46,6 @@ CMAKE_OPTIONS += \
 
 define Build/InstallDev
 	$(call Build/InstallDev/cmake,$(1))
-ifdef CONFIG_DEBUG
-	$(LN) libpng16d.so $(1)/usr/lib/libpng16.so
-endif
 	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' $(1)/usr/bin/libpng{,16}-config
 	$(SED) '/^includedir=/s|/usr|$$$${prefix}|' $(1)/usr/bin/libpng{,16}-config
 	$(SED) '/^libdir=/s|/usr|$$$${prefix}|' $(1)/usr/bin/libpng{,16}-config
@@ -62,10 +59,7 @@ endef
 
 define Package/libpng/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpng16$(if $(CONFIG_DEBUG),d).so* $(1)/usr/lib/
-ifdef CONFIG_DEBUG
-	$(LN) libpng16d.so $(1)/usr/lib/libpng16.so
-endif
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpng16.so* $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpng.so $(1)/usr/lib/
 endef
 

--- a/libs/libpng/Makefile
+++ b/libs/libpng/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpng
-PKG_VERSION:=1.6.44
-PKG_RELEASE:=2
+PKG_VERSION:=1.6.48
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/libpng
-PKG_HASH:=60c4da1d5b7f0aa8d158da48e8f8afa9773c1c8baa5d21974df61f1886b8ce8e
+PKG_HASH:=46fd06ff37db1db64c0dc288d78a3f5efd23ad9ac41561193f983e20937ece03
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=Libpng GPL-2.0-or-later BSD-3-Clause

--- a/libs/libpng/patches/100-config_fix.patch
+++ b/libs/libpng/patches/100-config_fix.patch
@@ -1,6 +1,6 @@
 --- a/scripts/libpng-config-body.in
 +++ b/scripts/libpng-config-body.in
-@@ -83,6 +83,7 @@ while test $# -gt 0; do
+@@ -82,6 +82,7 @@ while test $# -gt 0; do
  
      --static)
          R_opts=""


### PR DESCRIPTION
This reverts commit 5313dd9be from PR #25324 , related to #25323 and https://github.com/openwrt/openwrt/pull/16899

The additional symlink `libpng16.so -> libpng16d.so` is now unnecessary as OpenWrt main repo PR https://github.com/openwrt/openwrt/pull/18709 commit https://github.com/openwrt/openwrt/commit/703e7d2d5b58e68528cb5fadfc1185bd3904b3d9 changed the cmake build type from 'Debug' to 'RelWithDebInfo', which causes libpng .so to be again compiled with the normal name `libpng16.so` (instead of the debug-styled `libpng16d.so`).

Maintainer: @jow- 
cc due to earlier PRs: @nwf @dangowrt

Compile & run tested with CONFIG_DEBUG enabled : mediatek/filogic MT-6000