### PR TITLE
tvheadend: update to 2024-11-12, new options, patch for bug #26422

### DIFF
--- a/multimedia/tvheadend/Config.in
+++ b/multimedia/tvheadend/Config.in
@@ -9,6 +9,14 @@ config TVHEADEND_OPTIMIZE_SPEED
     Optimize tvheadend for speed instead of size. This option adds -O3 and LTO (Link Time Optimization).
     Note: No benchmarks were performed when this option was added. Speed improvements (if any) are not known.
 
+config TVHEADEND_MEMORYINFO
+  bool "Memory info"
+  depends on PACKAGE_tvheadend
+  default n
+  help
+    Add htsmsg/htsmsg_field to Memory Information Entries tab.
+    Note: impacts performance.
+
 config TVHEADEND_TRACE
   bool "Low level debug trace"
   depends on PACKAGE_tvheadend
@@ -19,6 +27,22 @@ config TVHEADEND_TRACE
     Note: Selecting this option does not automatically enable trace logging.
     It only includes support for --trace command line option and GUI.
 
+choice
+  prompt "Regular Expression"
+  depends on PACKAGE_tvheadend
+  default TVHEADEND_REGEX_PCRE2
+  config TVHEADEND_REGEX_POSIX
+    bool "POSIX (internal)"
+    help
+      Use internal POSIX Regular Expressions.
+      Note: Some EPG parsers will not work with POSIX RegEx.
+  config TVHEADEND_REGEX_PCRE2
+    bool "PCRE2 (libpcre2)"
+    select PACKAGE_libpcre2
+    help
+      Use more advanced Perl-Compatible Regular Expressions, provided by libpcre2.
+endchoice
+
 config TVHEADEND_AVAHI_SUPPORT
   bool "Avahi client"
   depends on PACKAGE_tvheadend
@@ -28,32 +52,28 @@ config TVHEADEND_AVAHI_SUPPORT
     Enables the opensource implementation of Apple's zero configuration protocol.
     Tvheadend will advertise itself on the network using this protocol.
 
-choice
-  prompt "Regular Expression"
+config TVHEADEND_TIMESHIFT
+  bool "Timeshift"
   depends on PACKAGE_tvheadend
-  config TVHEADEND_REGEX_POSIX
-    bool "POSIX (internal)"
-    help
-      Use internal POSIX Regular Expressions.
-      Note that not all EPG parsers will work with POSIX RegEx.
-  config TVHEADEND_REGEX_PCRE2
-    bool "PCRE2 (libpcre2)"
-    select PACKAGE_libpcre2
-    help
-      Use more advanced Perl-Compatible Regular Expressions, provided by libpcre2.
-endchoice
-
-config TVHEADEND_IMAGECACHE
-  bool "Image cache"
-  depends on PACKAGE_tvheadend
-  default n
+  default y
   help
-    Support caching TV station logos and other images on disk.
-    Note: Activating disk cache will increase fash memory wear.
-    Selecting this option does not automatically enable disk caching. It only includes support for it.
+    Allow continuous recording of a selected TV channel in a circular memory or file buffer,
+    and allow clients playing that live TV channel to pause/rewind/replay/ffwd within the limits of the buffer.
+    Note: Timeshift must be supported by the clients too.
+    Note: Timeshift recording is continuous. It must be stopped manually. Recording on flash-based storage is NOT recommended!
 
 comment "Input & output support"
   depends on PACKAGE_tvheadend
+
+# BUG in tvheadend. Can't be disabled.
+#config TVHEADEND_TSFILE
+#  bool "ts file streaming"
+#  depends on PACKAGE_tvheadend
+#  default n
+#  help
+#    Support creation of a virtual TV network that streams from a file.
+#    This is done manually with --tsfile_tuners <no> and --tsfile <file> command line arguments
+#    and is not supported by OpenWrt tvheadend configuration and startup script.
 
 config TVHEADEND_LINUXDVB_SUPPORT
   bool "DVB tuners"
@@ -61,14 +81,14 @@ config TVHEADEND_LINUXDVB_SUPPORT
   default y
   help
     Include support for DVB tuners.
-    Note: Kernel driver(s) and firmware must also be installed.
+    Note: Kernel driver(s) and firmware must also be installed. These are not available as OpenWrt packages.
 
 config TVHEADEND_DVBSCAN_SUPPORT
   bool "Include DVB-scan tables"
   depends on TVHEADEND_LINUXDVB_SUPPORT
   default TVHEADEND_LINUXDVB_SUPPORT
   help
-    Download and include DVB scan tables.
+    Download and include DVB scan tables into the package.
 
 config TVHEADEND_IPTV
   bool "IPTV client"
@@ -97,9 +117,35 @@ config TVHEADEND_HDHOMERUN_CLIENT
   default y
   help
     Include HDHomeRun client.
-    HDHomeRun is a network-attached, digital television tuner box.
+    HDHomeRun is a network-attached digital television tuner box.
 
-comment "SoftCAM (Software Conditional Access Module)"
+config TVHEADEND_HDHOMERUN_SERVER
+  bool "HDHomeRun server emulation"
+  depends on PACKAGE_tvheadend
+  default y
+  help
+    Support emulating a HDHomeRun device (live TV only).
+    HDHomeRun is a network-attached digital television tuner box.
+    This option will allow tvheadend to act as a server and stream live TV to HDHomeRun clients.
+
+comment "Hardware descrambling"
+  depends on PACKAGE_tvheadend
+
+config TVHEADEND_DVB_DDCI
+  bool "DVB CI cards from Digital Devices"
+  depends on PACKAGE_tvheadend
+  depends on TVHEADEND_LINUXDVB_SUPPORT
+  default n
+  help
+    Support DVB CI (Common Interface) adapter cards from Digital Devices.
+    Note: Kernel drivers are required for the adapter cards. These are not available as OpenWrt packages.
+    Note: Not tested due to lack of hardware.
+
+comment "Software descrambling and some codecs are only available with BUILD_PATENTED."
+  depends on PACKAGE_tvheadend
+  depends on !BUILD_PATENTED
+
+comment "Software descrambling, SoftCAM (Software Conditional Access Module)"
   depends on PACKAGE_tvheadend
   depends on BUILD_PATENTED
 
@@ -110,7 +156,7 @@ config TVHEADEND_CSA
   select PACKAGE_libdvbcsa
   default n
   help
-    Support decoding CSA (Common Scrambling Algorithm). Uses libdvbcsa package.
+    Support CSA (Common Scrambling Algorithm). Uses libdvbcsa package.
 
 config TVHEADEND_CONSTCW
   bool "CCW"
@@ -120,11 +166,11 @@ config TVHEADEND_CONSTCW
     Support Constant Control Word.
 
 config TVHEADEND_CAPMT
-  bool "CWC capmt client"
+  bool "capmt client"
   depends on TVHEADEND_CSA
   default n
   help
-    Support Control Word Client capmt (Linux Network DVBAPI) protocol.
+    Support capmt (Linux Network DVBAPI) protocol.
 
 config TVHEADEND_NEWCAMD
   bool "CWC newcamd client"
@@ -137,10 +183,6 @@ config TVHEADEND_CCCAM
   bool "CCCam client"
   depends on TVHEADEND_CSA
   default n
-
-comment "DVB descrambling and some codecs are only available with BUILD_PATENTED."
-  depends on PACKAGE_tvheadend
-  depends on !BUILD_PATENTED
 
 ## Transcoding | Uncomment these options.
 ##comment "Transcoding and codecs"

--- a/multimedia/tvheadend/Makefile
+++ b/multimedia/tvheadend/Makefile
@@ -5,9 +5,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/tvheadend/tvheadend
-PKG_MIRROR_HASH:=0dbdc13634db4150e772aec8da730ffb7f0cadf3d3c46158a422a7dada16dcfc
-PKG_SOURCE_VERSION:=adef81b8d2a6edb3a665679f394bac05b7dc91c8
-PKG_SOURCE_DATE:=2024-08-12
+PKG_MIRROR_HASH:=53b0a85ceee9989688471220dfb2070fe4cd68ceef50234202f9c1af1b8b5dc8
+PKG_SOURCE_VERSION:=653bd0400b4413db96b80c807f0f7524f9248adb
+PKG_SOURCE_DATE:=2024-11-12
 
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=LICENSE.md
@@ -52,7 +52,7 @@ endef
 define Package/tvheadend/description
   Tvheadend is a TV streaming server and recorder for Linux, FreeBSD and Android
   supporting DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, IPTV, SAT>IP and HDHomeRun as input sources.
-  Tvheadend offers the HTTP (VLC, MPlayer), HTSP (Kodi, Movian) and SAT>IP streaming.
+  Tvheadend supports streaming to clients via HTTP (VLC, MPlayer), HTSP (Kodi, Movian), SAT>IP and TVHeadEnd emulation.
 endef
 
 define Package/tvheadend/config
@@ -74,14 +74,18 @@ endif
 ifeq ($(CONFIG_TVHEADEND_TRACE),)
 	CONFIGURE_ARGS += --disable-trace
 endif
-
-CONFIGURE_ARGS += --disable-pcre
-ifneq ($(CONFIG_TVHEADEND_REGEX_PCRE2),)
-	CONFIGURE_ARGS += --enable-pcre2
-else
-ifneq ($(CONFIG_TVHEADEND_REGEX_POSIX),)
-	CONFIGURE_ARGS += --disable-pcre2
+ifneq ($(CONFIG_TVHEADEND_MEMORYINFO),)
+	CONFIGURE_ARGS += --enable-slow_memoryinfo
 endif
+
+ifeq ($(CONFIG_TVHEADEND_REGEX_PCRE2),)
+	CONFIGURE_ARGS += --disable-pcre2
+else
+	CONFIGURE_ARGS += --enable-pcre2
+endif
+
+ifeq ($(CONFIG_TVHEADEND_TIMESHIFT),)
+	CONFIGURE_ARGS += --disable-timeshift
 endif
 
 ifeq ($(CONFIG_TVHEADEND_AVAHI_SUPPORT),)
@@ -90,13 +94,13 @@ else
 	CONFIGURE_ARGS += --enable-avahi
 endif
 
-ifeq ($(CONFIG_TVHEADEND_IMAGECACHE),)
-	CONFIGURE_ARGS += --disable-imagecache
-else
-	CONFIGURE_ARGS += --enable-imagecache
-endif
-
 ## TV sources
+
+# Bug in tvheadend. Can't be disabled.
+#ifeq ($(CONFIG_TVHEADEND_TSFILE),)
+#	CONFIGURE_ARGS += --disable-tsfile
+#endif
+
 ifeq ($(CONFIG_TVHEADEND_LINUXDVB_SUPPORT),)
 	CONFIGURE_ARGS += --disable-linuxdvb
 endif
@@ -118,12 +122,29 @@ ifeq ($(CONFIG_TVHEADEND_SATIP_CLIENT),)
 endif
 
 ifeq ($(CONFIG_TVHEADEND_HDHOMERUN_CLIENT),)
-	CONFIGURE_ARGS += --disable-hdhomerun_static
+ifeq ($(CONFIG_TVHEADEND_HDHOMERUN_SERVER),)
+	CONFIGURE_ARGS += --disable-hdhomerun_static --disable-hdhomerun_client --disable-hdhomerun_server
 else
-	CONFIGURE_ARGS += --enable-hdhomerun_client
+	CONFIGURE_ARGS += --enable-hdhomerun_static --disable-hdhomerun_client --enable-hdhomerun_server
+endif
+else
+	CONFIGURE_ARGS += --enable-hdhomerun_static --enable-hdhomerun_client
+ifeq ($(CONFIG_TVHEADEND_HDHOMERUN_SERVER),)
+	CONFIGURE_ARGS += --disable-hdhomerun_server
+else
+	CONFIGURE_ARGS += --enable-hdhomerun_server
+endif
 endif
 
 ## Descrambling
+ifeq ($(CONFIG_TVHEADEND_LINUXDVB_SUPPORT),)
+	CONFIGURE_ARGS += --disable-ddci
+else
+ifeq ($(CONFIG_TVHEADEND_DVB_DDCI),)
+	CONFIGURE_ARGS += --disable-ddci
+endif
+endif
+
 ifeq ($(CONFIG_BUILD_PATENTED),)
 	CONFIGURE_ARGS += --disable-tvhcsa --disable-dvbcsa --disable-constcw --disable-cwc --disable-capmt --disable-cccam
 else
@@ -196,6 +217,7 @@ CONFIGURE_ARGS += \
 	--arch=$(ARCH) \
 	--disable-libsystemd_daemon \
 	--disable-dbus_1 \
+	--disable-pcre \
 	--disable-libav \
 	--disable-ffmpeg_static \
 	--disable-libx264 \

--- a/multimedia/tvheadend/patches/010-fix-tvheadend-bug-1786.patch
+++ b/multimedia/tvheadend/patches/010-fix-tvheadend-bug-1786.patch
@@ -1,0 +1,11 @@
+--- a/src/webui/static/lovcombo/lovcombo-all.js
++++ b/src/webui/static/lovcombo/lovcombo-all.js
+@@ -297,7 +297,7 @@ Ext.ux.form.LovCombo = Ext.extend(Ext.ux
+ 				this.store.clearFilter();
+ 				this.store.each(function(r) {
+ 					var checked = !(!v.match(
+-						 '(^|' + this.separator + ')' + RegExp.escape(r.get(this.valueField))
++						 '(^|' + this.separator + ')' + RegExp.escape(String(r.get(this.valueField)))
+ 						+'(' + this.separator + '|$)'))
+ 					;
+ 


### PR DESCRIPTION
Maintainer: me
Compile tested: Gentoo Linux, OpenWrt r28997
Run tested: arm_cortex-a9_vfpv3 Turris Omnia r28997
- DVB-C works
- HTSP streaming to Kodi works
- recording works
- IPTV, SAT>IP, HDHomeRun, CA modules not tested - I don't have any of those.

Description:
- update to git master 2024-11-12 (dev stalled since then)
- patch for OpenWrt bug #26422 from [tvheadend PR #1786](https://github.com/tvheadend/tvheadend/pull/1786)
- Options removed:
  - imagecache = tvheadend doesn't support disabling it anymore
- Options added:
  - detailed (but slow) memory utilization reporting = default off
  - Timeshift = default on
  - tsfile = currently bugged in tvheadend, commented out / always on
  - HDHomeRun server emulation = default on
  - Digital Devices DVB CI descrambling cards = default off
- RegEx options cleaned up, PCRE2 is the new default.
- Some help texts improved