### PR TITLE
perl: do not set LD_LIBRARY_PATH for cross compile

### DIFF
--- a/lang/perl/patches/101-cross-compile-ldlibpth.patch
+++ b/lang/perl/patches/101-cross-compile-ldlibpth.patch
@@ -1,0 +1,15 @@
+--- a/Makefile.SH
++++ b/Makefile.SH
+@@ -174,6 +174,12 @@ EOT
+ 		;;
+ 	esac
+ 
++	case "$usecrosscompile$perl" in
++	define?*)
++	        ldlibpth=''
++		;;
++	esac
++
+ 	;;
+ 
+ *)	pldlflags=''

--- a/lang/perl/patches/900-use-rm-force.patch
+++ b/lang/perl/patches/900-use-rm-force.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.SH
 +++ b/Makefile.SH
-@@ -289,6 +289,7 @@ LNS = $lns
+@@ -295,6 +295,7 @@ LNS = $lns
  # NOTE: some systems don't grok "cp -f". XXX Configure test needed?
  CPS = $cp
  RMS = rm -f
@@ -8,7 +8,7 @@
  ranlib = $ranlib
  ECHO = $echo
  
-@@ -802,7 +803,7 @@ bitcount.h: generate_uudmap$(HOST_EXE_EX
+@@ -808,7 +809,7 @@ bitcount.h: generate_uudmap$(HOST_EXE_EX
  	./generate_uudmap$(HOST_EXE_EXT) $(generated_headers)
  
  generate_uudmap$(HOST_EXE_EXT): generate_uudmap$(OBJ_EXT)
@@ -17,7 +17,7 @@
  	$(LNS) $(HOST_GENERATE) generate_uudmap$(HOST_EXE_EXT)
  
  !NO!SUBS!
-@@ -907,26 +908,26 @@ mydtrace.h: $(DTRACE_H)
+@@ -913,26 +914,26 @@ mydtrace.h: $(DTRACE_H)
  	define)
  		$spitshell >>$Makefile <<'!NO!SUBS!'
  $(DTRACE_MINI_O): perldtrace.d $(miniperl_objs_nodt)
@@ -48,7 +48,7 @@
  
  !NO!SUBS!
  		;;
-@@ -937,13 +938,13 @@ $(LIBPERL): $& $(perllib_dep) $(DYNALOAD
+@@ -943,13 +944,13 @@ $(LIBPERL): $& $(perllib_dep) $(DYNALOAD
  	case "$useshrplib" in
  	true)
  		$spitshell >>$Makefile <<'!NO!SUBS!'
@@ -64,7 +64,7 @@
  	mv $@ libperl$(OBJ_EXT)
  	$(AR) qv $(LIBPERL) libperl$(OBJ_EXT)
  !NO!SUBS!
-@@ -952,7 +953,7 @@ $(LIBPERL): $& $(perllib_dep) $(DYNALOAD
+@@ -958,7 +959,7 @@ $(LIBPERL): $& $(perllib_dep) $(DYNALOAD
  		;;
  	*)
  		$spitshell >>$Makefile <<'!NO!SUBS!'
@@ -73,7 +73,7 @@
  	$(AR) rc $(LIBPERL) $(perllib_objs) $(DYNALOADER)
  	@$(ranlib) $(LIBPERL)
  !NO!SUBS!
-@@ -986,7 +987,7 @@ $(MINIPERL_EXE): lib/buildcustomize.pl
+@@ -992,7 +993,7 @@ $(MINIPERL_EXE): lib/buildcustomize.pl
  	amigaos*)
  		$spitshell >>$Makefile <<'!NO!SUBS!'
  lib/buildcustomize.pl: $& $(miniperl_objs) write_buildcustomize.pl
@@ -82,7 +82,7 @@
  	$(CC) $(CLDFLAGS) -o $(MINIPERL_EXE) \
  	    $(miniperl_objs) $(libs)
  #	$(LDLIBPTH) ./miniperl$(HOST_EXE_EXT) -w -Ilib -Idist/Exporter/lib -MExporter -e '<?>' || sh -c 'echo >&2 Failed to build miniperl.  Please run make minitest; exit 1'
-@@ -1008,7 +1009,7 @@ NAMESPACEFLAGS = -force_flat_namespace
+@@ -1014,7 +1015,7 @@ NAMESPACEFLAGS = -force_flat_namespace
  		esac
  		$spitshell >>$Makefile <<'!NO!SUBS!'
  lib/buildcustomize.pl: $& $(miniperl_objs) write_buildcustomize.pl
@@ -91,7 +91,7 @@
  	$(CC) $(CLDFLAGS) $(NAMESPACEFLAGS) -o $(MINIPERL_EXE) \
  	    $(miniperl_objs) $(libs)
  	$(LDLIBPTH) ./miniperl$(HOST_EXE_EXT) -w -Ilib -Idist/Exporter/lib -MExporter -e '<?>' || sh -c 'echo >&2 Failed to build miniperl.  Please run make minitest; exit 1'
-@@ -1019,8 +1020,8 @@ lib/buildcustomize.pl: $& $(miniperl_obj
+@@ -1025,8 +1026,8 @@ lib/buildcustomize.pl: $& $(miniperl_obj
  		if test "X$hostperl" != X; then
  			$spitshell >>$Makefile <<!GROK!THIS!
  lib/buildcustomize.pl: \$& \$(miniperl_dep) write_buildcustomize.pl
@@ -102,7 +102,7 @@
  	\$(LNS) \$(HOST_PERL) \$(MINIPERL_EXE)
  	\$(LDLIBPTH) ./miniperl\$(HOST_EXE_EXT) -w -Ilib -Idist/Exporter/lib -MExporter -e '<?>' || sh -c 'echo >&2 Failed to build miniperl.  Please run make minitest; exit 1'
  	\$(MINIPERL) -f write_buildcustomize.pl 'osname' "$osname"
-@@ -1028,7 +1029,7 @@ lib/buildcustomize.pl: \$& \$(miniperl_d
+@@ -1034,7 +1035,7 @@ lib/buildcustomize.pl: \$& \$(miniperl_d
  		else
  			$spitshell >>$Makefile <<'!NO!SUBS!'
  lib/buildcustomize.pl: $& $(miniperl_dep) write_buildcustomize.pl
@@ -111,7 +111,7 @@
  	$(CC) $(CLDFLAGS) -o $(MINIPERL_EXE) \
  	    $(miniperl_objs) $(libs)
  	$(LDLIBPTH) ./miniperl$(HOST_EXE_EXT) -w -Ilib -Idist/Exporter/lib -MExporter -e '<?>' || sh -c 'echo >&2 Failed to build miniperl.  Please run make minitest; exit 1'
-@@ -1041,7 +1042,7 @@ lib/buildcustomize.pl: $& $(miniperl_dep
+@@ -1047,7 +1048,7 @@ lib/buildcustomize.pl: $& $(miniperl_dep
  	$spitshell >>$Makefile <<'!NO!SUBS!'
  
  $(PERL_EXE): $& $(perlmain_dep) $(LIBPERL) $(static_ext) ext.libs $(PERLEXPORT) write_buildcustomize.pl
@@ -120,7 +120,7 @@
  !NO!SUBS!
  
          case "$osname" in
-@@ -1141,8 +1142,8 @@ pod/perl5400delta.pod: pod/perldelta.pod
+@@ -1147,8 +1148,8 @@ pod/perl5400delta.pod: pod/perldelta.pod
  	$(LNS) perldelta.pod pod/perl5400delta.pod
  
  extra.pods: $(MINIPERL_EXE)
@@ -131,7 +131,7 @@
  	-@for x in `grep -l '^=[a-z]' README.* | grep -v README.vms` ; do \
  	    nx=`echo $$x | sed -e "s/README\.//"`; \
  	    $(LNS) ../$$x "pod/perl"$$nx".pod" ; \
-@@ -1341,11 +1342,11 @@ realclean:	_realcleaner _mopup
+@@ -1347,11 +1348,11 @@ realclean:	_realcleaner _mopup
  	@echo "Note that '$(MAKE) realclean' does not delete config.sh or Policy.sh"
  
  _clobber:
@@ -148,7 +148,7 @@
  
  clobber:	_realcleaner _mopup _clobber
  
-@@ -1353,24 +1354,24 @@ distclean:	clobber
+@@ -1359,24 +1360,24 @@ distclean:	clobber
  
  # Like distclean but also removes emacs backups and *.orig.
  veryclean:	_verycleaner _mopup _clobber
@@ -184,7 +184,7 @@
  	-cd pod; $(LDLIBPTH) $(MAKE) $(CLEAN)
  	-cd utils; $(LDLIBPTH) $(MAKE) $(CLEAN)
  	-@if test -f $(MINIPERL_EXE) ; then \
-@@ -1380,8 +1381,8 @@ _cleaner1:
+@@ -1386,8 +1387,8 @@ _cleaner1:
  	else \
  	sh $(CLEAN).sh ; \
  	fi
@@ -195,7 +195,7 @@
  
  # Dear POSIX, thanks for making the default to xargs to be
  # run once if nothing is passed in. It is such a great help.
-@@ -1396,24 +1397,24 @@ _cleaner1:
+@@ -1402,24 +1403,24 @@ _cleaner1:
  # Add new rules before that line - the next line (rm -f so_locations ...) is
  # used as a placeholder by a regen script.
  _cleaner2:
@@ -237,7 +237,7 @@
  	-rmdir lib/version lib/threads lib/inc/ExtUtils lib/inc lib/encoding
  	-rmdir lib/autodie/exception lib/autodie/Scope lib/autodie lib/XS
  	-rmdir lib/Win32API lib/VMS lib/Unicode/Collate/Locale
-@@ -1470,11 +1471,11 @@ _realcleaner:
+@@ -1476,11 +1477,11 @@ _realcleaner:
  _verycleaner:
  	@$(LDLIBPTH) $(MAKE) _cleaner1 CLEAN=veryclean
  	@$(LDLIBPTH) $(MAKE) _cleaner2
@@ -251,7 +251,7 @@
  	lint $(lintflags) -DPERL_CORE -D_REENTRANT -DDEBUGGING -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 $(c)
  
  cscopeflags = -Rb  # Recursive, build-only.
-@@ -1535,7 +1536,7 @@ case "$targethost" in
+@@ -1541,7 +1542,7 @@ case "$targethost" in
  '') $spitshell >>$Makefile <<'!NO!SUBS!'
  test_prep test-prep: test_prep_pre $(MINIPERL_EXE) $(unidatafiles) $(PERL_EXE) \
  	$(dynamic_ext) $(TEST_PERL_DLL) runtests $(generated_pods) common_build
@@ -260,7 +260,7 @@
  
  !NO!SUBS!
  ;;
-@@ -1585,7 +1586,7 @@ test_prep test-prep: test_prep_pre \$(MI
+@@ -1591,7 +1592,7 @@ test_prep test-prep: test_prep_pre \$(MI
  	$to config.sh
  # --- For lib/diagnostics.t with -Duseshrplib
  	$to \$(PERL_EXE)
@@ -269,7 +269,7 @@
  	$to t/\$(PERL_EXE)
  
  !GROK!THIS!
-@@ -1603,7 +1604,7 @@ else
+@@ -1609,7 +1610,7 @@ else
  $spitshell >>$Makefile <<'!NO!SUBS!'
  test_prep_reonly: $(MINIPERL_EXE) $(PERL_EXE) $(dynamic_ext_re) $(TEST_PERL_DLL)
  	$(MINIPERL) make_ext.pl $(dynamic_ext_re) MAKE="$(MAKE)" LIBPERL_A=$(LIBPERL) LINKTYPE=dynamic
@@ -278,7 +278,7 @@
  !NO!SUBS!
  fi
  
-@@ -1659,7 +1660,7 @@ minitest_prep: $(MINIPERL_EXE)
+@@ -1665,7 +1666,7 @@ minitest_prep: $(MINIPERL_EXE)
  	@echo "You may see some irrelevant test failures if you have been unable"
  	@echo "to build lib/Config.pm, or the Unicode data files."
  	@echo " "

--- a/lang/perl/patches/920-Revert-perl-127606-adjust-dependency-paths-on-instal.patch
+++ b/lang/perl/patches/920-Revert-perl-127606-adjust-dependency-paths-on-instal.patch
@@ -30,7 +30,7 @@ Signed-off-by: Georgi Valkov <gvalkov@gmail.com>
  		;;
  	cygwin*)
  		shrpldflags="$shrpldflags -Wl,--out-implib=libperl.dll.a"
-@@ -353,14 +345,6 @@ MANIFEST_SRT = MANIFEST.srt
+@@ -359,14 +351,6 @@ MANIFEST_SRT = MANIFEST.srt
  
  !GROK!THIS!
  
@@ -45,7 +45,7 @@ Signed-off-by: Georgi Valkov <gvalkov@gmail.com>
  case "$usecrosscompile$perl" in
  define?*)
  	$spitshell >>$Makefile <<!GROK!THIS!
-@@ -1056,20 +1040,6 @@ $(PERL_EXE): $& $(perlmain_dep) $(LIBPER
+@@ -1062,20 +1046,6 @@ $(PERL_EXE): $& $(perlmain_dep) $(LIBPER
  	$(SHRPENV) $(CC) -o perl $(CLDFLAGS) $(CCDLFLAGS) $(perlmain_objs) $(LLIBPERL) $(static_ext) `cat ext.libs` $(libs)
  !NO!SUBS!
          ;;


### PR DESCRIPTION
Maintainer: @Naoir, @pprindeville
Compile tested: x86-64
Run tested: no (build fix only)

Description:

We don't want to set LD_LIBRARY_PATH to a directory filled with target libraries when running a host perl. When the host and target architecture are the same, some libraries will be loaded from this path, resulting in the build to break because of glibc/musl mismatch.

Reported-by: John Audia <therealgraysky@proton.me>
Fixes: e7b5a35e5caa ("perl: drop 110-always_use_miniperl.patch")

Closes #26486