### PR TITLE
php8: update to 8.4.7 and adapt CI test helper

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.4.6
+PKG_VERSION:=8.4.7
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.php.net/distributions/
-PKG_HASH:=089b08a5efef02313483325f3bacd8c4fe311cf1e1e56749d5cc7d059e225631
+PKG_HASH:=e29f4c23be2816ed005aa3f06bbb8eae0f22cc133863862e893515fc841e65e3
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16

--- a/lang/php8/test.sh
+++ b/lang/php8/test.sh
@@ -14,7 +14,11 @@ case "$1" in
 		PHP_MOD="${1#php8-mod-}"
 		PHP_MOD="${PHP_MOD//-/_}"
 
-		opkg install php8-cli
+		if command -v opkg >/dev/null 2>&1; then
+			opkg install php8-cli
+		else
+			apk add php8-cli
+		fi
 
 		php8-cli -m | grep -i "$PHP_MOD"
 		;;


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs, bcm27xx
Run tested: bcm27xx, Raspberry Pi

Description:

Upstream changelog:
https://www.php.net/ChangeLog-8.php#8.4.7

Since some buildbots failed on this PR, I included a second commit which adapts the CI helper script for apk.
