### PR TITLE
fx: update to 36.0.1

### DIFF
--- a/utils/fx/Makefile
+++ b/utils/fx/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fx
-PKG_VERSION:=35.0.0
+PKG_VERSION:=36.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/antonmedv/fx/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=5ab642bb91ad9c1948de1add2d62acec22d82398e420957c191c1549999eb351
+PKG_HASH:=fc32fcf5c7f813d4adb43dbb77dda449cb1451a4d115e3f612aa1f31da76cb2e
 
 PKG_MAINTAINER:=Fabian Lipken <dynasticorpheus@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @dynasticorpheus 
Compile tested: Ubuntu 23.04 x64 / OpenWrt SNAPSHOT @ https://github.com/openwrt/packages/commit/36b1dd75fd9da1ea13f1ce1ee679c6b3c9c402cc
Run tested: Linksys WRT32X / OpenWrt SNAPSHOT r24315-ae500e62e2

Description: Update to [36.0.1](https://github.com/antonmedv/fx/compare/35.0.0...36.0.1)

Fx is a dual-purpose command-line tool tailored for JSON, providing both a terminal-based JSON viewer and a JSON processing utility.
