### PR TITLE
[24.10] adblock-fast: Fixed non-printable characters and bump PKG_VERSION

### DIFF
--- a/net/adblock-fast/Makefile
+++ b/net/adblock-fast/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.1.3
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=AGPL-3.0-or-later
 

--- a/net/adblock-fast/files/etc/init.d/adblock-fast
+++ b/net/adblock-fast/files/etc/init.d/adblock-fast
@@ -469,7 +469,8 @@ get_url_filesize() {
 	is_present 'curl' || return 0
 	size_command='curl --silent --insecure --fail --head --request GET'
 #	size="$($size_command "$url" | grep -Po '^[cC]ontent-[lL]ength: \K\w+')"
-	size="$($size_command "$url" | grep -Eo '^[cC]ontent-[lL]ength: (.*)' | awk '{print $2}')"
+# shellcheck disable=SC1017
+	size="$($size_command "$url" | awk -F": " '{IGNORECASE=1}/content-length/ {gsub(/\r/, ""); print $2}' )"
 # shellcheck disable=SC3037
 	echo -en "$size"
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 24.10.0
Run tested: x86_64, Dell EMC Edge620, OpenWrt 24.10.0

Description:
(cherry picked from commit 3d9eb08f8e4c63b7f5d6c057f8d5f7e54ba4158e)
