### PR TITLE
net/bcp38: Add cgnat shared space to bcp38  nonrouteable list

### DIFF
--- a/net/bcp38/Makefile
+++ b/net/bcp38/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcp38
 PKG_VERSION:=5
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 PKG_LICENSE:=GPL-3.0-or-later
 
 include $(INCLUDE_DIR)/package.mk

--- a/net/bcp38/files/bcp38.config
+++ b/net/bcp38/files/bcp38.config
@@ -10,6 +10,7 @@ config bcp38
 	list match '10.0.0.0/8'      # RFC 1918
 	list match '172.16.0.0/12'   # RFC 1918
 	list match '169.254.0.0/16'  # RFC 3927
+	list match '100.64.0.0/10'   # RFC 6598
 
 # 	list nomatch '172.26.0.0/21' # Example of something not to match
 #	There is a dhcp trigger to do this for the netmask of a 

--- a/net/bcp38/files/run.sh
+++ b/net/bcp38/files/run.sh
@@ -85,7 +85,7 @@ setup_chains()
 	nft add chain "$FAMILY" "$TABLE" "$CHAIN" 2>/dev/null
 	nft flush chain "$FAMILY" "$TABLE" "$CHAIN" 2>/dev/null
 
-	nft add rule "$FAMILY" "$TABLE" "$CHAIN" udp dport {67,68} udp sport {67,68} counter return comment \"always accept DHCP traffic\"
+	nft add rule "$FAMILY" "$TABLE" "$CHAIN" udp sport . udp dport { 68 . 67, 67 . 68 } counter return comment \"always accept DHCP traffic\"
 	nft add rule "$FAMILY" "$TABLE" "$CHAIN" oifname $interface ip daddr @"$MATCHSET" ip daddr != @"$NOMATCHSET" counter reject with icmp type host-unreachable
 	nft add rule "$FAMILY" "$TABLE" "$CHAIN" iifname $interface ip saddr @"$MATCHSET" ip saddr != @"$NOMATCHSET" counter drop
 


### PR DESCRIPTION
Maintainer @tohojo 
Patched respective files on live routers, still worked nicely after.
Run tested: 24.10.1 23.05.5 aarch64 x86/64 ramips
Description:
Add CG-NAT address space to non-routable list, while others are null routed by many intermediaries, cg-nat in particular kits at ttl reminder 55-60 ie half world's away.

Make dhcp filter stricter
