### PR TITLE
tcp_wrappers: update patches for gcc14

### DIFF
--- a/libs/tcp_wrappers/patches/001-debian_subset.patch
+++ b/libs/tcp_wrappers/patches/001-debian_subset.patch
@@ -724,16 +724,13 @@
  #endif
 --- a/fix_options.c
 +++ b/fix_options.c
-@@ -35,7 +35,12 @@ struct request_info *request;
+@@ -35,7 +35,8 @@ struct request_info *request;
  #ifdef IP_OPTIONS
      unsigned char optbuf[BUFFER_SIZE / 3], *cp;
      char    lbuf[BUFFER_SIZE], *lp;
-+#if !defined(__GLIBC__)
-     int     optsize = sizeof(optbuf), ipproto;
-+#else /* __GLIBC__ */
-+    size_t  optsize = sizeof(optbuf);
+-    int     optsize = sizeof(optbuf), ipproto;
++    socklen_t  optsize = sizeof(optbuf);
 +    int     ipproto;
-+#endif /* __GLIBC__ */
      struct protoent *ip;
      int     fd = request->fd;
      unsigned int opt;
@@ -753,27 +750,21 @@
      struct sockaddr_in *sin = (struct sockaddr_in *) sa;
 --- a/socket.c
 +++ b/socket.c
-@@ -76,7 +76,11 @@ struct request_info *request;
+@@ -76,7 +76,7 @@ struct request_info *request;
  {
      static struct sockaddr_in client;
      static struct sockaddr_in server;
-+#if !defined (__GLIBC__)
-     int     len;
-+#else /* __GLIBC__ */
-+    size_t  len;
-+#endif /* __GLIBC__ */
+-    int     len;
++    socklen_t  len;
      char    buf[BUFSIZ];
      int     fd = request->fd;
  
-@@ -224,7 +228,11 @@ int     fd;
+@@ -224,7 +224,7 @@ int     fd;
  {
      char    buf[BUFSIZ];
      struct sockaddr_in sin;
-+#if !defined(__GLIBC__)
-     int     size = sizeof(sin);
-+#else /* __GLIBC__ */
-+    size_t  size = sizeof(sin);
-+#endif /* __GLIBC__ */
+-    int     size = sizeof(sin);
++    socklen_t  size = sizeof(sin);
  
      /*
       * Eat up the not-yet received datagram. Some systems insist on a

--- a/libs/tcp_wrappers/patches/006-compilation-warnings.patch
+++ b/libs/tcp_wrappers/patches/006-compilation-warnings.patch
@@ -93,24 +93,15 @@
  #endif
  
  #include <sys/types.h>
-@@ -29,14 +29,14 @@ static char sccsid[] = "@(#) fix_options
+@@ -29,7 +29,7 @@ static char sccsid[] = "@(#) fix_options
  
  /* fix_options - get rid of IP-level socket options */
  
 -fix_options(request)
--struct request_info *request;
-+void    fix_options(request)
-+struct  request_info *request;
++void fix_options(request)
+ struct request_info *request;
  {
  #ifdef IP_OPTIONS
-     unsigned char optbuf[BUFFER_SIZE / 3], *cp;
-     char    lbuf[BUFFER_SIZE], *lp;
- #if !defined(__GLIBC__)
--    int     optsize = sizeof(optbuf), ipproto;
-+    unsigned int  optsize = sizeof(optbuf), ipproto;
- #else /* __GLIBC__ */
-     size_t  optsize = sizeof(optbuf);
-     int     ipproto;
 --- a/fromhost.c
 +++ b/fromhost.c
 @@ -11,7 +11,7 @@
@@ -545,24 +536,6 @@
  #endif
  
  /* System libraries. */
-@@ -77,7 +77,7 @@ struct request_info *request;
-     static struct sockaddr_in client;
-     static struct sockaddr_in server;
- #if !defined (__GLIBC__)
--    int     len;
-+    unsigned int  len;
- #else /* __GLIBC__ */
-     size_t  len;
- #endif /* __GLIBC__ */
-@@ -229,7 +229,7 @@ int     fd;
-     char    buf[BUFSIZ];
-     struct sockaddr_in sin;
- #if !defined(__GLIBC__)
--    int     size = sizeof(sin);
-+    unsigned int  size = sizeof(sin);
- #else /* __GLIBC__ */
-     size_t  size = sizeof(sin);
- #endif /* __GLIBC__ */
 --- a/tcpd.c
 +++ b/tcpd.c
 @@ -11,7 +11,7 @@


### PR DESCRIPTION
Maintainer: @neheb (last person to touch it)
Compile tested: aarch64, 24.10.1

Description: The portable way is to use `socklen_t`. This fixes int-conversion in both glibc and musl based builds.
