### PR TITLE
rsyslog: add mmnormalize module support

### DIFF
--- a/admin/rsyslog/Config.in
+++ b/admin/rsyslog/Config.in
@@ -67,4 +67,9 @@ if PACKAGE_rsyslog
 		default n
 		help
 		  Enable input file module in rsyslog
+	config RSYSLOG_mmnormalize
+		bool "Enable mmnormalize module support"
+		default n
+		help
+		  Enable mmnormalize module in rsyslog
 endif

--- a/admin/rsyslog/Makefile
+++ b/admin/rsyslog/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsyslog
 PKG_VERSION:=8.2606.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -38,7 +38,7 @@ define Package/rsyslog
 	+RSYSLOG_libdbi:libdbi +libestr +libfastjson +RSYSLOG_gnutls:libgnutls \
 	+RSYSLOG_mmdblookup:libmaxminddb +RSYSLOG_mysql:libmysqlclient \
 	+RSYSLOG_omhttp:libcurl +RSYSLOG_openssl:libopenssl \
-	+RSYSLOG_pgsql:libpq +RSYSLOG_libyaml:libyaml +libuuid +zlib
+	+RSYSLOG_pgsql:libpq +RSYSLOG_libyaml:libyaml +libuuid +zlib +RSYSLOG_mmnormalize:liblognorm
   MENU:=1
 endef
 
@@ -64,7 +64,8 @@ CONFIGURE_ARGS+= \
 	$(if $(CONFIG_RSYSLOG_mail),--enable-mail) \
 	$(if $(CONFIG_RSYSLOG_mmjsonparse),--enable-mmjsonparse) \
 	$(if $(CONFIG_RSYSLOG_mmdblookup),--enable-mmdblookup) \
-	$(if $(CONFIG_RSYSLOG_imfile),--enable-imfile)
+	$(if $(CONFIG_RSYSLOG_imfile),--enable-imfile) \
+	$(if $(CONFIG_RSYSLOG_mmnormalize),--enable-mmnormalize)
 
 define Package/rsyslog/install
 	$(INSTALL_DIR) $(1)/usr/sbin

--- a/libs/liblognorm/Makefile
+++ b/libs/liblognorm/Makefile
@@ -1,0 +1,53 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=liblognorm
+PKG_VERSION:=2.1.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/rsyslog/liblognorm/archive/v$(PKG_VERSION)
+PKG_HASH:=3decedd036916639f8394ac5efd593127eb35c3ed8b115d44fe0cb4292bd9a06
+
+PKG_MAINTAINER:=Carlo Filippi <carlo@common-net.org>
+PKG_LICENSE:=LGPL-2.1-or-later Apache-2.0
+PKG_LICENSE_FILES:=COPYING COPYING.ASL20
+
+PKG_FIXUP:=autoreconf
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/liblognorm
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Lognorm library
+  URL:=https://www.liblognorm.com/
+  DEPENDS:=+libestr +libfastjson
+endef
+
+define Package/liblognorm/description
+  Liblognorm is a fast-samples based log normalization library
+endef
+
+CONFIGURE_ARGS += \
+	--disable-docs \
+	--disable-regexp \
+	--disable-testbench \
+	--disable-tools
+TARGET_CFLAGS += $(FPIC)
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
+endef
+
+define Package/liblognorm/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liblognorm.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,liblognorm))


### PR DESCRIPTION
Maintainer: @neheb (last person to touch it)
Compile tested: mvebu, cortexa72, mikrotik_rb5009ug, openwrt-24.10; ramips, mt7621, ubnt_edgerouter-x, openwrt-24.10.
Run tested: mvebu, cortexa72, mikrotik_rb5009ug, openwrt-24.10; ramips, mt7621, ubnt_edgerouter-x, openwrt-24.10; in both devices, rsyslog was configured to normalize the received log messages and write them to a file and it was verified that the output complied with the configured normalization function.

Description: This adds mmnormalize module support to rsyslog. The module provides the capability to normalize log messages via liblognorm.

---

PR needs to be merged before:

- https://github.com/rsyslog/liblognorm/pull/374
