### PR TITLE
uvol: fix autopart on devices using fitblk

### DIFF
--- a/utils/uvol/Makefile
+++ b/utils/uvol/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uvol
-PKG_VERSION:=0.9
-PKG_RELEASE:=3
+PKG_VERSION:=1.0
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/utils/uvol/files/autopart.defaults
+++ b/utils/uvol/files/autopart.defaults
@@ -91,12 +91,22 @@ lvm_init() {
 }
 
 autopart_init() {
-	local diskdev
+	local fitpart diskdev
 	local lvmpart
 	local diskserial diskhash
 
-	export_bootdevice && export_partdevice diskdev 0
-
+	if [ -e "/lib/upgrade/fit.sh" ]; then
+		. /lib/upgrade/fit.sh
+		export_fitblk_bootdev
+		if [ "$EMMC_KERN_DEV" ]; then
+			for fitpart in /sys/class/block/*/${EMMC_KERN_DEV:5}; do
+				[ -e "$fitpart" ] || continue
+				diskdev="${fitpart%/*}"
+				diskdev="${diskdev##*/}"
+			done
+		fi
+	fi
+	[ "$diskdev" ] || export_bootdevice && export_partdevice diskdev 0
 	[ "$diskdev" ] || return
 
 	[ -e "/sys/class/block/$diskdev/device/serial" ] && diskserial="$(cat "/sys/class/block/$diskdev/device/serial")"


### PR DESCRIPTION
Maintainer: me
Compile tested: n/a
Run tested: BananaPi R4

Description:
Correctly detect the block device used for booting also on devices using the new fitblk driver.
