### PR TITLE
php8: update to 8.2.28

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.2.26
+PKG_VERSION:=8.2.28
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.php.net/distributions/
-PKG_HASH:=54747400cb4874288ad41a785e6147e2ff546cceeeb55c23c00c771ac125c6ef
+PKG_HASH:=af8c9153153a7f489153b7a74f2f29a5ee36f5cb2c6c6929c98411a577e89c91
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs, Duckbill

Description:

This fixes:
    - CVE-2025-1217
    - CVE-2025-1219
    - CVE-2025-1734
    - CVE-2025-1736
    - CVE-2025-1861

Upstream changelog:
https://www.php.net/ChangeLog-8.php#8.2.28
