### PR TITLE
[24.10] php8: update to 8.3.21

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.3.12
+PKG_VERSION:=8.3.21
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.php.net/distributions/
-PKG_HASH:=f774e28633e26fc8c5197f4dae58ec9e3ff87d1b4311cbc61ab05a7ad24bd131
+PKG_HASH:=4dfb329f209a552c3716394fc123bb62e80a468b55ce27fc8cb0fd5f30b9dcd6
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16

--- a/lang/php8/patches/0022-Use-system-timezone.patch
+++ b/lang/php8/patches/0022-Use-system-timezone.patch
@@ -15,7 +15,7 @@ To be used in tandem with use_embedded_timezonedb.patch and use_embedded_timezon
 
 --- a/ext/date/php_date.c
 +++ b/ext/date/php_date.c
-@@ -567,6 +567,23 @@ static const char* guess_timezone(const
+@@ -568,6 +568,23 @@ static const char* guess_timezone(const
  	} else if (*DATEG(default_timezone)) {
  		return DATEG(default_timezone);
  	}

--- a/lang/php8/patches/0025-php-5.4.9-fixheader.patch
+++ b/lang/php8/patches/0025-php-5.4.9-fixheader.patch
@@ -9,7 +9,7 @@ Make generated php_config.h constant across rebuilds.
 
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1507,7 +1507,7 @@ PHP_REMOVE_USR_LIB(LDFLAGS)
+@@ -1501,7 +1501,7 @@ PHP_REMOVE_USR_LIB(LDFLAGS)
  EXTRA_LDFLAGS="$EXTRA_LDFLAGS $PHP_LDFLAGS"
  EXTRA_LDFLAGS_PROGRAM="$EXTRA_LDFLAGS_PROGRAM $PHP_LDFLAGS"
  

--- a/lang/php8/patches/1004-disable-phar-command.patch
+++ b/lang/php8/patches/1004-disable-phar-command.patch
@@ -11,7 +11,7 @@
  
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1703,13 +1703,13 @@ CFLAGS_CLEAN="$CFLAGS \$(PROF_FLAGS)"
+@@ -1697,13 +1697,13 @@ CFLAGS_CLEAN="$CFLAGS \$(PROF_FLAGS)"
  CFLAGS="\$(CFLAGS_CLEAN) $standard_libtool_flag"
  CXXFLAGS="$CXXFLAGS $standard_libtool_flag \$(PROF_FLAGS)"
  


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs, bcm2709
Run tested: bcm2709 (Raspberry Pi 2B)

Description:

Upstream changelog:
https://www.php.net/ChangeLog-8.php#8.3.21
