### PR TITLE
strongswan: mark UCI plugin as broken

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -745,7 +745,7 @@ $(eval $(call BuildPlugin,sqlite,SQLite database interface,+strongswan-mod-sql +
 $(eval $(call BuildPlugin,sshkey,SSH key decoding,))
 $(eval $(call BuildPlugin,stroke,Stroke,+strongswan-charon +strongswan-ipsec))
 $(eval $(call BuildPlugin,test-vectors,crypto test vectors,))
-$(eval $(call BuildPlugin,uci,UCI config interface,+PACKAGE_strongswan-mod-uci:libuci))
+$(eval $(call BuildPlugin,uci,UCI config interface,+PACKAGE_strongswan-mod-uci:libuci @BROKEN))
 $(eval $(call BuildPlugin,unity,Cisco Unity extension,))
 $(eval $(call BuildPlugin,updown,updown firewall,+iptables +IPV6:ip6tables +iptables-mod-ipsec +kmod-ipt-ipsec))
 $(eval $(call BuildPlugin,vici,Versatile IKE Configuration Interface,))


### PR DESCRIPTION
Maintainer: @lowjoel @kevinoid @peci1 
Compile tested: qualcommax/ipq807x,main
Run tested: None

Description:
UCI plugin in strongswan has been broken for years, and now its causing strongswan to fail compilation.

So, instead of the whole strongswan package to be failing and missing from feeds simply make UCI plug depend on @BROKEN.