### PR TITLE
miniupnpd: Update miniupnpd to 2.3.9 and add `force` option to ignore ip/nat check

### DIFF
--- a/utils/lxc/files/lxc-auto.init
+++ b/utils/lxc/files/lxc-auto.init
@@ -62,12 +62,6 @@ stop() {
 	fi
 }
 
-#Export systemd cgroups
 boot() {
-	if [ ! -d /sys/fs/cgroup/systemd ]; then
-		mkdir -p /sys/fs/cgroup/systemd
-		mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,none,name=systemd cgroup /sys/fs/cgroup/systemd
-	fi
-
 	start
 }


### PR DESCRIPTION
Compile tested: BananaPI-R3 with openwrt 24.10
Run tested: BananaPI-R3 with openwrt 24.10

Description:

Update miniupnpd to 2.3.9 and add `force` option to ignore ip/nat check
