### PR TITLE
bind: bump to 9.18.36

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.18.33
+PKG_VERSION:=9.18.36
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=fb373fac5ebbc41c645160afd5a9fb451918f6c0e69ab1d9474154e2b515de40
+PKG_HASH:=cd9a667bd33637dd9af331e4a203837cb3d53de5747eb2973c816dfaa68708f1
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: me 
Compile tested: mvebu, OpenWRT 23.05
Run tested: mvebu, OpenWRT 23.05. Basic DNS functionality. Recursive and authoritative responses.

Description:

Bump openwrt 23.05 to the latest bind 9.18.x release.