### PR TITLE
modemmanager: add sourcefilter option support

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -245,7 +245,11 @@ modemmanager_connected_method_static_ipv6() {
 	[ -n "${gateway}" ] && {
 		echo "adding default IPv6 route via ${gateway}"
 		proto_add_ipv6_route "${gateway}" "128"
-		proto_add_ipv6_route "::0" "0" "${gateway}" "" "" "${address}/${prefix}"
+		[ "$sourcefilter" = "0" ] && {
+			proto_add_ipv6_route "::0" "0" "${gateway}"
+		} || {
+			proto_add_ipv6_route "::0" "0" "${gateway}" "" "" "${address}/${prefix}"
+		}
 	}
 	[ -n "${dns1}" ] && {
 		echo "adding primary DNS at ${dns1}"


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: aarch64, Banana Pi-R4, snapshot 4-16-2025
Run tested: aarch64, Banana Pi-R4, snapshot 4-16-2025, tested and checked routing table with sourcefilter set to both options.

Description:
This makes source based IPv6 routing option available for modemmanager.
