### PR TITLE
ovpn-dco: update to version 0.2.20241216

### DIFF
--- a/kernel/ovpn-dco/Makefile
+++ b/kernel/ovpn-dco/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ovpn-dco
-PKG_VERSION:=0.2.20240320
+PKG_VERSION:=0.2.20241216
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://codeload.github.com/OpenVPN/ovpn-dco/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=83a02dc3e6e40b0ef128cd32ce7f47da7fccd759af68657f44925d64a88db37b
+PKG_HASH:=0b30b8973b362b80a05f278ae217f01a2a2417e16e9c68c486960275a55306cc
 
 PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: @zhaojh329 
Compile tested: ramips/mt7620 (6.12), ramips/mt7621 (6.6)
Run tested: Xiaomi Mi router 3 pro, Beeline smartbox giga

Added compatibility with 6.12 kernel