### PR TITLE
lvm2: install: fix "Argument list too long" error when copying symlinks

### DIFF
--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -151,7 +151,7 @@ define Package/lvm2/install
 	$(INSTALL_BIN) ./files/lvm2.init $(1)/etc/init.d/lvm2
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/block
 	$(INSTALL_DATA) ./files/lvm2.hotplug $(1)/etc/hotplug.d/block/20-lvm2
-	$(FIND) $(PKG_INSTALL_DIR)/usr/sbin/ -type l -exec $(CP) -a {} $(1)/sbin/ \;
+	$(FIND) $(PKG_INSTALL_DIR)/usr/sbin/ -type l -print0 | xargs -0 -r $(CP) -a -t $(1)/sbin/
 endef
 
 Package/lvm2-selinux/install = $(Package/lvm2/install)


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: N/A
Run tested: N/A

Description:

It was reported that in some build environments the install step fails with following:

 find /home/.../buildsystem/build_dir/target-aarch64-unknown-linux-gnu_musl/lvm2-normal/LVM2.2.03.22/ipkg-install/usr/sbin/ -type l -exec cp -fpR -a {} /home/.../buildsystem/build_dir/target-aarch64-unknown-linux-gnu_musl/lvm2-normal/LVM2.2.03.22/.pkgdir/lvm2/sbin/ \;
 make[6]: /bin/sh: Argument list too long

This is likely happening once the number of symlinks exceeds the shell's maximum argument limit.

So lets fix it by switching to more reliable xargs based solution:

 print0/xargs -0 to handle filenames with special characters
 xargs -r to skip execution if no files are found
 cp -t to specify the target directory once instead of for each file

Fixes: #26552