### PR TITLE
bind: bump to 9.20.9

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.20.8
+PKG_VERSION:=9.20.9
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=3004d99c476beab49a986c2d49f902e2cd7766c9ab18b261e8b353cabf3a04b5
+PKG_HASH:=3d26900ed9c9a859073ffea9b97e292c1248dad18279b17b05fcb23c3091f86d
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
CVE-2025-40775: Prevent assertion when processing TSIG algorithm.  DNS messages that included a Transaction Signature (TSIG) containing an invalid value in the algorithm field caused named to crash with an assertion failure. This has been fixed.

Maintainer: me
Compile tested: master, compile is pending
Run tested: pending compile

