### PR TITLE
cjson: update to 1.7.18

### DIFF
--- a/libs/cjson/Makefile
+++ b/libs/cjson/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cJSON
-PKG_VERSION:=1.7.17
+PKG_VERSION:=1.7.18
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/DaveGamble/cJSON/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c91d1eeb7175c50d49f6ba2a25e69b46bd05cffb798382c19bfb202e467ec51c
+PKG_HASH:=3aa806844a03442c00769b83e99970be70fbef03735ff898f4811dd03b9f5ee5
 
 PKG_MAINTAINER:=Karl Palsson <karlp@etactica.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @karlp 
Compile tested:  x86, 64, snapshot 21 May 2025
Run tested: x86, 64, snapshot r29619

Description:

This is a bugfix release
Full release notes available at:
https://github.com/DaveGamble/cJSON/releases/tag/v1.7.18