### PR TITLE
tailscale: update to 1.84.0

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.82.5
+PKG_VERSION:=1.84.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=09685251057c96b7aa01e62b982a90824559ffd7113c8b69b9fc454c611f40a9
+PKG_HASH:=cbb0eb69643a30a10d583bb68fff09720c23c39d6109f3f6390b34aed77db47b
 
 PKG_MAINTAINER:=Zephyr Lykos <self@mochaa.ws>, \
 		Sandro Jäckel <sandro.jaeckel@gmail.com>


### PR DESCRIPTION
Maintainer: me / @mochaaP 
Compile tested: arm_cortex-a7_neon-vfpv4 OpenWrt 24.10.0
Run tested: arm_cortex-a7_neon-vfpv4 OpenWrt 24.10.0, connected to my tailscale net and things continued to work

Description:
