### PR TITLE
fping: update to version 5.3

### DIFF
--- a/net/fping/Makefile
+++ b/net/fping/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fping
-PKG_VERSION:=5.2
+PKG_VERSION:=5.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://fping.org/dist
-PKG_HASH:=a7692d10d73fb0bb76e1f7459aa7f19bbcdbfc5adbedef02f468974b18b0e42f
+PKG_HASH:=d57bd0141aea082e3adfc198bfc3db5dfd12a7014c7c2655e97f61cd54901d0e
 
 PKG_MAINTAINER:=Nikil Mehta <nikil.mehta@gmail.com>
 PKG_LICENSE:=BSD-4-Clause

--- a/net/fping/test.sh
+++ b/net/fping/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+"$1" -v 2>&1 | grep "$PKG_VERSION"


### PR DESCRIPTION
Maintainer: @nikil
Compile tested: OpenWrt 24.10.1 r28597-0425664679
Run tested: OpenWrt 24.10.1 r28597-0425664679

Description:

- update to version 5.3
- added test.sh file for ci testing

Fixes #26223 
