### PR TITLE
openthread-br: fix build on GCC 14

### DIFF
--- a/net/openthread-br/Makefile
+++ b/net/openthread-br/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openthread-br
 PKG_SOURCE_DATE:=2024-11-20
 PKG_SOURCE_VERSION:=bd7bc77742920eba3b3801a410c3eba3372c98bb
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://github.com/openthread/ot-br-posix.git

--- a/net/openthread-br/patches/100-fix-gcc14-build.patch
+++ b/net/openthread-br/patches/100-fix-gcc14-build.patch
@@ -1,0 +1,11 @@
+--- a/third_party/openthread/repo/third_party/mbedtls/repo/library/common.h
++++ b/third_party/openthread/repo/third_party/mbedtls/repo/library/common.h
+@@ -199,7 +199,7 @@ static inline void mbedtls_xor(unsigned
+         uint8x16_t x = veorq_u8(v1, v2);
+         vst1q_u8(r + i, x);
+     }
+-#if defined(__IAR_SYSTEMS_ICC__)
++#if defined(__IAR_SYSTEMS_ICC__) || (defined(MBEDTLS_COMPILER_IS_GCC) && MBEDTLS_GCC_VERSION >= 140100)
+     /* This if statement helps some compilers (e.g., IAR) optimise out the byte-by-byte tail case
+      * where n is a constant multiple of 16.
+      * For other compilers (e.g. recent gcc and clang) it makes no difference if n is a compile-time


### PR DESCRIPTION
Maintainer: @stintel
Compile tested: mediatek/filogic
Run tested: none

Description:
This patch is taken from openwrt/openwrt@a41747ac8e82 ("mbedtls: fix build on GCC 14").
Fixes: https://github.com/openwrt/packages/issues/26570
