### PR TITLE
named: /var/run/named isn't being created with correct permissions

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.20.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>

--- a/net/bind/files/named.init
+++ b/net/bind/files/named.init
@@ -13,6 +13,7 @@ named_options_file=/etc/bind/named-rndc.conf
 rndc_conf_file=/etc/bind/rndc.conf
 pid_file=/var/run/named/named.pid
 
+rundir=$(dirname $pid_file)
 logdir=/var/log/named/
 cachedir=/var/cache/bind
 libdir=/var/lib/bind
@@ -21,7 +22,7 @@ dyndir=/tmp/bind
 conf_local_file=$dyndir/named.conf.local
 
 fix_perms() {
-    for dir in $libdir $logdir $cachedir $dyndir; do
+    for dir in $rundir $libdir $logdir $cachedir $dyndir; do
 	test -e "$dir" || {
             mkdir -p "$dir"
             chgrp bind "$dir"


### PR DESCRIPTION
It needs to be group writable or session.key can't be written once named drops privileges.

Maintainer: @nmeyerhans 
Compile tested: x86_64, generic, HEAD (7193539c98)
Run tested: same, installed on production router

Description:
