### PR TITLE
linuxptp: add config & init scripts for ptp4l and phc2sys

### DIFF
--- a/net/linuxptp/Makefile
+++ b/net/linuxptp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linuxptp
 PKG_VERSION:=4.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://downloads.nwtime.org/linuxptp/
@@ -38,6 +38,10 @@ define Package/linuxptp/description
  computers.
 endef
 
+define Package/linuxptp/conffiles
+/etc/config/linuxptp
+endef
+
 EXTRA_CFLAGS += -DHAVE_CLOCK_ADJTIME -DHAVE_POSIX_SPAWN -DHAVE_ONESTEP_SYNC
 
 MAKE_VARS += \
@@ -45,8 +49,25 @@ MAKE_VARS += \
 	KBUILD_OUTPUT="$(LINUX_DIR)" \
 	NO_AUTODETECT_SAD_MAC_LIB="y"
 
+# separate compile step for helper utility
+define Build/Compile/sysclock-discipline-check
+	$(TARGET_CC) $(TARGET_CFLAGS) -o $(PKG_BUILD_DIR)/sysclock-discipline-check $(CURDIR)/files/sysclock-discipline-check.c $(TARGET_LDFLAGS)
+endef
+
+# override/extend the default Build/Compile
+define Build/Compile
+	$(call Build/Compile/Default)
+	$(call Build/Compile/sysclock-discipline-check)
+endef
+
 define Package/linuxptp/install
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) $(CURDIR)/files/linuxptp.config $(1)/etc/config/linuxptp
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(CURDIR)/files/phc2sys.init $(1)/etc/init.d/phc2sys
+	$(INSTALL_BIN) $(CURDIR)/files/ptp4l.init $(1)/etc/init.d/ptp4l
 	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/sysclock-discipline-check $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hwstamp_ctl $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/phc2sys $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/phc_ctl $(1)/usr/sbin/

--- a/net/linuxptp/files/linuxptp.config
+++ b/net/linuxptp/files/linuxptp.config
@@ -1,0 +1,35 @@
+config ptp4l 'ptp4l' # configures the ptp4l daemon
+	#option role 'auto'			# role to use: 'auto' (default) - BMCA algo determines role
+						# 'client' - will never attempt to be a server
+						# 'server' - will never attempt to be a client
+
+	#option loglevel '6'			# Logging verbosity for ptp4l (0-7). 6=INFO (default), 7=DEBUG.
+
+	#option require_clock_sync '0'		# 0 - skip waiting for kernel to report clock is sync'd (default unless server)
+						# 1 - require clock-in-sync check before starting (default if server)
+
+	# For global lines in ptp4l.conf - Each item is one line like "key value" for the [global] section
+	#list global_opts 'clockClass 6'
+
+config ptp_interface # repeat multiple times for each interface ptp4l should work on
+	option interface 'lan'			# required - UCI's interface name, init-script looks up kernel ifname as needed
+	#option transport 'UDPv4'		# Network transport: UDPv4 (default), UDPv6, L2.
+	#option delay_mechanism 'E2E'		# PTP delay mechanism: E2E (End-to-End, default), P2P (Peer-to-Peer).
+
+	# For interface-specific sections in ptp4l.conf
+	#list interface_opts 'logSyncInterval -3'
+
+config phc2sys 'phc2sys' # configures the phc2sys daemon, which syncs either system clock from PHC in NIC (as a client, or vice versa as a server)
+	#option phc_device '/dev/ptp0'		# PTP Hardware Clock device
+						# User should verify this is the correct PHC for their PTP interface
+	# specifies clock sync'ing direction 	# 'phc_to_sys': PHC (sync'd by ptp4l) disciplines system clock (default unless ptp4l role is 'server')
+	#option sync_direction 'phc_to_sys'	# 'sys_to_phc': System clock disciplines PHC (default if ptp4l's role is 'server')
+
+	#option loglevel '5'			# Logging verbosity for phc2sys, 5 by default, 6 if stats_interval is set
+
+	#option stats_interval '0'		# Log status updates every N seconds (N defaults to 1 when -R param (by-default) is 1Hz).
+						# By default/if unset, log-level (above) will be set to 5 and these messages will not be seen
+
+	list extra_args ''			# For other phc2sys command line options.
+						# Example: list extra_args '-O 0'
+

--- a/net/linuxptp/files/phc2sys.init
+++ b/net/linuxptp/files/phc2sys.init
@@ -1,0 +1,69 @@
+#!/bin/sh /etc/rc.common
+# Init script for phc2sys from linuxptp
+
+START=55
+USE_PROCD=1
+PROG=/usr/sbin/phc2sys
+
+ID=phc2sys
+ID_PTP4L=ptp4l
+
+log() {
+	local loglvl=$1; shift; local msg="$*"
+	logger -t phc2sys-init -p daemon.$loglvl "$msg"
+}
+
+make_cmdline() {
+	local cfg=$1
+	local args dev dir loglvl quiet ptp4l_role stats_set syncdir wanted_stats=0
+
+	echo $PROG 
+
+	config_get dev $cfg "phc_device" "/dev/ptp0"
+	! [ -c "$dev" ] && { log crit "PHC device '$dev' not found!"; return 1; }
+
+	dir='phc_to_sys'
+	config_get ptp4l_role $ID_PTP4L "role" "auto" # fetch instead from ptp4l config
+	[ $ptp4l_role = "server" ] && dir='sys_to_phc'
+
+	config_get syncdir $cfg "sync_direction" "$dir"
+	if [ $syncdir = "phc_to_sys" ]; then
+		echo "-s $dev -w"
+	elif [ $syncdir = "sys_to_phc" ]; then
+		echo "-s CLOCK_REALTIME -c $dev -w -O 0"
+	else
+		log err "Invalid sync_direction '$syncdir'! valid values: 'sys_to_phc', 'phc_to_sys'"; return 1
+	fi
+
+	echo "-m"
+	echo "-q"
+
+	config_get stats_set $cfg "stats_interval" "0"
+	[ -n $stats_set ] && wanted_stats=1
+	[ $wanted_stats -eq 1 ] && [ $stats_set -ge 1 ] && echo "-u $stats_set"
+
+	config_get loglvl $cfg "loglvl" "5"
+	[ $wanted_stats -eq 1 ] && [ $stats_set -ge 1 ] && config_get loglvl $cfg "loglvl" "6"
+	echo "-l $loglvl"
+
+	config_list_foreach $cfg "extra_args" echo
+}
+
+start_service() {
+	local cmdline
+
+	config_load linuxptp
+
+	cmdline=$(make_cmdline $ID)
+	log info "Starting phc2sys: $cmdline"
+
+	procd_open_instance phc2sys
+	procd_set_param command $cmdline
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+stop_service() {
+	log info "phc2sys exitting (if running)."
+}

--- a/net/linuxptp/files/ptp4l.init
+++ b/net/linuxptp/files/ptp4l.init
@@ -1,0 +1,158 @@
+#!/bin/sh /etc/rc.common
+# Init script for ptp4l daemon, from linuxptp package
+
+START=45
+USE_PROCD=1
+
+PROG=/usr/sbin/ptp4l
+HELPER=/usr/sbin/sysclock-discipline-check
+CONFIGFILE=/var/etc/ptp4l.conf
+
+ID=ptp4l
+
+log() {
+	local loglvl=$1; shift; local msg="$*"
+	logger -t ptp4l-init -p daemon.$loglvl "$msg"
+}
+
+is_clock_disciplined() {
+	local output rc
+
+	if ! [ -x "$HELPER" ]; then
+		echo "Helper $HELPER not found or not executable." >&2
+		echo "Error: Clock sync helper tool missing." # This goes to stdout
+		return 2
+	fi
+
+	output=$($HELPER)
+	rc=$?
+	echo $output
+
+	[ $rc -eq 2 ] && log err "ERROR: $HELPER call unsuccessful (rc=$rc): $output"
+	return $rc
+}
+
+wait_disciplined() {
+	local check_msg interval is_synced=0 rc role
+
+	config_get role $ID "role" ""
+	config_get interval $ID "clock_sync_check_interval" "15"
+
+	log info "Preparing to start with role:$role -> first checking if system clock is disciplined (has been syncronized)..."
+	while [ $is_synced -eq 0 ]; do
+		check_msg=$(is_clock_disciplined); rc=$?
+
+		if [ $rc -eq 0 ]; then
+			is_synced=1
+			log info "sysclock-discipline-check: $check_msg. Continuing."
+			return 0
+		elif [ $rc -eq 1 ]; then
+			log info "sysclock-discipline-check: $check_msg. Waiting..."
+		else
+			log crit "Clock sync check FAILED: $check_msg."
+			log err "ptp4l will NOT start. Resolve issue, or set 'require_clock_sync' to 0"
+			return 1
+		fi
+		sleep $interval
+	done
+}
+
+handle_interface() {
+	local cfg=$1 delay_mechanism interface ifname transport
+
+	config_get interface $cfg "interface" ""
+	[ -z $interface ] && { log err "Required 'interface' option missing in 'ptp_interface' section"; exit 1; }
+
+	network_get_device ifname $interface
+	[ -z $ifname ] && { log err "Cannot resolve UCI interface '$interface' to kernel-compatible ifname."; exit 1; }
+
+	config_get transport $cfg "transport" "UDPv4"
+	config_get delay_mechanism $cfg "delay_mechanism" "E2E"
+
+	echo "" 
+	echo "[$ifname]"
+	[ $transport != "UDPv4" ] && echo "network_transport $transport"
+	[ $delay_mechanism != "E2E" ] && echo "delay_mechanism $delay_mechanism"
+	config_list_foreach $cfg "interface_opts" echo
+}
+
+handle_global() {
+	local cfg=$1 role
+
+	config_get role $cfg "role" "auto"
+
+	echo "[global]"
+
+	case "$role" in
+		server) printf "serverOnly 1\n";;
+		client) printf "clientOnly 1\n";;
+		auto) printf "";;
+		*) log err "Invalid role: $role! valid values: 'auto', 'client', 'server'"; return 1;;
+	esac
+
+	config_list_foreach $cfg "global_opts" echo
+}
+
+make_configfile() {
+	local cfg=$1 rc
+
+	. /lib/functions/network.sh
+
+	(
+		handle_global $cfg || exit 1
+		config_foreach handle_interface ptp_interface
+	) > "$CONFIGFILE"
+	rc=$? 
+
+	return $rc
+}
+
+make_cmdline() {
+	local cfg=$1 loglvl quiet 
+
+	config_get loglvl $cfg "loglvl" "6"
+
+	echo $PROG
+	echo "-l $loglvl"
+	echo "-f $CONFIGFILE"
+	echo "-m"
+	echo "-q"
+
+	config_list_foreach $cfg "extra_args" echo
+}
+
+start_service() {
+	local clocksync_wanted rc role should_have_disciplined_clock=0
+
+	config_load linuxptp
+
+	cmdline=$(make_cmdline $ID)
+
+	procd_open_instance "ptp4l"
+	procd_set_param command $cmdline
+	procd_set_param file $CONFIGFILE
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+
+	config_get role $ID "role" "auto"
+	[ $role = "server" ] && should_have_disciplined_clock=1
+	config_get_bool clocksync_wanted $ID "require_clock_sync" "$should_have_disciplined_clock"
+
+	if [ $clocksync_wanted = 1 ]; then
+		wait_disciplined || return 1
+	fi
+
+	make_configfile $ID; rc=$?
+	if [ $rc -ne 0 ] || [ ! -s $CONFIGFILE ]; then
+		 log err "Failed to generate $CONFIGFILE. Aborting."
+		 rm -f $CONFIGFILE
+		 return 1
+	fi
+
+	log info "Starting ptp4l: $cmdline"
+}
+
+stop_service() {
+	log info "ptp4l exitting (if running)"
+}

--- a/net/linuxptp/files/sysclock-discipline-check.c
+++ b/net/linuxptp/files/sysclock-discipline-check.c
@@ -1,0 +1,35 @@
+/*
+
+This is a helper utility command to query the kernel for status of the system clock.
+
+The kernel maintains internal flags and information about the state of CLOCK_REALTIME. This includes 
+whether the clock is currently being disciplined by a reliable external time source or if it is simply 
+free-running (or has just been roughly set).
+
+This helper utility is used to delay starting ptp4l until the kernel can confirm the clock is accurate.
+
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/timex.h> // For adjtimex() and struct timex, STA_UNSYNC
+
+int main() {
+    struct timex txc;
+
+    txc.modes = 0; // We are only reading, not setting any modes
+
+    if (adjtimex(&txc) < 0) {
+        perror("adjtimex failed");
+        return 2; // Error calling adjtimex
+    }
+
+    // STA_UNSYNC is defined in <sys/timex.h> (usually 0x0040)
+    if (txc.status & STA_UNSYNC) {
+        fprintf(stdout, "Clock status: 0x%04X (STA_UNSYNC is SET - Unsynchronized)\n", txc.status);
+        return 1;       // Exit code 1 for unsynchronized
+    } else {
+        fprintf(stdout, "Clock status: 0x%04X (STA_UNSYNC is CLEAR - Synchronized)\n", txc.status);
+        return 0;       // Exit code 0 for synchronized
+    }
+}


### PR DESCRIPTION
linuxptp: add config & init scripts for ptp4l and phc2sys

- config file for both phc2sys and ptp4l (still no support for timemaster daemon at the moment)
- new init script by default starts ptp4l in 'auto' role
- new init script for phc2sys (will set sync-direction based on ptp4l role set)
- added helper utility to help init-script be able to delay start of ptp4l when in 'server' role (acting as PTP-master on network) to ensure the kernel can confirm the clock has been externally disciplined (otherwise as typical openwrt-running systems lack an RTC, on boot-up their time often is quite off and would otherwise advertise this wildy off time.  The expectation is host uses ntp or chrony or something else similar, that would set time in the right ballpark first, tells the kernel the clock is disciplined, init script will detect this and continue to launch ptp4l afterwards (this check is skipped if in 'auto' or 'client' mode).

fixes issue #26546 

Signed-off-by: Aleks Mariusz <a+git-commit@alek.cx>