### PR TITLE
mbpoll: Modbus command line interface

### DIFF
--- a/utils/mbpoll/Makefile
+++ b/utils/mbpoll/Makefile
@@ -1,0 +1,37 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mbpoll
+PKG_VERSION:=1.5.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/epsilonrt/mbpoll/archive/refs/tags/v$(PKG_VERSION).tar.gz?
+PKG_HASH:=7d960cd4459b5f7c2412abc51aba93a20b6114fd75d1de412b1e540cfb63bfec
+
+PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/mbpoll
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Command line utility to communicate with Modbus slaves (RTU/TCP)
+  URL:=https://epsilonrt.fr/
+  DEPENDS:=+libmodbus
+endef
+
+define Package/mbpoll/description
+  mbpoll is a command line utility to communicate with Modbus slaves
+  (RTU/TCP). It can handle discrete inputs, binary outputs (coils),
+  input registers and write output registers (holding registers)
+endef
+
+define Package/mbpoll/install
+	$(INSTALL_DIR) $(1)/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/mbpoll $(1)/bin/
+endef
+
+$(eval $(call BuildPackage,mbpoll))


### PR DESCRIPTION
Maintainer: Jens Wagner <jens@wagner2013.de>
Compile tested: aarch64_cortex-a53, RPi3, 24.10.1
Run tested: mipsel_24kc, RT-AX53U, 24.10.0, via USB/RTU to Waveshare RTU Relais(B)

Description: mbpoll is a command line interface to Modbus RTU & TCP, it is based on libmodbus.

Supported functions:
- read discrete inputs
- read and write binary outputs (coil)
- read input registers
- read and write output registers (holding register)
