### PR TITLE
[openwrt-23.05] rust: update to 1.85.0

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
-PKG_VERSION:=1.84.0
+PKG_VERSION:=1.85.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
-PKG_HASH:=15cee7395b07ffde022060455b3140366ec3a12cbbea8f1ef2ff371a9cca51bf
+PKG_HASH:=2f4f3142ffb7c8402139cfa0796e24baaac8b9fd3f96b2deec3b94b4045c6a8a
 HOST_BUILD_DIR:=$(BUILD_DIR)/host/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>

--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
-PKG_VERSION:=1.81.0
+PKG_VERSION:=1.84.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
-PKG_HASH:=872448febdff32e50c3c90a7e15f9bb2db131d13c588fe9071b0ed88837ccfa7
+PKG_HASH:=15cee7395b07ffde022060455b3140366ec3a12cbbea8f1ef2ff371a9cca51bf
 HOST_BUILD_DIR:=$(BUILD_DIR)/host/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>

--- a/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
+++ b/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Update xz2 and use it static
 
 --- a/src/bootstrap/Cargo.toml
 +++ b/src/bootstrap/Cargo.toml
-@@ -60,7 +60,7 @@ tar = "0.4"
+@@ -59,7 +59,7 @@ tar = "0.4"
  termcolor = "1.4"
  toml = "0.5"
  walkdir = "2.4"
@@ -17,4 +17,4 @@ Subject: [PATCH] Update xz2 and use it static
 +xz2 = { version = "0.1", features = ["static"] }
  
  # Dependencies needed by the build-metrics feature
- sysinfo = { version = "0.30", default-features = false, optional = true }
+ sysinfo = { version = "0.33.0", default-features = false, optional = true, features = ["system"] }

--- a/net/netavark/Makefile
+++ b/net/netavark/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netavark
 PKG_VERSION:=1.9.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containers/netavark/tar.gz/v$(PKG_VERSION)?
@@ -39,10 +39,6 @@ endef
 
 CARGO_PKG_VARS += \
 	PROTOC=$(STAGING_DIR_HOSTPKG)/bin/protoc
-
-define Build/Compile
-	$(call Build/Compile/Cargo,,--locked)
-endef
 
 define Package/netavark/install
 	$(INSTALL_DIR) $(1)/etc/config $(1)/usr/lib/podman


### PR DESCRIPTION
Maintainer: @lu-zero
Compile tested: rockchip/armv8, tested with bottom and netavark
Run tested: nanopi-r5c (bottom)

Description:
Update rust to 1.85.0

Fixes: #26582
