### PR TITLE
netatop: patch for removal of hardcoded make

### DIFF
--- a/admin/netatop/patches/020-makefile-make.patch
+++ b/admin/netatop/patches/020-makefile-make.patch
@@ -1,0 +1,12 @@
+diff -ur a/module/Makefile b/module/Makefile
+--- a/module/Makefile	2020-04-28 11:31:23
++++ b/module/Makefile	2025-05-29 09:20:28
+@@ -7,7 +7,7 @@
+ 
+ $(MYMODULE).ko: $(MYMODULE).c 
+ 		echo start the make
+-		make -C $(KERNDIR) M=$(THISDIR) modules
++		$(MAKE) -C $(KERNDIR) M=$(THISDIR) modules
+ 
+ clean:
+ 	rm -f *.o *.ko


### PR DESCRIPTION
Maintainer: Toni Uhlig <matzeton[at]googlemail.com>
Compile tested: Darwin 24.5.0
Run tested: -

Description: In `module/Makefile` on the aforementioned package includes a hardcoded make call in `module/Makefile:L10`: `make -C $(KERNDIR) M=$(THISDIR) modules `.

Maybe this should go to upstream??

Anyway, this PR includes a patch that fixes the issue

Thanks!