### PR TITLE
bogofilter: update to 1.3.0.rc1

### DIFF
--- a/mail/bogofilter/Makefile
+++ b/mail/bogofilter/Makefile
@@ -8,17 +8,26 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bogofilter
-PKG_VERSION:=1.2.5
+PKG_VERSION:=1.3.0_rc1
+# Drop and replace all uses below with PKG_VERSION upon final 1.3.0 release:
+PKG_VERSION2:=1.3.0.rc1
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:bogofilter:bogofilter
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=@SF/project/bogofilter/bogofilter-stable/
-PKG_HASH:=3248a1373bff552c500834adbea4b6caee04224516ae581fb25a4c6a6dee89ea
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION2).tar.bz2
+PKG_SOURCE_URL:=https://gitlab.com/bogofilter/bogofilter/-/archive/$(PKG_NAME)-$(PKG_VERSION2)
+PKG_HASH:=8d01dccaa7cac73ae88cc9d00ec28e5885589bd4413306c5671e9088d81bc9c8
+# Source tarball named as indicated (double PKG_NAME), and directory therein
+# follows the same name. Set PKG_BUILD_DIR here and MAKE_PATH,
+# PKG_AUTOMAKE_PATHS, and PKG_BUILD_DIR below.
+MAKE_PATH:=bogofilter
+PKG_AUTOMAKE_PATHS:=$(MAKE_PATH)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION2)
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
@@ -27,7 +36,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/bogofilter
   SECTION:=mail
   CATEGORY:=Mail
-  DEPENDS:=+libdb47
+  DEPENDS:=+libsqlite3
   TITLE:=bogofilter
   MAINTAINER:=W. Michael Petullo <mike@flyn.org>
   URL:=http://bogofilter.sourceforge.net/
@@ -37,9 +46,12 @@ define Package/bogofilter/description
 	Bogofilter is a fast Bayesian spam filter
 endef
 
+CONFIGURE_PATH:=bogofilter
+MAKE_PATH:=bogofilter
+PKG_AUTOMAKE_PATHS:=$(MAKE_PATH)
+
 CONFIGURE_ARGS += \
-	--disable-unicode \
-	--with-libdb-prefix=$(STAGING_DIR) \
+	--with-database=sqlite3 \
 	--with-included-gsl
 
 define Package/bogofilter/conffiles
@@ -50,7 +62,7 @@ define Package/bogofilter/install
 	$(INSTALL_DIR)  $(1)/etc/ \
                         $(1)/usr/bin \
                         $(1)/usr/sbin
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/bogofilter.cf.example $(1)/etc/bogofilter.cf
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/$(MAKE_PATH)/bogofilter.cf.example $(1)/etc/bogofilter.cf
 	$(INSTALL_BIN) ./files/postfix-bogofilter $(1)/usr/sbin/postfix-bogofilter
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/bf_compact $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/bf_copy $(1)/usr/bin/

--- a/mail/bogofilter/patches/010-no-docs.patch
+++ b/mail/bogofilter/patches/010-no-docs.patch
@@ -1,0 +1,11 @@
+--- a/bogofilter/Makefile.am
++++ b/bogofilter/Makefile.am
+@@ -4,7 +4,7 @@ AUTOMAKE_OPTIONS =
+ # search path for m4 macros
+ ACLOCAL_AMFLAGS = -I m4
+ 
+-SUBDIRS = src . doc
++SUBDIRS = src .
+ SYSCONFDIR = @sysconfdir@
+ 
+ # what to build


### PR DESCRIPTION
Maintainer: me

Description:

Update bogofilter package to 1.3.0.rc1. This is partially in response to https://github.com/openwrt/packages/pull/26400#issuecomment-2848152109.