### PR TITLE
mqttled: remove python-netifaces dependency

### DIFF
--- a/utils/mqttled/Makefile
+++ b/utils/mqttled/Makefile
@@ -28,7 +28,6 @@ define Package/mqttled
 	+python3-jsonpath-ng \
 	+python3-yaml \
 	+python3-schema \
-	+python3-netifaces \
 	+python3-logging \
 	+python3-urllib \
 	+python3-asyncio \


### PR DESCRIPTION
Remove python-netifaces dependency. This package was removed: https://github.com/openwrt/packages/commit/8bb5a41cdfd00465527ad30a8c04c4629086985f

**Fix:** WARNING: Makefile 'package/feeds/packages/mqttled/Makefile' has a dependency on 'python3-netifaces', which does not exist