### PR TITLE
tio:  update to version 3.9

### DIFF
--- a/utils/tio/Makefile
+++ b/utils/tio/Makefile
@@ -8,16 +8,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tio
-PKG_VERSION:=2.7
+PKG_VERSION:=3.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/tio/tio/releases/download/v$(PKG_VERSION)
-PKG_HASH:=bf8fe434848c2c1b6540af0b42503c986068176ddc1a988cf02e521e7de5daa5
+PKG_HASH:=06fe0c22e3e75274643c017928fbc85e86589bc1acd515d92f98eecd4bbab11b
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_FLAGS:=no-mips16
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/meson.mk
@@ -28,12 +30,16 @@ define Package/tio
   SUBMENU:=Terminal
   TITLE:=A simple TTY terminal I/O application
   URL:=https://tio.github.io/
-  DEPENDS:=+libinih
+  DEPENDS:=+lua +glib2
 endef
 
 define Package/tio/description
   A small and simple TTY terminal I/O application
 endef
+
+MESON_ARGS += \
+	-Dbashcompletiondir=no \
+	-Dinstall_man_pages=false
 
 define Package/tio/install
 	$(INSTALL_DIR) $(1)/usr/sbin

--- a/utils/tio/test.sh
+++ b/utils/tio/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+tio --version | grep "$PKG_VERSION"


### PR DESCRIPTION
Maintainer: nobody
Compile tested: OpenWrt 24.10.1 r28597-0425664679
Run tested: OpenWrt 24.10.1 r28597-0425664679

Description:

* update to version 3.9
* added lua as build dependency
* added glib2 as build dependency
* removed libinih as dependency
* disable bash-completion and man pages
* added test.sh file for ci testing

