### PR TITLE
eza: update to 0.21.4

### DIFF
--- a/utils/eza/Makefile
+++ b/utils/eza/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=eza
-PKG_VERSION:=0.21.0
+PKG_VERSION:=0.21.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eza-community/eza/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=885ae7a12c7ed68dd3a7cca76d4e8beaa100c9e9d6b7ad136b5bb6785e16b28b
+PKG_HASH:=dbe04448febef15b144e86551db633146864f4afb272f96c4d586e0bc8284ffb
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=EUPL-1.2


### PR DESCRIPTION
Maintainer: me
Compile tested: Banana Pi R4 (mediatek/filogic,aarch64), OpenWrt latest snapshot
Run tested: Banana Pi R4 (mediatek/filogic,aarch64), OpenWrt latest snapshot, basic run test

[release notes]
0.21.1: https://github.com/eza-community/eza/releases/tag/v0.21.1
0.21.2: https://github.com/eza-community/eza/releases/tag/v0.21.2
0.21.3: https://github.com/eza-community/eza/releases/tag/v0.21.3
0.21.4: https://github.com/eza-community/eza/releases/tag/v0.21.4

