### PR TITLE
rust: Make sure bootstrap does not try to guess it is in the upstream CI environment

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -89,6 +89,7 @@ define Host/Compile
 	CARGO_HOME=$(CARGO_HOME) \
 	TARGET_CFLAGS="$(TARGET_CFLAGS)" \
 	$(PYTHON) $(HOST_BUILD_DIR)/x.py \
+		--ci false \
 		--build-dir $(HOST_BUILD_DIR)/build \
 		dist build-manifest rustc rust-std cargo llvm-tools rust-src
 endef


### PR DESCRIPTION
Fixes #26623

Maintainer: me 
Compile tested: aarch64
Run tested: NA
Description:
