### PR TITLE
unbound: bring back the service to the startup menu

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.23.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound

--- a/net/unbound/files/unbound.init
+++ b/net/unbound/files/unbound.init
@@ -1,15 +1,7 @@
 #!/bin/sh /etc/rc.common
-##############################################################################
-#
 # Copyright (C) 2016 Michael Hanselmann, Eric Luehrsen
-#
-##############################################################################
-#
 # This init script is just the entry point for Unbound UCI.
 #
-##############################################################################
-
-# while useful (sh)ellcheck is pedantic and noisy
 # shellcheck disable=1091,2002,2004,2034,2039,2086,2094,2140,2154,2155
 
 START=19


### PR DESCRIPTION

Maintainer: @EricLuehrsen 
Compile tested: n/a, just comment removal in init script
Run tested: Bananapi BPI-R3, mediatek/filogic, OpenWrt SNAPSHOT r29909-ba674fea40

Description:
* trivial fix for #25963 to workaround the current "10 line parsing limit"
