### PR TITLE
gdbm: bump to 1.25 and include fix for GCC 15.1

### DIFF
--- a/libs/gdbm/Makefile
+++ b/libs/gdbm/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gdbm
-PKG_VERSION:=1.23
+PKG_VERSION:=1.25
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/gdbm
-PKG_HASH:=74b1081d21fff13ae4bd7c16e5d6e504a4c26f7cde1dca0d963a484174bbcacd
+PKG_HASH:=d02db3c5926ed877f8817b81cd1f92f53ef74ca8c6db543fbba0271b34f393ec
 
 PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>
 PKG_LICENSE:=GPL-3.0-or-later

--- a/libs/gdbm/patches/100-Add-missing-include.patch
+++ b/libs/gdbm/patches/100-Add-missing-include.patch
@@ -1,0 +1,20 @@
+From 39ef0347f78ef691c9ad815360198f577043ce4c Mon Sep 17 00:00:00 2001
+From: Sergey Poznyakoff <gray@gnu.org>
+Date: Mon, 24 Mar 2025 07:56:00 +0200
+Subject: [PATCH] Add missing include
+
+* tools/gdbmapp.h: Include sys/types.h
+---
+ tools/gdbmapp.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/tools/gdbmapp.h
++++ b/tools/gdbmapp.h
+@@ -16,6 +16,7 @@
+ 
+ #include <stdlib.h>
+ #include <stdarg.h>
++#include <sys/types.h>
+ #include "gettext.h"
+ #ifdef HAVE_LOCALE_H
+ # include <locale.h>


### PR DESCRIPTION
Added a patch to fix build for GCC 15.1

Maintainer: @Naoir 