### PR TITLE
bc: fix building with GCC 15.1

### DIFF
--- a/utils/bc/Makefile
+++ b/utils/bc/Makefile
@@ -21,6 +21,8 @@ PKG_LICENSE_FILES:=COPYING
 PKG_FIXUP:=autoreconf
 PKG_CPE_ID:=cpe:/a:gnu:bc
 
+TARGET_CFLAGS += $(FPIC) -std=gnu17
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/bc/Default


### PR DESCRIPTION
Force the default C version to -std=gnu17.

Maintainer: @krant 