### PR TITLE
samba4: fix building with GCC 15.1

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -128,7 +128,7 @@ define Package/samba4-utils/description
   Utilities collection
 endef
 
-TARGET_CFLAGS += $(FPIC)
+TARGET_CFLAGS += $(FPIC) -std=gnu17
 TARGET_LDFLAGS += -Wl,--as-needed
 # dont mess with sambas private rpath!
 RSTRIP:=:


### PR DESCRIPTION
Force the default C version to -std=gnu17.

Maintainer: