### PR TITLE
yt-dlp: bump to 2025.05.22

### DIFF
--- a/multimedia/yt-dlp/Makefile
+++ b/multimedia/yt-dlp/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yt-dlp
-PKG_VERSION:=2025.4.30
+PKG_VERSION:=2025.5.22
 PKG_RELEASE:=1
 
 PYPI_NAME:=yt-dlp
-PKG_HASH:=d01367d0c3ae94e35cb1e2eccb7a7c70e181c4ca448f4ee2374f26489d263603
+PKG_HASH:=ea73854c5dabc124f29a35a8fae9bc5d422ef3231bebeea2bdfa82ac191a9c29
 PYPI_SOURCE_NAME:=yt_dlp
 
 PKG_MAINTAINER:=George Sapkin <george@sapk.in>


### PR DESCRIPTION
Maintainer: me
Compile tested: x86/64, 24.10.1
Run tested: x86/64, 24.10.0, QEMU

- yt-dlp reports the correct version
- tested downloading a few videos

Description:

This is a backport of #26599 to 24.10. Commits marked as cherry-picked.