### PR TITLE
[24.10] perl: Modules for IO::Async

### DIFF
--- a/lang/perl-class-inspector/Makefile
+++ b/lang/perl-class-inspector/Makefile
@@ -1,0 +1,48 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-class-inspector
+PKG_VERSION:=1.36
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=Class-Inspector
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=cc295d23a472687c24489d58226ead23b9fdc2588e522f0b5f0747741700694e
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
+PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-class-inspector
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Get information about a class and its structure
+  URL:=https://metacpan.org/pod/Class::Inspector
+  DEPENDS:=perl +perlbase-essential +perlbase-file +perlbase-base
+endef
+
+define Package/perl-class-inspector/description
+  Class::Inspector allows you to get information about a loaded class.
+  While most or all of this information can be found in other ways,
+  Class::Inspector provides an easier interface to this information.
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-class-inspector/install
+	$(call perlmod/Install,$(1),Class)
+endef
+
+
+$(eval $(call BuildPackage,perl-class-inspector))

--- a/lang/perl-file-sharedir/Makefile
+++ b/lang/perl-file-sharedir/Makefile
@@ -1,0 +1,47 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-file-sharedir
+PKG_VERSION:=1.118
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=File-ShareDir
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/R/RE/REHSACK/
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=3bb2a20ba35df958dc0a4f2306fc05d903d8b8c4de3c8beefce17739d281c958
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
+PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-file-sharedir
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Locate per-dist and per-module shared files
+  URL:=https://metacpan.org/pod/File::ShareDir
+  DEPENDS:=perl +perlbase-essential +perlbase-file +perl-class-inspector
+endef
+
+define Package/perl-file-sharedir/description
+  File::ShareDir locates shared files distributed with a Perl distribution
+  or module.
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-file-sharedir/install
+	$(call perlmod/Install,$(1),File)
+endef
+
+
+$(eval $(call BuildPackage,perl-file-sharedir))

--- a/lang/perl-future-asyncawait/Makefile
+++ b/lang/perl-future-asyncawait/Makefile
@@ -1,0 +1,48 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-future-asyncawait
+PKG_VERSION:=0.70
+PKG_RELEASE:=2
+
+PKG_SOURCE_NAME:=Future-AsyncAwait
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/P/PE/PEVANS
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=842899049c977fb2326a8096926441e57beca912bb2b4918d5ce090df4d4a6b7
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
+PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-future-asyncawait
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Deferred subroutine syntax for futures in Perl
+  URL:=https://metacpan.org/pod/Future::AsyncAwait
+  DEPENDS:=perl +perl-future +perl-xs-parse-keyword +perl-xs-parse-sublike +perlbase-xsloader +perlbase-scalar
+endef
+
+define Package/perl-future-asyncawait/description
+  This module provides syntax for deferring and resuming subroutines while
+  waiting for Futures to complete.
+  The new syntax takes the form of two new keywords, async and await.
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-future-asyncawait/install
+	$(call perlmod/Install,$(1),Future auto/Future)
+endef
+
+
+$(eval $(call BuildPackage,perl-future-asyncawait))

--- a/lang/perl-future-asyncawait/src/Makefile.PL
+++ b/lang/perl-future-asyncawait/src/Makefile.PL
@@ -1,0 +1,19 @@
+require 5.016;
+use ExtUtils::MakeMaker;
+WriteMakefile
+(
+  'NAME' => 'Future::AsyncAwait',
+  'VERSION_FROM' => 'lib/Future/AsyncAwait.pm',
+  'PREREQ_PM' => {
+                   'Future' => '0.50',
+                   'XS::Parse::Keyword' => '0.13',
+                   'XS::Parse::Sublike' => '0.31',
+                 },
+  'INSTALLDIRS' => 'site',
+  'EXE_FILES' => [],
+  'PL_FILES' => {},
+  'INC' => '-I. -Ishare/include -Ihax -I'.$ENV{STAGING_PREFIX}.'/share/perl/include',
+  'XSMULTI' => 1,
+)
+;
+

--- a/lang/perl-future/Makefile
+++ b/lang/perl-future/Makefile
@@ -1,0 +1,48 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-future
+PKG_VERSION:=0.51
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=Future
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/P/PE/PEVANS
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=563ce37383a000ecfd6b7942dd0f4b9fafb2b2c45e0b731029361f261c2f4a36
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
+PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-future
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Future represents an operation awaiting completion
+  URL:=https://metacpan.org/pod/Future
+  DEPENDS:=perl +perlbase-essential +perlbase-b +perlbase-time +perlbase-list
+endef
+
+define Package/perl-future/description
+  A Future object represents an operation that is currently in progress,
+  or has recently completed. It can be used in a variety of ways to manage
+  the flow of control, and data, through an asynchronous program.
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-future/install
+	$(call perlmod/Install,$(1),Future.pm Future)
+endef
+
+
+$(eval $(call BuildPackage,perl-future))

--- a/lang/perl-future/src/Makefile.PL
+++ b/lang/perl-future/src/Makefile.PL
@@ -1,0 +1,17 @@
+require 5.014;
+use ExtUtils::MakeMaker;
+WriteMakefile
+(
+  'NAME' => 'Future',
+  'VERSION_FROM' => 'lib/Future.pm',
+  'PREREQ_PM' => {
+                   'Carp' => '1.25',
+                   'List::Util' => '1.29',
+                   'Time::HiRes' => 0,
+                 },
+  'INSTALLDIRS' => 'site',
+  'EXE_FILES' => [],
+  'PL_FILES' => {}
+)
+;
+

--- a/lang/perl-io-async-ssl/Makefile
+++ b/lang/perl-io-async-ssl/Makefile
@@ -1,0 +1,46 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-io-async-ssl
+PKG_VERSION:=0.25
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=IO-Async-SSL
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/P/PE/PEVANS
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=4def485db1eff4e139b4b5912202c0fd61c3aed2cec35bd5ab8bf7bbd83f5a75
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
+PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-io-async-ssl
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=SSL/TLS with IO::Async
+  URL:=https://metacpan.org/pod/IO::Async::SSL
+  DEPENDS:=perl +perlbase-io +perl-future +perl-io-async
+endef
+
+define Package/perl-io-async-ssl/description
+  This module extends existing IO::Async classes with extra methods to
+  allow the use of SSL or TLS-based connections using IO::Socket::SSL.
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-io-async-ssl/install
+	$(call perlmod/Install,$(1),IO)
+endef
+
+$(eval $(call BuildPackage,perl-io-async-ssl))

--- a/lang/perl-io-async-ssl/src/Makefile.PL
+++ b/lang/perl-io-async-ssl/src/Makefile.PL
@@ -1,0 +1,20 @@
+use 5.014;
+use ExtUtils::MakeMaker;
+WriteMakefile
+(
+  'NAME' => 'IO::Async::SSL',
+  'VERSION_FROM' => 'lib/IO/Async/SSL.pm',
+  'PREREQ_PM' => {
+                   'Future' => '0.33',
+                   'IO::Async::Loop' => '0.66',
+                   'IO::Async::Handle' => '0.29',
+                   'IO::Async::Protocol::Stream' => 0,
+                   'IO::Async::Stream' => '0.59',
+                   'IO::Socket::SSL' => '2.003',
+                 },
+  'INSTALLDIRS' => 'site',
+  'EXE_FILES' => [],
+  'PL_FILES' => {}
+)
+;
+

--- a/lang/perl-io-async/Makefile
+++ b/lang/perl-io-async/Makefile
@@ -1,0 +1,47 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-io-async
+PKG_VERSION:=0.804
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=IO-Async
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/P/PE/PEVANS
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=90615432918164cd6f9e6dc2521195a4589606ffd017e03d5aa97f407d39c494
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
+PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-io-async
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Asynchronous event-driven programming for Perl
+  URL:=https://metacpan.org/pod/Net::SSLeay
+  DEPENDS:=perl +perlbase-essential +perlbase-file +perlbase-io +perlbase-list +perlbase-socket +perlbase-storable +perlbase-time +perlbase-encode +perlbase-experimental +perl-future +perl-struct-dumb
+endef
+
+define Package/perl-io-async/description
+  This collection of modules allows programs to be written that perform
+  asynchronous filehandle IO operations.
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-io-async/install
+	$(call perlmod/Install,$(1),IO Future)
+endef
+
+$(eval $(call BuildPackage,perl-io-async))
+

--- a/lang/perl-io-async/src/Makefile.PL
+++ b/lang/perl-io-async/src/Makefile.PL
@@ -1,0 +1,24 @@
+require 5.014;
+use ExtUtils::MakeMaker;
+WriteMakefile
+(
+  'NAME' => 'IO::Async',
+  'VERSION_FROM' => 'lib/IO/Async.pm',
+  'PREREQ_PM' => {
+                   'Future' => '0.44',
+                   'Future::Utils' => '0.18',
+                   'Exporter' => '5.57',
+                   'File::stat' => 0,
+                   'IO::Poll' => 0,
+                   'List::Util' => 0,
+                   'Socket' => '2.007',
+                   'Storable' => 0,
+                   'Struct::Dumb' => 0,
+                   'Time::HiRes' => 0,
+                 },
+  'INSTALLDIRS' => 'site',
+  'EXE_FILES' => [],
+  'PL_FILES' => {}
+)
+;
+

--- a/lang/perl-io-socket-ssl/Makefile
+++ b/lang/perl-io-socket-ssl/Makefile
@@ -1,0 +1,48 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-io-socket-ssl
+PKG_VERSION:=2.089
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=IO-Socket-SSL
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/S/SU/SULLR
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=f683112c1642967e9149f51ad553eccd017833b2f22eb23a9055609d2e3a14d1
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
+PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-io-socket-ssl
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Perl SSL sockets with IO::Socket interface
+  URL:=https://metacpan.org/pod/Net::SSLeay
+  DEPENDS:=perl +perlbase-autoloader +perlbase-io +perlbase-list +perl-net-ssleay
+endef
+
+define Package/perl-io-socket-ssl/description
+  IO::Socket::SSL makes using SSL/TLS much easier by wrapping the
+  functionality into the familiar IO::Socket interface and providing
+  secure defaults whenever possible.
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-io-socket-ssl/install
+	$(call perlmod/Install,$(1),IO)
+endef
+
+$(eval $(call BuildPackage,perl-io-socket-ssl))
+

--- a/lang/perl-metrics-any/Makefile
+++ b/lang/perl-metrics-any/Makefile
@@ -1,0 +1,45 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-metrics-any
+PKG_VERSION:=0.10
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=Metrics-Any
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/P/PE/PEVANS
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=a90eadf9c8af24a516bb9a1b67061f641853f90b8fee9ffc24d2bb9720e8b99b
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
+PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-metrics-any
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Abstract collection of monitoring metrics
+  URL:=https://metacpan.org/pod/Metrics::Any
+  DEPENDS:=perl +perlbase-list
+endef
+
+define Package/perl-metrics-any/description
+  Provides a central location for modules to report monitoring metrics.
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-metrics-any/install
+	$(call perlmod/Install,$(1),Metrics)
+endef
+
+$(eval $(call BuildPackage,perl-metrics-any))

--- a/lang/perl-metrics-any/src/Makefile.PL
+++ b/lang/perl-metrics-any/src/Makefile.PL
@@ -1,0 +1,15 @@
+use 5.014;
+use ExtUtils::MakeMaker;
+WriteMakefile
+(
+  'NAME' => 'Metrics::Any',
+  'VERSION_FROM' => 'lib/Metrics/Any.pm',
+  'PREREQ_PM' => {
+                   'List::Util' => '1.29',
+                 },
+  'INSTALLDIRS' => 'site',
+  'EXE_FILES' => [],
+  'PL_FILES' => {}
+)
+;
+

--- a/lang/perl-net-async-http/Makefile
+++ b/lang/perl-net-async-http/Makefile
@@ -1,0 +1,46 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-net-async-http
+PKG_VERSION:=0.50
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=Net-Async-HTTP
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/P/PE/PEVANS
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=92845b8ffdd2dc81decbe8a7b99203e4e34971de6624acb5c10aa9ff07885b87
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
+PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-net-async-http
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=HTTP with IO::Async
+  URL:=https://metacpan.org/pod/Net::Async::HTTP
+  DEPENDS:=perl +perlbase-list +perlbase-socket +perlbase-time +perl-future +perl-http-message +perl-io-async +perl-metrics-any +perl-struct-dumb +perl-uri
+endef
+
+define Package/perl-net-async-http/description
+  This object class implements an asynchronous HTTP user agent.
+  Similar to LWP::UserAgent, but for IO::Async.
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-net-async-http/install
+	$(call perlmod/Install,$(1),Net)
+endef
+
+$(eval $(call BuildPackage,perl-net-async-http))

--- a/lang/perl-net-async-http/src/Makefile.PL
+++ b/lang/perl-net-async-http/src/Makefile.PL
@@ -1,0 +1,28 @@
+use 5.014;
+use ExtUtils::MakeMaker;
+WriteMakefile
+(
+  'NAME' => 'Net::Async::HTTP',
+  'VERSION_FROM' => 'lib/Net/Async/HTTP.pm',
+  'PREREQ_PM' => {
+                   'Future' => '0.28',
+                   'Future::Utils' => '0.16',
+                   'HTTP::Request' => 0,
+                   'HTTP::Request::Common' => 0,
+                   'HTTP::Response' => 0,
+                   'IO::Async::Loop' => '0.59',
+                   'IO::Async::Stream' => '0.59',
+                   'IO::Async::Timer::Countdown' => 0,
+                   'List::Util' => "1.29",
+                   'Metrics::Any' => '0.05',
+                   'Socket' => '2.010',
+                   'Struct::Dumb' => '0.07',
+                   'Time::HiRes' => 0,
+                   'URI' => 0,
+                 },
+  'INSTALLDIRS' => 'site',
+  'EXE_FILES' => [],
+  'PL_FILES' => {}
+)
+;
+

--- a/lang/perl-net-dns-sec/Makefile
+++ b/lang/perl-net-dns-sec/Makefile
@@ -1,0 +1,45 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-net-dns-sec
+PKG_VERSION:=1.26
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=Net-DNS-SEC
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/N/NL/NLNETLABS
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=88592c65487fb7b4d05134f2f9c48e649a9cd533a8493c50189b649b4ea711a6
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-net-dns-sec
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=DNSSEC extensions to Net::DNS
+  URL:=https://metacpan.org/pod/Net::DNS::SEC
+  DEPENDS:=perl +perlbase-essential +perlbase-dynaloader +perlbase-file +perlbase-io +perlbase-mime +perl-net-dns +libopenssl
+endef
+
+define Package/perl-net-dns-sec/description
+  This module extends Net::DNS to support DNSSEC
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-net-dns-sec/install
+	$(call perlmod/Install,$(1),Net auto/Net)
+endef
+
+$(eval $(call BuildPackage,perl-net-dns-sec))

--- a/lang/perl-net-ssleay/Makefile
+++ b/lang/perl-net-ssleay/Makefile
@@ -1,0 +1,47 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-net-ssleay
+PKG_VERSION:=1.94
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=Net-SSLeay
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/C/CH/CHRISN
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=9d7be8a56d1bedda05c425306cc504ba134307e0c09bda4a788c98744ebcd95d
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
+PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-net-ssleay
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Perl bindings for OpenSSL and LibreSSL
+  URL:=https://metacpan.org/pod/Net::SSLeay
+  DEPENDS:=perl +perlbase-essential +perlbase-mime +libopenssl +zlib
+endef
+
+define Package/perl-net-ssleay/description
+  This module provides Perl bindings for libssl (an SSL/TLS API)
+  and libcrypto (a cryptography API).
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-net-ssleay/install
+	$(call perlmod/Install,$(1),Net auto/Net)
+endef
+
+$(eval $(call BuildPackage,perl-net-ssleay))
+

--- a/lang/perl-net-ssleay/patches/001-prefix.patch
+++ b/lang/perl-net-ssleay/patches/001-prefix.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.PL
++++ b/Makefile.PL
+@@ -12,6 +12,8 @@ use File::Spec::Functions qw(catfile);
+ use Symbol qw(gensym);
+ use Text::Wrap;
+ 
++$ENV{OPENSSL_PREFIX} = $ENV{STAGING_PREFIX};
++
+ # According to http://cpanwiki.grango.org/wiki/CPANAuthorNotes, the ideal
+ # behaviour to exhibit when a prerequisite does not exist is to use exit code 0
+ # to ensure smoke testers stop immediately without reporting a FAIL; in all

--- a/lang/perl-struct-dumb/Makefile
+++ b/lang/perl-struct-dumb/Makefile
@@ -1,0 +1,47 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-struct-dumb
+PKG_VERSION:=0.14
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=Struct-Dumb
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/P/PE/PEVANS
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=13c148536b10e28c6e0b4e132f29e4ca6e69b5749059c44157a27e84a5459436
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
+PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-struct-dumb
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Make simple lightweight record-like structures
+  URL:=https://metacpan.org/pod/Struct::Dumb
+  DEPENDS:=perl +perlbase-essential +perlbase-scalar
+endef
+
+define Package/perl-struct-dumb/description
+  Struct::Dumb creates record-like structure types,
+  similar to the struct keyword in C, C++ or Record in Pascal.
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-struct-dumb/install
+	$(call perlmod/Install,$(1),Struct)
+endef
+
+$(eval $(call BuildPackage,perl-struct-dumb))
+

--- a/lang/perl-struct-dumb/src/Makefile.PL
+++ b/lang/perl-struct-dumb/src/Makefile.PL
@@ -1,0 +1,15 @@
+require 5.014;
+use ExtUtils::MakeMaker;
+WriteMakefile
+(
+  'NAME' => 'Struct::Dumb',
+  'VERSION_FROM' => 'lib/Struct/Dumb.pm',
+  'PREREQ_PM' => {
+                   'Scalar::Util' => 0,
+                 },
+  'INSTALLDIRS' => 'site',
+  'EXE_FILES' => [],
+  'PL_FILES' => {}
+)
+;
+

--- a/lang/perl-xs-parse-keyword/Makefile
+++ b/lang/perl-xs-parse-keyword/Makefile
@@ -1,0 +1,53 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-xs-parse-keyword
+PKG_VERSION:=0.48
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=XS-Parse-Keyword
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/P/PE/PEVANS
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=857a070ba465ab5b89d4d8d36d92358edd66e5e7b4a91584611d85125ac9a9c7
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
+PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-xs-parse-keyword
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=XS functions to assist in parsing keyword syntax
+  URL:=https://metacpan.org/pod/XS::Parse::Keyword
+  DEPENDS:=perl +perlbase-essential +perlbase-xsloader
+endef
+
+define Package/perl-xs-parse-keyword/description
+  This module provides some XS functions to assist in writing syntax
+  modules that provide new Perl-visible syntax, primarily for authors
+  of keyword plugins using the PL_keyword_plugin hook mechanism.
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-xs-parse-keyword/install
+	$(call perlmod/Install,$(1),XS auto/XS)
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/share/perl/include
+	$(CP) $(PKG_BUILD_DIR)/share-infix/include/XSParseInfix.h $(1)/usr/share/perl/include/
+	$(CP) $(PKG_BUILD_DIR)/share-keyword/include/XSParseKeyword.h $(1)/usr/share/perl/include/
+endef
+
+$(eval $(call BuildPackage,perl-xs-parse-keyword))

--- a/lang/perl-xs-parse-keyword/src/Makefile.PL
+++ b/lang/perl-xs-parse-keyword/src/Makefile.PL
@@ -1,0 +1,29 @@
+require 5.014;
+use ExtUtils::MakeMaker;
+if ( ! -e "Keyword.xs" ) {
+  die $! unless open SRC, "<lib/XS/Parse/Keyword.xs";
+  my $xs = join "", <SRC>;
+  close SRC;
+  die $! unless open DST, ">Keyword.xs";
+  print DST $xs;
+  close DST;
+}
+WriteMakefile
+(
+  'NAME' => 'XS::Parse::Keyword',
+  'VERSION_FROM' => 'lib/XS/Parse/Keyword.pm',
+  'PREREQ_PM' => {
+                   'ExtUtils::CBuilder' => 0,
+                   'ExtUtils::ParseXS' => '3.16',
+                   'File::ShareDir' => '1.00'
+                 },
+  'INSTALLDIRS' => 'site',
+  'EXE_FILES' => [],
+  'PL_FILES' => {},
+  'INC' => '-I. -I./hax -I./src -Ishare-infix/include -Ishare-keyword/include',
+  'C' => ["Keyword.c", glob('src/*.c')],
+  'OBJECT' =>'$(O_FILES)',
+  'DEFINE' =>'-o $@',
+)
+;
+

--- a/lang/perl-xs-parse-sublike/Makefile
+++ b/lang/perl-xs-parse-sublike/Makefile
@@ -1,0 +1,52 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-xs-parse-sublike
+PKG_VERSION:=0.37
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=XS-Parse-Sublike
+PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/P/PE/PEVANS
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=736528c888ea7b6a6191011e5d5a7824ec38a5620507de6ef45e4bc6e1cf0da9
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
+PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-xs-parse-sublike
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=XS functions to assist in parsing sub-like syntax
+  URL:=https://metacpan.org/pod/XS::Parse::Sublike
+  DEPENDS:=perl +perlbase-essential +perlbase-xsloader
+endef
+
+define Package/perl-xs-parse-sublike/description
+  This module provides some XS functions to assist in writing parsers for
+  sub-like syntax, primarily for authors of keyword plugins using the
+  PL_keyword_plugin hook mechanism.
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-xs-parse-sublike/install
+	$(call perlmod/Install,$(1),Sublike XS auto/XS)
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/share/perl/include
+	$(CP) $(PKG_BUILD_DIR)/share/include/XSParseSublike.h $(1)/usr/share/perl/include/
+endef
+
+$(eval $(call BuildPackage,perl-xs-parse-sublike))

--- a/lang/perl-xs-parse-sublike/src/Makefile.PL
+++ b/lang/perl-xs-parse-sublike/src/Makefile.PL
@@ -1,0 +1,28 @@
+require 5.016;
+use ExtUtils::MakeMaker;
+if ( ! -e "Sublike.xs" ) {
+  die $! unless open SRC, "<lib/XS/Parse/Sublike.xs";
+  my $xs = join "", <SRC>;
+  close SRC;
+  die $! unless open DST, ">Sublike.xs";
+  print DST $xs;
+  close DST;
+}
+WriteMakefile
+(
+  'NAME' => 'XS::Parse::Sublike',
+  'VERSION_FROM' => 'lib/XS/Parse/Sublike.pm',
+  'PREREQ_PM' => {
+                   'ExtUtils::CBuilder' => 0,
+                   'File::ShareDir' => '1.00'
+                 },
+  'INSTALLDIRS' => 'site',
+  'EXE_FILES' => [],
+  'PL_FILES' => {},
+  'INC' => '-I. -Ishare/include -Iinclude -Ihax',
+  'C' => ["Sublike.c", glob('src/*.c')],
+  'OBJECT' =>'$(O_FILES)',
+  'DEFINE' =>'-o $@',
+)
+;
+


### PR DESCRIPTION
Backport of Perl modules related to IO::Async,
Cherry picked from commits:
70f8dd8aa3c1729c0574d11e10f0822d3d101324, c30cec814486b393e9d02d4be2132c007fd1b516, c4136bbc1afd56373897b4feb4ac46fca36b29be, f9aada2b276cb86be07e6bf5718b22d674568c08, e74e9710bc47deaa2f2da2085efa25995f35e080, 594657b149d7c4f096cee24efd0559ca1a1e6fe3, 62e5e1f82f6851345c2b2956679c50eeba1aa98d, 3a2ce3480c6eea241803468d10c92c40c55153a8, 8a235d67b6017392c9df319fe4ee6429ba0f9279, 3ea60604f1a6d3d53d2b35cf364ad67edf7f9682, c10d0d2c6660539afd136bbb2bffaba94aed29d8, fa6c3dbe328c42173b50543e79803990163da457, e35fe955d8ba05dc5578c6ed714aab6a4f67159c, e168d9fdfb350953c521cfcbc03a4b1dd06cf01a, 71581bf947c91c02f52b48a2e9ddbd1bd411a27d, 3dd50523900521543d791179b25e53226e588503, 1bc3bf261b249dd832a631f65639a006391f7ca1, bf5002488f30f4bd1f1ce909a1e4190f1cfe2f23, d824ce3137e8b3eb29294cd50213ad98bbef3015, ec90c9fe909d2930650e298db9c7f1862a13a7e3, 9cab02e71fe97ff10efcab8a35fbc285c379ee0a, 79725e5c616b51f809eeaff37b5a24bae7d3552c, c46536d76fd0e01a79de8e8a6726cca90259823d, d09299c2b65c8548fc2363b8acbb409b1b46bb79

**Package details**

    Maintainer: Jens Wagner <jens@wagner2013.de>
    Description: Modules for modern Perl development

**Indication of run testing**

     OpenWrt version: 24.10.0
     OpenWrt target/subtarget: mipsel_24kc
     OpenWrt device: RT-AX53U

**Formalities**

     [X] Review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

     If your PR contains a patch
     [X] Make sure that it can be applied by `git am`
     [X] It must be refreshed to avoid offsets, fuzzes, etc by `make package/foo/refresh V=s`
     [X] It must be in a way that it is potentially upstreamable (subject, commit description, etc.), and we must try to upstream it so we have fewer patches and fewer.
