### PR TITLE
luabitop: update to 1.0.3

### DIFF
--- a/lang/luabitop/Makefile
+++ b/lang/luabitop/Makefile
@@ -8,15 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luabitop
-PKG_VERSION:=1.0.2
+PKG_VERSION:=1.0.3
 PKG_RELEASE:=1
 
 _BASENAME:=LuaBitOp
 
-PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_SOURCE:=$(_BASENAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://bitop.luajit.org/download/
-PKG_HASH:=1207c9293dcd52eb9dca6538d1b87352bd510f4e760938f5048433f7f272ce99
+PKG_HASH:=d514a3d2cefa76c8d11c1b9ec740d5fae316a9c9764e1e12ddea21e4982fab4b
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(_BASENAME)-$(PKG_VERSION)
 PKG_LICENSE:=MIT
 


### PR DESCRIPTION
Remove myself as a maintainer

**Package details**

    Maintainer: not me anymore
    Description: update to 1.0.3, remove myself as a maintainer

**Indication of run testing**

     OpenWrt version: r28979+3-9a79cdc7ee
     OpenWrt target/subtarget: qualcommax/ipq807x
     OpenWrt device: Dynalink DL-WRX36

**Formalities**

     [x] Review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

     If your PR contains a patch
     [ ] Make sure that it can be applied by `git am`
     [ ] It must be refreshed to avoid offsets, fuzzes, etc by `make package/foo/refresh V=s`
     [ ] It must be in a way that it is potentially upstreamable (subject, commit description, etc.), and we must try to upstream it so we have fewer patches and fewer.
