### PR TITLE
prometheus-node-exporter-lua: add newline to error messages

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2025.06.08
+PKG_VERSION:=2025.06.23
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/utils/prometheus-node-exporter-lua/files/usr/bin/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/bin/prometheus-node-exporter-lua
@@ -33,6 +33,9 @@ end
 
 function print_metric(metric, labels, value)
   local label_string = ""
+  if type(value) == "nil" then
+    return
+  end
   if labels then
     for label,value in pairs(labels) do
       label_string =  label_string .. label .. '="' .. value .. '",'
@@ -59,7 +62,7 @@ function timed_scrape(collector)
   local status, err = pcall(collector.scrape)
   if not status then
     success = 0
-    io.stderr:write(err)
+    io.stderr:write(err .. '\n')
   end
   return (socket.gettime() - start_time), success
 end


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @champtar

**Description:**
1. Avoid error on nil value by skipping over it
1. Adds a newline to error messages

## 🧪 Run Testing Details

- **OpenWrt Version: 24.10 **
- **OpenWrt Target/Subtarget: **
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

Fixes https://github.com/openwrt/packages/issues/26673
