### PR TITLE
rtl_433: bump version to 25.02

### DIFF
--- a/utils/rtl_433/Makefile
+++ b/utils/rtl_433/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtl_433
-PKG_VERSION:=23.11
+PKG_VERSION:=25.02
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/merbanan/rtl_433/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=1260c58400bf35832ac1b76cb3cccf3dc1335ffa2416909c63c7d7060c74663b
+PKG_HASH:=5a409ea10e6d3d7d4aa5ea91d2d6cc92ebb2d730eb229c7b37ade65458223432
 
 PKG_MAINTAINER:=Jasper Scholte <NightNL@outlook.com>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -54,7 +54,11 @@ define Package/rtl_433-ssl/description
   This package includes OpenSSL support which allows you to send data to influxDB/MQTT using TLS.
 endef
 
-CMAKE_OPTIONS += -DENABLE_SOAPYSDR=NO
+define Package/conffiles
+/etc/config/rtl_433
+endef
+
+CMAKE_OPTIONS += -DFORCED_GIT_DIR=$(PKG_BUILD_DIR)/.git -DENABLE_SOAPYSDR=NO
 ifeq ($(BUILD_VARIANT),ssl)
   CMAKE_OPTIONS += -DENABLE_OPENSSL=ON
 else
@@ -68,9 +72,14 @@ define Build/InstallDev
 endef
 
 define Package/rtl_433/install
-	$(INSTALL_DIR) $(1)/etc/rtl_433
-	$(CP) $(PKG_INSTALL_DIR)/usr/etc/rtl_433/*.conf $(1)/etc/rtl_433
-	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DIR) \
+		$(1)/etc/config \
+		$(1)/etc/init.d \
+		$(1)/etc/rtl_433 \
+		$(1)/usr/bin
+	$(INSTALL_CONF) ./files/rtl_433.conf $(1)/etc/config/rtl_433
+	$(INSTALL_BIN) ./files/rtl_433.init $(1)/etc/init.d/rtl_433
+	$(CP) $(PKG_INSTALL_DIR)/etc/rtl_433/*.conf $(1)/etc/rtl_433
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/rtl_433 $(1)/usr/bin
 endef
 

--- a/utils/rtl_433/files/rtl_433.conf
+++ b/utils/rtl_433/files/rtl_433.conf
@@ -1,0 +1,7 @@
+config rtl_433 rtl_433
+  option enabled 0
+  list env "MQTT_USERNAME=mqtt_user"
+  list env "MQTT_PASSWORD=secret"
+  list env "TZ=America/Chicago"
+  list flags "-Fmqtts://mqtt.example.com:8883,retain=1"
+  list flags "-Mtime:usec"

--- a/utils/rtl_433/files/rtl_433.init
+++ b/utils/rtl_433/files/rtl_433.init
@@ -1,0 +1,34 @@
+#!/bin/sh /etc/rc.common
+
+START=90
+
+USE_PROCD=1
+
+PROG=/usr/bin/rtl_433
+
+start_service() {
+    config_load rtl_433
+
+    local enabled
+    config_get enabled rtl_433 enabled
+    [ "$enabled" -gt 0 ] || return
+
+    local flags
+    config_get flags rtl_433 flags
+
+    procd_open_instance
+    config_list_foreach rtl_433 env "procd_append_param env"
+    procd_set_param command $PROG $flags
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_close_instance
+}
+
+reload_service() {
+    stop
+    start
+}
+
+restart() {
+    reload_service
+}


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, OpenWRT 24.10 stable branch on 6/3/2025 for aarch64
Runtime tested: aarch64, OpenWRT 24.10 stable brance on 6/3/2025
OpenWRT Device: gl-inet mt6000

Description:
Updates rtl_433 to its latest release. This also adds a simple init script and sample config file.

changelog: https://github.com/merbanan/rtl_433/releases/tag/25.02