### PR TITLE
netbird: update to 0.45.3

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.45.2
+PKG_VERSION:=0.45.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=e33db322cdc38ddddcc6b4f2f34c6b31741b7a279b0b85352c14c4859dee97b2
+PKG_HASH:=57723dcf41d0cfc73205ec82cf8e409ede94e072076cfb73cd8f0c361833c7b8
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

- `netbird` update to [0.45.3](https://github.com/netbirdio/netbird/releases/tag/v0.45.3)
    - Full changelog: https://github.com/netbirdio/netbird/compare/v0.45.2...v0.45.3
    - Breaking change:
      - N/A

Used a 'dirty' installation of the `OpenWrt` image instead of starting with a clean state:
```shell
apk --update-cache upgrade
apk add --allow-untrusted <package_name>.apk
reboot
```

**Tests checklist:**
- [X] Connection to the NetBird Cloud Dashboard (not self-hosted).
- [X] Firewall configured with nftables.
- [X] Connection established in P2P mode.
- [X] `wireguard` kernel mode active.
- [X] Routes configured between my homelab and my cloud server.
- [X] `netbird` DNS server functioning correctly.
- [ ] NAT operational (not needed by me at this time, may consider testing in the future).
- [ ] Permissions rules is enforced (not needed by me at this time, may consider testing in the future).

**Additional information**

`x86_64` is running in a container using [`incus`](https://github.com/lxc/incus).
The package(s) was compiled with the container [`sdk`](https://github.com/openwrt/docker).
The `OpenWrt` image(s) was built using the container [`imagebuilder`](https://github.com/openwrt/docker) or [`distrobuilder`](https://github.com/lxc/distrobuilder).

You can view my repository with the patch applied and the automated build here:
`This repository is temporary and will be removed or modified after the merge.`
- https://github.com/wehagy/owpib/tree/netbird/update

You can find my artifacts here:
- https://github.com/wehagy/owpib/actions/runs/15407523044

I see in my [automated build](https://github.com/wehagy/owpib/actions/runs/15407523044/job/43352953000#step:3:2524) this unrelated error:


```
1.693 gpg:                using EDDSA key 92C561DE55AE6552F3C736B82B0151090606D1D9
1.701 gpg: Good signature from "OpenWrt Build System (Nitrokey3) <contact@openwrt.org>" [unknown]
1.706 gpg: WARNING: This key is not certified with a trusted signature!
1.706 gpg:          There is no indication that the signature belongs to the owner.
1.706 Primary key fingerprint: 8A8B C12F 46B8 36C0 F9CD  B36F 1D53 D187 7742 E911
1.706      Subkey fingerprint: 92C5 61DE 55AE 6552 F3C7  36B8 2B01 5109 0606 D1D9
31.22 2025-06-03 03:15:28 URL:https://downloads.openwrt.org/snapshots/targets/ramips/mt7621/openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst [183173745/183173745] -> "openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst" [2]
31.23 ade80e02523975b085a027e52c65b63156f04bae96da7d5956b11b615ac9a5ca *openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst
31.93 openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst: FAILED
31.93 sha256sum: WARNING: 1 computed checksum did NOT match
```

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT r29922-e50c8f959d
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** B75 M.2 Intel LGA 1155 DDR3

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.