### PR TITLE
gihub: fix PR template broken URL

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@
 
 ## ✅ Formalities
 
-- [ ] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
+- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
 
 ### If your PR contains a patch:
 


### PR DESCRIPTION
## Proposed Change Details

**Steps to Reproduce**

1. Open a PR
2. Click to Preview the PR template
3. Click the URL in CONTRIBUTING.md
4. See the "Not Found" error

1. Alternatively just click the URL for CONTRIBUTING.md below

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Changes the relative URL in the PR template to an absolute URL to resolve a "Not Found" error.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.