### PR TITLE
ddns-scripts: fix parsing of parameters for cloudflare.com

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=71
+PKG_RELEASE:=72
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare_com_v4.sh
@@ -30,12 +30,16 @@
 local __HOST __DOMAIN __TYPE __URLBASE __PRGBASE __RUNPROG __DATA __IPV6 __ZONEID __RECID
 local __URLBASE="https://api.cloudflare.com/client/v4"
 
-# split __HOST __DOMAIN from $domain
-# given data:
-# @example.com for "domain record"
-# host.sub@example.com for a "host record"
-__HOST=$(printf %s "$domain" | cut -d@ -f1)
-__DOMAIN=$(printf %s "$domain" | cut -d@ -f2)
+if echo "$domain" | grep -Fq '@'; then
+	# split __HOST __DOMAIN from $domain
+	# given data:
+	# @example.com for "domain record"
+	# host.sub@example.com for a "host record"
+	__HOST=$(printf %s "$domain" | cut -d@ -f1)
+	__DOMAIN=$(printf %s "$domain" | cut -d@ -f2)
+else
+	__DOMAIN=$domain
+fi
 
 # Cloudflare v4 needs:
 # __DOMAIN = the base domain i.e. example.com


### PR DESCRIPTION
Compatible with domain without the `@` symbol, consistent with the previous.

Fixes 8c55d089 ("ddns-scripts: fix parsing of parameters for cloudflare.com")

## 📦 Package Details

**Maintainer:** @feckert 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Compatible with domain without the `@` symbol, consistent with the previous.

Fixes 8c55d089 ("ddns-scripts: fix parsing of parameters for cloudflare.com")

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.1
- **OpenWrt Target/Subtarget:** rockchip/armv8
- **OpenWrt Device:** Easepi R1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
