### PR TITLE
bcm27xx-eeprom: update to v2025-05-08-2712

### DIFF
--- a/utils/bcm27xx-eeprom/Makefile
+++ b/utils/bcm27xx-eeprom/Makefile
@@ -5,9 +5,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/raspberrypi/rpi-eeprom
-PKG_SOURCE_DATE:=2025-02-12
-PKG_SOURCE_VERSION:=c954a72f6301b8ac0fc4b0fe252e1c5024d2862b
-PKG_MIRROR_HASH:=fb45c5d65c70dc7b68c8b63ab2641706e44a54042c6817d7a9167c55d51f3794
+PKG_SOURCE_DATE:=2025-05-08
+PKG_SOURCE_VERSION:=1bb6edeff52c6d30c358f0a7e7a0db47427a7e21
+PKG_MIRROR_HASH:=3c1a9d91eb1d77df97084497c7e1ceac770dbefeac3d6544c3b4514d225e03f4
 
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 PKG_LICENSE:=BSD-3-Clause Custom
@@ -76,7 +76,7 @@ define Package/bcm2711-eeprom/install
 	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader-2711
-	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/pieeprom-2025-02-11.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
+	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/pieeprom-2025-05-08.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/recovery.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/vl805-000138c0.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 endef
@@ -86,7 +86,7 @@ define Package/bcm2712-eeprom/install
 	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
 
 	$(CP) $(PKG_BUILD_DIR)/firmware-2712/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader-2712
-	$(CP) $(PKG_BUILD_DIR)/firmware-2712/latest/pieeprom-2025-02-12.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
+	$(CP) $(PKG_BUILD_DIR)/firmware-2712/latest/pieeprom-2025-05-08.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
 	$(CP) $(PKG_BUILD_DIR)/firmware-2712/latest/recovery.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
 endef
 


### PR DESCRIPTION
bcm2711:
https://github.com/raspberrypi/rpi-eeprom/blob/v2025.05.08-2712/firmware-2711/release-notes.md#2025-05-08-implement-tcp-window-for-net-boot-latest

bcm2712:
https://github.com/raspberrypi/rpi-eeprom/blob/v2025.05.08-2712/firmware-2712/release-notes.md#2025-02-12-fixup-change-to-disable-37v-pmic-output-on-cm5-no-wifi-latest
https://github.com/raspberrypi/rpi-eeprom/blob/v2025.05.08-2712/firmware-2712/release-notes.md#2025-03-03-fix-bootloader-pull-configuration-on-2712d0-latest
https://github.com/raspberrypi/rpi-eeprom/blob/v2025.05.08-2712/firmware-2712/release-notes.md#2025-03-10-add-boot_partition-filter-plus-sdram-init-fixes-latest
https://github.com/raspberrypi/rpi-eeprom/blob/v2025.05.08-2712/firmware-2712/release-notes.md#2025-03-19-log-the-fan-speed-at-boot-latest
https://github.com/raspberrypi/rpi-eeprom/blob/v2025.05.08-2712/firmware-2712/release-notes.md#2025-03-27-os_check-cm5-check-for-cm5-specific-dtbs-latest
https://github.com/raspberrypi/rpi-eeprom/blob/v2025.05.08-2712/firmware-2712/release-notes.md#2025-04-07-arm_dt-revert-to-using-the-max-fan-speed-latest
https://github.com/raspberrypi/rpi-eeprom/blob/v2025.05.08-2712/firmware-2712/release-notes.md#2025-05-08-implement-tcp-window-for-net-boot-latest

## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
