### PR TITLE
libarchive: bump to 3.8.1

### DIFF
--- a/libs/libarchive/Makefile
+++ b/libs/libarchive/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libarchive
-PKG_VERSION:=3.7.9
+PKG_VERSION:=3.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.libarchive.org/downloads
-PKG_HASH:=ed8b5732e4cd6e30fae909fb945cad8ff9cb7be5c6cdaa3944ec96e4a200c04c
+PKG_HASH:=19f917d42d530f98815ac824d90c7eaf648e9d9a50e4f309c812457ffa5496b5
 
 PKG_MAINTAINER:=Johannes Morgenroth <morgenroth@ibr.cs.tu-bs.de>
 PKG_LICENSE:=BSD-2-Clause


### PR DESCRIPTION
This is a feaure and bugfix release.

New features:
bsdtar: support --mtime and --clamp-mtime (#2601)
lib: mbedtls 3.x compatibility (#2602)
7-zip reader: improve self-extracting archive detection (#2088) xar: xmllite support for the XAR reader and writer (#2388) zip writer: added XZ, LZMA, ZSTD and BZIP2 support (#2137, #2284, #2391) zip writer: added LZMA + RISCV BCJ filter (#2403)

Notable security fixes:
rar: do not skip past EOF while reading (#2584)
rar: fix double free with over 4 billion nodes (#2598) rar: fix heap-buffer-overflow (#2599)
warc: prevent signed integer overflow (#2568)
tar: fix overflow in build_ustar_entry (#2588)

Notable bugfixes:
ibarchive: fix FILE_skip regression (#2642)
compress: Prevent call stack overflow (#2649)
iso9660: always check archive_string_ensure return value (#2651) tar: Support negative time values with pax (#2634) tar: Reset accumulated header state after reading macOS metadata blob (#2636) tar: Keep block alignment after pax error (#2637)
tar: Handle extra bytes after sparse entries (#2643) windows: check archive_wstring_ensure return value (#2652) bsdtar: don't hardlink negative inode files together (#2587) gz: allow setting the original filename for gzip compressed files (#2544) lib: improve lseek handling (#2564)
lib: support @-prefixed Unix epoch timestamps as date strings (#2606) rar: support large headers on 32 bit systems (#2596) tar reader: Improve LFS support on 32 bit systems (#2582)

Full changelog: https://github.com/libarchive/libarchive/compare/v3.7.9...v3.8.1

## 📦 Package Details

**Maintainer:** @morgenroth
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- Build system: x86/64
- Build-tested: x86/64
- Run-tested: x86/64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
