### PR TITLE
[24.10] curl: Backport fix for timer callbacks not being invoked

### DIFF
--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=8.10.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \

--- a/net/curl/patches/0001-multi-fix-callback-for-CURLMOPT_TIMERFUNCTION-not-be.patch
+++ b/net/curl/patches/0001-multi-fix-callback-for-CURLMOPT_TIMERFUNCTION-not-be.patch
@@ -1,0 +1,34 @@
+From 407deeaaa346119ab570540f11987830b0dcdf82 Mon Sep 17 00:00:00 2001
+From: Vladislavs Sokurenko <vladislavs.sokurenko@gmail.com>
+Date: Fri, 22 Nov 2024 17:00:14 +0200
+Subject: [PATCH] multi: fix callback for `CURLMOPT_TIMERFUNCTION` not being
+ called again when...
+
+Issue is reproducible for me if I have made request with multi handle,
+then I make request that will take very long and then I make request
+that should be fast again, however what happens it is that it seems
+to think that timeout was not changed and it makes it not call initial
+`CURLMOPT_TIMERFUNCTION`.
+
+Closes #15627
+---
+ lib/multi.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+--- a/lib/multi.c
++++ b/lib/multi.c
+@@ -3225,6 +3225,14 @@ static CURLMcode multi_socket(struct Cur
+       }
+     }
+   }
++  else {
++    /* Asked to run due to time-out. Clear the 'last_expire_ts' variable to
++       force Curl_update_timer() to trigger a callback to the app again even
++       if the same timeout is still the one to run after this call. That
++       handles the case when the application asks libcurl to run the timeout
++       prematurely. */
++    memset(&multi->last_expire_ts, 0, sizeof(multi->last_expire_ts));
++  }
+ 
+   result = multi_run_expired(&mrc);
+   if(result)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @krant @BKPepe 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
*(copied from the commit message)*

Curl 8.10.x and 8.11.0 have a bug where, when using the multi interface, timer callbacks might not always be invoked properly:

https://github.com/curl/curl/pull/15627

In particular, on my setup, this results in https-dns-proxy being unable to time out a hanging HTTP/2 connection, which in turn causes all future multiplexed requests to also get stuck in `MSTATE_INIT`. 8.11.1 got the aforementioned fix, but it never made it into the 8.10.x line, so OpenWRT is still affected.

---

## 🧪 Run Testing Details

Important note: **I do not understand exactly what run testing is.** What I'm describing below are the circumstances under which I've tested this for the past several days with no issues, but if "run testing" means something else then please feel free to point that out!

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** mediatek filogic
- **OpenWrt Device:** MT6000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] ~~It is structured in a way that it is potentially upstreamable~~ this is a backport from 8.11.1
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>

---

**Side notes:** this is, in my testing, *technically* also able to be worked around in https-dns-proxy itself, so if preferred I can just PR the needed changes there instead. The main reason I first thought to backport the fix is that I'd imagine that https-dns-proxy isn't the only consumer of curl's multi interface, so this might be silently affecting other things as well.