### PR TITLE
openssh: wrong permissions on /etc/ssh

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openssh
 PKG_REALVERSION:=10.0p1
 PKG_VERSION:=10.0_p1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_REALVERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
@@ -211,12 +211,12 @@ define Build/Compile
 endef
 
 define Package/openssh-moduli/install
-	install -d -m0700 $(1)/etc/ssh
+	install -d -m0755 $(1)/etc/ssh
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/ssh/moduli $(1)/etc/ssh/
 endef
 
 define Package/openssh-client/install
-	install -d -m0700 $(1)/etc/ssh
+	install -d -m0755 $(1)/etc/ssh
 	$(CP) $(PKG_INSTALL_DIR)/etc/ssh/ssh_config $(1)/etc/ssh/
 	$(INSTALL_DIR) $(1)/usr/libexec
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ssh $(1)/usr/libexec/ssh-openssh
@@ -239,7 +239,7 @@ define Package/openssh-sk-helper/install
 endef
 
 define Package/openssh-server/install
-	install -d -m0700 $(1)/etc/ssh $(1)/etc/ssh/sshd_config.d
+	install -d -m0755 $(1)/etc/ssh $(1)/etc/ssh/sshd_config.d
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/ssh/sshd_config $(1)/etc/ssh/
 	sed -r -i 's,^#(HostKey /etc/ssh/ssh_host_(rsa|ed25519)_key)$$$$,\1,' $(1)/etc/ssh/sshd_config
 	$(INSTALL_DIR) $(1)/etc/init.d


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @tripolar 

**Description:**
Users don't have access to system-wide settings when running clients like `ssh` and `sftp`.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** HEAD (7193539c98)
- **OpenWrt Target/Subtarget:** x86_64/generic
- **OpenWrt Device:** PC Engines APU-6

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [X] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
