### PR TITLE
Add jemalloc and integrate into bind

### DIFF
--- a/libs/libjemalloc/Makefile
+++ b/libs/libjemalloc/Makefile
@@ -1,0 +1,61 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=jemalloc
+PKG_VERSION:=5.3.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/jemalloc/jemalloc/archive/refs/tags/
+PKG_SOURCE_URL_FILE:=$(PKG_VERSION).tar.gz
+PKG_HASH:=ef6f74fd45e95ee4ef7f9e19ebe5b075ca6b7fbe0140612b2a161abafb7ee179
+
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libjemalloc
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Jemalloc general purpose allocator
+  URL:=https://github.com/jemalloc/jemalloc
+  DEPENDS:= +libunwind +libstdcpp
+  ABI_VERSION:=2
+endef
+
+define Package/libjemalloc/Description
+  Jemalloc is a general purpose malloc(3) implementation that emphasizes
+  fragmentation avoidance and scalable concurrency support.
+endef
+
+CONFIGURE_ARGS += \
+	--enable-shared \
+	--disable-static \
+	--enable-prof \
+	--enable-prof-libunwind \
+	--enable-readlinkat
+
+MAKE_FLAGS += enable_doc=0
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/lib/libjemalloc.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/include/jemalloc
+	$(CP) $(PKG_BUILD_DIR)/include/jemalloc/*.h $(1)/usr/include/jemalloc
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_BUILD_DIR)/jemalloc.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libjemalloc/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/lib/libjemalloc.so.$(ABI_VERSION) $(1)/usr/lib
+	$(LN) libjemalloc.so.$(ABI_VERSION) $(1)/usr/lib/libjemalloc.so
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/{jemalloc-config,jemalloc.sh,jeprof} $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,libjemalloc))

--- a/net/bind/Config.in
+++ b/net/bind/Config.in
@@ -42,3 +42,13 @@ config BIND_ENABLE_GSSAPI
 		Disable it by default as krb5-libs is rather large.
 
 endif
+
+config BIND_JEMALLOC
+	bool
+	default n
+	prompt "Include jemalloc for heap debugging in bind-server"
+	help
+		BIND 9 allows linking against jemalloc which can provide
+		more detailed memory usage information to assist in
+		diagnosing heap utilization issues.
+

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.20.9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -34,10 +34,14 @@ PKG_BUILD_PARALLEL:=1
 PKG_CONFIG_DEPENDS := \
 	CONFIG_BIND_LIBJSON \
 	CONFIG_BIND_LIBXML2 \
+	CONFIG_BIND_JEMALLOC \
 	CONFIG_BIND_ENABLE_DOH \
 	CONFIG_BIND_ENABLE_GSSAPI
 
-PKG_BUILD_DEPENDS += BIND_LIBXML2:libxml2 BIND_LIBJSON:libjson-c
+PKG_BUILD_DEPENDS += \
+	BIND_LIBXML2:libxml2 \
+	BIND_LIBJSON:libjson-c \
+	BIND_JEMALLOC:libjemalloc
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -66,7 +70,8 @@ define Package/bind-libs
 	+BIND_ENABLE_GSSAPI:krb5-libs \
 	+BIND_ENABLE_GSSAPI:libcomerr \
 	+BIND_LIBXML2:libxml2 \
-	+BIND_LIBJSON:libjson-c
+	+BIND_LIBJSON:libjson-c \
+	+BIND_JEMALLOC:libjemalloc
   TITLE:=bind shared libraries
   URL:=https://www.isc.org/software/bind
 endef
@@ -168,6 +173,14 @@ ifdef CONFIG_BIND_LIBXML2
 else
 	CONFIGURE_ARGS += \
 		--with-libxml2=no
+endif
+
+ifdef CONFIG_BIND_JEMALLOC
+	CONFIGURE_ARGS += \
+		--with-jemalloc=yes
+else
+	CONFIGURE_ARGS += \
+		--without-jemalloc
 endif
 
 ifdef CONFIG_BIND_ENABLE_DOH


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @pprindeville, @nmeyerhans 

**Description:**
Adding the `jemalloc` package, and allowing `bind` to link against it.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** HEAD
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** PC Engines APU6

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [X] It is structured in a way that it is potentially upstreamable

