### PR TITLE
bluez: fix need re-pairing after daemon restarts

### DIFF
--- a/utils/bluez/Makefile
+++ b/utils/bluez/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bluez
 PKG_VERSION:=5.72
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/bluetooth/

--- a/utils/bluez/patches/010-adapter-Fix-up-address-type-when-loading-keys.patch
+++ b/utils/bluez/patches/010-adapter-Fix-up-address-type-when-loading-keys.patch
@@ -1,0 +1,48 @@
+From 366a8c522b648f47147de4852c5c030d69b916b3 Mon Sep 17 00:00:00 2001
+From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
+Date: Wed, 28 Aug 2024 11:30:16 -0400
+Subject: [PATCH] adapter: Fix up address type when loading keys
+
+Due to kernel change 59b047bc9808
+("Bluetooth: MGMT/SMP: Fix address type when using SMP over BREDR/LE")
+some keys maybe store using the wrong/invalid address type as per MGMT
+API, so this attempts to fix them up.
+
+Fixes: https://github.com/bluez/bluez/issues/875
+---
+ src/adapter.c | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
+
+--- a/src/adapter.c
++++ b/src/adapter.c
+@@ -4989,12 +4989,28 @@ static void load_devices(struct btd_adap
+ 			goto free;
+ 		}
+ 
+-		if (key_info)
++		if (key_info) {
++			/* Fix up address type if it was stored with the wrong
++			 * address type since Load Link Keys are only meant to
++			 * work with BR/EDR addresses as per MGMT documentation.
++			 */
++			if (key_info->bdaddr_type != BDADDR_BREDR)
++				key_info->bdaddr_type = BDADDR_BREDR;
++
+ 			adapter->load_keys = g_slist_append(adapter->load_keys,
+ 								key_info);
++		}
++
++		if (ltk_info) {
++			/* Fix up address type if it was stored with the wrong
++			 * address type since Load Long Term Keys are only meant
++			 * to work with LE addresses as per MGMT documentation.
++			 */
++			if (ltk_info->bdaddr_type == BDADDR_BREDR)
++				ltk_info->bdaddr_type = BDADDR_LE_PUBLIC;
+ 
+-		if (ltk_info)
+ 			ltks = g_slist_append(ltks, ltk_info);
++		}
+ 
+ 		if (peripheral_ltk_info)
+ 			ltks = g_slist_append(ltks, peripheral_ltk_info);


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** none

**Description:**
Backport an upstream patch to fix load link-keys with kernel >= 6.10, see bluez/bluez#973.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** rockchip/armv8
- **OpenWrt Device:** see immortalwrt/packages#1614

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable