### PR TITLE
libopenldap: Add missing Config.in hook

### DIFF
--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -53,6 +53,10 @@ define Package/libopenldap
   TITLE+= (libraries)
 endef
 
+define Package/libopenldap/config
+  source "$(SOURCE)/Config.in"
+endef
+
 define Package/openldap/config
   source "$(SOURCE)/Config.in"
 endef


### PR DESCRIPTION
Package has a consistent Config.in file, but it isn't added to all parts of the file.

libopenldap is unable to be built with --enable-debug because the Config.in is never attached to the libopenldap.

## 📦 Package Details

**Maintainer:** me

**Description:**
Cherry pick from master branch according to request at https://github.com/openwrt/packages/pull/23826.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** x86
- **OpenWrt Device:** 64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
