### PR TITLE
zerotier: fix system include path

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
 PKG_VERSION:=1.14.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
@@ -61,6 +61,9 @@ endef
 # Make binary smaller
 TARGET_CFLAGS += -Wl,-z,noexecstack
 TARGET_LDFLAGS += -Wl,--as-needed -Wl,-z,noexecstack
+
+# Prevent `-isystem ext` from causing the wrong miniupnpc header to be used (OpenWrt packages issue - 18019)
+TARGET_CFLAGS += -isystem $(STAGING_DIR)/usr/include
 
 define Package/zerotier/conffiles
 /etc/config/zerotier


### PR DESCRIPTION
`-isystem ext` makes `#include <miniupnpc/miniupnpc.h>` actually include `ext/miniupnpc/miniupnpc.h`.

we should use `$(STAGING_DIR)/usr/include` as a higher priority system include path.

Fix https://github.com/openwrt/openwrt/issues/18019

## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Fix https://github.com/openwrt/openwrt/issues/18019

---

## 🧪 Run Testing Details

- **OpenWrt Version: 24.10.1
- **OpenWrt Target/Subtarget: armsr/armv8
- **OpenWrt Device: virtualbox

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
cannot be upstram, this is a part of openwrt cross compiling path hack.