### PR TITLE
perl-authen-sasl-xs: fix issues with gcc-14

### DIFF
--- a/lang/perl-authen-sasl-xs/Makefile
+++ b/lang/perl-authen-sasl-xs/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-authen-sasl-xs
 PKG_VERSION:=1.00
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_NAME:=Authen-SASL-XS
 PKG_SOURCE_URL:=http://www.cpan.org/authors/id/G/GB/GBARR/
@@ -17,7 +17,7 @@ PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=1b0eaa0e7ac3a45857147d837e3d34c80c6eca1d9fdcb826a213c2a105454234
 
 PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
-PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>
+PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>, Jens Wagner <jens@wagner2013.de>
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
 
@@ -30,8 +30,13 @@ define Package/perl-authen-sasl-xs
   CATEGORY:=Languages
   TITLE:=Authen::XS hooks into libsasl.
   URL:=http://search.cpan.org/dist/$(PKG_SOURCE_NAME)/
-  # DEPENDS:=perl +perl-authen-sasl +libsasl2 +perl-devel-checklib/host
-  DEPENDS:=perl +perl-authen-sasl +libsasl2
+  DEPENDS:=perl +perlbase-dynaloader +perl-authen-sasl +libsasl2
+endef
+
+define Package/perl-authen-sasl-xs/description
+  SASL is a generic mechanism for authentication used by several
+  network protocols. Authen::SASL::XS provides an implementation
+  framework that all protocols should be able to share.
 endef
 
 define Build/Configure
@@ -43,7 +48,7 @@ define Build/Compile
 endef
 
 define Package/perl-authen-sasl-xs/install
-	$(call perlmod/Install,$(1),Authen)
+	$(call perlmod/Install,$(1),Authen auto/Authen)
 endef
 
 

--- a/lang/perl-authen-sasl-xs/patches/102-strlen-size.patch
+++ b/lang/perl-authen-sasl-xs/patches/102-strlen-size.patch
@@ -1,0 +1,24 @@
+Description: Fix type mismatches on 64-bit platforms
+Author: Russ Allbery <rra@debian.org>
+Reviewed-by: gregor herrmann <gregoa@debian.org>
+Last-Update: 2023-10-25
+
+Change the data types used in the XS code for the module to ensure data
+types match Perl's expectations on 64-bit platforms.
+
+Note:
+(libauthen-sasl-xs-perl is the successor of libauthen-sasl-cyrus-perl)
+Most of the original changes are applied upstream, one remains.
+[gregor 2023-10-25]
+
+--- a/XS.xs
++++ b/XS.xs
+@@ -946,7 +946,7 @@ void ExtractParentCallbacks(SV *parent,
+ {
+ 	char *key;
+ 	int count=0,i;
+-	long l;
++	I32 l;
+ #ifndef SASL2
+ 	// Missing SASL1 canonuser workaround
+ 	int canon=-1,auth=-1;

--- a/lang/perl-authen-sasl-xs/patches/104-use-int2ptr.patch
+++ b/lang/perl-authen-sasl-xs/patches/104-use-int2ptr.patch
@@ -1,0 +1,25 @@
+Description: Use INT2PTR to map objects to Cyrus SASL pointers
+Author: Russ Allbery <rra@debian.org>
+Reviewed-by: gregor herrmann <gregoa@debian.org>
+Last-Update: 2023-10-25
+
+Rather than directly casting the IV to the target pointer, use
+Perl's standard INT2PTR macro.  This shouldn't change the resulting
+code, but it will suppress build warnings and make it easier to
+spot real build issues.
+
+Note:
+(libauthen-sasl-xs-perl is the successor of libauthen-sasl-cyrus-perl)
+[gregor 2023-10-25]
+
+--- a/typemap
++++ b/typemap
+@@ -6,7 +6,7 @@ INPUT
+ T_PTROBJ_SPECIAL
+ 	if (sv_derived_from($arg, \"${(my $ntt=$ntype)=~s/_/::/g; \$ntt}\")) {
+ 		IV tmp = SvIV((SV*)SvRV($arg));
+-		$var = ($type) tmp;
++		$var = INT2PTR($type, tmp);
+ 	}
+ 	else
+ 		croak(\"$var is not of type ${(my $ntt=$ntype)=~s /_/::/g;\$ntt}\")

--- a/lang/perl-authen-sasl-xs/patches/105-gcc-14.patch
+++ b/lang/perl-authen-sasl-xs/patches/105-gcc-14.patch
@@ -1,0 +1,88 @@
+Description: fix multiple build issues with gcc 14.
+ Multiple callbacks are cast due to otherwise incompatible pointer
+ types.  The target pointer cb->proc cannot really see its type adjusted
+ for two reasons.  First, it is declared in the libsasl2, and changing
+ it might cause an ABI/API breakage.  Second, the different callbacks
+ also have different function signatures anyway.
+ .
+ Another issue seems to be a casting error while trying to set an IV:
+ .
+ 	XS.xs:1886:40: error:
+	        initialization of ‘IV’ {aka ‘long int’} from ‘int *’
+                makes integer from pointer without a cast [-Wint-conversion]
+ 	 1886 |                                 XPUSHi((int *)value);
+ 	      |                                        ^
+ 	/usr/lib/x86_64-linux-gnu/perl/5.38/CORE/pp.h:428:23: note: in definition of macro ‘TARGi’
+ 	  428 |         IV TARGi_iv = i;                                                \
+ 	      |                       ^
+ 	XS.xs:1886:33: note: in expansion of macro ‘XPUSHi’
+ 	 1886 |                                 XPUSHi((int *)value);
+ 	      |                                 ^~~~~~
+ .
+ It is unclear to me what was the motivation for the initial wrong type.
+
+Author: Étienne Mollier <emollier@debian.org>
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1075146
+Forwarded: no
+Last-Update: 2024-07-26
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/XS.xs
++++ b/XS.xs
+@@ -892,39 +892,39 @@ void AddCallback(SV *action, struct _per
+ 		case SASL_CB_USER:
+ 		case SASL_CB_AUTHNAME:
+ 		case SASL_CB_LANGUAGE:
+-				 cb->proc = PerlCallback;
++				 cb->proc = (int (*)(void))PerlCallback;
+ 			break;
+ 
+ 		case SASL_CB_PASS:
+-				cb->proc = PerlCallbackSecret;
++				cb->proc = (int (*)(void))PerlCallbackSecret;
+ 			break;
+ 
+ 		case SASL_CB_GETREALM:
+-				cb->proc = PerlCallbackRealm;
++				cb->proc = (int (*)(void))PerlCallbackRealm;
+ 			break;
+ 
+ 		case SASL_CB_ECHOPROMPT:
+ 		case SASL_CB_NOECHOPROMPT:
+ 			break;
+ 		case SASL_CB_PROXY_POLICY:
+-				cb->proc = PerlCallbackAuthorize;
++				cb->proc = (int (*)(void))PerlCallbackAuthorize;
+ 			break;
+ 
+ 		case SASL_CB_CANON_USER:
+-				cb->proc = PerlCallbackCanonUser;
++				cb->proc = (int (*)(void))PerlCallbackCanonUser;
+ 			break;
+ #ifdef SASL2
+ 		case SASL_CB_SERVER_USERDB_CHECKPASS:
+-				cb->proc = PerlCallbackServerCheckPass;
++				cb->proc = (int (*)(void))PerlCallbackServerCheckPass;
+ 			break;
+ 
+ 		case SASL_CB_SERVER_USERDB_SETPASS:
+-				cb->proc = PerlCallbackServerSetPass;
++				cb->proc = (int (*)(void))PerlCallbackServerSetPass;
+ 			break;
+ #else
+ 		// SASL 1 Servercallbacks:
+ 		case SASL_CB_SERVER_GETSECRET:
+-				cb->proc = PerlCallbackGetSecret;
++				cb->proc = (int (*)(void))PerlCallbackGetSecret;
+ 			break;
+ 		case SASL_CB_SERVER_PUTSECRET:
+ 				// Not implemented yet maybe TODO, if ever needed
+@@ -1883,7 +1883,7 @@ PPCODE:
+ 			break;
+ 			case SASL_SSF:
+ 			case SASL_MAXOUTBUF:
+-				XPUSHi((int *)value);
++				XPUSHi((long int)value);
+ 			break;
+ #ifdef SASL2
+ 			case SASL_IPLOCALPORT:

--- a/lang/perl-authen-sasl-xs/patches/106-fix-sasl_ssf-and-sasl_maxoutbuf-property.patch
+++ b/lang/perl-authen-sasl-xs/patches/106-fix-sasl_ssf-and-sasl_maxoutbuf-property.patch
@@ -1,0 +1,23 @@
+From: Niko Tyni <ntyni@debian.org>
+Date: Mon, 5 Aug 2024 16:50:56 +0100
+X-Dgit-Generated: 1.00-2 fe76997d50267530dd5a5f73995d11987547ac4d
+Subject: Fix SASL_SSF and SASL_MAXOUTBUF property handling
+
+sasl_getprop() returns a pointer which needs to be dereferenced to get
+the actual value.
+
+Bug-Debian: https://bugs.debian.org/1075146
+
+---
+
+--- a/XS.xs
++++ b/XS.xs
+@@ -1883,7 +1883,7 @@ PPCODE:
+ 			break;
+ 			case SASL_SSF:
+ 			case SASL_MAXOUTBUF:
+-				XPUSHi((long int)value);
++				XPUSHi(*((IV *)value));
+ 			break;
+ #ifdef SASL2
+ 			case SASL_IPLOCALPORT:


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @jw2013
**Description:** Fixes #26576
Corrected Makefile, and adopted various patches from https://sources.debian.org/patches/libauthen-sasl-xs-perl/1.00-3/

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.0
- **OpenWrt Target/Subtarget:** mipsel_24kc
- **OpenWrt Device:** RT-AX53U

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [X] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
