### PR TITLE
nft-qos: Update core.sh

### DIFF
--- a/net/nft-qos/files/lib/core.sh
+++ b/net/nft-qos/files/lib/core.sh
@@ -6,7 +6,7 @@
 # for uci_validate_section()
 . /lib/functions/procd.sh
 
-NFT_QOS_HAS_BRIDGE=
+NFT_QOS_HAS_BRIDGE=y
 NFT_QOS_INET_FAMILY=ip
 NFT_QOS_SCRIPT_TEXT=
 NFT_QOS_SCRIPT_FILE=/tmp/qos.nft


### PR DESCRIPTION
Fix for unable to limit the Download speed for using the "Limit Rate by Mac Address"

## 📦 Package Details

**Maintainer:** @OpenWrt LuCI community @wulfy23
<sub>(Package/nft-qos)</sub>

**Description:**
<!-- nft-qos is a package that provides per-user or per-device bandwidth management using the nftables framework, allowing you to control network traffic based on various criteria like IP address or MAC address. It's a useful tool for managing bandwidth when you have specific needs that go beyond the default behavior of SQM (Smart Queue Management -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:24.10.1**
- **OpenWrt Target/Subtarget:ramips/mt7621**
- **OpenWrt Device:Xiaomi Mi Router 4A Gigabit Edition**


