### PR TITLE
[24.10] python-pyserial: add hostbuild

### DIFF
--- a/lang/python/python-pyserial/Makefile
+++ b/lang/python/python-pyserial/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyserial
 PKG_VERSION:=3.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pyserial
 PKG_HASH:=3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb
@@ -18,9 +18,13 @@ PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_MAINTAINER:=Micke Prag <micke.prag@telldus.se>
 
+HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-wheel/host
+
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-pyserial
   SECTION:=lang
@@ -41,3 +45,4 @@ endef
 $(eval $(call Py3Package,python3-pyserial))
 $(eval $(call BuildPackage,python3-pyserial))
 $(eval $(call BuildPackage,python3-pyserial-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jefferyto 

**Description:**
Add hostbuild directives for python-pyserial in OpenWRT 24.10.

This package is a host-requirement for [PlatformIO](https://github.com/openwrt/packages/tree/master/lang/python/python-platformio) and projects which depend on PlatformIO, including [Meshtastic OpenWRT Packaging](https://github.com/meshtastic/openwrt).

(cherry picked from commit ac212e0c43e9671b9415a44c3c8eccf3286e1c3e)

Related `master` PR: https://github.com/openwrt/packages/pull/25494

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2710
- **OpenWrt Device:** Raspberry Pi CM3

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.