### PR TITLE
[24.10] python-platformio: Add package (build system)

### DIFF
--- a/lang/python/python-platformio/Makefile
+++ b/lang/python/python-platformio/Makefile
@@ -5,11 +5,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-platformio
-PKG_VERSION:=6.1.16
+PKG_VERSION:=6.1.18
 PKG_RELEASE:=1
 
 PYPI_NAME:=platformio
-PKG_HASH:=79387b45ca7df9c0c51cae82b3b0a40ba78d11d87cea385db47e1033d781e959
+PKG_HASH:=6ea19c66fba3c5272378afa6ae11abbf883243dd8e503ac5f4ff8ac277ccc7c6
 
 PKG_MAINTAINER:=Austin Lane <vidplace7@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/lang/python/python-platformio/Makefile
+++ b/lang/python/python-platformio/Makefile
@@ -1,0 +1,61 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-platformio
+PKG_VERSION:=6.1.16
+PKG_RELEASE:=1
+
+PYPI_NAME:=platformio
+PKG_HASH:=79387b45ca7df9c0c51cae82b3b0a40ba78d11d87cea385db47e1033d781e959
+
+PKG_MAINTAINER:=Austin Lane <vidplace7@gmail.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_HOST_ONLY:=1
+HOST_BUILD_DEPENDS:= \
+	python3/host \
+	python-build/host \
+	python-installer/host \
+	python-pyserial/host \
+	python-click/host \
+	python-semantic-version/host \
+	python-requests/host \
+	python-tabulate/host \
+	python-pyelftools/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include ../python3-package.mk
+include ../python3-host-build.mk
+
+define Package/python3-platformio
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=PlatformIO Host Tools
+  URL:=https://github.com/platformio/platformio-core
+  BUILDONLY:=1
+  DEPENDS:= \
+	+python3-light \
+	+python3-pyserial \
+	+python3-click \
+	+python3-semantic-version \
+	+python3-requests \
+	+python3-tabulate \
+	+python3-pyelftools
+endef
+
+define Package/python3-platformio/description
+PlatformIO is an open-source build system for embedded development,
+supporting multiple platforms, frameworks, and boards
+with features like dependency management and IDE integration.
+endef
+
+$(eval $(call Py3Package,python3-platformio))
+$(eval $(call BuildPackage,python3-platformio))
+$(eval $(call HostBuild))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me (@vidplace7)

**Description:**
Add PlatformIO build system, required for compiling [`meshtasticd`](https://github.com/meshtastic/openwrt/blob/openwrt-24.10/meshtasticd/Makefile) and other PlatformIO-based projects.

PlatformIO is a Python-based IDE / build system for embedded development, including Linux-based targets (among many others).

(cherry picked from commits 6d35e8920046014769e92c9efcb0517c40e2af8f, d3ba424c0c62b0d4a7f89cac055815fe795ff015)

Requires PRs for dependencies, marking DRAFT until they are merged:
- #25542
- #26743
- #26744
- #26746
- #26747

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2710
- **OpenWrt Device:** Raspberry Pi CM3

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
