### PR TITLE
amneziawg: add new package

### DIFF
--- a/amneziawg-tools/Makefile
+++ b/amneziawg-tools/Makefile
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2016-2019 Jason A. Donenfeld <Jason@zx2c4.com>
+# Copyright (C) 2016 Baptiste Jonglez <openwrt@bitsofnetworks.org>
+# Copyright (C) 2016-2017 Dan Luedtke <mail@danrl.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=amneziawg-tools
+PKG_VERSION:=1.0.20241018
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/amnezia-vpn/amneziawg-tools/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=60f1cec1774fb871a2d8dc24e4f731625516d90f663d6e0d2c77d9247222f2f9
+
+PKG_MAINTAINER:=Gregory Gullin <gargullia@proton.me>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+
+PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+MAKE_PATH:=src
+MAKE_VARS += PLATFORM=linux
+
+define Package/amneziawg-tools
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=VPN
+  URL:=https://amnezia.org/
+  TITLE:=AmneziaWG userspace control program (amneziawg)
+  DEPENDS:= \
+	  +!BUSYBOX_CONFIG_IP:ip \
+	  +!BUSYBOX_CONFIG_FEATURE_IP_LINK:ip \
+	  +kmod-amneziawg \
+	  +ip-full \
+	  +ip-tiny
+endef
+
+define Package/amneziawg-tools/description
+  Amnezia VPN — simple and free app to run a self-hosted VPN with
+	high privacy requirements.
+
+  This package provides the userspace control program for AmneziaWG,
+  `amneziawg`, a netifd protocol helper, and a re-resolve watchdog script.
+endef
+
+define Package/amneziawg-tools/install
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/wg $(1)/usr/bin/awg
+	$(INSTALL_BIN) ./files/amneziawg_watchdog $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/lib/netifd/proto/
+	$(INSTALL_BIN) ./files/amneziawg.sh $(1)/lib/netifd/proto/
+endef
+
+$(eval $(call BuildPackage,amneziawg-tools))

--- a/amneziawg-tools/files/amneziawg.sh
+++ b/amneziawg-tools/files/amneziawg.sh
@@ -1,0 +1,312 @@
+#!/bin/sh
+# Copyright 2016-2017 Dan Luedtke <mail@danrl.com>
+# Licensed to the public under the Apache License 2.0.
+
+WG=/usr/bin/awg
+if [ ! -x $WG ]; then
+	logger -t "amneziawg" "error: missing amneziawg-tools (${WG})"
+	exit 0
+fi
+
+[ -n "$INCLUDE_ONLY" ] || {
+	. /lib/functions.sh
+	. ../netifd-proto.sh
+	init_proto "$@"
+}
+
+proto_amneziawg_init_config() {
+	proto_config_add_string "private_key"
+	proto_config_add_int "listen_port"
+	proto_config_add_int "mtu"
+	proto_config_add_string "fwmark"
+	proto_config_add_int "awg_jc"
+	proto_config_add_int "awg_jmin"
+	proto_config_add_int "awg_jmax"
+	proto_config_add_int "awg_s1"
+	proto_config_add_int "awg_s2"
+	proto_config_add_int "awg_h1"
+	proto_config_add_int "awg_h2"
+	proto_config_add_int "awg_h3"
+	proto_config_add_int "awg_h4"
+	available=1
+	no_proto_task=1
+}
+
+proto_amneziawg_is_kernel_mode() {
+	if [ ! -e /sys/module/amneziawg ]; then
+		modprobe amneziawg >/dev/null 2>&1 || true
+
+		if [ -e /sys/module/amneziawg ]; then
+			return 0
+		else
+			if ! command -v "${WG_QUICK_USERSPACE_IMPLEMENTATION:-amneziawg-go}" >/dev/null; then
+				ret=$?
+				echo "Please install either kernel module (kmod-amneziawg package) or user-space implementation in /usr/bin/amneziawg-go."
+				exit $ret
+			else
+				return 1
+			fi
+		fi
+	else
+		return 0
+	fi
+}
+
+proto_amneziawg_setup_peer() {
+	local peer_config="$1"
+
+	local disabled
+	local public_key
+	local preshared_key
+	local allowed_ips
+	local route_allowed_ips
+	local endpoint_host
+	local endpoint_port
+	local persistent_keepalive
+
+	config_get_bool disabled "${peer_config}" "disabled" 0
+	config_get public_key "${peer_config}" "public_key"
+	config_get preshared_key "${peer_config}" "preshared_key"
+	config_get allowed_ips "${peer_config}" "allowed_ips"
+	config_get_bool route_allowed_ips "${peer_config}" "route_allowed_ips" 0
+	config_get endpoint_host "${peer_config}" "endpoint_host"
+	config_get endpoint_port "${peer_config}" "endpoint_port"
+	config_get persistent_keepalive "${peer_config}" "persistent_keepalive"
+
+	if [ "${disabled}" -eq 1 ]; then
+		# skip disabled peers
+		return 0
+	fi
+
+	if [ -z "$public_key" ]; then
+		echo "Skipping peer config $peer_config because public key is not defined."
+		return 0
+	fi
+
+	echo "[Peer]" >> "${wg_cfg}"
+	echo "PublicKey=${public_key}" >> "${wg_cfg}"
+	if [ "${preshared_key}" ]; then
+		echo "PresharedKey=${preshared_key}" >> "${wg_cfg}"
+	fi
+	for allowed_ip in $allowed_ips; do
+		echo "AllowedIPs=${allowed_ip}" >> "${wg_cfg}"
+	done
+	if [ "${endpoint_host}" ]; then
+		case "${endpoint_host}" in
+			*:*)
+				endpoint="[${endpoint_host}]"
+				;;
+			*)
+				endpoint="${endpoint_host}"
+				;;
+		esac
+		if [ "${endpoint_port}" ]; then
+			endpoint="${endpoint}:${endpoint_port}"
+		else
+			endpoint="${endpoint}:51820"
+		fi
+		echo "Endpoint=${endpoint}" >> "${wg_cfg}"
+	fi
+	if [ "${persistent_keepalive}" ]; then
+		echo "PersistentKeepalive=${persistent_keepalive}" >> "${wg_cfg}"
+	fi
+
+	if [ "${route_allowed_ips}" -ne 0 ]; then
+		for allowed_ip in ${allowed_ips}; do
+			case "${allowed_ip}" in
+				*:*/*)
+					proto_add_ipv6_route "${allowed_ip%%/*}" "${allowed_ip##*/}"
+					;;
+				*.*/*)
+					proto_add_ipv4_route "${allowed_ip%%/*}" "${allowed_ip##*/}"
+					;;
+				*:*)
+					proto_add_ipv6_route "${allowed_ip%%/*}" "128"
+					;;
+				*.*)
+					proto_add_ipv4_route "${allowed_ip%%/*}" "32"
+					;;
+			esac
+		done
+	fi
+}
+
+ensure_key_is_generated() {
+	local private_key
+	private_key="$(uci get network."$1".private_key)"
+
+	if [ "$private_key" == "generate" ]; then
+		local ucitmp
+		oldmask="$(umask)"
+		umask 077
+		ucitmp="$(mktemp -d)"
+		private_key="$("${WG}" genkey)"
+		uci -q -t "$ucitmp" set network."$1".private_key="$private_key" && \
+			uci -q -t "$ucitmp" commit network
+		rm -rf "$ucitmp"
+		umask "$oldmask"
+	fi
+}
+
+proto_amneziawg_setup() {
+	local config="$1"
+	local wg_dir="/tmp/wireguard"
+	local wg_cfg="${wg_dir}/${config}"
+
+	local private_key
+	local listen_port
+	local addresses
+	local mtu
+	local fwmark
+	local ip6prefix
+	local nohostroute
+	local tunlink
+
+	# Amnezia WG specific parameters
+	local awg_jc
+	local awg_jmin
+	local awg_jmax
+	local awg_s1
+	local awg_s2
+	local awg_h1
+	local awg_h2
+	local awg_h3
+	local awg_h4
+
+	ensure_key_is_generated "${config}"
+
+	config_load network
+	config_get private_key "${config}" "private_key"
+	config_get listen_port "${config}" "listen_port"
+	config_get addresses "${config}" "addresses"
+	config_get mtu "${config}" "mtu"
+	config_get fwmark "${config}" "fwmark"
+	config_get ip6prefix "${config}" "ip6prefix"
+	config_get nohostroute "${config}" "nohostroute"
+	config_get tunlink "${config}" "tunlink"
+
+	config_get awg_jc "${config}" "awg_jc"
+	config_get awg_jmin "${config}" "awg_jmin"
+	config_get awg_jmax "${config}" "awg_jmax"
+	config_get awg_s1 "${config}" "awg_s1"
+	config_get awg_s2 "${config}" "awg_s2"
+	config_get awg_h1 "${config}" "awg_h1"
+	config_get awg_h2 "${config}" "awg_h2"
+	config_get awg_h3 "${config}" "awg_h3"
+	config_get awg_h4 "${config}" "awg_h4"
+
+	if proto_amneziawg_is_kernel_mode; then
+		logger -t "amneziawg" "info: using kernel-space kmod-amneziawg for ${WG}"
+  		ip link del dev "${config}" 2>/dev/null
+		ip link add dev "${config}" type amneziawg
+	else
+		logger -t "amneziawg" "info: using user-space amneziawg-go for ${WG}"
+		rm -f "/var/run/wireguard/${config}.sock"
+		amneziawg-go "${config}"
+	fi
+
+	if [ "${mtu}" ]; then
+		ip link set mtu "${mtu}" dev "${config}"
+	fi
+
+	proto_init_update "${config}" 1
+
+	umask 077
+	mkdir -p "${wg_dir}"
+	echo "[Interface]" > "${wg_cfg}"
+	echo "PrivateKey=${private_key}" >> "${wg_cfg}"
+	if [ "${listen_port}" ]; then
+		echo "ListenPort=${listen_port}" >> "${wg_cfg}"
+	fi
+	if [ "${fwmark}" ]; then
+		echo "FwMark=${fwmark}" >> "${wg_cfg}"
+	fi
+	# AWG
+	if [ "${awg_jc}" ]; then
+		echo "Jc = ${awg_jc}" >> "${wg_cfg}"
+	fi
+	if [ "${awg_jmin}" ]; then
+		echo "Jmin = ${awg_jmin}" >> "${wg_cfg}"
+	fi
+	if [ "${awg_jmax}" ]; then
+		echo "Jmax = ${awg_jmax}" >> "${wg_cfg}"
+	fi
+	if [ "${awg_s1}" ]; then
+		echo "S1 = ${awg_s1}" >> "${wg_cfg}"
+	fi
+	if [ "${awg_s2}" ]; then
+		echo "S2 = ${awg_s2}" >> "${wg_cfg}"
+	fi
+	if [ "${awg_h1}" ]; then
+		echo "H1 = ${awg_h1}" >> "${wg_cfg}"
+	fi
+	if [ "${awg_h2}" ]; then
+		echo "H2 = ${awg_h2}" >> "${wg_cfg}"
+	fi
+	if [ "${awg_h3}" ]; then
+		echo "H3 = ${awg_h3}" >> "${wg_cfg}"
+	fi
+	if [ "${awg_h4}" ]; then
+		echo "H4 = ${awg_h4}" >> "${wg_cfg}"
+	fi
+
+	config_foreach proto_amneziawg_setup_peer "amneziawg_${config}"
+
+	# apply configuration file
+	${WG} setconf "${config}" "${wg_cfg}"
+	WG_RETURN=$?
+
+	rm -f "${wg_cfg}"
+
+	if [ ${WG_RETURN} -ne 0 ]; then
+		sleep 5
+		proto_setup_failed "${config}"
+		exit 1
+	fi
+
+	for address in ${addresses}; do
+		case "${address}" in
+			*:*/*)
+				proto_add_ipv6_address "${address%%/*}" "${address##*/}"
+				;;
+			*.*/*)
+				proto_add_ipv4_address "${address%%/*}" "${address##*/}"
+				;;
+			*:*)
+				proto_add_ipv6_address "${address%%/*}" "128"
+				;;
+			*.*)
+				proto_add_ipv4_address "${address%%/*}" "32"
+				;;
+		esac
+	done
+
+	for prefix in ${ip6prefix}; do
+		proto_add_ipv6_prefix "$prefix"
+	done
+
+	# endpoint dependency
+	if [ "${nohostroute}" != "1" ]; then
+		awg show "${config}" endpoints | \
+		sed -E 's/\[?([0-9.:a-f]+)\]?:([0-9]+)/\1 \2/' | \
+		while IFS=$'\t ' read -r key address port; do
+			[ -n "${port}" ] || continue
+			proto_add_host_dependency "${config}" "${address}" "${tunlink}"
+		done
+	fi
+
+	proto_send_update "${config}"
+}
+
+proto_amneziawg_teardown() {
+	local config="$1"
+	if proto_amneziawg_is_kernel_mode; then
+		ip link del dev "${config}" >/dev/null 2>&1
+	else
+		rm -f "/var/run/amneziawg/${config}.sock"
+	fi
+}
+
+[ -n "$INCLUDE_ONLY" ] || {
+	add_protocol amneziawg
+}

--- a/amneziawg-tools/files/amneziawg_watchdog
+++ b/amneziawg-tools/files/amneziawg_watchdog
@@ -1,0 +1,67 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2018 Aleksandr V. Piskunov <aleksandr.v.piskunov@gmail.com>.
+# Copyright (C) 2015-2018 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
+#
+# This watchdog script tries to re-resolve hostnames for inactive WireGuard peers.
+# Use it for peers with a frequently changing dynamic IP.
+# persistent_keepalive must be set, recommended value is 25 seconds.
+#
+# Run this script from cron every minute:
+# echo '* * * * * /usr/bin/wireguard_watchdog' >> /etc/crontabs/root
+
+. /lib/functions.sh
+
+check_peer_activity() {
+  local cfg="$1"
+  local iface="$2"
+  local disabled
+  local public_key
+  local endpoint_host
+  local endpoint_port
+  local persistent_keepalive
+  local last_handshake
+  local idle_seconds
+
+  config_get_bool disabled "${cfg}" "disabled" 0
+  config_get public_key    "${cfg}" "public_key"
+  config_get endpoint_host "${cfg}" "endpoint_host"
+  config_get endpoint_port "${cfg}" "endpoint_port"
+
+  if [ "${disabled}" -eq 1 ]; then
+    # skip disabled peers
+    return 0
+  fi
+
+  persistent_keepalive=$(awg show "${iface}" persistent-keepalive | grep "${public_key}" | awk '{print $2}')
+
+  # only process peers with endpoints and keepalive set
+  [ -z "${endpoint_host}" ] && return 0;
+  if [ -z "${persistent_keepalive}" ] || [ "${persistent_keepalive}" = "off" ]; then return 0; fi
+
+  # skip IP addresses
+  # check taken from packages/net/ddns-scripts/files/dynamic_dns_functions.sh
+  local IPV4_REGEX="[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}"
+  local IPV6_REGEX="\(\([0-9A-Fa-f]\{1,4\}:\)\{1,\}\)\(\([0-9A-Fa-f]\{1,4\}\)\{0,1\}\)\(\(:[0-9A-Fa-f]\{1,4\}\)\{1,\}\)"
+  local IPV4="$(echo "${endpoint_host}" | grep -m 1 -o "$IPV4_REGEX$")"    # do not detect ip in 0.0.0.0.example.com
+  local IPV6="$(echo "${endpoint_host}" | grep -m 1 -o "$IPV6_REGEX")"
+  [ -n "${IPV4}" -o -n "${IPV6}" ] && return 0;
+
+  # re-resolve endpoint hostname if not responding for too long
+  last_handshake=$(awg show "${iface}" latest-handshakes | grep "${public_key}" | awk '{print $2}')
+  [ -z "${last_handshake}" ] && return 0;
+  idle_seconds=$(($(date +%s)-"${last_handshake}"))
+  [ ${idle_seconds} -lt 150 ] && return 0;
+  logger -t "amneziawg_monitor" "${iface} endpoint ${endpoint_host}:${endpoint_port} is not responding for ${idle_seconds} seconds, trying to re-resolve hostname"
+  awg set "${iface}" peer "${public_key}" endpoint "${endpoint_host}:${endpoint_port}"
+}
+
+# query ubus for all active wireguard interfaces
+eval $(ubus -S call network.interface dump | jsonfilter -e 'wg_ifaces=@.interface[@.up=true && @.proto="amneziawg"].interface')
+
+# check every peer in every active wireguard interface
+config_load network
+for iface in $wg_ifaces; do
+  config_foreach check_peer_activity "amneziawg_${iface}" "${iface}"
+done

--- a/kmod-amneziawg/Makefile
+++ b/kmod-amneziawg/Makefile
@@ -1,0 +1,43 @@
+include $(TOPDIR)/rules.mk
+
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=kmod-amneziawg
+PKG_RELEASE:=$(AUTORELEASE)
+
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/amneziawg
+	SECTION:=kernel
+	CATEGORY:=Kernel modules
+	SUBMENU:=Network Support
+	URL:=https://amnezia.org/
+	TITLE:=AmneziaWG Kernel Module
+	FILES:=$(PKG_BUILD_DIR)/amneziawg.ko
+	DEPENDS:= \
+		+kmod-udptunnel4 \
+		+IPV6:kmod-udptunnel6 \
+		+kmod-crypto-lib-chacha20poly1305 \
+		+kmod-crypto-lib-curve25519
+	AUTOLOAD:=$(call AutoProbe,amneziawg)
+endef
+
+define Build/Prepare
+	cp -fr $(LINUX_DIR)/drivers/net/wireguard/{*.c,*.h,selftest/} $(PKG_BUILD_DIR)
+	mkdir -p $(PKG_BUILD_DIR)/uapi
+	cp -f $(LINUX_DIR)/include/uapi/linux/wireguard.h $(PKG_BUILD_DIR)/uapi/
+	for patch in `ls files/*`; do \
+		patch -d $(PKG_BUILD_DIR)/ -F3 -t -p0 -i "$$$$(pwd)/$$$${patch}"; \
+	done
+	cp -f src/Makefile $(PKG_BUILD_DIR)
+endef
+
+define Build/Compile
+	$(MAKE) -C "$(LINUX_DIR)" \
+		$(KERNEL_MAKE_FLAGS) \
+		M="$(PKG_BUILD_DIR)" \
+		EXTRA_CFLAGS="$(BUILDFLAGS)" \
+		modules
+endef
+
+$(eval $(call KernelPackage,amneziawg))

--- a/kmod-amneziawg/files/000-initial-amneziawg.patch
+++ b/kmod-amneziawg/files/000-initial-amneziawg.patch
@@ -1,0 +1,833 @@
+diff --git cookie.c cookie.c
+index 8b7d1fe..3120094 100644
+--- cookie.c
++++ cookie.c
+@@ -179,13 +179,13 @@ void wg_cookie_add_mac_to_packet(void *message, size_t len,
+ 
+ void wg_cookie_message_create(struct message_handshake_cookie *dst,
+ 			      struct sk_buff *skb, __le32 index,
+-			      struct cookie_checker *checker)
++			      struct cookie_checker *checker, u32 message_type)
+ {
+ 	struct message_macs *macs = (struct message_macs *)
+ 		((u8 *)skb->data + skb->len - sizeof(*macs));
+ 	u8 cookie[COOKIE_LEN];
+ 
+-	dst->header.type = cpu_to_le32(MESSAGE_HANDSHAKE_COOKIE);
++	dst->header.type = cpu_to_le32(message_type);
+ 	dst->receiver_index = index;
+ 	get_random_bytes_wait(dst->nonce, COOKIE_NONCE_LEN);
+ 
+diff --git cookie.h cookie.h
+index c4bd61c..2b50660 100644
+--- cookie.h
++++ cookie.h
+@@ -52,7 +52,7 @@ void wg_cookie_add_mac_to_packet(void *message, size_t len,
+ 
+ void wg_cookie_message_create(struct message_handshake_cookie *src,
+ 			      struct sk_buff *skb, __le32 index,
+-			      struct cookie_checker *checker);
++			      struct cookie_checker *checker, u32 message_type);
+ void wg_cookie_message_consume(struct message_handshake_cookie *src,
+ 			       struct wg_device *wg);
+ 
+diff --git device.c device.c
+index 062490f..40c4f1c 100644
+--- device.c
++++ device.c
+@@ -377,6 +377,11 @@ static int wg_newlink(struct net *src_net, struct net_device *dev,
+ 	 */
+ 	dev->priv_destructor = wg_destruct;
+ 
++	wg->advanced_security_config.init_packet_magic_header = MESSAGE_HANDSHAKE_INITIATION;
++	wg->advanced_security_config.response_packet_magic_header = MESSAGE_HANDSHAKE_RESPONSE;
++	wg->advanced_security_config.cookie_packet_magic_header = MESSAGE_HANDSHAKE_COOKIE;
++	wg->advanced_security_config.transport_packet_magic_header = MESSAGE_DATA;
++
+ 	pr_debug("%s: Interface created\n", dev->name);
+ 	return ret;
+ 
+@@ -473,3 +478,118 @@ void wg_device_uninit(void)
+ #endif
+ 	rcu_barrier();
+ }
++
++int wg_device_handle_post_config(struct net_device *dev, struct amnezia_config *asc)
++{
++	struct wg_device *wg = netdev_priv(dev);
++	bool a_sec_on = false;
++	int ret = 0;
++
++	if (!asc->advanced_security_enabled)
++		goto out;
++
++	if (asc->junk_packet_count < 0) {
++		net_dbg_ratelimited("%s: JunkPacketCount should be non negative\n", dev->name);
++		ret = -EINVAL;
++	}
++
++	wg->advanced_security_config.junk_packet_count = asc->junk_packet_count;
++	if (asc->junk_packet_count != 0)
++		a_sec_on = true;
++
++	wg->advanced_security_config.junk_packet_min_size = asc->junk_packet_min_size;
++	if (asc->junk_packet_min_size != 0)
++		a_sec_on = true;
++
++	if (asc->junk_packet_count > 0 && asc->junk_packet_min_size == asc->junk_packet_max_size)
++		asc->junk_packet_max_size++;
++
++	if (asc->junk_packet_max_size >= MESSAGE_MAX_SIZE) {
++		wg->advanced_security_config.junk_packet_min_size = 0;
++		wg->advanced_security_config.junk_packet_max_size = 1;
++
++		net_dbg_ratelimited("%s: JunkPacketMaxSize: %d; should be smaller than maxSegmentSize: %d\n",
++							dev->name, asc->junk_packet_max_size,
++							MESSAGE_MAX_SIZE);
++		ret = -EINVAL;
++	} else if (asc->junk_packet_max_size < asc->junk_packet_min_size) {
++		net_dbg_ratelimited("%s: maxSize: %d; should be greater than minSize: %d\n",
++							dev->name, asc->junk_packet_max_size,
++							asc->junk_packet_min_size);
++		ret = -EINVAL;
++	} else
++		wg->advanced_security_config.junk_packet_max_size = asc->junk_packet_max_size;
++
++	if (asc->junk_packet_max_size != 0)
++		a_sec_on = true;
++
++	if (asc->init_packet_junk_size + MESSAGE_INITIATION_SIZE >= MESSAGE_MAX_SIZE) {
++		net_dbg_ratelimited("%s: init header size (%d) + junkSize (%d) should be smaller than maxSegmentSize: %d\n",
++		                    dev->name, MESSAGE_INITIATION_SIZE,
++							asc->init_packet_junk_size, MESSAGE_MAX_SIZE);
++		ret = -EINVAL;
++	} else
++		wg->advanced_security_config.init_packet_junk_size = asc->init_packet_junk_size;
++
++	if (asc->init_packet_junk_size != 0)
++		a_sec_on = true;
++
++	if (asc->response_packet_junk_size + MESSAGE_RESPONSE_SIZE >= MESSAGE_MAX_SIZE) {
++		net_dbg_ratelimited("%s: response header size (%d) + junkSize (%d) should be smaller than maxSegmentSize: %d\n",
++		                    dev->name, MESSAGE_RESPONSE_SIZE,
++		                    asc->response_packet_junk_size, MESSAGE_MAX_SIZE);
++		ret = -EINVAL;
++	} else
++		wg->advanced_security_config.response_packet_junk_size = asc->response_packet_junk_size;
++
++	if (asc->response_packet_junk_size != 0)
++		a_sec_on = true;
++
++	if (asc->init_packet_magic_header > MESSAGE_DATA) {
++		a_sec_on = true;
++		wg->advanced_security_config.init_packet_magic_header = asc->init_packet_magic_header;
++	}
++
++	if (asc->response_packet_magic_header > MESSAGE_DATA) {
++		a_sec_on = true;
++		wg->advanced_security_config.response_packet_magic_header = asc->response_packet_magic_header;
++	}
++
++	if (asc->cookie_packet_magic_header > MESSAGE_DATA) {
++		a_sec_on = true;
++		wg->advanced_security_config.cookie_packet_magic_header = asc->cookie_packet_magic_header;
++	}
++
++	if (asc->transport_packet_magic_header > MESSAGE_DATA) {
++		a_sec_on = true;
++		wg->advanced_security_config.transport_packet_magic_header = asc->transport_packet_magic_header;
++	}
++
++	if (wg->advanced_security_config.init_packet_magic_header == wg->advanced_security_config.response_packet_magic_header ||
++			wg->advanced_security_config.init_packet_magic_header == wg->advanced_security_config.cookie_packet_magic_header ||
++			wg->advanced_security_config.init_packet_magic_header == wg->advanced_security_config.transport_packet_magic_header ||
++			wg->advanced_security_config.response_packet_magic_header == wg->advanced_security_config.cookie_packet_magic_header ||
++			wg->advanced_security_config.response_packet_magic_header == wg->advanced_security_config.transport_packet_magic_header ||
++			wg->advanced_security_config.cookie_packet_magic_header == wg->advanced_security_config.transport_packet_magic_header) {
++		net_dbg_ratelimited("%s: magic headers should differ; got: init:%d; recv:%d; unde:%d; tran:%d\n",
++		                    dev->name,
++							wg->advanced_security_config.init_packet_magic_header,
++		                    wg->advanced_security_config.response_packet_magic_header,
++							wg->advanced_security_config.cookie_packet_magic_header,
++							wg->advanced_security_config.transport_packet_magic_header);
++		ret = -EINVAL;
++	}
++
++	if (MESSAGE_INITIATION_SIZE + wg->advanced_security_config.init_packet_junk_size ==
++		MESSAGE_RESPONSE_SIZE + wg->advanced_security_config.response_packet_junk_size) {
++		net_dbg_ratelimited("%s: new init size:%d; and new response size:%d; should differ\n",
++		                    dev->name,
++		                    MESSAGE_INITIATION_SIZE + asc->init_packet_junk_size,
++		                    MESSAGE_RESPONSE_SIZE + asc->response_packet_junk_size);
++		ret = -EINVAL;
++	}
++
++	wg->advanced_security_config.advanced_security_enabled = a_sec_on;
++out:
++	return ret;
++}
+diff --git device.h device.h
+index 43c7ceb..89e946c 100644
+--- device.h
++++ device.h
+@@ -37,6 +37,19 @@ struct prev_queue {
+ 	atomic_t count;
+ };
+ 
++struct amnezia_config {
++	bool advanced_security_enabled;
++	u16 junk_packet_count;
++	u16 junk_packet_min_size;
++	u16 junk_packet_max_size;
++	u16 init_packet_junk_size;
++	u16 response_packet_junk_size;
++	u32 init_packet_magic_header;
++	u32 response_packet_magic_header;
++	u32 cookie_packet_magic_header;
++	u32 transport_packet_magic_header;
++};
++
+ struct wg_device {
+ 	struct net_device *dev;
+ 	struct crypt_queue encrypt_queue, decrypt_queue, handshake_queue;
+@@ -50,6 +63,7 @@ struct wg_device {
+ 	struct allowedips peer_allowedips;
+ 	struct mutex device_update_lock, socket_update_lock;
+ 	struct list_head device_list, peer_list;
++	struct amnezia_config advanced_security_config;
+ 	atomic_t handshake_queue_len;
+ 	unsigned int num_peers, device_update_gen;
+ 	u32 fwmark;
+@@ -58,5 +72,6 @@ struct wg_device {
+ 
+ int wg_device_init(void);
+ void wg_device_uninit(void);
++int wg_device_handle_post_config(struct net_device *dev, struct amnezia_config *asc);
+ 
+ #endif /* _WG_DEVICE_H */
+diff --git main.c main.c
+index 5506738..b45253d 100644
+--- main.c
++++ main.c
+@@ -9,9 +9,7 @@
+ #include "queueing.h"
+ #include "ratelimiter.h"
+ #include "netlink.h"
+-
+-#include <uapi/linux/wireguard.h>
+-
++#include "uapi/wireguard.h"
+ #include "crypto/zinc.h"
+ 
+ #include <linux/init.h>
+@@ -52,7 +50,7 @@ static int __init wg_mod_init(void)
+ 	if (ret < 0)
+ 		goto err_netlink;
+ 
+-	pr_info("WireGuard " WIREGUARD_VERSION " loaded. See www.wireguard.com for information.\n");
++	pr_info("WireGuard " WIREGUARD_VERSION " (AmneziaWG) loaded. See www.amnezia.org for information.\n");
+ 	pr_info("Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.\n");
+ 
+ 	return 0;
+@@ -78,7 +76,7 @@ static void __exit wg_mod_exit(void)
+ module_init(wg_mod_init);
+ module_exit(wg_mod_exit);
+ MODULE_LICENSE("GPL v2");
+-MODULE_DESCRIPTION("WireGuard secure network tunnel");
++MODULE_DESCRIPTION("WireGuard (AmneziaWG) secure network tunnel");
+ MODULE_AUTHOR("Jason A. Donenfeld <Jason@zx2c4.com>");
+ MODULE_VERSION(WIREGUARD_VERSION);
+ MODULE_ALIAS_RTNL_LINK(KBUILD_MODNAME);
+diff --git messages.h messages.h
+index 1d1ed18..42cd054 100644
+--- messages.h
++++ messages.h
+@@ -117,6 +117,14 @@ enum message_alignments {
+ 	MESSAGE_MINIMUM_LENGTH = message_data_len(0)
+ };
+ 
++enum message_size {
++	MESSAGE_INITIATION_SIZE = sizeof(struct message_handshake_initiation),
++	MESSAGE_RESPONSE_SIZE = sizeof(struct message_handshake_response),
++	MESSAGE_COOKIE_REPLY_SIZE = sizeof(struct message_handshake_cookie),
++	MESSAGE_TRANSPORT_SIZE = sizeof(struct message_data),
++	MESSAGE_MAX_SIZE = 65535
++};
++
+ #define SKB_HEADER_LEN                                       \
+ 	(max(sizeof(struct iphdr), sizeof(struct ipv6hdr)) + \
+ 	 sizeof(struct udphdr) + NET_SKB_PAD)
+diff --git netlink.c netlink.c
+index e3420e0..1d03aef 100644
+--- netlink.c
++++ netlink.c
+@@ -9,9 +9,7 @@
+ #include "socket.h"
+ #include "queueing.h"
+ #include "messages.h"
+-
+-#include <uapi/linux/wireguard.h>
+-
++#include "uapi/wireguard.h"
+ #include <linux/if.h>
+ #include <net/genetlink.h>
+ #include <net/sock.h>
+@@ -27,7 +25,16 @@ static const struct nla_policy device_policy[WGDEVICE_A_MAX + 1] = {
+ 	[WGDEVICE_A_FLAGS]		= { .type = NLA_U32 },
+ 	[WGDEVICE_A_LISTEN_PORT]	= { .type = NLA_U16 },
+ 	[WGDEVICE_A_FWMARK]		= { .type = NLA_U32 },
+-	[WGDEVICE_A_PEERS]		= { .type = NLA_NESTED }
++	[WGDEVICE_A_PEERS]		= { .type = NLA_NESTED },
++	[WGDEVICE_A_JC]		= { .type = NLA_U16 },
++	[WGDEVICE_A_JMIN]		= { .type = NLA_U16 },
++	[WGDEVICE_A_JMAX]		= { .type = NLA_U16 },
++	[WGDEVICE_A_S1]		= { .type = NLA_U16 },
++	[WGDEVICE_A_S2]		= { .type = NLA_U16 },
++	[WGDEVICE_A_H1]		= { .type = NLA_U32 },
++	[WGDEVICE_A_H2]		= { .type = NLA_U32 },
++	[WGDEVICE_A_H3]		= { .type = NLA_U32 },
++	[WGDEVICE_A_H4]		= { .type = NLA_U32 }
+ };
+ 
+ static const struct nla_policy peer_policy[WGPEER_A_MAX + 1] = {
+@@ -233,7 +240,25 @@ static int wg_get_device_dump(struct sk_buff *skb, struct netlink_callback *cb)
+ 				wg->incoming_port) ||
+ 		    nla_put_u32(skb, WGDEVICE_A_FWMARK, wg->fwmark) ||
+ 		    nla_put_u32(skb, WGDEVICE_A_IFINDEX, wg->dev->ifindex) ||
+-		    nla_put_string(skb, WGDEVICE_A_IFNAME, wg->dev->name))
++		    nla_put_string(skb, WGDEVICE_A_IFNAME, wg->dev->name) ||
++		    nla_put_u16(skb, WGDEVICE_A_JC,
++					    wg->advanced_security_config.junk_packet_count) ||
++		    nla_put_u16(skb, WGDEVICE_A_JMIN,
++					    wg->advanced_security_config.junk_packet_min_size) ||
++		    nla_put_u16(skb, WGDEVICE_A_JMAX,
++					    wg->advanced_security_config.junk_packet_max_size) ||
++		    nla_put_u16(skb, WGDEVICE_A_S1,
++					    wg->advanced_security_config.init_packet_junk_size) ||
++		    nla_put_u16(skb, WGDEVICE_A_S2,
++					    wg->advanced_security_config.response_packet_junk_size) ||
++		    nla_put_u32(skb, WGDEVICE_A_H1,
++					    wg->advanced_security_config.init_packet_magic_header) ||
++		    nla_put_u32(skb, WGDEVICE_A_H2,
++					    wg->advanced_security_config.response_packet_magic_header) ||
++		    nla_put_u32(skb, WGDEVICE_A_H3,
++					    wg->advanced_security_config.cookie_packet_magic_header) ||
++		    nla_put_u32(skb, WGDEVICE_A_H4,
++					    wg->advanced_security_config.transport_packet_magic_header))
+ 			goto out;
+ 
+ 		down_read(&wg->static_identity.lock);
+@@ -494,6 +519,7 @@ out:
+ static int wg_set_device(struct sk_buff *skb, struct genl_info *info)
+ {
+ 	struct wg_device *wg = lookup_interface(info->attrs, skb);
++	struct amnezia_config *asc = kzalloc(sizeof(*asc), GFP_KERNEL);
+ 	u32 flags = 0;
+ 	int ret;
+ 
+@@ -538,6 +564,51 @@ static int wg_set_device(struct sk_buff *skb, struct genl_info *info)
+ 			goto out;
+ 	}
+ 
++	if (info->attrs[WGDEVICE_A_JC]) {
++		asc->advanced_security_enabled = true;
++		asc->junk_packet_count = nla_get_u16(info->attrs[WGDEVICE_A_JC]);
++	}
++
++	if (info->attrs[WGDEVICE_A_JMIN]) {
++		asc->advanced_security_enabled = true;
++		asc->junk_packet_min_size = nla_get_u16(info->attrs[WGDEVICE_A_JMIN]);
++	}
++
++	if (info->attrs[WGDEVICE_A_JMAX]) {
++		asc->advanced_security_enabled = true;
++		asc->junk_packet_max_size = nla_get_u16(info->attrs[WGDEVICE_A_JMAX]);
++	}
++
++	if (info->attrs[WGDEVICE_A_S1]) {
++		asc->advanced_security_enabled = true;
++		asc->init_packet_junk_size = nla_get_u16(info->attrs[WGDEVICE_A_S1]);
++	}
++
++	if (info->attrs[WGDEVICE_A_S2]) {
++		asc->advanced_security_enabled = true;
++		asc->response_packet_junk_size = nla_get_u16(info->attrs[WGDEVICE_A_S2]);
++	}
++
++	if (info->attrs[WGDEVICE_A_H1]) {
++		asc->advanced_security_enabled = true;
++		asc->init_packet_magic_header = nla_get_u32(info->attrs[WGDEVICE_A_H1]);
++	}
++
++	if (info->attrs[WGDEVICE_A_H2]) {
++		asc->advanced_security_enabled = true;
++		asc->response_packet_magic_header = nla_get_u32(info->attrs[WGDEVICE_A_H2]);
++	}
++
++	if (info->attrs[WGDEVICE_A_H3]) {
++		asc->advanced_security_enabled = true;
++		asc->cookie_packet_magic_header = nla_get_u32(info->attrs[WGDEVICE_A_H3]);
++	}
++
++	if (info->attrs[WGDEVICE_A_H4]) {
++		asc->advanced_security_enabled = true;
++		asc->transport_packet_magic_header = nla_get_u32(info->attrs[WGDEVICE_A_H4]);
++	}
++
+ 	if (flags & WGDEVICE_F_REPLACE_PEERS)
+ 		wg_peer_remove_all(wg);
+ 
+@@ -591,13 +662,14 @@ skip_set_private_key:
+ 				goto out;
+ 		}
+ 	}
+-	ret = 0;
++	ret = wg_device_handle_post_config(wg->dev, asc);
+
+ out:
+ 	mutex_unlock(&wg->device_update_lock);
+ 	rtnl_unlock();
+ 	dev_put(wg->dev);
+ out_nodev:
++	kfree(asc);
+ 	if (info->attrs[WGDEVICE_A_PRIVATE_KEY])
+ 		memzero_explicit(nla_data(info->attrs[WGDEVICE_A_PRIVATE_KEY]),
+ 				 nla_len(info->attrs[WGDEVICE_A_PRIVATE_KEY]));
+diff --git noise.c noise.c
+index baf455e..9a4e8e0 100644
+--- noise.c
++++ noise.c
+@@ -484,7 +484,7 @@ static void tai64n_now(u8 output[NOISE_TIMESTAMP_LEN])
+ 
+ bool
+ wg_noise_handshake_create_initiation(struct message_handshake_initiation *dst,
+-				     struct noise_handshake *handshake)
++				     struct noise_handshake *handshake, u32 message_type)
+ {
+ 	u8 timestamp[NOISE_TIMESTAMP_LEN];
+ 	u8 key[NOISE_SYMMETRIC_KEY_LEN];
+@@ -501,7 +501,7 @@ wg_noise_handshake_create_initiation(struct message_handshake_initiation *dst,
+ 	if (unlikely(!handshake->static_identity->has_identity))
+ 		goto out;
+ 
+-	dst->header.type = cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION);
++	dst->header.type = cpu_to_le32(message_type);
+ 
+ 	handshake_init(handshake->chaining_key, handshake->hash,
+ 		       handshake->remote_static);
+@@ -634,7 +634,7 @@ out:
+ }
+ 
+ bool wg_noise_handshake_create_response(struct message_handshake_response *dst,
+-					struct noise_handshake *handshake)
++					struct noise_handshake *handshake, u32 message_type)
+ {
+ 	u8 key[NOISE_SYMMETRIC_KEY_LEN];
+ 	bool ret = false;
+@@ -650,7 +650,7 @@ bool wg_noise_handshake_create_response(struct message_handshake_response *dst,
+ 	if (handshake->state != HANDSHAKE_CONSUMED_INITIATION)
+ 		goto out;
+ 
+-	dst->header.type = cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE);
++	dst->header.type = cpu_to_le32(message_type);
+ 	dst->receiver_index = handshake->remote_index;
+ 
+ 	/* e */
+diff --git noise.h noise.h
+index c527253..300d9d4 100644
+--- noise.h
++++ noise.h
+@@ -118,13 +118,13 @@ void wg_noise_precompute_static_static(struct wg_peer *peer);
+ 
+ bool
+ wg_noise_handshake_create_initiation(struct message_handshake_initiation *dst,
+-				     struct noise_handshake *handshake);
++				     struct noise_handshake *handshake, u32 message_type);
+ struct wg_peer *
+ wg_noise_handshake_consume_initiation(struct message_handshake_initiation *src,
+ 				      struct wg_device *wg);
+ 
+ bool wg_noise_handshake_create_response(struct message_handshake_response *dst,
+-					struct noise_handshake *handshake);
++					struct noise_handshake *handshake, u32 message_type);
+ struct wg_peer *
+ wg_noise_handshake_consume_response(struct message_handshake_response *src,
+ 				    struct wg_device *wg);
+diff --git receive.c receive.c
+index 214889e..d6566e6 100644
+--- receive.c
++++ receive.c
+@@ -33,25 +33,51 @@ static void update_rx_stats(struct wg_peer *peer, size_t len)
+ 
+ #define SKB_TYPE_LE32(skb) (((struct message_header *)(skb)->data)->type)
+ 
+-static size_t validate_header_len(struct sk_buff *skb)
++static size_t validate_header_len(struct sk_buff *skb, struct wg_device *wg)
+ {
+ 	if (unlikely(skb->len < sizeof(struct message_header)))
+ 		return 0;
+-	if (SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_DATA) &&
++	if (SKB_TYPE_LE32(skb) == cpu_to_le32(wg->advanced_security_config.transport_packet_magic_header) &&
+ 	    skb->len >= MESSAGE_MINIMUM_LENGTH)
+ 		return sizeof(struct message_data);
+-	if (SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION) &&
+-	    skb->len == sizeof(struct message_handshake_initiation))
+-		return sizeof(struct message_handshake_initiation);
+-	if (SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE) &&
+-	    skb->len == sizeof(struct message_handshake_response))
+-		return sizeof(struct message_handshake_response);
+-	if (SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_COOKIE) &&
+-	    skb->len == sizeof(struct message_handshake_cookie))
+-		return sizeof(struct message_handshake_cookie);
++	if (SKB_TYPE_LE32(skb) == cpu_to_le32(wg->advanced_security_config.init_packet_magic_header) &&
++	    skb->len == MESSAGE_INITIATION_SIZE)
++		return MESSAGE_INITIATION_SIZE;
++	if (SKB_TYPE_LE32(skb) == cpu_to_le32(wg->advanced_security_config.response_packet_magic_header) &&
++	    skb->len == MESSAGE_RESPONSE_SIZE)
++		return MESSAGE_RESPONSE_SIZE;
++	if (SKB_TYPE_LE32(skb) == cpu_to_le32(wg->advanced_security_config.cookie_packet_magic_header) &&
++	    skb->len == MESSAGE_COOKIE_REPLY_SIZE)
++		return MESSAGE_COOKIE_REPLY_SIZE;
+ 	return 0;
+ }
+ 
++void prepare_advanced_secured_message(struct sk_buff *skb, struct wg_device *wg)
++{
++	u32 assumed_type = SKB_TYPE_LE32(skb);
++	u32 assumed_offset;
++
++	if (wg->advanced_security_config.advanced_security_enabled) {
++		if (skb->len == MESSAGE_INITIATION_SIZE + wg->advanced_security_config.init_packet_junk_size) {
++			assumed_type = cpu_to_le32(wg->advanced_security_config.init_packet_magic_header);
++			assumed_offset = wg->advanced_security_config.init_packet_junk_size;
++		} else if (skb->len == MESSAGE_RESPONSE_SIZE + wg->advanced_security_config.response_packet_junk_size) {
++			assumed_type = cpu_to_le32(wg->advanced_security_config.response_packet_magic_header);
++			assumed_offset = wg->advanced_security_config.response_packet_junk_size;
++		} else
++			return;
++
++		if (unlikely(assumed_offset <= 0) || unlikely(!pskb_may_pull(skb, assumed_offset)))
++			return;
++
++		skb_pull(skb, assumed_offset);
++
++		if (SKB_TYPE_LE32(skb) != assumed_type) {
++			skb_push(skb, assumed_offset);
++		}
++	}
++}
++
+ static int prepare_skb_header(struct sk_buff *skb, struct wg_device *wg)
+ {
+ 	size_t data_offset, data_len, header_len;
+@@ -87,7 +113,8 @@ static int prepare_skb_header(struct sk_buff *skb, struct wg_device *wg)
+ 	if (unlikely(skb->len != data_len))
+ 		/* Final len does not agree with calculated len */
+ 		return -EINVAL;
+-	header_len = validate_header_len(skb);
++	prepare_advanced_secured_message(skb, wg);
++	header_len = validate_header_len(skb, wg);
+ 	if (unlikely(!header_len))
+ 		return -EINVAL;
+ 	__skb_push(skb, data_offset);
+@@ -109,7 +136,7 @@ static void wg_receive_handshake_packet(struct wg_device *wg,
+ 	bool packet_needs_cookie;
+ 	bool under_load;
+ 
+-	if (SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_COOKIE)) {
++	if (SKB_TYPE_LE32(skb) == cpu_to_le32(wg->advanced_security_config.cookie_packet_magic_header)) {
+ 		net_dbg_skb_ratelimited("%s: Receiving cookie response from %pISpfsc\n",
+ 					wg->dev->name, skb);
+ 		wg_cookie_message_consume(
+@@ -139,8 +166,7 @@ static void wg_receive_handshake_packet(struct wg_device *wg,
+ 		return;
+ 	}
+ 
+-	switch (SKB_TYPE_LE32(skb)) {
+-	case cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION): {
++	if (SKB_TYPE_LE32(skb) == cpu_to_le32(wg->advanced_security_config.init_packet_magic_header)) {
+ 		struct message_handshake_initiation *message =
+ 			(struct message_handshake_initiation *)skb->data;
+ 
+@@ -160,9 +186,8 @@ static void wg_receive_handshake_packet(struct wg_device *wg,
+ 				    wg->dev->name, peer->internal_id,
+ 				    &peer->endpoint.addr);
+ 		wg_packet_send_handshake_response(peer);
+-		break;
+ 	}
+-	case cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE): {
++	if (SKB_TYPE_LE32(skb) == cpu_to_le32(wg->advanced_security_config.response_packet_magic_header)) {
+ 		struct message_handshake_response *message =
+ 			(struct message_handshake_response *)skb->data;
+ 
+@@ -193,8 +218,6 @@ static void wg_receive_handshake_packet(struct wg_device *wg,
+ 			 */
+ 			wg_packet_send_keepalive(peer);
+ 		}
+-		break;
+-	}
+ 	}
+ 
+ 	if (unlikely(!peer)) {
+@@ -559,10 +582,10 @@ void wg_packet_receive(struct wg_device *wg, struct sk_buff *skb)
+ {
+ 	if (unlikely(prepare_skb_header(skb, wg) < 0))
+ 		goto err;
+-	switch (SKB_TYPE_LE32(skb)) {
+-	case cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION):
+-	case cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE):
+-	case cpu_to_le32(MESSAGE_HANDSHAKE_COOKIE): {
++
++	if (SKB_TYPE_LE32(skb) == cpu_to_le32(wg->advanced_security_config.init_packet_magic_header) ||
++	    SKB_TYPE_LE32(skb) == cpu_to_le32(wg->advanced_security_config.response_packet_magic_header) ||
++	    SKB_TYPE_LE32(skb) == cpu_to_le32(wg->advanced_security_config.cookie_packet_magic_header)) {
+ 		int cpu, ret = -EBUSY;
+ 
+ 		if (unlikely(!rng_is_initialized()))
+@@ -575,23 +598,20 @@ void wg_packet_receive(struct wg_device *wg, struct sk_buff *skb)
+ 		} else
+ 			ret = ptr_ring_produce_bh(&wg->handshake_queue.ring, skb);
+ 		if (ret) {
+-	drop:
++drop:
+ 			net_dbg_skb_ratelimited("%s: Dropping handshake packet from %pISpfsc\n",
+-						wg->dev->name, skb);
++			                        wg->dev->name, skb);
+ 			goto err;
+ 		}
+ 		atomic_inc(&wg->handshake_queue_len);
+ 		cpu = wg_cpumask_next_online(&wg->handshake_queue.last_cpu);
+ 		/* Queues up a call to packet_process_queued_handshake_packets(skb): */
+ 		queue_work_on(cpu, wg->handshake_receive_wq,
+-			      &per_cpu_ptr(wg->handshake_queue.worker, cpu)->work);
+-		break;
+-	}
+-	case cpu_to_le32(MESSAGE_DATA):
++		              &per_cpu_ptr(wg->handshake_queue.worker, cpu)->work);
++	} else if (SKB_TYPE_LE32(skb) == cpu_to_le32(wg->advanced_security_config.transport_packet_magic_header)) {
+ 		PACKET_CB(skb)->ds = ip_tunnel_get_dsfield(ip_hdr(skb), skb);
+ 		wg_packet_consume_data(wg, skb);
+-		break;
+-	default:
++	} else {
+ 		WARN(1, "Non-exhaustive parsing of packet header lead to unknown packet type!\n");
+ 		goto err;
+ 	}
+diff --git send.c send.c
+index 2b19344..c96d2a2 100644
+--- send.c
++++ send.c
+@@ -15,13 +15,24 @@
+ #include <linux/uio.h>
+ #include <linux/inetdevice.h>
+ #include <linux/socket.h>
++#include <linux/random.h>
+ #include <net/ip_tunnels.h>
+ #include <net/udp.h>
+ #include <net/sock.h>
+ 
++u32 wg_get_random_u32_inclusive(u32 floor, u32 ceil)
++{
++	u32 diff = ceil - floor + 1;
++	return floor + (get_random_u32() % diff);
++}
++
+ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
+ {
+ 	struct message_handshake_initiation packet;
++	struct wg_device *wg = peer->device;
++	void *buffer;
++	u8 ds;
++	u16 junk_packet_count, junk_packet_size;
+ 
+ 	if (!wg_birthdate_has_expired(atomic64_read(&peer->last_sent_handshake),
+ 				      REKEY_TIMEOUT))
+@@ -32,14 +43,37 @@ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
+ 			    peer->device->dev->name, peer->internal_id,
+ 			    &peer->endpoint.addr);
+ 
+-	if (wg_noise_handshake_create_initiation(&packet, &peer->handshake)) {
++	if (wg->advanced_security_config.advanced_security_enabled) {
++		junk_packet_count = wg->advanced_security_config.junk_packet_count;
++		buffer = kzalloc(wg->advanced_security_config.junk_packet_max_size, GFP_KERNEL);
++
++		while (junk_packet_count-- > 0) {
++			junk_packet_size = (u16) wg_get_random_u32_inclusive(
++					wg->advanced_security_config.junk_packet_min_size,
++					wg->advanced_security_config.junk_packet_max_size);
++
++			get_random_bytes(buffer, junk_packet_size);
++			get_random_bytes(&ds, 1);
++			wg_socket_send_buffer_to_peer(peer, buffer, junk_packet_size, ds);
++		}
++
++		kfree(buffer);
++	}
++
++	if (wg_noise_handshake_create_initiation(&packet, &peer->handshake, wg->advanced_security_config.init_packet_magic_header)) {
+ 		wg_cookie_add_mac_to_packet(&packet, sizeof(packet), peer);
+ 		wg_timers_any_authenticated_packet_traversal(peer);
+ 		wg_timers_any_authenticated_packet_sent(peer);
+ 		atomic64_set(&peer->last_sent_handshake,
+ 			     ktime_get_coarse_boottime_ns());
+-		wg_socket_send_buffer_to_peer(peer, &packet, sizeof(packet),
+-					      HANDSHAKE_DSCP);
++
++		if (wg->advanced_security_config.advanced_security_enabled) {
++			wg_socket_send_junked_buffer_to_peer(peer, &packet, sizeof(packet),
++			                              HANDSHAKE_DSCP, wg->advanced_security_config.init_packet_junk_size);
++		} else {
++			wg_socket_send_buffer_to_peer(peer, &packet, sizeof(packet),
++			                              HANDSHAKE_DSCP);
++		}
+ 		wg_timers_handshake_initiated(peer);
+ 	}
+ }
+@@ -86,13 +120,14 @@ out:
+ void wg_packet_send_handshake_response(struct wg_peer *peer)
+ {
+ 	struct message_handshake_response packet;
++	struct wg_device *wg = peer->device;
+ 
+ 	atomic64_set(&peer->last_sent_handshake, ktime_get_coarse_boottime_ns());
+ 	net_dbg_ratelimited("%s: Sending handshake response to peer %llu (%pISpfsc)\n",
+ 			    peer->device->dev->name, peer->internal_id,
+ 			    &peer->endpoint.addr);
+ 
+-	if (wg_noise_handshake_create_response(&packet, &peer->handshake)) {
++	if (wg_noise_handshake_create_response(&packet, &peer->handshake, wg->advanced_security_config.response_packet_magic_header)) {
+ 		wg_cookie_add_mac_to_packet(&packet, sizeof(packet), peer);
+ 		if (wg_noise_handshake_begin_session(&peer->handshake,
+ 						     &peer->keypairs)) {
+@@ -101,9 +136,16 @@ void wg_packet_send_handshake_response(struct wg_peer *peer)
+ 			wg_timers_any_authenticated_packet_sent(peer);
+ 			atomic64_set(&peer->last_sent_handshake,
+ 				     ktime_get_coarse_boottime_ns());
+-			wg_socket_send_buffer_to_peer(peer, &packet,
+-						      sizeof(packet),
+-						      HANDSHAKE_DSCP);
++			if (wg->advanced_security_config.advanced_security_enabled) {
++				wg_socket_send_junked_buffer_to_peer(peer, &packet,
++				                              sizeof(packet),
++				                              HANDSHAKE_DSCP,
++				                              wg->advanced_security_config.response_packet_junk_size);
++			} else {
++				wg_socket_send_buffer_to_peer(peer, &packet,
++							      sizeof(packet),
++							      HANDSHAKE_DSCP);
++			}
+ 		}
+ 	}
+ }
+@@ -117,7 +159,7 @@ void wg_packet_send_handshake_cookie(struct wg_device *wg,
+ 	net_dbg_skb_ratelimited("%s: Sending cookie response for denied handshake message for %pISpfsc\n",
+ 				wg->dev->name, initiating_skb);
+ 	wg_cookie_message_create(&packet, initiating_skb, sender_index,
+-				 &wg->cookie_checker);
++				 &wg->cookie_checker, wg->advanced_security_config.cookie_packet_magic_header);
+ 	wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb, &packet,
+ 					      sizeof(packet));
+ }
+@@ -160,7 +202,7 @@ static unsigned int calculate_skb_padding(struct sk_buff *skb)
+ 	return padded_size - last_unit;
+ }
+ 
+-static bool encrypt_packet(struct sk_buff *skb, struct noise_keypair *keypair)
++static bool encrypt_packet(u32 message_type, struct sk_buff *skb, struct noise_keypair *keypair)
+ {
+ 	unsigned int padding_len, plaintext_len, trailer_len;
+ 	struct scatterlist sg[MAX_SKB_FRAGS + 8];
+@@ -204,7 +246,7 @@ static bool encrypt_packet(struct sk_buff *skb, struct noise_keypair *keypair)
+ 	 */
+ 	skb_set_inner_network_header(skb, 0);
+ 	header = (struct message_data *)skb_push(skb, sizeof(*header));
+-	header->header.type = cpu_to_le32(MESSAGE_DATA);
++	header->header.type = cpu_to_le32(message_type);
+ 	header->key_idx = keypair->remote_index;
+ 	header->counter = cpu_to_le64(PACKET_CB(skb)->nonce);
+ 	pskb_put(skb, trailer, trailer_len);
+@@ -291,6 +333,7 @@ void wg_packet_encrypt_worker(struct work_struct *work)
+ 	struct crypt_queue *queue = container_of(work, struct multicore_worker,
+ 						 work)->ptr;
+ 	struct sk_buff *first, *skb, *next;
++	struct wg_device *wg;
+ 	simd_context_t simd_context;
+ 
+ 	simd_get(&simd_context);
+@@ -298,7 +341,10 @@ void wg_packet_encrypt_worker(struct work_struct *work)
+ 		enum packet_state state = PACKET_STATE_CRYPTED;
+ 
+ 		skb_list_walk_safe(first, skb, next) {
+-			if (likely(encrypt_packet(skb,
++			wg = PACKET_PEER(first)->device;
++
++			if (likely(encrypt_packet(wg->advanced_security_config.transport_packet_magic_header,
++						  skb,
+ 						  PACKET_CB(first)->keypair,
+ 						  &simd_context))) {
+ 				wg_reset_packet(skb, true);
+diff --git socket.c socket.c
+index 9e0af93..2dd574f 100644
+--- socket.c
++++ socket.c
+@@ -200,6 +200,18 @@ int wg_socket_send_buffer_to_peer(struct wg_peer *peer, void *buffer,
+ 	return wg_socket_send_skb_to_peer(peer, skb, ds);
+ }
+ 
++int wg_socket_send_junked_buffer_to_peer(struct wg_peer *peer, void *buffer,
++                                          size_t len, u8 ds, u16 junk_size)
++{
++	int ret;
++	void *new_buffer = kzalloc(len + junk_size, GFP_KERNEL);
++	get_random_bytes(new_buffer, junk_size);
++	memcpy(new_buffer + junk_size, buffer, len);
++	ret = wg_socket_send_buffer_to_peer(peer, new_buffer, len + junk_size, ds);
++	kfree(new_buffer);
++	return ret;
++}
++
+ int wg_socket_send_buffer_as_reply_to_skb(struct wg_device *wg,
+ 					  struct sk_buff *in_skb, void *buffer,
+ 					  size_t len)
+diff --git socket.h socket.h
+index bab5848..e4e3f96 100644
+--- socket.h
++++ socket.h
+@@ -16,6 +16,8 @@ void wg_socket_reinit(struct wg_device *wg, struct sock *new4,
+ 		      struct sock *new6);
+ int wg_socket_send_buffer_to_peer(struct wg_peer *peer, void *data,
+ 				  size_t len, u8 ds);
++int wg_socket_send_junked_buffer_to_peer(struct wg_peer *peer, void *data,
++                                  size_t len, u8 ds, u16 junk_size);
+ int wg_socket_send_skb_to_peer(struct wg_peer *peer, struct sk_buff *skb,
+ 			       u8 ds);
+ int wg_socket_send_buffer_as_reply_to_skb(struct wg_device *wg,
+diff --git uapi/wireguard.h uapi/wireguard.h
+index ae88be1..f6698e8 100644
+--- uapi/wireguard.h
++++ uapi/wireguard.h
+@@ -131,7 +131,7 @@
+ #ifndef _WG_UAPI_WIREGUARD_H
+ #define _WG_UAPI_WIREGUARD_H
+ 
+-#define WG_GENL_NAME "wireguard"
++#define WG_GENL_NAME "amneziawg"
+ #define WG_GENL_VERSION 1
+ 
+ #define WG_KEY_LEN 32
+@@ -157,6 +157,15 @@ enum wgdevice_attribute {
+ 	WGDEVICE_A_LISTEN_PORT,
+ 	WGDEVICE_A_FWMARK,
+ 	WGDEVICE_A_PEERS,
++	WGDEVICE_A_JC,
++	WGDEVICE_A_JMIN,
++	WGDEVICE_A_JMAX,
++	WGDEVICE_A_S1,
++	WGDEVICE_A_S2,
++	WGDEVICE_A_H1,
++	WGDEVICE_A_H2,
++	WGDEVICE_A_H3,
++	WGDEVICE_A_H4,
+ 	__WGDEVICE_A_LAST
+ };
+ #define WGDEVICE_A_MAX (__WGDEVICE_A_LAST - 1)

--- a/kmod-amneziawg/src/Makefile
+++ b/kmod-amneziawg/src/Makefile
@@ -1,0 +1,20 @@
+# WIREGUARD_VERSION = 1.0.0-awg
+
+ccflags-y := -D'pr_fmt(fmt)=KBUILD_MODNAME ": " fmt'
+# ccflags-y += -D'WIREGUARD_VERSION="$(WIREGUARD_VERSION)"'
+# ccflags-y += -DDEBUG
+amneziawg-y := main.o
+amneziawg-y += noise.o
+amneziawg-y += device.o
+amneziawg-y += peer.o
+amneziawg-y += timers.o
+amneziawg-y += queueing.o
+amneziawg-y += send.o
+amneziawg-y += receive.o
+amneziawg-y += socket.o
+amneziawg-y += peerlookup.o
+amneziawg-y += allowedips.o
+amneziawg-y += ratelimiter.o
+amneziawg-y += cookie.o
+amneziawg-y += netlink.o
+obj-m := amneziawg.o

--- a/net/amneziawg-go/Makefile
+++ b/net/amneziawg-go/Makefile
@@ -1,0 +1,52 @@
+# This is free software, licensed under the MIT License.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=amneziawg-go
+PKG_VERSION:=0.2.12
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/amnezia-vpn/amneziawg-go/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=df6a9bbd2321e801d67ea2ea94c355a8c6d07477b083ed7f3de215254aed2882
+
+PKG_MAINTAINER:=Gregory Gullin <gargullia@proton.me>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/amnezia-vpn/amneziawg-go
+GO_PKG_LDFLAGS_X:=\
+	main.Build=$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../packages/lang/golang/golang-package.mk
+
+define Package/amneziawg-go
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=AmneziaWG userspace implementation program (amneziawg-go)
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Build/Compile
+  $(call GoPackage/Build/Compile)
+endef
+
+define Package/amneziawg-go/description
+  AmneziaWG is a contemporary version of the WireGuard protocol. It's a fork of
+  WireGuard-Go and offers protection against detection by Deep Packet Inspection
+  (DPI) systems. At the same time, it retains the simplified architecture and
+  high performance of the original.
+endef
+
+define Package/amneziawg-go/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/amneziawg-go $(1)/usr/bin/amneziawg-go
+endef
+
+$(eval $(call BuildPackage,amneziawg-go))


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, arm64
Run tested: x86_64, arm64, mipsle

Description:
AmneziaWG VPN kernel module makes it resource efficient to connect to Amnezia VPN services. It is the hardened version of WireGuard protocol that allows to change key WG header values and add junk to handshake. This is the tools (awg and watchdog) used to manage AmneziaWG interfaces.