### PR TITLE
[24.10] libulfius: Install library on target

### DIFF
--- a/libs/libulfius/Makefile
+++ b/libs/libulfius/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libulfius
 PKG_VERSION:=2.7.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/babelouest/ulfius/tar.gz/v$(PKG_VERSION)?
@@ -59,6 +59,14 @@ ifeq ($(BUILD_VARIANT),gnutls)
 else
 	CMAKE_OPTIONS += -DWITH_GNUTLS=OFF
 endif
+
+define Package/libulfius/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libulfius.so* $(1)/usr/lib/
+endef
+
+Package/libulfius-nossl/install = $(Package/libulfius/install)
+Package/libulfius-gnutls/install = $(Package/libulfius/install)
 
 $(eval $(call BuildPackage,libulfius-gnutls))
 $(eval $(call BuildPackage,libulfius-nossl))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @utoni

**Description:**
Backport `libulfius` fix to OpenWRT 24.10

> The current liborcania / libulfius packages do not install to the target, resulting in messages like:
> ```
> Package meshtasticd is missing dependencies for the following libraries:
> liborcania.so.2.3
> libulfius.so.2.7
> ```
> This change corrects the issue by installing the library `.so`s to the target.

(cherry picked from commit 6c62e0fcfecf5a322cba368e5410f5e2f693b411)

Related `master` PR:
- #25527

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2710
- **OpenWrt Device:** Raspberry Pi CM3

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
