### PR TITLE
btop: add migration for alias command

### DIFF
--- a/admin/btop/Makefile
+++ b/admin/btop/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btop
 PKG_VERSION:=1.4.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://codeload.github.com/aristocratos/btop/tar.gz/v$(PKG_VERSION)?
@@ -47,6 +47,8 @@ define Package/btop/install
 
 	$(INSTALL_DIR) $(1)/etc/profile.d
 	$(CP) $(CURDIR)/files/btop.sh $(1)/etc/profile.d/
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(CP) $(CURDIR)/files/btop.uci $(1)/etc/uci-defaults/90-btop-migrate-alias
 endef
 
 $(eval $(call BuildPackage,btop))

--- a/admin/btop/files/btop.uci
+++ b/admin/btop/files/btop.uci
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+grep -q "utf-force" "/etc/profile.d/btop.sh" && sed -i "s,utf-force,force-utf,g" "/etc/profile.d/btop.sh"
+
+exit 0


### PR DESCRIPTION
## 📦 Package Details
**Maintainer:** me

**Description:**
Files in `/etc/profile.d/` are marked as user configs and won't be replaced to new version when update the package, so add a migration script for this.

Fixes: #26709

---

## 🧪 Run Testing Details

- **OpenWrt Version:** n/a
- **OpenWrt Target/Subtarget:** n/a
- **OpenWrt Device:** n/a

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
