### PR TITLE
amneziawg-go: add new package

### DIFF
--- a/net/amneziawg-go/Makefile
+++ b/net/amneziawg-go/Makefile
@@ -23,7 +23,7 @@ GO_PKG_LDFLAGS_X:=\
 	main.Build=$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
-include ../../packages/lang/golang/golang-package.mk
+include ../../lang/golang/golang-package.mk
 
 define Package/amneziawg-go
   SECTION:=net

--- a/net/amneziawg-go/Makefile
+++ b/net/amneziawg-go/Makefile
@@ -1,0 +1,52 @@
+# This is free software, licensed under the MIT License.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=amneziawg-go
+PKG_VERSION:=0.2.12
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/amnezia-vpn/amneziawg-go/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=df6a9bbd2321e801d67ea2ea94c355a8c6d07477b083ed7f3de215254aed2882
+
+PKG_MAINTAINER:=Gregory Gullin <gargullia@proton.me>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/amnezia-vpn/amneziawg-go
+GO_PKG_LDFLAGS_X:=\
+	main.Build=$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../packages/lang/golang/golang-package.mk
+
+define Package/amneziawg-go
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=AmneziaWG userspace implementation program
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Build/Compile
+  $(call GoPackage/Build/Compile)
+endef
+
+define Package/amneziawg-go/description
+  AmneziaWG is a contemporary version of the WireGuard protocol. It's a fork of
+  WireGuard-Go and offers protection against detection by Deep Packet Inspection
+  (DPI) systems. At the same time, it retains the simplified architecture and
+  high performance of the original.
+endef
+
+define Package/amneziawg-go/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/amneziawg-go $(1)/usr/bin/amneziawg-go
+endef
+
+$(eval $(call BuildPackage,amneziawg-go))


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, arm64
Run tested: x86_64, arm64

Description:
AmneziaWG VPN kernel module makes it resource efficient to connect to Amnezia VPN services. It is the hardened version of WireGuard protocol that allows to change key WG header values and add junk to handshake. This is the tools (awg and watchdog) used to manage AmneziaWG interfaces.