### PR TITLE
fuse3: update to version 3.17.2

### DIFF
--- a/utils/fuse3/Makefile
+++ b/utils/fuse3/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=fuse3
 PKG_VERSION:=3.17.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=fuse-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/libfuse/libfuse/releases/download/fuse-$(PKG_VERSION)

--- a/utils/fuse3/Makefile
+++ b/utils/fuse3/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=fuse3
 PKG_VERSION:=3.17.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=fuse-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/libfuse/libfuse/releases/download/fuse-$(PKG_VERSION)

--- a/utils/fuse3/Makefile
+++ b/utils/fuse3/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=fuse3
-PKG_VERSION:=3.16.2
+PKG_VERSION:=3.17.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=fuse-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/libfuse/libfuse/releases/download/fuse-$(PKG_VERSION)
-PKG_HASH:=f797055d9296b275e981f5f62d4e32e089614fc253d1ef2985851025b8a0ce87
+PKG_HASH:=3d932431ad94e86179e5265cddde1d67aa3bb2fb09a5bd35c641f86f2b5ed06f
 PKG_BUILD_DIR:=$(BUILD_DIR)/fuse-$(PKG_VERSION)
 
 PKG_MAINTAINER:=

--- a/utils/fuse3/patches/100-fuse_signals.c-fix-build-warning-when-HAVE_BACKTRACE.patch
+++ b/utils/fuse3/patches/100-fuse_signals.c-fix-build-warning-when-HAVE_BACKTRACE.patch
@@ -1,0 +1,31 @@
+From: Georgi Valkov <gvalkov@gmail.com>
+Date: Thu, 12 Jun 2025 07:36:14 +0300
+Subject: [PATCH] fuse_signals.c: fix build warning when HAVE_BACKTRACE is
+ undefined
+
+BT_STACK_SZ and backtrace_buffer are not used when
+HAVE_BACKTRACE is undefined. Wrap them in #ifdef
+to avoid a build warning:
+
+../lib/fuse_signals.c:31:14: warning: 'backtrace_buffer' defined but not used [-Wunused-variable]
+   31 | static void *backtrace_buffer[BT_STACK_SZ];
+      |              ^~~~~~~~~~~~~~~~
+
+Signed-off-by: Georgi Valkov <gvalkov@gmail.com>
+---
+ lib/fuse_signals.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/lib/fuse_signals.c
++++ b/lib/fuse_signals.c
+@@ -27,8 +27,10 @@ static int ignore_sigs[] = { SIGPIPE};
+ static int fail_sigs[] = { SIGILL, SIGTRAP, SIGABRT, SIGBUS, SIGFPE, SIGSEGV };
+ static struct fuse_session *fuse_instance;
+ 
++#ifdef HAVE_BACKTRACE
+ #define BT_STACK_SZ (1024 * 1024)
+ static void *backtrace_buffer[BT_STACK_SZ];
++#endif
+ 
+ static void dump_stack(void)
+ {

--- a/utils/fuse3/patches/101-mount_util.c-restore-symlink-check.patch
+++ b/utils/fuse3/patches/101-mount_util.c-restore-symlink-check.patch
@@ -1,0 +1,36 @@
+From: Georgi Valkov <gvalkov@gmail.com>
+Date: Fri, 13 Jun 2025 08:49:22 +0300
+Subject: [PATCH] mount_util.c: restore symlink check
+
+Fixes the following error when mounting iPhone using ifuse:
+ifuse /mnt --container com.httpstorm.httpstorm
+mount: mounting ifuse on /mnt failed: Invalid argument
+
+The regression was introduced in
+74b1df2e84e836a1710561f52075d51f20cd5c78
+
+Signed-off-by: Georgi Valkov <gvalkov@gmail.com>
+---
+ lib/mount_util.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/lib/mount_util.c
++++ b/lib/mount_util.c
+@@ -54,6 +54,7 @@ static int mtab_needs_update(const char
+ 	 * Skip mtab update if /etc/mtab:
+ 	 *
+ 	 *  - doesn't exist,
++	 *  - is a symlink,
+ 	 *  - is on a read-only filesystem.
+ 	 */
+ 	res = lstat(_PATH_MOUNTED, &stbuf);
+@@ -64,6 +65,9 @@ static int mtab_needs_update(const char
+ 		uid_t ruid;
+ 		int err;
+ 
++		if (S_ISLNK(stbuf.st_mode))
++			return 0;
++
+ 		ruid = getuid();
+ 		if (ruid != 0)
+ 			setreuid(0, -1);


### PR DESCRIPTION
## 📦 Package Details

**Description:**
FUSE utilities: `fusermount3`, `mount.fuse3` and shared libraries: `libfuse3`

1. Update to version 3.17.2

Fix a bug that may result in incorrect behaviour:
``` C
../util/fusermount.c:1069:17: warning: unsigned conversion from 'long long int' to 'long unsigned int' changes value from '8315462406243767374' to '1397118030' [-Woverflow]
 1069 |                 0x736675005346544e /* UFSD */,
      |                 ^~~~~~~~~~~~~~~~~~
```

2. Fix build warning when `HAVE_BACKTRACE` is not defined
`BT_STACK_SZ` and `backtrace_buffer` are not used when `HAVE_BACKTRACE` is undefined. Wrap them in `#ifdef`
to avoid a build warning:

``` C
../lib/fuse_signals.c:31:14: warning: 'backtrace_buffer' defined but not used [-Wunused-variable]
   31 | static void *backtrace_buffer[BT_STACK_SZ];
      |              ^~~~~~~~~~~~~~~~
```

This commit has no impact on the work. Merged upstream [1].

3. Restore symlink check in `mount_util.c`
Fix the following error when mounting iPhone documents and containers using  `ifuse`:
``` bash
ifuse /mnt --container com.httpstorm.httpstorm
mount: mounting ifuse on /mnt failed: Invalid argument
```

Upstream:
[1] https://github.com/libfuse/libfuse/pull/1245 (merged)
[2] https://github.com/libfuse/libfuse/pull/1247 (sent)

@BKPepe @neheb @aparcar @hnyman @robimarko @1715173329 @Noltari @dangowrt 

---

## 🧪 Run Testing Details

- **OpenWrt Version:** main r29266+799-8ffb3b2829
- **OpenWrt Target/Subtarget:** mvebu/cortexa9 / Marvell Armada 37x/38x/XP
- **OpenWrt Device:** WRT3200ACM

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc.
- [x] It is structured in a way that it is potentially upstreamable
