### PR TITLE
libradcli: fix build options, allow TLS build

### DIFF
--- a/libs/libradcli/Config.in
+++ b/libs/libradcli/Config.in
@@ -5,6 +5,5 @@ menu "Configuration"
 
 config RADCLI_TLS
 	bool "enable TLS support"
-	default y
 
 endmenu

--- a/libs/libradcli/Makefile
+++ b/libs/libradcli/Makefile
@@ -19,6 +19,8 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/radcli-$(PKG_VERSION)
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
+PKG_CONFIG_DEPENDS := CONFIG_RADCLI_TLS
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/libradcli
@@ -35,6 +37,10 @@ define Package/libradcli/decription
   approach is to allow writing RADIUS-aware application in less than 50 lines
   of C code. It was based originally on freeradius-client and is source 
   compatible with it.
+endef
+
+define Package/libradcli/config
+        source "$(SOURCE)/Config.in"
 endef
 
 CONFIGURE_ARGS+= \


### PR DESCRIPTION
**Maintainer:** @PolynomialDivision, @neheb 

**Description:**
Enable toggling TLS support. The provided Config.in was never sourced from the Makefile, making it impossible to toggle TLS support. This commit adds the necessary Makefile glue to fix this.
Also default to TLS disabled, as was the de-facto case since Config.in was never sourced (and thus the default 'y' never enabled).