### PR TITLE
mstflint: add missing nls.mk include

### DIFF
--- a/utils/mstflint/Makefile
+++ b/utils/mstflint/Makefile
@@ -25,6 +25,7 @@ PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/mstflint
   SECTION:=Utilities


### PR DESCRIPTION


## 📦 Package Details

**Maintainer:** me

**Description:**
If `nls.mk` is not included and `BUILD_NLS` is set compilation will fail with various undefined references to the `libiconv` library. So this commit includes the missing `nls.mk`.
This fixes #26763.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt Snapshot
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** Mellanox Spectrum SN2100

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
- [ ] ~~It is structured in a way that it is potentially upstreamable~~
