### PR TITLE
treewide: drop anything related to uClibc

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -121,15 +121,6 @@ PGSQL_CONFIG_VARS:= \
 	ac_cv_file__dev_urandom="/dev/urandom" \
 	ZIC=zic
 
-ifeq ($(CONFIG_USE_UCLIBC),y)
-# PostgreSQL does not build against uClibc with locales
-# enabled, due to an uClibc bug, see
-# http://lists.uclibc.org/pipermail/uclibc/2014-April/048326.html
-# so overwrite automatic detection and disable locale support
-PGSQL_CONFIG_VARS+= \
-		pgac_cv_type_locale_t=no
-endif
-
 TARGET_CONFIGURE_OPTS+=$(PGSQL_CONFIG_VARS)
 
 HOST_CONFIGURE_ARGS += \

--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -68,16 +68,11 @@ define Package/haproxy-nossl/description
  This package is built without SSL support.
 endef
 
-TARGET=linux-glibc
+TARGET=linux-musl
 ENABLE_LUA:=y
 
-ifeq ($(CONFIG_USE_UCLIBC),y)
-	ADDON+=USE_BACKTRACE=
-	ADDON+=USE_LIBCRYPT=
-endif
-
-ifeq ($(CONFIG_USE_MUSL),y)
-	TARGET=linux-musl
+ifeq ($(CONFIG_USE_GLIBC),y)
+	TARGET=linux-glibc
 endif
 
 ifeq ($(BUILD_VARIANT),ssl)

--- a/net/linknx/Makefile
+++ b/net/linknx/Makefile
@@ -19,7 +19,7 @@ PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DEPENDS:=USE_UCLIBC:argp-standalone USE_MUSL:argp-standalone
+PKG_BUILD_DEPENDS:=USE_MUSL:argp-standalone
 PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk

--- a/net/netifyd/Makefile
+++ b/net/netifyd/Makefile
@@ -32,7 +32,7 @@ define Package/netifyd
   CATEGORY:=Network
   TITLE:=Netify Agent
   URL:=http://www.netify.ai/
-  DEPENDS:=+ca-bundle +libatomic +libcurl +libmnl +libnetfilter-conntrack +libpcap +zlib +libpthread @!USE_UCLIBC
+  DEPENDS:=+ca-bundle +libatomic +libcurl +libmnl +libnetfilter-conntrack +libpcap +zlib +libpthread
   # Explicitly depend on libstdcpp rather than $(CXX_DEPENDS).  At the moment
   # std::unordered_map is only available via libstdcpp which is required for
   # performance reasons.

--- a/net/torsocks/Makefile
+++ b/net/torsocks/Makefile
@@ -39,13 +39,6 @@ define Package/torsocks/description
  It ensures that DNS requests are handled safely and explicitly rejects any traffic other than TCP from the application you're using.
 endef
 
-define Build/Configure
-	$(call Build/Configure/Default)
-ifeq ($(CONFIG_USE_UCLIBC),y)
-	find $(PKG_BUILD_DIR) -name 'Makefile' -exec sed -i 's|--param ssp-buffer-size=1 -fstack-protector-all||' \{\} \+
-endif
-endef
-
 define Package/conffiles
 /etc/tor/torsocks.conf
 endef


### PR DESCRIPTION
uClibc-ng was removed in 2020 from OpenWrt main repo [1]. These things are leftovers.

[1] https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=63fb175203bbf3b336804587c2f5b3a2d8132ec1

cc: @neheb 

Package maintainers:
- postgresql: @dangowrt
- haproxy: @gladiac 
- netifyid: @dsokoloski 
- torsocks: @ja-pa 