### PR TITLE
btop: add patch to fix download/upload display

### DIFF
--- a/admin/btop/Makefile
+++ b/admin/btop/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btop
 PKG_VERSION:=1.4.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://codeload.github.com/aristocratos/btop/tar.gz/v$(PKG_VERSION)?

--- a/admin/btop/patches/001-Fix-incorrect-positioning-and-start-symbol-of-second.patch
+++ b/admin/btop/patches/001-Fix-incorrect-positioning-and-start-symbol-of-second.patch
@@ -1,0 +1,21 @@
+From d758fc8dc647a12c1bf1b1c1aa5893f92e4daf91 Mon Sep 17 00:00:00 2001
+From: xDMPx <57721731+xDMPx@users.noreply.github.com>
+Date: Tue, 13 May 2025 00:06:09 +0200
+Subject: [PATCH] Fix incorrect positioning and start symbol of second title
+ introduced in 2538d89ed97bd98b8c092ca73ec75be7db888467
+
+---
+ src/btop_draw.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/btop_draw.cpp
++++ b/src/btop_draw.cpp
+@@ -293,7 +293,7 @@ namespace Draw {
+ 		}
+ 		if (not title2.empty()) {
+ 			out += fmt::format(
+-				"{}{}{}{}{}{}{}{}{}", Mv::to(y, x + 2), Symbols::title_left, Fx::b, numbering, Theme::c("title"), title2, Fx::ub,
++				"{}{}{}{}{}{}{}{}{}", Mv::to(y + height - 1, x + 2), Symbols::title_left_down, Fx::b, numbering, Theme::c("title"), title2, Fx::ub,
+ 				line_color, Symbols::title_right_down
+ 			);
+ 		}


### PR DESCRIPTION
Uses https://github.com/aristocratos/btop/pull/1156

```
https://patch-diff.githubusercontent.com/raw/aristocratos/btop/pull/1156.patch
```

## 📦 Package Details

**Maintainer:** @1715173329
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
