### PR TITLE
syslog-ng: update to version 4.10.0

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
-PKG_VERSION:=4.7.1
-PKG_RELEASE:=2
+PKG_VERSION:=4.10.0
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later
@@ -11,7 +11,7 @@ PKG_CPE_ID:=cpe:/a:oneidentity:syslog-ng
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syslog-ng/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
-PKG_HASH:=5477189a2d12325aa4faebfcf59f5bdd9084234732f0c3ec16dd253847dacf1c
+PKG_HASH:=219fbdb1685b6fa61674712f21c7b46e5e09b2533518c57689eaa827f57b1609
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -92,11 +92,13 @@ CONFIGURE_ARGS +=  \
 	--disable-linux-caps \
 	--with-jsonc=system \
 	--enable-cpp=no \
+	--disable-example-modules \
 	--enable-json=yes \
 	$(if $(CONFIG_LIBCURL_ZLIB),--enable-http=yes,--enable-http=no) \
 	--disable-smtp \
 	--disable-mqtt \
 	--disable-redis \
+	--disable-stackdump \
 	--disable-dependency-tracking \
 	--disable-python \
 	--disable-geoip2 \

--- a/admin/syslog-ng/files/syslog-ng.conf
+++ b/admin/syslog-ng/files/syslog-ng.conf
@@ -1,7 +1,7 @@
 # Collect all local logs into a single file /var/log/messages.
 # See https://www.syslog-ng.com/technical-documents/list/syslog-ng-open-source-edition
 
-@version: 4.7
+@version: current
 @include "scl.conf"
 
 options {


### PR DESCRIPTION
Package maintainer: me
No, I am trying to be like others - no run testing (this time). 😆 😆 Waiting for CI/CD.

Release notes:
https://www.syslog-ng.com/community/b/blog/posts/syslog-ng-4-8-3-is-now-available
