### PR TITLE
[23.05] liborcania: Install library on target

### DIFF
--- a/libs/liborcania/Makefile
+++ b/libs/liborcania/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=liborcania
 PKG_VERSION:=2.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/babelouest/orcania/tar.gz/v$(PKG_VERSION)?
@@ -33,6 +33,11 @@ endef
 
 define Package/liborcania/description
   Potluck with different functions for different purposes that can be shared among C programs.
+endef
+
+define Package/liborcania/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liborcania.so* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,liborcania))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @utoni

**Description:**
Backport `liborcania` fix to OpenWRT 23.05

> The current liborcania / libulfius packages do not install to the target, resulting in messages like:
> ```
> Package meshtasticd is missing dependencies for the following libraries:
> liborcania.so.2.3
> libulfius.so.2.7
> ```
> This change corrects the issue by installing the library `.so`s to the target.

(cherry picked from commit 768b995f980f2875f588ab8f90e5b597cfa4f5d8)

Related `master` PR:
- #25526

Related `openwrt-24.10` PR:
- #26750

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 23.05
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2710
- **OpenWrt Device:** Raspberry Pi CM3

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
