### PR TITLE
sox_ng: Remove (lib)speex un-expected inclusion by discovery

### DIFF
--- a/sound/sox_ng/Makefile
+++ b/sound/sox_ng/Makefile
@@ -46,6 +46,7 @@ CONFIGURE_ARGS += \
 		--without-libltdl \
 		--with-flac \
 		--without-ladspa \
+		--without-speexdsp \
 		--without-png \
 		--without-sndfile \
 		--with-opus \


### PR DESCRIPTION
Fix build errors when libspeex-dev (include files) are discovered running `configure` in the buildbots. Speex is an obsolete codec superseded by Opus. Does anyone want/need this? 
