### PR TITLE
dufs: do not reload firewall manually

### DIFF
--- a/net/dufs/Makefile
+++ b/net/dufs/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dufs
 PKG_VERSION:=0.43.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/sigoden/dufs/tar.gz/v$(PKG_VERSION)?

--- a/net/dufs/files/dufs.init
+++ b/net/dufs/files/dufs.init
@@ -79,7 +79,6 @@ start_service() {
 		json_add_array firewall
 			json_add_object ""
 			json_add_string type rule
-			json_add_string name "Allow-access-dufs-at-$listen_port"
 			json_add_string src "*"
 			json_add_string dest_port "$listen_port"
 			json_add_string proto tcp
@@ -90,14 +89,6 @@ start_service() {
 	fi
 
 	procd_close_instance
-}
-
-service_started() {
-	procd_set_config_changed firewall
-}
-
-service_stopped() {
-	procd_set_config_changed firewall
 }
 
 service_triggers() {


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
This is no longer required after commit openwrt/procd@2e206dbe77ec ("service: add support for triggers on service/instance data changes").

Also remove unused 'name' field.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** rockchip/armv8
- **OpenWrt Device:** nanopi-r5c

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
