### PR TITLE
samba4: add conditional depends

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
 PKG_VERSION:=4.22.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -65,6 +65,7 @@ define Package/samba4-libs
   $(call Package/samba4/Default)
   TITLE+= libs
   DEPENDS:= +libtirpc +libreadline +libpopt +libcap +zlib +libgnutls +libtasn1 +libuuid +libopenssl +libpthread +KERNEL_IO_URING:liburing \
+	+PACKAGE_icu:icu \
 	+PACKAGE_libpam:libpam \
 	+SAMBA4_SERVER_VFS:attr \
 	+SAMBA4_SERVER_AVAHI:libavahi-client \


### PR DESCRIPTION
If users are building icu we need to depend on the corresponding shared objects to avoid missing library dependencies, for example:
```
libicui18n.so.77
libicuuc.so.77
```
## 📦 Package Details

**Maintainer:** 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

Although not maintainers, both of these guys helped to bring this to light and troubleshoot: @hnyman @BKPepe 

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Add conditional depends based on discussion in https://github.com/openwrt/packages/pull/26683
---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
