### PR TITLE
bind: prevent mismatch of bind-libs version

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.20.21
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -49,6 +49,7 @@ define Package/bind/Default
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=+bind-libs +@OPENSSL_WITH_EC
+  EXTRA_DEPENDS:=bind-libs (=$(PKG_VERSION)-r$(PKG_RELEASE))
   TITLE:=bind
   URL:=https://www.isc.org/software/bind
   SUBMENU:=IP Addresses and Names
@@ -78,6 +79,7 @@ define Package/bind-server
   TITLE+= DNS server
   DEPENDS+= +libcap \
 	+bind-rndc
+  EXTRA_DEPENDS+=, bind-rndc (=$(PKG_VERSION)-r$(PKG_RELEASE))
 endef
 
 define Package/bind-server/config
@@ -87,6 +89,7 @@ endef
 define Package/bind-server-filter-aaaa
   $(call Package/bind-server)
   DEPENDS:=bind-server
+  EXTRA_DEPENDS:=bind-server (=$(PKG_VERSION)-r$(PKG_RELEASE))
   TITLE+= filter AAAA plugin
 endef
 
@@ -98,7 +101,7 @@ endef
 define Package/bind-tools
   $(call Package/bind/Default)
   TITLE+= administration tools (all)
-	DEPENDS:= \
+  DEPENDS:= \
 	+bind-check \
 	+bind-dig \
 	+bind-nslookup \
@@ -106,6 +109,14 @@ define Package/bind-tools
 	+bind-host \
 	+bind-rndc \
 	+bind-ddns-confgen
+  EXTRA_DEPENDS:= \
+	bind-check (=$(PKG_VERSION)-r$(PKG_RELEASE)), \
+	bind-dig (=$(PKG_VERSION)-r$(PKG_RELEASE)), \
+	bind-nslookup (=$(PKG_VERSION)-r$(PKG_RELEASE)), \
+	bind-dnssec (=$(PKG_VERSION)-r$(PKG_RELEASE)), \
+	bind-host (=$(PKG_VERSION)-r$(PKG_RELEASE)), \
+	bind-rndc (=$(PKG_VERSION)-r$(PKG_RELEASE)), \
+	bind-ddns-confgen (=$(PKG_VERSION)-r$(PKG_RELEASE))
 endef
 
 define Package/bind-rndc


### PR DESCRIPTION
When upgrading packages manually, like:

        opkg install bind-dig

the bind-libs package is not upgraded, which results in problems when running the program, for example:

        root@OpenWrt:~# dig
        Error loading shared library libisc-9.20.10.so: No such file or directory (needed by /usr/bin/dig)
        Error loading shared library libdns-9.20.10.so: No such file or directory (needed by /usr/bin/dig)
        Error loading shared library libisccfg-9.20.10.so: No such file or directory (needed by /usr/bin/dig)
        Error relocating /usr/bin/dig: cfg_map_getname: symbol not found
        Error relocating /usr/bin/dig: irs_resconf_getndots: symbol not found
        Error relocating /usr/bin/dig: isc_managers_destroy: symbol not found
        Error relocating /usr/bin/dig: dns_fixedname_init: symbol not found
        Error relocating /usr/bin/dig: isc_nm_read: symbol not found
        Error relocating /usr/bin/dig: dns_rdata_init: symbol not found
        Error relocating /usr/bin/dig: isc_random_uniform: symbol not found
        [...]

This has happened to me twice on 24.10.

To fix this, enforce that the version of bind-libs matches the version of any dependent packages. Use the same approach as in net/knot/Makefile: make the dependency be present twice, once in DEPENDS, the other one in EXTRA_DEPENDS.

---

## 📦 Package Details

**Maintainer:** @nmeyerhans 

**Description:**
bind: prevent mismatch of bind-libs version

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (r30114-9b777547be) 
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** Generic x86/64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.