### PR TITLE
libical: update to 3.0.20

### DIFF
--- a/libs/libical/Makefile
+++ b/libs/libical/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libical
-PKG_VERSION:=3.0.9
-PKG_RELEASE:=2
+PKG_VERSION:=3.0.20
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=bd26d98b7fcb2eb0cd5461747bbb02024ebe38e293ca53a7dfdcb2505265a728
+PKG_HASH:=e73de92f5a6ce84c1b00306446b290a2b08cdf0a80988eca0a2c9d5c3510b4c2
 PKG_SOURCE_URL:=https://github.com/libical/libical/releases/download/v$(PKG_VERSION)/
 
 PKG_MAINTAINER:=Jose Zapater <jzapater@gmail.com>

--- a/libs/libical/patches/001-disable-icu-and-bdb-support.patch
+++ b/libs/libical/patches/001-disable-icu-and-bdb-support.patch
@@ -1,18 +1,18 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -192,7 +192,6 @@ endif()
- # libicu is highly recommended for RSCALE support
- #  libicu can be found at http://www.icu-project.org
- #  RSCALE info at https://tools.ietf.org/html/rfc7529
--find_package(ICU)
+@@ -211,7 +211,6 @@ if(NOT DEFINED ENV{ICU_ROOT} AND APPLE)
+   #Use the homebrew version. MacOS provided ICU doesn't provide development files
+   set(ICU_ROOT "/usr/local/opt/icu4c")
+ endif()
+-find_package(ICU COMPONENTS uc i18n data)
  set_package_properties(ICU PROPERTIES
    TYPE RECOMMENDED
    PURPOSE "For RSCALE (RFC7529) support"
-@@ -216,7 +215,6 @@ if(ICU_I18N_FOUND)
+@@ -253,7 +252,6 @@ if(NOT "$ENV{BerkeleyDB_ROOT_DIR}")
+     set(BerkeleyDB_ROOT_DIR "/usr/local/opt/berkeley-db")
+   endif()
  endif()
- 
- # compile in Berkeley DB support
--find_package(BDB)
- set_package_properties(BDB PROPERTIES
+-find_package(BerkeleyDB)
+ set_package_properties(BerkeleyDB PROPERTIES
    TYPE OPTIONAL
    PURPOSE "For Berkeley DB storage support"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jzapater 

**Description:**
Update libical to the latest 3.0.20 version,
refreshing the single patch in the progress.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt Snapshot
- **OpenWrt Target/Subtarget:** MediaTek ARM/MT7622
- **OpenWrt Device:** BananaPi R64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] ~~It is structured in a way that it is potentially upstreamable~~