### PR TITLE
lttng-ust: bump version to 2.13.9

### DIFF
--- a/libs/lttng-ust/Makefile
+++ b/libs/lttng-ust/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lttng-ust
-PKG_VERSION:=2.13.5
+PKG_VERSION:=2.13.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://lttng.org/files/$(PKG_NAME)/
-PKG_HASH:=f1d7bb4984a3dc5dacd3b7bcb4c10c04b041b0eecd7cba1fef3d8f86aff02bd6
+PKG_HASH:=2ad6d69a54a1d924c18a4aa7a233db104e3cc332bcdd240e196bf7adbed3f712
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=LGPL-2.1 GPL-2.0


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @none

**Description:**
Fixes build on platforms without 64-bit atomics.

Should be cherry-picked to 24.10 branch, as it also plagues builds there:
https://downloads.openwrt.org/releases/faillogs-24.10/mips_24kc/packages/lttng-ust/compile.txt

Fixes: https://github.com/openwrt/packages/issues/26575
Changelog: https://github.com/lttng/lttng-ust/compare/v2.13.5...v2.13.9

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** tegra/generic
- **OpenWrt Device:** trimslice

---

## ✅ Formalities

- [✅] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
