### PR TITLE
rrdtool1: fix compilation with GCC 15

### DIFF
--- a/utils/rrdtool1/Makefile
+++ b/utils/rrdtool1/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rrdtool1
 PKG_VERSION:=1.0.50
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/rrdtool-$(PKG_VERSION)
 PKG_SOURCE:=rrdtool-$(PKG_VERSION).tar.gz
@@ -86,7 +86,7 @@ $(call Package/rrdtool1/description/Default)
  This package contains command line tools used to manage RRDs.
 endef
 
-TARGET_CFLAGS += $(FPIC)
+TARGET_CFLAGS += $(FPIC) -std=gnu17
 
 CONFIGURE_ARGS += \
 	$(DISABLE_NLS) \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jow- 

**Description:**
Currently, `rrdtool1` produces the following build error for various C files while building with GCC 15:
```
In file included from rrd_tool.h:93,
                 from rrd_cgi.c:11:
getopt.h:108:12: error: conflicting types for 'getopt'; have 'int(void)'
  108 | extern int getopt ();
      |            ^~~~~~
In file included from include/fortify/unistd.h:22,
                 from rrd_tool.h:56:
include/unistd.h:127:5: note: previous declaration of 'getopt' with type 'int(int,  char * const*, const char *)'
  127 | int getopt(int, char * const [], const char *);
      |     ^~~~~~
```
This adds `-std=gnu17` to `TARGET_CFLAGS` to fix the compilation error.
This should fix #26786.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt Snapshot
- **OpenWrt Target/Subtarget:** MediaTek ARM/MT7622
- **OpenWrt Device:** BananaPi R64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] ~~It is structured in a way that it is potentially upstreamable~~