### PR TITLE
rust: Make sure it doesn't guess if it's in a CI environment

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -90,6 +90,7 @@ define Host/Compile
 	TARGET_CFLAGS="$(TARGET_CFLAGS)" \
 	$(PYTHON) $(HOST_BUILD_DIR)/x.py \
 		--build-dir $(HOST_BUILD_DIR)/build \
+		--ci false \
 		dist build-manifest rustc rust-std cargo llvm-tools rust-src
 endef
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @smallprogram

**Description:**
When compiling openwrt, rust will detect whether the current environment is in ci, such as github action. When it is detected as a CI environment, it will cause llvm download to fail. This PR will make rust ignore the current environment, thereby solving the problem of compiling errors in the CI environment (github action), This solution is better than #26644 , which can also solve the problem, but will extend the compilation time by 1 hour.
Fixed #26623 

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt Snapshot
- **OpenWrt Target/Subtarget:** X86/64, rockchip 
- **OpenWrt Device:** R2 Max, R2S, R4S, R5S, R6S

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
