### PR TITLE
libtheora: use CONFIGURE_ARGS, fix build on armeb

### DIFF
--- a/libs/libtheora/Makefile
+++ b/libs/libtheora/Makefile
@@ -42,14 +42,15 @@ features supported by the decoder to improve over what is
 is possible with VP3.
 endef
 
-define Build/Configure
-	$(call Build/Configure/Default, \
-		--disable-examples \
-		--disable-oggtest \
-		--disable-vorbistest \
-		--disable-sdltest \
-	)
-endef
+CONFIGURE_ARGS += \
+	--disable-examples \
+	--disable-oggtest \
+	--disable-vorbistest \
+	--disable-sdltest
+
+ifneq ($(findstring armeb,$(CONFIG_ARCH)),)
+CONFIGURE_ARGS += --disable-asm
+endif
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/theora/


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @flyn-org 

**Description:**
Use CONFIGURE_ARGS instead of defining a custom Build/Configure target.

Set --disable-asm on armeb to fix build error:
```
  CC       apiwrapper.lo
In file included from state.h:56,
                 from apiwrapper.h:24,
                 from apiwrapper.c:21:
arm/armint.h:24:5: error: #error "Big-endian configurations are not supported by the ARM asm. " "Reconfigure with --disable-asm or undefine OC_ARM_ASM."
   24 | #   error "Big-endian configurations are not supported by the ARM asm. " \
      |     ^~~~~
```
---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** ixp4xx
- **OpenWrt Device:** dlink_dsm_g600
(compile tested only)
---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
