### PR TITLE
prometheus-node-exporter-lua: mwan3: speed up

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,8 +4,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2025.06.23
-PKG_RELEASE:=6
+PKG_VERSION:=2025.06.24
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/mwan3.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/mwan3.lua
@@ -2,7 +2,7 @@ local ubus = require "ubus"
 
 local function scrape()
     local u = ubus.connect()
-    local status = u:call("mwan3", "status", {})
+    local status = u:call("mwan3", "status", {section="interfaces"})
     if status == nil then
         error("Could not get mwan3 status")
     end


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
Request only 'interfaces' status, as we don't use 'connected' and 'policies' status. On my router with 5 wans / 2 tracking IPs per wan, scrape time goes from 1.90s to 1.30s (still pretty slow but better)
(cherry picked from commit caeb4c1834b68c37647143363bf643b8f79040cc)

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10