### PR TITLE
[24.10] netbird: update to 0.50.2

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.45.3
+PKG_VERSION:=0.49.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=57723dcf41d0cfc73205ec82cf8e409ede94e072076cfb73cd8f0c361833c7b8
+PKG_HASH:=8b71fb9964bb3e9c81dd141658fc6aaae78cc2a1145fe4b8be79b67a30efac61
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.45.2
+PKG_VERSION:=0.45.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=e33db322cdc38ddddcc6b4f2f34c6b31741b7a279b0b85352c14c4859dee97b2
+PKG_HASH:=57723dcf41d0cfc73205ec82cf8e409ede94e072076cfb73cd8f0c361833c7b8
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.44.0
+PKG_VERSION:=0.45.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=d1b30bf732e68feda7a9e77bb837eba27debe022c1743623ee4a3c58ec906e8c
+PKG_HASH:=cef8ef4f602fc0c4e6e23b0145a50bb9e5581e5169c75ee343f4304f61a70812
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.45.1
+PKG_VERSION:=0.45.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=cef8ef4f602fc0c4e6e23b0145a50bb9e5581e5169c75ee343f4304f61a70812
+PKG_HASH:=e33db322cdc38ddddcc6b4f2f34c6b31741b7a279b0b85352c14c4859dee97b2
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.50.1
+PKG_VERSION:=0.50.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=b68305db151475ac58e3ff2144dd4ed955b99bcf462d8da118073f29b432be74
+PKG_HASH:=d3f0838dfa279ed8af9443294770308be8d2a9e070478dbba23ca42e20da403b
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.49.0
+PKG_VERSION:=0.50.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8b71fb9964bb3e9c81dd141658fc6aaae78cc2a1145fe4b8be79b67a30efac61
+PKG_HASH:=b68305db151475ac58e3ff2144dd4ed955b99bcf462d8da118073f29b432be74
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.43.2
+PKG_VERSION:=0.43.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=0788b84a6c0b5fc33268a5c3865af610b8231f642da1eda37bc16c4d50c25858
+PKG_HASH:=23474655290b23125ae269fdc89a772b4c9aeb5c854c056d61744f10a76fc3ab
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.42.0
+PKG_VERSION:=0.43.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=fb9f46acd38c2ac043c7dd66b715453f1c7b2973879001d3c1812df21bed618e
+PKG_HASH:=7450a173b755597461cc0fdd0a3d5c91384c7a4c985677eb17362dd40ee01296
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.43.0
+PKG_VERSION:=0.43.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=7450a173b755597461cc0fdd0a3d5c91384c7a4c985677eb17362dd40ee01296
+PKG_HASH:=a93d6ae78a0ee2f74ddbb5e86d581ed465091a4924ffddac6475bda3b6b31425
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.43.3
+PKG_VERSION:=0.44.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=23474655290b23125ae269fdc89a772b4c9aeb5c854c056d61744f10a76fc3ab
+PKG_HASH:=d1b30bf732e68feda7a9e77bb837eba27debe022c1743623ee4a3c58ec906e8c
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.43.1
+PKG_VERSION:=0.43.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=a93d6ae78a0ee2f74ddbb5e86d581ed465091a4924ffddac6475bda3b6b31425
+PKG_HASH:=0788b84a6c0b5fc33268a5c3865af610b8231f642da1eda37bc16c4d50c25858
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.39.2
+PKG_VERSION:=0.40.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=79553c2555e3cd03d0386e23f17ba3dd0e4437fecc9ffd82d6b5a557af7bffc0
+PKG_HASH:=2bf6dd2a9aa7d0c77c7c2a70b215f137e24f08f958c7efcf2ae863afb080fc53
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.41.3
+PKG_VERSION:=0.42.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=69a9f7f67321dfbf339135b33c6e3a9ed468a657b81a1519b98e3b653dd8d58d
+PKG_HASH:=fb9f46acd38c2ac043c7dd66b715453f1c7b2973879001d3c1812df21bed618e
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.41.2
+PKG_VERSION:=0.41.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=d315e05476d50ee7333c3a7feb9faee4cab08c400ad64055c28420846fbe6560
+PKG_HASH:=69a9f7f67321dfbf339135b33c6e3a9ed468a657b81a1519b98e3b653dd8d58d
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.40.0
+PKG_VERSION:=0.40.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2bf6dd2a9aa7d0c77c7c2a70b215f137e24f08f958c7efcf2ae863afb080fc53
+PKG_HASH:=373d1797fdbfb9df22d4a9064af62cdc7b25f314a934ea5d442d3e57c8a263b1
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.41.1
+PKG_VERSION:=0.41.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8ac588fb9ed67ba105a9d55c7d0322907c4a05ab345cd417a12f94ef284da921
+PKG_HASH:=d315e05476d50ee7333c3a7feb9faee4cab08c400ad64055c28420846fbe6560
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.40.1
+PKG_VERSION:=0.41.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=373d1797fdbfb9df22d4a9064af62cdc7b25f314a934ea5d442d3e57c8a263b1
+PKG_HASH:=8ac588fb9ed67ba105a9d55c7d0322907c4a05ab345cd417a12f94ef284da921
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

- `netbird` update to [0.50.2](https://github.com/netbirdio/netbird/releases/tag/v0.50.2)
    - Full changelog: https://github.com/netbirdio/netbird/compare/v0.39.2...v0.50.2
      - Cherry picked from: bcb6992f4b07b91ff22dc35cfe6dd80112bcd83e
        - PR: https://github.com/openwrt/packages/pull/26954
      - Cherry picked from: 9d0a14ed4edc7488cd5e999f6b6bae130b32a69c
        - PR: https://github.com/openwrt/packages/pull/26948
      - Cherry picked from: 5745ffb5475f2d422acc2b90b94ac5aa2b9211f1
        - PR: https://github.com/openwrt/packages/pull/26828
      - Cherry picked from: f71550540e43e3f17ac8338140b2c2043f284b4b
        - PR: https://github.com/openwrt/packages/pull/26682
      - Cherry picked from: 1bba5b93f9350c5b47e4ae883a6193c027c3b8a5
        - PR: https://github.com/openwrt/packages/pull/26647
      - Cherry picked from: 37ff02b7167e529fc9c13fde5de6401537273dd9
        - PR: https://github.com/openwrt/packages/pull/26594
      - Cherry picked from: cffbe8b32a26efeaae0f0d8ce896756da77e16e2
        - PR: https://github.com/openwrt/packages/pull/26534
      - Cherry picked from: c91e9322ce71d051f53595d060e15eb7cc5368b2
        - PR: https://github.com/openwrt/packages/pull/26508
      - Cherry picked from: cef2fb9d8eda3a068651d0125a495893fdafe495
        - PR: https://github.com/openwrt/packages/pull/26477
      - Cherry picked from: af32ef43f87696153d3b019972b905c7e94729c3
        - PR: https://github.com/openwrt/packages/pull/26419
      - Cherry picked from: c3692c601e7b59b5b564415eaea24c607c585ed7
        - PR: https://github.com/openwrt/packages/pull/26380
      - Cherry picked from: 2da44915c94753628d367101c2ab658885324552 and 2ac31acc54bf4f997ff28b2e26cda2e48fc406e4
        - PR: https://github.com/openwrt/packages/pull/26350
      - Cherry picked from: 4dee0fc39e7c77a3255c32ea037b26f384e57bd6 and 9c557d206b2017b802172a26293103a89a7661db
        - PR: https://github.com/openwrt/packages/pull/26326
      - Cherry picked from: c5576299a0450435e77e67b2a364f9514465cc50
        - PR: https://github.com/openwrt/packages/pull/26307
      - Cherry picked from: d520931ef394e8fe98de45bfd98fba89e6b57982
        - PR: https://github.com/openwrt/packages/pull/26281
    - Breaking change:
      - N/A

**Tests checklist:**
- [x] Connection to the NetBird Cloud Dashboard (not self-hosted).
- [x] Firewall configured with nftables.
- [x] Connection established in P2P mode.
- [x] `wireguard` kernel mode active.
- [x] Routes configured between my homelab and my cloud server.
- [x] `netbird` DNS server functioning correctly.
- [ ] NAT operational (not needed by me at this time, may consider testing in the future).
- [ ] Permissions rules is enforced (not needed by me at this time, may consider testing in the future).

**Additional information**

The package(s) was compiled with the container [`sdk`](https://github.com/openwrt/docker).
The `OpenWrt` image(s) was built using the container [`imagebuilder`](https://github.com/openwrt/docker).

You can view my repository with the patch applied and the automated build here:
- https://github.com/wehagy/owpib/tree/openwrt-24.10/netbird/update
  <sub>This repository branch is temporary and will be removed or modified after the merge.</sub>

You can find my artifacts here:
- https://github.com/wehagy/owpib/actions/runs/16232832291

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10-SNAPSHOT r28759-49fdb75c7b
- **OpenWrt Target/Subtarget:** QEMU (x86_64)
- **OpenWrt Device:** qemu-9.2.4-1.fc42

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.