### PR TITLE
dtbocfg: Add kmod for loading device-tree overlays

### DIFF
--- a/kernel/dtbocfg/Makefile
+++ b/kernel/dtbocfg/Makefile
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dtbocfg
+PKG_VERSION:=0.1.1
+PKG_RELEASE:=1
+
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/ikwzm/dtbocfg.git
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_MIRROR_HASH:=2d6a31ba01d05ab9bd15f127c06fab0e504dd6d7e41115be53e0021e6f8ba877
+
+PKG_MAINTAINER:=Austin Lane <vidplace7@gmail.com>, Tomasz Maciej Nowak <tmn505@gmail.com>
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/fs-dtbocfg
+  SECTION:=kernel
+  CATEGORY:=Kernel modules
+  SUBMENU:=Filesystem
+  URL:=https://github.com/ikwzm/dtbocfg
+  TITLE:=Device Tree Blob Overlay Configuration File System
+  DEPENDS:=+kmod-fs-configfs @!TARGET_bcm27xx
+  FILES:=$(PKG_BUILD_DIR)/dtbocfg.$(LINUX_KMOD_SUFFIX)
+  AUTOLOAD:=$(call AutoLoad,31,dtbocfg)
+endef
+
+define KernelPackage/fs-dtbocfg/description
+  dtbocfg is a kernel module that allows device-tree overlay blobs
+  to be loaded and unloaded from a configfs filesystem in userspace.
+endef
+
+define Build/Compile
+	$(KERNEL_MAKE) M="$(PKG_BUILD_DIR)" modules
+endef
+
+$(eval $(call KernelPackage,fs-dtbocfg))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me (@vidplace7), @tmn505

**Description:**

Add kmod package [dtbocfg](https://github.com/ikwzm/dtbocfg).
This kmod allows loading device-tree overlay blobs from userspace using a `configfs` mount. Similar to the way it is handled (via kernel patching) for Raspberry Pi targets.

Should allow for much more extensibility on **OpenWRT One** and other platforms with Mikrobus / IO / expansion ports.

This also allows for packages like [openwrt-one-mikrobus-spidev](https://github.com/vidplace7/openwrt-dtbo/blob/main/openwrt-one-mikrobus-spidev/Makefile) to [dynamically load](https://github.com/vidplace7/openwrt-dtbo/blob/main/openwrt-one-mikrobus-spidev/files/dtbo-mikrobus-spidev.init) device-tree overlay blobs.

Serves as a good answer to PRs upstream:
- https://github.com/openwrt/openwrt/pull/17682
- https://github.com/openwrt/openwrt/pull/17399

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** OpenWRT One

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
