### PR TITLE
[ksmbd-tools] Don't disregard user access control list

### DIFF
--- a/net/ksmbd-tools/files/ksmbd.init
+++ b/net/ksmbd-tools/files/ksmbd.init
@@ -116,10 +116,9 @@ smb_add_share()
 		if [ "$force_root" -eq 1 ]; then
 			printf "\tforce user = %s\n" "root"
 			printf "\tforce group = %s\n" "root"
-		else
-			[ -n "$users" ] && printf "\tvalid users = %s\n" "$users"
 		fi
 
+		[ -n "$users" ] && printf "\tvalid users = %s\n" "$users"
 		[ -n "$create_mask" ] && printf "\tcreate mask = %s\n" "$create_mask"
 		[ -n "$dir_mask" ] && printf "\tdirectory mask = %s\n" "$dir_mask"
 		[ -n "$force_create_mode" ] && printf "\tforce create mode = %s\n" "$force_create_mode"

--- a/net/ksmbd-tools/files/ksmbd.init
+++ b/net/ksmbd-tools/files/ksmbd.init
@@ -111,10 +111,9 @@ smb_add_share()
 		if [ "$force_root" -eq 1 ]; then
 			printf "\tforce user = %s\n" "root"
 			printf "\tforce group = %s\n" "root"
-		else
-			[ -n "$users" ] && printf "\tvalid users = %s\n" "$users"
 		fi
 
+		[ -n "$users" ] && printf "\tvalid users = %s\n" "$users"
 		[ -n "$create_mask" ] && printf "\tcreate mask = %s\n" "$create_mask"
 		[ -n "$dir_mask" ] && printf "\tdirectory mask = %s\n" "$dir_mask"
 		[ -n "$force_create_mode" ] && printf "\tforce create mode = %s\n" "$force_create_mode"


### PR DESCRIPTION
`force_root` and `users` are entirely independent settings.

Enabling `force_root` should not cause the configured `users` ACL to be ignored as is currently the case.

Fixes #25978 (Remote root filesystem access vulnerability in OpenWRT ksmbd server)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
