### PR TITLE
treewide: include `nls.mk` when depending on glib2

### DIFF
--- a/libs/glib-networking/Makefile
+++ b/libs/glib-networking/Makefile
@@ -15,6 +15,7 @@ PKG_CPE_ID:=cpe:/a:gnome:glib-networking
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/meson.mk
+include $(INCLUDE_DIR)/nls.mk
 
 MESON_ARGS += \
 	-Dgnutls=enabled \

--- a/sound/fluidsynth/Makefile
+++ b/sound/fluidsynth/Makefile
@@ -14,6 +14,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
+include $(INCLUDE_DIR)/nls.mk
 
 CMAKE_INSTALL:=1
 

--- a/utils/swanmon/Makefile
+++ b/utils/swanmon/Makefile
@@ -24,6 +24,7 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/swanmon
   SECTION:=utils


### PR DESCRIPTION
## 📦 Package Details

**Maintainers:**
@dangowrt
@lvoegl

**Description:**
When compiling glib2 with NLS, it automatically sets linker flags to `-lglib-2.0 -lintl` in pkg-config (.pc) files.

Fixes #26810

```
/openwrt/staging_dir/toolchain-x86_64_gcc-14.2.0_musl/lib/gcc/x86_64-openwrt-linux-musl/14.2.0/../../../../x86_64-openwrt-linux-musl/bin/ld.bfd: cannot find -lintl: No such file or directory
/openwrt/staging_dir/toolchain-x86_64_gcc-14.2.0_musl/lib/gcc/x86_64-openwrt-linux-musl/14.2.0/../../../../x86_64-openwrt-linux-musl/bin/ld.bfd: cannot find -lintl: No such file or directory
/openwrt/staging_dir/toolchain-x86_64_gcc-14.2.0_musl/lib/gcc/x86_64-openwrt-linux-musl/14.2.0/../../../../x86_64-openwrt-linux-musl/bin/ld.bfd: cannot find -lintl: No such file or directory
/openwrt/staging_dir/toolchain-x86_64_gcc-14.2.0_musl/lib/gcc/x86_64-openwrt-linux-musl/14.2.0/../../../../x86_64-openwrt-linux-musl/bin/ld.bfd: cannot find -lintl: No such file or directory
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
make[2]: *** [Makefile:88: /openwrt/build_dir/target-x86_64_musl/glib-networking-2.80.1/.built] Error 1
```

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.