### PR TITLE
tailscale: disable logging

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
 PKG_VERSION:=1.84.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?

--- a/net/tailscale/files/tailscale.init
+++ b/net/tailscale/files/tailscale.init
@@ -19,7 +19,8 @@ start_service() {
   config_get state_file "settings" state_file /etc/tailscale/tailscaled.state
   config_get fw_mode "settings" fw_mode nftables
 
-  /usr/sbin/tailscaled --cleanup
+  # Clean up state
+  /usr/sbin/tailscaled --cleanup --no-logs-no-support
 
   procd_open_instance
   procd_set_param command /usr/sbin/tailscaled
@@ -27,6 +28,9 @@ start_service() {
   # Starting with v1.48.1 ENV variable is required to enable use of iptables / nftables.
   # Use nftables by default - can be changed to 'iptables' in tailscale config
   procd_set_param env TS_DEBUG_FIREWALL_MODE="$fw_mode"
+
+  # Disable logging to log.tailscale.com
+  procd_append_param command --no-logs-no-support
 
   # Set the port to listen on for incoming VPN packets.
   # Remote nodes will automatically be informed about the new port number,
@@ -43,5 +47,5 @@ start_service() {
 }
 
 stop_service() {
-  /usr/sbin/tailscaled --cleanup
+  /usr/sbin/tailscaled --cleanup --no-logs-no-support
 }


### PR DESCRIPTION
https://tailscale.com/kb/1011/log-mesh-traffic?tab=linux#opting-out-of-client-logging

## 📦 Package Details

**Maintainer:** @SuperSandro2000 


**Description:**

Disable sending logs to log.tailscale.com

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r30244+1-1831966406
- **OpenWrt Target/Subtarget:** ramips/mt7621
- **OpenWrt Device:** ASUS RT-AX54
---
- **OpenWrt Version:** OpenWrt SNAPSHOT r30247+1-978d24ce40
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** ASUS TUF-AX6000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
