### PR TITLE
[24.10] realtek-poe: increase version

### DIFF
--- a/utils/realtek-poe/Makefile
+++ b/utils/realtek-poe/Makefile
@@ -3,14 +3,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=realtek-poe
+PKG_VERSION:=1.2
 PKG_RELEASE:=1
-PKG_LICENSE:=GPL-2.0
+PKG_LICENSE:=GPL-2.0-or-later
 PKG_MAINTAINER:=Martin Kennedy <hurricos@gmail.com>
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/Hurricos/realtek-poe.git
-PKG_SOURCE_VERSION:=ea32075ae41874043eeed14156755a4c0f114582
-PKG_MIRROR_HASH:=5883af61645216eaf90e86a372df055ef352c4445d4f5010da629d98771da0ec
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/Hurricos/realtek-poe/archive/refs/tags/v$(PKG_VERSION)
+PKG_HASH:=ebe58d2e0f630889d79fb84155936bc43253242857dabfb80d9da71edf92d1e0
 CMAKE_SOURCE_SUBDIR:=src
 
 include $(INCLUDE_DIR)/package.mk
@@ -21,6 +21,13 @@ define Package/realtek-poe
   CATEGORY:=Network
   TITLE:=Realtek PoE Switch Port daemon
   DEPENDS:=+libubox +libubus +libuci
+  URL:=https://github.com/Hurricos/realtek-poe
+endef
+
+define Package/realtek-poe/description
+	Power over Ethernet interface for Realtek switches.
+	Supports enabling/disabling PoE supply on ports and monitoring PoE client
+	 power usage as well as total switch power budget.
 endef
 
 define Package/realtek-poe/install


### PR DESCRIPTION
* Reduce regularly queried items
* Avoid queuing items endlessly to cap memory usage

## 📦 Package Details

backport of https://github.com/openwrt/packages/pull/26789 onto 24.10

**Maintainer:** @Hurricos 

**Description:**
Update realtek-poe to latest commit and add the version field (PKG_VERSION) to enable package upgrades (current version is missing version field and has an assumed version of 0.
As per the [spec](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md#makefile-contents-should-contain) I have reset the PKG_RELEASE version to 1 due to the version increase with the addition of PKG_VERSION. 

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- 24.10.1
- main
- **OpenWrt Target/Subtarget:**
- realtek/rtl839x
- **OpenWrt Device:**
- HPE JG928A

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

