### PR TITLE
syncthing: fix relay and discovery args and permissions

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
 PKG_VERSION:=1.29.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
@@ -42,12 +42,12 @@ define Package/syncthing/Default
   DEPENDS:=$(GO_ARCH_DEPENDS)
   SECTION:=utils
   CATEGORY:=Utilities
+  USERID:=syncthing=499:syncthing=499
 endef
 
 define Package/syncthing
   $(call Package/syncthing/Default)
   TITLE:=Continuous file synchronization program
-  USERID:=syncthing=499:syncthing=499
 endef
 
 define Package/stdiscosrv

--- a/utils/syncthing/files/stdiscosrv.init
+++ b/utils/syncthing/files/stdiscosrv.init
@@ -43,31 +43,35 @@ start_service() {
 	# Options with default value different with the syncthing should be defined explicitly here
 	local enabled=0
 	local listen=":8443"
-	local cert="/etc/stdiscosrv/cert.pem"
-	local key="/etc/stdiscosrv/key.pem"
-	local db_dir="/etc/stdiscosrv/discovery.db"
+	local conf_dir="/etc/stdiscosrv"
+	local cert="$conf_dir/cert.pem"
+	local key="$conf_dir/key.pem"
+	local db_dir="$conf_dir/discovery.db"
 	local nice=0
+	local user="syncthing"
 
 	config_load "stdiscosrv"
 
 	[ "$enabled" -gt 0 ] || return 0
 
+	local group=$(id -gn $user)
+
 	[ -d "$db_dir" ] || mkdir -p "$db_dir"
-	[ -d "$db_dir" ] && chown -R nobody:nogroup "$db_dir"
+	[ -d "$conf_dir" ] && chown -R "$user":"$group" "$conf_dir"
 
 	config_get nice stdiscosrv nice "0"
 
 	procd_open_instance
 	procd_set_param command "$PROG"
-	procd_append_param command -listen="$listen"
-	procd_append_param command -db-dir="$db_dir"
-	procd_append_param command -cert="$cert"
-	procd_append_param command -key="$key"
+	procd_append_param command --listen="$listen"
+	procd_append_param command --db-dir="$db_dir"
+	procd_append_param command --cert="$cert"
+	procd_append_param command --key="$key"
 	[ -z "$extra_args" ] || procd_append_param command "$extra_args"
 
 	procd_set_param nice "$nice"
 	procd_set_param term_timeout 15
-	procd_set_param user "nobody"
+	procd_set_param user "$user"
 	procd_set_param respawn
 	procd_set_param stdout 1
 	procd_set_param stderr 1

--- a/utils/syncthing/files/strelaysrv.init
+++ b/utils/syncthing/files/strelaysrv.init
@@ -44,13 +44,16 @@ start_service() {
 	local enabled=0
 	local keys="/etc/strelaysrv"
 	local nice=0
+	local user="syncthing"
 
 	config_load "strelaysrv"
 
 	[ "$enabled" -gt 0 ] || return 0
 
+	local group=$(id -gn $user)
+
 	[ -d "$keys" ] || mkdir -p "$keys"
-	[ -d "$keys" ] && chown -R nobody:nogroup "$keys"
+	[ -d "$keys" ] && chown -R "$user":"$group" "$keys"
 
 	config_get nice strelaysrv nice "0"
 
@@ -65,7 +68,7 @@ start_service() {
 
 	procd_set_param nice "$nice"
 	procd_set_param term_timeout 15
-	procd_set_param user "nobody"
+	procd_set_param user "$user"
 	procd_set_param respawn
 	procd_set_param stdout 1
 	procd_set_param stderr 1


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @aparcar, @brvphoenix 

**Description:**

Fixes: #26829

Also fixes file permissions when creating new keys and uses the same user/group as the main service.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.