### PR TITLE
mdns-repeater: update to 2023-12-16

### DIFF
--- a/net/mdns-repeater/Makefile
+++ b/net/mdns-repeater/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mdns-repeater
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=https://github.com/kennylevinsen/mdns-repeater.git
+PKG_SOURCE_URL:=https://github.com/geekman/mdns-repeater.git
 PKG_SOURCE_PROTO=git
-PKG_SOURCE_DATE:=2020-05-03
-PKG_SOURCE_VERSION:=921d8850e988d0bd8d60899d933c4ad3094d73ca
-PKG_MIRROR_HASH:=19997460a7eb9816b0c13328ce02331fac532dab549d602e35d671d5f481bfee
+PKG_SOURCE_DATE:=2023-12-16
+PKG_SOURCE_VERSION:=f714ec4d8a0eee248ead29c2ae1bb37f124a568f
+PKG_MIRROR_HASH:=ccc76784483550bcbe3b65f2efee39372516c2cf5d18ef58636cf2661139c4b8
 
 PKG_MAINTAINER:=Alexander Koenig <alex@lisas.de>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -25,7 +25,7 @@ define Package/mdns-repeater
   CATEGORY:=Network
   TITLE:=Multicast DNS repeater for Linux
   SUBMENU:=IP Addresses and Names
-  URL:=https://github.com/kennylevinsen/mdns-repeater
+  URL:=https://github.com/geekman/mdns-repeater
 endef
 
 TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me (@axkg)

**Description:**
Resolves openwrt/packages#26835 by updating to new upstream github handle und latest version committed.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.2
- **OpenWrt Target/Subtarget:** ath79-generic
- **OpenWrt Device:** tplink_tl-wr1043nd-v4

---

## ✅ Formalities

- [ x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
