### PR TITLE
nextdns: Update to version 1.46.0

### DIFF
--- a/net/nextdns/Makefile
+++ b/net/nextdns/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nextdns
-PKG_VERSION:=1.45.0
+PKG_VERSION:=1.46.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=nextdns-$(PKG_VERSION).tar.gz
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.github.com/nextdns/nextdns/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6222359c4a1ea3106c0a13d470806ed833bfbc7a1d10bd91aa3f4701927031b0
+PKG_HASH:=4260824fc20d9d15956c681e6c2025a097f3d350c6dd03dca662f5bbc12bcacc
 
 PKG_MAINTAINER:=Olivier Poitrey <rs@nextdns.io>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Update to version 1.46.0