### PR TITLE
syncthing: bump to 1.30.0

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.29.7
-PKG_RELEASE:=2
+PKG_VERSION:=1.30.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=7b29b2bb1fb85adf6f3baf120ff725a19b06ed13b95011fe67dd952349e0e212
+PKG_HASH:=ef1be71c66753c04212ab1c9c548e678d468bad98dc5461e83540a4ef5c2fcba
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 

--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -10,7 +10,7 @@ PKG_HASH:=7b29b2bb1fb85adf6f3baf120ff725a19b06ed13b95011fe67dd952349e0e212
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 
-PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>, Van Waholtz <brvphoenix@gmail.com>
+PKG_MAINTAINER:=Van Waholtz <brvphoenix@gmail.com>, George Sapkin <george@sapk.in>
 PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:syncthing:syncthing


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @brvphoenix, me?
**Description:**

- Bump syncthing to 1.30.0
  Changelog: https://github.com/syncthing/syncthing/releases/tag/v1.30.0

- Add myself as a maintainer instead of @aparcar according to the discussion in #26856

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.