### PR TITLE
yt-dlp: bump to 2025.06.30

### DIFF
--- a/multimedia/yt-dlp/Makefile
+++ b/multimedia/yt-dlp/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yt-dlp
-PKG_VERSION:=2025.6.25
+PKG_VERSION:=2025.6.30
 PKG_RELEASE:=1
 
 PYPI_NAME:=yt-dlp
-PKG_HASH:=242b648e1a18ab04bdd4cc175a317fe8ec3ad7d0175eee9f981912624b3d6c8b
+PKG_HASH:=6d0ae855c0a55bfcc28dffba804ec8525b9b955d34a41191a1561a4cec03d8bd
 PYPI_SOURCE_NAME:=yt_dlp
 
 PKG_MAINTAINER:=George Sapkin <george@sapk.in>


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Changelog: https://github.com/yt-dlp/yt-dlp/releases/tag/2025.06.30

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.