### PR TITLE
chrony: update to 4.7

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
-PKG_VERSION:=4.6.1
-PKG_RELEASE:=2
+PKG_VERSION:=4.7
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://chrony-project.org/releases/
-PKG_HASH:=571ff73fbf0ae3097f0604eca2e00b1d8bb2e91affe1a3494785ff21d6199c5c
+PKG_HASH:=c0de41a8c051e5d32b101b5f7014b98ca978b18e592f30ce6840b6d4602d947b
 
 PKG_MAINTAINER:=Miroslav Lichvar <mlichvar0@gmail.com>
 PKG_LICENSE:=GPL-2.0


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
Update to the latest upstream release

---

## 🧪 Run Testing Details

- **OpenWrt Version: 24.10.2
- **OpenWrt Target/Subtarget: ramips/mt7621 
- **OpenWrt Device: cudy_wr1300-v1

---

## ✅ Formalities

- [x ] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

