### PR TITLE
autojump-rs: add new package

### DIFF
--- a/utils/autojump-rs/Makefile
+++ b/utils/autojump-rs/Makefile
@@ -1,0 +1,53 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=autojump-rs
+PKG_VERSION:=0.5.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/xen0n/autojump-rs/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=c04be3d0fbeef741ce9363c4f29d1b61b94f6614ed046e283062f9692cfcf584
+
+PKG_MAINTAINER:=John Audia <therealgraysky@proton.me>
+PKG_LICENSE:=GPL-3.0-only
+PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:autojump_project:autojump
+
+PKG_BUILD_DEPENDS:=rust/host
+PKG_BUILD_FLAGS:=no-mold
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/autojump-rs
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=A shell extension to jump to frequently used directories
+  DEPENDS:=$(RUST_ARCH_DEPENDS) @!(i386||mips64)
+  URL:=https://github.com/wting/autojump
+endef
+
+define Package/autojump-rs/description
+  Autojump provides a more efficient way to navigate the filesystem, with a "cd command that learns."
+  It works by maintaining a database of directories and allows users to "jump" to frequently used
+  directories by typing only a small pattern. Supported shells include: bash, fish, and zsh.
+endef
+
+define Package/autojump-rs/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/etc/profile.d
+	$(INSTALL_DIR) $(1)/etc/fish/conf.d
+	$(INSTALL_DIR) $(1)/usr/share/autojump
+	$(INSTALL_DIR) $(1)/usr/share/zsh/site-functions
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/autojump $(1)/usr/bin/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/integrations/autojump.sh $(1)/etc/profile.d/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/integrations/autojump.fish $(1)/etc/fish/conf.d
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/integrations/autojump.bash $(1)/usr/share/autojump/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/integrations/autojump.zsh $(1)/usr/share/autojump/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/integrations/_j $(1)/usr/share/zsh/site-functions
+endef
+
+$(eval $(call RustBinPackage,autojump-rs))
+$(eval $(call BuildPackage,autojump-rs))

--- a/utils/autojump-rs/patches/010-fix-poolean-flags-PR-250.patch
+++ b/utils/autojump-rs/patches/010-fix-poolean-flags-PR-250.patch
@@ -1,0 +1,48 @@
+From 06d2cd186a376bd02386eb92f8eb236c0a8102fa Mon Sep 17 00:00:00 2001
+From: Nikolai Hartmann <nikoladze@posteo.de>
+Date: Sun, 21 May 2023 16:21:50 +0200
+Subject: [PATCH] fix boolean flags
+
+---
+ src/bin/autojump/main.rs | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+--- a/src/bin/autojump/main.rs
++++ b/src/bin/autojump/main.rs
+@@ -52,17 +52,20 @@ pub fn main() {
+             .arg(
+                 Arg::new("complete")
+                     .long("complete")
++                    .action(ArgAction::SetTrue)
+                     .help("used for tab completion"),
+             )
+             .arg(
+                 Arg::new("purge")
+                     .long("purge")
++                    .action(ArgAction::SetTrue)
+                     .help("remove non-existent paths from database"),
+             )
+             .arg(
+                 Arg::new("stat")
+                     .short('s')
+                     .long("stat")
++                    .action(ArgAction::SetTrue)
+                     .help("show database entries and their key weights"),
+             )
+             .arg(
+@@ -103,12 +106,12 @@ pub fn main() {
+             arg_dir: app
+                 .get_many::<String>("dir")
+                 .map_or(vec![], |x| x.cloned().collect()),
+-            flag_complete: app.contains_id("complete"),
+-            flag_purge: app.contains_id("purge"),
++            flag_complete: app.get_flag("complete"),
++            flag_purge: app.get_flag("purge"),
+             flag_add: app.get_one::<String>("add").cloned(),
+             flag_increase,
+             flag_decrease,
+-            flag_stat: app.contains_id("stat"),
++            flag_stat: app.get_flag("stat"),
+         }
+     };
+     let config = Config::defaults();


### PR DESCRIPTION
Autojump is a faster way to navigate your filesystem. It works by maintaining a database of the directories you use the most from the command line.

Upstream URL to python code: https://github.com/wting/autojump
Upstream URL to rust port: https://github.com/xen0n/autojump-rs

The rust port is advantageous for several reasons:
1. Avoids 13,640 KiB in python3-codecs dependency tree: 
```
libpython3-3.11-3.11.10-r1 installed size: 4528 KiB
python3-base-3.11.10-r1 installed size: 1140 KiB
python3-codecs-3.11.10-r1 installed size: 1944 KiB
python3-light-3.11.10-r1 installed size: 8028 KiB
```
2. According to upstream testing, is much faster and more efficient particularly on low power hardware like many of OpenWrt SoCs.


## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Included in commit message. For these reasons I closed my initial PR of the python version, https://github.com/openwrt/packages/pull/26887

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** generic PC

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
