### PR TITLE
csshnpd: Preserve .atsign directory

### DIFF
--- a/net/csshnpd/Makefile
+++ b/net/csshnpd/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
 PKG_VERSION:=1.0.13
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
@@ -49,6 +49,7 @@ endef
 
 define Package/csshnpd/conffiles
 /etc/config/sshnpd
+/root/.atsign/
 endef
 
 define Package/csshnpd/install	


### PR DESCRIPTION
Ensure that the default location for atKeys is preserved on upgrade

## 📦 Package Details

**Maintainer:** @cpswan 

**Description:**

Ensure that the default location for atKeys is preserved on upgrade.

Whilst going through the review process for luci-app-csshnpd @systemcrash [highlighted](https://github.com/openwrt/luci/pull/7832#discussion_r2172316552) that enrolled atKeys would not be included in backups or preserved during upgrades.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT r28146
- **OpenWrt Target/Subtarget:** aarch64_cortex-a53
- **OpenWrt Device:** OpenWrt One

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.