### PR TITLE
knot-resolver: disable jemalloc support

### DIFF
--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -66,7 +66,8 @@ MESON_ARGS+= \
 	-Dkeyfile_default=/etc/knot-resolver/root.keys \
 	-Dprefix=/usr \
 	-Dunit_tests=disabled \
-	-Dutils=disabled
+	-Dutils=disabled \
+	-Dmalloc=disabled
 
 define Package/knot-resolver/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
See https://github.com/openwrt/packages/pull/26721#issuecomment-2973865778

## 📦 Package Details

**Maintainer:** Jan Pavlinec <jan.pavlinec1@gmail.com> (not on Github?)

**Description:**

knot-resolving will attempt to use jemalloc if it's available. Jemalloc was added to openwrt packages in #26721. At this time, we would rather continue linking with the libc malloc, implementation, so this PR disables jemalloc support explicitly in the knot-resolver build configuration.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
