### PR TITLE
lsof: update to 4.99.5

### DIFF
--- a/utils/lsof/Makefile
+++ b/utils/lsof/Makefile
@@ -7,20 +7,23 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=lsof
-PKG_VERSION:=4.99.4
+PKG_VERSION:=4.99.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lsof-org/lsof/releases/download/$(PKG_VERSION)
-PKG_HASH:=0c444e2dabec14ad146cbb7f5b52b5ab4976728402ff348d9feced9ad9740c66
+PKG_HASH:=4682c2491ec8b3d62f84e135afc1d9ead1bad5f034b50716f0c3826a4ee7d229
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=lsof
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:lsof_project:lsof
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
+
+DISABLE_NLS:=
 
 define Package/lsof
   SECTION:=utils


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @mstorchak 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Update to 4.99.5
---

## 🧪 Run Testing Details

- **OpenWrt Version:** r30028+3-2b0b16f1d1
- **OpenWrt Target/Subtarget:** qualcommax/ipq807x
- **OpenWrt Device:** Dynalink DL-WRX36

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
