### PR TITLE
mpack: fix build errors

### DIFF
--- a/utils/mpack/Makefile
+++ b/utils/mpack/Makefile
@@ -9,13 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpack
 PKG_VERSION:=1.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=NLPL
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://fossies.org/linux/misc/old
 PKG_HASH:=274108bb3a39982a4efc14fb3a65298e66c8e71367c3dabf49338162d207a94c
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/utils/mpack/patches/000-remove-lib-socket.patch
+++ b/utils/mpack/patches/000-remove-lib-socket.patch
@@ -1,0 +1,46 @@
+ Makefile.am | 4 ++--
+ Makefile.in | 5 ++---
+ 2 files changed, 4 insertions(+), 5 deletions(-)
+
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -5,12 +5,12 @@ bin_PROGRAMS=mpack munpack
+ 
+ mpack_SOURCES=unixpk.c encode.c codes.c magic.c unixos.c xmalloc.c \
+ 	md5c.c
+-mpack_LDADD=@LIBOBJS@ @LIB_SOCKET@
++mpack_LDADD=@LIBOBJS@
+ 
+ munpack_SOURCES=unixunpk.c decode.c uudecode.c codes.c unixos.c \
+ 	part.c xmalloc.c md5c.c
+ 
+-munpack_LDADD=@LIBOBJS@ @LIB_SOCKET@
++munpack_LDADD=@LIBOBJS@
+ 
+ noinst_HEADERS=common.h md5.h part.h version.h xmalloc.h
+ man_MANS=mpack.1 munpack.1
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -56,7 +56,6 @@ NORMAL_UNINSTALL = :
+ PRE_UNINSTALL = :
+ POST_UNINSTALL = :
+ CC = @CC@
+-LIB_SOCKET = @LIB_SOCKET@
+ MAKEINFO = @MAKEINFO@
+ PACKAGE = @PACKAGE@
+ VERSION = @VERSION@
+@@ -68,12 +67,12 @@ bin_PROGRAMS = mpack munpack
+ 
+ mpack_SOURCES = unixpk.c encode.c codes.c magic.c unixos.c xmalloc.c 	md5c.c
+ 
+-mpack_LDADD = @LIBOBJS@ @LIB_SOCKET@
++mpack_LDADD = @LIBOBJS@
+ 
+ munpack_SOURCES = unixunpk.c decode.c uudecode.c codes.c unixos.c 	part.c xmalloc.c md5c.c
+ 
+ 
+-munpack_LDADD = @LIBOBJS@ @LIB_SOCKET@
++munpack_LDADD = @LIBOBJS@
+ 
+ noinst_HEADERS = common.h md5.h part.h version.h xmalloc.h
+ man_MANS = mpack.1 munpack.1

--- a/utils/mpack/patches/001-use-stdlib.patch
+++ b/utils/mpack/patches/001-use-stdlib.patch
@@ -1,3 +1,32 @@
+ decode.c   | 1 +
+ part.c     | 1 +
+ unixos.c   | 5 +----
+ unixpk.c   | 4 +---
+ unixunpk.c | 1 +
+ uudecode.c | 1 +
+ xmalloc.c  | 2 +-
+ 7 files changed, 7 insertions(+), 8 deletions(-)
+
+--- a/decode.c
++++ b/decode.c
+@@ -27,6 +27,7 @@
+ 
+ #include <stdio.h>
+ #include <string.h>
++#include <stdlib.h>
+ #include <ctype.h>
+ #include "xmalloc.h"
+ #include "common.h"
+--- a/part.c
++++ b/part.c
+@@ -28,6 +28,7 @@
+ 
+ #include <stdio.h>
+ #include <string.h>
++#include <stdlib.h>
+ 
+ #include "part.h"
+ #include "xmalloc.h"
 --- a/unixos.c
 +++ b/unixos.c
 @@ -25,6 +25,7 @@
@@ -8,15 +37,57 @@
  #include <errno.h>
  #include <sys/types.h>
  #include <sys/param.h>
-@@ -39,8 +40,6 @@
+@@ -38,10 +39,6 @@
+ #define MAXHOSTNAMELEN 64
  #endif
  
- extern int errno;
+-extern int errno;
 -extern char *malloc();
 -extern char *getenv();
- 
+-
  int overwrite_files = 0;
  int didchat;
+ 
+--- a/unixpk.c
++++ b/unixpk.c
+@@ -24,6 +24,7 @@
+  */
+ #include <stdio.h>
+ #include <string.h>
++#include <stdlib.h>
+ #include <errno.h>
+ #include "common.h"
+ #include "version.h"
+@@ -31,9 +32,6 @@
+ 
+ #define MAXADDRESS 100
+ 
+-extern char *getenv();
+-
+-extern int errno;
+ extern int optind;
+ extern char *optarg;
+ 
+--- a/unixunpk.c
++++ b/unixunpk.c
+@@ -23,6 +23,7 @@
+  * SOFTWARE.
+  */
+ #include <stdio.h>
++#include <stdlib.h>
+ #include "version.h"
+ #include "part.h"
+ 
+--- a/uudecode.c
++++ b/uudecode.c
+@@ -25,6 +25,7 @@
+ #include <stdio.h>
+ #include <ctype.h>
+ #include <string.h>
++#include <stdlib.h>
+ #include "xmalloc.h"
+ #include "common.h"
+ #include "part.h"
 --- a/xmalloc.c
 +++ b/xmalloc.c
 @@ -24,7 +24,7 @@

--- a/utils/mpack/patches/002-missing-decl.patch
+++ b/utils/mpack/patches/002-missing-decl.patch
@@ -1,0 +1,172 @@
+ common.h   |  1 +
+ decode.c   | 17 +++++++++++++++++
+ encode.c   |  2 ++
+ magic.c    |  1 +
+ unixos.c   |  3 +++
+ unixpk.c   |  4 ++++
+ unixunpk.c |  2 ++
+ uudecode.c | 15 +++++++++++++--
+ 8 files changed, 43 insertions(+), 2 deletions(-)
+
+--- a/common.h
++++ b/common.h
+@@ -30,6 +30,7 @@
+ #endif
+ 
+ #if defined(unix) && !defined(remove)
++#include <unistd.h>
+ #define remove unlink
+ #endif
+ 
+--- a/decode.c
++++ b/decode.c
+@@ -38,6 +38,18 @@ extern char *os_idtodir(char *id);
+ extern FILE *os_newtypedfile(char *fname, char *contentType, int flags, params contentParams);
+ extern FILE *os_createnewfile(char *fname);
+ extern char *md5contextTo64(MD5_CTX *context);
++extern void warn(char *s);
++extern int part_depth(struct part *part);
++extern int part_close(struct part *part);
++extern int handleUuencode(struct part *inpart, char *subject, int extractText);
++extern int part_ungets(char *s, struct part *part);
++extern void chat(char *s);
++extern void os_donewithdir(char *dir);
++extern int part_fill(struct part *part);
++extern int part_addboundary(struct part *part, char *boundary);
++extern int part_readboundary(struct part *part);
++extern void os_warnMD5mismatch(void);
++extern void os_closetypedfile(FILE *outfile);
+ 
+ /* The possible content transfer encodings */
+ enum encoding { enc_none, enc_qp, enc_base64 };
+@@ -50,6 +62,11 @@ char *getDispositionFilename(char *dispo
+ void from64(struct part *inpart, FILE *outfile, char **digestp, int suppressCR);
+ void fromqp(struct part *inpart, FILE *outfile, char **digestp);
+ void fromnone(struct part *inpart, FILE *outfile, char **digestp);
++int ignoreMessage(struct part *inpart);
++int handlePartial(struct part *inpart, char *headers, params contentParams, int extractText);
++int handleMultipart(struct part *inpart, char *contentType, params contentParams, int extractText);
++int handleText(struct part *inpart, enum encoding contentEncoding);
++int saveToFile(struct part *inpart, int inAppleDouble, char *contentType, params contentParams, enum encoding contentEncoding, char *contentDisposition, char *contentMD5);
+ /*
+  * Read and handle an RFC 822 message from the body-part 'inpart'.
+  */
+--- a/encode.c
++++ b/encode.c
+@@ -24,11 +24,13 @@
+  */
+ #include <stdio.h>
+ #include <string.h>
++#include <stdlib.h>
+ 
+ extern char *magic_look(FILE *infile);
+ extern char *os_genid(void);
+ extern FILE *os_createnewfile(char *fname);
+ extern char *md5digest(FILE *infile, long int *len);
++extern int to64(FILE *infile, FILE *outfile, long int limit);
+ 
+ #define NUMREFERENCES 4
+ 
+--- a/magic.c
++++ b/magic.c
+@@ -23,6 +23,7 @@
+  * SOFTWARE.
+  */
+ #include <stdio.h>
++#include <string.h>
+ 
+ /* Description of the various file formats and their magic numbers */
+ struct magic {
+--- a/unixos.c
++++ b/unixos.c
+@@ -27,6 +27,9 @@
+ #include <string.h>
+ #include <stdlib.h>
+ #include <errno.h>
++#include <time.h>
++#include <unistd.h>
++#include <sys/stat.h>
+ #include <sys/types.h>
+ #include <sys/param.h>
+ #include <netdb.h>
+--- a/unixpk.c
++++ b/unixpk.c
+@@ -26,9 +26,11 @@
+ #include <string.h>
+ #include <stdlib.h>
+ #include <errno.h>
++#include <unistd.h>
+ #include "common.h"
+ #include "version.h"
+ #include "xmalloc.h"
++#include <sys/wait.h>
+ 
+ #define MAXADDRESS 100
+ 
+@@ -39,6 +41,8 @@ void usage(void);
+ void sendmail(FILE *infile, char **addr, int start);
+ void inews(FILE *infile);
+ 
++extern int encode(FILE *infile, FILE *applefile, char *fname, FILE *descfile, char *subject, char *headers, long int maxsize, char *typeoverride, char *outfname);
++
+ int main(int argc, char **argv)
+ {
+     int opt;
+--- a/unixunpk.c
++++ b/unixunpk.c
+@@ -24,12 +24,14 @@
+  */
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <unistd.h>
+ #include "version.h"
+ #include "part.h"
+ 
+ extern int optind;
+ extern char *optarg;
+ 
++extern int handleMessage(struct part *inpart, char *defaultContentType, int inAppleDouble, int extractText);
+ extern int overwrite_files;
+ extern int didchat;
+ int quiet;
+--- a/uudecode.c
++++ b/uudecode.c
+@@ -33,9 +33,21 @@
+ extern char *os_idtodir(char *id);
+ extern FILE *os_newtypedfile(char *fname, char *contentType, int flags, params contentParams);
+ extern FILE *os_createnewfile(char *fname);
++extern int os_binhex(struct part *inpart, int part, int nparts);
++extern int part_ungets(char *s, struct part *part);
++extern int handleMessage(struct part *inpart, char *defaultContentType, int inAppleDouble, int extractText);
++extern void chat(char *s);
++extern int part_close(struct part *part);
++extern void os_closetypedfile(FILE *outfile);
++extern void os_donewithdir(char *dir);
+ 
+ static FILE *startDescFile(char *fname);
+ 
++int parseSubject(char *subject, char **fnamep, int *partp, int *npartsp);
++int saveUuFile(struct part *inpart, char *fname, int part, int nparts, char *firstline);
++int descEnd(char *line);
++int uudecodefiles(char *dir, int nparts);
++void uudecodeline(char *line, FILE *outfile);
+ 
+ /* Length of a normal uuencoded line, including newline */
+ #define UULENGTH 62
+@@ -827,7 +839,7 @@ uudecodefiles(char *dir, int nparts)
+ /*
+  * Decode a uuencoded line to 'outfile'
+  */
+-int uudecodeline(char *line, FILE *outfile)
++void uudecodeline(char *line, FILE *outfile)
+ {
+     int c, len;
+ 
+@@ -846,7 +858,6 @@ int uudecodeline(char *line, FILE *outfi
+ 	}
+ 	line += 4;
+     }
+-    return;
+ }
+ 
+     

--- a/utils/mpack/patches/003-fix-perror.patch
+++ b/utils/mpack/patches/003-fix-perror.patch
@@ -1,0 +1,129 @@
+ decode.c   | 12 ++++++------
+ encode.c   |  2 +-
+ unixpk.c   |  4 ++--
+ uudecode.c |  8 ++++----
+ 4 files changed, 13 insertions(+), 13 deletions(-)
+
+--- a/decode.c
++++ b/decode.c
+@@ -652,7 +652,7 @@ int handlePartial(struct part *inpart, c
+ 	sprintf(buf, "%sCT", dir);
+ 	partfile = os_createnewfile(buf);
+ 	if (!partfile) {
+-	    os_perror(buf);
++	    perror(buf);
+ 	    goto ignore;
+ 	}
+ 	fprintf(partfile, "%d\n", nparts);
+@@ -685,7 +685,7 @@ int handlePartial(struct part *inpart, c
+     sprintf(buf, "%s%d", dir, thispart);
+     partfile = os_createnewfile(buf);
+     if (!partfile) {
+-	os_perror(buf);
++	perror(buf);
+ 	goto ignore;
+     }
+ 
+@@ -759,14 +759,14 @@ int handlePartial(struct part *inpart, c
+     sprintf(buf, "%sFULL", dir);
+     outfile = os_createnewfile(buf);
+     if (!outfile) {
+-	os_perror(buf);
++	perror(buf);
+ 	return 1;
+     }
+     for (i=1; i<=nparts; i++) {
+ 	sprintf(buf, "%s%d", dir, i);
+ 	partfile = fopen(buf, "r");
+ 	if (!partfile) {
+-	    os_perror(buf);
++	    perror(buf);
+ 	    return 1;
+ 	}
+ 	while (fgets(buf, sizeof(buf), partfile)) {
+@@ -784,7 +784,7 @@ int handlePartial(struct part *inpart, c
+     sprintf(buf, "%sFULL", dir);
+     outfile = fopen(buf, "r");
+     if (!outfile) {
+-	os_perror(buf);
++	perror(buf);
+ 	return 1;
+     }
+     outpart = part_init(outfile);
+@@ -885,7 +885,7 @@ int handleText(struct part *inpart, enum
+ 
+     descfile = os_createnewfile(TEMPFILENAME);
+     if (!descfile) {
+-	os_perror(TEMPFILENAME);
++	perror(TEMPFILENAME);
+ 	ignoreMessage(inpart);
+ 	return 1;
+     }
+--- a/encode.c
++++ b/encode.c
+@@ -117,7 +117,7 @@ int encode(FILE *infile, FILE *applefile
+ 	    outfile = os_createnewfile(buf);
+ 	}
+ 	if (!outfile) {
+-	    os_perror(buf);
++	    perror(buf);
+             return 1;
+         }
+ 	
+--- a/unixpk.c
++++ b/unixpk.c
+@@ -175,14 +175,14 @@ int main(int argc, char **argv)
+ 
+     infile = fopen(fname, "r");
+     if (!infile) {
+-	os_perror(fname);
++	perror(fname);
+ 	exit(1);
+     }
+ 
+     if (descfname) {
+ 	descfile = fopen(descfname, "r");
+ 	if (!descfile) {
+-	    os_perror(descfname);
++	    perror(descfname);
+ 	    exit(1);
+ 	}
+     }
+--- a/uudecode.c
++++ b/uudecode.c
+@@ -441,7 +441,7 @@ saveUuFile(struct part *inpart, char *fn
+     sprintf(buf, "%s%d", dir, part);
+     partfile = os_createnewfile(buf);
+         if (!partfile) {
+-	os_perror(buf);
++	perror(buf);
+ 	return 1;
+     }
+     if (firstline) fputs(firstline, partfile);
+@@ -454,7 +454,7 @@ saveUuFile(struct part *inpart, char *fn
+ 	    sprintf(buf, "%sCT", dir);
+ 	    partfile = os_createnewfile(buf);
+ 	    if (!partfile) {
+-		os_perror(buf);
++		perror(buf);
+ 	    }
+ 	    else {
+ 		fprintf(partfile, "%d\n", nparts);
+@@ -658,7 +658,7 @@ static FILE *startDescFile(char *fname)
+ 
+     descfile = os_createnewfile(buf);
+     if (!descfile) {
+-	os_perror(buf);
++	perror(buf);
+ 	return 0;
+     }
+     return descfile;
+@@ -706,7 +706,7 @@ uudecodefiles(char *dir, int nparts)
+ 	sprintf(buf, "%s%d", dir, part);
+ 	infile = fopen(buf, "r");
+ 	if (!infile) {
+-	    os_perror(buf);
++	    perror(buf);
+ 	    if (outfile) fclose(outfile);
+ 	    remove(TEMPFILENAME);
+ 	    return 1;

--- a/utils/mpack/patches/004-fix-warn.patch
+++ b/utils/mpack/patches/004-fix-warn.patch
@@ -1,0 +1,44 @@
+ unixos.c   | 8 +-------
+ unixpk.c   | 5 -----
+ unixunpk.c | 2 +-
+ 3 files changed, 2 insertions(+), 13 deletions(-)
+
+--- a/unixos.c
++++ b/unixos.c
+@@ -263,13 +263,7 @@ os_binhex(struct part *inpart, int part,
+  */
+ void os_warnMD5mismatch(void)
+ {
+-    char *warning;
+-
+-    warning = xmalloc(strlen(output_fname) + 100);
+-    sprintf(warning, "%s was corrupted in transit",
+-	    output_fname);
+-    warn(warning);
+-    free(warning);
++    fprintf(stderr, "warning: %s was corrupted in transit\n", output_fname);
+ }
+ 
+ /*
+--- a/unixpk.c
++++ b/unixpk.c
+@@ -293,8 +293,3 @@ void inews(FILE *infile)
+     perror("execl");
+     _exit(1);
+ }
+-
+-void warn(void)
+-{
+-    abort();
+-}
+--- a/unixunpk.c
++++ b/unixunpk.c
+@@ -109,7 +109,7 @@ void usage(void) {
+ 
+ void warn(char *s)
+ {
+-    fprintf(stderr, "munpack: warning: %s\n", s);
++    fprintf(stderr, "warning: %s\n", s);
+ }
+ 
+ void chat(char *s)


### PR DESCRIPTION
It seems that mpack doesn't compile well with modern toolchain/libc but source code is not maintained so try to fix most obvious errors with patches.