### PR TITLE
golang: disable CGO for ppc64

### DIFF
--- a/lang/golang/golang-values.mk
+++ b/lang/golang/golang-values.mk
@@ -205,7 +205,7 @@ endif
 
 # Target Go
 
-GO_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||loongarch64||mips||mips64||mips64el||mipsel||powerpc64||riscv64||x86_64)
+GO_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||loongarch64||mips||mips64||mips64el||mipsel||riscv64||x86_64)
 
 
 # ASLR/PIE


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jefferyto 

**Description:**
Golang does not support CGO on ppc64:
/builder/shared-workdir/build/sdk/staging_dir/hostpkg/lib/go-cross/pkg/tool/linux_amd64/link: external linking not supported for linux/ppc64

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** qoriq/generic
- **OpenWrt Device:** qemu

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.