### PR TITLE
modemmanager: change to configuration option disable_modem

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -877,14 +877,11 @@ proto_modemmanager_teardown() {
 	mmcli --modem="${device}" --simple-disconnect ||
 		proto_notify_error "${interface}" DISCONNECT_FAILED
 
-	# reading variable from var state which was set in
-	# '/usr/lib/ModemManager/connection.d/10-report-down'
-	# because of a reconnect event.
-	# The modem therefore does not need to be disabled.
-	local disable="$(uci_get_state network "$interface" disable_modem "1")"
+	# Variable is set to '1' if modem should be disabled on ifdown,
+	# otherwise it stays connected.
+	local disable="$(uci_get network "$interface" disable_modem "1")"
 	if [ "${disable}" -eq 0 ]; then
 		echo "Skipping modem disable"
-		uci_revert_state network "${interface}" disable_modem
 	else
 		mmcli --modem="${device}" --disable
 	fi

--- a/net/modemmanager/files/usr/lib/ModemManager/connection.d/10-report-down
+++ b/net/modemmanager/files/usr/lib/ModemManager/connection.d/10-report-down
@@ -32,7 +32,6 @@ IFUP=$(ifstatus "${CFG}" | jsonfilter -e "@.up")
 
 [ "${IFUP}" = "true" ] && {
 	mm_log "info" "Reconnecting '${CFG}' on '${STATE}' event"
-	uci_toggle_state network "${CFG}" disable_modem "0"
 	ubus call network.interface down "{ 'interface': '${CFG}'}"
 	ubus call network.interface up "{ 'interface': '${CFG}'}"
 }


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @feckert 

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
This commit sets default of `disable_modem` to 1 and disconnects modem. If set otherwise it keeps the modem connected.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** owrt-24.10.2
- **OpenWrt Target/Subtarget:** x86/64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
