### PR TITLE
libdeflate: update to 1.24

### DIFF
--- a/libs/libdeflate/Makefile
+++ b/libs/libdeflate/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdeflate
-PKG_VERSION:=1.22
+PKG_VERSION:=1.24
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/ebiggers/libdeflate/releases/download/v$(PKG_VERSION)
-PKG_HASH:=7834d9adbc9a809e0fb0d7b486060a9ae5f7819eb7f55bb8c22b10d7b3bed8da
+PKG_HASH:=a0dda1c4b804742066db07b9510876edd09cc0ca06cdc32c5dfe1b2016a26463
 
 PKG_LICENSE:=COPYING
 PKG_LICENSE_FILES:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->


## Version 1.24

* The CMake-based build system now supports Apple Framework builds.

* libdeflate now builds for Windows ARM64EC.

* Made another small optimization to the x86 and ARM CRC32 code.

* Fixed a compiler warning on certain platforms (issue ebiggers/libdeflate#416).

## Version 1.23

* Fixed bug introduced in 1.20 where incorrect checksums could be calculated if
  libdeflate was compiled with clang at -O0 and run on a CPU supporting AVX512.

* Fixed bug introduced in 1.20 where incorrect checksums could be calculated in
  rare cases on macOS computers that support AVX512 and are running an older
  version of macOS that contains a bug that corrupts AVX512 registers.  This
  could occur only if code outside libdeflate enabled AVX512 in the thread.

* Fixed build error when using -mno-evex512 with clang 18+ or gcc 14+.

* Increased the minimum CMake version to 3.10.

* Further optimized the x86 CRC code.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** aarch64/cortex-a53
- **OpenWrt Device:** -

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
