### PR TITLE
libevdev: update to 1.13.4

### DIFF
--- a/libs/libevdev/Makefile
+++ b/libs/libevdev/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libevdev
-PKG_VERSION:=1.13.1
+PKG_VERSION:=1.13.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libevdev/
-PKG_HASH:=06a77bf2ac5c993305882bc1641017f5bec1592d6d1b64787bad492ab34f2f36
+PKG_HASH:=f00ab8d42ad8b905296fab67e13b871f1a424839331516642100f82ad88127cd
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Apart from documentation and improvements for the meson-based build there are two functional changes since 1.13.1:
```
 080d1d0 include: sync event codes with kernel 6.9
 d06abb8 Always push changed mt events when syncing
```

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** aarch64/cortex-a53
- **OpenWrt Device:** -

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
