### PR TITLE
lvm2: update to 2.03.33 and libdm to 1.02.207

### DIFF
--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -9,15 +9,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=LVM2
-PKG_VERSION:=2.03.31
-PKG_VERSION_DM:=1.02.205
-PKG_RELEASE:=3
+PKG_VERSION:=2.03.33
+PKG_VERSION_DM:=1.02.207
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://sourceware.org/pub/lvm2 \
                 https://www.mirrorservice.org/sites/sourceware.org/pub/lvm2
 
-PKG_HASH:=5db2956a00fbf87d92274cccc92436387ec0c3faadece7413ece1ba1c10c98ff
+PKG_HASH:=be4babd8a986d73279f1e75fbb1d33cb41559b75c2063611781bfeb8c2def139
 PKG_BUILD_DIR:=$(BUILD_DIR)/lvm2-$(BUILD_VARIANT)/$(PKG_NAME).$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>

--- a/utils/lvm2/patches/002-const-stdio.patch
+++ b/utils/lvm2/patches/002-const-stdio.patch
@@ -34,7 +34,7 @@
  
 --- a/tools/lvmcmdline.c
 +++ b/tools/lvmcmdline.c
-@@ -3386,6 +3386,7 @@ int lvm_split(char *str, int *argc, char
+@@ -3404,6 +3404,7 @@ int lvm_split(char *str, int *argc, char
  /* Make sure we have always valid filedescriptors 0,1,2 */
  static int _check_standard_fds(void)
  {
@@ -42,7 +42,7 @@
  	int err = is_valid_fd(STDERR_FILENO);
  
  	if (!is_valid_fd(STDIN_FILENO) &&
-@@ -3412,6 +3413,12 @@ static int _check_standard_fds(void)
+@@ -3430,6 +3431,12 @@ static int _check_standard_fds(void)
  		       strerror(errno));
  		return 0;
  	}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

# LVM changes

Version 2.03.33 - 27th June 2025
================================
  Various spelling, grammar, formatting, test, and build script improvements.
  Override LC_NUMERIC locale if unsuitable for json_std report format.
  Repair raid arrays with transiently lost devices.

Version 2.03.32 - 05th May 2025
===============================
  Lvconvert vdopool conversion properly validates acceptable LVs.
  Accept thin pool data LV as cacheable LV.
  Allow using zram block devices (likely for testing).
  Fix lvresize when resizing COW snapshots already covering origin.
  Fix lvmdbusd read of executed lvm commands output.
  Fix construction of DM UUID for cachevol _cdata and _cmeta devices.
  Ignore PV claims from old metadata when then PV belongs to a new VG.
  Fix integrity metadata rounding.
  Accept --autobackup option in pvresize.

# libdm changes

Version 1.02.207 - 27th June 2025
=================================
  Escape the escape character itself on JSON report format output.
  Fail dm_report_group_create if radix char from locale unsuitable for JSON_STD.

Version 1.02.206 - 05th May 2025
================================
  Add support for using regex in selection criteria for string lists.
  Fix string list selection when using [<item> || <item> ...].

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
