### PR TITLE
libpbc: update to 1.0.0

### DIFF
--- a/libs/libpbc/Makefile
+++ b/libs/libpbc/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpbc
-PKG_VERSION:=0.5.14
-PKG_RELEASE:=2
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=pbc-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://crypto.stanford.edu/pbc/files/
-PKG_HASH:=772527404117587560080241cedaf441e5cac3269009cdde4c588a1dce4c23d2
+PKG_HASH:=18275a367283077bafe35f443200499e3b19c4a3754953da2a1b2f0d6b5922dc
 PKG_BUILD_DIR:=$(BUILD_DIR)/pbc-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>

--- a/libs/libpbc/patches/010-pass-cflags.patch
+++ b/libs/libpbc/patches/010-pass-cflags.patch
@@ -1,8 +1,8 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -10,7 +10,6 @@ AC_CONFIG_SRCDIR([./])
- LT_INIT
- #AC_CANONICAL_HOST
+@@ -9,7 +9,6 @@ AC_CONFIG_MACRO_DIR([m4])
+ AC_CONFIG_SRCDIR([./])
+ LT_INIT(win32-dll)
  
 -CFLAGS=
  default_fink_path=/sw

--- a/libs/libpbc/patches/020-autoconf-flex-noyywrap.patch
+++ b/libs/libpbc/patches/020-autoconf-flex-noyywrap.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -75,7 +75,7 @@ AC_PROG_INSTALL
+ AC_PROG_LN_S
+ AC_PROG_MAKE_SET
+ 
+-AC_PROG_LEX(yywrap)
++AC_PROG_LEX(noyywrap)
+ if test "x$LEX" != xflex; then
+   echo "************************"
+   echo "flex not found"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
The author writes on https://crypto.stanford.edu/pbc/news.html

---
pbc-1.0.0 released

Thanks to many contributors for fixes, wrappers, and tests.

It’s been over a decade since the last release, and over two since pbc-0.0.0. I had thought this project would have faded into obscurity by now, but I still receive patches occasionally. I challenged myself to build a new release. Miraculously, the old scripts still seem to work, and the only non-trivial edit was renaming a few MinGW invocations in a Makefile.

I bumped up the major version number. At the rate I’m going, this could be the last release, and it’d be a shame if the project never reached v1.0!

Tue Jun 10 09:15:34 PM PDT 2025

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** aarch64/cortex-a53
- **OpenWrt Device:** -

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
