### PR TITLE
libcurl-gnutls: update to cURL release 8.14.1

### DIFF
--- a/net/libcurl-gnutls/Makefile
+++ b/net/libcurl-gnutls/Makefile
@@ -10,12 +10,12 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=libcurl-gnutls
 
 PKG_SOURCE_NAME:=curl
-PKG_VERSION:=8.9.1
+PKG_VERSION:=8.14.1
 PKG_RELEASE:=1
 PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \
 	https://curl.se/download/
-PKG_HASH:=f292f6cc051d5bbabf725ef85d432dfeacc8711dd717ea97612ae590643801e5
+PKG_HASH:=f4619a1e2474c4bbfedc88a7c2191209c8334b48fa1f4e53fd584cc12e9120dd
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Quite a few versions of cURL have been released since last updating libcurl-gnutls. See release notes since 8.9.1

https://curl.se/ch/8.10.0.html

https://curl.se/ch/8.10.1.html

https://curl.se/ch/8.11.0.html

https://curl.se/ch/8.11.1.html

https://curl.se/ch/8.12.0.html

https://curl.se/ch/8.12.1.html

https://curl.se/ch/8.13.0.html

https://curl.se/ch/8.14.0.html

https://curl.se/ch/8.14.1.html

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** aarch64/cortex-a53
- **OpenWrt Device:** -

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
