### PR TITLE
unifdef: fix build with GCC 15

### DIFF
--- a/devel/unifdef/Makefile
+++ b/devel/unifdef/Makefile
@@ -17,6 +17,9 @@ HOST_BUILD_PARALLEL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 
+HOST_CFLAGS += -std=gnu17
+TARGET_CFLAGS += -std=gnu17
+
 define Package/unifdef
   SECTION:=devel
   CATEGORY:=Development


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Using GCC compiler on the host breaks the build due to 'constexpr' being a reserved keyword in C22.
Build expecting the sources to be in GNU17 standard fixes that.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** n/a

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
