### PR TITLE
shadow: restore PKG_BUILD_DEPENDS to libxcrypt

### DIFF
--- a/utils/shadow/Makefile
+++ b/utils/shadow/Makefile
@@ -22,7 +22,7 @@ PKG_CPE_ID:=cpe:/a:debian:shadow
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_DEPENDS:=xcrypt
+PKG_BUILD_DEPENDS:=libxcrypt
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk


### PR DESCRIPTION
## 📦 Package Details

**Description:**
This reverts commit f18594a00f6324045a7019863a5278a3f6f52e64.

The whole libxcrypt package was reworked in the base repo to fix libcrypto-compat and the name was restored to libxcrypt.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** main
- **OpenWrt Target/Subtarget:** qualcommax/ipq807x
- **OpenWrt Device:** None

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
