### PR TITLE
afraid.org-v2-token.json: Fix 404 on update

### DIFF
--- a/net/ddns-scripts/files/usr/share/ddns/default/afraid.org-v2-token.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/afraid.org-v2-token.json
@@ -1,9 +1,9 @@
 {
 	"name": "afraid.org-v2-token",
 	"ipv4": {
-		"url": "https://sync.afraid.org/u/[PASSWORD]/?address=[IP]"
+		"url": "https://freedns.afraid.org/dynamic/update.php?[PASSWORD]&address=[IP]"
 	},
 	"ipv6": {
-		"url": "https://v6.sync.afraid.org/u/[PASSWORD]/?address=[IP]"
+		"url": "https://freedns.afraid.org/dynamic/update.php?[PASSWORD]&address=[IP]"
 	}
 }


### PR DESCRIPTION
The URL for update changed and updates were silently failing with HTTP 404. Fixed the URL

## 📦 Package Details

**Maintainer:**

 contact@ericleung.dev @ericleun

**Description:**

ddns-scripts support affraid.org but the v2 token update is not working and when it is ran it lead to a 404.
This PR updates the URL so it works again.

---

## 🧪 Run Testing Details

- **OpenWrt Version: 22.03.0 r19685-512e76967f / LuCI openwrt-22.03 branch git-22.245.77528-487e58a
Ran it on my router logs below:

Before my patch
```
Detect local IP on 'interface'
 173441       : #> ip -o addr show dev eth0.2 scope global >/var/run/ddns/***.dat 2>/var/run/ddns/***.err
 173441       : Local IP ***' detected on interface 'eth0.2'
 173441       : Update needed - L: '***' <> R: '***'
 173441       : #> /usr/bin/curl -RsS -o /var/run/ddns/***.dat --stderr /var/run/ddns/***.err --insecure --noproxy '*' 'https://sync.afraid.org/u/***PW***/?address=***'
 173443       : DDNS Provider answered:
Error 404 : Page not found
 173443  info : Update successful - IP '***' send
 173443  info : Forced update successful - IP: '***' send
 173443       : Waiting 600 seconds (Check Interval)
```

After my patch
```
181129       : Update needed - L: '***' <> R: '127.0.0.10'
 181129       : #> /usr/bin/curl -RsS -o /var/run/ddns/***.dat --stderr /var/run/ddns/***.err --insecure --noproxy '*' 'https://freedns.afraid.org/dynamic/update.php?***PW***&address=***'
 181130       : DDNS Provider answered:
Updated 1 host(s) *** to *** in 0.005 seconds
 181131  info : Update successful - IP '***' send
 181131       : Waiting 600 seconds (Check Interval)
```

---

Moreover, curl is not ran with `-f` so the 404 went unnoticed, but i dont know where to make the change. If you can point me out I can add it and errors like these will be visible in the future.
## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
