### PR TITLE
netbird: update to 0.50.2

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.50.1
+PKG_VERSION:=0.50.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=b68305db151475ac58e3ff2144dd4ed955b99bcf462d8da118073f29b432be74
+PKG_HASH:=d3f0838dfa279ed8af9443294770308be8d2a9e070478dbba23ca42e20da403b
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

- `netbird` update to [0.50.2](https://github.com/netbirdio/netbird/releases/tag/v0.50.2)
    - Full changelog: https://github.com/netbirdio/netbird/compare/v0.50.1...v0.50.2
    - Breaking change:
      - N/A

Used a "dirty" installation of the `OpenWrt` image instead of starting with a clean state:
```shell
apk --update-cache upgrade
apk add --allow-untrusted <package_name>.apk
reboot
```

**Tests checklist:**
- [x] Connection to the NetBird Cloud Dashboard (not self-hosted).
- [x] Firewall configured with nftables.
- [x] Connection established in P2P mode.
- [x] `wireguard` kernel mode active.
- [x] Routes configured between my homelab and my cloud server.
- [x] `netbird` DNS server functioning correctly.
- [ ] NAT operational (not needed by me at this time, may consider testing in the future).
- [ ] Permissions rules is enforced (not needed by me at this time, may consider testing in the future).

**Additional information**

`x86_64` is running in a container using [`incus`](https://github.com/lxc/incus).
The package(s) was compiled with the container [`sdk`](https://github.com/openwrt/docker).
The `OpenWrt` image(s) was built using the container [`imagebuilder`](https://github.com/openwrt/docker) or [`distrobuilder`](https://github.com/lxc/distrobuilder).

You can view my repository with the patch applied and the automated build here:
- https://github.com/wehagy/owpib/tree/netbird/update
  <sub>This repository branch is temporary and will be removed or modified after the merge.</sub>

You can find my artifacts here:
- https://github.com/wehagy/owpib/actions/runs/16208447501

My CI have the unrelated error:
- https://github.com/wehagy/owpib/actions/runs/16208447501/job/45763772025#step:3:162

```
  > [stage-sdk 3/6] RUN <<"EOF" (#!/usr/bin/env bash  ...):
2.725 gpg:                using EDDSA key 92C561DE55AE6552F3C736B82B0151090606D1D9
2.732 gpg: Good signature from "OpenWrt Build System (Nitrokey3) <contact@openwrt.org>" [unknown]
2.738 gpg: WARNING: This key is not certified with a trusted signature!
2.738 gpg:          There is no indication that the signature belongs to the owner.
2.738 Primary key fingerprint: 8A8B C12F 46B8 36C0 F9CD  B36F 1D53 D187 7742 E911
2.738      Subkey fingerprint: 92C5 61DE 55AE 6552 F3C7  36B8 2B01 5109 0606 D1D9
82.56 2025-07-10 23:53:07 URL:https://downloads.openwrt.org/snapshots/targets/ath79/generic/openwrt-sdk-ath79-generic_gcc-14.3.0_musl.Linux-x86_64.tar.zst [215306016/215306016] -> "openwrt-sdk-ath79-generic_gcc-14.3.0_musl.Linux-x86_64.tar.zst" [5]
82.57 ef087d3192737bae167b9e7e35936cd9493971cdd35c624ed16ee222029bf2bf *openwrt-sdk-ath79-generic_gcc-14.3.0_musl.Linux-x86_64.tar.zst
83.39 openwrt-sdk-ath79-generic_gcc-14.3.0_musl.Linux-x86_64.tar.zst: FAILED
83.39 sha256sum: WARNING: 1 computed checksum did NOT match
```

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT r30289-e1d39bdbdb
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** B75 M.2 Intel LGA 1155 DDR3

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.





<!-- For my reference

| Package architecture | Target | Subtarget | Brand | Model | Hardware Version | OpenWrt version |
|----------------------|--------|-----------|-------|-------|------------------|-----------------|
| [x86_64](https://openwrt.org/docs/techref/instructionset/x86_64) | [x86](https://openwrt.org/docs/techref/targets/x86) | 64 | WOVIBO | B75 M.2 Intel LGA 1155 DDR3 | N/A | OpenWrt <change_me> |
| [x86_64](https://openwrt.org/docs/techref/instructionset/x86_64) | [x86](https://openwrt.org/docs/techref/targets/x86) | 64 | [Duex](https://duex.com.br/) | [DX B75ZG M.2 Intel LGA 1155 DDR3](https://duex.com.br/produto/placa-mae-dx-b75zg-m-2-intel-lga-1155-ddr3/) | N/A | OpenWrt <change_me> |
| [x86_64](https://openwrt.org/docs/techref/instructionset/x86_64) | [x86](https://openwrt.org/docs/techref/targets/x86) | 64 | QEMU (x86_64) | qemu-system-x86_64 | qemu-9.1.3-2.fc41 | OpenWrt <change_me> |

-->