### PR TITLE
gnutls: Update to version 3.8.10

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
-PKG_VERSION:=3.8.9
+PKG_VERSION:=3.8.10
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.8
-PKG_HASH:=69e113d802d1670c4d5ac1b99040b1f2d5c7c05daec5003813c049b5184820ed
+PKG_HASH:=db7fab7cce791e7727ebbef2334301c821d79a550ec55c9ef096b610b03eb6b7
 
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <nmav@gnutls.org>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/libs/gnutls/patches/010-m4.patch
+++ b/libs/gnutls/patches/010-m4.patch
@@ -62,7 +62,7 @@
      [AC_COMPILE_IFELSE(
 --- a/src/gl/m4/gnulib-comp.m4
 +++ b/src/gl/m4/gnulib-comp.m4
-@@ -1440,7 +1440,7 @@ changequote([, ])dnl
+@@ -1432,7 +1432,7 @@ changequote([, ])dnl
    AC_CHECK_DECLS_ONCE([alarm])
    gl_SNAN
    gl_NAN_MIPS


### PR DESCRIPTION
Single patches automatically refreshed.

Changelog: https://lists.gnupg.org/pipermail/gnutls-help/2025-July/004883.html

Build system: 
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc

## 📦 Package Details

**Maintainer:** @nmav 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** x86/64
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** x86/64-glibc

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
