### PR TITLE
kmod-amneziawg: add new package

### DIFF
--- a/net/kmod-amneziawg/Makefile
+++ b/net/kmod-amneziawg/Makefile
@@ -1,0 +1,49 @@
+include $(TOPDIR)/rules.mk
+
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=kmod-amneziawg
+PKG_VERSION:=1.0.20251104
+PKG_RELEASE:=1
+WIREGUARD_VERSION:=1.0.0
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/amnezia-vpn/amneziawg-linux-kernel-module.git
+PKG_MIRROR_HASH:=32eeca0c579e60f62ee8e23c163afea0f9cf79727817c4a698a806a5d10f2cb9
+PKG_SOURCE_VERSION:=866b0abe820d5a9c115fe3e4221132ecf8e39b94
+
+PKG_MAINTAINER:=Gregory Gullin <garuwex@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/amneziawg
+	SECTION:=kernel
+	CATEGORY:=Kernel modules
+	SUBMENU:=Network Support
+	URL:=https://amnezia.org/
+	TITLE:=AmneziaWG Kernel Module
+
+	DEPENDS:= \
+		+kmod-crypto-lib-chacha20poly1305 \
+		+kmod-crypto-lib-curve25519 \
+		+kmod-udptunnel4 \
+		+IPV6:kmod-udptunnel6
+	FILES:=$(PKG_BUILD_DIR)/$(MAKE_PATH)/amneziawg.ko
+	AUTOLOAD:=$(call AutoProbe,amneziawg)
+endef
+
+MAKE_PATH:=src
+
+define KernelPackage/amneziawg/description
+	This package provides the kernel module for AmneziaWG.
+endef
+
+define Build/Compile
+	$(KERNEL_MAKE) \
+		M="$(PKG_BUILD_DIR)/$(MAKE_PATH)" \
+		EXTRA_CFLAGS="$(BUILDFLAGS)" \
+		WIREGUARD_VERSION="$(WIREGUARD_VERSION)" \
+		modules
+endef
+
+$(eval $(call KernelPackage,amneziawg))


### PR DESCRIPTION
This adds support for the AmneziaWG Linux kernel module

https://github.com/amnezia-vpn/amneziawg-linux-kernel-module

## 📦 Package Details

**Maintainer:** @gargullia
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.1 r28597-0425664679 / SNAPSHOT
- **OpenWrt Target/Subtarget:** mediatek/filogic / x86/64
- **OpenWrt Device:** Xiaomi Mi Router AX3000T / QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
