### PR TITLE
Revert "afraid.org-v2-token.json: Fix 404 on update"

### DIFF
--- a/net/ddns-scripts/files/usr/share/ddns/default/afraid.org-v2-token.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/afraid.org-v2-token.json
@@ -1,9 +1,9 @@
 {
 	"name": "afraid.org-v2-token",
 	"ipv4": {
-		"url": "https://freedns.afraid.org/dynamic/update.php?[PASSWORD]&address=[IP]"
+		"url": "https://sync.afraid.org/u/[PASSWORD]/?address=[IP]"
 	},
 	"ipv6": {
-		"url": "https://freedns.afraid.org/dynamic/update.php?[PASSWORD]&address=[IP]"
+		"url": "https://v6.sync.afraid.org/u/[PASSWORD]/?address=[IP]"
 	}
 }


### PR DESCRIPTION
This reverts commit 366629b117b49dab040b98dcb6433e4dc9772a36. This commit mixed v1 with v2 afraid.org APIs. Reverts #26946 

Signed-off-by: Paulo Neves <paulo@myneves.com>