### PR TITLE
Stress ng: update to 0.19.02 and fix glibc fail to build

### DIFF
--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
 PKG_VERSION:=0.19.00
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ColinIanKing/stress-ng/tar.gz/refs/tags/V$(PKG_VERSION)?
@@ -29,7 +29,7 @@ define Package/stress-ng
   CATEGORY:=Utilities
   TITLE:=stress-ng is a stress test utility
   URL:=https://github.com/ColinIanKing/stress-ng
-  DEPENDS:=+zlib +libbsd +libaio +libsctp +libkmod +libatomic +libjpeg
+  DEPENDS:=+zlib +libbsd +libaio +libsctp +libkmod +libatomic +libjpeg +USE_GLIBC:libcrypt-compat
   PROVIDES:=stress
 endef
 

--- a/utils/stress-ng/Makefile
+++ b/utils/stress-ng/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stress-ng
-PKG_VERSION:=0.19.00
-PKG_RELEASE:=2
+PKG_VERSION:=0.19.02
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ColinIanKing/stress-ng/tar.gz/refs/tags/V$(PKG_VERSION)?
-PKG_HASH:=7d0be69dcdad655145026f499863de01d317e87ff87acd48c3343d451540d172
+PKG_HASH:=15a07030a14bbfd5991e9ba3fbfbc24ed3ae72a2c946b033c06b820bc16f41c4
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-only

--- a/utils/stress-ng/patches/002-disable-atomics-mips-and-ppc.patch
+++ b/utils/stress-ng/patches/002-disable-atomics-mips-and-ppc.patch
@@ -13,7 +13,7 @@
   *	get next row to be computed, will wrap around. Wrap arounds
 --- a/stress-misaligned.c
 +++ b/stress-misaligned.c
-@@ -49,6 +49,10 @@
+@@ -51,6 +51,10 @@
  #undef HAVE_ATOMIC
  #endif
  


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @commodo 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
update to 0.19.02 and fix glibc fail to build
---

## 🧪 Run Testing Details

- **OpenWrt Version:** x86/64
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** x86/64-glibc

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
