### PR TITLE
owut: refactor packaging

### DIFF
--- a/utils/owut/Makefile
+++ b/utils/owut/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=owut
 PKG_SOURCE_DATE:=2025-07-11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=0d00192dbe0d7fcc50a67ddab62a593dbfd91295
@@ -27,7 +27,8 @@ define Package/owut
   DEPENDS:=+attendedsysupgrade-common \
     +rpcd-mod-file \
     +ucode +ucode-mod-fs +ucode-mod-ubus \
-    +ucode-mod-uci +ucode-mod-uclient +ucode-mod-uloop
+    +ucode-mod-uci +ucode-mod-uclient +ucode-mod-uloop \
+    +ucode-mod-argparse
   PKGARCH:=all
 endef
 
@@ -58,14 +59,35 @@ define Package/owut/install
 	$(INSTALL_DIR) $(1)/etc/owut.d
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/pre-install.sh $(1)/etc/owut.d/pre-install.sh
 
-	$(INSTALL_DIR) $(1)/usr/share/ucode/utils
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/argparse.uc $(1)/usr/share/ucode/utils
-
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/owut $(1)/usr/bin
 
 	sed -i -e "s/%%VERSION%%/$(PKG_VERSION)-r$(PKG_RELEASE)/" $(1)/usr/bin/owut
+endef
+
+define Package/ucode-mod-argparse
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=ucode module providing argument parsing inspired by Python argparse
+  URL:=http://github.com/efahl/owut
+  DEPENDS:=+ucode +ucode-mod-fs +ucode-mod-uci
+  PKGARCH:=all
+endef
+
+define Package/ucode-mod-argparse/description
+  The argparse module provides argument parsing and validation for
+  various types of command line options and parameters.  It supports
+  subcommands, use of a standard uci config file for dynamic default
+  values, type and range checking, and provides an API for user
+  extension of the typing and validation methods.
+endef
+
+define Package/ucode-mod-argparse/install
+	$(INSTALL_DIR) $(1)/usr/share/ucode/utils
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/argparse.uc $(1)/usr/share/ucode/utils
+
 	sed -i -e "s/%%VERSION%%/$(PKG_VERSION)-r$(PKG_RELEASE)/" $(1)/usr/share/ucode/utils/argparse.uc
 endef
 
 $(eval $(call BuildPackage,owut))
+$(eval $(call BuildPackage,ucode-mod-argparse))


### PR DESCRIPTION
Maintainer: me
Tested-on: x86/64 snapshot

This is a preliminary refactoring of the package boundaries with no changes in functionality.  It simply breaks out the argparse component into its own ucode-mod-argparse so others can install and use it without installing owut.