### PR TITLE
libpam: prevent building unconditionally when not selected

### DIFF
--- a/libs/libpam/Makefile
+++ b/libs/libpam/Makefile
@@ -52,6 +52,8 @@ MESON_ARGS += \
 	-Ddb=db \
 	-Dxauth=disabled
 
+ifneq ($(CONFIG_PACKAGE_libpam),)
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(INSTALL_DIR) $(1)/usr/lib
@@ -72,5 +74,16 @@ define Package/libpam/install
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc $(1)/usr/lib/pkgconfig/
 endef
+else
+
+define Build/Compile
+	:
+endef
+
+define Build/Install
+	:
+endef
+
+endif
 
 $(eval $(call BuildPackage,libpam))


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @nmav, @BKPepe
**Description:** libpam is being built even when it's explicitly disabled in the configuration

---

```vim
$ grep libpam .config
# CONFIG_PACKAGE_libpam is not set
```

The OpenWrt build system evaluates all package Makefiles during the dependency resolution phase, even for packages that aren't selected.

When a package defines build targets (Build/InstallDev, Package/*/install) without proper conditional guards, the build system may still attempt to process them.

The trigger appears to be from Busybox's conditional PAM dependency:

```vim
PKG_BUILD_DEPENDS:=BUSYBOX_CONFIG_PAM:libpam
DEPENDS:= ... +BUSYBOX_CONFIG_PAM:libpam ...
```

Even though `BUSYBOX_CONFIG_PAM` is disabled, the build system processes the `libpam` Makefile during dependency evaluation, causing it to be built unconditionally.

Add conditional compilation guards that only define build targets when the package is actually selected

## 🧪 Run Testing Details

- **OpenWrt Version:** main
