### PR TITLE
libpam: fix mold linking error regarding assigning global to symbol

### DIFF
--- a/libs/libpam/patches/001-fix-global-symbol-err.patch
+++ b/libs/libpam/patches/001-fix-global-symbol-err.patch
@@ -1,0 +1,19 @@
+--- a/modules/meson.build
++++ b/modules/meson.build
+@@ -1,8 +1,14 @@
+ pam_module_map = 'modules.map'
+ pam_module_map_path = meson.current_source_dir() / pam_module_map
+ 
+-pam_module_link_deps = ['..' / pam_module_map]
+-pam_module_link_args = ['-Wl,--version-script=' + pam_module_map_path]
++if meson.get_compiler('c').get_linker_id() == 'ld.mold'
++  # mold is strict about version scripts, disable for now
++  pam_module_link_deps = []
++  pam_module_link_args = []
++else
++  pam_module_link_deps = ['..' / pam_module_map]
++  pam_module_link_args = ['-Wl,--version-script=' + pam_module_map_path]
++endif
+ 
+ subdir('pam_access')
+ subdir('pam_canonicalize_user')


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @nmav, @BKPepe
**Description:**

The following error occurs when building libpam-1.7.1 with mold as the linker:

```
FAILED: modules/pam_canonicalize_user/pam_canonicalize_user.so
mold: error: Linux-PAM-1.7.1/modules/modules.map: cannot assign version `global` to symbol `pam_sm_acct_mgmt`: symbol not found
mold: error: Linux-PAM-1.7.1/modules/modules.map: cannot assign version `global` to symbol `pam_sm_chauthtok`: symbol not found
mold: error: Linux-PAM-1.7.1/modules/modules.map: cannot assign version `global` to symbol `pam_sm_close_session`: symbol not found
mold: error: Linux-PAM-1.7.1/modules/modules.map: cannot assign version `global` to symbol `pam_sm_open_session`: symbol not found
```

Mold linker strictly requires all symbols listed in version scripts to be present in object files, while traditional linkers (like GNU ld) are more permissive.

PAM modules implement different subsets of the standard PAM functions, so many modules don't provide all the symbols listed in modules.map.

Proposed solution:

Add conditional logic to detect the mold linker and disable version scripts when mold is used.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
