### PR TITLE
prometheus-node-exporter-lua: Fix broken textfile collector

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2025.06.29
+PKG_VERSION:=2025.07.15
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/textfile.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/textfile.lua
@@ -4,7 +4,8 @@ local function scrape()
   local mtime_metric = metric("node_textfile_mtime_seconds", "gauge")
 
   for metrics in fs.glob("/var/prometheus/*.prom") do
-    output(get_contents(metrics), '\n')
+    out:write(get_contents(metrics))
+    out:write('\n')
     local stat = fs.stat(metrics)
     if stat then
       mtime_metric({ file = metrics }, stat.mtime)


### PR DESCRIPTION
A recent change (00d420e80) removed the `output` function, which textfile.lua was using to output metrics.  So use the underlying output handle instead.

## 📦 Package Details

**Maintainer:** @champtar 

**Description:** Fixes a small bug that breaks the `textfile.lua` collector
---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.0
- **OpenWrt Target/Subtarget:** ipq806x/generic
- **OpenWrt Device:** Netgear R7800

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.