### PR TITLE
libpam: fix build with mold linker

### DIFF
--- a/libs/libpam/Makefile
+++ b/libs/libpam/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpam
 PKG_VERSION:=1.7.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=Linux-PAM-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/linux-pam/linux-pam/releases/download/v$(PKG_VERSION)
@@ -22,6 +22,7 @@ PKG_LICENSE_FILES:=COPYING Copyright
 PKG_CPE_ID:=cpe:/a:linux-pam:linux-pam
 
 PKG_FIXUP:=autoreconf
+PKG_BUILD_FLAGS:=no-mold
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 


### PR DESCRIPTION
Apparently, building with mold linking is not supported.

Closes #26996


## 📦 Package Details

**Maintainer:** @nmav 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** x86/64
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** x86/64-glibc

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
