### PR TITLE
pyuci: update to version 0.10.3 + add two patches

### DIFF
--- a/lang/python/python-uci/Makefile
+++ b/lang/python/python-uci/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-uci
-PKG_VERSION:=0.9.0
+PKG_VERSION:=0.10.3
 PKG_RELEASE:=1
 
 PYPI_NAME:=pyuci
-PKG_HASH:=865a45d48fb5d363f1230e94fa2c5b01ae6487f02f2180b0a6f78193a70166e2
+PKG_HASH:=3b0f72ea81ed7a7999b2eb73f57a93019c0d359efaa9efb44fdf377fa09c1da6
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later

--- a/lang/python/python-uci/patches/0001-Revert-CI-setup.py-removed-and-testing-updates-in-CI.patch
+++ b/lang/python/python-uci/patches/0001-Revert-CI-setup.py-removed-and-testing-updates-in-CI.patch
@@ -1,0 +1,75 @@
+From 24dd211a0a99e95e79f5a6b2054e60dae878410d Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Tue, 15 Jul 2025 10:18:19 +0200
+Subject: [PATCH] Revert "CI: setup.py removed and testing updates in CI"
+
+This commit adds setup.py back to be compatible with OpenWrt.
+OpenWrt ships Python 3.11 and that version is using bundled
+setuptools and pip. These versions for py-uci are kinda outdated,
+because in the latest release Stepan is using ext-modules
+via pyproject.toml, which is experimental [1] and thus this
+is not present in Python 3.11.
+
+Newer Python versions such as 3.12 and 3.13 are not shipping
+bunled setuptools anymore. This needs to be reworked to
+be working with OpenWrt build system.
+
+How it is implemented right now, Python packages
+can be compiled with pyproject.toml with OpenWrt. See this PR [2],
+but as said earlier newest features from setuptools are missing.
+
+[1] https://setuptools.pypa.io/en/stable/history.html#v74-1-0
+[2] https://github.com/openwrt/packages/pull/20801
+
+This reverts commit 8a1e5c3218f16f46a25379dc2e9651fa74a7d349.
+---
+ setup.py | 43 +++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 43 insertions(+)
+ create mode 100644 setup.py
+
+--- /dev/null
++++ b/setup.py
+@@ -0,0 +1,43 @@
++import os
++from setuptools import setup
++from setuptools.extension import Extension
++
++ext_compile_args = None
++ext_link_args = None
++
++if 'COVERAGE' in os.environ:
++    ext_compile_args = ["-fprofile-arcs", "-ftest-coverage"]
++    ext_link_args = ["-fprofile-arcs"]
++
++
++with open("README.md", "r") as fh:
++    long_description = fh.read()
++
++
++setup(
++    name='pyuci',
++    version='0.10.3',
++    author='CZ.NIC z.s.p.o',
++    author_email='karel.koci@nic.cz',
++    description='Python UCI bindings',
++    long_description=long_description,
++    long_description_content_type="text/markdown",
++    url="https://gitlab.nic.cz/turris/pyuci",
++    license="MIT",
++
++    packages=['euci'],
++    ext_modules=[
++        Extension("uci", ["ucimodule.c", "pyuci.c", "pyhelper.c"],
++                  libraries=["uci"], language="c",
++                  extra_compile_args=ext_compile_args,
++                  extra_link_args=ext_link_args)
++    ],
++
++    classifiers=[
++        "Development Status :: 5 - Production/Stable",
++        "License :: OSI Approved :: MIT License",
++        "Operating System :: POSIX :: Linux",
++        "Programming Language :: Python :: 3",
++    ],
++    python_requires='>=3.7',
++)

--- a/lang/python/python-uci/patches/0001-pyproject.toml-remove-it-in-favor-of-setup.py.patch
+++ b/lang/python/python-uci/patches/0001-pyproject.toml-remove-it-in-favor-of-setup.py.patch
@@ -1,0 +1,63 @@
+From a480a4223639766f4f0625434a28204b014fd882 Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Tue, 15 Jul 2025 10:31:08 +0200
+Subject: [PATCH] pyproject.toml: remove it in favor of setup.py
+
+This patch is I would say kinda hacky. OpenWrt
+can compile Python packages with pyproject.toml,
+but this pyproject.toml requires the latest
+setuptools, which is shipped separately these days.
+
+But Python 3.11, which is used in OpenWrt
+is using bundled setuptools together with pip
+and the version of setuptools does not support
+ext-modules [1].
+
+[1] https://github.com/pypa/setuptools/pull/4568
+
+Signed-off-by: Josef Schlehofer <pepe.schlehofer@gmail.com>
+---
+ pyproject.toml | 37 -------------------------------------
+ 1 file changed, 37 deletions(-)
+ delete mode 100644 pyproject.toml
+
+--- a/pyproject.toml
++++ /dev/null
+@@ -1,37 +0,0 @@
+-[build-system]
+-requires = ["setuptools", "wheel"]
+-build-backend = "setuptools.build_meta"
+-
+-[project]
+-name = "pyuci"
+-dynamic = []
+-description = "Python UCI bindings"
+-readme = "README.md"
+-license = {file = "LICENSE"}
+-version = "0.10.3"
+-requires-python = ">=3.7"
+-authors = [
+-    { name = "CZ.NIC z.s.p.o", email = "karel.koci@nic.cz" },
+-]
+-classifiers = [
+-    "Development Status :: 5 - Production/Stable",
+-    "License :: OSI Approved :: MIT License",
+-    "Operating System :: POSIX :: Linux",
+-    "Programming Language :: Python :: 3",
+-]
+-
+-[project.urls]
+-Homepage = "https://gitlab.nic.cz/turris/pyuci"
+-
+-[tool.setuptools]
+-packages = ["euci"]
+-
+-[[tool.setuptools.ext-modules]]
+-name = "uci"
+-sources = ["ucimodule.c", "pyuci.c", "pyhelper.c"]
+-language = "c"
+-libraries = ["uci"]
+-
+-# Uncomment to enable coverage measurement
+-#extra-compile-args = ["-fprofile-arcs", "-ftest-coverage"]
+-#extra-link-args = ["-fprofile-arcs"]


### PR DESCRIPTION
# Package details:
Maintainer: me

# Release notes:
https://gitlab.nic.cz/turris/pyuci/-/tags/v0.10.0
https://gitlab.nic.cz/turris/pyuci/-/tags/v0.10.1
https://gitlab.nic.cz/turris/pyuci/-/tags/v0.10.2
https://gitlab.nic.cz/turris/pyuci/-/tags/v0.10.3

# Upstream (pyuci developers) removed setup.py,
I bring it back to be able to compile it despite
that we do support building packages, which are
using pyproject.toml, but the thing here is
that their pyproject.toml requires setuptools 74.1.0 [1] [2], but Python 3.11 is using bundled setuptools and pip [3] [4]. In current version 3.11.13,
there is still outdated version of setuptools, but it looks like that in the newer version, there will be new one [5].

Once, there is released Python 3.11.14 and updated in OpenWrt, these patches can be dropped.

[1] https://gitlab.nic.cz/turris/pyuci/-/blob/240180b2946fdd1fd46c7f023f224acce5a55511/pyproject.toml#L29
[2] https://setuptools.pypa.io/en/stable/history.html#v74-1-0
[3] https://github.com/openwrt/packages/blob/c94ab433caf345ebc6bef9a7174d1f65f676fc87/lang/python/python3-version.mk#L18
[4] https://github.com/python/cpython/commits/3.11/Lib/ensurepip/_bundled
[5] https://github.com/python/cpython/commit/c96ab19ae460911e40ffa502f1bf945ab6c53a2e

Compile tested for Turris Omnia, OpenWrt 23.05
Fixes: https://github.com/openwrt/packages/issues/25079