### PR TITLE
[23.05] python-click: add hostbuild

### DIFF
--- a/lang/python/python-click/Makefile
+++ b/lang/python/python-click/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-click
 PKG_VERSION:=8.1.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=click
 PKG_HASH:=ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de
@@ -15,9 +15,13 @@ PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
 
+HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-wheel/host
+
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ../python3-package.mk
+include ../python3-host-build.mk
 
 define Package/python3-click
   SECTION:=lang
@@ -38,3 +42,4 @@ endef
 $(eval $(call Py3Package,python3-click))
 $(eval $(call BuildPackage,python3-click))
 $(eval $(call BuildPackage,python3-click-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jefferyto 

**Description:**
Add hostbuild directives for `python-click` in OpenWRT 23.05.

This package is a host-requirement for [PlatformIO](https://github.com/openwrt/packages/tree/master/lang/python/python-platformio) and projects which depend on PlatformIO, including [Meshtastic OpenWRT Packaging](https://github.com/meshtastic/openwrt).

(cherry picked from commit 117a3a2b1b58917acfedde7df0f7abd3b0b3b17d)

Related `master` PR: https://github.com/openwrt/packages/pull/25492
Related `24.10` PR: https://github.com/openwrt/packages/pull/26744

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 23.05
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2710
- **OpenWrt Device:** Raspberry Pi CM3

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.