### PR TITLE
rngd-tools: run as unprivileged user

### DIFF
--- a/utils/rng-tools/Makefile
+++ b/utils/rng-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rng-tools
 PKG_VERSION:=6.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/nhorman/rng-tools/tar.gz/v$(PKG_VERSION)?
@@ -32,6 +32,7 @@ define Package/rng-tools
   CATEGORY:=Utilities
   TITLE:=Daemon for adding entropy to kernel entropy pool
   URL:=https://github.com/nhorman/rng-tools
+  USERID:=rngd=209:rngd=209
   DEPENDS:=+libopenssl +libcap +libcurl +jansson
 endef
 

--- a/utils/rng-tools/files/rngd.init
+++ b/utils/rng-tools/files/rngd.init
@@ -20,7 +20,7 @@ start_service() {
 	[ -z "$watermark" ] || watermark="-W ${watermark}"
 
 	procd_open_instance
-	procd_set_param command "$PROG" -f ${device} ${watermark}
+	procd_set_param command "$PROG" -D rngd:rngd -f ${device} ${watermark}
 	procd_set_param stderr 1
 	procd_close_instance
 }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  @hnyman @nwf @pprindeville ???
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**

For better security and isolation, used the -D option to run as newly created unprivileged user.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** generic PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
