### PR TITLE
php8: update to 8.4.10

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.4.8
+PKG_VERSION:=8.4.10
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.php.net/distributions/
-PKG_HASH:=aa6a4d330b47eacd83e351658ba8c47747a1e4356456219cfb6d75e7838da091
+PKG_HASH:=14983a9ef8800e6bc2d920739fd386054402f7976ca9cd7f711509496f0d2632
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** me

**Description:**
Upstream changelog:
https://www.php.net/ChangeLog-8.php#8.4.10

## 🧪 Run Testing Details

- **OpenWrt Version:** https://github.com/openwrt/openwrt/commit/efb4200ba569d6ff79ec58a3c44cd8769ba40fdc  
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2708
- **OpenWrt Device:** Raspberry Pi 2

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
