### PR TITLE
bind: bump to 9.20.10

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.20.9
+PKG_VERSION:=9.20.10
 PKG_RELEASE:=3
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=3d26900ed9c9a859073ffea9b97e292c1248dad18279b17b05fcb23c3091f86d
+PKG_HASH:=0fb3ba2c337bb488ca68f5df296c435cd255058fb63d0822e91db0235c905716
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.20.10
-PKG_RELEASE:=3
+PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>


### PR DESCRIPTION
**New Features**
- Implemented new `notify-defer` option to defer sending NOTIFY messages for zones.  
  (GL #5259, MR !10465)

**Removed**
- Removed dependency on `libsystemd`, replaced with a manual implementation of `sd_notify`.  
  Reduces attack surface and avoids heavy library dependency.  
  (MR !10454, see also: https://www.openwall.com/lists/oss-security/2024/03/29/4)

**Bug Fixes**
- Fixed issue where deleted secondary zones could still be transferred.  
  (GL #5291, MR !10496)
- Fixed zone refresh failure when reconfiguring during SOA query.  
  (GL #5307, MR !10495)
- Fixed Solaris build: `keystore.c` now includes `isc/dir.h` to define `NAME_MAX`.  
  (GL #5327, MR !10523)
- Set name for all `isc_mem` contexts.  
  (MR !10498)

Tested on:  
Device: Redmi AX6  
Firmware: OpenWrt 24.10