### PR TITLE
strongswan: fix build issues around PARSE_ERROR

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=6.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/patches/0100-work-around-parse_error-clash.patch
+++ b/net/strongswan/patches/0100-work-around-parse_error-clash.patch
@@ -1,0 +1,11 @@
+--- a/src/libstrongswan/plugins/wolfssl/wolfssl_plugin.c
++++ b/src/libstrongswan/plugins/wolfssl/wolfssl_plugin.c
+@@ -27,6 +27,8 @@
+ #include <library.h>
+ #include <utils/debug.h>
+ 
++#define PARSE_ERROR	WOLFSSL_PARSE_ERROR
++
+ #include "wolfssl_plugin.h"
+ #include "wolfssl_aead.h"
+ #include "wolfssl_crypter.h"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me, @Thermi 

**Description:**
This symbol is an enum defined both in wolfssl and strongswan.  This creates a clash in C's flat namespace.  A workaround is to redefine it when we include wolfssl headers, but really one of the other should pick a better name.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
HEAD
- **OpenWrt Target/Subtarget:**
mediatek/filogic
- **OpenWrt Device:**
Banana Pi-R4
---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
- [X] It is structured in a way that it is potentially upstreamable
