### PR TITLE
snort3: remove gperftools dep for mips* and powerpc

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.9.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
@@ -27,8 +27,9 @@ define Package/snort3
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:= \
+	    +@!(TARGET_powerpc||TARGET_mips||TARGET_mips64||TARGET_mipsel):gperftools-runtime \
 	    +(TARGET_x86||TARGET_x86_64):hyperscan-runtime \
-	    +gperftools-runtime +libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre2 \
+	    +libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre2 \
 	    +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic \
 	    +kmod-nft-queue +liblzma +ucode +ucode-mod-fs +ucode-mod-uci
   TITLE:=Lightweight Network Intrusion Detection System


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Add conditional to disable gperftools-runtime depends for powerpc and mips due to inability
to compile introduced with 7345b73c3094e2aa2e085954a584ab15a9e3b939
    
## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
