### PR TITLE
snort3: fix logic in gpertools-runtime depends

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.9.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
@@ -22,16 +22,23 @@ PKG_CPE_ID:=cpe:/a:snort:snort
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
+ifeq ($(filter $(ARCH),mips mips64 mipsel powerpc),)
+  EXTRA_DEPENDS += +gperftools-runtime
+endif
+ifeq ($(filter $(ARCH),x86_64),$(ARCH))
+  EXTRA_DEPENDS += +hyperscan-runtime
+  CMAKE_OPTIONS += -DHS_INCLUDE_DIRS=$(STAGING_DIR)/usr/include/hs
+endif
+
+SNORT3DEPS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre2 \
+    +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic \
+    +kmod-nft-queue +liblzma +ucode +ucode-mod-fs +ucode-mod-uci $(EXTRA_DEPENDS)
+
 define Package/snort3
   SUBMENU:=Firewall
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:= \
-	    +@!(TARGET_powerpc||TARGET_mips||TARGET_mips64||TARGET_mipsel):gperftools-runtime \
-	    +(TARGET_x86||TARGET_x86_64):hyperscan-runtime \
-	    +libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre2 \
-	    +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic \
-	    +kmod-nft-queue +liblzma +ucode +ucode-mod-fs +ucode-mod-uci
+  DEPENDS:=$(SNORT3DEPS)
   TITLE:=Lightweight Network Intrusion Detection System
   URL:=http://www.snort.org/
   MENU:=1
@@ -44,11 +51,6 @@ define Package/snort3/description
   analysis and pattern matching in order to detect anomalies, misuse and
   attacks.
 endef
-
-# Hyperscan only builds for x86
-ifdef CONFIG_TARGET_x86_64
-	CMAKE_OPTIONS += -DHS_INCLUDE_DIRS=$(STAGING_DIR)/usr/include/hs
-endif
 
 CMAKE_OPTIONS += \
 	-DUSE_TIRPC:BOOL=YES \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me and cc @BKPepe 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

The logic in e57cc9898a362d81e8dec5dd779293e6ff3d4710 was flawed causing gperftools-runtime to fail to get detected when building resulting in: ...
ninja: Entering directory `/scratch/union/build_dir/target-x86_64_glibc/snort3-3.9.1.0' ninja: error: '/scratch/union/staging_dir/target-x86_64_glibc/usr/lib/libtcmalloc.so', needed by 'src/snort', missing and no known rule to make it make[2]: *** [Makefile:161: /scratch/union/build_dir/target-x86_64_glibc/snort3-3.9.1.0/.built] Error 1

It was missed due testing in build root that already had gperftools-runtime built only discovered when building from a clean build root.

Test:
```
cat <<EOF > .config
CONFIG_TARGET_x86=y
CONFIG_TARGET_x86_64=y
CONFIG_TARGET_x86_64_DEVICE_generic=y
CONFIG_PACKAGE_snort3=y
EOF

make defconfig
grep gperftools-run .config
CONFIG_PACKAGE_gperftools-runtime=y

cat <<EOF > .config
CONFIG_TARGET_qoriq=y
CONFIG_TARGET_qoriq_generic=y
CONFIG_TARGET_qoriq_generic_DEVICE_watchguard_firebox-m300=y CONFIG_PACKAGE_snort3=y
EOF

make defconfig
grep gperftools-run .config
# CONFIG_PACKAGE_gperftools-runtime is not set
```

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** generic

Beyond this change, this PR also adds a semi-privileged user to run snort and also adds ethtool (missed before) as a depends.
---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
