### PR TITLE
prometheus-node-exporter-lua: Avoid error when type(s["mac"]) is not string

### DIFF
--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/uci_dhcp_host.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/uci_dhcp_host.lua
@@ -6,7 +6,7 @@ local function scrape()
 
   curs:foreach("dhcp", "host", function(s)
     if s[".type"] == "host" then
-      labels = {name=s["name"], mac=string.upper(s["mac"]), dns=s["dns"], ip=s["ip"]}
+      labels = {name=s["name"], mac=s["mac"] and string.upper(s["mac"]), dns=s["dns"], ip=s["ip"]}
       metric_uci_host(labels, 1)
     end
   end)

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/uci_dhcp_host.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/uci_dhcp_host.lua
@@ -6,7 +6,11 @@ local function scrape()
 
   curs:foreach("dhcp", "host", function(s)
     if s[".type"] == "host" then
-      labels = {name=s["name"], mac=s["mac"] and string.upper(s["mac"]), dns=s["dns"], ip=s["ip"]}
+      if s["mac"] and type(s["mac"]) == "string" then
+        labels = {name=s["name"], mac=string.upper(s["mac"]), dns=s["dns"], ip=s["ip"]}
+      else
+        labels = {name=s["name"], dns=s["dns"], ip=s["ip"]}
+      end
       metric_uci_host(labels, 1)
     end
   end)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jan-kardell 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Fixes error reported in syslog when `s["mac"]` is `nil`.

```
/usr/lib/lua/prometheus-collectors/uci_dhcp_host.lua:9: bad argument #1 to 'upper' (string expected, got nil)
```
---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.2
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2711
- **OpenWrt Device:** Raspberry Pi 4B

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
