### PR TITLE
bind: bump to 9.20.11

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.20.10
+PKG_VERSION:=9.20.11
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=0fb3ba2c337bb488ca68f5df296c435cd255058fb63d0822e91db0235c905716
+PKG_HASH:=4da2d532e668bc21e883f6e6d9d3d81794d9ec60b181530385649a56f46ee17a
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Fix a possible assertion failure when stale-answer-client-timeout is set to 0. (CVE-2025-40777)

## 📦 Package Details

**Maintainer:** @nmeyerhans 

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 24.10
- **OpenWrt Target/Subtarget:** qualcommax/ipq807x
- **OpenWrt Device:** Redmi AX6
- **Tested:** recursive queries, authoritative responses, DNSSEC validation, and dynamic updates via nsupdate