### PR TITLE
perl-html-parser: add perl/host to HOST_BUILD_DEPENDS

### DIFF
--- a/lang/perl/perl-html-parser/Makefile
+++ b/lang/perl/perl-html-parser/Makefile
@@ -12,6 +12,8 @@ PKG_MAINTAINER:=Jens Wagner <jens@wagner2013.de>
 PKG_LICENSE:=GPL-1.0-or-later Artistic-1.0-Perl
 PKG_LICENSE_FILES:=LICENSE
 
+HOST_BUILD_DEPENDS:=perl/host
+
 include ../metacpan.mk
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk


### PR DESCRIPTION
Added `perl/host` to the `HOST_BUILD_DEPENDS` variable to ensure Perl is available during the host build process. This is required for scripts or tools that rely on Perl on the host system.

Fixes: ebfb47aa7448d46f950164e9d5835da5151182b1 ("perl-html-parser: restructure and update to 3.83")

Reported by @dangowrt in https://github.com/openwrt/packages/commit/ebfb47aa7448d46f950164e9d5835da5151182b1#commitcomment-162422317