### PR TITLE
qemu: disable dbus-display to fix build with new glibc

### DIFF
--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qemu
 PKG_VERSION:=10.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_HASH:=ef786f2398cb5184600f69aef4d5d691efd44576a3cff4126d38d4c6fec87759
 PKG_SOURCE_URL:=https://download.qemu.org/
@@ -355,6 +355,7 @@ CONFIGURE_ARGS +=			\
 	--$(if $(CONFIG_QEMU_UI_VNC),enable,disable)-vnc			\
 	--$(if $(CONFIG_QEMU_UI_VNC_JPEG),enable,disable)-vnc-jpeg		\
 	--$(if $(CONFIG_QEMU_UI_VNC_SASL),enable,disable)-vnc-sasl		\
+	--disable-dbus-display		\
 	--disable-vte			\
 	--enable-curses			\
 	--enable-iconv			\


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @yousong 

**Description:**

Fix errors like `#if GLIB_VERSION_MAX_ALLOWED >= GLIB_VERSION_2_84` from `ui/dbus-display1.c` on OpenWRT master.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** x86_64 / glibc
- **OpenWrt Device:** generic x86 based router

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

There is no updates of paches.