### PR TITLE
rsync: run as regular user rather than as root

### DIFF
--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsync
 PKG_VERSION:=3.4.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.samba.org/pub/$(PKG_NAME)/src
@@ -67,6 +67,7 @@ define Package/rsyncd
   SUBMENU:=File Transfer
   TITLE:=Rsync daemon
   DEPENDS:=+rsync
+  USERID:=rsyncd=976:rsyncd=976
   URL:=https://rsync.samba.org/
 endef
 
@@ -108,6 +109,8 @@ define Package/rsyncd/install
 	$(INSTALL_DATA) ./files/rsyncd.conf $(1)/etc/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/rsyncd.init $(1)/etc/init.d/rsyncd
+	$(INSTALL_DIR) $(1)/etc/capabilities
+	$(INSTALL_DATA) ./files/rsyncd.json $(1)/etc/capabilities
 endef
 
 define Package/rrsync/description

--- a/net/rsync/files/rsyncd.init
+++ b/net/rsync/files/rsyncd.init
@@ -10,5 +10,12 @@ PROG=/usr/bin/rsync
 start_service() {
 	procd_open_instance
 	procd_set_param command "$PROG" --daemon --no-detach
+	[ -x /sbin/ujail -a -e /etc/capabilities/rsyncd.json ] && {
+		procd_add_jail rsyncd
+		procd_set_param capabilities /etc/capabilities/rsyncd.json
+		procd_set_param user rsyncd
+		procd_set_param group rsyncd
+		procd_set_param no_new_privs 1
+	}
 	procd_close_instance
 }

--- a/net/rsync/files/rsyncd.json
+++ b/net/rsync/files/rsyncd.json
@@ -1,0 +1,37 @@
+{
+	"bounding": [
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SYS_CHROOT",
+		"CAP_SETUID",
+		"CAP_SETGID",
+		"CAP_DAC_OVERRIDE"
+	],
+	"effective": [
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SYS_CHROOT",
+		"CAP_SETUID",
+		"CAP_SETGID",
+		"CAP_DAC_OVERRIDE"
+	],
+	"ambient": [
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SYS_CHROOT",
+		"CAP_SETUID",
+		"CAP_SETGID",
+		"CAP_DAC_OVERRIDE"
+	],
+	"permitted": [
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SYS_CHROOT",
+		"CAP_SETUID",
+		"CAP_SETGID",
+		"CAP_DAC_OVERRIDE"
+	],
+	"inheritable": [
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SYS_CHROOT",
+		"CAP_SETUID",
+		"CAP_SETGID",
+		"CAP_DAC_OVERRIDE"
+	]
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @mstorchak 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Rsyncd only needs a subset of all capabilities so create a dedicated user with these capabilities. This is better from both a security and an isolation perspective than running as root.

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** generic PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
