### PR TITLE
libmicrohttpd: update to 1.0.2

### DIFF
--- a/libs/libmicrohttpd/Makefile
+++ b/libs/libmicrohttpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmicrohttpd
-PKG_VERSION:=1.0.1
+PKG_VERSION:=1.0.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/libmicrohttpd
-PKG_HASH:=a89e09fc9b4de34dde19f4fcb4faaa1ce10299b9908db1132bbfa1de47882b94
+PKG_HASH:=df324fcd0834175dab07483133902d9774a605bfa298025f69883288fd20a8c7
 
 PKG_MAINTAINER:=Alexander Couzens <lynxis@fe80.eu>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lynxis

**Description:** libmicrohttpd: update to 1.0.2

---

## 🧪 Run Testing Details

- **OpenWrt Version:** main / c1c11120069b8e04ad4b0c6e815d2e3421944933
- **OpenWrt Target/Subtarget:** ramips/mt7621
- **OpenWrt Device:** TP-Link Archer C6 v3
