### PR TITLE
rtty: update to 9.0.1

### DIFF
--- a/utils/rtty/Makefile
+++ b/utils/rtty/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtty
-PKG_VERSION:=9.0.0
-PKG_RELEASE:=2
+PKG_VERSION:=9.0.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://github.com/zhaojh329/rtty/releases/download/v$(PKG_VERSION)
-PKG_HASH:=5137cbe2f58588851376f2e74ded7f570320bd7cfc437d47d2485fb4be5042a1
+PKG_HASH:=d061e94236b711c95d4ad953a26bea9a212d8ee11273a6148f58e1f7aea585ec
 
 PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @me

**Description:**

changelog: https://github.com/zhaojh329/rtty/releases/tag/v9.0.1

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** GL-MT3000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
