### PR TITLE
libcoap: fix missing *-notls binaries

### DIFF
--- a/libs/libcoap/Makefile
+++ b/libs/libcoap/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libcoap
 PKG_VERSION:=4.3.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/obgm/libcoap/tar.gz/v$(PKG_VERSION)?
@@ -86,12 +86,15 @@ endef
 define Package/coap-client/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/coap-client $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/coap-client-notls $(1)/usr/bin/
 endef
 
 define Package/coap-server/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/coap-server $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/coap-server-notls $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/coap-rd $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/coap-rd-notls $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,libcoap))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @toxxin 

**Description:**
Fixes #26132.
This commit includes the coap-client-notls, coap-server-notls, and coap-rd-notls binaries in the package.
These notls binaries are necessary because coap-client, coap-server, and coap-rd are symbolic links to their notls versions. 


<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 23.05
- **OpenWrt Target/Subtarget:** mt76x8
- **OpenWrt Device:** Hi-Link HLK-7688A

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
