### PR TITLE
dbus: run as regular user rather than as root

### DIFF
--- a/utils/dbus/Makefile
+++ b/utils/dbus/Makefile
@@ -33,6 +33,7 @@ define Package/dbus/Default
   CATEGORY:=Utilities
   TITLE:=Simple interprocess messaging system
   URL:=https://dbus.freedesktop.org/
+  USERID:=dbus=91:dbus=91
 endef
 
 define Package/dbus/Default/description
@@ -146,6 +147,8 @@ define Package/dbus/install
 	$(INSTALL_BIN) ./files/dbus.init $(1)/etc/init.d/dbus
 	$(INSTALL_DIR) $(1)/usr/share/dbus-1
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/dbus-1 $(1)/usr/share/
+	$(INSTALL_DIR) $(1)/etc/capabilities
+	$(INSTALL_DATA) ./files/dbus.json $(1)/etc/capabilities
 endef
 
 define Package/dbus-utils/install

--- a/utils/dbus/files/dbus.init
+++ b/utils/dbus/files/dbus.init
@@ -14,6 +14,7 @@ PROG=/usr/bin/dbus-daemon
 start_service() {
 	mkdir -m 0755 -p /var/lib/dbus
 	mkdir -m 0755 -p /var/run/dbus
+	chown dbus:dbus /var/lib/dbus /var/run/dbus
 
 	[ -x /usr/bin/dbus-uuidgen ] && /usr/bin/dbus-uuidgen --ensure
 
@@ -24,6 +25,12 @@ start_service() {
 	[ -n "$DEBUG" ] && procd_set_param env DBUS_VERBOSE=1
 	procd_set_param stdout 1
 	procd_set_param stderr 1
+	[ -x /sbin/ujail -a -e /etc/capabilities/dbus.json ] && {
+		procd_add_jail dbus
+		procd_set_param user dbus
+		procd_set_param group dbus
+		procd_set_param capabilities /etc/capabilities/dbus.json
+	}
 	procd_close_instance
 }
 

--- a/utils/dbus/files/dbus.json
+++ b/utils/dbus/files/dbus.json
@@ -1,0 +1,27 @@
+{
+	"bounding": [
+		"CAP_SETPCAP",
+		"CAP_SETUID",
+		"CAP_SETGID"
+	],
+	"effective": [
+		"CAP_SETPCAP",
+		"CAP_SETUID",
+		"CAP_SETGID"
+	],
+	"ambient": [
+		"CAP_SETPCAP",
+		"CAP_SETUID",
+		"CAP_SETGID"
+	],
+	"permitted": [
+		"CAP_SETPCAP",
+		"CAP_SETUID",
+		"CAP_SETGID"
+	],
+	"inheritable": [
+		"CAP_SETPCAP",
+		"CAP_SETUID",
+		"CAP_SETGID"
+	]
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @robimarko 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Running as a dedicated dbus users is better from both a security and an isolation perspective than running as root.

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
