### PR TITLE
eza: update to 0.23.0

### DIFF
--- a/utils/eza/Makefile
+++ b/utils/eza/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=eza
-PKG_VERSION:=0.21.6
+PKG_VERSION:=0.23.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eza-community/eza/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8433260eff7be158cfdfafc7dffd620d878c1470b937a88f8a20117591990c67
+PKG_HASH:=119973d58aef7490f6c553f818cfde142998f5e93205f53f94981a9631b50310
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=EUPL-1.2


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
update to latest release

release notes:
0.22.0: https://github.com/eza-community/eza/releases/tag/v0.22.0
0.22.1: https://github.com/eza-community/eza/releases/tag/v0.22.1
0.23.0: https://github.com/eza-community/eza/releases/tag/v0.23.0

---

## 🧪 Run Testing Details

- **OpenWrt Version:** latest snapshot
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** BananaPi R4

---
