### PR TITLE
dbus: update to 1.16.2

### DIFF
--- a/utils/dbus/Makefile
+++ b/utils/dbus/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dbus
-PKG_VERSION:=1.14.10
+PKG_VERSION:=1.16.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://dbus.freedesktop.org/releases/dbus
-PKG_HASH:=ba1f21d2bd9d339da2d4aa8780c09df32fea87998b73da24f49ab9df1e36a50f
+PKG_HASH:=0ba2a1a4b16afe7bceb2c07e9ce99a8c2c3508e5dec290dbb643384bd6beb7e2
 
 PKG_MAINTAINER:=Robert Marko <robimarko@gmail.com>
 PKG_LICENSE:=AFL-2.1
@@ -26,6 +26,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_DBUS_VERBOSE
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/meson.mk
 
 define Package/dbus/Default
   SECTION:=utils
@@ -80,37 +81,35 @@ define Package/dbus/config
   source "$(SOURCE)/Config.in"
 endef
 
-CONFIGURE_ARGS += \
-	--disable-maintainer-mode \
-	--disable-developer \
-	--enable-debug=no \
-	--enable-shared \
-	--disable-static \
-	--disable-verbose-mode \
-	--disable-asserts \
-	--disable-xml-docs \
-	--disable-doxygen-docs \
-	--disable-ducktype-docs \
-	--disable-selinux \
-	--disable-apparmor \
-	--disable-libaudit \
-	--enable-inotify \
-	--disable-kqueue \
-	--disable-console-owner-file \
-	--disable-systemd \
-	--disable-tests \
-	--disable-code-coverage \
-	--disable-x11-autolaunch \
-	--with-session-socket-dir=/tmp \
-	--with-system-socket=/var/run/dbus/system_bus_socket \
-	--with-system-pid-file=/var/run/dbus.pid \
-	--with-dbus-user=root \
-	--without-x \
-	--enable-qt-help=no \
-	--disable-xml-docs
+MESON_ARGS += \
+	-Ddbus_user=root \
+	-Dsession_socket_dir=/tmp \
+	-Dsystem_socket=/var/run/dbus/system_bus_socket \
+	-Dsystem_pid_file=/var/run/dbus.pid \
+	-Dasserts=false \
+	-Dchecks=false \
+	-Ddoxygen_docs=disabled \
+	-Dxml_docs=disabled \
+	-Dducktype_docs=disabled \
+	-Dselinux=disabled \
+	-Dapparmor=disabled \
+	-Dlibaudit=disabled \
+	-Dinotify=enabled \
+	-Dkqueue=disabled \
+	-Dsystemd=disabled \
+	-Dmodular_tests=disabled \
+	-Dintrusive_tests=false \
+	-Dinstalled_tests=false \
+	-Dx11_autolaunch=disabled \
+	-Dtools=true \
+	-Duser_session=false \
+	-Dmessage_bus=true \
+	-Dstats=false
 
 ifeq ($(CONFIG_DBUS_VERBOSE),y)
-  CONFIGURE_ARGS += --enable-verbose-mode
+  MESON_ARGS += -Dverbose_mode=true
+else
+  MESON_ARGS += -Dverbose_mode=false
 endif
 
 define Build/InstallDev
@@ -142,7 +141,7 @@ define Package/dbus/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/dbus-uuidgen $(1)/usr/bin/
 	$(INSTALL_BIN) ./files/dbus-launch $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/dbus-daemon-launch-helper $(1)/usr/lib/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/libexec/dbus-daemon-launch-helper $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/dbus.init $(1)/etc/init.d/dbus
 	$(INSTALL_DIR) $(1)/usr/share/dbus-1


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @robimarko 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**

Update the 1.16.2 and adapt Makefile to meson build system.

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64glibc
- **OpenWrt Device:** generic PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
