### PR TITLE
gst1-plugins-bad: fix duplicate codecparsers library package

### DIFF
--- a/multimedia/gst1-plugins-bad/Makefile
+++ b/multimedia/gst1-plugins-bad/Makefile
@@ -329,15 +329,14 @@ define GstBuildLibrary
 endef
 
 $(eval $(call GstBuildLibrary,adaptivedemux,adaptivedemux,app uridownloader,))
-$(eval $(call GstBuildLibrary,codecs,codecs,codecparsers,))
+$(eval $(call GstBuildLibrary,basecamerabinsrc,basecamerabinsrc,app,))
 $(eval $(call GstBuildLibrary,codecparsers,codecparsers,,))
+$(eval $(call GstBuildLibrary,codecs,codecs,codecparsers,))
+$(eval $(call GstBuildLibrary,mpegts,mpegts,,))
 $(eval $(call GstBuildLibrary,photography,photography,,))
 $(eval $(call GstBuildLibrary,play,play,,))
 $(eval $(call GstBuildLibrary,player,player,play,))
-$(eval $(call GstBuildLibrary,basecamerabinsrc,basecamerabinsrc,app,))
 $(eval $(call GstBuildLibrary,uridownloader,uridownloader,,))
-$(eval $(call GstBuildLibrary,codecparsers,codecparsers,,))
-$(eval $(call GstBuildLibrary,mpegts,mpegts,,))
 $(eval $(call GstBuildLibrary,transcoder,transcoder,,))
 
 # 1: short name
@@ -429,7 +428,7 @@ $(eval $(call GstBuildPlugin,speed,speed support,audio,,))
 $(eval $(call GstBuildPlugin,subenc,subenc support,controller,,))
 $(eval $(call GstBuildPlugin,switchbin,switchbin support,,,))
 $(eval $(call GstBuildPlugin,timecode,timecode support,,,))
-$(eval $(call GstBuildPlugin,v4l2codecs,V4L2 stateless codecs support,codecparsers codecs,,))
+$(eval $(call GstBuildPlugin,v4l2codecs,V4L2 stateless codecs support,codecs,,))
 $(eval $(call GstBuildPlugin,videofiltersbad,videofiltersbad support,,,))
 $(eval $(call GstBuildPlugin,videoframe_audiolevel,videoframe_audiolevel support,,,))
 $(eval $(call GstBuildPlugin,videoparsersbad,videoparsersbad support,codecparsers,,))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @thess @flyn-org 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
The codecparsers package was accidentally added another time. Sort libraries alphabetically to avoid this kind of mistake in the future.

Fixes: a014537e0 ("gstreamer: update to 1.26.4")

---

## 🧪 Run Testing Details

- **OpenWrt Version:** -
- **OpenWrt Target/Subtarget:** -
- **OpenWrt Device:** -

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.