### PR TITLE
ddns-scripts: add dondominio.com

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=75
+PKG_RELEASE:=76
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/dondominio.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/dondominio.com.json
@@ -1,0 +1,7 @@
+{
+	"name": "dondominio.com",
+	"ipv4": {
+		"url": "http://dondns.dondominio.com/plain/?user=[USERNAME]&password=[PASSWORD]&host=[DOMAIN]&ip=[IP]",
+		"answer": "OK"
+	}
+}

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -21,6 +21,7 @@ dnsomatic.com
 dnspark.com
 do.de
 domopoli.de
+dondominio.com
 duckdns.org
 duiadns.net
 dy.fi


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @systemcrash 

**Description:**
Adds support for dondominio.com to the ddns-scripts package.
https://dondominio.dev/en/dondns/docs/api/#usage

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.2
- **OpenWrt Target/Subtarget:** mvebu/cortexa9
- **OpenWrt Device:** Turris Omnia

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
