### PR TITLE
lua-eco: update to 3.11.0

### DIFF
--- a/lang/lua-eco/Makefile
+++ b/lang/lua-eco/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lua-eco
-PKG_VERSION:=3.10.0
+PKG_VERSION:=3.11.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://github.com/zhaojh329/lua-eco/releases/download/v$(PKG_VERSION)
-PKG_HASH:=0205e0c20c4bbaa0829909b0722ac77df6f8a47d87669edaa8f79bdf87d15510
+PKG_HASH:=81d260935fa391fb52b9659e21aaada52482a1894782d9781911ff0fe8e3ab33
 
 PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @me

**Description:**

changelog: https://github.com/zhaojh329/lua-eco/releases/tag/v3.11.0

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** GL-MT3000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
