### PR TITLE
ksmbd-tools: force use -Os instead of user selection example -O2

### DIFF
--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
 PKG_VERSION:=3.5.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/cifsd-team/ksmbd-tools/releases/download/$(PKG_VERSION)
@@ -17,6 +17,13 @@ PKG_BUILD_FLAGS:=gc-sections
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/meson.mk
+
+#Force use -Os
+TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS)) -Os
+TARGET_CXXFLAGS := $(filter-out -O%,$(TARGET_CXXFLAGS)) -Os
+MESON_ENV_VARS += CFLAGS="$(TARGET_CFLAGS)" CXXFLAGS="$(TARGET_CXXFLAGS)"
+MESON_ARGS += -Dc_args="$(TARGET_CFLAGS)" -Dcpp_args="$(TARGET_CXXFLAGS)"
+
 
 define Package/ksmbd-tools/Default
   SECTION:=net


### PR DESCRIPTION
- update package release to rev.3

**Maintainer:** nobody

**Description:** force compiler option to -Os

Due to observed ksmbd-tools crash:
`kern.err kernel: [ 3499.958783] ksmbd: No IPC daemon response for 20s`

with flag -O2 I suggest to force -Os for this package also if user set different optization

---

## 🧪 Run Testing Details

- **OpenWrt Version: snapshot - 24.10
- **OpenWrt Target/Subtarget: mediatek filogic aarch64_cortex-a53  -  ath79 mips24kc
- **OpenWrt Device: MT6000 - AR300M16

---
Thanks

Andrea

