### PR TITLE
bind: fix typo

### DIFF
--- a/net/bind/Config.in
+++ b/net/bind/Config.in
@@ -36,7 +36,7 @@ config BIND_ENABLE_DOH
 config BIND_ENABLE_GSSAPI
 	bool
 	default n
-	prompt "Include GSSPAI support in bind"
+	prompt "Include GSSAPI support in bind"
 	help
 		BIND 9 supports GSSAPI. This depends on libcomerr and krb5-libs.
 		Disable it by default as krb5-libs is rather large.


### PR DESCRIPTION
Fix a trivial typo in bind's configuration script

## 📦 Package Details

**Maintainer:** @nmeyerhans
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
