### PR TITLE
msftlint and bluez-tools: fix SECTION variable typo 

### DIFF
--- a/utils/bluez-tools/Makefile
+++ b/utils/bluez-tools/Makefile
@@ -26,7 +26,7 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
 define Package/bluez-tools
-  SECTION:=Utilities
+  SECTION:=utils
   CATEGORY:=Utilities
   DEPENDS:=+bluez-daemon +glib2
   TITLE:=Bluetooth tools

--- a/utils/mstflint/Makefile
+++ b/utils/mstflint/Makefile
@@ -28,7 +28,7 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
 define Package/mstflint
-  SECTION:=Utilities
+  SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Mellanox Firmware Burning and Diagnostics Tools
   URL:=https://github.com/Mellanox/mstflint


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>
- `mstflint` @tk154
- `bluez-tools` @CarlosDerSeher

**Description:**

Change SECTION variable value from `Utilities` to `utils`,
probably a confusion with the variable CATEGORY.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** N/A
- **OpenWrt Target/Subtarget:** N/A
- **OpenWrt Device:** N/A

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.