### PR TITLE
CONTRIBUTING.md: fix commit subject example format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ guidelines:
 ### Commits in your pull-requests should
 
 - Have a useful commit subject prefixed with the package name (E.g.: `foopkg:
-  Add libzot dependency`).
+  add libzot dependency`).
 - Include Signed-off-by tag in the commit comments.  See: [Sign your
   work](https://openwrt.org/submitting-patches#sign_your_work)
 - Author and sign-off must match and be a real name or known identity and


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** N/A
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Update the commit subject example in CONTRIBUTING.md to match the documented guidelines,
ensuring it uses lowercase after the package prefix.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** N/A
- **OpenWrt Target/Subtarget:** N/A
- **OpenWrt Device:** N/A

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
