### PR TITLE
openvpn: add peer-fingerprint support

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.6.14
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/openvpn.options
+++ b/net/openvpn/files/openvpn.options
@@ -70,6 +70,7 @@ mssfix
 mtu_disc
 mute
 nice
+peer_fingerprint
 ping
 ping_exit
 ping_restart


### PR DESCRIPTION
This lets the --peer-fingerprint openvpn option be parsed which requires a client TLS certificate fingerprint (colon separated SHA256 hash) to match one specified in the option argument, during authentication.