### PR TITLE
[24.10] hev-socks5-server: update to 2.9.0

### DIFF
--- a/net/hev-socks5-server/Makefile
+++ b/net/hev-socks5-server/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hev-socks5-server
-PKG_VERSION:=2.8.0
+PKG_VERSION:=2.9.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/heiher/hev-socks5-server/releases/download/$(PKG_VERSION)
-PKG_HASH:=3be87e76ae8c187636225ecc0ffc44c9e74313894a6af0dd2753ffd27debbce7
+PKG_HASH:=21cd97afd3ec6d52e580fa92c1cc8c4cf8f58669da8182c3a072ba434d717dce
 
-PKG_MAINTAINER:=Ray Wang <r@hev.cc>
+PKG_MAINTAINER:=Ray Wang <git@hev.cc>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=License
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:** update to 2.9.0

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** armv8
- **OpenWrt Device:** armsr

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
