### PR TITLE
atop: update to 2.12.0

### DIFF
--- a/admin/atop/Makefile
+++ b/admin/atop/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=atop
-PKG_VERSION:=2.11.0
-PKG_RELEASE:=2
+PKG_VERSION:=2.12.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.atoptool.nl/download/
-PKG_HASH:=9b94c666602efff7bf402ecce706c347f38c39cb63498f9d39626861e5646e20
+PKG_HASH:=0d09ecc90c14e6ef41c22e3c57c142c3e4fb9cf3c94379077a33c961d5343086
 
 PKG_MAINTAINER:=Toni Uhlig <matzeton@googlemail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @robimarko 

2.11.0 will not compile with GCC15, so update to 2.12.0. It also fixes CVE-2025-31160.

Fixes: #27085
---

## 🧪 Run Testing Details

- **OpenWrt Version:** main
- **OpenWrt Target/Subtarget:** ramips/mt7621
- **OpenWrt Device:** no

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
