### PR TITLE
gateway-go: update to 2.0.10

### DIFF
--- a/net/gateway-go/Makefile
+++ b/net/gateway-go/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gateway-go
-PKG_VERSION:=0.3.16
+PKG_VERSION:=2.0.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/OpenIoTHub/gateway-go/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=82dfbce4fd34829e57bbd88f57f560daa975521cff930bd984182b03d423ecf9
+PKG_HASH:=95de453e76a22ae69a1bc9c32d6930278980c98decbe7a511fd9870bcdf90d2d
 
 PKG_MAINTAINER:=Yu Fang <newfarry@126.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @IoTServ 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
upgrade version, support ipv6 transport for remote access
---

## 🧪 Run Testing Details

- **OpenWrt Version:** x86-64, OpenWrt master
- **OpenWrt Target/Subtarget:** x86-64, OpenWrt master
- **OpenWrt Device:** VM

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
