### PR TITLE
iozone: add new package

### DIFF
--- a/utils/iozone/Makefile
+++ b/utils/iozone/Makefile
@@ -1,0 +1,49 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=iozone
+PKG_REAL_VERSION:=3_511
+PKG_VERSION:=$(subst _,.,$(PKG_REAL_VERSION))
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)$(PKG_REAL_VERSION).tgz
+PKG_SOURCE_URL:=https://www.iozone.org/src/current/
+PKG_HASH:=1aa00bc3cd627ec46ca17aa78c8fabd143d32025155c741f49392b1bdd776298
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)$(PKG_REAL_VERSION)
+MAKE_PATH:=src/current
+
+PKG_MAINTAINER:=John Audia <therealgraysky@proton.me>
+PKG_LICENSE:=LicenseRef-CUSTOM
+PKG_LICENSE_FILES:=docs/License.txt
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/iozone
+  SECTION:=utils
+  SUBMENU:=Filesystem
+  CATEGORY:=Utilities
+  TITLE:=A filesystem benchmark tool
+  URL:=https://www.iozone.org
+endef
+
+
+define Package/iozone/description
+ IOzone is a filesystem benchmark tool. The benchmark generates and
+ measures a variety of file operations. Iozone has been ported to
+ many machines and runs under many operating systems.
+ Iozone is useful for performing a broad filesystem analysis of a vendors
+ computer platform. The benchmark tests file I/O performance for the following
+ operations: Read, write, re-read, re-write, read backwards, read strided,
+ fread, fwrite, random read, pread ,mmap, aio_read, aio_write.
+endef
+
+define Build/Compile
+	$(call Build/Compile/Default,linux-generic)
+endef
+
+define Package/iozone/install
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/iozone $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,iozone))

--- a/utils/iozone/patches/020-makefile-add-generic-linux-cross-compile-target.patch
+++ b/utils/iozone/patches/020-makefile-add-generic-linux-cross-compile-target.patch
@@ -1,0 +1,53 @@
+From c43c0306ae1a49fdb225fc7b11473e5baef5d5d2 Mon Sep 17 00:00:00 2001
+From: graysky <therealgraysky AT proton DOT me>
+Date: Sat, 13 Jun 2026 12:32:56 -0400
+Subject: [PATCH 2/3] makefile: add generic linux cross-compile target
+
+Single arch-agnostic target honoring CC/CFLAGS/LDFLAGS; no -m64
+or per-arch defines (bitness via __LP64__).
+---
+ src/current/makefile | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+--- a/src/current/makefile
++++ b/src/current/makefile
+@@ -221,6 +221,20 @@ linux-ia64:	iozone_linux-ia64.o  libbif.
+ 	$(CC)  -O3 -Dlinux pit_server.o -o pit_server
+ 
+ #
++# Generic GNU/Clang Linux cross-compile build with threads, largefiles, async I/O.
++# Honors the toolchain's $(CC), $(CFLAGS) and $(LDFLAGS); the data model (32- vs
++# 64-bit) is taken from the compiler's target ABI via __LP64__ in iozone.c, so no
++# -m64 and no per-architecture defines are needed. A single recipe therefore
++# serves every Linux architecture (arm, aarch64, x86, x86_64, powerpc, powerpc64,
++# mips, ...). Intended for distribution/cross builds; see also the per-arch targets.
++#
++linux-generic:	iozone_linux-generic.o libasync.o libbif.o fileop_linux.o pit_server.o
++	$(CC) -O3 $(CFLAGS) $(LDFLAGS) iozone_linux-generic.o libasync.o libbif.o \
++		-lpthread -lrt -o iozone
++	$(CC) -O3 $(CFLAGS) $(LDFLAGS) -Dlinux fileop_linux.o -o fileop
++	$(CC) -O3 $(CFLAGS) $(LDFLAGS) -Dlinux pit_server.o -o pit_server
++
++#
+ # GNU 'C' compiler Linux build for powerpc chip with threads, largefiles, async I/O 
+ #
+ linux-powerpc64: iozone_linux-powerpc64.o  libbif.o libasync.o fileop_linux-ppc64.o pit_server-linux-powerpc64.o
+@@ -889,6 +903,18 @@ iozone_linux.o:	iozone.c libbif.c libasy
+ 	$(CC) -Wmissing-prototypes -c -O3 -Dunix -Dlinux -DHAVE_ANSIC_C -DASYNC_IO \
+ 		-D_LARGEFILE64_SOURCE $(CFLAGS) libasync.c  -o libasync.o 
+ 
++iozone_linux-generic.o:	iozone.c libbif.c libasync.c
++	@echo ""
++	@echo "Building iozone for Linux (generic cross-compile)"
++	@echo ""
++	$(CC) -c -O3 -Dunix -DHAVE_ANSIC_C -DASYNC_IO -DHAVE_PREAD \
++		-DSHARED_MEM -Dlinux -D_LARGEFILE64_SOURCE $(CFLAGS) iozone.c \
++		-DNAME='"linux-generic"' -o iozone_linux-generic.o
++	$(CC) -c -O3 -Dunix -DHAVE_ANSIC_C -DASYNC_IO -D_LARGEFILE64_SOURCE \
++		-DSHARED_MEM -Dlinux $(CFLAGS) libbif.c -o libbif.o
++	$(CC) -c -O3 -Dunix -Dlinux -DHAVE_ANSIC_C -DASYNC_IO \
++		-D_LARGEFILE64_SOURCE $(CFLAGS) libasync.c  -o libasync.o 
++
+ fileop_AIX.o:	fileop.c
+ 	@echo ""
+ 	@echo "Building fileop for AIX"

--- a/utils/iozone/test.sh
+++ b/utils/iozone/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+iozone -v | grep -F "${PKG_VERSION}"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**

IOzone is useful for performing various IO operations for benchmarking of mounted filesystems. The following can approximate the output of several tests of CrystalDiskMark[1], a popular Windows benchmarking utility:
```
Sequential 1M read/write:   iozone -e -I -s 1g -r 1m -i 0 -i 1
Sequential 128k read/write: iozone -e -I -s 1g -r 128k -i 0 -i 1
Random 4k read/write:       iozone -e -I -s 1g -r 4k -i 0 -i 2 -i 1
```
Results will be in Kb/s so divide by 1024 to get them in MB/s.

Build system: x86/64
Build-tested: flogic/glinet_gl-mt6000, x86/64-glibc
Run-tested: flogic/glinet_gl-mt6000, x86/64-glibc

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc and flogic
- **OpenWrt Device:** generic PC and MT6000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
