### PR TITLE
softethervpn5: fix compilation without OS ncurses

### DIFF
--- a/net/softethervpn5/Makefile
+++ b/net/softethervpn5/Makefile
@@ -83,6 +83,9 @@ export USE_MUSL=YES
 # BUG: outdated host/include/elf.h
 HOST_CFLAGS += $(FPIC) -DAT_HWCAP2=26
 TARGET_CFLAGS += $(FPIC)
+CMAKE_HOST_OPTIONS += \
+	-DCURSES_CURSES_LIBRARY=$(STAGING_DIR_HOSTPKG)/lib/libncursesw.a \
+	-DCURSES_INCLUDE_PATH=$(STAGING_DIR_HOSTPKG)/include
 CMAKE_OPTIONS += -DICONV_LIB_PATH="$(ICONV_PREFIX)/lib"
 
 # static build for host (hamcorebuilder), avoid -fpic on ncurses/host and shared libs can't be found on host


### PR DESCRIPTION
For some reason, the ncurses.pc file for the host build gets installed in host instead of hostpkg. Just override the whole thing. The tool built doesn't even use ncurses.

## 📦 Package Details

**Maintainer:** nobody