### PR TITLE
rclone: backport ftp insecure TLS ciphers fix

### DIFF
--- a/net/rclone/Makefile
+++ b/net/rclone/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rclone
 PKG_VERSION:=1.70.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/rclone/rclone/tar.gz/v$(PKG_VERSION)?

--- a/net/rclone/patches/001-ftp-allow-insecure-TLS-ciphers-fixes-8701.patch
+++ b/net/rclone/patches/001-ftp-allow-insecure-TLS-ciphers-fixes-8701.patch
@@ -1,0 +1,98 @@
+From d71a4195d68f2a3b0b5359240036e9770962c8d6 Mon Sep 17 00:00:00 2001
+From: Anagh Kumar Baranwal <6824881+darthShadow@users.noreply.github.com>
+Date: Wed, 23 Jul 2025 20:20:31 +0530
+Subject: [PATCH] ftp: allow insecure TLS ciphers - fixes #8701
+
+Signed-off-by: Anagh Kumar Baranwal <6824881+darthShadow@users.noreply.github.com>
+---
+ backend/ftp/ftp.go | 65 ++++++++++++++++++++++++++++++----------------
+ 1 file changed, 42 insertions(+), 23 deletions(-)
+
+--- a/backend/ftp/ftp.go
++++ b/backend/ftp/ftp.go
+@@ -164,6 +164,16 @@ Enabled by default. Use 0 to disable.`,
+ 			Default:  false,
+ 			Advanced: true,
+ 		}, {
++			Name: "allow_insecure_tls_ciphers",
++			Help: `Allow insecure TLS ciphers
++
++Setting this flag will allow the usage of the following TLS ciphers in addition to the secure defaults:
++
++- TLS_RSA_WITH_AES_128_GCM_SHA256
++`,
++			Default:  false,
++			Advanced: true,
++		}, {
+ 			Name:     "shut_timeout",
+ 			Help:     "Maximum time to wait for data connection closing status.",
+ 			Default:  fs.Duration(60 * time.Second),
+@@ -236,29 +246,30 @@ a write only folder.
+ 
+ // Options defines the configuration for this backend
+ type Options struct {
+-	Host              string               `config:"host"`
+-	User              string               `config:"user"`
+-	Pass              string               `config:"pass"`
+-	Port              string               `config:"port"`
+-	TLS               bool                 `config:"tls"`
+-	ExplicitTLS       bool                 `config:"explicit_tls"`
+-	TLSCacheSize      int                  `config:"tls_cache_size"`
+-	DisableTLS13      bool                 `config:"disable_tls13"`
+-	Concurrency       int                  `config:"concurrency"`
+-	SkipVerifyTLSCert bool                 `config:"no_check_certificate"`
+-	DisableEPSV       bool                 `config:"disable_epsv"`
+-	DisableMLSD       bool                 `config:"disable_mlsd"`
+-	DisableUTF8       bool                 `config:"disable_utf8"`
+-	WritingMDTM       bool                 `config:"writing_mdtm"`
+-	ForceListHidden   bool                 `config:"force_list_hidden"`
+-	IdleTimeout       fs.Duration          `config:"idle_timeout"`
+-	CloseTimeout      fs.Duration          `config:"close_timeout"`
+-	ShutTimeout       fs.Duration          `config:"shut_timeout"`
+-	AskPassword       bool                 `config:"ask_password"`
+-	Enc               encoder.MultiEncoder `config:"encoding"`
+-	SocksProxy        string               `config:"socks_proxy"`
+-	HTTPProxy         string               `config:"http_proxy"`
+-	NoCheckUpload     bool                 `config:"no_check_upload"`
++	Host                    string               `config:"host"`
++	User                    string               `config:"user"`
++	Pass                    string               `config:"pass"`
++	Port                    string               `config:"port"`
++	TLS                     bool                 `config:"tls"`
++	ExplicitTLS             bool                 `config:"explicit_tls"`
++	TLSCacheSize            int                  `config:"tls_cache_size"`
++	DisableTLS13            bool                 `config:"disable_tls13"`
++	AllowInsecureTLSCiphers bool                 `config:"allow_insecure_tls_ciphers"`
++	Concurrency             int                  `config:"concurrency"`
++	SkipVerifyTLSCert       bool                 `config:"no_check_certificate"`
++	DisableEPSV             bool                 `config:"disable_epsv"`
++	DisableMLSD             bool                 `config:"disable_mlsd"`
++	DisableUTF8             bool                 `config:"disable_utf8"`
++	WritingMDTM             bool                 `config:"writing_mdtm"`
++	ForceListHidden         bool                 `config:"force_list_hidden"`
++	IdleTimeout             fs.Duration          `config:"idle_timeout"`
++	CloseTimeout            fs.Duration          `config:"close_timeout"`
++	ShutTimeout             fs.Duration          `config:"shut_timeout"`
++	AskPassword             bool                 `config:"ask_password"`
++	Enc                     encoder.MultiEncoder `config:"encoding"`
++	SocksProxy              string               `config:"socks_proxy"`
++	HTTPProxy               string               `config:"http_proxy"`
++	NoCheckUpload           bool                 `config:"no_check_upload"`
+ }
+ 
+ // Fs represents a remote FTP server
+@@ -407,6 +418,14 @@ func (f *Fs) tlsConfig() *tls.Config {
+ 		if f.opt.DisableTLS13 {
+ 			tlsConfig.MaxVersion = tls.VersionTLS12
+ 		}
++		if f.opt.AllowInsecureTLSCiphers {
++			var ids []uint16
++			// Read default ciphers
++			for _, cs := range tls.CipherSuites() {
++				ids = append(ids, cs.ID)
++			}
++			tlsConfig.CipherSuites = append(ids, tls.TLS_RSA_WITH_AES_128_GCM_SHA256)
++		}
+ 	}
+ 	return tlsConfig
+ }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @ElonH, me

**Description:**
Added config field to allow insecure TLS ciphers that were disabled in Go 1.22.
Fixes: #27039

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** rockchip/armv8
- **OpenWrt Device:** none

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable