### PR TITLE
linknx: prevent jsoncpp dependency

### DIFF
--- a/net/linknx/Makefile
+++ b/net/linknx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linknx
 PKG_VERSION:=0.0.1.39
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-${PKG_VERSION}.tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/linknx/linknx/tar.gz/$(PKG_VERSION)?
@@ -39,6 +39,8 @@ CONFIGURE_ARGS+= \
 	--without-log4cpp \
 	--with-lua \
 	--with-libcurl \
+	--without-jsoncpp \
+	--without-cppunit \
 	--without-mysql
 
 define Package/linknx/install


### PR DESCRIPTION
## 📦 Package Details

**Maintainer: ** me

**Description:**
set compile options to prevent dependency from jsoncpp and cppunit

---

## 🧪 Run Testing Details

- **OpenWrt Version:** trunk
- **OpenWrt Target/Subtarget:** mpc85xx, ath79, ramips
- **OpenWrt Device:** tl-wdr4900-v1, tplink_archer-c7-v4, mt7620a

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
