### PR TITLE
[openwrt-24.10] aliyun-cli: add new package

### DIFF
--- a/utils/aliyun-cli/Makefile
+++ b/utils/aliyun-cli/Makefile
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=aliyun-cli
+PKG_VERSION:=3.0.290
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/aliyun/aliyun-cli.git
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_MIRROR_HASH:=8074f35cefe15ae85bc20444e653bde9620b2c3272f222a2a2699efdf3cd2bf3
+
+PKG_LICENSE=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Bruce Chen <a805899926@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/aliyun/aliyun-cli/v3
+GO_PKG_LDFLAGS_X:=$(GO_PKG)/cli.Version=$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/aliyun-cli
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Alibaba Cloud OpenAPI
+  URL:=https://github.com/aliyun/aliyun-cli
+  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+endef
+
+define Package/aliyun-cli/conffiles
+/root/.aliyun/config.json
+endef
+
+define Package/aliyun-cli/description
+  The Alibaba Cloud CLI is a tool to manage and use Alibaba Cloud resources through a command line interface.
+endef
+
+define Package/aliyun-cli/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/main $(1)/usr/bin/aliyun
+endef
+
+$(eval $(call GoBinPackage,aliyun-cli))
+$(eval $(call BuildPackage,aliyun-cli))

--- a/utils/aliyun-cli/test.sh
+++ b/utils/aliyun-cli/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+aliyun | grep -F "$PKG_VERSION"


### PR DESCRIPTION
The Alibaba Cloud CLI is a tool to manage and
use Alibaba Cloud resources through a command line interface


(cherry picked from commit f6e404e96d0a263e94f3183de0bb5139a3dc1099)

## 📦 Package Details

**Maintainer:** @czy21 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

At present, I want to use it to manage the real-time records of DNS.
---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 24.10.2
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** vm

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
