### PR TITLE
libsodium: fix building with GCC 15.1

### DIFF
--- a/libs/libsodium/Makefile
+++ b/libs/libsodium/Makefile
@@ -55,6 +55,8 @@ menu "Configuration"
 endmenu
 endef
 
+TARGET_CFLAGS += -std=gnu17
+
 CONFIGURE_ARGS+= \
 	--disable-ssp \
 	$(if $(CONFIG_LIBSODIUM_MINIMAL),--enable,--disable)-minimal


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jedisct1
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**

Force the default C version to -std=gnu17,

to fix the following build error:
```shell
<command-line>: error: unknown type name 'thread_local'; did you mean 'pthread_rwlock_t'?
randombytes/internal/randombytes_internal_random.c:132:8: note: in expansion of macro 'TLS'
  132 | static TLS InternalRandom stream = {
      |        ^~~
randombytes/internal/randombytes_internal_random.c:132:27: error: expected '=', ',', ';', 'asm' or '__attribute__' before 'stream'
  132 | static TLS InternalRandom stream = {
      |                           ^~~~~~
```

[1] https://github.com/openwrt/openwrt/pull/16522#issuecomment-3134756935
[2] https://github.com/openwrt/packages/issues/27122

<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- OpenWrt Version: SNAPSHOT
- OpenWrt Target/Subtarget: x86_64
- OpenWrt Device: x86_64

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
