### PR TITLE
rpcsvc-proto: fix build with autotools gettext macros 0.22

### DIFF
--- a/libs/rpcsvc-proto/Makefile
+++ b/libs/rpcsvc-proto/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rpcsvc-proto
 PKG_VERSION:=1.4.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/thkukuk/rpcsvc-proto/releases/download/v$(PKG_VERSION)

--- a/libs/rpcsvc-proto/patches/0001-po-update-for-gettext-0.22.patch
+++ b/libs/rpcsvc-proto/patches/0001-po-update-for-gettext-0.22.patch
@@ -1,0 +1,26 @@
+From 600879af780453bfe86e1e75f7a9f8a959982f29 Mon Sep 17 00:00:00 2001
+From: Vladimir Ermakov <vooon341@gmail.com>
+Date: Thu, 31 Jul 2025 09:36:47 +0200
+Subject: [PATCH] po: update for autoconf gettext macros 0.22
+
+Fix build error:
+```
+*** error: gettext infrastructure mismatch: using a Makefile.in.in from gettext version 0.20 but the autoconf macros are from gettext version 0.22
+```
+
+Signed-off-by: Vladimir Ermakov <vooon341@gmail.com>
+---
+ po/Makefile.in.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/po/Makefile.in.in
++++ b/po/Makefile.in.in
+@@ -8,7 +8,7 @@
+ # without any warranty.
+ #
+ # Origin: gettext-0.20.2
+-GETTEXT_MACRO_VERSION = 0.20
++GETTEXT_MACRO_VERSION = 0.22
+ 
+ PACKAGE = @PACKAGE@
+ VERSION = @VERSION@


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** **no?**

**Description:**

Fix #27131

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** x86_64 glibc gcc-15
- **OpenWrt Device:** x86_64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
