### PR TITLE
[openwrt-24.10] openlist: Remove dependency on fuse

### DIFF
--- a/net/openlist/Makefile
+++ b/net/openlist/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openlist
 PKG_VERSION:=4.0.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/OpenListTeam/OpenList/tar.gz/v$(PKG_VERSION)?
@@ -17,7 +17,7 @@ PKG_LICENSE:=AGPL-3.0-only
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 
-PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_DEPENDS:=golang/host fuse
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
@@ -37,7 +37,7 @@ define Package/openlist
   CATEGORY:=Network
   TITLE:=A file list program that supports multiple storage
   URL:=https://docs.oplist.org
-  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle +fuse-utils
+  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
   PROVIDES:=alist
 endef
 


### PR DESCRIPTION
Fixes https://github.com/openwrt/packages/issues/27011


(cherry picked from commit 68c60fdc5d8b42b3179fc341e6033288f1aaad06)

## 📦 Package Details

**Maintainer:** @1715173329
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

cherry-picked from master PR #27136

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.2
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** virtualbox

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
