### PR TITLE
dbus: use pid file owned by dbus

### DIFF
--- a/utils/dbus/Makefile
+++ b/utils/dbus/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dbus
 PKG_VERSION:=1.16.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://dbus.freedesktop.org/releases/dbus
@@ -86,7 +86,7 @@ MESON_ARGS += \
 	-Ddbus_user=root \
 	-Dsession_socket_dir=/tmp \
 	-Dsystem_socket=/var/run/dbus/system_bus_socket \
-	-Dsystem_pid_file=/var/run/dbus.pid \
+	-Dsystem_pid_file=/var/run/dbus/dbus.pid \
 	-Dasserts=false \
 	-Dchecks=false \
 	-Ddoxygen_docs=disabled \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @robimarko 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Switching to the dbus user in edc5a534 also needed to redefine the location of dbus.pid into the directory under its ownership. This commit fixes that omission.

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
