### PR TITLE
modemmanager: change permissions on dbus file

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git
@@ -125,6 +125,7 @@ define Package/modemmanager/install
 
 	$(INSTALL_DIR) $(1)/etc/dbus-1/system.d
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/dbus-1/system.d/org.freedesktop.ModemManager1.conf $(1)/etc/dbus-1/system.d
+	chmod 644 $(1)/etc/dbus-1/system.d/org.freedesktop.ModemManager1.conf
 
 	$(INSTALL_DIR) $(1)/usr/share/dbus-1/system-services
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/dbus-1/system-services/org.freedesktop.ModemManager1.service $(1)/usr/share/dbus-1/system-services


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**

`/etc/dbus-1/system.d/org.freedesktop.ModemManager1.conf` needs to be 644 so that it can be read to prevent the following since dbus runs as an unprivileged user:
```
dbus-daemon[12465]: Encountered error 'Failed to open "/etc/dbus-1/system.d/org.freedesktop.ModemManager1.conf": Permission denied' while parsing '/etc/dbus-1/system.d/org.freedesktop.ModemManager1.conf
```
Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** generic PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
