### PR TITLE
mwan3: handle missing interface gracefully

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.12.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/usr/share/rpcd/ucode/mwan3
+++ b/net/mwan3/files/usr/share/rpcd/ucode/mwan3
@@ -141,7 +141,7 @@ function interfaces_status(request) {
 			'age': get_x_time(uptime, ifname, 'TIME'),
 			'online': get_x_time(uptime, ifname, 'ONLINE'),
 			'offline': get_x_time(uptime, ifname, 'OFFLINE'),
-			'uptime': netstatus.uptime || 0,
+			'uptime': netstatus?.uptime || 0,
 			'score': get_int(ifname, 'SCORE'),
 			'lost': get_int(ifname, 'LOST'),
 			'turn': get_int(ifname, 'TURN'),
@@ -149,7 +149,7 @@ function interfaces_status(request) {
 			'enabled': ucibool(intf['enabled']),
 			'running': track_status == 'active',
 			'tracking': track_status,
-			'up': netstatus.up,
+			'up': netstatus?.up || false,
 			'track_ip': track_ips,
 		};
 	});


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert 

**Description:**
`ubus.call(sprintf('network.interface.%s', ifname), 'status', {})` returns null if the interface `ifname` doesn't exists (yet).

For pppoe interfaces using `option ipv6 auto`, a virtual interface suffixed `_6` is automatically created once the connection is established, but until then it doesn't exists.

Fixes: 6423781254b9f3e52c6102fb2cbcd9f99f2445a3 ("mwan3: reimplement rpcd plugin using ucode")

Fixes #27145 

---

## 🧪 Run Testing Details

Not run tested
