### PR TITLE
nfs-kernel-server: provide a NFSv3 and NFSv4 daemon

### DIFF
--- a/net/nfs-kernel-server/Config.in
+++ b/net/nfs-kernel-server/Config.in
@@ -1,8 +1,0 @@
-menu "Select nfs-kernel-server configuration options"
-        depends on PACKAGE_nfs-kernel-server
-
-config NFS_KERNEL_SERVER_V4
-	bool "Include support for NFSv4"
-	default y
-
-endmenu

--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -1,4 +1,4 @@
-# Copyright (C) 2009-2019 OpenWrt.org
+# Copyright (C) 2009-2025 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,11 +8,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
 PKG_VERSION:=2.8.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_HASH:=11c4cc598a434d7d340bad3e072a373ba1dcc2c49f855d44b202222b78ecdbf5
 
-PKG_SOURCE_URL:=@KERNEL/linux/utils/nfs-utils/$(PKG_VERSION)
 PKG_SOURCE:=nfs-utils-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=@KERNEL/linux/utils/nfs-utils/$(PKG_VERSION)
+MAINTAINER:=John Audia <therealgraysky@proton.me>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_CPE_ID:=cpe:/a:nfs_project:nfs-utils
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/nfs-utils-$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/nfs-utils-$(PKG_VERSION)
@@ -20,10 +23,7 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=$(PKG_NAME)/host libevent2
 HOST_BUILD_DEPENDS:=libtirpc/host
-
-PKG_CONFIG_DEPENDS:= \
-	CONFIG_IPV6 \
-	CONFIG_NFS_KERNEL_SERVER_V4
+PKG_CONFIG_DEPENDS:=CONFIG_IPV6
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
@@ -37,70 +37,82 @@ define Package/nfs-kernel-server/Default
 	URL:=http://nfs.sourceforge.net/
 endef
 
+define Package/nfs-utils/Default
+	SECTION:=utils
+	CATEGORY:=Utilities
+	SUBMENU:=Filesystem
+	URL:=http://nfs.sourceforge.net/
+endef
+
 define Package/nfs-kernel-server
 	$(call Package/nfs-kernel-server/Default)
-	TITLE:=Kernel NFS server support
-	DEPENDS+= +kmod-fs-nfsd +kmod-fs-nfs +NFS_KERNEL_SERVER_V4:kmod-fs-nfs-v4 +rpcbind +NFS_KERNEL_SERVER_V4:nfs-utils-libs +NFS_KERNEL_SERVER_V4:libkeyutils +NFS_KERNEL_SERVER_V4:libdevmapper
+	TITLE:=Kernel NFS server (NFSv3)
+	DEPENDS+= +kmod-fs-nfsd +kmod-fs-nfs +rpcbind
+	VARIANT:=v3
 	USERID:=nfs:nfs
 endef
 
 define Package/nfs-kernel-server/description
-Kernel NFS server support
+Kernel NFS server with NFSv3 support
 endef
 
-define Package/nfs-kernel-server/config
-	source "$(SOURCE)/Config.in"
+define Package/nfs-kernel-server-v4
+	$(call Package/nfs-kernel-server/Default)
+	TITLE:=Kernel NFS server (NFSv4.x)
+	DEPENDS+= +kmod-fs-nfsd +kmod-fs-nfs +rpcbind +kmod-fs-nfs-v4 +libkeyutils +libdevmapper +libevent2-core +libreadline
+	CONFLICTS:=nfs-kernel-server
+	VARIANT:=v4
+	PROVIDES:=nfs-kernel-server
+	USERID:=nfs:nfs
+endef
+
+define Package/nfs-kernel-server-v4/description
+Kernel NFS server with NFSv4.x support
+endef
+
+define Package/nfs-utils
+	$(call Package/nfs-utils/Default)
+	TITLE:=NFS mount and umount utils (NFSv3)
+	DEPENDS:=+libtirpc
+	VARIANT:=v3
+endef
+
+define Package/nfs-utils/description
+Mount/umount utilities for NFSv3
+endef
+
+define Package/nfs-utils-v4
+	$(call Package/nfs-utils/Default)
+	TITLE:=NFS mount and umount utils (NFSv4.x)
+	DEPENDS:=+libtirpc +libkeyutils +libdevmapper
+	CONFLICTS:=nfs-utils
+	VARIANT:=v4
+	PROVIDES:=nfs-utils
+endef
+
+define Package/nfs-utils-v4/description
+Mount/umount utilities for NFSv4.x
 endef
 
 define Package/nfs-kernel-server-utils
 	$(call Package/nfs-kernel-server/Default)
 	TITLE:=NFS server utils
-	DEPENDS:=nfs-kernel-server
+	DEPENDS:=nfs-kernel-server +libtirpc
 endef
 
 define Package/nfs-kernel-server-utils/description
-NFS server utils
-endef
-
-define Package/nfs-kernel-server/conffiles
-/etc/exports
-endef
-
-define Package/nfs-utils/Default
-	$(call Package/nfs-kernel-server/Default)
-	SECTION:=utils
-	CATEGORY:=Utilities
-	DEPENDS+= +NFS_KERNEL_SERVER_V4:libkeyutils +NFS_KERNEL_SERVER_V4:libdevmapper
-	URL:=http://nfs.sourceforge.net/
-endef
-
-define Package/nfs-utils
-	$(call Package/nfs-utils/Default)
-	TITLE:=updated mount utility (includes nfs4)
-endef
-
-define Package/nfs-utils/description
-Updated mount.nfs command - allows mounting nfs4 volumes
-endef
-
-define Package/nfs-utils-libs
-	$(call Package/nfs-utils/Default)
-	TITLE:=libraries provided by nfs-utils
-endef
-
-define Package/nfs-utils-libs/description
-Libraries provided by nfs-utils
+NFS server utils including showmount and nfsstat
 endef
 
 TARGET_CFLAGS += -Wno-error=implicit-function-declaration \
-		 -Wno-error=strict-prototypes \
-		 -Wno-error=incompatible-pointer-types \
-		 -Wno-error=format-security \
-		 -Wno-error=undef \
-		 -Wno-error=missing-include-dirs
+		-Wno-error=strict-prototypes \
+		-Wno-error=incompatible-pointer-types \
+		-Wno-error=format-security \
+		-Wno-error=undef \
+		-Wno-error=missing-include-dirs
 
 ifneq ($(CONFIG_USE_MUSL),)
-  TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
+	TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
 endif
 
 TARGET_LDFLAGS += -L$(STAGING_DIR)/usr/lib/libevent
@@ -108,25 +120,35 @@ TARGET_LDFLAGS += -L$(STAGING_DIR)/usr/lib/libevent
 CONFIGURE_ARGS += \
 	--disable-caps \
 	--disable-gss \
-	--disable-nfsdcld \
-	--disable-nfsdcltrack \
-	--enable-shared \
 	--enable-static \
-	--with-rpcgen=internal \
-	$(if $(CONFIG_NFS_KERNEL_SERVER_V4),--enable,--disable)-nfsv4 \
-	$(if $(CONFIG_NFS_KERNEL_SERVER_V4),--enable,--disable)-nfsv41 \
-	$(if $(CONFIG_NFS_KERNEL_SERVER_V4),--enable,--disable)-nfsv42
+	--with-rpcgen=internal
 
 ifeq ($(CONFIG_IPV6),n)
 	CONFIGURE_ARGS += --disable-ipv6
 endif
 
+ifeq ($(BUILD_VARIANT),v3)
+	CONFIGURE_ARGS += \
+	--disable-nfsdcld \
+	--disable-nfsv4server \
+	--disable-nfsv4 \
+	--disable-nfsv41 \
+	--disable-nfsv42
+endif
+
+ifeq ($(BUILD_VARIANT),v4)
+	CONFIGURE_ARGS += \
+	--enable-nfsdcld \
+	--enable-nfsv4server \
+	--enable-nfsv4 \
+	--enable-nfsv41 \
+	--enable-nfsv42
+endif
+
 CONFIGURE_VARS += \
 	libblkid_cv_is_recent=yes \
 	ac_cv_lib_resolv___res_querydomain=yes \
-	ac_cv_lib_bsd_daemon=no \
-	CONFIG_SQLITE3_TRUE="\#" \
-	CONFIG_NFSDCLD_TRUE="\#"
+	ac_cv_lib_bsd_daemon=no
 
 MAKE_FLAGS += \
 	OPT="$(TARGET_CFLAGS)" \
@@ -140,8 +162,6 @@ HOST_CFLAGS += -Dlinux \
 
 HOST_CONFIGURE_ARGS += \
 	--disable-gss \
-	--disable-nfsv4 \
-	--disable-nfsv41 \
 	--disable-nfsrahead \
 	--disable-nfsdctl \
 	--without-tcp-wrappers \
@@ -166,12 +186,12 @@ HOST_CONFIGURE_VARS += \
 	GSSGLUE_LIBS=" " \
 	RPCSECGSS_CFLAGS=" " \
 	RPCSECGSS_LIBS=" " \
-	CONFIG_SQLITE3_TRUE="\#" \
-	CONFIG_NFSDCLD_TRUE="\#" \
 	ac_cv_lib_event_core_event_base_dispatch=yes \
 	ac_cv_header_event2_event_h=yes \
 	c_cv_lib_sqlite3_sqlite3_libversion_number=yes \
-	libsqlite3_cv_is_recent=yes
+	libsqlite3_cv_is_recent=yes \
+	ac_cv_header_libdevmapper_h=yes \
+	ac_cv_lib_devmapper_dm_task_create=yes
 
 define Host/Compile
 	$(MAKE) -C $(HOST_BUILD_DIR)/tools/rpcgen all
@@ -182,22 +202,11 @@ define Host/Install
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/tools/rpcgen/rpcgen $(STAGING_DIR_HOSTPKG)/bin/rpcgen
 endef
 
-define Package/nfs-kernel-server/install
-	$(INSTALL_DIR) $(1)/etc/init.d $(1)/usr/sbin
-	$(INSTALL_DATA) ./files/nfsd.exports $(1)/etc/exports
-	$(INSTALL_BIN) ./files/nfsd.init $(1)/etc/init.d/nfsd
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/statd/sm-notify $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/statd/statd $(1)/usr/sbin/rpc.statd
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/nfsd/nfsd $(1)/usr/sbin/rpc.nfsd
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/mountd/mountd $(1)/usr/sbin/rpc.mountd
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/exportfs/exportfs $(1)/usr/sbin/
+define Package/nfs-kernel-server/conffiles
+/etc/exports
 endef
 
-define Package/nfs-kernel-server-utils/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/showmount/showmount $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/nfsstat/nfsstat $(1)/usr/sbin
-endef
+Package/nfs-kernel-server-v4/conffiles = $(Package/nfs-kernel-server/conffiles)
 
 define Package/nfs-utils/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
@@ -208,19 +217,53 @@ define Package/nfs-utils/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libnfsidmap.pc $(1)/usr/lib/pkgconfig/
 endef
 
+define Package/nfs-kernel-server/install
+	$(INSTALL_DIR) $(1)/etc/config $(1)/usr/sbin $(1)/etc/init.d
+	$(INSTALL_DATA) ./files/nfsd.v3.exports $(1)/etc/exports
+	$(INSTALL_BIN) ./files/nfsd.v3.init $(1)/etc/init.d/nfsd
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/statd/sm-notify $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/statd/statd $(1)/usr/sbin/rpc.statd
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/nfsd/nfsd $(1)/usr/sbin/rpc.nfsd
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/mountd/mountd $(1)/usr/sbin/rpc.mountd
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/exportfs/exportfs $(1)/usr/sbin/
+endef
+
+define Package/nfs-kernel-server-v4/install
+	$(INSTALL_DIR) $(1)/etc/config $(1)/usr/sbin $(1)/etc/init.d
+	$(INSTALL_DATA) ./files/nfsd.v4.exports $(1)/etc/exports
+	$(INSTALL_BIN) ./files/nfsd.v4.init $(1)/etc/init.d/nfsd
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/statd/sm-notify $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/nfsd/nfsd $(1)/usr/sbin/rpc.nfsd
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/exportfs/exportfs $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/nfsdcld/nfsdcld $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/rpc.idmapd $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/nfsv4.exportd $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnfsidmap.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnfsidmap/*.so $(1)/usr/lib/
+endef
+
 define Package/nfs-utils/install
+	$(INSTALL_DIR) $(1)/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/sbin/mount.nfs $(1)/sbin/
+	(cd $(1)/sbin; ln -sf mount.nfs umount.nfs)
+endef
+
+define Package/nfs-utils-v4/install
 	$(INSTALL_DIR) $(1)/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/sbin/mount.nfs $(1)/sbin/
 	(cd $(1)/sbin; ln -sf mount.nfs mount.nfs4; ln -sf mount.nfs umount.nfs; ln -sf mount.nfs umount.nfs4)
 endef
 
-define Package/nfs-utils-libs/install
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(if $(CONFIG_NFS_KERNEL_SERVER_V4),$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnfsidmap.so* $(1)/usr/lib/,)
+define Package/nfs-kernel-server-utils/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/showmount/showmount $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/nfsstat/nfsstat $(1)/usr/sbin
 endef
 
 $(eval $(call HostBuild))
-$(eval $(call BuildPackage,nfs-utils))
-$(eval $(call BuildPackage,nfs-utils-libs))
 $(eval $(call BuildPackage,nfs-kernel-server))
+$(eval $(call BuildPackage,nfs-kernel-server-v4))
+$(eval $(call BuildPackage,nfs-utils))
+$(eval $(call BuildPackage,nfs-utils-v4))
 $(eval $(call BuildPackage,nfs-kernel-server-utils))

--- a/net/nfs-kernel-server/files/nfsd.exports
+++ b/net/nfs-kernel-server/files/nfsd.exports
@@ -1,1 +1,0 @@
-# /mnt	*(ro,all_squash,insecure,sync)

--- a/net/nfs-kernel-server/files/nfsd.v3.exports
+++ b/net/nfs-kernel-server/files/nfsd.v3.exports
@@ -1,0 +1,4 @@
+# /etc/exports - exports(5) - directories exported to NFS clients
+#
+# Example for NFSv3:
+#  /srv/home        hostname1(rw,sync) hostname2(ro,sync)

--- a/net/nfs-kernel-server/files/nfsd.v3.init
+++ b/net/nfs-kernel-server/files/nfsd.v3.init
@@ -1,26 +1,24 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2006 OpenWrt.org
+# NFSV3 init script for OpenWrt
+# Copyright (C) 2025 OpenWrt.org
 
 START=99
 STOP=60
-
 USE_PROCD=1
 
+CONFIG_FILE="/etc/config/nfsd"
 NFS_D=/var/lib/nfs
 RECOVERY_D=$NFS_D/v4recovery
 LOCK_D=/var/lib/nfs/sm
 VAR_NFS=/var/lib/nfs
 
 start_service() {
+	logger -t "nfsd" -p notice "Starting the NFSV3 daemon"
 	grep -q /proc/fs/nfsd /proc/mounts || \
 		mount -t nfsd nfsd /proc/fs/nfsd
-	mkdir -p $NFS_D
-	mkdir -p $RECOVERY_D
-	mkdir -p $LOCK_D
-	touch $NFS_D/rmtab
-
-	mkdir -p $VAR_NFS
-	chown nfs:nfs $VAR_NFS
+	mkdir -p "$NFS_D" "$RECOVERY_D" "$LOCK_D" "$VAR_NFS"
+	chown nfs:nfs "$VAR_NFS"
+	touch "$NFS_D/rmtab"
 
 	sysctl -w fs.nfs.nlm_tcpport=32777 fs.nfs.nlm_udpport=32777 > /dev/null
 
@@ -37,13 +35,12 @@ start_service() {
 }
 
 stop_service() {
-	rpc.nfsd 0 2> /dev/null
+	rpc.nfsd 0 2>/dev/null
 	/usr/sbin/exportfs -au
-	grep -q /proc/fs/nfsd /proc/mounts && \
-		umount /proc/fs/nfsd
+	grep -q /proc/fs/nfsd /proc/mounts && umount /proc/fs/nfsd
 }
 
 service_triggers() {
-	local export_dirs="$(while read mp _r ; do echo -n "$mp " ; done < /etc/exports)"
-	procd_add_reload_mount_trigger $export_dirs
+	export_dirs="$(while read -r mp _r; do echo "$mp "; done < /etc/exports)"
+	procd_add_reload_mount_trigger "$export_dirs"
 }

--- a/net/nfs-kernel-server/files/nfsd.v4.exports
+++ b/net/nfs-kernel-server/files/nfsd.v4.exports
@@ -1,0 +1,7 @@
+# /etc/exports - exports(5) - directories exported to NFS clients
+#
+# Example for NFSv3:
+#  /srv/home        hostname1(rw,sync) hostname2(ro,sync)
+# Example for NFSv4:
+#  /srv/nfs4	    hostname1(rw,sync,fsid=0)
+#  /srv/nfs4/home   hostname1(rw,sync,nohide)

--- a/net/nfs-kernel-server/files/nfsd.v4.init
+++ b/net/nfs-kernel-server/files/nfsd.v4.init
@@ -1,0 +1,57 @@
+#!/bin/sh /etc/rc.common
+# NFSV4 init script for OpenWrt
+# Copyright (C) 2025 OpenWrt.org
+
+START=99
+STOP=60
+USE_PROCD=1
+
+CONFIG_FILE="/etc/config/nfsd"
+NFS_D=/var/lib/nfs
+RPC_PIPEFS_D=/var/lib/nfs/rpc_pipefs
+NFSDCLD_PID=/var/run/nfsdcld.pid
+
+start_service() {
+	logger -t "nfsd" -p notice "Starting the NFSV4 daemon"
+	mkdir -p "$RPC_PIPEFS_D" "$NFS_D"
+	chown nfs:nfs "$NFS_D"
+
+	grep -q /proc/fs/nfsd /proc/mounts || mount -t nfsd nfsd /proc/fs/nfsd
+	grep -q "$RPC_PIPEFS_D" /proc/mounts || mount -t rpc_pipefs sunrpc "$RPC_PIPEFS_D"
+
+	procd_open_instance
+	procd_set_param command /usr/sbin/nfsv4.exportd -f
+	procd_close_instance
+
+	procd_open_instance
+	procd_set_param command /usr/sbin/rpc.idmapd -f
+	procd_close_instance
+
+	procd_open_instance
+	procd_set_param command /usr/sbin/nfsdcld
+	procd_append_param -F
+	procd_close_instance
+
+	/usr/sbin/exportfs -r
+
+	procd_open_instance
+	procd_set_param command /usr/sbin/rpc.nfsd -N 3
+	procd_close_instance
+}
+
+stop_service() {
+	/usr/sbin/rpc.nfsd 0
+	/usr/sbin/exportfs -au
+	/usr/sbin/exportfs -f
+	/usr/bin/killall nfsdcld 2>/dev/null
+	(
+		sleep 1s
+		grep -q "$RPC_PIPEFS_D" /proc/mounts && umount "$RPC_PIPEFS_D"
+		grep -q /proc/fs/nfsd /proc/mounts && umount /proc/fs/nfsd
+		) &
+}
+
+service_triggers() {
+	export_dirs="$(while read -r mp _r; do echo "$mp "; done < /etc/exports)"
+	procd_add_reload_mount_trigger "$export_dirs"
+}

--- a/net/nfs-kernel-server/patches/240-fix-cleanup_lockfiles-function-linkage-in-exportd.patch
+++ b/net/nfs-kernel-server/patches/240-fix-cleanup_lockfiles-function-linkage-in-exportd.patch
@@ -1,0 +1,44 @@
+From d18643a9fe0e612e823d07cb75d36b4641033f09 Mon Sep 17 00:00:00 2001
+From: John Audia <therealgraysky@proton.me>
+Date: Sun, 24 Aug 2025 11:00:44 -0400
+Subject: [PATCH] fix cleanup_lockfiles function linkage in exportd
+
+The cleanup_lockfiles function in utils/exportd/exportd.c was declared
+as 'inline void' without a proper function prototype, causing linker
+errors during the build process:
+
+  exportd.c:(.text+0x5a): undefined reference to `cleanup_lockfiles'
+  exportd.c:(.text.startup+0x317): undefined reference to `cleanup_lockfiles'
+
+This occurred because:
+1. The inline keyword prevented the compiler from generating a callable
+   function symbol in some build configurations
+2. The function lacked a proper prototype declaration, triggering
+   -Werror=missing-prototypes
+
+The fix changes the function to:
+- Remove the 'inline' keyword to ensure symbol generation
+- Add a proper static function prototype
+- Make the function 'static' since it's only used within exportd.c
+
+This resolves both the linking error and the missing prototype warning,
+allowing exportd to build successfully in OpenWrt's cross-compilation
+environment.
+---
+ utils/exportd/exportd.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/utils/exportd/exportd.c
++++ b/utils/exportd/exportd.c
+@@ -51,9 +51,10 @@ static char shortopts[] = "d:fghs:t:liT:
+ /*
+  * Signal handlers.
+  */
++static void cleanup_lockfiles(void);
+ inline static void set_signals(void);
+ 
+-inline void
++static void
+ cleanup_lockfiles (void)
+ {
+ 	unlink(etab.lockfn);


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** no one
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Update build and serve exports in NFSv3 and NFSv4 configurations. The default, do nothing option will be NFSv3 so updates should be seamless as the current package is broken wrt NFSv4.

This PR also split the package into a default NFSv3-only (lite) series of packages and into a NFSv3/4 (full) series of packages. In doing this the build-time V4 options are removed which is good from a user's perspective because it means that for both release and for snapshot builds, both options will be available to users of the binary hosted packages.

The new V4 code is 100% functional based on my testing with multiple clients.

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** generic PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
