### PR TITLE
adblock-fast: fix TLD sanity check for unbound list

### DIFF
--- a/net/adblock-fast/files/etc/init.d/adblock-fast
+++ b/net/adblock-fast/files/etc/init.d/adblock-fast
@@ -1140,12 +1140,24 @@ resolver() {
 		sanity)
 			[ -n "$sanity_check" ] || return 0
 			output_dns "Sanity check for $dns TLDs "
-			if ! grep -q -v '\.' "$outputFile"; then
-				output_ok
-			else
-				json add warning 'warningSanityCheckTLD' "$outputFile"
-				output_warn
-			fi
+			case "$dns" in
+				unbound.*)
+					if ! grep -v '\.' "$outputFile" | grep -q 'local-zone:'; then
+						output_ok
+					else
+						json add warning 'warningSanityCheckTLD' "$outputFile"
+						output_warn
+					fi
+					;;
+				*)
+					if ! grep -q -v '\.' "$outputFile"; then
+						output_ok
+					else
+						json add warning 'warningSanityCheckTLD' "$outputFile"
+						output_warn
+					fi
+					;;
+			esac
 			output_dns "Sanity check for $dns leading dots "
 			case "$dns" in
 				dnsmasq.*)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @stangri 

**Description:**
Sanity check for TLDs was simply checking if every line contained a dot ("."). This works if every line follows the same format:

Example, dnsmasq list /var/run/adblock-fast/dnsmasq.addnhosts

server=/example.com/
server=/other-example.com/

However, unbound lists start with a `server:` block, causing the simple check to fail and show warnings in logs.

```yaml
server:
local-zone: "example.com"
```

Update to follow similar logic when checking backend specific config.

First filter out lines not containing a dot, and then check if any of those contain "local-zone:"

This should then catch instances like:

```yaml
server:
local-zone: example.com always_nxdomain
local-zone: badTLD always_nxdomain
```


---

## 🧪 Run Testing Details

- **OpenWrt Version:** main
- **OpenWrt Target/Subtarget:** qualcommax/ipq807x

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
