### PR TITLE
adblock-fast: bugfixes: status & TLD check with unbound

### DIFF
--- a/net/adblock-fast/Makefile
+++ b/net/adblock-fast/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.1.4
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=AGPL-3.0-or-later
 

--- a/net/adblock-fast/files/etc/init.d/adblock-fast
+++ b/net/adblock-fast/files/etc/init.d/adblock-fast
@@ -459,7 +459,7 @@ json() {
 			'get')
 				case "$param" in
 					'errors'|'warnings')
-						json_select "$param" >/dev/null 2>&1
+						json_select "$param" >/dev/null 2>&1 || return
 						if [ -z "$value" ]; then
 							json_get_keys i
 						else
@@ -1140,7 +1140,7 @@ resolver() {
 		sanity)
 			[ -n "$sanity_check" ] || return 0
 			output_dns "Sanity check for $dns TLDs "
-			if ! grep -q -v '\.' "$outputFile"; then
+			if ! grep -qvE '\.|server:' "$outputFile"; then
 				output_ok
 			else
 				json add warning 'warningSanityCheckTLD' "$outputFile"
@@ -1985,7 +1985,7 @@ adb_check_tld() {
 		output "No block-list ('$outputFile') found.\n"
 		return 0
 	fi
-	c="$(grep -c -v '\.' "$outputFile")"
+	c="$(grep -cvE '\.|server:' "$outputFile")"
 	if [ "$c" -gt 0 ]; then
 		if [ "$c" -eq 1 ]; then
 			output 1 "Found 1 match for TLD in '$outputFile'.\n"
@@ -1995,7 +1995,7 @@ adb_check_tld() {
 			output 2 "[PROC] Found $c matches for TLDs in '$outputFile'.\n"
 		fi
 		if [ "$c" -le 20 ]; then
-			grep -v '\.' "$outputFile" | sed "$outputOutputFilter"
+			grep -vE '\.|server:' "$outputFile" | sed "$outputOutputFilter"
 		fi
 	else
 		output 1 "No TLD was found in current block-list ('$outputFile').\n"


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge 640vn, OpenWrt 24.10.2
Run tested: x86_64, Dell EMC Edge 640vn, OpenWrt 24.10.2

Description:
fixes: https://github.com/openwrt/packages/issues/27146
supercedes: https://github.com/openwrt/packages/pull/27159
