### PR TITLE
crowdsec-firewall-bouncer: update to 0.0.34

### DIFF
--- a/net/crowdsec-firewall-bouncer/Makefile
+++ b/net/crowdsec-firewall-bouncer/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crowdsec-firewall-bouncer
-PKG_VERSION:=0.0.33
+PKG_VERSION:=0.0.34
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/crowdsecurity/cs-firewall-bouncer/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=464955805ab85b08a3249b5bbcb6f2fce9a1ffe15768f5753fd23ea907f052ca
+PKG_HASH:=5bd62250f40fc0a05d2431f3ea1cb211d7fc4cc755b53a23585aa2cede8ff985
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Kerma Gérald <gandalf@gk2.net>

**Description:**
updated to new upstream release version 0.0.34

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.2
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** BPI-R3

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
