### PR TITLE
CONTRIBUTING.md: accept only real names in the SoB

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,8 @@ guidelines:
   add libzot dependency`).
 - Include Signed-off-by tag in the commit comments.  See: [Sign your
   work](https://openwrt.org/submitting-patches#sign_your_work)
-- Author and sign-off must match and be a real name or known identity and
-  a real email address. GitHub private email addresses will not be accepted.
+- Author and sign-off must match and be a real name and real email address.
+  GitHub private email addresses will not be accepted.
 - Follow all [Submission Guidelines](https://openwrt.org/submitting-patches#submission_guidelines)
   requirements, including maximum characters per line.
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** N/A
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**

Follow the rule from the Submission Guidelines:
https://openwrt.org/submitting-patches#submission_guidelines

And the shared formal check:
https://github.com/openwrt/actions-shared-workflows/blob/ba03db3b5ae747ed9f38df6c96eb4a37a9f7f7c5/.github/workflows/formal.yml#L37-L43

And this commit 07c12180097283a7a53d14d173d7a7e6a1c43be8

---

## 🧪 Run Testing Details

- **OpenWrt Version:** N/A
- **OpenWrt Target/Subtarget:** N/A
- **OpenWrt Device:** N/A

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.