### PR TITLE
dbus: fix ujail configuration

### DIFF
--- a/utils/dbus/Makefile
+++ b/utils/dbus/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dbus
 PKG_VERSION:=1.16.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://dbus.freedesktop.org/releases/dbus

--- a/utils/dbus/files/dbus.init
+++ b/utils/dbus/files/dbus.init
@@ -15,6 +15,7 @@ start_service() {
 	mkdir -m 0755 -p /var/lib/dbus
 	mkdir -m 0755 -p /var/run/dbus
 	chown dbus:dbus /var/lib/dbus /var/run/dbus
+	chown -R dbus:dbus /etc/dbus-1
 
 	[ -x /usr/bin/dbus-uuidgen ] && /usr/bin/dbus-uuidgen --ensure
 
@@ -26,6 +27,7 @@ start_service() {
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	[ -x /sbin/ujail -a -e /etc/capabilities/dbus.json ] && {
+		procd_append_param command --nopidfile
 		procd_add_jail dbus
 		procd_set_param user dbus
 		procd_set_param group dbus


### PR DESCRIPTION
Running dbus as an unprivileged user fails for two reasons: Cannot write pid file and cannot read the installed policies:

 Tue Aug  5 17:12:41 2025 daemon.info dbus-daemon[8568]: jail: exec-ing /usr/bin/dbus-daemon
 Tue Aug  5 17:12:41 2025 daemon.info dbus-daemon[8585]: Encountered error 'Failed to open "/etc/dbus-1/system.d/org.freedesktop.ModemManager1.conf": Permission denied' while parsing '/etc/dbus-1/system.d/org.freedesktop.ModemManager1.conf'
 Tue Aug  5 17:12:41 2025 daemon.err dbus-daemon[8568]: dbus-daemon[8585]: Encountered error 'Failed to open "/etc/dbus-1/system.d/org.freedesktop.ModemManager1.conf": Permission denied' while parsing '/etc/dbus-1/system.d/org.freedesktop.ModemManager1.conf'
 Tue Aug  5 17:12:41 2025 daemon.warn dbus-daemon[8585]: Failed to start message bus: Failed to open "/var/run/dbus.pid": Permission denied
 Tue Aug  5 17:12:41 2025 daemon.err dbus-daemon[8568]: dbus-daemon[8585]: Failed to start message bus: Failed to open "/var/run/dbus.pid": Permission denied
 Tue Aug  5 17:12:41 2025 daemon.info dbus-daemon[8568]: jail: jail (8585) exited with exit: 1

Fix by dropping the pid file when running unprivileged and changing the owner of the installed policies.

Fixes: f238d6dd0996 ("dbus: run as regular user rather than as root")

## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
