### PR TITLE
iodine: use procd, add extra options

### DIFF
--- a/net/iodine/Makefile
+++ b/net/iodine/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iodine
 PKG_VERSION:=0.8.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://code.kryo.se/iodine/

--- a/net/iodine/files/iodined.config
+++ b/net/iodine/files/iodined.config
@@ -1,5 +1,8 @@
 config iodined
         option address     ''
         option password    ''
-        option tunnelip    '10.0.0.1'
+        option tunnelip    '10.0.0.1/24'
         option tld     	   ''
+	#option port	   '53'
+	#option client_ip_check '0'
+	#option debuglevel '0'

--- a/net/iodine/files/iodined.init
+++ b/net/iodine/files/iodined.init
@@ -2,26 +2,51 @@
 # Copyright (C) 2006-2011 OpenWrt.org
 
 START=50
+PROG=/usr/sbin/iodined
+USE_PROCD=1
+NAME=iodined
 
-start_instance () {
-	local section="$1"
-	config_get address  "$section" 'address'
-	config_get password "$section" 'password'
-	config_get tunnelip "$section" 'tunnelip'
-	config_get tld      "$section" 'tld'
-	config_get port     "$section" 'port'
-	
-	test -n "$address" || address='0.0.0.0'
-	test -n "$port" || port='53'
-
-	service_start /usr/sbin/iodined -l "$address" -P "$password" -p "$port" "$tunnelip" "$tld"
+validate_section_iodined()
+{
+	uci_load_validate iodined iodined "$1" "$2" \
+		'enable:bool:1' \
+		'address:cidr4' \
+		'password:string' \
+		'tunnelip:cidr4' \
+		'tld:string' \
+		'port:range(0,65535)' \
+		'debuglevel:range(0,6):0' \
+		'client_ip_check:bool:1'
 }
 
-start() {
-	config_load 'iodined'
-	config_foreach start_instance 'iodined'
+iodined_instance()
+{
+	[ "$2" = 0 ] || {
+		echo "validation failed"
+		return 1
+	}
+
+	[ "$enable" = "0" ] && return 1
+
+	procd_open_instance
+	procd_set_param command "$PROG" -f
+	[ -n "$address" ] && procd_append_param command -l "$address"
+	[ -n "$password" ] && procd_append_param command -P "$password"
+	[ -n "$port" ] && procd_append_param command -p "$port"
+	[ "$debuglevel" -gt 0 ] && procd_append_param command -$(printf 'D%.0s' $(seq $debuglevel))
+	[ "$client_ip_check" -eq 0 ] && procd_append_param command -c
+	procd_append_param command "$tunnelip" "$tld"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
 }
 
-stop() {
-	service_stop /usr/sbin/iodined
+start_service () {
+	config_load "$NAME"
+	config_foreach validate_section_iodined iodined iodined_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger "$NAME"
+	procd_add_validation validate_section_iodined
 }


### PR DESCRIPTION
Iodine now uses a procd init.d service and output is sent to the system log.

Two new options have been added:

- debuglevel — increases the verbosity of debug output.

- check_client_ip — controls whether to accept or reject queries from different IP addresses for the same login. This should be disabled if the recursive DNS server might send queries from varying IPs. However, disabling this option also makes replay attacks significantly easier.

## 📦 Package Details

**Maintainer:**
@ukleinek @neheb 

**Description:**
This package creates a TUN tunnel over a DNS protocol. This change migrates the init.d script to procd style. It also exposes some extra arguments via config file.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Bananapi BPI-R3

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
