### PR TITLE
db: add explanatory comments to Makefile

### DIFF
--- a/libs/db/Makefile
+++ b/libs/db/Makefile
@@ -5,26 +5,37 @@
 # See /LICENSE for more information.
 #
 
+# Include the main OpenWrt build system rules
 include $(TOPDIR)/rules.mk
 
+# Basic package metadata
 PKG_NAME:=db
 PKG_VERSION:=5.3.28
 PKG_RELEASE:=2
 
+# Source download location and verification
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.oracle.com/berkeley-db/
 PKG_HASH:=e0a992d740709892e81f9d93f06daf305cf73fb81b545afe72478043172c3628
 
+# Package maintainer and license details
 PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>
 PKG_LICENSE:=Sleepycat
 PKG_LICENSE_FILES:=LICENSE
 
+# Apply 'autoreconf' to regenerate build scripts before compiling
 PKG_FIXUP:=autoreconf
+
+# Specify build-time dependency on libxml2
 PKG_BUILD_DEPENDS:=libxml2
+
+# Enable parallel compilation
 PKG_BUILD_PARALLEL:=1
 
+# Include the OpenWrt package helper macros
 include $(INCLUDE_DIR)/package.mk
 
+# Define metadata for the libdb47 package
 define Package/libdb47
   SECTION:=libs
   CATEGORY:=Libraries
@@ -34,10 +45,12 @@ define Package/libdb47
   ABI_VERSION:=5
 endef
 
+# Description shown in package listings
 define Package/libdb47/description
   Berkeley DB library.
 endef
 
+# Define metadata for the libdb47xx package
 define Package/libdb47xx
   SECTION:=libs
   CATEGORY:=Libraries
@@ -52,9 +65,11 @@ define Package/libdb47xx/description
   Berkeley DB library C++ wrapper.
 endef
 
+# Build configuration
 CONFIGURE_PATH = build_unix
 CONFIGURE_CMD = ../dist/configure
 
+# Configuration options passed to the build system
 CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
@@ -65,8 +80,10 @@ CONFIGURE_ARGS += \
 	--disable-debug \
 	$(if $(CONFIG_PACKAGE_libdb47xx),--enable-cxx,--disable-cxx)
 
+# Additional C compiler flags
 TARGET_CFLAGS += $(FPIC) -std=gnu17
 
+# Define how to build the package
 define Build/Compile
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/build_unix \
 		DESTDIR="$(PKG_INSTALL_DIR)" all
@@ -74,16 +91,19 @@ define Build/Compile
 		DESTDIR="$(PKG_INSTALL_DIR)" install
 endef
 
+# Installation instructions for the libdb47 package
 define Package/libdb47/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdb-*.so $(1)/usr/lib/
 endef
 
+# Installation instructions for the libdb47xx package
 define Package/libdb47xx/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdb_cxx-*.so $(1)/usr/lib/
 endef
 
+# Instructions for installing development headers and libraries
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/db.h $(1)/usr/include/
@@ -92,5 +112,6 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdb*.{a,so} $(1)/usr/lib
 endef
 
+# Register packages with the build system
 $(eval $(call BuildPackage,libdb47))
 $(eval $(call BuildPackage,libdb47xx))


### PR DESCRIPTION
This commit adds inline comments to improve the readability of the Makefile in the db package.

## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
