### PR TITLE
syncthing: improve discovery and relay argument parsing

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
 PKG_VERSION:=1.30.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)

--- a/utils/syncthing/files/stdiscosrv.conf
+++ b/utils/syncthing/files/stdiscosrv.conf
@@ -7,11 +7,13 @@ config stdiscosrv 'stdiscosrv'
 	# Find the documents from: https://docs.syncthing.net/users/stdiscosrv.html
 	# option cert '/etc/stdiscosrv/cert.pem'
 	# option key '/etc/stdiscosrv/key.pem'
- 	# option db_flush_interval '5m'
+	# option db_flush_interval '5m'
 	# option metrics_listen ''
 
-	# CLI options with no value should be defined as booleans and theirs names
-	# should be prefixed with '_'.
-	# option _compression '0'
-	# option _debug '0'
-	# option _http '1'
+	# Running as 'root' is possible, but not recommended
+	# option user 'syncthing'
+
+	# CLI options with no value should be defined as booleans
+	# option compression '0'
+	# option debug '0'
+	# option http '1'

--- a/utils/syncthing/files/stdiscosrv.init
+++ b/utils/syncthing/files/stdiscosrv.init
@@ -13,43 +13,36 @@ config_cb() {
 	option_cb() {
 		local option="$1"
 		local value="$2"
-		case $option in
-		enabled|listen|cert|db_dir|key)
-			eval $option=$value
-			;;
-		_*)
-			[ "$value" = "0" ] || extra_args="$extra_args -${option//_/-}"
-			;;
-		*)
-			extra_args="$extra_args --${option//_/-}='$value'"
-			;;
-		esac
-	}
-
-	list_cb() {
-		local name="$1"
-		local value="$2"
-		[ "$name" = "_" ] && extra_args="$extra_args --${value//_/-}" || return 0
+		# Remove the leading underscore from the option name for backward
+		# compatibility
+		option="${option#_}"
+		eval $option="$value"
 	}
 }
 
 service_triggers() {
-	procd_add_reload_trigger "stdiscosrv"
+	procd_add_reload_trigger 'stdiscosrv'
 }
 
 start_service() {
-	local extra_args
-	# Options with default value different with the syncthing should be defined explicitly here
-	local enabled=0
-	local listen=":8443"
-	local conf_dir="/etc/stdiscosrv"
-	local cert="$conf_dir/cert.pem"
-	local key="$conf_dir/key.pem"
-	local db_dir="$conf_dir/discovery.db"
-	local nice=0
-	local user="syncthing"
+	local conf_dir='/etc/stdiscosrv'
 
-	config_load "stdiscosrv"
+	# Options with default value different with the syncthing should be defined
+	# explicitly here
+	local enabled=0
+	local compression=0
+	local cert="$conf_dir/cert.pem"
+	local db_dir="$conf_dir/discovery.db"
+	local db_flush_interval=''
+	local debug=0
+	local http=0
+	local key="$conf_dir/key.pem"
+	local listen=':8443'
+	local metrics_listen=''
+	local nice=0
+	local user='syncthing'
+
+	config_load 'stdiscosrv'
 
 	[ "$enabled" -gt 0 ] || return 0
 
@@ -58,19 +51,22 @@ start_service() {
 	[ -d "$db_dir" ] || mkdir -p "$db_dir"
 	[ -d "$conf_dir" ] && chown -R "$user":"$group" "$conf_dir"
 
-	config_get nice stdiscosrv nice "0"
-
 	procd_open_instance
 	procd_set_param command "$PROG"
-	procd_append_param command --listen="$listen"
-	procd_append_param command --db-dir="$db_dir"
 	procd_append_param command --cert="$cert"
+	[ "$compression" -eq 0 ] || procd_append_param command --compression
+	procd_append_param command --db-dir="$db_dir"
+	[ -z "$db_flush_interval" ] || procd_append_param command --db-flush-interval="$db_flush_interval"
+	[ "$debug" -eq 0 ] || procd_append_param command --debug
+	[ "$http" -eq 0 ] || procd_append_param command --http
 	procd_append_param command --key="$key"
-	[ -z "$extra_args" ] || procd_append_param command "$extra_args"
+	procd_append_param command --listen="$listen"
+	[ -z "$metrics_listen" ] || procd_append_param command --metrics-listen="$metrics_listen"
 
 	procd_set_param nice "$nice"
 	procd_set_param term_timeout 15
 	procd_set_param user "$user"
+	procd_set_param group "$group"
 	procd_set_param respawn
 	procd_set_param stdout 1
 	procd_set_param stderr 1

--- a/utils/syncthing/files/strelaysrv.conf
+++ b/utils/syncthing/files/strelaysrv.conf
@@ -20,8 +20,10 @@ config strelaysrv 'strelaysrv'
 	# option status_srv ':22070'
 	# option token ''
 
-	# CLI options with no value should be defined as booleans and theirs names
-	# should be prefixed with '_'.
-	# option _debug '0'
-	# option _nat '0'
-	# option _pprof '0'
+	# Running as 'root' is possible, but not recommended
+	# option user 'syncthing'
+
+	# CLI options with no value should be defined as booleans
+	# option debug '0'
+	# option nat '0'
+	# option pprof '0'

--- a/utils/syncthing/files/strelaysrv.init
+++ b/utils/syncthing/files/strelaysrv.init
@@ -13,39 +13,44 @@ config_cb() {
 	option_cb() {
 		local option="$1"
 		local value="$2"
-		case $option in
-		enabled|keys|pools|status_srv)
-			eval $option=$value
-			;;
-		_*)
-			[ "$value" = "0" ] || extra_args="$extra_args ${option//_/-}"
-			;;
-		*)
-			extra_args="$extra_args -${option//_/-}='$value'"
-			;;
-		esac
-	}
-
-	list_cb() {
-		local name="$1"
-		local value="$2"
-		[ "$name" = "_" ] && extra_args="$extra_args -${value//_/-}" || return 0
+		# Remove the leading underscore from the option name for backward
+		# compatibility
+		option="${option#_}"
+		eval $option="$value"
 	}
 }
 
 service_triggers() {
-	procd_add_reload_trigger "strelaysrv"
+	procd_add_reload_trigger 'strelaysrv'
 }
 
 start_service() {
-	local pools status_srv extra_args
-	# Options with default value different with the syncthing should be defined explicitly here
+	# Options with default value different with the syncthing should be defined
+	# explicitly here
 	local enabled=0
-	local keys="/etc/strelaysrv"
+	local debug=0
+	local ext_address=''
+	local global_rate=''
+	local keys='/etc/strelaysrv'
+	local listen=':22067'
+	local message_timeout=''
+	local nat=0
+	local nat_lease=''
+	local nat_renewal=''
+	local nat_timeout=''
+	local network_timeout=''
 	local nice=0
-	local user="syncthing"
+	local per_session_rate=''
+	local ping_interval=''
+	local pools=''
+	local pprof=0
+	local protocol=''
+	local provided_by=''
+	local status_srv=''
+	local token=''
+	local user='syncthing'
 
-	config_load "strelaysrv"
+	config_load 'strelaysrv'
 
 	[ "$enabled" -gt 0 ] || return 0
 
@@ -58,16 +63,32 @@ start_service() {
 
 	procd_open_instance
 	procd_set_param command "$PROG"
+	[ "$debug" -eq 0 ] || procd_append_param command -debug
+	[ -z "$ext_address" ] || procd_append_param command -ext-address="$ext_address"
+	[ -z "$global_rate" ] || procd_append_param command -global-rate="$global_rate"
 	procd_append_param command -keys="$keys"
-
-	# pools and status-srv are set to empty value by default
+	[ -z "$listen" ] || procd_append_param command -listen="$listen"
+	[ -z "$message_timeout" ] || procd_append_param command -message-timeout="$message_timeout"
+	[ "$nat" -eq 0 ] || procd_append_param command -nat
+	[ -z "$nat_lease" ] || procd_append_param command -nat-lease="$nat_lease"
+	[ -z "$nat_renewal" ] || procd_append_param command -nat-renewal="$nat_renewal"
+	[ -z "$nat_timeout" ] || procd_append_param command -nat-timeout="$nat_timeout"
+	[ -z "$network_timeout" ] || procd_append_param command -network-timeout="$network_timeout"
+	[ -z "$per_session_rate" ] || procd_append_param command -per-session-rate="$per_session_rate"
+	[ -z "$ping_interval" ] || procd_append_param command -ping-interval="$ping_interval"
+	# pools is set to an empty value by default
 	procd_append_param command -pools="$pools"
+	[ "$pprof" -eq 0 ] || procd_append_param command -pprof
+	[ -z "$protocol" ] || procd_append_param command -protocol="$protocol"
+	[ -z "$provided_by" ] || procd_append_param command -provided-by="$provided_by"
+	# status-srv is set to an empty value by default
 	procd_append_param command -status-srv="$status_srv"
-	[ -z "$extra_args" ] || procd_append_param command $extra_args
+	[ -z "$token" ] || procd_append_param command -token="$token"
 
 	procd_set_param nice "$nice"
 	procd_set_param term_timeout 15
 	procd_set_param user "$user"
+	procd_set_param group "$group"
 	procd_set_param respawn
 	procd_set_param stdout 1
 	procd_set_param stderr 1


### PR DESCRIPTION
**Maintainer:** @brvphoenix, me

**Description:**

I didn't properly test the argument handling in #27127 and there were issues both with discovery and relay services. This PR rewrites the logic to explicitly set each command line argument when necessary, changes the config format for boolean arguments, but handles them in backward-compatible manner.

Fixes: 47644ba ("syncthing: fix discovery and relay extra args")

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

Both services seem to be starting with all the configured arguments as expected this time around.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.