### PR TITLE
squashfs-tools: bump to version 4.7

### DIFF
--- a/utils/squashfs-tools/Makefile
+++ b/utils/squashfs-tools/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squashfs-tools
-PKG_VERSION:=4.6.1
+PKG_VERSION:=4.7
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0-only
@@ -18,7 +18,7 @@ PKG_CPE_ID:=cpe:/a:squashfs-tools_project:squashfs-tools
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/plougher/squashfs-tools/tar.gz/${PKG_VERSION}?
-PKG_HASH:=94201754b36121a9f022a190c75f718441df15402df32c2b520ca331a107511c
+PKG_HASH:=f1605ef720aa0b23939a49ef4491f6e734333ccc4bda4324d330da647e105328
 
 PKG_BUILD_PARALLEL:=1
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
This updates squashfs-tools to version 4.7

## 📦 Package Details

**Maintainer:** me

**Description:**

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master 
- **OpenWrt Target/Subtarget:** x86
- **OpenWrt Device:** x86 VM

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
