### PR TITLE
uspot: update to Git HEAD (2025-08-02)

### DIFF
--- a/net/uspot/Makefile
+++ b/net/uspot/Makefile
@@ -8,14 +8,16 @@ PKG_MAINTAINER:=Thibaut VARÈNE <hacks@slashdirt.org>
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/f00b4r0/uspot.git
-PKG_SOURCE_DATE:=2025-01-20
-PKG_SOURCE_VERSION:=644fd6f52a8e7b1a72e0937ad0d4cea8e86186a9
-PKG_MIRROR_HASH:=588bf718fc9a0576ec6d53c48b7298b3a719cbcbfc0fe15a9b1d01fc70d54ea1
+PKG_SOURCE_DATE:=2025-08-07
+PKG_SOURCE_VERSION:=8599a968877b55b0ce29f37d4b2d78036b257787
+PKG_MIRROR_HASH:=554da4ea779ea69c20ef424f7e880156d463e35240b5099ded8453c455d2f617
 
 CMAKE_SOURCE_SUBDIR:=src
+PKG_BUILD_DEPENDS:=bpf-headers
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
+include $(INCLUDE_DIR)/bpf.mk
 
 define Package/uspot
   SUBMENU:=Captive Portals
@@ -26,8 +28,8 @@ define Package/uspot
   DEPENDS:=+conntrack \
 	   +libblobmsg-json +liblucihttp-ucode +libradcli +libubox +libubus +libuci \
 	   +uspotfilter \
-	   +ucode +ucode-mod-log +ucode-mod-math +ucode-mod-nl80211 +ucode-mod-rtnl +uhttpd-mod-ucode +ucode-mod-uloop
-
+	   +ucode +ucode-mod-log +ucode-mod-math +ucode-mod-nl80211 +ucode-mod-rtnl +uhttpd-mod-ucode +ucode-mod-uloop \
+	   +ucode-mod-bpf +ucode-mod-struct +kmod-sched-core +kmod-sched-bpf $(BPF_DEPENDS)
 endef
 
 define Package/uspot/description
@@ -63,7 +65,7 @@ define Package/uspotfilter
   CATEGORY:=Network
   TITLE:=uspot firewall interface
   EXTRA_DEPENDS:=ucode (>= 2023.11.07)
-  DEPENDS:=+conntrack +nftables-json +ucode +ucode-mod-rtnl +ucode-mod-uloop
+  DEPENDS:=+conntrack +nftables-json +ucode +ucode-mod-rtnl +ucode-mod-uloop +ucode-mod-log
   PKGARCH:=all
 endef
 
@@ -72,11 +74,17 @@ define Package/uspotfilter/description
   It is compatible with firewall4.
 endef
 
+define Build/Compile
+	$(call CompileBPF,$(PKG_BUILD_DIR)/src/uspot-bpf.c)
+	$(call Build/Compile/Default,)
+endef
+
 define Package/uspot/install
-	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/share $(1)/usr/lib/ucode $(1)/etc/init.d $(1)/etc/config
+	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/share $(1)/usr/lib/ucode $(1)/etc/init.d $(1)/etc/config $(1)/lib/bpf
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/radius-client $(1)/usr/bin/radius-client
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/uspot-das $(1)/usr/bin/uspot-das
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/libuam.so $(1)/usr/lib/ucode/uam.so
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/src/uspot-bpf.o $(1)/lib/bpf/uspot.o
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/files/etc/config/uspot $(1)/etc/config/uspot
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/etc/init.d/uspot $(1)/etc/init.d/uspot
 	$(CP) $(PKG_BUILD_DIR)/files/usr/bin $(1)/usr/


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
**Description:** Update uspot to Git HEAD (2025-08-02)

Makefile edits related to introduction of an eBPF module and a missing dependency in uspotfilter.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master / 24.10
- **OpenWrt Target/Subtarget:** ath79/generic, ramips/mt7621, x86/64


Please cherry-pick to 24.10 once merged, thanks 🙏
I'll deal with 23.05 (due to non-cherry-pickable MIRROR_HASH)