### PR TITLE
kea: update to 2.6.4

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kea
-PKG_VERSION:=2.6.3
+PKG_VERSION:=2.6.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.isc.org/isc/kea/$(PKG_VERSION)
-PKG_HASH:=00241a5955ffd3d215a2c098c4527f9d7f4b203188b276f9a36250dd3d9dd612
+PKG_HASH:=6806405e4d559abc10febd2c273dc6e2bc6ac42767afa5ca20b118ffba84a671
 
 PKG_MAINTAINER:=BangLang Huang <banglang.huang@foxmail.com>, Rosy Song <rosysong@rosinson.com>
 PKG_LICENSE:=MPL-2.0

--- a/net/kea/files/kea.init
+++ b/net/kea/files/kea.init
@@ -29,7 +29,9 @@ start_kea() {
 			cnf="${CONF_PATH}/kea-${name}.conf"
 			;;
 		*)
-			return 0
+			echo "Error: Invalid service name '$name'" >&2
+			return 1
+			;;
 	esac
 
 	procd_open_instance "$name"


### PR DESCRIPTION
Upstream changelog:
https://downloads.isc.org/isc/kea/2.6.4/Kea-2.6.4-ReleaseNotes.txt

## 📦 Package Details

**Maintainer:** @pangpang, @rosysong

**Description:**
Update to 2.6.4

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r30792-d79bcc6b6a
- **OpenWrt Target/Subtarget:** qualcommax/ipq807x
- **OpenWrt Device:** Redmi AX6

It has been running well on my router for about a week.
Known issue: This program starts too early during boot. After the system starts, you must run service kea-dhcp4 restart for it to work properly.
For details, see: https://github.com/openwrt/packages/issues/26886

---

