### PR TITLE
ariang: bump to 1.3.11

### DIFF
--- a/net/ariang/Makefile
+++ b/net/ariang/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ariang
-PKG_VERSION:=1.3.10
+PKG_VERSION:=1.3.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
 PKG_SOURCE_URL:=https://github.com/mayswind/AriaNg/releases/download/$(PKG_VERSION)
-PKG_HASH:=5b76f02ff208b8c948bf8b614511687b7e6d1562323b29494528d89c032fe086
+PKG_HASH:=deaaebaf8d59901f0fbdb839daceb1f2768b3d65425e393202786fa2c804bcf9
 UNPACK_CMD=unzip -q -d $(1) $(DL_DIR)/$(PKG_SOURCE)
 
 PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>


### PR DESCRIPTION
Maintainer: @Ansuel 

## Description:

ariang: bump to 1.3.11

Change log is available at https://github.com/mayswind/AriaNg/releases/tag/1.3.11


## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** aarch64/qualcommax
- **OpenWrt Device:** ipq6000-360v6

<img width="1440" height="813" alt="Snipaste_2025-08-08_15-22-59" src="https://github.com/user-attachments/assets/205b071c-9351-4c01-b481-4c1377058494" />


