### PR TITLE
frp: bump to 0.63.0

### DIFF
--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=frp
-PKG_VERSION:=0.51.3
+PKG_VERSION:=0.63.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=83032399773901348c660d41c967530e794ab58172ccd070db89d5e50d915fef
+PKG_HASH:=e5269cf3d545a90fe3773dd39abe6eb8511f02c1dc0cdf759a65d1e776dc1520
 
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -26,7 +26,8 @@ define Package/frp/install
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/$(2) $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/etc/frp/$(2).d/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/conf/$(2)_full.ini $(1)/etc/frp/$(2).d/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/conf/legacy/$(2)_legacy_full.ini $(1)/etc/frp/$(2).d/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/conf/$(2)_full_example.toml $(1)/etc/frp/$(2).d/
 	$(INSTALL_DIR) $(1)/etc/config/
 	$(INSTALL_CONF) ./files/$(2).config $(1)/etc/config/$(2)
 	$(INSTALL_DIR) $(1)/etc/init.d/


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @ysc3839 Richard Yu <yurichard3839@gmail.com>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**

Change log is available at https://github.com/fatedier/frp/compare/v0.51.3...v0.63.0

The configuration file has changed in the new version, but the old configuration file is still applicable. 
If new features need to be added, modifications to LuCI are also required.​

Thanks, @Siwind !​​ https://github.com/openwrt/packages/pull/26772

---

## 🧪 Run Testing Details

- **OpenWrt Version:** main/snapshot
- **OpenWrt Target/Subtarget:** aarch64/qualcommax
- **OpenWrt Device:** ipq6000-360v6

<img width="1440" height="813" alt="Snipaste_2025-08-09_08-38-22" src="https://github.com/user-attachments/assets/b99fb3a1-750a-4b29-bd21-7320494e175c" />
<img width="1440" height="813" alt="Snipaste_2025-08-09_08-38-53" src="https://github.com/user-attachments/assets/d956a792-ecc5-463f-9e58-113d03731e06" />


---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
