### PR TITLE
docker-compose: Update to version 2.39.2

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=2.39.1
+PKG_VERSION:=2.39.2
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=35287aff54d826241fb727b3024b1cb46849770ac8dd166f0702f8aa2b5f7e30
+PKG_HASH:=3d082806391381310ba509a106dafa01c435b86b15818de541afe9d6c68a1cee
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
New upstream release. [Changelog](https://github.com/docker/compose/releases/tag/v2.39.2)
---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** x86/64
---
