### PR TITLE
ccrypt: fix compilation with gcc15

### DIFF
--- a/utils/ccrypt/Makefile
+++ b/utils/ccrypt/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ccrypt
 PKG_VERSION:=1.11
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/ccrypt
@@ -31,6 +31,8 @@ define Package/ccrypt
 endef
 
 CONFIGURE_ARGS += --disable-emacs
+
+EXTRA_CFLAGS += -std=c17
 
 define Package/ccrypt/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION


## 📦 Package Details

**Maintainer:** @hnyman

**Description:**
gcc15 is using iso9899:2024 by default. ccrypt fails to compile with it.
--> use previous standard "-std=c17" instead.
Ref.: https://github.com/openwrt/packages/issues/27112

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** qualcommax/ipq807x
- **OpenWrt Device:** Zyxel NBG7815

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
