### PR TITLE
python3: fix host uuid and ncurses

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -312,6 +312,11 @@ HOST_CONFIGURE_ARGS += \
 	--with-system-expat \
 	--without-cxx-main
 
+# ncurses and uuid have seemingly unsolvable issues with pkgconfig
+HOST_CFLAGS += \
+	-I$(STAGING_DIR_HOSTPKG)/include/ncursesw \
+	-I$(STAGING_DIR_HOST)/include/uuid
+
 define Host/Configure
 	$(SED) 's/^ENABLE_USER_SITE = None$$$$/ENABLE_USER_SITE = False/' $(HOST_BUILD_DIR)/Lib/site.py
 	$(call Host/Configure/Default)

--- a/lang/python/python3/patches/020-uuid.patch
+++ b/lang/python/python3/patches/020-uuid.patch
@@ -1,0 +1,35 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -3438,10 +3438,6 @@ AS_VAR_IF([have_uuid], [missing], [
+             AC_DEFINE([HAVE_UUID_GENERATE_TIME_SAFE], [1])
+           ])
+         ])
+-        AS_VAR_IF([have_uuid], [yes], [
+-          LIBUUID_CFLAGS=${LIBUUID_CFLAGS-""}
+-          LIBUUID_LIBS=${LIBUUID_LIBS-"-luuid"}
+-        ])
+       ])
+     ]
+   )
+@@ -3452,8 +3448,8 @@ AS_VAR_IF([have_uuid], [missing], [
+   AC_CHECK_HEADERS([uuid/uuid.h], [
+     AC_CHECK_FUNC([uuid_generate_time], [
+       have_uuid=yes
+-      LIBUUID_CFLAGS=${LIBUUID_CFLAGS-""}
+-      LIBUUID_LIBS=${LIBUUID_LIBS-""}
++      LIBUUID_CFLAGS=${LIBUUID_CFLAGS:""}
++      LIBUUID_LIBS=${LIBUUID_LIBS:""}
+     ])
+   ])
+ ])
+--- a/setup.py
++++ b/setup.py
+@@ -1118,8 +1118,6 @@ class PyBuildExt(build_ext):
+         panel_library = 'panel'
+         if curses_library == 'ncursesw':
+             curses_defines.append(('HAVE_NCURSESW', '1'))
+-            if not CROSS_COMPILING:
+-                curses_includes.append('/usr/include/ncursesw')
+             # Bug 1464056: If _curses.so links with ncursesw,
+             # _curses_panel.so must link with panelw.
+             panel_library = 'panelw'


### PR DESCRIPTION
pkgconfig doesn't work correct for these two packages. Just readd the proper paths.

## 📦 Package Details

**Maintainer:** @jefferyto 