### PR TITLE
rsyslog: update to 8.2506.0

### DIFF
--- a/admin/rsyslog/Makefile
+++ b/admin/rsyslog/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsyslog
-PKG_VERSION:=8.2408.0
+PKG_VERSION:=8.2506.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	https://fossies.org/linux/misc \
 	https://www.rsyslog.com/files/download/rsyslog
-PKG_HASH:=8bb2f15f9bf9bb7e635182e3d3e370bfc39d08bf35a367dce9714e186f787206
+PKG_HASH:=6d6fd0257c95e756765d4d585a833d54dd3a0e5eeb8308b862a81b368a74bb7b
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
Fixes compilation with GCC15.

## 📦 Package Details

**Maintainer:** none