### PR TITLE
lua-argparse: bump to luarocks' 0.7.1

### DIFF
--- a/lang/lua-argparse/Makefile
+++ b/lang/lua-argparse/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lua-argparse
-PKG_VERSION:=0.6.0
+PKG_VERSION:=0.7.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/mpeterv/argparse/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=0eddda29d591536bc7310b99ce7acc3e5e00557f18d6e63ab10d56683e8952f1
+PKG_SOURCE_URL:=https://codeload.github.com/luarocks/argparse/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=d344e49404c3e7b3e7fa4fe6741c106f25909d9b24923cb08dcceda1f9754809
 PKG_BUILD_DIR:=$(BUILD_DIR)/argparse-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Vladimir Malyutin <first-leon@yandex.ru>


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @first-leon

**Description:**

Bump lua-argparse to the [luarocks argparse](https://github.com/luarocks/argparse) 0.7.1 release.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** `HEAD`
- **OpenWrt Target/Subtarget:** `octeon`
- **OpenWrt Device:** Ubiquti ERPro-8

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.