### PR TITLE
isc-dhcp: fix build issues with stricter compilers

### DIFF
--- a/net/isc-dhcp/Makefile
+++ b/net/isc-dhcp/Makefile
@@ -11,7 +11,7 @@ PKG_NAME:=isc-dhcp
 UPSTREAM_NAME:=dhcp
 PKG_REALVERSION:=4.4.3-P1
 PKG_VERSION:=4.4.3_p1
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -189,6 +189,9 @@ ifeq ($(BUILD_VARIANT),ipv6)
 endif
 
 TARGET_CFLAGS += -fcommon
+
+# don't know why anyone is still publishing K&R-style C code
+TARGET_CFLAGS += -Wno-old-style-definition
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR)			\

--- a/net/isc-dhcp/patches/910-incompatible-pointers.patch
+++ b/net/isc-dhcp/patches/910-incompatible-pointers.patch
@@ -1,0 +1,45 @@
+--- a/server/dhcpv6.c
++++ b/server/dhcpv6.c
+@@ -5843,14 +5843,29 @@ exit:
+ 	option_state_dereference(&host_opt_state, MDL);
+ }
+ 
++typedef void ia_na_match_t(
++	const struct data_string *client_id,
++	const struct data_string *iaaddr,
++	struct iasubopt *lease
++	);
++
++typedef void ia_na_nomatch_t(
++	const struct data_string *client_id,
++	const struct data_string *iaaddr,
++	u_int32_t *data,
++	struct packet *packet,
++	char *reply_data,
++	int *reply_ofs,
++	int reply_data_sz);
++
+ static void
+ iterate_over_ia_na(struct data_string *reply_ret,
+ 		   struct packet *packet,
+ 		   const struct data_string *client_id,
+ 		   const struct data_string *server_id,
+ 		   const char *packet_type,
+-		   void (*ia_na_match)(),
+-		   void (*ia_na_nomatch)())
++		   ia_na_match_t ia_na_match,
++		   ia_na_nomatch_t ia_na_nomatch)
+ {
+ 	struct option_state *opt_state;
+ 	struct host_decl *packet_host;
+@@ -6351,8 +6366,8 @@ iterate_over_ia_pd(struct data_string *r
+ 		   const struct data_string *client_id,
+ 		   const struct data_string *server_id,
+ 		   const char *packet_type,
+-		   void (*ia_pd_match)(),
+-		   void (*ia_pd_nomatch)())
++		   ia_na_match_t ia_pd_match,
++		   ia_na_nomatch_t ia_pd_nomatch)
+ {
+ 	struct data_string reply_new;
+ 	int reply_len;


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**
me

**Description:**
The new gcc in the toolchain is failing K&R style prototypes. There are also some function pointers passed as parameters that didn't have prototypes so were causing incompatible pointer clashes.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
HEAD
- **OpenWrt Target/Subtarget:**
x86_64/generic
- **OpenWrt Device:**
Supermicro SYS-D5018-FN4T
---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
- [X] It is structured in a way that it is potentially upstreamable

