### PR TITLE
fx: update to 39.0.1

### DIFF
--- a/utils/fx/Makefile
+++ b/utils/fx/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fx
-PKG_VERSION:=36.0.3
+PKG_VERSION:=39.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/antonmedv/fx/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=1159bc6b556d39843f7e786b06ad8918e4d1a6e64f21539598d3a72dbbc9b1c7
+PKG_HASH:=0ddbef45762a3a2b4b13afb03093139121422b6f73aecbf2b6655598bd98575f
 
 PKG_MAINTAINER:=Fabian Lipken <dynasticorpheus@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: @dynasticorpheus 
Compile tested: Ubuntu 23.04 x64 / OpenWrt SNAPSHOT @ https://github.com/openwrt/packages/commit/36b1dd75fd9da1ea13f1ce1ee679c6b3c9c402cc
Run tested: Linksys WRT32X / OpenWrt SNAPSHOT r24315-ae500e62e2

Description: Update to [39.0.1](https://github.com/antonmedv/fx/compare/36.0.3...39.0.1)

Fx is a dual-purpose command-line tool tailored for JSON, providing both a terminal-based JSON viewer and a JSON processing utility.
