### PR TITLE
[openwrt-23.05] strongswan: fix build with wolfssl 5.7.6

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.9.11
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/patches/0010-wolfssl-Don-t-undef-PARSE_ERROR-as-headers-included-later.patch
+++ b/net/strongswan/patches/0010-wolfssl-Don-t-undef-PARSE_ERROR-as-headers-included-later.patch
@@ -1,0 +1,21 @@
+From 60336ceecbd1cda73aa26dd44cfdaf2e31a046e1 Mon Sep 17 00:00:00 2001
+From: Tobias Brunner <tobias@strongswan.org>
+Date: Fri, 4 Oct 2024 11:23:28 +0200
+Subject: [PATCH] wolfssl: Don't undef PARSE_ERROR as headers included later
+ might refer to it
+
+---
+ src/libstrongswan/plugins/wolfssl/wolfssl_common.h | 2 --
+ 1 file changed, 2 deletions(-)
+
+--- a/src/libstrongswan/plugins/wolfssl/wolfssl_common.h
++++ b/src/libstrongswan/plugins/wolfssl/wolfssl_common.h
+@@ -78,8 +78,6 @@ typedef union {
+ } wolfssl_ed_key;
+ #endif /* HAVE_ED25519 || HAVE_ED448 */
+ 
+-#undef PARSE_ERROR
+-
+ /* Eliminate macro conflicts */
+ #undef RNG
+ 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @pprindeville @Thermi

**Description:**
Backport an upstream patch to fix build with wolfssl 5.7.6.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 23.05 snapshot
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** none

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable