### PR TITLE
NUT: Fix typo in nut-monitor.init

### DIFF
--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -90,7 +90,7 @@ nut_upsmon_conf() {
 	{
 		echo "NOTIFYFLAG ONLINE $(setnotify "$cfg" onlinenotify)" ; \
 		echo "NOTIFYFLAG ONBATT $(setnotify "$cfg" onbattnotify)" ; \
-		echo "NOTIFYFLAG LOWBATT $(setnotify "$cfg" lowbatnotify)" ; \
+		echo "NOTIFYFLAG LOWBATT $(setnotify "$cfg" lowbattnotify)" ; \
 		echo "NOTIFYFLAG FSD $(setnotify "$cfg" fsdnotify)" ; \
 		echo "NOTIFYFLAG COMMOK $(setnotify "$cfg" commoknotify)" ; \
 		echo "NOTIFYFLAG COMMBAD $(setnotify "$cfg" commbadnotify)" ; \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jp-bennett 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

lowbattnotify was misspelled as lowbatnotify and resulted in a configuration error when transferring /etc/config/nut_monitor values to /var/etc/nut/upsmon.conf
---

## 🧪 Run Testing Details

- **OpenWrt Version: 24.10.2
- **OpenWrt Target/Subtarget: mvebu
- **OpenWrt Device: wrt3200

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
