### PR TITLE
packages/net-snmp: fix typo

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -52,7 +52,7 @@ define Package/libnetsnmp-nossl
   VARIANT:=nossl
   PROVIDES:=libnetsnmp
   DEFAULT_VARIANT:=1
-  CONFILTS:=libnetsnmp-ssl
+  CONFLICTS:=libnetsnmp-ssl
 endef
 
 define Package/libnetsnmp-nossl/description


### PR DESCRIPTION
CONFILTS is changed to CONFLICTS to enable condition.

## 📦 Package Details

**Maintainer:** @stintel 

**Description:**
CONFILTS seems to be a typo and is changed to CONFLICTS

## 🧪 Run Testing Details

- **OpenWrt Version:** openwrt-24.10
- **OpenWrt Target/Subtarget:** x86/64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
