### PR TITLE
coova-chilli: fix compilation with GCC15

### DIFF
--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coova-chilli
 PKG_VERSION:=1.6
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/coova/coova-chilli/tar.gz/$(PKG_VERSION)?

--- a/net/coova-chilli/patches/040-gcc15.patch
+++ b/net/coova-chilli/patches/040-gcc15.patch
@@ -1,0 +1,22 @@
+--- a/src/chilli.c
++++ b/src/chilli.c
+@@ -7867,7 +7867,7 @@ int chilli_main(int argc, char **argv) {
+      */
+ 
+ #ifdef ENABLE_CHILLIQUERY
+-    cmdsock_shutdown();
++    cmdsock_shutdown(cmdsock);
+ #endif
+ 
+ #ifdef ENABLE_CHILLIREDIR
+--- a/src/chilli.h
++++ b/src/chilli.h
+@@ -266,7 +266,7 @@ int cmdsock_init(void);
+ 
+ int cmdsock_port_init(void);
+ 
+-void cmdsock_shutdown();
++void cmdsock_shutdown(int s);
+ 
+ time_t mainclock_tick(void);
+ time_t mainclock_now(void);


### PR DESCRIPTION
No idea how this even worked. cmdsock never got closed.

## 📦 Package Details

**Maintainer:** @teslamint 

ping @nasbdh9

Fixes: https://github.com/openwrt/packages/issues/26903