### PR TITLE
python-certifi: assign PKG_CPE_ID & update to 2025.8.3

### DIFF
--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
-PKG_VERSION:=2024.2.2
-PKG_RELEASE:=2
+PKG_VERSION:=2025.8.3
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=MPL-2.0
@@ -15,7 +15,7 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:certifi:certifi
 
 PYPI_NAME:=certifi
-PKG_HASH:=0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f
+PKG_HASH:=e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407
 
 HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-wheel/host
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @cotequeiroz

**Description:**
Assign PKG_CPE_ID to python-certifi and update the package to version 2025.8.3.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 23.05
- **OpenWrt Target/Subtarget:** NXP i.MX/NXP i.MX8 boards
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.