### PR TITLE
nginx: update CPE ID

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=69ee2b237744036e61d24b836668aad3040dda461fe6f570f1787eab570c75aa
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de> \
 				Christian Marangi <ansuelsmth@gmail.com>
 PKG_LICENSE:=2-clause BSD-like license
-PKG_CPE_ID:=cpe:/a:nginx:nginx
+PKG_CPE_ID:=cpe:/a:f5:nginx_open_source
 
 PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @Ansuel

**Description:**

Looking at the official CPE dictionary [1], `cpe:/a:nginx:nginx` was only used until 1.21.4 inclusively. Later it was renamed to `cpe:/a:f5:nginx`, and it showed up in a few more non-contiguous versions numbers after 1.21.4.

In all nginx security advisories [2] starting from year 2024, the CPE ID used is `cpe:/a:f5:nginx_open_source`. This includes versions 1.25.0 and newer.

Update the CPE ID to the newest known value of `cpe:/a:f5:nginx_open_source` used in nginx's own security advirosies/CVEs.

[1]: https://nvd.nist.gov/products/cpe
[2]: https://nginx.org/en/security_advisories.html

This should be applied to OpenWrt 24.10 (nginx 1.26.1) and 23.05 (nginx 1.25.0) as well, so that generated SBOMs would contain the correct CPE ID for those nginx versions.

---

## 🧪 Run Testing Details

Only changes metadata in the Makefile, namely the CPE ID, thus should not in any way affect compilation/execution.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.