### PR TITLE
krb5: update to 1.22

### DIFF
--- a/net/krb5/Makefile
+++ b/net/krb5/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=krb5
-PKG_VERSION:=1.21.3
-PKG_RELEASE:=2
+PKG_VERSION:=1.22
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -18,8 +18,8 @@ PKG_LICENSE_FILES:=NOTICE
 PKG_CPE_ID:=cpe:/a:mit:kerberos_5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://web.mit.edu/kerberos/dist/krb5/1.21
-PKG_HASH:=b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35
+PKG_SOURCE_URL:=https://web.mit.edu/kerberos/dist/krb5/1.22
+PKG_HASH:=652be617b4647f3c5dcac21547d47c7097101aad4e306f1778fb48e17b220ba3
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1

--- a/net/krb5/patches/0001-do-not-set-root-as-owner.patch
+++ b/net/krb5/patches/0001-do-not-set-root-as-owner.patch
@@ -1,0 +1,30 @@
+The krb5 build process tries to install the setuid-bit program ksu such
+that it is owned by root. This fails when the build executes as a normal
+user, which is usually the case when building OpenWrt. This patch fixes
+this. Here is the symptom:
+
+making install in clients/ksu...
+make[6]: Entering directory '.../build_dir/target-x86_64_musl/krb5-1.22/src/clients/ksu'
+for f in ksu; do \
+  .../staging_dir/host/bin/ginstall -c  -m 4755 -o root $f \
+        .../build_dir/target-x86_64_musl/krb5-1.22/ipkg-install/usr/bin/`echo $f|sed 's&$&&;s&^&&'`; \
+done
+ginstall: invalid user 'root'
+make[6]: [Makefile:640: install] Error 1 (ignored)
+
+As of publication, Fedora applies a similar
+patch for the same reason. Their patch, which can be
+found in the repository for their krb5 package, is named
+0010-downstream-Do-not-set-root-as-ksu-file-owner.patch.
+
+--- a/src/config/pre.in
++++ b/src/config/pre.in
+@@ -185,7 +185,7 @@ INSTALL_PROGRAM=@INSTALL_PROGRAM@ $(INST
+ INSTALL_SCRIPT=@INSTALL_PROGRAM@
+ INSTALL_DATA=@INSTALL_DATA@
+ INSTALL_SHLIB=@INSTALL_SHLIB@
+-INSTALL_SETUID=$(INSTALL) $(INSTALL_STRIP) -m 4755 -o root
++INSTALL_SETUID=$(INSTALL) $(INSTALL_STRIP) -m 4755
+ ## This is needed because autoconf will sometimes define @exec_prefix@ to be
+ ## ${prefix}.
+ prefix=@prefix@


### PR DESCRIPTION
Upstream list of changes is available at
https://web.mit.edu/kerberos/krb5-1.22/krb5-1.22.html.

Of note is that this release fixes the build with GCC 15.1.  As with other recent versions, GCC 15.1 transforms some warnings into errors, and this release remediates those warnings, now errors.

## 📦 Package Details

**Maintainer:** me

**Description:**
Includes patch not meant for upstream.


---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** Generic PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.