### PR TITLE
ufp: add ubus_rpc_session to call arguments

### DIFF
--- a/utils/ufp/patches/0001-add-ubus-rpc-session-to-ufp.patch
+++ b/utils/ufp/patches/0001-add-ubus-rpc-session-to-ufp.patch
@@ -1,0 +1,10 @@
+--- a/ufpd
++++ b/ufpd
+@@ -363,6 +363,7 @@ global.ubus_object = {
+ 	fingerprint: {
+ 		args: {
+ 			macaddr: "",
++			ubus_rpc_session: "",
+ 			weight: false,
+ 			local: false
+ 		},


### PR DESCRIPTION
To display vendor information via ubus call in uhttpd, it is necessary to add `ubus_rpc_session` as argument to fingerprint.

Fixes:#27124

## 📦 Package Details

**Maintainer:** @blogic 

**Description:**

---

## 🧪 Run Testing Details

- **OpenWrt Version:** owrt-24.10
- **OpenWrt Target/Subtarget:** x86/64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
- [x] It is structured in a way that it is potentially upstreamable
