### PR TITLE
lighttpd: update to lighttpd 1.4.81 release hash

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
-PKG_VERSION:=1.4.79
+PKG_VERSION:=1.4.81
 PKG_RELEASE:=1
 # release candidate ~rcX testing; remove for release
 #PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x
-PKG_HASH:=3b29a625b3ad88702d1fea4f5f42bb7d87488f2e4efc977d7f185329ca6084bd
+PKG_HASH:=d7d42c3fd2fd94b63c915aa7d18f4da3cac5937ddba33e909f81cf50842a5840
 
 PKG_MAINTAINER:=Glenn Strauss <gstrauss@gluelogic.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/lighttpd/patches/020-meson-mod_webdav_min.patch
+++ b/net/lighttpd/patches/020-meson-mod_webdav_min.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] [meson] mod_webdav_min w/o deps: xml2 sqlite3 uuid
 
 --- a/src/meson.build
 +++ b/src/meson.build
-@@ -887,6 +887,16 @@ if (host_machine.system() == 'darwin')
+@@ -908,6 +908,16 @@ if (host_machine.system() == 'darwin')
  	plugin_suffix = 'so'  # use "so" instead of "dylib"
  endif
  


### PR DESCRIPTION
## 📦 Package Details

Maintainer: @gstrauss
Compile tested: arm_cortex-a9 OpenWrt master

Description:
lighttpd: update to lighttpd 1.4.80 release hash

Release notes:
https://www.lighttpd.net/2025/8/17/1.4.81/

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>