### PR TITLE
lxc: update to 6.0.5

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
-PKG_VERSION:=6.0.4
+PKG_VERSION:=6.0.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/
-PKG_HASH:=872d26ce8512b9f993d194816e336bf9f3ad8326f22dc24ef0f01f85599fa8b9
+PKG_HASH:=2e540c60b9dd49e7ee1a4efa5e9c743b05df911b81b375ed5043d9dd7ee0b48a
 
 PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later BSD-2-Clause GPL-2.0

--- a/utils/lxc/patches/030-start-re-introduce-first-SET_DUMPABLE-call.patch
+++ b/utils/lxc/patches/030-start-re-introduce-first-SET_DUMPABLE-call.patch
@@ -15,8 +15,8 @@ Signed-off-by: Stéphane Graber <stgraber@stgraber.org>
 
 --- a/src/lxc/start.c
 +++ b/src/lxc/start.c
-@@ -1125,6 +1125,11 @@ static int do_start(void *data)
- 		if (!lxc_switch_uid_gid(nsuid, nsgid))
+@@ -1130,6 +1130,11 @@ static int do_start(void *data)
+ 		if (ret < 0)
  			goto out_warn_father;
  
 +		ret = prctl(PR_SET_DUMPABLE, prctl_arg(1), prctl_arg(0),


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @ratkaj 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

6.0.5 is a bug fix release, see:
https://discuss.linuxcontainers.org/t/lxc-6-0-5-lts-has-been-released/24438

Full changelog: https://github.com/lxc/lxc/compare/v6.0.4...v6.0.5

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc (Intel N150 based box)

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:**  x86/64-glibc
- **OpenWrt Device:** Intel N150 based PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
