### PR TITLE
[24.10] yt-dlp: bump to 2025.08.11

### DIFF
--- a/multimedia/yt-dlp/Makefile
+++ b/multimedia/yt-dlp/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yt-dlp
-PKG_VERSION:=2025.7.21
+PKG_VERSION:=2025.8.11
 PKG_RELEASE:=1
 
 PYPI_NAME:=yt-dlp
-PKG_HASH:=46fbb53eab1afbe184c45b4c17e9a6eba614be680e4c09de58b782629d0d7f43
+PKG_HASH:=dc7c120a367fe55e0f711613dc80ea29d3a4e0ed8d66104cebfbe3d36e81fdfc
 PYPI_SOURCE_NAME:=yt_dlp
 
 PKG_MAINTAINER:=George Sapkin <george@sapk.in>


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Backport #27240 to 24.10.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.0
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.