### PR TITLE
[23.05] glib2: address CVE-2024-52533

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.74.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/$(basename $(PKG_VERSION))

--- a/libs/glib2/patches/021-CVE-2024-52533.patch
+++ b/libs/glib2/patches/021-CVE-2024-52533.patch
@@ -1,0 +1,34 @@
+From: Michael Catanzaro <mcatanzaro@redhat.com>
+Date: Thu, 19 Sep 2024 18:35:53 +0100
+Subject: [PATCH] gsocks4aproxy: Fix a single byte buffer overflow in connect
+ messages
+
+`SOCKS4_CONN_MSG_LEN` failed to account for the length of the final nul
+byte in the connect message, which is an addition in SOCKSv4a vs
+SOCKSv4.
+
+This means that the buffer for building and transmitting the connect
+message could be overflowed if the username and hostname are both
+`SOCKS4_MAX_LEN` (255) bytes long.
+
+Proxy configurations are normally statically configured, so the username
+is very unlikely to be near its maximum length, and hence this overflow
+is unlikely to be triggered in practice.
+
+(Commit message by Philip Withnall, diagnosis and fix by Michael
+Catanzaro.)
+
+--- a/gio/gsocks4aproxy.c
++++ b/gio/gsocks4aproxy.c
+@@ -79,9 +79,9 @@ g_socks4a_proxy_init (GSocks4aProxy *pro
+  * +----+----+----+----+----+----+----+----+----+----+....+----+------+....+------+
+  * | VN | CD | DSTPORT |      DSTIP        | USERID       |NULL| HOST |    | NULL |
+  * +----+----+----+----+----+----+----+----+----+----+....+----+------+....+------+
+- *    1    1      2              4           variable       1    variable
++ *    1    1      2              4           variable       1    variable    1
+  */
+-#define SOCKS4_CONN_MSG_LEN	    (9 + SOCKS4_MAX_LEN * 2)
++#define SOCKS4_CONN_MSG_LEN	    (10 + SOCKS4_MAX_LEN * 2)
+ static gint
+ set_connect_msg (guint8      *msg,
+ 		 const gchar *hostname,


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @peter-wagner

**Description:**
Address CVE-2024-52533.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 23.05
- **OpenWrt Target/Subtarget:** NXP i.MX/NXP i.MX8 boards
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>