### PR TITLE
go2rtc: jail service, add uci config

### DIFF
--- a/multimedia/go2rtc/Makefile
+++ b/multimedia/go2rtc/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=go2rtc
 PKG_VERSION:=1.9.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AlexxIT/go2rtc/tar.gz/v$(PKG_VERSION)?
@@ -37,6 +37,7 @@ endef
 
 define Package/go2rtc/conffiles
 /etc/go2rtc.yaml
+/etc/config/go2rtc
 endef
 
 define Package/go2rtc/install
@@ -46,6 +47,10 @@ define Package/go2rtc/install
 	$(INSTALL_CONF) $(CURDIR)/files/go2rtc.yaml $(1)/etc/go2rtc.yaml
 	$(INSTALL_DIR) $(1)/etc/init.d/
 	$(INSTALL_BIN) $(CURDIR)/files/go2rtc.init $(1)/etc/init.d/go2rtc
+	$(INSTALL_DIR) $(1)/etc/capabilities/
+	$(INSTALL_DATA) $(CURDIR)/files/go2rtc.json $(1)/etc/capabilities/go2rtc.json
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) $(CURDIR)/files/go2rtc.conf $(1)/etc/config/go2rtc
 endef
 
 $(eval $(call BuildPackage,go2rtc))

--- a/multimedia/go2rtc/files/go2rtc.conf
+++ b/multimedia/go2rtc/files/go2rtc.conf
@@ -1,0 +1,6 @@
+config daemon 'daemon'
+	option disable_jail         0
+	option user                 go2rtc
+	option group                go2rtc
+	option limit_nofile         ''
+    option allow_config_edit    0

--- a/multimedia/go2rtc/files/go2rtc.init
+++ b/multimedia/go2rtc/files/go2rtc.init
@@ -4,14 +4,54 @@ START=99
 
 USE_PROCD=1
 PROG=/usr/bin/go2rtc
-USER=go2rtc
-GROUP=go2rtc
+CONF=go2rtc
 
 start_service() {
+	local disable_jail
+	local user
+	local group
+	local limit_nofile
+	local allow_config_edit
+	local ycfg=/etc/go2rtc.yaml
+
+	config_load "$CONF"
+	config_get_bool disable_jail daemon disable_jail 0
+	config_get user daemon user go2rtc
+	config_get group daemon group go2rtc
+	config_get limit_nofile daemon limit_nofile ''
+	config_get_bool allow_config_edit daemon allow_config_edit 0
+
+	chown "$user:$group" "$ycfg"
+	if [[ "$allow_config_edit" -ne 0 ]]; then
+		chmod 640 "$ycfg"
+	else
+		chmod 440 "$ycfg"
+	fi
+
 	procd_open_instance
-	procd_set_param command "$PROG" -config /etc/go2rtc.yaml
-	procd_set_param user "$USER"
-	procd_set_param group "$GROUP"
+	procd_set_param command "$PROG" -config "$ycfg"
+	procd_set_param user "$user"
+	procd_set_param group "$group"
 	procd_set_param respawn
+	procd_set_param capabilities "/etc/capabilities/go2rtc.json"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+
+	[[ -n "$limit_nofile" ]] && procd_append_param limits nofile="$limit_nofile"
+
+	if [[ "$disable_jail" -eq 0 ]]; then
+		procd_add_jail go2rtc log
+
+		procd_add_jail_mount /etc/TZ
+		procd_add_jail_mount /etc/ssl/certs
+		procd_add_jail_mount /usr/bin/ffmpeg
+
+		if [[ "$allow_config_edit" -ne 0 ]]; then
+			procd_add_jail_mount_rw "$ycfg"
+		else
+			procd_add_jail_mount "$ycfg"
+		fi
+	fi
+
 	procd_close_instance
 }

--- a/multimedia/go2rtc/files/go2rtc.json
+++ b/multimedia/go2rtc/files/go2rtc.json
@@ -1,0 +1,17 @@
+{
+	"bounding": [
+		"CAP_NET_BIND_SERVICE"
+	],
+	"effective": [
+		"CAP_NET_BIND_SERVICE"
+	],
+	"ambient": [
+		"CAP_NET_BIND_SERVICE"
+	],
+	"permitted": [
+		"CAP_NET_BIND_SERVICE"
+	],
+	"inheritable": [
+		"CAP_NET_BIND_SERVICE"
+	]
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @vooon 

**Description:**

- Add UCI configuration to be able to switch user/group and set ulimit.
- Place daemon into jail by default, to allow bind on lower ports, such as 554 (RTSP)
- Add option to allow or deny config.yaml editing from the web interface.
- Connect stdout/err to log

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
