### PR TITLE
[24.10] python-urllib3: update to 2.0.7

### DIFF
--- a/lang/python/python-urllib3/Makefile
+++ b/lang/python/python-urllib3/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-urllib3
-PKG_VERSION:=2.0.4
-PKG_RELEASE:=2
+PKG_VERSION:=2.0.7
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
@@ -17,7 +17,7 @@ PKG_LICENSE_FILES:=LICENSE.txt
 PKG_CPE_ID:=cpe:/a:python:urllib3
 
 PYPI_NAME:=urllib3
-PKG_HASH:=8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11
+PKG_HASH:=c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84
 
 PKG_BUILD_DEPENDS:=python-hatchling/host
 HOST_BUILD_DEPENDS:=python-hatchling/host


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @BKPepe

**Description:**
Update python-urllib3 to version 2.0.7.  
This fixes CVE-2023-45803 and CVE-2023-43804.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 23.05
- **OpenWrt Target/Subtarget:** NXP i.MX/NXP i.MX8 boards
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.