### PR TITLE
frp: Remove myself as maintainer

### DIFF
--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -8,7 +8,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v${PKG_VERSION}?
 PKG_HASH:=c755c0aaeec3999cb259a312f3327db205a834abf0beeb6410dcdc818d9719a4
 
-PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
+PKG_MAINTAINER:=
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
frp is using a new config format, the old INI format is deprecated.
The new config format is using TOML and all option names are changed.
A complete rewrite is required to support new config format.

I have replace frp with WireGuard+firewall forwarding some years ago.

Now I have no time and no test environment to maintain these packages.
So remove myself as maintainer.

---

## 🧪 Run Testing Details

N/A

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
