### PR TITLE
boost: Updates package to version 1.89.0

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -11,13 +11,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=boost
-PKG_VERSION:=1.88.0
-PKG_SOURCE_VERSION:=1_88_0
+PKG_VERSION:=1.89.0
+PKG_SOURCE_VERSION:=1_89_0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://boostorg.jfrog.io/artifactory/main/release/$(PKG_VERSION)/source/
-PKG_HASH:=46d9d2c06637b219270877c9e16155cbd015b6dc84349af064c088e9b5b12f7b
+PKG_HASH:=85a33fa22621b4f314f8e85e1a5e2a9363d22e4f4992925d4bb3bc631b5a0c7a
 
 PKG_MAINTAINER:=Carlos M. Ferreira <carlosmf.pt@gmail.com>
 PKG_LICENSE:=BSL-1.0
@@ -42,7 +42,7 @@ define Package/boost/Default
 endef
 
 define Package/boost/description
-This package provides the Boost v1.88.0 libraries.
+This package provides the Boost v1.89.0 libraries.
 Boost is a set of free, peer-reviewed, portable C++ source libraries.
 
 This package provides the following run-time libraries:
@@ -72,7 +72,6 @@ This package provides the following run-time libraries:
  - regex
  - serialization and wserialization
  - stackstrace
- - system
  - thread
  - timer
  - type_erasure
@@ -80,7 +79,7 @@ This package provides the following run-time libraries:
  - wave
 
 There are many more header-only libraries supported by Boost.
-See more at http://www.boost.org/doc/libs/1_88_0/
+See more at http://www.boost.org/doc/libs/1_89_0/
 endef
 
 PKG_BUILD_DEPENDS:=boost/host
@@ -298,7 +297,7 @@ define Package/boost-test
 	$(call Package/boost/Default)
 	TITLE+= (test)
 	HIDDEN:=1
-	DEPENDS+=+boost-system +boost-timer
+	DEPENDS+=+boost-timer
 endef
 
 define Build/Configure
@@ -336,38 +335,37 @@ define DefineBoostLibrary
   endef
 endef
 
-$(eval $(call DefineBoostLibrary,atomic,system))
+$(eval $(call DefineBoostLibrary,atomic))
 $(eval $(call DefineBoostLibrary,charconv,,,,libquadmath))
-$(eval $(call DefineBoostLibrary,chrono,system))
-$(eval $(call DefineBoostLibrary,cobalt,system container context date_time))
+$(eval $(call DefineBoostLibrary,chrono))
+$(eval $(call DefineBoostLibrary,cobalt,container context date_time))
 $(eval $(call DefineBoostLibrary,container))
-$(eval $(call DefineBoostLibrary,context,chrono system,,!boost-context-exclude))
-$(eval $(call DefineBoostLibrary,contract,system))
-$(eval $(call DefineBoostLibrary,coroutine,system chrono context thread,,!boost-coroutine-exclude))
+$(eval $(call DefineBoostLibrary,context,chrono ,,!boost-context-exclude))
+$(eval $(call DefineBoostLibrary,contract,atomic chrono container date_time thread))
+$(eval $(call DefineBoostLibrary,coroutine,chrono context thread,,!boost-coroutine-exclude))
 $(eval $(call DefineBoostLibrary,date_time))
 #$(eval $(call DefineBoostLibrary,exception,,))
 $(eval $(call DefineBoostLibrary,fiber,coroutine filesystem,,!boost-fiber-exclude))
-$(eval $(call DefineBoostLibrary,filesystem,system atomic))
+$(eval $(call DefineBoostLibrary,filesystem,atomic))
 $(eval $(call DefineBoostLibrary,graph))
-$(eval $(call DefineBoostLibrary,iostreams,system random regex,,,zlib liblzma libbz2 libzstd))
+$(eval $(call DefineBoostLibrary,iostreams,random regex,,,zlib liblzma libbz2 libzstd))
 $(eval $(call DefineBoostLibrary,json,container))
-$(eval $(call DefineBoostLibrary,locale,system chrono thread charconv,,,icu))
-$(eval $(call DefineBoostLibrary,log,system chrono date_time thread filesystem regex))
-$(eval $(call DefineBoostLibrary,math, container random system))
+$(eval $(call DefineBoostLibrary,locale,chrono thread charconv,,,icu))
+$(eval $(call DefineBoostLibrary,log,chrono date_time thread filesystem regex serialization))
+$(eval $(call DefineBoostLibrary,math, container random))
 #$(eval $(call DefineBoostLibrary,mpi,,)) # OpenMPI does no exist in OpenWRT at this time.
 $(eval $(call DefineBoostLibrary,nowide))
 $(eval $(call DefineBoostLibrary,program_options))
 $(eval $(call DefineBoostLibrary,python3,container graph,,,python3-base))
-$(eval $(call DefineBoostLibrary,random,system))
+$(eval $(call DefineBoostLibrary,random))
 $(eval $(call DefineBoostLibrary,regex,,,,icu))
 $(eval $(call DefineBoostLibrary,serialization))
 $(eval $(call DefineBoostLibrary,wserialization,serialization))
 $(eval $(call DefineBoostLibrary,stacktrace))
-$(eval $(call DefineBoostLibrary,system))
-$(eval $(call DefineBoostLibrary,thread,system chrono atomic))
+$(eval $(call DefineBoostLibrary,thread,chrono atomic container date_time))
 $(eval $(call DefineBoostLibrary,timer,chrono))
-$(eval $(call DefineBoostLibrary,type_erasure,chrono system thread))
-$(eval $(call DefineBoostLibrary,url, system))
+$(eval $(call DefineBoostLibrary,type_erasure,chrono thread))
+$(eval $(call DefineBoostLibrary,url))
 $(eval $(call DefineBoostLibrary,wave,date_time thread filesystem container serialization regex))
 
 include $(INCLUDE_DIR)/host-build.mk
@@ -378,7 +376,7 @@ define Host/Compile
 
 	( cd $(HOST_BUILD_DIR) ; \
 		./bootstrap.sh --prefix=$(STAGING_DIR_HOSTPKG) \
-			--with-libraries=context,filesystem,program_options,regex,system ;\
+			--with-libraries=context,filesystem,program_options,regex ;\
 		./b2 --ignore-site-config install )
 endef
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @ClaymorePT 

**Description:**
This commit updates boost to version 1.89.0

New libraries in this release:
* Bloom [2]: filters, from Joaquín M López Muñoz.

Other Notes:
* Boost.System is now a header-only library [3]

More info about Boost 1.89.0 can be found at the usual place [1].

[1]: https://www.boost.org/users/history/version_1_89_0.html
[2]: https://www.boost.org/libs/bloom/
[3]: https://github.com/boostorg/system/commit/7a495bb46d7ccd808e4be2a6589260839b0fd3a3


---

## 🧪 Run Testing Details
openwrt-sdk-24.10.2-bcm27xx-bcm2712_gcc-13.3.0_musl.Linux-x86_64
- **OpenWrt Version:** 24.10.2
- **OpenWrt Target/Subtarget:** BCM27xx 
- **OpenWrt Device:** RaspberryPi 5

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:
- *No patches exist to be applied.*

- [x] It is structured in a way that it is potentially upstreamable.
