### PR TITLE
v4l2loopback: update to version 0.15.1

### DIFF
--- a/kernel/v4l2loopback/Makefile
+++ b/kernel/v4l2loopback/Makefile
@@ -6,13 +6,13 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=v4l2loopback
-PKG_VERSION:=0.13.2
+PKG_VERSION:=0.15.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/umlaeute/v4l2loopback
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
-PKG_MIRROR_HASH:=06b786138b35daab3edfafb95432f1b838676e6dd615c481eae0553182eac67b
+PKG_MIRROR_HASH:=ffd44e59bef318d7cb72d3f00a3512c7712fd5ce9b41875f27e061864c67457f
 
 PKG_MAINTAINER:=Michel Promonet <michel.promonet@free.fr>
 PKG_CPE_ID:=cpe:/o:v4l2loopback_project:v4l2loopback


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @mpromonet 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
update to version 0.15.1
---

## 🧪 Run Testing Details

- **OpenWrt Version: latest**
- **OpenWrt Target/Subtarget: Allwinner/H3**
- **OpenWrt Device: Nanopi NEO Air**

<sub>start v4l2tools to compress /dev/video0 (real device) UYVY to /dev/video1 (v4l2loopback) JPEG</sub>
<sub>start v4l2rtspserver to stream /dev/video1</sub>   
<sub>start on remote VLC to connect to rtsp stream.</sub>

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
