### PR TITLE
haproxy: update to v3.2.4

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=3.0.10
-PKG_RELEASE:=2
+PKG_VERSION:=3.2.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://www.haproxy.org/download/3.0/src
-PKG_HASH:=d1508670b6fd5839c669a0a916842f0d3d3d0b578bb351a2a74a1de3d929ce26
+PKG_SOURCE_URL:=https://www.haproxy.org/download/3.2/src
+PKG_HASH:=5d4b2ee6fe56b8098ebb9c91a899d728f87d64cd7be8804d2ddcc5f937498c1d
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Christian Lachner <gladiac@gmail.com>
@@ -84,7 +84,6 @@ ifeq ($(BUILD_VARIANT),ssl)
 	ADDON+=USE_OPENSSL=1
 	ADDON+=ADDLIB="-lcrypto -lm"
 	ADDON+=USE_QUIC=1
-	ADDON+=USE_QUIC_OPENSSL_COMPAT=1
 endif
 
 define Build/Compile
@@ -93,8 +92,7 @@ define Build/Compile
 		CC="$(TARGET_CC)" \
 		PCREDIR="$(STAGING_DIR)/usr/" \
 		USE_LUA=1 LUA_LIB_NAME="lua5.4" LUA_INC="$(STAGING_DIR)/usr/include/lua5.4" LUA_LIB="$(STAGING_DIR)/usr/lib" \
-		SMALL_OPTS="-DBUFSIZE=16384 -DMAXREWRITE=1030 -DSYSTEM_MAXCONN=165530" \
-		USE_ZLIB=1 USE_PCRE2=1 USE_PCRE2_JIT=1 USE_PTHREAD_PSHARED=1 USE_LIBATOMIC=1 USE_PROMEX=1 \
+		USE_ZLIB=1 USE_PCRE2=1 USE_PCRE2_JIT=1 USE_LIBATOMIC=1 USE_PROMEX=1 \
 		VERSION="$(PKG_VERSION)" SUBVERS="-$(PKG_RELEASE)" \
 		VERDATE="$(shell date -d @$(SOURCE_DATE_EPOCH) '+%Y/%m/%d')" IGNOREGIT=1 \
 		$(ADDON) \

--- a/net/haproxy/files/haproxy.cfg
+++ b/net/haproxy/files/haproxy.cfg
@@ -11,6 +11,9 @@ global
 	# are allowed.
 	#log 10.0.0.1 daemon info
 
+	# Logging events to the local syslog server is possible too.
+	#log /dev/log local0 info
+
 	# Specifiy the maximum number of allowed connections.
 	maxconn 32000
 
@@ -29,7 +32,6 @@ global
 	# Daemonize on startup
 	daemon
 
-	nosplice
 	# Enable debugging
 	#debug
 
@@ -37,6 +39,9 @@ global
 	# used for multi-core environments or to circumvent per-process
 	# limits like number of open file descriptors. Default is 1.
 	#nbproc 2
+
+	# SSL/TLS configuration. You can use the Mozilla SSL Config
+	# Generator. See: https://ssl-config.mozilla.org/#server=haproxy
 
 # Default parameters
 defaults
@@ -99,9 +104,9 @@ listen local_health_check
 	# Listen on port 60000
 	bind :60000
 
-	# This is a health check
-	mode health
+	# This health check requires http-mode
+	mode http
 
-	# Enable HTTP-style responses: "HTTP/1.0 200 OK"
-	# else just print "OK".
-	#option httpchk
+	# This is a health check
+	http-request return status 200
+

--- a/net/haproxy/get-latest-patches.sh
+++ b/net/haproxy/get-latest-patches.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-CLONEURL=https://git.haproxy.org/git/haproxy-3.0.git
-BASE_TAG=v3.0.10
+CLONEURL=https://git.haproxy.org/git/haproxy-3.2.git
+BASE_TAG=v3.2.4
 TMP_REPODIR=tmprepo
 PATCHESDIR=patches
 


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Christian Lachner <gladiac@gmail.com> (/me)
Compile tested: ipq806x
Run tested: ipq806x (r7800)

Description: Update to v3.2.4
- Major version bump to the latest HAProxy v3.2 LTS release.
- Updated haproxy PKG_VERSION and PKG_HASH
- Updated build-parameters:
  - Removed USE_QUIC_OPENSSL_COMPAT as OpenSSL v3.5.1+ ships with good enough Quic support. HAProxy does not need the compat code with these newer versions of OpenSSL anymore.
  - Removed obsolete build options.
- Updated example configuration so it works with the new version.
- See changes: http://git.haproxy.org/?p=haproxy-3.2.git;a=shortlog