### PR TITLE
python-hatchling, python-packaging, python-urllib3: update to the latest version

### DIFF
--- a/lang/python/python-packaging/Makefile
+++ b/lang/python/python-packaging/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-packaging
-PKG_VERSION:=23.2
+PKG_VERSION:=25.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=packaging
-PKG_HASH:=048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5
+PKG_HASH:=d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>, Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=Apache-2.0 BSD-2-Clause

--- a/lang/python/python-urllib3/Makefile
+++ b/lang/python/python-urllib3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-urllib3
-PKG_VERSION:=2.0.7
+PKG_VERSION:=2.5.0
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
@@ -17,10 +17,16 @@ PKG_LICENSE_FILES:=LICENSE.txt
 PKG_CPE_ID:=cpe:/a:python:urllib3
 
 PYPI_NAME:=urllib3
-PKG_HASH:=c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84
+PKG_HASH:=3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760
 
-PKG_BUILD_DEPENDS:=python-hatchling/host
-HOST_BUILD_DEPENDS:=python-hatchling/host
+PKG_BUILD_DEPENDS:= \
+	python-hatch-vcs/host \
+	python-hatchling/host \
+	python-setuptools-scm/host
+HOST_BUILD_DEPENDS:= \
+	python-hatch-vcs/host \
+	python-hatchling/host \
+	python-setuptools-scm/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @BKPepe, @ja-pa, @jefferyto

**Description:**
Update python-hatchling to version 1.27.0.
Update python-packaging to version 25.0.
Update python-urllib3 to version 2.5.0.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 24.10
- **OpenWrt Target/Subtarget:** NXP Layerscape / ARMv8 64-bit based boards
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.