### PR TITLE
bird-lgproxy-go: Add package

### DIFF
--- a/utils/bird-lgproxy-go/Makefile
+++ b/utils/bird-lgproxy-go/Makefile
@@ -1,0 +1,64 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bird-lgproxy-go
+PKG_VERSION:=1.3.10
+PKG_RELEASE:=1
+
+PKG_SOURCE:=v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/xddxdd/bird-lg-go/archive/refs/tags/
+PKG_HASH:=493c76519f85396ffb01ec38a8d72b5bfce4a7ceb8d0470efea6a735cf71189a
+
+PKG_BUILD_DIR=$(BUILD_DIR)/bird-lg-go-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Grafcube <grafcube@disroot.org>
+PKG_LICENSE:=GPL-3.0-only
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/xddxdd/bird-lg-go/proxy
+GO_PKG_BUILD_PKG:=$(GO_PKG)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+GO_PKG_BUILD_VARS += GO111MODULE=auto
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(CP) $(PKG_BUILD_DIR)/proxy/* $(PKG_BUILD_DIR)/
+endef
+
+define Package/bird-lgproxy-go
+	URL:=https://github.com/xddxdd/bird-lg-go
+	DEPENDS:=$(GO_ARCH_DEPENDS)
+	SECTION:=utils
+	CATEGORY:=Utilities
+	TITLE:=BIRD looking glass proxy in Go
+endef
+
+define Package/bird-lgproxy-go/conffiles
+	/etc/bird-lg/bird-lgproxy.json
+endef
+
+define Package/bird-lgproxy-go/description
+	BIRD looking glass in Go, for better maintainability, easier deployment &
+	smaller memory footprint
+endef
+
+define Package/bird-lgproxy-go/install
+	$(INSTALL_DIR) $(1)/etc/
+	$(INSTALL_DIR) $(1)/etc/bird-lg
+
+	$(INSTALL_CONF) $(CURDIR)/files/bird-lgproxy.json $(1)/etc/bird-lg/bird-lgproxy.json
+
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) $(CURDIR)/files/bird-lgproxy-go.init $(1)/etc/init.d/bird-lgproxy-go
+
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/proxy $(1)/usr/bin/bird-lgproxy-go
+endef
+
+$(eval $(call BuildPackage,bird-lgproxy-go))

--- a/utils/bird-lgproxy-go/files/bird-lgproxy-go.init
+++ b/utils/bird-lgproxy-go/files/bird-lgproxy-go.init
@@ -1,0 +1,16 @@
+#!/bin/sh /etc/rc.common
+
+START=90
+STOP=01
+USE_PROCD=1
+
+start_service() {
+	procd_open_instance
+	procd_set_param command /usr/bin/bird-lgproxy-go
+	procd_set_param pidfile /var/run/bird-lgproxy-go.pid
+	procd_set_param term_timeout 1
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn 150 10 10
+	procd_close_instance
+}

--- a/utils/bird-lgproxy-go/files/bird-lgproxy.json
+++ b/utils/bird-lgproxy-go/files/bird-lgproxy.json
@@ -1,0 +1,4 @@
+{
+	"bird_socket": "/var/run/bird.ctl",
+	"listen": 8179
+}


### PR DESCRIPTION
Package for the proxy part of bird-lg-go.

<https://github.com/xddxdd/bird-lg-go>

## 📦 Package Details

**Maintainer:** Me

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

This package is used by the bird looking glass to see information about BGP sessions. Specifically, it's the proxy part of the program. It is installed on devices running bird and provides data for the frontend to use remotely.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** ipq40xx/generic arm_cortex-a7_neon-vfpv4
- **OpenWrt Device:** asus_rt-ac58u

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
