### PR TITLE
vips: update to 8.17.1

### DIFF
--- a/libs/vips/Makefile
+++ b/libs/vips/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vips
-PKG_VERSION:=8.16.1
+PKG_VERSION:=8.17.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/libvips/libvips/releases/download/v$(PKG_VERSION)
-PKG_HASH:=d114d7c132ec5b45f116d654e17bb4af84561e3041183cd4bfd79abfb85cf724
+PKG_HASH:=4d8c3325922c5300253d7594507a8f1d3caf8eed70dfb66cc7eb2cbed65bb5ca
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPL-2.1-or-later
@@ -34,7 +34,8 @@ define Package/vips
 endef
 
 MESON_ARGS += \
-	-Dgtk_doc=false \
+	-Ddocs=false \
+	-Dcpp-docs=false \
 	-Dintrospection=disabled \
 	-Danalyze=false \
 	-Dcfitsio=disabled \


### PR DESCRIPTION
Upstream list of changes is available at
https://github.com/libvips/libvips/releases/tag/v8.17.1.

## 📦 Package Details

**Maintainer:** me

**Description:**

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** Generic PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.