### PR TITLE
[24.10] libradcli: fix build options

### DIFF
--- a/libs/libradcli/Config.in
+++ b/libs/libradcli/Config.in
@@ -5,6 +5,5 @@ menu "Configuration"
 
 config RADCLI_TLS
 	bool "enable TLS support"
-	default y
 
 endmenu

--- a/libs/libradcli/Makefile
+++ b/libs/libradcli/Makefile
@@ -19,6 +19,8 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/radcli-$(PKG_VERSION)
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
+PKG_CONFIG_DEPENDS := CONFIG_RADCLI_TLS
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/libradcli
@@ -35,6 +37,10 @@ define Package/libradcli/decription
   approach is to allow writing RADIUS-aware application in less than 50 lines
   of C code. It was based originally on freeradius-client and is source 
   compatible with it.
+endef
+
+define Package/libradcli/config
+        source "$(SOURCE)/Config.in"
 endef
 
 CONFIGURE_ARGS+= \


### PR DESCRIPTION


## 📦 Package Details

**Maintainer:** @nmav.

**Description:**

The provided Config.in was never sourced from the Makefile, making it impossible to toggle TLS support.

This commit adds the necessary Makefile glue to fix this.

Also default to TLS disabled, as was the de-facto case since Config.in was never sourced (and thus the default 'y' never enabled).

(cherry picked from commit 5ffca82f54e7bb611c04ddcc60ee3f81f36cf77e)

---

## 🧪 Run Testing Details

- **OpenWrt Version: 24.10**
- **OpenWrt Target/Subtarget: x86**
- **OpenWrt Device: NUC**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
