### PR TITLE
django-restframework: assign PKG_CPE_ID

### DIFF
--- a/lang/python/django-restframework/Makefile
+++ b/lang/python/django-restframework/Makefile
@@ -17,6 +17,7 @@ PKG_HASH:=166809528b1aced0a17dc66c24492af18049f2c9420dbd0be29422029cfc3ff7
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.md
+PKG_CPE_ID:=cpe:/a:django-rest-framework:django_rest_framework
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @commodo

**Description:**
Assign PKG_CPE_ID to DRF.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.