### PR TITLE
lsof: fix compilation issue with "libtirpc"

### DIFF
--- a/utils/lsof/Makefile
+++ b/utils/lsof/Makefile
@@ -8,7 +8,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=lsof
 PKG_VERSION:=4.99.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lsof-org/lsof/releases/download/$(PKG_VERSION)
@@ -28,12 +28,11 @@ DISABLE_NLS:=
 define Package/lsof
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libtirpc
   TITLE:=LiSt Open Files - a diagnostic tool
   URL:=http://people.freebsd.org/~abe/
 endef
 
-CONFIGURE_ARGS += --without-selinux
+CONFIGURE_ARGS += --without-selinux --without-libtirpc
 
 define Package/lsof/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
adding --without-libtirpc to CONFIGURE_ARGS fixing the issue in the Description Ref.: https://github.com/openwrt/packages/issues/27357 + version bump.

## 📦 Package Details

**Maintainer:**
Maxim Storchak [m.storchak@gmail.com](mailto:m.storchak@gmail.com)

**Description:**
Ref.: https://github.com/openwrt/packages/issues/27357

---

## 🧪 Run Testing Details

- snapshot
- qualcommax/ipq807x
- nbg7815

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
