### PR TITLE
netbird: update to 0.55.1, cleanup init script, add support for profile feature

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.52.2
+PKG_VERSION:=0.53.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=0c798932bed1b1c2dbe1de692efad7f60c875caee2da9fa797de5b4740b8a0e5
+PKG_HASH:=47dde2b5b8fcb488bd6aa9aab769efb45ca4c1cc21253d44f7a68b44e7aeda8a
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.53.0
+PKG_VERSION:=0.55.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=47dde2b5b8fcb488bd6aa9aab769efb45ca4c1cc21253d44f7a68b44e7aeda8a
+PKG_HASH:=b9465a2b6b7600ec7f22a706b2f2891fdb19a07ffcbfd82cd0e33176d3c69b75
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.51.2
-PKG_RELEASE:=2
+PKG_VERSION:=0.52.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=98d6dba5c6b63c2742471ef8a09628e46bf0b2545f99a327537a60b27391c73e
+PKG_HASH:=0c798932bed1b1c2dbe1de692efad7f60c875caee2da9fa797de5b4740b8a0e5
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
 PKG_VERSION:=0.51.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?

--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
 PKG_VERSION:=0.55.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
@@ -41,7 +41,7 @@ define Package/netbird/description
 endef
 
 define Package/netbird/conffiles
-/etc/netbird/config.json
+/root/.config/netbird/
 endef
 
 define Package/netbird/install

--- a/net/netbird/files/netbird.init
+++ b/net/netbird/files/netbird.init
@@ -1,19 +1,11 @@
 #!/bin/sh /etc/rc.common
 
-. /lib/netifd/netifd-proto.sh
-
 START=99
 STOP=10
 
 USE_PROCD=1
 
-service_triggers() {
-	procd_add_interface_trigger "interface.*" "wan" /etc/init.d/netbird restart
-}
-
 start_service() {
-	local device
-
 	procd_open_instance
 	procd_set_param command /usr/bin/netbird
 	procd_append_param command service run

--- a/net/netbird/files/netbird.init
+++ b/net/netbird/files/netbird.init
@@ -8,6 +8,7 @@ USE_PROCD=1
 start_service() {
 	procd_open_instance
 	procd_set_param command /usr/bin/netbird
+	procd_set_param env NB_CONFIG="/etc/netbird/config.json"
 	procd_append_param command service run
 	procd_set_param pidfile /var/run/netbird.pid
 	procd_close_instance

--- a/net/netbird/files/netbird.init
+++ b/net/netbird/files/netbird.init
@@ -8,7 +8,7 @@ USE_PROCD=1
 start_service() {
 	procd_open_instance
 	procd_set_param command /usr/bin/netbird
-	procd_set_param env NB_CONFIG="/etc/netbird/config.json"
+	procd_set_param env NB_STATE_DIR="/root/.config/netbird"
 	procd_append_param command service run
 	procd_set_param pidfile /var/run/netbird.pid
 	procd_close_instance


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

- Supersedes: https://github.com/openwrt/packages/pull/27354.
- Removed unnecessary parameters from the `netbird` init script that attempted to reestablish the connection when changing the `wan` state, this should be managed by `netbird` itself.
- Updated `netbird` multiple times (0.52.2, 0.53.0, and 0.55.1) to maintain a version history:
  - **0.52.2**: Introduced [profiles feature](https://docs.netbird.io/how-to/profiles) and moved the configuration from `/etc/netbird/config.json` to `/var/lib/netbird`. This poses a risk of configuration loss on OpenWrt, as `/var` is a link to `/tmp`. This behavior has been [reported upstream](https://github.com/netbirdio/netbird/issues/4322).
  - **0.53.0**: Fixed the init script to resolve the behavior introduced earlier, using the variable `NB_CONFIG="/etc/netbird/config.json`, ensuring compatibility with existing configurations. Some components changed their license to **AGPLv3**, but these components are not included in the OpenWrt package.
  - **0.55.1**: Simple update.
- Modified the init script and Makefile to utilize the profile-based mode of `netbird`, replacing `NB_CONFIG` with the variable `NB_STATE_DIR="/root/.config/netbird"`, `netbird` will automatically migrate existing configurations.

**Tests checklist:**
- [x] Connection to the NetBird Cloud Dashboard (not self-hosted).
- [x] Firewall configured with nftables.
- [x] Connection established in P2P mode.
- [x] `wireguard` kernel mode active.
- [x] Routes configured between my homelab and my cloud server.
- [x] `netbird` DNS server functioning correctly.
- [ ] NAT operational (not needed by me at this time, may consider testing in the future).
- [ ] Permissions rules is enforced (not needed by me at this time, may consider testing in the future).

**Additional information**

`x86_64` is running in a virtual machine using [`incus`](https://github.com/lxc/incus).
The package(s) was compiled with the container [`sdk`](https://github.com/openwrt/docker).
The `OpenWrt` image(s) was built using the container [`imagebuilder`](https://github.com/openwrt/docker).
<sub>No more container or [`distrobuilder`](https://github.com/lxc/distrobuilder).</sub>

You can view my repository with the patch applied and the automated build here:
- https://github.com/wehagy/owpib/tree/netbird/update
  <sub>This repository branch is temporary and will be removed or modified after the merge.</sub>

You can find my artifacts here:
- https://github.com/wehagy/owpib/actions/runs/17310240506

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT r30880-44f76177d
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.