### PR TITLE
libtirpc: fix build for client packages

### DIFF
--- a/libs/libtirpc/Makefile
+++ b/libs/libtirpc/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtirpc
 PKG_VERSION:=1.3.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=@SF/libtirpc
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -27,8 +27,8 @@ define Package/libtirpc
   DEPENDS:=+libpthread
 endef
 
-CONFIGURE_ARGS += --disable-gssapi
-HOST_CONFIGURE_ARGS += --disable-gssapi --disable-shared
+CONFIGURE_ARGS += --disable-gssapi --enable-rpcdb
+HOST_CONFIGURE_ARGS += --disable-gssapi --disable-shared --enable-rpcdb
 
 ifeq ($(HOST_OS),Darwin)
 HOST_CONFIGURE_ARGS += --disable-symvers


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @hnyman 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Version 1.3.7 introduced a feature which moved symbols into an optional database section[1]. Add corresponding configure args to fix the build with our packages.

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64 (using external toolchain from snapshot)
- **OpenWrt Device:** Not run tested, only build tested

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
