### PR TITLE
sing-box: Update to 1.12.4

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.12.1
+PKG_VERSION:=1.12.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8c7de6f996c9d3ad363d60b52828dc649a579ae8a5f0b596fc8ff7ea7622908d
+PKG_HASH:=9a14ffa04fee1a1091ca1995a45f3e3feee460bddff0a72da2febc05a05b2660
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @brvphoenix

**Description:**

Made a mistake when creating a branch [here](https://github.com/openwrt/packages/pull/27365).
The package has been tested by me and @itdoginfo. The issue described in this [PR](https://github.com/openwrt/packages/pull/27339) has been fixed. 

I propose to disable by default the tailscale option because:
1. It increases the package size by 4mb: 10.5 -> 14.4
2. Updating the package requires about 40 Mb of RAM instead of 30.
3. Makes it impossible to compile firmware for devices with 16 MB of memory, as it increases the size by 3 MB.
4. If someone uses tailscale in sing-box, they can download the package from the official sing-box repository. I haven't met anyone who uses it yet.

changelog: https://github.com/SagerNet/sing-box/releases/tag/v1.12.4

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Xiaomi Redmi ax6000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>

