### PR TITLE
[24.10] ampr-ripd: add new package

### DIFF
--- a/net/ampr-ripd/Makefile
+++ b/net/ampr-ripd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ampr-ripd
 PKG_VERSION:=2.4.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://yo2loj.ro/hamprojects
@@ -24,7 +24,8 @@ define Package/ampr-ripd
 endef
 
 define Package/ampr-ripd/description
-  Routing daemon written in C similar to Hessu's rip44d including optional resending of RIPv2 broadcasts for router injection.
+  Routing daemon written in C similar to Hessu's rip44d including
+  optional resending of RIPv2 broadcasts for router injection.
 endef
 
 CONFIGURE_VARS+= \
@@ -48,46 +49,43 @@ define Package/ampr-ripd/postrm
 [ -z "$${IPKG_INSTROOT}" ] || exit 0
 
 echo "Removing firewall rules..."
-for i in $$(seq 99 -1 0); do
-   if [ $$(uci -q get firewall.@rule[$$i]) ]; then
-      name=$$(uci get firewall.@rule[$$i].name)
-      if [ "$$name" = "Net 44 ICMP Echo Request" ] \
-         || [ "$$name" = "Net 44 Router ICMP" ]    \
-         || [ "$$name" = "ipip" ]; then
-         uci del firewall.@rule[$$i]
-      fi
+count=$$(( $$(uci show firewall | grep -c "=rule") - 1 ))
+for i in $$(seq "$$count" -1 0); do
+   name=$$(uci get firewall.@rule["$$i"].name)
+   if [ "$$name" = "Net 44 ICMP Echo Request" ] \
+      || [ "$$name" = "Net 44 Router ICMP" ]    \
+      || [ "$$name" = "ipip" ]; then
+      uci del firewall.@rule["$$i"]
    fi
 done
 uci commit firewall
 
 echo "Removing network rules..."
-for i in $$(seq 99 -1 0); do
-   if [ $$(uci -q get network.@rule[$$i]) ]; then
-      lookup=$$(uci get network.@rule[$$i].lookup)
-      if [ "$$lookup" = "44" ]; then
-         uci del network.@rule[$$i]
-      fi
+count=$$(( $$(uci show network | grep -c "=rule") - 1 ))
+for i in $$(seq "$$count" -1 0); do
+   lookup=$$(uci get network.@rule["$$i"].lookup)
+   if [ "$$lookup" = "44" ]; then
+      uci del network.@rule["$$i"]
    fi
 done
 uci commit network
 
 echo "Removing firewall zone forwarding rules..."
-for i in $$(seq 99 -1 0); do
-   if [ $$(uci -q get firewall.@forwarding[$$i]) ]; then
-      name=$$(uci get firewall.@forwarding[$$i].src)
-      if [ "$$name" = "amprlan" ] || [ "$$name" = "amprwan" ]; then
-         uci del firewall.@forwarding[$$i]
-      fi
+count=$$(( $$(uci show firewall | grep -c "=forwarding") -1 ))
+for i in $$(seq "$$count" -1 0); do
+   name=$$(uci get firewall.@forwarding["$$i"].src)
+   if [ "$$name" = "amprlan" ] || [ "$$name" = "amprwan" ]; then
+      uci del firewall.@forwarding["$$i"]
    fi
 done
+uci commit firewall
 
 echo "Removing firewall zones..."
-for i in $$(seq 99 -1 0); do
-   if [ $$(uci -q get firewall.@zone[$$i]) ]; then
-      name=$$(uci get firewall.@zone[$$i].name)
-      if [ "$$name" = "amprlan" ] || [ "$$name" = "amprwan" ]; then
-         uci del firewall.@zone[$$i]
-      fi
+count=$$(( $$(uci show firewall | grep -c "=zone") -1 ))
+for i in $$(seq "$$count" -1 0); do
+   name=$$(uci get firewall.@zone["$$i"].name)
+   if [ "$$name" = "amprlan" ] || [ "$$name" = "amprwan" ]; then
+      uci del firewall.@zone["$$i"]
    fi
 done
 uci commit firewall

--- a/net/ampr-ripd/Makefile
+++ b/net/ampr-ripd/Makefile
@@ -1,0 +1,102 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ampr-ripd
+PKG_VERSION:=2.4.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
+PKG_SOURCE_URL:=https://yo2loj.ro/hamprojects
+PKG_HASH:=e4635bd0f88c1f2b0777e948a00d0470aa97254ec4b0b8fd75c79d109995a350
+
+PKG_MAINTAINER:=Dan Srebnick <k2ie@k2ie.net>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ampr-ripd
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  DEPENDS:=+kmod-ipip +ip
+  TITLE:=Routing daemon for the AMPR network
+  URL:=https://www.yo2loj.ro/hamprojects
+endef
+
+define Package/ampr-ripd/description
+  Routing daemon written in C similar to Hessu's rip44d including optional resending of RIPv2 broadcasts for router injection.
+endef
+
+CONFIGURE_VARS+= \
+	CC="$(TOOLCHAIN_DIR)/bin/$(TARGET_CC)"
+	COPT="$(TARGET_COPT)"
+
+define Package/ampr-ripd/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ampr-ripd $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/ampr-ripd-init $(1)/etc/init.d/ampr-ripd
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DATA) ./files/99-ampr-ripd $(1)/etc/uci-defaults/99-ampr-ripd
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/ampr-ripd-config $(1)/etc/config/ampr-ripd
+endef
+
+define Package/ampr-ripd/postrm
+#!/bin/sh
+[ "$${PKG_UPGRADE}" = 1 ] && exit 0
+[ -z "$${IPKG_INSTROOT}" ] || exit 0
+
+echo "Removing firewall rules..."
+for i in $$(seq 99 -1 0); do
+   if [ $$(uci -q get firewall.@rule[$$i]) ]; then
+      name=$$(uci get firewall.@rule[$$i].name)
+      if [ "$$name" = "Net 44 ICMP Echo Request" ] \
+         || [ "$$name" = "Net 44 Router ICMP" ]    \
+         || [ "$$name" = "ipip" ]; then
+         uci del firewall.@rule[$$i]
+      fi
+   fi
+done
+uci commit firewall
+
+echo "Removing network rules..."
+for i in $$(seq 99 -1 0); do
+   if [ $$(uci -q get network.@rule[$$i]) ]; then
+      lookup=$$(uci get network.@rule[$$i].lookup)
+      if [ "$$lookup" = "44" ]; then
+         uci del network.@rule[$$i]
+      fi
+   fi
+done
+uci commit network
+
+echo "Removing firewall zone forwarding rules..."
+for i in $$(seq 99 -1 0); do
+   if [ $$(uci -q get firewall.@forwarding[$$i]) ]; then
+      name=$$(uci get firewall.@forwarding[$$i].src)
+      if [ "$$name" = "amprlan" ] || [ "$$name" = "amprwan" ]; then
+         uci del firewall.@forwarding[$$i]
+      fi
+   fi
+done
+
+echo "Removing firewall zones..."
+for i in $$(seq 99 -1 0); do
+   if [ $$(uci -q get firewall.@zone[$$i]) ]; then
+      name=$$(uci get firewall.@zone[$$i].name)
+      if [ "$$name" = "amprlan" ] || [ "$$name" = "amprwan" ]; then
+         uci del firewall.@zone[$$i]
+      fi
+   fi
+done
+uci commit firewall
+
+echo "Removing network interfaces..."
+uci del network.amprwan
+uci del network.amprlan
+uci commit network
+
+endef
+
+$(eval $(call BuildPackage,ampr-ripd))

--- a/net/ampr-ripd/files/99-ampr-ripd
+++ b/net/ampr-ripd/files/99-ampr-ripd
@@ -1,0 +1,112 @@
+##############################################################################
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# Copyright (C) 2025 Dan Srebnick (K2IE)
+#
+##############################################################################
+
+# Check to see if network.amprlan.ipaddr and network.amprwan.ipaddr exist.
+# If so, no need to apply defaults.
+
+if [ -z "$(uci -q get network.amprlan.ipaddr)" ] && \
+   [ -z "$(uci -q get network.amprwan.ipaddr)" ]; then
+
+echo Installing default routing rules...
+r=$(uci add network rule)
+uci -q batch << EOI
+set network.$r.dest='44.0.0.0/9'
+set network.$r.lookup='44'
+set network.$r.priority='44'
+EOI
+r=$(uci add network rule)
+uci -q batch << EOI
+set network.$r.dest='44.128.0.0/10'
+set network.$r.lookup='44'
+set network.$r.priority='44'
+EOI
+r=$(uci add network rule)
+uci -q batch << EOI
+set network.$r.src='44.127.254.0/24'
+set network.$r.lookup='44'
+set network.$r.priority='45'
+EOI
+
+echo Installing default network interfaces...
+uci -q batch << EOI
+set network.amprlan=interface
+set network.amprlan.proto='static'
+set network.amprlan.device='br-lan'
+set network.amprlan.force_link='0'
+set network.amprlan.ipaddr='44.127.254.254'
+set network.amprlan.netmask='255.255.255.0'
+set network.amprlan.defaultroute='0'
+set network.amprlan.ip4table='44'
+set network.amprlan.delegate='0'
+set network.amprwan=interface
+set network.amprwan.device='tunl0'
+set network.amprwan.proto='static'
+set network.amprwan.ipaddr='44.127.254.254'
+set network.amprwan.netmask='255.255.255.0'
+commit network
+EOI
+
+echo Installing default firewall zones...
+z=$(uci add firewall zone)
+uci -q batch << EOI
+set firewall.$z.name='amprlan'
+set firewall.$z.network='amprlan'
+EOI
+z=$(uci add firewall zone)
+uci -q batch << EOI
+set firewall.$z.name='amprwan'
+set firewall.$z.network='amprwan'
+set firewall.$z.input='REJECT'
+EOI
+z=$(uci add firewall forwarding)
+uci -q batch << EOI
+set firewall.$z.src='amprlan'
+set firewall.$z.dest='amprwan'
+commit firewall
+EOI
+
+echo Installing default firewall rules...
+f=$(uci add firewall rule)
+uci -q batch << EOI
+set firewall.$f.name='ipip'
+set firewall.$f.proto='ipencap'
+set firewall.$f.src='wan'
+set firewall.$f.target='ACCEPT'
+set firewall.$f.family='ipv4'
+set firewall.$f.icmp_type='echo-request'
+EOI
+f=$(uci add firewall rule)
+uci -q batch << EOI
+set firewall.$f.name='Net 44 ICMP Echo Request'
+set firewall.$f.proto='icmp'
+set firewall.$f.src='amprwan'
+set firewall.$f.dest='amprlan'
+set firewall.$f.target='ACCEPT'
+set firewall.$f.family='ipv4'
+set firewall.$f.icmp_type='echo-request'
+EOI
+f=$(uci add firewall rule)
+uci -q batch << EOI
+set firewall.$f.name='Net 44 Router ICMP'
+set firewall.$f.proto='icmp'
+set firewall.$f.src='amprwan'
+set firewall.$f.target='ACCEPT'
+set firewall.$f.family='ipv4'
+set firewall.$f.icmp_type='echo-request'
+commit firewall
+EOI
+
+fi
+exit

--- a/net/ampr-ripd/files/ampr-ripd-config
+++ b/net/ampr-ripd/files/ampr-ripd-config
@@ -1,0 +1,4 @@
+
+config ampr-ripd 'network'
+	option tunnet 44.127.254.0/255.255.255.0
+

--- a/net/ampr-ripd/files/ampr-ripd-init
+++ b/net/ampr-ripd/files/ampr-ripd-init
@@ -3,8 +3,7 @@
 START=95
 STOP=10
 
-EXTRA_COMMANDS="configure"
-EXTRA_HELP="        configure       Configure service parameters"
+extra_command "configure" "Configure service parameters"
 
 start() {
 	default_addr="44.127.254.254"
@@ -66,12 +65,9 @@ configure() {
 	uci set network.amprlan.netmask="$amprmask"
 	uci set network.amprwan.ipaddr="$amprhost"
 	uci set network.amprwan.netmask="$amprmask"
-	for i in $(seq 0 -1 -99); do
-		if [ ! -z $(uci -q get network.@rule[$i].src) ] && \
-			[ "$(uci get network.@rule[$i].lookup)" = "44" ] && \
-			[ "$(uci get network.@rule[$i].priority)" = "45" ]; then
-				uci set network.@rule[$i].src="$tunnet"
-				break
+	for i in $(uci show network | awk -F= "/@rule/ && /lookup='44'/ {split(\$1, conf, /[.=]/); print conf[2]}"); do
+		if [ "$(uci -q get "network.$i.priority")" = "45" ]; then
+			uci set "network.$i.src=$tunnet"
 		fi
 	done
 	uci commit network

--- a/net/ampr-ripd/files/ampr-ripd-init
+++ b/net/ampr-ripd/files/ampr-ripd-init
@@ -1,0 +1,87 @@
+#!/bin/sh /etc/rc.common
+
+START=95
+STOP=10
+
+EXTRA_COMMANDS="configure"
+EXTRA_HELP="        configure       Configure service parameters"
+
+start() {
+	default_addr="44.127.254.254"
+	if [ "$(uci get network.amprlan.ipaddr)" = "$default_addr" ] || \
+		[ "$(uci get network.amprwan.ipaddr)" = "$default_addr" ]; then
+
+		cat <<-EOF
+		ampr-ripd is not fully configured.
+		You must run /etc/init.d/ampr-ripd configure.
+		EOF
+
+		exit 1
+	fi
+	if [ ! -d /var/lib/ampr-ripd ]; then
+		mkdir -p /var/lib/ampr-ripd
+	fi
+	ip tunnel change ttl 64 mode ipip tunl0
+	ip link set dev tunl0 up
+	ifconfig tunl0 mtu 1480
+	tunnet=$(uci -q get ampr-ripd.network.tunnet)
+	/usr/sbin/ampr-ripd -s -r -t 44 -i tunl0 -a "$tunnet"
+}
+
+stop() {
+	ifconfig tunl0 down
+	killall ampr-ripd
+}
+
+configure() {
+	if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
+		cat <<-EOF
+
+		Usage: /etc/init.d/ampr-ripd configure [amprhost] [amprmask] [amprnet]
+
+		       amprhost is the 44 net address assigned to your OpenWrt host
+		       amprmask is the full netmask of your AMPR assigned network
+		       amprnet is the network number of your AMPR assigned network 
+
+		   Eg. /etc/init.d/ampr-ripd configure 44.127.254.1 255.255.255.0 44.127.254.0
+		EOF
+		exit 1
+	fi
+	amprhost=$1
+	amprmask=$2
+	amprnet=$3
+
+	cat <<-EOF
+	Configuring ampr-ripd with values:
+
+	amprhost=$amprhost
+	amprmask=$amprmask
+	amprnet=$amprnet
+	EOF
+
+	tunnet=$amprnet/$amprmask
+	uci set ampr-ripd.network.tunnet="$tunnet"
+	uci commit ampr-ripd
+	uci set network.amprlan.ipaddr="$amprhost"
+	uci set network.amprlan.netmask="$amprmask"
+	uci set network.amprwan.ipaddr="$amprhost"
+	uci set network.amprwan.netmask="$amprmask"
+	for i in $(seq 0 -1 -99); do
+		if [ ! -z $(uci -q get network.@rule[$i].src) ] && \
+			[ "$(uci get network.@rule[$i].lookup)" = "44" ] && \
+			[ "$(uci get network.@rule[$i].priority)" = "45" ]; then
+				uci set network.@rule[$i].src="$tunnet"
+				break
+		fi
+	done
+	uci commit network
+
+	cat <<-EOF
+
+	Now, do the following:
+	/etc/init.d/ampr-ripd restart
+	/etc/init.d/network restart
+	EOF
+
+	exit 0
+}

--- a/net/ampr-ripd/test.sh
+++ b/net/ampr-ripd/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+"$1" -h 2>&1 | grep "$PKG_VERSION"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @k2ie

**Description:**
ampr-ripd is a modified RIPv2 listener that provides route
information for ARDC IPIP Mesh tunnels.  It is intended for use
only by licensed amateur radio operators.

cherry picked using -x from commit 19249742cda92b6895ba236ca6fb3acac5abeacc and commit 551ef4a7c1abe3be192d7eba9f7a193e54e92dd0

backported from PR #27375 and #26259

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.1
- **OpenWrt Target/Subtarget:** bcm27xx-bcm2711
- **OpenWrt Device:** RPi CM4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
