### PR TITLE
syncthing: bump to 2.0.9

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.30.0
-PKG_RELEASE:=3
+PKG_VERSION:=2.0.9
+PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=ef1be71c66753c04212ab1c9c548e678d468bad98dc5461e83540a4ef5c2fcba
+PKG_HASH:=803ea5e50c0cdb465b03245a75715d3a9c69f929876d0956ef07c6f3a25dee69
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 

--- a/utils/syncthing/files/stdiscosrv.conf
+++ b/utils/syncthing/files/stdiscosrv.conf
@@ -4,7 +4,7 @@ config stdiscosrv 'stdiscosrv'
 	option listen ':8443'
 	option db_dir '/etc/stdiscosrv/discovery.db'
 
-	# Find the documents from: https://docs.syncthing.net/users/stdiscosrv.html
+	# More info: https://docs.syncthing.net/users/stdiscosrv.html
 	# option cert '/etc/stdiscosrv/cert.pem'
 	# option key '/etc/stdiscosrv/key.pem'
 	# option db_flush_interval '5m'

--- a/utils/syncthing/files/strelaysrv.conf
+++ b/utils/syncthing/files/strelaysrv.conf
@@ -4,7 +4,7 @@ config strelaysrv 'strelaysrv'
 	option keys '/etc/strelaysrv'
 	option listen ':22067'
 
-	# Find the documents from: https://docs.syncthing.net/users/strelaysrv.html
+	# More info: https://docs.syncthing.net/users/strelaysrv.html
 	# option ext_address ''
 	# option global_rate ''
 	# option message_timeout '1m0s'

--- a/utils/syncthing/files/syncthing.conf
+++ b/utils/syncthing/files/syncthing.conf
@@ -4,35 +4,30 @@ config syncthing 'syncthing'
 
 	option gui_address 'http://0.0.0.0:8384'
 
-	# Use internal flash for evaluation purpouses. Use external storage
-	#   for production.
-	# This filesystem must either support ownership/attributes or
-	#   be readable/writable by the user specified in
-	#   'option user'.
+	# Use internal flash for evaluation purposes. Use external storage for
+	# production. This filesystem must either support ownership/attributes or
+	# be readable/writable by the user specified in 'option user'.
 	# Consult syslog if things go wrong.
 	option home '/etc/syncthing'
 
-	# Changes to "niceness"/macprocs are not picked up by "reload_config"
-	#   nor by "restart": the service has to be stopped/started
-	#   for those to take effect
+	# Changes to "niceness"/macprocs are not picked up by "reload_config" or by
+	# "restart": the service has to be stopped/started for those to take effect.
 	option nice '19'
 
 	# 0 to match the number of CPUs (default)
 	# >0 to explicitly specify concurrency
 	option macprocs '0'
 
+	# More info: https://docs.syncthing.net/users/syncthing.html
+	# option db_delete_retention_interval ''
+	# option db_maintenance_interval ''
+	# option gui_apikey ''
+
 	# Running as 'root' is possible, but not recommended
-	option user 'syncthing'
+	# option user 'syncthing'
 
-	option logfile '/var/log/syncthing.log'
-	option log_max_old_files 7
+	option log_file '/var/log/syncthing.log'
+	# option log_level 'INFO'
+	option log_max_old_files '7'
 	# Size in bytes
-	option log_max_size 1048576
-
-	# # CLI options with no value should be defined as booleans and theirs
-	# # names should be prefixed with '_'.
-	option _no_default_folder '1'
-
-	# # Extra settings
-	# list _ 'verbose'
-
+	option log_max_size '1048576'

--- a/utils/syncthing/files/syncthing.init
+++ b/utils/syncthing/files/syncthing.init
@@ -13,72 +13,53 @@ config_cb() {
 	option_cb() {
 		local option="$1"
 		local value="$2"
-		case $option in
-		enabled|gui_address|home|logfile|macprocs|nice|user)
-			eval $option=$value
-			;;
-		debug)
-			extra_args="$extra_args --${option//_/-}-$value"
-			;;
-		_*)
-			[ "$value" = "0" ] || extra_args="$extra_args -${option//_/-}"
-			;;
-		*)
-			extra_args="$extra_args --${option//_/-}=$value"
-			;;
-		esac
-	}
 
-	list_cb() {
-		local name="$1"
-		local value="$2"
-		[ "$name" = "_" ] && extra_args="$extra_args --${value//_/-}" || return 0
+		case $option in
+
+		# Support old option names
+		logfile)
+			option='log_file'
+			;;
+
+		esac
+
+		eval $option="$value"
 	}
 }
 
-service_triggers()
-{
-	procd_add_reload_trigger "syncthing"
+service_triggers() {
+	procd_add_reload_trigger 'syncthing'
 }
 
 start_service() {
-	local extra_args="--no-browser"
-
-	# Options with default value different with the syncthing should be defined explicitly here
+	# Options with default value different with the syncthing should be defined
+	# explicitly here
 	local enabled=0
-	local gui_address="http://0.0.0.0:8384"
-	local home="/etc/syncthing"
-	local logfile="/var/log/syncthing.log"
+	local db_delete_retention_interval=''
+	local db_maintenance_interval=''
+	local gui_address='http://0.0.0.0:8384'
+	local gui_apikey=''
+	local home='/etc/syncthing'
+	local log_file='/var/log/syncthing.log'
+	local log_level='INFO'
+	local log_max_old_files=7
+	local log_max_size=1048576
 	local macprocs=0
 	local nice=0
-	local user="syncthing"
+	local user='syncthing'
 
-	config_load "syncthing"
+	config_load 'syncthing'
 
 	local group=$(id -gn $user)
 
-	# Some of the default values below might not match the defaults
-	#   in /etc/config/syncthing: the reason is to remain backwards
-	#   compatible with the older versions of this service as it
-	#   evolves.
 	[ "$enabled" -gt 0 ] || return 0
-
-	# For backwards compatibility
-	IDX_DB=$(readlink -n "$home"/index-v0.14.0.db)
-	if [ ! -z "$IDX_DB" ]; then
-		[ -d "$IDX_DB" ] || mkdir -p "$IDX_DB"
-
-		# A separate step to handle an upgrade use case
-		[ -d "$IDX_DB" ] && chown -R $user:$group "$IDX_DB"
-	fi
 
 	[ -d "$home" ] || mkdir -p "$home"
 	# A separate step to handle an upgrade use case
 	[ -d "$home" ] && chown -R $user:$group "$home"
 
-	# Changes to "niceness"/macprocs are not picked up by "reload_config"
-	#   nor by "restart": the service has to be stopped/started
-	#   for it to take effect
+	# Changes to "niceness"/macprocs are not picked up either by reload_config
+	# or by restart: the service has to be stopped/started for it to take effect
 	if [ $macprocs -le 0 ]; then
 		# Default to the number of cores in this case
 		macprocs=$(grep -c ^processor /proc/cpuinfo)
@@ -86,16 +67,26 @@ start_service() {
 
 	procd_open_instance
 	procd_set_param command "$PROG"
-	procd_set_param env GOMAXPROCS="$macprocs" STNOUPGRADE=1
+	procd_set_param env GOMAXPROCS="$macprocs"
 	procd_append_param command serve
+	[ -z "$db_delete_retention_interval" ] || procd_append_param command --db-delete-retention-interval="$db_delete_retention_interval"
+	[ -z "$db_maintenance_interval" ] || procd_append_param command --db-maintenance-interval="$db_maintenance_interval"
 	procd_append_param command --gui-address="$gui_address"
+	[ -z "$gui_apikey" ] || procd_append_param command --gui_apikey="$gui_apikey"
 	procd_append_param command --home="$home"
-	procd_append_param command --logfile="$logfile"
-	[ -z "$extra_args" ] || procd_append_param command $extra_args
+	procd_append_param command --log-file="$log_file"
+	[ -z "$log_level" ] || procd_append_param command --log-level="$log_level"
+	[ -z "$log_max_old_files" ] || procd_append_param command --log-max-old-files="$log_max_old_files"
+	[ -z "$log_max_size" ] || procd_append_param command --log-max-size="$log_max_size"
+	procd_append_param command --no-browser
+	procd_append_param command --no-port-probing
+	procd_append_param command --no-restart
+	# The package is built with noupgrade tag so --no-upgrade is not necessary
 
 	procd_set_param nice "$nice"
 	procd_set_param term_timeout 15
 	procd_set_param user "$user"
+	procd_set_param group "$group"
 	procd_set_param respawn
 	procd_set_param stdout 0
 	procd_set_param stderr 1


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @brvphoenix, me

**Description:**

Major version change that switches DB backend from LevelDB to SQLite.

> [!CAUTION]
> [Requires golang 1.24+](https://github.com/syncthing/syncthing/commit/01257e838b12250df5f470eef311fab5f80181bb) so this can't be backported to 24.10 at the moment.

- improve syncthing argument parsing to be more robust
- remove unused and add updated config options

Changelog: https://github.com/syncthing/syncthing/releases/tag/v2.0.0
Changelog: https://github.com/syncthing/syncthing/releases/tag/v2.0.1
Changelog: https://github.com/syncthing/syncthing/releases/tag/v2.0.2
Changelog: https://github.com/syncthing/syncthing/releases/tag/v2.0.3
Changelog: https://github.com/syncthing/syncthing/releases/tag/v2.0.4
Changelog: https://github.com/syncthing/syncthing/releases/tag/v2.0.5
Changelog: https://github.com/syncthing/syncthing/releases/tag/v2.0.6
Changelog: https://github.com/syncthing/syncthing/releases/tag/v2.0.7
Changelog: https://github.com/syncthing/syncthing/releases/tag/v2.0.8
Changelog: https://github.com/syncthing/syncthing/releases/tag/v2.0.9

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

Everything starts and runs, migration seems to work in my setup. And I have a working mixed 1.x/2.x network at the moment. But 2.x feels like a moving target right now.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
