### PR TITLE
ruby: update to 3.3.9

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=3.3.6
+PKG_VERSION:=3.3.9
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=8dc48fffaf270f86f1019053f28e51e4da4cce32a36760a0603a9aee67d7fd8d
+PKG_HASH:=d1991690a4e17233ec6b3c7844c1e1245c0adce3e00d713551d0458467b727b1
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
3.3.9 release includes the following security fix of default gems:

- CVE-2025-24294: Possible Denial of Service in resolv gem

And the following fixes for build issues:

- GCC 15.1
- Visual Studio 2022 Version 17.14

3.3.7 and 3.3.8 are routine update that includes minor bug fixes.

## 📦 Package Details

**Maintainer:** @luizluca (a.k.a. me)
**Description:** bump to 3.3.9 (bugfixes)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master and 24.10
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** qemu

Executing "gem update"

---

## ✅ Formalities

- [X ] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
- [X] It is structured in a way that it is potentially upstreamable