### PR TITLE
stunnel: update to the latest version 5.75

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.74
+PKG_VERSION:=5.75
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0-or-later
@@ -23,7 +23,7 @@ PKG_SOURCE_URL:= \
 	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=9bef235ab5d24a2a8dff6485dfd782ed235f4407e9bc8716deb383fc80cd6230
+PKG_HASH:=0c1ef0ed85240974dccb94fe74fb92d6383474c7c0d10e8796d1f781a3ba5683
 
 PKG_FIXUP:=autoreconf
 PKG_FIXUP:=patch-libtool

--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.73
+PKG_VERSION:=5.74
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0-or-later
@@ -23,7 +23,7 @@ PKG_SOURCE_URL:= \
 	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=bc917c3bcd943a4d632360c067977a31e85e385f5f4845f69749bce88183cb38
+PKG_HASH:=9bef235ab5d24a2a8dff6485dfd782ed235f4407e9bc8716deb383fc80cd6230
 
 PKG_FIXUP:=autoreconf
 PKG_FIXUP:=patch-libtool

--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.72
+PKG_VERSION:=5.73
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0-or-later
@@ -23,11 +23,12 @@ PKG_SOURCE_URL:= \
 	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=3d532941281ae353319735144e4adb9ae489a10b7e309c58a48157f08f42e949
+PKG_HASH:=bc917c3bcd943a4d632360c067977a31e85e385f5f4845f69749bce88183cb38
 
 PKG_FIXUP:=autoreconf
 PKG_FIXUP:=patch-libtool
 PKG_INSTALL:=1
+PKG_BUILD_FLAGS:=no-mips16
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
Update stunnel to latest version 5.75
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version: master**
- **OpenWrt Target/Subtarget: x86/64**
- **OpenWrt Device: APU3**

Starting without config:
```
root@G3-10940 ~ # stunnel -v
[ ] Initializing inetd mode configuration
[ ] Clients allowed=500
[.] stunnel 5.75 on x86_64-openwrt-linux-gnu platform
[.] Compiled/running with OpenSSL 3.5.2 5 Aug 2025
[.] Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,OCSP,PSK,SNI
[ ] errno: (*__errno_location())
[!] Invalid configuration file name "-v"
[!] realpath: No such file or directory (2)
```

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
