### PR TITLE
modemmanager: always add ifname option to ppp connection and delete initial eps 

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -629,13 +629,10 @@ proto_modemmanager_setup() {
 	}
 
 	# set initial eps bearer settings
-	[ -z "${init_epsbearer}" ] || {
+	if [ -z "${init_epsbearer}" ]; then
+		modemmanager_init_epsbearer "none" "$device" "" "$apn"
+	else
 		case "$init_epsbearer" in
-			"none")
-				connectargs=""
-				modemmanager_init_epsbearer "none" \
-					"$device" "${connectargs}" "$apn"
-				;;
 			"default")
 				cliauth=""
 				for auth in $allowedauth; do
@@ -667,7 +664,7 @@ proto_modemmanager_setup() {
 		esac
 		# check error for init_epsbearer function call
 		[ "$?" -ne "0" ] && return 1
-	}
+	fi
 
 	if [ -z "${allowedmode}" ]; then
 		modemmanager_set_allowed_mode "$device" "$interface" "any"

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -83,6 +83,7 @@ modemmanager_connected_method_ppp_ipv4() {
 
 	proto_run_command "${interface}" /usr/sbin/pppd \
 		"${ttyname}" \
+		ifname "ppp-${interface}" \
 		115200 \
 		nodetach \
 		noaccomp \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me


**Description:**
modemmanager: add missing ppp ifname option value
modemmanager: always reset the init_eps if not configured

---

## 🧪 Run Testing Details

- **OpenWrt Version: master**
- **OpenWrt Target/Subtarget: x86/64**
- **OpenWrt Device: APU3**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.