### PR TITLE
acme-common: cleanup acme start crontab migration

### DIFF
--- a/net/acme-common/Makefile
+++ b/net/acme-common/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-common
-PKG_VERSION:=1.4.3
+PKG_VERSION:=1.4.4
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/acme-common/files/acme.uci-defaults
+++ b/net/acme-common/files/acme.uci-defaults
@@ -55,7 +55,8 @@ uci_commit
 
 # Migrate '/etc/init.d/acme start' to '/etc/init.d/acme renew'
 grep -q '/etc/init.d/acme start' /etc/crontabs/root 2>/dev/null && {
-	echo "0 0 * * * /etc/init.d/acme renew" >>/etc/crontabs/root
+	grep -q '/etc/init.d/acme' /etc/crontabs/root 2>/dev/null || echo "0 0 * * * /etc/init.d/acme renew" >>/etc/crontabs/root
+	sed '/0 0 * * * \/etc\/init.d\/acme start/d' /etc/crontabs/root
 }
 
 exit 0


### PR DESCRIPTION
/etc/init.d/acme start migration in the crontab should also delete the existing /etc/init.d/acme start line.

Otherwise, on every sysupgrade that carries forward existing configurations, a new 'acme renew' line is added to the crontab.

Also, do not add an 'acme renew' crontab line if it already exists.

## 📦 Package Details

**Maintainer:** @feckert @tohojo 


**Description:**
Currently, I'm getting a new `0 0 * * * /etc/init.d/acme renew` line added to my crontab every time I do a snapshot upgrade that preserves my configuration. 

I traced this to `net/acme-common/files/acme.uci-defaults`:
1. It  adds that line when it sees `acme start` in the crontab as part of a migration to `acme renew`.
2. Since the migration doesn't actually remove the `acme start` line from the crontab, the `acme renew` line gets re-added every single time I do an upgrade.

My suggested changes would be to check to see if the `acme renew` line already exists before adding it, which `start_service` in `/etc/init.d/acme` already does, but also remove the `acme start` line from crontab, since in theory this is a migration.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
