### PR TITLE
adguardhome: Add acme cert path to def jail mounts

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
 PKG_VERSION:=0.107.65
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/AdGuardHome/tar.gz/v$(PKG_VERSION)?

--- a/net/adguardhome/files/adguardhome.init
+++ b/net/adguardhome/files/adguardhome.init
@@ -74,6 +74,11 @@ start_service() {
 	procd_add_jail_mount_rw "$config_dir"
 	procd_add_jail_mount_rw "$work_dir"
 
+	# acme cert folders should be made readable with chown
+	# or by using setfacl from the acl package, e.g.,
+	# by having a line like this in /etc/crontabs/root:
+	# @reboot setfacl -R -m g:adguardhome:r-x /etc/acme/example.com_ecc
+	[ -d '/etc/acme' ] && procd_add_jail_mount /etc/acme
 	procd_add_jail_mount /etc/hosts
 	procd_add_jail_mount /etc/ssl/certs
 	config_list_foreach config jail_mount procd_add_jail_mount


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @GeorgeSapkin


**Description:**
acme stores certs in subdirectories of /etc/acme.
Adguardhome will whitelist a cert dir specified by
certificate_path in the adguardhome yaml config if
 one is configured. However, the web gui does not
allow an ssl cert to be configured unless it can
validate teh cert.

This is not possible (by default) for acme certs
since the /etc/acme cert dir is not whitelisted
for jail mounting by default using the list
jail_mount cert dir whitelisting algorithm.

To solve for this, add /etc/acme to the default
jail mounts if the /etc/acme dir exists.

Note also that a user also needs to enable acls or
permissions to allow the adguardhome user to
access /etc/acme/<cert dir> since the default
acme permissions only allow root access.

That should be done separately, e.g.,
```
apk add acl
grep -q 'setfacl -R -m g:adguardhome:r-x /etc/acme/example.com_ecc' /etc/crontabs/root 2>/dev/null || {
                echo "@reboot setfacl -R -m g:adguardhome:r-x /etc/acme/example.com_ecc" >>/etc/crontabs/root
        }
```

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
