### PR TITLE
port-mirroring: share pragma pack on struct

### DIFF
--- a/net/port-mirroring/patches/030-remove-pack.patch
+++ b/net/port-mirroring/patches/030-remove-pack.patch
@@ -1,0 +1,18 @@
+--- a/include/config.h
++++ b/include/config.h
+@@ -46,6 +46,7 @@
+ #define PID_PATH    "/var/run/port-mirroring.pid"
+ 
+ // program-wide configuration settings and variables
++#pragma pack(push, 1)
+ struct pm_cfg
+ {
+     char        *cfg_file;              /* path to configuration file       */
+@@ -61,6 +62,7 @@ struct pm_cfg
+     time_t      init_time;              /* used to check for timeouts       */
+     int         packet_count;           /* number of packets processed      */
+ };
++#pragma pack(pop)
+ 
+ void find_cfg(struct pm_cfg *cfg);
+ char * printMACStr(const char *mac);


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @mmaraya

**Description:**
For following issue:
https://github.com/openwrt/packages/issues/27394

Found `struct pm_cfg cfg;` is also used on `config.c`.
So I think sharing alignment for struct pm_cfg is better than just moving `getRemoteARP` to `main.c` (which I suggested on issue`)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.0
- **OpenWrt Target/Subtarget:** ramips/mt7621
- **OpenWrt Device:** iptime A8004T

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
