### PR TITLE
[24.10] Sing-box: update to 1.12.4

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.12.0
+PKG_VERSION:=1.12.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=1093254161d2dac2175a589eb0b43415b89b3e0c10bb2a09ac230f320d974c82
+PKG_HASH:=9a14ffa04fee1a1091ca1995a45f3e3feee460bddff0a72da2febc05a05b2660
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @brvphoenix

**Description:**

 changelog: https://github.com/SagerNet/sing-box/releases/tag/v1.12.4
(cherry picked from commit 28ac7b8dc14bb46efd8f8ed8d7e4ca516674808c)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Xiaomi Redmi AX6000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
