### PR TITLE
tang: Make sure output and errors of tang are logged to system log

### DIFF
--- a/utils/tang/files/tang.init
+++ b/utils/tang/files/tang.init
@@ -21,5 +21,7 @@ start_service() {
 	procd_set_param command /usr/sbin/tangd -p "${port}" -l /usr/share/tang/db
 	procd_set_param respawn
 	procd_set_param user tang
+	procd_set_param stderr 1
+	procd_set_param stdout 1
 	procd_close_instance
 }


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @nmav
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Without this, it is not logged at all.

Found solution here, so credits go to @q-b: https://github.com/openwrt/packages/issues/26076#issuecomment-2786136107

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 22.03.7
- **OpenWrt Target/Subtarget:** r20341-591b7e93d3
- **OpenWrt Device:** Gli.NET

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am` (it's a git diff, so yeah, I guess?)
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using (I have no idea what this means, but I guess it doe snot apply.)
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
