### PR TITLE
github: fix dead link and add format spaces

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,9 +10,9 @@
 
 ## 🧪 Run Testing Details
 
-- **OpenWrt Version:**
-- **OpenWrt Target/Subtarget:**
-- **OpenWrt Device:**
+- **OpenWrt Version:** 
+- **OpenWrt Target/Subtarget:** 
+- **OpenWrt Device:** 
 
 ---
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

This commit fixes a link to CONTRIBUTING.md. Clicking it will open a page displaying "Not Found." Also add a space to after the formatting markup in the Run Testing Details section since users will have to add one to each bullet manually.

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
