### PR TITLE
rust: add loongarch64 and powerpc to supported targets

### DIFF
--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -69,7 +69,7 @@ ifeq ($(ARCH),aarch64)
 endif
 
 # Support only a subset for now.
-RUST_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||mips||mipsel||mips64||mips64el||mipsel||powerpc64||riscv64||x86_64)
+RUST_ARCH_DEPENDS:=@(aarch64||arm||i386||loongarch64||mips||mips64||mips64el||mipsel||powerpc||powerpc64||riscv64||x86_64)
 
 ifneq ($(CONFIG_RUST_SCCACHE),)
   RUST_SCCACHE_DIR:=$(if $(call qstrip,$(CONFIG_RUST_SCCACHE_DIR)),$(call qstrip,$(CONFIG_RUST_SCCACHE_DIR)),$(TOPDIR)/.sccache)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lu-zero 

**Description:**
Add loongarch64 and powerpc to supported targets.
Also removed i686 as OpenWrt replaces it with i386 in $(ARCH).

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** apm821xx/nand, loongarch64/generic
- **OpenWrt Device:** none

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.