### PR TITLE
snort3: run as regular user rather than as root

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.9.6.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/snort3/snort3/tar.gz/$(PKG_VERSION)?
@@ -30,6 +30,7 @@ define Package/snort3
     +kmod-nft-queue +liblzma +ucode +ucode-mod-fs +ucode-mod-uci \
     +PACKAGE_gperftools:gperftools \
     +PACKAGE_vectorscan:vectorscan
+  USERID:=snort=975:snort=975
   TITLE:=Lightweight Network Intrusion Detection System
   URL:=http://www.snort.org/
   MENU:=1

--- a/net/snort3/files/snort.init
+++ b/net/snort3/files/snort.init
@@ -43,6 +43,14 @@ start_service() {
 		procd_set_param env SNORT_LUA_PATH="$config_dir"
 		procd_set_param file $CONFIGFILE
 	fi
+	[ -x /sbin/ujail -a -e /etc/capabilities/snort.json ] && {
+		chown -R snort:snort "$config_dir"
+		procd_add_jail snort
+		procd_set_param capabilities /etc/capabilities/snort.json
+		procd_set_param user snort
+		procd_set_param group snort
+		procd_set_param no_new_privs 1
+	}
 	procd_set_param respawn
 	procd_set_param stdout 0
 	procd_set_param stderr 1

--- a/net/snort3/files/snort.json
+++ b/net/snort3/files/snort.json
@@ -1,0 +1,27 @@
+{
+	"bounding": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_RAW",
+		"CAP_IPC_LOCK"
+	],
+	"effective": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_RAW",
+		"CAP_IPC_LOCK"
+	],
+	"ambient": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_RAW",
+		"CAP_IPC_LOCK"
+	],
+	"permitted": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_RAW",
+		"CAP_IPC_LOCK"
+	],
+	"inheritable": [
+		"CAP_NET_ADMIN",
+		"CAP_NET_RAW",
+		"CAP_IPC_LOCK"
+	]
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Running as a dedicated user is better from both a security and an isolation perspective than running as root.

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** 

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
