### PR TITLE
[24.10] sing-box: add variant tiny

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -31,12 +31,24 @@ define Package/sing-box
   URL:=https://sing-box.sagernet.org
   DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle +kmod-inet-diag +kmod-tun
   USERID:=sing-box=5566:sing-box=5566
+  VARIANT:=full
+  DEFAULT_VARIANT:=1
 endef
 
 define Package/sing-box/description
   Sing-box is a universal proxy platform which supports hysteria, SOCKS, Shadowsocks,
   ShadowTLS, Tor, trojan, VLess, VMess, WireGuard and so on.
 endef
+
+define Package/sing-box-tiny
+  $(Package/sing-box)
+  TITLE+=(tiny)
+  PROVIDES:=sing-box
+  VARIANT:=tiny
+  CONFLICTS:=sing-box
+endef
+
+Package/sing-box-tiny/description:=$(Package/sing-box/description)
 
 define Package/sing-box/config
 	menu "Select build options"
@@ -96,6 +108,12 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_SINGBOX_WITH_V2RAY_API \
 	CONFIG_SINGBOX_WITH_WIREGUARD
 
+ifeq ($(BUILD_VARIANT),tiny)
+ifeq ($(CONFIG_SMALL_FLASH),)
+GO_PKG_TAGS:=with_gvisor
+endif
+GO_PKG_TAGS:=$(GO_PKG_TAGS),with_quic,with_utls,with_clash_api
+else
 GO_PKG_TAGS:=$(subst $(space),$(comma),$(strip \
 	$(if $(CONFIG_SINGBOX_WITH_ACME),with_acme) \
 	$(if $(CONFIG_SINGBOX_WITH_CLASH_API),with_clash_api) \
@@ -109,11 +127,14 @@ GO_PKG_TAGS:=$(subst $(space),$(comma),$(strip \
 	$(if $(CONFIG_SINGBOX_WITH_V2RAY_API),with_v2ray_api) \
 	$(if $(CONFIG_SINGBOX_WITH_WIREGUARD),with_wireguard) \
 ))
+endif
 
 define Package/sing-box/conffiles
 /etc/config/sing-box
 /etc/sing-box/
 endef
+
+Package/sing-box-tiny/conffiles=$(Package/sing-box/conffiles)
 
 define Package/sing-box/install
 	$(INSTALL_DIR) $(1)/usr/bin/
@@ -128,4 +149,7 @@ define Package/sing-box/install
 	$(INSTALL_BIN) ./files/sing-box.init $(1)/etc/init.d/sing-box
 endef
 
+Package/sing-box-tiny/install=$(Package/sing-box/install)
+
 $(eval $(call BuildPackage,sing-box))
+$(eval $(call BuildPackage,sing-box-tiny))

--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
 PKG_VERSION:=1.12.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
@@ -24,13 +24,18 @@ GO_PKG_LDFLAGS_X:=$(GO_PKG)/constant.Version=$(PKG_VERSION)
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
-define Package/sing-box
+define Package/sing-box-default
   TITLE:=The universal proxy platform
   SECTION:=net
   CATEGORY:=Network
   URL:=https://sing-box.sagernet.org
   DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle +kmod-inet-diag +kmod-tun
   USERID:=sing-box=5566:sing-box=5566
+endef
+
+define Package/sing-box
+  $(Package/sing-box-default)
+  TITLE+= (full)
   VARIANT:=full
   DEFAULT_VARIANT:=1
 endef
@@ -41,8 +46,8 @@ define Package/sing-box/description
 endef
 
 define Package/sing-box-tiny
-  $(Package/sing-box)
-  TITLE+=(tiny)
+  $(Package/sing-box-default)
+  TITLE+= (tiny)
   PROVIDES:=sing-box
   VARIANT:=tiny
   CONFLICTS:=sing-box


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @brvphoenix

**Description:**

Add variant tiny.

(cherry picked from commit 16ada8307b0170bb4343ae7e163bd3dc9aa98b49 and 2e2cc335a6968bad3b4ade69ca53831d91aa9c6f) 

I don't know how to do it correctly if I use cherrypick from two commits. If it's not correct, please tell me how to do it correctly.


---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Xiaomi Redmi AX6000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
