### PR TITLE
libjcat: update to 0.2.3

### DIFF
--- a/libs/libjcat/Config.in
+++ b/libs/libjcat/Config.in
@@ -1,6 +1,12 @@
 menu "Select libjcat options"
 	depends on PACKAGE_libjcat
 
+config LIBJCAT_CLI
+	bool "Command-line tool"
+	default n
+	help
+	  Compile and install the libjcat cli tool
+
 config LIBJCAT_GPG
 	bool "GPG"
 	default y
@@ -15,7 +21,7 @@ config LIBJCAT_PKCS7
 
 config LIBJCAT_ED25519
 	bool "ed25519"
-	default n
+	default y
 	help
 	  Compile libjcat with ed25519 support
 

--- a/libs/libjcat/Makefile
+++ b/libs/libjcat/Makefile
@@ -8,18 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libjcat
-PKG_VERSION:=0.2.1
+PKG_VERSION:=0.2.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/hughsie/libjcat/releases/download/$(PKG_VERSION)
-PKG_HASH:=a6232aeca3c3fab6dbb3bed06ec3832088b49a4b278a7119558d72be60ce921f
+PKG_HASH:=f2f115aad8a8f16b8dde1ed55de7abacb91d0878539aa29b2b60854b499db639
 
 PKG_MAINTAINER:=Lukas Voegl <lvoegl@tdt.de>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=LICENSE
-
-PKG_BUILD_DEPENDS:=glib2/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -36,8 +34,7 @@ define Package/libjcat
 	+LIBJCAT_GPG:libgpgme \
 	+LIBJCAT_GPG:libgpg-error \
 	+LIBJCAT_PKCS7:libgnutls \
-	+LIBJCAT_ED25519:libgnutls \
-	+LIBJCAT_ED25519:libnettle
+	+LIBJCAT_ED25519:libgnutls
 endef
 
 define Package/libjcat/description
@@ -50,13 +47,12 @@ define Package/libjcat/config
 endef
 
 MESON_ARGS += \
-	-Db_lto=true \
 	-Dgtkdoc=false \
 	-Dintrospection=false \
 	-Dvapi=false \
 	-Dtests=false \
 	-Dman=false \
-	-Dcli=false \
+	-Dcli=$(if $(CONFIG_LIBJCAT_CLI),true,false) \
 	-Dgpg=$(if $(CONFIG_LIBJCAT_GPG),true,false) \
 	-Dpkcs7=$(if $(CONFIG_LIBJCAT_PKCS7),true,false) \
 	-Ded25519=$(if $(CONFIG_LIBJCAT_ED25519),true,false)
@@ -78,6 +74,10 @@ endef
 define Package/libjcat/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libjcat.so* $(1)/usr/lib
+
+	$(if $(CONFIG_LIBJCAT_CLI), \
+		$(INSTALL_DIR) $(1)/usr/bin; \
+		$(CP) $(PKG_INSTALL_DIR)/usr/bin/jcat-tool $(1)/usr/bin)
 endef
 
 $(eval $(call BuildPackage,libjcat))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lvoegl

**Description:**
- Update to 0.2.3
- Remove `glib2/host` dependency
- New _cli_ option
- `libnettle` was dropped and therefore _ed25519_ can be enabled by default
---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** APU3

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.