### PR TITLE
ufp: Patch reference counting to fix memory leak

### DIFF
--- a/utils/ufp/patches/900-fix-reference-counting.patch
+++ b/utils/ufp/patches/900-fix-reference-counting.patch
@@ -1,0 +1,18 @@
+--- a/src/ucode.c
++++ b/src/ucode.c
+@@ -110,13 +110,13 @@ __reader_get_value(uc_vm_t *vm, struct u
+ 		if (type == UHT_HASHTBL)
+ 			ucv_object_add(val, hash_key, ucv_boolean_new(true));
+ 		uht_for_each(r, iter, attr)
+-			ucv_object_add(val, iter.key, ucv_get(__reader_get_value(vm, r, iter.val, dump)));
++			ucv_object_add(val, iter.key, __reader_get_value(vm, r, iter.val, dump));
+ 		return val;
+ 	case UHT_ARRAY:
+ 		val = ucv_array_new(vm);
+ 		i = 0;
+ 		uht_for_each(r, iter, attr)
+-			ucv_array_set(val, i++, ucv_get(__reader_get_value(vm, r, iter.val, dump)));
++			ucv_array_set(val, i++, __reader_get_value(vm, r, iter.val, dump));
+ 		return val;
+ 	}
+ 


### PR DESCRIPTION
## 📦 Package Details

Felix Fietkau @nbd168 

**Description:**
`__reader_get_value` only ever returns a new object so the `ucv_get` is not needed and adds an extra reference to the object.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** r30885-2ec7d57e0bc
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** SDG-8733

---

## ✅ Formalities

- [ x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
