### PR TITLE
snort3: cleanup and simplify Makefile

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -105,22 +105,6 @@ define Package/snort3/install
 
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/snort.config $(1)/etc/config/snort
-	
-	sed \
-		-i \
-		-e "/^-- HOME_NET and EXTERNAL_NET/ i -- The values for the two variables HOME_NET and EXTERNAL_NET have been" \
-		-e "/^-- HOME_NET and EXTERNAL_NET/ i -- moved to /etc/config/snort, so do not modify them here without good" \
-		-e "/^-- HOME_NET and EXTERNAL_NET/ i -- reason.\n" \
-		-e 's/^\(HOME_NET\s\+=\)/--\1/g' \
-		-e 's/^\(EXTERNAL_NET\s\+=\)/--\1/g' \
-		$(1)/etc/snort/snort.lua
-	sed \
-		-i -e "s/^\\(RULE_PATH\\s\\+=\\).*/\\1 'rules'/g" \
-		-e "s/^\\(BUILTIN_RULE_PATH\\s\\+=\\).*/\\1 'builtin_rules'/g" \
-		-e "s/^\\(PLUGIN_RULE_PATH\\s\\+=\\).*/\\1 'so_rules'/g" \
-		-e "s/^\\(WHITE_LIST_PATH\\s\\+=\\).*/\\1 'lists'/g" \
-		-e "s/^\\(BLACK_LIST_PATH\\s\\+=\\).*/\\1 'lists'/g" \
-		$(1)/etc/snort/snort_defaults.lua
 endef
 
 $(eval $(call BuildPackage,snort3))

--- a/net/snort3/patches/101-OpenWrt-package-modifications.patch
+++ b/net/snort3/patches/101-OpenWrt-package-modifications.patch
@@ -1,0 +1,43 @@
+--- a/lua/snort.lua
++++ b/lua/snort.lua
+@@ -19,13 +19,17 @@
+ -- 1. configure defaults
+ ---------------------------------------------------------------------------
+ 
++-- The values for the two variables HOME_NET and EXTERNAL_NET have been
++-- moved to /etc/config/snort, so do not modify them here without good
++-- reason.
++
+ -- HOME_NET and EXTERNAL_NET must be set now
+ -- setup the network addresses you are protecting
+-HOME_NET = 'any'
++--HOME_NET = 'any'
+ 
+ -- set up the external network addresses.
+ -- (leave as "any" in most situations)
+-EXTERNAL_NET = 'any'
++--EXTERNAL_NET = 'any'
+ 
+ include 'snort_defaults.lua'
+ 
+--- a/lua/snort_defaults.lua
++++ b/lua/snort_defaults.lua
+@@ -19,13 +19,13 @@
+ ---------------------------------------------------------------------------
+ 
+ -- Path to your rules files (this can be a relative path)
+-RULE_PATH = '../rules'
+-BUILTIN_RULE_PATH = '../builtin_rules'
+-PLUGIN_RULE_PATH = '../so_rules'
++RULE_PATH = 'rules'
++BUILTIN_RULE_PATH = 'builtin_rules'
++PLUGIN_RULE_PATH = 'so_rules'
+ 
+ -- If you are using reputation preprocessor set these
+-WHITE_LIST_PATH = '../lists'
+-BLACK_LIST_PATH = '../lists'
++WHITE_LIST_PATH = 'lists'
++BLACK_LIST_PATH = 'lists'
+ 
+ ---------------------------------------------------------------------------
+ -- default networks - used in Talos rules


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

1.  switch from git proto to tarballs. This gives a cleaner Makefile and faster build.
2. remove line splits to increase readability
3. replace complex sed calls with a patch to improve readability.

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/x86_64-glibc
- **OpenWrt Device:** generic PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
