### PR TITLE
Fix license fields for tiff, yaml and liburcu

### DIFF
--- a/libs/liburcu/Makefile
+++ b/libs/liburcu/Makefile
@@ -10,11 +10,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=liburcu
 PKG_VERSION:=0.15.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
-PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later MIT
-PKG_LICENSE_FILES:=lgpl-2.1.txt gpl-2.0.txt lgpl-relicensing.txt
+PKG_LICENSE:=LGPL-2.1-only LGPL-2.1-or-later GPL-2.0-or-later-with-Autoconf-exception-2.0 \
+             GPL-2.0-or-later-with-LicenseRef-Autoconf-exception-macro MIT FSFAP LicenseRef-Boehm-GC
+PKG_LICENSE_FILES:=LICENSES/LGPL-2.1-only.txt LICENSES/LGPL-2.1-or-later.txt LICENSES/GPL-2.0-or-later.txt \
+                   LICENSES/Autoconf-exception-2.0.txt LICENSES/LicenseRef-Autoconf-exception-macro.txt \
+                   LICENSES/MIT.txt LICENSES/FSFAP.txt LICENSES/LicenseRef-Boehm-GC.txt lgpl-relicensing.md LICENSE.md
 
 PKG_SOURCE:=userspace-rcu-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://lttng.org/files/urcu/

--- a/libs/tiff/Makefile
+++ b/libs/tiff/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tiff
 PKG_VERSION:=4.7.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.osgeo.org/libtiff
@@ -17,7 +17,7 @@ PKG_HASH:=67160e3457365ab96c5b3286a0903aa6e78bdc44c4bc737d2e486bcecb6ba976
 
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 PKG_LICENSE:=libtiff
-PKG_LICENSE_FILES:=COPYRIGHT
+PKG_LICENSE_FILES:=LICENSE.md
 PKG_CPE_ID:=cpe:/a:libtiff:libtiff
 
 include $(INCLUDE_DIR)/package.mk

--- a/libs/yaml/Makefile
+++ b/libs/yaml/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yaml
 PKG_VERSION:=0.2.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pyyaml.org/download/libyaml/
@@ -17,7 +17,7 @@ PKG_HASH:=c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=MIT
-PKG_LICENSE_FILES:=COPYING
+PKG_LICENSE_FILES:=License
 PKG_CPE_ID:=cpe:/a:pyyaml_project:pyyaml
 
 PKG_INSTALL:=1


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jslachta @salzmdan @neheb (yaml has an empty PKG_MAINTAINER, so I took the person who's committed the most to it)

**Description:** Correct license fields for tiff, yaml, and liburcu
<!-- Briefly describe what this package does or what changes are introduced -->


---

## 🧪 Run Testing Details

- **OpenWrt Version:**  24.10.2
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

Nothing to test, as it's just package metadata.

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.