### PR TITLE
cjson: update to 1.7.19

### DIFF
--- a/libs/cjson/Makefile
+++ b/libs/cjson/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cJSON
-PKG_VERSION:=1.7.18
+PKG_VERSION:=1.7.19
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/DaveGamble/cJSON/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=3aa806844a03442c00769b83e99970be70fbef03735ff898f4811dd03b9f5ee5
+PKG_HASH:=7fa616e3046edfa7a28a32d5f9eacfd23f92900fe1f8ccd988c1662f30454562
 
 PKG_MAINTAINER:=Karl Palsson <karlp@etactica.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @karlp

**Description:**

This is a bugfix release
Full release notes available at:
https://github.com/DaveGamble/cJSON/releases/tag/v1.7.19

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot r29619
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** x86 VM

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
