### PR TITLE
ruby: update to 3.4.5

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=3.3.9
+PKG_VERSION:=3.4.5
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=d1991690a4e17233ec6b3c7844c1e1245c0adce3e00d713551d0458467b727b1
+PKG_HASH:=1d88d8a27b442fdde4aa06dc99e86b0bbf0b288963d8433112dd5fac798fd5ee
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING
@@ -252,13 +252,23 @@ endef
 define Package/ruby-abbrev/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/abbrev.rb
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/abbrev-*/
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/abbrev-*.gemspec
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/abbrev-*.gemspec
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/abbrev-*/
+endef
+define Package/ruby-abbrev/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/abbrev-*/LICENSE.txt
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/abbrev-*/README.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/abbrev-*/Rakefile
 endef
 
 define Package/ruby-base64/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/base64.rb
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/base64-*/
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/base64-*.gemspec
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/base64-*.gemspec
+endef
+define Package/ruby-base64/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/base64-*/LICENSE.txt
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/base64-*/README.md
 endef
 
 define Package/ruby-benchmark/files
@@ -272,7 +282,14 @@ define Package/ruby-bigdecimal/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/*/bigdecimal.so
 /usr/lib/ruby/$(PKG_ABI_VERSION)/bigdecimal/
 /usr/lib/ruby/$(PKG_ABI_VERSION)/bigdecimal.rb
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/bigdecimal-*/
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/bigdecimal-*.gemspec
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/bigdecimal-*.gemspec
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/extensions/*/$(PKG_ABI_VERSION)/bigdecimal-*/
+endef
+define Package/ruby-bigdecimal/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/bigdecimal-*/sample/*
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/bigdecimal-*/Rakefile
 endef
 
 define Package/ruby-bundler/files
@@ -317,7 +334,15 @@ endef
 define Package/ruby-csv/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/csv.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/csv/
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/csv-*.gemspec
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/csv-*/
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/csv-*.gemspec
+endef
+define Package/ruby-csv/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/csv-*/doc/*
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/csv-*/LICENSE
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/csv-*/LICENSE.txt
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/csv-*/NEWS.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/csv-*/README.md
 endef
 
 define Package/ruby-date/files
@@ -337,6 +362,7 @@ define Package/ruby-debug/files-excluded
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/debug-*/LICENSE.txt
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/debug-*/README.md
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/debug-*/TODO.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/debug-*/Rakefile
 endef
 define Package/ruby-debug/install
 	$(INSTALL_DIR) $(1)/usr/bin
@@ -387,7 +413,11 @@ endef
 define Package/ruby-drb/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/drb.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/drb
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/drb-*.gemspec
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/drb-*/
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/drb-*.gemspec
+endef
+define Package/ruby-drb/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/drb-*/LICENSE.txt
 endef
 
 define Package/ruby-enc/files
@@ -492,7 +522,13 @@ define Package/ruby-getoptlong/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/getoptlong.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/getoptlong/
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/getoptlong-*/
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/getoptlong-*.gemspec
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/getoptlong-*.gemspec
+endef
+define Package/ruby-getoptlong/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/getoptlong-*/LICENSE.txt
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/getoptlong-*/README.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/getoptlong-*/Rakefile
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/getoptlong-*/sample/*
 endef
 
 define Package/ruby-io-console/files
@@ -557,6 +593,7 @@ define Package/ruby-minitest/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/minitest-*
 endef
 define Package/ruby-minitest/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/minitest-*/Rakefile
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/minitest-*/test
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/minitest-*/*.rdoc
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/minitest-*/*.txt
@@ -577,7 +614,13 @@ endef
 
 define Package/ruby-mutex_m/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/mutex_m.rb
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/mutex_m-*.gemspec
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/mutex_m-*/
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/mutex_m-*.gemspec
+endef
+define Package/ruby-mutex_m/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/mutex_m-*/BSDL
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/mutex_m-*/COPYING
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/mutex_m-*/README.md
 endef
 
 define Package/ruby-net-ftp/files
@@ -585,8 +628,11 @@ define Package/ruby-net-ftp/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/net-ftp-*.gemspec
 endef
 define Package/ruby-net-ftp/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-ftp-*/BSDL
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-ftp-*/COPYING
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-ftp-*/LICENSE.txt
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-ftp-*/README.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-ftp-*/Rakefile
 endef
 
 define Package/ruby-net-http/files
@@ -602,8 +648,12 @@ define Package/ruby-net-imap/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/net-imap-*.gemspec
 endef
 define Package/ruby-net-imap/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-imap-*/BSDL
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-imap-*/COPYING
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-imap-*/LICENSE.txt
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-imap-*/README.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-imap-*/Rakefile
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-imap-*/sample/*
 endef
 
 define Package/ruby-net-pop/files
@@ -613,6 +663,7 @@ endef
 define Package/ruby-net-pop/files-excluded
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-pop-*/LICENSE.txt
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-pop-*/README.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/net-pop-*/Rakefile
 endef
 
 define Package/ruby-net-protocol/files
@@ -633,7 +684,15 @@ endef
 define Package/ruby-nkf/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/kconv.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/*/nkf.so
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/nkf-*.gemspec
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/extensions/*/$(PKG_ABI_VERSION)/nkf-*/
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/nkf-*/*
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/nkf-*.gemspec
+endef
+define Package/ruby-nkf/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/nkf-*/*ext/java/*
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/nkf-*/Rakefile
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/nkf-*/LICENSE.txt
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/nkf-*/README.md
 endef
 
 define Package/ruby-objspace/files
@@ -646,7 +705,12 @@ define Package/ruby-observer/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/observer.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/observer/
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/observer-*/
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/observer-*.gemspec
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/observer-*.gemspec
+endef
+define Package/ruby-observer/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/observer-*/LICENSE.txt
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/observer-*/README.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/observer-*/Rakefile
 endef
 
 define Package/ruby-open-uri/files
@@ -695,6 +759,9 @@ define Package/ruby-powerassert/files-excluded
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/power_assert-*/*.rdoc
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/power_assert-*/.travis.yml
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/power_assert-*/README.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/power_assert-*/BSDL
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/power_assert-*/COPYING
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/power_assert-*/Rakefile
 endef
 
 define Package/ruby-pp/files
@@ -714,6 +781,9 @@ endef
 define Package/ruby-prime/files-excluded
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/prime-*/LICENSE.txt
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/prime-*/README.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/prime-*/BSDL
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/prime-*/COPYING
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/prime-*/Rakefile
 endef
 
 define Package/ruby-prism/files
@@ -747,6 +817,16 @@ define Package/ruby-racc/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/racc-*/
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/racc-*.gemspec
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/extensions/*/$(PKG_ABI_VERSION)/racc-*/*
+endef
+define Package/ruby-racc/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/racc-*/BSDL
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/racc-*/COPYING
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/racc-*/LICENSE.txt
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/racc-*/README.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/racc-*/README.ja.rdoc
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/racc-*/README.rdoc
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/racc-*/Rakefile
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/racc-*/doc/*
 endef
 define Package/ruby-racc/install
 	$(INSTALL_DIR) $(1)/usr/bin
@@ -787,6 +867,10 @@ define Package/ruby-rbs/files-excluded
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rbs-*/test
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rbs-*/sample
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rbs-*/*.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rbs-*/BSDL
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rbs-*/COPYING
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rbs-*/Rakefile
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/extensions/gems/rbs-*/Rakefile
 endef
 define Package/ruby-rbs/install
 	$(INSTALL_DIR) $(1)/usr/bin
@@ -826,6 +910,16 @@ define Package/ruby-reline/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/reline-*.gemspec
 endef
 
+define Package/ruby-repl_type_completor/files
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/repl_type_completor-*/*
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/repl_type_completor-*.gemspec
+endef
+define Package/ruby-repl_type_completor/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/repl_type_completor-*/Rakefile
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/repl_type_completor-*/LICENSE.txt
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/repl_type_completor-*/README.md
+endef
+
 define Package/ruby-resolv/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/resolv.rb
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/resolv-*.gemspec
@@ -836,7 +930,13 @@ endef
 
 define Package/ruby-resolv-replace/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/resolv-replace.rb
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/resolv-replace*.gemspec
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/resolv-replace-*/*
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/resolv-replace*.gemspec
+endef
+define Package/ruby-resolv-replace/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/resolv-replace-*/LICENSE.txt
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/resolv-replace-*/README.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/resolv-replace-*/Rakefile
 endef
 
 define Package/ruby-rexml/files
@@ -854,8 +954,14 @@ define Package/ruby-rexml/files-excluded
 endef
 
 define Package/ruby-rinda/files
-/usr/lib/ruby/$(PKG_ABI_VERSION)/rinda
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/rinda-*.gemspec
+/usr/lib/ruby/$(PKG_ABI_VERSION)/rinda/*
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rinda-*/
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/rinda-*.gemspec
+endef
+define Package/ruby-rinda/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rinda-*/LICENSE.txt
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rinda-*/README.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/rinda-*/Rakefile
 endef
 
 define Package/ruby-ripper/files
@@ -921,6 +1027,7 @@ define Package/ruby-stringio/files
 endef
 
 define Package/ruby-strscan/files
+/usr/lib/ruby/$(PKG_ABI_VERSION)/strscan/strscan.rb
 /usr/lib/ruby/$(PKG_ABI_VERSION)/*/strscan.so
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/strscan-*.gemspec
 endef
@@ -940,7 +1047,15 @@ endef
 define Package/ruby-syslog/files
 /usr/lib/ruby/$(PKG_ABI_VERSION)/*/syslog.so
 /usr/lib/ruby/$(PKG_ABI_VERSION)/syslog/logger.rb
-/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/default/syslog-*.gemspec
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/syslog-*/
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/extensions/*/$(PKG_ABI_VERSION)/syslog-*/
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/specifications/syslog-*.gemspec
+endef
+define Package/ruby-syslog/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/syslog-*/LICENSE.txt
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/syslog-*/README.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/syslog-*/Rakefile
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/syslog-*/ext/syslog/syslog.txt
 endef
 
 define Package/ruby-testunit/files
@@ -948,10 +1063,13 @@ define Package/ruby-testunit/files
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/test-unit-*
 endef
 define Package/ruby-testunit/files-excluded
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/test-unit-*/BSDL
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/test-unit-*/COPYING
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/test-unit-*/doc
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/test-unit-*/test
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/test-unit-*/sample
 /usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/test-unit-*/*.md
+/usr/lib/ruby/gems/$(PKG_ABI_VERSION)/gems/test-unit-*/Rakefile
 endef
 
 define Package/ruby-time/files
@@ -1110,13 +1228,13 @@ $(eval $(call RubyBuildPackage,abbrev,Calculates the set of unambiguous abbrevia
 $(eval $(call RubyBuildPackage,base64,Encode and decode base64,))
 $(eval $(call RubyBuildPackage,benchmark,Performance benchmarking library,))
 $(eval $(call RubyBuildPackage,bigdecimal,Arbitrary-precision decimal floating-point library,))
-$(eval $(call RubyBuildPackage,bundler,Manage dependencies,+ruby-erb +ruby-irb +ruby-logger +ruby-readline +ruby-yaml))
+$(eval $(call RubyBuildPackage,bundler,Manage dependencies,+ruby-erb +ruby-logger +ruby-readline +ruby-yaml))
 $(eval $(call RubyBuildPackage,cgi,CGI support toolkit,+ruby-pstore +ruby-securerandom +ruby-shellwords +ruby-stringio +ruby-tempfile))
 $(eval $(call RubyBuildPackage,continuation,Similar to C setjmp/longjmp with extra states,))
 $(eval $(call RubyBuildPackage,coverage,Coverage measurement,))
-$(eval $(call RubyBuildPackage,csv,CSV Reading and Writing,+ruby-date +ruby-english +ruby-forwardable +ruby-stringio +ruby-strscan))
+$(eval $(call RubyBuildPackage,csv,CSV Reading and Writing,+ruby-enc +ruby-english +ruby-forwardable +ruby-pp +ruby-stringio +ruby-strscan +ruby-time))
 $(eval $(call RubyBuildPackage,date,Comparable module for handling dates,))
-$(eval $(call RubyBuildPackage,debug,generic command line interface for ruby-debug,+ruby-base64 +ruby-irb +ruby-mkmf +ruby-objspace +ruby-readline))
+$(eval $(call RubyBuildPackage,debug,generic command line interface for ruby-debug,+ruby-irb +ruby-objspace +ruby-readline))
 $(eval $(call RubyBuildPackage,delegate,lib to delegate method calls to an object,))
 $(eval $(call RubyBuildPackage,did-you-mean,did you mean? experience,+ruby-rbconfig))
 $(eval $(call RubyBuildPackage,digest,Digest Library,+RUBY_DIGEST_USE_OPENSSL:libopenssl))
@@ -1125,7 +1243,7 @@ $(eval $(call RubyBuildPackage,enc,character re-coding library charset (small su
 $(eval $(call RubyBuildPackage,enc-extra,character re-coding library charset (extra subset),+ruby-enc))
 $(eval $(call RubyBuildPackage,english,Reference some global vars as english variables,))
 $(eval $(call RubyBuildPackage,erb,(embedded interpreter),+ruby-gems))
-$(eval $(call RubyBuildPackage,error_highlight,Fine-grained error location in backtrace,))
+$(eval $(call RubyBuildPackage,error_highlight,Fine-grained error location in backtrace,+ruby-io-console +ruby-prism))
 $(eval $(call RubyBuildPackage,etc,Access info typically stored in /etc,))
 $(eval $(call RubyBuildPackage,expect,Expect-like for IO,))
 $(eval $(call RubyBuildPackage,fcntl,Loads constants defined in the OS fcntl.h C header file,))
@@ -1138,19 +1256,19 @@ $(eval $(call RubyBuildPackage,getoptlong,implementation of getoptLong,))
 $(eval $(call RubyBuildPackage,io-console,Console interface,))
 $(eval $(call RubyBuildPackage,io-nonblock,Non-blocking mode with IO class,))
 $(eval $(call RubyBuildPackage,io-wait,Waits until IO is readable or writable without blocking,))
-$(eval $(call RubyBuildPackage,ipaddr,Set of methods to manipulate an IP address,+ruby-socket))
-$(eval $(call RubyBuildPackage,irb,(interactive shell),+ruby-gems +ruby-reline +ruby-ripper))
-$(eval $(call RubyBuildPackage,json,JSON Implementation for Ruby,+ruby-bigdecimal +ruby-date +ruby-ostruct))
+$(eval $(call RubyBuildPackage,ipaddr,Set of methods to manipulate an IP address,+ruby-enc +ruby-socket))
+$(eval $(call RubyBuildPackage,irb,(interactive shell),+ruby-reline +ruby-repl_type_completor))
+$(eval $(call RubyBuildPackage,json,JSON Implementation for Ruby,+ruby-bigdecimal +ruby-date +ruby-enc +ruby-ostruct +ruby-set))
 $(eval $(call RubyBuildPackage,logger,logger and syslog library,+ruby-monitor +ruby-rbconfig))
 $(eval $(call RubyBuildPackage,matrix,implementation of Matrix and Vector classes,))
-$(eval $(call RubyBuildPackage,minitest,Gem minitest,+ruby-gems +ruby-mutex_m))
+$(eval $(call RubyBuildPackage,minitest,Gem minitest,+ruby-did-you-mean +ruby-json +ruby-rake +ruby-stringio +ruby-tempfile))
 $(eval $(call RubyBuildPackage,mjit,Method Based Just-in-Time Compiler,+ruby-fiddle))
 $(eval $(call RubyBuildPackage,mkmf,makefile library,+ruby-shellwords +ruby-tmpdir))
 $(eval $(call RubyBuildPackage,monitor,Object or module methods are executed with mutual exclusion,))
 $(eval $(call RubyBuildPackage,mutex_m,extend objects to be handled like a Mutex,))
 $(eval $(call RubyBuildPackage,net-ftp,FTP lib,+ruby-monitor +ruby-net-protocol +ruby-openssl +ruby-time))
 $(eval $(call RubyBuildPackage,net-http,HTTP lib,+ruby-cgi +ruby-net-protocol +ruby-resolv +ruby-strscan +ruby-uri +ruby-zlib))
-$(eval $(call RubyBuildPackage,net-imap,IMAP lib,+ruby-json +ruby-monitor +ruby-net-protocol +ruby-securerandom +ruby-strscan +ruby-time))
+$(eval $(call RubyBuildPackage,net-imap,IMAP lib,+ruby-forwardable +ruby-json +ruby-monitor +ruby-net-protocol +ruby-securerandom +ruby-strscan +ruby-time))
 $(eval $(call RubyBuildPackage,net-pop,POP3 lib,+ruby-net-protocol +ruby-openssl))
 $(eval $(call RubyBuildPackage,net-protocol,Abstract for net-* clients,+ruby-socket +ruby-timeout))
 $(eval $(call RubyBuildPackage,net-smtp,SMTP lib,+ruby-net-protocol +ruby-openssl))
@@ -1159,10 +1277,10 @@ $(eval $(call RubyBuildPackage,objspace,Routines to interact with the garbage co
 $(eval $(call RubyBuildPackage,observer,Observer design pattern,))
 $(eval $(call RubyBuildPackage,open-uri,Wrapper for Net::HTTP Net::HTTPS and Net::,+ruby-net-ftp +ruby-net-http))
 $(eval $(call RubyBuildPackage,open3,popen with stderr,))
-$(eval $(call RubyBuildPackage,openssl,SSL TLS and general purpose cryptography,+ruby-digest +ruby-enc +ruby-io-nonblock +ruby-ipaddr +libopenssl))
+$(eval $(call RubyBuildPackage,openssl,SSL TLS and general purpose cryptography,+ruby-digest +ruby-io-nonblock +ruby-ipaddr +libopenssl))
 $(eval $(call RubyBuildPackage,optparse,command-line option analysis,+ruby-enc-extra +ruby-pp +ruby-shellwords +ruby-time +ruby-uri))
 $(eval $(call RubyBuildPackage,ostruct,build custom data structures,))
-$(eval $(call RubyBuildPackage,pathname,Pathname lib,+ruby-fileutils +ruby-find))
+$(eval $(call RubyBuildPackage,pathname,Pathname lib,+ruby-find +ruby-tmpdir))
 $(eval $(call RubyBuildPackage,powerassert,Gem power_assert,+ruby-irb))
 $(eval $(call RubyBuildPackage,pp,Pretty print objects,+ruby-etc +ruby-io-console +ruby-prettyprint))
 $(eval $(call RubyBuildPackage,prettyprint,PrettyPrint library,))
@@ -1171,15 +1289,16 @@ $(eval $(call RubyBuildPackage,prism,parser for the Ruby programming language,+r
 $(eval $(call RubyBuildPackage,pstore,file based persistence,+ruby-digest +ruby-enc))
 $(eval $(call RubyBuildPackage,psych,YAML parser and emitter,+ruby-bigdecimal +ruby-date +ruby-enc +ruby-stringio +libyaml))
 $(eval $(call RubyBuildPackage,pty,Creates and manages pseudo terminals,))
-$(eval $(call RubyBuildPackage,racc,LALR parser generator,+ruby-forwardable +ruby-mkmf +ruby-optparse +ruby-stringio))
-$(eval $(call RubyBuildPackage,rake,Rake (make replacement),+ruby-fileutils +ruby-monitor +ruby-optparse +ruby-ostruct +ruby-set +ruby-singleton))
+$(eval $(call RubyBuildPackage,racc,LALR parser generator,+ruby-forwardable +ruby-optparse +ruby-rbconfig +ruby-stringio))
+$(eval $(call RubyBuildPackage,rake,Rake (make replacement),+ruby-fileutils +ruby-monitor +ruby-optparse +ruby-set +ruby-singleton))
 $(eval $(call RubyBuildPackage,random_formatter,Formats generated random numbers in many manners,))
 $(eval $(call RubyBuildPackage,rbconfig,RbConfig,))
-$(eval $(call RubyBuildPackage,rbs,RBS provides syntax and semantics definition for the Ruby Signature language,+ruby-abbrev +ruby-logger +ruby-rdoc))
-$(eval $(call RubyBuildPackage,rdoc,RDoc produces HTML and command-line documentation for Ruby projects,+ruby-did-you-mean +ruby-erb +ruby-racc +ruby-ripper +ruby-yaml))
+$(eval $(call RubyBuildPackage,rbs,RBS provides syntax and semantics definition for the Ruby Signature language,+ruby-logger +ruby-rdoc))
+$(eval $(call RubyBuildPackage,rdoc,RDoc produces HTML and command-line documentation for Ruby projects,+ruby-did-you-mean +ruby-erb +ruby-prism +ruby-racc +ruby-yaml))
 $(eval $(call RubyBuildPackage,readline-ext,support for native GNU readline,+libncurses +libreadline))
 $(eval $(call RubyBuildPackage,readline,loads readline-ext(native) or reline(ruby),+ruby-reline))
 $(eval $(call RubyBuildPackage,reline,alternative to readline-ext in pure ruby,+ruby-fiddle +ruby-forwardable +ruby-io-console +ruby-tempfile))
+$(eval $(call RubyBuildPackage,repl_type_completor,type based completor for REPL,+ruby-rbs))
 $(eval $(call RubyBuildPackage,resolv,DNS resolver library,+ruby-securerandom +ruby-timeout))
 $(eval $(call RubyBuildPackage,resolv-replace,Replace Socket DNS with Resolv,+ruby-resolv))
 $(eval $(call RubyBuildPackage,rexml,XML toolkit,+ruby-enc +ruby-forwardable +ruby-pp +ruby-set +ruby-stringio +ruby-strscan))
@@ -1198,13 +1317,13 @@ $(eval $(call RubyBuildPackage,strscan,Lexical scanning operations on a String,)
 $(eval $(call RubyBuildPackage,syntax_suggest,Find missing end syntax errors,+ruby-gems +ruby-prism))
 $(eval $(call RubyBuildPackage,syslog,Syslog Lib,+ruby-logger))
 $(eval $(call RubyBuildPackage,tempfile,Manages temporary files,+ruby-delegate +ruby-tmpdir))
-$(eval $(call RubyBuildPackage,testunit,Gem test-unit,+ruby-csv +ruby-debug +ruby-erb +ruby-powerassert +ruby-rexml +ruby-yaml))
+$(eval $(call RubyBuildPackage,testunit,Gem test-unit,+ruby-csv +ruby-debug +ruby-powerassert +ruby-rexml))
 $(eval $(call RubyBuildPackage,time,Extends Time with additional methods for parsing and converting Times,+ruby-date))
 $(eval $(call RubyBuildPackage,timeout,Auto-terminate potentially long-running operations,))
 $(eval $(call RubyBuildPackage,tmpdir,Get temp dir path,+ruby-fileutils))
 $(eval $(call RubyBuildPackage,tsort,Topological sorting using Tarjan s algorithm,))
-$(eval $(call RubyBuildPackage,typeprof,A type analysis tool for Ruby code based on abstract interpretation,+ruby-coverage +ruby-rbs))
-$(eval $(call RubyBuildPackage,unicodenormalize,String additions for Unicode normalization,+ruby-enc +ruby-enc-extra))
+$(eval $(call RubyBuildPackage,typeprof,A type analysis tool for Ruby code based on abstract interpretation,+ruby-rbs))
+$(eval $(call RubyBuildPackage,unicodenormalize,String additions for Unicode normalization,+ruby-enc-extra))
 $(eval $(call RubyBuildPackage,un,Utilities to replace common UNIX commands in Makefiles,+ruby-irb +ruby-mkmf))
 $(eval $(call RubyBuildPackage,uri,library to handle URI,+ruby-enc))
 $(eval $(call RubyBuildPackage,weakref,Weak reference to be garbage collected,+ruby-delegate))

--- a/lang/ruby/patches/010-fix-riscv64-build.patch
+++ b/lang/ruby/patches/010-fix-riscv64-build.patch
@@ -15,7 +15,7 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
 
 --- a/vm_dump.c
 +++ b/vm_dump.c
-@@ -39,6 +39,15 @@
+@@ -40,6 +40,15 @@
  
  #define MAX_POSBUF 128
  

--- a/lang/ruby/ruby_find_pkgsdeps
+++ b/lang/ruby/ruby_find_pkgsdeps
@@ -1,68 +1,86 @@
 #!/usr/bin/ruby -Eutf-8
 # encoding: utf-8
 #
+# -*- mode: ruby -*-
+# vi: set tabstop=8 shiftwidth=8 noexpandtab:
+#
+#
 # Find dependencies between ruby packages
 #
 # Must run inside a openwrt with all *ruby* packages installed
 #
+#
+$debug=$stderr
+$info=$stderr
+$error=$stderr
+
+#$debug=File.open("/dev/null")
 
 require "rbconfig"
-
 RUBY_SIMPLE_VERSION = RUBY_VERSION.split(".")[0..1].join(".")
 failed = false
 
-puts "Loading all installed gems (unstable after external gems are instaled/update)"
+$info.puts "Loading all installed gems (unstable after external gems are instaled/update)"
 require 'rubygems'
 Gem::Specification.collect{ |g| g.name.downcase }.uniq.each {|g| gem g }
 
-puts "Looking for installed ruby packages..."
-packages=`opkg list-installed '*ruby*' | cut -d' ' -f 1`.split("\n")
-
-puts "Looking for packages files..."
-package_files=Hash.new { |h,k| h[k]=[] }
-packages.each do
-	|pkg|
-	files=`opkg files "#{pkg}" | sed -e 1d`.split("\n")
-	package_files[pkg]=files if files
+$info.puts "Looking for installed ruby packages (and its files)..."
+packages = []
+package_files = {}
+package_depends = {}
+packages_json=`apk info --format json --contents --depends --match url 'http://www.ruby-lang.org/'`
+require "json"
+JSON.parse(packages_json).each do |pkg|
+  next if not pkg["contents"]
+  packages << pkg["name"]
+  package_files[pkg["name"]] = pkg["contents"].map() {|file| "/#{file}" }
+  package_depends[pkg["name"]] = pkg["depends"].reject{|dep| dep =~ /^lib/ or dep == "ruby" }
 end
 # Fake enc/utf_16 to dummy enc:
 package_files["ruby-enc"]+=[RbConfig::CONFIG["rubylibdir"] + "/enc/utf_16.rb" ]
 
-require_regex=/^ *require ["']([^"']+)["'].*/
-require_regex_ignore=/^ *require ([a-zA-Z\$]|["']\$|.*\/$|.*#.*|.*\.$)/
+# These are Encodings that does not require extra files
+builtin_enc=[
+	Encoding.find("ASCII-8BIT"),
+	Encoding.find("UTF-8"),
+	Encoding.find("UTF-7"),
+	Encoding.find("US-ASCII"),
+]
+
+# List of requires that can be simply ignored, normally because they are conditional
+# requirements or to break loops
 require_ignore=%w{
 	bundler
 	capistrano/version
-	coverage/helpers
 	dbm
 	ffi
 	fiber
-	foo
 	gettext/mo
 	gettext/po_parser
 	graphviz
 	iconv
 	java
+	json/truffle_ruby/generator
 	jruby
-	json/pure
 	minitest/proveit
+	nkf.jar
 	open3/jruby_windows
+	parser
 	prism/prism
 	profile
+	psych_jars
 	racc/cparse-jruby.jar
-	repl_type_completor
+	ruby_parser
 	rubygems/defaults/operating_system
 	rubygems/net/http
 	rubygems/timeout
 	sorted_set
 	stackprof
-	thread
 	tracer
 	uconv
 	webrick
 	webrick/https
 	win32api
-	win32ole
 	win32/resolv
 	win32/sspi
 	xml/encoding-ja
@@ -71,111 +89,255 @@ require_ignore=%w{
 	xmlparser
 	xmlscan/scanner
 }
+# Keep track of which of these ignores really matters
+require_ignore_that_matched={}
 
-matched_ignored={}
+files_ignore=%w{
+	extconf.rb
+}
 
-builtin_enc=[
-	Encoding.find("ASCII-8BIT"),
-	Encoding.find("UTF-8"),
-	Encoding.find("UTF-7"),
-	Encoding.find("US-ASCII"),
-]
+# The digestor that parsers the ruby source code for requires or use of Encodings
+require "ripper"
+def parse_requires_ripper(source)
+	requires = []
+	encodings = []
 
-puts "Looking for requires in files..."
+	ast = Ripper.sexp(source)
+	stack = [ast]
+
+	until stack.empty?
+		node = stack.pop
+		next unless node.is_a?(Array)
+
+		case node[0]
+		when :command
+			req = nil
+			case node[1][1]
+			when "require"
+				#[:command, [:@ident, "require", [3, 0]], [:args_add_block, [[:string_literal, [:string_content, [:@tstring_content, "pathname", [3, 9]]]]], false]]
+				#[:command, [:@ident, "require", [3, 0]], [:args_add_block, [[:string_literal, [:string_content, [:@tstring_content, "rbconfig", [3, 9]]]]], false]]
+				#[:command, [:@ident, "require", [3, 0]], [:args_add_block, [[:string_literal, [:string_content, [:@tstring_content, "rubygems/dependency", [3, 9]]]]], false]]
+				# Only accepts requires with only a literal strings (without embeded expressions)
+				req = node[2][1][0][1][1][1] if node[2][1][0][1][1][0] == :@tstring_content and node[2][1][0][1].length == 2 rescue nil
+				requires << req if req
+			end
+
+			# node = [:command, [:@ident, "pp", [ln,col]], [:args_add_block, ...]]
+			if node[1][0] == :@ident && node[1][1] == "pp"
+				requires << "pp"
+			end
+
+		when :command_call
+			req = nil
+			# node = [:command_call, receiver, [:@period, ".", [ln,col]], [:@ident, "require", [ln,col]], args]
+			if node[3][1] == "require"
+				# Only accepts requires with only a literal strings (without embedded expressions)
+				args = node[4] rescue nil
+				if args && args[1] && args[1][0] && args[1][0][1] && args[1][0][1][1][0] == :@tstring_content && args[1][0][1].length == 2
+					req = args[1][0][1][1][1] rescue nil
+					requires << req if req
+				end
+			end			
+		# The args in Encoding.find (if a string constant) should also requires the encoding (but,in practice,
+		# there is no case for it current ruby code
+		when :const_path_ref
+			# [:const_path_ref, [:var_ref, [:@const, "Encoding", [136, 9]]], [:@const, "US_ASCII", [136, 19]]]
+			if node[1][0]=:const_ref and node[1][1][1] == "Encoding" and node[2][0] = :@const
+				enc = node[2][1]
+
+				enc = eval("Encoding::#{enc}")
+				encodings << enc if enc.kind_of? Encoding
+
+				# The builtin encodings do not populate Encoding::XXX constants
+				requires << "enc/encdb"
+			end
+
+			node.each do |child|
+				stack << child if child.is_a?(Array)
+			end
+
+		when :method_add_arg
+			# Detects fcall :pp => [:method_add_arg, [:fcall, [:@ident, "pp", [1,0]]], ...]
+			if node[1][0] == :fcall && node[1][1][0] == :@ident && node[1][1][1] == "pp"
+				requires << "pp"
+			end
+
+			# Detects Kernel.pp => [:method_add_arg, [:call, [:var_ref, [:@const, "Kernel", [1,0]]], :".", [:@ident, "pp", [1,8]]], ...]
+			if node[1][0] == :call &&
+			   node[1][1][0] == :var_ref && node[1][1][1][1] == "Kernel" &&
+			   node[1][3][0] == :@ident && node[1][3][1] == "pp"
+				requires << "pp"
+			end
+		end
+
+		node.each do |child|
+			stack << child if child.is_a?(Array)
+		end
+	end
+
+	return requires, encodings
+end
+
+require "prism"
+def parse_requires_prism(source)
+	requires  = []
+	encodings = []
+
+	result = Prism.parse(source)
+	stack  = [result.value] # root node
+
+	until stack.empty?
+		node = stack.pop
+		next unless node.is_a?(Prism::Node)
+
+		case node
+		when Prism::CallNode
+			# e.g. `require "foo"`
+			if node.name == :require && node.arguments&.arguments&.size == 1
+				arg = node.arguments.arguments.first
+				if arg.is_a?(Prism::StringNode)
+					requires << arg.unescaped
+				end
+			end
+
+			# Detects Kernel.pp or pp(...)
+			if node.name == :pp
+				if node.receiver.nil? # just `pp(...)`
+					requires << "pp"
+				elsif node.receiver.is_a?(Prism::ConstantReadNode) && node.receiver.name == :Kernel
+					requires << "pp"
+				end
+			end
+
+		when Prism::ConstantPathNode
+			# e.g. Encoding::US_ASCII
+			if node.parent.is_a?(Prism::ConstantReadNode) &&
+			   node.parent.name == :Encoding &&
+			   node.child.is_a?(Prism::ConstantReadNode)
+
+				enc = node.child.name.to_s
+				begin
+					enc_obj = Encoding.const_get(enc)
+					encodings << enc_obj if enc_obj.is_a?(Encoding)
+					requires << "enc/encdb"
+				rescue NameError
+					# ignore if unknown
+				end
+			end
+
+
+			# e.g. ::Encoding::XXX
+			if node.parent.is_a?(Prism::ConstantPathNode) &&
+			   node.parent.child.is_a?(Prism::ConstantReadNode) &&
+			   node.parent.child.name == :Encoding &&
+			   node.child.is_a?(Prism::ConstantReadNode)
+
+				enc = node.child.name.to_s
+				begin
+					enc_obj = Encoding.const_get(enc)
+					encodings << enc_obj if enc_obj.is_a?(Encoding)
+					requires << "enc/encdb"
+				rescue NameError
+				end
+			end
+		end
+
+		# Recurse through children
+		node.child_nodes.compact.each do |child|
+			stack << child
+		end
+	end
+
+	[requires, encodings]
+end
+
+# Now check what each files in packages needs
+$info.puts "Looking for requires in files..."
 files_requires=Hash.new { |h,k| h[k]=[] }
 packages.each do
-        |pkg|
+	|pkg|
+	$debug.puts "Checking pkg #{pkg}..."
+
 	package_files[pkg].each do
 		|file|
-		next if not File.file?(file)
+		next if not File.file?(file) or not File.readable?(file)
 
-		if not file =~ /.rb$/
-			if File.executable?(file)
-				magic=`head -c50 '#{file}' | head -1`
-				begin
-					if not magic =~ /ruby/
-						next
-					end
-				rescue
-					next
-				end
-			else
-				next
-			end
+		next if files_ignore.include?(file) or files_ignore.include?(file.sub(/.*\//,""))
+
+		#file = "/usr/lib/ruby/3.4/bundler/rubygems_ext.rb"
+		#file = "/usr/lib/ruby/3.4/openssl/buffering.rb"
+		#file = "/usr/lib/ruby/3.4/unicode_normalize/normalize.rb"
+		#file = "/usr/lib/ruby/3.4/rdoc/encoding.rb"
+		#file = "/usr/lib/ruby/3.4/bundler.rb"
+		#file = "/usr/lib/ruby/3.4/bundler/rubygems_ext.rb"
+		#file = "/usr/lib/ruby/gems/3.4/gems/debug-1.11.0/lib/debug/server.rb"
+
+		f = File.open(file,"r")
+		line1 = f.gets()
+
+		if not file =~ /\.rb$/
+			next if not File.executable?(file)
+			next if not line1[0..1] == "#!"
+			next if not line1 =~ /^#!.*ruby/
+			$debug.puts "File #{pkg}:#{file} is a ruby script"
 		end
-		#puts "Checking #{file}..."
-		File.open(file, "r") do
-			|f|
-			lineno=0
-			while line=f.gets() do
-				lineno+=1; encs=[]; requires=[]; need_encdb=false
+		# Ignore the shebang if present
+		line1 = f.gets() if line1 =~ /#!.*ruby/
 
-				line=line.chomp.gsub!(/^[[:blank:]]*/,"")
+		# Rewind to parse it all again
+		f.rewind()
 
-				case line
-				when /^#.*coding *:/
-					if lineno <= 2
-						enc=line.sub(/.*coding *: */,"").sub(/ .*/,"")
-						encs << Encoding.find(enc)
-					end
-				end
-				line.gsub!(/#.*/,"")
-				case line
-				when "__END__"
-					break
-				when /^require /
-					#puts "#{file}:#{line}"
-					if require_regex_ignore =~ line
-						puts "Ignoring #{line} at #{file}:#{lineno} (REGEX)..."
-						next
-					end
-					if not require_regex =~ line
-						puts "Unknown require: '#{line}' at file #{file}:#{lineno} and it did not match #{require_regex_ignore}"
-						failed=true
-					end
-					require=line.gsub(require_regex,"\\1")
-					require.gsub!(/\.(so|rb)$/,"")
+		#$debug.puts "Checking file #{pkg}:#{file}..."
+		requires, encodings = parse_requires_prism(f.read)
+		#requires2, encodings2 = parse_requires_ripper(f.read)
+		#if requires != requires2 or encodings != encodings2
+		#	p pkg
+		#	p file
+		#	pp requires, encodings
+		#	pp requires2, encodings2
+		#	exit
+		#end
 
-					if require_ignore.include?(require)
-						puts "Ignoring #{line} at #{file}:#{lineno} (STR)..."
-                                                matched_ignored[require]=1
-						next
-					end
+		requires.reject! {|req| require_ignore_that_matched[req]=1 if require_ignore.include?(req) }
+		# Relative paths are always internal
+		requires.reject! {|req| req =~ /^\./ }
 
-					files_requires[file] += [require]
-
-				when /Encoding::/
-					encs=line.scan(/Encoding::[[:alnum:]_]+/).collect {|enc| eval(enc) }.select {|enc| enc.kind_of? Encoding }
-					need_encdb=true
-				end
-
-				next if encs.empty?
-				required_encs = (encs - builtin_enc).collect {|enc| "enc/#{enc.name.downcase.gsub("-","_")}" }
-				required_encs << "enc/encdb" if need_encdb
-
-				files_requires[file] += required_encs
-			end
+		# get the magic encoding if present
+		if line1 =~ /^#\s*(en)?coding\s*[:=]\s*([a-zA-Z0-9_\-]+)\n/i
+			encodings << Encoding.find($2)
 		end
+
+		# ignore buildin encodings
+		encodings -= builtin_enc
+
+		# convert encodings to requires
+		requires += encodings.collect {|enc| "enc/#{enc.name.downcase.gsub("-","_")}" }
+		requires << "enc/encdb" if not encodings.empty?
+
+		files_requires[file] = requires
 	end
 end
 exit(1) if failed
 
-missed_ignored = (require_ignore - matched_ignored.keys).sort.join(",")
+# Check which require_ignore arr not in use
+missed_ignored = (require_ignore - require_ignore_that_matched.keys).sort.join(",")
 if not missed_ignored.empty?
-    puts "These 'require_ignore' didn't match anything: ",(require_ignore - matched_ignored.keys).sort.join(","),""
+	$error.puts "These 'require_ignore' didn't match anything: ",(require_ignore - require_ignore_that_matched.keys).sort.join(","),""
 end
 
-# From ruby source: grep -E 'rb_require' -R . | grep -E '\.c:.*rb_require.*'
 # Add dependencies of ruby files from ruby lib.so
 package_files.each do |(pkg,files)| files.each do |file|
 	case file
 	when /\/nkf\.so$/    ; files_requires[file]=files_requires[file] + ["enc/encdb"]
-	when /\/objspace\.so$/; files_requires[file]=files_requires[file] + ["tempfile"] 	# dump_output from ext/objspace/objspace_dump.c
-	when /\/openssl\.so$/; files_requires[file]=files_requires[file] + ["digest"] 		# Init_ossl_digest from ext/openssl/ossl_digest.c
+	when /\/json\/ext\/generator\.so$/ ; files_requires[file]=files_requires[file] + ["enc/encdb"]
+	when /\/json\/ext\/parser\.so$/ ; files_requires[file]=files_requires[file] + ["enc/encdb"]
+	when /\/nkf\.so$/    ; files_requires[file]=files_requires[file] + ["enc/encdb"]
+	when /\/objspace\.so$/; files_requires[file]=files_requires[file] + ["tempfile"]	# dump_output from ext/objspace/objspace_dump.c
+	when /\/openssl\.so$/; files_requires[file]=files_requires[file] + ["digest"]		# Init_ossl_digest from ext/openssl/ossl_digest.c
 	end
 end; end
 
-puts "Grouping package requirements per package"
+$info.puts "Grouping package requirements per package"
 package_requires_files = Hash.new{|h,k| h[k] = Hash.new { |h2,k2| h2[k2] = [] } }
 package_files.each do |(pkg,files)|
 	package_requires_files[pkg]
@@ -189,7 +351,7 @@ end
 # For optional require or for breaking cycle dependencies
 weak_dependency=Hash.new { |h,k| h[k]=[] }
 weak_dependency.merge!({
-	"ruby-irb"      =>%w{ruby-rdoc ruby-readline ruby-debug}, # irb/cmd/help.rb irb/cmd/debug.rb,3.2/irb/cmd/debug.rb 
+	"ruby-irb"      =>%w{ruby-rdoc ruby-readline ruby-debug}, # irb/cmd/help.rb irb/cmd/debug.rb,3.2/irb/cmd/debug.rb
 	"ruby-gems"     =>%w{ruby-bundler ruby-rdoc},             # rubygems.rb rubygems/server.rb rdoc/rubygems_hook
 	"ruby-racc"     =>%w{ruby-gems},			  # /usr/bin/racc*
 	"ruby-rake"     =>%w{ruby-gems ruby-debug},               # /usr/bin/rake gems/3.3/gems/rake-13.1.0/lib/rake/application.rb
@@ -198,58 +360,72 @@ weak_dependency.merge!({
 	"ruby-net-http" =>%w{ruby-open-uri}			  # net/http/status.rb
 })
 
-puts "Looking for package dependencies..."
-package_provides = {}
+# Identify which files a package requires
+$info.puts "Looking for package dependencies..."
+provided_by = {}
+package_provides = Hash[package_files.map() {|(pkg,files)| [pkg,files.map() {|file| file.sub(/\.(so|rb)$/,"")}]}]
 package_dependencies = Hash.new { |h,k| h[k]=[] }
 package_requires_files.each do
 	|(pkg,requires_files)|
 
 	requires_files.each do
 		|(require,files)|
-		if package_provides.include?(require)
-			found = package_provides[require]
-		else
-			found = package_files.detect {|(pkg,files)| files.detect {|file| $:.detect {|path| "#{path}/#{require}" == file.gsub(/\.(so|rb)$/,"") } } }
+
+		found = provided_by[require]
+		if not found
+			# local dir or in search path are acceptables
+			#search_paths = (files.map() {|file| file.sub(/\/[^\/]+$/,"") } + $:).uniq
+			search_files = $:.map() {|path| "#{path}/#{require.sub(/\.(so|rb)$/,"")}" }
+
+			found = package_provides.detect {|(_pkg,_files)| not (_files & search_files).empty? }
+
 			if not found
-				$stderr.puts "#{pkg}: Nothing provides #{require} for #{files.collect {|file| file.sub("/usr/lib/ruby/","") }.join(",")}"
+				$error.puts "#{pkg}: Nothing provides #{require} for #{files.collect {|file| file.sub("/usr/lib/ruby/","") }.join(",")}"
 				failed = true
 				next
 			end
 			found = found.first
-			package_provides[require] = found
+			provided_by[require] = found
 		end
+
 		if weak_dependency[pkg].include?(found)
-                        puts "#{pkg}: #{found} provides #{require} (weak depedendency ignored) for #{files.collect {|file| file.sub("/usr/lib/ruby/","") }.join(",")}"
+			$debug.puts "#{pkg}: #{found} provides #{require} (weak depedendency ignored) for #{files.collect {|file| file.sub("/usr/lib/ruby/","") }.join(",")}"
 		else
-			puts "#{pkg}: #{found} provides #{require} for #{files.collect {|file| file.sub("/usr/lib/ruby/","") }.join(",")}"
+			$debug.puts "#{pkg}: #{found} provides #{require} for #{files.collect {|file| file.sub("/usr/lib/ruby/","") }.join(",")}"
 			package_dependencies[pkg] += [found]
 		end
 	end
+	#break if pkg =~ /ruby-bundler.*/
 end
 if failed
-	puts "There is some missing requirements not mapped to files in packages."
-	puts "Please, fix the missing files or ignore them on require_ignore var"
+	$error.puts "There is some missing requirements not mapped to files in packages."
+	$error.puts "Please, fix the missing files or ignore them on require_ignore var"
 	exit(1)
 end
+
 # Remove self dependency
 package_dependencies = Hash[package_dependencies.collect {|(pkg,deps)| [pkg,package_dependencies[pkg]=deps.uniq.sort - [pkg]]}]
 package_dependencies.default = []
 
-puts "Expanding dependencies..."
+# Add explicity dependency
+package_dependencies["ruby-enc-extra"]+=["ruby-enc"]
+
+# Expanding dependencies, including the depedencies from required packages
+$info.puts "Expanding dependencies..."
 begin
 	changed=false
 	package_dependencies.each do
 		|(pkg,deps)|
 		next if deps.empty?
-		deps.each {|dep| puts "#{pkg}: #{dep} also depends on #{pkg}" if package_dependencies[dep].include?(pkg) }
+		deps.each {|dep| $info.puts "#{pkg}: #{dep} also depends on #{pkg}" if package_dependencies[dep].include?(pkg) }
 		deps_new = deps.collect {|dep| [dep] + package_dependencies[dep] }.inject([],:+).uniq.sort
 		if not deps == deps_new
-			puts "#{pkg}: {deps.join(",")} (OLD)"
-			puts "#{pkg}: #{deps_new.join(",")} (NEW)"
+			$debug.puts "#{pkg}: #{deps.join(",")} (OLD)"
+			$debug.puts "#{pkg}: #{deps_new.join(",")} (NEW)"
 			package_dependencies[pkg]=deps_new
 
 			if deps_new.include?(pkg)
-				$stderr.puts "#{pkg}: Circular dependency detected (#1)!"
+				$error.puts "#{pkg}: Circular dependency detected (#1)!"
 				exit 1
 			end
 			changed=true
@@ -257,17 +433,17 @@ begin
 	end
 end if not changed
 
-puts "Removing redundant dependencies..."
+$info.puts "Removing redundant dependencies..."
 package_dependencies.each do
 	|(pkg,deps)|
 	package_dependencies[pkg]=deps.uniq - [pkg]
 end
 
-puts "Checking for mutual dependencies..."
+$info.puts "Checking for mutual dependencies..."
 package_dependencies.each do
 	|(pkg,deps)|
 	if deps.include? pkg
-		$stderr.puts "#{pkg}: Circular dependency detected (#2)!"
+		$error.puts "#{pkg}: Circular dependency detected (#2)!"
 		failed = true
 	end
 end
@@ -280,11 +456,11 @@ package_dependencies.each do
 
 	# Ignore dependencies that are already required by another dependency
 	deps_clean = deps.reject {|dep_suspect| deps.detect {|dep_provider|
-			if package_dependencies[dep_provider].include?(dep_suspect)
-				puts "#{pkg}: #{dep_suspect} is already required by #{dep_provider}"
-				true
-			end
-		 } }
+		if package_dependencies[dep_provider].include?(dep_suspect)
+			$info.puts "#{pkg}: #{dep_suspect} is already required by #{dep_provider}"
+			true
+		end
+	}}
 
 	if not deps==deps_clean
 		puts "before: #{deps.join(",")}"
@@ -294,22 +470,18 @@ package_dependencies.each do
 end
 package_dependencies=package_dependencies2
 
-puts "Checking current packages dependencies..."
+$info.puts "Checking current packages dependencies..."
 ok=true
 package_dependencies.each do
 	|(pkg,deps)|
-	current_deps=`opkg depends #{pkg} | sed -r -e '1d;s/^[[:blank:]]*//'`.split("\n")
-	current_deps.reject!{|dep| dep =~ /^lib/ }
-	current_deps -= ["ruby"]
-
-	extra_dep = current_deps - deps
-	$stderr.puts "Package #{pkg} does not need to depend on #{extra_dep.join(" ")} " if not extra_dep.empty?
-	missing_dep = deps - current_deps
-	$stderr.puts "Package #{pkg} needs to depend on #{missing_dep.join(" ")} " if not missing_dep.empty?
+	extra_dep = package_depends[pkg] - deps
+	$info.puts "Package #{pkg} does not need to depend on #{extra_dep.join(" ")} " if not extra_dep.empty?
+	missing_dep = deps - package_depends[pkg]
+	$info.puts "Package #{pkg} needs to depend on #{missing_dep.join(" ")} " if not missing_dep.empty?
 
 	if not extra_dep.empty? or not missing_dep.empty?
-		$stderr.puts "define Package/#{pkg}"
-		$stderr.puts "  DEPENDS:=ruby#{([""] +deps).join(" +")}"
+		puts "define Package/#{pkg}"
+		puts "  DEPENDS:=ruby#{([""] +deps).join(" +")}"
 		ok=false
 	end
 end

--- a/lang/ruby/ruby_missingfiles
+++ b/lang/ruby/ruby_missingfiles
@@ -31,14 +31,19 @@ function list_staging_files {
 		-not -name "*.doc" \
 		-not -name "*.md" \
 		-not -name "*.txt" \
+		-not -name "BSDL" \
+		-not -name "COPYING" \
 		-not -name "*.travis.yml" \
+		-not -name "Rakefile" \
+		-not -path "*/ext/java/*" \
+		-not -name "gem.build_complete" \
 		-not -regex ".*/usr/lib/ruby/gems/[^/]*/gems/[^/]*/benchmark/.*" \
 		-not -regex ".*/usr/lib/ruby/gems/[^/]*/gems/[^/]*/evaluation/.*" \
 		-not -regex ".*/usr/lib/ruby/gems/[^/]*/gems/[^/]*/sample/.*" \
 		-not -regex ".*/usr/lib/ruby/gems/[^/]*/gems/[^/]*/test/.*" \
 		-not -regex ".*/usr/lib/ruby/gems/[^/]*/gems/[^/]*/doc/.*" \
 		-not -type d \
-		-print | sort
+		-print | sort | sed -e 's,^\./,/,'
 }
 
 function list_ipkg_files {
@@ -47,17 +52,28 @@ function list_ipkg_files {
 	done | sort -u | grep -v ./usr/lib/ruby/ruby...-bin
 }
 
+function list_apk_file {
+	local pkg
+	$HOST_STAGING_DIR/bin/apk adbdump --allow-untrusted "$@" |
+	sed -e '/|$/{N;s/|\n *//}' |
+	awk '/^  - name: / { dir=$3 } /^      - name:/ { printf "%s/%s\n", dir, $3}' |
+	grep -v ^lib/apk/packages | sort -u | sed -e 's,^,/,' | grep -v /usr/lib/ruby/ruby...-bin
+
+}
+
 
 
 set -e
 : ${1:?First arg is staging_dir}
 : ${2:?Second and following args are ruby ipkg packages}
 STAGING_DIR=$1; shift
+HOST_STAGING_DIR=$STAGING_DIR/../host
 (cd "$STAGING_DIR" )
 if ! [ -e "$1" ]; then
 	echo "$1 does not exist!"
 	exit 1
 fi
 printf '%-62s %-62s\n' "Installed in Staging" "From Packages Files"
-diff -d -y <(list_staging_files "$STAGING_DIR") <(list_ipkg_files "$@") -W $COLUMNS
+#diff -d -y <(list_staging_files "$STAGING_DIR") <(list_ipkg_files "$@") -W $COLUMNS
+diff -d -y <(list_staging_files "$STAGING_DIR") <(list_apk_file "$@") -W $COLUMNS
 


### PR DESCRIPTION
Ruby 3.4.0 is a major release that introduces several changes:
- Adds `it` block parameter reference
- Switches default parser to Prism
- Implements Happy Eyeballs Version 2 in the socket library
- Improves YJIT
- Adds Modular GC
- And more (see changelog for full details)

Subsequent minor releases include:
- 3.4.1: fixes version description
- 3.4.2: routine bugfix release
- 3.4.3: routine bugfix release
- 3.4.4: routine bugfix release (Linux-specific)
- 3.4.5: routine bugfix release, adds GCC 15 support

Packaging changes:
- (NEW) ruby-repl_type_completor (packaging the repl_type_completor gem)
- Refreshed package dependencies
- Updated `ruby_missingfiles` (detects unpacked files) to use `apk`
- Refactored `ruby_find_pkgsdeps` (detects inter-package dependencies) to use the Ruby parser (Prism) instead of heuristic string matching

Changelog: https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/

## 📦 Package Details

**Maintainer:** @luizluca (a.k.a. me)

**Description:**
Update to the latest version

---

## 🧪 Run Testing Details

- **OpenWrt Version:** r31007-35ff70e807
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** qemu

exec: gem update

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
- [X] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
