### PR TITLE
ovpn dco: fix package dependencies and bump version to 0.2.20250801

### DIFF
--- a/kernel/ovpn-dco/Makefile
+++ b/kernel/ovpn-dco/Makefile
@@ -9,12 +9,14 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ovpn-dco
-PKG_VERSION:=0.2.20241216
-PKG_RELEASE:=2
+PKG_VERSION:=0.2.20250801
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL=https://codeload.github.com/OpenVPN/ovpn-dco/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=0b30b8973b362b80a05f278ae217f01a2a2417e16e9c68c486960275a55306cc
+PKG_SOURCE_URL= \
+	https://build.openvpn.net/downloads/releases \
+	https://codeload.github.com/OpenVPN/ovpn-dco/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=542677e69266e99babb560408b61705ef38a7c469eb820a81f609171faa61b20
 
 PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
 PKG_LICENSE:=GPL-2.0-only

--- a/kernel/ovpn-dco/Makefile
+++ b/kernel/ovpn-dco/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ovpn-dco
 PKG_VERSION:=0.2.20241216
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://codeload.github.com/OpenVPN/ovpn-dco/tar.gz/v$(PKG_VERSION)?
@@ -25,7 +25,9 @@ include $(INCLUDE_DIR)/package.mk
 define KernelPackage/ovpn-dco-v2
   SUBMENU:=Network Support
   TITLE:=OpenVPN data channel offload
-  DEPENDS:=+kmod-crypto-aead +kmod-udptunnel4 +IPV6:kmod-udptunnel6
+  DEPENDS:= \
+	+kmod-udptunnel4 +IPV6:kmod-udptunnel6 \
+	+kmod-crypto-chacha20poly1305 +kmod-crypto-lib-chacha20 +kmod-crypto-lib-poly1305
   FILES:=$(PKG_BUILD_DIR)/drivers/net/ovpn-dco/ovpn-dco-v2.ko
   AUTOLOAD:=$(call AutoLoad,30,ovpn-dco-v2)
 endef


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @zhaojh329 

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
1. add kmod-crypto-chacha20poly1305 kmod-crypto-lib-chacha20 kmod-crypto-lib-poly1305 for chacha20
2. bump version to 0.2.20250801
---

## 🧪 Run Testing Details

- **OpenWrt Version:** r31015-20d761cf19
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** N100 based router

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.