### PR TITLE
zerotier: update to 1.16.0

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
-PKG_VERSION:=1.14.1
-PKG_RELEASE:=3
+PKG_VERSION:=1.16.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=4f9f40b27c5a78389ed3f3216c850921f6298749e5819e9f2edabb2672ce9ca0
+PKG_HASH:=aa9de313d365bf0efb3871aaa56f2d323a08f46df47b627c4eff4f4203fa7fc5
 PKG_BUILD_DIR:=$(BUILD_DIR)/ZeroTierOne-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>

--- a/net/zerotier/patches/0001-fix-miniupnpc-natpmp-include-path.patch
+++ b/net/zerotier/patches/0001-fix-miniupnpc-natpmp-include-path.patch
@@ -1,7 +1,7 @@
-From ec02787ae7c5b6e906ab50bcebcd676d4219c812 Mon Sep 17 00:00:00 2001
+From 7d8541e66196e1429af49947aa9d283cb923d260 Mon Sep 17 00:00:00 2001
 From: Moritz Warning <moritzwarning@web.de>
-Date: Tue, 17 Sep 2024 14:17:08 +0200
-Subject: [PATCH 1/5] fix miniupnpc natpmp include path
+Date: Fri, 12 Sep 2025 11:07:23 +0200
+Subject: [PATCH 1/6] fix miniupnpc natpmp include path
 
 ---
  make-linux.mk | 6 +++---
@@ -9,7 +9,7 @@ Subject: [PATCH 1/5] fix miniupnpc natpmp include path
 
 --- a/make-linux.mk
 +++ b/make-linux.mk
-@@ -26,8 +26,8 @@ TIMESTAMP=$(shell date +"%Y%m%d%H%M")
+@@ -41,8 +41,8 @@ TIMESTAMP=$(shell date +"%Y%m%d%H%M")
  # otherwise build into binary as done on Mac and Windows.
  ONE_OBJS+=osdep/PortMapper.o
  override DEFS+=-DZT_USE_MINIUPNPC
@@ -20,7 +20,7 @@ Subject: [PATCH 1/5] fix miniupnpc natpmp include path
  ifeq ($(MINIUPNPC_IS_NEW_ENOUGH),1)
  	override DEFS+=-DZT_USE_SYSTEM_MINIUPNPC
  	LDLIBS+=-lminiupnpc
-@@ -35,7 +35,7 @@ else
+@@ -50,7 +50,7 @@ else
  	override DEFS+=-DMINIUPNP_STATICLIB -DMINIUPNPC_SET_SOCKET_TIMEOUT -DMINIUPNPC_GET_SRC_ADDR -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -DOS_STRING="\"Linux\"" -DMINIUPNPC_VERSION_STRING="\"2.0\"" -DUPNP_VERSION_STRING="\"UPnP/1.1\"" -DENABLE_STRNATPMPERR
  	ONE_OBJS+=ext/miniupnpc/connecthostport.o ext/miniupnpc/igd_desc_parse.o ext/miniupnpc/minisoap.o ext/miniupnpc/minissdpc.o ext/miniupnpc/miniupnpc.o ext/miniupnpc/miniwget.o ext/miniupnpc/minixml.o ext/miniupnpc/portlistingparse.o ext/miniupnpc/receivedata.o ext/miniupnpc/upnpcommands.o ext/miniupnpc/upnpdev.o ext/miniupnpc/upnperrors.o ext/miniupnpc/upnpreplyparse.o
  endif

--- a/net/zerotier/patches/0002-remove-PIE-options.patch
+++ b/net/zerotier/patches/0002-remove-PIE-options.patch
@@ -1,7 +1,7 @@
-From 81a632c99b581790344729ad327eb473c4c05260 Mon Sep 17 00:00:00 2001
+From 43993df3a98d1f832b7596cd528249cb3534ed88 Mon Sep 17 00:00:00 2001
 From: Moritz Warning <moritzwarning@web.de>
-Date: Tue, 17 Sep 2024 15:36:36 +0200
-Subject: [PATCH 2/5] remove PIE options
+Date: Fri, 12 Sep 2025 11:12:27 +0200
+Subject: [PATCH 2/6] remove PIE options
 
 ---
  make-linux.mk | 6 +++---
@@ -9,7 +9,7 @@ Subject: [PATCH 2/5] remove PIE options
 
 --- a/make-linux.mk
 +++ b/make-linux.mk
-@@ -333,7 +333,7 @@ ifeq ($(ZT_CONTROLLER),1)
+@@ -359,7 +359,7 @@ ifeq ($(ZT_CONTROLLER),1)
  endif
  
  # ARM32 hell -- use conservative CFLAGS
@@ -18,7 +18,7 @@ Subject: [PATCH 2/5] remove PIE options
  	ifeq ($(shell if [ -e /usr/bin/dpkg ]; then dpkg --print-architecture; fi),armel)
  		override CFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
  		override CXXFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
-@@ -360,8 +360,8 @@ ifeq ($(ZT_USE_ARM32_NEON_ASM_CRYPTO),1)
+@@ -390,8 +390,8 @@ ifeq ($(ZT_USE_ARM32_NEON_ASM_CRYPTO),1)
  endif
  
  # Position Independence

--- a/net/zerotier/patches/0003-fix-compilation-for-arm_cortex-a7-neon.patch
+++ b/net/zerotier/patches/0003-fix-compilation-for-arm_cortex-a7-neon.patch
@@ -1,7 +1,7 @@
-From 71ed5b791fb0f7bfe1f564726fdc979b71313fbe Mon Sep 17 00:00:00 2001
+From 02bd2334eb3d623f4af0afb5ec14e90410ad309b Mon Sep 17 00:00:00 2001
 From: Moritz Warning <moritzwarning@web.de>
-Date: Tue, 17 Sep 2024 15:38:01 +0200
-Subject: [PATCH 3/5] fix compilation for arm_cortex a7 neon
+Date: Fri, 12 Sep 2025 10:35:32 +0200
+Subject: [PATCH 3/6] fix compilation for arm_cortex a7 neon
 
 ---
  node/Constants.hpp | 2 +-
@@ -9,12 +9,12 @@ Subject: [PATCH 3/5] fix compilation for arm_cortex a7 neon
 
 --- a/node/Constants.hpp
 +++ b/node/Constants.hpp
-@@ -123,7 +123,7 @@
- #include <immintrin.h>
+@@ -118,7 +118,7 @@
+ #include <xmmintrin.h>
  #endif
  
 -#if (defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(ZT_ARCH_ARM_HAS_NEON))
 +#if (defined(__aarch64__) || defined(ZT_ARCH_ARM_HAS_NEON))
- #if (defined(__APPLE__) && !defined(__LP64__)) || (defined(__ANDROID__) && defined(__arm__))
+ #if (defined(__APPLE__) && ! defined(__LP64__)) || (defined(__ANDROID__) && defined(__arm__))
  #ifdef ZT_ARCH_ARM_HAS_NEON
  #undef ZT_ARCH_ARM_HAS_NEON

--- a/net/zerotier/patches/0004-add-missing-libatomic.patch
+++ b/net/zerotier/patches/0004-add-missing-libatomic.patch
@@ -1,7 +1,7 @@
-From d6197554b3f52ee9d8d81374141aa82014b4fc7b Mon Sep 17 00:00:00 2001
+From 3c4f6d71dde297be573e28d3027e2ce51c82c238 Mon Sep 17 00:00:00 2001
 From: Moritz Warning <moritzwarning@web.de>
-Date: Tue, 17 Sep 2024 15:38:34 +0200
-Subject: [PATCH 4/5] add missing libatomic
+Date: Fri, 12 Sep 2025 11:15:43 +0200
+Subject: [PATCH 4/6] add missing libatomic
 
 ---
  make-linux.mk | 2 +-

--- a/net/zerotier/patches/0005-remove-noexecstack.patch
+++ b/net/zerotier/patches/0005-remove-noexecstack.patch
@@ -1,7 +1,7 @@
-From 8e89af98ac00b1c9c019865faca7479fa0de6084 Mon Sep 17 00:00:00 2001
+From 74e9711e4dbab4f8323a7081915d7d95aa04967b Mon Sep 17 00:00:00 2001
 From: Moritz Warning <moritzwarning@web.de>
-Date: Tue, 17 Sep 2024 21:26:08 +0200
-Subject: [PATCH 5/5] remove noexecstack
+Date: Fri, 12 Sep 2025 11:17:47 +0200
+Subject: [PATCH 5/6] remove noexecstack
 
 ---
  make-linux.mk | 2 +-
@@ -9,7 +9,7 @@ Subject: [PATCH 5/5] remove noexecstack
 
 --- a/make-linux.mk
 +++ b/make-linux.mk
-@@ -364,7 +364,7 @@ endif
+@@ -394,7 +394,7 @@ endif
  #override CXXFLAGS+=-fPIC -fPIE
  
  # Non-executable stack

--- a/net/zerotier/patches/0006-add-support-for-miniupnpc-2.2.8.patch
+++ b/net/zerotier/patches/0006-add-support-for-miniupnpc-2.2.8.patch
@@ -1,25 +1,25 @@
-From a8cb9d188fabe750821661b5e34e9be467846283 Mon Sep 17 00:00:00 2001
+From 102ea404b6ee0099c43e8058366b19ce92c4e4c7 Mon Sep 17 00:00:00 2001
 From: Moritz Warning <moritzwarning@web.de>
-Date: Mon, 3 Mar 2025 23:26:42 +0100
-Subject: [PATCH] add support for miniupnpc 2.2.8
+Date: Thu, 18 Sep 2025 23:21:53 +0200
+Subject: [PATCH 6/6] add support for miniupnpc 2.2.8
 
-Signed-off-by: Moritz Warning <moritzwarning@web.de>
 ---
- osdep/PortMapper.cpp | 5 +++++
- 1 file changed, 5 insertions(+)
+ osdep/PortMapper.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
 
 --- a/osdep/PortMapper.cpp
 +++ b/osdep/PortMapper.cpp
-@@ -230,7 +230,12 @@ public:
- 					OSUtils::ztsnprintf(inport,sizeof(inport),"%d",localPort);
+@@ -222,7 +222,13 @@ class PortMapperImpl {
+ 					OSUtils::ztsnprintf(inport, sizeof(inport), "%d", localPort);
  
  					int foundValidIGD = 0;
++
 +#if MINIUPNPC_API_VERSION < 18
- 					if ((foundValidIGD = UPNP_GetValidIGD(devlist,&urls,&data,lanaddr,sizeof(lanaddr)))&&(lanaddr[0])) {
+ 					if ((foundValidIGD = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr))) && (lanaddr[0])) {
 +#else
-+					if ((foundValidIGD = UPNP_GetValidIGD(devlist,&urls,&data,lanaddr,sizeof(lanaddr),NULL,0))&&(lanaddr[0])) {
++					if ((foundValidIGD = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr), NULL, 0)) && (lanaddr[0])) {
 +#endif
 +
  #ifdef ZT_PORTMAPPER_TRACE
-                         PM_TRACE("PortMapper: UPnP: my LAN IP address: %s" ZT_EOL_S,lanaddr);
+ 						PM_TRACE("PortMapper: UPnP: my LAN IP address: %s" ZT_EOL_S, lanaddr);
  #endif


### PR DESCRIPTION
Authored-by: Óscar García Amor <ogarcia@connectical.com>

## 📦 Package Details

**Maintainer:** @mwarning 

**Description:**

Update to new relase 1.6.0

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** ramips/mt76x8
- **OpenWrt Device:** WR902AC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
