### PR TITLE
snapcast: fix PulseAudio dependency

### DIFF
--- a/sound/snapcast/Makefile
+++ b/sound/snapcast/Makefile
@@ -20,6 +20,8 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
 CMAKE_OPTIONS += -DBUILD_TESTS=OFF
+CMAKE_OPTIONS += -DBUILD_WITH_PULSE=OFF
+CMAKE_OPTIONS += -DBUILD_WITH_AVAHI=OFF
 
 define Package/snapcast/Default
   SECTION:=sound


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me (@xabolcs), @davidandreoletti 

**Description:**
While testing my integration of Snapcast, I didn't test with `CONFIG_ALL*` and `CONFIG_BUILDBOT` flags, but the buildbots did and failed with a lot of undefined reference to PulseAudio.

Fix it with preventing PulseAudio detection.
While at it, prevent Avahi detection too to save more flash space.

These features will be available later, through flavours.

Fixes: #23956
Fixes: eeb8d131fc93 ("snapcast: add package snapserver and snapclient")


---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** `mediatek/mt7622`
- **OpenWrt Device:** Xiaomi AX3200

**Not run tested**, but compile tested:
```bash
$ find bin -type f -name 'snap*' -exec ls -gGh {} \;
-rw-r--r-- 1 240K Sep 13 17:58 bin/packages/aarch64_cortex-a53/packages/snapclient-0.28.0-r1.apk
-rw-r--r-- 1 755K Sep 13 17:58 bin/packages/aarch64_cortex-a53/packages/snapserver-0.28.0-r1.apk
```

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable:
N/A

