### PR TITLE
[24.10] php8 update to 8.3.25

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.3.24
+PKG_VERSION:=8.3.25
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.php.net/distributions/
-PKG_HASH:=388ee5fd111097e97bae439bff46aec4ea27f816d3f0c2cb5490a41410d44251
+PKG_HASH:=187b61bb795015adacf53f8c55b44414a63777ec19a776b75fb88614506c0d37
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Upstream changelog:
https://www.php.net/ChangeLog-8.php#8.3.25

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 
- **OpenWrt Target/Subtarget:** mxs
- **OpenWrt Device:** Duckbill

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc.
- [ ] It is structured in a way that it is potentially upstreamable
