### PR TITLE
csshnpd: bump to c1.0.16 release

### DIFF
--- a/net/csshnpd/Makefile
+++ b/net/csshnpd/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
-PKG_VERSION:=1.0.14
+PKG_VERSION:=1.0.16
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
-PKG_HASH:=86c9f3e5d3b149df9a32ef7b3ae52e78623c1beed4bedcfe90c852ea8504b40f
+PKG_HASH:=209501b5623cbb25e22b5f39eeedcb79c2b658a250ff31dd88b27b31677b6763
 
 PKG_MAINTAINER:=Chris Swan <chris@atsign.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @cpswan 

**Description:**
Upstream release aligned to cJSON 1.7.19

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT, r29619
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** x86_64 VM

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.