### PR TITLE
netbird: update to 0.57.1

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.55.1
-PKG_RELEASE:=2
+PKG_VERSION:=0.57.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=b9465a2b6b7600ec7f22a706b2f2891fdb19a07ffcbfd82cd0e33176d3c69b75
+PKG_HASH:=9ae0ce9b4367be44a4107aba7cd0d9d362e7636f880960c2d5e2c72b437afb1b
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

changelog: https://github.com/netbirdio/netbird/releases/tag/v0.57.1

##

**Tests checklist:**
- [ ] Connection to the NetBird Cloud Dashboard (not self-hosted).
- [ ] Firewall configured with nftables.
- [ ] Connection established in P2P mode.
- [ ] `wireguard` kernel mode active.
- [ ] Routes configured between my homelab and my cloud server.
- [ ] `netbird` DNS server functioning correctly.
- [ ] NAT operational (not needed by me at this time, may consider testing in the future).
- [ ] Permissions rules is enforced (not needed by me at this time, may consider testing in the future).

##

**Additional information:**

`x86_64` is running in a virtual machine using [`incus`](https://github.com/lxc/incus).
The package(s) was compiled with the container [`sdk`](https://github.com/openwrt/docker).
The `OpenWrt` image(s) was built using the container [`imagebuilder`](https://github.com/openwrt/docker).
<sub>No more container or [`distrobuilder`](https://github.com/lxc/distrobuilder).</sub>

You can view my repository with the patch applied and the automated build here:
- https://github.com/wehagy/owpib/tree/netbird/update
  <sub>This repository branch is temporary and will be removed or modified after the merge.</sub>

You can find my artifacts here:
- https://github.com/wehagy/owpib/actions/runs/<change_me>

---

## 🧪 Run Testing Details

- **OpenWrt Version:** <change_me>
- **OpenWrt Target/Subtarget:** <change_me>
- **OpenWrt Device:** <change_me>

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.