### PR TITLE
[24.10] micro: add new package

### DIFF
--- a/utils/micro/Makefile
+++ b/utils/micro/Makefile
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=micro
+PKG_VERSION:=2.0.14
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/zyedidia/micro/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=40177579beb3846461036387b649c629395584a4bbe970f61ba7591bd9c0185a
+
+PKG_MAINTAINER:=Gregory Gullin <garuwex@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE LICENSE-THIRD-PARTY
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/zyedidia/micro/v2
+GO_PKG_LDFLAGS_X:=$(GO_PKG)/internal/util.Version=$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/micro
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Editors
+  TITLE:=Modern and intuitive terminal-based text editor
+  URL:=https://micro-editor.github.io/
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/micro/description
+  micro is a terminal-based text editor that aims to be easy to use and intuitive,
+  while also taking advantage of the capabilities of modern terminals.
+  It comes as a single, batteries-included, static binary with no dependencies;
+  you can download and use it right now!
+endef
+
+define Package/micro/conffiles
+/root/.config/micro/
+endef
+
+$(eval $(call GoBinPackage,micro))
+$(eval $(call BuildPackage,micro))

--- a/utils/micro/test.sh
+++ b/utils/micro/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+micro -version | grep -F "${PKG_VERSION}"


### PR DESCRIPTION
Modern and intuitive terminal-based text editor

https://micro-editor.github.io



(cherry picked from commit 2d05ae0b4e20689a5476e03ee24cb682367d6ef9)

## 📦 Package Details

**Maintainer:** @gargullia
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.1 r28597-0425664679
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Xiaomi Mi Router AX3000T

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.