### PR TITLE
[24.10] nnn: update to version 5.1

### DIFF
--- a/utils/nnn/Makefile
+++ b/utils/nnn/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nnn
-PKG_VERSION:=4.9
+PKG_VERSION:=5.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jarun/nnn/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=9e25465a856d3ba626d6163046669c0d4010d520f2fb848b0d611e1ec6af1b22
+PKG_HASH:=9faaff1e3f5a2fd3ed570a83f6fb3baf0bfc6ebd6a9abac16203d057ac3fffe3
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=BSD-2-Clause

--- a/utils/nnn/patches/musl-fts.patch
+++ b/utils/nnn/patches/musl-fts.patch
@@ -1,6 +1,6 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -152,7 +152,7 @@ CFLAGS += -std=c11 -Wall -Wextra -Wshado
+@@ -165,7 +165,7 @@ CFLAGS += -std=c11 -Wall -Wextra -Wshado
  CFLAGS += $(CFLAGS_OPTIMIZATION)
  CFLAGS += $(CFLAGS_CURSES)
  


### PR DESCRIPTION
Release notes: https://github.com/jarun/nnn/compare/v4.9...v5.1


(cherry picked from commit ebb0d87450c9bbf1008990ddc2c68d3cfdae5f5a)

## 📦 Package Details

**Maintainer:** @BKPepe 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
