### PR TITLE
[24.10] fx: update to 39.0.1

### DIFF
--- a/utils/fx/Makefile
+++ b/utils/fx/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fx
-PKG_VERSION:=36.0.3
+PKG_VERSION:=39.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/antonmedv/fx/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=1159bc6b556d39843f7e786b06ad8918e4d1a6e64f21539598d3a72dbbc9b1c7
+PKG_HASH:=0ddbef45762a3a2b4b13afb03093139121422b6f73aecbf2b6655598bd98575f
 
 PKG_MAINTAINER:=Fabian Lipken <dynasticorpheus@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details
update fx from version 35.0.0 to 39.0.1


(cherry picked from commit 5c00fe3a2905638601097404867f2319b016ad4a)
(cherry picked from commit 822fd64d381c6b3530a955933fa07291f3c3208a)
(cherry picked from commit 6c5eb88a3267d343f1dbec2d8824b37d7045abd2)
(cherry picked from commit d65397a2d25cbae876eb325604c5379cb6bb61cc)

**Maintainer:** @dynasticorpheus
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.1 r28597-0425664679
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Xiaomi Mi Router AX3000T

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
