### PR TITLE
gnuplot: fix PKG_CPE_ID

### DIFF
--- a/utils/gnuplot/Makefile
+++ b/utils/gnuplot/Makefile
@@ -4,7 +4,7 @@ PKG_NAME:=gnuplot
 PKG_VERSION:=6.0.1
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Matteo Cicuttin <datafl4sh@toxicnet.eu>
-PKG_CPE_ID:=cpe:/a:gnuplot_project:gnuplot
+PKG_CPE_ID:=cpe:/a:gnuplot:gnuplot
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/gnuplot-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz


### PR DESCRIPTION
`gnuplot_project:gnuplot `has been deprecated in favour of `gnuplot:gnuplot`:
https://nvd.nist.gov/products/cpe/detail/DB68C9F5-3330-4749-A6F5-61FF041037CC

Maintainer:
Compile tested: Not needed
Run tested: Not needed