### PR TITLE
sendmail: update to 8.18.1

### DIFF
--- a/mail/sendmail/Makefile
+++ b/mail/sendmail/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sendmail
-PKG_VERSION:=8.16.1
-PKG_RELEASE:=2
+PKG_VERSION:=8.18.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://ftp.sendmail.org/pub/sendmail
-PKG_HASH:=7886d5dc4b436b86175f32b5b9c7305c80787749847e2909bf99123ecc4e64ba
+PKG_HASH:=cbf1f309c38e4806f7cf3ead24260f17d1fe8fb63256d13edb3cdd1a098f0770
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
 PKG_LICENSE:=Sendmail
@@ -127,4 +127,3 @@ endef
 
 $(eval $(call BuildPackage,libmilter-sendmail))
 #$(eval $(call BuildPackage,sendmail))
-

--- a/mail/sendmail/patches/010-enable-nonroot-install.patch
+++ b/mail/sendmail/patches/010-enable-nonroot-install.patch
@@ -87,7 +87,16 @@
  bldFINISH
 --- a/sendmail/Makefile.m4
 +++ b/sendmail/Makefile.m4
-@@ -68,7 +68,7 @@ ifdef(`confNO_STATISTICS_INSTALL',, `bld
+@@ -55,8 +55,6 @@ ${DESTDIR}${MSPQ}:
+ 	@echo "You must have set up a new user ${MSPQOWN} and a new group ${GBINGRP}"
+ 	@echo "as explained in sendmail/SECURITY."
+ 	mkdir -p ${DESTDIR}${MSPQ}
+-	chown ${MSPQOWN} ${DESTDIR}${MSPQ}
+-	chgrp ${GBINGRP} ${DESTDIR}${MSPQ}
+ 	chmod 0770 ${DESTDIR}${MSPQ}
+ 
+ divert(0)
+@@ -68,7 +66,7 @@ ifdef(`confNO_STATISTICS_INSTALL',, `bld
  divert(bldTARGETS_SECTION)
  
  install-set-user-id: bldCURRENT_PRODUCT ifdef(`confNO_HELPFILE_INSTALL',, `install-hf') ifdef(`confNO_STATISTICS_INSTALL',, `install-st') ifdef(`confNO_MAN_BUILD',, `install-docs')
@@ -96,7 +105,7 @@
  	for i in ${sendmailTARGET_LINKS}; do \
  		rm -f $$i; \
  		${LN} ${LNOPTS} ${M`'BINDIR}/sendmail $$i; \
-@@ -76,7 +76,7 @@ install-set-user-id: bldCURRENT_PRODUCT
+@@ -76,7 +74,7 @@ install-set-user-id: bldCURRENT_PRODUCT
  
  define(`confMTA_LINKS', `${DESTDIR}${UBINDIR}/newaliases ${DESTDIR}${UBINDIR}/mailq ${DESTDIR}${UBINDIR}/hoststat ${DESTDIR}${UBINDIR}/purgestat')
  install-sm-mta: bldCURRENT_PRODUCT
@@ -105,7 +114,7 @@
  	for i in confMTA_LINKS; do \
  		rm -f $$i; \
  		${LN} ${LNOPTS} ${M`'BINDIR}/sm-mta $$i; \
-@@ -84,14 +84,14 @@ install-sm-mta: bldCURRENT_PRODUCT
+@@ -84,14 +82,14 @@ install-sm-mta: bldCURRENT_PRODUCT
  
  install-hf:
  	if [ ! -d ${DESTDIR}${HFDIR} ]; then mkdir -p ${DESTDIR}${HFDIR}; else :; fi

--- a/mail/sendmail/patches/100-misc-os-musl-fixes.patch
+++ b/mail/sendmail/patches/100-misc-os-musl-fixes.patch
@@ -28,7 +28,7 @@
  # endif
  
  /**********************************************************************
-@@ -1484,7 +1484,9 @@ extern void		*malloc();
+@@ -1485,7 +1485,9 @@ extern void		*malloc();
  #  define SM_CONF_GETOPT	0	/* need a replacement for getopt(3) */
  #  define HASUNAME	1	/* use System V uname(2) system call */
  #  define HASUNSETENV	1	/* has unsetenv(3) call */
@@ -39,7 +39,7 @@
  #  define GIDSET_T	gid_t	/* from <linux/types.h> */
  #  ifndef HASGETUSERSHELL
  #   define HASGETUSERSHELL 0	/* getusershell(3) broken in Slackware 2.0 */
-@@ -1522,6 +1524,7 @@ extern void		*malloc();
+@@ -1523,6 +1525,7 @@ extern void		*malloc();
  #  if defined(__GLIBC__) && defined(__GLIBC_MINOR__)
  #   define HASSTRERROR	1	/* has strerror(3) */
  #  endif

--- a/mail/sendmail/patches/103-create-install-dirs.patch
+++ b/mail/sendmail/patches/103-create-install-dirs.patch
@@ -1,6 +1,6 @@
 --- a/sendmail/Makefile.m4
 +++ b/sendmail/Makefile.m4
-@@ -71,6 +71,7 @@ install-set-user-id: bldCURRENT_PRODUCT
+@@ -69,6 +69,7 @@ install-set-user-id: bldCURRENT_PRODUCT
  	${INSTALL} -c -m ${S`'BINMODE} bldCURRENT_PRODUCT ${DESTDIR}${M`'BINDIR}
  	for i in ${sendmailTARGET_LINKS}; do \
  		rm -f $$i; \
@@ -8,7 +8,7 @@
  		${LN} ${LNOPTS} ${M`'BINDIR}/sendmail $$i; \
  	done
  
-@@ -79,6 +80,7 @@ install-sm-mta: bldCURRENT_PRODUCT
+@@ -77,6 +78,7 @@ install-sm-mta: bldCURRENT_PRODUCT
  	${INSTALL} -c -m ${M`'BINMODE} bldCURRENT_PRODUCT ${DESTDIR}${M`'BINDIR}/sm-mta
  	for i in confMTA_LINKS; do \
  		rm -f $$i; \

--- a/mail/sendmail/patches/220-sm_strtoll.patch
+++ b/mail/sendmail/patches/220-sm_strtoll.patch
@@ -1,0 +1,29 @@
+Bug: https://bugs.gentoo.org/944460
+
+--- a/libsm/vfscanf.c
++++ b/libsm/vfscanf.c
+@@ -240,13 +240,13 @@ literal:
+ 			/* FALLTHROUGH */
+ 		  case 'd':
+ 			c = CT_INT;
+-			ccfn = (ULONGLONG_T (*)())sm_strtoll;
++			ccfn = (ULONGLONG_T (*)(const char *, char **, int))sm_strtoll;
+ 			base = 10;
+ 			break;
+ 
+ 		  case 'i':
+ 			c = CT_INT;
+-			ccfn = (ULONGLONG_T (*)())sm_strtoll;
++			ccfn = (ULONGLONG_T (*)(const char *, char **, int))sm_strtoll;
+ 			base = 0;
+ 			break;
+ 
+@@ -324,7 +324,7 @@ literal:
+ 			if (isupper(c))
+ 				flags |= LONG;
+ 			c = CT_INT;
+-			ccfn = (ULONGLONG_T (*)()) sm_strtoll;
++			ccfn = (ULONGLONG_T (*)(const char *, char **, int)) sm_strtoll;
+ 			base = 10;
+ 			break;
+ 		}

--- a/mail/sendmail/patches/230-ctime.patch
+++ b/mail/sendmail/patches/230-ctime.patch
@@ -1,0 +1,13 @@
+Bug: https://bugs.gentoo.org/945726
+
+--- a/mailstats/mailstats.c
++++ b/mailstats/mailstats.c
+@@ -65,7 +65,7 @@ main(argc, argv)
+ 	char sfilebuf[MAXPATHLEN];
+ 	char buf[MAXLINE];
+ 	struct statistics stats;
+-	extern char *ctime();
++	extern char *ctime(const time_t *);
+ 	extern char *optarg;
+ 	extern int optind;
+ # define MSOPTS "cC:f:opP"


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: arm_cortex-a9_neon, GCC 15, clamav builds all right

- Fix GCC 15 build with 2 patches from Gentoo [1] [2]
- Refresh existing patch

[1]: https://github.com/gentoo/gentoo/blob/master/mail-mta/sendmail/files/sendmail-8.18.1-c23-sm_strtoll.patch
[2]: https://github.com/gentoo/gentoo/blob/master/mail-mta/sendmail/files/sendmail-8.18.1-c23-ctime.patch

