### PR TITLE
cjson: fix PKG_CPE_ID

### DIFF
--- a/libs/cjson/Makefile
+++ b/libs/cjson/Makefile
@@ -13,7 +13,7 @@ PKG_HASH:=7fa616e3046edfa7a28a32d5f9eacfd23f92900fe1f8ccd988c1662f30454562
 PKG_MAINTAINER:=Karl Palsson <karlp@etactica.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
-PKG_CPE_ID:=cpe:/a:cjson_project:cjson
+PKG_CPE_ID:=cpe:/a:davegamble:cjson
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION
`cjson_project:cjson` has been deprecated in favour of `davegamble:cjson`: https://nvd.nist.gov/products/cpe/detail/70BC45DA-D915-4A1D-96AF-84A6CECEE148

Maintainer:
Compile tested: Not needed
Run tested: Not needed