### PR TITLE
bind: don't break IPv6 support

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.20.11
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>

--- a/net/bind/files/named.init
+++ b/net/bind/files/named.init
@@ -33,7 +33,7 @@ start_service() {
 	done
 
 	if [ ! -e $lib_dir ]; then
-		mkdir -p $(dirname $lib_dir)
+		mkdir -p "$(dirname $lib_dir)"
 		ln -sf $zone_dir $lib_dir
 	fi
 
@@ -43,14 +43,8 @@ start_service() {
 		chmod 0640 /etc/bind/rndc.key
 	fi
 
-	if [ -z "$(ip -6 -o route show default)" ]; then
-		args="-4"
-	else
-		args=""
-	fi
-
 	procd_open_instance
-	procd_set_param command /usr/sbin/named -u bind -f $args -c $config_file
+	procd_set_param command /usr/sbin/named -u bind -f -c $config_file
 	procd_set_param file $config_file $config_dir/db.*
 	procd_set_param respawn
 	procd_close_instance


### PR DESCRIPTION
What started in #20183 as a attempt to clean up noise in the logfiles, turned out to be causing denial-of-service for dual-stack and especially IPv6-only environments.

Breaking core network functionality cannot possibly be less important than cosmetic issues, and those affected by log spam can avoid it via other means (e.g. "query-source-v6 none;" in named.conf).

There's no reliable heuristic for determining whether there's IPv6 connectivity at the time bind is started which will catch any and all corner cases, as discussed in #26327.

So, remove this logic for now. If a suitable heuristic can be devised, it can always be added in a subsequent patch, but I have my doubts.

(Also, quote one variable to make shellcheck happy)

Closes: #26327
Closes: #20468

## 📦 Package Details

**Maintainer:** @nmeyerhans
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version: 24.10 (backport)**
- **OpenWrt Target/Subtarget: mvebu/cortexa9**
- **OpenWrt Device: Turris Omnia**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable **No applicable**
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
