### PR TITLE
ddns-scripts: stash the next check time

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=77
+PKG_RELEASE:=78
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
@@ -102,6 +102,7 @@ esac
 # set file names
 PIDFILE="$ddns_rundir/$SECTION_ID.pid"	# Process ID file
 UPDFILE="$ddns_rundir/$SECTION_ID.update"	# last update successful send (system uptime)
+CHKFILE="$ddns_rundir/$SECTION_ID.nextcheck" # next check (system uptime + check interval)
 DATFILE="$ddns_rundir/$SECTION_ID.dat"	# save stdout data of WGet and other extern programs called
 ERRFILE="$ddns_rundir/$SECTION_ID.err"	# save stderr output of WGet and other extern programs called
 IPFILE="$ddns_rundir/$SECTION_ID.ip"	#
@@ -397,7 +398,10 @@ while : ; do
 
 	# now we wait for check interval before testing if update was recognized
 	[ $DRY_RUN -eq 0 ] && {
-		write_log 7 "Waiting $CHECK_SECONDS seconds (Check Interval)"
+		get_uptime NOW_TIME
+		echo $(($NOW_TIME + $CHECK_SECONDS)) > $CHKFILE   # save the next scheduled check time
+		NEXT_CHECK_TIME=$( date -d @$(( $(date +%s) + $CHECK_SECONDS )) +"$ddns_dateformat" )
+		write_log 7 "Waiting $CHECK_SECONDS seconds (Check Interval); Next check at $NEXT_CHECK_TIME"
 		sleep $CHECK_SECONDS &
 		PID_SLEEP=$!
 		wait $PID_SLEEP	# enable trap-handler


### PR DESCRIPTION
Calculating the next check time based on the last update time is not very accurate if the next check is a large multiple forwards from the last update time because the cumulative sleeps and wake times are not exact but best effort of the OS. Other factors including clock-drift give rise to a larger time discrepancy the further the next update is in the future.

Stash the next check time which should be quite accurate since it's only one sleep instance away. This is also for use in the GUI.

Tested on 24.10.2

ping @feckert 

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.