### PR TITLE
openvswitch: add missing dependency for kmod-openvswitch<->psample (6.12 kernel)

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -17,7 +17,7 @@ include ./openvswitch.mk
 #
 PKG_NAME:=openvswitch
 PKG_VERSION:=$(ovs_version)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openvswitch.org/releases/
 PKG_HASH:=e1b3fa472676626853f22d63f959e5ad061e1bf57e1bbd444d0ed88f947ef8b1
@@ -83,6 +83,7 @@ ovs_kmod_openvswitch_depends:=\
 	  +IPV6:kmod-nf-conntrack6 \
 	  +kmod-nsh \
 	  +kmod-ipt-conntrack-extra \
+	  +kmod-sched-act-sample \
 
 ovs_kmod_openvswitch_files:=$(ovs_kmod_upstream_dir)/openvswitch.ko
 $(eval $(call OvsKmodPackageTemplate,openvswitch))


### PR DESCRIPTION
This resolves this failure observed when building on a 6.12 kernel:

`Package kmod-openvswitch is missing dependencies for the following libraries: psample.ko`

Existing issue: https://github.com/openwrt/packages/issues/26571

With only a [small number](https://github.com/openwrt/openwrt/issues/16569#issuecomment-3262280375) of targets left on 6.6, we could delete the `LINUX_6_12` conditional?

**Maintainer:** @yousong 

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT (as of 2025-09-19)
- **OpenWrt Target/Subtarget:** x86/64 and armsr/armv8
- **OpenWrt Device:** KVM virtual machine

I have only done a basic test:
* openvswitch module loads without any issue, as does psample
```
root@OpenWrt:~# lsmod | grep psample
psample                16384  2 openvswitch,act_sample
```
* I can create an ovs bridge (`ovs-vsctl add-br br0`) once the OVS database server has been enabled

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guide