### PR TITLE
rust: Update to 1.90.0

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
-PKG_VERSION:=1.89.0
+PKG_VERSION:=1.90.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.xz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
-PKG_HASH:=0b9d55610d8270e06c44f459d1e2b7918a5e673809c592abed9b9c600e33d95a
+PKG_HASH:=6bfeaddd90ffda2f063492b092bfed925c4b8c701579baf4b1316e021470daac
 HOST_BUILD_DIR:=$(BUILD_DIR)/host/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>

--- a/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
+++ b/lang/rust/patches/0001-Update-xz2-and-use-it-static.patch
@@ -17,4 +17,4 @@ Subject: [PATCH] Update xz2 and use it static
 +xz2 = { version = "0.1", features = ["static"] }
  
  # Dependencies needed by the build-metrics feature
- sysinfo = { version = "0.35.0", default-features = false, optional = true, features = ["system"] }
+ sysinfo = { version = "0.36.0", default-features = false, optional = true, features = ["system"] }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lu-zero 

**Description:**
Release note: https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** rockchip/armv8
- **OpenWrt Device:** n/a

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
