### PR TITLE
msmtp: also build msmtpd

### DIFF
--- a/mail/msmtp/Makefile
+++ b/mail/msmtp/Makefile
@@ -98,14 +98,24 @@ $(call Package/msmtp/Default/description)
  This package contains the msmtp queue scripts.
 endef
 
+define Package/msmtpd
+$(call Package/msmtp/Default)
+  TITLE:=Minimal SMTP server
+endef
+
+define Package/msmtpd/description
+ Msmtpd is a minimal SMTP server that pipes mails to msmtp or some other
+ program for delivery. It can be used with system services that expect
+ an SMTP server on the local host.
+endef
+
 CONFIGURE_ARGS += \
 	--disable-rpath \
 	--without-libintl-prefix \
 	--without-libgsasl \
 	--without-libidn \
 	--without-libsecret \
-	--without-macosx-keyring \
-	--without-msmtpd
+	--without-macosx-keyring
 
 ifeq ($(BUILD_VARIANT),ssl)
 	CONFIGURE_ARGS += --with-tls=gnutls
@@ -134,7 +144,13 @@ define Package/msmtp-queue/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/scripts/msmtpqueue/msmtp-{en,list,run}queue.sh $(1)/usr/bin/
 endef
 
+define Package/msmtpd/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/msmtpd $(1)/usr/bin/
+endef
+
 $(eval $(call BuildPackage,msmtp))
 $(eval $(call BuildPackage,msmtp-nossl))
 $(eval $(call BuildPackage,msmtp-queue))
 $(eval $(call BuildPackage,msmtp-mta))
+$(eval $(call BuildPackage,msmtpd))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** field is empty

**Description:**
Build msmtpd binary when building msmtp packages - it as a separate package.
It is really useful utility when working with programs that can only notify via email, with it you can redirect the mail to a custom script that can send it to anything you want.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

I've been successful at building this on Entware with similar Makefile: https://github.com/jacklul/entware-packages/blob/master/msmtpd/Makefile
It is working without any issues on armv7 Entware build.

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>

---

**Right now I am marking this PR as draft because:**
- I cannot test it on OpenWRT since I don't own any compatible device
- I will need to set up build system in a VM and try to build it
- I'm unsure if the new package should be called just '**msmtpd**' or '**msmtp-msmtpd**'
- I'm unsure whenever startup script should be added, this utility deos not seem have an option to start in the background

I would really like some input on the above.
