### PR TITLE
microsocks: run as unprivileged user

### DIFF
--- a/net/microsocks/Makefile
+++ b/net/microsocks/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=microsocks
 PKG_VERSION:=1.0.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/rofl0r/microsocks/tar.gz/v$(PKG_VERSION)?
@@ -21,6 +21,7 @@ define Package/microsocks
   SUBMENU:=Web Servers/Proxies
   CATEGORY:=Network
   TITLE:=SOCKS5 TCP/IP only proxy
+  USERID:=microsocks:microsocks
 endef
 
 define Package/microsocks/description

--- a/net/microsocks/files/microsocks.init
+++ b/net/microsocks/files/microsocks.init
@@ -7,12 +7,12 @@ CONF="microsocks"
 
 start_service() {
 	config_load "$CONF"
-    
+
 	local _enabled
 	config_get_bool _enabled "config" "enabled" "0"
 	[ "$_enabled" -eq "1" ] || return 1
-    
-    	local _port
+
+	local _port
 	local _listenip
 	local _bindaddr
 	local _user
@@ -27,7 +27,7 @@ start_service() {
 	config_get _password "config" "password"
 	config_get_bool _auth_once "config" "auth_once" 0
 	config_get_bool _quiet "config" "quiet" 0
-    
+
 	procd_open_instance "$CONF"
 	procd_set_param command /usr/bin/microsocks
 	[ -z "$_port" ] || procd_append_param command -p "${_port}"
@@ -37,12 +37,15 @@ start_service() {
 	[ -z "$_password" ] || procd_append_param command -P "${_password}"
 	[ "$_auth_once" -eq "0" ] || procd_append_param command -1
 	[ "$_quiet" -eq "0" ] || procd_append_param command -q
-	
+
+	procd_set_param user microsocks
+	procd_set_param group microsocks
+
 	procd_set_param respawn
 	procd_set_param stderr 1
 	# TODO: Make it dependable on some verbose/debug config setting?
 	# procd_set_param stdout 1
-    
+
 	procd_close_instance
 }
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @matkor

**Description:**
Run the daemon as unprivileged user for better security.

Trim whitespaces while at it.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** rockchip/armv8
- **OpenWrt Device:** nanopi-r5c

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.