### PR TITLE
rust: override default patch behavior

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -84,6 +84,19 @@ define Host/Uninstall
 		$(BASH) $(RUST_UNINSTALL) || echo No Uninstall
 endef
 
+define Host/Patch
+	$(if $(HOST_QUILT),rm -rf $(HOST_BUILD_DIR)/patches; mkdir -p $(HOST_BUILD_DIR)/patches)
+	$(if $(HOST_QUILT),$(call PatchDir/Quilt,$(HOST_BUILD_DIR),$(HOST_PATCH_DIR),))
+	$(if $(HOST_QUILT),touch $(HOST_BUILD_DIR)/.quilt_used)
+	$(if $(HOST_QUILT),,$(if $(wildcard $(HOST_PATCH_DIR)/*.patch), \
+		$(foreach p,$(sort $(wildcard $(HOST_PATCH_DIR)/*.patch)), \
+			echo "Applying patch $(notdir $p)" ; \
+			$(PATCH) -f -p1 -d $(HOST_BUILD_DIR) < $p || \
+			{ echo "Patch failed! Please fix: $(notdir $p)!" ; exit 1 ; } ; \
+		) \
+	))
+endef
+
 define Host/Compile
 	$(RUST_SCCACHE_VARS) \
 	CARGO_HOME=$(CARGO_HOME) \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lu-zero 

**Description:**
The scripts/patch-kernel.sh script will simply remove all files suffixed with `.orig`, and it breaks rust's integrity check as these files actually come with upstream tarball.

Create a customized Host/Patch recipe to work around the issue.

I'm not sure if it's the way to go, honestly these commands in [patch-kernel.sh](https://github.com/openwrt/openwrt/blob/fe27cce1ecb78d3f26137d44d8a20845a18af3ec/scripts/patch-kernel.sh#L47-L54) looks really overdone:

```
# Check for rejects...
if [ "`find $targetdir/ '(' -name '*.rej' -o -name '.*.rej' ')' -print`" ] ; then
    echo "Aborting.  Reject files found."
    exit 1
fi

# Remove backup files
find $targetdir/ '(' -name '*.orig' -o -name '.*.orig' ')' -exec rm -f {} \;
```

Cc: @hauke

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** rockchip/armv8
- **OpenWrt Device:** n/a

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.