### PR TITLE
ampr-ripd: changes to support future config via luci

### DIFF
--- a/net/ampr-ripd/Makefile
+++ b/net/ampr-ripd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ampr-ripd
 PKG_VERSION:=2.4.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://yo2loj.ro/hamprojects
@@ -38,7 +38,7 @@ define Package/ampr-ripd/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/ampr-ripd-init $(1)/etc/init.d/ampr-ripd
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
-	$(INSTALL_DATA) ./files/99-ampr-ripd $(1)/etc/uci-defaults/99-ampr-ripd
+	$(INSTALL_BIN) ./files/99-ampr-ripd $(1)/etc/uci-defaults/99-ampr-ripd
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/ampr-ripd-config $(1)/etc/config/ampr-ripd
 endef

--- a/net/ampr-ripd/files/99-ampr-ripd
+++ b/net/ampr-ripd/files/99-ampr-ripd
@@ -1,3 +1,4 @@
+#!/bin/sh
 ##############################################################################
 #
 # This program is free software; you can redistribute it and/or modify
@@ -13,8 +14,23 @@
 #
 ##############################################################################
 
+. /lib/functions.sh
+
+# Convert deprecated 'tunnet' option into separate
+# amprnet and amprmask options
+config_load ampr-ripd
+config_get tunnet network tunnet
+if [ -n "$tunnet" ]; then
+   amprnet=$(echo "$tunnet" | cut -d "/" -f 1)
+   amprmask=$(echo "$tunnet" | cut -d "/" -f 2)
+   uci set ampr-ripd.network.amprnet="$amprnet"
+   uci set ampr-ripd.network.amprmask="$amprmask"
+   uci del ampr-ripd.network.tunnet
+   uci commit ampr-ripd
+fi
+
 # Check to see if network.amprlan.ipaddr and network.amprwan.ipaddr exist.
-# If so, no need to apply defaults.
+# If so, no need to apply network and firewall defaults.
 
 if [ -z "$(uci -q get network.amprlan.ipaddr)" ] && \
    [ -z "$(uci -q get network.amprwan.ipaddr)" ]; then
@@ -109,4 +125,17 @@ commit firewall
 EOI
 
 fi
+
+# create amprhost if migrating config from 'tunnet' option
+if [ -n "$tunnet" ]; then
+   uci set ampr-ripd.network.amprhost=$(uci get network.amprwan.ipaddr)
+fi
+
+# If enabled does not exist default to 1
+config_get_bool enabled network enabled
+if [ -z "$enabled" ]; then
+   uci set ampr-ripd.network.enabled='1'
+fi
+uci commit ampr-ripd
+
 exit

--- a/net/ampr-ripd/files/ampr-ripd-config
+++ b/net/ampr-ripd/files/ampr-ripd-config
@@ -1,4 +1,5 @@
-
 config ampr-ripd 'network'
-	option tunnet 44.127.254.0/255.255.255.0
-
+	option enabled '0'
+	option amprhost '44.127.254.254'
+	option amprmask '255.255.255.0'
+	option amprnet '44.127.254.0'

--- a/net/ampr-ripd/files/ampr-ripd-init
+++ b/net/ampr-ripd/files/ampr-ripd-init
@@ -17,14 +17,19 @@ start() {
 
 		exit 1
 	fi
-	if [ ! -d /var/lib/ampr-ripd ]; then
-		mkdir -p /var/lib/ampr-ripd
+	config_load ampr-ripd
+	config_get enabled network enabled 0
+	if [ "$enabled" != 1 ]; then
+		echo "ampr-ripd disabled via config"
+		exit 1
 	fi
+	mkdir -p /var/lib/ampr-ripd
 	ip tunnel change ttl 64 mode ipip tunl0
 	ip link set dev tunl0 up
 	ifconfig tunl0 mtu 1480
-	tunnet=$(uci -q get ampr-ripd.network.tunnet)
-	/usr/sbin/ampr-ripd -s -r -t 44 -i tunl0 -a "$tunnet"
+	config_get amprnet network amprnet
+	config_get amprmask network amprmask
+	/usr/sbin/ampr-ripd -s -r -t 44 -i tunl0 -a "$amprnet/$amprmask"
 }
 
 stop() {
@@ -58,16 +63,19 @@ configure() {
 	amprnet=$amprnet
 	EOF
 
-	tunnet=$amprnet/$amprmask
-	uci set ampr-ripd.network.tunnet="$tunnet"
+	uci set ampr-ripd.network.amprhost="$amprhost"
+	uci set ampr-ripd.network.amprmask="$amprmask"
+	uci set ampr-ripd.network.amprnet="$amprnet"
+	uci set ampr-ripd.network.enabled='1'
 	uci commit ampr-ripd
+
 	uci set network.amprlan.ipaddr="$amprhost"
 	uci set network.amprlan.netmask="$amprmask"
 	uci set network.amprwan.ipaddr="$amprhost"
 	uci set network.amprwan.netmask="$amprmask"
 	for i in $(uci show network | awk -F= "/@rule/ && /lookup='44'/ {split(\$1, conf, /[.=]/); print conf[2]}"); do
 		if [ "$(uci -q get "network.$i.priority")" = "45" ]; then
-			uci set "network.$i.src=$tunnet"
+			uci set "network.$i.src=$amprnet/$amprmask"
 		fi
 	done
 	uci commit network


### PR DESCRIPTION
In developing a Luci interface for this package, it was determined
that there is utility in parsing out the address and netmask parts
of tunnet into separate values and adding the host address to
the config file.

## 📦 Package Details

**Maintainer:** @K2IE

**Description:**
Change /etc/config/ampr-ripd to no longer use tunnet, instead
   using amprnet and amprmask for CLI configuration
Add amprhost to the config for future use in by luci
Modify initscript to migrate to the new options when needed

## 🧪 Run Testing Details

- **OpenWrt Version: 24.10.2**
- **OpenWrt Target/Subtarget: bcm27xx/bcm2711**
- **OpenWrt Device: RPi CM4**

Tested as a new install and as upgrade to rev 2.  Worked as expected in all cases.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
