### PR TITLE
sqlite3: fix building with line editing libs

### DIFF
--- a/libs/linenoise/Makefile
+++ b/libs/linenoise/Makefile
@@ -1,0 +1,47 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=linenoise
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/antirez/linenoise.git
+PKG_SOURCE_DATE:=2025-09-10
+PKG_SOURCE_VERSION:=880b94130ffa5f8236392392b447ff2234b11983
+PKG_MIRROR_HASH:=a554a5ea9b2111cfb1d844a072933109f8316914eb40edca3919915a5ddb5df9
+
+PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/linenoise
+  TITLE:=A minimal, zero-config, readline replacement
+  CATEGORY:=Libraries
+  URL:=https://github.com/antirez/linenoise
+  BUILDONLY:=1
+endef
+
+define Package/linenoise/description
+ A minimal, zero-config, BSD licensed, readline replacement used in Redis,
+ MongoDB, Android and many other projects.
+endef
+
+define Build/Compile
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/linenoise
+	$(CP) $(PKG_BUILD_DIR)/linenoise.[ch] $(1)/usr/include/linenoise
+endef
+
+define Build/Clean
+	$(RM) -rf $(STAGING_DIR)/usr/include/linenoise
+endef
+
+$(eval $(call BuildPackage,linenoise))

--- a/libs/sqlite3/Config-cli.in
+++ b/libs/sqlite3/Config-cli.in
@@ -3,17 +3,22 @@ menu "Configuration"
 
 choice
 	prompt "Select command-line editing support"
-	default SQLITE3_LIBEDIT
+	default SQLITE3_LINENOISE
+
+	config SQLITE3_LINENOISE
+	bool "linenoise"
+	help
+	  Build with linenoise. This is the default. Adds ~12k compared to the "none" variant
 
 	config SQLITE3_LIBEDIT
 	bool "libedit"
 	help
-	  Link against libedit. This is the default.
+	  Link against libedit. Adds 4k + ~192k for libedit + ~341k for ncurses
 
 	config SQLITE3_READLINE
 	bool "readline"
 	help
-	  Link against GNU readline.
+	  Link against GNU readline. Adds 4k + ~333k for readline + ~341k for ncurses
 
 	config SQLITE3_READLINE_NONE
 	bool "none"

--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=sqlite
 PKG_VERSION:=3.50.4
 PKG_SRC_VERSION:=3500400
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-autoconf-$(PKG_SRC_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.sqlite.org/2025/
@@ -34,9 +34,12 @@ PKG_CONFIG_DEPENDS := \
 	CONFIG_SQLITE3_FTS4 \
 	CONFIG_SQLITE3_FTS5 \
 	CONFIG_SQLITE3_LIBEDIT \
+	CONFIG_SQLITE3_LINENOISE \
 	CONFIG_SQLITE3_READLINE \
 	CONFIG_SQLITE3_RTREE \
 	CONFIG_SQLITE3_SESSION
+
+PKG_BUILD_DEPENDS += SQLITE3_LINENOISE:linenoise
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -77,8 +80,7 @@ define Package/sqlite3-cli
   DEPENDS := \
     +libsqlite3 \
     +SQLITE3_LIBEDIT:libedit \
-    +SQLITE3_READLINE:libreadline \
-    +SQLITE3_READLINE:libncursesw
+    +SQLITE3_READLINE:libreadline
   EXTRA_DEPENDS:=libsqlite3 (=$(PKG_VERSION)-r$(PKG_RELEASE))
   TITLE+= (cli)
 endef
@@ -99,7 +101,9 @@ TARGET_CFLAGS += \
 	-DHAVE_MALLOC_USABLE_SIZE \
 	-DSQLITE_ENABLE_UNLOCK_NOTIFY \
 	$(if $(CONFIG_SQLITE3_BATCH_ATOMIC_WRITE),-DSQLITE_ENABLE_BATCH_ATOMIC_WRITE) \
-	$(if $(CONFIG_SQLITE3_COLUMN_METADATA),-DSQLITE_ENABLE_COLUMN_METADATA)
+	$(if $(CONFIG_SQLITE3_COLUMN_METADATA),-DSQLITE_ENABLE_COLUMN_METADATA) \
+	-DHAVE_EDITLINE=$(if $(CONFIG_SQLITE3_LIBEDIT),1,0) \
+	-DHAVE_READLINE=$(if $(CONFIG_SQLITE3_READLINE),1,0)
 
 CONFIGURE_ARGS := \
 	$(filter-out --target=% $(DISABLE_IPV6) $(DISABLE_NLS),$(CONFIGURE_ARGS)) \
@@ -117,9 +121,11 @@ CONFIGURE_ARGS := \
 	$(if $(CONFIG_SQLITE3_SESSION),--enable-session,--disable-session)
 
 ifeq ($(CONFIG_SQLITE3_LIBEDIT),y)
-CONFIGURE_ARGS+=--disable-readline
+CONFIGURE_ARGS+=--editline --with-readline-header=$(STAGING_DIR)/usr/include/editline/readline.h
 else ifeq ($(CONFIG_SQLITE3_READLINE),y)
-CONFIGURE_ARGS+=--disable-editline
+CONFIGURE_ARGS+=--readline --with-readline-header=$(STAGING_DIR)/usr/include/readline/readline.h
+else ifeq ($(CONFIG_SQLITE3_LINENOISE),y)
+CONFIGURE_ARGS+=--with-linenoise=$(STAGING_DIR)/usr/include/linenoise
 else
 CONFIGURE_ARGS+=--disable-editline --disable-readline
 endif


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** none

**Description:**
1.
Tell `configure` where to find include directories for libreadline and libeditline.
In the case of cross-compilation, `--readline` or `--editline` alone is not enough, configure can't test if the corresponding include file is available:
```
$ grep -E  'CONFIG_SQLITE3_(LIB|READ)'  .config
CONFIG_SQLITE3_LIBEDIT=y
# CONFIG_SQLITE3_READLINE is not set
# CONFIG_SQLITE3_READLINE_NONE is not set
...
Checking for line-editing capability...
Readline support explicitly disabled with --disable-readline
Line-editing support for the sqlite3 shell: none
```

```
$ grep -E  'CONFIG_SQLITE3_(LIB|READ)'  .config
# CONFIG_SQLITE3_LIBEDIT is not set
CONFIG_SQLITE3_READLINE=y
# CONFIG_SQLITE3_READLINE_NONE is not set
...
Checking for line-editing capability...
WARNING: [sqlite-check-line-editing]:  Skipping check for readline.h because we're cross-compiling.
Line-editing support for the sqlite3 shell: none
```
2.
Use linenoise as the default line editing option. This adds 12k on top of sqlite3-cli with no line editing capabilities, but doesn't add any extra dependencies like ncurses or readline/libedit.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** r31110+2-41aaebad98
- **OpenWrt Target/Subtarget:** qualcommax/ipq807x
- **OpenWrt Device:** Dynalink DL-WRX36

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

