### PR TITLE
sendmail: fix build on hosts with Berkley DB installed

### DIFF
--- a/mail/sendmail/Makefile
+++ b/mail/sendmail/Makefile
@@ -8,10 +8,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sendmail
 PKG_VERSION:=8.18.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=ftp://ftp.sendmail.org/pub/sendmail
+PKG_SOURCE_URL:=https://ftp.sendmail.org
 PKG_HASH:=cbf1f309c38e4806f7cf3ead24260f17d1fe8fb63256d13edb3cdd1a098f0770
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 

--- a/mail/sendmail/files/site.OpenWrt.m4
+++ b/mail/sendmail/files/site.OpenWrt.m4
@@ -1,5 +1,5 @@
 define(`confCC', `TARGET_CC')
 define(`confCCOPTS', `TARGET_CFLAGS')
 APPENDDEF(`confENVDEF',`-DSTARTTLS')
+APPENDDEF(`confENVDEF',`-DHASFLOCK')
 APPENDDEF(`confLIBS', `-lssl -lcrypto')
-


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: arm_cortex-a9_neon

Buildbot caught an error:
  "Berkeley DB file locking needs flock() for version 5.x (and greater?)"

It is caused by leakage of host-installed Berkley DB into the build. Since libmilter is not using the DB and because of convoluted build process of sendmail, we do the workaround  - define a macro which prevents the error without affecting libmilter binary.
