### PR TITLE
knot: update to version 3.5.0

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.4.8
+PKG_VERSION:=3.5.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=6730a73dbfc12d79d8000ffe22d36d068b7467e74bee1eb122ac4935ecea49f9
+PKG_HASH:=d52538bf7364c280999dec58c2a02a405dd922ef5794da1473ca7c3cf7f01277
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
-PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8
+PKG_LICENSE:=GPL-2.0-or-later LGPL-2.0-or-later MIT ISC BSD-3-Clause
 PKG_CPE_ID:=cpe:/a:knot-dns:knot_dns
 
 PKG_FIXUP:=autoreconf

--- a/net/knot/patches/01_zscanner_tests.patch
+++ b/net/knot/patches/01_zscanner_tests.patch
@@ -1,7 +1,8 @@
 --- a/tests/libzscanner/test_zscanner.in
 +++ b/tests/libzscanner/test_zscanner.in
-@@ -1,15 +1,14 @@
- #!/bin/sh
+@@ -3,16 +3,15 @@
+ # SPDX-License-Identifier: GPL-2.0-or-later
+ # For more information, see <https://www.knot-dns.cz/>
  
 -SOURCE=@top_srcdir@/tests/libzscanner
 -BUILD=@top_builddir@/tests/libzscanner

--- a/net/knot/patches/03_common_stats.patch
+++ b/net/knot/patches/03_common_stats.patch
@@ -1,0 +1,22 @@
+From 4f02c29b67790ff05f23fc6593e145be7c223c70 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20H=C3=A1k?= <jan.hak@nic.cz>
+Date: Tue, 23 Sep 2025 12:52:25 +0200
+Subject: [PATCH] fix: failing build of knot/common/stats.c on PowerPC and MIPS
+
+---
+ src/knot/common/stats.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/src/knot/common/stats.c
++++ b/src/knot/common/stats.c
+@@ -127,8 +127,8 @@ int stats_server(stats_dump_ctr_f fcn, s
+ 	}
+ 
+ 	DUMP_VAL(params, "zone-count", knot_zonedb_size(ctx->server->zone_db));
+-	DUMP_VAL(params, "tcp-io-timeout", ctx->server->stats.tcp_io_timeout);
+-	DUMP_VAL(params, "tcp-idle-timeout", ctx->server->stats.tcp_idle_timeout);
++	DUMP_VAL(params, "tcp-io-timeout", ATOMIC_GET(ctx->server->stats.tcp_io_timeout));
++	DUMP_VAL(params, "tcp-idle-timeout", ATOMIC_GET(ctx->server->stats.tcp_idle_timeout));
+ 
+ 	return KNOT_EOK;
+ }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @salzmdan

**Description:** 

- Release upgrade (https://www.knot-dns.cz/2025-09-18-version-350.html)
- Change of license (details at https://gitlab.nic.cz/knot/knot-dns/-/blob/3.5/distro/pkg/deb/copyright?ref_type=heads)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** TurrisOS 9.0.0
- **OpenWrt Target/Subtarget:** mvebu/cortexa9
- **OpenWrt Device:** Turris Omnia

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
