### PR TITLE
snort3: fix detection of deps

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.9.5.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/snort3/snort3/tar.gz/$(PKG_VERSION)?
@@ -21,23 +21,44 @@ PKG_CPE_ID:=cpe:/a:snort:snort
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-ifeq ($(filter $(ARCH),mips mips64 mipsel powerpc),)
-  EXTRA_DEPENDS += +gperftools-runtime
-endif
-ifeq ($(filter $(ARCH),x86_64 aarch64),$(ARCH))
-  EXTRA_DEPENDS += +vectorscan-runtime
-  CMAKE_OPTIONS += -DHS_INCLUDE_DIRS=$(STAGING_DIR)/usr/include/hs
-endif
-
 SNORT3DEPS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre2 \
     +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic \
-    +kmod-nft-queue +liblzma +ucode +ucode-mod-fs +ucode-mod-uci $(EXTRA_DEPENDS)
+    +kmod-nft-queue +liblzma +ucode +ucode-mod-fs +ucode-mod-uci
+
+ifeq ($(filter $(ARCH),mips mips64 mipsel powerpc),)
+  SNORT3DEPS += +gperftools-runtime
+  CMAKE_OPTIONS += -DENABLE_TCMALLOC=ON \
+		   -DTCMALLOC_LIBRARIES=$(STAGING_DIR)/usr/lib/libtcmalloc.so
+
+endif
+
+ifeq ($(filter $(ARCH),x86_64 aarch64),$(ARCH))
+  CMAKE_OPTIONS += -DHS_INCLUDE_DIRS=$(STAGING_DIR)/usr/include/hs
+endif
 
 define Package/snort3
   SUBMENU:=Firewall
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=$(SNORT3DEPS)
+  DEPENDS:=$(SNORT3DEPS) \
+	+TARGET_x86:vectorscan-runtime \
+	+TARGET_bcm4908:vectorscan-runtime \
+	+TARGET_qualcommax:vectorscan-runtime \
+	+TARGET_qualcommbe:vectorscan-runtime \
+	+TARGET_bcm27xx_bcm2710:vectorscan-runtime \
+	+TARGET_bcm27xx_bcm2711:vectorscan-runtime \
+	+TARGET_bcm27xx_bcm2712:vectorscan-runtime \
+	+TARGET_armsr_armv8:vectorscan-runtime \
+	+TARGET_airoha_an7581:vectorscan-runtime \
+	+TARGET_imx_cortexa53:vectorscan-runtime \
+	+TARGET_layerscape_armv8_64b:vectorscan-runtime \
+	+TARGET_mediatek_filogic:vectorscan-runtime \
+	+TARGET_mediatek_mt7622:vectorscan-runtime \
+	+TARGET_mvebu_cortexa53:vectorscan-runtime \
+	+TARGET_mvebu_cortexa72:vectorscan-runtime \
+	+TARGET_rockchip_armv8:vectorscan-runtime \
+	+TARGET_sunxi_cortex53:vectorscan-runtime
+
   TITLE:=Lightweight Network Intrusion Detection System
   URL:=http://www.snort.org/
   MENU:=1
@@ -64,8 +85,6 @@ CMAKE_OPTIONS += \
 	-DMAKE_PDF_DOC:BOOL=NO \
 	-DMAKE_TEXT_DOC:BOOL=NO \
 	-DHAVE_LIBUNWIND=OFF \
-	-DENABLE_TCMALLOC=ON \
-	-DTCMALLOC_LIBRARIES=$(STAGING_DIR)/usr/lib/libtcmalloc.so \
 	-DHAVE_LZMA=ON
 
 TARGET_CFLAGS  += -I$(STAGING_DIR)/usr/include/daq3 -I$(STAGING_DIR)/usr/include/tirpc


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

This should fix the detection of deps in the snort3 package which is currently not building for a number of targets as pointed out in here: https://github.com/openwrt/packages/pull/27022#issuecomment-3317449743

I can find no way to define all aarch64 targets without manually doing so. I generated the list by:
```
% find target/linux -name Makefile -print0 | xargs -0 grep ARCH | grep aarch64
% find target/linux -name target.mk -print0 | xargs -0 grep ARCH | grep aarch64 | sort
```
As a test, I used this script to spot check:
```cat <<EOF > x86
CONFIG_TARGET_x86=y
CONFIG_TARGET_x86_64=y
CONFIG_TARGET_x86_64_DEVICE_generic=y
CONFIG_PACKAGE_snort3=y
EOF

cat <<EOF > rpi5
CONFIG_TARGET_bcm27xx=y
CONFIG_TARGET_bcm27xx_bcm2712=y
CONFIG_TARGET_bcm27xx_bcm2712_DEVICE_rpi-5=y
CONFIG_PACKAGE_snort3=y
EOF

cat <<EOF > rpi
CONFIG_TARGET_bcm27xx=y
CONFIG_TARGET_bcm27xx_bcm2708=y
CONFIG_TARGET_bcm27xx_bcm2708_DEVICE_rpi=y
CONFIG_PACKAGE_snort3=y
EOF

for i in rpi x86 rpi5; do
	echo " >>> $i"
	cp $i .config
	make defconfig &>/dev/null ; grep --color=auto -E '(gperftools-run|snort3|vectorscan-run)' .config
	echo
done
```
The result:
```
 >>> rpi
CONFIG_PACKAGE_gperftools-runtime=y
CONFIG_PACKAGE_snort3=y
 >>> x86
CONFIG_PACKAGE_gperftools-runtime=y
CONFIG_PACKAGE_vectorscan-runtime=y
CONFIG_PACKAGE_snort3=y
 >>> rpi5
CONFIG_PACKAGE_gperftools-runtime=y
CONFIG_PACKAGE_vectorscan-runtime=y
CONFIG_PACKAGE_snort3=y
```

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** Intel N150 PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
