### PR TITLE
ufp: add ubus_rpc_session to call arguments

### DIFF
--- a/utils/ufp/patches/0001-add-ubus-rpc-session-to-ufp.patch
+++ b/utils/ufp/patches/0001-add-ubus-rpc-session-to-ufp.patch
@@ -1,0 +1,10 @@
+--- a/ufpd
++++ b/ufpd
+@@ -363,6 +363,7 @@ global.ubus_object = {
+ 	fingerprint: {
+ 		args: {
+ 			macaddr: "",
++			ubus_rpc_session: "",
+ 			weight: false,
+ 			local: false
+ 		},


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @blogic 

**Description:**

For the time being this patch enables lookup of vendors for MAC ouis with ubus method `fingerprint`, while it is not merged into upstream repo.
---

## 🧪 Run Testing Details

- **OpenWrt Version:** openwrt-24.10
- **OpenWrt Target/Subtarget:** x86/64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
