### PR TITLE
gperftools: allow building for powerpc

### DIFF
--- a/libs/gperftools/Makefile
+++ b/libs/gperftools/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gperftools
 PKG_VERSION:=2.17.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/gperftools/gperftools/tar.gz/$(PKG_NAME)-$(PKG_VERSION)?
@@ -27,7 +27,7 @@ define Package/gperftools
   CATEGORY:=Libraries
   TITLE:=Gperftools Runtime
   URL:=https://github.com/gperftools/gperftools
-  DEPENDS:=+PACKAGE_libunwind:libunwind +libstdcpp @!(powerpc)
+  DEPENDS:=+PACKAGE_libunwind:libunwind +libstdcpp
   ABI_VERSION:=4
 endef
 

--- a/libs/gperftools/patches/0001-powerpc-include-asm-ptrace.h-for-PT_NIP-declaration.patch
+++ b/libs/gperftools/patches/0001-powerpc-include-asm-ptrace.h-for-PT_NIP-declaration.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Tue, 23 Sep 2025 18:35:30 +0200
+Subject: [PATCH] powerpc: include <asm/ptrace.h> for PT_NIP declaration
+
+This patch conditionally includes <asm/ptrace.h> when available to
+ensure PT_NIP is properly declared, fixing build failures such as:
+
+  error: 'PT_NIP' was not declared in this scope; did you mean 'PT_NUM'?
+
+It happened on musl and powerpc
+---
+ src/stacktrace_powerpc-linux-inl.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/src/stacktrace_powerpc-linux-inl.h
++++ b/src/stacktrace_powerpc-linux-inl.h
+@@ -48,6 +48,9 @@
+ #include <gperftools/stacktrace.h>
+ #include <base/vdso_support.h>
+ 
++#ifdef HAVE_ASM_PTRACE_H
++#include <asm/ptrace.h>
++#endif
+ #if HAVE_SYS_UCONTEXT_H
+ #include <sys/ucontext.h>
+ #elif HAVE_UCONTEXT_H

--- a/libs/gperftools/patches/0002-elf_mem_image-derive-ELF-class-from-pointer-size-not.patch
+++ b/libs/gperftools/patches/0002-elf_mem_image-derive-ELF-class-from-pointer-size-not.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Wed, 24 Sep 2025 10:57:08 +0200
+Subject: [PATCH] elf_mem_image: derive ELF class from pointer size, not
+ __WORDSIZE
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+__WORDSIZE is a non-standard glibc macro that musl does not expose
+through the headers included here, so the build fails on musl-based
+systems:
+
+  src/base/elf_mem_image.cc:95:18: error: '__WORDSIZE' was not declared in this scope
+     95 | typedef ElfClass<__WORDSIZE> CurrentElfClass;
+        |                  ^~~~~~~~~~
+
+This code is ELF-only, where the pointer size can be assumed to be the
+word size, so compute the ELF class from sizeof(void*) instead of
+relying on a libc-specific macro.
+
+Co-authored-by: Karel Kočí <cynerd@email.cz>
+---
+ src/base/elf_mem_image.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/base/elf_mem_image.cc
++++ b/src/base/elf_mem_image.cc
+@@ -92,7 +92,7 @@ template <> class ElfClass<64> {
+   }
+ };
+ 
+-typedef ElfClass<__WORDSIZE> CurrentElfClass;
++typedef ElfClass<sizeof(void*) * 8> CurrentElfClass;
+ 
+ // Extract an element from one of the ELF tables, cast it to desired type.
+ // This is just a simple arithmetic and a glorified cast.

--- a/libs/gperftools/patches/0003-powerpc-fix-PT_NIP-access-in-ucontext-for-glibc-vs-n.patch
+++ b/libs/gperftools/patches/0003-powerpc-fix-PT_NIP-access-in-ucontext-for-glibc-vs-n.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Tue, 23 Sep 2025 18:40:37 +0200
+Subject: [PATCH] powerpc: fix PT_NIP access in ucontext for glibc vs non-glibc
+
+The layout of ucontext_t differs between glibc and some
+other C libraries. Specifically, the instruction pointer (PT_NIP) is
+accessed through:
+
+  uc.uc_mcontext.uc_regs->gregs[PT_NIP]   (glibc)
+  uc.uc_mcontext.gregs[PT_NIP]            (non-glibc)
+
+Without this distinction, builds on non-glibc systems fail with
+invalid field access errors.
+
+Based on https://gcc.gnu.org/cgit/gcc/commit/?id=6a4e9934545c112eef5eb7248636baa96cbfd2c0
+---
+ src/stacktrace_powerpc-linux-inl.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/src/stacktrace_powerpc-linux-inl.h
++++ b/src/stacktrace_powerpc-linux-inl.h
+@@ -207,7 +207,11 @@ static int GET_STACK_TRACE_OR_FRAMES {
+           ucontext_t uc;
+           // We don't care about the rest, since IP value is at 'uc' field.A
+         } *sigframe = reinterpret_cast<rt_signal_frame_32*>(current);
++#if defined(__GLIBC__)
+         result[n] = (void*) sigframe->uc.uc_mcontext.uc_regs->gregs[PT_NIP];
++#else
++        result[n] = (void*) sigframe->uc.uc_mcontext.gregs[PT_NIP];
++#endif
+       }
+ #endif
+ 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @graysky2 

**Description:**
This commit also adds pending patch, which was submitted to upstream to fix issues discovered by using powerpc and musl. See: https://github.com/gperftools/gperftools/issues/1602

---

## 🧪 Run Testing Details

NO
---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable

_____

@graysky2 If you would like to have it fixed for mips, please report it as upstream as suggested in https://github.com/openwrt/packages/pull/21627#issuecomment-3075332950
