### PR TITLE
vectorscan: adjust DEPENDS to include other targets

### DIFF
--- a/libs/vectorscan/Makefile
+++ b/libs/vectorscan/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vectorscan
 PKG_VERSION:=5.4.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/VectorCamp/vectorscan/tar.gz/$(PKG_NAME)/$(PKG_VERSION)?
@@ -24,7 +24,7 @@ PKG_BUILD_DEPENDS:=ragel/host python3/host boost/host
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-DEPENDS_COMMON:=@(x86_64||aarch64)
+DEPENDS_COMMON:=@(aarch64||arm||i386||i686||x86_64)
 
 # With at least version 5.4.12, Neon/ASIMD is required for Arm support
 ifeq ($(CONFIG_CPU_NEON),)


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Correct an oversight on my part to extend the DEPENDS to other values beyond just x86_64 and aarch64.

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** Generic PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
