### PR TITLE
lvm2: disable readline and interactive shell

### DIFF
--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=LVM2
 PKG_VERSION:=2.03.33
 PKG_VERSION_DM:=1.02.207
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://sourceware.org/pub/lvm2 \
@@ -68,7 +68,7 @@ define Package/lvm2/default
   SUBMENU:=Disc
   TITLE:=The Linux Logical Volume Manager
   URL:=https://sourceware.org/lvm2/
-  DEPENDS:=+libreadline +libncurses +libaio
+  DEPENDS:=+libaio
 endef
 
 define Package/lvm2
@@ -104,6 +104,8 @@ CONFIGURE_ARGS += \
 	--with-default-run-dir=/var/run/lvm \
 	--with-default-locking-dir=/var/lock/lvm \
 	--without-libnvme \
+	--disable-readline \
+	--disable-libedit \
 	--$(if $(findstring selinux,$(BUILD_VARIANT)),en,dis)able-selinux
 
 ifneq ($(shell /bin/sh -c "echo -n 'X'"),X)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**

remove support of interactive mode in `/sbin/lvm`

Benefits:
- drop dependency on readline and ncurses (-700kb if there are no other users of these libs)
- shrink the `lvm` binary itself (-260k)

Drawback:
- lose interactive shell:
```
lvm> vgchange -ay
  4 logical volume(s) in volume group "vg0" now active
lvm>
```

`lvm <subcommand> --params` and `<subcommand> --params` entry points are still available

All use cases in this repo use `lvm <subcommand>` calling convention

---

## 🧪 Run Testing Details

- **OpenWrt Version:** r31110+2-41aaebad98
- **OpenWrt Target/Subtarget:** qualcommax/ipq807x
- **OpenWrt Device:** Dynalink DL-WRX36

Tested by running the updated lvm binary:
```
# /tmp/test/lvm pvs
  PV         VG     Fmt  Attr PSize  PFree
  /dev/sda   vg0 lvm2 a--  <1.82t <1.04t
  /dev/sdb   vg0 lvm2 a--  <2.73t <2.05t

# ls -la /tmp/test/pvs
lrwxrwxrwx    1 root     root             3 Sep 25 13:58 /tmp/test/pvs -> lvm
# /tmp/test/pvs
  PV         VG     Fmt  Attr PSize  PFree
  /dev/sda   vg0 lvm2 a--  <1.82t <1.04t
  /dev/sdb   vg0 lvm2 a--  <2.73t <2.05t
```
---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

