### PR TITLE
knot: fix missing hiredis dependecy on some platforms

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -157,6 +157,7 @@ CONFIGURE_ARGS += 			\
 	--enable-dbus=libdbus           \
 	--enable-quic			\
 	--disable-fastparser		\
+	--disable-redis			\
 	--without-libidn		\
 	--with-libnghttp2=no		\
 	--with-rundir=/var/run/knot	\


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @salzmdan

**Description:** 

- Fix problem with hiredis library on some platforms where is automatically detected Redis support.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** TurrisOS 9.0.0
- **OpenWrt Target/Subtarget:** mvebu/cortexa9
- **OpenWrt Device:** Turris Omnia

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
