### PR TITLE
syslog-ng: add runtime test

### DIFF
--- a/admin/syslog-ng/test.sh
+++ b/admin/syslog-ng/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+syslog-ng --version | grep "$2"


### PR DESCRIPTION
It adds a runtime test to verify that the compiled binary in CI/CD runs without segfault and prints the version.