### PR TITLE
snapcast: show snapweb placeholder and remove (now) unused avahi dependency

### DIFF
--- a/sound/snapcast/Makefile
+++ b/sound/snapcast/Makefile
@@ -27,7 +27,7 @@ define Package/snapcast/Default
   SECTION:=sound
   CATEGORY:=Sound
   TITLE:=Synchronous multiroom audio player
-  DEPENDS:=+AUDIO_SUPPORT:alsa-lib +libavahi-client +libatomic +libogg +libflac +libopus +boost +libsoxr
+  DEPENDS:=+AUDIO_SUPPORT:alsa-lib +libexpat +libatomic +libogg +libflac +libopus +boost +libsoxr
   URL:=https://github.com/badaix/snapcast
 endef
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me (@xabolcs), @davidandreoletti 

**Description:**
snapserver has a built-in player: [snapweb](https://github.com/badaix/snapweb).
It is accessible at http://snapcast:1780/ but without this placeholder the browser shows an empty page with a message:
```
The resource '/' was not found.
```

Fix this with including the Snapweb placeholder.

This was reported in an [upstream discussion](https://github.com/badaix/snapcast/discussions/1417#discussioncomment-14480178) by Robert Muth.

Fixes: eeb8d131fc9 ("snapcast: add package snapserver and snapclient")

While at it, remove the (now) unused `libavahi-client` dependency.

Fixes: a9ac8666da5f ("snapcast: fix PulseAudio")

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** ath79/nand
- **OpenWrt Device:** GL-AR300M

Before:
> <img width="1043" height="640" alt="Screenshot 2025-09-26 at 00-40-50 " src="https://github.com/user-attachments/assets/89de7c21-1c57-497b-a669-5e75c590dcbf" />


After:
> <img width="944" height="390" alt="Screenshot 2025-10-05 at 11-43-35 Snapcast Default Page" src="https://github.com/user-attachments/assets/5bc506e0-a847-43a3-8e2a-6a103c2639fc" />


---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:
Doesn't contain patch.

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
