### PR TITLE
frp: bump to 0.65.0

### DIFF
--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=frp
-PKG_VERSION:=0.64.0
+PKG_VERSION:=0.65.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=c755c0aaeec3999cb259a312f3327db205a834abf0beeb6410dcdc818d9719a4
+PKG_HASH:=bbec0d1855e66c96e3a79ff97b8c74d9b1b45ec560aa7132550254d48321f7de
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** N/A

**Description:**

Change log is available at: https://github.com/fatedier/frp/releases/tag/v0.65.0

- Add NAT traversal configuration options for XTCP proxies and visitors. Support disabling assisted addresses to avoid using slow VPN connections during NAT hole punching.
- Enhanced OIDC client configuration with support for custom TLS certificate verification and proxy settings. Added trustedCaFile, insecureSkipVerify, and proxyURL options for OIDC token endpoint connections.
- Added detailed Prometheus metrics with proxy_counts_detailed metric that includes both proxy type and proxy name labels, enabling monitoring of individual proxy connections instead of just aggregate counts.

---

## 🧪 Run Testing Details

- **OpenWrt Version: main/snapshot
- **OpenWrt Target/Subtarget: qualcommax/aarch64
- **OpenWrt Device: ipq6000-360v6

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
