### PR TITLE
gperftools: allow it for mips

### DIFF
--- a/libs/gperftools/Makefile
+++ b/libs/gperftools/Makefile
@@ -26,7 +26,7 @@ define Package/gperftools-headers
   SECTION:=libs
   TITLE:=Gperftools Headers
   URL:=https://github.com/gperftools/gperftools
-  DEPENDS:= @!(mips||mips64||mipsel||powerpc)
+  DEPENDS:= @!(powerpc)
 endef
 
 define Package/gperftools-runtime
@@ -34,7 +34,7 @@ define Package/gperftools-runtime
   CATEGORY:=Libraries
   TITLE:=Gperftools Runtime
   URL:=https://github.com/gperftools/gperftools
-  DEPENDS:= +libunwind +libstdcpp @!(mips||mips64||mipsel||powerpc)
+  DEPENDS:= +libunwind +libstdcpp @!(powerpc)
 endef
 
 define Package/gperftools-headers/description


### PR DESCRIPTION
Maintainer: @graysky2

It looks like I will be the one, who will report it to upstream regarding mips (https://github.com/openwrt/packages/pull/21627#issuecomment-3075332950)