### PR TITLE
fix(rust): correct Makefile indentation for Host/Prepare

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -104,5 +104,11 @@ define Host/Install
 	)
 endef
 
+define Host/Prepare
+	$(call Host/Prepare/Default)
+	find $(HOST_BUILD_DIR)/vendor -name '*.orig' -delete || true
+endef
+
+
 $(eval $(call HostBuild))
 $(eval $(call BuildPackage,rust))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
