### PR TITLE
expat: upgrade to 2.7.3

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -6,14 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
-PKG_VERSION:=2.7.1
+PKG_VERSION:=2.7.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$(PKG_VERSION))
-PKG_HASH:=0cce2e6e69b327fc607b8ff264f4b66bdf71ead55a87ffd5f3143f535f15cfa2
+PKG_HASH:=821ac9710d2c073eaf13e1b1895a9c9aa66c1157a99635c639fbff65cdbdd732
 
-PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:libexpat_project:libexpat


### PR DESCRIPTION
**📦 Package Details**

Upstream changelog: https://github.com/libexpat/libexpat/blob/R_2_7_3/expat/Changes


**🧪 Run Testing Details**

- **OpenWrt Version:** trunk
- **OpenWrt Target/Subtarget:** Mediatek/MT7622
- **OpenWrt Device:** Linksys E8450

