### PR TITLE
poemgr: update to latest HEAD

### DIFF
--- a/utils/poemgr/Makefile
+++ b/utils/poemgr/Makefile
@@ -3,13 +3,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=poemgr
-PKG_SOURCE_DATE:=2025-07-23
-PKG_SOURCE_VERSION:=f1f093852abaab506d54fd2c5384fec9b798dd1a
+PKG_SOURCE_DATE:=2025-09-27
+PKG_SOURCE_VERSION:=17771dd7b3a74a64c14351d1cbf8e61676934cbe
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://github.com/blocktrron/poemgr.git
-PKG_MIRROR_HASH:=e96aeabd3380a4b9a737a7a731a34f315e92534ae22d54db000a523077192531
+PKG_MIRROR_HASH:=4c49491037d3250f740a9420bff6f09ab0cd0f5ccead6bdf0fba33de03f1c7a2
 
 PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
 PKG_LICENSE:=GPL-2.0-only
@@ -20,7 +20,7 @@ define Package/poemgr
   SECTION:=utils
   CATEGORY:=Utilities
   DEPENDS:=+libuci +libjson-c
-  TITLE:=Utility to control PoE ports on the UniFi Flex switch
+  TITLE:=Utility to control PoE ports on UniFi Flex and Plasma Cloud switches
 endef
 
 define Package/poemgr/conffiles


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @blocktrron

**Description:**

* Minor memory leak fix from https://github.com/blocktrron/poemgr/pull/15
* PSX8 + PSX10 + PSX28 support from: https://github.com/blocktrron/poemgr/pull/16

They are now integrated in OpenWrt package. New changes are:

* https://github.com/blocktrron/poemgr/pull/16/commits/17771dd poemgr: Add support for Plasma Cloud PSX28
* https://github.com/blocktrron/poemgr/pull/16/commits/530433d poemgr: Add support for RTL8239 PSE solution
* https://github.com/blocktrron/poemgr/pull/16/commits/8821bad poemgr: Add support for Plasma Cloud PSX8/PSX10
* https://github.com/blocktrron/poemgr/pull/16/commits/ab466a7 poemgr: Add support for IP8008 PSE chip
* https://github.com/blocktrron/poemgr/pull/16/commits/7863fa8 poemgr: Add support to display POE output type
* https://github.com/blocktrron/poemgr/pull/16/commits/d81ac54 poemgr: Add support to export port specific device specific metrics
* https://github.com/blocktrron/poemgr/pull/15/commits/5033450 pd69104: Avoid resource leaks (memory, fds) on init failure

---

## 🧪 Run Testing Details

- **OpenWrt Version:** r31173-2838e015d9
- **OpenWrt Target/Subtarget:** realtek/rtl930x + realtek/rtl931x 
- **OpenWrt Device:** Plasma Cloud PSX28/PSX8/PSX10+$secret_one (extra patches on top of this one)

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.