### PR TITLE
boost: fix PKG_SOURCE_URL

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -16,7 +16,7 @@ PKG_SOURCE_VERSION:=1_89_0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
-PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://boostorg.jfrog.io/artifactory/main/release/$(PKG_VERSION)/source/
+PKG_SOURCE_URL:=https://archives.boost.io/release/$(PKG_VERSION)/source @SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION)
 PKG_HASH:=85a33fa22621b4f314f8e85e1a5e2a9363d22e4f4992925d4bb3bc631b5a0c7a
 
 PKG_MAINTAINER:=Carlos M. Ferreira <carlosmf.pt@gmail.com>


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @ClaymorePT

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
boostorg.jfrog.io is no longer available for download, so remove it.
use archives.boost.io (fastly cdn) to download first.

---

## 🧪 Run Testing Details

- OpenWrt Version: r31015-20d761cf19
- OpenWrt Target/Subtarget: x86/64
- OpenWrt Device: N100 based router

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.