### PR TITLE
owntone: update to 29.0

### DIFF
--- a/sound/owntone/Makefile
+++ b/sound/owntone/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=owntone
-PKG_VERSION:=28.11
+PKG_VERSION:=29.0
 PKG_RELEASE:=1
 
 # Release
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/owntone/owntone-server/releases/download/$(PKG_VERSION)/
-PKG_HASH:=98538566a993638ec569fc44ea2c7a7fcb5dd925c47b84b64ac2d63fc8b056b8
+PKG_HASH:=b9cbb9521aed06253b05902a8393a12cd0214d29a7f174855af9ff15a3742b0d
 
 PKG_FIXUP:=autoreconf
 PKG_BUILD_FLAGS:=no-mips16
@@ -35,7 +35,8 @@ URL:=https://github.com/owntone/owntone-server
 DEPENDS:=+libgpg-error +libgcrypt +libgdbm +zlib +libexpat +libunistring \
 	+libevent2 +libevent2-pthreads +libdaemon +confuse +alsa-lib +libffmpeg-full \
 	+libxml2 +libavahi-client +sqlite3-cli +libplist +libcurl +libjson-c \
-	+libprotobuf-c +libgnutls +libsodium +libwebsockets +libuuid $(ICONV_DEPENDS)
+	+libprotobuf-c +libgnutls +libsodium +libwebsockets +libuuid +libmount \
+	$(ICONV_DEPENDS)
 endef
 
 define Package/owntone/description


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**
me

**Description:**
Update to version 29.0, see changes here: https://github.com/owntone/owntone-server/releases/tag/29.0

---

## 🧪 Run Testing Details

- **OpenWrt Version:** trunk
- **OpenWrt Target/Subtarget:** x86
- **OpenWrt Device:** vm

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
