### PR TITLE
syslog-ng: add ivykis dependency to fix building with enabled KERNEL_IO_URING

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=4.10.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later
@@ -34,7 +34,7 @@ define Package/syslog-ng
   CATEGORY:=Administration
   TITLE:=A powerful syslog daemon
   URL:=https://www.syslog-ng.com/products/open-source-log-management/
-  DEPENDS:=+libpcre2 +glib2 +libopenssl +libpthread +librt +libdbi +libjson-c +libcurl +libuuid +SYSLOGNG_LOGROTATE:logrotate +LIBCURL_ZLIB:zlib
+  DEPENDS:=+libpcre2 +glib2 +libopenssl +libpthread +librt +libdbi +libjson-c +libcurl +libuuid +ivykis +SYSLOGNG_LOGROTATE:logrotate +LIBCURL_ZLIB:zlib
   ALTERNATIVES:=300:/sbin/logread:/usr/libexec/logread.sh
 endef
 
@@ -91,6 +91,7 @@ CONFIGURE_ARGS +=  \
 	--disable-sql \
 	--disable-linux-caps \
 	--with-jsonc=system \
+	--with-ivykis=system \
 	--enable-cpp=no \
 	--disable-example-modules \
 	--enable-json=yes \


### PR DESCRIPTION
Maintainer: me
Compile and run tested: NO
Currently don't have aarch64 env.

On OpenWrt buildbots, I noticed that syslog-ng fails for aarch64 and x86_64, because these two targets has enabled KERNEL_IO_URING [1] and syslog-ng detects it, wants to use it and thus it fails on buildbots: 
```
In file included from iv_private.h:35,
                 from iv_event.c:27:
iv_private_posix.h:110:49: error: field 'ring' has incomplete type
  110 |                         struct io_uring         ring;
      |                                                 ^~~~
iv_private_posix.h:113:57: error: field 'ts' has incomplete type
  113 |                         struct __kernel_timespec        ts;
      |                                                         ^~
make[9]: *** [Makefile:575: iv_event.lo] Error 1
```

[1] https://github.com/openwrt/openwrt/blob/0147d213ffaf52a444bf0dd0c2ccd9b929ef448c/config/Config-kernel.in#L571

____

Buildbots failure:

OpenWrt 24.10: https://downloads.openwrt.org/releases/faillogs-24.10/aarch64_cortex-a53/packages/syslog-ng/compile.txt

OpenWrt snapshot: https://downloads.openwrt.org/snapshots/faillogs/aarch64_cortex-a53/packages/syslog-ng/compile.txt
