### PR TITLE
nfs-kernel-server: fix recursive Kconfig dependencies

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -50,6 +50,7 @@ define Package/nfs-kernel-server
 	DEPENDS+= +kmod-fs-nfsd +kmod-fs-nfs +rpcbind
 	VARIANT:=v3
 	USERID:=nfs:nfs
+	CONFLICTS:=nfs-kernel-server-v4
 endef
 
 define Package/nfs-kernel-server/description
@@ -60,7 +61,6 @@ define Package/nfs-kernel-server-v4
 	$(call Package/nfs-kernel-server/Default)
 	TITLE:=Kernel NFS server (NFSv4.x)
 	DEPENDS+= +kmod-fs-nfsd +kmod-fs-nfs +rpcbind +kmod-fs-nfs-v4 +libkeyutils +libdevmapper +libevent2-core +libreadline
-	CONFLICTS:=nfs-kernel-server
 	VARIANT:=v4
 	PROVIDES:=nfs-kernel-server
 	USERID:=nfs:nfs
@@ -74,6 +74,7 @@ define Package/nfs-utils
 	$(call Package/nfs-utils/Default)
 	TITLE:=NFS mount and umount utils (NFSv3)
 	DEPENDS:=+libtirpc
+	CONFLICTS:=nfs-utils-v4
 	VARIANT:=v3
 endef
 
@@ -85,7 +86,6 @@ define Package/nfs-utils-v4
 	$(call Package/nfs-utils/Default)
 	TITLE:=NFS mount and umount utils (NFSv4.x)
 	DEPENDS:=+libtirpc +libkeyutils +libdevmapper
-	CONFLICTS:=nfs-utils
 	VARIANT:=v4
 	PROVIDES:=nfs-utils
 endef


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @graysky2 

**Description:**
Move CONFLICTS definition to the respective v4 packages to avoid creating a recursive dependency.

Fixes: ee3b06e42 ("nfs-kernel-server: provide a NFSv3 and NFSv4 daemon")
Fixes: #27555

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** -
- **OpenWrt Device:** -

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.