### PR TITLE
[24.10] openvpn: enable DCO by default

### DIFF
--- a/net/openvpn/Config-mbedtls.in
+++ b/net/openvpn/Config-mbedtls.in
@@ -35,7 +35,7 @@ config OPENVPN_mbedtls_ENABLE_IPROUTE2
 config OPENVPN_mbedtls_ENABLE_DCO
 	depends on !OPENVPN_mbedtls_ENABLE_IPROUTE2
 	bool "Enable support for data channel offload"
-	default n if OPENVPN_mbedtls_ENABLE_IPROUTE2
+	default y if !OPENVPN_mbedtls_ENABLE_IPROUTE2
 	help
 	  enable data channel offload support
 	  using the ovpn-dco-v2 kernel module

--- a/net/openvpn/Config-openssl.in
+++ b/net/openvpn/Config-openssl.in
@@ -39,7 +39,7 @@ config OPENVPN_openssl_ENABLE_IPROUTE2
 config OPENVPN_openssl_ENABLE_DCO
 	depends on !OPENVPN_openssl_ENABLE_IPROUTE2
 	bool "Enable support for data channel offload"
-	default n if OPENVPN_openssl_ENABLE_IPROUTE2
+	default y if !OPENVPN_openssl_ENABLE_IPROUTE2
 	help
 	  enable data channel offload support
 	  using the ovpn-dco-v2 kernel module

--- a/net/openvpn/Config-wolfssl.in
+++ b/net/openvpn/Config-wolfssl.in
@@ -44,7 +44,7 @@ config OPENVPN_wolfssl_ENABLE_IPROUTE2
 config OPENVPN_wolfssl_ENABLE_DCO
 	depends on !OPENVPN_wolfssl_ENABLE_IPROUTE2
 	bool "Enable support for data channel offload"
-	default n if OPENVPN_openssl_ENABLE_IPROUTE2
+	default y if !OPENVPN_wolfssl_ENABLE_IPROUTE2
 	select WOLFSSL_HAS_OPENVPN
 	help
 	  enable data channel offload support

--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -37,7 +37,7 @@ define Package/openvpn/Default
   SUBMENU:=VPN
   MENU:=1
   DEPENDS:=+kmod-tun +libcap-ng +OPENVPN_$(1)_ENABLE_LZO:liblzo +OPENVPN_$(1)_ENABLE_LZ4:liblz4 +OPENVPN_$(1)_ENABLE_IPROUTE2:ip \
-	+OPENVPN_$(1)_ENABLE_DCO:libnl-genl +OPENVPN_$(1)_ENABLE_DCO:kmod-ovpn-dco-v2 $(3)
+	+OPENVPN_$(1)_ENABLE_DCO:libnl-genl $(3)
   VARIANT:=$(1)
   PROVIDES:=openvpn openvpn-crypto
 endef

--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.6.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @AuthorReflex @neheb

**Description:**
This is a cherry-pick from https://github.com/openwrt/packages/commit/01fafd69ef276cd3ae80e9a633391d5f7a8d7dfe and https://github.com/openwrt/packages/commit/11e17a3ed625c34501568669303e3f447fe4f693 (see https://github.com/openwrt/packages/pull/25645) to enable DCO by default in the `openvpn` package.

Also cherry-picks 7c88f99 to bump the `PKG_RELEASE`.

Thanks to @sideeffect42 and @wehagy for the work on the initial commits.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** x86-64
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.