### PR TITLE
 telegraf: update to 1.36.2

### DIFF
--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telegraf
-PKG_VERSION:=1.36.1
+PKG_VERSION:=1.36.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2478f4c9543300ed44cc0a3329e5a4c6095d9a6eae86aa2deab4ff9d19c1fdd5
+PKG_HASH:=f4d0f3c430a0a8a9f8888c6e6038f8ce58111c1f3bbf222799ed965df94afdca
 
 PKG_MAINTAINER:=Niklas Thorild <niklas@thorild.se>
 PKG_LICENSE:=MIT
@@ -23,7 +23,7 @@ GO_PKG_BUILD_PKG:=github.com/influxdata/telegraf/cmd/telegraf
 GO_PKG_LDFLAGS_X := \
   github.com/influxdata/telegraf/internal.Version=$(PKG_VERSION) \
   github.com/influxdata/telegraf/internal.Branch=HEAD \
-  github.com/influxdata/telegraf/internal.Commit=cbb7f134
+  github.com/influxdata/telegraf/internal.Commit=8bdd0265
 
 ifeq ($(CONFIG_mips)$(CONFIG_mipsel),y)
   TARGET_LDFLAGS += -static

--- a/utils/telegraf/files/etc/init.d/telegraf
+++ b/utils/telegraf/files/etc/init.d/telegraf
@@ -8,7 +8,6 @@ STOP=01
 start_service() {
     procd_open_instance
     procd_set_param command /usr/bin/telegraf --config /etc/telegraf.conf
-    procd_set_param env HOME=/root
     procd_set_param stdout 1
     procd_set_param stderr 1
     procd_close_instance


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
- Update Telegraf to v1.36.2
- Remove HOME environment variable in service file since the bug that required it has been fixed upstream

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** LXC container

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
