### PR TITLE
prometheus-node-exporter-lua: check if status is nil before processing wifi device metrics interfaces

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2026.05.09
+PKG_VERSION:=2026.05.10
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi.lua
@@ -10,6 +10,10 @@ local function scrape()
   local u = ubus.connect()
   local status = u:call("network.wireless", "status", {})
 
+  if not status then
+    return
+  end
+  
   for dev, dev_table in pairs(status) do
     for _, intf in ipairs(dev_table['interfaces']) do
       local ifname = intf['ifname']

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi.lua
@@ -10,6 +10,10 @@ local function scrape()
   local u = ubus.connect()
   local status = u:call("network.wireless", "status", {})
 
+  if not status then
+    return
+  end
+
   for dev, dev_table in pairs(status) do
     for _, intf in ipairs(dev_table['interfaces']) do
       local ifname = intf['ifname']

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
@@ -23,6 +23,10 @@ local function scrape()
   local u = ubus.connect()
   local status = u:call("network.wireless", "status", {})
 
+  if not status then
+    return
+  end
+  
   for dev, dev_table in pairs(status) do
     for _, intf in ipairs(dev_table['interfaces']) do
       local ifname = intf['ifname']

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
@@ -23,6 +23,10 @@ local function scrape()
   local u = ubus.connect()
   local status = u:call("network.wireless", "status", {})
 
+  if not status then
+    return
+  end
+
   for dev, dev_table in pairs(status) do
     for _, intf in ipairs(dev_table['interfaces']) do
       local ifname = intf['ifname']


### PR DESCRIPTION


Add a check for status existence before processing.


In my OpenWRT device, it did not have a Wi-Fi device, so if I use `prometheus-node-exporter-lua`, I found below error in my syslog.
<img width="2937" height="473" alt="image" src="https://github.com/user-attachments/assets/dab05671-75e3-4101-bb51-46e5de39e31f" />


## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
