### PR TITLE
syslog-ng: update to version 4.10.1

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
-PKG_VERSION:=4.10.0
+PKG_VERSION:=4.10.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
@@ -11,7 +11,7 @@ PKG_CPE_ID:=cpe:/a:oneidentity:syslog-ng
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syslog-ng/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
-PKG_HASH:=219fbdb1685b6fa61674712f21c7b46e5e09b2533518c57689eaa827f57b1609
+PKG_HASH:=dea90cf1dc4b8674ff191e0032f9dabc24b291abfd7f110fd092ae5f21cde5d7
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1


### PR DESCRIPTION
Maintainer: me

Release notes:
https://github.com/syslog-ng/syslog-ng/releases/tag/syslog-ng-4.10.1

Compile and run tested locally: NO
I am not able to compile it on macOS anymore since https://github.com/syslog-ng/syslog-ng/issues/5499#issuecomment-3350423850

Maybe macOS gurus for OpenWrt: @httpstorm and @svlobanov will dig deeper into it more
It fails on this one:
```
/Volumes/OpenWrt/mox-hbk/build/staging_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/lib/gcc/aarch64-openwrt-linux-musl/13.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld.bfd: unrecognized -a option `ll_load'
collect2: error: ld returned 1 exit status
make[5]: *** [Makefile:14622: lib/libsyslog-ng.la] Error 1
make[4]: *** [Makefile:30527: all-recursive] Error 1
make[3]: *** [Makefile:13304: all] Error 2
make[3]: Leaving directory '/Volumes/OpenWrt/mox-hbk/build/build_dir/target-aarch64_cortex-a53_musl/syslog-ng-4.10.1'
make[2]: *** [Makefile:161: /Volumes/OpenWrt/mox-hbk/build/build_dir/target-aarch64_cortex-a53_musl/syslog-ng-4.10.1/.built] Error 2
make[2]: Leaving directory '/Volumes/OpenWrt/mox-hbk/build/feeds/packages/admin/syslog-ng'
```

However on GNU/Linux as said by @muzikr, it works. 

@muzikr Could you please test it on your case, if this update works for you?
