### PR TITLE
gzip: update to version 1.14

### DIFF
--- a/utils/gzip/Makefile
+++ b/utils/gzip/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gzip
-PKG_VERSION:=1.13
+PKG_VERSION:=1.14
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/gzip
-PKG_HASH:=7454eb6935db17c6655576c2e1b0fabefd38b4d0936e0f87f48cd062ce91a057
+PKG_HASH:=01a7b881bd220bfdf615f97b8718f80bdfd3f6add385b993dcf6efd14e8c0ac6
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_CPE_ID:=cpe:/a:gnu:gzip
 
@@ -39,6 +39,9 @@ define Package/gzip/description
 	gzip (GNU zip) is a compression utility designed to be a \
 	replacement for compress.
 endef
+
+
+TARGET_CFLAGS += -std=gnu17
 
 CONFIGURE_VARS += \
 	gl_cv_func_getopt_gnu=yes \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @bk138
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Release announcement:
https://lists.gnu.org/archive/html/info-gnu/2025-04/msg00007.html

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** powerpc8540/mpc85xx
- **OpenWrt Device:** Turris 1.1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
