### PR TITLE
base16384: update to version 2.3.2

### DIFF
--- a/utils/base16384/Makefile
+++ b/utils/base16384/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=base16384
-PKG_VERSION:=2.3.1
+PKG_VERSION:=2.3.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fumiama/base16384/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=71ee39510c8c687254315ccc1aa5de601a5e2a2554b6db843f3874c12415a77a
+PKG_HASH:=3b612e8ab32e7b108a08cdf4112a04fbebaaa572bc60d386343a954c695e450b
 
 PKG_MAINTAINER:=源 文雨 <fumiama@foxmail.com>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  @fumiama
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Release notes:
https://github.com/fumiama/base16384/releases/tag/v2.3.2

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
