### PR TITLE
tailscale: update to 1.88.3

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.88.1
+PKG_VERSION:=1.88.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=54626fe39c82a6841487131c0e2b7afce4090873d3dca7501e178a232c9313a1
+PKG_HASH:=98eaf276e86272fce2ab435e23235e31ff73a8759e556b74d31f9c905702d567
 
 PKG_MAINTAINER:=Zephyr Lykos <self@mochaa.ws>, \
 		Sandro Jäckel <sandro.jaeckel@gmail.com>


### PR DESCRIPTION
Changelog: https://tailscale.com/changelog#2025-09-25

## 📦 Package Details

**Maintainer:** me / @mochaaP

**Description:** update tailscale to 1.88.3

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.0
- **OpenWrt Target/Subtarget:** arm_cortex-a7_neon-vfpv4
- **OpenWrt Device:** AVM FRITZ!Box 7530

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
