### PR TITLE
 openwrt-23.05: tunneldigger: add broker_selection option

### DIFF
--- a/net/tunneldigger/Makefile
+++ b/net/tunneldigger/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tunneldigger
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://github.com/wlanslovenija/tunneldigger.git
 PKG_SOURCE_PROTO:=git

--- a/net/tunneldigger/files/config.default
+++ b/net/tunneldigger/files/config.default
@@ -5,4 +5,5 @@ config broker
 	option uuid 'abcd'
 	option interface 'l2tp0'
 	option limit_bw_down '1024'
+	option broker_selection 'usage'
 	option enabled '0'

--- a/net/tunneldigger/files/tunneldigger.init
+++ b/net/tunneldigger/files/tunneldigger.init
@@ -22,6 +22,7 @@ parse_broker() {
 	config_get hook_script "$section" hook_script
 	config_get bind_interface "$section" bind_interface
 	config_get group "$section" group
+	config_get broker_selection "$section" broker_selection
 	
 	[ $enabled -eq 0 ] && return
 
@@ -37,6 +38,20 @@ parse_broker() {
 		unset _bind_interface
 		network_get_device _bind_interface "${bind_interface}" || _bind_interface="${bind_interface}"
 		append broker_opts "-I ${_bind_interface}"
+	}
+	[ ! -z "${broker_selection}" ] && {
+		# Set broker selection.
+		case "${broker_selection}" in
+			usage)
+				append broker_opts "-a"
+			;;
+			first)
+				append broker_opts "-g"
+			;;
+			random)
+				append broker_opts "-r"
+			;;
+		esac
 	}
 
 	if [ -z "$uuid" ]; then


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @PolynomialDivision 

**Description:**
backport of #27448

This is confirmed to be working as a patch on a 23.05 build.

---

## 🧪 Run Testing Details

- **OpenWrt Version: 23.05 gluon v2023.2.x**
- **OpenWrt Target/Subtarget: **
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
