### PR TITLE
syslog-ng: use CMake instead of autotools

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=4.11.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later
@@ -13,9 +13,6 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syslog-ng/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 PKG_HASH:=37ea0d4588533316de122df4e1b249867b0a0575f646c7478d0cc4d747462943
 
-PKG_BUILD_PARALLEL:=1
-PKG_INSTALL:=1
-
 PKG_BUILD_DEPENDS:= \
 	HOST_OS_MACOS:fakeuname/host \
 
@@ -23,7 +20,10 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_IPV6 \
 	CONFIG_LIBCURL_ZLIB
 
+PKG_BUILD_DEPENDS:=gperf/host
+
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 include $(INCLUDE_DIR)/nls.mk
 ifeq ($(CONFIG_HOST_OS_MACOS),y)
     include ../../utils/fakeuname/fakeuname.mk
@@ -34,7 +34,7 @@ define Package/syslog-ng
   CATEGORY:=Administration
   TITLE:=A powerful syslog daemon
   URL:=https://www.syslog-ng.com/products/open-source-log-management/
-  DEPENDS:=+libpcre2 +glib2 +libopenssl +libpthread +librt +libdbi +libjson-c +libcurl +libuuid +ivykis +SYSLOGNG_LOGROTATE:logrotate +LIBCURL_ZLIB:zlib
+  DEPENDS:=+libpcre2 +glib2 +libopenssl +libdbi +libjson-c +libcurl +libuuid +SYSLOGNG_LOGROTATE:logrotate +LIBCURL_ZLIB:zlib +ivykis
   ALTERNATIVES:=300:/sbin/logread:/usr/libexec/logread.sh
 endef
 
@@ -75,56 +75,70 @@ config SYSLOGNG_LOGROTATE_ROTATE_COUNT
 	  versions are removed rather than rotated.
 endef
 
-define Build/Configure
-	$(SED) 's,-I/usr/include,,' $(PKG_BUILD_DIR)/configure
-	$(Build/Configure/Default)
-endef
-
 LOGROTATE_MAXSIZE:=$(call qstrip,$(CONFIG_SYSLOGNG_LOGROTATE_MAXSIZE))
 LOGROTATE_ROTATE:=$(call qstrip,$(CONFIG_SYSLOGNG_LOGROTATE_ROTATE_COUNT))
 
-CONFIGURE_ARGS +=  \
-	--disable-afsnmp \
-	$(call autoconf_bool,CONFIG_IPV6,ipv6) \
-	--disable-tcp-wrapper \
-	--disable-spoof-source \
-	--disable-sql \
-	--disable-linux-caps \
-	--with-jsonc=system \
-	--with-ivykis=system \
-	--enable-cpp=no \
-	--disable-example-modules \
-	--enable-json=yes \
-	$(if $(CONFIG_LIBCURL_ZLIB),--enable-http=yes,--enable-http=no) \
-	--disable-smtp \
-	--disable-mqtt \
-	--disable-redis \
-	--disable-stackdump \
-	--disable-dependency-tracking \
-	--disable-python \
-	--disable-geoip2 \
-	--disable-java \
-	--disable-java-modules \
-	--with-librabbitmq-client=no \
-	--with-mongoc=no
-
-CONFIGURE_VARS += \
-	$(if $(CONFIG_HOST_OS_MACOS),PATH=$(FAKEUNAME_PATH):$(PATH)) \
-	LIBDBI_CFLAGS="-I$(STAGING_DIR)/usr/include"
+CMAKE_OPTIONS += \
+	-DBUILD_TESTING=OFF \
+	-DENABLE_IPV6=$(if $(CONFIG_IPV6),ON,OFF) \
+	-DENABLE_TCP_WRAPPER=OFF \
+	-DENABLE_SPOOF_SOURCE=OFF \
+	-DENABLE_LINUX_CAPS=OFF \
+	-DENABLE_JSON=ON \
+	-DENABLE_CPP=OFF \
+	-DENABLE_AFSNMP=OFF \
+	-DENABLE_AFUSER=ON \
+	-DENABLE_EXAMPLE_MODULES=OFF \
+	-DENABLE_EBPF=OFF \
+	-DENABLE_HTTP=$(if $(CONFIG_LIBCURL_ZLIB),ON,OFF) \
+	-DENABLE_SMTP=OFF \
+	-DENABLE_REDIS=OFF \
+	-DENABLE_STACKDUMP=OFF \
+	-DENABLE_PYTHON=OFF \
+	-DENABLE_GEOIP2=OFF \
+	-DENABLE_JAVA=OFF \
+	-DENABLE_JAVA_MODULES=OFF \
+	-DENABLE_GRPC=OFF \
+	-DENABLE_AFAMQP=OFF \
+	-DENABLE_APPMODEL=OFF \
+	-DENABLE_AZURE_AUTH_HEADER=OFF \
+	-DENABLE_GETENT=OFF \
+	-DENABLE_HOOK_COMMANDS=OFF \
+	-DENABLE_MAP_VALUE_PAIRS=OFF \
+	-DENABLE_NATIVE=OFF \
+	-DENABLE_PACCT=OFF \
+	-DENABLE_STARDATE=OFF \
+	-DENABLE_STOMP=OFF \
+	-DENABLE_XML=OFF \
+	-DENABLE_MANPAGES=OFF \
+	-DENABLE_MANPAGES_INSTALL=OFF \
+	-DENABLE_TOOLS=ON \
+	-DENABLE_KAFKA=OFF \
+	-DENABLE_MQTT=OFF \
+	-DNEABLE_SQL=OFF \
+	-DENABLE_IO_URING=OFF \
+	-DWITH_JSONC=system \
+	-DWITH_SYSTEMD_JOURNAL=OFF \
+	-DIVYKIS_SOURCE=system
 
 define Package/syslog-ng/install
-	cd $(PKG_BUILD_DIR); make DESTDIR=$(1) install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
 
-	$(call libtool_remove_files,$(1)) # This removes .la files in folder (including subfolders) /usr/lib
-	rm -rf $(1)/usr/lib/pkgconfig \
-	$(1)/usr/lib/*.a \
-	$(1)/usr/include \
-	$(1)/var
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/* $(1)/usr/sbin/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
+	
+	$(INSTALL_DIR) $(1)/usr/lib/syslog-ng
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/syslog-ng/* $(1)/usr/lib/syslog-ng/
 
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/syslog-ng.init $(1)/etc/init.d/syslog-ng
+
 	$(INSTALL_DIR) $(1)/etc/syslog-ng.d
-	$(INSTALL_DATA) ./files/syslog-ng.conf $(1)/etc
+	$(INSTALL_CONF) ./files/syslog-ng.conf $(1)/etc
 	touch $(1)/etc/syslog-ng.d/.keep
 
 	$(INSTALL_DIR) $(1)/usr/libexec

--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=4.12.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later
@@ -95,20 +95,21 @@ CMAKE_OPTIONS += \
 	-DENABLE_JAVA_MODULES=OFF \
 	-DENABLE_GRPC=OFF \
 	-DENABLE_AFAMQP=OFF \
-	-DENABLE_APPMODEL=OFF \
-	-DENABLE_AZURE_AUTH_HEADER=OFF \
-	-DENABLE_GETENT=OFF \
-	-DENABLE_HOOK_COMMANDS=OFF \
-	-DENABLE_MAP_VALUE_PAIRS=OFF \
+	-DENABLE_APPMODEL=ON \
+	-DENABLE_AZURE_AUTH_HEADER=ON \
+	-DENABLE_GETENT=ON \
+	-DENABLE_HOOK_COMMANDS=ON \
+	-DENABLE_MAP_VALUE_PAIRS=ON \
 	-DENABLE_NATIVE=OFF \
 	-DENABLE_PACCT=OFF \
-	-DENABLE_STARDATE=OFF \
-	-DENABLE_STOMP=OFF \
-	-DENABLE_XML=OFF \
+	-DENABLE_STARDATE=ON \
+	-DENABLE_STOMP=ON \
+	-DENABLE_XML=ON \
 	-DENABLE_MANPAGES=OFF \
 	-DENABLE_MANPAGES_INSTALL=OFF \
 	-DENABLE_KAFKA=OFF \
 	-DENABLE_MQTT=OFF \
+	-DENABLE_MONGODB=OFF \
 	-DENABLE_SQL=OFF \
 	-DJSONC_SOURCE=system \
 	-DWITH_SYSTEMD_JOURNAL=OFF \
@@ -134,6 +135,9 @@ define Package/syslog-ng/install
 	$(INSTALL_DIR) $(1)/etc/syslog-ng.d
 	$(INSTALL_CONF) ./files/syslog-ng.conf $(1)/etc/syslog-ng.conf
 	touch $(1)/etc/syslog-ng.d/.keep
+
+	# upstream creates it under /usr/etc, which is pruned above
+	$(INSTALL_DIR) $(1)/etc/patterndb.d
 
 	$(INSTALL_DIR) $(1)/usr/libexec
 	$(INSTALL_BIN) ./files/logread.sh $(1)/usr/libexec/logread.sh

--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -13,28 +13,22 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syslog-ng/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 PKG_HASH:=03a03d19ac203dca53c7ec79a7005c8a850665a95ff4cd0f1e7bb4c497c64d46
 
-PKG_BUILD_PARALLEL:=1
-PKG_INSTALL:=1
-
-PKG_BUILD_DEPENDS:= \
-	HOST_OS_MACOS:fakeuname/host \
+PKG_BUILD_DEPENDS:=gperf/host
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_IPV6 \
 	CONFIG_LIBCURL_ZLIB
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 include $(INCLUDE_DIR)/nls.mk
-ifeq ($(CONFIG_HOST_OS_MACOS),y)
-    include ../../utils/fakeuname/fakeuname.mk
-endif
 
 define Package/syslog-ng
   SECTION:=admin
   CATEGORY:=Administration
   TITLE:=A powerful syslog daemon
   URL:=https://www.syslog-ng.com/products/open-source-log-management/
-  DEPENDS:=+libpcre2 +glib2 +libopenssl +libpthread +librt +libdbi +libjson-c +libcurl +libuuid +ivykis +SYSLOGNG_LOGROTATE:logrotate +LIBCURL_ZLIB:zlib
+  DEPENDS:=+libpcre2 +glib2 +libopenssl +libdbi +libjson-c +libcurl +libuuid +SYSLOGNG_LOGROTATE:logrotate +LIBCURL_ZLIB:zlib +ivykis
   ALTERNATIVES:=300:/sbin/logread:/usr/libexec/logread.sh
 endef
 
@@ -47,7 +41,6 @@ endef
 define Package/syslog-ng/conffiles
 /etc/syslog-ng.conf
 /etc/syslog-ng.d/
-/etc/scl.conf
 endef
 
 define Package/syslog-ng/config
@@ -75,55 +68,66 @@ config SYSLOGNG_LOGROTATE_ROTATE_COUNT
 	  versions are removed rather than rotated.
 endef
 
-define Build/Configure
-	$(SED) 's,-I/usr/include,,' $(PKG_BUILD_DIR)/configure
-	$(Build/Configure/Default)
-endef
-
 LOGROTATE_MAXSIZE:=$(call qstrip,$(CONFIG_SYSLOGNG_LOGROTATE_MAXSIZE))
 LOGROTATE_ROTATE:=$(call qstrip,$(CONFIG_SYSLOGNG_LOGROTATE_ROTATE_COUNT))
 
-CONFIGURE_ARGS +=  \
-	--disable-afsnmp \
-	$(call autoconf_bool,CONFIG_IPV6,ipv6) \
-	--disable-tcp-wrapper \
-	--disable-spoof-source \
-	--disable-sql \
-	--disable-linux-caps \
-	--with-jsonc=system \
-	--with-ivykis=system \
-	--enable-cpp=no \
-	--disable-example-modules \
-	--enable-json=yes \
-	$(if $(CONFIG_LIBCURL_ZLIB),--enable-http=yes,--enable-http=no) \
-	--disable-smtp \
-	--disable-mqtt \
-	--disable-redis \
-	--disable-stackdump \
-	--disable-dependency-tracking \
-	--disable-python \
-	--disable-geoip2 \
-	--disable-java \
-	--disable-java-modules \
-	--with-librabbitmq-client=no \
-	--with-mongoc=no
-
-CONFIGURE_VARS += \
-	$(if $(CONFIG_HOST_OS_MACOS),PATH=$(FAKEUNAME_PATH):$(PATH)) \
-	LIBDBI_CFLAGS="-I$(STAGING_DIR)/usr/include"
+CMAKE_OPTIONS += \
+	-DBUILD_TESTING=OFF \
+	-DENABLE_IPV6=$(if $(CONFIG_IPV6),ON,OFF) \
+	-DENABLE_TCP_WRAPPER=OFF \
+	-DENABLE_SPOOF_SOURCE=OFF \
+	-DENABLE_LINUX_CAPS=OFF \
+	-DENABLE_JSON=ON \
+	-DENABLE_CPP=OFF \
+	-DENABLE_AFSNMP=OFF \
+	-DENABLE_AFUSER=ON \
+	-DENABLE_EXAMPLE_MODULES=OFF \
+	-DENABLE_EBPF=OFF \
+	-DENABLE_HTTP=$(if $(CONFIG_LIBCURL_ZLIB),ON,OFF) \
+	-DENABLE_SMTP=OFF \
+	-DENABLE_REDIS=OFF \
+	-DENABLE_STACKDUMP=OFF \
+	-DENABLE_PYTHON=OFF \
+	-DENABLE_GEOIP2=OFF \
+	-DENABLE_JAVA=OFF \
+	-DENABLE_JAVA_MODULES=OFF \
+	-DENABLE_GRPC=OFF \
+	-DENABLE_AFAMQP=OFF \
+	-DENABLE_APPMODEL=OFF \
+	-DENABLE_AZURE_AUTH_HEADER=OFF \
+	-DENABLE_GETENT=OFF \
+	-DENABLE_HOOK_COMMANDS=OFF \
+	-DENABLE_MAP_VALUE_PAIRS=OFF \
+	-DENABLE_NATIVE=OFF \
+	-DENABLE_PACCT=OFF \
+	-DENABLE_STARDATE=OFF \
+	-DENABLE_STOMP=OFF \
+	-DENABLE_XML=OFF \
+	-DENABLE_MANPAGES=OFF \
+	-DENABLE_MANPAGES_INSTALL=OFF \
+	-DENABLE_KAFKA=OFF \
+	-DENABLE_MQTT=OFF \
+	-DENABLE_SQL=OFF \
+	-DJSONC_SOURCE=system \
+	-DWITH_SYSTEMD_JOURNAL=OFF \
+	-DIVYKIS_SOURCE=system
 
 define Package/syslog-ng/install
-	cd $(PKG_BUILD_DIR); make DESTDIR=$(1) install
+	$(INSTALL_DIR) $(1)
+	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
 
-	$(call libtool_remove_files,$(1)) # This removes .la files in folder (including subfolders) /usr/lib
+	$(call libtool_remove_files,$(1))
 	rm -rf $(1)/usr/lib/pkgconfig \
-	$(1)/usr/lib/*.a \
-	$(1)/usr/include \
-	$(1)/usr/bin/syslog-ng-update-virtualenv \
-	$(1)/var
+		$(1)/usr/lib/*.a \
+		$(1)/usr/lib/syslog-ng/loggen/*.a \
+		$(1)/usr/include \
+		$(1)/usr/bin/syslog-ng-update-virtualenv \
+		$(1)/usr/var \
+		$(1)/var
 
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/syslog-ng.init $(1)/etc/init.d/syslog-ng
+
 	$(INSTALL_DIR) $(1)/etc/syslog-ng.d
 	$(INSTALL_CONF) ./files/syslog-ng.conf $(1)/etc/syslog-ng.conf
 	touch $(1)/etc/syslog-ng.d/.keep

--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -73,6 +73,8 @@ LOGROTATE_ROTATE:=$(call qstrip,$(CONFIG_SYSLOGNG_LOGROTATE_ROTATE_COUNT))
 
 CMAKE_OPTIONS += \
 	-DBUILD_TESTING=OFF \
+	-DSYSLOG_NG_PATH_SYSCONFDIR=/etc \
+	-DSYSLOG_NG_PATH_LOCALSTATEDIR=/var \
 	-DENABLE_IPV6=$(if $(CONFIG_IPV6),ON,OFF) \
 	-DENABLE_TCP_WRAPPER=OFF \
 	-DENABLE_SPOOF_SOURCE=OFF \
@@ -122,6 +124,7 @@ define Package/syslog-ng/install
 		$(1)/usr/lib/syslog-ng/loggen/*.a \
 		$(1)/usr/include \
 		$(1)/usr/bin/syslog-ng-update-virtualenv \
+		$(1)/usr/etc \
 		$(1)/usr/var \
 		$(1)/var
 

--- a/admin/syslog-ng/patches/100-cmake-ship-jemalloc-modules.patch
+++ b/admin/syslog-ng/patches/100-cmake-ship-jemalloc-modules.patch
@@ -1,0 +1,174 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Mon, 18 Aug 2026 09:00:00 +0200
+Subject: [PATCH] cmake: ship the jemalloc modules missing from the tarball
+
+CMakeLists.txt includes enable_jemalloc, but neither cmake/enable_jemalloc.cmake
+nor cmake/find_jemalloc.cmake is part of the 4.12.0 release tarball, so any CMake
+build of it stops at
+
+  CMake Error at CMakeLists.txt:105 (include):
+    include could not find requested file:
+      enable_jemalloc
+
+Both files are present in the syslog-ng-4.12.0 git tag; they are only missing
+from the generated dist. Add them verbatim from there.
+
+Upstream-Status: Inappropriate [4.12.0 tarball only, upstream fixed the tarball generation in https://github.com/syslog-ng/syslog-ng/commit/491f29dd71f75b3fc017334c284a2f146623754e]
+---
+--- /dev/null
++++ b/cmake/enable_jemalloc.cmake
+@@ -0,0 +1,53 @@
++# ############################################################################
++# Copyright (c) 2025 Istvan Hoffmann <hofione@gmail.com>
++#
++# This library is free software; you can redistribute it and/or
++# modify it under the terms of the GNU Lesser General Public
++# License as published by the Free Software Foundation; either
++# version 2.1 of the License, or (at your option) any later version.
++#
++# This library is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++# Lesser General Public License for more details.
++#
++# You should have received a copy of the GNU Lesser General Public
++# License along with this library; if not, write to the Free Software
++# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
++#
++# As an additional exemption you are allowed to compile & link against the
++# OpenSSL libraries as published by the OpenSSL project. See the file
++# COPYING for details.
++#
++# ############################################################################
++
++set(ENABLE_JEMALLOC "OFF" CACHE STRING "Enable jemalloc memory allocator support: ON, OFF, AUTO")
++set_property(CACHE ENABLE_JEMALLOC PROPERTY STRINGS AUTO ON OFF)
++message(STATUS "Checking jemalloc support")
++
++if(ENABLE_JEMALLOC STREQUAL "OFF")
++  set(SYSLOG_NG_ENABLE_JEMALLOC OFF)
++  message(STATUS "  jemalloc support: disabled (forced OFF)")
++  return()
++endif()
++
++include(find_jemalloc)
++
++if("${ENABLE_JEMALLOC}" MATCHES "^(auto|AUTO)$")
++  if(JEMALLOC_FOUND)
++    set(SYSLOG_NG_ENABLE_JEMALLOC ON)
++    message(STATUS "  jemalloc support: enabled (AUTO, found libjemalloc)")
++  else()
++    set(SYSLOG_NG_ENABLE_JEMALLOC OFF)
++    message(STATUS "  jemalloc support: disabled (AUTO, libjemalloc not found)")
++  endif()
++elseif(ENABLE_JEMALLOC STREQUAL "ON")
++  if(NOT JEMALLOC_FOUND)
++    message(FATAL_ERROR "Could not find libjemalloc, and jemalloc support was explicitly enabled.")
++  endif()
++
++  set(SYSLOG_NG_ENABLE_JEMALLOC ON)
++  message(STATUS "  jemalloc support: enabled (forced ON)")
++else()
++  message(FATAL_ERROR "Invalid value (${ENABLE_JEMALLOC}) for ENABLE_JEMALLOC (must be ON, OFF, or AUTO)")
++endif()
+--- /dev/null
++++ b/cmake/find_jemalloc.cmake
+@@ -0,0 +1,97 @@
++# ############################################################################
++# Copyright (c) 2025 Istvan Hoffmann <hofione@gmail.com>
++#
++# This library is free software; you can redistribute it and/or
++# modify it under the terms of the GNU Lesser General Public
++# License as published by the Free Software Foundation; either
++# version 2.1 of the License, or (at your option) any later version.
++#
++# This library is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++# Lesser General Public License for more details.
++#
++# You should have received a copy of the GNU Lesser General Public
++# License along with this library; if not, write to the Free Software
++# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
++#
++# As an additional exemption you are allowed to compile & link against the
++# OpenSSL libraries as published by the OpenSSL project. See the file
++# COPYING for details.
++#
++# ############################################################################
++
++# Find jemalloc library
++#
++# On FreeBSD, jemalloc is built into libc, so no separate library is needed.
++# On Linux, jemalloc is a separate library.
++#
++# Sets the following variables:
++# JEMALLOC_FOUND        - True if jemalloc found
++# JEMALLOC_INCLUDE_DIRS - where to find jemalloc headers
++# JEMALLOC_LIBRARIES    - List of libraries when using jemalloc (empty on FreeBSD)
++
++include(FindPackageHandleStandardArgs)
++include(CheckIncludeFile)
++
++message(STATUS "  Searching for jemalloc...")
++message(STATUS "    CMAKE_SYSTEM_NAME = ${CMAKE_SYSTEM_NAME}")
++
++# Check if we're on FreeBSD where jemalloc is built into libc
++if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
++  message(STATUS "    Detected FreeBSD - checking for built-in jemalloc")
++
++  # On FreeBSD, jemalloc functions are in stdlib.h and malloc_np.h
++  check_include_file(malloc_np.h HAVE_MALLOC_NP_H)
++
++  if(HAVE_MALLOC_NP_H)
++    set(JEMALLOC_FOUND TRUE)
++    set(JEMALLOC_INCLUDE_DIR "")
++    set(JEMALLOC_INCLUDE_DIRS "")
++    set(JEMALLOC_LIBRARY "")
++    set(JEMALLOC_LIBRARIES "")
++    message(STATUS "    FreeBSD built-in jemalloc found (part of libc)")
++  else()
++    set(JEMALLOC_FOUND FALSE)
++    message(STATUS "    FreeBSD built-in jemalloc not found")
++  endif()
++
++else() # On other systems, look for jemalloc as a separate library
++  # Look for the header file
++  find_path(JEMALLOC_INCLUDE_DIR
++    NAMES jemalloc/jemalloc.h
++    HINTS
++    ENV JEMALLOC_ROOT
++    ${JEMALLOC_ROOT}
++  )
++  mark_as_advanced(JEMALLOC_INCLUDE_DIR)
++
++  message(STATUS "    JEMALLOC_INCLUDE_DIR: ${JEMALLOC_INCLUDE_DIR}")
++
++  # Look for the library
++  find_library(JEMALLOC_LIBRARY
++    NAMES jemalloc
++    HINTS
++    ENV JEMALLOC_ROOT
++    ${JEMALLOC_ROOT}
++  )
++  mark_as_advanced(JEMALLOC_LIBRARY)
++
++  message(STATUS "    JEMALLOC_LIBRARY: ${JEMALLOC_LIBRARY}")
++
++  find_package_handle_standard_args(jemalloc REQUIRED_VARS JEMALLOC_LIBRARY JEMALLOC_INCLUDE_DIR)
++
++  # Copy the result to output variables
++  if(JEMALLOC_FOUND)
++    set(JEMALLOC_LIBRARIES ${JEMALLOC_LIBRARY})
++    set(JEMALLOC_INCLUDE_DIRS ${JEMALLOC_INCLUDE_DIR})
++  endif()
++endif()
++
++# Clear variables if not found
++if(NOT JEMALLOC_FOUND)
++  set(JEMALLOC_LIBRARY)
++  set(JEMALLOC_LIBRARIES)
++  set(JEMALLOC_INCLUDE_DIR)
++  set(JEMALLOC_INCLUDE_DIRS)
++endif()

--- a/admin/syslog-ng/patches/101-cmake-libcap-interface.patch
+++ b/admin/syslog-ng/patches/101-cmake-libcap-interface.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Mon, 24 Aug 2026 10:00:00 +0200
+Subject: [PATCH] cmake: only link libcap when capabilities are enabled
+
+Upstream-Status: Backport [https://github.com/syslog-ng/syslog-ng/commit/1a23b0d4fb36d5758a8ba635977b73040edf290f]
+---
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -387,13 +387,16 @@ target_link_libraries(syslog-ng
+     ${Libsystemd_LIBRARIES}
+     ${LIBUNWIND_LIBRARIES}
+     resolv
+-    libcap
+     OpenSSL::SSL
+     OpenSSL::Crypto
+     Threads::Threads
+     secret-storage
+ )
+ 
++if(SYSLOG_NG_ENABLE_LINUX_CAPS)
++  target_link_libraries(syslog-ng PUBLIC libcap)
++endif()
++
+ set_target_properties(syslog-ng
+     PROPERTIES VERSION ${SYSLOG_NG_VERSION}
+     SOVERSION ${SYSLOG_NG_VERSION})

--- a/admin/syslog-ng/patches/102-cmake-overridable-sysconfdir-localstatedir.patch
+++ b/admin/syslog-ng/patches/102-cmake-overridable-sysconfdir-localstatedir.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Sun, 7 Sep 2026 14:00:00 +0200
+Subject: [PATCH] cmake: let sysconfdir and localstatedir be set on the command line
+
+The autotools build takes --sysconfdir and --localstatedir, and
+distributions rely on them to keep the configuration in /etc and the
+runtime state in /var while the prefix stays /usr. The CMake build
+hardcodes both as ${prefix}/etc and ${prefix}/var, and because they are
+plain set() calls a -D on the command line is silently overridden.
+
+Only set the defaults when nothing was passed in, so that
+-DSYSLOG_NG_PATH_SYSCONFDIR=/etc -DSYSLOG_NG_PATH_LOCALSTATEDIR=/var
+behaves like the autotools options. Everything derived from the two,
+the default configuration file, the persist file, the pid file and the
+control socket, follows.
+
+Upstream-Status: Pending
+---
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -42,11 +42,15 @@ set(SYSLOG_NG_COMBINED_VERSION ${SYSLOG_
+ set(SYSLOG_NG_SOURCE_REVISION ${SYSLOG_NG_VERSION})
+ 
+ set(SYSLOG_NG_PATH_PREFIX ${CMAKE_INSTALL_PREFIX})
+-set(SYSLOG_NG_PATH_SYSCONFDIR "\${prefix}/etc")
++if(NOT DEFINED SYSLOG_NG_PATH_SYSCONFDIR)
++  set(SYSLOG_NG_PATH_SYSCONFDIR "\${prefix}/etc")
++endif()
+ set(SYSLOG_NG_PATH_DATADIR "\${datarootdir}")
+ set(SYSLOG_NG_PATH_PKGDATADIR "\${datarootdir}/syslog-ng")
+ set(SYSLOG_NG_PATH_PIDFILEDIR "\${localstatedir}")
+-set(SYSLOG_NG_PATH_LOCALSTATEDIR "\${prefix}/var")
++if(NOT DEFINED SYSLOG_NG_PATH_LOCALSTATEDIR)
++  set(SYSLOG_NG_PATH_LOCALSTATEDIR "\${prefix}/var")
++endif()
+ set(SYSLOG_NG_MODULE_PATH "\${exec_prefix}/lib/syslog-ng")
+ set(SYSLOG_NG_PATH_EXECPREFIX "\${prefix}")
+ set(SYSLOG_NG_PATH_CONFIG_INCLUDEDIR "\${datadir}/syslog-ng/include")


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @BKPepe

**Description:**
Switches syslog-ng from autotools to CMake, using the external `ivykis` package instead of the bundled copy.

The series is split so the parts that stand on their own can be reviewed separately:

1. **use CMake instead of autotools**: the port itself. The `fakeuname` host tool is dropped, it exists because the autotools `configure` reads the host `uname`, which reports Darwin on a macOS build host, while the CMake build never calls `uname` and keys off `CMAKE_SYSTEM_NAME`, which OpenWrt sets to `Linux`. The install recipe copies what the build produced and prunes what does not belong, the way the autotools one did. Picking directories by hand dropped all of `/usr/share`, where the SCL library and the patterndb XSD schemas live. `scl.conf` now lives under `/usr/share/syslog-ng/include`, so it is no longer a conffile.

2. **backport the CMake build fixes from upstream**: the 4.12.0 tarball cannot be built with CMake at all. `cmake/enable_jemalloc.cmake` and `cmake/find_jemalloc.cmake` are in the git tag but missing from the dist, and `lib/CMakeLists.txt` links the `libcap` target unconditionally while `enable_caps.cmake` returns before `FindLIBCAP` defines it when capabilities are disabled. Both are merged upstream, syslog-ng/syslog-ng#5752 fixed the tarball generation and syslog-ng/syslog-ng#5753 is backported as is, so the next release needs neither patch.

3. **keep the configuration in /etc and the state in /var**: the CMake build hardcodes sysconfdir as `${prefix}/etc` and localstatedir as `${prefix}/var` with plain `set()` calls, so `-D` cannot override them. The daemon read `/usr/etc/syslog-ng.conf` instead of the packaged `/etc/syslog-ng.conf`, and the persist file, pid file and control socket moved from the tmpfs `/var` to `/usr/var` on the overlay. A small patch makes the two overridable and the package passes `/etc` and `/var` the way the autotools build did.

4. **keep the module set of the autotools build**: the port had turned off eight modules the autotools build ships. `scl.conf` loads `appmodel` unconditionally and `default-network-drivers()` calls `hook-commands()`, so syslog-ng refused to parse its own default configuration. The rest would have silently dropped features.

Related upstream reports opened while working on this: syslog-ng/syslog-ng#5754 (source path in shipped binaries) and syslog-ng/syslog-ng#5755 (library names and SONAMEs differ between the two build systems).

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt master
- **OpenWrt Target/Subtarget:** mpc85xx/p2020
- **OpenWrt Device:** CZ.NIC Turris 1.1

Tested on 2026-08-18 with the revision that passed the configuration path on the command line: `syslog-ng --syntax-only` passes, the service starts and logs:

```
Aug 18 08:18:47 OpenWrt syslog-ng[8319]: syslog-ng starting up; version=4.12.0
```

Package contents were diffed against the autotools build for the same target: no module is missing, and the remaining differences are the library naming covered by syslog-ng/syslog-ng#5755.

With the current revision the generated `syslog-ng-config.h` has `SYSLOG_NG_PATH_SYSCONFDIR "/etc"` and `SYSLOG_NG_PATH_LOCALSTATEDIR "/var"`, and the package contains neither `/usr/etc` nor `/usr/var`. The service start on the device will be re-run with it.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
- [x] Sending a pull request against the correct branch: `master`

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc.
- [x] It is structured in a way that it is potentially upstreamable
