### PR TITLE
snort3: depend on libtirpc only for musl builds

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.9.5.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/snort3/snort3/tar.gz/$(PKG_VERSION)?
@@ -26,7 +26,7 @@ define Package/snort3
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre2 \
-    +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic \
+    +libpthread +libuuid +zlib +libhwloc +USE_MUSL:libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic \
     +kmod-nft-queue +liblzma +ucode +ucode-mod-fs +ucode-mod-uci \
     +PACKAGE_gperftools-runtime:gperftools-runtime \
     +PACKAGE_vectorscan-runtime:vectorscan-runtime
@@ -44,7 +44,7 @@ define Package/snort3/description
 endef
 
 CMAKE_OPTIONS += \
-	-DUSE_TIRPC:BOOL=YES \
+	-DUSE_TIRPC=$(if $(CONFIG_USE_MUSL),ON,OFF) \
 	-DENABLE_STATIC_DAQ:BOOL=NO \
 	-DDAQ_INCLUDE_DIR=$(STAGING_DIR)/usr/include/daq3 \
 	-DDAQ_LIBRARIES_DIR_HINT:PATH=$(STAGING_DIR)/usr/lib/daq3 \
@@ -76,8 +76,7 @@ else
 	-DENABLE_HYPERSCAN=OFF
 endif
 
-TARGET_CFLAGS  += -I$(STAGING_DIR)/usr/include/daq3 -I$(STAGING_DIR)/usr/include/tirpc
-TARGET_LDFLAGS += -L$(STAGING_DIR)/usr/lib/daq3 -ltirpc
+TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include/daq3
 
 define Package/snort3/conffiles
 /etc/config/snort


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

The libtirpc package is only needed when building with musl, as glibc includes the required RPC functionality. This change  makes libtirpc a conditional dependency and adjusts the build flags accordingly.

Building with x86_64-glibc:
```
...
Feature options:
    DAQ Modules:    Dynamic
    libatomic:      User-specified
    Hyperscan:      ON  
    ICONV:          ON
    Libunwind:      OFF 
    LZMA:           ON
    RPC DB:         Built-in
    SafeC:          OFF
    TCMalloc:       ON
    JEMalloc:       OFF
    UUID:           ON
    NUMA:           OFF
    LibML:          OFF
...
```
Building with aarch64_cortex-a76_musl:
```
...
Feature options:
    DAQ Modules:    Dynamic
    libatomic:      User-specified
    Hyperscan:      ON  
    ICONV:          ON
    Libunwind:      OFF 
    LZMA:           ON
    RPC DB:         TIRPC
    SafeC:          OFF
    TCMalloc:       ON
    JEMalloc:       OFF
    UUID:           ON
    NUMA:           OFF
    LibML:          OFF
...
```

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** generic PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
