### PR TITLE
phantap: bump minimum cmake version to 3.10

### DIFF
--- a/net/phantap/Makefile
+++ b/net/phantap/Makefile
@@ -11,9 +11,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/nccgroup/phantap
-PKG_MIRROR_HASH:=ab869c7617ff23af9dfd142b9788a307e1f3b13d43aae2c602ea89da5f9ce97c
-PKG_SOURCE_DATE:=2022.10.30
-PKG_SOURCE_VERSION:=815c312c1843ef02d758b10f3d24ccaad96e1782
+PKG_MIRROR_HASH:=6835a7161c8719bcfecbc3e9680ba5d7d1c44ae2e52e43b91a6153bea9c7d440
+PKG_SOURCE_DATE:=2025.10.06
+PKG_SOURCE_VERSION:=e8d10eafd2142b179dcb4eb90a172137ab60d539
 
 PKG_MAINTAINER:=Diana Dragusin <diana.dragusin@nccgroup.com>, \
     Etienne Champetier <champetier.etienne@gmail.com>


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
bump minimum cmake version to 3.10, see #27607

## 🧪 Run Testing Details

NONE

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.