### PR TITLE
xl2tpd: UCI support + add new option "hostname" to proto handler

### DIFF
--- a/net/xl2tpd/Makefile
+++ b/net/xl2tpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xl2tpd
 PKG_VERSION:=1.3.18
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -61,6 +61,7 @@ ifneq (0,0)
 endif
 
 define Package/xl2tpd/conffiles
+/etc/config/xl2tp
 /etc/xl2tpd/xl2tpd.conf
 /etc/xl2tpd/xl2tp-secrets
 /etc/ppp/options.xl2tpd
@@ -73,6 +74,10 @@ define Package/xl2tpd/install
 
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/xl2tpd.init $(1)/etc/init.d/xl2tpd
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/xl2tp.config \
+		$(1)/etc/config/xl2tp
 
 	$(INSTALL_DIR) $(1)/etc/xl2tpd
 	$(INSTALL_DATA) ./files/xl2tpd.conf $(1)/etc/xl2tpd/

--- a/net/xl2tpd/files/xl2tp.config
+++ b/net/xl2tpd/files/xl2tp.config
@@ -1,0 +1,40 @@
+config global 'globals'
+	option use_legacy_config '1'
+	option port '1701'
+#	option access_control '0'
+#	option ipsec_saref '0'
+#	option saref_refinfo '30'
+#	option listen-addr '0.0.0.0'
+#	option debug_avp '1'
+#	option debug_network '1'
+#	option debug_packet '1'
+#	option debug_state '1'
+#	option debug_tunnel '1'
+#	option max_retries '5'
+
+#config lns 'default'
+#	option exclusive '1'
+#	option ip_range '192.168.254.202-192.168.254.210'
+#	option lac '10.0.1.2'
+#	option hidden_bit '0'
+#	option local_ip '192.168.254.200'
+#	option length_bit '1'
+#	option refuse_authentication '1'
+#	option name 'VersaLink'
+#	option ppp_debug '1'
+#	option pppoptfile '/etc/ppp/options.xl2tpd'
+
+#config secret
+#	option local '*'
+#	option remote 'marko'
+#	option secret 'blah2'
+
+#config secret
+#	option local 'zeus'
+#	option remote 'marko'
+#	option secret 'blah'
+
+#config secret
+#	option local '*'
+#	option remote '*'
+#	option secret 'interop'

--- a/net/xl2tpd/files/xl2tpd.init
+++ b/net/xl2tpd/files/xl2tpd.init
@@ -7,13 +7,111 @@ USE_PROCD=1
 BIN=xl2tpd
 RUN_D="/var/run/xl2tpd"
 PID_F="/var/run/xl2tpd.pid"
+CONF_F="$RUN_D/xl2tpd.conf"
+SECRETS_F="$RUN_D/xl2tp-secrets"
+# Flag to use legacy config files rather then UCI-generated ones
+USE_LEGACY_CONFIG=0
+
+XL2TP_BOOLS='
+ipsec_saref
+access_control
+debug_avp
+debug_network
+debug_packet
+debug_state
+debug_tunnel
+exclusive
+assign_ip
+hidden_bit
+length_bit
+refuse_chap
+require_chap
+refuse_pap
+require_pap
+refuse_authentication
+require_authentication
+unix_authentication
+ppp_debug
+flow_bits
+challenge
+autodial
+redial
+'
+
+config_cb() {
+	config_type="$1"
+	config_name="$2"
+
+	# ignore empty type
+	[ -z "$config_type" ] && return 0
+
+	# ignore 'secret' sections
+	[ "$config_type" = "secret" ] && return 0
+
+	echo -e "\n[$config_type]" >> "$CONF_F"
+}
+
+option_cb() {
+	option_name="$1"
+	option_value="$2"
+
+	# ignore 'secret' sections
+	[ "$config_type" = "secret" ] && return 0
+
+	[ "$config_type" = "global" -a "$option_name" = "use_legacy_config" ] && {
+		[ "$option_value" = 1 ] && USE_LEGACY_CONFIG=1
+		return 0
+	}
+
+	for p in $XL2TP_BOOLS; do
+		[ "$p" = "$option_name" ] && {
+			if [ "$option_value" = 1 ]; then
+				option_value="yes"
+			else
+				option_value="no"
+			fi
+		}
+	done
+
+	echo "${option_name//_/ } = $option_value" >> "$CONF_F"
+}
+
+secrets_add() {
+	# set path to UCI-generated secrets file
+	SECRETS_F="$RUN_D/xl2tp-secrets"
+
+	local cfg="$1"
+	config_get local "$cfg" local
+	config_get remote "$cfg" remote
+	config_get secret "$cfg" secret
+
+	echo "$local $remote $secret" >> "$SECRETS_F"
+}
+
+reload_service() {
+	restart
+}
+
+service_triggers() {
+	procd_add_reload_trigger xl2tp
+}
 
 start_service() {
+	local
 	rm -rf "$RUN_D"
 	mkdir -p "$RUN_D"
 
+        config_load xl2tp
+        config_foreach secrets_add secret
+
+	[ "$USE_LEGACY_CONFIG" = 1 ] && {
+		# set paths to legacy config files for backward compatibility
+		CONF_F="/etc/xl2tpd/xl2tpd.conf"
+		SECRETS_F="/etc/xl2tpd/xl2tp-secrets"
+	}
+
 	procd_open_instance
-	procd_set_param command $BIN -D -l -p "$PID_F"
+	procd_set_param command $BIN -D -l -p "$PID_F" -c "$CONF_F" -s "$SECRETS_F"
 	procd_set_param respawn
 	procd_close_instance
 }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @yousong 

**Description:**
1. This adds UCI support for xl2tpd. To maintain backward compatibility, I
    have introduced the config option “use_legacy_config,” which is enabled
    by default. If you want to use the UCI config, you must disable or delete this
    option.

2. Add support to set own hostname in proto handler
    This is needed if the peer only allows certain hostnames to connect.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** lantiq/xrx200
- **OpenWrt Device:** own

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
