### PR TITLE
cjson: bump minimum cmake version to 3.10

### DIFF
--- a/libs/cjson/patches/900-cmake-4-compatibility.patch
+++ b/libs/cjson/patches/900-cmake-4-compatibility.patch
@@ -1,0 +1,9 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ set(CMAKE_LEGACY_CYGWIN_WIN32 0)
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.10)
+ 
+ project(cJSON
+     VERSION 1.7.19


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @karlp 

**Description:**
Starting cmake 4.0, anything under 3.5 produces an error, see https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-version

Use a patch instead of CMAKE_OPTIONS so we don't forget to remove this hack.

upstream issue: https://github.com/DaveGamble/cJSON/pull/935

## 🧪 Run Testing Details

NONE

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
