### PR TITLE
miniupnpd-nftables: reduce hook weight

### DIFF
--- a/net/miniupnpd/files/nftables.d/chain-post/dstnat/20-miniupnpd.nft
+++ b/net/miniupnpd/files/nftables.d/chain-post/dstnat/20-miniupnpd.nft
@@ -1,1 +1,1 @@
-jump upnp_prerouting comment "Hook into miniupnpd prerouting chain";
+ct state new jump upnp_prerouting comment "Hook into miniupnpd prerouting chain";

--- a/net/miniupnpd/files/nftables.d/chain-post/forward/20-miniupnpd.nft
+++ b/net/miniupnpd/files/nftables.d/chain-post/forward/20-miniupnpd.nft
@@ -1,1 +1,1 @@
-jump upnp_forward comment "Hook into miniupnpd forwarding chain";
+ct status dnat accept comment "Permit miniupnpd forwarding"

--- a/net/miniupnpd/files/nftables.d/chain-post/srcnat/20-miniupnpd.nft
+++ b/net/miniupnpd/files/nftables.d/chain-post/srcnat/20-miniupnpd.nft
@@ -1,1 +1,0 @@
-jump upnp_postrouting comment "Hook into miniupnpd postrouting chain";

--- a/net/miniupnpd/files/nftables.d/table-post/20-miniupnpd.nft
+++ b/net/miniupnpd/files/nftables.d/table-post/20-miniupnpd.nft
@@ -1,3 +1,2 @@
 chain upnp_forward {}
 chain upnp_prerouting {}
-chain upnp_postrouting {}


### PR DESCRIPTION
Reduce usage of resources of miniupnp ruleset
- do payload matching only once per connection state 
- trust dnat mark to forward packet
- leave dangling unreachable resources, their only function is to sink miniupnpd logging their absence on every client request.

Fixes: https://github.com/openwrt/packages/issues/29712

## 📦 Package Details

**Maintainer:** @Self-Hosting-Group 

**Description: Forwards ports, post PR using less resources to do so**
---

## 🧪 Run Testing Details

- **24 and SNAPSHOT and 25**
- **three**
- **four of them**

---

## ✅ Formalities

- [ x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ x] It can be applied using `git am`
- [ x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ x] It is structured in a way that it is potentially upstreamable
The idea is upstreamable, patched ruleset hooks bypass misteaks