### PR TITLE
snort3: refactor architecture-specific dependencies and CMake options

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.9.5.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/snort3/snort3/tar.gz/$(PKG_VERSION)?
@@ -21,23 +21,15 @@ PKG_CPE_ID:=cpe:/a:snort:snort
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-ifeq ($(filter $(ARCH),mips mips64 mipsel powerpc),)
-  EXTRA_DEPENDS += +gperftools-runtime
-endif
-ifeq ($(filter $(ARCH),x86_64),$(ARCH))
-  EXTRA_DEPENDS += +hyperscan-runtime
-  CMAKE_OPTIONS += -DHS_INCLUDE_DIRS=$(STAGING_DIR)/usr/include/hs
-endif
-
-SNORT3DEPS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre2 \
-    +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic \
-    +kmod-nft-queue +liblzma +ucode +ucode-mod-fs +ucode-mod-uci $(EXTRA_DEPENDS)
-
 define Package/snort3
   SUBMENU:=Firewall
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=$(SNORT3DEPS)
+  DEPENDS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre2 \
+    +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic \
+    +kmod-nft-queue +liblzma +ucode +ucode-mod-fs +ucode-mod-uci \
+    +PACKAGE_gperftools-runtime:gperftools-runtime \
+    +PACKAGE_hyperscan-runtime:hyperscan-runtime
   TITLE:=Lightweight Network Intrusion Detection System
   URL:=http://www.snort.org/
   MENU:=1
@@ -64,9 +56,25 @@ CMAKE_OPTIONS += \
 	-DMAKE_PDF_DOC:BOOL=NO \
 	-DMAKE_TEXT_DOC:BOOL=NO \
 	-DHAVE_LIBUNWIND=OFF \
-	-DENABLE_TCMALLOC=ON \
-	-DTCMALLOC_LIBRARIES=$(STAGING_DIR)/usr/lib/libtcmalloc.so \
 	-DHAVE_LZMA=ON
+
+ifneq ($(findstring powerpc,$(CONFIG_ARCH))$(findstring mips,$(CONFIG_ARCH)),)
+  CMAKE_OPTIONS += \
+	-DENABLE_TCMALLOC=OFF
+else
+  CMAKE_OPTIONS += \
+	-DENABLE_TCMALLOC=ON \
+	-DTCMALLOC_LIBRARIES=$(STAGING_DIR)/usr/lib/libtcmalloc.so
+endif
+
+ifneq ($(findstring x86_64,$(CONFIG_ARCH))$(findstring aarch64,$(CONFIG_ARCH)),)
+  CMAKE_OPTIONS += \
+	-DENABLE_HYPERSCAN=ON \
+	-DHS_INCLUDE_DIRS=$(STAGING_DIR)/usr/include/hs
+else
+  CMAKE_OPTIONS += \
+	-DENABLE_HYPERSCAN=OFF
+endif
 
 TARGET_CFLAGS  += -I$(STAGING_DIR)/usr/include/daq3 -I$(STAGING_DIR)/usr/include/tirpc
 TARGET_LDFLAGS += -L$(STAGING_DIR)/usr/lib/daq3 -ltirpc


### PR DESCRIPTION
Maintainer: @graysky2

1. Enabled hyperscan/vectorscan together with adding dependency only for x86_64 and aarch64.
2. Disabled tmalloc (from gperftools package) for powerpc and mips.

By doing this refactor, snort3 is going to be available for more OpenWrt devices (as it was in the past) as currently it was compiled only for x86_x64 and aarch64 by mistake.

Fixes: 257e2fc38aa694604e7be9e70e58082037133434 ("snort3: fix logic in gpertools-runtime depends")


(cherry picked from commit 126364e105fbcfde0617f58c39048c7d56c17a06)
[For OpenWrt 24.10: There is hyperscan instead of vectorscan]
Backport of https://github.com/openwrt/packages/pull/27037
