### PR TITLE
[24.10] samba: update to version 4.18.11

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.18.8
+PKG_VERSION:=4.18.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -13,7 +13,7 @@ PKG_SOURCE_URL:= \
 		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
-PKG_HASH:=4fb87bceaeb01d832a59046c197a044b7e8e8000581548b5d577a6cda03344d1
+PKG_HASH:=9e52a7fe1c62aba9a648a725fcf51996ebb4b08e7410afa7a229c1b9f50c9c54
 
 PKG_BUILD_FLAGS:=gc-sections
 


### PR DESCRIPTION
For details see upstream release notes:

https://www.samba.org/samba/history/samba-4.18.9.html
https://www.samba.org/samba/history/samba-4.18.10.html
https://www.samba.org/samba/history/samba-4.18.11.html

## 📦 Package Details

**Maintainer:** none

**Description:** Update to the last version in the branch

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** mvebu
- **OpenWrt Device:** Turris Omnia

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
