### PR TITLE
gperftools: include headers in the staging_dir

### DIFF
--- a/libs/gperftools/Makefile
+++ b/libs/gperftools/Makefile
@@ -55,6 +55,8 @@ CONFIGURE_ARGS += \
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libtcmalloc.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/include/gperftools
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/gperftools/*.h $(1)/usr/include/gperftools/
 endef
 
 define Package/gperftools-headers/install


### PR DESCRIPTION
Maintainer: @graysky2

This fixes version detection issues when other packages (like snort3) try to find the tcmalloc library using CMake's find_package(). Without the headers in the staging directory, CMake cannot read the version information from tcmalloc.h, resulting in empty version strings.

Fixes:
Found TCMalloc: /builder/staging_dir/target-x86_64_musl/usr/lib/libtcmalloc.so (found version "")