### PR TITLE
lua-cjson: bump minimum cmake version to 3.10

### DIFF
--- a/lang/lua-cjson/patches/900-cmake-4-compatibility.patch
+++ b/lang/lua-cjson/patches/900-cmake-4-compatibility.patch
@@ -1,0 +1,12 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,8 +3,8 @@
+ #       Unix: export LUA_DIR=/home/user/pkg
+ #       Windows: set LUA_DIR=c:\lua51
+ 
++cmake_minimum_required(VERSION 3.10)
+ project(lua-cjson C)
+-cmake_minimum_required(VERSION 2.6)
+ 
+ option(USE_INTERNAL_FPCONV "Use internal strtod() / g_fmt() code for performance")
+ option(MULTIPLE_THREADS "Support multi-threaded apps with internal fpconv - recommended" ON)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @srdgame 

**Description:**
Starting cmake 4.0, anything under 3.5 produces an error, see https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-version

Use a patch instead of CMAKE_OPTIONS so we don't forget to remove this hack.

Related to #27607 

## 🧪 Run Testing Details

NONE

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
