### PR TITLE
adblock-fast: bugfixes

### DIFF
--- a/net/adblock-fast/Makefile
+++ b/net/adblock-fast/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.2.0
-PKG_RELEASE:=20
+PKG_RELEASE:=22
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=AGPL-3.0-or-later
 

--- a/net/adblock-fast/files/etc/init.d/adblock-fast
+++ b/net/adblock-fast/files/etc/init.d/adblock-fast
@@ -8,8 +8,6 @@ START=20
 USE_PROCD=1
 LC_ALL=C
 
-[ -n "${IPKG_INSTROOT}" ] && return 0
-
 if type extra_command 1>/dev/null 2>&1; then
 	extra_command 'allow' 'Allows domain in current block-list and config'
 	extra_command 'check' 'Checks if specified domain is found in current block-list'
@@ -1839,6 +1837,7 @@ adb_config_update() {
 	load_dl_command
 	label="${config_update_url##*//}"
 	label="${label%%/*}";
+	[ -n "$enabled" ] || return 0
 	[ -n "$config_update_enabled" ] || return 0
 
 	if [ "$param" != 'download' ]; then


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge 620, OpenWrt 24.10.3
Run tested: x86_64, Dell EMC Edge 620, OpenWrt 24.10.3

Description:
* bugfix: remove IPKG_INSTROOT check
* bugfix: do not attempt to download config update if package is disabled

