### PR TITLE
[24.10] https-dns-proxy: bugfix: remove IPKG_INSTROOT check

### DIFF
--- a/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
+++ b/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
@@ -9,8 +9,6 @@ STOP=15
 # shellcheck disable=SC2034
 USE_PROCD=1
 
-[ -n "${IPKG_INSTROOT}" ] && exit 0
-
 if type extra_command 1>/dev/null 2>&1; then
 	extra_command 'version' 'Show version information'
 else


### PR DESCRIPTION
(cherry picked from commit 8301996f679075660faa30e5ae1ef46fd67220cd)
