### PR TITLE
lrzsz: fix compilation with gcc15

### DIFF
--- a/utils/lrzsz/Makefile
+++ b/utils/lrzsz/Makefile
@@ -41,6 +41,8 @@ define Package/lrzsz/description
   from a variety of programs running under various operating systems.
 endef
 
+TARGET_CFLAGS += -std=gnu11
+
 define Package/lrzsz/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/lrz $(1)/usr/bin/


### PR DESCRIPTION
Add gnu11 to fix compilation. Support for the latest standard takes too much patching.

## 📦 Package Details

**Maintainer:** @kuoruan 