### PR TITLE
fish: update to 4.1.2

### DIFF
--- a/utils/fish/Makefile
+++ b/utils/fish/Makefile
@@ -5,14 +5,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fish
-PKG_VERSION:=4.0.2
+PKG_VERSION:=4.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/fish-shell/fish-shell/releases/download/$(PKG_VERSION)
-PKG_HASH:=6e1ecdb164285fc057b2f35acbdc20815c1623099e7bb47bbfc011120adf7e83
+PKG_HASH:=52873934fc1ee21a1496e9f4521409013e540f77cbf29142a1b17ab93ffaafac
 
-PKG_MAINTAINER:=Curtis Jiang <jqqqqqqqqqq@gmail.com>, Hao Dong <halbertdong@gmail.com>
+PKG_MAINTAINER:=Curtis Jiang <jqqqqqqqqqq@gmail.com>
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:fishshell:fish


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jqqqqqqqqqq
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Update fish shell to version 4.1.2. This release fixes several regressions in 4.1.0, including spurious error output when completing remote file paths for scp, multiline prompt redraw issues, Midnight Commander compatibility issues, and Zellij escape key processing.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 23.05.0
- **OpenWrt Target/Subtarget:** armsr/armv8
- **OpenWrt Device:** qemu

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>