### PR TITLE
nebula: bump version to 1.9.7

### DIFF
--- a/net/nebula/Makefile
+++ b/net/nebula/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nebula
-PKG_VERSION:=1.9.6
+PKG_VERSION:=1.9.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/slackhq/nebula/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=cb0246ee02e03d84237f0a8e0daf6236ea65d299c275bcd4f2d324a66d1d738b
+PKG_HASH:=b8ca239c6c728deadbb28927c5332e4abf0466121d76616827adbaabbba32d05
 
 PKG_MAINTAINER:=Yuxi Yang <i@bgme.me>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @yingziwu (me)

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

bump version to 1.9.7
changelog: https://github.com/slackhq/nebula/releases/tag/v1.9.7


## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:**  x86/64
- **OpenWrt Device:** QEMU

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
