### PR TITLE
fluent-bit: update to 4.1.1

### DIFF
--- a/admin/fluent-bit/Makefile
+++ b/admin/fluent-bit/Makefile
@@ -1,13 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fluent-bit
-PKG_VERSION:=4.1.0
+PKG_VERSION:=4.1.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/fluent/fluent-bit.git
 PKG_SOURCE_VERSION=v$(PKG_VERSION)
-PKG_MIRROR_HASH:=37c8e452cb2b492eb364bad350ebe2675e413e1bf83e8ca3e4607ade1084fb71
+PKG_MIRROR_HASH:=b9616878a8af6aa3942b988ac39491a32ac1ca73c1c4d2ce6ff3960516836544
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -20,7 +20,8 @@ define Package/fluent-bit
   CATEGORY:=Administration
   TITLE:=Fast and Lightweight Logs and Metrics processor
   URL:=https://fluentbit.io/
-  DEPENDS:= +libyaml +libopenssl +libcurl +libstdcpp +libatomic +musl-fts +flex +bison
+  DEPENDS:= +libyaml +libopenssl +libcurl +libstdcpp +libatomic +musl-fts +flex +bison \
+	    +libsasl2
 endef
 
 define Package/fluent-bit/description


### PR DESCRIPTION
- Add newly libsasl2 dependency

Build system: aarch64
Build-tested: mediatek/filogic
Run-tested: mediatek/filogic

## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version: OpenWrt 24.10.2 r28739-d9340319c6 / LuCI openwrt-24.10 branch 25.168.50434~d6b13f6**
- **OpenWrt Target/Subtarget: mediatek/filogic**
- **OpenWrt Device: Xiaomi Redmi Router AX6000 (OpenWrt U-Boot layout)**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
