### PR TITLE
ksmbd-tools: update to 3.5.5

### DIFF
--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
-PKG_VERSION:=3.5.4
+PKG_VERSION:=3.5.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/cifsd-team/ksmbd-tools/releases/download/$(PKG_VERSION)
-PKG_HASH:=948a367c76d68614e7dc291b536d383654c66bb44739b217dfdbc29496a53af9
+PKG_HASH:=72310cf88723d44cb8144a4fa6aa2c60acf84bdc8bb6384547d6a48bc015af9a
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING

--- a/net/ksmbd-tools/files/ksmbd.conf.template
+++ b/net/ksmbd-tools/files/ksmbd.conf.template
@@ -7,3 +7,4 @@
 	ipc timeout = 20
 	deadtime = 15
 	map to guest = Bad User
+	server signing = auto


### PR DESCRIPTION
**Description:**
 - set server signing to auto by default.

In recent versions of Windows 11, server signing is required. However, server signing is disabled by default in ksmbd server. So It is recommended to set server signing = auto as default, so that it is used whenever it is required.

**Maintainer:** nobody

## 🧪 Run Testing Details

- **OpenWrt Version: snapshot**
- **OpenWrt Target/Subtarget: mediatek/filogic**
- **OpenWrt Device: mt6000**
