### PR TITLE
openconnect: introduce useragent parameter

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=9.12
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.infradead.org/openconnect/download

--- a/net/openconnect/README
+++ b/net/openconnect/README
@@ -14,6 +14,8 @@ config interface 'MYVPN'
 	option authgroup 'DEFAULT'
 	# usergroup option, if required by some servers
 	# option usergroup 'USERGROUP'
+	# useragent option used connecting to the server
+	# option useragent 'AnyConnect'
 
 	# Reconnect after a temporary network down time (in seconds)
 	#option reconnect_timeout '30'

--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -38,6 +38,7 @@ proto_openconnect_init_config() {
 	proto_config_add_string "proxy"
 	proto_config_add_array 'form_entry:regex("[^:]+:[^=]+=.*")'
 	proto_config_add_string "script"
+	proto_config_add_string "useragent"
 	no_device=1
 	available=1
 }
@@ -75,6 +76,7 @@ proto_openconnect_setup() {
 		usergroup \
 		username \
 		script \
+		useragent \
 
 	ifname="vpn-$config"
 
@@ -159,6 +161,7 @@ proto_openconnect_setup() {
 	[ -n "$csd_wrapper" ] && [ -x "$csd_wrapper" ] && append_args "--csd-wrapper=$csd_wrapper"
 	[ -n "$proxy" ] && append_args "--proxy=$proxy"
 	[ -n "$reconnect_timeout" ] && append_args "--reconnect-timeout=$reconnect_timeout"
+	[ -n "$useragent" ] && append_args "--useragent=$useragent"
 
 	json_for_each_item proto_openconnect_add_form_entry form_entry
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @immens 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Allows setting a custom user agent as required by some VPN servers.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
