### PR TITLE
znc: fix config path for external config

### DIFF
--- a/net/znc/Makefile
+++ b/net/znc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=znc
 PKG_VERSION:=1.10.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://znc.in/releases \

--- a/net/znc/files/znc.init
+++ b/net/znc/files/znc.init
@@ -205,7 +205,6 @@ start_service() {
 
 	procd_open_instance
 	procd_set_param file /etc/config/znc
-	[ "$EXTERNAL_CONFIG" -eq 1 ] && procd_set_param file "${ZNC_CONFIG}/configs/znc.conf"
 	procd_set_param command /usr/bin/znc
 	procd_append_param command -f -d$ZNC_CONFIG_PATH
 	procd_set_param user ${RUNAS_USER}


### PR DESCRIPTION
With EXTERNAL_CONFIG=1 the wrong path to the external config is being
passed. It uses /tmp/etc/znc/configs/znc.conf/configs/znc.conf which
does not exist, causing znc to fail to startup.

Fix this by using the user-specified path via ZNC_CONFIG_DIR.

Signed-off-by: Ralph Siemsen <ralph.siemsen@linaro.org>

## 📦 Package Details

**Maintainer:** @KanjiMonster
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 21.02 (old, sorry I know...) but mainline has same bug
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
