### PR TITLE
banip: add IPEX DBL to banip.feeds

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
 PKG_VERSION:=1.5.6
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/banip/files/README.md
+++ b/net/banip/files/README.md
@@ -37,6 +37,7 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 | firehol4            | firehol level 4 compilation    |    x    |          |                   | [Link](https://iplists.firehol.org/?ipset=firehol_level4)    |
 | greensnow           | suspicious server IPs          |    x    |          |                   | [Link](https://greensnow.co)                                 |
 | hagezi              | Threat IP blocklist            |         |    x     | tcp, udp: 80, 443 | [Link](https://github.com/hagezi/dns-blocklists)             |
+| ipexdbl             | Threat IP blocklist            |         |    x     |                   | [Link](https://raw.githubusercontent.com/ZEROF/ipextractor/main/ipexdbl.txt)             |
 | ipblackhole         | blackhole IPs                  |    x    |          |                   | [Link](https://github.com/BlackHoleMonster/IP-BlackHole)     |
 | ipsum               | malicious IPs                  |    x    |          |                   | [Link](https://github.com/stamparm/ipsum)                    |
 | ipthreat            | hacker and botnet TPs          |    x    |          |                   | [Link](https://ipthreat.net)                                 |

--- a/net/banip/files/banip.feeds
+++ b/net/banip/files/banip.feeds
@@ -134,6 +134,12 @@
 		"descr": "Threat IP blocklist",
 		"flag": "tcp udp 80 443"
 	},
+	"ipexdbl":{
+		"url_4": "https://raw.githubusercontent.com/ZEROF/ipextractor/main/ipexdbl.txt",
+		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "out",
+		"descr": "minimalist dbl service"
+	},
 	"ipblackhole":{
 		"url_4": "https://blackhole.s-e-r-v-e-r.pw/blackhole-today",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",


### PR DESCRIPTION
# 📦 Package Details

**Maintainer: @dibdot**
**Description:** Add IPEX DBL to banip.feeds, an egress ip blocklist updated every 4h and is currently aggregated from the sources  IPEX Hunters, BinaryDefense, DShield, Crowdsec, Bruteforce, Talos, BlocklistDE, HoneypotProject, Spamhaus and ThreatFox
**Location: https://raw.githubusercontent.com/ZEROF/ipextractor/main/ipexdbl.txt**

# 🧪 Run Testing Details
* OpenWrt Version:
* OpenWrt Target/Subtarget:
* OpenWrt Device:

# ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

**If your PR contains a patch:**

- [x] It can be applied using git am
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
```
make package/<your-package>/refresh V=s
```
- [x] It is structured in a way that it is potentially upstreamable
