### PR TITLE
domoticz: update to 2025.2 and add jwt-cpp dependency

### DIFF
--- a/libs/jwt-cpp/Makefile
+++ b/libs/jwt-cpp/Makefile
@@ -1,0 +1,53 @@
+#
+# Copyright © 2025 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=jwt-cpp
+PKG_VERSION:=0.7.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/Thalhammer/jwt-cpp/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=d45894f57437ce45233cfe0e07383c4e1f32f969edfd8df8347e177b13bf74e5
+
+PKG_MAINTAINER:=David Woodhouse <dwmw2@infradead.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+# To build the examples and tests.
+PKG_BUILD_DEPENDS:=openssl nlohmannjson
+
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+# The tarball doesn't include the top-level jwt-cpp-v$(PKG_VERSION)/ directory
+TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
+
+# We *should* be able to build the examples and tests, but cmake insists on
+# finding it using its own nonsense instead of pkg-config, so it isn't found.
+CMAKE_OPTIONS += \
+	-DJWT_EXTERNAL_NLOHMANN_JSON=yes \
+	-DJWT_BUILD_TESTS=no \
+	-DJWT_BUILD_EXAMPLES=no
+
+define Package/jwt-cpp
+  BUILDONLY:=1
+  SECTION:=devel
+  CATEGORY:=Development
+  SUBMENU:=Libraries
+  TITLE:=Header-only C++ library for JSON Web Tokens
+  URL:=https://github.com/Thalhammer/jwt-cpp
+endef
+
+define Package/jwt-cpp/description
+  jwt-cpp is a header only library for creating and validating JSON Web Tokens in C++11
+endef
+
+$(eval $(call BuildPackage,jwt-cpp))

--- a/utils/domoticz/Makefile
+++ b/utils/domoticz/Makefile
@@ -8,19 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=domoticz
-PKG_VERSION:=2023.2
-PKG_RELEASE:=2
+PKG_VERSION:=2025.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/domoticz/domoticz/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=32bcf49df8c80c470352e63004a82d9601b90ccf406096099656250a4515ac28
+PKG_HASH:=fd016f4ffe419e8d559bc0a7f9de5ec4fcaf485fc9d1464c8e8221102b13f589
 
 PKG_MAINTAINER:=David Woodhouse <dwmw2@infradead.org>
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=License.txt
 PKG_CPE_ID:=cpe:/a:domoticz:domoticz
 
-PKG_BUILD_DEPENDS:=python3 minizip cereal boost
+PKG_BUILD_DEPENDS:=python3 minizip cereal boost jwt-cpp
 PKG_BUILD_FLAGS:=no-mips16 lto
 
 include $(INCLUDE_DIR)/package.mk
@@ -65,6 +65,7 @@ CMAKE_OPTIONS += \
 	-DUSE_BUILTIN_JSONCPP=no \
 	-DUSE_BUILTIN_MINIZIP=no \
 	-DUSE_BUILTIN_LIBFMT=no \
+	-DUSE_BUILTIN_JWTCPP=no \
 	-DUSE_LUA_STATIC=no \
 	-DUSE_STATIC_BOOST=no \
 	-DUSE_STATIC_LIBSTDCXX=no \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dwmw2

**Description:**
Update to 2025.2 release.

---

## 🧪 Run Testing Details

- **OpenWrt Version: 2025.10 snapshot**
- **OpenWrt Target/Subtarget: mediatek/filogic**
- **OpenWrt Device: OpenWrt One**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
