### PR TITLE
digitemp: fix compilation with gcc15

### DIFF
--- a/utils/digitemp/Makefile
+++ b/utils/digitemp/Makefile
@@ -11,14 +11,16 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=digitemp
 PKG_VERSION:=3.7.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/bcl/digitemp/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=683df4ab5cc53a45fe4f860c698f148d34bcca91b3e0568a342f32d64d12ba24
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/bcl/digitemp
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_MIRROR_HASH:=4b2a3f074c98a56e1816d760ecf5f26fb2293b26a8bda362d86627c3ddc8b318
 
 PKG_MAINTAINER:=Jasper Scholte <NightNL@outlook.com>
 PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/utils/digitemp/patches/010-prototype.patch
+++ b/utils/digitemp/patches/010-prototype.patch
@@ -1,0 +1,30 @@
+From fa56b0f78d12f97ac44e0a367d413a9e88611d1c Mon Sep 17 00:00:00 2001
+From: Robert Scheck <robert-scheck@users.noreply.github.com>
+Date: Thu, 16 Jan 2025 21:24:41 +0100
+Subject: [PATCH] Fix conflicting prototype
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+src/digitemp.c:171:6: error: conflicting types for ‘free_coupler’; have ‘void(int)’
+  171 | void free_coupler( int free_only )
+      |      ^~~~~~~~~~~~
+In file included from src/digitemp.c:78:
+src/digitemp.h:90:6: note: previous declaration of ‘free_coupler’ with type ‘void(void)’
+   90 | void free_coupler();
+      |      ^~~~~~~~~~~~
+---
+ src/digitemp.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/digitemp.h
++++ b/src/digitemp.h
+@@ -87,7 +87,7 @@ struct _coupler {
+ 
+ /* Prototypes */
+ void usage();
+-void free_coupler();
++void free_coupler( int free_only );
+ float c2f( float temp );
+ int build_tf( char *time_format, char *format, int sensor, 
+               float temp_c, int humidity, unsigned char *sn );

--- a/utils/digitemp/patches/020-time.patch
+++ b/utils/digitemp/patches/020-time.patch
@@ -1,0 +1,21 @@
+From 1fe5da089ffcba6ef6560d5c3e67149035f55cb6 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Fri, 17 Oct 2025 14:41:32 -0700
+Subject: [PATCH] fix wrong format for 32-bit and 64-bit time
+
+Just cast the whole thing.
+---
+ src/digitemp.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/digitemp.c
++++ b/src/digitemp.c
+@@ -2744,7 +2744,7 @@ int main( int argc, char *argv[] )
+     if( (time(NULL) > last_time + sample_delay) && (sample_delay > 0) )
+     {
+       fprintf(stderr, "Warning: delay (-d) is less than the time needed to ");
+-      fprintf(stderr, "read all of the attached sensors. It took %ld seconds", (long int) time(NULL) - last_time );
++      fprintf(stderr, "read all of the attached sensors. It took %ld seconds", (long int) (time(NULL) - last_time) );
+       fprintf(stderr, " to read the sensors\n" );
+     }
+ 


### PR DESCRIPTION
Upstream backports.

Move away from codeload. Local tar archives are smaller.

Add missing PKG_LICENSE_FILES.

## 📦 Package Details

**Maintainer:** @TimelessNL 