### PR TITLE
syslog-ng: update to version 4.10.2

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
-PKG_VERSION:=4.10.1
+PKG_VERSION:=4.10.2
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
@@ -11,7 +11,7 @@ PKG_CPE_ID:=cpe:/a:oneidentity:syslog-ng
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syslog-ng/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
-PKG_HASH:=dea90cf1dc4b8674ff191e0032f9dabc24b291abfd7f110fd092ae5f21cde5d7
+PKG_HASH:=841503de6c2486e66fd08f0c62ac2568fc8ed1021297f855e8acd58ad7caff76
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Release notes:
https://github.com/syslog-ng/syslog-ng/releases/tag/syslog-ng-4.10.2

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 24.10
- **OpenWrt Target/Subtarget:** mpc85xx
- **OpenWrt Device:** Turris 1.1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
