### PR TITLE
ddns-script: removes linefeed which causes 401 err

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=79
+PKG_RELEASE:=80
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_ovh_com.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_ovh_com.sh
@@ -12,7 +12,7 @@
 http_basic_encoding() {
 	local user="$1"
 	local password="$2"
-	echo "${user}:${password}" | openssl base64 
+	printf "${user}:${password}" | openssl base64 -in /dev/stdin
 }
 
 [ -z "$domain" ] && write_log 14 "Service section not configured correctly! Missing domain name as 'Domain'"


### PR DESCRIPTION
the linefeed at the end causes ovh-api to return 401 even if the password is correct.

Fixes #27693

## 📦 Package Details

**Maintainer:** @feckert @davidandreoletti 

**Description:**
fixes #27693 - caused by linefeed.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.