### PR TITLE
bind: bump to 9.18.41

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.18.37
-PKG_RELEASE:=2
+PKG_VERSION:=9.18.41
+PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=b322aaa4b0a98dba7507a18107b06283ec969af9af4797992e0a200fabace646
+PKG_HASH:=6ddc1d981511c4da0b203b0513af131e5d15e5f1c261145736fe1f35dd1fe79d
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
Addresses the following security issues:
- CVE-2025-8677: DNSSEC validation fails if matching but invalid DNSKEY is found.
- CVE-2025-40778: Address various spoofing attacks.
- CVE-2025-40780: Cache-poisoning due to weak pseudo-random number generator.

Full upstream changelog at
https://ftp.isc.org/isc/bind9/9.18.41/doc/arm/html/changelog.html

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 23.05
- **OpenWrt Target/Subtarget:** malta
- **OpenWrt Device:** qemu

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
