### PR TITLE
modemmanager: allow empty initial EPS bearer

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -526,13 +526,6 @@ modemmanager_init_epsbearer() {
 	local connectargs="$3"
 	local apn="$4"
 
-	[ "$eps" != 'none' ] && [ -z "${apn}" ] && {
-		echo "No '$eps' init eps bearer apn configured"
-		proto_notify_error "${interface}" MM_INIT_EPS_BEARER_APN_NOT_CONFIGURED
-		proto_block_restart "${interface}"
-		return 1
-	}
-
 	if [ "$eps" = "none" ]; then
 		echo "Deleting inital EPS bearer..."
 	else


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
This PR remove non empty APN requirement for initial EPS bearer.
Empty APN value is valid one and means that modem will use network
provided APN which can be offered by operator.

For more detailed explanation I will add an example:
```
at+cgdcont?
+CGDCONT: 1,"IPV4V6","","0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",0,0,0,0,,,,,,,,,,"",,,,0
```
First PDP profile in modem usually is used for initial connection to operator. This AT command show that 1st PDP profile settings does not have APN specified and by default it means, that modem will use network provided APN.

Second AT command indicate that PDP profile 1 is using APN "omnitel", this indicate that network gave that APN in initial connectivity request.
```
at+cgcontrdp
+CGCONTRDP: 1,5,"omnitel","100.95.237.xxx"....
```

---

## 🧪 Run Testing Details

- **OpenWrt Version: master**
- **OpenWrt Target/Subtarget: mediatek/filogic**
- **OpenWrt Device: RUTC50**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
