### PR TITLE
nfs-kernel-server: disable kerberos and ldap

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
 PKG_VERSION:=2.8.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_HASH:=11c4cc598a434d7d340bad3e072a373ba1dcc2c49f855d44b202222b78ecdbf5
 
 PKG_SOURCE:=nfs-utils-$(PKG_VERSION).tar.xz
@@ -140,6 +140,8 @@ ifeq ($(BUILD_VARIANT),v4)
 	CONFIGURE_ARGS += \
 	--enable-nfsdcld \
 	--enable-nfsv4server \
+	--disable-ldap \
+	--disable-gss \
 	--enable-nfsv4 \
 	--enable-nfsv41 \
 	--enable-nfsv42
@@ -162,6 +164,7 @@ HOST_CFLAGS += -Dlinux \
 
 HOST_CONFIGURE_ARGS += \
 	--disable-gss \
+	--disable-ldap \
 	--disable-nfsrahead \
 	--disable-nfsdctl \
 	--without-tcp-wrappers \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Some targets are failing due likely to build order issues suggested by Daniel[1] so disable these two options for the v4 package.

Example:
```
make[4]: Leaving directory '/builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/nfs-utils-2.8.4' Package nfs-kernel-server-v4 is missing dependencies for the following libraries: libgssapi_krb5.so.2
libldap.so.2
```
1. https://github.com/openwrt/packages/pull/27150#issuecomment-3446589119

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** None locally, depending on CI to understand if successful due to failure to reproduce in my build environment
- **OpenWrt Device:** same

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
