### PR TITLE
zabbix: Add optional SNMP support for all server/proxy variants

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -27,7 +27,8 @@ PKG_BUILD_PARALLEL:=1
 PKG_CONFIG_DEPENDS:= \
   CONFIG_ZABBIX_MYSQL \
   CONFIG_ZABBIX_POSTGRESQL \
-  CONFIG_ZABBIX_SQLITE
+  CONFIG_ZABBIX_SQLITE \
+  CONFIG_ZABBIX_SNMP
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -48,6 +49,14 @@ choice
         config ZABBIX_SQLITE
                 bool "SQLite"
 endchoice
+
+config ZABBIX_SNMP
+        bool "Enable SNMP support"
+        depends on PACKAGE_zabbix-server || PACKAGE_zabbix-server-openssl || PACKAGE_zabbix-server-gnutls || PACKAGE_zabbix-proxy || PACKAGE_zabbix-proxy-openssl || PACKAGE_zabbix-proxy-gnutls
+        default n
+        help
+          Enable SNMP support for Zabbix server and proxy.
+          This requires libnetsnmp package.
 endef
 
 define Package/zabbix/Default
@@ -166,6 +175,7 @@ endef
 define Package/zabbix-server
   $(call Package/zabbix-server/Default)
   PROVIDES:=zabbix-server
+  DEPENDS+= +ZABBIX_SNMP:libnetsnmp
   VARIANT:=nossl
   DEFAULT_VARIANT:=1
 endef
@@ -174,7 +184,7 @@ define Package/zabbix-server-openssl
   $(call Package/zabbix-server/Default)
   TITLE+= (with OpenSSL)
   PROVIDES:=zabbix-server
-  DEPENDS+= +libopenssl
+  DEPENDS+= +libopenssl +ZABBIX_SNMP:libnetsnmp
   VARIANT:=openssl
 endef
 
@@ -182,7 +192,7 @@ define Package/zabbix-server-gnutls
   $(call Package/zabbix-server/Default)
   TITLE+= (with GnuTLS)
   PROVIDES:=zabbix-server
-  DEPENDS+= +libgnutls
+  DEPENDS+= +libgnutls +ZABBIX_SNMP:libnetsnmp
   VARIANT:=gnutls
 endef
 
@@ -220,6 +230,7 @@ endef
 define Package/zabbix-proxy
   $(call Package/zabbix-proxy/Default)
   PROVIDES:=zabbix-proxy
+  DEPENDS+= +ZABBIX_SNMP:libnetsnmp
   VARIANT:=nossl
   DEFAULT_VARIANT:=1
 endef
@@ -228,7 +239,7 @@ define Package/zabbix-proxy-openssl
   $(call Package/zabbix-proxy/Default)
   TITLE+= (with OpenSSL)
   PROVIDES:=zabbix-proxy
-  DEPENDS+= +libopenssl
+  DEPENDS+= +libopenssl +ZABBIX_SNMP:libnetsnmp
   VARIANT:=openssl
 endef
 
@@ -236,7 +247,7 @@ define Package/zabbix-proxy-gnutls
   $(call Package/zabbix-proxy/Default)
   TITLE+= (with GnuTLS)
   PROVIDES:=zabbix-proxy
-  DEPENDS+= +libgnutls
+  DEPENDS+= +libgnutls +ZABBIX_SNMP:libnetsnmp
   VARIANT:=gnutls
 endef
 
@@ -267,6 +278,7 @@ CONFIGURE_ARGS+= \
 	$(if $(CONFIG_ZABBIX_MYSQL),--with-mysql) \
 	$(if $(CONFIG_ZABBIX_POSTGRESQL),--with-postgresql) \
 	$(if $(CONFIG_ZABBIX_SQLITE),--with-sqlite3=$(STAGING_DIR)/usr) \
+	$(if $(CONFIG_ZABBIX_SNMP),--with-net-snmp) \
 	--with-libevent=$(STAGING_DIR)/usr/include \
 	--with-libpcre2=$(STAGING_DIR)/usr/include \
 	--with-zlib=$(STAGING_DIR)/usr/include

--- a/admin/zabbix/patches/120-fix-netsnmp-strong-auth-detection.patch
+++ b/admin/zabbix/patches/120-fix-netsnmp-strong-auth-detection.patch
@@ -1,0 +1,11 @@
+--- a/m4/netsnmp.m4
++++ b/m4/netsnmp.m4
+@@ -168,6 +168,7 @@ AC_DEFUN([LIBNETSNMP_CHECK_CONFIG],[
+ 		]], [[
+ struct snmp_session session;
+ session.securityAuthProto = usmHMAC384SHA512AuthProtocol;
++return (int)(long)session.securityAuthProto;
+ 		]])],[
+ 		AC_DEFINE(HAVE_NETSNMP_STRONG_AUTH, 1, [Define to 1 if strong SHA auth protocols are supported.])
+ 		AC_MSG_RESULT(yes)
+


### PR DESCRIPTION
- Add CONFIG_ZABBIX_SNMP menuconfig option to enable SNMP support
- Support all zabbix-server and zabbix-proxy variants (nossl, openssl, gnutls)
- Add conditional libnetsnmp dependency based on SNMP config
- Add --with-net-snmp configure option when SNMP is enabled
- Include patch to fix NetSNMP strong auth detection issue



## 📦 Package Details

**Maintainer:** @robimarko 

**Description:**

This allows users to optionally enable SNMP support for Zabbix server and proxy components through menuconfig, with proper dependency management and build configuration.

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.3
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** KVM

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.