### PR TITLE
umurmur: move config file to its default location

### DIFF
--- a/net/umurmur/Makefile
+++ b/net/umurmur/Makefile
@@ -68,9 +68,9 @@ define Package/umurmur-openssl/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/umurmurd $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/umurmur/
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/openwrt/files/umurmur.conf $(1)/etc/umurmur/
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/umurmur.conf.example $(1)/etc/umurmur/umurmur.conf
 	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openwrt/files/umurmur.init $(1)/etc/init.d/umurmur
+	$(INSTALL_BIN) ./files/umurmur.init $(1)/etc/init.d/umurmur
 endef
 
 Package/umurmur-mbedtls/install = $(Package/umurmur-openssl/install)

--- a/net/umurmur/files/umurmur.init
+++ b/net/umurmur/files/umurmur.init
@@ -1,0 +1,26 @@
+#!/bin/sh /etc/rc.common
+
+START=90
+STOP=10
+
+USE_PROCD=1
+
+PROG=/usr/sbin/umurmurd
+CONF=/etc/umurmur/umurmur.conf
+
+start_service() {
+	procd_open_instance
+	procd_set_param command $PROG -d -c $CONF
+	procd_set_param respawn
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger umurmur
+}
+
+reload_service() {
+	procd_send_signal umurmur
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** none
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
This was changed in version 0.3.1 [1]

Fixes initial start of umurmur:
```
root@turris:~# umurmurd
Error in config file /etc/umurmur/umurmur.conf line 0: file I/O error
```

And also while running help of umurmurd, the defailt location is /etc/umurmur/umurmur.conf
```
Usage: umurmurd [-d] [-r] [-h] [-p <pidfile>] [-t] [-c <conf file>] [-a <addr>] [-b <port>]
       -c <conf file> - Specify configuration file (default /etc/umurmur/umurmur.conf)
```
[1] https://github.com/umurmur/umurmur/commit/4f3ed41357bb6fcb7afddd5343b59cfef54d65a4

Fixes: c4a23ca99662e67c8b6f5b8bad76d93fc2381ea0 ("umurmur: update to version 0.3.1")
Fixes: https://github.com/openwrt/packages/issues/27726

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** mpc85xx
- **OpenWrt Device:** Turris 1.1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
