### PR TITLE
chrony: add provides logic to Makefile

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
 PKG_VERSION:=4.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://chrony-project.org/releases/
 PKG_HASH:=33ea8eb2a4daeaa506e8fcafd5d6d89027ed6f2f0609645c6f149b560d301706
 
 PKG_MAINTAINER:=Miroslav Lichvar <mlichvar0@gmail.com>
-PKG_LICENSE:=GPL-2.0
+PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:tuxfamily:chrony
 
@@ -32,8 +32,7 @@ define Package/chrony/Default
   DEPENDS:=+libcap +libpthread
   USERID:=chrony=323:chrony=323
   TITLE:=A versatile NTP client and server
-  URL:=http://chrony.tuxfamily.org/
-  PROVIDES:=nts
+  URL:=https://chrony-project.org/
 endef
 
 define Package/chrony


### PR DESCRIPTION
This satisfies other packages which might depend on either chrony variant.

E.g. luci interface where either -nts or non variants are acceptable.

## 📦 Package Details

**Maintainer:** @mlichvar 
