### PR TITLE
Add missing .fscrypt conffiles dir for fscrypt package

### DIFF
--- a/utils/fscrypt/Makefile
+++ b/utils/fscrypt/Makefile
@@ -50,6 +50,7 @@ endef
 
 define Package/fscrypt/conffiles
 /etc/fscrypt.conf
+/.fscrypt/
 endef
 
 $(eval $(call GoBinPackage,fscrypt))


### PR DESCRIPTION
The fscrypt metadata directory for the root filesystem (`/.fscrypt`) *should* be preserved across sysupgrades even if the facility is not used on the root fs, and *must* be preserved if the feature is ever used, per fscrypt docs.

Amends package definition added in #25706 
