### PR TITLE
sstp: correct certificate handling

### DIFF
--- a/net/sstp-client/files/lib/netifd/proto/sstp.sh
+++ b/net/sstp-client/files/lib/netifd/proto/sstp.sh
@@ -76,7 +76,6 @@ proto_sstp_setup() {
 	proto_send_update "$config"
 
 	proto_run_command "$config" sstpc \
-		--cert-warn \
 		--password $password \
 		--user $username \
 		--log-level $log_level \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @fededim 

**Description:**

By using `--cert-warn` this silently ignores certificate warnings. Removing it so the connection is properly terminated.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** CI
- **OpenWrt Target/Subtarget:** CI
- **OpenWrt Device:** CI

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
