### PR TITLE
mox-pkcs11: add new package

### DIFF
--- a/utils/mox-pkcs11/Makefile
+++ b/utils/mox-pkcs11/Makefile
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: GPL-3.0-only
+# Copyright (C) 2020, 2025 CZ.NIC z.s.p.o. (https://www.nic.cz/)
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mox-pkcs11
+PKG_VERSION:=2.0
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://gitlab.nic.cz/turris/mox-pkcs11.git
+PKG_MIRROR_HASH:=424b5247288310c6a71b7babed201dc153c58fca73241530254d2cbc84f1b4ef
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+
+PKG_MAINTAINER:=Tomáš Macholda <tomas.macholda@nic.cz>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE.txt
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/mox-pkcs11
+	SECTION:=utils
+	CATEGORY:=Utilities
+	TITLE:=MOX PKCS11 module
+	DEPENDS:=@(TARGET_mvebu_cortexa53_DEVICE_ripe_atlas-v5||TARGET_mvebu_cortexa53_DEVICE_cznic_turris-mox) +libopenssl +libkeyutils
+	URL:=https://gitlab.nic.cz/turris/mox-pkcs11
+endef
+
+define Package/mox-pkcs11/description
+  PKCS#11 module that provides access to Turris MOX internal ECDSA key
+  for cryptographic operations.
+endef
+
+define Build/Compile
+	$(TARGET_CC) \
+	$(TARGET_CFLAGS) \
+	$(TARGET_LDFLAGS) \
+	$(FPIC) \
+	-o $(PKG_BUILD_DIR)/libmox-pkcs11.so $(PKG_BUILD_DIR)/mox-pkcs11.c
+	-lcrypto \
+	-lkeyutils \
+	-Wall \
+	-shared
+endef
+
+define Package/mox-pkcs11/install
+	$(INSTALL_DIR) $(1)/usr/lib/pkcs11/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/libmox-pkcs11.so $(1)/usr/lib/pkcs11/
+endef
+
+$(eval $(call BuildPackage,mox-pkcs11))


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Adds a library for using built-in ECDSA key in devices based on Turris MOX for PKCS11 authentication.

Currently depends on `TARGET_mvebu_cortexa53_DEVICE_ripe_atlas-v5` or `TARGET_mvebu_cortexa53_DEVICE_cznic_turris-mox` which are pending at `openwrt/openwrt`:
- RIPE Atlas v5: https://github.com/openwrt/openwrt/pull/20031
- Turris MOX: https://github.com/openwrt/openwrt/pull/20356

### Example usage:

Export public key:
```
ssh-keygen -D /usr/lib/pkcs11/libmox-pkcs11.so -e
```
Connect:
```
ssh -o 'PKCS11Provider /usr/lib/pkcs11/libmox-pkcs11.so' user@host
```

---

## 🧪 Run Testing Details

- **OpenWrt Version:** `OpenWrt SNAPSHOT r31381+1-8a8bfcc7fe`
- **OpenWrt Target/Subtarget:** `mvebu/cortexa53`
- **OpenWrt Device:** RIPE Atlas probe v5, Turris MOX

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.