### PR TITLE
fscrypt: make sysupgrade aware of /.fscrypt/

### DIFF
--- a/utils/fscrypt/Makefile
+++ b/utils/fscrypt/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fscrypt
 PKG_VERSION:=0.3.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/google/fscrypt/tar.gz/v$(PKG_VERSION)?
@@ -50,6 +50,7 @@ endef
 
 define Package/fscrypt/conffiles
 /etc/fscrypt.conf
+/.fscrypt/
 endef
 
 $(eval $(call GoBinPackage,fscrypt))


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Preserve `/.fscrypt/` by defining it in the Makefile so that sysupgrade is aware of it. This should cover more use cases of this tool.

Closes #27725.

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPTHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** Intel N150-based PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
