### PR TITLE
strongswan: Add support for EAP-TLS authentication

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=6.0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -550,7 +550,9 @@ config_remote() {
 	[ -n "$pools" ] && swanctl_xappend2 "pools = $pools"
 
 	local local_auth_method="$auth_method"
-	[ "$auth_method" = "eap-mschapv2" ] && local_auth_method="pubkey"
+	if [ "$auth_method" = "eap-mschapv2" ] || [ "$auth_method" = "eap-tls" ]; then
+		local_auth_method="pubkey"
+	fi
 
 	swanctl_xappend2 "local {"
 	swanctl_xappend3 "auth = $local_auth_method"
@@ -564,7 +566,9 @@ config_remote() {
 	swanctl_xappend3 "auth = $auth_method"
 	[ -n "$remote_identifier" ] && swanctl_xappend3 "id = \"$remote_identifier\""
 	[ -n "$remote_ca_certs" ] && swanctl_xappend3 "cacerts = \"$remote_ca_certs\""
-	[ "$auth_method" = eap-mschapv2 ] && swanctl_xappend3 "eap_id = $eap_id"
+	if [ "$auth_method" = "eap-mschapv2" ] || [ "$auth_method" = "eap-tls" ]; then
+		swanctl_xappend3 "eap_id = $eap_id"
+	fi
 	swanctl_xappend2 "}"
 
 	swanctl_xappend2 "children {"
@@ -637,6 +641,9 @@ config_remote() {
 		swanctl_xappend0 "}"
 	elif [ "$auth_method" = eap-mschapv2 ]; then
 		# EAP-MSCHAPv2 secrets are handled in config_mschapv2_secrets globally
+		:  # empty command
+	elif [ "$auth_method" = eap-tls ]; then
+		# EAP-TLS approved client certs are restricted by remote_ca_certs option
 		:  # empty command
 	else
 		fatal "AuthenticationMode $auth_mode not supported"


### PR DESCRIPTION
Support for configuring EAP-TLS authentication scheme is added.
Required for certificate authenticated road warriors on clients that don't support pubkey (Windows, MacOS, probably more)

Maintainer: @pprindeville 
Runtested: 24.10.2
