### PR TITLE
adguardhome: refactor config loading and migration

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
 PKG_VERSION:=0.107.69
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/AdGuardHome/tar.gz/v$(PKG_VERSION)?

--- a/net/adguardhome/files/adguardhome.config
+++ b/net/adguardhome/files/adguardhome.config
@@ -1,9 +1,8 @@
 config adguardhome 'config'
-	# All paths except for PID must be readable by the configured user
-	option config '/etc/adguardhome/adguardhome.yaml'
+	# All paths must be readable by the configured user
+	option config_file '/etc/adguardhome/adguardhome.yaml'
 	# Where to store persistent data by AdGuard Home
-	option workdir '/var/lib/adguardhome'
-	option pidfile '/run/adguardhome.pid'
+	option work_dir '/var/lib/adguardhome'
 	option user 'adguardhome'
 	option group 'adguardhome'
 	option verbose '0'

--- a/net/adguardhome/files/adguardhome.defaults
+++ b/net/adguardhome/files/adguardhome.defaults
@@ -1,7 +1,9 @@
 #!/bin/sh
 
+# Migrate old config format only
 OLD_CONFIG_FILE=$(uci -q get adguardhome.config.config)
 OLD_CONFIG_FILE=${OLD_CONFIG_FILE:-/etc/adguardhome.yaml}
+OLD_CONFIG_NEW_OPT_FILE=$(uci -q get adguardhome.config.config_file)
 NEW_CONFIG_DIR=/etc/adguardhome
 NEW_CONFIG_FILE="$NEW_CONFIG_DIR/adguardhome.yaml"
 
@@ -17,7 +19,16 @@ stop_service() {
 	fi
 }
 
-if [ -f "$OLD_CONFIG_FILE" ] && [ "$OLD_CONFIG_FILE" != "$NEW_CONFIG_FILE" ]; then
+if [ -f "$OLD_CONFIG_NEW_OPT_FILE" ] && [ "$OLD_CONFIG_NEW_OPT_FILE" != "$NEW_CONFIG_FILE" ]; then
+	echo "Old AdGuard Home config found in '$OLD_CONFIG_NEW_OPT_FILE'"
+
+	USER=$(uci -q get adguardhome.config.user)
+	USER=${USER:-adguardhome}
+
+	echo "AdGuard Home config is stored in a non-default path."
+	echo "Ensure configured service user '$USER' can access it."
+
+elif [ -f "$OLD_CONFIG_FILE" ] && [ "$OLD_CONFIG_FILE" != "$NEW_CONFIG_FILE" ]; then
 	echo "Old AdGuard Home config found in '$OLD_CONFIG_FILE'"
 	OLD_CONFIG_DIR=$(dirname "$OLD_CONFIG_FILE")
 
@@ -26,25 +37,27 @@ if [ -f "$OLD_CONFIG_FILE" ] && [ "$OLD_CONFIG_FILE" != "$NEW_CONFIG_FILE" ]; th
 	GROUP=$(uci -q get adguardhome.config.group)
 	GROUP=${GROUP:-adguardhome}
 
-	echo "Using $USER:$GROUP for file ownership."
-
 	CUR_CONFIG_FILE="$OLD_CONFIG_FILE"
 	if [ "$OLD_CONFIG_DIR" = "/etc" ]; then
 		echo "AdGuard Home config must be stored in its own directory. Migrating..."
 		stop_service
 
+		echo "Using $USER:$GROUP for file ownership."
+
 		[ -d "$NEW_CONFIG_DIR" ] || mkdir -m 0700 -p "$NEW_CONFIG_DIR"
 		mv "$OLD_CONFIG_FILE" "$NEW_CONFIG_FILE"
 		chown -R "$USER":"$GROUP" "$NEW_CONFIG_DIR"
 		CUR_CONFIG_FILE="$NEW_CONFIG_FILE"
-		uci set adguardhome.config.config="$NEW_CONFIG_FILE"
 
 		echo "Config migrated to '$NEW_CONFIG_FILE'"
 
-	elif [ "$OLD_CONFIG_DIR" != "$NEW_CONFIG_DIR" ]; then
-		echo "AdGuard Home config is stored in a non-default path. " \
-			+ "Ensure configured service user '$USER' can access it."
+	else
+		echo "AdGuard Home config is stored in a non-default path."
+		echo "Ensure configured service user '$USER' can access it."
 	fi
+
+	uci set adguardhome.config.config_file="$CUR_CONFIG_FILE"
+	uci -q delete adguardhome.config.config
 
 	# Use awk to split match on :, remove double quotes and trim leading and
 	# trailing spaces
@@ -77,17 +90,18 @@ if [ -f "$OLD_CONFIG_FILE" ] && [ "$OLD_CONFIG_FILE" != "$NEW_CONFIG_FILE" ]; th
 	uci commit adguardhome
 	start_service
 
-elif [ "$OLD_CONFIG_FILE" != "$NEW_CONFIG_FILE" ]; then
+elif [ -z "$OLD_CONFIG_NEW_OPT_FILE" ] && [ "$OLD_CONFIG_FILE" != "$NEW_CONFIG_FILE" ]; then
 	echo "Old AdGuard Home config not found in '$OLD_CONFIG_FILE'"
 	stop_service
 
 	# Service script will create the new config directory
-	uci set adguardhome.config.config="$NEW_CONFIG_FILE"
+	uci set adguardhome.config.config_file="$NEW_CONFIG_FILE"
+	uci -q delete adguardhome.config.config
 	echo "Config path changed to '$NEW_CONFIG_FILE'"
 
 	uci commit adguardhome
 	start_service
 
 else
-	echo "AdGuard Home config is in its default path '$NEW_CONFIG_FILE'. Nothing to do."
+	echo "AdGuard Home config is in its default path '$NEW_CONFIG_FILE'"
 fi

--- a/net/adguardhome/files/adguardhome.init
+++ b/net/adguardhome/files/adguardhome.init
@@ -10,6 +10,30 @@ START=19
 # stops before networking stops
 STOP=89
 
+config_cb() {
+	[ $# -eq 0 ] && return
+
+	option_cb() {
+		local option="$1"
+		local value="$2"
+
+		case $option in
+
+		# Support old option names
+		config)
+			option='config_file'
+			;;
+
+		workdir)
+			option='work_dir'
+			;;
+
+		esac
+
+		eval $option="$value"
+	}
+}
+
 boot() {
 	ADGUARDHOME_BOOT=1
 	start "$@"
@@ -21,27 +45,19 @@ start_service() {
 		return 0
 	fi
 
-	local config_file
-	local group
-	local pid_file
-	local user
-	local verbose
-	local work_dir
+	local config_file='/etc/adguardhome/adguardhome.yaml'
+	local group='adguardhome'
+	local user='adguardhome'
+	local verbose=0
+	local work_dir='/var/lib/adguardhome'
 
-	config_load adguardhome
-	config_get config_file config config "/etc/adguardhome/adguardhome.yaml"
-	config_get work_dir config workdir "/var/lib/adguardhome"
-	config_get pid_file config pidfile "/run/adguardhome.pid"
-	config_get_bool verbose config verbose
-
-	config_get user config user adguardhome
-	config_get group config group adguardhome
+	config_load 'adguardhome'
 
 	local config_dir
 	config_dir=$(dirname "$config_file")
 	if [ "$config_dir" = '/etc' ]; then
 		echo "AdGuard Home config must be stored in its own directory, and not in /etc" >&2
-		exit 1
+		return 1
 	fi
 	mkdir -m 0700 -p "$config_dir"
 	chown -R "$user":"$group" "$config_dir"
@@ -53,12 +69,12 @@ start_service() {
 
 	procd_set_param command "$PROG"
 	procd_append_param command --config "$config_file"
-	procd_append_param command --work-dir "$work_dir"
 	procd_append_param command --logfile syslog
 	procd_append_param command --no-check-update
-	[ "$verbose" = 1 ] && procd_append_param command --verbose
+	[ "$verbose" = 1 ] && \
+		procd_append_param command --verbose
+	procd_append_param command --work-dir "$work_dir"
 
-	procd_set_param pidfile "$pid_file"
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_set_param user "$user"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dobo90, me

**Description:**

Refactor config loading and migration. Rename config options and remove unused ones.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT, 24.10.4
- **OpenWrt Target/Subtarget:** x86/64, mediatek/filogic
- **OpenWrt Device:** QEMU, Zyxel EX5601-T0 ubootmod

Tested all configuration and migration scenarios.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.