### PR TITLE
mwan3: refresh source ip in mwan3track

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.12.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -283,6 +283,8 @@ main() {
 			wait $!
 		}
 		sleep_time=$interval
+		network_flush_cache
+		mwan3_get_src_ip SRC_IP $INTERFACE
 		for track_ip in $track_ips; do
 			if [ $host_up_count -lt $reliability ]; then
 				case "$track_method" in


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert

**Description:**

It is possible for the source IP to change without an ifup event. As the USR1 and USR2 signal are already used for ifup and ifdown, there is no possibility to add another trigger for refreshing the source IP only.

When receiving an ifup, then the source IP is refreshed. However, in addition to that, the current interface state is set to the assumed initial interface state which is an unwanted side effect in this case.

This patch refreshes the source IP during every iteration of the main loop, that is all sleep_time seconds where sleep_time is by default ten seconds. There is one mwan3track process per interface. Thus, I make the assumption that this does not cause a noticable amount of extra system load.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.2
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** KVM virtual machine

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
