### PR TITLE
pdns-recursor: security update to 5.1.8

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
-PKG_VERSION:=5.1.2
+PKG_VERSION:=5.1.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=b3a37ebb20285ab9acbbb0e1370e623bb398ed3087f0e678f23ffa3b0063983d
+PKG_HASH:=9d2cc864d815010c39902c7f6a4c838c5d7f3a767c9897a44dc6afa3a815a40e
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>, Remi Gacogne <remi.gacogne@powerdns.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** me / @rgacogne 

**Description:**
includes fix for CVE-2025-30192 (from 5.1.6)
includes fixes for CVE-2025-59023 and CVE-2025-59024 (from 5.1.8)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10-SNAPSHOT
- **OpenWrt Target/Subtarget:** x86 x86_64
- **OpenWrt Device:** docker rootfs

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
