### PR TITLE
lxc: lxc-auto: don't mount systemd cgroup v1

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=6.0.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/

--- a/utils/lxc/files/lxc-auto.init
+++ b/utils/lxc/files/lxc-auto.init
@@ -87,13 +87,3 @@ stop() {
 		done
 	fi
 }
-
-#Export systemd cgroups
-boot() {
-	if [ ! -d /sys/fs/cgroup/systemd ]; then
-		mkdir -p /sys/fs/cgroup/systemd
-		mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,none,name=systemd cgroup /sys/fs/cgroup/systemd
-	fi
-
-	start
-}

--- a/utils/lxc/test-version.sh
+++ b/utils/lxc/test-version.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+#
+# Generic version-check override.
+#
+# Most lxc-* binaries print only the bare version number (e.g. "6.0.6")
+# via --version, which the framework's generic probe picks up correctly.
+# The exceptions are:
+#   lxc-checkconfig  - shell script, prints no machine-readable version
+#   lxc-config       - binary but version output not matched by generic probe
+#   lxc-monitord     - libexec helper, no --version flag
+#   lxc-user-nic     - libexec helper, no --version flag
+#
+# Packages that do expose a usable version string are probed directly.
+# Meta/library/script packages that do not are skipped here; functionality
+# is covered by the build itself.
+
+case "$PKG_NAME" in
+lxc|\
+lxc-common|\
+lxc-hooks|\
+lxc-templates|\
+lxc-configs|\
+lxc-init|\
+lxc-auto|\
+lxc-unprivileged|\
+liblxc|\
+lxc-checkconfig|\
+lxc-config|\
+lxc-monitord|\
+lxc-user-nic|\
+lxc-usernsexec)
+	# No machine-readable version output; skip generic version check.
+	exit 0
+	;;
+
+lxc-attach|\
+lxc-autostart|\
+lxc-cgroup|\
+lxc-copy|\
+lxc-console|\
+lxc-create|\
+lxc-destroy|\
+lxc-device|\
+lxc-execute|\
+lxc-freeze|\
+lxc-info|\
+lxc-monitor|\
+lxc-snapshot|\
+lxc-start|\
+lxc-stop|\
+lxc-unfreeze|\
+lxc-unshare|\
+lxc-wait|\
+lxc-top|\
+lxc-ls)
+	# These binaries print just the version number to stdout on --version.
+	"$PKG_NAME" --version | grep -F "$PKG_VERSION"
+	;;
+
+*)
+	echo "test-version.sh: unhandled sub-package '$PKG_NAME'" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @graysky2 @ratkaj

**Description:**

Mounting the systemd cgroup v1 hierarchy puts LXC into hybrid mode resulting in the host's
cgroup.subtree_control being empty so cgroup v2 controllers are not delegated to containers.
Users wanting cgroup v1 should mount it manually.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.2
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** BananaPi BPI-R3

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

---

Close #27755 #25424
