### PR TITLE
libtiff: update to 4.7.1

### DIFF
--- a/libs/tiff/Makefile
+++ b/libs/tiff/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tiff
-PKG_VERSION:=4.7.0
-PKG_RELEASE:=2
+PKG_VERSION:=4.7.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.osgeo.org/libtiff
-PKG_HASH:=67160e3457365ab96c5b3286a0903aa6e78bdc44c4bc737d2e486bcecb6ba976
+PKG_HASH:=f698d94f3103da8ca7438d84e0344e453fe0ba3b7486e04c5bf7a9a3fabe9b69
 
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 PKG_LICENSE:=libtiff
@@ -25,7 +25,7 @@ include $(INCLUDE_DIR)/cmake.mk
 
 define Package/tiff/Default
   TITLE:=TIFF
-  URL:=http://simplesystems.org/libtiff/
+  URL:=https://libtiff.gitlab.io/libtiff/
 endef
 
 define Package/libtiff
@@ -43,7 +43,7 @@ $(call Package/tiff/Default)
   CATEGORY:=Utilities
   SUBMENU:=Image Manipulation
   TITLE+= utilities
-  DEPENDS:=+libtiff
+  DEPENDS:=+libtiff +libstdcpp
 endef
 
 CMAKE_OPTIONS += \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jslachta

**Description:**
Fixes CMake build error (caused by https://github.com/openwrt/openwrt/commit/1b48ebd31c28f5b2ad3f964c25f34d33badbb979)
Also update URL.

Release info: https://gitlab.com/libtiff/libtiff/-/releases/v4.7.1

Related issue #27607

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek_filogic
- **OpenWrt Device:** bananapi_bpi-r3

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.


