### PR TITLE
poemgr: Install default PSX10 + PSX28 configuration

### DIFF
--- a/utils/poemgr/Makefile
+++ b/utils/poemgr/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=poemgr
 PKG_SOURCE_DATE:=2025-09-27
 PKG_SOURCE_VERSION:=17771dd7b3a74a64c14351d1cbf8e61676934cbe
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://github.com/blocktrron/poemgr.git
@@ -31,6 +31,8 @@ define Package/poemgr/install
 	$(INSTALL_DIR) $(1)/sbin $(1)/usr/lib/poemgr/config $(1)/etc/config $(1)/etc/uci-defaults $(1)/etc/init.d
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/poemgr $(1)/sbin/poemgr
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/uswlite-pse-enable $(1)/usr/lib/poemgr/uswlite-pse-enable
+	$(CP) $(PKG_BUILD_DIR)/contrib/psx10.config $(1)/usr/lib/poemgr/config/psx10.config
+	$(CP) $(PKG_BUILD_DIR)/contrib/psx28.config $(1)/usr/lib/poemgr/config/psx28.config
 	$(CP) $(PKG_BUILD_DIR)/contrib/usw-lite.config $(1)/usr/lib/poemgr/config/usw-lite.config
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/uci-defaults.sh $(1)/etc/uci-defaults/99-poemgr
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/procd-init.sh $(1)/etc/init.d/poemgr


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  @blocktrron


**Description:**

The Plasma Cloud PSX10 and Plasma Cloud PSX28 are officially supported by upstream main. Their default configuration files must be installed to be able to use poemgr on these devices out of the box.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** r31654-3570dee5f0
- **OpenWrt Target/Subtarget:** realtek/rtl930x + realtek/rtl931x
- **OpenWrt Device:** Plasma Cloud PSX28 + PSX10

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.