### PR TITLE
libid3tag: require cmake >= 3.10 due to removed legacy support

### DIFF
--- a/libs/libid3tag/Makefile
+++ b/libs/libid3tag/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libid3tag
 PKG_VERSION:=0.16.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://codeberg.org/tenacityteam/libid3tag.git

--- a/libs/libid3tag/patches/001-cmake-version.patch
+++ b/libs/libid3tag/patches/001-cmake-version.patch
@@ -1,0 +1,20 @@
+From eee94b22508a066f7b9bc1ae05d2d85982e73959 Mon Sep 17 00:00:00 2001
+From: heitbaum <heitbaum@noreply.codeberg.org>
+Date: Thu, 1 May 2025 05:34:30 +0000
+Subject: [PATCH] Allow build with CMake 4.0.0
+
+CMake 4.0.0 deprecates CMake syntax < 3.10. Update to using a minimum of 3.10.
+
+ref: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1.0)
++cmake_minimum_required(VERSION 3.10)
+ project(id3tag VERSION 0.16.3)
+ 
+ option(BUILD_SHARED_LIBS "Build dynamic library" ON)


### PR DESCRIPTION
Link: https://github.com/openwrt/packages/issues/27607

Link: https://github.com/openwrt/openwrt/commit/1b48ebd31c28f5b2ad3f964c25f34d33badbb979

## 📦 Package Details

**Maintainer:** Ted Hess <thess@kitschensync.net>
<sub>https://codeberg.org/tenacityteam/libid3tag.git</sub>

**Description:**
libid3tag is a library for reading and (eventually) writing ID3 tags, both ID3v1 and the various versions of ID3v2

---

## 🧪 Run Testing Details

- **OpenWrt Version: master**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/feeds/packages/libid3tag/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
