### PR TITLE
libvorbis: require cmake >= 3.10 due to removed legacy support

### DIFF
--- a/libs/libvorbis/Makefile
+++ b/libs/libvorbis/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libvorbis
 PKG_VERSION:=1.3.7
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://downloads.xiph.org/releases/vorbis/

--- a/libs/libvorbis/patches/001-cmake-version.patch
+++ b/libs/libvorbis/patches/001-cmake-version.patch
@@ -1,0 +1,8 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 3.10)
+ project(vorbis)
+ 
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")


### PR DESCRIPTION
Link: https://github.com/openwrt/packages/issues/27607
Link: https://github.com/openwrt/openwrt/commit/1b48ebd31c28f5b2ad3f964c25f34d33badbb979

## 📦 Package Details

**Maintainer:** Ted Hess <thess@kitschensync.net>
<sub>http://xiph.org/vorbis/</sub>

**Description:**

Vorbis is a general purpose audio and music encoding format contemporary to MPEG-4's AAC and TwinVQ, the next generation beyond MPEG audio layer 3. Unlike the MPEG sponsored formats (and other proprietary formats such as RealAudio G2 and Windows' flavor of the month), the Vorbis CODEC specification belongs to the public domain. All the technical details are published and documented, and any software entity may make full use of the format without license
fee, royalty or patent concerns.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/feeds/packages/libvorbis/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
