### PR TITLE
arvancloud-cloudlogs: new package (0.1.0)

### DIFF
--- a/utils/arvancloud-cloudlogs/Makefile
+++ b/utils/arvancloud-cloudlogs/Makefile
@@ -1,0 +1,59 @@
+# Copyright (c) Mohammad Abbasi <mohammad.v184@gmail.com>
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=arvancloud-cloudlogs
+PKG_VERSION:=0.1.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Mohammad Abbasi <mohammad.v184@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/mohammadv184/openwrt-arvancloud-cloudlogs
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_SOURCE_DATE:=2025-11-07
+PKG_MIRROR_HASH:=233208bb96f0d98e0e213b6beae025974413debe66b73f71b3f44e3f9cd5f203
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/arvancloud-cloudlogs
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Forward OpenWrt logd entries to ArvanCloud CloudLogs
+  URL:=https://github.com/mohammadv184/openwrt-arvancloud-cloudlogs
+  DEPENDS:=+libubus +libubox +libcurl
+endef
+
+define Package/arvancloud-cloudlogs/description
+ A small daemon that subscribes to logd via ubus and forwards logs to ArvanCloud CloudLogs service.
+endef
+
+
+TARGET_CFLAGS += -Wall -Wextra
+
+TARGET_LDFLAGS += -lubus -lubox -lcurl
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR)/src \
+		CC="$(TARGET_CC)" \
+		CFLAGS="$(TARGET_CFLAGS)" \
+		LDFLAGS="$(TARGET_LDFLAGS)"
+endef
+
+define Package/arvancloud-cloudlogs/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/arvancloud-cloudlogs $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/arvancloud-cloudlogs.init $(1)/etc/init.d/arvancloud-cloudlogs
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/arvancloud-cloudlogs.conf $(1)/etc/config/arvancloud-cloudlogs
+endef
+
+define Package/arvancloud-cloudlogs/conffiles
+/etc/config/arvancloud-cloudlogs
+endef
+
+$(eval $(call BuildPackage,arvancloud-cloudlogs))

--- a/utils/arvancloud-cloudlogs/files/arvancloud-cloudlogs.conf
+++ b/utils/arvancloud-cloudlogs/files/arvancloud-cloudlogs.conf
@@ -1,0 +1,20 @@
+# OpenWrt UCI configuration for ArvanCloud CloudLogs forwarder
+#
+# - Set 'enabled' to '1' to start the service via procd.
+# - 'api_key' is required; the service will not start without it.
+# - 'device_name' is optional; defaults to system hostname if empty.
+# - 'max_buffer_size' controls the number of log entries buffered.
+# - 'max_buffer_bytes' sets the maximum size of the buffer in bytes.
+# - 'flush_interval_sec' defines how often logs are sent to the server.
+# - 'min_batch_size' is the minimum number of log entries to send in one batch.
+# - 'allow_partial_process' determines if partial processing is allowed on errors.
+
+config arvancloud-cloudlogs 'main'
+	option enabled '0'
+	option api_key ''
+	option device_name ''
+	option max_buffer_size '500'
+	option max_buffer_bytes '524288'
+	option flush_interval_sec '10'
+	option min_batch_size '10'
+	option allow_partial_process '0'

--- a/utils/arvancloud-cloudlogs/files/arvancloud-cloudlogs.init
+++ b/utils/arvancloud-cloudlogs/files/arvancloud-cloudlogs.init
@@ -1,0 +1,86 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=95
+STOP=10
+
+SERVICE_NAME="arvancloud-cloudlogs"
+PROG=/usr/sbin/arvancloud-cloudlogs
+
+. /lib/functions.sh
+
+service_triggers() {
+	procd_add_reload_trigger arvancloud-cloudlogs
+}
+
+resolve_section() {
+	# Prefer named section 'main' if present; otherwise use first anonymous section
+	if uci -q get "arvancloud-cloudlogs.main.enabled" >/dev/null; then
+		SECTION="arvancloud-cloudlogs.main"
+	else
+		SECTION="arvancloud-cloudlogs.@arvancloud-cloudlogs[0]"
+	fi
+
+	return 0
+}
+
+uci_get_cfg() {
+	# uci_get_cfg <option> <default>
+	local opt="$1"
+	local def="$2"
+	local val
+	val=$(uci -q get "$SECTION.$opt" 2>/dev/null)
+	[ -n "$val" ] && {
+		echo "$val"
+		return 0
+	}
+	echo "$def"
+	return 0
+}
+
+start_service() {
+	# Load configuration from the first anonymous section of type arvancloud-cloudlogs
+	resolve_section
+	enabled=$(uci_get_cfg enabled 0)
+	api_key=$(uci_get_cfg api_key '')
+	device_name=$(uci_get_cfg device_name '')
+	max_buffer_size=$(uci_get_cfg max_buffer_size '')
+	max_buffer_bytes=$(uci_get_cfg max_buffer_bytes '')
+	flush_interval_sec=$(uci_get_cfg flush_interval_sec '')
+	min_batch_size=$(uci_get_cfg min_batch_size '')
+	allow_partial_process=$(uci_get_cfg allow_partial_process '')
+
+	[ "$enabled" = "1" ] || {
+		echo "$SERVICE_NAME: disabled in UCI; run 'uci set arvancloud-cloudlogs.main.enabled=1; uci commit arvancloud-cloudlogs' to enable"
+		return 0
+	}
+
+	[ -n "$api_key" ] || {
+		echo "$SERVICE_NAME: api_key is not configured"
+		return 1
+	}
+
+	procd_open_instance
+	procd_set_param command "$PROG"
+	# Only append CLI args when provided in UCI and not empty
+	[ -n "$device_name" ] && procd_append_param command -d "$device_name"
+	[ -n "$max_buffer_size" ] && procd_append_param command -b "$max_buffer_size"
+	[ -n "$max_buffer_bytes" ] && procd_append_param command -m "$max_buffer_bytes"
+	[ -n "$flush_interval_sec" ] && procd_append_param command -f "$flush_interval_sec"
+	[ -n "$min_batch_size" ] && procd_append_param command -t "$min_batch_size"
+	[ -n "$allow_partial_process" ] && procd_append_param command -p "$allow_partial_process"
+	procd_set_param env CLOUDLOGS_API_KEY="$api_key"
+	procd_set_param respawn 3600 5 0
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+reload_service() {
+	stop
+	start
+}
+
+stop_service() {
+	return 0
+}


### PR DESCRIPTION
This commit adds the arvancloud-cloudlogs daemon, which subscribes to logd via ubus and forwards logs in
batches to the ArvanCloud CloudLogs service.

## 📦 Package Details

**Maintainer:** @mohammadv184
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
A small daemon that subscribes to logd via ubus and forwards logs to the ArvanCloud CloudLogs service.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** `24.10.0`
- **OpenWrt Target/Subtarget:**  `mediatek/filogic`
- **OpenWrt Device:** `Xiaomi Mi Router AX3000T`

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
