### PR TITLE
xxhash: update to 0.8.3

### DIFF
--- a/utils/xxhash/Makefile
+++ b/utils/xxhash/Makefile
@@ -11,13 +11,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xxhash
-PKG_VERSION:=0.8.2
-PKG_RELEASE:=2
+PKG_VERSION:=0.8.3
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://github.com/Cyan4973/xxHash
-PKG_MIRROR_HASH:=0602a12e9ecd009f97a2a845fb5e46af69a60f96547952e5b00228f33bed5cdd
+PKG_MIRROR_HASH:=573f8b8ca3b6c2be412f4b68ee0a82f43c32f59607981a8b68f9c8985d979fe1
 
 # The source for the library (xxhash.c and xxhash.h) is BSD
 # The source for the command line tool (xxhsum.c) is GPLv2+


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @julienmalik

**Description:**


Update to version 0.8.3
Fixed compatibility with cmake 4.0
Release notes: https://github.com/Cyan4973/xxHash/releases/tag/v0.8.3

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** ramips/mt7620, ramips/mt7621, mediatek/mt7622
- **OpenWrt Device:** Xiaomi Mi Router R3, Xiaomi Mi Router 4A GE, Xiaomi Redmi Router AX6S

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

