### PR TITLE
qrencode: cmake minimum required version to 3.10

### DIFF
--- a/libs/qrencode/Makefile
+++ b/libs/qrencode/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qrencode
 PKG_VERSION:=4.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://fukuchi.org/works/qrencode

--- a/libs/qrencode/patches/001-cmake-version.patch
+++ b/libs/qrencode/patches/001-cmake-version.patch
@@ -1,0 +1,8 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1.0)
++cmake_minimum_required(VERSION 3.10)
+ 
+ project(QRencode VERSION 4.1.1 LANGUAGES C)
+ 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Jonathan Bennett <JBennett@incomsystems.biz>

**Description:**
- bump to r2 to adjust cmake minimum required version to 3.10

Link: openwrt#27607
Link: openwrt/openwrt@1b48ebd

---

## 🧪 Run Testing Details

- **OpenWrt Version: snapshot**
- **OpenWrt Target/Subtarget: mediatek/filogic**
- **OpenWrt Device: MT6000**

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
