### PR TITLE
cloudflared: fix argument order for tunnel command

### DIFF
--- a/net/cloudflared/Makefile
+++ b/net/cloudflared/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cloudflared
 PKG_VERSION:=2025.10.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cloudflare/cloudflared/tar.gz/$(PKG_VERSION)?

--- a/net/cloudflared/files/cloudflared.init
+++ b/net/cloudflared/files/cloudflared.init
@@ -28,16 +28,6 @@ start_service() {
 	procd_append_param command "--no-autoupdate"
 	procd_append_param command "run"
 
-	config_get token "config" "token"
-	if [ -n "$token" ]; then
-		# Remotely-managed tunnel (recommended by Cloudflare)
-		procd_append_param command "--token" "$token"
-	else
-		# Locally-managed tunnels
-		append_param_arg "config" "/etc/cloudflared/config.yml"
-		append_param_arg "origincert" "/etc/cloudflared/cert.pem"
-	fi
-
 	append_param_arg "edge_bind_address"
 	append_param_arg "edge_ip_version"
 	append_param_arg "grace_period"
@@ -48,6 +38,20 @@ start_service() {
 	append_param_arg "metrics"
 	append_param_arg "loglevel"
 	append_param_arg "logfile"
+
+	config_get token "config" "token"
+	if [ -z "$token" ]; then
+		# Locally-managed tunnels
+		append_param_arg "config" "/etc/cloudflared/config.yml"
+		append_param_arg "origincert" "/etc/cloudflared/cert.pem"
+	fi
+
+	procd_append_param command "run"
+
+	if [ -n "$token" ]; then
+		# Remotely-managed tunnel (recommended by Cloudflare)
+		procd_append_param command "--token" "$token"
+	fi
 
 	procd_set_param respawn
 	procd_set_param stderr 1


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @1715173329
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
- [Tunnel run parameters](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/run-parameters/): Move all global options (`--protocol`, `--loglevel`, `--logfile`, `--config`, `--origincert`, etc.) before the `run` subcommand, and keep `--token` after it to match the correct cloudflared CLI syntax. (close #27785)
- Bump `PKG_RELEASE`

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** GL.iNet GL-MT3000

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [X] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
