### PR TITLE
libid3tag: cmake minimum required version to 3.10

### DIFF
--- a/libs/libid3tag/Makefile
+++ b/libs/libid3tag/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libid3tag
 PKG_VERSION:=0.16.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://codeberg.org/tenacityteam/libid3tag.git

--- a/libs/libid3tag/patches/001-cmake-version.patch
+++ b/libs/libid3tag/patches/001-cmake-version.patch
@@ -1,0 +1,8 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1.0)
++cmake_minimum_required(VERSION 3.10)
+ project(id3tag VERSION 0.16.3)
+ 
+ option(BUILD_SHARED_LIBS "Build dynamic library" ON)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Ted Hess <thess@kitschensync.net>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
- bump to r2 to adjust cmake minimum required version to 3.10

Link: #27607
Link: openwrt/openwrt@1b48ebd

---

## 🧪 Run Testing Details

- **OpenWrt Version: snapshot**
- **OpenWrt Target/Subtarget: mediatek/filogic**
- **OpenWrt Device: MT6000**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
