### PR TITLE
[24.10] hev-socks5-tproxy: update to 2.10.0

### DIFF
--- a/net/hev-socks5-tproxy/Makefile
+++ b/net/hev-socks5-tproxy/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hev-socks5-tproxy
-PKG_VERSION:=2.9.0
+PKG_VERSION:=2.10.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/heiher/hev-socks5-tproxy/releases/download/$(PKG_VERSION)
-PKG_HASH:=2a1c76bfb986e34ab8ba54be9a6c8faf4fa4854b7ee45b0f8e4d108c4c9d4cb2
+PKG_HASH:=4f495a7393afe4b4d36f86e94faddf992def010ff67c02e8ce09693a3a1bd20d
 
 PKG_MAINTAINER:=Ray Wang <git@hev.cc>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @heiher 

**Description:** Update to 2.10.0

Upstream changelog:
https://github.com/heiher/hev-socks5-tproxy/releases/tag/2.10.0

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** armv8
- **OpenWrt Device:** armsr

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.