### PR TITLE
python3: add libatomic as dependency

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 include ../python3-version.mk
 
 PKG_NAME:=python3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=$(PYTHON3_VERSION).$(PYTHON3_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -70,7 +70,7 @@ endef
 define Package/libpython3
 $(call Package/python3/Default)
   TITLE+= core library
-  DEPENDS:=+libpthread
+  DEPENDS:=+libpthread +libatomic
   ABI_VERSION:=$(PYTHON3_VERSION)
 endef
 


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** me, @jefferyto 


**Description:**
For some architectures (like mips24) this solves some build errors.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** mips24 master
- **OpenWrt Target/Subtarget:** mips24 master
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
