### PR TITLE
tini: add patches for minimal cmake version 2.8.12...3.10

### DIFF
--- a/utils/tini/Makefile
+++ b/utils/tini/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tini
 PKG_VERSION:=0.19.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/krallin/tini/tar.gz/v${PKG_VERSION}?

--- a/utils/tini/patches/003-chore-bump-minimum-CMake-to-2.8.12.patch
+++ b/utils/tini/patches/003-chore-bump-minimum-CMake-to-2.8.12.patch
@@ -1,0 +1,21 @@
+From 41685c0ade9793a6ca51ad9f908f92ea5bbb49a9 Mon Sep 17 00:00:00 2001
+From: Bjorn Neergaard <bneergaard@mirantis.com>
+Date: Fri, 27 Jan 2023 08:07:51 -0700
+Subject: [PATCH 1/2] chore: bump minimum CMake to 2.8.12
+
+This is both the last version supported by current CMake, and the
+version in use on Enterprise Linux 7.
+
+Signed-off-by: Bjorn Neergaard <bneergaard@mirantis.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 2.8.0)
++cmake_minimum_required (VERSION 2.8.12)
+ project (tini C)
+ 
+ # Config

--- a/utils/tini/patches/004-chore-allow-CMake-though-to-3.10.patch
+++ b/utils/tini/patches/004-chore-allow-CMake-though-to-3.10.patch
@@ -1,0 +1,31 @@
+From 32e503365205cac479ad2110d72d18b2072fd93c Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Fri, 28 Mar 2025 19:10:02 +1100
+Subject: [PATCH 2/2] chore: allow CMake though to 3.10
+
+This is allows the build with cmake-4.0.0 without deprecation warnings.
+
+use min...max syntax to allow build with newer cmake.
+ref: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
+
+Fixes:
+CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
+  Compatibility with CMake < 3.5 has been removed from CMake.
+
+  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+  to tell CMake that the project requires at least <min> but has been updated
+  to work with policies introduced by <max> or earlier.
+
+  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 2.8.12)
++cmake_minimum_required (VERSION 2.8.12...3.10)
+ project (tini C)
+ 
+ # Config


### PR DESCRIPTION
## 📦 Package Details


**Maintainer:** @G-M0N3Y-2503

**Description:**
tini: backport upstream patches to increase the minimal cmake version to 3.10. This fixes this compilation error (https://github.com/openwrt/packages/issues/27607)
Patch 3: https://github.com/krallin/tini/commit/0b44d3665869e46ccbac7414241b8256d6234dc4
Patch 4: https://github.com/krallin/tini/commit/071c715e376e9ee0ac1a196fe8c38bcb61ad385c

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2708 
- **OpenWrt Device:** Raspberry Pi Zero 1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
It is cherry-picked from the original repository via git cherry-pick
