### PR TITLE
Mosquitto cmake min version fix

### DIFF
--- a/net/mosquitto/patches/001_cmake_fix.patch
+++ b/net/mosquitto/patches/001_cmake_fix.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,7 +4,7 @@
+ # To configure the build options either use the CMake gui, or run the command
+ # line utility including the "-i" option.
+ 
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.10)
+ cmake_policy(SET CMP0042 NEW)
+ 
+ project(mosquitto)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @karlp 

**Description:** Fix CMake min version. See https://github.com/openwrt/openwrt/pull/20265.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** `ramips/mt7621`
- **OpenWrt Device:** `wodesys,wd-r1802u`

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
