### PR TITLE
protobuf: add cmake 4.x compatibility, remove maintainer

### DIFF
--- a/libs/protobuf/Makefile
+++ b/libs/protobuf/Makefile
@@ -9,13 +9,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=protobuf
 PKG_VERSION:=3.17.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-cpp-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/google/protobuf/releases/download/v$(PKG_VERSION)
 PKG_HASH:=51cec99f108b83422b7af1170afd7aeb2dd77d2bcbb7b6bad1f92509e9ccf8cb
 
-PKG_MAINTAINER:=Ken Keys <kkeys@caida.org>
+PKG_MAINTAINER:=
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:google:protobuf

--- a/libs/protobuf/patches/001-cmake4.patch
+++ b/libs/protobuf/patches/001-cmake4.patch
@@ -1,0 +1,9 @@
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ # Minimum CMake required
+-cmake_minimum_required(VERSION 3.1.3)
++cmake_minimum_required(VERSION 3.10)
+ 
+ if(protobuf_VERBOSE)
+   message(STATUS "Protocol Buffers Configuring...")


### PR DESCRIPTION
Add a patch for cmake 4.x compatibility.
Remove maintainer who has not been active for several years.


**Maintainer:** @kenkeys  who has not been active with this package since 2018

Compile-tested for MT6000.
