### PR TITLE
cloudflared: fix duplicate "run" command argument

### DIFF
--- a/net/cloudflared/Makefile
+++ b/net/cloudflared/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cloudflared
 PKG_VERSION:=2025.11.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cloudflare/cloudflared/tar.gz/$(PKG_VERSION)?

--- a/net/cloudflared/files/cloudflared.init
+++ b/net/cloudflared/files/cloudflared.init
@@ -26,7 +26,6 @@ start_service() {
 	procd_open_instance "$CONF"
 	procd_set_param command "$PROG" "tunnel"
 	procd_append_param command "--no-autoupdate"
-	procd_append_param command "run"
 
 	append_param_arg "edge_bind_address"
 	append_param_arg "edge_ip_version"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @1715173329
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
This pull request fixes a regression introduced in PR #27786 that prevented the `cloudflared` service from starting.

The changes include:
1.  Removing a duplicate and misplaced `run` argument from the init script that caused a command syntax error.
2.  Bump `PKG_RELEASE`

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Xiaomi Redmi Router AX6000 (OpenWrt U-Boot layout)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
