### PR TITLE
trafficshaper: remove test codes

### DIFF
--- a/net/trafficshaper/Makefile
+++ b/net/trafficshaper/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=trafficshaper
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 
 PKG_LICENSE:=GPL-2.0-or-later
@@ -19,7 +19,7 @@ define Package/trafficshaper
   SECTION:=net
   CATEGORY:=Network
   TITLE:=WAN traffic shaper based on LAN addresses
-  DEPENDS:=+tc +kmod-sched-core +kmod-sched-connmark +kmod-ifb +iptables +kmod-sched-cake +iptables-mod-conntrack-extra
+  DEPENDS:=+tc +kmod-sched-core +kmod-sched-connmark +kmod-ifb +iptables +IPV6:ip6tables +kmod-sched-cake +iptables-mod-conntrack-extra
   PKGARCH:=all
 endef
 

--- a/net/trafficshaper/files/trafficshaper.init
+++ b/net/trafficshaper/files/trafficshaper.init
@@ -47,9 +47,6 @@ IP6T="debug_exec ip6tables -w 5"
 #QDISC="cake autorate_ingress internet ethernet diffserv4 triple-isolate"
 QDISC="cake"
 
-REQ_MODULES="sch_htb sch_cake act_connmark act_mirred em_u32"
-REQ_CMDS="ip tc iptables"
-
 preinit(){
 	[ "$LOGLEVEL" -ge 1 ] && e() { msg ERROR "$@"; } || e() { true; }
 	[ "$LOGLEVEL" -ge 2 ] && v() { msg INFO "$@"; } || v() { true; }
@@ -59,15 +56,6 @@ preinit(){
 }
 
 requires() {
-	for module in $REQ_MODULES; do
-		[ -d /sys/module/$module ] || insert_modules "$module" ||
-			die 2 "cannot load $module. Please install kmod-$module"
-	done
-	for cmd in $REQ_CMDS; do
-		command -v $cmd &>/dev/null ||
-			die 2 "cannot find command $cmd. Please install $cmd"
-	done
-
 	if ! command -v ip6tables &>/dev/null; then
 		v "Disabling IPv6 as ip6tables was not found"
 		IP6T=true


### PR DESCRIPTION
Remove requirement test code as it is already supplied by package dependencies
Depend on ip6tables to satisfy description claim

maintainer: @luizluca 

Fixes: #27805
