### PR TITLE
CI: mark and close PRs with formality issues

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -1,0 +1,30 @@
+name: Mark and close stale PRs
+
+on:
+  schedule:
+    # Run once a day at 05:30
+    - cron: '30 5 * * *'
+
+permissions:
+  actions: write
+  # BUG: required due to a bug in the stale action:
+  #      https://github.com/actions/stale/issues/840#issuecomment-2195082494
+  issues: read
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Mark and close PRs with formality issues
+        uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: |
+            This PR is stale because it has been open for 14 days with no activity and has the "not following guidelines" label.
+            It will be closed if no further activity occurs within 14 days.
+          close-pr-message: 'This PR was closed because it has been marked stale for 14 days with no activity.'
+          days-before-stale: 14
+          days-before-close: 14
+          only-labels: 'not following guidelines'
+          stale-pr-label: 'stale'


### PR DESCRIPTION
**Description:**

Add a recurring workflow that runs every day at 5:30 and marks all PRs that have formality check failures (i.e. marked as 'not following guidelines') that have not been active in the past 14 days as stale. Close stale PRs after 14 more days.

The stale/close days and the schedule are just a suggestion.

This can be expanded to mark stale issue as well.

Loosely depends on:

- [x] #27790 

---

## 🧪 Run Testing Details

Tested in my local fork.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.