### PR TITLE
netbird: update to 0.59.12

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.58.2
+PKG_VERSION:=0.59.12
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=bd423e49d1bf27fc4ad0de68deacbfb48c7d964982744e102d1cd3766d09e024
+PKG_HASH:=2f0bdd45996f46f2e2c1dbf5a6712bba38a06cbfb7e4c00f814b0ffe149d7c6d
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

changelog: https://github.com/netbirdio/netbird/releases/tag/v0.59.12

I want to highlight the new **remote access to SSH and RDP resources directly from your web browser** feature added in [`v0.59.0`](github.com/netbirdio/netbird/releases/tag/v0.59.0). I haven't tested the **RDP** part, but the **SSH** feature works like a charm. I personally don't need this feature, so I'll add it to my list below but will probably never test it again.

**Tests checklist:**
- [x] Connection to the NetBird Cloud Dashboard (not self-hosted).
- [x] Firewall configured with nftables.
- [x] Connection established in P2P mode.
- [x] `wireguard` kernel mode active.
- [x] Routes configured between my homelab and my cloud server.
- [x] `netbird` DNS server functioning correctly.
- [ ] NAT operational (not needed by me at this time, may consider testing in the future).
- [ ] Permissions rules is enforced (not needed by me at this time, may consider testing in the future).
- [x] SSH access via browser.

**Additional information:**

`x86_64` is running in a virtual machine using [`incus`](https://github.com/lxc/incus).
The package(s) was compiled with the container [`sdk`](https://github.com/openwrt/docker).
The `OpenWrt` image(s) was built using the container [`imagebuilder`](https://github.com/openwrt/docker).
<sub>No more container or [`distrobuilder`](https://github.com/lxc/distrobuilder).</sub>

You can view my repository with the patch applied and the automated build here:
- https://github.com/wehagy/owpib/tree/netbird/update
  <sub>This repository branch is temporary and will be removed or modified after the merge.</sub>

You can find my artifacts here:
- https://github.com/wehagy/owpib/actions/runs/19114068118

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT r31660-32c46b569f
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.