### PR TITLE
frr: update to 10.4.1

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -7,19 +7,18 @@
 
 include $(TOPDIR)/rules.mk
 PKG_NAME:=frr
-PKG_VERSION:=10.3.1
+PKG_VERSION:=10.4.1
 PKG_RELEASE:=1
-PKG_SOURCE_DATE:=2025-06-08
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_DATE).tar.gz
-PKG_SOURCE_VERSION:=44789ae469c30896d8b13b30bd429c01a4b0d96e
-PKG_SOURCE_URL:=https://codeload.github.com/FRRouting/frr/tar.gz/$(PKG_SOURCE_VERSION)?
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/FRRouting/frr/tar.gz/$(PKG_NAME)-$(PKG_VERSION)?
+PKG_HASH:=8e4003eaba168626c5ea7a6735f2c85c87b04214e6f8c8f2715b21f8ae40970b
 
-PKG_HASH:=b4c341be50dc76a3b96727dc41310745171e0d9affb137b8894d14f6eb6e226a
+
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
-HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION)
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-2.0-only LGPL-2.1-only
 PKG_CPE_ID:=cpe:/a:ffrouting:ffrouting
@@ -215,8 +214,9 @@ define Package/frr-watchfrr/install
 endef
 
 define Package/frr-zebra/install
-	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/usr/lib
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/zebra $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libmlag_pb.so* $(1)/usr/lib/
 endef
 
 define Package/frr-pythontools/install

--- a/net/frr/files/frrcommon.sh
+++ b/net/frr/files/frrcommon.sh
@@ -35,7 +35,7 @@ FRR_DEFAULT_PROFILE="traditional" # traditional / datacenter
 # - keep zebra first
 # - watchfrr does NOT belong in this list
 
-DAEMONS="zebra mgmtd bgpd ripd ripngd ospfd ospf6d isisd babeld pimd pim6d ldpd nhrpd eigrpd sharpd pbrd staticd bfdd fabricd vrrpd pathd"
+DAEMONS="mgmtd zebra bgpd ripd ripngd ospfd ospf6d isisd babeld pimd pim6d ldpd nhrpd eigrpd sharpd pbrd staticd bfdd fabricd vrrpd pathd"
 
 RELOAD_SCRIPT="$D_PATH/frr-reload.py"
 

--- a/net/frr/patches/098-fix_mips_libyang.patch
+++ b/net/frr/patches/098-fix_mips_libyang.patch
@@ -1,6 +1,6 @@
 --- a/lib/northbound.h
 +++ b/lib/northbound.h
-@@ -711,11 +711,7 @@ struct frr_yang_module_info {
+@@ -747,11 +747,7 @@ struct frr_yang_module_info {
  
  		/* Priority - lower priorities are processed first. */
  		uint32_t priority;

--- a/net/frr/patches/997-reverse_python_test.patch
+++ b/net/frr/patches/997-reverse_python_test.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -932,7 +932,6 @@ AC_DEFINE_UNQUOTED([DFLT_NAME], ["$DFLT_
+@@ -954,7 +954,6 @@ AC_DEFINE_UNQUOTED([DFLT_NAME], ["$DFLT_
  #
  
  AS_IF([test "$host" = "$build"], [


### PR DESCRIPTION
also switch to codeload release images, version 10.5.0 needs more work
also fix https://github.com/openwrt/packages/issues/27702
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

update to 10.4.1, 10.5.0 needs more work as mgmtd fails to start with some locking issue

```
Tue Nov 11 21:18:06 2025 daemon.err mgmtd[9770]: [HD3VA-5FCFX] mgmt_ds_lock: ERROR: lock already taken on DS:running by session-id 2
Tue Nov 11 21:18:06 2025 daemon.err mgmtd[9770]: [VNSS1-Q9XX7] XXX txn in progress, retry init

```


---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** x86-64
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
