### PR TITLE
cereal: Update to 1.3.2

### DIFF
--- a/libs/cereal/Makefile
+++ b/libs/cereal/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cereal
-PKG_VERSION:=1.3.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.3.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/USCiLab/cereal/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=329ea3e3130b026c03a4acc50e168e7daff4e6e661bc6a7dfec0d77b570851d5
+PKG_HASH:=16a7ad9b31ba5880dac55d62b5d6f243c3ebc8d46a3514149e56b5e7ea81f85f
 
 PKG_MAINTAINER:=David Woodhouse <dwmw2@infradead.org>
 PKG_LICENSE:=BSD-3-Clause
@@ -26,6 +26,7 @@ include $(INCLUDE_DIR)/cmake.mk
 
 CMAKE_OPTIONS += \
 	-DCMAKE_CXX_FLAGS=-latomic \
+	-DBUILD_DOC=OFF \
 	-DJUST_INSTALL_CEREAL=ON \
 	-DSKIP_PORTABILITY_TEST=ON \
 	-DSKIP_PERFORMANCE_COMPARISON=ON \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dwmw2

**Description:**
Disable build for useless docs.

Changelog:
- https://github.com/USCiLab/cereal/releases/tag/v1.3.1
- https://github.com/USCiLab/cereal/releases/tag/v1.3.2

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** rockchip/armv8
- **OpenWrt Device:** n/a

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.