### PR TITLE
libyang: add dependency on libxxhash

### DIFF
--- a/libs/libyang/Makefile
+++ b/libs/libyang/Makefile
@@ -31,7 +31,7 @@ define Package/libyang
   CATEGORY:=Libraries
   TITLE:=YANG data modeling language library
   URL:=https://github.com/CESNET/libyang
-  DEPENDS:=+libpcre2 +libpthread
+  DEPENDS:=+libpcre2 +libpthread +libxxhash
 endef
 
 define Package/yanglint


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** Jakov Smolic <jakov.smolic@sartura.hr>

**Description:**

Fix #27856

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** kvm

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.