### PR TITLE
python-toml: fix build dependency on python-setuptools

### DIFF
--- a/lang/python/python-toml/Makefile
+++ b/lang/python/python-toml/Makefile
@@ -13,6 +13,7 @@ PKG_RELEASE:=1
 
 PYPI_NAME:=toml
 PKG_HASH:=b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
+PKG_BUILD_DEPENDS:=python-setuptools/host
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Jan Pavlinec [jan.pavlinec1@gmail.com](mailto:jan.pavlinec1@gmail.com)

**Description:**

Fix #27855

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** kvm

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.