### PR TITLE
mc: update to 4.8.33

### DIFF
--- a/utils/mc/patches/020-fix-mouse-handling-newer-terminfo.patch
+++ b/utils/mc/patches/020-fix-mouse-handling-newer-terminfo.patch
@@ -1,0 +1,11 @@
+--- a/lib/tty/tty.c
++++ b/lib/tty/tty.c
+@@ -408,7 +408,7 @@ tty_init_xterm_support (gboolean is_xter
+     if (xmouse_seq != NULL)
+     {
+         if (strcmp (xmouse_seq, ESC_STR "[<") == 0)
+-            xmouse_seq = ESC_STR "[M";
++            xmouse_seq = NULL;
+ 
+         xmouse_extended_seq = ESC_STR "[<";
+     }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** N/A


**Description:**
mc: update to 4.8.33
Drop unnecessary patches. Changes in upstream repository already include them.
Changelog: https://raw.githubusercontent.com/MidnightCommander/mc/refs/tags/4.8.33/doc/NEWS

Revert "mc: drop patches to handle newer terminfo"
Unfortunately, without this patch, there's still a problem with mouse handling using xterm-256color/busybox/ash.
A partial workaround is to run mc through screen.
After applying the fix, it works in both cases.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** mvebu/cortexa9
- **OpenWrt Device:** wrt1200ac

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
