### PR TITLE
iperf3: update to 3.20

### DIFF
--- a/net/iperf3/Makefile
+++ b/net/iperf3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
-PKG_VERSION:=3.19.1
+PKG_VERSION:=3.20
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.es.net/pub/iperf
-PKG_HASH:=dc63f89ec581ea99f8b558d8eb35109de06383010db5a1906c208a562ba0c270
+PKG_HASH:=3acc572d1ecca4e0b20359c7bf0132ddc80d982efeee20c86f6726a9a6094388
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @nbd168 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Update to latest upstream release.

Changelog: https://github.com/esnet/iperf/releases/tag/3.20


## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** : x86/64-glibc
- **OpenWrt Device:** Intel N150

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
