### PR TITLE
zmq: add cmake 4.x compatibility

### DIFF
--- a/libs/zmq/Makefile
+++ b/libs/zmq/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zeromq
 PKG_VERSION:=4.3.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/zeromq/libzmq/releases/download/v$(PKG_VERSION)

--- a/libs/zmq/patches/029-cmake-1.patch
+++ b/libs/zmq/patches/029-cmake-1.patch
@@ -1,0 +1,36 @@
+From 34f7fa22022bed9e0e390ed3580a1c83ac4a2834 Mon Sep 17 00:00:00 2001
+From: rp42 <rp42@users.noreply.github.com>
+Date: Mon, 30 Dec 2024 11:01:39 +0000
+Subject: [PATCH] cmake_minimum_required() before project()
+
+ * Without this CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded (MT) Windows builds still produced incompatible MultiThreadedDLL (MD) output.
+
+ * Resolves following warning:
+
+CMake Warning (dev) at CMakeLists.txt:2 (project):
+  cmake_minimum_required() should be called prior to this top-level project()
+  call.
+
+ * Use ${CMAKE_HOST_SYSTEM_NAME} as ${CMAKE_SYSTEM_NAME} not set before project().
+---
+ CMakeLists.txt | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,12 +1,13 @@
+ # CMake build script for ZeroMQ
+-project(ZeroMQ)
+ 
+-if(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
++if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Darwin)
+   cmake_minimum_required(VERSION 3.0.2)
+ else()
+   cmake_minimum_required(VERSION 2.8.12)
+ endif()
+ 
++project(ZeroMQ)
++
+ include(CheckIncludeFiles)
+ include(CheckCCompilerFlag)
+ include(CheckCXXCompilerFlag)

--- a/libs/zmq/patches/030-cmake-2.patch
+++ b/libs/zmq/patches/030-cmake-2.patch
@@ -1,0 +1,47 @@
+From b91a6201307b72beb522300366aad763d19b1456 Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Thu, 20 Mar 2025 14:51:18 +0100
+Subject: [PATCH] set upper bound in cmake_minimum_required
+
+setting an upper bound improves forward-compatibility as legacy version support is dropped
+
+- 3.5 compat is deprecated in 3.27 (2023), removed in 4.0 (2025)
+- 3.10 compat is deprecated in 3.31 (2024)
+---
+ CMakeLists.txt           | 4 ++--
+ tests/CMakeLists.txt     | 2 +-
+ unittests/CMakeLists.txt | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,9 +1,9 @@
+ # CMake build script for ZeroMQ
+ 
+ if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Darwin)
+-  cmake_minimum_required(VERSION 3.0.2)
++  cmake_minimum_required(VERSION 3.0.2...3.31)
+ else()
+-  cmake_minimum_required(VERSION 2.8.12)
++  cmake_minimum_required(VERSION 2.8.12...3.31)
+ endif()
+ 
+ project(ZeroMQ)
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ # CMake build script for ZeroMQ tests
+-cmake_minimum_required(VERSION "2.8.1")
++cmake_minimum_required(VERSION 2.8.1...3.31)
+ 
+ # On Windows: solution file will be called tests.sln
+ project(tests)
+--- a/unittests/CMakeLists.txt
++++ b/unittests/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ # CMake build script for ZeroMQ unit tests
+-cmake_minimum_required(VERSION "2.8.1")
++cmake_minimum_required(VERSION 2.8.1...3.31)
+ 
+ set(unittests
+     unittest_ypipe


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @srdgame, @neheb

**Description:**

Add upstream cmake 4.x patches.

Related:
- #27607

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

Tested building and running mjpg-streamer (requires a cmake patch as well).

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable