### PR TITLE
sysrepo: add cmake 4.x compatibility

### DIFF
--- a/net/sysrepo/patches/010-build-UPDATE-set-max-cmake-version.patch
+++ b/net/sysrepo/patches/010-build-UPDATE-set-max-cmake-version.patch
@@ -1,0 +1,17 @@
+From e81f2b5f9ad8ca61df7142f6eaae6e67e79be50f Mon Sep 17 00:00:00 2001
+From: Michal Vasko <mvasko@cesnet.cz>
+Date: Wed, 31 Jan 2024 09:44:41 +0100
+Subject: [PATCH] build UPDATE set max cmake version
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 2.8.12...3.28.1)
+ 
+ project(sysrepo)
+ set(SYSREPO_DESC "YANG-based system repository for all-around configuration management.")


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jsmolic

**Description:**
Upstream backport.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** none
- **OpenWrt Device:** none

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable