### PR TITLE
tcpreplay: add libbpf dependency

### DIFF
--- a/net/tcpreplay/Makefile
+++ b/net/tcpreplay/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tcpreplay
 PKG_VERSION:=4.5.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/appneta/tcpreplay/releases/download/v$(PKG_VERSION)
@@ -35,7 +35,7 @@ define Package/tcpreplay/default
   CATEGORY:=Network
   URL:=http://tcpreplay.appneta.com/
   MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
-  DEPENDS:=+librt +libpcap +libdnet +USE_MUSL:musl-fts
+  DEPENDS:=+librt +libpcap +libdnet +libbpf +USE_MUSL:musl-fts
 endef
 
 define Package/tcpbridge


### PR DESCRIPTION
Since compiling tcpbridge requires linking libbpf.so.1, compiling tcpbridge first may result in compilation failure, like: 
Package tcpbridge is missing dependencies for the following libraries: libbpf.so.1

The simplest way to solve it is to add libbpf dependency in Makefile

## 📦 Package Details

**Maintainer:** Alexandru Ardelean <ardeleanalex@gmail.com>

**Description:**
Add a dependency on libbpf in tcprepaly

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r31857-501f4edb04
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** CMCC RAX3000M

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
