### PR TITLE
busybox-httpd: add BusyBox HTTP daemon

### DIFF
--- a/net/busybox-httpd/Makefile
+++ b/net/busybox-httpd/Makefile
@@ -1,0 +1,57 @@
+#
+# Copyright (C) 2007-2021 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=busybox-httpd
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Sergey Ponomarev <stokito@gmail.com>
+PKG_LICENSE:=ISC
+
+include $(INCLUDE_DIR)/package.mk
+
+# The BB httpd needs to be first enabled for compilation CONFIG_BUSYBOX_CONFIG_HTTPD=y.
+# Using `make menuconfig`:
+# Base System / Customize Busybox options / Network utilities / httpd
+#   Support Common Gateway Interface (CGI)
+#   Set REMOTE_PORT environment variable for CGI
+#   Recommended: Support 'Ranges:' header
+#   Recommended: Add Last-Modified header to response
+#   Recommended: Enable HTTP authentication
+# Note that it conflicts with uhttpd so disable it: `uci set uhttpd.main.enabled=0; uci commit`
+define Package/busybox-httpd
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Web Servers/Proxies
+  TITLE:=BusyBox HTTP server
+  URL:=https://openwrt.org/docs/guide-user/services/webserver/http.httpd
+  DEPENDS:=@BUSYBOX_CONFIG_HTTPD
+  PKGARCH:=all
+endef
+
+define Package/busybox-httpd/description
+  A service package to run BusyBox HTTP daemon.
+endef
+
+define Package/busybox-httpd/conffiles
+/etc/httpd.conf
+/etc/config/httpd
+endef
+
+define Build/Compile
+endef
+
+define Package/busybox-httpd/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/etc/init.d/busybox-httpd $(1)/etc/init.d/busybox-httpd
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/etc/config/httpd $(1)/etc/config/httpd
+endef
+
+$(eval $(call BuildPackage,busybox-httpd))

--- a/net/busybox-httpd/files/etc/config/httpd
+++ b/net/busybox-httpd/files/etc/config/httpd
@@ -1,0 +1,6 @@
+config httpd main
+	option enabled 1
+	option port 80
+	option home /www
+	option realm ''
+	option c_file ''

--- a/net/busybox-httpd/files/etc/init.d/busybox-httpd
+++ b/net/busybox-httpd/files/etc/init.d/busybox-httpd
@@ -1,0 +1,39 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2025 OpenWrt.org
+START=51
+USE_PROCD=1
+
+validate_section_httpd() {
+	uci_load_validate httpd httpd "$1" "$2" \
+		'enabled:bool:1' \
+		'port:port:80' \
+		'home:directory:/www' \
+		'realm:string' \
+		'c_file:file'
+}
+
+start_httpd_instance() {
+	[ "$2" = 0 ] || {
+		echo "validation failed"
+		return 1
+	}
+	[ "$enabled" = 0 ] && return 1
+	local cfg="$1"
+	procd_open_instance "$cfg"
+	procd_set_param respawn
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param command /usr/sbin/httpd -f
+	procd_append_param command -p "$port"
+	procd_append_param command -h "$home"
+	[ -z "$realm" ] && realm="$(cat /proc/sys/kernel/hostname)"
+	procd_append_param command -r "$realm"
+	[ -n "$c_file" ] && procd_append_param command -c "$c_file"
+	procd_close_instance
+}
+
+start_service()
+{
+	config_load httpd
+	config_foreach validate_section_httpd httpd start_httpd_instance
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me @stokito

**Description:**
The BB has a small web server that OpenWrt used before migrating to uhttpd https://openwrt.org/docs/guide-user/base-system/httpd
It supports CGI (Lua, ucode) and Luci.
The new package uses the same config options in `/etc/config/httpd` as if was years ago to avoid confusion.

It's smaller than uhttpd and can be useful for small routers and custom firmwares. It doesn't support TLS but it has some basic reverse proxy that is also may be interesting.

Documentation: https://openwrt.org/docs/guide-user/services/webserver/http.httpd

Reload is not implemented. But the BB httpd can re-read /etc/httpd.conf on SIGHUP but it's unlikely to be needed.


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
