### PR TITLE
realtek-poe: increase version to v1.3.1

### DIFF
--- a/utils/realtek-poe/Makefile
+++ b/utils/realtek-poe/Makefile
@@ -3,14 +3,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=realtek-poe
-PKG_VERSION:=1.3
+PKG_VERSION:=1.3.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_MAINTAINER:=Martin Kennedy <hurricos@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Hurricos/realtek-poe/archive/refs/tags/v$(PKG_VERSION)
-PKG_HASH:=b006ebf74dc552f82ef6e7b01a10bf2c5b8e46b5c1b833f0512946e76da1b9ca
+PKG_HASH:=e4d3b8fec1bd7cdab0355fd65b66e0f598d223e1dc92f460f28dfa5a94566c9a
 CMAKE_SOURCE_SUBDIR:=src
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
This enables cmake 3.10, and allows realtek-poe to be built again.

## 📦 Package Details

**Maintainer:** @Hurricos (me)

**Description:**
Competes with https://github.com/openwrt/packages/pull/27888, but instead of introducing a patch, actually bumps realtek-poe by bumping the built version.

---

## 🧪 Run Testing Details

I am genuinely assuming https://github.com/openwrt/packages/pull/27888 tested this -- so, ask @hauke.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

