### PR TITLE
python-pynacl: fix typo in PKG_BUILD_DEPENDS

### DIFF
--- a/lang/python/python-pynacl/Makefile
+++ b/lang/python/python-pynacl/Makefile
@@ -11,7 +11,11 @@ PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DEPENDS:=python3-setuptools/host libffi/host python-cffi/host  # cffi>=1.4.1
+PKG_BUILD_DEPENDS:= \
+	python3/host \
+	python-setuptools/host \
+	libffi/host \
+	python-cffi/host  # cffi>=1.4.1
 
 PYTHON3_PKG_BUILD_VARS:=SODIUM_INSTALL=system
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jmarcet 

**Description:**

Fixes
   https://github.com/openwrt/packages/pull/27863/commits/0c11fe96b000583b50565b1788cde6fb56131b62

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
