### PR TITLE
tgt: update to 1.0.97

### DIFF
--- a/net/tgt/Makefile
+++ b/net/tgt/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tgt
-PKG_VERSION:=1.0.96
+PKG_VERSION:=1.0.97
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fujita/tgt/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=d613a345fef795e76766e50775e123fb0bf43b10d6e26f11910647ed9639621a
+PKG_HASH:=459a3ee133fbd850519cde15784664934d29e5dc9680f21142247746e62d9082
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-2.0-only
@@ -18,6 +18,8 @@ PKG_CPE_ID:=cpe:/a:zaal:tgt
 PKG_BUILD_FLAGS:=no-mips16
 PKG_INSTALL:=1
 
+PKG_CONFIG_DEPENDS:=CONFIG_PACKAGE_tgt_without_aio
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/tgt
@@ -25,7 +27,7 @@ define Package/tgt
 	CATEGORY:=Network
 	URL:=https://github.com/fujita/tgt
 	TITLE:=userspace iSCSI target
-	DEPENDS:=+libpthread +libaio
+	DEPENDS:=+libpthread +!PACKAGE_tgt_without_aio:libaio
 endef
 
 define Package/tgt/description
@@ -34,6 +36,25 @@ that supports the iSCSI and iSER transport protocols and that also
 supports multiple methods for accessing block storage. Tgt consists of
 user-space daemon and tools.
 endef
+
+define Package/tgt/config
+	config PACKAGE_tgt_without_aio
+	depends on PACKAGE_tgt
+	bool "Build without AIO support"
+	default n
+	help
+		Disable aio bs type, don't depend on libaio
+
+
+	config PACKAGE_tgt_without_sheepdog
+	depends on PACKAGE_tgt
+	bool "Build without Sheepdog support"
+	default y
+	help
+		Disable sheepdog bs type to save some space
+endef
+
+MAKE_FLAGS += WITHOUT_AIO=$(CONFIG_PACKAGE_tgt_without_aio) WITHOUT_SHEEPDOG=$(CONFIG_PACKAGE_tgt_without_sheepdog)
 
 define Build/Compile
 	$(call Build/Compile/Default,programs)

--- a/net/tgt/patches/020-usr_Makefile.patch
+++ b/net/tgt/patches/020-usr_Makefile.patch
@@ -14,16 +14,26 @@
  CFLAGS += -DUSE_TIMERFD
  endif
  
-@@ -25,7 +25,7 @@ ifneq ($(SD_NOTIFY),)
+@@ -25,11 +25,17 @@ ifneq ($(SD_NOTIFY),)
  CFLAGS += -DUSE_SYSTEMD
  endif
  
 -ifneq ($(shell test -e /usr/include/sys/eventfd.h && test -e /usr/include/libaio.h && echo 1),)
++ifeq ($(WITHOUT_AIO),)
 +ifneq ($(shell test -n $(shell find $(STAGING_DIR)/usr/include -name "eventfd.h" | head -n1) && test -n $(shell find $(STAGING_DIR)/usr/include -name "libaio.h" | head -n1) && echo 1),)
  CFLAGS += -DUSE_EVENTFD
  TGTD_OBJS += bs_aio.o
  LIBS += -laio
-@@ -56,7 +56,7 @@ ifneq ($(SD_NOTIFY),)
+ endif
++endif
++
++ifeq ($(WITHOUT_SHEEPDOG),)
++TGTD_OBJS += bs_sheepdog.o
++endif
+ 
+ ifneq ($(ISCSI_RDMA),)
+ TGTD_OBJS += iscsi/iser.o iscsi/iser_text.o
+@@ -56,11 +62,11 @@ ifneq ($(SD_NOTIFY),)
  LIBS += -lsystemd
  endif
  
@@ -32,7 +42,12 @@
  TGTD_OBJS += tgtd.o mgmt.o target.o scsi.o log.o driver.o util.o work.o \
  		concat_buf.o parser.o spc.o sbc.o mmc.o osd.o scc.o smc.o \
  		ssc.o libssc.o bs_rdwr.o bs_ssc.o \
-@@ -83,14 +83,6 @@ tgtadm: $(TGTADM_OBJS)
+-		bs_null.o bs_sg.o bs.o libcrc32c.o bs_sheepdog.o
++		bs_null.o bs_sg.o bs.o libcrc32c.o
+ 
+ TGTD_DEP = $(TGTD_OBJS:.o=.d)
+ 
+@@ -83,14 +89,6 @@ tgtadm: $(TGTADM_OBJS)
  
  -include $(TGTADM_DEP)
  


### PR DESCRIPTION
- bump the version
- make aio support optional, enabled by default
- make sheepdog support optional, disabled by default

## 📦 Package Details

**Maintainer:** me

**Description:**
- no functional changes compared to 1.0.96
- make aio and sheepdog backing store types optional
```
-rwxr-xr-x 1 wrt wrt 376000 Nov 19 14:06 /tmp/tgtd-aio-nosheepdog
-rwxr-xr-x 1 wrt wrt 376112 Nov 19 13:24 /tmp/tgtd-aio-sheepdog
-rwxr-xr-x 1 wrt wrt 310336 Nov 19 13:13 /tmp/tgtd-noaio-nosheepdog
-rwxr-xr-x 1 wrt wrt 375984 Nov 19 14:07 /tmp/tgtd-noaio-sheepdog
```
---

## 🧪 Run Testing Details

- **OpenWrt Version:** r31864+2-2cce634a9e
- **OpenWrt Target/Subtarget:** qualcommax/ipq807x
- **OpenWrt Device:** Dynalink DL-WRX36

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
