### PR TITLE
avahi: define missing DEFAULT_VARIANT and add conflicts

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -82,10 +82,12 @@ define Package/avahi-dbus-daemon
   $(call Package/avahi/Default)
   PROVIDES:=avahi-daemon
   VARIANT:=dbus
+  DEFAULT_VARIANT:=1
   SUBMENU:=IP Addresses and Names
   DEPENDS:=+libavahi-dbus-support +libexpat +librt +libdaemon
   TITLE+= (daemon)
   USERID:=avahi=105:avahi=105
+  CONFLICTS:=libavahi-nodbus-support
 endef
 
 define Package/avahi-nodbus-daemon
@@ -167,8 +169,10 @@ endef
 define Package/libavahi-dbus-support
   $(call Package/libavahi/Default)
   VARIANT:=dbus
-  DEPENDS:=+dbus
+  DEFAULT_VARIANT:=1
+  DEPENDS:=+PACKAGE_libavahi-dbus-support:dbus
   TITLE+= (D-Bus support)
+  CONFLICTS:=libavahi-nodbus-support
 endef
 
 define Package/libavahi-nodbus-support
@@ -207,6 +211,7 @@ define Package/libavahi-client
   VARIANT:=dbus
   DEPENDS:=+avahi-dbus-daemon
   TITLE+= (libavahi-client library)
+  CONFLICTS:=libavahi-nodbus-support
 endef
 
 define Package/libavahi-client/description
@@ -224,6 +229,7 @@ define Package/avahi-utils
   VARIANT:=dbus
   DEPENDS:=+libavahi-client +libgdbm
   TITLE+= (utilities)
+  CONFLICTS:=libavahi-nodbus-support
 endef
 
 define Package/avahi-utils/description


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @

**Description:**
- Add DEFAULT_VARIANT to "avahi-daemon" and "libavahi" virtual packages; set to "dbus" variant because it is more compatible. When some package depends on one of these virtual packages an arbitrarily variant it is selected. This avoids that.

- Add conflicts in order to avoid mixing packages with different variants (when defining a DEFAULT_VARIANT the conflicts definition should be on that side of the dependency to avoid recursive dependencies).

- Avoid building unused "dbus" dependency.

Fixes: ASU sysupgrade problem with avahi packages https://forum.openwrt.org/t/luci-attended-sysupgrade-support-thread/230552/137
Fixes: https://github.com/openwrt/packages/commit/9bc03b9d9971c2f1e146f7c2d287d1fc16e776f0

---

## 🧪 Run Testing Details

- **OpenWrt Version:** Snapshot
- **OpenWrt Target/Subtarget:** Malta le
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
