### PR TITLE
sqlite3: don't install ABI-less library

### DIFF
--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=sqlite
 PKG_VERSION:=3.51.0
 PKG_SRC_VERSION:=3510000
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-autoconf-$(PKG_SRC_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.sqlite.org/2025/
@@ -137,7 +137,7 @@ endef
 
 define Package/libsqlite3/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsqlite3.so* $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsqlite3.so.{$(PKG_VERSION),$(ABI_VERSION)} $(1)/usr/lib
 endef
 
 define Package/sqlite3-cli/install

--- a/libs/sqlite3/test.sh
+++ b/libs/sqlite3/test.sh
@@ -2,6 +2,44 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-if [ "$1" = 'sqlite3-cli' ]; then
-	sqlite3 -version | grep -F "$PKG_VERSION"
-fi
+case "$PKG_NAME" in
+	libsqlite3)
+		apk add binutils
+
+		readelf_out=$(readelf --dynamic "/usr/lib/libsqlite3.so.$PKG_VERSION")
+		if [ $? -ne 0 ]; then
+			echo "readelf failed for /usr/lib/libsqlite3.so.$PKG_VERSION" >&2
+			exit 1
+		fi
+
+		soname=$(echo "$readelf_out" \
+			| grep -F '(SONAME)' \
+			| sed -E 's/.*\[(.*)\]/\1/')
+
+		if [ -z "$soname" ]; then
+			echo "soname not found in /usr/lib/libsqlite3.so.$PKG_VERSION" >&2
+			exit 1
+		fi
+
+		link_target=$(readlink "/usr/lib/$soname")
+		if [ $? -ne 0 ]; then
+			echo "Failed to read soname link /usr/lib/$soname" >&2
+			exit 1
+		fi
+
+		expected_target="libsqlite3.so.$PKG_VERSION"
+		if [ "$link_target" != "$expected_target" ]; then
+			echo "soname link /usr/lib/$soname points to '$link_target', expected '$expected_target'" >&2
+			exit 1
+		fi
+
+		if [ -f '/usr/lib/libsqlite3.so' ]; then
+			echo "/usr/lib/libsqlite3.so shouldn't be installed" >&2
+			exit 1
+		fi
+		;;
+
+	sqlite3-cli)
+		sqlite3 -version | grep -F "$PKG_VERSION"
+		;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** nobody, @1715173329 

**Description:**

Don't install the ABI-less library to support potential multiple ABIs side by side.

Add a matching test to check the soname and ensure the ABI-less library is not installed. OpenWrt 24.10 and below use the older SQLite3 package version format and lacks CI tests, hence there's no point supporting opkg.

Replace boilerplate license header with a SPDX license identifier.

Set correct package license to blessing according to https://spdx.org/licenses/blessing.html

Fixes: 9236e4f ("sqlite3: import 3.7.12.1 (2012-05-22) from packages")
Fixes: aebfd49 ("sqlite3: bump to 3.49.1")

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

Tested with CLI and yt-dlp.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.