### PR TITLE
spawn-fcgi: update to 1.6.6

### DIFF
--- a/net/spawn-fcgi/Makefile
+++ b/net/spawn-fcgi/Makefile
@@ -8,19 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=spawn-fcgi
-PKG_VERSION:=1.6.4
-PKG_RELEASE:=2
+PKG_VERSION:=1.6.6
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/spawn-fcgi/releases-1.6.x/
-PKG_HASH:=423b0c317e0084773b483985cc21930c4b8dfcb411f7353d6ee6fc41d9cb9d45
+PKG_HASH:=c962345eecf0553edd9bf5cf61ee45e7d11837f34037067fbda165cf4addce18
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/cmake.mk
+include $(INCLUDE_DIR)/meson.mk
 
 define Package/spawn-fcgi
   SUBMENU:=Web Servers/Proxies
@@ -33,6 +33,8 @@ endef
 define Package/spawn-fcgi/description
 	spawn-fcgi is used to spawn fastcgi applications
 endef
+
+MESON_ARGS += -Dipv6=$(if $(CONFIG_IPV6),true,false)
 
 define Package/spawn-fcgi/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Changes to meson. No more CMake.

ping @dangowrt 