### PR TITLE
ddns-scripts: Use parameter-based authentication for he.net

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=80
+PKG_RELEASE:=81
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/he.net.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/he.net.json
@@ -1,11 +1,11 @@
 {
 	"name": "he.net",
 	"ipv4": {
-		"url": "http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]",
+		"url": "https://dyn.dns.he.net/nic/update?hostname=[DOMAIN]&password=[PASSWORD]&myip=[IP]",
 		"answer": "good|nochg"
 	},
 	"ipv6": {
-		"url": "http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]",
+		"url": "https://dyn.dns.he.net/nic/update?hostname=[DOMAIN]&password=[PASSWORD]&myip=[IP]",
 		"answer": "good|nochg"
 	}
 }


### PR DESCRIPTION
According to [1] Basic Auth seems to be broken since a while for he.net. The documentation [2] is outdated, and still mentions Basic Auth, but switching to parameter-based authentication seems to fix the issue.

[1]: https://github.com/openwrt/packages/issues/27593
[2]: https://dns.he.net/docs.html

## 📦 Package Details

**Maintainer:** @feckert (?)

**Description:**
ddns-scripts: Use parameter-based authentication for he.net
According to [1] Basic Auth seems to be broken since a while for he.net.
The documentation [2] is outdated, and still mentions Basic Auth, but
switching to parameter-based authentication seems to fix the issue.

[1]: https://github.com/openwrt/packages/issues/27593
[2]: https://dns.he.net/docs.html

Signed-off-by: Karol Babioch <karol@babioch.de>

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
