### PR TITLE
apfree-wifidog: backport patch fixing CMake >= 4.0 support

### DIFF
--- a/net/apfree-wifidog/patches/001-refactor-update-CMake-configuration-for-improved-str.patch
+++ b/net/apfree-wifidog/patches/001-refactor-update-CMake-configuration-for-improved-str.patch
@@ -1,0 +1,236 @@
+From 66e8f953cc297c7263b3a8f99caedb2ad40816b3 Mon Sep 17 00:00:00 2001
+From: Dengfeng Liu <liudf0716@gmail.com>
+Date: Mon, 18 Nov 2024 15:46:04 +0800
+Subject: [PATCH] refactor: update CMake configuration for improved structure
+ and clarity
+
+Signed-off-by: Dengfeng Liu <liudf0716@gmail.com>
+---
+ CMakeLists.txt     |  47 +++++++++-------
+ src/CMakeLists.txt | 134 ++++++++++++++++++++-------------------------
+ 2 files changed, 85 insertions(+), 96 deletions(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,32 +1,37 @@
+-cmake_minimum_required(VERSION 2.8.12)
+-project(ApFreeWiFidog C)
++cmake_minimum_required(VERSION 3.12)
++project(apfree-wifidog 
++  VERSION 1.0.0
++  DESCRIPTION "ApFree WiFiDog"
++  LANGUAGES C)
+ 
++# Set C standard and module path
+ set(CMAKE_C_STANDARD 11)
+-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+-
+-option(AW_DEBUG		"Build debug"	ON)
+-option(AW_WEBSSH	"Build with web ssh support"	OFF)
+-option(AW_FW3   "Build with fw3 support"	OFF)
+-
+-find_package(LibEvent)
+-if(NOT LibEvent_FOUND)
+-  message(FATAL_ERROR "libevent2 not found!")
+-endif(NOT LibEvent_FOUND)
+-
+-find_package(OpenSSL)
+-if(NOT OPENSSL_FOUND)
+-  message(FATAL_ERROR "OpenSSL not found!")
+-endif(NOT OPENSSL_FOUND)
++set(CMAKE_C_STANDARD_REQUIRED ON)
++set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules" ${CMAKE_MODULE_PATH})
+ 
++# Options
++option(AW_DEBUG "Build with debug support" ON)
++option(AW_FW3 "Build with iptables support" OFF)
++
++# Required packages
++include(FindPackageHandleStandardArgs)
++
++# Find and include dependencies
++find_package(LibEvent REQUIRED)
++find_package(OpenSSL REQUIRED)
+ find_package(JSON-C REQUIRED)
+-include_directories(${JSON-C_INCLUDE_DIR})
+-
+ find_package(UCI REQUIRED)
+-include_directories(${UCI_INCLUDE_DIR})
+ 
+-if(LIB_INSTALL_DIR)
+-else()
+-  set(LIB_INSTALL_DIR lib)
++# Set installation directory
++if(NOT DEFINED LIB_INSTALL_DIR)
++    set(LIB_INSTALL_DIR lib)
+ endif()
+ 
++# Include directories
++include_directories(
++    ${JSON-C_INCLUDE_DIR}
++    ${UCI_INCLUDE_DIR}
++)
++
++# Add subdirectories
+ add_subdirectory(src)
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1,96 +1,80 @@
+-
++# Define source file groups
+ set(src_apfreewifidog
+-	main.c
+-	gateway.c 
+-	commandline.c 
+-	conf.c 
+-	debug.c 
+-	firewall.c 
+-	centralserver.c 
+-	http.c 
+-	auth.c 
+-	client_list.c 
+-	util.c 
+-	wdctl_thread.c 
+-	ping_thread.c 
+-	safe.c 
+-	pstring.c 
+-	ssl_redir.c
+-	wd_client.c
+-	wd_util.c 
+-	mqtt_thread.c
+-	ws_thread.c
+-	dns_forward.c
++	main.c gateway.c commandline.c conf.c debug.c
++	firewall.c centralserver.c http.c auth.c client_list.c
++	util.c wdctl_thread.c ping_thread.c safe.c pstring.c
++	ssl_redir.c wd_client.c wd_util.c mqtt_thread.c
++	ws_thread.c dns_forward.c
+ )
+ 
++set(src_fw3
++	fw_iptables.c fw3_iptc.c ipset.c
++)
+ 
+-if(AW_FW3)
+-	set(src_fw3
+-		fw_iptables.c 
+-		fw3_iptc.c
+-		ipset.c
+-	)
+-else()
+-	set(src_fw4
+-		fw_nft.c
+-	)
+-endif()
++set(src_fw4
++	fw_nft.c
++)
+ 
+ set(src_dhcp
+-	dhcp_cpi.c
+-	dhcp.c
+-	ipv4.c
+-	options.c
+-)
+-
+-set(src_wdctlx wdctl.c util.c debug.c)
+-
+-set(libs 
+-	pthread 
+-	m
+-	z
+-	json-c
+-	uci
+-	ssl
+-	crypto
+-	event
+-	event_openssl
+-	netfilter_queue
+-	resolv
+-	mosquitto)
++	dhcp_cpi.c dhcp.c ipv4.c options.c
++)
++
++set(src_wdctlx 
++	wdctl.c util.c debug.c
++)
++
++# Define common libraries
++set(common_libs
++	pthread m z json-c uci ssl crypto
++	event event_openssl netfilter_queue
++	resolv mosquitto
++)
+ 
++# Set compiler flags
++set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall --std=gnu99 -Wmissing-declarations")
+ if(AW_DEBUG)
+-	message("Building debug")
+-	ADD_DEFINITIONS(-ggdb -Wall --std=gnu99 -Wmissing-declarations)
++	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb")
++	message(STATUS "Building in DEBUG mode")
+ else()
+-	message("Buildign release")
+-	ADD_DEFINITIONS(-O2 -Wall --std=gnu99 -Wmissing-declarations)
++	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2")
++	message(STATUS "Building in RELEASE mode")
+ endif()
+ 
+-if (AW_FW3)
+-	message("Building with fw3")
+-	ADD_DEFINITIONS(-DAW_FW3)
+-	set(fw3_libs
+-		dl
+-		ip4tc
+-		iptext
+-		iptext4
+-		xtables)
++# Handle firewall version
++if(AW_FW3)
++	set(fw_source ${src_fw3})
++	set(fw_libs dl ip4tc iptext iptext4 xtables)
++	add_definitions(-DAW_FW3)
++	message(STATUS "Building with fw3")
++	set(src_fw3
++		fw_iptables.c fw3_iptc.c ipset.c
++	)
+ else()
+-	message("Building with fw4")
+-	ADD_DEFINITIONS(-DAW_FW4)
++	set(fw_source ${src_fw4})
++	set(fw_libs "")
++	add_definitions(-DAW_FW4)
++	message(STATUS "Building with fw4")
++	set(src_fw4
++		fw_nft.c
++	)
+ endif()
+ 
++# Build targets
+ add_executable(wdctlx ${src_wdctlx})
+-if(AW_FW3)
+-	add_executable(wifidogx ${src_apfreewifidog} ${src_fw3} ${src_dhcp})
+-	target_link_libraries(wifidogx ${libs}  ${fw3_libs} ${CURL_LIBRARIES})
+-else()
+-	add_executable(wifidogx ${src_apfreewifidog} ${src_fw4} ${src_dhcp})
+-	target_link_libraries(wifidogx ${libs} ${CURL_LIBRARIES})
+-endif()
+ 
+-install(TARGETS wifidogx wdctlx
+-		RUNTIME DESTINATION bin
++add_executable(wifidogx 
++	${src_apfreewifidog}
++	${fw_source}
++	${src_dhcp}
+ )
+ 
++target_link_libraries(wifidogx
++	${common_libs}
++	${fw_libs}
++	${CURL_LIBRARIES}
++)
++
++# Installation
++install(TARGETS wifidogx wdctlx
++	RUNTIME DESTINATION bin
++)

--- a/net/apfree-wifidog/patches/002-refactor-disable-debug-support-by-default-in-CMake-c.patch
+++ b/net/apfree-wifidog/patches/002-refactor-disable-debug-support-by-default-in-CMake-c.patch
@@ -1,0 +1,22 @@
+From eda722063c6774f7adce0e75cccf4c1493b9e3cd Mon Sep 17 00:00:00 2001
+From: Dengfeng Liu <liudf0716@gmail.com>
+Date: Sat, 14 Dec 2024 10:14:52 +0800
+Subject: [PATCH] refactor: disable debug support by default in CMake
+ configuration
+
+Signed-off-by: Dengfeng Liu <liudf0716@gmail.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,7 +10,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
+ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules" ${CMAKE_MODULE_PATH})
+ 
+ # Options
+-option(AW_DEBUG "Build with debug support" ON)
++option(AW_DEBUG "Build with debug support" OFF)
+ option(AW_FW3 "Build with iptables support" OFF)
+ 
+ # Required packages


### PR DESCRIPTION
Backport upstream patch fixing support for CMake >= 4.0 version.