### PR TITLE
tinyproxy: support DisableViaHeader option

### DIFF
--- a/net/tinyproxy/Makefile
+++ b/net/tinyproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tinyproxy
 PKG_VERSION:=1.11.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/tinyproxy/tinyproxy/releases/download/$(PKG_VERSION)

--- a/net/tinyproxy/files/tinyproxy.config
+++ b/net/tinyproxy/files/tinyproxy.config
@@ -148,6 +148,15 @@ list Allow 127.0.0.1
 option ViaProxyName "tinyproxy"
 
 #
+# DisableViaHeader: When this is set to yes, Tinyproxy does NOT add
+# the Via header to the requests. This virtually puts Tinyproxy into
+# stealth mode. Note that RFC 2616 requires proxies to set the Via
+# header, so by enabling this option, you break compliance.
+# Don't disable the Via header unless you know what you are doing...
+#
+#option DisableViaHeader 1
+
+#
 # The location of the filter file.
 #
 #option Filter "/etc/tinyproxy/filter"

--- a/net/tinyproxy/files/tinyproxy.init
+++ b/net/tinyproxy/files/tinyproxy.init
@@ -132,6 +132,7 @@ start_proxy() {
 	proxy_list "$1" Allow
 
 	proxy_string "$1" ViaProxyName
+	proxy_flag "$1" DisableViaHeader Yes No
 	proxy_string "$1" Filter
 
 	proxy_flag "$1" FilterURLs


### PR DESCRIPTION
This option is required for the proxy to be transparent, and has been supported since [at least 2009](https://github.com/tinyproxy/tinyproxy/commit/1c0bda0e7cc99d39309f63fa719cbce756599f68). Description taken from upstream.

## 📦 Package Details

**Maintainer:** @jow-

**Description:**
tinyproxy: support DisableViaHeader option
This option is required for the proxy to be transparent, and has been supported since at least 2009. Description taken from upstream.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.1
- **OpenWrt Target/Subtarget:** ramips/mt76x8
- **OpenWrt Device:** glinet_gl-mt300n-v2

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
