### PR TITLE
openthread-br: bump to 2025-06-12 and add patch for CMake >= 4.0 support

### DIFF
--- a/net/openthread-br/Makefile
+++ b/net/openthread-br/Makefile
@@ -4,13 +4,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openthread-br
-PKG_SOURCE_DATE:=2024-11-20
-PKG_SOURCE_VERSION:=bd7bc77742920eba3b3801a410c3eba3372c98bb
-PKG_RELEASE:=2
+PKG_SOURCE_DATE:=2025-06-12
+PKG_SOURCE_VERSION:=2f3c799c7463c8f674754e65c53f78bc0bbcbd58
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://github.com/openthread/ot-br-posix.git
-PKG_MIRROR_HASH:=ca4352e527e38de26c8c4242ced5899e6fd1e4fea57d0dc4b2a6bd433e6b14b6
+PKG_MIRROR_HASH:=fae1c7c88102f88bac32f8ee25e044b9a8781eef6b9acef39388e1e11a44a195
 
 PKG_MAINTAINER:=Stijn Tintel <stijn@linux-ipv6.be>
 PKG_LICENSE:=BSD-3-Clause
@@ -35,6 +35,7 @@ define Package/openthread-br
 	+kmod-tun \
 	+libblobmsg-json \
 	+libjson-c \
+	+cJSON \
 	+libncurses \
 	+libnetfilter-queue \
 	+libreadline \

--- a/net/openthread-br/patches/101-rest-Permit-to-externally-provide-cJSON-library.patch
+++ b/net/openthread-br/patches/101-rest-Permit-to-externally-provide-cJSON-library.patch
@@ -1,0 +1,56 @@
+From 59c389a91cfe91eebed9c36887fa2a3eca4cbd6f Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Mon, 24 Nov 2025 18:53:28 +0100
+Subject: [PATCH] [rest] Permit to externally provide cJSON library
+
+Permit to externally provide cJSON library if found with PKGConfig.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ src/rest/CMakeLists.txt    | 12 +++++++++++-
+ third_party/CMakeLists.txt |  5 ++++-
+ 2 files changed, 15 insertions(+), 2 deletions(-)
+
+--- a/src/rest/CMakeLists.txt
++++ b/src/rest/CMakeLists.txt
+@@ -36,11 +36,22 @@ add_library(otbr-rest
+     response.cpp
+ )
+ 
++if (CJSON_FOUND)
++    set(CJSON_LIB_TARGETS ${CJSON_LINK_LIBRARIES})
++else()
++    set(CJSON_LIB_TARGETS cjson)
++endif()
++
++target_include_directories(otbr-rest
++    PRIVATE
++        ${CJSON_INCLUDE_DIRS}
++)
++
+ target_link_libraries(otbr-rest
+     PUBLIC
+         http_parser
+     PRIVATE
+-        cjson
++        ${CJSON_LIB_TARGETS}
+         otbr-config
+         otbr-utils
+         openthread-ftd
+--- a/third_party/CMakeLists.txt
++++ b/third_party/CMakeLists.txt
+@@ -28,6 +28,13 @@
+ 
+ add_subdirectory(openthread)
+ if(OTBR_REST)
+-    add_subdirectory(cJSON)
++    pkg_check_modules(CJSON libcjson)
++    if (CJSON_FOUND)
++        set(CJSON_FOUND ${CJSON_FOUND} PARENT_SCOPE)
++        set(CJSON_INCLUDE_DIRS ${CJSON_INCLUDE_DIRS} PARENT_SCOPE)
++        set(CJSON_LINK_LIBRARIES ${CJSON_LINK_LIBRARIES} PARENT_SCOPE)
++    else()
++        add_subdirectory(cJSON)
++    endif()
+     add_subdirectory(http-parser)
+ endif()


### PR DESCRIPTION
Bump to version 2025-06-12 and add pending patch for openthread-br for CMake >= 4.0 support.

The package use an old cJSON version that cause compilation problem with CMake >= 4.0 support. To handle this, add a pending patch to use an external version of cJSON.

We already ship this package so it's trivial to use that instead of the one in the openthread-br repository.

---

@stintel 