### PR TITLE
[24.10] kea: bump to 2.6.4

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -9,14 +9,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kea
-PKG_VERSION:=2.6.0
+PKG_VERSION:=2.6.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.isc.org/isc/kea/$(PKG_VERSION)
-PKG_HASH:=207ceae33eb3b81ec4e6ac5605249a85b93779333b62aadf39e489f11dbcdc8d
+PKG_HASH:=6806405e4d559abc10febd2c273dc6e2bc6ac42767afa5ca20b118ffba84a671
 
-PKG_MAINTAINER:=BangLang Huang <banglang.huang@foxmail.com>, Rosy Song <rosysong@rosinson.com>
+PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>, Noah Meyerhans <frodo@morgul.net>
 PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=COPYING
 

--- a/net/kea/files/kea.init
+++ b/net/kea/files/kea.init
@@ -8,7 +8,8 @@ BIN_PATH="/usr/sbin"
 CONF_PATH="/etc/kea"
 
 start_service() {
-	mkdir -p /var/run/kea
+	mkdir -p /var/run/kea /var/lib/kea
+    chmod 0750 /var/run/kea /var/lib/kea
 
 	config_load "kea"
 	config_foreach start_kea "service"

--- a/net/kea/patches/003-no-test-compile.patch
+++ b/net/kea/patches/003-no-test-compile.patch
@@ -225,7 +225,7 @@
 +SUBDIRS = .
  
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
- AM_CPPFLAGS += $(BOOST_INCLUDES)
+ AM_CPPFLAGS += -DDEFAULT_HOOKS_PATH=\"$(libdir)/kea/hooks\"
 --- a/src/lib/http/Makefile.am
 +++ b/src/lib/http/Makefile.am
 @@ -1,4 +1,4 @@

--- a/net/kea/patches/004-use-shell-expansion-instead.patch
+++ b/net/kea/patches/004-use-shell-expansion-instead.patch
@@ -6,7 +6,7 @@ Date:   Sat Aug 3 10:19:05 2024 -0600
 
 --- a/src/bin/keactrl/keactrl.in
 +++ b/src/bin/keactrl/keactrl.in
-@@ -112,7 +112,8 @@ get_pid_from_file() {
+@@ -116,7 +116,8 @@ get_pid_from_file() {
  
      # Extract the name portion (from last slash to last dot) of the config file name.
      local conf_name


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @nmeyerhans, @pprindeville 

**Description:**

Bump kea to the latest release on the 2.6.y branch on the openwrt-24.10 branch

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** mvebu
- **OpenWrt Device:** WRT 1900ACS

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
