### PR TITLE
lpeg: bump to 1.1.0 and add InstallDev

### DIFF
--- a/lang/lua/lpeg/LICENSE
+++ b/lang/lua/lpeg/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2007-2023 Lua.org, PUC-Rio.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/lang/lua/lpeg/Makefile
+++ b/lang/lua/lpeg/Makefile
@@ -8,14 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lpeg
-PKG_VERSION:=1.0.2
+PKG_VERSION:=1.1.0
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Dirk Chang <dirk@kooiot.com>
 PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.inf.puc-rio.br/~roberto/lpeg/
-PKG_HASH:=48d66576051b6c78388faad09b70493093264588fcd0f258ddaab1cdd4a15ffe
+PKG_HASH:=4b155d67d2246c1ffa7ad7bc466c1ea899bbc40fef0257cc9c03cecbaed4352a
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -25,19 +26,21 @@ define Package/lpeg
   CATEGORY:=Languages
   TITLE:=LPeg
   URL:=https://www.inf.puc-rio.br/~roberto/lpeg/
+  TITLE:=Pattern-matching library for Lua
   DEPENDS:=+lua
 endef
 
 define Package/lpeg/description
-	LPeg is a new pattern-matching library for Lua, based on Parsing Expression Grammars (PEGs)
+  LPeg is a pattern-matching library for Lua based on Parsing Expression Grammars (PEGs).
 endef
 
-define Build/Configure
-endef
-
-# add make variable overrides here
 MAKE_FLAGS += \
 	COPT="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS) -O2"
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/lib/lua
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lpeg.so $(1)/usr/lib/lua
+endef
 
 define Package/lpeg/install
 	$(INSTALL_DIR) $(1)/usr/lib/lua


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Dirk Chang <dirk@kooiot.com>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
- Bump version to 1.1.0
- Add Build/InstallDev section
- Add license file
- Minor style tweaks
---

## 🧪 Run Testing Details

- **OpenWrt Version: OpenWrt SNAPSHOT r31813**
- **OpenWrt Target/Subtarget: mediatek/filogic**
- **OpenWrt Device: Banana Pi BPI-R4 (2x SFP+)**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
