### PR TITLE
utf8proc: add new package

### DIFF
--- a/libs/utf8proc/Makefile
+++ b/libs/utf8proc/Makefile
@@ -1,0 +1,46 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=utf8proc
+PKG_VERSION:=2.11.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/JuliaStrings/utf8proc/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=abfed50b6d4da51345713661370290f4f4747263ee73dc90356299dfc7990c78
+
+PKG_MAINTAINER:=Valeriy Kosikhin <vkosikhin@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.md
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libutf8proc
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Clean C library for processing UTF-8 Unicode data
+  URL:=https://github.com/JuliaStrings/utf8proc/
+endef
+
+define Package/libutf8proc/description
+  utf8proc is a small, clean C library that provides Unicode normalization,
+  case-folding, and other operations for data in the UTF-8 encoding.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/local/include/utf8proc.h $(1)/usr/include
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/local/lib/pkgconfig/libutf8proc.pc $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/local/lib/libutf8proc.a $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/local/lib/libutf8proc.so* $(1)/usr/lib
+endef
+
+define Package/libutf8proc/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/local/lib/libutf8proc.so* $(1)/usr/lib
+endef
+
+$(eval $(call BuildPackage,libutf8proc))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @betonmischer86 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
utf8proc is a small, clean C library that provides Unicode normalization, case-folding, and other operations for data in the UTF-8 encoding.

---

## 🧪 Run Testing Details

- **OpenWrt Version: OpenWrt SNAPSHOT r31813**
- **OpenWrt Target/Subtarget: mediatek/filogic**
- **OpenWrt Device: Banana Pi BPI-R4 (2x SFP+)**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
