### PR TITLE
tree-sitter-cli: add new package

### DIFF
--- a/utils/tree-sitter-cli/Makefile
+++ b/utils/tree-sitter-cli/Makefile
@@ -1,0 +1,43 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tree-sitter-cli
+PKG_VERSION:=0.25.10
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/tree-sitter/tree-sitter/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=ad5040537537012b16ef6e1210a572b927c7cdc2b99d1ee88d44a7dcdc3ff44c
+
+PKG_MAINTAINER:=Valeriy Kosikhin <vkosikhin@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=rust/host
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/tree-sitter-cli
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=CLI tool for creating and testing Tree-sitter parsers
+  URL:=https://tree-sitter.github.io/
+  DEPENDS:=$(RUST_ARCH_DEPENDS)
+endef
+
+define Package/tree-sitter-cli/description
+  Tree-sitter CLI allows you to develop, test, and use Tree-sitter grammars from the command line.
+endef
+
+TAR_OPTIONS+= --strip-components 1
+TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
+MAKE_PATH:=cli
+
+define Package/tree-sitter-cli/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/tree-sitter $(1)/usr/bin
+endef
+
+$(eval $(call RustBinPackage,tree-sitter-cli))
+$(eval $(call BuildPackage,tree-sitter-cli))

--- a/utils/tree-sitter-cli/patches/010-fix-cross-compilation.patch
+++ b/utils/tree-sitter-cli/patches/010-fix-cross-compilation.patch
@@ -1,0 +1,22 @@
+From: Valeriy Kosikhin <vkosikhin@gmail.com>
+Subject: [PATCH] Set correct runtime host for cc while cross-compiling
+
+--- a/cli/loader/src/lib.rs
++++ b/cli/loader/src/lib.rs
+@@ -303,7 +303,6 @@ impl Config {
+ }
+ 
+ const BUILD_TARGET: &str = env!("BUILD_TARGET");
+-const BUILD_HOST: &str = env!("BUILD_HOST");
+ 
+ pub struct LanguageConfiguration<'a> {
+     pub scope: Option<String>,
+@@ -821,7 +820,7 @@ impl Loader {
+             .cargo_metadata(false)
+             .cargo_warnings(false)
+             .target(BUILD_TARGET)
+-            .host(BUILD_HOST)
++            .host(BUILD_TARGET)
+             .debug(self.debug_build)
+             .file(&config.parser_path)
+             .includes(&config.header_paths)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @betonmischer86 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Tree-sitter CLI allows you to develop, test, and use Tree-sitter grammars from the command line.
Used by Neovim plugins. While Neovim itself hasn't been ported to OpenWrt, it can be built for the system
or on the system, making tree-sitter-cli a welcome addition.

This package includes a patch, which will be dropped in subsequent revisions as the necessary changes
have already been merged into the development branch of tree-sitter.

---

## 🧪 Run Testing Details

- **OpenWrt Version: OpenWrt SNAPSHOT r31813**
- **OpenWrt Target/Subtarget: mediatek/filogic**
- **OpenWrt Device: Banana Pi BPI-R4 (2x SFP+)**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
