### PR TITLE
tree-sitter: add new package

### DIFF
--- a/libs/tree-sitter/Makefile
+++ b/libs/tree-sitter/Makefile
@@ -1,0 +1,46 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tree-sitter
+PKG_VERSION:=0.25.10
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/tree-sitter/tree-sitter/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=ad5040537537012b16ef6e1210a572b927c7cdc2b99d1ee88d44a7dcdc3ff44c
+
+PKG_MAINTAINER:=Valeriy Kosikhin <vkosikhin@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libtree-sitter
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Incremental parsing system for programming tools
+  URL:=https://tree-sitter.github.io/
+endef
+
+define Package/libtree-sitter/description
+  Tree-sitter is an incremental parsing library.
+  For the CLI tool, see tree-sitter-cli.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/tree_sitter
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/local/include/tree_sitter/api.h $(1)/usr/include/tree_sitter
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/local/lib/pkgconfig/tree-sitter.pc $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/local/lib/libtree-sitter.a $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/local/lib/libtree-sitter.so* $(1)/usr/lib
+endef
+
+define Package/libtree-sitter/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/local/lib/libtree-sitter.so* $(1)/usr/lib
+endef
+
+$(eval $(call BuildPackage,libtree-sitter))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @betonmischer86 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Tree-sitter is an incremental parsing library. It can build a concrete syntax tree for a source file and efficiently update the syntax tree as the source file is edited.

This is a package for the tree-sitter library separate from the tree-sitter CLI tool.

---

## 🧪 Run Testing Details

- **OpenWrt Version: OpenWrt SNAPSHOT r31813**
- **OpenWrt Target/Subtarget: mediatek/filogic**
- **OpenWrt Device: Banana Pi BPI-R4 (2x SFP+)**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
