### PR TITLE
ddns-scripts: Add tb.netassist.ua as service

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=81
+PKG_RELEASE:=82
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/tb.netassist.ua.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/tb.netassist.ua.json
@@ -1,0 +1,11 @@
+{
+	"name": "tb.netassist.ua",
+	"ipv4": {
+		"url": "https://tb.netassist.ua/autochangeip.php?l=[USERNAME]&p=[PASSWORD]&ip=[IP]",
+		"answer": "OK!"
+	},
+	"ipv6": {
+		"url": "https://tb.netassist.ua/autochangeip.php?l=[USERNAME]&p=[PASSWORD]&ip=[IP]",
+		"answer": "OK!"
+	}
+}

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -63,6 +63,7 @@ sitelutions.com
 spdyn.de
 strato.com
 system-ns.com
+tb.netassist.ua
 thatip.com
 transip.nl
 twodns.de


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert

**Description:**

This adds support for tb.nettassist.ua as requested by [1].

The service seems to have a somewhat broken API in that it returns `OK!` for the first update, but will return `FAIL!` for any consecutive update with the same IP.

For example:

```
curl "https://tb.netassist.ua/autochangeip.php?l=[USERNAME]&p=[PASSWORD]&ip=1.2.3.4"
OK!
The IP will be updated in 60 seconds.%

curl "https://tb.netassist.ua/autochangeip.php?l=[USERNAME]&p=[PASSWORD]&ip=1.2.3.4"
FAIL!
IPv4 address you entered "<b>1.2.3.4</b>" is already registered in our
system for another customer. Try another one. Sorry.%
```

On the other hand, it doesn't feel right to add `FAIL!` as expected response for an successful update.

If anything, the service provider should be contacted and asked to fix the API.

[1]: https://github.com/openwrt/packages/issues/25861

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.