### PR TITLE
python-certifi: fix build (depend on setuptools)

### DIFF
--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
 PKG_VERSION:=2025.8.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=MPL-2.0
@@ -17,7 +17,13 @@ PKG_CPE_ID:=cpe:/a:certifi:certifi
 PYPI_NAME:=certifi
 PKG_HASH:=e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407
 
-HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-wheel/host
+HOST_BUILD_DEPENDS:= \
+	python3/host \
+	python-build/host \
+	python-installer/host \
+	python-wheel/host \
+	python-setuptools/host
+PKG_BUILD_DEPENDS:=python-setuptools/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @cotequeiroz @Yang-Wei-Ting 

**Description:**
Add setuptools to `HOST_BUILD_DEPENDS` and `PKG_BUILD_DEPENDS`.

setuptools has been required since certifi 2025.06.15 https://github.com/certifi/python-certifi/pull/350
Currently certifi only builds correctly when setuptools/host *happens* to have been installed before (not good for reproducible builds)

Relates to:
- #27968 

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** OpenWRT One

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
