### PR TITLE
python-pypubsub: switch to PyPi sdist

### DIFF
--- a/lang/python/python-pypubsub/Makefile
+++ b/lang/python/python-pypubsub/Makefile
@@ -6,19 +6,19 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pypubsub
 PKG_VERSION:=4.0.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
-PYTHON3_PKG_WHEEL_NAME:=Pypubsub
+PYPI_NAME:=Pypubsub
+PYPI_SOURCE_NAME:=pypubsub
+PKG_HASH:=32d662de3ade0fb0880da92df209c62a4803684de5ccb8d19421c92747a258c7
 
-PKG_SOURCE:=pypubsub-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/schollii/pypubsub/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=0df83daa1cb0021bab858ff6812d836c9712dea59a5172be1888bb554c3a89a2
-PKG_BUILD_DIR:=$(BUILD_DIR)/pypubsub-$(PKG_VERSION)
+PKG_BUILD_DEPENDS:=python-setuptools/host
 
 PKG_MAINTAINER:=Austin Lane <vidplace7@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=src/pubsub/LICENSE_BSD_Simple.txt
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me (@vidplace7)

**Description:**
- PyPi sdist was recently added for this package. Switch to using it.
- Add `python-setuptools/host` to PKG_BUILD_DEPENDS, it is required.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** OpenWRT One

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
