### PR TITLE
Revert "tar: fix EXTRA_DEPENDS"

### DIFF
--- a/utils/tar/Makefile
+++ b/utils/tar/Makefile
@@ -35,7 +35,8 @@ include $(INCLUDE_DIR)/package.mk
 define Package/tar
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+PACKAGE_TAR_POSIX_ACL:libacl +PACKAGE_TAR_XATTR:libattr +PACKAGE_TAR_BZIP2:bzip2 +PACKAGE_TAR_XZ:xz
+  DEPENDS:=+PACKAGE_TAR_POSIX_ACL:libacl +PACKAGE_TAR_XATTR:libattr +PACKAGE_TAR_BZIP2:bzip2
+  EXTRA_DEPENDS:=$(if $(CONFIG_PACKAGE_TAR_XZ),xz)
   TITLE:=GNU tar
   URL:=https://www.gnu.org/software/tar/
   MENU:=1


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @Noltari, cc: @@peterwillcn

**Description:**

Previous commit broke tar that has some kind of a recursive config dependency. Reverting for now.

```
tmp/.config-package.in:11747:error: recursive dependency detected!
tmp/.config-package.in:11747:	symbol PACKAGE_TAR_XZ depends on PACKAGE_tar
tmp/.config-package.in:11713:	symbol PACKAGE_tar depends on PACKAGE_TAR_XZ
```

This reverts commit 593267af241de9cc1e425036305988ccbc396862.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.