### PR TITLE
watchcat: passing the interface in the ping_reboot

### DIFF
--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=18
+PKG_RELEASE:=19
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/utils/watchcat/files/watchcat.init
+++ b/utils/watchcat/files/watchcat.init
@@ -104,7 +104,7 @@ config_watchcat() {
 		;;
 	ping_reboot)
 		procd_open_instance "watchcat_${1}"
-		procd_set_param command /usr/bin/watchcat.sh "ping_reboot" "$period" "$forcedelay" \"$pinghosts\" "$pingperiod" "$pingsize" "$addressfamily"
+		procd_set_param command /usr/bin/watchcat.sh "ping_reboot" "$period" "$forcedelay" \"$pinghosts\" "$pingperiod" "$pingsize" "$addressfamily" "$interface"
 		procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 		procd_close_instance
 		;;

--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -188,6 +188,7 @@ watchcat_ping() {
 	ping_frequency_interval="$4"
 	ping_size="$5"
 	address_family="$6"
+	iface="$7"
 
 	time_now="$(cat /proc/uptime)"
 	time_now="${time_now%%.*}"
@@ -252,8 +253,8 @@ periodic_reboot)
 	watchcat_periodic "$2" "$3"
 	;;
 ping_reboot)
-	# args from init script: period forcedelay pinghosts pingperiod pingsize addressfamily
-	watchcat_ping "$2" "$3" "$4" "$5" "$6" "$7"
+	# args from init script: period forcedelay pinghosts pingperiod pingsize addressfamily interface
+	watchcat_ping "$2" "$3" "$4" "$5" "$6" "$7" "$8"
 	;;
 restart_iface)
 	# args from init script: period pinghosts pingperiod pingsize interface mmifacename unlockbands addressfamily


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  @roger-  Roger D <rogerdammit@gmail.com>

**Description:**
Although the watchcat_ping function also checked the iface variable, that variable was never populated. As a result we could not check if there was connectivity via a specific interface and restart the device if there is not.

---

## 🧪 Run Testing Details

- **OpenWrt Version: 23.05**
- **OpenWrt Device: GL-BE9300**

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
