### PR TITLE
Fix tcpreplay depends

### DIFF
--- a/net/tcpreplay/Makefile
+++ b/net/tcpreplay/Makefile
@@ -35,7 +35,7 @@ define Package/tcpreplay/default
   CATEGORY:=Network
   URL:=http://tcpreplay.appneta.com/
   MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
-  DEPENDS:=+librt +libpcap +libdnet +USE_MUSL:musl-fts
+  DEPENDS:=+librt +libpcap +libdnet +USE_MUSL:musl-fts +libbpf
 endef
 
 define Package/tcpbridge


### PR DESCRIPTION
tcpreplay needed

+libbpf

## 📦 Package Details

**Maintainer:** @commodo
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**

<!-- Briefly describe what this package does or what changes are introduced -->
This Makefile doesn't build for me unless I add libbpf.

```
find /home/caleb/experiments/avionics_test/auto-kiosk-tiger/cudy/openwrt/build_dir/target-aarch64_cortex-a53_musl/tcpreplay-4.5.1/ipkg-aarch64_cortex-a53/tcpreplay -name 'CVS' -o -name '.svn' -o -name '.#*' -o -name '*~'| xargs -r rm -rf
Package tcpreplay is missing dependencies for the following libraries:
libbpf.so.1
make[2]: *** [Makefile:167: /home/caleb/experiments/avionics_test/auto-kiosk-tiger/cudy/openwrt/bin/packages/aarch64_cortex-a53/packages/tcpreplay_4.5.1-r1_aarch64_cortex-a53.ipk] Error 1
make[2]: Leaving directory '/home/caleb/experiments/avionics_test/auto-kiosk-tiger/cudy/openwrt/feeds/packages/net/tcpreplay'
time: package/feeds/packages/tcpreplay/compile#45.35#8.98#53.00
    ERROR: package/feeds/packages/tcpreplay failed to build.
make[1]: *** [package/Makefile:176: package/feeds/packages/tcpreplay/compile] Error 1
```


---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.4
- **OpenWrt Target/Subtarget:** MediaTek ARM/(Filogic 8x0 (MT798x))
- **OpenWrt Device:**Multiple devices/Cudy Tr3000 v1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
