### PR TITLE
lm-sensors: pass TARGET_LDFLAGS to fix shared library link error

### DIFF
--- a/utils/lm-sensors/Makefile
+++ b/utils/lm-sensors/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lm-sensors
 PKG_VERSION:=3.6.2
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_VERSION_SUBST=$(subst .,-,$(PKG_VERSION))
 PKG_SOURCE_URL:=https://codeload.github.com/hramrach/lm-sensors/tar.gz/V$(PKG_VERSION_SUBST)?
@@ -110,6 +110,7 @@ define Build/Compile
 		LINUX="$(LINUX_DIR)" \
 		CC="$(TARGET_CC)" \
 		CFLAGS="$(TARGET_CFLAGS)" \
+		LDFLAGS="$(TARGET_LDFLAGS)" \
 		CPPFLAGS="$(TARGET_CPPFLAGS)" \
 		STAGING_DIR="$(STAGING_DIR)" \
 		PREFIX="/usr" \


### PR DESCRIPTION
## Package Details

**Maintainer:** @jow-

**Description:**
Explicitly pass $(TARGET_LDFLAGS) to the build system to resolve MIPS linker errors related to missing -fPIC.

**Fixes:**
```
<artificial>:(.text+0x5130): relocation R_MIPS16_26 against `__stack_chk_fail' cannot be used when making a shared object; recompile with -fPIC
openwrt/staging_dir/toolchain-mips_24kc_gcc-15.2.0_musl/lib/gcc/mips-openwrt-linux-musl/15.2.0/../../../../mips-openwrt-linux-musl/bin/ld: non-dynamic relocations refer to dynamic symbol strcpy
openwrt/staging_dir/toolchain-mips_24kc_gcc-15.2.0_musl/lib/gcc/mips-openwrt-linux-musl/15.2.0/../../../../mips-openwrt-linux-musl/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
```
---

## Build Testing Details
- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** ath79
- **OpenWrt Device:** tplink_tl-wr842n-v3