### PR TITLE
shairport-sync: enable Airplay 2 for shairport-sync-openssl only

### DIFF
--- a/sound/shairport-sync/Makefile
+++ b/sound/shairport-sync/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shairport-sync
 PKG_VERSION:=4.3.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikebrady/shairport-sync/tar.gz/$(PKG_VERSION)?
@@ -29,7 +29,7 @@ define Package/shairport-sync/default
   SECTION:=sound
   CATEGORY:=Sound
   TITLE:=AirPlay compatible audio player
-  DEPENDS:=@AUDIO_SUPPORT +libpthread +alsa-lib +libconfig +libdaemon +libpopt +libplist +libsodium +libgcrypt +libffmpeg-full +libuuid +nqptp +libmosquitto
+  DEPENDS:=@AUDIO_SUPPORT +libpthread +alsa-lib +libconfig +libdaemon +libpopt +libmosquitto
   PROVIDES:=shairport-sync
   URL:=https://github.com/mikebrady/shairport-sync
 endef
@@ -37,7 +37,7 @@ endef
 define Package/shairport-sync-openssl
   $(Package/shairport-sync/default)
   TITLE+= (openssl)
-  DEPENDS+= +libopenssl +libavahi-client +libsoxr
+  DEPENDS+= +libopenssl +libavahi-client +libsoxr +libplist +libsodium +libgcrypt +libffmpeg-full +libuuid +nqptp
   VARIANT:=openssl
 endef
 
@@ -73,18 +73,28 @@ define Package/shairport-sync-mini/description
   $(Package/shairport-sync/default/description)
 
   Minimal version uses mbed TLS and does not include libsoxr and avahi support.
+  Only supports classic AirPlay aka AirPlay 1. Please note that the minimal
+  version does not make use of the FFmpeg ALAC decoder that fixes some security
+  issues in the original decoder.
+endef
+
+define Package/shairport-sync-mbedtls/description
+  $(Package/shairport-sync/default/description)
+
+  mbed TLS version only supports classic AirPlay aka AirPlay 1. Please note that
+  the mbed TLS version does not make use of the FFmpeg ALAC decoder that fixes
+  some security issues in the original decoder.
 endef
 
 CONFIGURE_ARGS += \
 	--with-alsa \
 	--with-libdaemon \
-	--with-airplay-2 \
 	--with-pipe \
 	--with-mqtt-client \
 	--with-metadata
 
 ifeq ($(BUILD_VARIANT),openssl)
-  CONFIGURE_ARGS+= --with-ssl=openssl
+  CONFIGURE_ARGS+= --with-ssl=openssl --with-airplay-2
 endif
 
 ifeq ($(BUILD_VARIANT),mbedtls)


### PR DESCRIPTION
https://github.com/mikebrady/shairport-sync/blob/master/CONFIGURATION%20FLAGS.md#cryptography states that only the OpenSSL cryptography backend is suitable for Airplay 2.

Further investigation revealed that the pair_ap module within shairport-sync, which is needed for Airplay 2, does not have an Mbed TLS backend.

Accordingly, this commit enables Airplay 2 only for the OpenSSL build.

This has the nice side effect that for Airplay 1 the -mini or -mbedtls versions can be used without pulling in 6 MB of ffmepg libs.

## 📦 Package Details

**Maintainer:** @thess @mikebrady 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
https://github.com/mikebrady/shairport-sync/blob/master/CONFIGURATION%20FLAGS.md#cryptography states that only the OpenSSL cryptography backend is suitable for Airplay 2.

Further investigation revealed that the pair_ap module within shairport-sync, which is needed for Airplay 2, does not have an Mbed TLS backend.

Accordingly, this commit enables Airplay 2 only for the OpenSSL build.

This has the nice side effect that for Airplay 1 the -mini or -mbedtls versions can be used without pulling in 6 MB of ffmepg libs.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** ath79
- **OpenWrt Device:** EPG5000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.


