### PR TITLE
pv: explicitly enable ncursesw, add dependency, remove maintainer

### DIFF
--- a/utils/pv/Makefile
+++ b/utils/pv/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pv
 PKG_VERSION:=1.9.31
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.ivarch.com/programs/sources
@@ -28,6 +28,7 @@ define Package/pv
   CATEGORY:=Utilities
   TITLE:=Shell pipeline element to meter data passing through
   URL:=https://www.ivarch.com/programs/pv.shtml
+  DEPENDS:=+libncursesw
 endef
 
 define Package/pv/description
@@ -37,6 +38,8 @@ define Package/pv/description
  through, how long it has taken, how near to completion it is, and an
  estimate of how long it will be until completion.
 endef
+
+CONFIGURE_ARGS += --with-ncurses
 
 define Package/pv/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
pv: explicitly enable ncursesw, add dependency

Explicitly enable ncurses usage and add dependency for it.

Feature was added 1.9.24, and buildbot has now occasionally failed due to the missing dependency, when ncurses has been built first and it has been detected:

```
Package pv is missing dependencies for the following libraries:
libncursesw.so.6
make[3]: *** [Makefile:56: /builder/shared-workdir/build/sdk/bin/packages/aarch64_cortex-a76/packages/pv-1.9.31-r1.apk] Error 1
```

Maintainer:  @jow-
This PR also removes Jow from the maintainer line, as he has not been committing to this package since 2016. 
Any objections, @jow- ?

Compile tested for qualcommax/DL-WRX36
