### PR TITLE
knot: update to version 3.5.2

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.5.1
+PKG_VERSION:=3.5.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=a614d5226ceed4b4cdd4a3badbb0297ea0f987f65948e4eb828119a3b5ac0a4b
+PKG_HASH:=6f577c247ef870a55fe3377246bc1c2d643c673cd32de6c26231ff51d3fc7093
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.0-or-later MIT ISC BSD-3-Clause

--- a/net/knot/patches/01_zscanner_tests.patch
+++ b/net/knot/patches/01_zscanner_tests.patch
@@ -20,5 +20,5 @@
 -ZSCANNER_TOOL="$BUILD"/zscanner-tool
 +ZSCANNER_TOOL="$SOURCE"/zscanner-tool
  
- plan 87
+ plan 88
  


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @salzmdan

**Description:** 

- Release upgrade (https://www.knot-dns.cz/2025-11-28-version-352.htmll)
- Patch refresh

---

## 🧪 Run Testing Details

- **OpenWrt Version:** TurrisOS 9.0.0
- **OpenWrt Target/Subtarget:** mvebu/cortexa9
- **OpenWrt Device:** Turris Omnia

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
