### PR TITLE
cyrus-sasl: depends on libcrypt-compat when building with glibc

### DIFF
--- a/libs/cyrus-sasl/Makefile
+++ b/libs/cyrus-sasl/Makefile
@@ -37,7 +37,7 @@ endef
 
 define Package/libsasl2
   $(call Package/libsasl2/Default)
-  DEPENDS:=+libopenssl
+  DEPENDS:=+USE_GLIBC:libcrypt-compat +libopenssl
   TITLE+= (libraries)
 endef
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @flyn-org

**Description:**
Add missing dependency `+USE_GLIBC:libcrypt-compat` to express dependency on `libcrypto.so.1` when building with GNU glibc.

Bumping PKG_RELEASE isn't required as the package anyway didn't build against glibc previously and no changes are introduced when building against musl.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
