### PR TITLE
banip: Split log and drop into different rules

### DIFF
--- a/net/banip/files/banip-functions.sh
+++ b/net/banip/files/banip-functions.sh
@@ -652,9 +652,9 @@ f_nftinit() {
 		printf "%s\n" "add chain inet banIP _reject"
 		# flood chains
 		#
-		printf "%s\n" "add chain inet banIP _icmpflood"
-		printf "%s\n" "add chain inet banIP _udpflood"
-		printf "%s\n" "add chain inet banIP _synflood"
+		[ "${ban_icmplimit}" -gt "0" ] && printf "%s\n" "add chain inet banIP _icmpflood"
+		[ "${ban_udplimit}" -gt "0" ] && printf "%s\n" "add chain inet banIP _udpflood"
+		[ "${ban_synlimit}" -gt "0" ] && printf "%s\n" "add chain inet banIP _synflood"
 		# named counter
 		#
 		printf "%s\n" "add counter inet banIP cnt_icmpflood"
@@ -666,12 +666,18 @@ f_nftinit() {
 		# default flood chains rules
 		#
 		#
-		[ -n "${log_icmp}" ] && printf "%s\n" "add rule inet banIP _icmpflood ${log_icmp}"
-		printf "%s\n" "add rule inet banIP _icmpflood counter name cnt_icmpflood drop"
-		[ -n "${log_udp}" ] && printf "%s\n" "add rule inet banIP _udpflood ${log_udp}"
-		printf "%s\n" "add rule inet banIP _udpflood counter name cnt_udpflood drop"
-		[ -n "${log_syn}" ] && printf "%s\n" "add rule inet banIP _synflood ${log_syn}"
-		printf "%s\n" "add rule inet banIP _synflood counter name cnt_synflood drop"
+		if [ "${ban_icmplimit}" -gt "0" ]; then
+			[ -n "${log_icmp}" ] && printf "%s\n" "add rule inet banIP _icmpflood ${log_icmp}"
+			printf "%s\n" "add rule inet banIP _icmpflood counter name cnt_icmpflood drop"
+		fi
+		if [ "${ban_udplimit}" -gt "0" ]; then
+			[ -n "${log_udp}" ] && printf "%s\n" "add rule inet banIP _udpflood ${log_udp}"
+			printf "%s\n" "add rule inet banIP _udpflood counter name cnt_udpflood drop"
+		fi
+		if [ "${ban_synlimit}" -gt "0" ]; then
+			[ -n "${log_syn}" ] && printf "%s\n" "add rule inet banIP _synflood ${log_syn}"
+			printf "%s\n" "add rule inet banIP _synflood counter name cnt_synflood drop"
+		fi
 
 		# default reject chain rules
 		#


### PR DESCRIPTION
Rules that log with limits and drop are not working as expected because the limits are also affecting the action, causing the packets over the limit to skip the drop.

Fix this by splitting log (with limit) and drop into separate rules.

For the flood rules that use "limit rate over", create separate chains to log and drop.

Fixes openwrt/packages#27990

## 📦 Package Details

**Maintainer:** @dibdot
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Split nft rules that log and drop into 2 different rules so that the `limit` option doesn't affect the drop.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.4
- **OpenWrt Target/Subtarget:** mediatek/mt7622
- **OpenWrt Device:** Linksys E8450 (UBI)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/banip/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
