### PR TITLE
bind: save out served domains on service stop

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.20.15
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>

--- a/net/bind/files/named.init
+++ b/net/bind/files/named.init
@@ -20,6 +20,10 @@ reload_service() {
 	rndc -q reload
 }
 
+stop_service() {
+	rndc stop
+}
+
 start_service() {
 	user_exists bind 57 || user_add bind 57
 	group_exists bind 57 || group_add bind 57


### PR DESCRIPTION
If named gets stopped, then started again, but isc-dhcpd isn't also restarted, then we want named to at least have the existing content.

## 📦 Package Details

**Maintainer:** @nmeyerhans 

**Description:**
Save domains we serve dynamically so they're reloaded if the server gets started after a stop.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** HEAD
- **OpenWrt Target/Subtarget:** x86_64/generic
- **OpenWrt Device:** supermicro-sys-5018d-fn8t

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
 - [ ] It is structured in a way that it is potentially upstreamable

cc: @Alphix @systemcrash 