### PR TITLE
django: update to version 5.1.14

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=5.1.7
+PKG_VERSION:=5.1.14
 PKG_RELEASE:=1
 
 PYPI_NAME:=Django
-PKG_HASH:=30de4ee43a98e5d3da36a9002f287ff400b43ca51791920bfb35f6917bfe041c
+PKG_HASH:=b98409fb31fdd6e8c3a6ba2eef3415cc5c0020057b43b21ba7af6eff5f014831
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Peter Stadler <peter.stadler@student.uibk.ac.at>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: @commodo 

Includes many CVEs fixes e.g.
- CVE-2025-64458
- CVE-2025-64459
- CVE-2025-59681
- CVE-2025-59682 and others while bumping this from version 5.1.7

Release notes:
https://docs.djangoproject.com/en/5.2/releases/5.1.14/

Fixes:
```
ERROR Missing dependencies:
	setuptools<69.3.0,>=61.0.0
make[3]: *** [Makefile:51: /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/pypi/Django-5.1.7/.built] Error 1
time: package/feeds/packages/django/compile#4.09#1.44#5.60
```

From https://downloads.openwrt.org/releases/faillogs-24.10/aarch64_cortex-a53/packages/django/compile.txt