### PR TITLE
CI: set explicit workflow permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   labeler:

--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -3,6 +3,10 @@ name: Test and Build
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   formalities:
     name: Test Formalities


### PR DESCRIPTION
Add explicit permissions for modifying pull requests to labeler and multi-arch-test-build.. The workflow works as is without these in a fork and the token has correct permissions, but it doesn't when running in an org repo, so hopefully this does the trick.