### PR TITLE
net-snmp: fix literal string test in snmpd_sink_add

### DIFF
--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -233,7 +233,7 @@ snmpd_sink_add() {
 	local host
 
 	config_get host "$cfg" host
-	[ -n "section" -a -n "$host" ] || return 0
+	[ -n "$section" -a -n "$host" ] || return 0
 	# optional community
 	config_get community "$cfg" community
 	# optional port


### PR DESCRIPTION
The function snmpd_sink_add() has a guard clause that tests the literal string "section", not the variable value "$section".

The test `[ -n "section" ]` always evaluates to true because the string literal "section" is non-empty, making the check useless.

This function is only called internally with hardcoded arguments, so the bug has no actual impact currently. For the same reason, this change should not break existing configurations. However, I think it should be fixed so future callers do not have a false sense of security.

## 📦 Package Details

**Maintainer:** @stintel 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

This modifies the `snmpd_sink_add` function, used to create SNMP configuration directives including `trapsink`, `trap2sink`, and `informsink`, to fix a semantically useless non-empty string literal test.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 21.02-SNAPSHOT
- **OpenWrt Target/Subtarget:** Redacted for privacy reasons (bug isn't platform-specific)
- **OpenWrt Device:** Redacted for privacy reasons (bug isn't platform-specific)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
