### PR TITLE
ksmbd-tools: bump to 3.5.6

### DIFF
--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
-PKG_VERSION:=3.5.5
+PKG_VERSION:=3.5.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/cifsd-team/ksmbd-tools/releases/download/$(PKG_VERSION)
-PKG_HASH:=72310cf88723d44cb8144a4fa6aa2c60acf84bdc8bb6384547d6a48bc015af9a
+PKG_HASH:=8ce27cf947667b634478186aa7ef91fce68461c781d3880693a4639f8fecc397
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING

--- a/net/ksmbd-tools/files/ksmbd.init
+++ b/net/ksmbd-tools/files/ksmbd.init
@@ -54,6 +54,7 @@ smb_header()
 
 	config_get_sane workgroup "$1" workgroup "WORKGROUP"
 	config_get_sane description "$1" description "Ksmbd on OpenWrt"
+	config_get_bool ALLOW_GUEST_IPC "$1" allow_guest_ipc 0
 	config_get_bool ALLOW_LEGACY_PROTOCOLS "$1" allow_legacy_protocols 0
 
 	sed -e "s#|NAME|#$hostname#g" \
@@ -67,6 +68,10 @@ smb_header()
 		
 		printf "\n######### Dynamic written config options #########\n"
 
+		if [ "$ALLOW_GUEST_IPC" -eq 1 ]; then
+			logger -p daemon.info -t 'ksmbd' "Guest access to the IPC$ share is enabled!"
+			printf "\tguest ok = yes\n"
+		fi
 		if [ "$ALLOW_LEGACY_PROTOCOLS" -eq 1 ]; then
 			logger -p daemon.info -t 'ksmbd' "Legacy Protocols allowed, don't use this option for secure environments!"
 			printf "\tserver min protocol = NT1\n"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** nobody


**Description:**
Major changes are:

- Increase max ip connections(8->32) and max connections(128->256).
https://github.com/cifsd-team/ksmbd-tools/commit/4f579760c1cdec3d551df379f55627cf47debba4

- Unset guest_ok = yes for $ipc share by default.
https://github.com/cifsd-team/ksmbd-tools/commit/ba8dff03998b13942d2adf4ef167073504e95ce6

- add new UCI option "allow_guest_ipc" to section [globals] (default disabled)

---

## 🧪 Run Testing Details

- **OpenWrt Version: snapshot**
- **OpenWrt Target/Subtarget: mediatek/filogic**
- **OpenWrt Device: MT6000**

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
