### PR TITLE
openconnect: fix off-by-one while condition

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=9.12
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.infradead.org/openconnect/download

--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -86,7 +86,7 @@ proto_openconnect_setup() {
 		[ -n $uri ] && server=$(echo $uri | awk -F[/:] '{print $4}')
 
 		logger -t "openconnect" "adding host dependency for $server at $config"
-		while resolveip -t 10 "$server" > "$tmpfile" && [ "$trials" -gt 0 ]; do
+		while ! resolveip -t 10 "$server" > "$tmpfile" && [ "$trials" -gt 0 ]; do
 			sleep 5
 			trials=$((trials - 1))
 		done


### PR DESCRIPTION
resolveip returns 0 on success. This means that the while loop will just run until all tries are exhausted. But this was not the intended behaviour.

Fixes: 20ea72607bbf ("openconnect: make host dependency more resilient")

## 📦 Package Details

**Maintainer:** @nmav 

**Description:**
Fixes #28015 

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable