### PR TITLE
tcpreplay: link against libbpf if enabled 

### DIFF
--- a/net/tcpreplay/Makefile
+++ b/net/tcpreplay/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tcpreplay
 PKG_VERSION:=4.5.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/appneta/tcpreplay/releases/download/v$(PKG_VERSION)
@@ -35,7 +35,8 @@ define Package/tcpreplay/default
   CATEGORY:=Network
   URL:=http://tcpreplay.appneta.com/
   MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
-  DEPENDS:=+librt +libpcap +libdnet +USE_MUSL:musl-fts
+  DEPENDS:=+librt +libpcap +libdnet +USE_MUSL:musl-fts \
+           +PACKAGE_libbpf:libbpf
 endef
 
 define Package/tcpbridge
@@ -139,10 +140,9 @@ CONFIGURE_VARS += \
 	ac_cv_path_pcncfg=no
 
 CONFIGURE_ARGS += \
-	--enable-force-pf \
-	--enable-dynamic-link \
 	--with-libdnet="$(STAGING_DIR)/usr" \
-	--with-libpcap="$(STAGING_DIR)/usr"
+	--with-libpcap="$(STAGING_DIR)/usr" \
+	--enable-dynamic-link
 
 TARGET_CFLAGS += -std=gnu11
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  me

**Description:**

When libbpf is enabled, it is detected by the configure logic.
So, when that happens, add it as a dependency.


---

## 🧪 Run Testing Details

- **OpenWrt Version:** x86 master
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
