### PR TITLE
ddns-scripts: fix luci XHR timeout when restarting ddns service

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=85
+PKG_RELEASE:=86
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_lucihelper.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_lucihelper.sh
@@ -149,7 +149,7 @@ case "$1" in
 	start)
 		[ -z "$SECTION" ] &&  usage_err "command 'start': 'SECTION' not set"
 		if [ "$VERBOSE" -eq 0 ]; then	# start in background
-			"$DDNSPRG" -v 0 -S "$SECTION" -- start &
+			("$DDNSPRG" -v 0 -S "$SECTION" -- start >/dev/null 2>&1 &)
 		else
 			"$DDNSPRG" -v "$VERBOSE" -S "$SECTION" -- start
 		fi
@@ -160,7 +160,7 @@ case "$1" in
 	restart)
 		"$DDNSPRG" -- stop
 		sleep 1
-		"$DDNSPRG" -- start
+		"$DDNSPRG" -- start >/dev/null 2>&1
 		;;
 	stop)
 		if [ -n "$SECTION" ]; then


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert 

**Description:**
Redirect stdout and stderr to /dev/null when starting/restarting the ddns service in the background. Without this redirection, file descriptors are inherited by the child process, preventing proper process detachment and causing luci's XHR requests to timeout when using.

Both, start and restart actions are affected by this issue

---

## 🧪 Run Testing Details

- **OpenWrt Version:24.10.4-r28959-29397011cc**

Other versions are also affected (Found this on a commercial router running some 21.02)

### Without changes
```shell
curl 'http://192.168.1.250/ubus/?1765142364195' \
  -X POST \
  -H 'Referer: http://192.168.1.250/cgi-bin/luci/admin/services/ddns' \
  --data-raw '[{"jsonrpc":"2.0","id":47,"method":"call","params":["f1f750f0759e06723be41c4df8ff0d42","file","exec",{"command":"/usr/lib/ddns/dynamic_dns_lucihelper.sh","params":["-S","duckdns","--","start"],"env":null}]}]'
curl: (18) transfer closed with outstanding read data remaining
[%  
``` 
### With these changes
```shell
curl 'http://192.168.1.250/ubus/?1765142364195' \
  -X POST \
  -H 'Referer: http://192.168.1.250/cgi-bin/luci/admin/services/ddns' \
  --data-raw '[{"jsonrpc":"2.0","id":47,"method":"call","params":["f1f750f0759e06723be41c4df8ff0d42","file","exec",{"command":"/usr/lib/ddns/dynamic_dns_lucihelper.sh","params":["-S","duckdns","--","restart"],"env":null}]}]'

[{"jsonrpc":"2.0","id":47,"result":[0,{"code":0}]}]% 
``` 
---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.