### PR TITLE
vim: disable wayland to fix missing dependency

### DIFF
--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=vim
 PKG_VERSION:=9.1.1918
 PKG_XXD_VERSION:=2025.08.24
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 VIMVER:=91
 
 PKG_SOURCE_PROTO:=git
@@ -126,7 +126,8 @@ CONFIGURE_ARGS += \
 	--disable-libsodium \
 	--disable-selinux \
 	--with-tlib=ncurses \
-	--with-compiledby="non-existent-hostname-compiled"
+	--with-compiledby="non-existent-hostname-compiled" \
+	--with-wayland=no
 
 CONFIGURE_VARS += \
 	ac_cv_header_elf_h=no \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @ratkaj, @neheb

**Description:**

vim autodetects wayland if it's installed, but there's no dependency on it which results in:

```
Package vim-full is missing dependencies for the following libraries: libwayland-client.so.0
```

Fixes: 4406b79 ("vim: bump to 9.1.1918")

Related:
- #27892

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

vim-full installs, runs and reports being compiled without wayland.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.