### PR TITLE
unbound: minimal fix for odhcpd lease file parsing

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound

--- a/net/unbound/files/odhcpd.awk
+++ b/net/unbound/files/odhcpd.awk
@@ -190,6 +190,9 @@ function ipv6_ptr( ipv6, arpa, ary, end, m, n, new6, sz, start ) {
 ##############################################################################
 
 function slaac_eui64( mac,    ary, glbit, eui64 ) {
+  # Remove any colons from mac
+  gsub(":", "", mac) ;
+
   if ( length(mac) >= 12 ) {
     # RFC2373 and use DHCPv4 registered MAC to find SLAAC addresses
     split( mac , ary , "" ) ;


### PR DESCRIPTION
**Maintainer:** @EricLuehrsen 

**Description:**
Current odhcpd in master writes MAC addresses with colons in his lease file, this new odhcpd format leads to a crash loop in unbound (if DHCPv4 to SLAAC is selected).

Just remove the colons, before the processing in slaac_eui64 begins, fixes #28032

**Testing:**
Briefly tested with Bananapi BPI-R3, mediatek/filogic, OpenWrt SNAPSHOT r32231-35dbdd644c
