### PR TITLE
treewide: remove python3-distutils dependency

### DIFF
--- a/lang/python/python-babel/Makefile
+++ b/lang/python/python-babel/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-babel
 PKG_VERSION:=2.17.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=babel
 PKG_HASH:=0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d
@@ -40,7 +40,6 @@ define Package/python3-babel
   URL:=https://babel.pocoo.org/
   DEPENDS:= \
     +python3-decimal \
-    +python3-distutils \
     +python3-email \
     +python3-light \
     +python3-logging \

--- a/lang/python/python-docker/Makefile
+++ b/lang/python/python-docker/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-docker
 PKG_VERSION:=7.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=docker
 PKG_HASH:=ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c
@@ -25,8 +25,8 @@ define Package/python3-docker
   TITLE:=A Python library for the Docker Engine API
   URL:=https://github.com/docker/docker-py
   DEPENDS:=\
-	  +python3-light +python3-distutils +python3-logging \
-	  +python3-openssl +python3-packaging +python3-paramiko +python3-six \
+	  +python3-light +python3-logging +python3-openssl \
+	  +python3-packaging +python3-paramiko +python3-six \
 	  +python3-requests +python3-urllib3 +python3-websocket-client
 endef
 

--- a/lang/python/python-incremental/Makefile
+++ b/lang/python/python-incremental/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-incremental
 PKG_VERSION:=24.7.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=incremental
 PKG_HASH:=fb4f1d47ee60efe87d4f6f0ebb5f70b9760db2b2574c59c8e8912be4ebd464c9
@@ -32,7 +32,7 @@ define Package/python3-incremental
   SUBMENU:=Python
   TITLE:=Versions your Python projects
   URL:=https://github.com/twisted/incremental
-  DEPENDS:=+python3-light +python3-distutils +python3-pkg-resources
+  DEPENDS:=+python3-light +python3-pkg-resources
 endef
 
 define Package/python3-incremental/description

--- a/net/fail2ban/Makefile
+++ b/net/fail2ban/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fail2ban
 PKG_VERSION:=1.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fail2ban/fail2ban/tar.gz/$(PKG_VERSION)?
@@ -30,7 +30,6 @@ define Package/fail2ban
   +nftables \
   +python3-light \
   +python3-ctypes \
-  +python3-distutils \
   +python3-email \
   +python3-logging \
   +python3-sqlite3 \

--- a/net/flent/Makefile
+++ b/net/flent/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=flent
 PKG_VERSION:=2.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=flent
 PKG_HASH:=04fc21de858863560423e79c822f405225f829afd8e5d62293099fbef341f9e8
@@ -26,7 +26,6 @@ define Package/flent
     +python3-light \
     +python3-uuid \
     +python3-logging \
-    +python3-distutils \
     +python3-defusedxml \
     +flent-tools \
     +netperf \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @BKPepe @jmarcet @jefferyto @PolynomialDivision 

**Description:**
As the `python3-distutils` was dropped while bumping the version to `3.13.9` via 97a92f2e7a77c39d087892f5c9a7350c31f3d65b, remove the `python3-distutils` from all packages that are currently using it.

OpenWrt already uses recent enough releases of these packages that have adapted to work without distutils, so the dependency can be safely removed.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** Snapshot r32247-75915e3580
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** Mellanox Spectrum, Gowin

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
~~- [ ] It is structured in a way that it is potentially upstreamable~~