### PR TITLE
lxc: fix meson.build on esoteric host systems

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -10,13 +10,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=6.0.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/
 PKG_HASH:=2e540c60b9dd49e7ee1a4efa5e9c743b05df911b81b375ed5043d9dd7ee0b48a
 
-PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
+PKG_MAINTAINER:=
 PKG_LICENSE:=LGPL-2.1-or-later BSD-2-Clause GPL-2.0
 PKG_LICENSE_FILES:=COPYING LICENSE.GPL2 LICENSE.LGPL2.1
 PKG_CPE_ID:=cpe:/a:linuxcontainers:lxc
@@ -32,6 +32,7 @@ MESON_ARGS += \
 	-Dman=false \
 	-Dapparmor=false \
 	-Dselinux=false \
+	-Ddistrosysconfdir=/etc/default \
 	-Dseccomp=$(if $(CONFIG_LXC_SECCOMP),true,false) \
 	-Dexamples=false \
 	-Db_pie=true \


### PR DESCRIPTION
When building lxc's meson.build tries to infer
something for the target system out of the host
build OS. This isn't reproducible and can actually fail on some OS' like NixOS.

The failure looked like this, early in the
building stage of lxc:

> ../../../../build_dir/target-aarch64_cortex-a53_musl/lxc-6.0.5/meson.build:166:8: ERROR: Problem encountered: "distrosysconfdir" is not set

The /etc/default seems to be something that is
derived on most host systems, so use that as the
explicit config.

This fixes building lxc on NixOS and similar.

This also makes the build more pure and
reproducible. Before this commit building the same set of checkouts, same config would yield
different lxc artifacts on RedHat and Ubuntu.
It was probably harmless though.

---

## 📦 Package Details

**Maintainer:** @ratkaj 

**Description:** LXC is the userspace control package for Linux Containers(...)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** d11b77db5eca3e20c5c238c55d80059229a188b3
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

