### PR TITLE
[24.10] unbound: update to 1.24.2

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.24.0
+PKG_VERSION:=1.24.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound
-PKG_HASH:=147b22983cc7008aa21007e251b3845bfcf899ffd2d3b269253ebf2e27465086
+PKG_HASH:=44e7b53e008a6dcaec03032769a212b46ab5c23c105284aa05a4f3af78e59cdb
 
 PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/unbound/patches/010-configure-uname.patch
+++ b/net/unbound/patches/010-configure-uname.patch
@@ -3,7 +3,7 @@ Fix cross compile errors by inserting an environment variable for the
 target. Use "uname" on host only if "UNAME" variable is empty.
 --- a/configure.ac
 +++ b/configure.ac
-@@ -902,7 +902,7 @@ if test x_$ub_test_python != x_no; then
+@@ -904,7 +904,7 @@ if test x_$ub_test_python != x_no; then
     fi
  fi
  


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @EricLuehrsen 

**Description:**
Fixes: Possible Domain Hijacking via promiscuous NS Records (CVE-2025-11411) Changelog: https://www.nlnetlabs.nl/projects/unbound/download/#unbound-1-24-2 Upstream commit f6269baa605d31859f28770e01a24e3677e5f82c https://github.com/NLnetLabs/unbound/commit/f6269baa605d31859f28770e01a24e3677e5f82c


(cherry picked from commit 0ca33e71e99275e77884590006bcfc704cbcfec7)
---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10-SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
