### PR TITLE
[25.12] CI: disable comments and labels

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -11,33 +11,6 @@ jobs:
   formalities:
     name: Test Formalities
     uses: openwrt/actions-shared-workflows/.github/workflows/formal.yml@main
-    with:
-      post_comment: true
-
-  label_formality_status:
-    name: Add formality check labels
-    runs-on: ubuntu-slim
-    needs: formalities
-    if: always()
-    permissions:
-      pull-requests: write
-
-    steps:
-      - name: Add 'not following guidelines' label
-        if: needs.formalities.result == 'failure'
-        uses: buildsville/add-remove-label@v2.0.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: "not following guidelines"
-          type: add
-
-      - name: Remove 'not following guidelines' label
-        if: needs.formalities.result == 'success'
-        uses: buildsville/add-remove-label@v2.0.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: "not following guidelines"
-          type: remove
 
   build:
     name: Feeds Package Test Build


### PR DESCRIPTION
Disable posting formality check status comments and adding related labels while the security token is being figured out.

Backport from stable:
- #28054

Link: https://github.com/openwrt/packages/pull/28011
Fixes: 2c558a8 ("ci: label formality failures")
Fixes: 7658669 ("multi-arch-test-build: post formal summaries to PR")
