### PR TITLE
bind: manual fix for IPv6 server unreachable noise

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.20.15
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>

--- a/net/bind/files/bind/named.conf
+++ b/net/bind/files/bind/named.conf
@@ -7,6 +7,9 @@ options {
 
 	// This is used e.g. by isc-dhcp
 	allow-new-zones yes;
+
+	// Uncomment this if you don't have IPv6 connectivity
+	//query-source-v6 none;
 };
 
 // prime the server with knowledge of the root servers


### PR DESCRIPTION
Until we have a failsafe way of detecting no IPv6 internet connectivity automatically, allow the users to set it manually for now.

## 📦 Package Details

**Maintainer:** @nmeyerhans 

**Description:**
We don't need to start named with '-4', we can just use this line instead.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** HEAD
- **OpenWrt Target/Subtarget:** x86_64/generic
- **OpenWrt Device:** pc-engines-apu6

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
- [ ] It is structured in a way that it is potentially upstreamable
