### PR TITLE
zoneinfo: updated to 2025c release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2025b
+PKG_VERSION:=2025c
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public-Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.iana.org/time-zones/repository/releases
-PKG_HASH:=11810413345fc7805017e27ea9fa4885fd74cd61b2911711ad038f5d28d71474
+PKG_HASH:=4aa79e4effee53fc4029ffe5f6ebe97937282ebcdf386d5d2da91ce84142f957
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=05f8fedb3525ee70d49c87d3fae78a8a0dbae4fe87aa565c65cda9948ae135ec
+   HASH:=697ebe6625444aef5080f58e49d03424bbb52e08bf483d3ddb5acf10cbd15740
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT master
Run tested: n/a

Description:

This release contains the following changes:

   Briefly:

     Several code changes for compatibility with FreeBSD.

   Changes to past timestamps

     Baja California agreed with California’s DST rules in 1953 and in
     1961 through 1975, instead of observing standard time all year.
     (Thanks to Alois Treindl.)

   Changes to build procedure

     Files in distributed tarballs now have correct commit times.
     Formerly, the committer’s time zone was incorrectly ignored.

     Distribution products (*.asc, *.gz, and *.lz) now have
     reproducible timestamps.  Formerly, only the contents of the
     compressed tarballs had reproducible timestamps.

     By default, distributed formatted man pages (*.txt) now use UTF-8
     and are left-adjusted more consistently.  A new Makefile macro
     MANFLAGS can override these defaults.  (Thanks to G. Branden
     Robinson for inspiring these changes.)

   Changes to code

     An unset TZ is no longer invalid when /etc/localtime is missing,
     and is abbreviated "UTC" not "-00".  This reverts to 2024b behavior.
     (Problem and patch reported by Dag-Erling Smørgrav.)

     New function offtime_r, short for fixed-offset localtime_rz.
     It is defined if STD_INSPIRED is defined.
     (Patch from Dag-Erling Smørgrav.)

     tzset etc. are now more cautious about questionable TZ settings.
     Privileged programs now reject TZ settings that start with '/',
     unless they are TZDEFAULT (default "/etc/localtime") or
     start with TZDIR then '/' (default "/usr/share/zoneinfo/").
     Unprivileged programs now require files to be regular files
     and reject relative names containing ".." directory components;
     formerly, only privileged programs did those two things.
     These changes were inspired by similar behavior in FreeBSD.
     On NetBSD, unprivileged programs now use O_REGULAR to check
     whether a TZ setting starting with '/' names a regular file,
     avoiding a minor security race still present elsewhere.
     TZ strings taken from tzalloc arguments are now treated with
     no less caution than TZ strings taken from the environment, as
     the old undocumented behavior would have been hard to explain.
     tzset etc. no longer use the ‘access’ system call to check access;
     instead they now use the system calls issetugid, getauxval,
     getresuid/getresgid, and geteuid/getegid/getuid/getgid (whichever
     first works) to test whether a program is privileged.
     Compile with -DHAVE_SYS_AUXV_H=[01] to enable or disable
     <sys/auxv.h> which (if it defines AT_SECURE) enables getauxval,
     and compile with -DHAVE_ISSETUGID=[01], -DHAVE_GETRESUID=[01], and
     -DHAVE_GETEUID=[01] to enable or disable the other calls’ use.

     The new CFLAGS option -DTZ_CHANGE_INTERVAL=N makes tzset etc.
     check for TZif file changes if the in-memory data are N seconds
     old or more, and are derived from the TZ environment variable.
     This is intended for platforms that want tzset etc. to reflect
     changes to whatever file TZ selects (including changes to
     /etc/localtime if TZ is unset).  If N is negative (the default)
     these checks are omitted; this is the traditional behavior.

     The new CFLAGS options -DHAVE_STRUCT_STAT_ST_CTIM=0 and
     -DHAVE_STRUCT_TIMESPEC=0 port to non-POSIX.1-2008 platforms
     that lack st_ctim and struct timespec, respectively.

     tzset etc. now treat ' ' like '_' in time zone abbreviations,
     just as they treat other invalid bytes.  This continues the
     transition begun in release 96k, which removed spaces in tzdata
     because the spaces break time string parsers.

     The new CFLAGS option -DTHREAD_PREFER_SINGLE causes tzcode
     in single-threaded processes to avoid locks, as FreeBSD does.
     This can save time in single-threaded apps.  The threadedness
     testing costs CPU time and energy in multi-threaded apps.
     New options -DHAVE___ISTHREADED and -DHAVE_SYS_SINGLE_THREADED_H
     can help configure how to test for single-threadedness.

     The new CFLAGS option -DTHREAD_RWLOCK uses read-write locks, as
     macOS does, instead of mutexes.  This saves real time when TZ is
     rarely changing and many threads call tzcode simultaneously.
     It costs more CPU time and energy.

     The new CFLAGS option -TTHREAD_TM_MULTI causes localtime to return
     a pointer to thread-specific memory, as FreeBSD does, instead of
     to the same memory in all threads.  This supports unportable
     programs that incorrectly use localtime instead of localtime_r.
     This option affects gmtime and offtime similarly to localtime.
     Because the corresponding storage is freed on thread exit, this
     option is incompatible with POSIX.1-2024 and earlier.  It also
     costs CPU time and memory.

     tzfree now preserves errno, consistently with POSIX.1-2024 ‘free’.

     tzcode now uses mempcpy if available, guessing its availability.
     Compile with -DHAVE_MEMPCPY=1 or 0 to override the guess.

     tzcode now uses strnlen to improve asymptotic performance a bit.
     Compile with -DHAVE_STRNLEN=0 if your platform lacks it.

     tzcode now hand-declares unistd.h-provided symbols like getopt
     if HAVE_UNISTD_H=0, not if HAVE_POSIX_DECLS=0.

     tzset etc. now have an experimental OPENAT_TZDIR option;
     see Makefile and localtime.c for details.

     On platforms like GNU/Hurd that do not define PATH_MAX,
     exceedingly long TZ strings no longer fail merely because they
     exceed an arbitrary file name length limit imposed by tzcode.

     zic has new options inspired by FreeBSD.  ‘-D’ skips creation of
     output ancestor directories, ‘-m MODE’ sets output files’ mode,
     and ‘-u OWNER[:GROUP]’ sets output files’ owner and group.

     zic now uses the fdopen function, which was standardized by
     POSIX.1-1988 and is now safe to use in portable code.
     This replaces its use of the older umask function, which
     complicated maintenance.

   Changes to commentary

     The leapseconds file contains commentary about the IERS and NIST
     last-modified and expiration timestamps for leap second data.
     (Thanks to Judah Levine.)

     Commentary now also uses characters from the set –‘’“”•≤ as this
     can be useful and should work with current applications.  This
     also affects data in iso3166.tab and zone1970.tab, which now
     contain strings like “Côte d’Ivoire” instead of “Côte d'Ivoire”.