### PR TITLE
postgresql: fix missing symbols at runtime

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postgresql
 PKG_VERSION:=17.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=PostgreSQL
 PKG_CPE_ID:=cpe:/a:postgresql:postgresql
@@ -119,7 +119,9 @@ PGSQL_CONFIG_VARS:= \
 	pgac_cv_snprintf_size_t_support=yes \
 	USE_DEV_URANDOM=1 \
 	ac_cv_file__dev_urandom="/dev/urandom" \
-	ZIC=zic
+	ZIC=zic \
+	pgac_cv_prog_cc_LDFLAGS_EX_BE__Wl___export_dynamic=yes \
+	pgac_cv_prog_cc_LDFLAGS__Wl___as_needed=yes
 
 TARGET_CONFIGURE_OPTS+=$(PGSQL_CONFIG_VARS)
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt 
**Description:**

Fixes pgsql-server: the setup fails for any folder
Fixes #27228

Sets postgresql-specific configure flags that configure cannot run-test to determine their value. This fixes improperly linked files that prevent database initialization (at least) from working on the device.

Thank you to @Yang-Wei-Ting for pointing me to the fix.

---

## 🧪 Run Testing Details

Self-built snapshot of master as of Dec 13 (main repo commit: 24b8db118b) as packages are out of date for `aarch64_cortex-a76`.

- **OpenWrt Version:** r32307-24b8db118b
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** raspberrypi,5-model-b
- **Board Profile:** rpi-5

1. Built SDK and ImageBuilder
2. In the SDK built postgresql, Zabbix, and dependencies and packages for image
3. Used ImageBuilder to create squashfs images ('factory' and 'sysupgrade')
4. Created an image with the packages built above
5. Observed that postgresql DB was correctly created (which was not the case before)
6. Followed my guide for Zabbix Web UI and server (https://www.wildtechgarden.ca/doc/presentations/zabbix-on-openwrt/zabbix-host-monitoring-on-openwrt/)
7. Observed that Zabbix server and Zabbix WebUI operated correctly using PostgreSQL.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
