### PR TITLE
php8: fix missing dependency with gettext

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=8.4.15
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=PHP-3.01


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @mhei 

**Description:**

Some binaries gain a dependency on libstdcpp when mod-gettext is included
in the build, however this was not explicitly declared, so packaging
fails with (e.g.):

Package php8-cgi is missing dependencies for the following libraries:
libstdc++.so.6

EDIT for revised PR:

Updated commits (per #28078) fix this by:

* Make use of --with-gettext depend on a configure flag (enabled by
  default, since that matches current full build behaviour)
* Make sub-packages which require --with-gettext depend on the
  configure flag

This means that e.g. php-cgi would not have gettext support if the
configure flag was disabled, and e.g. php-mod-gettext and php-mod-intl
would not be selectable.

Similarly for LIBXML:

PHP8_LIBXML and PHP8_DOM are are enabled by default and packages
which depend on libxml2 and --enable-dom=shared are not shown (and
the related configure args are disabled) if the config options are
not enabled.

---

## 🧪 Run Testing Details

Self-built snapshot of master as of Dec 13 (main repo commit: 24b8db118b) as packages are out of date for `aarch64_cortex-a76`.

- **OpenWrt Version:** r32307-24b8db118b
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** raspberrypi,5-model-b
- **Board Profile:** rpi-5


1. Built SDK and ImageBuilder
2. In the SDK built php8, Zabbix, and dependencies and packages for image
3. Used ImageBuilder to create squashfs images ('factory' and 'sysupgrade')
4. Created an image with the packages built above
5. Observed Zabbix frontend operates correctly (it depends on php8-cgi and apache-mod-php8
   which depend on php8-mod-gettext).

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
