### PR TITLE
ariang: bump to 1.3.14

### DIFF
--- a/net/ariang/Makefile
+++ b/net/ariang/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ariang
-PKG_VERSION:=1.3.11
+PKG_VERSION:=1.3.12
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
 PKG_SOURCE_URL:=https://github.com/mayswind/AriaNg/releases/download/$(PKG_VERSION)
-PKG_HASH:=deaaebaf8d59901f0fbdb839daceb1f2768b3d65425e393202786fa2c804bcf9
+PKG_HASH:=55132161c640df4d2cba28d6eaeca3bec753776756870cf3b365416d3fb01122
 UNPACK_CMD=unzip -q -d $(1) $(DL_DIR)/$(PKG_SOURCE)
 
 PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>

--- a/net/ariang/Makefile
+++ b/net/ariang/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ariang
-PKG_VERSION:=1.3.12
+PKG_VERSION:=1.3.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
 PKG_SOURCE_URL:=https://github.com/mayswind/AriaNg/releases/download/$(PKG_VERSION)
-PKG_HASH:=55132161c640df4d2cba28d6eaeca3bec753776756870cf3b365416d3fb01122
+PKG_HASH:=8ad64e6e8e6639d2d8125f6fae2110c1f4015cec8fe003aa563d2b372f889297
 UNPACK_CMD=unzip -q -d $(1) $(DL_DIR)/$(PKG_SOURCE)
 
 PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>

--- a/net/ariang/Makefile
+++ b/net/ariang/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ariang
-PKG_VERSION:=1.3.11
+PKG_VERSION:=1.3.14
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
 PKG_SOURCE_URL:=https://github.com/mayswind/AriaNg/releases/download/$(PKG_VERSION)
-PKG_HASH:=deaaebaf8d59901f0fbdb839daceb1f2768b3d65425e393202786fa2c804bcf9
+PKG_HASH:=e00db79b4cabac70f71c2673a6d454c8a92bfa9aa1f37bb00b01b7505f956805
 UNPACK_CMD=unzip -q -d $(1) $(DL_DIR)/$(PKG_SOURCE)
 
 PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>
@@ -39,7 +39,7 @@ endef
 
 define Package/ariang-nginx
   $(Package/ariang/default)
-  DEPENDS += +nginx
+  EXTRA_DEPENDS:=nginx$(if $(CONFIG_USE_APK), (>=0))
   TITLE += for nginx webserver
 endef
 


### PR DESCRIPTION
Maintainer: @Ansuel Ansuel Smith [ansuelsmth@gmail.com](mailto:ansuelsmth@gmail.com)

## Description:

ariang: bump to 1.3.13

Change log is available at: 
https://github.com/mayswind/AriaNg/releases/tag/1.3.12
https://github.com/mayswind/AriaNg/releases/tag/1.3.13

## 🧪 Run Testing Details

- OpenWrt Version: snapshot
- OpenWrt Target/Subtarget: aarch64/qualcommax
- OpenWrt Device: ipq6000-360v6

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
