### PR TITLE
[zerotier] Update license in Makefile

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
 PKG_VERSION:=1.16.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
@@ -15,7 +15,7 @@ PKG_HASH:=aa9de313d365bf0efb3871aaa56f2d323a08f46df47b627c4eff4f4203fa7fc5
 PKG_BUILD_DIR:=$(BUILD_DIR)/ZeroTierOne-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
-PKG_LICENSE:=BSL 1.1
+PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=LICENSE.txt
 
 PKG_ASLR_PIE:=0
@@ -48,6 +48,7 @@ endif
 MAKE_FLAGS += \
 	ZT_EMBEDDED=1 \
 	ZT_SSO_SUPPORTED=0 \
+	ZT_NONFREE=0 \
 	DEFS="" \
 	OSTYPE="Linux" \
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @mwarning

**Description:**
ZeroTier 1.16.0 changed the license to `MPL-2.0` if compiled with `ZT_NONFREE=0`, this patch reflect that change in license. The non-free code only contains the controller, which is by default not included (so the binary should not change compared to the previous package release).

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.4
- **OpenWrt Target/Subtarget:** ath79/generic
- **OpenWrt Device:** tl-wr1043nd-v3

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.