### PR TITLE
squid: restore upstream acl

### DIFF
--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -56,7 +56,6 @@ endef
 
 define Package/squid/conffiles
 /etc/config/squid
-/etc/squid/squid.conf
 endef
 
 CONFIGURE_ARGS += \

--- a/net/squid/files/squid.conf
+++ b/net/squid/files/squid.conf
@@ -39,7 +39,8 @@ http_access deny CONNECT !SSL_ports
 # We strongly recommend the following be uncommented to protect innocent
 # web applications running on the proxy server who think the only
 # one who can access services on "localhost" is a local user
-#http_access deny to_localhost
+http_access deny to_localhost
+http_access deny to_linklocal
 
 #
 # INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS


### PR DESCRIPTION
Restore upstream acl denying access from network to proxy host
Also looping via local link-local addresses since squid 5

Fixes: 78dcc29e47079b6f5aad917dcdf935325b5e4fdf

## 📦 Package Details

**Maintainer:** @ratkaj 

