### PR TITLE
tang: Make sure output and errors of tang are logged to system log

### DIFF
--- a/utils/tang/files/tang.init
+++ b/utils/tang/files/tang.init
@@ -21,5 +21,7 @@ start_service() {
 	procd_set_param command /usr/sbin/tangd -p "${port}" -l /usr/share/tang/db
 	procd_set_param respawn
 	procd_set_param user tang
+	procd_set_param stderr 1
+	procd_set_param stdout 1
 	procd_close_instance
 }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @nmav 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Currently, there is no logging at all, causing difficulties with troubleshooting. Edit originally proposed by @q-b #26076 (comment) and implemented by @rugk #27401

Prior PR was not merged apparently only due to issues with incorrect sign-off, so replicating here,

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.3
- **OpenWrt Target/Subtarget:** x86
- **OpenWrt Device:** LXC

---

## ✅ Formalities

- [ X ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ X ] It can be applied using `git am`
- [ X ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ X ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>