### PR TITLE
prometheus-node-exporter-lua: add chip_name to temperature metric collection

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
 PKG_VERSION:=2026.06.05
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/hwmon.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/hwmon.lua
@@ -39,7 +39,7 @@ local function scrape()
     for sensor_path in fs.glob(hwmon_path .. "/temp*_input") do
       local sensor = string.gsub(fs.basename(sensor_path), "_input$", "")
       local temp = get_contents(sensor_path) / 1000
-      metric_temp_celsius({chip=chip, sensor=sensor}, temp)
+      metric_temp_celsius({chip=chip, sensor=sensor, chip_name=chip_name}, temp)
     end
 
     -- Produce node_hwmon_pwm

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/hwmon.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/hwmon.lua
@@ -10,6 +10,9 @@ local function scrape()
   local metric_temp_celsius = metric("node_hwmon_temp_celsius", "gauge")
   local metric_pwm = metric("node_hwmon_pwm", "gauge")
 
+  local temp_sensors = {}
+  local temp_sensor_counts = {}
+
   for hwmon_path in fs.glob("/sys/class/hwmon/hwmon*") do
     -- Produce node_hwmon_chip_names
     -- See https://github.com/prometheus/node_exporter/blob/7c564bcbeffade3dacac43b07c2eeca4957ca71d/collector/hwmon_linux.go#L415
@@ -35,11 +38,17 @@ local function scrape()
       metric_sensor_label({chip=chip, sensor=sensor, label=sensor_label}, 1)
     end
 
-    -- Produce node_hwmon_temp_celsius
+    -- Collect node_hwmon_temp_celsius
     for sensor_path in fs.glob(hwmon_path .. "/temp*_input") do
       local sensor = string.gsub(fs.basename(sensor_path), "_input$", "")
-      local temp = get_contents(sensor_path) / 1000
-      metric_temp_celsius({chip=chip, sensor=sensor, chip_name=chip_name}, temp)
+      local key = chip .. "\0" .. sensor
+      temp_sensor_counts[key] = (temp_sensor_counts[key] or 0) + 1
+      temp_sensors[#temp_sensors + 1] = {
+        chip = chip,
+        chip_name = chip_name,
+        sensor = sensor,
+        temp = get_contents(sensor_path) / 1000,
+      }
     end
 
     -- Produce node_hwmon_pwm
@@ -50,6 +59,15 @@ local function scrape()
         metric_pwm({chip=chip, sensor=sensor}, pwm)
       end
     end
+  end
+
+  -- Produce node_hwmon_temp_celsius without duplicates
+  for _, sensor_data in ipairs(temp_sensors) do
+    local labels = {chip=sensor_data.chip, sensor=sensor_data.sensor}
+    if (temp_sensor_counts[sensor_data.chip .. "\0" .. sensor_data.sensor] or 0) > 1 then
+      labels.chip_name = sensor_data.chip_name
+    end
+    metric_temp_celsius(labels, sensor_data.temp)
   end
 end
 


### PR DESCRIPTION
removes duplicate sample with mt7996 and others with multiple radios

## 📦 Package Details

**Maintainer:** @champtar

**Description:**
Using the hwmon collector with a Banana Pi BPI-R4 there are duplicate samples for `node_hwmon_temp_celsius{sensor="temp1",chip="ieee80211_phy0"}`. This results in prometheus warnings:
`level=WARN source=scrape.go:1923 msg="Error on ingesting samples with different value but same timestamp" component="scrape manager" scrape_pool=node-exporter target=http://<ip>:9100/metrics num_dropped=2`

Adding the chip_name to node_hwmon_temp_celsius fixes this. 

Current metrics:
Banana Pi BPI-R4
```
node_hwmon_chip_names{chip_name="mt7996_phy0.0",chip="ieee80211_phy0"} 1
node_hwmon_temp_celsius{sensor="temp1",chip="ieee80211_phy0"} 49
node_hwmon_chip_names{chip_name="mt7996_phy0.1",chip="ieee80211_phy0"} 1
node_hwmon_temp_celsius{sensor="temp1",chip="ieee80211_phy0"} 49
node_hwmon_chip_names{chip_name="mt7996_phy0.2",chip="ieee80211_phy0"} 1
node_hwmon_temp_celsius{sensor="temp1",chip="ieee80211_phy0"} 51
```
GL.iNet GL-MT6000
```
node_hwmon_chip_names{chip_name="cpu_thermal",chip="thermal_thermal_zone0"} 1
node_hwmon_temp_celsius{sensor="temp1",chip="thermal_thermal_zone0"} 45.499
node_hwmon_chip_names{chip_name="mdio_bus:01",chip="mdio-bus_mdio-bus:01"} 1
node_hwmon_temp_celsius{sensor="temp1",chip="mdio-bus_mdio-bus:01"} 52
node_hwmon_chip_names{chip_name="mdio_bus:07",chip="mdio-bus_mdio-bus:07"} 1
node_hwmon_temp_celsius{sensor="temp1",chip="mdio-bus_mdio-bus:07"} 64
node_hwmon_chip_names{chip_name="mt7915_phy0",chip="ieee80211_phy0"} 1
node_hwmon_temp_celsius{sensor="temp1",chip="ieee80211_phy0"} 49
node_hwmon_chip_names{chip_name="mt7915_phy1",chip="ieee80211_phy1"} 1
node_hwmon_temp_celsius{sensor="temp1",chip="ieee80211_phy1"} 49
```

Fixed metrics:
Banana Pi BPI-R4
```
node_hwmon_chip_names{chip_name="mt7996_phy0.0",chip="ieee80211_phy0"} 1
node_hwmon_temp_celsius{sensor="temp1",chip_name="mt7996_phy0.0",chip="ieee80211_phy0"} 55
node_hwmon_chip_names{chip_name="mt7996_phy0.1",chip="ieee80211_phy0"} 1
node_hwmon_temp_celsius{sensor="temp1",chip_name="mt7996_phy0.1",chip="ieee80211_phy0"} 55
node_hwmon_chip_names{chip_name="mt7996_phy0.2",chip="ieee80211_phy0"} 1
node_hwmon_temp_celsius{sensor="temp1",chip_name="mt7996_phy0.2",chip="ieee80211_phy0"} 55
```
GL.iNet GL-MT6000
```
node_hwmon_chip_names{chip_name="cpu_thermal",chip="thermal_thermal_zone0"} 1
node_hwmon_temp_celsius{sensor="temp1",chip_name="cpu_thermal",chip="thermal_thermal_zone0"} 45.499
node_hwmon_chip_names{chip_name="mdio_bus:01",chip="mdio-bus_mdio-bus:01"} 1
node_hwmon_temp_celsius{sensor="temp1",chip_name="mdio_bus:01",chip="mdio-bus_mdio-bus:01"} 52
node_hwmon_chip_names{chip_name="mdio_bus:07",chip="mdio-bus_mdio-bus:07"} 1
node_hwmon_temp_celsius{sensor="temp1",chip_name="mdio_bus:07",chip="mdio-bus_mdio-bus:07"} 64
node_hwmon_chip_names{chip_name="mt7915_phy0",chip="ieee80211_phy0"} 1
node_hwmon_temp_celsius{sensor="temp1",chip_name="mt7915_phy0",chip="ieee80211_phy0"} 49
node_hwmon_chip_names{chip_name="mt7915_phy1",chip="ieee80211_phy1"} 1
node_hwmon_temp_celsius{sensor="temp1",chip_name="mt7915_phy1",chip="ieee80211_phy1"} 48
```


---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r32316
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Banana Pi BPI-R4, GL.iNet GL-MT6000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
