### PR TITLE
gstreamer1: fix compilation on armeb

### DIFF
--- a/multimedia/gstreamer1/Makefile
+++ b/multimedia/gstreamer1/Makefile
@@ -101,7 +101,7 @@ endef
 define Package/libgstreamer1
   $(call Package/gstreamer1/Default)
   TITLE+= library (core)
-  DEPENDS+= +glib2 +libpthread +libxml2 +(powerpc||mips||mipsel):libatomic
+  DEPENDS+= +glib2 +libpthread +libxml2 +(armeb||powerpc||mips||mipsel):libatomic
   HIDDEN:=1
 endef
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @flyn-org


**Description:**

The build fails on xscale because the dependency to libatomic.so.1 is missing.

Problem is seen here: https://downloads.openwrt.org/releases/faillogs-25.12/armeb_xscale/packages/gstreamer1/compile.txt

---

## 🧪 Run Testing Details

- **OpenWrt Version:** No
- **OpenWrt Target/Subtarget:** No
- **OpenWrt Device:** No

---

## ✅ Formalities

- [ X ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ X ] It can be applied using `git am`
- [ X ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ X ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
