### PR TITLE
[24.10] ruby: update to 3.3.10

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=3.3.9
+PKG_VERSION:=3.3.10
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=d1991690a4e17233ec6b3c7844c1e1245c0adce3e00d713551d0458467b727b1
+PKG_HASH:=b555baa467a306cfc8e6c6ed24d0d27b27e9a1bed1d91d95509859eac6b0e928
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
This release includes some general fixes and a uri gem security fix:

- CVE-2025-61594: URI Credential Leakage Bypass previous fixes

Changelog: https://github.com/ruby/ruby/releases/tag/v3_3_10

## 📦 Package Details

**Maintainer:** @luizluca (me)

**Description:**
Normal release with a security fix

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10 (https://github.com/openwrt/openwrt/commit/d9c5716d1d75e652d57b42a514b20145a24eee18)
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** qemu

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
- [X] It is structured in a way that it is potentially upstreamable