### PR TITLE
[25.12] ruby: update to 3.4.8

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=3.4.7
+PKG_VERSION:=3.4.8
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=23815a6d095696f7919090fdc3e2f9459b2c83d57224b2e446ce1f5f7333ef36
+PKG_HASH:=53c4ddad41fbb6189f1f5ee0db57a51d54bd1f87f8755b3d68604156a35b045b
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
This release includes some general fixes and a uri gem security fix:

- CVE-2025-61594: URI Credential Leakage Bypass previous fixes

Changelog: https://github.com/ruby/ruby/releases/tag/v3_4_7

(cherry picked from commit 82c3465e665831d8400e57bab12811515146176e)

This release is a routine update that includes bug fixes.

Changelog: https://github.com/ruby/ruby/releases/tag/v3_4_8

(cherry picked from commit 992ccadea006c5e65357dd459f07f3ae7b7d1b94)

## 📦 Package Details

**Maintainer:** @luizluca (me)

**Description:**
Normal release with a security fix (backported from master)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12
- **OpenWrt Target/Subtarget:** x86/64 mediatek/filogic
- **OpenWrt Device:** qemu bpi_r3

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
- [X] It is structured in a way that it is potentially upstreamable
