### PR TITLE
[25.12] eza: update to 0.23.4

### DIFF
--- a/utils/eza/Makefile
+++ b/utils/eza/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=eza
-PKG_VERSION:=0.23.0
+PKG_VERSION:=0.23.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eza-community/eza/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=119973d58aef7490f6c553f818cfde142998f5e93205f53f94981a9631b50310
+PKG_HASH:=9fbcad518b8a2095206ac385329ca62d216bf9fdc652dde2d082fcb37c309635
 
 PKG_MAINTAINER:=Jonas Jelonek <jelonek.jonas@gmail.com>
 PKG_LICENSE:=EUPL-1.2


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jonasjelonek 

**Description:**
update from 0.23.0 to 0.23.4

Changelogs:
0.23.1: https://github.com/eza-community/eza/releases/tag/v0.23.1
0.23.2: https://github.com/eza-community/eza/releases/tag/v0.23.2
0.23.3: https://github.com/eza-community/eza/releases/tag/v0.23.3
0.23.4: https://github.com/eza-community/eza/releases/tag/v0.23.4

(cherry-picked from cf39ccc1b)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** BananaPi R4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
