### PR TITLE
unbound: prevent reloading local-data every 5 minutes for unchanged records in odhcpd.sh (longtime)

### DIFF
--- a/net/unbound/files/odhcpd.sh
+++ b/net/unbound/files/odhcpd.sh
@@ -107,13 +107,13 @@ odhcpd_zonedata() {
       cp "$dns_ls_new" "$dns_ls_old"
 
       # Determine common elements (in joined data+ptr records) 
-      cat "${dns_ls_add}.0" "${dns_ls_del}.0" | tr '\n' $'\034' | sed -E 's/(PTR[^'$'\034'']+)'$'\034''/\1\n/g' | \
+      cat "${dns_ls_add}.0" "${dns_ls_del}.0" | tr '\n' $'\034' | sed -E 's/( IN PTR [^'$'\034'']+)'$'\034''/\1\n/g' | \
           sort | uniq -d > "${dns_ls_com}"
 
       # Filter out common records from del and add lists
-      tr '\n' $'\034' <"${dns_ls_del}.0" | sed -E 's/(PTR[^'$'\034'']+)'$'\034''/\1\n/g' | \
+      tr '\n' $'\034' <"${dns_ls_del}.0" | sed -E 's/( IN PTR [^'$'\034'']+)'$'\034''/\1\n/g' | \
           grep -vF --file="${dns_ls_com}" | sed -E 's/'$'\034''/\n/g; s/^ //' >"${dns_ls_del}"
-      tr '\n' $'\034' <"${dns_ls_add}.0" | sed -E 's/(PTR[^'$'\034'']+)'$'\034''/\1\n/g' | \
+      tr '\n' $'\034' <"${dns_ls_add}.0" | sed -E 's/( IN PTR [^'$'\034'']+)'$'\034''/\1\n/g' | \
           grep -vF --file="${dns_ls_com}" | sed -E 's/'$'\034''/\n/g; s/^ //' >"${dns_ls_add}"
 
       # Apply only real changes

--- a/net/unbound/files/odhcpd.sh
+++ b/net/unbound/files/odhcpd.sh
@@ -52,6 +52,7 @@ odhcpd_zonedata() {
     local dns_ls_del=$UB_VARDIR/dhcp_dns.del
     local dns_ls_new=$UB_VARDIR/dhcp_dns.new
     local dns_ls_old=$UB_VARDIR/dhcp_dns.old
+    local dns_ls_com=$UB_VARDIR/dhcp_dns.common
     local dhcp_ls_new=$UB_VARDIR/dhcp_lease.new
 
     if [ ! -f $UB_DHCP_CONF ] || [ ! -f $dns_ls_old ] ; then
@@ -95,17 +96,31 @@ odhcpd_zonedata() {
       ;;
 
     longtime)
+      # Only process true lease changes to reduce Unbound reloads and memory spikes
       awk -v conffile=$UB_DHCP_CONF -v pipefile=$dns_ls_new \
           -v domain=$dhcp_domain -v bslaac=$dhcp4_slaac6 \
           -v bisolt=0 -v bconf=1 -v exclude_ipv6_ga=$exclude_ipv6_ga \
           -f /usr/lib/unbound/odhcpd.awk $dhcp_ls_new
 
-      awk '{ print $1 }' $dns_ls_old | sort | uniq > $dns_ls_del
-      cp $dns_ls_new $dns_ls_add
-      cp $dns_ls_new $dns_ls_old
-      cat $dns_ls_del | $UB_CONTROL_CFG local_datas_remove
-      cat $dns_ls_add | $UB_CONTROL_CFG local_datas
-      rm -f $dns_ls_new $dns_ls_del $dns_ls_add $dhcp_ls_new
+      awk '{ print $1 }' $dns_ls_old | sort | uniq > "${dns_ls_del}.0"
+      cp "$dns_ls_new" "${dns_ls_add}.0"
+      cp "$dns_ls_new" "$dns_ls_old"
+
+      # Determine common elements (in joined data+ptr records) 
+      cat "${dns_ls_add}.0" "${dns_ls_del}.0" | tr '\n' $'\034' | sed -E 's/(PTR[^'$'\034'']+)'$'\034''/\1\n/g' | \
+          sort | uniq -d > "${dns_ls_com}"
+
+      # Filter out common records from del and add lists
+      tr '\n' $'\034' <"${dns_ls_del}.0" | sed -E 's/(PTR[^'$'\034'']+)'$'\034''/\1\n/g' | \
+          grep -vF --file="${dns_ls_com}" | sed -E 's/'$'\034''/\n/g; s/^ //' >"${dns_ls_del}"
+      tr '\n' $'\034' <"${dns_ls_add}.0" | sed -E 's/(PTR[^'$'\034'']+)'$'\034''/\1\n/g' | \
+          grep -vF --file="${dns_ls_com}" | sed -E 's/'$'\034''/\n/g; s/^ //' >"${dns_ls_add}"
+
+      # Apply only real changes
+      [ -s "${dns_ls_del}" ] && cat "${dns_ls_del}" | $UB_CONTROL_CFG local_datas_remove
+      [ -s "${dns_ls_add}" ] && cat "${dns_ls_add}" | $UB_CONTROL_CFG local_datas
+
+      rm -f "$dns_ls_new" "$dns_ls_del" "$dns_ls_add" "$dhcp_ls_new" "${dns_ls_del}.0" "${dns_ls_add}.0" "${dns_ls_com}"
       ;;
 
     increment)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @EricLuehrsen, @dibdot
**Description:** modifies the "longtime" method in odhcpd.sh so that DHCP leases that appear identically on both the "del" and "add" lists are removed from both lists and are not unloaded then immediately reloaded via unbound-control

The default longtime handler dumps and reloads the full lease list every 5 minutes, causing Unbound to reload all local-data records even when nothing changed. This creates periodic CPU/RSS spikes and increases memory fragmentation, increasing the chance of earlyoom killing Unbound on low-memory devices (i.e., on most devices running openwrt). This can leave the router unable to resolve DNS queries or hand out DHCP leases until the unbound service is manually restarted.

This patch adds a small pipeline (tr | sed | grep | sed) to filter out unchanged lease entries, so only true deltas are sent to Unbound via local_datas / local_datas_remove. Filtering is done using grouped local-data + local-data-ptr pairs. When there are no changes to any DHCP leases from the last 5 minutes, unbound-control is not called at all. This is implemented so that:

- No change to real-time lease updates.
- Fail-safe: if filtering fails, falls back to stock full reload.
- Preserves original record ordering.
- Works with busybox or GNU versions of tr, sed, grep, sort, uniq
- Tested on IPQ8074 (dynalink dl-wrx36) with NSS + SQM + Unbound + odhcpd + large adblock list.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot (Dec 7th, 2025) -  custom build with qosmio's NSS patches (12/7/25)
- **OpenWrt Target/Subtarget:** qualcommax (ipq807x)
- **OpenWrt Device:** Dynalink dl-wrx36

---

## ✅ Formalities

- [✅] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

Signed-off-by: Anthony Barone <anthonywbarone@gmail.com>
