### PR TITLE
[23.05] php8: update to 8.2.30

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.2.29
+PKG_VERSION:=8.2.30
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.php.net/distributions/
-PKG_HASH:=475f991afd2d5b901fb410be407d929bc00c46285d3f439a02c59e8b6fe3589c
+PKG_HASH:=bc90523e17af4db46157e75d0c9ef0b9d0030b0514e62c26ba7b513b8c4eb015
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  me

**Description:**

This fixes:
    - CVE-2025-14177
    - CVE-2025-14178
    - CVE-2025-14180

Upstream changelog:
https://www.php.net/ChangeLog-8.php#8.2.30

---

## 🧪 Run Testing Details

- **OpenWrt Version:** https://github.com/openwrt/openwrt/commit/b6d7048c8bcf23d9852cf17f1fa1d532d1552474
- **OpenWrt Target/Subtarget:** mxs/Duckbill
- **OpenWrt Device:** Duckbill

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
