### PR TITLE
netbird: update to 0.60.8 (breaking change)

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.59.13
+PKG_VERSION:=0.60.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=43b96a4df6c5c77285b47aa7ecc4d9b37527c1fb9bac4a5c776a86e9878a2afe
+PKG_HASH:=c7d13a75dc1e245cafff371e63d20b7f8c977179a3b956ef4ba6caafa7998425
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/files/netbird.init
+++ b/net/netbird/files/netbird.init
@@ -8,8 +8,11 @@ USE_PROCD=1
 start_service() {
 	procd_open_instance
 	procd_set_param command /usr/bin/netbird
-	procd_set_param env NB_STATE_DIR="/root/.config/netbird"
 	procd_append_param command service run
+
+	procd_set_param env NB_STATE_DIR="/root/.config/netbird"
+	procd_append_param env NB_DISABLE_SSH_CONFIG="1"
+
 	procd_set_param pidfile /var/run/netbird.pid
 	procd_close_instance
 }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

- Changelog: https://github.com/netbirdio/netbird/releases/tag/v0.59.13

  This update only exists to be the last backport to OpenWrt 24.10. More details will be added in the PR that does the backport.

- Changelog: https://github.com/netbirdio/netbird/releases/tag/v0.60.8

  This is the first `netbird` release that introduces a breaking change\[1]. Therefore, versions after the `0.60.x` will not be backported to OpenWrt 24.10. They will be backported to OpenWrt 25.12, because that release has not been officially launched yet.

  By default netbird now creates/updates\[2] `/etc/ssh/ssh_config.d/99-netbird.conf` for use with `openssh-client`. OpenWrt uses `dropbear`, and this behavior may cause storage wear. This behavior has been disabled with `NB_DISABLE_SSH_CONFIG="1"`\[3] in the init file.

  \[1]: https://forum.netbird.io/t/netbird-v0-60-0-released/334#p-610-upgrade-compatibility-notes-4
  \[2]: https://docs.netbird.io/manage/peers/ssh#native-ssh-clients-open-ssh
  \[3]: https://github.com/netbirdio/netbird/blob/v0.60.8/client/ssh/config/manager.go#L167-L172

**Tests checklist:**
- [x] Connection to the NetBird Cloud Dashboard (not self-hosted).
- [x] Firewall configured with nftables.
- [x] Connection established in P2P mode.
- [x] `wireguard` kernel mode active.
- [x] Routes configured between my homelab and my cloud server.
- [x] `netbird` DNS server functioning correctly.
- [ ] NAT operational (not needed by me at this time, may consider testing in the future).
- [ ] Permissions rules is enforced (not needed by me at this time, may consider testing in the future).
- [x] SSH access (I will probably never test it again... Again :thinking:).
  - [x] Browser.
  - [x] SFTP.
  - [x] With `netbird` client `netbird ssh...`.
  - [x] Native OpenSSH client `ssh...`.
 
**Additional information:**

`x86_64` is running in a virtual machine using [`incus`](https://github.com/lxc/incus).
The package(s) was compiled with the container [`sdk`](https://github.com/openwrt/docker).
The `OpenWrt` image(s) was built using the container [`imagebuilder`](https://github.com/openwrt/docker).
<sub>No more container or [`distrobuilder`](https://github.com/lxc/distrobuilder).</sub>

No artifact or repository this time. :smiling_face_with_tear:

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT r32350-41a1874c70
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.