### PR TITLE
[24.10] netbird: update to 0.59.13

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.59.12
+PKG_VERSION:=0.59.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2f0bdd45996f46f2e2c1dbf5a6712bba38a06cbfb7e4c00f814b0ffe149d7c6d
+PKG_HASH:=43b96a4df6c5c77285b47aa7ecc4d9b37527c1fb9bac4a5c776a86e9878a2afe
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Changelog: https://github.com/netbirdio/netbird/releases/tag/v0.59.13

I have decided with @egc112 that this will be the last backport, aside from critical bug fixes or security updates, for OpenWrt 24.10, for two reasons:

- I can't update beyond `0.60.2`, `0.60.3` requires a newer Golang version than what's available in OpenWrt 24.10.
- The `0.60.x` version contains breaking changes, and I don't want to risk breaking other installations.

So anyone who wants a newer `netbird` can wait for OpenWrt 25.12, install a pre-release build, or (like me) be adventurous and use the OpenWrt SNAPSHOT.

**Additional info:**

Calling @egc112 for testing. I don't expect anything too big, this is just a minor bug fix update. Thanks.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** <change_me>
- **OpenWrt Target/Subtarget:** <change_me>
- **OpenWrt Device:** <change_me>

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.