### PR TITLE
[25.12] netbird: update to 0.60.8 (breaking change)

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.59.13
+PKG_VERSION:=0.60.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=43b96a4df6c5c77285b47aa7ecc4d9b37527c1fb9bac4a5c776a86e9878a2afe
+PKG_HASH:=c7d13a75dc1e245cafff371e63d20b7f8c977179a3b956ef4ba6caafa7998425
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/netbird/files/netbird.init
+++ b/net/netbird/files/netbird.init
@@ -8,8 +8,11 @@ USE_PROCD=1
 start_service() {
 	procd_open_instance
 	procd_set_param command /usr/bin/netbird
-	procd_set_param env NB_STATE_DIR="/root/.config/netbird"
 	procd_append_param command service run
+
+	procd_set_param env NB_STATE_DIR="/root/.config/netbird"
+	procd_append_param env NB_DISABLE_SSH_CONFIG="1"
+
 	procd_set_param pidfile /var/run/netbird.pid
 	procd_close_instance
 }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Changelog: https://github.com/netbirdio/netbird/releases/tag/v0.60.8

Newer OpenWrt version mean newer software, which can bring some headaches. This backport contains breaking changes (the first for `netbird`), but OpenWrt 25.12 has not been released yet, so this is appropriate for now.

**Additional info:**

@egc112, more tests incoming. What I'm looking for is that the line below does not appear in the `netbird` logs (`/var/log/netbird/client.log`). This means `NB_DISABLE_SSH_CONFIG="1"` is doing its job. Thanks.

```
...Created NetBird SSH client config: /etc/ssh/ssh_config.d/99-netbird.conf
```

---

## 🧪 Run Testing Details

- **OpenWrt Version:** <change_me>
- **OpenWrt Target/Subtarget:** <change_me>
- **OpenWrt Device:** <change_me>

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
