### PR TITLE
ddns-scripts: switch from API key to Private Access Token for gandi.net LiveDNS

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=82
+PKG_RELEASE:=83
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_gandi_net.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_gandi_net.sh
@@ -22,13 +22,13 @@ json_close_array
 
 # Log the curl command
 write_log 7 "curl -s -X PUT \"$__ENDPOINT/domains/$domain/records/$username/$__RRTYPE\" \
-	-H \"Authorization: Apikey $password\" \
+	-H \"Authorization: Bearer $password\" \
 	-H \"Content-Type: application/json\" \
 	-d \"$(json_dump)\" \
 	--connect-timeout 30"
 
 __STATUS=$(curl -s -X PUT "$__ENDPOINT/domains/$domain/records/$username/$__RRTYPE" \
-	-H "Authorization: Apikey $password" \
+	-H "Authorization: Bearer $password" \
 	-H "Content-Type: application/json" \
 	-d "$(json_dump)" \
 	--connect-timeout 30 \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert

**Description:**
Gandi LiveDNS now only allows the use of Personal Access Tokens (PATs). There seems to be no way to create and use API keys, so the script could be adapted as suggested by @nicholasdavidson in https://github.com/openwrt/packages/issues/24194.

I am still unfamiliar with pull requests in GitHub and do not know what git am is or whether this can be used as a patch.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** filogic
- **OpenWrt Device:** bananapi_bpi-r4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
