### PR TITLE
tar: fix circular dependency on xz

### DIFF
--- a/utils/tar/Makefile
+++ b/utils/tar/Makefile
@@ -35,7 +35,12 @@ include $(INCLUDE_DIR)/package.mk
 define Package/tar
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+PACKAGE_TAR_POSIX_ACL:libacl +PACKAGE_TAR_XATTR:libattr +PACKAGE_TAR_BZIP2:bzip2 +PACKAGE_TAR_XZ:xz +PACKAGE_TAR_XZ:xz-utils
+  DEPENDS:= \
+    +PACKAGE_TAR_BZIP2:bzip2 \
+    +PACKAGE_TAR_POSIX_ACL:libacl \
+    +PACKAGE_TAR_XATTR:libattr \
+    +PACKAGE_TAR_ZSTD:libzstd \
+    +PACKAGE_TAR_XZ:xz
   TITLE:=GNU tar
   URL:=https://www.gnu.org/software/tar/
   MENU:=1
@@ -43,34 +48,31 @@ define Package/tar
 endef
 
 define Package/tar/config
-	if PACKAGE_tar
-		config PACKAGE_TAR_POSIX_ACL
-			bool "tar: Enable POSIX ACL support"
-			default y if USE_FS_ACL_ATTR
-			default n
+	config PACKAGE_TAR_POSIX_ACL
+		bool "tar: Enable POSIX ACL support"
+		default y if USE_FS_ACL_ATTR
+		default n
 
-		config PACKAGE_TAR_XATTR
-			bool "tar: Enable extended attribute (xattr) support"
-			default y if USE_FS_ACL_ATTR
-			default n
+	config PACKAGE_TAR_XATTR
+		bool "tar: Enable extended attribute (xattr) support"
+		default y if USE_FS_ACL_ATTR
+		default n
 
-		config PACKAGE_TAR_BZIP2
-			bool "tar: Enable seamless bzip2 support"
-			default y
+	config PACKAGE_TAR_BZIP2
+		bool "tar: Enable seamless bzip2 support"
+		default y
 
-		config PACKAGE_TAR_GZIP
-			bool "tar: Enable seamless gzip support. Needed for sysupgrade."
-			default y
+	config PACKAGE_TAR_GZIP
+		bool "tar: Enable seamless gzip support. Needed for sysupgrade."
+		default y
 
-		config PACKAGE_TAR_XZ
-			bool "tar: Enable seamless xz support"
-			default y
+	config PACKAGE_TAR_XZ
+		bool "tar: Enable seamless xz support"
+		default y
 
-		config PACKAGE_TAR_ZSTD
-			bool "tar: Enable seamless zstd support"
-			select PACKAGE_libzstd
-			default y
-	endif
+	config PACKAGE_TAR_ZSTD
+		bool "tar: Enable seamless zstd support"
+		default y
 endef
 
 define Package/tar/description


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @noltari, cc: @sinancetinkaya

**Description:**

Third time's the charm :see_no_evil:

tar depended both on xz and xz-utils which xz already depended on. Coupled with `if PACKAGE_tar` check it caused all packages that depended on tar to have a circular Kconfig dependency. Remove the check and dependency on xz-utils and leave xz one only.

Move libzstd dependency into DEPENDS.


Fixes: ad82c17 ("tar: fix EXTRA_DEPENDS")
Fixes: #28141

Related:
- #28114

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

`make defconfig` doesn't return any error related to tar with all the packages that depend on it selected. tar itself works as expected and installs xz with it.  But I'm having issues building packages that depend on Perl locally (will do a clean build of the toolchain), so I can't fully test everything.

@sinancetinkaya can you test backuppc?

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.