### PR TITLE
coreutils: update to 9.9

### DIFF
--- a/utils/coreutils/Makefile
+++ b/utils/coreutils/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coreutils
-PKG_VERSION:=9.7
+PKG_VERSION:=9.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/coreutils
-PKG_HASH:=e8bb26ad0293f9b5a1fc43fb42ba970e312c66ce92c1b0b16713d7500db251bf
+PKG_HASH:=19bcb6ca867183c57d77155eae946c5eced88183143b45ca51ad7d26c628ca75
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -26,12 +26,12 @@ PKG_BUILD_PARALLEL:=1
 include $(INCLUDE_DIR)/package.mk
 
 COREUTILS_APPLETS := \
-	base32 base64 basename basenc b2sum cat chcon chgrp chmod chown chroot	\
+	base32 base64 basename basenc b2sum cat chgrp chmod chown chroot	\
 	cksum comm cp csplit cut date dd df dir dircolors dirname du echo env	\
 	expand expr factor false fmt fold groups head hostid id install join	\
 	kill link ln logname ls md5sum mkdir mkfifo mknod mktemp mv nice nl	\
 	nohup nproc numfmt od paste pathchk pinky pr printenv printf ptx pwd	\
-	readlink realpath rm rmdir runcon seq sha1sum sha224sum sha256sum	\
+	readlink realpath rm rmdir seq sha1sum sha224sum sha256sum		\
 	sha384sum sha512sum shred shuf sleep sort split stat stdbuf stty sum	\
 	sync tac tail tee test timeout touch tr true truncate tsort tty uname	\
 	unexpand uniq unlink uptime users vdir wc who whoami yes
@@ -42,9 +42,9 @@ DIR_BIN := \
 	touch true uname
 
 DIR_USR_BIN := \
-	basename chcon cksum comm cut dirname du env expand expr factor fold	\
+	basename cksum comm cut dirname du env expand expr factor fold		\
 	groups head hostid id install logname md5sum mkfifo nl nohup nproc od	\
-	paste printf readlink realpath runcon seq sha1sum sha256sum sha512sum	\
+	paste printf readlink realpath seq sha1sum sha256sum sha512sum		\
 	shred shuf sort split sum tac tail tee test timeout tr truncate tty	\
 	unexpand uniq unlink uptime users wc who whoami yes
 
@@ -60,6 +60,7 @@ $(eval $(foreach a,$(DIR_BIN),ALTS_$(a):=300:/bin/$(a):/usr/libexec/$(a)-coreuti
 $(eval $(foreach a,$(DIR_USR_BIN),ALTS_$(a):=300:/usr/bin/$(a):/usr/libexec/$(a)-coreutils$(newline)))
 $(eval $(foreach a,$(DIR_USR_SBIN),ALTS_$(a):=300:/usr/sbin/$(a):/usr/libexec/$(a)-coreutils$(newline)))
 
+DEPENDS_basenc = +libgmp
 DEPENDS_cp = +libacl
 DEPENDS_dir = +libacl +libcap
 DEPENDS_expr = +libgmp
@@ -129,7 +130,7 @@ CONFIGURE_ARGS += \
 	--$(if $(CONFIG_USE_MUSL),with,without)-included-regex \
 	--without-selinux
 
-TARGET_CFLAGS += -std=c17
+TARGET_CFLAGS += -std=gnu17
 
 define Package/coreutils/install
 	true

--- a/utils/coreutils/patches/001-no_docs_man_tests.patch
+++ b/utils/coreutils/patches/001-no_docs_man_tests.patch
@@ -9,7 +9,7 @@
  
  EXTRA_DIST =				\
    .mailmap				\
-@@ -211,6 +211,3 @@ AM_CPPFLAGS = -Ilib -I$(top_srcdir)/lib
+@@ -209,6 +209,3 @@ AM_CPPFLAGS = -Ilib -I$(top_srcdir)/lib
  include $(top_srcdir)/gl/local.mk
  include $(top_srcdir)/lib/local.mk
  include $(top_srcdir)/src/local.mk
@@ -18,7 +18,7 @@
 -include $(top_srcdir)/tests/local.mk
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -4400,11 +4400,7 @@ RECURSIVE_TARGETS = all-recursive check-
+@@ -4701,11 +4701,7 @@ RECURSIVE_TARGETS = all-recursive check-
  	install-ps-recursive install-recursive installcheck-recursive \
  	installdirs-recursive pdf-recursive ps-recursive \
  	tags-recursive uninstall-recursive
@@ -31,7 +31,7 @@
  am__vpath_adj_setup = srcdirstrip=`echo "$(srcdir)" | sed 's|.|.|g'`;
  am__vpath_adj = case $$p in \
      $(srcdir)/*) f=`echo "$$p" | sed "s|^$$srcdirstrip/||"`;; \
-@@ -4654,11 +4650,10 @@ am__DIST_COMMON = $(doc_coreutils_TEXINF
+@@ -4960,11 +4956,10 @@ am__DIST_COMMON = $(doc_coreutils_TEXINF
  	$(top_srcdir)/build-aux/missing \
  	$(top_srcdir)/build-aux/test-driver \
  	$(top_srcdir)/build-aux/texinfo.tex \
@@ -46,7 +46,7 @@
  	$(top_srcdir)/tests/local.mk ABOUT-NLS AUTHORS COPYING \
  	ChangeLog INSTALL NEWS README THANKS TODO build-aux/compile \
  	build-aux/config.guess build-aux/config.rpath \
-@@ -4781,7 +4776,7 @@ ERRNO_H = @ERRNO_H@
+@@ -5085,7 +5080,7 @@ ERRNO_H = @ERRNO_H@
  ETAGS = @ETAGS@
  EUIDACCESS_LIBGEN = @EUIDACCESS_LIBGEN@
  EXEEXT = @EXEEXT@
@@ -55,7 +55,7 @@
  FDATASYNC_LIB = @FDATASYNC_LIB@
  FILE_HAS_ACL_LIB = @FILE_HAS_ACL_LIB@
  FLOAT_H = @FLOAT_H@
-@@ -6824,7 +6819,7 @@ localedir_c_make = @localedir_c_make@
+@@ -7185,7 +7180,7 @@ localedir_c_make = @localedir_c_make@
  localstatedir = @localstatedir@
  localstatedir_c = @localstatedir_c@
  localstatedir_c_make = @localstatedir_c_make@
@@ -64,7 +64,7 @@
  mandir = @mandir@
  mandir_c = @mandir_c@
  mandir_c_make = @mandir_c_make@
-@@ -6873,7 +6868,7 @@ top_build_prefix = @top_build_prefix@
+@@ -7234,7 +7229,7 @@ top_build_prefix = @top_build_prefix@
  top_builddir = @top_builddir@
  top_srcdir = @top_srcdir@
  ALL_RECURSIVE_TARGETS = distcheck-hook check-root
@@ -73,7 +73,7 @@
  EXTRA_DIST = .mailmap .prev-version .version .vg-suppressions \
  	README-install THANKS.in THANKS-to-translators THANKStt.in \
  	bootstrap bootstrap.conf build-aux/gen-lists-of-programs.sh \
-@@ -9197,7 +9192,7 @@ all: $(BUILT_SOURCES)
+@@ -9633,7 +9628,7 @@ all: $(BUILT_SOURCES)
  .SUFFIXES: .1 .c .dvi .log .o .obj .pl .pl$(EXEEXT) .ps .sh .sh$(EXEEXT) .trs .x .xpl .xpl$(EXEEXT) .y
  am--refresh: Makefile
  	@:
@@ -82,7 +82,7 @@
  	@for dep in $?; do \
  	  case '$(am__configure_deps)' in \
  	    *$$dep*) \
-@@ -9219,7 +9214,7 @@ Makefile: $(srcdir)/Makefile.in $(top_bu
+@@ -9655,7 +9650,7 @@ Makefile: $(srcdir)/Makefile.in $(top_bu
  	    echo ' cd $(top_builddir) && $(SHELL) ./config.status $@ $(am__maybe_remake_depfiles)'; \
  	    cd $(top_builddir) && $(SHELL) ./config.status $@ $(am__maybe_remake_depfiles);; \
  	esac;


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jow-

**Description:**
Update coreutils to version 9.9.
Drop chcon and runcon as they require SELinux support and cannot be built from coreutils 9.9 when configured with --without-selinux.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** Arm SystemReady (EFI) compliant / 64-bit (armv8) machines
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>