### PR TITLE
[RFC] CI: switch formal to an external action

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -10,7 +10,19 @@ permissions:
 jobs:
   formalities:
     name: Test Formalities
-    uses: openwrt/actions-shared-workflows/.github/workflows/formal.yml@main
+    runs-on: ubuntu-slim
+    steps:
+      - name: HyperStickler
+        uses: georgesapkin/hyperstickler@v1-beta.3
+        with:
+          check_signoff: true
+          feedback_url: 'https://github.com/openwrt/actions-shared-workflows/issues'
+          guideline_url: 'https://openwrt.org/submitting-patches#submission_guidelines'
+          # This still needs a fine-grained token related to:
+          # https://github.com/openwrt/packages/pull/28011
+          # job_step: 2
+          # post_comment: true
+          # warn_on_no_modify: true
 
   build:
     name: Feeds Package Test Build


### PR DESCRIPTION
Switch formal to use an external action - [HyperStickler](https://github.com/marketplace/actions/hyperstickler) (by me) - directly to test it in packages, before introducing it into the main actions repo.

This is a complete rewrite of the recent formality check improvements to simplify definition, clean up the messaging (no more differently phrased messages for the same check), make them more configurable, generic and add tests. I extracted them into a separate action for easier maintenance and not to clutter the org action repo with multiple commits and random files.

Subject/line lengths are configurable by the way :see_no_evil:

The long term plan is to add more optional checks, like the package Makefile sanity checks wrt `PKG_VERSION`, `PKG_RELEASE`, hashes, etc.

Releases are marked as immutable so I can't go back add anything malicious to an existing one.

This doesn't change anything about the comment situation in this repo, which still requires a fine-grained token to securely trigger build, unless formal and build are split up.

Aside from this PR, which has trivial changes, I'd appreciate a sanity check of the actual [action source](https://github.com/GeorgeSapkin/hyperstickler/tree/main/src).

<img width="779" height="573" alt="image" src="https://github.com/user-attachments/assets/21966d14-7615-4c44-ba62-c2f6cfae9eaf" />

Example output with various scenarios:
- https://github.com/GeorgeSapkin/openwrt-packages/actions/runs/20417266292/job/58662747267?pr=1#step:2:147

cc: @BKPepe, @hnyman, @systemcrash

More info:
- https://github.com/marketplace/actions/hyperstickler