### PR TITLE
[25.12] php8: backport of latest packaging fixes and update to 8.4.16

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.4.15
-PKG_RELEASE:=3
+PKG_VERSION:=8.4.16
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=PHP-3.01
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.php.net/distributions/
-PKG_HASH:=a060684f614b8344f9b34c334b6ba8db1177555997edb5b1aceab0a4b807da7e
+PKG_HASH:=f66f8f48db34e9e29f7bfd6901178e9cf4a1b163e6e497716dfcb8f88bcfae30
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

This PR accumulates the latest packaging fixes from main branch and the most recent update to version 8.4.16 which fixes several CVEs.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** https://github.com/openwrt/packages/commit/c3cf33f98bbe1bf4394e331e84da6481788338c1
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2709
- **OpenWrt Device:** Raspberry Pi 2 Model B Rev 1.1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
