### PR TITLE
lighttpd: Malformed dependencies cause unselected packages to be compiled

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -254,12 +254,12 @@ endef
 $(eval $(call BuildPackage,lighttpd))
 
 $(eval $(call BuildPlugin,auth,Authentication,$(cryptolibdep),20))
-$(eval $(call BuildPlugin,authn_dbi,DBI-based authentication,lighttpd-mod-auth libdbi $(cryptolibdep),20))
+$(eval $(call BuildPlugin,authn_dbi,DBI-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_dbi:libdbi $(cryptolibdep),20))
 $(eval $(call BuildPlugin,authn_file,File-based authentication,lighttpd-mod-auth $(cryptolibdep),20))
-$(eval $(call BuildPlugin,authn_gssapi,Kerberos-based authentication,lighttpd-mod-auth krb5-libs $(cryptolibdep),20))
-$(eval $(call BuildPlugin,authn_ldap,LDAP-based authentication,lighttpd-mod-auth libopenldap,20))
-$(eval $(call BuildPlugin,authn_pam,PAM-based authentication,lighttpd-mod-auth libpam,20))
-$(eval $(call BuildPlugin,authn_sasl,SASL-based authentication,lighttpd-mod-auth libsasl2,20))
+$(eval $(call BuildPlugin,authn_gssapi,Kerberos-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_gssapi:krb5-libs $(cryptolibdep),20))
+$(eval $(call BuildPlugin,authn_ldap,LDAP-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_ldap:libopenldap,20))
+$(eval $(call BuildPlugin,authn_pam,PAM-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_pam:libpam,20))
+$(eval $(call BuildPlugin,authn_sasl,SASL-based authentication,lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_sasl:libsasl2,20))
 
 $(eval $(call BuildPlugin,accesslog,Access logging,,30))
 $(eval $(call BuildPlugin,ajp13,AJP13 Tomcat connector,,30))


### PR DESCRIPTION
Dependencies for plugin authn_gssapi, authn_ldap, authn_pam, authn_dbi and authn_sasl are not correctly written.

This cause lighttpd package to always compile krb5-libs, libopenldap and libpam, even if not selected

Before the fix:

grep -e libpam -e krb5-libs -e libopenldap .config 
\# CONFIG_PACKAGE_libpam is not set
\# CONFIG_PACKAGE_libopenldap is not set
\# CONFIG_PACKAGE_krb5-libs is not set

make | grep -e libpam -e krb5 -e ldap
make[3] -C feeds/packages/net/krb5 compile
make[3] -C feeds/packages/libs/libpam compile
make[3] -C feeds/packages/libs/openldap compile

With the fix:

make | grep -e libpam -e krb5 -e ldap
"nothing compiled"

Check the fix works when token are selected (select lighttpd-mod-authn_xxx):

grep lighttpd-mod-authn .config
CONFIG_PACKAGE_lighttpd-mod-authn_file=y
CONFIG_PACKAGE_lighttpd-mod-authn_gssapi=m
CONFIG_PACKAGE_lighttpd-mod-authn_ldap=m
CONFIG_PACKAGE_lighttpd-mod-authn_pam=y

make | grep -e libpam -e krb5 -e ldap
make[3] -C feeds/packages/net/krb5 compile
make[3] -C feeds/packages/libs/libpam compile
make[3] -C feeds/packages/libs/openldap compile

## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
