### PR TITLE
vim: fix missing package

### DIFF
--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -45,7 +45,7 @@ define Package/vim-full
   TITLE+= (Normal)
   PROVIDES:=vim
   CONFLICTS:=vim
-  DEPENDS:=vim-runtime
+  DEPENDS:=+vim-runtime
   EXTRA_DEPENDS:=vim-runtime (=$(PKG_VERSION)-r$(PKG_RELEASE))
 endef
 
@@ -54,7 +54,7 @@ define Package/vim-fuller
   TITLE+= (Huge)
   PROVIDES:=vim vim-full
   CONFLICTS:=vim vim-full
-  DEPENDS:=vim-runtime
+  DEPENDS:=+vim-runtime
   EXTRA_DEPENDS:=vim-runtime (=$(PKG_VERSION)-r$(PKG_RELEASE))
 endef
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**
Marko Ratkaj <markoratkaj@gmail.com>

**Description:**
Due to the incorrect DEPENDS configuration, the vim-full and vim-fuller packages won't show up in menuconfig if the vim-runtime package is not selected, as these packages depend on vim-runtime.

To fix this, the + symbol should be added to the DEPENDS line, which indicates that vim-full and vim-fuller both depend on vim-runtime.

And please @GeorgeSapkin review this PR. Thanks a lot!

---

## 🧪 Run Testing Details

- **OpenWrt Version:** r32359-22a69dfa4a
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** CMCC RAX3000M

---

## ✅ Formalities

- [ x ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
