### PR TITLE
[25.12] vim: fix depends

### DIFF
--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -45,7 +45,7 @@ define Package/vim-full
   TITLE+= (Normal)
   PROVIDES:=vim
   CONFLICTS:=vim
-  DEPENDS:=vim-runtime
+  DEPENDS:=+vim-runtime
   EXTRA_DEPENDS:=vim-runtime (=$(PKG_VERSION)-r$(PKG_RELEASE))
 endef
 
@@ -54,7 +54,7 @@ define Package/vim-fuller
   TITLE+= (Huge)
   PROVIDES:=vim vim-full
   CONFLICTS:=vim vim-full
-  DEPENDS:=vim-runtime
+  DEPENDS:=+vim-runtime
   EXTRA_DEPENDS:=vim-runtime (=$(PKG_VERSION)-r$(PKG_RELEASE))
 endef
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** nobody, cc: @teleostnacl

**Description:**

Due to the incorrect DEPENDS configuration, the vim-full and vim-fuller packages won't show up in menuconfig if the vim-runtime package is not selected. This happens because these packages depend on vim-runtime.

To fix this, add the '+' symbol to the DEPENDS line. This ensures that when either vim-full or vim-fuller is selected, the vim-runtime package (which is a dependency) will also be selected automatically.

Fixes: d1351b3 ("vim: fix config and runtime")

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.