### PR TITLE
libmodbus: update to 3.1.11

### DIFF
--- a/libs/libmodbus/Makefile
+++ b/libs/libmodbus/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmodbus
-PKG_VERSION:=3.1.8
+PKG_VERSION:=3.1.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/stephane/libmodbus/releases/download/v$(PKG_VERSION)/
-PKG_HASH:=b122f2bc29f749702a22c0a760a7ca2182d541f5fa26bf25e3431f907b606f3c
+PKG_HASH:=15b4b2e0f68122c2da9b195de5c330489a9c97d40b4a95d2822378dc14d780e7
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 


### PR DESCRIPTION
fixes float endianness issues in 3.1.8.

I use a small, custom application to convert data from my electricity meter into Modbus format for my inverter and wallbox. I developed against an earlier version of libmodbus on x86, and it ran flawlessly on my ath79 router (big endian). After migrating to a Mediatek router (little endian), the program only outputted huge, meaningless values. However, it ran perfectly fine on my x86 system (little endian), which is running Fedora with libmodbus v3.1.11.

I then found upstream bug reports https://github.com/stephane/libmodbus/issues/665 https://github.com/stephane/libmodbus/issues/757 and the [changelog of libmodbus v3.1.11](https://github.com/stephane/libmodbus/releases/tag/v3.1.11) with the fix. Update openwrt to libmodbus v3.1.11 to get the fix.

## 📦 Package Details

**Maintainer:** @mhei 

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** ath79, mediatek/filogic, x86/64
- **OpenWrt Device:** tplink_archer-c7-v2, bananapi_bpi-r4, x86 virtual machine

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.