### PR TITLE
zabbix: tweak frontend dependencies

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=7.0.21
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
@@ -194,8 +194,10 @@ define Package/zabbix-server-frontend
     +php8-mod-gd \
     +php8-mod-bcmath \
     +php8-mod-ctype \
+    +php8-mod-filter \
     +php8-mod-xmlreader \
     +php8-mod-xmlwriter \
+    +php8-mod-openssl \
     +php8-mod-session \
     +php8-mod-sockets \
     +php8-mod-mbstring \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**

For zabbix-server-frontend, the absence of php8-mod-filter results in many of the frontend's pages failing to render.  Therefore add this module as a frontend dependency.

Without php8-mod-openssl the frontend fails with:

[13-Dec-2025 18:47:25 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function openssl_random_pseudo_bytes() in /www/zabbix/include/classes/helpers/CEncryptHelper.php:89 Stack trace:
CEncryptHelper::generateKey()
  thrown in /www/zabbix/include/classes/helpers/CEncryptHelper.php on
  line 89

Therefore add php8-mod-openssl as a frontend dependency.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (r32402-501e54b6c2)
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** rpi-5

Created a new Zabbix server (with frontend and agent) install.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- N/A It is structured in a way that it is potentially upstreamable
