### PR TITLE
curl: enable wrongly disabled HTTP_AUTH

### DIFF
--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -172,5 +172,5 @@ config LIBCURL_NTLM
 
 config LIBCURL_HTTP_AUTH
 	bool "Enable HTTP authentication support"
-	default n
+	default y
 endif

--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=8.15.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert @hnyman @GeorgeSapkin (As krant has requested removal as maintainer)

**Description:**

commit ea66e463cffc0811757eedee80889323ff66191c added a new config option LIBCURL_HTTP_AUTH to enable or disable HTTP_AUTH support in cURL. It defaulted the option to n (disabled).

However, prior to this change HTTP_AUTH was enabled for cURL, as the configure script defaults to HTTP_AUTH enabled when it is not explicitly disabled.

This impacts any consumer of cURL that uses HTTP_AUTH, including authentication by username and password in the URL. (Confirmed via run testing).

So we set the default for the option to y (enabled).

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (32402-501e54b6c2)
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** rpi-5

See also https://github.com/openwrt/packages/issues/28172

With https://github.com/openwrt/packages/pull/28175 also applied, used cURL to update an
OVH DynHost.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

N/A
