### PR TITLE
ddns-scripts: add API-based registered IP verification for Cloudflare proxied records

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=91
+PKG_RELEASE:=92
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/etc/config/ddns
+++ b/net/ddns-scripts/files/etc/config/ddns
@@ -18,6 +18,7 @@ config service "myddns_ipv4"
 	option interface	"wan"
 	option ip_source	"network"
 	option ip_network	"wan"
+	option use_api_check    "0"
 
 config service "myddns_ipv6"
 	option update_url	"http://[USERNAME]:[PASSWORD]@your.provider.net/nic/update?hostname=[DOMAIN]&myip=[IP]"
@@ -29,4 +30,4 @@ config service "myddns_ipv6"
 	option interface	"wan6"
 	option ip_source	"network"
 	option ip_network	"wan6"
-
+	option use_api_check    "0"


### PR DESCRIPTION
<h2>Description</h2>
<h3>Problem</h3>
<p>When using Cloudflare with proxy enabled (orange cloud), DNS lookups 
return Cloudflare's edge IP instead of the actual origin IP registered 
in the dashboard. This causes ddns-scripts to incorrectly detect IP 
mismatches, triggering unnecessary updates and potential rate limiting.</p>
<h3>Solution</h3>
<p>Add an optional <code node="[object Object]">use_api_check</code> configuration option that enables provider scripts to fetch the registered IP directly via their API, bypassing DNS lookups.</p>
<h3>Changes</h3>
<p><strong><code node="[object Object]">dynamic_dns_functions.sh</code>:</strong></p>
<ul>
<li>Add API check block to <code node="[object Object]">get_registered_ip()</code> (~25 lines)</li>
<li>When <code node="[object Object]">use_api_check</code> is enabled, sources the provider script with <code node="[object Object]">GET_REGISTERED_IP=1</code> flag</li>
<li>Falls back to DNS lookup if API check is disabled, unsupported, or fails</li>
</ul>
<p><strong><code node="[object Object]">update_cloudflare_com_v4.sh</code>:</strong></p>
<ul>
<li>Add handler for <code node="[object Object]">GET_REGISTERED_IP</code> mode (~15 lines)</li>
<li>Reuses existing cURL setup and authentication to query Cloudflare API for actual record content</li>
</ul>
<h3>Usage</h3>
<p>Enable in <code node="[object Object]">/etc/config/ddns</code>:</p>
<figure class="CodeBlock-module__container--QRI4L CodeBlock-module__immersive--D8NjT" aria-labelledby="_r_4i3_"><div class="CodeBlock-module__header--K8Zrp"><span class="LanguageDot-module__languageDot--O6n2z"></span><span id="_r_4i3_" class="CodeBlock-module__languageName--fxI6n">Code</span></div></figure><div class="CodeBlock-module__header--K8Zrp"></div><div class="CodeBlock-module__copyContainer--jLoHL"><div class="CodeBlock-module__copyContent--BH7EX"></div></div><figure class="CodeBlock-module__container--QRI4L CodeBlock-module__immersive--D8NjT" aria-labelledby="_r_4i3_"><div class="CodeBlock-module__copyContainer--jLoHL"><div class="CodeBlock-module__copyContent--BH7EX"></div></div><div class="CodeBlock-module__codeContainer--snQei"><pre class="CodeBlock-module__code--gyjSL" tabindex="0"><code class="">config service 'myddns'
    option use_api_check '1'
    ... 
</code></pre></div></figure>
<h3>Behavior</h3>

use_api_check | Provider Support | Result
-- | -- | --
0 or unset | N/A | DNS lookup (existing behavior)
1 | Yes (e.g., Cloudflare) | API query for real IP
1 | No | Falls back to DNS lookup
1 | API fails | Falls back to DNS lookup


<h3>Testing</h3>
<ul>
<li> Cloudflare (proxied): Correctly retrieves origin IP via API</li>
<li> Cloudflare (non-proxied): Works correctly</li>
<li> No-IP: DNS lookup works (no regression)</li>
<li> IPv4 and IPv6 records</li>
<li> API failure gracefully falls back to DNS</li>
</ul>
<h3>References</h3>
<ul>
<li><a href="https://openwrt.org/docs/guide-user/services/ddns/client" target="_blank" rel="noopener noreferrer">OpenWrt DDNS Guide</a></li>
<li><a href="https://developers.cloudflare.com/api/" target="_blank" rel="noopener noreferrer">Cloudflare API</a></li>
</ul>
<hr>
<p></p>
Testing Environment

OpenWrt mediatek/filogic 24.10.5 r29087-d9c5716d1d / LuCI openwrt-24.10 branch 25.365.52131~3ac2e08
GL.iNet GL-MT6000 ARMv8 Processor rev 4
ddns-scripts 2.8.2-r64

Test Log Output

Cloudflare with use_api_check '1' (proxied record):

```
030911 : Using provider API for registered IP check via '/usr/lib/ddns/update_cloudflare_com_v4.sh'
030911 : Registered IP '2600:100f:a020::' detected via Cloudflare API
030911 : Registered IP '2600:100f:a020::' detected via provider API
```
No-IP without use_api_check (regression test):

```
115936  note : drill - no support to 'force IP Version' (ignored)
115936       :  #> /usr/bin/drill test.ddnsking.com >/var/run/ddns/noip. dat 2>/var/run/ddns/noip.err
115936       :  Registered IP '75.253. - -  detected
```

