### PR TITLE
curl: enable wrongly disabled HTTP_AUTH

### DIFF
--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -172,5 +172,5 @@ config LIBCURL_NTLM
 
 config LIBCURL_HTTP_AUTH
 	bool "Enable HTTP authentication support"
-	default n
+	default y
 endif

--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=8.15.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert @hnyman @GeorgeSapkin @BKPepe (As krant has requested removal as maintainer)

commit ea66e463cffc0811757eedee80889323ff66191c added a new config option LIBCURL_HTTP_AUTH to enable or disable HTTP_AUTH support in cURL. It defaulted the option to n (disabled).

However, prior to this change HTTP_AUTH was enabled for cURL, as the configure script defaults to HTTP_AUTH enabled when it is not explicitly disabled.

This impacts any consumer of cURL that uses HTTP_AUTH, including authentication by username and password in the URL. (Confirmed via run testing).

So we set the default for the option to y (enabled).

(cherry picked from commit 57e6f89c02112689e9ae9a489fd03dec4fae4b85)

---

Note the comment in the origin commit misattributed the change to ea66e46, but the problem commit is https://github.com/openwrt/packages/commit/43b9a37a6ef0c69e834cf2967a3796804b7e3a48.
What is the best way to handle that?

See also: https://github.com/openwrt/packages/pull/28174#issuecomment-3692547662 ,
https://forum.openwrt.org/t/curl-digest-auth-broken/230370 , and https://forum.openwrt.org/t/dynalink-dl-wrx36-snapshot-curl-not-working/228864 .

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt-25.12-rc1
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** rpi-i5

1. Verified curl https://user:password@host/path works.
2. Verified login to a Syncthing instance using `curl URL --user`
3. Used ddns-scripts with an OVH DynHost (with the template-based version not the new update script version) with curl configured in global settings.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
