### PR TITLE
monit: update to 5.35.2

### DIFF
--- a/admin/monit/Makefile
+++ b/admin/monit/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=monit
-PKG_VERSION:=5.34.0
+PKG_VERSION:=5.35.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://bitbucket.org/tildeslash/monit/downloads/
-PKG_HASH:=37f514cd8973bbce104cb8517ff3fc504052a083703eee0d0e873db26b919820
+PKG_HASH:=4dfef54329e63d9772a9e1c36ac99bc41173b79963dc0d8235f2c32f4b9e078f
 
 PKG_MAINTAINER:=Yaroslav Petrov <info@lank.me>
 PKG_LICENSE:=AGPL-3.0


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @Lankaster 

**Description:** update from 5.24.0 to 5.35.2

See changelog: https://mmonit.com/monit/changes/

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12, main
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** PC Engines APU4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>

Signed-off-by: Yaroslav Petrov <info@lank.me>