### PR TITLE
[25.12] python-aio-mqtt-mod: update to 0.4.0

### DIFF
--- a/lang/python/python-aio-mqtt-mod/Makefile
+++ b/lang/python/python-aio-mqtt-mod/Makefile
@@ -7,15 +7,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-aio-mqtt-mod
-PKG_VERSION:=0.3.4
+PKG_VERSION:=0.4.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=aio-mqtt-mod
-PKG_HASH:=340184b35771b7eb7982072fcca313213d856638dd7f98b99bda3ab16ba23552
+PYPI_SOURCE_NAME=aio_mqtt_mod
+PKG_HASH:=14784b0deedc9e91ef0980046c03cecff685b6e4364b6f3a66d41bca4b98b58f
 
 PKG_MAINTAINER:=Quintin Hill <stuff@quintin.me.uk>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=python-setuptools/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @QuintinHill

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Cherry-pick of https://github.com/openwrt/packages/pull/28178

Add support of building against python 3.12+
Replace imp module with importlib

Full changelog:
https://github.com/devbis/aio-mqtt/compare/0.3.4...0.4.0


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
