### PR TITLE
tree-wide: remove obsolete SDK in conditionals

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -230,25 +230,25 @@ else
   CONFIGURE_ARGS+= --disable-intl
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-bcmath),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-bcmath),)
   CONFIGURE_ARGS+= --enable-bcmath=shared
 else
   CONFIGURE_ARGS+= --disable-bcmath
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-calendar),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-calendar),)
   CONFIGURE_ARGS+= --enable-calendar=shared
 else
   CONFIGURE_ARGS+= --disable-calendar
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-ctype),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-ctype),)
   CONFIGURE_ARGS+= --enable-ctype=shared
 else
   CONFIGURE_ARGS+= --disable-ctype
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-curl),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-curl),)
   CONFIGURE_ARGS+= --with-curl=shared
 else
   CONFIGURE_ARGS+= --without-curl
@@ -260,31 +260,31 @@ else
   CONFIGURE_ARGS+= --disable-dom
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-exif),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-exif),)
   CONFIGURE_ARGS+= --enable-exif=shared
 else
   CONFIGURE_ARGS+= --disable-exif
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-fileinfo),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-fileinfo),)
   CONFIGURE_ARGS+= --enable-fileinfo=shared,"$(STAGING_DIR)/usr"
 else
   CONFIGURE_ARGS+= --disable-fileinfo
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-filter),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-filter),)
   CONFIGURE_ARGS+= --enable-filter=shared,"$(STAGING_DIR)/usr"
 else
   CONFIGURE_ARGS+= --disable-filter
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-ftp),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-ftp),)
   CONFIGURE_ARGS+= --enable-ftp=shared
 else
   CONFIGURE_ARGS+= --disable-ftp
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-gd),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-gd),)
   CONFIGURE_ARGS+= \
 	--enable-gd=shared,"$(STAGING_DIR)/usr" \
 	--with-external-gd
@@ -292,13 +292,13 @@ else
   CONFIGURE_ARGS+= --disable-gd
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-gmp),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-gmp),)
   CONFIGURE_ARGS+= --with-gmp=shared,"$(STAGING_DIR)/usr"
 else
   CONFIGURE_ARGS+= --without-gmp
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-iconv),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-iconv),)
   ifeq ($(CONFIG_BUILD_NLS),y)
     CONFIGURE_VARS+= iconv_impl_name="gnu_libiconv"
     CONFIGURE_ARGS+= --with-iconv=shared,"$(ICONV_PREFIX)"
@@ -310,7 +310,7 @@ else
   CONFIGURE_ARGS+= --without-iconv
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-ldap),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-ldap),)
   CONFIGURE_ARGS+= \
 	--with-ldap=shared,"$(STAGING_DIR)/usr" \
 	--with-ldap-sasl
@@ -318,7 +318,7 @@ else
   CONFIGURE_ARGS+= --without-ldap
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-mbstring),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-mbstring),)
   CONFIGURE_ARGS+= \
 	--enable-mbstring=shared \
 	--enable-mbregex
@@ -326,25 +326,25 @@ else
   CONFIGURE_ARGS+= --disable-mbstring
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-mysqli),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-mysqli),)
   CONFIGURE_ARGS+= --with-mysqli=shared
 else
   CONFIGURE_ARGS+= --without-mysqli
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-mysqlnd),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-mysqlnd),)
   CONFIGURE_ARGS+= --enable-mysqlnd=shared
 else
   CONFIGURE_ARGS+= --disable-mysqlnd
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-opcache),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-opcache),)
   CONFIGURE_ARGS+= --enable-opcache=shared
 else
   CONFIGURE_ARGS+= --disable-opcache
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-openssl)$(CONFIG_PACKAGE_php8-mod-ftp)$(CONFIG_PACKAGE_php8-mod-snmp),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-openssl)$(CONFIG_PACKAGE_php8-mod-ftp)$(CONFIG_PACKAGE_php8-mod-snmp),)
   CONFIGURE_ARGS+= \
 	--with-openssl=shared \
 	--with-kerberos=no \
@@ -353,25 +353,25 @@ else
   CONFIGURE_ARGS+= --without-openssl
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-pcntl),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-pcntl),)
   CONFIGURE_ARGS+= --enable-pcntl=shared
 else
   CONFIGURE_ARGS+= --disable-pcntl
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-pdo),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-pdo),)
   CONFIGURE_ARGS+= --enable-pdo=shared
-  ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-pdo-mysql),)
+  ifneq ($(CONFIG_PACKAGE_php8-mod-pdo-mysql),)
     CONFIGURE_ARGS+= --with-pdo-mysql=shared
   else
     CONFIGURE_ARGS+= --without-pdo-mysql
   endif
-  ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-pdo-pgsql),)
+  ifneq ($(CONFIG_PACKAGE_php8-mod-pdo-pgsql),)
     CONFIGURE_ARGS+= --with-pdo-pgsql=shared,"$(STAGING_DIR)/usr"
   else
     CONFIGURE_ARGS+= --without-pdo-pgsql
   endif
-  ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-pdo-sqlite),)
+  ifneq ($(CONFIG_PACKAGE_php8-mod-pdo-sqlite),)
     CONFIGURE_ARGS+= --with-pdo-sqlite=shared
   else
     CONFIGURE_ARGS+= --without-pdo-sqlite
@@ -380,32 +380,32 @@ else
   CONFIGURE_ARGS+= --disable-pdo
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-pgsql),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-pgsql),)
   CONFIGURE_ARGS+= --with-pgsql=shared,"$(STAGING_DIR)/usr"
 else
   CONFIGURE_ARGS+= --without-pgsql
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-phar),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-phar),)
   CONFIGURE_ARGS+= --enable-phar=shared
 else
   CONFIGURE_ARGS+= --disable-phar
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-session),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-session),)
   CONFIGURE_ARGS+= --enable-session=shared
 else
   CONFIGURE_ARGS+= --disable-session
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-shmop),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-shmop),)
   CONFIGURE_ARGS+= --enable-shmop=shared
 else
   CONFIGURE_ARGS+= --disable-shmop
 endif
 
 ifeq ($(CONFIG_PHP8_LIBXML),y)
-  ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-simplexml),)
+  ifneq ($(CONFIG_PACKAGE_php8-mod-simplexml),)
     CONFIGURE_ARGS+= --enable-simplexml=shared
   else
     CONFIGURE_ARGS+= --disable-simplexml
@@ -414,7 +414,7 @@ else
   CONFIGURE_ARGS+= --disable-simplexml
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-snmp),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-snmp),)
   CONFIGURE_ARGS+= --with-snmp=shared,"$(STAGING_DIR)/usr"
   CONFIGURE_VARS+= \
     ac_cv_have_decl_usmHMAC192SHA256AuthProtocol=no \
@@ -424,7 +424,7 @@ else
 endif
 
 ifeq ($(CONFIG_PHP8_LIBXML),y)
-  ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-soap),)
+  ifneq ($(CONFIG_PACKAGE_php8-mod-soap),)
     CONFIGURE_ARGS+= --enable-soap=shared
   else
     CONFIGURE_ARGS+= --disable-soap
@@ -433,49 +433,49 @@ else
   CONFIGURE_ARGS+= --disable-soap
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-sockets),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-sockets),)
   CONFIGURE_ARGS+= --enable-sockets=shared
 else
   CONFIGURE_ARGS+= --disable-sockets
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-sodium),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-sodium),)
   CONFIGURE_ARGS+= --with-sodium=shared,"$(STAGING_DIR)/usr"
 else
   CONFIGURE_ARGS+= --without-sodium
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-sqlite3),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-sqlite3),)
   CONFIGURE_ARGS+= --with-sqlite3=shared
 else
   CONFIGURE_ARGS+= --without-sqlite3
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-sysvmsg),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-sysvmsg),)
   CONFIGURE_ARGS+= --enable-sysvmsg=shared
 else
   CONFIGURE_ARGS+= --disable-sysvmsg
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-sysvsem),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-sysvsem),)
   CONFIGURE_ARGS+= --enable-sysvsem=shared
 else
   CONFIGURE_ARGS+= --disable-sysvsem
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-sysvshm),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-sysvshm),)
   CONFIGURE_ARGS+= --enable-sysvshm=shared
 else
   CONFIGURE_ARGS+= --disable-sysvshm
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-tokenizer),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-tokenizer),)
   CONFIGURE_ARGS+= --enable-tokenizer=shared
 else
   CONFIGURE_ARGS+= --disable-tokenizer
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-xml),)
+ifneq ($(CONFIG_PACKAGE_php8-mod-xml),)
   CONFIGURE_ARGS+= --enable-xml=shared,"$(STAGING_DIR)/usr"
   ifneq ($(CONFIG_PHP8_LIBXML),y)
     CONFIGURE_ARGS+= --with-expat
@@ -485,7 +485,7 @@ else
 endif
 
 ifeq ($(CONFIG_PHP8_LIBXML),y)
-  ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-xmlreader),)
+  ifneq ($(CONFIG_PACKAGE_php8-mod-xmlreader),)
     CONFIGURE_ARGS+= --enable-xmlreader=shared,"$(STAGING_DIR)/usr"
   else
     CONFIGURE_ARGS+= --disable-xmlreader
@@ -495,7 +495,7 @@ else
 endif
 
 ifeq ($(CONFIG_PHP8_LIBXML),y)
-  ifneq ($(SDK)$(CONFIG_PACKAGE_php8-mod-xmlwriter),)
+  ifneq ($(CONFIG_PACKAGE_php8-mod-xmlwriter),)
     CONFIGURE_ARGS+= --enable-xmlwriter=shared,"$(STAGING_DIR)/usr"
   else
     CONFIGURE_ARGS+= --disable-xmlwriter

--- a/libs/libdbi-drivers/Makefile
+++ b/libs/libdbi-drivers/Makefile
@@ -73,7 +73,7 @@ else
 	CONFIGURE_ARGS += --without-mysql
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_libdbd-pgsql),)
+ifneq ($(CONFIG_PACKAGE_libdbd-pgsql),)
 	CONFIGURE_ARGS += \
 		--with-pgsql \
 		--with-pgsql-incdir=$(STAGING_DIR)/usr/include \
@@ -82,7 +82,7 @@ else
 	CONFIGURE_ARGS += --without-pgsql
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_libdbd-sqlite3),)
+ifneq ($(CONFIG_PACKAGE_libdbd-sqlite3),)
 	CONFIGURE_ARGS += \
 		--with-sqlite3 \
 		--with-sqlite3-incdir=$(STAGING_DIR)/usr/include \

--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -762,7 +762,7 @@ PKG_DICTIONARIES:= \
 	microsoft \
 	wispr \
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-cache-redis),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-cache-redis),)
   CONFIGURE_ARGS+= \
 		--with-rlm_cache_redis \
 		--with-rlm_cache_redis-include-dir="$(STAGING_DIR)/usr/include" \
@@ -771,7 +771,7 @@ else
   CONFIGURE_ARGS+= --without-rlm_cache_redis
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-eap-fast),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-eap-fast),)
   CONFIGURE_ARGS+= \
 		--with-rlm_eap_fast \
 		--with-rlm_eap_fast-include-dir="$(STAGING_DIR)/usr/include" \
@@ -781,7 +781,7 @@ else
   CONFIGURE_ARGS+= --without-rlm_eap_fast
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-eap-peap),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-eap-peap),)
   CONFIGURE_ARGS+= \
 		--with-rlm_eap_peap \
 		--with-rlm_eap_peap-include-dir="$(STAGING_DIR)/usr/include" \
@@ -791,7 +791,7 @@ else
   CONFIGURE_ARGS+= --without-rlm_eap_peap
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-eap-pwd),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-eap-pwd),)
   CONFIGURE_ARGS+= \
 		--with-rlm_eap_pwd \
 		--with-rlm_eap_pwd-include-dir="$(STAGING_DIR)/usr/include" \
@@ -801,7 +801,7 @@ else
   CONFIGURE_ARGS+= --without-rlm_eap_pwd
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-eap-tls),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-eap-tls),)
   CONFIGURE_ARGS+= \
 		--with-rlm_eap_tls \
 		--with-rlm_eap_tls-include-dir="$(STAGING_DIR)/usr/include" \
@@ -811,7 +811,7 @@ else
   CONFIGURE_ARGS+= --without-rlm_eap_tls
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-eap-ttls),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-eap-ttls),)
   CONFIGURE_ARGS+= \
 		--with-rlm_eap_ttls \
 		--with-rlm_eap_ttls-include-dir="$(STAGING_DIR)/usr/include" \
@@ -821,7 +821,7 @@ else
   CONFIGURE_ARGS+= --without-rlm_eap_ttls
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-ippool),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-ippool),)
   CONFIGURE_ARGS+= --with-rlm_ippool \
 		--with-rlm_ippool-include-dir="$(STAGING_DIR)/usr/include" \
 		--with-rlm_ippool-lib-dir="$(STAGING_DIR)/usr/lib"
@@ -829,7 +829,7 @@ else
   CONFIGURE_ARGS+= --without-rlm_ippool
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-json),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-json),)
   CONFIGURE_ARGS+= --with-rlm_json \
 		--with-rlm_json-include-dir="$(STAGING_DIR)/usr/include" \
 		--with-rlm_json-lib-dir="$(STAGING_DIR)/usr/lib"
@@ -837,7 +837,7 @@ else
   CONFIGURE_ARGS+= --without-rlm_json
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-krb5),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-krb5),)
   CONFIGURE_ARGS+= \
 		--with-rlm_krb5 \
 		--with-rlm-krb5-dir="$(STAGING_DIR)/host/bin/krb5-config"
@@ -845,7 +845,7 @@ else
   CONFIGURE_ARGS+= --without-rlm_krb5
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-ldap),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-ldap),)
   CONFIGURE_ARGS+= --with-rlm_ldap \
 		--with-rlm_ldap-include-dir="$(STAGING_DIR)/usr/include" \
 		--with-rlm_ldap-lib-dir="$(STAGING_DIR)/usr/lib"
@@ -853,7 +853,7 @@ else
   CONFIGURE_ARGS+= --without-rlm_ldap
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-python3),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-python3),)
   CFLAGS+= -fPIC
   CONFIGURE_ARGS+= \
 		--with-modules="rlm_python3" \
@@ -862,13 +862,13 @@ else
   CONFIGURE_ARGS+= --without-rlm_python3
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-radutmp),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-radutmp),)
   CONFIGURE_ARGS+= --with-rlm_radutmp
 else
   CONFIGURE_ARGS+= --without-rlm_radutmp
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-redis),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-redis),)
   CONFIGURE_ARGS+= \
 		--with-rlm_redis \
 		--with-rlm_redis-include-dir="$(STAGING_DIR)/usr/include" \
@@ -877,7 +877,7 @@ else
   CONFIGURE_ARGS+= --without-rlm_redis
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-rediswho),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-rediswho),)
   CONFIGURE_ARGS+= \
 		--with-rlm_rediswho \
 		--with-rlm_rediswho-include-dir="$(STAGING_DIR)/usr/include" \
@@ -886,19 +886,19 @@ else
   CONFIGURE_ARGS+= --without-rlm_rediswho
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-rest),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-rest),)
   CONFIGURE_ARGS+= --with-rlm_rest
 else
   CONFIGURE_ARGS+= --without-rlm_rest
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-sql),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-sql),)
   CONFIGURE_ARGS+= --with-rlm_sql
 else
   CONFIGURE_ARGS+= --without-rlm_sql
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-sql-mysql),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-sql-mysql),)
   CONFIGURE_ARGS+= \
 		--with-rlm_sql_mysql \
 		--with-mysql-include-dir="$(STAGING_DIR)/usr/include/mysql"
@@ -906,19 +906,19 @@ else
   CONFIGURE_ARGS+= --without-rlm_sql_mysql
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-sql-postgresql),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-sql-postgresql),)
   CONFIGURE_ARGS+= --with-rlm_sql_postgresql
 else
   CONFIGURE_ARGS+= --without-rlm_sql_postgresql
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-sql-sqlite),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-sql-sqlite),)
   CONFIGURE_ARGS+= --with-rlm_sql_sqlite
 else
   CONFIGURE_ARGS+= --without-rlm_sql_sqlite
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-sql-unixodbc),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-sql-unixodbc),)
   CONFIGURE_ARGS+= \
 		--with-rlm_sql_unixodbc \
 		--with-rlm_sql_unixodbc-include-dir="$(STAGING_DIR)/usr/include" \
@@ -927,19 +927,19 @@ else
   CONFIGURE_ARGS+= --without-rlm_sql_unixodbc
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-sqlcounter),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-sqlcounter),)
   CONFIGURE_ARGS+= --with-rlm_sqlcounter
 else
   CONFIGURE_ARGS+= --without-rlm_sqlcounter
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-sqlippool),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-sqlippool),)
   CONFIGURE_ARGS+= --with-rlm_sqlippool
 else
   CONFIGURE_ARGS+= --without-rlm_sqlippool
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-unbound),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-unbound),)
   CONFIGURE_ARGS+= \
 		--with-rlm_unbound \
 		--with-rlm_unbound-include-dir="$(STAGING_DIR)/usr/include" \
@@ -948,7 +948,7 @@ else
   CONFIGURE_ARGS+= --without-rlm_unbound
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-unix),)
+ifneq ($(CONFIG_PACKAGE_freeradius3-mod-unix),)
   CONFIGURE_ARGS+= --with-rlm_unix
 else
   CONFIGURE_ARGS+= --without-rlm_unix

--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -231,7 +231,7 @@ define BuildPlugin
 /etc/lighttpd/conf.d/$(4)-$(1).conf
   endef
 
- ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-$(1)),)
+ ifneq ($(CONFIG_PACKAGE_lighttpd-mod-$(1)),)
   define Package/lighttpd-mod-$(1)/install
 	$(INSTALL_DIR) $$(1)/usr/lib/lighttpd
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lighttpd/mod_$(1).so $$(1)/usr/lib/lighttpd
@@ -303,7 +303,7 @@ define BuiltinPlugin
 /etc/lighttpd/conf.d/$(4)-$(1).conf
   endef
 
- ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-$(1)),)
+ ifneq ($(CONFIG_PACKAGE_lighttpd-mod-$(1)),)
   define Package/lighttpd-mod-$(1)/install
 	$(INSTALL_DIR) $$(1)/etc/lighttpd/conf.d
 	if [ -f $(PKG_BUILD_DIR)/doc/config/conf.d/$(1).conf ]; then \

--- a/net/ulogd/Makefile
+++ b/net/ulogd/Makefile
@@ -127,7 +127,7 @@ CONFIGURE_ARGS += \
 	--enable-nfct \
 	--enable-nflog
 
-ifneq ($(DEVELOPER)$(SDK)$(CONFIG_PACKAGE_ulogd-mod-dbi),)
+ifneq ($(DEVELOPER)$(CONFIG_PACKAGE_ulogd-mod-dbi),)
 	CONFIGURE_ARGS += --with-dbi \
 		--with-dbi-inc=$(STAGING_DIR)/usr/include/dbi \
 		--with-dbi-lib=$(STAGING_DIR)/usr/lib
@@ -135,7 +135,7 @@ else
 	CONFIGURE_ARGS += --without-dbi
 endif
 
-ifneq ($(DEVELOPER)$(SDK)$(CONFIG_PACKAGE_ulogd-mod-mysql),)
+ifneq ($(DEVELOPER)$(CONFIG_PACKAGE_ulogd-mod-mysql),)
 	CONFIGURE_ARGS += \
 		--with-mysql-inc=$(STAGING_DIR)/usr/include/mysql \
 		--with-mysql-lib=$(STAGING_DIR)/usr/lib/mysql
@@ -143,13 +143,13 @@ else
 	CONFIGURE_ARGS += --without-mysql
 endif
 
-ifneq ($(DEVELOPER)$(SDK)$(CONFIG_PACKAGE_ulogd-mod-pgsql),)
+ifneq ($(DEVELOPER)$(CONFIG_PACKAGE_ulogd-mod-pgsql),)
 	CONFIGURE_ARGS += --with-pgsql="$(STAGING_DIR)/usr"
 else
 	CONFIGURE_ARGS += --without-pgsql
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_ulogd-mod-sqlite),)
+ifneq ($(CONFIG_PACKAGE_ulogd-mod-sqlite),)
 	CONFIGURE_ARGS += --with-sqlite="$(STAGING_DIR)/usr"
 else
 	CONFIGURE_ARGS += --without-sqlite

--- a/utils/ntfs-3g/Makefile
+++ b/utils/ntfs-3g/Makefile
@@ -127,7 +127,7 @@ else
 endif
 
 # enable ntfsprogs and extras
-ifneq ($(CONFIG_PACKAGE_ntfs-3g-utils)$(SDK)$(DEVELOPER),)
+ifneq ($(CONFIG_PACKAGE_ntfs-3g-utils)$(DEVELOPER),)
 	CONFIGURE_ARGS += --enable-ntfsprogs --enable-extras
 else
 	CONFIGURE_ARGS += --disable-ntfsprogs --disable-extras


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @GeorgeSapkin @hnyman @mhei @gstrauss @systemcrash @commodo @nicolas-thill @BKPepe 

**Description:**

Obsolete use of $(SDK) in configure conditionals can result in dependency errors when building a subset of packages for packages which have multiple sub-packages.

The reason it causes dependency issues is that (using libdbi-drivers as an example) lines like:

`ifneq ($(SDK)$(CONFIG_PACKAGE_libdbd-sqlite3),)`

always evaluate to true if you are compiling in the SDK. So for a user compiling from the SDK, the configure arguments are always added to the package build.

In the case of libdbi-drivers:

```Makefile
CONFIGURE_ARGS += \
  --with-sqlite3 \
  --with-sqlite3-incdir=$(STAGING_DIR)/usr/include \
  -with-sqlite3-libdir=$(STAGING_DIR)/usr/lib
```

is always added even if PACKAGE_libdbd-sqlite3 is deselected. When libdbd-sqlite3 is deselected, this dependency:

```Makefile
DEPENDS:=libdbi +libsqlite3
```

is not present, so when configure tries to find sqlite3 it fails.

Closes #28173 "tree-wide: obsolete $(SDK) in conditionals"

See also:

* "include: remove SDK exception from package install targets" openwrt/openwrt@28f44a4

Performed tree-wide to ease revert if necessary, per: https://github.com/openwrt/packages/issues/28173#issuecomment-3694615980

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (r32409-9da57e2f82)
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** rpi-5

Did a basic smoke test with each of:

* php8 (using Zabbix)
* freeradius3 (just binary runs)
* lighttpd (with alternate docroot and port)
* ulogd (basic binary execution and plugin loading)
* ntfs-3g basic binary execution

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
