### PR TITLE
[25.12]: freeradius 3.2.8

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
-PKG_VERSION:=3.2.7
+PKG_VERSION:=3.2.8
 PKG_VERSION_UNDERSCORE:=$(subst .,_,${PKG_VERSION})
-PKG_RELEASE:=3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=freeradius-server-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/releases/download/release_$(PKG_VERSION_UNDERSCORE)/
-PKG_HASH:=3fd3b7725faa8b5e6c5a331a395e392ea9f7eceb3c0d42e82e82c32f2ff5b098
+PKG_HASH:=3846498103d3faf182abd968a440128cb0c5589330bdcdd58c466ef15d9f9fdf
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0
@@ -742,6 +742,7 @@ CONFIGURE_ARGS+= \
 	--without-rlm_couchbase \
 	--without-rlm_eap_ikev2 \
 	--without-rlm_eap_tnc \
+	--without-rlm_kafka \
 	--without-rlm_perl \
 	--without-rlm_python \
 	--without-rlm_sql_db2 \

--- a/net/freeradius3/patches/002-disable-session-cache-CVE-2017-9148.patch
+++ b/net/freeradius3/patches/002-disable-session-cache-CVE-2017-9148.patch
@@ -9,7 +9,7 @@ Last-Update: 2020-04-28
 
 --- a/src/main/tls.c
 +++ b/src/main/tls.c
-@@ -848,7 +848,7 @@ after_chain:
+@@ -860,7 +860,7 @@ after_chain:
  	}
  	if (vp) vp->vp_integer = state->mtu;
  
@@ -18,7 +18,7 @@ Last-Update: 2020-04-28
  
  	return state;
  }
-@@ -4496,7 +4496,7 @@ post_ca:
+@@ -4520,7 +4520,7 @@ post_ca:
  	/*
  	 *	Callbacks, etc. for session resumption.
  	 */
@@ -27,7 +27,7 @@ Last-Update: 2020-04-28
  		/*
  		 *	Cache sessions on disk if requested.
  		 */
-@@ -4576,7 +4576,7 @@ post_ca:
+@@ -4600,7 +4600,7 @@ post_ca:
  	/*
  	 *	Setup session caching
  	 */
@@ -36,7 +36,7 @@ Last-Update: 2020-04-28
  		/*
  		 *	Create a unique context Id per EAP-TLS configuration.
  		 */
-@@ -4864,7 +4864,7 @@ fr_tls_server_conf_t *tls_server_conf_pa
+@@ -4890,7 +4890,7 @@ fr_tls_server_conf_t *tls_server_conf_pa
  		goto error;
  	}
  

--- a/net/freeradius3/patches/004-get-hostname-from-proc-in-radtest.patch
+++ b/net/freeradius3/patches/004-get-hostname-from-proc-in-radtest.patch
@@ -1,6 +1,6 @@
 --- a/src/main/radtest.in
 +++ b/src/main/radtest.in
-@@ -112,7 +112,7 @@ if [ "$7" ]
+@@ -117,7 +117,7 @@ if [ "$7" ]
  then
  	nas=$7
  else

--- a/net/freeradius3/patches/010-openssl-deprecated.patch
+++ b/net/freeradius3/patches/010-openssl-deprecated.patch
@@ -26,7 +26,7 @@
  
  #if OPENSSL_VERSION_NUMBER >= 0x30000000L
  #  include <openssl/provider.h>
-@@ -2929,7 +2930,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
+@@ -2943,7 +2944,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
  	int		my_ok = ok;
  
  	ASN1_INTEGER	*sn = NULL;
@@ -35,7 +35,7 @@
  	VALUE_PAIR	**certs;
  	char **identity;
  #ifdef HAVE_OPENSSL_OCSP_H
-@@ -3021,7 +3022,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
+@@ -3035,7 +3036,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
  	 *	Get the Expiration Date
  	 */
  	buf[0] = '\0';
@@ -44,7 +44,7 @@
  	if (certs && (lookup <= 1) && asn_time &&
  	    (asn_time->length < (int) sizeof(buf))) {
  		memcpy(buf, (char*) asn_time->data, asn_time->length);
-@@ -3034,7 +3035,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
+@@ -3048,7 +3049,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
  	 *	Get the Valid Since Date
  	 */
  	buf[0] = '\0';
@@ -53,7 +53,7 @@
  	if (certs && (lookup <= 1) && asn_time &&
  	    (asn_time->length < (int) sizeof(buf))) {
  		memcpy(buf, (char*) asn_time->data, asn_time->length);
-@@ -3638,10 +3639,12 @@ static int set_ecdh_curve(SSL_CTX *ctx,
+@@ -3655,10 +3656,12 @@ static int set_ecdh_curve(SSL_CTX *ctx,
   */
  int tls_global_init(TLS_UNUSED bool spawn_flag, TLS_UNUSED bool check)
  {
@@ -65,8 +65,8 @@
 +#endif
  
  #if OPENSSL_VERSION_NUMBER >= 0x30000000L
- 	EVP_set_default_properties(NULL, "fips=no");
-@@ -3745,6 +3748,7 @@ int tls_global_version_check(char const
+ 	EVP_set_default_properties(NULL, "-fips");
+@@ -3762,6 +3765,7 @@ int tls_global_version_check(char const
   */
  void tls_global_cleanup(void)
  {
@@ -74,7 +74,7 @@
  #if OPENSSL_VERSION_NUMBER < 0x10000000L
  	ERR_remove_state(0);
  #elif OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-@@ -3770,6 +3774,7 @@ void tls_global_cleanup(void)
+@@ -3787,6 +3791,7 @@ void tls_global_cleanup(void)
  	ERR_free_strings();
  	EVP_cleanup();
  	CRYPTO_cleanup_all_ex_data();


### PR DESCRIPTION
Closes #28161

Resolves runtime openssl error

Patches refreshed


(cherry picked from commit 1b1aa825a2143c8c85d710c864dcc6e97be31694)

@hnyman 