### PR TITLE
treewide: remove FTP usage

### DIFF
--- a/devel/gcc/Makefile
+++ b/devel/gcc/Makefile
@@ -115,7 +115,7 @@ endif
 GMPSRC=gmp-6.1.0
 
 define Download/gmp
-  URL:=ftp://gcc.gnu.org/pub/gcc/infrastructure/
+  URL:=https://gcc.gnu.org/pub/gcc/infrastructure/
   FILE:=$(GMPSRC).tar.bz2
   HASH:=498449a994efeba527885c10405993427995d3f86b8768d8cdf8d9dd7c6b73e8
 endef
@@ -124,7 +124,7 @@ $(eval $(call Download,gmp))
 MPCSRC=mpc-1.0.3
 
 define Download/mpc
-  URL:=ftp://gcc.gnu.org/pub/gcc/infrastructure/
+  URL:=https://gcc.gnu.org/pub/gcc/infrastructure/
   FILE:=$(MPCSRC).tar.gz
   HASH:=617decc6ea09889fb08ede330917a00b16809b8db88c29c31bfbb49cbf88ecc3
 endef
@@ -133,7 +133,7 @@ $(eval $(call Download,mpc))
 MPFRSRC=mpfr-3.1.4
 
 define Download/mpfr
-  URL:=ftp://gcc.gnu.org/pub/gcc/infrastructure/
+  URL:=https://gcc.gnu.org/pub/gcc/infrastructure/
   FILE:=$(MPFRSRC).tar.bz2
   HASH:=d3103a80cdad2407ed581f3618c4bed04e0c92d1cf771a65ead662cc397f7775
 endef

--- a/libs/file/Makefile
+++ b/libs/file/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.openpkg.org/components/cache/file/ \
-	ftp://ftp.astron.com/pub/file/
+	http://ftp.astron.com/pub/file/
 PKG_HASH:=fc97f51029bb0e2c9f4e3bffefdaf678f0e039ee872b9de5c002a6d09c784d82
 
 PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>

--- a/libs/libnetfilter-cthelper/Makefile
+++ b/libs/libnetfilter-cthelper/Makefile
@@ -12,9 +12,7 @@ PKG_VERSION:=1.0.0
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:= \
-	http://www.netfilter.org/projects/libnetfilter_cthelper/files/ \
-	ftp://ftp.netfilter.org/pub/libnetfilter_cthelper/
+PKG_SOURCE_URL:=http://www.netfilter.org/projects/libnetfilter_cthelper/files/
 PKG_HASH:=07618e71c4d9a6b6b3dc1986540486ee310a9838ba754926c7d14a17d8fccf3d
 
 PKG_FIXUP:=autoreconf

--- a/libs/libnetfilter-cttimeout/Makefile
+++ b/libs/libnetfilter-cttimeout/Makefile
@@ -12,9 +12,7 @@ PKG_VERSION:=1.0.0
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:= \
-	http://www.netfilter.org/projects/libnetfilter_cttimeout/files/ \
-	ftp://ftp.netfilter.org/pub/libnetfilter_cttimeout/
+PKG_SOURCE_URL:=http://www.netfilter.org/projects/libnetfilter_cttimeout/files/
 PKG_HASH:=aeab12754f557cba3ce2950a2029963d817490df7edb49880008b34d7ff8feba
 
 PKG_FIXUP:=autoreconf

--- a/libs/libnetfilter-log/Makefile
+++ b/libs/libnetfilter-log/Makefile
@@ -12,9 +12,7 @@ PKG_VERSION:=1.0.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:= \
-	http://www.netfilter.org/projects/libnetfilter_log/files/ \
-	ftp://ftp.netfilter.org/pub/libnetfilter_log/
+PKG_SOURCE_URL:=http://www.netfilter.org/projects/libnetfilter_log/files/
 PKG_HASH:=e3f408575614d849e4726b45e90c7ebb0e6744b04859555a9ce6ec40744ffeea
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 

--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -14,8 +14,7 @@ PKG_CPE_ID:=cpe:/a:postgresql:postgresql
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=\
 	https://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
-	http://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
-	ftp://ftp.postgresql.org/pub/source/v$(PKG_VERSION)
+	http://ftp.postgresql.org/pub/source/v$(PKG_VERSION)
 
 PKG_HASH:=fcb7ab38e23b264d1902cb25e6adafb4525a6ebcbd015434aeef9eda80f528d8
 

--- a/libs/tcp_wrappers/Makefile
+++ b/libs/tcp_wrappers/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=7.6
 PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=ftp://ftp.porcupine.org/pub/security
+PKG_SOURCE_URL:=http://ftp.porcupine.org/pub/security
 PKG_HASH:=9543d7adedf78a6de0b221ccbbd1952e08b5138717f4ade814039bb489a4315d
 
 PKG_LICENSE:=TCP-wrappers
@@ -27,7 +27,7 @@ define Package/libwrap
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Security wrapper library for TCP services
-  URL:=ftp://ftp.porcupine.org/pub/security/index.html
+  URL:=http://ftp.porcupine.org/pub/security/index.html
   MAINTAINER:=Peter Wagner <tripolar@gmx.at>
 endef
 

--- a/net/isc-dhcp/Makefile
+++ b/net/isc-dhcp/Makefile
@@ -19,7 +19,7 @@ PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>
 PKG_CPE_ID:=cpe:/a:isc:dhcp
 
 PKG_SOURCE:=$(UPSTREAM_NAME)-$(PKG_REALVERSION).tar.gz
-PKG_SOURCE_URL:=ftp://ftp.isc.org/isc/dhcp/$(PKG_REALVERSION) \
+PKG_SOURCE_URL:=https://ftp.isc.org/isc/dhcp/$(PKG_REALVERSION) \
 		http://ftp.funet.fi/pub/mirrors/ftp.isc.org/isc/dhcp/$(PKG_REALVERSION) \
 		http://ftp.iij.ad.jp/pub/network/isc/dhcp/$(PKG_REALVERSION)
 PKG_HASH:=0ac416bb55997ca8632174fd10737fd61cdb8dba2752160a335775bc21dc73c7

--- a/net/ulogd/Makefile
+++ b/net/ulogd/Makefile
@@ -12,8 +12,7 @@ PKG_VERSION:=2.0.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://netfilter.org/projects/ulogd/files/ \
-	ftp://ftp.netfilter.org/pub/ulogd/
+PKG_SOURCE_URL:=https://netfilter.org/projects/ulogd/files/
 PKG_HASH:=523a651fe0a9f25b0cd87d5d35fc37d9382e7eecfcf61e48d5505ff3cf80eda5
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>

--- a/sound/madplay/Makefile
+++ b/sound/madplay/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/mad \
-	ftp://ftp.mars.org/pub/mpeg/
+	https://ftp.mars.org/pub/mpeg/
 PKG_HASH:=5a79c7516ff7560dffc6a14399a389432bc619c905b13d3b73da22fa65acede0
 
 PKG_MAINTAINER:=Simon Peter <probono@puredarwin.org>


### PR DESCRIPTION
Drop obsolete protocol usage.
Use HTTPS (if possible) or HTTP instead.

## 📦 Package Details

**Maintainer:** @flyn-org @yousong @dangowrt @tripolar @pprindeville @commodo @probonopd 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
