### PR TITLE
python-yarl: update to version 1.22.0

### DIFF
--- a/lang/python/python-yarl/Makefile
+++ b/lang/python/python-yarl/Makefile
@@ -8,15 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yarl
-PKG_VERSION:=1.9.2
+PKG_VERSION:=1.22.0
 PKG_RELEASE:=1
 
-PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=04ab9d4b9f587c06d801c2abfe9317b77cdf996c65a90d5e84ecc45010823571
+PYPI_NAME:=yarl
+PKG_HASH:=bebf8557577d4401ba8bd9ff33906f1376c877aa78d1fe216ad01b4d6745af71
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=python3-setuptools/host python3-wheel/host python3-cython/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -30,7 +32,6 @@ define Package/python3-yarl
   URL:=https://github.com/aio-libs/yarl
   DEPENDS:= \
   +python3-light \
-  +python3-multidict \
   +python3-urllib \
   +python3-idna
 endef


### PR DESCRIPTION
Maintainer: me

Release notes:
https://github.com/aio-libs/yarl/releases/tag/v1.22.0
