### PR TITLE
jq: refactor variants and fix PROVIDES

### DIFF
--- a/utils/jq/Makefile
+++ b/utils/jq/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=jq
 PKG_VERSION:=1.8.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/jqlang/jq/releases/download/$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/jqlang/jq/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 PKG_HASH:=2be64e7129cecb11d5906290eba10af694fb9e3e7f9fc208a311dc33ca837eb0
 
 PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
@@ -24,55 +24,56 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-CONFIGURE_ARGS+= \
-	--disable-docs \
-	--disable-valgrind \
-
 define Package/jq/Default
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Lightweight and flexible command-line JSON processor
   URL:=https://jqlang.github.io/jq/
-  PROVIDES:=jq
 endef
 
 define Package/jq
-  $(Package/jq/Default)
-  TITLE+= without regex support.
+  $(call Package/jq/Default)
+  TITLE+= (noregex)
   VARIANT:=noregex
   DEFAULT_VARIANT:=1
 endef
 
 define Package/jq/description
   Lightweight and flexible command-line JSON processor.
-  This package was compiled without ONIGURUMA regex libary. match/test/sub and related functions are not available. 
+  This package was compiled without ONIGURUMA regex library. match/test/sub and related functions are not available.
 endef
 
 define Package/jq-full
-  $(Package/jq/Default)
-  TITLE+= with regex support.
-  VARIANT:=regex
+  $(call Package/jq/Default)
+  TITLE+= (full)
   DEPENDS+=+oniguruma
+  VARIANT:=full
+  PROVIDES:=jq
 endef
 
 define Package/jq-full/description
   Lightweight and flexible command-line JSON processor.
-  This package was compiled with ONIGURUMA regex libary and has full regex support.
+  This package was compiled with ONIGURUMA regex library and has full regex support.
 endef
 
-ifeq ($(BUILD_VARIANT),noregex)
-	CONFIGURE_ARGS += --without-oniguruma
+CONFIGURE_ARGS+= \
+	--disable-docs \
+	--disable-valgrind \
+
+ifeq ($(BUILD_VARIANT),full)
+  CONFIGURE_ARGS += --with-oniguruma
+else
+  CONFIGURE_ARGS += --without-oniguruma
 endif
 
-define Package/jq/install/Default
+define Package/jq/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libjq.so* $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libjq.so* $(1)/usr/lib/
 endef
 
-Package/jq/install = $(Package/jq/install/Default)
-Package/jq-full/install = $(Package/jq/install/Default)
+Package/jq-full/install = $(Package/jq/install)
 
 $(eval $(call BuildPackage,jq))
 $(eval $(call BuildPackage,jq-full))


### PR DESCRIPTION
Refactor package variants definition to be cleaner and more robust. E.g.:
- Remove redundant PROVIDES:=jq from the main 'jq' package (it provides itself automatically).
- Keep PROVIDES:=jq only on the 'jq-full' variant so it can serve as a drop-in replacement.

Fixes: 711a19c4b23f3517ece5296d323c8f0220a0ff4e ("jq: provide regex support in additional package jq-full") from https://github.com/openwrt/packages/pull/26046

Fixes: https://github.com/openwrt/packages/issues/28201