### PR TITLE
tcpreplay: add libxdp as dependency

### DIFF
--- a/net/tcpreplay/Makefile
+++ b/net/tcpreplay/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tcpreplay
 PKG_VERSION:=4.5.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/appneta/tcpreplay/releases/download/v$(PKG_VERSION)
@@ -35,7 +35,7 @@ define Package/tcpreplay/default
   CATEGORY:=Network
   URL:=http://tcpreplay.appneta.com/
   MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
-  DEPENDS:=+librt +libpcap +libdnet +libbpf +USE_MUSL:musl-fts
+  DEPENDS:=+librt +libpcap +libdnet +libbpf +libxdp +USE_MUSL:musl-fts
 endef
 
 define Package/tcpbridge
@@ -139,7 +139,6 @@ CONFIGURE_VARS += \
 	ac_cv_path_pcncfg=no
 
 CONFIGURE_ARGS += \
-	--enable-force-pf \
 	--enable-dynamic-link \
 	--with-libdnet="$(STAGING_DIR)/usr" \
 	--with-libpcap="$(STAGING_DIR)/usr"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
If libxdp is built before tcpreplay, it will pick it up. So, might as well just add it as a dependency (for now).


---

## 🧪 Run Testing Details

- **OpenWrt Version:** master x86
- **OpenWrt Target/Subtarget:**  master x86
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
