### PR TITLE
php8: fix PHP8_GETTEXT missing icu dependency

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -81,6 +81,7 @@ define Package/php8/config
 
 	config PHP8_GETTEXT
 		bool "Enable gettext"
+		select PACKAGE_icu
 		default y
 
 	config PHP8_INTL


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @mhei

**Description:**

With CONFIG_PHP8_GETTEXT php8 always gains a
dependency on a version of the 'icu' package,
however said dependency is not declared, so
on gets compilation errors when
CONFIG_PHP8_GETTEXT=y but PACKAGE_icu is not
selected.

Therefore select PACKAGE_icu when PHP8_GETTEXT is
selected.

Closes #28207

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** rpi-5

Confirmed build succeeded and php8 modules work with Zabbix frontend.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
