### PR TITLE
rclone: add config to be a restic rest-server

### DIFF
--- a/net/rclone/Makefile
+++ b/net/rclone/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rclone
 PKG_VERSION:=1.72.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/rclone/rclone/tar.gz/v$(PKG_VERSION)?
@@ -54,13 +54,28 @@ define Package/rclone-config
   DEPENDS:=+rclone
 endef
 
+define Package/rclone-config-rest-server
+  $(call Package/rclone/Default)
+  TITLE+= (As Restic Rest-Server)
+  DEPENDS:=+rclone
+
 define Package/rclone/description
   Rclone ("rsync for cloud storage") is a command line program to sync
   files and directories to and from different cloud storage providers.
 endef
 
+define Package/rclone-config-rest-server/description
+  Rclone ("rsync for cloud storage") can act as a 'rest-server' for restic
+  backups (https://restic.readthedocs.io). This package provides an UCI
+  configuration for using Rclone this way.
+endef
+
 define Package/rclone-config/conffiles
 /etc/config/rclone
+endef
+
+define Package/rclone-config-rest-server/conffiles
+/etc/config/rclone-rest-server
 endef
 
 define Package/rclone/install
@@ -76,6 +91,14 @@ define Package/rclone-config/install
 	$(INSTALL_BIN) $(CURDIR)/files/rclone.init $(1)/etc/init.d/rclone
 endef
 
+define Package/rclone-config-rest-server/install
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_CONF) $(CURDIR)/files/rclone-rest-server.config $(1)/etc/config/rclone-rest-server
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) $(CURDIR)/files/rclone-rest-server.init $(1)/etc/init.d/rclone-rest-server
+endef
+
 $(eval $(call GoBinPackage,rclone))
 $(eval $(call BuildPackage,rclone))
 $(eval $(call BuildPackage,rclone-config))
+$(eval $(call BuildPackage,rclone-config-rest-server))

--- a/net/rclone/files/rclone-rest-server.config
+++ b/net/rclone/files/rclone-rest-server.config
@@ -1,0 +1,21 @@
+config rclone-rest-server
+	option enabled '0'
+  #	option addr ':8000'
+  #	option path '/srv/restic'			# data directory (default "/tmp/restic")
+	# option append_only '0'				# enable append only mode
+	# option htpasswd_file '/etc/rclone-rest-server/users'	# location of .htpasswd file (default: "<data directory>/.htpasswd")
+	# option private_repos '0'			# users can only access their private repo
+	# option tls '1'						# turn on TLS support
+	# option cert '/etc/uhttpd.cer' # TLS certificate path
+	# option key '/etc/uhttpd.key' # TLS key path
+
+# config rclone-rest-server
+	# option enabled '0'
+  #	option addr ':8081'
+  #	option path '/srv/restic2'			# data directory (default "/tmp/restic")
+	# option append_only '0'				# enable append only mode
+	# option htpasswd_file '/etc/rclone-rest-server/users2'	# location of .htpasswd file (default: "<data directory>/.htpasswd")
+	# option private_repos '0'			# users can only access their private repo
+	# option tls '1'						# turn on TLS support
+	# option cert '/etc/uhttpd.cer' # TLS certificate path
+	# option key '/etc/uhttpd.key' # TLS key path

--- a/net/rclone/files/rclone-rest-server.init
+++ b/net/rclone/files/rclone-rest-server.init
@@ -1,0 +1,49 @@
+#!/bin/sh /etc/rc.common
+# shellcheck shell=ash
+# cspell:words rclone httpasswd restic
+
+# shellcheck disable=SC2034
+START=99
+USE_PROCD=1
+
+PROG=/usr/bin/rclone
+
+start_instance() {
+	local cfg="$1"
+	local var
+	local val
+
+	config_get_bool val "$cfg" 'enabled' '0'
+	[ "$val" = 0 ] && return 1
+
+	procd_open_instance "$cfg"
+	config_get remote "$cfg" "remote" bad-remote
+        config_get path "$cfg" "path" invalid-path
+	config_get rclone_config "$cfg" "rclone_config" invalid-config
+
+	# shellcheck disable=SC2154
+	procd_set_param command "$PROG" serve restic "$remote":"$path" --config "$rclone_config"
+	for var in append_only private_repos; do
+		config_get_bool val "$cfg" "$var" 0
+		# shellcheck disable=SC3060
+		[ "$val" = 0 ] || procd_append_param command "--${var//_/-}"
+	done
+	for var in addr httpasswd cert key min_tls_version; do
+		config_get val "$cfg" "$var"
+		# shellcheck disable=SC3060
+		[ -z "$val" ] || procd_append_param command "--${var//_/-}" "$val"
+	done
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn
+	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger rclone-rest-server
+}
+
+start_service() {
+	config_load rclone-rest-server
+	config_foreach start_instance rclone-rest-server
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @1715173329 

**Description:**

Rclone ("rsync for cloud storage") can act as a 'rest-server' for restic backups (https://restic.readthedocs.io).

Here we add a package (configuration and initscript) that enables this use case with an UCI configuration.

The initscript is a modified version of the restic-rest-server initscript in this repo.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** openwrt_one

While I have been using this initscript and configuration, the packaging is new, hence a draft PR until I deploy from the new packaging and verify over some time that all continues to function well.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
