### PR TITLE
[24.10] python-msgpack: update to version 1.1.0

### DIFF
--- a/lang/python/python-msgpack/Makefile
+++ b/lang/python/python-msgpack/Makefile
@@ -8,17 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-msgpack
-PKG_VERSION:=1.0.7
+PKG_VERSION:=1.1.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=msgpack
-PKG_HASH:=572efc93db7a4d27e404501975ca6d2d9775705c2d922390d878fcf768d92c87
+PKG_HASH:=dd432ccc2c72b914e4cb77afce64aab761c1137cc698be3984eee260bcb2896e
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=COPYING
 
-PKG_BUILD_DEPENDS:=python-cython/host
+PKG_BUILD_DEPENDS:=python-cython/host python-setuptools
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Release notes:
https://github.com/msgpack/msgpack-python/releases/tag/v1.1.2
(cherry picked from commit a1c1bfc24bd5000e0747948dff5e8127fa8582bd)

Fixes:
```
ERROR Missing dependencies:
	Cython~=3.0.0
make[3]: *** [Makefile:46: /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/pypi/msgpack-1.0.7/.built] Error 1
time: package/feeds/packages/python-msgpack/compile#2.84#0.41#3.35
```