### PR TITLE
php8: fix and enhance configuration and dependencies

### DIFF
--- a/lang/php8/Config.in
+++ b/lang/php8/Config.in
@@ -7,7 +7,7 @@ config PHP8_LIBXML
 
 config PHP8_DOM
 	bool "PHP8 DOM support"
-	depends on PHP8_LIBXML
+	select PHP8_LIBXML
 	default y
 	help
 	  Without php8-mod-dom, this option does not provide a PHP8
@@ -35,7 +35,6 @@ config PHP8_GETTEXT
 
 config PHP8_INTL
 	bool "Enable Internationalization"
-	depends on PHP8_GETTEXT
 	default y
 	help
 	  Note that this option depends in ICU library which is built without data
@@ -51,7 +50,6 @@ config PHP8_INTL
 
 config PHP8_FULLICUDATA
 	bool "Add dependency to full ICU Data"
-	depends on PHP8_INTL
 	default n
 
 endmenu

--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=8.4.16
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=PHP-3.01
@@ -46,6 +46,8 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PHP8_INTL \
 	CONFIG_PHP8_LIBXML \
 	CONFIG_PHP8_SYSTEMTZDATA
+
+PKG_BUILD_DEPENDS:= PHP8_INTL:icu
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -88,7 +90,7 @@ endef
 
 define Package/php8-cli
   $(call Package/php8/Default)
-  DEPENDS+= +PHP8_GETTEXT:libstdcpp +riscv64:libatomic
+  DEPENDS+= +PHP8_INTL:libstdcpp +riscv64:libatomic
   TITLE+= (CLI)
 endef
 
@@ -99,7 +101,7 @@ endef
 
 define Package/php8-cgi
   $(call Package/php8/Default)
-  DEPENDS+= +PHP8_GETTEXT:libstdcpp +riscv64:libatomic
+  DEPENDS+= +PHP8_INTL:libstdcpp +riscv64:libatomic
   TITLE+= (CGI & FastCGI)
 endef
 
@@ -121,7 +123,7 @@ endef
 
 define Package/php8-fpm
   $(call Package/php8/Default)
-  DEPENDS+= +PHP8_GETTEXT:libstdcpp +riscv64:libatomic
+  DEPENDS+= +PHP8_INTL:libstdcpp +riscv64:libatomic
   TITLE+= (FPM)
 endef
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @mhei 

**Description:**

This commit cleans up and enhances the changes from https://github.com/openwrt/packages/commit/6d6233b6b7f5190d4e14e0da9e50838de33a29ce, https://github.com/openwrt/packages/commit/f9591b8518f13f4d74be99d0a0ea816ea85b6bef, https://github.com/openwrt/packages/commit/e6c59b518878a92bd48cde4c8e5b25c8c0ac27cb, and properly implements the attempt from https://github.com/openwrt/packages/commit/996046e642426f900809d07f5bedb6f2807f0816.

By reasoning carefully about the impact of combinations of configuration options, and thoroughly setting config options and checking actual dynamic dependencies using `readelf --dynamic`, the configuration and dependency handling of these options has been improved.

In addition, cleanups and enhancements like reorganizing CONFIG_DEPENDS, adding more Kconfig help text, and cleaning up some whitespace have been performed.

* A missing conditional BUILD_DEPENDS on package icu when PHP8_GETTEXT is defined has been added.
* The PHP8_GETTEXT, PHP8_INTL, PHP8_FULLICUDATA, php8-mod-gettext, and php8-mod-intl interactions have been verified, fixed, and improved.
* A circular dependency with php8-mod-xmlreader, PHP8_DOM, and php8-mod-dom when php8-mod-xmlreader is depended on by another package (e.g. zabbix-server-frontend) has been corrected
* As these changes potentially impact binaries, there is a PKG_RELEASE bump.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (r32450-8b93c563ad)
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** rpi-5

The following have been tested using Zabbix server frontend as the PHP test application:

1. Included php8-mod-gettext but not php8-mod-intl, set PHP8_GETTEXT and PHP8_INTL, but not PHP8_FULLICU_DATA.
2. Included php8-mod-gettext but not php8-mod-intl, set PHP8_GETTEXT, not PHP8_INTL, and not PHP8_FULLICU_DATA.
3. Included php8-mod-gettext (compiled and in image) and php8-mod-intl (compiled only), set PHP8_GETTEXT and PHP8_INTL, but not PHP8_FULLICU_DATA.
4. Included php8-mod-gettext (compiled and in image) and php8-mod-intl (compiled and in image), set PHP8_GETTEXT and PHP8_INTL, and PHP8_FULLICU_DATA.
5. Included php8-mod-gettext (compiled and in image) and php8-mod-intl (compiled and in image), set PHP8_GETTEXT and PHP8_INTL, but not PHP8_FULLICU_DATA.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
