### PR TITLE
v2ray-geodata: provide a virtual package

### DIFF
--- a/net/v2ray-geodata/Makefile
+++ b/net/v2ray-geodata/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v2ray-geodata
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
@@ -50,7 +50,7 @@ endef
 define Package/v2ray-geoip
   $(call Package/v2ray-geodata/template)
   TITLE:=GeoIP List for V2Ray
-  PROVIDES:=v2ray-geodata xray-geodata xray-geoip
+  PROVIDES:=@v2ray-geodata @xray-geodata @xray-geoip
   VERSION:=$(GEOIP_VER)-r$(PKG_RELEASE)
   LICENSE:=CC-BY-SA-4.0
 endef
@@ -58,7 +58,7 @@ endef
 define Package/v2ray-geosite
   $(call Package/v2ray-geodata/template)
   TITLE:=Geosite List for V2Ray
-  PROVIDES:=v2ray-geodata xray-geodata xray-geosite
+  PROVIDES:=@v2ray-geodata @xray-geodata @xray-geosite
   VERSION:=$(GEOSITE_VER)-r$(PKG_RELEASE)
   LICENSE:=MIT
 endef
@@ -66,7 +66,7 @@ endef
 define Package/v2ray-geosite-ir
   $(call Package/v2ray-geodata/template)
   TITLE:=Iran Geosite List for V2Ray
-  PROVIDES:=xray-geosite-ir
+  PROVIDES:=@xray-geosite-ir
   VERSION:=$(GEOSITE_IRAN_VER)-r$(PKG_RELEASE)
   LICENSE:=MIT
 endef


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** 
@1715173329  Tianling Shen <cnsztl@immortalwrt.org>

**Description:**
According to https://github.com/openwrt/openwrt/pull/21288/, switch v2ray-geodata provides to use the new virtual provides semantic that enables v2ray-geoip and v2ray-geosite to be installed side-by-side.

This resolves the conflict between the v2ray-geoip and v2ray-geosite packages during `make package/install` .

Without this PR, the following error occurs when running `make package/install`:
```
ERROR: unable to select packages:
  v2ray-geoip-202512201334-r1:
    conflicts: v2ray-geosite-20251231040011-r1[v2ray-geodata=202512201334-r1]
               v2ray-geosite-20251231040011-r1[xray-geodata=202512201334-r1]
    satisfies: world[v2ray-geoip] luci-app-passwall2-25.12.25-r1[v2ray-geoip]
  v2ray-geosite-20251231040011-r1:
    conflicts: v2ray-geoip-202512201334-r1[v2ray-geodata=20251231040011-r1]
               v2ray-geoip-202512201334-r1[xray-geodata=20251231040011-r1]
    satisfies: world[v2ray-geosite] luci-app-passwall2-25.12.25-r1[v2ray-geosite]
```

---

## 🧪 Run Testing Details

- **OpenWrt Version:** r32463-8e6cd2608a
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** CMCC RAX3000M

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
