### PR TITLE
crowdsec-firewall-bouncer: fix version in binary

### DIFF
--- a/net/crowdsec-firewall-bouncer/Makefile
+++ b/net/crowdsec-firewall-bouncer/Makefile
@@ -25,7 +25,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/cs-firewall-bouncer-$(PKG_VERSION)
 CSFB_BUILD_VERSION?=v$(PKG_VERSION)
 CSFB_BUILD_TIMESTAMP:=$(shell date +%F"_"%T)
 CSFB_BUILD_TAG:=openwrt-$(PKG_VERSION)-$(PKG_RELEASE)
-CSFB_VERSION_PKG:=github.com/crowdsecurity/cs-firewall-bouncer/pkg/version
+CSFB_VERSION_PKG:=github.com/crowdsecurity/go-cs-lib/version
 
 GO_PKG:=github.com/crowdsecurity/cs-firewall-bouncer
 GO_PKG_INSTALL_ALL:=1


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Kerma Gérald <gandalf@gk2.net> / @ne20002 

**Description:**
Package version string was changed in upstream and binary did not report any build info anymore.
This included upstream LAPI version reporting.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** GL.iNet GL-MT6000

```
root@GL-MT6000:~# /usr/bin/cs-firewall-bouncer --version
version: v0.0.34-openwrt-0.0.34-1
BuildDate: 2026-01-01_13:46:35
GoVersion: 1.25.4
Platform: linux
```

Also reports correctly to crowdsec LAPI:
```
0b855931ddb8:/# cscli bouncer list
───────────────────────────────────────────────────────────────────────────────────────────────────────
 Name       ...   Last API pull         Type                       Version                   Auth Type
───────────────────────────────────────────────────────────────────────────────────────────────────────
 openwrt    ...   2026-01-01T14:03:46Z  crowdsec-firewall-bouncer  v0.0.34-openwrt-0.0.34-1  api-key
───────────────────────────────────────────────────────────────────────────────────────────────────────
```

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
