### PR TITLE
acme-acmesh: support --cert-profile option

### DIFF
--- a/net/acme-acmesh/Makefile
+++ b/net/acme-acmesh/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-acmesh
-PKG_VERSION:=3.1.1
-PKG_RELEASE:=4
+PKG_VERSION:=3.1.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/acmesh-official/acme.sh/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=c5d623ac0af400e83cd676aefaf045228f60e9fc597fea5db4c3a5bd7f6bfcf4
+PKG_HASH:=a51511ad0e2912be45125cf189401e4ae776ca1a29d5768f020a1e35a9560186
 PKG_BUILD_DIR:=$(BUILD_DIR)/acme.sh-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>

--- a/net/acme-acmesh/files/hook.sh
+++ b/net/acme-acmesh/files/hook.sh
@@ -156,6 +156,10 @@ get)
 		set -- "$@" --days "$days"
 	fi
 
+	if [ "$cert_profile" ]; then
+		set -- "$@" --cert-profile "$cert_profile"
+	fi
+
 	case "$validation_method" in
 	"dns")
 		set -- "$@" --dns "$dns"

--- a/net/acme-common/Makefile
+++ b/net/acme-common/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-common
-PKG_VERSION:=1.5.0
+PKG_VERSION:=1.5.1
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/acme-common/files/acme.init
+++ b/net/acme-common/files/acme.init
@@ -61,6 +61,8 @@ load_options() {
 	procd_append_param env acme_server="$acme_server"
 	config_get days "$section" days
 	procd_append_param env days="$days"
+	config_get cert_profile "$section" cert_profile
+	procd_append_param env cert_profile="$cert_profile"
 	config_get dns_wait "$section" dns_wait
 	procd_append_param env dns_wait="$dns_wait"
 	config_get webroot "$section" webroot


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @tohojo 

**Description:**
This PR adds support for specifying a `--cert-profile` which was added to acme.sh `3.1.2`. This enables the use of [profiles](https://letsencrypt.org/docs/profiles/) like `shortlived` from Letsencrypt.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
