### PR TITLE
perlbase-encode: added dependency on perlbase-storable

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -11,7 +11,7 @@ include perlver.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=$(PERL_VERSION)
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=https://www.cpan.org/src/5.0
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/lang/perl/perlbase.mk
+++ b/lang/perl/perlbase.mk
@@ -468,7 +468,7 @@ $(eval $(call BuildPackage,perlbase-dynaloader))
 define Package/perlbase-encode
 $(call Package/perlbase-template)
 TITLE:=Encode perl module
-DEPENDS+=+perlbase-essential +perlbase-mime +perlbase-utf8 +perlbase-xsloader
+DEPENDS+=+perlbase-essential +perlbase-mime +perlbase-storable +perlbase-utf8 +perlbase-xsloader
 endef
 
 define Package/perlbase-encode/install


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @pprindeville  

**Description:**
The Encode module always uses the Storable module.
It does not work without it, ```use Storable;``` is hardcoded.

---

## 🧪 Run Testing Details
No code changes, just added a missing dependency to the Makefile.
---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

