### PR TITLE
hostlog: package integration

### DIFF
--- a/utils/hostlog/Makefile
+++ b/utils/hostlog/Makefile
@@ -1,0 +1,45 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=hostlog
+PKG_VERSION:=1.0.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/kixorz/hostlog/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=a48ec02a6e55df24bbe9f0818b4e86bd494c97a4c3a9cd283a2093ed38a00bad
+
+PKG_MAINTAINER:=Adam Konrad <git@adamkonrad.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.md
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=hostlog
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/hostlog
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Hostlog syslog server
+  URL:=https://github.com/kixorz/hostlog
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/hostlog/description
+  A syslog server with visibility scoring and MCP support.
+endef
+
+define Package/hostlog/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/hostlog.init $(1)/etc/init.d/hostlog
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/hostlog.config $(1)/etc/config/hostlog
+endef
+
+$(eval $(call GoBinPackage,hostlog))
+$(eval $(call BuildPackage,hostlog))

--- a/utils/hostlog/files/hostlog.config
+++ b/utils/hostlog/files/hostlog.config
@@ -1,0 +1,6 @@
+
+config hostlog 'config'
+	option enabled '0'
+	option db_path '/var/hostlog/logs.db'
+	option http_port '8080'
+	option syslog_port '514'

--- a/utils/hostlog/files/hostlog.init
+++ b/utils/hostlog/files/hostlog.init
@@ -1,0 +1,31 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+USE_PROCD=1
+
+start_service() {
+	config_load 'hostlog'
+	local enabled
+	local db_path
+	local http_port
+	local syslog_port
+
+	config_get_bool enabled 'config' 'enabled' 0
+	[ "$enabled" -eq 0 ] && return
+
+	config_get db_path 'config' 'db_path' '/var/hostlog/logs.db'
+	config_get http_port 'config' 'http_port' '8080'
+	config_get syslog_port 'config' 'syslog_port' '514'
+
+	mkdir -p "$(dirname "$db_path")"
+
+	procd_open_instance
+	procd_set_param command /usr/bin/hostlog
+	procd_set_param env HOSTLOG_DB_PATH="$db_path"
+	procd_set_param env HOSTLOG_HTTP_PORT="$http_port"
+	procd_set_param env HOSTLOG_SYSLOG_PORT="$syslog_port"
+	procd_set_param respawn
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}


### PR DESCRIPTION
Based on the `utils/hostlog/Makefile` and the recent changes in the repository, here is the filled-out pull request template for the `hostlog` package:

### 📦 Package Details

**Maintainer:** @kixorz
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
This PR introduces the `hostlog` package, a syslog server with visibility scoring and MCP (Model Context Protocol) support. 

Key features included in this integration:
- Go-based syslog server implementation.
- OpenWrt `init` script for service management via `procd`.
- Default configuration file supporting database path, HTTP port, and syslog port customization.
- Integration with the OpenWrt build system using the `golang-package` mk file.

---

### 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt v25.12.2
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU Standard PC

---

### ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

#### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/hostlog/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>