### PR TITLE
ua3f: add new package

### DIFF
--- a/net/ua3f/Makefile
+++ b/net/ua3f/Makefile
@@ -1,0 +1,57 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ua3f
+PKG_VERSION:=3.6.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=UA3F-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/SunBK201/UA3F/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=067664cf78e2bdb7855e474903da1755d28bee511b5e70b5751d6dc677788bd5
+PKG_BUILD_DIR:=$(BUILD_DIR)/UA3F-$(PKG_VERSION)
+
+PKG_LICENSE:=GPL-3.0-only
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=SunBK201 <sunbk201gm@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/sunbk201/ua3f
+GO_PKG_LDFLAGS_X:=main.appVersion=v$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include $(TOPDIR)/feeds/packages/lang/golang/golang-package.mk
+
+define Package/ua3f
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Web Servers/Proxies
+  TITLE:=Advanced HTTP Rewriting Proxy
+  URL:=https://github.com/SunBK201/UA3F
+  DEPENDS:=$(GO_ARCH_DEPENDS) +nftables +kmod-nft-queue +kmod-nft-tproxy +kmod-nf-conntrack-netlink
+endef
+
+define Package/ua3f/description
+  UA3F is an HTTP rewriting tool that transparently rewrites HTTP (e.g., User-Agent) as an HTTP, SOCKS5, TPROXY, REDIRECT, or NFQUEUE server.
+endef
+
+define Package/ua3f/conffiles
+/etc/config/ua3f
+endef
+
+define Package/ua3f/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/ua3f $(1)/usr/bin/ua3f
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/ua3f.conf $(1)/etc/config/ua3f
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/ua3f.init $(1)/etc/init.d/ua3f
+endef
+
+$(eval $(call GoBinPackage,ua3f))
+$(eval $(call BuildPackage,ua3f))

--- a/net/ua3f/files/ua3f.conf
+++ b/net/ua3f/files/ua3f.conf
@@ -1,0 +1,10 @@
+config 'ua3f' 'enabled'
+	option enabled '0'
+
+config 'ua3f' 'main'
+	option server_mode 'SOCKS5'
+	option port '1080'
+	option bind '127.0.0.1'
+	option rewrite_mode 'GLOBAL'
+	option ua 'FFF'
+	option log_level 'WARN'

--- a/net/ua3f/files/ua3f.init
+++ b/net/ua3f/files/ua3f.init
@@ -1,0 +1,105 @@
+#!/bin/sh /etc/rc.common
+# shellcheck disable=SC2034,SC3043
+
+USE_PROCD=1
+START=99
+
+NAME="ua3f"
+PROG="/usr/bin/$NAME"
+
+start_service() {
+    config_load "$NAME"
+
+    local enabled
+    config_get_bool enabled "enabled" "enabled" "0"
+    [ "$enabled" -eq "1" ] || return 0
+
+    local server_mode
+    local port
+    local bind
+    local ua
+    local log_level
+    local ua_regex
+    local partial_replace
+    local rewrite_mode
+    local header_rewrite
+    local body_rewrite
+    local url_redirect
+    local set_ttl
+    local set_ipid
+    local del_tcpts
+    local set_tcp_init_window
+    config_get server_mode "main" "server_mode" "TPROXY"
+    config_get port "main" "port" "1080"
+    config_get bind "main" "bind" "127.0.0.1"
+    config_get ua "main" "ua" "FFF"
+    config_get ua_regex "main" "ua_regex" ""
+    config_get_bool partial_replace "main" "partial_replace" 0
+    config_get log_level "main" "log_level" "WARN"
+    config_get rewrite_mode "main" "rewrite_mode" "GLOBAL"
+    config_get header_rewrite "main" "header_rewrite" ""
+    config_get body_rewrite "main" "body_rewrite" ""
+    config_get url_redirect "main" "url_redirect" ""
+    config_get_bool set_ttl "main" "set_ttl" 0
+    config_get_bool set_ipid "main" "set_ipid" 0
+    config_get_bool del_tcpts "main" "del_tcpts" 0
+    config_get_bool set_tcp_init_window "main" "set_tcp_init_window" 0
+
+    local desync_ports
+    local desync_reorder
+    local desync_reorder_bytes
+    local desync_reorder_packets
+    local desync_inject
+    local desync_inject_ttl
+    config_get desync_ports "main" "desync_ports" ""
+    config_get_bool desync_reorder "main" "desync_reorder" 0
+    config_get_bool desync_inject "main" "desync_inject" 0
+    if [ "$desync_reorder" -eq "1" ]; then
+        config_get desync_reorder_bytes "main" "desync_reorder_bytes" "1500"
+        config_get desync_reorder_packets "main" "desync_reorder_packets" "8"
+    fi
+    if [ "$desync_inject" -eq "1" ]; then
+        config_get desync_inject_ttl "main" "desync_inject_ttl" "3"
+    fi
+
+    procd_open_instance "$NAME"
+    procd_set_param command "$PROG"
+    procd_append_param command -m "$server_mode"
+    procd_append_param command -p "$port"
+    procd_append_param command -b "$bind"
+    procd_append_param command -f "$ua"
+    procd_append_param command -r "$ua_regex"
+    procd_append_param command -l "$log_level"
+    procd_append_param command -x "$rewrite_mode"
+    procd_append_param command -header-rewrite "$header_rewrite"
+    procd_append_param command -body-rewrite "$body_rewrite"
+    procd_append_param command -url-redirect "$url_redirect"
+    [ "$partial_replace" = "1" ] && procd_append_param command -s
+
+    procd_append_param env UA3F_TTL="$set_ttl"
+    procd_append_param env UA3F_IPID="$set_ipid"
+    procd_append_param env UA3F_TCPTS="$del_tcpts"
+    procd_append_param env UA3F_TCP_INIT_WINDOW="$set_tcp_init_window"
+    procd_append_param env UA3F_DESYNC_REORDER="$desync_reorder"
+    [ "$desync_reorder" -eq "1" ] && procd_append_param env UA3F_DESYNC_REORDER_BYTES="$desync_reorder_bytes"
+    [ "$desync_reorder" -eq "1" ] && procd_append_param env UA3F_DESYNC_REORDER_PACKETS="$desync_reorder_packets"
+    procd_append_param env UA3F_DESYNC_INJECT="$desync_inject"
+    [ "$desync_inject" -eq "1" ] && procd_append_param env UA3F_DESYNC_INJECT_TTL="$desync_inject_ttl"
+    procd_append_param env UA3F_DESYNC_PORTS="$desync_ports"
+
+    procd_set_param respawn
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_set_param pidfile "/var/run/$NAME.pid"
+
+    procd_close_instance
+}
+
+reload_service() {
+    stop
+    start
+}
+
+service_triggers() {
+    procd_add_reload_trigger "$NAME"
+}

--- a/net/ua3f/test.sh
+++ b/net/ua3f/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+ua3f -v | grep "$PKG_VERSION"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @SunBK201

**Description:**
UA3F is an HTTP rewriting tool that transparently rewrites HTTP (e.g., User-Agent) as an HTTP, SOCKS5, TPROXY, REDIRECT, or NFQUEUE server.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.4
- **OpenWrt Target/Subtarget:** ramips/mt7621
- **OpenWrt Device:** GL-MT1300

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
