### PR TITLE
fscrypt: update to 0.3.6

### DIFF
--- a/utils/fscrypt/Makefile
+++ b/utils/fscrypt/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fscrypt
-PKG_VERSION:=0.3.5
+PKG_VERSION:=0.3.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/google/fscrypt/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=368119b5e67c64bdc5f7872ffc7beed425e1401778003f4c7ae7c1062a45ebaf
+PKG_HASH:=6d71e17ef3e48cd5df22190df6925f39ee4a5b24e672f0fa616f3b57f52b2a12
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Latest upstream source. shortlog:
```
Eric Biggers (13):
      README.md: fix a typo
      Fix non-constant format string passed to errors.Wrapf()
      ci.yml: upgrade ubuntu-20.04 to ubuntu-latest
      filesystem/mountpoint: fall back to using mount source field
      Bump up required Go version to 1.23
      Upgrade golang.org/x/sys
      Upgrade golang.org/x/term
      Upgrade golang.org/x/crypto
      Upgrade google.golang.org/protobuf
      Upgrade honnef.co/go/tools
      Upgrade golang.org/x/tools
      Upgrade github.com/urfave/cli
      v0.3.6

NymanRobin (1):
      Compare mount by value instead of reference

Petteri Räty (1):
      Document stdin behaviour for getting raw key

dependabot[bot] (1):
      build(deps): bump golang.org/x/crypto in the go_modules group

dkg (1):
      README.md: link to RFE about systemd-homed fscrypt version support (#412)
```
---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** Intel N150-based PC

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
