### PR TITLE
frp: bump to 0.66.0

### DIFF
--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=frp
-PKG_VERSION:=0.65.0
+PKG_VERSION:=0.66.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=bbec0d1855e66c96e3a79ff97b8c74d9b1b45ec560aa7132550254d48321f7de
+PKG_HASH:=afe1aca9f6e7680a95652e8acf84aef4a74bcefe558b5b91270876066fff3019
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** N/A

**Description:**
Change log is available at: https://github.com/fatedier/frp/releases/tag/v0.66.0

**Features**

- HTTPS proxies now support load balancing groups. Multiple HTTPS proxies can be configured with the same loadBalancer.group and loadBalancer.groupKey to share the same custom domain and distribute traffic across multiple backend services, similar to the existing TCP and HTTP load balancing capabilities.
- Individual frpc proxies and visitors now accept an enabled flag (defaults to true), letting you disable specific entries without relying on the global start list—disabled blocks are skipped when client configs load.
- OIDC authentication now supports a tokenSource field to dynamically obtain tokens from external sources. You can use type = "file" to read a token from a file, or type = "exec" to run an external command (e.g., a cloud CLI or secrets manager) and capture its stdout as the token. The exec type requires the --allow-unsafe=TokenSourceExec CLI flag for security reasons.

**Improvements**

- VirtualNet: Implemented intelligent reconnection with exponential backoff. When connection errors occur repeatedly, the reconnect interval increases from 60s to 300s (max), reducing unnecessary reconnection attempts. Normal disconnections still reconnect quickly at 10s intervals.

**Fixes**

- Fix deadlock issue when TCP connection is closed. Previously, sending messages could block forever if the connection handler had already stopped.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**main/snapshot
- **OpenWrt Target/Subtarget:**qualcommax/aarch64
- **OpenWrt Device:**ipq6000-360v6

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
