### PR TITLE
[openwrt-24.10] Revert "exim: adjust with glibc and libcrypt-compat"

### DIFF
--- a/mail/exim/Makefile
+++ b/mail/exim/Makefile
@@ -45,7 +45,7 @@ LOOKUPS:= \
 define Package/exim/Default
   SECTION:=mail
   CATEGORY:=Mail
-  DEPENDS:= +USE_GLIBC:libcrypt-compat +libdb47 +libpcre2 $(ICONV_DEPENDS) +BUILD_NLS:libidn2 +BUILD_NLS:libidn
+  DEPENDS:=+libdb47 +libpcre2 $(ICONV_DEPENDS) +BUILD_NLS:libidn2 +BUILD_NLS:libidn
   TITLE:=Exim message transfer agent
   URL:=http://www.exim.org/
   USERID:=exim=42:exim=42


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
This commit only applies to master and 25.12 branch which have newer glibc (2.39). We don't have `libcrypt-compat` package on 24.10 branch.

This reverts commit 80c90e9049092b0f709b7e534f8210d42ec4a92e.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.