### PR TITLE
Remove docker dependency declaration to use it standalone

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
 PKG_VERSION:=5.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -29,7 +29,7 @@ define Package/docker-compose
   CATEGORY:=Utilities
   TITLE:=Docker Compose
   URL:=https://github.com/docker/compose
-  DEPENDS:=$(GO_ARCH_DEPENDS) +docker
+  DEPENDS:=$(GO_ARCH_DEPENDS)
 endef
 
 define Package/docker-compose/description


### PR DESCRIPTION
This is helpful for using docker compose for podman without the need of installing docker.

## 📦 Package Details

**Maintainer:** @jmarcet 

**Description:**
Removing the dependency has the effect that it can be used for podman which is natively supported. Docker Compose can be installed standalone since v2.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.4
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Banana Pi R4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
