### PR TITLE
python-pyelftools: add dependency python-setuptools

### DIFF
--- a/lang/python/python-pyelftools/Makefile
+++ b/lang/python/python-pyelftools/Makefile
@@ -19,7 +19,8 @@ HOST_BUILD_DEPENDS:= \
 	python3/host \
 	python-build/host \
 	python-installer/host \
-	python-wheel/host
+	python-wheel/host \
+	python-setuptools/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @vidplace7 

**Description:**

Builds fail sometimes without it. It most likely works most of the time because other packages depend on python-setuptools.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** v25.12.0-rc1
- **OpenWrt Target/Subtarget:** x86/x86_64
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

not applicable