### PR TITLE
Add some tools to test various real time Linux features

### DIFF
--- a/utils/numactl/Makefile
+++ b/utils/numactl/Makefile
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2026 Bootlin
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=numactl
+PKG_VERSION:=2.0.19
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/numactl/numactl/releases/download/v$(PKG_VERSION)
+PKG_HASH:=f2672a0381cb59196e9c246bf8bcc43d5568bc457700a697f1a1df762b9af884
+
+PKG_MAINTAINER:=Thomas Richard <thomas.richard@bootlin.com>
+PKG_LICENSE:=GPL-2.0 (libnuma), LGPL-2.1 (programs)
+PKG_LICENSE_FILES:=LICENSE.GPL2 LICENSE.LGPL2.1
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/numactl/Default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  URL:=https://github.com/numactl/numactl
+endef
+
+define Package/libnuma
+  TITLE:=libnuma
+  ABI_VERSION:=1.0.0
+  DEPENDS:= +libatomic
+endef
+
+define Package/numactl
+  TITLE=numactl and other utilities
+  DEPENDS:= +libnuma
+endef
+
+define Package/numactl/Default/description
+Simple NUMA policy support. It consists of a numactl program to run other
+programs with a specific NUMA policy and a libnuma to do allocations with NUMA
+policy in applications.
+endef
+
+define Package/numactl/description
+$(call Package/numactl/Default/description)
+
+This package provides the binaries.
+endef
+
+define Package/libnuma/description
+$(call Package/numactl/Default/description)
+
+This package provides the libnuma library.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/numaif.h $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/numacompat1.h $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/numa.h $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnuma.so.$(ABI_VERSION) $(1)/usr/lib/
+	$(LN) libnuma.so.$(ABI_VERSION) $(1)/usr/lib/libnuma.so.1
+	$(LN) libnuma.so.$(ABI_VERSION) $(1)/usr/lib/libnuma.so
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnuma.a $(1)/usr/lib/
+endef
+
+define Package/libnuma/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libnuma.so.$(ABI_VERSION) $(1)/usr/lib/
+	$(LN) libnuma.so.$(ABI_VERSION) $(1)/usr/lib/libnuma.so.1
+	$(LN) libnuma.so.$(ABI_VERSION) $(1)/usr/lib/libnuma.so
+endef
+
+define Package/numactl/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/memhog $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/migratepages $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/migspeed $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/numactl $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/numademo $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/numastat $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,libnuma))
+$(eval $(call BuildPackage,numactl))

--- a/utils/rt-tests/Makefile
+++ b/utils/rt-tests/Makefile
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2026 Bootlin
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rt-tests
+PKG_VERSION:=2.9
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@KERNEL/linux/utils/rt-tests
+PKG_HASH:=95acf47cd8cbea2f8acd616fe590031daed8156d6f753093f2931a6e9cbeed8f
+
+PKG_MAINTAINER:=Thomas Richard <thomas.richard@bootlin.com>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/rt-tests
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Real-Time preemption testcases
+  URL:=https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git
+  DEPENDS:= @USE_GLIBC +libnuma +python3-light
+endef
+
+define Package/rt-tests/description
+Test suite that contains programs to test various real time Linux features.
+endef
+
+define Package/hwlatdetect
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Hardware latency detector
+  URL:=https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git
+  DEPENDS:= @KERNEL_HWLAT_TRACER +python3-light
+endef
+
+define Package/hwlatdetect/description
+Python utility for controlling the kernel hardware latency detection module
+(hwlat_detector.ko).
+endef
+
+define Package/rt-tests/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/cyclicdeadline $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/cyclictest $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/deadline_test $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hackbench $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/oslat $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/pip_stress $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/pi_stress $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/pmqtest $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ptsematest $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/queuelat $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/rt-migrate-test $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/signaltest $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/sigwaittest $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ssdd $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/svsematest $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/cyclictest/get_cyclictest_snapshot.py \
+		$(1)/usr/bin/get_cyclictest_snapshot
+endef
+
+define Package/hwlatdetect/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/hwlatdetect/hwlatdetect.py \
+		$(1)/usr/bin/hwlatdetect
+endef
+
+$(eval $(call BuildPackage,rt-tests))
+$(eval $(call BuildPackage,hwlatdetect))

--- a/utils/rtla/Makefile
+++ b/utils/rtla/Makefile
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2026 Bootlin
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=rtla
+PKG_VERSION:=$(LINUX_VERSION)
+
+PKG_MAINTAINER:=Benjamin Robin <benjamin.robin@bootlin.com>
+PKG_LICENSE:=GPL-2.0-only
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/rtla
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Real-Time Linux Analysis tools
+  URL:=https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+  DEPENDS:= @USE_GLIBC @(KERNEL_OSNOISE_TRACER||KERNEL_TIMERLAT_TRACER) +libtracefs +libtraceevent
+endef
+
+define Package/rtla/description
+The rtla meta-tool includes a set of commands that aims to analyze
+the real-time properties of Linux. Instead of testing Linux as a black box,
+rtla leverages kernel tracing capabilities to provide precise information
+about the properties and root causes of unexpected results.
+
+Available commands are:
+- osnoise (requires osnoise tracer)
+- hwnoise (requires osnoise tracer)
+- timerlat (requires timerlat tracer)
+endef
+
+MAKE_FLAGS = \
+	CROSS_COMPILE="$(TARGET_CROSS)" \
+	CC="$(TARGET_CC)" \
+	CFLAGS='$(TARGET_CFLAGS) $(TARGET_CPPFLAGS) -DVERSION="\"$(PKG_VERSION)\"" -I$(STAGING_DIR)/usr/include/traceevent' \
+	LDFLAGS="$(TARGET_LDFLAGS)"
+
+define Build/Compile
+	$(MAKE) -C $(LINUX_DIR)/tools/tracing/rtla $(MAKE_FLAGS)
+endef
+
+define Package/rtla/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(LINUX_DIR)/tools/tracing/rtla/rtla $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,rtla))


### PR DESCRIPTION
A pull request [1] has been opened in the OpenWrt core repository to introduce the PREEMPT_RT kernel configuration option for x86_64, arm64, and RISC-V architectures.
Enabling PREEMPT_RT makes it essential to analyze and characterize the kernel’s real-time performance. To support this, this pull request integrates existing tools for real-time behavior analysis into OpenWrt.

Some tools require the new tracers introduced in [1].

It can also be applied safely on openwrt-25.12 branch

[1] https://github.com/openwrt/openwrt/pull/21413