### PR TITLE
turbostat: add new package

### DIFF
--- a/utils/turbostat/Makefile
+++ b/utils/turbostat/Makefile
@@ -1,0 +1,44 @@
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=turbostat
+PKG_VERSION:=$(LINUX_VERSION)
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=John Audia <therealgraysky@proton.me>
+PKG_LICENSE:=GPL-2.0-only
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/turbostat
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Report processor frequency and idle statistics
+  URL:=https://www.kernel.org
+  DEPENDS:=@(TARGET_x86_64||TARGET_x86) +libpci +libcap
+endef
+
+define Package/turbostat/description
+  Turbostat reports processor topology, frequency, idle power-state statistics,
+  temperature and power on X86 processors.
+endef
+
+MAKE_FLAGS = \
+	ARCH="$(LINUX_KARCH)" \
+	CROSS_COMPILE="$(TARGET_CROSS)" \
+	CC="$(TARGET_CC)" \
+	CFLAGS="$(TARGET_CFLAGS/ -fhonour-copts/) $(TARGET_CPPFLAGS) -I$(STAGING_DIR)/usr/include" \
+	LDFLAGS="$(TARGET_LDFLAGS) -L$(STAGING_DIR)/usr/lib"
+
+define Build/Compile
+	sed -i '/^CROSS/d' $(LINUX_DIR)/tools/power/x86/turbostat/Makefile
+	-$(MAKE) clean -C $(LINUX_DIR)/tools/power/x86/turbostat
+	+$(MAKE) -C $(LINUX_DIR)/tools/power/x86/turbostat $(MAKE_FLAGS)
+endef
+
+define Package/turbostat/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(LINUX_DIR)/tools/power/x86/turbostat/turbostat $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,turbostat))

--- a/utils/turbostat/test.sh
+++ b/utils/turbostat/test.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+turbostat --version | grep version


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Turbostat is a Linux utility that reports processor topology, real operating frequency, idle states, temperature, and power usage on x86 processors. It is useful to see actual hardware‑measured CPU behavior, not the policy targets exposed by cpufreq. It shows true core frequencies, boost behavior, idle‑state residency, thermal and power telemetry, and throttling indicators, all sampled directly from MSRs.

This makes it far more accurate than tools like lscpu or /sys frequency files, especially when diagnosing boost limits, thermal constraints, or governor behavior under load.

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glib
- **OpenWrt Device:** Intel N150 based PC

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
