### PR TITLE
madplay: fix compilation with GCC 15

### DIFF
--- a/sound/madplay/Makefile
+++ b/sound/madplay/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=madplay
 PKG_VERSION:=0.15.2b
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/mad \
@@ -52,6 +52,8 @@ CONFIGURE_ARGS += \
 
 CONFIGURE_VARS += \
 	lt_prog_compiler_pic="$(FPIC)"
+
+TARGET_CFLAGS += -D__GNU_LIBRARY__
 
 MAKE_FLAGS += CFLAGS="$(TARGET_CFLAGS)"
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @probonopd 

**Description:**
Currently, `madplay` fails to build while using GCC 15:
```
In file included from ../../../staging_dir/toolchain-x86_64_gcc-15.2.0_musl/include/fortify/unistd.h:22,
                 from madplay.c:42:
staging_dir/toolchain-x86_64_gcc-15.2.0_musl/include/unistd.h:127:5: error: conflicting types for 'getopt'; have 'int(int,  char * const*, const char *)'
  127 | int getopt(int, char * const [], const char *);
      |     ^~~~~~
In file included from madplay.c:29:
getopt.h:147:12: note: previous declaration of 'getopt' with type 'int(void)'
  147 | extern int getopt ();
      |            ^~~~~~
```

This patch defines `__GNU_LIBRARY__` for a proper `getopt` declaration when building with GCC 15.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** Snapshot
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** Generic x86/64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.