### PR TITLE
ifstat: fix build with GCC 15

### DIFF
--- a/net/ifstat/Makefile
+++ b/net/ifstat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ifstat
 PKG_VERSION:=1.1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://gael.roualland.free.fr/ifstat/
@@ -18,6 +18,8 @@ PKG_HASH:=8599063b7c398f9cfef7a9ec699659b25b1c14d2bc0f535aed05ce32b7d9f507
 PKG_MAINTAINER:=Nikil Mehta <nikil.mehta@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
+
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @nikil 

**Description:**
`ifstat` fails to build with GCC 15 due to an incorrect detection of the signal handler return type.
The configure script shipped with `ifstat` uses an obsolete K&R-style declaration: `void (*signal())();`

With GCC 15 this causes the `signal()` return type check to incorrectly assume `int` instead of `void`.
As a result, the generated code defines signal handlers returning `int`, which conflicts with `struct sigaction` expecting a `void (*)(int)` handler and leads to a build failure:
```
ifstat.c: In function '_setsig':                                                                                                                                                                                    
ifstat.c:75:17: error: assignment to 'void (*)(int)' from incompatible pointer type 'int (*)(int)' [-Wincompatible-pointer-types]                                                                                   
   75 |   sa.sa_handler = handler;                                                                                                                                                                                  
      |                 ^
```
Enable `autoreconf` during the build to regenerate the configure script, which correctly detects the signal handler type and fixes the compilation error.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** Snapshot
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** Generic x86/64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.