### PR TITLE
hwloc: update to 2.12.2

### DIFF
--- a/libs/hwloc/Makefile
+++ b/libs/hwloc/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hwloc
-PKG_VERSION:=2.12.1
+PKG_VERSION:=2.12.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.open-mpi.org/release/$(PKG_NAME)/v2.12
-PKG_HASH:=38a90328bb86259f9bb2fe1dc57fd841e111d1e6358012bef23dfd95d21dc66b
+PKG_HASH:=563e61d70febb514138af0fac36b97621e01a4aacbca07b86e7bd95b85055ba0
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
This upstream release fixed a number of small issues.

## 📦 Package Details

**Maintainer:** me

**Description:**
Update to 2.12.2

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.