### PR TITLE
vips: update to 8.18.0

### DIFF
--- a/libs/vips/Makefile
+++ b/libs/vips/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vips
-PKG_VERSION:=8.17.1
+PKG_VERSION:=8.18.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/libvips/libvips/releases/download/v$(PKG_VERSION)
-PKG_HASH:=4d8c3325922c5300253d7594507a8f1d3caf8eed70dfb66cc7eb2cbed65bb5ca
+PKG_HASH:=b85ab92280c30d22f5c8fe2f68b809cddb7eaac437d8c33474475dac84ddc574
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Upstream list of changes is available at
https://github.com/libvips/libvips/releases/tag/v8.18.0.

## 📦 Package Details

**Maintainer:** me

**Description:**
Update to 8.18.0

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.