### PR TITLE
python-greenlet: update to 3.3.1

### DIFF
--- a/lang/python/python-greenlet/Makefile
+++ b/lang/python/python-greenlet/Makefile
@@ -8,17 +8,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-greenlet
-PKG_VERSION:=3.2.4
+PKG_VERSION:=3.3.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=greenlet
-PKG_HASH:=0dca0d95ff849f9a364385f36ab49f50065d76964944638be9691e1832e9f86d
+PKG_HASH:=41848f3230b58c08bb43dee542e74a2a2e34d3c59dc3076cec9151aeeedcae98
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
-# FIXME: remove when GCC10 is the oldest supported compiler, or the issue goes away
-PKG_BUILD_FLAGS:=no-mips16
+
+PKG_BUILD_DEPENDS:= \
+	python3/host \
+	python-setuptools/host \
+	python-wheel/host
 
 HOST_BUILD_DEPENDS:= \
 	python3/host \
@@ -41,21 +44,13 @@ define Package/python3-greenlet
   URL:=https://github.com/python-greenlet/greenlet
   DEPENDS:= \
 	+python3-light \
-	+libstdcpp \
-	@!arc
+	+libstdcpp
 endef
 
 define Package/python3-greenlet/description
   The greenlet package is a spin-off of Stackless
   a version of CPython that supports micro-threads called tasklets.
 endef
-
-# FIXME: remove when GCC10 is the oldest supported compiler, or the issue goes away
-# This is required in addition to PKG_BUILD_FLAGS:=no-mips16 because otherwise MIPS16
-# flags are inherited from the Python base package (via sysconfig module)
-ifdef CONFIG_USE_MIPS16
-TARGET_CFLAGS += -mno-mips16 -mno-interlink-mips16
-endif
 
 $(eval $(call Py3Package,python3-greenlet))
 $(eval $(call BuildPackage,python3-greenlet))


### PR DESCRIPTION
Add patch fixing MIPS compilation.

Removed MIPS16 hacks as a result. They didn't work anyway.