### PR TITLE
[25.12] python-certifi: update to 2026.1.4

### DIFF
--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
-PKG_VERSION:=2025.8.3
-PKG_RELEASE:=2
+PKG_VERSION:=2026.1.4
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=MPL-2.0
@@ -15,7 +15,7 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:certifi:certifi
 
 PYPI_NAME:=certifi
-PKG_HASH:=e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407
+PKG_HASH:=ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120
 
 HOST_BUILD_DEPENDS:= \
 	python3/host \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @cotequeiroz

**Description:**
Use the latest CA bundle from Mozilla.

Backport of https://github.com/openwrt/packages/pull/28260 to 25.12.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.