### PR TITLE
vscode: update editor settings and commit constraints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-    "git.alwaysSignOff": true
+    "git.alwaysSignOff": true,
+    "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
+    "files.eol": "\n",
+    "git.inputValidation": true,
+    "git.inputValidationSubjectLength": 60,
+    "git.inputValidationLineLength": 75
 }


### PR DESCRIPTION
Enable trailing whitespace trimming, insert final newline, and force LF. Configure git input validation to warn if subject exceeds 60 characters or if body lines exceed 75 characters.

More changes to file, which was added in https://github.com/openwrt/packages/pull/25034

cc: @bam80 