### PR TITLE
nut-server: Fix the other/otherflag functionality

### DIFF
--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -201,7 +201,7 @@ build_ups_config() {
 	config_list_foreach "$ups" override defoverride override
 	config_list_foreach "$ups" default defoverride default
 
-	other() {
+	do_other() {
 		# shellcheck disable=SC2317
 		local othervar="$1"
 		# shellcheck disable=SC2317
@@ -219,8 +219,13 @@ build_ups_config() {
 		fi
 	}
 
-	config_list_foreach "$ups" other other other
-	config_list_foreach "$ups" otherflag other otherflag
+	# For each entry in the list "other", get the variable "other_${entry}",
+	# and if not empty, write "${entry} = ${value of other_${entry}}" to the config file.
+	config_list_foreach "$ups" other do_other other
+
+	# For each entry in the list "otherflag", get the variable "otherflag_${entry}",
+	# and if true, write "${entry}" to the config file.
+	config_list_foreach "$ups" otherflag do_other otherflag
 	echo "" >>$UPS_C
 	haveupscfg=1
 }

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -211,10 +211,10 @@ build_ups_config() {
 
 		# shellcheck disable=SC2317
 		if [ "$othervarflag" = "otherflag" ]; then
-			config_get_bool otherval "${othervarflag}_${othervar}" value
+			config_get_bool otherval "${ups}" "${othervarflag}_${othervar}" value
 			[ "$otherval" = "1" ] && echo "${othervar}" >>"$UPS_C"
 		else
-			config_get otherval "${othervarflag}_${othervar}" value
+			config_get otherval "${ups}" "${othervarflag}_${othervar}" value
 			[ -n "$otherval" ] && echo "${othervar} = $otherval" >>"$UPS_C"
 		fi
 	}


### PR DESCRIPTION
Signed-off-by: Rylie Pavlik <rylie@ryliepavlik.com>

## 📦 Package Details

**Maintainer:** @s-hamann, @hnyman, @tofurky, @neheb

**Description:**
There is an unclear reference to handling unknown config fields for driver config files in the wiki. This adjusts the service script so that they actually work.

- For each value "x" in the per-driver list "other", get the per-driver config variable "other_x", and if it is not empty, write "x = {value of other_x}" to the config file.
- For each value "x" in the per-driver list "otherflag", get the per-driver config variable "otherflag_x", and if it is true, write "x " to the config file.

I think this should be safe to backport, if desired. I tested it on a stable release device.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.5
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** OpenWrt One

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

