### PR TITLE
miniupnpd: Enable IPv6 leases file

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.3.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://github.com/miniupnp/miniupnp/releases/download/miniupnpd_$(subst .,_,$(PKG_VERSION))
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -61,7 +61,7 @@ upnpd() {
 	local external_iface external_iface6 external_zone external_ip internal_iface
 	local upload download log_output port config_file serial_number model_number
 	local use_stun stun_host stun_port uuid notify_interval presentation_url
-	local upnp_lease_file ipv6_disable
+	local upnp_lease_file upnp_lease_file6 ipv6_disable
 
 	local enabled
 	config_get_bool enabled config enabled 1
@@ -86,6 +86,7 @@ upnpd() {
 	config_get notify_interval config notify_interval
 	config_get presentation_url config presentation_url
 	config_get upnp_lease_file config upnp_lease_file
+	config_get upnp_lease_file6 config upnp_lease_file6
 	config_get ipv6_disable config ipv6_disable 0
 
 	local conf ifname ifname6
@@ -151,6 +152,7 @@ upnpd() {
 		}
 
 		[ -n "$upnp_lease_file" ] && touch "$upnp_lease_file" && echo "lease_file=$upnp_lease_file"
+		[ -n "$upnp_lease_file6" ] && touch "$upnp_lease_file6" && echo "lease_file6=$upnp_lease_file6"
 		[ -n "$presentation_url" ] && echo "presentation_url=$presentation_url"
 		[ -n "$notify_interval" ] && echo "notify_interval=$notify_interval"
 		[ -n "$serial_number" ] && echo "serial=$serial_number"

--- a/net/miniupnpd/files/upnpd.config
+++ b/net/miniupnpd/files/upnpd.config
@@ -11,6 +11,7 @@ config upnpd config
 	option internal_iface	lan
 	option port		5000
 	option upnp_lease_file	/var/run/miniupnpd.leases
+	option upnp_lease_file6	/var/run/miniupnpd.leases6
 	option igdv1		1
 
 config perm_rule


### PR DESCRIPTION
## 📦 miniupnpd

**Maintainer:** N/A


**Description:**
Introduces the IPv6 Leases file by default. This file will display active IPv6 leases requested under the IPv6 PCP (Port Control Protocol) a.k.a _IPv6 Pinholes_.

miniupnpd must be compiled with ENABLE_UPNPPINHOLE set for this to take effect. This is taken care of currently by setting CONFIG_IPV6.
The lease file looks something like
```
Proto;ClientIP;ClientPort;RemoteIP;RemotePort;UID;Timestamp;Description
```

This PR **does not** take care of the Luci changes necessary to expose this extra data to the GUI.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** Gargoyle 1.15.x (OpenWrt 24.10.5)
- **OpenWrt Target/Subtarget:** x86/x64
- **OpenWrt Device:** Generic x86

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
