### PR TITLE
sysrepo: drop libredblack from dependencies

### DIFF
--- a/net/sysrepo/Makefile
+++ b/net/sysrepo/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sysrepo
 PKG_VERSION:=3.7.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/sysrepo/sysrepo/tar.gz/v$(PKG_VERSION)?
@@ -29,7 +29,7 @@ define Package/libsysrepo
   CATEGORY:=Libraries
   TITLE:=YANG-based data store library
   URL:=https://www.sysrepo.org/
-  DEPENDS:=+libyang +libatomic +libprotobuf-c +libev +libredblack +librt +libpthread
+  DEPENDS:=+libyang +libatomic +libprotobuf-c +libev +librt +libpthread
 endef
 
 define Package/sysrepo


### PR DESCRIPTION
Only sysrepo version 0.x.x requires libredblack,
so current version of sysrepo doesn't depend on it.
After merge of this PR, we can drop libredblack from repo.

## 📦 Package Details

**Maintainer:** None

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
