### PR TITLE
libteam: disable zmq and dbus

### DIFF
--- a/net/libteam/Makefile
+++ b/net/libteam/Makefile
@@ -19,7 +19,10 @@ PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
 
-CONFIGURE_ARGS+=--disable-static
+CONFIGURE_ARGS+=\
+	--disable-static \
+	--disable-dbus \
+	--disable-zmq
 
 define Package/libteam/default
   SECTION:=libs


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:** Fix build error when zmq or dbus is detected by autoconf.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT r32606-93665d0aa3
- **OpenWrt Target/Subtarget:** mediatek/mt7622
- **OpenWrt Device:** Xiaomi Redmi Router AX6S

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.