### PR TITLE
ddns-scripts: add apertodns.com-token to provider list

### DIFF
--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -6,6 +6,7 @@ afraid.org-v2-token
 all-inkl.com
 aliyun.com
 apertodns.com
+apertodns.com-token
 changeip.com
 core-networks.de
 ddnss.de


### PR DESCRIPTION
Add the token-based authentication variant to the provider list.
The configuration file (apertodns.com-token.json) was already merged in PR #28160, but the list entry was missing.

thanks @feckert 