### PR TITLE
liboqs: fix missing symbolic link installation

### DIFF
--- a/libs/liboqs/Makefile
+++ b/libs/liboqs/Makefile
@@ -60,7 +60,7 @@ define Build/InstallDev
 		$(1)/usr/include/oqs/
 
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liboqs.so.* \
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liboqs.so* \
 		$(1)/usr/lib/
 
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig


### PR DESCRIPTION
The current installation process fails to correctly install the 'liboqs.so' symbolic link due to an incorrect path syntax (extra dot). This prevents other packages from linking against liboqs (e.g., using -loqs) during development, which was discovered while testing PQC key exchange implementations dependent on OQS.

Removes the trailing dot to ensure the symbolic link is preserved and copied correctly to the destination directory.

## 📦 Package Details

**Maintainer:**  @Ansuel 

**Description:**
liboqs is an open source C library for quantum-safe cryptographic algorithms.


## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12
- **OpenWrt Target/Subtarget:** MediaTek ARM/Filogic 8x0 (MT798x)
- **OpenWrt Device:** ipTIME AX3000SE

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
