### PR TITLE
[25.12] perl-www: added dependency on perlbase-module

### DIFF
--- a/lang/perl/perl-www/Makefile
+++ b/lang/perl/perl-www/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-www
 PKG_VERSION:=6.78
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 METACPAN_NAME:=libwww-perl
 METACPAN_AUTHOR:=OALDERS
@@ -22,7 +22,7 @@ define Package/perl-www
   CATEGORY:=Languages
   TITLE:=The World-Wide Web library for Perl
   URL:=https://metacpan.org/pod/LWP
-  DEPENDS:=perl +perlbase-base +perlbase-digest +perlbase-encode +perlbase-essential +perlbase-io +perlbase-mime +perlbase-net +perl-encode-locale +perl-file-listing +perl-html-parser +perl-http-cookies +perl-http-daemon +perl-http-date +perl-http-message +perl-http-negotiate +perl-lwp-mediatypes +perl-net-http +perl-try-tiny +perl-uri +perl-www-robotrules
+  DEPENDS:=perl +perlbase-base +perlbase-digest +perlbase-encode +perlbase-essential +perlbase-io +perlbase-mime +perlbase-module +perlbase-net +perl-encode-locale +perl-file-listing +perl-html-parser +perl-http-cookies +perl-http-daemon +perl-http-date +perl-http-message +perl-http-negotiate +perl-lwp-mediatypes +perl-net-http +perl-try-tiny +perl-uri +perl-www-robotrules
 endef
 
 define Package/perl-www/description


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jw2013

**Description:**
Add missing dependency on perlbase-module (cherry-picked from https://github.com/openwrt/packages/pull/28241)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12-rc2
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** x86_64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
