### PR TITLE
add package shadowsocks-rust

### DIFF
--- a/net/shadowsocks-rust/Makefile
+++ b/net/shadowsocks-rust/Makefile
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2017-2020 Yousong Zhou <yszhou4tech@gmail.com>
+# Copyright (C) 2026 Jove Yu <yushijun110@gmail.com>
+#
+# vim: set noexpandtab ts=8 sw=8 sts=0:
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=shadowsocks-rust
+PKG_VERSION:=1.24.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/shadowsocks/shadowsocks-rust/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=a89865d1c5203de1b732017dd032e85f943d1592e8d3152eb7d2c4f3fca387bf
+
+PKG_MAINTAINER:=Jove Yu <yushijun110@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=rust/host
+PKG_BUILD_PARALLEL:=1
+
+RUST_PKG_FEATURES:=aead-cipher-2022,local-dns,local-http,local-redir,local-tun,local-tunnel
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/shadowsocks-rust-config
+	SECTION:=net
+	CATEGORY:=Network
+	SUBMENU:=Web Servers/Proxies
+	TITLE:=shadowsocks-rust config script
+	URL:=https://github.com/shadowsocks/shadowsocks-rust
+endef
+
+define Package/shadowsocks-rust-config/conffiles
+	/etc/config/shadowsocks-rust
+endef
+
+define Package/shadowsocks-rust-config/install
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./shadowsocks-rust.config $(1)/etc/config/shadowsocks-rust
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./shadowsocks-rust.init $(1)/etc/init.d/shadowsocks-rust
+endef
+
+define Package/shadowsocks-rust-ssrules
+	SECTION:=net
+	CATEGORY:=Network
+	SUBMENU:=Web Servers/Proxies
+	TITLE:=shadowsocks-rust ssrules
+	URL:=https://github.com/shadowsocks/shadowsocks-rust
+	DEPENDS:=+firewall4 \
+		+ip \
+		+shadowsocks-rust-sslocal \
+		+shadowsocks-rust-config \
+		+kmod-nft-tproxy
+endef
+
+define Package/shadowsocks-rust-ssrules/install
+	$(INSTALL_DIR) $(1)/usr/share/shadowsocks-rust/
+	$(INSTALL_DATA) ./ssrules/* $(1)/usr/share/shadowsocks-rust/
+endef
+
+define Package/shadowsocks-rust/Default
+define Package/shadowsocks-rust-$(1)
+	SECTION:=net
+	CATEGORY:=Network
+	SUBMENU:=Web Servers/Proxies
+	TITLE:=shadowsocks-rust $(1)
+	URL:=https://github.com/shadowsocks/shadowsocks-rust
+	DEPENDS:=$$(RUST_ARCH_DEPENDS) @!i386
+endef
+
+define Package/shadowsocks-rust-$(1)/install
+	$$(INSTALL_DIR) $$(1)/usr/bin
+	$$(INSTALL_BIN) $$(PKG_INSTALL_DIR)/bin/$(1) $$(1)/usr/bin/
+endef
+endef
+
+SHADOWSOCKS_COMPONENTS:=sslocal ssmanager ssserver ssurl ssservice
+define shadowsocks-rust/templates
+	$(foreach component,$(SHADOWSOCKS_COMPONENTS),
+		$(call Package/shadowsocks-rust/Default,$(component))
+	)
+endef
+$(eval $(call shadowsocks-rust/templates))
+
+$(eval $(call BuildPackage,shadowsocks-rust-config))
+$(eval $(call BuildPackage,shadowsocks-rust-ssrules))
+$(foreach component,$(SHADOWSOCKS_COMPONENTS), \
+	$(eval $(call BuildPackage,shadowsocks-rust-$(component))) \
+)
+
+

--- a/net/shadowsocks-rust/shadowsocks-rust.config
+++ b/net/shadowsocks-rust/shadowsocks-rust.config
@@ -1,0 +1,74 @@
+config local 'socks5'
+    option disabled 1
+    option protocol 'socks'
+    option server 'sss0'
+    option local_address '::'
+    option local_port 1080
+    option mode 'tcp_only'
+
+config local 'http'
+    option disabled 1
+    option protocol 'http'
+    option server 'sss0'
+    option local_address '::'
+    option local_port 1081
+    option mode 'tcp_only'
+
+config local 'redir'
+    option disabled 1
+    option protocol 'redir'
+    option server 'sss0'
+    option local_address '::'
+    option local_port 1082
+    option mode 'tcp_only'
+
+config local 'tunnel'
+    option disabled 1
+    option protocol 'tunnel'
+    option server 'sss0'
+    option local_address '::'
+    option local_port 1083
+    option forward_address '8.8.8.8'
+    option forward_port 53
+    option mode 'tcp_only'
+
+config local 'dns'
+    option disabled 1
+    option protocol 'dns'
+    option server 'sss0'
+    option local_address '::'
+    option local_port 1084
+    option local_dns_address '114.114.114.114'
+    option local_dns_port 53
+    option remote_dns_address '8.8.8.8'
+    option remote_dns_port 53
+    option client_cache_size 5
+    option mode 'udp_only'
+
+config local 'tun'
+    option disabled 1
+    option protocol 'tun'
+    option server 'sss0'
+    option local_address '::'
+    option local_port 1085
+    option tun_interface_name 'tun0'
+    option tun_interface_address '10.255.0.1/24'
+
+config rules 'rules'
+    option disabled 1
+    option redir_tcp 'redir'
+    option redir_udp 'redir'
+    option src_default 'checkdst'
+    option dst_default 'bypass'
+    option local_default 'checkdst'
+    list src_ips_forward '192.168.1.4'
+
+config server 'sss0'
+    option disabled 1
+    option server '1.1.1.1'
+    option server_port '12345'
+    option method 'chacha20-ietf-poly1305'
+    option password 'password'
+    option plugin ''
+    option plugin_opts ''
+    option timeout 30

--- a/net/shadowsocks-rust/shadowsocks-rust.init
+++ b/net/shadowsocks-rust/shadowsocks-rust.init
@@ -1,0 +1,213 @@
+#!/bin/sh /etc/rc.common
+#
+# Copyright (C) 2017-2019 Yousong Zhou <yszhou4tech@gmail.com>
+# Copyright (C) 2026 Jove Yu <yushijun110@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v3.
+# See /LICENSE for more information.
+
+USE_PROCD=1
+START=99
+
+. /usr/share/libubox/jshn.sh
+
+confdir=/var/etc/shadowsocks-rust
+ssrules_uc="/usr/share/shadowsocks-rust/ssrules.uc"
+ssrules_nft="/etc/nftables.d/90-shadowsocks-rust-ssrules.nft"
+
+gen_server_conf() {
+    local server_cfg="$1"
+    local jsonpath="$2"
+    local method # do not delete
+    local has_local=0
+
+    validate_server_section "$server_cfg" || return 1
+    [ "$disabled" = "1" ] && return 1
+    json_init
+    [ -z "$server" ] || json_add_string server "$server"
+    [ -z "$server_port" ] || json_add_int server_port "$server_port"
+    [ -z "$password" ] || json_add_string password "$password"
+    [ -z "$method" ] || json_add_string method "$method"
+    [ -z "$plugin" ] || json_add_string plugin "$plugin"
+    [ -z "$plugin_opts" ] || json_add_string plugin_opts "$plugin_opts"
+    [ -z "$timeout" ] || json_add_int timeout "$timeout"
+    json_add_array locals
+
+    add_local_to_json() {
+        local local_cfg="$1"
+        validate_local_section "$local_cfg" || return
+        [ "$disabled" = "1" ] && return
+        [ "$server" = "$server_cfg" ] || return
+        has_local=1
+
+        json_add_object
+        [ -z "$protocol" ] || json_add_string protocol "$protocol"
+        [ -z "$mode" ] || json_add_string mode "$mode"
+        [ -z "$local_address" ] || json_add_string local_address "$local_address"
+        [ -z "$local_port" ] || json_add_int local_port "$local_port"
+        if [ "$protocol" = "tunnel" ]; then
+            [ -z "$forward_address" ] || json_add_string forward_address "$forward_address"
+            [ -z "$forward_port" ] || json_add_int forward_port "$forward_port"
+        elif [ "$protocol" = "dns" ]; then
+            [ -z "$local_dns_address" ] || json_add_string local_dns_address "$local_dns_address"
+            [ -z "$local_dns_port" ] || json_add_int local_dns_port "$local_dns_port"
+            [ -z "$remote_dns_address" ] || json_add_string remote_dns_address "$remote_dns_address"
+            [ -z "$remote_dns_port" ] || json_add_int remote_dns_port "$remote_dns_port"
+            [ -z "$client_cache_size" ] || json_add_int client_cache_size "$client_cache_size"
+        elif [ "$protocol" = "redir" ]; then
+            json_add_string tcp_redir "tproxy"
+            json_add_string udp_redir "tproxy"
+        elif [ "$protocol" = "tun" ]; then
+            [ -z "$tun_interface_name" ] || json_add_string tun_interface_name "$tun_interface_name"
+            [ -z "$tun_interface_address" ] || json_add_string tun_interface_address "$tun_interface_address"
+        fi
+        json_close_object
+    }
+
+    config_foreach add_local_to_json local
+    json_close_array
+    [ "$has_local" = "1" ] || return 1
+    json_dump > $jsonpath
+}
+
+start_server() {
+    local cfg="$1"
+    local jsonpath="$confdir/sslocal.$cfg.json"
+
+    if gen_server_conf "$cfg" "$jsonpath"; then
+        procd_open_instance "ssserver.$cfg"
+        procd_set_param command /usr/bin/sslocal -c "$jsonpath"
+        procd_set_param respawn
+        procd_set_param file "/etc/config/shadowsocks-rust"
+        procd_set_param stdout 1
+        procd_set_param stderr 1
+        procd_close_instance
+    fi
+}
+
+start_service() {
+    mkdir -p "$confdir"
+    config_load shadowsocks-rust
+    config_foreach start_server server
+    ss_rules
+}
+
+stop_service() {
+    ss_rules_nft_reset
+    rm -rf "$confdir"
+}
+
+ss_rules_nft_gen() {
+    [ -s "$ssrules_uc" ] || return 1
+    validate_rules_section "rules" || return 1
+    [ "$disabled" = "1" ] && return 1
+
+    if [ -n "$redir_tcp" ]; then
+        config_get local_port_tcp "$redir_tcp" local_port
+    fi
+    if [ -n "$redir_udp" ]; then
+        config_get local_port_udp "$redir_udp" local_port
+    fi
+    
+    [ -n "$local_port_tcp" ] || [ -n "$local_port_udp" ] || return 1
+
+    local tmp="/tmp/ssrules"
+    json_init
+    json_add_string o_remote_servers ""
+    json_add_int o_redir_tcp_port "$local_port_tcp"
+    json_add_int o_redir_udp_port "$local_port_udp"
+    json_add_string o_ifnames "$ifnames"
+    json_add_string o_local_default "$local_default"
+    json_add_string o_src_bypass "$src_ips_bypass"
+    json_add_string o_src_forward "$src_ips_forward"
+    json_add_string o_src_checkdst "$src_ips_checkdst"
+    json_add_string o_src_default "$src_default"
+    json_add_string o_dst_bypass "$dst_ips_bypass"
+    json_add_string o_dst_forward "$dst_ips_forward"
+    json_add_string o_dst_bypass_file "$dst_ips_bypass_file"
+    json_add_string o_dst_forward_file "$dst_ips_forward_file"
+    json_add_string o_dst_default "$dst_default"
+    json_add_string o_nft_tcp_extra "$nft_tcp_extra"
+    json_add_string o_nft_udp_extra "$nft_udp_extra"
+    json_dump -i >"$tmp.json"
+
+    if utpl -S -F "$tmp.json" "$ssrules_uc" >"$tmp.nft" \
+        && ! cmp -s "$tmp.nft" "$ssrules_nft"; then
+        echo "table inet chk {include \"$tmp.nft\";}" >"$tmp.nft.chk"
+        if nft -f "$tmp.nft.chk" -c; then
+            mv "$tmp.nft" "$ssrules_nft"
+            fw4 restart
+        fi
+        rm -f "$tmp.nft.chk"
+    fi
+    rm -f "$tmp.json"
+    rm -f "$tmp.nft"
+}
+
+ss_rules_nft_reset() {
+    if [ -f "$ssrules_nft" ]; then
+        rm -f "$ssrules_nft"
+        fw4 restart
+    fi
+}
+
+ss_rules() {
+    if ! ss_rules_nft_gen; then
+        ss_rules_nft_reset
+    fi
+}
+
+service_triggers() {
+    procd_add_reload_trigger shadowsocks-rust
+}
+
+validate_server_section() {
+    uci_validate_section shadowsocks-rust server "$1" \
+        'disabled:bool:0' \
+        'server:host' \
+        'server_port:port' \
+        'password:string' \
+        'method:string' \
+        'plugin:string' \
+        'plugin_opts:string' \
+        'timeout:uinteger:60'
+}
+
+validate_local_section() {
+    uci_validate_section shadowsocks-rust 'local' "$1" \
+        'disabled:bool:0' \
+        'server:uci("shadowsocks-rust", "@server")' \
+        'protocol:or("socks", "http", "redir", "tunnel", "dns", "tun"):socks' \
+        'local_address:ipaddr:0.0.0.0' \
+        'local_port:port' \
+        'forward_address:host' \
+        'forward_port:port' \
+        'local_dns_address:host' \
+        'local_dns_port:port' \
+        'remote_dns_address:host' \
+        'remote_dns_port:port' \
+        'client_cache_size:uinteger:10' \
+        'tun_interface_name:string:tun0' \
+        'tun_interface_address:cidr' \
+        'mode:or("tcp_only", "udp_only", "tcp_and_udp"):tcp_only'
+}
+
+validate_rules_section() {
+    uci_validate_section shadowsocks-rust rules "$1" \
+        'disabled:bool:0' \
+        'redir_tcp:uci("shadowsocks-rust", "@local")' \
+        'redir_udp:uci("shadowsocks-rust", "@local")' \
+        'src_ips_bypass:or(ipaddr,cidr)' \
+        'src_ips_forward:or(ipaddr,cidr)' \
+        'src_ips_checkdst:or(ipaddr,cidr)' \
+        'dst_ips_bypass_file:file' \
+        'dst_ips_bypass:or(ipaddr,cidr)' \
+        'dst_ips_forward_file:file' \
+        'dst_ips_forward:or(ipaddr,cidr)' \
+        'src_default:or("bypass", "forward", "checkdst"):checkdst' \
+        'dst_default:or("bypass", "forward"):bypass' \
+        'local_default:or("bypass", "forward", "checkdst"):bypass' \
+        'nft_tcp_extra:string' \
+        'nft_udp_extra:string' \
+        'ifnames:maxlength(15)'
+}

--- a/net/shadowsocks-rust/ssrules/chain.uc
+++ b/net/shadowsocks-rust/ssrules/chain.uc
@@ -1,0 +1,115 @@
+{%
+function get_local_verdict() {
+        let v = o_local_default;
+        if (v == "checkdst") {
+                return "goto ss_rules_dst_" + proto;
+        } else if (v == "forward") {
+                return "goto ss_rules_forward_" + proto;
+        } else {
+                return null;
+        }
+}
+
+function get_src_default_verdict() {
+        let v = o_src_default;
+        if (v == "checkdst") {
+                return "goto ss_rules_dst_" + proto;
+        } else if (v == "forward") {
+                return "goto ss_rules_forward_" + proto;
+        } else {
+                return "accept";
+        }
+}
+
+function get_dst_default_verdict() {
+        let v = o_dst_default;
+        if (v == "forward") {
+                return "goto ss_rules_forward_" + proto;
+        } else {
+                return "accept";
+        }
+}
+
+function get_ifnames() {
+        let res = [];
+        for (let ifname in split(o_ifnames, /[ \t\n]/)) {
+                ifname = trim(ifname);
+                if (ifname) push(res, ifname);
+        }
+        return res;
+}
+
+let type, hook, priority, redir_port;
+if (proto == "tcp") {
+        redir_port = o_redir_tcp_port;
+} else if (proto == "udp") {
+        redir_port = o_redir_udp_port;
+}
+        type = "filter";
+        hook = "prerouting";
+        priority = "mangle";
+        system("
+                set -o errexit
+                iprr() {
+                        while ip $1 rule del fwmark 100 lookup 100 2>/dev/null; do true; done
+                        ip $1 rule add fwmark 100 lookup 100
+                        ip $1 route flush table 100 2>/dev/null || true
+                        ip $1 route add local default dev lo table 100
+                }
+                iprr -4
+                iprr -6
+        ")
+
+%}
+{% if (redir_port): %}
+
+chain ss_rules_pre_{{ proto }} {
+        type {{ type }} hook {{ hook }} priority {{ priority }};
+        meta l4proto {{ proto }}{%- let ifnames=get_ifnames(); if (length(ifnames)): %} iifname { {{join(", ", ifnames)}} }{% endif %} goto ss_rules_pre_src_{{ proto }};
+}
+
+chain ss_rules_pre_src_{{ proto }} {
+        ip daddr @ss_rules_dst_bypass_ accept;
+        ip6 daddr @ss_rules6_dst_bypass_ accept;
+        goto ss_rules_src_{{ proto }};
+}
+
+chain ss_rules_src_{{ proto }} {
+        ip saddr @ss_rules_src_bypass accept;
+        ip saddr @ss_rules_src_forward goto ss_rules_forward_{{ proto }};
+        ip saddr @ss_rules_src_checkdst goto ss_rules_dst_{{ proto }};
+        ip6 saddr & ::ffff:ffff:ffff:ffff @ss_rules6_src_bypass accept;
+        ip6 saddr & ::ffff:ffff:ffff:ffff @ss_rules6_src_forward goto ss_rules_forward_{{ proto }};
+        ip6 saddr & ::ffff:ffff:ffff:ffff @ss_rules6_src_checkdst goto ss_rules_dst_{{ proto }};
+        {{ get_src_default_verdict() }};
+}
+
+chain ss_rules_dst_{{ proto }} {
+        ip daddr @ss_rules_dst_bypass accept;
+        ip daddr @ss_rules_dst_forward goto ss_rules_forward_{{ proto }};
+        ip6 daddr @ss_rules6_dst_bypass accept;
+        ip6 daddr @ss_rules6_dst_forward goto ss_rules_forward_{{ proto }};
+        {{ get_dst_default_verdict() }};
+}
+
+{%   if (proto == "tcp"): %}
+chain ss_rules_forward_{{ proto }} {
+        meta l4proto tcp {{ o_nft_tcp_extra }} meta mark set 100 tproxy to :{{ redir_port }};
+}
+{%   let local_verdict = get_local_verdict(); if (local_verdict): %}
+chain ss_rules_local_out {
+        type {{ type }} hook output priority -1;
+        meta l4proto != tcp accept;
+        ip daddr @ss_rules_dst_bypass_ accept;
+        ip daddr @ss_rules_dst_bypass accept;
+        ip6 daddr @ss_rules6_dst_bypass_ accept;
+        ip6 daddr @ss_rules6_dst_bypass accept;
+        {{ local_verdict }};
+}
+{%     endif %}
+{%   elif (proto == "udp"): %}
+chain ss_rules_forward_{{ proto }} {
+        meta l4proto udp {{ o_nft_udp_extra }} meta mark set 100 tproxy to :{{ redir_port }};
+}
+{%   endif %}
+{% endif %}

--- a/net/shadowsocks-rust/ssrules/set.uc
+++ b/net/shadowsocks-rust/ssrules/set.uc
@@ -1,0 +1,114 @@
+{%
+let fs = require("fs");
+
+let o_dst_bypass4_ = "
+    0.0.0.0/8
+    10.0.0.0/8
+    100.64.0.0/10
+    127.0.0.0/8
+    169.254.0.0/16
+    172.16.0.0/12
+    192.0.0.0/24
+    192.0.2.0/24
+    192.31.196.0/24
+    192.52.193.0/24
+    192.88.99.0/24
+    192.168.0.0/16
+    192.175.48.0/24
+    198.18.0.0/15
+    198.51.100.0/24
+    203.0.113.0/24
+    224.0.0.0/4
+    240.0.0.0/4
+";
+let o_dst_bypass6_ = "
+    ::1/128
+    ::/128
+    ::ffff:0:0/96
+    64:ff9b:1::/48
+    100::/64
+    fe80::/10
+    2001::/23
+    fc00::/7
+";
+let o_dst_bypass_ = o_dst_bypass4_ + " " + o_dst_bypass6_;
+
+let set_suffix = {
+    "src_bypass": {
+        str: o_src_bypass,
+    },
+    "src_forward": {
+        str: o_src_forward,
+    },
+    "src_checkdst": {
+        str: o_src_checkdst,
+    },
+    "dst_bypass": {
+        str: o_dst_bypass + " " + o_remote_servers,
+        file: o_dst_bypass_file,
+    },
+    "dst_bypass_": {
+        str: o_dst_bypass_,
+    },
+    "dst_forward": {
+        str: o_dst_forward,
+        file: o_dst_forward_file,
+    },
+    "dst_forward_rrst_": {},
+};
+
+function set_name(suf, af) {
+    if (af == 4) {
+        return "ss_rules_"+suf;
+    } else {
+        return "ss_rules6_"+suf;
+    }
+}
+
+function set_elements_parse(res, str, af) {
+    for (let addr in split(str, /[ \t\n]/)) {
+        addr = trim(addr);
+        if (!addr) continue;
+        if (af == 4 && index(addr, ":") != -1) continue;
+        if (af == 6 && index(addr, ":") == -1) continue;
+        push(res, addr);
+    }
+}
+
+function set_elements(suf, af) {
+    let obj = set_suffix[suf];
+    let res = [];
+    let addr;
+
+    let str = obj["str"];
+    if (str) {
+        set_elements_parse(res, str, af);
+    }
+
+    let file = obj["file"];
+    if (file) {
+        let fd = fs.open(file);
+        if (fd) {
+            str = fd.read("all");
+            set_elements_parse(res, str, af);
+        }
+    }
+
+    return res;
+}
+%}
+
+{% for (let suf in set_suffix): for (let af in [4, 6]): %}
+set {{ set_name(suf, af) }} {
+    type ipv{{af}}_addr;
+    flags interval;
+    auto-merge;
+{%   let elems = set_elements(suf, af); if (length(elems)): %}
+    elements = {
+{%     for (let i = 0; i < length(elems); i++): %}
+        {{ elems[i] }}{% if (i < length(elems) - 1): %},{% endif %}{% print("\n") %}
+{%     endfor %}
+    }
+{%   endif %}
+}
+{% endfor; endfor %}

--- a/net/shadowsocks-rust/ssrules/ssrules.uc
+++ b/net/shadowsocks-rust/ssrules/ssrules.uc
@@ -1,0 +1,8 @@
+{%
+
+include("set.uc");
+include("chain.uc", {proto: "tcp"});
+include("chain.uc", {proto: "udp"});
+
+%}
+


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @JoveYu

**Description:**
The only Shadowsocks client implementation in the repository `shadowsocks-libev` has been removed since version 24.10. #24540 

This package is a Rust implementation of Shadowsocks and is currently well-maintained. Startup scripts have been integrated, and the transparent proxy functionality from the previous shadowsocks-libev has been ported over. 

luci-app-shadowsocks-rust openwrt/luci#8225

---

## 🧪 Run Testing Details

- **OpenWrt Version: 24.10
- **OpenWrt Target/Subtarget: x86_64
- **OpenWrt Device: x86_64 device

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

