### PR TITLE
Kea init script fixes

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kea
 PKG_VERSION:=3.0.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ftp.isc.org/isc/kea/$(PKG_VERSION)

--- a/net/kea/files/kea.init
+++ b/net/kea/files/kea.init
@@ -8,7 +8,7 @@ BIN_PATH="/usr/sbin"
 CONF_PATH="/etc/kea"
 
 start_service() {
-	mkdir --mode=0750 -p /var/run/kea
+	mkdir --mode=0750 -p /var/lib/kea /var/run/kea
 
 	config_load "kea"
 	config_foreach start_kea "service"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @pprindeville @nmeyerhans 


**Description:**
Newer versions of Kea are apparently much stricter in where the control-socket and lease-database can be placed on the filesystem. When the requirements are not met, Kea refuses to start.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master r32663-bd1cf1b18a
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** Qemu VM

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
