### PR TITLE
[25.12] wget: provide virtual wget-any 

### DIFF
--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wget
 PKG_VERSION:=1.25.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -32,7 +32,7 @@ define Package/wget/Default
   SUBMENU:=File Transfer
   TITLE:=Non-interactive network downloader
   URL:=https://www.gnu.org/software/wget/index.html
-  PROVIDES:=gnu-wget wget
+  PROVIDES:=wget @wget-any
 endef
 
 define Package/wget/Default/description


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** nobody

**Description:**

Backport #28246 to 25.12.

Depends on:
- https://github.com/openwrt/openwrt/pull/21547

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12-rc2
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.