### PR TITLE
haproxy: Implement force_reload init option and use it for acme-reload events

### DIFF
--- a/net/haproxy/files/haproxy.init
+++ b/net/haproxy/files/haproxy.init
@@ -1,5 +1,5 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2009-2019 OpenWrt.org
+# Copyright (C) 2009-2026 OpenWrt.org
 
 START=99
 STOP=80
@@ -18,11 +18,16 @@ start_service() {
 	procd_close_instance
 }
 
-service_triggers() {
-	procd_add_raw_trigger acme.renew 5000 /etc/init.d/haproxy reload
+extra_command "force_reload" "Forcibly reload configuration files"
+force_reload() {
+	procd_send_signal haproxy '*' USR2
 }
 
 extra_command "check" "Check haproxy config"
 check() {
 	$HAPROXY_BIN -c -q -V -f $HAPROXY_CONFIG
+}
+
+service_triggers() {
+	procd_add_raw_trigger acme.renew 5000 /etc/init.d/haproxy force_reload
 }


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Christian Lachner <gladiac@gmail.com> (/me)
Compile tested: aarch64
Run tested: aarch64 (mt6000)

Description: Implement force_reload init option and use it for acme-reload events
- This is necessary since the default reload mechanism would not send the USR2 signal if the haproxy.cfg did not change.
- Fixes issue #28038