### PR TITLE
sslh: update to 2.3.1, add libproxyprotocol support

### DIFF
--- a/libs/libproxyprotocol/Makefile
+++ b/libs/libproxyprotocol/Makefile
@@ -1,0 +1,53 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libproxyprotocol
+PKG_VERSION:=1.3.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/kosmas-valianos/libproxyprotocol/archive/refs/tags/v$(PKG_VERSION).tar.gz?
+PKG_HASH:=4f1cbd714e5b52a91a9a43228d55c8165b578b738f743d057ae321b69b8437f7
+
+PKG_MAINTAINER:=Peter Meiser <peter.meiser@gmx.com>
+PKG_LICENSE:=LGPL-3.0
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libproxyprotocol
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=PROXY Protocol v1/v2 parsing library
+  URL:=https://github.com/kosmas-valianos/libproxyprotocol
+endef
+
+define Package/libproxyprotocol/description
+  An ANSI C library to parse and create PROXY Protocol v1 and v2 headers.
+endef
+
+TARGET_CFLAGS += -fPIC
+MAKE_FLAGS += \
+	CC="$(TARGET_CC)" \
+	CFLAGS="$(TARGET_CFLAGS)"
+
+define Build/Compile
+	$(MAKE) build -C $(PKG_BUILD_DIR) $(MAKE_FLAGS)
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/src/proxy_protocol.h $(1)/usr/include/
+	$(CP) $(PKG_BUILD_DIR)/libs/libproxyprotocol.so $(1)/usr/lib/
+endef
+
+define Package/libproxyprotocol/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/libs/libproxyprotocol.so $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libproxyprotocol))

--- a/net/sslh/Makefile
+++ b/net/sslh/Makefile
@@ -28,7 +28,7 @@ define Package/sslh
   CATEGORY:=Network
   SUBMENU:=Routing and Redirection
   TITLE:=SSL/SSH multiplexer
-  DEPENDS:=+libconfig +libcap +libpcre2
+  DEPENDS:=+libconfig +libcap +libpcre2 +libproxyprotocol
   URL:=https://rutschle.net/tech/sslh/README.html
 endef
 

--- a/net/sslh/Makefile
+++ b/net/sslh/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sslh
-PKG_VERSION:=2.1.2
+PKG_VERSION:=2.3.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://rutschle.net/tech/sslh/
-PKG_HASH:=dce8e1a77f48017b5164486084f000d9f20de2d54d293385aec18d606f9c61d9
+PKG_HASH:=51a5516ec5cb01823633b4d8cacdeee4efa0c56ef620d1c996d4f52ca51a601b
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Jonathan McCrohan <jmccrohan@gmail.com>


### PR DESCRIPTION
See https://rutschle.net/tech/sslh/doc/proxyprotocol

## 📦 Package Details

**Maintainer:** @neheb 

**Description:**
Add libproxysupport to sslh by adding the libproxysupport library and compile sslh against it.
---

## 🧪 Run Testing Details

- **OpenWrt Version: master
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device: x86_64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.