### PR TITLE
speedtest-netperf: add passphrase option

### DIFF
--- a/net/speedtest-netperf/files/README.md
+++ b/net/speedtest-netperf/files/README.md
@@ -44,23 +44,27 @@ opkg install speedtest-netperf_1.0.0-1_all.ipk
 
 ## Usage
 
+> [!WARNING]
+> You may now need to specify a passphrase for the selected netperf server with the `-Z` option. The passphrase for the default netperf server can be found at http://netperf.bufferbloat.net/.
+
 The speedtest-netperf.sh script measures throughput, latency and CPU usage during file transfers and when idle. To invoke it:
 
-    speedtest-netperf.sh [-4 | -6] [-H netperf-server] [-t duration] [-p host-to-ping] [-n simultaneous-streams ] [-s | -c [duration] ] [ -i [duration] ]
+    speedtest-netperf.sh [-4 | -6] [-H netperf-server] [-t duration] [-p host-to-ping] [-n simultaneous-streams ] [-s | -c [duration] ] [ -i [duration] ] [ -Z passphrase ]
 
 Options, if present, are:
 
     -4 | -6:           Enable ipv4 or ipv6 testing (default - ipv4)
     -H | --host:       DNS or Address of a netperf server (default - netperf.bufferbloat.net)
                        Alternate servers are netperf-east (US, east coast),
-                       netperf-west (US, California), and netperf-eu (Denmark).
+                       netperf-west (US, California) and netperf-eu (Denmark).
     -t | --time:       Duration for how long each direction's test should run - (default - 30 seconds)
     -p | --ping:       Host to ping to measure latency (default - one.one.one.one)
     -n | --number:     Number of simultaneous sessions (default - 5 sessions)
     -s | --sequential: Sequential download/upload (default - disabled)
     -c | --concurrent: Concurrent download/upload (default - disabled)
     -i | --idle:       Measure idle latency before speed test (default - disabled)
-
+    -Z | --passphrase: Passphrase to access the selected host. (default - none)
+                       See http://netperf.bufferbloat.net for the passphrase.
 The primary script output shows download and upload speeds, together with the percent packet loss, and a summary of latencies, including min, max, average, median, and 10th and 90th percentiles so you can get a sense of the distribution.
 
 The tool also summarizes CPU usage statistics during the test, to highlight whether speeds may be CPU-bound during testing, and to provide a better sense of how much CPU "headroom" would be available during normal operation. The data includes per-CPU load and frequency (if supported), and CPU usage of the `netperf` test programs.


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @guidosarducci 

**Description:**
speedtest-netperf provides a quick and easy way to test a network's performance under high loads by creating multiple instances of netperf and pinging to check for latency changes under load. 

netperf servers can now optionally have a passphrase. The default "netperf.bufferbloat.net/" uses a rotating password that is listed on a webpage hosted on the same domain. Right now, `netperf -H netperf.bufferbloat.net` (which speedtest-netperf uses by default) throws "recv_response: partial response received: 0 bytes". As a result, the output of `speedtest-netperf.sh -s` contains very little data.

An optional `-Z` or `--passphrase` option has been added to `speedtest-netperf.sh` which is passed to the `-Z` option of netperf. The `-Z` option has been added to usage instructions in script and README.md
Warnings have been put in the script's error output and in the README.md to check the server's web page for a passphrase.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.4
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** BPI-R4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.