### PR TITLE
simple-captive-portal: Multiple enhancements

### DIFF
--- a/net/simple-captive-portal/Makefile
+++ b/net/simple-captive-portal/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-captive-portal
-PKG_VERSION:=2025.06.22
+PKG_VERSION:=2026.01.14
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/net/simple-captive-portal/Makefile
+++ b/net/simple-captive-portal/Makefile
@@ -23,8 +23,6 @@ endef
 define Package/simple-captive-portal/install
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/etc/config/simple-captive-portal $(1)/etc/config/simple-captive-portal
-	$(INSTALL_DIR) $(1)/etc/hotplug.d/net/
-	$(INSTALL_DATA) ./files/etc/hotplug.d/net/00-simple-captive-portal $(1)/etc/hotplug.d/net/00-simple-captive-portal
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/etc/init.d/simple-captive-portal $(1)/etc/init.d/simple-captive-portal
 	$(INSTALL_DIR) $(1)/etc/simple-captive-portal/

--- a/net/simple-captive-portal/Makefile
+++ b/net/simple-captive-portal/Makefile
@@ -29,6 +29,7 @@ define Package/simple-captive-portal/install
 	$(INSTALL_BIN) ./files/etc/init.d/simple-captive-portal $(1)/etc/init.d/simple-captive-portal
 	$(INSTALL_DIR) $(1)/etc/simple-captive-portal/
 	$(INSTALL_DATA) ./files/etc/simple-captive-portal/index.html $(1)/etc/simple-captive-portal/index.html
+	$(INSTALL_DATA) ./files/etc/simple-captive-portal/connected.html $(1)/etc/simple-captive-portal/connected.html
 	$(INSTALL_DIR) $(1)/usr/share/simple-captive-portal/
 	$(INSTALL_DATA) ./files/usr/share/simple-captive-portal/capabilities.json $(1)/usr/share/simple-captive-portal/capabilities.json
 	$(INSTALL_DATA) ./files/usr/share/simple-captive-portal/portal.lua $(1)/usr/share/simple-captive-portal/portal.lua

--- a/net/simple-captive-portal/files/etc/config/simple-captive-portal
+++ b/net/simple-captive-portal/files/etc/config/simple-captive-portal
@@ -3,3 +3,4 @@ config simple-captive-portal main
         #option port_redirect 8888
         #option port_portal 8889
         #option timeout 86400
+        #list exempt '01:23:45:67:89:0A'

--- a/net/simple-captive-portal/files/etc/config/simple-captive-portal
+++ b/net/simple-captive-portal/files/etc/config/simple-captive-portal
@@ -1,5 +1,5 @@
 config simple-captive-portal main
-        #option interface guest
+        #list interface guest
         #option port_redirect 8888
         #option port_portal 8889
         #option timeout 86400

--- a/net/simple-captive-portal/files/etc/hotplug.d/net/00-simple-captive-portal
+++ b/net/simple-captive-portal/files/etc/hotplug.d/net/00-simple-captive-portal
@@ -1,5 +1,0 @@
-INTF=$(uci -q get simple-captive-portal.main.interface)
-
-if [ "$ACTION" = add -a "$DEVICENAME" == "$INTF" ]; then
-    /etc/init.d/simple-captive-portal firewall
-fi

--- a/net/simple-captive-portal/files/etc/init.d/simple-captive-portal
+++ b/net/simple-captive-portal/files/etc/init.d/simple-captive-portal
@@ -11,6 +11,10 @@ add_interface() {
     [ -z "${1}" ] || /usr/sbin/nft add element inet simple-captive-portal portal_ifs { "${1}" }
 }
 
+service_triggers() {
+    procd_add_reload_trigger "simple-captive-portal"
+}
+
 start_service() {
     local INTF INTF_COUNT PORT_REDIRECT PORT_PORTAL TIMEOUT
     config_load "simple-captive-portal"

--- a/net/simple-captive-portal/files/etc/init.d/simple-captive-portal
+++ b/net/simple-captive-portal/files/etc/init.d/simple-captive-portal
@@ -3,6 +3,10 @@ START=10
 USE_PROCD=1
 EXTRA_COMMANDS='firewall'
 
+add_exempt() {
+    [ -z "${1}" ] || /usr/sbin/nft add element inet simple-captive-portal exempt_macs { "${1}" }
+}
+
 firewall() {
     local INTF PORT_REDIRECT TIMEOUT
     config_load "simple-captive-portal"
@@ -20,16 +24,23 @@ table inet simple-captive-portal {
         timeout ${TIMEOUT}s
     }
 
+    set exempt_macs {
+        type ether_addr
+    }
+
     chain prerouting {
         type nat hook prerouting priority mangle; policy drop;
         iif != ${INTF} accept
+        ether saddr @exempt_macs accept
         ether saddr @guest_macs accept
         tcp dport 80 redirect to ${PORT_REDIRECT}
         fib daddr . iif type { local, broadcast, multicast } accept
         reject
     }
 }
+flush set inet simple-captive-portal exempt_macs
 EOF
+    config_list_foreach main exempt add_exempt
 }
 
 boot() {

--- a/net/simple-captive-portal/files/etc/init.d/simple-captive-portal
+++ b/net/simple-captive-portal/files/etc/init.d/simple-captive-portal
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 START=10
 USE_PROCD=1
-EXTRA_COMMANDS='firewall'
+EXTRA_COMMANDS='firewall flush_guests'
 
 add_exempt() {
     [ -z "${1}" ] || /usr/sbin/nft add element inet simple-captive-portal exempt_macs { "${1}" }
@@ -89,4 +89,8 @@ start_service() {
     procd_set_param stdout 1
     procd_set_param stderr 1
     procd_close_instance
+}
+
+flush_guests() {
+    /usr/sbin/nft flush set inet simple-captive-portal guest_macs
 }

--- a/net/simple-captive-portal/files/etc/init.d/simple-captive-portal
+++ b/net/simple-captive-portal/files/etc/init.d/simple-captive-portal
@@ -92,6 +92,11 @@ EOF
     procd_close_instance
 }
 
+stop_service() {
+    # Delete the rule that blocks traffic
+    /usr/sbin/nft delete chain inet simple-captive-portal prerouting &> /dev/null
+}
+
 flush_guests() {
     /usr/sbin/nft flush set inet simple-captive-portal guest_macs
 }

--- a/net/simple-captive-portal/files/etc/init.d/simple-captive-portal
+++ b/net/simple-captive-portal/files/etc/init.d/simple-captive-portal
@@ -1,18 +1,24 @@
 #!/bin/sh /etc/rc.common
 START=10
 USE_PROCD=1
-EXTRA_COMMANDS='firewall flush_guests'
+EXTRA_COMMANDS='flush_guests'
 
 add_exempt() {
     [ -z "${1}" ] || /usr/sbin/nft add element inet simple-captive-portal exempt_macs { "${1}" }
 }
 
-firewall() {
-    local INTF PORT_REDIRECT TIMEOUT
+add_interface() {
+    [ -z "${1}" ] || /usr/sbin/nft add element inet simple-captive-portal portal_ifs { "${1}" }
+}
+
+start_service() {
+    local INTF INTF_COUNT PORT_REDIRECT PORT_PORTAL TIMEOUT
     config_load "simple-captive-portal"
     config_get INTF main interface
     [ -z "${INTF}" ] && exit 0
+    config_get INTF_COUNT main interface_LENGTH
     config_get PORT_REDIRECT main port_redirect 8888
+    config_get PORT_PORTAL main port_portal 8889
     config_get TIMEOUT main timeout 86400
 
     /usr/sbin/nft -f- <<EOF
@@ -28,9 +34,13 @@ table inet simple-captive-portal {
         type ether_addr
     }
 
+    set portal_ifs {
+        type ifname
+    }
+
     chain prerouting {
         type nat hook prerouting priority mangle; policy drop;
-        iif != ${INTF} accept
+        iifname != @portal_ifs accept
         ether saddr @exempt_macs accept
         ether saddr @guest_macs accept
         tcp dport 80 redirect to ${PORT_REDIRECT}
@@ -39,25 +49,16 @@ table inet simple-captive-portal {
     }
 }
 flush set inet simple-captive-portal exempt_macs
+flush set inet simple-captive-portal portal_ifs
 EOF
     config_list_foreach main exempt add_exempt
-}
 
-boot() {
-    BOOT=1
-    start "$@"
-}
-
-start_service() {
-    # firewall() called by hotplug on boot
-    [ -z "${BOOT}" ] && firewall
-
-    local INTF PORT_REDIRECT PORT_PORTAL
-    config_load "simple-captive-portal"
-    config_get INTF main interface
-    [ -z "${INTF}" ] && exit 0
-    config_get PORT_REDIRECT main port_redirect 8888
-    config_get PORT_PORTAL main port_portal 8889
+    # Detect whether the interface is an option or a list
+    if [ -n "${INTF_COUNT}" ]; then
+        config_list_foreach main interface add_interface
+    else
+        add_interface "${INTF}"
+    fi
 
     procd_open_instance redirect
     procd_set_param command /usr/sbin/uhttpd -f -c /dev/null -k0 -h /etc/simple-captive-portal/ -l / -L /usr/share/simple-captive-portal/redirect.lua -p "${PORT_REDIRECT}"

--- a/net/simple-captive-portal/files/etc/simple-captive-portal/connected.html
+++ b/net/simple-captive-portal/files/etc/simple-captive-portal/connected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Simple captive portal</title>
+</head>
+<body style="text-align:center">
+<h1>Free Wifi</h1>
+<p>You are now connected. You may close this page.</p>
+</body>
+</html>

--- a/net/simple-captive-portal/files/usr/share/simple-captive-portal/portal.lua
+++ b/net/simple-captive-portal/files/usr/share/simple-captive-portal/portal.lua
@@ -20,8 +20,24 @@ function handle_request(env)
         return
     end
 
-    uhttpd.send("Status: 200 OK\r\n")
+    if string.find(env.SERVER_ADDR, ":") == nil then
+        url = "http://" .. env.SERVER_ADDR .. ":" .. env.SERVER_PORT .. "/connected.html"
+    else
+        url = "http://[" .. env.SERVER_ADDR .. "]:" .. env.SERVER_PORT .. "/connected.html"
+    end
+
+    body = "<!DOCTYPE html>\r\n" ..
+           "<html lang=\"en\"><head>\r\n" ..
+           "<title>Connected</title>\r\n" ..
+           "</head><body>\r\n"..
+           "<p>You are now connected. You may close this page.</p>\r\n" ..
+           "</body></html>\r\n"
+
+    uhttpd.send("Status: 302 Found\r\n")
     uhttpd.send("Server: simple-captive-portal\r\n")
-    uhttpd.send("Content-Type: text/plain\r\n\r\n")
-    uhttpd.send("You now have internet access\n")
+    uhttpd.send("Location: " .. url .. "\r\n")
+    uhttpd.send("Cache-Control: no-cache\r\n")
+    uhttpd.send("Content-Type: text/html\r\n")
+    uhttpd.send("Content-Length: " .. string.len(body) .. "\r\n\r\n")
+    uhttpd.send(body)
 end

--- a/net/simple-captive-portal/files/usr/share/simple-captive-portal/redirect.lua
+++ b/net/simple-captive-portal/files/usr/share/simple-captive-portal/redirect.lua
@@ -1,13 +1,27 @@
 port_portal = os.getenv("PORT_PORTAL")
 
 function handle_request(env)
+    if string.find(env.SERVER_ADDR, ":") == nil then
+        url = "http://" .. env.SERVER_ADDR .. ":" .. port_portal .. "/"
+    else
+        url = "http://[" .. env.SERVER_ADDR .. "]:" .. port_portal .. "/"
+    end
+
+    body = "<!DOCTYPE html>\r\n" ..
+           "<html lang=\"en\"><head>\r\n" ..
+           "<title>Redirecting to login</title>\r\n" ..
+           "</head><body>\r\n"..
+           "<p>Redirecting to login page...</p>\r\n" ..
+           "<p><a href=\"" .. url .. "\">" ..
+           "Click here if the page does not automatically redirect." ..
+           "</a></p>\r\n" ..
+           "</body></html>\r\n"
+
     uhttpd.send("Status: 302 Found\r\n")
     uhttpd.send("Server: simple-captive-portal\r\n")
-    if string.find(env.SERVER_ADDR, ":") == nil then
-        uhttpd.send("Location: http://" .. env.SERVER_ADDR .. ":" .. port_portal .. "/\r\n")
-    else
-        uhttpd.send("Location: http://[" .. env.SERVER_ADDR .. "]:" .. port_portal .. "/\r\n")
-    end
+    uhttpd.send("Location: " .. url .. "\r\n")
     uhttpd.send("Cache-Control: no-cache\r\n")
-    uhttpd.send("Content-Length: 0\r\n\r\n")
+    uhttpd.send("Content-Type: text/html\r\n")
+    uhttpd.send("Content-Length: " .. string.len(body) .. "\r\n\r\n")
+    uhttpd.send(body)
 end


### PR DESCRIPTION
## 📦 Package Details
**Maintainer:** @champtar

**Description:**
`simple-captive-portal` is a nice and simple implementation of a click-through captive portal. It is significantly easier to get working than the alternatives, so thanks a lot!

While I was implementing this service in my network, I found a need to add a few features and smooth over a few issues with devices that I ran into during the deployment. Hopefully these improvements can be useful to everyone. :>

Please check the individual commit descriptions for explanations of each change.

I wasn't sure how best to submit multiple changes like this since there isn't really a proper upstream. Let me know if I should instead squash or split this up into separate PRs for each change.

---

## 🧪 Run Testing Details
- **OpenWrt Version:** 24.10.5
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** GL-iNet GL-MT6000

---

## ✅ Formalities
- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:
- [x] It is structured in a way that it is potentially upstreamable