### PR TITLE
zabbix: fix agentd default user and minor issues

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=7.0.22
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
@@ -91,21 +91,21 @@ define Package/zabbix-extra-mac80211
   $(call Package/zabbix/Default)
   TITLE+= discovery/userparameters for mac80211
   DEPENDS = +zabbix-agentd @PACKAGE_MAC80211_DEBUGFS @KERNEL_DEBUG_FS
-  BUILD_VARIANT:=no-configure
+  VARIANT:=no-configure
 endef
 
 define Package/zabbix-extra-network
   $(call Package/zabbix/Default)
   TITLE+= discovery/userparameters for network
   DEPENDS = +zabbix-agentd +libubus-lua +lua
-  BUILD_VARIANT:=no-configure
+  VARIANT:=no-configure
 endef
 
 define Package/zabbix-extra-wifi
   $(call Package/zabbix/Default)
   TITLE+= discovery/userparameters for wifi
   DEPENDS = +zabbix-agentd +libiwinfo-lua +libubus-lua +lua
-  BUILD_VARIANT:=no-configure
+  VARIANT:=no-configure
 endef
 
 define Package/zabbix-sender

--- a/admin/zabbix/patches/010-change-agentd-config.patch
+++ b/admin/zabbix/patches/010-change-agentd-config.patch
@@ -4,7 +4,7 @@ Date: Wed, 17 Dec 2025 18:28:37 -0500
 Subject: [PATCH] zabbix_agentd: Tweak config file for OpenWrt
 
 Note: original patch had no header, header added 2025-12-16, while
-bumping package version. Modified 2025-12-25.
+bumping package version. Modified 2025-12-25. Modified 2026-01-21.
 
 1. Use syslog not a file for logging
 2. Place PidFile under /var/run/zabbix
@@ -12,6 +12,7 @@ bumping package version. Modified 2025-12-25.
 4. Do not do active checks by default
 5. Use the system hostname as hostname (except on zabbix server)
 6. Include configurations under /etc/zabbix_agentd.conf.d/
+7. Drop privileges to the zabbix-agent user (instead of zabbix)
 
 Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 ---
@@ -73,6 +74,15 @@ Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
  ### Option: HostnameItem
  #	Item used for generating Hostname if it is undefined. Ignored if Hostname is defined.
  #	Does not support UserParameters or aliases.
+@@ -315,7 +309,7 @@ Hostname=Zabbix server
+ #
+ # Mandatory: no
+ # Default:
+-# User=zabbix
++User=zabbix-agent
+ 
+ ####### USER-DEFINED MONITORED PARAMETERS #######
+ 
 @@ -545,5 +539,5 @@ Hostname=Zabbix server
  # Include=
  

--- a/admin/zabbix/patches/020-change-server-config.patch
+++ b/admin/zabbix/patches/020-change-server-config.patch
@@ -5,7 +5,9 @@ Subject: [PATCH] Make zabbix_server config suitable for OpenWrt
 
 1. Log to (default ephemeral) syslog, not a file (and don't rotate)
 2. Update PidFile path so correct permissions can be set for access by
-   Zabbix server running without privileges.
+   Zabbix server running without privileges
+3. If started as root, drop privileges to zabbix-server user (instead of
+   zabbix)
 
 Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 ---
@@ -50,3 +52,12 @@ Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
  ### Option: SocketDir
  #	IPC socket directory.
  #		Directory to store IPC sockets used by internal Zabbix services.
+@@ -698,7 +704,7 @@ LogSlowQueries=3000
+ #
+ # Mandatory: no
+ # Default:
+-# User=zabbix
++User=zabbix-server
+ 
+ ### Option: SSLCertLocation
+ #	Location of SSL client certificates.


### PR DESCRIPTION
So we fix those issues.

## 📦 Package Details

**Maintainer:** @danielfdickinson

**Description:**
The last PR (https://github.com/openwrt/packages/pull/28370) missed including two needed changes, and had a minor packaging Makefile mistake.

The Zabbix Agent needs to drop privileges to the zabbix-agent user. Similarly, if run as root (not the default), the Zabbix server needs to drop privileges to the zabbix-server user.

There are also, in the Makefile, three instances of using BUILD_VARIANT instead of VARIANT in package definitions.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT r32673-9d1f6ec49d
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- N/A It is structured in a way that it is potentially upstreamable
  Not upstream applicable.