### PR TITLE
valkey: add new package

### DIFF
--- a/libs/valkey/Makefile
+++ b/libs/valkey/Makefile
@@ -1,0 +1,105 @@
+#
+# Copyright (C) 2025 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=valkey
+PKG_VERSION:=9.0.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/valkey-io/valkey/archive/refs/tags/$(PKG_VERSION).tar.gz?
+PKG_HASH:=9cfbc5f32a2a6058ee0f8c532b9c4d24167cc49d719f091dd75f1bb8353a1fc5
+
+PKG_MAINTAINER:=Matthew Cather <mattbob4@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=COPYING
+
+PKG_FORTIFY_SOURCE:=0
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/valkey/Default
+  SUBMENU:=Database
+  SECTION:=libs
+  CATEGORY:=Libraries
+  URL:=https://valkey.io/
+endef
+
+define Package/valkey-server
+$(call  Package/valkey/Default)
+  TITLE:=Valkey in-memory key-value data store (server)
+endef
+
+define Package/valkey-server/description
+  Valkey is an open source (BSD) high-performance key/value datastore
+  that supports a variety of workloads such as caching, message queues,
+  and can act as a primary database. This package contains the Valkey server.
+endef
+
+define Package/valkey-cli
+$(call  Package/valkey/Default)
+  TITLE:=Valkey in-memory key-value data store (CLI client)
+endef
+
+define Package/valkey-cli/description
+  Valkey is an open source (BSD) high-performance key/value datastore.
+  This package contains the Valkey CLI client.
+endef
+
+define Package/valkey-utils
+$(call  Package/valkey/Default)
+  TITLE:=Valkey in-memory key-value data store (utilities)
+  DEPENDS:=+valkey-server
+endef
+
+define Package/valkey-utils/description
+  Valkey is an open source (BSD) high-performance key/value datastore.
+  This package contains Valkey utilities (valkey-benchmark, valkey-check-aof,
+  valkey-check-rdb).
+endef
+
+MAKE_FLAGS+= \
+	MALLOC="libc" \
+	USE_JEMALLOC="no" \
+	PREFIX="$(PKG_INSTALL_DIR)/usr" \
+	ARCH=""
+
+define Package/valkey-server/conffiles
+/etc/valkey/valkey.conf
+/etc/config/valkey
+endef
+
+define Package/valkey-server/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/valkey-server $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/valkey
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/valkey.conf $(1)/etc/valkey/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/valkey.init $(1)/etc/init.d/valkey
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/valkey.config $(1)/etc/config/valkey
+endef
+
+define Package/valkey-cli/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/valkey-cli $(1)/usr/bin/
+endef
+
+define Package/valkey-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/valkey-benchmark $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/valkey-check-aof $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/valkey-check-rdb $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,valkey-server))
+$(eval $(call BuildPackage,valkey-cli))
+$(eval $(call BuildPackage,valkey-utils))
+

--- a/libs/valkey/files/valkey.config
+++ b/libs/valkey/files/valkey.config
@@ -1,0 +1,15 @@
+config instance 'main'
+	option enabled '1'
+	option port '6379'
+	option bind '127.0.0.1'
+	option dir '/var/lib/valkey'
+	option logfile '/var/log/valkey.log'
+	# Memory management
+	option maxmemory '64mb'
+	option maxmemory_policy 'allkeys-lru'
+	# Persistence settings
+	list save '900 1'
+	list save '300 10'
+	list save '60 10000'
+	option appendonly '0'
+	option appendfilename 'appendonly.aof'

--- a/libs/valkey/files/valkey.init
+++ b/libs/valkey/files/valkey.init
@@ -1,0 +1,107 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2025 OpenWrt.org
+
+START=95
+STOP=10
+
+USE_PROCD=1
+
+PROG=/usr/bin/valkey-server
+CONF=/etc/valkey/valkey.conf
+
+validate_valkey_section() {
+	uci_validate_section valkey instance "${1}" \
+		'enabled:bool:1' \
+		'port:port:6379' \
+		'bind:host:127.0.0.1' \
+		'dir:directory:/var/lib/valkey' \
+		'logfile:string:/var/log/valkey.log' \
+		'daemonize:bool:0' \
+		'maxmemory:string' \
+		'maxmemory_policy:string' \
+		'save:list(string)' \
+		'appendonly:bool:0' \
+		'appendfilename:string:appendonly.aof'
+}
+
+valkey_instance() {
+	local cfg="$1"
+	local enabled port bind dir logfile daemonize maxmemory maxmemory_policy save appendonly appendfilename
+
+	validate_valkey_section "${cfg}" || {
+		echo "validation failed"
+		return 1
+	}
+
+	[ "${enabled}" = "0" ] && return 0
+
+	# Create necessary directories
+	mkdir -p "${dir}"
+	mkdir -p "$(dirname ${logfile})"
+
+	# Generate runtime config
+	local config_file="/var/etc/valkey-${cfg}.conf"
+	mkdir -p /var/etc
+
+	# Start with base config if exists
+	if [ -f "$CONF" ]; then
+		grep -v "^port\|^bind\|^dir\|^logfile\|^daemonize\|^maxmemory\|^save\|^appendonly\|^appendfilename" "$CONF" > "$config_file"
+	else
+		> "$config_file"
+	fi
+
+	# Add runtime configuration
+	cat >> "$config_file" <<-EOF
+		port ${port}
+		bind ${bind}
+		dir ${dir}
+		logfile ${logfile}
+		daemonize no
+	EOF
+
+	# Add optional settings
+	[ -n "${maxmemory}" ] && echo "maxmemory ${maxmemory}" >> "$config_file"
+	[ -n "${maxmemory_policy}" ] && echo "maxmemory-policy ${maxmemory_policy}" >> "$config_file"
+
+	# Add save directives
+	if [ -n "${save}" ]; then
+		for save_rule in ${save}; do
+			echo "save ${save_rule}" >> "$config_file"
+		done
+	fi
+
+	# Add append-only file settings
+	if [ "${appendonly}" = "1" ]; then
+		echo "appendonly yes" >> "$config_file"
+		[ -n "${appendfilename}" ] && echo "appendfilename ${appendfilename}" >> "$config_file"
+	fi
+
+	procd_open_instance
+	procd_set_param command "$PROG" "$config_file"
+	procd_set_param file "$config_file"
+	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param user valkey
+	procd_close_instance
+}
+
+start_service() {
+	# Create valkey user if it doesn't exist
+	if ! grep -q "^valkey:" /etc/passwd; then
+		user_exists valkey || user_add valkey 450 450 "Valkey" /var/lib/valkey /bin/false
+	fi
+
+	config_load 'valkey'
+	config_foreach valkey_instance 'instance'
+}
+
+service_triggers() {
+	procd_add_reload_trigger "valkey"
+	procd_add_validation validate_valkey_section
+}
+
+stop_service() {
+	# Clean up any leftover socket files
+	rm -f /tmp/valkey*.sock
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Valkey is a community fork of the  key-value database Redis. It is a drop in replacement to Redis so most of the files are derived from their Redis equivalent.  

---

## 🧪 Run Testing Details

- **OpenWrt Version:** r32661-530179bae3
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** SDG-8733

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
