### PR TITLE
jool: remove dependency on kmod-nf-conntrack6

### DIFF
--- a/net/jool/Makefile
+++ b/net/jool/Makefile
@@ -84,8 +84,7 @@ define KernelPackage/jool-netfilter
 	DEPENDS:= \
 		@IPV6 \
 		+kmod-crypto-md5 \
-		+kmod-nf-conntrack \
-		+kmod-nf-conntrack6
+		+kmod-nf-conntrack
 	FILES:= \
 		$(PKG_BUILD_DIR)/src/mod/common/jool_common.$(LINUX_KMOD_SUFFIX) \
 		$(PKG_BUILD_DIR)/src/mod/nat64/jool.$(LINUX_KMOD_SUFFIX) \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me / @tiagogaspar8
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
nf-conntrack_ipv6 is not longer a separate kernel module and was removed. This prevents installation of jool.

```
ERROR: unable to select packages:
  kmod-nf-conntrack6 (no such package):
    required by: kmod-jool-netfilter-6.12.66.4.1.14-r3[kmod-nf-conntrack6]
```

Fixes: 5b61a50244ebc82096f5949de294ad69851e1fd6 ("netfilter: remove nf-conntrack6")
https://github.com/openwrt/openwrt/commit/5b61a50244ebc82096f5949de294ad69851e1fd6
## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
