### PR TITLE
bind: bump to 9.20.18

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.20.15
-PKG_RELEASE:=3
+PKG_VERSION:=9.20.18
+PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=d62b38fae48ba83fca6181112d0c71018d8b0f2ce285dc79dc6a0367722ccabb
+PKG_HASH:=dfc546c990ac4515529cd45c4dd995862b18ae8a2d0cb29208e8896a5d325331
 
 PKG_INSTALL:=1
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION
Fixes security issues:

 - CVE-2025-13878: Malformed BRID and HHIT records could trigger an assertion failure.

## 📦 Package Details

**Maintainer:** @nmeyerhans 



---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

