### PR TITLE
watchcat: fix interface reset does not work

### DIFF
--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=20
+PKG_RELEASE:=21
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -83,8 +83,7 @@ watchcat_restart_modemmanager_iface() {
 
 watchcat_restart_network_iface() {
 	logger -p daemon.info -t "watchcat[$$]" "Restarting network interface: \"$1\"."
-	ip link set "$1" down
-	ip link set "$1" up
+	ifup "$1"
 }
 
 watchcat_run_script() {


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @roger- @feckert

**Description:**
As reported in #23410 Network interface reset doesn't work as expected on a Wireguard VPN interface and in #27927 lt2p interface won't reboot, and mentioned in #27248, the current implementation of the option to restart an interface when connectivity check fails for some period does not result in an interface restart for all interface.

Notably 'virtual' interfaces such as Wireguard and L2TP do not restart.

The solution that works is to use `ifup <interface>` instead of only changing the link status.

This commit is based on the one in #27248 by @rondoval, who unfortunately has not updated the commit message as requested for half a year.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT r32783-cf84e8ee86
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
