### PR TITLE
Feature configurable prometheus ucode jail mounts

### DIFF
--- a/utils/prometheus-node-exporter-ucode/Makefile
+++ b/utils/prometheus-node-exporter-ucode/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-ucode
 PKG_VERSION:=2024.02.07
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Andre Heider <a.heider@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-ucode/files/config
+++ b/utils/prometheus-node-exporter-ucode/files/config
@@ -2,6 +2,7 @@ config prometheus-node-exporter-ucode 'main'
 	option listen_interface 'loopback'
 	option listen_port '9101'
 	option http_keepalive '70'
+	#list add_jail '/path/to/jail'
 
 config collector 'wifi'
 	option stations '1'

--- a/utils/prometheus-node-exporter-ucode/files/init
+++ b/utils/prometheus-node-exporter-ucode/files/init
@@ -17,6 +17,7 @@ start_service() {
 	config_get interface "main" listen_interface "loopback"
 	config_get port "main" listen_port 9101
 	config_get keepalive "main" http_keepalive 70
+	config_get add_jails "main" add_jail ""
 
 	[ "$interface" = "*" ] || {
 		network_get_ipaddr  bind4 "$interface"
@@ -47,6 +48,12 @@ start_service() {
 	procd_add_jail_mount "/usr/lib/libnl*.so*"
 	procd_add_jail_mount "/usr/share/ucode/node-exporter"
 	procd_add_jail_mount "/etc/config"
+
+	for add_jail in $add_jails; do
+		if [ -e "$add_jail" ]; then
+			procd_add_jail_mount "$add_jail"
+		fi
+	done
 
 	# TODO breaks the dsl collector?
 	#procd_set_param user nobody


### PR DESCRIPTION
Add support for additional jail mounts specified in configuration.

## 📦 Package Details

**Maintainer:**

**Description:**
With this change users can configure additional jail mounts so ucode scripts which needs access to other paths would be possible if user allows it. For example a ucode script which interacts with podman would need a jail mount to `/run/podman` to get it working.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Banana Pi R4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

---

If applied it should maybe documented somewhere or putted as comment into the config file