### PR TITLE
CI: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: 'ci'


### PR DESCRIPTION
Add dependabot config to automatically check for action updates once a week and open PRs if any are found.

I'm not sure if anything needs to be configured in the repos settings though, as I don't have access.