### PR TITLE
[25.12] php8: backports of dependency and small maintainance cleanups

### DIFF
--- a/lang/php8/Config.in
+++ b/lang/php8/Config.in
@@ -2,11 +2,11 @@ menu "Configuration"
 	depends on PACKAGE_php8
 
 config PHP8_LIBXML
-	bool "PHP8 LIBXML support"
+	bool "Enable LIBXML support"
 	default y
 
 config PHP8_DOM
-	bool "PHP8 DOM support"
+	bool "Enable DOM support"
 	select PHP8_LIBXML
 	default y
 	help
@@ -15,17 +15,8 @@ config PHP8_DOM
 	  use by php-cli, php-cgi, etc.). Therefore please consider adding
 	  php8-mod-dom to provide this functionality to PHP8 consumers.
 
-config PHP8_SYSTEMTZDATA
-	bool "Use system timezone data instead of php's built-in database"
-	depends on PACKAGE_php8-cli || PACKAGE_php8-cgi || PACKAGE_apache-mod-php8
-	default y
-	help
-	  Enabling this feature automatically selects the zoneinfo-core package
-	  which contains data for UTC timezone. To use other timezones you have
-	  to install the corresponding zoneinfo-... package(s).
-
 config PHP8_GETTEXT
-	bool "Enable gettext"
+	bool "Enable gettext support"
 	default y
 	help
 	  Without php8-mod-gettext, this option does not provide a PHP8
@@ -34,7 +25,7 @@ config PHP8_GETTEXT
 	  php8-mod-gettext to provide this functionality to PHP8 consumers.
 
 config PHP8_INTL
-	bool "Enable Internationalization"
+	bool "Enable Internationalization support"
 	default y
 	help
 	  Note that this option depends in ICU library which is built without data
@@ -51,5 +42,22 @@ config PHP8_INTL
 config PHP8_FULLICUDATA
 	bool "Add dependency to full ICU Data"
 	default n
+	help
+	  The ICU library is built without data by default. This is to satisfy
+	  programs build and run dependencies but to keep the installed footprint
+	  small on the target system(s).
+	  However, the data is required to make the ICU library useful - and thus
+	  directly affects PHP's intl extension, too.
+	  When you do not enable this here, then you can still manually select
+	  the package icu-full-data, or install it later.
+
+config PHP8_SYSTEMTZDATA
+	bool "Use system timezone data instead of PHP's built-in database"
+	depends on PACKAGE_php8-cli || PACKAGE_php8-cgi || PACKAGE_apache-mod-php8
+	default y
+	help
+	  Enabling this feature automatically selects the zoneinfo-core package
+	  which contains data for UTC timezone. To use other timezones you have
+	  to install the corresponding zoneinfo-... package(s).
 
 endmenu

--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=8.4.16
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=PHP-3.01
@@ -76,16 +76,12 @@ define Package/php8
   DEPENDS:=+libpcre2 +zlib \
            +PHP8_LIBXML:libxml2 \
            +PHP8_SYSTEMTZDATA:zoneinfo-core
-  CONFLICTS:=php7
 endef
 
 define Package/php8/description
   $(call Package/php8/Default/description)
   This package contains only the PHP config file. You must actually choose
   your PHP flavour (cli, cgi or fastcgi).
-
-  Please note, that installing php5 and php8 in parallel on the same target
-  is not supported in OpenWrt/LEDE.
 endef
 
 define Package/php8-cli
@@ -325,10 +321,7 @@ else
 endif
 
 ifneq ($(CONFIG_PACKAGE_php8-mod-openssl)$(CONFIG_PACKAGE_php8-mod-ftp)$(CONFIG_PACKAGE_php8-mod-snmp),)
-  CONFIGURE_ARGS+= \
-	--with-openssl=shared \
-	--with-kerberos=no \
-	--with-openssl-dir="$(STAGING_DIR)/usr"
+  CONFIGURE_ARGS+= --with-openssl=shared
 else
   CONFIGURE_ARGS+= --without-openssl
 endif


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

This PR backports the latest changes for PHP8 on main branch.

@danielfdickinson : FYI

---

## 🧪 Run Testing Details

- **OpenWrt Version:** https://github.com/openwrt/openwrt/commit/27b48d0002ca80253c40d0b351718395fa94c096 
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2709
- **OpenWrt Device:** Raspberry Pi 2 Model B Rev 1.1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

