### PR TITLE
adguardhome: use correct capabilities

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
 PKG_VERSION:=0.107.71
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/AdGuardHome/tar.gz/v$(PKG_VERSION)?

--- a/net/adguardhome/files/adguardhome.json
+++ b/net/adguardhome/files/adguardhome.json
@@ -1,22 +1,22 @@
 {
 	"bounding": [
 		"CAP_NET_BIND_SERVICE",
-		"CAP_NET_RAW"
+		"CAP_NET_ADMIN"
 	],
 	"effective": [
 		"CAP_NET_BIND_SERVICE",
-		"CAP_NET_RAW"
+		"CAP_NET_ADMIN"
 	],
 	"ambient": [
 		"CAP_NET_BIND_SERVICE",
-		"CAP_NET_RAW"
+		"CAP_NET_ADMIN"
 	],
 	"permitted": [
 		"CAP_NET_BIND_SERVICE",
-		"CAP_NET_RAW"
+		"CAP_NET_ADMIN"
 	],
 	"inheritable": [
 		"CAP_NET_BIND_SERVICE",
-		"CAP_NET_RAW"
+		"CAP_NET_ADMIN"
 	]
 }


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @GeorgeSapkin @dobo90 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

The previous json file incorrectly granted `CAP_NET_RAW`, which AdGuardHome does not use for either DNS or DHCP AFAIK. `CAP_NET_BIND_SERVICE` is needed for binding privileged DNS and HTTPS ports and `CAP_NET_ADMIN` for DHCP functionality, matching guidance in the Linux capability documentation (man 7 capabilities, man 7 packet) and consistent with AdGuardHome’s DHCP implementation, which relies on packet sockets and interface operations rather than raw ICMP.

If users are only using adguard for DNS, `CAP_NET_ADMIN` is not needed at all.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** generic PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
