### PR TITLE
samba4: fix compiling bundled Kerberos

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
 PKG_VERSION:=4.22.7
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -65,6 +65,7 @@ define Package/samba4-libs
   $(call Package/samba4/Default)
   TITLE+= libs
   DEPENDS:= \
+	+(arm||armeb||mips||mipsel||powerpc):libatomic \
 	+libcap \
 	+libgnutls \
 	+libopenssl \
@@ -147,7 +148,8 @@ define Package/samba4-utils/description
 endef
 
 TARGET_CFLAGS += $(FPIC) -std=gnu17
-TARGET_LDFLAGS += -Wl,--as-needed
+TARGET_LDFLAGS += -Wl,--as-needed $(if $(filter arm armeb mips mipsel powerpc,$(ARCH)),-latomic)
+
 # dont mess with sambas private rpath!
 RSTRIP:=:
 
@@ -205,6 +207,7 @@ CONFIGURE_ARGS += \
 	--without-gettext \
 	--without-gpgme \
 	--without-iconv \
+	--without-kernel-keyring \
 	--without-lttng \
 	--without-pam \
 	--without-regedit \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** nobody, cc: @hnyman 

**Description:**

Samba fails compiling bundled libraries in buildbot, but not locally or in GitHub CI:

```
/builder/shared-workdir/build/sdk/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/bin/../lib/gcc/mips-openwrt-linux-musl/14.3.0/../../../../mips-openwrt-linux-musl/bin/ld.bfd: third_party/heimdal/lib/krb5/krcache.c.55.o: in function `update_change_time':
krcache.c:(.text.update_change_time+0x34): undefined reference to `__atomic_exchange_8'
/builder/shared-workdir/build/sdk/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/bin/../lib/gcc/mips-openwrt-linux-musl/14.3.0/../../../../mips-openwrt-linux-musl/bin/ld.bfd: krcache.c:(.text.update_change_time+0x58): undefined reference to `__atomic_store_8'
/builder/shared-workdir/build/sdk/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/bin/../lib/gcc/mips-openwrt-linux-musl/14.3.0/../../../../mips-openwrt-linux-musl/bin/ld.bfd: third_party/heimdal/lib/krb5/krcache.c.55.o: in function `alloc_cache':
krcache.c:(.text.alloc_cache+0xea): undefined reference to `__atomic_store_8'
/builder/shared-workdir/build/sdk/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/bin/../lib/gcc/mips-openwrt-linux-musl/14.3.0/../../../../mips-openwrt-linux-musl/bin/ld.bfd: third_party/heimdal/lib/krb5/krcache.c.55.o: in function `krcc_lastchange':
krcache.c:(.text.krcc_lastchange+0x30): undefined reference to `__atomic_load_8'
/builder/shared-workdir/build/sdk/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/bin/../lib/gcc/mips-openwrt-linux-musl/14.3.0/../../../../mips-openwrt-linux-musl/bin/ld.bfd: third_party/heimdal/lib/krb5/krcache.c.55.o: in function `initialize_internal.isra.0':
krcache.c:(.text.initialize_internal.isra.0+0x40): undefined reference to `__atomic_load_8'
/builder/shared-workdir/build/sdk/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/bin/../lib/gcc/mips-openwrt-linux-musl/14.3.0/../../../../mips-openwrt-linux-musl/bin/ld.bfd: krcache.c:(.text.initialize_internal.isra.0+0x4c): undefined reference to `__atomic_store_8'
/builder/shared-workdir/build/sdk/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/bin/../lib/gcc/mips-openwrt-linux-musl/14.3.0/../../../../mips-openwrt-linux-musl/bin/ld.bfd: krcache.c:(.text.initialize_internal.isra.0+0x286): undefined reference to `__atomic_load_8'
/builder/shared-workdir/build/sdk/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/bin/../lib/gcc/mips-openwrt-linux-musl/14.3.0/../../../../mips-openwrt-linux-musl/bin/ld.bfd: krcache.c:(.text.initialize_internal.isra.0+0x296): undefined reference to `__atomic_store_8'
/builder/shared-workdir/build/sdk/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/bin/../lib/gcc/mips-openwrt-linux-musl/14.3.0/../../../../mips-openwrt-linux-musl/bin/ld.bfd: third_party/heimdal/lib/krb5/krcache.c.55.o: in function `krcc_get_principal':
krcache.c:(.text.krcc_get_principal+0x5e): undefined reference to `__atomic_load_8'
/builder/shared-workdir/build/sdk/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/bin/../lib/gcc/mips-openwrt-linux-musl/14.3.0/../../../../mips-openwrt-linux-musl/bin/ld.bfd: krcache.c:(.text.krcc_get_principal+0x6a): undefined reference to `__atomic_store_8'
/builder/shared-workdir/build/sdk/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/bin/../lib/gcc/mips-openwrt-linux-musl/14.3.0/../../../../mips-openwrt-linux-musl/bin/ld.bfd: third_party/heimdal/lib/krb5/krcache.c.55.o: in function `krcc_remove_cred':
krcache.c:(.text.krcc_remove_cred+0x5a): undefined reference to `__atomic_load_8'
/builder/shared-workdir/build/sdk/staging_dir/toolchain-mips_24kc_gcc-14.3.0_musl/bin/../lib/gcc/mips-openwrt-linux-musl/14.3.0/../../../../mips-openwrt-linux-musl/bin/ld.bfd: krcache.c:(.text.krcc_remove_cred+0x68): undefined reference to `__atomic_store_8'
```

Fix compiling bundled Kerberos library on several 32-bit architectures by linking with libatomic.

Disable kernel keyring being picked up from a dirty buildbot environment.

Remove libpthread dependency since it's integrated into libc.

Lexicographically sort configuration arguments and dependencies.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.