### PR TITLE
p910nd: log messages if the daemon doesn't start

### DIFF
--- a/net/p910nd/files/p910nd.init
+++ b/net/p910nd/files/p910nd.init
@@ -88,7 +88,15 @@ start_p910nd() {
 			MDNS_INSTANCE_NAME="$mdns_ty" procd_add_mdns "$@"
 		fi
 		procd_close_instance
+	else
+		if [ "$enabled" -le 0 ]; then
+			logger "Not enabled, daemon won't be started"
+		fi
+		if [ ! -e "$device" ]; then
+			logger "Device path does not exist, daemon won't be started"
+		fi
 	fi
+
 }
 
 service_triggers()

--- a/net/p910nd/files/p910nd.init
+++ b/net/p910nd/files/p910nd.init
@@ -89,11 +89,8 @@ start_p910nd() {
 		fi
 		procd_close_instance
 	else
-		if [ "$enabled" -le 0 ]; then
-			logger "Not enabled, daemon won't be started"
-		fi
 		if [ ! -e "$device" ]; then
-			logger "Device path does not exist, daemon won't be started"
+			logger "Device path $device does not exist, daemon won't be started"
 		fi
 	fi
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @systemcrash 

**Description:**
Initscript prints the reason in case it doesn't start the daemon.
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.5
- **OpenWrt Target/Subtarget:** ramips/mt7621
- **OpenWrt Device:** Xiaomi MiWiFi 3G v1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
