### PR TITLE
CI: add day of the week and labels to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,10 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
+      day: 'saturday'
       interval: 'weekly'
     commit-message:
       prefix: 'ci'
+    labels:
+      - dependencies
+      - GitHub/CI


### PR DESCRIPTION
Run dependabot every Saturday and label PRs with `GitHub/CI` and `dependencies` labels.
