### PR TITLE
libimobiledevice: fix dependency on libtatsu

### DIFF
--- a/libs/libimobiledevice/Makefile
+++ b/libs/libimobiledevice/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libimobiledevice
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/libimobiledevice/libimobiledevice.git
@@ -41,7 +41,7 @@ define Package/libimobiledevice
   $(call Package/libimobiledevice/Default)
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libplist +libimobiledevice-glue +libtatsu +libusbmuxd +libopenssl
+  DEPENDS:=+libplist +libimobiledevice-glue +libusbmuxd +libopenssl
   LICENSE:=LGPL-2.1-or-later
   LICENSE_FILES:=COPYING.LESSER
 endef
@@ -54,7 +54,7 @@ define Package/libimobiledevice-utils
   $(call Package/libimobiledevice/Default)
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libimobiledevice
+  DEPENDS:=+libimobiledevice +libtatsu
   LICENSE:=GPL-2.0-or-later
   ICENSE_FILES:=COPYING
 endef


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @neheb 

**Description:**
`libtatsu` is a dependency only for `libimobiledevice-utils` the library itself does not use it during build, and is a core component for iPhone tethering, while the utils are optional.

Move the dependency to the utils, to reduce the build size:
`libtatsu` depends on `libcurl`, which is compiled with a TLS library, so users of prebuilt packages are forced to install both OpenSSL and mbed TLS. This patch removes the unnecessary dependency.

Fixes: #28427
libimobiledevice: strange dependencies when installing it for iPhone tethering support

@czo asked if we can backport this fix to `openwrt-25.12` before it gets released.
Please let me know if I need to open any additional PR for that.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** `main` r32847+5-bc8424ab89
- **OpenWrt Target/Subtarget:** mvebu/cortexa9
- **OpenWrt Device:** WRT3200ACM

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

@robimarko @BKPepe @1715173329