### PR TITLE
prometheus-node-exporter-lua: add listen_addresses

### DIFF
--- a/utils/prometheus-node-exporter-lua/files/etc/config/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/etc/config/prometheus-node-exporter-lua
@@ -1,5 +1,6 @@
 config prometheus-node-exporter-lua 'main'
 	option listen_interface 'loopback'
 	option listen_port '9100'
+	#list listen_addresses '100.64.0.1'
 	#option cert '/etc/uhttpd.crt'
 	#option key '/etc/uhttpd.key'

--- a/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
@@ -8,10 +8,18 @@ _log() {
 	logger -p daemon.info -t prometheus-node-exporter-lua "$@"
 }
 
+append_addr() {
+	has_listen_addr=1
+	case "$1" in
+		*:*) procd_append_param command "$listenflag" "[$1]:$port" ;;
+		*) procd_append_param command "$listenflag" "$1:$port" ;;
+	esac
+}
+
 start_service() {
 	. /lib/functions/network.sh
 
-	local interface port listenflag cert key bind4 bind6 omit_zero_values
+	local interface port listenflag cert key bind4 bind6 omit_zero_values has_listen_addr
 
 	config_load prometheus-node-exporter-lua.main
 	config_get keepalive "main" http_keepalive 70
@@ -20,15 +28,6 @@ start_service() {
 	config_get cert "main" cert
 	config_get key "main" key
 	config_get omit_zero_values "main" omit_zero_values 0
-
-	[ "$interface" = "*" ] || {
-		network_get_ipaddr  bind4 "$interface"
-		network_get_ipaddr6 bind6 "$interface"
-		[ -n "$bind4$bind6" ] || {
-			_log "defering start until listen interface $interface becomes ready"
-			return 0
-		}
-	}
 
 	procd_open_instance
 
@@ -44,12 +43,25 @@ start_service() {
 		listenflag=-p
 	fi
 
-	if [ "$interface" = "*" ]; then
-		procd_append_param command $listenflag $port
-	else
-		[ -n "$bind4" ] && procd_append_param command $listenflag $bind4:$port
-		[ -n "$bind6" ] && procd_append_param command $listenflag [$bind6]:$port
-	fi
+	config_list_foreach "main" listen_addresses append_addr
+	[ -n "$has_listen_addr" ] || {
+		[ "$interface" = "*" ] || {
+			network_get_ipaddr  bind4 "$interface"
+			network_get_ipaddr6 bind6 "$interface"
+			[ -n "$bind4$bind6" ] || {
+				_log "defering start until listen interface $interface becomes ready"
+				procd_close_instance
+				return 0
+			}
+		}
+
+		if [ "$interface" = "*" ]; then
+			procd_append_param command $listenflag $port
+		else
+			[ -n "$bind4" ] && procd_append_param command $listenflag $bind4:$port
+			[ -n "$bind6" ] && procd_append_param command $listenflag [$bind6]:$port
+		fi
+	}
 
 	procd_set_param stdout 1
 	procd_set_param stderr 1


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @champtar 

Add listen_addresses list option to allow binding to specific IP addresses instead of resolving addresses from an interface.
Uses listen_port for the port. Falls back to listen_interface when not set. If it's set listen_interface is ignored.       

Fixes both #21175 and #28449.
                             
Configuration example:
```
config prometheus-node-exporter-lua 'main'  
        #option listen_interface 'lan'       
        option listen_port '9100'           
        list listen_addresses '100.64.0.1
        list listen_addresses '::1'                                   
        #option cert '/etc/uhttpd.crt'      
        #option key '/etc/uhttpd.key'       
```


---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.5
- **OpenWrt Target/Subtarget:** mediatek/mt7622
- **OpenWrt Device:** Xiaomi AX3200

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
