### PR TITLE
containerd: bump to 2.2.1

### DIFF
--- a/utils/containerd/Makefile
+++ b/utils/containerd/Makefile
@@ -1,15 +1,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=containerd
-PKG_VERSION:=1.7.22
-PKG_RELEASE:=2
+PKG_VERSION:=2.2.1
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:linuxfoundation:containerd
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containerd/containerd/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=8c5edde741b7596af63c021429a1212bd616350ed65a7b741eeffc47e27ee9a9
+PKG_HASH:=af5707a26891486332142cc0ade4f0c543f707d3954838f5cecee73b833cf9b4
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
@@ -59,7 +59,7 @@ Build/Compile=$(call Build/Compile/Default)
 
 define Package/containerd/install
 	$(INSTALL_DIR) $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/{ctr,containerd,containerd-stress,containerd-shim,containerd-shim-runc-v1,containerd-shim-runc-v2} $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/{ctr,containerd,containerd-stress,containerd-shim-runc-v2} $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,containerd))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @1715173329 @hnyman @jmarcet
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Changes: https://github.com/containerd/containerd/compare/v1.7.22...v2.2.1

---

## Related PR

https://github.com/openwrt/packages/pull/28452
https://github.com/openwrt/packages/pull/28453
https://github.com/openwrt/packages/pull/28454
https://github.com/openwrt/packages/pull/28455

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.