### PR TITLE
docker-compose: bump to 5.0.2

### DIFF
--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=compose
-PKG_VERSION:=5.0.1
+PKG_VERSION:=5.0.2
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/compose/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=e48ebd8c71bb805c0b97b9705ac03513e9a0c872fa73cb0525141d0f49148b5e
+PKG_HASH:=9cd91c987bfe5924c1883b7ccd82a5a052e97d0ea149d6a00b2a8c3bf3148009
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @1715173329 @hnyman
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Fixed progress UI to adapt to terminal width by @ndeloof in https://github.com/docker/compose/pull/13519
Removed warning when no explicit build has been requested. by @ndeloof in https://github.com/docker/compose/pull/13493
Restored runtime_flags support in models by @ilopezluna in https://github.com/docker/compose/pull/13460
Added service name completion to down command by @bmo-at in https://github.com/docker/compose/pull/13470
Fixed tilde in --env-file paths expanded to user home directory by @tensorworkerr in https://github.com/docker/compose/pull/13510
Handle healthcheck.disable: true by @stavros-k in https://github.com/docker/compose/pull/13494
Fixed shutdown and error handling for large file change batches in watch by @amyssnippet in https://github.com/docker/compose/pull/13525

---

## Related PR

https://github.com/openwrt/packages/pull/28451
https://github.com/openwrt/packages/pull/28452
https://github.com/openwrt/packages/pull/28453
https://github.com/openwrt/packages/pull/28454

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.