### PR TITLE
tailscale: update to 1.94.1

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
-PKG_VERSION:=1.92.3
+PKG_VERSION:=1.94.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=805b2eb3526e14c61c09b7e14ee2ad5bd17ce25ff13961342302737c138041d4
+PKG_HASH:=80eec367cabd6012a668233b11ca5c6df29b0dd24c7cfd74b71958c93ec9b644
 
 PKG_MAINTAINER:=Zephyr Lykos <self@mochaa.ws>, \
 		Sandro Jäckel <sandro.jaeckel@gmail.com>


### PR DESCRIPTION
Changelog: https://tailscale.com/changelog#2026-01-26

## 📦 Package Details

Maintainer: me / @mochaaP

Description: update tailscale to 1.94.1

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.5
- **OpenWrt Target/Subtarget:** arm_cortex-a7_neon-vfpv4
- **OpenWrt Device:** AVM FRITZ!Box 7530

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>

---

@GeorgeSapkin backporting to 25.12 can be done as normal? 24.10 we cannot use the go backports feature, right?