### PR TITLE
xz: update to 5.8.2

### DIFF
--- a/utils/xz/Makefile
+++ b/utils/xz/Makefile
@@ -9,13 +9,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xz
-PKG_VERSION:=5.8.1
+PKG_VERSION:=5.8.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/tukaani-project/xz/releases/download/v$(PKG_VERSION) \
 		@SF/lzmautils
-PKG_HASH:=5965c692c4c8800cd4b33ce6d0f6ac9ac9d6ab227b17c512b6561bce4f08d47e
+PKG_HASH:=60345d7c0b9c8d7ffa469e96898c300def3669f5047fc76219b819340839f3d8
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=Public-Domain LGPL-2.1-or-later 0BSD


### PR DESCRIPTION
Update xz to version 5.8.2 to match version in build tools.

Maintainer: nobody

run-tested with MT6000
