### PR TITLE
frp: bump to 0.68.1

### DIFF
--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -1,37 +1,46 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=frp
-PKG_VERSION:=0.66.0
+PKG_VERSION:=0.68.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=afe1aca9f6e7680a95652e8acf84aef4a74bcefe558b5b91270876066fff3019
+PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=44ed7107bf35e4f68dc0e77cd5805102effa5301528b89ee5ab0ab379088edc6
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_DEPENDS:=golang/host node/host
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/fatedier/frp
 GO_PKG_BUILD_PKG:=github.com/fatedier/frp/cmd/...
+GO_PKG_LDFLAGS:=-s -w
+GO_PKG_LDFLAGS_X:=github.com/fatedier/frp/pkg/util/version.version=$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
+define Build/Compile
+	( \
+		$(MAKE) -C $(PKG_BUILD_DIR)/web/frpc install ; \
+		$(MAKE) -C $(PKG_BUILD_DIR)/web/frps install ; \
+		$(MAKE) -C $(PKG_BUILD_DIR) web ; \
+		$(call GoPackage/Build/Compile) ; \
+	)
+endef
+
 define Package/frp/install
 	$(INSTALL_DIR) $(1)/usr/bin/
-	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/$(2) $(1)/usr/bin/
-	$(INSTALL_DIR) $(1)/etc/frp/$(2).d/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/conf/legacy/$(2)_legacy_full.ini $(1)/etc/frp/$(2).d/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/conf/$(2)_full_example.toml $(1)/etc/frp/$(2).d/
 	$(INSTALL_DIR) $(1)/etc/config/
-	$(INSTALL_CONF) ./files/$(2).config $(1)/etc/config/$(2)
 	$(INSTALL_DIR) $(1)/etc/init.d/
-	$(INSTALL_BIN) ./files/$(2).init $(1)/etc/init.d/$(2)
+
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/$(2) $(1)/usr/bin/
+	$(INSTALL_CONF) ./files/$(2).config $(1)/etc/config/$(2)
+	$(INSTALL_BIN)  ./files/$(2).init   $(1)/etc/init.d/$(2)
 
 	if [ -r ./files/$(2).uci-defaults ]; then \
 		$(INSTALL_DIR) $(1)/etc/uci-defaults; \
@@ -50,8 +59,8 @@ define Package/frp/template
   endef
 
   define Package/$(1)/description
-    $(1) is a fast reverse proxy $(2) to help you expose a local server behind
-    a NAT or firewall to the internet.
+    $(1) is a fast reverse proxy $(2) that helps you expose a local server
+    behind a NAT or firewall to the internet.
   endef
 
   define Package/$(1)/conffiles

--- a/net/frp/files/frpc.config
+++ b/net/frp/files/frpc.config
@@ -4,11 +4,8 @@ config init
 	option user frpc
 	option group frpc
 	option respawn 1
-#	OS environments pass to frp for config file template, see
-#	https://github.com/fatedier/frp#configuration-file-template
-#	list env 'ENV_NAME=value'
-#	Config files include in temporary config file.
-#	list conf_inc '/etc/frp/frpc.d/frpc_full.ini'
+#	For full configuration options, see:
+#	https://github.com/fatedier/frp/blob/master/conf/legacy/frpc_legacy_full.ini
 
 config conf 'common'
 	option server_addr 127.0.0.1

--- a/net/frp/files/frps.config
+++ b/net/frp/files/frps.config
@@ -4,11 +4,8 @@ config init
 	option user frps
 	option group frps
 	option respawn 1
-#	OS environments pass to frp for config file template, see
-#	https://github.com/fatedier/frp#configuration-file-template
-#	list env 'ENV_NAME=value'
-#	Config files include in temporary config file.
-#	list conf_inc '/etc/frp/frps.d/frps_full.ini'
+#	For full configuration options, see:
+#	https://github.com/fatedier/frp/blob/master/conf/legacy/frps_legacy_full.ini
 
 config conf 'common'
 	option bind_port 7000


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** N/A

**Description:**
Change log is available at: https://github.com/fatedier/frp/releases/tag/v0.67.0
Change log is available at: https://github.com/fatedier/frp/releases/tag/v0.68.0
Change log is available at: https://github.com/fatedier/frp/releases/tag/v0.68.1

**Features**

- frpc now supports a clientID option to uniquely identify client instances. The server dashboard displays all connected clients with their online/offline status, connection history, and metadata, making it easier to monitor and manage multiple frpc deployments.
- Redesigned the frp web dashboard with a modern UI, dark mode support, and improved navigation.

**Fixes**

- Fixed UDP proxy protocol sending header on every packet instead of only the first packet of each session.

---

## 🧪 Run Testing Details

**OpenWrt Version:**main/snapshot
**OpenWrt Target/Subtarget:**qualcommax/aarch64
**OpenWrt Device:**ipq6000-360v6

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
