### PR TITLE
zabbix: fix compile issues from #28428 final tweaks

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -269,8 +269,8 @@ define Package/zabbix-frontend-server
   TITLE+= frontend server
   DEPENDS:= \
     @PACKAGE_php8 \
-    +ZABBIX_MYSQL:php8-mod-mysqli \
-    +ZABBIX_POSTGRESQL:php8-mod-pgsql \
+    @ZABBIX_MYSQL:php8-mod-mysqli \
+    @ZABBIX_POSTGRESQL:php8-mod-pgsql \
     @(!ZABBIX_SQLITE) \
     +php8-cgi \
     +php8-mod-gd \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**
The final update to #28428 added the use of line continuation on long lines in the Makefile.

Using line continuation (\\) in GNU Make `$(foreach ...)` and `$(call ...)` resulted in the install section for many of the packages not being defined. This resulted in 'skipping [package-name] no install section' messages and no new package being generated.

We remove the line continuation from the uses of foreach and call, in order to restore compilation and creation of packages.

Also, the renaming of zabbix-proxy to zabbix-proxy-nossl without updating the config section for database selection resulted in missing database config for server and proxy.

We update the package name for the config section for database config.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT r32902-b7cd16dba3
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
