### PR TITLE
ddns-scripts: remove service start in postinst

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=89
+PKG_RELEASE:=90
 
 PKG_LICENSE:=GPL-2.0
 
@@ -425,24 +425,6 @@ define Package/ddns-scripts/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_DATA) ./files/etc/uci-defaults/50-ddns-migrate-retry-count \
 		$(1)/etc/uci-defaults/
-endef
-
-define Package/ddns-scripts/postinst
-#!/bin/sh
-if [ -z "$${IPKG_INSTROOT}" ]; then
-	/etc/init.d/ddns enabled
-	/etc/init.d/ddns start
-fi
-exit 0
-endef
-
-define Package/ddns-scripts/prerm
-#!/bin/sh
-if [ -n "$${IPKG_INSTROOT}" ]; then
-	/etc/init.d/ddns stop
-	/etc/init.d/ddns disable
-fi
-exit 0
 endef
 
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @me
**Description:**
Fixes: #28377 
For reasons that have not been investigated in detail, the package blocks during 'postinst' with the new 'apk' backend when the package is installed on the target. Deleting this script call '/etc/init.d/ddns start' in postinst solves the problem for apk. This was not observed in the OPKG backend.

Unfortunately, I do not know what side effect this change will have. I never install the package afterwards.

---

## 🧪 Run Testing Details

- **OpenWrt Version: master**
- **OpenWrt Target/Subtarget: no**
- **OpenWrt Device: no**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.