### PR TITLE
luasocket: Add Lua5.4 support

### DIFF
--- a/lang/lua/luasocket/Makefile
+++ b/lang/lua/luasocket/Makefile
@@ -44,6 +44,13 @@ define Package/luasocket5.3
   VARIANT:=lua-53
 endef
 
+define Package/luasocket5.4
+  $(Package/luasocket/default)
+  TITLE:=LuaSocket 5.4
+  DEPENDS:=+liblua5.4
+  VARIANT:=lua-54
+endef
+
 ifeq ($(BUILD_VARIANT),lua-51)
   LUA_VERSION=5.1
 endif
@@ -52,14 +59,19 @@ ifeq ($(BUILD_VARIANT),lua-53)
   LUA_VERSION=5.3
 endif
 
+ifeq ($(BUILD_VARIANT),lua-54)
+  LUA_VERSION=5.4
+endif
+
 
 define Package/luasocket/default/description
   LuaSocket is the most comprehensive networking support
   library for the Lua language. It provides easy access to
   TCP, UDP, DNS, SMTP, FTP, HTTP, MIME and much more.
 endef
-Package/luasocket/description     = $(Package/luasocket/default/description)
+Package/luasocket/description    = $(Package/luasocket/default/description)
 Package/luasocket5.3/description = $(Package/luasocket/default/description)
+Package/luasocket5.4/description = $(Package/luasocket/default/description)
 
 define Build/Configure
 endef
@@ -95,6 +107,13 @@ define Package/luasocket5.3/install
 		install
 endef
 
+define Package/luasocket5.4/install
+	$(MAKE) -C $(PKG_BUILD_DIR)/src \
+		DESTDIR="$(1)" \
+		LUAV=$(LUA_VERSION) \
+		install
+endef
 
 $(eval $(call BuildPackage,luasocket))
 $(eval $(call BuildPackage,luasocket5.3))
+$(eval $(call BuildPackage,luasocket5.4))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @flyn-org 

**Description:**
Adds Lua5.4 support for luasocket.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** v24.10.0
- **OpenWrt Target/Subtarget:** bcm27xx
- **OpenWrt Device:** Raspberry Pi Compute Module 4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
