### PR TITLE
btop: patch to move the log file to tmpfs

### DIFF
--- a/admin/btop/Makefile
+++ b/admin/btop/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btop
 PKG_VERSION:=1.4.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL=https://codeload.github.com/aristocratos/btop/tar.gz/v$(PKG_VERSION)?

--- a/admin/btop/patches/001-move-log-to-tmpfs.patch
+++ b/admin/btop/patches/001-move-log-to-tmpfs.patch
@@ -1,0 +1,14 @@
+--- a/src/btop_config.cpp
++++ b/src/btop_config.cpp
+@@ -800,10 +800,7 @@ namespace Config {
+ 			if (xdg_state_home_ptr != nullptr) {
+ 				xdg_state_home = std::make_optional(fs::path(xdg_state_home_ptr));
+ 			} else {
+-				const auto* home_ptr = std::getenv("HOME");
+-				if (home_ptr != nullptr) {
+-					xdg_state_home = std::make_optional(fs::path(home_ptr) / ".local" / "state");
+-				}
++				xdg_state_home = std::make_optional(fs::path("/tmp/log"));
+ 			}
+ 		}
+ 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @1715173329

**Description:**
btop: patch to move the log file to tmpfs. fixes #28493 

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.0-rc4
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** glinet_gl-mt6000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
