### PR TITLE
zabbix: fix no-configure build variant

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -335,13 +335,13 @@ endif
 
 else
 
-define Build/Prepare
-	true
-endef
 define Build/Configure
 	true
 endef
 define Build/Compile
+	true
+endef
+define Build/Install
 	true
 endef
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**

When selecting only a single package of "no-configure" build variant, e.g. CONFIG_PACKAGE_zabbix-frontend-server=y
but not any other zabbix package, then the build fails. The sources are not extracted and the install fails finally with:

```
make[4]: Entering directory '/srv/openwrt/openwrt-2.git/build_dir/target-arm_arm926ej-s_musl_eabi/zabbix-no-configure/zabbix-7.0.22'
make[4]: *** No rule to make target 'install'.  Stop.
make[4]: Leaving directory '/srv/openwrt.git/build_dir/target-arm_arm926ej-s_musl_eabi/zabbix-no-configure/zabbix-7.0.22'
make[3]: *** [Makefile:522: /srv/openwrt.git/build_dir/target-arm_arm926ej-s_musl_eabi/zabbix-no-configure/zabbix-7.0.22/.built] Error 2
```

This PR fixes this by always running the standard Prepare stage, but skip the Install one when nothing needs to be compiled.

---

## 🧪 Run Testing Details

not run tested, addresses only a build issue

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

