### PR TITLE
[25.12] jq: add host build

### DIFF
--- a/utils/jq/Makefile
+++ b/utils/jq/Makefile
@@ -1,7 +1,8 @@
 #
 # Copyright (C) 2017 OpenWrt.org
 #
-# This is free software, licensed under the GNU General Public License v2.
+# This is free software, licensed under the
+# GNU General Public License v2.
 # See /LICENSE for more information.
 #
 
@@ -15,7 +16,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/jqlang/jq/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 PKG_HASH:=2be64e7129cecb11d5906290eba10af694fb9e3e7f9fc208a311dc33ca837eb0
 
-PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
+PKG_MAINTAINER:=
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:jqlang:jq
@@ -23,6 +24,7 @@ PKG_CPE_ID:=cpe:/a:jqlang:jq
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 
 define Package/jq/Default
   SECTION:=utils
@@ -40,7 +42,8 @@ endef
 
 define Package/jq/description
   Lightweight and flexible command-line JSON processor.
-  This package was compiled without ONIGURUMA regex library. match/test/sub and related functions are not available.
+  This package was compiled without ONIGURUMA regex library.
+  match/test/sub and related functions are not available.
 endef
 
 define Package/jq-full
@@ -58,13 +61,24 @@ endef
 
 CONFIGURE_ARGS+= \
 	--disable-docs \
+	--disable-valgrind
+
+HOST_CONFIGURE_ARGS+= \
+	--disable-docs \
 	--disable-valgrind \
+	--without-oniguruma
 
 ifeq ($(BUILD_VARIANT),full)
   CONFIGURE_ARGS += --with-oniguruma
 else
   CONFIGURE_ARGS += --without-oniguruma
 endif
+
+define Host/Configure
+	cd $(HOST_BUILD_DIR) && \
+	autoreconf -fiv && \
+	$(call Host/Configure/Default)
+endef
 
 define Package/jq/install
 	$(INSTALL_DIR) $(1)/usr/bin
@@ -75,5 +89,6 @@ endef
 
 Package/jq-full/install = $(Package/jq/install)
 
+$(eval $(call HostBuild))
 $(eval $(call BuildPackage,jq))
 $(eval $(call BuildPackage,jq-full))


### PR DESCRIPTION
Compile tested: x86_64, OpenWrt 24.10

Description:
* luci-app-advanced-reboot requires jq on host, this adds host build of jq
* remove maintainer


(cherry picked from commit b6c16750e5f9184d711d70068b8d1aa615be2c0b)
