### PR TITLE
rp-pppoe: fix pppoe-server init script

### DIFF
--- a/net/rp-pppoe/Makefile
+++ b/net/rp-pppoe/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rp-pppoe
 PKG_VERSION:=4.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.uls.co.za/rp-pppoe/

--- a/net/rp-pppoe/files/pppoe-server.init
+++ b/net/rp-pppoe/files/pppoe-server.init
@@ -16,7 +16,9 @@ pppoe_triggers() {
 
 pppoe_instance() {
     local cfg="$1"
-    local enabled interface device ac_name service_names service_name maxsessionsperpeer localip firstremoteip maxsessions optionsfiles randomsession unit offset timeout mss sync OPTIONS
+    local enabled interface device ac_name service_names service_name
+    local maxsessionsperpeer localip firstremoteip maxsessions optionsfile
+    local randomsession unit offset timeout mss sync OPTIONS
     config_get_bool enabled "$cfg" enabled 1
     [ "$enabled" -gt 0 ] || return 0
     config_get interface "$cfg" interface
@@ -48,8 +50,8 @@ pppoe_instance() {
 	[ -n "$maxsessionsperpeer" ] && append OPTIONS "-x $maxsessionsperpeer"
 	[ -n "$localip" ] && append OPTIONS "-L $localip"
 	[ -n "$firstremoteip" ] && append OPTIONS "-R $firstremoteip"
-	[ -n "maxsessions" ] && append OPTIONS "-N $maxsessions"
-	[ -n "optionsfile" ] && append OPTIONS "-O $optionsfile"
+	[ -n "$maxsessions" ] && append OPTIONS "-N $maxsessions"
+	[ -n "$optionsfile" ] && append OPTIONS "-O $optionsfile"
 	[ "$randomsession" = "1" ] && append OPTIONS "-r"
 	[ "$unit" = "1" ] && append OPTIONS "-u"
 	[ -n "$offset" ] && append OPTIONS "-o $offset"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @neheb @feckert 


**Description:**
There were 2 missing "$" when options "maxsessions" and "optionsfile" are checked for some content.

Also the local declaration of "optionsfile" was incorrect.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** bpi-r4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
