### PR TITLE
openthread-br: create state dir before starting

### DIFF
--- a/net/openthread-br/files/openthread-proto.sh
+++ b/net/openthread-br/files/openthread-proto.sh
@@ -59,6 +59,8 @@ proto_openthread_setup() {
 	interface="$1"
 	device="$2"
 
+	mkdir -p /var/lib/thread
+
 	json_get_vars backbone_network dataset device radio_url verbose:0
 
 	[ -n "$backbone_network" ] || proto_openthread_setup_error "$interface" MISSING_BACKBONE_NETWORK
@@ -88,7 +90,6 @@ proto_openthread_setup() {
 	}
 
 	json_for_each_item proto_openthread_add_prefix prefix
-	mkdir -p /var/lib/thread
 	ubus call otbr threadstart || proto_openthread_setup_error "$interface" MISSING_UBUS_OBJ
 	$OTCTL netdata register
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
If the directory is missing, otbr-agent will fail to start, and it's not immediately clear from the logs why:
```
netifd: Interface 'thread' is setting up now
: [NOTE]-AGENT---: Backbone interface: br-iot
otbr-agent[5682]: [NOTE]-AGENT---: Running 0.3.0
otbr-agent[5682]: [NOTE]-AGENT---: Thread version: 1.4.0
otbr-agent[5682]: [NOTE]-AGENT---: Thread interface: wpan0
otbr-agent[5682]: [NOTE]-AGENT---: Radio URL: spinel+hdlc_uart:///dev/ttyS1?uart-baudrate=921600
otbr-agent[5682]: [NOTE]-AGENT---: Radio URL: trel://br-iot
otbr-agent[5682]: [NOTE]-ILS-----: Infra link selected: br-iot
otbr-agent[5682]: [INFO]-RCP_HOS-: OpenThread log level changed to 4
otbr-agent[5682]: 49d.17:03:10.822 [I] P-SpinelDrive-: co-processor reset: RESET_POWER_ON
otbr-agent[5682]: 49d.17:03:10.822 [C] P-SpinelDrive-: Software reset co-processor successfully
otbr-agent[5682]: 49d.17:03:10.825 [C] Platform------: Init() at settings_file.cpp:65: No such file or directory
netifd: thread (5684): Command failed: Not found
netifd: Interface 'thread' is now down
```
---

## 🧪 Run Testing Details

- **OpenWrt Version:** master r32942-f750e3096f
- **OpenWrt Target/Subtarget:** sunxi/cortexa53
- **OpenWrt Device:** Olimex A64-Olinuxino-eMMC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
