### PR TITLE
lxc-auto: add optional dnsmasq dep wait on startup

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=6.0.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/

--- a/utils/lxc/files/lxc-auto.config
+++ b/utils/lxc/files/lxc-auto.config
@@ -1,3 +1,9 @@
+# Global configuration (optional)
+# Uncomment to enable waiting for dnsmasq before starting containers
+#config global 'global'
+#	option wait_dnsmasq '1'
+#	option dnsmasq_timeout '30'
+
 #config container
 	#option name container1
 	#option timeout 300

--- a/utils/lxc/files/lxc-auto.init
+++ b/utils/lxc/files/lxc-auto.init
@@ -43,6 +43,32 @@ stop_container() {
 
 start() {
 	config_load lxc-auto
+	
+	local wait_dnsmasq
+	local dnsmasq_timeout
+	config_get_bool wait_dnsmasq global wait_dnsmasq 0
+	config_get dnsmasq_timeout global dnsmasq_timeout 30
+	
+	if [ "$wait_dnsmasq" -eq 1 ]; then
+		local count=0
+
+		while [ $count -lt $dnsmasq_timeout ]; do
+			local dnsmasq_running=$(ubus call service list '{"name":"dnsmasq"}' 2>/dev/null | jsonfilter -e '@.dnsmasq.instances.*.running')
+
+			if [ "$dnsmasq_running" = "true" ]; then
+				logger -t lxc-auto "dnsmasq service confirmed running via procd"
+				break
+			fi
+
+			sleep 1
+			count=$((count + 1))
+		done
+
+		if [ $count -ge $dnsmasq_timeout ]; then
+			logger -t lxc-auto "WARNING: dnsmasq not running after ${dnsmasq_timeout}s, starting containers anyway"
+		fi
+	fi
+	config_load lxc-auto
 	config_foreach start_container container
 }
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @ratkaj 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Add opt-in support for waiting for dnsmasq to be fully initialized before starting LXC containers. This addresses issues where containers that depend on DNS resolution (e.g., AdGuardHome) start before dnsmasq has loaded its DHCP lease table, resulting in hostnames not being resolved to IP addresses.

The feature is controlled by two new optional UCI config options in `/etc/config/lxc-auto` whose usage is commented therein.

No new depends are introduced with this change.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** Intel N150 based PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
