### PR TITLE
glib2: fix builds by explicitly disabling libelf

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.82.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/$(basename $(PKG_VERSION))
@@ -67,6 +67,9 @@ COMP_ARGS+=-Dintrospection=disabled
 
 # set runtime dir to /var/run
 COMP_ARGS+=-Druntime_dir=/var/run
+
+# default feature=auto see meson_options.txt
+COMP_ARGS+=-Dlibelf=disabled
 
 MESON_HOST_ARGS += $(COMP_ARGS) -Dxattr=false -Dnls=disabled
 MESON_ARGS += $(COMP_ARGS) -Dxattr=true -Db_lto=true -Dnls=$(if $(CONFIG_BUILD_NLS),en,dis)abled


### PR DESCRIPTION
glib2 compile randomly failed due to

```
../gio/gresource-tool.c:34:10: fatal error: libelf.h: No such file or directory
   34 | #include <libelf.h>
      |          ^~~~~~~~~~
compilation terminated.
```
mechanism is unclear yet. the direct reason is:
1, meson detected dependency libelf (refer to glib2/gio/meson.build rules)
2, but the libelf.h is not in the staging directory

although the mechanism is unclear, here in glib2/makefile something can be fixed.
1, commit `e1d8f4f` disabled the libelf feature
2, commit `71b7b44` deleted that, to avoid setting default meson options

the argument is: libelf feature is not "disabled" by default in glib2 meson options, it is "auto", and "auto" is not equivalent to "disabled". based on the argument, suggest to disable glib2 feature explicitly.

fixes: #23459

## 📦 Package Details

**Maintainer:** @neheb @Ansuel @GeorgeSapkin 

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** openwrt-24.10
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Mozart V2

---

## ✅ Formalities

- [✅] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
