### PR TITLE
ddns-script: update namesilo.com

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=90
+PKG_RELEASE:=91
 
 PKG_LICENSE:=GPL-2.0
 


### PR DESCRIPTION
Switch XML parser to xmllint because xmlstarlet is not available.

## 📦 Package Details

**Maintainer:** @feckert

**Description:** NameSilo's API supports both JSON and XML response formats, with this script defaulting to JSON. If a user selects the XML format, the script originally calls xmlstarlet for parsing. However, since OpenWrt does not include the xmlstarlet package, it always fallback to grep & sed. In this new commit, it has been switched to use xmllint for XML parsing instead.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** Snapshot
- **OpenWrt Target/Subtarget:** Filogic
- **OpenWrt Device:** Cudy TR3000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

