### PR TITLE
ustreamer: update to 6.52

### DIFF
--- a/multimedia/ustreamer/Makefile
+++ b/multimedia/ustreamer/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ustreamer
-PKG_VERSION:=6.51
+PKG_VERSION:=6.52
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Georgi Valkov <gvalkov@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/pikvm/ustreamer/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=384e90b0b8e9669cf903fad10e361401bfb1b2f808be44498e3855a65d7c0145
+PKG_HASH:=db00adfa02acfbdf6682ffae8e418b582d623e1971672d5df19858e02e2f3b0e
 
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @httpstorm

**Description:**
Fix a build error [1] when compiled with `WITH_SETPROCTITLE=1` undefined reference to `setproctitle_init`.

TODO:
- `luci-app-mjpg-streamer` which is pending removal [3] is able to open the HTTP stream from `ustreamer`. It would be nice to create `luci-app-ustreamer` based on that first, before dropping it and `mjpg-streamer` [2]. Any volunteers?

[1] https://github.com/openwrt/packages/pull/28472#issuecomment-3863583824
[2] https://github.com/openwrt/packages/pull/28344
[3] https://github.com/openwrt/luci/pull/8221

@hnyman @GeorgeSapkin @systemcrash @intelfx @mdevaev

---

## 🧪 Run Testing Details

- **OpenWrt Version:** `main` r32847+5-bc8424ab89
- **OpenWrt Target/Subtarget:** mvebu/cortexa9
- **OpenWrt Device:** WRT3200ACM

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
