### PR TITLE
webauthn-helper: add package

### DIFF
--- a/utils/webauthn-helper/Makefile
+++ b/utils/webauthn-helper/Makefile
@@ -1,0 +1,43 @@
+# Copyright (C) 2026 tokisaki galaxy <moebest@outlook.jp>
+# This is free software, licensed under the MIT License.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=webauthn-helper
+PKG_VERSION:=1.0.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/tokisaki-galaxy/webauthn-helper/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=574f72498f5c092a275252a549ea978f766b5b181b4eee1ac9a87c17fdb51ab0
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=tokisaki galaxy <moebest@outlook.jp>
+
+PKG_BUILD_DEPENDS:=rust/host
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/webauthn-helper
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=webauthn helper tools for OpenWrt
+  URL:=https://github.com/tokisaki-galaxy/webauthn-helper
+  DEPENDS:=$(RUST_ARCH_DEPENDS)
+endef
+
+define Package/webauthn-helper/description
+  This is a webauthn tools written in Rust, optimized for OpenWrt.
+endef
+
+define Package/webauthn-helper/install
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/$(PKG_NAME) $(1)/usr/libexec/
+endef
+
+$(eval $(call RustBinPackage,webauthn-helper))
+$(eval $(call BuildPackage,webauthn-helper))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @Tokisaki-Galaxy 

**Description:**
This package provides a pure Rust-based WebAuthn/Passkey backend implementation for OpenWrt. It is designed to address the lack of modern authentication support in LuCI as discussed in  https://github.com/openwrt/luci/issues/8273

Key features:
    Implements WebAuthn RP (Relying Party) logic for OpenWrt.
    Lightweight and optimized for embedded systems (using Rust/Musl).
    Provides the necessary backend API for LuCI to support Passkey login.
```
UPX COMPRESSION SUMMARY
==========================================
| Target                                   | Before (KB)  | After (KB)   | Ratio      |
| ---------------------------------------- | ------------ | ------------ | ---------- |
| aarch64-unknown-linux-musl               |        956 KB |        371 KB |     61.2% |
| arm-unknown-linux-musleabi               |       1090 KB |        412 KB |     62.2% |
| arm-unknown-linux-musleabihf             |       1086 KB |        411 KB |     62.1% |
| armv5te-unknown-linux-musleabi           |       1094 KB |        414 KB |     62.2% |
| armv7-unknown-linux-musleabi             |       1078 KB |        409 KB |     62.1% |
| armv7-unknown-linux-musleabihf           |       1058 KB |        412 KB |     61.0% |
| mips-unknown-linux-musl                  |       1395 KB |        452 KB |     67.6% |
| mipsel-unknown-linux-musl                |       1395 KB |        461 KB |     66.9% |
| powerpc64le-unknown-linux-musl           |       1220 KB |        429 KB |     64.8% |
| riscv64gc-unknown-linux-musl             |        961 KB |        399 KB |     58.4% |
| x86_64-unknown-linux-musl                |       1140 KB |        418 KB |     63.3% |
==========================================
```
https://github.com/Tokisaki-Galaxy/webauthn-helper/actions/runs/21793715110/job/62877699717

---

## 🧪 Run Testing Details

- **OpenWrt Version:23.05/24.10**
- **OpenWrt Target/Subtarget:multiarch**
- **OpenWrt Device:Docker(x86_64)/aarch(MT7981)**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
