### PR TITLE
[25.12]: owut: activate by default in buildbot

### DIFF
--- a/utils/owut/Makefile
+++ b/utils/owut/Makefile
@@ -29,6 +29,7 @@ define Package/owut
     +ucode +ucode-mod-fs +ucode-mod-ubus \
     +ucode-mod-uci +ucode-mod-uclient +ucode-mod-uloop
   PKGARCH:=all
+  DEFAULT:=y if (BUILDBOT && !SMALL_FLASH)
 endef
 
 define Package/owut/description


### PR DESCRIPTION
This will activate owut in buildbot builds for targets with large flash by default. This will integrate it into most images by default.

The buildbots already build LuCI with luci-app-attendedsysupgrade. This adds ucode-mod-uclient and owut to the image.

These are the package sizes for mips_24kc:
```
29270 bin/packages/mips_24kc/packages/owut-2026.01.13~2526d84b-r1.apk
 5449 bin/packages/mips_24kc/base/ucode-mod-uclient-2026.01.31~931bbfeb-r1.apk
```

(cherry picked from commit 79d60466683d9f265df5fb2beb581ceff58aed78) (https://github.com/openwrt/packages/pull/28512)

## 📦 Package Details

**Maintainer:** @efahl 


**Description:**

