### PR TITLE
modemmanager: fix netifd proto sim path

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -393,6 +393,7 @@ modemmanager_check_state_locked() {
 
 	local unlock_required unlock_retries unlock_retry unlock_lock
 	local unlock_value unlock_match
+	local sim_path
 
 	if [ -z "$pincode" ]; then
 		echo "PIN required"
@@ -434,7 +435,8 @@ modemmanager_check_state_locked() {
 		return 1
 	fi
 
-	mmcli --modem="${device}" -i any --pin=${pincode} || {
+	sim_path="$(modemmanager_get_field "${modemstatus}" "modem.generic.sim")"
+	mmcli --modem="${device}" -i "${sim_path}" --pin=${pincode} || {
 		proto_notify_error "${interface}" MM_PINCODE_WRONG
 		proto_block_restart "${interface}"
 		return 1


### PR DESCRIPTION
Use specific SIM path instead of 'any' when unlocking with PIN code.
This fixes PIN unlock issues on devices with multiple modems where 'any' could select the wrong modem.