### PR TITLE
zabbix: remove virtual provides and add PKGARCH all

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -133,7 +133,7 @@ define Package/zabbix-get/Default
     $(ICONV_DEPENDS) \
     +libpcre2 \
     +zlib
-  PROVIDES:=@zabbix-get
+  PROVIDES:=zabbix-get
 endef
 
 define Package/zabbix-get-nossl


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**
* For architecture-independent packages set PKGARCH:=all
* Use a normal provides not virtual provides where virtual provides is not needed.

---

## 🧪 Run Testing Details

To be done

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
