### PR TITLE
ddns-scripts: update hotplug to handle ip address changing by ifupdate

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/etc/hotplug.d/iface/ddns
+++ b/net/ddns-scripts/files/etc/hotplug.d/iface/ddns
@@ -38,4 +38,10 @@ case "$ACTION" in
 	ifdown)
 		ddns_service "ifdown" "$INTERFACE"
 		;;
+	ifupdate)
+		[ -z "$IFUPDATE_ADDRESSES" ] && exit 0
+		ddns_service "ifdown" "$INTERFACE"
+		sleep 1	# give time to shutdown
+		/etc/init.d/ddns enabled && ddns_service "ifup" "$INTERFACE"
+		;;
 esac


### PR DESCRIPTION
Description:
When the ipv6 address is updated for an interface. (some ISP only give dynamic ipv6 address)
The ddns script will go into dead loop, as the new ipv6 address is not used.
The simple change is restarting ddns when ip address is changed.
see the log below
180654       : #> /usr/bin/wget --hsts-file=/tmp/.wget-hsts -nv -t 1 -O /var/run/ddns/myddns_ipv6.dat -o /var/run/ddns/myddns_ipv6.err --bind-address=0000:0000:0000:0000::1 --no-proxy 'https://update.dedyn.io/update?username=*&password=***PW***&hostname=*&myipv6=0000:0000:0000:0000:0000:0000:0000:0001&myipv4=preserve' 180654 ERROR : GNU Wget Error: '4' 180654       : failed: Address not available. failed: Address family not supported by protocol. 180654  WARN : Transfer failed - retry 4914/0 in 60 seconds