### PR TITLE
borgbackup: update to 1.4.3

### DIFF
--- a/utils/borgbackup/Makefile
+++ b/utils/borgbackup/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=borgbackup
-PKG_VERSION:=1.4.0
+PKG_VERSION:=1.4.3
 PKG_RELEASE:=1
 
 PYPI_NAME:=borgbackup
-PKG_HASH:=c54c45155643fa66fed7f9ff2d134ea0a58d0ac197c18781ddc2fb236bf6ed29
+PKG_HASH:=79bbfa745d1901d685973584bd2d16a350686ddd176f6a2244490fb01996441f
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -35,8 +35,8 @@ define Package/borgbackup
       +python3-logging \
       +python3-lzma \
       +python3-msgpack \
+      +python3-openssl \
       +python3-packaging \
-      +python3-pyfuse3 \
       +python3-readline \
       +python3-unittest \
       +python3-urllib \


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @julienmalik
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
This is an update to the latest stable release, which fixes incompatibility with python-msgpack 1.1.2. It adds a missing dependency on python3-openssl (#28156) and drops the optional dependency on python-pyfuse3, which doesn't work with the current version (not installing the package avoids the need to set environment variable BORG_FUSE_IMPL=none).

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12-rc4
- **OpenWrt Target/Subtarget:** x86/x86_64
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [x ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

No patches included