### PR TITLE
ddns-scripts: change servercow.de to new dns api

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=92
+PKG_RELEASE:=93
 
 PKG_LICENSE:=GPL-2.0
 
@@ -387,6 +387,16 @@ define Package/ddns-scripts-aliyun/description
 	Dynamic DNS Client scripts extension for aliyun.com API
 endef
 
+define Package/ddns-scripts-servercow
+	$(call Package/ddns-scripts/Default)
+	TITLE:=Extension for Servercow DNS API
+	DEPENDS:=ddns-scripts +curl +openssl-util
+endef
+
+define Package/ddns-scripts-servercow/description
+	Dynamic DNS Client scripts extension for servercow.de API
+endef
+
 define Build/Configure
 endef
 
@@ -458,6 +468,7 @@ define Package/ddns-scripts-services/install
 	rm $(1)/usr/share/ddns/default/porkbun.com-v3.json
 	rm $(1)/usr/share/ddns/default/huaweicloud.com.json
 	rm $(1)/usr/share/ddns/default/aliyun.com.json
+	rm $(1)/usr/share/ddns/default/servercow.de.json
 endef
 
 
@@ -920,6 +931,23 @@ fi
 exit 0
 endef
 
+define Package/ddns-scripts-servercow/install
+	$(INSTALL_DIR) $(1)/usr/lib/ddns
+	$(INSTALL_BIN) ./files/usr/lib/ddns/update_servercow_de.sh \
+		$(1)/usr/lib/ddns
+
+	$(INSTALL_DIR) $(1)/usr/share/ddns/default
+	$(INSTALL_DATA) ./files/usr/share/ddns/default/servercow.de.json \
+		$(1)/usr/share/ddns/default/
+endef
+
+define Package/ddns-scripts-servercow/prerm
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	/etc/init.d/ddns stop
+fi
+exit 0
+endef
 
 $(eval $(call BuildPackage,ddns-scripts))
 $(eval $(call BuildPackage,ddns-scripts-services))
@@ -948,3 +976,4 @@ $(eval $(call BuildPackage,ddns-scripts-one))
 $(eval $(call BuildPackage,ddns-scripts-porkbun))
 $(eval $(call BuildPackage,ddns-scripts-huaweicloud))
 $(eval $(call BuildPackage,ddns-scripts-aliyun))
+$(eval $(call BuildPackage,ddns-scripts-servercow))

--- a/net/ddns-scripts/files/usr/lib/ddns/update_servercow_de.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_servercow_de.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Based on update_gandi_net.sh script
+# New servercow.de DNS-API https://wiki.servercow.de/de/domains/dns_api/api-syntax/
+
+. /usr/share/libubox/jshn.sh
+
+local __TTL=600
+local __RRTYPE
+local __ENDPOINT="https://api.servercow.de/dns/v1/domains"
+local __STATUS
+
+[ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing username"
+[ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing password"
+
+[ $use_ipv6 -ne 0 ] && __RRTYPE="AAAA" || __RRTYPE="A"
+
+# Get host and domain from $domain
+__RECORD="${domain%%.*}"
+__DOMAIN="${domain#*.}"
+
+# Construct JSON payload
+json_init
+json_add_string "type" "$__RRTYPE"
+json_add_string "name" "$__RECORD"
+json_add_string "content" "$__IP"
+json_add_string "ttl" "60"
+json_close_array
+
+# Log the curl command
+write_log 7 "curl -s -X POST \"$__ENDPOINT/$__DOMAIN\" \
+		-H \"X-Auth-Username: $username\" \
+		-H \"X-Auth-Password: $password\" \
+		-H \"Content-Type: application/json\" \
+		-d \"$(json_dump)\" \
+		--connect-timeout 30"
+
+__STATUS=$(curl -s -X POST "$__ENDPOINT/$__DOMAIN" \
+		-H "X-Auth-Username: $username" \
+		-H "X-Auth-Password: $password" \
+		-H "Content-Type: application/json" \
+		-d "$(json_dump)" \
+		--connect-timeout 30 \
+		-w "%{http_code}\n" -o $DATFILE 2>$ERRFILE)
+
+local __ERRNO=$?
+if [ $__ERRNO -ne 0 ]; then
+		write_log 14 "Curl failed with $__ERRNO: $(cat $ERRFILE)"
+		return 1
+elif [ -z $__STATUS ] || [ $__STATUS != 200 ]; then
+		write_log 14 "DNS API Update failed: $__STATUS \napi.servercow.de answered: $(cat $DATFILE)"
+		return 1
+fi
+
+write_log 7 "api.servercow.de answered: $(cat $DATFILE)"
+
+return 0

--- a/net/ddns-scripts/files/usr/share/ddns/default/servercow.de.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/servercow.de.json
@@ -1,11 +1,9 @@
 {
-	"name": "servercow.de",
-	"ipv4": {
-		"url": "http://www.servercow.de/dnsupdate/update.php?username=[USERNAME]&pass=[PASSWORD]&hostname=[DOMAIN]&ipaddr=[IP]",
-		"answer": "OKv4"
-	},
-	"ipv6": {
-		"url": "http://www.servercow.de/dnsupdate/update.php?username=[USERNAME]&pass=[PASSWORD]&hostname=[DOMAIN]&ip6addr=[IP]",
-		"answer": "OKv6"
-	}
+		"name": "servercow.de",
+		"ipv4": {
+				"url": "update_servercow_de.sh"
+		},
+		"ipv6": {
+			"url": "update_servercow_de.sh"
+		}
 }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jummo 

**Description:**
Change servercow.de to use new dns api, see https://wiki.servercow.de/de/domains/dns_api/api-syntax/.
Sorry for creating another Pull Request, but I still couldn't figure out how to do it properly.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** r29087-d9c5716d1d
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** KVM

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.