### PR TITLE
[25.12] django: bump to version 6.0.2

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=5.2.9
+PKG_VERSION:=6.0.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=django
-PKG_HASH:=16b5ccfc5e8c27e6c0561af551d2ea32852d7352c67d452ae3e76b4f6b2ca495
+PKG_HASH:=3046a53b0e40d4b676c3b774c73411d7184ae2745fe8ce5e45c0f33d3ddb71a7
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Peter Stadler <peter.stadler@student.uibk.ac.at>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @commodo, @peter-stadler

**Description:**
Update django to version 6.0.2.

Backport of https://github.com/openwrt/packages/pull/28501 to 25.12.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12
- **OpenWrt Target/Subtarget:** Arm SystemReady (EFI) compliant / 64-bit (armv8) machines
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.