### PR TITLE
bluld: bump to version 1.1.3

### DIFF
--- a/utils/bluld/Makefile
+++ b/utils/bluld/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bluld
-PKG_VERSION:=1.1.2
+PKG_VERSION:=1.1.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/ktgeek/$(PKG_NAME)/releases/download/v$(PKG_VERSION)
-PKG_HASH:=94e42999bf701ea01296d614fe298af3bd5b91d3bdab6adda7ecc24af69f8230
+PKG_HASH:=382def82bb1486633b2dbf2f399b7b11ab854c4f79957066b7a31b556abd0158
 
 PKG_MAINTAINER:=Keith T. Garner <kgarner@kgarner.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Release notes:
https://github.com/ktgeek/bluld/releases/tag/v1.1.3

## 📦 Package Details

**Maintainer:** @ktgeek 

**Description:**
Update bluld to version 1.1.3

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12, r32538-cca2f56023
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** x86_64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.