### PR TITLE
haproxy: update to v3.2.12 [SECURITY]

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=3.2.9
+PKG_VERSION:=3.2.12
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/3.2/src
-PKG_HASH:=e660d141b29019f4d198785b0834cc3e9c96efceeb807c2fff2fc935bd3354c2
+PKG_HASH:=310b424e60db2f3990206ca7c81293586842cb628e7dfad572c7146ae9e95a91
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Christian Lachner <gladiac@gmail.com>

--- a/net/haproxy/get-latest-patches.sh
+++ b/net/haproxy/get-latest-patches.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CLONEURL=https://git.haproxy.org/git/haproxy-3.2.git
-BASE_TAG=v3.2.9
+BASE_TAG=v3.2.12
 TMP_REPODIR=tmprepo
 PATCHESDIR=patches
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @gladiac

**Description:**
- Fixes CVE-2026-26080 and CVE-2026-26081 https://www.haproxy.com/blog/cves-2026-quic-denial-of-service
- Updated haproxy PKG_VERSION and PKG_HASH
- See changes: http://git.haproxy.org/?p=haproxy-3.2.git;a=shortlog

---

## 🧪 Run Testing Details

- **OpenWrt Version:** Master
- **OpenWrt Target/Subtarget:** Mediatek MT798x
- **OpenWrt Device:** GL.iNet GL-MT6000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.