### PR TITLE
socat: update to 1.8.1.1

### DIFF
--- a/net/socat/Makefile
+++ b/net/socat/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=socat
-PKG_VERSION:=1.8.0.3
-PKG_RELEASE:=2
+PKG_VERSION:=1.8.1.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.dest-unreach.org/socat/download
-PKG_HASH:=01eb017361d95bb3a6941e840b59e4463a3fabf92df4154ed02b16a2ed6a0095
+PKG_HASH:=5ebc636b7f427053f98806696521653a614c7e06464910353cbf54e2327adc1b
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=GPL-2.0-or-later OpenSSL
@@ -44,6 +44,7 @@ define Package/socat/config
 config SOCAT_SSL
         bool "SSL support"
         depends on PACKAGE_socat
+        select OPENSSL_WITH_DEPRECATED
         default n
         help
           Implements SSL support in socat (using libopenssl).


### PR DESCRIPTION
- update the package
- make SOCAT_SSL select OPENSSL_WITH_DEPRECATED

## 📦 Package Details

**Maintainer:** @thess 

**Description:** update to the latest release, fix compilation with openssl

---

## 🧪 Run Testing Details

- **OpenWrt Version:** r33052+2-8b9bd686e7
- **OpenWrt Target/Subtarget:** qualcommax/ipq807x, aarch64_cortex-a53
- **OpenWrt Device:** Dynalink DL-WRX36

Forwarding https to busybox httpd works.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.