### PR TITLE
zabbix: cherry-pick changes to date to fix a build isssue and a packaging issue (and more)

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -133,7 +133,7 @@ define Package/zabbix-get/Default
     $(ICONV_DEPENDS) \
     +libpcre2 \
     +zlib
-  PROVIDES:=@zabbix-get
+  PROVIDES:=zabbix-get
 endef
 
 define Package/zabbix-get-nossl


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson
**Also mention:** @mhei @hnyman @systemcrash

**Description:**
Cherry picks the following patches from master:

dcf8dbb77 zabbix: fix unnecessary virtual provides
b8eb3191a zabbix: set PKGARCH all for non-binary packages
3c37f5288 zabbix: fix no-configure build variant
558852ed8 zabbix: fix recursive depedency warning on build
5d66c39c2 zabbix: fix package rename missed database config
0f63f7984 zabbix: fix compile skipped due to line continuation
81c429066 zabbix: deduplicate and reorganize package defines

Of these, ' 3c37f5288 zabbix: fix no-configure build variant' fixes a build issue and ' dcf8dbb77 zabbix: fix unnecessary virtual provides' are the most important fixes.

' 3c37f5288 zabbix: fix no-configure build variant' was reported and fixed in PR #28495 and is present on openwrt-25.12. A test build with current 25.12-snapshot and openwrt-25.12 branch gives:

```plaintext
make[4]: Entering directory '/home/daniel/Build/snapshot-25.12-bcm27xx-bcm2712-2/openwrt-sdk/build_dir/target-aarch64_cortex-a76_musl/zabbix-no-configure/zabbix-7.0.22'
make[4]: *** No rule to make target 'install'.  Stop.
make[4]: Leaving directory '/home/daniel/Build/snapshot-25.12-bcm27xx-bcm2712-2/openwrt-sdk/build_dir/target-aarch64_cortex-a76_musl/zabbix-no-configure/zabbix-7.0.22'
make[3]: *** [Makefile:485: /home/daniel/Build/snapshot-25.12-bcm27xx-bcm2712-2/openwrt-sdk/build_dir/target-aarch64_cortex-a76_musl/zabbix-no-configure/zabbix-7.0.22/.built] Error 2
```

without that cherry-pick.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12-SNAPSHOT r32613-bffedc5784
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.