### PR TITLE
zabbix: add configurable full variant, limited core variant, and  update packaging

### DIFF
--- a/admin/zabbix/Config-build.in
+++ b/admin/zabbix/Config-build.in
@@ -1,0 +1,8 @@
+config ZABBIX_BUILD_SUPPORT_BIN
+  bool
+  depends on (PACKAGE_zabbix-agentd || PACKAGE_zabbix-proxy || PACKAGE_zabbix-server)
+  default y
+  help
+    This option exists to prevent trying to build get and/or sender when none
+    of agentd, server, or proxy are being built. In that case get and sender are
+    not built by the Zabbix build system.

--- a/admin/zabbix/Config-db.in
+++ b/admin/zabbix/Config-db.in
@@ -1,0 +1,13 @@
+choice
+        prompt "Select Database Software for Zabbix"
+        default ZABBIX_POSTGRESQL
+
+        config ZABBIX_MYSQL
+                bool "MySQL/MariaDB"
+
+        config ZABBIX_POSTGRESQL
+                bool "PostgreSQL"
+
+        config ZABBIX_SQLITE
+                bool "SQLite3"
+endchoice

--- a/admin/zabbix/Config.in
+++ b/admin/zabbix/Config.in
@@ -1,0 +1,37 @@
+choice
+        prompt "Select SSL Library"
+
+        default ZABBIX_OPENSSL
+
+        config ZABBIX_GNUTLS
+                bool "GnuTLS"
+
+        config ZABBIX_NOSSL
+                bool "NoSSL"
+
+        config ZABBIX_OPENSSL
+                bool "OpenSSL"
+endchoice
+
+menu "Modify features for non-core variants"
+
+        config ZABBIX_CURL
+                bool "cURL support (default SSL)"
+                default y
+                depends on !ZABBIX_GNUTLS && !ZABBIX_NOSSL
+
+        config ZABBIX_CURL_GNUTLS
+                bool "cURL support (GnuTLS)"
+                default n
+                depends on !ZABBIX_CURL
+
+        config ZABBIX_LDAP
+                bool "LDAP support"
+                depends on ZABBIX_OPENSSL
+                default y
+
+        config ZABBIX_NETSNMP
+                bool "NetSNMP support (OpenSSL)"
+                depends on ZABBIX_OPENSSL
+                default y
+endmenu

--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=7.0.22
-PKG_RELEASE:=7
+PKG_VERSION:=7.0.23
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
 	https://cdn.zabbix.com/zabbix/sources/oldstable/$(basename $(PKG_VERSION))/
-PKG_HASH:=7a74794b2124607d8036be36cc104da056a2fb653811c84acbe29f3f6d97860a
+PKG_HASH:=43ea5fcb1e5db25e74bdc83ea8936d79b8093b614af4e889417485bc74f061e2
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 PKG_LICENSE:=AGPL-3.0-only

--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=7.0.22
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
@@ -271,10 +271,10 @@ define Package/zabbix-frontend-server
   TITLE+= frontend server
   PKGARCH:=all
   DEPENDS:= \
-    @PACKAGE_php8 \
-    @ZABBIX_MYSQL:php8-mod-mysqli \
-    @ZABBIX_POSTGRESQL:php8-mod-pgsql \
+    php8 \
     @(!ZABBIX_SQLITE) \
+    +ZABBIX_MYSQL:php8-mod-mysqli \
+    +ZABBIX_POSTGRESQL:php8-mod-pgsql \
     +php8-cgi \
     +php8-mod-gd \
     +php8-mod-bcmath \

--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=7.0.22
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
@@ -25,29 +25,28 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 PKG_CONFIG_DEPENDS:= \
+  CONFIG_ZABBIX_CURL \
+  CONFIG_ZABBIX_CURL_GNUTLS \
+  CONFIG_ZABBIX_GNUTLS \
+  CONFIG_ZABBIX_LDAP \
   CONFIG_ZABBIX_MYSQL \
-  CONFIG_ZABBIX_POSTGRESQL \
-  CONFIG_ZABBIX_SQLITE
+  CONFIG_ZABBIX_NETSNMP \
+  CONFIG_ZABBIX_OPENSSL \
+  CONFIG_ZABBIX_POSTGRESQL
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
-define Package/zabbix-proxy-nossl/config
-comment "Database Software"
+define Package/zabbix-agentd/config
+  source "$(SOURCE)/Config.in"
+endef
 
-choice
-        prompt "Selected Database Software"
-        default ZABBIX_POSTGRESQL
+define Package/zabbix-proxy/config
+  source "$(SOURCE)/Config-db.in"
+endef
 
-        config ZABBIX_MYSQL
-                bool "MySQL/MariaDB"
-
-        config ZABBIX_POSTGRESQL
-                bool "PostgreSQL"
-
-        config ZABBIX_SQLITE
-                bool "SQLite"
-endchoice
+define Package/zabbix-get/config
+  source "$(SOURCE)/Config-build.in"
 endef
 
 define Package/zabbix/Default
@@ -58,6 +57,37 @@ define Package/zabbix/Default
   URL:=https://www.zabbix.com/
 endef
 
+define Package/zabbix/description/Default
+Zabbix is a software that monitors numerous parameters of a network and the
+health and integrity of servers, virtual machines, applications, services,
+databases, websites, the cloud and more. Zabbix offers excellent reporting and
+data visualization features based on the stored data.
+.
+Only one variant may be installed per binary (e.g. agent and agentd-basic cannot
+both be installed on the same system).
+endef
+
+define Package/zabbix-basic/description/Default
+$(call Package/zabbix/description/Default)
+.
+Provides only basic functionality with SSL/TLS.
+endef
+
+define Package/zabbix-basic-sqlite/description/Default
+$(call Package/zabbix/description/Default)
+.
+Provides only the basic functionality with SSL/TLS.
+Uses SQLite3 for the database.
+endef
+
+define Package/zabbix-full/description/Default
+$(call Package/zabbix/description/Default)
+.
+Provides the full functionality available in OpenWrt with OpenSSL.
+Includes NetSNMP, cURL, and OpenLDAP support.
+Requires a database server.
+endef
+
 define Package/zabbix-agentd/Default
   $(call Package/zabbix/Default)
   TITLE+= agentd
@@ -66,105 +96,76 @@ define Package/zabbix-agentd/Default
     +libevent2-pthreads \
     +libpcre2 \
     +zlib
-  PROVIDES:=zabbix-agentd
+  PROVIDES:=\
+    @zabbix-agentd-any \
+    zabbix-agentd-ssl \
+    zabbix-agentd-openssl
   USERID:=zabbix-agent=53:zabbix-agent=53
 endef
 
-define Package/zabbix-agentd-nossl
+define Package/zabbix-agentd
   $(call Package/zabbix-agentd/Default)
-  TITLE+= (no SSL)
-  VARIANT:=nossl
+  TITLE+= (full/with TLS)
+  DEPENDS+= \
+    +ZABBIX_CURL:libcurl \
+    +ZABBIX_CURL_GNUTLS:libcurl-gnutls \
+    +ZABBIX_GNUTLS:libgnutls \
+    +ZABBIX_LDAP:libopenldap \
+    +ZABBIX_NETSNMP:libnetsnmp-ssl \
+    +ZABBIX_OPENSSL:libopenssl
+  VARIANT:=full
   DEFAULT_VARIANT:=1
 endef
 
-define Package/zabbix-agentd-openssl
-  $(call Package/zabbix-agentd/Default)
-  TITLE+= (with OpenSSL)
-  DEPENDS+= +libopenssl
-  PROVIDES+= zabbix-agentd-ssl
-  VARIANT:=openssl
+define Package/zabbix-agentd/description
+$(call Package/zabbix-full/description/Default)
+.
+Provides 'Zabbix Agent'.
+.
+Note that 'Zabbix Agent' does not directly use the database, but sends data to
+a 'Zabbix Server' or a 'Zabbix Proxy', which writes to a database.
 endef
 
-define Package/zabbix-agentd-gnutls
+define Package/zabbix-agentd-basic
   $(call Package/zabbix-agentd/Default)
-  TITLE+= (with GnuTLS)
-  DEPENDS+= +libgnutls
-  PROVIDES+= zabbix-agentd-ssl
-  VARIANT:=gnutls
+  TITLE+= (basic/with TLS)
+  DEPENDS += +libopenssl
+  VARIANT:=basic
 endef
 
-define Package/zabbix-sender/Default
+define Package/zabbix-agentd-basic/description
+$(call Package/zabbix-basic/description/Default)
+.
+Provides 'Zabbix Agent'.
+endef
+
+define Package/zabbix-get
   $(call Package/zabbix/Default)
-  TITLE+= sender
+  TITLE+= get (with TLS)
   DEPENDS:= \
+    @(ZABBIX_BUILD_SUPPORT_BIN) \
     $(ICONV_DEPENDS) \
+    +ZABBIX_GNUTLS:libgnutls \
+    +ZABBIX_OPENSSL:libopenssl \
     +libpcre2 \
     +zlib
-  PROVIDES:=zabbix-sender
+  PROVIDES:= \
+    zabbix-get-ssl \
+    zabbix-get-openssl
+  VARIANT:=full
 endef
 
-define Package/zabbix-sender-nossl
-  $(call Package/zabbix-sender/Default)
-  TITLE+= (no SSL)
-  VARIANT:=nossl
-  DEFAULT_VARIANT:=1
+define Package/zabbix-get/description
+$(call Package/zabbix-basic/description/Default)
+.
+Provides 'Zabbix Get'.
 endef
 
-define Package/zabbix-sender-openssl
-  $(call Package/zabbix-sender/Default)
-  TITLE+= (with OpenSSL)
-  DEPENDS+= +libopenssl
-  PROVIDES+= zabbix-sender-ssl
-  VARIANT:=openssl
-endef
-
-define Package/zabbix-sender-gnutls
-  $(call Package/zabbix-sender/Default)
-  TITLE+= (with GnuTLS)
-  DEPENDS+= +libgnutls
-  PROVIDES+= zabbix-sender-ssl
-  VARIANT:=gnutls
-endef
-
-define Package/zabbix-get/Default
-  $(call Package/zabbix/Default)
-  TITLE+= get
-  DEPENDS:= \
-    $(ICONV_DEPENDS) \
-    +libpcre2 \
-    +zlib
-  PROVIDES:=zabbix-get
-endef
-
-define Package/zabbix-get-nossl
-  $(call Package/zabbix-get/Default)
-  TITLE+= (no SSL)
-  VARIANT:=nossl
-  DEFAULT_VARIANT:=1
-endef
-
-define Package/zabbix-get-openssl
-  $(call Package/zabbix-get/Default)
-  TITLE+= (with OpenSSL)
-  DEPENDS+= +libopenssl
-  PROVIDES+= zabbix-get-ssl
-  VARIANT:=openssl
-endef
-
-define Package/zabbix-get-gnutls
-  $(call Package/zabbix-get/Default)
-  TITLE+= (with GnuTLS)
-  DEPENDS+= +libgnutls
-  PROVIDES+= zabbix-get-ssl
-  VARIANT:=gnutls
-endef
 
 define Package/zabbix-server-or-proxy/Default
   $(call Package/zabbix/Default)
   DEPENDS:= \
     $(ICONV_DEPENDS) \
-    +ZABBIX_MYSQL:libmariadbclient \
-    +ZABBIX_POSTGRESQL:libpq \
     +fping \
     +libevent2 \
     +libevent2-pthreads \
@@ -174,64 +175,99 @@ define Package/zabbix-server-or-proxy/Default
   USERID:=zabbix-server=70:zabbix-server=70
 endef
 
-define Package/zabbix-server/Default
-  $(call Package/zabbix-server-or-proxy/Default)
-  TITLE+= server
-  DEPENDS+= @(!ZABBIX_SQLITE)
-  PROVIDES:=zabbix-server
-endef
-
-define Package/zabbix-server-nossl
-  $(call Package/zabbix-server/Default)
-  TITLE+= (no SSL)
-  VARIANT:=nossl
-  DEFAULT_VARIANT:=1
-endef
-
-define Package/zabbix-server-openssl
-  $(call Package/zabbix-server/Default)
-  TITLE+= (with OpenSSL)
-  DEPENDS+= +libopenssl
-  PROVIDES+= zabbix-server-ssl
-  VARIANT:=openssl
-endef
-
-define Package/zabbix-server-gnutls
-  $(call Package/zabbix-server/Default)
-  TITLE+= (with GnuTLS)
-  DEPENDS+= +libgnutls
-  PROVIDES+= zabbix-server-ssl
-  VARIANT:=gnutls
-endef
-
 define Package/zabbix-proxy/Default
   $(call Package/zabbix-server-or-proxy/Default)
   TITLE+= proxy
-  DEPENDS+= +ZABBIX_SQLITE:libsqlite3
-  PROVIDES:=zabbix-proxy
+  PROVIDES:=\
+    @zabbix-proxy-any \
+    zabbix-proxy-ssl \
+    zabbix-proxy-openssl
 endef
 
-define Package/zabbix-proxy-nossl
+define Package/zabbix-proxy
   $(call Package/zabbix-proxy/Default)
-  TITLE+= (no SSL)
-  VARIANT:=nossl
+  TITLE+= (full/with OpenSSL)
+  DEPENDS+= \
+    +ZABBIX_CURL:libcurl \
+    +ZABBIX_CURL_GNUTLS:libcurl-gnutls \
+    +ZABBIX_GNUTLS:libgnutls \
+    +ZABBIX_LDAP:libopenldap \
+    +ZABBIX_MYSQL:libmariadbclient \
+    +ZABBIX_NETSNMP:libnetsnmp-ssl \
+    +ZABBIX_OPENSSL:libopenssl \
+    +ZABBIX_POSTGRESQL:libpq \
+    +ZABBIX_SQLITE:libsqlite3
+  VARIANT:=full
   DEFAULT_VARIANT:=1
 endef
 
-define Package/zabbix-proxy-openssl
-  $(call Package/zabbix-proxy/Default)
-  TITLE+= (with OpenSSL)
-  DEPENDS+= +libopenssl
-  PROVIDES+= zabbix-proxy-ssl
-  VARIANT:=openssl
+define Package/zabbix-proxy/description
+$(call Package/zabbix-full/description/Default)
+.
+Provides 'Zabbix Proxy'.
 endef
 
-define Package/zabbix-proxy-gnutls
+define Package/zabbix-proxy-basic-sqlite
   $(call Package/zabbix-proxy/Default)
-  TITLE+= (with GnuTLS)
-  DEPENDS+= +libgnutls
-  PROVIDES+= zabbix-proxy-ssl
-  VARIANT:=gnutls
+  TITLE+= sqlite3 (basic/with TLS)
+  DEPENDS+= \
+    +libopenssl \
+    +libsqlite3
+  VARIANT:=basic
+endef
+
+define Package/zabbix-proxy-basic-sqlite/description
+$(call Package/zabbix-basic/description/Default)
+.
+Provides 'Zabbix Proxy' using sqlite3 for
+the database.
+endef
+
+define Package/zabbix-sender
+  $(call Package/zabbix/Default)
+  TITLE+= sender (with TLS)
+  DEPENDS:= \
+    @(ZABBIX_BUILD_SUPPORT_BIN) \
+    $(ICONV_DEPENDS) \
+    +ZABBIX_GNUTLS:libgnutls \
+    +ZABBIX_OPENSSL:libopenssl \
+    +libpcre2 \
+    +zlib
+  PROVIDES:=\
+    zabbix-sender-ssl \
+    zabbix-sender-openssl
+  VARIANT:=full
+endef
+
+define Package/zabbix-sender/description
+$(call Package/zabbix-basic/description/Default)
+.
+Provides 'Zabbix Sender'.
+endef
+
+define Package/zabbix-server
+  $(call Package/zabbix-server-or-proxy/Default)
+  TITLE+= server (full/with OpenSSL)
+  DEPENDS+= \
+    @(!ZABBIX_SQLITE) \
+    +ZABBIX_CURL:libcurl \
+    +ZABBIX_CURL_GNUTLS:libcurl-gnutls \
+    +ZABBIX_GNUTLS:libgnutls \
+    +ZABBIX_LDAP:libopenldap \
+    +ZABBIX_MYSQL:libmariadbclient \
+    +ZABBIX_OPENSSL:libopenssl \
+    +ZABBIX_NETSNMP:libnetsnmp-ssl \
+    +ZABBIX_POSTGRESQL:libpq
+  PROVIDES:=\
+    zabbix-server-ssl \
+    zabbix-server-openssl
+  VARIANT:=full
+endef
+
+define Package/zabbix-server/description
+$(call Package/zabbix-full/description/Default)
+.
+Provides 'Zabbix Server'.
 endef
 
 define Package/zabbix-extra-mac80211
@@ -240,8 +276,14 @@ define Package/zabbix-extra-mac80211
   DEPENDS:= \
     @KERNEL_DEBUG_FS \
     @PACKAGE_MAC80211_DEBUGFS \
-    +zabbix-agentd
+    @zabbix-agentd-any
   VARIANT:=no-configure
+endef
+
+define Package/zabbix-extra-mac80211/description
+An extra package for zabbix-agentd that adds a discovery rule for mac80211 wifi phy and many userparameters.
+It contains an suid helper to allow zabbix-agentd to still run as zabbix user and not as root.
+See https://openwrt.org/docs/guide-user/services/network_monitoring/zabbix for ready to use zabbix templates.
 endef
 
 define Package/zabbix-extra-network
@@ -251,8 +293,14 @@ define Package/zabbix-extra-network
   DEPENDS:= \
     +libubus-lua \
     +lua \
-    +zabbix-agentd
+    @zabbix-agentd-any
   VARIANT:=no-configure
+endef
+
+define Package/zabbix-extra-network/description
+An extra package for zabbix-agentd that adds a discovery rule for openwrt network interfaces.
+The idea here is to discover only interfaces listed in /etc/config/network (discover br-lan and not eth0.1 and wlan0)
+See https://openwrt.org/docs/guide-user/services/network_monitoring/zabbix for ready to use zabbix templates.
 endef
 
 define Package/zabbix-extra-wifi
@@ -262,8 +310,14 @@ define Package/zabbix-extra-wifi
   DEPENDS:= \
     +libiwinfo-lua \
     +libubus-lua +lua \
-    +zabbix-agentd
+    @zabbix-agentd-any
   VARIANT:=no-configure
+endef
+
+define Package/zabbix-extra-wifi/description
+An extra package for zabbix-agentd that adds a discovery rule for wifi interfaces and many userparameters.
+As it uses libiwinfo, it works with all wifi devices supported by openwrt.
+See https://openwrt.org/docs/guide-user/services/network_monitoring/zabbix for ready to use zabbix templates.
 endef
 
 define Package/zabbix-frontend-server
@@ -279,8 +333,10 @@ define Package/zabbix-frontend-server
     +php8-mod-gd \
     +php8-mod-bcmath \
     +php8-mod-ctype \
+    +php8-mod-curl \
     +php8-mod-filter \
     +php8-mod-gettext \
+    +php8-mod-ldap \
     +php8-mod-mbstring \
     +php8-mod-openssl \
     +php8-mod-session \
@@ -291,52 +347,69 @@ define Package/zabbix-frontend-server
   VARIANT:=no-configure
 endef
 
-define Package/zabbix-extra-mac80211/description
-An extra package for zabbix-agentd that adds a discovery rule for mac80211 wifi phy and many userparameters.
-It contains an suid helper to allow zabbix-agentd to still run as zabbix user and not as root.
-See https://openwrt.org/docs/guide-user/services/network_monitoring/zabbix for ready to use zabbix templates.
-endef
-
-define Package/zabbix-extra-network/description
-An extra package for zabbix-agentd that adds a discovery rule for openwrt network interfaces.
-The idea here is to discover only interfaces listed in /etc/config/network (discover br-lan and not eth0.1 and wlan0)
-See https://openwrt.org/docs/guide-user/services/network_monitoring/zabbix for ready to use zabbix templates.
-endef
-
-define Package/zabbix-extra-wifi/description
-An extra package for zabbix-agentd that adds a discovery rule for wifi interfaces and many userparameters.
-As it uses libiwinfo, it works with all wifi devices supported by openwrt.
-See https://openwrt.org/docs/guide-user/services/network_monitoring/zabbix for ready to use zabbix templates.
+define Package/zabbix-frontend-server/description
+$(call Package/zabbix/description/Default)
+.
+Provides the Web UI (frontend server) for Zabbix.
 endef
 
 ifneq ($(BUILD_VARIANT),no-configure)
-
 CONFIGURE_ARGS+= \
-	--enable-agent \
-	$(if $(CONFIG_ZABBIX_SQLITE),--disable-server,--enable-server) \
-	--enable-proxy \
 	$(call autoconf_bool,CONFIG_IPV6,ipv6) \
 	--disable-java \
-	$(if $(CONFIG_ZABBIX_MYSQL),--with-mysql) \
-	$(if $(CONFIG_ZABBIX_POSTGRESQL),--with-postgresql) \
-	$(if $(CONFIG_ZABBIX_SQLITE),--with-sqlite3=$(STAGING_DIR)/usr) \
 	--with-libevent=$(STAGING_DIR)/usr/include \
 	--with-libpcre2=$(STAGING_DIR)/usr/include \
 	--with-zlib=$(STAGING_DIR)/usr/include
-
-ifeq ($(BUILD_VARIANT),nossl)
-	CONFIGURE_ARGS+= --with-openssl="no" --with-gnutls="no"
 endif
 
-ifeq ($(BUILD_VARIANT),openssl)
-	CONFIGURE_ARGS+= --with-openssl="$(STAGING_DIR)/usr"
+ifeq ($(BUILD_VARIANT),basic)
+CONFIGURE_ARGS+= \
+	$(if $(CONFIG_PACKAGE_zabbix-agentd-basic),--enable-agent,--disable-agent) \
+	$(if $(CONFIG_PACKAGE_zabbix-proxy-basic-sqlite),--enable-proxy --with-sqlite3,--disable-proxy) \
+	--with-openssl="$(STAGING_DIR)/usr" \
+	--disable-server
 endif
 
-ifeq ($(BUILD_VARIANT),gnutls)
-	CONFIGURE_ARGS+= --with-gnutls="$(STAGING_DIR)/usr"
+ifeq ($(BUILD_VARIANT),full)
+
+CONFIGURE_ARGS+= \
+	$(if $(CONFIG_PACKAGE_zabbix-agentd),--enable-agent,--disable-agent) \
+	$(if $(CONFIG_PACKAGE_zabbix-proxy),--enable-proxy,--disable-proxy) \
+	$(if $(CONFIG_PACKAGE_zabbix-server),--enable-server,--disable-server) \
+	$(if $(CONFIG_ZABBIX_GNUTLS),--with-gnutls="$(STAGING_DIR)/usr",--with-gnutls="no") \
+	$(if $(CONFIG_ZABBIX_LDAP),--with-ldap="$(STAGING_DIR)/usr",--with-ldap="no") \
+	$(if $(CONFIG_ZABBIX_MYSQL),--with-mysql,--with-mysql="no") \
+	$(if $(CONFIG_ZABBIX_NETSNMP),--with-net-snmp="$(STAGING_DIR)/usr",--with-net-snmp="no") \
+	$(if $(CONFIG_ZABBIX_OPENSSL),--with-openssl="$(STAGING_DIR)/usr",--with-openssl="no") \
+	$(if $(CONFIG_ZABBIX_POSTGRESQL),--with-postgresql,--with-postgresql="no") \
+	$(if $(CONFIG_ZABBIX_SQLITE),--with-sqlite3,--with-sqlite3="no") \
+  --enable-year2038
+
+ifeq ($(CONFIG_ZABBIX_CURL),y)
+CONFIGURE_ARGS += \
+  --with-libcurl
 endif
 
-else
+ifeq ($(CONFIG_ZABBIX_CURL_GNUTLS),y)
+CONFIGURE_VARS += \
+  ac_cv_path__libcurl_config="/bin/true" \
+  LIBCURL_CPPFLAGS="-I$(STAGING_DIR)/usr/include" \
+  LIBCURL_LDFLAGS="-L$(STAGING_DIR)/usr/lib" \
+  LIBCURL_LIBS="-lcurl-gnutls" \
+  libcurl_cv_lib_curl_usable=yes \
+  libcurl_cv_lib_curl_version=8.14.1 \
+  libcurl_cv_lib_curl_version_ok=yes
+CONFIGURE_ARGS += --with-libcurl="yes"
+endif
+
+ifeq ($(CONFIG_ZABBIX_CURL)$(CONFIG_ZABBIX_CURL_GNUTLS),)
+CONFIGURE_ARGS += \
+  --with-libcurl="no"
+endif
+
+endif
+
+ifeq ($(BUILD_VARIANT),no-configure)
 
 define Build/Configure
 	true
@@ -421,11 +494,11 @@ endef
 # Due to nested defines, eval, and call, the extra spaces for the nested define,
 # and tabs for the part that actually executes in a shell, is essential.
 define Package/zabbix-daemon/files
-        define Package/zabbix-$(1)-$(2)/conffiles
+        define Package/zabbix-$(1)$(2)/conffiles
   /etc/zabbix_$(1).conf
   $(3)
         endef
-        define Package/zabbix-$(1)-$(2)/install
+        define Package/zabbix-$(1)$(2)/install
 		$(INSTALL_DIR) $$(1)/etc/zabbix_$(1).conf.d
 		$(call Package/zabbix/install/sbin,$$(1),$(1))
 		$(4)
@@ -454,30 +527,28 @@ define Package/zabbix-server/install-extra
 	$(INSTALL_BIN) ./files/zabbix_server.defaults $$(1)/etc/uci-defaults/90_zabbix_server
 endef
 
-$(foreach zvariant,nossl openssl gnutls,$(eval $(call Package/zabbix-daemon/files,agentd,$(zvariant),,$(call Package/zabbix-agentd/install-extra))))
-$(foreach zvariant,nossl openssl gnutls,$(eval $(call Package/zabbix-daemon/files,server,$(zvariant),$(call Package/zabbix-server/conffiles-extra),$(call Package/zabbix-server/install-extra))))
-$(foreach zvariant,nossl openssl gnutls,$(eval $(call Package/zabbix-daemon/files,proxy,$(zvariant))))
+$(eval $(call Package/zabbix-daemon/files,agentd,-basic,,$(call Package/zabbix-agentd/install-extra)))
+$(eval $(call Package/zabbix-daemon/files,agentd,,,$(call Package/zabbix-agentd/install-extra)))
+$(eval $(call Package/zabbix-daemon/files,proxy,-basic-sqlite))
+$(eval $(call Package/zabbix-daemon/files,proxy))
+$(eval $(call Package/zabbix-daemon/files,server,,$(call Package/zabbix-server/conffiles-extra),$(call Package/zabbix-server/install-extra)))
+
+define Package/zabbix-server/postinst
+  #!/bin/sh
+  [ -n "$${IPKG_INSTROOT}" ] || (. /etc/uci-defaults/90_zabbix_server) && rm -f /etc/uci-defaults/90_zabbix_server
+  exit 0
+endef
 
 # Due to nested defines, eval, and call, the extra spaces for the nested define
 # is essential.
-define Package/zabbix-server/postinst/Default
-        define Package/zabbix-server-$(1)/postinst
-  #!/bin/sh
-  [ -n "$$$${IPKG_INSTROOT}" ] || (. /etc/uci-defaults/90_zabbix_server) && rm -f /etc/uci-defaults/90_zabbix_server
-  exit 0
-         endef
-endef
-
-$(foreach zvariant,nossl openssl gnutls,$(eval $(call Package/zabbix-server/postinst/Default,$(zvariant))))
-
 define Package/zabbix-program/files
-        define Package/zabbix-$(1)-$(2)/install
+        define Package/zabbix-$(1)/install
 		$(call Package/zabbix/install/bin,$$(1),$(1))
         endef
 endef
 
-$(foreach zvariant,nossl openssl gnutls,$(eval $(call Package/zabbix-program/files,sender,$(zvariant))))
-$(foreach zvariant,nossl openssl gnutls,$(eval $(call Package/zabbix-program/files,get,$(zvariant))))
+$(eval $(call Package/zabbix-program/files,get))
+$(eval $(call Package/zabbix-program/files,sender))
 
 define Package/zabbix-extra-mac80211/install
 	$(call Package/zabbix/install/zabbix.conf.d,$(1),mac80211)
@@ -517,21 +588,15 @@ define Package/zabbix-frontend-server/install
 	$(CP) $(PKG_BUILD_DIR)/ui/* $(1)/www/zabbix
 endef
 
-$(eval $(call BuildPackage,zabbix-agentd-nossl))
-$(eval $(call BuildPackage,zabbix-agentd-openssl))
-$(eval $(call BuildPackage,zabbix-agentd-gnutls))
-$(eval $(call BuildPackage,zabbix-get-nossl))
-$(eval $(call BuildPackage,zabbix-get-openssl))
-$(eval $(call BuildPackage,zabbix-get-gnutls))
-$(eval $(call BuildPackage,zabbix-sender-nossl))
-$(eval $(call BuildPackage,zabbix-sender-openssl))
-$(eval $(call BuildPackage,zabbix-sender-gnutls))
-$(eval $(call BuildPackage,zabbix-proxy-nossl))
-$(eval $(call BuildPackage,zabbix-proxy-openssl))
-$(eval $(call BuildPackage,zabbix-proxy-gnutls))
-$(eval $(call BuildPackage,zabbix-server-nossl))
-$(eval $(call BuildPackage,zabbix-server-openssl))
-$(eval $(call BuildPackage,zabbix-server-gnutls))
+# zabbix compiled variants (configured)
+$(eval $(call BuildPackage,zabbix-agentd))
+$(eval $(call BuildPackage,zabbix-agentd-basic))
+$(eval $(call BuildPackage,zabbix-get))
+$(eval $(call BuildPackage,zabbix-sender))
+$(eval $(call BuildPackage,zabbix-server))
+$(eval $(call BuildPackage,zabbix-proxy))
+$(eval $(call BuildPackage,zabbix-proxy-basic-sqlite))
+# no-configure packages
 $(eval $(call BuildPackage,zabbix-extra-mac80211))
 $(eval $(call BuildPackage,zabbix-extra-network))
 $(eval $(call BuildPackage,zabbix-extra-wifi))

--- a/admin/zabbix/patches/010-change-agentd-config.patch
+++ b/admin/zabbix/patches/010-change-agentd-config.patch
@@ -56,7 +56,7 @@ Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
  
  ##### Active checks related
  
-@@ -164,8 +162,6 @@ Server=127.0.0.1
+@@ -166,8 +164,6 @@ Server=127.0.0.1
  # Default:
  # ServerActive=
  
@@ -65,7 +65,7 @@ Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
  ### Option: Hostname
  #	List of comma delimited unique, case sensitive hostnames.
  #	Required for active checks and must match hostnames as configured on the server.
-@@ -175,8 +171,6 @@ ServerActive=127.0.0.1
+@@ -177,8 +173,6 @@ ServerActive=127.0.0.1
  # Default:
  # Hostname=
  
@@ -74,7 +74,7 @@ Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
  ### Option: HostnameItem
  #	Item used for generating Hostname if it is undefined. Ignored if Hostname is defined.
  #	Does not support UserParameters or aliases.
-@@ -315,7 +309,7 @@ Hostname=Zabbix server
+@@ -317,7 +311,7 @@ Hostname=Zabbix server
  #
  # Mandatory: no
  # Default:
@@ -83,7 +83,7 @@ Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
  
  ####### USER-DEFINED MONITORED PARAMETERS #######
  
-@@ -545,5 +539,5 @@ Hostname=Zabbix server
+@@ -547,5 +541,5 @@ Hostname=Zabbix server
  # Include=
  
  # Include=/usr/local/etc/zabbix_agentd.userparams.conf


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

Using the php8 dependency allows use to go back to using the
+ZABBIX_POSTGRESQL:php8-mod-pgsql (and like dependency for
mysql/mariadb).

This has the benefit of being an apk dependency so the user does not
install the frontend without a php8 database module.

Rather than having a database selection for SQLITE which prevents
the server or frontend from building, we add a 'basic'
variant for the proxy which uses sqlite3, and have the database
Kconfig affect only the server and frontend.

* There are now only three variants:
  1. full, which is the default. It includes the full monitoring feature
     set currently available on openwrt, including netsnmp, curl-based
     checks, and ldap. In addition these features, plus the choice of
     database and ssl provider (or no ssl) are configuration options for
     this variant.
  2. basic, which provides basic functions with openssl support
  3. no-configure, for packages which are not part of the main Zabbix
     compile process (including the WebUI which only requires copying
     files for use by a web server with PHP CGI support).

* Full is the default variant for agentd and proxy, which are the only
  packages with a choice between full and basic. All other packages only
  are part of one variant.

* Full variants are the base version of the packages (that is
  zabbix-agentd is the 'full' version while zabbix-agentd-basic is the
  core version). The proxy version is named zabbix-proxy-basic-sqlite to
  announce that it is using the sqlite3 database and not a database
  server.

* get and sender only build if at least one of agentd, server, or proxy
are built. Therefore prevent selection get or sender when they would not
build.

* Zabbix's use of NetSNMP requires that Zabbix be build with OpenSSL

* While we are here, enable support for dates after 2038 (64-bit time_t).

* https://github.com/openwrt/packages/pull/28585#issuecomment-3984978895
  * we updated the name to reflect that it is for basic functionality
    that can standalone, rather then being a core the other packages
    build on.
  * basic has been used rather than tiny or small since the sentence
    'Provides only tiny/small functionality with SSL/TLS' in the
    description, sounds strange, but using basic this reads properly.

* Finally: Update version to 7.0.23 - latest LTS.

This approach keeps the number packages reasonable (< 15). With a different set of choices in the patch series at <https://gitlab.com/dfd-web/firmware/openwrt-mirrors/packages/-/tree/pr-add-zabbix-variants-and-capabilities?ref_type=heads> the number packages exploded to almost 40. In that series I not only kept the different SSL variants, but made database selection variants instead of a Kconfig options.

Even without that, if we do not make SSL a configuration option, we end up with upwards of 30 packages.

I believe this patch series provides the right balance between features and OpenWrt project resources.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT r33186-85250b94f6
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
