### PR TITLE
smart-reboot: add network-idle aware scheduled reboot utility

### DIFF
--- a/utils/smart-reboot/Makefile
+++ b/utils/smart-reboot/Makefile
@@ -1,0 +1,43 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=smart-reboot
+PKG_VERSION:=1
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Min Choi <3387910@naver.com>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/smart-reboot
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Smart reboot based on network idle state
+  DEPENDS:=+ucode +ucode-mod-uci +ucode-mod-log +ucode-mod-fs +ucode-mod-ubus +ucode-mod-uloop
+  PKGARCH:=all
+endef
+
+define Package/smart-reboot/description
+  Reboot router at configured dawn time window only when monitored interfaces are idle.
+endef
+
+define Package/smart-reboot/conffiles
+/etc/config/smart-reboot
+endef
+
+define Build/Compile
+endef
+
+define Package/smart-reboot/install
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/smart-reboot.config $(1)/etc/config/smart-reboot
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/smart-reboot.init $(1)/etc/init.d/smart-reboot
+
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/smart-reboot.uc $(1)/usr/sbin/smart-reboot
+endef
+
+$(eval $(call BuildPackage,smart-reboot))

--- a/utils/smart-reboot/files/smart-reboot.config
+++ b/utils/smart-reboot/files/smart-reboot.config
@@ -1,0 +1,8 @@
+config settings 'settings'
+	option enabled '0'
+	option window_start '03:00'
+	option window_end '06:00'
+	option check_interval '300'
+	option sample_seconds '60'
+	option threshold_kb '256'
+	list ifaces 'wan'

--- a/utils/smart-reboot/files/smart-reboot.init
+++ b/utils/smart-reboot/files/smart-reboot.init
@@ -1,0 +1,26 @@
+#!/bin/sh /etc/rc.common
+
+START=95
+STOP=10
+USE_PROCD=1
+
+PROG="/usr/sbin/smart-reboot"
+
+start_service() {
+	config_load smart-reboot
+	local enabled
+	config_get enabled settings enabled '0'
+	[ "$enabled" = "1" ] || return 0
+
+	procd_open_instance "smart-reboot"
+	procd_set_param command "$PROG"
+	procd_set_param respawn 3600 5 0
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param pidfile /var/run/smart-reboot.pid
+	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger "smart-reboot"
+}

--- a/utils/smart-reboot/files/smart-reboot.uc
+++ b/utils/smart-reboot/files/smart-reboot.uc
@@ -1,0 +1,320 @@
+#!/usr/bin/ucode
+'use strict';
+
+import * as uci from "uci";
+import * as uloop from "uloop";
+import * as log from "log";
+import * as fs from "fs";
+import * as ubus from "ubus";
+
+const CFG = "smart-reboot";
+const SECTION = "settings";
+const LOCK_FILE = "/var/lock/smart-reboot.lock";
+const STATE_FILE = "/etc/smart-reboot.date";
+
+log.openlog("smart-reboot", log.LOG_PID);
+
+function logger(level, msg) {
+	log.syslog(level, msg);
+}
+
+function parse_hhmm(str, def_h, def_m) {
+	if (!str || type(str) != "string")
+		return { hour: def_h, min: def_m };
+
+	let m = match(str, /^([0-9]{1,2}):([0-9]{1,2})$/);
+	if (!m)
+		return { hour: def_h, min: def_m };
+
+	let h = int(m[1]);
+	let min = int(m[2]);
+
+	if (!(h >= 0 && h <= 23 && min >= 0 && min <= 59))
+		return { hour: def_h, min: def_m };
+
+	return { hour: h, min: min };
+}
+
+function is_in_window(w_start, w_end, now) {
+	let now_m = now.hour * 60 + now.min;
+	let s_m = w_start.hour * 60 + w_start.min;
+	let e_m = w_end.hour * 60 + w_end.min;
+
+	if (s_m <= e_m)
+		return (now_m >= s_m && now_m < e_m);
+	else
+		return (now_m >= s_m || now_m < e_m);
+}
+
+function get_seconds_until(target_hour, target_min, now) {
+	let now_sec = now.hour * 3600 + now.min * 60 + now.sec;
+	let target_sec = target_hour * 3600 + target_min * 60;
+	let diff = target_sec - now_sec;
+
+	if (diff <= 0)
+		diff += 86400;
+
+	return diff;
+}
+
+function resolve_interfaces(u, cfg_ifaces) {
+	if (cfg_ifaces == "all" || (type(cfg_ifaces) == "array" && index(cfg_ifaces, "all") >= 0))
+		return null;
+
+	let resolved = {};
+	let list = [];
+
+	if (type(cfg_ifaces) == "array")
+		list = cfg_ifaces;
+	else if (type(cfg_ifaces) == "string" && length(trim(cfg_ifaces)))
+		list = split(trim(cfg_ifaces), /[ \t\r\n]+/);
+
+	if (length(list)) {
+		for (let name in list) {
+			if (!name)
+				continue;
+
+			if (fs.stat(`/sys/class/net/${name}`)) {
+				resolved[name] = true;
+				continue;
+			}
+
+			if (u) {
+				try {
+					let st = u.call(`network.interface.${name}`, "status");
+					let dev = st?.l3_device || st?.device;
+					if (dev && fs.stat(`/sys/class/net/${dev}`))
+						resolved[dev] = true;
+				} catch (e) {}
+			}
+		}
+		return resolved;
+	}
+
+	if (u) {
+		try {
+			let dump = u.call("network.interface", "dump");
+			for (let iface in dump?.interface || []) {
+				if (iface.up && (iface.interface == "wan" || length(iface.route || []))) {
+					let dev = iface.l3_device || iface.device;
+					if (dev && fs.stat(`/sys/class/net/${dev}`))
+						resolved[dev] = true;
+				}
+			}
+		} catch (e) {}
+	}
+
+	return resolved;
+}
+
+function get_traffic_snapshot(target_devs) {
+	let raw = fs.readfile("/proc/net/dev");
+	if (!raw)
+		return null;
+
+	let snap = {};
+	for (let line in split(raw, "\n")) {
+		let colon = index(line, ":");
+		if (colon < 0)
+			continue;
+
+		let dev = trim(substr(line, 0, colon));
+		if (!length(dev) || dev == "lo")
+			continue;
+
+		if (target_devs && !target_devs[dev])
+			continue;
+
+		let fields = filter(split(trim(substr(line, colon + 1)), /[ \t]+/), length);
+		if (length(fields) < 9)
+			continue;
+
+		let rx = int(fields[0]);
+		let tx = int(fields[8]);
+
+		snap[dev] = {
+			rx: (rx >= 0) ? rx : 0,
+			tx: (tx >= 0) ? tx : 0
+		};
+	}
+	return snap;
+}
+
+function calc_total_delta(snap1, snap2) {
+	let total = 0;
+
+	for (let dev, s1 in snap1) {
+		let s2 = snap2[dev];
+		if (!s2)
+			continue;
+
+		let drx = (s2.rx >= s1.rx) ? (s2.rx - s1.rx) : s2.rx;
+		let dtx = (s2.tx >= s1.tx) ? (s2.tx - s1.tx) : s2.tx;
+		total += (drx + dtx);
+	}
+
+	return total;
+}
+
+function record_auto_reboot(now) {
+	let ts = sprintf("%04d-%02d-%02d %02d:%02d:%02d",
+		now.year, now.mon, now.mday, now.hour, now.min, now.sec);
+	fs.writefile(STATE_FILE, ts);
+}
+
+function run_check(is_cli_force) {
+	let cursor = uci.cursor();
+	let enabled = cursor.get(CFG, SECTION, "enabled");
+
+	if (enabled != "1" && !is_cli_force)
+		return;
+
+	let now = localtime(time());
+
+	if (!is_cli_force && !(now.year >= 2020)) {
+		logger(log.LOG_WARNING, "System clock not synchronized via NTP yet. Retrying in 15s.");
+		uloop.timer(15000, () => run_check(false));
+		return;
+	}
+
+	let raw_start = cursor.get(CFG, SECTION, "window_start");
+	let raw_end = cursor.get(CFG, SECTION, "window_end");
+	let w_start = parse_hhmm(raw_start, 3, 0);
+	let w_end = parse_hhmm(raw_end, (w_start.hour + 3) % 24, w_start.min);
+
+	if (!is_cli_force) {
+		let uptime_raw = fs.readfile("/proc/uptime");
+		if (uptime_raw) {
+			let up_sec = int(split(trim(uptime_raw), " ")[0]);
+			if (!(up_sec >= 300)) {
+				logger(log.LOG_INFO, `Uptime is ${up_sec}s (< 300s). Skipping check to prevent reboot loop.`);
+				uloop.timer(60000, () => run_check(false));
+				return;
+			}
+		}
+
+		let last_reboot = trim(fs.readfile(STATE_FILE) || "");
+		let today_str = sprintf("%04d-%02d-%02d", now.year, now.mon, now.mday);
+		if (last_reboot && index(last_reboot, today_str) == 0) {
+			logger(log.LOG_INFO, `Already rebooted today (${last_reboot}). Waiting for next day window.`);
+			let delay = get_seconds_until(w_start.hour, w_start.min, now);
+			uloop.timer(delay * 1000, () => run_check(false));
+			return;
+		}
+	}
+
+	let sample_sec = int(cursor.get(CFG, SECTION, "sample_seconds") || "60");
+	if (!(sample_sec >= 10))
+		sample_sec = 60;
+
+	let check_int = int(cursor.get(CFG, SECTION, "check_interval") || "300");
+	if (!(check_int >= 10))
+		check_int = 300;
+
+	let threshold_kb = int(cursor.get(CFG, SECTION, "threshold_kb") || "256");
+	if (!(threshold_kb >= 0))
+		threshold_kb = 256;
+	let byte_thresh = threshold_kb * 1024;
+
+	if (!is_cli_force && !is_in_window(w_start, w_end, now)) {
+		let delay = get_seconds_until(w_start.hour, w_start.min, now);
+		logger(log.LOG_INFO, `Outside dawn window (${w_start.hour}:${w_start.min} - ${w_end.hour}:${w_end.min}). Sleeping for ${delay}s.`);
+		uloop.timer(delay * 1000, () => run_check(false));
+		return;
+	}
+
+	let u = null;
+	try {
+		u = ubus.connect();
+	} catch (e) {}
+
+	let target_devs = resolve_interfaces(u, cursor.get(CFG, SECTION, "ifaces"));
+	let dev_names = (target_devs == null) ? "all non-lo" : join(", ", keys(target_devs));
+
+	let snap1 = get_traffic_snapshot(target_devs);
+	if (!snap1 || !length(keys(snap1))) {
+		logger(log.LOG_WARNING, "No target network interfaces active. Retrying in 60s.");
+		if (!is_cli_force)
+			uloop.timer(60000, () => run_check(false));
+		return;
+	}
+
+	logger(log.LOG_INFO, `Sampling traffic on [${dev_names}] for ${sample_sec}s (threshold=${byte_thresh}B)...`);
+
+	if (is_cli_force) {
+		sleep(sample_sec * 1000);
+		let snap2 = get_traffic_snapshot(target_devs);
+		if (!snap2) {
+			logger(log.LOG_ERR, "Failed to capture second traffic snapshot");
+			return;
+		}
+		let delta = calc_total_delta(snap1, snap2);
+		if (delta <= byte_thresh) {
+			logger(log.LOG_INFO, `[TEST MODE] Network IDLE confirmed (delta=${delta}B <= ${byte_thresh}B). System would reboot.`);
+		} else {
+			logger(log.LOG_INFO, `[TEST MODE] Network ACTIVE (delta=${delta}B > ${byte_thresh}B). Reboot skipped.`);
+		}
+		return;
+	}
+
+	uloop.timer(sample_sec * 1000, function() {
+		cursor.unload(CFG);
+		cursor.load(CFG);
+		if (cursor.get(CFG, SECTION, "enabled") != "1") {
+			logger(log.LOG_INFO, "Service disabled during sampling. Aborting reboot.");
+			return;
+		}
+
+		let snap2 = get_traffic_snapshot(target_devs);
+		if (!snap2) {
+			logger(log.LOG_ERR, "Failed to capture second traffic snapshot. Retrying later.");
+			uloop.timer(check_int * 1000, () => run_check(false));
+			return;
+		}
+
+		let delta = calc_total_delta(snap1, snap2);
+
+		if (delta <= byte_thresh) {
+			logger(log.LOG_INFO, `Network idle confirmed (delta=${delta}B <= threshold=${byte_thresh}B). Triggering smart reboot now.`);
+			record_auto_reboot(localtime(time()));
+			system("/bin/sync");
+			system("/sbin/reboot");
+		} else {
+			logger(log.LOG_INFO, `Network active (delta=${delta}B > threshold=${byte_thresh}B). Retrying in ${check_int}s.`);
+			uloop.timer(check_int * 1000, () => run_check(false));
+		}
+	});
+}
+
+function main() {
+	let is_force = false;
+	for (let arg in ARGV) {
+		if (arg == "-f" || arg == "--force" || arg == "check" || arg == "test")
+			is_force = true;
+	}
+
+	let lockfd = fs.open(LOCK_FILE, "w+");
+	if (!lockfd || !lockfd.lock("xn")) {
+		if (is_force)
+			logger(log.LOG_WARNING, "Another smart-reboot instance is already running.");
+		return 0;
+	}
+
+	if (is_force) {
+		logger(log.LOG_INFO, "Running smart-reboot in manual test mode...");
+		run_check(true);
+		lockfd.lock("u");
+		lockfd.close();
+		return 0;
+	}
+
+	uloop.init();
+	run_check(false);
+	uloop.run();
+
+	lockfd.lock("u");
+	lockfd.close();
+	return 0;
+}
+
+exit(main());


### PR DESCRIPTION
This adds `smart-reboot`, a lightweight OpenWrt utility that performs scheduled reboot only when monitored interfaces are considered idle.

### Summary
Add `smart-reboot`, a lightweight OpenWrt daemon that performs scheduled reboots during a configurable dawn time window when network traffic is idle.

### Features
- Procd-managed background service using ucode and `uloop`
- Dawn time window (`window_start` / `window_end`) with periodic retry interval (`check_interval`) on active network traffic
- POSIX-compliant `/proc/net/dev` atomic telemetry and dynamic ubus L3 device resolution
- Failsafe guards (NTP clock sync check, system uptime threshold, and persistent daily single-reboot guard via `/etc/smart-reboot.date`)
- Full LuCI WebUI support via `luci-app-smart-reboot`

## Testing

- Build target: `ipq806x/generic`
- Architecture: `arm_cortex-a15_neon-vfpv4`
- Verified package install and service startup

## Notes

- This PR contains backend package only.
- LuCI frontend is submitted separately in OpenWrt LuCI repository.

Signed-off-by: minicom365 <3387910@naver.com>