### PR TITLE
nginx: fix module depends on nginx

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -199,7 +199,7 @@ define Package/nginx-mod-luci
   SUBMENU:=Web Servers/Proxies
   TITLE:=Support file for Nginx
   URL:=http://nginx.org/
-  DEPENDS:=+uwsgi +uwsgi-luci-support +nginx +nginx-mod-ubus
+  DEPENDS:=nginx +uwsgi +uwsgi-luci-support +nginx-mod-ubus
 endef
 
 define Package/nginx-mod-luci/description
@@ -402,7 +402,7 @@ endef
 define BuildModule
   define Package/nginx-mod-$(1)
     $(call Package/nginx/default)
-    DEPENDS:=+nginx $(2)
+    DEPENDS:=nginx $(2)
     TITLE:=Nginx $(1) module
   endef
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @Ansuel
**Also-mention:** @robimarko @GeorgeSapkin

**Description:**
Closes #28587
nginx: many module recursive dependencies

The solution turns out to be pretty trivial.
Replace the +nginx in the module DEPENDS.

This means the modules do not 'select' nginx, but the do 'depend on' nginx. So nginx is required to install the modules.

This is the same approach taken with PHP8 and #28585 for Zabbix.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT r33092-98e7ed1462
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
