### PR TITLE
chrony: make chrony-hotplug more reliable

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
 PKG_VERSION:=4.8
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://chrony-project.org/releases/

--- a/net/chrony/files/chrony.ntp-hotplug
+++ b/net/chrony/files/chrony.ntp-hotplug
@@ -1,4 +1,25 @@
 #!/bin/sh
+
+# Find interface corresponding to lo device
+IFACE=$(ubus call network.interface dump | \
+            jsonfilter -e '@.interface[@.device="lo"].interface')
+
+# During boot network.interface dump can be empty; try UCI instead
+if [ -z "${IFACE}" ]; then
+    . /lib/functions.sh
+    handle_interface () {
+        local iface="$1"
+        local device
+        config_get device "${iface}" device
+        [ "${device}" = "lo" ] && IFACE=${iface}
+    }
+    config_load network
+    config_foreach handle_interface interface
+fi
+
+[ -z "${IFACE}" ] || \
+    ubus -t 30 wait_for network.interface.${IFACE}
+
 # Wait for sync for up to 5 minutes and notify other services
 
 /usr/bin/chronyc waitsync 300 1 0.0 1 || exit 0


### PR DESCRIPTION
At startup there's a race situation where "chronyc waitsync" (and thus chrony-hotplug) will exit right away because it can't bind to loopback.

This change tries quite hard to make chrony-hotplug wait for loopback to come up before running chronyc.

Fixes #28434.

## 📦 Package Details

**Maintainer:** @mlichvar
**Description:**

---

## 🧪 Run Testing Details

- **OpenWrt Version:** r29103-46f9fc3b71
- **OpenWrt Target/Subtarget:** ipq40xx/generic
- **OpenWrt Device:** AVM FRITZ!Box 7530

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.