### PR TITLE
tor: update to 0.4.9.5 stable

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.8.22
+PKG_VERSION:=0.4.9.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=c88620d9278a279e3d227ff60975b84aa41359211f8ecff686019923b9929332
+PKG_HASH:=c949c2f86b348e64891976f6b1e49c177655b23df97193049bf1b8cd3099e179
 PKG_MAINTAINER:=Rui Salvaterra <rsalvaterra@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE

--- a/net/tor/patches/001-torrc.patch
+++ b/net/tor/patches/001-torrc.patch
@@ -18,7 +18,7 @@
  
  ## The port on which Tor will listen for local connections from Tor
  ## controller applications, as documented in control-spec.txt.
-@@ -251,3 +251,4 @@
+@@ -255,3 +255,4 @@
  ## The %include option can be used recursively.
  #%include /etc/torrc.d/*.conf
  


### PR DESCRIPTION
First stable release of the 0.4.9.x series, see the changelog [1] for what's new.

[1] https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.5/ChangeLog

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>