### PR TITLE
liburing: update to v2.14

### DIFF
--- a/libs/liburing/Makefile
+++ b/libs/liburing/Makefile
@@ -1,12 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=liburing
-PKG_VERSION:=2.7
+PKG_VERSION:=2.14
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=https://git.kernel.dk/cgit/liburing/snapshot
-PKG_HASH:=cc5268f97d089bc21d3d5848959e6620b2dfc85023b92479dad0496b2c51df06
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/axboe/$(PKG_NAME)/tar.gz/$(PKG_NAME)-$(PKG_VERSION)?
+PKG_HASH:=5f80964108981c6ad979c735f0b4877d5f49914c2a062f8e88282f26bf61de0c
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Christian Lachner <gladiac@gmail.com>
 PKG_LICENSE:=MIT
@@ -32,7 +33,7 @@ define Package/liburing/description
   For more info on io_uring, please see: https://kernel.dk/io_uring.pdf
 endef
 
-CONFIGURE_ARGS:=--prefix=$(CONFIGURE_PREFIX) --cc="${TARGET_CC}"
+CONFIGURE_ARGS:=--prefix=$(CONFIGURE_PREFIX) --cc="${TARGET_CC}" --use-libc
 
 define Build/Compile
 	$(MAKE) $(PKG_BUILD_DIR) \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @gladiac

**Description:**
- Updated download URL and hash
- Switched to GitHub mirror
- Adapted configure parameters to fix build errors
- See changes: https://github.com/axboe/liburing/releases/tag/liburing-2.14

---

## 🧪 Run Testing Details

- **OpenWrt Version:** Master
- **OpenWrt Target/Subtarget:** Mediatek MT798x
- **OpenWrt Device:** GL.iNet GL-MT6000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.