### PR TITLE
modbus: update to 3.1.12

### DIFF
--- a/libs/libmodbus/Makefile
+++ b/libs/libmodbus/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmodbus
-PKG_VERSION:=3.1.11
+PKG_VERSION:=3.1.12
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/stephane/libmodbus/releases/download/v$(PKG_VERSION)/
-PKG_HASH:=a7a2c4f6e7e3c9bd49a574e9f30f6f87b8f162a58c7a67cb1c75470991b7680a
+PKG_HASH:=2f4d4191cd196c1fba131daec03b621db75129d8255c832fc66b259d9fc46e7b
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 


### PR DESCRIPTION
Update modbus to version 3.1.12 in order to fix the current breakage in buildbot. Apparently PR #28573 for 3.1.11 has somehow misfired, but luckily there is a new upstream release.

(current faillog: https://downloads.openwrt.org/snapshots/faillogs/arm_cortex-a9/packages/libmodbus/compile.txt )

Release notes:
https://github.com/stephane/libmodbus/releases/tag/v3.1.12

-  Fix FD_SET overflow when socket fd >= FD_SETSIZE.
-  Check dest pointer not null and nb in read functions.
-  NULL check for src and nb < 1 validation in write functions.
-  modbus_reply: don't compute address for FC 0x07/0x11.
-  Use O_NONBLOCK instead of deprecated O_NDELAY.
-  Explicit cast for Coverity CID 416366.
-  Document required buffer size of modbus_receive.
-  Document macros for error codes corresponding to Modbus exceptions.
-  Fix example of modbus_rtu_set_serial_mode.
-  Test filesystem provides symlink in autogen.sh.
-  Sync API signatures with the documentation.
-  Many documentation fixes and typo corrections.
-  Add coverage target and helper script.

## 📦 Package Details

**Maintainer:** @mhei 

Compile-tested with mediatek/RT3200
