### PR TITLE
acpid: prevent duplicate daemon instances

### DIFF
--- a/utils/acpid/Makefile
+++ b/utils/acpid/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acpid
 PKG_VERSION:=2.0.34
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/acpid2

--- a/utils/acpid/files/acpid.hotplug
+++ b/utils/acpid/files/acpid.hotplug
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-. /lib/functions.sh
-
 if [ "$ACTION" = add ] && [ "$DEVICENAME" = event0 ]; then
-        ( /etc/init.d/acpid/stop; sleep 3; /usr/sbin/acpid )&
+	/etc/init.d/acpid start
 fi

--- a/utils/acpid/files/acpid.init
+++ b/utils/acpid/files/acpid.init
@@ -12,6 +12,7 @@ start_service() {
 	procd_append_param command -f
 	procd_append_param command -S
 	procd_set_param pidfile "/var/run/acpid.pid"
+	procd_close_instance
 }
 
 reload_service() {


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @heil @neheb 

**Description:**
The hotplug script directly invokes /usr/sbin/acpid. If hotplug fires before procd starts acpid, it cannot stop the procd-managed instance, resulting in a second unmanaged acpid process running alongside it.

Fix this issue by letting ONLY procd manage the acpi daemon.

---

## 🧪 Run Testing Details

- **OpenWrt Target/Subtarget:** x86/64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
