### PR TITLE
gpsd: add wrapper script for hotplug/respawn handling

### DIFF
--- a/utils/gpsd/Makefile
+++ b/utils/gpsd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gpsd
 PKG_VERSION:=3.26.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SAVANNAH/$(PKG_NAME)
@@ -141,6 +141,7 @@ define Package/gpsd/install
 	$(INSTALL_BIN) ./files/gpsd.init $(1)/etc/init.d/gpsd
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/gpsd $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/usr/sbin/gpsd-wrapper $(1)/usr/sbin/
 
 	$(INSTALL_DIR) $(1)/etc/gpsd
 	$(INSTALL_BIN) ./files/etc/gpsd/device-hook $(1)/etc/gpsd/

--- a/utils/gpsd/files/gpsd.init
+++ b/utils/gpsd/files/gpsd.init
@@ -3,8 +3,9 @@
 START=50
 
 USE_PROCD=1
-PROG=/usr/sbin/gpsd
+PROG=/usr/sbin/gpsd-wrapper
 NAME=gpsd
+SOCKET=/var/run/gpsd.sock
 
 LOG_LEVEL="0"
 
@@ -36,7 +37,7 @@ gpsd_instance()
 	procd_append_param command -S "$port"
 	procd_append_param command -D "$LOG_LEVEL"
 	[ "$readonly" = "1" ] && procd_append_param command -b
-	procd_append_param command -F /var/run/gpsd.sock
+	procd_append_param command -F "$SOCKET"
 	for device in $devices; do
 		procd_append_param command "$device"
 	done
@@ -54,13 +55,4 @@ start_service()
 service_triggers() {
 	procd_add_reload_trigger "$NAME"
 	procd_add_validation validate_section_gpsd
-}
-
-service_started() {
-	local enabled
-
-	enabled="$(uci_get gpsd core enabled 0)"
-	[ "$enabled" = "0" ] && return
-
-	env -i ACTION="STARTED" /sbin/hotplug-call gpsd
 }

--- a/utils/gpsd/files/usr/sbin/gpsd-wrapper
+++ b/utils/gpsd/files/usr/sbin/gpsd-wrapper
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+SOCKET="/var/run/gpsd.sock"
+
+trap_with_arg() {
+	func="$1" ; shift
+	for sig; do
+		# shellcheck disable=SC2064
+		trap "$func $sig" "$sig"
+	done
+}
+
+func_trap() {
+	logger -t "gpsd-wrapper[$$]" "Sending signal ${1}..."
+	kill "-${1}" "$CHILD" 2>/dev/null
+}
+
+wait_for_socket_and_hotplug() {
+	local count=0
+	while [ $count -lt 15 ]; do
+		[ -S "$SOCKET" ] && break
+		sleep 1
+		count=$((count + 1))
+	done
+
+	if [ -S "$SOCKET" ]; then
+		logger -t "gpsd-wrapper[$$]" "Socket ready, sending hotplug call"
+		env -i ACTION="STARTED" /sbin/hotplug-call gpsd
+	else
+		logger -t "gpsd-wrapper[$$]" \
+			"Socket $SOCKET not ready after ${count}s, hotplug skipped"
+	fi
+}
+
+main() {
+	trap_with_arg func_trap INT TERM KILL
+
+	/usr/sbin/gpsd "$@" &
+	CHILD="$!"
+
+	wait_for_socket_and_hotplug
+
+	wait "$CHILD"
+}
+
+main "$@"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @psidhu (MIA)
CC: @PolynomialDivision @BKPepe  @feckert 

**Description:**
Gpsd needs some time to create its Unix socket after the process starts. The hotplug call in service_started() is triggered too early, before the socket is ready, causing failures in scripts that depend on it.

Additionally, when gpsd crashes and procd respawns it, service_started() is not called again, so no hotplug event is emitted on respawn. Therefore scripts listening for gpsd availability miss the STARTED event.

This pr ensures the hotplug call waits for the socket to appear, so dependent scripts reliably see the STARTED event, even after respawns.

---

## 🧪 Run Testing Details

- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** bananapi_r4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.