### PR TITLE
fail2ban: Add host build deps to fix #28520

### DIFF
--- a/net/fail2ban/Makefile
+++ b/net/fail2ban/Makefile
@@ -18,6 +18,10 @@ PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:fail2ban:fail2ban
 
+PKG_BUILD_DEPENDS:= \
+	python3/host \
+	python-setuptools/host
+
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @<github-user>
<sub>Undefined</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Adds the misssing build dependencies to remove `Cannot import 'setuptools.build_meta'` build error with 25.12.0-rc1 to 25.12.0-rc5
---

## 🧪 Run Testing Details

- **OpenWrt Version:25.12.0-rc5**
- **OpenWrt Target/Subtarget:ipq40xx/generic**
- **OpenWrt Device:Linksys WHW03 V2**

---

## ✅ Formalities

- [x ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
