### PR TITLE
tailscale: fix fw_mode env is missed

### DIFF
--- a/net/tailscale/Makefile
+++ b/net/tailscale/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
 PKG_VERSION:=1.94.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?

--- a/net/tailscale/files/tailscale.init
+++ b/net/tailscale/files/tailscale.init
@@ -31,7 +31,7 @@ start_service() {
   procd_set_param env TS_DEBUG_FIREWALL_MODE="$fw_mode"
 
   # Disable logging to log.tailscale.com
-  procd_set_param env TS_NO_LOGS_NO_SUPPORT=true
+  procd_append_param env TS_NO_LOGS_NO_SUPPORT=true
 
   # Set the port to listen on for incoming VPN packets.
   # Remote nodes will automatically be informed about the new port number,


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @mochaaP 
fix fw_mode env is missed

**Description:**
09c14817 break "fw_mode" env, fix it by appending it.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Xiaomi Redmi Router AX6000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
