### PR TITLE
nordvpnlite: add new package

### DIFF
--- a/net/nordvpnlite/Makefile
+++ b/net/nordvpnlite/Makefile
@@ -1,0 +1,82 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nordvpnlite
+PKG_VERSION:=0.1.0
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/NordSecurity/libtelio.git
+PKG_SOURCE_VERSION:=nordvpnlite/v$(PKG_VERSION)
+PKG_MIRROR_HASH:=f1bb174bc87248981f5852ed500f016689177a9987813505d10b1677bffb0572
+
+MAKE_PATH:=clis/nordvpnlite
+
+PKG_MAINTAINER:=Lukas Pukenis <lukas.pukenis@nordsec.com>, \
+	Oleksandr Oliinyk <oleksandr.oliinyk@nordsec.com>, \
+	Tomasz Grzegowski <tomasz.grzegowski@nordsec.com>
+PKG_LICENSE:=GPL-3.0-only
+PKG_LICENSE_FILES:=LICENSE clis/nordvpnlite/openwrt/feed/net/nordvpnlite/THIRD-PARTY-NOTICES
+PKG_BUILD_DEPENDS:=rust/host protobuf/host
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+# Upstream build.rs checks for git hooks which don't exist in the build directory
+CARGO_PKG_VARS += BYPASS_LLT_SECRETS=1
+# Short commit hash for the nordvpnlite/v0.1.0 tag
+CARGO_PKG_VARS += LIBTELIO_COMMIT_SHA=8dabaf3
+
+define Package/nordvpnlite
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=NordVPN Lite
+  URL:=https://www.nordsecurity.com
+  DEPENDS:=$(RUST_ARCH_DEPENDS) @!i386 +kmod-tun +kmod-wireguard
+endef
+
+define Package/nordvpnlite/description
+  NordVPN Lite is the gateway to a secure and private access to the internet.
+endef
+
+define Package/nordvpnlite/conffiles
+/etc/nordvpnlite/config.json
+endef
+
+define Package/nordvpnlite/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/nordvpnlite $(1)/usr/sbin/
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/nordvpnlite.init \
+		$(1)/etc/init.d/nordvpnlite
+
+	$(INSTALL_DIR) $(1)/etc/nordvpnlite
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/config.json \
+		$(1)/etc/nordvpnlite/config.json
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/nordvpnlite.conf \
+		$(1)/etc/config/nordvpnlite
+endef
+
+define Package/nordvpnlite/postinst
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	echo "Enabling nordvpnlite service"
+	/etc/init.d/nordvpnlite enable
+fi
+exit 0
+endef
+
+define Package/nordvpnlite/prerm
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	echo "Disabling nordvpnlite service"
+	/etc/init.d/nordvpnlite disable
+fi
+exit 0
+endef
+
+$(eval $(call RustBinPackage,nordvpnlite))
+$(eval $(call BuildPackage,nordvpnlite))

--- a/net/nordvpnlite/test.sh
+++ b/net/nordvpnlite/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+case "$1" in
+    "nordvpnlite")
+        nordvpnlite --version 2>&1 | grep "$2"
+        ;;
+esac


### PR DESCRIPTION
NordVPN Lite is a lightweight, standalone VPN client built around the libtelio library.

## 📦 Package Details

**Maintainer:** @olekoliinyk

**Description:**
Lightweight standalone VPN client built around [libtelio](https://github.com/NordSecurity/libtelio), NordSecurity's open-source networking library. 
Uses WireGuard for secure VPN connectivity. 
Designed for embedded and resource-constrained environments.

### Build notes

- Built from the libtelio monorepo using the `nordvpnlite/v0.1.0` tag
- `PKG_SOURCE_PROTO:=git` is used because nordvpnlite is a subdirectory
  of the libtelio monorepo 
- `BYPASS_LLT_SECRETS=1` is required because upstream's `build.rs`
  checks for git hooks which don't exist in the build directory
- `protobuf/host` is needed because libtelio workspace dependencies
  include protobuf-based crates
- Config files and init script are sourced from the upstream repo
  (`clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/`)

### Documentation

Full usage instructions and configuration guide:
https://github.com/NordSecurity/libtelio/tree/main/clis/nordvpnlite

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master (snapshot), 24.10
- **OpenWrt Target/Subtarget:** mediatek/filogic, ramips/mt76x8
- **OpenWrt Device:** GL.iNet GL-MT6000 (aarch64_cortex-a53), mipsel_24kc device

### Testing performed

- [x] Compiled successfully on `master` (aarch64_cortex-a53, mipsel_24kc)
- [x] Compiled successfully on `openwrt-24.10` (aarch64_cortex-a53)
- [x] Binary installs and runs correctly
- [x] Init script starts/stops the service via procd
- [x] Config files install to correct locations
- [x] `make package/nordvpnlite/check V=s` passes
- [x] Tested on real hardware

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
