### PR TITLE
collectd: remove redundant liblua link flag

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -232,8 +232,7 @@ $(call Package/collectd/Default)
   DEPENDS:= +libpthread \
 	  +zlib \
 	  +libltdl \
-	  +jshn \
-	  +PACKAGE_collectd-mod-lua:liblua
+	  +jshn
   MENU:=1
 endef
 
@@ -271,11 +270,6 @@ CONFIGURE_VARS+= \
 	CFLAGS="$$$$CFLAGS $(FPIC)" \
 	LDFLAGS="$$$$LDFLAGS -lm -lz" \
 	KERNEL_DIR="$(LINUX_DIR)"
-
-ifneq ($(CONFIG_PACKAGE_collectd-mod-lua),)
-CONFIGURE_VARS+= \
-	LDFLAGS="$$$$LDFLAGS -llua"
-endif
 
 ifneq ($(CONFIG_PACKAGE_COLLECTD_ENCRYPTED_NETWORK),)
 CONFIGURE_ARGS+= \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jow- @hnyman

**Description:**
The link flag makes the main program depend on liblua in official package feeds, even if collectd-mod-lua is not installed. The plugin is already linked against liblua.so, so this can be removed.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**  r33209-ba57225066
- **OpenWrt Target/Subtarget:** mediatek/mt7622
- **OpenWrt Device:** Xiaomi Redmi Router AX6S

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.