### PR TITLE
netbird: strip debug symbols to reduce size

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -18,7 +18,9 @@ PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/netbirdio/netbird
 GO_PKG_BUILD_PKG:=$(GO_PKG)/client
+GO_PKG_LDFLAGS:=-s -w
 GO_PKG_LDFLAGS_X:=$(GO_PKG)/version.version=$(PKG_VERSION)
+GO_PARAMS_EXTRA:=-trimpath
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
@@ -48,6 +50,7 @@ define Package/netbird/install
 	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/etc/init.d
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/client $(1)/usr/bin/netbird
+	strip --strip-all $(1)/usr/bin/netbird
 	$(INSTALL_BIN) ./files/netbird.init $(1)/etc/init.d/netbird
 endef
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @wehagy

**Description:** Changes the build flags to strip debug symbols, to reduce the binary size so that the package can be installed on consumer routers with limited flash storage.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.0-rc5
- **OpenWrt Target/Subtarget:** ath79/generic
- **OpenWrt Device:** TP-Link Archer C7 v5

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
