### PR TITLE
miniupnpd: add config support for ext_allow_private_ipv4

### DIFF
--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -61,7 +61,7 @@ upnpd() {
 	local external_iface external_iface6 external_zone external_ip internal_iface
 	local upload download log_output port config_file serial_number model_number
 	local use_stun stun_host stun_port uuid notify_interval presentation_url
-	local upnp_lease_file upnp_lease_file6 ipv6_disable
+	local upnp_lease_file upnp_lease_file6 ipv6_disable external_allow_private_ipv4
 
 	local enabled
 	config_get_bool enabled config enabled 1
@@ -88,6 +88,7 @@ upnpd() {
 	config_get upnp_lease_file config upnp_lease_file
 	config_get upnp_lease_file6 config upnp_lease_file6
 	config_get ipv6_disable config ipv6_disable 0
+	config_get_bool external_allow_private_ipv4 config external_allow_private_ipv4 0
 
 	local conf ifname ifname6
 
@@ -140,6 +141,7 @@ upnpd() {
 		upnpd_write_bool igdv1 0 force_igd_desc_v1
 		upnpd_write_bool use_stun 0 ext_perform_stun
 		upnpd_write_bool ipv6_disable $ipv6_disable
+		upnpd_write_bool external_allow_private_ipv4 0 ext_allow_private_ipv4
 
 		[ "$use_stun" -eq 0 ] || {
 			[ -n "$stun_host" ] && echo "ext_stun_host=$stun_host"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** "common packages maintainers" (according to https://openwrt.org/packages/pkgdata/miniupnpd-nftables)

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Currently miniupnpd defaults to disable forwarding if it detects wan ipv4 is private address. A miniupnpd config called `ext_allow_private_ipv4` exists which enables forwarding in the above case. Add parsing to init script so that uci config can enable this option.

Sidenotes: This is my 1st commit to openwrt, I read the contribution guide, but there appears to be a two-line signoffs caused by github, which I don't know how to circumvent. Feel free to tell me where's wrong.

Hope it can get into v25.12, but also fine otherwise.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12.0-rc5
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
