### PR TITLE
fix #28639 with procd_add_jail_mount for default geoip paths

### DIFF
--- a/net/snowflake/files/snowflake-proxy.init
+++ b/net/snowflake/files/snowflake-proxy.init
@@ -17,6 +17,9 @@ start_service() {
 	[ -x /sbin/ujail ] && {
 		procd_add_jail snowflake-proxy ronly
 		procd_add_jail_mount /etc/ssl/certs
+		# change the following if specifying non default paths with the -geoipdb or -geoip6db command parameters 
+		procd_add_jail_mount /usr/share/tor/geoip
+		procd_add_jail_mount /usr/share/tor/geoip6
 		procd_set_param no_new_privs 1
 	}
 	procd_close_instance


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @PolynomialDivision

**Description:**
Allows jailed process to read geoip files
---

## 🧪 Run Testing Details

- **25.12.0-rc5**
- **mediatek/filogic**
- **OpenWrt One**

---

## ✅ Formalities

- [ y] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ y] It is structured in a way that it is potentially upstreamable