### PR TITLE
lxc: update to 6.0.6

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
-PKG_VERSION:=6.0.5
-PKG_RELEASE:=2
+PKG_VERSION:=6.0.6
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/
-PKG_HASH:=2e540c60b9dd49e7ee1a4efa5e9c743b05df911b81b375ed5043d9dd7ee0b48a
+PKG_HASH:=b0ba4537258d2b848fd07dedb1044dab132de3fb3f1976d240da40a7dee1b8cf
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=LGPL-2.1-or-later BSD-2-Clause GPL-2.0

--- a/utils/lxc/patches/030-start-re-introduce-first-SET_DUMPABLE-call.patch
+++ b/utils/lxc/patches/030-start-re-introduce-first-SET_DUMPABLE-call.patch
@@ -15,7 +15,7 @@ Signed-off-by: Stéphane Graber <stgraber@stgraber.org>
 
 --- a/src/lxc/start.c
 +++ b/src/lxc/start.c
-@@ -1130,6 +1130,11 @@ static int do_start(void *data)
+@@ -1127,6 +1127,11 @@ static int do_start(void *data)
  		if (ret < 0)
  			goto out_warn_father;
  


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @ratkaj
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

6.0.5 is a bug fix release, see:
https://discuss.linuxcontainers.org/t/lxc-6-0-6-lts-has-been-released/26294

Full changelog: https://github.com/lxc/lxc/compare/v6.0.5...v6.0.6

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** Intel N150 based PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
