### PR TITLE
mstflint: update to 4.35.0-1

### DIFF
--- a/utils/mstflint/Makefile
+++ b/utils/mstflint/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mstflint
-PKG_VERSION:=4.34.1
-PKG_SUBVERSION:=4
+PKG_VERSION:=4.35.0
+PKG_SUBVERSION:=1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SUBVERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Mellanox/$(PKG_NAME)/releases/download/v$(PKG_VERSION)-$(PKG_SUBVERSION)
-PKG_SOURCE_DATE:=2026-01-29
-PKG_HASH:=3316ccaca1942f3e012fd9c45aa4f904e3d5e8a6794a5b4a69a06ee08da85e89
+PKG_SOURCE_DATE:=2026-02-22
+PKG_HASH:=a138686f9298cd057371bc9bb2673e97b5b3e4b022b91ce1f6538533664c112d
 
 PKG_MAINTAINER:=Til Kaiser <mail@tk154.de>
 PKG_LICENSE:=GPL-2.0-only
@@ -133,6 +133,7 @@ define Package/mstflint/install
 ifeq ($(CONFIG_PACKAGE_MSTFLINT_INCLUDE_PYTHON),y)
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstfwreset $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstfwtrace $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstgenerate_pgcb_commands $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstprivhost $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstresourcedump $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstresourceparse $(1)/usr/bin/

--- a/utils/mstflint/patches/0001-fwctrl-replace-__uint32_t-with-__u32.patch
+++ b/utils/mstflint/patches/0001-fwctrl-replace-__uint32_t-with-__u32.patch
@@ -1,0 +1,30 @@
+From 630513e058a321b32d691a6a765a218bcc00b5fa Mon Sep 17 00:00:00 2001
+From: Til Kaiser <mail@tk154.de>
+Date: Thu, 26 Feb 2026 15:25:05 +0100
+Subject: [PATCH] fwctrl: replace __uint32_t with __u32
+
+musl doesn't provide __uint32_t, so compilation
+fails when building with musl.
+
+This header already uses Linux UAPI types, so use __u32 here too.
+
+Signed-off-by: Til Kaiser <mail@tk154.de>
+---
+ include/mtcr_ul/fwctrl_ioctl.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/include/mtcr_ul/fwctrl_ioctl.h
++++ b/include/mtcr_ul/fwctrl_ioctl.h
+@@ -153,9 +153,9 @@ struct fwctl_rpc {
+ struct mlx5_umem_buff {
+ 	void *buff;
+ 	size_t size;
+-	__uint32_t umem_id;
+-	__uint32_t umem_mkey;
+-	__uint32_t rsc_id;
++	__u32 umem_id;
++	__u32 umem_mkey;
++	__u32 rsc_id;
+ };
+ 
+ struct fwctl_rsc_umem_reg {


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @tk154 

**Description:**
This commit updates the `mstflint` package to the latest 4.35.0-1 release.
It also includes a patch to fix a build error that has been merged into their development branch [1] but is not inside the current release version.
Additionally, the new Python script `mstgenerate_pgcb_commands` introduced in 4.35.0 has been added to the package.

Release notes:
https://github.com/Mellanox/mstflint/releases/tag/v4.35.0-1

[1] https://github.com/Mellanox/mstflint/pull/1568

---

## 🧪 Run Testing Details

- **OpenWrt Version:** Snapshot
- **OpenWrt Target/Subtarget:** `x86/64`
- **OpenWrt Device:** Mellanox Spectrum, Gowin BS-1UR2-25G

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable