### PR TITLE
openvpn: handle ovpnproto exclusively

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.6.14
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/etc/uci-defaults/60_openvpn_migrate.sh
+++ b/net/openvpn/files/etc/uci-defaults/60_openvpn_migrate.sh
@@ -1,48 +1,55 @@
 #!/bin/sh
 
-OPENVPN_PKG="openvpn"
-NETWORK_PKG="network"
+OPENVPN_PKG="/etc/config/openvpn"
+NETWORK_PKG="/etc/config/network"
 
-# Exit if no openvpn config exists
-uci -q show "$OPENVPN_PKG" >/dev/null || exit 0
+[ -f "$OPENVPN_PKG" ] || exit 0
 
-uci batch <<EOF
-$(
+awk '
+function section_exists(name) {
+	cmd = "uci -q get network." name " >/dev/null 2>&1"
+	return (system(cmd) == 0)
+}
 
-# Find named openvpn sections
-uci show "$OPENVPN_PKG" | \
-sed -n "s/^$OPENVPN_PKG\.\\([^=]*\\)=openvpn$/\\1/p" | \
-while read -r sec; do
-	iface="$sec"
+BEGIN {
+	in_section=0
+	secname = ""
+}
 
-	# Skip if interface already exists
-	uci -q get $NETWORK_PKG.$iface >/dev/null && continue
+/^config[ \t]+openvpn[ \t]+/ {
+	# get section name
+	secname = $3
+	gsub(/'\''/, "", secname)
 
-	# Create interface in network 
-	echo "set $NETWORK_PKG.$iface=interface"
-	# Set the interface protocol to 'openvpn'
-	echo "set $NETWORK_PKG.$iface.proto='openvpn'"
+	if (section_exists(secname)) {
+		in_section=0
+		next
+	}
 
-	# Copy options, skipping the section header
-	uci show "$OPENVPN_PKG.$sec" | \
-	while IFS='=' read -r key val; do
-		case "$key" in
-			# section declaration: openvpn.vpn0=openvpn
-			"$OPENVPN_PKG.$sec") continue ;;
-			"$OPENVPN_PKG.$sec.proto")
-				echo "set $NETWORK_PKG.$iface.ovpnproto=$val"
-				continue
-				;;
-		esac
+	in_section=1
 
-		opt="${key##*.}"
+	sub(/^config[ \t]+openvpn/, "config interface")
+	print
+	print "\toption proto '\''openvpn'\''"
+	next
+}
 
-		echo "set $NETWORK_PKG.$iface.$opt=$val"
-	done
-done
+# Start of another section
+/^config[ \t]+/ {
+	in_section=0
+}
 
-echo "commit $NETWORK_PKG"
-)
-EOF
+# Inside openvpn section, rename proto
+in_section && /^[ \t]*option[ \t]+proto[ \t]/ {
+	sub(/option[ \t]+proto/, "option ovpnproto")
+	print
+	next
+}
+
+# Inside openvpn section; copy as-is
+in_section {
+	print
+}
+' "$OPENVPN_PKG" >> "$NETWORK_PKG"
 
 exit 0

--- a/net/openvpn/files/lib/netifd/proto/openvpn.sh
+++ b/net/openvpn/files/lib/netifd/proto/openvpn.sh
@@ -152,9 +152,11 @@ proto_openvpn_setup() {
 	# ${tls_exit:+--tls-exit} \
 
 	json_get_var dev_type dev_type
+	json_get_var ovpnproto ovpnproto
 	# shellcheck disable=SC2086
 	proto_run_command "$config" openvpn \
 		$([ -z "$dev_type" ] && echo " --dev-type tun") \
+		$([ -z "$ovpnproto" ] && echo " --proto $ovpnproto") \
 		--cd "$cd_dir" \
 		--status "/var/run/openvpn.$config.status" \
 		--syslog "openvpn_$config" \

--- a/net/openvpn/files/lib/netifd/proto/openvpn.uc
+++ b/net/openvpn/files/lib/netifd/proto/openvpn.uc
@@ -79,7 +79,6 @@ const OPENVPN_STRING_PARAMS = [
 	{ name: 'mark' },
 	{ name: 'mode' },
 	{ name: 'mtu_disc' },
-	{ name: 'ovpnproto' },
 	{ name: 'peer_fingerprint' },
 	{ name: 'pkcs11_id' },
 	{ name: 'pkcs11_providers' },
@@ -360,6 +359,9 @@ function build_exec_params(cfg) {
 					add_param(params, k.name, item);
 		}
 	}
+
+	if (cfg['ovpnproto'])
+		add_param(params, 'proto', cfg['ovpnproto']);
 
 	return params;
 }

--- a/net/openvpn/files/openvpn.options
+++ b/net/openvpn/files/openvpn.options
@@ -65,7 +65,6 @@ management_external_key
 mark
 mode
 mtu_disc
-ovpnproto
 peer_fingerprint
 pkcs11_id
 pkcs11_providers


### PR DESCRIPTION
Since proto was migrated to ovpnproto to avoid collision with netifd proto, this shall be handled separately.

follow-up to 2607b761549a4793eff91dcb60a287c05f631846

Addresses problems in #28533 and #28657