### PR TITLE
mdio-netlink: do not select KCONFIG

### DIFF
--- a/kernel/mdio-netlink/Makefile
+++ b/kernel/mdio-netlink/Makefile
@@ -22,7 +22,7 @@ define KernelPackage/mdio-netlink
   CATEGORY:=Kernel modules
   SUBMENU:=Network Support
   TITLE:=mdio-netlink Linux MDIO netlink kernel module
-  KCONFIG:=CONFIG_PHYLIB=y CONFIG_MDIO_BUS=y
+  DEPENDS:=+kmod-libphy
   URL:=https://github.com/wkz/mdio-tools.git
   FILES:=$(PKG_BUILD_DIR)/kernel/mdio-netlink.ko
   AUTOLOAD:=$(call AutoProbe,mdio-netlink)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @robimarko @dmascord

**Description:**
mdio-netlink is forcing all targets in buildbot to build PHY and MDIO support. Convert the dependency into the PHYLIB kmod to avoid that.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** TBD
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.