### PR TITLE
[24.10] adblock-fast: update to 1.2.2-r8

### DIFF
--- a/net/adblock-fast/Makefile
+++ b/net/adblock-fast/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=6
+PKG_RELEASE:=8
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=AGPL-3.0-or-later
 

--- a/net/adblock-fast/files/etc/init.d/adblock-fast
+++ b/net/adblock-fast/files/etc/init.d/adblock-fast
@@ -15,7 +15,7 @@ if type extra_command 1>/dev/null 2>&1; then
 	extra_command 'check_lists' 'Checks if specified domain is found in enabled block-lists'
 	extra_command 'dl' 'Force-downloads all enabled block-list'
 	extra_command 'killcache' 'Delete all cached files'
-	extra_command 'pause' 'Pauses ad-blocking for specified number of seconds (default: 60)'
+	extra_command 'pause' 'Pauses ad-blocking for specified number of seconds (default: 20)'
 	extra_command 'show_blocklist' 'List currently blocked domains'
 	extra_command 'sizes' 'Displays the file-sizes of configured block-lists'
 	extra_command 'version' 'Show version information'
@@ -108,7 +108,7 @@ load_validate_config() {
 		'config_update_enabled:bool:0' \
 		'config_update_url:string:https://cdn.jsdelivr.net/gh/openwrt/packages/net/adblock-fast/files/adblock-fast.config.update' \
 		'download_timeout:range(1,60):20' \
-		'pause_timeout:range(1,60):20' \
+		'pause_timeout:range(1,600):20' \
 		'curl_additional_param:or("", string)' \
 		'curl_max_file_size:or("", uinteger)' \
 		'curl_retry:range(0,30):3' \

--- a/net/adblock-fast/files/lib/adblock-fast/adblock-fast.uc
+++ b/net/adblock-fast/files/lib/adblock-fast/adblock-fast.uc
@@ -234,6 +234,24 @@ function mkdir_p(path) {
 	return mkdir(path) != null;
 }
 
+function move_file(src, dst) {
+	if (rename(src, dst) == true) return true;
+	// rename failed (possibly cross-filesystem); fall back to copy + unlink
+	let src_f = open(src, 'r');
+	if (!src_f) return false;
+	let dst_f = open(dst, 'w');
+	if (!dst_f) { src_f.close(); return false; }
+	let ok = true, chunk;
+	while ((chunk = src_f.read(65536)) && length(chunk)) {
+		if (dst_f.write(chunk) == null) { ok = false; break; }
+	}
+	src_f.close();
+	dst_f.close();
+	if (!ok) { unlink(dst); return false; }
+	unlink(src);
+	return true;
+}
+
 function is_present(cmd) {
 	if (index(cmd, '/') >= 0)
 		return access(cmd, 'x') == true;
@@ -756,12 +774,12 @@ function adb_file(action) {
 	case 'create':
 	case 'backup':
 		if (stat(dns_output.file)?.size > 0)
-			return rename(dns_output.file, dns_output.cache) == true;
+			return move_file(dns_output.file, dns_output.cache);
 		return false;
 	case 'restore':
 	case 'use':
 		if (stat(dns_output.cache)?.size > 0)
-			return rename(dns_output.cache, dns_output.file) == true;
+			return move_file(dns_output.cache, dns_output.file);
 		return false;
 	case 'test':
 	case 'test_file':
@@ -1653,7 +1671,7 @@ function download_dnsmasq_file() {
 	output.info('Downloading dnsmasq file ');
 	process_file_url(null, cfg.dnsmasq_config_file_url, 'file');
 	output.dns('Moving dnsmasq file ');
-	if (rename(tmp.b, dns_output.file)) {
+	if (move_file(tmp.b, dns_output.file)) {
 		output.ok();
 	} else {
 		output.fail();
@@ -1878,7 +1896,7 @@ function download_lists() {
 	output.verbose('[PROC] ' + step_title + ' ');
 	status_data.message = get_text('statusProcessing') + ': ' + step_title;
 
-	if (rename(tmp.b, dns_output.file)) {
+	if (move_file(tmp.b, dns_output.file)) {
 		output.ok();
 	} else {
 		output.fail();
@@ -2730,6 +2748,7 @@ function get_init_status(name) {
 		stats: svc_data?.stats || '',
 		entries: svc_data?.entries || 0,
 		dns: svc_data?.dns || cfg.dns,
+		pause_timeout: cfg.pause_timeout,
 		outputFile: svc_data?.outputFile || dns_output.file,
 		outputCache: svc_data?.outputCache || dns_output.cache,
 		outputGzip: gzip_path,

--- a/net/adblock-fast/tests/mocks/uci/adblock-fast.json
+++ b/net/adblock-fast/tests/mocks/uci/adblock-fast.json
@@ -19,6 +19,7 @@
 			"update_config_sizes": "0",
 			"heartbeat_domain": "-",
 			"download_timeout": "10",
+			"pause_timeout": "20",
 			"curl_retry": "1",
 			"compressed_cache_dir": "TESTDIR/cache"
 		}


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.0-rc4
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.0-rc4

Description:
* bugfix: support TMP and final block-list destination on different
  partitions
* update pause-related code/defaults/validation

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 5ad634eac956f29865a23b6650a7fa975a83c110)