### PR TITLE
rust: Set llvm.download-ci-llvm=false.

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
 PKG_VERSION:=1.90.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.xz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
@@ -75,7 +75,7 @@ HOST_CONFIGURE_ARGS = \
 	--release-channel=stable \
 	--enable-cargo-native-static \
 	--bootstrap-cache-path=$(DL_DIR)/rustc \
-	--set=llvm.download-ci-llvm=true \
+	--set=llvm.download-ci-llvm=false \
 	$(TARGET_CONFIGURE_ARGS)
 
 define Host/Uninstall


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lu-zero

**Description:**

These LLVM builds get deleted after a certain time, causing Rust builds to break as the LLVM build can no longer be downloaded. This already happens at the last tagged OpenWrt version. The last tagged OpenWrt version is v24.10.5, which pins the packages feed to commit `953b6d47b4e9f0ad3c39547c6d3f9a828f10e206` (https://github.com/openwrt/openwrt/blob/v24.10.5/feeds.conf.default#L1C60-L1C100). At this commit the Rust version is v1.89.0 (https://github.com/openwrt/packages/blob/953b6d47b4e9f0ad3c39547c6d3f9a828f10e206/lang/rust/Makefile).

While this takes a bit more time to build the Rust package, I think it is better than constantly having to update the Rust version to a version of which the LLVM builds are still available.

This PR fixes #27331.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.5
- **OpenWrt Target/Subtarget:** bcm27xx / bcm709 / 10 / 11
- **OpenWrt Device:** Raspberry Pi

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
