### PR TITLE
adguardhome: add GC and thread control variables

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
 PKG_VERSION:=0.107.72
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/AdGuardHome/tar.gz/v$(PKG_VERSION)?

--- a/net/adguardhome/files/adguardhome.config
+++ b/net/adguardhome/files/adguardhome.config
@@ -1,3 +1,4 @@
+
 config adguardhome 'config'
 	# All paths must be readable by the configured user
 	option config_file '/etc/adguardhome/adguardhome.yaml'
@@ -9,3 +10,16 @@ config adguardhome 'config'
 	# Files and directories that AdGuard Home has read-only access to
 	# list jail_mount '/etc/ssl/adguardhome.crt'
 	# list jail_mount '/etc/ssl/adguardhome.key'
+
+	# Advanced options. Modify at your own risk.
+
+	# https://go.dev/doc/gc-guide#GOGC
+	option gc '0'
+
+	# Max number of OS threads to use
+	# 0 to match the number of CPUs (default)
+	# >0 to explicitly specify concurrency
+	option maxprocs '0'
+
+	# Soft memory limit in MB, 0 to disable
+	option memlimit '0'

--- a/net/adguardhome/files/adguardhome.init
+++ b/net/adguardhome/files/adguardhome.init
@@ -48,7 +48,10 @@ start_service() {
 	fi
 
 	local config_file='/etc/adguardhome/adguardhome.yaml'
+	local gc=0
 	local group='adguardhome'
+	local maxprocs=0
+	local memlimit=0
 	local user='adguardhome'
 	local verbose=0
 	local work_dir='/var/lib/adguardhome'
@@ -70,6 +73,9 @@ start_service() {
 	procd_open_instance
 
 	procd_set_param command "$PROG"
+	[ "$gc" -le 0 ] || procd_append_param env GOGC="$gc"
+	[ "$maxprocs" -le 0 ] || procd_append_param env GOMAXPROCS="$maxprocs"
+	[ "$memlimit" -le 0 ] || procd_append_param env GOMEMLIMIT="$memlimit"
 	procd_append_param command --config "$config_file"
 	procd_append_param command --logfile syslog
 	procd_append_param command --no-check-update


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** me

**Description:**

Add Go GC and threading control variables - `GOGC`, `GOMEMLIMIT`, and `GOMAXPROCS` - to allow more granular control of the memory management on lower memory devices.

Fixes: https://github.com/openwrt/packages/issues/28676
Link: https://go.dev/doc/gc-guide#GOGC
Link: https://pkg.go.dev/runtime#pkg-overview
Link: https://go.dev/blog/container-aware-gomaxprocs

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12-rc3
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.