### PR TITLE
keepalived-sync: fix mkdir permission denied in rsync.sh

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.3.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software
@@ -373,7 +373,7 @@ mkdir -m 700 -p "$(USER_HOME)/.ssh"
 chown "$(USER)":"$(USER)" "$(USER_HOME)" -R
 
 [ ! -d "$(SUDO_DIR)" ] && mkdir "$(SUDO_DIR)"
-echo "$(USER) ALL= NOPASSWD:/usr/bin/rsync" > "$(SUDO_FILE)"
+echo "$(USER) ALL= NOPASSWD:/usr/bin/rsync,/bin/mkdir" > "$(SUDO_FILE)"
 EOF
 
 	[ -z "$${IPKG_INSTROOT}" ] && [ -f "$${DEFAULT_SCRIPT}" ] && sh "$${DEFAULT_SCRIPT}"

--- a/net/keepalived/files/usr/share/keepalived/scripts/rsync.sh
+++ b/net/keepalived/files/usr/share/keepalived/scripts/rsync.sh
@@ -55,7 +55,7 @@ ha_sync_send() {
 	ssh_remote="$RSYNC_USER@$address"
 
 	# shellcheck disable=SC2086
-	timeout 10 ssh $ssh_options $ssh_remote mkdir -m 755 -p "$dirs_list /tmp" || {
+	timeout 10 ssh $ssh_options $ssh_remote sudo mkdir -m 755 -p "$dirs_list /tmp" || {
 		log_err "can not connect to $address. check key or connection"
 		update_last_sync_time "$cfg"
 		update_last_sync_status "$cfg" "SSH Connection Failed"


### PR DESCRIPTION
**Maintainer:** @feckert

The rsync.sh script uses sudo for rsync but not for mkdir. After the first sync, rsync -a preserves root ownership on directories under the sync target. Subsequent syncs fail at the mkdir step because the keepalived user cannot create subdirectories inside root-owned directories.

Add sudo to the mkdir command to match the existing sudo rsync usage.

Also update the sudoers configuration in the postinst script to permit /bin/mkdir in addition to /usr/bin/rsync.

Fixes: #28565