### PR TITLE
utils/vzlogger: new package

### DIFF
--- a/libs/libsml/Makefile
+++ b/libs/libsml/Makefile
@@ -1,0 +1,50 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libsml
+PKG_VERSION:=1.1.4
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/volkszaehler/libsml/tar.gz/v${PKG_VERSION}?
+PKG_HASH:=97d5647e5805b7f0e31d8875a1867a6afccbff1c1945b961b36041af3597f275
+
+PKG_MAINTAINER:=Andy Voigt <a.voigt@mailbox.org>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libsml
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Smart Message Language (SML) library
+  URL:=https://volkszaehler.org
+  DEPENDS:=+libuuid
+  ABI_VERSION:=1
+endef
+
+define Package/libsml/description
+ libSML implements the Smart Message Language (SML) protocol specified by
+ VDE's Forum Netztechnik/Netzbetrieb (FNN). It can be used to communicate
+ with SML-based smart meters and related components (EDL/MUC).
+endef
+
+define Build/Compile
+	$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/sml \
+		CC="$(TARGET_CC)" \
+		LD="$(TARGET_CROSS)ld"
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_BUILD_DIR)/sml/include/* $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/sml/lib/libsml.{a,so*} $(1)/usr/lib/
+endef
+
+define Package/libsml/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/sml/lib/libsml.so.$(ABI_VERSION) $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libsml))

--- a/utils/vzlogger/Makefile
+++ b/utils/vzlogger/Makefile
@@ -1,0 +1,56 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=vzlogger
+PKG_VERSION:=0.8.9
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/volkszaehler/vzlogger/tar.gz/v${PKG_VERSION}?
+PKG_HASH:=734fcd78ef5e1a41913fdef627b8382d9c0c04cb99fe023cdb50dc2ad2d972a4
+
+PKG_MAINTAINER:=Andy Voigt <a.voigt@mailbox.org>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+CMAKE_INSTALL:=1
+CMAKE_OPTIONS += -DBUILD_TEST:BOOL=OFF
+
+define Package/vzlogger
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Data logger for smart meters (SML) with MQTT support
+  URL:=https://volkszaehler.org/
+  DEPENDS:= \
+    +libcurl \
+    +libgcrypt \
+    +libgnutls \
+    +libjson-c \
+    +libmicrohttpd-no-ssl \
+    +libmosquitto-ssl \
+    +libsasl2 \
+    +libsml \
+    +libstdcpp \
+    +libunistring
+endef
+
+define Package/vzlogger/description
+  vzlogger is a tool to read values from sensors and smartmeters. It is
+  used to collect data which can be forwarded to the volkszaehler.org
+  Middleware or to an MQTT broker.
+endef
+
+define Package/vzlogger/conffiles
+/etc/vzlogger.conf
+endef
+
+define Package/vzlogger/install
+	$(INSTALL_DIR) $(1)/usr/bin $(1)/etc/init.d $(1)/etc/config
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/vzlogger $(1)/usr/bin/
+	$(INSTALL_BIN) ./files/vzlogger.init $(1)/etc/init.d/vzlogger
+	$(INSTALL_CONF) ./files/vzlogger.conf $(1)/etc/vzlogger.conf
+endef
+
+$(eval $(call BuildPackage,vzlogger))

--- a/utils/vzlogger/files/vzlogger.conf
+++ b/utils/vzlogger/files/vzlogger.conf
@@ -1,0 +1,29 @@
+{
+  "retry": 2,
+  "verbosity": 1,
+  "log": "/var/log/vzlogger.log",
+  "push": [],
+  "local": {
+    "enabled": true,
+    "port": 8080,
+    "index": true,
+    "timeout": 0,
+    "buffer": 0
+  },
+  "meters": [
+    {
+      "enabled": true,
+      "allowskip": false,
+      "interval": -1,
+      "aggtime": 10,
+      "aggfixedinterval": true,
+      "channels": [],
+      "protocol": "sml",
+      "device": "/dev/ttyUSB0",
+      "pullseq": "",
+      "baudrate": 9600,
+      "parity": "8n1",
+      "use_local_time": false
+    }
+  ]
+}

--- a/utils/vzlogger/files/vzlogger.init
+++ b/utils/vzlogger/files/vzlogger.init
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+START=95
+STOP=01
+
+start_service() {
+    procd_open_instance
+    procd_set_param command /usr/bin/vzlogger -c /etc/vzlogger.conf
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_close_instance
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Quote: https://github.com/volkszaehler/vzlogger

> vzlogger is a tool to read and log measurements of a wide variety of smart meters and sensors to the volkszaehler.org middleware

Quote from https://github.com/volkszaehler/libsml README:

> libSML is a library which implements the Smart Message Language (SML) protocol specified by VDE's Forum Netztechnik/Netzbetrieb (FNN). It can be utilized to communicate to FNN specified Smart Meters or Smart Meter components (EDL/MUC).

This PR adds the vzlogger service and smlib C library to OpenWrt. You can finde the application, [vzlogger](https://github.com/volkszaehler/vzlogger) here.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 24.10
- **OpenWrt Target/Subtarget:** x86/x86_64
- **OpenWrt Device:** Generic x86/64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
