### PR TITLE
pulseaudio: lower START= value in init script

### DIFF
--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pulseaudio
 PKG_VERSION:=17.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://freedesktop.org/software/pulseaudio/releases

--- a/sound/pulseaudio/files/pulseaudio.init
+++ b/sound/pulseaudio/files/pulseaudio.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2011 OpenWrt.org
 
-START=99
+START=90
 STOP=65
 
 USE_PROCD=1


### PR DESCRIPTION
Lower the START value from 99 to 90. This allows other applications that use pulseaudio to start after it with the pulse client socket being available.
