### PR TITLE
adguardhome: add jail_mount_rw config

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
 PKG_VERSION:=0.107.72
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/AdGuardHome/tar.gz/v$(PKG_VERSION)?

--- a/net/adguardhome/files/adguardhome.config
+++ b/net/adguardhome/files/adguardhome.config
@@ -7,9 +7,13 @@ config adguardhome 'config'
 	option user 'adguardhome'
 	option group 'adguardhome'
 	option verbose '0'
+
 	# Files and directories that AdGuard Home has read-only access to
 	# list jail_mount '/etc/ssl/adguardhome.crt'
 	# list jail_mount '/etc/ssl/adguardhome.key'
+
+	# Files and directories that AdGuard Home has read-write access to
+	# list jail_mount_rw '/path/to/dir'
 
 	# Advanced options. Modify at your own risk.
 

--- a/net/adguardhome/files/adguardhome.init
+++ b/net/adguardhome/files/adguardhome.init
@@ -102,6 +102,7 @@ start_service() {
 	procd_add_jail_mount /etc/hosts
 	procd_add_jail_mount /etc/ssl/certs
 	config_list_foreach config jail_mount procd_add_jail_mount
+	config_list_foreach config jail_mount_rw procd_add_jail_mount_rw
 
 	procd_close_instance
 }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dobo90 @GeorgeSapkin 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**

Add `jail_mount_rw` config to allow user add file and directory read-write access for AGH.

This is fix for a breaking regression from 24.10. Previously AGH was run as root. PR https://github.com/openwrt/packages/pull/26225 changed this behavior so AGH will be run unprivileged using jail. As AGH will be run using jail, user need to explicitly grant AGH access to files and directories using jail mount.

I assume the regression as breaking as user need to update their configuration to restore AGH behavior as before.

Fix: https://forum.openwrt.org/t/adguardhome-cannot-read-write-external-mounted-drive/247253

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.0
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Flint 2

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.