### PR TITLE
coredns: update to 1.14.2

### DIFF
--- a/net/coredns/Config.in
+++ b/net/coredns/Config.in
@@ -1,84 +1,138 @@
 if PACKAGE_coredns
 
-config COREDNS_PLUGIN_GEOIP
-	bool "GeoIP plugin"
-	default n
+comment "Transport & Security"
 
 config COREDNS_PLUGIN_TLS
 	bool "TLS plugin"
 	default y
+	help
+	  Enable TLS (DNS-over-TLS) listener support.
 
 config COREDNS_PLUGIN_QUIC
-	bool "QUIC plugin"
+	bool "QUIC plugin (DNS-over-QUIC)"
 	default n
-
-config COREDNS_PLUGIN_ROUTE53
-	bool "Route53 plugin"
-	default n
-
-config COREDNS_PLUGIN_AZURE
-	bool "Azure plugin"
-	default n
-
-config COREDNS_PLUGIN_CLOUDDNS
-	bool "CloudDNS plugin"
-	default n
-
-config COREDNS_PLUGIN_K8S_EXTERNAL
-	bool "k8s_external plugin"
-	default n
-
-config COREDNS_PLUGIN_KUBERNETES
-	bool "Kubernetes plugin"
-	default n
-
-config COREDNS_PLUGIN_ETCD
-	bool "Etcd plugin"
-	default n
+	help
+	  Enable DNS-over-QUIC (DoQ) listener support. Requires TLS certificates.
 
 config COREDNS_PLUGIN_GRPC
 	bool "gRPC plugin"
 	default n
+	help
+	  Forward or receive DNS messages over gRPC.
 
-config COREDNS_PLUGIN_ON
-	bool "On event plugin"
+config COREDNS_PLUGIN_PROXYPROTO
+	bool "Proxy Protocol plugin"
 	default n
+	help
+	  Add PROXY protocol (v1/v2) support to preserve original client IPs
+	  when CoreDNS sits behind a load balancer or reverse proxy.
+
+comment "Service Discovery Backends"
+
+config COREDNS_PLUGIN_KUBERNETES
+	bool "Kubernetes plugin"
+	default n
+	help
+	  Serve DNS records for Kubernetes services and pods.
+	  Only useful when running inside a Kubernetes cluster.
+
+config COREDNS_PLUGIN_K8S_EXTERNAL
+	bool "k8s_external plugin"
+	default n
+	help
+	  Serve DNS records for external-facing Kubernetes services
+	  (e.g. LoadBalancer / ExternalName).
+
+config COREDNS_PLUGIN_ETCD
+	bool "Etcd plugin"
+	default n
+	help
+	  Serve DNS records from an etcd v3 datastore (SkyDNS-compatible).
 
 config COREDNS_PLUGIN_NOMAD
 	bool "Nomad plugin"
 	default n
+	help
+	  Serve DNS records from HashiCorp Nomad service registrations.
+
+comment "Cloud DNS Backends"
+
+config COREDNS_PLUGIN_ROUTE53
+	bool "Route53 plugin (AWS)"
+	default n
+	help
+	  Serve DNS records from AWS Route 53 hosted zones.
+	  Adds significant binary size due to AWS SDK.
+
+config COREDNS_PLUGIN_AZURE
+	bool "Azure DNS plugin"
+	default n
+	help
+	  Serve DNS records from Azure DNS hosted zones.
+	  Adds significant binary size due to Azure SDK.
+
+config COREDNS_PLUGIN_CLOUDDNS
+	bool "Cloud DNS plugin (GCP)"
+	default n
+	help
+	  Serve DNS records from Google Cloud DNS managed zones.
+	  Adds significant binary size due to GCP SDK.
+
+comment "Extra Built-in Plugins"
+
+config COREDNS_PLUGIN_GEOIP
+	bool "GeoIP plugin"
+	default n
+	help
+	  Add GeoIP-based metadata to requests (requires MaxMind database).
+
+config COREDNS_PLUGIN_ON
+	bool "On-event plugin"
+	default n
+	help
+	  Execute a command on server start/shutdown events.
+
+comment "Third-party Plugins"
 
 config COREDNS_PLUGIN_WGSD
 	bool "WireGuard Service Discovery plugin"
 	default y if PACKAGE_wgsd-coredns
 	select COREDNS_REQUIRE_GO_GET
 	help
-		wgsd is a CoreDNS plugin that serves WireGuard peer information via DNS-SD (RFC6763) semantics.
-		This enables use cases such as:
-
-		- Building a mesh of WireGuard peers from a central registry
-		- Dynamic discovery of WireGuard Endpoint addressing (both IP address and port number)
-		- NAT-to-NAT WireGuard connectivity where UDP hole punching is supported.
+	  wgsd serves WireGuard peer information via DNS-SD (RFC 6763)
+	  semantics. Use cases include:
+	   - Building a mesh of WireGuard peers from a central registry
+	   - Dynamic discovery of WireGuard endpoint addressing
+	   - NAT-to-NAT connectivity where UDP hole punching is supported
 
 config COREDNS_PLUGIN_NETBOX
 	bool "Netbox plugin"
 	default n
 	select COREDNS_REQUIRE_GO_GET
+	help
+	  Serve DNS records from a NetBox IPAM/DCIM instance.
 
 config COREDNS_PLUGIN_FANOUT
 	bool "Fanout plugin"
 	default n
 	select COREDNS_REQUIRE_GO_GET
+	help
+	  Forward DNS queries to multiple upstreams simultaneously and return
+	  the first successful response (race / fan-out strategy).
 
 config COREDNS_PLUGIN_FINALIZE
 	bool "Finalize plugin"
 	default n
 	select COREDNS_REQUIRE_GO_GET
+	help
+	  Ensure all CNAME chains in responses are fully resolved before
+	  sending the answer to the client.
 
 config COREDNS_REQUIRE_GO_GET
 	bool
 	default n
 	help
-		Custom plugins require `go get ./...` to pull dependencies.
+	  Custom / third-party plugins require 'go get ./...' during build
+	  to pull their module dependencies.
 
 endif

--- a/net/coredns/Makefile
+++ b/net/coredns/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coredns
-PKG_VERSION:=1.14.1
+PKG_VERSION:=1.14.2
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/coredns/coredns.git
-PKG_MIRROR_HASH:=be51352801f5455ac0a7f3c97adaa86587bb2343f50ee2779f48121c96e2f4f9
+PKG_MIRROR_HASH:=6d82a06f7fe8b0f54a919058e8cd2839a113b81dd9d0217e280d2bea665668ce
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 
 PKG_LICENSE:=Apache-2.0
@@ -53,10 +53,9 @@ define Package/coredns/conffiles
 endef
 
 define configure-plugin
-	$(SED) '/^$(2):/d' "$(PKG_BUILD_DIR)/plugin.cfg"
-ifeq ($(1),y)
-	echo "$(2):$(3)" >> "$(PKG_BUILD_DIR)/plugin.cfg"
-endif
+	$(if $(filter y,$(1)),\
+		grep -q '^$(2):' "$(PKG_BUILD_DIR)/plugin.cfg" || echo "$(2):$(3)" >> "$(PKG_BUILD_DIR)/plugin.cfg",\
+		$(SED) '/^$(2):/d' "$(PKG_BUILD_DIR)/plugin.cfg")
 endef
 
 define Build/Configure
@@ -73,6 +72,7 @@ define Build/Configure
 	$(call configure-plugin,$(CONFIG_COREDNS_PLUGIN_KUBERNETES),kubernetes,kubernetes)
 	$(call configure-plugin,$(CONFIG_COREDNS_PLUGIN_ETCD),etcd,etcd)
 	$(call configure-plugin,$(CONFIG_COREDNS_PLUGIN_GRPC),grpc,grpc)
+	$(call configure-plugin,$(CONFIG_COREDNS_PLUGIN_PROXYPROTO),proxyproto,proxyproto)
 	$(call configure-plugin,$(CONFIG_COREDNS_PLUGIN_ON),on,github.com/coredns/caddy/onevent)
 	$(call configure-plugin,$(CONFIG_COREDNS_PLUGIN_NOMAD),nomad,nomad)
 	$(call configure-plugin,$(CONFIG_COREDNS_PLUGIN_WGSD),wgsd,github.com/jwhited/wgsd)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @vooon 

**Description:**
Security fixes for CVE-2026-26017, CVE-2026-26018.

Release notes: https://github.com/coredns/coredns/releases/tag/v1.14.2

Package changes:
- Add optional proxyproto plugin config
- Fix configure-plugin macro to preserve upstream plugin ordering
- Reorganize Config.in with section headers and help texts

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** VM

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.