### PR TITLE
openwrt-hardening: add base and strict sysctl hardening profiles

### DIFF
--- a/package/admin/openwrt-hardening/Makefile
+++ b/package/admin/openwrt-hardening/Makefile
@@ -1,0 +1,68 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=openwrt-hardening
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0-only
+PKG_MAINTAINER:=Edwin ten Brink <git@tenbrink-bekkers.nl>
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/openwrt-hardening-base
+  SECTION:=admin
+  CATEGORY:=Administration
+  TITLE:=Conservative sysctl hardening profile
+  PKGARCH:=all
+endef
+
+define Package/openwrt-hardening-base/description
+A conservative kernel/sysctl hardening profile for general OpenWrt systems.
+This package installs a small /etc/sysctl.d snippet with low-risk hardening
+settings intended for broad compatibility on routers and access points.
+endef
+
+define Package/openwrt-hardening-base/conffiles
+/etc/sysctl.d/90-openwrt-hardening-base.conf
+endef
+
+define Package/openwrt-hardening-strict
+  SECTION:=admin
+  CATEGORY:=Administration
+  TITLE:=Stricter sysctl hardening profile
+  PKGARCH:=all
+  DEPENDS:=+openwrt-hardening-base
+endef
+
+define Package/openwrt-hardening-strict/description
+A stricter sysctl hardening profile for OpenWrt systems.
+This package adds more restrictive kernel hardening settings on top of
+openwrt-hardening-base, but avoids irreversible or high-breakage settings.
+endef
+
+define Package/openwrt-hardening-strict/conffiles
+/etc/sysctl.d/95-openwrt-hardening-strict.conf
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/openwrt-hardening-base/install
+	$(INSTALL_DIR) $(1)/etc/sysctl.d
+	$(INSTALL_DATA) ./files/90-openwrt-hardening-base.conf \
+		$(1)/etc/sysctl.d/90-openwrt-hardening-base.conf
+	$(INSTALL_DIR) $(1)/usr/share/doc/openwrt-hardening
+	$(INSTALL_DATA) ./files/README \
+		$(1)/usr/share/doc/openwrt-hardening/README
+endef
+
+define Package/openwrt-hardening-strict/install
+	$(INSTALL_DIR) $(1)/etc/sysctl.d
+	$(INSTALL_DATA) ./files/95-openwrt-hardening-strict.conf \
+		$(1)/etc/sysctl.d/95-openwrt-hardening-strict.conf
+endef
+
+$(eval $(call BuildPackage,openwrt-hardening-base))
+$(eval $(call BuildPackage,openwrt-hardening-strict))

--- a/package/admin/openwrt-hardening/files/90-openwrt-hardening-base.conf
+++ b/package/admin/openwrt-hardening/files/90-openwrt-hardening-base.conf
@@ -1,0 +1,14 @@
+# openwrt-hardening-base
+# Conservative hardening for general OpenWrt systems.
+# Avoids network-policy choices, developer-oriented tuning, and irreversible locks.
+
+# Block unsafe core dumps from privileged / setuid binaries.
+fs.suid_dumpable = 0
+
+# Harden sticky world-writable directories against hardlink/symlink abuse.
+fs.protected_hardlinks = 1
+fs.protected_symlinks = 1
+
+# Reduce kernel information exposure.
+kernel.dmesg_restrict = 1
+kernel.kptr_restrict = 2

--- a/package/admin/openwrt-hardening/files/95-openwrt-hardening-strict.conf
+++ b/package/admin/openwrt-hardening/files/95-openwrt-hardening-strict.conf
@@ -1,0 +1,10 @@
+# openwrt-hardening-strict
+# Adds stricter kernel hardening on top of openwrt-hardening-base.
+# Still avoids irreversible or service-breaking settings.
+
+# Disable unprivileged BPF usage.
+kernel.unprivileged_bpf_disabled = 2
+
+# Do not expose BPF JIT addresses; harden JITed BPF.
+net.core.bpf_jit_kallsyms = 0
+net.core.bpf_jit_harden = 2

--- a/package/admin/openwrt-hardening/files/README
+++ b/package/admin/openwrt-hardening/files/README
@@ -1,0 +1,26 @@
+openwrt-hardening-base
+----------------------
+Low-risk sysctl hardening intended for broad compatibility.
+
+openwrt-hardening-strict
+------------------------
+Adds stricter kernel hardening settings on top of the base profile.
+
+Not included on purpose
+-----------------------
+The following settings are intentionally NOT enabled by these packages because
+they are either irreversible, more likely to break services, or too deployment-
+specific for a generic package:
+
+- kernel.modules_disabled=1
+- TCP congestion control changes
+- qdisc / traffic shaping tuning
+- firewall policy changes
+- conntrack timeout changes
+
+Operational note
+----------------
+These packages install /etc/sysctl.d snippets. Installation applies the settings
+at runtime via the normal OpenWrt sysctl restart path. Removing the package
+removes the configuration for future boots, but runtime kernel values may persist
+until reboot.


### PR DESCRIPTION
Add two optional sysctl hardening profile packages:

- openwrt-hardening-base
- openwrt-hardening-strict

The goal is to provide a small, well-scoped hardening option for users who want additional kernel/sysctl hardening without changing OpenWrt defaults.

The base profile provides a conservative set of low-risk hardening settings suitable for broad use on OpenWrt routers and access points.

The strict profile builds on the base profile and adds a small set of stricter hardening settings while intentionally avoiding irreversible, service-breaking, or deployment-specific choices.

Design principles:
- no firewall policy changes
- no network topology assumptions
- no performance tuning disguised as security tuning
- no irreversible or high-breakage settings

Installed files:
- /etc/sysctl.d/90-openwrt-hardening-base.conf
- /etc/sysctl.d/95-openwrt-hardening-strict.conf

## 📦 Package Details

**Maintainer:** @etb-source

**Description:**
This PR adds two optional sysctl hardening profile packages for OpenWrt:

- `openwrt-hardening-base`  
  A conservative hardening profile with low-risk settings intended for broad compatibility.

- `openwrt-hardening-strict`  
  A stricter profile layered on top of the base package, adding a small set of additional hardening settings while still avoiding settings that are irreversible, likely to break services, or too deployment-specific for a generic package.

The following are intentionally not included:
- `kernel.modules_disabled=1`
- `kernel.io_uring_disabled=2`
- TCP congestion control changes
- qdisc / traffic shaping tuning
- firewall policy changes
- conntrack timeout changes

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.5
- **OpenWrt Target/Subtarget:** ipq806x/generic
- **OpenWrt Device:** NETGEAR Nighthawk X4S R7800

Tested by:
- building the package in the matching OpenWrt SDK
- installing the generated `.ipk` packages on the target device
- verifying that the sysctl snippets are installed into `/etc/sysctl.d/`
- verifying that the selected sysctl settings are applied as intended
- verifying that the included settings do not alter firewall policy or require topology-specific assumptions

---

## ✅ Formalities

- [x] I have reviewed the CONTRIBUTING.md file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using `make package/admin/openwrt-hardening/refresh V=s`
- [x] It is structured in a way that it is potentially upstreamable