### PR TITLE
zoneinfo: updated to 2026a release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2025 OpenWrt.org
+# Copyright (C) 2007-2026 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2025c
+PKG_VERSION:=2026a
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public-Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.iana.org/time-zones/repository/releases
-PKG_HASH:=4aa79e4effee53fc4029ffe5f6ebe97937282ebcdf386d5d2da91ce84142f957
+PKG_HASH:=77b541725937bb53bd92bd484c0b43bec8545e2d3431ee01f04ef8f2203ba2b7
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=697ebe6625444aef5080f58e49d03424bbb52e08bf483d3ddb5acf10cbd15740
+   HASH:=f80a17a2eddd2b54041f9c98d75b0aa8038b016d7c5de72892a146d9938740e1
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @me

**Description:**
Briefly:

     Moldova has used EU transition times since 2022.
     The "right" TZif files are no longer installed by default.
     -DTZ_RUNTIME_LEAPS=0 disables runtime support for leap seconds.
     TZif files are no longer limited to 50 bytes of abbreviations.
     zic is no longer limited to 50 leap seconds.
     Several integer overflow bugs have been fixed.

   Changes to past and future timestamps

     Since 2022 Moldova has observed EU transition times, that is, it
     has sprung forward at 03:00, not 02:00, and has fallen back at
     04:00, not 03:00.  (Thanks to Heitor David Pinto.)

   Changes to data

     Remove Europe/Chisinau from zonenow.tab, as it now agrees with
     Europe/Athens for future timestamps.

   Changes to build procedure

     The Makefile no longer by default installs an alternate set
     of TZif files for system clocks that count leap seconds.
     Install with 'make REDO=posix_right' to get the old default,
     which is rarely used in major downstream distributions.
     If your system clock counts leap seconds (contrary to POSIX),
     it is better to install with 'make REDO=right_only'.
     This change does not affect the leapseconds file, which is still
     installed as before.

     The Makefile's POSIXRULES option, which was declared obsolete in
     release 2019b, has been removed.  The Makefile's build procedure
     thus no longer optionally installs the obsolete posixrules file.

   Changes to code

     Compiling with the new option -DTZ_RUNTIME_LEAPS=0 disables
     runtime support for leap seconds.  Although this conforms to
     POSIX, shrinks tzcode's attack surface, and is more efficient,
     it fails to support Internet RFC 9636's leap seconds.

     zic now can generate, and localtime.c can now use, TZif files that
     hold up to 256 bytes of abbreviations, counting trailing NULs.
     The previous limit was 50 bytes, and some tzdata TZif files were
     already consuming 40 bytes.  zic -v warns if it generates a file
     that exceeds the old 50-byte limit.

     zic -L can now generate TZif files with more than 50 leap seconds.
     This helps test TZif readers not limited to 50 leap seconds, as
     tzcode's localtime.c is; it has little immediate need for
     practical timekeeping as there have been only 27 leap seconds and
     possibly there will be no more, due to planned changes to UTC.
     zic -v warns if its output exceeds the old 50-second limit.

     localtime.c no longer accesses the posixrules file generated by
     zic -p.  Hence for obsolete and nonconforming settings like
     TZ="AST4ADT" it now typically falls back on US DST rules, rather
     than attempting to override this fallback with the contents of the
     posixrules file.  This removes library support that was declared
     obsolete in release 2019b, and fixes some undefined behavior.
     (Undefined behavior reported by GitHub user Naveed8951.)

     The posix2time, posix2time_z, time2posix, and time2posix_z
     functions now set errno=EOVERFLOW and return ((time_t) -1) if the
     result is not representable.  Formerly they had undefined behavior
     that could in practice result in crashing, looping indefinitely,
     or returning an incorrect result.  As before, these functions are
     defined only when localtime.c is compiled with the -DSTD_INSPIRED
     option.

     Some other undefined behavior, triggered by TZif files containing
     outlandish but conforming UT offsets or leap second corrections,
     has also been fixed.  (Some of these bugs reported by Naveed8951.)

     localtime.c no longer rejects TZif files that exactly fit in its
     internal structures, fixing off-by-one typos introduced in 2014g.

     zic no longer generates a no-op transition when
     simultaneous Rule and Zone changes cancel each other out.
     This occurs in tzdata only in Asia/Tbilisi on 1997-03-30.
     (Thanks to Renchunhui for a test case showing the bug.)

     zic no longer assumes you can fflush a read-only stream.
     (Problem reported by Christos Zoulas.)

     zic no longer generates UT offsets equal to -2**31 and localtime.c
     no longer accepts them, as they can cause trouble in both
     localtime.c and its callers.  RFC 9636 prohibits such offsets.

     zic -p now warns that the -p option is obsolete and likely
     ineffective.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWRT master
- **OpenWrt Target/Subtarget:**  TI OMAP3/4/AM33xx, default
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.