### PR TITLE
containerd: preserve config file during sysupgrade + add init script

### DIFF
--- a/utils/containerd/Makefile
+++ b/utils/containerd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=containerd
 PKG_VERSION:=1.7.22
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:linuxfoundation:containerd
@@ -36,6 +36,10 @@ define Package/containerd/description
 An industry-standard container runtime with an emphasis on simplicity, robustness and portability
 endef
 
+define Package/containerd/conffiles
+/etc/containerd/config.toml
+endef
+
 GO_PKG_INSTALL_EXTRA:=\
 	vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb \
 	Makefile \
@@ -60,6 +64,8 @@ Build/Compile=$(call Build/Compile/Default)
 define Package/containerd/install
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/{ctr,containerd,containerd-stress,containerd-shim,containerd-shim-runc-v1,containerd-shim-runc-v2} $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/containerd.init $(1)/etc/init.d/containerd
 endef
 
 $(eval $(call BuildPackage,containerd))

--- a/utils/containerd/files/containerd.init
+++ b/utils/containerd/files/containerd.init
@@ -1,0 +1,16 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2009-2026 OpenWrt.org
+
+START=99
+STOP=80
+
+USE_PROCD=1
+
+CONTAINERD_BIN="/usr/bin/containerd"
+
+start_service() {
+	procd_open_instance
+	procd_set_param respawn
+	procd_set_param command $CONTAINERD_BIN
+	procd_close_instance
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lu-zero 

**Description:**
Added config.toml into conffiles to preserve it during sysupgrades + added basic init script

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.0
- **OpenWrt Target/Subtarget:** mvebu/cortexa72
- **OpenWrt Device:** Globalscale MOCHAbin

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
