### PR TITLE
curl: enable zlib support by default

### DIFF
--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -140,7 +140,7 @@ config LIBCURL_THREADED_RESOLVER
 
 config LIBCURL_ZLIB
 	bool "Enable zlib support"
-	default n
+	default y
 
 config LIBCURL_ZSTD
 	bool "Enable zstd support"

--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=8.15.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** currently none

**Description:**
This is to enable zlib support in lib/curl by default. zlib is already a default package required by apk therefore this doesn't create additional dependancy.
Please note that having zlib support will consequently enable HTTP support in syslog-ng.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.0
- **OpenWrt Target/Subtarget:** mvebu/cortexa72
- **OpenWrt Device:** Globalscale MOCHAbin

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
