### PR TITLE
openconnect: fix token_script error handling/logging

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=9.12
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.infradead.org/openconnect/download

--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -146,8 +146,10 @@ proto_openconnect_setup() {
 		}
 		[ "$token_mode" = "script" ] && {
 			$token_script >> "$pwfile" 2> /dev/null || {
-				logger -t openconenct "Cannot get password from script '$token_script'"
+				logger -t openconnect "Cannot get password from script '$token_script'"
+				sleep 5
 				proto_setup_failed "$config"
+				exit 1
 			}
 		}
 		append_args --passwd-on-stdin


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @nmav 

**Description:**
When token_script fails, proto_setup_failed() notifies netifd that setup has failed, but script execution continues regardless. This commit adds exit 1 and sleep 5 (consistent with wireguard.sh error handling) to abort setup on token_script failure. Also fix typo in logger tag ("openconenct" -> "openconnect").

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.0
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:**

---

## ✅ Formalities

- [ X ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
