### PR TITLE
openconnect: implement --no-external-auth

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=9.12
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.infradead.org/openconnect/download

--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -23,6 +23,7 @@ proto_openconnect_init_config() {
 	proto_config_add_string "vpn_protocol"
 	proto_config_add_boolean "pfs"
 	proto_config_add_boolean "no_dtls"
+	proto_config_add_boolean "no_external_auth"
 	proto_config_add_string "interface"
 	proto_config_add_string "username"
 	proto_config_add_string "serverhash"
@@ -58,6 +59,7 @@ proto_openconnect_setup() {
 		juniper \
 		vpn_protocol \
 		mtu \
+		no_external_auth \
 		no_dtls \
 		os \
 		password \
@@ -107,6 +109,7 @@ proto_openconnect_setup() {
 	[ -n "$script" ] && append_args --script "$script"
 	[ "$pfs" = 1 ] && append_args --pfs
 	[ "$no_dtls" = 1 ] && append_args --no-dtls
+	[ "$no_external_auth" = 1 ] && append_args "--no-external-auth"
 	[ -n "$mtu" ] && append_args --mtu "$mtu"
 
 	# migrate to standard config files


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @nmav 

**Description:**
The "no-external-auth" option prevents OpenConnect from advertising to the server that it supports any kind of authentication mode that requires an external browser. Some servers will force the client to use such  an authentication mode if the client advertises it, but  fallback to a more "scriptable" authentication mode if  the client doesn’t appear to support it.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.0
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:**

---

## ✅ Formalities

- [ X ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
