### PR TITLE
lang/python: Add python-pyudev and python-rtslib-fb

### DIFF
--- a/lang/python/python-pyudev/Makefile
+++ b/lang/python/python-pyudev/Makefile
@@ -32,9 +32,6 @@ define Package/python3-pyudev
   DEPENDS:=+python3-light +python3-ctypes +libudev-zero
 endef
 
-define Package/python3-pyudev-src
-  TITLE:=pyudev source package
-endef
 
 define Package/python3-pyudev/description
  pyudev is a pure Python binding for libudev.

--- a/lang/python/python-rtslib-fb/Makefile
+++ b/lang/python/python-rtslib-fb/Makefile
@@ -39,9 +39,6 @@ define Package/python3-rtslib-fb
   DEPENDS:=+python3-light +python3-pyudev +python3-uuid +python3-ctypes
 endef
 
-define Package/python3-rtslib-fb-src
-  TITLE:=rtslib-fb source package
-endef
 
 define Package/python3-rtslib-fb/description
  rtslib-fb is a Python object API for configuring the Linux LIO target subsystem.


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @johnnyleone

**Description:**
This PR adds two new packages:
- `python-pyudev` (`0.24.4`): Python bindings for `libudev`
- `python-rtslib-fb` (`2.2.4`): Python API for the Linux LIO target subsystem

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.0
- **OpenWrt Target/Subtarget:** mvebu/cortexa9
- **OpenWrt Device:** helios4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
