### PR TITLE
squashfs-tools: bump to 4.7.5

### DIFF
--- a/utils/squashfs-tools/Makefile
+++ b/utils/squashfs-tools/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squashfs-tools
-PKG_VERSION:=4.7.2
+PKG_VERSION:=4.7.5
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0-only
@@ -18,7 +18,7 @@ PKG_CPE_ID:=cpe:/a:squashfs-tools_project:squashfs-tools
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/plougher/squashfs-tools/tar.gz/${PKG_VERSION}?
-PKG_HASH:=4672b5c47d9418d3a5ae5b243defc6d9eae8275b9771022247c6a6082c815914
+PKG_HASH:=547b7b7f4d2e44bf91b6fc554664850c69563701deab9fd9cd7e21f694c88ea6
 
 PKG_BUILD_PARALLEL:=1
 include $(INCLUDE_DIR)/package.mk

--- a/utils/squashfs-tools/test.sh
+++ b/utils/squashfs-tools/test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+case "$1" in
+	squashfs-tools-mksquashfs)
+		mksquashfs -version 2>&1 | grep -F "$2"
+		;;
+	squashfs-tools-unsquashfs)
+		unsquashfs -version 2>&1 | grep -F "$2"
+		;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Changes since 4.7.2:
- Fix potential corruption in Squashfs filesystems containing sparse files
- Fix pseudo file creation failures with large blocks of contiguous zeros
- Fix duplicate file detection for files exceeding available buffer space
- Add -numeric-owner option to mksquashfs/sqfstar
- Fix segfault when using pseudo file root definitions with only Xattr metadata
- Fix conflict between -offset and -stream options
- Fix directory modification timestamp issues in pseudo file hierarchy
- Fix -max-depth incorrectly marking empty directories as excluded

Full release notes:
https://github.com/plougher/squashfs-tools/releases/tag/4.7.5

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:**  master
- **OpenWrt Device:** x86

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
