### PR TITLE
python-pytz: bump to 2026.1

### DIFF
--- a/lang/python/python-pytz/Makefile
+++ b/lang/python/python-pytz/Makefile
@@ -8,15 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pytz
-PKG_VERSION:=2025.2
+PKG_VERSION:=2026.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=pytz
-PKG_HASH:=360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3
+PKG_HASH:=10413c35476919b4c07bda6b9810c6e24d914378c430070bdb1869e18a37eee5
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
+
+PKG_BUILD_DEPENDS:=python-setuptools/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk

--- a/lang/python/python-pytz/test.sh
+++ b/lang/python/python-pytz/test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+[ "$1" = python3-pytz ] || exit 0
+
+python3 - << 'EOF'
+import pytz
+import datetime
+
+utc = pytz.utc
+assert utc.zone == 'UTC'
+
+eastern = pytz.timezone('US/Eastern')
+fmt = '%Y-%m-%d %H:%M:%S %Z%z'
+loc_dt = eastern.localize(datetime.datetime(2026, 1, 1, 0, 0, 0))
+assert loc_dt.strftime(fmt) is not None
+
+utc_dt = loc_dt.astimezone(pytz.utc)
+assert utc_dt.tzinfo is pytz.utc
+EOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Updated timezone data to 2026.1 release.

Full release notes:
https://github.com/stub42/pytz/blob/master/src/CHANGES.rst

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** master
- **OpenWrt Device:** x86

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
