### PR TITLE
adguardhome: add config reload trigger

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
 PKG_VERSION:=0.107.73
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/AdGuardHome/tar.gz/v$(PKG_VERSION)?

--- a/net/adguardhome/files/adguardhome.init
+++ b/net/adguardhome/files/adguardhome.init
@@ -108,6 +108,8 @@ start_service() {
 }
 
 service_triggers() {
+	procd_add_reload_trigger 'adguardhome'
+
 	if [ -n "$ADGUARDHOME_BOOT" ]; then
 		# Wait for interfaces to be up before starting AdGuard Home for real.
 		# Prevents issues like https://github.com/openwrt/packages/issues/21868.


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Restart the service when config is changed from the app.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12-rc3
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.