### PR TITLE
libtorrent-rasterbar: add boost as dependency for python package

### DIFF
--- a/libs/libtorrent-rasterbar/Makefile
+++ b/libs/libtorrent-rasterbar/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtorrent-rasterbar
 PKG_VERSION:=2.0.11
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/arvidn/libtorrent/releases/download/v$(PKG_VERSION)/
@@ -41,7 +41,7 @@ define Package/python3-libtorrent
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE+= (Python 3)
-  DEPENDS:=+libtorrent-rasterbar +boost-python3
+  DEPENDS:=+libtorrent-rasterbar +boost +boost-python3
 endef
 
 define Package/libtorrent-rasterbar/description


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @yangfl 

**Description:**
`boost-python3` will be only selectable after `boost` is selected, so add `boost` to dependencies as well.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** sunxi/cortexa53
- **OpenWrt Device:** n/a

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.