### PR TITLE
miniupnpd: Update, revision, new access control and UCI options…

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -98,8 +98,10 @@ define Package/miniupnpd/install/Default
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/miniupnpd $(1)/usr/sbin/miniupnpd
 	$(INSTALL_BIN) ./files/miniupnpd.init $(1)/etc/init.d/miniupnpd
+	$(INSTALL_BIN) ./files/upnpd-migration.uci-defaults $(1)/etc/uci-defaults/99-miniupnpd-upnpd-migration
 	$(INSTALL_CONF) ./files/upnpd.config $(1)/etc/config/upnpd
 	$(INSTALL_DATA) ./files/miniupnpd.hotplug $(1)/etc/hotplug.d/iface/50-miniupnpd
 endef

--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
-PKG_VERSION:=2.3.9
-PKG_RELEASE:=3
+PKG_VERSION:=2.3.11
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://github.com/miniupnp/miniupnp/releases/download/miniupnpd_$(subst .,_,$(PKG_VERSION))
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=66cb3c3d697ab2bb3a61d3c48628166d6ba328d7c2dbeb95898fdf2a3202af7b
+PKG_HASH:=91994b127da735b2c97f19992e34420648c0e8c4ace8a4bcb0596e7685c48678
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -106,8 +106,10 @@ define Package/miniupnpd/install/Default
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/miniupnpd $(1)/usr/sbin/miniupnpd
 	$(INSTALL_BIN) ./files/miniupnpd.init $(1)/etc/init.d/miniupnpd
+	$(INSTALL_BIN) ./files/upnpd-migration.uci-defaults $(1)/etc/uci-defaults/99-miniupnpd-upnpd-migration
 	$(INSTALL_CONF) ./files/upnpd.config $(1)/etc/config/upnpd
 	$(INSTALL_DATA) ./files/miniupnpd.hotplug $(1)/etc/hotplug.d/iface/50-miniupnpd
 endef

--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -8,12 +8,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
-PKG_VERSION:=2.3.9
-PKG_RELEASE:=3
+PKG_VERSION:=2.3.11
+PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=https://github.com/miniupnp/miniupnp/releases/download/miniupnpd_$(subst .,_,$(PKG_VERSION))
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=66cb3c3d697ab2bb3a61d3c48628166d6ba328d7c2dbeb95898fdf2a3202af7b
+#PKG_SOURCE_URL:=https://github.com/miniupnp/miniupnp/releases/download/miniupnpd_$(subst .,_,$(PKG_VERSION))
+#PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+#PKG_HASH:=66cb3c3d697ab2bb3a61d3c48628166d6ba328d7c2dbeb95898fdf2a3202af7b
+# Build from GitHub tag archives, as release archive differ in code comments to the public repository
+PKG_SOURCE_VERSION:=63ac33eaa49332cde15fd509b539a260b531da05
+PKG_SOURCE_URL:=https://codeload.github.com/miniupnp/miniupnp/tar.gz/$(PKG_SOURCE_VERSION)?
+PKG_SOURCE:=miniupnp-$(PKG_SOURCE_VERSION).tar.gz
+PKG_HASH:=dd658488226186cb32331d6769897d49fd202171b366ebb64c612e03ecd0b1c4
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)/miniupnpd
+TAR_OPTIONS+= --strip-components 1
+TAR_CMD=$(HOST_TAR) -C $(1)/.. $(TAR_OPTIONS)
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/miniupnpd/files/firewall3.include
+++ b/net/miniupnpd/files/firewall3.include
@@ -20,36 +20,36 @@ iptables_prepend_rule() {
 	local chain="$3"
 	local target="$4"
 
-	$iptables "$IPTARGS" -t "$table" -I "$chain" $($iptables "$IPTARGS" -t "$table" --line-numbers -nL "$chain" | \
+	$iptables "$IPTARGS" -t "$table" -I "$chain" $($iptables "$IPTARGS" -t "$table" --line-numbers -nL "$chain" |
 		sed -ne '$s/[^0-9].*//p') -j "$target"
 }
 
 ADDED=0
 
 add_extzone_rules() {
-    local ext_zone="$1"
+	local ext_zone="$1"
 
-    [ -z "$ext_zone" ] && return
+	[ -z "$ext_zone" ] && return
 
-    # IPv4 - due to NAT, need to add both to nat and filter table
-    # need to insert as penultimate rule for input & forward & postrouting since final rule might be a fw3 REJECT
-    iptables_prepend_rule "$IPTABLES" filter "zone_${ext_zone}_input" MINIUPNPD
-    iptables_prepend_rule "$IPTABLES" filter "zone_${ext_zone}_forward" MINIUPNPD
-    $IPTABLES -t nat -A "zone_${ext_zone}_prerouting"  -j MINIUPNPD
-    iptables_prepend_rule "$IPTABLES" nat "zone_${ext_zone}_postrouting" MINIUPNPD-POSTROUTING
+	# IPv4 - due to NAT, need to add both to nat and filter table
+	# need to insert as penultimate rule for input & forward & postrouting since final rule might be a fw3 REJECT
+	iptables_prepend_rule "$IPTABLES" filter "zone_${ext_zone}_input" MINIUPNPD
+	iptables_prepend_rule "$IPTABLES" filter "zone_${ext_zone}_forward" MINIUPNPD
+	$IPTABLES -t nat -A "zone_${ext_zone}_prerouting" -j MINIUPNPD
+	iptables_prepend_rule "$IPTABLES" nat "zone_${ext_zone}_postrouting" MINIUPNPD-POSTROUTING
 
-    # IPv6 if available - filter only
-    [ -x $IP6TABLES ] && {
-	iptables_prepend_rule "$IP6TABLES" filter "zone_${ext_zone}_input" MINIUPNPD
-	iptables_prepend_rule "$IP6TABLES" filter "zone_${ext_zone}_forward" MINIUPNPD
-    }
-    ADDED=$(($ADDED + 1))
+	# IPv6 if available - filter only
+	[ -x $IP6TABLES ] && {
+		iptables_prepend_rule "$IP6TABLES" filter "zone_${ext_zone}_input" MINIUPNPD
+		iptables_prepend_rule "$IP6TABLES" filter "zone_${ext_zone}_forward" MINIUPNPD
+	}
+	ADDED=$(($ADDED + 1))
 }
 
 # By default, user configuration is king.
 
 for ext_iface in $(uci -q get upnpd.settings.external_iface); do
-    add_extzone_rules $(fw3 -q network "$ext_iface")
+	add_extzone_rules $(fw3 -q network "$ext_iface")
 done
 
 add_extzone_rules $(uci -q get upnpd.settings.external_zone)
@@ -66,7 +66,7 @@ network_find_wan wan_iface
 network_find_wan6 wan6_iface
 
 for ext_iface in $wan_iface $wan6_iface; do
-    # fw3 -q network fails on sub-interfaces => map to device first
-    network_get_device ext_device $ext_iface
-    add_extzone_rules $(fw3 -q device "$ext_device")
+	# fw3 -q network fails on sub-interfaces => map to device first
+	network_get_device ext_device $ext_iface
+	add_extzone_rules $(fw3 -q device "$ext_device")
 done

--- a/net/miniupnpd/files/firewall3.include
+++ b/net/miniupnpd/files/firewall3.include
@@ -48,11 +48,11 @@ add_extzone_rules() {
 
 # By default, user configuration is king.
 
-for ext_iface in $(uci -q get upnpd.config.external_iface); do
+for ext_iface in $(uci -q get upnpd.settings.external_iface); do
     add_extzone_rules $(fw3 -q network "$ext_iface")
 done
 
-add_extzone_rules $(uci -q get upnpd.config.external_zone)
+add_extzone_rules $(uci -q get upnpd.settings.external_zone)
 
 [ "$ADDED" -ne 0 ] && exit 0
 

--- a/net/miniupnpd/files/miniupnpd.hotplug
+++ b/net/miniupnpd/files/miniupnpd.hotplug
@@ -10,9 +10,9 @@
 [ "$ACTION" != "ifup" ] && /etc/init.d/miniupnpd running && exit 0
 
 tmpconf="/var/etc/miniupnpd.conf"
-external_iface=$(uci -q get upnpd.config.external_iface)
-external_iface6=$(uci -q get upnpd.config.external_iface6)
-external_zone=$(uci -q get upnpd.config.external_zone)
+external_iface=$(uci -q get upnpd.settings.external_iface)
+external_iface6=$(uci -q get upnpd.settings.external_iface6)
+external_zone=$(uci -q get upnpd.settings.external_zone)
 [ -x "$(command -v nft)" ] && FW="fw4" || FW="fw3"
 
 . /lib/functions/network.sh

--- a/net/miniupnpd/files/miniupnpd.hotplug
+++ b/net/miniupnpd/files/miniupnpd.hotplug
@@ -1,11 +1,9 @@
+#!/bin/sh
 /etc/init.d/miniupnpd enabled || exit 0
 
-# If miniupnpd is not running:
-# - check on _any_ event (event updates may contribute to network_find_wan*)
-
-# If miniupnpd _is_ running:
-# - check only on ifup (otherwise lease updates etc would cause
-#   miniupnpd state loss)
+# If daemon is:
+# - not running: check on any event (event updates may contribute to network_find_wan*)
+# - running: check only on ifup (otherwise lease updates etc. would cause daemon state loss)
 
 [ "$ACTION" != "ifup" ] && /etc/init.d/miniupnpd running && exit 0
 
@@ -16,26 +14,19 @@ external_zone=$(uci -q get upnpd.settings.external_zone)
 [ -x "$(command -v nft)" ] && FW="fw4" || FW="fw3"
 
 . /lib/functions/network.sh
-
-if [ -n "$external_iface" ] ; then
+if [ -n "$external_iface" ]; then
 	network_get_device ifname "$external_iface"
+elif [ -n "$external_zone" ]; then
+	ifname=$($FW -q zone "$external_zone" 2>/dev/null | head -1)
 else
-	if [ -n "$external_zone" ] ; then
-		ifname=$($FW -q zone "$external_zone" 2>/dev/null | head -1)
-	else
-		network_find_wan external_iface && \
-			network_get_device ifname "$external_iface"
-	fi
+	network_find_wan external_iface && network_get_device ifname "$external_iface"
 fi
-if [ -n "$external_iface6" ] ; then
+if [ -n "$external_iface6" ]; then
 	network_get_device ifname6 "$external_iface6"
+elif [ -n "$external_zone" ]; then
+	ifname6=$($FW -q zone "$external_zone" 2>/dev/null | head -1)
 else
-	if [ -n "$external_zone" ] ; then
-		ifname6=$($FW -q zone "$external_zone" 2>/dev/null | head -1)
-	else
-		network_find_wan6 external_iface6 && \
-			network_get_device ifname6 "$external_iface6"
-	fi
+	network_find_wan6 external_iface6 && network_get_device ifname6 "$external_iface6"
 fi
 
 [ "$DEVICE" != "$ifname" ] && [ "$DEVICE" != "$ifname6" ] && exit 0

--- a/net/miniupnpd/files/miniupnpd.hotplug
+++ b/net/miniupnpd/files/miniupnpd.hotplug
@@ -40,6 +40,6 @@ fi
 
 [ "$DEVICE" != "$ifname" ] && [ "$DEVICE" != "$ifname6" ] && exit 0
 
-grep -qs "^ext_ifname=$ifname" "$tmpconf" && grep -qs "^ext_ifname6=$ifname6" "$tmpconf" && exit 0
+grep -qs "^ext_ifname=$ifname" "$tmpconf" && grep -qs "^ext_ifname6=${ifname6:-$ifname}" "$tmpconf" && exit 0
 
 /etc/init.d/miniupnpd restart

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -42,25 +42,16 @@ upnpd_add_acl_entry() {
 	echo "$action $ext_port $int_addr $int_port${descr_filter} # $comment"
 }
 
-upnpd() {
-	config_load "upnpd"
-	local enabled
-	config_get enabled settings enabled 0
-	if [ "$enabled" != "1" ]; then
-		log "Service disabled, enabled UCI option not set"
-		return 1
-	fi
+upnpd_generate_config() {
 	# Daemon
-	local enable_protocols allow_cgnat stun_host allow_third_party_mapping ipv6_disable system_uptime log_output lease_file config_file
+	local enable_protocols allow_cgnat stun_host allow_third_party_mapping ipv6_disable system_uptime lease_file
 	config_get enable_protocols settings enable_protocols all
 	config_get allow_cgnat settings allow_cgnat 0
 	config_get stun_host settings stun_host stun.nextcloud.com
 	config_get allow_third_party_mapping settings allow_third_party_mapping 0
 	config_get ipv6_disable settings ipv6_disable 0
 	config_get system_uptime settings system_uptime 1
-	config_get log_output settings log_output
 	config_get lease_file settings lease_file /var/run/miniupnpd.leases
-	config_get config_file settings config_file
 
 	# UPnP IGD
 	local upnp_igd_compat download_kbps upload_kbps friendly_name model_number serial_number presentation_url uuid http_port notify_interval
@@ -82,53 +73,51 @@ upnpd() {
 	config_get external_zone settings external_zone
 	config_get external_ip settings external_ip
 
-	local conf ifname ifname6
+	local ifname ifname6
 	. /lib/functions/network.sh
-
-	if [ -n "$external_iface" ] ; then
+	if [ -n "$external_iface" ]; then
 		network_get_device ifname "$external_iface"
+	elif [ -n "$external_zone" ]; then
+		ifname=$($FW -q zone "$external_zone" 2>/dev/null | head -1)
 	else
-		if [ -n "$external_zone" ] ; then
-			ifname=$($FW -q zone "$external_zone" 2>/dev/null | head -1)
-		else
-			network_find_wan external_iface && \
-				network_get_device ifname "$external_iface"
-		fi
+		network_find_wan external_iface && network_get_device ifname "$external_iface"
 	fi
-	if [ -n "$external_iface6" ] ; then
+	if [ -n "$external_iface6" ]; then
 		network_get_device ifname6 "$external_iface6"
+	elif [ -n "$external_zone" ]; then
+		ifname6=$($FW -q zone "$external_zone" 2>/dev/null | head -1)
 	else
-		if [ -n "$external_zone" ] ; then
-			ifname6=$($FW -q zone "$external_zone" 2>/dev/null | head -1)
-		else
-			network_find_wan6 external_iface6 && \
-				network_get_device ifname6 "$external_iface6"
-		fi
+		network_find_wan6 external_iface6 && network_get_device ifname6 "$external_iface6"
 	fi
+	if [ "$ifname" = "" ]; then
+		log "No external network interface found, not starting" daemon.err
+		return 1
+	fi
+	# Workaround for daemon bug with UPnP IGDv2 if IPv6 is not ready at start
+	if [ "$ipv6_disable" = "0" ] && [ "$(uci -q get firewall.@defaults[0].disable_ipv6)" != "1" ] &&
+		[ "$(uci -q get network.wan6.disabled)" != "1" ]; then
+		local pass=0
+		while ! ip -6 addr show dev "${ifname6:-$ifname}" | grep -q "inet6 [23]"; do
+			log "IPv6 not ready yet; delay start"
+			sleep 5
+			pass=$((pass + 1))
+			[ "$pass" = "4" ] && log "IPv6 GUA not yet available, UPnP IGD mapping not possible" && break
+		done
+	fi
+	if ! uci -q get upnpd.@internal_network[0].interface >/dev/null; then
+		log "No internal networks configured, not starting" daemon.err
+		return 1
+	fi
+	# Only perform an STUN CGNAT test if necessary, with a private/CGNAT-reserved external IPv4
+	local extipv4 extipv4private
+	extipv4="$(ip -4 addr show dev "$ifname" | grep inet | head -1 | sed -E "s/.*inet ([0-9.]+).*/\1/")"
+	case "$extipv4" in
+	10.* | 100.6[4-9].* | 100.[7-9][0-9].* | 100.1[0-1][0-9].* | 100.12[0-7].* | 172.1[6-9].* | \
+		172.2[0-9].* | 172.3[0-1].* | 192.0.0.[1-6] | 192.168.* | 198.1[89].*) extipv4private=1 ;;
+	esac
+	[ "$extipv4private" = "1" ] && log "Private/CGNAT-reserved external IPv4 detected ($extipv4)"
 
-	if [ -n "$config_file" ]; then
-		conf="$config_file"
-	else
-		local tmpconf="/var/etc/miniupnpd.conf"
-		conf="$tmpconf"
-		mkdir -p /var/etc
-		if [ "$ifname" = "" ]; then
-			log "No external network interface found, not starting" daemon.err
-			return 1
-		fi
-		if ! uci -q get upnpd.@internal_network[0].interface >/dev/null; then
-			log "No internal networks configured, not starting" daemon.err
-			return 1
-		fi
-		# Only perform an STUN CGNAT test if necessary, with a private/CGNAT-reserved external IPv4
-		local extipv4 extipv4private
-		extipv4="$(ip -4 addr show dev "$ifname" | grep inet | head -1 | sed -E "s/.*inet ([0-9.]+).*/\1/")"
-		case "$extipv4" in
-		10.* | 100.6[4-9].* | 100.[7-9][0-9].* | 100.1[0-1][0-9].* | 100.12[0-7].* | 172.1[6-9].* | \
-			172.2[0-9].* | 172.3[0-1].* | 192.0.0.[1-6] | 192.168.* | 198.1[89].*) extipv4private=1 ;;
-		esac
-		[ "$extipv4private" = "1" ] && log "Private/CGNAT-reserved external IPv4 detected ($extipv4)"
-		{
+	{
 		echo "# Daemon"
 		[ "$enable_protocols" = "all" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=yes"
 		[ "$enable_protocols" = "upnp-igd" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=no"
@@ -190,32 +179,15 @@ upnpd() {
 		config_foreach upnpd_add_int_network_and_defaults internal_network post-acl
 		echo "deny 1-65535 0.0.0.0/0 1-65535 # Reject ACL by default"
 
-		} > "$tmpconf"
-	fi
-
-	if [ -n "$ifname" ]; then
-		if [ "$FW" = "fw4" ]; then
-			nft -s -t -n list chain inet fw4 upnp_forward >/dev/null 2>&1 || fw4 reload
-		else
-			iptables -L MINIUPNPD >/dev/null 2>&1 || fw3 reload
-		fi
-	fi
-
-	procd_open_instance
-	procd_set_param file "$conf" "/etc/config/firewall"
-	procd_set_param command "$PROG"
-	procd_append_param command -f "$conf"
-	[ "$log_output" = "info" ] && procd_append_param command -v
-	[ "$log_output" = "debug" ] && procd_append_param command -v -v
-	procd_close_instance
+	} >"$1"
 }
 
 stop_service() {
 	if [ "$FW" = "fw3" ]; then
-		iptables -t nat -F MINIUPNPD 2>/dev/null
-		iptables -t nat -F MINIUPNPD-POSTROUTING 2>/dev/null
 		iptables -t filter -F MINIUPNPD 2>/dev/null
 		[ -x /usr/sbin/ip6tables ] && ip6tables -t filter -F MINIUPNPD 2>/dev/null
+		iptables -t nat -F MINIUPNPD 2>/dev/null
+		iptables -t nat -F MINIUPNPD-POSTROUTING 2>/dev/null
 	else
 		nft flush chain inet fw4 upnp_forward 2>/dev/null
 		nft flush chain inet fw4 upnp_prerouting 2>/dev/null
@@ -225,11 +197,41 @@ stop_service() {
 
 start_service() {
 	config_load "upnpd"
-	config_foreach upnpd "upnpd"
+	local enabled config_file log_output conf
+	config_get enabled settings enabled 0
+	config_get config_file settings config_file
+	config_get log_output settings log_output
+	if [ "$enabled" != "1" ]; then
+		log "Service disabled, enabled UCI option not set"
+		return 1
+	fi
+
+	if [ -n "$config_file" ]; then
+		conf="$config_file"
+	else
+		local tmpconf="/var/etc/miniupnpd.conf"
+		conf="$tmpconf"
+		mkdir -p /var/etc
+		upnpd_generate_config "$tmpconf" || return 1
+	fi
+
+	if [ "$FW" = "fw4" ]; then
+		nft -s -t -n list chain inet fw4 upnp_forward >/dev/null 2>&1 || fw4 reload
+	else
+		iptables -L MINIUPNPD >/dev/null 2>&1 || fw3 reload
+	fi
+
+	procd_open_instance
+	procd_set_param file "$conf"
+	procd_set_param command "$PROG"
+	procd_append_param command -f "$conf"
+	[ "$log_output" = "info" ] && procd_append_param command -v
+	[ "$log_output" = "debug" ] && procd_append_param command -v -v
+	procd_close_instance
 }
 
 service_triggers() {
-	procd_add_reload_trigger "upnpd"
+	procd_add_reload_trigger "upnpd" "firewall"
 }
 
 log() {

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -44,42 +44,42 @@ conf_rule_add() {
 upnpd() {
 	config_load "upnpd"
 	local enabled
-	config_get enabled config enabled 0
+	config_get enabled settings enabled 0
 	if [ "$enabled" != "1" ]; then
 		log "Service disabled, enabled UCI option not set"
 		return 1
 	fi
 	# Daemon
 	local enable_protocols allow_cgnat stun_host allow_third_party_mapping ipv6_disable system_uptime log_output lease_file config_file
-	config_get enable_protocols config enable_protocols all
-	config_get allow_cgnat config allow_cgnat 0
-	config_get stun_host config stun_host stun.nextcloud.com
-	config_get allow_third_party_mapping config allow_third_party_mapping 0
-	config_get ipv6_disable config ipv6_disable 0
-	config_get system_uptime config system_uptime 1
-	config_get log_output config log_output
-	config_get lease_file config lease_file /var/run/miniupnpd.leases
-	config_get config_file config config_file
+	config_get enable_protocols settings enable_protocols all
+	config_get allow_cgnat settings allow_cgnat 0
+	config_get stun_host settings stun_host stun.nextcloud.com
+	config_get allow_third_party_mapping settings allow_third_party_mapping 0
+	config_get ipv6_disable settings ipv6_disable 0
+	config_get system_uptime settings system_uptime 1
+	config_get log_output settings log_output
+	config_get lease_file settings lease_file /var/run/miniupnpd.leases
+	config_get config_file settings config_file
 
 	# UPnP IGD
 	local upnp_igd_compat download_kbps upload_kbps friendly_name model_number serial_number presentation_url uuid http_port notify_interval
-	config_get upnp_igd_compat config upnp_igd_compat igdv1
-	config_get download_kbps config download_kbps
-	config_get upload_kbps config upload_kbps
-	config_get friendly_name config friendly_name "OpenWrt UPnP IGD & PCP"
-	config_get model_number config model_number
-	config_get serial_number config serial_number
-	config_get presentation_url config presentation_url
-	config_get uuid config uuid
-	config_get http_port config http_port 5000
-	config_get notify_interval config notify_interval
+	config_get upnp_igd_compat settings upnp_igd_compat igdv1
+	config_get download_kbps settings download_kbps
+	config_get upload_kbps settings upload_kbps
+	config_get friendly_name settings friendly_name "OpenWrt UPnP IGD & PCP"
+	config_get model_number settings model_number
+	config_get serial_number settings serial_number
+	config_get presentation_url settings presentation_url
+	config_get uuid settings uuid
+	config_get http_port settings http_port 5000
+	config_get notify_interval settings notify_interval
 
 	# External network interface
 	local external_iface external_iface6 external_zone external_ip
-	config_get external_iface config external_iface
-	config_get external_iface6 config external_iface6
-	config_get external_zone config external_zone
-	config_get external_ip config external_ip
+	config_get external_iface settings external_iface
+	config_get external_iface6 settings external_iface6
+	config_get external_zone settings external_zone
+	config_get external_ip settings external_ip
 
 	local conf ifname ifname6
 	. /lib/functions/network.sh
@@ -161,7 +161,7 @@ upnpd() {
 			[ -z "$uuid" ] && {
 				log "Generate UPnP IGD UUID"
 				uuid="$(cat /proc/sys/kernel/random/uuid)"
-				uci set upnpd.config.uuid="$uuid"
+				uci set upnpd.settings.uuid="$uuid"
 				uci commit upnpd
 			}
 			[ "$uuid" != "nocli" ] && echo "uuid=$uuid" || log "uuid=nocli deprecated, set to 00000000-0000-0000-0000-000000000000 instead"

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -7,38 +7,39 @@ USE_PROCD=1
 PROG=/usr/sbin/miniupnpd
 [ -x "$(command -v nft)" ] && FW="fw4" || FW="fw3"
 
-upnpd_get_port_range() {
-	local var="$1"; shift
-	local val
-
-	config_get val "$@"
-
-	case "$val" in
-		[0-9]*[:-][0-9]*)
-			export -n -- "${var}_start=${val%%[:-]*}"
-			export -n -- "${var}_end=${val##*[:-]}"
-		;;
-		[0-9]*)
-			export -n -- "${var}_start=$val"
-			export -n -- "${var}_end="
-		;;
-	esac
+is_port_or_range() {
+	[ "$1" = "0" ] && [ "$2" != "allowport0" ] && return 1
+	[ "$1" -ge "1" ] 2>/dev/null && [ "$1" -le "65535" ] 2>/dev/null && return 0
+	[ "$2" = "allowport0" ] && local minport=0 || local minport=1
+	[ "${1%%-*}" -ge "$minport" ] 2>/dev/null && [ "${1%%-*}" -le "65535" ] 2>/dev/null &&
+		[ "${1##*-}" -ge "$minport" ] 2>/dev/null && [ "${1##*-}" -le "65535" ] 2>/dev/null &&
+		[ "${1##*-}" -ge "${1%%-*}" ] 2>/dev/null && return 0 || return 1
 }
 
-conf_rule_add() {
+upnpd_add_acl_entry() {
 	local cfg="$1"
-	local action int_addr
-	local ext_start ext_end int_start int_end comment
-	config_get action "$cfg" action "deny"                # allow or deny
-	upnpd_get_port_range "ext" "$cfg" ext_ports "0-65535" # external ports: x, x-y, x:y
-	config_get int_addr "$cfg" int_addr "0.0.0.0/0"       # ip or network and subnet mask (internal)
-	upnpd_get_port_range "int" "$cfg" int_ports "0-65535" # internal ports: x, x-y, x:y or range
-	config_get comment "$cfg" comment "ACL"		      # comment
-
-	# Make a single IP IP/32 so that miniupnpd.conf can use it.
-	[ "${int_addr%/*}" = "$int_addr" ] && int_addr="$int_addr/32"
-
-	echo "$action $ext_start${ext_end:+-}$ext_end $int_addr $int_start${int_end:+-}$int_end #$comment"
+	local comment int_addr int_port ext_port descr_filter action
+	config_get comment "$cfg" comment "unspecified" # comment
+	config_get int_addr "$cfg" int_addr "0.0.0.0/0" # IPv4 address or address and netmask (internal)
+	config_get int_port "$cfg" int_port "1-65535"   # internal port or range: x or x-y
+	config_get ext_port "$cfg" ext_port "1-65535"   # external port or range: x or x-y
+	config_get descr_filter "$cfg" descr_filter     # description regex filter (must be built in)
+	config_get action "$cfg" action                 # accept/reject/disabled
+	! is_port_or_range "$int_port" allowport0 &&
+		log "ACL entry: Invalid port or port range ($int_port) in int_port ignored" daemon.warn && int_port=1-65535
+	! is_port_or_range "$ext_port" allowport0 &&
+		log "ACL entry: Invalid port or port range ($ext_port) in ext_port ignored" daemon.warn && ext_port=1-65535
+	[ "$descr_filter" != "" ] && descr_filter=" \"$descr_filter\""
+	if [ "$action" = "accept" ]; then
+		action=allow
+	elif [ "$action" = "reject" ]; then
+		action=deny
+	elif [ "$action" != "disabled" ]; then
+		log "ACL entry: Entry with invalid action ($action) ignored" daemon.warn
+		action=disabled
+	fi
+	[ "$action" = "disabled" ] && return 0
+	echo "$action $ext_port $int_addr $int_port${descr_filter} # $comment"
 }
 
 upnpd() {
@@ -185,8 +186,9 @@ upnpd() {
 
 		echo "# Enable internal networks / access control"
 		config_foreach upnpd_add_int_network_and_defaults internal_network pre-acl
-		config_foreach conf_rule_add perm_rule
+		config_foreach upnpd_add_acl_entry acl_entry
 		config_foreach upnpd_add_int_network_and_defaults internal_network post-acl
+		echo "deny 1-65535 0.0.0.0/0 1-65535 # Reject ACL by default"
 
 		} > "$tmpconf"
 	fi
@@ -255,18 +257,9 @@ upnpd_add_int_network_and_defaults() {
 		echo "# Enable internal network $interface ($device) with access defaults $access_defaults and check ACL $check_acl"
 		echo "listening_ip=$device"
 		for rejectport in $reject_ports; do
-			if [ "$rejectport" -ge "1" ] 2>/dev/null && [ "$rejectport" -le "65535" ] 2>/dev/null ||
-				{
-					[ "${rejectport%%-*}" -ge "1" ] 2>/dev/null &&
-						[ "${rejectport%%-*}" -le "65535" ] 2>/dev/null &&
-						[ "${rejectport##*-}" -ge "1" ] 2>/dev/null &&
-						[ "${rejectport##*-}" -le "65535" ] 2>/dev/null &&
-						[ "${rejectport##*-}" -ge "${rejectport%%-*}" ] 2>/dev/null
-				}; then
-				echo "deny $rejectport 0.0.0.0/0 $rejectport # Reject port $rejectport"
-			else
+			is_port_or_range "$rejectport" allowport0 && echo "deny 1-65535 0.0.0.0/0 $rejectport # Reject port $rejectport" &&
+				echo "deny $rejectport 0.0.0.0/0 1-65535 # Reject external port $rejectport" ||
 				log "Invalid port or port range ($rejectport) in reject_ports ignored" daemon.warn
-			fi
 		done
 	fi
 	if { [ "$2" = "post-acl" ] && [ "$check_acl" = "1" ]; } ||
@@ -283,18 +276,8 @@ upnpd_add_int_network_and_defaults() {
 			log "Invalid access_defaults ($access_defaults) ignored" daemon.warn
 		fi
 		for acceptport in $accessdefaultsports $accept_ports; do
-			if [ "$acceptport" -ge "1" ] 2>/dev/null && [ "$acceptport" -le "65535" ] 2>/dev/null ||
-				{
-					[ "${acceptport%%-*}" -ge "1" ] 2>/dev/null &&
-						[ "${acceptport%%-*}" -le "65535" ] 2>/dev/null &&
-						[ "${acceptport##*-}" -ge "1" ] 2>/dev/null &&
-						[ "${acceptport##*-}" -le "65535" ] 2>/dev/null &&
-						[ "${acceptport##*-}" -ge "${acceptport%%-*}" ] 2>/dev/null
-				}; then
-				echo "allow $acceptport $subnet $acceptport # Accept port $acceptport on $interface"
-			else
+			is_port_or_range "$acceptport" && echo "allow $acceptport $subnet $acceptport # Accept port $acceptport on $interface" ||
 				log "Invalid port or port range ($acceptport) in accept_ports ignored" daemon.warn
-			fi
 		done
 	fi
 	if [ "$2" = "pre-acl" ] && [ "$check_acl" = "0" ]; then

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -61,14 +61,21 @@ service_triggers() {
 
 upnpd_generate_config() {
 	# Daemon
-	local enable_protocols allow_cgnat stun_host allow_third_party_mapping ipv6_disable system_uptime lease_file
+	local enable_protocols allow_cgnat stun_host allow_third_party_mapping system_uptime lease_file
 	config_get enable_protocols settings enable_protocols all
 	config_get allow_cgnat settings allow_cgnat 0
 	config_get stun_host settings stun_host stun.nextcloud.com
 	config_get allow_third_party_mapping settings allow_third_party_mapping 0
-	config_get ipv6_disable settings ipv6_disable 0
 	config_get system_uptime settings system_uptime 1
 	config_get lease_file settings lease_file /var/run/miniupnpd.leases
+
+	# Access control
+	local access_defaults accept_ports reject_ports check_acl ipv6_disable
+	config_get access_defaults settings access_defaults none
+	config_get accept_ports settings accept_ports
+	config_get reject_ports settings reject_ports "21 23 135 137-139 445 3389"
+	config_get check_acl settings check_acl 1
+	config_get ipv6_disable settings ipv6_disable 0
 
 	# UPnP IGD
 	local upnp_igd_compat download_kbps upload_kbps friendly_name model_number serial_number presentation_url uuid http_port notify_interval
@@ -83,12 +90,13 @@ upnpd_generate_config() {
 	config_get http_port settings http_port 5000
 	config_get notify_interval settings notify_interval
 
-	# External network interface
-	local external_iface external_iface6 external_zone external_ip
+	# Network interfaces
+	local external_iface external_iface6 external_zone external_ip internal_iface
 	config_get external_iface settings external_iface
 	config_get external_iface6 settings external_iface6
 	config_get external_zone settings external_zone
 	config_get external_ip settings external_ip
+	config_get internal_iface settings internal_iface lan
 
 	local ifname ifname6
 	. /lib/functions/network.sh
@@ -121,10 +129,6 @@ upnpd_generate_config() {
 			[ "$pass" = "4" ] && log "IPv6 GUA not yet available, UPnP IGD mapping not possible" && break
 		done
 	fi
-	if ! uci -q get upnpd.@internal_network[0].interface >/dev/null; then
-		log "No internal networks configured, not starting" daemon.err
-		return 1
-	fi
 	# Only perform an STUN CGNAT test if necessary, with a private/CGNAT-reserved external IPv4
 	local extipv4 extipv4private
 	extipv4="$(ip -4 addr show dev "$ifname" | grep inet | head -1 | sed -E "s/.*inet ([0-9.]+).*/\1/")"
@@ -151,7 +155,6 @@ upnpd_generate_config() {
 		[ "$allow_third_party_mapping" = "1" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=yes"
 		[ "$allow_third_party_mapping" = "upnp-igd" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=no"
 		[ "$allow_third_party_mapping" = "pcp" ] && echo "secure_mode=yes" && echo "pcp_allow_thirdparty=yes"
-		[ "$ipv6_disable" = "0" ] && echo "ipv6_disable=no" || echo "ipv6_disable=yes"
 		[ "$system_uptime" = "0" ] && echo "system_uptime=no" || echo "system_uptime=yes"
 		touch "$lease_file" && echo "lease_file=$lease_file"
 		[ "$ipv6_disable" = "0" ] && touch "${lease_file}-ipv6" && echo "lease_file6=${lease_file}-ipv6"
@@ -191,9 +194,38 @@ upnpd_generate_config() {
 		[ -n "$external_ip" ] && echo "ext_ip=$external_ip"
 
 		echo "# Enable internal networks / access control"
-		config_foreach upnpd_add_int_network_and_defaults internal_network pre-acl
-		config_foreach upnpd_add_acl_entry acl_entry
-		config_foreach upnpd_add_int_network_and_defaults internal_network post-acl
+		[ "$ipv6_disable" = "0" ] && echo "ipv6_disable=no" || echo "ipv6_disable=yes"
+		local rejectport
+		for rejectport in $reject_ports; do
+			is_port_or_range "$rejectport" allowport0 && echo "deny 1-65535 0.0.0.0/0 $rejectport # Reject port $rejectport" &&
+				echo "deny $rejectport 0.0.0.0/0 1-65535 # Reject external port $rejectport" ||
+				log "Invalid port or port range ($rejectport) in reject_ports ignored" daemon.warn
+		done
+		[ "$check_acl" = "1" ] && echo "# Access control list" && config_foreach upnpd_add_acl_entry acl_entry
+		local iface
+		for iface in $internal_iface; do
+			local device subnet accessdefaultsports acceptport
+			network_get_device device "$iface"
+			network_get_subnet subnet "$iface"
+			[ "$subnet" = "" ] && log "Cannot get IPv4 subnet for network $iface, network ignored" daemon.warn && continue
+			echo "# Enable internal network $iface ($device) with access defaults $access_defaults and check ACL $check_acl"
+			echo "listening_ip=$device"
+			if [ "$access_defaults" = "accept-high-ports" ]; then
+				accessdefaultsports="1024-65535"
+			elif [ "$access_defaults" = "accept-web+high-ports" ]; then
+				accessdefaultsports="80 443 1024-65535"
+			elif [ "$access_defaults" = "accept-web-ports" ]; then
+				accessdefaultsports="80 443"
+			elif [ "$access_defaults" = "accept-all-ports" ]; then
+				accessdefaultsports="1-65535"
+			elif [ "$access_defaults" != "none" ]; then
+				log "Invalid access_defaults ($access_defaults) ignored" daemon.warn
+			fi
+			for acceptport in $accessdefaultsports $accept_ports; do
+				is_port_or_range "$acceptport" && echo "allow $acceptport $subnet $acceptport # Accept port $acceptport on $iface" ||
+					log "Invalid port or port range ($acceptport) in accept_ports ignored" daemon.warn
+			done
+		done
 		echo "deny 1-65535 0.0.0.0/0 1-65535 # Reject ACL by default"
 
 	} >"$1"
@@ -215,50 +247,6 @@ is_port_or_range() {
 	[ "${1%%-*}" -ge "$minport" ] 2>/dev/null && [ "${1%%-*}" -le "65535" ] 2>/dev/null &&
 		[ "${1##*-}" -ge "$minport" ] 2>/dev/null && [ "${1##*-}" -le "65535" ] 2>/dev/null &&
 		[ "${1##*-}" -ge "${1%%-*}" ] 2>/dev/null && return 0 || return 1
-}
-
-upnpd_add_int_network_and_defaults() {
-	local cfg="$1"
-	local interface access_defaults accept_ports reject_ports check_acl
-	config_get interface "$cfg" interface
-	config_get access_defaults "$cfg" access_defaults none
-	config_get accept_ports "$cfg" accept_ports
-	config_get reject_ports "$cfg" reject_ports "21 23 135 137-139 445 3389"
-	config_get check_acl "$cfg" check_acl 1
-	local device subnet rejectport accessdefaultsports acceptport
-	network_get_device device "$interface"
-	network_get_subnet subnet "$interface"
-	[ "$subnet" = "" ] && log "Cannot get IPv4 subnet for network $interface, network ignored" daemon.warn && return 0
-	if [ "$2" = "pre-acl" ]; then
-		echo "# Enable internal network $interface ($device) with access defaults $access_defaults and check ACL $check_acl"
-		echo "listening_ip=$device"
-		for rejectport in $reject_ports; do
-			is_port_or_range "$rejectport" allowport0 && echo "deny 1-65535 0.0.0.0/0 $rejectport # Reject port $rejectport" &&
-				echo "deny $rejectport 0.0.0.0/0 1-65535 # Reject external port $rejectport" ||
-				log "Invalid port or port range ($rejectport) in reject_ports ignored" daemon.warn
-		done
-	fi
-	if { [ "$2" = "post-acl" ] && [ "$check_acl" = "1" ]; } ||
-		{ [ "$2" = "pre-acl" ] && [ "$check_acl" = "0" ]; }; then
-		if [ "$access_defaults" = "accept-high-ports" ]; then
-			accessdefaultsports="1024-65535"
-		elif [ "$access_defaults" = "accept-web+high-ports" ]; then
-			accessdefaultsports="80 443 1024-65535"
-		elif [ "$access_defaults" = "accept-web-ports" ]; then
-			accessdefaultsports="80 443"
-		elif [ "$access_defaults" = "accept-all-ports" ]; then
-			accessdefaultsports="1-65535"
-		elif [ "$access_defaults" != "none" ]; then
-			log "Invalid access_defaults ($access_defaults) ignored" daemon.warn
-		fi
-		for acceptport in $accessdefaultsports $accept_ports; do
-			is_port_or_range "$acceptport" && echo "allow $acceptport $subnet $acceptport # Accept port $acceptport on $interface" ||
-				log "Invalid port or port range ($acceptport) in accept_ports ignored" daemon.warn
-		done
-	fi
-	if [ "$2" = "pre-acl" ] && [ "$check_acl" = "0" ]; then
-		echo "deny 1-65535 $subnet 1-65535 # Reject ACL by default on $interface"
-	fi
 }
 
 upnpd_add_acl_entry() {

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -7,39 +7,56 @@ USE_PROCD=1
 PROG=/usr/sbin/miniupnpd
 [ -x "$(command -v nft)" ] && FW="fw4" || FW="fw3"
 
-is_port_or_range() {
-	[ "$1" = "0" ] && [ "$2" != "allowport0" ] && return 1
-	[ "$1" -ge "1" ] 2>/dev/null && [ "$1" -le "65535" ] 2>/dev/null && return 0
-	[ "$2" = "allowport0" ] && local minport=0 || local minport=1
-	[ "${1%%-*}" -ge "$minport" ] 2>/dev/null && [ "${1%%-*}" -le "65535" ] 2>/dev/null &&
-		[ "${1##*-}" -ge "$minport" ] 2>/dev/null && [ "${1##*-}" -le "65535" ] 2>/dev/null &&
-		[ "${1##*-}" -ge "${1%%-*}" ] 2>/dev/null && return 0 || return 1
+start_service() {
+	config_load "upnpd"
+	local enabled config_file log_output conf
+	config_get enabled settings enabled 0
+	config_get config_file settings config_file
+	config_get log_output settings log_output
+	if [ "$enabled" != "1" ]; then
+		log "Service disabled, enabled UCI option not set"
+		return 1
+	fi
+
+	if [ -n "$config_file" ]; then
+		conf="$config_file"
+	else
+		local tmpconf="/var/etc/miniupnpd.conf"
+		conf="$tmpconf"
+		mkdir -p /var/etc
+		upnpd_generate_config "$tmpconf" || return 1
+	fi
+
+	if [ "$FW" = "fw4" ]; then
+		nft -s -t -n list chain inet fw4 upnp_forward >/dev/null 2>&1 || fw4 reload
+	else
+		iptables -L MINIUPNPD >/dev/null 2>&1 || fw3 reload
+	fi
+
+	procd_open_instance
+	procd_set_param file "$conf"
+	procd_set_param command "$PROG"
+	procd_append_param command -f "$conf"
+	[ "$log_output" = "info" ] && procd_append_param command -v
+	[ "$log_output" = "debug" ] && procd_append_param command -v -v
+	procd_close_instance
 }
 
-upnpd_add_acl_entry() {
-	local cfg="$1"
-	local comment int_addr int_port ext_port descr_filter action
-	config_get comment "$cfg" comment "unspecified" # comment
-	config_get int_addr "$cfg" int_addr "0.0.0.0/0" # IPv4 address or address and netmask (internal)
-	config_get int_port "$cfg" int_port "1-65535"   # internal port or range: x or x-y
-	config_get ext_port "$cfg" ext_port "1-65535"   # external port or range: x or x-y
-	config_get descr_filter "$cfg" descr_filter     # description regex filter (must be built in)
-	config_get action "$cfg" action                 # accept/reject/disabled
-	! is_port_or_range "$int_port" allowport0 &&
-		log "ACL entry: Invalid port or port range ($int_port) in int_port ignored" daemon.warn && int_port=1-65535
-	! is_port_or_range "$ext_port" allowport0 &&
-		log "ACL entry: Invalid port or port range ($ext_port) in ext_port ignored" daemon.warn && ext_port=1-65535
-	[ "$descr_filter" != "" ] && descr_filter=" \"$descr_filter\""
-	if [ "$action" = "accept" ]; then
-		action=allow
-	elif [ "$action" = "reject" ]; then
-		action=deny
-	elif [ "$action" != "disabled" ]; then
-		log "ACL entry: Entry with invalid action ($action) ignored" daemon.warn
-		action=disabled
+stop_service() {
+	if [ "$FW" = "fw3" ]; then
+		iptables -t filter -F MINIUPNPD 2>/dev/null
+		[ -x /usr/sbin/ip6tables ] && ip6tables -t filter -F MINIUPNPD 2>/dev/null
+		iptables -t nat -F MINIUPNPD 2>/dev/null
+		iptables -t nat -F MINIUPNPD-POSTROUTING 2>/dev/null
+	else
+		nft flush chain inet fw4 upnp_forward 2>/dev/null
+		nft flush chain inet fw4 upnp_prerouting 2>/dev/null
+		#nft flush chain inet fw4 upnp_postrouting 2>/dev/null # Not used with nftables
 	fi
-	[ "$action" = "disabled" ] && return 0
-	echo "$action $ext_port $int_addr $int_port${descr_filter} # $comment"
+}
+
+service_triggers() {
+	procd_add_reload_trigger "upnpd" "firewall"
 }
 
 upnpd_generate_config() {
@@ -182,58 +199,6 @@ upnpd_generate_config() {
 	} >"$1"
 }
 
-stop_service() {
-	if [ "$FW" = "fw3" ]; then
-		iptables -t filter -F MINIUPNPD 2>/dev/null
-		[ -x /usr/sbin/ip6tables ] && ip6tables -t filter -F MINIUPNPD 2>/dev/null
-		iptables -t nat -F MINIUPNPD 2>/dev/null
-		iptables -t nat -F MINIUPNPD-POSTROUTING 2>/dev/null
-	else
-		nft flush chain inet fw4 upnp_forward 2>/dev/null
-		nft flush chain inet fw4 upnp_prerouting 2>/dev/null
-		#nft flush chain inet fw4 upnp_postrouting 2>/dev/null # Not used with nftables
-	fi
-}
-
-start_service() {
-	config_load "upnpd"
-	local enabled config_file log_output conf
-	config_get enabled settings enabled 0
-	config_get config_file settings config_file
-	config_get log_output settings log_output
-	if [ "$enabled" != "1" ]; then
-		log "Service disabled, enabled UCI option not set"
-		return 1
-	fi
-
-	if [ -n "$config_file" ]; then
-		conf="$config_file"
-	else
-		local tmpconf="/var/etc/miniupnpd.conf"
-		conf="$tmpconf"
-		mkdir -p /var/etc
-		upnpd_generate_config "$tmpconf" || return 1
-	fi
-
-	if [ "$FW" = "fw4" ]; then
-		nft -s -t -n list chain inet fw4 upnp_forward >/dev/null 2>&1 || fw4 reload
-	else
-		iptables -L MINIUPNPD >/dev/null 2>&1 || fw3 reload
-	fi
-
-	procd_open_instance
-	procd_set_param file "$conf"
-	procd_set_param command "$PROG"
-	procd_append_param command -f "$conf"
-	[ "$log_output" = "info" ] && procd_append_param command -v
-	[ "$log_output" = "debug" ] && procd_append_param command -v -v
-	procd_close_instance
-}
-
-service_triggers() {
-	procd_add_reload_trigger "upnpd" "firewall"
-}
-
 log() {
 	logger -s -p "${2:-daemon.notice}" -t "miniupnpd-init" "$1" || echo "miniupnpd-init: $1" >&2
 }
@@ -241,6 +206,15 @@ log() {
 xml_encode() {
 	# Encode required XML entities of text UPnP IGD config options until the daemon does so
 	echo "$1" | sed "s/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g"
+}
+
+is_port_or_range() {
+	[ "$1" = "0" ] && [ "$2" != "allowport0" ] && return 1
+	[ "$1" -ge "1" ] 2>/dev/null && [ "$1" -le "65535" ] 2>/dev/null && return 0
+	[ "$2" = "allowport0" ] && local minport=0 || local minport=1
+	[ "${1%%-*}" -ge "$minport" ] 2>/dev/null && [ "${1%%-*}" -le "65535" ] 2>/dev/null &&
+		[ "${1##*-}" -ge "$minport" ] 2>/dev/null && [ "${1##*-}" -le "65535" ] 2>/dev/null &&
+		[ "${1##*-}" -ge "${1%%-*}" ] 2>/dev/null && return 0 || return 1
 }
 
 upnpd_add_int_network_and_defaults() {
@@ -285,4 +259,30 @@ upnpd_add_int_network_and_defaults() {
 	if [ "$2" = "pre-acl" ] && [ "$check_acl" = "0" ]; then
 		echo "deny 1-65535 $subnet 1-65535 # Reject ACL by default on $interface"
 	fi
+}
+
+upnpd_add_acl_entry() {
+	local cfg="$1"
+	local comment int_addr int_port ext_port descr_filter action
+	config_get comment "$cfg" comment "unspecified" # comment
+	config_get int_addr "$cfg" int_addr "0.0.0.0/0" # IPv4 address or address and netmask (internal)
+	config_get int_port "$cfg" int_port "1-65535"   # internal port or range: x or x-y
+	config_get ext_port "$cfg" ext_port "1-65535"   # external port or range: x or x-y
+	config_get descr_filter "$cfg" descr_filter     # description regex filter (must be built in)
+	config_get action "$cfg" action                 # accept/reject/disabled
+	! is_port_or_range "$int_port" allowport0 &&
+		log "ACL entry: Invalid port or port range ($int_port) in int_port ignored" daemon.warn && int_port=1-65535
+	! is_port_or_range "$ext_port" allowport0 &&
+		log "ACL entry: Invalid port or port range ($ext_port) in ext_port ignored" daemon.warn && ext_port=1-65535
+	[ "$descr_filter" != "" ] && descr_filter=" \"$descr_filter\""
+	if [ "$action" = "accept" ]; then
+		action=allow
+	elif [ "$action" = "reject" ]; then
+		action=deny
+	elif [ "$action" != "disabled" ]; then
+		log "ACL entry: Entry with invalid action ($action) ignored" daemon.warn
+		action=disabled
+	fi
+	[ "$action" = "disabled" ] && return 0
+	echo "$action $ext_port $int_addr $int_port${descr_filter} # $comment"
 }

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -42,53 +42,44 @@ conf_rule_add() {
 	echo "$action $ext_start${ext_end:+-}$ext_end $int_addr $int_start${int_end:+-}$int_end #$comment"
 }
 
-upnpd_write_bool() {
-	local opt="$1"
-	local def="${2:-0}"
-	local alt="${3:-$opt}"
-	local val
-
-	config_get_bool val config "$opt" "$def"
-	if [ "$val" -eq 0 ]; then
-		echo "$alt=no"
-	else
-		echo "$alt=yes"
-	fi
-}
-
 upnpd() {
 	config_load "upnpd"
-	local external_iface external_iface6 external_zone external_ip internal_iface
-	local upload download log_output port config_file serial_number model_number
-	local use_stun stun_host stun_port uuid notify_interval presentation_url
-	local upnp_lease_file upnp_lease_file6 ipv6_disable ext_allow_private_ipv4
+	local external_iface external_iface6 external_zone external_ip
+	local upload_kbps download_kbps log_output http_port config_file serial_number model_number
+	local allow_cgnat stun_host uuid notify_interval presentation_url
+	local lease_file ipv6_disable
+	local enable_protocols allow_third_party_mapping system_uptime upnp_igd_compat
+	local friendly_name
 
 	local enabled
-	config_get_bool enabled config enabled 1
-	[ "$enabled" -eq 0 ] && return 1
-
+	config_get enabled config enabled 0
+	if [ "$enabled" != "1" ]; then
+		log "Service disabled, enabled UCI option not set"
+		return 1
+	fi
 	config_get external_iface config external_iface
 	config_get external_iface6 config external_iface6
 	config_get external_zone config external_zone
 	config_get external_ip config external_ip
-	config_get internal_iface config internal_iface
-	config_get port config port 5000
-	config_get upload config upload
-	config_get download config download
-	config_get_bool log_output config log_output 0
+	config_get http_port config http_port 5000
+	config_get upload_kbps config upload_kbps
+	config_get download_kbps config download_kbps
+	config_get log_output config log_output
 	config_get config_file config config_file
 	config_get serial_number config serial_number
 	config_get model_number config model_number
 	config_get uuid config uuid
-	config_get use_stun config use_stun 0
-	config_get stun_host config stun_host
-	config_get stun_port config stun_port
+	config_get allow_cgnat config allow_cgnat 0
+	config_get stun_host config stun_host stun.nextcloud.com
 	config_get notify_interval config notify_interval
 	config_get presentation_url config presentation_url
-	config_get upnp_lease_file config upnp_lease_file
-	config_get upnp_lease_file6 config upnp_lease_file6
+	config_get lease_file config lease_file /var/run/miniupnpd.leases
 	config_get ipv6_disable config ipv6_disable 0
-	config_get ext_allow_private_ipv4 config ext_allow_private_ipv4 0
+	config_get enable_protocols config enable_protocols all
+	config_get allow_third_party_mapping config allow_third_party_mapping 0
+	config_get system_uptime config system_uptime 1
+	config_get upnp_igd_compat config upnp_igd_compat igdv1
+	config_get friendly_name config friendly_name "OpenWrt UPnP IGD & PCP"
 
 	local conf ifname ifname6
 
@@ -121,55 +112,66 @@ upnpd() {
 		local tmpconf="/var/etc/miniupnpd.conf"
 		conf="$tmpconf"
 		mkdir -p /var/etc
-
+		if [ "$ifname" = "" ]; then
+			log "No external network interface found, not starting" daemon.err
+			return 1
+		fi
+		if ! uci -q get upnpd.@internal_network[0].interface >/dev/null; then
+			log "No internal networks configured, not starting" daemon.err
+			return 1
+		fi
 		{
 		echo "ext_ifname=$ifname"
 		echo "ext_ifname6=$ifname6"
 		[ -n "$external_ip" ] && echo "ext_ip=$external_ip"
 
-		local iface
-		for iface in ${internal_iface:-lan}; do
-			local device
-			network_get_device device "$iface" && echo "listening_ip=$device"
-		done
+		[ "$enable_protocols" = "all" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=yes"
+		[ "$enable_protocols" = "upnp-igd" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=no"
+		[ "$enable_protocols" = "pcp+nat-pmp" ] && echo "enable_upnp=no" && echo "enable_pcp_pmp=yes"
+		[ "$allow_third_party_mapping" = "0" ] && echo "secure_mode=yes" && echo "pcp_allow_thirdparty=no"
+		[ "$allow_third_party_mapping" = "1" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=yes"
+		[ "$allow_third_party_mapping" = "upnp-igd" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=no"
+		[ "$allow_third_party_mapping" = "pcp" ] && echo "secure_mode=yes" && echo "pcp_allow_thirdparty=yes"
+		[ "$system_uptime" = "0" ] && echo "system_uptime=no" || echo "system_uptime=yes"
+		[ "$upnp_igd_compat" = "igdv1" ] && echo "force_igd_desc_v1=yes" || echo "force_igd_desc_v1=no"
+		# Only perform an STUN CGNAT test if necessary, with a private/CGNAT-reserved external IPv4
+		local extipv4 extipv4private
+		extipv4="$(ip -4 addr show dev "$ifname" | grep inet | head -1 | sed -E "s/.*inet ([0-9.]+).*/\1/")"
+		case "$extipv4" in
+		10.* | 100.6[4-9].* | 100.[7-9][0-9].* | 100.1[0-1][0-9].* | 100.12[0-7].* | 172.1[6-9].* | \
+			172.2[0-9].* | 172.3[0-1].* | 192.0.0.[1-6] | 192.168.* | 198.1[89].*) extipv4private=1 ;;
+		esac
+		[ "$extipv4private" = "1" ] && log "Private/CGNAT-reserved external IPv4 detected ($extipv4)"
+		if [ "$extipv4private" = "1" ] && [ "$allow_cgnat" != "0" ]; then
+			[ "$allow_cgnat" = "1" ] && echo "ext_perform_stun=yes"
+			[ "$allow_cgnat" = "allow-filtered" ] && echo "ext_perform_stun=allow-filtered"
+			# Avoid next option, as no STUN public IPv4 detection, required by clients (PCP/NAT-PMP among others)
+			[ "$allow_cgnat" = "report-private-ipv4" ] && echo "ext_allow_private_ipv4=yes"
+			echo "ext_stun_host=${stun_host%%:*}"
+			[ "${stun_host%%:*}" != "${stun_host##*:}" ] && echo "ext_stun_port=${stun_host##*:}"
+		fi
+		[ "$ipv6_disable" = "0" ] && echo "ipv6_disable=no" || echo "ipv6_disable=yes"
 
-		config_load "upnpd"
-		upnpd_write_bool enable_natpmp 1
-		upnpd_write_bool enable_upnp 1
-		upnpd_write_bool secure_mode 1
-		upnpd_write_bool system_uptime 1
-		upnpd_write_bool igdv1 0 force_igd_desc_v1
-		upnpd_write_bool use_stun 0 ext_perform_stun
-		upnpd_write_bool ipv6_disable $ipv6_disable
-		upnpd_write_bool ext_allow_private_ipv4 $ext_allow_private_ipv4
+		[ -n "$download_kbps" ] && echo "bitrate_down=$((download_kbps * 1000))"
+		[ -n "$upload_kbps" ] && echo "bitrate_up=$((upload_kbps * 1000))"
 
-		[ "$use_stun" -eq 0 ] || {
-			[ -n "$stun_host" ] && echo "ext_stun_host=$stun_host"
-			[ -n "$stun_port" ] && echo "ext_stun_port=$stun_port"
-		}
-
-		[ -n "$upload" ] && [ -n "$download" ] && {
-			echo "bitrate_down=$((download * 1024 * 8))"
-			echo "bitrate_up=$((upload * 1024 * 8))"
-		}
-
-		[ -n "$upnp_lease_file" ] && touch "$upnp_lease_file" && echo "lease_file=$upnp_lease_file"
-		[ -n "$upnp_lease_file6" ] && touch "$upnp_lease_file6" && echo "lease_file6=$upnp_lease_file6"
+		touch "$lease_file" && echo "lease_file=$lease_file"
+		[ "$ipv6_disable" = "0" ] && touch "${lease_file}-ipv6" && echo "lease_file6=${lease_file}-ipv6"
+		[ -n "$friendly_name" ] && echo "friendly_name=$friendly_name"
 		[ -n "$presentation_url" ] && echo "presentation_url=$presentation_url"
 		[ -n "$notify_interval" ] && echo "notify_interval=$notify_interval"
-		[ -n "$serial_number" ] && echo "serial=$serial_number"
-		[ -n "$model_number" ] && echo "model_number=$model_number"
-		[ -n "$port" ] && echo "port=$port"
+		echo "serial=$serial_number"
+		echo "model_number=$model_number"
+		echo "http_port=$http_port"
 
 		[ -z "$uuid" ] && {
+			log "Generate UPnP IGD UUID"
 			uuid="$(cat /proc/sys/kernel/random/uuid)"
 			uci set upnpd.config.uuid="$uuid"
 			uci commit upnpd
 		}
 
-		[ "$uuid" = "nocli" ] || echo "uuid=$uuid"
-
-		config_foreach conf_rule_add perm_rule
+		[ "$uuid" != "nocli" ] && echo "uuid=$uuid" || log "uuid=nocli deprecated, set to 00000000-0000-0000-0000-000000000000 instead"
 
 		if [ "$FW" = "fw4" ]; then
 			#When using nftables configure miniupnpd to use its own table and chains
@@ -177,8 +179,13 @@ upnpd() {
 			echo "upnp_nat_table_name=fw4"
 			echo "upnp_forward_chain=upnp_forward"
 			echo "upnp_nat_chain=upnp_prerouting"
-			echo "upnp_nat_postrouting_chain=upnp_postrouting"
+			#echo "upnp_nat_postrouting_chain=upnp_postrouting" # Not used with nftables
 		fi
+
+		echo "# Enable internal networks / access control"
+		config_foreach upnpd_add_int_network_and_defaults internal_network pre-acl
+		config_foreach conf_rule_add perm_rule
+		config_foreach upnpd_add_int_network_and_defaults internal_network post-acl
 
 		} > "$tmpconf"
 	fi
@@ -190,15 +197,14 @@ upnpd() {
 		else
 			iptables -L MINIUPNPD >/dev/null 2>&1 || fw3 reload
 		fi
-	else
-		logger -t "upnp daemon" "external interface not found, not starting"
 	fi
 
 	procd_open_instance
 	procd_set_param file "$conf" "/etc/config/firewall"
 	procd_set_param command "$PROG"
 	procd_append_param command -f "$conf"
-	[ "$log_output" = "1" ] && procd_append_param command -d
+	[ "$log_output" = "info" ] && procd_append_param command -v
+	[ "$log_output" = "debug" ] && procd_append_param command -v -v
 	procd_close_instance
 }
 
@@ -211,7 +217,7 @@ stop_service() {
 	else
 		nft flush chain inet fw4 upnp_forward 2>/dev/null
 		nft flush chain inet fw4 upnp_prerouting 2>/dev/null
-		nft flush chain inet fw4 upnp_postrouting 2>/dev/null
+		#nft flush chain inet fw4 upnp_postrouting 2>/dev/null # Not used with nftables
 	fi
 }
 
@@ -222,4 +228,71 @@ start_service() {
 
 service_triggers() {
 	procd_add_reload_trigger "upnpd"
+}
+
+log() {
+	logger -s -p "${2:-daemon.notice}" -t "miniupnpd-init" "$1" || echo "miniupnpd-init: $1" >&2
+}
+
+upnpd_add_int_network_and_defaults() {
+	local cfg="$1"
+	local interface access_defaults accept_ports reject_ports check_acl
+	config_get interface "$cfg" interface
+	config_get access_defaults "$cfg" access_defaults none
+	config_get accept_ports "$cfg" accept_ports
+	config_get reject_ports "$cfg" reject_ports "21 23 135 137-139 445 3389"
+	config_get check_acl "$cfg" check_acl 1
+	local device subnet rejectport accessdefaultsports acceptport
+	network_get_device device "$interface"
+	network_get_subnet subnet "$interface"
+	[ "$subnet" = "" ] && log "Cannot get IPv4 subnet for network $interface, network ignored" daemon.warn && return 0
+	if [ "$2" = "pre-acl" ]; then
+		echo "# Enable internal network $interface ($device) with access defaults $access_defaults and check ACL $check_acl"
+		echo "listening_ip=$device"
+		for rejectport in $reject_ports; do
+			if [ "$rejectport" -ge "1" ] 2>/dev/null && [ "$rejectport" -le "65535" ] 2>/dev/null ||
+				{
+					[ "${rejectport%%-*}" -ge "1" ] 2>/dev/null &&
+						[ "${rejectport%%-*}" -le "65535" ] 2>/dev/null &&
+						[ "${rejectport##*-}" -ge "1" ] 2>/dev/null &&
+						[ "${rejectport##*-}" -le "65535" ] 2>/dev/null &&
+						[ "${rejectport##*-}" -ge "${rejectport%%-*}" ] 2>/dev/null
+				}; then
+				echo "deny $rejectport 0.0.0.0/0 $rejectport # Reject port $rejectport"
+			else
+				log "Invalid port or port range ($rejectport) in reject_ports ignored" daemon.warn
+			fi
+		done
+	fi
+	if { [ "$2" = "post-acl" ] && [ "$check_acl" = "1" ]; } ||
+		{ [ "$2" = "pre-acl" ] && [ "$check_acl" = "0" ]; }; then
+		if [ "$access_defaults" = "accept-high-ports" ]; then
+			accessdefaultsports="1024-65535"
+		elif [ "$access_defaults" = "accept-web+high-ports" ]; then
+			accessdefaultsports="80 443 1024-65535"
+		elif [ "$access_defaults" = "accept-web-ports" ]; then
+			accessdefaultsports="80 443"
+		elif [ "$access_defaults" = "accept-all-ports" ]; then
+			accessdefaultsports="1-65535"
+		elif [ "$access_defaults" != "none" ]; then
+			log "Invalid access_defaults ($access_defaults) ignored" daemon.warn
+		fi
+		for acceptport in $accessdefaultsports $accept_ports; do
+			if [ "$acceptport" -ge "1" ] 2>/dev/null && [ "$acceptport" -le "65535" ] 2>/dev/null ||
+				{
+					[ "${acceptport%%-*}" -ge "1" ] 2>/dev/null &&
+						[ "${acceptport%%-*}" -le "65535" ] 2>/dev/null &&
+						[ "${acceptport##*-}" -ge "1" ] 2>/dev/null &&
+						[ "${acceptport##*-}" -le "65535" ] 2>/dev/null &&
+						[ "${acceptport##*-}" -ge "${acceptport%%-*}" ] 2>/dev/null
+				}; then
+				echo "allow $acceptport $subnet $acceptport # Accept port $acceptport on $interface"
+			else
+				log "Invalid port or port range ($acceptport) in accept_ports ignored" daemon.warn
+			fi
+		done
+	fi
+	if [ "$2" = "pre-acl" ] && [ "$check_acl" = "0" ]; then
+		echo "deny 1-65535 $subnet 1-65535 # Reject ACL by default on $interface"
+	fi
 }

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -29,7 +29,6 @@ conf_rule_add() {
 	local cfg="$1"
 	local action int_addr
 	local ext_start ext_end int_start int_end comment
-
 	config_get action "$cfg" action "deny"                # allow or deny
 	upnpd_get_port_range "ext" "$cfg" ext_ports "0-65535" # external ports: x, x-y, x:y
 	config_get int_addr "$cfg" int_addr "0.0.0.0/0"       # ip or network and subnet mask (internal)
@@ -44,45 +43,45 @@ conf_rule_add() {
 
 upnpd() {
 	config_load "upnpd"
-	local external_iface external_iface6 external_zone external_ip
-	local upload_kbps download_kbps log_output http_port config_file serial_number model_number
-	local allow_cgnat stun_host uuid notify_interval presentation_url
-	local lease_file ipv6_disable
-	local enable_protocols allow_third_party_mapping system_uptime upnp_igd_compat
-	local friendly_name
-
 	local enabled
 	config_get enabled config enabled 0
 	if [ "$enabled" != "1" ]; then
 		log "Service disabled, enabled UCI option not set"
 		return 1
 	fi
+	# Daemon
+	local enable_protocols allow_cgnat stun_host allow_third_party_mapping ipv6_disable system_uptime log_output lease_file config_file
+	config_get enable_protocols config enable_protocols all
+	config_get allow_cgnat config allow_cgnat 0
+	config_get stun_host config stun_host stun.nextcloud.com
+	config_get allow_third_party_mapping config allow_third_party_mapping 0
+	config_get ipv6_disable config ipv6_disable 0
+	config_get system_uptime config system_uptime 1
+	config_get log_output config log_output
+	config_get lease_file config lease_file /var/run/miniupnpd.leases
+	config_get config_file config config_file
+
+	# UPnP IGD
+	local upnp_igd_compat download_kbps upload_kbps friendly_name model_number serial_number presentation_url uuid http_port notify_interval
+	config_get upnp_igd_compat config upnp_igd_compat igdv1
+	config_get download_kbps config download_kbps
+	config_get upload_kbps config upload_kbps
+	config_get friendly_name config friendly_name "OpenWrt UPnP IGD & PCP"
+	config_get model_number config model_number
+	config_get serial_number config serial_number
+	config_get presentation_url config presentation_url
+	config_get uuid config uuid
+	config_get http_port config http_port 5000
+	config_get notify_interval config notify_interval
+
+	# External network interface
+	local external_iface external_iface6 external_zone external_ip
 	config_get external_iface config external_iface
 	config_get external_iface6 config external_iface6
 	config_get external_zone config external_zone
 	config_get external_ip config external_ip
-	config_get http_port config http_port 5000
-	config_get upload_kbps config upload_kbps
-	config_get download_kbps config download_kbps
-	config_get log_output config log_output
-	config_get config_file config config_file
-	config_get serial_number config serial_number
-	config_get model_number config model_number
-	config_get uuid config uuid
-	config_get allow_cgnat config allow_cgnat 0
-	config_get stun_host config stun_host stun.nextcloud.com
-	config_get notify_interval config notify_interval
-	config_get presentation_url config presentation_url
-	config_get lease_file config lease_file /var/run/miniupnpd.leases
-	config_get ipv6_disable config ipv6_disable 0
-	config_get enable_protocols config enable_protocols all
-	config_get allow_third_party_mapping config allow_third_party_mapping 0
-	config_get system_uptime config system_uptime 1
-	config_get upnp_igd_compat config upnp_igd_compat igdv1
-	config_get friendly_name config friendly_name "OpenWrt UPnP IGD & PCP"
 
 	local conf ifname ifname6
-
 	. /lib/functions/network.sh
 
 	if [ -n "$external_iface" ] ; then
@@ -120,20 +119,6 @@ upnpd() {
 			log "No internal networks configured, not starting" daemon.err
 			return 1
 		fi
-		{
-		echo "ext_ifname=$ifname"
-		echo "ext_ifname6=$ifname6"
-		[ -n "$external_ip" ] && echo "ext_ip=$external_ip"
-
-		[ "$enable_protocols" = "all" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=yes"
-		[ "$enable_protocols" = "upnp-igd" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=no"
-		[ "$enable_protocols" = "pcp+nat-pmp" ] && echo "enable_upnp=no" && echo "enable_pcp_pmp=yes"
-		[ "$allow_third_party_mapping" = "0" ] && echo "secure_mode=yes" && echo "pcp_allow_thirdparty=no"
-		[ "$allow_third_party_mapping" = "1" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=yes"
-		[ "$allow_third_party_mapping" = "upnp-igd" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=no"
-		[ "$allow_third_party_mapping" = "pcp" ] && echo "secure_mode=yes" && echo "pcp_allow_thirdparty=yes"
-		[ "$system_uptime" = "0" ] && echo "system_uptime=no" || echo "system_uptime=yes"
-		[ "$upnp_igd_compat" = "igdv1" ] && echo "force_igd_desc_v1=yes" || echo "force_igd_desc_v1=no"
 		# Only perform an STUN CGNAT test if necessary, with a private/CGNAT-reserved external IPv4
 		local extipv4 extipv4private
 		extipv4="$(ip -4 addr show dev "$ifname" | grep inet | head -1 | sed -E "s/.*inet ([0-9.]+).*/\1/")"
@@ -142,6 +127,11 @@ upnpd() {
 			172.2[0-9].* | 172.3[0-1].* | 192.0.0.[1-6] | 192.168.* | 198.1[89].*) extipv4private=1 ;;
 		esac
 		[ "$extipv4private" = "1" ] && log "Private/CGNAT-reserved external IPv4 detected ($extipv4)"
+		{
+		echo "# Daemon"
+		[ "$enable_protocols" = "all" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=yes"
+		[ "$enable_protocols" = "upnp-igd" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=no"
+		[ "$enable_protocols" = "pcp+nat-pmp" ] && echo "enable_upnp=no" && echo "enable_pcp_pmp=yes"
 		if [ "$extipv4private" = "1" ] && [ "$allow_cgnat" != "0" ]; then
 			[ "$allow_cgnat" = "1" ] && echo "ext_perform_stun=yes"
 			[ "$allow_cgnat" = "allow-filtered" ] && echo "ext_perform_stun=allow-filtered"
@@ -150,37 +140,48 @@ upnpd() {
 			echo "ext_stun_host=${stun_host%%:*}"
 			[ "${stun_host%%:*}" != "${stun_host##*:}" ] && echo "ext_stun_port=${stun_host##*:}"
 		fi
+		[ "$allow_third_party_mapping" = "0" ] && echo "secure_mode=yes" && echo "pcp_allow_thirdparty=no"
+		[ "$allow_third_party_mapping" = "1" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=yes"
+		[ "$allow_third_party_mapping" = "upnp-igd" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=no"
+		[ "$allow_third_party_mapping" = "pcp" ] && echo "secure_mode=yes" && echo "pcp_allow_thirdparty=yes"
 		[ "$ipv6_disable" = "0" ] && echo "ipv6_disable=no" || echo "ipv6_disable=yes"
-
-		[ -n "$download_kbps" ] && echo "bitrate_down=$((download_kbps * 1000))"
-		[ -n "$upload_kbps" ] && echo "bitrate_up=$((upload_kbps * 1000))"
-
+		[ "$system_uptime" = "0" ] && echo "system_uptime=no" || echo "system_uptime=yes"
 		touch "$lease_file" && echo "lease_file=$lease_file"
 		[ "$ipv6_disable" = "0" ] && touch "${lease_file}-ipv6" && echo "lease_file6=${lease_file}-ipv6"
-		[ -n "$friendly_name" ] && echo "friendly_name=$friendly_name"
-		[ -n "$presentation_url" ] && echo "presentation_url=$presentation_url"
-		[ -n "$notify_interval" ] && echo "notify_interval=$notify_interval"
-		echo "serial=$serial_number"
-		echo "model_number=$model_number"
-		echo "http_port=$http_port"
 
-		[ -z "$uuid" ] && {
-			log "Generate UPnP IGD UUID"
-			uuid="$(cat /proc/sys/kernel/random/uuid)"
-			uci set upnpd.config.uuid="$uuid"
-			uci commit upnpd
-		}
-
-		[ "$uuid" != "nocli" ] && echo "uuid=$uuid" || log "uuid=nocli deprecated, set to 00000000-0000-0000-0000-000000000000 instead"
+		if [ "$enable_protocols" = "upnp-igd" ] || [ "$enable_protocols" = "all" ]; then
+			echo "# UPnP IGD"
+			[ "$upnp_igd_compat" = "igdv1" ] && echo "force_igd_desc_v1=yes" || echo "force_igd_desc_v1=no"
+			[ -n "$download_kbps" ] && echo "bitrate_down=$((download_kbps * 1000))"
+			[ -n "$upload_kbps" ] && echo "bitrate_up=$((upload_kbps * 1000))"
+			[ -n "$friendly_name" ] && echo "friendly_name=$(xml_encode "$friendly_name")"
+			[ -n "$model_number" ] && echo "model_number=$(xml_encode "$model_number")" || echo "model_number="
+			[ -n "$serial_number" ] && echo "serial=$(xml_encode "$serial_number")" || echo "serial="
+			[ -n "$presentation_url" ] && echo "presentation_url=$presentation_url"
+			[ -z "$uuid" ] && {
+				log "Generate UPnP IGD UUID"
+				uuid="$(cat /proc/sys/kernel/random/uuid)"
+				uci set upnpd.config.uuid="$uuid"
+				uci commit upnpd
+			}
+			[ "$uuid" != "nocli" ] && echo "uuid=$uuid" || log "uuid=nocli deprecated, set to 00000000-0000-0000-0000-000000000000 instead"
+			echo "http_port=$http_port"
+			[ -n "$notify_interval" ] && echo "notify_interval=$notify_interval"
+		fi
 
 		if [ "$FW" = "fw4" ]; then
-			#When using nftables configure miniupnpd to use its own table and chains
+			echo "# Firewall backend"
 			echo "upnp_table_name=fw4"
 			echo "upnp_nat_table_name=fw4"
 			echo "upnp_forward_chain=upnp_forward"
 			echo "upnp_nat_chain=upnp_prerouting"
 			#echo "upnp_nat_postrouting_chain=upnp_postrouting" # Not used with nftables
 		fi
+
+		echo "# External network interface"
+		echo "ext_ifname=$ifname"
+		echo "ext_ifname6=${ifname6:-$ifname}"
+		[ -n "$external_ip" ] && echo "ext_ip=$external_ip"
 
 		echo "# Enable internal networks / access control"
 		config_foreach upnpd_add_int_network_and_defaults internal_network pre-acl
@@ -191,7 +192,6 @@ upnpd() {
 	fi
 
 	if [ -n "$ifname" ]; then
-		# start firewall
 		if [ "$FW" = "fw4" ]; then
 			nft -s -t -n list chain inet fw4 upnp_forward >/dev/null 2>&1 || fw4 reload
 		else
@@ -232,6 +232,11 @@ service_triggers() {
 
 log() {
 	logger -s -p "${2:-daemon.notice}" -t "miniupnpd-init" "$1" || echo "miniupnpd-init: $1" >&2
+}
+
+xml_encode() {
+	# Encode required XML entities of text UPnP IGD config options until the daemon does so
+	echo "$1" | sed "s/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g"
 }
 
 upnpd_add_int_network_and_defaults() {

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -42,25 +42,16 @@ upnpd_add_acl_entry() {
 	echo "$action $ext_port $int_addr $int_port${descr_filter} # $comment"
 }
 
-upnpd() {
-	config_load "upnpd"
-	local enabled
-	config_get enabled settings enabled 0
-	if [ "$enabled" != "1" ]; then
-		log "Service disabled, enabled UCI option not set"
-		return 1
-	fi
+upnpd_generate_config() {
 	# Daemon
-	local enable_protocols allow_cgnat stun_host allow_third_party_mapping ipv6_disable system_uptime log_output lease_file config_file
+	local enable_protocols allow_cgnat stun_host allow_third_party_mapping ipv6_disable system_uptime lease_file
 	config_get enable_protocols settings enable_protocols all
 	config_get allow_cgnat settings allow_cgnat 0
 	config_get stun_host settings stun_host stun.nextcloud.com
 	config_get allow_third_party_mapping settings allow_third_party_mapping 0
 	config_get ipv6_disable settings ipv6_disable 0
 	config_get system_uptime settings system_uptime 1
-	config_get log_output settings log_output
 	config_get lease_file settings lease_file /var/run/miniupnpd.leases
-	config_get config_file settings config_file
 
 	# UPnP IGD
 	local upnp_igd_compat download_kbps upload_kbps friendly_name model_number serial_number presentation_url uuid http_port notify_interval
@@ -82,53 +73,51 @@ upnpd() {
 	config_get external_zone settings external_zone
 	config_get external_ip settings external_ip
 
-	local conf ifname ifname6
+	local ifname ifname6
 	. /lib/functions/network.sh
-
-	if [ -n "$external_iface" ] ; then
+	if [ -n "$external_iface" ]; then
 		network_get_device ifname "$external_iface"
+	elif [ -n "$external_zone" ]; then
+		ifname=$($FW -q zone "$external_zone" 2>/dev/null | head -1)
 	else
-		if [ -n "$external_zone" ] ; then
-			ifname=$($FW -q zone "$external_zone" 2>/dev/null | head -1)
-		else
-			network_find_wan external_iface && \
-				network_get_device ifname "$external_iface"
-		fi
+		network_find_wan external_iface && network_get_device ifname "$external_iface"
 	fi
-	if [ -n "$external_iface6" ] ; then
+	if [ -n "$external_iface6" ]; then
 		network_get_device ifname6 "$external_iface6"
+	elif [ -n "$external_zone" ]; then
+		ifname6=$($FW -q zone "$external_zone" 2>/dev/null | head -1)
 	else
-		if [ -n "$external_zone" ] ; then
-			ifname6=$($FW -q zone "$external_zone" 2>/dev/null | head -1)
-		else
-			network_find_wan6 external_iface6 && \
-				network_get_device ifname6 "$external_iface6"
-		fi
+		network_find_wan6 external_iface6 && network_get_device ifname6 "$external_iface6"
 	fi
+	if [ "$ifname" = "" ]; then
+		log "No external network interface detected yet, not starting" daemon.err
+		return 1
+	fi
+	# Workaround for daemon bug with UPnP IGDv2 if IPv6 is not ready at start
+	if [ "$ipv6_disable" = "0" ] && [ "$(uci -q get firewall.@defaults[0].disable_ipv6)" != "1" ] &&
+		[ "$(uci -q get network.wan6.disabled)" != "1" ]; then
+		local pass=0
+		while ! ip -6 addr show dev "${ifname6:-$ifname}" | grep -q "inet6 [23]"; do
+			log "IPv6 not ready yet; delay start"
+			sleep 5
+			pass=$((pass + 1))
+			[ "$pass" = "4" ] && log "IPv6 GUA not yet available, UPnP IGD mapping not possible" && break
+		done
+	fi
+	if ! uci -q get upnpd.@internal_network[0].interface >/dev/null; then
+		log "No internal networks configured, not starting" daemon.err
+		return 1
+	fi
+	# Only perform an STUN CGNAT test if necessary, with a private/CGNAT-reserved external IPv4
+	local extipv4 extipv4private
+	extipv4="$(ip -4 addr show dev "$ifname" | grep inet | head -1 | sed -E "s/.*inet ([0-9.]+).*/\1/")"
+	case "$extipv4" in
+	10.* | 100.6[4-9].* | 100.[7-9][0-9].* | 100.1[0-1][0-9].* | 100.12[0-7].* | 172.1[6-9].* | \
+		172.2[0-9].* | 172.3[0-1].* | 192.0.0.[1-6] | 192.168.* | 198.1[89].*) extipv4private=1 ;;
+	esac
+	[ "$extipv4private" = "1" ] && log "Private/CGNAT-reserved external IPv4 detected"
 
-	if [ -n "$config_file" ]; then
-		conf="$config_file"
-	else
-		local tmpconf="/var/etc/miniupnpd.conf"
-		conf="$tmpconf"
-		mkdir -p /var/etc
-		if [ "$ifname" = "" ]; then
-			log "No external network interface detected yet, not starting" daemon.err
-			return 1
-		fi
-		if ! uci -q get upnpd.@internal_network[0].interface >/dev/null; then
-			log "No internal networks configured, not starting" daemon.err
-			return 1
-		fi
-		# Only perform an STUN CGNAT test if necessary, with a private/CGNAT-reserved external IPv4
-		local extipv4 extipv4private
-		extipv4="$(ip -4 addr show dev "$ifname" | grep inet | head -1 | sed -E "s/.*inet ([0-9.]+).*/\1/")"
-		case "$extipv4" in
-		10.* | 100.6[4-9].* | 100.[7-9][0-9].* | 100.1[0-1][0-9].* | 100.12[0-7].* | 172.1[6-9].* | \
-			172.2[0-9].* | 172.3[0-1].* | 192.0.0.[1-6] | 192.168.* | 198.1[89].*) extipv4private=1 ;;
-		esac
-		[ "$extipv4private" = "1" ] && log "Private/CGNAT-reserved external IPv4 detected"
-		{
+	{
 		echo "# Daemon"
 		[ "$enable_protocols" = "all" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=yes"
 		[ "$enable_protocols" = "upnp-igd" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=no"
@@ -190,32 +179,15 @@ upnpd() {
 		config_foreach upnpd_add_int_network_and_defaults internal_network post-acl
 		echo "deny 1-65535 0.0.0.0/0 1-65535 # Reject ACL by default"
 
-		} > "$tmpconf"
-	fi
-
-	if [ -n "$ifname" ]; then
-		if [ "$FW" = "fw4" ]; then
-			nft -s -t -n list chain inet fw4 upnp_forward >/dev/null 2>&1 || fw4 reload
-		else
-			iptables -L MINIUPNPD >/dev/null 2>&1 || fw3 reload
-		fi
-	fi
-
-	procd_open_instance
-	procd_set_param file "$conf" "/etc/config/firewall"
-	procd_set_param command "$PROG"
-	procd_append_param command -f "$conf"
-	[ "$log_output" = "info" ] && procd_append_param command -v
-	[ "$log_output" = "debug" ] && procd_append_param command -v -v
-	procd_close_instance
+	} >"$1"
 }
 
 stop_service() {
 	if [ "$FW" = "fw3" ]; then
-		iptables -t nat -F MINIUPNPD 2>/dev/null
-		iptables -t nat -F MINIUPNPD-POSTROUTING 2>/dev/null
 		iptables -t filter -F MINIUPNPD 2>/dev/null
 		[ -x /usr/sbin/ip6tables ] && ip6tables -t filter -F MINIUPNPD 2>/dev/null
+		iptables -t nat -F MINIUPNPD 2>/dev/null
+		iptables -t nat -F MINIUPNPD-POSTROUTING 2>/dev/null
 	else
 		nft flush chain inet fw4 upnp_forward 2>/dev/null
 		nft flush chain inet fw4 upnp_prerouting 2>/dev/null
@@ -225,11 +197,41 @@ stop_service() {
 
 start_service() {
 	config_load "upnpd"
-	config_foreach upnpd "upnpd"
+	local enabled config_file log_output conf
+	config_get enabled settings enabled 0
+	config_get config_file settings config_file
+	config_get log_output settings log_output
+	if [ "$enabled" != "1" ]; then
+		log "Service disabled, enabled UCI option not set"
+		return 1
+	fi
+
+	if [ -n "$config_file" ]; then
+		conf="$config_file"
+	else
+		local tmpconf="/var/etc/miniupnpd.conf"
+		conf="$tmpconf"
+		mkdir -p /var/etc
+		upnpd_generate_config "$tmpconf" || return 1
+	fi
+
+	if [ "$FW" = "fw4" ]; then
+		nft -s -t -n list chain inet fw4 upnp_forward >/dev/null 2>&1 || fw4 reload
+	else
+		iptables -L MINIUPNPD >/dev/null 2>&1 || fw3 reload
+	fi
+
+	procd_open_instance
+	procd_set_param file "$conf"
+	procd_set_param command "$PROG"
+	procd_append_param command -f "$conf"
+	[ "$log_output" = "info" ] && procd_append_param command -v
+	[ "$log_output" = "debug" ] && procd_append_param command -v -v
+	procd_close_instance
 }
 
 service_triggers() {
-	procd_add_reload_trigger "upnpd"
+	procd_add_reload_trigger "upnpd" "firewall"
 }
 
 log() {

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -61,14 +61,21 @@ service_triggers() {
 
 upnpd_generate_config() {
 	# Daemon
-	local enable_protocols allow_cgnat stun_host allow_third_party_mapping ipv6_disable system_uptime lease_file
+	local enable_protocols allow_cgnat stun_host allow_third_party_mapping system_uptime lease_file
 	config_get enable_protocols settings enable_protocols all
 	config_get allow_cgnat settings allow_cgnat 0
 	config_get stun_host settings stun_host stun.nextcloud.com
 	config_get allow_third_party_mapping settings allow_third_party_mapping 0
-	config_get ipv6_disable settings ipv6_disable 0
 	config_get system_uptime settings system_uptime 1
 	config_get lease_file settings lease_file /var/run/miniupnpd.leases
+
+	# Access control
+	local access_defaults accept_ports reject_ports check_acl ipv6_disable
+	config_get access_defaults settings access_defaults none
+	config_get accept_ports settings accept_ports
+	config_get reject_ports settings reject_ports "21 23 135 137-139 445 3389"
+	config_get check_acl settings check_acl 1
+	config_get ipv6_disable settings ipv6_disable 0
 
 	# UPnP IGD
 	local upnp_igd_compat download_kbps upload_kbps friendly_name model_number serial_number presentation_url uuid http_port notify_interval
@@ -83,12 +90,13 @@ upnpd_generate_config() {
 	config_get http_port settings http_port 5000
 	config_get notify_interval settings notify_interval
 
-	# External network interface
-	local external_iface external_iface6 external_zone external_ip
+	# Network interfaces
+	local external_iface external_iface6 external_zone external_ip internal_iface
 	config_get external_iface settings external_iface
 	config_get external_iface6 settings external_iface6
 	config_get external_zone settings external_zone
 	config_get external_ip settings external_ip
+	config_get internal_iface settings internal_iface lan
 
 	local ifname ifname6
 	. /lib/functions/network.sh
@@ -121,10 +129,6 @@ upnpd_generate_config() {
 			[ "$pass" = "4" ] && log "IPv6 GUA not yet available, UPnP IGD mapping not possible" && break
 		done
 	fi
-	if ! uci -q get upnpd.@internal_network[0].interface >/dev/null; then
-		log "No internal networks configured, not starting" daemon.err
-		return 1
-	fi
 	# Only perform an STUN CGNAT test if necessary, with a private/CGNAT-reserved external IPv4
 	local extipv4 extipv4private
 	extipv4="$(ip -4 addr show dev "$ifname" | grep inet | head -1 | sed -E "s/.*inet ([0-9.]+).*/\1/")"
@@ -151,7 +155,6 @@ upnpd_generate_config() {
 		[ "$allow_third_party_mapping" = "1" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=yes"
 		[ "$allow_third_party_mapping" = "upnp-igd" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=no"
 		[ "$allow_third_party_mapping" = "pcp" ] && echo "secure_mode=yes" && echo "pcp_allow_thirdparty=yes"
-		[ "$ipv6_disable" = "0" ] && echo "ipv6_disable=no" || echo "ipv6_disable=yes"
 		[ "$system_uptime" = "0" ] && echo "system_uptime=no" || echo "system_uptime=yes"
 		touch "$lease_file" && echo "lease_file=$lease_file"
 		[ "$ipv6_disable" = "0" ] && touch "${lease_file}-ipv6" && echo "lease_file6=${lease_file}-ipv6"
@@ -191,9 +194,39 @@ upnpd_generate_config() {
 		[ -n "$external_ip" ] && echo "ext_ip=$external_ip"
 
 		echo "# Enable internal networks / access control"
-		config_foreach upnpd_add_int_network_and_defaults internal_network pre-acl
-		config_foreach upnpd_add_acl_entry acl_entry
-		config_foreach upnpd_add_int_network_and_defaults internal_network post-acl
+		[ "$ipv6_disable" = "0" ] && echo "ipv6_disable=no" || echo "ipv6_disable=yes"
+		local rejectport
+		for rejectport in $reject_ports; do
+			[ "$rejectport" = "0" ] && continue
+			is_port_or_range "$rejectport" allowport0 && echo "deny 1-65535 0.0.0.0/0 $rejectport # Reject internal port $rejectport" &&
+				echo "deny $rejectport 0.0.0.0/0 1-65535 # Reject external port $rejectport" ||
+				log "Invalid port or port range ($rejectport) in reject_ports ignored" daemon.warn
+		done
+		[ "$check_acl" = "1" ] && echo "# Access control list" && config_foreach upnpd_add_acl_entry acl_entry
+		local iface
+		for iface in $internal_iface; do
+			local device subnet accessdefaultsports acceptport
+			network_get_device device "$iface"
+			network_get_subnet subnet "$iface"
+			[ "$subnet" = "" ] && log "Cannot get IPv4 subnet for network $iface, network ignored" daemon.warn && continue
+			echo "# Enable internal network $iface ($device) with access defaults $access_defaults and check ACL $check_acl"
+			echo "listening_ip=$device"
+			if [ "$access_defaults" = "accept-high-ports" ]; then
+				accessdefaultsports="1024-65535"
+			elif [ "$access_defaults" = "accept-web+high-ports" ]; then
+				accessdefaultsports="80 443 1024-65535"
+			elif [ "$access_defaults" = "accept-web-ports" ]; then
+				accessdefaultsports="80 443"
+			elif [ "$access_defaults" = "accept-all-ports" ]; then
+				accessdefaultsports="1-65535"
+			elif [ "$access_defaults" != "none" ]; then
+				log "Invalid access_defaults ($access_defaults) ignored" daemon.warn
+			fi
+			for acceptport in $accessdefaultsports $accept_ports; do
+				is_port_or_range "$acceptport" && echo "allow $acceptport $subnet $acceptport # Accept port $acceptport on $iface" ||
+					log "Invalid port or port range ($acceptport) in accept_ports ignored" daemon.warn
+			done
+		done
 		echo "deny 1-65535 0.0.0.0/0 1-65535 # Reject ACL by default"
 
 	} >"$1"
@@ -215,50 +248,6 @@ is_port_or_range() {
 	[ "${1%%-*}" -ge "$minport" ] 2>/dev/null && [ "${1%%-*}" -le "65535" ] 2>/dev/null &&
 		[ "${1##*-}" -ge "$minport" ] 2>/dev/null && [ "${1##*-}" -le "65535" ] 2>/dev/null &&
 		[ "${1##*-}" -ge "${1%%-*}" ] 2>/dev/null && return 0 || return 1
-}
-
-upnpd_add_int_network_and_defaults() {
-	local cfg="$1"
-	local interface access_defaults accept_ports reject_ports check_acl
-	config_get interface "$cfg" interface
-	config_get access_defaults "$cfg" access_defaults none
-	config_get accept_ports "$cfg" accept_ports
-	config_get reject_ports "$cfg" reject_ports "21 23 135 137-139 445 3389"
-	config_get check_acl "$cfg" check_acl 1
-	local device subnet rejectport accessdefaultsports acceptport
-	network_get_device device "$interface"
-	network_get_subnet subnet "$interface"
-	[ "$subnet" = "" ] && log "Cannot get IPv4 subnet for network $interface, network ignored" daemon.warn && return 0
-	if [ "$2" = "pre-acl" ]; then
-		echo "# Enable internal network $interface ($device) with access defaults $access_defaults and check ACL $check_acl"
-		echo "listening_ip=$device"
-		for rejectport in $reject_ports; do
-			is_port_or_range "$rejectport" allowport0 && echo "deny 1-65535 0.0.0.0/0 $rejectport # Reject internal port $rejectport" &&
-				echo "deny $rejectport 0.0.0.0/0 1-65535 # Reject external port $rejectport" ||
-				log "Invalid port or port range ($rejectport) in reject_ports ignored" daemon.warn
-		done
-	fi
-	if { [ "$2" = "post-acl" ] && [ "$check_acl" = "1" ]; } ||
-		{ [ "$2" = "pre-acl" ] && [ "$check_acl" = "0" ]; }; then
-		if [ "$access_defaults" = "accept-high-ports" ]; then
-			accessdefaultsports="1024-65535"
-		elif [ "$access_defaults" = "accept-web+high-ports" ]; then
-			accessdefaultsports="80 443 1024-65535"
-		elif [ "$access_defaults" = "accept-web-ports" ]; then
-			accessdefaultsports="80 443"
-		elif [ "$access_defaults" = "accept-all-ports" ]; then
-			accessdefaultsports="1-65535"
-		elif [ "$access_defaults" != "none" ]; then
-			log "Invalid access_defaults ($access_defaults) ignored" daemon.warn
-		fi
-		for acceptport in $accessdefaultsports $accept_ports; do
-			is_port_or_range "$acceptport" && echo "allow $acceptport $subnet $acceptport # Accept port $acceptport on $interface" ||
-				log "Invalid port or port range ($acceptport) in accept_ports ignored" daemon.warn
-		done
-	fi
-	if [ "$2" = "pre-acl" ] && [ "$check_acl" = "0" ]; then
-		echo "deny 1-65535 $subnet 1-65535 # Reject ACL by default on $interface"
-	fi
 }
 
 upnpd_add_acl_entry() {

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -29,7 +29,6 @@ conf_rule_add() {
 	local cfg="$1"
 	local action int_addr
 	local ext_start ext_end int_start int_end comment
-
 	config_get action "$cfg" action "deny"                # allow or deny
 	upnpd_get_port_range "ext" "$cfg" ext_ports "0-65535" # external ports: x, x-y, x:y
 	config_get int_addr "$cfg" int_addr "0.0.0.0/0"       # ip or network and subnet mask (internal)
@@ -44,45 +43,45 @@ conf_rule_add() {
 
 upnpd() {
 	config_load "upnpd"
-	local external_iface external_iface6 external_zone external_ip
-	local upload_kbps download_kbps log_output http_port config_file serial_number model_number
-	local allow_cgnat stun_host uuid notify_interval presentation_url
-	local lease_file ipv6_disable
-	local enable_protocols allow_third_party_mapping system_uptime upnp_igd_compat
-	local friendly_name
-
 	local enabled
 	config_get enabled config enabled 0
 	if [ "$enabled" != "1" ]; then
 		log "Service disabled, enabled UCI option not set"
 		return 1
 	fi
+	# Daemon
+	local enable_protocols allow_cgnat stun_host allow_third_party_mapping ipv6_disable system_uptime log_output lease_file config_file
+	config_get enable_protocols config enable_protocols all
+	config_get allow_cgnat config allow_cgnat 0
+	config_get stun_host config stun_host stun.nextcloud.com
+	config_get allow_third_party_mapping config allow_third_party_mapping 0
+	config_get ipv6_disable config ipv6_disable 0
+	config_get system_uptime config system_uptime 1
+	config_get log_output config log_output
+	config_get lease_file config lease_file /var/run/miniupnpd.leases
+	config_get config_file config config_file
+
+	# UPnP IGD
+	local upnp_igd_compat download_kbps upload_kbps friendly_name model_number serial_number presentation_url uuid http_port notify_interval
+	config_get upnp_igd_compat config upnp_igd_compat igdv1
+	config_get download_kbps config download_kbps
+	config_get upload_kbps config upload_kbps
+	config_get friendly_name config friendly_name "OpenWrt UPnP IGD & PCP"
+	config_get model_number config model_number
+	config_get serial_number config serial_number
+	config_get presentation_url config presentation_url
+	config_get uuid config uuid
+	config_get http_port config http_port 5000
+	config_get notify_interval config notify_interval
+
+	# External network interface
+	local external_iface external_iface6 external_zone external_ip
 	config_get external_iface config external_iface
 	config_get external_iface6 config external_iface6
 	config_get external_zone config external_zone
 	config_get external_ip config external_ip
-	config_get http_port config http_port 5000
-	config_get upload_kbps config upload_kbps
-	config_get download_kbps config download_kbps
-	config_get log_output config log_output
-	config_get config_file config config_file
-	config_get serial_number config serial_number
-	config_get model_number config model_number
-	config_get uuid config uuid
-	config_get allow_cgnat config allow_cgnat 0
-	config_get stun_host config stun_host stun.nextcloud.com
-	config_get notify_interval config notify_interval
-	config_get presentation_url config presentation_url
-	config_get lease_file config lease_file /var/run/miniupnpd.leases
-	config_get ipv6_disable config ipv6_disable 0
-	config_get enable_protocols config enable_protocols all
-	config_get allow_third_party_mapping config allow_third_party_mapping 0
-	config_get system_uptime config system_uptime 1
-	config_get upnp_igd_compat config upnp_igd_compat igdv1
-	config_get friendly_name config friendly_name "OpenWrt UPnP IGD & PCP"
 
 	local conf ifname ifname6
-
 	. /lib/functions/network.sh
 
 	if [ -n "$external_iface" ] ; then
@@ -120,20 +119,6 @@ upnpd() {
 			log "No internal networks configured, not starting" daemon.err
 			return 1
 		fi
-		{
-		echo "ext_ifname=$ifname"
-		echo "ext_ifname6=$ifname6"
-		[ -n "$external_ip" ] && echo "ext_ip=$external_ip"
-
-		[ "$enable_protocols" = "all" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=yes"
-		[ "$enable_protocols" = "upnp-igd" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=no"
-		[ "$enable_protocols" = "pcp+nat-pmp" ] && echo "enable_upnp=no" && echo "enable_pcp_pmp=yes"
-		[ "$allow_third_party_mapping" = "0" ] && echo "secure_mode=yes" && echo "pcp_allow_thirdparty=no"
-		[ "$allow_third_party_mapping" = "1" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=yes"
-		[ "$allow_third_party_mapping" = "upnp-igd" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=no"
-		[ "$allow_third_party_mapping" = "pcp" ] && echo "secure_mode=yes" && echo "pcp_allow_thirdparty=yes"
-		[ "$system_uptime" = "0" ] && echo "system_uptime=no" || echo "system_uptime=yes"
-		[ "$upnp_igd_compat" = "igdv1" ] && echo "force_igd_desc_v1=yes" || echo "force_igd_desc_v1=no"
 		# Only perform an STUN CGNAT test if necessary, with a private/CGNAT-reserved external IPv4
 		local extipv4 extipv4private
 		extipv4="$(ip -4 addr show dev "$ifname" | grep inet | head -1 | sed -E "s/.*inet ([0-9.]+).*/\1/")"
@@ -142,6 +127,11 @@ upnpd() {
 			172.2[0-9].* | 172.3[0-1].* | 192.0.0.[1-6] | 192.168.* | 198.1[89].*) extipv4private=1 ;;
 		esac
 		[ "$extipv4private" = "1" ] && log "Private/CGNAT-reserved external IPv4 detected"
+		{
+		echo "# Daemon"
+		[ "$enable_protocols" = "all" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=yes"
+		[ "$enable_protocols" = "upnp-igd" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=no"
+		[ "$enable_protocols" = "pcp+nat-pmp" ] && echo "enable_upnp=no" && echo "enable_pcp_pmp=yes"
 		if [ "$extipv4private" = "1" ] && [ "$allow_cgnat" != "0" ]; then
 			[ "$allow_cgnat" = "1" ] && echo "ext_perform_stun=yes"
 			[ "$allow_cgnat" = "allow-filtered" ] && echo "ext_perform_stun=allow-filtered"
@@ -150,37 +140,48 @@ upnpd() {
 			echo "ext_stun_host=${stun_host%%:*}"
 			[ "${stun_host%%:*}" != "${stun_host##*:}" ] && echo "ext_stun_port=${stun_host##*:}"
 		fi
+		[ "$allow_third_party_mapping" = "0" ] && echo "secure_mode=yes" && echo "pcp_allow_thirdparty=no"
+		[ "$allow_third_party_mapping" = "1" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=yes"
+		[ "$allow_third_party_mapping" = "upnp-igd" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=no"
+		[ "$allow_third_party_mapping" = "pcp" ] && echo "secure_mode=yes" && echo "pcp_allow_thirdparty=yes"
 		[ "$ipv6_disable" = "0" ] && echo "ipv6_disable=no" || echo "ipv6_disable=yes"
-
-		[ -n "$download_kbps" ] && echo "bitrate_down=$((download_kbps * 1000))"
-		[ -n "$upload_kbps" ] && echo "bitrate_up=$((upload_kbps * 1000))"
-
+		[ "$system_uptime" = "0" ] && echo "system_uptime=no" || echo "system_uptime=yes"
 		touch "$lease_file" && echo "lease_file=$lease_file"
 		[ "$ipv6_disable" = "0" ] && touch "${lease_file}-ipv6" && echo "lease_file6=${lease_file}-ipv6"
-		[ -n "$friendly_name" ] && echo "friendly_name=$friendly_name"
-		[ -n "$presentation_url" ] && echo "presentation_url=$presentation_url"
-		[ -n "$notify_interval" ] && echo "notify_interval=$notify_interval"
-		echo "serial=$serial_number"
-		echo "model_number=$model_number"
-		echo "http_port=$http_port"
 
-		[ -z "$uuid" ] && {
-			log "Generate UPnP IGD UUID"
-			uuid="$(cat /proc/sys/kernel/random/uuid)"
-			uci set upnpd.config.uuid="$uuid"
-			uci commit upnpd
-		}
-
-		[ "$uuid" != "nocli" ] && echo "uuid=$uuid" || log "uuid=nocli deprecated, set to 00000000-0000-0000-0000-000000000000 instead"
+		if [ "$enable_protocols" = "upnp-igd" ] || [ "$enable_protocols" = "all" ]; then
+			echo "# UPnP IGD"
+			[ "$upnp_igd_compat" = "igdv1" ] && echo "force_igd_desc_v1=yes" || echo "force_igd_desc_v1=no"
+			[ -n "$download_kbps" ] && echo "bitrate_down=$((download_kbps * 1000))"
+			[ -n "$upload_kbps" ] && echo "bitrate_up=$((upload_kbps * 1000))"
+			[ -n "$friendly_name" ] && echo "friendly_name=$(xml_encode "$friendly_name")"
+			[ -n "$model_number" ] && echo "model_number=$(xml_encode "$model_number")" || echo "model_number="
+			[ -n "$serial_number" ] && echo "serial=$(xml_encode "$serial_number")" || echo "serial="
+			[ -n "$presentation_url" ] && echo "presentation_url=$presentation_url"
+			[ -z "$uuid" ] && {
+				log "Generate UPnP IGD UUID"
+				uuid="$(cat /proc/sys/kernel/random/uuid)"
+				uci set upnpd.config.uuid="$uuid"
+				uci commit upnpd
+			}
+			[ "$uuid" != "nocli" ] && echo "uuid=$uuid" || log "uuid=nocli deprecated, set to 00000000-0000-0000-0000-000000000000 instead"
+			echo "http_port=$http_port"
+			[ -n "$notify_interval" ] && echo "notify_interval=$notify_interval"
+		fi
 
 		if [ "$FW" = "fw4" ]; then
-			#When using nftables configure miniupnpd to use its own table and chains
+			echo "# Firewall backend"
 			echo "upnp_table_name=fw4"
 			echo "upnp_nat_table_name=fw4"
 			echo "upnp_forward_chain=upnp_forward"
 			echo "upnp_nat_chain=upnp_prerouting"
 			#echo "upnp_nat_postrouting_chain=upnp_postrouting" # Not used with nftables
 		fi
+
+		echo "# External network interface"
+		echo "ext_ifname=$ifname"
+		echo "ext_ifname6=${ifname6:-$ifname}"
+		[ -n "$external_ip" ] && echo "ext_ip=$external_ip"
 
 		echo "# Enable internal networks / access control"
 		config_foreach upnpd_add_int_network_and_defaults internal_network pre-acl
@@ -191,7 +192,6 @@ upnpd() {
 	fi
 
 	if [ -n "$ifname" ]; then
-		# start firewall
 		if [ "$FW" = "fw4" ]; then
 			nft -s -t -n list chain inet fw4 upnp_forward >/dev/null 2>&1 || fw4 reload
 		else
@@ -232,6 +232,11 @@ service_triggers() {
 
 log() {
 	logger -s -p "${2:-daemon.notice}" -t "miniupnpd-init" "$1" || echo "miniupnpd-init: $1" >&2
+}
+
+xml_encode() {
+	# Encode required XML entities of text UPnP IGD config options until the daemon does so
+	echo "$1" | sed "s/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g"
 }
 
 upnpd_add_int_network_and_defaults() {

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -42,53 +42,44 @@ conf_rule_add() {
 	echo "$action $ext_start${ext_end:+-}$ext_end $int_addr $int_start${int_end:+-}$int_end #$comment"
 }
 
-upnpd_write_bool() {
-	local opt="$1"
-	local def="${2:-0}"
-	local alt="${3:-$opt}"
-	local val
-
-	config_get_bool val config "$opt" "$def"
-	if [ "$val" -eq 0 ]; then
-		echo "$alt=no"
-	else
-		echo "$alt=yes"
-	fi
-}
-
 upnpd() {
 	config_load "upnpd"
-	local external_iface external_iface6 external_zone external_ip internal_iface
-	local upload download log_output port config_file serial_number model_number
-	local use_stun stun_host stun_port uuid notify_interval presentation_url
-	local upnp_lease_file upnp_lease_file6 ipv6_disable ext_allow_private_ipv4
+	local external_iface external_iface6 external_zone external_ip
+	local upload_kbps download_kbps log_output http_port config_file serial_number model_number
+	local allow_cgnat stun_host uuid notify_interval presentation_url
+	local lease_file ipv6_disable
+	local enable_protocols allow_third_party_mapping system_uptime upnp_igd_compat
+	local friendly_name
 
 	local enabled
-	config_get_bool enabled config enabled 1
-	[ "$enabled" -eq 0 ] && return 1
-
+	config_get enabled config enabled 0
+	if [ "$enabled" != "1" ]; then
+		log "Service disabled, enabled UCI option not set"
+		return 1
+	fi
 	config_get external_iface config external_iface
 	config_get external_iface6 config external_iface6
 	config_get external_zone config external_zone
 	config_get external_ip config external_ip
-	config_get internal_iface config internal_iface
-	config_get port config port 5000
-	config_get upload config upload
-	config_get download config download
-	config_get_bool log_output config log_output 0
+	config_get http_port config http_port 5000
+	config_get upload_kbps config upload_kbps
+	config_get download_kbps config download_kbps
+	config_get log_output config log_output
 	config_get config_file config config_file
 	config_get serial_number config serial_number
 	config_get model_number config model_number
 	config_get uuid config uuid
-	config_get use_stun config use_stun 0
-	config_get stun_host config stun_host
-	config_get stun_port config stun_port
+	config_get allow_cgnat config allow_cgnat 0
+	config_get stun_host config stun_host stun.nextcloud.com
 	config_get notify_interval config notify_interval
 	config_get presentation_url config presentation_url
-	config_get upnp_lease_file config upnp_lease_file
-	config_get upnp_lease_file6 config upnp_lease_file6
+	config_get lease_file config lease_file /var/run/miniupnpd.leases
 	config_get ipv6_disable config ipv6_disable 0
-	config_get ext_allow_private_ipv4 config ext_allow_private_ipv4 0
+	config_get enable_protocols config enable_protocols all
+	config_get allow_third_party_mapping config allow_third_party_mapping 0
+	config_get system_uptime config system_uptime 1
+	config_get upnp_igd_compat config upnp_igd_compat igdv1
+	config_get friendly_name config friendly_name "OpenWrt UPnP IGD & PCP"
 
 	local conf ifname ifname6
 
@@ -121,55 +112,66 @@ upnpd() {
 		local tmpconf="/var/etc/miniupnpd.conf"
 		conf="$tmpconf"
 		mkdir -p /var/etc
-
+		if [ "$ifname" = "" ]; then
+			log "No external network interface detected yet, not starting" daemon.err
+			return 1
+		fi
+		if ! uci -q get upnpd.@internal_network[0].interface >/dev/null; then
+			log "No internal networks configured, not starting" daemon.err
+			return 1
+		fi
 		{
 		echo "ext_ifname=$ifname"
 		echo "ext_ifname6=$ifname6"
 		[ -n "$external_ip" ] && echo "ext_ip=$external_ip"
 
-		local iface
-		for iface in ${internal_iface:-lan}; do
-			local device
-			network_get_device device "$iface" && echo "listening_ip=$device"
-		done
+		[ "$enable_protocols" = "all" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=yes"
+		[ "$enable_protocols" = "upnp-igd" ] && echo "enable_upnp=yes" && echo "enable_pcp_pmp=no"
+		[ "$enable_protocols" = "pcp+nat-pmp" ] && echo "enable_upnp=no" && echo "enable_pcp_pmp=yes"
+		[ "$allow_third_party_mapping" = "0" ] && echo "secure_mode=yes" && echo "pcp_allow_thirdparty=no"
+		[ "$allow_third_party_mapping" = "1" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=yes"
+		[ "$allow_third_party_mapping" = "upnp-igd" ] && echo "secure_mode=no" && echo "pcp_allow_thirdparty=no"
+		[ "$allow_third_party_mapping" = "pcp" ] && echo "secure_mode=yes" && echo "pcp_allow_thirdparty=yes"
+		[ "$system_uptime" = "0" ] && echo "system_uptime=no" || echo "system_uptime=yes"
+		[ "$upnp_igd_compat" = "igdv1" ] && echo "force_igd_desc_v1=yes" || echo "force_igd_desc_v1=no"
+		# Only perform an STUN CGNAT test if necessary, with a private/CGNAT-reserved external IPv4
+		local extipv4 extipv4private
+		extipv4="$(ip -4 addr show dev "$ifname" | grep inet | head -1 | sed -E "s/.*inet ([0-9.]+).*/\1/")"
+		case "$extipv4" in
+		10.* | 100.6[4-9].* | 100.[7-9][0-9].* | 100.1[0-1][0-9].* | 100.12[0-7].* | 172.1[6-9].* | \
+			172.2[0-9].* | 172.3[0-1].* | 192.0.0.[1-6] | 192.168.* | 198.1[89].*) extipv4private=1 ;;
+		esac
+		[ "$extipv4private" = "1" ] && log "Private/CGNAT-reserved external IPv4 detected"
+		if [ "$extipv4private" = "1" ] && [ "$allow_cgnat" != "0" ]; then
+			[ "$allow_cgnat" = "1" ] && echo "ext_perform_stun=yes"
+			[ "$allow_cgnat" = "allow-filtered" ] && echo "ext_perform_stun=allow-filtered"
+			# Avoid next option, as no STUN public IPv4 detection, required by clients (PCP/NAT-PMP among others)
+			[ "$allow_cgnat" = "report-private-ipv4" ] && echo "ext_allow_private_ipv4=yes"
+			echo "ext_stun_host=${stun_host%%:*}"
+			[ "${stun_host%%:*}" != "${stun_host##*:}" ] && echo "ext_stun_port=${stun_host##*:}"
+		fi
+		[ "$ipv6_disable" = "0" ] && echo "ipv6_disable=no" || echo "ipv6_disable=yes"
 
-		config_load "upnpd"
-		upnpd_write_bool enable_natpmp 1
-		upnpd_write_bool enable_upnp 1
-		upnpd_write_bool secure_mode 1
-		upnpd_write_bool system_uptime 1
-		upnpd_write_bool igdv1 0 force_igd_desc_v1
-		upnpd_write_bool use_stun 0 ext_perform_stun
-		upnpd_write_bool ipv6_disable $ipv6_disable
-		upnpd_write_bool ext_allow_private_ipv4 $ext_allow_private_ipv4
+		[ -n "$download_kbps" ] && echo "bitrate_down=$((download_kbps * 1000))"
+		[ -n "$upload_kbps" ] && echo "bitrate_up=$((upload_kbps * 1000))"
 
-		[ "$use_stun" -eq 0 ] || {
-			[ -n "$stun_host" ] && echo "ext_stun_host=$stun_host"
-			[ -n "$stun_port" ] && echo "ext_stun_port=$stun_port"
-		}
-
-		[ -n "$upload" ] && [ -n "$download" ] && {
-			echo "bitrate_down=$((download * 1024 * 8))"
-			echo "bitrate_up=$((upload * 1024 * 8))"
-		}
-
-		[ -n "$upnp_lease_file" ] && touch "$upnp_lease_file" && echo "lease_file=$upnp_lease_file"
-		[ -n "$upnp_lease_file6" ] && touch "$upnp_lease_file6" && echo "lease_file6=$upnp_lease_file6"
+		touch "$lease_file" && echo "lease_file=$lease_file"
+		[ "$ipv6_disable" = "0" ] && touch "${lease_file}-ipv6" && echo "lease_file6=${lease_file}-ipv6"
+		[ -n "$friendly_name" ] && echo "friendly_name=$friendly_name"
 		[ -n "$presentation_url" ] && echo "presentation_url=$presentation_url"
 		[ -n "$notify_interval" ] && echo "notify_interval=$notify_interval"
-		[ -n "$serial_number" ] && echo "serial=$serial_number"
-		[ -n "$model_number" ] && echo "model_number=$model_number"
-		[ -n "$port" ] && echo "port=$port"
+		echo "serial=$serial_number"
+		echo "model_number=$model_number"
+		echo "http_port=$http_port"
 
 		[ -z "$uuid" ] && {
+			log "Generate UPnP IGD UUID"
 			uuid="$(cat /proc/sys/kernel/random/uuid)"
 			uci set upnpd.config.uuid="$uuid"
 			uci commit upnpd
 		}
 
-		[ "$uuid" = "nocli" ] || echo "uuid=$uuid"
-
-		config_foreach conf_rule_add perm_rule
+		[ "$uuid" != "nocli" ] && echo "uuid=$uuid" || log "uuid=nocli deprecated, set to 00000000-0000-0000-0000-000000000000 instead"
 
 		if [ "$FW" = "fw4" ]; then
 			#When using nftables configure miniupnpd to use its own table and chains
@@ -177,8 +179,13 @@ upnpd() {
 			echo "upnp_nat_table_name=fw4"
 			echo "upnp_forward_chain=upnp_forward"
 			echo "upnp_nat_chain=upnp_prerouting"
-			echo "upnp_nat_postrouting_chain=upnp_postrouting"
+			#echo "upnp_nat_postrouting_chain=upnp_postrouting" # Not used with nftables
 		fi
+
+		echo "# Enable internal networks / access control"
+		config_foreach upnpd_add_int_network_and_defaults internal_network pre-acl
+		config_foreach conf_rule_add perm_rule
+		config_foreach upnpd_add_int_network_and_defaults internal_network post-acl
 
 		} > "$tmpconf"
 	fi
@@ -190,15 +197,14 @@ upnpd() {
 		else
 			iptables -L MINIUPNPD >/dev/null 2>&1 || fw3 reload
 		fi
-	else
-		logger -t "upnp daemon" "external interface not found, not starting"
 	fi
 
 	procd_open_instance
 	procd_set_param file "$conf" "/etc/config/firewall"
 	procd_set_param command "$PROG"
 	procd_append_param command -f "$conf"
-	[ "$log_output" = "1" ] && procd_append_param command -d
+	[ "$log_output" = "info" ] && procd_append_param command -v
+	[ "$log_output" = "debug" ] && procd_append_param command -v -v
 	procd_close_instance
 }
 
@@ -211,7 +217,7 @@ stop_service() {
 	else
 		nft flush chain inet fw4 upnp_forward 2>/dev/null
 		nft flush chain inet fw4 upnp_prerouting 2>/dev/null
-		nft flush chain inet fw4 upnp_postrouting 2>/dev/null
+		#nft flush chain inet fw4 upnp_postrouting 2>/dev/null # Not used with nftables
 	fi
 }
 
@@ -222,4 +228,71 @@ start_service() {
 
 service_triggers() {
 	procd_add_reload_trigger "upnpd"
+}
+
+log() {
+	logger -s -p "${2:-daemon.notice}" -t "miniupnpd-init" "$1" || echo "miniupnpd-init: $1" >&2
+}
+
+upnpd_add_int_network_and_defaults() {
+	local cfg="$1"
+	local interface access_defaults accept_ports reject_ports check_acl
+	config_get interface "$cfg" interface
+	config_get access_defaults "$cfg" access_defaults none
+	config_get accept_ports "$cfg" accept_ports
+	config_get reject_ports "$cfg" reject_ports "21 23 135 137-139 445 3389"
+	config_get check_acl "$cfg" check_acl 1
+	local device subnet rejectport accessdefaultsports acceptport
+	network_get_device device "$interface"
+	network_get_subnet subnet "$interface"
+	[ "$subnet" = "" ] && log "Cannot get IPv4 subnet for network $interface, network ignored" daemon.warn && return 0
+	if [ "$2" = "pre-acl" ]; then
+		echo "# Enable internal network $interface ($device) with access defaults $access_defaults and check ACL $check_acl"
+		echo "listening_ip=$device"
+		for rejectport in $reject_ports; do
+			if [ "$rejectport" -ge "1" ] 2>/dev/null && [ "$rejectport" -le "65535" ] 2>/dev/null ||
+				{
+					[ "${rejectport%%-*}" -ge "1" ] 2>/dev/null &&
+						[ "${rejectport%%-*}" -le "65535" ] 2>/dev/null &&
+						[ "${rejectport##*-}" -ge "1" ] 2>/dev/null &&
+						[ "${rejectport##*-}" -le "65535" ] 2>/dev/null &&
+						[ "${rejectport##*-}" -ge "${rejectport%%-*}" ] 2>/dev/null
+				}; then
+				echo "deny $rejectport 0.0.0.0/0 $rejectport # Reject port $rejectport"
+			else
+				log "Invalid port or port range ($rejectport) in reject_ports ignored" daemon.warn
+			fi
+		done
+	fi
+	if { [ "$2" = "post-acl" ] && [ "$check_acl" = "1" ]; } ||
+		{ [ "$2" = "pre-acl" ] && [ "$check_acl" = "0" ]; }; then
+		if [ "$access_defaults" = "accept-high-ports" ]; then
+			accessdefaultsports="1024-65535"
+		elif [ "$access_defaults" = "accept-web+high-ports" ]; then
+			accessdefaultsports="80 443 1024-65535"
+		elif [ "$access_defaults" = "accept-web-ports" ]; then
+			accessdefaultsports="80 443"
+		elif [ "$access_defaults" = "accept-all-ports" ]; then
+			accessdefaultsports="1-65535"
+		elif [ "$access_defaults" != "none" ]; then
+			log "Invalid access_defaults ($access_defaults) ignored" daemon.warn
+		fi
+		for acceptport in $accessdefaultsports $accept_ports; do
+			if [ "$acceptport" -ge "1" ] 2>/dev/null && [ "$acceptport" -le "65535" ] 2>/dev/null ||
+				{
+					[ "${acceptport%%-*}" -ge "1" ] 2>/dev/null &&
+						[ "${acceptport%%-*}" -le "65535" ] 2>/dev/null &&
+						[ "${acceptport##*-}" -ge "1" ] 2>/dev/null &&
+						[ "${acceptport##*-}" -le "65535" ] 2>/dev/null &&
+						[ "${acceptport##*-}" -ge "${acceptport%%-*}" ] 2>/dev/null
+				}; then
+				echo "allow $acceptport $subnet $acceptport # Accept port $acceptport on $interface"
+			else
+				log "Invalid port or port range ($acceptport) in accept_ports ignored" daemon.warn
+			fi
+		done
+	fi
+	if [ "$2" = "pre-acl" ] && [ "$check_acl" = "0" ]; then
+		echo "deny 1-65535 $subnet 1-65535 # Reject ACL by default on $interface"
+	fi
 }

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -7,38 +7,39 @@ USE_PROCD=1
 PROG=/usr/sbin/miniupnpd
 [ -x "$(command -v nft)" ] && FW="fw4" || FW="fw3"
 
-upnpd_get_port_range() {
-	local var="$1"; shift
-	local val
-
-	config_get val "$@"
-
-	case "$val" in
-		[0-9]*[:-][0-9]*)
-			export -n -- "${var}_start=${val%%[:-]*}"
-			export -n -- "${var}_end=${val##*[:-]}"
-		;;
-		[0-9]*)
-			export -n -- "${var}_start=$val"
-			export -n -- "${var}_end="
-		;;
-	esac
+is_port_or_range() {
+	[ "$1" = "0" ] && [ "$2" != "allowport0" ] && return 1
+	[ "$1" -ge "1" ] 2>/dev/null && [ "$1" -le "65535" ] 2>/dev/null && return 0
+	[ "$2" = "allowport0" ] && local minport=0 || local minport=1
+	[ "${1%%-*}" -ge "$minport" ] 2>/dev/null && [ "${1%%-*}" -le "65535" ] 2>/dev/null &&
+		[ "${1##*-}" -ge "$minport" ] 2>/dev/null && [ "${1##*-}" -le "65535" ] 2>/dev/null &&
+		[ "${1##*-}" -ge "${1%%-*}" ] 2>/dev/null && return 0 || return 1
 }
 
-conf_rule_add() {
+upnpd_add_acl_entry() {
 	local cfg="$1"
-	local action int_addr
-	local ext_start ext_end int_start int_end comment
-	config_get action "$cfg" action "deny"                # allow or deny
-	upnpd_get_port_range "ext" "$cfg" ext_ports "0-65535" # external ports: x, x-y, x:y
-	config_get int_addr "$cfg" int_addr "0.0.0.0/0"       # ip or network and subnet mask (internal)
-	upnpd_get_port_range "int" "$cfg" int_ports "0-65535" # internal ports: x, x-y, x:y or range
-	config_get comment "$cfg" comment "ACL"		      # comment
-
-	# Make a single IP IP/32 so that miniupnpd.conf can use it.
-	[ "${int_addr%/*}" = "$int_addr" ] && int_addr="$int_addr/32"
-
-	echo "$action $ext_start${ext_end:+-}$ext_end $int_addr $int_start${int_end:+-}$int_end #$comment"
+	local comment int_addr int_port ext_port descr_filter action
+	config_get comment "$cfg" comment "unspecified" # comment
+	config_get int_addr "$cfg" int_addr "0.0.0.0/0" # IPv4 address or address and netmask (internal)
+	config_get int_port "$cfg" int_port "1-65535"   # internal port or range: x or x-y
+	config_get ext_port "$cfg" ext_port "1-65535"   # external port or range: x or x-y
+	config_get descr_filter "$cfg" descr_filter     # description regex filter (must be built in)
+	config_get action "$cfg" action                 # accept/reject/disabled
+	! is_port_or_range "$int_port" allowport0 &&
+		log "ACL entry: Invalid port or port range ($int_port) in int_port ignored" daemon.warn && int_port=1-65535
+	! is_port_or_range "$ext_port" allowport0 &&
+		log "ACL entry: Invalid port or port range ($ext_port) in ext_port ignored" daemon.warn && ext_port=1-65535
+	[ "$descr_filter" != "" ] && descr_filter=" \"$descr_filter\""
+	if [ "$action" = "accept" ]; then
+		action=allow
+	elif [ "$action" = "reject" ]; then
+		action=deny
+	elif [ "$action" != "disabled" ]; then
+		log "ACL entry: Entry with invalid action ($action) ignored" daemon.warn
+		action=disabled
+	fi
+	[ "$action" = "disabled" ] && return 0
+	echo "$action $ext_port $int_addr $int_port${descr_filter} # $comment"
 }
 
 upnpd() {
@@ -185,8 +186,9 @@ upnpd() {
 
 		echo "# Enable internal networks / access control"
 		config_foreach upnpd_add_int_network_and_defaults internal_network pre-acl
-		config_foreach conf_rule_add perm_rule
+		config_foreach upnpd_add_acl_entry acl_entry
 		config_foreach upnpd_add_int_network_and_defaults internal_network post-acl
+		echo "deny 1-65535 0.0.0.0/0 1-65535 # Reject ACL by default"
 
 		} > "$tmpconf"
 	fi
@@ -255,18 +257,9 @@ upnpd_add_int_network_and_defaults() {
 		echo "# Enable internal network $interface ($device) with access defaults $access_defaults and check ACL $check_acl"
 		echo "listening_ip=$device"
 		for rejectport in $reject_ports; do
-			if [ "$rejectport" -ge "1" ] 2>/dev/null && [ "$rejectport" -le "65535" ] 2>/dev/null ||
-				{
-					[ "${rejectport%%-*}" -ge "1" ] 2>/dev/null &&
-						[ "${rejectport%%-*}" -le "65535" ] 2>/dev/null &&
-						[ "${rejectport##*-}" -ge "1" ] 2>/dev/null &&
-						[ "${rejectport##*-}" -le "65535" ] 2>/dev/null &&
-						[ "${rejectport##*-}" -ge "${rejectport%%-*}" ] 2>/dev/null
-				}; then
-				echo "deny $rejectport 0.0.0.0/0 $rejectport # Reject port $rejectport"
-			else
+			is_port_or_range "$rejectport" allowport0 && echo "deny 1-65535 0.0.0.0/0 $rejectport # Reject internal port $rejectport" &&
+				echo "deny $rejectport 0.0.0.0/0 1-65535 # Reject external port $rejectport" ||
 				log "Invalid port or port range ($rejectport) in reject_ports ignored" daemon.warn
-			fi
 		done
 	fi
 	if { [ "$2" = "post-acl" ] && [ "$check_acl" = "1" ]; } ||
@@ -283,18 +276,8 @@ upnpd_add_int_network_and_defaults() {
 			log "Invalid access_defaults ($access_defaults) ignored" daemon.warn
 		fi
 		for acceptport in $accessdefaultsports $accept_ports; do
-			if [ "$acceptport" -ge "1" ] 2>/dev/null && [ "$acceptport" -le "65535" ] 2>/dev/null ||
-				{
-					[ "${acceptport%%-*}" -ge "1" ] 2>/dev/null &&
-						[ "${acceptport%%-*}" -le "65535" ] 2>/dev/null &&
-						[ "${acceptport##*-}" -ge "1" ] 2>/dev/null &&
-						[ "${acceptport##*-}" -le "65535" ] 2>/dev/null &&
-						[ "${acceptport##*-}" -ge "${acceptport%%-*}" ] 2>/dev/null
-				}; then
-				echo "allow $acceptport $subnet $acceptport # Accept port $acceptport on $interface"
-			else
+			is_port_or_range "$acceptport" && echo "allow $acceptport $subnet $acceptport # Accept port $acceptport on $interface" ||
 				log "Invalid port or port range ($acceptport) in accept_ports ignored" daemon.warn
-			fi
 		done
 	fi
 	if [ "$2" = "pre-acl" ] && [ "$check_acl" = "0" ]; then

--- a/net/miniupnpd/files/nftables.d/chain-post/srcnat/20-miniupnpd.nft
+++ b/net/miniupnpd/files/nftables.d/chain-post/srcnat/20-miniupnpd.nft
@@ -1,1 +1,0 @@
-jump upnp_postrouting comment "Hook into miniupnpd postrouting chain";

--- a/net/miniupnpd/files/nftables.d/table-post/20-miniupnpd.nft
+++ b/net/miniupnpd/files/nftables.d/table-post/20-miniupnpd.nft
@@ -1,3 +1,2 @@
 chain upnp_forward {}
 chain upnp_prerouting {}
-chain upnp_postrouting {}

--- a/net/miniupnpd/files/upnpd-migration.uci-defaults
+++ b/net/miniupnpd/files/upnpd-migration.uci-defaults
@@ -212,6 +212,8 @@ else
 	fi
 	while uci -q delete upnpd.@perm_rule[-1]; do :; done
 fi
+[ "$access_defaults" != "" ] && uci set upnpd.config.access_defaults="$access_defaults"
+[ "$check_acl" = "0" ] && uci set upnpd.config.check_acl="0"
 if [ "$addtemplateentries" = "1" ]; then
 	uci batch >/dev/null <<-EOF
 		add upnpd acl_entry
@@ -229,20 +231,6 @@ if [ "$addtemplateentries" = "1" ]; then
 	EOF
 	uci -q get upnpd.@acl_entry[-3] >/dev/null &&
 		uci reorder upnpd.@acl_entry[-2]=0 && uci reorder upnpd.@acl_entry[-1]=1
-fi
-
-# Migrate internal_iface option to new internal_network section
-if ! uci -q get upnpd.@internal_network[0] >/dev/null; then
-	ifnr=0
-	for interface in $(uci -q get upnpd.config.internal_iface || echo lan); do
-		log "Create new internal_network section for $interface"
-		uci add upnpd internal_network >/dev/null
-		uci set upnpd.@internal_network[$ifnr].interface="$interface"
-		[ "$access_defaults" != "" ] && uci set upnpd.@internal_network[$ifnr].access_defaults="$access_defaults"
-		[ "$check_acl" = "0" ] && uci set upnpd.@internal_network[$ifnr].check_acl="0"
-		ifnr=$((ifnr + 1))
-	done
-	uci -q delete upnpd.config.internal_iface
 fi
 
 # Rename UCI section config -> settings (v2.0)

--- a/net/miniupnpd/files/upnpd-migration.uci-defaults
+++ b/net/miniupnpd/files/upnpd-migration.uci-defaults
@@ -147,6 +147,90 @@ if [ "$(uci -q get upnpd.config.notify_interval)" -le "900" ] 2>/dev/null; then
 	uci delete upnpd.config.notify_interval
 fi
 
+# Migrate ACL to new section, note that an empty ACL is now rejected alone
+# a) Empty/unmodified ACL: Set access defaults, add/update template entries
+# b) Modified ACL:
+#    - Add missing entry action to avoid adding inverted actions when changing via LuCI
+#    - Update entry action allow/deny -> accept/reject
+#    - Update entry port options to only use the LuCI (and daemon) supported hyphen (-) as port range separator
+#    - Not using access defaults, add template entries
+if uci -q get upnpd.@acl_entry[0] >/dev/null; then
+	log "Error migrating ACL, as the new UCI section already exists" daemon.err
+elif ! uci -q get upnpd.@perm_rule[0] >/dev/null; then
+	log "Empty ACL: Set access defaults, add templates, empty ACL rejected alone"
+	access_defaults=accept-all-ports
+	check_acl=0
+	addtemplateentries=1
+elif ! uci -q get upnpd.@perm_rule[2] >/dev/null &&
+	[ "$(uci -q get upnpd.@perm_rule[0].int_addr)" = "0.0.0.0/0" ] &&
+	[ "$(uci -q get upnpd.@perm_rule[0].int_ports)" = "1024-65535" ] &&
+	[ "$(uci -q get upnpd.@perm_rule[0].ext_ports)" = "1024-65535" ] &&
+	[ "$(uci -q get upnpd.@perm_rule[0].action)" = "allow" ] &&
+	[ "$(uci -q get upnpd.@perm_rule[1].int_addr)" = "0.0.0.0/0" ] &&
+	[ "$(uci -q get upnpd.@perm_rule[1].int_ports)" = "0-65535" ] &&
+	[ "$(uci -q get upnpd.@perm_rule[1].ext_ports)" = "0-65535" ] &&
+	[ "$(uci -q get upnpd.@perm_rule[1].action)" = "deny" ]; then
+	log "Unmodified ACL: Set access defaults, empty ACL rejected alone"
+	access_defaults=accept-high-ports
+	check_acl=0
+	addtemplateentries=1
+	uci delete upnpd.@perm_rule[-1]
+	uci delete upnpd.@perm_rule[-1]
+else
+	log "Modified ACL: Migrate entries/section, empty ACL rejected alone"
+	addtemplateentries=1
+	entrynr=0
+	while uci -q get upnpd.@perm_rule[$entrynr] >/dev/null; do
+		comment="$(uci -q get upnpd.@perm_rule[$entrynr].comment)"
+		int_addr="$(uci -q get upnpd.@perm_rule[$entrynr].int_addr)"
+		int_port="$(uci -q get upnpd.@perm_rule[$entrynr].int_ports)"
+		ext_port="$(uci -q get upnpd.@perm_rule[$entrynr].ext_ports)"
+		action="$(uci -q get upnpd.@perm_rule[$entrynr].action)"
+		echo "$int_port" | grep -q ":" &&
+			log "ACL entry: Update int_port to use hyphen (-) as port range separator" &&
+			int_port="$(echo "$int_port" | tr ":" "-")"
+		echo "$ext_port" | grep -q ":" &&
+			log "ACL entry: Update ext_port to use hyphen (-) as port range separator" &&
+			ext_port="$(echo "$ext_port" | tr ":" "-")"
+		[ "$action" = "" ] && log "ACL entry: Add missing action option" && action=reject
+		[ "$action" = "allow" ] && action=accept
+		[ "$action" = "deny" ] && action=reject
+		uci batch >/dev/null <<-EOF
+			add upnpd acl_entry
+			set upnpd.@acl_entry[-1].comment="${comment:-unspecified}"
+			set upnpd.@acl_entry[-1].int_addr="${int_addr:-0.0.0.0/0}"
+			set upnpd.@acl_entry[-1].int_port="$int_port"
+			set upnpd.@acl_entry[-1].ext_port="$ext_port"
+			set upnpd.@acl_entry[-1].action="$action"
+		EOF
+		entrynr=$((entrynr + 1))
+	done
+	if [ "${int_addr:-0.0.0.0/0}" = "0.0.0.0/0" ] && [ "${int_port:-0-65535}" = "0-65535" ] &&
+		[ "${ext_port:-0-65535}" = "0-65535" ] && [ "$action" = "reject" ]; then
+		log "ACL entry: Remove no longer useful reject by default entry"
+		uci delete upnpd.@acl_entry[-1]
+	fi
+	while uci -q delete upnpd.@perm_rule[-1]; do :; done
+fi
+if [ "$addtemplateentries" = "1" ]; then
+	uci batch >/dev/null <<-EOF
+		add upnpd acl_entry
+		add upnpd acl_entry
+		set upnpd.@acl_entry[-2].comment="High ports"
+		set upnpd.@acl_entry[-2].int_addr="0.0.0.0/0"
+		set upnpd.@acl_entry[-2].int_port="1024-65535"
+		set upnpd.@acl_entry[-2].ext_port="1024-65535"
+		set upnpd.@acl_entry[-2].action="disabled"
+		set upnpd.@acl_entry[-1].comment="Low/system ports"
+		set upnpd.@acl_entry[-1].int_addr="0.0.0.0/0"
+		set upnpd.@acl_entry[-1].int_port="1-1023"
+		set upnpd.@acl_entry[-1].ext_port="1-1023"
+		set upnpd.@acl_entry[-1].action="disabled"
+	EOF
+	uci -q get upnpd.@acl_entry[-3] >/dev/null &&
+		uci reorder upnpd.@acl_entry[-2]=0 && uci reorder upnpd.@acl_entry[-1]=1
+fi
+
 # Migrate internal_iface option to new internal_network section
 if ! uci -q get upnpd.@internal_network[0] >/dev/null; then
 	ifnr=0
@@ -154,6 +238,8 @@ if ! uci -q get upnpd.@internal_network[0] >/dev/null; then
 		log "Create new internal_network section for $interface"
 		uci add upnpd internal_network >/dev/null
 		uci set upnpd.@internal_network[$ifnr].interface="$interface"
+		[ "$access_defaults" != "" ] && uci set upnpd.@internal_network[$ifnr].access_defaults="$access_defaults"
+		[ "$check_acl" = "0" ] && uci set upnpd.@internal_network[$ifnr].check_acl="0"
 		ifnr=$((ifnr + 1))
 	done
 	uci -q delete upnpd.config.internal_iface

--- a/net/miniupnpd/files/upnpd-migration.uci-defaults
+++ b/net/miniupnpd/files/upnpd-migration.uci-defaults
@@ -1,0 +1,159 @@
+#!/bin/sh
+
+log() {
+	logger -s -p "${2:-daemon.notice}" -t "upnpd" "$1" || echo "upnpd: $1" >&2
+}
+
+log "Check UCI options in /etc/config/upnpd to be migrated to v2.0"
+
+# Migrate boolean options to only use 0/1 for LuCI flag support
+for option in enabled ipv6_disable system_uptime; do
+	if uci -q get upnpd.config.$option >/dev/null; then
+		uci get upnpd.config.$option | grep -q -E -x "0|off|false|no|disabled" && uci set upnpd.config.$option="0"
+		uci get upnpd.config.$option | grep -q -E -x "1|on|true|yes|enabled" && uci set upnpd.config.$option="1"
+	fi
+done
+
+# Set missing enabled option to fix previously different defaults in LuCI/config (0) and init UCI (1)
+if ! uci -q get upnpd.config.enabled >/dev/null; then
+	uci -q set upnpd.config.enabled="1"
+fi
+
+# Migrate enable_upnp/enable_natpmp -> enable_protocols: Combined option
+if uci -q get upnpd.config.enable_upnp >/dev/null || uci -q get upnpd.config.enable_natpmp >/dev/null; then
+	log "enable_upnp/enable_natpmp -> enable_protocols: Combined option"
+	if ! uci -q get upnpd.config.enable_upnp | grep -q -E -x "0|off|false|no|disabled"; then
+		uci -q get upnpd.config.enable_natpmp | grep -q -E -x "0|off|false|no|disabled" &&
+			uci set upnpd.config.enable_protocols="upnp-igd" ||
+			uci set upnpd.config.enable_protocols="all"
+	elif ! uci -q get upnpd.config.enable_natpmp | grep -q -E -x "0|off|false|no|disabled"; then
+		uci set upnpd.config.enable_protocols="pcp+nat-pmp"
+	else
+		uci set upnpd.config.enable_protocols="all"
+		uci set upnpd.config.enabled="0"
+	fi
+	uci -q delete upnpd.config.enable_upnp
+	uci -q delete upnpd.config.enable_natpmp
+fi
+
+# Rename use_stun -> allow_cgnat
+if uci -q get upnpd.config.use_stun >/dev/null; then
+	log "use_stun -> allow_cgnat"
+	uci rename upnpd.config.use_stun="allow_cgnat"
+fi
+
+# Remove known unsupported (not CGNAT filtering test capable) STUN servers and include stun_port in stun_host
+if uci -q get upnpd.config.stun_host | grep -q -E "stun[0-9]?.l.google.com|stun.cloudflare.com"; then
+	log "stun_host: Unsupported STUN server ($(uci -q get upnpd.config.stun_host)) set, remove to set default"
+	uci delete upnpd.config.stun_host
+	uci -q delete upnpd.config.stun_port
+	# To keep behaviour with daemon <2.3.10 as previously, a false-negative filter result was returned for unsupported servers
+	uci set upnpd.config.allow_cgnat="allow-filtered"
+elif uci -q get upnpd.config.stun_port >/dev/null; then
+	uci -q get upnpd.config.stun_host >/dev/null && [ "$(uci -q get upnpd.config.stun_port)" != "3478" ] &&
+		log "stun_port: Include stun_port in stun_host, and remove option" &&
+		uci set upnpd.config.stun_host="$(uci -q get upnpd.config.stun_host | cut -d ":" -f 1):$(uci -q get upnpd.config.stun_port)"
+	uci delete upnpd.config.stun_port
+fi
+
+# Migrate force_forwarding=1 (in X-Wrt since 2021) to new similar option allow_cgnat=allow-filtered for cross-upgrades
+if uci -q get upnpd.config.force_forwarding >/dev/null; then
+	log "force_forwarding=1 -> allow_cgnat=allow-filtered: New option"
+	uci get upnpd.config.force_forwarding | grep -q -E -x "1|on|true|yes|enabled" &&
+		uci set upnpd.config.allow_cgnat="allow-filtered"
+	uci delete upnpd.config.force_forwarding
+fi
+
+# Migrate secure_mode=1/0 -> allow_third_party_mapping=0/upnp-igd/pcp/1: Invert/extend to PCP
+if uci -q get upnpd.config.secure_mode >/dev/null; then
+	log "secure_mode=1/0 -> allow_third_party_mapping=0/upnp-igd/pcp/1: Invert/extend to PCP"
+	uci get upnpd.config.secure_mode | grep -q -E -x "0|off|false|no|disabled" &&
+		uci set upnpd.config.allow_third_party_mapping="upnp-igd" ||
+		uci set upnpd.config.allow_third_party_mapping="0"
+	uci delete upnpd.config.secure_mode
+fi
+
+# Migrate log_output=0/1 -> log_output=default/debug: Now info also allowed
+if uci -q get upnpd.config.log_output >/dev/null; then
+	log "log_output=0/1 -> log_output=default/debug: Now info also allowed"
+	uci get upnpd.config.log_output | grep -q -E -x "1|on|true|yes|enabled" &&
+		uci set upnpd.config.log_output="debug"
+	uci get upnpd.config.log_output | grep -q -E -x "0|off|false|no|disabled" &&
+		uci set upnpd.config.log_output="default"
+fi
+
+# Rename upnp_lease_file -> lease_file: To daemon option name, and remove if UCI default set
+if uci -q get upnpd.config.upnp_lease_file >/dev/null; then
+	if [ "$(uci -q get upnpd.config.upnp_lease_file)" = "/var/run/miniupnpd.leases" ]; then
+		log "upnp_lease_file -> lease_file: Remove option as UCI default set"
+		uci delete upnpd.config.upnp_lease_file
+	else
+		log "upnp_lease_file -> lease_file"
+		uci rename upnpd.config.upnp_lease_file="lease_file"
+	fi
+fi
+if uci -q get upnpd.config.upnp_lease_file6 >/dev/null; then
+	uci delete upnpd.config.upnp_lease_file6
+fi
+
+# Migrate igdv1=1/0 -> upnp_igd_compat=igdv1/igdv2: Extensible/clearer
+if uci -q get upnpd.config.igdv1 >/dev/null; then
+	log "igdv1=1/0 -> upnp_igd_compat=igdv1/igdv2"
+	uci get upnpd.config.igdv1 | grep -q -E -x "1|on|true|yes|enabled" &&
+		uci set upnpd.config.upnp_igd_compat="igdv1" ||
+		uci set upnpd.config.upnp_igd_compat="igdv2"
+	uci delete upnpd.config.igdv1
+fi
+
+# Migrate download/upload -> download_kbps/upload_kbps: Convert to kbit/s
+if uci -q get upnpd.config.download >/dev/null; then
+	download="$(uci -q get upnpd.config.download)"
+	if [ "$download" != "1024" ] && [ "$download" -ge "1" ] 2>/dev/null; then
+		log "download -> download_kbps: Convert to kbit/s"
+		download_kbps="$((download * 8 * 1024 / 1000))"
+		uci set upnpd.config.download_kbps="$download_kbps"
+	fi
+	uci delete upnpd.config.download
+fi
+if uci -q get upnpd.config.upload >/dev/null; then
+	upload="$(uci -q get upnpd.config.upload)"
+	if [ "$upload" != "512" ] && [ "$upload" -ge "1" ] 2>/dev/null; then
+		log "upload -> upload_kbps: Convert to kbit/s"
+		upload_kbps="$((upload * 8 * 1024 / 1000))"
+		uci set upnpd.config.upload_kbps="$upload_kbps"
+	fi
+	uci delete upnpd.config.upload
+fi
+
+# Rename port -> http_port: Remove if UCI default set
+if uci -q get upnpd.config.port >/dev/null; then
+	if [ "$(uci -q get upnpd.config.port)" = "5000" ]; then
+		log "port -> http_port: Remove option as UCI default set"
+		uci delete upnpd.config.port
+	else
+		log "port -> http_port"
+		uci rename upnpd.config.port="http_port"
+	fi
+fi
+
+# Migrate notify_interval <= 900 s: Remove to set minimum of 900 (default)
+if [ "$(uci -q get upnpd.config.notify_interval)" -le "900" ] 2>/dev/null; then
+	log "notify_interval <= 900 s: Remove to set minimum of 900 (default)"
+	uci delete upnpd.config.notify_interval
+fi
+
+# Migrate internal_iface option to new internal_network section
+if ! uci -q get upnpd.@internal_network[0] >/dev/null; then
+	ifnr=0
+	for interface in $(uci -q get upnpd.config.internal_iface || echo lan); do
+		log "Create new internal_network section for $interface"
+		uci add upnpd internal_network >/dev/null
+		uci set upnpd.@internal_network[$ifnr].interface="$interface"
+		ifnr=$((ifnr + 1))
+	done
+	uci -q delete upnpd.config.internal_iface
+fi
+
+uci commit upnpd >/dev/null
+
+exit 0

--- a/net/miniupnpd/files/upnpd-migration.uci-defaults
+++ b/net/miniupnpd/files/upnpd-migration.uci-defaults
@@ -4,7 +4,12 @@ log() {
 	logger -s -p "${2:-daemon.notice}" -t "upnpd" "$1" || echo "upnpd: $1" >&2
 }
 
+# Skip migration with existing settings (v2.0) or with no config (v1.0) UCI section
+# Enables the creation of a merged v1.0/v2.0 config file
+{ uci -q get upnpd.settings >/dev/null || ! uci -q get upnpd.config >/dev/null; } && exit 0
+
 log "Check UCI options in /etc/config/upnpd to be migrated to v2.0"
+cp /etc/config/upnpd /tmp
 
 # Migrate boolean options to only use 0/1 for LuCI flag support
 for option in enabled ipv6_disable system_uptime; do
@@ -154,6 +159,12 @@ if ! uci -q get upnpd.@internal_network[0] >/dev/null; then
 	uci -q delete upnpd.config.internal_iface
 fi
 
+# Rename UCI section config -> settings (v2.0)
+log "Rename UCI section config -> settings (v2.0)"
+uci rename upnpd.config="settings" || log "Error renaming the UCI section" daemon.err
+
 uci commit upnpd >/dev/null
+
+log "Previous v1.0 config file copied to /tmp/upnpd (kept until reboot)"
 
 exit 0

--- a/net/miniupnpd/files/upnpd-migration.uci-defaults
+++ b/net/miniupnpd/files/upnpd-migration.uci-defaults
@@ -1,0 +1,159 @@
+#!/bin/sh
+
+log() {
+	logger -s -p "${2:-daemon.notice}" -t "upnpd" "$1" || echo "upnpd: $1" >&2
+}
+
+log "Check UCI options in /etc/config/upnpd to be migrated to v2.0"
+
+# Migrate boolean options to only use 0/1 for LuCI flag support
+for option in enabled ipv6_disable system_uptime; do
+	if uci -q get upnpd.config.$option >/dev/null; then
+		uci get upnpd.config.$option | grep -q -E -x "0|off|false|no|disabled" && uci set upnpd.config.$option="0"
+		uci get upnpd.config.$option | grep -q -E -x "1|on|true|yes|enabled" && uci set upnpd.config.$option="1"
+	fi
+done
+
+# Set missing enabled option to fix previously different defaults in LuCI/config (0) and init UCI (1)
+if ! uci -q get upnpd.config.enabled >/dev/null; then
+	uci -q set upnpd.config.enabled="1"
+fi
+
+# Migrate enable_upnp/enable_natpmp -> enable_protocols: Combined option
+if uci -q get upnpd.config.enable_upnp >/dev/null || uci -q get upnpd.config.enable_natpmp >/dev/null; then
+	log "enable_upnp/enable_natpmp -> enable_protocols: Combined option"
+	if ! uci -q get upnpd.config.enable_upnp | grep -q -E -x "0|off|false|no|disabled"; then
+		uci -q get upnpd.config.enable_natpmp | grep -q -E -x "0|off|false|no|disabled" &&
+			uci set upnpd.config.enable_protocols="upnp-igd" ||
+			uci set upnpd.config.enable_protocols="all"
+	elif ! uci -q get upnpd.config.enable_natpmp | grep -q -E -x "0|off|false|no|disabled"; then
+		uci set upnpd.config.enable_protocols="pcp+nat-pmp"
+	else
+		uci set upnpd.config.enable_protocols="all"
+		uci set upnpd.config.enabled="0"
+	fi
+	uci -q delete upnpd.config.enable_upnp
+	uci -q delete upnpd.config.enable_natpmp
+fi
+
+# Rename use_stun -> allow_cgnat
+if uci -q get upnpd.config.use_stun >/dev/null; then
+	log "use_stun -> allow_cgnat"
+	uci rename upnpd.config.use_stun="allow_cgnat"
+fi
+
+# Remove known unsupported (not CGNAT filtering test capable) STUN servers and include stun_port in stun_host
+if uci -q get upnpd.config.stun_host | grep -q -E "stun[0-9]?.l.google.com|stun.cloudflare.com"; then
+	log "stun_host: Unsupported STUN server ($(uci -q get upnpd.config.stun_host)) set, remove to set default"
+	uci delete upnpd.config.stun_host
+	uci -q delete upnpd.config.stun_port
+	# To keep behaviour with daemon <2.3.10 as previously, a false-negative filter result was returned for unsupported servers
+	[ "$(uci -q get upnpd.config.allow_cgnat)" = "1" ] && uci set upnpd.config.allow_cgnat="allow-filtered"
+elif uci -q get upnpd.config.stun_port >/dev/null; then
+	uci -q get upnpd.config.stun_host >/dev/null && [ "$(uci -q get upnpd.config.stun_port)" != "3478" ] &&
+		log "stun_port: Include stun_port in stun_host, and remove option" &&
+		uci set upnpd.config.stun_host="$(uci -q get upnpd.config.stun_host | cut -d ":" -f 1):$(uci -q get upnpd.config.stun_port)"
+	uci delete upnpd.config.stun_port
+fi
+
+# Migrate force_forwarding=1 (in X-Wrt since 2021) to new similar option allow_cgnat=allow-filtered for cross-upgrades
+if uci -q get upnpd.config.force_forwarding >/dev/null; then
+	log "force_forwarding=1 -> allow_cgnat=allow-filtered: New option"
+	uci get upnpd.config.force_forwarding | grep -q -E -x "1|on|true|yes|enabled" &&
+		uci set upnpd.config.allow_cgnat="allow-filtered"
+	uci delete upnpd.config.force_forwarding
+fi
+
+# Migrate secure_mode=1/0 -> allow_third_party_mapping=0/upnp-igd/pcp/1: Invert/extend to PCP
+if uci -q get upnpd.config.secure_mode >/dev/null; then
+	log "secure_mode=1/0 -> allow_third_party_mapping=0/upnp-igd/pcp/1: Invert/extend to PCP"
+	uci get upnpd.config.secure_mode | grep -q -E -x "0|off|false|no|disabled" &&
+		uci set upnpd.config.allow_third_party_mapping="upnp-igd" ||
+		uci set upnpd.config.allow_third_party_mapping="0"
+	uci delete upnpd.config.secure_mode
+fi
+
+# Migrate log_output=0/1 -> log_output=default/debug: Now info also allowed
+if uci -q get upnpd.config.log_output >/dev/null; then
+	log "log_output=0/1 -> log_output=default/debug: Now info also allowed"
+	uci get upnpd.config.log_output | grep -q -E -x "1|on|true|yes|enabled" &&
+		uci set upnpd.config.log_output="debug"
+	uci get upnpd.config.log_output | grep -q -E -x "0|off|false|no|disabled" &&
+		uci set upnpd.config.log_output="default"
+fi
+
+# Rename upnp_lease_file -> lease_file: To daemon option name, and remove if UCI default set
+if uci -q get upnpd.config.upnp_lease_file >/dev/null; then
+	if [ "$(uci -q get upnpd.config.upnp_lease_file)" = "/var/run/miniupnpd.leases" ]; then
+		log "upnp_lease_file -> lease_file: Remove option as UCI default set"
+		uci delete upnpd.config.upnp_lease_file
+	else
+		log "upnp_lease_file -> lease_file"
+		uci rename upnpd.config.upnp_lease_file="lease_file"
+	fi
+fi
+if uci -q get upnpd.config.upnp_lease_file6 >/dev/null; then
+	uci delete upnpd.config.upnp_lease_file6
+fi
+
+# Migrate igdv1=1/0 -> upnp_igd_compat=igdv1/igdv2: Extensible/clearer
+if uci -q get upnpd.config.igdv1 >/dev/null; then
+	log "igdv1=1/0 -> upnp_igd_compat=igdv1/igdv2"
+	uci get upnpd.config.igdv1 | grep -q -E -x "1|on|true|yes|enabled" &&
+		uci set upnpd.config.upnp_igd_compat="igdv1" ||
+		uci set upnpd.config.upnp_igd_compat="igdv2"
+	uci delete upnpd.config.igdv1
+fi
+
+# Migrate download/upload -> download_kbps/upload_kbps: Convert to kbit/s
+if uci -q get upnpd.config.download >/dev/null; then
+	download="$(uci -q get upnpd.config.download)"
+	if [ "$download" != "1024" ] && [ "$download" -ge "1" ] 2>/dev/null; then
+		log "download -> download_kbps: Convert to kbit/s"
+		download_kbps="$((download * 8 * 1024 / 1000))"
+		uci set upnpd.config.download_kbps="$download_kbps"
+	fi
+	uci delete upnpd.config.download
+fi
+if uci -q get upnpd.config.upload >/dev/null; then
+	upload="$(uci -q get upnpd.config.upload)"
+	if [ "$upload" != "512" ] && [ "$upload" -ge "1" ] 2>/dev/null; then
+		log "upload -> upload_kbps: Convert to kbit/s"
+		upload_kbps="$((upload * 8 * 1024 / 1000))"
+		uci set upnpd.config.upload_kbps="$upload_kbps"
+	fi
+	uci delete upnpd.config.upload
+fi
+
+# Rename port -> http_port: Remove if UCI default set
+if uci -q get upnpd.config.port >/dev/null; then
+	if [ "$(uci -q get upnpd.config.port)" = "5000" ]; then
+		log "port -> http_port: Remove option as UCI default set"
+		uci delete upnpd.config.port
+	else
+		log "port -> http_port"
+		uci rename upnpd.config.port="http_port"
+	fi
+fi
+
+# Migrate notify_interval <= 900 s: Remove to set minimum of 900 (default)
+if [ "$(uci -q get upnpd.config.notify_interval)" -le "900" ] 2>/dev/null; then
+	log "notify_interval <= 900 s: Remove to set minimum of 900 (default)"
+	uci delete upnpd.config.notify_interval
+fi
+
+# Migrate internal_iface option to new internal_network section
+if ! uci -q get upnpd.@internal_network[0] >/dev/null; then
+	ifnr=0
+	for interface in $(uci -q get upnpd.config.internal_iface || echo lan); do
+		log "Create new internal_network section for $interface"
+		uci add upnpd internal_network >/dev/null
+		uci set upnpd.@internal_network[$ifnr].interface="$interface"
+		ifnr=$((ifnr + 1))
+	done
+	uci -q delete upnpd.config.internal_iface
+fi
+
+uci commit upnpd >/dev/null
+
+exit 0

--- a/net/miniupnpd/files/upnpd.config
+++ b/net/miniupnpd/files/upnpd.config
@@ -1,6 +1,6 @@
 # UPnP IGD & PCP/NAT-PMP Service Settings (v2.0)
 
-config upnpd 'config'
+config upnpd 'settings'
 	option enabled                    '0'
 	# Can be set to all/upnp-igd/pcp+nat-pmp
 	option enable_protocols           'all'

--- a/net/miniupnpd/files/upnpd.config
+++ b/net/miniupnpd/files/upnpd.config
@@ -4,18 +4,15 @@ config upnpd 'settings'
 	option enabled                    '0'
 	# Can be set to all/upnp-igd/pcp+nat-pmp
 	option enable_protocols           'all'
+	# Enable networks, multiple can be specified, separated by a space
+	option internal_iface             'lan'
+	option access_defaults            'accept-high-ports' # default none
+	option check_acl                  '0' # default 1
 	#option ipv6_disable              '0'
 	#option allow_third_party_mapping '0'
 	# Extra logging by setting to info or debug (previously 1)
 	option log_output                 'default'
 	option upnp_igd_compat            'igdv1'
-
-# Enable Networks / Access Control
-
-config internal_network
-	option interface                  'lan'
-	option access_defaults            'accept-high-ports' # default none
-	option check_acl                  '0' # default 1
 
 # Access Control List
 # Empty ACL rejected alone, IPv6 accepted unless disabled, action: accept/reject

--- a/net/miniupnpd/files/upnpd.config
+++ b/net/miniupnpd/files/upnpd.config
@@ -1,29 +1,35 @@
-config upnpd config
-	option enabled		0
-	option enable_natpmp	1
-	option enable_upnp	1
-	option secure_mode	1
-	option log_output	0
-	option download		1024
-	option upload		512
-#by default, looked up dynamically from ubus
-#	option external_iface	wan
-	option internal_iface	lan
-	option port		5000
-	option upnp_lease_file	/var/run/miniupnpd.leases
-	option upnp_lease_file6	/var/run/miniupnpd.leases6
-	option igdv1		1
+# UPnP IGD & PCP/NAT-PMP Service Settings (v2.0)
+
+config upnpd 'config'
+	option enabled                    '0'
+	# Can be set to all/upnp-igd/pcp+nat-pmp
+	option enable_protocols           'all'
+	#option ipv6_disable              '0'
+	#option allow_third_party_mapping '0'
+	# Extra logging by setting to info or debug (previously 1)
+	option log_output                 'default'
+	option upnp_igd_compat            'igdv1'
+
+# Enable Networks / Access Control
+
+config internal_network
+	option interface                  'lan'
+	option access_defaults            'accept-high-ports' # default none
+	option check_acl                  '0' # default 1
+
+# Access Control List
+# Empty ACL rejected alone, IPv6 accepted unless disabled
 
 config perm_rule
-	option action		allow
-	option ext_ports	1024-65535
-	option int_addr		0.0.0.0/0	# Does not override secure_mode
-	option int_ports	1024-65535
-	option comment		"Allow high ports"
+	option comment                    'Allow high ports'
+	option int_addr                   '0.0.0.0/0'
+	option int_ports                  '1024-65535'
+	option ext_ports                  '1024-65535'
+	option action                     'allow'
 
 config perm_rule
-	option action		deny
-	option ext_ports	0-65535
-	option int_addr		0.0.0.0/0
-	option int_ports	0-65535
-	option comment		"Default deny"
+	option comment                    'Default deny'
+	option int_addr                   '0.0.0.0/0'
+	option int_ports                  '1-65535'
+	option ext_ports                  '1-65535'
+	option action                     'deny'

--- a/net/miniupnpd/files/upnpd.config
+++ b/net/miniupnpd/files/upnpd.config
@@ -18,18 +18,18 @@ config internal_network
 	option check_acl                  '0' # default 1
 
 # Access Control List
-# Empty ACL rejected alone, IPv6 accepted unless disabled
+# Empty ACL rejected alone, IPv6 accepted unless disabled, action: accept/reject
 
-config perm_rule
-	option comment                    'Allow high ports'
+config acl_entry
+	option comment                    'High ports'
 	option int_addr                   '0.0.0.0/0'
-	option int_ports                  '1024-65535'
-	option ext_ports                  '1024-65535'
-	option action                     'allow'
+	option int_port                   '1024-65535'
+	option ext_port                   '1024-65535'
+	option action                     'disabled'
 
-config perm_rule
-	option comment                    'Default deny'
+config acl_entry
+	option comment                    'Low/system ports'
 	option int_addr                   '0.0.0.0/0'
-	option int_ports                  '1-65535'
-	option ext_ports                  '1-65535'
-	option action                     'deny'
+	option int_port                   '1-1023'
+	option ext_port                   '1-1023'
+	option action                     'disabled'

--- a/net/miniupnpd/patches/10-upnp-igdv2-compat.patch
+++ b/net/miniupnpd/patches/10-upnp-igdv2-compat.patch
@@ -1,0 +1,80 @@
+From f94e5bf7a60a41911af8d7e23cdb4ebe166257e2 Mon Sep 17 00:00:00 2001
+From: Self-Hosting-Group
+ <155233284+Self-Hosting-Group@users.noreply.github.com>
+Date: Fri, 14 Aug 2026 00:00:00 +0000
+Subject: [PATCH] miniupnpd: UPnP IGDv2 Microsoft/Apple compatibility
+
+* Add workaround to list port maps with the Windows IGDv2-incompatible
+  client by returning an infinite (0) lease duration. To fix listing and
+  editing via GUI (Explorer/Network), if daemon was compiled with IGDv2
+* Extend detection to older versions of Windows and add Xbox
+* Detect Apple IGDv2-incompatible clients and apply existing workaround,
+  that only caused problems if PCP/NAT-PMP (prioritised) was disabled
+
+Link: https://github.com/Self-Hosting-Group/miniupnp/tree/upnp-igdv2-compat
+Link: https://github.com/Self-Hosting-Group/wiki/wiki/Port-Mapping-Protocols-Overview#compatibility-issues
+---
+ upnphttp.c | 19 ++++++++++++++++---
+ upnpsoap.c | 16 ++++++++++++++++
+ 2 files changed, 32 insertions(+), 3 deletions(-)
+
+--- a/upnphttp.c
++++ b/upnphttp.c
+@@ -307,9 +307,22 @@ ParseHttpHeaders(struct upnphttp * h)
+ 			}
+ 			else if(strncasecmp(line, "user-agent:", 11) == 0)
+ 			{
+-				/* - User-Agent: Microsoft-Windows/10.0 UPnP/1.0
+-				 * - User-Agent: FDSSDP                           */
+-				if(strcasestr(line + 11, "microsoft") != NULL || strstr(line + 11, "FDSSDP") != NULL) {
++				/* Detect Microsoft UPnP IGDv2-incompatible clients that only support IGDv1 routers,
++				 * and Windows requires extra UDA 1.x (Win XP 1.0), via User-Agent SOAP/HTTP header:
++				 * - Microsoft-Windows/10.0 UPnP/1.0 (Win >=10)
++				 * - Microsoft-Windows/6.1 UPnP/1.0 (Win 7)
++				 * - FDSSDP (Win >=Vista for GET)
++				 * - Mozilla/4.0 (compatible; UPnP/1.0; Windows NT/5.1) (Win XP/Vista for GET)
++				 * - Mozilla/4.0 (compatible; UPnP/1.0; Windows 9x) (Win XP/Vista for POST)
++				 * - Xbox/2.0.17559.0 UPnP/1.0 Xbox/2.0.17559.0
++				 * Detect Apple UPnP IGDv2-incompatible clients that only support IGDv1 routers:
++				 * - Mozilla/4.0 (compatible; UPnP/1.0; Windows NT/5.1) (for GET)
++				 * - Mozilla/4.0 (compatible; UPnP/1.0; Windows 9x) (for POST) */
++				if (((strstr(line + 11, "Microsoft-Windows/") != NULL ||
++							strstr(line + 11, "Xbox/") != NULL) &&
++						 strstr(line + 11, " UPnP/1.0") != NULL) ||
++						strstr(line + 11, "FDSSDP") != NULL ||
++						strstr(line + 11, "Mozilla/4.0 (compatible; UPnP/1.0; Windows") != NULL) {
+ 					h->respflags |= FLAG_MS_CLIENT;
+ 				}
+ 			}
+--- a/upnpsoap.c
++++ b/upnpsoap.c
+@@ -920,6 +920,14 @@ GetSpecificPortMappingEntry(struct upnph
+ #ifdef ENABLE_PCP
+ 		hide_pcp_nonce(desc);
+ #endif
++#ifdef IGD_V2
++		/* Workaround to list port maps with the Windows IGDv2-incompatible client
++		 * by returning an infinite (0) lease duration. To fix listing and editing
++		 * via GUI (Explorer/Network), if daemon was compiled with IGDv2 */
++		if (h->respflags & FLAG_MS_CLIENT) {
++			leaseduration = 0;
++		}
++#endif
+ 		bodylen = snprintf(body, sizeof(body), resp,
+ 				action, ns/*SERVICE_TYPE_WANIPC*/,
+ 				(unsigned int)iport, int_ip, desc, leaseduration,
+@@ -1208,6 +1216,14 @@ GetGenericPortMappingEntry(struct upnpht
+ #ifdef ENABLE_PCP
+ 		hide_pcp_nonce(desc);
+ #endif
++#ifdef IGD_V2
++		/* Workaround to list port maps with the Windows IGDv2-incompatible client
++		 * by returning an infinite (0) lease duration. To fix listing and editing
++		 * via GUI (Explorer/Network), if daemon was compiled with IGDv2 */
++		if (h->respflags & FLAG_MS_CLIENT) {
++			leaseduration = 0;
++		}
++#endif
+ 		bodylen = snprintf(body, sizeof(body), resp,
+ 			action, ns, /*SERVICE_TYPE_WANIPC,*/ rhost,
+ 			(unsigned int)eport, protocol, (unsigned int)iport, iaddr, desc,

--- a/net/miniupnpd/patches/10-upnp-igdv2-compat.patch
+++ b/net/miniupnpd/patches/10-upnp-igdv2-compat.patch
@@ -1,0 +1,80 @@
+From f94e5bf7a60a41911af8d7e23cdb4ebe166257e2 Mon Sep 17 00:00:00 2001
+From: Self-Hosting-Group
+ <155233284+Self-Hosting-Group@users.noreply.github.com>
+Date: Fri, 14 Aug 2026 00:00:00 +0000
+Subject: [PATCH] miniupnpd: UPnP IGDv2 Microsoft/Apple compatibility
+
+* Add workaround to list port maps with the Windows IGDv2-incompatible
+  client by returning an infinite (0) lease duration. To fix listing and
+  editing via GUI (Explorer/Network), if daemon was compiled with IGDv2
+* Extend detection to older versions of Windows and add Xbox
+* Detect Apple IGDv2-incompatible clients and apply existing workaround,
+  that only caused problems if PCP/NAT-PMP (prioritised) was disabled
+
+Link: https://github.com/Self-Hosting-Group/miniupnp/tree/upnp-igdv2-compat
+Link: https://github.com/Self-Hosting-Group/wiki/wiki/Port-Mapping-Protocols-Overview#compatibility-issues
+---
+ upnphttp.c | 19 ++++++++++++++++---
+ upnpsoap.c | 16 ++++++++++++++++
+ 2 files changed, 32 insertions(+), 3 deletions(-)
+
+--- a/upnphttp.c
++++ b/upnphttp.c
+@@ -319,9 +319,22 @@ ParseHttpHeaders(struct upnphttp * h)
+ 			}
+ 			else if(strncasecmp(line, "user-agent:", 11) == 0)
+ 			{
+-				/* - User-Agent: Microsoft-Windows/10.0 UPnP/1.0
+-				 * - User-Agent: FDSSDP                           */
+-				if(strcasestr(line + 11, "microsoft") != NULL || strstr(line + 11, "FDSSDP") != NULL) {
++				/* Detect Microsoft UPnP IGDv2-incompatible clients that only support IGDv1 routers,
++				 * and Windows requires extra UDA 1.x (Win XP 1.0), via User-Agent SOAP/HTTP header:
++				 * - Microsoft-Windows/10.0 UPnP/1.0 (Win >=10)
++				 * - Microsoft-Windows/6.1 UPnP/1.0 (Win 7)
++				 * - FDSSDP (Win >=Vista for GET)
++				 * - Mozilla/4.0 (compatible; UPnP/1.0; Windows NT/5.1) (Win XP/Vista for GET)
++				 * - Mozilla/4.0 (compatible; UPnP/1.0; Windows 9x) (Win XP/Vista for POST)
++				 * - Xbox/2.0.17559.0 UPnP/1.0 Xbox/2.0.17559.0
++				 * Detect Apple UPnP IGDv2-incompatible clients that only support IGDv1 routers:
++				 * - Mozilla/4.0 (compatible; UPnP/1.0; Windows NT/5.1) (for GET)
++				 * - Mozilla/4.0 (compatible; UPnP/1.0; Windows 9x) (for POST) */
++				if (((strstr(line + 11, "Microsoft-Windows/") != NULL ||
++							strstr(line + 11, "Xbox/") != NULL) &&
++						 strstr(line + 11, " UPnP/1.0") != NULL) ||
++						strstr(line + 11, "FDSSDP") != NULL ||
++						strstr(line + 11, "Mozilla/4.0 (compatible; UPnP/1.0; Windows") != NULL) {
+ 					h->respflags |= FLAG_MS_CLIENT;
+ 				}
+ 			}
+--- a/upnpsoap.c
++++ b/upnpsoap.c
+@@ -920,6 +920,14 @@ GetSpecificPortMappingEntry(struct upnph
+ #ifdef ENABLE_PCP
+ 		hide_pcp_nonce(desc);
+ #endif
++#ifdef IGD_V2
++		/* Workaround to list port maps with the Windows IGDv2-incompatible client
++		 * by returning an infinite (0) lease duration. To fix listing and editing
++		 * via GUI (Explorer/Network), if daemon was compiled with IGDv2 */
++		if (h->respflags & FLAG_MS_CLIENT) {
++			leaseduration = 0;
++		}
++#endif
+ 		bodylen = snprintf(body, sizeof(body), resp,
+ 				action, ns/*SERVICE_TYPE_WANIPC*/,
+ 				(unsigned int)iport, int_ip, desc, leaseduration,
+@@ -1208,6 +1216,14 @@ GetGenericPortMappingEntry(struct upnpht
+ #ifdef ENABLE_PCP
+ 		hide_pcp_nonce(desc);
+ #endif
++#ifdef IGD_V2
++		/* Workaround to list port maps with the Windows IGDv2-incompatible client
++		 * by returning an infinite (0) lease duration. To fix listing and editing
++		 * via GUI (Explorer/Network), if daemon was compiled with IGDv2 */
++		if (h->respflags & FLAG_MS_CLIENT) {
++			leaseduration = 0;
++		}
++#endif
+ 		bodylen = snprintf(body, sizeof(body), resp,
+ 			action, ns, /*SERVICE_TYPE_WANIPC,*/ rhost,
+ 			(unsigned int)eport, protocol, (unsigned int)iport, iaddr, desc,

--- a/net/miniupnpd/patches/20-improve-logging.patch
+++ b/net/miniupnpd/patches/20-improve-logging.patch
@@ -1,0 +1,1247 @@
+From a7cebfc522306295cc1745c637f64d0e7d659795 Mon Sep 17 00:00:00 2001
+From: Self-Hosting-Group
+ <155233284+Self-Hosting-Group@users.noreply.github.com>
+Date: Fri, 14 Aug 2026 00:00:00 +0000
+Subject: [PATCH] miniupnpd: Improve logging
+
+* Clearer logging of enabled protocols/ports, IPv6 mapping, and UPnP IGD
+  compatibility mode… in start banner
+* Log warnings with an enabled allow third-party mapping option
+* Change the log level (less verbose) of many internal or normally
+  occurring messages, and some error messages, without functional
+  restrictions, to DEBUG, client requests/actions and their errors to
+  INFO, and only daemon-wide messages to NOTICE/WARNING/ERR…
+* Comment out some log-filling messages when internal interfaces lose
+  link, and for e.g. `rule with label '%s' is not a IGD pinhole`, as
+  normally occurring
+
+Fixes: https://redirect.github.com/openwrt/packages/issues/17601
+Fixes: https://redirect.github.com/openwrt/packages/issues/26483
+Link: https://github.com/Self-Hosting-Group/miniupnp/tree/improve-logging
+---
+ asyncsendto.c                 |  4 ++--
+ getifaddr.c                   |  4 ++--
+ minissdp.c                    | 24 ++++++++++++------------
+ miniupnpd.c                   | 92 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--------------------------------
+ natpmp.c                      | 16 ++++++++--------
+ netfilter/iptcrdr.c           | 10 +++++-----
+ netfilter/iptpinhole.c        |  4 ++--
+ netfilter_nft/nftnlrdr.c      |  2 +-
+ netfilter_nft/nftnlrdr_misc.c |  8 ++++----
+ netfilter_nft/nftpinhole.c    | 10 +++++-----
+ pcpserver.c                   | 18 +++++++++---------
+ pf/obsdrdr.c                  |  6 +++---
+ pf/pfpinhole.c                | 12 ++++++------
+ upnphttp.c                    |  6 +++---
+ upnppinhole.c                 | 48 ++++++++++++++++++++++++------------------------
+ upnpredirect.c                | 20 ++++++++++----------
+ upnpsoap.c                    | 30 +++++++++++++++---------------
+ 17 files changed, 171 insertions(+), 143 deletions(-)
+
+--- a/asyncsendto.c
++++ b/asyncsendto.c
+@@ -254,9 +254,9 @@ int try_sendto(fd_set * writefds)
+ 					/* uncatched error */
+ 					if(sockaddr_to_string(elt->dest_addr, addr_str, sizeof(addr_str)) <= 0)
+ 						addr_str[0] = '\0';
+-					syslog(LOG_ERR, "%s(sock=%d, len=%u, dest=%s): sendto: %m",
++					/*syslog(LOG_DEBUG, "%s(sock=%d, len=%u, dest=%s): sendto: %m",
+ 					       "try_sendto", elt->sockfd, (unsigned)elt->len,
+-					       addr_str);
++					       addr_str);*/
+ 					ret--;
+ 				}
+ 			} else if((int)n != (int)elt->len) {
+--- a/getifaddr.c
++++ b/getifaddr.c
+@@ -74,7 +74,7 @@ getifaddr(const char * ifname, char * bu
+ 		} else {
+ 			r = GETIFADDR_IOCTL_ERROR;
+ 		}
+-		syslog(LOG_ERR, "ioctl(s, SIOCGIFADDR, ...): %m");
++		syslog(LOG_DEBUG, "ioctl(s, SIOCGIFADDR, ...): %m");
+ 		close(s);
+ 		return r;
+ 	}
+@@ -149,7 +149,7 @@ getifaddr(const char * ifname, char * bu
+ 		if(addr) *addr = ((struct sockaddr_in *)candidate->ifa_addr)->sin_addr;
+ 		if(mask) *mask = ((struct sockaddr_in *)candidate->ifa_netmask)->sin_addr;
+ 	} else {
+-		syslog(LOG_WARNING, "no AF_INET address found for %s", ifname);
++		syslog(LOG_DEBUG, "no AF_INET address found for %s", ifname);
+ 		freeifaddrs(ifap);
+ 		return GETIFADDR_NO_ADDRESS;
+ 	}
+--- a/minissdp.c
++++ b/minissdp.c
+@@ -743,8 +743,8 @@ SendSSDPNotify(int s, const struct socka
+ 	}
+ 	n = sendto_or_schedule(s, bufr, l, 0, dest, dest_len);
+ 	if(n < 0) {
+-		syslog(LOG_ERR, "sendto(udp_notify=%d, %s): %m", s,
+-		       host ? host : "NULL");
++		/*syslog(LOG_DEBUG, "sendto(udp_notify=%d, %s): %m", s,
++		       host ? host : "NULL");*/
+ 	} else if(n != l) {
+ 		syslog(LOG_NOTICE, "sendto() sent %d out of %d bytes", n, l);
+ 	}
+@@ -754,8 +754,8 @@ SendSSDPNotify(int s, const struct socka
+ 	 * discovery messages SHOULD NOT be sent more than three times. */
+ 	n = sendto_schedule(s, bufr, l, 0, dest, dest_len, 250);
+ 	if(n < 0) {
+-		syslog(LOG_ERR, "sendto(udp_notify=%d, %s): %m", s,
+-		       host ? host : "NULL");
++		/*syslog(LOG_DEBUG, "sendto(udp_notify=%d, %s): %m", s,
++		       host ? host : "NULL");*/
+ 	}
+ }
+ 
+@@ -1060,7 +1060,7 @@ ProcessSSDPData(int s, const char *bufr,
+ 	}
+ 	if(lan_addr == NULL)
+ 	{
+-		syslog(LOG_WARNING, "SSDP packet sender %s (if_index=%d) not from a LAN, ignoring",
++		syslog(LOG_DEBUG, "SSDP packet sender %s (if_index=%d) not from a LAN, ignoring",
+ 		       sender_str, source_if);
+ 		return;
+ 	}
+@@ -1163,7 +1163,7 @@ ProcessSSDPData(int s, const char *bufr,
+ 	           sender_str );*/
+ 		if(st && (st_len > 0))
+ 		{
+-			syslog(LOG_INFO, "SSDP M-SEARCH from %s ST: %.*s",
++			syslog(LOG_DEBUG, "SSDP M-SEARCH from %s ST: %.*s",
+ 			       sender_str, st_len, st);
+ 			/* find in which sub network the client is */
+ #ifdef ENABLE_IPV6
+@@ -1276,7 +1276,7 @@ ProcessSSDPData(int s, const char *bufr,
+ 					else
+ 						snprintf(ver_str, sizeof(ver_str), "%d", known_service_types[i].version);
+ #endif
+-					syslog(LOG_INFO, "Single search found");
++					syslog(LOG_DEBUG, "Single search found");
+ #ifdef DELAY_MSEARCH_RESPONSE
+ 					delay = random() / (1 + RAND_MAX / (1000 * mx_value));
+ #ifdef DEBUG
+@@ -1305,7 +1305,7 @@ ProcessSSDPData(int s, const char *bufr,
+ #ifdef DELAY_MSEARCH_RESPONSE
+ 				unsigned int delay_increment = (mx_value * 1000) / 15;
+ #endif
+-				syslog(LOG_INFO, "ssdp:all found");
++				syslog(LOG_DEBUG, "ssdp:all found");
+ 				for(i=0; known_service_types[i].s; i++)
+ 				{
+ #ifdef DELAY_MSEARCH_RESPONSE
+@@ -1363,7 +1363,7 @@ ProcessSSDPData(int s, const char *bufr,
+ #endif
+ 				if(0 == memcmp(st, uuidvalue_igd, l))
+ 				{
+-					syslog(LOG_INFO, "ssdp:uuid (IGD) found");
++					syslog(LOG_DEBUG, "ssdp:uuid (IGD) found");
+ 					SendSSDPResponse(s, sender, st, st_len, "",
+ 					                 announced_host, http_port,
+ #ifdef ENABLE_HTTPS
+@@ -1373,7 +1373,7 @@ ProcessSSDPData(int s, const char *bufr,
+ 				}
+ 				else if(0 == memcmp(st, uuidvalue_wan, l))
+ 				{
+-					syslog(LOG_INFO, "ssdp:uuid (WAN) found");
++					syslog(LOG_DEBUG, "ssdp:uuid (WAN) found");
+ 					SendSSDPResponse(s, sender, st, st_len, "",
+ 					                 announced_host, http_port,
+ #ifdef ENABLE_HTTPS
+@@ -1383,7 +1383,7 @@ ProcessSSDPData(int s, const char *bufr,
+ 				}
+ 				else if(0 == memcmp(st, uuidvalue_wcd, l))
+ 				{
+-					syslog(LOG_INFO, "ssdp:uuid (WCD) found");
++					syslog(LOG_DEBUG, "ssdp:uuid (WCD) found");
+ 					SendSSDPResponse(s, sender, st, st_len, "",
+ 					                 announced_host, http_port,
+ #ifdef ENABLE_HTTPS
+@@ -1444,7 +1444,7 @@ SendSSDPbyebye(int s, const struct socka
+ 	n = sendto_or_schedule(s, bufr, l, 0, dest, destlen);
+ 	if(n < 0)
+ 	{
+-		syslog(LOG_ERR, "sendto(udp_shutdown=%d) to %s: %m", s, dest_str);
++		syslog(LOG_DEBUG, "sendto(udp_shutdown=%d) to %s: %m", s, dest_str);
+ 		return -1;
+ 	}
+ 	else if(n != l)
+--- a/miniupnpd.c
++++ b/miniupnpd.c
+@@ -496,7 +496,7 @@ ProcessIncomingHTTP(int shttpl, const ch
+ 		if(get_lan_for_peer((struct sockaddr *)&clientname) == NULL)
+ 		{
+ 			/* The peer is not a LAN ! */
+-			syslog(LOG_WARNING,
++			syslog(LOG_DEBUG,
+ 			       "%s peer %s is not from a LAN, closing the connection",
+ 			       protocol, addr_str);
+ 			close(shttp);
+@@ -867,7 +867,7 @@ set_startup_time(void)
+ 			}
+ 			else
+ 			{
+-				syslog(LOG_INFO, "system uptime is %lu seconds", uptime);
++				syslog(LOG_DEBUG, "system uptime is %lu seconds", uptime);
+ 			}
+ 			fclose(f);
+ 			startup_time -= uptime;
+@@ -2228,6 +2228,22 @@ init(int argc, char * * argv, struct run
+ 		pidfilename = NULL;
+ #endif
+ 
++syslog(LOG_NOTICE, "MiniUPnP daemon " MINIUPNPD_VERSION " starting, enable protocols %s%s%s, ext_ifname=%s BOOTID=%u",
++	GETFLAG(ENABLEUPNPMASK) ? "UPnP IGD" : "",
++#ifdef ENABLE_NATPMP
++	GETFLAG(ENABLEUPNPMASK) && GETFLAG(ENABLENATPMPMASK) ? " & " : "",
++#ifdef ENABLE_PCP
++	GETFLAG(ENABLENATPMPMASK) ? "PCP/NAT-PMP" : "",
++#else
++	GETFLAG(ENABLENATPMPMASK) ? "NAT-PMP" : "",
++#endif
++#else
++	"", "",
++#endif
++	ext_if_name, upnp_bootid);
++syslog(LOG_INFO, "More information at https://miniupnp.tuxfamily.org/ or http://miniupnp.free.fr/");
++syslog(LOG_NOTICE, "Extra logging with log level info (-v) or debug (-v -v)");
++
+ #ifdef USE_SYSTEMD
+ 	if (systemd_flag) {
+ 		int r = sd_notify(0,
+@@ -2240,7 +2256,7 @@ init(int argc, char * * argv, struct run
+ 
+ #ifdef ENABLE_LEASEFILE
+ 	/*remove(lease_file);*/
+-	syslog(LOG_INFO, "Reloading rules from lease file");
++	syslog(LOG_INFO, "Reloading port maps from lease file");
+ 	reload_from_lease_file();
+ #ifdef ENABLE_UPNPPINHOLE
+ 	reload_from_lease_file6();
+@@ -2431,21 +2447,9 @@ main(int argc, char * * argv)
+ 		goto shutdown;
+ 	}
+ 
+-	syslog(LOG_INFO, "version " MINIUPNPD_VERSION " starting%s%sext if %s BOOTID=%u",
+-#ifdef ENABLE_NATPMP
+-#ifdef ENABLE_PCP
+-	       GETFLAG(ENABLENATPMPMASK) ? " NAT-PMP/PCP " : " ",
+-#else
+-	       GETFLAG(ENABLENATPMPMASK) ? " NAT-PMP " : " ",
+-#endif
+-#else
+-	       " ",
+-#endif
+-	       GETFLAG(ENABLEUPNPMASK) ? "UPnP-IGD " : "",
+-	       ext_if_name, upnp_bootid);
+ #ifdef ENABLE_IPV6
+ 	if (strcmp(ext_if_name6, ext_if_name) != 0) {
+-		syslog(LOG_INFO, "specific IPv6 ext if %s", ext_if_name6);
++		syslog(LOG_INFO, "Separate ext_ifname6=%s set", ext_if_name6);
+ 	}
+ #endif
+ 
+@@ -2494,7 +2498,7 @@ main(int argc, char * * argv)
+ #ifdef ENABLE_NFQUEUE
+ 		nfqueue_data.http_port = listen_port;
+ #endif /* ENABLE_NFQUEUE */
+-		syslog(LOG_NOTICE, "HTTP listening on port %d", v.port);
++		syslog(LOG_NOTICE, "Listening for UPnP IGD (SOAP/HTTP) traffic on port %d/TCP, SSDP 1900/UDP", v.port);
+ #if defined(V6SOCKETS_ARE_V6ONLY) && defined(ENABLE_IPV6)
+ 		if(!GETFLAG(IPV6DISABLEDMASK))
+ 		{
+@@ -2525,7 +2529,7 @@ main(int argc, char * * argv)
+ #ifdef ENABLE_NFQUEUE
+ 		nfqueue_data.https_port = listen_port;
+ #endif /* ENABLE_NFQUEUE */
+-		syslog(LOG_NOTICE, "HTTPS listening on port %d", v.https_port);
++		syslog(LOG_NOTICE, "Listening for UPnP IGD (SOAP/HTTPS) traffic on port %d/TCP", v.https_port);
+ #if defined(V6SOCKETS_ARE_V6ONLY) && defined(ENABLE_IPV6)
+ 		shttpsl_v4 =  OpenAndConfHTTPSocket(&listen_port, 0);
+ 		if(shttpsl_v4 < 0)
+@@ -2540,11 +2544,11 @@ main(int argc, char * * argv)
+ 		if(!GETFLAG(IPV6DISABLEDMASK)) {
+ 			if(find_ipv6_addr(lan_addrs.lh_first ? lan_addrs.lh_first->ifname : NULL,
+ 			                  ipv6_addr_for_http_with_brackets, sizeof(ipv6_addr_for_http_with_brackets)) > 0) {
+-				syslog(LOG_NOTICE, "HTTP IPv6 address given to control points : %s",
++				syslog(LOG_NOTICE, "IPv6 address given to UPnP IGD clients: %s",
+ 				       ipv6_addr_for_http_with_brackets);
+ 			} else {
+ 				memcpy(ipv6_addr_for_http_with_brackets, "[::1]", 6);
+-				syslog(LOG_WARNING, "no HTTP IPv6 address, disabling IPv6");
++				syslog(LOG_DEBUG, "no HTTP IPv6 address, disabling IPv6");
+ 				SETFLAG(IPV6DISABLEDMASK);
+ 			}
+ 		}
+@@ -2601,7 +2605,7 @@ main(int argc, char * * argv)
+ 			if(SendSSDPGoodbye(snotify, addr_count * 2) < 0)
+ #endif
+ 			{
+-				syslog(LOG_WARNING, "Failed to broadcast good-bye notifications");
++				syslog(LOG_DEBUG, "Failed to broadcast good-bye notifications");
+ 			}
+ 		}
+ #endif /* UPNP_STRICT */
+@@ -2626,16 +2630,16 @@ main(int argc, char * * argv)
+ 		if(OpenAndConfNATPMPSockets(snatpmp) < 0)
+ #ifdef ENABLE_PCP
+ 		{
+-			syslog(LOG_ERR, "Failed to open sockets for NAT-PMP/PCP.");
++			syslog(LOG_ERR, "Failed to open port 5351/UDP for PCP/NAT-PMP");
+ 		} else {
+-			syslog(LOG_NOTICE, "Listening for NAT-PMP/PCP traffic on port %u",
++			syslog(LOG_NOTICE, "Listening for PCP/NAT-PMP traffic on port %u/UDP",
+ 			       NATPMP_PORT);
+ 		}
+ #else
+ 		{
+-			syslog(LOG_ERR, "Failed to open sockets for NAT PMP.");
++			syslog(LOG_ERR, "Failed to open port 5351/UDP for NAT-PMP");
+ 		} else {
+-			syslog(LOG_NOTICE, "Listening for NAT-PMP traffic on port %u",
++			syslog(LOG_NOTICE, "Listening for NAT-PMP traffic on port %u/UDP",
+ 			       NATPMP_PORT);
+ 		}
+ #endif
+@@ -2746,6 +2750,30 @@ main(int argc, char * * argv)
+ 	}
+ #endif /* HAS_LIBCAP_NG */
+ 
++if (GETFLAG(ENABLEUPNPMASK) && !GETFLAG(SECUREMODEMASK))
++	syslog(LOG_WARNING, "WARNING: Allow adding port maps for non-requesting IP addresses via UPnP IGD, as secure_mode=no set");
++#ifdef ENABLE_PCP
++if (GETFLAG(ENABLENATPMPMASK) && GETFLAG(PCP_ALLOWTHIRDPARTYMASK))
++	syslog(LOG_WARNING, "WARNING: Allow adding port maps for non-requesting IP addresses via PCP, as pcp_allow_thirdparty=yes set");
++#endif
++#ifdef ENABLE_IPV6
++if (GETFLAG(IPV6DISABLEDMASK))
++	syslog(LOG_NOTICE, "IPv6 mapping disabled");
++#else
++syslog(LOG_NOTICE, "IPv6 mapping disabled");
++#endif
++if (GETFLAG(ENABLEUPNPMASK)) {
++#ifdef IGD_V2
++	if (GETFLAG(FORCEIGDDESCV1MASK)) {
++		syslog(LOG_NOTICE, "UPnP IGD compatibility mode set to IGDv1 (IPv4 only)");
++	} else {
++		syslog(LOG_NOTICE, "UPnP IGD compatibility mode set to IGDv2 (with workarounds)");
++	}
++#else
++	syslog(LOG_NOTICE, "UPnP IGD compatibility mode set to IGDv1 (IPv4 only)");
++#endif
++}
++
+ #ifdef USE_SYSTEMD
+ 	if (v.systemd_notify) {
+ 		upnp_update_status();
+@@ -3056,7 +3084,7 @@ main(int argc, char * * argv)
+ 		}
+ 		i = try_sendto(&writeset);
+ 		if(i < 0) {
+-			syslog(LOG_ERR, "try_sendto failed to send %d packets", -i);
++			/*syslog(LOG_DEBUG, "try_sendto failed to send %d packets", -i);*/
+ 		}
+ #ifdef USE_MINIUPNPDCTL
+ 		for(ectl = ctllisthead.lh_first; ectl;)
+@@ -3156,7 +3184,7 @@ main(int argc, char * * argv)
+ 					if(lan_addr == NULL) {
+ 						char sender_str[64];
+ 						sockaddr_to_string((struct sockaddr *)&senderaddr, sender_str, sizeof(sender_str));
+-						syslog(LOG_WARNING, "NAT-PMP packet sender %s not from a LAN, ignoring",
++						syslog(LOG_DEBUG, "NAT-PMP packet sender %s not from a LAN, ignoring",
+ 						       sender_str);
+ 						continue;
+ 					}
+@@ -3179,7 +3207,7 @@ main(int argc, char * * argv)
+ 				if(lan_addr == NULL) {
+ 					char sender_str[64];
+ 					sockaddr_to_string((struct sockaddr *)&senderaddr, sender_str, sizeof(sender_str));
+-					syslog(LOG_WARNING, "NAT-PMP packet sender %s not from a LAN, ignoring",
++					syslog(LOG_DEBUG, "NAT-PMP packet sender %s not from a LAN, ignoring",
+ 					       sender_str);
+ 					continue;
+ 				}
+@@ -3213,7 +3241,7 @@ main(int argc, char * * argv)
+ 		/* process SSDP packets */
+ 		if(sudp >= 0 && FD_ISSET(sudp, &readset))
+ 		{
+-			/*syslog(LOG_INFO, "Received UDP Packet");*/
++			/*syslog(LOG_DEBUG, "Received UDP Packet");*/
+ #ifdef ENABLE_HTTPS
+ 			ProcessSSDPRequest(sudp, (unsigned short)v.port, (unsigned short)v.https_port);
+ #else
+@@ -3223,7 +3251,7 @@ main(int argc, char * * argv)
+ #ifdef ENABLE_IPV6
+ 		if(sudpv6 >= 0 && FD_ISSET(sudpv6, &readset))
+ 		{
+-			syslog(LOG_INFO, "Received UDP Packet (IPv6)");
++			/*syslog(LOG_DEBUG, "Received UDP Packet (IPv6)");*/
+ #ifdef ENABLE_HTTPS
+ 			ProcessSSDPRequest(sudpv6, (unsigned short)v.port, (unsigned short)v.https_port);
+ #else
+@@ -3325,7 +3353,7 @@ main(int argc, char * * argv)
+ 
+ shutdown:
+ 
+-	syslog(LOG_NOTICE, "shutting down MiniUPnPd");
++	syslog(LOG_NOTICE, "Shutting down MiniUPnPd");
+ #ifdef USE_SYSTEMD
+ 	if (v.systemd_notify) {
+ 		sd_notify(0,
+@@ -3344,7 +3372,7 @@ shutdown:
+ 		if(SendSSDPGoodbye(snotify, addr_count * 2) < 0)
+ #endif
+ 		{
+-			syslog(LOG_ERR, "Failed to broadcast good-bye notifications");
++			syslog(LOG_DEBUG, "Failed to broadcast good-bye notifications");
+ 		}
+ 	}
+ 	/* try to send pending packets */
+--- a/natpmp.c
++++ b/natpmp.c
+@@ -106,7 +106,7 @@ static void FillPublicAddressResponse(un
+ 			resp[3] = 3;	/* Network Failure (e.g. NAT box itself
+ 			                 * has not obtained a DHCP lease) */
+ 		} else if(getifaddr(ext_if_name, tmp, INET_ADDRSTRLEN, &addr, NULL) < 0) {
+-			syslog(LOG_ERR, "Failed to get IP for interface %s", ext_if_name);
++			syslog(LOG_DEBUG, "Failed to get IP for interface %s", ext_if_name);
+ 			resp[3] = 3;	/* Network Failure (e.g. NAT box itself
+ 			                 * has not obtained a DHCP lease) */
+ 		} else if (!GETFLAG(ALLOWPRIVATEIPV4MASK) && addr_is_reserved(&addr)) {
+@@ -231,7 +231,7 @@ void ProcessIncomingNATPMPPacket(int s,
+ 		syslog(LOG_ERR, "inet_ntop(natpmp): %m");
+ 	}
+ 
+-	syslog(LOG_INFO, "NAT-PMP request received from %s:%hu %dbytes",
++	syslog(LOG_DEBUG, "NAT-PMP request received from %s:%hu %d bytes",
+ 	       senderaddrstr, ntohs(senderaddr->sin_port), n);
+ 
+ 	if(n<2 || ((((req[1]-1)&~1)==0) && n<12)) {
+@@ -260,7 +260,7 @@ void ProcessIncomingNATPMPPacket(int s,
+ 		resp[3] = 1;	/* unsupported version */
+ 	} else switch(req[1]) {
+ 	case 0:	/* Public address request */
+-		syslog(LOG_INFO, "NAT-PMP public address request");
++		syslog(LOG_DEBUG, "NAT-PMP public address request");
+ 		FillPublicAddressResponse(resp, senderaddr->sin_addr.s_addr);
+ 		resplen = 12;
+ 		break;
+@@ -319,7 +319,7 @@ void ProcessIncomingNATPMPPacket(int s,
+ 								resp[3] = 2;	/* Not Authorized/Refused */
+ 								break;
+ 							} else {
+-								syslog(LOG_INFO, "NAT-PMP %s port %hu mapping removed",
++								syslog(LOG_DEBUG, "NAT-PMP %s port %hu mapping removed",
+ 								       proto2==IPPROTO_TCP?"TCP":"UDP", eport2);
+ 								index--;
+ 							}
+@@ -340,7 +340,7 @@ void ProcessIncomingNATPMPPacket(int s,
+ 						eport_first = eport;
+ 					} else if(eport == eport_first) { /* no eport available */
+ 						if(any_eport_allowed == 0) { /* all eports rejected by permissions */
+-							syslog(LOG_ERR, "No allowed eport for NAT-PMP %hu %s->%s:%hu",
++							syslog(LOG_INFO, "No allowed eport for NAT-PMP %hu %s->%s:%hu",
+ 							       eport, proto_itoa(proto), senderaddrstr, iport);
+ 							resp[3] = 2;	/* Not Authorized/Refused */
+ 						} else { /* at least one eport allowed (but none available) */
+@@ -443,7 +443,7 @@ void SendNATPMPPublicAddressChangeNotifi
+ 	FillPublicAddressResponse(notif, 0);
+ 	if(notif[3])
+ 	{
+-		syslog(LOG_WARNING, "%s: cannot get public IP address, stopping",
++		syslog(LOG_DEBUG, "%s: cannot get public IP address, stopping",
+ 		       "SendNATPMPPublicAddressChangeNotification");
+ 		return;
+ 	}
+@@ -471,7 +471,7 @@ void SendNATPMPPublicAddressChangeNotifi
+ 		           (struct sockaddr *)&sockname, sizeof(struct sockaddr_in));
+ 		if(n < 0)
+ 		{
+-			syslog(LOG_ERR, "%s: sendto(s_udp=%d, port=%d): %m",
++			syslog(LOG_DEBUG, "%s: sendto(s_udp=%d, port=%d): %m",
+ 			       "SendNATPMPPublicAddressChangeNotification", sockets[j], NATPMP_PORT);
+ 			return;
+ 		}
+@@ -481,7 +481,7 @@ void SendNATPMPPublicAddressChangeNotifi
+ 		           (struct sockaddr *)&sockname, sizeof(struct sockaddr_in));
+ 		if(n < 0)
+ 		{
+-			syslog(LOG_ERR, "%s: sendto(s_udp=%d, port=%d): %m",
++			syslog(LOG_DEBUG, "%s: sendto(s_udp=%d, port=%d): %m",
+ 			       "SendNATPMPPublicAddressChangeNotification", sockets[j], NATPMP_NOTIF_PORT);
+ 			return;
+ 		}
+--- a/netfilter/iptcrdr.c
++++ b/netfilter/iptcrdr.c
+@@ -715,7 +715,7 @@ delete_filter_rule(const char * ifname,
+ 						continue;
+ 				}
+ 				index = i;
+-				/*syslog(LOG_INFO, "Trying to delete filter rule at index %u", index);*/
++				/*syslog(LOG_DEBUG, "Trying to delete filter rule at index %u", index);*/
+ 				r = delete_rule_and_commit(index, h, miniupnpd_forward_chain, "delete_filter_rule");
+ 				h = NULL;
+ 				break;
+@@ -808,7 +808,7 @@ delete_redirect_and_filter_rules(unsigne
+ #endif
+ 	if(r == 0)
+ 	{
+-		syslog(LOG_INFO, "Trying to delete nat rule at index %u", index);
++		syslog(LOG_DEBUG, "Trying to delete nat rule at index %u", index);
+ 		/* Now delete both rules */
+ 		/* first delete the nat rule */
+ 		h = iptc_init("nat");
+@@ -852,7 +852,7 @@ delete_redirect_and_filter_rules(unsigne
+ 					if(iaddr != e->ip.dst.s_addr)
+ 						continue;
+ 					index = i;
+-					syslog(LOG_INFO, "Trying to delete filter rule at index %u", index);
++					syslog(LOG_DEBUG, "Trying to delete filter rule at index %u", index);
+ 					r = delete_rule_and_commit(index, h, miniupnpd_forward_chain, "delete_filter_rule");
+ 					h = NULL;
+ 					break;
+@@ -910,7 +910,7 @@ delete_redirect_and_filter_rules(unsigne
+ 				}
+ 
+ 				index = i;
+-				syslog(LOG_INFO, "Trying to delete peer rule at index %u", index);
++				syslog(LOG_DEBUG, "Trying to delete peer rule at index %u", index);
+ 				r2 = delete_rule_and_commit(index, h, miniupnpd_nat_postrouting_chain, "delete_peer_rule");
+ 				h = NULL;
+ 				break;
+@@ -962,7 +962,7 @@ delete_redirect_and_filter_rules(unsigne
+ 				if(iaddr != e->ip.src.s_addr)
+ 					continue;
+ 				index = i;
+-				syslog(LOG_INFO, "Trying to delete dscp rule at index %u", index);
++				syslog(LOG_DEBUG, "Trying to delete dscp rule at index %u", index);
+ 				r2 = delete_rule_and_commit(index, h, miniupnpd_nat_chain, "delete_dscp_rule");
+ 				h = NULL;
+ 				break;
+--- a/netfilter/iptpinhole.c
++++ b/netfilter/iptpinhole.c
+@@ -295,14 +295,14 @@ find_pinhole(const char * ifname,
+ 
+ 	if(rem_host && (rem_host[0] != '\0')) {
+ 		if (inet_pton(AF_INET6, rem_host, &saddr) < 1) {
+-			syslog(LOG_WARNING, "Failed to parse INET6 address \"%s\"", rem_host);
++			syslog(LOG_INFO, "Failed to parse INET6 address \"%s\"", rem_host);
+ 			memset(&saddr, 0, sizeof(struct in6_addr));
+ 		}
+ 	} else {
+ 		memset(&saddr, 0, sizeof(struct in6_addr));
+ 	}
+ 	if (inet_pton(AF_INET6, int_client, &daddr) < 1) {
+-		syslog(LOG_WARNING, "Failed to parse INET6 address \"%s\"", int_client);
++		syslog(LOG_INFO, "Failed to parse INET6 address \"%s\"", int_client);
+ 		memset(&daddr, 0, sizeof(struct in6_addr));
+ 	}
+ 	for(p = pinhole_list.lh_first; p != NULL; p = p->entries.le_next) {
+--- a/netfilter_nft/nftnlrdr.c
++++ b/netfilter_nft/nftnlrdr.c
+@@ -353,7 +353,7 @@ delete_redirect_and_filter_rules(unsigne
+ 			}
+ 		}
+ 	} else {
+-		syslog(LOG_WARNING, "%s: redirect rule with eport=%hu proto %d NOT FOUND",
++		syslog(LOG_INFO, "%s: redirect rule with eport=%hu proto %d NOT FOUND",
+ 		       "delete_redirect_and_filter_rules", eport, proto);
+ 	}
+ 
+--- a/netfilter_nft/nftnlrdr_misc.c
++++ b/netfilter_nft/nftnlrdr_misc.c
+@@ -110,7 +110,7 @@ nft_mnl_connect(void)
+ 		return -1;
+ 	}
+ 	mnl_portid = mnl_socket_get_portid(mnl_sock);
+-	syslog(LOG_INFO, "mnl_socket bound, port_id=%u", mnl_portid);
++	syslog(LOG_DEBUG, "mnl_socket bound, port_id=%u", mnl_portid);
+ 	return 0;
+ }
+ 
+@@ -751,7 +751,7 @@ refresh_nft_cache(struct rule_list *head
+ 		errno = 0;
+ 		ret = mnl_cb_run(buf, n, mnl_seq, mnl_portid, table_cb, &data);
+ 		if (ret <= -1 /*== MNL_CB_ERROR*/) {
+-			syslog(LOG_ERR, "%s: mnl_cb_run returned %d: %m",
++			syslog(LOG_DEBUG, "%s: mnl_cb_run returned %d: %m",
+ 			       "refresh_nft_cache", ret);
+ 			return -1;
+ 		}
+@@ -1288,7 +1288,7 @@ nft_send_rule(struct nftnl_rule * rule,
+ 
+ 		result = send_batch(batch);
+ 		if (result < 0) {
+-			syslog(LOG_ERR, "%s(%p, %d, %d) send_batch failed %d",
++			syslog(LOG_DEBUG, "%s(%p, %d, %d) send_batch failed %d",
+ 			       "nft_send_rule", rule, (int)cmd, (int)chain_type, result);
+ 		}
+ 	}
+@@ -1474,7 +1474,7 @@ send_batch(struct mnl_nlmsg_batch *batch
+ 		errno = 0;
+ 		ret = mnl_cb_run(buf, n, 0, mnl_portid, NULL, NULL);
+ 		if (ret <= -1 /*== MNL_CB_ERROR*/) {
+-			syslog(LOG_ERR, "%s: mnl_cb_run returned %d: %m",
++			syslog(LOG_DEBUG, "%s: mnl_cb_run returned %d: %m",
+ 			       "send_batch", ret);
+ 			return -4;
+ 		}
+--- a/netfilter_nft/nftpinhole.c
++++ b/netfilter_nft/nftpinhole.c
+@@ -129,7 +129,7 @@ find_pinhole(const char * ifname,
+ 
+ 	if (rem_host && rem_host[0] != '\0' && rem_host[0] != '*') {
+ 		if (inet_pton(AF_INET6, rem_host, &saddr) < 1) {
+-			syslog(LOG_WARNING, "Failed to parse INET6 address \"%s\"", rem_host);
++			syslog(LOG_INFO, "Failed to parse INET6 address \"%s\"", rem_host);
+ 			memset(&saddr, 0, sizeof(struct in6_addr));
+ 		}
+ 	} else {
+@@ -137,7 +137,7 @@ find_pinhole(const char * ifname,
+ 	}
+ 
+ 	if (inet_pton(AF_INET6, int_client, &daddr) < 1) {
+-		syslog(LOG_WARNING, "Failed to parse INET6 address \"%s\"", int_client);
++		syslog(LOG_INFO, "Failed to parse INET6 address \"%s\"", int_client);
+ 		memset(&daddr, 0, sizeof(struct in6_addr));
+ 	}
+ 
+@@ -159,7 +159,7 @@ find_pinhole(const char * ifname,
+ 		   (0 == memcmp(&daddr, &p->daddr6, sizeof(struct in6_addr)))) {
+ 
+ 			if (sscanf(p->desc, PINEHOLE_LABEL_FORMAT_SKIPDESC, &uid, &ts) != 2) {
+-				syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", p->desc);
++				/*syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", p->desc);*/
+ 				continue;
+ 			}
+ 
+@@ -396,7 +396,7 @@ get_pinhole_info(unsigned short uid,
+ 			if (timestamp) {
+ 				int uid_temp;
+ 				if (sscanf(p->desc, PINEHOLE_LABEL_FORMAT_SKIPDESC, &uid_temp, &ts) != 2) {
+-					syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", p->desc);
++					/*syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", p->desc);*/
+ 					continue;
+ 				}
+ 
+@@ -460,7 +460,7 @@ clean_pinhole_list(unsigned int * next_t
+ 			continue;
+ 
+ 		if (sscanf(p->desc, PINEHOLE_LABEL_FORMAT_SKIPDESC, &uid, &ts) != 2) {
+-			syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", p->desc);
++			/*syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", p->desc);*/
+ 			continue;
+ 		}
+ 
+--- a/pcpserver.c
++++ b/pcpserver.c
+@@ -1094,7 +1094,7 @@ static void CreatePCPMap(pcp_info_t *pcp
+ 	else
+ 		r = CreatePCPMap_NAT(pcp_msg_info);
+ 	pcp_msg_info->result_code = r;
+-	syslog(r == PCP_SUCCESS ? LOG_INFO : LOG_ERR,
++	syslog(LOG_INFO,
+ 	      "PCP MAP: %s mapping %s %hu->%s:%hu '%s'",
+ 	       r == PCP_SUCCESS ? "added" : "failed to add",
+ 	       proto_itoa(pcp_msg_info->protocol),
+@@ -1136,7 +1136,7 @@ static void DeletePCPMap(pcp_info_t *pcp
+ 				if(0 != strcmp(desc, pcp_msg_info->desc)) {
+ 					/* nonce does not match */
+ 					pcp_msg_info->result_code = PCP_ERR_NOT_AUTHORIZED;
+-					syslog(LOG_ERR, "Unauthorized to remove PCP mapping internal port %hu, protocol %s",
++					syslog(LOG_INFO, "Unauthorized to remove PCP mapping internal port %hu, protocol %s",
+ 					       iport, proto_itoa(pcp_msg_info->protocol));
+ 					return;
+ 				} else {
+@@ -1154,14 +1154,14 @@ static void DeletePCPMap(pcp_info_t *pcp
+ 						desc, sizeof(desc),
+ 						NULL /* lifetime */);
+ 		if (uid < 0) {
+-			syslog(LOG_ERR, "Failed to find mapping to %s:%hu, protocol %s",
++			syslog(LOG_INFO, "Failed to find mapping to %s:%hu, protocol %s",
+ 			       pcp_msg_info->mapped_str, iport, proto_itoa(pcp_msg_info->protocol));
+ 			return;
+ 		} else {
+ 			if(0 != strcmp(desc, pcp_msg_info->desc)) {
+ 				/* nonce does not match */
+ 				pcp_msg_info->result_code = PCP_ERR_NOT_AUTHORIZED;
+-				syslog(LOG_ERR, "Unauthorized to remove PCP mapping internal port %hu, protocol %s",
++				syslog(LOG_INFO, "Unauthorized to remove PCP mapping internal port %hu, protocol %s",
+ 				       iport, proto_itoa(pcp_msg_info->protocol));
+ 				return;
+ 			} else {
+@@ -1176,7 +1176,7 @@ static void DeletePCPMap(pcp_info_t *pcp
+ 		syslog(LOG_INFO, "PCP: %s port %hu mapping removed",
+ 		       proto==IPPROTO_TCP?"TCP":"UDP", (pcp_msg_info->is_fw ? iport : eport2));
+ 	} else {
+-		syslog(LOG_ERR, "Failed to remove PCP mapping to %s:%hu %s",
++		syslog(LOG_INFO, "Failed to remove PCP mapping to %s:%hu %s",
+ 		       pcp_msg_info->mapped_str, iport, proto_itoa(proto));
+ 		pcp_msg_info->result_code = PCP_ERR_NO_RESOURCES;
+ 	}
+@@ -1399,7 +1399,7 @@ static int processPCPRequest(void * req,
+ 					CreatePCPMap(pcp_msg_info);
+ 				}
+ 			} else {
+-				syslog(LOG_ERR, "PCP: Invalid PCP v2 MAP message.");
++				syslog(LOG_DEBUG, "PCP: Invalid PCP v2 MAP message.");
+ 				return pcp_msg_info->result_code;
+ 			}
+ 
+@@ -1609,7 +1609,7 @@ int ProcessIncomingPCPPacket(int s, unsi
+ 	if (!GETFLAG(PCP_ALLOWTHIRDPARTYMASK)) {
+ 		lan_addr = get_lan_for_peer(senderaddr);
+ 		if(lan_addr == NULL) {
+-			syslog(LOG_WARNING, "PCP packet sender %s not from a LAN, ignoring",
++			syslog(LOG_DEBUG, "PCP packet sender %s not from a LAN, ignoring",
+ 			       addr_str);
+ 			return 0;
+ 		}
+@@ -1730,7 +1730,7 @@ void PCPSendUnsolicitedAnnounce(int * so
+ 		}
+ 		len = sendto_or_schedule(sockets[i], buff, PCP_MIN_LEN, 0, (struct sockaddr *)&addr, sizeof(struct sockaddr_in));
+ 		if( len < 0 ) {
+-			syslog(LOG_ERR, "PCPSendUnsolicitedAnnounce(sockets[%d]) sendto(): %m", i);
++			syslog(LOG_DEBUG, "PCPSendUnsolicitedAnnounce(sockets[%d]) sendto(): %m", i);
+ 		}
+ 	}
+ #ifdef ENABLE_IPV6
+@@ -1741,7 +1741,7 @@ void PCPSendUnsolicitedAnnounce(int * so
+ 		addr6.sin6_port = htons(5350);
+ 		len = sendto_or_schedule(socket6, buff, PCP_MIN_LEN, 0, (struct sockaddr *)&addr6, sizeof(struct sockaddr_in6));
+ 		if( len < 0 ) {
+-			syslog(LOG_ERR, "PCPSendUnsolicitedAnnounce() IPv6 sendto(): %m");
++			syslog(LOG_DEBUG, "PCPSendUnsolicitedAnnounce() IPv6 sendto(): %m");
+ 		}
+ 	}
+ #endif /* ENABLE_IPV6 */
+--- a/pf/obsdrdr.c
++++ b/pf/obsdrdr.c
+@@ -601,7 +601,7 @@ delete_nat_rule(const char * ifname, uns
+ 			pr.nr = i;
+ 			if(ioctl(dev, DIOCCHANGERULE, &pr) < 0)
+ 			{
+-				syslog(LOG_ERR, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
++				syslog(LOG_DEBUG, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
+ 				r = -1;
+ 			}
+ 			else
+@@ -1290,7 +1290,7 @@ priv_delete_redirect_rule_check_desc(con
+ 			pr.nr = i;
+ 			if(ioctl(dev, DIOCCHANGERULE, &pr) < 0)
+ 			{
+-				syslog(LOG_ERR, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
++				syslog(LOG_DEBUG, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
+ 				r = -1;
+ 				break;
+ 			}
+@@ -1375,7 +1375,7 @@ syslog(LOG_DEBUG, "%2d port=%hu proto=%d
+ 			pr.nr = i;
+ 			if(ioctl(dev, DIOCCHANGERULE, &pr) < 0)
+ 			{
+-				syslog(LOG_ERR, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
++				syslog(LOG_DEBUG, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
+ 				r = -1;
+ 			}
+ 			else
+--- a/pf/pfpinhole.c
++++ b/pf/pfpinhole.c
+@@ -246,12 +246,12 @@ int find_pinhole(const char * ifname,
+ 		   (0 == memcmp(&daddr, &RULE.dst.addr.v.a.addr.v6, sizeof(struct in6_addr)))) {
+ #ifdef USE_LIBPFCTL
+ 			if(sscanf(RULE.label[0], PINEHOLE_LABEL_FORMAT_SKIPDESC, &uid, &ts) != 2) {
+-				syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label[0]);
++				/*syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label[0]);*/
+ 				continue;
+ 			}
+ #else /* USE_LIBPFCTL */
+ 			if(sscanf(RULE.label, PINEHOLE_LABEL_FORMAT_SKIPDESC, &uid, &ts) != 2) {
+-				syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label);
++				/*syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label);*/
+ 				continue;
+ 			}
+ #endif /* USE_LIBPFCTL */
+@@ -360,7 +360,7 @@ int delete_pinhole(unsigned short uid)
+ 			pr.action = PF_CHANGE_REMOVE;
+ 			pr.nr = i;
+ 			if(ioctl(dev, DIOCCHANGERULE, &pr) < 0) {
+-				syslog(LOG_ERR, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
++				syslog(LOG_DEBUG, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
+ 				release_ticket(dev, tnum);
+ 				return -1;
+ 			}
+@@ -565,7 +565,7 @@ int clean_pinhole_list(unsigned int * ne
+ 			return -1;
+ 		}
+ 		if(sscanf(RULE.label[0], PINEHOLE_LABEL_FORMAT_SKIPDESC, &uid, &ts) != 2) {
+-			syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label[0]);
++			/*syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label[0]);*/
+ 			continue;
+ 		}
+ #else /* USE_LIBPFCTL */
+@@ -576,7 +576,7 @@ int clean_pinhole_list(unsigned int * ne
+ 			return -1;
+ 		}
+ 		if(sscanf(RULE.label, PINEHOLE_LABEL_FORMAT_SKIPDESC, &uid, &ts) != 2) {
+-			syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label);
++			/*syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label);*/
+ 			continue;
+ 		}
+ #endif /* USE_LIBPFCTL */
+@@ -602,7 +602,7 @@ int clean_pinhole_list(unsigned int * ne
+ 			pr.action = PF_CHANGE_REMOVE;
+ 			pr.nr = i;
+ 			if(ioctl(dev, DIOCCHANGERULE, &pr) < 0) {
+-				syslog(LOG_ERR, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
++				syslog(LOG_DEBUG, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
+ 				release_ticket(dev, tnum);
+ 				return -1;
+ 			}
+--- a/upnphttp.c
++++ b/upnphttp.c
+@@ -517,7 +517,7 @@ ProcessHTTPPOST_upnphttp(struct upnphttp
+ 		if(h->req_soapActionOff > 0)
+ 		{
+ 			/* we can process the request */
+-			syslog(LOG_INFO, "SOAPAction: %.*s",
++			syslog(LOG_DEBUG, "SOAPAction: %.*s",
+ 			       h->req_soapActionLen, h->req_buf + h->req_soapActionOff);
+ 			ExecuteSoapAction(h,
+ 				h->req_buf + h->req_soapActionOff,
+@@ -822,7 +822,7 @@ ProcessHttpQuery_upnphttp(struct upnphtt
+ 	for(i = 0; i<15 && *p != '\r'; i++)
+ 		HttpVer[i] = *(p++);
+ 	HttpVer[i] = '\0';
+-	syslog(LOG_INFO, "HTTP REQUEST from %s : %s %s (%s)",
++	syslog(LOG_DEBUG, "HTTP REQUEST from %s : %s %s (%s)",
+ 	       h->clientaddr_str, HttpCommand, HttpUrl, HttpVer);
+ 	ParseHttpHeaders(h);
+ 	if(h->req_HostOff > 0 && h->req_HostLen > 0) {
+@@ -902,7 +902,7 @@ ProcessHttpQuery_upnphttp(struct upnphtt
+ 			return;
+ 		}
+ #endif
+-		syslog(LOG_NOTICE, "%s not found, responding ERROR 404", HttpUrl);
++		syslog(LOG_DEBUG, "%s not found, responding ERROR 404", HttpUrl);
+ 		Send404(h);
+ 	}
+ #ifdef ENABLE_EVENTS
+--- a/upnppinhole.c
++++ b/upnppinhole.c
+@@ -110,7 +110,7 @@ lease_file6_add(const char * rem_client,
+ 
+ 	fd = fopen( lease_file6, "a");
+ 	if (fd==NULL) {
+-		syslog(LOG_ERR, "could not open lease file: %s", lease_file);
++		syslog(LOG_DEBUG, "could not open lease file: %s", lease_file);
+ 		return -1;
+ 	}
+ 
+@@ -189,13 +189,13 @@ lease_file6_update(int uid, unsigned int
+ 		proto = line;
+ 		p = strchr(line, ';');
+ 		if(!p) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p++) = '\0';
+ 		p2 = strchr(p, ';');
+ 		if(!p2) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p2++) = '\0';
+@@ -203,13 +203,13 @@ lease_file6_update(int uid, unsigned int
+ 		int_client = p;
+ 		p = strchr(p2, ';');
+ 		if(!p) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p++) = '\0';
+ 		p2 = strchr(p, ';');
+ 		if(!p2) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p2++) = '\0';
+@@ -217,20 +217,20 @@ lease_file6_update(int uid, unsigned int
+ 		rem_client = p;
+ 		p = strchr(p2, ';');
+ 		if(!p) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p++) = '\0';
+ 		p2 = strchr(p, ';');
+ 		if(!p2) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p2++) = '\0';
+ 		desc = strchr(p2, ';');
+ 		uid_rule = atoi(p);
+ 		if(!desc) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(desc++) = '\0';
+@@ -385,49 +385,49 @@ int lease_file6_expire(void)
+ 		// Internal Host
+ 		p = strchr(line, ';');
+ 		if(!p) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p++) = '\0';
+ 		// Internal Port
+ 		p2 = strchr(p, ';');
+ 		if(!p2) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p2++) = '\0';
+ 		// External Host
+ 		p = strchr(p2, ';');
+ 		if(!p) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p++) = '\0';
+ 		// External Port
+ 		p2 = strchr(p, ';');
+ 		if(!p2) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p2++) = '\0';
+ 		// uid
+ 		p = strchr(p2, ';');
+ 		if(!p) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p++) = '\0';
+ 		// Timestamp
+ 		p2 = strchr(p, ';');
+ 		if(!p2) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p2++) = '\0';
+ 		// descr
+ 		desc = strchr(p2, ';');
+ 		if(!desc) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(desc++) = '\0';
+@@ -476,7 +476,7 @@ int reload_from_lease_file6(void)
+ 	if(!lease_file6) return -1;
+ 	fd = fopen( lease_file6, "r");
+ 	if (fd==NULL) {
+-		syslog(LOG_ERR, "could not open lease file: %s", lease_file6);
++		syslog(LOG_DEBUG, "could not open lease file: %s", lease_file6);
+ 		return -1;
+ 	}
+ 	if(unlink(lease_file6) < 0) {
+@@ -491,13 +491,13 @@ int reload_from_lease_file6(void)
+ 		proto = line;
+ 		p = strchr(line, ';');
+ 		if(!p) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p++) = '\0';
+ 		p2 = strchr(p, ';');
+ 		if(!p2) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p2++) = '\0';
+@@ -505,13 +505,13 @@ int reload_from_lease_file6(void)
+ 		int_client = p;
+ 		p = strchr(p2, ';');
+ 		if(!p) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p++) = '\0';
+ 		p2 = strchr(p, ';');
+ 		if(!p2) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p2++) = '\0';
+@@ -519,20 +519,20 @@ int reload_from_lease_file6(void)
+ 		rem_client = p;
+ 		p = strchr(p2, ';');
+ 		if(!p) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p++) = '\0';
+ 		p2 = strchr(p, ';');
+ 		if(!p2) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p2++) = '\0';
+ 		desc = strchr(p2, ';');
+ 		uid = atoi(p);
+ 		if(!desc) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(desc++) = '\0';
+@@ -549,7 +549,7 @@ int reload_from_lease_file6(void)
+ 
+ 		if(timestamp > 0) {
+ 			if(timestamp <= (unsigned int)current_unix_time) {
+-				syslog(LOG_NOTICE, "already expired lease in lease file");
++				syslog(LOG_INFO, "already expired lease in lease file");
+ 				continue;
+ 			} else {
+ 				leaseduration = timestamp - current_unix_time;
+--- a/upnpredirect.c
++++ b/upnpredirect.c
+@@ -66,7 +66,7 @@ lease_file_add(unsigned short eport,
+ 
+ 	fd = fopen( lease_file, "a");
+ 	if (fd==NULL) {
+-		syslog(LOG_ERR, "could not open lease file: %s", lease_file);
++		syslog(LOG_DEBUG, "could not open lease file: %s", lease_file);
+ 		return -1;
+ 	}
+ 
+@@ -175,7 +175,7 @@ int reload_from_lease_file(void)
+ 	if(!lease_file) return -1;
+ 	fd = fopen( lease_file, "r");
+ 	if (fd==NULL) {
+-		syslog(LOG_ERR, "could not open lease file: %s", lease_file);
++		syslog(LOG_DEBUG, "could not open lease file: %s", lease_file);
+ 		return -1;
+ 	}
+ 	if(unlink(lease_file) < 0) {
+@@ -191,33 +191,33 @@ int reload_from_lease_file(void)
+ 		proto = line;
+ 		p = strchr(line, ':');
+ 		if(!p) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p++) = '\0';
+ 		iaddr = strchr(p, ':');
+ 		if(!iaddr) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(iaddr++) = '\0';
+ 		eport = (unsigned short)atoi(p);
+ 		p = strchr(iaddr, ':');
+ 		if(!p) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p++) = '\0';
+ 		iport = (unsigned short)atoi(p);
+ 		p = strchr(p, ':');
+ 		if(!p) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(p++) = '\0';
+ 		desc = strchr(p, ':');
+ 		if(!desc) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file");
+ 			continue;
+ 		}
+ 		*(desc++) = '\0';
+@@ -238,7 +238,7 @@ int reload_from_lease_file(void)
+ 			timestamp += current_time;	/* convert to our time */
+ #else
+ 			if(timestamp <= (unsigned int)current_unix_time) {
+-				syslog(LOG_NOTICE, "already expired lease in lease file (%hu=>%s:%hu %s)",
++				syslog(LOG_INFO, "already expired lease in lease file (%hu=>%s:%hu %s)",
+ 				       eport, iaddr, iport, proto);
+ 				continue;
+ 			} else {
+@@ -398,7 +398,7 @@ upnp_redirect(const char * rhost, unsign
+ #endif /* CHECK_PORTINUSE */
+ 	} else {
+ 		timestamp = (leaseduration > 0) ? upnp_time() + leaseduration : 0;
+-		syslog(LOG_INFO, "redirecting port %hu to %s:%hu protocol %s for: %s",
++		syslog(LOG_DEBUG, "redirecting port %hu to %s:%hu protocol %s for: %s",
+ 			eport, iaddr, iport, protocol, desc);
+ 		return upnp_redirect_internal(rhost, eport, iaddr, iport, proto,
+ 		                              desc, timestamp);
+@@ -648,7 +648,7 @@ get_upnp_rules_state_list(int max_rules_
+ 	{
+ 		if(tmp->to_remove)
+ 		{
+-			syslog(LOG_NOTICE, "remove port mapping %hu %s because it has expired",
++			syslog(LOG_INFO, "remove port mapping %hu %s because it has expired",
+ 			       tmp->eport, proto_itoa(tmp->proto));
+ 			_upnp_delete_redir(tmp->eport, tmp->proto);
+ 			*p = tmp->next;
+--- a/upnpsoap.c
++++ b/upnpsoap.c
+@@ -545,7 +545,7 @@ AddPortMapping(struct upnphttp * h, cons
+ 		}
+ 		else
+ 		{
+-			syslog(LOG_ERR, "Failed to convert hostname '%s' to ip address", int_ip);
++			syslog(LOG_INFO, "Failed to convert hostname '%s' to ip address", int_ip);
+ 			ClearNameValueList(&data);
+ 			SoapError(h, 402, "Invalid Args");
+ 			return;
+@@ -750,7 +750,7 @@ AddAnyPortMapping(struct upnphttp * h, c
+ 		}
+ 		else
+ 		{
+-			syslog(LOG_ERR, "Failed to convert hostname '%s' to ip address", int_ip);
++			syslog(LOG_INFO, "Failed to convert hostname '%s' to ip address", int_ip);
+ 			ClearNameValueList(&data);
+ 			SoapError(h, 402, "Invalid Args");
+ 			return;
+@@ -913,7 +913,7 @@ GetSpecificPortMappingEntry(struct upnph
+ 	}
+ 	else
+ 	{
+-		syslog(LOG_INFO, "%s: rhost='%s' %s %s found => %s:%u desc='%s' duration=%u",
++		syslog(LOG_DEBUG, "%s: rhost='%s' %s %s found => %s:%u desc='%s' duration=%u",
+ 		       action,
+ 		       r_host ? r_host : "NULL", ext_port, protocol, int_ip,
+ 		       (unsigned int)iport, desc, leaseduration);
+@@ -1003,7 +1003,7 @@ DeletePortMapping(struct upnphttp * h, c
+ 		return;
+ 	}
+ 
+-	syslog(LOG_INFO, "%s: external port: %hu, protocol: %s",
++	syslog(LOG_DEBUG, "%s: external port: %hu, protocol: %s",
+ 		action, eport, protocol);
+ 
+ 	/* if in secure mode, check the IP
+@@ -1125,7 +1125,7 @@ DeletePortMappingRange(struct upnphttp *
+ 	for(i = 0; i < number; i++)
+ 	{
+ 		r = upnp_delete_redirection(port_list[i], protocol);
+-		syslog(LOG_INFO, "%s: deleting external port: %hu, protocol: %s: %s",
++		syslog(LOG_DEBUG, "%s: deleting external port: %hu, protocol: %s: %s",
+ 		       action, port_list[i], protocol, r < 0 ? "failed" : "ok");
+ 	}
+ 	free(port_list);
+@@ -1196,7 +1196,7 @@ GetGenericPortMappingEntry(struct upnpht
+ 		return;
+ 	}
+ 
+-	syslog(LOG_INFO, "%s: index=%d", action, (int)index);
++	syslog(LOG_DEBUG, "%s: index=%d", action, (int)index);
+ 
+ 	rhost[0] = '\0';
+ 	r = upnp_get_redirection_infos_by_index((int)index, &eport, protocol, &iport,
+@@ -1777,7 +1777,7 @@ PinholeVerification(struct upnphttp * h,
+ 			struct addrinfo hints, *ai, *p;
+ 			int found = 0;
+ 
+-			syslog(LOG_INFO, "%s: InternalClient %s is not an IPv6, assume hostname and convert",
++			syslog(LOG_DEBUG, "%s: InternalClient %s is not an IPv6, assume hostname and convert",
+ 			       "PinholeVerification", int_ip);
+ 
+ 			memset(&hints, 0, sizeof(hints));
+@@ -1788,7 +1788,7 @@ PinholeVerification(struct upnphttp * h,
+ 			r = getaddrinfo(int_ip, NULL, &hints, &ai);
+ 			if (r != 0)
+ 			{
+-				syslog(LOG_WARNING, "%s: Failed to convert hostname '%s' to IP address : %s",
++				syslog(LOG_INFO, "%s: Failed to convert hostname '%s' to IP address : %s",
+ 				       "PinholeVerification", int_ip, gai_strerror(r));
+ 				SoapError(h, 402, "Invalid Args");
+ 				return -1;
+@@ -1803,11 +1803,11 @@ PinholeVerification(struct upnphttp * h,
+ 
+ 						if (inet_ntop(AF_INET6, &result_ip, int_ip_resolved, INET6_ADDRSTRLEN) == NULL)
+ 						{
+-							syslog(LOG_WARNING, "%s: inet_ntop(): %m", "PinholeVerification");
++							syslog(LOG_INFO, "%s: inet_ntop(): %m", "PinholeVerification");
+ 							SoapError(h, 501, "Action Failed");
+ 							return -1;
+ 						}
+-						syslog(LOG_INFO, "%s: InternalClient \"%s\" resolved as %s",
++						syslog(LOG_DEBUG, "%s: InternalClient \"%s\" resolved as %s",
+ 						       "PinholeVerification", int_ip, int_ip_resolved);
+ 						found = 1;
+ 					}
+@@ -1823,7 +1823,7 @@ PinholeVerification(struct upnphttp * h,
+ 			freeaddrinfo(ai);
+ 			if (!found)
+ 			{
+-				syslog(LOG_NOTICE, "%s: No IPv6 address for hostname '%s'",
++				syslog(LOG_INFO, "%s: No IPv6 address for hostname '%s'",
+ 				       "PinholeVerification", int_ip);
+ 				SoapError(h, 402, "Invalid Args");
+ 				return -1;
+@@ -1841,7 +1841,7 @@ PinholeVerification(struct upnphttp * h,
+ 		/* no need to copy to int_ip_resolved, but we still need to fill result_ip up */
+ 		if (inet_pton(AF_INET6, int_ip, &result_ip) <= 0)
+ 		{
+-			syslog(LOG_ERR, "inet_pton(%s)", int_ip);
++			syslog(LOG_DEBUG, "inet_pton(%s)", int_ip);
+ 			SoapError(h, 501, "Action Failed");
+ 			return -1;
+ 		}
+@@ -1974,7 +1974,7 @@ AddPinhole(struct upnphttp * h, const ch
+ 					inet_ntop(AF_INET6,
+ 					          &(((struct sockaddr_in6 *)p->ai_addr)->sin6_addr),
+ 					          rem_ip, sizeof(rem_ip));
+-					syslog(LOG_INFO, "resolved '%s' to '%s'", rem_host, rem_ip);
++					syslog(LOG_DEBUG, "resolved '%s' to '%s'", rem_host, rem_ip);
+ 					rem_host = rem_ip;
+ 					break;
+ 				}
+@@ -1983,7 +1983,7 @@ AddPinhole(struct upnphttp * h, const ch
+ 		}
+ 		else
+ 		{
+-			syslog(LOG_WARNING, "AddPinhole : getaddrinfo(%s) : %s",
++			syslog(LOG_INFO, "AddPinhole : getaddrinfo(%s) : %s",
+ 			       rem_host, gai_strerror(err));
+ #if 0
+ 			SoapError(h, 402, "Invalid Args");
+@@ -2696,7 +2696,7 @@ SoapError(struct upnphttp * h, int errCo
+ 	char body[2048];
+ 	int bodylen;
+ 
+-	syslog(LOG_INFO, "Returning UPnPError %d: %s", errCode, errDesc);
++	syslog(LOG_DEBUG, "Returning UPnPError %d: %s", errCode, errDesc);
+ 	bodylen = snprintf(body, sizeof(body), resp, errCode, errDesc);
+ 	if(bodylen < 0) {
+ 		syslog(LOG_ERR, "snprintf() returned %d", bodylen);

--- a/net/miniupnpd/patches/20-improve-logging.patch
+++ b/net/miniupnpd/patches/20-improve-logging.patch
@@ -1,0 +1,1379 @@
+From 22a056e0c4b7c117bd2e0c06e93771c3961dcb15 Mon Sep 17 00:00:00 2001
+From: Self-Hosting-Group
+ <155233284+Self-Hosting-Group@users.noreply.github.com>
+Date: Wed, 9 Sep 2026 00:00:00 +0000
+Subject: [PATCH] miniupnpd: Improve logging and CGNAT use
+
+* Clearer logging of enabled protocols/ports, IPv6 mapping, and UPnP IGD
+  compatibility mode… in start banner
+* Log warnings with an enabled allow third-party mapping option
+* Change the log level (less verbose) of many internal or normally
+  occurring messages, and some error messages, without functional
+  restrictions, to DEBUG, client requests/actions and their errors to
+  INFO, and only daemon-wide messages to NOTICE/WARNING/ERR…
+* Comment out some log-filling messages when internal interfaces lose
+  link, and for e.g. `rule with label '%s' is not a IGD pinhole`, as
+  normally occurring
+* Log IPv4 mapping disabled/enabled messages by default
+* Fix IPv4 mapping re-enable after external interface down/up with a
+  CGNAT option set; handling was previously not entirely implemented for
+  both options, incl. miniupnp/miniupnp@bbdd738, miniupnp/miniupnp#905
+* No IPv4 mapping disabled logging on requests, but more cases
+* Clearer IPv4 mapping disabled/enabled logging
+
+Fixes: https://github.com/openwrt/packages/issues/11971
+Fixes: https://github.com/openwrt/packages/issues/17601
+Fixes: https://github.com/openwrt/packages/issues/26483
+Link: https://github.com/miniupnp/miniupnp/pull/764
+---
+ asyncsendto.c                 |   4 +-
+ getifaddr.c                   |   4 +-
+ minissdp.c                    |  24 ++--
+ miniupnpd.c                   | 208 +++++++++++++++++++-------------
+ natpmp.c                      |  16 +--
+ netfilter/iptcrdr.c           |  10 +-
+ netfilter/iptpinhole.c        |   4 +-
+ netfilter_nft/nftnlrdr.c      |   2 +-
+ netfilter_nft/nftnlrdr_misc.c |   8 +-
+ netfilter_nft/nftpinhole.c    |  10 +-
+ pcpserver.c                   |  18 +--
+ pf/obsdrdr.c                  |   6 +-
+ pf/pfpinhole.c                |  12 +-
+ upnphttp.c                    |   6 +-
+ upnppinhole.c                 |   8 +-
+ upnpredirect.c                |  10 +-
+ upnpsoap.c                    |  43 +++----
+ upnpstun.c                    |  37 +++---
+ 18 files changed, 229 insertions(+), 201 deletions(-)
+
+--- a/asyncsendto.c
++++ b/asyncsendto.c
+@@ -254,9 +254,9 @@ int try_sendto(fd_set * writefds)
+ 					/* uncatched error */
+ 					if(sockaddr_to_string(elt->dest_addr, addr_str, sizeof(addr_str)) <= 0)
+ 						addr_str[0] = '\0';
+-					syslog(LOG_ERR, "%s(sock=%d, len=%u, dest=%s): sendto: %m",
++					/*syslog(LOG_DEBUG, "%s(sock=%d, len=%u, dest=%s): sendto: %m",
+ 					       "try_sendto", elt->sockfd, (unsigned)elt->len,
+-					       addr_str);
++					       addr_str);*/
+ 					ret--;
+ 				}
+ 			} else if((int)n != (int)elt->len) {
+--- a/getifaddr.c
++++ b/getifaddr.c
+@@ -74,7 +74,7 @@ getifaddr(const char * ifname, char * bu
+ 		} else {
+ 			r = GETIFADDR_IOCTL_ERROR;
+ 		}
+-		syslog(LOG_ERR, "ioctl(s, SIOCGIFADDR, ...): %m");
++		syslog(LOG_DEBUG, "ioctl(s, SIOCGIFADDR, ...): %m");
+ 		close(s);
+ 		return r;
+ 	}
+@@ -149,7 +149,7 @@ getifaddr(const char * ifname, char * bu
+ 		if(addr) *addr = ((struct sockaddr_in *)candidate->ifa_addr)->sin_addr;
+ 		if(mask) *mask = ((struct sockaddr_in *)candidate->ifa_netmask)->sin_addr;
+ 	} else {
+-		syslog(LOG_WARNING, "no AF_INET address found for %s", ifname);
++		syslog(LOG_DEBUG, "no AF_INET address found for %s", ifname);
+ 		freeifaddrs(ifap);
+ 		return GETIFADDR_NO_ADDRESS;
+ 	}
+--- a/minissdp.c
++++ b/minissdp.c
+@@ -743,8 +743,8 @@ SendSSDPNotify(int s, const struct socka
+ 	}
+ 	n = sendto_or_schedule(s, bufr, l, 0, dest, dest_len);
+ 	if(n < 0) {
+-		syslog(LOG_ERR, "sendto(udp_notify=%d, %s): %m", s,
+-		       host ? host : "NULL");
++		/*syslog(LOG_DEBUG, "sendto(udp_notify=%d, %s): %m", s,
++		       host ? host : "NULL");*/
+ 	} else if(n != l) {
+ 		syslog(LOG_NOTICE, "sendto() sent %d out of %d bytes", n, l);
+ 	}
+@@ -754,8 +754,8 @@ SendSSDPNotify(int s, const struct socka
+ 	 * discovery messages SHOULD NOT be sent more than three times. */
+ 	n = sendto_schedule(s, bufr, l, 0, dest, dest_len, 250);
+ 	if(n < 0) {
+-		syslog(LOG_ERR, "sendto(udp_notify=%d, %s): %m", s,
+-		       host ? host : "NULL");
++		/*syslog(LOG_DEBUG, "sendto(udp_notify=%d, %s): %m", s,
++		       host ? host : "NULL");*/
+ 	}
+ }
+ 
+@@ -1060,7 +1060,7 @@ ProcessSSDPData(int s, const char *bufr,
+ 	}
+ 	if(lan_addr == NULL)
+ 	{
+-		syslog(LOG_WARNING, "SSDP packet sender %s (if_index=%d) not from a LAN, ignoring",
++		syslog(LOG_DEBUG, "SSDP packet sender %s (if_index=%d) not from a LAN, ignoring",
+ 		       sender_str, source_if);
+ 		return;
+ 	}
+@@ -1163,7 +1163,7 @@ ProcessSSDPData(int s, const char *bufr,
+ 	           sender_str );*/
+ 		if(st && (st_len > 0))
+ 		{
+-			syslog(LOG_INFO, "SSDP M-SEARCH from %s ST: %.*s",
++			syslog(LOG_DEBUG, "SSDP M-SEARCH from %s ST: %.*s",
+ 			       sender_str, st_len, st);
+ 			/* find in which sub network the client is */
+ #ifdef ENABLE_IPV6
+@@ -1276,7 +1276,7 @@ ProcessSSDPData(int s, const char *bufr,
+ 					else
+ 						snprintf(ver_str, sizeof(ver_str), "%d", known_service_types[i].version);
+ #endif
+-					syslog(LOG_INFO, "Single search found");
++					syslog(LOG_DEBUG, "Single search found");
+ #ifdef DELAY_MSEARCH_RESPONSE
+ 					delay = random() / (1 + RAND_MAX / (1000 * mx_value));
+ #ifdef DEBUG
+@@ -1305,7 +1305,7 @@ ProcessSSDPData(int s, const char *bufr,
+ #ifdef DELAY_MSEARCH_RESPONSE
+ 				unsigned int delay_increment = (mx_value * 1000) / 15;
+ #endif
+-				syslog(LOG_INFO, "ssdp:all found");
++				syslog(LOG_DEBUG, "ssdp:all found");
+ 				for(i=0; known_service_types[i].s; i++)
+ 				{
+ #ifdef DELAY_MSEARCH_RESPONSE
+@@ -1363,7 +1363,7 @@ ProcessSSDPData(int s, const char *bufr,
+ #endif
+ 				if(0 == memcmp(st, uuidvalue_igd, l))
+ 				{
+-					syslog(LOG_INFO, "ssdp:uuid (IGD) found");
++					syslog(LOG_DEBUG, "ssdp:uuid (IGD) found");
+ 					SendSSDPResponse(s, sender, st, st_len, "",
+ 					                 announced_host, http_port,
+ #ifdef ENABLE_HTTPS
+@@ -1373,7 +1373,7 @@ ProcessSSDPData(int s, const char *bufr,
+ 				}
+ 				else if(0 == memcmp(st, uuidvalue_wan, l))
+ 				{
+-					syslog(LOG_INFO, "ssdp:uuid (WAN) found");
++					syslog(LOG_DEBUG, "ssdp:uuid (WAN) found");
+ 					SendSSDPResponse(s, sender, st, st_len, "",
+ 					                 announced_host, http_port,
+ #ifdef ENABLE_HTTPS
+@@ -1383,7 +1383,7 @@ ProcessSSDPData(int s, const char *bufr,
+ 				}
+ 				else if(0 == memcmp(st, uuidvalue_wcd, l))
+ 				{
+-					syslog(LOG_INFO, "ssdp:uuid (WCD) found");
++					syslog(LOG_DEBUG, "ssdp:uuid (WCD) found");
+ 					SendSSDPResponse(s, sender, st, st_len, "",
+ 					                 announced_host, http_port,
+ #ifdef ENABLE_HTTPS
+@@ -1444,7 +1444,7 @@ SendSSDPbyebye(int s, const struct socka
+ 	n = sendto_or_schedule(s, bufr, l, 0, dest, destlen);
+ 	if(n < 0)
+ 	{
+-		syslog(LOG_ERR, "sendto(udp_shutdown=%d) to %s: %m", s, dest_str);
++		syslog(LOG_DEBUG, "sendto(udp_shutdown=%d) to %s: %m", s, dest_str);
+ 		return -1;
+ 	}
+ 	else if(n != l)
+--- a/miniupnpd.c
++++ b/miniupnpd.c
+@@ -496,7 +496,7 @@ ProcessIncomingHTTP(int shttpl, const ch
+ 		if(get_lan_for_peer((struct sockaddr *)&clientname) == NULL)
+ 		{
+ 			/* The peer is not a LAN ! */
+-			syslog(LOG_WARNING,
++			syslog(LOG_DEBUG,
+ 			       "%s peer %s is not from a LAN, closing the connection",
+ 			       protocol, addr_str);
+ 			close(shttp);
+@@ -867,7 +867,7 @@ set_startup_time(void)
+ 			}
+ 			else
+ 			{
+-				syslog(LOG_INFO, "system uptime is %lu seconds", uptime);
++				syslog(LOG_DEBUG, "system uptime is %lu seconds", uptime);
+ 			}
+ 			fclose(f);
+ 			startup_time -= uptime;
+@@ -1061,10 +1061,10 @@ parselanaddr(struct lan_addr_s * lan_add
+ 			}
+ 			if(addr_is_reserved(&lan_addr->ext_ip_addr)) {
+ 				if (GETFLAG(ALLOWPRIVATEIPV4MASK)) {
+-					syslog(LOG_WARNING, "IGNORED : option ext_ip address contains reserved / private address : %s", lan_addr->ext_ip_str);
++					syslog(LOG_WARNING, "WARNING: IPv4 mapping enabled forcibly, as ext_allow_private_ipv4=yes set; check security note if not set");
+ 				} else {
+ 					/* error */
+-					INIT_PRINT_ERR("Error: option ext_ip address contains reserved / private address : %s\n", lan_addr->ext_ip_str);
++					INIT_PRINT_ERR("Option ext_ip set to private/CGNAT-reserved (%s) IPv4, exiting\n", lan_addr->ext_ip_str);
+ 					return -1;
+ 				}
+ 			}
+@@ -1118,20 +1118,19 @@ parselan_error:
+ 
+ static char ext_addr_str[INET_ADDRSTRLEN];
+ 
+-int update_ext_ip_addr_from_stun(int init)
++int update_ext_ip_addr_from_stun(void)
+ {
+ 	struct in_addr if_addr, ext_addr;
+-	int restrictive_nat;
++	int restrictive_nat, reserved;
+ 	char if_addr_str[INET_ADDRSTRLEN];
+ 
+-	syslog(LOG_INFO, "STUN: Performing with host=%s and port=%u ...", ext_stun_host, (unsigned)ext_stun_port);
+-
+ 	if (getifaddr(ext_if_name, if_addr_str, INET_ADDRSTRLEN, &if_addr, NULL) < 0) {
+-		syslog(LOG_ERR, "STUN: Cannot get IP address for ext interface %s", ext_if_name);
++		syslog(LOG_ERR, "Detected no IPv4 address on external network interface %s", ext_if_name);
+ 		return 1;
+ 	}
++	syslog(LOG_INFO, "STUN: Detecting public IPv4 and testing for unrestricted endpoint-independent (1:1) CGNAT via %s:%u...", ext_stun_host, ext_stun_port ? ext_stun_port : 3478);
+ 	if (perform_stun(ext_if_name, if_addr_str, ext_stun_host, ext_stun_port, &ext_addr, &restrictive_nat) != 0) {
+-		syslog(LOG_ERR, "STUN: Performing STUN failed: %s", strerror(errno));
++		syslog(LOG_ERR, "STUN: Performing test failed");
+ 		return 1;
+ 	}
+ 	if (!inet_ntop(AF_INET, &ext_addr, ext_addr_str, sizeof(ext_addr_str))) {
+@@ -1139,32 +1138,29 @@ int update_ext_ip_addr_from_stun(int ini
+ 		return 1;
+ 	}
+ 
+-	if ((init || disable_port_forwarding) && !restrictive_nat) {
+-		if (addr_is_reserved(&if_addr))
+-			syslog(LOG_INFO, "STUN: ext interface %s with IP address %s is now behind unrestricted full-cone NAT 1:1 with public IP address %s and firewall does not block incoming connections set by miniupnpd", ext_if_name, if_addr_str, ext_addr_str);
+-		else
+-			syslog(LOG_INFO, "STUN: ext interface %s has now public IP address %s and firewall does not block incoming connections set by miniupnpd", ext_if_name, if_addr_str);
+-		syslog(LOG_INFO, "Port forwarding is now enabled");
+-	} else if ((init || !disable_port_forwarding) && restrictive_nat) {
+-		if (addr_is_reserved(&if_addr)) {
+-			syslog(LOG_WARNING, "STUN: ext interface %s with private IP address %s is now possibly behind restrictive or symmetric NAT with public IP address %s which does not support port forwarding", ext_if_name, if_addr_str, ext_addr_str);
+-			syslog(LOG_WARNING, "NAT on upstream router blocks incoming connections set by miniupnpd");
+-			syslog(LOG_WARNING, "Turn off NAT on upstream router or change it to full-cone NAT 1:1 type");
++	reserved = addr_is_reserved(&if_addr);
++	if (!restrictive_nat && !reserved) {
++		syslog(LOG_INFO, "STUN: Detected unrestricted public external IPv4 %s on %s", if_addr_str, ext_if_name);
++	} else if (!restrictive_nat && reserved) {
++		syslog(LOG_INFO, "STUN: Detected unrestricted endpoint-independent (1:1) CGNAT with public IPv4 %s and %s as external on %s", ext_addr_str, if_addr_str, ext_if_name);
++	} else if (restrictive_nat && !reserved) {
++		syslog(LOG_INFO, "STUN: Detected restricted public external IPv4 %s on %s, IPv4 mapping may not work", if_addr_str, ext_if_name);
++	} else if (restrictive_nat && reserved) {
++		syslog(LOG_INFO, "STUN: Detected restricted or address- and port-dependent (symmetric) CGNAT with public IPv4 %s and %s as external on %s, IPv4 mapping may not work", ext_addr_str, if_addr_str, ext_if_name);
++	}
++
++	use_ext_ip_addr = ext_addr_str;
++	if (!restrictive_nat || GETFLAG(ALLOWFILTEREDSTUNMASK)) {
++		if (!restrictive_nat) {
++			syslog(LOG_NOTICE, "IPv4 mapping enabled, and reachability/non-filtering tested via STUN");
+ 		} else {
+-			syslog(LOG_WARNING, "STUN: ext interface %s has now public IP address %s but firewall filters incoming connections set by miniunnpd", ext_if_name, if_addr_str);
+-			syslog(LOG_WARNING, "Check configuration of firewall on local machine and also on upstream router");
+-		}
+-		if (!GETFLAG(ALLOWFILTEREDSTUNMASK)) {
+-			syslog(LOG_WARNING, "Port forwarding is now disabled");
+-			syslog(LOG_WARNING, "Set ext_perform_stun=allow-filtered if you still want to use port forwarding in current situation");
++			syslog(LOG_WARNING, "WARNING: IPv4 mapping enabled forcibly, as ext_perform_stun=allow-filtered set; check security note if not set");
+ 		}
++		disable_port_forwarding = 0;
+ 	} else {
+-		syslog(LOG_INFO, "STUN: ... done");
++		syslog(LOG_WARNING, "IPv4 mapping disabled, as own/upstream router filters incoming, or there is an address- and port-dependent (symmetric) CGNAT; to workaround current daemon limitation, or enable it anyway, set ext_perform_stun=allow-filtered; check security note if not set");
++		disable_port_forwarding = 1;
+ 	}
+-
+-	use_ext_ip_addr = ext_addr_str;
+-	if (!GETFLAG(ALLOWFILTEREDSTUNMASK))
+-		disable_port_forwarding = restrictive_nat;
+ 	return 0;
+ }
+ 
+@@ -1184,32 +1180,41 @@ static void update_disable_port_forwardi
+ 			syslog(LOG_WARNING, "ext interface %s is down", ext_if_name);
+ 			break;
+ 		case GETIFADDR_NO_ADDRESS:
+-			syslog(LOG_WARNING, "ext interface %s has no IPv4 address. Network is down", ext_if_name);
++			syslog(LOG_ERR, "Detected no IPv4 address on external network interface %s", ext_if_name);
+ 			break;
+ 		default:
+-			syslog(LOG_ERR, "Error getting IPv4 address for ext interface %s. Network is down", ext_if_name);
++			syslog(LOG_ERR, "Detected no IPv4 address on external network interface %s", ext_if_name);
+ 		}
++		syslog(LOG_WARNING, "IPv4 mapping disabled");
+ 		disable_port_forwarding = 1;
++
+ 	} else {
+ 		int reserved = addr_is_reserved(&addr);
+-		if (!disable_port_forwarding && reserved) {
+-			if (GETFLAG(ALLOWPRIVATEIPV4MASK)) {
+-				syslog(LOG_WARNING, "IGNORED : Reserved / private IP address %s on ext interface %s", if_addr, ext_if_name);
++		if (!reserved) {
++			syslog(LOG_INFO, "Detected public external IPv4 %s on %s", if_addr, ext_if_name);
++		} else {
++			syslog(LOG_INFO, "Detected private/CGNAT-reserved external IPv4 %s on %s, IPv4 mapping may not work", if_addr, ext_if_name);
++		}
++
++		if (!reserved || GETFLAG(ALLOWPRIVATEIPV4MASK)) {
++			if (!reserved) {
++				syslog(LOG_NOTICE, "IPv4 mapping enabled");
+ 			} else {
+-				syslog(LOG_WARNING, "Reserved / private IP address %s on ext interface %s: Port forwarding is impossible", if_addr, ext_if_name);
+-				syslog(LOG_INFO, "You are probably behind NAT, enable option ext_perform_stun=yes to detect public IP address");
+-				syslog(LOG_INFO, "Or use ext_ip= / -o option to declare public IP address");
+-				syslog(LOG_INFO, "In case that miniupnpd is thinking that it's behind symmetric NAT while it actually is full-cone");
+-				syslog(LOG_INFO, "You can set option ext_allow_private_ipv4=yes to enable port forwarding");
+-				syslog(LOG_INFO, "But you may still need to configure stun server or ext_ip to make it work correctly");
+-				syslog(LOG_INFO, "Public IP address is required by UPnP/PCP/PMP protocols and clients do not work without it");
+-				disable_port_forwarding = 1;
+-			}
+-		} else if (disable_port_forwarding &&
+-		           (!reserved || GETFLAG(ALLOWPRIVATEIPV4MASK))) {
+-			syslog(LOG_INFO, "%s IP address %s on ext interface %s: Port forwarding is enabled",
+-			       reserved ? "Reserved / private" : "Public", if_addr, ext_if_name);
++				syslog(LOG_WARNING, "WARNING: IPv4 mapping enabled forcibly, as ext_allow_private_ipv4=yes set; check compatibility/security notes if not set");
++			}
+ 			disable_port_forwarding = 0;
++		} else {
++			syslog(LOG_WARNING, "IPv4 mapping disabled by default, as private/CGNAT-reserved external IPv4 detected. Prevented for:");
++			syslog(LOG_WARNING, "- Info, as port maps not reachable via internet without an unrestricted endpoint-independent (1:1) IPv4 CGNAT; possibly from within");
++			syslog(LOG_WARNING, "- Compatibility, as many UPnP IGD & PCP/NAT-PMP clients require a returned public external IPv4");
++			syslog(LOG_WARNING, "- Security, to prevent access via internet if the external/internal network interface has been configured swapped");
++			syslog(LOG_WARNING, "To enable IPv4 mapping anyway, select one of the following options, listed by priority:");
++			syslog(LOG_WARNING, "A) Detect public external IPv4 and test for unrestricted endpoint-independent (1:1) CGNAT via STUN server, set ext_perform_stun=yes");
++			syslog(LOG_WARNING, "B) As A, but workaround filtered CGNAT result daemon limitation (without an extra firewall rule), set ext_perform_stun=allow-filtered; check security note");
++			syslog(LOG_WARNING, "C) Manually override reported external IPv4 with public, set ext_ip; check security note");
++			syslog(LOG_WARNING, "D) Report private/CGNAT-reserved external IPv4 to clients, set ext_allow_private_ipv4=yes; check compatibility/security notes");
++			syslog(LOG_WARNING, "IPv4 mapping disabled");
++			disable_port_forwarding = 1;
+ 		}
+ 	}
+ }
+@@ -2095,9 +2100,9 @@ init(int argc, char * * argv, struct run
+ 		}
+ 		if (addr_is_reserved(&addr)) {
+ 			if (GETFLAG(ALLOWPRIVATEIPV4MASK)) {
+-				syslog(LOG_WARNING, "IGNORED : option ext_ip contains reserved / private address %s, not public routable", use_ext_ip_addr);
++				syslog(LOG_WARNING, "WARNING: IPv4 mapping enabled forcibly, as ext_allow_private_ipv4=yes set; check compatibility/security notes if not set");
+ 			} else {
+-				INIT_PRINT_ERR("Error: option ext_ip contains reserved / private address %s, not public routable\n", use_ext_ip_addr);
++				INIT_PRINT_ERR("Option ext_ip set to private/CGNAT-reserved (%s) IPv4, exiting\n", use_ext_ip_addr);
+ 				return 1;
+ 			}
+ 		}
+@@ -2230,6 +2235,22 @@ init(int argc, char * * argv, struct run
+ 		pidfilename = NULL;
+ #endif
+ 
++	syslog(LOG_NOTICE, "MiniUPnP daemon " MINIUPNPD_VERSION " starting, enabled protocols %s%s%s, ext_ifname=%s BOOTID=%u",
++		GETFLAG(ENABLEUPNPMASK) ? "UPnP IGD" : "",
++#ifdef ENABLE_NATPMP
++		GETFLAG(ENABLEUPNPMASK) && GETFLAG(ENABLENATPMPMASK) ? " & " : "",
++#ifdef ENABLE_PCP
++		GETFLAG(ENABLENATPMPMASK) ? "PCP/NAT-PMP" : "",
++#else
++		GETFLAG(ENABLENATPMPMASK) ? "NAT-PMP" : "",
++#endif
++#else
++		"", "",
++#endif
++		ext_if_name, upnp_bootid);
++	syslog(LOG_INFO, "More information at https://miniupnp.tuxfamily.org/ or http://miniupnp.free.fr/");
++	syslog(LOG_NOTICE, "Extra logging with log level info (-v) or debug (-v -v)");
++
+ #ifdef USE_SYSTEMD
+ 	if (systemd_flag) {
+ 		int r = sd_notify(0,
+@@ -2242,7 +2263,7 @@ init(int argc, char * * argv, struct run
+ 
+ #ifdef ENABLE_LEASEFILE
+ 	/*remove(lease_file);*/
+-	syslog(LOG_INFO, "Reloading rules from lease file");
++	syslog(LOG_INFO, "Reloading port maps from lease file");
+ 	reload_from_lease_file();
+ #ifdef ENABLE_UPNPPINHOLE
+ 	reload_from_lease_file6();
+@@ -2433,28 +2454,16 @@ main(int argc, char * * argv)
+ 		goto shutdown;
+ 	}
+ 
+-	syslog(LOG_INFO, "version " MINIUPNPD_VERSION " starting%s%sext if %s BOOTID=%u",
+-#ifdef ENABLE_NATPMP
+-#ifdef ENABLE_PCP
+-	       GETFLAG(ENABLENATPMPMASK) ? " NAT-PMP/PCP " : " ",
+-#else
+-	       GETFLAG(ENABLENATPMPMASK) ? " NAT-PMP " : " ",
+-#endif
+-#else
+-	       " ",
+-#endif
+-	       GETFLAG(ENABLEUPNPMASK) ? "UPnP-IGD " : "",
+-	       ext_if_name, upnp_bootid);
+ #ifdef ENABLE_IPV6
+ 	if (strcmp(ext_if_name6, ext_if_name) != 0) {
+-		syslog(LOG_INFO, "specific IPv6 ext if %s", ext_if_name6);
++		syslog(LOG_INFO, "Separate ext_ifname6=%s set", ext_if_name6);
+ 	}
+ #endif
+ 
+ 	if(GETFLAG(PERFORMSTUNMASK))
+ 	{
+-		if (update_ext_ip_addr_from_stun(1) != 0) {
+-			syslog(LOG_ERR, "Performing STUN failed. EXITING");
++		if (update_ext_ip_addr_from_stun() != 0) {
++			syslog(LOG_ERR, "STUN: Performing test failed, exiting");
+ 			return_code = 1;
+ 			goto shutdown;
+ 		}
+@@ -2462,6 +2471,8 @@ main(int argc, char * * argv)
+ 	else if (!use_ext_ip_addr)
+ 	{
+ 		update_disable_port_forwarding();
++	} else {
++		syslog(LOG_NOTICE, "IPv4 mapping enabled");
+ 	}
+ 
+ #ifdef DYNAMIC_OS_VERSION
+@@ -2496,7 +2507,7 @@ main(int argc, char * * argv)
+ #ifdef ENABLE_NFQUEUE
+ 		nfqueue_data.http_port = listen_port;
+ #endif /* ENABLE_NFQUEUE */
+-		syslog(LOG_NOTICE, "HTTP listening on port %d", v.port);
++		syslog(LOG_NOTICE, "Listening for UPnP IGD (SOAP/HTTP) traffic on port %d/TCP, SSDP 1900/UDP", v.port);
+ #if defined(V6SOCKETS_ARE_V6ONLY) && defined(ENABLE_IPV6)
+ 		if(!GETFLAG(IPV6DISABLEDMASK))
+ 		{
+@@ -2527,7 +2538,7 @@ main(int argc, char * * argv)
+ #ifdef ENABLE_NFQUEUE
+ 		nfqueue_data.https_port = listen_port;
+ #endif /* ENABLE_NFQUEUE */
+-		syslog(LOG_NOTICE, "HTTPS listening on port %d", v.https_port);
++		syslog(LOG_NOTICE, "Listening for UPnP IGD (SOAP/HTTPS) traffic on port %d/TCP", v.https_port);
+ #if defined(V6SOCKETS_ARE_V6ONLY) && defined(ENABLE_IPV6)
+ 		shttpsl_v4 =  OpenAndConfHTTPSocket(&listen_port, 0);
+ 		if(shttpsl_v4 < 0)
+@@ -2542,11 +2553,11 @@ main(int argc, char * * argv)
+ 		if(!GETFLAG(IPV6DISABLEDMASK)) {
+ 			if(find_ipv6_addr(lan_addrs.lh_first ? lan_addrs.lh_first->ifname : NULL,
+ 			                  ipv6_addr_for_http_with_brackets, sizeof(ipv6_addr_for_http_with_brackets)) > 0) {
+-				syslog(LOG_NOTICE, "HTTP IPv6 address given to control points : %s",
++				syslog(LOG_INFO, "IPv6 address given to UPnP IGD clients: %s",
+ 				       ipv6_addr_for_http_with_brackets);
+ 			} else {
+ 				memcpy(ipv6_addr_for_http_with_brackets, "[::1]", 6);
+-				syslog(LOG_WARNING, "no HTTP IPv6 address, disabling IPv6");
++				syslog(LOG_DEBUG, "no HTTP IPv6 address, disabling IPv6");
+ 				SETFLAG(IPV6DISABLEDMASK);
+ 			}
+ 		}
+@@ -2603,7 +2614,7 @@ main(int argc, char * * argv)
+ 			if(SendSSDPGoodbye(snotify, addr_count * 2) < 0)
+ #endif
+ 			{
+-				syslog(LOG_WARNING, "Failed to broadcast good-bye notifications");
++				syslog(LOG_DEBUG, "Failed to broadcast good-bye notifications");
+ 			}
+ 		}
+ #endif /* UPNP_STRICT */
+@@ -2628,16 +2639,16 @@ main(int argc, char * * argv)
+ 		if(OpenAndConfNATPMPSockets(snatpmp) < 0)
+ #ifdef ENABLE_PCP
+ 		{
+-			syslog(LOG_ERR, "Failed to open sockets for NAT-PMP/PCP.");
++			syslog(LOG_ERR, "Failed to open port 5351/UDP for PCP/NAT-PMP");
+ 		} else {
+-			syslog(LOG_NOTICE, "Listening for NAT-PMP/PCP traffic on port %u",
++			syslog(LOG_NOTICE, "Listening for PCP/NAT-PMP traffic on port %u/UDP",
+ 			       NATPMP_PORT);
+ 		}
+ #else
+ 		{
+-			syslog(LOG_ERR, "Failed to open sockets for NAT PMP.");
++			syslog(LOG_ERR, "Failed to open port 5351/UDP for NAT-PMP");
+ 		} else {
+-			syslog(LOG_NOTICE, "Listening for NAT-PMP traffic on port %u",
++			syslog(LOG_NOTICE, "Listening for NAT-PMP traffic on port %u/UDP",
+ 			       NATPMP_PORT);
+ 		}
+ #endif
+@@ -2748,6 +2759,30 @@ main(int argc, char * * argv)
+ 	}
+ #endif /* HAS_LIBCAP_NG */
+ 
++if (GETFLAG(ENABLEUPNPMASK) && !GETFLAG(SECUREMODEMASK))
++	syslog(LOG_WARNING, "WARNING: Allow adding port maps for non-requesting IP addresses via UPnP IGD, as secure_mode=no set");
++#ifdef ENABLE_PCP
++if (GETFLAG(ENABLENATPMPMASK) && GETFLAG(PCP_ALLOWTHIRDPARTYMASK))
++	syslog(LOG_WARNING, "WARNING: Allow adding port maps for non-requesting IP addresses via PCP, as pcp_allow_thirdparty=yes set");
++#endif
++#ifdef ENABLE_IPV6
++if (GETFLAG(IPV6DISABLEDMASK))
++	syslog(LOG_NOTICE, "IPv6 mapping disabled");
++#else
++syslog(LOG_NOTICE, "IPv6 mapping disabled");
++#endif
++if (GETFLAG(ENABLEUPNPMASK)) {
++#ifdef IGD_V2
++	if (GETFLAG(FORCEIGDDESCV1MASK)) {
++		syslog(LOG_NOTICE, "UPnP IGD compatibility mode set to IGDv1 (IPv4 only)");
++	} else {
++		syslog(LOG_NOTICE, "UPnP IGD compatibility mode set to IGDv2");
++	}
++#else
++	syslog(LOG_NOTICE, "UPnP IGD compatibility mode set to IGDv1 (IPv4 only)");
++#endif
++}
++
+ #ifdef USE_SYSTEMD
+ 	if (v.systemd_notify) {
+ 		upnp_update_status();
+@@ -2777,12 +2812,13 @@ main(int argc, char * * argv)
+ 		/* send public address change notifications if needed */
+ 		if(should_send_public_address_change_notif)
+ 		{
+-			syslog(LOG_INFO, "should send external iface address change notification(s)");
++			syslog(LOG_NOTICE, "External network interface link/address change detected");
+ 			if(GETFLAG(PERFORMSTUNMASK))
+ 			{
+-				if (update_ext_ip_addr_from_stun(0) != 0) {
++				if (update_ext_ip_addr_from_stun() != 0) {
+ 					/* if stun succeed it updates disable_port_forwarding;
+ 					 * if stun failed (non-zero return value) then port forwarding would not work, so disable it */
++					syslog(LOG_WARNING, "IPv4 mapping disabled");
+ 					disable_port_forwarding = 1;
+ 				}
+ 			}
+@@ -3058,7 +3094,7 @@ main(int argc, char * * argv)
+ 		}
+ 		i = try_sendto(&writeset);
+ 		if(i < 0) {
+-			syslog(LOG_ERR, "try_sendto failed to send %d packets", -i);
++			/*syslog(LOG_DEBUG, "try_sendto failed to send %d packets", -i);*/
+ 		}
+ #ifdef USE_MINIUPNPDCTL
+ 		for(ectl = ctllisthead.lh_first; ectl;)
+@@ -3158,7 +3194,7 @@ main(int argc, char * * argv)
+ 					if(lan_addr == NULL) {
+ 						char sender_str[64];
+ 						sockaddr_to_string((struct sockaddr *)&senderaddr, sender_str, sizeof(sender_str));
+-						syslog(LOG_WARNING, "NAT-PMP packet sender %s not from a LAN, ignoring",
++						syslog(LOG_DEBUG, "NAT-PMP packet sender %s not from a LAN, ignoring",
+ 						       sender_str);
+ 						continue;
+ 					}
+@@ -3181,7 +3217,7 @@ main(int argc, char * * argv)
+ 				if(lan_addr == NULL) {
+ 					char sender_str[64];
+ 					sockaddr_to_string((struct sockaddr *)&senderaddr, sender_str, sizeof(sender_str));
+-					syslog(LOG_WARNING, "NAT-PMP packet sender %s not from a LAN, ignoring",
++					syslog(LOG_DEBUG, "NAT-PMP packet sender %s not from a LAN, ignoring",
+ 					       sender_str);
+ 					continue;
+ 				}
+@@ -3215,7 +3251,7 @@ main(int argc, char * * argv)
+ 		/* process SSDP packets */
+ 		if(sudp >= 0 && FD_ISSET(sudp, &readset))
+ 		{
+-			/*syslog(LOG_INFO, "Received UDP Packet");*/
++			/*syslog(LOG_DEBUG, "Received UDP Packet");*/
+ #ifdef ENABLE_HTTPS
+ 			ProcessSSDPRequest(sudp, (unsigned short)v.port, (unsigned short)v.https_port);
+ #else
+@@ -3225,7 +3261,7 @@ main(int argc, char * * argv)
+ #ifdef ENABLE_IPV6
+ 		if(sudpv6 >= 0 && FD_ISSET(sudpv6, &readset))
+ 		{
+-			syslog(LOG_INFO, "Received UDP Packet (IPv6)");
++			/*syslog(LOG_DEBUG, "Received UDP Packet (IPv6)");*/
+ #ifdef ENABLE_HTTPS
+ 			ProcessSSDPRequest(sudpv6, (unsigned short)v.port, (unsigned short)v.https_port);
+ #else
+@@ -3327,7 +3363,7 @@ main(int argc, char * * argv)
+ 
+ shutdown:
+ 
+-	syslog(LOG_NOTICE, "shutting down MiniUPnPd");
++	syslog(LOG_NOTICE, "Shutting down MiniUPnPd");
+ #ifdef USE_SYSTEMD
+ 	if (v.systemd_notify) {
+ 		sd_notify(0,
+@@ -3346,7 +3382,7 @@ shutdown:
+ 		if(SendSSDPGoodbye(snotify, addr_count * 2) < 0)
+ #endif
+ 		{
+-			syslog(LOG_ERR, "Failed to broadcast good-bye notifications");
++			syslog(LOG_DEBUG, "Failed to broadcast good-bye notifications");
+ 		}
+ 	}
+ 	/* try to send pending packets */
+--- a/natpmp.c
++++ b/natpmp.c
+@@ -106,7 +106,7 @@ static void FillPublicAddressResponse(un
+ 			resp[3] = 3;	/* Network Failure (e.g. NAT box itself
+ 			                 * has not obtained a DHCP lease) */
+ 		} else if(getifaddr(ext_if_name, tmp, INET_ADDRSTRLEN, &addr, NULL) < 0) {
+-			syslog(LOG_ERR, "Failed to get IP for interface %s", ext_if_name);
++			syslog(LOG_DEBUG, "Failed to get IP for interface %s", ext_if_name);
+ 			resp[3] = 3;	/* Network Failure (e.g. NAT box itself
+ 			                 * has not obtained a DHCP lease) */
+ 		} else if (!GETFLAG(ALLOWPRIVATEIPV4MASK) && addr_is_reserved(&addr)) {
+@@ -231,7 +231,7 @@ void ProcessIncomingNATPMPPacket(int s,
+ 		syslog(LOG_ERR, "inet_ntop(natpmp): %m");
+ 	}
+ 
+-	syslog(LOG_INFO, "NAT-PMP request received from %s:%hu %dbytes",
++	syslog(LOG_DEBUG, "NAT-PMP request received from %s:%hu %d bytes",
+ 	       senderaddrstr, ntohs(senderaddr->sin_port), n);
+ 
+ 	if(n<2 || ((((req[1]-1)&~1)==0) && n<12)) {
+@@ -260,7 +260,7 @@ void ProcessIncomingNATPMPPacket(int s,
+ 		resp[3] = 1;	/* unsupported version */
+ 	} else switch(req[1]) {
+ 	case 0:	/* Public address request */
+-		syslog(LOG_INFO, "NAT-PMP public address request");
++		syslog(LOG_DEBUG, "NAT-PMP public address request");
+ 		FillPublicAddressResponse(resp, senderaddr->sin_addr.s_addr);
+ 		resplen = 12;
+ 		break;
+@@ -319,7 +319,7 @@ void ProcessIncomingNATPMPPacket(int s,
+ 								resp[3] = 2;	/* Not Authorized/Refused */
+ 								break;
+ 							} else {
+-								syslog(LOG_INFO, "NAT-PMP %s port %hu mapping removed",
++								syslog(LOG_DEBUG, "NAT-PMP %s port %hu mapping removed",
+ 								       proto2==IPPROTO_TCP?"TCP":"UDP", eport2);
+ 								index--;
+ 							}
+@@ -340,7 +340,7 @@ void ProcessIncomingNATPMPPacket(int s,
+ 						eport_first = eport;
+ 					} else if(eport == eport_first) { /* no eport available */
+ 						if(any_eport_allowed == 0) { /* all eports rejected by permissions */
+-							syslog(LOG_ERR, "No allowed eport for NAT-PMP %hu %s->%s:%hu",
++							syslog(LOG_INFO, "No allowed eport for NAT-PMP %hu %s->%s:%hu",
+ 							       eport, proto_itoa(proto), senderaddrstr, iport);
+ 							resp[3] = 2;	/* Not Authorized/Refused */
+ 						} else { /* at least one eport allowed (but none available) */
+@@ -443,7 +443,7 @@ void SendNATPMPPublicAddressChangeNotifi
+ 	FillPublicAddressResponse(notif, 0);
+ 	if(notif[3])
+ 	{
+-		syslog(LOG_WARNING, "%s: cannot get public IP address, stopping",
++		syslog(LOG_DEBUG, "%s: cannot get public IP address, stopping",
+ 		       "SendNATPMPPublicAddressChangeNotification");
+ 		return;
+ 	}
+@@ -471,7 +471,7 @@ void SendNATPMPPublicAddressChangeNotifi
+ 		           (struct sockaddr *)&sockname, sizeof(struct sockaddr_in));
+ 		if(n < 0)
+ 		{
+-			syslog(LOG_ERR, "%s: sendto(s_udp=%d, port=%d): %m",
++			syslog(LOG_DEBUG, "%s: sendto(s_udp=%d, port=%d): %m",
+ 			       "SendNATPMPPublicAddressChangeNotification", sockets[j], NATPMP_PORT);
+ 			return;
+ 		}
+@@ -481,7 +481,7 @@ void SendNATPMPPublicAddressChangeNotifi
+ 		           (struct sockaddr *)&sockname, sizeof(struct sockaddr_in));
+ 		if(n < 0)
+ 		{
+-			syslog(LOG_ERR, "%s: sendto(s_udp=%d, port=%d): %m",
++			syslog(LOG_DEBUG, "%s: sendto(s_udp=%d, port=%d): %m",
+ 			       "SendNATPMPPublicAddressChangeNotification", sockets[j], NATPMP_NOTIF_PORT);
+ 			return;
+ 		}
+--- a/netfilter/iptcrdr.c
++++ b/netfilter/iptcrdr.c
+@@ -715,7 +715,7 @@ delete_filter_rule(const char * ifname,
+ 						continue;
+ 				}
+ 				index = i;
+-				/*syslog(LOG_INFO, "Trying to delete filter rule at index %u", index);*/
++				/*syslog(LOG_DEBUG, "Trying to delete filter rule at index %u", index);*/
+ 				r = delete_rule_and_commit(index, h, miniupnpd_forward_chain, "delete_filter_rule");
+ 				h = NULL;
+ 				break;
+@@ -808,7 +808,7 @@ delete_redirect_and_filter_rules(unsigne
+ #endif
+ 	if(r == 0)
+ 	{
+-		syslog(LOG_INFO, "Trying to delete nat rule at index %u", index);
++		syslog(LOG_DEBUG, "Trying to delete nat rule at index %u", index);
+ 		/* Now delete both rules */
+ 		/* first delete the nat rule */
+ 		h = iptc_init("nat");
+@@ -852,7 +852,7 @@ delete_redirect_and_filter_rules(unsigne
+ 					if(iaddr != e->ip.dst.s_addr)
+ 						continue;
+ 					index = i;
+-					syslog(LOG_INFO, "Trying to delete filter rule at index %u", index);
++					syslog(LOG_DEBUG, "Trying to delete filter rule at index %u", index);
+ 					r = delete_rule_and_commit(index, h, miniupnpd_forward_chain, "delete_filter_rule");
+ 					h = NULL;
+ 					break;
+@@ -910,7 +910,7 @@ delete_redirect_and_filter_rules(unsigne
+ 				}
+ 
+ 				index = i;
+-				syslog(LOG_INFO, "Trying to delete peer rule at index %u", index);
++				syslog(LOG_DEBUG, "Trying to delete peer rule at index %u", index);
+ 				r2 = delete_rule_and_commit(index, h, miniupnpd_nat_postrouting_chain, "delete_peer_rule");
+ 				h = NULL;
+ 				break;
+@@ -962,7 +962,7 @@ delete_redirect_and_filter_rules(unsigne
+ 				if(iaddr != e->ip.src.s_addr)
+ 					continue;
+ 				index = i;
+-				syslog(LOG_INFO, "Trying to delete dscp rule at index %u", index);
++				syslog(LOG_DEBUG, "Trying to delete dscp rule at index %u", index);
+ 				r2 = delete_rule_and_commit(index, h, miniupnpd_nat_chain, "delete_dscp_rule");
+ 				h = NULL;
+ 				break;
+--- a/netfilter/iptpinhole.c
++++ b/netfilter/iptpinhole.c
+@@ -295,14 +295,14 @@ find_pinhole(const char * ifname,
+ 
+ 	if(rem_host && (rem_host[0] != '\0')) {
+ 		if (inet_pton(AF_INET6, rem_host, &saddr) < 1) {
+-			syslog(LOG_WARNING, "Failed to parse INET6 address \"%s\"", rem_host);
++			syslog(LOG_INFO, "Failed to parse INET6 address \"%s\"", rem_host);
+ 			memset(&saddr, 0, sizeof(struct in6_addr));
+ 		}
+ 	} else {
+ 		memset(&saddr, 0, sizeof(struct in6_addr));
+ 	}
+ 	if (inet_pton(AF_INET6, int_client, &daddr) < 1) {
+-		syslog(LOG_WARNING, "Failed to parse INET6 address \"%s\"", int_client);
++		syslog(LOG_INFO, "Failed to parse INET6 address \"%s\"", int_client);
+ 		memset(&daddr, 0, sizeof(struct in6_addr));
+ 	}
+ 	for(p = pinhole_list.lh_first; p != NULL; p = p->entries.le_next) {
+--- a/netfilter_nft/nftnlrdr.c
++++ b/netfilter_nft/nftnlrdr.c
+@@ -353,7 +353,7 @@ delete_redirect_and_filter_rules(unsigne
+ 			}
+ 		}
+ 	} else {
+-		syslog(LOG_WARNING, "%s: redirect rule with eport=%hu proto %d NOT FOUND",
++		syslog(LOG_INFO, "%s: redirect rule with eport=%hu proto %d NOT FOUND",
+ 		       "delete_redirect_and_filter_rules", eport, proto);
+ 	}
+ 
+--- a/netfilter_nft/nftnlrdr_misc.c
++++ b/netfilter_nft/nftnlrdr_misc.c
+@@ -110,7 +110,7 @@ nft_mnl_connect(void)
+ 		return -1;
+ 	}
+ 	mnl_portid = mnl_socket_get_portid(mnl_sock);
+-	syslog(LOG_INFO, "mnl_socket bound, port_id=%u", mnl_portid);
++	syslog(LOG_DEBUG, "mnl_socket bound, port_id=%u", mnl_portid);
+ 	return 0;
+ }
+ 
+@@ -751,7 +751,7 @@ refresh_nft_cache(struct rule_list *head
+ 		errno = 0;
+ 		ret = mnl_cb_run(buf, n, mnl_seq, mnl_portid, table_cb, &data);
+ 		if (ret <= -1 /*== MNL_CB_ERROR*/) {
+-			syslog(LOG_ERR, "%s: mnl_cb_run returned %d: %m",
++			syslog(LOG_DEBUG, "%s: mnl_cb_run returned %d: %m",
+ 			       "refresh_nft_cache", ret);
+ 			return -1;
+ 		}
+@@ -1288,7 +1288,7 @@ nft_send_rule(struct nftnl_rule * rule,
+ 
+ 		result = send_batch(batch);
+ 		if (result < 0) {
+-			syslog(LOG_ERR, "%s(%p, %d, %d) send_batch failed %d",
++			syslog(LOG_DEBUG, "%s(%p, %d, %d) send_batch failed %d",
+ 			       "nft_send_rule", rule, (int)cmd, (int)chain_type, result);
+ 		}
+ 	}
+@@ -1474,7 +1474,7 @@ send_batch(struct mnl_nlmsg_batch *batch
+ 		errno = 0;
+ 		ret = mnl_cb_run(buf, n, 0, mnl_portid, NULL, NULL);
+ 		if (ret <= -1 /*== MNL_CB_ERROR*/) {
+-			syslog(LOG_ERR, "%s: mnl_cb_run returned %d: %m",
++			syslog(LOG_DEBUG, "%s: mnl_cb_run returned %d: %m",
+ 			       "send_batch", ret);
+ 			return -4;
+ 		}
+--- a/netfilter_nft/nftpinhole.c
++++ b/netfilter_nft/nftpinhole.c
+@@ -133,7 +133,7 @@ find_pinhole(const char * ifname,
+ 
+ 	if (rem_host && rem_host[0] != '\0' && rem_host[0] != '*') {
+ 		if (inet_pton(AF_INET6, rem_host, &saddr) < 1) {
+-			syslog(LOG_WARNING, "Failed to parse INET6 address \"%s\"", rem_host);
++			syslog(LOG_INFO, "Failed to parse INET6 address \"%s\"", rem_host);
+ 			memset(&saddr, 0, sizeof(struct in6_addr));
+ 		}
+ 	} else {
+@@ -141,7 +141,7 @@ find_pinhole(const char * ifname,
+ 	}
+ 
+ 	if (inet_pton(AF_INET6, int_client, &daddr) < 1) {
+-		syslog(LOG_WARNING, "Failed to parse INET6 address \"%s\"", int_client);
++		syslog(LOG_INFO, "Failed to parse INET6 address \"%s\"", int_client);
+ 		memset(&daddr, 0, sizeof(struct in6_addr));
+ 	}
+ 
+@@ -163,7 +163,7 @@ find_pinhole(const char * ifname,
+ 		   (0 == memcmp(&daddr, &p->daddr6, sizeof(struct in6_addr)))) {
+ 
+ 			if (sscanf(p->desc, PINEHOLE_LABEL_FORMAT_SKIPDESC, &uid, &ts) != 2) {
+-				syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", p->desc);
++				/*syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", p->desc);*/
+ 				continue;
+ 			}
+ 
+@@ -400,7 +400,7 @@ get_pinhole_info(unsigned short uid,
+ 			if (timestamp) {
+ 				int uid_temp;
+ 				if (sscanf(p->desc, PINEHOLE_LABEL_FORMAT_SKIPDESC, &uid_temp, &ts) != 2) {
+-					syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", p->desc);
++					/*syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", p->desc);*/
+ 					continue;
+ 				}
+ 
+@@ -464,7 +464,7 @@ clean_pinhole_list(unsigned int * next_t
+ 			continue;
+ 
+ 		if (sscanf(p->desc, PINEHOLE_LABEL_FORMAT_SKIPDESC, &uid, &ts) != 2) {
+-			syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", p->desc);
++			/*syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", p->desc);*/
+ 			continue;
+ 		}
+ 
+--- a/pcpserver.c
++++ b/pcpserver.c
+@@ -1094,7 +1094,7 @@ static void CreatePCPMap(pcp_info_t *pcp
+ 	else
+ 		r = CreatePCPMap_NAT(pcp_msg_info);
+ 	pcp_msg_info->result_code = r;
+-	syslog(r == PCP_SUCCESS ? LOG_INFO : LOG_ERR,
++	syslog(LOG_INFO,
+ 	      "PCP MAP: %s mapping %s %hu->%s:%hu '%s'",
+ 	       r == PCP_SUCCESS ? "added" : "failed to add",
+ 	       proto_itoa(pcp_msg_info->protocol),
+@@ -1136,7 +1136,7 @@ static void DeletePCPMap(pcp_info_t *pcp
+ 				if(0 != strcmp(desc, pcp_msg_info->desc)) {
+ 					/* nonce does not match */
+ 					pcp_msg_info->result_code = PCP_ERR_NOT_AUTHORIZED;
+-					syslog(LOG_ERR, "Unauthorized to remove PCP mapping internal port %hu, protocol %s",
++					syslog(LOG_INFO, "Unauthorized to remove PCP mapping internal port %hu, protocol %s",
+ 					       iport, proto_itoa(pcp_msg_info->protocol));
+ 					return;
+ 				} else {
+@@ -1154,14 +1154,14 @@ static void DeletePCPMap(pcp_info_t *pcp
+ 						desc, sizeof(desc),
+ 						NULL /* lifetime */);
+ 		if (uid < 0) {
+-			syslog(LOG_ERR, "Failed to find mapping to %s:%hu, protocol %s",
++			syslog(LOG_INFO, "Failed to find mapping to %s:%hu, protocol %s",
+ 			       pcp_msg_info->mapped_str, iport, proto_itoa(pcp_msg_info->protocol));
+ 			return;
+ 		} else {
+ 			if(0 != strcmp(desc, pcp_msg_info->desc)) {
+ 				/* nonce does not match */
+ 				pcp_msg_info->result_code = PCP_ERR_NOT_AUTHORIZED;
+-				syslog(LOG_ERR, "Unauthorized to remove PCP mapping internal port %hu, protocol %s",
++				syslog(LOG_INFO, "Unauthorized to remove PCP mapping internal port %hu, protocol %s",
+ 				       iport, proto_itoa(pcp_msg_info->protocol));
+ 				return;
+ 			} else {
+@@ -1176,7 +1176,7 @@ static void DeletePCPMap(pcp_info_t *pcp
+ 		syslog(LOG_INFO, "PCP: %s port %hu mapping removed",
+ 		       proto==IPPROTO_TCP?"TCP":"UDP", (pcp_msg_info->is_fw ? iport : eport2));
+ 	} else {
+-		syslog(LOG_ERR, "Failed to remove PCP mapping to %s:%hu %s",
++		syslog(LOG_INFO, "Failed to remove PCP mapping to %s:%hu %s",
+ 		       pcp_msg_info->mapped_str, iport, proto_itoa(proto));
+ 		pcp_msg_info->result_code = PCP_ERR_NO_RESOURCES;
+ 	}
+@@ -1399,7 +1399,7 @@ static int processPCPRequest(void * req,
+ 					CreatePCPMap(pcp_msg_info);
+ 				}
+ 			} else {
+-				syslog(LOG_ERR, "PCP: Invalid PCP v2 MAP message.");
++				syslog(LOG_DEBUG, "PCP: Invalid PCP v2 MAP message.");
+ 				return pcp_msg_info->result_code;
+ 			}
+ 
+@@ -1609,7 +1609,7 @@ int ProcessIncomingPCPPacket(int s, unsi
+ 	if (!GETFLAG(PCP_ALLOWTHIRDPARTYMASK)) {
+ 		lan_addr = get_lan_for_peer(senderaddr);
+ 		if(lan_addr == NULL) {
+-			syslog(LOG_WARNING, "PCP packet sender %s not from a LAN, ignoring",
++			syslog(LOG_DEBUG, "PCP packet sender %s not from a LAN, ignoring",
+ 			       addr_str);
+ 			return 0;
+ 		}
+@@ -1730,7 +1730,7 @@ void PCPSendUnsolicitedAnnounce(int * so
+ 		}
+ 		len = sendto_or_schedule(sockets[i], buff, PCP_MIN_LEN, 0, (struct sockaddr *)&addr, sizeof(struct sockaddr_in));
+ 		if( len < 0 ) {
+-			syslog(LOG_ERR, "PCPSendUnsolicitedAnnounce(sockets[%d]) sendto(): %m", i);
++			syslog(LOG_DEBUG, "PCPSendUnsolicitedAnnounce(sockets[%d]) sendto(): %m", i);
+ 		}
+ 	}
+ #ifdef ENABLE_IPV6
+@@ -1741,7 +1741,7 @@ void PCPSendUnsolicitedAnnounce(int * so
+ 		addr6.sin6_port = htons(5350);
+ 		len = sendto_or_schedule(socket6, buff, PCP_MIN_LEN, 0, (struct sockaddr *)&addr6, sizeof(struct sockaddr_in6));
+ 		if( len < 0 ) {
+-			syslog(LOG_ERR, "PCPSendUnsolicitedAnnounce() IPv6 sendto(): %m");
++			syslog(LOG_DEBUG, "PCPSendUnsolicitedAnnounce() IPv6 sendto(): %m");
+ 		}
+ 	}
+ #endif /* ENABLE_IPV6 */
+--- a/pf/obsdrdr.c
++++ b/pf/obsdrdr.c
+@@ -602,7 +602,7 @@ delete_nat_rule(const char * ifname, uns
+ 			pr.nr = i;
+ 			if(ioctl(dev, DIOCCHANGERULE, &pr) < 0)
+ 			{
+-				syslog(LOG_ERR, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
++				syslog(LOG_DEBUG, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
+ 				r = -1;
+ 			}
+ 			else
+@@ -1292,7 +1292,7 @@ priv_delete_redirect_rule_check_desc(con
+ 			pr.nr = i;
+ 			if(ioctl(dev, DIOCCHANGERULE, &pr) < 0)
+ 			{
+-				syslog(LOG_ERR, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
++				syslog(LOG_DEBUG, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
+ 				r = -1;
+ 				break;
+ 			}
+@@ -1377,7 +1377,7 @@ syslog(LOG_DEBUG, "%2d port=%hu proto=%d
+ 			pr.nr = i;
+ 			if(ioctl(dev, DIOCCHANGERULE, &pr) < 0)
+ 			{
+-				syslog(LOG_ERR, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
++				syslog(LOG_DEBUG, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
+ 				r = -1;
+ 			}
+ 			else
+--- a/pf/pfpinhole.c
++++ b/pf/pfpinhole.c
+@@ -246,12 +246,12 @@ int find_pinhole(const char * ifname,
+ 		   (0 == memcmp(&daddr, &RULE.dst.addr.v.a.addr.v6, sizeof(struct in6_addr)))) {
+ #ifdef USE_LIBPFCTL
+ 			if(sscanf(RULE.label[0], PINEHOLE_LABEL_FORMAT_SKIPDESC, &uid, &ts) != 2) {
+-				syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label[0]);
++				/*syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label[0]);*/
+ 				continue;
+ 			}
+ #else /* USE_LIBPFCTL */
+ 			if(sscanf(RULE.label, PINEHOLE_LABEL_FORMAT_SKIPDESC, &uid, &ts) != 2) {
+-				syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label);
++				/*syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label);*/
+ 				continue;
+ 			}
+ #endif /* USE_LIBPFCTL */
+@@ -360,7 +360,7 @@ int delete_pinhole(unsigned short uid)
+ 			pr.action = PF_CHANGE_REMOVE;
+ 			pr.nr = i;
+ 			if(ioctl(dev, DIOCCHANGERULE, &pr) < 0) {
+-				syslog(LOG_ERR, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
++				syslog(LOG_DEBUG, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
+ 				release_ticket(dev, tnum);
+ 				return -1;
+ 			}
+@@ -565,7 +565,7 @@ int clean_pinhole_list(unsigned int * ne
+ 			return -1;
+ 		}
+ 		if(sscanf(RULE.label[0], PINEHOLE_LABEL_FORMAT_SKIPDESC, &uid, &ts) != 2) {
+-			syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label[0]);
++			/*syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label[0]);*/
+ 			continue;
+ 		}
+ #else /* USE_LIBPFCTL */
+@@ -576,7 +576,7 @@ int clean_pinhole_list(unsigned int * ne
+ 			return -1;
+ 		}
+ 		if(sscanf(RULE.label, PINEHOLE_LABEL_FORMAT_SKIPDESC, &uid, &ts) != 2) {
+-			syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label);
++			/*syslog(LOG_DEBUG, "rule with label '%s' is not a IGD pinhole", RULE.label);*/
+ 			continue;
+ 		}
+ #endif /* USE_LIBPFCTL */
+@@ -602,7 +602,7 @@ int clean_pinhole_list(unsigned int * ne
+ 			pr.action = PF_CHANGE_REMOVE;
+ 			pr.nr = i;
+ 			if(ioctl(dev, DIOCCHANGERULE, &pr) < 0) {
+-				syslog(LOG_ERR, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
++				syslog(LOG_DEBUG, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
+ 				release_ticket(dev, tnum);
+ 				return -1;
+ 			}
+--- a/upnphttp.c
++++ b/upnphttp.c
+@@ -545,7 +545,7 @@ ProcessHTTPPOST_upnphttp(struct upnphttp
+ 		if(h->req_soapActionOff > 0)
+ 		{
+ 			/* we can process the request */
+-			syslog(LOG_INFO, "SOAPAction: %.*s",
++			syslog(LOG_DEBUG, "SOAPAction: %.*s",
+ 			       h->req_soapActionLen, h->req_buf + h->req_soapActionOff);
+ 			ExecuteSoapAction(h,
+ 				h->req_buf + h->req_soapActionOff,
+@@ -845,7 +845,7 @@ ProcessHttpQuery_upnphttp(struct upnphtt
+ 	for(i = 0; i<15 && *p != '\r'; i++)
+ 		HttpVer[i] = *(p++);
+ 	HttpVer[i] = '\0';
+-	syslog(LOG_INFO, "HTTP REQUEST from %s : %s %s (%s)",
++	syslog(LOG_DEBUG, "HTTP REQUEST from %s : %s %s (%s)",
+ 	       h->clientaddr_str, HttpCommand, HttpUrl, HttpVer);
+ 	ParseHttpHeaders(h);
+ 	if(h->req_contentlen > CONTENT_LENGTH_LIMIT) {
+@@ -931,7 +931,7 @@ ProcessHttpQuery_upnphttp(struct upnphtt
+ 			return;
+ 		}
+ #endif
+-		syslog(LOG_NOTICE, "%s not found, responding ERROR 404", HttpUrl);
++		syslog(LOG_DEBUG, "%s not found, responding ERROR 404", HttpUrl);
+ 		Send404(h);
+ 	}
+ #ifdef ENABLE_EVENTS
+--- a/upnppinhole.c
++++ b/upnppinhole.c
+@@ -110,7 +110,7 @@ lease_file6_add(const char * rem_client,
+ 
+ 	fd = fopen( lease_file6, "a");
+ 	if (fd==NULL) {
+-		syslog(LOG_ERR, "could not open lease file: %s", lease_file);
++		syslog(LOG_DEBUG, "could not open lease file: %s", lease_file);
+ 		return -1;
+ 	}
+ 
+@@ -398,7 +398,7 @@ int lease_file6_expire(void)
+ 		// Internal Host
+ 		p = strchr(line, ';');
+ 		if(!p) {
+-			syslog(LOG_ERR, "unrecognized data in lease file");
++			syslog(LOG_DEBUG, "unrecognized data in lease file (bug)");
+ 			continue;
+ 		}
+ 		*(p++) = '\0';
+@@ -489,7 +489,7 @@ int reload_from_lease_file6(void)
+ 	if(!lease_file6) return -1;
+ 	fd = fopen( lease_file6, "r");
+ 	if (fd==NULL) {
+-		syslog(LOG_ERR, "could not open lease file: %s", lease_file6);
++		syslog(LOG_DEBUG, "could not open lease file: %s", lease_file6);
+ 		return -1;
+ 	}
+ 	if(unlink(lease_file6) < 0) {
+@@ -575,7 +575,7 @@ int reload_from_lease_file6(void)
+ 
+ 		if(timestamp > 0) {
+ 			if(timestamp <= (unsigned int)current_unix_time) {
+-				syslog(LOG_NOTICE, "already expired lease in lease file");
++				syslog(LOG_INFO, "already expired lease in lease file");
+ 				continue;
+ 			} else {
+ 				leaseduration = timestamp - current_unix_time;
+--- a/upnpredirect.c
++++ b/upnpredirect.c
+@@ -67,7 +67,7 @@ lease_file_add(const char * rhost,
+ 
+ 	fd = fopen( lease_file, "a");
+ 	if (fd==NULL) {
+-		syslog(LOG_ERR, "could not open lease file: %s", lease_file);
++		syslog(LOG_DEBUG, "could not open lease file: %s", lease_file);
+ 		return -1;
+ 	}
+ 
+@@ -196,7 +196,7 @@ int reload_from_lease_file(void)
+ 	if(!lease_file) return -1;
+ 	fd = fopen( lease_file, "r");
+ 	if (fd==NULL) {
+-		syslog(LOG_ERR, "could not open lease file: %s", lease_file);
++		syslog(LOG_DEBUG, "could not open lease file: %s", lease_file);
+ 		return -1;
+ 	}
+ 	if(unlink(lease_file) < 0) {
+@@ -266,7 +266,7 @@ int reload_from_lease_file(void)
+ 			timestamp += current_time;	/* convert to our time */
+ #else
+ 			if(timestamp <= (unsigned int)current_unix_time) {
+-				syslog(LOG_NOTICE, "already expired lease in lease file (%hu=>%s:%hu %s)",
++				syslog(LOG_INFO, "already expired lease in lease file (%hu=>%s:%hu %s)",
+ 				       eport, iaddr, iport, proto);
+ 				continue;
+ 			} else {
+@@ -425,7 +425,7 @@ upnp_redirect(const char * rhost, unsign
+ #endif /* CHECK_PORTINUSE */
+ 	} else {
+ 		timestamp = (leaseduration > 0) ? upnp_time() + leaseduration : 0;
+-		syslog(LOG_INFO, "redirecting port %hu to %s:%hu protocol %s for: %s",
++		syslog(LOG_DEBUG, "redirecting port %hu to %s:%hu protocol %s for: %s",
+ 			eport, iaddr, iport, protocol, desc);
+ 		return upnp_redirect_internal(rhost, eport, iaddr, iport, proto,
+ 		                              desc, timestamp);
+@@ -675,7 +675,7 @@ get_upnp_rules_state_list(int max_rules_
+ 	{
+ 		if(tmp->to_remove)
+ 		{
+-			syslog(LOG_NOTICE, "remove port mapping %hu %s because it has expired",
++			syslog(LOG_INFO, "remove port mapping %hu %s because it has expired",
+ 			       tmp->eport, proto_itoa(tmp->proto));
+ 			_upnp_delete_redir(tmp->eport, tmp->proto);
+ 			*p = tmp->next;
+--- a/upnpsoap.c
++++ b/upnpsoap.c
+@@ -412,18 +412,9 @@ GetExternalIPAddress(struct upnphttp * h
+ 	else
+ 	{
+ 		struct in_addr addr;
+-		if(getifaddr(ext_if_name, ext_ip_addr, INET_ADDRSTRLEN, &addr, NULL) < 0)
+-		{
+-			syslog(LOG_ERR, "Failed to get ip address for interface %s",
+-				ext_if_name);
+-			ext_ip_addr[0] = '\0';
+-		} else if (addr_is_reserved(&addr)) {
+-			if (GETFLAG(ALLOWPRIVATEIPV4MASK)) {
+-				syslog(LOG_WARNING, "IGNORED : private/reserved address %s is not suitable for external IP", ext_ip_addr);
+-			} else {
+-				syslog(LOG_NOTICE, "private/reserved address %s is not suitable for external IP", ext_ip_addr);
++		if (getifaddr(ext_if_name, ext_ip_addr, INET_ADDRSTRLEN, &addr, NULL) < 0 ||
++			(addr_is_reserved(&addr) && !GETFLAG(ALLOWPRIVATEIPV4MASK))) {
+ 				ext_ip_addr[0] = '\0';
+-			}
+ 		}
+ 	}
+ #else
+@@ -545,7 +536,7 @@ AddPortMapping(struct upnphttp * h, cons
+ 		}
+ 		else
+ 		{
+-			syslog(LOG_ERR, "Failed to convert hostname '%s' to ip address", int_ip);
++			syslog(LOG_INFO, "Failed to convert hostname '%s' to ip address", int_ip);
+ 			ClearNameValueList(&data);
+ 			SoapError(h, 402, "Invalid Args");
+ 			return;
+@@ -750,7 +741,7 @@ AddAnyPortMapping(struct upnphttp * h, c
+ 		}
+ 		else
+ 		{
+-			syslog(LOG_ERR, "Failed to convert hostname '%s' to ip address", int_ip);
++			syslog(LOG_INFO, "Failed to convert hostname '%s' to ip address", int_ip);
+ 			ClearNameValueList(&data);
+ 			SoapError(h, 402, "Invalid Args");
+ 			return;
+@@ -913,7 +904,7 @@ GetSpecificPortMappingEntry(struct upnph
+ 	}
+ 	else
+ 	{
+-		syslog(LOG_INFO, "%s: rhost='%s' %s %s found => %s:%u desc='%s' duration=%u",
++		syslog(LOG_DEBUG, "%s: rhost='%s' %s %s found => %s:%u desc='%s' duration=%u",
+ 		       action,
+ 		       r_host ? r_host : "NULL", ext_port, protocol, int_ip,
+ 		       (unsigned int)iport, desc, leaseduration);
+@@ -1003,7 +994,7 @@ DeletePortMapping(struct upnphttp * h, c
+ 		return;
+ 	}
+ 
+-	syslog(LOG_INFO, "%s: external port: %hu, protocol: %s",
++	syslog(LOG_DEBUG, "%s: external port: %hu, protocol: %s",
+ 		action, eport, protocol);
+ 
+ 	/* if in secure mode, check the IP
+@@ -1125,7 +1116,7 @@ DeletePortMappingRange(struct upnphttp *
+ 	for(i = 0; i < number; i++)
+ 	{
+ 		r = upnp_delete_redirection(port_list[i], protocol);
+-		syslog(LOG_INFO, "%s: deleting external port: %hu, protocol: %s: %s",
++		syslog(LOG_DEBUG, "%s: deleting external port: %hu, protocol: %s: %s",
+ 		       action, port_list[i], protocol, r < 0 ? "failed" : "ok");
+ 	}
+ 	free(port_list);
+@@ -1196,7 +1187,7 @@ GetGenericPortMappingEntry(struct upnpht
+ 		return;
+ 	}
+ 
+-	syslog(LOG_INFO, "%s: index=%d", action, (int)index);
++	syslog(LOG_DEBUG, "%s: index=%d", action, (int)index);
+ 
+ 	rhost[0] = '\0';
+ 	r = upnp_get_redirection_infos_by_index((int)index, &eport, protocol, &iport,
+@@ -1777,7 +1768,7 @@ PinholeVerification(struct upnphttp * h,
+ 			struct addrinfo hints, *ai, *p;
+ 			int found = 0;
+ 
+-			syslog(LOG_INFO, "%s: InternalClient %s is not an IPv6, assume hostname and convert",
++			syslog(LOG_DEBUG, "%s: InternalClient %s is not an IPv6, assume hostname and convert",
+ 			       "PinholeVerification", int_ip);
+ 
+ 			memset(&hints, 0, sizeof(hints));
+@@ -1788,7 +1779,7 @@ PinholeVerification(struct upnphttp * h,
+ 			r = getaddrinfo(int_ip, NULL, &hints, &ai);
+ 			if (r != 0)
+ 			{
+-				syslog(LOG_WARNING, "%s: Failed to convert hostname '%s' to IP address : %s",
++				syslog(LOG_INFO, "%s: Failed to convert hostname '%s' to IP address : %s",
+ 				       "PinholeVerification", int_ip, gai_strerror(r));
+ 				SoapError(h, 402, "Invalid Args");
+ 				return -1;
+@@ -1803,11 +1794,11 @@ PinholeVerification(struct upnphttp * h,
+ 
+ 						if (inet_ntop(AF_INET6, &result_ip, int_ip_resolved, INET6_ADDRSTRLEN) == NULL)
+ 						{
+-							syslog(LOG_WARNING, "%s: inet_ntop(): %m", "PinholeVerification");
++							syslog(LOG_INFO, "%s: inet_ntop(): %m", "PinholeVerification");
+ 							SoapError(h, 501, "Action Failed");
+ 							return -1;
+ 						}
+-						syslog(LOG_INFO, "%s: InternalClient \"%s\" resolved as %s",
++						syslog(LOG_DEBUG, "%s: InternalClient \"%s\" resolved as %s",
+ 						       "PinholeVerification", int_ip, int_ip_resolved);
+ 						found = 1;
+ 					}
+@@ -1823,7 +1814,7 @@ PinholeVerification(struct upnphttp * h,
+ 			freeaddrinfo(ai);
+ 			if (!found)
+ 			{
+-				syslog(LOG_NOTICE, "%s: No IPv6 address for hostname '%s'",
++				syslog(LOG_INFO, "%s: No IPv6 address for hostname '%s'",
+ 				       "PinholeVerification", int_ip);
+ 				SoapError(h, 402, "Invalid Args");
+ 				return -1;
+@@ -1841,7 +1832,7 @@ PinholeVerification(struct upnphttp * h,
+ 		/* no need to copy to int_ip_resolved, but we still need to fill result_ip up */
+ 		if (inet_pton(AF_INET6, int_ip, &result_ip) <= 0)
+ 		{
+-			syslog(LOG_ERR, "inet_pton(%s)", int_ip);
++			syslog(LOG_DEBUG, "inet_pton(%s)", int_ip);
+ 			SoapError(h, 501, "Action Failed");
+ 			return -1;
+ 		}
+@@ -1974,7 +1965,7 @@ AddPinhole(struct upnphttp * h, const ch
+ 					inet_ntop(AF_INET6,
+ 					          &(((struct sockaddr_in6 *)p->ai_addr)->sin6_addr),
+ 					          rem_ip, sizeof(rem_ip));
+-					syslog(LOG_INFO, "resolved '%s' to '%s'", rem_host, rem_ip);
++					syslog(LOG_DEBUG, "resolved '%s' to '%s'", rem_host, rem_ip);
+ 					rem_host = rem_ip;
+ 					break;
+ 				}
+@@ -1983,7 +1974,7 @@ AddPinhole(struct upnphttp * h, const ch
+ 		}
+ 		else
+ 		{
+-			syslog(LOG_WARNING, "AddPinhole : getaddrinfo(%s) : %s",
++			syslog(LOG_INFO, "AddPinhole : getaddrinfo(%s) : %s",
+ 			       rem_host, gai_strerror(err));
+ #if 0
+ 			SoapError(h, 402, "Invalid Args");
+@@ -2696,7 +2687,7 @@ SoapError(struct upnphttp * h, int errCo
+ 	char body[2048];
+ 	int bodylen;
+ 
+-	syslog(LOG_INFO, "Returning UPnPError %d: %s", errCode, errDesc);
++	syslog(LOG_DEBUG, "Returning UPnPError %d: %s", errCode, errDesc);
+ 	bodylen = snprintf(body, sizeof(body), resp, errCode, errDesc);
+ 	if(bodylen < 0) {
+ 		syslog(LOG_ERR, "snprintf() returned %d", bodylen);
+--- a/upnpstun.c
++++ b/upnpstun.c
+@@ -10,9 +10,10 @@
+ /*! \file upnpstun.c
+  * \brief STUN client implementation
+  *
+- * - https://datatracker.ietf.org/doc/html/rfc3489 (obsolete)
+- * - https://datatracker.ietf.org/doc/html/rfc5389
+- * - https://datatracker.ietf.org/doc/html/rfc5780 (experimental)
++ * - https://www.rfc-editor.org/info/rfc3489/ (classic STUN, obsoleted)
++ * - https://www.rfc-editor.org/info/rfc5389/ (STUN obsoleted)
++ * - https://www.rfc-editor.org/info/rfc5780/ (STUN NAT behavior, experimental)
++ * - https://www.rfc-editor.org/info/rfc8489/ (STUN current, not implemented)
+  */
+ #include <sys/select.h>
+ #include <sys/time.h>
+@@ -124,8 +125,8 @@ static int resolve_stun_host(const char
+ 
+ 	r = getaddrinfo(stun_host, service, &hints, &result);
+ 	if (r != 0) {
+-		syslog(LOG_ERR, "%s: getaddrinfo(%s, %s, ...) failed : %s",
+-		       "resolve_stun_host", stun_host, service, gai_strerror(r));
++		syslog(LOG_ERR, "STUN: Failed to resolve hostname (%s) to IPv4 address (%s)",
++		       stun_host, gai_strerror(r));
+ 		errno = EHOSTUNREACH;
+ 		return -1;
+ 	}
+@@ -149,8 +150,8 @@ static int resolve_stun_host(const char
+ 	} else {
+ 		char addr_str[48];
+ 		if (sockaddr_to_string((struct sockaddr *)sock_addr, addr_str, sizeof(addr_str)) > 0) {
+-			syslog(LOG_DEBUG, "%s: %s:%s => %s",
+-			       "resolve_stun_host", stun_host, service, addr_str);
++			syslog(LOG_DEBUG, "%s: Resolve hostname (%s) and connect to %s",
++				"resolve_stun_host", stun_host, addr_str);
+ 		}
+ 	}
+ 
+@@ -274,7 +275,7 @@ static int wait_for_stun_responses(int f
+ 			FD_SET(fds[i], &fdset);
+ 		}
+ 
+-		syslog(LOG_DEBUG, "%s: waiting %ld secs and %ld usecs", "wait_for_stun_responses", (long)timeout.tv_sec, (long)timeout.tv_usec);
++		syslog(LOG_DEBUG, "%s: waiting %ld.%ld s", "wait_for_stun_responses", (long)timeout.tv_sec, (long)timeout.tv_usec);
+ 		ret = select(max_fd+1, &fdset, NULL, NULL, &timeout);
+ 		if (ret < 0) {
+ 			if (errno == EINTR)
+@@ -484,7 +485,8 @@ static int parse_stun_response(unsigned
+ 	if (!have_other_address && have_address) {
+ 		syslog(LOG_ERR, "STUN server not supported, not returning "
+ 			"OTHER-ADDRESS / support CHANGE-REQUEST's required for "
+-			"endpoint-independent (1:1) CGNAT filtering tests per RFC 5780.");
++			"endpoint-independent (1:1) CGNAT filtering tests per RFC 5780, "
++			"see compatible servers in sample config");
+ 		return -1;
+ 	}
+ 	return (have_address && have_other_address) ? 0 : -1;
+@@ -529,13 +531,13 @@ int perform_stun(const char *if_name, co
+ 
+ 		/* Determine unrestricted endpoint-independent (1:1) CGNAT in two STUN requests per RFC 5780 4.4 test I/II */
+ 		/* 1. Connectivity (binding, detect public IPv4), 2. CHANGE-REQUEST with change-IP and change-port set */
+-		/* https://datatracker.ietf.org/doc/html/rfc5780#section-4.4 */
++		/* https://www.rfc-editor.org/info/rfc5780/#section-4.4 */
+ 		fill_request(requests[i], i, i);
+ 		transaction_ids[i] = requests[i]+8;
+ 	}
+ 
+-	syslog(LOG_INFO, "%s: local ports %hu %hu %hu %hu",
+-	       "perform_stun", local_ports[0], local_ports[1],
++	syslog(LOG_INFO, "STUN: Testing with local UDP ports %hu %hu %hu %hu",
++		local_ports[0], local_ports[1],
+ 	       local_ports[2], local_ports[3]);
+ 
+ 	/* Unblock local ports */
+@@ -600,16 +602,15 @@ int perform_stun(const char *if_name, co
+ 	if (mapped_addrs_count < 4) {
+ 		/* We have not received all four responses,
+ 		 * therefore NAT or firewall is doing some filtering */
+-		syslog(LOG_NOTICE, "%s: %d response out of 4 received",
+-		       "perform_stun", mapped_addrs_count);
++		syslog(LOG_NOTICE, "STUN: Filtering detected as %d/4 responses received (1: IPv4 detection, 2-4: filtering tests)",
++			mapped_addrs_count);
+ 		*restrictive_nat = 1;
+ 	}
+ 
+ 	if (memcmp(&remote_addr, &peer_addrs[0], sizeof(peer_addrs[0])) != 0) {
+ 		/* We received STUN response from different address
+ 		 * even we did not asked for it, so some strange NAT is active */
+-		syslog(LOG_NOTICE, "%s: address changed",
+-		       "perform_stun");
++		syslog(LOG_NOTICE, "STUN: Public IPv4 change detected in responses");
+ 		*restrictive_nat = 1;
+ 	}
+ 
+@@ -621,8 +622,8 @@ int perform_stun(const char *if_name, co
+ 			sockaddr_to_string((struct sockaddr *)&mapped_addrs[i], mapped_addr_str, sizeof(mapped_addr_str));
+ 			/* External IP address or port was changed,
+ 			 * therefore symmetric NAT is active */
+-			syslog(LOG_NOTICE, "%s: #%d external address or port changed : %s:%hu => %s",
+-			       "perform_stun", i, inet_ntoa(*ext_addr), local_ports[i], mapped_addr_str);
++			syslog(LOG_NOTICE, "STUN: Public IPv4/port change detected in response #%d (%s:%hu => %s)",
++				i+1, inet_ntoa(*ext_addr), local_ports[i], mapped_addr_str);
+ 			*restrictive_nat = 1;
+ 		}
+ 	}


### PR DESCRIPTION
As this PR is extensive, the descriptions of the individual commits are collapsed here:

<details><summary><b>0. Update to 2.3.9 to fix issues, refresh building (merged <a href="https://github.com/openwrt/packages/commit/70ce349f1c9d915d4f3f49758a3aff2bb83664db"><tt>70ce349</tt></a> 2025-12-24, in 24.10/25.12 packages 2025-12-30)</b></summary>

- Update daemon to 2.3.9 to fix removal of nftables rules in `upnp_forward` and return the correct internal port; also resulted in the excessive opening of new ports. Accept interface names starting with digits
- Build from GitHub releases to get a reliable HTTPS server, as the HTTP-only/HTTPS mirror were only available ~85%/77% over 3 months https://github.com/miniupnp/miniupnp/issues/770 https://stats.uptimerobot.com/DwGDxUB914
- Build daemon with `--disable-pppconn` to remove the old/IGDv1-only extra WANPPPConnection SSDP announcements workaround not included in other implementations since >15y
- Build daemon with `--vendorcfg` to allow customisation of the router/friendly name (+5 potential options) displayed in Windows Explorer, 384 bytes extra required on ARMv7 (binary)
- Remove old (iptables variant only) patches, as no longer needed
- Remove `clean_ruleset_interval/threshold` UCI config options as not standard/working since OpenWrt 22.03, as nftables not supported

Fixes: https://github.com/openwrt/openwrt/issues/18011
Fixes: https://github.com/openwrt/luci/issues/7759
Fixes: https://github.com/openwrt/packages/issues/26352
</details>

<details><summary><b>1. Update to 2.3.11 to fix issues</b></summary>

Update daemon to 2.3.11 to fix multiple issues, including security-related ones

Link: https://www.cve.org/CVERecord?id=CVE-2026-5720
Link: https://github.com/miniupnp/miniupnp/issues/898
</details>

<details><summary><b><i>2. Patch for UPnP IGDv2 Microsoft/Apple compatibility</i></b></summary>

- Add workaround to list port maps with the Windows IGDv2-incompatible client by returning an infinite (0) lease duration. To fix listing and editing via GUI (Explorer/Network), if daemon was compiled with IGDv2
- Extend detection to older versions of Windows and add Xbox
- Detect Apple IGDv2-incompatible clients and apply existing workaround, that only caused problems if PCP/NAT-PMP (prioritised) was disabled

(to merge with prior)

Link: https://github.com/Self-Hosting-Group/miniupnp/tree/upnp-igdv2-compat
Link: https://github.com/Self-Hosting-Group/wiki/wiki/Port-Mapping-Protocols-Overview#compatibility-issues
</details>

<details><summary><b><i>3. Patch to improve logging</i></b></summary>

- Clearer logging of enabled protocols/ports, IPv6 mapping, and UPnP IGD compatibility mode… in start banner
- Log warnings with an enabled allow third-party mapping option
- Change the log level (less verbose) of many internal or normally occurring messages, and some error messages, without functional restrictions, to DEBUG, client requests/actions and their errors to INFO, and only daemon-wide messages to NOTICE/WARNING/ERR…
- Comment out some log-filling messages when internal interfaces lose link, and for e.g. `rule with label '%s' is not a IGD pinhole`, as normally occurring

(to merge with prior)

Fixes: https://github.com/openwrt/packages/issues/17601
Fixes: https://github.com/openwrt/packages/issues/26483
Link: https://github.com/Self-Hosting-Group/miniupnp/tree/improve-logging
</details>

<details><summary><b>4. Package revision and new UCI options</b></summary>

The following settings UCI options been added or changed, and the previous options are migrated on updating:

upnpd.config UCI options     | Change                    | Previous name
-----------------------------|---------------------------|--------------
enabled                      | Match default         (1) |
enable_protocols=upnp-igd    | Combined option           | enable_upnp=1
enable_protocols=pcp+nat-pmp | Combined option           | enable_natpmp=1
allow_cgnat                  | Accept extra values   (2) | use_stun
stun_host                    | Accept port inclusion (3) |
stun_port                    | Removed, included in host |
allow_third_party_mapping=0  | Inverted/extended to PCP  | secure_mode=1
log_output                   | Allow info log level      |
lease_file                   | Set by default + IPv6 (4) | upnp_lease_file
upnp_igd_compat=igdv1        | Renamed/match default (1) | igdv1=1
download_kbps                | In kbit/s and renamed (5) | download
upload_kbps                  | In kbit/s and renamed (5) | upload
friendly_name                | New option, router name   |
http_port                    | Renamed, rem. if default  | port
notify_interval              | Removed if <900s, minimum |
internal_iface               | Migrated, new section     |

internal_network UCI options | Change                    | Previous name
-----------------------------|---------------------------|--------------
interface                    | New option                |
access_defaults              | New option            (6) |
accept_ports                 | New option            (6) |
reject_ports                 | New option            (7) |
check_acl                    | New option            (6) |

Notes:
1. Init UCI default now matches LuCI and initial config file defaults for: enabled=0 and upnp_igd_compat=igdv1
2. Accept extra values for IPv4 CGNAT use, migrate option from X-Wrt and only use STUN when necessary with a private/CGNAT external IPv4
3. Remove known unsupported STUN servers and set compatible by default
4. Configure undocumented daemon option `lease_file6=${lease_file}-ipv6` so that active IPv6 port maps are not lost when service restarts, e.g. by deleting an active port map. Remove option if UCI default set
5. Gets converted, config file now defaults to interface link speed instead of 8/4 Mbit/s, which is removed on migration
6. New options added for default ports that all devices on a network can map, client-specific permissions using the access control list (ACL) can extend/override the defaults. Access defaults: accept-high-ports accept-web+high-ports/accept-web-ports/accept-all-ports
7. Reject ports; overrides other settings. By default reject unsafe: FTP (21), Telnet (23), DCE/NetBIOS/SMB (135/137-139/445), RDP (3389)

Code refactoring:
- Add a function for logging and output to stderr, and extend logging
- Revise daemon init/config-gen slightly by declare all UCI options (incl. booleans) according to the same principle and remove `upnpd_write_bool`
- Document and reformat default `/etc/config/upnpd` UCI config file
- Don't configure/flush unnecessary `upnp_postrouting` nftables chain

Fixes: https://github.com/openwrt/packages/issues/17413
Fixes: https://github.com/openwrt/packages/issues/29314
Fixes: https://github.com/openwrt/packages/pull/28644
Depends on: https://github.com/openwrt/luci/pull/8415
</details>

<details><summary><b><i>5. Group/rearrange config-gen, refactoring</i></b></summary>

- Group and rearrange UCI option declaration and config-gen by function/LuCI UI, and comment
- Encode required XML entities of text UPnP IGD config options until the daemon does so using the created function `xml_encode`
- Only generate UPnP IGD config if the protocol is enabled

(to merge with prior)
</details>

<details><summary><b><i>6. Rename UCI section to settings v2.0</i></b></summary>

Rename UCI section `config` (v1.0) -> `settings` (v2.0), helps on migration and to distinguish the updated config from the previous one

(to merge with prior)
</details>

<details><summary><b><i>7. Update ACL options, migrate section</i></b></summary>

- The ACL is now rejected last if not accepted by access defaults. Add (disabled) ACL template entries on migration
- Migrate ACL entries to the new section name `acl_entry`
- The following ACL UCI options been added or changed, and the previous options are migrated on updating:

acl_entry UCI options       | Change                     | Previous name
----------------------------|----------------------------|--------------
action                      | New/updated values     (1) |
int_port                    | Remove colon separator (2) | int_ports
ext_port                    | Remove colon separator (2) | ext_ports
descr_filter                | New option             (3) |

1. Allow disabled, and update action option to use the nftables terms (allow/deny -> accept/reject). To avoid adding inverted actions when changing via LuCI, ensure any missing are set, as LuCI and UCI had not matching action defaults. Missing actions are now ignored/logged
2. Ensure that the hyphen (-) is only used as a port range separator by migration, as the colon (:) is not valid in LuCI
3. Add missing UCI option to set a regular expression to check for a UPnP IGD IPv4 port map description, and fix the current collision with the comment field which was not noticed due to a daemon bug https://github.com/openwrt/packages/pull/24495 https://github.com/miniupnp/miniupnp/pull/853

- Refactoring by adding a more universal usable `is_port_or_range` function instead of `upnpd_get_port_range` and check if it has a valid range, and removes a shellcheck warning
- Rename `conf_rule_add` function to `upnpd_add_acl_entry`

(to merge with prior)
</details>

<details><summary><b><i>8. Separate service start and config-gen</i></b></summary>

- Remove `config_foreach upnpd "upnpd"` and replace it with regular function call, as init was not designed for a multi-instance setup, as the same `tmpconf` will be used/overwritten, and non-anonymous section
- Move code to make the custom vs. config file generation decision earlier, and only perform external interface detection with the second one, and rename function `upnpd` to `upnpd_generate_config`
- Replace unnecessary `if` cases with `elif` in init/hotplug
- Exit with 1 on errors to get an inactive service status
- Use `procd_add_reload_trigger "firewall"` instead of listening `/etc/config/firewall`

(to merge with prior)
</details>

<details><summary><b><i>9. Rearrange init, format `firewall3.include`</i></b></summary>

- Arrange `start_service` and main init functions first
- Format `firewall3.include` using shfmt

(to merge with prior)
</details>

<details><summary><b><i>10. Service-wide access control settings</i></b></summary>

This implements variant B

upnpd.settings UCI options   | Change                    | Previous name
-----------------------------|---------------------------|--------------
access_defaults              | New option            (1) |
accept_ports                 | New option            (1) |
reject_ports                 | New option            (2) |
check_acl                    | New option            (1) |

Notes:
1. New options added for default ports that all devices can map, client-specific permissions using the access control list (ACL) can extend/override the defaults. Access defaults: accept-high-ports accept-web+high-ports/accept-web-ports/accept-all-ports
2. Reject ports; overrides other settings. By default reject unsafe: FTP (21), Telnet (23), DCE/NetBIOS/SMB (135/137-139/445), RDP (3389)

(to merge with prior)
</details>

(The italic commits are intended to be merged with the prior ones after review)

#### Screenshots

The new service-wide access control functionality… can best be described using the LuCI screenshots:

<details><summary><b>New Access Control tab</b></summary>

<img width="940" height="707" alt="luci-access-control" src="https://github.com/user-attachments/assets/86a57126-6437-489e-bad6-b957e7fd33d1" />
</details>

<details><summary><b>Advanced Settings with new CGNAT functionality</b></summary>

<img width="940" height="389" alt="luci-advanced" src="https://github.com/user-attachments/assets/1bd3ad2b-b7b7-4af0-9f24-2c5e217a49ea" />
</details>

<details><summary><b>UPnP IGD Adjustments tab (new)</b></summary>

<img width="940" height="440" alt="luci-igd" src="https://github.com/user-attachments/assets/cea2bf80-1ced-4f26-baa8-907f6d5976b8" />
</details>

<details><summary><b>LuCI notification if the related package is not updated</b></summary>

<img width="940" height="107" alt="luci-notification" src="https://github.com/user-attachments/assets/6f813b44-83d5-4d34-99a3-afb7f6d03c02" />
</details>

<details><summary><b>Full LuCI screenshot</b></summary>

<img width="940" height="642" alt="luci-screenshot" src="https://github.com/user-attachments/assets/c627c93c-b1a3-4aeb-b292-856ed004714e" />
</details>

Depends on LuCI PR: https://github.com/openwrt/luci/pull/8415
Tested on: OpenWrt 24.10.8/25.12.5 with iptables/nftables

**miniupnpd: Core functionality issues**
https://github.com/Self-Hosting-Group/miniupnpd-issues

The Port Control Protocol (PCP) is the successor to NAT-PMP, shares similar protocol concepts and packet formats, but supports IPv6 port mapping and options/extensions. For more information, see:
**Port Mapping Protocols Overview and Comparison 2026+: About UPnP IGD & PCP/NAT-PMP**
https://github.com/Self-Hosting-Group/wiki/wiki/Port-Mapping-Protocols-Overview