### PR TITLE
net-snmp: add distro extend and use br-lan engineidnic

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.9.4
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp

--- a/net/net-snmp/files/snmpd.conf
+++ b/net/net-snmp/files/snmpd.conf
@@ -93,6 +93,11 @@ config exec
 	option args	/proc/sys/fs/file-nr
 #	option miboid	1.2.3.4
 
+config extend
+	option name	distro
+	option prog	/bin/grep
+	option args	-m1 OpenWrt /etc/banner
+
 config engineid
 #	option engineid 'LEDE'
 	option engineidtype '3'


### PR DESCRIPTION
This updates the default `net/net-snmp/files/snmpd.conf` with two practical defaults for modern OpenWrt deployments.

Changes:
- Add a `distro` extend that reports the first OpenWrt banner line:
  - `option prog /bin/grep`
  - `option args -m1 OpenWrt /etc/banner`
- Switch `engineidnic` default from `eth0` to `br-lan`

Rationale:
- The new `distro` extend exposes OS version details over SNMP without external scripts.
- On many current OpenWrt targets, `br-lan` is the stable LAN interface while `eth0` may not exist or may not be the intended identity interface.

This keeps the default config fully self-contained and compatible with existing deployments.
