### PR TITLE
net-snmp: use br-lan as default engineidnic interface

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.9.4
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp

--- a/net/net-snmp/files/snmpd.conf
+++ b/net/net-snmp/files/snmpd.conf
@@ -96,7 +96,7 @@ config exec
 config engineid
 #	option engineid 'LEDE'
 	option engineidtype '3'
-	option engineidnic 'eth0'
+	option engineidnic 'br-lan'
 
 #config trapcommunity 'trapcommunity'
 #	option community 'public'


### PR DESCRIPTION
The engineidnic option controls which network interface MAC address is used to generate the SNMPv3 engine ID. The previous default of 'eth0' is not reliable on OpenWrt because:
- Many devices do not have an 'eth0' interface at all; the first Ethernet port is often named differently (e.g. eth1, lan0, ...).
- On typical OpenWrt installations the LAN bridge 'br-lan' is always present and has a stable, predictable MAC address derived from the hardware, making it a better anchor for a persistent engine ID.

Using 'br-lan' ensures that snmpd can reliably compute its engine ID on the vast majority of OpenWrt targets without manual configuration.

PKG_RELEASE is bumped to 8.

## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
