### PR TITLE
ddns-scripts: switch to procd handling

### DIFF
--- a/net/ddns-scripts/files/etc/hotplug.d/iface/ddns
+++ b/net/ddns-scripts/files/etc/hotplug.d/iface/ddns
@@ -1,11 +1,42 @@
 #!/bin/sh
 
-# there are other ACTIONs like ifupdate we don't need
-case "$ACTION" in
-	ifup)					# OpenWrt is giving a network not phys. Interface
-		/etc/init.d/ddns enabled && /usr/lib/ddns/dynamic_dns_updater.sh -n "$INTERFACE" -- start
+. /lib/functions.sh
+
+start_ddns_service() {
+	local cfg="$1"
+	local interface_event="$2"
+	local action="$3"
+
+	local interface
+
+	config_get interface $cfg interface
+	[ -z "$interface" ] && return
+
+	[ "$interface" != "$interface_event" ] && return
+
+	case "$action" in
+	ifup)
+		/etc/init.d/ddns start "$cfg"
 		;;
 	ifdown)
-		/usr/lib/ddns/dynamic_dns_updater.sh -n "$INTERFACE" -- stop
+		/etc/init.d/ddns stop "$cfg"
+		;;
+	esac
+}
+
+ddns_service() {
+	local action="$1"
+	local interface="$2"
+
+	config_load ddns
+	config_foreach start_ddns_service "service" "$interface" "$action"
+}
+
+case "$ACTION" in
+	ifup)
+		/etc/init.d/ddns enabled && ddns_service "ifup" "$INTERFACE"
+		;;
+	ifdown)
+		ddns_service "ifdown" "$INTERFACE"
 		;;
 esac

--- a/net/ddns-scripts/files/etc/init.d/ddns
+++ b/net/ddns-scripts/files/etc/init.d/ddns
@@ -1,31 +1,51 @@
 #!/bin/sh /etc/rc.common
+
+USE_PROCD=1
 START=95
 STOP=10
 
-boot() {
-	return 0
+PROG=/usr/lib/ddns/dynamic_dns_updater.sh
+
+start_ddns() {
+	local cfg="$1"
+
+	local enabled
+
+	config_get_bool enabled $cfg enabled '0'
+	[ "$enabled" = "0" ] && return
+
+	procd_open_instance "$cfg"
+	procd_set_param command $PROG
+	procd_append_param command -S "$cfg"
+	procd_set_param respawn
+	procd_close_instance
 }
 
-kill() {
-	/usr/lib/ddns/dynamic_dns_updater.sh -- kill
-	return 0
+start_ddns_service() {
+	local cfg="$1"
+	local section="$2"
+
+	# start section if no section name is specified
+	[ -z "$section" ] && {
+		start_ddns "$cfg"
+		return
+	}
+
+	# start 'exactly' this section if a section name is specified
+	[ "$section" = "$cfg" ] && {
+		start_ddns "$cfg"
+		return
+	}
 }
 
-reload() {
-	restart
+start_service() {
+	local section="$1"
+
+	config_load ddns
+	config_foreach start_ddns_service "service" "$section"
 }
 
-restart() {
-	/usr/lib/ddns/dynamic_dns_updater.sh -- stop
-	sleep 1	# give time to shutdown
-	/usr/lib/ddns/dynamic_dns_updater.sh -- start
-}
-
-start() {
-	/usr/lib/ddns/dynamic_dns_updater.sh -- start
-}
-
-stop() {
-	/usr/lib/ddns/dynamic_dns_updater.sh -- stop
-	return 0
+service_triggers()
+{
+	procd_add_reload_trigger ddns
 }

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -165,69 +165,6 @@ load_all_config_options()
 	return 0
 }
 
-# read's all service sections from ddns config
-# $1 = Name of variable to store
-load_all_service_sections() {
-	local __DATA=""
-	config_cb()
-	{
-		# only look for section type "service", ignore everything else
-		[ "$1" = "service" ] && __DATA="$__DATA $2"
-	}
-	config_load "ddns"
-
-	eval "$1=\"$__DATA\""
-	return
-}
-
-# starts updater script for all given sections or only for the one given
-# $1 = interface (Optional: when given only scripts are started
-# configured for that interface)
-# used by /etc/hotplug.d/iface/95-ddns on IFUP
-# and by /etc/init.d/ddns start
-start_daemon_for_all_ddns_sections()
-{
-	local event_if sections section_id configured_if
-	event_if="$1"
-
-	load_all_service_sections sections
-	for section_id in $sections; do
-		config_get configured_if "$section_id" interface "wan"
-		[ -z "$event_if" ] || [ "$configured_if" = "$event_if" ] || continue
-		/usr/lib/ddns/dynamic_dns_updater.sh -v "$VERBOSE" -S "$section_id" -- start &
-	done
-}
-
-# stop sections process incl. childs (sleeps)
-# $1 = section
-stop_section_processes() {
-	local pid_file
-	pid_file="$ddns_rundir/$1.pid"
-	[ $# -ne 1 ] && write_log 12 "Error: 'stop_section_processes()' requires exactly one parameter"
-
-	[ -e "$pid_file" ] && {
-		xargs kill < "$pid_file" 2>/dev/null && return 1
-	}
-	return 0 # nothing killed
-}
-
-# stop updater script for all defines sections or only for one given
-# $1 = interface (optional)
-# used by /etc/hotplug.d/iface/95-ddns on 'ifdown'
-# and by /etc/init.d/ddns stop
-# needed because we also need to kill "sleep" child processes
-stop_daemon_for_all_ddns_sections() {
-	local event_if sections section_id configured_if
-	event_if="$1"
-
-	load_all_service_sections sections
-	for section_id in $sections;	do
-		config_get configured_if "$section_id" interface "wan"
-		[ -z "$event_if" ] || [ "$configured_if" = "$event_if" ] || continue
-		stop_section_processes "$section_id"
-	done
-}
-
 # reports to console, logfile, syslog
 # $1	loglevel 7 == Debug to 0 == EMERG
 #	value +10 will exit the scripts

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
@@ -19,14 +19,9 @@ usage() {
 	cat << EOF
 
 Usage:
- $MYPROG [options] -- command
-
-Commands:
-start                Start SECTION or NETWORK or all
-stop                 Stop SECTION or NETWORK or all
+ $MYPROG [options]
 
 Parameters:
- -n NETWORK          Start/Stop sections in background monitoring NETWORK, force VERBOSE=0
  -S SECTION          SECTION to start
                      use either -N NETWORK or -S SECTION
 
@@ -53,7 +48,6 @@ while getopts ":hv:dn:S:V" OPT; do
 		h)	usage; exit 0;;
 		v)	VERBOSE=$OPTARG;;
 		d)	DRY_RUN=1;;
-		n)	NETWORK=$OPTARG;;
 		S)	SECTION_ID=$OPTARG;;
 		V)	printf %s\\n "ddns-scripts $VERSION"; exit 0;;
 		:)	usage_err "option -$OPTARG missing argument";;
@@ -63,41 +57,7 @@ while getopts ":hv:dn:S:V" OPT; do
 done
 shift $((OPTIND - 1 ))	# OPTIND is 1 based
 
-[ -n "$NETWORK" -a -n "$SECTION_ID" ] && usage_err "use either option '-N' or '-S' not both"
-[ $# -eq 0 ] && usage_err "missing command"
-[ $# -gt 1 ] && usage_err "to much commands"
-
-case "$1" in
-	start)
-		if [ -n "$NETWORK" ]; then
-			start_daemon_for_all_ddns_sections "$NETWORK"
-			exit 0
-		fi
-		if [ -z "$SECTION_ID" ]; then
-			start_daemon_for_all_ddns_sections
-			exit 0
-		fi
-		;;
-	stop)
-		if [ -n "$SECTION_ID" ]; then
-			stop_section_processes "$SECTION_ID"
-			exit 0
-		fi
-		if [ -n "$NETWORK" ]; then
-			stop_daemon_for_all_ddns_sections "$NETWORK"
-			exit 0
-		else
-			stop_daemon_for_all_ddns_sections
-			exit 0
-		fi
-		exit 1
-		;;
-	kill)
-		killall dynamic_dns_updater.sh 2>/dev/null
-		exit $?
-		;;
-	*)	usage_err "unknown command - $1";;
-esac
+[ -z "$SECTION_ID" ] && usage_err "option '-N' is missing"
 
 # set file names
 PIDFILE="$ddns_rundir/$SECTION_ID.pid"	# Process ID file


### PR DESCRIPTION
This commit changes the ddns-scripts handling to use procd service.

## 📦 Package Details

**Maintainer:** me


**Description:**
The 'ddns-scripts' still uses **not** the procd service handling. This commit changes this.

In the LuCI, the [dynamic_dns_updater](https://github.com/openwrt/luci/blob/master/applications/luci-app-ddns/root/usr/share/rpcd/ucode/ddns.uc#L14) is still being called via the helper function. This also needs to be refactored before merge. Otherwise, LuCI will stop working.

Should Fixes: https://github.com/openwrt/packages/issues/28722


---

## 🧪 Run Testing Details

- **OpenWrt Version: master**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
