### PR TITLE
net/dhcpcd: fix PKG_CPE_ID

### DIFF
--- a/net/dhcpcd/Makefile
+++ b/net/dhcpcd/Makefile
@@ -17,7 +17,7 @@ PKG_HASH:=d582012992efddd2442bb1213c518a37d90febbcf8b11f8e76448c710dacad27
 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE
-PKG_CPE_ID:=cpe:/a:roy_marples:dhcpcd
+PKG_CPE_ID:=cpe:/a:dhcpcd_project:dhcpcd
 
 PKG_MAINTAINER:=Marko Ratkaj <markoratkaj@gmail.com>
 


### PR DESCRIPTION
cpe:/a:dhcpcd_project:dhcpcd is the correct CPE ID for dhcpcd: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:dhcpcd_project:dhcpcd

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

**Maintainer:** @ratkaj