### PR TITLE
prometheus-node-exporter-lua: add unbound stats collector

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2026.03.13
+PKG_VERSION:=2026.03.28
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/unbound.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/unbound.lua
@@ -1,39 +1,59 @@
+-- Unbound stats exporter
+
+local socket = require("socket")
+local unix = require("socket.unix")
+
 local function scrape()
     local metrics = {
         ["total.num.queries"                ] = metric("unbound_num_queries_total",                "counter"),
-        ["total.num.queries.ip.ratelimited" ] = metric("unbound_num_queries_ip_ratelimited_total", "counter"),
-        ["total.num.queries.cookie.valid"   ] = metric("unbound_num_queries_cookie_valid_total",   "counter"),
-        ["total.num.queries.cookie.client"  ] = metric("unbound_num_queries_cookie_client_total",  "counter"),
-        ["total.num.queries.cookie.invalid" ] = metric("unbound_num_queries_cookie_invalid_total", "counter"),
-        ["total.num.queries.discard.timeout"] = metric("unbound_num_queries_discard_timeout_total","counter"),
-        ["total.num.queries.wait.limit"     ] = metric("unbound_num_queries_wait_limit_total",     "counter"),
+        ["total.num.queries_ip_ratelimited" ] = metric("unbound_num_queries_ip_ratelimited_total", "counter"),
+        ["total.num.queries_cookie_valid"   ] = metric("unbound_num_queries_cookie_valid_total",   "counter"),
+        ["total.num.queries_cookie_client"  ] = metric("unbound_num_queries_cookie_client_total",  "counter"),
+        ["total.num.queries_cookie_invalid" ] = metric("unbound_num_queries_cookie_invalid_total", "counter"),
+        ["total.num.queries_discard_timeout"] = metric("unbound_num_queries_discard_timeout_total","counter"),
+        ["total.num.queries_wait_limit"     ] = metric("unbound_num_queries_wait_limit_total",     "counter"),
         ["total.num.cachehits"              ] = metric("unbound_cachehits_total",                  "counter"),
         ["total.num.cachemiss"              ] = metric("unbound_cachemiss_total",                  "counter"),
         ["total.num.prefetch"               ] = metric("unbound_prefetch_total",                   "counter"),
-        ["total.num.queries.timed.out"      ] = metric("unbound_num_queries_timed_out_total",      "counter"),
-        ["total.query.queue.time.us.max"    ] = metric("unbound_query_queue_time_us_max_total",    "counter"),
+        ["total.num.queries_timed_out"      ] = metric("unbound_num_queries_timed_out_total",      "counter"),
+        ["total.query.queue_time_us.max"    ] = metric("unbound_query_queue_time_us_max",          "gauge"),
         ["total.num.expired"                ] = metric("unbound_num_expired_total",                "counter"),
         ["total.num.recursivereplies"       ] = metric("unbound_num_recursivereplies_total",       "counter"),
-        ["total.num.dns.error.reports"      ] = metric("unbound_num_dns_error_reports_total",      "counter"),
-        ["total.requestlist.avg"            ] = metric("unbound_requestlist_avg_total",            "counter"),
-        ["total.requestlist.max"            ] = metric("unbound_requestlist_max_total",            "counter"),
+        ["total.num.dns_error_reports"      ] = metric("unbound_num_dns_error_reports_total",      "counter"),
+        ["total.requestlist.avg"            ] = metric("unbound_requestlist_avg",                  "gauge"),
+        ["total.requestlist.max"            ] = metric("unbound_requestlist_max",                  "gauge"),
         ["total.requestlist.overwritten"    ] = metric("unbound_requestlist_overwritten_total",    "counter"),
         ["total.requestlist.exceeded"       ] = metric("unbound_requestlist_exceeded_total",       "counter"),
-        ["total.requestlist.current.all"    ] = metric("unbound_requestlist_current_all_total",    "counter"),
-        ["total.requestlist.current.user"   ] = metric("unbound_requestlist_current_user_total",   "counter"),
-        ["total.recursion.time.avg"         ] = metric("unbound_recursion_time_avg_total",         "counter"),
-        ["total.recursion.time.median"      ] = metric("unbound_recursion_time_median_total",      "counter"),
+        ["total.requestlist.current.all"    ] = metric("unbound_requestlist_current_all",          "gauge"),
+        ["total.requestlist.current.user"   ] = metric("unbound_requestlist_current_user",         "gauge"),
+        ["total.recursion.time.avg"         ] = metric("unbound_recursion_time_avg",               "gauge"),
+        ["total.recursion.time.median"      ] = metric("unbound_recursion_time_median",            "gauge"),
     }
 
-    local handle = io.popen("/usr/sbin/unbound-control stats_noreset | sed 's/_/./g'")
-    if not handle then
-        return nil, "failed to run unbound-control"
+    local sock = unix()
+    local ok, err = sock:connect("/run/unbound.ctl")
+    if not ok then
+        return nil, "failed to connect to unbound socket: " .. (err or "unknown")
     end
-    local out = handle:read("*a")
-    handle:close()
+
+    sock:settimeout(1)
+    sock:send("UBCT1 stats_noreset\n")
+
+    local chunks = {}
+    while true do
+        local chunk, err, partial = sock:receive(4096)
+        if partial and partial ~= "" then
+            chunks[#chunks + 1] = partial
+        end
+        if not chunk then break end
+        chunks[#chunks + 1] = chunk
+    end
+    sock:close()
+
+    local out = table.concat(chunks)
 
     for line in out:gmatch("[^\r\n]+") do
-        local key, val = line:match("^([%w%.]+)=(%-?[%d%.]+)$")
+        local key, val = line:match("^([%w%._]+)=(%-?[%d%.]+)$")
         if key and val then
             local n = tonumber(val)
             if metrics[key] then


### PR DESCRIPTION
## 📦 prometheus-node-exporter-lua

**Maintainer:**  @champtar 

**Description:** Add a collector for unbound statistics

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12
- **OpenWrt Target/Subtarget:** MediaTek ARM/Filogic 8x0 (MT798x)
- **OpenWrt Device:** GL.iNet GL-MT6000

---

Signed-off-by: Bruno Marinier <bmgm41@gmail.com>