### PR TITLE
net/boinc-wrapper: drop PKG_CPE_ID

### DIFF
--- a/net/boinc-wrapper/Makefile
+++ b/net/boinc-wrapper/Makefile
@@ -16,7 +16,6 @@ PKG_HASH:=a93ae0a9e640a893e78f523c6d93f31b1d5812092f85af4e9ce964846373f55d
 PKG_MAINTAINER:=Vitalii Koshura <lestat.de.lionkur@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:boinc-wrapper:boinc-wrapper
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=0


### PR DESCRIPTION
cpe:/a:boinc-wrapper:boinc-wrapper is not a correct CPE ID for boinc-wrapper: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:boinc-wrapper:boinc-wrapper

Fixes: 40e144be7d4b4a7a9d3d3fd45b39878c73dee406 (boinc-wrapper: add new package)

**Maintainer:** @AenBleidd