### PR TITLE
net/memcached: fix PKG_CPE_ID

### DIFF
--- a/net/memcached/Makefile
+++ b/net/memcached/Makefile
@@ -19,7 +19,7 @@ PKG_HASH:=20d8d339b8fb1f6c79cee20559dc6ffb5dfee84db9e589f4eb214f6d2c873ef5
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:memcachedb:memcached
+PKG_CPE_ID:=cpe:/a:memcached:memcached
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
cpe:/a:memcached:memcached is the correct CPE ID for memcached: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:memcached:memcached

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)