### PR TITLE
net/rsync: fix PKG_CPE_ID

### DIFF
--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=2924bcb3a1ed8b551fc101f740b9f0fe0a202b115027647cf69850d65fd88c52
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:rsync:rsync
+PKG_CPE_ID:=cpe:/a:samba:rsync
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
cpe:/a:samba:rsync is the correct CPE ID for rsync: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:samba:rsync

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)

**Maintainer:** @mstorchak