### PR TITLE
net/nfs-kernel-server: fix PKG_CPE_ID

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -15,7 +15,7 @@ PKG_SOURCE:=nfs-utils-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/nfs-utils/$(PKG_VERSION)
 MAINTAINER:=John Audia <therealgraysky@proton.me>
 PKG_LICENSE:=GPL-2.0-or-later
-PKG_CPE_ID:=cpe:/a:nfs_project:nfs-utils
+PKG_CPE_ID:=cpe:/a:linux-nfs:nfs-utils
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/nfs-utils-$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/nfs-utils-$(PKG_VERSION)


### PR DESCRIPTION
cpe:/a:linux-nfs:nfs-utils is the correct CPE ID for nfs-kernel-server: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:linux-nfs:nfs-utils

Fixes: ee3b06e42cb86756b0fed1dd4e03aee1b358f759 (nfs-kernel-server: provide a NFSv3 and NFSv4 daemon)

**Maintainer:** @graysky2