### PR TITLE
libs/openpgm: drop PKG_CPE_ID

### DIFF
--- a/libs/openpgm/Makefile
+++ b/libs/openpgm/Makefile
@@ -24,7 +24,6 @@ PKG_AUTOMAKE_PATHS:=$(MAKE_PATH)
 PKG_MAINTAINER:=Ye Holmes <yeholmes@outlook.com>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=$(MAKE_PATH)/LICENSE
-PKG_CPE_ID:=cpe:/a:openpgm:openpgm
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
cpe:/a:openpgm:openpgm is not a correct CPE ID for openpgm: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:openpgm:openpgm

Fixes: 20f05f8e585e01729defe53fdbc49738c260fc5a (openpgm: Add Pragmatic General Multicast library)

**Maintainer:** @ye-holmes