### PR TITLE
libs/iniparser: fix PKG_CPE_ID

### DIFF
--- a/libs/iniparser/Makefile
+++ b/libs/iniparser/Makefile
@@ -16,7 +16,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 PKG_MAINTAINER:=Antonio Pastor <antonio.pastor@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:iniparser:iniparser
+PKG_CPE_ID:=cpe:/a:ndevilla:iniparser
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION
cpe:/a:ndevilla:iniparser is not a correct CPE ID for iniparser: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:ndevilla:iniparser

Fixes: 456d8ff5d58edd84ab361cc8c289d1d6c7507acc (iniparser: library for parsing of ini files in C)

**Maintainer:** @Antonio Pastor