### PR TITLE
net/frr: fix PKG_CPE_ID

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -21,7 +21,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-2.0-only LGPL-2.1-only
-PKG_CPE_ID:=cpe:/a:ffrouting:ffrouting
+PKG_CPE_ID:=cpe:/a:frrouting:frrouting
 
 PKG_DAEMON_AVAILABLE:= \
 	babeld \


### PR DESCRIPTION
cpe:/a:frrouting:frrouting is the correct CPE ID for frr: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:frrouting:frrouting

Fixes: 5afe5c9031190844f267357c68efe3c9c3cbe51d (treewide: assign PKG_CPE_ID)

**Maintainer:** @lucize