### PR TITLE
python-pyopenssl: fix PKG_CPE_ID

### DIFF
--- a/lang/python/python-pyopenssl/Makefile
+++ b/lang/python/python-pyopenssl/Makefile
@@ -17,7 +17,7 @@ PKG_HASH:=6b2cba5cc46e822750ec3e5a81ee12819850b11303630d575e98108a079c2b12
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
-PKG_CPE_ID:=cpe:/a:pyopenssl_project:pyopenssl
+PKG_CPE_ID:=cpe:/a:pyopenssl:pyopenssl
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
cpe:/a:pyopenssl:pyopenssl is the correct CPE ID for python-pyopenssl: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:pyopenssl:pyopenssl

Fixes: ceadbcbb64de727c3a974e552d9a723d532e4e40 (treewide: add PKG_CPE_ID for cvescanner)