### PR TITLE
libs/libsoxr: drop PKG_CPE_ID

### DIFF
--- a/libs/libsoxr/Makefile
+++ b/libs/libsoxr/Makefile
@@ -19,7 +19,6 @@ PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Mike Brady <mikebrady@eircom.net>
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=LICENCE
-PKG_CPE_ID:=cpe:/a:sox:sox
 
 CMAKE_INSTALL:=1
 


### PR DESCRIPTION
cpe:/a:sox:sox is not a correct CPE ID for libsoxr: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:sox:sox

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)