### PR TITLE
lang/erlang: fix PKG_CPE_ID

### DIFF
--- a/lang/erlang/Makefile
+++ b/lang/erlang/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=0cdf3b44e327439ea6677e61e06f28a0f82ea080af2dcbd665bc5a945b167012
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_MAINTAINER:=
-PKG_CPE_ID:=cpe:/a:erlang:erlang
+PKG_CPE_ID:=cpe:/a:erlang:erlang\/otp
 
 PKG_BUILD_DEPENDS:=erlang/host openssl unixodbc/host
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION
cpe:/a:erlang:erlang\/otp is the correct CPE ID for erlang: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:erlang:erlang%5C/otp

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)