### PR TITLE
admin/netdata: fix PKG_CPE_ID

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=4
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:my-netdata:netdata
+PKG_CPE_ID:=cpe:/a:netdata:netdata
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/netdata/netdata/releases/download/v$(PKG_VERSION)


### PR DESCRIPTION
cpe:/a:netdata:netdata is the correct CPE ID for netdata: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:netdata:netdata

Fixes: cbfc396ca6ab24d7607741fd63e27bd705ca1ede (netdata: update to version 1.14.0)