### PR TITLE
utils/minicom: fix PKG_CPE_ID

### DIFF
--- a/utils/minicom/Makefile
+++ b/utils/minicom/Makefile
@@ -18,7 +18,7 @@ PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:minicom:minicom
+PKG_CPE_ID:=cpe:/a:minicom_project:minicom
 
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
cpe:/a:minicom_project:minicom is the correct CPE ID for minicom: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:minicom_project:minicom

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)