### PR TITLE
python-gnupg: bump to 0.5.6

### DIFF
--- a/lang/python/python-gnupg/Makefile
+++ b/lang/python/python-gnupg/Makefile
@@ -5,18 +5,22 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-gnupg
-PKG_VERSION:=0.5.1
+PKG_VERSION:=0.5.6
 PKG_RELEASE:=1
 
 PYPI_NAME:=python-gnupg
-PKG_HASH:=5674bad4e93876c0b0d3197e314d7f942d39018bf31e2b833f6788a6813c3fb8
+PKG_SOURCE:=python_gnupg-$(PKG_VERSION).tar.gz
+PKG_HASH:=5743e96212d38923fc19083812dc127907e44dbd3bcf0db4d657e291d3c21eac
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_CPE_ID:=cpe:/a:python:python-gnupg
 
+PKG_BUILD_DEPENDS:=python-setuptools/host
+
 include ../pypi.mk
+
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
@@ -26,7 +30,7 @@ define Package/python3-gnupg
   SUBMENU:=Python
   TITLE:=A wrapper for GnuPG
   URL:=https://github.com/vsajip/python-gnupg
-  DEPENDS:=+python3-light +python3-logging
+  DEPENDS:=+python3-light +python3-logging +python3-email +python3-urllib
 endef
 
 define Package/python3-gnupg/description

--- a/lang/python/python-gnupg/test.sh
+++ b/lang/python/python-gnupg/test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+[ "$1" = python3-gnupg ] || exit 0
+
+python3 - << 'EOF'
+import gnupg
+
+gpg = gnupg.GPG.__new__(gnupg.GPG)
+assert gpg is not None
+EOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Changelog since 0.5.1:
- Add configurable I/O buffer size via buffer_size attribute (0.5.2)
- Add Web Key Directory (WKD) support for automatic key location (0.5.3)
- Fix sensitive data exposure by removing decryption result logging (0.5.3)
- Fix exception handling in on_data callable during GPG operations (0.5.4)
- Fix GPG version detection robustness (0.5.5)
- Add uid_map attribute to capture UID information (0.5.5)
- Add capability, fingerprint and keygrip to subkey_info (0.5.6)
- Fix username handling when verification keys are expired/revoked (0.5.6)

Full changelog:
https://github.com/vsajip/python-gnupg/releases

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
