### PR TITLE
python-mako: bump to 1.3.5

### DIFF
--- a/lang/python/python-mako/Makefile
+++ b/lang/python/python-mako/Makefile
@@ -6,11 +6,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-mako
-PKG_VERSION:=1.3.0
+PKG_VERSION:=1.3.5
 PKG_RELEASE:=1
 
 PYPI_NAME:=Mako
-PKG_HASH:=e3a9d388fd00e87043edbe8792f45880ac0114e9c4adc69f6e9bfb2c55e3b11b
+PKG_HASH:=48dbc20568c1d276a2698b36d968fa76161bf127194907ea6fc594fa81f943bc
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT

--- a/lang/python/python-mako/test.sh
+++ b/lang/python/python-mako/test.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+[ "$1" = python3-mako ] || exit 0
+
+python3 - << 'EOF'
+from mako.template import Template
+
+# Basic variable rendering
+t = Template("Hello, ${name}!")
+result = t.render(name="World")
+assert result == "Hello, World!", f"Unexpected: {result!r}"
+
+# Control flow
+t = Template("""
+% for item in items:
+- ${item}
+% endfor
+""".strip())
+result = t.render(items=["a", "b", "c"])
+assert "- a" in result
+assert "- b" in result
+assert "- c" in result
+
+# Expression evaluation
+t = Template("${2 + 2}")
+result = t.render()
+assert result.strip() == "4", f"Unexpected: {result!r}"
+EOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

    Changelog since 1.3.0:
    - Fix escaped percent signs (%%) not rendering correctly when not at
      line beginnings (1.3.1/1.3.2)
    - Add 'pass' statements to empty control blocks to prevent errors (1.3.3)
    - Fix strict_undefined mode conflicts with comprehensions inside
      function definitions (1.3.3)
    - Revert dictionary literal parsing changes that caused bracketed
      expression regressions (1.3.5)
    
    Full changelog:
    https://docs.makotemplates.org/en/latest/changelog.html


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
