### PR TITLE
utils/usbmuxd: drop PKG_CPE_ID

### DIFF
--- a/utils/usbmuxd/Makefile
+++ b/utils/usbmuxd/Makefile
@@ -19,7 +19,6 @@ PKG_MIRROR_HASH:=f340f0bbbe65135a9a9d52a4e28cd64b1285930560f999f156124dfde7b4285
 PKG_MAINTAINER:=Rosen Penev <rosenp@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING.GPLv2
-PKG_CPE_ID:=cpe:/a:libimobiledevice:usbmuxd
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
cpe:/a:libimobiledevice:usbmuxd is not a correct CPE ID for usbmuxd: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:libimobiledevice:usbmuxd

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)