### PR TITLE
utils/ifuse: drop PKG_CPE_ID

### DIFF
--- a/utils/ifuse/Makefile
+++ b/utils/ifuse/Makefile
@@ -17,7 +17,6 @@ PKG_MIRROR_HASH:=b9bfd08c62cbb1dc8e36c1d8713be03149d87dbd6adc8aef952b7209c9c97a2
 PKG_MAINTAINER:=Rosen Penev <rosenp@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:libimobiledevice:ifuse
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
cpe:/a:libimobiledevice:ifuse is not a correct CPE ID for ifuse: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:libimobiledevice:ifuse

Fixes: 512afeb406126bfda22d1c4d1f5fe274fe02f357 (ifuse: add package from git)