### PR TITLE
net/davfs2: fix PKG_CPE_ID

### DIFF
--- a/net/davfs2/Makefile
+++ b/net/davfs2/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=ce3eb948ece582a51c934ccb0cc70e659839172717caff173f69a5e2af90c5c0
 PKG_MAINTAINER:=Federico Di Marco <fededim@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:davfs2:davfs2
+PKG_CPE_ID:=cpe:/a:werner_baumann:davfs2
 
 PKG_FIXUP:=gettext-version
 PKG_INSTALL:=1


### PR DESCRIPTION
cpe:/a:werner_baumann:davfs2 is the correct CPE ID for davfs2: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:werner_baumann:davfs2

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)