### PR TITLE
admin/iotop: drop PKG_CPE_ID

### DIFF
--- a/admin/iotop/Makefile
+++ b/admin/iotop/Makefile
@@ -10,7 +10,6 @@ PKG_HASH:=862e3d3d0263e4171aa9c5aaed2dd7d76ca746afa58ecbb6eca002717e9fa240
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE
-PKG_CPE_ID=cpe:/a:iotop:iotop
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
cpe:/a:iotop:iotop is not a correct CPE ID for iotop: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:iotop:iotop

Fixes: aca8d8d088d41baa724d635d5965af4ea62a8f35 (iotop: add new package)

**Maintainer:** @graysky2