### PR TITLE
net/smartdns: assign PKG_CPE_ID

### DIFF
--- a/net/smartdns/Makefile
+++ b/net/smartdns/Makefile
@@ -17,6 +17,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-Release$(PKG_VERSION)
 PKG_MAINTAINER:=Nick Peng <pymumu@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:pymumu:smartdns
 
 PKG_BUILD_PARALLEL:=1
 


### PR DESCRIPTION
cpe:/a:pymumu:smartdns is the correct CPE ID for smartdns: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:pymumu:smartdns

**Maintainer:** @pymumu