### PR TITLE
net/sing-box: assign PKG_CPE_ID

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -11,6 +11,7 @@ PKG_HASH:=6c4333c3f53a07cc96b63a801fdf6c156820d51cd2eb05e44ea78df290a45377
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Van Waholtz <brvphoenix@gmail.com>
+PKG_CPE_ID:=cpe:/a:sagernet:sing-box
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
cpe:/a:sagernet:sing-box is the correct CPE ID for sing-box: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:sagernet:sing-box

**Maintainer:** @brvphoenix 