### PR TITLE
lang/rust: assign PKG_CPE_ID

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -16,6 +16,7 @@ HOST_BUILD_DIR:=$(BUILD_DIR)/host/rustc-$(PKG_VERSION)-src
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>
 PKG_LICENSE:=Apache-2.0 MIT
 PKG_LICENSE_FILES:=LICENSE-APACHE LICENSE-MIT
+PKG_CPE_ID:=cpe:/a:rust-lang:rust
 
 PKG_HOST_ONLY:=1
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION
cpe:/a:rust-lang:rust is the correct CPE ID for rust: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:rust-lang:rust

**Maintainer:** @lu-zero