### PR TITLE
utils/opendoas: assign PKG_CPE_ID

### DIFF
--- a/utils/opendoas/Makefile
+++ b/utils/opendoas/Makefile
@@ -11,6 +11,7 @@ PKG_HASH:=4e98828056d6266bd8f2c93e6ecf12a63a71dbfd70a5ea99ccd4ab6d0745adf0
 PKG_MAINTAINER:=Michal Vasilek <michal.vasilek@nic.cz>
 PKG_LICENSE:=ISC BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:opendoas_project:opendoas
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
cpe:/a:opendoas_project:opendoas is the correct CPE ID for opendoas: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:opendoas_project:opendoas

**Maintainer:** @paper42