### PR TITLE
net/mac-telnet: assign PKG_CPE_ID

### DIFF
--- a/net/mac-telnet/Makefile
+++ b/net/mac-telnet/Makefile
@@ -17,6 +17,7 @@ PKG_BUILD_FLAGS:=gc-sections
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+PKG_CPE_ID:=cpe:/a:mac-telnet_project:mac-telnet
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
cpe:/a:mac-telnet_project:mac-telnet is the correct CPE ID for mac-telnet: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:mac-telnet_project:mac-telnet

**Maintainer:** @jow- 