### PR TITLE
libs/libesmtp: assign PKG_CPE_ID

### DIFF
--- a/libs/libesmtp/Makefile
+++ b/libs/libesmtp/Makefile
@@ -14,6 +14,7 @@ PKG_RELEASE:=3
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=LGPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:libesmtp_project:libesmtp
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/libesmtp/libESMTP/tar.gz/v$(PKG_VERSION)?


### PR DESCRIPTION
cpe:/a:libesmtp_project:libesmtp is the correct CPE ID for libesmtp: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:libesmtp_project:libesmtp