### PR TITLE
utils/borgbackup: assign PKG_CPE_ID

### DIFF
--- a/utils/borgbackup/Makefile
+++ b/utils/borgbackup/Makefile
@@ -17,6 +17,7 @@ PKG_HASH:=79bbfa745d1901d685973584bd2d16a350686ddd176f6a2244490fb01996441f
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Julien Malik <julien.malik@paraiso.me>
+PKG_CPE_ID:=cpe:/a:borgbackup:borg
 
 include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
cpe:/a:borgbackup:borg is the correct CPE ID for borgbackup: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:borgbackup:borg