### PR TITLE
admin/backuppc: assign PKG_CPE_ID

### DIFF
--- a/admin/backuppc/Makefile
+++ b/admin/backuppc/Makefile
@@ -17,6 +17,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/BackupPC-$(PKG_VERSION)
 PKG_MAINTAINER:=Carsten Wolff <carsten@wolffcarsten.de>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:backuppc:backuppc
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
cpe:/a:backuppc:backuppc is the correct CPE ID for backuppc: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:backuppc:backuppc

**Maintainer:** @cawo-odoo