### PR TITLE
utils/dockerd: assign PKG_CPE_ID

### DIFF
--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -5,6 +5,7 @@ PKG_VERSION:=27.3.1
 PKG_RELEASE:=4
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:mobyproject:moby
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby


### PR DESCRIPTION
cpe:/a:mobyproject:moby is the correct CPE ID for docker: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:mobyproject:moby

**Maintainer:** @G-M0N3Y-2503 