### PR TITLE
libs/gperftools: assign PKG_CPE_ID

### DIFF
--- a/libs/gperftools/Makefile
+++ b/libs/gperftools/Makefile
@@ -12,6 +12,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION)
 PKG_MAINTAINER:=John Audia <therealgraysky@proton.me>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:gperftools_project:gperftools
 
 PKG_BUILD_FLAGS:=no-mips16
 PKG_INSTALL:=1


### PR DESCRIPTION
cpe:/a:gperftools_project:gperftools is the correct CPE ID for gperftools: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:gperftools_project:gperftools

**Maintainer:** @graysky2