### PR TITLE
libs/libedit: assign PKG_CPE_ID

### DIFF
--- a/libs/libedit/Makefile
+++ b/libs/libedit/Makefile
@@ -16,6 +16,7 @@ PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=BSD-3-Clause
+PKG_CPE_ID:=cpe:/a:libedit_project:libedit
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(RELEASE_DATE)-$(VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(RELEASE_DATE)-$(VERSION).tar.gz


### PR DESCRIPTION
cpe:/a:libedit_project:libedit is the correct CPE ID for libedit: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:libedit_project:libedit

**Maintainer:** @salzmdan