### PR TITLE
hwdata: bump to 0.405

### DIFF
--- a/utils/hwdata/Makefile
+++ b/utils/hwdata/Makefile
@@ -6,14 +6,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hwdata
-PKG_VERSION:=0.387
-PKG_RELEASE:=2
+PKG_VERSION:=0.405
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/vcrhonek/hwdata/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8c6be8f0863a8ff5c83b2c46aa525b503b30d42792ed57891c40849de543e1ee
+PKG_HASH:=13605519e72e46aa13d5eede1901a07a6c83cd25ef866a86e7458047b5c81ce5
 
-PKG_MAINTAINER:=
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING LICENSE
 

--- a/utils/hwdata/test.sh
+++ b/utils/hwdata/test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+case "$1" in
+	pciids)
+		test -s /usr/share/hwdata/pci.ids
+		;;
+	usbids)
+		test -s /usr/share/hwdata/usb.ids
+		;;
+	pnpids)
+		test -s /usr/share/hwdata/pnp.ids
+		;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Update PCI and USB vendor/device IDs database.

Full release notes:
https://github.com/vcrhonek/hwdata/releases/tag/v0.405

Add test.sh

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.