### PR TITLE
pillow: update to 12.1.1

### DIFF
--- a/lang/python/pillow/Makefile
+++ b/lang/python/pillow/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pillow
-PKG_VERSION:=10.1.0
+PKG_VERSION:=12.1.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=Pillow
-PKG_HASH:=e6bf8de6c36ed96c86ea3b6e1d5273c53f46ef518a062464cd7ef5dd2cf92e38
+PKG_HASH:=9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4
 
 PKG_BUILD_DEPENDS:=python-setuptools-scm/host
 


### PR DESCRIPTION
Should fix compilation issues with newer Python versions.

## 📦 Package Details

**Maintainer:** @commodo 