### PR TITLE
mailsend: cherry-pick fix ssl variant to use opensssl

### DIFF
--- a/mail/mailsend/Makefile
+++ b/mail/mailsend/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mailsend
 PKG_VERSION:=1.19
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/muquit/mailsend/archive/$(PKG_VERSION)
@@ -65,6 +65,10 @@ TARGET_CFLAGS += \
 	-DHAVE_UNISTD_H \
 	-DSTDC_HEADERS \
 	-DTIME_WITH_SYS_TIME
+
+ifeq ($(BUILD_VARIANT),ssl)
+TARGET_CFLAGS += "-DHAVE_OPENSSL=1"
+endif
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) DEFS="$(TARGET_CFLAGS)"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @thess

**Description:**
As described in #28261 Not compiled with OpenSSL, the SSL variant of the mailsend package is not actually being compiled with OpenSSL.

This is due to an upstream configure check borrowed from an ancient version of BIND, which no longer works.

As a workaround we add `-DHAVE_OPENSSL=1` to the `TARGET_CFLAGS` when building the SSL variant.

This results in a complaint about COPTS not being honoured correctly, but results in `mailsend` compiled with OpenSSL (i.e. works).

(cherry picked from commit 444b62cbccf13492096fc0216d661f2ccf47f069)

Closes #28695 

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12-SNAPSHOT r32755-008e51950b
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

Using self-built 25.12 OpenWrt core because of an issue with libubox ABI when using the 25.12-SNAPSHOT SDK.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
