### PR TITLE
[24.10] nextdns: update to version 1.47.1

### DIFF
--- a/net/nextdns/Makefile
+++ b/net/nextdns/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nextdns
-PKG_VERSION:=1.45.0
+PKG_VERSION:=1.47.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=nextdns-$(PKG_VERSION).tar.gz
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.github.com/nextdns/nextdns/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6222359c4a1ea3106c0a13d470806ed833bfbc7a1d10bd91aa3f4701927031b0
+PKG_HASH:=3356b283a8eeb675efee8163854c83c65d1dbb7743bac04db696751290f8ee64
 
 PKG_MAINTAINER:=Olivier Poitrey <rs@nextdns.io>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Backport merged `nextdns` package changes from `master` into `openwrt-24.10`.

Current branch version: `1.45.0`
Target branch version: `1.47.1`
Cherry picked from commits:
- 7f3badc94bf421eafe6e5096381fd110d1ef6b09