### PR TITLE
nut: ensure correct settings names

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.8.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.networkupstools.org/source/2.8/
@@ -17,6 +17,8 @@ PKG_HASH:=a2fe55bc2d90b4a848d6ff8bac361e6d1c97f899a545219cad707d17a27ff127
 PKG_LICENSE:=GPL-2.0-or-later GPL-3.0-or-later GPL-1.0-or-later Artistic-1.0-Perl
 PKG_LICENSE_FILES:=LICENSE-GPL2 LICENSE-GPL3 COPYING
 PKG_FIXUP:=autoreconf
+
+PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 
 PKG_INSTALL:=1
 
@@ -156,7 +158,7 @@ part of UPS monitoring--shutting down the system when the power goes
 out. It can call out to other helper programs for notification purposes
 during power events. upsmon can monitor multiple systems using a single
 process. Every UPS that is defined in the upsmon.conf configuration file
-is assigned a power value and a type (slave or master).
+is assigned a power value and a type (secondary or primary).
 endef
 
 define Package/nut-upsmon/conffiles

--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -9,118 +9,110 @@ USE_PROCD=1
 UPSMON_C=/var/etc/nut/upsmon.conf
 PIDFILE=/var/run/upsmon.pid
 
+# Upstream NUT event type names (in the order listed in
+# https://networkupstools.org/docs/man/upsmon.conf.html)
+NUT_EVENT_TYPES=" ONLINE ONBATT LOWBATT FSD COMMOK COMMBAD SHUTDOWN REPLBATT NOCOMM NOPARENT CAL NOTCAL OFF NOTOFF BYPASS NOTBYPASS ECO NOTECO OVER NOTOVER TRIM NOTTRIM BOOST NOTBOOST OTHER NOTOTHER SUSPEND_STARTING SUSPEND_FINISHED "
+
+nut_get_notifications() {
+	local event="$1"
+	local defaultnotify="$2"
+
+	if [ "${NUT_EVENT_TYPES#*" $event "}" != "${NUT_EVENT_TYPES}" ]; then
+		config_get val "$event" message
+		[ -n "$val" ] && echo "NOTIFYMSG $event \"$val\"" >>"$UPSMON_C"
+		config_get val "$event" flag "$defaultnotify"
+		[ -n "$val" ] && echo "NOTIFYFLAG $event $val" >>"$UPSMON_C"
+	else
+		logger -t nut-monitor -s "$event is not a valid NUT message event type"
+	fi
+}
+
 nut_upsmon_conf() {
 	local cfg="$1"
-	local RUNAS val optval
+	local RUNAS val optval defaultnotify
 
-	echo "# Config file automatically generated from UCI config" > "$UPSMON_C"
+	echo "# Config file automatically generated from UCI config" >"$UPSMON_C"
 
 	config_get RUNAS "$cfg" runas "nutmon"
-	[ -n "$RUNAS" ] && echo "RUN_AS_USER $RUNAS" >> "$UPSMON_C"
+	[ -n "$RUNAS" ] && echo "RUN_AS_USER $RUNAS" >>"$UPSMON_C"
 	runas="$RUNAS"
 
-	config_get val "$cfg" minsupplies 1
-	echo "MINSUPPLIES $val" >> "$UPSMON_C"
-
-	config_get val "$cfg" shutdowncmd "/usr/sbin/nutshutdown"
-	echo "SHUTDOWNCMD \"$val\"" >> "$UPSMON_C"
-
-	config_get val "$cfg" notifycmd
-	[ -n "$val" ] && echo "NOTIFYCMD \"$val\"" >> "$UPSMON_C"
-
-	config_get val "$cfg" pollfreq 5
-	echo "POLLFREQ $val" >> "$UPSMON_C"
-
-	config_get val "$cfg" pollfreqalert 5
-	echo "POLLFREQALERT $val" >> "$UPSMON_C"
-
-	config_get val "$cfg" hostsync 15
-	echo "HOSTSYNC $val" >> "$UPSMON_C"
-
 	config_get val "$cfg" deadtime 15
-	echo "DEADTIME $val" >> "$UPSMON_C"
-
-	echo "POWERDOWNFLAG /var/run/killpower" >> "$UPSMON_C"
-
-	config_get val "$cfg" onlinemsg
-	[ -n "$val" ] && echo "NOTIFYMSG ONLINE \"$val\"" >> "$UPSMON_C"
-	config_get val "$cfg" onbattmsg
-	[ -n "$val" ] && echo "NOTIFYMSG ONBATT \"$val\"" >> "$UPSMON_C"
-	config_get val "$cfg" lowbattmsg
-	[ -n "$val" ] && echo "NOTIFYMSG LOWBATT \"$val\"" >> "$UPSMON_C"
-	config_get val "$cfg" fsdmsg
-	[ -n "$val" ] && echo "NOTIFYMSG FSD \"$val\"" >> "$UPSMON_C"
-	config_get val "$cfg" commokmsg
-	[ -n "$val" ] && echo "NOTIFYMSG COMMOK \"$val\"" >> "$UPSMON_C"
-	config_get val "$cfg" commbadmsg
-	[ -n "$val" ] && echo "NOTIFYMSG COMMBAD \"$val\"" >> "$UPSMON_C"
-	config_get val "$cfg" shutdownmsg
-	[ -n "$val" ] && echo "NOTIFYMSG SHUTDOWN \"$val\"" >> "$UPSMON_C"
-	config_get val "$cfg" replbattmsg
-	[ -n "$val" ] && echo "NOTIFYMSG REPLBATT \"$val\"" >> "$UPSMON_C"
-	config_get val "$cfg" nocommmsg
-	[ -n "$val" ] && echo "NOTIFYMSG NOCOMM \"$val\"" >> "$UPSMON_C"
-	config_get val "$cfg" noparentmsg
-	[ -n "$val" ] && echo "NOTIFYMSG NOPARENT \"$val\"" >> "$UPSMON_C"
-
-	notifylist() {
-		local value="$1"
-		append optval "$value" "+"
-	}
-
-	setnotify() {
-		local cfg="$1"
-		local optname="$2"
-		local optval
-		config_list_foreach "$cfg" "$optname" notifylist
-		if [ -z "$optval" ]; then
-			# If no list fallback to trying option, fallback to default
-			config_get optval "$cfg" "$optname" "$default"
-			if [ -n "$optval" ]; then
-				echo "$optval"
-			else
-				# No default, so do the NUT default
-				echo "SYSLOG"
-			fi
-		else
-			echo "$optval"
-		fi
-        }
-
-	local default optval
-	val=""
-	config_list_foreach "$cfg" defaultnotify notifylist
-	default="$optval"
-	{
-		echo "NOTIFYFLAG ONLINE $(setnotify "$cfg" onlinenotify)" ; \
-		echo "NOTIFYFLAG ONBATT $(setnotify "$cfg" onbattnotify)" ; \
-		echo "NOTIFYFLAG LOWBATT $(setnotify "$cfg" lowbatnotify)" ; \
-		echo "NOTIFYFLAG FSD $(setnotify "$cfg" fsdnotify)" ; \
-		echo "NOTIFYFLAG COMMOK $(setnotify "$cfg" commoknotify)" ; \
-		echo "NOTIFYFLAG COMMBAD $(setnotify "$cfg" commbadnotify)" ; \
-		echo "NOTIFYFLAG SHUTDOWN $(setnotify "$cfg" shutdownnotify)" ; \
-		echo "NOTIFYFLAG REPLBATT $(setnotify "$cfg" replbattnotify)" ; \
-		echo "NOTIFYFLAG NOCOMM $(setnotify "$cfg" nocommnotify)" ; \
-		echo "NOTIFYFLAG NOPARENT $(setnotify "$cfg" noparentnotify)" ; \
-	} >> "$UPSMON_C"
-
-	config_get val "$cfg" rbwarntime 43200
-	echo "RBWARNTIME $val" >> "$UPSMON_C"
-
-	config_get val "$cfg" nocommwarntime 300
-	echo "NOCOMMWARNTIME $val" >> "$UPSMON_C"
+	echo "DEADTIME $val" >>"$UPSMON_C"
 
 	config_get val "$cfg" finaldelay 5
-	echo "FINALDELAY $val" >> "$UPSMON_C"
+	echo "FINALDELAY $val" >>"$UPSMON_C"
+
+	config_get val "$cfg" hostsync 15
+	echo "HOSTSYNC $val" >>"$UPSMON_C"
+
+	config_get val "$cfg" minsupplies 1
+	echo "MINSUPPLIES $val" >>"$UPSMON_C"
+
+	config_get val "$cfg" nocommwarntime 300
+	echo "NOCOMMWARNTIME $val" >>"$UPSMON_C"
+
+	config_get val "$cfg" pollfaillogthrottlemax -1
+	echo "POLLFAIL_LOG_THROTTLE_MAX $val" >>"$UPSMON_C"
+
+	config_get val "$cfg" notifycmd
+	[ -n "$val" ] && echo "NOTIFYCMD \"$val\"" >>"$UPSMON_C"
+
+	config_get val "$cfg" pollfreq 5
+	echo "POLLFREQ $val" >>"$UPSMON_C"
+
+	config_get val "$cfg" pollfreqalert 5
+	echo "POLLFREQALERT $val" >>"$UPSMON_C"
+
+	echo "POWERDOWNFLAG /var/run/killpower" >>"$UPSMON_C"
+
+	config_get val "$cfg" offduration 30
+	echo "OFFDURATION $val" >>"$UPSMON_C"
+
+	config_get val "$cfg" overduration -1
+	echo "OVERDURATION $val" >>"$UPSMON_C"
+
+	config_get val "$cfg" oblbduration 0
+	echo "OBLBDURATION $val" >>"$UPSMON_C"
+
+	config_get val "$cfg" rbwarntime 43200
+	echo "RBWARNTIME $val" >>"$UPSMON_C"
+
+	config_get val "$cfg" alarmcritical 1
+	echo "ALARMCRITICAL $val" >>"$UPSMON_C"
+
+	config_get val "$cfg" shutdownexit 0
+	echo "SHUTDOWNEXIT $val" >>"$UPSMON_C"
+
+	config_get val "$cfg" shutdowncmd "/usr/sbin/nutshutdown"
+	echo "SHUTDOWNCMD \"$val\"" >>"$UPSMON_C"
 
 	config_get val "$cfg" certpath
-	if [ -n "$val" ]; then echo "CERTPATH $val" >> "$UPSMON_C"; fi
+	if [ -n "$val" ]; then echo "CERTPATH $val" >>"$UPSMON_C"; fi
 
 	config_get_bool val "$cfg" certverify 0
-	if [ -n "$val" ]; then echo "CERTVERIFY $val" >> "$UPSMON_C"; fi
+	if [ -n "$val" ]; then echo "CERTVERIFY $val" >>"$UPSMON_C"; fi
 
 	config_get_bool val "$cfg" forcessl 0
-	if [ -n "$val" ]; then echo "FORCESSL $val" >> "$UPSMON_C"; fi
+	if [ -n "$val" ]; then echo "FORCESSL $val" >>"$UPSMON_C"; fi
+
+	# debugmin must be a positive integer or zero
+	config_get val "$cfg" debugmin 0
+	case "$val" in
+		''|*[!0-9]*) ;;
+		*) echo "DEBUG_MIN $val" >>"$UPSMON_C" ;;
+	esac
+
+	config_get val "$cfg" defaultnotify "SYSLOG"
+	defaultnotify="$val"
+	config_foreach nut_get_notifications notifications "$val"
+
+	# Otherwise the default is WALL+SYSLOG
+	for event in $NUT_EVENT_TYPES; do
+		if ! grep -q "NOTIFYFLAG $event" "$UPSMON_C"; then
+			echo "NOTIFYFLAG $event $defaultnotify" >>"$UPSMON_C"
+		fi
+	done
 
 	havemon=1
 }
@@ -142,11 +134,13 @@ nut_upsmon_add() {
 	config_get powervalue "$cfg" powervalue 1
 	config_get username "$cfg" username
 	config_get password "$cfg" password
+	config_get type "$cfg" type "${type:-secondary}"
+
 	system="$upsname@$hostname"
 	if [ -n "$port" ]; then
-	    system="$system:$port";
+		system="$system:$port"
 	fi
-	echo "MONITOR $system $powervalue $username $password $type" >> "$UPSMON_C"
+	echo "MONITOR $system $powervalue $username $password $type" >>"$UPSMON_C"
 
 	havems=1
 }
@@ -157,8 +151,12 @@ build_config() {
 
 	config_load nut_monitor
 	config_foreach nut_upsmon_conf upsmon
-	config_foreach nut_upsmon_add master master
-	config_foreach nut_upsmon_add slave slave
+	config_foreach nut_upsmon_add primary primary
+	config_foreach nut_upsmon_add secondary secondary
+	config_foreach nut_upsmon_add monitor
+	# master and slave are legacy section names. Prefer monitor.
+	config_foreach nut_upsmon_add master primary
+	config_foreach nut_upsmon_add slave secondary
 
 	[ ! -s /var/etc/nut/nut.conf ] && {
 		echo "MODE=netclient" >>/var/etc/nut/nut.conf

--- a/net/nut/files/nut-sendmail-notify.default
+++ b/net/nut/files/nut-sendmail-notify.default
@@ -34,11 +34,15 @@ if [ "$REMOVEDEFAULTNOTIFY" = "1" ]; then
 fi
 
 if [ "$SKIPADDEXEC" != "1" ]; then
-	uci add_list nut_monitor.@upsmon[-1].defaultnotify="EXEC"
-fi
-
-if [ "$SKIPADDSYSLOG" != "1" ]; then
-	uci add_list nut_monitor.@upsmon[-1].defaultnotify="SYSLOG"
+	if [ "$SKIPADDSYSLOG" != "1" ]; then
+		uci set nut_monitor.@upsmon[-1].defaultnotify="SYSLOG+EXEC"
+	else
+		uci set nut_monitor.@upsmon[-1].defaultnotify="EXEC"
+	fi
+else
+	if [ "$SKIPADDSYSLOG" != "1" ]; then
+		uci set nut_monitor.@upsmon[-1].defaultnotify="SYSLOG"
+	fi
 fi
 
 uci commit nut_monitor

--- a/net/nut/files/nut_monitor
+++ b/net/nut/files/nut_monitor
@@ -1,41 +1,29 @@
 #config upsmon 'upsmon'
 #	option runas nutmon
+#	option deadtime 15
+#	option finaldelay 5 # final delay
+#	option hostsync 15
 #	option minsupplies 1
-#	option shutdowncmd '/usr/sbin/nutshutdown'
-#	option notifycmd /path/to/cmd
-#	list defaultnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
+#	option nocommwarntime 300 # no communications warn time
+#	option pollfaillogthrottlemax -1
+#	option notifycmd '/path/to/cmd'
 #	option pollfreq 5
 #	option pollfreqalert 5
-# 	option hostsync 15
-#	option deadtime 15
-#	option onlinemsg "online message"
-#	option onbattmsg "on battery message"
-#	option lowbattmsg "low battery message"
-#	option fsdmsg "forced shutdown message"
-#	option comokmsg "communications restored message"
-#	option combadmsg "communications bad message"
-#	option shutdowmsg "shutdown message"
-#	option replbattmsg "replace battery message"
-#	option nocommmsg "no communications message"
-#	option noparentmsg "no parent message"
-#	list onlinenotify SYSLOG # can be SYSLOG or EXEC or IGNORE
-#	list onbattnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
-#	list lowbattnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
-#	list fsdnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
-#	list comoknotify SYSLOG # can be SYSLOG or EXEC or IGNORE
-#	list combadnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
-#	list shutdownotify SYSLOG # can be SYSLOG or EXEC or IGNORE
-#	list replbattnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
-#	list nocommnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
-#	list noparentnotify SYSLOG # can be SYSLOG or EXEC or IGNORE
-#	option rbwarntime 4200 # replace battery warn time
-#	option nocommwarntime 300 # no communications warn time
-#	option finaldelay 5 # final delay
+#	option offduration 30
+#	option overduration -1
+#	option oblbduration 0
+#	option shutdowncmd '/usr/sbin/nutshutdown'
+#	option rbwarntime 43200 # replace battery warn time
+#	option alarmcritical 1
+#	option shutdownexit 0
 #	option certpath /path/to/ca/dir
 #	option certverify 0
 #	option forcessl 0
+#	option debugmin 0
+# option defaultnotify SYSLOG
 
-#config master
+#config monitor
+#	option type primary
 #	option upsname upsname
 #	option hostname localhost
 #	option port # optional port number
@@ -43,10 +31,27 @@
 #	option username upsuser
 #	option password upspassword
 
-#config slave
+#config monitor
+#	option type secondary
 #	option upsname upsname
 #	option hostname localhost
 #	option port # optional port number
 #	option powervalue 1
 #	option username upsuser
 #	option password upspassword
+
+#config notifications 'COMMOK'
+#	option message "Communications with UPS %s established"
+#	option flag "SYSLOG"
+
+#config notifications 'COMMBAD'
+#	option message "Communications with UPS %s lost"
+#	option flag "SYSLOG+EXEC"
+
+#config notifications 'ONLINE'
+#	option message "UPS %s is on line power"
+#	option flag "SYSLOG"
+
+#config notifications 'ONBATT'
+#	option message "UPS %s is on battery power"
+#	option flag "SYSLOG+EXEC"

--- a/net/nut/files/nut_server
+++ b/net/nut/files/nut_server
@@ -11,7 +11,7 @@
 #	option password upspassword
 #	option actions optional-action
 #	list instcmd optional-instant-command
-#	option upsmon slave|master
+#	option upsmon secondary|primary
 
 #config listen_address
 #	option address ::1


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 
**Also-mention:** @systemcrash @hnyman @mhei @usamanassir


**Description:**

Prompted by
https://github.com/openwrt/luci/pull/8420#issuecomment-4071252681
we update upsmon configs to ensure they are correct according to
upstream. We reorder the options so that they match upstream
documentation at
<https://networkupstools.org/docs/man/upsmon.conf.html> to be sure
we have not missed any items.
While at it, we add configuration options from the upstream
documentation that are not currently present in the UCI configs.

Some years ago upstream changed the names the primary/secondary
UPS system/monitor from master/slave to primary/secondary. It
is uncertain how much longer these deprecated names will be
accepted by NUT.
Therefore update naming to match upstream documentation and
configuration. See
<https://networkupstools.org/docs/man/upsmon.html>,
<https://networkupstools.org/docs/man/upsmon.conf.html>, and
<https://networkupstools.org/docs/man/upsd.users.html>.

At the same time, prompted by
https://github.com/openwrt/packages/pull/28875#issuecomment-4079307540
we simplify the configuration and add checks to avoid bad configs
due to misspellings/typos of configuation options by users.

Add myself as maintainer, and bump PKG_RELEASE.

A sample config

```
config upsmon 'upsmon'
       option notifycmd '/usr/bin/logger -t nut-monitor-exec '

config monitor
        option type primary
        option upsname upsname
        option hostname localhost
        option username upsuser
        option password upspassword

config notifications 'ONLINE'
        option message "UPS %s is on line power"
        option flag "SYSLOG"

config notifications 'ONBATT'
        option message "UPS %s is on battery power"
        option flag "SYSLOG+EXEC"
```

In order to iterate through the notifications, we use named 'notifications' sections and compare the section name to list of notification events defined by NUT. If they don't match, warn during initscript startup.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r33802-6c3c959b1b
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2709
- **OpenWrt Device:** Raspberry Pi 2 Model B Rev 1.1

UPS: Tripp-Lite ECO550U
UPS: Tripp-Lite AVR550UPS
UPS: dummy-ups

---

In particular, the configuration of custom notification messages, and notification methods (SYSLOG, EXEC'ing a script) has breaking changes and we want to hear if there as anyone a) actually using that functionality and b) how they feel about the change to how this is configured.

---

**Note:** Matching LuCI app update: https://github.com/openwrt/luci/pull/8533

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
