### PR TITLE
utils/beep: assign PKG_CPE_ID

### DIFF
--- a/utils/beep/Makefile
+++ b/utils/beep/Makefile
@@ -13,6 +13,7 @@ PKG_RELEASE:=6
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:beep_project:beep
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/spkr-beep/beep/tar.gz/v$(PKG_VERSION)?


### PR DESCRIPTION
cpe:/a:beep_project:beep is the correct CPE ID for beep: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:beep_project:beep

**Maintainer:** @riptidewave93