### PR TITLE
lang/chicken-scheme: assign PKG_CPE_ID

### DIFF
--- a/lang/chicken-scheme/Makefile
+++ b/lang/chicken-scheme/Makefile
@@ -16,6 +16,7 @@ PKG_MAINTAINER:=Jeronimo Pellegrini <j_p@aleph0.info>
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:call-cc:chicken
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
cpe:/a:call-cc:chicken is the correct CPE ID for chicken-scheme: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:call-cc:chicken

**Maintainer:** @jpellegrini