### PR TITLE
net/zerotier: assign PKG_CPE_ID

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -17,6 +17,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/ZeroTierOne-$(PKG_VERSION)
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
 PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=LICENSE.txt
+PKG_CPE_ID:=cpe:/a:zerotier:zerotierone
 
 PKG_ASLR_PIE:=0
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
cpe:/a:zerotier:zerotierone is the correct CPE ID for zerotier: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:zerotier:zerotierone

**Maintainer:** @mwarning