### PR TITLE
python/python-wheel: assign PKG_CPE_ID

### DIFF
--- a/lang/python/python-wheel/Makefile
+++ b/lang/python/python-wheel/Makefile
@@ -17,6 +17,7 @@ PKG_HASH:=661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_CPE_ID:=cpe:/a:wheel_project:wheel
 
 PKG_HOST_ONLY:=1
 HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-flit-core/host


### PR DESCRIPTION
cpe:/a:wheel_project:wheel is the correct CPE ID for python-wheel: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:wheel_project:wheel

**Maintainer:** @commodo