### PR TITLE
python-setuptools: bump to 82.0.1

### DIFF
--- a/lang/python/python-setuptools/Makefile
+++ b/lang/python/python-setuptools/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-setuptools
-PKG_VERSION:=80.9.0
-PKG_RELEASE:=2
+PKG_VERSION:=82.0.1
+PKG_RELEASE:=1
 
 PYPI_NAME:=setuptools
-PKG_HASH:=f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
+PKG_HASH:=7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -37,19 +37,13 @@ define Package/python3-setuptools/Default
   URL:=https://github.com/pypa/setuptools
 endef
 
-define Package/python3-pkg-resources
-$(call Package/python3-setuptools/Default)
-  TITLE:=Package resource API
-  DEPENDS:=+python3-light +python3-email +python3-logging +python3-urllib
-endef
-
 define Package/python3-setuptools
 $(call Package/python3-setuptools/Default)
   TITLE:=Fully-featured library to package Python projects
-  DEPENDS:=+python3 +python3-pkg-resources
+  DEPENDS:=+python3
 endef
 
-define Package/python3-setuptools/description/Default
+define Package/python3-setuptools/description
 Setuptools is a fully-featured, actively-maintained, and stable library
 designed to facilitate packaging Python projects.
 
@@ -58,34 +52,10 @@ library) and programs (e.g., CLI/GUI tools implemented in Python), that
 can be installed with pip and uploaded to PyPI.
 endef
 
-define Package/python3-pkg-resources/description
-$(call Package/python3-setuptools/description/Default)
-
-This is the pkg_resources module of setuptools.
-endef
-
-define Package/python3-setuptools/description
-$(call Package/python3-setuptools/description/Default)
-
-This is the main setuptools module.
-endef
-
-define Py3Package/python3-pkg-resources/filespec
-+|$(PYTHON3_PKG_DIR)/pkg_resources
-endef
-
-define Py3Package/python3-setuptools/filespec
-+|$(PYTHON3_PKG_DIR)
--|$(PYTHON3_PKG_DIR)/pkg_resources
-endef
-
-$(eval $(call Py3Package,python3-pkg-resources))
 $(eval $(call Py3Package,python3-setuptools))
 
-$(eval $(call BuildPackage,python3-pkg-resources))
 $(eval $(call BuildPackage,python3-setuptools))
 
-$(eval $(call BuildPackage,python3-pkg-resources-src))
 $(eval $(call BuildPackage,python3-setuptools-src))
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Changelog since 80.9.0:
- v81.0.0: Remove --dry-run parameter from setup.py
- v82.0.0: Remove pkg_resources module (deprecated since 67.5.0); users should migrate to importlib.resources / importlib.metadata
- v82.0.1: Fix loading of launcher manifest.xml file; documentation improvements for installing source distributions

Since pkg_resources has been removed in v82.0.0, drop the python3-pkg-resources sub-package and remove it as a dependency from python3-setuptools.

Full changelog:
https://github.com/pypa/setuptools/releases
---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
