### PR TITLE
python-pyasn1: bump to 0.6.2

### DIFF
--- a/lang/python/python-pyasn1/Makefile
+++ b/lang/python/python-pyasn1/Makefile
@@ -8,15 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyasn1
-PKG_VERSION:=0.5.1
+PKG_VERSION:=0.6.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=pyasn1
-PKG_HASH:=6d391a96e59b23130a5cfa74d6fd7f388dbbe26cc8f1edf39fdddf08d9d6676c
+PKG_HASH:=9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b
 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+
+PKG_BUILD_DEPENDS:=python-setuptools/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Changelog since 0.5.1:
- v0.6.0: Drop Python 2.7 and Python 3.6/3.7 support; add support for RELATIVE-OID construct
- v0.6.1: Add Python 3.13 compatibility; remove legacy Python 2 code
- v0.6.2: Fix continuation octet limits in OID/RELATIVE-OID decoder (CVE-2026-23490); add Python 3.14 support; switch to pyproject.toml

Full changelog:
https://github.com/pyasn1/pyasn1/releases

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.