### PR TITLE
python-gmpy2: bump to 2.3.0

### DIFF
--- a/lang/python/python-gmpy2/Makefile
+++ b/lang/python/python-gmpy2/Makefile
@@ -8,18 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-gmpy2
-PKG_VERSION:=2.2.2
+PKG_VERSION:=2.3.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=gmpy2
-PKG_HASH:=d9b8c81e0f5e1a3cabf1ea8d154b29b5ef6e33b8f4e4c37b3da957b2dd6a3fa8
+PKG_HASH:=2d943cc9051fcd6b15b2a09369e2f7e18c526bc04c210782e4da61b62495eb4a
 
 PKG_LICENSE:=LGPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING.LESSER
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 
 PKG_BUILD_DEPENDS:= \
-	python-setuptools/host
+	python-setuptools/host \
+	python-setuptools-scm/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -31,7 +32,7 @@ define Package/python3-gmpy2
   SUBMENU:=Python
   TITLE:=GMP/MPIR, MPFR, and MPC interface
   URL:=https://github.com/aleaxit/gmpy
-  DEPENDS:=+libgmp +libmpc +libmpfr +python3-light
+  DEPENDS:=+libgmp +libmpc +libmpfr +python3-light +python3-email python3-urllib
 endef
 
 define Package/python3-gmpy2/description

--- a/lang/python/python-gmpy2/patches/001-relax-setuptools-version-constraint.patch
+++ b/lang/python/python-gmpy2/patches/001-relax-setuptools-version-constraint.patch
@@ -1,0 +1,9 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ['setuptools>=77,<80', 'setuptools_scm[toml]>=6.0']
++requires = ['setuptools>=77', 'setuptools_scm[toml]>=6.0']
+ build-backend = 'setuptools.build_meta'
+ 
+ [project]

--- a/lang/python/python-gmpy2/test.sh
+++ b/lang/python/python-gmpy2/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ "$1" = python3-gmpy2 ] || exit 0
+
+python3 -c 'import gmpy2'


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Changelog since 2.2.2:
- Add mpz.array() method for NumPy interaction
- Implement mpq.limit_denominator() functionality
- Add is_integer() method for mpz/mpq types
- Add mixed-mode arithmetic support for mpc types
- Enhanced formatting using context's rounding mode defaults
- Full free-threaded Python build support
- Fix memory leaks in MPFR/MPC cache and context exit
- Drop CPython 3.8 support (requires 3.9+)

Add test.sh.

Full changelog:
https://github.com/aleaxit/gmpy/releases


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
