### PR TITLE
adguardhome: validate config

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
 PKG_VERSION:=0.107.73
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/AdGuardHome/tar.gz/v$(PKG_VERSION)?
@@ -74,7 +74,7 @@ define Package/adguardhome/install
 	$(INSTALL_CONF) ./files/adguardhome.json $(1)/etc/capabilities/adguardhome.json
 
 	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_CONF) ./files/adguardhome.config $(1)/etc/config/adguardhome
+	$(INSTALL_CONF) ./files/adguardhome.conf $(1)/etc/config/adguardhome
 
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/adguardhome.init $(1)/etc/init.d/adguardhome

--- a/net/adguardhome/files/adguardhome.conf
+++ b/net/adguardhome/files/adguardhome.conf
@@ -17,7 +17,7 @@ config adguardhome 'config'
 
 	# Advanced options. Modify at your own risk.
 
-	# https://go.dev/doc/gc-guide#GOGC
+	# More info: https://go.dev/doc/gc-guide#GOGC
 	option gc '0'
 
 	# Max number of OS threads to use

--- a/net/adguardhome/files/adguardhome.init
+++ b/net/adguardhome/files/adguardhome.init
@@ -12,30 +12,6 @@ STOP=89
 PROG=/usr/bin/AdGuardHome
 USE_PROCD=1
 
-config_cb() {
-	[ $# -eq 0 ] && return
-
-	option_cb() {
-		local option="$1"
-		local value="$2"
-
-		case $option in
-
-		# Support old option names
-		config)
-			option='config_file'
-			;;
-
-		workdir)
-			option='work_dir'
-			;;
-
-		esac
-
-		eval $option="$value"
-	}
-}
-
 boot() {
 	ADGUARDHOME_BOOT=1
 	start "$@"
@@ -47,21 +23,34 @@ start_service() {
 		return 0
 	fi
 
-	local config_file='/etc/adguardhome/adguardhome.yaml'
-	local gc=0
-	local group='adguardhome'
-	local maxprocs=0
-	local memlimit=0
-	local user='adguardhome'
-	local verbose=0
-	local work_dir='/var/lib/adguardhome'
-
 	config_load 'adguardhome'
+
+	local config_name='config'
+	local config_file config group user verbose work_dir workdir
+	local gc maxprocs memlimit
+
+	uci_validate_section 'adguardhome' 'adguardhome' "$config_name" \
+		'gc:uinteger:0' \
+		'group:string:adguardhome' \
+		'config:string' \
+		'config_file:string:/etc/adguardhome/adguardhome.yaml' \
+		'jail_mount:list(string)' \
+		'jail_mount_rw:list(string)' \
+		'maxprocs:uinteger:0' \
+		'memlimit:uinteger:0' \
+		'user:string:adguardhome' \
+		'verbose:bool:0' \
+		'workdir:string' \
+		'work_dir:string:/var/lib/adguardhome'
+
+	# Compatibility with older configs
+	[ -n "$config" ] && config_file="$config"
+	[ -n "$workdir" ] && work_dir="$workdir"
 
 	local config_dir
 	config_dir=$(dirname "$config_file")
 	if [ "$config_dir" = '/etc' ]; then
-		echo "AdGuard Home config must be stored in its own directory, and not in /etc" >&2
+		echo 'AdGuard Home config must be stored in its own directory, and not in /etc' >&2
 		return 1
 	fi
 	mkdir -m 0700 -p "$config_dir"
@@ -70,24 +59,25 @@ start_service() {
 	mkdir -m 0700 -p "$work_dir"
 	chown -R "$user":"$group" "$work_dir"
 
-	procd_open_instance
+	procd_open_instance adguardhome
 
 	procd_set_param command "$PROG"
+
 	[ "$gc" -le 0 ] || procd_append_param env GOGC="$gc"
 	[ "$maxprocs" -le 0 ] || procd_append_param env GOMAXPROCS="$maxprocs"
 	[ "$memlimit" -le 0 ] || procd_append_param env GOMEMLIMIT="$memlimit"
+
 	procd_append_param command --config "$config_file"
 	procd_append_param command --logfile syslog
 	procd_append_param command --no-check-update
-	[ "$verbose" = 1 ] && \
-		procd_append_param command --verbose
+	[ "$verbose" = 1 ] && procd_append_param command --verbose
 	procd_append_param command --work-dir "$work_dir"
 
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_set_param user "$user"
 	procd_set_param group "$group"
-	procd_set_param capabilities /etc/capabilities/adguardhome.json
+	procd_set_param capabilities '/etc/capabilities/adguardhome.json'
 	procd_set_param no_new_privs 1
 	procd_set_param respawn
 
@@ -99,20 +89,20 @@ start_service() {
 	procd_add_jail_mount_rw "$config_dir"
 	procd_add_jail_mount_rw "$work_dir"
 
-	procd_add_jail_mount /etc/hosts
-	procd_add_jail_mount /etc/ssl/certs
-	config_list_foreach config jail_mount procd_add_jail_mount
-	config_list_foreach config jail_mount_rw procd_add_jail_mount_rw
+	procd_add_jail_mount '/etc/hosts'
+	procd_add_jail_mount '/etc/ssl/certs'
+	config_list_foreach "$config_name" jail_mount procd_add_jail_mount
+	config_list_foreach "$config_name" jail_mount_rw procd_add_jail_mount_rw
 
 	procd_close_instance
 }
 
 service_triggers() {
-	procd_add_reload_trigger 'adguardhome'
+	procd_add_reload_trigger adguardhome
 
 	if [ -n "$ADGUARDHOME_BOOT" ]; then
 		# Wait for interfaces to be up before starting AdGuard Home for real.
 		# Prevents issues like https://github.com/openwrt/packages/issues/21868.
-		procd_add_raw_trigger "interface.*.up" 5000 /etc/init.d/adguardhome restart
+		procd_add_raw_trigger 'interface.*.up' 5000 /etc/init.d/adguardhome restart
 	fi
 }


### PR DESCRIPTION
**Maintainer:** me

**Description:**

Backport to 25.12:
- #28781 

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.1
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Zyxel EX5601-T0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.