### PR TITLE
sound/owntone: fix typo in PKG_CPE_ID

### DIFF
--- a/sound/owntone/Makefile
+++ b/sound/owntone/Makefile
@@ -23,7 +23,7 @@ PKG_INSTALL:=1
 PKG_MAINTAINER:=Espen Jürgensen <espenjurgensen+openwrt@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:owntone:owtone_server
+PKG_CPE_ID:=cpe:/a:owntone:owntone_server
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk


### PR DESCRIPTION
cpe:/a:owntone:owntone_server is the correct CPE ID for owntone: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:owntone:owntone_server

Fixes: e8360bc4e1205e9b931623f9a9a1044056af85cd (sound/owntone: assign PKG_CPE_ID)