### PR TITLE
mail/bogofilter: fix PKG_CPE_ID

### DIFF
--- a/mail/bogofilter/Makefile
+++ b/mail/bogofilter/Makefile
@@ -15,7 +15,7 @@ PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:bogofilter:bogofilter
+PKG_CPE_ID:=cpe:/a:bogofilter_project:bogofilter
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION2).tar.bz2
 PKG_SOURCE_URL:=https://gitlab.com/bogofilter/bogofilter/-/archive/$(PKG_NAME)-$(PKG_VERSION2)


### PR DESCRIPTION
cpe:/a:bogofilter_project:bogofilter is the correct CPE ID for bogofilter: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:bogofilter_project:bogofilter

Fixes: 299e5b0a9bce19d6e96cb9ff217028b36ee2dd36 (treewide: add PKG_CPE_ID for better cvescanner coverage)