### PR TITLE
multimedia/icecast: fix PKG_CPE_ID

### DIFF
--- a/multimedia/icecast/Makefile
+++ b/multimedia/icecast/Makefile
@@ -18,7 +18,7 @@ PKG_MAINTAINER:=André Gaul <andre@gaul.io>, \
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:icecast:icecast
+PKG_CPE_ID:=cpe:/a:xiph:icecast
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:= 1


### PR DESCRIPTION
cpe:/a:xiph:icecast is the correct CPE ID for icecast: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:xiph:icecast

Fixes: a36f265f767da363b60ef09a3b72bb84d9d3cf33 (icecast: Update to 2.4.4)