### PR TITLE
net/smcroute: assign PKG_CPE_ID

### DIFF
--- a/net/smcroute/Makefile
+++ b/net/smcroute/Makefile
@@ -12,6 +12,7 @@ PKG_VERSION:=2.5.6
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:troglobit:smcroute
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/troglobit/smcroute/releases/download/$(PKG_VERSION)


### PR DESCRIPTION
cpe:/a:troglobit:smcroute is the correct CPE ID for smcroute: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:troglobit:smcroute