### PR TITLE
python/python-orjson: assign PKG_CPE_ID

### DIFF
--- a/lang/python/python-orjson/Makefile
+++ b/lang/python/python-orjson/Makefile
@@ -10,6 +10,7 @@ PKG_HASH:=0a78bbda3aea0f9f079057ee1ee8a1ecf790d4f1af88dd67493c6b8ee52506ff
 PKG_MAINTAINER:=Timothy Ace <openwrt@timothyace.com>
 PKG_LICENSE:=Apache-2.0 MIT
 PKG_LICENSE_FILES:=LICENSE-APACHE LICENSE-MIT
+PKG_CPE_ID:=cpe:/a:ijl:orjson
 
 PKG_BUILD_DEPENDS:=python-maturin/host
 


### PR DESCRIPTION
cpe:/a:ijl:orjson is the correct CPE ID for orjson: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:ijl:orjson