### PR TITLE
python/python-eventlet: assign PKG_CPE_ID

### DIFF
--- a/lang/python/python-eventlet/Makefile
+++ b/lang/python/python-eventlet/Makefile
@@ -17,6 +17,7 @@ PKG_HASH:=69bef712b1be18b4930df6f0c495d2a882bf7b63aa111e7b6eeff461cfcaf26f
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:eventlet:eventlet
 
 PKG_BUILD_DEPENDS:= \
 	python3/host \


### PR DESCRIPTION
cpe:/a:eventlet:eventlet is the correct CPE ID for python-eventlet: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:eventlet:eventlet