### PR TITLE
[24.10] hev-socks5-tunnel: update to 2.14.3 (Backport from 25.12)

### DIFF
--- a/net/hev-socks5-tunnel/Makefile
+++ b/net/hev-socks5-tunnel/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hev-socks5-tunnel
-PKG_VERSION:=2.14.0
+PKG_VERSION:=2.14.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/heiher/hev-socks5-tunnel/releases/download/$(PKG_VERSION)
-PKG_HASH:=f0c5909b188272a6cee2b3c92e13cf16d927ba29a20bd1d750a2ff3419cda381
+PKG_HASH:=d517a16072eea7320b0430bdf8a152a901a3f3569ff86858729d1a80fa9d5cd0
 
 PKG_MAINTAINER:=Ray Wang <git@hev.cc>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @heiher

**Description:** Update to 2.14.3

Upstream changelog:
https://github.com/heiher/hev-socks5-tunnel/releases/tag/2.14.3

This update backported from https://github.com/openwrt/packages/pull/28391 and solves that problem: https://github.com/heiher/hev-socks5-tunnel/issues/288 

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.5
- **OpenWrt Target/Subtarget:** aarch64_cortex-a53
- **OpenWrt Device:** Cudy WR3000P v1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
