### PR TITLE
python-incremental: bump to 24.11.0

### DIFF
--- a/lang/python/python-incremental/Makefile
+++ b/lang/python/python-incremental/Makefile
@@ -8,17 +8,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-incremental
-PKG_VERSION:=24.7.2
-PKG_RELEASE:=2
+PKG_VERSION:=24.11.0
+PKG_RELEASE:=1
 
 PYPI_NAME:=incremental
-PKG_HASH:=fb4f1d47ee60efe87d4f6f0ebb5f70b9760db2b2574c59c8e8912be4ebd464c9
+PKG_HASH:=87d3480dbb083c1d736222511a8cf380012a8176c2456d01ef483242abbbcf8c
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 
-HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-wheel/host
+HOST_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-hatchling/host
+PKG_BUILD_DEPENDS:=python3/host python-build/host python-installer/host python-hatchling/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -32,7 +33,7 @@ define Package/python3-incremental
   SUBMENU:=Python
   TITLE:=Versions your Python projects
   URL:=https://github.com/twisted/incremental
-  DEPENDS:=+python3-light +python3-pkg-resources
+  DEPENDS:=+python3-light +python3-packaging
 endef
 
 define Package/python3-incremental/description

--- a/lang/python/python-incremental/test.sh
+++ b/lang/python/python-incremental/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ "$1" = python3-incremental ] || exit 0
+
+python3 -c 'import incremental'


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me


**Description:**

Changelog since 24.7.2:
- Switch build system from wheel to hatchling
- Switch runtime dependency from setuptools/pkg-resources to packaging
- Add CLI script (pipx run incremental)
- Add Python 3.13 and 3.14 support; drop Python 3.8 support
- Drop Click dependency from CLI

Update HOST_BUILD_DEPENDS to use python-hatchling/host instead of python-wheel/host, and replace +python3-pkg-resources dependency with +python3-packaging in DEPENDS.

Add test.sh.

Full changelog:
https://github.com/twisted/incremental/releases

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

