### PR TITLE
[25.12] telegraf: add disk plugin to small variant

### DIFF
--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telegraf
 PKG_VERSION:=1.38.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
@@ -30,6 +30,7 @@ endif
 
 TELEGRAF_SMALL_PLUGINS:=custom \
 	inputs.cpu \
+	inputs.disk \
 	inputs.ethtool \
 	inputs.http \
 	inputs.internal \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
This pull requests adds the inputs.disk plugin to the small variant of the package. It has no affect on the final package size and is a nice-to-have plugin for monitoring storage usage for example.

```bash
du old.apk new.apk 
10284	old.apk
10284	new.apk
```
---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.1
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** LXC container

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.