### PR TITLE
python-greenlet: bump to 3.3.2

### DIFF
--- a/lang/python/python-greenlet/Makefile
+++ b/lang/python/python-greenlet/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-greenlet
-PKG_VERSION:=3.3.1
+PKG_VERSION:=3.3.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=greenlet
-PKG_HASH:=41848f3230b58c08bb43dee542e74a2a2e34d3c59dc3076cec9151aeeedcae98
+PKG_HASH:=2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT

--- a/lang/python/python-greenlet/test.sh
+++ b/lang/python/python-greenlet/test.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+[ "$1" = python3-greenlet ] || exit 0
+
+python3 - <<'EOF'
+import greenlet
+
+results = []
+
+def consumer():
+    while True:
+        value = greenlet.getcurrent().parent.switch()
+        if value is None:
+            break
+        results.append(value * 2)
+
+c = greenlet.greenlet(consumer)
+c.switch()  # start consumer, runs until first switch back
+
+for i in [1, 2, 3]:
+    c.switch(i)
+c.switch(None)  # signal done
+
+assert results == [2, 4, 6], f"Expected [2, 4, 6], got {results}"
+EOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me


**Description:**

Changelog since 3.3.1:
- v3.3.2: Fix crash on Python 3.10 during interpreter shutdown with active greenlets

Add test.sh.

Full changelog:
https://github.com/python-greenlet/greenlet/releases

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

