### PR TITLE
python-apipkg: bump to 3.0.2

### DIFF
--- a/lang/python/python-apipkg/Makefile
+++ b/lang/python/python-apipkg/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-apipkg
-PKG_VERSION:=3.0.1
+PKG_VERSION:=3.0.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=apipkg
-PKG_HASH:=f8c021adafc9132ac2fba9fd3c5768365d0a8c10aa375fb15e329f1fce8a5f01
+PKG_HASH:=c7aa61a4f82697fdaa667e70af1505acf1f7428b1c27b891d204ba7a8a3c5e0d
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT

--- a/lang/python/python-apipkg/test.sh
+++ b/lang/python/python-apipkg/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ "$1" = python3-apipkg ] || exit 0
+
+python3 -c 'import apipkg'


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Changelog since 3.0.1:
- Fix import path to make it vendoring-friendly
- Remove py reference from test suite

Add test.sh.

Full changelog:
https://github.com/pytest-dev/apipkg/releases

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.