### PR TITLE
python-zipp: bump to 3.23.0

### DIFF
--- a/lang/python/python-zipp/Makefile
+++ b/lang/python/python-zipp/Makefile
@@ -1,17 +1,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-zipp
-PKG_VERSION:=3.16.2
+PKG_VERSION:=3.23.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=zipp
-PKG_HASH:=ebc15946aa78bd63458992fc81ec3b6f7b1e92d51c35e6de1c3804e73b799147
+PKG_HASH:=a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DEPENDS:=python-setuptools-scm/host  # setuptools_scm[toml] >= 3.4.1
+PKG_BUILD_DEPENDS:=python-setuptools/host python-setuptools-scm/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk

--- a/lang/python/python-zipp/patches/001-remove-coherent-licensed-build-dep.patch
+++ b/lang/python/python-zipp/patches/001-remove-coherent-licensed-build-dep.patch
@@ -1,0 +1,10 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -3,7 +3,6 @@ requires = [
+ 	"setuptools>=77",
+ 	"setuptools_scm[toml]>=3.4.1",
+ 	# jaraco/skeleton#174
+-	"coherent.licensed",
+ ]
+ build-backend = "setuptools.build_meta"
+ 

--- a/lang/python/python-zipp/test.sh
+++ b/lang/python/python-zipp/test.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+[ "$1" = python3-zipp ] || exit 0
+
+python3 - <<'EOF'
+import io
+import zipfile
+import zipp
+
+# Create an in-memory zip with a nested structure
+buf = io.BytesIO()
+with zipfile.ZipFile(buf, "w") as zf:
+    zf.writestr("a/b/c.txt", "hello")
+    zf.writestr("a/d.txt", "world")
+buf.seek(0)
+
+zf = zipfile.ZipFile(buf)
+root = zipp.Path(zf)
+
+# Navigate and read
+c = root / "a" / "b" / "c.txt"
+assert c.read_text() == "hello", f"unexpected content: {c.read_text()!r}"
+
+d = root / "a" / "d.txt"
+assert d.read_text() == "world", f"unexpected content: {d.read_text()!r}"
+
+# Test iterdir
+names = {p.name for p in (root / "a").iterdir()}
+assert names == {"b", "d.txt"}, f"unexpected names: {names}"
+
+# Test is_file / is_dir
+assert c.is_file()
+assert (root / "a" / "b").is_dir()
+EOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Changelog since 3.16.2:
- v3.17.0: Add CompleteDirs.inject classmethod; prevent path separators from matching '?' wildcards in glob
- v3.18.0: Improve glob performance bypassing ZipFile.namelist; support platform-specific path separators in glob
- v3.19.1: Fix handling of malformed zip files
- v3.19.3: Fix glob to match directories in addition to files
- v3.20.0: Expose zipfile compatibility overlay as public API (zipp.compat.overlay)
- v3.20.1: Fix infinite loops in archive name handling preserving special chars
- v3.20.2: Make zipfile compatibility overlay hashable
- v3.21.0: Enhance performance for zipfile.Path.open in non-reading modes
- v3.22.0: Fix basename-based properties on Windows; backport CPython tests
- v3.23.0: Add compatibility shim supporting Python 3.13 and earlier

Add python-setuptools/host to PKG_BUILD_DEPENDS (now requires setuptools>=77). Patch out coherent.licensed build dependency (not packaged). Add test.sh.

Full changelog:
https://github.com/jaraco/zipp/releases

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
