### PR TITLE
adblock-fast: update to 1.2.2-r14

### DIFF
--- a/net/adblock-fast/Makefile
+++ b/net/adblock-fast/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=12
+PKG_RELEASE:=14
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=AGPL-3.0-or-later
 

--- a/net/adblock-fast/files/lib/adblock-fast/adblock-fast.uc
+++ b/net/adblock-fast/files/lib/adblock-fast/adblock-fast.uc
@@ -157,7 +157,6 @@ const canary = {
 
 let state = {
 	script_name: pkg.name,
-	is_tty: false,
 	output_queue: '',
 	fw4_restart: false,
 };
@@ -474,9 +473,8 @@ let _write = function(level, ...args) {
 	let msg = join('', args);
 	if (level != null && (cfg.verbosity & level) == 0) return;
 
-	// Print to stderr (terminal)
-	if (state.is_tty)
-		warn(replace(msg, /\\n/g, '\n'));
+	// Print to stderr (terminal / console)
+	warn(replace(msg, /\\n/g, '\n'));
 
 	// Queue for logger: flush on newline
 	if (index(msg, '\\n') >= 0 || index(msg, '\n') >= 0) {
@@ -900,8 +898,6 @@ function parse_options(raw, schema) { // ucode-lsp disable
 // ── env.load_config ─────────────────────────────────────────────────
 
 env.load_config = function() {
-	if (state.is_tty == null)
-		state.is_tty = system('[ -t 2 ]') == 0 ? true : false;
 	let raw = uci(pkg.name, true).get_all(pkg.name, 'config') || {};
 	cfg = parse_options(raw, config_schema);
 	env.dns_set_output_values(cfg.dns);
@@ -2306,6 +2302,10 @@ function start(args) {
 		output.info('Starting ' + pkg.service_name + '...\\n');
 		output.verbose('[INIT] Starting ' + pkg.service_name + '...\\n');
 		status_data.status = 'statusStarting';
+		// Ensure cache/output directories exist (on_boot skips _setup_directories)
+		for (let f in [dns_output.file, dns_output.cache]) {
+			if (f) mkdir_p(dirname(f));
+		}
 		if (adb_file('test_gzip') && !adb_file('test_cache') && !adb_file('test')) {
 			output.info('Found compressed cache file, unpacking it ');
 			output.verbose('[INIT] Found compressed cache file, unpacking it ');

--- a/net/adblock-fast/tests/03_functional/01_check_domain
+++ b/net/adblock-fast/tests/03_functional/01_check_domain
@@ -1,11 +1,11 @@
 Test that check() correctly identifies blocked and unblocked domains.
-check() output goes to stderr via output.info/output.print when is_tty=true.
+check() output goes to stderr via output.info/output.print.
 
 -- Testcase --
 import adb from 'adblock-fast';
 let ti = adb._test_internals;
 
-// Build the blocklist
+// Build the blocklist with verbosity=0 (from mock config) to suppress progress
 adb.env.load_config();
 ti.set_cfg('dns', 'dnsmasq.servers');
 ti.set_cfg('dnsmasq_sanity_check', false);
@@ -17,12 +17,10 @@ ti.env.dns_set_output_values('dnsmasq.servers');
 ti.append_urls();
 ti.download_lists();
 
-// Enable tty mode so output goes to stderr (captured by test framework)
-// Use verbosity=2 to get verbose output (which includes [PROC] prefix)
-ti.state.is_tty = true;
+// Set verbosity=2 for check() output, then call check() directly
+// (bypassing check()'s internal load_config() which would reset to 0)
 ti.set_cfg('verbosity', 2);
-
-// Now test check()
+adb.env.load_config = function() {};
 adb.check('ad.doubleclick.test.example.com this-domain-not-in-list.test.example.com');
 -- End --
 

--- a/net/adblock-fast/tests/mocks/uci/adblock-fast.json
+++ b/net/adblock-fast/tests/mocks/uci/adblock-fast.json
@@ -5,7 +5,7 @@
 			".type": "config",
 			"enabled": "1",
 			"dns": "dnsmasq.servers",
-			"verbosity": "2",
+			"verbosity": "0",
 			"force_dns": "0",
 			"compressed_cache": "0",
 			"config_update_enabled": "0",


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.0
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.0

Description:
* fix: ensure output in CLI in status and quick start commands
* fix: ensure relevant directories exist when using a (gzip) cache file on
  first boot
* add: update functional tests

Signed-off-by: Stan Grishin <stangri@melmac.ca>