### PR TITLE
python-werkzeug: bump to 3.1.6

### DIFF
--- a/lang/python/python-werkzeug/Makefile
+++ b/lang/python/python-werkzeug/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-werkzeug
-PKG_VERSION:=3.1.3
+PKG_VERSION:=3.1.6
 PKG_RELEASE:=1
 
 PYPI_NAME:=Werkzeug
 PYPI_SOURCE_NAME:=werkzeug
-PKG_HASH:=60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746
+PKG_HASH:=210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/lang/python/python-werkzeug/test.sh
+++ b/lang/python/python-werkzeug/test.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+[ "$1" = python3-werkzeug ] || exit 0
+
+python3 - <<'EOF'
+from werkzeug.test import Client
+from werkzeug.wrappers import Request, Response
+
+def app(environ, start_response):
+    request = Request(environ)
+    text = f"Hello, {request.args.get('name', 'world')}!"
+    response = Response(text, mimetype='text/plain')
+    return response(environ, start_response)
+
+client = Client(app)
+
+resp = client.get('/')
+assert resp.status_code == 200
+assert resp.data == b'Hello, world!'
+
+resp = client.get('/?name=OpenWrt')
+assert resp.status_code == 200
+assert resp.data == b'Hello, OpenWrt!'
+EOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  me

**Description:**

Changelog since 3.1.3:
- v3.1.4: Fix special device name access on Windows in send_from_directory (security); fix multipart parser \r\n handling at chunk boundaries; improve Watchdog reloader CPU efficiency
- v3.1.5: Extend Windows path protection against special device names (security); fix multipart form parser \r\n at chunk boundaries; fix AttributeError in DebuggedApplication with pin_security=False
- v3.1.6: Block special device names in multi-segment paths on Windows via safe_join (security)

Add test.sh.

Full changelog:
https://werkzeug.palletsprojects.com/en/stable/changes/

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
