### PR TITLE
python-socketio: bump to 5.11.2

### DIFF
--- a/lang/python/python-bidict/Makefile
+++ b/lang/python/python-bidict/Makefile
@@ -18,6 +18,8 @@ PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>, Alexandru Ardelean <arde
 PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 
+PKG_BUILD_DEPENDS:=python-setuptools/host
+
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk

--- a/lang/python/python-engineio/Makefile
+++ b/lang/python/python-engineio/Makefile
@@ -19,6 +19,8 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:python-engineio_project:python-engineio
 
+PKG_BUILD_DEPENDS:=python-setuptools/host
+
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk

--- a/lang/python/python-socketio/Makefile
+++ b/lang/python/python-socketio/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-socketio
-PKG_VERSION:=5.8.0
+PKG_VERSION:=5.11.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=python-socketio
-PKG_HASH:=e714f4dddfaaa0cb0e37a1e2deef2bb60590a5b9fea9c343dd8ca5e688416fd9
+PKG_HASH:=ae6a1de5c5209ca859dc574dccc8931c4be17ee003e74ce3b8d1306162bb4a37
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT

--- a/lang/python/python-socketio/test.sh
+++ b/lang/python/python-socketio/test.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+[ "$1" = python3-socketio ] || exit 0
+
+python3 - <<'EOF'
+import socketio
+
+# Test server creation and event registration
+sio = socketio.Server()
+
+received = []
+
+@sio.event
+def connect(sid, environ):
+    received.append(('connect', sid))
+
+@sio.event
+def message(sid, data):
+    received.append(('message', data))
+
+@sio.event
+def disconnect(sid):
+    received.append(('disconnect', sid))
+
+# Verify the handlers are registered
+assert 'connect' in sio.handlers['/']
+assert 'message' in sio.handlers['/']
+assert 'disconnect' in sio.handlers['/']
+
+# Test namespace creation
+ns = socketio.Namespace('/test')
+sio.register_namespace(ns)
+assert '/test' in sio.namespace_handlers
+
+# Test AsyncServer exists
+asio = socketio.AsyncServer()
+assert asio is not None
+EOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Changelog since 5.8.0:
- v5.9.0: Optimize performance and memory usage for broadcasts
- v5.10.0: Add SimpleClient and AsyncSimpleClient classes; add reporting to Socket.IO Admin UI; add server shutdown() function; make async enter_room/leave_room proper coroutines
- v5.11.0: Add catch-all namespace support; improve pubsub manager robustness; fix background task garbage collection
- v5.11.1: Add connection retry option in client; drop Python 3.7 support; add Python 3.12 support
- v5.11.2: Improve routing to catch-all namespace handlers; add option to disable routing in ASGIApp

Add test.sh.

Full changelog:
https://github.com/miguelgrinberg/python-socketio/releases
---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
