### PR TITLE
python-six: bump to 1.17.0

### DIFF
--- a/lang/python/python-six/Makefile
+++ b/lang/python/python-six/Makefile
@@ -8,15 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-six
-PKG_VERSION:=1.16.0
+PKG_VERSION:=1.17.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=six
-PKG_HASH:=1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926
+PKG_HASH:=ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+
+PKG_BUILD_DEPENDS:=python-setuptools/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk

--- a/lang/python/python-six/test.sh
+++ b/lang/python/python-six/test.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+[ "$1" = python3-six ] || exit 0
+
+python3 - <<'EOF'
+import six
+
+# Check version
+assert six.PY3, "Expected PY3 to be True"
+assert not six.PY2, "Expected PY2 to be False"
+
+# Test string types
+assert six.string_types == (str,)
+assert six.text_type == str
+assert six.binary_type == bytes
+assert six.integer_types == (int,)
+
+# Test moves
+from six.moves import range
+assert list(range(3)) == [0, 1, 2]
+
+# Test b() and u() helpers
+assert six.b('hello') == b'hello'
+assert six.u('hello') == 'hello'
+
+# Test ensure_str / ensure_binary / ensure_text
+assert six.ensure_str('hello') == 'hello'
+assert six.ensure_binary('hello') == b'hello'
+assert six.ensure_text(b'hello') == 'hello'
+
+print("python-six OK")
+EOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Changes since 1.16.0:
- Drop Python 2.7 and 3.5 support
- Add ensure_str(), ensure_binary(), ensure_text() helpers
- Various minor fixes and maintenance updates

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
