### PR TITLE
python-bidict: bump to 0.23.1

### DIFF
--- a/lang/python/python-bidict/Makefile
+++ b/lang/python/python-bidict/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-bidict
-PKG_VERSION:=0.22.1
+PKG_VERSION:=0.23.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=bidict
-PKG_HASH:=1e0f7f74e4860e6d0943a05d4134c63a2fad86f3d4732fb265bd79e4e856d81d
+PKG_HASH:=03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MPL-2.0

--- a/lang/python/python-bidict/test.sh
+++ b/lang/python/python-bidict/test.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+[ "$1" = python3-bidict ] || exit 0
+
+python3 - <<'EOF'
+from bidict import bidict
+
+# Basic creation and lookup
+b = bidict({'a': 1, 'b': 2, 'c': 3})
+assert b['a'] == 1
+assert b.inverse[1] == 'a'
+assert b.inverse[2] == 'b'
+
+# Put and update
+b['d'] = 4
+assert b['d'] == 4
+assert b.inverse[4] == 'd'
+
+# Delete
+del b['d']
+assert 'd' not in b
+assert 4 not in b.inverse
+
+# Inverse of inverse is the original
+assert b.inverse.inverse is b
+
+# len
+assert len(b) == 3
+
+print("python-bidict OK")
+EOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Changes since 0.22.1:
- Require Python >= 3.8 (dropped 3.7)
- Performance improvements and internal refactoring
- Better type annotations and mypy support
- Various bug fixes

Also add PKG_BUILD_DEPENDS on python-setuptools/host as bidict uses setuptools.build_meta build backend.


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

