### PR TITLE
newt: bump to 0.52.25

### DIFF
--- a/libs/newt/Makefile
+++ b/libs/newt/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=newt
-PKG_VERSION:=0.52.24
+PKG_VERSION:=0.52.25
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://releases.pagure.org/newt
-PKG_HASH:=5ded7e221f85f642521c49b1826c8de19845aa372baf5d630a51774b544fbdbb
+PKG_HASH:=ef0ca9ee27850d1a5c863bb7ff9aa08096c9ed312ece9087b30f3a426828de82
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=LGPL-2.0-only

--- a/libs/newt/patches/0001-Revert-install-python-modules-to-purelib-and-platlib.patch
+++ b/libs/newt/patches/0001-Revert-install-python-modules-to-purelib-and-platlib.patch
@@ -1,0 +1,30 @@
+From ce2b86fe32047f0c2d59273bf3ca5bbafd7f740a Mon Sep 17 00:00:00 2001
+From: Alexandru Ardelean <alex@shruggie.ro>
+Date: Mon, 23 Mar 2026 16:51:22 +0200
+Subject: [PATCH] Revert "install python modules to purelib and platlib"
+
+This reverts commit ecd43ab512e707f6e7873368871b517ed3206859.
+---
+ Makefile.in | 11 ++++-------
+ 1 file changed, 4 insertions(+), 7 deletions(-)
+
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -161,13 +161,10 @@ endif
+ 
+ install-py: _snack.$(SOEXT)
+ ifneq ($(PYTHONVERS),)
+-	@for ver in $(PYTHONVERS); do \
+-		PLATLIB=`$$ver -c "import sysconfig; print(sysconfig.get_path('platlib'))"`; \
+-		[ -d $(instroot)/$$PLATLIB ] || install -m 755 -d $(instroot)/$$PLATLIB ;\
+-		echo install -m 755 $$ver/_snack.$(SOEXT) $(instroot)/$$PLATLIB;\
+-		install -m 755 $$ver/_snack.$(SOEXT) $(instroot)/$$PLATLIB;\
+-		echo install -m 644 snack.py $(instroot)/$$PLATLIB;\
+-		install -m 644 snack.py $(instroot)/$$PLATLIB;\
++	for ver in $(PYTHONVERS); do \
++	   [ -d $(instroot)/$(libdir)/$$ver/site-packages ] || install -m 755 -d $(instroot)/$(libdir)/$$ver/site-packages ;\
++	   install -m 755 $$ver/_snack.$(SOEXT) $(instroot)/$(libdir)/$$ver/site-packages ;\
++	   install -m 644 snack.py $(instroot)/$(libdir)/$$ver/site-packages ;\
+ 	done
+ endif
+ 

--- a/libs/newt/patches/002-use-target-ar-python-config.patch
+++ b/libs/newt/patches/002-use-target-ar-python-config.patch
@@ -1,9 +1,9 @@
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -84,12 +84,7 @@ showkey:	showkey.o $(LIBNEWT)
- 
+@@ -85,12 +85,7 @@ showkey:	showkey.o $(LIBNEWT)
  _snack.$(SOEXT):   snack.c $(LIBNEWTSH)
- 	@[ -n "$(PYTHONVERS)" ] && for ver in $(PYTHONVERS); do \
+ ifneq ($(PYTHONVERS),)
+ 	@for ver in $(PYTHONVERS); do \
 -		pyconfig=$$ver-config; \
 -		if ! $$pyconfig --cflags > /dev/null 2>&1 && \
 -				python-config --cflags > /dev/null 2>&1; then \
@@ -13,13 +13,4 @@
 +		pyconfig=$(PYTHON_CONFIG_PATH)/$$ver-config; \
  		mkdir -p $$ver; \
  		PCFLAGS=`$$pyconfig --cflags`; \
- 		PIFLAGS=`$$pyconfig --includes`; \
-@@ -109,7 +104,7 @@ whiptcl.$(SOEXT): $(WHIPTCLOBJS) $(LIBNE
- 	$(CC) -shared $(SHCFLAGS) $(LDFLAGS) -o whiptcl.$(SOEXT) $(WHIPTCLOBJS) -L. -lnewt  $(LIBTCL) -lpopt $(LIBS)
- 
- $(LIBNEWT): $(LIBOBJS)
--	ar rv $@ $^
-+	$(AR) rv $@ $^
- 
- newt.o $(SHAREDDIR)/newt.o: newt.c Makefile
- 
+ 		PLDFLAGS=`$$pyconfig --ldflags --embed || $$pyconfig --ldflags`; \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Changes since 0.52.24:
- Bug fixes and maintenance updates

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
