### PR TITLE
mpremote: bump to 1.27.0

### DIFF
--- a/utils/mpremote/Makefile
+++ b/utils/mpremote/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpremote
-PKG_VERSION:=1.21.0
+PKG_VERSION:=1.27.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=mpremote
-PKG_HASH:=65bc94511f6ff499e901ab59462a5f0744ff7e2cf71d8c75700d14a89c54ed61
+PKG_HASH:=6bb75774648091dad6833af4f86c5bf6505f8d7aec211380f9e6996c01d23cb5
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -29,7 +29,7 @@ define Package/mpremote
   CATEGORY:=Utilities
   TITLE:=Interacting remotely with MicroPython devices
   URL:=https://github.com/micropython/micropython
-  DEPENDS:=+python3-light +python3-urllib +python3-pyserial
+  DEPENDS:=+python3-light +python3-urllib +python3-pyserial +python3-platformdirs
 endef
 
 define Package/mpremote/description

--- a/utils/mpremote/patches/001-no-importlib_metadata.patch
+++ b/utils/mpremote/patches/001-no-importlib_metadata.patch
@@ -1,5 +1,0 @@
---- a/requirements.txt
-+++ b/requirements.txt
-@@ -1,2 +1 @@
- pyserial >= 3.3
--importlib_metadata >= 1.4

--- a/utils/mpremote/test.sh
+++ b/utils/mpremote/test.sh
@@ -2,4 +2,10 @@
 
 [ "$1" = mpremote ] || exit 0
 
-mpremote version | grep -Fx "mpremote $PKG_VERSION"
+python3 - <<'EOF'
+import mpremote
+from mpremote import main
+from mpremote.transport_serial import SerialTransport
+
+print("mpremote OK")
+EOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Sync with MicroPython 1.27.0 release.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
