### PR TITLE
micropython: bump to 1.27.0

### DIFF
--- a/lang/python/micropython-lib/Makefile
+++ b/lang/python/micropython-lib/Makefile
@@ -8,13 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=micropython-lib
+PKG_VERSION:=1.27.0
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/micropython/micropython-lib.git
-PKG_SOURCE_VERSION:=68e3e07bc7ab63931cead3854b2a114e9a084248
-PKG_SOURCE_DATE:=20241017
-PKG_MIRROR_HASH:=7ed2c1b4a5af1b00364e2e017b2b416865713dc82d94737a3ea605f9aeaed54a
+PKG_SOURCE:=micropython-lib-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/micropython/micropython-lib/archive/refs/tags/v$(PKG_VERSION)
+PKG_HASH:=d108975cc3940c868aa934adac9553f36bf6bcbb2a77190a6f78724ffc6bbeb5
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT Python-2.0.1

--- a/lang/python/micropython/Makefile
+++ b/lang/python/micropython/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=micropython
-PKG_VERSION:=1.23.0
+PKG_VERSION:=1.27.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/micropython/micropython/releases/download/v$(PKG_VERSION)
-PKG_HASH:=0ab283c2fc98d466c1ff26692bee46abaeeab55d488a36fc3cb6372cb8fb390d
+PKG_HASH:=9874b20646c3bbe81d524f779a16875e5d088b7065e175ffd2aa2a02f50573c9
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
@@ -86,6 +86,13 @@ endif
 ifeq ($(ARCH),riscv64)
   MAKE_FLAGS += CFLAGS_EXTRA=-Wno-error=clobbered
 endif
+
+TARGET_CFLAGS += \
+	-DMBEDTLS_CONFIG_FILE=\\\"mbedtls/build_info.h\\\"
+
+# FIXME: remove this asap; this fixes some build issues with mbedtls from OpenWrt
+TARGET_CFLAGS += \
+	-Wno-error=implicit-function-declaration
 
 MAKE_PATH = ports/unix
 

--- a/lang/python/micropython/patches/030-target-no-darwin.patch
+++ b/lang/python/micropython/patches/030-target-no-darwin.patch
@@ -1,6 +1,6 @@
 --- a/ports/unix/Makefile
 +++ b/ports/unix/Makefile
-@@ -31,7 +31,7 @@ QSTR_DEFS += qstrdefsport.h
+@@ -34,7 +34,7 @@ QSTR_DEFS += qstrdefsport.h
  QSTR_GLOBAL_DEPENDENCIES += $(VARIANT_DIR)/mpconfigvariant.h
  
  # OS name, for simple autoconfig

--- a/lang/python/micropython/patches/040-extmod-use-external-mbedtls.patch
+++ b/lang/python/micropython/patches/040-extmod-use-external-mbedtls.patch
@@ -9,7 +9,7 @@ Subject: [PATCH 06/10] extmod: Use system mbedtls
 
 --- a/extmod/extmod.mk
 +++ b/extmod/extmod.mk
-@@ -235,86 +235,8 @@ SRC_THIRDPARTY_C += $(addprefix $(AXTLS_
+@@ -242,91 +242,12 @@ SRC_THIRDPARTY_C += $(addprefix $(AXTLS_
  	crypto/sha1.c \
  	)
  else ifeq ($(MICROPY_SSL_MBEDTLS),1)
@@ -18,6 +18,12 @@ Subject: [PATCH 06/10] extmod: Use system mbedtls
 -GIT_SUBMODULES += $(MBEDTLS_DIR)
 -CFLAGS_EXTMOD += -DMBEDTLS_CONFIG_FILE=$(MBEDTLS_CONFIG_FILE)
 -CFLAGS_EXTMOD += -DMICROPY_SSL_MBEDTLS=1 -I$(TOP)/$(MBEDTLS_DIR)/include
++CFLAGS_EXTMOD += -DMICROPY_SSL_MBEDTLS=1
++LDFLAGS_MOD += -lmbedx509 -lmbedtls -lmbedcrypto
+ ifeq ($(MICROPY_PY_SSL_ECDSA_SIGN_ALT),1)
+ CFLAGS_EXTMOD += -DMICROPY_PY_SSL_ECDSA_SIGN_ALT=1
+ LDFLAGS_EXTMOD += -Wl,--wrap=mbedtls_ecdsa_write_signature
+ endif
 -SRC_THIRDPARTY_C += lib/mbedtls_errors/mp_mbedtls_errors.c
 -SRC_THIRDPARTY_C += $(addprefix $(MBEDTLS_DIR)/library/,\
 -	aes.c \
@@ -63,6 +69,7 @@ Subject: [PATCH 06/10] extmod: Use system mbedtls
 -	pkcs12.c \
 -	pkcs5.c \
 -	pkparse.c \
+-	pk_ecc.c \
 -	pk_wrap.c \
 -	pkwrite.c \
 -	platform.c \
@@ -93,8 +100,6 @@ Subject: [PATCH 06/10] extmod: Use system mbedtls
 -	x509write_crt.c \
 -	x509write_csr.c \
 -	)
-+CFLAGS_EXTMOD += -DMICROPY_SSL_MBEDTLS=1
-+LDFLAGS_MOD += -lmbedx509 -lmbedtls -lmbedcrypto
  endif
  endif
  


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Also update micropython-lib to v1.27.0. Switch micropython-lib from a git source to the release tarball from:
https://github.com/micropython/micropython-lib/releases/tag/v1.27.0

MPY_VERSION remains at 6, no ABI change.
---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

