### PR TITLE
snapcast: update to v0.35.0

### DIFF
--- a/sound/snapcast/Makefile
+++ b/sound/snapcast/Makefile
@@ -3,13 +3,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snapcast
-PKG_VERSION:=0.34.0
+PKG_VERSION:=0.35.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/snapcast/snapcast.git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
-PKG_MIRROR_HASH=b47c44e208708cbfd6fb89b5874ed05ffa165b959904ccc11b03073bf9b55b0a
+PKG_MIRROR_HASH=b21791cda7f0b403b45401ea3c8b742013d81b5f7fff524bf93365db92320140
 
 PKG_MAINTAINER:=Szabolcs Hubai <szab.hu@gmail.com>, David Andreoletti <david@andreoletti.net>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**
* me (@xabolcs)
* @davidandreoletti 

**Description:**
A straightforward update from 0.34.0 ([2025-10-12](https://github.com/snapcast/snapcast/releases/tag/v0.34.0)) to 0.35.0 ([2026-03-10](https://github.com/snapcast/snapcast/releases/tag/v0.35.0))

Upstream changelog:
https://github.com/snapcast/snapcast/blob/v0.35.0/changelog.md

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
  - `OpenWrt SNAPSHOT, r33501-3e1d391db6`
  - `OpenWrt SNAPSHOT, r32241-cc20942931`
- **OpenWrt Target/Subtarget:** 
  - `mediatek/filogic`
  - `ath79/nand`
- **OpenWrt Device:**
  - GL.iNet GL-MT6000
  - GL.Inet GL-AR300M

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] My PR doesn't contain a patch
