### PR TITLE
python-psutil: bump to 7.2.2

### DIFF
--- a/lang/python/python-psutil/Makefile
+++ b/lang/python/python-psutil/Makefile
@@ -8,11 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-psutil
-PKG_VERSION:=5.9.5
+PKG_VERSION:=7.2.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=psutil
-PKG_HASH:=5410638e4df39c54d957fc51ce03048acd8e6d60abc0f5107af51e5fb566eb3c
+PKG_HASH:=0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372
+
+PKG_BUILD_DEPENDS:=python-setuptools/host
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/lang/python/python-psutil/patches/100-fix-non-Linux-compile.patch
+++ b/lang/python/python-psutil/patches/100-fix-non-Linux-compile.patch
@@ -1,19 +1,19 @@
 --- a/setup.py
 +++ b/setup.py
-@@ -43,16 +43,16 @@ HERE = os.path.abspath(os.path.dirname(_
- # ...so we can import _common.py and _compat.py
+@@ -55,16 +55,16 @@ HERE = os.path.abspath(os.path.dirname(_
+ # ...so we can import _common.py
  sys.path.insert(0, os.path.join(HERE, "psutil"))
  
--from _common import AIX  # NOQA
--from _common import BSD  # NOQA
--from _common import FREEBSD  # NOQA
--from _common import LINUX  # NOQA
--from _common import MACOS  # NOQA
--from _common import NETBSD  # NOQA
--from _common import OPENBSD  # NOQA
--from _common import POSIX  # NOQA
--from _common import SUNOS  # NOQA
--from _common import WINDOWS  # NOQA
+-from _common import AIX  # noqa: E402
+-from _common import BSD  # noqa: E402
+-from _common import FREEBSD  # noqa: E402
+-from _common import LINUX  # noqa: E402
+-from _common import MACOS  # noqa: E402
+-from _common import NETBSD  # noqa: E402
+-from _common import OPENBSD  # noqa: E402
+-from _common import POSIX  # noqa: E402
+-from _common import SUNOS  # noqa: E402
+-from _common import WINDOWS  # noqa: E402
 +AIX = False
 +BSD = False
 +FREEBSD = False
@@ -24,6 +24,6 @@
 +POSIX = True
 +SUNOS = False
 +WINDOWS = False
- from _common import hilite  # NOQA
- from _compat import PY3  # NOQA
- from _compat import which  # NOQA
+ from _common import hilite  # noqa: E402
+ 
+ PYPY = '__pypy__' in sys.builtin_module_names

--- a/lang/python/python-psutil/test.sh
+++ b/lang/python/python-psutil/test.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+[ "$1" = "python3-psutil" ] || exit 0
+
+python3 - << EOF
+import sys
+import psutil
+
+if psutil.__version__ != "$2":
+    print("Wrong version: " + psutil.__version__)
+    sys.exit(1)
+
+# Test basic process info
+p = psutil.Process()
+assert p.pid > 0, "Expected valid PID"
+assert p.status() in (psutil.STATUS_RUNNING, psutil.STATUS_SLEEPING), \
+    f"Unexpected status: {p.status()}"
+
+# Test system-wide functions
+mem = psutil.virtual_memory()
+assert mem.total > 0, "Expected non-zero total memory"
+assert 0.0 <= mem.percent <= 100.0, f"Memory percent out of range: {mem.percent}"
+
+cpu = psutil.cpu_count()
+assert cpu is not None and cpu > 0, f"Expected positive CPU count, got {cpu}"
+
+# Test disk usage
+disk = psutil.disk_usage("/")
+assert disk.total > 0, "Expected non-zero disk total"
+
+sys.exit(0)
+EOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Notable changes since 5.9.5:

v6.0.0:
- process_iter() is now ~20x faster (no longer pre-emptively checks PID reuse); add process_iter.cache_clear() API
- Process.connections() renamed to Process.net_connections() (old name deprecated)
- disk_partitions() namedtuple drops maxfile/maxpath fields
- Support building with free-threaded CPython 3.13

v7.0.0:
- Drop Python 2.7 support

v7.2.0:
- New heap_info() and heap_trim() functions for native C heap allocator access (glibc, mimalloc, libmalloc)
- Tests are no longer part of the installed package

v7.2.2:
- [Linux] Process.wait() now uses pidfd_open() + poll() for waiting (no busy loop, faster response); requires Linux >= 5.3 + Python 3.9, falls back to polling otherwise
- [macOS/BSD] Process.wait() now uses kqueue() for waiting
- Various macOS memory leak and error handling fixes

Also refresh 100-fix-non-Linux-compile.patch for the updated setup.py (noqa comment style changed; _compat imports removed upstream). Add test.sh.

Full changelog:
https://github.com/giampaolo/psutil/blob/master/HISTORY.rst

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
