### PR TITLE
libvpx: update to 1.16.0

### DIFF
--- a/libs/libvpx/Makefile
+++ b/libs/libvpx/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libvpx
-PKG_VERSION:=1.14.1
+PKG_VERSION:=1.16.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://chromium.googlesource.com/webm/libvpx
-PKG_MIRROR_HASH:=a9737eadde24611fbbf080f28c792d804ea0970dadbc9421b427e18bb8f14820
+PKG_MIRROR_HASH:=a9df693a24f89687b9b716f2e07ea79522df3d684069446d1d0456a111d831dc
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>


### PR DESCRIPTION
Update libvpx to v1.16.0 "Xenonetta Duck". Highlights include:
- Arm SVE2 and Neon optimizations for 12-tap filters.
- AVX512 implementations for Sum of Absolute Differences (SAD).
- Support for per-frame and per-spatial-layer PSNR calculation.
- ABI incompatible with the previous release.

Includes changes from intermediate releases:
- v1.15.2: Fixes CVE-2025-5283 (bug webm:413411335).
- v1.15.1: SO major version bump and changelog corrections.
- v1.15.0: New codec control for key frame filtering and RTC improvements.

Changelog: https://github.com/webmproject/libvpx/blob/v1.16.0/CHANGELOG

## 📦 Package Details

**Maintainer:** Me

**Description:**

---

## 🧪 Run Testing Details

- **OpenWrt Version:** current main
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** Qemu

Tested using:

```shell
gst-launch-1.0 videotestsrc num-buffers=200 ! \
vp8enc deadline=1 cpu-used=4 lag-in-frames=0 ! \
webmmux ! filesink location=/www/test.webm
```
---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [X] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
