### PR TITLE
ruby: update to 4.0.2

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=4.0.0
+PKG_VERSION:=4.0.2
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=2e8389c8c072cb658c93a1372732d9eac84082c88b065750db1e52a5ac630271
+PKG_HASH:=51502b26b50b68df4963336ca41e368cde92c928faf91654de4c4c1791f82aac
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING LICENSE LICENSE.txt BSDL


### PR DESCRIPTION
ruby 4.0.2 is a routine update that includes a bugfix in YJIT for NoMethodError on Puma, along with other bugfixes.

ruby 4.0.1 includes a bugfix for spurious wakeup from Kernel#sleep when subprocess exits in another thread, along with other bugfixes.

Link: https://www.ruby-lang.org/en/news/2026/03/16/ruby-4-0-2-released/
Changelog: https://github.com/ruby/ruby/releases/tag/v4.0.2
Link: https://www.ruby-lang.org/en/news/2026/01/13/ruby-4-0-1-released/
Changelog: https://github.com/ruby/ruby/releases/tag/v4.0.1

## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** main
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** qemu

Tested with:
```shell
ruby -r open-uri -e 'puts URI.open("https://www.google.com").status[0]'
```

---

## ✅ Formalities

- [x ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ x] It can be applied using `git am`
- [ x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
