### PR TITLE
python-pyopenssl: bump to 26.0.0

### DIFF
--- a/lang/python/python-pyopenssl/Makefile
+++ b/lang/python/python-pyopenssl/Makefile
@@ -8,11 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyopenssl
-PKG_VERSION:=23.3.0
+PKG_VERSION:=26.0.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=pyOpenSSL
-PKG_HASH:=6b2cba5cc46e822750ec3e5a81ee12819850b11303630d575e98108a079c2b12
+PYPI_SOURCE_NAME:=pyopenssl
+PKG_HASH:=f293934e52936f2e3413b89c6ce36df66a0b34ae1ea3a053b8c5020ff2f513fc
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -32,7 +33,8 @@ define Package/python3-pyopenssl
   DEPENDS:= \
       +python3-light \
       +python3-openssl \
-      +python3-cryptography
+      +python3-cryptography \
+      +python3-typing-extensions
 endef
 
 define Package/python3-pyopenssl/description

--- a/lang/python/python-pyopenssl/test.sh
+++ b/lang/python/python-pyopenssl/test.sh
@@ -2,4 +2,84 @@
 
 [ "$1" = python3-pyopenssl ] || exit 0
 
-python3 -m OpenSSL.debug
+# Basic sanity check (prints linked OpenSSL version info)
+python3 -m OpenSSL.debug || exit 1
+
+python3 - << EOF
+import sys
+import importlib.metadata
+
+version = importlib.metadata.version("pyOpenSSL")
+if version != "$2":
+    print("Wrong version: " + version)
+    sys.exit(1)
+
+from OpenSSL import SSL, crypto
+from OpenSSL.crypto import (
+    PKey, TYPE_RSA, TYPE_EC,
+    X509, X509Req, X509Store, X509StoreContext,
+    dump_certificate, dump_privatekey, load_certificate, load_privatekey,
+    dump_certificate_request,
+    FILETYPE_PEM,
+)
+
+# --- Key generation ---
+
+rsa_key = PKey()
+rsa_key.generate_key(TYPE_RSA, 2048)
+assert rsa_key.bits() == 2048
+assert rsa_key.type() == TYPE_RSA
+
+ec_key = PKey()
+ec_key.generate_key(TYPE_EC, 256)
+assert ec_key.type() == TYPE_EC
+
+# --- Self-signed certificate ---
+
+cert = X509()
+cert.get_subject().CN = "test.example.com"
+cert.get_subject().O = "Test Org"
+cert.set_serial_number(1)
+cert.gmtime_adj_notBefore(0)
+cert.gmtime_adj_notAfter(365 * 24 * 60 * 60)
+cert.set_issuer(cert.get_subject())
+cert.set_pubkey(rsa_key)
+cert.sign(rsa_key, "sha256")
+
+assert cert.get_subject().CN == "test.example.com"
+assert cert.get_serial_number() == 1
+assert not cert.has_expired()
+
+# --- PEM round-trip (cert) ---
+
+pem = dump_certificate(FILETYPE_PEM, cert)
+assert pem.startswith(b"-----BEGIN CERTIFICATE-----")
+cert2 = load_certificate(FILETYPE_PEM, pem)
+assert cert2.get_subject().CN == "test.example.com"
+
+# --- PEM round-trip (private key) ---
+
+key_pem = dump_privatekey(FILETYPE_PEM, rsa_key)
+assert key_pem.startswith(b"-----BEGIN")
+key2 = load_privatekey(FILETYPE_PEM, key_pem)
+assert key2.bits() == 2048
+
+# --- Certificate signing request ---
+
+req = X509Req()
+req.get_subject().CN = "csr.example.com"
+req.set_pubkey(rsa_key)
+req.sign(rsa_key, "sha256")
+assert req.verify(rsa_key)
+csr_pem = dump_certificate_request(FILETYPE_PEM, req)
+assert csr_pem.startswith(b"-----BEGIN CERTIFICATE REQUEST-----")
+
+# --- X509Store verification ---
+
+store = X509Store()
+store.add_cert(cert)
+ctx = X509StoreContext(store, cert)
+ctx.verify_certificate()  # raises if invalid
+
+sys.exit(0)
+EOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Notable changes since 23.3.0:

v26.0.0:
- Drop Python 3.7 support
- Minimum cryptography version is now 46.0.0
- Security fix: properly raise an error if a DTLS cookie callback returned a cookie longer than DTLS1_COOKIE_LENGTH bytes, previously resulting in a buffer-overflow (CVE-2026-27459)
- Security fix: Context.set_tlsext_servername_callback now handles exceptions raised in the callback instead of silently swallowing them (CVE-2026-27448)
- Added support for using aws-lc instead of OpenSSL
- Added OpenSSL.SSL.Connection.get_group_name

v25.x:
- Added OpenSSL.SSL.Context.set_tls13_ciphersuites
- Added OpenSSL.SSL.Connection.set_info_callback
- Added OpenSSL.SSL.Context.clear_mode
- pyOpenSSL now sets SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER by default
- typing-extensions added as a runtime dependency (for Python < 3.13)

Full changelog:
https://www.pyopenssl.org/en/stable/changelog.html

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
