### PR TITLE
openvpn: remove excessive quoting on OPENVPN_LIST options

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.6.19
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/lib/netifd/proto/openvpn.sh
+++ b/net/openvpn/files/lib/netifd/proto/openvpn.sh
@@ -62,7 +62,7 @@ option_builder() {
 						json_get_keys keys
 						for key in $keys; do
 							json_get_var val "$key"
-							append exec_params "--${f//_/-} \"$val\""
+							append exec_params "--${f//_/-} $val"
 						done
 						json_select ..
 						;;


### PR DESCRIPTION
The extra quoting specifically breaks the multiparameter --remote option by quoting the parameters. For example:

  --remote "myhost myport myproto"

the quoted string gets interpretted by openvpn as a hostname, which fails DNS lookup. Removing the quoting turns it into:

  --remote myhost myport myproto [...]

which works. Fixes otherwise broken multi-parameter --remote options.