### PR TITLE
nerdctl: preserve config file during sysupgrade

### DIFF
--- a/utils/nerdctl/Makefile
+++ b/utils/nerdctl/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nerdctl
 PKG_VERSION:=1.7.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containerd/nerdctl/tar.gz/v$(PKG_VERSION)?
@@ -33,6 +33,10 @@ endef
 define Package/nerdctl/description
   Docker-compatible CLI for containerd, with support for Compose, Rootless,
   eStargz, OCIcrypt, IPFS, ...
+endef
+
+define Package/nerdctl/conffiles
+/etc/nerdctl/nerdctl.toml
 endef
 
 $(eval $(call GoBinPackage,nerdctl))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lu-zero

**Description:**
Added nerdctl.toml into conffiles to preserve it during sysupgrades

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.0
- **OpenWrt Target/Subtarget:** mvebu/cortexa72
- **OpenWrt Device:** Globalscale MOCHAbin

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
