### PR TITLE
openvpn: fix quoting and deprecated option filtering

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.6.19
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/lib/netifd/proto/openvpn.sh
+++ b/net/openvpn/files/lib/netifd/proto/openvpn.sh
@@ -23,9 +23,8 @@ option_builder() {
 
 	for f in $(eval echo \$"$list_var")
 	do
-		f=${f%%:*}
-
 		if [ "$action" = "add" ]; then
+			f=${f%%:*}
 			case "$opt_type" in
 				bool) proto_config_add_boolean "$f:bool" ;;
 				protobool) proto_config_add_boolean "$f:protobool" ;;
@@ -38,6 +37,7 @@ option_builder() {
 			esac
 		elif [ "$action" = "build" ]; then
 			[ "${f#*:}" = "d" ] && [ "$ALLOW_DEPRECATED" = 0 ] && continue
+			f=${f%%:*}
 			case "$opt_type" in
 				bool)
 					json_get_var v "$f"
@@ -45,12 +45,19 @@ option_builder() {
 					;;
 				uinteger|integer|string)
 					json_get_var v "$f"
-					[ -n "$v" ] && append exec_params "--${f//_/-} $v"
+					case $f in
+						push_remove)
+							[ -n "$v" ] && append exec_params "--${f//_/-} '$v'"
+						;;
+						*)
+							[ -n "$v" ] && append exec_params "--${f//_/-} $v"
+						;;
+					esac
 					;;
 				file)
 					json_get_var v "$f"
 					[ -f "$v" ] || continue
-					[ -n "$v" ] && append exec_params "--${f//_/-} \"$v\""
+					[ -n "$v" ] && append exec_params "--${f//_/-} '$v'"
 					;;
 				list)
 					local type
@@ -62,7 +69,14 @@ option_builder() {
 						json_get_keys keys
 						for key in $keys; do
 							json_get_var val "$key"
-							append exec_params "--${f//_/-} \"$val\""
+							case $f in
+								push)
+									append exec_params "--${f//_/-} '$val'"
+								;;
+								*)
+									append exec_params "--${f//_/-} $val"
+								;;
+							esac
 						done
 						json_select ..
 						;;


### PR DESCRIPTION
This patch fixes two issues in the netifd protocol script:

1. Fix logic error in deprecated option filtering: Previously, ${f%%:*} was called before checking for the deprecated flag (:d). This stripped the suffix and made the check [ "${f#*:}" = "d" ] always fail. The cleaning of $f is now deferred until after this check.

2. Improve parameter quoting for specific options:
   - Adds single quotes to --push and --push-remove parameters to handle spaces (e.g., "route 10.0.0.0 255.255.255.0").
   - Unifies quoting for 'file' type options to improve shell safety.
   - Refactors the build logic using a case statement for better extensibility.
