### PR TITLE
[25.12] fail2ban: add host build deps to fix #28520

### DIFF
--- a/net/fail2ban/Makefile
+++ b/net/fail2ban/Makefile
@@ -18,6 +18,10 @@ PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:fail2ban:fail2ban
 
+PKG_BUILD_DEPENDS:= \
+	python3/host \
+	python-setuptools/host
+
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** 


**Description:**

Adds the misssing build dependencies to remove the "Cannot import 'setuptools.build_meta'" build error with 25.12.0-rc1 to 25.12.0-rc5


(cherry picked from commit 6b3c95cbd8f7f84aa9f0c1c7ebc5c81e305254b4)


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
