### PR TITLE
openssh: add SFTP server to large flash targets

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -146,6 +146,7 @@ endef
 define Package/openssh-sftp-server
 	$(call Package/openssh/Default)
 	TITLE+= SFTP server
+	DEFAULT:=y if (BUILDBOT && !SMALL_FLASH)
 endef
 
 define Package/openssh-sftp-server/description

--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -136,6 +136,7 @@ endef
 define Package/openssh-sftp-server
 	$(call Package/openssh/Default)
 	TITLE+= SFTP server
+	DEFAULT:=y if (BUILDBOT && !SMALL_FLASH)
 endef
 
 define Package/openssh-sftp-server/description


### PR DESCRIPTION
This will integrate SFTP server support into most images by default. SFTP is the default protocol used by the scp client since OpenSSH 9.0.

This change will activate openssh-sftp-server in buildbot by defalut for targets with large flash. For those targets, dropbear is already being built with support for an external SFTP server binary.

The package size is around 55 to 60 KB depending on target.

---

@hauke i think you make these decisions.

OpenSSH 9.0 (released in 2022) [changed](https://www.openssh.org/txt/release-9.0) the way `scp` works, from using the legacy scp/rcp protocol to using the sftp protocol by default. (*)

The scp protocol has long been discouraged in favor of sftp given its various limitations. sftp on the other hand fully allows mounting remote file systems, and i had always found it indispensable for administering my openwrt boxes.

At least for large flash devices, `openssh-sftp-server` brings in no extra dependencies. Given that openssh broke `scp` on openwrt, and `ssh`/`scp` being such basic necessity, shouldn't `openssh-sftp-server` be included by default on devices with large flash?

(*) The old scp behavior can be invoked with the `-O` flag.

---

## 📦 Package Details

**Maintainer:** @hnyman
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
