### PR TITLE
[25.12] telegraf: update to 1.38.2

### DIFF
--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telegraf
-PKG_VERSION:=1.38.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.38.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=ad1cd8da4b1494537911d00e094712fa99612de99713524439a5159842f94c51
+PKG_HASH:=8f67651b9ff690593b57a8ff7703dbf9764bb1a356433503a4d9a27a69d26321
 
 PKG_MAINTAINER:=Niklas Thorild <niklas@thorild.se>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
- Update Telegraf to v1.38.2
---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** LXC container

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.