### PR TITLE
lmdb: set SONAME for liblmdb.so

### DIFF
--- a/libs/lmdb/patches/020-set-soname-for-liblmdb-so.patch
+++ b/libs/lmdb/patches/020-set-soname-for-liblmdb-so.patch
@@ -1,0 +1,11 @@
+--- a/libraries/liblmdb/Makefile
++++ b/libraries/liblmdb/Makefile
+@@ -67,7 +67,7 @@ liblmdb.a:	mdb.o midl.o
+ 
+ liblmdb$(SOEXT):	mdb.lo midl.lo
+ #	$(CC) $(LDFLAGS) -pthread -shared -Wl,-Bsymbolic -o $@ mdb.o midl.o $(SOLIBS)
+-	$(CC) $(LDFLAGS) -pthread -shared -o $@ mdb.lo midl.lo $(SOLIBS)
++	$(CC) $(LDFLAGS) -pthread -shared -Wl,-soname,$@ -o $@ mdb.lo midl.lo $(SOLIBS)
+ 
+ mdb_stat: mdb_stat.o liblmdb.a
+ mdb_copy: mdb_copy.o liblmdb.a


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @commodo

**Description:**

The LMDB shared library (`liblmdb.so`) does not currently have a `SONAME` set, which can cause issues when linking against it.  Specifically, when an object is linked against the library using its absolute path (for example, in Meson builds), that path (as seen in the build environment) is stored in the resulting object's `DT_NEEDED` entry.  This can prevent the library from being found during runtime linking.  Set the `SONAME` to `liblmdb.so` to ensure proper runtime linking.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2
- **OpenWrt Target/Subtarget:** ath79/mikrotik
- **OpenWrt Device:** Mikrotik RouterBOARD 951G-2HnD

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable

---

This PR uses the same approach as already used in [other][1] [projects][2].

As for upstreaming perspectives, the first attempts to fix this issue seemingly date back to a quarter of a century ago, so I wouldn't hold my breath for it.

AFAICT, this change voids the need for workarounds like this one:

https://github.com/openwrt/packages/blob/884b71edf309a1c07b92c99cca2956ecf6543b09/net/knot-resolver/patches/010-fix-lmdb.patch

and it is the correct fix for the issue that #10981 tried to address.

Full disclosure: my primary agenda here is to ensure that BIND 9.21.21+ builds on OpenWRT as [LMDB will be a required dependency for BIND's next stable branch (9.22)][3]. I verified that applying this patch enables BIND 9.21.21 to be built for OpenWRT. CC: @nmeyerhans, @pprindeville

See also: https://github.com/mesonbuild/meson/issues/7766

[1]: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=211700
[2]: https://github.com/openbmc/openbmc/blob/991de8113f8deea0ffb2aade388aa19a36e0959d/upstream-layers/meta-openembedded/meta-oe/recipes-dbs/lmdb/files/0001-make-set-soname-on-liblmdb.patch
[3]: https://gitlab.isc.org/isc-projects/bind9/-/merge_requests/11688
