### PR TITLE
lmdb: update to 0.9.35

### DIFF
--- a/libs/lmdb/Makefile
+++ b/libs/lmdb/Makefile
@@ -1,13 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lmdb
-PKG_VERSION:=0.9.33
+PKG_VERSION:=0.9.35
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://git.openldap.org/openldap/openldap.git
 PKG_SOURCE_VERSION:=LMDB_$(PKG_VERSION)
-PKG_MIRROR_HASH:=cf6c73e3397ab8b8d81f45dd49a9becccf3c44727ffc640d4b905afda992b58b
+PKG_MIRROR_HASH:=0196b429f21f06fa2a53666e20ae744932dbe08e58825d25e2663e8d306f7f44
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=OLDAP-2.8


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @commodo

**Description:**

Update to upstream version 0.9.35.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2
- **OpenWrt Target/Subtarget:** ath79/mikrotik
- **OpenWrt Device:** Mikrotik RouterBOARD 951G-2HnD

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
