### PR TITLE
kea: add a kea-hook-runscript package

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -142,6 +142,17 @@ define Package/kea-hook-lease-cmds/description
 	The lease commands hook library.
 endef
 
+###### *************************************************************************
+define Package/kea-hook-runscript
+	$(call Package/kea/Default)
+	TITLE+=Run Script hook library
+	DEPENDS:=+kea-libs
+endef
+define Package/kea-hook-runscript/description
+	The Run Script hook library allows executing external scripts
+	at various points in the DHCP processing.
+endef
+
 ##### *************************************************************************
 define Package/kea-lfc
 	$(call Package/kea/Default)
@@ -233,6 +244,13 @@ define Package/kea-hook-lease-cmds/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/kea/hooks/libdhcp_lease_cmds.so $(1)/usr/lib/kea/hooks
 endef
 
+define Package/kea-hook-runscript/install
+	$(INSTALL_DIR) $(1)/usr/lib/kea/hooks
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/kea/hooks/libdhcp_run_script.so $(1)/usr/lib/kea/hooks
+	$(INSTALL_DIR) $(1)/etc/kea/scripts
+	$(CP) ./files/kea-runscripts-README $(1)/etc/kea/scripts/README
+endef
+
 define Package/kea-ctrl/install
 	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/kea
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/keactrl $(1)/usr/sbin/keactrl
@@ -275,6 +293,7 @@ $(eval $(call BuildPackage,kea-dhcp-ddns))
 $(eval $(call BuildPackage,kea-admin))
 $(eval $(call BuildPackage,kea-hook-ha))
 $(eval $(call BuildPackage,kea-hook-lease-cmds))
+$(eval $(call BuildPackage,kea-hook-runscript))
 $(eval $(call BuildPackage,kea-lfc))
 $(eval $(call BuildPackage,kea-perfdhcp))
 $(eval $(call BuildPackage,kea-shell))

--- a/net/kea/files/kea-runscripts-README
+++ b/net/kea/files/kea-runscripts-README
@@ -1,0 +1,36 @@
+# Kea Run Script Hook (libdhcp_run_script.so)
+
+This directory is intended for custom user scripts triggered by the Kea DHCP 
+Run Script Hook library. This hook allows external scripts to be executed 
+at various points in the DHCP lease lifecycle.
+
+## Configuration
+
+To enable a script, add the following to the "hooks-libraries" section of 
+your /etc/kea/kea-dhcp4.conf or /etc/kea/kea-dhcp6.conf file:
+
+"hooks-libraries": [
+    {
+        "library": "libdhcp_run_script.so",
+        "parameters": {
+            "name": "/etc/kea/scripts/your-script.sh",
+            "sync": false
+        }
+    }
+]
+
+## Usage Notes
+
+1. Permissions: Scripts must be executable (e.g., chmod +x /etc/kea/scripts/your-script.sh).
+2. Environment Variables: Kea passes DHCP data to the script via environment 
+   variables. Based on the current build, useful variables include:
+   - LEASE4_ADDRESS / LEASE6_ADDRESS: The IP address being assigned.
+   - LEASE4_HOSTNAME: The hostname associated with the lease.
+   - QUERY4_TYPE: The type of DHCP packet (e.g., DHCPREQUEST).
+   - QUERY4_HWADDR: The MAC address of the requesting client.
+3. Exit Codes: Scripts should generally exit with 0. A non-zero exit code 
+   may affect packet processing depending on your Kea configuration.
+
+## Official Documentation
+
+https://kea.readthedocs.io/en/kea-3.0.2/arm/hooks.html#libdhcp-run-script-so-run-script-support-for-external-hook-scripts

--- a/net/kea/files/kea.init
+++ b/net/kea/files/kea.init
@@ -38,6 +38,7 @@ start_kea() {
 	procd_set_param command "$cmd" -c "$cnf"
 	procd_set_param env KEA_LOCKFILE_DIR=/tmp
 	procd_append_param env KEA_PIDFILE_DIR=/tmp
+	procd_append_param env KEA_HOOK_SCRIPTS_PATH=/etc/kea/scripts
 	procd_set_param file "$cnf"
 	procd_set_param stderr 1
 	procd_set_param stdout 1


### PR DESCRIPTION
The Run Script hook library adds support for calling an external script for specific packet-processing hook points.

## 📦 Package Details

**Maintainer:** @pprindeville, @nmeyerhans

**Description:**
I got bored one weekend and decided to replace dnsmasq with Kea, Uradvd (for router advertisements) and Coredns and noticed Kea is missing a lot of hooks. Here's all the hooks included with Kea on an Archlinux distribution, for example:

```
libddns_gss_tsig.so     libdhcp_flex_id.so      libdhcp_host_cmds.so    libdhcp_limits.so   libdhcp_ping_check.so  libdhcp_subnet_cmds.so
libdhcp_bootp.so        libdhcp_flex_option.so  libdhcp_lease_cmds.so   libdhcp_mysql.so    libdhcp_radius.so
libdhcp_class_cmds.so   libdhcp_ha.so           libdhcp_lease_query.so  libdhcp_perfmon.so  libdhcp_run_script.so
libdhcp_ddns_tuning.so  libdhcp_host_cache.so   libdhcp_legal_log.so    libdhcp_pgsql.so    libdhcp_stat_cmds.so
```

I think it would be useful to package more of them (the ping_check module sounds like it'd be useful. I recently ran into an ARP conflict on my network for the first time. That was fun.) and maybe even have a kea-full package that includes the database modules (if someone wants to run mysql or postgres on OpenWRT or to connect to one then why shouldn't they be able to?).

I think I quite like Kea. I'd love to see better support for it in OpenWRT. Maybe even UCI integration or displaying leases in Luci, etc, in the future.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** HEAD
- **OpenWrt Target/Subtarget:** X86_64/Generic
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
