### PR TITLE
zabbix: fix username for ubus acls

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=7.0.23
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \

--- a/admin/zabbix/files/zabbix-network-ubus-acl.json
+++ b/admin/zabbix/files/zabbix-network-ubus-acl.json
@@ -1,5 +1,5 @@
 {
-	"user": "zabbix",
+	"user": "zabbix-agent",
 	"access": {
 		"network.interface": {
 			"methods": [

--- a/admin/zabbix/files/zabbix-wifi-ubus-acl.json
+++ b/admin/zabbix/files/zabbix-wifi-ubus-acl.json
@@ -1,5 +1,5 @@
 {
-	"user": "zabbix",
+	"user": "zabbix-agent",
 	"access": {
 		"network.wireless": {
 			"methods": [


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

When we updated the zabbix agent to use username zabbix-agent
we neglected to update ubus acls for zabbix-extra-network.

Therefore update the username for the network and wifi acls.

Will close https://github.com/openwrt/packages/issues/29058 once backported to 25.12.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT r33773-d3a905e0cd
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi Compute Module 5 Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
