### PR TITLE
[25.12] python-setuptools: re-introduce patch from python3

### DIFF
--- a/lang/python/python-setuptools/Makefile
+++ b/lang/python/python-setuptools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-setuptools
 PKG_VERSION:=80.9.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=setuptools
 PKG_HASH:=f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c

--- a/lang/python/python-setuptools/patches/0001-distutils-use-python-sysroot.patch
+++ b/lang/python/python-setuptools/patches/0001-distutils-use-python-sysroot.patch
@@ -1,0 +1,60 @@
+From e359a7a3c4f9e70360a068bef19c95938fdacede Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+Date: Wed, 23 Dec 2015 11:33:14 +0100
+Subject: [PATCH] Adjust library/header paths for cross-compilation
+
+When cross-compiling third-party extensions, the get_python_inc() or
+get_python_lib() can be called, to return the path to headers or
+libraries. However, they use the sys.prefix of the host Python, which
+returns incorrect paths when cross-compiling (paths pointing to host
+headers and libraries).
+
+In order to fix this, we introduce the _python_sysroot, _python_prefix
+and _python_exec_prefix variables, that allow to override these
+values, and get correct header/library paths when cross-compiling
+third-party Python modules.
+
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+---
+ setuptools/_distutils/command/build_ext.py |  5 ++++-
+ setuptools/_distutils/sysconfig.py         | 15 +++++++++++----
+ 2 files changed, 15 insertions(+), 5 deletions(-)
+
+--- a/setuptools/_distutils/command/build_ext.py
++++ b/setuptools/_distutils/command/build_ext.py
+@@ -156,7 +156,10 @@ class build_ext(Command):
+             yield os.path.join(installed_dir, lib_dir)
+         else:
+             # building third party extensions
+-            yield sysconfig.get_config_var('LIBDIR')
++            libdir = sysconfig.get_config_var('LIBDIR')
++            if "_python_sysroot" in os.environ:
++                libdir = os.environ.get("_python_sysroot") + libdir
++            yield libdir
+ 
+     def finalize_options(self) -> None:  # noqa: C901
+         from distutils import sysconfig
+--- a/setuptools/_distutils/sysconfig.py
++++ b/setuptools/_distutils/sysconfig.py
+@@ -37,10 +37,17 @@ else:
+ IS_PYPY = '__pypy__' in sys.builtin_module_names
+ 
+ # These are needed in a couple of spots, so just compute them once.
+-PREFIX = os.path.normpath(sys.prefix)
+-EXEC_PREFIX = os.path.normpath(sys.exec_prefix)
+-BASE_PREFIX = os.path.normpath(sys.base_prefix)
+-BASE_EXEC_PREFIX = os.path.normpath(sys.base_exec_prefix)
++if "_python_sysroot" in os.environ:
++    _sysroot=os.environ.get('_python_sysroot')
++    PREFIX = os.path.normpath(_sysroot + os.environ.get('_python_prefix'))
++    EXEC_PREFIX = os.path.normpath(_sysroot + os.environ.get('_python_exec_prefix'))
++    BASE_PREFIX = PREFIX
++    BASE_EXEC_PREFIX = EXEC_PREFIX
++else:
++    PREFIX = os.path.normpath(sys.prefix)
++    EXEC_PREFIX = os.path.normpath(sys.exec_prefix)
++    BASE_PREFIX = os.path.normpath(sys.base_prefix)
++    BASE_EXEC_PREFIX = os.path.normpath(sys.base_exec_prefix)
+ 
+ # Path to the base directory of the project. On Windows the binary may
+ # live in project/PCbuild/win32 or project/PCbuild/amd64.


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me, @jefferyto for 25.12

**Description:**

When Python3 was updated via commit 97a92f2e7 , distutils was disappeared from Python3 and moved to setuptools.
So that patch should have moved here as well.

This should fix all packages which still use the 'build_ext' module from setuptools.


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
