### PR TITLE
zabbix: cherry pick a fix and an update

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=7.0.22
-PKG_RELEASE:=6
+PKG_VERSION:=7.0.23
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
 	https://cdn.zabbix.com/zabbix/sources/oldstable/$(basename $(PKG_VERSION))/
-PKG_HASH:=7a74794b2124607d8036be36cc104da056a2fb653811c84acbe29f3f6d97860a
+PKG_HASH:=43ea5fcb1e5db25e74bdc83ea8936d79b8093b614af4e889417485bc74f061e2
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 PKG_LICENSE:=AGPL-3.0-only

--- a/admin/zabbix/patches/010-change-agentd-config.patch
+++ b/admin/zabbix/patches/010-change-agentd-config.patch
@@ -56,7 +56,7 @@ Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
  
  ##### Active checks related
  
-@@ -164,8 +162,6 @@ Server=127.0.0.1
+@@ -166,8 +164,6 @@ Server=127.0.0.1
  # Default:
  # ServerActive=
  
@@ -65,7 +65,7 @@ Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
  ### Option: Hostname
  #	List of comma delimited unique, case sensitive hostnames.
  #	Required for active checks and must match hostnames as configured on the server.
-@@ -175,8 +171,6 @@ ServerActive=127.0.0.1
+@@ -177,8 +173,6 @@ ServerActive=127.0.0.1
  # Default:
  # Hostname=
  
@@ -74,7 +74,7 @@ Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
  ### Option: HostnameItem
  #	Item used for generating Hostname if it is undefined. Ignored if Hostname is defined.
  #	Does not support UserParameters or aliases.
-@@ -315,7 +309,7 @@ Hostname=Zabbix server
+@@ -317,7 +311,7 @@ Hostname=Zabbix server
  #
  # Mandatory: no
  # Default:
@@ -83,7 +83,7 @@ Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
  
  ####### USER-DEFINED MONITORED PARAMETERS #######
  
-@@ -545,5 +539,5 @@ Hostname=Zabbix server
+@@ -547,5 +541,5 @@ Hostname=Zabbix server
  # Include=
  
  # Include=/usr/local/etc/zabbix_agentd.userparams.conf


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**

* Using the php8 dependency allows use to go back to using the
+ZABBIX_POSTGRESQL:php8-mod-pgsql (and like dependency for
mysql/mariadb).

  This has the benefit of being an apk dependency so the user does not
install the frontend without a php8 database module.

* Update version to 7.0.23 - was latest LTS.
  Will bump to 7.0.24 once I do the update in master

* Needs https://github.com/openwrt/packages/pull/29069 once it is in master (i.e. can be cherry-picked).

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12-SNAPSHOT r32840-f778841d02
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
