### PR TITLE
watchcat: use logical network to fix restart_interface 

### DIFF
--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=21
+PKG_RELEASE:=22
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -6,6 +6,8 @@
 # This is free software, licensed under the GNU General Public License v2.
 #
 
+. /lib/network/config.sh
+
 get_ping_size() {
 	ps=$1
 	case "$ps" in
@@ -82,8 +84,10 @@ watchcat_restart_modemmanager_iface() {
 }
 
 watchcat_restart_network_iface() {
-	logger -p daemon.info -t "watchcat[$$]" "Restarting network interface: \"$1\"."
-	ifup "$1"
+	local network
+	network="$(find_config "$1")"
+	logger -p daemon.info -t "watchcat[$$]" "Restarting network interface: \"$1\" (network: \"$network\")."
+	ifup "$network"
 }
 
 watchcat_run_script() {


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @roger-

**Description:**

Watchcat was failing to restart layer-3 interfaces when in mode
'restart_iface'. The previously attempted fix made the situation
worse in that it resulted in layer 2 interfaces also failing to
start.

This was because we are passed the interface name (e.g. eth0,
l2p0, or br-lan), but ifup needs the logical network (e.g. 'lan'
which corresponds to the network device).

Update to use find_config from /lib/network/config.sh to find the
logical network from the interface name, and use ifup on the
logical network to restart the underlying interface(s) associated
with the logical network.

Should help with https://github.com/openwrt/packages/issues/27927

@vdmorozov

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r33773-d3a905e0cd
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

Used a 2m reboot, and 5s check with a non-existent IP for the ping.
Verified the interface restarts every 2 minutes.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
