### PR TITLE
python-orjson: update to 3.11.8, add test.sh

### DIFF
--- a/lang/python/python-orjson/Makefile
+++ b/lang/python/python-orjson/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-orjson
-PKG_VERSION:=3.10.12
+PKG_VERSION:=3.11.8
 PKG_RELEASE:=1
 
 PYPI_NAME:=orjson
-PKG_HASH:=0a78bbda3aea0f9f079057ee1ee8a1ecf790d4f1af88dd67493c6b8ee52506ff
+PKG_HASH:=96163d9cdc5a202703e9ad1b9ae757d5f0ca62f4fa0cc93d1f27b0e180cc404e
 
 PKG_MAINTAINER:=Timothy Ace <openwrt@timothyace.com>
 PKG_LICENSE:=Apache-2.0 MIT
@@ -26,6 +26,7 @@ define Package/python3-orjson
   URL:=https://github.com/ijl/orjson
   DEPENDS:= \
 	+python3-light \
+	+python3-uuid \
 	$(RUST_ARCH_DEPENDS)
 endef
 

--- a/lang/python/python-orjson/test.sh
+++ b/lang/python/python-orjson/test.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+[ "$1" = python3-orjson ] || exit 0
+
+python3 - << 'EOF'
+import faulthandler
+faulthandler.enable()
+
+print("importing orjson...", flush=True)
+import orjson
+print("import OK", flush=True)
+
+# Basic encode/decode
+data = {"key": "value", "number": 42, "flag": True, "empty": None}
+encoded = orjson.dumps(data)
+assert isinstance(encoded, bytes)
+decoded = orjson.loads(encoded)
+assert decoded == data
+print("basic encode/decode OK", flush=True)
+
+# List roundtrip
+lst = [1, 2, 3, "hello"]
+assert orjson.loads(orjson.dumps(lst)) == lst
+print("list roundtrip OK", flush=True)
+
+# Nested structures
+nested = {"a": {"b": {"c": 1}}}
+assert orjson.loads(orjson.dumps(nested)) == nested
+print("nested OK", flush=True)
+
+# OPT_SORT_KEYS option
+obj = {"z": 1, "a": 2, "m": 3}
+sorted_json = orjson.dumps(obj, option=orjson.OPT_SORT_KEYS)
+assert sorted_json == b'{"a":2,"m":3,"z":1}'
+print("sort_keys OK", flush=True)
+
+print("orjson OK")
+EOF


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @ecammit

**Description:**

orjson imports uuid.py at module init to look up uuid.UUID type;
python3-uuid is a separate package not included in python3-light,
causing a segfault when python3-uuid is absent. Add it as an explicit
dependency to fix the crash on all architectures.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
