### PR TITLE
knot: update to version 3.5.4

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.5.3
+PKG_VERSION:=3.5.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=e003ad1eef229c4e65a6cac876ee773e25a06177ecdc83795a26617a6eebe471
+PKG_HASH:=4a0bc892dfaa5a150ff2855f0a88f2267124bc271818eae9a2b1f6da487c34e4
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.0-or-later MIT ISC BSD-3-Clause

--- a/net/knot/patches/01_zscanner_tests.patch
+++ b/net/knot/patches/01_zscanner_tests.patch
@@ -20,5 +20,5 @@
 -ZSCANNER_TOOL="$BUILD"/zscanner-tool
 +ZSCANNER_TOOL="$SOURCE"/zscanner-tool
  
- plan 89
+ plan 90
  


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @salzmdan

**Description:** 

- Release upgrade (https://www.knot-dns.cz/2026-04-02-version-354.html)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** TurrisOS 9.0.0
- **OpenWrt Target/Subtarget:** mvebu/cortexa9
- **OpenWrt Device:** Turris Omnia

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
