### PR TITLE
zabbix: update to 7.0.24 and tweak server configuration

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=7.0.23
-PKG_RELEASE:=3
+PKG_VERSION:=7.0.24
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
 	https://cdn.zabbix.com/zabbix/sources/oldstable/$(basename $(PKG_VERSION))/
-PKG_HASH:=43ea5fcb1e5db25e74bdc83ea8936d79b8093b614af4e889417485bc74f061e2
+PKG_HASH:=6f8ae990b9b25767e4fffbcb5cc7c455d674e2a392dc21478488a5d1c0e7d597
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 PKG_LICENSE:=AGPL-3.0-only

--- a/admin/zabbix/patches/020-change-server-config.patch
+++ b/admin/zabbix/patches/020-change-server-config.patch
@@ -1,4 +1,4 @@
-From 9675bd17ae35744696c90b423b0c19905349c8a1 Mon Sep 17 00:00:00 2001
+From ca45744e63b957d83cdbc2a28588077cbf8b5639 Mon Sep 17 00:00:00 2001
 From: "Daniel F. Dickinson" <dfdpublic@wildtechgarden.ca>
 Date: Wed, 17 Dec 2025 06:39:16 -0500
 Subject: [PATCH] Make zabbix_server config suitable for OpenWrt
@@ -8,11 +8,14 @@ Subject: [PATCH] Make zabbix_server config suitable for OpenWrt
    Zabbix server running without privileges
 3. If started as root, drop privileges to zabbix-server user (instead of
    zabbix)
+4. Set the fping location properly for OpenWrt (/usr/bin not /usr/sbin)
+5. Configure fping as the ipv6 fping as well
+6. For privacy, disable the public API call to check Zabbix version
 
 Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 ---
- conf/zabbix_server.conf | 8 +++++++-
- 1 file changed, 7 insertions(+), 1 deletion(-)
+ conf/zabbix_server.conf | 15 +++++++++++----
+ 1 file changed, 11 insertions(+), 4 deletions(-)
 
 --- a/conf/zabbix_server.conf
 +++ b/conf/zabbix_server.conf
@@ -52,7 +55,24 @@ Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
  ### Option: SocketDir
  #	IPC socket directory.
  #		Directory to store IPC sockets used by internal Zabbix services.
-@@ -698,7 +704,7 @@ LogSlowQueries=3000
+@@ -610,7 +616,7 @@ Timeout=4
+ #
+ # Mandatory: no
+ # Default:
+-# FpingLocation=/usr/sbin/fping
++FpingLocation=/usr/bin/fping
+ 
+ ### Option: Fping6Location
+ #	Location of fping6.
+@@ -620,6 +626,7 @@ Timeout=4
+ # Mandatory: no
+ # Default:
+ # Fping6Location=/usr/sbin/fping6
++Fping6Location=
+ 
+ ### Option: SSHKeyLocation
+ #	Location of public and private keys for SSH checks and actions.
+@@ -698,7 +705,7 @@ LogSlowQueries=3000
  #
  # Mandatory: no
  # Default:
@@ -61,3 +81,12 @@ Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
  
  ### Option: SSLCertLocation
  #	Location of SSL client certificates.
+@@ -1050,7 +1057,7 @@ EnableGlobalScripts=0
+ #
+ # Mandatory: no
+ # Default:
+-# AllowSoftwareUpdateCheck=1
++AllowSoftwareUpdateCheck=0
+ 
+ ### Option: SMSDevices
+ #	List of comma delimited modem files allowed to use Zabbix server


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**

* Fix path to fping and use fping as fping6
* For privacy, disable call to public API to check for Zabbix version update
* Bump version and refresh patches.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r33834-7f94645fef
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi Compute Module 5 Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
  The patches are distro-specific and will not be accepted as part of the upstream
  source builds. Upstream expects that distro packagers will ship configurations
  suitable for their environment, not necessarily the low-common-denominator
  conifgurations from the source tarball (for example the use of
  /tmp for PID files - it works everywhere, but is not best practise).
