### PR TITLE
radicale3: update to 3.7.0

### DIFF
--- a/net/radicale3/Makefile
+++ b/net/radicale3/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radicale3
-PKG_VERSION:=3.6.1
+PKG_VERSION:=3.7.0
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-3.0-or-later
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:radicale:radicale
 
 PYPI_NAME:=Radicale
 PYPI_SOURCE_NAME:=radicale
-PKG_HASH:=5b5529c093fc3a6e9eba6a3280d930ea6573b485a1bd8d25b7daa6ee70f5224b
+PKG_HASH:=0c70356330da373adf65ef2ec2a0ea938ab18dabc6b045a1b1778cc41b7834df
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 

--- a/net/radicale3/files/radicale3.init
+++ b/net/radicale3/files/radicale3.init
@@ -134,6 +134,7 @@ conf_section() {
 			echo "Access-Control-Allow-Origin = $cors" >> "$cfgfile"
 		fi
 		;;
+  # TODO: Add sharing configuration
 	esac
 
 	echo "" >> "$cfgfile"
@@ -142,7 +143,7 @@ conf_section() {
 add_missing_sections() {
 	local cfgfile="$1"
 
-	for section in server encoding auth rights storage web logging headers; do
+	for section in server encoding auth rights storage web logging headers sharing; do
 		if ! grep -q "\[$section\]" "$cfgfile"; then
 			echo "[$section]" >> "$cfgfile"
 			case $section in


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson

**Description:**
Bump version and add placeholder for new [sharing] section/capability.

Intent is to add a new radicale-ng package that reworks the initscripts
and LuCI app (luci-app-radicale-ng) to better support Radicale 3.x features.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r33834-7f94645fef
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
