### PR TITLE
ddns-scripts: fix netcup.com for multiple runs

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_netcup_com.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_netcup_com.sh
@@ -127,7 +127,7 @@ netcup_check_response() {
 	local __context="$1"
 	local __status __statuscode __shortmsg
 
-	json_load "$(cat "$DATFILE")"
+	json_load_file "$DATFILE"
 	json_get_var __status     "status"
 	json_get_var __statuscode "statuscode"
 	json_get_var __shortmsg   "shortmessage"

--- a/net/ddns-scripts/files/usr/lib/ddns/update_netcup_com.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_netcup_com.sh
@@ -32,7 +32,7 @@
 # Constants
 # ---------------------------------------------------------------------------
 
-readonly __NETCUP_ENDPOINT="https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON"
+__NETCUP_ENDPOINT="https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON"
 
 # ---------------------------------------------------------------------------
 # Validate required configuration variables

--- a/net/ddns-scripts/files/usr/lib/ddns/update_netcup_com.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_netcup_com.sh
@@ -134,8 +134,10 @@ netcup_check_response() {
 
 	if [ "$__status" != "success" ]; then
 		json_cleanup
-		write_log 14 "netcup DDNS: $__context failed (status='$__status' code=$__statuscode): $__shortmsg"
+		write_log 3 "netcup DDNS: $__context failed (status='$__status' code=$__statuscode): $__shortmsg"
+		return 1
 	fi
+	return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -154,16 +156,21 @@ json_add_object "param"
 	json_add_string "apipassword"    "$password"
 json_close_object
 
-netcup_post || write_log 14 "netcup DDNS: HTTP request failed during login"
-netcup_check_response "login"
+if ! netcup_post; then
+	write_log 3 "netcup DDNS: HTTP request failed during login"
+	return 1
+fi
+netcup_check_response "login" || return 1
 
 json_select "responsedata"
 json_get_var __SESSION_ID "apisessionid"
 json_select ".."
 json_cleanup
 
-[ -z "$__SESSION_ID" ] && \
-	write_log 14 "netcup DDNS: login succeeded but no session ID was returned"
+if [ -z "$__SESSION_ID" ]; then
+	write_log 3 "netcup DDNS: login succeeded but no session ID was returned"
+	return 1
+fi
 
 write_log 6 "netcup DDNS: login successful"
 
@@ -178,8 +185,11 @@ json_add_object "param"
 	json_add_string "apisessionid"   "$__SESSION_ID"
 json_close_object
 
-netcup_post || write_log 14 "netcup DDNS: HTTP request failed during infoDnsRecords"
-netcup_check_response "infoDnsRecords"
+if ! netcup_post; then
+	write_log 3 "netcup DDNS: HTTP request failed during infoDnsRecords"
+	return 1
+fi
+netcup_check_response "infoDnsRecords" || return 1
 
 # --- Step 3: Find the record matching our hostname and type ----------------
 #
@@ -216,8 +226,10 @@ done
 
 json_cleanup
 
-[ -z "$__MATCH_ID" ] && \
-	write_log 14 "netcup DDNS: no [$__RRTYPE] record found for hostname '$__REC_HOSTNAME' in zone '$__ZONE'"
+if [ -z "$__MATCH_ID" ]; then
+	write_log 3 "netcup DDNS: no [$__RRTYPE] record found for hostname '$__REC_HOSTNAME' in zone '$__ZONE'"
+	return 1
+fi
 
 # --- Step 4: Update the matched record with the new IP ---------------------
 
@@ -242,8 +254,12 @@ json_add_object "param"
 	json_close_object
 json_close_object
 
-netcup_post || write_log 14 "netcup DDNS: HTTP request failed during updateDnsRecords"
-netcup_check_response "updateDnsRecords"
+if ! netcup_post; then
+	write_log 3 "netcup DDNS: HTTP request failed during updateDnsRecords"
+	return 1
+fi
+
+netcup_check_response "updateDnsRecords" || return 1
 json_cleanup
 
 write_log 6 "netcup DDNS: '$__REC_HOSTNAME.$__ZONE' [$__RRTYPE] updated to $__IP"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
This PR fixes an issue where the netcup DDNS update script fails on subsequent runs due to reassigning a `readonly` variable. The variable has been changed to a regular assignment to ensure the script can be sourced multiple times without errors.

Additionally, error handling has been improved:

* Several hard failures (`write_log 14`) have been replaced with soft failures (`return 1`) to allow the ddns framework to retry updates according to the configured retry policy.
* Hard failures are now reserved for critical issues such as missing dependencies or invalid configuration.
* JSON parsing has been made more robust by replacing `cat`-based loading with json_load_file, which is the intended method for handling JSON input in this context.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12.2 r32802-f505120278
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:** TP-Link Archer C7 v4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
