### PR TITLE
cloudflared: support multiple upstream interfaces in init script

### DIFF
--- a/net/cloudflared/Makefile
+++ b/net/cloudflared/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cloudflared
 PKG_VERSION:=2026.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cloudflare/cloudflared/tar.gz/$(PKG_VERSION)?

--- a/net/cloudflared/files/cloudflared.config
+++ b/net/cloudflared/files/cloudflared.config
@@ -1,6 +1,7 @@
 
 config cloudflared 'config'
 	option enabled '0'
+	list interfaces 'wan'
 	option token ''
 #	option config '/etc/cloudflared/config.yml'
 #	option origincert '/etc/cloudflared/cert.pem'

--- a/net/cloudflared/files/cloudflared.init
+++ b/net/cloudflared/files/cloudflared.init
@@ -59,6 +59,10 @@ start_service() {
 }
 
 service_triggers() {
+	config_load "$CONF"
 	procd_add_reload_trigger "$CONF"
-	procd_add_interface_trigger "interface.*.up" "wan" /etc/init.d/cloudflared restart
+	config_get interfaces "config" "interfaces" "wan"
+	for ifname in $interfaces; do
+		procd_add_interface_trigger "interface.*.up" "$ifname" /etc/init.d/cloudflared restart
+	done
 }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @1715173329
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
This pull request implements the ability to restart `cloudflared` service in the event of an upstream interface other than the "wan" defined by default, as well as multiple upstream interfaces.

The changes include:
1. In 'cloudflared.config', Removed the redundant space and added the interface option 'list interface' to detect the up event.
2. In 'cloudflared.init', Added configuration readout to 'service_triggers()' and added a for loop to configure each target interface. If there is no "interface" list in the config, the same default value of "wan" will be used as before.

---

## 🧪 Run Testing Details

- **OpenWrt Version: 25.12.2 r32802-f505120278
- **OpenWrt Target/Subtarget: mediatek/filogic
- **OpenWrt Device: Banana Pi BPI-R4 (2x SFP+)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
