### PR TITLE
python-ubus: backport patch for newer Python

### DIFF
--- a/lang/python/python-ubus/Makefile
+++ b/lang/python/python-ubus/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-ubus
 PKG_VERSION:=0.1.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=ubus
 PKG_HASH:=4dc4ef0fbcc8abb7a2354691475a58ff3eb015f1bab3150750729f7f657dd440
@@ -17,6 +17,8 @@ PKG_HASH:=4dc4ef0fbcc8abb7a2354691475a58ff3eb015f1bab3150750729f7f657dd440
 PKG_MAINTAINER:=Erik Larsson <who+openwrt@cnackers.org>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=python-setuptools/host
 
 PYTHON3_PKG_FORCE_DISTUTILS_SETUP:=1
 

--- a/lang/python/python-ubus/patches/0001-make-project-compatible-with-python3.13.patch
+++ b/lang/python/python-ubus/patches/0001-make-project-compatible-with-python3.13.patch
@@ -1,0 +1,21 @@
+From e76b4f915c80d0fdfdd6602593b1f7bd7e078c3b Mon Sep 17 00:00:00 2001
+From: Stepan Henek <stepan.henek@nic.cz>
+Date: Thu, 5 Mar 2026 12:38:21 +0100
+Subject: [PATCH] make project compatible with python3.13
+
+---
+ ubus_python.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/ubus_python.c
++++ b/ubus_python.c
+@@ -1078,7 +1078,8 @@ static PyObject *ubus_python_add(PyObjec
+ 	if (PyList_Append(python_alloc_list, methods)) {
+ 		ubus_remove_object(ctx, &object->object);
+ 		free_ubus_object(object);
+-		PyEval_CallMethod(python_alloc_list, "pop", "");
++		PyObject *_pop_result = PyObject_CallMethod(python_alloc_list, "pop", NULL);
++		Py_XDECREF(_pop_result);
+ 		return NULL;
+ 	}
+ 

--- a/lang/python/python-ubus/test.sh
+++ b/lang/python/python-ubus/test.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+[ "$1" = python3-ubus ] || exit 0
+
+python3 - << 'EOF'
+import ubus
+
+# Constants must be present
+assert hasattr(ubus, "BLOBMSG_TYPE_STRING"), "missing BLOBMSG_TYPE_STRING"
+assert hasattr(ubus, "BLOBMSG_TYPE_BOOL"),   "missing BLOBMSG_TYPE_BOOL"
+assert hasattr(ubus, "BLOBMSG_TYPE_INT32"),  "missing BLOBMSG_TYPE_INT32"
+
+# Not connected by default
+assert ubus.get_connected() is False, "should not be connected on import"
+assert ubus.get_socket_path() is None, "socket path should be None when not connected"
+
+# Connecting to a non-existent socket must raise IOError
+try:
+    ubus.connect(socket_path="/non/existing/ubus.sock")
+    raise AssertionError("expected IOError for missing socket")
+except IOError:
+    pass
+
+# Operations that require a connection must raise RuntimeError when disconnected
+for fn, args in [
+    (ubus.disconnect, ()),
+    (ubus.send,       ("event", {})),
+    (ubus.loop,       (1,)),
+    (ubus.objects,    ()),
+]:
+    try:
+        fn(*args)
+        raise AssertionError(f"{fn.__name__} should raise RuntimeError when not connected")
+    except RuntimeError:
+        pass
+EOF


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @whooo 

**Description:**

Build is failing for a while now with error:
```
14.3.0_musl/usr/include -I/builder/shared-workdir/build/sdk/staging_dir/toolchain-mipsel_24kc_gcc-14.3.0_musl/include -I/builder/shared-workdir/build/sdk/staging_dir/toolchain-mipsel_24kc_gcc-14.3.0_musl/include/fortify -I/builder/shared-workdir/build/sdk/staging_dir/target-mipsel_24kc_musl/usr/include/python3.14 -fPIC -I/builder/shared-workdir/build/sdk/staging_dir/target-mipsel_24kc_musl/usr/include/python3.14 -c ./ubus_python.c -o build/temp.linux-mipsel-cpython-314/ubus_python.o
./ubus_python.c: In function 'ubus_python_add':
./ubus_python.c:1081:17: error: implicit declaration of function 'PyEval_CallMethod'; did you mean 'PyObject_CallMethod'? [-Wimplicit-function-declaration]
 1081 |                 PyEval_CallMethod(python_alloc_list, "pop", "");
      |                 ^~~~~~~~~~~~~~~~~
      |                 PyObject_CallMethod
error: command '/builder/shared-workdir/build/sdk/staging_dir/toolc
```

This has been fixed on version 0.1.3, but that hasn't been published to pypi yet.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
