### PR TITLE
watchcat: use logical network to fix restart_interface 

### DIFF
--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=20
+PKG_RELEASE:=21
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=21
+PKG_RELEASE:=22
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -83,8 +83,7 @@ watchcat_restart_modemmanager_iface() {
 
 watchcat_restart_network_iface() {
 	logger -p daemon.info -t "watchcat[$$]" "Restarting network interface: \"$1\"."
-	ip link set "$1" down
-	ip link set "$1" up
+	ifup "$1"
 }
 
 watchcat_run_script() {

--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -6,6 +6,8 @@
 # This is free software, licensed under the GNU General Public License v2.
 #
 
+. /lib/network/config.sh
+
 get_ping_size() {
 	ps=$1
 	case "$ps" in
@@ -82,8 +84,10 @@ watchcat_restart_modemmanager_iface() {
 }
 
 watchcat_restart_network_iface() {
-	logger -p daemon.info -t "watchcat[$$]" "Restarting network interface: \"$1\"."
-	ifup "$1"
+	local network
+	network="$(find_config "$1")"
+	logger -p daemon.info -t "watchcat[$$]" "Restarting network interface: \"$1\" (network: \"$network\")."
+	ifup "$network"
 }
 
 watchcat_run_script() {


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @roger- 

**Description:**

As reported in https://github.com/openwrt/packages/issues/23410 Network interface reset doesn't work as expected
on a Wireguard VPN interface and in https://github.com/openwrt/packages/issues/27927 lt2p interface won't reboot,
and mentioned in https://github.com/openwrt/packages/pull/27248, the current implementation of the option to
restart an interface when connectivity check fails for some period does
not result in an interface restart for all interface.

Notably 'virtual' interfaces such as Wireguard and L2TP do not restart.

The solution that works is to use `ifup <interface>` instead of only
changing the link status.

This commit is based on the one in https://github.com/openwrt/packages/pull/27248 by @rondoval, who unfortunately
has not updated the commit message as requested for half a year.

and an update:

Watchcat was failing to restart layer-3 interfaces when in mode
'restart_iface'. The previously attempted fix made the situation
worse in that it resulted in layer 2 interfaces also failing to
start.

This was because we are passed the interface name (e.g. eth0,
l2p0, or br-lan), but ifup needs the logical network (e.g. 'lan'
which corresponds to the network device).

Update to use find_config from /lib/network/config.sh to find the
logical network from the interface name, and use ifup on the
logical network to restart the underlying interface(s) associated
with the logical network.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12-SNAPSHOT r32848-1f535037b1
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
