### PR TITLE
openvpn: handler: refine netifd routing and config

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.7.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/net/openvpn/files/lib/netifd/proto/openvpn.sh
+++ b/net/openvpn/files/lib/netifd/proto/openvpn.sh
@@ -92,6 +92,7 @@ option_builder() {
 # Not real config params used by openvpn - only by our proto handler
 PROTO_BOOLS='
 allow_deprecated
+ipv6
 '
 
 PROTO_STRINGS='
@@ -191,6 +192,7 @@ proto_openvpn_setup() {
 
 	# Add default hotplug handling if 'script_security' option is equal '3'
 	if [ "$script_security" -eq '3' ]; then
+		local ipv6
 		local up down route_up route_pre_down
 		local client tls_client tls_server
 		local tls_crypt_v2_verify mode learn_address client_connect
@@ -205,6 +207,11 @@ proto_openvpn_setup() {
 		json_get_vars up down route_up route_pre_down
 		json_get_vars tls_crypt_v2_verify mode learn_address client_connect
 		json_get_vars client_crresponse client_disconnect auth_user_pass_verify
+
+		json_get_vars ipv6
+		#default ipv6 is enabled
+		[ -n "$ipv6" ] || ipv6=1
+		append exec_params "--setenv IPV6 '$ipv6'"
 
 		json_get_vars ifconfig_noexec route_noexec
 		[ -z "$ifconfig_noexec" ] && append exec_params "--ifconfig-noexec"

--- a/net/openvpn/files/usr/libexec/openvpn-hotplug
+++ b/net/openvpn/files/usr/libexec/openvpn-hotplug
@@ -49,13 +49,17 @@ case "$script_type" in
 
 		[ -n "$ifconfig_local" ] && proto_add_ipv4_address "$ifconfig_local" "${ifconfig_netmask:-255.255.255.255}"
 
-		[ -n "$trusted_ip" ] && [ -n "$route_net_gateway" ] && {
-			proto_add_ipv4_route "$trusted_ip" 32 "$route_net_gateway"
+		[ -n "$trusted_ip" ] && {
+			if [ -n "$route_net_gateway" -a "$route_net_gateway" != "0.0.0.0" ]; then
+				proto_add_ipv4_route "$trusted_ip" 32 "$route_net_gateway"
+			fi
 		}
 
 		[ -n "$route_vpn_gateway" ] && proto_add_ipv4_route "0.0.0.0" 0 "$route_vpn_gateway"
 
-		for i in $(seq 1 32); do
+		i=0
+		while :; do
+			i=$((i+1))
 			eval "net=\$route_network_$i mask=\$route_netmask_$i gw=\$route_gateway_$i"
 			[ -z "$net" ] && break
 			[ -z "$mask" ] && continue
@@ -64,32 +68,40 @@ case "$script_type" in
 			proto_add_ipv4_route "$net" "$plen" "$gw"
 		done
 
-		if [ -n "$ifconfig_ipv6_local" ]; then
-			read -r v6addr v6plen <<-EOF
-				$(parse_cidr6 "$ifconfig_ipv6_local" "${ifconfig_ipv6_netbits:-128}")
-			EOF
-			proto_add_ipv6_address "$v6addr" "$v6plen"
+		if [ "$IPV6" = "1" ]; then
+			if [ -n "$ifconfig_ipv6_local" ]; then
+				read -r v6addr v6plen <<-EOF
+					$(parse_cidr6 "$ifconfig_ipv6_local" "${ifconfig_ipv6_netbits:-128}")
+				EOF
+				proto_add_ipv6_address "$v6addr" "$v6plen"
+			fi
+
+			[ -n "$trusted_ip6" ] && {
+				if [ -n "$route_ipv6_gateway" -a "$route_ipv6_gateway" != "::" ]; then
+					proto_add_ipv6_route "$trusted_ip6" 128 "$route_ipv6_gateway"
+				fi
+			}
+
+			[ -n "$ifconfig_ipv6_remote" ] && proto_add_ipv6_route "::" 0 "$ifconfig_ipv6_remote"
+
+			i=0
+			while :; do
+				i=$((i+1))
+				eval "net=\$route_ipv6_network_$i gw=\$route_ipv6_gateway_$i"
+				[ -z "$net" ] && break
+
+				read -r v6net v6plen <<-EOF
+					$(parse_cidr6 "$net" 128)
+				EOF
+				proto_add_ipv6_route "$v6net" "$v6plen" "$gw"
+			done
 		fi
-
-		[ -n "$trusted_ip6" ] && [ -n "$route_ipv6_gateway" ] && {
-			proto_add_ipv6_route "$trusted_ip6" 128 "$route_ipv6_gateway"
-		}
-
-		[ -n "$ifconfig_ipv6_remote" ] && proto_add_ipv6_route "::" 0 "$ifconfig_ipv6_remote"
-
-		for i in $(seq 1 32); do
-			eval "net=\$route_ipv6_network_$i gw=\$route_ipv6_gateway_$i"
-			[ -z "$net" ] && break
-
-			read -r v6net v6plen <<-EOF
-				$(parse_cidr6 "$net" 128)
-			EOF
-			proto_add_ipv6_route "$v6net" "$v6plen" "$gw"
-		done
 
 		[ -n "$tun_mtu" ] && json_add_int mtu "$tun_mtu"
 
-		for i in $(seq 1 32); do
+		i=0
+		while :; do
+			i=$((i+1))
 			eval "option=\$foreign_option_$i"
 			[ -z "$option" ] && break
 


### PR DESCRIPTION
This commit introduces several improvements to the openvpn proto handler and hotplug script:

- Add `ipv6` boolean option (default: 1) to allow enabling/disabling IPv6 hotplug processing.
- Increase the maximum number of processed pushed routes from 32 to 128 for both IPv4 and IPv6.
- Prevent adding host routes for `trusted_ip` and `trusted_ip6` if the gateway is unspecified ("0.0.0.0" or "::").

@feckert 