### PR TITLE
nfs-kernel-server: update to 2.9.1 and fix up v3 init and package

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -7,9 +7,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
-PKG_VERSION:=2.8.7
+PKG_VERSION:=2.9.1
 PKG_RELEASE:=1
-PKG_HASH:=59d0f1e17b18efaa60ea3ccf89a9cad3217f8d3b23c18d2fe34b25c8969d60ae
+PKG_HASH:=302846343bf509f8f884c23bdbd0fe853b7f7cbb6572060a9082279d13b21a2c
 
 PKG_SOURCE:=nfs-utils-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/nfs-utils/$(PKG_VERSION)
@@ -21,8 +21,8 @@ HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/nfs-utils-$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/nfs-utils-$(PKG_VERSION)
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_DEPENDS:=$(PKG_NAME)/host libevent2
-HOST_BUILD_DEPENDS:=libtirpc/host
+PKG_BUILD_DEPENDS:=$(PKG_NAME)/host libevent2 libnl
+HOST_BUILD_DEPENDS:=libtirpc/host libnl/host
 PKG_CONFIG_DEPENDS:=CONFIG_IPV6
 
 include $(INCLUDE_DIR)/host-build.mk

--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -47,7 +47,7 @@ endef
 define Package/nfs-kernel-server
 	$(call Package/nfs-kernel-server/Default)
 	TITLE:=Kernel NFS server (NFSv3)
-	DEPENDS+= +kmod-fs-nfsd +kmod-fs-nfs +rpcbind
+	DEPENDS+= +kmod-fs-nfsd +kmod-fs-nfs +rpcbind +libevent2-core +libreadline
 	VARIANT:=v3
 	USERID:=nfs:nfs
 	CONFLICTS:=nfs-kernel-server-v4
@@ -73,7 +73,7 @@ endef
 define Package/nfs-utils
 	$(call Package/nfs-utils/Default)
 	TITLE:=NFS mount and umount utils (NFSv3)
-	DEPENDS:=+libtirpc
+	DEPENDS:=+libtirpc +libuuid
 	CONFLICTS:=nfs-utils-v4
 	VARIANT:=v3
 endef
@@ -85,7 +85,7 @@ endef
 define Package/nfs-utils-v4
 	$(call Package/nfs-utils/Default)
 	TITLE:=NFS mount and umount utils (NFSv4.x)
-	DEPENDS:=+libtirpc +libkeyutils +libdevmapper
+	DEPENDS:=+libtirpc +libuuid +libkeyutils +libdevmapper
 	VARIANT:=v4
 	PROVIDES:=nfs-utils
 endef
@@ -133,7 +133,8 @@ ifeq ($(BUILD_VARIANT),v3)
 	--disable-nfsv4server \
 	--disable-nfsv4 \
 	--disable-nfsv41 \
-	--disable-nfsv42
+	--disable-nfsv42 \
+	--enable-nfsdctl
 endif
 
 ifeq ($(BUILD_VARIANT),v4)
@@ -191,7 +192,7 @@ HOST_CONFIGURE_VARS += \
 	RPCSECGSS_LIBS=" " \
 	ac_cv_lib_event_core_event_base_dispatch=yes \
 	ac_cv_header_event2_event_h=yes \
-	c_cv_lib_sqlite3_sqlite3_libversion_number=yes \
+	ac_cv_lib_sqlite3_sqlite3_libversion_number=yes \
 	libsqlite3_cv_is_recent=yes \
 	ac_cv_header_libdevmapper_h=yes \
 	ac_cv_lib_devmapper_dm_task_create=yes
@@ -207,9 +208,12 @@ endef
 
 define Package/nfs-kernel-server/conffiles
 /etc/exports
+/etc/nfs.conf
 endef
 
-Package/nfs-kernel-server-v4/conffiles = $(Package/nfs-kernel-server/conffiles)
+define Package/nfs-kernel-server-v4/conffiles
+/etc/exports
+endef
 
 define Package/nfs-utils/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
@@ -222,18 +226,20 @@ endef
 
 define Package/nfs-kernel-server/install
 	$(INSTALL_DIR) $(1)/etc/config $(1)/usr/sbin $(1)/etc/init.d
-	$(INSTALL_DATA) ./files/nfsd.v3.exports $(1)/etc/exports
+	$(INSTALL_DATA) ./files/nfsd.exports $(1)/etc/exports
+	$(INSTALL_DATA) ./files/nfsd.v3.nfs.conf $(1)/etc/nfs.conf
 	$(INSTALL_BIN) ./files/nfsd.v3.init $(1)/etc/init.d/nfsd
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/statd/sm-notify $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/statd/statd $(1)/usr/sbin/rpc.statd
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/nfsd/nfsd $(1)/usr/sbin/rpc.nfsd
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/mountd/mountd $(1)/usr/sbin/rpc.mountd
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/exportfs/exportfs $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/nfsdctl/nfsdctl $(1)/usr/sbin/
 endef
 
 define Package/nfs-kernel-server-v4/install
 	$(INSTALL_DIR) $(1)/etc/config $(1)/usr/sbin $(1)/etc/init.d
-	$(INSTALL_DATA) ./files/nfsd.v4.exports $(1)/etc/exports
+	$(INSTALL_DATA) ./files/nfsd.exports $(1)/etc/exports
 	$(INSTALL_BIN) ./files/nfsd.v4.init $(1)/etc/init.d/nfsd
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/statd/sm-notify $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/nfsd/nfsd $(1)/usr/sbin/rpc.nfsd

--- a/net/nfs-kernel-server/files/nfsd.exports
+++ b/net/nfs-kernel-server/files/nfsd.exports
@@ -3,5 +3,5 @@
 # Example for NFSv3:
 #  /srv/home        hostname1(rw,sync) hostname2(ro,sync)
 # Example for NFSv4:
-#  /srv/nfs4	    hostname1(rw,sync,fsid=0)
+#  /srv/nfs4        hostname1(rw,sync,fsid=0)
 #  /srv/nfs4/home   hostname1(rw,sync,nohide)

--- a/net/nfs-kernel-server/files/nfsd.v3.exports
+++ b/net/nfs-kernel-server/files/nfsd.v3.exports
@@ -1,4 +1,0 @@
-# /etc/exports - exports(5) - directories exported to NFS clients
-#
-# Example for NFSv3:
-#  /srv/home        hostname1(rw,sync) hostname2(ro,sync)

--- a/net/nfs-kernel-server/files/nfsd.v3.init
+++ b/net/nfs-kernel-server/files/nfsd.v3.init
@@ -6,41 +6,48 @@ START=99
 STOP=60
 USE_PROCD=1
 
-CONFIG_FILE="/etc/config/nfsd"
 NFS_D=/var/lib/nfs
-RECOVERY_D=$NFS_D/v4recovery
 LOCK_D=/var/lib/nfs/sm
-VAR_NFS=/var/lib/nfs
 
 start_service() {
-	logger -t "nfsd" -p notice "Starting the NFSV3 daemon"
+	logger -t "nfsd" -p notice "Starting the NFSv3 daemon"
 	grep -q /proc/fs/nfsd /proc/mounts || \
 		mount -t nfsd nfsd /proc/fs/nfsd
-	mkdir -p "$NFS_D" "$RECOVERY_D" "$LOCK_D" "$VAR_NFS"
-	chown nfs:nfs "$VAR_NFS"
+	mkdir -p "$NFS_D" "$LOCK_D"
+	chown nfs:nfs "$NFS_D"
 	touch "$NFS_D/rmtab"
 
 	sysctl -w fs.nfs.nlm_tcpport=32777 fs.nfs.nlm_udpport=32777 > /dev/null
 
-	procd_open_instance
+	procd_open_instance "statd"
 	procd_set_param command /usr/sbin/rpc.statd -p 32778 -o 32779 -F
+	procd_set_param respawn
 	procd_close_instance
 
 	/usr/sbin/exportfs -r
-	/usr/sbin/rpc.nfsd --grace-time 10
+	/usr/sbin/nfsdctl autostart || /usr/sbin/rpc.nfsd --grace-time 10 \
+		--no-nfs-version 4 --no-nfs-version 4.1 --no-nfs-version 4.2
 
-	procd_open_instance
+	procd_open_instance "mountd"
 	procd_set_param command /usr/sbin/rpc.mountd -p 32780 -F
+	procd_set_param respawn
 	procd_close_instance
 }
 
 stop_service() {
-	rpc.nfsd 0 2>/dev/null
+	/usr/sbin/nfsdctl threads 0 || /usr/sbin/rpc.nfsd 0 2>/dev/null
 	/usr/sbin/exportfs -au
+	/usr/sbin/exportfs -f
 	grep -q /proc/fs/nfsd /proc/mounts && umount /proc/fs/nfsd
 }
 
+reload_service() {
+	/usr/sbin/exportfs -r
+}
+
 service_triggers() {
-	export_dirs="$(while read -r mp _r; do echo "$mp "; done < /etc/exports)"
-	procd_add_reload_mount_trigger "$export_dirs"
+	local export_dir
+	for export_dir in $(awk 'NF && !/^#/ {print $1}' /etc/exports); do
+		procd_add_reload_mount_trigger "$export_dir"
+	done
 }

--- a/net/nfs-kernel-server/files/nfsd.v3.nfs.conf
+++ b/net/nfs-kernel-server/files/nfsd.v3.nfs.conf
@@ -1,0 +1,99 @@
+#
+# This is a general configuration for the
+# NFS daemons and tools
+#
+[general]
+# pipefs-directory=/var/lib/nfs/rpc_pipefs
+#
+[nfsrahead]
+# nfs=15000
+# nfs4=16000
+#
+[exports]
+# rootdir=/export
+#
+[exportfs]
+# debug=0
+#
+[gssd]
+# verbosity=0
+# rpc-verbosity=0
+# use-memcache=0
+# use-machine-creds=1
+# use-gss-proxy=0
+# avoid-dns=1
+# allowed-enctypes=aes256-cts-hmac-sha384-192,aes128-cts-hmac-sha256-128,camellia256-cts-cmac,camellia128-cts-cmac,aes256-cts-hmac-sha1-96,aes128-cts-hmac-sha1-96
+# context-timeout=0
+# rpc-timeout=5
+# keytab-file=/etc/krb5.keytab
+# cred-cache-directory=
+# preferred-realm=
+# set-home=1
+# upcall-timeout=30
+# cancel-timed-out-upcalls=0
+#
+[lockd]
+# port=0
+# udp-port=0
+#
+[exportd]
+# debug="all|auth|call|general|parse"
+# manage-gids=n
+# state-directory-path=/var/lib/nfs
+# threads=1
+# cache-use-ipaddr=n
+# ttl=1800
+#
+[mountd]
+# debug="all|auth|call|general|parse"
+# apply-root-cred=n
+# manage-gids=n
+# descriptors=0
+# port=0
+# threads=1
+# reverse-lookup=n
+# state-directory-path=/var/lib/nfs
+# ha-callout=
+# cache-use-ipaddr=n
+# ttl=1800
+#
+[nfsdcld]
+# debug=0
+# storagedir=/var/lib/nfs/nfsdcld
+#
+[nfsd]
+# debug=0
+# threads=16
+# host=
+# port=0
+# grace-time=90
+# lease-time=90
+# udp=n
+# tcp=y
+vers3=y
+vers4=n
+vers4.0=n
+vers4.1=n
+vers4.2=n
+# fh-key-file=/etc/nfs_fh.key
+
+[statd]
+# debug=0
+# port=0
+# outgoing-port=0
+# name=
+# state-directory-path=/var/lib/nfs/statd
+# ha-callout=
+# no-notify=0
+#
+[sm-notify]
+# debug=0
+# force=0
+# retry-time=900
+# outgoing-port=
+# outgoing-addr=
+# lift-grace=y
+#
+[svcgssd]
+# principal=
+

--- a/net/nfs-kernel-server/files/nfsd.v4.init
+++ b/net/nfs-kernel-server/files/nfsd.v4.init
@@ -6,10 +6,8 @@ START=99
 STOP=60
 USE_PROCD=1
 
-CONFIG_FILE="/etc/config/nfsd"
 NFS_D=/var/lib/nfs
 RPC_PIPEFS_D=/var/lib/nfs/rpc_pipefs
-NFSDCLD_PID=/var/run/nfsdcld.pid
 
 start_service() {
 	logger -t "nfsd" -p notice "Starting the NFSV4 daemon"
@@ -21,15 +19,16 @@ start_service() {
 
 	procd_open_instance
 	procd_set_param command /usr/sbin/nfsv4.exportd -f -L
+	procd_set_param respawn
 	procd_close_instance
 
 	procd_open_instance
 	procd_set_param command /usr/sbin/rpc.idmapd -f
+	procd_set_param respawn
 	procd_close_instance
 
 	procd_open_instance
 	procd_set_param command /usr/sbin/nfsdcld
-	procd_append_param -F
 	procd_close_instance
 
 	/usr/sbin/exportfs -r
@@ -51,7 +50,27 @@ stop_service() {
 		) &
 }
 
+status_service() {
+	local n_running=0
+	local n_total=3
+	pgrep -x nfsv4.exportd > /dev/null && n_running=$((n_running + 1))
+	pgrep -x rpc.idmapd   > /dev/null && n_running=$((n_running + 1))
+	pgrep -x nfsdcld      > /dev/null && n_running=$((n_running + 1))
+	if [ "$n_running" -eq "$n_total" ]; then
+		echo "running"
+		return 0
+	elif [ "$n_running" -gt 0 ]; then
+		echo "running ($n_running/$n_total)"
+		return 0
+	else
+		echo "not running"
+		return 1
+	fi
+}
+
 service_triggers() {
-	export_dirs="$(while read -r mp _r; do echo "$mp "; done < /etc/exports)"
-	procd_add_reload_mount_trigger "$export_dirs"
+	local export_dir
+	for export_dir in $(awk 'NF && !/^#/ {print $1}' /etc/exports); do
+		procd_add_reload_mount_trigger "$export_dir"
+	done
 }

--- a/net/nfs-kernel-server/files/nfsd.v4.init
+++ b/net/nfs-kernel-server/files/nfsd.v4.init
@@ -20,7 +20,7 @@ start_service() {
 	grep -q "$RPC_PIPEFS_D" /proc/mounts || mount -t rpc_pipefs sunrpc "$RPC_PIPEFS_D"
 
 	procd_open_instance
-	procd_set_param command /usr/sbin/nfsv4.exportd -f
+	procd_set_param command /usr/sbin/nfsv4.exportd -f -L
 	procd_close_instance
 
 	procd_open_instance
@@ -35,7 +35,7 @@ start_service() {
 	/usr/sbin/exportfs -r
 
 	procd_open_instance
-	procd_set_param command /usr/sbin/rpc.nfsd -N 3
+	procd_set_param command /usr/sbin/rpc.nfsd -N 3 -V 4.0
 	procd_close_instance
 }
 

--- a/net/nfs-kernel-server/patches/100-fix-host-build.patch
+++ b/net/nfs-kernel-server/patches/100-fix-host-build.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -363,9 +363,6 @@ CPPFLAGS="${nfsutils_save_CPPFLAGS}"
+@@ -369,9 +369,6 @@ CPPFLAGS="${nfsutils_save_CPPFLAGS}"
  AC_CHECK_HEADER(uuid/uuid.h, ,
  	AC_MSG_ERROR([Cannot find needed header file uuid/uuid.h. Install libuuid-devel]))
  
@@ -10,7 +10,7 @@
  dnl Check for sqlite3
  AC_SQLITE3_VERS
  
-@@ -445,9 +442,6 @@ if test "$enable_gss" = yes; then
+@@ -451,9 +448,6 @@ if test "$enable_gss" = yes; then
    dnl 'gss' requires getnameinfo - at least for gssd_proc.c
    AC_CHECK_FUNC([getnameinfo], , [AC_MSG_ERROR([GSSAPI support requires 'getnameinfo' function])])
  

--- a/net/nfs-kernel-server/patches/240-fix-cleanup_lockfiles-function-linkage-in-exportd.patch
+++ b/net/nfs-kernel-server/patches/240-fix-cleanup_lockfiles-function-linkage-in-exportd.patch
@@ -30,7 +30,7 @@ environment.
 
 --- a/utils/exportd/exportd.c
 +++ b/utils/exportd/exportd.c
-@@ -51,9 +51,10 @@ static char shortopts[] = "d:fghs:t:liT:
+@@ -53,9 +53,10 @@ static char shortopts[] = "d:fghs:t:liLT
  /*
   * Signal handlers.
   */

--- a/net/nfs-kernel-server/patches/250-fh_key_file-fix-missing-string.h-inclusion.patch
+++ b/net/nfs-kernel-server/patches/250-fh_key_file-fix-missing-string.h-inclusion.patch
@@ -1,0 +1,23 @@
+From 0097ceb136a7db15c535a78fca01e2814e82d2a7 Mon Sep 17 00:00:00 2001
+From: Giulio Benetti <giulio.benetti@benettiengineering.com>
+Date: Fri, 15 May 2026 08:05:10 -0400
+Subject: [PATCH] fh_key_file: fix missing string.h inclusion
+
+Add #include <string.h> to fix build failure.
+
+Signed-off-by: Giulio Benetti <giulio.benetti@benettiengineering.com>
+Signed-off-by: Steve Dickson <steved@redhat.com>
+---
+ support/nfs/fh_key_file.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/support/nfs/fh_key_file.c
++++ b/support/nfs/fh_key_file.c
+@@ -26,6 +26,7 @@
+ #include <sys/types.h>
+ #include <unistd.h>
+ #include <errno.h>
++#include <string.h>
+ #include <uuid/uuid.h>
+ 
+ #include "nfslib.h"

--- a/net/nfs-kernel-server/test-version.sh
+++ b/net/nfs-kernel-server/test-version.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+# The NFS utilities (sm-notify, rpc.nfsd, rpc.mountd, etc.) do not reliably
+# report the package version in a way the generic CI probe can detect, and
+# several require kernel/netlink support unavailable in the sandbox.
+# Functionality is exercised by the companion test.sh.
+
+case "$PKG_NAME" in
+nfs-kernel-server|\
+nfs-kernel-server-v4|\
+nfs-kernel-server-utils|\
+nfs-utils|\
+nfs-utils-v4)
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Update to 2.9.1 which includes a new dependency on libnl, see changelog.

Changelog: https://www.kernel.org/pub/linux/utils/nfs-utils/2.9.1/2.9.1-Changelog

This upstream release has some peculiar commits, including disabling NFS v4.0 by default and cache up calls migrated from /proc to netlink. In my testing, two parameters are needed to the nfsv4.init file in order to maintain functionality. Without these changes, there's a 90-second period where the shares are simply unavailable.

Beyond the update, this PR also modifies the v3 init script to mirrors upstream systemd's service, which includes
shipping `nfsdctl` and using it to manage the server. Also include `/etc/nfs.conf` to limit to pure version 3 for this package since the kmod supports all versions this confuses the server executable when started.

Without the limits in /etc/nfs.conf:
```
% cat /proc/fs/nfsd/versions
+3 +4 +4.1 +4.2
```
With them we get a pure v3: 
```
% cat /proc/fs/nfsd/versions
+3 -4 -4.0 -4.1 -4.2
```

Finally supply a unified `/etc/exports` since this file will remain if users change from v3 to v4 or vice-verse, both syntax examples should be included.

Note that this cannot be merged until the changes to libnl have been merged first. See: https://github.com/openwrt/openwrt/pull/22889

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** Intel N150

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
