### PR TITLE
lpac: remove depends on PACKAGE_lpac from Config.in

### DIFF
--- a/utils/lpac/Config.in
+++ b/utils/lpac/Config.in
@@ -1,5 +1,4 @@
 menu "Configuration"
-	depends on PACKAGE_lpac
 
 config LPAC_WITH_PCSC
 	bool "Include APDU PCSC Backend support"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** David Bauer <david.bauer@uniberg.com>

**Description:**
fix eror message after make menuconfig (https://github.com/openwrt/packages/pull/29044#issuecomment-4230243845)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2
- **OpenWrt Target/Subtarget:** Mediatek/flogic
- **OpenWrt Device:** Huasifei WH3000 Pro

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.