### PR TITLE
python-pyusb: add version 1.3.1

### DIFF
--- a/lang/python/python-pyusb/Makefile
+++ b/lang/python/python-pyusb/Makefile
@@ -1,0 +1,45 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pyusb
+PKG_VERSION:=1.3.1
+PKG_RELEASE:=1
+
+PYPI_NAME:=pyusb
+PKG_HASH:=3af070b607467c1c164f49d5b0caabe8ac78dbed9298d703a8dbf9df4052d17e
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=python-setuptools/host python-setuptools-scm/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-pyusb
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Easy USB access for Python
+  URL:=https://pyusb.github.io/pyusb
+  DEPENDS:=+python3-light \
+           +python3-ctypes \
+           +python3-logging \
+           +libusb-1.0
+endef
+
+define Package/python3-pyusb/description
+PyUSB provides easy USB access for Python. It runs on any platform
+supported by libusb and offers a high-level, Pythonic interface to
+USB devices.
+endef
+
+$(eval $(call Py3Package,python3-pyusb))
+$(eval $(call BuildPackage,python3-pyusb))
+$(eval $(call BuildPackage,python3-pyusb-src))

--- a/lang/python/python-pyusb/test.sh
+++ b/lang/python/python-pyusb/test.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+[ "$1" = python3-pyusb ] || exit 0
+
+python3 - << 'EOF'
+import usb
+import usb.core
+import usb.util
+import usb.control
+import usb.backend.libusb1
+
+# version string is a non-empty string
+assert isinstance(usb.__version__, str) and len(usb.__version__) > 0,     'bad version: ' + repr(usb.__version__)
+
+# exception classes are proper Exception subclasses
+assert issubclass(usb.core.USBError, Exception)
+assert issubclass(usb.core.NoBackendError, Exception)
+
+# find() returns an empty list, or raises NoBackendError when no backend is available
+try:
+    devices = list(usb.core.find(find_all=True))
+    assert isinstance(devices, list), 'find() did not return a list'
+except usb.core.NoBackendError:
+    pass  # acceptable: no USB backend available in test environment
+
+# util.find_descriptor is callable
+assert callable(usb.util.find_descriptor)
+EOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

PyUSB provides easy USB access in Python via libusb backend:
- Pure Python implementation working with libusb-1.0/0.1.x
- Requires Python >= 3.9
- High-level Pythonic interface to USB devices
- Supports bulk/interrupt/control/isochronous transfers
- Homepage: https://pyusb.github.io/pyusb
---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

