### PR TITLE
radicale3: update to 3.7.1

### DIFF
--- a/net/radicale3/Makefile
+++ b/net/radicale3/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radicale3
-PKG_VERSION:=3.7.0
+PKG_VERSION:=3.7.1
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-3.0-or-later
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:radicale:radicale
 
 PYPI_NAME:=Radicale
 PYPI_SOURCE_NAME:=radicale
-PKG_HASH:=0c70356330da373adf65ef2ec2a0ea938ab18dabc6b045a1b1778cc41b7834df
+PKG_HASH:=cabb87ad9f0b6aaa724f0621810c0e0c0421ef04ef2617e988d9da63859cd8ad
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 

--- a/net/radicale3/files/radicale3.init
+++ b/net/radicale3/files/radicale3.init
@@ -125,7 +125,6 @@ conf_section() {
 		;;
 	logging)
 		conf_getline "$cfg" "$cfgfile" level info 0
-		conf_getline "$cfg" "$cfgfile" trace_on_debug 0 1
 		conf_getline "$cfg" "$cfgfile" mask_passwords 1 1
 		;;
 	headers)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson

**Description:**
Bump version for quickly discovered issues with 3.7.0

Requires updates to LuCI app (to be added shortly).

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r33893-15374ca2e7
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
