### PR TITLE
[25.12] nextdns: update to version 1.47.2

### DIFF
--- a/net/nextdns/Makefile
+++ b/net/nextdns/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nextdns
-PKG_VERSION:=1.47.1
+PKG_VERSION:=1.47.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=nextdns-$(PKG_VERSION).tar.gz
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.github.com/nextdns/nextdns/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=3356b283a8eeb675efee8163854c83c65d1dbb7743bac04db696751290f8ee64
+PKG_HASH:=d4a57f07f51a58ab57f8ff872678fc81be76c3985011ef0960b156df361ea44a
 
 PKG_MAINTAINER:=Olivier Poitrey <rs@nextdns.io>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Backport merged `nextdns` package changes from `master` into `openwrt-25.12`.

Current branch version: `1.47.1`
Target branch version: `1.47.2`
Cherry picked from commits:
- 9e7cb54a094d87e16c33bc398a53f3a88f059b87