### PR TITLE
xz: update to 5.8.3

### DIFF
--- a/utils/xz/Makefile
+++ b/utils/xz/Makefile
@@ -9,13 +9,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xz
-PKG_VERSION:=5.8.2
+PKG_VERSION:=5.8.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/tukaani-project/xz/releases/download/v$(PKG_VERSION) \
 		@SF/lzmautils
-PKG_HASH:=60345d7c0b9c8d7ffa469e96898c300def3669f5047fc76219b819340839f3d8
+PKG_HASH:=33bf69c0d6c698e83a68f77e6c1f465778e418ca0b3d59860d3ab446f4ac99a6
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=Public-Domain LGPL-2.1-or-later 0BSD


### PR DESCRIPTION
Update xz to match xz version in tools.

Update includes fix for CVE-2026-34743.

Release Notes:
https://github.com/tukaani-project/xz/releases/tag/v5.8.3

**Maintainer:** nobody
