### PR TITLE
[24.10] openwisp-config: update to 1.2.1

### DIFF
--- a/admin/openwisp-config/Makefile
+++ b/admin/openwisp-config/Makefile
@@ -5,14 +5,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openwisp-config
-PKG_VERSION:=1.2.0
+PKG_VERSION:=1.2.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Federico Capoano <f.capoano@openwisp.io>
 PKG_LICENSE:=GPL-3.0-or-later
 
 PKG_SOURCE_URL:=https://github.com/openwisp/openwisp-config.git
-PKG_MIRROR_HASH:=30258c3ef4895fbf6e4fed8caee9d0dfbf05aebebd52604d75febac1a11d78bd
+PKG_MIRROR_HASH:=f709f3aaf2e9ad61b2df378b7e6cfae7050d5f1d8c4c4bc038e92809c843c4b7
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
 


### PR DESCRIPTION
Backport of #29115 to openwrt 24.10.

Cherry picked from commit a9d2dbeeb455bcfcdc92be95f0d7f0edd131f471.
